### PR TITLE
feat(subjects): phase 4d prep — primary-aware subject dispatch (#354)

### DIFF
--- a/cli/internal/core/rooms.go
+++ b/cli/internal/core/rooms.go
@@ -2048,7 +2048,7 @@ func (c *ChattoCore) getRoomEventsInitialLoad(
 ) (*RoomEventsResult, error) {
 	// Find the last sequence for this room's root messages and meta events.
 	// Both are O(1) lookups in JetStream's subject index.
-	msgSubject := fmt.Sprintf("space.%s.room.%s.msg.*", space_id, room_id)
+	msgSubject := subjects.SpaceRoomRootMessages(space_id, room_id)
 	metaSubject := subjects.SpaceRoomMeta(space_id, room_id)
 
 	var lastSeq uint64

--- a/cli/internal/core/subjects/primary.go
+++ b/cli/internal/core/subjects/primary.go
@@ -1,0 +1,77 @@
+package subjects
+
+import "sync/atomic"
+
+// Primary-aware dispatch for the #330 phase 4d subject migration.
+//
+// Each space-stream subject helper checks `shouldUseServerSubjects(spaceID)`
+// and either produces the legacy per-space `space.{id}.>` shape (for
+// non-primary, non-DM spaces) or the consolidated `server.>` shape (for the
+// configured primary and the DM system space).
+//
+// Until `SetPrimarySpaceID` is called, the primary is unset and only the DM
+// space ID matches the server-subject path. Production wiring calls
+// `SetPrimarySpaceID` from `core.SetPrimarySpaceID` so the singleton tracks
+// whichever space the deployment is using as primary.
+
+// dmSpaceID is the well-known ID of the DM system space. Duplicated from the
+// `core` package to keep the subjects package free of core imports.
+const dmSpaceID = "DM"
+
+// primarySpaceID stores the configured primary space ID. Pointer-of-string
+// so the unset state is unambiguous.
+var primarySpaceID atomic.Pointer[string]
+
+// SetPrimarySpaceID records the deployment's primary space ID. Subsequent
+// subject construction for that space (and for the DM system space) uses
+// the consolidated `server.>` shape rather than the per-space `space.>`
+// shape. Safe to call concurrently; safe to call repeatedly with the same
+// value.
+//
+// Pass an empty string to clear the primary (used by tests).
+func SetPrimarySpaceID(id string) {
+	if id == "" {
+		primarySpaceID.Store(nil)
+		return
+	}
+	primarySpaceID.Store(&id)
+}
+
+// PrimarySpaceID returns the currently-set primary space ID, or "" if unset.
+func PrimarySpaceID() string {
+	if p := primarySpaceID.Load(); p != nil {
+		return *p
+	}
+	return ""
+}
+
+// shouldUseServerSubjects reports whether subjects for the given space
+// should use the consolidated `server.>` shape. True for the configured
+// primary and for the DM system space, but ONLY once the primary has
+// been set via SetPrimarySpaceID. Until then, all subjects (including
+// DM) stay on the legacy `space.{id}.>` shape.
+//
+// Gating DM on the singleton is deliberate: the `SERVER_EVENTS` stream
+// is created at the same time the primary is set. Auto-routing DM
+// before SERVER_EVENTS exists would direct publishes to a subject no
+// stream accepts.
+func shouldUseServerSubjects(spaceID string) bool {
+	p := primarySpaceID.Load()
+	if p == nil {
+		return false
+	}
+	return spaceID == dmSpaceID || spaceID == *p
+}
+
+// roomKind returns the kind segment that appears in `server.room.{kind}.>`
+// subjects: "dm" for the DM system space, "channel" for everything else.
+//
+// Only meaningful when `shouldUseServerSubjects(spaceID)` is true; non-
+// server-subject paths embed the spaceID directly and don't carry a kind
+// segment.
+func roomKind(spaceID string) string {
+	if spaceID == dmSpaceID {
+		return "dm"
+	}
+	return "channel"
+}

--- a/cli/internal/core/subjects/subjects.go
+++ b/cli/internal/core/subjects/subjects.go
@@ -2,213 +2,335 @@ package subjects
 
 import "fmt"
 
-// This file provides a single source of truth for all NATS subject patterns in the system.
-// All functions are pure - they construct subjects from entity IDs.
+// This file is the single source of truth for all NATS subject patterns in
+// the system. All functions are pure and construct subjects from entity
+// IDs.
 //
-// Simplified Subject Patterns (optimized for low cardinality):
-//   - Instance: instance.user.{userId}.{eventType}
-//   - Space:    space.{spaceId}.{eventType}
-//   - Room:     space.{spaceId}.room.{roomId}.{eventType}
-//   - User:     user.{userId}.event (transient, NATS Core only)
+// Two subject namespaces coexist during the #330 phase 4d migration:
 //
-// Note: Actor/user context is stored in event payloads, not subjects.
-// This minimizes subject cardinality for optimal NATS memory usage.
+//   - Legacy per-space (`space.{spaceId}.>`): for non-primary, non-DM
+//     spaces. Used by the per-space `SPACE_{spaceId}_EVENTS` JetStream
+//     streams.
+//
+//   - Consolidated (`server.>`): for the configured primary space and the
+//     DM system space. Used by the deployment-wide `SERVER_EVENTS` stream
+//     introduced in phase 4d.
+//
+// Each helper picks one of the two via `shouldUseServerSubjects(spaceID)`.
+// The room kind (channel/dm) is part of the consolidated subject so list
+// operations can prefix-filter without loading the room record — same
+// principle as the SERVER_CONFIG key prefix introduced in phase 4b.
+//
+// Subject shapes:
+//
+//   Room messages (root):
+//     space.{spaceId}.room.{roomId}.msg.{eventId}
+//     server.room.{kind}.{roomId}.msg.{eventId}
+//   Room messages (thread reply):
+//     space.{spaceId}.room.{roomId}.msg.{rootEventId}.replies.{eventId}
+//     server.room.{kind}.{roomId}.msg.{rootEventId}.replies.{eventId}
+//   Room meta (lifecycle/membership):
+//     space.{spaceId}.room.{roomId}.meta
+//     server.room.{kind}.{roomId}.meta
+//   Space-level (currently membership only):
+//     space.{spaceId}.{eventType}
+//     server.member.{eventType}
+//
+// Both formats place roomID at the same dot-segment index (3) and eventID
+// at index 5 (root) / 7 (thread reply), so parsers only need a prefix
+// check, not separate offset tables.
 
-// ===== SPACE STREAM SUBJECTS (space.{spaceId}.>) =====
+// ===== SPACE STREAM SUBJECTS =====
 
-// SpaceEvent returns the subject for space-level events in a SPACE stream.
-// Pattern: space.{spaceId}.{eventType}
-// Examples: joined, left
-// Note: Actor/user information is in the event payload, not the subject
+// SpaceEvent returns the subject for space-level events.
+//
+// Legacy: space.{spaceId}.{eventType}
+// Server: server.member.{eventType}
+//
+// Currently used only for membership lifecycle (member_deleted etc.).
+// Other "space-level" lifecycle (joined/left) is published via
+// LiveInstanceUserEvent against the user, not the space.
 func SpaceEvent(spaceID, eventType string) string {
+	if shouldUseServerSubjects(spaceID) {
+		return fmt.Sprintf("server.member.%s", eventType)
+	}
 	return fmt.Sprintf("space.%s.%s", spaceID, eventType)
 }
 
 // SpaceAllEvents returns the wildcard subject for all space-level events.
-// Pattern: space.{spaceId}.>
+//
+// Legacy: space.{spaceId}.>
+// Server: server.>
 func SpaceAllEvents(spaceID string) string {
+	if shouldUseServerSubjects(spaceID) {
+		return "server.>"
+	}
 	return fmt.Sprintf("space.%s.>", spaceID)
 }
 
 // ===== ROOM EVENT SUBJECTS =====
-// Room events are stored in the SPACE stream, not separate room streams.
-// This simplifies consumption - one subscription gets all space events.
-//
-// Subject structure (event IDs enable O(1) lookup via GetLastMsgForSubject):
-//   - Messages: space.{spaceId}.room.{roomId}.msg.{eventId}                             (root messages)
-//   - Threads:  space.{spaceId}.room.{roomId}.msg.{rootEventId}.replies.{eventId}       (thread replies)
-//   - Meta:     space.{spaceId}.room.{roomId}.meta                                      (lifecycle + membership)
-//
-// Filtering patterns:
-//   - All messages:    msg.>
-//   - Root only:       msg.*
-//   - All threads:     msg.*.replies.>
-//   - Specific thread: msg.{rootEventId}.replies.>
 
-// SpaceRoomMessage returns the subject for root message events in a room.
-// Pattern: space.{spaceId}.room.{roomId}.msg.{eventId}
-// Used for: Posting new top-level messages (not thread replies)
-// The eventId enables O(1) lookup via GetLastMsgForSubject.
+// SpaceRoomMessage returns the subject for a root message event.
+//
+// Legacy: space.{spaceId}.room.{roomId}.msg.{eventId}
+// Server: server.room.{kind}.{roomId}.msg.{eventId}
 func SpaceRoomMessage(spaceID, roomID, eventID string) string {
+	if shouldUseServerSubjects(spaceID) {
+		return fmt.Sprintf("server.room.%s.%s.msg.%s", roomKind(spaceID), roomID, eventID)
+	}
 	return fmt.Sprintf("space.%s.room.%s.msg.%s", spaceID, roomID, eventID)
 }
 
 // SpaceRoomThread returns the subject for a thread reply message.
-// Pattern: space.{spaceId}.room.{roomId}.msg.{rootEventId}.replies.{eventId}
-// Used for: Posting replies to a specific thread
-// The eventId enables O(1) lookup via GetLastMsgForSubject.
+//
+// Legacy: space.{spaceId}.room.{roomId}.msg.{rootEventId}.replies.{eventId}
+// Server: server.room.{kind}.{roomId}.msg.{rootEventId}.replies.{eventId}
 func SpaceRoomThread(spaceID, roomID, rootEventID, eventID string) string {
+	if shouldUseServerSubjects(spaceID) {
+		return fmt.Sprintf("server.room.%s.%s.msg.%s.replies.%s", roomKind(spaceID), roomID, rootEventID, eventID)
+	}
 	return fmt.Sprintf("space.%s.room.%s.msg.%s.replies.%s", spaceID, roomID, rootEventID, eventID)
 }
 
-// SpaceRoomThreadFilter returns the wildcard subject for all replies in a specific thread.
-// Pattern: space.{spaceId}.room.{roomId}.msg.{rootEventId}.replies.>
-// Used for: Consuming all thread replies regardless of their event IDs.
+// SpaceRoomThreadFilter returns the wildcard subject for all replies in a
+// specific thread.
+//
+// Legacy: space.{spaceId}.room.{roomId}.msg.{rootEventId}.replies.>
+// Server: server.room.{kind}.{roomId}.msg.{rootEventId}.replies.>
 func SpaceRoomThreadFilter(spaceID, roomID, rootEventID string) string {
+	if shouldUseServerSubjects(spaceID) {
+		return fmt.Sprintf("server.room.%s.%s.msg.%s.replies.>", roomKind(spaceID), roomID, rootEventID)
+	}
 	return fmt.Sprintf("space.%s.room.%s.msg.%s.replies.>", spaceID, roomID, rootEventID)
 }
 
-// SpaceRoomThreadLookup returns the wildcard subject for looking up a thread reply by event ID.
-// Pattern: space.{spaceId}.room.{roomId}.msg.*.replies.{eventId}
-// Used for: O(1) lookup of any thread reply by event ID via GetLastMsgForSubject.
+// SpaceRoomThreadLookup returns the wildcard subject for looking up a
+// thread reply by event ID via GetLastMsgForSubject.
+//
+// Legacy: space.{spaceId}.room.{roomId}.msg.*.replies.{eventId}
+// Server: server.room.{kind}.{roomId}.msg.*.replies.{eventId}
 func SpaceRoomThreadLookup(spaceID, roomID, eventID string) string {
+	if shouldUseServerSubjects(spaceID) {
+		return fmt.Sprintf("server.room.%s.%s.msg.*.replies.%s", roomKind(spaceID), roomID, eventID)
+	}
 	return fmt.Sprintf("space.%s.room.%s.msg.*.replies.%s", spaceID, roomID, eventID)
 }
 
-// SpaceRoomAllThreads returns the wildcard subject for all thread events in a room.
-// Pattern: space.{spaceId}.room.{roomId}.msg.*.replies.>
-// Used for: Consuming all thread activity in a room
+// SpaceRoomAllThreads returns the wildcard subject for all thread events
+// in a room.
+//
+// Legacy: space.{spaceId}.room.{roomId}.msg.*.replies.>
+// Server: server.room.{kind}.{roomId}.msg.*.replies.>
 func SpaceRoomAllThreads(spaceID, roomID string) string {
+	if shouldUseServerSubjects(spaceID) {
+		return fmt.Sprintf("server.room.%s.%s.msg.*.replies.>", roomKind(spaceID), roomID)
+	}
 	return fmt.Sprintf("space.%s.room.%s.msg.*.replies.>", spaceID, roomID)
 }
 
-// SpaceRoomMeta returns the subject for non-message room events.
-// Pattern: space.{spaceId}.room.{roomId}.meta
-// Used for: Room lifecycle (created, updated, deleted) and membership (joined, left)
-// Event type is determined by the event payload, not the subject.
+// SpaceRoomMeta returns the subject for non-message room events
+// (lifecycle, membership).
+//
+// Legacy: space.{spaceId}.room.{roomId}.meta
+// Server: server.room.{kind}.{roomId}.meta
 func SpaceRoomMeta(spaceID, roomID string) string {
+	if shouldUseServerSubjects(spaceID) {
+		return fmt.Sprintf("server.room.%s.%s.meta", roomKind(spaceID), roomID)
+	}
 	return fmt.Sprintf("space.%s.room.%s.meta", spaceID, roomID)
 }
 
-// SpaceRoomAllMessages returns the wildcard subject for all messages (root + thread) in a room.
-// Pattern: space.{spaceId}.room.{roomId}.msg.>
-// Used for: Deriving room's last message timestamp from JetStream (includes thread activity).
+// SpaceRoomAllMessages returns the wildcard subject for all messages
+// (root + thread) in a room. Used for deriving last-message timestamps.
+//
+// Legacy: space.{spaceId}.room.{roomId}.msg.>
+// Server: server.room.{kind}.{roomId}.msg.>
 func SpaceRoomAllMessages(spaceID, roomID string) string {
+	if shouldUseServerSubjects(spaceID) {
+		return fmt.Sprintf("server.room.%s.%s.msg.>", roomKind(spaceID), roomID)
+	}
 	return fmt.Sprintf("space.%s.room.%s.msg.>", spaceID, roomID)
 }
 
-// SpaceRoomRootMessages returns the wildcard subject for root messages only in a room.
-// Pattern: space.{spaceId}.room.{roomId}.msg.*
-// The single wildcard (*) matches one token (eventId for root messages) but excludes
-// thread replies which have subjects like msg.{rootId}.replies.{eventId} (3 tokens).
-// Used for: Deriving room's last root message sequence for unread tracking.
+// SpaceRoomRootMessages returns the wildcard subject for root messages
+// only in a room. The single-token wildcard (*) excludes thread replies
+// (which have an additional `.replies.{eventId}` suffix).
+//
+// Legacy: space.{spaceId}.room.{roomId}.msg.*
+// Server: server.room.{kind}.{roomId}.msg.*
 func SpaceRoomRootMessages(spaceID, roomID string) string {
+	if shouldUseServerSubjects(spaceID) {
+		return fmt.Sprintf("server.room.%s.%s.msg.*", roomKind(spaceID), roomID)
+	}
 	return fmt.Sprintf("space.%s.room.%s.msg.*", spaceID, roomID)
 }
 
-// SpaceRoomAllEvents returns the filter subject for all events in a specific room.
-// Pattern: space.{spaceId}.room.{roomId}.>
-// Matches all room events (messages, threads, meta) since they all have suffixes.
+// SpaceRoomAllEvents returns the filter subject for all events in a
+// specific room. Matches messages, threads, and meta events.
+//
+// Legacy: space.{spaceId}.room.{roomId}.>
+// Server: server.room.{kind}.{roomId}.>
 func SpaceRoomAllEvents(spaceID, roomID string) string {
+	if shouldUseServerSubjects(spaceID) {
+		return fmt.Sprintf("server.room.%s.%s.>", roomKind(spaceID), roomID)
+	}
 	return fmt.Sprintf("space.%s.room.%s.>", spaceID, roomID)
 }
 
-// SpaceAllRoomEvents returns the wildcard subject for all room events across a space.
-// Pattern: space.{spaceId}.room.>
-// Useful for indexers, notification services, etc. that need all room activity.
+// SpaceAllRoomEvents returns the wildcard subject for all room events
+// across a space.
+//
+// Legacy: space.{spaceId}.room.>
+// Server: server.room.{kind}.>
+//
+// In the server format, this filter is scoped to a specific kind so
+// channels and DMs stay distinguishable in subscriptions that are
+// already context-aware (a primary-space subscriber shouldn't see DM
+// traffic, and vice versa).
 func SpaceAllRoomEvents(spaceID string) string {
+	if shouldUseServerSubjects(spaceID) {
+		return fmt.Sprintf("server.room.%s.>", roomKind(spaceID))
+	}
 	return fmt.Sprintf("space.%s.room.>", spaceID)
 }
 
-// SpaceRoomRootEventsFilters returns filter subjects for root messages and meta events in a room.
-// Excludes thread replies (which have subjects like msg.{rootId}.replies.{eventId}).
-// Returns: ["space.{s}.room.{r}.msg.*", "space.{s}.room.{r}.meta"]
-// Use with JetStream consumer FilterSubjects for efficient server-side filtering.
+// SpaceRoomRootEventsFilters returns filter subjects for root messages
+// and meta events in a single room. Excludes thread replies.
+//
+// Legacy: ["space.{s}.room.{r}.msg.*", "space.{s}.room.{r}.meta"]
+// Server: ["server.room.{kind}.{r}.msg.*", "server.room.{kind}.{r}.meta"]
+//
+// Use with JetStream consumer FilterSubjects for efficient server-side
+// filtering.
 func SpaceRoomRootEventsFilters(spaceID, roomID string) []string {
+	if shouldUseServerSubjects(spaceID) {
+		kind := roomKind(spaceID)
+		return []string{
+			fmt.Sprintf("server.room.%s.%s.msg.*", kind, roomID),
+			fmt.Sprintf("server.room.%s.%s.meta", kind, roomID),
+		}
+	}
 	return []string{
 		fmt.Sprintf("space.%s.room.%s.msg.*", spaceID, roomID),
 		fmt.Sprintf("space.%s.room.%s.meta", spaceID, roomID),
 	}
 }
 
-// SpaceAllRoomEventsFilters returns filter subjects for ALL messages (root + thread replies)
-// and meta events across all rooms in a space.
-// Returns: ["space.{s}.room.*.msg.>", "space.{s}.room.*.meta"]
-// Use with JetStream consumer FilterSubjects for live subscriptions that need all messages.
+// SpaceAllRoomEventsFilters returns filter subjects for all messages
+// (root + thread) and meta events across all rooms in a space.
+//
+// Legacy: ["space.{s}.room.*.msg.>", "space.{s}.room.*.meta"]
+// Server: ["server.room.{kind}.*.msg.>", "server.room.{kind}.*.meta"]
+//
+// Use with JetStream consumer FilterSubjects for live subscriptions
+// that need all messages.
 func SpaceAllRoomEventsFilters(spaceID string) []string {
+	if shouldUseServerSubjects(spaceID) {
+		kind := roomKind(spaceID)
+		return []string{
+			fmt.Sprintf("server.room.%s.*.msg.>", kind),
+			fmt.Sprintf("server.room.%s.*.meta", kind),
+		}
+	}
 	return []string{
 		fmt.Sprintf("space.%s.room.*.msg.>", spaceID),
 		fmt.Sprintf("space.%s.room.*.meta", spaceID),
 	}
 }
 
-// ParseRoomIDFromSubject extracts the room ID from a space event subject.
-// Returns the room ID if the subject is a room event, or empty string if it's a space-level event.
-// Handles all room subject patterns:
-//   - space.{spaceId}.room.{roomId}.msg.{eventId}                        (root messages)
-//   - space.{spaceId}.room.{roomId}.meta                                 (lifecycle/membership)
-//   - space.{spaceId}.room.{roomId}.msg.{rootEventId}.replies.{eventId}  (thread replies)
+// ===== PARSERS =====
+//
+// All parsers accept either subject format. Index alignment makes this
+// cheap: roomID is always at index 3 and eventID at index 5 (root) / 7
+// (thread reply), regardless of whether the subject starts with `space.`
+// or `server.room.`.
+
+// ParseRoomIDFromSubject extracts the room ID from a room event subject.
+// Returns "" for space-level events or unrecognized subjects.
+//
+// Subjects:
+//
+//	space.{spaceId}.room.{roomId}.msg.{eventId}                          (root)
+//	space.{spaceId}.room.{roomId}.msg.{rootEventId}.replies.{eventId}    (thread)
+//	space.{spaceId}.room.{roomId}.meta                                   (meta)
+//	server.room.{kind}.{roomId}.msg.{eventId}                            (root)
+//	server.room.{kind}.{roomId}.msg.{rootEventId}.replies.{eventId}      (thread)
+//	server.room.{kind}.{roomId}.meta                                     (meta)
 func ParseRoomIDFromSubject(subject string) string {
 	parts := splitSubject(subject)
-	// Minimum 5 parts: space.{s}.room.{r}.meta (or .msg.{id} for messages)
-	if len(parts) >= 5 && parts[0] == "space" && parts[2] == "room" {
-		return parts[3] // roomId is always at index 3
+	if len(parts) >= 5 && isRoomEventSubject(parts) {
+		return parts[3]
 	}
 	return ""
 }
 
-// ParseThreadRootEventIDFromSubject extracts the root event ID from a thread message subject.
-// Returns (rootEventId, true) if the subject is a thread reply, or ("", false) if it's a root message or non-message event.
-// Pattern: space.{spaceId}.room.{roomId}.msg.{rootEventId}.replies.{eventId}
+// ParseThreadRootEventIDFromSubject extracts the root event ID from a
+// thread reply subject. Returns ("", false) for non-thread subjects.
 func ParseThreadRootEventIDFromSubject(subject string) (string, bool) {
 	parts := splitSubject(subject)
-	// Thread subjects have 8 parts: space.{s}.room.{r}.msg.{rootEventId}.replies.{eventId}
-	if len(parts) == 8 && parts[0] == "space" && parts[2] == "room" && parts[4] == "msg" && parts[6] == "replies" {
+	if len(parts) == 8 && isRoomEventSubject(parts) && parts[4] == "msg" && parts[6] == "replies" {
 		return parts[5], true
 	}
 	return "", false
 }
 
-// IsRootMessageSubject checks if a subject is for a top-level (root) message.
-// Pattern: space.{spaceId}.room.{roomId}.msg.{eventId} (6 parts with .msg. segment)
+// IsRootMessageSubject reports whether a subject is for a top-level
+// (root) message — 6 segments with `msg` at index 4.
 func IsRootMessageSubject(subject string) bool {
 	parts := splitSubject(subject)
-	return len(parts) == 6 && parts[0] == "space" && parts[2] == "room" && parts[4] == "msg"
+	return len(parts) == 6 && isRoomEventSubject(parts) && parts[4] == "msg"
 }
 
-// IsMetaSubject checks if a subject is for a meta event (lifecycle/membership).
-// Pattern: space.{spaceId}.room.{roomId}.meta
+// IsMetaSubject reports whether a subject is for a meta event — 5
+// segments with `meta` at index 4.
 func IsMetaSubject(subject string) bool {
 	parts := splitSubject(subject)
-	return len(parts) == 5 && parts[0] == "space" && parts[2] == "room" && parts[4] == "meta"
+	return len(parts) == 5 && isRoomEventSubject(parts) && parts[4] == "meta"
 }
 
-// IsThreadSubject checks if a subject is for a thread reply message.
-// Pattern: space.{spaceId}.room.{roomId}.msg.{rootEventId}.replies.{eventId}
+// IsThreadSubject reports whether a subject is for a thread reply — 8
+// segments with `msg` at index 4 and `replies` at index 6.
 func IsThreadSubject(subject string) bool {
 	parts := splitSubject(subject)
-	return len(parts) == 8 && parts[0] == "space" && parts[2] == "room" && parts[4] == "msg" && parts[6] == "replies"
+	return len(parts) == 8 && isRoomEventSubject(parts) && parts[4] == "msg" && parts[6] == "replies"
 }
 
 // ParseEventIDFromSubject extracts the event ID from a message subject.
-// Returns the event ID if the subject is a message event (root or thread), or empty string otherwise.
-// Patterns:
-//   - space.{spaceId}.room.{roomId}.msg.{eventId}                        -> eventId at index 5
-//   - space.{spaceId}.room.{roomId}.msg.{rootEventId}.replies.{eventId}  -> eventId at index 7
+// Returns "" for non-message subjects.
 func ParseEventIDFromSubject(subject string) string {
 	parts := splitSubject(subject)
-	if len(parts) < 5 || parts[0] != "space" || parts[2] != "room" {
+	if len(parts) < 5 || !isRoomEventSubject(parts) {
 		return ""
 	}
-	// Root message: space.{s}.room.{r}.msg.{eventId} (6 parts)
 	if len(parts) == 6 && parts[4] == "msg" {
 		return parts[5]
 	}
-	// Thread reply: space.{s}.room.{r}.msg.{rootId}.replies.{eventId} (8 parts)
 	if len(parts) == 8 && parts[4] == "msg" && parts[6] == "replies" {
 		return parts[7]
 	}
 	return ""
+}
+
+// isRoomEventSubject reports whether the dot-split segments belong to a
+// room event in either the legacy `space.{id}.room.{r}.>` shape or the
+// consolidated `server.room.{kind}.{r}.>` shape. Both shapes place the
+// roomID at index 3, so callers can read parts[3] directly after this
+// returns true.
+//
+// Discriminator:
+//   - Legacy starts with parts[0] == "space" and parts[2] == "room".
+//   - Server starts with parts[0] == "server" and parts[1] == "room".
+func isRoomEventSubject(parts []string) bool {
+	if len(parts) < 4 {
+		return false
+	}
+	if parts[0] == "space" && parts[2] == "room" {
+		return true
+	}
+	if parts[0] == "server" && parts[1] == "room" {
+		return true
+	}
+	return false
 }
 
 // splitSubject splits a NATS subject by dots.
@@ -227,99 +349,128 @@ func splitSubject(subject string) []string {
 	return parts
 }
 
-// ===== LIVE SUBJECT PATTERNS (live.>) =====
-// Live subjects are used for transient events that bypass JetStream storage.
-// Events are published directly via publishLiveSpaceEvent()/publishInstanceEvent() for real-time
-// notifications (reactions, message updates/deletes, space member removal, etc.).
+// ===== LIVE SUBJECTS =====
 //
-// Space live events use publishLiveSpaceEvent(), instance live events use publishInstanceEvent().
+// Live subjects are used for transient events that bypass JetStream
+// storage. Same primary-aware dispatch as the durable subjects above.
 
-// LiveInstanceAllEvents returns the live subject for all instance-level events.
-// Pattern: live.instance.>
-// Used for: Server-side subscription to all instance events with authorization filtering.
+// LiveInstanceAllEvents returns the live subject for all instance-level
+// events. Pattern: live.instance.>
+//
+// Instance-scoped, not space-scoped — unaffected by the migration.
 func LiveInstanceAllEvents() string {
 	return "live.instance.>"
 }
 
-// LiveInstanceUserAllEvents returns the live subject for all events for a specific user.
-// Pattern: live.instance.user.{userId}.>
-// Used for: Real-time instance notifications (space created/updated/deleted, profile changes)
+// LiveInstanceUserAllEvents returns the live subject for all events for
+// a specific user. Pattern: live.instance.user.{userId}.>
 func LiveInstanceUserAllEvents(userID string) string {
 	return fmt.Sprintf("live.instance.user.%s.>", userID)
 }
 
-// LiveInstanceUserEvent returns the live subject for a specific user's instance event.
-// Pattern: live.instance.user.{userId}.{eventType}
-// Used for: Transient events that bypass JetStream storage entirely (e.g., joined_space, left_space)
+// LiveInstanceUserEvent returns the live subject for a specific user's
+// instance event. Pattern: live.instance.user.{userId}.{eventType}
 func LiveInstanceUserEvent(userID, eventType string) string {
 	return fmt.Sprintf("live.instance.user.%s.%s", userID, eventType)
 }
 
-// LiveSpaceAllEvents returns the live subject for all space-level events.
-// Pattern: live.space.{spaceId}.>
-// Used for: Real-time space notifications (includes room events)
+// LiveSpaceAllEvents returns the live subject for all events tied to a
+// space.
+//
+// Legacy: live.space.{spaceId}.>
+// Server: live.server.>
 func LiveSpaceAllEvents(spaceID string) string {
+	if shouldUseServerSubjects(spaceID) {
+		return "live.server.>"
+	}
 	return fmt.Sprintf("live.space.%s.>", spaceID)
 }
 
-// LiveSpaceLevelEvents returns the live subject for space-level events only (not room events).
-// Pattern: live.space.{spaceId}.*
-// Uses single wildcard (*) to match only direct children like joined/left, excluding room.> subjects.
-// Used for: Real-time space membership notifications without room events
+// LiveSpaceLevelEvents returns the live subject for non-room space-level
+// events only.
+//
+// Legacy: live.space.{spaceId}.* — single-token wildcard excludes
+//
+//	`live.space.{id}.room.>` (different segment count).
+//
+// Server: live.server.member.> — non-room live events all live under the
+//
+//	`member` namespace post-4d.
 func LiveSpaceLevelEvents(spaceID string) string {
+	if shouldUseServerSubjects(spaceID) {
+		return "live.server.member.>"
+	}
 	return fmt.Sprintf("live.space.%s.*", spaceID)
 }
 
-// LiveSpaceEvent returns the live subject for a space-level event (direct publish, bypasses JetStream).
-// Pattern: live.space.{spaceId}.{eventType}
-// Used for: Transient space-level events that don't need storage (e.g., member_deleted)
+// LiveSpaceEvent returns the live subject for a space-level event
+// (currently membership lifecycle).
+//
+// Legacy: live.space.{spaceId}.{eventType}
+// Server: live.server.member.{eventType}
 func LiveSpaceEvent(spaceID, eventType string) string {
+	if shouldUseServerSubjects(spaceID) {
+		return fmt.Sprintf("live.server.member.%s", eventType)
+	}
 	return fmt.Sprintf("live.space.%s.%s", spaceID, eventType)
 }
 
-// LiveSpaceRoomEvent returns the live subject for a room event (direct publish, bypasses JetStream).
-// Pattern: live.space.{spaceId}.room.{roomId}.{eventType}
-// Used for: Transient room events that don't need storage (e.g., reactions)
+// LiveSpaceRoomEvent returns the live subject for a room event.
+//
+// Legacy: live.space.{spaceId}.room.{roomId}.{eventType}
+// Server: live.server.room.{kind}.{roomId}.{eventType}
 func LiveSpaceRoomEvent(spaceID, roomID, eventType string) string {
+	if shouldUseServerSubjects(spaceID) {
+		return fmt.Sprintf("live.server.room.%s.%s.%s", roomKind(spaceID), roomID, eventType)
+	}
 	return fmt.Sprintf("live.space.%s.room.%s.%s", spaceID, roomID, eventType)
 }
 
-// LiveSpaceRoomAllEvents returns the live subject for all transient room events in a space.
-// Pattern: live.space.{spaceId}.room.>
-// Used for: Subscribing to all live-only room events (reactions, typing indicators, etc.)
+// LiveSpaceRoomAllEvents returns the live subject for all transient room
+// events in a space.
+//
+// Legacy: live.space.{spaceId}.room.>
+// Server: live.server.room.{kind}.>
 func LiveSpaceRoomAllEvents(spaceID string) string {
+	if shouldUseServerSubjects(spaceID) {
+		return fmt.Sprintf("live.server.room.%s.>", roomKind(spaceID))
+	}
 	return fmt.Sprintf("live.space.%s.room.>", spaceID)
 }
 
-// LiveSpaceRoomReactionEvents returns the subscription subject for all live-only reaction events.
-// Pattern: live.space.{spaceId}.room.*.reaction_*
-// Used for: Subscribing to transient reaction events that bypass JetStream storage
+// LiveSpaceRoomReactionEvents returns the subscription subject for all
+// live-only reaction events.
+//
+// Legacy: live.space.{spaceId}.room.*.reaction_*
+// Server: live.server.room.{kind}.*.reaction_*
 func LiveSpaceRoomReactionEvents(spaceID string) string {
+	if shouldUseServerSubjects(spaceID) {
+		return fmt.Sprintf("live.server.room.%s.*.reaction_*", roomKind(spaceID))
+	}
 	return fmt.Sprintf("live.space.%s.room.*.reaction_*", spaceID)
 }
 
 // ===== INSTANCE LIVE SUBJECT PATTERNS =====
-// For transient instance-level events that bypass JetStream (config changes, etc.)
+// For transient instance-level events that bypass JetStream (config
+// changes, etc.). Instance-scoped, unaffected by the migration.
 
-// LiveInstanceConfigUpdated returns the subject for instance config update events.
-// Pattern: live.instance.config.updated
-// Used for: Broadcasting config changes to all connected clients
+// LiveInstanceConfigUpdated returns the subject for instance config
+// update events. Pattern: live.instance.config.updated
 func LiveInstanceConfigUpdated() string {
 	return "live.instance.config.updated"
 }
 
-// LiveInstanceConfigAllEvents returns the wildcard subject for all instance config events.
-// Pattern: live.instance.config.>
-// Used for: Subscribing to all instance config-related live events
+// LiveInstanceConfigAllEvents returns the wildcard subject for all
+// instance config events. Pattern: live.instance.config.>
 func LiveInstanceConfigAllEvents() string {
 	return "live.instance.config.>"
 }
 
-// LiveInstanceSpaceEvent returns the live subject for a space-wide instance event.
-// Pattern: live.instance.space.{spaceId}.{eventType}
-// Used for: Transient events broadcast to all space members (e.g., new_message_in_space)
-// These events bypass JetStream and are delivered via server-side filtering.
+// LiveInstanceSpaceEvent returns the live subject for a space-wide
+// instance event. Pattern: live.instance.space.{spaceId}.{eventType}
+//
+// Instance-scoped (used for fanout to space members with server-side
+// authorization filtering); unaffected by the migration.
 func LiveInstanceSpaceEvent(spaceID, eventType string) string {
 	return fmt.Sprintf("live.instance.space.%s.%s", spaceID, eventType)
 }
-

--- a/cli/internal/core/subjects/subjects_server_test.go
+++ b/cli/internal/core/subjects/subjects_server_test.go
@@ -1,0 +1,339 @@
+package subjects
+
+import "testing"
+
+// Tests for the consolidated `server.>` subject namespace introduced in
+// #330 phase 4d. The legacy tests in subjects_test.go cover the same
+// functions when the primary singleton is unset; these tests exercise
+// the server-format branch.
+//
+// The primary singleton is package-level state, so these tests do not
+// run in parallel and use t.Cleanup to restore it.
+
+// setPrimaryForTest installs primaryID for the duration of the test.
+func setPrimaryForTest(t *testing.T, primaryID string) {
+	t.Helper()
+	prev := PrimarySpaceID()
+	SetPrimarySpaceID(primaryID)
+	t.Cleanup(func() { SetPrimarySpaceID(prev) })
+}
+
+func TestShouldUseServerSubjects(t *testing.T) {
+	setPrimaryForTest(t, "Sprimary")
+
+	for _, tc := range []struct {
+		name    string
+		spaceID string
+		want    bool
+	}{
+		{"primary", "Sprimary", true},
+		{"DM", "DM", true},
+		{"non-primary", "Sother", false},
+		{"empty", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldUseServerSubjects(tc.spaceID); got != tc.want {
+				t.Errorf("shouldUseServerSubjects(%q) = %v, want %v", tc.spaceID, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestShouldUseServerSubjects_PrimaryUnset(t *testing.T) {
+	// No setPrimaryForTest — singleton stays at whatever the test runner
+	// inherited, then we explicitly clear it.
+	SetPrimarySpaceID("")
+	t.Cleanup(func() { SetPrimarySpaceID("") })
+
+	// Until SetPrimarySpaceID is called, nothing routes to server
+	// subjects — even DM stays on the legacy `space.DM.>` shape so that
+	// publishes still land on the (still-existing) `SPACE_DM_EVENTS`
+	// stream. Auto-routing DM before SERVER_EVENTS exists is what gets
+	// you "nats: no response from stream" errors.
+	if shouldUseServerSubjects("Sany") {
+		t.Error("expected false for arbitrary space when primary unset")
+	}
+	if shouldUseServerSubjects("DM") {
+		t.Error("DM should NOT route server-side until primary is set (SERVER_EVENTS doesn't exist yet)")
+	}
+}
+
+func TestRoomKind(t *testing.T) {
+	for _, tc := range []struct {
+		spaceID string
+		want    string
+	}{
+		{"DM", "dm"},
+		{"Sprimary", "channel"},
+		{"Sother", "channel"},
+	} {
+		if got := roomKind(tc.spaceID); got != tc.want {
+			t.Errorf("roomKind(%q) = %q, want %q", tc.spaceID, got, tc.want)
+		}
+	}
+}
+
+// ===== Constructor tests (server format) =====
+
+func TestServerFormat_Constructors(t *testing.T) {
+	setPrimaryForTest(t, "Sprimary")
+
+	for _, tc := range []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"SpaceEvent primary", SpaceEvent("Sprimary", "member_deleted"), "server.member.member_deleted"},
+		{"SpaceEvent DM", SpaceEvent("DM", "member_deleted"), "server.member.member_deleted"},
+		{"SpaceAllEvents primary", SpaceAllEvents("Sprimary"), "server.>"},
+		{"SpaceRoomMessage primary channel", SpaceRoomMessage("Sprimary", "Rroom", "Eevt"), "server.room.channel.Rroom.msg.Eevt"},
+		{"SpaceRoomMessage DM", SpaceRoomMessage("DM", "Rroom", "Eevt"), "server.room.dm.Rroom.msg.Eevt"},
+		{"SpaceRoomThread primary", SpaceRoomThread("Sprimary", "Rroom", "Eroot", "Erep"), "server.room.channel.Rroom.msg.Eroot.replies.Erep"},
+		{"SpaceRoomThreadFilter DM", SpaceRoomThreadFilter("DM", "Rroom", "Eroot"), "server.room.dm.Rroom.msg.Eroot.replies.>"},
+		{"SpaceRoomThreadLookup primary", SpaceRoomThreadLookup("Sprimary", "Rroom", "Erep"), "server.room.channel.Rroom.msg.*.replies.Erep"},
+		{"SpaceRoomAllThreads primary", SpaceRoomAllThreads("Sprimary", "Rroom"), "server.room.channel.Rroom.msg.*.replies.>"},
+		{"SpaceRoomMeta primary", SpaceRoomMeta("Sprimary", "Rroom"), "server.room.channel.Rroom.meta"},
+		{"SpaceRoomMeta DM", SpaceRoomMeta("DM", "Rroom"), "server.room.dm.Rroom.meta"},
+		{"SpaceRoomAllMessages primary", SpaceRoomAllMessages("Sprimary", "Rroom"), "server.room.channel.Rroom.msg.>"},
+		{"SpaceRoomRootMessages primary", SpaceRoomRootMessages("Sprimary", "Rroom"), "server.room.channel.Rroom.msg.*"},
+		{"SpaceRoomAllEvents primary", SpaceRoomAllEvents("Sprimary", "Rroom"), "server.room.channel.Rroom.>"},
+		{"SpaceRoomAllEvents DM", SpaceRoomAllEvents("DM", "Rroom"), "server.room.dm.Rroom.>"},
+		{"SpaceAllRoomEvents primary", SpaceAllRoomEvents("Sprimary"), "server.room.channel.>"},
+		{"SpaceAllRoomEvents DM", SpaceAllRoomEvents("DM"), "server.room.dm.>"},
+		{"LiveSpaceAllEvents primary", LiveSpaceAllEvents("Sprimary"), "live.server.>"},
+		{"LiveSpaceAllEvents DM", LiveSpaceAllEvents("DM"), "live.server.>"},
+		{"LiveSpaceLevelEvents primary", LiveSpaceLevelEvents("Sprimary"), "live.server.member.>"},
+		{"LiveSpaceEvent primary", LiveSpaceEvent("Sprimary", "member_deleted"), "live.server.member.member_deleted"},
+		{"LiveSpaceRoomEvent primary", LiveSpaceRoomEvent("Sprimary", "Rroom", "reaction_added"), "live.server.room.channel.Rroom.reaction_added"},
+		{"LiveSpaceRoomEvent DM", LiveSpaceRoomEvent("DM", "Rroom", "reaction_added"), "live.server.room.dm.Rroom.reaction_added"},
+		{"LiveSpaceRoomAllEvents primary", LiveSpaceRoomAllEvents("Sprimary"), "live.server.room.channel.>"},
+		{"LiveSpaceRoomReactionEvents primary", LiveSpaceRoomReactionEvents("Sprimary"), "live.server.room.channel.*.reaction_*"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Errorf("got %q, want %q", tc.got, tc.want)
+			}
+		})
+	}
+}
+
+func TestServerFormat_Filters(t *testing.T) {
+	setPrimaryForTest(t, "Sprimary")
+
+	gotRoot := SpaceRoomRootEventsFilters("Sprimary", "Rroom")
+	wantRoot := []string{"server.room.channel.Rroom.msg.*", "server.room.channel.Rroom.meta"}
+	if !equalStrings(gotRoot, wantRoot) {
+		t.Errorf("SpaceRoomRootEventsFilters(primary): got %v, want %v", gotRoot, wantRoot)
+	}
+
+	gotAll := SpaceAllRoomEventsFilters("DM")
+	wantAll := []string{"server.room.dm.*.msg.>", "server.room.dm.*.meta"}
+	if !equalStrings(gotAll, wantAll) {
+		t.Errorf("SpaceAllRoomEventsFilters(DM): got %v, want %v", gotAll, wantAll)
+	}
+}
+
+// Non-primary spaces still use the legacy format even when primary is set.
+func TestNonPrimary_StaysLegacy(t *testing.T) {
+	setPrimaryForTest(t, "Sprimary")
+
+	for _, tc := range []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"SpaceRoomMessage", SpaceRoomMessage("Sother", "Rroom", "Eevt"), "space.Sother.room.Rroom.msg.Eevt"},
+		{"SpaceRoomMeta", SpaceRoomMeta("Sother", "Rroom"), "space.Sother.room.Rroom.meta"},
+		{"LiveSpaceAllEvents", LiveSpaceAllEvents("Sother"), "live.space.Sother.>"},
+		{"SpaceAllEvents", SpaceAllEvents("Sother"), "space.Sother.>"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Errorf("got %q, want %q", tc.got, tc.want)
+			}
+		})
+	}
+}
+
+// ===== Parser tests (both formats) =====
+
+func TestParsers_AcceptBothFormats(t *testing.T) {
+	cases := []struct {
+		name        string
+		subject     string
+		wantRoom    string
+		wantEventID string
+		wantRootID  string // empty if not a thread reply
+		isRoot      bool
+		isMeta      bool
+		isThread    bool
+	}{
+		{
+			name:        "legacy root message",
+			subject:     "space.Sprimary.room.Rroom.msg.Eevt",
+			wantRoom:    "Rroom",
+			wantEventID: "Eevt",
+			isRoot:      true,
+		},
+		{
+			name:        "server root message channel",
+			subject:     "server.room.channel.Rroom.msg.Eevt",
+			wantRoom:    "Rroom",
+			wantEventID: "Eevt",
+			isRoot:      true,
+		},
+		{
+			name:        "server root message DM",
+			subject:     "server.room.dm.Rroom.msg.Eevt",
+			wantRoom:    "Rroom",
+			wantEventID: "Eevt",
+			isRoot:      true,
+		},
+		{
+			name:        "legacy thread reply",
+			subject:     "space.Sprimary.room.Rroom.msg.Eroot.replies.Erep",
+			wantRoom:    "Rroom",
+			wantEventID: "Erep",
+			wantRootID:  "Eroot",
+			isThread:    true,
+		},
+		{
+			name:        "server thread reply",
+			subject:     "server.room.channel.Rroom.msg.Eroot.replies.Erep",
+			wantRoom:    "Rroom",
+			wantEventID: "Erep",
+			wantRootID:  "Eroot",
+			isThread:    true,
+		},
+		{
+			name:     "legacy meta",
+			subject:  "space.Sprimary.room.Rroom.meta",
+			wantRoom: "Rroom",
+			isMeta:   true,
+		},
+		{
+			name:     "server meta DM",
+			subject:  "server.room.dm.Rroom.meta",
+			wantRoom: "Rroom",
+			isMeta:   true,
+		},
+		{
+			name:    "server space-level (not a room)",
+			subject: "server.member.member_deleted",
+		},
+		{
+			name:    "legacy space-level (not a room)",
+			subject: "space.Sprimary.member_deleted",
+		},
+		{
+			name:    "garbage",
+			subject: "wat",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ParseRoomIDFromSubject(tc.subject); got != tc.wantRoom {
+				t.Errorf("ParseRoomIDFromSubject = %q, want %q", got, tc.wantRoom)
+			}
+			if got := ParseEventIDFromSubject(tc.subject); got != tc.wantEventID {
+				t.Errorf("ParseEventIDFromSubject = %q, want %q", got, tc.wantEventID)
+			}
+			gotRoot, gotOK := ParseThreadRootEventIDFromSubject(tc.subject)
+			wantOK := tc.wantRootID != ""
+			if gotOK != wantOK || gotRoot != tc.wantRootID {
+				t.Errorf("ParseThreadRootEventIDFromSubject = (%q, %v), want (%q, %v)", gotRoot, gotOK, tc.wantRootID, wantOK)
+			}
+			if got := IsRootMessageSubject(tc.subject); got != tc.isRoot {
+				t.Errorf("IsRootMessageSubject = %v, want %v", got, tc.isRoot)
+			}
+			if got := IsMetaSubject(tc.subject); got != tc.isMeta {
+				t.Errorf("IsMetaSubject = %v, want %v", got, tc.isMeta)
+			}
+			if got := IsThreadSubject(tc.subject); got != tc.isThread {
+				t.Errorf("IsThreadSubject = %v, want %v", got, tc.isThread)
+			}
+		})
+	}
+}
+
+// ===== Round-trip: construct then parse =====
+
+func TestRoundTrip_ServerFormat(t *testing.T) {
+	setPrimaryForTest(t, "Sprimary")
+
+	for _, tc := range []struct {
+		name    string
+		spaceID string
+		roomID  string
+		eventID string
+	}{
+		{"primary channel", "Sprimary", "Rroom1", "Eevt1"},
+		{"DM", "DM", "Rroom2", "Eevt2"},
+	} {
+		t.Run(tc.name+"/root", func(t *testing.T) {
+			subject := SpaceRoomMessage(tc.spaceID, tc.roomID, tc.eventID)
+			if got := ParseRoomIDFromSubject(subject); got != tc.roomID {
+				t.Errorf("room: got %q, want %q (subject=%q)", got, tc.roomID, subject)
+			}
+			if got := ParseEventIDFromSubject(subject); got != tc.eventID {
+				t.Errorf("event: got %q, want %q (subject=%q)", got, tc.eventID, subject)
+			}
+			if !IsRootMessageSubject(subject) {
+				t.Errorf("IsRootMessageSubject(%q) = false", subject)
+			}
+		})
+
+		t.Run(tc.name+"/thread", func(t *testing.T) {
+			subject := SpaceRoomThread(tc.spaceID, tc.roomID, "Eroot", tc.eventID)
+			if got := ParseRoomIDFromSubject(subject); got != tc.roomID {
+				t.Errorf("room: got %q, want %q (subject=%q)", got, tc.roomID, subject)
+			}
+			if got := ParseEventIDFromSubject(subject); got != tc.eventID {
+				t.Errorf("event: got %q, want %q (subject=%q)", got, tc.eventID, subject)
+			}
+			gotRoot, ok := ParseThreadRootEventIDFromSubject(subject)
+			if !ok || gotRoot != "Eroot" {
+				t.Errorf("root: got (%q, %v) want (Eroot, true) (subject=%q)", gotRoot, ok, subject)
+			}
+			if !IsThreadSubject(subject) {
+				t.Errorf("IsThreadSubject(%q) = false", subject)
+			}
+		})
+
+		t.Run(tc.name+"/meta", func(t *testing.T) {
+			subject := SpaceRoomMeta(tc.spaceID, tc.roomID)
+			if got := ParseRoomIDFromSubject(subject); got != tc.roomID {
+				t.Errorf("room: got %q, want %q (subject=%q)", got, tc.roomID, subject)
+			}
+			if !IsMetaSubject(subject) {
+				t.Errorf("IsMetaSubject(%q) = false", subject)
+			}
+		})
+	}
+}
+
+// ===== Singleton behavior =====
+
+func TestSetPrimarySpaceID_ClearsOnEmpty(t *testing.T) {
+	setPrimaryForTest(t, "Sprimary")
+	if PrimarySpaceID() != "Sprimary" {
+		t.Fatalf("expected primary to be Sprimary, got %q", PrimarySpaceID())
+	}
+	SetPrimarySpaceID("")
+	if PrimarySpaceID() != "" {
+		t.Errorf("expected primary cleared, got %q", PrimarySpaceID())
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Phase 4d-prep of the #330 / #354 server-data consolidation: adds dual-format support to the `subjects` package ahead of the events-stream migration. Pure additive change with **zero behavior change** — the primary-singleton stays unset, every existing call site produces byte-identical legacy strings, and the full backend suite is green.

- **`subjects/primary.go`** (new): `atomic.Pointer[string]` singleton, `SetPrimarySpaceID` / `PrimarySpaceID`, `shouldUseServerSubjects(spaceID)` predicate, `roomKind(spaceID)` helper. DM is gated on the singleton (unlike core KV routing) so subjects don't direct publishes to a `SERVER_EVENTS` stream that doesn't exist yet.
- **Subject constructors**: every space-stream and live-space helper now dispatches on the singleton. Legacy `space.{id}.>` for non-primary/non-DM; consolidated `server.>` (with `{kind}` segment for room subjects, mirroring SERVER_CONFIG key prefix) for primary + DM.
- **Parsers**: accept either prefix; index alignment between formats made this a single prefix-detection branch.
- **Drive-by**: `rooms.go:2051` had a hardcoded `fmt.Sprintf("space.%s.room.%s.msg.*", ...)` — replaced with `subjects.SpaceRoomRootMessages()`.
- **Tests**: 24 new tests cover server-format constructors, parsers, round-trips, singleton state, and DM gating.

## Test plan

- [x] `mise test-cli` — full backend suite green
- [x] New subjects tests cover both formats and DM gating behavior
- [ ] Phase 4d-migrate (next PR) wires `SetPrimarySpaceID` after `SERVER_EVENTS` is created and adds the migrator