### PR TITLE
feat(frontend): resizable secondary sidebar and members pane

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -412,3 +412,14 @@
     font-size: 15px; /* 87.5% of default 16px */
   }
 }
+
+/* While the sidebar is being resized: lock the cursor to col-resize across the
+   whole page and suppress text selection so a fast drag doesn't accidentally
+   highlight room names or composer text. Set on <body> by SidebarResizeHandle. */
+body[data-resizing-sidebar],
+body[data-resizing-sidebar] * {
+  cursor: col-resize !important;
+}
+body[data-resizing-sidebar] {
+  user-select: none;
+}

--- a/frontend/src/lib/RoomList.svelte
+++ b/frontend/src/lib/RoomList.svelte
@@ -447,7 +447,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   </a>
 {/snippet}
 
-<nav class="room-list sidebar-nav p-2 md:w-64">
+<nav class="room-list sidebar-nav p-2 md:w-full">
   {#if roomsStore.layoutSections && roomsStore.layoutSections.length > 0}
     <!-- Sectioned layout -->
     {#each visibleSections as section, i (section.id)}

--- a/frontend/src/lib/components/ResizeHandle.svelte
+++ b/frontend/src/lib/components/ResizeHandle.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+  let {
+    width,
+    min,
+    max,
+    onResize,
+    onReset,
+    edge = 'right',
+    label = 'Resize'
+  }: {
+    width: number;
+    min: number;
+    max: number;
+    onResize: (newWidth: number) => void;
+    onReset?: () => void;
+    edge?: 'left' | 'right';
+    label?: string;
+  } = $props();
+
+  let dragging = $state(false);
+
+  function clamp(v: number): number {
+    return Math.min(max, Math.max(min, v));
+  }
+
+  function onPointerDown(e: PointerEvent) {
+    if (e.button !== 0) return;
+    e.preventDefault();
+    const target = e.currentTarget as HTMLElement;
+    target.setPointerCapture(e.pointerId);
+    const startX = e.clientX;
+    const startWidth = width;
+    const sign = edge === 'right' ? 1 : -1;
+    dragging = true;
+    document.body.dataset.resizingSidebar = 'true';
+
+    const onMove = (ev: PointerEvent) => {
+      onResize(clamp(startWidth + sign * (ev.clientX - startX)));
+    };
+
+    const onUp = (ev: PointerEvent) => {
+      target.releasePointerCapture(ev.pointerId);
+      target.removeEventListener('pointermove', onMove);
+      target.removeEventListener('pointerup', onUp);
+      target.removeEventListener('pointercancel', onUp);
+      delete document.body.dataset.resizingSidebar;
+      dragging = false;
+    };
+
+    target.addEventListener('pointermove', onMove);
+    target.addEventListener('pointerup', onUp);
+    target.addEventListener('pointercancel', onUp);
+  }
+
+  function onDoubleClick() {
+    onReset?.();
+  }
+
+  function onKeyDown(e: KeyboardEvent) {
+    const step = e.shiftKey ? 32 : 8;
+    const sign = edge === 'right' ? 1 : -1;
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      onResize(clamp(width - sign * step));
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      onResize(clamp(width + sign * step));
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      onResize(min);
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      onResize(max);
+    }
+  }
+</script>
+
+<button
+  type="button"
+  aria-label={label}
+  class={[
+    'group absolute top-0 bottom-0 z-10 hidden w-1.5 cursor-col-resize touch-none border-0 bg-transparent p-0 md:block',
+    edge === 'right' ? 'right-0' : 'left-0'
+  ]}
+  onpointerdown={onPointerDown}
+  ondblclick={onDoubleClick}
+  onkeydown={onKeyDown}
+>
+  <span
+    class={[
+      'pointer-events-none absolute top-0 bottom-0 w-px transition-colors',
+      edge === 'right' ? 'right-0' : 'left-0',
+      dragging
+        ? 'bg-primary'
+        : 'bg-transparent group-hover:bg-primary/60 group-focus-visible:bg-primary'
+    ]}
+  ></span>
+</button>

--- a/frontend/src/lib/components/SecondarySidebar.svelte
+++ b/frontend/src/lib/components/SecondarySidebar.svelte
@@ -2,13 +2,22 @@
   import type { Snippet } from 'svelte';
   import { SIDEBAR_PANEL_WIDTH_PX, sidebarSwipe } from '$lib/hooks/useSidebarSwipe.svelte';
   import { sidebarNav } from '$lib/state/globals.svelte';
+  import { secondarySidebarWidth } from '$lib/state/sidebarWidth.svelte';
+  import {
+    SECONDARY_SIDEBAR_MAX_WIDTH,
+    SECONDARY_SIDEBAR_MIN_WIDTH
+  } from '$lib/storage/secondarySidebarWidth';
+  import ResizeHandle from './ResizeHandle.svelte';
 
   let {
     children,
-    width = 'md:w-64',
+    width,
     mobileWidth = 'max-md:w-64'
   }: {
     children: Snippet;
+    /** Optional Tailwind class to lock the desktop width (e.g. "md:w-56"). When
+     *  omitted, the sidebar uses the user's persisted resizable width and shows
+     *  a drag handle. */
     width?: string;
     mobileWidth?: string;
   } = $props();
@@ -20,6 +29,7 @@
     sidebarNav.isMobile ? (sidebarNav.progress - 1) * SIDEBAR_PANEL_WIDTH_PX : 0
   );
   const dragging = $derived(sidebarNav.dragOffset !== null);
