### PR TITLE
style(frontend): restyle Jump to Present button to match menu system

### DIFF
--- a/frontend/src/routes/chat/[instanceId]/[spaceId]/[roomId]/EventList.svelte
+++ b/frontend/src/routes/chat/[instanceId]/[spaceId]/[roomId]/EventList.svelte
@@ -617,28 +617,32 @@
       transition:fade={{ duration: 150 }}
       onclick={onJumpToPresent}
       data-testid="jump-to-present"
-      class="absolute bottom-4 left-1/2 -translate-x-1/2 cursor-pointer whitespace-nowrap rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white shadow-lg hover:bg-primary/90"
+      class="menu absolute bottom-4 left-1/2 -translate-x-1/2 cursor-pointer whitespace-nowrap"
     >
-      {#if firstVisibleDate}
-        <span class="opacity-70">{firstVisibleDate}</span>
-        <span class="mx-1.5 opacity-40">|</span>
-      {/if}
-      Jump to Present
-      <span class="ml-1 iconify inline-block align-middle uil--arrow-down"></span>
+      <div class="menu-section flex items-center gap-2 px-3 py-1">
+        {#if firstVisibleDate}
+          <span class="text-muted">{firstVisibleDate}</span>
+          <span class="text-muted/40">|</span>
+        {/if}
+        <span>Jump to Present</span>
+        <span class="iconify uil--arrow-down"></span>
+      </div>
     </button>
   {:else if !alwaysScrollToBottom && !shouldScrollToBottom}
     <button
       transition:fade={{ duration: 150 }}
       onclick={scrollToBottom}
       data-testid="jump-to-present"
-      class="absolute bottom-4 left-1/2 -translate-x-1/2 cursor-pointer whitespace-nowrap rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white shadow-lg hover:bg-primary/90"
+      class="menu absolute bottom-4 left-1/2 -translate-x-1/2 cursor-pointer whitespace-nowrap"
     >
-      {#if firstVisibleDate}
-        <span class="opacity-70">{firstVisibleDate}</span>
-        <span class="mx-1.5 opacity-40">|</span>
-      {/if}
-      {hasNewMessages ? 'New messages' : 'Jump to Present'}
-      <span class="ml-1 iconify inline-block align-middle uil--arrow-down"></span>
+      <div class="menu-section flex items-center gap-2 px-3 py-1">
+        {#if firstVisibleDate}
+          <span class="text-muted">{firstVisibleDate}</span>
+          <span class="text-muted/40">|</span>
+        {/if}
+        <span>{hasNewMessages ? 'New messages' : 'Jump to Present'}</span>
+        <span class="iconify uil--arrow-down"></span>
+      </div>
     </button>
   {/if}
 </div>


### PR DESCRIPTION
## Summary
- Replace the solid primary-colored \"Jump to Present\" / \"New messages\" pill with the layered \`menu\` + \`menu-section\` look used by context menus, so the floating button sits more subtly over the message list.

## Test plan
- [ ] Scroll up in a room and verify the floating button appears with the new subtle styling in both light and dark mode
- [ ] Confirm the date prefix and label still render correctly, and clicking still scrolls to present