### PR TITLE
fix(dev): poll for file changes in dev containers

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile.dev
     working_dir: /app/cli
-    command: ["watchexec", "-r", "-e", "go", "--", "go", "run", "-tags", "dev", ".", "start"]
+    command: ["watchexec", "-r", "--poll", "500ms", "-e", "go", "--", "go", "run", "-tags", "dev", ".", "start"]
     environment:
       CHATTO_WEBSERVER_URL: https://${COMPOSE_PROJECT_NAME}.orb.local
       CHATTO_SMTP_HOST: mailpit.chatto-tools.orb.local

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -36,6 +36,13 @@ export default defineConfig({
     port: process.env.VITE_PORT ? parseInt(process.env.VITE_PORT) : undefined,
     host: true,
     allowedHosts: ['fatso.fritz.box', '.orb.local'],
+    // Bind-mount inotify on macOS (Docker Desktop / OrbStack) drops events
+    // during bursty changes. Polling is reliable; cost is negligible at this
+    // tree size.
+    watch: {
+      usePolling: true,
+      interval: 300
+    },
     proxy: {
       '/playground': {
         target: backendTarget,


### PR DESCRIPTION
## Summary
- Bind-mount inotify on macOS (OrbStack / Docker Desktop) drops events during bursty changes (codegen, branch switches), so watchexec and Vite HMR silently miss updates until the stack is restarted.
- `compose.yml`: add `--poll 500ms` to watchexec.
- `frontend/vite.config.ts`: enable `server.watch.usePolling` at 300ms.

CPU cost is negligible at this tree size (~600 files combined, ~1-3% of one core idle).

## Test plan
- [ ] Recreate dev stack (`docker compose -p <project> up -d --force-recreate app frontend`)
- [ ] Edit a `.go` file → backend reloads without manual restart
- [ ] Edit a frontend source file → Vite HMR fires
- [ ] Switch git branches → both watchers pick up the new state