### PR TITLE
test(e2e): replace injectRemoteInstance with real OAuth-driven flow

### DIFF
--- a/cli/internal/http_server/test_endpoints.go
+++ b/cli/internal/http_server/test_endpoints.go
@@ -4,6 +4,7 @@ package http_server
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/charmbracelet/log"
 	"github.com/gin-contrib/sessions"
@@ -29,6 +30,7 @@ func createMailer(_ config.SMTPConfig) (*email.MockSender, email.Sender) {
 //   - DELETE /auth/test/emails - Clear all captured emails
 //   - POST /auth/test/verify-email - Directly verify a user's email
 //   - POST /auth/test/oauth-callback - Simulate OAuth callback
+//   - POST /auth/test/oauth-authorize - Mint an OAuth authorization code without UI interaction
 func registerTestEndpoints(auth *gin.RouterGroup, s *HTTPServer) {
 	if s.mockMailer == nil {
 		return
@@ -168,6 +170,59 @@ func registerTestEndpoints(auth *gin.RouterGroup, s *HTTPServer) {
 				"login": existingUser.Login,
 			},
 		})
+	})
+
+	// Test-only endpoint to mint an OAuth authorization code for a known user
+	// without going through the login UI. Used by multi-instance E2E tests that
+	// drive the real /instances/add → /oauth/authorize → /instances/callback
+	// flow but bypass the human OAuth login form via Playwright route interception.
+	auth.POST("test/oauth-authorize", func(c *gin.Context) {
+		var req struct {
+			UserID              string `json:"userId" binding:"required"`
+			RedirectURI         string `json:"redirectUri" binding:"required"`
+			CodeChallenge       string `json:"codeChallenge" binding:"required"`
+			CodeChallengeMethod string `json:"codeChallengeMethod" binding:"required"`
+			State               string `json:"state"`
+		}
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		if req.CodeChallengeMethod != "S256" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "code_challenge_method must be S256"})
+			return
+		}
+		if !isValidRedirectURI(req.RedirectURI) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid redirect_uri: must be HTTPS or localhost"})
+			return
+		}
+
+		ctx := c.Request.Context()
+		if _, err := s.core.GetUser(ctx, req.UserID); err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "user not found: " + err.Error()})
+			return
+		}
+
+		code, err := s.core.CreateAuthCode(ctx, req.UserID, req.RedirectURI, req.CodeChallenge, req.CodeChallengeMethod)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create auth code: " + err.Error()})
+			return
+		}
+
+		u, err := url.Parse(req.RedirectURI)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid redirect_uri"})
+			return
+		}
+		q := u.Query()
+		q.Set("code", code)
+		if req.State != "" {
+			q.Set("state", req.State)
+		}
+		u.RawQuery = q.Encode()
+
+		c.JSON(http.StatusOK, gin.H{"redirectURL": u.String()})
 	})
 }
 

--- a/frontend/e2e/fixtures/multiInstance.ts
+++ b/frontend/e2e/fixtures/multiInstance.ts
@@ -236,70 +236,66 @@ export async function getRoomOnRemote(
 }
 
 /**
- * Gets the instance name from a remote server.
+ * Drives the real /instances/add → /oauth/authorize → /instances/callback flow
+ * to add `remoteServer` as a connected instance, while bypassing the human
+ * OAuth login form. The remote's `/oauth/authorize` request is intercepted via
+ * Playwright's `page.route`; we POST the PKCE params to the test-only
+ * `/auth/test/oauth-authorize` endpoint to mint a real authorization code,
+ * then fulfill the navigation with a 302 to the callback URL. From there the
+ * origin's callback page runs unchanged: PKCE verifier exchange via
+ * `/oauth/token`, real bearer token, real `instanceRegistry.addInstance()`.
+ *
+ * The user identified by `userId` must already exist on the remote (use
+ * `createUserOnRemote` to create one).
  */