+  const resizable = $derived(!width);
 </script>
 
 <!--
@@ -30,7 +40,7 @@
 <div
   use:sidebarSwipe
   class={[
-    'z-50 flex min-w-0 flex-col overflow-hidden border-r border-border bg-background',
+    'secondary-sidebar relative z-50 flex min-w-0 flex-col overflow-hidden border-r border-border bg-background',
     width,
     mobileWidth,
     'md:flex-initial',
@@ -46,9 +56,29 @@
     // accessibility tools and Playwright `toBeVisible()` agree the panel is
     // hidden, not just translated off-screen.
     sidebarNav.isMobile && sidebarNav.progress === 0 && !dragging && 'max-md:invisible',
-    !dragging && 'sidebar-mobile-anim'
+    !dragging && 'sidebar-mobile-anim',
+    resizable && 'secondary-sidebar--resizable'
   ]}
+  style:--secondary-sidebar-width={resizable ? `${secondarySidebarWidth.value}px` : undefined}
   style:transform={sidebarNav.isMobile ? `translateX(${tx}px)` : undefined}
 >
   {@render children()}
+  {#if resizable && !sidebarNav.isMobile}
+    <ResizeHandle
+      width={secondarySidebarWidth.value}
+      min={SECONDARY_SIDEBAR_MIN_WIDTH}
+      max={SECONDARY_SIDEBAR_MAX_WIDTH}
+      onResize={(w) => secondarySidebarWidth.set(w)}
+      onReset={() => secondarySidebarWidth.reset()}
+      label="Resize sidebar"
+    />
+  {/if}
 </div>
+
+<style>
+  @media (min-width: 768px) {
+    .secondary-sidebar--resizable {
+      width: var(--secondary-sidebar-width);
+    }
+  }
+</style>

--- a/frontend/src/lib/state/roomInfoWidth.svelte.ts
+++ b/frontend/src/lib/state/roomInfoWidth.svelte.ts
@@ -1,0 +1,27 @@
+import {
+  getRoomInfoWidth,
+  setRoomInfoWidth,
+  ROOM_INFO_DEFAULT_WIDTH,
+  ROOM_INFO_MAX_WIDTH,
+  ROOM_INFO_MIN_WIDTH
+} from '$lib/storage/roomInfoWidth';
+
+class RoomInfoWidthState {
+  #width = $state(getRoomInfoWidth());
+
+  get value(): number {
+    return this.#width;
+  }
+
+  set(width: number): void {
+    const clamped = Math.min(ROOM_INFO_MAX_WIDTH, Math.max(ROOM_INFO_MIN_WIDTH, width));
+    this.#width = clamped;
+    setRoomInfoWidth(clamped);
+  }
+
+  reset(): void {
+    this.set(ROOM_INFO_DEFAULT_WIDTH);
+  }
+}
+
+export const roomInfoWidth = new RoomInfoWidthState();

--- a/frontend/src/lib/state/sidebarWidth.svelte.ts
+++ b/frontend/src/lib/state/sidebarWidth.svelte.ts
@@ -1,0 +1,30 @@
+import {
+  getSecondarySidebarWidth,
+  setSecondarySidebarWidth,
+  SECONDARY_SIDEBAR_DEFAULT_WIDTH,
+  SECONDARY_SIDEBAR_MAX_WIDTH,
+  SECONDARY_SIDEBAR_MIN_WIDTH
+} from '$lib/storage/secondarySidebarWidth';
+
+class SecondarySidebarWidthState {
+  #width = $state(getSecondarySidebarWidth());
+
+  get value(): number {
+    return this.#width;
+  }
+
+  set(width: number): void {
+    const clamped = Math.min(
+      SECONDARY_SIDEBAR_MAX_WIDTH,
+      Math.max(SECONDARY_SIDEBAR_MIN_WIDTH, width)
+    );
+    this.#width = clamped;
+    setSecondarySidebarWidth(clamped);
+  }
+
+  reset(): void {
+    this.set(SECONDARY_SIDEBAR_DEFAULT_WIDTH);
+  }
+}
+
+export const secondarySidebarWidth = new SecondarySidebarWidthState();

--- a/frontend/src/lib/storage/roomInfoWidth.ts
+++ b/frontend/src/lib/storage/roomInfoWidth.ts
@@ -1,0 +1,37 @@
+const STORAGE_KEY = 'chatto:roomInfoWidth';
+
+export const ROOM_INFO_DEFAULT_WIDTH = 256;
+export const ROOM_INFO_MIN_WIDTH = 200;
+export const ROOM_INFO_MAX_WIDTH = 480;
+
+export function getRoomInfoWidth(): number {
+  if (typeof localStorage === 'undefined') {
+    return ROOM_INFO_DEFAULT_WIDTH;
+  }
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const value = parseFloat(stored);
+      if (
+        !isNaN(value) &&
+        value >= ROOM_INFO_MIN_WIDTH &&
+        value <= ROOM_INFO_MAX_WIDTH
+      ) {
+        return value;
+      }
+    }
+  } catch {
+    // Ignore storage errors
+  }
+  return ROOM_INFO_DEFAULT_WIDTH;
+}
+
+export function setRoomInfoWidth(width: number): void {
+  const clamped = Math.min(ROOM_INFO_MAX_WIDTH, Math.max(ROOM_INFO_MIN_WIDTH, width));
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, String(clamped));
+  } catch {
+    // Ignore storage errors
+  }
+}

