### PR TITLE
feat(server): primary-space config bridge + ADR-027 (#330 phase 1)

### DIFF
--- a/cli/chatto.toml
+++ b/cli/chatto.toml
@@ -80,8 +80,3 @@ password = 'devpassword'
 name = 'Engineering'
 description = 'Where things happen'
 owner_login = 'devuser'
-
-[[bootstrap.spaces]]
-name = 'Lounge'
-description = 'Off-topic chatter'
-owner_login = 'devuser'

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -122,6 +122,28 @@ func runServer(configPath string) {
 	// Run dev startup hook (auto-bootstrap in dev builds, no-op in prod)
 	devStartupHook(ctx, chattoCore, cfg)
 
+	// Resolve the primary space (ADR-027 migration bridge). Run after the dev
+	// startup hook so bootstrap-created spaces are visible.
+	//
+	// A configured-but-missing primary fails the boot — that's a faulty config
+	// and we'd rather refuse to start than silently pick something else. An
+	// ambiguous unset primary (multiple spaces, none configured) is logged as
+	// a warning and the deployment runs without a primary; later phases of the
+	// migration will tighten this into a hard error once callers exist.
+	primarySpaceID, err := chattoCore.ResolvePrimarySpaceID(ctx, cfg.Server.PrimarySpaceID)
+	switch {
+	case err != nil && cfg.Server.PrimarySpaceID != "":
+		log.Fatal("Failed to resolve configured primary space", "error", err)
+	case err != nil:
+		log.Warn("Could not auto-derive a primary space; set server.primary_space_id explicitly to silence this", "error", err)
+	case primarySpaceID == "":
+		log.Info("Primary space not yet set (no user-facing spaces exist)")
+	case cfg.Server.PrimarySpaceID != "":
+		log.Info("Primary space resolved from config", "spaceID", primarySpaceID)
+	default:
+		log.Info("Primary space auto-derived from single user-facing space", "spaceID", primarySpaceID)
+	}
+
 	// Run health checks in background (non-blocking)
 	go runHealthChecks(ctx, chattoCore)
 

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -341,6 +341,16 @@ func (c *OwnersConfig) IsInstanceOwnerEmail(email string) bool {
 	return false
 }
 
+// ServerConfig holds settings that pin "the one space that matters" for the
+// in-progress consolidation of Instance + Space into a single Server concept
+// (see ADR-027 / issue #330). This whole section is migration debt by design
+// — once phase 4 of that migration completes, Instance and Space have collapsed
+// into a single Server entity and there's no longer a distinction to bridge,
+// so this section is removed.
+type ServerConfig struct {
+	PrimarySpaceID string `toml:"primary_space_id,commented" env:"CHATTO_SERVER_PRIMARY_SPACE_ID" comment:"ID of the space treated as this deployment's primary (future Server). Leave unset on single-space instances — it auto-derives. Required when more than one user-facing space exists. See ADR-027; this setting is temporary and will be removed when the Instance/Space → Server migration completes."`
+}
+
 // SMTPConfig contains settings for sending transactional emails.
 type SMTPConfig struct {
 	Enabled  bool   `toml:"enabled" env:"CHATTO_SMTP_ENABLED" comment:"Enable SMTP for sending transactional emails (verification, password reset, etc.)."`
@@ -456,6 +466,7 @@ type ChattoConfig struct {
 	Core         CoreConfig         `toml:"core" comment:"Core service configuration."`
 	Auth         AuthConfig         `toml:"auth" comment:"Authentication configuration."`
 	Owners       OwnersConfig       `toml:"owners" comment:"Email addresses that confer instance-owner status."`
+	Server       ServerConfig       `toml:"server,commented" comment:"Migration bridge for the Instance + Space → Server consolidation (ADR-027). Temporary; will be removed when the migration completes."`
 	Limits       LimitsConfig       `toml:"limits,commented" comment:"Instance-wide resource limits. Use -1 for unlimited."`
 	SMTP         SMTPConfig         `toml:"smtp" comment:"SMTP configuration for transactional emails."`
 	Push         PushConfig         `toml:"push,commented" comment:"Web Push notification configuration."`
@@ -581,6 +592,12 @@ func (c *ChattoConfig) Validate() error {
 	}
 	if c.Limits.MaxUsers != nil && *c.Limits.MaxUsers < -1 {
 		errs = append(errs, "limits.max_users must be -1 (unlimited) or a non-negative integer")
+	}
+
+	// Server config (migration bridge for ADR-027). Existence of the space is
+	// checked at startup against actual KV state; this is just a shape check.
+	if c.Server.PrimarySpaceID != "" && strings.TrimSpace(c.Server.PrimarySpaceID) != c.Server.PrimarySpaceID {
+		errs = append(errs, "server.primary_space_id must not have leading or trailing whitespace")
 	}
 
 	// Asset cache configuration

--- a/cli/internal/core/server.go
+++ b/cli/internal/core/server.go
@@ -1,0 +1,70 @@
+package core
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+// ResolvePrimarySpaceID returns the space ID to treat as this deployment's
+// primary (future Server) for the migration described in ADR-027 and issue #330.
+//
+// The configuredID argument comes from config.ServerConfig.PrimarySpaceID
+// (env: CHATTO_SERVER_PRIMARY_SPACE_ID).
+//
+// Resolution rules:
+//
+//   - If configuredID is set, the named space must exist; we return its ID.
+//     A configured-but-missing primary is a faulty config and the caller (run.go)
+//     fails the boot rather than silently picking something else.
+//   - If configuredID is unset and there are zero user-facing spaces, returns
+//     ("", nil). This is the fresh-install case — no primary exists yet, and
+//     that's not an error.
+//   - If configuredID is unset and there is exactly one user-facing space,
+//     returns its ID (auto-derive). Covers the common single-space upgrade
+//     path with no operator action.
+//   - If configuredID is unset and there are two or more user-facing spaces,
+//     returns an error: the operator must pick one explicitly.
+//
+// "User-facing" here means: excluding the well-known DM hidden space
+// (DMSpaceID), which is created at core initialization for every deployment
+// and would otherwise mask the fresh-install case.
+func (c *ChattoCore) ResolvePrimarySpaceID(ctx context.Context, configuredID string) (string, error) {
+	if configuredID != "" {
+		if _, err := c.GetSpace(ctx, configuredID); err != nil {
+			return "", fmt.Errorf("configured server.primary_space_id %q does not exist: %w", configuredID, err)
+		}
+		return configuredID, nil
+	}
+
+	spaces, err := c.ListSpaces(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to list spaces while resolving primary space: %w", err)
+	}
+
+	userFacing := userFacingSpaces(spaces)
+	switch len(userFacing) {
+	case 0:
+		return "", nil
+	case 1:
+		return userFacing[0].Id, nil
+	default:
+		ids := make([]string, 0, len(userFacing))
+		for _, s := range userFacing {
+			ids = append(ids, s.Id)
+		}
+		return "", fmt.Errorf("multiple spaces present (%v) and server.primary_space_id is unset; set it explicitly to one of these IDs (see ADR-027)", ids)
+	}
+}
+
+func userFacingSpaces(spaces []*corev1.Space) []*corev1.Space {
+	out := make([]*corev1.Space, 0, len(spaces))
+	for _, s := range spaces {
+		if IsDMSpace(s.Id) {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}

--- a/cli/internal/core/server_test.go
+++ b/cli/internal/core/server_test.go
@@ -1,0 +1,89 @@
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolvePrimarySpaceID_ConfiguredAndExists(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	space, err := core.CreateSpace(ctx, "test-user", "Engineering", "")
+	if err != nil {
+		t.Fatalf("CreateSpace: %v", err)
+	}
+
+	got, err := core.ResolvePrimarySpaceID(ctx, space.Id)
+	if err != nil {
+		t.Fatalf("ResolvePrimarySpaceID: %v", err)
+	}
+	if got != space.Id {
+		t.Errorf("expected %q, got %q", space.Id, got)
+	}
+}
+
+func TestResolvePrimarySpaceID_ConfiguredButMissing(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	_, err := core.ResolvePrimarySpaceID(ctx, "Sdoesnotexist123")
+	if err == nil {
+		t.Fatal("expected error for missing configured space, got nil")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("expected 'does not exist' in error, got %v", err)
+	}
+}
+
+func TestResolvePrimarySpaceID_UnsetZeroSpaces(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	// Fresh-install case: only the DM space exists (created by core init).
+	got, err := core.ResolvePrimarySpaceID(ctx, "")
+	if err != nil {
+		t.Fatalf("ResolvePrimarySpaceID: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty primary on fresh install, got %q", got)
+	}
+}
+
+func TestResolvePrimarySpaceID_UnsetSingleSpace(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	space, err := core.CreateSpace(ctx, "test-user", "Engineering", "")
+	if err != nil {
+		t.Fatalf("CreateSpace: %v", err)
+	}
+
+	got, err := core.ResolvePrimarySpaceID(ctx, "")
+	if err != nil {
+		t.Fatalf("ResolvePrimarySpaceID: %v", err)
+	}
+	if got != space.Id {
+		t.Errorf("expected auto-derived %q, got %q", space.Id, got)
+	}
+}
+
+func TestResolvePrimarySpaceID_UnsetMultipleSpaces(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	if _, err := core.CreateSpace(ctx, "test-user", "Engineering", ""); err != nil {
+		t.Fatalf("CreateSpace: %v", err)
+	}
+	if _, err := core.CreateSpace(ctx, "test-user", "Lounge", ""); err != nil {
+		t.Fatalf("CreateSpace: %v", err)
+	}
+
+	_, err := core.ResolvePrimarySpaceID(ctx, "")
+	if err == nil {
+		t.Fatal("expected error for ambiguous unset primary, got nil")
+	}
+	if !strings.Contains(err.Error(), "multiple spaces") {
+		t.Errorf("expected 'multiple spaces' in error, got %v", err)
+	}
+}

--- a/docs/adr/ADR-027-instance-space-server-consolidation.md
+++ b/docs/adr/ADR-027-instance-space-server-consolidation.md
@@ -1,0 +1,67 @@
+# ADR-027: Consolidate Instance + Space into a Single "Server" Concept
+
+**Date:** 2026-05-04
+
+**Status:** Accepted (migration in progress)
+
+**Tracking issue:** [#330](https://github.com/chattocorp/chatto/issues/330)
+
+## Context
+
+Chatto currently has a two-layer top-level hierarchy: an **Instance** is the deployment-wide container (one per process / NATS account), and a **Space** is a membership group within an instance. Most concerns are duplicated across both layers:
+
+- Two parallel RBAC systems with overlapping role names (`instance-owner` vs `owner`, `instance-admin` vs `admin`, etc.) — see ADR-005 and `instance_rbac.go` / `space_rbac.go`.
+- Two membership models: a user belongs to an instance _and_ separately joins each space.
+- Two permission check paths in resolvers; helpers like `isConfigOwner` need to reason about both layers.
+- DMs are modelled as a hidden space (ADR-015), bolted on top of the space machinery.
+
+This is operationally redundant. In practice almost every deployment runs a single space per instance — the multi-space-per-instance flexibility is rarely exercised, but its cost is paid everywhere in the code and in the user's mental model. The terminology is also user-hostile: "instance" is alien outside the project, and "space" looks like Discord's "server" but isn't quite.
+
+The end state in #330 is a single **Server** concept where deployment = membership boundary = RBAC root, with one unified role hierarchy (`owner` / `admin` / `moderator` / `everyone`), DMs as rooms with `type: dm`, and a single auth/permission path through the codebase.
+
+We have public instances running with real user data, so this cannot be a flag-day rewrite. The migration must be incremental, with each step independently shippable and reversible.
+
+## Decision
+
+Migrate toward the unified **Server** model in small, independently mergeable PRs, using a **config-designated primary space** as the load-bearing bridge.
+
+### The primary space bridge
+
+Introduce a server-side configuration value (env var / `chatto.toml` setting) that names exactly one space within the instance as the **primary space**. Conceptually this primary space _is_ the future Server; everything else is legacy.
+
+- New deployments auto-create a primary space at bootstrap and the config points at it.
+- Existing deployments set the config to their existing single space (or, for the rare multi-space instance, pick one and treat the others as legacy until manually consolidated or dropped).
+- The config is **temporary** — its only purpose is to let us route code paths through "the one space that matters" without committing to schema changes yet. It will be removed at the end of the migration when Instance and Space have collapsed into a single Server entity.
+
+This bridge lets every subsequent step be a small, local refactor: each resolver, store, or UI surface that currently reasons about "the instance" or "all spaces" can be rewritten to reason about "the primary space," one at a time, with the legacy code paths kept alive until the last consumer is gone.
+
+### Migration phases (indicative, not contractual)
+
+Sequencing is decided per-PR; this is the rough order. The guiding principle is **behaviour-first, data-last**: change how the API, frontend, and product behave through the bridge config while the underlying schema, streams, and KV buckets stay exactly as they are today. Only once the codebase has settled into the Server shape do we touch the data layout, and only after _that_ do we simplify RBAC/membership.
+
+1. **Bridge in place.** Add the primary-space config (env var + `chatto.toml`), bootstrap behaviour for new instances (auto-create one space and point at it), and backfill behaviour for existing ones (point at the existing single space; for multi-space deployments, pick one and leave the rest as legacy). No semantic changes yet — every existing code path still works.
+2. **Rework API and frontend UX around the Server concept.** Anything user-facing or API-facing that currently splits instance from space gets reframed as a single layer routed through the primary space: GraphQL schema additions/aliases, frontend stores, navigation, settings pages, admin views, "this deployment" surfaces. Underlying storage and the legacy multi-space code paths stay intact behind the new surface.
+3. **DMs as rooms in the API/frontend.** Reframe DMs (currently a hidden space, ADR-015) as rooms with `type: dm` inside the Server at the API and UI level. The DM space's storage stays untouched at this stage — only how the API exposes them and how the frontend renders them changes.
+4. **Schema/data migration.** With the API and UX already behaving as if Server exists, rename streams and KV buckets to their Server-shaped equivalents and write a one-shot migration that copies data from the primary space's streams/buckets (and the DM hidden space) into the new layout. Legacy spaces that aren't the primary either get dropped, archived, or merged per a documented operator policy. The primary-space config is removed at the end of this phase — its job is done.
+5. **Consolidate and simplify membership and RBAC.** With a single Server and a single set of streams/buckets, collapse the instance-level and space-level role/membership systems into one. Remove the compatibility shims, the dual permission paths, and the `instance_*` vs `space_*` split in core. (Hierarchy-wins resolution from ADR-005 stays; only the two-layer split goes away.)
+
+Every PR contributing to this work references #330 and updates this ADR if it invalidates an assumption.
+
+### What we're explicitly _not_ doing
+
+- **No big-bang migration.** No single PR rewrites both layers at once.
+- **No data-layout changes until the API and UX have already settled into the Server shape.** Stream names, KV bucket names, and storage layout stay exactly as they are today through phases 1–3. This keeps the early phases trivially revertible and means we only run the data migration once we know the target shape is correct.
+- **No early RBAC/membership simplification.** RBAC and membership stay dual-layer through phases 1–4 even though it's tempting to clean them up sooner. Doing it before the data migration would mean re-doing it after, and the dual-layer code is the safety net that keeps the legacy paths working during migration.
+- **No removal of the multi-space-per-instance code paths until they have zero callers.** The legacy paths stay alive and tested until the data migration in phase 4 retires them.
+- **No support for multi-primary or pooled-tenant deployments.** One process = one server stays a hard invariant (per #330's "what stays the same").
+
+## Consequences
+
+- **Phases 1–3 are trivially revertible.** They only add new surfaces and reroute reads/writes through the bridge; the underlying streams, KV buckets, and legacy code paths stay byte-identical to today. Any PR in this range can be reverted without data loss or migration.
+- **Phase 4 is the one-way door.** Renaming streams/buckets and copying data is the irreversible step. By the time we run it, the API and UX have already proven out the Server shape end-to-end on real data, so the migration is mechanical rather than exploratory.
+- **Operators get a clear migration story.** "Set this one config value, point it at your existing space, keep running. When phase 4 ships, run `chatto migrate` once on upgrade." Multi-space operators get an explicit decision point at phase 4 (pick one, archive, or merge per the documented policy).
+- **The primary-space config is debt by design.** It exists only to enable the migration and is deleted at the end of phase 4. Leaving it in would re-introduce a two-layer model under a different name.
+- **Sustained duplication during phases 1–4.** Both instance-level and space-level code paths live in the tree simultaneously, and RBAC/membership stay dual-layer until phase 5. This is accepted; the alternative is doing the data migration and the RBAC simplification at the same time, which is exactly the flag-day risk we're trying to avoid.
+- **DMs cross the bridge twice.** Phase 3 reframes them at the API/UX level while their storage stays as the hidden DM space; phase 4 migrates that storage into the unified Server layout. Splitting it this way means the disruptive UX change and the disruptive data change never land in the same PR.
+- **Documentation churn.** `.claude/rules/admin.md`, `authorization.md`, and several feature docs reference "instance" and "space" as distinct concepts. They will be updated phase-by-phase as the underlying behaviour changes, not pre-emptively.
+- **#330 supersedes parts of ADR-015 in the long run.** ADR-015's "DMs as a hidden space" decision is retired once phase 4 completes; the consequences listed there (hardcoded permissions, `IsDMSpace` special cases) dissolve into normal room logic during phase 5's RBAC simplification.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -34,3 +34,4 @@ For more about ADRs, see [Michael Nygard's article](https://cognitect.com/blog/2
 | [ADR-024](ADR-024-opaque-bearer-tokens-for-cross-origin-auth.md) | Opaque Bearer Tokens for Cross-Origin Authentication | 2026-03-03 |
 | [ADR-025](ADR-025-multi-instance-client-architecture.md) | Multi-Instance Client Architecture | 2026-03-20 |
 | [ADR-026](ADR-026-event-identity-via-nanoid.md) | Event Identity via NanoID, Not JetStream Sequence Numbers | 2026-03-26 |
+| [ADR-027](ADR-027-instance-space-server-consolidation.md) | Consolidate Instance + Space into a Single "Server" Concept | 2026-05-04 |


### PR DESCRIPTION
## Summary

First step toward the Instance + Space → Server consolidation tracked in #330. Two commits:

- **ADR-027** lays out the five-phase, behaviour-first / data-last migration plan: bridge config → rework API+frontend → reframe DMs at the API level → migrate streams/KV and copy data → consolidate RBAC and membership. The primary-space config is migration debt by design and is removed at the end of phase 4.
- **The bridge itself**: new `[server] primary_space_id` config (env: `CHATTO_SERVER_PRIMARY_SPACE_ID`), a `core.ResolvePrimarySpaceID` resolver, and a startup check that fails boot on configured-but-missing primaries while warning on unset-but-ambiguous. The dev `chatto.toml` drops its second bootstrap space so the dev stack auto-derives cleanly. No callers yet — that's PR #2.

Refs #330.

## Test plan

- [x] `mise x -- go test ./internal/core/ ./internal/config/` (all green, including five new resolver tests)
- [x] `mise x -- go test -tags bootstrap ./cmd/` (bootstrap path still green after dropping Lounge)
- [x] `mise x -- go build -tags bootstrap ./...`
- [ ] Manual: spin up the dev stack and verify the "Primary space auto-derived from single user-facing space" log line fires