### PR TITLE
build(compose): bake pnpm install into frontend dev image

### DIFF
--- a/Dockerfile.frontend.compose
+++ b/Dockerfile.frontend.compose
@@ -1,0 +1,18 @@
+# Dev image for the frontend service in compose.yml.
+#
+# Bakes `pnpm install` into a layer keyed on package.json + pnpm-lock.yaml so
+# fresh Conductor worktrees don't have to re-link node_modules from the pnpm
+# store on every `compose up`. The empty per-project `node_modules` named
+# volume is pre-populated from the image's /app/node_modules on first mount.
+#
+# Build context: ./frontend
+
+FROM node:22-alpine
+RUN corepack enable pnpm
+WORKDIR /app
+
+# Deps layer — invalidated only when the lockfile or package.json changes.
+COPY package.json pnpm-lock.yaml .npmrc ./
+RUN pnpm install --frozen-lockfile
+
+# Source is bind-mounted at runtime; nothing to COPY here.

--- a/compose.yml
+++ b/compose.yml
@@ -32,12 +32,17 @@ services:
       - chatto-data:/app/cli/data
 
   frontend:
-    image: node:22-alpine
+    build:
+      context: ./frontend
+      dockerfile: ../Dockerfile.frontend.compose
     working_dir: /app
     labels:
       dev.orbstack.http-port: 5173
       dev.orbstack.domains: ${COMPOSE_PROJECT_NAME}.orb.local
-    command: sh -c "corepack enable pnpm && pnpm config set store-dir /pnpm-store && CI=true pnpm install && pnpm dev --host"
+    # `pnpm install` is baked into the image (see Dockerfile.frontend.compose);
+    # the node_modules named volume is pre-populated from the image on first
+    # attach, so fresh worktrees don't re-link from the pnpm store at startup.
+    command: pnpm dev --host
     environment:
       CHATTO_BACKEND_URL: http://app:4000
     volumes:


### PR DESCRIPTION
## Summary

- Adds `Dockerfile.frontend.compose` that installs frontend deps in a Docker layer keyed on `package.json` + `pnpm-lock.yaml` + `.npmrc`.
- Switches the compose `frontend` service from `image: node:22-alpine` + an in-container `pnpm install` to `build:` against the new Dockerfile, reducing the startup command to `pnpm dev --host`.

Fresh Conductor worktrees previously re-linked the entire `node_modules` tree from the shared pnpm store on every cold `compose up` (the `node_modules` named volume is per-compose-project). With install baked into the image, BuildKit's content-addressed layer cache is shared across worktrees and the empty named volume is pre-populated from the image's `/app/node_modules` on first attach.

## Test plan

- [x] Cold start with a fresh empty `node_modules` volume — vite ready in ~800ms, no `pnpm install` runs at startup.
- [ ] Bump `pnpm-lock.yaml` and confirm the deps layer rebuilds (and that subsequent worktrees with the same lockfile reuse the cached layer).