### PR TITLE
feat(migration): phase 4c — per-message KVs → SERVER_* (#354)

### DIFF
--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -464,26 +464,28 @@ type storage struct {
 	instanceRBACKV   jetstream.KeyValue // Instance-level roles and permissions
 	instanceConfigKV jetstream.KeyValue // Runtime configuration overrides
 
-	// Server-level metadata buckets (#330 phase 4a). Shared across all non-DM
-	// spaces — in practice, the primary space's data lives here. The DM
-	// space still uses the per-space lazycaches below for now; that fold-in
-	// is a separate later phase.
-	serverConfigKV   jetstream.KeyValue // SERVER_CONFIG - rooms, memberships
-	serverRuntimeKV  jetstream.KeyValue // SERVER_RUNTIME - sequences, timestamps, read state
-	serverRBACKV     jetstream.KeyValue // SERVER_RBAC - roles, permissions, assignments
-	serverRBACEngine *rbac.Engine       // rbac.Engine wrapping serverRBACKV
+	// Server-level KV buckets (#330 phase 4a, 4b, 4c). Shared by the primary
+	// and DM spaces; non-primary, non-DM spaces (test-created only in
+	// practice) keep their per-space lazycaches below.
+	serverConfigKV    jetstream.KeyValue // SERVER_CONFIG    - rooms, memberships
+	serverRuntimeKV   jetstream.KeyValue // SERVER_RUNTIME   - sequences, timestamps, read state
+	serverRBACKV      jetstream.KeyValue // SERVER_RBAC      - roles, permissions, assignments
+	serverRBACEngine  *rbac.Engine       // rbac.Engine wrapping serverRBACKV
+	serverBodiesKV    jetstream.KeyValue // SERVER_BODIES    - message bodies (#330 phase 4c)
+	serverReactionsKV jetstream.KeyValue // SERVER_REACTIONS - emoji reactions (#330 phase 4c)
+	serverThreadsKV   jetstream.KeyValue // SERVER_THREADS   - thread metadata (#330 phase 4c)
 
-	// Legacy per-space metadata caches. Still in use for the DM space until
-	// its fold-in. Non-DM spaces route directly to the server-level buckets
-	// above and don't populate these caches.
-	spaceConfigKV    *lazycache.Cache[jetstream.KeyValue]      // SPACE_{id}_CONFIG - rooms, memberships (DM only post-phase-4a)
-	spaceRuntimeKV   *lazycache.Cache[jetstream.KeyValue]      // SPACE_{id}_RUNTIME - sequences, timestamps, read status (DM only post-phase-4a)
-	spaceRBACKV      *lazycache.Cache[jetstream.KeyValue]      // SPACE_{id}_RBAC - roles, permissions, assignments (DM only post-phase-4a)
-	spaceRBACEngines *lazycache.Cache[*rbac.Engine]            // Cached rbac.Engine instances per space (DM only post-phase-4a)
-	bodiesKV         *lazycache.Cache[jetstream.KeyValue]      // SPACE_{id}_BODIES - message bodies
+	// Legacy per-space caches. Still backing non-primary, non-DM spaces.
+	// Primary and DM access route to the server-level buckets above and
+	// don't populate these caches.
+	spaceConfigKV    *lazycache.Cache[jetstream.KeyValue]      // SPACE_{id}_CONFIG
+	spaceRuntimeKV   *lazycache.Cache[jetstream.KeyValue]      // SPACE_{id}_RUNTIME
+	spaceRBACKV      *lazycache.Cache[jetstream.KeyValue]      // SPACE_{id}_RBAC
+	spaceRBACEngines *lazycache.Cache[*rbac.Engine]            // Cached rbac.Engine instances per space
+	bodiesKV         *lazycache.Cache[jetstream.KeyValue]      // SPACE_{id}_BODIES
 	attachments      *lazycache.Cache[jetstream.ObjectStore]   // SPACE_{id}_ASSETS - message attachments
-	reactionsKV      *lazycache.Cache[jetstream.KeyValue]      // SPACE_{id}_REACTIONS - emoji reactions
-	threadsKV        *lazycache.Cache[jetstream.KeyValue]      // SPACE_{id}_THREADS - thread metadata
+	reactionsKV      *lazycache.Cache[jetstream.KeyValue]      // SPACE_{id}_REACTIONS
+	threadsKV        *lazycache.Cache[jetstream.KeyValue]      // SPACE_{id}_THREADS
 	presenceKV            jetstream.KeyValue     // Instance-level presence bucket
 	imageCacheStore       jetstream.ObjectStore  // Optional: cached resized images (nil if disabled)
 	notificationsKV       jetstream.KeyValue     // User notifications with TTL
@@ -613,10 +615,10 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		return nil, fmt.Errorf("failed to create CALL_STATE KV bucket: %w", err)
 	}
 
-	// Initialize server-level metadata buckets (#330 phase 4a).
-	// SERVER_CONFIG, SERVER_RBAC, SERVER_RUNTIME are shared across all
-	// non-DM spaces. DM space data lives in SPACE_DM_* until a later phase
-	// folds it in.
+	// Initialize server-level KV buckets (#330 phase 4a, 4b, 4c). These hold
+	// the deployment-wide primary + DM data. Non-primary, non-DM spaces
+	// (test-created only in practice) keep their per-space SPACE_{id}_*
+	// buckets.
 	serverConfigKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
 		Bucket:      "SERVER_CONFIG",
 		Description: "Server-level configuration (rooms, memberships)",
@@ -647,6 +649,36 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		return nil, fmt.Errorf("failed to create SERVER_RUNTIME KV bucket: %w", err)
 	}
 
