### PR TITLE
feat: rate-limit POST /auth/register

### DIFF
--- a/cli/cmd/backup.go
+++ b/cli/cmd/backup.go
@@ -333,6 +333,8 @@ func skipReason(name string) string {
 		return "ephemeral (memory storage)"
 	case "KV_CALL_STATE":
 		return "ephemeral (memory storage)"
+	case "KV_RATELIMITS":
+		return "ephemeral (memory storage)"
 	case "KV_ENCRYPTION_KEYS":
 		return "security (keys excluded from backups)"
 	case "KV_LINK_PREVIEW_CACHE":

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -417,6 +417,7 @@ type storage struct {
 	notificationsKV       jetstream.KeyValue     // User notifications with TTL
 	callStateKV           jetstream.KeyValue     // Active voice call participants (ephemeral, memory-backed)
 	authTokensKV          jetstream.KeyValue     // Bearer auth tokens with TTL
+	ratelimitKV           jetstream.KeyValue     // Rate-limit counters (ephemeral, memory-backed)
 }
 
 // newStorage initializes all JetStream KV buckets and streams.
@@ -560,6 +561,22 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		return nil, fmt.Errorf("failed to create AUTH_TOKENS KV bucket: %w", err)
 	}
 
+	// Initialize rate-limit KV bucket (memory-backed, ephemeral).
+	// Stores per-(scope,key) windowed counters. Memory storage is intentional —
+	// rate-limit state losing its memory on restart is fine (limits reset). Per-key
+	// TTL via LimitMarkerTTL keeps cleanup automatic so the bucket doesn't grow.
+	ratelimitKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:         "RATELIMITS",
+		Description:    "Rate-limit counters (ephemeral, memory-backed)",
+		Storage:        jetstream.MemoryStorage,
+		History:        1,
+		Replicas:       cfg.Replicas,
+		LimitMarkerTTL: time.Hour,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create RATELIMITS KV bucket: %w", err)
+	}
+
 	// Return initialized storage and whether RBAC bucket was newly created
 	return &storage{
 		instanceKV:       instanceKV,
@@ -580,6 +597,7 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		notificationsKV:       notificationsKV,
 		callStateKV:           callStateKV,
 		authTokensKV:          authTokensKV,
+		ratelimitKV:           ratelimitKV,
 	}, nil
 }
 

