### PR TITLE
chore(config): remove obsolete MaxSpaces limit

### DIFF
--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -71,8 +71,7 @@ var initCmd = &cobra.Command{
 				DirectRegistration: &directRegistration,
 			},
 			Limits: config.LimitsConfig{
-				MaxSpaces: &unlimited,
-				MaxUsers:  &unlimited,
+				MaxUsers: &unlimited,
 			},
 			Webserver: config.WebserverConfig{
 				Port:                   4000,

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -290,22 +290,12 @@ func (c *NATSConfig) ReplicasOrDefault() int {
 // the count at that value.
 //
 // Enforcement note: limits are checked at the entry point of each gated operation
-// (CreateSpace, CreateUser) by counting current entries in KV. The check is not
-// atomic with the subsequent write, so a burst of concurrent requests at the
-// boundary can briefly overshoot by one or two. Tightening this requires an
-// instance-stats counter system with CAS-incrementing gates — tracked as a
-// follow-up to this PR.
+// (CreateUser) by counting current entries in KV. The check is not atomic with
+// the subsequent write, so a burst of concurrent requests at the boundary can
+// briefly overshoot by one or two. Tightening this requires an instance-stats
+// counter system with CAS-incrementing gates — tracked as a follow-up to this PR.
 type LimitsConfig struct {
-	MaxSpaces *int `toml:"max_spaces,commented" env:"CHATTO_LIMITS_MAX_SPACES" comment:"Maximum number of spaces allowed in this instance. -1 = unlimited (default), 0 = creation disabled, positive = cap."`
-	MaxUsers  *int `toml:"max_users,commented" env:"CHATTO_LIMITS_MAX_USERS" comment:"Maximum number of verified users allowed in this instance. -1 = unlimited (default), 0 = no new signups, positive = cap. Counts users with at least one verified email."`
-}
-
-// MaxSpacesOrDefault returns the configured max-spaces limit, defaulting to -1 (unlimited).
-func (c *LimitsConfig) MaxSpacesOrDefault() int {
-	if c.MaxSpaces == nil {
-		return -1
-	}
-	return *c.MaxSpaces
+	MaxUsers *int `toml:"max_users,commented" env:"CHATTO_LIMITS_MAX_USERS" comment:"Maximum number of verified users allowed in this instance. -1 = unlimited (default), 0 = no new signups, positive = cap. Counts users with at least one verified email."`
 }
 
 // MaxUsersOrDefault returns the configured max-users limit, defaulting to -1 (unlimited).
@@ -579,9 +569,6 @@ func (c *ChattoConfig) Validate() error {
 	}
 
 	// Limits configuration: must be -1 (unlimited) or non-negative.
-	if c.Limits.MaxSpaces != nil && *c.Limits.MaxSpaces < -1 {
-		errs = append(errs, "limits.max_spaces must be -1 (unlimited) or a non-negative integer")
-	}
 	if c.Limits.MaxUsers != nil && *c.Limits.MaxUsers < -1 {
 		errs = append(errs, "limits.max_users must be -1 (unlimited) or a non-negative integer")
 	}

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -261,26 +261,17 @@ func intPtr(i int) *int {
 
 func TestLimitsConfig_Defaults(t *testing.T) {
 	c := &LimitsConfig{}
-	if got := c.MaxSpacesOrDefault(); got != -1 {
-		t.Errorf("MaxSpacesOrDefault() with unset = %d, want -1", got)
-	}
 	if got := c.MaxUsersOrDefault(); got != -1 {
 		t.Errorf("MaxUsersOrDefault() with unset = %d, want -1", got)
 	}
 
 	zero := 0
-	c = &LimitsConfig{MaxSpaces: &zero, MaxUsers: &zero}
-	if got := c.MaxSpacesOrDefault(); got != 0 {
-		t.Errorf("MaxSpacesOrDefault() with explicit 0 = %d, want 0", got)
-	}
+	c = &LimitsConfig{MaxUsers: &zero}
 	if got := c.MaxUsersOrDefault(); got != 0 {
 		t.Errorf("MaxUsersOrDefault() with explicit 0 = %d, want 0", got)
 	}
 
-	c = &LimitsConfig{MaxSpaces: intPtr(42), MaxUsers: intPtr(100)}
-	if got := c.MaxSpacesOrDefault(); got != 42 {
-		t.Errorf("MaxSpacesOrDefault() with 42 = %d, want 42", got)
-	}
+	c = &LimitsConfig{MaxUsers: intPtr(100)}
 	if got := c.MaxUsersOrDefault(); got != 100 {
 		t.Errorf("MaxUsersOrDefault() with 100 = %d, want 100", got)
 	}
@@ -303,7 +294,6 @@ cookie_signing_secret = "x"
 signing_secret = "y"
 
 [limits]
-max_spaces = 5
 max_users = -1
 `
 	if err := os.WriteFile(filepath.Join(tmpDir, "chatto.toml"), []byte(configContent), 0644); err != nil {
@@ -313,9 +303,6 @@ max_users = -1
 	cfg, err := ReadConfig("")
 	if err != nil {
 		t.Fatalf("ReadConfig() failed: %v", err)
-	}
-	if got := cfg.Limits.MaxSpacesOrDefault(); got != 5 {
-		t.Errorf("MaxSpaces from TOML = %d, want 5", got)
 	}
 	if got := cfg.Limits.MaxUsersOrDefault(); got != -1 {
 		t.Errorf("MaxUsers from TOML = %d, want -1", got)
@@ -333,15 +320,11 @@ func TestReadConfig_LimitsFromEnv(t *testing.T) {
 	t.Setenv("CHATTO_WEBSERVER_PORT", "4000")
 	t.Setenv("CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET", "x")
 	t.Setenv("CHATTO_CORE_ASSETS_SIGNING_SECRET", "y")
-	t.Setenv("CHATTO_LIMITS_MAX_SPACES", "7")
 	t.Setenv("CHATTO_LIMITS_MAX_USERS", "0")
 
 	cfg, err := ReadConfig("")
 	if err != nil {
 		t.Fatalf("ReadConfig() failed: %v", err)
-	}
-	if got := cfg.Limits.MaxSpacesOrDefault(); got != 7 {
-		t.Errorf("MaxSpaces from env = %d, want 7", got)
 	}
 	if got := cfg.Limits.MaxUsersOrDefault(); got != 0 {
 		t.Errorf("MaxUsers from env (explicit 0) = %d, want 0", got)
@@ -356,14 +339,6 @@ func TestChattoConfig_Validate_Limits(t *testing.T) {
 		}
 	}
 
-	t.Run("rejects max_spaces below -1", func(t *testing.T) {
-		c := base()
-		c.Limits.MaxSpaces = intPtr(-2)
-		if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "limits.max_spaces") {
-			t.Errorf("expected limits.max_spaces validation error, got %v", err)
-		}
-	})
-
 	t.Run("rejects max_users below -1", func(t *testing.T) {
 		c := base()
 		c.Limits.MaxUsers = intPtr(-5)
@@ -375,7 +350,6 @@ func TestChattoConfig_Validate_Limits(t *testing.T) {
 	t.Run("accepts -1, 0, positive", func(t *testing.T) {
 		for _, v := range []int{-1, 0, 1, 100} {
 			c := base()
-			c.Limits.MaxSpaces = intPtr(v)
 			c.Limits.MaxUsers = intPtr(v)
 			if err := c.Validate(); err != nil {
 				t.Errorf("validate failed for %d: %v", v, err)

--- a/cli/internal/core/errors.go
+++ b/cli/internal/core/errors.go
@@ -106,7 +106,7 @@ var (
 	ErrInvalidEvent = errors.New("invalid event")
 
 	// ErrLimitExceeded is returned when an operation would exceed an instance-wide
-	// resource limit configured via [limits] (e.g. max_spaces, max_users).
+	// resource limit configured via [limits] (e.g. max_users).
 	ErrLimitExceeded = errors.New("instance limit reached")
 
 	// ErrInstanceNotBootstrapped is returned by API-layer helpers that need

--- a/cli/internal/core/limits_test.go
+++ b/cli/internal/core/limits_test.go
@@ -7,55 +7,6 @@ import (
 	"hmans.de/chatto/internal/config"
 )
 
-func TestCreateSpace_RespectsMaxSpacesLimit(t *testing.T) {
-	core, _ := setupTestCore(t)
-	ctx := testContext(t)
-
-	// Baseline includes the system DM space; the limit is checked against the raw count,
-	// so we offset by it.
-	baseline, _ := core.CountSpaces(ctx)
-
-	user, err := core.CreateUser(ctx, "system", "limit-user", "Limit User", "password123")
-	if err != nil {
-		t.Fatalf("create user: %v", err)
-	}
-
-	atBaseline := baseline
-	core.config.Limits = config.LimitsConfig{MaxSpaces: &atBaseline}
-	if _, err := core.CreateSpace(ctx, user.Id, "Locked", ""); !errors.Is(err, ErrLimitExceeded) {
-		t.Fatalf("expected ErrLimitExceeded when at baseline, got %v", err)
-	}
-
-	allowTwoMore := baseline + 2
-	core.config.Limits = config.LimitsConfig{MaxSpaces: &allowTwoMore}
-
-	if _, err := core.CreateSpace(ctx, user.Id, "First", ""); err != nil {
-		t.Fatalf("first space should succeed: %v", err)
-	}
-	if _, err := core.CreateSpace(ctx, user.Id, "Second", ""); err != nil {
-		t.Fatalf("second space should succeed: %v", err)
-	}
-	if _, err := core.CreateSpace(ctx, user.Id, "Third", ""); !errors.Is(err, ErrLimitExceeded) {
-		t.Fatalf("third space should be blocked, got %v", err)
-	}
-}
-
-func TestCreateSpace_UnlimitedByDefault(t *testing.T) {
-	core, _ := setupTestCore(t)
-	ctx := testContext(t)
-
-	user, err := core.CreateUser(ctx, "system", "unlim-user", "Unlim User", "password123")
-	if err != nil {
-		t.Fatalf("create user: %v", err)
-	}
-
-	for i, name := range []string{"a", "b", "c", "d"} {
-		if _, err := core.CreateSpace(ctx, user.Id, name, ""); err != nil {
-			t.Fatalf("space %d (%q) should succeed under default unlimited: %v", i, name, err)
-		}
-	}
-}
-
 func TestCreateUser_RespectsMaxUsersLimit(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)

--- a/cli/internal/core/spaces.go
+++ b/cli/internal/core/spaces.go
@@ -92,17 +92,6 @@ func (c *ChattoCore) CreateSpace(ctx context.Context, actorID string, name strin
 		return nil, ErrDescriptionTooLong
 	}
 
-	// Enforce instance-wide space limit (-1 = unlimited).
-	if max := c.config.Limits.MaxSpacesOrDefault(); max >= 0 {
-		count, err := c.CountSpaces(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to count spaces: %w", err)
-		}
-		if count >= max {
-			return nil, ErrLimitExceeded
-		}
-	}
-
 	space := &corev1.Space{
 		Id:          NewSpaceID(),
 		Name:        name,

--- a/docs-website/src/content/docs/reference/environment-variables.mdx
+++ b/docs-website/src/content/docs/reference/environment-variables.mdx
@@ -327,10 +327,6 @@ Only used when `storage_backend` is set to `s3`. See the [S3 Storage guide](/gui
 
 Instance-wide resource limits. Use `-1` for unlimited (the default), `0` to disable creation entirely, or any positive integer to cap.
 
-<EnvVar name="CHATTO_LIMITS_MAX_SPACES" toml="limits.max_spaces" default="-1">
-  Maximum number of spaces in this instance. When the limit is reached, `createSpace` returns an "instance limit reached" error.
-</EnvVar>
-
 <EnvVar name="CHATTO_LIMITS_MAX_USERS" toml="limits.max_users" default="-1">
   Maximum number of verified users in this instance. Enforced at signup: when the verified-user count is already at the limit, new signups are rejected. Note that the check is non-atomic, so a burst of concurrent signups at the boundary can briefly overshoot by one or two.
 </EnvVar>


### PR DESCRIPTION
## Summary

- `limits.max_spaces` / `CHATTO_LIMITS_MAX_SPACES` was a leftover from the multi-space-per-instance era; the codebase has consolidated around a single server model, so the cap is no longer a meaningful operator knob and only invites confusion.
- Removes the `MaxSpaces` field, helper, validation, env binding, TOML key, the `CreateSpace` enforcement block, and the matching tests / init scaffolding / env-variables doc entry. `MaxUsers` and the surrounding `[limits]` block are preserved unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/config/... ./internal/core/...`
- [x] Repo-wide grep for `max_spaces` / `MAX_SPACES` / `MaxSpaces` returns zero hits