### PR TITLE
refactor: registration & verification cleanups

### DIFF
--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -428,6 +428,11 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		Description: "Instance-level data (users, spaces, memberships)",
 		Storage:     jetstream.FileStorage,
 		Replicas:    cfg.Replicas,
+		// Enables per-key TTL via jetstream.KeyTTL(...) on Create. Used for short-lived
+		// entries like registration tokens and email-verification tokens so they leave
+		// the bucket automatically. The duration is how long delete markers from
+		// TTL-expiry are kept before purging.
+		LimitMarkerTTL: 24 * time.Hour,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create INSTANCE KV bucket: %w", err)

--- a/cli/internal/core/registration.go
+++ b/cli/internal/core/registration.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/nats-io/nats.go/jetstream"
@@ -55,16 +54,18 @@ func registrationTokenKey(token string) string {
 
 // CreateRegistrationToken creates a new registration token for an email address.
 // The token is stored in instanceKV and can be used to complete account creation.
+//
+// Email is expected to already be normalized (trimmed, lowercased) by the caller —
+// the HTTP handlers do this at the request boundary.
 func (c *ChattoCore) CreateRegistrationToken(ctx context.Context, email string) (string, error) {
-	normalizedEmail := strings.ToLower(strings.TrimSpace(email))
-	if normalizedEmail == "" {
+	if email == "" {
 		return "", fmt.Errorf("email is required")
 	}
 
 	token := NewRegistrationToken()
 
 	tokenData := RegistrationToken{
-		Email:     normalizedEmail,
+		Email:     email,
 		CreatedAt: time.Now(),
 	}
 
@@ -73,7 +74,7 @@ func (c *ChattoCore) CreateRegistrationToken(ctx context.Context, email string) 
 		return "", fmt.Errorf("failed to marshal registration token: %w", err)
 	}
 
-	_, err = c.storage.instanceKV.Put(ctx, registrationTokenKey(token), data)
+	_, err = c.storage.instanceKV.Create(ctx, registrationTokenKey(token), data, jetstream.KeyTTL(RegistrationTokenTTL))
 	if err != nil {
 		return "", fmt.Errorf("failed to store registration token: %w", err)
 	}

--- a/cli/internal/core/registration_test.go
+++ b/cli/internal/core/registration_test.go
@@ -26,8 +26,10 @@ func TestChattoCore_CreateRegistrationToken(t *testing.T) {
 		}
 	})
 
