### PR TITLE
feat(frontend): restructure reply preview and edited marker on messages

### DIFF
--- a/frontend/src/lib/components/MessageContent.svelte
+++ b/frontend/src/lib/components/MessageContent.svelte
@@ -14,10 +14,12 @@
   let {
     body,
     members = [],
+    edited = false,
     onMentionClick
   }: {
     body: string;
     members?: RoomMember[];
+    edited?: boolean;
     onMentionClick?: (userId: string, anchorRect: DOMRect) => void;
   } = $props();
 
@@ -29,10 +31,33 @@
     // Context not available - self-mention highlighting won't work
   }
 
+  function injectEditedMarker(html: string): string {
+    const doc = new DOMParser().parseFromString(`<div>${html}</div>`, 'text/html');
+    const root = doc.body.firstElementChild;
+    if (!root) return html;
+    const badge = doc.createElement('span');
+    badge.className = 'edited-marker text-xs whitespace-nowrap text-muted/70';
+    badge.textContent = '(edited)';
+    // Only inline the marker into a trailing <p> so it flows with the last word.
+    // For block-level last children (<pre>, <ul>, <blockquote>) fall back to a
+    // separate trailing line so the marker doesn't get clipped or look misplaced.
+    const last = root.lastElementChild;
+    if (last && last.tagName === 'P') {
+      last.appendChild(doc.createTextNode(' '));
+      last.appendChild(badge);
+    } else {
+      const trailer = doc.createElement('p');
+      trailer.appendChild(badge);
+      root.appendChild(trailer);
+    }
+    return root.innerHTML;
+  }
+
   // Render markdown then wrap valid mentions
-  async function render(body: string, members: RoomMember[]): Promise<string> {
+  async function render(body: string, members: RoomMember[], edited: boolean): Promise<string> {
     const html = await renderMd(body);
-    return wrapValidMentions(html, members, currentUser?.user?.login);
+    const wrapped = wrapValidMentions(html, members, currentUser?.user?.login);
+    return edited ? injectEditedMarker(wrapped) : wrapped;
   }
 
   // Handle clicks on links (open in system browser) and mentions (trigger callback).
@@ -72,7 +97,7 @@
 </script>
 
 <div class="prose max-w-none min-w-0" role="presentation" onclick={handleContentClick}>
-  {#await render(body, members)}
+  {#await render(body, members, edited)}
     <!-- Show escaped body while loading -->
     <!-- eslint-disable-next-line svelte/no-at-html-tags -->
     {@html body.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}

--- a/frontend/src/routes/chat/[instanceId]/[spaceId]/[roomId]/MessageEvent.svelte
+++ b/frontend/src/routes/chat/[instanceId]/[spaceId]/[roomId]/MessageEvent.svelte
@@ -613,44 +613,10 @@
             >
               {timestamp}
             </a>
-
-            {#if replyPreview}
-              <span class="shrink-0 text-xs leading-none text-muted/50">&middot;</span>
-              <!-- svelte-ignore a11y_no_static_element_interactions -->
-              <!-- svelte-ignore a11y_click_events_have_key_events -->
-              <div
-                data-testid="reply-attribution"
-                class="flex min-w-0 cursor-pointer items-center gap-1 text-xs leading-none text-muted hover:text-text"
-                onclick={scrollToReplyTarget}
-                onmousedown={(e) => e.stopPropagation()}
-              >
-                <span class="shrink-0">in reply to</span>
-                {#if replyPreview.actor}
-                  <button
-                    type="button"
-                    data-testid="reply-attribution-author"
-                    class="flex shrink-0 cursor-pointer items-center gap-1 hover:underline"
-                    onclick={(e) => {
-                      e.stopPropagation();
-                      showPopoverForReplyAuthor(e);
-                    }}
-                  >
-                    <UserAvatar user={replyPreview.actor} size="xs" showPresence={false} />
-                    <strong class="font-medium">{replyPreview.name}</strong>
-                  </button>
-                {:else}
-                  <div class="skeleton h-5 w-5 shrink-0 rounded-full"></div>
-                  <strong class="shrink-0 font-medium">{replyPreview.name}</strong>
-                {/if}
-                {#if replyPreview.body}<span class="min-w-0 truncate opacity-70"
-                    >{replyPreview.body.length > 80
-                      ? replyPreview.body.slice(0, 80) + '…'
-                      : replyPreview.body}</span
-                  >{/if}
-              </div>
-            {/if}
           </div>
-        {:else if replyPreview}
+        {/if}
+
+        {#if replyPreview}
           <!-- svelte-ignore a11y_no_static_element_interactions -->
           <!-- svelte-ignore a11y_click_events_have_key_events -->
           <div
@@ -674,13 +640,12 @@
                 <strong class="font-medium">{replyPreview.name}</strong>
               </button>
             {:else}
+              <div class="skeleton h-5 w-5 shrink-0 rounded-full"></div>
               <strong class="shrink-0 font-medium">{replyPreview.name}</strong>
             {/if}
-            {#if replyPreview.body}<span class="min-w-0 truncate opacity-70"
-                >{replyPreview.body.length > 80
-                  ? replyPreview.body.slice(0, 80) + '…'
-                  : replyPreview.body}</span
-              >{/if}
+            {#if replyPreview.body}
+              <span class="min-w-0 truncate opacity-70">{replyPreview.body}</span>
+            {/if}
           </div>
         {/if}
 
@@ -690,11 +655,13 @@
           <span class="text-muted/50">[Message deleted]</span>
         {:else if msg.body}
           <div class="pointer-fine:select-text">
-            <MessageContent body={msg.body} {members} onMentionClick={showPopoverForMember} />
+            <MessageContent
+              body={msg.body}
+              {members}
+              edited={isEdited}
+              onMentionClick={showPopoverForMember}
+            />
           </div>
-          {#if isEdited}
-            <span class="text-xs text-muted/70">(edited)</span>
-          {/if}
         {/if}
 
         <!-- Message attachments -->


### PR DESCRIPTION
## Summary

- Move the "in reply to ..." byline out of the author/timestamp row onto its own line above the message body, giving it the full content-column width.
- Drop the 80-character JS truncation on the reply body so it can use the full available width before CSS `truncate` ellipses it.
- Render the "(edited)" indicator inline at the end of the last paragraph so it flows with the final word; fall back to a trailing line when the last block is a code fence, list, or blockquote.

## Test plan

- [ ] Send a message replying to another — reply byline appears on its own line above the body, truncates only when it actually overflows.
- [ ] Edit a single-paragraph message — "(edited)" appears inline next to the last word.
- [ ] Edit a message ending in a code fence / list / blockquote — "(edited)" falls back to a trailing line.
- [ ] Resize the room column wider/narrower — reply preview body grows/shrinks accordingly.