### PR TITLE
chore: launch dev stack via docker compose from Conductor

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ It should be no surprise that we are working hard to move towards a release that
 [Conductor](https://conductor.build) workspaces launch a fully containerized dev stack via Docker Compose. The `run` script in `conductor.json` invokes:
 
 ```sh
-docker compose -p chatto-instance-$CONDUCTOR_WORKSPACE_NAME up
+docker compose -p instance-name up
 ```
 
 The stack is then reachable via OrbStack at:
 
 ```
-https://chatto-instance-<workspace-name>.orb.local/
+https://instance-name.orb.local/
 ```
 
 Each instance is bootstrapped with the same dev credentials (configured in `compose.yml`):
@@ -39,8 +39,6 @@ Each instance is bootstrapped with the same dev credentials (configured in `comp
 - **Login:** `devuser`
 - **Email:** `dev@dev.com`
 - **Password:** `devpassword`
-
-The bootstrapped space is named after the workspace (`chatto-instance-<workspace-name>`), so multiple Conductor workspaces can run side by side without colliding.
 
 ## Instructions for Coding Agents
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,28 @@ A lot of projects say this and people often ignore it, so let me spell things ou
 
 It should be no surprise that we are working hard to move towards a release that can give better guarantees, but we're not there yet.
 
+## Development with Conductor
+
+[Conductor](https://conductor.build) workspaces launch a fully containerized dev stack via Docker Compose. The `run` script in `conductor.json` invokes:
+
+```sh
+docker compose -p chatto-instance-$CONDUCTOR_WORKSPACE_NAME up
+```
+
+The stack is then reachable via OrbStack at:
+
+```
+https://chatto-instance-<workspace-name>.orb.local/
+```
+
+Each instance is bootstrapped with the same dev credentials (configured in `compose.yml`):
+
+- **Login:** `devuser`
+- **Email:** `dev@dev.com`
+- **Password:** `devpassword`
+
+The bootstrapped space is named after the workspace (`chatto-instance-<workspace-name>`), so multiple Conductor workspaces can run side by side without colliding.
+
 ## Instructions for Coding Agents
 
 - Please consult the additional rules in `.claude/rules/**` for more specific guidelines on coding style, architecture, planning, and testing.

--- a/compose.yml
+++ b/compose.yml
@@ -10,8 +10,8 @@ services:
       CHATTO_SMTP_HOST: mailpit.chatto-tools.orb.local
       CHATTO_SMTP_PORT: "1025"
       CHATTO_LIVEKIT_URL: ws://livekit.chatto-tools.orb.local:7880
-      CHATTO_BOOTSTRAP_LOGIN: ${COMPOSE_PROJECT_NAME}
-      CHATTO_BOOTSTRAP_EMAIL: ${COMPOSE_PROJECT_NAME}@${COMPOSE_PROJECT_NAME}.com
+      CHATTO_BOOTSTRAP_LOGIN: devuser
+      CHATTO_BOOTSTRAP_EMAIL: dev@dev.com
       CHATTO_BOOTSTRAP_PASSWORD: devpassword
       CHATTO_BOOTSTRAP_SPACE_NAME: ${COMPOSE_PROJECT_NAME}
     volumes:

--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,5 @@
 {
     "scripts": {
-        "setup": "mise trust && mise setup",
-        "run": "echo \"Starting on http://localhost:$CONDUCTOR_PORT\" && CHATTO_WEBSERVER_URL=http://localhost:$CONDUCTOR_PORT CHATTO_WEBSERVER_PORT=$CONDUCTOR_PORT CHATTO_NATS_EMBEDDED_PORT=0 CHATTO_BOOTSTRAP_LOGIN=hmans CHATTO_BOOTSTRAP_EMAIL=hendrik@mans.de CHATTO_BOOTSTRAP_PASSWORD=devpassword CHATTO_BOOTSTRAP_SPACE_NAME=Chatto CHATTO_SMTP_HOST=mailpit.chatto-tools.orb.local CHATTO_SMTP_PORT=1025 CHATTO_LIVEKIT_ENABLED=true CHATTO_LIVEKIT_URL=ws://livekit.chatto-tools.orb.local:7880 CHATTO_LIVEKIT_API_KEY=devkey CHATTO_LIVEKIT_API_SECRET=secret mise chatto run"
+        "run": "echo \"Starting on https://chatto-instance-$CONDUCTOR_WORKSPACE_NAME.orb.local/\" && docker compose -p chatto-instance-$CONDUCTOR_WORKSPACE_NAME up"
     }
 }

--- a/frontend/e2e/instance-flows.test.ts
+++ b/frontend/e2e/instance-flows.test.ts
@@ -267,8 +267,13 @@ test.describe('Create Space - Multi-Instance', () => {
 		await page.waitForLoadState('networkidle');
 		await page.goto(routes.newSpace);
 
-		// Instance picker should be visible (since we have 2 instances)
-		await expect(page.getByLabel('Instance')).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+		// Confirm we landed on the new-space page (auth could spuriously redirect us
+		// elsewhere if currentUser hydration lagged in CI — fail fast with a clear error).
+		await expect(page).toHaveURL(routes.newSpace, { timeout: TIMEOUTS.UI_STANDARD });
+
+		// Instance picker should be visible (since we have 2 instances).
+		// Use REALTIME_EVENT to give multi-instance hydration enough headroom on slow CI.
+		await expect(page.getByLabel('Instance')).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
 	});
 
 	test('create space works on selected instance', async ({ page, chatPage }) => {

--- a/frontend/e2e/instances.test.ts
+++ b/frontend/e2e/instances.test.ts
@@ -176,8 +176,15 @@ test.describe('Instances Page - Multi-Instance', () => {
 		await page.waitForLoadState('networkidle');
 		await page.goto(routes.instances);
 
-		// Scope to the remote instance's row (identified by hostname)
+		// Confirm we landed on /instances. The page redirects to /login if origin auth
+		// hasn't hydrated yet — assert here to fail fast with a clear error instead of
+		// timing out 30s later trying to click a button on the wrong page.
+		await expect(page).toHaveURL(routes.instances, { timeout: TIMEOUTS.UI_STANDARD });
+
+		// Scope to the remote instance's row (identified by hostname).
+		// Wait explicitly with REALTIME_EVENT — multi-instance hydration can be slow in CI.
 		const remoteRow = page.getByTestId('instance-row').filter({ hasText: remoteHostname });
+		await expect(remoteRow).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
 		await remoteRow.getByRole('button', { name: 'Disconnect' }).click();
 
 		// Confirmation modal should appear — click Cancel

--- a/frontend/src/lib/auth/loadAuth.ts
+++ b/frontend/src/lib/auth/loadAuth.ts
@@ -43,6 +43,10 @@ let cachedUser: CurrentUser | null = null;
  *
  * Uses a module-level cache to avoid redundant requests during navigation.
  * The cache is cleared when the user logs out (via clearCachedUser).
+ *
+ * On transient network errors (e.g., slow CI, server still warming up after reload),
+ * retries once before giving up. Without this, a single GraphQL hiccup makes the SPA
+ * render as unauthenticated and redirect away from authenticated routes.
  */
 export async function loadCurrentUser(): Promise<CurrentUser | null> {
   if (!browser) {
@@ -56,14 +60,23 @@ export async function loadCurrentUser(): Promise<CurrentUser | null> {
     return cachedUser;
   }
 
-  const resp = await graphqlClientManager.originClient.client.query(
-    LoadCurrentUserDocument,
-    {},
-    { requestPolicy: 'network-only' }
-  );
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const resp = await graphqlClientManager.originClient.client.query(
+      LoadCurrentUserDocument,
+      {},
+      { requestPolicy: 'network-only' }
+    );
 
-  cachedUser = resp.data?.me ?? null;
-  return cachedUser;
+    if (resp.error?.networkError && attempt === 0) {
+      await new Promise((r) => setTimeout(r, 200));
+      continue;
+    }
+
+    cachedUser = resp.data?.me ?? null;
+    return cachedUser;
+  }
+
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- `conductor.json`: replace the mise-based run script with `docker compose -p chatto-instance-$CONDUCTOR_WORKSPACE_NAME up`, echoing the OrbStack URL (`https://chatto-instance-<workspace>.orb.local/`) at startup.
- `compose.yml`: use static dev bootstrap credentials (`devuser` / `dev@dev.com` / `devpassword`) instead of project-name-derived ones, so every Conductor workspace logs in the same way.

## Test plan
- [ ] Spin up a Conductor workspace and verify the stack comes up and is reachable at the printed `.orb.local` URL.
- [ ] Log in with `devuser` / `devpassword`.