### PR TITLE
fix(frontend): polish Direct Messages list rendering

### DIFF
--- a/frontend/e2e/unified-dm-inbox.test.ts
+++ b/frontend/e2e/unified-dm-inbox.test.ts
@@ -166,14 +166,14 @@ test.describe('Unified DM Inbox — Multi-Instance', () => {
 		}).toPass({ timeout: TIMEOUTS.REALTIME_EVENT });
 	});
 
-	test('shows instance hostname for conversations in multi-instance mode', async ({ page }) => {
+	test('shows instance label for conversations in multi-instance mode', async ({ page }) => {
 		// Set up home instance with a DM
 		await createAndLoginTestUser(page);
 		const homeUser2 = await createSecondHomeUser(page);
 		const dmPage = new DMPage(page);
 		await dmPage.goto();
 		const roomPage = await dmPage.startConversation(homeUser2.login);
-		await roomPage.sendMessage(`Hostname test ${Date.now()}`);
+		await roomPage.sendMessage(`Instance label test ${Date.now()}`);
 
 		// Set up remote instance
 		const remoteUser = await createUserOnRemote(
@@ -188,15 +188,15 @@ test.describe('Unified DM Inbox — Multi-Instance', () => {
 		// Navigate to DM inbox
 		await page.goto(routes.dm);
 
-		// With multiple instances connected, hostname should be visible
-		// The home instance conversations should show "localhost" or similar
+		// With multiple instances connected, the instance label (display name,
+		// falling back to hostname) should be shown as a subtitle.
 		await expect(async () => {
 			await dmPage.expectConversationVisible(homeUser2.displayName);
-			// Instance hostname should be shown as a subtitle (text-xs distinguishes
-			// it from the avatar placeholder which also has text-muted)
+			// The subtitle is the only text-xs.text-muted span in the row.
 			const conv = dmPage.getConversation(homeUser2.displayName);
-			await expect(conv.locator('span.text-xs.text-muted')).toBeVisible();
-			await expect(conv.locator('span.text-xs.text-muted')).toContainText('localhost');
+			const subtitle = conv.locator('span.text-xs.text-muted');
+			await expect(subtitle).toBeVisible();
+			await expect(subtitle).not.toBeEmpty();
 		}).toPass({ timeout: TIMEOUTS.REALTIME_EVENT });
 	});
 

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -229,7 +229,7 @@
 }
 
 @utility sidebar-item {
-  @apply relative flex w-full cursor-pointer items-center gap-2 overflow-hidden rounded-md px-3 py-1.5 text-text;
+  @apply relative flex w-full shrink-0 cursor-pointer items-center gap-2 overflow-hidden rounded-md px-3 py-1.5 text-text;
   @apply hover:bg-surface-100 hover:text-text;
 }
 

--- a/frontend/src/lib/dm/DMConversationList.svelte
+++ b/frontend/src/lib/dm/DMConversationList.svelte
@@ -238,7 +238,7 @@
       <a
         href={resolve('/chat/dm/[instanceSegment]/[conversationId]', { instanceSegment: instanceIdToSegment(conv.instanceId), conversationId: conv.id })}
         class={[
-          'sidebar-item shrink-0 py-3',
+          'sidebar-item py-3',
           conv.id === activeConversationId ? 'bg-surface-100' : '',
           conv.hasUnread && conv.id !== activeConversationId ? 'font-semibold' : ''
         ]}

--- a/frontend/src/lib/dm/DMConversationList.svelte
+++ b/frontend/src/lib/dm/DMConversationList.svelte
@@ -27,7 +27,7 @@
   type DMConversation = {
     id: string;
     instanceId: string;
-    instanceHostname: string;
+    instanceLabel: string;
     hasUnread: boolean;
     participants: UserAvatarUserFragment[];
     currentUserId: string | undefined;
@@ -74,7 +74,7 @@
 
     const me = result.data.me;
     const meId = me?.id;
-    const hostname = getInstanceHostname(instance);
+    const label = instance.name?.trim() || getInstanceHostname(instance);
     const rooms = result.data.space.rooms ?? [];
 
     const newConversations: DMConversation[] = rooms.map((room) => {
@@ -85,7 +85,7 @@
       return {
         id: room.id,
         instanceId,
-        instanceHostname: hostname,
+        instanceLabel: label,
         hasUnread: room.hasUnread,
         participants,
         currentUserId: meId,
@@ -222,7 +222,7 @@
     return () => subs.forEach((s) => s());
   });
 
-  // Whether we're connected to multiple instances (controls hostname display)
+  // Whether we're connected to multiple instances (controls instance label display)
   let multiInstance = $derived(instanceRegistry.instances.length > 1);
 </script>
 
@@ -238,7 +238,7 @@
       <a
         href={resolve('/chat/dm/[instanceSegment]/[conversationId]', { instanceSegment: instanceIdToSegment(conv.instanceId), conversationId: conv.id })}
         class={[
-          'sidebar-item',
+          'sidebar-item shrink-0 py-3',
           conv.id === activeConversationId ? 'bg-surface-100' : '',
           conv.hasUnread && conv.id !== activeConversationId ? 'font-semibold' : ''
         ]}
@@ -247,13 +247,13 @@
         <div class="flex -space-x-2">
           {#if conv.isSelfConversation}
             {#each conv.participants.filter((p) => p.id === conv.currentUserId).slice(0, 1) as participant (participant.id)}
-              <UserAvatar user={participant} size="sm" />
+              <UserAvatar user={participant} size="md" />
             {/each}
           {:else}
             {#each conv.participants
               .filter((p) => p.id !== conv.currentUserId)
               .slice(0, 3) as participant (participant.id)}
-              <UserAvatar user={participant} size="sm" />
+              <UserAvatar user={participant} size="md" />
             {/each}
           {/if}
         </div>
@@ -261,7 +261,9 @@
         <div class="flex min-w-0 flex-1 flex-col">
           <span class="truncate">{getConversationDisplayName(conv)}</span>
           {#if multiInstance}
-            <span class="text-xs text-muted">{conv.instanceHostname}</span>
+            <span class="truncate text-xs text-muted" title={conv.instanceLabel}>
+              {conv.instanceLabel}
+            </span>
           {/if}
         </div>
 


### PR DESCRIPTION
## Summary

- Use the instance's human-friendly display name (with hostname fallback) instead of the raw hostname for the multi-instance subtitle, and truncate it properly with a `title` tooltip for the full value.
- Bump DM avatars from `sm` (32 px) to `md` (40 px) for a more balanced row.
- Add `shrink-0 py-3` to each row so the parent flex-column stops squashing items below their content height when the list overflows — that squashing was clipping avatars at top/bottom in long lists.

## Test plan

- [ ] Open `/chat/dm` with a single connected instance — rows show only the display name, avatars not clipped.
- [ ] Open `/chat/dm` with multiple connected instances — each row shows the instance display name underneath, truncates with ellipsis if long, and reveals the full value on hover.
- [ ] Long DM list (≥ ~15 rows) — list scrolls and avatars remain at full 40 px height.