### PR TITLE
fix(frontend): preserve last-space/last-room on transient reconnect failures

### DIFF
--- a/frontend/src/routes/chat/[instanceId]/[spaceId]/+layout.svelte
+++ b/frontend/src/routes/chat/[instanceId]/[spaceId]/+layout.svelte
@@ -7,7 +7,7 @@
   import { getActiveInstance } from '$lib/state/activeInstance.svelte';
   import { instanceIdToSegment } from '$lib/navigation';
   import { graphql } from '$lib/gql';
-  import { setLastSpace, clearLastSpace, clearLastRoom } from '$lib/storage/lastRoom';
+  import { setLastSpace } from '$lib/storage/lastRoom';
   import { useActiveInstanceEvent, useReconnectCallback } from '$lib/hooks';
   import SecondarySidebar from '$lib/components/SecondarySidebar.svelte';
   import { createSpacePermissions } from '$lib/state/space';
@@ -172,10 +172,11 @@
         spaceData = result;
         lastRevalidation = currentRevalidation;
 
-        // If space is invalid, redirect
+        // Don't clear lastSpace/lastRoom here: a transient network failure
+        // during wake-from-sleep produces the same null as genuine no-access,
+        // and wiping would lose the user's place. Storage is cleared only on
+        // explicit "leave space" via ModalContainer.
         if (result === null) {
-          clearLastSpace(getInstanceId());
-          clearLastRoom(getInstanceId(), currentSpaceId);
           goto(resolve('/chat/[instanceId]', { instanceId: instanceSegment }), { replaceState: true });
         }
       })

--- a/frontend/src/routes/chat/[instanceId]/[spaceId]/[roomId]/Room.svelte
+++ b/frontend/src/routes/chat/[instanceId]/[spaceId]/[roomId]/Room.svelte
@@ -17,7 +17,7 @@
   import { resolve } from '$app/paths';
   import { instanceIdToSegment } from '$lib/navigation';
   import { getActiveInstance } from '$lib/state/activeInstance.svelte';
-  import { clearLastRoom, setLastRoom } from '$lib/storage/lastRoom';
+  import { setLastRoom } from '$lib/storage/lastRoom';
   import PageTitle from '$lib/ui/PageTitle.svelte';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
   import { tick } from 'svelte';
@@ -86,11 +86,12 @@
 
   createRoomPermissions(() => permissions);
 
-  // If room not found or no access, clear storage and redirect
+  // Don't clear lastRoom here: a transient network failure during
+  // wake-from-sleep produces the same null as a genuinely missing room,
+  // and wiping would lose the user's place. Storage is cleared only on
+  // explicit "leave room" via ModalContainer.
   $effect.pre(() => {
     if (room.roomData === null) {
-      clearLastRoom(getInstanceId(), spaceId);
-
       if (room.isDM) {
         goto(resolve('/chat/dm'), { replaceState: true });
       } else {


### PR DESCRIPTION
## Summary

- The space- and room-validation effects were wiping \`lastSpace\` / \`lastRoom\` from localStorage whenever their GraphQL query resolved without data — but a transient network failure during wake-from-sleep produces that same null result, so users were losing their navigation memory on flaky reconnects.
- Drop the \`clearLastSpace\` / \`clearLastRoom\` calls from the validation-failed branches; keep the redirects so users aren't stuck on a dead URL. Explicit "leave room/space" via \`ModalContainer\` remains the only path that wipes storage.
- Trade-off: if a room/space is genuinely deleted while the user was away, their stored entry will trigger one extra redirect on next app open instead of being silently pruned. Acceptable in exchange for never losing memory on a network blip.

## Test plan

- [x] \`pnpm check\` (svelte-check) — clean
- [x] \`pnpm test\` (frontend) — 763 passing
- [ ] Manual: navigate into a space + room, set DevTools Network to Offline, dispatch \`new Event('online')\` (or hide tab >30s and re-show), then quickly switch back to Online. Confirm \`chatto:i:<id>:lastSpace\` and \`chatto:i:<id>:lastRooms\` survive.
- [ ] Manual: legitimate "leave room" / "leave space" via the modal still clears the relevant entries.