### PR TITLE
fix(e2e): w=2 workers + idempotent logout-dialog click retry

### DIFF
--- a/frontend/e2e/instance-flows.test.ts
+++ b/frontend/e2e/instance-flows.test.ts
@@ -219,12 +219,17 @@ test.describe('Sign Out', () => {
 		await createAndLoginTestUser(page);
 		await chatPage.goto();
 
-		// Click the sign out button in the header
-		await page.getByTitle('Sign Out').click();
-
-		// Confirmation dialog should appear
+		// Retry the click idempotently: the button can be visually hydrated
+		// before Svelte attaches its onclick handler, so the first click
+		// can be dropped. We only re-click if the dialog isn't open yet,
+		// to avoid clicking through an already-open dialog.
 		const dialog = page.getByRole('dialog');
-		await expect(dialog).toBeVisible({ timeout: TIMEOUTS.UI_FAST });
+		await expect(async () => {
+			if (!(await dialog.isVisible())) {
+				await page.getByTitle('Sign Out').click();
+			}
+			await expect(dialog).toBeVisible({ timeout: 1000 });
+		}).toPass({ timeout: TIMEOUTS.REALTIME_EVENT, intervals: [200, 500, 1000] });
 
 		// Confirm sign out
 		await dialog.getByRole('button', { name: 'Sign Out' }).click();

--- a/frontend/e2e/pages/AuthPage.ts
+++ b/frontend/e2e/pages/AuthPage.ts
@@ -297,12 +297,27 @@ export class AuthPage {
   }
 
   /**
+   * Open the logout confirmation dialog. Idempotent: if the dialog is already
+   * open, this is a no-op. Otherwise it clicks the Sign Out button and retries
+   * the click if the first attempt didn't open the dialog (Svelte hydration
+   * race: actionability checks pass before onclick is attached, so the first
+   * click can be dropped).
+   */
+  private async openLogoutDialog(): Promise<void> {
+    await expect(async () => {
+      if (!(await this.logoutDialog.isVisible())) {
+        await this.logoutButton.click();
+      }
+      await expect(this.logoutDialog).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: TIMEOUTS.REALTIME_EVENT, intervals: [200, 500, 1000] });
+  }
+
+  /**
    * Logout the current user by clicking the logout button.
    * Confirms the logout dialog and waits for redirect to home page.
    */
   async logoutViaUI(): Promise<void> {
-    await this.logoutButton.click();
-    await expect(this.logoutDialog).toBeVisible();
+    await this.openLogoutDialog();
     await this.confirmLogoutButton.click();
     await this.page.waitForURL('/');
   }
@@ -312,8 +327,7 @@ export class AuthPage {
    * Verifies the dialog closes without logging out.
    */
   async cancelLogoutViaUI(): Promise<void> {
-    await this.logoutButton.click();
-    await expect(this.logoutDialog).toBeVisible();
+    await this.openLogoutDialog();
     await this.cancelLogoutButton.click();
     await expect(this.logoutDialog).not.toBeVisible();
   }

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
   maxFailures: 5,
   timeout: 30_000,
-  workers: 2,
+  workers: 4,
   expect: {
     timeout: 15_000
   },

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
   maxFailures: 5,
   timeout: 30_000,
-  workers: 4,
+  workers: 2,
   expect: {
     timeout: 15_000
   },


### PR DESCRIPTION
## Summary

Follow-up to #375. After the deterministic flakes were fixed, residual flakes were worker-contention noise (different tests each run). Two changes:

- **`playwright.config.ts`**: `workers: 4 → 2`. Trades ~50% wall-time (4m→6.5m) for ~60% fewer flakes per run on average, with hard failures held at 0.
- **`AuthPage` + `instance-flows.test.ts`**: harden the Sign-Out button click against the same Svelte hydration race as quick-switcher's Cmd+K (actionability passes before the onclick is attached, so the first click can be dropped). Wrap in `toPass()` but make the click **idempotent** — only re-click if the dialog isn't already open. Without that guard, a slow first dialog mount would trigger a second click that toggles the dialog, breaking `cancelLogoutViaUI`'s "dialog closed" assertion (a regression I caught and fixed in this PR). Click-retry logic extracted into a shared `openLogoutDialog()` helper.

## Test plan

- [x] Full suite × 6 at w=2: 0 hard failures, 1-3 flakes/run (different tests each, all real-time subscription delivery, absorbed by retries)
- [x] `auth.test.ts` + `password-reset.test.ts` + `instance-flows.test.ts` × 1 with `--retries=0`: 56/56 clean