### PR TITLE
fix(sidebar): exclude self from DM label and avatars reliably

### DIFF
--- a/frontend/src/lib/RoomList.svelte
+++ b/frontend/src/lib/RoomList.svelte
@@ -172,15 +172,23 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
 
   // DM display name: comma-joined participants other than the current user
   // (or "You" for self-DMs).
+  //
+  // `meId` comes from `roomsStore.currentUserId`, which is captured from the
+  // same `me { id, rooms { members } }` query that produced `room.members`.
+  // Reading the viewer ID from a global auth context here is unsafe — the
+  // [instanceId] layout intentionally renders children while the per-instance
+  // CurrentUserState is still loading, so `currentUserState.user?.id` can be
+  // undefined for the first render and the filter would include self in the
+  // label/avatars (e.g. a 1:1 with Teal rendering as "Teal, hmans").
   function dmDisplayName(room: SpaceRoom): string {
-    const meId = currentUserState.user?.id;
+    const meId = roomsStore.currentUserId;
     const others = room.members.filter((m) => m.id !== meId);
     if (others.length === 0) return 'You';
     return others.map((m) => getLiveDisplayName(m.id, m.displayName || m.login)).join(', ');
   }
 
   function dmAvatarParticipants(room: SpaceRoom) {
-    const meId = currentUserState.user?.id;
+    const meId = roomsStore.currentUserId;
     const others = room.members.filter((m) => m.id !== meId);
     if (others.length === 0) {
       // Self-DM: show own avatar

--- a/frontend/src/lib/state/space/rooms.svelte.spec.ts
+++ b/frontend/src/lib/state/space/rooms.svelte.spec.ts
@@ -31,7 +31,7 @@ function makeRawRoom(id: string, overrides: Partial<RawRoom> = {}): RawRoom {
 }
 
 type QueryResponse = {
-  me: { rooms: RawRoom[] } | null;
+  me: { id: string; rooms: RawRoom[] } | null;
   space: {
     roomLayout: {
       sections: { id: string; name: string; rooms: { id: string }[] }[];
@@ -90,6 +90,7 @@ describe('SpaceRoomsStore — initial load', () => {
   it('populates rooms, filters archived, and clears loading flag', async () => {
     const { store } = makeStore({
       me: {
+        id: 'u_self',
         rooms: [
           makeRawRoom('r1', { name: 'general' }),
           makeRawRoom('r2', { name: 'archived', archived: true }),
@@ -114,9 +115,20 @@ describe('SpaceRoomsStore — initial load', () => {
     });
   });
 
+  it('captures the viewer id from me.id so the sidebar can filter self from DM members', async () => {
+    const { store } = makeStore({
+      me: { id: 'u_self', rooms: [makeRawRoom('r1')] },
+      space: null
+    });
+
+    expect(store.currentUserId).toBeNull();
+    await settle();
+    expect(store.currentUserId).toBe('u_self');
+  });
+
   it('maps room layout sections and unsectioned ids', async () => {
     const { store } = makeStore({
-      me: { rooms: [makeRawRoom('r1'), makeRawRoom('r2'), makeRawRoom('r3')] },
+      me: { id: 'u_self', rooms: [makeRawRoom('r1'), makeRawRoom('r2'), makeRawRoom('r3')] },
       space: {
         roomLayout: {
           sections: [
@@ -137,7 +149,7 @@ describe('SpaceRoomsStore — initial load', () => {
 
   it('leaves layout null when space has no roomLayout', async () => {
     const { store } = makeStore({
-      me: { rooms: [makeRawRoom('r1')] },
+      me: { id: 'u_self', rooms: [makeRawRoom('r1')] },
       space: { roomLayout: null }
     });
 
@@ -150,6 +162,7 @@ describe('SpaceRoomsStore — initial load', () => {
   it('forwards notification preferences and unread init to instance stores', async () => {
     const { store, notificationLevels, roomUnread } = makeStore({
       me: {
+        id: 'u_self',
         rooms: [
           makeRawRoom('r1', {
             viewerNotificationPreference: { level: 'ALL', effectiveLevel: 'ALL' }
@@ -187,6 +200,7 @@ describe('SpaceRoomsStore — flag mutations', () => {
   async function makeLoaded() {
     const fixture = makeStore({
       me: {
+        id: 'u_self',
         rooms: [
           makeRawRoom('r1', { hasUnread: true, hasMention: true }),
           makeRawRoom('r2')
@@ -275,7 +289,7 @@ describe('SpaceRoomsStore — ingestSpaceEvent', () => {
     'RoomArchivedEvent',
     'RoomUnarchivedEvent'
   ])('refreshes on %s', async (typename) => {
-    const { store, queryMock } = makeStore({ me: { rooms: [] }, space: null });
+    const { store, queryMock } = makeStore({ me: { id: 'u_self', rooms: [] }, space: null });
     await settle();
     const callsBefore = queryMock.mock.calls.length;
 
@@ -288,7 +302,7 @@ describe('SpaceRoomsStore — ingestSpaceEvent', () => {
   it.each(['MessagePostedEvent', 'ReactionAddedEvent', 'PresenceUpdatedEvent'])(
     'ignores %s',
     async (typename) => {
-      const { store, queryMock } = makeStore({ me: { rooms: [] }, space: null });
+      const { store, queryMock } = makeStore({ me: { id: 'u_self', rooms: [] }, space: null });
       await settle();
       const callsBefore = queryMock.mock.calls.length;
 
@@ -300,7 +314,7 @@ describe('SpaceRoomsStore — ingestSpaceEvent', () => {
   );
 
   it('ignores events with no event payload', async () => {
-    const { store, queryMock } = makeStore({ me: { rooms: [] }, space: null });
+    const { store, queryMock } = makeStore({ me: { id: 'u_self', rooms: [] }, space: null });
     await settle();
     const callsBefore = queryMock.mock.calls.length;
 
@@ -324,7 +338,7 @@ describe('SpaceRoomsStore — concurrent refresh guard', () => {
       resolveFirst = r;
     });
     const secondResponse = {
-      data: { me: { rooms: [makeRawRoom('r_second')] }, space: null },
+      data: { me: { id: 'u_self', rooms: [makeRawRoom('r_second')] }, space: null },
       error: null
     };
 
@@ -347,7 +361,7 @@ describe('SpaceRoomsStore — concurrent refresh guard', () => {
     void store.refresh();
 
     // Now resolve the first (stale) response. The store must NOT apply it.
-    resolveFirst({ data: { me: { rooms: [makeRawRoom('r_first')] }, space: null }, error: null });
+    resolveFirst({ data: { me: { id: 'u_self', rooms: [makeRawRoom('r_first')] }, space: null }, error: null });
     await settle();
 
     expect(store.rooms.map((r) => r.id)).toEqual(['r_second']);

--- a/frontend/src/lib/state/space/rooms.svelte.ts
+++ b/frontend/src/lib/state/space/rooms.svelte.ts
@@ -79,6 +79,12 @@ export class SpaceRoomsStore {
   layoutSections = $state<SpaceLayoutSection[] | null>(null);
   unsectionedRoomIds = $state<string[]>([]);
   isInitialLoading = $state(true);
+  // The viewer's user ID, captured from the same `me { id, rooms }` query
+  // that produced `rooms`. Use this in preference to a global auth context
+  // when filtering self out of `room.members` — by construction it is set
+  // whenever there are rooms (with members) to render, eliminating any race
+  // with the auth context being briefly empty during route transitions.
+  currentUserId = $state<string | null>(null);
 
   private loadId = 0;
 
@@ -101,6 +107,7 @@ export class SpaceRoomsStore {
     if (this.loadId !== thisLoad) return;
 
     if (result.data?.me) {
+      this.currentUserId = result.data.me.id;
       const allRooms = result.data.me.rooms;
 
       for (const room of allRooms) {


### PR DESCRIPTION
## Summary

The collapsed DM list in the sidebar would intermittently render the current user's own name in the participant label (e.g. a 1:1 with Teal showing as "Teal, hmans", and a self-DM showing as "hmans" instead of "You"). Root cause: `dmDisplayName` / `dmAvatarParticipants` filtered self out of `room.members` using `currentUserState.user?.id`, which can briefly be `undefined` during route transitions because `[instanceId]/+layout.svelte` intentionally renders children while the per-instance `CurrentUserState` is still loading.

Fixed by hoisting `me.id` from the rooms query into a new `SpaceRoomsStore.currentUserId` field and using that for the filter — by construction it is set atomically with `room.members`, eliminating the race entirely.

## Test plan

- [x] `mise test-frontend` — 780/780 pass (added a regression test asserting `currentUserId` is captured on load)
- [x] `mise x -- pnpm check` — 0 errors, 0 warnings
- [ ] Manual: confirm 1:1 and self DMs render correctly in the sidebar on the affected instance