### PR TITLE
fix(auth): cap password length at 128 bytes

### DIFF
--- a/cli/internal/core/errors.go
+++ b/cli/internal/core/errors.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"errors"
+	"fmt"
 	"time"
 )
 
@@ -112,6 +113,14 @@ var (
 	// ErrInstanceNotBootstrapped is returned by API-layer helpers that need
 	// the deployment's primary space ID before its bootstrap has run.
 	ErrInstanceNotBootstrapped = errors.New("instance not bootstrapped")
+
+	// ErrPasswordTooShort is returned when a password is shorter than MinPasswordLength.
+	ErrPasswordTooShort = fmt.Errorf("password must be at least %d characters long", MinPasswordLength)
+
+	// ErrPasswordTooLong is returned when a password exceeds MaxPasswordLength.
+	// bcrypt silently truncates input at 72 bytes, so we cap above that to ensure
+	// the entire user-provided password contributes to the hash and to bound work.
+	ErrPasswordTooLong = fmt.Errorf("password cannot exceed %d bytes", MaxPasswordLength)
 )
 
 // Input validation limits.
@@ -143,4 +152,13 @@ const (
 
 	// LoginChangeCooldown is the minimum duration between login changes.
 	LoginChangeCooldown = 30 * 24 * time.Hour
+
+	// MinPasswordLength is the minimum length of a password in bytes.
+	MinPasswordLength = 8
+
+	// MaxPasswordLength is the maximum length of a password in bytes.
+	// bcrypt silently truncates input at 72 bytes; capping above that prevents
+	// surprising hash collisions on long passwords sharing the same prefix while
+	// still leaving room for passphrases.
+	MaxPasswordLength = 128
 )

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -48,8 +48,10 @@ func (c *ChattoCore) CreateUser(ctx context.Context, actorID string, login, disp
 	}
 
 	// Validate password strength if password is provided
