### PR TITLE
feat(migration): phase 4a — primary's CONFIG/RBAC/RUNTIME → SERVER_* (#354)

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -131,17 +131,26 @@ func runServer(configPath string) {
 	// a warning and the deployment runs without a primary; later phases of the
 	// migration will tighten this into a hard error once callers exist.
 	primarySpaceID, err := chattoCore.ResolvePrimarySpaceID(ctx, cfg.Server.PrimarySpaceID)
-	switch {
-	case err != nil && cfg.Server.PrimarySpaceID != "":
-		log.Fatal("Failed to resolve configured primary space", "error", err)
-	case err != nil:
-		log.Warn("Could not auto-derive a primary space; set server.primary_space_id explicitly to silence this", "error", err)
-	case primarySpaceID == "":
-		log.Info("Primary space not yet set (no user-facing spaces exist)")
-	case cfg.Server.PrimarySpaceID != "":
-		log.Info("Primary space resolved from config", "spaceID", primarySpaceID)
-	default:
-		log.Info("Primary space auto-derived from single user-facing space", "spaceID", primarySpaceID)
+	if err != nil {
+		log.Fatal("Failed to resolve primary space", "error", err)
+	}
+	if primarySpaceID == "" {
+		log.Info("Primary space not yet set (fresh install — no user-facing spaces exist)")
+	} else {
+		log.Info("Primary space resolved", "spaceID", primarySpaceID)
+	}
+
+	// Record the primary space so the storage layer can route the primary's
+	// metadata reads/writes to the server-level SERVER_* buckets. Must be
+	// done before serving traffic.
+	chattoCore.SetPrimarySpaceID(primarySpaceID)
+
+	// Run schema migrations (#330 phase 4 onwards). Idempotent and safe to
+	// call concurrently from multiple pods (lock-protected internally).
+	// Refuses to start if migration fails so we don't serve traffic against
+	// half-migrated data.
+	if err := chattoCore.RunMigrationsIfNeeded(ctx, primarySpaceID); err != nil {
+		log.Fatal("Schema migration failed; refusing to start", "error", err)
 	}
 
 	// Run health checks in background (non-blocking)

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/charmbracelet/log"
@@ -71,6 +72,39 @@ type ChattoCore struct {
 	// PresenceHub runs a single KV watcher on presence.> per process and fans
 	// out updates to all space subscriptions. Must be started via Run() in an errgroup.
 	PresenceHub *PresenceHub
+
+	// primarySpaceID is the deployment-wide primary space (#330 / ADR-027).
+	// When non-empty, this single space's CONFIG/RBAC/RUNTIME data lives in
+	// the server-level SERVER_* buckets; all other spaces (including DM and
+	// any test-created spaces) keep their per-space SPACE_{id}_* buckets.
+	//
+	// Set once at boot via SetPrimarySpaceID after ResolvePrimarySpaceID
+	// returns. Empty during NewChattoCore so initDMSpace and any pre-resolve
+	// space creation always fall through to the per-space layout — migration
+	// then copies primary's data across when it runs.
+	primarySpaceID atomic.Value // string
+}
+
+// PrimarySpaceID returns the configured primary space ID, or "" if unset.
+func (c *ChattoCore) PrimarySpaceID() string {
+	v, _ := c.primarySpaceID.Load().(string)
+	return v
+}
+
+// SetPrimarySpaceID records the deployment-wide primary space. After this is
+// set, the primary's CONFIG/RBAC/RUNTIME accessors route to the SERVER_*
+// buckets instead of per-space SPACE_{id}_* buckets. Should be called once at
+// boot, after the primary has been resolved and before any traffic is served.
+func (c *ChattoCore) SetPrimarySpaceID(spaceID string) {
+	c.primarySpaceID.Store(spaceID)
+}
+
+// usesServerLevelMetadata reports whether the given spaceID's CONFIG / RBAC /
+// RUNTIME data lives in the shared SERVER_* buckets (true only for the
+// configured primary space).
+func (c *ChattoCore) usesServerLevelMetadata(spaceID string) bool {
+	primary := c.PrimarySpaceID()
+	return primary != "" && spaceID == primary
 }
 
 // assetURL prepends AssetBaseURL to an asset path.
@@ -322,6 +356,22 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 		Logger: slog.Default().With("component", "instance-rbac"),
 	})
 
+	// Initialize server-level (non-DM) RBAC engine wrapping SERVER_RBAC
+	// (#330 phase 4a). All non-DM spaces share this single engine.
+	storage.serverRBACEngine = rbac.NewEngine(storage.serverRBACKV, rbac.Config{
+		SystemRoles:  []string{SpaceRoleOwner, SpaceRoleModerator, SpaceRoleEveryone},
+		AdminRole:    SpaceRoleOwner,
+		VirtualRoles: SpaceVirtualRoles(),
+		ValidateVerbObjectType: func(verb, objectType string) error {
+			perm := ReconstructPermission(verb, objectType)
+			if perm == "" {
+				return fmt.Errorf("%w: verb=%s, objectType=%s", ErrInvalidPermission, verb, objectType)
+			}
+			return nil
+		},
+		Logger: slog.Default().With("component", "server-rbac"),
+	})
+
 	// Initialize config manager for runtime configuration
 	configMgr := NewConfigManager(storage.instanceConfigKV)
 
