### PR TITLE
fix(bootstrap): auto-join bootstrap users to the primary space

### DIFF
--- a/cli/cmd/bootstrap.go
+++ b/cli/cmd/bootstrap.go
@@ -13,6 +13,6 @@ func init() {
 	// Register the bootstrap hook. Reads the [bootstrap] section from
 	// chatto.toml and applies it on every startup.
 	devStartupHook = func(ctx context.Context, c *core.ChattoCore, cfg config.ChattoConfig) {
-		applyBootstrap(ctx, c, cfg.Bootstrap)
+		applyBootstrap(ctx, c, cfg.Bootstrap, cfg.Server.PrimarySpaceID)
 	}
 }

--- a/cli/cmd/bootstrap_apply.go
+++ b/cli/cmd/bootstrap_apply.go
@@ -21,7 +21,7 @@ import (
 // Only compiled into builds with the `bootstrap` tag; release binaries replace
 // this with a no-op so the [bootstrap] section in chatto.toml is parsed but
 // ignored.
-func applyBootstrap(ctx context.Context, c *core.ChattoCore, cfg config.BootstrapConfig) {
+func applyBootstrap(ctx context.Context, c *core.ChattoCore, cfg config.BootstrapConfig, primarySpaceID string) {
 	logger := log.WithPrefix("bootstrap")
 
 	if len(cfg.Users) == 0 && len(cfg.Spaces) == 0 {
@@ -57,6 +57,15 @@ func applyBootstrap(ctx context.Context, c *core.ChattoCore, cfg config.Bootstra
 		} else {
 			spacesExisting++
 		}
+	}
+
+	// Mirror the regular signup flow: every bootstrap user joins the deployment's
+	// primary space. Bootstrap creates users via core.CreateUser directly, which
+	// bypasses the auth signup path that normally calls this. Without it, users
+	// other than the configured space owner (e.g. alice/bob in the dev config)
+	// would land in the instance with no space membership.
+	for _, userID := range loginToUserID {
+		c.JoinPrimarySpaceIfAvailable(ctx, userID, primarySpaceID)
 	}
 
 	logger.Info("[bootstrap] apply complete",

--- a/cli/cmd/bootstrap_test.go
+++ b/cli/cmd/bootstrap_test.go
@@ -82,7 +82,7 @@ func TestApplyBootstrap_CreatesUsersAndSpaces(t *testing.T) {
 			},
 		},
 	}
-	applyBootstrap(ctx, c, cfg)
+	applyBootstrap(ctx, c, cfg, "")
 
 	alice, err := c.GetUserByLogin(ctx, "alice")
 	if err != nil || alice == nil {
@@ -144,8 +144,8 @@ func TestApplyBootstrap_IsIdempotent(t *testing.T) {
 		},
 	}
 
-	applyBootstrap(ctx, c, cfg)
-	applyBootstrap(ctx, c, cfg) // second run should be a no-op for the same entries
+	applyBootstrap(ctx, c, cfg, "")
+	applyBootstrap(ctx, c, cfg, "") // second run should be a no-op for the same entries
 
 	spaces, err := c.ListSpaces(ctx)
 	if err != nil {
@@ -166,10 +166,56 @@ func TestApplyBootstrap_EmptySectionIsNoOp(t *testing.T) {
 	c := setupCore(t)
 	ctx := context.Background()
 
-	applyBootstrap(ctx, c, config.BootstrapConfig{}) // zero value, nothing to do
+	applyBootstrap(ctx, c, config.BootstrapConfig{}, "") // zero value, nothing to do
 
 	if u, err := c.GetUserByLogin(ctx, "alice"); err == nil && u != nil {
 		t.Errorf("expected no users to be created from an empty section")
+	}
+}
+
+// Bootstrap users are auto-joined to the deployment's primary space so non-owner
+// users (alice/bob in the dev config) actually land in a space rather than
+// existing as orphan members of the instance.
+func TestApplyBootstrap_AutoJoinsPrimarySpace(t *testing.T) {
+	c := setupCore(t)
+	ctx := context.Background()
+
+	cfg := config.BootstrapConfig{
+		Users: []config.BootstrapUser{
+			{Login: "devuser", Email: "dev@example.com", Password: "devpassword", InstanceRole: "owner"},
+			{Login: "alice", Email: "alice@example.com", Password: "devpassword"},
+			{Login: "bob", Email: "bob@example.com", Password: "devpassword"},
+		},
+		Spaces: []config.BootstrapSpace{
+			{Name: "Engineering", OwnerLogin: "devuser"},
+		},
+	}
+	applyBootstrap(ctx, c, cfg, "") // configuredID empty -> auto-derive
+
+	var engID string
+	spaces, _ := c.ListSpaces(ctx)
+	for _, sp := range spaces {
+		if sp.Name == "Engineering" {
+			engID = sp.Id
+			break
+		}
+	}
+	if engID == "" {
+		t.Fatal("expected Engineering space to exist")
+	}
+
+	for _, login := range []string{"alice", "bob"} {
+		u, err := c.GetUserByLogin(ctx, login)
+		if err != nil || u == nil {
+			t.Fatalf("expected %s to exist: %v", login, err)
+		}
+		isMember, err := c.SpaceMembershipExists(ctx, u.Id, engID)
+		if err != nil {
+			t.Fatalf("SpaceMembershipExists(%s): %v", login, err)
+		}
+		if !isMember {
+			t.Errorf("expected %s to be auto-joined to Engineering", login)
+		}
 	}
 }
 
@@ -185,7 +231,7 @@ func TestApplyBootstrap_BadOwnerLoginSkipsSpace(t *testing.T) {
 			{Name: "Orphan", OwnerLogin: "ghost"},
 		},
 	}
-	applyBootstrap(ctx, c, cfg)
+	applyBootstrap(ctx, c, cfg, "")
 
 	spaces, _ := c.ListSpaces(ctx)
 	for _, sp := range spaces {


### PR DESCRIPTION
## Summary

Bootstrap users are created via `core.CreateUser` directly, bypassing the auth signup flow that calls `JoinPrimarySpaceIfAvailable`. As a result, non-owner bootstrap users (alice/bob in the dev config) ended up as orphan instance members with no space membership — only the configured space owner (devuser) was a member of `Engineering`.

This threads `cfg.Server.PrimarySpaceID` through `applyBootstrap` and, after spaces are processed, calls `JoinPrimarySpaceIfAvailable` for every bootstrap user — mirroring the regular signup flow. Doing it after spaces are created matters: on a brand-new instance the resolver would otherwise see zero user-facing spaces and skip. Adds `TestApplyBootstrap_AutoJoinsPrimarySpace` covering the new behavior.

## Test plan

- [x] `mise x -- go test -tags bootstrap -run TestApplyBootstrap ./cmd/` passes
- [x] `mise x -- go vet -tags bootstrap ./cmd/... ./internal/core/...` clean
- [ ] Spin up a fresh dev stack and confirm alice/bob land in Engineering on first boot