--- a/frontend/src/lib/storage/secondarySidebarWidth.ts
+++ b/frontend/src/lib/storage/secondarySidebarWidth.ts
@@ -1,0 +1,40 @@
+const STORAGE_KEY = 'chatto:secondarySidebarWidth';
+
+export const SECONDARY_SIDEBAR_DEFAULT_WIDTH = 256;
+export const SECONDARY_SIDEBAR_MIN_WIDTH = 200;
+export const SECONDARY_SIDEBAR_MAX_WIDTH = 480;
+
+export function getSecondarySidebarWidth(): number {
+  if (typeof localStorage === 'undefined') {
+    return SECONDARY_SIDEBAR_DEFAULT_WIDTH;
+  }
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const value = parseFloat(stored);
+      if (
+        !isNaN(value) &&
+        value >= SECONDARY_SIDEBAR_MIN_WIDTH &&
+        value <= SECONDARY_SIDEBAR_MAX_WIDTH
+      ) {
+        return value;
+      }
+    }
+  } catch {
+    // Ignore storage errors
+  }
+  return SECONDARY_SIDEBAR_DEFAULT_WIDTH;
+}
+
+export function setSecondarySidebarWidth(width: number): void {
+  const clamped = Math.min(
+    SECONDARY_SIDEBAR_MAX_WIDTH,
+    Math.max(SECONDARY_SIDEBAR_MIN_WIDTH, width)
+  );
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, String(clamped));
+  } catch {
+    // Ignore storage errors
+  }
+}