--- a/cli/internal/core/ratelimit.go
+++ b/cli/internal/core/ratelimit.go
@@ -1,0 +1,122 @@
+package core
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// rateLimitState is what we store in the RATELIMITS bucket. Compact field names
+// keep the JSON small since this is a hot path with many short-lived entries.
+type rateLimitState struct {
+	Count       int   `json:"c"`
+	WindowStart int64 `json:"w"` // unix milliseconds (sub-second precision matters for short windows in tests)
+}
+
+// rateLimitMaxRetries caps the CAS retry loop. With N concurrent callers all racing
+// to increment the same counter, the slowest caller can need up to N-1 retries (each
+// round, only one Update wins; losers re-Get and try again). 32 covers realistic
+// burst sizes against a single rate-limit key without busy-looping forever; in
+// production, typical contention is far below this since the limit itself caps the
+// per-key burst rate.
+const rateLimitMaxRetries = 32
+
+// rateLimitKey builds the KV key for a (scope, key) pair. The key portion is hashed
+// so callers can pass arbitrary input (IPs, emails) without worrying about NATS
+// subject character restrictions or PII leakage in stream subjects.
+func rateLimitKey(scope, key string) string {
+	hash := sha256.Sum256([]byte(key))
+	return fmt.Sprintf("%s.%s", scope, hex.EncodeToString(hash[:]))
+}
+
+// RateLimitCheck enforces a fixed-window rate limit and returns whether the call
+// is allowed. On allow it atomically increments the per-(scope,key) counter; on
+// deny it returns the time until the current window closes so the caller can set
+// a Retry-After header.
+//
+// scope namespaces buckets (e.g. "register.ip", "register.email"); key is the
+// per-caller identifier (the IP or email). max is the maximum number of allowed
+// calls per window.
+//
+// Implementation: stateful counter with optimistic CAS. Each call reads the
+// current state, resets if the window has expired, checks the count, and either
+// updates (existing entry) or creates (fresh window) with KeyTTL=2*window so old
+// state ages out automatically. Retries up to rateLimitMaxRetries times on
+// revision mismatch.
+//
+// Returns allowed=false with a non-nil err only when the underlying KV operation
+// fails. For consistency under contention the caller should treat err != nil
+// as "fail open" or "fail closed" depending on how strict the gate needs to be.
+func (c *ChattoCore) RateLimitCheck(ctx context.Context, scope, key string, max int, window time.Duration) (allowed bool, retryAfter time.Duration, err error) {
+	if max <= 0 || window <= 0 {
+		return true, 0, nil
+	}
+
+	kvKey := rateLimitKey(scope, key)
+	now := time.Now()
+	nowMs := now.UnixMilli()
+	// NATS rejects per-message TTL below 1 second, so clamp the floor for safety.
+	// The window logic itself is window-precision; this only governs how soon stale
+	// entries are GC'd from KV.
+	windowEntryTTL := 2 * window
+	if windowEntryTTL < time.Second {
+		windowEntryTTL = time.Second
+	}
+
+	for attempt := 0; attempt < rateLimitMaxRetries; attempt++ {
+		entry, getErr := c.storage.ratelimitKV.Get(ctx, kvKey)
+
+		// Fresh window — either the key doesn't exist or the window has rolled over.
+		// In both cases we Create a new entry. If another caller wins the race,
+		// we retry through the Update path.
+		if errors.Is(getErr, jetstream.ErrKeyNotFound) {
+			state := rateLimitState{Count: 1, WindowStart: nowMs}
+			data, _ := json.Marshal(state)
+			if _, createErr := c.storage.ratelimitKV.Create(ctx, kvKey, data, jetstream.KeyTTL(windowEntryTTL)); createErr != nil {
+				if errors.Is(createErr, jetstream.ErrKeyExists) {
+					continue
+				}
+				return false, 0, fmt.Errorf("rate limit create failed: %w", createErr)
+			}
+			return true, 0, nil
+		}
+		if getErr != nil {
+			return false, 0, fmt.Errorf("rate limit get failed: %w", getErr)
+		}
+
+		var state rateLimitState
+		if unmarshalErr := json.Unmarshal(entry.Value(), &state); unmarshalErr != nil {
+			// Corrupted entry — treat as fresh window and overwrite.
+			state = rateLimitState{}
+		}
+
+		windowEnd := time.UnixMilli(state.WindowStart).Add(window)
+		if !now.Before(windowEnd) {
+			// Window expired; reset.
+			state = rateLimitState{Count: 1, WindowStart: nowMs}
+		} else {
+			if state.Count >= max {
+				return false, time.Until(windowEnd), nil
+			}
+			state.Count++
+		}
+
+		data, _ := json.Marshal(state)
+		if _, updateErr := c.storage.ratelimitKV.Update(ctx, kvKey, data, entry.Revision()); updateErr != nil {
+			if errors.Is(updateErr, jetstream.ErrKeyExists) {
+				// Revision mismatch — another caller incremented first; retry.
+				continue
+			}
+			return false, 0, fmt.Errorf("rate limit update failed: %w", updateErr)
+		}
+		return true, 0, nil
+	}
+
+	return false, 0, fmt.Errorf("rate limit check exhausted retries for %s/%s", scope, key)
+}

