### PR TITLE
fix(frontend): restore DM list ordering, unread dot, notification dot

### DIFF
--- a/frontend/src/lib/dm/DMConversationList.svelte
+++ b/frontend/src/lib/dm/DMConversationList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { instanceIdToSegment } from '$lib/navigation';
   import { instanceRegistry } from '$lib/state/instance/registry.svelte';
@@ -18,6 +19,7 @@
   import { getLiveDisplayName } from '$lib/state/userProfiles.svelte';
   import { SvelteSet } from 'svelte/reactivity';
   import type { EventHandler } from '$lib/instanceEventBus.svelte';
+  import { mergeInstanceConversations } from './mergeConversations';
 
   let {
     activeConversationId
@@ -87,18 +89,16 @@
         id: room.id,
         instanceId,
         instanceLabel: label,
-        hasUnread: room.hasUnread,
+        // The active conversation is being viewed — don't let a refetch
+        // resurrect a stale `hasUnread: true` against the local clearing effect.
+        hasUnread: room.id === activeConversationId ? false : room.hasUnread,
         participants,
         currentUserId: meId,
         isSelfConversation: others.length === 0
       };
     });
 
-    // Replace this instance's conversations in the merged list
-    conversations = [
-      ...conversations.filter((c) => c.instanceId !== instanceId),
-      ...newConversations
-    ];
+    conversations = mergeInstanceConversations(conversations, instanceId, newConversations);
   }
 
   /** Load conversations from all connected instances in parallel. */
@@ -161,48 +161,62 @@
     loadAllConversations();
   });
 
-  // Clear unread status when entering a conversation
+  // Clear unread status and dismiss DM notifications when entering a conversation.
   $effect(() => {
-    if (activeConversationId) {
-      const conv = conversations.find((c) => c.id === activeConversationId);
-      if (conv) conv.hasUnread = false;
-    }
+    if (!activeConversationId) return;
+    const conv = conversations.find((c) => c.id === activeConversationId);
+    if (!conv) return;
+    conv.hasUnread = false;
+    const stores = instanceRegistry.tryGetStore(conv.instanceId);
+    void stores?.notifications.dismissDMNotifications(conv.id);
   });
 
-  // Subscribe to DM notifications from ALL instance event buses.
-  // This replaces the old useSpaceEvent + useNewDM pattern which required
-  // being inside a specific instance's context.
+  // Click handler for the per-conversation notification dot: dismiss the
+  // notification and navigate (mirrors RoomList's handleRoomNotificationClick).
+  async function handleDMNotificationClick(event: MouseEvent, conv: DMConversation) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const stores = instanceRegistry.tryGetStore(conv.instanceId);
+    if (!stores) return;
+    const notification = stores.notifications.getDMRoomNotification(conv.id);
+    if (!notification) return;
+
+    void stores.notifications.dismiss(notification.id);
+
+    const path = stores.notifications.getCleanPath(conv.instanceId, notification);
+    // eslint-disable-next-line svelte/no-navigation-without-resolve -- path from getCleanPath() is already resolved
+    await goto(path);
+  }
+
+  // Whether a given conversation has a pending DM notification on its instance.
+  function convHasNotification(conv: DMConversation): boolean {
+    return instanceRegistry.tryGetStore(conv.instanceId)?.notifications.hasDMRoomNotification(conv.id) ?? false;
+  }
+
+  // Per instance, subscribe to two event sources that should bump a DM
+  // conversation to the top: the instance event bus (NewDirectMessageNotificationEvent,
+  // covers incoming DMs from other users) and the DM space subscription
+  // (MessagePostedEvent, covers your own outgoing messages too).
   $effect(() => {
     const cleanups: (() => void)[] = [];
 
     for (const instance of instanceRegistry.instances) {
-      const bus = instanceEventBusManager.getBus(instance.id);
-      if (!bus) continue;
-
-      const handler: EventHandler = (event) => {
-        if (event.event?.__typename === 'NewDirectMessageNotificationEvent') {
-          bumpConversationToTop(
-            instance.id,
-            event.event.roomId,
-            event.event.roomId !== activeConversationId
-          );
-        }
+      const bumpFromEvent = (roomId: string) => {
+        bumpConversationToTop(instance.id, roomId, roomId !== activeConversationId);
       };
 
-      bus.handlers.add(handler);
-      cleanups.push(() => bus.handlers.delete(handler));
-    }
+      const bus = instanceEventBusManager.getBus(instance.id);
+      if (bus) {
+        const handler: EventHandler = (event) => {
+          if (event.event?.__typename === 'NewDirectMessageNotificationEvent') {
+            bumpFromEvent(event.event.roomId);
+          }
+        };
+        bus.handlers.add(handler);
+        cleanups.push(() => bus.handlers.delete(handler));
+      }
 
-    return () => cleanups.forEach((c) => c());
-  });
-
-  // Subscribe to DM space events (MessagePostedEvent) per instance.
-  // This catches ALL messages (including your own) so the sidebar updates
-  // immediately when you send a message — not just when you receive one.
-  $effect(() => {
-    const subs: (() => void)[] = [];
-
-    for (const instance of instanceRegistry.instances) {
       const client = graphqlClientManager.getClient(instance.id);
       const sub = client.client
         .subscription(SpaceEventBusSubscriptionDocument, { spaceId: DM_SPACE_ID })
@@ -210,17 +224,13 @@
           if (!result.data) return;
           const event = useFragment(RoomEventViewFragmentDoc, result.data.mySpaceEvents);
           if (event?.event?.__typename === 'MessagePostedEvent') {
-            bumpConversationToTop(
-              instance.id,
-              event.event.roomId,
-              event.event.roomId !== activeConversationId
-            );
+            bumpFromEvent(event.event.roomId);
           }
         });
-      subs.push(() => sub.unsubscribe());
+      cleanups.push(() => sub.unsubscribe());
     }
 
-    return () => subs.forEach((s) => s());
+    return () => cleanups.forEach((c) => c());
   });
 
   // Whether we're connected to multiple instances (controls instance label display)
