### PR TITLE
revert: re-enable GraphQL introspection and /api/playground for everyone

### DIFF
--- a/.claude/rules/general.md
+++ b/.claude/rules/general.md
@@ -15,6 +15,10 @@
 
 No data migration needed; breaking changes to APIs and storage schemas are acceptable.
 
+## Public API Surface
+
+- **GraphQL introspection and the `/api/playground` UI are intentionally enabled by default for everyone, including production deployments.** Letting people poke at Chatto's API is part of the product — it's how operators, integrators, and curious users learn the system. Do NOT propose gating either behind a "dev mode" flag, an admin-only toggle, env var, or build tag, even if a security review flags them as a "reconnaissance vector." A previous attempt to do this (PR #180, finding L1) was reverted on this branch. If a future security review raises this again, push back and reference this rule. Real protection for sensitive operations belongs in resolver-level authz, not in hiding the schema.
+
 ## Code Style & Approach
 
 - **Prefer the simplest possible approach first.** Do not over-engineer solutions. If a fix can be done in 2-3 lines, do not create abstractions, wrappers, or complex architectures. Wait for user feedback before adding complexity.

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -71,7 +71,6 @@ type WebserverConfig struct {
 	RequestLogging         *bool     `toml:"request_logging" env:"CHATTO_WEBSERVER_REQUEST_LOGGING" comment:"Log HTTP requests. Useful for debugging but can be noisy in production. Default: false."`
 	CookieSigningSecret    string    `toml:"cookie_signing_secret" env:"CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET" comment:"Secret for signing session cookies. NEVER SHARE THIS!\nIf it leaks, change it immediately, but please note that all existing sessions will become invalid."`
 	CookieEncryptionSecret string    `toml:"cookie_encryption_secret" env:"CHATTO_WEBSERVER_COOKIE_ENCRYPTION_SECRET" comment:"Optional hex-encoded secret used to encrypt session cookies (in addition to signing). Must decode to 16, 24, or 32 bytes (AES-128/192/256). If unset, cookies are signed but not encrypted — anything ever written to the session is readable by anyone who steals the cookie."`
-	DevMode                bool      `toml:"dev_mode" env:"CHATTO_WEBSERVER_DEV_MODE" comment:"Enable developer-mode endpoints: GraphQL introspection and the /api/playground UI. Default: false. Do NOT enable in production — it lets unauthenticated callers enumerate the full schema."`
 	TLS                    TLSConfig `toml:"tls" comment:"Automatic TLS configuration via Let's Encrypt."`
 }
 

--- a/cli/internal/http_server/graphql.go
+++ b/cli/internal/http_server/graphql.go
@@ -183,11 +183,10 @@ func (s *HTTPServer) setupGraphQLAPI(allowedOrigins []string) {
 
 	h.SetQueryCache(lru.New[*ast.QueryDocument](1000))
 
-	// Introspection lets callers enumerate the full schema. Useful in dev,
-	// reconnaissance vector in prod. Same gate covers /api/playground below.
-	if s.config.Webserver.DevMode {
-		h.Use(extension.Introspection{})
-	}
+	// Introspection and the /api/playground UI below are intentionally
+	// enabled unconditionally — exposing Chatto's GraphQL API for
+	// experimentation is part of the product. See .claude/rules/general.md.
+	h.Use(extension.Introspection{})
 	h.Use(extension.FixedComplexityLimit(500))
 	h.Use(&gqldepthlimit.Extension{MaxDepth: 12})
 	h.Use(extension.AutomaticPersistedQuery{
@@ -217,11 +216,8 @@ func (s *HTTPServer) setupGraphQLAPI(allowedOrigins []string) {
 		h.ServeHTTP(c.Writer, r)
 	})
 
-	// Configure API Playground (dev mode only — pairs with introspection above)
-	if s.config.Webserver.DevMode {
-		p := playground.Handler("CHATTO API Playground", "/api/graphql")
-		s.router.GET("/api/playground", func(c *gin.Context) {
-			p.ServeHTTP(c.Writer, c.Request)
-		})
-	}
+	p := playground.Handler("CHATTO API Playground", "/api/graphql")
+	s.router.GET("/api/playground", func(c *gin.Context) {
+		p.ServeHTTP(c.Writer, c.Request)
+	})
 }

--- a/compose.yml
+++ b/compose.yml
@@ -19,9 +19,6 @@ services:
       CHATTO_BOOTSTRAP_EMAIL: dev@dev.com
       CHATTO_BOOTSTRAP_PASSWORD: devpassword
       CHATTO_BOOTSTRAP_SPACE_NAME: ${COMPOSE_PROJECT_NAME}
-      # Dev mode enables GraphQL introspection + /api/playground.
-      # Self-hosted production deployments must leave this off.
-      CHATTO_WEBSERVER_DEV_MODE: "true"
     volumes:
       - ./cli:/app/cli
       # Shared host-side caches (see comment at the bottom of this file).


### PR DESCRIPTION
## Summary

Reverts the dev-mode gate that PR #180 (finding L1) put in front of GraphQL introspection and `/api/playground`. Exposing Chatto's GraphQL API for experimentation is intentional product behavior — operators, integrators, and curious users should be able to poke at it on any deployment, not just dev.

## Changes

- `cli/internal/http_server/graphql.go` — register introspection + playground unconditionally
- `cli/internal/config/config.go` — drop the now-unused `webserver.dev_mode` field
- `compose.yml` — drop the `CHATTO_WEBSERVER_DEV_MODE` override that's no longer needed
- `.claude/rules/general.md` — new "Public API Surface" rule so future security reviews don't relitigate this

## Test plan

- [x] `go build ./...` from `cli/` passes
- [ ] CI green