### PR TITLE
feat(migration): phase 4f — fresh-install bootstrap polish (#354)

### DIFF
--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -1362,7 +1362,16 @@ func newInstanceEvent(actorID string, event *corev1.InstanceEvent) *corev1.Insta
 
 // ensureSpaceStream creates or updates the SPACE_{spaceId}_EVENTS stream.
 // Uses sync.Map caching to avoid redundant CreateOrUpdateStream calls within a process lifetime.
+//
+// Post-#330 phase 4f: short-circuits for the primary and DM spaces, whose
+// events live in the deployment-wide `SERVER_EVENTS` stream (eager-created
+// in newStorage). The per-space stream isn't needed and would only sit
+// dormant.
 func (c *ChattoCore) ensureSpaceStream(ctx context.Context, spaceID string) error {
+	if c.usesServerLevelMetadata(spaceID) {
+		return nil
+	}
+
 	// Check if already ensured this process lifetime
 	if _, ok := c.ensuredStreams.Load(spaceID); ok {
 		return nil
@@ -1411,13 +1420,22 @@ func (c *ChattoCore) deleteSpaceStream(ctx context.Context, spaceID string) erro
 // Called during space creation to eagerly initialize all resources.
 // If creation fails partway, cleans up any successfully created resources.
 //
-// Always creates per-space CONFIG/RBAC/RUNTIME buckets even though the
-// primary space's data lives in the shared SERVER_* buckets post-migration.
-// This is intentional: at the moment a space is created we don't yet know
-// whether it will become the primary. Phase 4a's boot-time migrator copies
-// the primary's per-space data over to SERVER_* the first time the primary
-// is resolved. Non-primary spaces continue using their per-space buckets.
+// Post-#330 phase 4f: short-circuits for the primary and DM spaces, whose
+// CONFIG/RBAC/RUNTIME/BODIES/REACTIONS/THREADS/ASSETS data lives in the
+// deployment-wide SERVER_* buckets (eager-created in newStorage). Skipping
+// the per-space buckets here means fresh installs no longer accumulate
+// dormant SPACE_{primary}_* / SPACE_DM_* resources at first boot.
+//
+// Caveat: the very first space ever created on a fresh install (the
+// eventual primary) is created BEFORE SetPrimarySpaceID has been called,
+// so usesServerLevelMetadata returns false at that point and the per-
+// space resources still get made. They go dormant once the primary is
+// configured and ph4a runs (a no-op since the data is already at the
+// right place). This wart is small enough to leave alone.
 func (c *ChattoCore) createSpaceResources(ctx context.Context, spaceID string) error {
+	if c.usesServerLevelMetadata(spaceID) {
+		return nil
+	}
 	// Track created resources for cleanup on failure
 	var createdBuckets []string
 
@@ -1547,12 +1565,9 @@ func (c *ChattoCore) createSpaceResources(ctx context.Context, spaceID string) e
 // to use their per-space SPACE_{id}_EVENTS stream, lazily created on first
 // access via ensureSpaceStream.
 //
-// Routing is gated on the subjects singleton (`subjects.UsesServerSubjects`),
-// not on `usesServerLevelMetadata`. This keeps stream selection in lockstep
-// with subject construction: until SetPrimarySpaceID activates the singleton
-// (e.g., in tests that never call it), DM publishes still go to
-// `space.DM.>` subjects which land in `SPACE_DM_EVENTS` — so reads must look
-// there too, not in `SERVER_EVENTS`.
+// Routing is gated on `subjects.UsesServerSubjects`, which agrees with
+// `usesServerLevelMetadata` for DM (always true) and with the configured
+// primary once SetPrimarySpaceID has activated the singleton.
 func (c *ChattoCore) getSpaceStream(ctx context.Context, spaceID string) (jetstream.Stream, error) {
 	if subjects.UsesServerSubjects(spaceID) {
 		return c.storage.serverEventsStream, nil

--- a/cli/internal/core/schema_migration_test.go
+++ b/cli/internal/core/schema_migration_test.go
@@ -245,10 +245,7 @@ func TestPhase4bMigration_RewritesDMRoomsToKindPrefix(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	dmConfig, err := core.js.KeyValue(ctx, legacySpaceConfigBucket(DMSpaceID))
-	if err != nil {
-		t.Fatalf("open SPACE_DM_CONFIG: %v", err)
-	}
+	dmConfig := ensureLegacyKVBucket(t, ctx, core, legacySpaceConfigBucket(DMSpaceID))
 	roomID := "Rtest-dm-room-1"
 	legacyRoom := &corev1.Room{
 		Id:      roomID,
@@ -354,10 +351,7 @@ func TestPhase4cMigration_CopiesPerMessageKVs(t *testing.T) {
 		t.Fatalf("seed primary thread: %v", err)
 	}
 
-	dmBodies, err := core.js.KeyValue(ctx, legacySpaceBodiesBucket(DMSpaceID))
-	if err != nil {
-		t.Fatalf("open DM BODIES: %v", err)
-	}
+	dmBodies := ensureLegacyKVBucket(t, ctx, core, legacySpaceBodiesBucket(DMSpaceID))
 	if _, err := dmBodies.Put(ctx, "Uuser2.Eevent2", []byte("body-dm-1")); err != nil {
 		t.Fatalf("seed DM body: %v", err)
 	}
@@ -514,6 +508,40 @@ func assertKeysCopied(t *testing.T, ctx context.Context, target jetstream.KeyVal
 	}
 }
 
+// ensureLegacyKVBucket creates the named KV bucket if it doesn't already
+// exist and returns it. Migration tests use this to seed pre-migration
+// data into legacy `SPACE_*` buckets that #330 phase 4f no longer
+// auto-creates for primary/DM. In production these buckets exist on
+// instances created before phase 4f shipped; the helper simulates that
+// state for tests running on a fresh embedded NATS server.
+func ensureLegacyKVBucket(t *testing.T, ctx context.Context, core *ChattoCore, name string) jetstream.KeyValue {
+	t.Helper()
+	bucket, err := core.js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:  name,
+		Storage: jetstream.FileStorage,
+	})
+	if err != nil {
+		t.Fatalf("ensure legacy bucket %s: %v", name, err)
+	}
+	return bucket
+}
+
+// ensureLegacyObjectStore is the object-store counterpart to
+// ensureLegacyKVBucket — used by phase 4e tests to seed legacy
+// `SPACE_*_ASSETS` stores that 4f no longer auto-creates.
+func ensureLegacyObjectStore(t *testing.T, ctx context.Context, core *ChattoCore, name string) jetstream.ObjectStore {
+	t.Helper()
+	store, err := core.js.CreateOrUpdateObjectStore(ctx, jetstream.ObjectStoreConfig{
+		Bucket:      name,
+		Storage:     jetstream.FileStorage,
+		Compression: true,
+	})
+	if err != nil {
+		t.Fatalf("ensure legacy object store %s: %v", name, err)
+	}
+	return store
+}
+
 func equalKeySets(a, b map[string]struct{}) bool {
 	if len(a) != len(b) {
 		return false
@@ -552,10 +580,7 @@ func TestPhase4eMigration_CopiesAttachments(t *testing.T) {
 		t.Fatalf("seed primary attachment: %v", err)
 	}
 
-	dmSource, err := core.js.ObjectStore(ctx, legacySpaceAssetsBucket(DMSpaceID))
-	if err != nil {
-		t.Fatalf("open DM ASSETS: %v", err)
-	}
+	dmSource := ensureLegacyObjectStore(t, ctx, core, legacySpaceAssetsBucket(DMSpaceID))
 	if _, err := dmSource.Put(ctx, jetstream.ObjectMeta{
 		Name:    "att-dm-1",
 		Headers: map[string][]string{"Content-Type": {"text/plain"}, "Filename": {"note.txt"}},
@@ -921,6 +946,96 @@ func TestPhase4dMigration_EndToEndPostThenRead(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("post-migration event %q missing from GetRoomEvents", postEv.Id)
+	}
+}
+
+// TestPhase4fFreshInstall_NoLegacyDMResources verifies the phase 4f
+// outcome: on a fresh install, the DM system space exists in INSTANCE
+// KV and routes through SERVER_*, but no SPACE_DM_* per-space buckets,
+// object stores, or streams get created. The legacy resources
+// previously sat dormant after creation; 4f stops creating them in
+// the first place.
+//
+// Non-primary, non-DM spaces still get their per-space resources —
+// asserted by also creating a regular space and confirming its
+// SPACE_{id}_* bucket is present.
+func TestPhase4fFreshInstall_NoLegacyDMResources(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	// DM is created during setupTestCore via initDMSpace. None of the
+	// per-space DM resources should exist after that.
+	for _, name := range []string{
+		legacySpaceConfigBucket(DMSpaceID),
+		legacySpaceRBACBucket(DMSpaceID),
+		legacySpaceRuntimeBucket(DMSpaceID),
+		legacySpaceBodiesBucket(DMSpaceID),
+		legacySpaceReactionsBucket(DMSpaceID),
+		legacySpaceThreadsBucket(DMSpaceID),
+	} {
+		if _, err := core.js.KeyValue(ctx, name); !errors.Is(err, jetstream.ErrBucketNotFound) {
+			t.Errorf("expected %s to NOT exist on fresh install (got err=%v)", name, err)
+		}
+	}
+	if _, err := core.js.ObjectStore(ctx, legacySpaceAssetsBucket(DMSpaceID)); !errors.Is(err, jetstream.ErrBucketNotFound) {
+		t.Errorf("expected %s to NOT exist (got err=%v)", legacySpaceAssetsBucket(DMSpaceID), err)
+	}
+	if _, err := core.js.Stream(ctx, legacySpaceEventsStream(DMSpaceID)); !errors.Is(err, jetstream.ErrStreamNotFound) {
+		t.Errorf("expected %s to NOT exist (got err=%v)", legacySpaceEventsStream(DMSpaceID), err)
+	}
+
+	// A regular (non-primary, non-DM) space still creates its per-space
+	// resources as before — the gating only short-circuits for spaces
+	// that route through SERVER_*.
+	regular, err := core.CreateSpace(ctx, "test-user", "Regular", "")
+	if err != nil {
+		t.Fatalf("CreateSpace: %v", err)
+	}
+	if _, err := core.js.KeyValue(ctx, legacySpaceConfigBucket(regular.Id)); err != nil {
+		t.Errorf("regular space should still create SPACE_{id}_CONFIG: %v", err)
+	}
+	if _, err := core.js.Stream(ctx, legacySpaceEventsStream(regular.Id)); err != nil {
+		t.Errorf("regular space should still create SPACE_{id}_EVENTS: %v", err)
+	}
+}
+
+// TestPhase4fFreshInstall_NoLegacyPrimaryAfterSetPrimary verifies that
+// once a space has been designated primary via SetPrimarySpaceID and a
+// fresh boot creates that space (i.e., the rare case where the primary
+// is configured ahead of its existence), createSpaceResources +
+// ensureSpaceStream short-circuit for it too.
+func TestPhase4fFreshInstall_NoLegacyPrimaryAfterSetPrimary(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	primaryID := "Sprimary-known-ahead"
+
+	// Activate the singleton FIRST. (Production calls SetPrimarySpaceID
+	// with the resolved primary at boot before any space creation that
+	// might be the primary itself.) After this, usesServerLevelMetadata
+	// returns true for primaryID.
+	core.SetPrimarySpaceID(primaryID)
+
+	// Now create the primary space. With the singleton active,
+	// createSpaceResources + ensureSpaceStream skip the per-space
+	// resources because routing already lands on SERVER_*.
+	if _, err := core.storeSpaceAndCreateStream(ctx, &corev1.Space{
+		Id:   primaryID,
+		Name: "Primary",
+	}, false); err != nil {
+		t.Fatalf("storeSpaceAndCreateStream: %v", err)
+	}
+
+	for _, name := range []string{
+		legacySpaceConfigBucket(primaryID),
+		legacySpaceBodiesBucket(primaryID),
+	} {
+		if _, err := core.js.KeyValue(ctx, name); !errors.Is(err, jetstream.ErrBucketNotFound) {
+			t.Errorf("expected %s to NOT exist (got err=%v)", name, err)
+		}
+	}
+	if _, err := core.js.Stream(ctx, legacySpaceEventsStream(primaryID)); !errors.Is(err, jetstream.ErrStreamNotFound) {
+		t.Errorf("expected %s to NOT exist (got err=%v)", legacySpaceEventsStream(primaryID), err)
 	}
 }
 

--- a/cli/internal/core/subjects/primary.go
+++ b/cli/internal/core/subjects/primary.go
@@ -46,20 +46,26 @@ func PrimarySpaceID() string {
 }
 
 // shouldUseServerSubjects reports whether subjects for the given space
-// should use the consolidated `server.>` shape. True for the configured
-// primary and for the DM system space, but ONLY once the primary has
-// been set via SetPrimarySpaceID. Until then, all subjects (including
-// DM) stay on the legacy `space.{id}.>` shape.
+// should use the consolidated `server.>` shape.
 //
-// Gating DM on the singleton is deliberate: it keeps subject construction
-// in lockstep with stream routing in the core package, so writes and
-// reads always agree on which stream + which subject namespace to use.
+// True for:
+//   - The DM system space, unconditionally. The `SERVER_EVENTS` stream
+//     is eager-created in core.newStorage, so by the time any caller
+//     constructs a DM subject, the stream that accepts `server.>`
+//     exists. DM is the primary-as-Server shape from day one — there
+//     was never a per-space DM identity in the application model.
+//   - The configured primary space, once SetPrimarySpaceID has been
+//     called. Until then, primary-space callers (rare in tests, never
+//     in production after #354 phase 4d) fall through to the legacy
+//     `space.{id}.>` shape.
 func shouldUseServerSubjects(spaceID string) bool {
-	p := primarySpaceID.Load()
-	if p == nil {
-		return false
+	if spaceID == dmSpaceID {
+		return true
 	}
-	return spaceID == dmSpaceID || spaceID == *p
+	if p := primarySpaceID.Load(); p != nil {
+		return *p == spaceID
+	}
+	return false
 }
 
 // UsesServerSubjects is the public counterpart to shouldUseServerSubjects.

--- a/cli/internal/core/subjects/subjects_server_test.go
+++ b/cli/internal/core/subjects/subjects_server_test.go
@@ -45,16 +45,17 @@ func TestShouldUseServerSubjects_PrimaryUnset(t *testing.T) {
 	SetPrimarySpaceID("")
 	t.Cleanup(func() { SetPrimarySpaceID("") })
 
-	// Until SetPrimarySpaceID is called, nothing routes to server
-	// subjects — even DM stays on the legacy `space.DM.>` shape so that
-	// publishes still land on the (still-existing) `SPACE_DM_EVENTS`
-	// stream. Auto-routing DM before SERVER_EVENTS exists is what gets
-	// you "nats: no response from stream" errors.
+	// Arbitrary space without a configured primary stays on legacy
+	// subjects.
 	if shouldUseServerSubjects("Sany") {
 		t.Error("expected false for arbitrary space when primary unset")
 	}
-	if shouldUseServerSubjects("DM") {
-		t.Error("DM should NOT route server-side until primary is set (SERVER_EVENTS doesn't exist yet)")
+
+	// DM is unconditionally server-side. The `SERVER_EVENTS` stream is
+	// eager-created in core.newStorage, so DM publishes always have a
+	// stream to land on regardless of whether primary has been resolved.
+	if !shouldUseServerSubjects("DM") {
+		t.Error("DM must always route server-side, even when primary unset")
 	}
 }
 


### PR DESCRIPTION
## Summary

Phase 4f of the #330 / #354 server-data consolidation: stops `createSpaceResources` and `ensureSpaceStream` from creating per-space `SPACE_{id}_*` resources for the primary and DM spaces, since their data already lives in `SERVER_*` / `SERVER_EVENTS` post phases 4a–e. Production behaviour is unchanged on existing instances — the legacy resources already exist there and are already dormant; this PR just stops creating new dormant resources on fresh installs.

- **Subjects simplification**: `shouldUseServerSubjects` returns `true` for DM unconditionally. `SERVER_EVENTS` is eager-created in `newStorage`, so DM publishes always have a stream to land on regardless of whether `SetPrimarySpaceID` has been called. This collapses two near-identical predicates (`subjects.UsesServerSubjects` and `core.usesServerLevelMetadata`) into agreement on DM.
- **Resource creation gating**: `ensureSpaceStream` and `createSpaceResources` short-circuit when `usesServerLevelMetadata(spaceID)` is true. Non-primary, non-DM spaces still get their per-space resources as before.
- **Migration tests**: two helpers (`ensureLegacyKVBucket`, `ensureLegacyObjectStore`) for tests that simulate pre-4f instances by seeding legacy buckets manually. Three existing 4b/4c/4e tests updated to use them for DM. Two new fresh-install tests assert the new invariant.

## Test plan

- [x] `mise test-cli` — all 22 packages pass
- [x] `mise test-frontend` — 808/808
- [x] e2e (messages + pagination + dm): 37/37
- [ ] Deploy to dev, verify chat still works (no functional change expected since existing primary/DM resources are unaffected)