@@ -404,10 +454,22 @@ type storage struct {
 	instanceRBACKV   jetstream.KeyValue // Instance-level roles and permissions
 	instanceConfigKV jetstream.KeyValue // Runtime configuration overrides
 
-	spaceConfigKV    *lazycache.Cache[jetstream.KeyValue]      // SPACE_{id}_CONFIG - rooms, memberships
-	spaceRuntimeKV   *lazycache.Cache[jetstream.KeyValue]      // SPACE_{id}_RUNTIME - sequences, timestamps, read status
-	spaceRBACKV      *lazycache.Cache[jetstream.KeyValue]      // SPACE_{id}_RBAC - roles, permissions, assignments
-	spaceRBACEngines *lazycache.Cache[*rbac.Engine]            // Cached rbac.Engine instances per space
+	// Server-level metadata buckets (#330 phase 4a). Shared across all non-DM
+	// spaces — in practice, the primary space's data lives here. The DM
+	// space still uses the per-space lazycaches below for now; that fold-in
+	// is a separate later phase.
+	serverConfigKV   jetstream.KeyValue // SERVER_CONFIG - rooms, memberships
+	serverRuntimeKV  jetstream.KeyValue // SERVER_RUNTIME - sequences, timestamps, read state
+	serverRBACKV     jetstream.KeyValue // SERVER_RBAC - roles, permissions, assignments
+	serverRBACEngine *rbac.Engine       // rbac.Engine wrapping serverRBACKV
+
+	// Legacy per-space metadata caches. Still in use for the DM space until
+	// its fold-in. Non-DM spaces route directly to the server-level buckets
+	// above and don't populate these caches.
+	spaceConfigKV    *lazycache.Cache[jetstream.KeyValue]      // SPACE_{id}_CONFIG - rooms, memberships (DM only post-phase-4a)
+	spaceRuntimeKV   *lazycache.Cache[jetstream.KeyValue]      // SPACE_{id}_RUNTIME - sequences, timestamps, read status (DM only post-phase-4a)
+	spaceRBACKV      *lazycache.Cache[jetstream.KeyValue]      // SPACE_{id}_RBAC - roles, permissions, assignments (DM only post-phase-4a)
+	spaceRBACEngines *lazycache.Cache[*rbac.Engine]            // Cached rbac.Engine instances per space (DM only post-phase-4a)
 	bodiesKV         *lazycache.Cache[jetstream.KeyValue]      // SPACE_{id}_BODIES - message bodies
 	attachments      *lazycache.Cache[jetstream.ObjectStore]   // SPACE_{id}_ASSETS - message attachments
 	reactionsKV      *lazycache.Cache[jetstream.KeyValue]      // SPACE_{id}_REACTIONS - emoji reactions
@@ -541,6 +603,40 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		return nil, fmt.Errorf("failed to create CALL_STATE KV bucket: %w", err)
 	}
 
+	// Initialize server-level metadata buckets (#330 phase 4a).
+	// SERVER_CONFIG, SERVER_RBAC, SERVER_RUNTIME are shared across all
+	// non-DM spaces. DM space data lives in SPACE_DM_* until a later phase
+	// folds it in.
+	serverConfigKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:      "SERVER_CONFIG",
+		Description: "Server-level configuration (rooms, memberships)",
+		Storage:     jetstream.FileStorage,
+		Replicas:    cfg.Replicas,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SERVER_CONFIG KV bucket: %w", err)
+	}
+
+	serverRBACKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:      "SERVER_RBAC",
+		Description: "Server-level RBAC (roles, permissions, assignments)",
+		Storage:     jetstream.FileStorage,
+		Replicas:    cfg.Replicas,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SERVER_RBAC KV bucket: %w", err)
+	}
+
+	serverRuntimeKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:      "SERVER_RUNTIME",
+		Description: "Server-level runtime state (sequences, read status)",
+		Storage:     jetstream.FileStorage,
+		Replicas:    cfg.Replicas,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SERVER_RUNTIME KV bucket: %w", err)
+	}
+
 	// Initialize auth tokens KV bucket with configurable TTL
 	// Stores opaque bearer tokens for cross-origin API authentication.
 	// NATS TTL handles automatic token expiry.
@@ -567,6 +663,12 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		encryptionKV:     encryptionKV,
 		instanceRBACKV:   instanceRBACKV,
 		instanceConfigKV: instanceConfigKV,
+		serverConfigKV:   serverConfigKV,
+		serverRBACKV:     serverRBACKV,
+		serverRuntimeKV:  serverRuntimeKV,
+		// serverRBACEngine is constructed below (after the storage value
+		// exists) and assigned in NewChattoCore so it can use the same engine
+		// configuration as the per-space engines.
 		spaceConfigKV:    lazycache.New[jetstream.KeyValue](),
 		spaceRuntimeKV:   lazycache.New[jetstream.KeyValue](),
 		spaceRBACKV:      lazycache.New[jetstream.KeyValue](),
