### PR TITLE
feat(migration): phase 4e — per-space attachments → SERVER_ASSETS (#354)

### DIFF
--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -464,16 +464,17 @@ type storage struct {
 	instanceRBACKV   jetstream.KeyValue // Instance-level roles and permissions
 	instanceConfigKV jetstream.KeyValue // Runtime configuration overrides
 
-	// Server-level KV buckets (#330 phase 4a, 4b, 4c). Shared by the primary
+	// Server-level KV buckets (#330 phase 4a, 4b, 4c, 4e). Shared by the primary
 	// and DM spaces; non-primary, non-DM spaces (test-created only in
 	// practice) keep their per-space lazycaches below.
-	serverConfigKV    jetstream.KeyValue // SERVER_CONFIG    - rooms, memberships
-	serverRuntimeKV   jetstream.KeyValue // SERVER_RUNTIME   - sequences, timestamps, read state
-	serverRBACKV      jetstream.KeyValue // SERVER_RBAC      - roles, permissions, assignments
-	serverRBACEngine  *rbac.Engine       // rbac.Engine wrapping serverRBACKV
-	serverBodiesKV    jetstream.KeyValue // SERVER_BODIES    - message bodies (#330 phase 4c)
-	serverReactionsKV jetstream.KeyValue // SERVER_REACTIONS - emoji reactions (#330 phase 4c)
-	serverThreadsKV   jetstream.KeyValue // SERVER_THREADS   - thread metadata (#330 phase 4c)
+	serverConfigKV     jetstream.KeyValue    // SERVER_CONFIG    - rooms, memberships
+	serverRuntimeKV    jetstream.KeyValue    // SERVER_RUNTIME   - sequences, timestamps, read state
+	serverRBACKV       jetstream.KeyValue    // SERVER_RBAC      - roles, permissions, assignments
+	serverRBACEngine   *rbac.Engine          // rbac.Engine wrapping serverRBACKV
+	serverBodiesKV     jetstream.KeyValue    // SERVER_BODIES    - message bodies (#330 phase 4c)
+	serverReactionsKV  jetstream.KeyValue    // SERVER_REACTIONS - emoji reactions (#330 phase 4c)
+	serverThreadsKV    jetstream.KeyValue    // SERVER_THREADS   - thread metadata (#330 phase 4c)
+	serverAttachments  jetstream.ObjectStore // SERVER_ASSETS    - message attachments (#330 phase 4e)
 
 	// Legacy per-space caches. Still backing non-primary, non-DM spaces.
 	// Primary and DM access route to the server-level buckets above and
@@ -679,6 +680,17 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		return nil, fmt.Errorf("failed to create SERVER_THREADS KV bucket: %w", err)
 	}
 
+	serverAttachments, err := js.CreateOrUpdateObjectStore(ctx, jetstream.ObjectStoreConfig{
+		Bucket:      "SERVER_ASSETS",
+		Description: "Server-level message attachments",
+		Storage:     jetstream.FileStorage,
+		Compression: true,
+		Replicas:    cfg.Replicas,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SERVER_ASSETS object store: %w", err)
+	}
+
 	// Initialize auth tokens KV bucket with configurable TTL
 	// Stores opaque bearer tokens for cross-origin API authentication.
 	// NATS TTL handles automatic token expiry.
@@ -711,6 +723,7 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		serverBodiesKV:    serverBodiesKV,
 		serverReactionsKV: serverReactionsKV,
 		serverThreadsKV:   serverThreadsKV,
+		serverAttachments: serverAttachments,
 		// serverRBACEngine is constructed below (after the storage value
 		// exists) and assigned in NewChattoCore so it can use the same engine
 		// configuration as the per-space engines.
@@ -995,7 +1008,17 @@ func (c *ChattoCore) getSpaceBodiesKV(ctx context.Context, spaceID string) (jets
 
 // getSpaceAttachments retrieves or creates the ASSETS ObjectStore for a space.
 // The bucket stores message attachment binaries with S2 compression.
+//
+// Post-#330 phase 4e: the primary and DM spaces share `SERVER_ASSETS`. Other
+// spaces keep their per-space `SPACE_{id}_ASSETS`. Attachment IDs are
+// globally unique, so keys are preserved verbatim — no kind segment needed.
 func (c *ChattoCore) getSpaceAttachments(ctx context.Context, spaceID string) (jetstream.ObjectStore, error) {
+	if c.usesServerLevelMetadata(spaceID) {
+		if _, err := c.GetSpace(ctx, spaceID); err != nil {
+			return nil, fmt.Errorf("space %s does not exist: %w", spaceID, err)
+		}
+		return c.storage.serverAttachments, nil
+	}
 	return c.storage.attachments.GetOrCreate(spaceID, func() (jetstream.ObjectStore, error) {
 		if _, err := c.GetSpace(ctx, spaceID); err != nil {
 			return nil, fmt.Errorf("space %s does not exist: %w", spaceID, err)

--- a/cli/internal/core/schema_migration.go
+++ b/cli/internal/core/schema_migration.go
@@ -56,6 +56,12 @@ const (
 	// per-message KV buckets (BODIES, REACTIONS, THREADS) for primary +
 	// DM into the deployment-wide SERVER_* equivalents.
 	phase4cCompleteKey = "migration.phase4c_complete"
+
+	// phase4eCompleteKey marks phase 4e as done. Phase 4e migrates the
+	// per-space attachment object stores (SPACE_{id}_ASSETS) for primary +
+	// DM into the deployment-wide SERVER_ASSETS object store. Keys
+	// (attachment IDs) are globally unique and copied verbatim.
+	phase4eCompleteKey = "migration.phase4e_complete"
 )
 
 // RunMigrationsIfNeeded runs any pending schema migrations. Idempotent and
@@ -76,6 +82,9 @@ func (c *ChattoCore) RunMigrationsIfNeeded(ctx context.Context, primarySpaceID s
 		return err
 	}
 	if err := c.runPhase4cIfNeeded(ctx, primarySpaceID); err != nil {
+		return err
+	}
+	if err := c.runPhase4eIfNeeded(ctx, primarySpaceID); err != nil {
 		return err
 	}
 	return nil
@@ -499,6 +508,206 @@ func (c *ChattoCore) verifyPhase4c(ctx context.Context, primarySpaceID string) e
 	return nil
 }
 
+// runPhase4eIfNeeded folds the per-space attachment object stores
+// (`SPACE_{primary}_ASSETS`, `SPACE_DM_ASSETS`) into the deployment-wide
+// `SERVER_ASSETS` object store.
+//
+// Attachment IDs are globally unique, so object names (which are the keys)
+// are copied verbatim — no rewriting needed. Headers (Content-Type,
+// Filename, Room-Id) are preserved on the target.
+//
+// Object stores have no `Create`-style atomic insert, only `Put`. Re-running
+// on partial state therefore re-uploads bytes for objects already on the
+// target. That's wasteful but idempotent in effect — same Name, same
+// content, same headers — and the verify-after-copy step still catches a
+// torn copy. Source data is left intact per the no-deletes rule.
+func (c *ChattoCore) runPhase4eIfNeeded(ctx context.Context, primarySpaceID string) error {
+	if done, err := c.isMigrationComplete(ctx, phase4eCompleteKey); err != nil {
+		return fmt.Errorf("phase4e: check completion marker: %w", err)
+	} else if done {
+		return nil
+	}
+
+	release, err := c.acquireMigrationLock(ctx)
+	if err != nil {
+		return fmt.Errorf("phase4e: acquire lock: %w", err)
+	}
+	defer release()
+
+	if done, err := c.isMigrationComplete(ctx, phase4eCompleteKey); err != nil {
+		return fmt.Errorf("phase4e: re-check completion marker: %w", err)
+	} else if done {
+		return nil
+	}
+
+	c.logger.Info("phase4e: migrating per-space attachments to SERVER_ASSETS",
+		"primary_space_id", primarySpaceID)
+
+	if primarySpaceID != "" {
+		if err := c.copyObjectStore(ctx, legacySpaceAssetsBucket(primarySpaceID), c.storage.serverAttachments, "PRIMARY_ASSETS"); err != nil {
+			return fmt.Errorf("phase4e: copy primary assets: %w", err)
+		}
+	}
+	if err := c.copyObjectStore(ctx, legacySpaceAssetsBucket(DMSpaceID), c.storage.serverAttachments, "DM_ASSETS"); err != nil {
+		return fmt.Errorf("phase4e: copy DM assets: %w", err)
+	}
+
+	if err := c.verifyPhase4e(ctx, primarySpaceID); err != nil {
+		return fmt.Errorf("phase4e: verify: %w", err)
+	}
+
+	if err := c.markMigrationComplete(ctx, phase4eCompleteKey); err != nil {
+		return fmt.Errorf("phase4e: mark complete: %w", err)
+	}
+
+	c.logger.Info("phase4e: migration complete")
+	return nil
+}
+
+// copyObjectStore copies every object from sourceBucketName into target.
+// Object stores have no atomic-insert primitive, so this re-uploads bytes
+// on re-runs; that's safe (same Name, same content) and the eventual
+// verify pass would catch a torn copy. logTag identifies the bucket type
+// in logs.
+func (c *ChattoCore) copyObjectStore(ctx context.Context, sourceBucketName string, target jetstream.ObjectStore, logTag string) error {
+	source, err := c.js.ObjectStore(ctx, sourceBucketName)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrBucketNotFound) {
+			c.logger.Debug("phase4e: source bucket missing, skipping",
+				"bucket", sourceBucketName, "tag", logTag)
+			return nil
+		}
+		return fmt.Errorf("open source bucket %s: %w", sourceBucketName, err)
+	}
+
+	infos, err := source.List(ctx)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoObjectsFound) {
+			return nil
+		}
+		return fmt.Errorf("list objects in %s: %w", sourceBucketName, err)
+	}
+
+	copied := 0
+	for _, info := range infos {
+		if info.Deleted {
+			continue
+		}
+		if err := c.copyOneObject(ctx, source, target, info); err != nil {
+			return err
+		}
+		copied++
+	}
+
+	c.logger.Info("phase4e: copied object store",
+		"source", sourceBucketName,
+		"tag", logTag,
+		"copied", copied,
+	)
+	return nil
+}
+
+// copyOneObject reads a single object from source and writes it to target,
+// preserving the object's metadata. The source reader is closed before
+// returning. ErrObjectNotFound on the read side is tolerated — the source is
+// supposed to be quiescent, but races between List and Get are accepted.
+func (c *ChattoCore) copyOneObject(ctx context.Context, source, target jetstream.ObjectStore, info *jetstream.ObjectInfo) error {
+	obj, err := source.Get(ctx, info.Name)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrObjectNotFound) {
+			return nil
+		}
+		return fmt.Errorf("read object %q: %w", info.Name, err)
+	}
+	defer obj.Close()
+	if _, err := target.Put(ctx, jetstream.ObjectMeta{
+		Name:        info.Name,
+		Description: info.Description,
+		Headers:     info.Headers,
+		Metadata:    info.Metadata,
+		Opts:        info.Opts,
+	}, obj); err != nil {
+		return fmt.Errorf("write object %q to target: %w", info.Name, err)
+	}
+	return nil
+}
+
+// verifyPhase4e walks the source object stores for primary and DM,
+// confirming every object is present in `SERVER_ASSETS`.
+func (c *ChattoCore) verifyPhase4e(ctx context.Context, primarySpaceID string) error {
+	sourceBuckets := []struct {
+		name string
+		tag  string
+	}{
+		{legacySpaceAssetsBucket(DMSpaceID), "DM_ASSETS"},
+	}
+	if primarySpaceID != "" {
+		sourceBuckets = append(sourceBuckets,
+			struct {
+				name string
+				tag  string
+			}{legacySpaceAssetsBucket(primarySpaceID), "PRIMARY_ASSETS"})
+	}
+	for _, src := range sourceBuckets {
+		if err := c.verifyObjectStoreCopy(ctx, src.name, c.storage.serverAttachments, src.tag); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// verifyObjectStoreCopy walks the source object store and confirms every
+// non-deleted object exists in the target.
+func (c *ChattoCore) verifyObjectStoreCopy(ctx context.Context, sourceBucketName string, target jetstream.ObjectStore, tag string) error {
+	source, err := c.js.ObjectStore(ctx, sourceBucketName)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrBucketNotFound) {
+			return nil
+		}
+		return fmt.Errorf("open source bucket %s for verify: %w", sourceBucketName, err)
+	}
+
+	infos, err := source.List(ctx)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoObjectsFound) {
+			return nil
+		}
+		return fmt.Errorf("list objects in %s for verify: %w", sourceBucketName, err)
+	}
+
+	var sourceCount, missingCount int
+	for _, info := range infos {
+		if info.Deleted {
+			continue
+		}
+		sourceCount++
+		if _, err := target.GetInfo(ctx, info.Name); err != nil {
+			if errors.Is(err, jetstream.ErrObjectNotFound) {
+				missingCount++
+				c.logger.Error("phase4e: object missing in target after copy",
+					"source_bucket", sourceBucketName,
+					"tag", tag,
+					"name", info.Name,
+				)
+				continue
+			}
+			return fmt.Errorf("verify object %q in target: %w", info.Name, err)
+		}
+	}
+
+	if missingCount > 0 {
+		return fmt.Errorf("verification failed: %d of %d objects from %s missing in target",
+			missingCount, sourceCount, sourceBucketName)
+	}
+
+	c.logger.Info("phase4e: verified object store",
+		"source", sourceBucketName,
+		"tag", tag,
+		"objects_verified", sourceCount,
+	)
+	return nil
+}
+
 // isMigrationComplete returns true if the given completion marker key exists
 // in `KV_INSTANCE`.
 func (c *ChattoCore) isMigrationComplete(ctx context.Context, markerKey string) (bool, error) {
@@ -742,4 +951,8 @@ func legacySpaceReactionsBucket(spaceID string) string {
 
 func legacySpaceThreadsBucket(spaceID string) string {
 	return fmt.Sprintf("SPACE_%s_THREADS", spaceID)
+}
+
+func legacySpaceAssetsBucket(spaceID string) string {
+	return fmt.Sprintf("SPACE_%s_ASSETS", spaceID)
 }

--- a/cli/internal/core/schema_migration_test.go
+++ b/cli/internal/core/schema_migration_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"sync"
@@ -522,4 +523,156 @@ func equalKeySets(a, b map[string]struct{}) bool {
 		}
 	}
 	return true
+}
+
+// TestPhase4eMigration_CopiesAttachments verifies that the phase 4e migrator
+// copies every object from the per-space ASSETS object stores for primary +
+// DM into the deployment-wide SERVER_ASSETS store, preserves headers, and
+// leaves the source data intact (no-deletes rule).
+func TestPhase4eMigration_CopiesAttachments(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	space, err := core.CreateSpace(ctx, "test-user", "Primary", "")
+	if err != nil {
+		t.Fatalf("CreateSpace: %v", err)
+	}
+
+	// Seed legacy primary ASSETS via the per-space store directly. Bypassing
+	// the public API keeps the test focused on the migration's behavior.
+	primarySource, err := core.js.ObjectStore(ctx, legacySpaceAssetsBucket(space.Id))
+	if err != nil {
+		t.Fatalf("open primary ASSETS: %v", err)
+	}
+	if _, err := primarySource.Put(ctx, jetstream.ObjectMeta{
+		Name:    "att-primary-1",
+		Headers: map[string][]string{"Content-Type": {"image/png"}, "Filename": {"hello.png"}},
+	}, bytes.NewReader([]byte("primary-attachment-bytes"))); err != nil {
+		t.Fatalf("seed primary attachment: %v", err)
+	}
+
+	dmSource, err := core.js.ObjectStore(ctx, legacySpaceAssetsBucket(DMSpaceID))
+	if err != nil {
+		t.Fatalf("open DM ASSETS: %v", err)
+	}
+	if _, err := dmSource.Put(ctx, jetstream.ObjectMeta{
+		Name:    "att-dm-1",
+		Headers: map[string][]string{"Content-Type": {"text/plain"}, "Filename": {"note.txt"}},
+	}, bytes.NewReader([]byte("dm-attachment-bytes"))); err != nil {
+		t.Fatalf("seed DM attachment: %v", err)
+	}
+
+	core.SetPrimarySpaceID(space.Id)
+	if err := core.RunMigrationsIfNeeded(ctx, space.Id); err != nil {
+		t.Fatalf("RunMigrationsIfNeeded: %v", err)
+	}
+
+	// Marker set.
+	if _, err := core.storage.instanceKV.Get(ctx, phase4eCompleteKey); err != nil {
+		t.Fatalf("expected phase4e completion marker: %v", err)
+	}
+
+	// Objects landed in SERVER_ASSETS with content + headers preserved.
+	for _, tc := range []struct {
+		name        string
+		wantContent string
+		wantCT      string
+		wantFile    string
+	}{
+		{"att-primary-1", "primary-attachment-bytes", "image/png", "hello.png"},
+		{"att-dm-1", "dm-attachment-bytes", "text/plain", "note.txt"},
+	} {
+		got, err := core.storage.serverAttachments.GetBytes(ctx, tc.name)
+		if err != nil {
+			t.Errorf("read %q from SERVER_ASSETS: %v", tc.name, err)
+			continue
+		}
+		if string(got) != tc.wantContent {
+			t.Errorf("%q content mismatch: %q", tc.name, got)
+		}
+		info, err := core.storage.serverAttachments.GetInfo(ctx, tc.name)
+		if err != nil {
+			t.Errorf("GetInfo %q: %v", tc.name, err)
+			continue
+		}
+		if got := info.Headers.Get("Content-Type"); got != tc.wantCT {
+			t.Errorf("%q Content-Type: %q, want %q", tc.name, got, tc.wantCT)
+		}
+		if got := info.Headers.Get("Filename"); got != tc.wantFile {
+			t.Errorf("%q Filename: %q, want %q", tc.name, got, tc.wantFile)
+		}
+	}
+
+	// Source data left intact.
+	if _, err := primarySource.GetInfo(ctx, "att-primary-1"); err != nil {
+		t.Errorf("source primary attachment should still exist: %v", err)
+	}
+	if _, err := dmSource.GetInfo(ctx, "att-dm-1"); err != nil {
+		t.Errorf("source DM attachment should still exist: %v", err)
+	}
+}
+
+// TestPhase4eMigration_FreshInstall verifies the phase 4e migrator runs
+// cleanly on a fresh install with no attachment data and is a fast no-op
+// on a re-run.
+func TestPhase4eMigration_FreshInstall(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	if err := core.RunMigrationsIfNeeded(ctx, ""); err != nil {
+		t.Fatalf("RunMigrationsIfNeeded: %v", err)
+	}
+	if _, err := core.storage.instanceKV.Get(ctx, phase4eCompleteKey); err != nil {
+		t.Fatalf("expected phase4e completion marker: %v", err)
+	}
+
+	if err := core.RunMigrationsIfNeeded(ctx, ""); err != nil {
+		t.Fatalf("second run failed: %v", err)
+	}
+}
+
+// TestPhase4eMigration_AttachmentsRoutingAfterMigration verifies that once
+// the primary is set and migration has run, getSpaceAttachments routes
+// the primary and DM spaces to SERVER_ASSETS (not the legacy per-space
+// stores). Other spaces continue to use their per-space stores.
+func TestPhase4eMigration_AttachmentsRoutingAfterMigration(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	space, err := core.CreateSpace(ctx, "test-user", "Primary", "")
+	if err != nil {
+		t.Fatalf("CreateSpace: %v", err)
+	}
+	otherSpace, err := core.CreateSpace(ctx, "test-user", "Other", "")
+	if err != nil {
+		t.Fatalf("CreateSpace other: %v", err)
+	}
+	core.SetPrimarySpaceID(space.Id)
+	if err := core.RunMigrationsIfNeeded(ctx, space.Id); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		spaceID string
+		want    string
+	}{
+		{"primary attachments", space.Id, "SERVER_ASSETS"},
+		{"DM attachments", DMSpaceID, "SERVER_ASSETS"},
+		{"non-primary attachments", otherSpace.Id, "SPACE_" + otherSpace.Id + "_ASSETS"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store, err := core.getSpaceAttachments(ctx, tc.spaceID)
+			if err != nil {
+				t.Fatalf("getSpaceAttachments: %v", err)
+			}
+			status, err := store.Status(ctx)
+			if err != nil {
+				t.Fatalf("Status: %v", err)
+			}
+			if status.Bucket() != tc.want {
+				t.Errorf("expected %q, got %q", tc.want, status.Bucket())
+			}
+		})
+	}
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,8 @@ The GraphQL API is the primary client-facing interface for Chatto. It provides q
 | KV      | Per-space | `SPACE_{spaceId}_THREADS`     | Thread metadata (reply count, participants) |
 | Objects | Instance  | `INSTANCE_ASSETS`             | Avatars, icons                              |
 | Objects | Instance  | `ASSET_CACHE`                 | Cached resized images (optional, with TTL)  |
