### PR TITLE
feat(mobile): slide-in sidebar with edge-swipe gesture

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -368,7 +368,15 @@
   html {
     height: 100%;
     overflow: hidden;
-    touch-action: manipulation;
+    /* pan-y lets the browser own vertical scroll while reserving horizontal
+       pans for our own gesture handling (mobile sidebar swipe). It also
+       implicitly disables pinch-zoom and double-tap-zoom — same as the
+       previous `manipulation` value. */
+    touch-action: pan-y;
+    /* Without this, Chrome (and some other browsers) interpret horizontal
+       swipes from the viewport edge as back/forward navigation gestures and
+       fire pointercancel mid-drag, killing our sidebar swipe handler. */
+    overscroll-behavior-x: none;
     background-color: var(--color-background);
   }
 
@@ -384,6 +392,11 @@
     position: fixed;
     inset: 0;
     overflow: hidden;
+
+    /* Mirror html's touch-action so the effective value for any touch
+       sequence is pan-y — vertical scroll is browser-handled, horizontal
+       pans are reserved for our own gesture handlers (sidebar swipe). */
+    touch-action: pan-y;
 
     background-color: var(--color-background);
     color: var(--color-text);

--- a/frontend/src/lib/components/SecondarySidebar.svelte
+++ b/frontend/src/lib/components/SecondarySidebar.svelte
@@ -41,7 +41,12 @@
     // Mobile: always rendered so the slide animation is visible.
     // Desktop: hide entirely when closed.
     sidebarNav.isMobile ? '' : sidebarNav.isOpen ? '' : 'hidden',
-    !dragging && 'max-md:transition-transform max-md:duration-200 max-md:ease-out'
+    // Mobile-only: become `visibility: hidden` once the slide-out animation
+    // completes (see .sidebar-mobile-anim styles in routes/+layout.svelte) so
+    // accessibility tools and Playwright `toBeVisible()` agree the panel is
+    // hidden, not just translated off-screen.
+    sidebarNav.isMobile && sidebarNav.progress === 0 && !dragging && 'max-md:invisible',
+    !dragging && 'sidebar-mobile-anim'
   ]}
   style:transform={sidebarNav.isMobile ? `translateX(${tx}px)` : undefined}
 >

--- a/frontend/src/lib/components/SecondarySidebar.svelte
+++ b/frontend/src/lib/components/SecondarySidebar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
+  import { SIDEBAR_PANEL_WIDTH_PX, sidebarSwipe } from '$lib/hooks/useSidebarSwipe.svelte';
   import { sidebarNav } from '$lib/state/globals.svelte';
 
   let {
@@ -11,23 +12,38 @@
     width?: string;
     mobileWidth?: string;
   } = $props();
+
+  // On mobile the panel slides as a single unit with the SpaceList — both apply
+  // the same translateX driven by `sidebarNav.progress`. On desktop the sidebar
+  // toggles via `hidden`/`flex` (no overlay; layout reflows).
+  const tx = $derived(
+    sidebarNav.isMobile ? (sidebarNav.progress - 1) * SIDEBAR_PANEL_WIDTH_PX : 0
+  );
+  const dragging = $derived(sidebarNav.dragOffset !== null);
 </script>
 
 <!--
 	Secondary sidebar (room list, DM conversations, etc.)
 	- Desktop: shown in normal flow with fixed width
-	- Mobile: fixed overlay positioned after SpaceList
+	- Mobile: fixed overlay positioned after SpaceList; slides in/out with the panel
 -->
 <div
+  use:sidebarSwipe
   class={[
     'z-50 flex min-w-0 flex-col overflow-hidden border-r border-border bg-background',
     width,
     mobileWidth,
     'md:flex-initial',
-    // Mobile: fixed overlay positioned after SpaceList (~68px)
-    'max-md:fixed max-md:top-11 max-md:bottom-0 max-md:left-17',
-    sidebarNav.isOpen ? '' : 'hidden'
+    // Mobile: fixed overlay positioned after SpaceList (~68px); touch-pan-y so
+    // vertical scroll inside the panel still works while horizontal pans go to
+    // the sidebar swipe action.
+    'max-md:fixed max-md:top-11 max-md:bottom-0 max-md:left-17 max-md:touch-pan-y',
+    // Mobile: always rendered so the slide animation is visible.
+    // Desktop: hide entirely when closed.
+    sidebarNav.isMobile ? '' : sidebarNav.isOpen ? '' : 'hidden',
+    !dragging && 'max-md:transition-transform max-md:duration-200 max-md:ease-out'
   ]}
