### PR TITLE
feat(migration): phase 4d — per-space event streams → SERVER_EVENTS (#354)

### DIFF
--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -93,11 +93,21 @@ func (c *ChattoCore) PrimarySpaceID() string {
 }
 
 // SetPrimarySpaceID records the deployment-wide primary space. After this is
-// set, the primary's CONFIG/RBAC/RUNTIME accessors route to the SERVER_*
-// buckets instead of per-space SPACE_{id}_* buckets. Should be called once at
-// boot, after the primary has been resolved and before any traffic is served.
+// set:
+//
+//   - The primary's CONFIG/RBAC/RUNTIME/BODIES/REACTIONS/THREADS/ASSETS
+//     accessors route to the SERVER_* buckets/object store (#330 phase 4a–c, e).
+//   - The primary's event stream accessor routes to SERVER_EVENTS, and all
+//     subject construction for the primary and DM space switches to the
+//     consolidated `server.>` namespace (#330 phase 4d).
+//
+// Should be called once at boot, after the primary has been resolved and
+// before any traffic is served. Activating subject construction here
+// (rather than in newStorage) means SERVER_EVENTS already exists by the
+// time anyone publishes to a `server.>` subject.
 func (c *ChattoCore) SetPrimarySpaceID(spaceID string) {
 	c.primarySpaceID.Store(spaceID)
+	subjects.SetPrimarySpaceID(spaceID)
 }
 
 // usesServerLevelMetadata reports whether the given spaceID's CONFIG /
@@ -464,9 +474,10 @@ type storage struct {
 	instanceRBACKV   jetstream.KeyValue // Instance-level roles and permissions
 	instanceConfigKV jetstream.KeyValue // Runtime configuration overrides
 
-	// Server-level KV buckets (#330 phase 4a, 4b, 4c, 4e). Shared by the primary
-	// and DM spaces; non-primary, non-DM spaces (test-created only in
-	// practice) keep their per-space lazycaches below.
+	// Server-level KV buckets (#330 phase 4a, 4b, 4c, 4e) and event stream
+	// (#330 phase 4d). Shared by the primary and DM spaces; non-primary,
+	// non-DM spaces (test-created only in practice) keep their per-space
+	// lazycaches below.
 	serverConfigKV     jetstream.KeyValue    // SERVER_CONFIG    - rooms, memberships
 	serverRuntimeKV    jetstream.KeyValue    // SERVER_RUNTIME   - sequences, timestamps, read state
 	serverRBACKV       jetstream.KeyValue    // SERVER_RBAC      - roles, permissions, assignments
@@ -475,6 +486,7 @@ type storage struct {
 	serverReactionsKV  jetstream.KeyValue    // SERVER_REACTIONS - emoji reactions (#330 phase 4c)
 	serverThreadsKV    jetstream.KeyValue    // SERVER_THREADS   - thread metadata (#330 phase 4c)
 	serverAttachments  jetstream.ObjectStore // SERVER_ASSETS    - message attachments (#330 phase 4e)
+	serverEventsStream jetstream.Stream      // SERVER_EVENTS    - event stream (#330 phase 4d)
 
 	// Legacy per-space caches. Still backing non-primary, non-DM spaces.
 	// Primary and DM access route to the server-level buckets above and
@@ -691,6 +703,23 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		return nil, fmt.Errorf("failed to create SERVER_ASSETS object store: %w", err)
 	}
 
+	// Initialize the deployment-wide events stream (#330 phase 4d). Holds all
+	// JetStream events for the primary space and the DM system space; non-
+	// primary, non-DM spaces (test-created only in production) keep their
+	// per-space SPACE_{id}_EVENTS streams.
+	serverEventsStream, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+		Name:               "SERVER_EVENTS",
+		Description:        "Server-level event stream (primary + DM)",
+		Subjects:           []string{"server.>"},
+		Storage:            jetstream.FileStorage,
+		Compression:        jetstream.S2Compression,
+		AllowAtomicPublish: true,
+		Replicas:           cfg.Replicas,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SERVER_EVENTS stream: %w", err)
+	}
+
 	// Initialize auth tokens KV bucket with configurable TTL
 	// Stores opaque bearer tokens for cross-origin API authentication.
 	// NATS TTL handles automatic token expiry.
@@ -717,13 +746,14 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		encryptionKV:     encryptionKV,
 		instanceRBACKV:   instanceRBACKV,
 		instanceConfigKV: instanceConfigKV,
-		serverConfigKV:    serverConfigKV,
-		serverRBACKV:      serverRBACKV,
-		serverRuntimeKV:   serverRuntimeKV,
-		serverBodiesKV:    serverBodiesKV,
-		serverReactionsKV: serverReactionsKV,
-		serverThreadsKV:   serverThreadsKV,
-		serverAttachments: serverAttachments,
+		serverConfigKV:     serverConfigKV,
+		serverRBACKV:       serverRBACKV,
+		serverRuntimeKV:    serverRuntimeKV,
+		serverBodiesKV:     serverBodiesKV,
+		serverReactionsKV:  serverReactionsKV,
+		serverThreadsKV:    serverThreadsKV,
+		serverAttachments:  serverAttachments,
+		serverEventsStream: serverEventsStream,
 		// serverRBACEngine is constructed below (after the storage value
 		// exists) and assigned in NewChattoCore so it can use the same engine
 		// configuration as the per-space engines.
@@ -1511,8 +1541,23 @@ func (c *ChattoCore) createSpaceResources(ctx context.Context, spaceID string) e
 
 // getSpaceStream returns the stream for a given space, creating it if needed.
 // Used by consumers that need to subscribe to space or room events.
-// Room events are stored in the space stream with subjects like space.{spaceId}.room.{roomId}.>
+//
+// Post-#330 phase 4d: the primary and DM spaces share the deployment-wide
+// SERVER_EVENTS stream (eager-created in newStorage). Other spaces continue
+// to use their per-space SPACE_{id}_EVENTS stream, lazily created on first
+// access via ensureSpaceStream.
+//
+// Routing is gated on the subjects singleton (`subjects.UsesServerSubjects`),
+// not on `usesServerLevelMetadata`. This keeps stream selection in lockstep
+// with subject construction: until SetPrimarySpaceID activates the singleton
+// (e.g., in tests that never call it), DM publishes still go to
+// `space.DM.>` subjects which land in `SPACE_DM_EVENTS` — so reads must look
+// there too, not in `SERVER_EVENTS`.
 func (c *ChattoCore) getSpaceStream(ctx context.Context, spaceID string) (jetstream.Stream, error) {
+	if subjects.UsesServerSubjects(spaceID) {
+		return c.storage.serverEventsStream, nil
+	}
+
 	// Lazily ensure stream exists with current config
 	if err := c.ensureSpaceStream(ctx, spaceID); err != nil {
 		return nil, err

--- a/cli/internal/core/core_test.go
+++ b/cli/internal/core/core_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	"hmans.de/chatto/internal/config"
+	"hmans.de/chatto/internal/core/subjects"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
@@ -58,6 +59,10 @@ func setupTestCore(t *testing.T) (*ChattoCore, *nats.Conn) {
 		nc.Close()
 		ns.Shutdown()
 		ns.WaitForShutdown()
+		// The subjects package primary singleton is process-global; tests
+		// that call SetPrimarySpaceID would otherwise pollute subsequent
+		// tests in the same package run.
+		subjects.SetPrimarySpaceID("")
 	})
 
 	ctx := testContext(t)

--- a/cli/internal/core/schema_migration.go
+++ b/cli/internal/core/schema_migration.go
@@ -7,7 +7,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
+	"google.golang.org/protobuf/proto"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
 // Schema migration coordinates the move from the per-space `SPACE_{id}_*`
@@ -62,6 +66,15 @@ const (
 	// DM into the deployment-wide SERVER_ASSETS object store. Keys
 	// (attachment IDs) are globally unique and copied verbatim.
 	phase4eCompleteKey = "migration.phase4e_complete"
+
+	// phase4dCompleteKey marks phase 4d as done. Phase 4d migrates the
+	// per-space JetStream event streams (SPACE_{primary}_EVENTS,
+	// SPACE_DM_EVENTS) into the deployment-wide SERVER_EVENTS stream,
+	// rewriting subjects from `space.{id}.>` to `server.>` along the way.
+	// Runs after 4a–4c, 4e because the singleton-driven subject + stream
+	// switch must already be in place when this completes — once the
+	// marker is set, nothing else writes to the legacy streams.
+	phase4dCompleteKey = "migration.phase4d_complete"
 )
 
 // RunMigrationsIfNeeded runs any pending schema migrations. Idempotent and
@@ -85,6 +98,9 @@ func (c *ChattoCore) RunMigrationsIfNeeded(ctx context.Context, primarySpaceID s
 		return err
 	}
 	if err := c.runPhase4eIfNeeded(ctx, primarySpaceID); err != nil {
+		return err
+	}
+	if err := c.runPhase4dIfNeeded(ctx, primarySpaceID); err != nil {
 		return err
 	}
 	return nil
@@ -924,6 +940,316 @@ func (c *ChattoCore) acquireMigrationLock(ctx context.Context) (release func(), 
 		}
 	}
 	return release, nil
+}
+
+// runPhase4dIfNeeded copies events from the per-space JetStream streams
+// (SPACE_{primary}_EVENTS, SPACE_DM_EVENTS) into the deployment-wide
+// SERVER_EVENTS stream, rewriting each subject from `space.{id}.>` to
+// `server.>` along the way (see rewriteSubjectForServerStream).
+//
+// Re-publishing through the NATS client means JetStream stamps fresh
+// store-times on the migrated messages — but ChattoCore's read paths
+// already use the proto's `created_at` and JetStream sequences (see the
+// pagination-cursor refactor that landed before this phase), so the
+// reset store-times have no observable effect.
+//
+// Idempotency: re-runs detect already-migrated events by event ID and
+// skip them. The marker is the gating mechanism in steady state; the
+// per-event dedup is what keeps a crashed mid-run safe to resume.
+func (c *ChattoCore) runPhase4dIfNeeded(ctx context.Context, primarySpaceID string) error {
+	if done, err := c.isMigrationComplete(ctx, phase4dCompleteKey); err != nil {
+		return fmt.Errorf("phase4d: check completion marker: %w", err)
+	} else if done {
+		return nil
+	}
+
+	release, err := c.acquireMigrationLock(ctx)
+	if err != nil {
+		return fmt.Errorf("phase4d: acquire lock: %w", err)
+	}
+	defer release()
+
+	if done, err := c.isMigrationComplete(ctx, phase4dCompleteKey); err != nil {
+		return fmt.Errorf("phase4d: re-check completion marker: %w", err)
+	} else if done {
+		return nil
+	}
+
+	c.logger.Info("phase4d: migrating per-space event streams to SERVER_EVENTS",
+		"primary_space_id", primarySpaceID)
+
+	// Build the set of event IDs already present on the target so we can
+	// skip re-publishing them. On a fresh install this is empty; on a
+	// crashed-mid-run resume it covers everything we already wrote.
+	alreadyMigrated, err := c.collectServerEventIDs(ctx)
+	if err != nil {
+		return fmt.Errorf("phase4d: scan target stream: %w", err)
+	}
+
+	if primarySpaceID != "" {
+		if err := c.copyEventStream(ctx, legacySpaceEventsStream(primarySpaceID), "channel", alreadyMigrated, "PRIMARY_EVENTS"); err != nil {
+			return fmt.Errorf("phase4d: copy primary events: %w", err)
+		}
+	}
+	if err := c.copyEventStream(ctx, legacySpaceEventsStream(DMSpaceID), "dm", alreadyMigrated, "DM_EVENTS"); err != nil {
+		return fmt.Errorf("phase4d: copy DM events: %w", err)
+	}
+
+	if err := c.verifyPhase4d(ctx, primarySpaceID); err != nil {
+		return fmt.Errorf("phase4d: verify: %w", err)
+	}
+
+	if err := c.markMigrationComplete(ctx, phase4dCompleteKey); err != nil {
+		return fmt.Errorf("phase4d: mark complete: %w", err)
+	}
+
+	c.logger.Info("phase4d: migration complete")
+	return nil
+}
+
+// collectServerEventIDs walks SERVER_EVENTS and returns the set of event
+// IDs already present. Used by the migrator to dedup mid-run resumes.
+// Returns an empty set for a fresh install (no messages yet).
+func (c *ChattoCore) collectServerEventIDs(ctx context.Context) (map[string]struct{}, error) {
+	seen := make(map[string]struct{})
+	target := c.storage.serverEventsStream
+
+	info, err := target.Info(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("server stream info: %w", err)
+	}
+	if info.State.Msgs == 0 {
+		return seen, nil
+	}
+
+	consumer, err := target.CreateConsumer(ctx, jetstream.ConsumerConfig{
+		DeliverPolicy:     jetstream.DeliverAllPolicy,
+		AckPolicy:         jetstream.AckNonePolicy,
+		MemoryStorage:     true,
+		InactiveThreshold: 30 * time.Second,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create scan consumer: %w", err)
+	}
+	defer target.DeleteConsumer(context.Background(), consumer.CachedInfo().Name)
+
+	msgs, err := consumer.Fetch(int(info.State.Msgs), jetstream.FetchMaxWait(30*time.Second))
+	if err != nil && !errors.Is(err, jetstream.ErrNoMessages) {
+		return nil, fmt.Errorf("fetch existing events: %w", err)
+	}
+	if msgs != nil {
+		for msg := range msgs.Messages() {
+			id, ok := eventIDFromPayload(msg.Data())
+			if ok {
+				seen[id] = struct{}{}
+			}
+		}
+	}
+	return seen, nil
+}
+
+// copyEventStream reads every message in sourceStreamName, rewrites its
+// subject for the server format using `kind`, and publishes it to
+// SERVER_EVENTS. Skips messages whose event ID is already in
+// alreadyMigrated. Missing source stream is treated as nothing-to-do.
+func (c *ChattoCore) copyEventStream(ctx context.Context, sourceStreamName, kind string, alreadyMigrated map[string]struct{}, logTag string) error {
+	source, err := c.js.Stream(ctx, sourceStreamName)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrStreamNotFound) {
+			c.logger.Debug("phase4d: source stream missing, skipping",
+				"stream", sourceStreamName, "tag", logTag)
+			return nil
+		}
+		return fmt.Errorf("open source stream %s: %w", sourceStreamName, err)
+	}
+
+	info, err := source.Info(ctx)
+	if err != nil {
+		return fmt.Errorf("source %s info: %w", sourceStreamName, err)
+	}
+	if info.State.Msgs == 0 {
+		c.logger.Info("phase4d: source stream empty",
+			"stream", sourceStreamName, "tag", logTag)
+		return nil
+	}
+
+	consumer, err := source.CreateConsumer(ctx, jetstream.ConsumerConfig{
+		DeliverPolicy:     jetstream.DeliverAllPolicy,
+		AckPolicy:         jetstream.AckNonePolicy,
+		MemoryStorage:     true,
+		InactiveThreshold: 30 * time.Second,
+	})
+	if err != nil {
+		return fmt.Errorf("create source consumer: %w", err)
+	}
+	defer source.DeleteConsumer(context.Background(), consumer.CachedInfo().Name)
+
+	msgs, err := consumer.Fetch(int(info.State.Msgs), jetstream.FetchMaxWait(60*time.Second))
+	if err != nil && !errors.Is(err, jetstream.ErrNoMessages) {
+		return fmt.Errorf("fetch source messages: %w", err)
+	}
+
+	var copied, skippedDup, skippedUnknown int
+	if msgs != nil {
+		for msg := range msgs.Messages() {
+			eventID, hasID := eventIDFromPayload(msg.Data())
+			if hasID {
+				if _, dup := alreadyMigrated[eventID]; dup {
+					skippedDup++
+					continue
+				}
+			}
+
+			newSubject, ok := rewriteSubjectForServerStream(msg.Subject(), kind)
+			if !ok {
+				skippedUnknown++
+				c.logger.Warn("phase4d: skipping subject with unknown shape",
+					"stream", sourceStreamName, "subject", msg.Subject())
+				continue
+			}
+
+			if _, err := c.js.PublishMsg(ctx, &nats.Msg{
+				Subject: newSubject,
+				Header:  msg.Headers(),
+				Data:    msg.Data(),
+			}); err != nil {
+				return fmt.Errorf("publish %q to SERVER_EVENTS: %w", newSubject, err)
+			}
+			if hasID {
+				alreadyMigrated[eventID] = struct{}{}
+			}
+			copied++
+		}
+	}
+
+	c.logger.Info("phase4d: copied event stream",
+		"source", sourceStreamName,
+		"tag", logTag,
+		"copied", copied,
+		"skipped_already_migrated", skippedDup,
+		"skipped_unknown_subject", skippedUnknown,
+	)
+	return nil
+}
+
+// verifyPhase4d confirms every event ID in the source streams is present
+// in SERVER_EVENTS. Mismatch aborts the migration (marker stays unset,
+// next boot retries).
+func (c *ChattoCore) verifyPhase4d(ctx context.Context, primarySpaceID string) error {
+	targetIDs, err := c.collectServerEventIDs(ctx)
+	if err != nil {
+		return fmt.Errorf("scan target for verify: %w", err)
+	}
+
+	sourceStreams := []struct {
+		name string
+		tag  string
+	}{
+		{legacySpaceEventsStream(DMSpaceID), "DM_EVENTS"},
+	}
+	if primarySpaceID != "" {
+		sourceStreams = append(sourceStreams,
+			struct {
+				name string
+				tag  string
+			}{legacySpaceEventsStream(primarySpaceID), "PRIMARY_EVENTS"})
+	}
+
+	for _, src := range sourceStreams {
+		if err := c.verifyEventStreamCopy(ctx, src.name, targetIDs, src.tag); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// verifyEventStreamCopy walks one source stream and confirms each event
+// ID is present in targetIDs. Source-stream-not-found is fine (nothing
+// to verify). Subjects that don't yield an event ID are tolerated —
+// they're already accounted for as `skipped_unknown_subject` during the
+// copy phase.
+func (c *ChattoCore) verifyEventStreamCopy(ctx context.Context, sourceStreamName string, targetIDs map[string]struct{}, tag string) error {
+	source, err := c.js.Stream(ctx, sourceStreamName)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrStreamNotFound) {
+			return nil
+		}
+		return fmt.Errorf("open source %s for verify: %w", sourceStreamName, err)
+	}
+
+	info, err := source.Info(ctx)
+	if err != nil {
+		return fmt.Errorf("source %s info for verify: %w", sourceStreamName, err)
+	}
+	if info.State.Msgs == 0 {
+		return nil
+	}
+
+	consumer, err := source.CreateConsumer(ctx, jetstream.ConsumerConfig{
+		DeliverPolicy:     jetstream.DeliverAllPolicy,
+		AckPolicy:         jetstream.AckNonePolicy,
+		MemoryStorage:     true,
+		InactiveThreshold: 30 * time.Second,
+	})
+	if err != nil {
+		return fmt.Errorf("verify consumer: %w", err)
+	}
+	defer source.DeleteConsumer(context.Background(), consumer.CachedInfo().Name)
+
+	msgs, err := consumer.Fetch(int(info.State.Msgs), jetstream.FetchMaxWait(30*time.Second))
+	if err != nil && !errors.Is(err, jetstream.ErrNoMessages) {
+		return fmt.Errorf("verify fetch: %w", err)
+	}
+
+	var sourceCount, missingCount int
+	if msgs != nil {
+		for msg := range msgs.Messages() {
+			id, ok := eventIDFromPayload(msg.Data())
+			if !ok {
+				continue
+			}
+			sourceCount++
+			if _, present := targetIDs[id]; !present {
+				missingCount++
+				c.logger.Error("phase4d: event missing in target after copy",
+					"source_stream", sourceStreamName,
+					"tag", tag,
+					"event_id", id,
+				)
+			}
+		}
+	}
+
+	if missingCount > 0 {
+		return fmt.Errorf("verification failed: %d of %d events from %s missing in target",
+			missingCount, sourceCount, sourceStreamName)
+	}
+
+	c.logger.Info("phase4d: verified event stream",
+		"source", sourceStreamName,
+		"tag", tag,
+		"events_verified", sourceCount,
+	)
+	return nil
+}
+
+// eventIDFromPayload extracts the SpaceEvent.id field from a serialized
+// payload. Used by the migrator's dedup and verify steps. Returns
+// ("", false) if the payload doesn't deserialize as a SpaceEvent or the
+// id field is empty.
+func eventIDFromPayload(data []byte) (string, bool) {
+	var event corev1.SpaceEvent
+	if err := proto.Unmarshal(data, &event); err != nil {
+		return "", false
+	}
+	if event.Id == "" {
+		return "", false
+	}
+	return event.Id, true
+}
+
+func legacySpaceEventsStream(spaceID string) string {
+	return fmt.Sprintf("SPACE_%s_EVENTS", spaceID)
 }
 
 // legacy bucket name helpers — kept here so the legacy naming convention is