-	t.Run("normalizes email to lowercase", func(t *testing.T) {
-		token, err := core.CreateRegistrationToken(ctx, "  UpperCase@Example.COM  ")
+	t.Run("stores email as given (HTTP boundary normalizes)", func(t *testing.T) {
+		// Normalization (lowercase + trim) is now an HTTP-handler responsibility;
+		// core takes the email at face value.
+		token, err := core.CreateRegistrationToken(ctx, "already-normalized@example.com")
 		if err != nil {
 			t.Fatalf("Failed to create token: %v", err)
 		}
@@ -36,8 +38,8 @@ func TestChattoCore_CreateRegistrationToken(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to get token: %v", err)
 		}
-		if tokenData.Email != "uppercase@example.com" {
-			t.Errorf("Expected normalized email 'uppercase@example.com', got %q", tokenData.Email)
+		if tokenData.Email != "already-normalized@example.com" {
+			t.Errorf("Expected email %q, got %q", "already-normalized@example.com", tokenData.Email)
 		}
 	})
 
@@ -45,13 +47,6 @@ func TestChattoCore_CreateRegistrationToken(t *testing.T) {
 		_, err := core.CreateRegistrationToken(ctx, "")
 		if err == nil {
 			t.Error("Expected error for empty email")
-		}
-	})
-
-	t.Run("returns error for whitespace-only email", func(t *testing.T) {
-		_, err := core.CreateRegistrationToken(ctx, "   ")
-		if err == nil {
-			t.Error("Expected error for whitespace-only email")
 		}
 	})
 }
@@ -139,6 +134,32 @@ func TestChattoCore_RegistrationTokenExpiration(t *testing.T) {
 	t.Run("TTL is set to 24 hours", func(t *testing.T) {
 		if RegistrationTokenTTL != 24*time.Hour {
 			t.Errorf("Expected TTL of 24 hours, got %v", RegistrationTokenTTL)
+		}
+	})
+
+	t.Run("token expires from KV via per-key TTL", func(t *testing.T) {
+		token, err := core.CreateRegistrationToken(ctx, "ttl-test@example.com")
+		if err != nil {
+			t.Fatalf("Failed to create token: %v", err)
+		}
+
+		entry, err := core.storage.instanceKV.Get(ctx, registrationTokenKey(token))
+		if err != nil {
+			t.Fatalf("Failed to fetch entry: %v", err)
+		}
+
+		// Verify the underlying KV message carries a per-key TTL header.
+		// The Nats-TTL header is what NATS uses to enforce per-message expiry.
+		rawMsg, err := core.js.Stream(ctx, "KV_INSTANCE")
+		if err != nil {
+			t.Fatalf("Failed to get stream: %v", err)
+		}
+		msg, err := rawMsg.GetMsg(ctx, entry.Revision())
+		if err != nil {
+			t.Fatalf("Failed to fetch raw message: %v", err)
+		}
+		if msg.Header.Get("Nats-TTL") == "" {
+			t.Errorf("Expected Nats-TTL header on registration token KV entry, got headers: %v", msg.Header)
 		}
 	})
 }

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -169,6 +169,51 @@ func (c *ChattoCore) CreateUser(ctx context.Context, actorID string, login, disp
 	return user, nil
 }
 
+// CreateVerifiedUser creates a user and registers an already-verified email for them
+// in a single best-effort transaction. If verification fails after the user record is
+// written, the user record is rolled back so signup paths don't produce orphan accounts.
+//
+// Used by signup-completion (post email-link click) and OIDC callbacks, where the email
+// has already been proven (via clicking the link or via an OIDC `email_verified` claim).
+func (c *ChattoCore) CreateVerifiedUser(ctx context.Context, actorID, login, displayName, password, email string) (*corev1.User, error) {
+	user, err := c.CreateUser(ctx, actorID, login, displayName, password)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := c.AddVerifiedEmailDirect(ctx, user.Id, email); err != nil {
+		c.rollbackUserCreation(ctx, user)
+		return nil, fmt.Errorf("failed to verify email for new user: %w", err)
+	}
+
+	return user, nil
+}
+
+// rollbackUserCreation undoes the KV writes performed by CreateUser. Best-effort —
+// failures are logged but not returned, since the caller is already in an error path.
+//
+// Limitation: the instance's first-owner marker (PromoteFirstUserToOwner) is not
+// rolled back. If the very first user of an instance fails verification, that role
+// assignment leaks; subsequent users won't be auto-promoted and the operator must
+// reassign manually. Mitigated by the rarity of "verification fails on user #1".
+func (c *ChattoCore) rollbackUserCreation(ctx context.Context, user *corev1.User) {
+	c.logger.Warn("rolling back user creation", "user_id", user.Id, "login", user.Login)
+
+	keys := []string{
+		userKey(user.Id),
+		userByLoginKey(user.Login),
+		userAuthPasswordKey(user.Id),
+	}
+	for _, key := range keys {
+		if err := c.storage.instanceKV.Delete(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+			c.logger.Warn("rollback delete failed", "key", key, "error", err)
+		}
+	}
+	if err := c.DeleteUserEncryptionKey(ctx, user.Id); err != nil {
+		c.logger.Warn("rollback encryption key delete failed", "user_id", user.Id, "error", err)
+	}
+}
+
 // GetUser retrieves a user from the INSTANCE KV bucket.
 func (c *ChattoCore) GetUser(ctx context.Context, userID string) (*corev1.User, error) {
 	entry, err := c.storage.instanceKV.Get(ctx, userKey(userID))

--- a/cli/internal/core/users_verified_test.go
+++ b/cli/internal/core/users_verified_test.go
@@ -1,0 +1,79 @@
+package core
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func TestCreateVerifiedUser_HappyPath(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	user, err := core.CreateVerifiedUser(ctx, "system", "happy-user", "Happy", "password123", "happy@example.com")
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+
+	verified, _ := core.HasVerifiedEmail(ctx, user.Id)
+	if !verified {
+		t.Errorf("expected user to have verified email")
+	}
+
+	claimed, _ := core.IsEmailClaimed(ctx, "happy@example.com")
+	if !claimed {
+		t.Errorf("expected email to be claimed")
+	}
+}
+
+func TestCreateVerifiedUser_RollsBackOnEmailConflict(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	// Pre-claim the email under another user.
+	other, _ := core.CreateUser(ctx, "system", "other-user", "Other", "password123")
+	if err := core.AddVerifiedEmailDirect(ctx, other.Id, "shared@example.com"); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	// Attempt to create a new user with the same email — must fail and roll back.
+	_, err := core.CreateVerifiedUser(ctx, "system", "second-user", "Second", "password123", "shared@example.com")
+	if err == nil {
+		t.Fatalf("expected failure due to email conflict")
+	}
+	if !errors.Is(err, ErrEmailAlreadyVerified) {
+		t.Errorf("expected ErrEmailAlreadyVerified wrapped, got %v", err)
+	}
+
+	// User record must NOT exist (rollback).
+	if _, err := core.storage.instanceKV.Get(ctx, userByLoginKey("second-user")); !errors.Is(err, jetstream.ErrKeyNotFound) {
+		t.Errorf("expected login claim to be rolled back, got err=%v", err)
+	}
+}
+
+func TestCreateVerifiedUser_LoginCanBeReusedAfterRollback(t *testing.T) {
+	// After a rollback, the login should be free for someone else (or a retry) to claim.
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	pre, _ := core.CreateUser(ctx, "system", "pre", "Pre", "password123")
+	if err := core.AddVerifiedEmailDirect(ctx, pre.Id, "blocked@example.com"); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	// First attempt: blocked by email conflict, login "retry-me" gets rolled back.
+	if _, err := core.CreateVerifiedUser(ctx, "system", "retry-me", "Retry", "password123", "blocked@example.com"); err == nil {
+		t.Fatalf("expected failure")
+	}
+
+	// Second attempt: same login, different email — should succeed because the rollback
+	// freed up the login claim.
+	user, err := core.CreateVerifiedUser(ctx, "system", "retry-me", "Retry", "password123", "fresh@example.com")
+	if err != nil {
+		t.Fatalf("expected success on retry with fresh email, got %v", err)
+	}
+	if user.Login != "retry-me" {
+		t.Errorf("unexpected login: %s", user.Login)
+	}
+}

--- a/cli/internal/core/verified_emails.go
+++ b/cli/internal/core/verified_emails.go
@@ -94,7 +94,7 @@ func (c *ChattoCore) CreateEmailVerificationToken(ctx context.Context, userID, e
 		return "", fmt.Errorf("failed to marshal token: %w", err)
 	}
 
-	_, err = c.storage.instanceKV.Put(ctx, emailVerificationTokenKey(token), data)
+	_, err = c.storage.instanceKV.Create(ctx, emailVerificationTokenKey(token), data, jetstream.KeyTTL(EmailVerificationTokenTTL))
 	if err != nil {
 		return "", fmt.Errorf("failed to store verification token: %w", err)
 	}

--- a/cli/internal/http_server/auth.go
+++ b/cli/internal/http_server/auth.go
@@ -166,6 +166,8 @@ func (s *HTTPServer) setupAuthRoutes() {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "A valid email address is required"})
 			return
 		}
