### PR TITLE
feat(frontend): pin first 4 quick-reaction slots, recents fill the last 2

### DIFF
--- a/frontend/e2e/recent-reactions.test.ts
+++ b/frontend/e2e/recent-reactions.test.ts
@@ -17,21 +17,24 @@ test.describe('Recent reactions', () => {
     await roomPage.sendMessage('Message 1');
     const message2 = await roomPage.sendMessage('Message 2');
 
-    // Check default quick reactions on the toolbar
+    // Check default quick reactions on the toolbar:
+    // first 4 slots are pinned, last 2 are fallback defaults
     const defaultReactions = await message2.getToolbarQuickReactions();
-    expect(defaultReactions).toEqual(['👍', '❤️', '😂', '😮', '😢', '🎉']);
+    expect(defaultReactions).toEqual(['👍', '👋', '🤣', '🙏', '❤️', '😂']);
 
     // React with a non-default emoji via the emoji picker
     const message1 = roomPage.getMessage('Message 1');
     await message1.reactViaEmojiPicker('rocket', 'rocket');
     await message1.expectReaction('🚀', 1);
 
-    // Now hover message2 — rocket should be first in the quick reactions
+    // Now hover message2 — rocket should be at the first non-pinned slot (4).
+    // Pinned slots 0-3 are unchanged.
     const updatedReactions = await message2.getToolbarQuickReactions();
-    expect(updatedReactions[0]).toBe('🚀');
+    expect(updatedReactions.slice(0, 4)).toEqual(['👍', '👋', '🤣', '🙏']);
+    expect(updatedReactions[4]).toBe('🚀');
     expect(updatedReactions).toHaveLength(6);
-    // The last default emoji should have fallen off
-    expect(updatedReactions).not.toContain('🎉');
+    // The last fallback emoji should have been pushed off
+    expect(updatedReactions).not.toContain('😂');
   });
 
   test('recent reactions persist across page reload', async ({ page, chatPage, roomPage }) => {
@@ -50,10 +53,12 @@ test.describe('Recent reactions', () => {
     await page.reload();
     await expect(page.getByText('Persist test')).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
 
-    // Send another message and check the toolbar
+    // Send another message and check the toolbar:
+    // pinned slots 0-3 unchanged, fire surfaced at slot 4
     const message2 = await roomPage.sendMessage('After reload');
     const reactions = await message2.getToolbarQuickReactions();
-    expect(reactions[0]).toBe('🔥');
+    expect(reactions.slice(0, 4)).toEqual(['👍', '👋', '🤣', '🙏']);
+    expect(reactions[4]).toBe('🔥');
   });
 
   test('quick reaction buttons do not change order', async ({ page, chatPage, roomPage }) => {
@@ -67,11 +72,11 @@ test.describe('Recent reactions', () => {
 
     // React with a quick reaction via the toolbar (not the emoji picker)
     const message1 = roomPage.getMessage('First message');
-    await message1.reactViaToolbar('🎉');
-    await message1.expectReaction('🎉', 1);
+    await message1.reactViaToolbar('❤️');
+    await message1.expectReaction('❤️', 1);
 
     // Order should remain unchanged — quick reactions don't update recency
     const reactions = await message2.getToolbarQuickReactions();
-    expect(reactions).toEqual(['👍', '❤️', '😂', '😮', '😢', '🎉']);
+    expect(reactions).toEqual(['👍', '👋', '🤣', '🙏', '❤️', '😂']);
   });
 });

--- a/frontend/src/lib/emoji.ts
+++ b/frontend/src/lib/emoji.ts
@@ -85,10 +85,23 @@ export function searchEmojis(query: string, limit = 10): EmojiResult[] {
 }
 
 /**
- * Quick reaction emojis for the reaction picker toolbar.
- * Shared constant to avoid duplication across components.
+ * Total number of slots shown in the quick-reaction toolbar.
+ * The first PINNED_REACTIONS.length slots are stable; the rest track recent usage.
  */
-export const QUICK_REACTIONS = ['👍', '❤️', '😂', '😮', '😢', '🎉'] as const;
+export const QUICK_REACTIONS_COUNT = 6;
+
+/**
+ * Pinned emojis that always occupy the leading slots of the quick-reaction toolbar,
+ * in display order. Eventually intended to be user-configurable.
+ */
+export const PINNED_REACTIONS = ['👍', '👋', '🤣', '🙏'] as const;
+
+/**
+ * Fallback emojis used to fill the trailing (non-pinned) slots of the
+ * quick-reaction toolbar when the user has not yet accumulated enough
+ * non-pinned recent reactions. Listed in priority order.
+ */
+export const RECENT_REACTION_FALLBACKS = ['❤️', '😂', '😮', '😢', '🎉'] as const;
 
 /**
  * Reverse lookup: Unicode emoji → shortcode name.

--- a/frontend/src/lib/state/recentReactions.svelte.spec.ts
+++ b/frontend/src/lib/state/recentReactions.svelte.spec.ts
@@ -1,8 +1,15 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { QUICK_REACTIONS } from '$lib/emoji';
+import {
+  PINNED_REACTIONS,
+  QUICK_REACTIONS_COUNT,
+  RECENT_REACTION_FALLBACKS
+} from '$lib/emoji';
 import { RecentReactionsState } from './recentReactions.svelte';
 
 const STORAGE_KEY = 'chatto:recentReactions';
+
+const PINNED_COUNT = PINNED_REACTIONS.length;
+const TRAILING_SLOTS = QUICK_REACTIONS_COUNT - PINNED_COUNT;
 
 describe('RecentReactionsState', () => {
   beforeEach(() => {
@@ -10,76 +17,125 @@ describe('RecentReactionsState', () => {
   });
 
   describe('initial state', () => {
-    it('returns the default QUICK_REACTIONS list when storage is empty', () => {
+    it('returns the pinned set followed by fallbacks when storage is empty', () => {
       const state = new RecentReactionsState();
-      expect([...state.quickReactions]).toEqual([...QUICK_REACTIONS]);
+      expect([...state.quickReactions]).toEqual([
+        ...PINNED_REACTIONS,
+        ...RECENT_REACTION_FALLBACKS.slice(0, TRAILING_SLOTS)
+      ]);
     });
 
-    it('always returns exactly QUICK_REACTIONS.length items', () => {
+    it('always returns exactly QUICK_REACTIONS_COUNT items', () => {
       const state = new RecentReactionsState();
-      expect(state.quickReactions.length).toBe(QUICK_REACTIONS.length);
+      expect(state.quickReactions.length).toBe(QUICK_REACTIONS_COUNT);
     });
 
-    it('hydrates the persisted recent list', () => {
+    it('hydrates non-pinned recents into the trailing slots', () => {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(['🚀', '🔥']));
       const state = new RecentReactionsState();
-      expect(state.quickReactions.slice(0, 2)).toEqual(['🚀', '🔥']);
+      const list = [...state.quickReactions];
+      expect(list.slice(0, PINNED_COUNT)).toEqual([...PINNED_REACTIONS]);
+      expect(list[PINNED_COUNT]).toBe('🚀');
+      expect(list[PINNED_COUNT + 1]).toBe('🔥');
     });
 
     it('ignores corrupt JSON without throwing', () => {
       localStorage.setItem(STORAGE_KEY, 'not-json');
       const state = new RecentReactionsState();
-      expect([...state.quickReactions]).toEqual([...QUICK_REACTIONS]);
+      expect([...state.quickReactions]).toEqual([
+        ...PINNED_REACTIONS,
+        ...RECENT_REACTION_FALLBACKS.slice(0, TRAILING_SLOTS)
+      ]);
     });
 
     it('ignores non-array payloads', () => {
       localStorage.setItem(STORAGE_KEY, JSON.stringify({ not: 'an array' }));
       const state = new RecentReactionsState();
-      expect([...state.quickReactions]).toEqual([...QUICK_REACTIONS]);
+      expect([...state.quickReactions]).toEqual([
+        ...PINNED_REACTIONS,
+        ...RECENT_REACTION_FALLBACKS.slice(0, TRAILING_SLOTS)
+      ]);
     });
 
     it('filters non-string entries on load', () => {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(['🚀', 42, null, '🔥']));
       const state = new RecentReactionsState();
-      expect(state.quickReactions.slice(0, 2)).toEqual(['🚀', '🔥']);
+      const list = [...state.quickReactions];
+      expect(list[PINNED_COUNT]).toBe('🚀');
+      expect(list[PINNED_COUNT + 1]).toBe('🔥');
     });
   });
 
   describe('record', () => {
-    it('moves a recorded emoji to the front', () => {
+    it('surfaces a recorded non-pinned emoji at the first trailing slot', () => {
       const state = new RecentReactionsState();
       state.record('🚀');
-      expect(state.quickReactions[0]).toBe('🚀');
+      expect(state.quickReactions[PINNED_COUNT]).toBe('🚀');
     });
 
-    it('deduplicates: re-recording the same emoji keeps it at the front', () => {
+    it('does not shift the pinned set', () => {
+      const state = new RecentReactionsState();
+      state.record('🚀');
+      state.record('🔥');
+      state.record('✨');
+      expect(state.quickReactions.slice(0, PINNED_COUNT)).toEqual([...PINNED_REACTIONS]);
+    });
+
+    it('recording a pinned emoji does not duplicate it or push out non-pinned recents', () => {
+      const state = new RecentReactionsState();
+      state.record('🚀');
+      state.record('🔥');
+      const before = [...state.quickReactions];
+
+      // Record one of the pinned emojis
+      state.record(PINNED_REACTIONS[0]);
+
+      const after = [...state.quickReactions];
+      expect(after).toEqual(before);
+      // Pinned emoji should appear exactly once (in its pinned slot)
+      expect(after.filter((e) => e === PINNED_REACTIONS[0]).length).toBe(1);
+    });
+
+    it('only the most recent TRAILING_SLOTS non-pinned emojis are shown', () => {
+      const state = new RecentReactionsState();
+      state.record('🚀');
+      state.record('🔥');
+      state.record('✨');
+      state.record('🌟');
+
+      const list = [...state.quickReactions];
+      // Slots 4-5 should be the two most recently recorded
+      expect(list[PINNED_COUNT]).toBe('🌟');
+      expect(list[PINNED_COUNT + 1]).toBe('✨');
+    });
+
+    it('deduplicates: re-recording the same emoji keeps it at the first trailing slot', () => {
       const state = new RecentReactionsState();
       state.record('🚀');
       state.record('🔥');
       state.record('🚀');
-      expect(state.quickReactions[0]).toBe('🚀');
-      expect(state.quickReactions[1]).toBe('🔥');
+      expect(state.quickReactions[PINNED_COUNT]).toBe('🚀');
+      expect(state.quickReactions[PINNED_COUNT + 1]).toBe('🔥');
     });
 
-    it('caps the list at QUICK_REACTIONS.length', () => {
+    it('caps internal recent history at 10 entries', () => {
       const state = new RecentReactionsState();
-      const many = ['🚀', '🔥', '✨', '🌟', '💫', '⭐', '🌈', '🎯'];
+      const many = ['🚀', '🔥', '✨', '🌟', '💫', '⭐', '🌈', '🎯', '🦄', '🍕', '🎸'];
       for (const e of many) state.record(e);
-      expect(state.quickReactions.length).toBe(QUICK_REACTIONS.length);
-      expect(state.quickReactions[0]).toBe('🎯');
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]');
+      expect(stored.length).toBe(10);
+      expect(stored[0]).toBe('🎸');
     });
 
-    it('backfills with defaults when fewer than max have been recorded', () => {
+    it('backfills with fallback defaults when fewer than TRAILING_SLOTS non-pinned recents exist', () => {
       const state = new RecentReactionsState();
       state.record('🚀');
       const list = [...state.quickReactions];
-      expect(list.length).toBe(QUICK_REACTIONS.length);
-      expect(list[0]).toBe('🚀');
-      // Remaining slots are defaults (QUICK_REACTIONS may include the recorded emoji,
-      // which is fine — it just means it gets surfaced once at position 0).
-      for (let i = 1; i < list.length; i++) {
-        expect(QUICK_REACTIONS).toContain(list[i]);
-      }
+      expect(list.length).toBe(QUICK_REACTIONS_COUNT);
+      expect(list.slice(0, PINNED_COUNT)).toEqual([...PINNED_REACTIONS]);
+      expect(list[PINNED_COUNT]).toBe('🚀');
+      // Remaining trailing slots come from the fallback list
+      expect(RECENT_REACTION_FALLBACKS).toContain(list[PINNED_COUNT + 1]);
     });
 
     it('persists to localStorage', () => {

--- a/frontend/src/lib/state/recentReactions.svelte.ts
+++ b/frontend/src/lib/state/recentReactions.svelte.ts
@@ -5,14 +5,21 @@
  * as the quick reaction list (hover bar, context menu, mobile action sheet).
  * Persisted to localStorage so preferences survive page reloads.
  *
- * When a user reacts with any emoji, it moves to the front of the list.
- * The list is backfilled with defaults so there are always 6 quick reactions.
+ * The quick reaction list is a fixed-size array of QUICK_REACTIONS_COUNT
+ * slots: the first PINNED_REACTIONS.length slots are always the pinned
+ * emojis, and the remaining slots are filled with the user's most recently
+ * used non-pinned emojis (backfilled from RECENT_REACTION_FALLBACKS so the
+ * list always returns exactly QUICK_REACTIONS_COUNT entries).
  */
 
-import { QUICK_REACTIONS } from '$lib/emoji';
+import {
+  PINNED_REACTIONS,
+  QUICK_REACTIONS_COUNT,
+  RECENT_REACTION_FALLBACKS
+} from '$lib/emoji';
 
 const STORAGE_KEY = 'chatto:recentReactions';
-const MAX_RECENT = QUICK_REACTIONS.length;
+const MAX_RECENT = 10;
 
 export class RecentReactionsState {
   private recent = $state<string[]>([]);
@@ -34,17 +41,28 @@ export class RecentReactionsState {
   }
 
   /**
-   * The quick reactions list: user's recent emojis first,
-   * backfilled with defaults to always return exactly 6.
+   * The quick reactions list: pinned emojis followed by the user's most
+   * recent non-pinned emojis, backfilled with fallback defaults so the
+   * list always has exactly QUICK_REACTIONS_COUNT entries.
    */
   get quickReactions(): readonly string[] {
-    const result = [...this.recent];
-    for (const emoji of QUICK_REACTIONS) {
-      if (result.length >= MAX_RECENT) break;
+    const pinned = PINNED_REACTIONS as readonly string[];
+    const result: string[] = [...pinned];
+
+    for (const emoji of this.recent) {
+      if (result.length >= QUICK_REACTIONS_COUNT) break;
       if (!result.includes(emoji)) {
         result.push(emoji);
       }
     }
+
+    for (const emoji of RECENT_REACTION_FALLBACKS) {
+      if (result.length >= QUICK_REACTIONS_COUNT) break;
+      if (!result.includes(emoji)) {
+        result.push(emoji);
+      }
+    }
+
     return result;
   }
 


### PR DESCRIPTION
## Summary

The quick-reaction toolbar previously filled all 6 slots with the user's most-recent emojis, which made the bar shift on every reaction and hurt muscle memory. This PR reserves slots 0-3 for a stable pinned set (👍 👋 🤣 🙏) and only lets slots 4-5 track the most-recent non-pinned emojis, backfilling with fallback defaults so the bar always shows 6. The internal recent-history cap is bumped to 10 so we still have non-pinned recents to surface when the user mostly reacts with pinned ones. Pinned set is hardcoded for now but structured to be made configurable later.

## Test plan

- [x] Unit tests in `recentReactions.svelte.spec.ts` updated and extended (pinned-stays-stable, recording-pinned-is-noop, 2-most-recent-non-pinned)
- [x] Full frontend unit suite passes (`pnpm test:unit --run`)
- [x] `pnpm check` clean
- [ ] E2E `recent-reactions.test.ts` (updated, runs in CI)
- [ ] Manual: open hover toolbar, confirm slots 0-3 are 👍 👋 🤣 🙏 and slots 4-5 are fallback defaults; react via picker with a non-pinned emoji and confirm it surfaces at slot 4 without disturbing the pinned set