### PR TITLE
refactor(frontend): unify space-dot indicator decision

### DIFF
--- a/frontend/src/lib/InstanceSpaceSection.svelte
+++ b/frontend/src/lib/InstanceSpaceSection.svelte
@@ -46,6 +46,13 @@
   // Track unread space count to force re-render when unread status changes
   let unreadSpaceCount = $derived(roomUnreadStore.unreadSpaceCount);
 
+  // Single dispatcher for space-icon clicks — kind comes from spaceIndicator()
+  // so the two paths can't drift out of sync with what was rendered.
+  function handleSpaceIndicatorClick(spaceId: string, kind: 'notification' | 'unread') {
+    if (kind === 'notification') return handleSpaceNotificationClick(spaceId);
+    return handleSpaceUnreadClick(spaceId);
+  }
+
   // Get the GraphQL client for this instance
   function getClient() {
     return graphqlClientManager.getClient(instanceId).client;
@@ -333,10 +340,8 @@
       {space}
       href={resolve('/chat/[instanceId]/[spaceId]', { instanceId: instanceSegment, spaceId: space.id })}
       selected={space.id === activeSpaceId}
-      hasNotification={notificationStore.hasSpaceNotification(space.id)}
-      hasUnread={roomUnreadStore.spaceHasUnread(space.id)}
-      onNotificationClick={() => handleSpaceNotificationClick(space.id)}
-      onUnreadClick={() => handleSpaceUnreadClick(space.id)}
+      indicator={stores.spaceIndicator(space.id)}
+      onIndicatorClick={(kind) => handleSpaceIndicatorClick(space.id, kind)}
     />
   {/each}
 {/key}

--- a/frontend/src/lib/SpaceIcon.svelte
+++ b/frontend/src/lib/SpaceIcon.svelte
@@ -15,16 +15,15 @@
   import UnreadDot from './ui/UnreadDot.svelte';
   import { graphql } from './gql';
   import type { SpaceIconSpaceFragment } from './gql/graphql';
+  import type { SpaceIndicator } from './state/instance/store.svelte';
 
   let {
     space,
     icon,
     href,
     selected = false,
-    hasNotification = false,
-    hasUnread = false,
-    onNotificationClick,
-    onUnreadClick,
+    indicator = null,
+    onIndicatorClick,
     title
   }: {
     space?: SpaceIconSpaceFragment;
@@ -32,10 +31,10 @@
     icon?: string;
     href: string;
     selected?: boolean;
-    hasNotification?: boolean;
-    hasUnread?: boolean;
-    onNotificationClick?: (event: MouseEvent) => void;
-    onUnreadClick?: (event: MouseEvent) => void;
+    /** What indicator dot (if any) to render in the corner. */
+    indicator?: SpaceIndicator;
+    /** Click handler for the indicator dot. Receives the indicator kind. */
+    onIndicatorClick?: (kind: 'notification' | 'unread', event: MouseEvent) => void;
     title?: string;
   } = $props();
 </script>
@@ -55,48 +54,29 @@
     {/if}
   </a>
 
-  <!-- Notification badge -->
-  {#if hasNotification}
-    {#if onNotificationClick}
-      <!-- Clickable notification dot - navigates to notification source -->
+  {#if indicator}
+    {#if onIndicatorClick}
       <button
         type="button"
         onclick={(e) => {
           e.stopPropagation();
-          onNotificationClick(e);
+          onIndicatorClick(indicator, e);
         }}
         class="absolute -top-1.5 -right-1.5 z-10 flex h-6 w-6 cursor-pointer items-center justify-center notification-dot"
-        aria-label="Go to notification"
+        aria-label={indicator === 'notification' ? 'Go to notification' : 'Go to first unread room'}
       >
-        <UnreadDot overlay />
+        <UnreadDot
+          color={indicator === 'notification' ? 'warning' : 'muted'}
+          overlay
+          testid={indicator === 'unread' ? 'space-unread-dot' : undefined}
+        />
       </button>
     {:else}
-      <!-- Non-clickable notification dot (backward compatible) -->
-      <UnreadDot overlay class="absolute top-0 right-0 z-10" />
-    {/if}
-
-    <!-- Unread badge -->
-  {:else if hasUnread}
-    {#if onUnreadClick}
-      <!-- Clickable unread dot - navigates to first unread room -->
-      <button
-        type="button"
-        onclick={(e) => {
-          e.stopPropagation();
-          onUnreadClick(e);
-        }}
-        class="absolute -top-1.5 -right-1.5 z-10 flex h-6 w-6 cursor-pointer items-center justify-center notification-dot"
-        aria-label="Go to first unread room"
-      >
-        <UnreadDot color="muted" overlay testid="space-unread-dot" />
-      </button>
-    {:else}
-      <!-- Non-clickable unread dot (backward compatible) -->
       <UnreadDot
-        color="muted"
+        color={indicator === 'notification' ? 'warning' : 'muted'}
         overlay
         class="absolute top-0 right-0 z-10"
-        testid="space-unread-dot"
+        testid={indicator === 'unread' ? 'space-unread-dot' : undefined}
       />
     {/if}
   {/if}

--- a/frontend/src/lib/SpaceList.svelte
+++ b/frontend/src/lib/SpaceList.svelte
@@ -98,10 +98,7 @@
   const homeNotificationStore = originStores?.notifications;
   const homeRoomUnreadStore = originStores?.roomUnread;
 
-  // Use $derived for DM notifications check so it's reactive
-  let hasDMNotification = $derived(homeNotificationStore?.hasDMNotifications() ?? false);
-  let hasDMUnread = $derived(homeRoomUnreadStore?.spaceHasUnread(DM_SPACE_ID) ?? false);
-
+  let dmIndicator = $derived(originStores?.dmIndicator() ?? null);
 
   // Handle click on DM unread dot - navigate to first unread DM conversation
   async function handleDMUnreadClick() {
@@ -126,6 +123,11 @@
       await goto(path);
     }
   }
+
+  function handleDMIndicatorClick(kind: 'notification' | 'unread') {
+    if (kind === 'notification') return handleDMNotificationClick();
+    return handleDMUnreadClick();
+  }
 </script>
 
 <div class="space-list flex min-h-0 flex-1 flex-col border-r border-border">
@@ -142,10 +144,8 @@
           title="Direct Messages"
           href={resolve('/chat/dm')}
           selected={isDMActive}
-          hasNotification={hasDMNotification}
-          hasUnread={hasDMUnread}
-          onNotificationClick={handleDMNotificationClick}
-          onUnreadClick={handleDMUnreadClick}
+          indicator={dmIndicator}
+          onIndicatorClick={handleDMIndicatorClick}
         />
       </div>
     {/if}

--- a/frontend/src/lib/state/instance/store.svelte.ts
+++ b/frontend/src/lib/state/instance/store.svelte.ts
@@ -15,6 +15,16 @@ import { ActiveCallRoomsState } from './activeCallRooms.svelte';
 import type { GraphQLClient } from './graphqlClient.svelte';
 import type { RegisteredInstance } from './registry.svelte';
 
+/**
+ * What kind of indicator dot a space (or the DM area) should display.
+ * - 'notification' = orange dot, has a pending mention/reply/room-message
+ * - 'unread' = grey dot, has unread rooms but no pending notification
+ * - null = no indicator
+ */
+export type SpaceIndicator = 'notification' | 'unread' | null;
+
+const DM_SPACE_ID = 'DM';
+
 const EMPTY_PERMISSIONS: InstancePermissions = {
 	loaded: false,
 	canViewAdmin: false,
@@ -106,6 +116,26 @@ export class InstanceStateStore {
 	/** Update permissions from viewer query data. */
 	setPermissions(viewer: ViewerData): void {
 		this.permissions = { ...viewer, loaded: true };
+	}
+
+	/**
+	 * Single source of truth for the space-level indicator dot.
+	 * Notifications take precedence over plain unread.
+	 */
+	spaceIndicator(spaceId: string): SpaceIndicator {
+		if (this.notifications.hasSpaceNotification(spaceId)) return 'notification';
+		if (this.roomUnread.spaceHasUnread(spaceId)) return 'unread';
+		return null;
+	}
+
+	/**
+	 * Indicator for the DM area. DM notifications have no `spaceId` so they
+	 * need their own check; unread tracking uses the synthetic `'DM'` space id.
+	 */
+	dmIndicator(): SpaceIndicator {
+		if (this.notifications.hasDMNotifications()) return 'notification';
+		if (this.roomUnread.spaceHasUnread(DM_SPACE_ID)) return 'unread';
+		return null;
 	}
 
 	/** Clean up resources. */


### PR DESCRIPTION
## Summary

\`SpaceIcon\` previously took separate \`hasNotification\` / \`hasUnread\` booleans and separate \`onNotificationClick\` / \`onUnreadClick\` callbacks, with each caller deciding which from two different stores. The two stores could drift (e.g. a notification arrives but the unread mark gets filtered as 'from self'), and the precedence rule (notification wins over unread) lived in SpaceIcon's template.

Centralize via \`InstanceStateStore.spaceIndicator(spaceId)\` and \`.dmIndicator()\`, returning \`'notification' | 'unread' | null\`. \`SpaceIcon\` now takes a single \`indicator\` prop and a single \`onIndicatorClick\` callback that receives the indicator kind. The two callers (\`InstanceSpaceSection\` and \`SpaceList\` for DMs) dispatch to their existing handlers based on the kind.

The \`space-unread-dot\` testid is preserved for the unread variant; e2e tests should continue to work.

## Test plan
- [x] \`pnpm check\` (0 errors, 0 warnings)
- [x] \`pnpm test:unit --run\` (680 passing)
- [ ] Manual: orange dot still shows on spaces with mentions/replies; grey dot still shows on spaces with plain unread; clicks still navigate correctly; DM icon still shows the right dot.