### PR TITLE
fix(frontend): dismiss room-message notifications on room entry

### DIFF
--- a/frontend/src/routes/chat/[instanceId]/[spaceId]/[roomId]/Room.svelte
+++ b/frontend/src/routes/chat/[instanceId]/[spaceId]/[roomId]/Room.svelte
@@ -142,6 +142,7 @@
     } else {
       notificationStore.dismissMentionNotifications(currentRoomId);
       notificationStore.dismissRoomReplyNotifications(currentRoomId);
+      notificationStore.dismissRoomMessageNotifications(currentRoomId);
     }
   });
 


### PR DESCRIPTION
## Summary

\`Room.svelte\`'s room-entry effect already dismisses \`MentionNotificationItem\` and room-level \`ReplyNotificationItem\`, but \`RoomMessageNotificationItem\` (the 'all messages' notification mode) was leaking — visiting the room and reading everything left those notifications hanging in the bell. Adds the matching \`dismissRoomMessageNotifications\` call so the three room notification types are dismissed consistently on room entry.

## Test plan
- [x] \`pnpm check\` (0 errors, 0 warnings)
- [x] \`pnpm test:unit --run\` (680 passing)
- [ ] Manual: enable 'all messages' notifications on a room, have someone post, see bell count, enter the room, bell count should drop.