### PR TITLE
feat(frontend): InstancePill — subtle cross-instance label with hover card

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -36,6 +36,7 @@
   --color-warning: var(--color-amber-600);
   --color-danger: var(--color-red-600);
   --color-error: var(--color-red-600);
+  --color-instance: var(--color-indigo-600);
 
   /* Shimmer hover effect gradient */
   --shimmer-gradient: linear-gradient(
@@ -73,6 +74,7 @@
     --color-warning: var(--color-amber-500);
     --color-danger: var(--color-red-400);
     --color-error: var(--color-red-400);
+    --color-instance: var(--color-indigo-400);
   }
 }
 
@@ -100,6 +102,7 @@
   --color-warning: var(--color-warning);
   --color-danger: var(--color-danger);
   --color-error: var(--color-error);
+  --color-instance: var(--color-instance);
 }
 
 /* Button utilities */

--- a/frontend/src/lib/SpaceDirectory.svelte
+++ b/frontend/src/lib/SpaceDirectory.svelte
@@ -25,7 +25,6 @@
   type SpaceWithInstance = {
     space: SpaceCardSpaceFragment;
     instanceId: string;
-    instanceName: string;
   };
 
   /** Per-instance space data, keyed by instance ID. Survives other instances being added/removed.
@@ -46,15 +45,16 @@
     const result: SpaceWithInstance[] = [];
     for (const inst of instanceData) {
       if (inst.loading || inst.error || inst.canBrowse === false) continue;
-      const store = instanceRegistry.tryGetStore(inst.instanceId);
-      const instanceName = store?.instance.name ?? inst.instanceName;
       for (const space of inst.spaces) {
-        result.push({ space, instanceId: inst.instanceId, instanceName });
+        result.push({ space, instanceId: inst.instanceId });
       }
     }
     result.sort((a, b) => a.space.name.localeCompare(b.space.name));
     return result;
   });
+
+  /** Whether to show the instance pill on each card — only useful when more than one instance is connected. */
+  const multiInstance = $derived(instanceRegistry.instances.length > 1);
 
   const filteredSpaces = $derived.by(() => {
     if (!searchQuery.trim()) return allSpaces;
@@ -231,10 +231,10 @@
     <p class="mb-4 text-muted">No spaces match your filter.</p>
   {:else}
     <div class="mb-6 grid gap-4 grid-cols-[repeat(auto-fill,minmax(220px,1fr))]">
-      {#each filteredSpaces as { space, instanceId, instanceName } (`${instanceId}:${space.id}`)}
+      {#each filteredSpaces as { space, instanceId } (`${instanceId}:${space.id}`)}
         <SpaceCard
           {space}
-          {instanceName}
+          instanceId={multiInstance ? instanceId : undefined}
           joined={space.viewerIsMember}
           href={space.viewerIsMember
             ? resolve('/chat/[instanceId]/[spaceId]', { instanceId: instanceIdToSegment(instanceId), spaceId: space.id })

--- a/frontend/src/lib/components/InstancePill.svelte
+++ b/frontend/src/lib/components/InstancePill.svelte
@@ -1,0 +1,156 @@
+<!--
+@component
+
+A `<Pill tone="instance">` displaying an instance's name (truncated) with
+a globe icon, plus a hover card that previews the instance's branding
+(icon, OG image, welcome message).
+
+The data is read from `instanceRegistry` and the per-instance state store,
+both of which are populated when an instance is registered, so no extra
+network round trips are needed.
+
+```svelte
+<InstancePill instanceId={conv.instanceId} />
+```
+-->
+<script lang="ts">
+  import { instanceRegistry } from '$lib/state/instance/registry.svelte';
+  import { Pill } from '$lib/ui';
+  import ContextMenu from '$lib/ui/ContextMenu.svelte';
+  import SkeletonImg from '$lib/ui/SkeletonImg.svelte';
+
+  // Small grace period so brushing past the pill on the way to the card
+  // doesn't immediately dismiss the popover.
+  const CLOSE_DELAY_MS = 150;
+
+  let {
+    instanceId
+  }: {
+    instanceId: string;
+  } = $props();
+
+  const instance = $derived(instanceRegistry.getInstance(instanceId));
+  const store = $derived(instanceRegistry.tryGetStore(instanceId));
+
+  // Hide globally when the client is only connected to a single instance — the
+  // pill carries no useful information in that case, and is just visual noise.
+  const visible = $derived(instanceRegistry.instances.length > 1);
+
+  const name = $derived(instance?.name ?? '');
+  const iconUrl = $derived(instance?.iconUrl ?? null);
+  const ogImageUrl = $derived(store?.instance.ogImageUrl ?? null);
+  const welcomeMessage = $derived(store?.instance.welcomeMessage ?? null);
+  const motd = $derived(store?.instance.motd ?? null);
+  const hostname = $derived.by(() => {
+    if (!instance) return '';
+    try {
+      return new URL(instance.url).hostname;
+    } catch {
+      return instance.url;
+    }
+  });
+
+  // Strip markdown punctuation so the excerpt reads cleanly in a small
+  // popover. We don't render full markdown here — keeping the card light
+  // and predictable.
+  const blurb = $derived.by(() => {
+    const src = motd ?? welcomeMessage;
+    if (!src) return null;
+    const plain = src
+      .replace(/^#+\s+/gm, '')
+      .replace(/[*_`>]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    return plain.length > 180 ? plain.slice(0, 180).trimEnd() + '…' : plain;
+  });
+
+  let trigger = $state<HTMLSpanElement>();
+  let open = $state(false);
+  let anchor = $state<{ top: number; bottom: number; left: number } | null>(null);
+  let closeTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function cancelClose() {
+    if (closeTimer !== null) {
+      clearTimeout(closeTimer);
+      closeTimer = null;
+    }
+  }
+
+  function scheduleClose() {
+    cancelClose();
+    closeTimer = setTimeout(() => {
+      open = false;
+      closeTimer = null;
+    }, CLOSE_DELAY_MS);
+  }
+
+  function show() {
+    cancelClose();
+    if (!trigger) return;
+    const rect = trigger.getBoundingClientRect();
+    anchor = { top: rect.top, bottom: rect.bottom, left: rect.left };
+    open = true;
+  }
+</script>
+
+{#if visible}
+  <span
+    bind:this={trigger}
+    class="flex min-w-0 max-w-full align-middle"
+    onmouseenter={show}
+    onmouseleave={scheduleClose}
+    onfocusin={show}
+    onfocusout={scheduleClose}
+    role="presentation"
+  >
+    <Pill tone="subtle" class="flex min-w-0 max-w-full !px-1">
+      <span class="flex min-w-0 items-center gap-1">
+        <span
+          class="iconify shrink-0 text-xs text-instance uil--globe"
+          aria-hidden="true"
+        ></span>
+        <span class="truncate">{name}</span>
+      </span>
+    </Pill>
+  </span>
+{/if}
+
+{#if visible && open && instance && anchor}
+  <ContextMenu
+    {anchor}
+    role="tooltip"
+    ariaLabel="Instance details for {name}"
+    class="w-72"
+    onclose={() => (open = false)}
+    onmouseenter={cancelClose}
+    onmouseleave={scheduleClose}
+  >
+    <div class="menu-section overflow-hidden p-0">
+      {#if ogImageUrl}
+        <SkeletonImg src={ogImageUrl} alt="" class="block h-32 w-full object-cover" />
+      {/if}
+
+      <div class="flex items-start gap-3 p-3">
+        {#if iconUrl}
+          <img src={iconUrl} alt="" class="h-10 w-10 shrink-0 rounded-md" />
+        {:else}
+          <div
+            class="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-instance/10 text-instance"
+          >
+            <span class="iconify text-xl uil--globe" aria-hidden="true"></span>
+          </div>
+        {/if}
+        <div class="min-w-0 flex-1">
+          <div class="truncate font-semibold text-text">{name}</div>
+          <div class="truncate text-xs text-muted">{hostname}</div>
+        </div>
+      </div>
+
+      {#if blurb}
+        <div class="border-t border-border/60 px-3 py-2 text-xs text-muted">
+          {blurb}
+        </div>
+      {/if}
+    </div>
+  </ContextMenu>
+{/if}

--- a/frontend/src/lib/components/InstancePill.svelte.spec.ts
+++ b/frontend/src/lib/components/InstancePill.svelte.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { q } from '$lib/test-utils';
+
+interface RegisteredInstanceMock {
+  id: string;
+  name: string;
+  url: string;
+  iconUrl: string | null;
+}
+
+interface StoreMock {
+  instance: {
+    ogImageUrl: string | null;
+    welcomeMessage: string | null;
+    motd: string | null;
+  };
+}
+
+const { mockInstances, mockStores } = vi.hoisted(() => ({
+  mockInstances: { current: [] as RegisteredInstanceMock[] },
+  mockStores: { current: new Map<string, StoreMock>() }
+}));
+
+vi.mock('$lib/state/instance/registry.svelte', () => ({
+  instanceRegistry: {
+    get instances() {
+      return mockInstances.current;
+    },
+    getInstance: (id: string) =>
+      mockInstances.current.find((i) => i.id === id),
+    tryGetStore: (id: string) => mockStores.current.get(id)
+  }
+}));
+
+import InstancePill from './InstancePill.svelte';
+
+function makeInstance(o: Partial<RegisteredInstanceMock> = {}): RegisteredInstanceMock {
+  return {
+    id: 'a',
+    name: 'Instance A',
+    url: 'https://a.example.com',
+    iconUrl: null,
+    ...o
+  };
+}
+
+function makeStore(o: Partial<StoreMock['instance']> = {}): StoreMock {
+  return {
+    instance: {
+      ogImageUrl: null,
+      welcomeMessage: null,
+      motd: null,
+      ...o
+    }
+  };
+}
+
+beforeEach(() => {
+  mockInstances.current = [];
+  mockStores.current = new Map();
+});
+
+describe('InstancePill', () => {
+  describe('single-instance gating', () => {
+    it('renders nothing when no instances are registered', () => {
+      const { container } = render(InstancePill, { props: { instanceId: 'a' } });
+      expect(container.querySelector('[role="presentation"]')).toBeNull();
+    });
+
+    it('renders nothing when only a single instance is registered', () => {
+      mockInstances.current = [makeInstance({ id: 'a', name: 'Alpha' })];
+      mockStores.current.set('a', makeStore());
+
+      const { container } = render(InstancePill, { props: { instanceId: 'a' } });
+
+      expect(container.querySelector('[role="presentation"]')).toBeNull();
+      expect(container.textContent ?? '').not.toContain('Alpha');
+    });
+
+    it('renders the pill when more than one instance is registered', async () => {
+      mockInstances.current = [
+        makeInstance({ id: 'a', name: 'Alpha' }),
+        makeInstance({ id: 'b', name: 'Beta' })
+      ];
+      mockStores.current.set('a', makeStore());
+      mockStores.current.set('b', makeStore());
+
+      const { container } = render(InstancePill, { props: { instanceId: 'a' } });
+
+      await expect
+        .element(q(container, '[role="presentation"]'))
+        .toBeInTheDocument();
+      expect(container.textContent).toContain('Alpha');
+    });
+  });
+
+  describe('rendering', () => {
+    beforeEach(() => {
+      // Two instances → pill is visible
+      mockInstances.current = [
+        makeInstance({ id: 'a', name: 'Alpha' }),
+        makeInstance({ id: 'b', name: 'Beta' })
+      ];
+      mockStores.current.set('a', makeStore());
+      mockStores.current.set('b', makeStore());
+    });
+
+    it('renders the globe icon and the truncated instance name', async () => {
+      const { container } = render(InstancePill, { props: { instanceId: 'a' } });
+
+      await expect.element(q(container, '.uil--globe')).toBeInTheDocument();
+      await expect
+        .element(q(container, '.truncate'))
+        .toHaveTextContent('Alpha');
+    });
+
+    it('reflects the requested instance, not the first registered one', async () => {
+      const { container } = render(InstancePill, { props: { instanceId: 'b' } });
+
+      expect(container.textContent).toContain('Beta');
+      expect(container.textContent).not.toContain('Alpha');
+    });
+  });
+});

--- a/frontend/src/lib/components/SpaceCard.svelte
+++ b/frontend/src/lib/components/SpaceCard.svelte
@@ -21,6 +21,7 @@
   import type { SpaceCardSpaceFragment } from '$lib/gql/graphql';
   import { getGradientForName } from '$lib/utils/gradients';
   import SpaceLogo from './SpaceLogo.svelte';
+  import InstancePill from './InstancePill.svelte';
   import SkeletonImg from '$lib/ui/SkeletonImg.svelte';
 
   let {
@@ -28,15 +29,15 @@
     joining = false,
     joined = false,
     href,
-    instanceName,
+    instanceId,
     onjoin
   }: {
     space: SpaceCardSpaceFragment;
     joining?: boolean;
     joined?: boolean;
     href?: string;
-    /** Instance hostname shown below the space name in multi-instance views. */
-    instanceName?: string;
+    /** Instance ID shown as an InstancePill below the space name in multi-instance views. */
+    instanceId?: string;
     onjoin?: () => void;
   } = $props();
 
@@ -110,10 +111,12 @@
 
   <!-- Content area -->
   <div class="flex flex-1 flex-col p-4 pt-8">
-    <h3 class="font-semibold text-text">{space.name}</h3>
-    {#if instanceName}
-      <p class="text-xs text-muted">{instanceName}</p>
+    {#if instanceId}
+      <div class="-ml-1 mb-1">
+        <InstancePill instanceId={instanceId} />
+      </div>
     {/if}
+    <h3 class="font-semibold text-text">{space.name}</h3>
 
     {#if space.description}
       <p class="mt-1 line-clamp-2 text-sm text-muted">{space.description}</p>

--- a/frontend/src/lib/dm/DMConversationList.svelte
+++ b/frontend/src/lib/dm/DMConversationList.svelte
@@ -13,6 +13,7 @@
   } from '$lib/gql/graphql';
   import { DM_SPACE_ID } from '$lib/constants';
   import UserAvatar from '$lib/components/UserAvatar.svelte';
+  import InstancePill from '$lib/components/InstancePill.svelte';
   import UnreadDot from '$lib/ui/UnreadDot.svelte';
   import { getLiveDisplayName } from '$lib/state/userProfiles.svelte';
   import { SvelteSet } from 'svelte/reactivity';
@@ -258,12 +259,10 @@
           {/if}
         </div>
 
-        <div class="flex min-w-0 flex-1 flex-col">
+        <div class="flex min-w-0 flex-1 flex-col gap-1">
           <span class="truncate">{getConversationDisplayName(conv)}</span>
           {#if multiInstance}
-            <span class="truncate text-xs text-muted" title={conv.instanceLabel}>
-              {conv.instanceLabel}
-            </span>
+            <InstancePill instanceId={conv.instanceId} />
           {/if}
         </div>
 

--- a/frontend/src/lib/ui/Pill.svelte
+++ b/frontend/src/lib/ui/Pill.svelte
@@ -16,13 +16,14 @@ clickable toggleable variants use `<ToggleChip>`.
 <script lang="ts">
   import type { Snippet } from 'svelte';
 
-  type Tone = 'success' | 'danger' | 'primary' | 'accent' | 'muted';
+  type Tone = 'success' | 'danger' | 'primary' | 'accent' | 'muted' | 'subtle' | 'instance';
 
   let {
     children,
     tone = 'muted',
     dimmed = false,
-    title
+    title,
+    class: className
   }: {
     children: Snippet;
     /** Color tone of the pill. */
@@ -34,6 +35,12 @@ clickable toggleable variants use `<ToggleChip>`.
     dimmed?: boolean;
     /** Native title attribute for hover hints. */
     title?: string;
+    /**
+     * Additional layout classes for the pill itself (e.g. `flex min-w-0
+     * max-w-full` to make it shrink-friendly inside a constrained flex
+     * parent so its content can truncate based on container width).
+     */
+    class?: string;
   } = $props();
 
   const toneClasses: Record<Tone, string> = {
@@ -41,7 +48,9 @@ clickable toggleable variants use `<ToggleChip>`.
     danger: 'bg-danger/10 text-danger',
     primary: 'bg-primary/10 text-primary',
     accent: 'bg-accent/10 text-accent',
-    muted: 'bg-surface-200 text-muted'
+    muted: 'bg-surface-200 text-muted',
+    subtle: 'bg-text/5 text-muted ring-1 ring-text/10 shadow-xs shadow-text/5',
+    instance: 'bg-instance/10 text-instance'
   };
 </script>
 
@@ -50,7 +59,8 @@ clickable toggleable variants use `<ToggleChip>`.
   class={[
     'inline-block rounded px-2 py-0.5 text-xs font-medium',
     toneClasses[tone],
-    dimmed ? 'opacity-50 line-through' : ''
+    dimmed ? 'opacity-50 line-through' : '',
+    className
   ]}
 >
   {@render children()}


### PR DESCRIPTION
## Summary

Introduces a reusable `InstancePill` for surfaces that mention a specific Chatto instance. It renders a subtle pill (globe icon + truncated name) and reveals a hover card with the instance's branding (icon, OG image, motd/welcome message) — all from data already prefetched per-instance, so no extra round trips. Adopted in the DM conversation list and the Browse Spaces grid (`SpaceCard`); self-hides when only one instance is connected so callers can drop it in without their own gating. Also extends `Pill` with `subtle` and `instance` tones plus an optional `class` prop, and adds a reusable `--color-instance` theme token (indigo) for future cross-instance UI.

## Test plan

- [x] `pnpm test:unit` — new `InstancePill.svelte.spec.ts` covers the single-instance hide gate and basic rendering; full client suite (695 tests) green.
- [ ] Manually verify in a multi-instance dev session: pill renders in DM list and Browse Spaces, hover card opens with a small delay before closing, and the pill disappears entirely when disconnecting back to a single instance.