### PR TITLE
fix(frontend): render `**foo:**` as bold; add ATX heading support

### DIFF
--- a/frontend/src/lib/components/MessageContent.svelte.spec.ts
+++ b/frontend/src/lib/components/MessageContent.svelte.spec.ts
@@ -156,6 +156,20 @@ describe('renderMarkdown', () => {
       expect(html).toContain('outer');
       expect(html).toContain('inner');
     });
+
+    it('renders ATX headings h1 through h6', async () => {
+      for (let level = 1; level <= 6; level++) {
+        const hashes = '#'.repeat(level);
+        const html = await renderMarkdown(`${hashes} Heading ${level}`);
+        expect(html).toContain(`<h${level}>Heading ${level}</h${level}>`);
+      }
+    });
+
+    it('does not render setext (underline-style) headings', async () => {
+      const html = await renderMarkdown('Heading\n===');
+      expect(html).not.toContain('<h1');
+      expect(html).not.toContain('<h2');
+    });
   });
 
   describe('forbidden syntax (should render as literal text)', () => {
@@ -164,18 +178,6 @@ describe('renderMarkdown', () => {
       // Image syntax is disabled, so no <img> tag should be rendered
       // markdown-it parses this as "!" followed by a link, which is safe
       expect(html).not.toContain('<img');
-    });
-
-    it('does not render headings with #', async () => {
-      const html = await renderMarkdown('# Heading');
-      expect(html).not.toContain('<h1');
-      expect(html).toContain('# Heading');
-    });
-
-    it('does not render headings with ##', async () => {
-      const html = await renderMarkdown('## Heading');
-      expect(html).not.toContain('<h2');
-      expect(html).toContain('## Heading');
     });
 
     it('does not render horizontal rules', async () => {

--- a/frontend/src/lib/markdown.test.ts
+++ b/frontend/src/lib/markdown.test.ts
@@ -50,6 +50,48 @@ describe('renderMarkdown', () => {
       const html = await renderMarkdown('**...bold**');
       expect(html).toContain('<strong>...bold</strong>');
     });
+
+    it('renders `**foo:**` as bold with trailing colon', async () => {
+      const html = await renderMarkdown('**foo:**');
+      expect(html).toContain('<strong>foo:</strong>');
+    });
+
+    it('renders `__foo:__` as bold with trailing colon', async () => {
+      const html = await renderMarkdown('__foo:__');
+      expect(html).toContain('<strong>foo:</strong>');
+    });
+
+    it('renders `*foo:*` as italic with trailing colon', async () => {
+      const html = await renderMarkdown('*foo:*');
+      expect(html).toContain('<em>foo:</em>');
+    });
+
+    it('renders `_foo:_` as italic with trailing colon', async () => {
+      const html = await renderMarkdown('_foo:_');
+      expect(html).toContain('<em>foo:</em>');
+    });
+
+    it('renders `**foo:** bar` as bold followed by text', async () => {
+      const html = await renderMarkdown('**foo:** bar');
+      expect(html).toContain('<strong>foo:</strong>');
+    });
+
+    it('renders `**foo:** bar` inside a list item as bold', async () => {
+      const html = await renderMarkdown('- **foo:** bar');
+      expect(html).toContain('<strong>foo:</strong>');
+    });
+
+    it('renders both halves of `**foo:** bar **baz**` as bold', async () => {
+      const html = await renderMarkdown('**foo:** bar **baz**');
+      expect(html).toContain('<strong>foo:</strong>');
+      expect(html).toContain('<strong>baz</strong>');
+    });
+
+    it('renders both halves of `**foo:** **bar**` as bold', async () => {
+      const html = await renderMarkdown('**foo:** **bar**');
+      expect(html).toContain('<strong>foo:</strong>');
+      expect(html).toContain('<strong>bar</strong>');
+    });
   });
 
   describe('emphasis suppressed when not at word boundaries', () => {

--- a/frontend/src/lib/markdown.ts
+++ b/frontend/src/lib/markdown.ts
@@ -45,7 +45,6 @@ const LANGUAGE_IMPORTS: Record<string, () => Promise<unknown>> = {
  */
 const DISABLED_RULES = [
   // Block-level
-  'heading',
   'lheading',
   'hr',
   'table',
@@ -86,16 +85,31 @@ function wordBoundaryEmphasis(state: StateInline, silent: boolean): boolean {
 
   // Intraword: definitely literal (`snake_case`, `foo*bar*baz`).
   const intraword = beforeAlnum && afterAlnum;
-  // Kaomoji-like: punctuation on both sides AND no alphanumeric between this
-  // run and the next same-marker (so `_(ツ)_` suppresses, `_...moo_` doesn't).
+  // Kaomoji-like: punctuation on both sides AND neither direction crosses an
+  // alphanumeric before hitting a same-marker run or the input boundary. The
+  // bidirectional check distinguishes a true kaomoji marker (e.g. the trailing
+  // `_` in `_(ツ)_/¯` — only punctuation back to the opener and only
+  // punctuation forward to end of input) from a closer of a real emphasis
+  // run that happens to be followed by punctuation/another emphasis (e.g.
+  // the closing `**` in `**foo:** **bar**` — alnum `o` is right behind it).
   let kaomojiLike = false;
   if (!beforeAlnum && !afterAlnum) {
-    kaomojiLike = true;
+    let forwardOK = true;
     for (let i = runEnd; i < state.posMax; i++) {
       if (state.src.charCodeAt(i) === marker) break;
       if (ALPHANUMERIC.test(state.src[i])) {
-        kaomojiLike = false;
+        forwardOK = false;
         break;
+      }
+    }
+    if (forwardOK) {
+      kaomojiLike = true;
+      for (let i = start - 1; i >= 0; i--) {
+        if (state.src.charCodeAt(i) === marker) break;
+        if (ALPHANUMERIC.test(state.src[i])) {
+          kaomojiLike = false;
+          break;
+        }
       }
     }
   }

--- a/frontend/src/prose.css
+++ b/frontend/src/prose.css
@@ -12,32 +12,16 @@
     margin-top: 0.75em;
   }
 
-  /* Headings */
+  /* Headings: inherited font size, bold, underlined. */
   & h1,
   & h2,
   & h3,
   & h4,
   & h5,
   & h6 {
+    font-size: inherit;
     font-weight: 600;
-    line-height: 1.25;
-    margin-top: 1.5em;
-    margin-bottom: 0.5em;
-  }
-
-  & h1 {
-    font-size: 1.5em;
-  }
-  & h2 {
-    font-size: 1.25em;
-  }
-  & h3 {
-    font-size: 1.125em;
-  }
-  & h4,
-  & h5,
-  & h6 {
-    font-size: 1em;
+    text-decoration: underline;
   }
 
   /* First child has no top margin */


### PR DESCRIPTION
## Summary

- Fix markdown emphasis bug where `**foo:**` (and `*foo:*`, `__foo:__`, `_foo:_`) failed to render bold/italic when the closing run sat at end-of-string or next to another emphasis run. The custom `wordBoundaryEmphasis` rule's kaomoji-like detection now scans bidirectionally and only treats a run as kaomoji-like when neither direction crosses an alphanumeric before hitting a same-marker or input boundary — so `_(ツ)_/¯` is still suppressed, but `**foo:** **bar**` is not.
- Add ATX heading support (`#`..`######`); setext (underline-style) headings remain disabled. Style headings as inherited font size, bold, and underlined — nothing else.

## Test plan

- [x] `mise test-frontend` (721 tests pass)
- [x] New regression tests for `**foo:**` end-of-string, `**foo:** **bar**`, list-item context, and italic/underscore variants
- [x] Existing kaomoji and `snake_case` suppression tests still pass
- [x] New tests verify h1–h6 ATX render and setext stays disabled