### PR TITLE
build: re-create .client/.gitkeep after frontend build

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -87,6 +87,7 @@ run = [
     "pnpm build",
     "rm -rf ../cli/internal/http_server/.client",
     "cp -r build ../cli/internal/http_server/.client",
+    "touch ../cli/internal/http_server/.client/.gitkeep",
 ]
 sources = [
     "package.json",


### PR DESCRIPTION
## Summary

The `build-frontend` mise task does `rm -rf .client && cp -r build .client`, which deletes the committed `.gitkeep` that keeps the `//go:embed all:.client` target directory in git. After any build, an accidental `git add -A` would stage the deletion — which has happened repeatedly. Adding a `touch .gitkeep` after the copy fixes this at the root cause.

## Test plan
- [ ] Run `mise build-frontend` and confirm `cli/internal/http_server/.client/.gitkeep` still exists.