### PR TITLE
feat(quick-switcher): add header button to open palette

### DIFF
--- a/frontend/e2e/quick-switcher.test.ts
+++ b/frontend/e2e/quick-switcher.test.ts
@@ -40,6 +40,17 @@ test.describe('Quick Switcher (Cmd-K)', () => {
     await expect(dialog).not.toBeVisible({ timeout: TIMEOUTS.UI_FAST });
   });
 
+  test('opens via the header button', async ({ page, chatPage }) => {
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+
+    await page.getByRole('button', { name: 'Open quick switcher' }).click();
+
+    const dialog = page.locator('dialog.quick-switcher');
+    await expect(dialog).toBeVisible({ timeout: TIMEOUTS.UI_FAST });
+    await expect(switcherInput(dialog)).toBeFocused();
+  });
+
   test('closes when clicking outside the dialog', async ({ page, chatPage }) => {
     await createAndLoginTestUser(page);
     await chatPage.goto();

--- a/frontend/src/lib/components/GlobalKeyboardShortcuts.svelte
+++ b/frontend/src/lib/components/GlobalKeyboardShortcuts.svelte
@@ -11,13 +11,12 @@ once at the root layout level.
 -->
 <script lang="ts">
   import QuickSwitcher from './QuickSwitcher.svelte';
-
-  let quickSwitcher: ReturnType<typeof QuickSwitcher> | undefined = $state();
+  import { quickSwitcher } from '$lib/state/globals.svelte';
 
   function handleKeydown(e: KeyboardEvent) {
     if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
       e.preventDefault();
-      quickSwitcher?.open();
+      quickSwitcher.open();
       return;
     }
 
@@ -32,4 +31,4 @@ once at the root layout level.
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
-<QuickSwitcher bind:this={quickSwitcher} />
+<QuickSwitcher />

--- a/frontend/src/lib/components/QuickSwitcher.svelte
+++ b/frontend/src/lib/components/QuickSwitcher.svelte
@@ -15,6 +15,7 @@
   import SkeletonImg from '$lib/ui/SkeletonImg.svelte';
   import { getGradientForName } from '$lib/utils/gradients';
   import { recentQuickSwitcher } from '$lib/state/recentQuickSwitcher.svelte';
+  import { quickSwitcher } from '$lib/state/globals.svelte';
 
   type SpaceLogo = { name: string; logoUrl?: string | null };
 
@@ -34,7 +35,6 @@
     score: number;
   };
 
-  let visible = $state(false);
   let query = $state('');
   let selectedIndex = $state(0);
   let loading = $state(false);
@@ -320,12 +320,8 @@
 
   // --- Visibility ---
 
-  export function open() {
-    visible = true;
-  }
-
   $effect(() => {
-    if (visible) {
+    if (quickSwitcher.visible) {
       query = '';
       selectedIndex = 0;
       allItems = [];
@@ -348,7 +344,7 @@
   }
 
   function select(item: ResultItem) {
-    visible = false;
+    quickSwitcher.close();
 
     const url = itemUrl(item);
     if (url) {
@@ -384,7 +380,7 @@
   }
 
   function close() {
-    visible = false;
+    quickSwitcher.close();
   }
 
   // --- Kind labels ---
@@ -427,7 +423,7 @@
 <!-- Outer wrapper replicates ContextMenu.svelte's container exactly -->
 <dialog
   bind:this={dialogEl}
-  onclose={() => (visible = false)}
+  onclose={() => quickSwitcher.close()}
   onkeydown={(e) => {
     if (e.key === 'Escape') e.stopPropagation();
   }}
@@ -440,7 +436,7 @@
   }}
   class="quick-switcher m-auto mt-[15vh] max-h-none max-w-none overflow-visible border-none bg-transparent p-0 text-inherit backdrop:bg-black/50"
 >
-  {#if visible}
+  {#if quickSwitcher.visible}
   <div class="flex w-140 max-w-[90vw] flex-col gap-1 rounded-lg border border-text/10 bg-surface-100 p-1 text-sm shadow-xl">
     <!-- Search section -->
     <div class="menu-section">

--- a/frontend/src/lib/state/globals.svelte.ts
+++ b/frontend/src/lib/state/globals.svelte.ts
@@ -106,6 +106,29 @@ class SidebarNavState {
 export const sidebarNav = new SidebarNavState();
 
 // ---------------------------------------------------------------------------
+// QuickSwitcher — Cmd+K palette visibility
+// ---------------------------------------------------------------------------
+
+/**
+ * Controls visibility of the QuickSwitcher palette. The palette itself is
+ * mounted once at the root layout level; this singleton lets any component
+ * (header buttons, keyboard shortcuts, etc.) request that it open.
+ */
+class QuickSwitcherState {
+  visible = $state(false);
+
+  open() {
+    this.visible = true;
+  }
+
+  close() {
+    this.visible = false;
+  }
+}
+
+export const quickSwitcher = new QuickSwitcherState();
+
+// ---------------------------------------------------------------------------
 // FullscreenVideo — video overlay state
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/lib/ui/AppHeader.svelte
+++ b/frontend/src/lib/ui/AppHeader.svelte
@@ -5,7 +5,7 @@
   import { graphqlClientManager } from '$lib/state/instance/graphqlClient.svelte';
   import { renderMarkdown } from '$lib/markdown';
   import { version } from '$app/environment';
-  import { sidebarNav } from '$lib/state/globals.svelte';
+  import { sidebarNav, quickSwitcher } from '$lib/state/globals.svelte';
   import UnreadDot from '$lib/ui/UnreadDot.svelte';
 
   // AppHeader renders in the root layout (above [[instanceId=hostname]]),
@@ -57,6 +57,19 @@
         <UnreadDot class="absolute top-2 right-2" />
       {/if}
     </a>
+
+    <!-- Quick switcher trigger -->
+    {#if hasInstances}
+      <button
+        type="button"
+        class="-m-2 flex h-11 w-11 cursor-pointer items-center justify-center rounded active:bg-surface-200"
+        onclick={() => quickSwitcher.open()}
+        aria-label="Open quick switcher"
+        title="Quick switcher (⌘K)"
+      >
+        <span class="iconify text-lg uil--apps"></span>
+      </button>
+    {/if}
 
     <!-- Connection lost indicator: only show when an authenticated instance has lost connection.
          Skip the origin instance if the user isn't authenticated (no WebSocket expected). -->


### PR DESCRIPTION
## Summary

- Adds a button in `AppHeader` (where the globe icon used to live) that opens the QuickSwitcher palette — the palette was previously only reachable via ⌘K.
- Refactors palette visibility behind a `quickSwitcher` singleton in `globals.svelte.ts` so both the keyboard shortcut and the new header button drive it through the same surface, replacing the previous `bind:this` plumbing.
- Icon is `uil--apps` (3×3 grid), inheriting the header's `text-muted` to match the hamburger and bell.

## Test plan

- [ ] Click the new icon in the header — palette opens.
- [ ] ⌘K still opens the palette.
- [ ] Selecting an item closes it and navigates correctly.
- [ ] Esc / clicking the backdrop still closes it.