--- a/cli/internal/core/ratelimit_test.go
+++ b/cli/internal/core/ratelimit_test.go
@@ -1,0 +1,137 @@
+package core
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRateLimitCheck_AllowsUnderLimit(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	for i := 0; i < 3; i++ {
+		allowed, _, err := core.RateLimitCheck(ctx, "test.allow", "key-a", 3, time.Minute)
+		if err != nil {
+			t.Fatalf("call %d unexpected error: %v", i, err)
+		}
+		if !allowed {
+			t.Fatalf("call %d should be allowed under limit", i)
+		}
+	}
+}
+
+func TestRateLimitCheck_DeniesAtLimit(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	for i := 0; i < 3; i++ {
+		if allowed, _, _ := core.RateLimitCheck(ctx, "test.deny", "key-b", 3, time.Minute); !allowed {
+			t.Fatalf("setup call %d should be allowed", i)
+		}
+	}
+
+	allowed, retryAfter, err := core.RateLimitCheck(ctx, "test.deny", "key-b", 3, time.Minute)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if allowed {
+		t.Errorf("4th call should be denied")
+	}
+	if retryAfter <= 0 || retryAfter > time.Minute {
+		t.Errorf("retryAfter should be 0..1m, got %v", retryAfter)
+	}
+}
+
+func TestRateLimitCheck_ScopesAreIndependent(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	for i := 0; i < 2; i++ {
+		core.RateLimitCheck(ctx, "test.scope-a", "shared-key", 2, time.Minute)
+	}
+	// scope-a is now exhausted, but scope-b should still allow this key.
+	allowed, _, _ := core.RateLimitCheck(ctx, "test.scope-b", "shared-key", 2, time.Minute)
+	if !allowed {
+		t.Errorf("different scope should not share counters")
+	}
+}
+
+func TestRateLimitCheck_KeysAreIndependent(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	for i := 0; i < 2; i++ {
+		core.RateLimitCheck(ctx, "test.keys", "ip-1", 2, time.Minute)
+	}
+	allowed, _, _ := core.RateLimitCheck(ctx, "test.keys", "ip-2", 2, time.Minute)
+	if !allowed {
+		t.Errorf("different key in same scope should not share counter")
+	}
+}
+
+func TestRateLimitCheck_WindowExpiry(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	// Use a tiny window so we can wait it out without slowing the test.
+	window := 200 * time.Millisecond
+
+	for i := 0; i < 2; i++ {
+		core.RateLimitCheck(ctx, "test.win", "key-c", 2, window)
+	}
+	if allowed, _, _ := core.RateLimitCheck(ctx, "test.win", "key-c", 2, window); allowed {
+		t.Fatalf("3rd call within window should be denied")
+	}
+
+	time.Sleep(window + 50*time.Millisecond)
+
+	if allowed, _, _ := core.RateLimitCheck(ctx, "test.win", "key-c", 2, window); !allowed {
+		t.Errorf("call after window expiry should be allowed")
+	}
+}
+
+func TestRateLimitCheck_ConcurrentCASIsCorrect(t *testing.T) {
+	// Hammer the same (scope,key) from many goroutines and verify the total number
+	// of "allowed" responses equals the configured max — i.e. CAS retries don't
+	// allow over-shoot.
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	const max = 10
+	const goroutines = 50
+
+	var wg sync.WaitGroup
+	allowedCount := 0
+	var mu sync.Mutex
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			allowed, _, _ := core.RateLimitCheck(ctx, "test.concurrent", "race-key", max, time.Minute)
+			if allowed {
+				mu.Lock()
+				allowedCount++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if allowedCount != max {
+		t.Errorf("expected exactly %d calls allowed under contention, got %d", max, allowedCount)
+	}
+}
+
+func TestRateLimitCheck_ZeroMaxAllowsAll(t *testing.T) {
+	// Sentinel: max <= 0 disables the limit so callers can pass 0 to opt out.
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	for i := 0; i < 100; i++ {
+		if allowed, _, _ := core.RateLimitCheck(ctx, "test.disabled", "k", 0, time.Minute); !allowed {
+			t.Fatalf("max=0 should allow unconditionally, denied on call %d", i)
+		}
+	}
+}

--- a/cli/internal/http_server/auth.go
+++ b/cli/internal/http_server/auth.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/log"
 	"github.com/gin-contrib/sessions"
@@ -19,6 +21,15 @@ import (
 var (
 	validLoginRegex   = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 	invalidCharsRegex = regexp.MustCompile(`[^a-z0-9._-]`)
+)
+
+// Rate limits for POST /auth/register. Hardcoded for now; if operators ask to tune,
+// promote to LimitsConfig. Per-IP catches a single attacker pumping many emails;
+// per-email catches IP-rotating attacks targeting one inbox.
+const (
+	registerRateLimitWindow      = time.Hour
+	registerRateLimitPerIPMax    = 30
+	registerRateLimitPerEmailMax = 5
 )
 
 func (s *HTTPServer) setupAuthRoutes() {
@@ -176,6 +187,22 @@ func (s *HTTPServer) setupAuthRoutes() {
 		}
 
 		ctx := c.Request.Context()
+
+		// Rate limit: per-IP first, then per-email-target. We gate before the email-claimed
+		// check so the registration endpoint can't be used to probe for valid emails by
+		// timing differences, and so an attacker can't burn through SMTP credit hammering
+		// any address. "Resend" is just calling this endpoint again, naturally subject to
+		// the same limits.
+		if allowed, retryAfter, _ := s.core.RateLimitCheck(ctx, "register.ip", c.ClientIP(), registerRateLimitPerIPMax, registerRateLimitWindow); !allowed {
+			c.Header("Retry-After", strconv.Itoa(int(retryAfter.Seconds())+1))
+			c.JSON(http.StatusTooManyRequests, gin.H{"error": "Too many registration attempts from this address. Please try again later."})
+			return
+		}
+		if allowed, retryAfter, _ := s.core.RateLimitCheck(ctx, "register.email", req.Email, registerRateLimitPerEmailMax, registerRateLimitWindow); !allowed {
+			c.Header("Retry-After", strconv.Itoa(int(retryAfter.Seconds())+1))
+			c.JSON(http.StatusTooManyRequests, gin.H{"error": "Too many registration attempts for this email. Please try again later."})
+			return
+		}
 
 		// Check if email is already claimed — but always return 200 to prevent enumeration
 		emailClaimed, err := s.core.IsEmailClaimed(ctx, req.Email)

--- a/cli/internal/http_server/server_test.go
+++ b/cli/internal/http_server/server_test.go
@@ -598,6 +598,41 @@ func TestAuthRoutes_Register_EmailEnumeration(t *testing.T) {
 	}
 }
 
+func TestAuthRoutes_Register_RateLimitedPerEmail(t *testing.T) {
+	ts, client, _, _ := setupTestHTTPServerWithMailer(t)
+
+	// Per-email limit is 5/hour. After 5 successful calls for the same email,
+	// the 6th must be rejected with 429.
+	send := func() *http.Response {
+		reqBody := map[string]string{"email": "ratelimit-target@example.com"}
+		body, _ := json.Marshal(reqBody)
+		resp, err := client.Post(ts.URL+"/auth/register", "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		return resp
+	}
+
+	for i := 0; i < 5; i++ {
+		resp := send()
+		if resp.StatusCode != http.StatusOK {
+			respBody, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			t.Fatalf("call %d: expected 200, got %d: %s", i, resp.StatusCode, string(respBody))
+		}
+		resp.Body.Close()
+	}
+
+	resp := send()
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("6th call: expected 429, got %d", resp.StatusCode)
+	}
+	if retryAfter := resp.Header.Get("Retry-After"); retryAfter == "" {
+		t.Errorf("expected Retry-After header on 429 response")
+	}
+}
+
 func TestAuthRoutes_RegisterComplete_Success(t *testing.T) {
 	ts, client, chattoCore, _ := setupTestHTTPServerWithMailer(t)
 	ctx := testContext(t)


### PR DESCRIPTION
## Summary

- New memory-backed `RATELIMITS` KV bucket and a generic `core.RateLimitCheck(scope, key, max, window)` helper using a stateful fixed-window counter with optimistic CAS. Keys are sha256-hashed before storing so callers can pass arbitrary input (IPs, emails) without leaking PII into NATS subject names.
- `POST /auth/register` now gates on two limits before any work: 30/hour per IP, 5/hour per email. Hits return 429 with `Retry-After`. Gating early prevents email-enumeration via timing differences and stops attackers from burning SMTP credit.
- "Resend" is implicit — re-calling `/auth/register` with the same email coexists with the old token (first redeemed wins; old token ages out via the 24h KV TTL we shipped earlier).
- `RATELIMITS` is marked as a skip in `chatto backup` since it's ephemeral.

## Test plan

- [x] `mise test-cli` passes (full suite green; previously-flaky `TestAuthRoutes_TestEmailEndpoint` also passed this run).
- [x] Unit tests cover the helper: under-limit allow, at-limit deny, scope/key independence, window expiry, concurrent CAS correctness (50 goroutines × max=10), zero-max sentinel.
- [x] Integration test hits `/auth/register` 6× with the same email and verifies the 6th gets 429 + `Retry-After`.
- [ ] Manual: run a dev instance, hit `POST /auth/register` 31 times from one IP, confirm a 429 with `Retry-After: ~3600`.

## Design notes

- Limits are hardcoded constants in `auth.go` for now. If operators ask to tune, promote to `LimitsConfig`.
- Per-message TTL floor is clamped to 1s in the helper since NATS rejects sub-second per-message TTLs (only matters for tests with tiny windows).
- CAS retry budget is 32 — covers realistic burst contention against a single key without busy-looping.