### PR TITLE
fix(frontend): deleted messages stay on screen for other users until refresh

### DIFF
--- a/cli/internal/core/event_publishing_test.go
+++ b/cli/internal/core/event_publishing_test.go
@@ -1,10 +1,15 @@
 package core
 
 import (
+	"context"
 	"errors"
 	"testing"
+	"time"
 
+	"github.com/nats-io/nats.go"
+	"google.golang.org/protobuf/proto"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+	"hmans.de/chatto/internal/core/subjects"
 )
 
 func TestEventPublishingHelpers_RejectInvalidEvents(t *testing.T) {
@@ -58,4 +63,235 @@ func TestEventPublishingHelpers_RejectInvalidEvents(t *testing.T) {
 			t.Fatalf("expected ErrInvalidEvent, got: %v", err)
 		}
 	})
+}
+
+// setupRoomWithMessage creates a space, a user, a room, joins the user, and
+// posts one message. Returns the resulting MessagePostedEvent so the test can
+// pull MessageBodyId / event id off it.
+func setupRoomWithMessage(t *testing.T, core *ChattoCore, ctx context.Context, body string) (space, room, user struct{ Id string }, event *corev1.SpaceEvent) {
+	t.Helper()
+
+	createdSpace, err := core.CreateSpace(ctx, "system", "Test Space", "")
+	if err != nil {
+		t.Fatalf("CreateSpace: %v", err)
+	}
+	createdUser, err := core.CreateUser(ctx, "system", "msguser", "msguser", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if _, err := core.JoinSpace(ctx, createdUser.Id, createdSpace.Id); err != nil {
+		t.Fatalf("JoinSpace: %v", err)
+	}
+	createdRoom, err := core.CreateRoom(ctx, createdUser.Id, createdSpace.Id, "general", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, createdUser.Id, createdSpace.Id, createdUser.Id, createdRoom.Id); err != nil {
+		t.Fatalf("JoinRoom: %v", err)
+	}
+
+	posted, err := core.PostMessage(ctx, createdSpace.Id, createdRoom.Id, createdUser.Id, body, nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage: %v", err)
+	}
+
+	space.Id = createdSpace.Id
+	room.Id = createdRoom.Id
+	user.Id = createdUser.Id
+	event = posted
+	return
+}
+
+// TestDeleteMessage_PublishesLiveEvent verifies that calling DeleteMessage on
+// the core publishes a MessageDeletedEvent on the live room subject. This is
+// the publish side of the chain — without it, no client receives the
+// deletion. A future refactor that drops the publish would silently break the
+// frontend's ability to update.
+func TestDeleteMessage_PublishesLiveEvent(t *testing.T) {
+	core, nc := setupTestCore(t)
+	ctx := testContext(t)
+
+	space, room, user, event := setupRoomWithMessage(t, core, ctx, "delete me")
+	posted := event.GetMessagePosted()
+	if posted == nil {
+		t.Fatal("expected MessagePostedEvent")
+	}
+
+	subject := subjects.LiveSpaceRoomEvent(space.Id, room.Id, "message_deleted")
+	received := make(chan *nats.Msg, 1)
+	sub, err := nc.Subscribe(subject, func(msg *nats.Msg) {
+		select {
+		case received <- msg:
+		default:
+		}
+	})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer sub.Unsubscribe()
+
+	if err := core.DeleteMessage(ctx, user.Id, space.Id, room.Id, posted.MessageBodyId); err != nil {
+		t.Fatalf("DeleteMessage: %v", err)
+	}
+	_ = nc.Flush()
+
+	select {
+	case msg := <-received:
+		var got corev1.SpaceEvent
+		if err := proto.Unmarshal(msg.Data, &got); err != nil {
+			t.Fatalf("unmarshal published event: %v", err)
+		}
+		deleted := got.GetMessageDeleted()
+		if deleted == nil {
+			t.Fatalf("expected MessageDeletedEvent, got %T", got.Event)
+		}
+		if deleted.RoomId != room.Id {
+			t.Errorf("RoomId = %q, want %q", deleted.RoomId, room.Id)
+		}
+		if deleted.SpaceId != space.Id {
+			t.Errorf("SpaceId = %q, want %q", deleted.SpaceId, space.Id)
+		}
+		if deleted.MessageEventId != event.Id {
+			t.Errorf("MessageEventId = %q, want %q", deleted.MessageEventId, event.Id)
+		}
+		if got.ActorId != user.Id {
+			t.Errorf("ActorId = %q, want %q", got.ActorId, user.Id)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for MessageDeletedEvent on live subject")
+	}
+}
+
+// TestEditMessage_PublishesLiveEvent verifies that calling EditMessage
+// publishes a MessageUpdatedEvent on the live room subject — same contract as
+// the deletion path.
+func TestEditMessage_PublishesLiveEvent(t *testing.T) {
+	core, nc := setupTestCore(t)
+	ctx := testContext(t)
+
+	space, room, user, event := setupRoomWithMessage(t, core, ctx, "original")
+	posted := event.GetMessagePosted()
+	if posted == nil {
+		t.Fatal("expected MessagePostedEvent")
+	}
+
+	subject := subjects.LiveSpaceRoomEvent(space.Id, room.Id, "message_updated")
+	received := make(chan *nats.Msg, 1)
+	sub, err := nc.Subscribe(subject, func(msg *nats.Msg) {
+		select {
+		case received <- msg:
+		default:
+		}
+	})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer sub.Unsubscribe()
+
+	if err := core.EditMessage(ctx, user.Id, space.Id, room.Id, posted.MessageBodyId, "edited"); err != nil {
+		t.Fatalf("EditMessage: %v", err)
+	}
+	_ = nc.Flush()
+
+	select {
+	case msg := <-received:
+		var got corev1.SpaceEvent
+		if err := proto.Unmarshal(msg.Data, &got); err != nil {
+			t.Fatalf("unmarshal published event: %v", err)
+		}
+		updated := got.GetMessageUpdated()
+		if updated == nil {
+			t.Fatalf("expected MessageUpdatedEvent, got %T", got.Event)
+		}
+		if updated.RoomId != room.Id {
+			t.Errorf("RoomId = %q, want %q", updated.RoomId, room.Id)
+		}
+		if updated.MessageEventId != event.Id {
+			t.Errorf("MessageEventId = %q, want %q", updated.MessageEventId, event.Id)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for MessageUpdatedEvent on live subject")
+	}
+}
+
+// TestStreamMySpaceEvents_DeliversMessageDeleted is the integration test for
+// the room-id-extraction switch in StreamMySpaceEvents (cli/internal/core/core.go).
+// If a future refactor drops the MessageDeleted case from that switch, the
+// event would be silently dropped (the rule doc explicitly warns about this).
+// This test catches that regression by subscribing as a real space member and
+// asserting the event flows through end-to-end.
+func TestStreamMySpaceEvents_DeliversMessageDeleted(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	author, err := core.CreateUser(ctx, "system", "author", "Author", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser author: %v", err)
+	}
+	viewer, err := core.CreateUser(ctx, "system", "viewer", "Viewer", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser viewer: %v", err)
+	}
+
+	space, err := core.CreateSpace(ctx, author.Id, "Test Space", "")
+	if err != nil {
+		t.Fatalf("CreateSpace: %v", err)
+	}
+	if _, err := core.JoinSpace(ctx, viewer.Id, space.Id); err != nil {
+		t.Fatalf("JoinSpace viewer: %v", err)
+	}
+	room, err := core.CreateRoom(ctx, author.Id, space.Id, "general", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, author.Id, space.Id, author.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom author: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, viewer.Id, space.Id, viewer.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom viewer: %v", err)
+	}
+
+	posted, err := core.PostMessage(ctx, space.Id, room.Id, author.Id, "hello", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage: %v", err)
+	}
+	postedMsg := posted.GetMessagePosted()
+	if postedMsg == nil {
+		t.Fatal("expected MessagePostedEvent")
+	}
+
+	// Subscribe as viewer — they should receive the deletion event.
+	subCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	eventChan, err := core.StreamMySpaceEvents(subCtx, space.Id, viewer.Id)
+	if err != nil {
+		t.Fatalf("StreamMySpaceEvents: %v", err)
+	}
+
+	// Let subscription establish before publishing.
+	time.Sleep(100 * time.Millisecond)
+
+	if err := core.DeleteMessage(ctx, author.Id, space.Id, room.Id, postedMsg.MessageBodyId); err != nil {
+		t.Fatalf("DeleteMessage: %v", err)
+	}
+
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case ev := <-eventChan:
+			deleted := ev.GetMessageDeleted()
+			if deleted == nil {
+				continue
+			}
+			if deleted.RoomId != room.Id {
+				t.Errorf("RoomId = %q, want %q", deleted.RoomId, room.Id)
+			}
+			if deleted.MessageEventId != posted.Id {
+				t.Errorf("MessageEventId = %q, want %q", deleted.MessageEventId, posted.Id)
+			}
+			return
+		case <-timeout:
+			t.Fatal("viewer never received MessageDeletedEvent — room-id extraction switch likely dropped it")
+		}
+	}
 }

--- a/frontend/e2e/messages.test.ts
+++ b/frontend/e2e/messages.test.ts
@@ -2,6 +2,7 @@ import { expect } from '@playwright/test';
 import { TIMEOUTS } from './constants';
 import { test } from './setup';
 import { createAndLoginTestUser } from './fixtures/testUser';
+import { ChatPage, RoomPage, ExplorePage } from './pages';
 import * as routes from './routes';
 
 test('consecutive messages from same user are grouped', async ({ page, chatPage, roomPage }) => {
@@ -474,6 +475,66 @@ test('deleted message with reactions remains visible', async ({ page, chatPage, 
     const deletedMessage = roomPage.getMessageByEventId(eventId);
     await deletedMessage.expectDeleted();
     await deletedMessage.expectReaction('👍', 1);
+  }
+});
+
+test('deletion of a reacted message shows placeholder for other connected clients in real-time', async ({
+  page,
+  chatPage,
+  roomPage,
+  browser,
+  serverURL
+}) => {
+  // User 1 posts a message; User 2 reacts to it; User 1 deletes it.
+  // User 2 (already viewing the room) should see the original body replaced
+  // by the [Message deleted] placeholder while the reaction stays visible —
+  // this is the propagation case the single-user delete-with-reaction test
+  // doesn't cover and that the previous refetch-only path failed silently on.
+  await createAndLoginTestUser(page);
+  await chatPage.goto();
+  const spaceName = await chatPage.createSpace();
+  await chatPage.enterRoom('general');
+
+  const testMessage = `Real-time delete with reaction ${Date.now()}`;
+  const message1 = await roomPage.sendMessage(testMessage);
+  const eventId = await message1.getEventId();
+  if (!eventId) throw new Error('expected eventId from sent message');
+
+  const context2 = await browser!.newContext({
+    baseURL: serverURL,
+    viewport: { width: 1280, height: 720 }
+  });
+  const page2 = await context2.newPage();
+
+  try {
+    await createAndLoginTestUser(page2);
+
+    const chatPage2 = new ChatPage(page2);
+    const roomPage2 = new RoomPage(page2);
+    const explorePage2 = new ExplorePage(page2);
+
+    await chatPage2.goto();
+    await chatPage2.goToExploreSpaces();
+    await explorePage2.joinSpace(spaceName);
+    await chatPage2.enterRoom('general');
+    await roomPage2.expectMessageVisible(testMessage);
+
+    // User 2 reacts so the deletion can't take the "fully hidden" path.
+    const message2 = roomPage2.getMessageByEventId(eventId);
+    await message2.react('👍');
+    await message2.expectReaction('👍', 1);
+
+    // User 1 deletes their own message.
+    await message1.delete();
+
+    // User 2 must see the placeholder + reaction without a refresh.
+    await message2.expectDeleted();
+    await message2.expectReaction('👍', 1);
+    await expect(message2.locator.getByText(testMessage)).not.toBeVisible({
+      timeout: TIMEOUTS.UI_STANDARD
+    });
+  } finally {
+    await context2.close();
   }
 });
 

--- a/frontend/e2e/threading.test.ts
+++ b/frontend/e2e/threading.test.ts
@@ -144,6 +144,132 @@ test.describe('Message Threading', () => {
     }
   });
 
+  test('thread reply deletion propagates to other connected clients in real-time', async ({
+    page,
+    chatPage,
+    roomPage,
+    browser,
+    serverURL
+  }) => {
+    // Reproduces Felix's bug in the thread case: with the thread pane open on
+    // user B, user A deletes their own thread reply and B should see it
+    // disappear without a refresh. The store-level fix applies to threads
+    // because ThreadMessagesStore inherits ingestSpaceEvent from MessageListStore.
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.createSpace();
+    await chatPage.enterRoom('general');
+    const spaceId = chatPage.getSpaceId();
+
+    const rootMessage = `Thread root ${Date.now()}`;
+    const message1 = await roomPage.sendMessage(rootMessage);
+
+    await message1.openThread();
+    await roomPage.expectThreadPaneVisible();
+
+    const replyText = `Reply to delete ${Date.now()}`;
+    await roomPage.postThreadReply(replyText);
+
+    const context2 = await browser!.newContext({ baseURL: serverURL });
+    const page2 = await context2.newPage();
+
+    try {
+      await createAndLoginTestUser(page2);
+      await page2.goto(routes.joinSpace(spaceId));
+      await page2.getByRole('button', { name: 'Join Space' }).click();
+      await page2.waitForURL(routes.patterns.spaceOrRoomWithQuery);
+
+      const chatPage2 = new ChatPage(page2);
+      const roomPage2 = new RoomPage(page2);
+      await chatPage2.enterRoom('general');
+      await waitForRoomReady(page2, 'general');
+
+      const rootForB = roomPage2.getMessage(rootMessage);
+      await rootForB.openThread();
+      await roomPage2.expectThreadPaneVisible();
+
+      // User B sees the reply that user A posted.
+      await roomPage2.expectTextInThreadPane(replyText);
+      const replyForB = roomPage2.getThreadMessage(replyText);
+
+      // User A deletes the reply.
+      const replyForA = roomPage.getThreadMessage(replyText);
+      await replyForA.delete();
+
+      // User B should see the reply vanish — without refresh.
+      await replyForB.expectHidden();
+      await expect(roomPage2.threadPane.getByText(replyText)).not.toBeVisible({
+        timeout: TIMEOUTS.REALTIME_EVENT
+      });
+    } finally {
+      await context2.close();
+    }
+  });
+
+  test('thread reply edit propagates to other connected clients in real-time', async ({
+    page,
+    chatPage,
+    roomPage,
+    browser,
+    serverURL
+  }) => {
+    // Edits use the refetch path, which is the same chain as deletion before
+    // the fix. Locking it in for threads so a future regression in the
+    // refetchByMessageEventId branch surfaces here.
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.createSpace();
+    await chatPage.enterRoom('general');
+    const spaceId = chatPage.getSpaceId();
+
+    const rootMessage = `Thread root for edit ${Date.now()}`;
+    const message1 = await roomPage.sendMessage(rootMessage);
+
+    await message1.openThread();
+    await roomPage.expectThreadPaneVisible();
+
+    const originalReply = `Original reply ${Date.now()}`;
+    await roomPage.postThreadReply(originalReply);
+
+    const context2 = await browser!.newContext({ baseURL: serverURL });
+    const page2 = await context2.newPage();
+
+    try {
+      await createAndLoginTestUser(page2);
+      await page2.goto(routes.joinSpace(spaceId));
+      await page2.getByRole('button', { name: 'Join Space' }).click();
+      await page2.waitForURL(routes.patterns.spaceOrRoomWithQuery);
+
+      const chatPage2 = new ChatPage(page2);
+      const roomPage2 = new RoomPage(page2);
+      await chatPage2.enterRoom('general');
+      await waitForRoomReady(page2, 'general');
+
+      const rootForB = roomPage2.getMessage(rootMessage);
+      await rootForB.openThread();
+      await roomPage2.expectThreadPaneVisible();
+      await roomPage2.expectTextInThreadPane(originalReply);
+
+      // User A edits the reply.
+      const replyForA = roomPage.getThreadMessage(originalReply);
+      await replyForA.startEdit();
+      await roomPage.expectThreadEditModeActive();
+      const editedReply = `Edited reply ${Date.now()}`;
+      await roomPage.threadReplyInput.fill(editedReply);
+      await roomPage.threadReplyInput.press('Enter');
+
+      // User B should see the new content and the (edited) marker.
+      await expect(roomPage2.threadPane.getByText(editedReply)).toBeVisible({
+        timeout: TIMEOUTS.REALTIME_EVENT
+      });
+      await expect(roomPage2.threadPane.getByText(originalReply)).not.toBeVisible();
+      const editedForB = roomPage2.getThreadMessage(editedReply);
+      await editedForB.expectEdited();
+    } finally {
+      await context2.close();
+    }
+  });
+
   test('thread indicator shows reply count and participant avatars', async ({
     page,
     chatPage,

--- a/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -272,6 +272,84 @@ describe('RoomMessagesStore.ingestSpaceEvent', () => {
     expect(queryMock.mock.calls[0][1]).toMatchObject({ eventId: 'echo1' });
   });
 
+  it('clears body and attachments locally on MessageDeletedEvent (no refetch)', () => {
+    store.ingestSpaceEvent(rootMessage('m1'));
+    flushSync();
+    queryMock.mockClear();
+
+    store.ingestSpaceEvent(
+      simpleEvent('MessageDeletedEvent', { roomId: ROOM_ID, messageEventId: 'm1' })
+    );
+    flushSync();
+
+    // No round-trip — applied synchronously.
+    expect(queryMock).not.toHaveBeenCalled();
+    const m1 = store.events.find((e) => e.id === 'm1');
+    if (m1?.event?.__typename !== 'MessagePostedEvent') throw new Error('expected MessagePostedEvent');
+    expect(m1.event.body).toBeNull();
+    expect(m1.event.attachments).toEqual([]);
+  });
+
+  it('preserves reactions and reply metadata on MessageDeletedEvent (placeholder case)', () => {
+    const withEngagement = rootMessage('m1', { replyCount: 2, lastReplyAt: '2024-06-01T12:00:00Z' });
+    // Inject a reaction directly — the rootMessage helper defaults to none.
+    if (withEngagement.event?.__typename === 'MessagePostedEvent') {
+      (withEngagement.event as { reactions: unknown[] }).reactions = [
+        { emoji: 'thumbsup', count: 1, hasReacted: false, users: [] }
+      ];
+    }
+    store.ingestSpaceEvent(withEngagement);
+    flushSync();
+    queryMock.mockClear();
+
+    store.ingestSpaceEvent(
+      simpleEvent('MessageDeletedEvent', { roomId: ROOM_ID, messageEventId: 'm1' })
+    );
+    flushSync();
+
+    const m1 = store.events.find((e) => e.id === 'm1');
+    if (m1?.event?.__typename !== 'MessagePostedEvent') throw new Error('expected MessagePostedEvent');
+    expect(m1.event.body).toBeNull();
+    expect(m1.event.attachments).toEqual([]);
+    // Engagement preserved so MessageEvent.svelte renders the [Message deleted] stub.
+    expect(m1.event.reactions).toHaveLength(1);
+    expect(m1.event.replyCount).toBe(2);
+    expect(m1.event.lastReplyAt).toBe('2024-06-01T12:00:00Z');
+  });
+
+  it('clears body on a matching echo when its original is deleted', () => {
+    // Echo at the room level pointing at thread reply 't1'.
+    store.ingestSpaceEvent(rootMessage('echo1', { echoOfEventId: 't1' }));
+    flushSync();
+    queryMock.mockClear();
+
+    store.ingestSpaceEvent(
+      simpleEvent('MessageDeletedEvent', { roomId: ROOM_ID, messageEventId: 't1' })
+    );
+    flushSync();
+
+    expect(queryMock).not.toHaveBeenCalled();
+    const echo = store.events.find((e) => e.id === 'echo1');
+    if (echo?.event?.__typename !== 'MessagePostedEvent') throw new Error('expected MessagePostedEvent');
+    expect(echo.event.body).toBeNull();
+  });
+
+  it('leaves unrelated messages alone on MessageDeletedEvent', () => {
+    store.ingestSpaceEvent(rootMessage('m1'));
+    store.ingestSpaceEvent(rootMessage('m2'));
+    flushSync();
+    queryMock.mockClear();
+
+    store.ingestSpaceEvent(
+      simpleEvent('MessageDeletedEvent', { roomId: ROOM_ID, messageEventId: 'm1' })
+    );
+    flushSync();
+
+    const m2 = store.events.find((e) => e.id === 'm2');
+    if (m2?.event?.__typename !== 'MessagePostedEvent') throw new Error('expected MessagePostedEvent');
+    expect(m2.event.body).toBe('hello');
+  });
+
   it('triggers refetch on ReactionAddedEvent and ReactionRemovedEvent', () => {
     store.ingestSpaceEvent(rootMessage('m1'));
     flushSync();

--- a/frontend/src/lib/state/room/messages.svelte.ts
+++ b/frontend/src/lib/state/room/messages.svelte.ts
@@ -151,9 +151,17 @@ export abstract class MessageListStore {
     // From here on, only events scoped to this room are interesting.
     if ('roomId' in eventData && eventData.roomId !== this.roomId) return;
 
+    // Apply deletions locally — the post-deletion state is deterministic
+    // (body=null, attachments=[]) and we already know the affected event id,
+    // so a server round-trip is wasteful and a refetch failure would leave
+    // the original message visible on screen.
+    if (eventData.__typename === 'MessageDeletedEvent') {
+      this.applyDeletion(eventData.messageEventId);
+      return;
+    }
+
     if (
       eventData.__typename === 'MessageUpdatedEvent' ||
-      eventData.__typename === 'MessageDeletedEvent' ||
       eventData.__typename === 'ReactionAddedEvent' ||
       eventData.__typename === 'ReactionRemovedEvent' ||
       eventData.__typename === 'VideoProcessingCompletedEvent'
@@ -225,6 +233,28 @@ export abstract class MessageListStore {
       ) {
         await this.refetchOne(e.id);
       }
+    }
+  }
+
+  /**
+   * Apply a deletion locally to any matching MessagePostedEvent in the buffer
+   * (the original by id, plus any echo whose echoOfEventId points at it).
+   * Mirrors the server's post-deletion state: body=null, attachments=[].
+   * Reactions and reply metadata are left intact — the [Message deleted]
+   * placeholder relies on them to decide between hiding the row entirely
+   * and showing a stub for messages that already have engagement.
+   */
+  protected applyDeletion(messageEventId: string): void {
+    for (let i = 0; i < this.events.length; i++) {
+      const e = this.events[i];
+      const evt = e.event;
+      if (evt?.__typename !== 'MessagePostedEvent') continue;
+      if (e.id !== messageEventId && evt.echoOfEventId !== messageEventId) continue;
+
+      this.events[i] = {
+        ...e,
+        event: { ...evt, body: null, attachments: [] }
+      };
     }
   }
 


### PR DESCRIPTION
## Summary

- Live `MessageDeletedEvent` is now applied locally in `MessageListStore.ingestSpaceEvent` instead of triggering a refetch. The previous path silently failed (leaving the deleted message visible to other users) whenever `roomEventByEventId` returned null/error or the response was slow. The post-deletion state is deterministic (`body=null`, `attachments=[]`) and we already know the event id from the live event — no round-trip needed. Reactions and reply metadata are preserved so the `[Message deleted]` placeholder still renders for engaged messages. Both rooms and threads inherit the fix via `MessageListStore`.
- Adds component tests for the new path (no refetch, echo handling, placeholder preservation, no-op for unrelated messages), plus multi-user e2e tests for thread reply delete/edit propagation and room delete-with-reaction propagation.
- Adds Go tests that lock in `DeleteMessage`/`EditMessage` live-event publishing and the room-id extraction switch in `StreamMySpaceEvents` — that switch is silent-failure-prone (per `.claude/rules/live-events.md`) and previously had no test guarding it.

## Test plan

- [x] `mise test-frontend` (676/676)
- [x] `go test ./internal/core/ -count=1` (full package green)
- [x] `pnpm lint` and `pnpm check` clean
- [x] `playwright test --list` discovers the three new e2e tests
- [ ] Run the new e2e tests in CI
- [ ] Manual two-browser smoke: user A deletes a message, user B sees it disappear (no reactions case + with-reaction placeholder case + thread case)