### PR TITLE
feat(cli): add --include-keys flag to chatto backup

### DIFF
--- a/cli/cmd/backup.go
+++ b/cli/cmd/backup.go
@@ -42,18 +42,19 @@ type StreamBackupInfo struct {
 
 // BackupStats contains aggregate statistics about the backup
 type BackupStats struct {
-	TotalStreams int           `json:"total_streams"`
-	TotalBytes   uint64        `json:"total_bytes"`
-	DurationMs   int64         `json:"duration_ms"`
-	Skipped      int           `json:"skipped"`
-	Failed       int           `json:"failed"`
+	TotalStreams int    `json:"total_streams"`
+	TotalBytes   uint64 `json:"total_bytes"`
+	DurationMs   int64  `json:"duration_ms"`
+	Skipped      int    `json:"skipped"`
+	Failed       int    `json:"failed"`
 }
 
 var (
-	backupConfigFile string
-	backupOutput     string
-	backupEncrypt    bool
-	backupPassphrase string
+	backupConfigFile  string
+	backupOutput      string
+	backupEncrypt     bool
+	backupPassphrase  string
+	backupIncludeKeys bool
 )
 
 var backupCmd = &cobra.Command{
@@ -69,12 +70,18 @@ var backupCmd = &cobra.Command{
 - Per-space reactions
 - Per-space assets (attachments)
 
-Excluded from backups:
+Excluded from backups by default:
 - Encryption keys (security: keeps backup data encrypted at rest)
 - User presence (ephemeral, memory-only)
 - Link preview cache (regeneratable)
 - Asset cache (regeneratable)
 - Auth tokens (security: prevents token leakage via backups)
+
+Pass --include-keys to include KV_ENCRYPTION_KEYS in the archive. This
+makes the backup self-contained (encrypted message bodies become
+restorable) but means anyone with the archive can decrypt the contents,
+so the archive itself must be treated as sensitive (e.g. only stored on
+trusted media or used in combination with --encrypt).
 
 The backup is saved as a .tar.gz archive. Use --encrypt to protect
 the archive with a passphrase (uses age encryption).`,
@@ -87,6 +94,7 @@ func init() {
 	backupCmd.Flags().StringVarP(&backupOutput, "output", "o", "", "output path for the backup archive (default: backups/<timestamp>.tar.gz)")
 	backupCmd.Flags().BoolVar(&backupEncrypt, "encrypt", false, "encrypt the backup with a passphrase (age encryption)")
 	backupCmd.Flags().StringVar(&backupPassphrase, "passphrase", "", "encryption passphrase (if not set, prompts interactively)")
+	backupCmd.Flags().BoolVar(&backupIncludeKeys, "include-keys", false, "include KV_ENCRYPTION_KEYS in the archive (treat the archive as sensitive)")
 }
 
 func runBackup(cmd *cobra.Command, args []string) {
@@ -180,7 +188,7 @@ func runBackup(cmd *cobra.Command, args []string) {
 	}
 
 	for i, streamName := range streamNames {
-		info := backupStream(ctx, mgr, streamName, streamsDir, i+1, len(streamNames))
+		info := backupStream(ctx, mgr, streamName, streamsDir, i+1, len(streamNames), backupIncludeKeys)
 		manifest.Streams = append(manifest.Streams, info)
 
 		if info.Error != "" {
@@ -228,9 +236,15 @@ func runBackup(cmd *cobra.Command, args []string) {
 			"duration", time.Duration(manifest.Stats.DurationMs)*time.Millisecond,
 		)
 		log.Info("Archive created", "path", archivePath)
-		log.Warn("Encryption keys are excluded from backups by design. " +
-			"Encrypted message bodies in this backup cannot be decrypted without the keys. " +
-			"Back up your encryption keys separately if you need to restore encrypted content.")
+		if backupIncludeKeys {
+			log.Warn("Encryption keys are included in this backup. " +
+				"Anyone with this archive can decrypt all encrypted content. " +
+				"Treat the archive as sensitive material — keep it on trusted media or use --encrypt.")
+		} else {
+			log.Warn("Encryption keys are excluded from backups by default. " +
+				"Encrypted message bodies in this backup cannot be decrypted without the keys. " +
+				"Back up your encryption keys separately, or pass --include-keys to embed them.")
+		}
 	}
 }
 
@@ -251,12 +265,12 @@ func enumerateStreams(ctx context.Context, js jetstream.JetStream) ([]string, er
 }
 
 // backupStream backs up a single stream and returns info about the backup
-func backupStream(ctx context.Context, mgr *jsm.Manager, streamName, streamsDir string, current, total int) StreamBackupInfo {
+func backupStream(ctx context.Context, mgr *jsm.Manager, streamName, streamsDir string, current, total int, includeKeys bool) StreamBackupInfo {
 	streamType := classifyStream(streamName)
 	prefix := fmt.Sprintf("[%d/%d]", current, total)
 
 	// Check explicit skip list
-	if reason := skipReason(streamName); reason != "" {
+	if reason := skipReason(streamName, includeKeys); reason != "" {
 		log.Info(fmt.Sprintf("%s Skipping %s: %s", prefix, streamName, reason))
 		return StreamBackupInfo{
 			Name: streamName,
@@ -326,15 +340,19 @@ func backupStream(ctx context.Context, mgr *jsm.Manager, streamName, streamsDir 
 }
 
 // skipReason returns a human-readable reason if the stream should be skipped,
-// or an empty string if it should be backed up.
-func skipReason(name string) string {
+// or an empty string if it should be backed up. When includeKeys is true,
+// KV_ENCRYPTION_KEYS is backed up; the archive must then be treated as sensitive.
+func skipReason(name string, includeKeys bool) string {
 	switch name {
 	case "KV_USER_PRESENCE":
 		return "ephemeral (memory storage)"
 	case "KV_CALL_STATE":
 		return "ephemeral (memory storage)"
 	case "KV_ENCRYPTION_KEYS":
-		return "security (keys excluded from backups)"
+		if includeKeys {
+			return ""
+		}
+		return "security (keys excluded from backups; pass --include-keys to override)"
 	case "KV_LINK_PREVIEW_CACHE":
 		return "cache (regeneratable)"
 	case "KV_AUTH_TOKENS":

--- a/cli/cmd/backup_test.go
+++ b/cli/cmd/backup_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,37 +18,43 @@ import (
 
 func TestSkipReason(t *testing.T) {
 	tests := []struct {
-		name       string
-		wantSkip   bool
-		wantReason string
+		name        string
+		includeKeys bool
+		wantSkip    bool
+		wantReason  string
 	}{
-		// Should be skipped
-		{"KV_USER_PRESENCE", true, "ephemeral (memory storage)"},
-		{"KV_CALL_STATE", true, "ephemeral (memory storage)"},
-		{"KV_ENCRYPTION_KEYS", true, "security (keys excluded from backups)"},
-		{"KV_LINK_PREVIEW_CACHE", true, "cache (regeneratable)"},
-		{"KV_AUTH_TOKENS", true, "security (prevents token leakage)"},
-		{"OBJ_ASSET_CACHE", true, "cache (regeneratable)"},
+		// Should be skipped (default: includeKeys=false)
+		{"KV_USER_PRESENCE", false, true, "ephemeral (memory storage)"},
+		{"KV_CALL_STATE", false, true, "ephemeral (memory storage)"},
+		{"KV_ENCRYPTION_KEYS", false, true, "security (keys excluded from backups; pass --include-keys to override)"},
+		{"KV_LINK_PREVIEW_CACHE", false, true, "cache (regeneratable)"},
+		{"KV_AUTH_TOKENS", false, true, "security (prevents token leakage)"},
+		{"OBJ_ASSET_CACHE", false, true, "cache (regeneratable)"},
 
-		// Should NOT be skipped
-		{"KV_INSTANCE", false, ""},
-		{"KV_INSTANCE_RBAC", false, ""},
-		{"KV_INSTANCE_CONFIG", false, ""},
-		{"KV_NOTIFICATIONS", false, ""},
-		{"OBJ_INSTANCE_ASSETS", false, ""},
-		{"SPACE_abc123_EVENTS", false, ""},
-		{"KV_SPACE_abc123_CONFIG", false, ""},
-		{"KV_SPACE_abc123_RBAC", false, ""},
-		{"KV_SPACE_abc123_RUNTIME", false, ""},
-		{"KV_SPACE_abc123_BODIES", false, ""},
-		{"KV_SPACE_abc123_REACTIONS", false, ""},
-		{"KV_SPACE_abc123_THREADS", false, ""},
-		{"OBJ_SPACE_abc123_ASSETS", false, ""},
+		// With --include-keys, KV_ENCRYPTION_KEYS is backed up; others stay skipped.
+		{"KV_ENCRYPTION_KEYS", true, false, ""},
+		{"KV_USER_PRESENCE", true, true, "ephemeral (memory storage)"},
+		{"KV_AUTH_TOKENS", true, true, "security (prevents token leakage)"},
+
+		// Should NOT be skipped regardless of includeKeys
+		{"KV_INSTANCE", false, false, ""},
+		{"KV_INSTANCE_RBAC", false, false, ""},
+		{"KV_INSTANCE_CONFIG", false, false, ""},
+		{"KV_NOTIFICATIONS", false, false, ""},
+		{"OBJ_INSTANCE_ASSETS", false, false, ""},
+		{"SPACE_abc123_EVENTS", false, false, ""},
+		{"KV_SPACE_abc123_CONFIG", false, false, ""},
+		{"KV_SPACE_abc123_RBAC", false, false, ""},
+		{"KV_SPACE_abc123_RUNTIME", false, false, ""},
+		{"KV_SPACE_abc123_BODIES", false, false, ""},
+		{"KV_SPACE_abc123_REACTIONS", false, false, ""},
+		{"KV_SPACE_abc123_THREADS", false, false, ""},
+		{"OBJ_SPACE_abc123_ASSETS", false, false, ""},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			reason := skipReason(tt.name)
+		t.Run(fmt.Sprintf("%s/includeKeys=%v", tt.name, tt.includeKeys), func(t *testing.T) {
+			reason := skipReason(tt.name, tt.includeKeys)
 			if tt.wantSkip {
 				if reason == "" {
 					t.Errorf("expected stream %q to be skipped, but got no reason", tt.name)
@@ -293,7 +300,7 @@ func TestBackupRestoreRoundTrip(t *testing.T) {
 	}
 
 	for i, name := range streamNames {
-		info := backupStream(ctx, srcMgr, name, streamsDir, i+1, len(streamNames))
+		info := backupStream(ctx, srcMgr, name, streamsDir, i+1, len(streamNames), false)
 		manifest.Streams = append(manifest.Streams, info)
 
 		if info.Error != "" {


### PR DESCRIPTION
## Summary

By default, `chatto backup` excludes `KV_ENCRYPTION_KEYS` from the archive so an archive on its own can't decrypt anything — sensible for self-hosters who store backups offsite, but it means encrypted message bodies can never be restored without separately exporting the keys.

This adds an opt-in `--include-keys` flag that includes the encryption keys in the archive, making it self-contained. Default behaviour is unchanged.

The trailing log warning is updated to reflect which mode the run used and to remind the user to treat the archive as sensitive when keys are embedded.

## Why

`chatto-operator`'s backup CronJob currently produces archives that are useless for actual disaster recovery on instances with encrypted bodies — anything encrypted stays encrypted forever. Until proper backup encryption (age recipient model) is implemented, the operator wants to embed the keys and rely on bucket access controls for confidentiality.

## Test plan

- [x] `go test ./cmd/...` — covers the new `includeKeys` parameter on `skipReason` (both true and false branches) plus the existing roundtrip test
- [ ] Manual: `chatto backup --include-keys -o /tmp/backup.tar.gz` produces an archive whose `manifest.json` lists `KV_ENCRYPTION_KEYS` as backed up
- [ ] Manual: `chatto backup -o /tmp/backup.tar.gz` (no flag) still skips `KV_ENCRYPTION_KEYS`