--- a/frontend/src/routes/chat/[instanceId]/(chrome)/SpaceBanner.svelte
+++ b/frontend/src/routes/chat/[instanceId]/(chrome)/SpaceBanner.svelte
@@ -4,10 +4,22 @@
   let { url }: { url: string } = $props();
 </script>
 
-<div class="w-64 p-2">
-  <SkeletonImg
-    src={url}
-    alt="Server banner"
-    class="aspect-[1200/630] w-full rounded-lg object-cover shadow-md"
-  />
+<div class="w-full p-2">
+  <div class="relative aspect-[1200/630] max-h-32 w-full">
+    <div class="absolute inset-0 overflow-hidden rounded-lg bg-surface-100">
+      <img
+        src={url}
+        alt=""
+        aria-hidden="true"
+        class="pointer-events-none h-full w-full scale-125 object-cover blur-2xl"
+      />
+    </div>
+    <div class="relative flex h-full w-full items-center justify-center">
+      <SkeletonImg
+        src={url}
+        alt="Server banner"
+        class="h-full w-auto rounded-lg shadow-lg"
+      />
+    </div>
+  </div>
 </div>

--- a/frontend/src/routes/chat/[instanceId]/(chrome)/[roomId]/RoomInfo.svelte
+++ b/frontend/src/routes/chat/[instanceId]/(chrome)/[roomId]/RoomInfo.svelte
@@ -12,6 +12,9 @@
   import { getInstancePermissions } from '$lib/state/instance/permissions.svelte';
   import { getActiveInstance } from '$lib/state/activeInstance.svelte';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
+  import ResizeHandle from '$lib/components/ResizeHandle.svelte';
+  import { roomInfoWidth } from '$lib/state/roomInfoWidth.svelte';
+  import { ROOM_INFO_MAX_WIDTH, ROOM_INFO_MIN_WIDTH } from '$lib/storage/roomInfoWidth';
 
   const getInstanceId = getActiveInstance();
 
@@ -82,7 +85,20 @@
   );
 </script>
 
-<aside class="flex w-64 flex-col border-l border-border" aria-label="Room members">
+<aside
+  class="relative flex flex-col border-l border-border"
+  style:width="{roomInfoWidth.value}px"
+  aria-label="Room members"
+>
+  <ResizeHandle
+    width={roomInfoWidth.value}
+    min={ROOM_INFO_MIN_WIDTH}
+    max={ROOM_INFO_MAX_WIDTH}
+    onResize={(w) => roomInfoWidth.set(w)}
+    onReset={() => roomInfoWidth.reset()}
+    edge="left"
+    label="Resize members pane"
+  />
   <PaneHeader title="Members ({members.length})" {loading} skeletonButtons={0} />
 
   <nav class="flex flex-1 flex-col overflow-y-auto p-2" aria-label="Member list">


### PR DESCRIPTION
## Summary

- Make the secondary sidebar (room list) and the members pane resizable via a draggable separator, with widths persisted globally across servers in localStorage (defaults 256px, clamped 200–480px).
- Add a shared `ResizeHandle` component supporting pointer drag, double-click reset, and keyboard nudges (arrows ±8px, shift ±32px, home/end).
- Reshape the space banner into a fixed-height (h-32) card with a blurred backdrop that fills the horizontal slack when the sidebar is wide; foreground image keeps its aspect ratio with a shadow.
- Expand RoomList rows/sections and the banner to follow the resized sidebar width; lock cursor + suppress text selection while dragging.

## Test plan

- [ ] Drag the separator between the secondary sidebar and the chat view; width persists across reload and across multiple connected servers
- [ ] Drag the separator between the chat view and the members pane; width persists similarly
- [ ] Double-click each handle to reset; keyboard nudges work when handle is focused
- [ ] Mobile (<768px) layout unchanged — fixed 256px panels, swipe still works
- [ ] Banner blurred backdrop expands horizontally on wide sidebars; scales down vertically on narrow ones