### PR TITLE
refactor(rooms): claim room names atomically via KV create

### DIFF
--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -42,6 +42,7 @@ type ChattoCore struct {
 	encryption           *encryptionManager
 	configManager        *ConfigManager
 	ensuredStreams       sync.Map // tracks which space streams have been ensured this process lifetime
+	roomNameIndexBackfilled sync.Map // tracks which spaces have had their room-name index backfilled
 	instanceRBACEngine   *rbac.Engine
 	s3Client             *S3Client           // Optional S3 client for S3-compatible storage
 	permissionResolver   *PermissionResolver // Hierarchical permission resolver
@@ -637,6 +638,15 @@ func spaceKey(spaceID string) string {
 // roomKey returns the KV key for a room record in a space bucket.
 func roomKey(roomID string) string {
 	return fmt.Sprintf("room.%s", roomID)
+}
+
+// roomNameIndexKey returns the KV key that claims a room name within a space.
+// Names are lowercased and trimmed so the claim is case-insensitive. The value
+// stored at this key is the room ID, which lets us recover from partial failures
+// (a stale claim whose room never got written can be reclaimed by the same room
+// trying again).
+func roomNameIndexKey(name string) string {
+	return fmt.Sprintf("room_name_index.%s", strings.ToLower(strings.TrimSpace(name)))
 }
 
 // messageBodyKey returns the KV key for a message body in a bodies bucket.

--- a/cli/internal/core/rooms.go
+++ b/cli/internal/core/rooms.go
@@ -160,16 +160,27 @@ func (c *ChattoCore) CreateRoom(ctx context.Context, actorID string, space_id, n
 	// Trim whitespace from name
 	name = strings.TrimSpace(name)
 
-	// Check for duplicate room name in this space (case-insensitive)
-	exists, err := c.RoomNameExists(ctx, space_id, name)
+	bucket, err := c.getSpaceConfigBucket(ctx, space_id)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check for duplicate room name: %w", err)
+		return nil, fmt.Errorf("failed to get bucket: %w", err)
 	}
-	if exists {
-		return nil, ErrRoomNameExists
+
+	// Backfill name index for any pre-existing rooms (no-op after first call per process).
+	if err := c.ensureRoomNameIndex(ctx, space_id, bucket); err != nil {
+		return nil, fmt.Errorf("failed to ensure room name index: %w", err)
 	}
 
 	room_id := NewRoomID()
+
+	// Atomically claim the name. kv.Create fails with ErrKeyExists if the name is taken,
+	// which removes the read-then-write race that the previous list-and-scan check had.
+	indexKey := roomNameIndexKey(name)
+	if _, err := bucket.Create(ctx, indexKey, []byte(room_id)); err != nil {
+		if errors.Is(err, jetstream.ErrKeyExists) {
+			return nil, ErrRoomNameExists
+		}
+		return nil, fmt.Errorf("failed to claim room name: %w", err)
+	}
 
 	// Create room entity
 	room := &corev1.Room{
@@ -179,17 +190,14 @@ func (c *ChattoCore) CreateRoom(ctx context.Context, actorID string, space_id, n
 		Description: description,
 	}
 
-	// Write to KV store (source of truth)
-	bucket, err := c.getSpaceConfigBucket(ctx, space_id)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get bucket: %w", err)
-	}
 	roomData, err := proto.Marshal(room)
 	if err != nil {
+		// Roll back the name claim so the name doesn't end up reserved with no room behind it.
+		c.bestEffortReleaseRoomNameClaim(ctx, bucket, indexKey, room_id)
 		return nil, fmt.Errorf("failed to marshal room: %w", err)
 	}
-	_, err = bucket.Put(ctx, roomKey(room.Id), roomData)
-	if err != nil {
+	if _, err := bucket.Put(ctx, roomKey(room.Id), roomData); err != nil {
+		c.bestEffortReleaseRoomNameClaim(ctx, bucket, indexKey, room_id)
 		return nil, fmt.Errorf("failed to store room: %w", err)
 	}
 
@@ -248,13 +256,31 @@ func (c *ChattoCore) UpdateRoom(ctx context.Context, actorID string, space_id, r
 		return nil, err
 	}
 
-	// Check for duplicate room name in this space (exclude self for case changes)
-	exists, err := c.RoomNameExistsExcluding(ctx, space_id, name, room_id)
+	bucket, err := c.getSpaceConfigBucket(ctx, space_id)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check for duplicate room name: %w", err)
+		return nil, fmt.Errorf("failed to get bucket: %w", err)
 	}
-	if exists {
-		return nil, ErrRoomNameExists
+
+	// Backfill name index for pre-existing rooms (no-op after first call per process).
+	if err := c.ensureRoomNameIndex(ctx, space_id, bucket); err != nil {
+		return nil, fmt.Errorf("failed to ensure room name index: %w", err)
+	}
+
+	// Detect rename. Case-changes-only count as a rename for index purposes only when the
+	// lowercased form actually changes (e.g. "general" → "General" keeps the same index key).
+	oldIndexKey := roomNameIndexKey(room.Name)
+	newIndexKey := roomNameIndexKey(name)
+	renamed := oldIndexKey != newIndexKey
+
+	if renamed {
+		// Atomically claim the new name before writing the room. ErrKeyExists means the
+		// name is taken by another room — fail without touching the room record.
+		if _, err := bucket.Create(ctx, newIndexKey, []byte(room_id)); err != nil {
+			if errors.Is(err, jetstream.ErrKeyExists) {
+				return nil, ErrRoomNameExists
+			}
+			return nil, fmt.Errorf("failed to claim room name: %w", err)
+		}
 	}
 
 	// Update only the mutable fields
@@ -262,17 +288,26 @@ func (c *ChattoCore) UpdateRoom(ctx context.Context, actorID string, space_id, r
 	room.Description = description
 
 	// Write to KV store (source of truth)
-	bucket, err := c.getSpaceConfigBucket(ctx, space_id)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get bucket: %w", err)
-	}
 	roomData, err := proto.Marshal(room)
 	if err != nil {
+		if renamed {
+			c.bestEffortReleaseRoomNameClaim(ctx, bucket, newIndexKey, room_id)
+		}
 		return nil, fmt.Errorf("failed to marshal room: %w", err)
 	}
-	_, err = bucket.Put(ctx, roomKey(room.Id), roomData)
-	if err != nil {
+	if _, err := bucket.Put(ctx, roomKey(room.Id), roomData); err != nil {
+		if renamed {
+			c.bestEffortReleaseRoomNameClaim(ctx, bucket, newIndexKey, room_id)
+		}
 		return nil, fmt.Errorf("failed to update room: %w", err)
+	}
+
+	// Release the old name now that the room record points at the new one. Best-effort:
+	// a leftover index entry is harmless (it would be reclaimed by the same room ID on a
+	// retry, and a fresh CreateRoom for that name would still see ErrKeyExists, which is
+	// the conservative choice).
+	if renamed {
+		c.bestEffortReleaseRoomNameClaim(ctx, bucket, oldIndexKey, room_id)
 	}
 
 	// Create and publish audit event to space stream (best-effort)
@@ -301,7 +336,7 @@ func (c *ChattoCore) UpdateRoom(ctx context.Context, actorID string, space_id, r
 // Authorization: Caller must verify CanAdminRoomsManage before calling.
 func (c *ChattoCore) DeleteRoom(ctx context.Context, actorID string, space_id, room_id string) error {
 	// Verify room exists
-	_, err := c.GetRoom(ctx, space_id, room_id)
+	room, err := c.GetRoom(ctx, space_id, room_id)
 	if err != nil {
 		return err
 	}
@@ -329,6 +364,11 @@ func (c *ChattoCore) DeleteRoom(ctx context.Context, actorID string, space_id, r
 	if err != nil {
 		return fmt.Errorf("failed to delete room: %w", err)
 	}
+
+	// Release the room name so a new room can claim it. Best-effort: a stale entry only
+	// blocks reuse of that exact name, and the next CreateRoom for it would log a clear
+	// ErrRoomNameExists rather than silently wedging anything.
+	c.bestEffortReleaseRoomNameClaim(ctx, bucket, roomNameIndexKey(room.Name), room_id)
 
 	// Purge room events from the space stream
 	if err := c.purgeRoomEvents(ctx, space_id, room_id); err != nil {
@@ -533,48 +573,101 @@ func (c *ChattoCore) RoomNameExists(ctx context.Context, space_id, name string) 
 // RoomNameExistsExcluding checks if a room with the given name exists, excluding a specific room.
 // This is used by UpdateRoom to allow a room to keep its own name (with different casing).
 // It performs a case-insensitive comparison after trimming whitespace.
+//
+// Backed by the room_name_index.* keys, so it's O(1) per call after the per-space backfill
+// has run once. CreateRoom and UpdateRoom enforce uniqueness via atomic kv.Create rather
+// than calling this — this method exists for callers that want to query without mutating.
 func (c *ChattoCore) RoomNameExistsExcluding(ctx context.Context, space_id, name, excludeRoomID string) (bool, error) {
-	// Trim whitespace from name for consistent comparison
-	name = strings.TrimSpace(name)
-
 	bucket, err := c.getSpaceConfigBucket(ctx, space_id)
 	if err != nil {
 		return false, err
 	}
 
-	keyLister, err := bucket.ListKeysFiltered(ctx, "room.*")
+	if err := c.ensureRoomNameIndex(ctx, space_id, bucket); err != nil {
+		return false, fmt.Errorf("failed to ensure room name index: %w", err)
+	}
+
+	entry, err := bucket.Get(ctx, roomNameIndexKey(name))
 	if err != nil {
-		if err == jetstream.ErrNoKeysFound {
+		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return false, nil
 		}
-		return false, fmt.Errorf("failed to list room keys: %w", err)
+		return false, fmt.Errorf("failed to look up room name index: %w", err)
+	}
+
+	if string(entry.Value()) == excludeRoomID {
+		return false, nil
+	}
+	return true, nil
+}
+
+// ensureRoomNameIndex backfills room_name_index.<name> entries for any pre-existing rooms
+// that were created before atomic name claiming was introduced. Idempotent and cached
+// per-space-per-process so the cost is paid at most once. After that, every CreateRoom /
+// UpdateRoom / DeleteRoom keeps the index in sync directly.
+func (c *ChattoCore) ensureRoomNameIndex(ctx context.Context, spaceID string, bucket jetstream.KeyValue) error {
+	if _, ok := c.roomNameIndexBackfilled.Load(spaceID); ok {
+		return nil
+	}
+
+	keyLister, err := bucket.ListKeysFiltered(ctx, "room.*")
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			c.roomNameIndexBackfilled.Store(spaceID, struct{}{})
+			return nil
+		}
+		return fmt.Errorf("failed to list room keys for backfill: %w", err)
 	}
 
 	for key := range keyLister.Keys() {
 		entry, err := bucket.Get(ctx, key)
 		if err != nil {
-			c.logger.Warn("Failed to get room", "key", key, "error", err)
+			c.logger.Warn("Skipping room during name-index backfill: get failed", "key", key, "error", err)
 			continue
 		}
 
 		room := &corev1.Room{}
 		if err := proto.Unmarshal(entry.Value(), room); err != nil {
-			c.logger.Warn("Failed to unmarshal room", "key", key, "error", err)
+			c.logger.Warn("Skipping room during name-index backfill: unmarshal failed", "key", key, "error", err)
 			continue
 		}
 
-		// Skip the excluded room (for UpdateRoom self-rename checks)
-		if room.Id == excludeRoomID {
-			continue
-		}
-
-		// Compare trimmed names (case-insensitive)
-		if strings.EqualFold(strings.TrimSpace(room.Name), name) {
-			return true, nil
+		indexKey := roomNameIndexKey(room.Name)
+		if _, err := bucket.Create(ctx, indexKey, []byte(room.Id)); err != nil {
+			if errors.Is(err, jetstream.ErrKeyExists) {
+				continue // already indexed (idempotent retry)
+			}
+			c.logger.Warn("Failed to backfill room name index entry", "space_id", spaceID, "room_id", room.Id, "error", err)
 		}
 	}
 
-	return false, nil
+	c.roomNameIndexBackfilled.Store(spaceID, struct{}{})
+	return nil
+}
+
+// bestEffortReleaseRoomNameClaim removes a room_name_index entry but only if it still
+// points at the expected room ID. This protects against accidentally deleting an index
+// entry that another room has already claimed (e.g. after a partial failure that left
+// the value rewritten by a retry).
+func (c *ChattoCore) bestEffortReleaseRoomNameClaim(ctx context.Context, bucket jetstream.KeyValue, indexKey, expectedRoomID string) {
+	entry, err := bucket.Get(ctx, indexKey)
+	if err != nil {
+		if !errors.Is(err, jetstream.ErrKeyNotFound) {
+			c.logger.Warn("Failed to read room name index for release", "key", indexKey, "error", err)
+		}
+		return
+	}
+	if string(entry.Value()) != expectedRoomID {
+		// Some other room owns this name now — leave it alone.
+		return
+	}
+	if err := bucket.Delete(ctx, indexKey, jetstream.LastRevision(entry.Revision())); err != nil {
+		// LastRevision guards against racing with a concurrent update; if that race
+		// happened, the new owner still has the claim, which is exactly what we want.
+		if !errors.Is(err, jetstream.ErrKeyNotFound) {
+			c.logger.Warn("Failed to release room name index", "key", indexKey, "error", err)
+		}
+	}
 }
 
 // ============================================================================

--- a/cli/internal/core/rooms_test.go
+++ b/cli/internal/core/rooms_test.go
@@ -668,6 +668,93 @@ func TestChattoCore_DeleteRoom(t *testing.T) {
 	}
 }
 
+// TestChattoCore_RoomName_ReuseAfterDelete verifies that deleting a room frees its name
+// for reuse. Without index cleanup in DeleteRoom this would leak the name forever.
+func TestChattoCore_RoomName_ReuseAfterDelete(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	space, _ := core.CreateSpace(ctx, "test-user", "Test Space", "")
+	room, err := core.CreateRoom(ctx, "test-user", space.Id, "general", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+
+	if err := core.DeleteRoom(ctx, "test-user", space.Id, room.Id); err != nil {
+		t.Fatalf("DeleteRoom: %v", err)
+	}
+
+	// Same name (and case-variant) must be available again.
+	if _, err := core.CreateRoom(ctx, "test-user", space.Id, "General", ""); err != nil {
+		t.Fatalf("re-create after delete should succeed, got: %v", err)
+	}
+}
+
+// TestChattoCore_RoomName_ReuseAfterRename verifies that renaming a room frees its old
+// name so another room can claim it.
+func TestChattoCore_RoomName_ReuseAfterRename(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	space, _ := core.CreateSpace(ctx, "test-user", "Test Space", "")
+	room, err := core.CreateRoom(ctx, "test-user", space.Id, "old-name", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+
+	if _, err := core.UpdateRoom(ctx, "test-user", space.Id, room.Id, "new-name", ""); err != nil {
+		t.Fatalf("UpdateRoom rename: %v", err)
+	}
+
+	// The old name should now be free for a different room.
+	if _, err := core.CreateRoom(ctx, "test-user", space.Id, "old-name", ""); err != nil {
+		t.Fatalf("create with freed name should succeed, got: %v", err)
+	}
+
+	// And the new name should still be taken by the renamed room.
+	if _, err := core.CreateRoom(ctx, "test-user", space.Id, "new-name", ""); !errors.Is(err, ErrRoomNameExists) {
+		t.Errorf("expected ErrRoomNameExists for taken new name, got: %v", err)
+	}
+}
+
+// TestChattoCore_RoomName_BackfillFromBareRoom simulates a room created before atomic
+// name claiming existed: the room record is in the bucket but the index entry is not.
+// The next CreateRoom for that same name must still detect the collision via backfill.
+func TestChattoCore_RoomName_BackfillFromBareRoom(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	space, _ := core.CreateSpace(ctx, "test-user", "Test Space", "")
+	room, err := core.CreateRoom(ctx, "test-user", space.Id, "general", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+
+	// Simulate the pre-migration state: index entry is missing, room record is present.
+	bucket, err := core.getSpaceConfigBucket(ctx, space.Id)
+	if err != nil {
+		t.Fatalf("getSpaceConfigBucket: %v", err)
+	}
+	if err := bucket.Delete(ctx, roomNameIndexKey(room.Name)); err != nil {
+		t.Fatalf("delete index entry: %v", err)
+	}
+	core.roomNameIndexBackfilled.Delete(space.Id) // force backfill on next call
+
+	// A duplicate must still be rejected — backfill should re-claim the name from the room record.
+	if _, err := core.CreateRoom(ctx, "test-user", space.Id, "General", ""); !errors.Is(err, ErrRoomNameExists) {
+		t.Errorf("expected ErrRoomNameExists after backfill, got: %v", err)
+	}
+
+	// Existence query should agree.
+	exists, err := core.RoomNameExists(ctx, space.Id, "general")
+	if err != nil {
+		t.Fatalf("RoomNameExists: %v", err)
+	}
+	if !exists {
+		t.Error("expected room name to exist after backfill")
+	}
+}
+
 func TestChattoCore_ListRoomsBySpace(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -605,6 +605,7 @@ Notes: Excluded from backups so backup archives contain only encrypted data, not
 | Key                                       | Description                                      |
 | ----------------------------------------- | ------------------------------------------------ |
 | `room.{roomId}`                           | Room configurations                              |
+| `room_name_index.{lowercaseName}`         | Atomic name claim → room ID. Used to enforce case-insensitive uniqueness of room names without a read-then-write race. |
 | `room_membership.{userId}.{roomId}`       | User-room membership tracking                    |
 | `role.{roleName}`                               | Role metadata (name, display_name, description)         |
 | `role_permission.{roleName}.{permission}`       | Permission grant (empty value = granted)                |


### PR DESCRIPTION
## Summary

Replace the list-and-scan duplicate-name check in `CreateRoom` / `UpdateRoom` with an atomic `kv.Create` on a `room_name_index.<lowercase-name>` key. This is item (1) from the R3-readiness audit — closing the read-then-write race that today is small at R1 and would widen under R3 NATS clustering (where direct-gets can return stale data immediately after a write).

## Why

Today:
\`\`\`
RoomNameExists()      // scans every room, compares names
                      // ← race window here under R3
kv.Put(roomKey, ...)
\`\`\`

After this PR:
\`\`\`
kv.Create(roomNameIndexKey(name), roomID)   // ErrKeyExists ⇒ ErrRoomNameExists
kv.Put(roomKey, ...)
\`\`\`

Pure improvement at R1 too — removes a class of races and turns `RoomNameExists` from O(N) into O(1).

## Changes

- New KV key in `SPACE_{spaceId}_CONFIG`: `room_name_index.{lowercaseName}` → `roomId` (documented in `docs/ARCHITECTURE.md`)
- `CreateRoom` claims via `kv.Create`; rolls back the claim on subsequent marshal/store failures
- `UpdateRoom` claims the new name only when the lowercased form changes, then releases the old name post-write
- `DeleteRoom` releases the name claim so it can be reused
- `RoomNameExists` / `RoomNameExistsExcluding` now do a single `kv.Get` on the index
- One-time per-process-per-space **lazy backfill** populates index entries for rooms created before this change. Idempotent: `kv.Create` + ignore `ErrKeyExists`. Cached via `sync.Map` so the cost is paid at most once per space per process
- Release uses `LastRevision` + value match so a stale release never deletes an index entry that another room has re-claimed

## Migration

No ops action required. Pre-existing rooms get their index entries populated lazily on the first `CreateRoom` / `UpdateRoom` / `RoomNameExists` call after deploy. Backfill uses `kv.Create` with `ErrKeyExists` ignored, so it's safe to run repeatedly and concurrent with normal traffic.

## Test plan

- [x] `mise x -- go test ./internal/core/ -run 'Room'` — existing room tests still pass
- [x] New tests: `TestChattoCore_RoomName_ReuseAfterDelete`, `TestChattoCore_RoomName_ReuseAfterRename`, `TestChattoCore_RoomName_BackfillFromBareRoom`
- [x] Full `mise x -- go test ./internal/core/` (56s, all green)
- [x] `mise x -- go test ./internal/graph/ -run 'Room'`
- [x] `mise x -- go vet ./internal/core/`
- [x] CI green