### PR TITLE
chore(conductor): add archive script to clean up docker volumes

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,5 +1,6 @@
 {
     "scripts": {
-        "run": "docker compose up"
+        "run": "docker compose up",
+        "archive": "docker compose down -v"
     }
 }


### PR DESCRIPTION
## Summary
Adds a `scripts.archive` entry to `conductor.json` that runs `docker compose down -v` before Conductor archives a workspace, ensuring container volumes are cleaned up so old workspaces don't leave Docker state behind.

## Test plan
- [ ] Archive a workspace in Conductor and confirm `docker compose down -v` runs and removes volumes.