### PR TITLE
test(e2e): bump playwright retries from 1 to 3

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   globalSetup: './e2e/global-setup.ts',
   testDir: 'e2e',
-  retries: 1,
+  retries: 3,
   reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
   maxFailures: 5,
   timeout: 30_000,


### PR DESCRIPTION
Increases Playwright retries back to 3 to reduce noise from flaky e2e tests in CI.