### PR TITLE
feat(mobile): drag-to-dismiss bottom sheets, panGesture primitive

### DIFF
--- a/frontend/src/lib/hooks/panGesture.svelte.ts
+++ b/frontend/src/lib/hooks/panGesture.svelte.ts
@@ -1,0 +1,179 @@
+/**
+ * Generic single-axis pan-gesture primitive.
+ *
+ * Detects a press → optional long-press → drag claim → continuous update →
+ * release-with-velocity flow on a single host element, and exposes the
+ * decisions as plain callbacks. Specific use-sites (sidebar swipe, bottom-sheet
+ * drag-to-dismiss, ...) wire these callbacks to their own state.
+ *
+ * The host element MUST have `touch-action: none` (or at minimum block native
+ * panning along the chosen axis) — otherwise the browser fires `pointercancel`
+ * once it decides the drag is a scroll/back-navigation gesture and the slide
+ * aborts mid-way.
+ *
+ * Direction lock: we wait until movement reaches {@link DIRECTION_LOCK_PX} and
+ * the primary axis dominates the perpendicular axis before claiming the
+ * gesture. Perpendicular drags release the pointer without ever calling
+ * `onStart`. The optional {@link PanGestureConfig.shouldClaim} predicate gives
+ * call-sites a final say (e.g. reject "wrong direction" drags based on current
+ * state).
+ *
+ * Pointer capture is deferred until claim so taps and short presses bubble
+ * naturally; only confirmed drags lock the pointer.
+ */
+
+const DIRECTION_LOCK_PX = 8;
+const VELOCITY_SAMPLE_MS = 100;
+/** Hold time before a stationary press is reported via `onLongPress`. */
+const LONG_PRESS_MS = 500;
+/** Movement (px) that cancels the pending long-press timer. */
+const LONG_PRESS_CANCEL_PX = 4;
+
+export type PanGestureConfig = {
+  /** The axis the gesture tracks. The other axis is treated as perpendicular. */
+  axis: 'x' | 'y';
+  /** Optional gate evaluated on every `pointerdown`; if it returns false, the
+   *  press is ignored entirely. */
+  enabled?: () => boolean;
+  /** Final claim predicate, called once the direction lock has fired. Receives
+   *  the primary-axis delta (signed). Return false to abandon the gesture. */
+  shouldClaim?: (delta: number) => boolean;
+  /** Fired once when the gesture is claimed. */
+  onStart?: () => void;
+  /** Fired on every move while claimed. `delta` is signed primary-axis px. */
+  onUpdate?: (delta: number) => void;
+  /** Fired on release. `velocity` is signed primary-axis px/ms (sampled over
+   *  the last {@link VELOCITY_SAMPLE_MS}). */
+  onEnd?: (delta: number, velocity: number) => void;
+  /** Fired when the browser cancels a claimed gesture mid-drag. */
+  onCancel?: () => void;
+  /** Fired on release without meaningful movement. */
+  onTap?: (x: number, y: number) => void;
+  /** Fired when the press is held still for {@link LONG_PRESS_MS}. */
+  onLongPress?: (x: number, y: number) => void;
+};
+
+type Sample = { v: number; t: number };
+
+export function panGesture(node: HTMLElement, config: PanGestureConfig) {
+  let cfg = config;
+  let pointerId: number | null = null;
+  let startX = 0;
+  let startY = 0;
+  let claimed = false;
+  let captured = false;
+  let samples: Sample[] = [];
+  let longPressTimer: number | null = null;
+
+  const primary = (x: number, y: number) => (cfg.axis === 'x' ? x : y);
+  const secondary = (x: number, y: number) => (cfg.axis === 'x' ? y : x);
+
+  function clearLongPress() {
+    if (longPressTimer !== null) {
+      window.clearTimeout(longPressTimer);
+      longPressTimer = null;
+    }
+  }
+
+  function reset() {
+    if (pointerId !== null && captured) node.releasePointerCapture?.(pointerId);
+    clearLongPress();
+    pointerId = null;
+    claimed = false;
+    captured = false;
+    samples = [];
+  }
+
+  function onDown(e: PointerEvent) {
+    if (pointerId !== null) return;
+    if (cfg.enabled && !cfg.enabled()) return;
+    pointerId = e.pointerId;
+    startX = e.clientX;
+    startY = e.clientY;
+    claimed = false;
+    captured = false;
+    samples = [{ v: primary(e.clientX, e.clientY), t: e.timeStamp }];
+    if (cfg.onLongPress) {
+      longPressTimer = window.setTimeout(() => {
+        longPressTimer = null;
+        cfg.onLongPress?.(e.clientX, e.clientY);
+        reset();
+      }, LONG_PRESS_MS);
+    }
+  }
+
+  function onMove(e: PointerEvent) {
+    if (e.pointerId !== pointerId) return;
+    const dPrim = primary(e.clientX, e.clientY) - primary(startX, startY);
+    const dSec = secondary(e.clientX, e.clientY) - secondary(startX, startY);
+
+    if (Math.abs(dPrim) >= LONG_PRESS_CANCEL_PX || Math.abs(dSec) >= LONG_PRESS_CANCEL_PX) {
+      clearLongPress();
+    }
+
+    if (!claimed) {
+      if (Math.abs(dPrim) < DIRECTION_LOCK_PX && Math.abs(dSec) < DIRECTION_LOCK_PX) return;
+      if (Math.abs(dSec) > Math.abs(dPrim)) {
+        // Perpendicular movement won — release the pointer.
+        reset();
+        return;
+      }
+      if (cfg.shouldClaim && !cfg.shouldClaim(dPrim)) {
+        reset();
+        return;
+      }
+      claimed = true;
+      cfg.onStart?.();
+      node.setPointerCapture(e.pointerId);
+      captured = true;
+    }
+
+    cfg.onUpdate?.(dPrim);
+    samples.push({ v: primary(e.clientX, e.clientY), t: e.timeStamp });
+    const cutoff = e.timeStamp - VELOCITY_SAMPLE_MS;
+    while (samples.length > 2 && samples[0].t < cutoff) samples.shift();
+  }
+
+  function onUp(e: PointerEvent) {
+    if (e.pointerId !== pointerId) return;
+    if (!claimed) {
+      const movedFar =
+        Math.abs(e.clientX - startX) >= LONG_PRESS_CANCEL_PX ||
+        Math.abs(e.clientY - startY) >= LONG_PRESS_CANCEL_PX;
+      if (!movedFar) cfg.onTap?.(e.clientX, e.clientY);
+      reset();
+      return;
+    }
+    const dPrim = primary(e.clientX, e.clientY) - primary(startX, startY);
+    const last = samples[samples.length - 1];
+    const first = samples[0];
+    const dt = last.t - first.t;
+    const v = dt > 0 ? (last.v - first.v) / dt : 0;
+    cfg.onEnd?.(dPrim, v);
+    reset();
+  }
+
+  function onCancel(e: PointerEvent) {
+    if (e.pointerId !== pointerId) return;
+    if (claimed) cfg.onCancel?.();
+    reset();
+  }
+
+  node.addEventListener('pointerdown', onDown);
+  node.addEventListener('pointermove', onMove);
+  node.addEventListener('pointerup', onUp);
+  node.addEventListener('pointercancel', onCancel);
+
+  return {
+    update(next: PanGestureConfig) {
+      cfg = next;
+    },
+    destroy() {
+      clearLongPress();
+      node.removeEventListener('pointerdown', onDown);
+      node.removeEventListener('pointermove', onMove);
+      node.removeEventListener('pointerup', onUp);
+      node.removeEventListener('pointercancel', onCancel);
+    }
+  };
+}