-async function getInstanceName(remoteBaseURL: string): Promise<string> {
-	const response = await fetch(`${remoteBaseURL}/api/instance`);
-	if (!response.ok) {
-		return 'Remote Instance';
-	}
-	const data = await response.json();
-	return data.name ?? 'Remote Instance';
-}
-
-/**
- * Injects a remote instance into the browser's localStorage so the
- * frontend treats it as a connected instance. After injection, the page
- * must be reloaded for the instance registry to pick it up.
- */
-export async function injectRemoteInstance(
+export async function connectRemoteInstance(
 	page: Page,
 	remoteServer: ServerInfo,
-	token: string,
-	userId: string,
-	nameOverride?: string
-): Promise<string> {
-	const instanceName = nameOverride ?? (await getInstanceName(remoteServer.baseURL));
+	userId: string
+): Promise<void> {
+	const remoteBaseURL = remoteServer.baseURL;
+	const remoteOrigin = new URL(remoteBaseURL).origin;
+	const hostname = new URL(remoteBaseURL).host;
 
-	const instanceId = await page.evaluate(
-		({ url, token, userId, name }) => {
-			const STORAGE_KEY = 'chatto:instances';
-			const instances = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
-			const existingIds = instances.map((i: { id: string }) => i.id);
+	// Intercept the navigation to the remote's /oauth/authorize and fulfill
+	// with a 302 to the callback URL carrying a real authorization code.
+	await page.route(`${remoteOrigin}/oauth/authorize*`, async (route) => {
+		const requestUrl = new URL(route.request().url());
+		const codeChallenge = requestUrl.searchParams.get('code_challenge') ?? '';
+		const codeChallengeMethod =
+			requestUrl.searchParams.get('code_challenge_method') ?? '';
+		const redirectUri = requestUrl.searchParams.get('redirect_uri') ?? '';
+		const state = requestUrl.searchParams.get('state') ?? '';
 
-			// Generate ID from hostname (mirrors generateInstanceId in instanceRegistry)
-			let hostname: string;
-			try {
-				hostname = new URL(url).hostname;
-			} catch {
-				hostname = url.replace(/[^a-z0-9-]/gi, '-');
-			}
-			let id = hostname.replace(/\./g, '-').replace(/^-+|-+$/g, '');
-
-			// Handle duplicate IDs (e.g., multiple localhost instances)
-			if (existingIds.includes(id)) {
-				let suffix = 2;
-				while (existingIds.includes(`${id}-${suffix}`)) {
-					suffix++;
-				}
-				id = `${id}-${suffix}`;
-			}
-
-			instances.push({
-				id,
-				url,
-				name,
-				iconUrl: null,
-				token,
+		const resp = await fetch(`${remoteBaseURL}/auth/test/oauth-authorize`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
 				userId,
-				addedAt: Date.now()
-			});
+				redirectUri,
+				codeChallenge,
+				codeChallengeMethod,
+				state
+			})
+		});
 
-			localStorage.setItem(STORAGE_KEY, JSON.stringify(instances));
-			return id;
-		},
-		{ url: remoteServer.baseURL, token, userId, name: instanceName }
-	);
+		if (!resp.ok) {
+			throw new Error(
+				`test/oauth-authorize failed (${resp.status}): ${await resp.text()}`
+			);
+		}
 
-	return instanceId;
+		const { redirectURL } = (await resp.json()) as { redirectURL: string };
+		await route.fulfill({
+			status: 302,
+			headers: { Location: redirectURL }
+		});
+	});
+
+	// Drive the real UI: probe → PKCE state → would-redirect to /oauth/authorize
+	// (intercepted) → /instances/callback → token exchange → addInstance.
+	await page.goto(`/instances/add/${hostname}`);
+
+	// Callback page redirects to /chat/spaces on success.
+	await page.waitForURL(/\/chat\/spaces/);
 }

--- a/frontend/e2e/instance-flows.test.ts
+++ b/frontend/e2e/instance-flows.test.ts
@@ -4,7 +4,7 @@ import {
 	startSecondServer,
 	stopSecondServer,
 	createUserOnRemote,
-	injectRemoteInstance
+	connectRemoteInstance
 } from './fixtures/multiInstance';
 import type { ServerInfo } from './fixtures/server';
 import * as routes from './routes';