@@ -659,9 +761,21 @@ func eventIDFromBodyKey(bodyKey string) string {
 // Per-Space Bucket Accessors
 // ============================================================================
 
-// getSpaceConfigKV retrieves or creates the CONFIG bucket for a space.
-// The bucket contains structural data (rooms, memberships).
+// getSpaceConfigKV retrieves the CONFIG bucket for a space.
+//
+// Post-#330 phase 4a: the configured primary space's CONFIG data lives in
+// the server-level SERVER_CONFIG bucket. All other spaces (DM, plus any
+// test-created spaces) keep their per-space SPACE_{id}_CONFIG buckets.
+//
+// The space's existence is verified before returning, so callers can rely
+// on a not-found error here as a signal that the space ID is bogus.
 func (c *ChattoCore) getSpaceConfigKV(ctx context.Context, spaceID string) (jetstream.KeyValue, error) {
+	if c.usesServerLevelMetadata(spaceID) {
+		if _, err := c.GetSpace(ctx, spaceID); err != nil {
+			return nil, fmt.Errorf("space %s does not exist: %w", spaceID, err)
+		}
+		return c.storage.serverConfigKV, nil
+	}
 	return c.storage.spaceConfigKV.GetOrCreate(spaceID, func() (jetstream.KeyValue, error) {
 		if _, err := c.GetSpace(ctx, spaceID); err != nil {
 			return nil, fmt.Errorf("space %s does not exist: %w", spaceID, err)
@@ -680,9 +794,17 @@ func (c *ChattoCore) getSpaceConfigKV(ctx context.Context, spaceID string) (jets
 	})
 }
 
-// getSpaceRBACKV retrieves or creates the RBAC bucket for a space.
-// The bucket contains roles, permissions, and assignments.
+// getSpaceRBACKV retrieves the RBAC bucket for a space.
+//
+// Post-#330 phase 4a: the primary space's RBAC data lives in SERVER_RBAC;
+// other spaces keep their per-space SPACE_{id}_RBAC buckets.
 func (c *ChattoCore) getSpaceRBACKV(ctx context.Context, spaceID string) (jetstream.KeyValue, error) {
+	if c.usesServerLevelMetadata(spaceID) {
+		if _, err := c.GetSpace(ctx, spaceID); err != nil {
+			return nil, fmt.Errorf("space %s does not exist: %w", spaceID, err)
+		}
+		return c.storage.serverRBACKV, nil
+	}
 	return c.storage.spaceRBACKV.GetOrCreate(spaceID, func() (jetstream.KeyValue, error) {
 		if _, err := c.GetSpace(ctx, spaceID); err != nil {
 			return nil, fmt.Errorf("space %s does not exist: %w", spaceID, err)
@@ -701,9 +823,17 @@ func (c *ChattoCore) getSpaceRBACKV(ctx context.Context, spaceID string) (jetstr
 	})
 }
 
-// getSpaceRBACEngine retrieves or creates an rbac.Engine for a space.
-// Uses the space's RBAC bucket for storage.
+// getSpaceRBACEngine retrieves an rbac.Engine for a space.
+//
+// Post-#330 phase 4a: the primary space uses a single server-level engine
+// wrapping SERVER_RBAC. Other spaces keep per-space engines from the cache.
 func (c *ChattoCore) getSpaceRBACEngine(ctx context.Context, spaceID string) (*rbac.Engine, error) {
+	if c.usesServerLevelMetadata(spaceID) {
+		if _, err := c.GetSpace(ctx, spaceID); err != nil {
+			return nil, fmt.Errorf("space %s does not exist: %w", spaceID, err)
+		}
+		return c.storage.serverRBACEngine, nil
+	}
 	return c.storage.spaceRBACEngines.GetOrCreate(spaceID, func() (*rbac.Engine, error) {
 		kv, err := c.getSpaceRBACKV(ctx, spaceID)
 		if err != nil {
@@ -727,9 +857,17 @@ func (c *ChattoCore) getSpaceRBACEngine(ctx context.Context, spaceID string) (*r
 	})
 }
 
-// getSpaceRuntimeKV retrieves or creates the RUNTIME bucket for a space.
-// The bucket contains transient state (sequences, timestamps, read status).
+// getSpaceRuntimeKV retrieves the RUNTIME bucket for a space.
+//
+// Post-#330 phase 4a: the primary space's RUNTIME data lives in SERVER_RUNTIME;
+// other spaces keep their per-space SPACE_{id}_RUNTIME buckets.
 func (c *ChattoCore) getSpaceRuntimeKV(ctx context.Context, spaceID string) (jetstream.KeyValue, error) {
+	if c.usesServerLevelMetadata(spaceID) {
+		if _, err := c.GetSpace(ctx, spaceID); err != nil {
+			return nil, fmt.Errorf("space %s does not exist: %w", spaceID, err)
+		}
+		return c.storage.serverRuntimeKV, nil
+	}
 	return c.storage.spaceRuntimeKV.GetOrCreate(spaceID, func() (jetstream.KeyValue, error) {
 		if _, err := c.GetSpace(ctx, spaceID); err != nil {
 			return nil, fmt.Errorf("space %s does not exist: %w", spaceID, err)
@@ -1114,6 +1252,13 @@ func (c *ChattoCore) deleteSpaceStream(ctx context.Context, spaceID string) erro
 // createSpaceResources creates all NATS KV buckets and object stores for a space.
 // Called during space creation to eagerly initialize all resources.
 // If creation fails partway, cleans up any successfully created resources.
+//
+// Always creates per-space CONFIG/RBAC/RUNTIME buckets even though the
+// primary space's data lives in the shared SERVER_* buckets post-migration.
+// This is intentional: at the moment a space is created we don't yet know
+// whether it will become the primary. Phase 4a's boot-time migrator copies
+// the primary's per-space data over to SERVER_* the first time the primary
+// is resolved. Non-primary spaces continue using their per-space buckets.
 func (c *ChattoCore) createSpaceResources(ctx context.Context, spaceID string) error {
 	// Track created resources for cleanup on failure
 	var createdBuckets []string

--- a/cli/internal/core/schema_migration.go
+++ b/cli/internal/core/schema_migration.go
@@ -1,0 +1,348 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// Schema migration coordinates the move from the per-space `SPACE_{id}_*`
+// data layout to the unified `SERVER_*` layout described in #354 (phase 4 of
+// the #330 instance/space → server consolidation).
+//
+// Migrations run on instance boot. Completion is recorded with a per-phase
+// marker key in `KV_INSTANCE`; a leased lock prevents multiple pods of the
+// same deployment from running the same migration concurrently. Source data
+// is never mutated or deleted — the legacy `SPACE_*` resources stay in place
+// until a separate cleanup follow-up retires them.
+
+const (
+	// migrationLockKey is the KV_INSTANCE key used as a leased mutex while a
+	// migration is in progress. Owner identity + per-key TTL handle crash
+	// recovery: a pod that dies mid-migration eventually loses the lock and
+	// another pod can take over.
+	migrationLockKey = "migration_lock"
+
+	// migrationLockTTL is how long a held lock lives before another pod is
+	// allowed to take it. Long enough to comfortably cover phase-4a work on
+	// tiny-to-modest instances; if a migration takes longer, the lock will
+	// expire and another pod will pick up the (idempotent) work.
+	migrationLockTTL = 5 * time.Minute
+
+	// migrationLockAcquireTimeout caps how long we wait for a contended lock
+	// before giving up. Generous enough to outlast one TTL window so a
+	// crashed-pod scenario resolves automatically.
+	migrationLockAcquireTimeout = 10 * time.Minute
+
+	// migrationLockRetryInterval is the wait between attempts when the lock
+	// is held by another pod.
+	migrationLockRetryInterval = 2 * time.Second
+
+	// phase4aCompleteKey marks phase 4a as done. Presence-as-truth: the
+	// cleanup follow-up deletes this alongside the legacy resources, after
+	// which the migrator becomes a permanent no-op.
+	phase4aCompleteKey = "migration.phase4a_complete"
+)
+
+// RunMigrationsIfNeeded runs any pending schema migrations. Idempotent and
+// safe to call concurrently from multiple pods (lock-protected).
+//
+// Should be called once at boot, after `NewChattoCore` and after the primary
+// space ID has been resolved (so phase-4a knows what to migrate).
+//
+// Production deployments always have a primary configured; `primarySpaceID`
+// is only ever empty on truly fresh installs that haven't created their
+// first space yet, in which case there's no legacy data and the marker is
+// written immediately.
+func (c *ChattoCore) RunMigrationsIfNeeded(ctx context.Context, primarySpaceID string) error {
+	return c.runPhase4aIfNeeded(ctx, primarySpaceID)
+}
+
+// runPhase4aIfNeeded migrates the primary space's CONFIG, RBAC and RUNTIME
+// KV buckets from `SPACE_{primary}_*` into the shared `SERVER_*` buckets.
+// DM space data is intentionally not touched — that fold-in is a separate
+// later phase.
+func (c *ChattoCore) runPhase4aIfNeeded(ctx context.Context, primarySpaceID string) error {
+	if done, err := c.isMigrationComplete(ctx, phase4aCompleteKey); err != nil {
+		return fmt.Errorf("phase4a: check completion marker: %w", err)
+	} else if done {
+		return nil
+	}
+
+	release, err := c.acquireMigrationLock(ctx)
+	if err != nil {
+		return fmt.Errorf("phase4a: acquire lock: %w", err)
+	}
+	defer release()
+
+	// Re-check after acquiring the lock — another pod may have just finished.
+	if done, err := c.isMigrationComplete(ctx, phase4aCompleteKey); err != nil {
+		return fmt.Errorf("phase4a: re-check completion marker: %w", err)
+	} else if done {
+		return nil
+	}
+
+	hasLegacy, err := c.legacyPrimaryMetadataExists(ctx, primarySpaceID)
+	if err != nil {
+		return fmt.Errorf("phase4a: detect legacy data: %w", err)
+	}
+	if !hasLegacy {
+		c.logger.Info("phase4a: no legacy SPACE_{primary}_* metadata buckets found, marking migration complete",
+			"primary_space_id", primarySpaceID)
+		return c.markMigrationComplete(ctx, phase4aCompleteKey)
+	}
+
+	c.logger.Info("phase4a: migrating primary space metadata to SERVER_*",
+		"primary_space_id", primarySpaceID)
+
+	if err := c.copyPhase4aData(ctx, primarySpaceID); err != nil {
+		return fmt.Errorf("phase4a: copy data: %w", err)
+	}
+
+	if err := c.verifyPhase4a(ctx, primarySpaceID); err != nil {
+		return fmt.Errorf("phase4a: verify: %w", err)
+	}
+
+	if err := c.markMigrationComplete(ctx, phase4aCompleteKey); err != nil {
+		return fmt.Errorf("phase4a: mark complete: %w", err)
+	}
+
+	c.logger.Info("phase4a: migration complete", "primary_space_id", primarySpaceID)
+	return nil
+}
+
+// isMigrationComplete returns true if the given completion marker key exists
+// in `KV_INSTANCE`.
+func (c *ChattoCore) isMigrationComplete(ctx context.Context, markerKey string) (bool, error) {
+	_, err := c.storage.instanceKV.Get(ctx, markerKey)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, jetstream.ErrKeyNotFound) {
+		return false, nil
+	}
+	return false, err
+}
+
+// markMigrationComplete writes the given completion marker key in `KV_INSTANCE`.
+// Safe to call repeatedly — uses Put semantics; collision is impossible since
+// only one pod holds the lock when this runs.
+func (c *ChattoCore) markMigrationComplete(ctx context.Context, markerKey string) error {
+	_, err := c.storage.instanceKV.Put(ctx, markerKey, []byte("1"))
+	return err
+}
+
+// legacyPrimaryMetadataExists returns true if any of the legacy primary-space
+// metadata buckets (SPACE_{primary}_CONFIG/RBAC/RUNTIME) exist. Used to decide
+// whether phase 4a has anything to do.
+func (c *ChattoCore) legacyPrimaryMetadataExists(ctx context.Context, primarySpaceID string) (bool, error) {
+	for _, bucketName := range []string{
+		legacySpaceConfigBucket(primarySpaceID),
+		legacySpaceRBACBucket(primarySpaceID),
+		legacySpaceRuntimeBucket(primarySpaceID),
+	} {
+		_, err := c.js.KeyValue(ctx, bucketName)
+		if err == nil {
+			return true, nil
+		}
+		if !errors.Is(err, jetstream.ErrBucketNotFound) {
+			return false, fmt.Errorf("checking bucket %s: %w", bucketName, err)
+		}
+	}
+	return false, nil
+}
+
+// copyPhase4aData copies every key from each legacy primary-space metadata
+// bucket into the corresponding `SERVER_*` bucket. Idempotent: keys that
+// already exist in the target are skipped (so partial runs from a prior
+// crash resume cleanly).
+func (c *ChattoCore) copyPhase4aData(ctx context.Context, primarySpaceID string) error {
+	if err := c.copyKVBucket(ctx, legacySpaceConfigBucket(primarySpaceID), c.storage.serverConfigKV, "CONFIG"); err != nil {
+		return err
+	}
+	if err := c.copyKVBucket(ctx, legacySpaceRBACBucket(primarySpaceID), c.storage.serverRBACKV, "RBAC"); err != nil {
+		return err
+	}
+	if err := c.copyKVBucket(ctx, legacySpaceRuntimeBucket(primarySpaceID), c.storage.serverRuntimeKV, "RUNTIME"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// copyKVBucket copies every key from sourceBucketName into target. Uses
+// kv.Create on the target so re-running on partial state is a no-op for keys
+// that have already been copied. logTag identifies the bucket type in logs.
+func (c *ChattoCore) copyKVBucket(ctx context.Context, sourceBucketName string, target jetstream.KeyValue, logTag string) error {
+	source, err := c.js.KeyValue(ctx, sourceBucketName)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrBucketNotFound) {
+			c.logger.Debug("phase4a: source bucket missing, skipping",
+				"bucket", sourceBucketName, "tag", logTag)
+			return nil
+		}
+		return fmt.Errorf("open source bucket %s: %w", sourceBucketName, err)
+	}
+
+	keysLister, err := source.ListKeys(ctx)
+	if err != nil {
+		return fmt.Errorf("list keys in %s: %w", sourceBucketName, err)
+	}
+	defer keysLister.Stop()
+
+	copied := 0
+	skipped := 0
+	for key := range keysLister.Keys() {
+		entry, err := source.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				// Key was deleted between listing and reading — fine, nothing
+				// to copy. Source data is supposed to be quiescent during the
+				// migration, but we tolerate this rather than failing.
+				continue
+			}
+			return fmt.Errorf("read key %q from %s: %w", key, sourceBucketName, err)
+		}
+
+		_, err = target.Create(ctx, key, entry.Value())
+		switch {
+		case err == nil:
+			copied++
+		case errors.Is(err, jetstream.ErrKeyExists):
+			// Already copied in a previous (crashed?) run. Idempotent skip.
+			skipped++
+		default:
+			return fmt.Errorf("write key %q to target: %w", key, err)
+		}
+	}
+
+	c.logger.Info("phase4a: copied bucket",
+		"source", sourceBucketName,
+		"tag", logTag,
+		"copied", copied,
+		"skipped_existing", skipped,
+	)
+	return nil
+}
+
+// verifyPhase4a checks that every key in the legacy buckets has a corresponding
+// entry in the SERVER_* target. A mismatch causes the migration to fail without
+// writing the completion marker, so the next boot retries.
+func (c *ChattoCore) verifyPhase4a(ctx context.Context, primarySpaceID string) error {
+	for _, pair := range []struct {
+		sourceBucketName string
+		target           jetstream.KeyValue
+		tag              string
+	}{
+		{legacySpaceConfigBucket(primarySpaceID), c.storage.serverConfigKV, "CONFIG"},
+		{legacySpaceRBACBucket(primarySpaceID), c.storage.serverRBACKV, "RBAC"},
+		{legacySpaceRuntimeBucket(primarySpaceID), c.storage.serverRuntimeKV, "RUNTIME"},
+	} {
+		if err := c.verifyKVBucketCopy(ctx, pair.sourceBucketName, pair.target, pair.tag); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// verifyKVBucketCopy walks the source bucket and confirms every key exists in
+// the target. Counts both sides and includes them in the error on mismatch.
+func (c *ChattoCore) verifyKVBucketCopy(ctx context.Context, sourceBucketName string, target jetstream.KeyValue, tag string) error {
+	source, err := c.js.KeyValue(ctx, sourceBucketName)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrBucketNotFound) {
+			return nil // Source missing means nothing to verify.
+		}
+		return fmt.Errorf("open source bucket %s for verify: %w", sourceBucketName, err)
+	}
+
+	keysLister, err := source.ListKeys(ctx)
+	if err != nil {
+		return fmt.Errorf("list keys in %s for verify: %w", sourceBucketName, err)
+	}
+	defer keysLister.Stop()
+
+	var sourceCount, missingCount int
+	for key := range keysLister.Keys() {
+		sourceCount++
+		_, err := target.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				missingCount++
+				c.logger.Error("phase4a: key missing in target after copy",
+					"source_bucket", sourceBucketName,
+					"tag", tag,
+					"key", key,
+				)
+				continue
+			}
+			return fmt.Errorf("verify key %q in target: %w", key, err)
+		}
+	}
+
+	if missingCount > 0 {
+		return fmt.Errorf("verification failed: %d of %d keys from %s missing in target",
+			missingCount, sourceCount, sourceBucketName)
+	}
+
+	c.logger.Info("phase4a: verified bucket",
+		"source", sourceBucketName,
+		"tag", tag,
+		"keys_verified", sourceCount,
+	)
+	return nil
+}
+
+// acquireMigrationLock takes the `KV_INSTANCE` migration lock. The lock key
+// carries a TTL so a crashed pod's lock eventually expires and another pod
+// can pick up the (idempotent) work. Returns a release function that the
+// caller is expected to defer.
+func (c *ChattoCore) acquireMigrationLock(ctx context.Context) (release func(), err error) {
+	ownerID := newID("ML")
+
+	deadline := time.Now().Add(migrationLockAcquireTimeout)
+	for {
+		_, createErr := c.storage.instanceKV.Create(ctx, migrationLockKey, []byte(ownerID), jetstream.KeyTTL(migrationLockTTL))
+		if createErr == nil {
+			break
+		}
+		if !errors.Is(createErr, jetstream.ErrKeyExists) {
+			return nil, fmt.Errorf("create lock key: %w", createErr)
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("timed out waiting for migration lock after %s", migrationLockAcquireTimeout)
+		}
+		c.logger.Info("phase4a: waiting for migration lock held by another pod",
+			"retry_in", migrationLockRetryInterval)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(migrationLockRetryInterval):
+		}
+	}
+
+	release = func() {
+		// Best-effort delete; if it fails, the TTL will clean up.
+		if err := c.storage.instanceKV.Delete(ctx, migrationLockKey); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+			c.logger.Warn("phase4a: failed to release migration lock; will expire via TTL", "error", err)
+		}
+	}
+	return release, nil
+}
+
+// legacy bucket name helpers — kept here so the legacy naming convention is
+// expressed in exactly one place during the migration.
+
+func legacySpaceConfigBucket(spaceID string) string {
+	return fmt.Sprintf("SPACE_%s_CONFIG", spaceID)
+}
+
+func legacySpaceRBACBucket(spaceID string) string {
+	return fmt.Sprintf("SPACE_%s_RBAC", spaceID)
+}
+
+func legacySpaceRuntimeBucket(spaceID string) string {
+	return fmt.Sprintf("SPACE_%s_RUNTIME", spaceID)
+}

--- a/cli/internal/core/schema_migration_test.go
+++ b/cli/internal/core/schema_migration_test.go
@@ -1,0 +1,292 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// TestPhase4aMigration_FreshInstall verifies that a fresh install (no primary
+// space, no legacy data) writes the completion marker without doing any work
+// and is a fast no-op on subsequent calls.
+func TestPhase4aMigration_FreshInstall(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	if err := core.RunMigrationsIfNeeded(ctx, ""); err != nil {
+		t.Fatalf("first run failed: %v", err)
+	}
+
+	// Marker should be present after the run.
+	if _, err := core.storage.instanceKV.Get(ctx, phase4aCompleteKey); err != nil {
+		t.Fatalf("expected completion marker after fresh-install run: %v", err)
+	}
+
+	// A second run is a fast no-op via the marker check.
+	if err := core.RunMigrationsIfNeeded(ctx, ""); err != nil {
+		t.Fatalf("second run failed: %v", err)
+	}
+}
+
+// TestPhase4aMigration_NoLegacyData verifies that when a primary space exists
+// but its legacy SPACE_*_CONFIG buckets do not, the migration marks itself
+// complete without erroring.
+func TestPhase4aMigration_NoLegacyData(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	space, err := core.CreateSpace(ctx, "test-user", "Primary", "")
+	if err != nil {
+		t.Fatalf("CreateSpace: %v", err)
+	}
+
+	// Delete the per-space CONFIG/RBAC/RUNTIME buckets that CreateSpace just
+	// made, simulating an instance that's already been through migration
+	// (data lives in SERVER_* and the legacy buckets are gone).
+	for _, bucket := range []string{
+		legacySpaceConfigBucket(space.Id),
+		legacySpaceRBACBucket(space.Id),
+		legacySpaceRuntimeBucket(space.Id),
+	} {
+		if err := core.js.DeleteKeyValue(ctx, bucket); err != nil {
+			t.Fatalf("delete %s: %v", bucket, err)
+		}
+	}
+
+	if err := core.RunMigrationsIfNeeded(ctx, space.Id); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+
+	// Marker should be present.
+	if _, err := core.storage.instanceKV.Get(ctx, phase4aCompleteKey); err != nil {
+		t.Fatalf("expected completion marker: %v", err)
+	}
+}
+
+// TestPhase4aMigration_CopiesPrimaryData verifies the happy path: a primary
+// space with data in SPACE_{id}_CONFIG/RBAC/RUNTIME has all of its keys
+// copied into SERVER_*.
+func TestPhase4aMigration_CopiesPrimaryData(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	// Create a primary space without setting it as primary yet — its data
+	// goes into per-space SPACE_{id}_* buckets like a pre-migration install.
+	space, err := core.CreateSpace(ctx, "test-user", "Primary", "")
+	if err != nil {
+		t.Fatalf("CreateSpace: %v", err)
+	}
+
+	// Capture the keys CreateSpace wrote into the legacy buckets — these
+	// are what migration must reproduce in SERVER_*.
+	configKeys := snapshotKeys(t, ctx, core, legacySpaceConfigBucket(space.Id))
+	rbacKeys := snapshotKeys(t, ctx, core, legacySpaceRBACBucket(space.Id))
+	runtimeKeys := snapshotKeys(t, ctx, core, legacySpaceRuntimeBucket(space.Id))
+
+	// SERVER_* buckets should be empty before migration runs.
+	assertBucketEmpty(t, ctx, core.storage.serverConfigKV)
+	assertBucketEmpty(t, ctx, core.storage.serverRBACKV)
+	assertBucketEmpty(t, ctx, core.storage.serverRuntimeKV)
+
+	// Now mark the space as primary and run the migration.
+	core.SetPrimarySpaceID(space.Id)
+	if err := core.RunMigrationsIfNeeded(ctx, space.Id); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+
+	// Every key from the legacy buckets must now be present in SERVER_*.
+	assertKeysCopied(t, ctx, core.storage.serverConfigKV, configKeys, "SERVER_CONFIG")
+	assertKeysCopied(t, ctx, core.storage.serverRBACKV, rbacKeys, "SERVER_RBAC")
+	assertKeysCopied(t, ctx, core.storage.serverRuntimeKV, runtimeKeys, "SERVER_RUNTIME")
+
+	// Marker should be present.
+	if _, err := core.storage.instanceKV.Get(ctx, phase4aCompleteKey); err != nil {
+		t.Fatalf("expected completion marker: %v", err)
+	}
+
+	// Source data must be left intact (no-deletes rule).
+	for _, bucket := range []string{
+		legacySpaceConfigBucket(space.Id),
+		legacySpaceRBACBucket(space.Id),
+		legacySpaceRuntimeBucket(space.Id),
+	} {
+		if _, err := core.js.KeyValue(ctx, bucket); err != nil {
+			t.Errorf("legacy bucket %s should still exist after migration: %v", bucket, err)
+		}
+	}
+}
+
+// TestPhase4aMigration_IdempotentOnRerun verifies that running the migration
+// twice — including a second run after the marker is forcibly removed — does
+// not corrupt or duplicate target data and reports the same final state.
+func TestPhase4aMigration_IdempotentOnRerun(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	space, err := core.CreateSpace(ctx, "test-user", "Primary", "")
+	if err != nil {
+		t.Fatalf("CreateSpace: %v", err)
+	}
+	core.SetPrimarySpaceID(space.Id)
+
+	if err := core.RunMigrationsIfNeeded(ctx, space.Id); err != nil {
+		t.Fatalf("first run failed: %v", err)
+	}
+	configKeysAfterFirst := snapshotKeys(t, ctx, core, "SERVER_CONFIG")
+
+	// Force the marker off and re-run — simulates a crashed pod that wrote
+	// some data but never wrote the marker. Idempotent copy should leave
+	// the target identical.
+	if err := core.storage.instanceKV.Delete(ctx, phase4aCompleteKey); err != nil {
+		t.Fatalf("delete marker: %v", err)
+	}
+	if err := core.RunMigrationsIfNeeded(ctx, space.Id); err != nil {
+		t.Fatalf("second run failed: %v", err)
+	}
+	configKeysAfterSecond := snapshotKeys(t, ctx, core, "SERVER_CONFIG")
+
+	if !equalKeySets(configKeysAfterFirst, configKeysAfterSecond) {
+		t.Fatalf("expected idempotent target state; first=%v second=%v", configKeysAfterFirst, configKeysAfterSecond)
+	}
+
+	if _, err := core.storage.instanceKV.Get(ctx, phase4aCompleteKey); err != nil {
+		t.Fatalf("expected completion marker after second run: %v", err)
+	}
+}
+
+// TestPhase4aMigration_LockSerializesConcurrentRuns verifies the migration
+// lock prevents two concurrent calls from both running the work. Whichever
+// goroutine acquires first does the migration; the other observes the marker
+// after the lock releases and exits cleanly.
+func TestPhase4aMigration_LockSerializesConcurrentRuns(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	space, err := core.CreateSpace(ctx, "test-user", "Primary", "")
+	if err != nil {
+		t.Fatalf("CreateSpace: %v", err)
+	}
+	core.SetPrimarySpaceID(space.Id)
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i := range errs {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			errs[idx] = core.RunMigrationsIfNeeded(ctx, space.Id)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d returned error: %v", i, err)
+		}
+	}
+
+	if _, err := core.storage.instanceKV.Get(ctx, phase4aCompleteKey); err != nil {
+		t.Fatalf("expected completion marker after concurrent runs: %v", err)
+	}
+}
+
+// TestPhase4aMigration_PrimaryRoutingAfterMigration verifies that once the
+// primary is set and migration has run, reads through the bucket getters go
+// to SERVER_* (not the legacy SPACE_{id}_* buckets).
+func TestPhase4aMigration_PrimaryRoutingAfterMigration(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	space, err := core.CreateSpace(ctx, "test-user", "Primary", "")
+	if err != nil {
+		t.Fatalf("CreateSpace: %v", err)
+	}
+	core.SetPrimarySpaceID(space.Id)
+	if err := core.RunMigrationsIfNeeded(ctx, space.Id); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+
+	// The primary's CONFIG bucket access should now be SERVER_CONFIG.
+	bucket, err := core.getSpaceConfigKV(ctx, space.Id)
+	if err != nil {
+		t.Fatalf("getSpaceConfigKV: %v", err)
+	}
+	if status, err := bucket.Status(ctx); err != nil {
+		t.Fatalf("bucket status: %v", err)
+	} else if status.Bucket() != "SERVER_CONFIG" {
+		t.Fatalf("primary should route to SERVER_CONFIG after migration, got %q", status.Bucket())
+	}
+
+	// And the DM space (different ID) still routes to its per-space bucket.
+	dmBucket, err := core.getSpaceConfigKV(ctx, DMSpaceID)
+	if err != nil {
+		t.Fatalf("getSpaceConfigKV(DM): %v", err)
+	}
+	if status, err := dmBucket.Status(ctx); err != nil {
+		t.Fatalf("dm bucket status: %v", err)
+	} else if status.Bucket() != legacySpaceConfigBucket(DMSpaceID) {
+		t.Fatalf("DM should route to %q, got %q",
+			legacySpaceConfigBucket(DMSpaceID), status.Bucket())
+	}
+}
+
+// snapshotKeys returns the set of keys in the named bucket. Helper for the
+// tests above; doesn't fail on missing-bucket so callers can probe.
+func snapshotKeys(t *testing.T, ctx context.Context, core *ChattoCore, bucketName string) map[string]struct{} {
+	t.Helper()
+	bucket, err := core.js.KeyValue(ctx, bucketName)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrBucketNotFound) {
+			return map[string]struct{}{}
+		}
+		t.Fatalf("open bucket %s: %v", bucketName, err)
+	}
+	return listKeys(t, ctx, bucket)
+}
+
+func listKeys(t *testing.T, ctx context.Context, bucket jetstream.KeyValue) map[string]struct{} {
+	t.Helper()
+	out := make(map[string]struct{})
+	lister, err := bucket.ListKeys(ctx)
+	if err != nil {
+		t.Fatalf("list keys: %v", err)
+	}
+	defer lister.Stop()
+	for key := range lister.Keys() {
+		out[key] = struct{}{}
+	}
+	return out
+}
+
+func assertBucketEmpty(t *testing.T, ctx context.Context, bucket jetstream.KeyValue) {
+	t.Helper()
+	keys := listKeys(t, ctx, bucket)
+	if len(keys) != 0 {
+		t.Fatalf("expected bucket to be empty, found %d keys", len(keys))
+	}
+}
+
+func assertKeysCopied(t *testing.T, ctx context.Context, target jetstream.KeyValue, want map[string]struct{}, label string) {
+	t.Helper()
+	got := listKeys(t, ctx, target)
+	for key := range want {
+		if _, ok := got[key]; !ok {
+			t.Errorf("%s: expected key %q in target, missing", label, key)
+		}
+	}
+}
+
+func equalKeySets(a, b map[string]struct{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/frontend/src/lib/gql/gql.ts
+++ b/frontend/src/lib/gql/gql.ts
@@ -152,8 +152,6 @@ type Documents = {
     "\n            mutation RequestAccountDeletion {\n              requestAccountDeletion\n            }\n          ": typeof types.RequestAccountDeletionDocument,
     "\n            mutation DeleteMyAccount($input: DeleteMyAccountInput!) {\n              deleteMyAccount(input: $input)\n            }\n          ": typeof types.DeleteMyAccountDocument,
     "\n            mutation UpdateMySettings($input: UpdateUserSettingsInput!) {\n              updateMySettings(input: $input) {\n                timezone\n                timeFormat\n              }\n            }\n          ": typeof types.UpdateMySettingsDocument,
-    "\n            query SpaceJoinPage($spaceId: ID!) {\n              space(id: $spaceId) {\n                id\n                name\n                description\n                memberCount\n                viewerIsMember\n              }\n              me {\n                id\n              }\n            }\n          ": typeof types.SpaceJoinPageDocument,
-    "\n            mutation JoinSpaceFromInvite($input: JoinSpaceInput!) {\n              joinSpace(input: $input)\n            }\n          ": typeof types.JoinSpaceFromInviteDocument,
     "\n    query LoginPageInfo {\n      instance {\n        enabledAuthProviders\n        directRegistrationEnabled\n      }\n    }\n  ": typeof types.LoginPageInfoDocument,
 };
 const documents: Documents = {
@@ -295,8 +293,6 @@ const documents: Documents = {
     "\n            mutation RequestAccountDeletion {\n              requestAccountDeletion\n            }\n          ": types.RequestAccountDeletionDocument,
     "\n            mutation DeleteMyAccount($input: DeleteMyAccountInput!) {\n              deleteMyAccount(input: $input)\n            }\n          ": types.DeleteMyAccountDocument,
     "\n            mutation UpdateMySettings($input: UpdateUserSettingsInput!) {\n              updateMySettings(input: $input) {\n                timezone\n                timeFormat\n              }\n            }\n          ": types.UpdateMySettingsDocument,
-    "\n            query SpaceJoinPage($spaceId: ID!) {\n              space(id: $spaceId) {\n                id\n                name\n                description\n                memberCount\n                viewerIsMember\n              }\n              me {\n                id\n              }\n            }\n          ": types.SpaceJoinPageDocument,
-    "\n            mutation JoinSpaceFromInvite($input: JoinSpaceInput!) {\n              joinSpace(input: $input)\n            }\n          ": types.JoinSpaceFromInviteDocument,
     "\n    query LoginPageInfo {\n      instance {\n        enabledAuthProviders\n        directRegistrationEnabled\n      }\n    }\n  ": types.LoginPageInfoDocument,
 };
 
@@ -866,14 +862,6 @@ export function graphql(source: "\n            mutation DeleteMyAccount($input: 
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n            mutation UpdateMySettings($input: UpdateUserSettingsInput!) {\n              updateMySettings(input: $input) {\n                timezone\n                timeFormat\n              }\n            }\n          "): (typeof documents)["\n            mutation UpdateMySettings($input: UpdateUserSettingsInput!) {\n              updateMySettings(input: $input) {\n                timezone\n                timeFormat\n              }\n            }\n          "];
-/**
- * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
- */
-export function graphql(source: "\n            query SpaceJoinPage($spaceId: ID!) {\n              space(id: $spaceId) {\n                id\n                name\n                description\n                memberCount\n                viewerIsMember\n              }\n              me {\n                id\n              }\n            }\n          "): (typeof documents)["\n            query SpaceJoinPage($spaceId: ID!) {\n              space(id: $spaceId) {\n                id\n                name\n                description\n                memberCount\n                viewerIsMember\n              }\n              me {\n                id\n              }\n            }\n          "];
-/**
- * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
- */
-export function graphql(source: "\n            mutation JoinSpaceFromInvite($input: JoinSpaceInput!) {\n              joinSpace(input: $input)\n            }\n          "): (typeof documents)["\n            mutation JoinSpaceFromInvite($input: JoinSpaceInput!) {\n              joinSpace(input: $input)\n            }\n          "];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/frontend/src/lib/gql/graphql.ts
+++ b/frontend/src/lib/gql/graphql.ts
@@ -1175,8 +1175,8 @@ export type Mutation = {
   leaveSpace: Scalars['Boolean']['output'];
   /**
    * Mark a room as read for the current user.
-   * Stores the current stream lastSeq as the last read sequence.
-   * Returns the previous and new last-read sequence IDs.
+   * Stores the room's current last root message event ID as the user's read marker.
+   * Returns the timestamps of the new and previous last-read events.
    */
   markRoomAsRead: MarkRoomAsReadResult;
   /**
@@ -4596,20 +4596,6 @@ export type UpdateMySettingsMutationVariables = Exact<{
 
 export type UpdateMySettingsMutation = { __typename?: 'Mutation', updateMySettings: { __typename?: 'UserSettings', timezone?: string | null, timeFormat: TimeFormat } };
 
-export type SpaceJoinPageQueryVariables = Exact<{
-  spaceId: Scalars['ID']['input'];
-}>;
-
-
-export type SpaceJoinPageQuery = { __typename?: 'Query', space?: { __typename?: 'Space', id: string, name: string, description?: string | null, memberCount: number, viewerIsMember: boolean } | null, me?: { __typename?: 'User', id: string } | null };
-
-export type JoinSpaceFromInviteMutationVariables = Exact<{
-  input: JoinSpaceInput;
-}>;
-
-
-export type JoinSpaceFromInviteMutation = { __typename?: 'Mutation', joinSpace: boolean };
-
 export type LoginPageInfoQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -4753,6 +4739,4 @@ export const AccountPermissionsDocument = {"kind":"Document","definitions":[{"ki
 export const RequestAccountDeletionDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"RequestAccountDeletion"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"requestAccountDeletion"}}]}}]} as unknown as DocumentNode<RequestAccountDeletionMutation, RequestAccountDeletionMutationVariables>;
 export const DeleteMyAccountDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"DeleteMyAccount"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"DeleteMyAccountInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"deleteMyAccount"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}]}]}}]} as unknown as DocumentNode<DeleteMyAccountMutation, DeleteMyAccountMutationVariables>;
 export const UpdateMySettingsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateMySettings"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UpdateUserSettingsInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updateMySettings"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"timezone"}},{"kind":"Field","name":{"kind":"Name","value":"timeFormat"}}]}}]}}]} as unknown as DocumentNode<UpdateMySettingsMutation, UpdateMySettingsMutationVariables>;
-export const SpaceJoinPageDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"SpaceJoinPage"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"spaceId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"space"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"spaceId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"memberCount"}},{"kind":"Field","name":{"kind":"Name","value":"viewerIsMember"}}]}},{"kind":"Field","name":{"kind":"Name","value":"me"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<SpaceJoinPageQuery, SpaceJoinPageQueryVariables>;
-export const JoinSpaceFromInviteDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"JoinSpaceFromInvite"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"JoinSpaceInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"joinSpace"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}]}]}}]} as unknown as DocumentNode<JoinSpaceFromInviteMutation, JoinSpaceFromInviteMutationVariables>;
 export const LoginPageInfoDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"LoginPageInfo"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"instance"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"enabledAuthProviders"}},{"kind":"Field","name":{"kind":"Name","value":"directRegistrationEnabled"}}]}}]}}]} as unknown as DocumentNode<LoginPageInfoQuery, LoginPageInfoQueryVariables>;


### PR DESCRIPTION
## Summary

First sub-phase of #354 (data migration for #330). Adds a boot-time schema migration harness — KV-based lock, per-phase done marker in `KV_INSTANCE`, idempotent copy with verify-after-copy step — and uses it to move the configured primary space's `CONFIG`/`RBAC`/`RUNTIME` data from per-space `SPACE_{id}_*` buckets into shared deployment-wide `SERVER_*` buckets. Source `SPACE_*` data is left intact (no-deletes rule) and the migration is fully re-runnable; rolling back the deploy continues to read from the legacy buckets unchanged. Bucket-getter routing splits primary (→ `SERVER_*`) from DM and any other non-primary spaces (→ legacy `SPACE_{id}_*`), so existing per-space tests continue to pass and DM space behavior is unchanged in this PR.

Refs #330, #354.

## Test plan

- [x] `mise test-cli` — all core tests pass (existing + new `TestPhase4aMigration_*` covering fresh install, no-legacy-data, happy-path copy, idempotent rerun, lock contention, post-migration routing).
- [ ] Cluster dress-rehearsal against a small test instance running the currently-released version, before deploying to production.
- [ ] Backup before deploying to any production instance.