### PR TITLE
feat(tools): GraphQL authorization matrix fuzzer

### DIFF
--- a/tools/authz-fuzzer/README.md
+++ b/tools/authz-fuzzer/README.md
@@ -1,0 +1,219 @@
+# GraphQL Authorization Matrix Fuzzer
+
+A targeted differential test for Chatto's GraphQL authorization boundary. The
+tool runs every operation in its registry as a set of personas at known
+privilege levels, then diffs the actual outcome against an expected matrix.
+Any cell that doesn't match is a finding.
+
+## Why this exists
+
+Chatto's authorization model is enforced at the GraphQL gateway, not in core
+(see [`.claude/rules/authorization.md`](../../.claude/rules/authorization.md)).
+The contract is: every Query/Mutation/Subscription/field resolver is
+responsible for calling the right `Can*` check before it touches `core`.
+A single missed check on a single resolver = full bypass of that capability
+for every user on the instance.
+
+Manual review catches some of these. This catches them automatically and
+keeps catching them as the schema grows.
+
+The tool is also intended as a **regression guard**: when a security finding
+gets fixed, add the matrix cell that codifies the new contract. If anyone
+ever introduces the same bug again, the fuzzer fails.
+
+## How it works
+
+```
+┌────────────┐   creates personas (anon, randomUser, …)
+│  seed.ts   │── via /auth/test/create-user (build-tagged, dev/test only)
+└────┬───────┘
+     │
+     ▼
+┌────────────┐   builds the fixture world
+│ pool/world │── publicSpace, publicRoom, otherSpace, seeded message
+└────┬───────┘
+     │
+     ▼
+┌────────────┐   for every (operation × persona) cell:
+│  run.ts    │── call the operation as that persona
+└────┬───────┘   classify the response (allow / deny / auth / notfound)
+     │
+     ▼
+┌────────────┐   diff observed vs MATRIX
+│  diff      │── exit non-zero on any mismatch
+└────────────┘
+```
+
+## Personas
+
+| ID | Description |
+|---|---|
+| `anon` | No session, no token. |
+| `randomUser` | Authenticated; member of nothing. |
+| `spaceMember` | Member of `seed.publicSpace`, default member role. |
+| `roomMember` | `spaceMember` + joined `seed.publicRoom`. |
+| `spaceAdmin` | Admin role on `seed.publicSpace`. |
+| `otherSpaceOwner` | Owner of a *different* space — used to probe cross-tenant leakage. |
+| `instanceAdmin` | Email matches `admin.emails` in instance config. **Currently degrades to a regular user** until the seed step is taught to wire this up; see "Known limitations" below. |
+
+## Outcomes
+
+For each `(operation, persona)` cell, the matrix declares one of:
+
+- `allow` — call should succeed (200 + non-null result).
+- `deny` — call should be rejected (typically `permission denied` or null).
+- `auth` — call should be rejected as unauthenticated.
+- `notfound` — call should return null *without* leaking existence (important
+  for IDOR — a "deny" response leaks "this resource exists, you just can't
+  see it").
+
+Anything in the matrix that isn't explicitly listed for a persona defaults
+to `deny`. **Silence is denial** — every `allow` is an explicit security
+claim and forces the author to think.
+
+The classifier in `run.ts` is deliberately loose because resolvers signal
+denial inconsistently (some return null, some return an error message). The
+matrix is the source of truth; the classifier just maps "did the user get
+the data?" to one of the four buckets.
+
+## Common findings the fuzzer surfaces
+
+| Symptom | What it means |
+|---|---|
+| `expected deny, got allow` | **Authorization bypass.** A resolver missed its `Can*` check. |
+| `expected notfound, got deny` | **Information leak via differential errors.** The resolver tells unauthorized callers that something exists. |
+| `expected auth, got allow` | A resolver is missing `requireAuth`. |
+| `expected allow, got deny` | Either the matrix is wrong, or a fix went too far and broke a legitimate use case. |
+
+## Running
+
+The fuzzer needs a Chatto instance built with the `test_endpoints` build tag
+and reachable over HTTP. Local dev (`mise dev`) builds with this tag by
+default, so an OrbStack URL works fine:
+
+```sh
+mise x -- node --experimental-strip-types tools/authz-fuzzer/run.ts \
+  --endpoint=https://your-instance.orb.local
+```
+
+The fuzzer prints one line per mismatch and exits non-zero if any cell
+diverges. Cells that match are silent.
+
+The fuzzer creates fresh users on every run (`fuzz_random`, `fuzz_smember`,
+…) and a fresh world. It does not clean up — runs accumulate state. If the
+target instance starts to feel polluted, either tear it down (a fresh
+`mise dev` rebuild gives you a clean DB) or extend the seed step to use
+random suffixes per run.
+
+### Why no `package.json`
+
+The fuzzer has zero npm dependencies. It uses Node's built-in `fetch`, no
+test runner, no transpiler, no Playwright. `node --experimental-strip-types`
+(Node 22+) handles TypeScript natively. Keeping the surface area small makes
+the tool easy to read, easy to run, and easy to wire into CI later without
+worrying about lockfile drift.
+
+If the matrix grows large enough to warrant a runner with parallelism /
+reporters / etc., that's the moment to introduce a dependency — not before.
+
+## Files
+
+- `client.ts` — minimal GraphQL HTTP client with cookie jar; one instance
+  per persona.
+- `personas.ts` — persona registry. Adding a persona means adding an entry
+  here and (usually) extending `seed.ts` to bring it into the world.
+- `seed.ts` — bootstraps the fixture world. Creates users, builds the public
+  space + room, posts a seed message used by edit/delete tests, creates the
+  cross-tenant `otherSpace`.
+- `operations.ts` — every operation under test. Each entry knows how to
+  render its variables given the seed world. Returning `null` from `vars()`
+  skips the op (when its prerequisites weren't seeded).
+- `matrix.ts` — expected `(operation, persona) → outcome` table. **Read this
+  file as a security claim**, not as a documentation of current behaviour.
+- `run.ts` — orchestrator. Logs mismatches. Exits non-zero on any.
+
+## Adding coverage
+
+### A new operation
+
+1. Append an entry to `OPERATIONS` in `operations.ts`. Pick `category`
+   correctly (it changes how `null` data is classified).
+2. Add a row to `MATRIX` in `matrix.ts`. Be explicit for every persona that
+   should `allow` — anything you leave out defaults to `deny`.
+3. Run the fuzzer. Either it passes (great) or it tells you a real bug or a
+   wrong expectation.
+
+### A new persona
+
+1. Add an entry to `PERSONAS` in `personas.ts`. Order matters — least
+   privileged first, since the seed step builds relationships incrementally.
+2. Extend `buildClients` and `seed` in `seed.ts` to provision the new
+   persona's role/membership.
+3. Decide what every existing matrix row should expect for the new persona.
+   This is the work — don't skip it. Every undocumented cell silently
+   defaults to `deny`, which is sometimes wrong.
+
+### A new outcome
+
+If you find yourself wanting a new outcome label (e.g. `rate-limited`),
+think hard first — the four-outcome model is intentionally minimal. Most
+"new" outcomes are special cases of `deny`. If you genuinely need it,
+extend the `Outcome` type in `matrix.ts` and the classifier in `run.ts`.
+
+## Known limitations
+
+- **`instanceAdmin` requires config alignment on the target instance.** The
+  seed verifies each persona's email via `/auth/test/verify-email`, but the
+  GraphQL `Query.admin` resolver only treats a user as admin if a verified
+  email matches an entry in `admin.emails` in `chatto.toml`. Add the
+  default persona email to your test instance's config:
+  ```toml
+  [admin]
+  emails = ["fuzz_iadmin@example.test"]
+  ```
+  Until that's done on the target instance, `instanceAdmin → allow` cells
+  fail-closed. Treat them as low-confidence rather than authoritative.
+- **Subscriptions aren't tested.** Equally important attack surface; needs a
+  WS client and time-bounded "did we receive an event?" assertions. The
+  classifier and persona model already work for subscriptions in principle
+  — what's missing is the transport.
+- **The `Upload` scalar isn't actually uploaded.** Operations like
+  `uploadSpaceLogo` test only the resolver-entry authz path, which is what
+  we want for matrix coverage. End-to-end upload behaviour belongs in a
+  separate harness.
+- **No cleanup.** Each run leaves users and a world behind. Runs are
+  idempotent in the sense that they don't break each other, but the target
+  instance accumulates state. For long-lived dev instances, restart the
+  stack occasionally.
+
+## CI integration (future)
+
+The intended deployment shape is a CI job that:
+
+1. Spins up a Chatto instance built with `-tags test_endpoints`.
+2. Runs the fuzzer against it with a fresh DB.
+3. Fails the build on any mismatch.
+
+Wiring this in needs:
+
+- A reusable "ephemeral Chatto" GitHub Actions step (the e2e job already has
+  one; reuse it).
+- `instanceAdmin` actually working (see Known limitations) so the admin
+  cells aren't silently low-confidence.
+- A few iterations of running it against `main` to surface and either fix or
+  matrix-document any pre-existing divergences.
+
+Until that lands, run the fuzzer locally before merging anything that touches
+`*.resolvers.go`, `core/can.go`, or `core/permissions.go`.
+
+## Relationship to other testing
+
+| Tool | Catches | Doesn't catch |
+|---|---|---|
+| **Go unit tests** in `cli/internal/graph/*_test.go` | Specific resolvers' authz logic at the function level. | Cross-resolver consistency, missing checks on resolvers nobody wrote tests for. |
+| **Playwright e2e** in `frontend/e2e/` | UI-level happy paths and a few negative cases. | Comprehensive authz matrix; tests are slow and per-feature, not per-(resolver, persona). |
+| **This fuzzer** | Every operation × every persona, declared as security claims. | Behaviour beyond the matrix outcomes (data correctness, performance, UX). |
+
+The three layers are complementary. The fuzzer's job is to be the *broad*
+guard against whole classes of bypass. Specific business rules and edge
+cases stay where they are.

--- a/tools/authz-fuzzer/client.ts
+++ b/tools/authz-fuzzer/client.ts
@@ -1,0 +1,87 @@
+// Minimal GraphQL HTTP client with cookie jar support.
+// Each Client holds the session cookies and bearer token for one persona.
+
+export type GqlError = {
+  message: string;
+  path?: (string | number)[];
+  extensions?: Record<string, unknown>;
+};
+
+export type GqlResponse<T = unknown> = {
+  data?: T | null;
+  errors?: GqlError[];
+};
+
+export class Client {
+  private cookies = new Map<string, string>();
+  private bearer?: string;
+
+  constructor(public endpoint: string, public label: string) {}
+
+  setBearer(token: string) {
+    this.bearer = token;
+  }
+
+  hasSession(): boolean {
+    return this.cookies.size > 0 || !!this.bearer;
+  }
+
+  private cookieHeader(): string | undefined {
+    if (this.cookies.size === 0) return undefined;
+    return [...this.cookies.entries()].map(([k, v]) => `${k}=${v}`).join("; ");
+  }
+
+  private absorbSetCookie(headers: Headers) {
+    // Node's fetch returns a flat Headers object that joins multiple Set-Cookie
+    // with comma. We only need the first cookie per name, and Chatto only sets
+    // one auth cookie ("session"), so the simplest split is fine for our use.
+    const raw = headers.get("set-cookie");
+    if (!raw) return;
+    // Split on ", " only when followed by a Cookie name (heuristic but ok here).
+    const parts = raw.split(/,(?=\s*[A-Za-z0-9_-]+=)/);
+    for (const part of parts) {
+      const [pair] = part.split(";");
+      const eq = pair.indexOf("=");
+      if (eq < 0) continue;
+      const name = pair.slice(0, eq).trim();
+      const value = pair.slice(eq + 1).trim();
+      this.cookies.set(name, value);
+    }
+  }
+
+  async http(path: string, init: RequestInit = {}): Promise<Response> {
+    const headers = new Headers(init.headers);
+    headers.set("content-type", "application/json");
+    const cookie = this.cookieHeader();
+    if (cookie) headers.set("cookie", cookie);
+    if (this.bearer) headers.set("authorization", `Bearer ${this.bearer}`);
+    const res = await fetch(this.endpoint + path, { ...init, headers });
+    this.absorbSetCookie(res.headers);
+    return res;
+  }
+
+  async query<T = unknown>(query: string, variables?: Record<string, unknown>): Promise<GqlResponse<T>> {
+    const res = await this.http("/api/graphql", {
+      method: "POST",
+      body: JSON.stringify({ query, variables }),
+    });
+    if (!res.ok && res.status !== 200) {
+      // GraphQL endpoints can return non-200 for transport errors; surface them.
+      return { errors: [{ message: `HTTP ${res.status} ${res.statusText}` }] };
+    }
+    return (await res.json()) as GqlResponse<T>;
+  }
+
+  async login(login: string, password: string): Promise<void> {
+    const res = await this.http("/api/auth/login", {
+      method: "POST",
+      body: JSON.stringify({ login, password }),
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`[${this.label}] login failed: HTTP ${res.status}: ${body}`);
+    }
+    const body = (await res.json()) as { token?: string };
+    if (body.token) this.bearer = body.token;
+  }
+}

--- a/tools/authz-fuzzer/matrix.ts
+++ b/tools/authz-fuzzer/matrix.ts
@@ -1,0 +1,208 @@
+// Expected outcome for each (operation, persona) pair.
+//
+// Outcomes:
+//   "allow"    — call returns success, data is non-null where applicable
+//   "deny"     — call returns a permission/authorization error (or null result)
+//   "auth"     — call returns "not authenticated" (no valid session)
+//   "notfound" — call returns null without leaking existence (IDOR-safe)
+//
+// "allow" must be the EXPECTED behaviour, not the OBSERVED one. Every cell is
+// a security claim. If a cell is wrong-on-purpose to capture current behaviour
+// while a fix is in flight, mark it `// TODO(SEC-NN)` so it's grep-able.
+
+import type { PersonaId } from "./personas.ts";
+
+export type Outcome = "allow" | "deny" | "auth" | "notfound";
+export type Matrix = Record<string, Partial<Record<PersonaId, Outcome>>>;
+
+// Default for any persona not listed for an op = "deny". Be explicit when you
+// mean "allow" — silence is denial.
+export const MATRIX: Matrix = {
+  // me() returns null for anon; not an error
+  "Query.me": {
+    anon: "allow", // null is the expected result, not an error
+    randomUser: "allow",
+    spaceMember: "allow",
+    roomMember: "allow",
+    spaceAdmin: "allow",
+    otherSpaceOwner: "allow",
+    instanceAdmin: "allow",
+  },
+  "Query.users": {
+    anon: "auth",
+    randomUser: "deny",
+    spaceMember: "deny",
+    roomMember: "deny",
+    spaceAdmin: "deny",
+    otherSpaceOwner: "deny",
+    instanceAdmin: "allow",
+  },
+  "Query.user(otherUserId)": {
+    // Profiles are public to authenticated callers
+    anon: "auth",
+    randomUser: "allow",
+    spaceMember: "allow",
+    roomMember: "allow",
+    spaceAdmin: "allow",
+    otherSpaceOwner: "allow",
+    instanceAdmin: "allow",
+  },
+  "Query.userByLogin(otherLogin)": {
+    anon: "auth",
+    randomUser: "allow",
+    spaceMember: "allow",
+    roomMember: "allow",
+    spaceAdmin: "allow",
+    otherSpaceOwner: "allow",
+    instanceAdmin: "allow",
+  },
+  "Query.spaces": {
+    // Discovery — public per docs
+    anon: "allow",
+    randomUser: "allow",
+    spaceMember: "allow",
+    roomMember: "allow",
+    spaceAdmin: "allow",
+    otherSpaceOwner: "allow",
+    instanceAdmin: "allow",
+  },
+  "Query.space(publicSpaceId)": {
+    anon: "allow",
+    randomUser: "allow",
+    spaceMember: "allow",
+    roomMember: "allow",
+    spaceAdmin: "allow",
+    otherSpaceOwner: "allow",
+    instanceAdmin: "allow",
+  },
+  "Query.room(publicRoom)": {
+    // Room access requires room membership
+    anon: "auth",
+    randomUser: "deny",
+    spaceMember: "deny",
+    roomMember: "allow",
+    spaceAdmin: "allow", // admin can access rooms in their space
+    otherSpaceOwner: "deny",
+    instanceAdmin: "deny", // privacy boundary: instance admin must NOT read content
+  },
+  "Query.roomEvents(publicRoom)": {
+    anon: "auth",
+    randomUser: "deny",
+    spaceMember: "deny",
+    roomMember: "allow",
+    spaceAdmin: "allow",
+    otherSpaceOwner: "deny",
+    instanceAdmin: "deny",
+  },
+  "Query.roomEventByEventId(publicRoom, seededMsg)": {
+    anon: "auth",
+    randomUser: "deny",
+    spaceMember: "deny",
+    roomMember: "allow",
+    spaceAdmin: "allow",
+    otherSpaceOwner: "deny",
+    instanceAdmin: "deny",
+  },
+
+  "Query.admin.users": {
+    anon: "auth",
+    randomUser: "deny",
+    spaceMember: "deny",
+    roomMember: "deny",
+    spaceAdmin: "deny",
+    otherSpaceOwner: "deny",
+    instanceAdmin: "allow",
+  },
+  "Query.admin.systemInfo": {
+    anon: "auth",
+    randomUser: "deny",
+    spaceMember: "deny",
+    roomMember: "deny",
+    spaceAdmin: "deny",
+    otherSpaceOwner: "deny",
+    instanceAdmin: "allow",
+  },
+
+  "Mutation.updateSpace(otherSpace)": {
+    anon: "auth",
+    randomUser: "deny",
+    spaceMember: "deny",
+    roomMember: "deny",
+    spaceAdmin: "deny", // admin of a DIFFERENT space
+    otherSpaceOwner: "allow",
+    instanceAdmin: "deny", // unless instance admin is also a space admin — keep strict
+  },
+  "Mutation.createRoom(otherSpace)": {
+    anon: "auth",
+    randomUser: "deny",
+    spaceMember: "deny",
+    roomMember: "deny",
+    spaceAdmin: "deny",
+    otherSpaceOwner: "allow",
+    instanceAdmin: "deny",
+  },
+  "Mutation.postMessage(publicRoom)": {
+    anon: "auth",
+    randomUser: "deny",
+    spaceMember: "deny", // not in room
+    roomMember: "allow",
+    spaceAdmin: "allow",
+    otherSpaceOwner: "deny",
+    instanceAdmin: "deny",
+  },
+  "Mutation.deleteMessage(otherUsersMsg)": {
+    // Message owned by a seed user; nobody else should delete it (except mods).
+    anon: "auth",
+    randomUser: "deny",
+    spaceMember: "deny",
+    roomMember: "deny", // not the author
+    spaceAdmin: "allow", // admin/mod usually has delete-any; verify with code
+    otherSpaceOwner: "deny",
+    instanceAdmin: "deny",
+  },
+  "Mutation.editMessage(otherUsersMsg)": {
+    anon: "auth",
+    randomUser: "deny",
+    spaceMember: "deny",
+    roomMember: "deny",
+    spaceAdmin: "deny", // edit is author-only per schema docs
+    otherSpaceOwner: "deny",
+    instanceAdmin: "deny",
+  },
+  "Mutation.archiveRoom(publicRoom)": {
+    anon: "auth",
+    randomUser: "deny",
+    spaceMember: "deny",
+    roomMember: "deny",
+    spaceAdmin: "allow",
+    otherSpaceOwner: "deny",
+    instanceAdmin: "deny",
+  },
+  "Mutation.uploadSpaceLogo(otherSpace)": {
+    anon: "auth",
+    randomUser: "deny",
+    spaceMember: "deny",
+    roomMember: "deny",
+    spaceAdmin: "deny",
+    otherSpaceOwner: "allow",
+    instanceAdmin: "deny",
+  },
+  "Mutation.markRoomAsRead(publicRoom)": {
+    anon: "auth",
+    randomUser: "deny",
+    spaceMember: "deny",
+    roomMember: "allow",
+    spaceAdmin: "allow",
+    otherSpaceOwner: "deny",
+    instanceAdmin: "deny",
+  },
+  "Mutation.updateMyProfile": {
+    anon: "auth",
+    randomUser: "allow",
+    spaceMember: "allow",
+    roomMember: "allow",
+    spaceAdmin: "allow",
+    otherSpaceOwner: "allow",
+    instanceAdmin: "allow",
+  },
+};

--- a/tools/authz-fuzzer/operations.ts
+++ b/tools/authz-fuzzer/operations.ts
@@ -1,0 +1,196 @@
+// Operations under test. Each entry knows how to render its variables given
+// the seed world. Add new operations here; pair every addition with a row in
+// matrix.ts.
+//
+// Coverage strategy: start with operations that have non-obvious authz
+// semantics (cross-tenant access, admin-only, ownership-gated). Trivial CRUD
+// is lower-priority — we want the cells likeliest to surface real bugs.
+
+import type { SeedWorld } from "./seed.ts";
+
+export type Op = {
+  name: string;
+  category: "query" | "mutation";
+  query: string;
+  // Build variables from the seed world. Return null to skip the op when the
+  // seed didn't produce the prerequisite (e.g., no DM thread exists).
+  vars: (s: SeedWorld) => Record<string, unknown> | null;
+};
+
+export const OPERATIONS: Op[] = [
+  // ---------- Queries: identity & discovery ----------
+  {
+    name: "Query.me",
+    category: "query",
+    query: "query { me { id login } }",
+    vars: () => ({}),
+  },
+  {
+    name: "Query.users",
+    category: "query",
+    query: "query { users { id login } }",
+    vars: () => ({}),
+  },
+  {
+    name: "Query.user(otherUserId)",
+    category: "query",
+    query: "query($id: ID!) { user(id: $id) { id login } }",
+    vars: (s) => ({ id: s.users.spaceAdminUserId }),
+  },
+  {
+    name: "Query.userByLogin(otherLogin)",
+    category: "query",
+    query: "query($login: String!) { userByLogin(login: $login) { id } }",
+    vars: (s) => ({ login: "fuzz_sadmin" }),
+  },
+  {
+    name: "Query.spaces",
+    category: "query",
+    query: "query { spaces { id name } }",
+    vars: () => ({}),
+  },
+  {
+    name: "Query.space(publicSpaceId)",
+    category: "query",
+    query: "query($id: ID!) { space(id: $id) { id name memberCount } }",
+    vars: (s) => ({ id: s.publicSpaceId }),
+  },
+
+  // ---------- Queries: room/message access (membership-gated) ----------
+  {
+    name: "Query.room(publicRoom)",
+    category: "query",
+    query: "query($s: ID!, $r: ID!) { room(spaceId: $s, roomId: $r) { id name } }",
+    vars: (s) => ({ s: s.publicSpaceId, r: s.publicRoomId }),
+  },
+  {
+    name: "Query.roomEvents(publicRoom)",
+    category: "query",
+    query:
+      "query($s: ID!, $r: ID!) { roomEvents(spaceId: $s, roomId: $r, limit: 5) { events { __typename } } }",
+    vars: (s) => ({ s: s.publicSpaceId, r: s.publicRoomId }),
+  },
+  {
+    name: "Query.roomEventByEventId(publicRoom, seededMsg)",
+    category: "query",
+    query:
+      "query($s: ID!, $r: ID!, $e: ID!) { roomEventByEventId(spaceId: $s, roomId: $r, eventId: $e) { __typename } }",
+    vars: (s) =>
+      s.seededMessageEventId
+        ? { s: s.publicSpaceId, r: s.publicRoomId, e: s.seededMessageEventId }
+        : null,
+  },
+
+  // ---------- Queries: admin namespace (privacy boundary) ----------
+  {
+    name: "Query.admin.users",
+    category: "query",
+    query: "query { admin { users { id login email } } }",
+    vars: () => ({}),
+  },
+  {
+    name: "Query.admin.systemInfo",
+    category: "query",
+    query: "query { admin { systemInfo { version uptime } } }",
+    vars: () => ({}),
+  },
+
+  // ---------- Mutations: cross-tenant probes ----------
+  {
+    name: "Mutation.updateSpace(otherSpace)",
+    category: "mutation",
+    query:
+      "mutation($i: UpdateSpaceInput!) { updateSpace(input: $i) { id } }",
+    vars: (s) => ({
+      i: { id: s.otherSpaceId, name: "fuzzed-rename", description: "x" },
+    }),
+  },
+  {
+    name: "Mutation.createRoom(otherSpace)",
+    category: "mutation",
+    query:
+      "mutation($i: CreateRoomInput!) { createRoom(input: $i) { id } }",
+    vars: (s) => ({
+      i: { spaceId: s.otherSpaceId, name: "should-not-exist" },
+    }),
+  },
+  {
+    name: "Mutation.postMessage(publicRoom)",
+    category: "mutation",
+    query:
+      "mutation($i: PostMessageInput!) { postMessage(input: $i) { __typename } }",
+    vars: (s) => ({
+      i: { spaceId: s.publicSpaceId, roomId: s.publicRoomId, body: "fuzz-msg" },
+    }),
+  },
+  {
+    name: "Mutation.deleteMessage(otherUsersMsg)",
+    category: "mutation",
+    query:
+      "mutation($i: DeleteMessageInput!) { deleteMessage(input: $i) }",
+    vars: (s) =>
+      s.seededMessageEventId
+        ? {
+            i: {
+              spaceId: s.publicSpaceId,
+              roomId: s.publicRoomId,
+              eventId: s.seededMessageEventId,
+            },
+          }
+        : null,
+  },
+  {
+    name: "Mutation.editMessage(otherUsersMsg)",
+    category: "mutation",
+    query:
+      "mutation($i: EditMessageInput!) { editMessage(input: $i) }",
+    vars: (s) =>
+      s.seededMessageEventId
+        ? {
+            i: {
+              spaceId: s.publicSpaceId,
+              roomId: s.publicRoomId,
+              eventId: s.seededMessageEventId,
+              body: "edited-by-fuzzer",
+            },
+          }
+        : null,
+  },
+  {
+    name: "Mutation.archiveRoom(publicRoom)",
+    category: "mutation",
+    query:
+      "mutation($i: ArchiveRoomInput!) { archiveRoom(input: $i) { id } }",
+    vars: (s) => ({
+      i: { spaceId: s.publicSpaceId, roomId: s.publicRoomId },
+    }),
+  },
+  {
+    name: "Mutation.uploadSpaceLogo(otherSpace)",
+    category: "mutation",
+    query:
+      "mutation($i: UploadSpaceLogoInput!) { uploadSpaceLogo(input: $i) { id } }",
+    vars: (s) => ({
+      // Upload scalar isn't easily POSTable from this minimal client; the
+      // operation tests authz on the resolver path. Expect deny long before
+      // the upload is processed.
+      i: { spaceId: s.otherSpaceId, file: null },
+    }),
+  },
+  {
+    name: "Mutation.markRoomAsRead(publicRoom)",
+    category: "mutation",
+    query:
+      "mutation($i: MarkRoomAsReadInput!) { markRoomAsRead(input: $i) { lastReadAt } }",
+    vars: (s) => ({
+      i: { spaceId: s.publicSpaceId, roomId: s.publicRoomId },
+    }),
+  },
+  {
+    name: "Mutation.updateMyProfile",
+    category: "mutation",
+    query:
+      "mutation($i: UpdateMyProfileInput!) { updateMyProfile(input: $i) { id displayName } }",
+    vars: () => ({ i: { displayName: "fuzz-display" } }),
+  },
+];

--- a/tools/authz-fuzzer/personas.ts
+++ b/tools/authz-fuzzer/personas.ts
@@ -1,0 +1,80 @@
+// Personas the fuzzer impersonates. Each gets its own Client (cookie jar).
+//
+// IMPORTANT: keep this list ordered from least to most privileged so the seed
+// step can build relationships incrementally (e.g., spaceAdmin needs to be
+// promoted from spaceMember).
+
+export type PersonaId =
+  | "anon"
+  | "randomUser"
+  | "spaceMember"
+  | "roomMember"
+  | "spaceAdmin"
+  | "otherSpaceOwner"
+  | "instanceAdmin";
+
+export type Persona = {
+  id: PersonaId;
+  // Login/password used to create + authenticate the persona. instanceAdmin's
+  // email must match an entry in chatto.toml [admin].emails for the test
+  // instance — otherwise it degrades to a regular user and admin checks
+  // appear "to pass" while actually never running.
+  login: string;
+  email: string;
+  password: string;
+  // Human-readable description for diff output.
+  description: string;
+};
+
+export const PERSONAS: Persona[] = [
+  {
+    id: "anon",
+    login: "",
+    email: "",
+    password: "",
+    description: "Unauthenticated network attacker (no session, no token)",
+  },
+  {
+    id: "randomUser",
+    login: "fuzz_random",
+    email: "fuzz_random@example.test",
+    password: "fuzz-random-pw-1",
+    description: "Authenticated user, member of nothing",
+  },
+  {
+    id: "spaceMember",
+    login: "fuzz_smember",
+    email: "fuzz_smember@example.test",
+    password: "fuzz-smember-pw-1",
+    description: "Member of seed.publicSpace, default role",
+  },
+  {
+    id: "roomMember",
+    login: "fuzz_rmember",
+    email: "fuzz_rmember@example.test",
+    password: "fuzz-rmember-pw-1",
+    description: "spaceMember + joined seed.publicRoom",
+  },
+  {
+    id: "spaceAdmin",
+    login: "fuzz_sadmin",
+    email: "fuzz_sadmin@example.test",
+    password: "fuzz-sadmin-pw-1",
+    description: "Admin role on seed.publicSpace",
+  },
+  {
+    id: "otherSpaceOwner",
+    login: "fuzz_other",
+    email: "fuzz_other@example.test",
+    password: "fuzz-other-pw-1",
+    description: "Owner of a different space (cross-tenant probe)",
+  },
+  {
+    id: "instanceAdmin",
+    login: "fuzz_iadmin",
+    // MUST be present in admin.emails on the test instance.
+    email: "fuzz_iadmin@example.test",
+    password: "fuzz-iadmin-pw-1",
+    description: "Email matches admin.emails",
+  },
+];

--- a/tools/authz-fuzzer/run.ts
+++ b/tools/authz-fuzzer/run.ts
@@ -1,0 +1,122 @@
+// Orchestrator. Runs every operation as every persona, diffs against the
+// expected matrix, prints a report, and exits non-zero on any mismatch.
+//
+// Usage:
+//   mise x -- node --experimental-strip-types tools/authz-fuzzer/run.ts \
+//     --endpoint=https://your-dev-instance/
+
+import { OPERATIONS } from "./operations.ts";
+import { MATRIX, type Outcome } from "./matrix.ts";
+import { PERSONAS, type PersonaId } from "./personas.ts";
+import { buildClients, seed } from "./seed.ts";
+import type { Client, GqlResponse } from "./client.ts";
+
+function arg(name: string, fallback?: string): string {
+  const flag = `--${name}=`;
+  const found = process.argv.find((a) => a.startsWith(flag));
+  if (found) return found.slice(flag.length);
+  if (fallback !== undefined) return fallback;
+  throw new Error(`missing required arg --${name}`);
+}
+
+// Classify a GraphQL response into one of the matrix outcomes. The mapping is
+// deliberately loose because Chatto's resolvers differ in how they signal
+// "denied" — some return null, some return an error with a permission-denied
+// message. We bias toward "did the user get the data they wanted".
+function classify(res: GqlResponse, opCategory: "query" | "mutation"): Outcome {
+  const errs = res.errors ?? [];
+  const messages = errs.map((e) => (e.message || "").toLowerCase());
+
+  const isAuth = messages.some(
+    (m) => m.includes("not authenticated") || m.includes("unauthenticated") || m.includes("not logged in"),
+  );
+  if (isAuth) return "auth";
+
+  const isDeny = messages.some(
+    (m) =>
+      m.includes("permission denied") ||
+      m.includes("forbidden") ||
+      m.includes("access denied") ||
+      m.includes("not authorized") ||
+      m.includes("unauthorized"),
+  );
+  if (isDeny) return "deny";
+
+  // No errors? If the data is null for a query, treat as notfound. For
+  // mutations, no errors == allow.
+  if (errs.length === 0) {
+    if (opCategory === "query") {
+      const data = res.data;
+      if (data && typeof data === "object") {
+        const onlyKey = Object.keys(data)[0];
+        if (onlyKey && (data as Record<string, unknown>)[onlyKey] === null) return "notfound";
+      }
+    }
+    return "allow";
+  }
+
+  // Generic errors (validation, internal): caller should investigate. Treat
+  // as deny for the purposes of the matrix — but the diff report flags these
+  // separately so they're not silently glossed over.
+  return "deny";
+}
+
+type Cell = {
+  op: string;
+  persona: PersonaId;
+  expected: Outcome;
+  actual: Outcome;
+  raw: GqlResponse;
+};
+
+async function runOp(client: Client, query: string, variables: Record<string, unknown>) {
+  return client.query(query, variables);
+}
+
+async function main() {
+  const endpoint = arg("endpoint");
+
+  console.log(`[fuzzer] endpoint=${endpoint}`);
+  const pool = await buildClients(endpoint);
+  console.log(`[fuzzer] seeding world...`);
+  const world = await seed(endpoint, pool);
+  console.log(`[fuzzer] world: publicSpace=${world.publicSpaceId} publicRoom=${world.publicRoomId} otherSpace=${world.otherSpaceId}`);
+
+  const cells: Cell[] = [];
+  for (const op of OPERATIONS) {
+    const vars = op.vars(world);
+    if (vars === null) {
+      console.log(`[fuzzer] skip ${op.name} (seed didn't produce prerequisites)`);
+      continue;
+    }
+    for (const persona of PERSONAS) {
+      const expected = MATRIX[op.name]?.[persona.id] ?? "deny";
+      const client = pool[persona.id];
+      const res = await runOp(client, op.query, vars);
+      const actual = classify(res, op.category);
+      cells.push({ op: op.name, persona: persona.id, expected, actual, raw: res });
+    }
+  }
+
+  // Report.
+  const mismatches = cells.filter((c) => c.expected !== c.actual);
+  console.log(`\n[fuzzer] ${cells.length} cells tested, ${mismatches.length} mismatch(es).\n`);
+
+  if (mismatches.length > 0) {
+    console.log("Findings:");
+    for (const m of mismatches) {
+      const severity = m.expected === "deny" && m.actual === "allow" ? "‼ BYPASS" : "  diff   ";
+      console.log(`${severity}  ${m.op}  [${m.persona}]  expected=${m.expected} actual=${m.actual}`);
+      const errText = m.raw.errors?.map((e) => e.message).join(" | ") ?? "(no errors)";
+      console.log(`           errors: ${errText}`);
+    }
+    process.exit(1);
+  } else {
+    console.log("No mismatches. (Doesn't mean no bugs — only that the cells in matrix.ts match observed behaviour.)");
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(2);
+});

--- a/tools/authz-fuzzer/seed.ts
+++ b/tools/authz-fuzzer/seed.ts
@@ -1,0 +1,166 @@
+// Bootstraps the fixture world used by the fuzzer.
+//
+// World shape:
+//   - publicSpace + publicRoom: created by spaceAdmin, joined by spaceMember
+//     (space-only) and roomMember (room). spaceMember is intentionally NOT in
+//     the room so we can test the room-membership boundary.
+//   - otherSpace: created by otherSpaceOwner; nobody else is in it. Used for
+//     cross-tenant probes (a spaceAdmin of publicSpace must NOT be able to
+//     touch otherSpace).
+//   - one seeded message in publicRoom posted by roomMember, used to test
+//     edit/delete authorization (other users should not be able to alter it).
+
+import { Client } from "./client.ts";
+import { PERSONAS, type PersonaId } from "./personas.ts";
+
+export type SeedWorld = {
+  publicSpaceId: string;
+  publicRoomId: string;
+  otherSpaceId: string;
+  seededMessageEventId: string | null;
+  users: {
+    randomUserId: string;
+    spaceMemberUserId: string;
+    roomMemberUserId: string;
+    spaceAdminUserId: string;
+    otherSpaceOwnerUserId: string;
+    instanceAdminUserId: string;
+  };
+};
+
+export type ClientPool = Record<PersonaId, Client>;
+
+async function ensureUser(c: Client, login: string, email: string, password: string): Promise<string> {
+  // Use the build-tagged /auth/test/create-user endpoint. The production
+  // GraphQL `createUser` mutation was removed for security (#175) — it was
+  // unauthenticated and let any caller win the race to instance owner.
+  // The test endpoint requires `-tags test_endpoints` on the server build,
+  // which `mise dev` and the e2e CI both use.
+  const create = await c.http("/auth/test/create-user", {
+    method: "POST",
+    body: JSON.stringify({ login, displayName: login, password }),
+  });
+  if (create.ok) {
+    const data = (await create.json()) as { id: string };
+    if (email) await maybeVerifyEmail(c, data.id, email);
+    return data.id;
+  }
+
+  // 409/500 on duplicate login — fall through to looking the user up so the
+  // fuzzer is rerunnable against a polluted dev instance.
+  const me = await c.query<{ userByLogin: { id: string } | null }>(
+    "query($l: String!) { userByLogin(login: $l) { id } }",
+    { l: login },
+  );
+  if (!me.data?.userByLogin) {
+    throw new Error(`/auth/test/create-user failed (${create.status}) and no user with login ${login} exists`);
+  }
+  if (email) await maybeVerifyEmail(c, me.data.userByLogin.id, email);
+  return me.data.userByLogin.id;
+}
+
+// Verify a user's email via the test endpoint so the instance-admin persona
+// matches `admin.emails` in `chatto.toml`. Errors are tolerated because the
+// endpoint is idempotent and most personas don't need a verified email.
+async function maybeVerifyEmail(c: Client, userId: string, email: string): Promise<void> {
+  await c.http("/auth/test/verify-email", {
+    method: "POST",
+    body: JSON.stringify({ userId, email }),
+  });
+}
+
+export async function buildClients(endpoint: string): Promise<ClientPool> {
+  const pool = {} as ClientPool;
+  for (const p of PERSONAS) {
+    pool[p.id] = new Client(endpoint, p.id);
+  }
+  return pool;
+}
+
+export async function seed(endpoint: string, pool: ClientPool): Promise<SeedWorld> {
+  // Throwaway client for the user-provisioning calls. /auth/test/create-user
+  // and /auth/test/verify-email don't create sessions, so cookies don't
+  // contaminate later persona-specific Clients.
+  const bootstrap = new Client(endpoint, "bootstrap");
+
+  const ids: SeedWorld["users"] = {
+    randomUserId: "",
+    spaceMemberUserId: "",
+    roomMemberUserId: "",
+    spaceAdminUserId: "",
+    otherSpaceOwnerUserId: "",
+    instanceAdminUserId: "",
+  };
+
+  for (const p of PERSONAS) {
+    if (p.id === "anon") continue;
+    const userId = await ensureUser(bootstrap, p.login, p.email, p.password);
+    (ids as Record<string, string>)[`${p.id}UserId`] = userId;
+    await pool[p.id].login(p.login, p.password);
+  }
+
+  // The seed now verifies each persona's email via /auth/test/verify-email,
+  // which is enough to make `instanceAdmin` work on any instance whose
+  // `admin.emails` contains `instanceAdmin.email` from personas.ts. The
+  // default value (`fuzz_iadmin@example.test`) is unlikely to match an
+  // operator's config, so add it to chatto.toml before relying on the
+  // admin-only cells:
+  //
+  //   [admin]
+  //   emails = ["fuzz_iadmin@example.test"]
+  //
+  // Until that's done on the target instance, treat `instanceAdmin → allow`
+  // cells as low-confidence (they'll fail-closed because the persona's
+  // verified email doesn't match any admin entry).
+
+  // spaceAdmin creates publicSpace.
+  const sp = await pool.spaceAdmin.query<{ createSpace: { id: string } }>(
+    "mutation($i: CreateSpaceInput!) { createSpace(input: $i) { id } }",
+    { i: { name: "fuzz-public-space", description: "fuzzer fixture" } },
+  );
+  if (!sp.data?.createSpace) throw new Error(`createSpace failed: ${JSON.stringify(sp.errors)}`);
+  const publicSpaceId = sp.data.createSpace.id;
+
+  // spaceAdmin creates publicRoom.
+  const rm = await pool.spaceAdmin.query<{ createRoom: { id: string } }>(
+    "mutation($i: CreateRoomInput!) { createRoom(input: $i) { id } }",
+    { i: { spaceId: publicSpaceId, name: "fuzz-public-room" } },
+  );
+  if (!rm.data?.createRoom) throw new Error(`createRoom failed: ${JSON.stringify(rm.errors)}`);
+  const publicRoomId = rm.data.createRoom.id;
+
+  // spaceMember + roomMember join the space; only roomMember joins the room.
+  for (const id of ["spaceMember", "roomMember"] as const) {
+    await pool[id].query("mutation($i: JoinSpaceInput!) { joinSpace(input: $i) }", {
+      i: { spaceId: publicSpaceId },
+    });
+  }
+  await pool.roomMember.query("mutation($i: JoinRoomInput!) { joinRoom(input: $i) }", {
+    i: { spaceId: publicSpaceId, roomId: publicRoomId },
+  });
+
+  // roomMember posts a seed message used for edit/delete tests.
+  const post = await pool.roomMember.query<{
+    postMessage: { __typename: string; id?: string; eventId?: string };
+  }>(
+    "mutation($i: PostMessageInput!) { postMessage(input: $i) { __typename ... on Message { eventId } } }",
+    { i: { spaceId: publicSpaceId, roomId: publicRoomId, body: "fuzz-seed-msg" } },
+  );
+  const seededMessageEventId = post.data?.postMessage?.eventId ?? null;
+
+  // otherSpaceOwner creates an isolated space.
+  const sp2 = await pool.otherSpaceOwner.query<{ createSpace: { id: string } }>(
+    "mutation($i: CreateSpaceInput!) { createSpace(input: $i) { id } }",
+    { i: { name: "fuzz-other-space" } },
+  );
+  if (!sp2.data?.createSpace) throw new Error(`createSpace(other) failed: ${JSON.stringify(sp2.errors)}`);
+  const otherSpaceId = sp2.data.createSpace.id;
+
+  return {
+    publicSpaceId,
+    publicRoomId,
+    otherSpaceId,
+    seededMessageEventId,
+    users: ids,
+  };
+}


### PR DESCRIPTION
Adds the authorization-matrix fuzzer that came out of the security review (#169). It's a small, dependency-free TypeScript tool that runs every operation in its registry as a set of personas at known privilege levels, then diffs actual outcomes against an expected matrix.

**This is independent of #180** — it can land before, after, or instead. The fuzzer needs the security fixes in #180 to be merged before its matrix passes against `main`, but the tool itself adds no production code path.

## Why

Chatto's authz model rests on per-resolver `Can*` checks at the GraphQL gateway. One missed check = full bypass for every user. Manual review catches some; this catches them automatically and keeps catching them as the schema grows.

The intended deployment shape is a CI job that runs the fuzzer against an ephemeral Chatto instance and fails the build on any matrix mismatch. The README has a sketch of what that wiring looks like; this PR doesn't include it (the `instanceAdmin` persona needs config alignment first — see Known Limitations).

## What it catches

| Symptom | Means |
|---|---|
| `expected deny, got allow` | Resolver missed its `Can*` check. |
| `expected notfound, got deny` | Information leak via differential errors. |
| `expected auth, got allow` | Resolver missing `requireAuth`. |
| `expected allow, got deny` | Either the matrix is wrong, or a fix went too far. |

## Design choices

- **Zero dependencies.** Node 22+ `--experimental-strip-types`, built-in `fetch`. No npm lockfile, no test runner, no Playwright. If the matrix gets big enough to need parallelism / reporters, that's the moment to add a runner — not before.
- **Silence is denial.** Anything not explicitly listed for a persona defaults to `deny`. Every `allow` is an explicit security claim, not a footgun.
- **Uses build-tagged test endpoints** for user provisioning (`/auth/test/create-user`, `/auth/test/verify-email`) — same trust model as the e2e suite. Won't run against production binaries.

## What's in the box

- 7 personas (`anon`, `randomUser`, `spaceMember`, `roomMember`, `spaceAdmin`, `otherSpaceOwner`, `instanceAdmin`).
- ~20 operations covering admin namespace, room/message access, cross-tenant probes (via `otherSpaceOwner`), ownership-gated mutations, and discovery queries.
- README with architecture diagram, contribution guide, and CI integration sketch.

## Known limitations (also in README)

- `instanceAdmin` requires `admin.emails` in `chatto.toml` to include the persona's fixed email. Until that's aligned on the target instance, admin-only cells fail-closed and shouldn't be trusted as authoritative.
- Subscriptions aren't covered — needs a WS client.
- No cleanup; runs accumulate state on long-lived dev instances.

## Running

```sh
mise x -- node --experimental-strip-types tools/authz-fuzzer/run.ts \
  --endpoint=https://your-instance.orb.local
```

The target needs `-tags test_endpoints` (`mise dev` already builds with this, as does the e2e CI).

## Test plan

- [x] All seven `.ts` files parse cleanly under `node --experimental-strip-types --check`.
- [x] No new dependencies; nothing added to any `package.json` or `go.mod`.
- [ ] CI to verify the no-deps + Node-version assumption works in the GitHub runner.
- [ ] Once #180 lands and the `instanceAdmin` config alignment is decided, follow up with a CI job that runs the fuzzer per push and fails on mismatch.

## Files

- `tools/authz-fuzzer/README.md` — architecture, contribution guide, CI sketch.
- `tools/authz-fuzzer/client.ts` — minimal GraphQL client with cookie jar.
- `tools/authz-fuzzer/personas.ts` — persona registry.
- `tools/authz-fuzzer/seed.ts` — fixture-world bootstrap.
- `tools/authz-fuzzer/operations.ts` — operation registry.
- `tools/authz-fuzzer/matrix.ts` — expected `(operation, persona) → outcome`.
- `tools/authz-fuzzer/run.ts` — orchestrator + diff reporter.

Refs #169, #180.