### PR TITLE
refactor(frontend): centralize notification target extraction

### DIFF
--- a/frontend/src/lib/state/instance/notifications.svelte.ts
+++ b/frontend/src/lib/state/instance/notifications.svelte.ts
@@ -116,6 +116,80 @@ const DismissAllNotificationsMutationDoc = graphql(`
 export type NotificationItem = NotificationsQuery['notifications'][number];
 
 /**
+ * Normalized view of a notification's target (where it points to in the app).
+ * Avoids `__typename` switches at every read site — see {@link notificationTarget}.
+ */
+export type NotificationTarget = {
+  isDM: boolean;
+  spaceId: string | null;
+  spaceName: string | null;
+  roomId: string | null;
+  roomName: string | null;
+  eventId: string | null;
+  /** Thread root event ID for thread-reply notifications; null otherwise. */
+  threadRootId: string | null;
+};
+
+/**
+ * Extract the target a notification points to. Adding a new notification type
+ * means updating this single function instead of every read site.
+ */
+export function notificationTarget(n: NotificationItem): NotificationTarget {
+  switch (n.__typename) {
+    case 'DMMessageNotificationItem':
+      return {
+        isDM: true,
+        spaceId: null,
+        spaceName: null,
+        roomId: n.room.id,
+        roomName: null,
+        eventId: null,
+        threadRootId: null
+      };
+    case 'MentionNotificationItem':
+      return {
+        isDM: false,
+        spaceId: n.mentionSpace?.id ?? null,
+        spaceName: n.mentionSpace?.name ?? null,
+        roomId: n.mentionRoom?.id ?? null,
+        roomName: n.mentionRoom?.name ?? null,
+        eventId: n.mentionEventId ?? null,
+        threadRootId: null
+      };
+    case 'ReplyNotificationItem':
+      return {
+        isDM: false,
+        spaceId: n.replySpace?.id ?? null,
+        spaceName: n.replySpace?.name ?? null,
+        roomId: n.replyRoom?.id ?? null,
+        roomName: n.replyRoom?.name ?? null,
+        eventId: n.replyEventId ?? null,
+        threadRootId: n.replyInThread ?? null
+      };
+    case 'RoomMessageNotificationItem':
+      return {
+        isDM: false,
+        spaceId: n.roomMsgSpace?.id ?? null,
+        spaceName: n.roomMsgSpace?.name ?? null,
+        roomId: n.roomMsgRoom?.id ?? null,
+        roomName: n.roomMsgRoom?.name ?? null,
+        eventId: n.roomMsgEventId ?? null,
+        threadRootId: null
+      };
+    default:
+      return {
+        isDM: false,
+        spaceId: null,
+        spaceName: null,
+        roomId: null,
+        roomName: null,
+        eventId: null,
+        threadRootId: null
+      };
+  }
+}
+
+/**
  * Notification state store.
  * Manages notifications for the current user with real-time sync.
  */
@@ -162,78 +236,37 @@ export class NotificationStore {
   }
 
   /**
-   * Check if a specific room has pending notifications (thread replies or mentions).
+   * Check if a specific room has pending non-DM notifications.
    */
   hasRoomNotification(roomId: string): boolean {
     return this.notifications.some((n) => {
-      if (n.__typename === 'ReplyNotificationItem') {
-        return n.replyRoom?.id === roomId;
-      }
-      if (n.__typename === 'MentionNotificationItem') {
-        return n.mentionRoom?.id === roomId;
-      }
-      if (n.__typename === 'RoomMessageNotificationItem') {
-        return n.roomMsgRoom?.id === roomId;
-      }
-      return false;
+      const t = notificationTarget(n);
+      return !t.isDM && t.roomId === roomId;
     });
   }
 
   /**
-   * Check if a specific space has pending notifications (thread replies or mentions).
+   * Check if a specific space has pending notifications.
    */
   hasSpaceNotification(spaceId: string): boolean {
-    return this.notifications.some((n) => {
-      if (n.__typename === 'ReplyNotificationItem') {
-        return n.replySpace?.id === spaceId;
-      }
-      if (n.__typename === 'MentionNotificationItem') {
-        return n.mentionSpace?.id === spaceId;
-      }
-      if (n.__typename === 'RoomMessageNotificationItem') {
-        return n.roomMsgSpace?.id === spaceId;
-      }
-      return false;
-    });
+    return this.notifications.some((n) => notificationTarget(n).spaceId === spaceId);
   }
 
   /**
    * Get the most recent notification for a space.
-   * Returns undefined if no notifications exist for the space.
-   * Uses .find() which returns the first match - notifications are sorted by most recent first.
+   * Notifications are sorted most-recent-first, so .find returns the freshest.
    */
   getSpaceNotification(spaceId: string): NotificationItem | undefined {
-    return this.notifications.find((n) => {
-      if (n.__typename === 'ReplyNotificationItem') {
-        return n.replySpace?.id === spaceId;
-      }
-      if (n.__typename === 'MentionNotificationItem') {
-        return n.mentionSpace?.id === spaceId;
-      }
-      if (n.__typename === 'RoomMessageNotificationItem') {
-        return n.roomMsgSpace?.id === spaceId;
-      }
-      return false;
-    });
+    return this.notifications.find((n) => notificationTarget(n).spaceId === spaceId);
   }
 
   /**
-   * Get the most recent notification for a room.
-   * Returns undefined if no notifications exist for the room.
-   * Uses .find() which returns the first match - notifications are sorted by most recent first.
+   * Get the most recent non-DM notification for a room.
    */
   getRoomNotification(roomId: string): NotificationItem | undefined {
     return this.notifications.find((n) => {
-      if (n.__typename === 'ReplyNotificationItem') {
-        return n.replyRoom?.id === roomId;
-      }
-      if (n.__typename === 'MentionNotificationItem') {
-        return n.mentionRoom?.id === roomId;
-      }
-      if (n.__typename === 'RoomMessageNotificationItem') {
-        return n.roomMsgRoom?.id === roomId;
-      }
-      return false;
+      const t = notificationTarget(n);
+      return !t.isDM && t.roomId === roomId;
     });
   }
 
@@ -419,148 +452,51 @@ export class NotificationStore {
 
   /**
    * Get location string for a notification (e.g., "#general in My Space").
-   * Returns null for DM notifications (no space/room context needed).
+   * Returns null for DM notifications and any notification missing names.
    */
   getLocationString(notification: NotificationItem): string | null {
-    switch (notification.__typename) {
-      case 'MentionNotificationItem': {
-        const spaceName = notification.mentionSpace?.name;
-        const roomName = notification.mentionRoom?.name;
-        if (spaceName && roomName) {
-          return `#${roomName} in ${spaceName}`;
-        }
-        return null;
-      }
-
-      case 'ReplyNotificationItem': {
-        const spaceName = notification.replySpace?.name;
-        const roomName = notification.replyRoom?.name;
-        if (spaceName && roomName) {
-          return `#${roomName} in ${spaceName}`;
-        }
-        return null;
-      }
-
-      case 'RoomMessageNotificationItem': {
-        const spaceName = notification.roomMsgSpace?.name;
-        const roomName = notification.roomMsgRoom?.name;
-        if (spaceName && roomName) {
-          return `#${roomName} in ${spaceName}`;
-        }
-        return null;
-      }
-
-      default:
-        return null;
-    }
+    const t = notificationTarget(notification);
+    if (t.isDM || !t.spaceName || !t.roomName) return null;
+    return `#${t.roomName} in ${t.spaceName}`;
   }
 
   /**
-   * Get navigation info for a notification.
-   * Returns the path to navigate to when acting on the notification.
+   * Get the path to navigate to when acting on a notification.
+   * Includes ?highlight=<eventId> when the notification points to a specific message.
    */
   getNavigationPath(instanceId: string, notification: NotificationItem): string {
     const seg = instanceIdToSegment(instanceId);
+    const t = notificationTarget(notification);
 
-    switch (notification.__typename) {
-      case 'DMMessageNotificationItem':
-        return resolve('/chat/dm/[instanceSegment]/[conversationId]', {
-          instanceSegment: seg,
-          conversationId: notification.room.id
-        });
-
-      case 'MentionNotificationItem': {
-        // Navigate to the room, optionally with eventId to scroll to message
-        // Using aliased fields from query
-        const spaceId = notification.mentionSpace?.id;
-        const roomId = notification.mentionRoom?.id;
-        const eventId = notification.mentionEventId;
-        if (eventId && spaceId && roomId) {
-          return (
-            resolve('/chat/[instanceId]/[spaceId]/[roomId]', {
-              instanceId: seg,
-              spaceId,
-              roomId
-            }) +
-            '?highlight=' +
-            eventId
-          );
-        }
-        return spaceId && roomId
-          ? resolve('/chat/[instanceId]/[spaceId]/[roomId]', {
-              instanceId: seg,
-              spaceId,
-              roomId
-            })
-          : resolve('/chat/[instanceId]', { instanceId: seg });
-      }
-
-      case 'ReplyNotificationItem': {
-        // Using aliased fields from query
-        const spaceId = notification.replySpace?.id;
-        const roomId = notification.replyRoom?.id;
-        const eventId = notification.replyEventId;
-        const threadRootId = notification.replyInThread;
-        if (threadRootId && spaceId && roomId && eventId) {
-          // Thread reply: navigate to the thread (using thread root) and highlight the new reply
-          return (
-            resolve('/chat/[instanceId]/[spaceId]/[roomId]/[threadId]', {
-              instanceId: seg,
-              spaceId,
-              roomId,
-              threadId: threadRootId
-            }) +
-            '?highlight=' +
-            eventId
-          );
-        }
-        // Room-level reply: navigate to room and highlight the reply message
-        if (eventId && spaceId && roomId) {
-          return (
-            resolve('/chat/[instanceId]/[spaceId]/[roomId]', {
-              instanceId: seg,
-              spaceId,
-              roomId
-            }) +
-            '?highlight=' +
-            eventId
-          );
-        }
-        return spaceId && roomId
-          ? resolve('/chat/[instanceId]/[spaceId]/[roomId]', {
-              instanceId: seg,
-              spaceId,
-              roomId
-            })
-          : resolve('/chat/[instanceId]', { instanceId: seg });
-      }
-
-      case 'RoomMessageNotificationItem': {
-        const spaceId = notification.roomMsgSpace?.id;
-        const roomId = notification.roomMsgRoom?.id;
-        const eventId = notification.roomMsgEventId;
-        if (eventId && spaceId && roomId) {
-          return (
-            resolve('/chat/[instanceId]/[spaceId]/[roomId]', {
-              instanceId: seg,
-              spaceId,
-              roomId
-            }) +
-            '?highlight=' +
-            eventId
-          );
-        }
-        return spaceId && roomId
-          ? resolve('/chat/[instanceId]/[spaceId]/[roomId]', {
-              instanceId: seg,
-              spaceId,
-              roomId
-            })
-          : resolve('/chat/[instanceId]', { instanceId: seg });
-      }
-
-      default:
-        return resolve('/chat/[instanceId]', { instanceId: seg });
+    if (t.isDM && t.roomId) {
+      return resolve('/chat/dm/[instanceSegment]/[conversationId]', {
+        instanceSegment: seg,
+        conversationId: t.roomId
+      });
     }
+
+    if (!t.spaceId || !t.roomId) {
+      return resolve('/chat/[instanceId]', { instanceId: seg });
+    }
+
+    if (t.threadRootId && t.eventId) {
+      return (
+        resolve('/chat/[instanceId]/[spaceId]/[roomId]/[threadId]', {
+          instanceId: seg,
+          spaceId: t.spaceId,
+          roomId: t.roomId,
+          threadId: t.threadRootId
+        }) +
+        '?highlight=' +
+        t.eventId
+      );
+    }
+
+    const roomPath = resolve('/chat/[instanceId]/[spaceId]/[roomId]', {
+      instanceId: seg,
+      spaceId: t.spaceId,
+      roomId: t.roomId
+    });
+    return t.eventId ? `${roomPath}?highlight=${t.eventId}` : roomPath;
   }
 }

