### PR TITLE
feat(composer): auto-focus on room/DM navigation, skip on touch

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -4,7 +4,12 @@ services:
       context: .
       dockerfile: Dockerfile.dev
     working_dir: /app/cli
-    command: ["watchexec", "-r", "--poll", "500ms", "-e", "go", "--", "go", "run", "-tags", "bootstrap", ".", "start"]
+    # The Go backend has `//go:embed all:.client` pointing at the SvelteKit
+    # build output. Under Compose the frontend runs as a separate Vite dev
+    # server (no build copied into .client/), but the embed directive still
+    # requires the directory to exist or `go run` fails to compile. Ensure
+    # it's present before watchexec starts the build loop.
+    command: ["sh", "-c", "mkdir -p internal/http_server/.client && exec watchexec -r --poll 500ms -e go -- go run -tags bootstrap . start"]
     environment:
       CHATTO_WEBSERVER_URL: https://${COMPOSE_PROJECT_NAME}.orb.local
       # Shared dev infrastructure runs in OrbStack's Kubernetes (see the

--- a/frontend/e2e/composer.test.ts
+++ b/frontend/e2e/composer.test.ts
@@ -176,3 +176,120 @@ test.describe('Composer focus', () => {
     expect(fileChooser).toBeTruthy();
   });
 });
+
+// Use #general (postable) as the starting room and a freshly-created custom
+// room (also postable) as the navigation target. We can't use #announcements
+// — its special permissions deny message.post for regular members, which
+// leaves the composer's contenteditable disabled, so focus can never land
+// on it regardless of the navigation behaviour we're testing.
+
+async function setupTwoRooms(
+  page: import('@playwright/test').Page,
+  chatPage: import('./pages').ChatPage
+): Promise<string> {
+  await createAndLoginTestUser(page);
+  await chatPage.goto();
+  await chatPage.createSpace();
+  const targetRoom = await chatPage.createRoom();
+  await chatPage.enterRoom('general');
+  await waitForRoomReady(page, 'general');
+  return targetRoom;
+}
+
+async function navigateViaSidebar(
+  page: import('@playwright/test').Page,
+  chatPage: import('./pages').ChatPage,
+  targetRoom: string
+) {
+  // Move focus off the composer onto a sidebar link — a faithful proxy for
+  // "user clicked a sidebar room link, then we navigate".
+  const targetLink = chatPage.roomList.getByRole('link', { name: `# ${targetRoom}` });
+  await targetLink.focus();
+  await targetLink.click();
+  await waitForRoomReady(page, targetRoom);
+}
+
+async function navigateViaQuickSwitcher(
+  page: import('@playwright/test').Page,
+  targetRoom: string
+) {
+  const isMac = process.platform === 'darwin';
+  await page.keyboard.press(isMac ? 'Meta+k' : 'Control+k');
+  const dialog = page.locator('dialog.quick-switcher');
+  await expect(dialog).toBeVisible({ timeout: TIMEOUTS.UI_FAST });
+
+  // Filter to the target room and pick it via Enter. The <dialog>'s close()
+  // wants to return focus to its invoker — the composer must win that race
+  // on desktop, and stay out of the way on touch devices.
+  await dialog
+    .getByPlaceholder('Go to space, room, conversation, or user...')
+    .fill(`#${targetRoom}`);
+  await expect(
+    dialog.locator('button.sidebar-item').filter({ hasText: `#${targetRoom}` })
+  ).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+  await page.keyboard.press('Enter');
+
+  await expect(dialog).not.toBeVisible({ timeout: TIMEOUTS.UI_FAST });
+  await waitForRoomReady(page, targetRoom);
+}
+
+test.describe('Composer auto-focus on navigation (desktop)', () => {
+  test('clicking a room in the sidebar focuses the composer', async ({
+    page,
+    chatPage,
+    roomPage
+  }) => {
+    const targetRoom = await setupTwoRooms(page, chatPage);
+    await navigateViaSidebar(page, chatPage, targetRoom);
+    await expect(roomPage.messageInput).toBeFocused({ timeout: TIMEOUTS.UI_STANDARD });
+  });
+
+  test('selecting a room in the quick switcher focuses the composer', async ({
+    page,
+    chatPage,
+    roomPage
+  }) => {
+    const targetRoom = await setupTwoRooms(page, chatPage);
+    await navigateViaQuickSwitcher(page, targetRoom);
+    await expect(roomPage.messageInput).toBeFocused({ timeout: TIMEOUTS.UI_STANDARD });
+  });
+});
+
+test.describe('Composer auto-focus on navigation (touch device)', () => {
+  // `isMobile: true` on Chromium makes `(pointer: coarse)` match, which is
+  // what `shouldAutoFocus()` reads. We deliberately keep a desktop-sized
+  // viewport so the sidebar is visible (no hamburger) — this isolates the
+  // touch-detection gate from the mobile-layout chrome.
+  test.use({ hasTouch: true, isMobile: true, viewport: { width: 1280, height: 720 } });
+
+  test('does NOT focus the composer on sidebar navigation', async ({
+    page,
+    chatPage,
+    roomPage
+  }) => {
+    const targetRoom = await setupTwoRooms(page, chatPage);
+    await navigateViaSidebar(page, chatPage, targetRoom);
+
+    // Wait for canPost to load (editor becomes editable). On desktop this is
+    // when the autofocus effect fires — proves we've waited long enough that
+    // any focus would have landed.
+    await expect(roomPage.messageInput).toHaveAttribute('contenteditable', 'true', {
+      timeout: TIMEOUTS.UI_STANDARD
+    });
+    await expect(roomPage.messageInput).not.toBeFocused();
+  });
+
+  test('does NOT focus the composer on quick switcher selection', async ({
+    page,
+    chatPage,
+    roomPage
+  }) => {
+    const targetRoom = await setupTwoRooms(page, chatPage);
+    await navigateViaQuickSwitcher(page, targetRoom);
+
+    await expect(roomPage.messageInput).toHaveAttribute('contenteditable', 'true', {
+      timeout: TIMEOUTS.UI_STANDARD
+    });
+    await expect(roomPage.messageInput).not.toBeFocused();
+  });
+});

