### PR TITLE
ci: cap Playwright install at 5 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
 
       - name: Install Playwright dependencies
         run: cd frontend && pnpm exec playwright install chromium --with-deps
+        timeout-minutes: 5
 
       - name: Run frontend unit tests
         run: cd frontend && pnpm vitest --run
@@ -104,6 +105,7 @@ jobs:
 
       - name: Install Playwright dependencies
         run: cd frontend && pnpm exec playwright install chromium --with-deps
+        timeout-minutes: 5
 
       - name: Build E2E server
         run: cd cli && go build -tags test_endpoints -o ../frontend/e2e/fixtures/bin/chatto .


### PR DESCRIPTION
## Why

Two consecutive CI runs on #207 hung for ~30 minutes in `Install Playwright dependencies` (`test-frontend-unit` job, both runs) before being cancelled by hand. The hang was inside apt-get retrying \`azure.archive.ubuntu.com\` mirror endpoints that were returning \`Ign:\` responses. A healthy install of this step completes in well under a minute.

## Change

Add \`timeout-minutes: 5\` to both copies of the step (in the unit-test job and the e2e job). Five minutes is generous for a healthy run and gives flaky-mirror cases a fast fail so the next push retries on a fresh runner instead of waiting for someone to notice and cancel.

## Test plan
- [ ] CI runs as normal when mirrors are healthy (under-a-minute install)
- [ ] If a flaky mirror situation happens again, the step fails after 5 minutes instead of hanging