### PR TITLE
chore(conductor): tear down docker compose stack on exit

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,5 +1,5 @@
 {
     "scripts": {
-        "run": "echo \"Starting on https://chatto-instance-$CONDUCTOR_WORKSPACE_NAME.orb.local/\" && docker compose -p chatto-instance-$CONDUCTOR_WORKSPACE_NAME up"
+        "run": "echo \"Starting on https://chatto-instance-$CONDUCTOR_WORKSPACE_NAME.orb.local/\" && trap 'docker compose -p chatto-instance-$CONDUCTOR_WORKSPACE_NAME down' EXIT INT TERM && docker compose -p chatto-instance-$CONDUCTOR_WORKSPACE_NAME up"
     }
 }


### PR DESCRIPTION
## Summary
- Wrap the workspace `run` script with a `trap` on `EXIT INT TERM` so `docker compose down` runs whenever the process stops, leaving no stray containers or networks behind.
- Named volumes are preserved (no `-v`), so dev data survives stop/restart.

## Test plan
- [ ] Start a Conductor workspace, stop it, and verify containers/networks are gone while named volumes remain.