### PR TITLE
refactor(frontend): unify origin/remote auth handling

### DIFF
--- a/frontend/src/lib/SpaceDirectory.svelte
+++ b/frontend/src/lib/SpaceDirectory.svelte
@@ -71,19 +71,18 @@
     instanceData.filter((d) => !d.loading && (d.error || d.canBrowse === false))
   );
 
-  // Read currentUser from Svelte context — this is the SAME object that
-  // AuthenticatedChatProvider writes to. Reading from the instance store instead
-  // would break when the origin was probe-registered async (the store gets a
-  // different CurrentUserState than the one in context).
+  // Read currentUser from Svelte context — used as a fallback for the origin
+  // instance during the brief window between probe-registration and
+  // AuthenticatedChatProvider populating the store's currentUser.
   const currentUser = getCurrentUser();
 
   /** Reactively track which instances are authenticated. */
   const authenticatedInstances = $derived(
-    instanceRegistry.instances.filter((i) =>
-      instanceRegistry.isOriginInstance(i.id)
-        ? !!currentUser.user
-        : !!i.token
-    )
+    instanceRegistry.instances.filter((i) => {
+      const store = instanceRegistry.tryGetStore(i.id);
+      if (store?.isAuthenticated) return true;
+      return instanceRegistry.isOriginInstance(i.id) && !!currentUser.user;
+    })
   );
 
   const LoadInstanceSpacesQuery = graphql(`

--- a/frontend/src/lib/SpaceList.svelte
+++ b/frontend/src/lib/SpaceList.svelte
@@ -68,21 +68,20 @@
   let canViewAdmin = $derived(instancePerms.current.canViewAdmin);
 
   // Check whether any authenticated instance grants a permission.
-  // Optimistically returns true while permissions are still loading,
-  // but only for instances that are actually authenticated (origin with
-  // a current user, or remote with a token). Unauthenticated instances
-  // (e.g. origin before login) are skipped entirely.
+  // Optimistically returns true while permissions are still loading.
+  // Unauthenticated instances are skipped entirely.
   function anyInstanceHasPermission(key: keyof InstancePermissions): boolean {
     return instanceRegistry.instances.some((i) => {
-      const isOrigin = instanceRegistry.isOriginInstance(i.id);
       const store = instanceRegistry.tryGetStore(i.id);
       if (!store) return false;
 
-      // Skip unauthenticated instances — mirrors the guard in the template
-      const isAuthenticated = isOrigin
-        ? !!(store.currentUser.user ?? currentUserCtx.user)
-        : !!i.token;
-      if (!isAuthenticated) return false;
+      // Origin's currentUser is populated reactively by AuthenticatedChatProvider,
+      // but during the gap between probeOrigin and that mount the context user
+      // is the only signal — fall through to it for the origin slot.
+      const authed =
+        store.isAuthenticated ||
+        (instanceRegistry.isOriginInstance(i.id) && !!currentUserCtx.user);
+      if (!authed) return false;
 
       const perms = store.permissions;
       return !perms.loaded || perms[key];
@@ -154,9 +153,9 @@
     <!-- Per-instance space sections (only for authenticated instances) -->
     {#each instanceRegistry.instances as instance (instance.id)}
       {@const isOrigin = instanceRegistry.isOriginInstance(instance.id)}
-      {@const storeUser = instanceRegistry.tryGetStore(instance.id)?.currentUser.user}
-      {@const instanceUser = storeUser ?? (isOrigin ? currentUserCtx.user : undefined)}
-      {#if (isOrigin && instanceUser) || (!isOrigin && instance.token)}
+      {@const store = instanceRegistry.tryGetStore(instance.id)}
+      {@const instanceUser = store?.currentUser.user ?? (isOrigin ? currentUserCtx.user : undefined)}
+      {#if store?.isAuthenticated || (isOrigin && currentUserCtx.user)}
         <InstanceSpaceSection
           instanceId={instance.id}
           {activeSpaceId}

--- a/frontend/src/lib/auth/currentUser.svelte.ts
+++ b/frontend/src/lib/auth/currentUser.svelte.ts
@@ -1,10 +1,6 @@
 import { goto } from '$app/navigation';
 import { resolve } from '$app/paths';
-import {
-  graphqlClientManager,
-  setAuthFailureHandler,
-  setSessionValidationHandler
-} from '$lib/state/instance/graphqlClient.svelte';
+import { graphqlClientManager } from '$lib/state/instance/graphqlClient.svelte';
 import { createContext } from 'svelte';
 import type { Client } from '@urql/svelte';
 import { LoadCurrentUserDocument, clearCachedUser, type CurrentUser } from './loadAuth';
@@ -15,19 +11,20 @@ export type { CurrentUser };
  * Per-instance current user state. Tracks who the authenticated user is on a
  * given Chatto instance.
  *
- * For the origin instance (isOrigin=true), auth failure redirects to login.
- * For remote instances, auth failure just clears the user state.
+ * Cookie-authenticated instances (origin) handle auth failure with a full
+ * logout flow (clear cookie, redirect to login). Bearer-authenticated instances
+ * (remotes) just clear the local user state.
  */
 export class CurrentUserState {
   user = $state<CurrentUser | undefined>(undefined);
   loading = $state(true);
   #client: Client;
-  #isOrigin: boolean;
+  #cookieAuth: boolean;
   #isLoggingOut = false;
 
-  constructor(client: Client, isOrigin: boolean = false) {
+  constructor(client: Client, cookieAuth: boolean = false) {
     this.#client = client;
-    this.#isOrigin = isOrigin;
+    this.#cookieAuth = cookieAuth;
   }
 
   async load() {
@@ -41,66 +38,55 @@ export class CurrentUserState {
 
   /**
    * Re-validate the session by checking Query.me.
-   * If the session has expired, triggers logout and redirect (origin)
-   * or clears user state (remote).
+   * If the session has expired, triggers logout and redirect (cookie auth)
+   * or clears user state (bearer auth).
    */
   async validateSession() {
-    // Don't validate during initial load or if already logging out
     if (this.loading || this.#isLoggingOut) return;
-
-    // Only validate if we think we're logged in
     if (!this.user) return;
 
     const resp = await this.#client.query(
       LoadCurrentUserDocument,
       {},
-      { requestPolicy: 'network-only' } // Always fetch fresh, bypass any cache
+      { requestPolicy: 'network-only' }
     );
 
     // Network error (e.g., dead TCP connection after sleep) — don't treat as auth failure.
-    // The WebSocket reconnect handler will call triggerSessionValidation() again once
-    // connectivity is restored.
     if (resp.error?.networkError) {
       console.log('Session validation skipped — network error:', resp.error.networkError.message);
       return;
     }
 
-    // Server responded but me is null — session has genuinely expired
     if (!resp.data?.me) {
       console.log('Session validation failed — user no longer authenticated');
       this.handleAuthFailure();
     } else {
-      // Update user data in case it changed (e.g., avatar, display name)
       this.user = resp.data.me;
     }
   }
 
   /**
    * Handle auth failure.
-   * Origin instance: clears session and redirects to login.
-   * Remote instance: clears user state (instance becomes unauthenticated).
+   * Cookie auth (origin): clears session and redirects to login.
+   * Bearer auth (remote): clears user state (instance becomes unauthenticated).
    */
   async handleAuthFailure() {
     if (this.#isLoggingOut) return;
 
-    if (!this.#isOrigin) {
-      // Remote instance: just clear user state, no redirect
+    if (!this.#cookieAuth) {
       console.log('Remote instance auth failure — clearing user');
       this.user = undefined;
       this.loading = false;
       return;
     }
 
-    // Origin instance: full logout flow
     this.#isLoggingOut = true;
 
     console.log('Auth failure - redirecting to login');
     this.user = undefined;
 
-    // Clear the cached user in loadAuth so the next navigation will re-fetch
     clearCachedUser();
 
-    // Store current URL for redirect after login
     sessionStorage.setItem('returnUrl', window.location.pathname + window.location.search);
 
     // Clear the session cookie by calling the logout endpoint. This is necessary
@@ -130,7 +116,7 @@ export const [getCurrentUser, setCurrentUser] = createContext<CurrentUserState>(
  */
 export function initCurrentUserContext(): CurrentUserState {
   const s = new CurrentUserState(graphqlClientManager.originClient.client, true);
-  s.loading = false; // Not loading - we're not fetching
+  s.loading = false;
   setCurrentUser(s);
   return s;
 }
@@ -140,11 +126,6 @@ export async function initCurrentUser() {
     new CurrentUserState(graphqlClientManager.originClient.client, true)
   );
   await s.load();
-
-  // Register handlers for auth events from GraphQL client
-  setAuthFailureHandler(() => s.handleAuthFailure());
-  setSessionValidationHandler(() => s.validateSession());
-
   return s;
 }
 
@@ -156,22 +137,11 @@ export async function initCurrentUser() {
  *
  * @param user - The user data from the load function
  * @returns The initialized CurrentUserState
- *
- * @example
- * // In +layout.svelte
- * import { initCurrentUserFromData } from '$lib/auth/currentUser.svelte';
- * let { data } = $props();
- * initCurrentUserFromData(data.user);
  */
 export function initCurrentUserFromData(user: CurrentUser): CurrentUserState {
   const s = new CurrentUserState(graphqlClientManager.originClient.client, true);
   s.user = user;
   s.loading = false;
   setCurrentUser(s);
-
-  // Register handlers for auth events from GraphQL client
-  setAuthFailureHandler(() => s.handleAuthFailure());
-  setSessionValidationHandler(() => s.validateSession());
-
   return s;
 }

--- a/frontend/src/lib/components/NotificationSync.svelte
+++ b/frontend/src/lib/components/NotificationSync.svelte
@@ -26,10 +26,7 @@ Include this component once in the chat layout (unconditionally).
 
     for (const instance of instanceRegistry.instances) {
       const stores = instanceRegistry.getStore(instance.id);
-      // Skip unauthenticated instances
-      const isOrigin = instanceRegistry.isOriginInstance(instance.id);
-      if (isOrigin && !stores.currentUser.user) continue;
-      if (!isOrigin && !instance.token) continue;
+      if (!stores.isAuthenticated) continue;
 
       const bus = instanceEventBusManager.getBus(instance.id);
       if (!bus) continue;
@@ -62,9 +59,7 @@ Include this component once in the chat layout (unconditionally).
   let totalNotificationCount = $derived(
     instanceRegistry.instances.reduce((sum, instance) => {
       const stores = instanceRegistry.getStore(instance.id);
-      const isOrigin = instanceRegistry.isOriginInstance(instance.id);
-      if (isOrigin && !stores.currentUser.user) return sum;
-      if (!isOrigin && !instance.token) return sum;
+      if (!stores.isAuthenticated) return sum;
       return sum + stores.notifications.count;
     }, 0)
   );
@@ -72,9 +67,7 @@ Include this component once in the chat layout (unconditionally).
   let hasAnyUnread = $derived(
     instanceRegistry.instances.some((instance) => {
       const stores = instanceRegistry.getStore(instance.id);
-      const isOrigin = instanceRegistry.isOriginInstance(instance.id);
-      if (isOrigin && !stores.currentUser.user) return false;
-      if (!isOrigin && !instance.token) return false;
+      if (!stores.isAuthenticated) return false;
       return stores.roomUnread.hasAnyUnread;
     })
   );

--- a/frontend/src/lib/hooks/usePageTitle.svelte.ts
+++ b/frontend/src/lib/hooks/usePageTitle.svelte.ts
@@ -17,10 +17,9 @@ export function usePageTitle(): () => string {
       : instanceName;
 
     const totalCount = instanceRegistry.instances.reduce((sum, instance) => {
-      const isOrigin = instanceRegistry.isOriginInstance(instance.id);
-      if (isOrigin && !instanceRegistry.getStore(instance.id).currentUser.user) return sum;
-      if (!isOrigin && !instance.token) return sum;
-      return sum + instanceRegistry.getStore(instance.id).notifications.count;
+      const store = instanceRegistry.getStore(instance.id);
+      if (!store.isAuthenticated) return sum;
+      return sum + store.notifications.count;
     }, 0);
 
     return totalCount > 0 ? `(${totalCount}) ${base}` : base;

--- a/frontend/src/lib/state/instance/graphqlClient.svelte.spec.ts
+++ b/frontend/src/lib/state/instance/graphqlClient.svelte.spec.ts
@@ -8,11 +8,10 @@ const { mockWsDispose, mockWsTerminate, mockWsSubscribe, mockInstances, clientCo
 		mockWsSubscribe: vi.fn(() => vi.fn()),
 		mockInstances: new Map<
 			string,
-			{ id: string; url: string; token: string | null; isOrigin: boolean }
+			{ id: string; url: string; token: string | null }
 		>(),
 		clientConfigs: [] as Record<string, unknown>[]
 	}));
-
 
 
 vi.mock('graphql-ws', () => ({
@@ -31,18 +30,33 @@ vi.mock('@urql/svelte', () => ({
 	},
 	fetchExchange: { name: 'fetchExchange' },
 	subscriptionExchange: vi.fn(() => ({ name: 'subscriptionExchange' })),
-	mapExchange: vi.fn(() => ({ name: 'mapExchange' }))
+	mapExchange: vi.fn((config: { onResult: (result: unknown) => unknown }) => ({
+		name: 'mapExchange',
+		onResult: config.onResult
+	}))
 }));
 
 vi.mock('./registry.svelte', () => ({
 	instanceRegistry: {
 		getInstance: (id: string) => mockInstances.get(id),
-		isOriginInstance: (id: string) => mockInstances.get(id)?.isOrigin ?? false
+		isOriginInstance: (id: string) => mockInstances.get(id)?.token === null
 	}
 }));
 
 import { httpToWsUrl, GraphQLClient, type GraphQLClientConfig } from './graphqlClient.svelte';
 import { createClient as createWSClient } from 'graphql-ws';
+import { mapExchange } from '@urql/svelte';
+
+/** Pull the most recent mapExchange `onResult` callback so tests can fire it. */
+function lastMapExchangeOnResult(): (result: {
+	error?: { graphQLErrors?: { message?: string }[] };
+}) => unknown {
+	const calls = vi.mocked(mapExchange).mock.calls;
+	const lastConfig = calls[calls.length - 1][0] as {
+		onResult: (r: { error?: { graphQLErrors?: { message?: string }[] } }) => unknown;
+	};
+	return lastConfig.onResult;
+}
 
 function makeConfig(overrides: Partial<GraphQLClientConfig> = {}): GraphQLClientConfig {
 	return {
@@ -142,6 +156,69 @@ describe('GraphQLClient', () => {
 		client.forceReconnect('test');
 		expect(mockWsTerminate).toHaveBeenCalledOnce();
 	});
+
+	describe('setAuthHandlers', () => {
+		it('does not call onAuthFailure before handlers are wired', () => {
+			const client = new GraphQLClient(makeConfig());
+			const onResult = lastMapExchangeOnResult();
+			// No setAuthHandlers call — pre-wiring window
+			onResult({ error: { graphQLErrors: [{ message: 'not authenticated' }] } });
+			// Nothing to assert other than: no throw and no wired handler exists.
+			// This guards the synchronous gap between client construction and
+			// InstanceStateStore wiring its handlers.
+			expect(client).toBeDefined();
+		});
+
+		it('fires onAuthFailure when the result contains a "not authenticated" error', () => {
+			const client = new GraphQLClient(makeConfig());
+			const handler = vi.fn();
+			client.setAuthHandlers({ onAuthFailure: handler });
+
+			const onResult = lastMapExchangeOnResult();
+			onResult({ error: { graphQLErrors: [{ message: 'user not authenticated' }] } });
+
+			expect(handler).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not fire onAuthFailure for unrelated errors', () => {
+			const client = new GraphQLClient(makeConfig());
+			const handler = vi.fn();
+			client.setAuthHandlers({ onAuthFailure: handler });
+
+			const onResult = lastMapExchangeOnResult();
+			onResult({ error: { graphQLErrors: [{ message: 'something else broke' }] } });
+
+			expect(handler).not.toHaveBeenCalled();
+		});
+
+		it('replacing handlers swaps which callback fires next', () => {
+			const client = new GraphQLClient(makeConfig());
+			const first = vi.fn();
+			const second = vi.fn();
+
+			client.setAuthHandlers({ onAuthFailure: first });
+			client.setAuthHandlers({ onAuthFailure: second });
+
+			const onResult = lastMapExchangeOnResult();
+			onResult({ error: { graphQLErrors: [{ message: 'not authenticated' }] } });
+
+			expect(first).not.toHaveBeenCalled();
+			expect(second).toHaveBeenCalledTimes(1);
+		});
+
+		it('clearing handlers (passing {}) makes onAuthFailure a no-op again', () => {
+			const client = new GraphQLClient(makeConfig());
+			const handler = vi.fn();
+
+			client.setAuthHandlers({ onAuthFailure: handler });
+			client.setAuthHandlers({}); // unwired
+
+			const onResult = lastMapExchangeOnResult();
+			onResult({ error: { graphQLErrors: [{ message: 'not authenticated' }] } });
+
+			expect(handler).not.toHaveBeenCalled();
+		});
+	});
 });
 
 describe('GraphQLClientManager', () => {
@@ -171,8 +248,7 @@ describe('GraphQLClientManager', () => {
 		mockInstances.set('my-home', {
 			id: 'my-home',
 			url: 'http://localhost:4000',
-			token: null,
-			isOrigin: true
+			token: null
 		});
 
 		const client = mod.graphqlClientManager.getClient('my-home');
@@ -191,8 +267,7 @@ describe('GraphQLClientManager', () => {
 		mockInstances.set('remote-1', {
 			id: 'remote-1',
 			url: 'https://remote.example.com',
-			token: 'remote-token',
-			isOrigin: false
+			token: 'remote-token'
 		});
 
 		const client1 = mod.graphqlClientManager.getClient('remote-1');
@@ -206,8 +281,7 @@ describe('GraphQLClientManager', () => {
 		mockInstances.set('remote-2', {
 			id: 'remote-2',
 			url: 'https://other.example.com',
-			token: 'token-2',
-			isOrigin: false
+			token: 'token-2'
 		});
 
 		// Create the client first

--- a/frontend/src/lib/state/instance/graphqlClient.svelte.spec.ts
+++ b/frontend/src/lib/state/instance/graphqlClient.svelte.spec.ts
@@ -13,6 +13,8 @@ const { mockWsDispose, mockWsTerminate, mockWsSubscribe, mockInstances, clientCo
 		clientConfigs: [] as Record<string, unknown>[]
 	}));
 
+
+
 vi.mock('graphql-ws', () => ({
 	createClient: vi.fn(() => ({
 		subscribe: mockWsSubscribe,
@@ -47,7 +49,6 @@ function makeConfig(overrides: Partial<GraphQLClientConfig> = {}): GraphQLClient
 		url: '/api/graphql',
 		wsUrl: '/api/graphql',
 		token: null,
-		isOrigin: true,
 		...overrides
 	};
 }
@@ -99,14 +100,14 @@ describe('GraphQLClient', () => {
 	});
 
 	it('sets fetchOptions with Authorization header when token is provided', () => {
-		new GraphQLClient(makeConfig({ url: 'https://remote.example.com/api/graphql', token: 'my-token', isOrigin: false }));
+		new GraphQLClient(makeConfig({ url: 'https://remote.example.com/api/graphql', token: 'my-token' }));
 		expect(lastClientConfig()?.fetchOptions).toBeDefined();
 		const opts = (lastClientConfig()!.fetchOptions as () => Record<string, unknown>)();
 		expect(opts).toEqual({ headers: { Authorization: 'Bearer my-token' } });
 	});
 
 	it('sets connectionParams when token is provided', () => {
-		new GraphQLClient(makeConfig({ url: 'https://remote.example.com/api/graphql', token: 'my-token', isOrigin: false }));
+		new GraphQLClient(makeConfig({ url: 'https://remote.example.com/api/graphql', token: 'my-token' }));
 		expect(createWSClient).toHaveBeenCalledWith(
 			expect.objectContaining({
 				connectionParams: expect.any(Function)

--- a/frontend/src/lib/state/instance/graphqlClient.svelte.ts
+++ b/frontend/src/lib/state/instance/graphqlClient.svelte.ts
@@ -2,40 +2,16 @@ import { Client, fetchExchange, subscriptionExchange, mapExchange } from '@urql/
 import { createClient as createWSClient } from 'graphql-ws';
 import { instanceRegistry } from './registry.svelte';
 
-// Auth failure / session validation callbacks (origin instance only)
-let onAuthFailure: (() => void) | null = null;
-let onSessionValidationNeeded: (() => void) | null = null;
-let lastSessionValidation = 0;
 const SESSION_VALIDATION_COOLDOWN_MS = 5000;
 
-export function setAuthFailureHandler(handler: () => void) {
-	onAuthFailure = handler;
-}
-
-export function setSessionValidationHandler(handler: () => void) {
-	onSessionValidationNeeded = handler;
-}
-
-function triggerAuthFailure() {
-	if (onAuthFailure) {
-		onAuthFailure();
-	}
-}
-
-function triggerSessionValidation() {
-	if (!onSessionValidationNeeded) return;
-
-	// Skip if we've validated recently (within cooldown period)
-	const now = Date.now();
-	if (now - lastSessionValidation < SESSION_VALIDATION_COOLDOWN_MS) {
-		return;
-	}
-	lastSessionValidation = now;
-
-	onSessionValidationNeeded();
-}
-
 export type ConnectionStatus = 'connected' | 'connecting' | 'disconnected';
+
+export interface AuthHandlers {
+	/** Called when an auth-failure error is detected in a GraphQL response. */
+	onAuthFailure?: () => void;
+	/** Called on reconnect or when the tab becomes visible (for session re-validation). */
+	onSessionValidation?: () => void;
+}
 
 export interface GraphQLClientConfig {
 	/** GraphQL HTTP endpoint URL (relative for origin, absolute for remote) */
@@ -44,8 +20,6 @@ export interface GraphQLClientConfig {
 	wsUrl: string;
 	/** Bearer token for cross-origin auth, or null to use cookies */
 	token: string | null;
-	/** Whether this is the origin instance (controls auth failure / session validation) */
-	isOrigin: boolean;
 }
 
 /** Construct a WebSocket URL from an HTTP URL (http→ws, https→wss). */
@@ -69,6 +43,8 @@ export class GraphQLClient {
 	#onlineHandler: (() => void) | null = null;
 	#suspendDetectorInterval: ReturnType<typeof setInterval> | null = null;
 	#host: string;
+	#handlers: AuthHandlers = {};
+	#lastSessionValidation = 0;
 
 	get isConnected() {
 		return this.status === 'connected';
@@ -91,9 +67,26 @@ export class GraphQLClient {
 		this.#wsClient.terminate();
 	}
 
+	/**
+	 * Wire per-instance auth handlers. Called by InstanceStateStore once both the
+	 * client and the store's CurrentUserState exist. May be called more than once;
+	 * the latest handlers win.
+	 */
+	setAuthHandlers(handlers: AuthHandlers) {
+		this.#handlers = handlers;
+	}
+
+	#triggerSessionValidation() {
+		if (!this.#handlers.onSessionValidation) return;
+		const now = Date.now();
+		if (now - this.#lastSessionValidation < SESSION_VALIDATION_COOLDOWN_MS) return;
+		this.#lastSessionValidation = now;
+		this.#handlers.onSessionValidation();
+	}
+
 	constructor(config: GraphQLClientConfig) {
-		const { url, wsUrl, token, isOrigin } = config;
-		this.#host = isOrigin
+		const { url, wsUrl, token } = config;
+		this.#host = url.startsWith('/')
 			? (typeof window !== 'undefined' ? window.location.host : 'localhost')
 			: // eslint-disable-next-line svelte/prefer-svelte-reactivity -- extracting host string, URL not stored
 				new URL(url).host;
@@ -130,11 +123,9 @@ export class GraphQLClient {
 			on: {
 				ping: (received) => {
 					if (received) {
-						// Server sent us a ping — all good
 						console.debug('[ws:%s] Server ping received', this.#host);
 						return;
 					}
-					// We sent a ping to the server — start a 5s timeout for the pong
 					console.debug('[ws:%s] Client ping sent, awaiting pong', this.#host);
 					this.#pongTimeoutId = setTimeout(() => {
 						if (this.#activeSocket?.readyState === WebSocket.OPEN) {
@@ -148,7 +139,6 @@ export class GraphQLClient {
 				},
 				pong: (received) => {
 					if (received && this.#pongTimeoutId !== null) {
-						// Server responded to our ping — clear the timeout
 						console.debug('[ws:%s] Pong received', this.#host);
 						clearTimeout(this.#pongTimeoutId);
 						this.#pongTimeoutId = null;
@@ -165,8 +155,7 @@ export class GraphQLClient {
 							this.#host,
 							this.reconnectCount
 						);
-						// Re-validate session after reconnect (origin instance only)
-						if (isOrigin) triggerSessionValidation();
+						this.#triggerSessionValidation();
 					}
 					this.status = 'connected';
 					this.#failedAttempts = 0;
@@ -195,16 +184,14 @@ export class GraphQLClient {
 			preferGetMethod: false,
 			...(token ? { fetchOptions: () => ({ headers: { Authorization: `Bearer ${token}` } }) } : {}),
 			exchanges: [
-				// Auth error detection and reconnect trigger
 				mapExchange({
 					onResult: (result) => {
-						// Check for GraphQL errors indicating auth failure (origin instance only)
 						if (
-							isOrigin &&
+							this.#handlers.onAuthFailure &&
 							result.error?.graphQLErrors?.some((e) => e.message?.includes('not authenticated'))
 						) {
 							console.log('Auth failure detected in GraphQL error, triggering logout');
-							triggerAuthFailure();
+							this.#handlers.onAuthFailure();
 						}
 
 						// If an HTTP request succeeded but WebSocket is disconnected,
@@ -240,8 +227,7 @@ export class GraphQLClient {
 				if (document.visibilityState === 'visible') {
 					const hiddenDuration = Date.now() - this.#lastVisibleAt;
 
-					// Re-validate session when tab becomes visible (origin instance only)
-					if (isOrigin) triggerSessionValidation();
+					this.#triggerSessionValidation();
 
 					if (this.status === 'disconnected' || hiddenDuration > 30_000) {
 						this.forceReconnect(
@@ -311,8 +297,7 @@ class GraphQLClientManager {
 		this.#originClient = new GraphQLClient({
 			url: HOME_URL,
 			wsUrl: HOME_URL,
-			token: null,
-			isOrigin: true
+			token: null
 		});
 	}
 
@@ -323,16 +308,13 @@ class GraphQLClientManager {
 
 	/** Get or create a client for a registered instance. */
 	getClient(instanceId: string): GraphQLClient {
-		// Return origin client for the origin instance
 		if (instanceRegistry.isOriginInstance(instanceId)) {
 			return this.#originClient;
 		}
 
-		// Return cached client if available
 		const existing = this.#clients.get(instanceId);
 		if (existing) return existing;
 
-		// Create new client for remote instance
 		const instance = instanceRegistry.getInstance(instanceId);
 		if (!instance) {
 			throw new Error(`Instance "${instanceId}" not found in registry`);
@@ -342,8 +324,7 @@ class GraphQLClientManager {
 		const client = new GraphQLClient({
 			url,
 			wsUrl: httpToWsUrl(url),
-			token: instance.token,
-			isOrigin: false
+			token: instance.token
 		});
 
 		this.#clients.set(instanceId, client);
@@ -362,4 +343,3 @@ class GraphQLClientManager {
 }
 
 export const graphqlClientManager = new GraphQLClientManager();
-

--- a/frontend/src/lib/state/instance/registry.svelte.ts
+++ b/frontend/src/lib/state/instance/registry.svelte.ts
@@ -232,11 +232,14 @@ class InstanceRegistry {
 		}
 		this.instances.push(instance);
 		saveInstances(this.instances);
-		this.#createStore(instance);
+		const store = this.#createStore(instance);
 
-		// Start the event bus eagerly so child components (InstanceSpaceSection)
-		// can register handlers during their mount lifecycle.
-		if (instance.token) {
+		// Start the event bus eagerly for already-authenticated instances so
+		// child components (InstanceSpaceSection) can register handlers during
+		// their mount lifecycle. For cookie-auth instances the user is loaded
+		// asynchronously by AuthenticatedChatProvider, so the layout's $effect
+		// starts the bus once `isAuthenticated` flips true.
+		if (store.isAuthenticated) {
 			const gqlClient = graphqlClientManager.getClient(instance.id);
 			instanceEventBusManager.startBus(instance.id, gqlClient.client);
 		}
@@ -321,8 +324,7 @@ class InstanceRegistry {
 	/** Create a state store for an instance and wire up remote user sync. */
 	#createStore(instance: RegisteredInstance): InstanceStateStore {
 		const gqlClient = graphqlClientManager.getClient(instance.id);
-		const isOrigin = this.isOriginInstance(instance.id);
-		const store = new InstanceStateStore(instance.id, gqlClient.client, isOrigin);
+		const store = new InstanceStateStore(instance, gqlClient);
 		this.#stores.set(instance.id, store);
 
 		// Eagerly fetch instance info (name, MOTD, upload limits, etc.).
@@ -330,13 +332,12 @@ class InstanceRegistry {
 		// in the chat layout after the root layout script already ran).
 		store.instance.init();
 
-		// Token-authenticated instances: auto-load the authenticated user via bearer token.
-		// Origin instance uses cookie auth — the SvelteKit load function already determined
-		// auth state, so mark loading=false immediately. AuthenticatedChatProvider will
-		// set the user if authenticated.
-		if (!instance.token && isOrigin) {
+		if (instance.token === null) {
+			// Cookie auth (origin) — the SvelteKit load function already determined
+			// auth state. AuthenticatedChatProvider will set the user if authenticated.
 			store.currentUser.loading = false;
-		} else if (instance.token) {
+		} else {
+			// Bearer auth (remote) — auto-load the authenticated user via the token.
 			store.currentUser.load().then(() => {
 				const user = store.currentUser.user;
 				if (user) {
@@ -351,6 +352,11 @@ class InstanceRegistry {
 		}
 
 		return store;
+	}
+
+	/** Whether the instance has an authenticated user. False if not registered. */
+	isAuthenticated(instanceId: string): boolean {
+		return this.tryGetStore(instanceId)?.isAuthenticated ?? false;
 	}
 }
 

--- a/frontend/src/lib/state/instance/store.svelte.ts
+++ b/frontend/src/lib/state/instance/store.svelte.ts
@@ -51,15 +51,14 @@ export class InstanceStateStore {
 	 * instances in $state.
 	 */
 	readonly #registered: RegisteredInstance;
-	readonly #cookieAuth: boolean;
 
 	constructor(registered: RegisteredInstance, gqlClient: GraphQLClient) {
 		this.instanceId = registered.id;
 		this.#registered = registered;
-		this.#cookieAuth = registered.token === null;
+		const cookieAuth = this.#cookieAuth;
 
 		const client = gqlClient.client;
-		this.currentUser = new CurrentUserState(client, this.#cookieAuth);
+		this.currentUser = new CurrentUserState(client, cookieAuth);
 		this.instance = new InstanceState(client);
 		this.notifications = new NotificationStore(client);
 		this.roomUnread = new RoomUnreadStore();
@@ -68,10 +67,28 @@ export class InstanceStateStore {
 		this.callParticipants = new CallParticipantsState(client);
 		this.activeCallRooms = new ActiveCallRoomsState(client, this.voiceCall);
 
-		gqlClient.setAuthHandlers({
-			onAuthFailure: () => this.currentUser.handleAuthFailure(),
-			onSessionValidation: () => this.currentUser.validateSession()
-		});
+		// Gate session-revalidation and auth-failure dispatch to cookie-auth
+		// instances only. Bearer auth's `handleAuthFailure` would clear
+		// `currentUser.user` while leaving the bearer token intact, producing
+		// an inconsistent state where `isAuthenticated` (token != null) is
+		// still true but the user is gone. Until the data model has a clean
+		// way to represent "remote with revoked token", keep the existing
+		// behavior of letting the next failed query surface the error.
+		if (cookieAuth) {
+			gqlClient.setAuthHandlers({
+				onAuthFailure: () => this.currentUser.handleAuthFailure(),
+				onSessionValidation: () => this.currentUser.validateSession()
+			});
+		}
+	}
+
+	/**
+	 * Whether this instance uses cookie auth (origin) vs bearer auth (remote).
+	 * Read from the live registered instance so it stays correct if the token
+	 * field is ever updated.
+	 */
+	get #cookieAuth(): boolean {
+		return this.#registered.token === null;
 	}
 
 	/**

--- a/frontend/src/lib/state/instance/store.svelte.ts
+++ b/frontend/src/lib/state/instance/store.svelte.ts
@@ -3,7 +3,6 @@
  * Created and managed by the InstanceRegistry — do not instantiate directly.
  */
 
-import type { Client } from '@urql/svelte';
 import { CurrentUserState } from '$lib/auth/currentUser.svelte';
 import { InstanceState } from './state.svelte';
 import type { InstancePermissions, ViewerData } from './permissions.svelte';
@@ -13,6 +12,8 @@ import { NotificationLevelStore } from './notificationLevel.svelte';
 import { VoiceCallState } from './voiceCall.svelte';
 import { CallParticipantsState } from './callParticipants.svelte';
 import { ActiveCallRoomsState } from './activeCallRooms.svelte';
+import type { GraphQLClient } from './graphqlClient.svelte';
+import type { RegisteredInstance } from './registry.svelte';
 
 const EMPTY_PERMISSIONS: InstancePermissions = {
 	loaded: false,
@@ -44,10 +45,21 @@ export class InstanceStateStore {
 	/** Per-instance viewer permissions (loaded by InstanceSpaceSection). */
 	permissions = $state<InstancePermissions>(EMPTY_PERMISSIONS);
 
-	constructor(instanceId: string, client: Client, isOrigin: boolean) {
-		this.instanceId = instanceId;
+	/**
+	 * Live reference to the registered instance. Reads pick up `updateInstance`
+	 * mutations (e.g. token refresh, name change) because the registry stores
+	 * instances in $state.
+	 */
+	readonly #registered: RegisteredInstance;
+	readonly #cookieAuth: boolean;
 
-		this.currentUser = new CurrentUserState(client, isOrigin);
+	constructor(registered: RegisteredInstance, gqlClient: GraphQLClient) {
+		this.instanceId = registered.id;
+		this.#registered = registered;
+		this.#cookieAuth = registered.token === null;
+
+		const client = gqlClient.client;
+		this.currentUser = new CurrentUserState(client, this.#cookieAuth);
 		this.instance = new InstanceState(client);
 		this.notifications = new NotificationStore(client);
 		this.roomUnread = new RoomUnreadStore();
@@ -55,6 +67,23 @@ export class InstanceStateStore {
 		this.voiceCall = new VoiceCallState(client);
 		this.callParticipants = new CallParticipantsState(client);
 		this.activeCallRooms = new ActiveCallRoomsState(client, this.voiceCall);
+
+		gqlClient.setAuthHandlers({
+			onAuthFailure: () => this.currentUser.handleAuthFailure(),
+			onSessionValidation: () => this.currentUser.validateSession()
+		});
+	}
+
+	/**
+	 * Whether this instance currently has an authenticated user.
+	 * - Cookie auth (origin): true when `currentUser.user` is set.
+	 * - Bearer auth (remote): true when an access token is registered.
+	 */
+	get isAuthenticated(): boolean {
+		if (this.#cookieAuth) {
+			return this.currentUser.user != null;
+		}
+		return this.#registered.token != null;
 	}
 
 	/** Update permissions from viewer query data. */

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -48,11 +48,12 @@
   const profileCache = createUserProfileCache();
   const presenceCache = createPresenceCache();
 
-  // Start event buses for token-authenticated (remote) instances.
+  // Start event buses for every authenticated instance (origin or remote).
   // startBus is idempotent; cleanup is handled by removeInstance.
   $effect(() => {
     for (const instance of instanceRegistry.instances) {
-      if (instance.token) {
+      const store = instanceRegistry.tryGetStore(instance.id);
+      if (store?.isAuthenticated) {
         instanceEventBusManager.startBus(
           instance.id,
           graphqlClientManager.getClient(instance.id).client

--- a/frontend/src/routes/chat/AuthenticatedChatProvider.svelte
+++ b/frontend/src/routes/chat/AuthenticatedChatProvider.svelte
@@ -5,11 +5,7 @@
   import type { PresenceCache } from '$lib/state/presenceCache.svelte';
   import type { UserSettingsState } from '$lib/state/userSettings.svelte';
   import { instanceRegistry } from '$lib/state/instance/registry.svelte';
-  import {
-    graphqlClientManager,
-    setAuthFailureHandler,
-    setSessionValidationHandler
-  } from '$lib/state/instance/graphqlClient.svelte';
+  import { graphqlClientManager } from '$lib/state/instance/graphqlClient.svelte';
   import { initInstanceEventBus } from '$lib/instanceEventBus.svelte';
   import {
     useInstanceEvent,
@@ -39,15 +35,14 @@
     children: Snippet;
   } = $props();
 
-  // Populate the current user state from the load function data
+  // Populate the current user state from the load function data.
+  // The store's GraphQLClient already has its auth handlers wired (in
+  // InstanceStateStore's constructor) so a stale-cookie 'not authenticated'
+  // response will trigger the redirect/clear flow without further setup here.
   // svelte-ignore state_referenced_locally
   currentUserState.user = user;
   // svelte-ignore state_referenced_locally
   currentUserState.loading = false;
-
-  // Register auth event handlers from GraphQL client
-  setAuthFailureHandler(() => currentUserState.handleAuthFailure());
-  setSessionValidationHandler(() => currentUserState.validateSession());
 
   // Initialize user settings from the user's settings data
   // svelte-ignore state_referenced_locally

--- a/frontend/src/routes/chat/notifications/+page.svelte
+++ b/frontend/src/routes/chat/notifications/+page.svelte
@@ -25,9 +25,7 @@
 
     for (const instance of instanceRegistry.instances) {
       const stores = instanceRegistry.getStore(instance.id);
-      const isOrigin = instanceRegistry.isOriginInstance(instance.id);
-      if (isOrigin && !stores.currentUser.user) continue;
-      if (!isOrigin && !instance.token) continue;
+      if (!stores.isAuthenticated) continue;
 
       let hostname: string;
       try {
@@ -68,9 +66,7 @@
 
     for (const instance of instanceRegistry.instances) {
       const stores = instanceRegistry.getStore(instance.id);
-      const isOrigin = instanceRegistry.isOriginInstance(instance.id);
-      if (isOrigin && !stores.currentUser.user) continue;
-      if (!isOrigin && !instance.token) continue;
+      if (!stores.isAuthenticated) continue;
       fetches.push(stores.notifications.fetch());
     }
 
@@ -112,9 +108,7 @@
     const clears: Promise<number>[] = [];
     for (const instance of instanceRegistry.instances) {
       const stores = instanceRegistry.getStore(instance.id);
-      const isOrigin = instanceRegistry.isOriginInstance(instance.id);
-      if (isOrigin && !stores.currentUser.user) continue;
-      if (!isOrigin && !instance.token) continue;
+      if (!stores.isAuthenticated) continue;
       clears.push(stores.notifications.dismissAll());
     }
     await Promise.allSettled(clears);

--- a/frontend/src/routes/instances/+page.svelte
+++ b/frontend/src/routes/instances/+page.svelte
@@ -9,12 +9,7 @@
 
   // Redirect to login if origin exists but user isn't authenticated
   const origin = $derived(instanceRegistry.originInstance);
-  const originStore = $derived(origin ? instanceRegistry.tryGetStore(origin.id) : undefined);
-  const originAuthenticated = $derived(
-    origin ? (instanceRegistry.isOriginInstance(origin.id)
-      ? !!originStore?.currentUser.user
-      : !!origin.token) : false
-  );
+  const originAuthenticated = $derived(origin ? instanceRegistry.isAuthenticated(origin.id) : false);
   $effect(() => {
     if (origin && !originAuthenticated) {
       goto(resolve('/login'), { replaceState: true });
@@ -69,7 +64,7 @@
         {@const hostname = getHostname(instance.url)}
         {@const isOrigin = instanceRegistry.isOriginInstance(instance.id)}
         {@const store = instanceRegistry.getStore(instance.id)}
-        {@const authenticated = isOrigin ? !!store.currentUser.user : !!instance.token}
+        {@const authenticated = store.isAuthenticated}
 
         <div class="flex items-center gap-4 px-6 py-4" data-testid="instance-row">
           <!-- Instance icon -->

--- a/frontend/src/routes/instances/add/+page.svelte
+++ b/frontend/src/routes/instances/add/+page.svelte
@@ -8,12 +8,7 @@
 
   // Redirect to login if origin exists but user isn't authenticated
   const origin = $derived(instanceRegistry.originInstance);
-  const originStore = $derived(origin ? instanceRegistry.tryGetStore(origin.id) : undefined);
-  const originAuthenticated = $derived(
-    origin ? (instanceRegistry.isOriginInstance(origin.id)
-      ? !!originStore?.currentUser.user
-      : !!origin.token) : false
-  );
+  const originAuthenticated = $derived(origin ? instanceRegistry.isAuthenticated(origin.id) : false);
   $effect(() => {
     if (origin && !originAuthenticated) {
       goto(resolve('/login'), { replaceState: true });


### PR DESCRIPTION
## Summary

Collapses the `isOriginInstance(id) ? !!user : !!token` branch duplicated across ~8 components into a single `store.isAuthenticated` getter on `InstanceStateStore`. Per-instance auth handlers replace the module-level `setAuthFailureHandler` / `setSessionValidationHandler` globals — each `GraphQLClient` now wires its own handlers via the store constructor, dropping `isOrigin` from `GraphQLClientConfig` and renaming `CurrentUserState`'s `isOrigin` to `cookieAuth` for clarity. As a bonus, remote instances now get session revalidation on reconnect/visibility and detect `not authenticated` GraphQL errors (previously origin-only). 14 files, net –44 lines.

## Test plan

- [x] `mise x -- pnpm test:unit --run` — 634 passed
- [x] `mise x -- pnpm check` — 0 errors, 0 warnings
- [x] `mise x -- pnpm lint` — clean
- [x] `mise x -- pnpm build` — succeeds
- [ ] Manual: log in to origin, add a remote instance, verify both sidebars render and notifications aggregate
- [ ] Manual: trigger origin logout from another tab, confirm redirect still fires