-| Objects | Per-space | `SPACE_{spaceId}_ASSETS`      | Message attachments                         |
+| Objects | Server    | `SERVER_ASSETS`               | Message attachments (primary + DM)          |
+| Objects | Per-space | `SPACE_{spaceId}_ASSETS`      | Message attachments (non-primary, non-DM)   |
 | Stream  | Per-space | `SPACE_{spaceId}_EVENTS`      | Room lifecycle, messages, memberships       |
 
 See [NATS Resource Inventory](#nats-resource-inventory) for detailed key patterns and subjects.
@@ -523,7 +524,7 @@ All live events bypass JetStream entirely — KV buckets are the source of truth
 | `SPACE_{spaceId}_THREADS`     | Per-space | File    | Yes      | Thread metadata (reply count, participants)     |
 | `LINK_PREVIEW_CACHE`          | Instance  | File    | No       | Cached link preview metadata (48h TTL)          |
 
-**Migration note (#330 / ADR-027 phase 4a–4c):** the primary space's CONFIG/RBAC/RUNTIME/BODIES/REACTIONS/THREADS data and the DM system space's CONFIG/RUNTIME/BODIES/REACTIONS/THREADS data were folded into `SERVER_*`. The legacy `SPACE_{primary}_*` and `SPACE_DM_*` buckets are still present (no-deletes rule) but dormant — reads route to `SERVER_*`. A future cleanup pass will retire them. Per-space `ASSETS` (object store) is still per-space; later sub-phases fold those in too.
+**Migration note (#330 / ADR-027 phase 4a–4c, 4e):** the primary space's CONFIG/RBAC/RUNTIME/BODIES/REACTIONS/THREADS data and the DM system space's CONFIG/RUNTIME/BODIES/REACTIONS/THREADS data were folded into `SERVER_*` (4a–4c). Per-space attachment object stores (`SPACE_{primary}_ASSETS`, `SPACE_DM_ASSETS`) were folded into `SERVER_ASSETS` in phase 4e. The legacy `SPACE_{primary}_*` and `SPACE_DM_*` buckets/object stores are still present (no-deletes rule) but dormant — reads route to `SERVER_*`. A future cleanup pass will retire them.
 
 **INSTANCE keys:**
 
@@ -547,6 +548,7 @@ All live events bypass JetStream entirely — KV buckets are the source of truth
 | `migration.phase4a_complete`           | Phase 4a (primary CONFIG/RBAC/RUNTIME → `SERVER_*`) completion marker |
 | `migration.phase4b_complete`           | Phase 4b (DM merge + kind-prefixed keys) completion marker |
 | `migration.phase4c_complete`           | Phase 4c (per-message KVs: BODIES/REACTIONS/THREADS → `SERVER_*`) completion marker |
+| `migration.phase4e_complete`           | Phase 4e (per-space attachment object stores → `SERVER_ASSETS`) completion marker |
 
 Notes: Email verification uses SHA256 hashing for claim keys to ensure valid NATS subject characters and case-insensitive uniqueness. The claim key is created atomically when an email is verified, preventing race conditions where two users try to verify the same email. Verification tokens store userId and email in the JSON value for O(1) lookup by token.
 
@@ -686,11 +688,12 @@ Notes: Updated on each thread reply via optimistic locking. Tracks up to 50 part
 
 ### Object Store Buckets
 
-| Bucket                      | Scope     | Description                              |
-| --------------------------- | --------- | ---------------------------------------- |
-| `INSTANCE_ASSETS`           | Instance  | User avatars, space icons                |
-| `ASSET_CACHE`               | Instance  | Cached resized images (optional)         |
-| `SPACE_{spaceId}_ASSETS`    | Per-space | Message attachments                      |
+| Bucket                      | Scope     | Description                                       |
+| --------------------------- | --------- | ------------------------------------------------- |
+| `INSTANCE_ASSETS`           | Instance  | User avatars, space icons                         |
+| `ASSET_CACHE`               | Instance  | Cached resized images (optional)                  |
+| `SERVER_ASSETS`             | Server    | Message attachments (primary + DM)                |
+| `SPACE_{spaceId}_ASSETS`    | Per-space | Message attachments (non-primary, non-DM spaces)  |
 
 **INSTANCE_ASSETS keys:**
 
@@ -708,14 +711,23 @@ Notes: Content-Type stored in object headers. S2 compression enabled. Assets ref
 
 Notes: Only created when `[core.assets.cache]` is enabled in config. Uses TTL for automatic expiration (default 7 days). `paramsHash` is first 16 hex chars of SHA256(`{width}x{height}_{fit}`). Animated GIFs are not cached (served directly). S2 compression enabled.
 
-**SPACE\_{spaceId}\_ASSETS keys:**
+**SERVER\_ASSETS keys (primary + DM, post phase 4e):**
 
 | Key                   | Description                                     |
 | --------------------- | ----------------------------------------------- |
 | `{attachmentId}`      | Original attachment files (images, videos, etc.)|
 | `{attachmentId}_thumb`| WebP thumbnails (256px max dimension)           |
 
-Notes: Content-Type and original filename stored in object headers. S2 compression enabled. Attachment metadata stored in `MessageBody` proto in BODIES bucket.
+Notes: Same key shape as the legacy per-space `ASSETS` stores — attachment IDs are globally unique, so no kind segment is needed. Content-Type and original filename stored in object headers. S2 compression enabled. Attachment metadata stored in `MessageBody` proto in `SERVER_BODIES`.
+
+**SPACE\_{spaceId}\_ASSETS keys (non-primary, non-DM spaces only):**
+
+| Key                   | Description                                     |
+| --------------------- | ----------------------------------------------- |
+| `{attachmentId}`      | Original attachment files (images, videos, etc.)|
+| `{attachmentId}_thumb`| WebP thumbnails (256px max dimension)           |
+
+Notes: Same shape as `SERVER_ASSETS`. Content-Type and original filename stored in object headers. S2 compression enabled.
 
 ### Dynamic Image Transformation
 


### PR DESCRIPTION
## Summary

Phase 4e of the #330 / #354 server-data consolidation: folds per-space attachment object stores (`SPACE_{primary}_ASSETS`, `SPACE_DM_ASSETS`) into a deployment-wide `SERVER_ASSETS` store.

- New `SERVER_ASSETS` object store, eager-created with the same config as the legacy per-space stores (FileStorage, S2 compression).
- `getSpaceAttachments` now routes primary + DM via `usesServerLevelMetadata` to `SERVER_ASSETS`; non-primary, non-DM spaces stay on the per-space lazycache.
- New `runPhase4eIfNeeded` migrator follows the 4c shape (lock → check → re-check → copy → verify → mark). Object stores have no atomic-insert primitive, so copy uses `List` + `Get` + `Put`; re-runs replay the same Name/Headers and stay idempotent in effect. Source data is left intact (no-deletes rule).

## Test plan

- [x] `mise test-cli` (full backend suite green, including new phase-4e tests)
- [x] New tests cover: copy + headers preserved, source untouched, fresh-install no-op + idempotent re-run, post-migration routing for primary / DM / non-primary
- [ ] Deploy to dev instance and confirm primary + DM attachments still load