@@ -266,9 +276,19 @@
           {/if}
         </div>
 
-        <!-- Unread Indicator -->
-        {#if conv.hasUnread}
-          <UnreadDot />
+        {#if convHasNotification(conv)}
+          <button
+            type="button"
+            onclick={(e) => handleDMNotificationClick(e, conv)}
+            class="-mr-2 flex h-6 w-6 cursor-pointer items-center justify-center notification-dot"
+            aria-label="Go to notification"
+          >
+            <UnreadDot />
+          </button>
+          <span class="sr-only">new direct message</span>
+        {:else if conv.hasUnread}
+          <UnreadDot color="primary" testid="dm-unread-dot" />
+          <span class="sr-only">unread messages</span>
         {/if}
       </a>
     {/each}

--- a/frontend/src/lib/dm/mergeConversations.spec.ts
+++ b/frontend/src/lib/dm/mergeConversations.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { mergeInstanceConversations } from './mergeConversations';
+
+type Conv = { id: string; instanceId: string; tag?: string };
+
+const c = (id: string, instanceId: string, tag?: string): Conv => ({ id, instanceId, tag });
+
+describe('mergeInstanceConversations', () => {
+  it('preserves order of conversations from OTHER instances when one instance refetches', () => {
+    const existing = [c('a', 'i1'), c('b', 'i2'), c('c', 'i1'), c('d', 'i2')];
+    const loaded = [c('a', 'i1', 'fresh'), c('c', 'i1', 'fresh')];
+
+    const merged = mergeInstanceConversations(existing, 'i1', loaded);
+
+    // i2's entries stay in their original relative slots; i1's entries
+    // are replaced in place by their fresh versions.
+    expect(merged.map((x) => x.id)).toEqual(['a', 'b', 'c', 'd']);
+    expect(merged.find((x) => x.id === 'a')?.tag).toBe('fresh');
+    expect(merged.find((x) => x.id === 'c')?.tag).toBe('fresh');
+    expect(merged.find((x) => x.id === 'b')?.tag).toBeUndefined();
+  });
+
+  it('drops conversations that no longer exist server-side for this instance', () => {
+    const existing = [c('a', 'i1'), c('b', 'i1'), c('c', 'i1')];
+    const loaded = [c('a', 'i1'), c('c', 'i1')];
+
+    const merged = mergeInstanceConversations(existing, 'i1', loaded);
+
+    expect(merged.map((x) => x.id)).toEqual(['a', 'c']);
+  });
+
+  it('inserts genuinely new conversations at the front (server returns most-recent-first)', () => {
+    const existing = [c('a', 'i1'), c('b', 'i1')];
+    const loaded = [c('new', 'i1'), c('a', 'i1'), c('b', 'i1')];
+
+    const merged = mergeInstanceConversations(existing, 'i1', loaded);
+
+    expect(merged.map((x) => x.id)).toEqual(['new', 'a', 'b']);
+  });
+
+  it('does not touch other instances even when adding new conversations', () => {
+    const existing = [c('x', 'i2'), c('a', 'i1'), c('y', 'i2')];
+    const loaded = [c('new', 'i1'), c('a', 'i1')];
+
+    const merged = mergeInstanceConversations(existing, 'i1', loaded);
+
+    // 'new' goes to the front; 'a' stays where it was; i2 entries are
+    // untouched and keep their relative order.
+    expect(merged.map((x) => x.id)).toEqual(['new', 'x', 'a', 'y']);
+  });
+
+  it('handles initial load (empty existing)', () => {
+    const merged = mergeInstanceConversations<Conv>(
+      [],
+      'i1',
+      [c('a', 'i1'), c('b', 'i1')]
+    );
+    expect(merged.map((x) => x.id)).toEqual(['a', 'b']);
+  });
+
+  it('handles refetch returning empty (all conversations for the instance dropped)', () => {
+    const existing = [c('a', 'i1'), c('x', 'i2')];
+    const merged = mergeInstanceConversations(existing, 'i1', []);
+
+    expect(merged.map((x) => x.id)).toEqual(['x']);
+  });
+
+  it('preserves order when a bump-then-refetch happens (regression: refetch must not undo the bump)', () => {
+    // After a bump, conversation 'b' moved to the top of i1's slot.
+    const afterBump = [c('b', 'i1'), c('a', 'i1'), c('c', 'i1')];
+    // The server-driven refetch returns its own most-recent-first order
+    // (which happens to also have b at the top, since bumping was triggered
+    // by a new message in b).
+    const loaded = [c('b', 'i1'), c('a', 'i1'), c('c', 'i1')];
+
+    const merged = mergeInstanceConversations(afterBump, 'i1', loaded);
+
+    // The post-bump order is preserved — refetch replaces in place.
+    expect(merged.map((x) => x.id)).toEqual(['b', 'a', 'c']);
+  });
+});

--- a/frontend/src/lib/dm/mergeConversations.ts
+++ b/frontend/src/lib/dm/mergeConversations.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure merge helper for the DM conversation list.
+ *
+ * Goals:
+ * - Replacing entries for one instance must NOT move entries for OTHER
+ *   instances around. Otherwise a per-instance refetch (e.g. from
+ *   `bumpConversationToTop`'s "unknown room" path) destroys the
+ *   chronological ordering established by previous bumps.
+ * - Genuinely new conversations (server returned them but we hadn't seen
+ *   them locally) go to the front, since the server returns them sorted
+ *   most-recent-first.
+ * - Conversations that no longer exist server-side for this instance are
+ *   dropped.
+ */
+export function mergeInstanceConversations<T extends { id: string; instanceId: string }>(
+  existing: T[],
+  instanceId: string,
+  loaded: T[]
+): T[] {
+  const newById = new Map(loaded.map((c) => [c.id, c]));
+  const seenIds = new Set<string>();
+  const merged: T[] = [];
+
+  for (const conv of existing) {
+    if (conv.instanceId !== instanceId) {
+      merged.push(conv);
+      continue;
+    }
+    const replacement = newById.get(conv.id);
+    if (replacement) {
+      merged.push(replacement);
+      seenIds.add(conv.id);
+    }
+    // else: dropped (no longer exists server-side for this instance)
+  }
+
+  const additions = loaded.filter((c) => !seenIds.has(c.id));
+  return [...additions, ...merged];
+}

--- a/frontend/src/lib/state/instance/notifications.spec.ts
+++ b/frontend/src/lib/state/instance/notifications.spec.ts
@@ -201,6 +201,76 @@ describe('NotificationStore', () => {
     expect(store.notifications).toHaveLength(0);
   });
 
+  // The DM list dot uses hasDMRoomNotification per conversation. It must
+  // match DM notifications by room, and ignore non-DM notifications even if
+  // they happen to share a room id.
+  it('hasDMRoomNotification / getDMRoomNotification scope to DM notifications by room', () => {
+    const dmA = {
+      __typename: 'DMMessageNotificationItem',
+      id: 'dm-a',
+      createdAt: new Date('2026-04-29T12:00:00Z').toISOString(),
+      actor: {
+        id: 'u',
+        login: 't',
+        displayName: 't',
+        avatarUrl: null,
+        presenceStatus: 'OFFLINE'
+      },
+      summary: 'hi',
+      room: { id: 'roomA' }
+    } as unknown as NotificationItem;
+    const dmB = {
+      __typename: 'DMMessageNotificationItem',
+      id: 'dm-b',
+      createdAt: new Date('2026-04-29T13:00:00Z').toISOString(),
+      actor: {
+        id: 'u',
+        login: 't',
+        displayName: 't',
+        avatarUrl: null,
+        presenceStatus: 'OFFLINE'
+      },
+      summary: 'later',
+      room: { id: 'roomA' }
+    } as unknown as NotificationItem;
+    const roomMention = {
+      __typename: 'MentionNotificationItem',
+      id: 'mention-same-id',
+      createdAt: new Date().toISOString(),
+      actor: {
+        id: 'u',
+        login: 't',
+        displayName: 't',
+        avatarUrl: null,
+        presenceStatus: 'OFFLINE'
+      },
+      summary: 'mention',
+      mentionSpace: { id: 's', name: 'S' },
+      mentionRoom: { id: 'roomA', name: 'r' },
+      mentionEventId: 'e'
+    } as unknown as NotificationItem;
+
+    const store = new NotificationStore(makeClient({}));
+    // Most-recent-first ordering, as fetch() would produce.
+    store.notifications = [dmB, dmA, roomMention];
+
+    expect(store.hasDMRoomNotification('roomA')).toBe(true);
+    expect(store.hasDMRoomNotification('roomB')).toBe(false);
+
+    // getDMRoomNotification returns the freshest DM, not the mention,
+    // even when the mention's roomId matches.
+    expect(store.getDMRoomNotification('roomA')?.id).toBe('dm-b');
+
+    // hasRoomNotification (the non-DM variant) must NOT see DM notifications
+    // — that's how the regular sidebar dot stays orthogonal to the DM dot.
+    expect(store.hasRoomNotification('roomA')).toBe(true); // matched by mention
+    // If we drop the mention, hasRoomNotification goes false even though
+    // DMs still target that room id.
+    store.notifications = [dmB, dmA];
+    expect(store.hasRoomNotification('roomA')).toBe(false);
+    expect(store.hasDMRoomNotification('roomA')).toBe(true);
+  });
+
   // Per-instance isolation: each instance has its own NotificationStore, and
   // an error in one must not affect notifications loaded on another.
   it('one store failing does not affect a sibling store', async () => {

--- a/frontend/src/lib/state/instance/notifications.svelte.ts
+++ b/frontend/src/lib/state/instance/notifications.svelte.ts
@@ -287,6 +287,25 @@ export class NotificationStore {
   }
 
   /**
+   * Check if a specific DM conversation has pending notifications.
+   * Counterpart to {@link hasRoomNotification}, which excludes DMs.
+   */
+  hasDMRoomNotification(roomId: string): boolean {
+    return this.notifications.some(
+      (n) => n.__typename === 'DMMessageNotificationItem' && n.room.id === roomId
+    );
+  }
+
+  /**
+   * Get the most recent notification for a DM conversation.
+   */
+  getDMRoomNotification(roomId: string): NotificationItem | undefined {
+    return this.notifications.find(
+      (n) => n.__typename === 'DMMessageNotificationItem' && n.room.id === roomId
+    );
+  }
+
+  /**
    * Dismiss all thread-scoped notifications (replies + mentions) for a thread.
    * Called when a user opens a thread to clear the notification indicator.
    */


### PR DESCRIPTION
## Summary

- The DM list now keeps its chronological order across per-instance refetches: `mergeInstanceConversations` (extracted to a pure helper with tests) replaces an instance's entries in place instead of bucketing them to the bottom, which was scrambling the order whenever `bumpConversationToTop` had to refetch an unknown conversation.
- The unread dot is reliable again: the active conversation is loaded with `hasUnread: false` baked in, so a refetch can no longer resurrect a stale `true` against the clearing effect.
- A per-conversation DM notification dot is wired in (mirroring `RoomList`), backed by two new `NotificationStore` helpers (`hasDMRoomNotification` / `getDMRoomNotification`) that scope to `DMMessageNotificationItem` and stay orthogonal to the non-DM `hasRoomNotification`.
- The two per-instance subscription `$effect` blocks (instance event bus + DM space subscription) are collapsed into one with a shared `bumpFromEvent` closure.

## Test plan

- [x] `mise x -- pnpm run check` — 0 errors, 0 warnings
- [x] `mise test-frontend` — 46 files / 747 tests pass (+8 new tests across `mergeConversations.spec.ts` and `notifications.spec.ts`)
- [ ] Manual: post messages across DMs in one instance and confirm the list reorders to most-recent-first; reload to confirm the order persists.
- [ ] Manual: receive a DM in another conversation; the unread dot appears; clicking in clears it instantly with no flicker; reloading while parked on the conversation does not bring it back.
- [ ] Manual: trigger a DM notification (tab unfocused or via push) and confirm the warning-tone notification dot appears; clicking it dismisses the notification and navigates into the conversation.
- [ ] Multi-instance: post a new DM on instance #2; that conversation should bump to the top without disturbing instance #1's relative order.