--- a/frontend/src/lib/hooks/useSidebarSwipe.svelte.ts
+++ b/frontend/src/lib/hooks/useSidebarSwipe.svelte.ts
@@ -1,72 +1,27 @@
 import { sidebarNav, SIDEBAR_PANEL_WIDTH_PX } from '$lib/state/globals.svelte';
-
-const DIRECTION_LOCK_PX = 8;
-const VELOCITY_SAMPLE_MS = 100;
-/** Hold time before a stationary touch is forwarded as a contextmenu event. */
-const LONG_PRESS_MS = 500;
-/** Movement (px) that cancels the long-press timer. */
-const LONG_PRESS_CANCEL_PX = 4;
-
-type Sample = { x: number; t: number };
+import { panGesture } from './panGesture.svelte';
 
 /**
- * Svelte action: attaches a horizontal swipe handler to an element that
- * drives the mobile sidebar's open/close state.
+ * Svelte action: drives the mobile sidebar's open/close state from a
+ * horizontal pointer drag on the host element.
  *
- * The host element MUST have `touch-action: none` (or at least block
- * horizontal browser gestures) — otherwise Chrome / iOS Safari fire
- * `pointercancel` once they decide the drag is a navigation/selection
- * gesture, and the slide aborts mid-way.
+ * Ignored on desktop (gated by `sidebarNav.isMobile`). When closed, only
+ * rightward drags claim; when open, only leftward drags claim. Taps and
+ * long-presses are forwarded to the element directly underneath the host so
+ * dedicated overlay zones (the 24px edge strip, the backdrop) still let
+ * underlying content receive clicks and context menus.
  *
- * Direction lock: we wait until movement reaches {@link DIRECTION_LOCK_PX}
- * and X dominates Y before claiming the gesture; vertical drags release the
- * pointer without ever calling `startDrag()`.
- *
- *   <div use:sidebarSwipe class="touch-none ..." />
+ * The host MUST have `touch-action: none` along the X axis — without it,
+ * Chrome / iOS Safari fire `pointercancel` ~8px in when they decide a touch
+ * is a back-navigation / text-selection drag.
  */
 export function sidebarSwipe(node: HTMLElement) {
-  let pointerId: number | null = null;
-  let startX = 0;
-  let startY = 0;
-  let claimed = false;
-  let captured = false;
-  let baselineOpen = false;
-  let samples: Sample[] = [];
-  let longPressTimer: number | null = null;
-
-  function reset() {
-    if (pointerId !== null && captured) {
-      node.releasePointerCapture?.(pointerId);
-    }
-    clearLongPress();
-    pointerId = null;
-    claimed = false;
-    captured = false;
-    samples = [];
-  }
-
-  function clearLongPress() {
-    if (longPressTimer !== null) {
-      window.clearTimeout(longPressTimer);
-      longPressTimer = null;
-    }
-  }
-
-  /**
-   * Find the topmost interactive element underneath this swipe surface at
-   * (x, y), skipping the surface itself and anything inside it.
-   */
-  function elementBelow(x: number, y: number): Element | undefined {
+  function elementBelow(x: number, y: number) {
     return document
       .elementsFromPoint(x, y)
       .find((el) => el !== node && !node.contains(el));
   }
 
-  /**
-   * Forward a synthetic contextmenu event to the element below. Used when the
-   * user taps-and-holds without moving — preserves long-press / context-menu
-   * UX on content that the gesture surface visually overlaps (avatars, etc.).
-   */
   function forwardLongPress(x: number, y: number) {
     elementBelow(x, y)?.dispatchEvent(
       new MouseEvent('contextmenu', {
@@ -79,12 +34,6 @@ export function sidebarSwipe(node: HTMLElement) {
     );
   }
 
-  /**
-   * Forward a synthetic click sequence to the element below. Used when the
-   * user taps the gesture surface without dragging — preserves click UX on
-   * underlying interactive elements (back buttons, links, etc.) that happen
-   * to fall inside the gesture surface's hit-test area.
-   */
   function forwardTap(x: number, y: number) {
     const target = elementBelow(x, y);
     if (!target) return;
@@ -103,105 +52,17 @@ export function sidebarSwipe(node: HTMLElement) {
     target.dispatchEvent(new MouseEvent('click', opts));
   }
 
-  function onDown(e: PointerEvent) {
-    if (pointerId !== null) return;
-    if (!sidebarNav.isMobile) return;
-    pointerId = e.pointerId;
-    startX = e.clientX;
-    startY = e.clientY;
-    baselineOpen = sidebarNav.isOpen;
-    claimed = false;
-    captured = false;
-    samples = [{ x: e.clientX, t: e.timeStamp }];
-    longPressTimer = window.setTimeout(() => {
-      longPressTimer = null;
-      forwardLongPress(e.clientX, e.clientY);
-      reset();
-    }, LONG_PRESS_MS);
-  }
-
-  function onMove(e: PointerEvent) {
-    if (e.pointerId !== pointerId) return;
-    const dx = e.clientX - startX;
-    const dy = e.clientY - startY;
-
-    // Any meaningful movement cancels the long-press hand-off.
-    if (Math.abs(dx) >= LONG_PRESS_CANCEL_PX || Math.abs(dy) >= LONG_PRESS_CANCEL_PX) {
-      clearLongPress();
-    }
-
-    if (!claimed) {
-      if (Math.abs(dx) < DIRECTION_LOCK_PX && Math.abs(dy) < DIRECTION_LOCK_PX) return;
-      if (Math.abs(dy) > Math.abs(dx)) {
-        // Vertical movement won — bow out.
-        reset();
-        return;
-      }
-      // Reject drags in the wrong direction for the current state:
-      // closed → must drag right; open → must drag left.
-      if (baselineOpen ? dx > 0 : dx < 0) {
-        reset();
-        return;
-      }
-      claimed = true;
-      sidebarNav.startDrag();
-      // Capture only once we've claimed the gesture so taps and short presses
-      // can still bubble / be forwarded to the underlying content.
-      node.setPointerCapture(e.pointerId);
-      captured = true;
-    }
-
-    sidebarNav.updateDrag(dx);
-    samples.push({ x: e.clientX, t: e.timeStamp });
-    const cutoff = e.timeStamp - VELOCITY_SAMPLE_MS;
-    while (samples.length > 2 && samples[0].t < cutoff) samples.shift();
-  }
-
-  function onUp(e: PointerEvent) {
-    if (e.pointerId !== pointerId) return;
-    if (!claimed) {
-      // Tap (movement didn't cross the swipe threshold). Forward as a click so
-      // taps on underlying interactive content (back buttons, links, etc.)
-      // still work even though the gesture surface is on top. Note: if a
-      // long-press handoff already fired, `reset()` cleared `pointerId`, so
-      // we'd have early-returned above.
-      const movedFar =
-        Math.abs(e.clientX - startX) >= LONG_PRESS_CANCEL_PX ||
-        Math.abs(e.clientY - startY) >= LONG_PRESS_CANCEL_PX;
-      if (!movedFar) {
-        forwardTap(e.clientX, e.clientY);
-      }
-      reset();
-      return;
-    }
-    const last = samples[samples.length - 1];
-    const first = samples[0];
-    const dt = last.t - first.t;
-    const vx = dt > 0 ? (last.x - first.x) / dt : 0;
-    sidebarNav.endDrag(vx);
-    reset();
-  }
-
-  function onCancel(e: PointerEvent) {
-    if (e.pointerId !== pointerId) return;
-    if (claimed) sidebarNav.endDrag(0);
-    reset();
-  }
-
-  node.addEventListener('pointerdown', onDown);
-  node.addEventListener('pointermove', onMove);
-  node.addEventListener('pointerup', onUp);
-  node.addEventListener('pointercancel', onCancel);
-
-  return {
-    destroy() {
-      clearLongPress();
-      node.removeEventListener('pointerdown', onDown);
-      node.removeEventListener('pointermove', onMove);
-      node.removeEventListener('pointerup', onUp);
-      node.removeEventListener('pointercancel', onCancel);
-    }
-  };
+  return panGesture(node, {
+    axis: 'x',
+    enabled: () => sidebarNav.isMobile,
+    shouldClaim: (dx) => (sidebarNav.isOpen ? dx < 0 : dx > 0),
+    onStart: () => sidebarNav.startDrag(),
+    onUpdate: (dx) => sidebarNav.updateDrag(dx),
+    onEnd: (_dx, vx) => sidebarNav.endDrag(vx),
+    onCancel: () => sidebarNav.endDrag(0),
+    onTap: forwardTap,
+    onLongPress: forwardLongPress
+  });
 }
 
 export { SIDEBAR_PANEL_WIDTH_PX };

--- a/frontend/src/lib/ui/BottomSheet.svelte
+++ b/frontend/src/lib/ui/BottomSheet.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
+  import { panGesture } from '$lib/hooks/panGesture.svelte';
 
   let {
     children,
@@ -12,7 +13,16 @@
   } = $props();
 
   let dialogEl: HTMLDialogElement | undefined = $state();
+  let contentEl: HTMLElement | undefined = $state();
   let closing = $state(false);
+  let dragging = $state(false);
+  let dragOffsetY = $state(0);
+
+  // Threshold past which a release commits to closing (in px of drag, relative
+  // to the sheet's own height).
+  const DRAG_CLOSE_FRACTION = 0.5;
+  // Downward fling velocity (px/ms) that always closes regardless of distance.
+  const FLING_CLOSE_VELOCITY = 0.5;
 
   $effect(() => {
     if (visible) {
@@ -26,6 +36,8 @@
   function handleNativeClose() {
     visible = false;
     closing = false;
+    dragging = false;
+    dragOffsetY = 0;
     onclose?.();
   }
 
@@ -65,11 +77,53 @@
   class="bottom-sheet m-0 mt-auto w-full max-w-full bg-transparent p-0 backdrop:bg-black/50"
   class:closing
 >
-  <div class="pb-safe rounded-t-xl border-t border-border bg-surface">
-    <!-- Drag handle - click to close -->
+  <div
+    bind:this={contentEl}
+    class="pb-safe rounded-t-xl border-t border-border bg-surface"
+    class:dragging
+    style:transform={dragOffsetY > 0 ? `translateY(${dragOffsetY}px)` : undefined}
+  >
+    <!--
+      Drag handle: tap closes; drag down past 50% of sheet height (or with
+      enough downward velocity) closes; otherwise the sheet snaps back.
+      `touch-action: none` is required so the browser doesn't claim the
+      vertical pan as a native scroll mid-drag.
+    -->
     <button
+      use:panGesture={{
+        axis: 'y',
+        enabled: () => !closing,
+        shouldClaim: (dy) => dy > 0,
+        onStart: () => {
+          dragging = true;
+        },
+        onUpdate: (dy) => {
+          dragOffsetY = Math.max(0, dy);
+        },
+        onEnd: (dy, vy) => {
+          dragging = false;
+          const sheetH = contentEl?.offsetHeight ?? 0;
+          const past = sheetH > 0 && dy > sheetH * DRAG_CLOSE_FRACTION;
+          if (past || vy > FLING_CLOSE_VELOCITY) {
+            // Drag-close: transition inner offset DOWN to sheetH (same
+            // direction as the dialog's slide-down keyframe). If we
+            // transitioned back to 0 instead, the inner div would briefly
+            // move UP while the dialog keyframe was still slow-starting,
+            // producing a visible "bounce up before sliding down" glitch.
+            dragOffsetY = sheetH;
+            close();
+          } else {
+            // Snap back to fully open.
+            dragOffsetY = 0;
+          }
+        },
+        onCancel: () => {
+          dragging = false;
+          dragOffsetY = 0;
+        }
+      }}
       type="button"
-      class="flex w-full cursor-pointer justify-center py-3"
+      class="flex w-full cursor-pointer touch-none justify-center py-3"
       onclick={close}
       aria-label="Close"
     >
@@ -84,6 +138,18 @@
 </dialog>
 
 <style>
+  /*
+    Inner content has a transform transition so drag releases (snap-back to 0
+    or settle-at-0 during close) animate smoothly. While `dragging` is true the
+    transition is suppressed so the transform follows the finger 1:1.
+  */
+  dialog.bottom-sheet > div {
+    transition: transform 200ms ease-out;
+  }
+  dialog.bottom-sheet > div.dragging {
+    transition: none;
+  }
+
   dialog.bottom-sheet[open] {
     animation: slide-up 200ms ease-out;
   }


### PR DESCRIPTION
## Summary
- Extracted the pointer/long-press/sample/capture machinery from `useSidebarSwipe` into a reusable `panGesture` Svelte action: configurable axis, direction lock, `shouldClaim` predicate, and `onStart` / `onUpdate` / `onEnd(delta, velocity)` / `onCancel` / `onTap` / `onLongPress` callbacks.
- `useSidebarSwipe` shrinks to a thin wrapper that wires `sidebarNav` into `panGesture` (axis: 'x', per-drag direction check) — behavior unchanged.
- `BottomSheet` gets vertical drag-to-dismiss on the drag handle (axis: 'y', `shouldClaim: dy > 0`); release past 50% of sheet height or with downward fling velocity > 0.5 px/ms commits to close, otherwise it snaps back. The commit-close transitions the inner offset down to `sheetHeight` so it stacks with the existing dialog slide-down keyframe instead of bouncing up through 0 first.

## Test plan
- [x] `mise x -- pnpm run check` — 1291 files, 0 errors
- [x] `mise test-frontend` — 52 files, 801 tests pass
- [ ] Manual: sidebar edge-swipe and tap-forwarding still work on mobile (regression check)
- [ ] Manual: bottom sheet drag-down dismisses cleanly with no upward bounce, slow drags snap back below threshold, fast flicks dismiss