### PR TITLE
fix(frontend): render `_...word_` as italic when preceded by punctuation

### DIFF
--- a/frontend/src/lib/markdown.test.ts
+++ b/frontend/src/lib/markdown.test.ts
@@ -35,6 +35,21 @@ describe('renderMarkdown', () => {
       const html = await renderMarkdown('hello *world* foo');
       expect(html).toContain('<em>world</em>');
     });
+
+    it('renders `_...moo_` as italic with leading punctuation', async () => {
+      const html = await renderMarkdown('_...moo_');
+      expect(html).toContain('<em>...moo</em>');
+    });
+
+    it('renders `*...moo*` as italic with leading punctuation', async () => {
+      const html = await renderMarkdown('*...moo*');
+      expect(html).toContain('<em>...moo</em>');
+    });
+
+    it('renders `**...bold**` as bold with leading punctuation', async () => {
+      const html = await renderMarkdown('**...bold**');
+      expect(html).toContain('<strong>...bold</strong>');
+    });
   });
 
   describe('emphasis suppressed when not at word boundaries', () => {

--- a/frontend/src/lib/markdown.ts
+++ b/frontend/src/lib/markdown.ts
@@ -84,11 +84,22 @@ function wordBoundaryEmphasis(state: StateInline, silent: boolean): boolean {
   const beforeAlnum = ALPHANUMERIC.test(before);
   const afterAlnum = ALPHANUMERIC.test(after);
 
-  // Word boundary = exactly one side alphanumeric. Otherwise the run is
-  // either intraword (both sides alphanumeric) or fully embedded in
-  // non-alphanumeric context (neither side alphanumeric); both should be
-  // treated as literal text.
-  if (beforeAlnum === afterAlnum) {
+  // Intraword: definitely literal (`snake_case`, `foo*bar*baz`).
+  const intraword = beforeAlnum && afterAlnum;
+  // Kaomoji-like: punctuation on both sides AND no alphanumeric between this
+  // run and the next same-marker (so `_(ツ)_` suppresses, `_...moo_` doesn't).
+  let kaomojiLike = false;
+  if (!beforeAlnum && !afterAlnum) {
+    kaomojiLike = true;
+    for (let i = runEnd; i < state.posMax; i++) {
+      if (state.src.charCodeAt(i) === marker) break;
+      if (ALPHANUMERIC.test(state.src[i])) {
+        kaomojiLike = false;
+        break;
+      }
+    }
+  }
+  if (intraword || kaomojiLike) {
     if (!silent) state.pending += state.src.slice(start, runEnd);
     state.pos = runEnd;
     return true;


### PR DESCRIPTION
## Summary

- The custom emphasis-suppression rule in `markdown.ts` was eating the opening `_`/`*` of runs like `_...moo_` (both flanks non-alphanumeric → consumed as literal), so the message rendered as plain text instead of italic.
- Fix: in the "both flanks non-alphanumeric" branch, peek ahead to the next same-marker; only suppress if no alphanumeric appears in between (true kaomoji case like `_(ツ)_`). Real emphasis with leading punctuation now falls through to standard markdown-it.
- Added regression tests for `_...moo_`, `*...moo*`, and `**...bold**`; existing kaomoji and `snake_case` suppression tests still pass.

## Test plan

- [x] `mise x -- pnpm test:unit --run --project server src/lib/markdown.test.ts` (15/15 passing)
- [ ] Manual smoke: post `_...moo_` in a chat message and confirm italic rendering