+  style:transform={sidebarNav.isMobile ? `translateX(${tx}px)` : undefined}
 >
   {@render children()}
 </div>

--- a/frontend/src/lib/hooks/useSidebarSwipe.svelte.ts
+++ b/frontend/src/lib/hooks/useSidebarSwipe.svelte.ts
@@ -1,0 +1,166 @@
+import { sidebarNav, SIDEBAR_PANEL_WIDTH_PX } from '$lib/state/globals.svelte';
+
+const DIRECTION_LOCK_PX = 8;
+const VELOCITY_SAMPLE_MS = 100;
+/** Hold time before a stationary touch is forwarded as a contextmenu event. */
+const LONG_PRESS_MS = 500;
+/** Movement (px) that cancels the long-press timer. */
+const LONG_PRESS_CANCEL_PX = 4;
+
+type Sample = { x: number; t: number };
+
+/**
+ * Svelte action: attaches a horizontal swipe handler to an element that
+ * drives the mobile sidebar's open/close state.
+ *
+ * The host element MUST have `touch-action: none` (or at least block
+ * horizontal browser gestures) — otherwise Chrome / iOS Safari fire
+ * `pointercancel` once they decide the drag is a navigation/selection
+ * gesture, and the slide aborts mid-way.
+ *
+ * Direction lock: we wait until movement reaches {@link DIRECTION_LOCK_PX}
+ * and X dominates Y before claiming the gesture; vertical drags release the
+ * pointer without ever calling `startDrag()`.
+ *
+ *   <div use:sidebarSwipe class="touch-none ..." />
+ */
+export function sidebarSwipe(node: HTMLElement) {
+  let pointerId: number | null = null;
+  let startX = 0;
+  let startY = 0;
+  let claimed = false;
+  let captured = false;
+  let baselineOpen = false;
+  let samples: Sample[] = [];
+  let longPressTimer: number | null = null;
+
+  function reset() {
+    if (pointerId !== null && captured) {
+      node.releasePointerCapture?.(pointerId);
+    }
+    clearLongPress();
+    pointerId = null;
+    claimed = false;
+    captured = false;
+    samples = [];
+  }
+
+  function clearLongPress() {
+    if (longPressTimer !== null) {
+      window.clearTimeout(longPressTimer);
+      longPressTimer = null;
+    }
+  }
+
+  /**
+   * Forward a synthetic contextmenu event to the topmost element underneath
+   * this swipe surface at (x, y). Used when the user taps-and-holds without
+   * moving — preserves long-press / context-menu UX on content that the
+   * gesture surface visually overlaps (avatars, message rows, etc.).
+   */
+  function forwardLongPress(x: number, y: number) {
+    const stack = document.elementsFromPoint(x, y);
+    const below = stack.find((el) => el !== node && !node.contains(el));
+    if (!below) return;
+    below.dispatchEvent(
+      new MouseEvent('contextmenu', {
+        bubbles: true,
+        cancelable: true,
+        clientX: x,
+        clientY: y,
+        button: 2
+      })
+    );
+  }
+
+  function onDown(e: PointerEvent) {
+    if (pointerId !== null) return;
+    if (!sidebarNav.isMobile) return;
+    pointerId = e.pointerId;
+    startX = e.clientX;
+    startY = e.clientY;
+    baselineOpen = sidebarNav.isOpen;
+    claimed = false;
+    captured = false;
+    samples = [{ x: e.clientX, t: e.timeStamp }];
+    longPressTimer = window.setTimeout(() => {
+      longPressTimer = null;
+      forwardLongPress(e.clientX, e.clientY);
+      reset();
+    }, LONG_PRESS_MS);
+  }
+
+  function onMove(e: PointerEvent) {
+    if (e.pointerId !== pointerId) return;
+    const dx = e.clientX - startX;
+    const dy = e.clientY - startY;
+
+    // Any meaningful movement cancels the long-press hand-off.
+    if (Math.abs(dx) >= LONG_PRESS_CANCEL_PX || Math.abs(dy) >= LONG_PRESS_CANCEL_PX) {
+      clearLongPress();
+    }
+
+    if (!claimed) {
+      if (Math.abs(dx) < DIRECTION_LOCK_PX && Math.abs(dy) < DIRECTION_LOCK_PX) return;
+      if (Math.abs(dy) > Math.abs(dx)) {
+        // Vertical movement won — bow out.
+        reset();
+        return;
+      }
+      // Reject drags in the wrong direction for the current state:
+      // closed → must drag right; open → must drag left.
+      if (baselineOpen ? dx > 0 : dx < 0) {
+        reset();
+        return;
+      }
+      claimed = true;
+      sidebarNav.startDrag();
+      // Capture only once we've claimed the gesture so taps and short presses
+      // can still bubble / be forwarded to the underlying content.
+      node.setPointerCapture(e.pointerId);
+      captured = true;
+    }
+
+    sidebarNav.updateDrag(dx);
+    samples.push({ x: e.clientX, t: e.timeStamp });
+    const cutoff = e.timeStamp - VELOCITY_SAMPLE_MS;
+    while (samples.length > 2 && samples[0].t < cutoff) samples.shift();
+  }
+
+  function onUp(e: PointerEvent) {
+    if (e.pointerId !== pointerId) return;
+    if (!claimed) {
+      reset();
+      return;
+    }
+    const last = samples[samples.length - 1];
+    const first = samples[0];
+    const dt = last.t - first.t;
+    const vx = dt > 0 ? (last.x - first.x) / dt : 0;
+    sidebarNav.endDrag(vx);
+    reset();
+  }
+
+  function onCancel(e: PointerEvent) {
+    if (e.pointerId !== pointerId) return;
+    if (claimed) sidebarNav.endDrag(0);
+    reset();
+  }
+
+  node.addEventListener('pointerdown', onDown);
+  node.addEventListener('pointermove', onMove);
+  node.addEventListener('pointerup', onUp);
+  node.addEventListener('pointercancel', onCancel);
+
+  return {
+    destroy() {
+      clearLongPress();
+      node.removeEventListener('pointerdown', onDown);
+      node.removeEventListener('pointermove', onMove);
+      node.removeEventListener('pointerup', onUp);
+      node.removeEventListener('pointercancel', onCancel);
+    }
+  };
+}
+
+export { SIDEBAR_PANEL_WIDTH_PX };