+		// Normalize at the HTTP boundary so downstream core code can treat email as canonical.
+		req.Email = strings.ToLower(strings.TrimSpace(req.Email))
 
 		// Require mailer — can't do email-first registration without email delivery
 		if s.mailer == nil {
@@ -288,8 +290,8 @@ func (s *HTTPServer) setupAuthRoutes() {
 			return
 		}
 
-		// Create user (use login as display name initially)
-		user, err := s.core.CreateUser(ctx, "system", req.Login, req.Login, req.Password)
+		// Create user with verified email atomically (use login as display name initially)
+		user, err := s.core.CreateVerifiedUser(ctx, "system", req.Login, req.Login, req.Password, tokenData.Email)
 		if err != nil {
 			if errors.Is(err, core.ErrLoginAlreadyTaken) {
 				c.JSON(http.StatusConflict, gin.H{"error": "Username is already taken"})
@@ -299,15 +301,17 @@ func (s *HTTPServer) setupAuthRoutes() {
 				c.JSON(http.StatusBadRequest, gin.H{"error": "This username is not available"})
 				return
 			}
+			if errors.Is(err, core.ErrEmailAlreadyVerified) {
+				c.JSON(http.StatusConflict, gin.H{"error": "This email address is already in use"})
+				return
+			}
+			if errors.Is(err, core.ErrLimitExceeded) {
+				c.JSON(http.StatusForbidden, gin.H{"error": "This instance is not accepting new users"})
+				return
+			}
 			log.Error("Registration failed", "login", req.Login, "error", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Registration failed"})
 			return
-		}
-
-		// Auto-verify email (user proved ownership via email link)
-		if err := s.core.AddVerifiedEmailDirect(ctx, user.Id, tokenData.Email); err != nil {
-			log.Error("Failed to verify email during registration", "userId", user.Id, "email", tokenData.Email, "error", err)
-			// Don't fail — user was created successfully
 		}
 
 		// Delete registration token (consumed)

--- a/cli/internal/http_server/oidc.go
+++ b/cli/internal/http_server/oidc.go
@@ -227,6 +227,8 @@ func (s *HTTPServer) setupOIDCRoutes() {
 			c.Redirect(http.StatusTemporaryRedirect, "/login?error=oidc_no_email")
 			return
 		}
+		// Normalize at the HTTP boundary so downstream core code can treat email as canonical.
+		claims.Email = strings.ToLower(strings.TrimSpace(claims.Email))
 
 		issuer := idToken.Issuer
 		subject := idToken.Subject
@@ -259,16 +261,12 @@ func (s *HTTPServer) setupOIDCRoutes() {
 					displayName = login
 				}
 
-				user, err = s.core.CreateUser(ctx, "system", login, displayName, "")
+				// Create user with verified email atomically (OIDC provider already verified it)
+				user, err = s.core.CreateVerifiedUser(ctx, "system", login, displayName, "", claims.Email)
 				if err != nil {
 					log.Error("Failed to create user from OIDC", "error", err)
 					c.Redirect(http.StatusTemporaryRedirect, "/login?error=oidc_failed")
 					return
-				}
-
-				// Auto-verify email (OIDC provider already verified it)
-				if err := s.core.AddVerifiedEmailDirect(ctx, user.Id, claims.Email); err != nil {
-					log.Warn("Failed to auto-verify OIDC email", "error", err, "userId", user.Id)
 				}
 			}
 


### PR DESCRIPTION
## Summary

- **Per-key TTL on registration / email-verification tokens.** Enables `LimitMarkerTTL=24h` on the INSTANCE KV bucket and uses `kv.Create` with `jetstream.KeyTTL` for both token types — they now leave KV automatically instead of piling up until lazy retrieval, with the existing lazy-expiry checks acting as defense-in-depth.
- **New `core.CreateVerifiedUser` helper** that bundles `CreateUser + AddVerifiedEmailDirect` and rolls back the user record (login claim, password, encryption key) when verification fails. Used by `/auth/register/complete` and the OIDC callback to close the orphan-user hole; documented limitation is that the first-owner marker isn't rolled back.
- **Email normalization (trim + lowercase) moves to the HTTP boundary** (`auth.go` register handler, `oidc.go` callback) instead of being applied inside `core.CreateRegistrationToken`. Core now expects canonical emails from callers.

## Test plan

- [x] `mise test-cli` passes (only the documented pre-existing `TestAuthRoutes_TestEmailEndpoint` flake remains).
- [x] New tests cover: `Nats-TTL` header on token KV entries, `CreateVerifiedUser` happy path, rollback on email conflict, login reusability after rollback.
- [ ] Manual: hit `POST /auth/register` with `"  Foo@EXAMPLE.com  "`, confirm the resulting verified email is stored as `foo@example.com`.