### PR TITLE
fix(frontend): scroll thread to new reply on notification click

### DIFF
--- a/frontend/e2e/notifications.test.ts
+++ b/frontend/e2e/notifications.test.ts
@@ -819,11 +819,12 @@ test.describe('Navigation from Notifications', () => {
       await expect(notification).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
       await notificationsPage.clickNotification(notification);
 
-      // Verify navigated to thread (URL should have thread ID)
-      await page.waitForURL(routes.patterns.anyThread);
-      // Thread pane should be visible with the reply
+      // Verify navigated to thread with the new reply highlighted in the URL
+      await page.waitForURL(/\/chat\/-\/[a-zA-Z0-9]+\/[a-zA-Z0-9]+\/[a-zA-Z0-9]+\?highlight=/);
+      // Thread pane should be visible and scrolled to the new reply
       await roomPage.expectThreadPaneVisible();
       await roomPage.expectTextInThreadPane(replyText);
+      await expect(roomPage.threadPane.getByText(replyText)).toBeInViewport();
     } finally {
       await context2.close();
     }

--- a/frontend/src/lib/state/instance/notifications.svelte.ts
+++ b/frontend/src/lib/state/instance/notifications.svelte.ts
@@ -499,11 +499,10 @@ export class NotificationStore {
         // Using aliased fields from query
         const spaceId = notification.replySpace?.id;
         const roomId = notification.replyRoom?.id;
-        const inReplyToId = notification.inReplyToId;
         const eventId = notification.replyEventId;
         const threadRootId = notification.replyInThread;
-        if (threadRootId && spaceId && roomId) {
-          // Thread reply: navigate to the thread (using thread root) and highlight the replied-to message
+        if (threadRootId && spaceId && roomId && eventId) {
+          // Thread reply: navigate to the thread (using thread root) and highlight the new reply
           return (
             resolve('/chat/[instanceId]/[spaceId]/[roomId]/[threadId]', {
               instanceId: seg,
@@ -512,7 +511,7 @@ export class NotificationStore {
               threadId: threadRootId
             }) +
             '?highlight=' +
-            inReplyToId
+            eventId
           );
         }
         // Room-level reply: navigate to room and highlight the reply message


### PR DESCRIPTION
## Summary

- Thread reply notifications were highlighting `inReplyToId` (the replied-to message) instead of the new reply, so when the replied-to message was the thread root the thread pane opened scrolled to the top and the new reply stayed off-screen.
- Switched the thread-reply branch of `NotificationStore.getNavigationPath()` to highlight `replyEventId`, matching mention and room-reply notifications.
- Tightened the existing "clicking reply notification navigates to the thread" e2e to assert the URL contains `?highlight=` and that the new reply is in the viewport.

## Test plan

- [x] `mise run lint-frontend` clean
- [x] `mise run test-frontend` (672/672)
- [ ] Manual smoke: two browsers, post root → reply in thread → click notification → thread opens scrolled to the new reply with highlight flash