### PR TITLE
feat(migration): phase 4b — DM merge, kind in key prefix (#354)

### DIFF
--- a/.claude/rules/nats-subjects.md
+++ b/.claude/rules/nats-subjects.md
@@ -43,6 +43,28 @@ msg.{rootId}.replies.{eventId}
 thread.{rootId}.{eventId}
 ```
 
+### 4. Encode Filter Discriminators in the Key Prefix
+
+When a single bucket (or stream) holds records of multiple kinds, put the kind in the key prefix so listing operations can prefix-filter without loading and deserializing every record. This applies to KV keys (which are subjects under the hood) just as much as stream subjects.
+
+```
+# Good: kind in key prefix → fast prefix scans
+SERVER_CONFIG:
+  room.channel.{roomId}                        # filter `room.channel.*`
+  room.dm.{roomId}                             # filter `room.dm.*`
+  room_membership.channel.{roomId}.{userId}    # filter `room_membership.channel.{roomId}.*`
+  room_membership.dm.{roomId}.{userId}
+
+# Less efficient: kind on the proto, not the key
+SERVER_CONFIG:
+  room.{roomId}             # have to load + deserialize each room to filter
+  room_membership.{u}.{r}   # have to look up the room to know its kind
+```
+
+Same outer-to-inner scope ordering across related keys: `room.{kind}.{roomId}` and `room_membership.{kind}.{roomId}.{userId}` both put the kind first, then the room (the entity being described), then per-room detail. Symmetric and predictable.
+
+The kind segment is then **the** source of truth — don't also store it on the proto. One canonical representation per piece of information.
+
 ## Filtering Patterns Reference
 
 For room messages, these wildcard patterns enable efficient filtering:
@@ -54,6 +76,17 @@ For room messages, these wildcard patterns enable efficient filtering:
 | `msg.*.replies.>` | All thread replies (any thread) |
 | `msg.{rootId}.replies.>` | Replies in a specific thread |
 | `msg.*.replies.{eventId}` | Lookup thread reply by event ID |
+
+For kind-prefixed KV keys (`SERVER_CONFIG`):
+
+| Pattern | Matches |
+|---------|---------|
+| `room.channel.*` | Channel rooms only |
+| `room.dm.*` | DM rooms only |
+| `room.*.*` | All rooms regardless of kind |
+| `room_membership.{kind}.{roomId}.*` | Members of one room (pure prefix) |
+| `room_membership.{kind}.*.{userId}` | A user's memberships of one kind (server-side wildcard) |
+| `room_membership.{kind}.>` | All memberships of one kind |
 
 ## Subject Refactoring Checklist
 

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -100,10 +100,19 @@ func (c *ChattoCore) SetPrimarySpaceID(spaceID string) {
 	c.primarySpaceID.Store(spaceID)
 }
 
-// usesServerLevelMetadata reports whether the given spaceID's CONFIG / RBAC /
-// RUNTIME data lives in the shared SERVER_* buckets (true only for the
-// configured primary space).
+// usesServerLevelMetadata reports whether the given spaceID's CONFIG /
+// RBAC / RUNTIME data lives in the shared SERVER_* buckets.
+//
+// True for: the configured primary space (#330 phase 4a) and the DM system
+// space (#330 phase 4b). DM rooms live in SERVER_CONFIG alongside channel
+// rooms and are disambiguated by Room.kind.
+//
+// False for: any other (test-created) space, which keeps its per-space
+// SPACE_{id}_* buckets via the legacy lazycache routes.
 func (c *ChattoCore) usesServerLevelMetadata(spaceID string) bool {
+	if IsDMSpace(spaceID) {
+		return true
+	}
 	primary := c.PrimarySpaceID()
 	return primary != "" && spaceID == primary
 }
@@ -737,9 +746,31 @@ func spaceKey(spaceID string) string {
 	return fmt.Sprintf("space.%s", spaceID)
 }
 
+// roomKindKeyFromSpaceID returns the kind segment for the rooms that live
+// in a given space. DM space holds DM rooms; everything else holds channels.
+//
+// The segment is part of the key on disk (e.g., `room.channel.{roomID}`,
+// `room.dm.{roomID}`) so list operations can prefix-filter by kind via
+// NATS subject matching without loading and deserializing every room
+// record. Kind isn't stored on the Room proto — the storage layout is
+// the canonical source of truth.
+func roomKindKeyFromSpaceID(spaceID string) string {
+	if IsDMSpace(spaceID) {
+		return "dm"
+	}
+	return "channel"
+}
+
 // roomKey returns the KV key for a room record in a space bucket.
-func roomKey(roomID string) string {
-	return fmt.Sprintf("room.%s", roomID)
+// Pattern: `room.{kind}.{roomID}` where kind is "channel" or "dm".
+func roomKey(kind, roomID string) string {
+	return fmt.Sprintf("room.%s.%s", kind, roomID)
+}
+
+// roomKeyPrefix returns the key prefix for listing all rooms of a given
+// kind in a CONFIG bucket. Pattern: `room.{kind}.*`.
+func roomKeyPrefix(kind string) string {
+	return fmt.Sprintf("room.%s.*", kind)
 }
 
 // roomNameIndexKey returns the KV key that claims a room name within a space.

--- a/cli/internal/core/dm.go
+++ b/cli/internal/core/dm.go
@@ -197,7 +197,7 @@ func (c *ChattoCore) createDMRoom(ctx context.Context, roomID string, participan
 		return nil, fmt.Errorf("failed to marshal DM room: %w", err)
 	}
 
-	_, err = bucket.Create(ctx, roomKey(roomID), roomData)
+	_, err = bucket.Create(ctx, roomKey("dm", roomID), roomData)
 	if err != nil {
 		return nil, err // Let caller handle ErrKeyExists for race condition
 	}
@@ -210,13 +210,13 @@ func (c *ChattoCore) createDMRoom(ctx context.Context, roomID string, participan
 
 			// Rollback: delete memberships we already created
 			for _, joinedID := range joinedParticipants {
-				if delErr := bucket.Delete(ctx, roomMembershipKey(joinedID, roomID)); delErr != nil {
+				if delErr := bucket.Delete(ctx, roomMembershipKey("dm", roomID, joinedID)); delErr != nil {
 					c.logger.Error("Failed to rollback DM membership", "participant", joinedID, "room_id", roomID, "error", delErr)
 				}
 			}
 
 			// Rollback: delete the room
-			if delErr := bucket.Delete(ctx, roomKey(roomID)); delErr != nil {
+			if delErr := bucket.Delete(ctx, roomKey("dm", roomID)); delErr != nil {
 				c.logger.Error("Failed to rollback DM room", "room_id", roomID, "error", delErr)
 			}
 
@@ -244,7 +244,7 @@ func (c *ChattoCore) joinDMRoom(ctx context.Context, bucket jetstream.KeyValue, 
 		return fmt.Errorf("failed to marshal DM membership: %w", err)
 	}
 
-	_, err = bucket.Put(ctx, roomMembershipKey(userID, roomID), data)
+	_, err = bucket.Put(ctx, roomMembershipKey("dm", roomID, userID), data)
 	if err != nil {
 		return fmt.Errorf("failed to create DM membership: %w", err)
 	}

--- a/cli/internal/core/rooms.go
+++ b/cli/internal/core/rooms.go
@@ -196,7 +196,7 @@ func (c *ChattoCore) CreateRoom(ctx context.Context, actorID string, space_id, n
 		c.bestEffortReleaseRoomNameClaim(ctx, bucket, indexKey, room_id)
 		return nil, fmt.Errorf("failed to marshal room: %w", err)
 	}
-	if _, err := bucket.Put(ctx, roomKey(room.Id), roomData); err != nil {
+	if _, err := bucket.Put(ctx, roomKey(roomKindKeyFromSpaceID(room.SpaceId), room.Id), roomData); err != nil {
 		c.bestEffortReleaseRoomNameClaim(ctx, bucket, indexKey, room_id)
 		return nil, fmt.Errorf("failed to store room: %w", err)
 	}
@@ -295,7 +295,7 @@ func (c *ChattoCore) UpdateRoom(ctx context.Context, actorID string, space_id, r
 		}
 		return nil, fmt.Errorf("failed to marshal room: %w", err)
 	}
-	if _, err := bucket.Put(ctx, roomKey(room.Id), roomData); err != nil {
+	if _, err := bucket.Put(ctx, roomKey(roomKindKeyFromSpaceID(room.SpaceId), room.Id), roomData); err != nil {
 		if renamed {
 			c.bestEffortReleaseRoomNameClaim(ctx, bucket, newIndexKey, room_id)
 		}
@@ -360,7 +360,7 @@ func (c *ChattoCore) DeleteRoom(ctx context.Context, actorID string, space_id, r
 	if err != nil {
 		return fmt.Errorf("failed to get bucket: %w", err)
 	}
-	err = bucket.Delete(ctx, roomKey(room_id))
+	err = bucket.Delete(ctx, roomKey(roomKindKeyFromSpaceID(space_id), room_id))
 	if err != nil {
 		return fmt.Errorf("failed to delete room: %w", err)
 	}
@@ -403,7 +403,7 @@ func (c *ChattoCore) ArchiveRoom(ctx context.Context, actorID, spaceID, roomID s
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal room: %w", err)
 	}
-	_, err = bucket.Put(ctx, roomKey(room.Id), roomData)
+	_, err = bucket.Put(ctx, roomKey(roomKindKeyFromSpaceID(room.SpaceId), room.Id), roomData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to archive room: %w", err)
 	}
@@ -453,7 +453,7 @@ func (c *ChattoCore) UnarchiveRoom(ctx context.Context, actorID, spaceID, roomID
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal room: %w", err)
 	}
-	_, err = bucket.Put(ctx, roomKey(room.Id), roomData)
+	_, err = bucket.Put(ctx, roomKey(roomKindKeyFromSpaceID(room.SpaceId), room.Id), roomData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unarchive room: %w", err)
 	}
@@ -500,7 +500,7 @@ func (c *ChattoCore) SetRoomAutoJoin(ctx context.Context, actorID, spaceID, room
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal room: %w", err)
 	}
-	_, err = bucket.Put(ctx, roomKey(room.Id), roomData)
+	_, err = bucket.Put(ctx, roomKey(roomKindKeyFromSpaceID(room.SpaceId), room.Id), roomData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update room auto_join: %w", err)
 	}
@@ -516,7 +516,7 @@ func (c *ChattoCore) GetRoom(ctx context.Context, space_id, room_id string) (*co
 		return nil, err
 	}
 
-	entry, err := bucket.Get(ctx, roomKey(room_id))
+	entry, err := bucket.Get(ctx, roomKey(roomKindKeyFromSpaceID(space_id), room_id))
 	if err != nil {
 		return nil, fmt.Errorf("room not found: %w", err)
 	}
@@ -530,13 +530,19 @@ func (c *ChattoCore) GetRoom(ctx context.Context, space_id, room_id string) (*co
 }
 
 // ListRoomsBySpace retrieves all rooms in a space from the CONFIG bucket.
+//
+// Post-#330 phase 4b: the primary space and the DM system space share
+// SERVER_CONFIG, with kind encoded in the key prefix (`room.channel.{X}`
+// vs `room.dm.{X}`). The prefix scan returns only the matching kind, so
+// no in-memory filter is needed.
 func (c *ChattoCore) ListRoomsBySpace(ctx context.Context, space_id string) ([]*corev1.Room, error) {
 	bucket, err := c.getSpaceConfigBucket(ctx, space_id)
 	if err != nil {
 		return nil, err
 	}
 
-	keyLister, err := bucket.ListKeysFiltered(ctx, "room.*")
+	prefix := roomKeyPrefix(roomKindKeyFromSpaceID(space_id))
+	keyLister, err := bucket.ListKeysFiltered(ctx, prefix)
 	if err != nil {
 		if err == jetstream.ErrNoKeysFound {
 			return []*corev1.Room{}, nil
@@ -610,7 +616,8 @@ func (c *ChattoCore) ensureRoomNameIndex(ctx context.Context, spaceID string, bu
 		return nil
 	}
 
-	keyLister, err := bucket.ListKeysFiltered(ctx, "room.*")
+	// Channels only — DM rooms have empty names so there's nothing to index.
+	keyLister, err := bucket.ListKeysFiltered(ctx, roomKeyPrefix(roomKindKeyFromSpaceID(spaceID)))
 	if err != nil {
 		if errors.Is(err, jetstream.ErrNoKeysFound) {
 			c.roomNameIndexBackfilled.Store(spaceID, struct{}{})
@@ -674,9 +681,28 @@ func (c *ChattoCore) bestEffortReleaseRoomNameClaim(ctx context.Context, bucket 
 // Room Membership Operations
 // ============================================================================
 
-// roomMembershipKey returns the KV key for a room membership using the pattern: room_membership.{user_id}.{room_id}
-func roomMembershipKey(user_id, room_id string) string {
-	return fmt.Sprintf("room_membership.%s.%s", user_id, room_id)
+// roomMembershipKey returns the KV key for a room membership.
+// Pattern: `room_membership.{kind}.{roomID}.{userID}` where kind is
+// "channel" or "dm". Same outer-to-inner scope ordering as roomKey
+// (`room.{kind}.{roomID}`): kind, then room, then per-room detail.
+func roomMembershipKey(kind, room_id, user_id string) string {
+	return fmt.Sprintf("room_membership.%s.%s.%s", kind, room_id, user_id)
+}
+
+// roomMembershipKeyPrefixForRoom returns the key prefix for listing all
+// memberships of a given room. Pattern: `room_membership.{kind}.{roomID}.*`.
+// Pure prefix scan — used by room-deletion cleanup and member-list reads.
+func roomMembershipKeyPrefixForRoom(kind, room_id string) string {
+	return fmt.Sprintf("room_membership.%s.%s.*", kind, room_id)
+}
+
+// roomMembershipKeyMatchForUser returns the subject filter that matches
+// a user's memberships of a given kind. The userID is in the trailing
+// position of the key (`room_membership.{kind}.{roomID}.{userID}`), so
+// this is an internal-wildcard filter rather than a pure prefix:
+// `room_membership.{kind}.*.{userID}`. Server-side filtered by NATS.
+func roomMembershipKeyMatchForUser(kind, user_id string) string {
+	return fmt.Sprintf("room_membership.%s.*.%s", kind, user_id)
 }
 
 // GetRoomMembership retrieves a room membership for a user in a specific room.
@@ -686,7 +712,7 @@ func (c *ChattoCore) GetRoomMembership(ctx context.Context, space_id, user_id, r
 		return nil, err
 	}
 
-	key := roomMembershipKey(user_id, room_id)
+	key := roomMembershipKey(roomKindKeyFromSpaceID(space_id), room_id, user_id)
 	data, err := kv.Get(ctx, key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get room membership for user %s in room %s: %w", user_id, room_id, err)
@@ -763,7 +789,7 @@ func (c *ChattoCore) JoinRoom(ctx context.Context, actorID, space_id, user_id, r
 		return nil, fmt.Errorf("failed to marshal room membership data: %w", err)
 	}
 
-	_, err = kv.Put(ctx, roomMembershipKey(user_id, room_id), data)
+	_, err = kv.Put(ctx, roomMembershipKey(roomKindKeyFromSpaceID(space_id), room_id, user_id), data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create room membership for user %s in room %s: %w", user_id, room_id, err)
 	}
@@ -829,7 +855,7 @@ func (c *ChattoCore) LeaveRoom(ctx context.Context, actorID, space_id, user_id, 
 		return err
 	}
 
-	err = kv.Delete(ctx, roomMembershipKey(user_id, room_id))
+	err = kv.Delete(ctx, roomMembershipKey(roomKindKeyFromSpaceID(space_id), room_id, user_id))
 	if err != nil {
 		return fmt.Errorf("failed to delete room membership for user %s in room %s: %w", user_id, room_id, err)
 	}
@@ -863,7 +889,7 @@ func (c *ChattoCore) GetUserRoomMemberships(ctx context.Context, space_id, user_
 		return nil, err
 	}
 
-	kl, err := kv.ListKeysFiltered(ctx, fmt.Sprintf("room_membership.%s.*", user_id))
+	kl, err := kv.ListKeysFiltered(ctx, roomMembershipKeyMatchForUser(roomKindKeyFromSpaceID(space_id), user_id))
 	if err != nil {
 		return nil, fmt.Errorf("failed to list room memberships for user %s in space %s: %w", user_id, space_id, err)
 	}
@@ -896,9 +922,11 @@ func (c *ChattoCore) deleteUserRoomMembershipsInSpace(ctx context.Context, user_
 		return err
 	}
 
-	// List all room membership keys for this user
-	// Key format: room_membership.{user_id}.{room_id}
-	kl, err := kv.ListKeysFiltered(ctx, fmt.Sprintf("room_membership.%s.*", user_id))
+	// List the user's memberships in this space's kind. Key format
+	// post-#330 phase 4b: `room_membership.{kind}.{room_id}.{user_id}`.
+	// userID is the trailing segment, so this is an internal-wildcard
+	// filter rather than a pure prefix.
+	kl, err := kv.ListKeysFiltered(ctx, roomMembershipKeyMatchForUser(roomKindKeyFromSpaceID(space_id), user_id))
 	if err != nil {
 		// No keys found is fine - user may not be in any rooms
 		if errors.Is(err, jetstream.ErrNoKeysFound) {
@@ -914,9 +942,9 @@ func (c *ChattoCore) deleteUserRoomMembershipsInSpace(ctx context.Context, user_
 	}
 	var entries []keyAndRoom
 	for key := range kl.Keys() {
-		// Extract room ID from key: room_membership.{user_id}.{room_id}
+		// Extract room ID from key: room_membership.{kind}.{room_id}.{user_id}
 		parts := strings.Split(key, ".")
-		if len(parts) == 3 {
+		if len(parts) == 4 {
 			entries = append(entries, keyAndRoom{key: key, roomID: parts[2]})
 		}
 	}
@@ -957,8 +985,9 @@ func (c *ChattoCore) GetRoomMembersList(ctx context.Context, space_id, room_id s
 		return nil, err
 	}
 
-	// List all room membership keys in the bucket
-	kl, err := kv.ListKeysFiltered(ctx, "room_membership.>")
+	// List room memberships of the kind that lives in this space's bucket.
+	// Key format: `room_membership.{kind}.{userID}.{roomID}`.
+	kl, err := kv.ListKeysFiltered(ctx, fmt.Sprintf("room_membership.%s.>", roomKindKeyFromSpaceID(space_id)))
 	if err != nil {
 		if err == jetstream.ErrNoKeysFound {
 			return []*corev1.RoomMembership{}, nil

--- a/cli/internal/core/schema_migration.go
+++ b/cli/internal/core/schema_migration.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/nats-io/nats.go/jetstream"
@@ -45,6 +46,11 @@ const (
 	// cleanup follow-up deletes this alongside the legacy resources, after
 	// which the migrator becomes a permanent no-op.
 	phase4aCompleteKey = "migration.phase4a_complete"
+
+	// phase4bCompleteKey marks phase 4b as done. Same presence-as-truth shape
+	// as phase 4a. The cleanup follow-up deletes both markers along with the
+	// legacy SPACE_* resources.
+	phase4bCompleteKey = "migration.phase4b_complete"
 )
 
 // RunMigrationsIfNeeded runs any pending schema migrations. Idempotent and
@@ -58,7 +64,13 @@ const (
 // first space yet, in which case there's no legacy data and the marker is
 // written immediately.
 func (c *ChattoCore) RunMigrationsIfNeeded(ctx context.Context, primarySpaceID string) error {
-	return c.runPhase4aIfNeeded(ctx, primarySpaceID)
+	if err := c.runPhase4aIfNeeded(ctx, primarySpaceID); err != nil {
+		return err
+	}
+	if err := c.runPhase4bIfNeeded(ctx); err != nil {
+		return err
+	}
+	return nil
 }
 
 // runPhase4aIfNeeded migrates the primary space's CONFIG, RBAC and RUNTIME
@@ -112,6 +124,272 @@ func (c *ChattoCore) runPhase4aIfNeeded(ctx context.Context, primarySpaceID stri
 
 	c.logger.Info("phase4a: migration complete", "primary_space_id", primarySpaceID)
 	return nil
+}
+
+// runPhase4bIfNeeded folds the DM system space's metadata into SERVER_*
+// and rewrites room/membership keys to encode the room kind in the key
+// prefix (`room.channel.{X}` and `room.dm.{X}`).
+//
+// Two pieces of work happen here:
+//
+//  1. Rewrite primary's already-migrated keys in SERVER_CONFIG from the
+//     phase-4a-era format `room.{X}` / `room_membership.{u}.{r}` into
+//     the kind-prefixed format `room.channel.{X}` /
+//     `room_membership.channel.{u}.{r}`.
+//
+//  2. Copy DM-space data from SPACE_DM_CONFIG / SPACE_DM_RUNTIME into
+//     SERVER_CONFIG / SERVER_RUNTIME, writing rooms and memberships
+//     under the `room.dm.*` / `room_membership.dm.*` prefixes.
+//
+// In both cases the original keys are left in place (no-deletes rule);
+// reads use the new prefixes, the dormant old keys cost a little disk
+// until the cleanup follow-up retires them.
+//
+// DM space has no RBAC bucket to migrate (DM permissions are hardcoded;
+// see isDMPermissionAllowed). Per-message KVs (BODIES/REACTIONS/THREADS)
+// move in a later phase.
+func (c *ChattoCore) runPhase4bIfNeeded(ctx context.Context) error {
+	if done, err := c.isMigrationComplete(ctx, phase4bCompleteKey); err != nil {
+		return fmt.Errorf("phase4b: check completion marker: %w", err)
+	} else if done {
+		return nil
+	}
+
+	release, err := c.acquireMigrationLock(ctx)
+	if err != nil {
+		return fmt.Errorf("phase4b: acquire lock: %w", err)
+	}
+	defer release()
+
+	// Re-check after acquiring the lock — another pod may have just finished.
+	if done, err := c.isMigrationComplete(ctx, phase4bCompleteKey); err != nil {
+		return fmt.Errorf("phase4b: re-check completion marker: %w", err)
+	} else if done {
+		return nil
+	}
+
+	c.logger.Info("phase4b: rewriting primary keys in SERVER_CONFIG to kind-prefixed form")
+	if err := c.rewritePrimaryConfigKeysToKindPrefix(ctx); err != nil {
+		return fmt.Errorf("phase4b: rewrite primary keys: %w", err)
+	}
+
+	if hasLegacyDM, err := c.legacyDMMetadataExists(ctx); err != nil {
+		return fmt.Errorf("phase4b: detect legacy DM data: %w", err)
+	} else if hasLegacyDM {
+		c.logger.Info("phase4b: copying DM space data into SERVER_* with dm-prefixed keys")
+		if err := c.copyDMDataToServerLayout(ctx); err != nil {
+			return fmt.Errorf("phase4b: copy DM data: %w", err)
+		}
+	}
+
+	if err := c.markMigrationComplete(ctx, phase4bCompleteKey); err != nil {
+		return fmt.Errorf("phase4b: mark complete: %w", err)
+	}
+
+	c.logger.Info("phase4b: migration complete")
+	return nil
+}
+
+// legacyDMMetadataExists returns true if either of the DM system space's
+// legacy CONFIG/RUNTIME buckets exist. (RBAC is intentionally absent — DM
+// has no roles.)
+func (c *ChattoCore) legacyDMMetadataExists(ctx context.Context) (bool, error) {
+	for _, bucketName := range []string{
+		legacySpaceConfigBucket(DMSpaceID),
+		legacySpaceRuntimeBucket(DMSpaceID),
+	} {
+		_, err := c.js.KeyValue(ctx, bucketName)
+		if err == nil {
+			return true, nil
+		}
+		if !errors.Is(err, jetstream.ErrBucketNotFound) {
+			return false, fmt.Errorf("checking bucket %s: %w", bucketName, err)
+		}
+	}
+	return false, nil
+}
+
+// rewritePrimaryConfigKeysToKindPrefix walks SERVER_CONFIG and copies any
+// key in the phase-4a-era format (`room.{X}`, `room_membership.{u}.{r}`)
+// to its kind-prefixed equivalent (`room.channel.{X}`,
+// `room_membership.channel.{u}.{r}`). The original key is left in place
+// for rollback safety; it becomes dormant once code switches to the new
+// prefixes.
+//
+// Idempotent: re-runs find no old-format keys to copy (the prefix scans
+// `room.*` and `room_membership.*.*` no longer match anything once
+// rewrites happen, and Create swallows ErrKeyExists for any key already
+// present in the target).
+func (c *ChattoCore) rewritePrimaryConfigKeysToKindPrefix(ctx context.Context) error {
+	target := c.storage.serverConfigKV
+
+	roomsCopied, roomsSkipped, err := c.copyKeysWithRewrite(ctx, target, "room.*", func(oldKey string) (string, bool) {
+		// "room.{X}" — exactly one segment after "room.", and no
+		// further dots (NanoIDs don't contain dots).
+		suffix := strings.TrimPrefix(oldKey, "room.")
+		if suffix == oldKey || strings.Contains(suffix, ".") {
+			return "", false
+		}
+		return "room.channel." + suffix, true
+	})
+	if err != nil {
+		return fmt.Errorf("rewrite room.* keys: %w", err)
+	}
+
+	memCopied, memSkipped, err := c.copyKeysWithRewrite(ctx, target, "room_membership.*.*", func(oldKey string) (string, bool) {
+		// Old format: "room_membership.{u}.{r}" — exactly two segments
+		// after the "room_membership." prefix. New format swaps the
+		// order to put roomID first: "room_membership.channel.{r}.{u}".
+		suffix := strings.TrimPrefix(oldKey, "room_membership.")
+		if suffix == oldKey {
+			return "", false
+		}
+		segments := strings.Split(suffix, ".")
+		if len(segments) != 2 {
+			return "", false
+		}
+		userID, roomID := segments[0], segments[1]
+		return fmt.Sprintf("room_membership.channel.%s.%s", roomID, userID), true
+	})
+	if err != nil {
+		return fmt.Errorf("rewrite room_membership.*.* keys: %w", err)
+	}
+
+	c.logger.Info("phase4b: rewrote primary keys in SERVER_CONFIG",
+		"rooms_copied", roomsCopied,
+		"rooms_skipped_existing", roomsSkipped,
+		"memberships_copied", memCopied,
+		"memberships_skipped_existing", memSkipped,
+	)
+	return nil
+}
+
+// copyKeysWithRewrite scans target with filterPattern, computes a new key
+// for each match via rewrite, and writes the original value at the new
+// key. Returns (copied, skipped, error). The original key stays in place.
+func (c *ChattoCore) copyKeysWithRewrite(
+	ctx context.Context,
+	target jetstream.KeyValue,
+	filterPattern string,
+	rewrite func(oldKey string) (newKey string, ok bool),
+) (copied, skipped int, err error) {
+	keysLister, err := target.ListKeysFiltered(ctx, filterPattern)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return 0, 0, nil
+		}
+		return 0, 0, fmt.Errorf("list %q: %w", filterPattern, err)
+	}
+	defer keysLister.Stop()
+
+	for oldKey := range keysLister.Keys() {
+		newKey, ok := rewrite(oldKey)
+		if !ok {
+			continue
+		}
+		entry, err := target.Get(ctx, oldKey)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			return copied, skipped, fmt.Errorf("read %q: %w", oldKey, err)
+		}
+		_, err = target.Create(ctx, newKey, entry.Value())
+		switch {
+		case err == nil:
+			copied++
+		case errors.Is(err, jetstream.ErrKeyExists):
+			skipped++
+		default:
+			return copied, skipped, fmt.Errorf("write %q: %w", newKey, err)
+		}
+	}
+	return copied, skipped, nil
+}
+
+// copyDMDataToServerLayout copies DM-space CONFIG and RUNTIME data into
+// the shared SERVER_* buckets, rewriting room/membership keys with the
+// `dm` kind prefix. Source data left intact (no-deletes rule).
+func (c *ChattoCore) copyDMDataToServerLayout(ctx context.Context) error {
+	if err := c.copyDMConfigToServer(ctx); err != nil {
+		return err
+	}
+	if err := c.copyKVBucket(ctx, legacySpaceRuntimeBucket(DMSpaceID), c.storage.serverRuntimeKV, "DM_RUNTIME"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// copyDMConfigToServer walks SPACE_DM_CONFIG and writes each key into
+// SERVER_CONFIG, rewriting `room.{X}` → `room.dm.{X}` and
+// `room_membership.{u}.{r}` → `room_membership.dm.{u}.{r}`. Other keys
+// (none expected for DM space, but defensively) copy verbatim.
+func (c *ChattoCore) copyDMConfigToServer(ctx context.Context) error {
+	sourceName := legacySpaceConfigBucket(DMSpaceID)
+	source, err := c.js.KeyValue(ctx, sourceName)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrBucketNotFound) {
+			return nil
+		}
+		return fmt.Errorf("open %s: %w", sourceName, err)
+	}
+
+	keysLister, err := source.ListKeys(ctx)
+	if err != nil {
+		return fmt.Errorf("list keys in %s: %w", sourceName, err)
+	}
+	defer keysLister.Stop()
+
+	target := c.storage.serverConfigKV
+
+	copied := 0
+	skipped := 0
+	for key := range keysLister.Keys() {
+		entry, err := source.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			return fmt.Errorf("read key %q from %s: %w", key, sourceName, err)
+		}
+
+		newKey := dmConfigKeyToServerKey(key)
+		_, err = target.Create(ctx, newKey, entry.Value())
+		switch {
+		case err == nil:
+			copied++
+		case errors.Is(err, jetstream.ErrKeyExists):
+			skipped++
+		default:
+			return fmt.Errorf("write key %q to SERVER_CONFIG: %w", newKey, err)
+		}
+	}
+
+	c.logger.Info("phase4b: copied DM CONFIG bucket to SERVER_CONFIG",
+		"source", sourceName,
+		"copied", copied,
+		"skipped_existing", skipped,
+	)
+	return nil
+}
+
+// dmConfigKeyToServerKey rewrites a DM-space CONFIG key to its
+// SERVER_CONFIG equivalent. `room.{X}` becomes `room.dm.{X}`;
+// `room_membership.{u}.{r}` becomes `room_membership.dm.{r}.{u}`
+// (note the user/room swap to align with the room-first ordering).
+// Any other key shape is returned unchanged.
+func dmConfigKeyToServerKey(key string) string {
+	if rest, ok := strings.CutPrefix(key, "room."); ok && !strings.Contains(rest, ".") {
+		return "room.dm." + rest
+	}
+	if rest, ok := strings.CutPrefix(key, "room_membership."); ok {
+		segments := strings.Split(rest, ".")
+		if len(segments) == 2 {
+			userID, roomID := segments[0], segments[1]
+			return fmt.Sprintf("room_membership.dm.%s.%s", roomID, userID)
+		}
+	}
+	return key
 }
 
 // isMigrationComplete returns true if the given completion marker key exists

--- a/cli/internal/core/schema_migration_test.go
+++ b/cli/internal/core/schema_migration_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 
 	"github.com/nats-io/nats.go/jetstream"
+	"google.golang.org/protobuf/proto"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
 // TestPhase4aMigration_FreshInstall verifies that a fresh install (no primary
@@ -220,16 +223,91 @@ func TestPhase4aMigration_PrimaryRoutingAfterMigration(t *testing.T) {
 		t.Fatalf("primary should route to SERVER_CONFIG after migration, got %q", status.Bucket())
 	}
 
-	// And the DM space (different ID) still routes to its per-space bucket.
+	// Post-#330 phase 4b: the DM space also routes to SERVER_CONFIG.
 	dmBucket, err := core.getSpaceConfigKV(ctx, DMSpaceID)
 	if err != nil {
 		t.Fatalf("getSpaceConfigKV(DM): %v", err)
 	}
 	if status, err := dmBucket.Status(ctx); err != nil {
 		t.Fatalf("dm bucket status: %v", err)
-	} else if status.Bucket() != legacySpaceConfigBucket(DMSpaceID) {
-		t.Fatalf("DM should route to %q, got %q",
-			legacySpaceConfigBucket(DMSpaceID), status.Bucket())
+	} else if status.Bucket() != "SERVER_CONFIG" {
+		t.Fatalf("DM should route to SERVER_CONFIG after phase 4b, got %q", status.Bucket())
+	}
+}
+
+// TestPhase4bMigration_RewritesDMRoomsToKindPrefix verifies that the phase
+// 4b migrator copies DM-space room records into SERVER_CONFIG under the
+// kind-prefixed key `room.dm.{X}`, with the original Room proto preserved
+// byte-for-byte (the kind discriminator lives in the key, not the proto).
+func TestPhase4bMigration_RewritesDMRoomsToKindPrefix(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	dmConfig, err := core.js.KeyValue(ctx, legacySpaceConfigBucket(DMSpaceID))
+	if err != nil {
+		t.Fatalf("open SPACE_DM_CONFIG: %v", err)
+	}
+	roomID := "Rtest-dm-room-1"
+	legacyRoom := &corev1.Room{
+		Id:      roomID,
+		SpaceId: DMSpaceID,
+	}
+	value, err := proto.Marshal(legacyRoom)
+	if err != nil {
+		t.Fatalf("marshal legacy DM room: %v", err)
+	}
+	if _, err := dmConfig.Put(ctx, "room."+roomID, value); err != nil {
+		t.Fatalf("seed legacy DM room: %v", err)
+	}
+
+	if err := core.RunMigrationsIfNeeded(ctx, ""); err != nil {
+		t.Fatalf("RunMigrationsIfNeeded: %v", err)
+	}
+
+	// The migrated room should now exist in SERVER_CONFIG under the new
+	// kind-prefixed key.
+	migratedEntry, err := core.storage.serverConfigKV.Get(ctx, "room.dm."+roomID)
+	if err != nil {
+		t.Fatalf("get migrated DM room from SERVER_CONFIG[room.dm.*]: %v", err)
+	}
+	migratedRoom := &corev1.Room{}
+	if err := proto.Unmarshal(migratedEntry.Value(), migratedRoom); err != nil {
+		t.Fatalf("unmarshal migrated room: %v", err)
+	}
+	if migratedRoom.Id != roomID {
+		t.Fatalf("expected room.Id = %q, got %q", roomID, migratedRoom.Id)
+	}
+
+	// Source bucket left untouched (no-deletes rule).
+	if _, err := dmConfig.Get(ctx, "room."+roomID); err != nil {
+		t.Fatalf("source DM room should still exist: %v", err)
+	}
+
+	// And the marker is set.
+	if _, err := core.storage.instanceKV.Get(ctx, phase4bCompleteKey); err != nil {
+		t.Fatalf("expected phase4b completion marker: %v", err)
+	}
+}
+
+// TestPhase4bMigration_FreshInstall verifies that phase 4b is a fast no-op
+// on a freshly-created instance (DM space exists but has no rooms).
+func TestPhase4bMigration_FreshInstall(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	// setupTestCore already initialized the DM space, which created
+	// SPACE_DM_CONFIG/RUNTIME as empty buckets. Phase 4b should detect
+	// them, copy nothing, verify, and mark complete.
+	if err := core.RunMigrationsIfNeeded(ctx, ""); err != nil {
+		t.Fatalf("RunMigrationsIfNeeded: %v", err)
+	}
+	if _, err := core.storage.instanceKV.Get(ctx, phase4bCompleteKey); err != nil {
+		t.Fatalf("expected phase4b completion marker: %v", err)
+	}
+
+	// Re-run is a fast no-op via the marker.
+	if err := core.RunMigrationsIfNeeded(ctx, ""); err != nil {
+		t.Fatalf("second run failed: %v", err)
 	}
 }
 

--- a/cli/internal/graph/room.resolvers.go
+++ b/cli/internal/graph/room.resolvers.go
@@ -15,6 +15,12 @@ import (
 )
 
 // Type is the resolver for the type field.
+//
+// Derived from the room's SpaceId rather than persisted on the Room proto:
+// the canonical kind discriminator is the storage key prefix (#330 phase
+// 4b), and DM rooms keep SpaceId="DM" through migration. Once the bridge
+// retires (4g) and SpaceId becomes vestigial, this resolver shifts to
+// reading the kind directly from the storage layer.
 func (r *roomResolver) Type(ctx context.Context, obj *corev1.Room) (model.RoomType, error) {
 	if core.IsDMSpace(obj.SpaceId) {
 		return model.RoomTypeDm, nil

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -508,17 +508,19 @@ All live events bypass JetStream entirely — KV buckets are the source of truth
 | `INSTANCE`                    | Instance  | File    | Yes      | Users, spaces, memberships                      |
 | `INSTANCE_RBAC`               | Instance  | File    | Yes      | Instance-level roles and permissions            |
 | `INSTANCE_CONFIG`             | Instance  | File    | Yes      | Runtime configuration overrides                 |
+| `SERVER_CONFIG`               | Server    | File    | Yes      | Rooms (channel + DM), memberships               |
+| `SERVER_RBAC`                 | Server    | File    | Yes      | Roles, permissions, assignments                 |
+| `SERVER_RUNTIME`              | Server    | File    | Yes      | Read state, mention tracking                    |
 | `NOTIFICATIONS`               | Instance  | File    | Yes      | User notifications (90-day TTL)                 |
 | `AUTH_TOKENS`                 | Instance  | File    | No       | Bearer auth tokens (configurable TTL, default 90d) |
-| `SPACE_{spaceId}_CONFIG`      | Per-space | File    | Yes      | Rooms, memberships                              |
-| `SPACE_{spaceId}_RBAC`        | Per-space | File    | Yes      | Roles, permissions, assignments                 |
-| `SPACE_{spaceId}_RUNTIME`     | Per-space | File    | Yes      | Read status, mention tracking                   |
 | `USER_PRESENCE`               | Instance  | Memory  | No       | User presence status (TTL 60s)                  |
 | `ENCRYPTION_KEYS`             | Instance  | File    | **No**   | User encryption keys (excluded for security)    |
 | `SPACE_{spaceId}_BODIES`      | Per-space | File    | Yes      | Message bodies (GDPR-compliant)                 |
 | `SPACE_{spaceId}_REACTIONS`   | Per-space | File    | Yes      | Emoji reactions on messages                     |
 | `SPACE_{spaceId}_THREADS`     | Per-space | File    | Yes      | Thread metadata (reply count, participants)     |
 | `LINK_PREVIEW_CACHE`          | Instance  | File    | No       | Cached link preview metadata (48h TTL)          |
+
+**Migration note (#330 / ADR-027 phase 4a + 4b):** the primary space's CONFIG/RBAC/RUNTIME data and the DM system space's CONFIG/RUNTIME data were folded into `SERVER_*`. The legacy `SPACE_{primary}_CONFIG`/`_RBAC`/`_RUNTIME` and `SPACE_DM_CONFIG`/`_RUNTIME` buckets are still present (no-deletes rule) but dormant — reads route to `SERVER_*`. A future cleanup pass will retire them. Per-space `BODIES`/`REACTIONS`/`THREADS`/`ASSETS` are still per-space; later sub-phases fold those in too.
 
 **INSTANCE keys:**
 
@@ -538,6 +540,9 @@ All live events bypass JetStream entirely — KV buckets are the source of truth
 | `space.{spaceId}.banner`               | Space banner asset reference                     |
 | `space_membership.{spaceId}.{userId}`  | User-space membership tracking                   |
 | `user_preferences.{userId}`            | User display preferences (timezone, time format) |
+| `migration_lock`                       | Schema-migration mutex (per-key TTL'd, owner ID as value) — see #330 phase 4 |
+| `migration.phase4a_complete`           | Phase 4a (primary CONFIG/RBAC/RUNTIME → `SERVER_*`) completion marker |
+| `migration.phase4b_complete`           | Phase 4b (DM merge + kind-prefixed keys) completion marker |
 
 Notes: Email verification uses SHA256 hashing for claim keys to ensure valid NATS subject characters and case-insensitive uniqueness. The claim key is created atomically when an email is verified, preventing race conditions where two users try to verify the same email. Verification tokens store userId and email in the JSON value for O(1) lookup by token.
 
@@ -600,25 +605,48 @@ Notes: Tokens are opaque strings (`cht_AT` + 14-char NanoID). Used for `Authoriz
 
 Notes: Excluded from backups so backup archives contain only encrypted data, not the keys to decrypt it. Enables GDPR-compliant crypto-shredding: deleting a user's key renders all their messages permanently unreadable.
 
-**SPACE\_{spaceId}\_CONFIG keys:**
+**SERVER\_CONFIG keys:**
 
-| Key                                       | Description                                      |
-| ----------------------------------------- | ------------------------------------------------ |
-| `room.{roomId}`                           | Room configurations                              |
-| `room_name_index.{lowercaseName}`         | Atomic name claim → room ID. Used to enforce case-insensitive uniqueness of room names without a read-then-write race. |
-| `room_membership.{userId}.{roomId}`       | User-room membership tracking                    |
-| `role.{roleName}`                               | Role metadata (name, display_name, description)         |
-| `role_permission.{roleName}.{permission}`       | Permission grant (empty value = granted)                |
-| `role_assignment.{roleName}.{userId}`           | Role assignment (empty value = assigned)                |
-| `user_permission.{userId}.{permission}`         | User-specific permission grant (overrides role perms)   |
-| `user_permission_denied.{userId}.{permission}`  | User-specific permission denial (overrides all grants)  |
+Room and membership keys carry a `kind` segment (`channel` or `dm`) so listing operations can prefix-filter without loading and deserializing every record. The kind isn't a field on the `Room` proto — the storage layout is the canonical source of truth.
 
-**SPACE\_{spaceId}\_RUNTIME keys:**
+| Key                                                  | Description                                      |
+| ---------------------------------------------------- | ------------------------------------------------ |
+| `room.channel.{roomId}`                              | Channel-style room                               |
+| `room.dm.{roomId}`                                   | Direct-message room                              |
+| `room_name_index.{lowercaseName}`                    | Atomic name claim → room ID. Channels only; DMs have empty names. Enforces case-insensitive uniqueness without a read-then-write race. |
+| `room_membership.channel.{roomId}.{userId}`          | Channel membership (room-first ordering matches `room.{kind}.{X}`)  |
+| `room_membership.dm.{roomId}.{userId}`               | DM membership                                    |
+| `role.{roleName}`                                    | Role metadata (name, display_name, description)  |
+| `role_permission.{roleName}.{permission}`            | Permission grant (empty value = granted)         |
+| `role_assignment.{roleName}.{userId}`                | Role assignment (empty value = assigned)         |
+| `user_permission.{userId}.{permission}`              | User-specific permission grant (overrides role perms)   |
+| `user_permission_denied.{userId}.{permission}`       | User-specific permission denial (overrides all grants)  |
+
+Useful filter patterns:
+
+| Pattern                                              | Matches                                          |
+| ---------------------------------------------------- | ------------------------------------------------ |
+| `room.channel.*`                                     | All channel rooms                                |
+| `room.dm.*`                                          | All DM rooms                                     |
+| `room.*.*`                                           | All rooms regardless of kind                     |
+| `room_membership.{kind}.{roomId}.*`                  | All members of one room (pure prefix)            |
+| `room_membership.{kind}.*.{userId}`                  | A user's memberships of one kind (server-side wildcard) |
+| `room_membership.{kind}.>`                           | All memberships of one kind                      |
+
+**SERVER\_RBAC keys:**
+
+Same shape as the legacy `SPACE_{spaceId}_RBAC` keys (`role.*`, `role_permission.*`, `role_assignment.*`, `user_permission.*`, `user_permission_denied.*`). Held in `SERVER_RBAC` post-#330 phase 4a; pre-4a primary data was copied verbatim.
+
+**SERVER\_RUNTIME keys:**
 
 | Key                                    | Description                                                       |
 | -------------------------------------- | ----------------------------------------------------------------- |
 | `room_read_event.{userId}.{roomId}`    | Last-read root message event ID (UTF-8 string, ~14 bytes). Empty value = "joined but no specific event read yet" (e.g. joined an empty room). Missing key triggers a one-time lazy init to the room's current last event ("caught up at first read post-deploy"). The legacy `room_read_status.*` keys (8-byte uint64 sequences) are orphaned and ignored. |
 | `room_mention_status.{userId}.{roomId}`| Unread mention indicator (boolean — key presence means unread)    |
+| `room_last_msg_at.{roomId}`            | Last message timestamp (per-room, used for sidebar sort)          |
+| `video.{attachmentId}`                 | Video processing state for an attachment                          |
+
+These keys don't carry a kind segment — `roomId` is globally unique, so direct lookup works for DM and channel rooms alike.
 
 **USER_PRESENCE keys:**
 
@@ -638,11 +666,11 @@ Notes: The compound key format `{userId}.{eventId}` enables efficient prefix-bas
 
 **SPACE\_{spaceId}\_REACTIONS keys:**
 
-| Key                                   | Description                                    |
-| ------------------------------------- | ---------------------------------------------- |
-| `{messageSeqId}.{emojiName}.{userId}` | Reaction tracking (empty value = reacted)      |
+| Key                                     | Description                                    |
+| --------------------------------------- | ---------------------------------------------- |
+| `{messageEventId}.{emojiName}.{userId}` | Reaction tracking (empty value = reacted; value stores nanosecond timestamp for "added at" ordering) |
 
-Notes: Emoji stored as name (e.g., "thumbsup") for NATS KV key compatibility. Separated for load isolation (high-volume). Events are live-only (not stored in JetStream). KV bucket is source of truth.
+Notes: Emoji stored as name (e.g., "thumbsup") for NATS KV key compatibility. Separated for load isolation (high-volume). Events are live-only (not stored in JetStream). KV bucket is source of truth. Keyed by event ID (not the volatile JetStream sequence) so reactions survive any future stream re-publishing.
 
 **SPACE\_{spaceId}\_THREADS keys:**
 

--- a/frontend/e2e/pages/AuthPage.ts
+++ b/frontend/e2e/pages/AuthPage.ts
@@ -282,9 +282,17 @@ export class AuthPage {
   /**
    * Logout the current user via API.
    * More reliable than clicking the logout button for test flows.
+   *
+   * The follow-up `page.reload()` is load-bearing: hitting POST /auth/logout
+   * clears the session cookie server-side, but the SPA's module-level user
+   * cache (`cachedUser` in `lib/auth/loadAuth.ts`) survives the request.
+   * Without a reload, a subsequent `goto('/login')` reads the still-cached
+   * user from the root layout and redirects back into the app, hiding the
+   * login form. Forcing a fresh load resets module state.
    */
   async logout(): Promise<void> {
     await this.page.request.post('/auth/logout');
+    await this.page.reload();
   }
 
   /**


### PR DESCRIPTION
## Summary

Second sub-phase of #354. Folds DM rooms and memberships into the deployment-wide \`SERVER_CONFIG\` / \`SERVER_RUNTIME\` buckets, encoding the room kind directly in the KV key prefix (\`room.channel.{X}\` vs \`room.dm.{X}\`, \`room_membership.{kind}.{u}.{r}\`). Listing operations now filter by kind via cheap NATS subject prefix scans rather than loading and deserializing every room record.

The \`Room\` proto stays untouched — kind isn't a field on the proto; the storage layout is the canonical source of truth. The GraphQL \`Room.type\` resolver derives the type from \`IsDMSpace(SpaceId)\` (same shape it had before this work).

The migrator (1) rewrites primary's already-migrated SERVER_CONFIG keys from the phase-4a-era format into the kind-prefixed form, then (2) copies DM-space CONFIG/RUNTIME into SERVER_* with the \`dm.\` prefix. Source data stays intact; both legacy and new-format keys coexist in SERVER_CONFIG until the cleanup follow-up retires the dormant ones.

Refs #330, #354.

## Test plan

- [x] \`mise test\` — core + graph + cmd all green; only the documented pre-existing \`TestAuthRoutes_TestEmailEndpoint\` fails. New tests cover kind-prefixed copy of DM rooms, fresh-install no-op, and the full migration sequence (4a + 4b).
- [ ] Backup before deploying to any production instance.