### PR TITLE
refactor(read-state): key on event ID instead of JetStream sequence

### DIFF
--- a/cli/internal/core/dm.go
+++ b/cli/internal/core/dm.go
@@ -249,6 +249,12 @@ func (c *ChattoCore) joinDMRoom(ctx context.Context, bucket jetstream.KeyValue, 
 		return fmt.Errorf("failed to create DM membership: %w", err)
 	}
 
+	// Initialize an empty read marker so HasUnread distinguishes a fresh DM
+	// member from a deploy-era user without any marker (see GetLastReadEventID).
+	if err := c.SetLastReadEventID(ctx, DMSpaceID, userID, roomID, ""); err != nil {
+		c.logger.Warn("Failed to initialize DM read marker", "error", err, "user_id", userID, "room_id", roomID)
+	}
+
 	// Publish UserJoinedRoomEvent to seed the room's event stream.
 	// This event is filtered out in the frontend for DM rooms.
 	event := newSpaceEvent(userID, &corev1.SpaceEvent{

--- a/cli/internal/core/dm_test.go
+++ b/cli/internal/core/dm_test.go
@@ -615,19 +615,18 @@ func TestDMUnreadStatus(t *testing.T) {
 	})
 
 	t.Run("unread clears after marking as read", func(t *testing.T) {
-		// Get room's last sequence
-		lastSeq, err := core.GetRoomLastSequence(ctx, DMSpaceID, room.Id)
+		// Get room's last event
+		lastID, _, exists, err := core.GetRoomLastEvent(ctx, DMSpaceID, room.Id)
 		if err != nil {
-			t.Fatalf("GetRoomLastSequence error: %v", err)
+			t.Fatalf("GetRoomLastEvent error: %v", err)
 		}
-		if lastSeq == 0 {
-			t.Fatal("Expected non-zero last sequence after posting")
+		if !exists {
+			t.Fatal("Expected last event to exist after posting")
 		}
 
 		// Mark as read for user2
-		err = core.SetLastReadSequence(ctx, DMSpaceID, user2.Id, room.Id, lastSeq)
-		if err != nil {
-			t.Fatalf("SetLastReadSequence error: %v", err)
+		if err := core.SetLastReadEventID(ctx, DMSpaceID, user2.Id, room.Id, lastID); err != nil {
+			t.Fatalf("SetLastReadEventID error: %v", err)
 		}
 
 		// user2 should no longer have unread

--- a/cli/internal/core/rooms.go
+++ b/cli/internal/core/rooms.go
@@ -677,19 +677,21 @@ func (c *ChattoCore) JoinRoom(ctx context.Context, actorID, space_id, user_id, r
 
 	c.logger.Info("Created room membership", "user_id", user_id, "space_id", space_id, "room_id", room_id)
 
-	// Initialize read status for new members to the room's current last sequence.
-	// This ensures existing messages are considered "read" (the user wasn't there when they were posted)
-	// and only new messages after joining will be marked as unread.
+	// Initialize the read marker for new members. For non-empty rooms, mark
+	// them caught up to the current last event so existing messages don't
+	// surface as unread. For empty rooms, write an empty-string sentinel so
+	// the key's presence still distinguishes "member with nothing to read
+	// yet" from "no marker at all" (which the lazy-init path treats as a
+	// deploy-era upgrade — see GetLastReadEventID).
 	if isNew {
-		lastSeq, err := c.GetRoomLastSequence(ctx, space_id, room_id)
-		if err != nil {
-			c.logger.Warn("Failed to get room last sequence during join", "error", err, "room_id", room_id)
-			// Continue anyway - user can mark as read manually
-		} else if lastSeq > 0 {
-			if err := c.SetLastReadSequence(ctx, space_id, user_id, room_id, lastSeq); err != nil {
-				c.logger.Warn("Failed to initialize read status during join", "error", err, "room_id", room_id)
-				// Continue anyway - not critical
-			}
+		var initEventID string
+		if lastID, _, exists, err := c.GetRoomLastEvent(ctx, space_id, room_id); err != nil {
+			c.logger.Warn("Failed to get room last event during join", "error", err, "room_id", room_id)
+		} else if exists {
+			initEventID = lastID
+		}
+		if err := c.SetLastReadEventID(ctx, space_id, user_id, room_id, initEventID); err != nil {
+			c.logger.Warn("Failed to initialize read marker during join", "error", err, "room_id", room_id)
 		}
 	}
 
@@ -1148,9 +1150,20 @@ func (c *ChattoCore) PostMessage(ctx context.Context, space_id, room_id, user_id
 
 	c.logger.Info("Message posted", "space_id", space_id, "room_id", room_id, "message_body_key", messageBodyKey, "sequence_id", sequenceID, "user_id", user_id)
 
-	// Mark the room as read for the poster - they've obviously seen their own message
-	if err := c.SetLastReadSequence(ctx, space_id, user_id, room_id, sequenceID); err != nil {
-		c.logger.Warn("Failed to set last read sequence for poster", "error", err)
+	// Mark the room as read for the poster. For root posts, the just-
+	// published event is the new last root. For thread replies, we look up
+	// the room's current last root so the read marker tracks a real root
+	// event ID (HasUnread expects root events).
+	var posterReadEventID string
+	if inThread == "" {
+		posterReadEventID = event.Id
+	} else if lastRootID, _, exists, err := c.GetRoomLastEvent(ctx, space_id, room_id); err == nil && exists {
+		posterReadEventID = lastRootID
+	}
+	if posterReadEventID != "" {
+		if err := c.SetLastReadEventID(ctx, space_id, user_id, room_id, posterReadEventID); err != nil {
+			c.logger.Warn("Failed to set last read event for poster", "error", err)
+		}
 	}
 
 	// Update thread metadata if this is a thread reply
@@ -2965,133 +2978,158 @@ func (c *ChattoCore) StreamRoomEventsLive(ctx context.Context, space_id, room_id
 // ============================================================================
 // Unread Message Tracking
 // ============================================================================
+//
+// Per-user, per-room read state is keyed on the last-read root message's stable
+// event ID (14-char NanoID, see ADR-026), not on the (volatile) JetStream
+// sequence number. Event IDs are embedded in NATS subjects, so they survive
+// stream renumbering and rebuilds. See docs/adr/ADR-028 for rationale.
+//
+// The legacy `room_read_status.*` keys (uint64 sequence numbers) are orphaned
+// and ignored. Users with no `room_read_event.*` key are lazy-initialized to
+// the room's current last root event on first read — the "caught up at deploy
+// time" semantic.
 
-// GetRoomLastSequence returns the last root message sequence ID for a room.
-// Excludes thread replies — only root messages affect room-level unread tracking.
-// Derived directly from JetStream — no KV cache needed.
-// Returns 0 if the room has no root messages.
-func (c *ChattoCore) GetRoomLastSequence(ctx context.Context, spaceID, roomID string) (uint64, error) {
+// GetRoomLastEvent returns the last root message's event ID and JetStream
+// timestamp for a room. Excludes thread replies — only root messages affect
+// room-level unread tracking. exists is false if the room has no root messages.
+func (c *ChattoCore) GetRoomLastEvent(ctx context.Context, spaceID, roomID string) (eventID string, ts time.Time, exists bool, err error) {
 	msg, err := c.getRoomLastRootMessage(ctx, spaceID, roomID)
 	if err != nil {
-		return 0, err
+		return "", time.Time{}, false, err
 	}
 	if msg == nil {
-		return 0, nil
+		return "", time.Time{}, false, nil
 	}
-	return msg.Sequence, nil
+	return subjects.ParseEventIDFromSubject(msg.Subject), msg.Time, true, nil
 }
 
-// GetSequenceTimestamp returns the JetStream timestamp for a given stream sequence number.
-// Returns zero time if the sequence is 0 or the message doesn't exist.
-func (c *ChattoCore) GetSequenceTimestamp(ctx context.Context, spaceID string, sequence uint64) (time.Time, error) {
-	if sequence == 0 {
-		return time.Time{}, nil
-	}
-
-	stream, err := c.getSpaceStream(ctx, spaceID)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("failed to get stream: %w", err)
-	}
-
-	msg, err := stream.GetMsg(ctx, sequence)
-	if err != nil {
-		if errors.Is(err, jetstream.ErrMsgNotFound) {
-			return time.Time{}, nil
-		}
-		return time.Time{}, fmt.Errorf("failed to get message: %w", err)
-	}
-
-	return msg.Time, nil
+// roomReadEventKey returns the KV key for tracking the user's last-read root
+// event ID in a room.
+func roomReadEventKey(userID, roomID string) string {
+	return fmt.Sprintf("room_read_event.%s.%s", userID, roomID)
 }
 
-// roomReadStatusKey returns the KV key for tracking last read message sequence.
-func roomReadStatusKey(userID, roomID string) string {
-	return fmt.Sprintf("room_read_status.%s.%s", userID, roomID)
-}
-
-// GetLastReadSequence retrieves the last read sequence for a user in a room.
-// Returns 0 if no read status exists (all messages unread).
-func (c *ChattoCore) GetLastReadSequence(ctx context.Context, spaceID, userID, roomID string) (uint64, error) {
+// GetLastReadEventID returns the user's last-read root-message event ID for a
+// room. If no marker exists yet, it lazy-initializes the marker to the room's
+// current last root event ("caught up at deploy time"); if the room has no
+// messages, it returns "".
+func (c *ChattoCore) GetLastReadEventID(ctx context.Context, spaceID, userID, roomID string) (string, error) {
 	bucket, err := c.getSpaceRuntimeBucket(ctx, spaceID)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get runtime bucket: %w", err)
+		return "", fmt.Errorf("failed to get runtime bucket: %w", err)
 	}
 
-	entry, err := bucket.Get(ctx, roomReadStatusKey(userID, roomID))
+	key := roomReadEventKey(userID, roomID)
+	entry, err := bucket.Get(ctx, key)
+	if err == nil {
+		return string(entry.Value()), nil
+	}
+	if !errors.Is(err, jetstream.ErrKeyNotFound) {
+		return "", fmt.Errorf("failed to get read marker: %w", err)
+	}
+
+	// No marker yet — initialize to the room's current last root event so the
+	// user starts caught up rather than seeing a wall of unreads.
+	lastID, _, exists, err := c.GetRoomLastEvent(ctx, spaceID, roomID)
 	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			return 0, nil // No read status = all messages unread
-		}
-		return 0, fmt.Errorf("failed to get read status: %w", err)
+		return "", err
 	}
-
-	// Decode uint64 from bytes using binary.BigEndian
-	if len(entry.Value()) != 8 {
-		return 0, fmt.Errorf("invalid read status value")
+	if !exists {
+		return "", nil
 	}
-	seq := binary.BigEndian.Uint64(entry.Value())
-	return seq, nil
+	if _, err := bucket.Put(ctx, key, []byte(lastID)); err != nil {
+		c.logger.Warn("Failed to lazy-initialize read marker", "user_id", userID, "room_id", roomID, "error", err)
+	}
+	return lastID, nil
 }
 
-// SetLastReadSequence stores the last read sequence for a user in a room.
-func (c *ChattoCore) SetLastReadSequence(ctx context.Context, spaceID, userID, roomID string, sequence uint64) error {
+// SetLastReadEventID stores the user's last-read root-message event ID.
+func (c *ChattoCore) SetLastReadEventID(ctx context.Context, spaceID, userID, roomID, eventID string) error {
 	bucket, err := c.getSpaceRuntimeBucket(ctx, spaceID)
 	if err != nil {
 		return fmt.Errorf("failed to get runtime bucket: %w", err)
 	}
-
-	// Encode uint64 to bytes
-	buf := make([]byte, 8)
-	binary.BigEndian.PutUint64(buf, sequence)
-
-	_, err = bucket.Put(ctx, roomReadStatusKey(userID, roomID), buf)
-	if err != nil {
-		return fmt.Errorf("failed to set read status: %w", err)
+	if _, err := bucket.Put(ctx, roomReadEventKey(userID, roomID), []byte(eventID)); err != nil {
+		return fmt.Errorf("failed to set read marker: %w", err)
 	}
-
-	c.logger.Debug("Set last read sequence", "user_id", userID, "room_id", roomID, "sequence", sequence)
+	c.logger.Debug("Set last read event", "user_id", userID, "room_id", roomID, "event_id", eventID)
 	return nil
 }
 
-// HasUnread checks if a room has unread messages for a user.
-// Compares the room's last sequence (from KV) with the user's last read sequence.
-// Returns false if user is not a member, room has no messages, or room is muted.
+// GetEventTimestamp returns the JetStream-stored timestamp for a root message
+// event ID in a room. Returns zero time if the event ID is empty or the
+// message doesn't exist (e.g. deleted or never published).
+func (c *ChattoCore) GetEventTimestamp(ctx context.Context, spaceID, roomID, eventID string) (time.Time, error) {
+	if eventID == "" {
+		return time.Time{}, nil
+	}
+	stream, err := c.getSpaceStream(ctx, spaceID)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to get stream: %w", err)
+	}
+	msg, err := stream.GetLastMsgForSubject(ctx, subjects.SpaceRoomMessage(spaceID, roomID, eventID))
+	if err != nil {
+		if errors.Is(err, jetstream.ErrMsgNotFound) {
+			return time.Time{}, nil
+		}
+		return time.Time{}, fmt.Errorf("failed to get event: %w", err)
+	}
+	return msg.Time, nil
+}
+
+// HasUnread reports whether a room has unread messages for a user. Returns
+// false if the user is not a member, the room is muted, or there are no
+// messages. Compares the user's stored read marker (event ID) against the
+// room's current last root message.
 func (c *ChattoCore) HasUnread(ctx context.Context, spaceID, userID, roomID string) (bool, error) {
-	// Verify user is a member
 	isMember, err := c.RoomMembershipExists(ctx, spaceID, userID, roomID)
 	if err != nil {
 		return false, fmt.Errorf("failed to check room membership: %w", err)
 	}
 	if !isMember {
-		return false, nil // Not a member = no unread
+		return false, nil
 	}
 
-	// Check if user has muted this room
 	level, err := c.GetEffectiveNotificationLevel(ctx, spaceID, userID, roomID)
 	if err != nil {
 		c.logger.Warn("Failed to get notification level for unread check, continuing with default",
 			"user_id", userID, "space_id", spaceID, "room_id", roomID, "error", err)
 	} else if level == corev1.NotificationLevel_NOTIFICATION_LEVEL_MUTED {
-		return false, nil // Muted = never unread
+		return false, nil
 	}
 
-	// Get room's last sequence from KV
-	lastSeq, err := c.GetRoomLastSequence(ctx, spaceID, roomID)
+	lastID, lastTime, exists, err := c.GetRoomLastEvent(ctx, spaceID, roomID)
 	if err != nil {
 		return false, err
 	}
-	if lastSeq == 0 {
-		return false, nil // No messages in this room
+	if !exists {
+		return false, nil
 	}
 
-	// Get user's last read sequence
-	lastReadSeq, err := c.GetLastReadSequence(ctx, spaceID, userID, roomID)
+	readID, err := c.GetLastReadEventID(ctx, spaceID, userID, roomID)
 	if err != nil {
 		return false, err
 	}
+	if readID == "" {
+		// Member has a marker but no specific event read yet (joined an
+		// empty room, then messages arrived). Anything counts as unread.
+		return true, nil
+	}
+	if readID == lastID {
+		return false, nil // Caught up — fast path
+	}
 
-	// Has unread if room's last sequence is greater than user's last read
-	return lastSeq > lastReadSeq, nil
+	// Read marker points to an older (or deleted) message. Resolve its
+	// timestamp and compare. A missing message means the marker is stale —
+	// treat as unread; the user re-marks and state self-corrects.
+	readTime, err := c.GetEventTimestamp(ctx, spaceID, roomID, readID)
+	if err != nil {
+		return false, err
+	}
+	if readTime.IsZero() {
+		return true, nil
+	}
+	return lastTime.After(readTime), nil
 }
 
 // threadLastOpenedKey returns the KV key for tracking when a user last opened a thread.

--- a/cli/internal/core/rooms.go
+++ b/cli/internal/core/rooms.go
@@ -3037,13 +3037,28 @@ func (c *ChattoCore) GetLastReadEventID(ctx context.Context, spaceID, userID, ro
 	if !exists {
 		return "", nil
 	}
-	if _, err := bucket.Put(ctx, key, []byte(lastID)); err != nil {
+	// Use Create (atomic insert) rather than Put: a concurrent writer
+	// (PostMessage auto-mark, MarkRoomAsRead) may have set a real marker
+	// between our Get and our write, and we must not clobber it.
+	if _, err := bucket.Create(ctx, key, []byte(lastID)); err != nil {
+		if errors.Is(err, jetstream.ErrKeyExists) {
+			entry, getErr := bucket.Get(ctx, key)
+			if getErr != nil {
+				return "", fmt.Errorf("failed to re-read read marker after concurrent init: %w", getErr)
+			}
+			return string(entry.Value()), nil
+		}
 		c.logger.Warn("Failed to lazy-initialize read marker", "user_id", userID, "room_id", roomID, "error", err)
 	}
 	return lastID, nil
 }
 
 // SetLastReadEventID stores the user's last-read root-message event ID.
+//
+// Callers MUST pass either a root message event ID (one published with subject
+// `space.{s}.room.{r}.msg.{eventId}`) or the empty string. Thread-reply event
+// IDs would not resolve via GetEventTimestamp's root-subject lookup and would
+// keep the room permanently flagged as unread.
 func (c *ChattoCore) SetLastReadEventID(ctx context.Context, spaceID, userID, roomID, eventID string) error {
 	bucket, err := c.getSpaceRuntimeBucket(ctx, spaceID)
 	if err != nil {

--- a/cli/internal/core/rooms_test.go
+++ b/cli/internal/core/rooms_test.go
@@ -3007,6 +3007,80 @@ func TestChattoCore_HasUnread_JoiningRoomWithExistingMessages(t *testing.T) {
 	}
 }
 
+// TestChattoCore_HasUnread_StaleMarker verifies that if a user's read marker
+// points to a non-existent (e.g. deleted) event, HasUnread reports the room as
+// unread rather than falling silent — the next mark-read self-corrects.
+func TestChattoCore_HasUnread_StaleMarker(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	space, _ := core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
+	room, _ := core.CreateRoom(ctx, "test-user", space.Id, "General", "General discussion")
+	user, _ := core.CreateUser(ctx, "system", "stale-marker-user", "stale-marker-user", "password123")
+	core.JoinSpace(ctx, user.Id, space.Id)
+	core.JoinRoom(ctx, user.Id, space.Id, user.Id, room.Id)
+
+	if _, err := core.PostMessage(ctx, space.Id, room.Id, user.Id, "real msg", nil, "", "", nil, false); err != nil {
+		t.Fatalf("PostMessage error: %v", err)
+	}
+
+	// Force the read marker to reference a non-existent event ID — the
+	// "marker pointed at a deleted message" scenario.
+	if err := core.SetLastReadEventID(ctx, space.Id, user.Id, room.Id, "Edoesnotexist"); err != nil {
+		t.Fatalf("SetLastReadEventID error: %v", err)
+	}
+
+	hasUnread, err := core.HasUnread(ctx, space.Id, user.Id, room.Id)
+	if err != nil {
+		t.Fatalf("HasUnread error: %v", err)
+	}
+	if !hasUnread {
+		t.Error("Expected stale read marker to surface as unread")
+	}
+}
+
+// TestChattoCore_LastReadEventID_LazyInitRespectsExistingMarker verifies the
+// invariant the Create-not-Put fix is there to guarantee: a marker written by
+// any other path (MarkRoomAsRead, JoinRoom, PostMessage auto-mark) takes
+// precedence over the lazy-init fallback. The race itself isn't directly
+// exercisable without controlling KV timing, but the visible contract is
+// "if a marker exists, GetLastReadEventID returns *that* value, never
+// lazy-init's value."
+func TestChattoCore_LastReadEventID_LazyInitRespectsExistingMarker(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	space, _ := core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
+	room, _ := core.CreateRoom(ctx, "test-user", space.Id, "General", "General discussion")
+	poster, _ := core.CreateUser(ctx, "system", "race-poster", "race-poster", "password123")
+	core.JoinSpace(ctx, poster.Id, space.Id)
+	core.JoinRoom(ctx, poster.Id, space.Id, poster.Id, room.Id)
+	if _, err := core.PostMessage(ctx, space.Id, room.Id, poster.Id, "msg", nil, "", "", nil, false); err != nil {
+		t.Fatalf("PostMessage error: %v", err)
+	}
+
+	// "Stranger" has no marker yet — the post-deploy / deploy-era case that
+	// drives the lazy-init path. Pre-write the key directly with a marker
+	// the stranger never wrote, simulating a concurrent winner.
+	stranger, _ := core.CreateUser(ctx, "system", "race-stranger", "race-stranger", "password123")
+	const concurrentWinner = "Eraceconcurwin"
+	bucket, err := core.getSpaceRuntimeBucket(ctx, space.Id)
+	if err != nil {
+		t.Fatalf("getSpaceRuntimeBucket error: %v", err)
+	}
+	if _, err := bucket.Put(ctx, roomReadEventKey(stranger.Id, room.Id), []byte(concurrentWinner)); err != nil {
+		t.Fatalf("seed marker error: %v", err)
+	}
+
+	got, err := core.GetLastReadEventID(ctx, space.Id, stranger.Id, room.Id)
+	if err != nil {
+		t.Fatalf("GetLastReadEventID error: %v", err)
+	}
+	if got != concurrentWinner {
+		t.Errorf("Expected concurrent winner %q, got %q (lazy-init clobbered)", concurrentWinner, got)
+	}
+}
+
 func TestChattoCore_HasUnread_ThreadReplyDoesNotCauseUnread(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)

--- a/cli/internal/core/rooms_test.go
+++ b/cli/internal/core/rooms_test.go
@@ -2586,105 +2586,159 @@ func TestChattoCore_DeleteSpace_DeletesMessageBodiesBucket(t *testing.T) {
 // Unread Message Tracking Tests
 // ============================================================================
 
-func TestChattoCore_RoomLastSequence(t *testing.T) {
+func TestChattoCore_GetRoomLastEvent(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	// Create space
 	space, _ := core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
 	room, _ := core.CreateRoom(ctx, "test-user", space.Id, "General", "General discussion")
 
-	// Initially should return 0 (no messages)
-	seq, err := core.GetRoomLastSequence(ctx, space.Id, room.Id)
+	// Initially: no last event
+	id, _, exists, err := core.GetRoomLastEvent(ctx, space.Id, room.Id)
 	if err != nil {
-		t.Fatalf("Failed to get room last sequence: %v", err)
+		t.Fatalf("Failed to get room last event: %v", err)
 	}
-	if seq != 0 {
-		t.Errorf("Expected 0 for room with no messages, got %d", seq)
+	if exists || id != "" {
+		t.Errorf("Expected no last event for empty room, got id=%q exists=%v", id, exists)
 	}
 
-	// Post a message - this should update room_last_seq
 	user, _ := core.CreateUser(ctx, "system", "testuser", "testuser", "password123")
 	core.JoinSpace(ctx, user.Id, space.Id)
 	core.JoinRoom(ctx, user.Id, space.Id, user.Id, room.Id)
 
-	_, err = core.PostMessage(ctx, space.Id, room.Id, user.Id, "First message", nil, "", "", nil, false)
+	first, err := core.PostMessage(ctx, space.Id, room.Id, user.Id, "First message", nil, "", "", nil, false)
 	if err != nil {
 		t.Fatalf("Failed to post message: %v", err)
 	}
 
-	// Now should have a sequence > 0
-	seq, err = core.GetRoomLastSequence(ctx, space.Id, room.Id)
+	id, ts, exists, err := core.GetRoomLastEvent(ctx, space.Id, room.Id)
 	if err != nil {
-		t.Fatalf("Failed to get room last sequence after post: %v", err)
+		t.Fatalf("Failed to get room last event after post: %v", err)
 	}
-	if seq == 0 {
-		t.Error("Expected non-zero sequence after posting message")
+	if !exists {
+		t.Fatal("Expected room last event to exist after a post")
+	}
+	if id != first.Id {
+		t.Errorf("Expected last event id %q, got %q", first.Id, id)
+	}
+	if ts.IsZero() {
+		t.Error("Expected non-zero timestamp")
 	}
 
-	firstSeq := seq
-
-	// Post another message
-	_, err = core.PostMessage(ctx, space.Id, room.Id, user.Id, "Second message", nil, "", "", nil, false)
+	second, err := core.PostMessage(ctx, space.Id, room.Id, user.Id, "Second message", nil, "", "", nil, false)
 	if err != nil {
 		t.Fatalf("Failed to post second message: %v", err)
 	}
 
-	// Sequence should have increased
-	seq, err = core.GetRoomLastSequence(ctx, space.Id, room.Id)
+	id, _, _, err = core.GetRoomLastEvent(ctx, space.Id, room.Id)
 	if err != nil {
-		t.Fatalf("Failed to get room last sequence after second post: %v", err)
+		t.Fatalf("Failed to get room last event after second post: %v", err)
 	}
-	if seq <= firstSeq {
-		t.Errorf("Expected sequence to increase, got %d (was %d)", seq, firstSeq)
+	if id != second.Id {
+		t.Errorf("Expected last event id %q after second post, got %q", second.Id, id)
 	}
 }
 
-func TestChattoCore_LastReadSequence(t *testing.T) {
+func TestChattoCore_LastReadEventID(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	// Setup
 	space, _ := core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
 	room, _ := core.CreateRoom(ctx, "test-user", space.Id, "General", "General discussion")
 	user, _ := core.CreateUser(ctx, "system", "testuser", "testuser", "password123")
 
-	// Initially should return 0 (never read)
-	seq, err := core.GetLastReadSequence(ctx, space.Id, user.Id, room.Id)
+	// Initially: empty (never read)
+	id, err := core.GetLastReadEventID(ctx, space.Id, user.Id, room.Id)
 	if err != nil {
-		t.Fatalf("Failed to get last read sequence: %v", err)
+		t.Fatalf("Failed to get last read event id: %v", err)
 	}
-	if seq != 0 {
-		t.Errorf("Expected 0 for unread room, got %d", seq)
+	if id != "" {
+		t.Errorf("Expected empty for unread room, got %q", id)
 	}
 
-	// Set last read sequence
-	err = core.SetLastReadSequence(ctx, space.Id, user.Id, room.Id, 42)
+	// Set and read back
+	if err := core.SetLastReadEventID(ctx, space.Id, user.Id, room.Id, "Eabcdefghij012"); err != nil {
+		t.Fatalf("Failed to set last read event id: %v", err)
+	}
+	id, err = core.GetLastReadEventID(ctx, space.Id, user.Id, room.Id)
 	if err != nil {
-		t.Fatalf("Failed to set last read sequence: %v", err)
+		t.Fatalf("Failed to get last read event id after set: %v", err)
+	}
+	if id != "Eabcdefghij012" {
+		t.Errorf("Expected %q, got %q", "Eabcdefghij012", id)
 	}
 
-	// Should now return the set value
-	seq, err = core.GetLastReadSequence(ctx, space.Id, user.Id, room.Id)
-	if err != nil {
-		t.Fatalf("Failed to get last read sequence after set: %v", err)
+	// Overwrite
+	if err := core.SetLastReadEventID(ctx, space.Id, user.Id, room.Id, "Exyzxyzxyzxyz9"); err != nil {
+		t.Fatalf("Failed to update last read event id: %v", err)
 	}
-	if seq != 42 {
-		t.Errorf("Expected 42, got %d", seq)
+	id, err = core.GetLastReadEventID(ctx, space.Id, user.Id, room.Id)
+	if err != nil {
+		t.Fatalf("Failed to get last read event id after update: %v", err)
+	}
+	if id != "Exyzxyzxyzxyz9" {
+		t.Errorf("Expected %q, got %q", "Exyzxyzxyzxyz9", id)
+	}
+}
+
+// TestChattoCore_LastReadEventID_LazyInitCaughtUp verifies that a user with
+// no read marker yet (e.g. a pre-existing user encountering this code path
+// for the first time post-deploy) is lazy-initialized as caught up to the
+// room's current last root event, so they don't see a wall of unreads.
+func TestChattoCore_LastReadEventID_LazyInitCaughtUp(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	space, _ := core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
+	room, _ := core.CreateRoom(ctx, "test-user", space.Id, "General", "General discussion")
+	poster, _ := core.CreateUser(ctx, "system", "poster", "poster", "password123")
+	core.JoinSpace(ctx, poster.Id, space.Id)
+	core.JoinRoom(ctx, poster.Id, space.Id, poster.Id, room.Id)
+
+	posted, err := core.PostMessage(ctx, space.Id, room.Id, poster.Id, "msg", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage error: %v", err)
 	}
 
-	// Update to a higher value
-	err = core.SetLastReadSequence(ctx, space.Id, user.Id, room.Id, 100)
+	// A user that has never written a marker (simulating post-deploy upgrade
+	// where no `room_read_event` entry exists for them) should be lazy-
+	// initialized to the room's current last event, not treated as unread.
+	stranger, _ := core.CreateUser(ctx, "system", "stranger", "stranger", "password123")
+	got, err := core.GetLastReadEventID(ctx, space.Id, stranger.Id, room.Id)
 	if err != nil {
-		t.Fatalf("Failed to update last read sequence: %v", err)
+		t.Fatalf("GetLastReadEventID error: %v", err)
+	}
+	if got != posted.Id {
+		t.Errorf("Expected lazy init to current last event %q, got %q", posted.Id, got)
 	}
 
-	seq, err = core.GetLastReadSequence(ctx, space.Id, user.Id, room.Id)
+	// The marker should now be persisted — a second read returns the same
+	// value without re-running the init.
+	got2, err := core.GetLastReadEventID(ctx, space.Id, stranger.Id, room.Id)
 	if err != nil {
-		t.Fatalf("Failed to get updated last read sequence: %v", err)
+		t.Fatalf("Second GetLastReadEventID error: %v", err)
 	}
-	if seq != 100 {
-		t.Errorf("Expected 100, got %d", seq)
+	if got2 != posted.Id {
+		t.Errorf("Expected persisted marker %q, got %q", posted.Id, got2)
+	}
+}
+
+// TestChattoCore_LastReadEventID_LazyInitEmptyRoom verifies that lazy init
+// against an empty room returns "" without writing a marker.
+func TestChattoCore_LastReadEventID_LazyInitEmptyRoom(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	space, _ := core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
+	room, _ := core.CreateRoom(ctx, "test-user", space.Id, "General", "General discussion")
+	user, _ := core.CreateUser(ctx, "system", "empty-user", "empty-user", "password123")
+
+	got, err := core.GetLastReadEventID(ctx, space.Id, user.Id, room.Id)
+	if err != nil {
+		t.Fatalf("GetLastReadEventID error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("Expected empty event id for empty room, got %q", got)
 	}
 }
 
@@ -2777,16 +2831,18 @@ func TestChattoCore_HasUnread_AfterMarkingRead(t *testing.T) {
 		t.Error("Expected user1 to have unread from user2's message")
 	}
 
-	// Get the room's last sequence
-	lastSeq, err := core.GetRoomLastSequence(ctx, space.Id, room.Id)
+	// Get the room's last event
+	lastID, _, exists, err := core.GetRoomLastEvent(ctx, space.Id, room.Id)
 	if err != nil {
-		t.Fatalf("Failed to get room last sequence: %v", err)
+		t.Fatalf("Failed to get room last event: %v", err)
+	}
+	if !exists {
+		t.Fatal("Expected room to have a last event")
 	}
 
-	// User1 marks as read up to the last sequence
-	err = core.SetLastReadSequence(ctx, space.Id, user1.Id, room.Id, lastSeq)
-	if err != nil {
-		t.Fatalf("Failed to set last read sequence: %v", err)
+	// User1 marks as read up to the last event
+	if err := core.SetLastReadEventID(ctx, space.Id, user1.Id, room.Id, lastID); err != nil {
+		t.Fatalf("Failed to set last read event id: %v", err)
 	}
 
 	// User1 should have no unread now
@@ -2886,8 +2942,8 @@ func TestChattoCore_HasUnread_MultipleRooms(t *testing.T) {
 	}
 
 	// User1 marks room1 as read
-	lastSeq, _ := core.GetRoomLastSequence(ctx, space.Id, room1.Id)
-	core.SetLastReadSequence(ctx, space.Id, user1.Id, room1.Id, lastSeq)
+	lastID, _, _, _ := core.GetRoomLastEvent(ctx, space.Id, room1.Id)
+	core.SetLastReadEventID(ctx, space.Id, user1.Id, room1.Id, lastID)
 
 	// Room1 should now have no unread for user1
 	hasUnread, err = core.HasUnread(ctx, space.Id, user1.Id, room1.Id)
@@ -2972,11 +3028,11 @@ func TestChattoCore_HasUnread_ThreadReplyDoesNotCauseUnread(t *testing.T) {
 	}
 
 	// User2 reads the room (marks as read up to root message)
-	lastSeq, err := core.GetRoomLastSequence(ctx, space.Id, room.Id)
+	lastID, _, _, err := core.GetRoomLastEvent(ctx, space.Id, room.Id)
 	if err != nil {
-		t.Fatalf("Failed to get last sequence: %v", err)
+		t.Fatalf("Failed to get last event: %v", err)
 	}
-	if err := core.SetLastReadSequence(ctx, space.Id, user2.Id, room.Id, lastSeq); err != nil {
+	if err := core.SetLastReadEventID(ctx, space.Id, user2.Id, room.Id, lastID); err != nil {
 		t.Fatalf("Failed to set last read: %v", err)
 	}
 

--- a/cli/internal/graph/mutation.graphqls
+++ b/cli/internal/graph/mutation.graphqls
@@ -52,8 +52,8 @@ type Mutation {
 
   """
   Mark a room as read for the current user.
-  Stores the current stream lastSeq as the last read sequence.
-  Returns the previous and new last-read sequence IDs.
+  Stores the room's current last root message event ID as the user's read marker.
+  Returns the timestamps of the new and previous last-read events.
   """
   markRoomAsRead(input: MarkRoomAsReadInput!): MarkRoomAsReadResult!
 

--- a/cli/internal/graph/mutation.resolvers.go
+++ b/cli/internal/graph/mutation.resolvers.go
@@ -396,19 +396,30 @@ func (r *mutationResolver) PostMessage(ctx context.Context, input model.PostMess
 		}
 	}
 
-	// Auto-mark room as read since user is viewing it (avoids separate MarkRoomAsRead call)
-	lastSeq, err := r.core.GetRoomLastSequence(ctx, input.SpaceID, input.RoomID)
-	if err != nil {
-		r.logger.Warn("Failed to get room last sequence for auto-mark-read", "error", err)
+	// Auto-mark room as read since user is viewing it (avoids separate
+	// MarkRoomAsRead call). For root posts, we know the just-published event
+	// is the new last root. For thread replies, we look up the room's current
+	// last root so that posting in a thread also acknowledges any recent
+	// channel activity (preserves prior behavior).
+	var lastRootID string
+	if inThread == "" {
+		lastRootID = event.Id
 	} else {
-		if err := r.core.SetLastReadSequence(ctx, input.SpaceID, user.Id, input.RoomID, lastSeq); err != nil {
-			r.logger.Warn("Failed to auto-mark room as read", "error", err)
+		id, _, exists, err := r.core.GetRoomLastEvent(ctx, input.SpaceID, input.RoomID)
+		if err != nil {
+			r.logger.Warn("Failed to get room last event for auto-mark-read", "error", err)
+		} else if exists {
+			lastRootID = id
 		}
-		// Notify so other tabs/devices update their unread indicators
-		r.core.NotifyRoomMarkedAsRead(ctx, user.Id, input.SpaceID, input.RoomID)
-		// Clear any mention indicator for this room
-		if err := r.core.ClearMentionStatus(ctx, input.SpaceID, input.RoomID, user.Id); err != nil {
-			r.logger.Warn("Failed to clear mention status", "error", err)
+	}
+	if lastRootID != "" {
+		if err := r.core.SetLastReadEventID(ctx, input.SpaceID, user.Id, input.RoomID, lastRootID); err != nil {
+			r.logger.Warn("Failed to auto-mark room as read", "error", err)
+		} else {
+			r.core.NotifyRoomMarkedAsRead(ctx, user.Id, input.SpaceID, input.RoomID)
+			if err := r.core.ClearMentionStatus(ctx, input.SpaceID, input.RoomID, user.Id); err != nil {
+				r.logger.Warn("Failed to clear mention status", "error", err)
+			}
 		}
 	}
 
@@ -668,21 +679,22 @@ func (r *mutationResolver) MarkRoomAsRead(ctx context.Context, input model.MarkR
 		return nil, core.ErrNotRoomMember
 	}
 
-	// Get the user's previous last-read sequence (before updating)
-	previousSeq, err := r.core.GetLastReadSequence(ctx, input.SpaceID, user.Id, input.RoomID)
+	// Get the user's previous last-read event ID (before updating)
+	previousEventID, err := r.core.GetLastReadEventID(ctx, input.SpaceID, user.Id, input.RoomID)
 	if err != nil {
 		return nil, err
 	}
 
-	// Get room's last sequence to mark as read
-	lastSeq, err := r.core.GetRoomLastSequence(ctx, input.SpaceID, input.RoomID)
+	// Get the room's current last root event to mark as read
+	lastEventID, lastTime, hasLast, err := r.core.GetRoomLastEvent(ctx, input.SpaceID, input.RoomID)
 	if err != nil {
 		return nil, err
 	}
 
-	// Set the last read sequence
-	if err := r.core.SetLastReadSequence(ctx, input.SpaceID, user.Id, input.RoomID, lastSeq); err != nil {
-		return nil, err
+	if hasLast {
+		if err := r.core.SetLastReadEventID(ctx, input.SpaceID, user.Id, input.RoomID, lastEventID); err != nil {
+			return nil, err
+		}
 	}
 
 	// Notify user that they marked a room as read (for space unread indicator updates)
@@ -696,14 +708,12 @@ func (r *mutationResolver) MarkRoomAsRead(ctx context.Context, input model.MarkR
 
 	result := &model.MarkRoomAsReadResult{}
 
-	// Resolve JetStream timestamps for the sequence boundaries
-	if lastSeq > 0 {
-		if t, err := r.core.GetSequenceTimestamp(ctx, input.SpaceID, lastSeq); err == nil && !t.IsZero() {
-			result.LastReadAt = timestamppb.New(t)
-		}
+	// Resolve timestamps for the read boundaries
+	if hasLast && !lastTime.IsZero() {
+		result.LastReadAt = timestamppb.New(lastTime)
 	}
-	if previousSeq > 0 {
-		if t, err := r.core.GetSequenceTimestamp(ctx, input.SpaceID, previousSeq); err == nil && !t.IsZero() {
+	if previousEventID != "" {
+		if t, err := r.core.GetEventTimestamp(ctx, input.SpaceID, input.RoomID, previousEventID); err == nil && !t.IsZero() {
 			result.PreviousLastReadAt = timestamppb.New(t)
 		}
 	}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -616,7 +616,7 @@ Notes: Excluded from backups so backup archives contain only encrypted data, not
 
 | Key                                    | Description                                                       |
 | -------------------------------------- | ----------------------------------------------------------------- |
-| `room_read_status.{userId}.{roomId}`   | Last read message sequence (uint64, 8 bytes)                      |
+| `room_read_event.{userId}.{roomId}`    | Last-read root message event ID (UTF-8 string, ~14 bytes). Empty value = "joined but no specific event read yet" (e.g. joined an empty room). Missing key triggers a one-time lazy init to the room's current last event ("caught up at first read post-deploy"). The legacy `room_read_status.*` keys (8-byte uint64 sequences) are orphaned and ignored. |
 | `room_mention_status.{userId}.{roomId}`| Unread mention indicator (boolean — key presence means unread)    |
 
 **USER_PRESENCE keys:**

--- a/docs/adr/ADR-028-event-id-keyed-read-state.md
+++ b/docs/adr/ADR-028-event-id-keyed-read-state.md
@@ -34,9 +34,13 @@ A *missing* `room_read_event` key, by contrast, only happens for users who were 
 
 The honest semantic is "caught up at first read post-deploy", not strictly "at deploy time": if a deploy-era user's first post-deploy interaction with a room comes after new messages have arrived, those messages are silently swallowed into the lazy-init. For active users this window is small (next page load); for inactive users it's the price of avoiding a per-instance migration step. We accept that trade given Chatto's alpha posture and the fact that read state is the most disposable data class in a chat app.
 
+A related consequence: on a deploy-era user's *first* `markRoomAsRead` call, the GraphQL response's `previousLastReadAt` is null (because lazy-init makes the previous and new markers identical). The frontend's "messages since last read" highlight window is therefore empty for that one call. From the next mark-read onwards it works normally.
+
+Concurrency safety: lazy-init uses `bucket.Create` (atomic insert), not `Put`. If another writer (`MarkRoomAsRead`, `JoinRoom`, `PostMessage` auto-mark) wrote a real marker between our not-found read and our write, `Create` returns `ErrKeyExists` and we re-read instead of clobbering. This follows the project convention spelled out in `.claude/rules/backend.md`.
+
 ## Consequences
 
-- **Phase 4 of #330 doesn't have to translate read state.** Event IDs are stream-renumber-proof; the bulk stream copy doesn't touch the read-state bucket. Legacy `room_read_status.*` entries can be deleted at any time (or never — they're tiny).
+- **Phase 4 of #330 doesn't have to translate read state.** Event IDs are stream-renumber-proof; the bulk stream copy doesn't touch the read-state bucket. Legacy `room_read_status.*` entries can be deleted at any time (or never — they're tiny). Caveat: if Phase 4 ends up dropping and recreating the per-space RUNTIME KV bucket (rather than just renumbering the stream), all `room_read_event.*` markers go with it and every user becomes a deploy-era user under the lazy-init semantics above. That's likely tolerable but worth noting in the Phase 4 plan.
 - **`HasUnread` does up to one extra `GetLastMsgForSubject` call** in the "user has unread" case (the rare case where their marker is older than the latest root and not equal). Still O(1) per call.
 - **`GetSequenceTimestamp` is gone.** It only existed to resolve the old read-state seqs to timestamps for `markRoomAsRead`'s response. Replaced by `GetEventTimestamp(spaceID, roomID, eventID)`, which uses subject-based O(1) lookup. (`GetEventSequence` remains — it serves a different use case: deriving a JetStream consumer start position from an event ID.)
 - **`JoinRoom` / `joinDMRoom` always write a marker**, even for empty rooms. The empty-string sentinel is what lets `GetLastReadEventID` distinguish "fresh member, nothing read" from "deploy-era user, no marker at all".

--- a/docs/adr/ADR-028-event-id-keyed-read-state.md
+++ b/docs/adr/ADR-028-event-id-keyed-read-state.md
@@ -1,0 +1,45 @@
+# ADR-028: Event-ID-Keyed Read State
+
+**Date:** 2026-05-06
+
+**Status:** Accepted
+
+**Tracking issue:** [#330](https://github.com/chattocorp/chatto/issues/330)
+
+**Related:** [ADR-026](ADR-026-event-identity-via-nanoid.md), [ADR-027](ADR-027-instance-space-server-consolidation.md)
+
+## Context
+
+Each user's per-room read marker (`room_read_status.{userId}.{roomId}` in the per-space RUNTIME KV) used to be the absolute JetStream sequence number of the last-read root message, encoded as 8 BigEndian bytes. `HasUnread` compared that stored seq to the room's current last-root seq.
+
+ADR-026 already removed JetStream sequences from the public API and the event model — clients see only event IDs and timestamps. But the *persisted* read-state value remained sequence-keyed, which becomes a problem for the ADR-027 ("Server consolidation") migration: Phase 4 of #330 will copy / renumber JetStream streams. After renumbering, every stored uint64 sequence is either silently wrong (it now points to a different message) or out of range. We want Phase 4 to be a clean stream copy with no read-state translation logic in the migration script.
+
+## Decision
+
+Persist the **stable event ID** (14-char NanoID, see ADR-022/ADR-026) as the read marker instead of the volatile JetStream sequence number. Use a **new key prefix** (`room_read_event.*` instead of `room_read_status.*`) so the legacy 8-byte uint64 entries are simply orphaned, not translated.
+
+**Comparison logic in `HasUnread`:**
+
+1. Fetch the room's current last-root event via `GetLastMsgForSubject("space.{s}.room.{r}.msg.*")`. Extract the event ID from the returned subject and the timestamp from the message.
+2. Fetch the user's stored event ID. If it equals the room's last-root ID, they're caught up (fast path — no further lookups).
+3. Otherwise, resolve the stored event ID's timestamp via `GetLastMsgForSubject(SpaceRoomMessage(s, r, storedID))` and compare to the room's last-root timestamp.
+
+A missing stored event (deleted message) is treated as "unread"; the user re-marks and state self-corrects.
+
+### Lazy "caught up at first read post-deploy"
+
+Members always have a marker — `JoinRoom` and the DM `joinDMRoom` write either the room's current last event ID (room had messages) or an empty-string sentinel (room was empty). The empty string is a real value that means "member with nothing specific read yet"; `HasUnread` treats it as unread once any messages exist, so a brand-new member of an empty room correctly sees later posts as unread.
+
+A *missing* `room_read_event` key, by contrast, only happens for users who were members **before this PR shipped**. On their first `GetLastReadEventID` call post-deploy, the marker is lazy-initialized to the room's current last event ID and persisted, so they're treated as caught up. The legacy `room_read_status` key is never consulted.
+
+The honest semantic is "caught up at first read post-deploy", not strictly "at deploy time": if a deploy-era user's first post-deploy interaction with a room comes after new messages have arrived, those messages are silently swallowed into the lazy-init. For active users this window is small (next page load); for inactive users it's the price of avoiding a per-instance migration step. We accept that trade given Chatto's alpha posture and the fact that read state is the most disposable data class in a chat app.
+
+## Consequences
+
+- **Phase 4 of #330 doesn't have to translate read state.** Event IDs are stream-renumber-proof; the bulk stream copy doesn't touch the read-state bucket. Legacy `room_read_status.*` entries can be deleted at any time (or never — they're tiny).
+- **`HasUnread` does up to one extra `GetLastMsgForSubject` call** in the "user has unread" case (the rare case where their marker is older than the latest root and not equal). Still O(1) per call.
+- **`GetSequenceTimestamp` is gone.** It only existed to resolve the old read-state seqs to timestamps for `markRoomAsRead`'s response. Replaced by `GetEventTimestamp(spaceID, roomID, eventID)`, which uses subject-based O(1) lookup. (`GetEventSequence` remains — it serves a different use case: deriving a JetStream consumer start position from an event ID.)
+- **`JoinRoom` / `joinDMRoom` always write a marker**, even for empty rooms. The empty-string sentinel is what lets `GetLastReadEventID` distinguish "fresh member, nothing read" from "deploy-era user, no marker at all".
+- **Auto-mark on `PostMessage` for thread replies looks up the room's last root event** (one extra subject lookup per thread-reply auto-mark) so the marker always points to a real root event ID. Previously this worked by accident because seqs are linear across root and thread events; with event IDs, we have to be explicit. Whether thread replies should dismiss room-level unread *at all* is a separate question for a future ADR.
+- **Lazy init can silently swallow messages that arrived between deploy and a user's first post-deploy read.** Documented above; accepted.
+- **GraphQL contract is unchanged.** `MarkRoomAsReadResult` still returns `lastReadAt` and `previousLastReadAt` Times — the same shape the frontend already consumed under ADR-026.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -35,3 +35,4 @@ For more about ADRs, see [Michael Nygard's article](https://cognitect.com/blog/2
 | [ADR-025](ADR-025-multi-instance-client-architecture.md) | Multi-Instance Client Architecture | 2026-03-20 |
 | [ADR-026](ADR-026-event-identity-via-nanoid.md) | Event Identity via NanoID, Not JetStream Sequence Numbers | 2026-03-26 |
 | [ADR-027](ADR-027-instance-space-server-consolidation.md) | Consolidate Instance + Space into a Single "Server" Concept | 2026-05-04 |
+| [ADR-028](ADR-028-event-id-keyed-read-state.md) | Event-ID-Keyed Read State | 2026-05-06 |


### PR DESCRIPTION
## Summary

Prep work for #330 Phase 4. Per-user, per-room read markers now persist the last-read root message's stable event ID (NanoID, ADR-026) instead of its volatile JetStream sequence number, so the upcoming stream renumbering becomes a clean copy with no read-state translation logic. Uses a new KV key prefix (`room_read_event.*`) and orphans the legacy `room_read_status.*` uint64 entries; deploy-era users with no marker are lazy-initialized as caught up on first read. Behavior is preserved end-to-end (all read/unread tests, e2e indicator and DM tests pass), and ADR-028 documents the rationale and the "caught up at first read post-deploy" trade-off.

## Test plan

- [x] \`mise test-cli\` (only the pre-existing TestAuthRoutes_TestEmailEndpoint fails, per .claude/rules/backend.md)
- [x] \`pnpm exec playwright test e2e/unread-indicators.test.ts e2e/dm.test.ts\` — 17/17 pass
- [ ] Manual smoke: post in two browsers, verify unread dots / mark-as-read / cross-tab RoomMarkedAsRead behave correctly