-	if password != "" && len(password) < 8 {
-		return nil, fmt.Errorf("password must be at least 8 characters long")
+	if password != "" {
+		if err := ValidatePassword(password); err != nil {
+			return nil, err
+		}
 	}
 
 	// Check if login is blocked (defense in depth - HTTP layer should check first)
@@ -284,8 +286,8 @@ func (c *ChattoCore) GetUserByLogin(ctx context.Context, login string) (*corev1.
 // Password hashes are stored separately from user profile data and are not published to event streams.
 func (c *ChattoCore) SetPasswordHash(ctx context.Context, userID string, password string) error {
 	// Validate password strength
-	if len(password) < 8 {
-		return fmt.Errorf("password must be at least 8 characters long")
+	if err := ValidatePassword(password); err != nil {
+		return err
 	}
 
 	// Verify user exists

--- a/cli/internal/core/users_test.go
+++ b/cli/internal/core/users_test.go
@@ -2,10 +2,12 @@ package core
 
 import (
 	"bytes"
+	"errors"
 	"image"
 	"image/color"
 	"image/png"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -635,8 +637,37 @@ func TestChattoCore_CreateUser_ShortPassword(t *testing.T) {
 
 	// Try to create user with password that's too short
 	_, err := core.CreateUser(ctx, "system", "testuser", "testuser", "short")
-	if err == nil {
-		t.Error("Expected error when creating user with short password")
+	if !errors.Is(err, ErrPasswordTooShort) {
+		t.Errorf("Expected ErrPasswordTooShort, got: %v", err)
+	}
+}
+
+func TestChattoCore_CreateUser_TooLongPassword(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	// bcrypt silently truncates above 72 bytes, so passwords over MaxPasswordLength
+	// must be rejected outright to avoid surprising hash collisions on shared prefixes.
+	tooLong := strings.Repeat("a", MaxPasswordLength+1)
+	_, err := core.CreateUser(ctx, "system", "testuser", "testuser", tooLong)
+	if !errors.Is(err, ErrPasswordTooLong) {
+		t.Errorf("Expected ErrPasswordTooLong, got: %v", err)
+	}
+}
+
+func TestChattoCore_SetPasswordHash_TooLongPassword(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	user, err := core.CreateUser(ctx, "system", "testuser", "testuser", "initial123")
+	if err != nil {
+		t.Fatalf("Failed to create user: %v", err)
+	}
+
+	tooLong := strings.Repeat("a", MaxPasswordLength+1)
+	err = core.SetPasswordHash(ctx, user.Id, tooLong)
+	if !errors.Is(err, ErrPasswordTooLong) {
+		t.Errorf("Expected ErrPasswordTooLong, got: %v", err)
 	}
 }
 

--- a/cli/internal/core/validation.go
+++ b/cli/internal/core/validation.go
@@ -110,6 +110,18 @@ func ValidateLogin(login string) error {
 	return nil
 }
 
+// ValidatePassword validates that a password meets length requirements.
+// Length is measured in bytes (len), not Unicode characters, so the upper bound
+// also bounds the work done by bcrypt and storage cost.
+func ValidatePassword(password string) error {
+	if len(password) < MinPasswordLength {
+		return ErrPasswordTooShort
+	}
+	if len(password) > MaxPasswordLength {
+		return ErrPasswordTooLong
+	}
+	return nil
+}
 
 // HasVisibleContent returns true if the string contains at least one visible character.
 // A visible character is one that is not whitespace, not a format character (Cf),

--- a/cli/internal/http_server/auth.go
+++ b/cli/internal/http_server/auth.go
@@ -231,12 +231,12 @@ func (s *HTTPServer) setupAuthRoutes() {
 		var req struct {
 			Token                string `json:"token" binding:"required"`
 			Login                string `json:"login" binding:"required"`
-			Password             string `json:"password" binding:"required,min=8"`
+			Password             string `json:"password" binding:"required,min=8,max=128"`
 			PasswordConfirmation string `json:"passwordConfirmation" binding:"required"`
 		}
 
 		if err := c.ShouldBindJSON(&req); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Token, login, password, and password confirmation are required"})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Token, login, and a password between 8 and 128 characters are required"})
 			return
 		}
 
@@ -307,6 +307,10 @@ func (s *HTTPServer) setupAuthRoutes() {
 			}
 			if errors.Is(err, core.ErrLimitExceeded) {
 				c.JSON(http.StatusForbidden, gin.H{"error": "This instance is not accepting new users"})
+				return
+			}
+			if errors.Is(err, core.ErrPasswordTooShort) || errors.Is(err, core.ErrPasswordTooLong) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 				return
 			}
 			log.Error("Registration failed", "login", req.Login, "error", err)
@@ -427,11 +431,18 @@ func (s *HTTPServer) setupAuthRoutes() {
 	auth.POST("reset-password", func(c *gin.Context) {
 		var req struct {
 			Token    string `json:"token" binding:"required"`
-			Password string `json:"password" binding:"required,min=8"`
+			Password string `json:"password" binding:"required,min=8,max=128"`
 		}
 
 		if err := c.ShouldBindJSON(&req); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Token and password (min 8 characters) are required"})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Token and a password between 8 and 128 characters are required"})
+			return
+		}
+
+		// Defence in depth: validator's max=128 counts runes; core's check counts bytes.
+		// Enforce the byte cap here so a multi-byte payload can't slip past binding.
+		if err := core.ValidatePassword(req.Password); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
 


### PR DESCRIPTION
## Summary

bcrypt silently truncates input at 72 bytes, so any two passwords sharing the same first 72 bytes hash to the same value. This adds an explicit max-length check (and refactors the existing min check) so callers can't accidentally rely on truncated input.

- New `MinPasswordLength`/`MaxPasswordLength` constants and `ErrPasswordTooShort`/`ErrPasswordTooLong` sentinel errors, plus a shared `ValidatePassword` helper used by `CreateUser` and `SetPasswordHash`.
- HTTP `register/complete` and `reset-password` enforce `min=8,max=128` in their binding tags and surface password-length errors as 400; `reset-password` also calls `ValidatePassword` explicitly since `core.ResetPassword` only sees the hash.
- Adds tests for both the create and set paths.

Closes #67

## Test plan
- [x] `mise x -- go test ./internal/core/ -run "Password|CreateUser|SetPasswordHash"`
- [x] `mise x -- go vet ./internal/core/... ./internal/http_server/...`
- [ ] CI green