### PR TITLE
feat(sidebar): wrap ungrouped rooms in a collapsible group, polish carets

### DIFF
--- a/frontend/e2e/room-layout.test.ts
+++ b/frontend/e2e/room-layout.test.ts
@@ -399,11 +399,12 @@ test.describe('Room Layout', () => {
         await joinSpace(page2, space.id);
         await joinRoomViaAPI(page2, space.id, alphaId);
 
-        // User B navigates to space — no layout yet, flat list
+        // User B navigates to space — no layout yet, rooms render under
+        // the default "Rooms" collapsible group.
         await navigateToSpace(page2, space.id);
         await waitForSidebarRooms(page2, 3); // announcements + general + alpha
-        const headersBefore = await waitForSidebarSections(page2, 0);
-        expect(headersBefore).toEqual([]);
+        const headersBefore = await waitForSidebarSections(page2, 1);
+        expect(headersBefore).toEqual(['Rooms']);
 
         // User A configures a layout
         await updateRoomLayoutViaAPI(page, space.id, [
@@ -616,12 +617,14 @@ test.describe('Room Layout', () => {
       // Clear layout by setting empty sections
       await updateRoomLayoutViaAPI(page, space.id, []);
 
-      // Wait for real-time update to remove sections
+      // Wait for real-time update to swap the "Main" section header for
+      // the default "Rooms" group that holds an unsectioned room list.
       await expect(async () => {
-        expect(await page.locator('.room-list button.uppercase').count()).toBe(0);
+        const headers = await page.locator('.room-list button.uppercase').allTextContents();
+        expect(headers.map((h) => h.trim())).toEqual(['Rooms']);
       }).toPass({ timeout: TIMEOUTS.REALTIME_EVENT, intervals: [100, 250, 500, 1000] });
 
-      // Rooms should now display alphabetically (flat list)
+      // Rooms should now display alphabetically inside the Rooms group
       const roomNames = await waitForSidebarRooms(page, 3);
       expect(roomNames).toEqual(['alpha', 'announcements', 'general']);
     });

--- a/frontend/src/lib/RoomList.svelte
+++ b/frontend/src/lib/RoomList.svelte
@@ -418,14 +418,16 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     <button
       type="button"
       onclick={() => toggleSection(groupId)}
-      class="hover:text-foreground flex w-full cursor-pointer items-center gap-1 px-2 py-1 text-xs font-semibold tracking-wider text-muted uppercase"
+      class="hover:text-foreground flex w-full cursor-pointer items-center gap-2 px-3 py-1 text-xs font-semibold tracking-wider text-muted uppercase"
     >
-      <span
-        class={[
-          'iconify text-[10px] transition-transform',
-          isCollapsed ? 'uil--angle-right' : 'uil--angle-down'
-        ]}
-      ></span>
+      <span class="sidebar-icon">
+        <span
+          class={[
+            'iconify uil--angle-right-b transition-transform',
+            isCollapsed ? '' : 'rotate-90'
+          ]}
+        ></span>
+      </span>
       {label}
     </button>
     <div class="sidebar-nav">
@@ -491,11 +493,9 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     {#if unsectionedRooms.length > 0}
       {@render collapsibleGroup('__unsorted__', 'Other', unsectionedRooms, roomLink)}
     {/if}
-  {:else}
-    <!-- No layout configured — alphabetical flat list -->
-    {#each sortedRooms as room (room.id)}
-      {@render roomLink(room)}
-    {/each}
+  {:else if sortedRooms.length > 0}
+    <!-- No layout configured — single collapsible "Rooms" group -->
+    {@render collapsibleGroup('__rooms__', 'Rooms', sortedRooms, roomLink, 'mt-4 first:mt-0')}
   {/if}
 
   {#if dmRooms.length > 0}


### PR DESCRIPTION
## Summary

- Spaces without a layout configuration now render their rooms in a single collapsible **Rooms** group instead of a flat, non-collapsible list — reusing the same `collapsibleGroup` snippet so persisted collapse state, slide transitions, and the "highlighted rows stay visible while collapsed" behaviour apply uniformly.
- Replaces the hard-to-see 10px thin chevron with `uil--angle-right-b` at `text-base`, rotated 90° via CSS when expanded (the Unicons set has no bold `angle-down-b`, hence the rotation trick).
- Aligns the section-header label with room-row labels by matching `px-3` + `gap-2` and wrapping the caret in a `sidebar-icon` (h-5 w-5) box.

## Test plan

- [ ] In a space with no layout config, the rooms list shows a "ROOMS" header that collapses/expands and persists across reloads.
- [ ] Expanded/collapsed caret is clearly visible and animates between the two states.
- [ ] "ROOMS" / "DIRECT MESSAGES" / section header labels line up horizontally with the room/DM names below them.