@@ -250,20 +250,11 @@ test.describe('Create Space - Multi-Instance', () => {
 		await createAndLoginTestUser(page);
 		await chatPage.goto();
 
-		// Add remote instance
+		// Add remote instance via the real /instances/add → OAuth → callback flow
 		const baseURL = remoteBaseURL(remoteServer);
 		const remoteUser = await createUserOnRemote(baseURL, 'remoteuser', 'password123');
-		await injectRemoteInstance(
-			page,
-			{ ...remoteServer, baseURL },
-			remoteUser.token,
-			remoteUser.userId,
-			'Remote Space Server'
-		);
+		await connectRemoteInstance(page, { ...remoteServer, baseURL }, remoteUser.userId);
 
-		// Reload and navigate to create space
-		await page.reload();
-		await page.waitForLoadState('networkidle');
 		await page.goto(routes.newSpace);
 
 		// Confirm we landed on the new-space page (auth could spuriously redirect us

--- a/frontend/e2e/instances.test.ts
+++ b/frontend/e2e/instances.test.ts
@@ -4,7 +4,7 @@ import {
 	startSecondServer,
 	stopSecondServer,
 	createUserOnRemote,
-	injectRemoteInstance
+	connectRemoteInstance
 } from './fixtures/multiInstance';
 import type { ServerInfo } from './fixtures/server';
 import * as routes from './routes';
@@ -84,20 +84,11 @@ test.describe('Instances Page - Multi-Instance', () => {
 		await createAndLoginTestUser(page);
 		await chatPage.goto();
 
-		// Set up remote instance
+		// Set up remote instance via the real /instances/add → OAuth → callback flow
 		const baseURL = remoteBaseURL(remoteServer);
 		const remoteHostname = new URL(baseURL).hostname;
 		const remoteUser = await createUserOnRemote(baseURL, 'remoteuser1', 'password123');
-		await injectRemoteInstance(
-			page,
-			{ ...remoteServer, baseURL },
-			remoteUser.token,
-			remoteUser.userId
-		);
-
-		// Reload to pick up the injected instance
-		await page.reload();
-		await page.waitForLoadState('networkidle');
+		await connectRemoteInstance(page, { ...remoteServer, baseURL }, remoteUser.userId);
 
 		// Navigate to instances page
 		await page.goto(routes.instances);
@@ -119,20 +110,12 @@ test.describe('Instances Page - Multi-Instance', () => {
 		await createAndLoginTestUser(page);
 		await chatPage.goto();
 
-		// Set up remote instance
+		// Set up remote instance via the real /instances/add → OAuth → callback flow
 		const baseURL = remoteBaseURL(remoteServer);
 		const remoteHostname = new URL(baseURL).hostname;
 		const remoteUser = await createUserOnRemote(baseURL, 'remoteuser2', 'password123');
-		await injectRemoteInstance(
-			page,
-			{ ...remoteServer, baseURL },
-			remoteUser.token,
-			remoteUser.userId
-		);
+		await connectRemoteInstance(page, { ...remoteServer, baseURL }, remoteUser.userId);
 
-		// Reload and navigate to instances page
-		await page.reload();
-		await page.waitForLoadState('networkidle');
 		await page.goto(routes.instances);
 
 		// Scope to the remote instance's row (identified by hostname)
@@ -160,20 +143,12 @@ test.describe('Instances Page - Multi-Instance', () => {
 		await createAndLoginTestUser(page);
 		await chatPage.goto();
 
-		// Set up remote instance
+		// Set up remote instance via the real /instances/add → OAuth → callback flow
 		const baseURL = remoteBaseURL(remoteServer);
 		const remoteHostname = new URL(baseURL).hostname;
 		const remoteUser = await createUserOnRemote(baseURL, 'remoteuser3', 'password123');
-		await injectRemoteInstance(
-			page,
-			{ ...remoteServer, baseURL },
-			remoteUser.token,
-			remoteUser.userId
-		);
+		await connectRemoteInstance(page, { ...remoteServer, baseURL }, remoteUser.userId);
 
-		// Reload and navigate to instances page
-		await page.reload();
-		await page.waitForLoadState('networkidle');
 		await page.goto(routes.instances);
 
 		// Confirm we landed on /instances. The page redirects to /login if origin auth

--- a/frontend/e2e/multi-instance-browse.test.ts
+++ b/frontend/e2e/multi-instance-browse.test.ts
@@ -5,7 +5,7 @@ import {
 	stopSecondServer,
 	createUserOnRemote,
 	createSpaceOnRemote,
-	injectRemoteInstance
+	connectRemoteInstance
 } from './fixtures/multiInstance';
 import { ExplorePage } from './pages/ExplorePage';
 import type { ServerInfo } from './fixtures/server';
@@ -35,10 +35,8 @@ test.describe('Multi-Instance Browse Spaces', () => {
 		const remoteUser = await createUserOnRemote(remoteServer.baseURL, 'remoteuser1', 'password123');
 		await createSpaceOnRemote(remoteServer.baseURL, remoteUser.token, 'Remote Space');
 
-		// Inject remote instance into the browser and reload to pick it up
-		await injectRemoteInstance(page, remoteServer, remoteUser.token, remoteUser.userId);
-		await page.reload();
-		await page.waitForLoadState('networkidle');
+		// Connect remote instance via the real /instances/add → OAuth → callback flow
+		await connectRemoteInstance(page, remoteServer, remoteUser.userId);
 
 		// Navigate to Browse Spaces
 		const explorePage = new ExplorePage(page);
@@ -67,10 +65,8 @@ test.describe('Multi-Instance Browse Spaces', () => {
 		await createSpaceOnRemote(remoteServer.baseURL, remoteUser.token, 'Alpha Remote');
 		await createSpaceOnRemote(remoteServer.baseURL, remoteUser.token, 'Gamma Remote');
 
-		// Inject remote instance and reload to pick it up
-		await injectRemoteInstance(page, remoteServer, remoteUser.token, remoteUser.userId);
-		await page.reload();
-		await page.waitForLoadState('networkidle');
+		// Connect remote instance via the real /instances/add → OAuth → callback flow
+		await connectRemoteInstance(page, remoteServer, remoteUser.userId);
 
 		const explorePage = new ExplorePage(page);
 		await explorePage.goto();
@@ -104,10 +100,8 @@ test.describe('Multi-Instance Browse Spaces', () => {
 		await createSpaceOnRemote(remoteServer.baseURL, remoteOwner.token, 'Join Me Remote');
 		const remoteBrowser = await createUserOnRemote(remoteServer.baseURL, 'remotebrowser3', 'password123');
 
-		// Inject remote instance with the browser user (who hasn't joined the space)
-		await injectRemoteInstance(page, remoteServer, remoteBrowser.token, remoteBrowser.userId);
-		await page.reload();
-		await page.waitForLoadState('networkidle');
+		// Connect remote instance with the browser user (who hasn't joined the space)
+		await connectRemoteInstance(page, remoteServer, remoteBrowser.userId);
 
 		const explorePage = new ExplorePage(page);
 		await explorePage.goto();

--- a/frontend/e2e/multi-instance-identity.test.ts
+++ b/frontend/e2e/multi-instance-identity.test.ts
@@ -8,7 +8,7 @@ import {
 	joinSpaceOnRemote,
 	sendTypingOnRemote,
 	getRoomOnRemote,
-	injectRemoteInstance
+	connectRemoteInstance
 } from './fixtures/multiInstance';
 import { RoomPage } from './pages';
 import type { ServerInfo } from './fixtures/server';
@@ -50,13 +50,8 @@ test.describe('Multi-Instance Identity', () => {
 		await joinSpaceOnRemote(baseURL, remoteBrowser.token, spaceId);
 		const roomId = await getRoomOnRemote(baseURL, remoteOwner.token, spaceId, 'general');
 
-		// Inject remote instance and navigate directly to the room
-		await injectRemoteInstance(
-			page,
-			{ ...remoteServer, baseURL },
-			remoteBrowser.token,
-			remoteBrowser.userId
-		);
+		// Connect remote instance and navigate directly to the room
+		await connectRemoteInstance(page, { ...remoteServer, baseURL }, remoteBrowser.userId);
 		await page.goto(routes.remote.room('127.0.0.1', spaceId, roomId));
 		await page.waitForLoadState('networkidle');
 
@@ -88,13 +83,8 @@ test.describe('Multi-Instance Identity', () => {
 		await joinSpaceOnRemote(baseURL, remoteBrowser.token, spaceId);
 		const roomId = await getRoomOnRemote(baseURL, remoteOwner.token, spaceId, 'general');
 
-		// Inject remote instance and navigate directly to the room
-		await injectRemoteInstance(
-			page,
-			{ ...remoteServer, baseURL },
-			remoteBrowser.token,
-			remoteBrowser.userId
-		);
+		// Connect remote instance and navigate directly to the room
+		await connectRemoteInstance(page, { ...remoteServer, baseURL }, remoteBrowser.userId);
 		await page.goto(routes.remote.room('127.0.0.1', spaceId, roomId));
 		await page.waitForLoadState('networkidle');
 
@@ -128,13 +118,8 @@ test.describe('Multi-Instance Identity', () => {
 		await joinSpaceOnRemote(baseURL, remoteViewer.token, spaceId);
 		const roomId = await getRoomOnRemote(baseURL, remoteOwner.token, spaceId, 'general');
 
-		// Inject remote instance with the viewer user and navigate directly
-		await injectRemoteInstance(
-			page,
-			{ ...remoteServer, baseURL },
-			remoteViewer.token,
-			remoteViewer.userId
-		);
+		// Connect remote instance with the viewer user and navigate directly
+		await connectRemoteInstance(page, { ...remoteServer, baseURL }, remoteViewer.userId);
 		await page.goto(routes.remote.room('127.0.0.1', spaceId, roomId));
 		await page.waitForLoadState('networkidle');
 

--- a/frontend/e2e/unified-dm-inbox.test.ts
+++ b/frontend/e2e/unified-dm-inbox.test.ts
@@ -4,7 +4,7 @@ import {
 	startSecondServer,
 	stopSecondServer,
 	createUserOnRemote,
-	injectRemoteInstance
+	connectRemoteInstance
 } from './fixtures/multiInstance';
 import type { ServerInfo } from './fixtures/server';
 import { TIMEOUTS } from './constants';
@@ -150,10 +150,8 @@ test.describe('Unified DM Inbox — Multi-Instance', () => {
 			`Remote DM ${Date.now()}`
 		);
 
-		// 4. Inject remote instance and reload
-		await injectRemoteInstance(page, remoteServer, remoteUser.token, remoteUser.userId);
-		await page.reload();
-		await page.waitForLoadState('networkidle');
+		// 4. Connect remote instance via the real /instances/add → OAuth → callback flow
+		await connectRemoteInstance(page, remoteServer, remoteUser.userId);
 
 		// 5. Navigate to unified DM inbox
 		await page.goto(routes.dm);
@@ -189,10 +187,8 @@ test.describe('Unified DM Inbox — Multi-Instance', () => {
 			'password123'
 		);
 
-		// Inject remote instance and reload
-		await injectRemoteInstance(page, remoteServer, remoteUser.token, remoteUser.userId);
-		await page.reload();
-		await page.waitForLoadState('networkidle');
+		// Connect remote instance via the real /instances/add → OAuth → callback flow
+		await connectRemoteInstance(page, remoteServer, remoteUser.userId);
 
 		// Navigate to DM inbox
 		await page.goto(routes.dm);


### PR DESCRIPTION
## Summary

- Adds `POST /auth/test/oauth-authorize` behind the `test_endpoints` build tag, which mints a real authorization code via `core.CreateAuthCode` for a known user + PKCE pair and returns the redirect URL the OAuth provider would normally redirect to.
- Replaces the racy `injectRemoteInstance` helper (which wrote `chatto:instances` localStorage directly and got clobbered by background `saveInstances` writes) with `connectRemoteInstance`, which intercepts the navigation to the remote `/oauth/authorize` via Playwright `page.route`, calls the new endpoint, and fulfills with a 302 to `/instances/callback`. The origin's callback page runs unchanged from there: PKCE verifier exchange, real bearer token, atomic `instanceRegistry.addInstance()`. Migrates all 12 call sites; the existing real-OAuth-form test in `instance-flows.test.ts` is intentionally left as-is.

Closes #171.

## Test plan

- [x] \`mise x -- pnpm check\` (svelte-check) — 0 errors, 0 warnings
- [x] \`mise x -- pnpm lint\` — clean
- [x] \`go test -tags test_endpoints ./internal/http_server/...\` — pass
- [x] Playwright \`instances.test.ts\` + \`instance-flows.test.ts\` with \`--workers=4 --repeat-each=5\`: 110/110 pass
- [x] Playwright \`multi-instance-browse\` + \`multi-instance-identity\` + \`unified-dm-inbox\`: 14/14 pass
- [ ] CI on ubicloud (where the race used to surface deterministically)