--- a/frontend/src/routes/chat/[instanceId]/[spaceId]/MyThreadsNavItem.svelte
+++ b/frontend/src/routes/chat/[instanceId]/[spaceId]/MyThreadsNavItem.svelte
@@ -3,6 +3,7 @@
 	import { instanceIdToSegment } from '$lib/navigation';
 	import { getActiveInstance } from '$lib/state/activeInstance.svelte';
 	import { instanceRegistry } from '$lib/state/instance/registry.svelte';
+	import { notificationTarget } from '$lib/state/instance/notifications.svelte';
 	import UnreadDot from '$lib/ui/UnreadDot.svelte';
 
 	const getInstanceId = getActiveInstance();
@@ -12,12 +13,10 @@
 	const notificationStore = instanceRegistry.getStore(getInstanceId()).notifications;
 
 	const hasUnread = $derived(
-		notificationStore.notifications.some(
-			(n) =>
-				n.__typename === 'ReplyNotificationItem' &&
-				n.replyInThread &&
-				n.replySpace?.id === spaceId
-		)
+		notificationStore.notifications.some((n) => {
+			const t = notificationTarget(n);
+			return t.spaceId === spaceId && t.threadRootId !== null;
+		})
 	);
 </script>
 


### PR DESCRIPTION
## Summary

Extract a \`notificationTarget(n)\` helper that returns a normalized \`{ isDM, spaceId, spaceName, roomId, roomName, eventId, threadRootId }\` view of any \`NotificationItem\`. Refactor \`hasRoomNotification\`, \`hasSpaceNotification\`, \`getRoomNotification\`, \`getSpaceNotification\`, \`getLocationString\`, and \`getNavigationPath\` in \`NotificationStore\` to use it. Also update \`MyThreadsNavItem.svelte\`'s thread-reply check to use the same helper. Adding a new notification type now means updating one switch instead of seven.

## Test plan
- [x] \`pnpm check\` (0 errors, 0 warnings)
- [x] \`pnpm test:unit --run\` (680 passing)
- [ ] Manual smoke: clicking a mention/reply/room-message notification still navigates with \`?highlight=...\`; orange dots on spaces and rooms still appear; "My Threads" sidebar dot still appears for thread replies in the active space.