--- a/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -303,16 +303,19 @@
       (hasVisibleContent(message) || selectedFiles.length > 0 || isEditing)
   );
 
-  // Auto-focus the input when the component mounts, room changes, or a reply starts.
-  // Skip on touch devices where keyboard popup would be jarring.
+  // Auto-focus the input when the component mounts, room changes, a reply
+  // starts, or the editor becomes editable (canPost loads async after a
+  // navigation, so on sidebar/quick-switcher room changes the editor is
+  // briefly contenteditable=false — calling focus() then is a no-op).
+  // Skip on touch devices where the keyboard popup would be jarring.
   $effect(() => {
     if (!autoFocus || !shouldAutoFocus()) return;
 
-    // Track roomId, inReplyTo, and editorApi as dependencies
+    // Tracked as dependencies so the effect re-fires on each of these.
     void roomId;
     void inReplyTo;
 
-    if (editorApi) {
+    if (editorApi && !inputDisabled) {
       tick().then(() => editorApi?.focus());
     }
   });


### PR DESCRIPTION
## Summary

- Composer now auto-focuses when navigating to a room or DM via sidebar or quick switcher, by adding `inputDisabled` to the existing autofocus effect's deps so it re-fires when `canPost` finishes loading and the editor flips editable. Touch devices are unaffected via the existing `shouldAutoFocus()` (`pointer: coarse`) gate, so the on-screen keyboard does not pop.
- E2E coverage in `frontend/e2e/composer.test.ts`: desktop sidebar + quick-switcher both land focus on the composer; touch-device variants (`isMobile: true`) assert it stays unfocused. The touch tests were verified to fail when the gate is removed.
- Dev-stack drive-by: restores `cli/internal/http_server/.client/.gitkeep` (accidentally deleted in #333, which broke `//go:embed all:.client` on fresh checkouts) and hardens the Compose `app` service with a `mkdir -p` so the dev stack self-heals.

## Test plan

- [x] `mise x -- pnpm exec playwright test e2e/composer.test.ts` — 9/9 pass
- [ ] Manual: cold-load room URL, sidebar click between rooms, quick-switcher selection, all auto-focus the composer; opening a thread does not steal focus from ThreadPane; iOS Safari does not pop the keyboard.