### PR TITLE
fix(frontend): break redirect loop when lastRoom/lastSpace is stale

### DIFF
--- a/frontend/src/lib/hooks/useRoomData.svelte.ts
+++ b/frontend/src/lib/hooks/useRoomData.svelte.ts
@@ -114,6 +114,13 @@ export function useRoomData(getProps: () => { spaceId: string; roomId: string })
       .then((resp) => {
         if (roomLoadId.current !== thisLoadId) return;
 
+        // Transient network failure (e.g., wake-from-sleep) — keep prior data
+        // visible and let the reconnect handler retry. Don't flip to null,
+        // which would trigger the not-found redirect path.
+        if (resp.error?.networkError) {
+          return;
+        }
+
         if (!resp.data?.room) {
           roomData = null;
           return;

--- a/frontend/src/routes/chat/[instanceId]/[spaceId]/+layout.svelte
+++ b/frontend/src/routes/chat/[instanceId]/[spaceId]/+layout.svelte
@@ -7,7 +7,7 @@
   import { getActiveInstance } from '$lib/state/activeInstance.svelte';
   import { instanceIdToSegment } from '$lib/navigation';
   import { graphql } from '$lib/gql';
-  import { setLastSpace } from '$lib/storage/lastRoom';
+  import { clearLastRoom, clearLastSpace, setLastSpace } from '$lib/storage/lastRoom';
   import { useActiveInstanceEvent, useReconnectCallback } from '$lib/hooks';
   import SecondarySidebar from '$lib/components/SecondarySidebar.svelte';
   import { createSpacePermissions } from '$lib/state/space';
@@ -62,8 +62,24 @@
   // Create space permissions context (must be synchronous during init)
   const updateSpacePermissions = createSpacePermissions();
 
-  // Validate space access - returns null if space doesn't exist or user has no access
-  async function validateSpace(spaceId: string) {
+  type SpaceData = {
+    id: string;
+    name: string;
+    bannerUrl: string | null;
+    hasAnyAdminPermission: boolean;
+    canManage: boolean;
+    canBrowseRooms: boolean;
+    canManageRooms: boolean;
+    canManageRoles: boolean;
+    canAssignRoles: boolean;
+    canInviteMembers: boolean;
+  };
+
+  // Validate space access. Returns the space data on success, null if the
+  // server says the space genuinely doesn't exist / isn't accessible, or
+  // 'transient' if the request failed with a network error (treat as
+  // "try again later", not as access denial).
+  async function validateSpace(spaceId: string): Promise<SpaceData | null | 'transient'> {
     const result = await connection()
       .client.query(
         graphql(`
@@ -86,6 +102,13 @@
         { spaceId }
       )
       .toPromise();
+
+    // Transient network failure (e.g., wake-from-sleep) — caller should
+    // preserve existing data and storage, and rely on the reconnect handler
+    // to revalidate.
+    if (result.error?.networkError) {
+      return 'transient';
+    }
 
     // Space doesn't exist or no access
     if (!result.data?.space) {
@@ -113,18 +136,7 @@
 
   // Space validation state - uses $state instead of async $derived to avoid race conditions
   // See egg t4x5m3 for the pattern explanation
-  let spaceData = $state<{
-    id: string;
-    name: string;
-    bannerUrl: string | null;
-    hasAnyAdminPermission: boolean;
-    canManage: boolean;
-    canBrowseRooms: boolean;
-    canManageRooms: boolean;
-    canManageRoles: boolean;
-    canAssignRoles: boolean;
-    canInviteMembers: boolean;
-  } | null>(null);
+  let spaceData = $state<SpaceData | null>(null);
   let validationLoadId = { current: 0 };
 
   // Force re-validation after genuine WebSocket reconnections (not instance switches).
@@ -169,14 +181,21 @@
         // Skip if spaceId changed while validating
         if (validationLoadId.current !== thisLoadId) return;
 
+        // Transient network error — keep prior state visible (or skeleton if
+        // none) and let the reconnect handler retry. Don't redirect or wipe
+        // storage; the user's place must survive a brief offline blip.
+        if (result === 'transient') {
+          return;
+        }
+
         spaceData = result;
         lastRevalidation = currentRevalidation;
 
-        // Don't clear lastSpace/lastRoom here: a transient network failure
-        // during wake-from-sleep produces the same null as genuine no-access,
-        // and wiping would lose the user's place. Storage is cleared only on
-        // explicit "leave space" via ModalContainer.
+        // Genuine "no access" — clear stored navigation hints for this space
+        // so we don't loop back here, then redirect away.
         if (result === null) {
+          clearLastSpace(getInstanceId());
+          clearLastRoom(getInstanceId(), currentSpaceId);
           goto(resolve('/chat/[instanceId]', { instanceId: instanceSegment }), { replaceState: true });
         }
       })

--- a/frontend/src/routes/chat/[instanceId]/[spaceId]/[roomId]/Room.svelte
+++ b/frontend/src/routes/chat/[instanceId]/[spaceId]/[roomId]/Room.svelte
@@ -17,7 +17,7 @@
   import { resolve } from '$app/paths';
   import { instanceIdToSegment } from '$lib/navigation';
   import { getActiveInstance } from '$lib/state/activeInstance.svelte';
-  import { setLastRoom } from '$lib/storage/lastRoom';
+  import { clearLastRoom, setLastRoom } from '$lib/storage/lastRoom';
   import PageTitle from '$lib/ui/PageTitle.svelte';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
   import { tick } from 'svelte';
@@ -86,12 +86,15 @@
 
   createRoomPermissions(() => permissions);
 
-  // Don't clear lastRoom here: a transient network failure during
-  // wake-from-sleep produces the same null as a genuinely missing room,
-  // and wiping would lose the user's place. Storage is cleared only on
-  // explicit "leave room" via ModalContainer.
+  // roomData === null means the server returned a clean response with no room
+  // (deleted, archived, no access). Transient network failures are filtered
+  // upstream in useRoomData, so reaching this branch is genuine — clear
+  // lastRoom so [spaceId]/+page.svelte's onMount doesn't redirect us right
+  // back here in an infinite loop.
   $effect.pre(() => {
     if (room.roomData === null) {
+      clearLastRoom(getInstanceId(), spaceId);
+
       if (room.isDM) {
         goto(resolve('/chat/dm'), { replaceState: true });
       } else {


### PR DESCRIPTION
## Summary

Clicking a space sometimes resulted in a blank main pane (often with the secondary sidebar visible but appearing to have an empty rooms list). Root cause: an infinite redirect loop introduced by #164 — when \`localStorage.lastRoom[S]\` pointed at a room that was no longer accessible (deleted, archived, or membership lost), \`+page.svelte\` redirected to that room, \`Room.svelte\` redirected back (without clearing \`lastRoom\`), and the cycle repeated.

This PR distinguishes urql transient network errors from genuine "not found" responses in both \`useRoomData\` and the \`[spaceId]\` validation effect. On a \`networkError\`, prior state and storage are preserved (preserving #164's wake-from-sleep fix). On a genuinely missing/inaccessible room or space, \`lastRoom\` / \`lastSpace\` are cleared before redirecting, breaking the loop.

## Test plan

- [x] \`mise run lint-frontend\` (svelte-check + eslint) — clean
- [x] \`mise run test-frontend\` — 489 passing
- [ ] Manual: set \`localStorage\` \`chatto:i:<id>:lastRooms\` to \`{"<spaceId>":"R_nonexistent"}\`, click that space — verify single redirect to the space's "No Room Selected" page (or first available room) instead of an infinite URL flicker.
- [ ] Manual regression for #164: navigate into a valid space + room, set DevTools Network to Offline, dispatch \`new Event('online')\`, return to Online — verify \`lastSpace\` and \`lastRooms\` survive.