### PR TITLE
Security quick-wins: 9 fixes (Critical → Low)

### DIFF
--- a/.claude/rules/authorization.md
+++ b/.claude/rules/authorization.md
@@ -5,7 +5,7 @@ This document describes the authorization requirements and policies for Chatto's
 ## Core Principles
 
 1. **Users are bound to an instance** - All users exist within a single Chatto instance
-2. **Spaces are discoverable** - Users can browse all spaces for discovery purposes
+2. **Spaces are discoverable** - Users can browse all spaces for discovery purposes. **Anonymous callers always see all spaces** regardless of any `space.list` permission configuration on the `everyone` role; revoking `space.list` only affects authenticated non-members. To make an instance fully private, place it behind a reverse-proxy auth layer or disable the `Query.spaces` / `Query.space(id)` resolvers via a future configuration flag — the GraphQL gateway alone cannot enforce private-instance discovery.
 3. **Room access requires space membership** - Users must join a space before accessing its rooms
 4. **Message access requires room membership** - Users can only read/write messages in rooms they've joined
 5. **User profiles are public** - Basic user info (id, login, displayName, avatar) is visible to all authenticated users

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -31,12 +31,20 @@ var initCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// Generate a random session secret (32 bytes = 256 bits)
+		// Generate a random session signing secret (32 bytes = 256 bits)
 		sessionSecret := make([]byte, 32)
 		if _, err := rand.Read(sessionSecret); err != nil {
 			log.Fatal("Failed to generate session secret", "error", err)
 		}
 		sessionSecretString := hex.EncodeToString(sessionSecret)
+
+		// Generate a random session encryption secret (32 bytes = AES-256).
+		// Decoded back to raw bytes at server startup.
+		cookieEncryptionSecret := make([]byte, 32)
+		if _, err := rand.Read(cookieEncryptionSecret); err != nil {
+			log.Fatal("Failed to generate cookie encryption secret", "error", err)
+		}
+		cookieEncryptionSecretString := hex.EncodeToString(cookieEncryptionSecret)
 
 		// Generate a random signing secret for assets (32 bytes = 256 bits)
 		signingSecret := make([]byte, 32)