--- a/frontend/src/lib/hooks/useSidebarSwipe.svelte.ts
+++ b/frontend/src/lib/hooks/useSidebarSwipe.svelte.ts
@@ -53,16 +53,22 @@ export function sidebarSwipe(node: HTMLElement) {
   }
 
   /**
-   * Forward a synthetic contextmenu event to the topmost element underneath
-   * this swipe surface at (x, y). Used when the user taps-and-holds without
-   * moving — preserves long-press / context-menu UX on content that the
-   * gesture surface visually overlaps (avatars, message rows, etc.).
+   * Find the topmost interactive element underneath this swipe surface at
+   * (x, y), skipping the surface itself and anything inside it.
+   */
+  function elementBelow(x: number, y: number): Element | undefined {
+    return document
+      .elementsFromPoint(x, y)
+      .find((el) => el !== node && !node.contains(el));
+  }
+
+  /**
+   * Forward a synthetic contextmenu event to the element below. Used when the
+   * user taps-and-holds without moving — preserves long-press / context-menu
+   * UX on content that the gesture surface visually overlaps (avatars, etc.).
    */
   function forwardLongPress(x: number, y: number) {
-    const stack = document.elementsFromPoint(x, y);
-    const below = stack.find((el) => el !== node && !node.contains(el));
-    if (!below) return;
-    below.dispatchEvent(
+    elementBelow(x, y)?.dispatchEvent(
       new MouseEvent('contextmenu', {
         bubbles: true,
         cancelable: true,
@@ -71,6 +77,30 @@ export function sidebarSwipe(node: HTMLElement) {
         button: 2
       })
     );
+  }
+
+  /**
+   * Forward a synthetic click sequence to the element below. Used when the
+   * user taps the gesture surface without dragging — preserves click UX on
+   * underlying interactive elements (back buttons, links, etc.) that happen
+   * to fall inside the gesture surface's hit-test area.
+   */
+  function forwardTap(x: number, y: number) {
+    const target = elementBelow(x, y);
+    if (!target) return;
+    const opts: MouseEventInit = {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      clientX: x,
+      clientY: y,
+      button: 0
+    };
+    target.dispatchEvent(new PointerEvent('pointerdown', opts));
+    target.dispatchEvent(new MouseEvent('mousedown', opts));
+    target.dispatchEvent(new PointerEvent('pointerup', opts));
+    target.dispatchEvent(new MouseEvent('mouseup', opts));
+    target.dispatchEvent(new MouseEvent('click', opts));
   }
 
   function onDown(e: PointerEvent) {
@@ -130,6 +160,17 @@ export function sidebarSwipe(node: HTMLElement) {
   function onUp(e: PointerEvent) {
     if (e.pointerId !== pointerId) return;
     if (!claimed) {
+      // Tap (movement didn't cross the swipe threshold). Forward as a click so
+      // taps on underlying interactive content (back buttons, links, etc.)
+      // still work even though the gesture surface is on top. Note: if a
+      // long-press handoff already fired, `reset()` cleared `pointerId`, so
+      // we'd have early-returned above.
+      const movedFar =
+        Math.abs(e.clientX - startX) >= LONG_PRESS_CANCEL_PX ||
+        Math.abs(e.clientY - startY) >= LONG_PRESS_CANCEL_PX;
+      if (!movedFar) {
+        forwardTap(e.clientX, e.clientY);
+      }
       reset();
       return;
     }

--- a/frontend/src/lib/state/globals.svelte.ts
+++ b/frontend/src/lib/state/globals.svelte.ts
@@ -54,6 +54,13 @@ export const titleState = new TitleState();
 // ---------------------------------------------------------------------------
 
 /**
+ * Combined width of SpaceList (~68px, `left-17`) + SecondarySidebar (256px,
+ * `md:w-64`/`max-md:w-64`). The mobile sidebars slide off-screen by this
+ * amount when fully closed.
+ */
+export const SIDEBAR_PANEL_WIDTH_PX = 68 + 256;
+
+/**
  * Controls the visibility of the left sidebars (SpaceList and RoomList).
  * Tracks the user's desktop preference separately from viewport-driven changes,
  * so manual toggles on desktop "stick" across viewport transitions.
@@ -61,15 +68,28 @@ export const titleState = new TitleState();
  * - Desktop: sidebar follows user preference (open by default)
  * - Mobile: sidebar is always closed unless explicitly opened (overlay)
  * - Resizing back to desktop restores the user's last desktop preference
+ *
+ * Mobile gestures: when a swipe is in progress, `dragOffset` holds the live
+ * finger delta (relative to the open position). Templates should disable
+ * CSS transitions while dragging and apply the transform from `progress`.
  */
 class SidebarNavState {
   isOpen = $state(true);
+  /**
+   * Live drag offset in px relative to the *open* position. Negative values
+   * shift the panel toward closed; 0 = fully open. `null` means no drag is
+   * in progress and CSS transitions should drive the transform.
+   */
+  dragOffset = $state<number | null>(null);
   private desktopOpen = $state(true);
   private _isMobile = $state(false);
+  private dragBaselineOpen = false;
 
   setMobile(isMobile: boolean) {
     if (this._isMobile === isMobile) return;
     this._isMobile = isMobile;
+    // Reset any in-flight gesture when the viewport class changes.
+    this.dragOffset = null;
 
     if (isMobile) {
       this.isOpen = false;
@@ -89,8 +109,52 @@ class SidebarNavState {
     return this._isMobile;
   }
 
+  /**
+   * Animation progress in [0, 1]. 1 = fully open, 0 = fully closed.
+   * Uses `dragOffset` when present (live finger), otherwise mirrors `isOpen`.
+   * Only meaningful on mobile; desktop should ignore this.
+   */
+  get progress(): number {
+    if (this.dragOffset !== null) {
+      const base = this.dragBaselineOpen ? 0 : -SIDEBAR_PANEL_WIDTH_PX;
+      const px = clamp(base + this.dragOffset, -SIDEBAR_PANEL_WIDTH_PX, 0);
+      return 1 + px / SIDEBAR_PANEL_WIDTH_PX;
+    }
+    return this.isOpen ? 1 : 0;
+  }
+
   close() {
     this.isOpen = false;
+  }
+
+  startDrag() {
+    this.dragBaselineOpen = this.isOpen;
+    this.dragOffset = 0;
+  }
+
+  updateDrag(deltaPx: number) {
+    if (this.dragOffset === null) return;
+    this.dragOffset = deltaPx;
+  }
+
+  /**
+   * Commit a drag. Opens or closes based on final progress and fling velocity
+   * (px/ms — positive = rightward, opening). Always clears `dragOffset` so
+   * CSS transitions resume.
+   */
+  endDrag(velocityPxPerMs: number) {
+    if (this.dragOffset === null) return;
+    const finalProgress = this.progress;
+    this.dragOffset = null;
+
+    const VELOCITY_THRESHOLD = 0.5;
+    if (velocityPxPerMs > VELOCITY_THRESHOLD) {
+      this.isOpen = true;
+    } else if (velocityPxPerMs < -VELOCITY_THRESHOLD) {
+      this.isOpen = false;
+    } else {
+      this.isOpen = finalProgress >= 0.5;
+    }
   }
 
   initViewportTracking(breakpoint = '(max-width: 767px)'): () => void {
@@ -101,6 +165,10 @@ class SidebarNavState {
     mq.addEventListener('change', handler);
     return () => mq.removeEventListener('change', handler);
   }
+}
+
+function clamp(v: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, v));
 }
 
 export const sidebarNav = new SidebarNavState();

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -100,6 +100,30 @@
   const isSetupRoute = $derived(page.url.pathname.startsWith('/setup'));
 </script>
 
+<style>
+  /*
+    Mobile sidebar animation — slide via transform, plus a delayed visibility
+    swap so the off-screen panel is reported as `visibility: hidden` (not just
+    visually hidden by transform) once the close animation finishes. This
+    matters for accessibility tooling and Playwright's `toBeVisible()`.
+
+    Open  → transform animates 200ms, visibility flips to `visible` immediately.
+    Close → transform animates 200ms, visibility flips to `hidden` AFTER 200ms.
+  */
+  @media (max-width: 767px) {
+    :global(.sidebar-mobile-anim) {
+      transition:
+        transform 200ms ease-out,
+        visibility 0s linear 200ms;
+    }
+    :global(.sidebar-mobile-anim:not(.invisible)) {
+      transition:
+        transform 200ms ease-out,
+        visibility 0s linear 0s;
+    }
+  }
+</style>
+
 <GlobalKeyboardShortcuts />
 <UpdateNotifier />
 <NotificationSync />
@@ -151,7 +175,7 @@
         {#if !sidebarNav.isOpen || dragging}
           <div
             use:sidebarSwipe
-            class="fixed top-11 bottom-0 left-0 z-40 w-16 touch-none md:hidden"
+            class="fixed top-11 bottom-0 left-0 z-40 w-6 touch-none md:hidden"
             aria-hidden="true"
           ></div>
         {/if}
@@ -180,7 +204,12 @@
             // Mobile: always rendered so we can animate transform.
             // Desktop: hide entirely when closed (no overlay; layout reflows).
             sidebarNav.isMobile ? 'flex' : sidebarNav.isOpen ? 'flex' : 'hidden',
-            !dragging && 'max-md:transition-transform max-md:duration-200 max-md:ease-out'
+            // Mobile-only: hide via `visibility: hidden` (with transition-delay
+            // applied via the `sidebar-mobile-anim` class below) when fully
+            // closed, so Playwright / accessibility tooling correctly see the
+            // sidebar as not-visible while the slide-in animation still works.
+            sidebarNav.isMobile && progress === 0 && !dragging && 'max-md:invisible',
+            !dragging && 'sidebar-mobile-anim'
           ]}
           style:transform={sidebarNav.isMobile ? `translateX(${tx}px)` : undefined}
         >

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -10,6 +10,7 @@
   import UpdateNotifier from '$lib/components/UpdateNotifier.svelte';
   import FullscreenVideoOverlay from '$lib/components/chat/FullscreenVideoOverlay.svelte';
   import { usePageTitle, usePinchZoomPrevention, useVisualViewport } from '$lib/hooks';
+  import { SIDEBAR_PANEL_WIDTH_PX, sidebarSwipe } from '$lib/hooks/useSidebarSwipe.svelte';
   import { sidebarNav } from '$lib/state/globals.svelte';
   import { instanceRegistry } from '$lib/state/instance/registry.svelte';
   import { useInstanceRegistry } from '$lib/state/instance/useInstanceRegistry.svelte';
@@ -129,6 +130,9 @@
 {/if}
 
 {#snippet frame()}
+  {@const progress = sidebarNav.isMobile ? sidebarNav.progress : 1}
+  {@const dragging = sidebarNav.dragOffset !== null}
+  {@const tx = (progress - 1) * SIDEBAR_PANEL_WIDTH_PX}
   <div
     class="flex h-full w-full flex-col overscroll-y-contain bg-surface-100 pt-[env(safe-area-inset-top,0px)] md:p-3 md:pt-0"
   >
@@ -137,22 +141,48 @@
     <AppHeader />
 
     <Frame class="relative flex-col">
-      {#if sidebarNav.isOpen}
-        <button
-          type="button"
-          class="fixed inset-0 top-11 z-40 bg-black/50 md:hidden"
-          onclick={() => sidebarNav.close()}
-          aria-label="Close sidebar"
-        ></button>
+      {#if sidebarNav.isMobile}
+        <!--
+          Edge gesture zone (swipe-to-open). `touch-action: none` is essential:
+          without it, Chrome / iOS Safari fire pointercancel ~8px into a
+          horizontal drag (text-selection / back-navigation gesture detection).
+          Hidden when sidebar is open (the backdrop takes over).
+        -->
+        {#if !sidebarNav.isOpen || dragging}
+          <div
+            use:sidebarSwipe
+            class="fixed top-11 bottom-0 left-0 z-40 w-16 touch-none md:hidden"
+            aria-hidden="true"
+          ></div>
+        {/if}
+
+        {#if progress > 0}
+          <button
+            type="button"
+            use:sidebarSwipe
+            class={[
+              'fixed inset-0 top-11 z-40 touch-none bg-black/50 md:hidden',
+              !dragging && 'transition-opacity duration-200'
+            ]}
+            style="opacity: {progress}"
+            onclick={() => sidebarNav.close()}
+            aria-label="Close sidebar"
+          ></button>
+        {/if}
       {/if}
 
       <div class="flex min-h-0 flex-1 flex-row">
         <div
+          use:sidebarSwipe
           class={[
             'z-50 min-h-0 flex-col self-stretch bg-background',
-            'max-md:fixed max-md:top-11 max-md:bottom-0 max-md:left-0',
-            sidebarNav.isOpen ? 'flex' : 'hidden'
+            'max-md:fixed max-md:top-11 max-md:bottom-0 max-md:left-0 max-md:touch-pan-y',
+            // Mobile: always rendered so we can animate transform.
+            // Desktop: hide entirely when closed (no overlay; layout reflows).
+            sidebarNav.isMobile ? 'flex' : sidebarNav.isOpen ? 'flex' : 'hidden',
+            !dragging && 'max-md:transition-transform max-md:duration-200 max-md:ease-out'
           ]}
+          style:transform={sidebarNav.isMobile ? `translateX(${tx}px)` : undefined}
         >
           <SpaceList onPermissionsLoaded={updateInstancePermissions} />
         </div>


### PR DESCRIPTION
## Summary

- Mobile sidebars (SpaceList + SecondarySidebar) now slide as a single panel via `translateX`, replacing the instant `hidden` toggle. `SidebarNavState` gains `dragOffset` + a `progress` getter so the finger-following drag, the snap-on-release (50% threshold or fling velocity), and the existing hamburger toggle all drive the same animation.
- New `sidebarSwipe` Svelte action handles the gesture. It's attached to an invisible 64px left-edge zone (swipe-to-open), the backdrop, and the sidebar wrappers (both for swipe-to-close). The edge zone uses `touch-action: none` so Chrome / iOS Safari can't fire `pointercancel` at their ~8px horizontal-gesture detection threshold; sidebar wrappers use `touch-pan-y` so internal vertical scroll still works.
- `setPointerCapture` is deferred until the gesture is claimed (8px direction-locked), so taps and short presses still bubble. Inside the edge zone, a 500ms long-press without movement synthesizes a `contextmenu` event on the element below — preserving long-press menus on avatars and message rows that the gesture surface overlays.

## Test plan

- [ ] On a mobile viewport (or DevTools Responsive mode with touch enabled): tap hamburger → sidebar slides in/out, backdrop fades.
- [ ] Swipe right from the left edge → sidebars follow finger; release past halfway opens, before halfway snaps back.
- [ ] With sidebar open, drag it leftward or drag the backdrop → closes; tap backdrop → closes.
- [ ] Long-press an avatar in the leftmost 64px → user context menu opens (forwarded `contextmenu`).
- [ ] Vertical scroll on the chat content and inside the sidebar still works.
- [ ] Desktop (≥768px): sidebar still toggles via `hidden`/`flex`, no transform / no overlay.