### PR TITLE
fix(frontend): stop blank lines doubling when editing messages

### DIFF
--- a/frontend/e2e/message-editing.test.ts
+++ b/frontend/e2e/message-editing.test.ts
@@ -469,6 +469,76 @@ test.describe('Message editing', () => {
     await expect(roomPage.attachButton).toBeVisible();
   });
 
+  test('editing a multi-line message does not double blank lines', async ({
+    page,
+    chatPage,
+    roomPage
+  }) => {
+    // Regression test: blank lines used to double on each edit-save cycle
+    // because plainTextToHtml emitted <p><br></p> for empty lines, and the
+    // HardBreak's renderText contributed an extra '\n' on top of the block
+    // separator when getText() serialized the doc back to plain text.
+
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.createSpace();
+    await chatPage.enterRoom('general');
+
+    // Compose "line1" + blank line + "line2". Shift+Enter inserts a hard
+    // break in the composer (Enter alone submits the message).
+    await roomPage.waitForInputEditable();
+    await roomPage.messageInput.click();
+    await page.keyboard.type('line1');
+    await page.keyboard.press('Shift+Enter');
+    await page.keyboard.press('Shift+Enter');
+    await page.keyboard.type('line2');
+    await roomPage.messageInput.press('Enter');
+
+    const message = roomPage.getMessage('line1');
+    await expect(message.locator).toBeVisible();
+
+    // Snapshot the composer's visible state: rendered text, rendered height,
+    // and paragraph count. All three grew on every edit-save cycle pre-fix,
+    // so any of them changing across cycles signals the regression.
+    const composerSnapshot = async () => ({
+      text: await roomPage.composer.evaluate((el: HTMLElement) => el.innerText),
+      height: await roomPage.getComposerHeight(),
+      paragraphs: await roomPage.composer.locator('p').count()
+    });
+
+    // Each edit cycle: open the editor, snapshot it, then save. The no-op
+    // change (Ctrl/Cmd+End to ensure cursor is at end of doc, then type a
+    // char and delete it) is essential: it forces the composer's `message`
+    // state to refresh from the editor's getText() output, which is the
+    // round-trip the bug lived in. Saving without any change would send the
+    // original body verbatim and bypass the bug.
+    const isMac = process.platform === 'darwin';
+    const docEnd = isMac ? 'Meta+ArrowDown' : 'Control+End';
+    const cycleAndSnapshot = async () => {
+      await message.startEdit();
+      await roomPage.expectEditModeActive();
+      const snapshot = await composerSnapshot();
+      await page.keyboard.press(docEnd);
+      await page.keyboard.type('x');
+      await page.keyboard.press('Backspace');
+      await roomPage.composer.press('Enter');
+      await roomPage.expectEditModeInactive();
+      return snapshot;
+    };
+
+    const firstEditState = await cycleAndSnapshot();
+    // Sanity-check the initial render: two content lines + one blank.
+    expect(firstEditState.paragraphs).toBe(3);
+
+    // Re-enter edit mode twice more. Pre-fix, each cycle would grow the
+    // composer state (paragraph count, height, rendered text) because every
+    // round-trip through plainTextToHtml + getText doubled the blank lines.
+    for (let i = 0; i < 2; i++) {
+      const state = await cycleAndSnapshot();
+      expect(state).toEqual(firstEditState);
+    }
+  });
+
   test('pending file attachments are cleared when entering edit mode', async ({
     page,
     chatPage,

--- a/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -643,10 +643,17 @@
     return false; // Let TipTap handle text pastes
   }
 
+  // Collapse runs of 3+ newlines down to 2 (one blank line max).
+  // Applied symmetrically on post and edit so blank-line runs don't
+  // accumulate over time and pasted blank-line runs stay reasonable.
+  function normalizeMessageBody(text: string): string {
+    return text.replace(/\n{3,}/g, '\n\n');
+  }
+
   async function postMessage() {
     // Require either non-empty message body or attachments.
     // hasVisibleContent rejects messages with only invisible Unicode characters.
-    const bodyToSend = message.trim();
+    const bodyToSend = normalizeMessageBody(message.trim());
     const hasBody = hasVisibleContent(bodyToSend);
     const filesToSend = selectedFiles.length > 0 ? [...selectedFiles] : null;
     if (!hasBody && !filesToSend) return;
@@ -729,7 +736,7 @@
   }
 
   async function editMessage() {
-    const trimmedBody = message.trim();
+    const trimmedBody = normalizeMessageBody(message.trim());
     if (!trimmedBody) {
       toast.error('Message cannot be empty');
       return;

--- a/frontend/src/lib/components/composer/TipTapEditor.svelte
+++ b/frontend/src/lib/components/composer/TipTapEditor.svelte
@@ -62,15 +62,17 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
 
   /**
    * Convert plain text to TipTap-compatible HTML.
-   * Each line becomes a paragraph; empty lines become empty paragraphs with <br>.
+   * Each line becomes a paragraph. Empty lines use `<p></p>` (no `<br>`):
+   * the HardBreak extension's renderText returns `\n`, so a `<br>` inside an
+   * empty paragraph would round-trip back through getText() as an extra
+   * newline on top of the block separator, doubling blank lines on each edit.
    */
   function plainTextToHtml(text: string): string {
     if (!text) return '<p></p>';
     return text
       .split('\n')
       .map((line) => {
-        if (!line) return '<p><br></p>';
-        // Escape HTML entities in the text
+        if (!line) return '<p></p>';
         const escaped = line.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
         return `<p>${escaped}</p>`;
       })


### PR DESCRIPTION
## Summary

When editing a multiline message containing blank lines, the blank lines doubled on every edit-save cycle (1 → 2 → 4 → 8…). Two changes fix it:

- **`TipTapEditor.plainTextToHtml`**: emit empty lines as `<p></p>` instead of `<p><br></p>`. The HardBreak extension's `renderText` returns `\n`, which was stacking on top of the block separator and doubling blank-line runs every round-trip through `getText()`.
- **`MessageComposer`**: collapse runs of 3+ newlines to 2 on both `postMessage` and `editMessage` — heals already-bloated bodies on the next edit and caps paste-bombs.

Added an E2E regression test that asserts the composer's visible state (rendered text, pixel height, paragraph count) stays identical across three edit-save cycles. Verified the test fails against the buggy code and passes with the fix.

## Test plan

- [x] `mise x -- pnpm run check` and `mise x -- pnpm run lint` pass
- [x] Full `message-editing.test.ts` suite (15 tests) passes
- [x] New regression test fails against reverted fix, passes with fix restored, stable across 5 consecutive runs