### PR TITLE
build(frontend): pin pnpm to 10.19.0 via packageManager field

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.155",
   "type": "module",
+  "packageManager": "pnpm@10.19.0",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",


### PR DESCRIPTION
## Summary

`Dockerfile.frontend.compose` runs `corepack enable pnpm` without an explicit version. Without a `packageManager` field in `package.json`, corepack activates whatever it considers current — which has drifted ahead of local mise (10.19.0). A newer pnpm 10.x in the container promotes `ERR_PNPM_IGNORED_BUILDS` (for `@parcel/watcher`, `esbuild`, `sharp`) to a hard error in non-interactive contexts, breaking `docker compose up` even though local installs still succeed. Pinning to 10.19.0 matches the container to local and freezes the version until we deliberately bump.

## Test plan

- [ ] `docker compose -p <instance-name> build --no-cache frontend` succeeds
- [ ] `docker compose -p <instance-name> up` starts cleanly
- [ ] `mise x -- pnpm install` still works locally (no behavior change since 10.19.0 is what's installed already)