### PR TITLE
fix(push): align notification URLs with collapsed /chat/[instanceId]/[roomId] shape

### DIFF
--- a/cli/internal/push/push.go
+++ b/cli/internal/push/push.go
@@ -165,6 +165,8 @@ func BuildPayloadFromNotification(notif *corev1.Notification, actorDisplayName, 
 
 	// URL prefix for the home instance. Push notifications are always generated
 	// by the server the user is connected to, so the instance segment is always "-".
+	// Chat URLs go straight from instance segment to room ID — no spaceId, no /dm/
+	// prefix (DMs are surfaced as rooms under the primary space).
 	chatPrefix := baseURL + "/chat/-"
 
 	switch n := notif.Notification.(type) {
@@ -172,7 +174,7 @@ func BuildPayloadFromNotification(notif *corev1.Notification, actorDisplayName, 
 		payload.Title = fmt.Sprintf("@%s sent you a new DM", actorDisplayName)
 		payload.Body = preview
 		payload.Tag = "dm-" + n.DmMessage.EventId
-		payload.URL = chatPrefix + "/dm/" + n.DmMessage.RoomId
+		payload.URL = chatPrefix + "/" + n.DmMessage.RoomId
 
 	case *corev1.Notification_Mention:
 		if roomName != "" {
@@ -182,7 +184,7 @@ func BuildPayloadFromNotification(notif *corev1.Notification, actorDisplayName, 
 		}
 		payload.Body = preview
 		payload.Tag = "mention-" + n.Mention.EventId
-		payload.URL = chatPrefix + "/" + n.Mention.SpaceId + "/" + n.Mention.RoomId
+		payload.URL = chatPrefix + "/" + n.Mention.RoomId
 		if n.Mention.EventId != "" {
 			payload.URL += "?highlight=" + n.Mention.EventId
 		}
@@ -197,10 +199,10 @@ func BuildPayloadFromNotification(notif *corev1.Notification, actorDisplayName, 
 		payload.Tag = "reply-" + n.Reply.EventId
 		if n.Reply.InThread != "" {
 			// Thread reply: navigate to the thread (using thread root) and highlight the replied-to message
-			payload.URL = chatPrefix + "/" + n.Reply.SpaceId + "/" + n.Reply.RoomId + "/" + n.Reply.InThread + "?highlight=" + n.Reply.InReplyToId
+			payload.URL = chatPrefix + "/" + n.Reply.RoomId + "/" + n.Reply.InThread + "?highlight=" + n.Reply.InReplyToId
 		} else {
 			// Room-level reply: navigate to room and highlight the reply message
-			payload.URL = chatPrefix + "/" + n.Reply.SpaceId + "/" + n.Reply.RoomId + "?highlight=" + n.Reply.EventId
+			payload.URL = chatPrefix + "/" + n.Reply.RoomId + "?highlight=" + n.Reply.EventId
 		}
 
 	default:

--- a/cli/internal/push/push_test.go
+++ b/cli/internal/push/push_test.go
@@ -138,7 +138,7 @@ func TestBuildPayloadFromNotification(t *testing.T) {
 		if payload.Tag != "dm-event-789" {
 			t.Errorf("Expected tag 'dm-event-789', got %s", payload.Tag)
 		}
-		if payload.URL != "https://chatto.example.com/chat/-/dm/dm-room-456" {
+		if payload.URL != "https://chatto.example.com/chat/-/dm-room-456" {
 			t.Errorf("Expected URL for DM room, got %s", payload.URL)
 		}
 		if payload.NotificationID != "notif-123" {
@@ -187,7 +187,7 @@ func TestBuildPayloadFromNotification(t *testing.T) {
 		if payload.Body != "" {
 			t.Errorf("Expected empty body, got %s", payload.Body)
 		}
-		if payload.URL != "https://chatto.example.com/chat/-/space-1/room-2?highlight=event-3" {
+		if payload.URL != "https://chatto.example.com/chat/-/room-2?highlight=event-3" {
 			t.Errorf("Expected URL with highlight param, got %s", payload.URL)
 		}
 	})
@@ -229,7 +229,7 @@ func TestBuildPayloadFromNotification(t *testing.T) {
 
 		payload := BuildPayloadFromNotification(notif, "Charlie", baseURL, nil)
 
-		if payload.URL != "https://chatto.example.com/chat/-/space-1/room-2" {
+		if payload.URL != "https://chatto.example.com/chat/-/room-2" {
 			t.Errorf("Expected URL without event param, got %s", payload.URL)
 		}
 	})
@@ -260,7 +260,7 @@ func TestBuildPayloadFromNotification(t *testing.T) {
 			t.Errorf("Expected tag 'reply-reply-event', got %s", payload.Tag)
 		}
 		// Room-level reply navigates to room with highlight
-		if payload.URL != "https://chatto.example.com/chat/-/space-x/room-y?highlight=reply-event" {
+		if payload.URL != "https://chatto.example.com/chat/-/room-y?highlight=reply-event" {
 			t.Errorf("Expected URL for room with highlight, got %s", payload.URL)
 		}
 	})
@@ -285,7 +285,7 @@ func TestBuildPayloadFromNotification(t *testing.T) {
 			t.Errorf("Expected '@Diana replied to you', got %s", payload.Title)
 		}
 		// Thread reply: navigate to thread root and highlight the replied-to message
-		expectedURL := "https://chatto.example.com/chat/-/space-x/room-y/thread-root?highlight=mid-thread-msg"
+		expectedURL := "https://chatto.example.com/chat/-/room-y/thread-root?highlight=mid-thread-msg"
 		if payload.URL != expectedURL {
 			t.Errorf("Expected URL %s, got %s", expectedURL, payload.URL)
 		}


### PR DESCRIPTION
## Summary

The recent URL collapse (#332/#335) dropped both the `[spaceId]` segment and the `/dm/` prefix from chat URLs, but `BuildPayloadFromNotification` was still producing the old shapes — meaning every push notification target URL was broken.

- DM: `/chat/-/dm/{roomId}` → `/chat/-/{roomId}`
- Mention / room-level reply: `/chat/-/{spaceId}/{roomId}[?highlight=…]` → `/chat/-/{roomId}[?highlight=…]`
- Thread reply: `/chat/-/{spaceId}/{roomId}/{threadRoot}?highlight=…` → `/chat/-/{roomId}/{threadRoot}?highlight=…`
- `push_test.go` expectations updated accordingly.

## Test plan

- [x] `mise x -- go test ./internal/push/...`
- [ ] Manual: trigger a DM, a mention, and a thread reply and confirm the push notification opens the right room/thread.