### PR TITLE
feat(quick-switcher): match against server name and support multi-token queries

### DIFF
--- a/frontend/src/lib/components/QuickSwitcher.svelte
+++ b/frontend/src/lib/components/QuickSwitcher.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
-  import { fuzzyMatch } from '$lib/fuzzyMatch';
+  import { scoreItem } from './quickSwitcherSearch';
   import { instanceIdToSegment } from '$lib/navigation';
   import { instanceRegistry } from '$lib/state/instance/registry.svelte';
   import { graphqlClientManager } from '$lib/state/instance/graphqlClient.svelte';
@@ -25,6 +25,7 @@
     label: string;
     detail: string;
     instanceId: string;
+    instanceName: string;
     spaceId?: string;
     spaceLogo?: SpaceLogo;
     participants?: UserAvatarUserFragment[];
@@ -47,6 +48,7 @@
   type InstanceContext = {
     instanceId: string;
     instanceLabel: string;
+    instanceName: string;
     spaceIds: string[];
     currentUserId: string | undefined;
     dmUserIds: Set<string>;
@@ -153,6 +155,7 @@
               label: space.name,
               detail: instanceLabel,
               instanceId: instance.id,
+              instanceName,
               spaceId: space.id,
               spaceLogo: logo,
               score: 0
@@ -192,6 +195,7 @@
               label,
               detail: instanceLabel,
               instanceId: instance.id,
+              instanceName,
               participants,
               currentUserId,
               score: 0
@@ -203,6 +207,7 @@
         contexts.push({
           instanceId: instance.id,
           instanceLabel,
+          instanceName,
           spaceIds: spaces.map((s) => s.id),
           currentUserId,
           dmUserIds
@@ -231,6 +236,7 @@
                   label: room.name,
                   detail: space.name,
                   instanceId: instance.id,
+                  instanceName,
                   spaceId: space.id,
                   spaceLogo: logo,
                   score: 0
@@ -250,6 +256,7 @@
         label: 'Browse Spaces',
         detail: '',
         instanceId: '',
+        instanceName: '',
         href: resolve('/chat/spaces'),
         icon: 'uil--compass',
         score: 0
@@ -261,6 +268,7 @@
       label: 'Notifications',
       detail: '',
       instanceId: '',
+      instanceName: '',
       href: '/chat/notifications',
       icon: 'uil--bell',
       score: 0
@@ -271,6 +279,7 @@
       label: 'Connected Instances',
       detail: '',
       instanceId: '',
+      instanceName: '',
       href: resolve('/instances'),
       icon: 'uil--globe',
       score: 0
@@ -330,6 +339,7 @@
                 label: user.displayName || user.login,
                 detail: ctx.instanceLabel,
                 instanceId: ctx.instanceId,
+                instanceName: ctx.instanceName,
                 participants: [user],
                 currentUserId: ctx.currentUserId,
                 score: 0
@@ -405,23 +415,22 @@
       return [...pool].sort((a, b) => a.label.localeCompare(b.label));
     }
 
-    // Client-side fuzzy match on eagerly loaded items (spaces, rooms, DMs, destinations)
+    // Multi-token fuzzy match across label, space name (detail), and instance name.
     const scored: ResultItem[] = [];
     for (const item of pool) {
-      const labelScore = fuzzyMatch(q, item.label);
-      const detailScore = fuzzyMatch(q, item.detail);
-      let best = Math.max(labelScore ?? 0, (detailScore ?? 0) * 0.5);
-      if (best > 0) {
-        // Boost recent destinations
-        const url = itemUrl(item);
-        if (url) {
-          const recentIndex = recentUrls.indexOf(url);
-          if (recentIndex !== -1) {
-            best += 300 - recentIndex * 20;
-          }
+      const matchScore = scoreItem(q, item);
+      if (matchScore === null) continue;
+
+      let best = matchScore;
+      // Boost recent destinations
+      const url = itemUrl(item);
+      if (url) {
+        const recentIndex = recentUrls.indexOf(url);
+        if (recentIndex !== -1) {
+          best += 300 - recentIndex * 20;
         }
-        scored.push({ ...item, score: best });
       }
+      scored.push({ ...item, score: best });
     }
 
     scored.sort((a, b) => b.score - a.score);

--- a/frontend/src/lib/components/quickSwitcherSearch.test.ts
+++ b/frontend/src/lib/components/quickSwitcherSearch.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { scoreItem, type Searchable } from './quickSwitcherSearch';
+
+const generalEng: Searchable = {
+  label: 'general',
+  detail: 'Engineering',
+  instanceName: 'Work'
+};
+
+const generalChatto: Searchable = {
+  label: 'general',
+  detail: 'Chatto Community',
+  instanceName: 'Chatto Community'
+};
+
+const random: Searchable = {
+  label: 'random',
+  detail: 'Engineering',
+  instanceName: 'Work'
+};
+
+describe('scoreItem', () => {
+  it('returns null for an empty query', () => {
+    expect(scoreItem('', generalEng)).toBeNull();
+    expect(scoreItem('   ', generalEng)).toBeNull();
+  });
+
+  it('matches a single token against the label', () => {
+    expect(scoreItem('general', generalEng)).not.toBeNull();
+    expect(scoreItem('general', random)).toBeNull();
+  });
+
+  it('matches a single token against the space name (detail)', () => {
+    expect(scoreItem('engineering', generalEng)).not.toBeNull();
+  });
+
+  it('matches a single token against the instance name', () => {
+    expect(scoreItem('chatto', generalChatto)).not.toBeNull();
+  });
+
+  it('requires every token to match somewhere', () => {
+    expect(scoreItem('general xyz', generalChatto)).toBeNull();
+  });
+
+  it('matches multi-token query across label and detail/instance', () => {
+    // The motivating case: "general chatto" should match the room in
+    // Chatto Community but not the one in Engineering / Work.
+    expect(scoreItem('general chatto', generalChatto)).not.toBeNull();
+    expect(scoreItem('general chatto', generalEng)).toBeNull();
+  });
+
+  it('is order-independent across tokens', () => {
+    const forward = scoreItem('general chatto', generalChatto);
+    const reverse = scoreItem('chatto general', generalChatto);
+    expect(forward).not.toBeNull();
+    expect(reverse).not.toBeNull();
+    // Same tokens, same per-token best — total should match.
+    expect(forward).toBe(reverse);
+  });
+
+  it('ranks label hits above detail hits above instance hits', () => {
+    const labelHit: Searchable = { label: 'foo', detail: 'bar', instanceName: 'baz' };
+    const detailHit: Searchable = { label: 'bar', detail: 'foo', instanceName: 'baz' };
+    const instanceHit: Searchable = { label: 'bar', detail: 'baz', instanceName: 'foo' };
+
+    const labelScore = scoreItem('foo', labelHit)!;
+    const detailScore = scoreItem('foo', detailHit)!;
+    const instanceScore = scoreItem('foo', instanceHit)!;
+
+    expect(labelScore).toBeGreaterThan(detailScore);
+    expect(detailScore).toBeGreaterThan(instanceScore);
+  });
+
+  it('a label match beats a detail-only match for tie-breaking similar items', () => {
+    // generalEng (label "general") vs generalChatto (label "general"); query
+    // "general" alone — both match in label, scores equal.
+    expect(scoreItem('general', generalEng)).toBe(scoreItem('general', generalChatto));
+  });
+});

--- a/frontend/src/lib/components/quickSwitcherSearch.ts
+++ b/frontend/src/lib/components/quickSwitcherSearch.ts
@@ -1,0 +1,36 @@
+import { fuzzyMatch } from '$lib/fuzzyMatch';
+
+export type Searchable = {
+  label: string;
+  detail: string;
+  instanceName: string;
+};
+
+const DETAIL_WEIGHT = 0.5;
+const INSTANCE_WEIGHT = 0.4;
+
+/**
+ * Score a Quick Switcher item against a multi-token query.
+ *
+ * Whitespace-separated tokens are matched independently; each token must
+ * match at least one of `label`, `detail`, or `instanceName` (best-of-three,
+ * weighted). All tokens must match for the item to be a candidate, and the
+ * total score is the sum of per-token best matches.
+ *
+ * Returns `null` when the query is empty or any token fails to match.
+ */
+export function scoreItem(query: string, item: Searchable): number | null {
+  const tokens = query.split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return null;
+
+  let total = 0;
+  for (const token of tokens) {
+    const labelScore = fuzzyMatch(token, item.label) ?? 0;
+    const detailScore = (fuzzyMatch(token, item.detail) ?? 0) * DETAIL_WEIGHT;
+    const instanceScore = (fuzzyMatch(token, item.instanceName) ?? 0) * INSTANCE_WEIGHT;
+    const tokenBest = Math.max(labelScore, detailScore, instanceScore);
+    if (tokenBest === 0) return null;
+    total += tokenBest;
+  }
+  return total;
+}


### PR DESCRIPTION
## Summary

- The Cmd-K quick switcher now matches against the instance/server name in addition to the room and space names, so users can disambiguate identically-named rooms across servers.
- Queries are tokenized on whitespace and each token is matched independently against `label` / `detail` / `instanceName` with AND semantics — so `general chatto` finds `#general` in the Chatto Community server, and `chatto general` works equally (token order is independent).
- Scoring extracted into a pure `scoreItem` helper with unit tests covering the motivating case, order-independence, AND semantics, and field-weight ranking (label > space name > server name).

## Test plan

- [x] `pnpm test:unit --run` — 789/789 passing (9 new tests in `quickSwitcherSearch.test.ts`)
- [x] `pnpm check` — 0 errors / 0 warnings
- [ ] Manual: open Cmd-K with at least two servers (or two spaces with overlapping room names), type `general chatto` and confirm only the Chatto Community `#general` shows; try `chatto general` for the same result.