### PR TITLE
chore(dev): rename bootstrapped dev space to "Local Development"

### DIFF
--- a/cli/chatto.toml
+++ b/cli/chatto.toml
@@ -77,6 +77,6 @@ email = 'bob@example.com'
 password = 'devpassword'
 
 [[bootstrap.spaces]]
-name = 'Engineering'
+name = 'Local Development'
 description = 'Where things happen'
 owner_login = 'devuser'

--- a/compose.yml
+++ b/compose.yml
@@ -21,7 +21,7 @@ services:
       CHATTO_LIVEKIT_API_KEY: devkey
       CHATTO_LIVEKIT_API_SECRET: devsecret
       # Dev bootstrap (devuser, dev@dev.com, devpassword, plus alice/bob and
-      # the Engineering/Lounge spaces) is now declared in cli/chatto.toml under
+      # the Local Development/Lounge spaces) is now declared in cli/chatto.toml under
       # [bootstrap]. The bootstrap-tagged binary applies it on startup; release
       # binaries ignore the section.
     volumes:


### PR DESCRIPTION
## Summary
Renames the dev compose stack's bootstrapped space from `Engineering` to the more descriptive `Local Development`, and updates the matching reference comment in `compose.yml`.

## Test plan
- [ ] Fresh `docker compose up` bootstraps a space named "Local Development"