### PR TITLE
fix(frontend): reset Create Room form on each open

### DIFF
--- a/frontend/src/lib/CreateRoom.svelte
+++ b/frontend/src/lib/CreateRoom.svelte
@@ -79,8 +79,6 @@
         return;
       }
 
-      name = '';
-      description = '';
       isLoading = false;
       onroomcreated?.(roomId);
     } catch (err) {

--- a/frontend/src/routes/chat/[instanceId]/[spaceId]/admin/rooms/+page.svelte
+++ b/frontend/src/routes/chat/[instanceId]/[spaceId]/admin/rooms/+page.svelte
@@ -904,7 +904,9 @@
 
 <!-- Create Room Dialog -->
 <Dialog bind:visible={createRoomDialogVisible} title="Create Room" size="sm">
-  <CreateRoom {spaceId} onroomcreated={handleRoomCreated} />
+  {#if createRoomDialogVisible}
+    <CreateRoom {spaceId} onroomcreated={handleRoomCreated} />
+  {/if}
 </Dialog>
 
 <!-- Edit Room Dialog -->


### PR DESCRIPTION
## Summary

The Create Room dialog on the admin rooms page kept typed values across open/close cycles because the persistent `<dialog>` element never unmounts its children. Gating `<CreateRoom>` on `createRoomDialogVisible` makes it remount on each open, giving fresh `$state` for the cancel, submit-error, and success paths uniformly. Drops the now-redundant explicit `name = ''; description = ''` reset.

Closes #27

## Test plan
- [ ] Open admin rooms → New Room → type, close via X / Esc / click-outside / Cancel → reopen → fields are empty
- [ ] Submit successfully → reopen → fields are empty
- [ ] Trigger a submission error → close and reopen → fields are empty