### PR TITLE
fix(core): derive inThread from inReplyTo target when caller omits it

### DIFF
--- a/cli/internal/core/rooms.go
+++ b/cli/internal/core/rooms.go
@@ -993,6 +993,8 @@ func (c *ChattoCore) GetMessageBody(ctx context.Context, space_id string, messag
 // This eliminates race conditions where subscribers receive the event before body is stored.
 // Attachments should already be uploaded to ObjectStore; pass their metadata here.
 // inThread is the event ID of the thread root message for thread replies, or empty string for top-level messages.
+// If inThread is empty but inReplyTo points at a message that is itself in a thread, inThread is
+// derived from the target's own inThread so the new message correctly joins that thread.
 // inReplyTo is the event ID of the message this responds to (attribution only), or empty string.
 // alsoSendToChannel publishes a MessagePostedEvent echo to the root subject for channel visibility.
 // Authorization: Caller must verify room membership and CanPostMessage/CanPostInThread before calling, and CanEchoMessage (if alsoSendToChannel).
@@ -1016,8 +1018,20 @@ func (c *ChattoCore) PostMessage(ctx context.Context, space_id, room_id, user_id
 		return nil, err
 	}
 
+	// If replying to a message inside a thread, inherit its thread root.
+	// This keeps the data invariant intact even when callers (bots, older clients,
+	// extensions) only set inReplyTo. inReplyTo is attribution-only, so a lookup
+	// failure here is not fatal — fall through and let the message post as a root.
+	if inReplyTo != "" && inThread == "" {
+		target, err := c.GetRoomEventByEventID(ctx, space_id, room_id, inReplyTo)
+		if err == nil && target != nil {
+			if msg := target.GetMessagePosted(); msg != nil && msg.InThread != "" {
+				inThread = msg.InThread
+			}
+		}
+	}
+
 	// Validate thread root exists if posting to a thread.
-	// inThread is explicitly provided by the caller (not derived from inReplyTo).
 	if inThread != "" {
 		rootEvent, err := c.GetRoomEventByEventID(ctx, space_id, room_id, inThread)
 		if err != nil {

--- a/cli/internal/core/rooms_test.go
+++ b/cli/internal/core/rooms_test.go
@@ -1999,6 +1999,60 @@ func TestChattoCore_PostMessage_Threading(t *testing.T) {
 			t.Errorf("Expected ReplyCount=3, got %d", metadata.ReplyCount)
 		}
 	})
+
+	t.Run("inThread is derived from inReplyTo target when caller omits it", func(t *testing.T) {
+		// Post a root message that starts a thread.
+		rootEvent, err := core.PostMessage(ctx, space.Id, room.Id, user.Id, "Inherit-thread root", nil, "", "", nil, false)
+		if err != nil {
+			t.Fatalf("Failed to post root message: %v", err)
+		}
+
+		// Post a thread reply (this is what the next message will reply to).
+		threadReply, err := core.PostMessage(ctx, space.Id, room.Id, user.Id, "Reply inside thread", nil, rootEvent.Id, "", nil, false)
+		if err != nil {
+			t.Fatalf("Failed to post thread reply: %v", err)
+		}
+
+		// Post a message with inReplyTo pointing into the thread but inThread empty,
+		// simulating a bot/extension/older client that doesn't know about inThread.
+		inherited, err := core.PostMessage(ctx, space.Id, room.Id, user.Id, "Reply attribution-only", nil, "", threadReply.Id, nil, false)
+		if err != nil {
+			t.Fatalf("Failed to post reply with empty inThread: %v", err)
+		}
+
+		msg := inherited.GetMessagePosted()
+		if msg == nil {
+			t.Fatal("Expected MessagePosted event")
+		}
+		if msg.InThread != rootEvent.Id {
+			t.Errorf("Expected InThread to be derived to %q, got %q", rootEvent.Id, msg.InThread)
+		}
+		if msg.InReplyTo != threadReply.Id {
+			t.Errorf("Expected InReplyTo to be %q, got %q", threadReply.Id, msg.InReplyTo)
+		}
+	})
+
+	t.Run("inThread stays empty when inReplyTo target is itself a root", func(t *testing.T) {
+		// Post a plain root message (not part of any thread).
+		root, err := core.PostMessage(ctx, space.Id, room.Id, user.Id, "Plain root", nil, "", "", nil, false)
+		if err != nil {
+			t.Fatalf("Failed to post root: %v", err)
+		}
+
+		// Reply to it with attribution only — no thread should be inferred.
+		reply, err := core.PostMessage(ctx, space.Id, room.Id, user.Id, "Channel reply to root", nil, "", root.Id, nil, false)
+		if err != nil {
+			t.Fatalf("Failed to post reply: %v", err)
+		}
+
+		msg := reply.GetMessagePosted()
+		if msg == nil {
+			t.Fatal("Expected MessagePosted event")
+		}
+		if msg.InThread != "" {
+			t.Errorf("Expected InThread to remain empty, got %q", msg.InThread)
+		}
+	})
 }
 
 func TestChattoCore_StreamRoomEventsLive(t *testing.T) {


### PR DESCRIPTION
## Summary

- `core.PostMessage` now derives `inThread` from the `inReplyTo` target when the caller leaves `inThread` empty, so messages from bots/extensions/older clients that only set attribution still join the right thread.
- Fixes broken "in reply to" navigation: clicking the attribution link previously fell back to room-scrolling and couldn't find a target that lived inside a thread.
- Added two unit tests under `TestChattoCore_PostMessage_Threading` covering the derivation case and the no-thread negative case. Existing data already written without `inThread` is not retroactively repaired (accepted in alpha).

## Test plan

- [x] `go test ./internal/core/ -run TestChattoCore_PostMessage`
- [x] `go test ./internal/graph/...`
- [ ] Manually post via NATS extension a message with `inReplyTo` pointing into a thread and no `inThread`; click the attribution link in the channel UI and verify the thread pane opens with the target highlighted.