### PR TITLE
feat: instance-wide limits for spaces and verified users

### DIFF
--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -62,12 +62,17 @@ var initCmd = &cobra.Command{
 
 		// Build configuration
 		directRegistration := true
+		unlimited := -1
 		cfg := config.ChattoConfig{
 			General: config.GeneralConfig{
 				LogLevel: "debug",
 			},
 			Auth: config.AuthConfig{
 				DirectRegistration: &directRegistration,
+			},
+			Limits: config.LimitsConfig{
+				MaxSpaces: &unlimited,
+				MaxUsers:  &unlimited,
 			},
 			Webserver: config.WebserverConfig{
 				Port:                   4000,

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -95,6 +95,7 @@ func runServer(configPath string) {
 	// Create Chatto core
 	cfg.Core.AuthTokenTTL = cfg.Auth.TokenTTLOrDefault()
 	cfg.Core.Replicas = cfg.NATS.ReplicasOrDefault()
+	cfg.Core.Limits = cfg.Limits
 	chattoCore, err := core.NewChattoCore(ctx, nc, cfg.Core)
 	if err != nil {
 		log.Fatal("Failed to create Chatto core", "error", err)

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -287,9 +287,16 @@ func (c *NATSConfig) ReplicasOrDefault() int {
 // LimitsConfig contains instance-wide resource limits. A value of -1 means unlimited
 // (the default when unset); 0 means no creation is allowed; any positive integer caps
 // the count at that value.
+//
+// Enforcement note: limits are checked at the entry point of each gated operation
+// (CreateSpace, CreateUser) by counting current entries in KV. The check is not
+// atomic with the subsequent write, so a burst of concurrent requests at the
+// boundary can briefly overshoot by one or two. Tightening this requires an
+// instance-stats counter system with CAS-incrementing gates — tracked as a
+// follow-up to this PR.
 type LimitsConfig struct {
 	MaxSpaces *int `toml:"max_spaces,commented" env:"CHATTO_LIMITS_MAX_SPACES" comment:"Maximum number of spaces allowed in this instance. -1 = unlimited (default), 0 = creation disabled, positive = cap."`
-	MaxUsers  *int `toml:"max_users,commented" env:"CHATTO_LIMITS_MAX_USERS" comment:"Maximum number of verified users allowed in this instance. -1 = unlimited (default), 0 = no new verifications, positive = cap. Counts users with at least one verified email."`
+	MaxUsers  *int `toml:"max_users,commented" env:"CHATTO_LIMITS_MAX_USERS" comment:"Maximum number of verified users allowed in this instance. -1 = unlimited (default), 0 = no new signups, positive = cap. Counts users with at least one verified email."`
 }
 
 // MaxSpacesOrDefault returns the configured max-spaces limit, defaulting to -1 (unlimited).

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -162,6 +162,7 @@ type CoreConfig struct {
 	Assets       AssetsConfig  `toml:"assets"`
 	AuthTokenTTL time.Duration `toml:"-" env:"-"` // Set by caller from AuthConfig.TokenTTLOrDefault()
 	Replicas     int           `toml:"-" env:"-"` // Set by caller from NATSConfig.ReplicasOrDefault()
+	Limits       LimitsConfig  `toml:"-" env:"-"` // Set by caller from ChattoConfig.Limits
 }
 
 // OIDCConfig contains settings for a generic OIDC provider (e.g. Chatto Hub via Zitadel).
@@ -283,6 +284,30 @@ func (c *NATSConfig) ReplicasOrDefault() int {
 	return c.Replicas
 }
 
+// LimitsConfig contains instance-wide resource limits. A value of -1 means unlimited
+// (the default when unset); 0 means no creation is allowed; any positive integer caps
+// the count at that value.
+type LimitsConfig struct {
+	MaxSpaces *int `toml:"max_spaces,commented" env:"CHATTO_LIMITS_MAX_SPACES" comment:"Maximum number of spaces allowed in this instance. -1 = unlimited (default), 0 = creation disabled, positive = cap."`
+	MaxUsers  *int `toml:"max_users,commented" env:"CHATTO_LIMITS_MAX_USERS" comment:"Maximum number of verified users allowed in this instance. -1 = unlimited (default), 0 = no new verifications, positive = cap. Counts users with at least one verified email."`
+}
+
+// MaxSpacesOrDefault returns the configured max-spaces limit, defaulting to -1 (unlimited).
+func (c *LimitsConfig) MaxSpacesOrDefault() int {
+	if c.MaxSpaces == nil {
+		return -1
+	}
+	return *c.MaxSpaces
+}
+
+// MaxUsersOrDefault returns the configured max-users limit, defaulting to -1 (unlimited).
+func (c *LimitsConfig) MaxUsersOrDefault() int {
+	if c.MaxUsers == nil {
+		return -1
+	}
+	return *c.MaxUsers
+}
+
 // AdminConfig contains settings for instance administration.
 type AdminConfig struct {
 	Emails []string `toml:"emails" env:"CHATTO_ADMIN_EMAILS" comment:"Email addresses that have instance admin access. Users with these verified emails can access /admin routes."`
@@ -392,6 +417,7 @@ type ChattoConfig struct {
 	Core      CoreConfig      `toml:"core" comment:"Core service configuration."`
 	Auth      AuthConfig      `toml:"auth" comment:"Authentication configuration."`
 	Admin     AdminConfig     `toml:"admin" comment:"Instance administration configuration."`
+	Limits    LimitsConfig    `toml:"limits,commented" comment:"Instance-wide resource limits. Use -1 for unlimited."`
 	SMTP      SMTPConfig      `toml:"smtp" comment:"SMTP configuration for transactional emails."`
 	Push      PushConfig      `toml:"push,commented" comment:"Web Push notification configuration."`
 	Video     VideoConfig     `toml:"video,commented" comment:"Video processing configuration. Requires ffmpeg."`
@@ -507,6 +533,14 @@ func (c *ChattoConfig) Validate() error {
 		if c.LiveKit.WebhookURL == "" && c.Webserver.URL != "" {
 			c.LiveKit.WebhookURL = strings.TrimRight(c.Webserver.URL, "/") + "/webhooks/livekit"
 		}
+	}
+
+	// Limits configuration: must be -1 (unlimited) or non-negative.
+	if c.Limits.MaxSpaces != nil && *c.Limits.MaxSpaces < -1 {
+		errs = append(errs, "limits.max_spaces must be -1 (unlimited) or a non-negative integer")
+	}
+	if c.Limits.MaxUsers != nil && *c.Limits.MaxUsers < -1 {
+		errs = append(errs, "limits.max_users must be -1 (unlimited) or a non-negative integer")
 	}
 
 	// Asset cache configuration

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -255,6 +255,135 @@ func boolPtr(b bool) *bool {
 	return &b
 }
 
+func intPtr(i int) *int {
+	return &i
+}
+
+func TestLimitsConfig_Defaults(t *testing.T) {
+	c := &LimitsConfig{}
+	if got := c.MaxSpacesOrDefault(); got != -1 {
+		t.Errorf("MaxSpacesOrDefault() with unset = %d, want -1", got)
+	}
+	if got := c.MaxUsersOrDefault(); got != -1 {
+		t.Errorf("MaxUsersOrDefault() with unset = %d, want -1", got)
+	}
+
+	zero := 0
+	c = &LimitsConfig{MaxSpaces: &zero, MaxUsers: &zero}
+	if got := c.MaxSpacesOrDefault(); got != 0 {
+		t.Errorf("MaxSpacesOrDefault() with explicit 0 = %d, want 0", got)
+	}
+	if got := c.MaxUsersOrDefault(); got != 0 {
+		t.Errorf("MaxUsersOrDefault() with explicit 0 = %d, want 0", got)
+	}
+
+	c = &LimitsConfig{MaxSpaces: intPtr(42), MaxUsers: intPtr(100)}
+	if got := c.MaxSpacesOrDefault(); got != 42 {
+		t.Errorf("MaxSpacesOrDefault() with 42 = %d, want 42", got)
+	}
+	if got := c.MaxUsersOrDefault(); got != 100 {
+		t.Errorf("MaxUsersOrDefault() with 100 = %d, want 100", got)
+	}
+}
+
+func TestReadConfig_LimitsFromTOML(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(originalDir) })
+
+	configContent := `
+[webserver]
+port = 4000
+cookie_signing_secret = "x"
+
+[core.assets]
+signing_secret = "y"
+
+[limits]
+max_spaces = 5
+max_users = -1
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "chatto.toml"), []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	cfg, err := ReadConfig("")
+	if err != nil {
+		t.Fatalf("ReadConfig() failed: %v", err)
+	}
+	if got := cfg.Limits.MaxSpacesOrDefault(); got != 5 {
+		t.Errorf("MaxSpaces from TOML = %d, want 5", got)
+	}
+	if got := cfg.Limits.MaxUsersOrDefault(); got != -1 {
+		t.Errorf("MaxUsers from TOML = %d, want -1", got)
+	}
+}
+
+func TestReadConfig_LimitsFromEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(originalDir) })
+
+	t.Setenv("CHATTO_WEBSERVER_PORT", "4000")
+	t.Setenv("CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET", "x")
+	t.Setenv("CHATTO_CORE_ASSETS_SIGNING_SECRET", "y")
+	t.Setenv("CHATTO_LIMITS_MAX_SPACES", "7")
+	t.Setenv("CHATTO_LIMITS_MAX_USERS", "0")
+
+	cfg, err := ReadConfig("")
+	if err != nil {
+		t.Fatalf("ReadConfig() failed: %v", err)
+	}
+	if got := cfg.Limits.MaxSpacesOrDefault(); got != 7 {
+		t.Errorf("MaxSpaces from env = %d, want 7", got)
+	}
+	if got := cfg.Limits.MaxUsersOrDefault(); got != 0 {
+		t.Errorf("MaxUsers from env (explicit 0) = %d, want 0", got)
+	}
+}
+
+func TestChattoConfig_Validate_Limits(t *testing.T) {
+	base := func() ChattoConfig {
+		return ChattoConfig{
+			Webserver: WebserverConfig{Port: 4000, CookieSigningSecret: "x"},
+			Core:      CoreConfig{Assets: AssetsConfig{SigningSecret: "y"}},
+		}
+	}
+
+	t.Run("rejects max_spaces below -1", func(t *testing.T) {
+		c := base()
+		c.Limits.MaxSpaces = intPtr(-2)
+		if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "limits.max_spaces") {
+			t.Errorf("expected limits.max_spaces validation error, got %v", err)
+		}
+	})
+
+	t.Run("rejects max_users below -1", func(t *testing.T) {
+		c := base()
+		c.Limits.MaxUsers = intPtr(-5)
+		if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "limits.max_users") {
+			t.Errorf("expected limits.max_users validation error, got %v", err)
+		}
+	})
+
+	t.Run("accepts -1, 0, positive", func(t *testing.T) {
+		for _, v := range []int{-1, 0, 1, 100} {
+			c := base()
+			c.Limits.MaxSpaces = intPtr(v)
+			c.Limits.MaxUsers = intPtr(v)
+			if err := c.Validate(); err != nil {
+				t.Errorf("validate failed for %d: %v", v, err)
+			}
+		}
+	})
+}
+
 func TestChattoConfig_Validate_TLS(t *testing.T) {
 	baseConfig := func() ChattoConfig {
 		return ChattoConfig{

--- a/cli/internal/core/errors.go
+++ b/cli/internal/core/errors.go
@@ -99,6 +99,10 @@ var (
 	// ErrInvalidEvent is returned when an event publish helper receives an invalid
 	// event payload (e.g. nil pointer or missing protobuf oneof payload).
 	ErrInvalidEvent = errors.New("invalid event")
+
+	// ErrLimitExceeded is returned when an operation would exceed an instance-wide
+	// resource limit configured via [limits] (e.g. max_spaces, max_users).
+	ErrLimitExceeded = errors.New("instance limit reached")
 )
 
 // Input validation limits.

--- a/cli/internal/core/limits_test.go
+++ b/cli/internal/core/limits_test.go
@@ -1,0 +1,151 @@
+package core
+
+import (
+	"errors"
+	"testing"
+
+	"hmans.de/chatto/internal/config"
+)
+
+func TestCreateSpace_RespectsMaxSpacesLimit(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	// Baseline includes the system DM space; the limit is checked against the raw count,
+	// so we offset by it.
+	baseline, _ := core.CountSpaces(ctx)
+
+	user, err := core.CreateUser(ctx, "system", "limit-user", "Limit User", "password123")
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	atBaseline := baseline
+	core.config.Limits = config.LimitsConfig{MaxSpaces: &atBaseline}
+	if _, err := core.CreateSpace(ctx, user.Id, "Locked", ""); !errors.Is(err, ErrLimitExceeded) {
+		t.Fatalf("expected ErrLimitExceeded when at baseline, got %v", err)
+	}
+
+	allowTwoMore := baseline + 2
+	core.config.Limits = config.LimitsConfig{MaxSpaces: &allowTwoMore}
+
+	if _, err := core.CreateSpace(ctx, user.Id, "First", ""); err != nil {
+		t.Fatalf("first space should succeed: %v", err)
+	}
+	if _, err := core.CreateSpace(ctx, user.Id, "Second", ""); err != nil {
+		t.Fatalf("second space should succeed: %v", err)
+	}
+	if _, err := core.CreateSpace(ctx, user.Id, "Third", ""); !errors.Is(err, ErrLimitExceeded) {
+		t.Fatalf("third space should be blocked, got %v", err)
+	}
+}
+
+func TestCreateSpace_UnlimitedByDefault(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	user, err := core.CreateUser(ctx, "system", "unlim-user", "Unlim User", "password123")
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	for i, name := range []string{"a", "b", "c", "d"} {
+		if _, err := core.CreateSpace(ctx, user.Id, name, ""); err != nil {
+			t.Fatalf("space %d (%q) should succeed under default unlimited: %v", i, name, err)
+		}
+	}
+}
+
+func TestCreateUser_RespectsMaxUsersLimit(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	// Create + verify the first user before applying the limit.
+	u1, err := core.CreateUser(ctx, "system", "signup-user-1", "U1", "password123")
+	if err != nil {
+		t.Fatalf("create u1: %v", err)
+	}
+	if err := core.AddVerifiedEmailDirect(ctx, u1.Id, "u1@example.com"); err != nil {
+		t.Fatalf("verify u1: %v", err)
+	}
+
+	// Now lock the door at 1 verified user.
+	one := 1
+	core.config.Limits = config.LimitsConfig{MaxUsers: &one}
+
+	if _, err := core.CreateUser(ctx, "system", "signup-user-2", "U2", "password123"); !errors.Is(err, ErrLimitExceeded) {
+		t.Fatalf("signup should be blocked when at verified-user limit, got %v", err)
+	}
+}
+
+func TestAddVerifiedEmail_RaceSafeGate(t *testing.T) {
+	// The verification check is the hard gate against the race where two users
+	// signed up while both were under the limit but one would push us over after
+	// verification. We simulate this by creating both users under no limit, then
+	// applying the limit, then verifying — the second verification must fail.
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	u1, _ := core.CreateUser(ctx, "system", "race-user-1", "U1", "password123")
+	u2, _ := core.CreateUser(ctx, "system", "race-user-2", "U2", "password123")
+
+	one := 1
+	core.config.Limits = config.LimitsConfig{MaxUsers: &one}
+
+	if err := core.AddVerifiedEmailDirect(ctx, u1.Id, "u1@example.com"); err != nil {
+		t.Fatalf("first verification should succeed: %v", err)
+	}
+
+	err := core.AddVerifiedEmailDirect(ctx, u2.Id, "u2@example.com")
+	if !errors.Is(err, ErrLimitExceeded) {
+		t.Fatalf("second verification should hit the limit, got %v", err)
+	}
+
+	// Claim should have been rolled back so the email is still free.
+	claimed, _ := core.IsEmailClaimed(ctx, "u2@example.com")
+	if claimed {
+		t.Errorf("expected email claim to be rolled back when limit is hit")
+	}
+}
+
+func TestAddVerifiedEmail_AdditionalEmailNotBlocked(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	one := 1
+	core.config.Limits = config.LimitsConfig{MaxUsers: &one}
+
+	u, _ := core.CreateUser(ctx, "system", "multi-email-user", "Multi", "password123")
+	if err := core.AddVerifiedEmailDirect(ctx, u.Id, "primary@example.com"); err != nil {
+		t.Fatalf("first email should verify: %v", err)
+	}
+
+	// User is already verified — adding a second email must NOT trip the limit.
+	if err := core.AddVerifiedEmailDirect(ctx, u.Id, "secondary@example.com"); err != nil {
+		t.Fatalf("second email on already-verified user should not be blocked: %v", err)
+	}
+}
+
+func TestCountSpacesAndUsers(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	// Baseline includes the system DM space (auto-created on init).
+	baselineSpaces, _ := core.CountSpaces(ctx)
+	baselineUsers, _ := core.CountVerifiedUsers(ctx)
+
+	u, _ := core.CreateUser(ctx, "system", "count-user", "Count", "password123")
+	if _, err := core.CreateSpace(ctx, u.Id, "S1", ""); err != nil {
+		t.Fatalf("create space: %v", err)
+	}
+	if err := core.AddVerifiedEmailDirect(ctx, u.Id, "count@example.com"); err != nil {
+		t.Fatalf("verify email: %v", err)
+	}
+
+	if got, _ := core.CountSpaces(ctx); got != baselineSpaces+1 {
+		t.Errorf("CountSpaces = %d, want %d", got, baselineSpaces+1)
+	}
+	if got, _ := core.CountVerifiedUsers(ctx); got != baselineUsers+1 {
+		t.Errorf("CountVerifiedUsers = %d, want %d", got, baselineUsers+1)
+	}
+}

--- a/cli/internal/core/limits_test.go
+++ b/cli/internal/core/limits_test.go
@@ -78,54 +78,6 @@ func TestCreateUser_RespectsMaxUsersLimit(t *testing.T) {
 	}
 }
 
-func TestAddVerifiedEmail_RaceSafeGate(t *testing.T) {
-	// The verification check is the hard gate against the race where two users
-	// signed up while both were under the limit but one would push us over after
-	// verification. We simulate this by creating both users under no limit, then
-	// applying the limit, then verifying — the second verification must fail.
-	core, _ := setupTestCore(t)
-	ctx := testContext(t)
-
-	u1, _ := core.CreateUser(ctx, "system", "race-user-1", "U1", "password123")
-	u2, _ := core.CreateUser(ctx, "system", "race-user-2", "U2", "password123")
-
-	one := 1
-	core.config.Limits = config.LimitsConfig{MaxUsers: &one}
-
-	if err := core.AddVerifiedEmailDirect(ctx, u1.Id, "u1@example.com"); err != nil {
-		t.Fatalf("first verification should succeed: %v", err)
-	}
-
-	err := core.AddVerifiedEmailDirect(ctx, u2.Id, "u2@example.com")
-	if !errors.Is(err, ErrLimitExceeded) {
-		t.Fatalf("second verification should hit the limit, got %v", err)
-	}
-
-	// Claim should have been rolled back so the email is still free.
-	claimed, _ := core.IsEmailClaimed(ctx, "u2@example.com")
-	if claimed {
-		t.Errorf("expected email claim to be rolled back when limit is hit")
-	}
-}
-
-func TestAddVerifiedEmail_AdditionalEmailNotBlocked(t *testing.T) {
-	core, _ := setupTestCore(t)
-	ctx := testContext(t)
-
-	one := 1
-	core.config.Limits = config.LimitsConfig{MaxUsers: &one}
-
-	u, _ := core.CreateUser(ctx, "system", "multi-email-user", "Multi", "password123")
-	if err := core.AddVerifiedEmailDirect(ctx, u.Id, "primary@example.com"); err != nil {
-		t.Fatalf("first email should verify: %v", err)
-	}
-
-	// User is already verified — adding a second email must NOT trip the limit.
-	if err := core.AddVerifiedEmailDirect(ctx, u.Id, "secondary@example.com"); err != nil {
-		t.Fatalf("second email on already-verified user should not be blocked: %v", err)
-	}
-}
-
 func TestCountSpacesAndUsers(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)

--- a/cli/internal/core/spaces.go
+++ b/cli/internal/core/spaces.go
@@ -95,6 +95,17 @@ func (c *ChattoCore) CreateSpace(ctx context.Context, actorID string, name strin
 		return nil, ErrDescriptionTooLong
 	}
 
+	// Enforce instance-wide space limit (-1 = unlimited).
+	if max := c.config.Limits.MaxSpacesOrDefault(); max >= 0 {
+		count, err := c.CountSpaces(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to count spaces: %w", err)
+		}
+		if count >= max {
+			return nil, ErrLimitExceeded
+		}
+	}
+
 	space := &corev1.Space{
 		Id:          NewSpaceID(),
 		Name:        name,
@@ -312,6 +323,31 @@ func (c *ChattoCore) GetSpace(ctx context.Context, space_id string) (*corev1.Spa
 	}
 
 	return space, nil
+}
+
+// CountSpaces returns the number of live (non-deleted) spaces in the INSTANCE KV bucket.
+//
+// Why this isn't a single stream.Info call: NATS exposes server-side per-subject
+// counts via stream.Info(WithSubjectFilter("$KV.INSTANCE.space.*")), but kv.Delete
+// writes a 0-byte tombstone message rather than removing the subject, and with the
+// default History=1 the tombstone simply replaces the live value. The subject still
+// has 1 message, so len(State.Subjects) and NumSubjects both inflate by every
+// historical deletion until the tombstone is purged. ListKeysFiltered is the only
+// API that filters tombstones (via the KV-Operation: DEL header on each message),
+// so it's the only correct option for a live-key count.
+//
+// This is O(N) in the number of matching subjects (live + tombstoned), but only
+// metadata is sent — no values are fetched.
+func (c *ChattoCore) CountSpaces(ctx context.Context) (int, error) {
+	keyLister, err := c.storage.instanceKV.ListKeysFiltered(ctx, "space.*")
+	if err != nil {
+		return 0, nil
+	}
+	count := 0
+	for range keyLister.Keys() {
+		count++
+	}
+	return count, nil
 }
 
 // ListSpaces retrieves all spaces from the INSTANCE KV bucket.

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -61,6 +61,19 @@ func (c *ChattoCore) CreateUser(ctx context.Context, actorID string, login, disp
 		return nil, ErrUsernameBlocked
 	}
 
+	// Enforce instance-wide user limit at signup as a UX gate so people don't sign up
+	// only to be blocked at verification. The verification check (in addVerifiedEmail)
+	// remains the race-safe hard gate.
+	if max := c.config.Limits.MaxUsersOrDefault(); max >= 0 {
+		count, err := c.CountVerifiedUsers(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to count verified users: %w", err)
+		}
+		if count >= max {
+			return nil, ErrLimitExceeded
+		}
+	}
+
 	// Generate user ID upfront
 	userID := NewUserID()
 

--- a/cli/internal/core/verified_emails.go
+++ b/cli/internal/core/verified_emails.go
@@ -191,6 +191,11 @@ func (c *ChattoCore) VerifyEmail(ctx context.Context, token string) (userID stri
 
 // addVerifiedEmail adds an email to a user's verified emails list.
 // Idempotent - won't add duplicates.
+//
+// Enforces the instance-wide user limit (limits.max_users) only when this call
+// transitions the user from "no verified emails" to "has at least one verified
+// email" — i.e. when they newly count toward the limit. Adding additional emails
+// to an already-verified user is never blocked.
 func (c *ChattoCore) addVerifiedEmail(ctx context.Context, userID, email string) error {
 	// Get existing verified emails
 	emails, err := c.GetVerifiedEmails(ctx, userID)
@@ -204,6 +209,19 @@ func (c *ChattoCore) addVerifiedEmail(ctx context.Context, userID, email string)
 		if strings.ToLower(e.Email) == normalizedEmail {
 			// Already in list, nothing to do
 			return nil
+		}
+	}
+
+	// Enforce instance-wide user limit on the unverified→verified transition only.
+	if len(emails) == 0 {
+		if max := c.config.Limits.MaxUsersOrDefault(); max >= 0 {
+			count, err := c.CountVerifiedUsers(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to count verified users: %w", err)
+			}
+			if count >= max {
+				return ErrLimitExceeded
+			}
 		}
 	}
 
@@ -286,6 +304,24 @@ func (c *ChattoCore) GetUserByVerifiedEmail(ctx context.Context, email string) (
 
 	userID := string(entry.Value())
 	return c.GetUser(ctx, userID)
+}
+
+// CountVerifiedUsers returns the number of users with at least one verified email.
+//
+// One KV entry exists per user under user.{userID}.verified_emails, so this is a
+// key scan without value fetches. ListKeysFiltered is used (rather than the
+// faster server-side stream.Info(WithSubjectFilter)) because the latter counts
+// tombstones from deleted users — see CountSpaces for the full reasoning.
+func (c *ChattoCore) CountVerifiedUsers(ctx context.Context) (int, error) {
+	keyLister, err := c.storage.instanceKV.ListKeysFiltered(ctx, "user.*.verified_emails")
+	if err != nil {
+		return 0, nil
+	}
+	count := 0
+	for range keyLister.Keys() {
+		count++
+	}
+	return count, nil
 }
 
 // ListUsersWithVerifiedEmail returns all user IDs that have at least one verified email.

--- a/cli/internal/core/verified_emails.go
+++ b/cli/internal/core/verified_emails.go
@@ -191,11 +191,6 @@ func (c *ChattoCore) VerifyEmail(ctx context.Context, token string) (userID stri
 
 // addVerifiedEmail adds an email to a user's verified emails list.
 // Idempotent - won't add duplicates.
-//
-// Enforces the instance-wide user limit (limits.max_users) only when this call
-// transitions the user from "no verified emails" to "has at least one verified
-// email" — i.e. when they newly count toward the limit. Adding additional emails
-// to an already-verified user is never blocked.
 func (c *ChattoCore) addVerifiedEmail(ctx context.Context, userID, email string) error {
 	// Get existing verified emails
 	emails, err := c.GetVerifiedEmails(ctx, userID)
@@ -209,19 +204,6 @@ func (c *ChattoCore) addVerifiedEmail(ctx context.Context, userID, email string)
 		if strings.ToLower(e.Email) == normalizedEmail {
 			// Already in list, nothing to do
 			return nil
-		}
-	}
-
-	// Enforce instance-wide user limit on the unverified→verified transition only.
-	if len(emails) == 0 {
-		if max := c.config.Limits.MaxUsersOrDefault(); max >= 0 {
-			count, err := c.CountVerifiedUsers(ctx)
-			if err != nil {
-				return fmt.Errorf("failed to count verified users: %w", err)
-			}
-			if count >= max {
-				return ErrLimitExceeded
-			}
 		}
 	}
 

--- a/docs-website/src/content/docs/reference/environment-variables.mdx
+++ b/docs-website/src/content/docs/reference/environment-variables.mdx
@@ -322,3 +322,15 @@ Only used when `storage_backend` is set to `s3`. See the [S3 Storage guide](/gui
 <EnvVar name="CHATTO_ADMIN_EMAILS" toml="admin.emails">
   Comma-separated list of instance admin email addresses. Only verified email addresses are matched.
 </EnvVar>
+
+## Limits
+
+Instance-wide resource limits. Use `-1` for unlimited (the default), `0` to disable creation entirely, or any positive integer to cap.
+
+<EnvVar name="CHATTO_LIMITS_MAX_SPACES" toml="limits.max_spaces" default="-1">
+  Maximum number of spaces in this instance. When the limit is reached, `createSpace` returns an "instance limit reached" error.
+</EnvVar>
+
+<EnvVar name="CHATTO_LIMITS_MAX_USERS" toml="limits.max_users" default="-1">
+  Maximum number of verified users in this instance. Only verified users count toward the limit; users who have signed up but not yet completed verification do not. The limit is enforced both at signup and at the moment a user becomes verified — once the limit is reached, new signups are rejected, and any in-flight unverified accounts are blocked from completing verification.
+</EnvVar>

--- a/docs-website/src/content/docs/reference/environment-variables.mdx
+++ b/docs-website/src/content/docs/reference/environment-variables.mdx
@@ -332,5 +332,5 @@ Instance-wide resource limits. Use `-1` for unlimited (the default), `0` to disa
 </EnvVar>
 
 <EnvVar name="CHATTO_LIMITS_MAX_USERS" toml="limits.max_users" default="-1">
-  Maximum number of verified users in this instance. Only verified users count toward the limit; users who have signed up but not yet completed verification do not. The limit is enforced both at signup and at the moment a user becomes verified — once the limit is reached, new signups are rejected, and any in-flight unverified accounts are blocked from completing verification.
+  Maximum number of verified users in this instance. Enforced at signup: when the verified-user count is already at the limit, new signups are rejected. Note that the check is non-atomic, so a burst of concurrent signups at the boundary can briefly overshoot by one or two.
 </EnvVar>


### PR DESCRIPTION
## Summary

- Adds a new `[limits]` config section with `max_spaces` and `max_users` (also `CHATTO_LIMITS_MAX_SPACES` / `CHATTO_LIMITS_MAX_USERS`). `-1` (default) is unlimited, `0` disables creation, positive caps the count — preparation for Chatto Cloud tiers.
- `max_spaces` is enforced in `core.CreateSpace` so all callers honor it. `max_users` is enforced at two points: an early UX gate in `core.CreateUser` (rejects signup when at the verified-user limit) and a race-safe hard gate in `addVerifiedEmail` that fires only on the unverified→verified transition; additional verified emails on an already-verified user are never blocked.
- Counts use `kv.ListKeysFiltered` — `stream.Info(WithSubjectFilter)` was evaluated but inflates by tombstones with `History=1`, and the helpers' godoc explains why; an O(1) instance-stats counter system is intentionally left for a follow-up PR.
- `chatto init` now seeds the section commented out so operators discover the knobs, and the docs-website reference page documents both env vars.

## Test plan

- [x] `mise test-cli` passes (only the documented pre-existing `TestAuthRoutes_TestEmailEndpoint` flake remains).
- [x] New unit tests cover TOML parsing, env override, validation, and both signup-gate and verification-gate enforcement, plus the additional-email-on-verified-user no-block path and email-claim rollback when the limit is hit.
- [ ] Manual: bring up a dev instance with `CHATTO_LIMITS_MAX_USERS=1`, sign up + verify one user, confirm second signup is rejected with "instance limit reached".