### PR TITLE
chore: drop chatto-instance- compose project prefix

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,5 +1,5 @@
 {
     "scripts": {
-        "run": "echo \"Starting on https://chatto-instance-$CONDUCTOR_WORKSPACE_NAME.orb.local/\" && trap 'docker compose -p chatto-instance-$CONDUCTOR_WORKSPACE_NAME down' EXIT INT TERM && docker compose -p chatto-instance-$CONDUCTOR_WORKSPACE_NAME up"
+        "run": "echo \"Starting on https://$CONDUCTOR_WORKSPACE_NAME.orb.local/\" && trap 'docker compose down' EXIT INT TERM && docker compose up"
     }
 }


### PR DESCRIPTION
## Summary
- Remove the explicit `-p chatto-instance-$CONDUCTOR_WORKSPACE_NAME` flag from `docker compose up`/`down` in `conductor.json` so the project name derives from the workspace directory.
- Update the startup echo URL to match (`$CONDUCTOR_WORKSPACE_NAME.orb.local`).

## Test plan
- [ ] Launch a Conductor workspace and confirm the stack comes up at `https://<workspace>.orb.local/`.