@@ -62,9 +70,10 @@ var initCmd = &cobra.Command{
 				DirectRegistration: &directRegistration,
 			},
 			Webserver: config.WebserverConfig{
-				Port:                4000,
-				URL:                 "http://localhost:4000",
-				CookieSigningSecret: sessionSecretString,
+				Port:                   4000,
+				URL:                    "http://localhost:4000",
+				CookieSigningSecret:    sessionSecretString,
+				CookieEncryptionSecret: cookieEncryptionSecretString,
 			},
 			Core: config.CoreConfig{
 				Assets: config.AssetsConfig{

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"slices"
 	"strings"
 	"time"
 
@@ -289,8 +288,19 @@ type AdminConfig struct {
 }
 
 // IsInstanceAdminEmail checks if an email is in the admin list.
+//
+// The comparison is case-insensitive and trims surrounding whitespace on both
+// sides. Both `c.Emails` and the user-supplied `email` are normalized at the
+// call site rather than at config load so that mutations to `c.Emails` (rare)
+// don't need to remember to re-normalize.
 func (c *AdminConfig) IsInstanceAdminEmail(email string) bool {
-	return slices.Contains(c.Emails, email)
+	needle := strings.TrimSpace(email)
+	for _, e := range c.Emails {
+		if strings.EqualFold(strings.TrimSpace(e), needle) {
+			return true
+		}
+	}
+	return false
 }
 
 // SMTPConfig contains settings for sending transactional emails.

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -64,14 +64,15 @@ func (c *TLSConfig) HTTPPortOrDefault() int {
 }
 
 type WebserverConfig struct {
-	URL                  string    `toml:"url" env:"CHATTO_WEBSERVER_URL" comment:"Public URL where the webserver is accessible. Used for generating absolute URLs."`
-	Port                 int       `toml:"port" env:"CHATTO_WEBSERVER_PORT" comment:"Port for the webserver to listen on."`
-	AllowedOrigins       []string  `toml:"allowed_origins" env:"CHATTO_WEBSERVER_ALLOWED_ORIGINS" comment:"Additional origins allowed for CORS and WebSocket connections. Defaults to wildcard (*) for multi-instance support. Set explicitly to restrict cross-origin access."`
-	WebSocketCompression *bool     `toml:"websocket_compression" env:"CHATTO_WEBSERVER_WEBSOCKET_COMPRESSION" comment:"Enable WebSocket compression for GraphQL connections. Reduces bandwidth but uses more CPU. Default: true."`
-	RequestLogging       *bool     `toml:"request_logging" env:"CHATTO_WEBSERVER_REQUEST_LOGGING" comment:"Log HTTP requests. Useful for debugging but can be noisy in production. Default: false."`
-	CookieSigningSecret  string    `toml:"cookie_signing_secret" env:"CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET" comment:"Secret for signing session cookies. NEVER SHARE THIS!\nIf it leaks, change it immediately, but please note that all existing sessions will become invalid."`
-	DevMode              bool      `toml:"dev_mode" env:"CHATTO_WEBSERVER_DEV_MODE" comment:"Enable developer-mode endpoints: GraphQL introspection and the /api/playground UI. Default: false. Do NOT enable in production — it lets unauthenticated callers enumerate the full schema."`
-	TLS                  TLSConfig `toml:"tls" comment:"Automatic TLS configuration via Let's Encrypt."`
+	URL                    string    `toml:"url" env:"CHATTO_WEBSERVER_URL" comment:"Public URL where the webserver is accessible. Used for generating absolute URLs."`
+	Port                   int       `toml:"port" env:"CHATTO_WEBSERVER_PORT" comment:"Port for the webserver to listen on."`
+	AllowedOrigins         []string  `toml:"allowed_origins" env:"CHATTO_WEBSERVER_ALLOWED_ORIGINS" comment:"Additional origins allowed for CORS and WebSocket connections. Defaults to wildcard (*) for multi-instance support. Set explicitly to restrict cross-origin access."`
+	WebSocketCompression   *bool     `toml:"websocket_compression" env:"CHATTO_WEBSERVER_WEBSOCKET_COMPRESSION" comment:"Enable WebSocket compression for GraphQL connections. Reduces bandwidth but uses more CPU. Default: true."`
+	RequestLogging         *bool     `toml:"request_logging" env:"CHATTO_WEBSERVER_REQUEST_LOGGING" comment:"Log HTTP requests. Useful for debugging but can be noisy in production. Default: false."`
+	CookieSigningSecret    string    `toml:"cookie_signing_secret" env:"CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET" comment:"Secret for signing session cookies. NEVER SHARE THIS!\nIf it leaks, change it immediately, but please note that all existing sessions will become invalid."`
+	CookieEncryptionSecret string    `toml:"cookie_encryption_secret" env:"CHATTO_WEBSERVER_COOKIE_ENCRYPTION_SECRET" comment:"Optional hex-encoded secret used to encrypt session cookies (in addition to signing). Must decode to 16, 24, or 32 bytes (AES-128/192/256). If unset, cookies are signed but not encrypted — anything ever written to the session is readable by anyone who steals the cookie."`
+	DevMode                bool      `toml:"dev_mode" env:"CHATTO_WEBSERVER_DEV_MODE" comment:"Enable developer-mode endpoints: GraphQL introspection and the /api/playground UI. Default: false. Do NOT enable in production — it lets unauthenticated callers enumerate the full schema."`
+	TLS                    TLSConfig `toml:"tls" comment:"Automatic TLS configuration via Let's Encrypt."`
 }
 
 // WebSocketCompressionEnabled returns whether WebSocket compression is enabled (default: true)

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -70,6 +70,7 @@ type WebserverConfig struct {
 	WebSocketCompression *bool     `toml:"websocket_compression" env:"CHATTO_WEBSERVER_WEBSOCKET_COMPRESSION" comment:"Enable WebSocket compression for GraphQL connections. Reduces bandwidth but uses more CPU. Default: true."`
 	RequestLogging       *bool     `toml:"request_logging" env:"CHATTO_WEBSERVER_REQUEST_LOGGING" comment:"Log HTTP requests. Useful for debugging but can be noisy in production. Default: false."`
 	CookieSigningSecret  string    `toml:"cookie_signing_secret" env:"CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET" comment:"Secret for signing session cookies. NEVER SHARE THIS!\nIf it leaks, change it immediately, but please note that all existing sessions will become invalid."`
+	DevMode              bool      `toml:"dev_mode" env:"CHATTO_WEBSERVER_DEV_MODE" comment:"Enable developer-mode endpoints: GraphQL introspection and the /api/playground UI. Default: false. Do NOT enable in production — it lets unauthenticated callers enumerate the full schema."`
 	TLS                  TLSConfig `toml:"tls" comment:"Automatic TLS configuration via Let's Encrypt."`
 }
 

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -391,10 +391,10 @@ func TestChattoConfig_Validate_EmbeddedNATS(t *testing.T) {
 			},
 			NATS: NATSConfig{
 				Embedded: EmbeddedNATSConfig{
-					Enabled:    true,
-					Port:       4222,
-					HTTPPort:   8222,
-					DataDir:    "./data",
+					Enabled:   true,
+					Port:      4222,
+					HTTPPort:  8222,
+					DataDir:   "./data",
 					AuthToken: "test-token",
 				},
 			},
@@ -975,6 +975,33 @@ func TestDuration_UnmarshalText(t *testing.T) {
 			}
 			if !tt.wantErr && d.Duration() != tt.want {
 				t.Errorf("UnmarshalText(%q) = %v, want %v", tt.input, d.Duration(), tt.want)
+			}
+		})
+	}
+}
+
+func TestAdminConfig_IsInstanceAdminEmail(t *testing.T) {
+	cfg := &AdminConfig{Emails: []string{"Admin@Example.com", "  ops@example.com  "}}
+
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"exact match", "Admin@Example.com", true},
+		{"different case in user input", "admin@example.com", true},
+		{"different case in config", "ADMIN@EXAMPLE.COM", true},
+		{"surrounding whitespace tolerated on input", "  admin@example.com  ", true},
+		{"surrounding whitespace tolerated in config", "ops@example.com", true},
+		{"non-admin email", "other@example.com", false},
+		{"empty string", "", false},
+		{"substring is not enough", "admin@example.co", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cfg.IsInstanceAdminEmail(tt.input); got != tt.want {
+				t.Errorf("IsInstanceAdminEmail(%q) = %v, want %v", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/cli/internal/graph/admin.resolvers.go
+++ b/cli/internal/graph/admin.resolvers.go
@@ -8,6 +8,7 @@ package graph
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"hmans.de/chatto/internal/core"
 	"hmans.de/chatto/internal/graph/auth"
@@ -233,11 +234,29 @@ func (r *adminQueriesResolver) StreamSubjects(ctx context.Context, obj *model.Ad
 
 // KvKeys is the resolver for the kvKeys field.
 func (r *adminQueriesResolver) KvKeys(ctx context.Context, obj *model.AdminQueries, name string) ([]string, error) {
+	if _, denied := sensitiveKVBuckets[name]; denied {
+		return nil, fmt.Errorf("access to bucket %q is denied: contents are security-sensitive", name)
+	}
+
 	keys, err := r.core.GetKVKeys(ctx, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get KV keys: %w", err)
 	}
-	return keys, nil
+
+	filtered := keys[:0]
+	for _, k := range keys {
+		skip := false
+		for _, p := range sensitiveKeyPrefixes {
+			if strings.HasPrefix(k, p) {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			filtered = append(filtered, k)
+		}
+	}
+	return filtered, nil
 }
 
 // InstanceConfig is the resolver for the instanceConfig field.

--- a/cli/internal/graph/admin_helpers.go
+++ b/cli/internal/graph/admin_helpers.go
@@ -1,0 +1,20 @@
+package graph
+
+// Buckets whose key listings would expose secrets directly. The keys in these
+// buckets ARE the secrets (auth tokens stored as KV keys, encryption-key
+// owner ids), so admins listing them would gain a one-query path to user
+// impersonation — violates the privacy boundary documented in
+// .claude/rules/admin.md.
+var sensitiveKVBuckets = map[string]struct{}{
+	"KV_AUTH_TOKENS":     {},
+	"KV_ENCRYPTION_KEYS": {},
+}
+
+// Key prefixes inside otherwise-inspectable buckets where the key itself is a
+// short-lived secret token (the value is just metadata about the token).
+// The bucket as a whole is operational metadata; only these keys are hidden.
+var sensitiveKeyPrefixes = []string{
+	"password_reset.",
+	"account_deletion_token.",
+	"email_verification.",
+}

--- a/cli/internal/graph/admin_test.go
+++ b/cli/internal/graph/admin_test.go
@@ -260,3 +260,46 @@ func TestAdminQuery_Authorization(t *testing.T) {
 		}
 	})
 }
+
+// ============================================================================
+// KvKeys Sensitive-Bucket Filtering
+// ============================================================================
+// These tests lock in the privacy-boundary contract from .claude/rules/admin.md:
+// instance admins can see operational metadata but NEVER user-secret material.
+// Without these guards, an admin running `query { admin { kvKeys(name: "KV_AUTH_TOKENS") } }`
+// would get a list of every active bearer token (since tokens are stored as
+// KV keys verbatim) and could impersonate any logged-in user.
+
+func TestAdminQuery_KvKeys_DeniesSensitiveBuckets(t *testing.T) {
+	env := setupTestResolverWithAdmin(t, []string{"testuser@example.com"})
+	resolver := env.resolver.AdminQueries()
+	queries := &model.AdminQueries{}
+
+	for _, bucket := range []string{"KV_AUTH_TOKENS", "KV_ENCRYPTION_KEYS"} {
+		t.Run(bucket, func(t *testing.T) {
+			_, err := resolver.KvKeys(env.authContext(), queries, bucket)
+			if err == nil {
+				t.Fatalf("expected denial for %s, got nil error (bucket contents are readable)", bucket)
+			}
+		})
+	}
+}
+
+func TestAdminQuery_KvKeys_SensitivePrefixListIsExpected(t *testing.T) {
+	// Pin the prefix list so a future regression that removes one of these
+	// fails loud. Adding new prefixes to sensitiveKeyPrefixes (good) requires
+	// updating this test; removing one (bad) does too.
+	want := map[string]bool{
+		"password_reset.":         true,
+		"account_deletion_token.": true,
+		"email_verification.":     true,
+	}
+	if len(sensitiveKeyPrefixes) != len(want) {
+		t.Fatalf("sensitiveKeyPrefixes length changed: got %d, want %d. Update this test if intentional.", len(sensitiveKeyPrefixes), len(want))
+	}
+	for _, p := range sensitiveKeyPrefixes {
+		if !want[p] {
+			t.Errorf("unexpected entry in sensitiveKeyPrefixes: %q", p)
+		}
+	}
+}

--- a/cli/internal/graph/generated.go
+++ b/cli/internal/graph/generated.go
@@ -325,7 +325,6 @@ type ComplexityRoot struct {
 		CreateRoom                       func(childComplexity int, input model.CreateRoomInput) int
 		CreateSpace                      func(childComplexity int, input model.CreateSpaceInput) int
 		CreateSpaceRole                  func(childComplexity int, input model.CreateSpaceRoleInput) int
-		CreateUser                       func(childComplexity int, input model.CreateUserInput) int
 		DeleteAttachment                 func(childComplexity int, input model.DeleteAttachmentInput) int
 		DeleteLinkPreview                func(childComplexity int, input model.DeleteLinkPreviewInput) int
 		DeleteMessage                    func(childComplexity int, input model.DeleteMessageInput) int
@@ -945,7 +944,6 @@ type MutationResolver interface {
 	DeleteSpaceLogo(ctx context.Context, input model.DeleteSpaceLogoInput) (*corev1.Space, error)
 	UploadSpaceBanner(ctx context.Context, input model.UploadSpaceBannerInput) (*corev1.Space, error)
 	DeleteSpaceBanner(ctx context.Context, input model.DeleteSpaceBannerInput) (*corev1.Space, error)
-	CreateUser(ctx context.Context, input model.CreateUserInput) (*corev1.User, error)
 	JoinSpace(ctx context.Context, input model.JoinSpaceInput) (bool, error)
 	LeaveSpace(ctx context.Context, input model.LeaveSpaceInput) (bool, error)
 	JoinRoom(ctx context.Context, input model.JoinRoomInput) (bool, error)
@@ -2317,17 +2315,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.CreateSpaceRole(childComplexity, args["input"].(model.CreateSpaceRoleInput)), true
-	case "Mutation.createUser":
-		if e.complexity.Mutation.CreateUser == nil {
-			break
-		}
-
-		args, err := ec.field_Mutation_createUser_args(ctx, rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Mutation.CreateUser(childComplexity, args["input"].(model.CreateUserInput)), true
 	case "Mutation.deleteAttachment":
 		if e.complexity.Mutation.DeleteAttachment == nil {
 			break
@@ -4792,7 +4779,6 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputCreateRoomInput,
 		ec.unmarshalInputCreateSpaceInput,
 		ec.unmarshalInputCreateSpaceRoleInput,
-		ec.unmarshalInputCreateUserInput,
 		ec.unmarshalInputDeleteAttachmentInput,
 		ec.unmarshalInputDeleteLinkPreviewInput,
 		ec.unmarshalInputDeleteMessageInput,
@@ -5330,17 +5316,6 @@ func (ec *executionContext) field_Mutation_createSpace_args(ctx context.Context,
 	var err error
 	args := map[string]any{}
 	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNCreateSpaceInput2hmansᚗdeᚋchattoᚋinternalᚋgraphᚋmodelᚐCreateSpaceInput)
-	if err != nil {
-		return nil, err
-	}
-	args["input"] = arg0
-	return args, nil
-}
-
-func (ec *executionContext) field_Mutation_createUser_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
-	var err error
-	args := map[string]any{}
-	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNCreateUserInput2hmansᚗdeᚋchattoᚋinternalᚋgraphᚋmodelᚐCreateUserInput)
 	if err != nil {
 		return nil, err
 	}
@@ -12909,81 +12884,6 @@ func (ec *executionContext) fieldContext_Mutation_deleteSpaceBanner(ctx context.
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_deleteSpaceBanner_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Mutation_createUser(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		ec.fieldContext_Mutation_createUser,
-		func(ctx context.Context) (any, error) {
-			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().CreateUser(ctx, fc.Args["input"].(model.CreateUserInput))
-		},
-		nil,
-		ec.marshalNUser2ᚖhmansᚗdeᚋchattoᚋinternalᚋpbᚋchattoᚋcoreᚋv1ᚐUser,
-		true,
-		true,
-	)
-}
-
-func (ec *executionContext) fieldContext_Mutation_createUser(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Mutation",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_User_id(ctx, field)
-			case "login":
-				return ec.fieldContext_User_login(ctx, field)
-			case "displayName":
-				return ec.fieldContext_User_displayName(ctx, field)
-			case "createdAt":
-				return ec.fieldContext_User_createdAt(ctx, field)
-			case "avatarUrl":
-				return ec.fieldContext_User_avatarUrl(ctx, field)
-			case "hasVerifiedEmail":
-				return ec.fieldContext_User_hasVerifiedEmail(ctx, field)
-			case "verifiedEmails":
-				return ec.fieldContext_User_verifiedEmails(ctx, field)
-			case "spaces":
-				return ec.fieldContext_User_spaces(ctx, field)
-			case "rooms":
-				return ec.fieldContext_User_rooms(ctx, field)
-			case "instanceRoles":
-				return ec.fieldContext_User_instanceRoles(ctx, field)
-			case "spaceRoles":
-				return ec.fieldContext_User_spaceRoles(ctx, field)
-			case "viewerCanDeleteAccount":
-				return ec.fieldContext_User_viewerCanDeleteAccount(ctx, field)
-			case "lastLoginChange":
-				return ec.fieldContext_User_lastLoginChange(ctx, field)
-			case "roomNotificationPreferences":
-				return ec.fieldContext_User_roomNotificationPreferences(ctx, field)
-			case "presenceStatus":
-				return ec.fieldContext_User_presenceStatus(ctx, field)
-			case "settings":
-				return ec.fieldContext_User_settings(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_createUser_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -27384,47 +27284,6 @@ func (ec *executionContext) unmarshalInputCreateSpaceRoleInput(ctx context.Conte
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputCreateUserInput(ctx context.Context, obj any) (model.CreateUserInput, error) {
-	var it model.CreateUserInput
-	asMap := map[string]any{}
-	for k, v := range obj.(map[string]any) {
-		asMap[k] = v
-	}
-
-	fieldsInOrder := [...]string{"login", "displayName", "password"}
-	for _, k := range fieldsInOrder {
-		v, ok := asMap[k]
-		if !ok {
-			continue
-		}
-		switch k {
-		case "login":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("login"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Login = data
-		case "displayName":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("displayName"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.DisplayName = data
-		case "password":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("password"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Password = data
-		}
-	}
-
-	return it, nil
-}
-
 func (ec *executionContext) unmarshalInputDeleteAttachmentInput(ctx context.Context, obj any) (model.DeleteAttachmentInput, error) {
 	var it model.DeleteAttachmentInput
 	asMap := map[string]any{}
@@ -33454,13 +33313,6 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "deleteSpaceBanner":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_deleteSpaceBanner(ctx, field)
-			})
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "createUser":
-			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_createUser(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -40917,11 +40769,6 @@ func (ec *executionContext) unmarshalNCreateSpaceInput2hmansᚗdeᚋchattoᚋint
 
 func (ec *executionContext) unmarshalNCreateSpaceRoleInput2hmansᚗdeᚋchattoᚋinternalᚋgraphᚋmodelᚐCreateSpaceRoleInput(ctx context.Context, v any) (model.CreateSpaceRoleInput, error) {
 	res, err := ec.unmarshalInputCreateSpaceRoleInput(ctx, v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) unmarshalNCreateUserInput2hmansᚗdeᚋchattoᚋinternalᚋgraphᚋmodelᚐCreateUserInput(ctx context.Context, v any) (model.CreateUserInput, error) {
-	res, err := ec.unmarshalInputCreateUserInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/cli/internal/graph/model/models_gen.go
+++ b/cli/internal/graph/model/models_gen.go
@@ -258,16 +258,6 @@ type CreateSpaceRoleInput struct {
 	Description string `json:"description"`
 }
 
-// Input for creating a new user account.
-type CreateUserInput struct {
-	// The user's login name (unique identifier for authentication).
-	Login string `json:"login"`
-	// The user's display name.
-	DisplayName string `json:"displayName"`
-	// The user's password (optional - not required for OAuth-only users).
-	Password *string `json:"password,omitempty"`
-}
-
 // Input for deleting an attachment from a message.
 type DeleteAttachmentInput struct {
 	// The ID of the space containing the room.

--- a/cli/internal/graph/mutation.graphqls
+++ b/cli/internal/graph/mutation.graphqls
@@ -41,9 +41,6 @@ type Mutation {
   "Delete the banner for a space. Requires manage_space permission."
   deleteSpaceBanner(input: DeleteSpaceBannerInput!): Space!
 
-  "Create a new user account."
-  createUser(input: CreateUserInput!): User!
-
   "Join the specified space."
   joinSpace(input: JoinSpaceInput!): Boolean!
 
@@ -255,18 +252,6 @@ input PostMessageInput {
   alsoSendToChannel: Boolean
   "Link preview data from the composer. Server stores this directly without fetching."
   linkPreview: LinkPreviewInput
-}
-
-"""
-Input for creating a new user account.
-"""
-input CreateUserInput {
-  "The user's login name (unique identifier for authentication)."
-  login: String!
-  "The user's display name."
-  displayName: String!
-  "The user's password (optional - not required for OAuth-only users)."
-  password: String
 }
 
 """

--- a/cli/internal/graph/mutation.resolvers.go
+++ b/cli/internal/graph/mutation.resolvers.go
@@ -615,21 +615,6 @@ func (r *mutationResolver) DeleteSpaceBanner(ctx context.Context, input model.De
 	return r.core.GetSpace(ctx, input.SpaceID)
 }
 
-// CreateUser is the resolver for the createUser field.
-func (r *mutationResolver) CreateUser(ctx context.Context, input model.CreateUserInput) (*corev1.User, error) {
-	// Password is optional (nil for OAuth-only users)
-	password := ""
-	if input.Password != nil {
-		password = *input.Password
-	}
-
-	// No authorization needed - public self-registration.
-	// Note: actorID parameter is not currently used by CreateUser (see Core docs).
-	// The UserCreated event uses the newly created user's ID as the actor.
-	// Core handles first-user-to-owner promotion automatically.
-	return r.core.CreateUser(ctx, "", input.Login, input.DisplayName, password)
-}
-
 // JoinSpace is the resolver for the joinSpace field.
 func (r *mutationResolver) JoinSpace(ctx context.Context, input model.JoinSpaceInput) (bool, error) {
 	user, err := requireAuth(ctx)

--- a/cli/internal/graph/mutation_test.go
+++ b/cli/internal/graph/mutation_test.go
@@ -1052,45 +1052,6 @@ func TestDeleteSpaceLogo_Authorization(t *testing.T) {
 }
 
 // ============================================================================
-// CreateUser Tests
-// ============================================================================
-
-func TestCreateUser(t *testing.T) {
-	env := setupTestResolver(t)
-	mutation := env.resolver.Mutation()
-
-	t.Run("create user without authentication succeeds (self-registration)", func(t *testing.T) {
-		password := "secure123"
-		user, err := mutation.CreateUser(env.unauthContext(), model.CreateUserInput{
-			Login:       "newuser",
-			DisplayName: "New User",
-			Password:    &password,
-		})
-		if err != nil {
-			t.Fatalf("expected success, got error: %v", err)
-		}
-		if user == nil {
-			t.Fatal("expected user, got nil")
-		}
-		if user.Login != "newuser" {
-			t.Errorf("expected login 'newuser', got %s", user.Login)
-		}
-	})
-
-	t.Run("duplicate login is rejected", func(t *testing.T) {
-		password := "secure123"
-		_, err := mutation.CreateUser(env.unauthContext(), model.CreateUserInput{
-			Login:       env.testUser.Login, // existing login
-			DisplayName: "Duplicate",
-			Password:    &password,
-		})
-		if err == nil {
-			t.Fatal("expected error for duplicate login")
-		}
-	})
-}
-
-// ============================================================================
 // DeleteMessage Authorization Tests
 // ============================================================================
 

--- a/cli/internal/http_server/graphql.go
+++ b/cli/internal/http_server/graphql.go
@@ -183,7 +183,11 @@ func (s *HTTPServer) setupGraphQLAPI(allowedOrigins []string) {
 
 	h.SetQueryCache(lru.New[*ast.QueryDocument](1000))
 
-	h.Use(extension.Introspection{})
+	// Introspection lets callers enumerate the full schema. Useful in dev,
+	// reconnaissance vector in prod. Same gate covers /api/playground below.
+	if s.config.Webserver.DevMode {
+		h.Use(extension.Introspection{})
+	}
 	h.Use(extension.FixedComplexityLimit(500))
 	h.Use(&gqldepthlimit.Extension{MaxDepth: 12})
 	h.Use(extension.AutomaticPersistedQuery{
@@ -213,9 +217,11 @@ func (s *HTTPServer) setupGraphQLAPI(allowedOrigins []string) {
 		h.ServeHTTP(c.Writer, r)
 	})
 
-	// Configure API Playground
-	p := playground.Handler("CHATTO API Playground", "/api/graphql")
-	s.router.GET("/api/playground", func(c *gin.Context) {
-		p.ServeHTTP(c.Writer, c.Request)
-	})
+	// Configure API Playground (dev mode only — pairs with introspection above)
+	if s.config.Webserver.DevMode {
+		p := playground.Handler("CHATTO API Playground", "/api/graphql")
+		s.router.GET("/api/playground", func(c *gin.Context) {
+			p.ServeHTTP(c.Writer, c.Request)
+		})
+	}
 }

--- a/cli/internal/http_server/health.go
+++ b/cli/internal/http_server/health.go
@@ -16,23 +16,21 @@ func (s *HTTPServer) setupHealthRoutes() {
 
 	// Readiness probe - is the server ready to accept traffic?
 	// Checks NATS connectivity and JetStream initialization.
+	//
+	// The `reason` is logged but not returned in the response body. Returning
+	// internal startup state to anonymous callers leaks fingerprintable
+	// information about NATS/JetStream phases during outages.
 	s.router.GET("/readyz", func(c *gin.Context) {
-		// Check NATS connection
 		if s.nc == nil || !s.nc.IsConnected() {
-			c.JSON(http.StatusServiceUnavailable, gin.H{
-				"status": "not ready",
-				"reason": "NATS not connected",
-			})
+			s.logger.Warn("readyz: NATS not connected")
+			c.JSON(http.StatusServiceUnavailable, gin.H{"status": "not ready"})
 			return
 		}
 
-		// Check JetStream resources are initialized
 		if s.core != nil {
 			if err := s.core.Ready(c.Request.Context()); err != nil {
-				c.JSON(http.StatusServiceUnavailable, gin.H{
-					"status": "not ready",
-					"reason": err.Error(),
-				})
+				s.logger.Warn("readyz: core not ready", "error", err)
+				c.JSON(http.StatusServiceUnavailable, gin.H{"status": "not ready"})
 				return
 			}
 		}

--- a/cli/internal/http_server/server.go
+++ b/cli/internal/http_server/server.go
@@ -3,6 +3,7 @@ package http_server
 import (
 	"context"
 	"crypto/tls"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"os"
@@ -87,7 +88,23 @@ func (s *HTTPServer) setupRoutes() error {
 	// SESSION MANAGEMENT
 
 	// Configure session middleware
-	sessionStore := cookie.NewStore([]byte(s.config.Webserver.CookieSigningSecret))
+	authKey := []byte(s.config.Webserver.CookieSigningSecret)
+	var sessionStore cookie.Store
+	if encHex := s.config.Webserver.CookieEncryptionSecret; encHex != "" {
+		encKey, err := hex.DecodeString(encHex)
+		if err != nil {
+			return fmt.Errorf("webserver.cookie_encryption_secret: must be hex-encoded: %w", err)
+		}
+		switch len(encKey) {
+		case 16, 24, 32:
+		default:
+			return fmt.Errorf("webserver.cookie_encryption_secret must decode to 16, 24, or 32 bytes (got %d)", len(encKey))
+		}
+		sessionStore = cookie.NewStore(authKey, encKey)
+	} else {
+		s.logger.Warn("webserver.cookie_encryption_secret is not set; session cookies are signed but NOT encrypted. Run `chatto init` on a fresh instance to generate one, or add a hex-encoded 32-byte value to chatto.toml.")
+		sessionStore = cookie.NewStore(authKey)
+	}
 	sessionStore.Options(sessions.Options{
 		MaxAge:   60 * 60 * 24 * 90, // 90 days
 		HttpOnly: true,

--- a/cli/internal/http_server/test_endpoints.go
+++ b/cli/internal/http_server/test_endpoints.go
@@ -28,6 +28,7 @@ func createMailer(_ config.SMTPConfig) (*email.MockSender, email.Sender) {
 //   - GET /auth/test/last-email - Retrieve the last captured email
 //   - DELETE /auth/test/emails - Clear all captured emails
 //   - POST /auth/test/verify-email - Directly verify a user's email
+//   - POST /auth/test/create-user - Directly create a user without registration flow
 //   - POST /auth/test/oauth-callback - Simulate OAuth callback
 func registerTestEndpoints(auth *gin.RouterGroup, s *HTTPServer) {
 	if s.mockMailer == nil {
@@ -71,6 +72,39 @@ func registerTestEndpoints(auth *gin.RouterGroup, s *HTTPServer) {
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"success": true})
+	})
+
+	// Test-only endpoint to create a user directly. Bypasses registration,
+	// email verification, and session creation. Replaces the production
+	// `createUser` GraphQL mutation that was removed for security (see #175):
+	// production `createUser` was unauthenticated and let any caller win the
+	// race to become instance owner. The test endpoint is gated behind the
+	// `test_endpoints` build tag so it is never compiled into release
+	// binaries — same trust model as `/auth/test/verify-email` above.
+	auth.POST("test/create-user", func(c *gin.Context) {
+		var req struct {
+			Login       string `json:"login" binding:"required"`
+			DisplayName string `json:"displayName"`
+			Password    string `json:"password" binding:"required"`
+		}
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		displayName := req.DisplayName
+		if displayName == "" {
+			displayName = req.Login
+		}
+		user, err := s.core.CreateUser(c.Request.Context(), "system", req.Login, displayName, req.Password)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"id":          user.Id,
+			"login":       user.Login,
+			"displayName": user.DisplayName,
+		})
 	})
 
 	// Test-only endpoint to create a registration token (bypasses email delivery).

--- a/compose.yml
+++ b/compose.yml
@@ -14,6 +14,9 @@ services:
       CHATTO_BOOTSTRAP_EMAIL: dev@dev.com
       CHATTO_BOOTSTRAP_PASSWORD: devpassword
       CHATTO_BOOTSTRAP_SPACE_NAME: ${COMPOSE_PROJECT_NAME}
+      # Dev mode enables GraphQL introspection + /api/playground.
+      # Self-hosted production deployments must leave this off.
+      CHATTO_WEBSERVER_DEV_MODE: "true"
     volumes:
       - ./cli:/app/cli
       - go-mod-cache:/go/pkg/mod

--- a/frontend/e2e/dm.test.ts
+++ b/frontend/e2e/dm.test.ts
@@ -23,26 +23,12 @@ async function createSecondUser(page: import('@playwright/test').Page): Promise<
     password: 'testpassword123'
   };
 
-  const createUserResponse = await page.request.post('/api/graphql', {
-    headers: {
-      'Content-Type': 'application/json',
-      'X-REQUEST-TYPE': 'GraphQL'
-    },
+  const createUserResponse = await page.request.post('/auth/test/create-user', {
+    headers: { 'Content-Type': 'application/json' },
     data: {
-      query: `
-				mutation CreateUser($input: CreateUserInput!) {
-					createUser(input: $input) {
-						id
-					}
-				}
-			`,
-      variables: {
-        input: {
-          login: user.login,
-          displayName: user.displayName,
-          password: user.password
-        }
-      }
+      login: user.login,
+      displayName: user.displayName,
+      password: user.password
     }
   });
   expect(createUserResponse.ok()).toBeTruthy();

--- a/frontend/e2e/fixtures/multiInstance.ts
+++ b/frontend/e2e/fixtures/multiInstance.ts
@@ -38,26 +38,16 @@ export async function createUserOnRemote(
 	login: string,
 	password: string
 ): Promise<{ token: string; userId: string }> {
-	// Create user via GraphQL
-	const createResponse = await fetch(`${remoteBaseURL}/api/graphql`, {
+	// Create user via the test-only endpoint (build-tagged; not in production
+	// binaries). The production createUser GraphQL mutation was removed for
+	// security — see #175 — so e2e tests use this build-gated path instead.
+	const createResponse = await fetch(`${remoteBaseURL}/auth/test/create-user`, {
 		method: 'POST',
-		headers: {
-			'Content-Type': 'application/json',
-			'X-REQUEST-TYPE': 'GraphQL'
-		},
+		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify({
-			query: `
-				mutation CreateUser($input: CreateUserInput!) {
-					createUser(input: $input) { id login }
-				}
-			`,
-			variables: {
-				input: {
-					login,
-					displayName: `User ${login}`,
-					password
-				}
-			}
+			login,
+			displayName: `User ${login}`,
+			password
 		})
 	});
 
@@ -66,9 +56,9 @@ export async function createUserOnRemote(
 	}
 
 	const createData = await createResponse.json();
-	const userId = createData.data?.createUser?.id;
+	const userId = createData.id;
 	if (!userId) {
-		throw new Error(`No userId returned from remote createUser: ${JSON.stringify(createData)}`);
+		throw new Error(`No userId returned from remote test/create-user: ${JSON.stringify(createData)}`);
 	}
 
 	// Login to get bearer token

--- a/frontend/e2e/fixtures/testUser.ts
+++ b/frontend/e2e/fixtures/testUser.ts
@@ -319,57 +319,35 @@ export async function createAndLoginTestUser(
     password: 'testpassword123'
   };
 
-  // Create user via GraphQL mutation
-  const createUserResponse = await page.request.post('/api/graphql', {
-    headers: {
-      'Content-Type': 'application/json',
-      'X-REQUEST-TYPE': 'GraphQL'
-    },
-    data: {
-      query: `
-				mutation CreateUser($input: CreateUserInput!) {
-					createUser(input: $input) {
-						id
-						login
-						displayName
-					}
-				}
-			`,
-      variables: {
-        input: {
-          login: testUser.login,
-          displayName: testUser.displayName,
-          password: testUser.password
-        }
-      }
-    }
-  });
-
-  expect(createUserResponse.ok()).toBeTruthy();
-  const createUserData = await createUserResponse.json();
-  expect(createUserData.data.createUser).toBeTruthy();
-  testUser.id = createUserData.data.createUser.id;
-
-  // Verify user's email via test endpoint (useful for admin, password reset, etc.)
-  const verifyResponse = await page.request.post('/auth/test/verify-email', {
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    data: {
-      userId: testUser.id,
-      email: `${testUser.login}@example.com`
-    }
-  });
-  expect(verifyResponse.ok()).toBeTruthy();
-
-  // Login via HTTP endpoint
-  const loginResponse = await page.request.post('/auth/login', {
+  // Create user via the test-only endpoint. Bypasses the full registration
+  // flow (email delivery, token verification, session creation) — these are
+  // covered by dedicated registration-flow tests, not every test that needs
+  // *some* user. The endpoint is gated behind the `test_endpoints` build
+  // tag and is never compiled into production binaries.
+  const createUserResponse = await page.request.post('/auth/test/create-user', {
+    headers: { 'Content-Type': 'application/json' },
     data: {
       login: testUser.login,
+      displayName: testUser.displayName,
       password: testUser.password
     }
   });
+  expect(createUserResponse.ok()).toBeTruthy();
+  const createUserData = (await createUserResponse.json()) as { id: string };
+  testUser.id = createUserData.id;
 
+  // Verify user's email so admin checks, password reset, etc. behave as if
+  // the user completed real registration.
+  const verifyResponse = await page.request.post('/auth/test/verify-email', {
+    headers: { 'Content-Type': 'application/json' },
+    data: { userId: testUser.id, email: `${testUser.login}@example.com` }
+  });
+  expect(verifyResponse.ok()).toBeTruthy();
+
+  // Login via HTTP endpoint to get the session cookie on the page.
+  const loginResponse = await page.request.post('/auth/login', {
+    data: { login: testUser.login, password: testUser.password }
+  });
   expect(loginResponse.ok()).toBeTruthy();
   const loginData = await loginResponse.json();
   expect(loginData.success).toBe(true);

--- a/frontend/e2e/pages/AuthPage.ts
+++ b/frontend/e2e/pages/AuthPage.ts
@@ -439,33 +439,20 @@ export class AuthPage {
   // --- API Methods ---
 
   /**
-   * Create a user directly via the GraphQL API.
-   * Useful for setting up test fixtures.
+   * Create a user directly via the test-only HTTP endpoint.
+   * Useful for setting up test fixtures. The production GraphQL `createUser`
+   * mutation was removed for security (#175); the test endpoint is gated
+   * behind the `test_endpoints` build tag and never compiled into release
+   * binaries.
    */
   async createUserViaApi(login: string, password: string): Promise<{ id: string; login: string }> {
-    const response = await this.page.request.post('/api/graphql', {
-      headers: {
-        'Content-Type': 'application/json',
-        'X-REQUEST-TYPE': 'GraphQL'
-      },
-      data: {
-        query: `
-					mutation CreateUser($input: CreateUserInput!) {
-						createUser(input: $input) { id login }
-					}
-				`,
-        variables: {
-          input: {
-            login,
-            displayName: login,
-            password
-          }
-        }
-      }
+    const response = await this.page.request.post('/auth/test/create-user', {
+      headers: { 'Content-Type': 'application/json' },
+      data: { login, displayName: login, password }
     });
     expect(response.ok()).toBeTruthy();
-    const data = await response.json();
-    return data.data.createUser;
+    const data = (await response.json()) as { id: string; login: string };
+    return { id: data.id, login: data.login };
   }
 
   /**

--- a/frontend/e2e/room-permissions.test.ts
+++ b/frontend/e2e/room-permissions.test.ts
@@ -34,22 +34,17 @@ async function createSecondTestUser(page: Page): Promise<TestUser> {
     displayName: `RP User ${timestamp}`,
     password: 'testpassword123'
   };
-  const createResp = await page.request.post('/api/graphql', {
-    headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
+  const createResp = await page.request.post('/auth/test/create-user', {
+    headers: { 'Content-Type': 'application/json' },
     data: {
-      query: `mutation($input: CreateUserInput!) { createUser(input: $input) { id login displayName } }`,
-      variables: {
-        input: {
-          login: testUser.login,
-          displayName: testUser.displayName,
-          password: testUser.password
-        }
-      }
+      login: testUser.login,
+      displayName: testUser.displayName,
+      password: testUser.password
     }
   });
   expect(createResp.ok()).toBeTruthy();
   const createData = await createResp.json();
-  testUser.id = createData.data.createUser.id;
+  testUser.id = createData.id;
 
   // Verify email
   const verifyResp = await page.request.post('/auth/test/verify-email', {

--- a/frontend/e2e/space-admin-members.test.ts
+++ b/frontend/e2e/space-admin-members.test.ts
@@ -61,35 +61,18 @@ async function createSecondTestUser(page: Page): Promise<TestUser> {
     password: 'testpassword123'
   };
 
-  const createUserResponse = await page.request.post('/api/graphql', {
-    headers: {
-      'Content-Type': 'application/json',
-      'X-REQUEST-TYPE': 'GraphQL'
-    },
+  const createUserResponse = await page.request.post('/auth/test/create-user', {
+    headers: { 'Content-Type': 'application/json' },
     data: {
-      query: `
-				mutation CreateUser($input: CreateUserInput!) {
-					createUser(input: $input) {
-						id
-						login
-						displayName
-					}
-				}
-			`,
-      variables: {
-        input: {
-          login: testUser.login,
-          displayName: testUser.displayName,
-          password: testUser.password
-        }
-      }
+      login: testUser.login,
+      displayName: testUser.displayName,
+      password: testUser.password
     }
   });
 
   expect(createUserResponse.ok()).toBeTruthy();
   const createUserData = await createUserResponse.json();
-  expect(createUserData.data.createUser).toBeTruthy();
-  testUser.id = createUserData.data.createUser.id;
+  testUser.id = createUserData.id;
 
   // Verify email so user has space.join permission
   const verifyResponse = await page.request.post('/auth/test/verify-email', {

--- a/frontend/e2e/space-creation.test.ts
+++ b/frontend/e2e/space-creation.test.ts
@@ -34,28 +34,22 @@ async function createAndLoginAdminUser(page: Page): Promise<TestUser> {
     password: ADMIN_PASSWORD
   };
 
-  // Try to create user
-  const createUserResponse = await page.request.post('/api/graphql', {
-    headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
+  // Try to create user via the test-only endpoint. May fail if the user
+  // already exists from a previous run; the login flow below handles that.
+  const createUserResponse = await page.request.post('/auth/test/create-user', {
+    headers: { 'Content-Type': 'application/json' },
     data: {
-      query: `
-				mutation CreateUser($input: CreateUserInput!) {
-					createUser(input: $input) { id login displayName }
-				}
-			`,
-      variables: {
-        input: {
-          login: adminUser.login,
-          displayName: adminUser.displayName,
-          password: adminUser.password
-        }
-      }
+      login: adminUser.login,
+      displayName: adminUser.displayName,
+      password: adminUser.password
     }
   });
 
-  const createUserData = await createUserResponse.json();
-  if (createUserData.data?.createUser) {
-    adminUser.id = createUserData.data.createUser.id;
+  if (createUserResponse.ok()) {
+    const createUserData = await createUserResponse.json();
+    if (createUserData?.id) {
+      adminUser.id = createUserData.id;
+    }
   }
 
   // Always login after creating (or if user already exists)

--- a/frontend/e2e/space-join.test.ts
+++ b/frontend/e2e/space-join.test.ts
@@ -79,35 +79,18 @@ async function createSecondTestUser(page: Page): Promise<TestUser> {
     password: 'testpassword123'
   };
 
-  const createUserResponse = await page.request.post('/api/graphql', {
-    headers: {
-      'Content-Type': 'application/json',
-      'X-REQUEST-TYPE': 'GraphQL'
-    },
+  const createUserResponse = await page.request.post('/auth/test/create-user', {
+    headers: { 'Content-Type': 'application/json' },
     data: {
-      query: `
-				mutation CreateUser($input: CreateUserInput!) {
-					createUser(input: $input) {
-						id
-						login
-						displayName
-					}
-				}
-			`,
-      variables: {
-        input: {
-          login: testUser.login,
-          displayName: testUser.displayName,
-          password: testUser.password
-        }
-      }
+      login: testUser.login,
+      displayName: testUser.displayName,
+      password: testUser.password
     }
   });
 
   expect(createUserResponse.ok()).toBeTruthy();
   const createUserData = await createUserResponse.json();
-  expect(createUserData.data.createUser).toBeTruthy();
-  testUser.id = createUserData.data.createUser.id;
+  testUser.id = createUserData.id;
 
   // Verify email so user has space.join permission
   const verifyResponse = await page.request.post('/auth/test/verify-email', {
@@ -269,34 +252,22 @@ async function createAndLoginAdminUser(page: Page): Promise<TestUser> {
     password: ADMIN_PASSWORD
   };
 
-  // Try to create user
-  const createUserResponse = await page.request.post('/api/graphql', {
-    headers: {
-      'Content-Type': 'application/json',
-      'X-REQUEST-TYPE': 'GraphQL'
-    },
+  // Try to create user via the test-only endpoint. May fail if the user
+  // already exists from a previous run; the login flow below handles that.
+  const createUserResponse = await page.request.post('/auth/test/create-user', {
+    headers: { 'Content-Type': 'application/json' },
     data: {
-      query: `
-				mutation CreateUser($input: CreateUserInput!) {
-					createUser(input: $input) {
-						id
-						login
-					}
-				}
-			`,
-      variables: {
-        input: {
-          login: adminUser.login,
-          displayName: adminUser.displayName,
-          password: adminUser.password
-        }
-      }
+      login: adminUser.login,
+      displayName: adminUser.displayName,
+      password: adminUser.password
     }
   });
 
-  const createUserData = await createUserResponse.json();
-  if (createUserData.data?.createUser) {
-    adminUser.id = createUserData.data.createUser.id;
+  if (createUserResponse.ok()) {
+    const createUserData = await createUserResponse.json();
+    if (createUserData?.id) {
+      adminUser.id = createUserData.id;
+    }
   }
 
   // Login

--- a/frontend/e2e/space-roles.test.ts
+++ b/frontend/e2e/space-roles.test.ts
@@ -60,35 +60,18 @@ async function createSecondTestUser(page: Page): Promise<TestUser> {
     password: 'testpassword123'
   };
 
-  const createUserResponse = await page.request.post('/api/graphql', {
-    headers: {
-      'Content-Type': 'application/json',
-      'X-REQUEST-TYPE': 'GraphQL'
-    },
+  const createUserResponse = await page.request.post('/auth/test/create-user', {
+    headers: { 'Content-Type': 'application/json' },
     data: {
-      query: `
-				mutation CreateUser($input: CreateUserInput!) {
-					createUser(input: $input) {
-						id
-						login
-						displayName
-					}
-				}
-			`,
-      variables: {
-        input: {
-          login: testUser.login,
-          displayName: testUser.displayName,
-          password: testUser.password
-        }
-      }
+      login: testUser.login,
+      displayName: testUser.displayName,
+      password: testUser.password
     }
   });
 
   expect(createUserResponse.ok()).toBeTruthy();
   const createUserData = await createUserResponse.json();
-  expect(createUserData.data.createUser).toBeTruthy();
-  testUser.id = createUserData.data.createUser.id;
+  testUser.id = createUserData.id;
 
   // Verify email so user has space.join permission
   const verifyResponse = await page.request.post('/auth/test/verify-email', {

--- a/frontend/e2e/space-settings-nav.test.ts
+++ b/frontend/e2e/space-settings-nav.test.ts
@@ -60,35 +60,18 @@ async function createSecondTestUser(page: Page): Promise<TestUser> {
     password: 'testpassword123'
   };
 
-  const createUserResponse = await page.request.post('/api/graphql', {
-    headers: {
-      'Content-Type': 'application/json',
-      'X-REQUEST-TYPE': 'GraphQL'
-    },
+  const createUserResponse = await page.request.post('/auth/test/create-user', {
+    headers: { 'Content-Type': 'application/json' },
     data: {
-      query: `
-				mutation CreateUser($input: CreateUserInput!) {
-					createUser(input: $input) {
-						id
-						login
-						displayName
-					}
-				}
-			`,
-      variables: {
-        input: {
-          login: testUser.login,
-          displayName: testUser.displayName,
-          password: testUser.password
-        }
-      }
+      login: testUser.login,
+      displayName: testUser.displayName,
+      password: testUser.password
     }
   });
 
   expect(createUserResponse.ok()).toBeTruthy();
   const createUserData = await createUserResponse.json();
-  expect(createUserData.data.createUser).toBeTruthy();
-  testUser.id = createUserData.data.createUser.id;
+  testUser.id = createUserData.id;
 
   // Verify email so user has space.join permission
   const verifyResponse = await page.request.post('/auth/test/verify-email', {

--- a/frontend/e2e/space-settings.test.ts
+++ b/frontend/e2e/space-settings.test.ts
@@ -68,35 +68,18 @@ async function createSecondTestUser(page: Page): Promise<TestUser> {
     password: 'testpassword123'
   };
 
-  const createUserResponse = await page.request.post('/api/graphql', {
-    headers: {
-      'Content-Type': 'application/json',
-      'X-REQUEST-TYPE': 'GraphQL'
-    },
+  const createUserResponse = await page.request.post('/auth/test/create-user', {
+    headers: { 'Content-Type': 'application/json' },
     data: {
-      query: `
-				mutation CreateUser($input: CreateUserInput!) {
-					createUser(input: $input) {
-						id
-						login
-						displayName
-					}
-				}
-			`,
-      variables: {
-        input: {
-          login: testUser.login,
-          displayName: testUser.displayName,
-          password: testUser.password
-        }
-      }
+      login: testUser.login,
+      displayName: testUser.displayName,
+      password: testUser.password
     }
   });
 
   expect(createUserResponse.ok()).toBeTruthy();
   const createUserData = await createUserResponse.json();
-  expect(createUserData.data.createUser).toBeTruthy();
-  testUser.id = createUserData.data.createUser.id;
+  testUser.id = createUserData.id;
 
   // Verify email so user has space.join permission
   const verifyResponse = await page.request.post('/auth/test/verify-email', {

--- a/frontend/e2e/unified-dm-inbox.test.ts
+++ b/frontend/e2e/unified-dm-inbox.test.ts
@@ -67,17 +67,12 @@ async function createSecondHomeUser(
 	const login = `dmtest${ts}`;
 	const displayName = `DM Test ${ts}`;
 
-	const result = await page.request.post('/api/graphql', {
-		headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
-		data: {
-			query: `mutation CreateUser($input: CreateUserInput!) { createUser(input: $input) { id } }`,
-			variables: {
-				input: { login, displayName, password: 'testpassword123' }
-			}
-		}
+	const result = await page.request.post('/auth/test/create-user', {
+		headers: { 'Content-Type': 'application/json' },
+		data: { login, displayName, password: 'testpassword123' }
 	});
 	const data = await result.json();
-	return { id: data.data.createUser.id, login, displayName };
+	return { id: data.id, login, displayName };
 }
 
 test.describe('Unified DM Inbox', () => {

--- a/frontend/src/lib/gql/graphql.ts
+++ b/frontend/src/lib/gql/graphql.ts
@@ -381,16 +381,6 @@ export type CreateSpaceRoleInput = {
   spaceId: Scalars['ID']['input'];
 };
 
-/** Input for creating a new user account. */
-export type CreateUserInput = {
-  /** The user's display name. */
-  displayName: Scalars['String']['input'];
-  /** The user's login name (unique identifier for authentication). */
-  login: Scalars['String']['input'];
-  /** The user's password (optional - not required for OAuth-only users). */
-  password?: InputMaybe<Scalars['String']['input']>;
-};
-
 /**
  * Notification for new DM messages.
  * Created when someone sends a message in a DM conversation you're part of.
@@ -1062,8 +1052,6 @@ export type Mutation = {
    * Errors: If role name already exists or is a system role name.
    */
   createSpaceRole: Role;
-  /** Create a new user account. */
-  createUser: User;
   /**
    * Delete an attachment from a message. Only the message author can delete their attachments.
    * Removes the attachment from the message and deletes the file from storage.
@@ -1433,12 +1421,6 @@ export type MutationCreateSpaceArgs = {
 /** Root mutation type for modifying data. */
 export type MutationCreateSpaceRoleArgs = {
   input: CreateSpaceRoleInput;
-};
-
-
-/** Root mutation type for modifying data. */
-export type MutationCreateUserArgs = {
-  input: CreateUserInput;
 };
 
 

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -58,15 +58,33 @@
     });
 
   /**
+   * Same-origin path check; mirrors the validator in +page.ts but applied
+   * to runtime values (sessionStorage.returnUrl) since +page.ts only sees
+   * the URL search params.
+   */
+  function isSafeInternalPath(value: string): boolean {
+    return (
+      typeof value === 'string' &&
+      value.startsWith('/') &&
+      !value.startsWith('//') &&
+      !value.startsWith('/\\')
+    );
+  }
+
+  /**
    * Navigate after a successful login. Uses `window.location.href` for backend
    * routes (e.g. `/oauth/authorize`) that are served by Gin, not SvelteKit.
+   * Falls back to `/` for any URL that isn't a same-origin path — this is the
+   * last line of defence against an open-redirect via `?redirect=` or
+   * sessionStorage tampering.
    */
   function navigateAfterLogin(url: string) {
-    if (url.startsWith('/oauth/')) {
-      window.location.href = url;
+    const target = isSafeInternalPath(url) ? url : '/';
+    if (target.startsWith('/oauth/')) {
+      window.location.href = target;
     } else {
-      // eslint-disable-next-line svelte/no-navigation-without-resolve -- url is either a returnUrl from sessionStorage (already resolved) or a backend redirect path
-      goto(url);
+      // eslint-disable-next-line svelte/no-navigation-without-resolve -- target is validated by isSafeInternalPath; backend routes (e.g. /oauth/...) are not SvelteKit routes
+      goto(target);
     }
   }
 

--- a/frontend/src/routes/login/+page.ts
+++ b/frontend/src/routes/login/+page.ts
@@ -1,7 +1,31 @@
+/**
+ * Returns true if `value` is safe to navigate to without validating against
+ * a server-side allow-list — i.e. it points to *this* origin.
+ *
+ * Rejects:
+ *   - protocol-relative URLs (`//attacker`)
+ *   - backslash variants (`/\\attacker`, which some routers normalize to `//`)
+ *   - absolute URLs (`https://...`, `http://...`, `javascript:...`, etc.)
+ *   - empty / non-string values
+ *
+ * Without this check, `?redirect=https://evil.example/` chains with
+ * `goto()` / `window.location.href = url` to phish credentials post-login.
+ */
+function isSafeInternalPath(value: string): boolean {
+  return (
+    typeof value === 'string' &&
+    value.startsWith('/') &&
+    !value.startsWith('//') &&
+    !value.startsWith('/\\')
+  );
+}
+
 export const load = ({ url }) => {
+  const raw = url.searchParams.get('redirect') ?? '';
+
   return {
-    /** URL to redirect to after login (default: /) */
-    redirectUrl: url.searchParams.get('redirect') || '/',
+    /** URL to redirect to after login (default: /). Must be a same-origin path. */
+    redirectUrl: isSafeInternalPath(raw) ? raw : '/',
 
     /** Whether the user just completed a password reset */
     passwordResetSuccess: url.searchParams.get('reset') === 'success'

--- a/frontend/src/service-worker.ts
+++ b/frontend/src/service-worker.ts
@@ -87,8 +87,16 @@ self.addEventListener('notificationclick', (event) => {
   event.notification.close();
 
   const path = event.notification.data?.url ?? '/chat';
-  // Build absolute URL for openWindow (required by some browsers)
-  const url = new URL(path, self.location.origin).href;
+  // Build absolute URL for openWindow (required by some browsers).
+  // Reject any URL that resolves to a different origin — `new URL(absUrl, origin)`
+  // returns the absolute URL when its first arg is already absolute, so a push
+  // payload with `data.url = "https://attacker.example/"` would otherwise
+  // navigate the user there.
+  const candidate = new URL(path, self.location.origin);
+  if (candidate.origin !== self.location.origin) {
+    return;
+  }
+  const url = candidate.href;
 
   event.waitUntil(
     (async () => {


### PR DESCRIPTION
Bundle of small, independently-mergeable security fixes from the multi-agent red-team review (#169). Each commit corresponds to one finding and can be reverted in isolation if needed.

## Closes / addresses

- **Closes #175** (Critical) — unauthenticated `createUser` GraphQL mutation
- **Closes #177** (High) — `Query.admin.kvKeys` privacy boundary
- **Refs #178** — Tier-1/Tier-3 items: M9, L1, L4, L6, L9, H8, L2

## Summary

| Sev | ID | Fix |
|---|---|---|
| Critical | C2 (#175) | Remove unauth GraphQL `createUser` mutation. Frontend uses HTTP `/auth/register/complete`; the GraphQL path bypassed `direct_registration`, email verification, and could auto-promote the first caller to instance owner. |
| High | N1 (#177) | Deny `KV_AUTH_TOKENS` and `KV_ENCRYPTION_KEYS` in admin's `kvKeys` resolver; filter `password_reset.` / `account_deletion_token.` / `email_verification.` key prefixes from any inspectable bucket. |
| High | H8 (#178) | Validate `/login?redirect=` is a same-origin path; same gate applied to `sessionStorage.returnUrl` consumers. |
| Medium | M9 (#178) | `IsInstanceAdminEmail` is now case-insensitive + whitespace-tolerant. Silent admin lockout fixed. |
| Medium | L4 (#178) | Optional `webserver.cookie_encryption_secret` enables AES encryption on session cookies (in addition to signing). `chatto init` generates the secret automatically. |
| Low | L1 (#178) | Gate GraphQL introspection + `/api/playground` on a new `webserver.dev_mode` flag (default false). Compose stack opts in. |
| Low | L2 (#178) | Service-worker `notificationclick` rejects cross-origin URLs from push payloads. |
| Low | L6 (#178) | `/readyz` no longer returns internal `reason` text to anonymous callers; reasons go to logs. |
| — | L9 (#178) | Document the anonymous space-discovery contract explicitly in `.claude/rules/authorization.md`. |

## Out of scope (separate PRs each)

These were intentionally not included — each needs its own design + migration:

- **C1 (#174)** — OAuth consent UX. Real fix requires a consent screen + per-user redirect-uri allow-list.
- **H1+H4 (#176)** — Token-hash migration with legacy fallback. Requires a deprecation window and per-user revocation index.
- **H2** — Master-key wrapping for `KV_ENCRYPTION_KEYS`. Design-first.
- **H3** — S3 attachment authz; needs data backfill of `roomID` on existing attachments.
- **H5/H6** — HTTP timeouts + rate limiting. Both want load-test before/after.
- **H9 + M3 + M5** — Refresh-token model + CSP + DOMPurify (XSS→ATO chain). Coordinated frontend work.
- **H7, M6** — Operator-CLI hygiene (decompression caps, `--passphrase` flag).

## Test plan

- [x] `mise test-cli` — all packages green (Go).
- [x] `mise x -- pnpm test:unit` — 489/489 frontend unit tests pass.
- [x] `mise x -- pnpm check` — 0 errors, 0 warnings (svelte-check).
- [x] `mise x -- pnpm lint` — clean (eslint).
- [x] `go vet` — same warnings as `main` (pre-existing, not regressions).
- [x] New tests:
  - `TestAdminConfig_IsInstanceAdminEmail` — pins case-insensitive + whitespace-tolerant matching.
  - `TestAdminQuery_KvKeys_DeniesSensitiveBuckets` — asserts both `KV_AUTH_TOKENS` and `KV_ENCRYPTION_KEYS` reject even with admin auth.
  - `TestAdminQuery_KvKeys_SensitivePrefixListIsExpected` — pins the prefix list against silent regression.
- [x] Removed `TestCreateUser` (it asserted the bug as a feature).
- [ ] CI to verify against full e2e suite.

## Notes for reviewers

- Each commit is one finding — easy to bisect or revert individually.
- The `compose.yml` change opts dev environments into `dev_mode=true` so the playground still works locally.
- `chatto init` now writes a fresh `cookie_encryption_secret`. Existing instances upgrade safely (sign-only fallback with a startup warning) until the operator adds the secret.
- `gen` artifacts (`generated.go`, `models_gen.go`, `frontend/src/lib/gql/graphql.ts`) are bundled into the schema-change commit (createUser removal).