### PR TITLE
fix(restore): report whether encryption keys were actually restored

### DIFF
--- a/cli/cmd/restore.go
+++ b/cli/cmd/restore.go
@@ -22,9 +22,9 @@ import (
 )
 
 var (
-	restoreConfigFile  string
-	restoreConflict    string
-	restorePassphrase  string
+	restoreConfigFile string
+	restoreConflict   string
+	restorePassphrase string
 )
 
 var restoreCmd = &cobra.Command{
@@ -159,17 +159,14 @@ func runRestore(cmd *cobra.Command, args []string) {
 		log.Fatal("Failed to create JSM manager", "error", err)
 	}
 
-	// Build set of existing streams for conflict detection
+	// Build set of existing streams for conflict detection.
 	existingStreams := make(map[string]bool)
-	if restoreConflict != "error" || true {
-		// Always enumerate so we can detect conflicts
-		streamLister := js.ListStreams(ctx)
-		for info := range streamLister.Info() {
-			existingStreams[info.Config.Name] = true
-		}
-		if err := streamLister.Err(); err != nil {
-			log.Fatal("Failed to enumerate existing streams", "error", err)
-		}
+	streamLister := js.ListStreams(ctx)
+	for info := range streamLister.Info() {
+		existingStreams[info.Config.Name] = true
+	}
+	if err := streamLister.Err(); err != nil {
+		log.Fatal("Failed to enumerate existing streams", "error", err)
 	}
 
 	// Restore each stream from the manifest
@@ -238,8 +235,26 @@ func runRestore(cmd *cobra.Command, args []string) {
 		log.Warn("Some streams failed to restore. Check the errors above.")
 	}
 
-	log.Warn("Encryption keys are NOT included in backups. " +
-		"If this instance uses encryption, restore your encryption keys separately.")
+	if manifestIncludesEncryptionKeys(manifest) {
+		log.Info("Encryption keys were included in the backup and have been restored. " +
+			"Encrypted message bodies should be readable by the application.")
+	} else {
+		log.Warn("Encryption keys were NOT included in this backup. " +
+			"Encrypted message bodies cannot be decrypted without them — restore your " +
+			"encryption keys separately, or recreate the backup with --include-keys.")
+	}
+}
+
+// manifestIncludesEncryptionKeys reports whether KV_ENCRYPTION_KEYS was actually
+// backed up (i.e. present and not marked skipped/failed in the manifest).
+func manifestIncludesEncryptionKeys(m BackupManifest) bool {
+	for _, s := range m.Streams {
+		if s.Name != "KV_ENCRYPTION_KEYS" {
+			continue
+		}
+		return s.Type != "skipped" && s.Error == ""
+	}
+	return false
 }
 
 // connectForRestore establishes a NATS connection for restore operations.

--- a/cli/cmd/restore_test.go
+++ b/cli/cmd/restore_test.go
@@ -1,0 +1,52 @@
+package cmd
+
+import "testing"
+
+func TestManifestIncludesEncryptionKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		streams []StreamBackupInfo
+		want    bool
+	}{
+		{
+			name: "keys included as kv",
+			streams: []StreamBackupInfo{
+				{Name: "KV_INSTANCE", Type: "kv", Messages: 10},
+				{Name: "KV_ENCRYPTION_KEYS", Type: "kv", Messages: 4, Bytes: 1401},
+			},
+			want: true,
+		},
+		{
+			name: "keys explicitly skipped",
+			streams: []StreamBackupInfo{
+				{Name: "KV_INSTANCE", Type: "kv", Messages: 10},
+				{Name: "KV_ENCRYPTION_KEYS", Type: "skipped"},
+			},
+			want: false,
+		},
+		{
+			name: "keys present but errored",
+			streams: []StreamBackupInfo{
+				{Name: "KV_ENCRYPTION_KEYS", Type: "kv", Error: "snapshot failed"},
+			},
+			want: false,
+		},
+		{
+			name: "keys absent from manifest",
+			streams: []StreamBackupInfo{
+				{Name: "KV_INSTANCE", Type: "kv"},
+				{Name: "KV_USER_PRESENCE", Type: "skipped"},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := manifestIncludesEncryptionKeys(BackupManifest{Streams: tt.streams})
+			if got != tt.want {
+				t.Errorf("manifestIncludesEncryptionKeys() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Two small follow-ups after #359 (which added `--include-keys` to `chatto backup`):

- `chatto restore`'s trailing log warning unconditionally said *\"Encryption keys are NOT included in backups\"*, which is wrong when the archive was created with `--include-keys`. Now the message is chosen based on whether `KV_ENCRYPTION_KEYS` is actually present (and not skipped/errored) in the manifest. When keys are present, log an informational message saying decryption should work.
- Drop the dead `if restoreConflict != \"error\" || true {` guard around existing-stream enumeration. Always evaluated true; we always need the listing to detect conflicts. Removed for clarity.

No behaviour change for the actual restore path — `KV_ENCRYPTION_KEYS` is restored like any other KV bucket when present in the archive (just like #359 already does on the backup side).

## Test plan

- [x] `go test ./cmd -run TestManifestIncludesEncryptionKeys` covers present / skipped / errored / absent cases for the new helper
- [x] `go test ./cmd -run TestBackupRestoreRoundTrip` still passes (existing roundtrip is unchanged)
- [ ] Manual: `chatto restore archive-with-keys.tar.gz` ends with the new info-level message; `chatto restore archive-without-keys.tar.gz` keeps the original warning