+	serverBodiesKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:      "SERVER_BODIES",
+		Description: "Server-level message bodies",
+		Storage:     jetstream.FileStorage,
+		Replicas:    cfg.Replicas,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SERVER_BODIES KV bucket: %w", err)
+	}
+
+	serverReactionsKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:      "SERVER_REACTIONS",
+		Description: "Server-level emoji reactions",
+		Storage:     jetstream.FileStorage,
+		Replicas:    cfg.Replicas,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SERVER_REACTIONS KV bucket: %w", err)
+	}
+
+	serverThreadsKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:      "SERVER_THREADS",
+		Description: "Server-level thread metadata",
+		Storage:     jetstream.FileStorage,
+		Replicas:    cfg.Replicas,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SERVER_THREADS KV bucket: %w", err)
+	}
+
 	// Initialize auth tokens KV bucket with configurable TTL
 	// Stores opaque bearer tokens for cross-origin API authentication.
 	// NATS TTL handles automatic token expiry.
@@ -673,9 +705,12 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		encryptionKV:     encryptionKV,
 		instanceRBACKV:   instanceRBACKV,
 		instanceConfigKV: instanceConfigKV,
-		serverConfigKV:   serverConfigKV,
-		serverRBACKV:     serverRBACKV,
-		serverRuntimeKV:  serverRuntimeKV,
+		serverConfigKV:    serverConfigKV,
+		serverRBACKV:      serverRBACKV,
+		serverRuntimeKV:   serverRuntimeKV,
+		serverBodiesKV:    serverBodiesKV,
+		serverReactionsKV: serverReactionsKV,
+		serverThreadsKV:   serverThreadsKV,
 		// serverRBACEngine is constructed below (after the storage value
 		// exists) and assigned in NewChattoCore so it can use the same engine
 		// configuration as the per-space engines.
@@ -927,10 +962,19 @@ func (c *ChattoCore) getSpaceRuntimeKV(ctx context.Context, spaceID string) (jet
 	})
 }
 
