### PR TITLE
fix: require display name to start with letter or digit

### DIFF
--- a/cli/internal/core/errors.go
+++ b/cli/internal/core/errors.go
@@ -68,6 +68,11 @@ var (
 	// disallowed characters (control chars, zero-width chars, consecutive spaces).
 	ErrDisplayNameInvalidCharacter = errors.New("display name contains invalid characters")
 
+	// ErrDisplayNameInvalidStart is returned when a display name does not start
+	// with a letter or digit. Required so the auto-generated avatar placeholder
+	// (which uses the first character) renders sensibly.
+	ErrDisplayNameInvalidStart = errors.New("display name must start with a letter or digit")
+
 	// ErrDescriptionTooLong is returned when a description exceeds the maximum length.
 	ErrDescriptionTooLong = errors.New("description exceeds maximum length")
 

--- a/cli/internal/core/validation.go
+++ b/cli/internal/core/validation.go
@@ -18,7 +18,10 @@ func ValidateDisplayName(name string) error {
 	}
 
 	prevWasSpace := false
-	for _, r := range name {
+	for i, r := range name {
+		if i == 0 && !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			return ErrDisplayNameInvalidStart
+		}
 		// Check for consecutive spaces
 		if r == ' ' {
 			if prevWasSpace {

--- a/cli/internal/core/validation_test.go
+++ b/cli/internal/core/validation_test.go
@@ -37,10 +37,7 @@ func TestValidateDisplayName(t *testing.T) {
 
 		// Valid names - emoji
 		{"emoji suffix", "Alice 🚀", nil},
-		{"emoji prefix", "🎮 Gamer", nil},
-		{"multiple emoji", "🌟 Star ⭐", nil},
-		{"emoji only", "🦄", nil},
-		{"flag emoji", "🇺🇸 American", nil},
+		{"trailing emoji after digit", "Player1 ⭐", nil},
 
 		// Valid names - mixed scripts
 		{"mixed Latin-Japanese", "John 田中", nil},
@@ -49,7 +46,24 @@ func TestValidateDisplayName(t *testing.T) {
 		// Valid edge cases
 		{"empty string", "", nil}, // Empty check handled elsewhere
 		{"single char", "A", nil},
-		{"single emoji", "😀", nil},
+
+		// Invalid - must start with letter or digit (avatar placeholder uses first char)
+		{"emoji prefix", "🎮 Gamer", ErrDisplayNameInvalidStart},
+		{"emoji only", "🦄", ErrDisplayNameInvalidStart},
+		{"flag emoji prefix", "🇺🇸 American", ErrDisplayNameInvalidStart},
+		{"single emoji", "😀", ErrDisplayNameInvalidStart},
+		{"multiple emoji prefix", "🌟 Star ⭐", ErrDisplayNameInvalidStart},
+		{"starts with hyphen", "-Alice", ErrDisplayNameInvalidStart},
+		{"starts with apostrophe", "'Alice", ErrDisplayNameInvalidStart},
+		{"starts with period", ".Alice", ErrDisplayNameInvalidStart},
+		{"starts with underscore", "_Alice", ErrDisplayNameInvalidStart},
+		{"starts with tilde", "~user", ErrDisplayNameInvalidStart},
+		{"starts with backtick", "`code", ErrDisplayNameInvalidStart},
+		{"starts with plus", "+Alice", ErrDisplayNameInvalidStart},
+		{"starts with equals", "=Alice", ErrDisplayNameInvalidStart},
+		{"starts with caret", "^Alice", ErrDisplayNameInvalidStart},
+		{"starts with pipe", "|Alice", ErrDisplayNameInvalidStart},
+		{"starts with angle bracket", "<Alice", ErrDisplayNameInvalidStart},
 
 		// Invalid - control characters
 		{"with newline", "John\nDoe", ErrDisplayNameInvalidCharacter},
@@ -76,28 +90,29 @@ func TestValidateDisplayName(t *testing.T) {
 		{"with curly brace", "John{test}", ErrDisplayNameInvalidCharacter},
 		{"with semicolon", "John; DROP TABLE", ErrDisplayNameInvalidCharacter},
 		{"with at sign", "user@domain", ErrDisplayNameInvalidCharacter},
-		{"with hash", "#hashtag", ErrDisplayNameInvalidCharacter},
+		{"with hash", "Pre#hashtag", ErrDisplayNameInvalidCharacter},
 		{"with exclamation", "Hello!", ErrDisplayNameInvalidCharacter},
 		{"with question mark", "Who?", ErrDisplayNameInvalidCharacter},
 		{"with comma", "Last, First", ErrDisplayNameInvalidCharacter},
 		{"with colon", "Title: Name", ErrDisplayNameInvalidCharacter},
 		{"with slash", "A/B", ErrDisplayNameInvalidCharacter},
 		{"with backslash", "A\\B", ErrDisplayNameInvalidCharacter},
-		{"with quotes", `"quoted"`, ErrDisplayNameInvalidCharacter},
-		{"with parentheses", "(name)", ErrDisplayNameInvalidCharacter},
-		{"with square brackets", "[name]", ErrDisplayNameInvalidCharacter},
+		{"with quotes", `Pre"quoted"`, ErrDisplayNameInvalidCharacter},
+		{"with parentheses", "Pre(name)", ErrDisplayNameInvalidCharacter},
+		{"with square brackets", "Pre[name]", ErrDisplayNameInvalidCharacter},
 		{"with ampersand", "A&B", ErrDisplayNameInvalidCharacter},
 		{"with asterisk", "star*", ErrDisplayNameInvalidCharacter},
 		{"with percent", "100%", ErrDisplayNameInvalidCharacter},
 
 		// These are Unicode symbols (allowed alongside emoji)
-		// They're harmless when properly escaped in rendering
+		// They're harmless when properly escaped in rendering, as long as
+		// they're not the first character.
 		{"with angle bracket (symbol)", "John<3", nil},
 		{"with equals (symbol)", "a=b", nil},
 		{"with pipe (symbol)", "A|B", nil},
 		{"with caret (symbol)", "A^B", nil},
-		{"with tilde (symbol)", "~user", nil},
-		{"with backtick (symbol)", "`code`", nil},
+		{"with tilde (symbol)", "u~ser", nil},
+		{"with backtick (symbol)", "co`de`", nil},
 		{"with plus (symbol)", "A+B", nil},
 	}
 

--- a/frontend/src/lib/validation/displayName.spec.ts
+++ b/frontend/src/lib/validation/displayName.spec.ts
@@ -30,21 +30,16 @@ describe('validateDisplayName', () => {
       ['Thai script', 'สมชาย'],
       ['Hindi Devanagari', 'राजेश कुमार'],
       ['emoji suffix', 'Alice 🚀'],
-      ['emoji prefix', '🎮 Gamer'],
-      ['multiple emoji', '🌟 Star ⭐'],
-      ['emoji only', '🦄'],
-      ['flag emoji', '🇺🇸 American'],
       ['mixed Latin-Japanese', 'John 田中'],
       ['mixed with emoji', 'Müller 🎵'],
       ['single char', 'A'],
-      ['single emoji', '😀'],
-      // Symbols allowed alongside emoji
+      // Symbols allowed alongside emoji (when not the first character)
       ['with angle bracket (symbol)', 'John<3'],
       ['with equals (symbol)', 'a=b'],
       ['with pipe (symbol)', 'A|B'],
       ['with caret (symbol)', 'A^B'],
-      ['with tilde (symbol)', '~user'],
-      ['with backtick (symbol)', '`code`'],
+      ['with tilde (symbol)', 'u~ser'],
+      ['with backtick (symbol)', 'co`de`'],
       ['with plus (symbol)', 'A+B']
     ] as const;
 
@@ -109,21 +104,50 @@ describe('validateDisplayName', () => {
     });
   });
 
+  describe('invalid names - must start with letter or digit', () => {
+    const invalidStarts = [
+      ['emoji prefix', '🎮 Gamer'],
+      ['emoji only', '🦄'],
+      ['flag emoji', '🇺🇸 American'],
+      ['multiple emoji', '🌟 Star ⭐'],
+      ['single emoji', '😀'],
+      ['starts with hyphen', '-Alice'],
+      ['starts with apostrophe', "'Alice"],
+      ['starts with period', '.Alice'],
+      ['starts with underscore', '_Alice'],
+      ['starts with tilde', '~user'],
+      ['starts with backtick', '`code`'],
+      ['starts with plus', '+Alice'],
+      ['starts with equals', '=Alice'],
+      ['starts with caret', '^Alice'],
+      ['starts with pipe', '|Alice'],
+      ['starts with angle bracket', '<Alice']
+    ] as const;
+
+    for (const [description, name] of invalidStarts) {
+      it(`rejects ${description}: "${name}"`, () => {
+        const result = validateDisplayName(name);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('must start with a letter or digit');
+      });
+    }
+  });
+
   describe('invalid names - disallowed punctuation', () => {
     const invalidNames = [
       ['with curly brace', 'John{test}'],
       ['with semicolon', 'John; DROP TABLE'],
       ['with at sign', 'user@domain'],
-      ['with hash', '#hashtag'],
+      ['with hash', 'Pre#hashtag'],
       ['with exclamation', 'Hello!'],
       ['with question mark', 'Who?'],
       ['with comma', 'Last, First'],
       ['with colon', 'Title: Name'],
       ['with slash', 'A/B'],
       ['with backslash', 'A\\B'],
-      ['with quotes', '"quoted"'],
-      ['with parentheses', '(name)'],
-      ['with square brackets', '[name]'],
+      ['with quotes', 'Pre"quoted"'],
+      ['with parentheses', 'Pre(name)'],
+      ['with square brackets', 'Pre[name]'],
       ['with ampersand', 'A&B'],
       ['with asterisk', 'star*'],
       ['with percent', '100%']

--- a/frontend/src/lib/validation/displayName.ts
+++ b/frontend/src/lib/validation/displayName.ts
@@ -97,6 +97,13 @@ export function validateDisplayName(name: string): ValidationResult {
     return { valid: false, error: 'Display name cannot contain consecutive spaces' };
   }
 
+  // Must start with a letter or digit (the avatar placeholder uses the first
+  // character, so leading symbols/punctuation/emoji render badly).
+  const firstChar = [...name][0];
+  if (!/^[\p{L}\p{N}]$/u.test(firstChar)) {
+    return { valid: false, error: 'Display name must start with a letter or digit' };
+  }
+
   // Check each character
   for (const char of name) {
     if (!isAllowedChar(char)) {


### PR DESCRIPTION
## Summary

The auto-generated avatar placeholder uses the first character of the display name. Display names that began with non-alphanumeric characters (emoji, symbols, punctuation) caused the placeholder to render incorrectly — emoji prefixes were particularly broken since indexing the first JS code unit returns half a surrogate pair. Validation now rejects these names on both backend (`ValidateDisplayName`) and frontend (`validateDisplayName`), with a new `ErrDisplayNameInvalidStart` error and matching tests covering emoji/flag/symbol/punctuation prefixes.

## Test plan
- [x] `go test ./internal/core/ -run TestValidateDisplayName` (Go)
- [x] `pnpm test:unit --project server src/lib/validation/` (frontend)