--- a/cli/internal/core/schema_migration_subjects.go
+++ b/cli/internal/core/schema_migration_subjects.go
@@ -1,0 +1,65 @@
+package core
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Subject rewriting helper for the #330 phase 4d migration. Pure
+// functions; isolated from NATS so they can be unit-tested without a
+// running JetStream.
+//
+// Each legacy subject from a per-space stream maps to exactly one
+// server-format subject. The mapping is deterministic from the legacy
+// subject and the room kind (channel for the primary, dm for the DM
+// space). Membership-event subjects strip the redundant `member_`
+// prefix because the new shape namespaces them under `member.` already.
+
+// rewriteSubjectForServerStream maps a legacy space-stream subject to
+// its server-format equivalent. `legacySubject` must start with
+// `space.{spaceID}.…`. `kind` is "channel" or "dm" — chosen by the
+// caller based on which source stream the message came from.
+//
+// Returns ("", false) for subjects that don't match a known legacy
+// shape; the caller logs and skips them rather than corrupting the
+// target stream with a misrouted message.
+//
+// Mappings:
+//
+//	space.{X}.room.{R}.msg.{E}                 → server.room.{kind}.{R}.msg.{E}
+//	space.{X}.room.{R}.msg.{root}.replies.{E}  → server.room.{kind}.{R}.msg.{root}.replies.{E}
+//	space.{X}.room.{R}.meta                    → server.room.{kind}.{R}.meta
+//	space.{X}.member_{verb}                    → server.member.{verb}
+func rewriteSubjectForServerStream(legacySubject, kind string) (string, bool) {
+	parts := strings.Split(legacySubject, ".")
+
+	// All legacy space-stream subjects start with `space.{spaceID}.…`.
+	if len(parts) < 3 || parts[0] != "space" {
+		return "", false
+	}
+
+	// Room subjects: space.{X}.room.{R}.…
+	if len(parts) >= 5 && parts[2] == "room" {
+		roomID := parts[3]
+		tail := parts[4:]
+		switch {
+		case len(tail) == 1 && tail[0] == "meta":
+			return fmt.Sprintf("server.room.%s.%s.meta", kind, roomID), true
+		case len(tail) == 2 && tail[0] == "msg":
+			return fmt.Sprintf("server.room.%s.%s.msg.%s", kind, roomID, tail[1]), true
+		case len(tail) == 4 && tail[0] == "msg" && tail[2] == "replies":
+			return fmt.Sprintf("server.room.%s.%s.msg.%s.replies.%s", kind, roomID, tail[1], tail[3]), true
+		}
+		return "", false
+	}
+
+	// Space-level (membership) subject: space.{X}.{eventType}. The
+	// `member_` prefix on the eventType is stripped to match the
+	// server-side `server.member.{verb}` shape.
+	if len(parts) == 3 {
+		verb := strings.TrimPrefix(parts[2], "member_")
+		return fmt.Sprintf("server.member.%s", verb), true
+	}
+
+	return "", false
+}

