### PR TITLE
fix(frontend): lower threshold for showing Jump to Present button

### DIFF
--- a/frontend/src/routes/chat/[instanceId]/[spaceId]/[roomId]/EventList.svelte
+++ b/frontend/src/routes/chat/[instanceId]/[spaceId]/[roomId]/EventList.svelte
@@ -422,7 +422,7 @@
     // Smart scroll: detect user scroll direction
     if (!alwaysScrollToBottom) {
       // Re-enable auto-scroll if we're at the bottom (and not locked)
-      if (distanceFromBottom < 50 && !scrollUpLock) {
+      if (distanceFromBottom < 10 && !scrollUpLock) {
         shouldScrollToBottom = true;
       }
       // Disable auto-scroll if user scrolled up (and clearly not near the bottom).
@@ -432,7 +432,7 @@
       else if (
         previousOffset !== null &&
         offset < previousOffset - 10 &&
-        distanceFromBottom > 100
+        distanceFromBottom > 20
       ) {
         shouldScrollToBottom = false;
         pendingScrollCorrection = false;


### PR DESCRIPTION
## Summary
- The Jump to Present button only appeared after a >100px scroll-up, leaving a dead zone where the latest message was partly hidden behind the composer but no button was shown.
- Lower the at-bottom snap from <50px to <10px and the scrolled-up trigger from >100px to >20px in `EventList.svelte`'s `handleVirtuaScroll`. The remaining direction check (`offset < previousOffset - 10`) plus the 150ms `scrollUpLock` continue to filter virtua's `$fixScrollJump` re-measurement corrections.

## Test plan
- [ ] Open a busy room, scroll up by ~one message — Jump to Present pill appears.
- [ ] Scroll back to the bottom — pill disappears, auto-scroll re-engages on new messages.
- [ ] Send a message yourself — no transient pill flicker.
- [ ] `frontend/e2e/auto-scroll.test.ts`, `jump-to-message.test.ts`, `message-links.test.ts` still pass.