### PR TITLE
fix(e2e): eliminate two deterministic flakes in the e2e suite

### DIFF
--- a/frontend/e2e/pages/AuthPage.ts
+++ b/frontend/e2e/pages/AuthPage.ts
@@ -280,11 +280,20 @@ export class AuthPage {
   // --- Logout ---
 
   /**
-   * Logout the current user via API.
-   * More reliable than clicking the logout button for test flows.
+   * Logout the current user.
+   *
+   * A pure API call (`page.request.post('/auth/logout')`) is not enough on its
+   * own: the response Set-Cookie doesn't reliably overwrite the page-side jar
+   * that the SPA's subsequent fetches use, so the SPA stays authenticated and
+   * a follow-up `goto('/login')` redirects back into the app instead of
+   * showing the sign-in form.
+   *
+   * Going through the UI button triggers the SPA's full sign-out path
+   * (instanceRegistry.removeAll() + `window.location.href = '/'`), which
+   * forces a hard reload and lands cleanly on the landing page.
    */
   async logout(): Promise<void> {
-    await this.page.request.post('/auth/logout');
+    await this.logoutViaUI();
   }
 
   /**

--- a/frontend/e2e/quick-switcher.test.ts
+++ b/frontend/e2e/quick-switcher.test.ts
@@ -6,12 +6,22 @@ import { TIMEOUTS } from './constants';
 /**
  * Opens the quick switcher palette via Cmd/Ctrl+K.
  * Returns the dialog locator.
+ *
+ * Retries the keypress: if the chat layout's <svelte:window onkeydown> handler
+ * isn't fully wired up yet (race after navigation), the first Meta+k can be
+ * dropped and the dialog never opens. quickSwitcher.open() is idempotent, so
+ * re-pressing while open is a safe no-op.
  */
 async function openSwitcher(page: import('@playwright/test').Page) {
   const isMac = process.platform === 'darwin';
-  await page.keyboard.press(isMac ? 'Meta+k' : 'Control+k');
+  const key = isMac ? 'Meta+k' : 'Control+k';
   const dialog = page.locator('dialog.quick-switcher');
-  await expect(dialog).toBeVisible({ timeout: TIMEOUTS.UI_FAST });
+
+  await expect(async () => {
+    await page.keyboard.press(key);
+    await expect(dialog).toBeVisible({ timeout: 500 });
+  }).toPass({ timeout: TIMEOUTS.UI_STANDARD, intervals: [200, 500, 1000] });
+
   return dialog;
 }
 


### PR DESCRIPTION
## Summary

Two targeted fixes for deterministic flakes that triggered Playwright's full retry chain on every CI run.

- **`quick-switcher.test.ts`** — wrap the `openSwitcher()` Cmd+K press in `toPass()`. A race where `<svelte:window onkeydown>` isn't wired up at press-time was silently dropping the first keypress; now we re-press until the dialog actually opens. `quickSwitcher.open()` is idempotent, so re-pressing while open is a no-op. Kills three sibling flakes (`:29 / :54 / :140`) that flaked in all 3 baseline runs.
- **`pages/AuthPage.ts`** — switch `logout()` from a raw `page.request.post('/auth/logout')` to the UI sign-out flow. The bare API call's Set-Cookie response doesn't reliably overwrite the page-side cookie jar that the SPA's subsequent fetches use, so the SPA stays authenticated and the next `goto('/login')` redirects back into the app. Kills `auth.test.ts:349` and `password-reset.test.ts:141`, which together failed all 4 retries in 2 of 3 baseline runs.

Across 3 post-fix full-suite runs: **0 hard failures** (was 1–2/run). Remaining flakes are emergent worker-contention (different tests each run, all pass 5/5 in isolation).

## Test plan

- [x] `mise test-e2e` × 3 — all green, no hard failures
- [x] `quick-switcher.test.ts` × 4 with `--retries=0` — 11/11 every time
- [x] `auth.test.ts` + `password-reset.test.ts` × 3 with `--retries=0` — 43/43 every time
- [x] 7 historically-flaky tests run 5× each in isolation — 35/35 (confirms residual flake is contention, not test bugs)