### PR TITLE
fix(thread): scroll thread pane to bottom on own reply

### DIFF
--- a/frontend/e2e/auto-scroll.test.ts
+++ b/frontend/e2e/auto-scroll.test.ts
@@ -660,6 +660,90 @@ test.describe('Message pane auto-scroll', () => {
     }).toPass({ timeout: TIMEOUTS.UI_STANDARD, intervals: POLLING_INTERVALS });
   });
 
+  test('thread pane scrolls to bottom when user posts a reply while scrolled up', async ({
+    page,
+    chatPage,
+    roomPage
+  }) => {
+    // Smaller viewport to make the thread pane scrollable with a reasonable
+    // number of replies.
+    await page.setViewportSize({ width: 1280, height: 500 });
+
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.createSpace();
+    const spaceId = await chatPage.getSpaceId();
+    await chatPage.enterRoom('general');
+
+    const url = page.url();
+    const match = url.match(/\/chat\/-\/([^/]+)/);
+    const roomId = match![1];
+
+    const timestamp = Date.now();
+
+    // Post a root message and open its thread.
+    const rootMessage = await roomPage.sendMessage(`Thread root ${timestamp}`);
+    const rootEventId = await rootMessage.getEventId();
+    if (!rootEventId) throw new Error('Could not read root event id');
+    await rootMessage.openThread();
+    await expect(roomPage.threadPane).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+
+    // Post enough thread replies via API to make the thread scrollable.
+    const longText =
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor.';
+    const replies = Array.from(
+      { length: 20 },
+      (_, i) => `Reply ${i + 1} - ${timestamp} - ${longText}`
+    );
+    for (const body of replies) {
+      await page.request.post('/api/graphql', {
+        headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
+        data: {
+          query: `mutation($input: PostMessageInput!) { postMessage(input: $input) { id } }`,
+          variables: { input: { spaceId, roomId, body, inThread: rootEventId } }
+        }
+      });
+    }
+
+    // Reload so the thread pane loads via initial query (URL-driven).
+    await page.reload();
+    await expect(roomPage.threadPane).toBeVisible({ timeout: TIMEOUTS.COMPLEX_OPERATION });
+    await expect(
+      roomPage.threadPane.getByText(`Reply 20 - ${timestamp}`)
+    ).toBeVisible({ timeout: TIMEOUTS.COMPLEX_OPERATION });
+
+    // The thread pane has its own messages-container; scope to it.
+    const threadContainer = roomPage.threadPane.getByTestId('messages-container');
+
+    // Scroll the thread to the top.
+    await scrollContainerToTop(page, threadContainer);
+
+    await expect(async () => {
+      const info = await threadContainer.evaluate((el) => ({
+        scrollTop: el.scrollTop,
+        scrollHeight: el.scrollHeight,
+        clientHeight: el.clientHeight
+      }));
+      const distanceFromBottom = info.scrollHeight - info.scrollTop - info.clientHeight;
+      expect(distanceFromBottom).toBeGreaterThan(100);
+    }).toPass({ timeout: TIMEOUTS.UI_STANDARD, intervals: POLLING_INTERVALS });
+
+    // Post a new reply while scrolled up.
+    const newReply = `Reply posted while scrolled up - ${Date.now()}`;
+    await roomPage.postThreadReply(newReply);
+
+    // The new reply should be at the bottom of the thread.
+    await expect(async () => {
+      const info = await threadContainer.evaluate((el) => ({
+        scrollTop: el.scrollTop,
+        scrollHeight: el.scrollHeight,
+        clientHeight: el.clientHeight
+      }));
+      const distanceFromBottom = info.scrollHeight - info.scrollTop - info.clientHeight;
+      expect(distanceFromBottom).toBeLessThan(50);
+    }).toPass({ timeout: TIMEOUTS.UI_STANDARD, intervals: POLLING_INTERVALS });
+  });
+
   test('stays at bottom when font size increases', async ({
     page,
     chatPage,

--- a/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -711,13 +711,11 @@
           filesWithUrls = filesToSend.map((f) => ({ file: f, url: URL.createObjectURL(f) }));
         }
       } else {
-        // Request scroll to bottom so user sees their new message.
-        // Only for main room posts — thread replies should not disturb
-        // the main chat's scroll position. The thread EventList handles
-        // its own scrolling via updateCounter.
-        if (!inThread) {
-          scrollState?.requestScrollToBottom();
-        }
+        // Scroll the enclosing pane to the user's new message. The composer
+        // reads `scrollState` from its surrounding ComposerContext, so this
+        // targets the main room's EventList in a room composer and the
+        // thread's EventList in a thread composer.
+        scrollState?.requestScrollToBottom();
 
         // Clear reply-in-room state after sending
         onCancelReply?.();

--- a/frontend/src/routes/chat/[instanceId]/(chrome)/[roomId]/ThreadPane.svelte
+++ b/frontend/src/routes/chat/[instanceId]/(chrome)/[roomId]/ThreadPane.svelte
@@ -80,8 +80,11 @@
     currentUserId: currentUser.user?.id ?? null
   }));
 
-  // Create thread-scoped contexts that shadow the parent Room's contexts
-  const composerContext = createComposerContext();
+  // Create thread-scoped contexts that shadow the parent Room's contexts.
+  // `{ scroll: true }` gives the thread its own ScrollState so the composer's
+  // scroll-to-bottom-on-own-post request lands on the *thread's* EventList,
+  // not the main room's.
+  const composerContext = createComposerContext({ scroll: true });
   const replyState = composerContext.replyState;
 
   // Thread-scoped jump state so "in reply to" clicks scroll within the thread.


### PR DESCRIPTION
## Summary

- `ThreadPane` now creates its composer context with `{ scroll: true }`, so the thread owns a `ScrollState` that shadows the room's — own-reply scrolls land on the *thread's* `EventList`, not the main room's.
- `MessageComposer` drops the `if (!inThread)` guard around `scrollState?.requestScrollToBottom()`; the call is naturally scoped via context, and was previously a no-op for thread replies.
- Adds an e2e regression mirroring the existing main-room scroll-on-own-post test for the thread pane.

## Test plan

- [x] \`mise test-frontend\` (808/808)
- [x] \`mise x -- pnpm exec playwright test e2e/auto-scroll.test.ts\` (12/12, including the new thread-pane test)
- [x] Existing main-room \"scrolls to bottom when user posts a message while scrolled up\" still passes