-// getSpaceBodiesKV retrieves or creates the BODIES bucket for a space.
-// The bucket stores message bodies, separated from the main space bucket for
-// performance, scaling, and operational flexibility.
+// getSpaceBodiesKV retrieves the BODIES bucket for a space.
+//
+// Post-#330 phase 4c: the primary and DM spaces share `SERVER_BODIES`.
+// Other spaces (test-created only in practice) keep their per-space
+// `SPACE_{id}_BODIES` bucket. Body keys (`{userID}.{eventID}`) don't carry
+// kind because both IDs are globally unique.
 func (c *ChattoCore) getSpaceBodiesKV(ctx context.Context, spaceID string) (jetstream.KeyValue, error) {
+	if c.usesServerLevelMetadata(spaceID) {
+		if _, err := c.GetSpace(ctx, spaceID); err != nil {
+			return nil, fmt.Errorf("space %s does not exist: %w", spaceID, err)
+		}
+		return c.storage.serverBodiesKV, nil
+	}
 	return c.storage.bodiesKV.GetOrCreate(spaceID, func() (jetstream.KeyValue, error) {
 		if _, err := c.GetSpace(ctx, spaceID); err != nil {
 			return nil, fmt.Errorf("space %s does not exist: %w", spaceID, err)
@@ -971,9 +1015,19 @@ func (c *ChattoCore) getSpaceAttachments(ctx context.Context, spaceID string) (j
 	})
 }
 
-// getSpaceReactionsKV retrieves or creates the REACTIONS bucket for a space.
-// The bucket stores emoji reactions to messages.
+// getSpaceReactionsKV retrieves the REACTIONS bucket for a space.
+//
+// Post-#330 phase 4c: the primary and DM spaces share `SERVER_REACTIONS`.
+// Other spaces keep their per-space `SPACE_{id}_REACTIONS`. Keys
+// (`{eventID}.{emojiName}.{userID}`) are globally unique on event ID; no
+// kind segment needed.
 func (c *ChattoCore) getSpaceReactionsKV(ctx context.Context, spaceID string) (jetstream.KeyValue, error) {
+	if c.usesServerLevelMetadata(spaceID) {
+		if _, err := c.GetSpace(ctx, spaceID); err != nil {
+			return nil, fmt.Errorf("space %s does not exist: %w", spaceID, err)
+		}
+		return c.storage.serverReactionsKV, nil
+	}
 	return c.storage.reactionsKV.GetOrCreate(spaceID, func() (jetstream.KeyValue, error) {
 		if _, err := c.GetSpace(ctx, spaceID); err != nil {
 			return nil, fmt.Errorf("space %s does not exist: %w", spaceID, err)
@@ -992,9 +1046,19 @@ func (c *ChattoCore) getSpaceReactionsKV(ctx context.Context, spaceID string) (j
 	})
 }
 
-// getSpaceThreadsKV retrieves or creates the THREADS bucket for a space.
-// The bucket contains thread metadata (reply count, last reply time, participants).
+// getSpaceThreadsKV retrieves the THREADS bucket for a space.
+//
+// Post-#330 phase 4c: the primary and DM spaces share `SERVER_THREADS`.
+// Other spaces keep their per-space `SPACE_{id}_THREADS`. Keys
+// (`{roomID}.{rootEventID}`) are globally unique on room ID; no kind
+// segment needed.
 func (c *ChattoCore) getSpaceThreadsKV(ctx context.Context, spaceID string) (jetstream.KeyValue, error) {
+	if c.usesServerLevelMetadata(spaceID) {
+		if _, err := c.GetSpace(ctx, spaceID); err != nil {
+			return nil, fmt.Errorf("space %s does not exist: %w", spaceID, err)
+		}
+		return c.storage.serverThreadsKV, nil
+	}
 	return c.storage.threadsKV.GetOrCreate(spaceID, func() (jetstream.KeyValue, error) {
 		if _, err := c.GetSpace(ctx, spaceID); err != nil {
 			return nil, fmt.Errorf("space %s does not exist: %w", spaceID, err)

--- a/cli/internal/core/schema_migration.go
+++ b/cli/internal/core/schema_migration.go
@@ -51,6 +51,11 @@ const (
 	// as phase 4a. The cleanup follow-up deletes both markers along with the
 	// legacy SPACE_* resources.
 	phase4bCompleteKey = "migration.phase4b_complete"
+
+	// phase4cCompleteKey marks phase 4c as done. Phase 4c migrates the
+	// per-message KV buckets (BODIES, REACTIONS, THREADS) for primary +
+	// DM into the deployment-wide SERVER_* equivalents.
+	phase4cCompleteKey = "migration.phase4c_complete"
 )
 
 // RunMigrationsIfNeeded runs any pending schema migrations. Idempotent and
@@ -68,6 +73,9 @@ func (c *ChattoCore) RunMigrationsIfNeeded(ctx context.Context, primarySpaceID s
 		return err
 	}
 	if err := c.runPhase4bIfNeeded(ctx); err != nil {
+		return err
+	}
+	if err := c.runPhase4cIfNeeded(ctx, primarySpaceID); err != nil {
 		return err
 	}
 	return nil
@@ -392,6 +400,105 @@ func dmConfigKeyToServerKey(key string) string {
 	return key
 }
 
+// runPhase4cIfNeeded folds the per-message KV buckets (BODIES, REACTIONS,
+// THREADS) for the primary and DM spaces into the deployment-wide
+// SERVER_BODIES / SERVER_REACTIONS / SERVER_THREADS buckets.
+//
+// Keys are copied verbatim — the existing key formats (`{userID}.{eventID}`
+// for bodies, `{eventID}.{emojiName}.{userID}` for reactions, and
+// `{roomID}.{rootEventID}` for threads) are already keyed on globally-unique
+// IDs, so no rewriting is needed.
+//
+// Idempotent (Create + ErrKeyExists swallowed). Source data left intact
+// per the no-deletes rule. Verify-after-copy aborts before the marker if
+// counts don't line up.
+func (c *ChattoCore) runPhase4cIfNeeded(ctx context.Context, primarySpaceID string) error {
+	if done, err := c.isMigrationComplete(ctx, phase4cCompleteKey); err != nil {
+		return fmt.Errorf("phase4c: check completion marker: %w", err)
+	} else if done {
+		return nil
+	}
+
+	release, err := c.acquireMigrationLock(ctx)
+	if err != nil {
+		return fmt.Errorf("phase4c: acquire lock: %w", err)
+	}
+	defer release()
+
+	if done, err := c.isMigrationComplete(ctx, phase4cCompleteKey); err != nil {
+		return fmt.Errorf("phase4c: re-check completion marker: %w", err)
+	} else if done {
+		return nil
+	}
+
+	c.logger.Info("phase4c: migrating per-message KVs (BODIES/REACTIONS/THREADS) to SERVER_*",
+		"primary_space_id", primarySpaceID)
+
+	// Copy primary's per-message KVs (skipped if no primary, or no legacy
+	// buckets to copy from — copyKVBucket handles a missing source).
+	if primarySpaceID != "" {
+		if err := c.copyKVBucket(ctx, legacySpaceBodiesBucket(primarySpaceID), c.storage.serverBodiesKV, "PRIMARY_BODIES"); err != nil {
+			return fmt.Errorf("phase4c: copy primary bodies: %w", err)
+		}
+		if err := c.copyKVBucket(ctx, legacySpaceReactionsBucket(primarySpaceID), c.storage.serverReactionsKV, "PRIMARY_REACTIONS"); err != nil {
+			return fmt.Errorf("phase4c: copy primary reactions: %w", err)
+		}
+		if err := c.copyKVBucket(ctx, legacySpaceThreadsBucket(primarySpaceID), c.storage.serverThreadsKV, "PRIMARY_THREADS"); err != nil {
+			return fmt.Errorf("phase4c: copy primary threads: %w", err)
+		}
+	}
+
+	// Copy DM per-message KVs.
+	if err := c.copyKVBucket(ctx, legacySpaceBodiesBucket(DMSpaceID), c.storage.serverBodiesKV, "DM_BODIES"); err != nil {
+		return fmt.Errorf("phase4c: copy DM bodies: %w", err)
+	}
+	if err := c.copyKVBucket(ctx, legacySpaceReactionsBucket(DMSpaceID), c.storage.serverReactionsKV, "DM_REACTIONS"); err != nil {
+		return fmt.Errorf("phase4c: copy DM reactions: %w", err)
+	}
+	if err := c.copyKVBucket(ctx, legacySpaceThreadsBucket(DMSpaceID), c.storage.serverThreadsKV, "DM_THREADS"); err != nil {
+		return fmt.Errorf("phase4c: copy DM threads: %w", err)
+	}
+
+	if err := c.verifyPhase4c(ctx, primarySpaceID); err != nil {
+		return fmt.Errorf("phase4c: verify: %w", err)
+	}
+
+	if err := c.markMigrationComplete(ctx, phase4cCompleteKey); err != nil {
+		return fmt.Errorf("phase4c: mark complete: %w", err)
+	}
+
+	c.logger.Info("phase4c: migration complete")
+	return nil
+}
+
+// verifyPhase4c walks the source per-message buckets for primary and DM,
+// confirming every key landed in the corresponding SERVER_* target.
+func (c *ChattoCore) verifyPhase4c(ctx context.Context, primarySpaceID string) error {
+	type pair struct {
+		sourceBucketName string
+		target           jetstream.KeyValue
+		tag              string
+	}
+	pairs := []pair{
+		{legacySpaceBodiesBucket(DMSpaceID), c.storage.serverBodiesKV, "DM_BODIES"},
+		{legacySpaceReactionsBucket(DMSpaceID), c.storage.serverReactionsKV, "DM_REACTIONS"},
+		{legacySpaceThreadsBucket(DMSpaceID), c.storage.serverThreadsKV, "DM_THREADS"},
+	}
+	if primarySpaceID != "" {
+		pairs = append(pairs,
+			pair{legacySpaceBodiesBucket(primarySpaceID), c.storage.serverBodiesKV, "PRIMARY_BODIES"},
+			pair{legacySpaceReactionsBucket(primarySpaceID), c.storage.serverReactionsKV, "PRIMARY_REACTIONS"},
+			pair{legacySpaceThreadsBucket(primarySpaceID), c.storage.serverThreadsKV, "PRIMARY_THREADS"},
+		)
+	}
+	for _, p := range pairs {
+		if err := c.verifyKVBucketCopy(ctx, p.sourceBucketName, p.target, p.tag); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // isMigrationComplete returns true if the given completion marker key exists
 // in `KV_INSTANCE`.
 func (c *ChattoCore) isMigrationComplete(ctx context.Context, markerKey string) (bool, error) {
@@ -623,4 +730,16 @@ func legacySpaceRBACBucket(spaceID string) string {
 
 func legacySpaceRuntimeBucket(spaceID string) string {
 	return fmt.Sprintf("SPACE_%s_RUNTIME", spaceID)
+}
+
+func legacySpaceBodiesBucket(spaceID string) string {
+	return fmt.Sprintf("SPACE_%s_BODIES", spaceID)
+}
+
+func legacySpaceReactionsBucket(spaceID string) string {
+	return fmt.Sprintf("SPACE_%s_REACTIONS", spaceID)
+}
+
+func legacySpaceThreadsBucket(spaceID string) string {
+	return fmt.Sprintf("SPACE_%s_THREADS", spaceID)
 }

--- a/cli/internal/core/schema_migration_test.go
+++ b/cli/internal/core/schema_migration_test.go
@@ -311,6 +311,161 @@ func TestPhase4bMigration_FreshInstall(t *testing.T) {
 	}
 }
 
+// TestPhase4cMigration_CopiesPerMessageKVs verifies that the phase 4c
+// migrator copies each per-message KV bucket (BODIES, REACTIONS, THREADS)
+// for both the primary and DM spaces into the matching SERVER_* bucket.
+// Keys are preserved verbatim — no kind segment, since IDs are globally
+// unique.
+func TestPhase4cMigration_CopiesPerMessageKVs(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	space, err := core.CreateSpace(ctx, "test-user", "Primary", "")
+	if err != nil {
+		t.Fatalf("CreateSpace: %v", err)
+	}
+
+	// Seed legacy per-space buckets with representative keys for primary
+	// and DM. We bypass the public API and write directly to the bucket
+	// so the migration has something to copy.
+	primaryBodies, err := core.js.KeyValue(ctx, legacySpaceBodiesBucket(space.Id))
+	if err != nil {
+		t.Fatalf("open primary BODIES: %v", err)
+	}
+	if _, err := primaryBodies.Put(ctx, "Uuser1.Eevent1", []byte("body-primary-1")); err != nil {
+		t.Fatalf("seed primary body: %v", err)
+	}
+
+	primaryReactions, err := core.js.KeyValue(ctx, legacySpaceReactionsBucket(space.Id))
+	if err != nil {
+		t.Fatalf("open primary REACTIONS: %v", err)
+	}
+	if _, err := primaryReactions.Put(ctx, "Eevent1.thumbsup.Uuser1", []byte("0")); err != nil {
+		t.Fatalf("seed primary reaction: %v", err)
+	}
+
+	primaryThreads, err := core.js.KeyValue(ctx, legacySpaceThreadsBucket(space.Id))
+	if err != nil {
+		t.Fatalf("open primary THREADS: %v", err)
+	}
+	if _, err := primaryThreads.Put(ctx, "Rroom1.Eroot1", []byte("thread-primary")); err != nil {
+		t.Fatalf("seed primary thread: %v", err)
+	}
+
+	dmBodies, err := core.js.KeyValue(ctx, legacySpaceBodiesBucket(DMSpaceID))
+	if err != nil {
+		t.Fatalf("open DM BODIES: %v", err)
+	}
+	if _, err := dmBodies.Put(ctx, "Uuser2.Eevent2", []byte("body-dm-1")); err != nil {
+		t.Fatalf("seed DM body: %v", err)
+	}
+
+	core.SetPrimarySpaceID(space.Id)
+	if err := core.RunMigrationsIfNeeded(ctx, space.Id); err != nil {
+		t.Fatalf("RunMigrationsIfNeeded: %v", err)
+	}
+
+	// Verify keys landed in SERVER_*.
+	if entry, err := core.storage.serverBodiesKV.Get(ctx, "Uuser1.Eevent1"); err != nil {
+		t.Fatalf("primary body missing in SERVER_BODIES: %v", err)
+	} else if string(entry.Value()) != "body-primary-1" {
+		t.Errorf("primary body value mismatch: %q", entry.Value())
+	}
+
+	if entry, err := core.storage.serverBodiesKV.Get(ctx, "Uuser2.Eevent2"); err != nil {
+		t.Fatalf("DM body missing in SERVER_BODIES: %v", err)
+	} else if string(entry.Value()) != "body-dm-1" {
+		t.Errorf("DM body value mismatch: %q", entry.Value())
+	}
+
+	if _, err := core.storage.serverReactionsKV.Get(ctx, "Eevent1.thumbsup.Uuser1"); err != nil {
+		t.Fatalf("primary reaction missing in SERVER_REACTIONS: %v", err)
+	}
+
+	if _, err := core.storage.serverThreadsKV.Get(ctx, "Rroom1.Eroot1"); err != nil {
+		t.Fatalf("primary thread missing in SERVER_THREADS: %v", err)
+	}
+
+	// Marker set.
+	if _, err := core.storage.instanceKV.Get(ctx, phase4cCompleteKey); err != nil {
+		t.Fatalf("expected phase4c completion marker: %v", err)
+	}
+
+	// Source data left intact (no-deletes rule).
+	if _, err := primaryBodies.Get(ctx, "Uuser1.Eevent1"); err != nil {
+		t.Errorf("source primary body should still exist: %v", err)
+	}
+	if _, err := dmBodies.Get(ctx, "Uuser2.Eevent2"); err != nil {
+		t.Errorf("source DM body should still exist: %v", err)
+	}
+}
+
+// TestPhase4cMigration_FreshInstall verifies the phase 4c migrator runs
+// cleanly on a fresh install with no per-message data (just the initial
+// DM space buckets that initDMSpace creates as empty).
+func TestPhase4cMigration_FreshInstall(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	if err := core.RunMigrationsIfNeeded(ctx, ""); err != nil {
+		t.Fatalf("RunMigrationsIfNeeded: %v", err)
+	}
+	if _, err := core.storage.instanceKV.Get(ctx, phase4cCompleteKey); err != nil {
+		t.Fatalf("expected phase4c completion marker: %v", err)
+	}
+
+	// Re-run is a fast no-op via the marker.
+	if err := core.RunMigrationsIfNeeded(ctx, ""); err != nil {
+		t.Fatalf("second run failed: %v", err)
+	}
+}
+
+// TestPhase4cMigration_PerMessageRoutingAfterMigration verifies that once
+// the primary is set and migration has run, the per-message bucket
+// getters route the primary and DM spaces to SERVER_* (not the legacy
+// per-space buckets).
+func TestPhase4cMigration_PerMessageRoutingAfterMigration(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	space, err := core.CreateSpace(ctx, "test-user", "Primary", "")
+	if err != nil {
+		t.Fatalf("CreateSpace: %v", err)
+	}
+	core.SetPrimarySpaceID(space.Id)
+	if err := core.RunMigrationsIfNeeded(ctx, space.Id); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		spaceID string
+		getter  func(ctx context.Context, spaceID string) (jetstream.KeyValue, error)
+		want    string
+	}{
+		{"primary BODIES", space.Id, core.getSpaceBodiesKV, "SERVER_BODIES"},
+		{"primary REACTIONS", space.Id, core.getSpaceReactionsKV, "SERVER_REACTIONS"},
+		{"primary THREADS", space.Id, core.getSpaceThreadsKV, "SERVER_THREADS"},
+		{"DM BODIES", DMSpaceID, core.getSpaceBodiesKV, "SERVER_BODIES"},
+		{"DM REACTIONS", DMSpaceID, core.getSpaceReactionsKV, "SERVER_REACTIONS"},
+		{"DM THREADS", DMSpaceID, core.getSpaceThreadsKV, "SERVER_THREADS"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bucket, err := tc.getter(ctx, tc.spaceID)
+			if err != nil {
+				t.Fatalf("getter: %v", err)
+			}
+			status, err := bucket.Status(ctx)
+			if err != nil {
+				t.Fatalf("Status: %v", err)
+			}
+			if status.Bucket() != tc.want {
+				t.Errorf("expected %q, got %q", tc.want, status.Bucket())
+			}
+		})
+	}
+}
+
 // snapshotKeys returns the set of keys in the named bucket. Helper for the
 // tests above; doesn't fail on missing-bucket so callers can probe.
 func snapshotKeys(t *testing.T, ctx context.Context, core *ChattoCore, bucketName string) map[string]struct{} {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -511,6 +511,9 @@ All live events bypass JetStream entirely — KV buckets are the source of truth
 | `SERVER_CONFIG`               | Server    | File    | Yes      | Rooms (channel + DM), memberships               |
 | `SERVER_RBAC`                 | Server    | File    | Yes      | Roles, permissions, assignments                 |
 | `SERVER_RUNTIME`              | Server    | File    | Yes      | Read state, mention tracking                    |
+| `SERVER_BODIES`               | Server    | File    | Yes      | Message bodies (GDPR-compliant)                 |
+| `SERVER_REACTIONS`            | Server    | File    | Yes      | Emoji reactions on messages                     |
+| `SERVER_THREADS`              | Server    | File    | Yes      | Thread metadata (reply count, participants)     |
 | `NOTIFICATIONS`               | Instance  | File    | Yes      | User notifications (90-day TTL)                 |
 | `AUTH_TOKENS`                 | Instance  | File    | No       | Bearer auth tokens (configurable TTL, default 90d) |
 | `USER_PRESENCE`               | Instance  | Memory  | No       | User presence status (TTL 60s)                  |
@@ -520,7 +523,7 @@ All live events bypass JetStream entirely — KV buckets are the source of truth
 | `SPACE_{spaceId}_THREADS`     | Per-space | File    | Yes      | Thread metadata (reply count, participants)     |
 | `LINK_PREVIEW_CACHE`          | Instance  | File    | No       | Cached link preview metadata (48h TTL)          |
 
-**Migration note (#330 / ADR-027 phase 4a + 4b):** the primary space's CONFIG/RBAC/RUNTIME data and the DM system space's CONFIG/RUNTIME data were folded into `SERVER_*`. The legacy `SPACE_{primary}_CONFIG`/`_RBAC`/`_RUNTIME` and `SPACE_DM_CONFIG`/`_RUNTIME` buckets are still present (no-deletes rule) but dormant — reads route to `SERVER_*`. A future cleanup pass will retire them. Per-space `BODIES`/`REACTIONS`/`THREADS`/`ASSETS` are still per-space; later sub-phases fold those in too.
+**Migration note (#330 / ADR-027 phase 4a–4c):** the primary space's CONFIG/RBAC/RUNTIME/BODIES/REACTIONS/THREADS data and the DM system space's CONFIG/RUNTIME/BODIES/REACTIONS/THREADS data were folded into `SERVER_*`. The legacy `SPACE_{primary}_*` and `SPACE_DM_*` buckets are still present (no-deletes rule) but dormant — reads route to `SERVER_*`. A future cleanup pass will retire them. Per-space `ASSETS` (object store) is still per-space; later sub-phases fold those in too.
 
 **INSTANCE keys:**
 
@@ -543,6 +546,7 @@ All live events bypass JetStream entirely — KV buckets are the source of truth
 | `migration_lock`                       | Schema-migration mutex (per-key TTL'd, owner ID as value) — see #330 phase 4 |
 | `migration.phase4a_complete`           | Phase 4a (primary CONFIG/RBAC/RUNTIME → `SERVER_*`) completion marker |
 | `migration.phase4b_complete`           | Phase 4b (DM merge + kind-prefixed keys) completion marker |
+| `migration.phase4c_complete`           | Phase 4c (per-message KVs: BODIES/REACTIONS/THREADS → `SERVER_*`) completion marker |
 
 Notes: Email verification uses SHA256 hashing for claim keys to ensure valid NATS subject characters and case-insensitive uniqueness. The claim key is created atomically when an email is verified, preventing race conditions where two users try to verify the same email. Verification tokens store userId and email in the JSON value for O(1) lookup by token.
 
@@ -656,15 +660,15 @@ These keys don't carry a kind segment — `roomId` is globally unique, so direct
 
 Notes: Memory-based storage (not persisted). 60-second TTL with 30-second client refresh. Uses `LimitMarkerTTL` so NATS emits delete markers on TTL expiry, allowing watchers to detect offline transitions. A single per-process **PresenceHub** watches `presence.>` and fans out updates to all space subscriptions (reducing KV watcher count from O(subscriptions) to O(1)). Subscriptions filter by space membership using a lazy positive-only cache. **Multi-device support**: On disconnect, clients stop refreshing but don't explicitly delete—TTL handles expiry. This means a user stays online if any device is still connected. **Event deduplication**: Presence events are only emitted when status actually changes (online→away, etc.), not on refresh cycles. **Client-driven status**: The `updateMyPresence` mutation allows clients to set AWAY or DO_NOT_DISTURB; heartbeat refreshes use optimistic locking to preserve these statuses.
 
-**SPACE\_{spaceId}\_BODIES keys:**
+**SERVER\_BODIES keys:**
 
 | Key                    | Description                                              |
 | ---------------------- | -------------------------------------------------------- |
 | `{userId}.{eventId}`   | Message body keyed by user ID and event ID               |
 
-Notes: The compound key format `{userId}.{eventId}` enables efficient prefix-based deletion for GDPR compliance (delete all messages for a user via prefix scan). Separated from metadata for performance and operational flexibility.
+Notes: The compound key format `{userId}.{eventId}` enables efficient prefix-based deletion for GDPR compliance (delete all messages for a user via prefix scan). Separated from metadata for performance and operational flexibility. No `kind` segment — both IDs are globally unique NanoIDs.
 
-**SPACE\_{spaceId}\_REACTIONS keys:**
+**SERVER\_REACTIONS keys:**
 
 | Key                                     | Description                                    |
 | --------------------------------------- | ---------------------------------------------- |
@@ -672,7 +676,7 @@ Notes: The compound key format `{userId}.{eventId}` enables efficient prefix-bas
 
 Notes: Emoji stored as name (e.g., "thumbsup") for NATS KV key compatibility. Separated for load isolation (high-volume). Events are live-only (not stored in JetStream). KV bucket is source of truth. Keyed by event ID (not the volatile JetStream sequence) so reactions survive any future stream re-publishing.
 
-**SPACE\_{spaceId}\_THREADS keys:**
+**SERVER\_THREADS keys:**
 
 | Key                       | Description                                              |
 | ------------------------- | -------------------------------------------------------- |


### PR DESCRIPTION
## Summary

Third sub-phase of #354. Folds the BODIES, REACTIONS, and THREADS per-message KV buckets for the primary and DM spaces into the deployment-wide \`SERVER_BODIES\` / \`SERVER_REACTIONS\` / \`SERVER_THREADS\` buckets. Keys are preserved verbatim — they're already keyed on globally-unique NanoIDs (\`{userID}.{eventID}\`, \`{eventID}.{emojiName}.{userID}\`, \`{roomID}.{rootEventID}\`), so no kind segment is needed; nothing iterates these in a kind-filtered way.

The per-message bucket-getters return the shared \`SERVER_*\` bucket for primary and DM; non-primary, non-DM (test-created only in practice) spaces continue using per-space \`SPACE_{id}_*\` via lazycache. Migrator \`runPhase4cIfNeeded\` copies primary's + DM's contents into \`SERVER_*\` with the same lock + idempotency + verify-after-copy pattern as 4a/4b.

New marker \`migration.phase4c_complete\` in \`KV_INSTANCE\`. Source data left intact per the no-deletes rule. \`ARCHITECTURE.md\` bucket inventory + per-bucket key tables updated.

Refs #330, #354.

## Test plan

- [x] \`mise test-cli\` — only the documented pre-existing \`TestAuthRoutes_TestEmailEndpoint\` fails. Three new tests cover the happy-path copy, the fresh-install no-op, and post-migration routing for primary + DM.
- [ ] Backup before deploying to any production instance.