### PR TITLE
fix(frontend): orange-dot click no longer scrolls to bottom of wrong room

### DIFF
--- a/frontend/src/lib/InstanceSpaceSection.svelte
+++ b/frontend/src/lib/InstanceSpaceSection.svelte
@@ -278,7 +278,10 @@
     const notification = notificationStore.getSpaceNotification(spaceId);
     if (notification) {
       const path = notificationStore.getNavigationPath(instanceId, notification);
-      await notificationStore.dismiss(notification.id);
+      // Fire dismiss in parallel — awaiting the server roundtrip before goto
+      // delays the highlight effect and risks the URL updating after Room.svelte
+      // has already settled on a scroll position.
+      void notificationStore.dismiss(notification.id);
 
       // eslint-disable-next-line svelte/no-navigation-without-resolve -- path from getNavigationPath() is already resolved
       await goto(path);

--- a/frontend/src/routes/chat/[instanceId]/[spaceId]/[roomId]/Room.svelte
+++ b/frontend/src/routes/chat/[instanceId]/[spaceId]/[roomId]/Room.svelte
@@ -157,6 +157,12 @@
     const highlightEventId = page.url.searchParams.get('highlight');
     if (!highlightEventId || !room.roomData) return;
 
+    // Room.svelte lives in +layout and is reused across roomId changes. During
+    // in-place navigation between rooms the URL can update before useRoomData
+    // resets roomData, so we'd otherwise fire jumpToMessage against the
+    // previous room's store and strip ?highlight before the new room loads.
+    if (room.roomData.room.id !== roomId) return;
+
     const cleanUrl = new URL(page.url);
     cleanUrl.searchParams.delete('highlight');
     // eslint-disable-next-line svelte/no-navigation-without-resolve -- cleanUrl is derived from current page URL, already resolved


### PR DESCRIPTION
## Summary

A user reported that clicking the orange notification dot on a space scrolled to the bottom of a channel and dropped the unread/highlight markers.

Root cause: `Room.svelte` is rendered in `+layout.svelte` and reused across roomId changes. During in-place navigation between rooms in the same space, the URL could update with `?highlight=eventX` before `useRoomData` reset `roomData`, so the highlight `$effect` fired `jumpToMessage` against the **previous** room's message store and stripped `?highlight` from the URL before the new room ever loaded — leaving the user at the bottom with no highlight and no separator.

Fixes:
- Gate the highlight `$effect` on `room.roomData.room.id === roomId` so it never fires against the previous room's store during in-place navigation.
- Drop the `await` on `notificationStore.dismiss(...)` in `handleSpaceNotificationClick` so navigation isn't delayed by the server roundtrip.

## Test plan
- [x] `pnpm test:unit --run` (680 passing)
- [x] `pnpm check` (0 errors, 0 warnings)
- [ ] Manual repro: two rooms A/B in one space, sit in A, generate a mention/reply notification in B, click the orange dot — should land in B at the highlighted message with the "New messages" separator visible.