--- a/cli/internal/core/schema_migration_subjects_test.go
+++ b/cli/internal/core/schema_migration_subjects_test.go
@@ -1,0 +1,100 @@
+package core
+
+import "testing"
+
+func TestRewriteSubjectForServerStream(t *testing.T) {
+	cases := []struct {
+		name    string
+		legacy  string
+		kind    string
+		want    string
+		wantOK  bool
+	}{
+		{
+			name:   "primary root message → channel kind",
+			legacy: "space.Sprimary.room.Rroom.msg.Eevt",
+			kind:   "channel",
+			want:   "server.room.channel.Rroom.msg.Eevt",
+			wantOK: true,
+		},
+		{
+			name:   "DM root message → dm kind",
+			legacy: "space.DM.room.Rroom.msg.Eevt",
+			kind:   "dm",
+			want:   "server.room.dm.Rroom.msg.Eevt",
+			wantOK: true,
+		},
+		{
+			name:   "primary thread reply",
+			legacy: "space.Sprimary.room.Rroom.msg.Eroot.replies.Erep",
+			kind:   "channel",
+			want:   "server.room.channel.Rroom.msg.Eroot.replies.Erep",
+			wantOK: true,
+		},
+		{
+			name:   "DM thread reply",
+			legacy: "space.DM.room.Rroom.msg.Eroot.replies.Erep",
+			kind:   "dm",
+			want:   "server.room.dm.Rroom.msg.Eroot.replies.Erep",
+			wantOK: true,
+		},
+		{
+			name:   "primary meta",
+			legacy: "space.Sprimary.room.Rroom.meta",
+			kind:   "channel",
+			want:   "server.room.channel.Rroom.meta",
+			wantOK: true,
+		},
+		{
+			name:   "DM meta",
+			legacy: "space.DM.room.Rroom.meta",
+			kind:   "dm",
+			want:   "server.room.dm.Rroom.meta",
+			wantOK: true,
+		},
+		{
+			name:   "membership: member_deleted strips prefix",
+			legacy: "space.Sprimary.member_deleted",
+			kind:   "channel",
+			want:   "server.member.deleted",
+			wantOK: true,
+		},
+		{
+			name:   "membership: bare verb passes through",
+			legacy: "space.Sprimary.joined",
+			kind:   "channel",
+			want:   "server.member.joined",
+			wantOK: true,
+		},
+		{
+			name:   "unknown shape: too few segments",
+			legacy: "space.Sprimary",
+			kind:   "channel",
+			wantOK: false,
+		},
+		{
+			name:   "unknown shape: garbage tail",
+			legacy: "space.Sprimary.room.Rroom.unexpected",
+			kind:   "channel",
+			wantOK: false,
+		},
+		{
+			name:   "unknown shape: wrong prefix",
+			legacy: "server.room.channel.Rroom.msg.Eevt",
+			kind:   "channel",
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := rewriteSubjectForServerStream(tc.legacy, tc.kind)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (got=%q)", ok, tc.wantOK, got)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/cli/internal/core/schema_migration_test.go
+++ b/cli/internal/core/schema_migration_test.go
@@ -631,6 +631,298 @@ func TestPhase4eMigration_FreshInstall(t *testing.T) {
 	}
 }
 
+// ===== Phase 4d (events stream) tests =====
+
+// TestPhase4dMigration_CopiesPrimaryAndDMStreams verifies the happy path:
+// events posted to the primary space and to a DM both end up in
+// SERVER_EVENTS with rewritten subjects after the migration runs.
+func TestPhase4dMigration_CopiesPrimaryAndDMStreams(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	user, err := core.CreateUser(ctx, "system", "poster1", "Poster", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	// Create a soon-to-be-primary space with a room and a few messages.
+	// Singleton stays unset for now → publishes go to `space.{id}.>`,
+	// which lands in `SPACE_{id}_EVENTS`. That's the legacy data the
+	// migrator will copy.
+	space, err := core.CreateSpace(ctx, user.Id, "Primary", "")
+	if err != nil {
+		t.Fatalf("CreateSpace: %v", err)
+	}
+	room, err := core.CreateRoom(ctx, user.Id, space.Id, "general", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, user.Id, space.Id, user.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom: %v", err)
+	}
+	primaryEvent, err := core.PostMessage(ctx, space.Id, room.Id, user.Id, "primary message", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage primary: %v", err)
+	}
+
+	// Seed a DM as well.
+	other, err := core.CreateUser(ctx, "system", "dm-peer", "DM Peer", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	dmRoom, _, err := core.FindOrCreateDM(ctx, user.Id, []string{other.Id})
+	if err != nil {
+		t.Fatalf("FindOrCreateDM: %v", err)
+	}
+	dmEvent, err := core.PostMessage(ctx, DMSpaceID, dmRoom.Id, user.Id, "dm message", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage DM: %v", err)
+	}
+
+	// Now activate the singleton + run migrations. From this point on,
+	// new publishes would go to `server.>` subjects, but we're not
+	// publishing more — we're verifying the migrator copies the legacy
+	// data over.
+	core.SetPrimarySpaceID(space.Id)
+	if err := core.RunMigrationsIfNeeded(ctx, space.Id); err != nil {
+		t.Fatalf("RunMigrationsIfNeeded: %v", err)
+	}
+
+	// Marker set.
+	if _, err := core.storage.instanceKV.Get(ctx, phase4dCompleteKey); err != nil {
+		t.Fatalf("expected phase4d completion marker: %v", err)
+	}
+
+	// Both events landed in SERVER_EVENTS at their rewritten subjects.
+	primarySubject := "server.room.channel." + room.Id + ".msg." + primaryEvent.Id
+	if got, err := core.storage.serverEventsStream.GetLastMsgForSubject(ctx, primarySubject); err != nil {
+		t.Errorf("primary event missing in SERVER_EVENTS at %q: %v", primarySubject, err)
+	} else {
+		var ev corev1.SpaceEvent
+		if err := proto.Unmarshal(got.Data, &ev); err != nil {
+			t.Fatalf("unmarshal primary: %v", err)
+		}
+		if ev.Id != primaryEvent.Id {
+			t.Errorf("primary event id mismatch: got %q want %q", ev.Id, primaryEvent.Id)
+		}
+	}
+
+	dmSubject := "server.room.dm." + dmRoom.Id + ".msg." + dmEvent.Id
+	if got, err := core.storage.serverEventsStream.GetLastMsgForSubject(ctx, dmSubject); err != nil {
+		t.Errorf("DM event missing in SERVER_EVENTS at %q: %v", dmSubject, err)
+	} else {
+		var ev corev1.SpaceEvent
+		if err := proto.Unmarshal(got.Data, &ev); err != nil {
+			t.Fatalf("unmarshal DM: %v", err)
+		}
+		if ev.Id != dmEvent.Id {
+			t.Errorf("DM event id mismatch: got %q want %q", ev.Id, dmEvent.Id)
+		}
+	}
+}
+
+// TestPhase4dMigration_FreshInstall verifies the migrator runs cleanly
+// on a fresh install with no events to copy.
+func TestPhase4dMigration_FreshInstall(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	if err := core.RunMigrationsIfNeeded(ctx, ""); err != nil {
+		t.Fatalf("RunMigrationsIfNeeded: %v", err)
+	}
+	if _, err := core.storage.instanceKV.Get(ctx, phase4dCompleteKey); err != nil {
+		t.Fatalf("expected phase4d completion marker: %v", err)
+	}
+
+	// Re-run is a fast no-op via the marker.
+	if err := core.RunMigrationsIfNeeded(ctx, ""); err != nil {
+		t.Fatalf("second run failed: %v", err)
+	}
+}
+
+// TestPhase4dMigration_IdempotentOnRerun verifies that re-running the
+// migrator after the marker has been forcibly cleared does not duplicate
+// events in SERVER_EVENTS.
+func TestPhase4dMigration_IdempotentOnRerun(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	user, err := core.CreateUser(ctx, "system", "poster2", "Poster", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	space, err := core.CreateSpace(ctx, user.Id, "Primary", "")
+	if err != nil {
+		t.Fatalf("CreateSpace: %v", err)
+	}
+	room, err := core.CreateRoom(ctx, user.Id, space.Id, "general", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, user.Id, space.Id, user.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if _, err := core.PostMessage(ctx, space.Id, room.Id, user.Id, "msg", nil, "", "", nil, false); err != nil {
+			t.Fatalf("PostMessage %d: %v", i, err)
+		}
+	}
+
+	core.SetPrimarySpaceID(space.Id)
+	if err := core.RunMigrationsIfNeeded(ctx, space.Id); err != nil {
+		t.Fatalf("first migration: %v", err)
+	}
+
+	infoAfterFirst, err := core.storage.serverEventsStream.Info(ctx)
+	if err != nil {
+		t.Fatalf("server stream info: %v", err)
+	}
+	msgsAfterFirst := infoAfterFirst.State.Msgs
+
+	// Force a re-run by deleting the marker, then run again.
+	if err := core.storage.instanceKV.Delete(ctx, phase4dCompleteKey); err != nil {
+		t.Fatalf("delete marker: %v", err)
+	}
+	if err := core.RunMigrationsIfNeeded(ctx, space.Id); err != nil {
+		t.Fatalf("second migration: %v", err)
+	}
+
+	infoAfterSecond, err := core.storage.serverEventsStream.Info(ctx)
+	if err != nil {
+		t.Fatalf("server stream info second: %v", err)
+	}
+	if infoAfterSecond.State.Msgs != msgsAfterFirst {
+		t.Errorf("re-run duplicated events: %d → %d", msgsAfterFirst, infoAfterSecond.State.Msgs)
+	}
+}
+
+// TestPhase4dMigration_RoutingAfterMigration verifies that once primary
+// is set + migration has run, getSpaceStream for primary and DM both
+// route to SERVER_EVENTS while non-primary spaces still use their
+// per-space stream.
+func TestPhase4dMigration_RoutingAfterMigration(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	space, err := core.CreateSpace(ctx, "test-user", "Primary", "")
+	if err != nil {
+		t.Fatalf("CreateSpace: %v", err)
+	}
+	otherSpace, err := core.CreateSpace(ctx, "test-user", "Other", "")
+	if err != nil {
+		t.Fatalf("CreateSpace other: %v", err)
+	}
+
+	core.SetPrimarySpaceID(space.Id)
+	if err := core.RunMigrationsIfNeeded(ctx, space.Id); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		spaceID string
+		want    string
+	}{
+		{"primary events", space.Id, "SERVER_EVENTS"},
+		{"DM events", DMSpaceID, "SERVER_EVENTS"},
+		{"non-primary events", otherSpace.Id, "SPACE_" + otherSpace.Id + "_EVENTS"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stream, err := core.getSpaceStream(ctx, tc.spaceID)
+			if err != nil {
+				t.Fatalf("getSpaceStream: %v", err)
+			}
+			info, err := stream.Info(ctx)
+			if err != nil {
+				t.Fatalf("Info: %v", err)
+			}
+			if info.Config.Name != tc.want {
+				t.Errorf("expected stream %q, got %q", tc.want, info.Config.Name)
+			}
+		})
+	}
+}
+
+// TestPhase4dMigration_EndToEndPostThenRead seeds a message before
+// migration and verifies it can be read back via GetRoomEvents after.
+// This is the user-facing protection: chat history survives the
+// migration intact.
+func TestPhase4dMigration_EndToEndPostThenRead(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	user, err := core.CreateUser(ctx, "system", "poster3", "Poster", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	space, err := core.CreateSpace(ctx, user.Id, "Primary", "")
+	if err != nil {
+		t.Fatalf("CreateSpace: %v", err)
+	}
+	room, err := core.CreateRoom(ctx, user.Id, space.Id, "general", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, user.Id, space.Id, user.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom: %v", err)
+	}
+
+	// Pre-migration: post a few messages. Singleton is unset → these
+	// land in SPACE_{primary}_EVENTS at `space.{id}.room.>` subjects.
+	preMigrationIDs := make([]string, 3)
+	for i := 0; i < 3; i++ {
+		ev, err := core.PostMessage(ctx, space.Id, room.Id, user.Id, "pre-migration", nil, "", "", nil, false)
+		if err != nil {
+			t.Fatalf("PostMessage %d: %v", i, err)
+		}
+		preMigrationIDs[i] = ev.Id
+	}
+
+	// Activate singleton + migrate.
+	core.SetPrimarySpaceID(space.Id)
+	if err := core.RunMigrationsIfNeeded(ctx, space.Id); err != nil {
+		t.Fatalf("RunMigrationsIfNeeded: %v", err)
+	}
+
+	// Post-migration: GetRoomEvents now reads from SERVER_EVENTS at
+	// `server.room.channel.>` subjects. Pre-migration messages should be
+	// visible.
+	result, err := core.GetRoomEvents(ctx, space.Id, room.Id, 50, nil)
+	if err != nil {
+		t.Fatalf("GetRoomEvents: %v", err)
+	}
+
+	got := make(map[string]struct{})
+	for _, e := range result.Events {
+		got[e.Id] = struct{}{}
+	}
+	for _, id := range preMigrationIDs {
+		if _, ok := got[id]; !ok {
+			t.Errorf("pre-migration event %q missing from GetRoomEvents", id)
+		}
+	}
+
+	// And new posts go to SERVER_EVENTS too — round-trip works post-migration.
+	postEv, err := core.PostMessage(ctx, space.Id, room.Id, user.Id, "post-migration", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage post-migration: %v", err)
+	}
+	result2, err := core.GetRoomEvents(ctx, space.Id, room.Id, 50, nil)
+	if err != nil {
+		t.Fatalf("GetRoomEvents post: %v", err)
+	}
+	found := false
+	for _, e := range result2.Events {
+		if e.Id == postEv.Id {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("post-migration event %q missing from GetRoomEvents", postEv.Id)
+	}
+}
+
 // TestPhase4eMigration_AttachmentsRoutingAfterMigration verifies that once
 // the primary is set and migration has run, getSpaceAttachments routes
 // the primary and DM spaces to SERVER_ASSETS (not the legacy per-space

--- a/cli/internal/core/schema_migration_test.go
+++ b/cli/internal/core/schema_migration_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 
@@ -921,6 +922,173 @@ func TestPhase4dMigration_EndToEndPostThenRead(t *testing.T) {
 	if !found {
 		t.Errorf("post-migration event %q missing from GetRoomEvents", postEv.Id)
 	}
+}
+
+// TestPhase4dMigration_KindFilterIsolatesChannelsFromDMs verifies that
+// post-migration subjects scoped to one kind (channel or dm) don't match
+// the other kind. Covers both direct GetLastMsgForSubject lookups and
+// wildcard subject filters via stream.Info — the two ways the rest of
+// the codebase queries for room events.
+//
+// Also exercises a thread reply through the migrator (not just root
+// messages), closing a gap in the other phase 4d tests.
+func TestPhase4dMigration_KindFilterIsolatesChannelsFromDMs(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	user, err := core.CreateUser(ctx, "system", "kind-test", "User", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	// Channel-side: primary space + room + a root message + a thread reply.
+	space, err := core.CreateSpace(ctx, user.Id, "Primary", "")
+	if err != nil {
+		t.Fatalf("CreateSpace: %v", err)
+	}
+	channelRoom, err := core.CreateRoom(ctx, user.Id, space.Id, "general", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, user.Id, space.Id, user.Id, channelRoom.Id); err != nil {
+		t.Fatalf("JoinRoom: %v", err)
+	}
+	channelRoot, err := core.PostMessage(ctx, space.Id, channelRoom.Id, user.Id, "channel root", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage channel root: %v", err)
+	}
+	channelReply, err := core.PostMessage(ctx, space.Id, channelRoom.Id, user.Id, "channel reply", nil, channelRoot.Id, "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage channel reply: %v", err)
+	}
+
+	// DM-side: a DM room + a root message + a thread reply.
+	other, err := core.CreateUser(ctx, "system", "kind-peer", "Peer", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser peer: %v", err)
+	}
+	dmRoom, _, err := core.FindOrCreateDM(ctx, user.Id, []string{other.Id})
+	if err != nil {
+		t.Fatalf("FindOrCreateDM: %v", err)
+	}
+	dmRoot, err := core.PostMessage(ctx, DMSpaceID, dmRoom.Id, user.Id, "dm root", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage DM root: %v", err)
+	}
+	dmReply, err := core.PostMessage(ctx, DMSpaceID, dmRoom.Id, user.Id, "dm reply", nil, dmRoot.Id, "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage DM reply: %v", err)
+	}
+
+	// Migrate.
+	core.SetPrimarySpaceID(space.Id)
+	if err := core.RunMigrationsIfNeeded(ctx, space.Id); err != nil {
+		t.Fatalf("RunMigrationsIfNeeded: %v", err)
+	}
+
+	stream := core.storage.serverEventsStream
+
+	// Direct subject lookups: each event must be findable at its own
+	// kind's subject and NOT findable at the other kind's subject. If
+	// the rewriter ever emits the wrong kind, one of these "should not
+	// exist" assertions catches it.
+	t.Run("channel root at channel subject", func(t *testing.T) {
+		subj := fmt.Sprintf("server.room.channel.%s.msg.%s", channelRoom.Id, channelRoot.Id)
+		if _, err := stream.GetLastMsgForSubject(ctx, subj); err != nil {
+			t.Errorf("expected to find channel root at %q: %v", subj, err)
+		}
+	})
+	t.Run("channel root NOT at dm subject", func(t *testing.T) {
+		subj := fmt.Sprintf("server.room.dm.%s.msg.%s", channelRoom.Id, channelRoot.Id)
+		_, err := stream.GetLastMsgForSubject(ctx, subj)
+		if !errors.Is(err, jetstream.ErrMsgNotFound) {
+			t.Errorf("channel root must not be findable under dm kind at %q: err=%v", subj, err)
+		}
+	})
+
+	t.Run("channel thread reply at channel subject", func(t *testing.T) {
+		subj := fmt.Sprintf("server.room.channel.%s.msg.%s.replies.%s", channelRoom.Id, channelRoot.Id, channelReply.Id)
+		if _, err := stream.GetLastMsgForSubject(ctx, subj); err != nil {
+			t.Errorf("expected to find channel reply at %q: %v", subj, err)
+		}
+	})
+	t.Run("channel thread reply NOT at dm subject", func(t *testing.T) {
+		subj := fmt.Sprintf("server.room.dm.%s.msg.%s.replies.%s", channelRoom.Id, channelRoot.Id, channelReply.Id)
+		_, err := stream.GetLastMsgForSubject(ctx, subj)
+		if !errors.Is(err, jetstream.ErrMsgNotFound) {
+			t.Errorf("channel reply must not be findable under dm kind: err=%v", err)
+		}
+	})
+
+	t.Run("dm root at dm subject", func(t *testing.T) {
+		subj := fmt.Sprintf("server.room.dm.%s.msg.%s", dmRoom.Id, dmRoot.Id)
+		if _, err := stream.GetLastMsgForSubject(ctx, subj); err != nil {
+			t.Errorf("expected to find dm root at %q: %v", subj, err)
+		}
+	})
+	t.Run("dm root NOT at channel subject", func(t *testing.T) {
+		subj := fmt.Sprintf("server.room.channel.%s.msg.%s", dmRoom.Id, dmRoot.Id)
+		_, err := stream.GetLastMsgForSubject(ctx, subj)
+		if !errors.Is(err, jetstream.ErrMsgNotFound) {
+			t.Errorf("dm root must not be findable under channel kind: err=%v", err)
+		}
+	})
+
+	t.Run("dm thread reply at dm subject", func(t *testing.T) {
+		subj := fmt.Sprintf("server.room.dm.%s.msg.%s.replies.%s", dmRoom.Id, dmRoot.Id, dmReply.Id)
+		if _, err := stream.GetLastMsgForSubject(ctx, subj); err != nil {
+			t.Errorf("expected to find dm reply at %q: %v", subj, err)
+		}
+	})
+	t.Run("dm thread reply NOT at channel subject", func(t *testing.T) {
+		subj := fmt.Sprintf("server.room.channel.%s.msg.%s.replies.%s", dmRoom.Id, dmRoot.Id, dmReply.Id)
+		_, err := stream.GetLastMsgForSubject(ctx, subj)
+		if !errors.Is(err, jetstream.ErrMsgNotFound) {
+			t.Errorf("dm reply must not be findable under channel kind: err=%v", err)
+		}
+	})
+
+	// Wildcard subject filters (the second way callers query the stream).
+	// `server.room.channel.>` must include the channel events and exclude
+	// the DM events, and vice versa. countMatchingSubjects sums per-subject
+	// counts returned by stream.Info(WithSubjectFilter).
+	channelEvents := countMatchingSubjects(t, ctx, stream, fmt.Sprintf("server.room.channel.%s.>", channelRoom.Id))
+	dmEvents := countMatchingSubjects(t, ctx, stream, fmt.Sprintf("server.room.dm.%s.>", dmRoom.Id))
+
+	if channelEvents < 2 {
+		t.Errorf("channel filter found %d events, expected at least 2 (root + reply)", channelEvents)
+	}
+	if dmEvents < 2 {
+		t.Errorf("dm filter found %d events, expected at least 2 (root + reply)", dmEvents)
+	}
+
+	// Cross-kind wildcards: a channel-scoped wildcard with the DM room ID
+	// must match nothing (different room ID + different kind), and vice
+	// versa. This catches a regression where the rewriter or filter
+	// helper accidentally widens the wildcard.
+	crossA := countMatchingSubjects(t, ctx, stream, fmt.Sprintf("server.room.channel.%s.>", dmRoom.Id))
+	crossB := countMatchingSubjects(t, ctx, stream, fmt.Sprintf("server.room.dm.%s.>", channelRoom.Id))
+	if crossA != 0 {
+		t.Errorf("channel filter with DM room ID matched %d events, expected 0", crossA)
+	}
+	if crossB != 0 {
+		t.Errorf("dm filter with channel room ID matched %d events, expected 0", crossB)
+	}
+}
+
+// countMatchingSubjects returns the total per-subject count for a stream
+// info request scoped by `filter`. Used to assert wildcard scoping.
+func countMatchingSubjects(t *testing.T, ctx context.Context, stream jetstream.Stream, filter string) uint64 {
+	t.Helper()
+	info, err := stream.Info(ctx, jetstream.WithSubjectFilter(filter))
+	if err != nil {
+		t.Fatalf("stream.Info(filter=%q): %v", filter, err)
+	}
+	var total uint64
+	for _, c := range info.State.Subjects {
+		total += c
+	}
+	return total
 }
 
 // TestPhase4eMigration_AttachmentsRoutingAfterMigration verifies that once

--- a/cli/internal/core/subjects/primary.go
+++ b/cli/internal/core/subjects/primary.go
@@ -51,16 +51,24 @@ func PrimarySpaceID() string {
 // been set via SetPrimarySpaceID. Until then, all subjects (including
 // DM) stay on the legacy `space.{id}.>` shape.
 //
-// Gating DM on the singleton is deliberate: the `SERVER_EVENTS` stream
-// is created at the same time the primary is set. Auto-routing DM
-// before SERVER_EVENTS exists would direct publishes to a subject no
-// stream accepts.
+// Gating DM on the singleton is deliberate: it keeps subject construction
+// in lockstep with stream routing in the core package, so writes and
+// reads always agree on which stream + which subject namespace to use.
 func shouldUseServerSubjects(spaceID string) bool {
 	p := primarySpaceID.Load()
 	if p == nil {
 		return false
 	}
 	return spaceID == dmSpaceID || spaceID == *p
+}
+
+// UsesServerSubjects is the public counterpart to shouldUseServerSubjects.
+// Callers outside this package (notably core's stream routing) need to
+// agree with subject construction about whether a given space is in the
+// server-format world; exposing this predicate is the single source of
+// truth for that decision.
+func UsesServerSubjects(spaceID string) bool {
+	return shouldUseServerSubjects(spaceID)
 }
 
 // roomKind returns the kind segment that appears in `server.room.{kind}.>`

--- a/cli/internal/core/subjects/subjects.go
+++ b/cli/internal/core/subjects/subjects.go
@@ -1,6 +1,9 @@
 package subjects
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // This file is the single source of truth for all NATS subject patterns in
 // the system. All functions are pure and construct subjects from entity
@@ -45,14 +48,18 @@ import "fmt"
 // SpaceEvent returns the subject for space-level events.
 //
 // Legacy: space.{spaceId}.{eventType}
-// Server: server.member.{eventType}
+// Server: server.member.{verb}, where {verb} is `eventType` with any
 //
-// Currently used only for membership lifecycle (member_deleted etc.).
-// Other "space-level" lifecycle (joined/left) is published via
+//	leading `member_` stripped (so the server-subject token is
+//	`joined`/`left`/`deleted` rather than the redundant
+//	`member_joined`/`member_left`/`member_deleted`).
+//
+// Currently used only for membership lifecycle. Other "space-level"
+// lifecycle (joined/left on the user side) is published via
 // LiveInstanceUserEvent against the user, not the space.
 func SpaceEvent(spaceID, eventType string) string {
 	if shouldUseServerSubjects(spaceID) {
-		return fmt.Sprintf("server.member.%s", eventType)
+		return fmt.Sprintf("server.member.%s", strings.TrimPrefix(eventType, "member_"))
 	}
 	return fmt.Sprintf("space.%s.%s", spaceID, eventType)
 }
@@ -407,10 +414,12 @@ func LiveSpaceLevelEvents(spaceID string) string {
 // (currently membership lifecycle).
 //
 // Legacy: live.space.{spaceId}.{eventType}
-// Server: live.server.member.{eventType}
+// Server: live.server.member.{verb} (`member_` prefix stripped from
+//
+//	`eventType` — see SpaceEvent for rationale).
 func LiveSpaceEvent(spaceID, eventType string) string {
 	if shouldUseServerSubjects(spaceID) {
-		return fmt.Sprintf("live.server.member.%s", eventType)
+		return fmt.Sprintf("live.server.member.%s", strings.TrimPrefix(eventType, "member_"))
 	}
 	return fmt.Sprintf("live.space.%s.%s", spaceID, eventType)
 }

--- a/cli/internal/core/subjects/subjects_server_test.go
+++ b/cli/internal/core/subjects/subjects_server_test.go
@@ -83,8 +83,9 @@ func TestServerFormat_Constructors(t *testing.T) {
 		got  string
 		want string
 	}{
-		{"SpaceEvent primary", SpaceEvent("Sprimary", "member_deleted"), "server.member.member_deleted"},
-		{"SpaceEvent DM", SpaceEvent("DM", "member_deleted"), "server.member.member_deleted"},
+		{"SpaceEvent primary strips member_ prefix", SpaceEvent("Sprimary", "member_deleted"), "server.member.deleted"},
+		{"SpaceEvent DM strips member_ prefix", SpaceEvent("DM", "member_deleted"), "server.member.deleted"},
+		{"SpaceEvent passes already-bare verb through", SpaceEvent("Sprimary", "joined"), "server.member.joined"},
 		{"SpaceAllEvents primary", SpaceAllEvents("Sprimary"), "server.>"},
 		{"SpaceRoomMessage primary channel", SpaceRoomMessage("Sprimary", "Rroom", "Eevt"), "server.room.channel.Rroom.msg.Eevt"},
 		{"SpaceRoomMessage DM", SpaceRoomMessage("DM", "Rroom", "Eevt"), "server.room.dm.Rroom.msg.Eevt"},
@@ -103,7 +104,7 @@ func TestServerFormat_Constructors(t *testing.T) {
 		{"LiveSpaceAllEvents primary", LiveSpaceAllEvents("Sprimary"), "live.server.>"},
 		{"LiveSpaceAllEvents DM", LiveSpaceAllEvents("DM"), "live.server.>"},
 		{"LiveSpaceLevelEvents primary", LiveSpaceLevelEvents("Sprimary"), "live.server.member.>"},
-		{"LiveSpaceEvent primary", LiveSpaceEvent("Sprimary", "member_deleted"), "live.server.member.member_deleted"},
+		{"LiveSpaceEvent primary strips member_ prefix", LiveSpaceEvent("Sprimary", "member_deleted"), "live.server.member.deleted"},
 		{"LiveSpaceRoomEvent primary", LiveSpaceRoomEvent("Sprimary", "Rroom", "reaction_added"), "live.server.room.channel.Rroom.reaction_added"},
 		{"LiveSpaceRoomEvent DM", LiveSpaceRoomEvent("DM", "Rroom", "reaction_added"), "live.server.room.dm.Rroom.reaction_added"},
 		{"LiveSpaceRoomAllEvents primary", LiveSpaceRoomAllEvents("Sprimary"), "live.server.room.channel.>"},
@@ -219,7 +220,7 @@ func TestParsers_AcceptBothFormats(t *testing.T) {
 		},
 		{
 			name:    "server space-level (not a room)",
-			subject: "server.member.member_deleted",
+			subject: "server.member.deleted",
 		},
 		{
 			name:    "legacy space-level (not a room)",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -161,7 +161,8 @@ The GraphQL API is the primary client-facing interface for Chatto. It provides q
 | Objects | Instance  | `ASSET_CACHE`                 | Cached resized images (optional, with TTL)  |
 | Objects | Server    | `SERVER_ASSETS`               | Message attachments (primary + DM)          |
 | Objects | Per-space | `SPACE_{spaceId}_ASSETS`      | Message attachments (non-primary, non-DM)   |
-| Stream  | Per-space | `SPACE_{spaceId}_EVENTS`      | Room lifecycle, messages, memberships       |
+| Stream  | Server    | `SERVER_EVENTS`               | Room/membership events (primary + DM)       |
+| Stream  | Per-space | `SPACE_{spaceId}_EVENTS`      | Room/membership events (non-primary, non-DM)|
 
 See [NATS Resource Inventory](#nats-resource-inventory) for detailed key patterns and subjects.
 
@@ -416,13 +417,23 @@ Events are published to two types of destinations:
 
 | Stream                       | Wrapper        | Scope      | Description                                      |
 | ---------------------------- | -------------- | ---------- | ------------------------------------------------ |
-| `SPACE_{spaceId}_EVENTS`     | SpaceEvent     | Per-space  | All space and room events in a unified stream    |
+| `SERVER_EVENTS`              | SpaceEvent     | Server     | All events for primary + DM (#330 phase 4d)      |
+| `SPACE_{spaceId}_EVENTS`     | SpaceEvent     | Per-space  | All events for non-primary, non-DM spaces        |
 | Live Instance Events         | InstanceEvent  | Transient  | Instance-level events (NATS Core, direct publish)|
 | Live Space/Room Events       | SpaceEvent     | Transient  | Real-time event notifications (direct publish)   |
 
-**SPACE\_{spaceId}\_EVENTS subjects:**
+**SERVER\_EVENTS subjects (primary + DM, post phase 4d):**
 
-Room events include event IDs in subjects for O(1) lookups via `GetLastMsgForSubject`:
+Room events include event IDs in subjects for O(1) lookups via `GetLastMsgForSubject`. The `{kind}` segment (`channel` or `dm`) lets a single subject namespace serve both primary-space rooms and DM rooms.
+
+| Subject                                                                       | Description                                    |
+| ----------------------------------------------------------------------------- | ---------------------------------------------- |
+| `server.member.joined` / `.left` / `.deleted`                                 | Membership lifecycle events                    |
+| `server.room.{kind}.{roomId}.msg.{eventId}`                                   | Root message posted                            |
+| `server.room.{kind}.{roomId}.msg.{rootEventId}.replies.{eventId}`             | Thread reply posted                            |
+| `server.room.{kind}.{roomId}.meta`                                            | Room lifecycle + membership                    |
+
+**SPACE\_{spaceId}\_EVENTS subjects (non-primary, non-DM spaces):**
 
 | Subject                                                              | Description                                    |
 | -------------------------------------------------------------------- | ---------------------------------------------- |
@@ -524,7 +535,7 @@ All live events bypass JetStream entirely — KV buckets are the source of truth
 | `SPACE_{spaceId}_THREADS`     | Per-space | File    | Yes      | Thread metadata (reply count, participants)     |
 | `LINK_PREVIEW_CACHE`          | Instance  | File    | No       | Cached link preview metadata (48h TTL)          |
 
-**Migration note (#330 / ADR-027 phase 4a–4c, 4e):** the primary space's CONFIG/RBAC/RUNTIME/BODIES/REACTIONS/THREADS data and the DM system space's CONFIG/RUNTIME/BODIES/REACTIONS/THREADS data were folded into `SERVER_*` (4a–4c). Per-space attachment object stores (`SPACE_{primary}_ASSETS`, `SPACE_DM_ASSETS`) were folded into `SERVER_ASSETS` in phase 4e. The legacy `SPACE_{primary}_*` and `SPACE_DM_*` buckets/object stores are still present (no-deletes rule) but dormant — reads route to `SERVER_*`. A future cleanup pass will retire them.
+**Migration note (#330 / ADR-027 phase 4a–4e):** the primary space's CONFIG/RBAC/RUNTIME/BODIES/REACTIONS/THREADS data and the DM system space's CONFIG/RUNTIME/BODIES/REACTIONS/THREADS data were folded into `SERVER_*` (4a–4c). Per-space attachment object stores (`SPACE_{primary}_ASSETS`, `SPACE_DM_ASSETS`) were folded into `SERVER_ASSETS` in phase 4e. Per-space event streams (`SPACE_{primary}_EVENTS`, `SPACE_DM_EVENTS`) were folded into `SERVER_EVENTS` in phase 4d, with subjects rewritten from `space.{id}.>` to `server.>` (kind discriminator now in the subject — see SERVER\_EVENTS subjects table). After phase 4d completes, all legacy `SPACE_{primary}_*` and `SPACE_DM_*` resources are dormant and may be deleted by an operator-triggered cleanup; the no-deletes rule applied during the migration itself, not after.
 
 **INSTANCE keys:**
 
@@ -549,6 +560,7 @@ All live events bypass JetStream entirely — KV buckets are the source of truth
 | `migration.phase4b_complete`           | Phase 4b (DM merge + kind-prefixed keys) completion marker |
 | `migration.phase4c_complete`           | Phase 4c (per-message KVs: BODIES/REACTIONS/THREADS → `SERVER_*`) completion marker |
 | `migration.phase4e_complete`           | Phase 4e (per-space attachment object stores → `SERVER_ASSETS`) completion marker |
+| `migration.phase4d_complete`           | Phase 4d (per-space event streams → `SERVER_EVENTS`, subjects rewritten to `server.>`) completion marker |
 
 Notes: Email verification uses SHA256 hashing for claim keys to ensure valid NATS subject characters and case-insensitive uniqueness. The claim key is created atomically when an email is verified, preventing race conditions where two users try to verify the same email. Verification tokens store userId and email in the JSON value for O(1) lookup by token.
 


### PR DESCRIPTION
## Summary

Phase 4d of the #330 / #354 server-data consolidation: folds `SPACE_{primary}_EVENTS` and `SPACE_DM_EVENTS` into a single deployment-wide `SERVER_EVENTS` stream, rewriting subjects from `space.{id}.>` to the consolidated `server.>` namespace. After this ships and the migration runs on each instance, **all legacy `SPACE_{primary}_*` and `SPACE_DM_*` resources** (from phases 4a–c, 4e, and now 4d) are dormant and may be deleted by an operator-triggered cleanup.

- **Stream + routing**: eager-create `SERVER_EVENTS` in `newStorage`; `core.SetPrimarySpaceID` activates the subjects-package singleton; new `subjects.UsesServerSubjects` predicate keeps subject construction and stream routing in lockstep so DM doesn't drift to `SERVER_EVENTS` until the singleton is set.
- **Subjects fix**: `server.member.{verb}` strips the redundant `member_` prefix (so it's `server.member.deleted`, not `server.member.member_deleted`).
- **Migrator**: `runPhase4dIfNeeded` scans the target for already-migrated event IDs, iterates source streams in stream-sequence order, rewrites subjects via the unit-tested `rewriteSubjectForServerStream` helper, publishes to `SERVER_EVENTS`, and verifies by event-ID set comparison. Idempotent on re-run.
- **Tests**: 5 phase 4d tests (happy path primary+DM, fresh install, idempotent re-run, post-migration routing, end-to-end post-then-read across the migration boundary), 11 subject-rewriter unit tests. `setupTestCore` now resets the subjects singleton on cleanup so package-level state doesn't leak between tests.

## Test plan

- [x] `mise test-cli` — all 22 packages pass
- [x] `mise test-frontend` — 808/808 tests
- [x] e2e: `messages.test.ts` + `pagination.test.ts` + `jump-to-message.test.ts` + `dm.test.ts` → 41/41
- [ ] Deploy to dev, verify `migration.phase4d_complete` marker is set + chat works
- [ ] Once stable on all instances, operator-delete legacy `SPACE_{primary}_*` and `SPACE_DM_*` resources