### PR TITLE
fix(frontend): isolate per-instance failures in multi-instance client

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.155",
   "type": "module",
+  "packageManager": "pnpm@10.19.0",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",

--- a/frontend/src/lib/auth/currentUser.svelte.ts
+++ b/frontend/src/lib/auth/currentUser.svelte.ts
@@ -30,6 +30,14 @@ export class CurrentUserState {
   async load() {
     const resp = await this.#client.query(LoadCurrentUserDocument, {});
 
+    if (resp.error) {
+      // Surface network failures (CORS, DNS, server down) as a console
+      // error so unreachable instances are visible in the dev console.
+      // Don't throw — the caller treats this as a per-instance soft
+      // failure, not a global crash.
+      console.error('[auth] failed to load current user', resp.error);
+    }
+
     if (resp.data?.me) {
       this.user = resp.data.me;
     }

--- a/frontend/src/lib/state/instance/eventBus.svelte.spec.ts
+++ b/frontend/src/lib/state/instance/eventBus.svelte.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Client } from '@urql/svelte';
+import { instanceEventBusManager } from './eventBus.svelte';
+
+type SubscriptionCallback = (result: { data?: unknown; error?: unknown }) => void;
+
+/** Captures the subscription callback so the test can drive results manually. */
+function makeClient(): { client: Client; deliver: (result: { data?: unknown; error?: unknown }) => void } {
+  let cb: SubscriptionCallback | null = null;
+  const client = {
+    subscription: vi.fn().mockReturnValue({
+      subscribe: (callback: SubscriptionCallback) => {
+        cb = callback;
+        return { unsubscribe: vi.fn() };
+      }
+    }),
+    query: vi.fn(),
+    mutation: vi.fn()
+  } as unknown as Client;
+
+  return {
+    client,
+    deliver: (result) => {
+      if (!cb) throw new Error('No subscriber attached yet');
+      cb(result);
+    }
+  };
+}
+
+describe('instanceEventBusManager subscription robustness', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+  const TEST_INSTANCE = 'test-instance-bus';
+
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    instanceEventBusManager.stopBus(TEST_INSTANCE);
+    consoleError.mockRestore();
+  });
+
+  it('logs an error when the subscription delivers result.error', () => {
+    const { client, deliver } = makeClient();
+    instanceEventBusManager.startBus(TEST_INSTANCE, client);
+
+    deliver({ error: new Error('subscription failed') });
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError.mock.calls[0][0]).toContain(TEST_INSTANCE);
+    expect(consoleError.mock.calls[0][0]).toContain('subscription error');
+  });
+
+  it('isolates handler errors so one throwing handler does not stop the others', () => {
+    const { client, deliver } = makeClient();
+    instanceEventBusManager.startBus(TEST_INSTANCE, client);
+
+    const bus = instanceEventBusManager.getBus(TEST_INSTANCE);
+    expect(bus).toBeDefined();
+
+    const ranBefore = vi.fn();
+    const ranAfter = vi.fn();
+    bus!.handlers.add(ranBefore);
+    bus!.handlers.add(() => {
+      throw new Error('handler boom');
+    });
+    bus!.handlers.add(ranAfter);
+
+    const event = { actorId: 'a', event: { __typename: 'SpaceCreatedEvent' } };
+    deliver({ data: { myInstanceEvents: event } });
+
+    expect(ranBefore).toHaveBeenCalledTimes(1);
+    expect(ranAfter).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalled();
+    expect(consoleError.mock.calls[0][0]).toContain('handler threw');
+  });
+
+  it('continues delivering events after a handler error on a previous event', () => {
+    const { client, deliver } = makeClient();
+    instanceEventBusManager.startBus(TEST_INSTANCE, client);
+
+    const bus = instanceEventBusManager.getBus(TEST_INSTANCE)!;
+    const handler = vi.fn();
+    let throwOnce = true;
+    bus.handlers.add(() => {
+      if (throwOnce) {
+        throwOnce = false;
+        throw new Error('handler boom');
+      }
+    });
+    bus.handlers.add(handler);
+
+    const event = { actorId: 'a', event: { __typename: 'SpaceCreatedEvent' } };
+    deliver({ data: { myInstanceEvents: event } });
+    deliver({ data: { myInstanceEvents: event } });
+
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/lib/state/instance/eventBus.svelte.ts
+++ b/frontend/src/lib/state/instance/eventBus.svelte.ts
@@ -37,9 +37,29 @@ class InstanceEventBusManager {
 		const bus: InstanceEventBus = { handlers };
 
 		const sub = client.subscription(MyInstanceEventsSubscriptionDoc, {}).subscribe((result) => {
+			if (result.error) {
+				// Surface subscription errors so unreachable instances and other
+				// real failures are visible in the dev console. Don't propagate
+				// — keep the subscription itself alive so it can recover.
+				console.error(
+					`[eventBus:${instanceId}] subscription error`,
+					result.error
+				);
+			}
 			if (!result.data) return;
 			const event = result.data.myInstanceEvents;
-			handlers.forEach((handler) => handler(event));
+			// Run handlers in isolation: a throw from one handler must not
+			// stop the others or tear down the subscription itself.
+			for (const handler of handlers) {
+				try {
+					handler(event);
+				} catch (err) {
+					console.error(
+						`[eventBus:${instanceId}] handler threw`,
+						err
+					);
+				}
+			}
 		});
 
 		this.#buses.set(instanceId, bus);

--- a/frontend/src/lib/state/instance/graphqlClient.svelte.ts
+++ b/frontend/src/lib/state/instance/graphqlClient.svelte.ts
@@ -4,6 +4,18 @@ import { instanceRegistry } from './registry.svelte';
 
 const SESSION_VALIDATION_COOLDOWN_MS = 5000;
 
+/**
+ * Stop retrying the WebSocket connection after this many consecutive failed
+ * attempts. With the 5s retry interval, ~30 attempts ≈ 2.5 minutes of
+ * trying — enough to ride out transient outages (server restart, brief
+ * network loss) but short enough that a permanently misconfigured instance
+ * (e.g. CORS, DNS) doesn't spam the console forever.
+ *
+ * After giving up, a `retry()` call from the UI (or a tab-visibility /
+ * online event) is required to start trying again.
+ */
+const MAX_WS_RETRY_ATTEMPTS = 30;
+
 export type ConnectionStatus = 'connected' | 'connecting' | 'disconnected';
 
 export interface AuthHandlers {
@@ -33,6 +45,12 @@ export class GraphQLClient {
 	status = $state<ConnectionStatus>('connecting');
 	reconnectCount = $state(0);
 	#failedAttempts = $state(0);
+	/**
+	 * True after the WS retry loop has given up (exceeded
+	 * MAX_WS_RETRY_ATTEMPTS). `shouldRetry` returns false in this state.
+	 * Reset to false by `retry()` or by `forceReconnect()`.
+	 */
+	gaveUp = $state(false);
 	client: Client;
 	#wsClient: ReturnType<typeof createWSClient>;
 	#activeSocket: WebSocket | null = null;
@@ -64,7 +82,17 @@ export class GraphQLClient {
 	forceReconnect(reason: string) {
 		console.log('[ws:%s] Force reconnect: %s (status: %s)', this.#host, reason, this.status);
 		this.#immediateReconnect = true;
+		this.gaveUp = false;
+		this.#failedAttempts = 0;
 		this.#wsClient.terminate();
+	}
+
+	/**
+	 * Explicit user-initiated retry after the WS retry loop gave up. Resets
+	 * the give-up flag and triggers an immediate reconnect attempt.
+	 */
+	retry() {
+		this.forceReconnect('user-initiated retry');
 	}
 
 	/**
@@ -99,7 +127,21 @@ export class GraphQLClient {
 			url: wsUrl,
 			keepAlive: 15_000,
 			retryAttempts: Infinity,
-			shouldRetry: () => true,
+			shouldRetry: () => {
+				// Stop retrying once we've crossed the threshold. Logs once
+				// when transitioning to the give-up state so the failure is
+				// visible in the console without spamming.
+				if (this.#failedAttempts >= MAX_WS_RETRY_ATTEMPTS) {
+					if (!this.gaveUp) {
+						this.gaveUp = true;
+						console.error(
+							`[ws:${this.#host}] giving up after ${this.#failedAttempts} failed attempts; instance unreachable`
+						);
+					}
+					return false;
+				}
+				return true;
+			},
 			...(token ? { connectionParams: () => ({ token }) } : {}),
 			retryWait: async (retries) => {
 				// Track failed attempts for UI display (banner shows after 6 failures)

--- a/frontend/src/lib/state/instance/registry.svelte.ts
+++ b/frontend/src/lib/state/instance/registry.svelte.ts
@@ -330,7 +330,14 @@ class InstanceRegistry {
 		// Eagerly fetch instance info (name, MOTD, upload limits, etc.).
 		// This is important for late-registered instances (e.g., origin registered
 		// in the chat layout after the root layout script already ran).
-		store.instance.init();
+		// init() is fail-soft (catches its own errors) but defensively swallow
+		// any unexpected rejection so it can never become an unhandled rejection.
+		store.instance.init().catch((err) => {
+			console.error(
+				`[instance:${instance.url}] unexpected init() rejection`,
+				err
+			);
+		});
 
 		if (instance.token === null) {
 			// Cookie auth (origin) — the SvelteKit load function already determined
@@ -338,17 +345,28 @@ class InstanceRegistry {
 			store.currentUser.loading = false;
 		} else {
 			// Bearer auth (remote) — auto-load the authenticated user via the token.
-			store.currentUser.load().then(() => {
-				const user = store.currentUser.user;
-				if (user) {
-					this.updateInstance(instance.id, {
-						userId: user.id,
-						userLogin: user.login,
-						userDisplayName: user.displayName,
-						userAvatarUrl: user.avatarUrl
-					});
-				}
-			});
+			// Catch failures (e.g. unreachable host, CORS) so they don't bubble up
+			// as an unhandled rejection and crash the entire client.
+			store.currentUser
+				.load()
+				.then(() => {
+					const user = store.currentUser.user;
+					if (user) {
+						this.updateInstance(instance.id, {
+							userId: user.id,
+							userLogin: user.login,
+							userDisplayName: user.displayName,
+							userAvatarUrl: user.avatarUrl
+						});
+					}
+				})
+				.catch((err) => {
+					console.error(
+						`[instance:${instance.url}] failed to load current user`,
+						err
+					);
+					store.currentUser.loading = false;
+				});
 		}
 
 		return store;

--- a/frontend/src/lib/state/instance/state.spec.ts
+++ b/frontend/src/lib/state/instance/state.spec.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Client } from '@urql/svelte';
+import { InstanceState } from './state.svelte';
+
+/** Build a minimal urql Client mock with controllable query result. */
+function makeClient(result: {
+  data?: unknown;
+  error?: { message: string; networkError?: Error } | null;
+}): Client {
+  return {
+    query: vi.fn().mockReturnValue({
+      toPromise: vi.fn().mockResolvedValue({
+        data: result.data ?? null,
+        error: result.error ?? null
+      })
+    }),
+    mutation: vi.fn(),
+    subscription: vi.fn()
+  } as unknown as Client;
+}
+
+/** Build a urql Client mock whose query rejects (synchronous throw inside the chain). */
+function makeRejectingClient(err: Error): Client {
+  return {
+    query: vi.fn().mockReturnValue({
+      toPromise: vi.fn().mockRejectedValue(err)
+    }),
+    mutation: vi.fn(),
+    subscription: vi.fn()
+  } as unknown as Client;
+}
+
+describe('InstanceState.init()', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('populates fields and clears loading on success', async () => {
+    const client = makeClient({
+      data: {
+        instance: {
+          directRegistrationEnabled: false,
+          pushNotificationsEnabled: true,
+          vapidPublicKey: 'vap',
+          livekitUrl: 'wss://lk',
+          maxUploadSize: 100,
+          maxVideoUploadSize: 200,
+          primarySpaceId: 'S1',
+          config: {
+            instanceName: 'Acme',
+            motd: 'hello',
+            welcomeMessage: 'welcome',
+            ogImageUrl: 'https://og'
+          }
+        }
+      }
+    });
+    const state = new InstanceState(client, 'https://acme.test');
+
+    await state.init();
+
+    expect(state.loading).toBe(false);
+    expect(state.error).toBeNull();
+    expect(state.name).toBe('Acme');
+    expect(state.primarySpaceId).toBe('S1');
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it('logs and sets error when urql returns a network error (CORS/unreachable)', async () => {
+    const client = makeClient({
+      error: {
+        message: '[Network] Failed to fetch',
+        networkError: new Error('Failed to fetch')
+      }
+    });
+    const state = new InstanceState(client, 'https://chatto.run');
+
+    await state.init();
+
+    expect(state.loading).toBe(false);
+    expect(state.error).toBe('[Network] Failed to fetch');
+    expect(state.name).toBe('Chatto'); // default unchanged
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError.mock.calls[0][0]).toContain('https://chatto.run');
+    expect(consoleError.mock.calls[0][0]).toContain('failed to load instance info');
+  });
+
+  it('logs and sets error when the query promise rejects', async () => {
+    const client = makeRejectingClient(new Error('boom'));
+    const state = new InstanceState(client, 'https://chatto.run');
+
+    await state.init();
+
+    expect(state.loading).toBe(false);
+    expect(state.error).toBe('boom');
+    // The .catch path logs at least once with our scoped message
+    // (there may be additional unhandled-rejection-style logs depending
+    // on the runtime, but our explicit log must be present).
+    const ourCalls = consoleError.mock.calls.filter(
+      (c: unknown[]) =>
+        typeof c[0] === 'string' &&
+        c[0].includes('https://chatto.run') &&
+        c[0].includes('failed to load instance info')
+    );
+    expect(ourCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does not throw — failure must be isolated to this instance', async () => {
+    const client = makeRejectingClient(new Error('boom'));
+    const state = new InstanceState(client);
+
+    // Must resolve, not reject.
+    await expect(state.init()).resolves.toBeUndefined();
+  });
+});

--- a/frontend/src/lib/state/instance/state.svelte.ts
+++ b/frontend/src/lib/state/instance/state.svelte.ts
@@ -8,6 +8,7 @@ import type { Client } from '@urql/svelte';
 
 export class InstanceState {
   #client: Client;
+  #label: string;
 
   name = $state('Chatto');
   motd = $state<string | null>(null);
@@ -29,8 +30,21 @@ export class InstanceState {
 
   loading = $state(true);
 
-  constructor(client: Client) {
+  /**
+   * Set when `init()` failed to fetch instance info (e.g. unreachable host,
+   * CORS misconfiguration). Consumers can use this to render a degraded UI
+   * for that instance without taking down the rest of the app.
+   */
+  error = $state<string | null>(null);
+
+  /**
+   * Human-readable label for this instance, used in log messages so console
+   * errors can be traced back to a specific instance. Pass the URL (or any
+   * stable identifier) — used purely for diagnostics.
+   */
+  constructor(client: Client, label = 'unknown') {
     this.#client = client;
+    this.#label = label;
   }
 
   /**
@@ -42,11 +56,13 @@ export class InstanceState {
    * (the chat-root page's redirect logic relies on this — see
    * `(chrome)/+page.svelte`).
    */
-  init(): void {
+  async init(): Promise<void> {
     this.loading = true;
-    this.#client
-      .query(
-        graphql(`
+    this.error = null;
+    try {
+      const resp = await this.#client
+        .query(
+          graphql(`
           query GetInstanceInfo {
             instance {
               directRegistrationEnabled
@@ -65,25 +81,47 @@ export class InstanceState {
             }
           }
         `),
-        {},
-        { requestPolicy: 'network-only' }
-      )
-      .then((resp) => {
-        if (resp.data?.instance) {
-          this.name = resp.data.instance.config.instanceName;
-          this.motd = resp.data.instance.config.motd ?? null;
-          this.welcomeMessage = resp.data.instance.config.welcomeMessage ?? null;
-          this.ogImageUrl = resp.data.instance.config.ogImageUrl ?? null;
-          this.directRegistrationEnabled = resp.data.instance.directRegistrationEnabled;
-          this.pushNotificationsEnabled = resp.data.instance.pushNotificationsEnabled;
-          this.vapidPublicKey = resp.data.instance.vapidPublicKey ?? null;
-          this.livekitUrl = resp.data.instance.livekitUrl ?? null;
-          this.maxUploadSize = resp.data.instance.maxUploadSize;
-          this.maxVideoUploadSize = resp.data.instance.maxVideoUploadSize;
-          this.primarySpaceId = resp.data.instance.primarySpaceId;
-        }
-        this.loading = false;
-      });
+          {},
+          { requestPolicy: 'network-only' }
+        )
+        .toPromise();
+
+      if (resp.error) {
+        // urql surfaces network failures (CORS, DNS, server down) as
+        // result.error.networkError rather than rejecting. Treat as a
+        // soft per-instance failure: log, set error state, and bail.
+        this.error = resp.error.message;
+        console.error(
+          `[instance:${this.#label}] failed to load instance info`,
+          resp.error
+        );
+        return;
+      }
+
+      if (resp.data?.instance) {
+        this.name = resp.data.instance.config.instanceName;
+        this.motd = resp.data.instance.config.motd ?? null;
+        this.welcomeMessage = resp.data.instance.config.welcomeMessage ?? null;
+        this.ogImageUrl = resp.data.instance.config.ogImageUrl ?? null;
+        this.directRegistrationEnabled = resp.data.instance.directRegistrationEnabled;
+        this.pushNotificationsEnabled = resp.data.instance.pushNotificationsEnabled;
+        this.vapidPublicKey = resp.data.instance.vapidPublicKey ?? null;
+        this.livekitUrl = resp.data.instance.livekitUrl ?? null;
+        this.maxUploadSize = resp.data.instance.maxUploadSize;
+        this.maxVideoUploadSize = resp.data.instance.maxVideoUploadSize;
+        this.primarySpaceId = resp.data.instance.primarySpaceId;
+      }
+    } catch (err) {
+      // Defensive: anything thrown during the query or above .then body.
+      // Don't re-throw — failure is isolated to this instance.
+      this.error = err instanceof Error ? err.message : String(err);
+      console.error(
+        `[instance:${this.#label}] failed to load instance info`,
+        err
+      );
+    } finally {
+      this.loading = false;
+    }
   }
 
   /**

--- a/frontend/src/lib/state/instance/store.svelte.ts
+++ b/frontend/src/lib/state/instance/store.svelte.ts
@@ -70,7 +70,7 @@ export class InstanceStateStore {
 
 		const client = gqlClient.client;
 		this.currentUser = new CurrentUserState(client, cookieAuth);
-		this.instance = new InstanceState(client);
+		this.instance = new InstanceState(client, registered.url);
 		this.notifications = new NotificationStore(client);
 		this.roomUnread = new RoomUnreadStore();
 		this.notificationLevels = new NotificationLevelStore();

--- a/frontend/src/routes/+error.svelte
+++ b/frontend/src/routes/+error.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import { page } from '$app/state';
+  import { dev } from '$app/environment';
+  import { EmptyState } from '$lib/ui';
+
+  const status = $derived(page.status);
+  const message = $derived(page.error?.message ?? 'Unknown error');
+</script>
+
+<div class="flex h-full flex-col">
+  <EmptyState icon="uil--exclamation-triangle" title="Something went wrong">
+    <p>An unexpected error occurred while rendering this page.</p>
+    {#if dev}
+      <pre
+        class="mt-3 max-w-xl overflow-auto rounded-md bg-surface-200 p-3 text-left text-xs"
+      >Status: {status}
+{message}</pre>
+    {/if}
+    <p class="mt-4">
+      <a class="underline" href={resolve('/')}>Go back to the home page</a>
+    </p>
+  </EmptyState>
+</div>


### PR DESCRIPTION
## Summary

A misconfigured or unreachable remote instance (e.g. CORS-blocked `/api/graphql`) used to crash the entire SPA — a thrown error from a layout effect or unhandled promise rejection would replace the whole UI with the SvelteKit error page, taking the origin instance down with the remote. This change makes per-instance failures fail closed but visibly logged: each failure path now scopes its `console.error` to the offending instance, the instance bus subscription survives a throwing handler, the WS retry loop gives up after ~2.5 min instead of looping forever, and a new `+error.svelte` provides a final safety net so a layout-level throw can't blank the app.

## Test plan

- [ ] `mise test-frontend` (808 tests pass locally; new specs cover `InstanceState.init()` failure paths and event-bus handler isolation)
- [ ] Manual: from `https://dev.chatto.run`, register a remote instance for `https://chatto.run` (no CORS allowlist for the dev origin) — origin keeps rendering, console shows scoped errors, no white screen
- [ ] Manual: take a real remote backend down mid-session — origin keeps flowing, remote shows disconnect indicator, reconnects when it returns