### PR TITLE
fix(frontend): MOTD reflects the currently-viewed server

### DIFF
--- a/frontend/e2e/fixtures/multiInstance.ts
+++ b/frontend/e2e/fixtures/multiInstance.ts
@@ -269,6 +269,79 @@ export async function getRoomOnRemote(
 }
 
 /**
+ * Logs in as the bootstrap admin user (`e2eadmin`) on a remote server and
+ * returns a bearer token. Mirrors `loginAsAdmin()` for the origin server.
+ */
+export async function loginAdminOnRemote(
+	remoteBaseURL: string
+): Promise<{ token: string; userId: string }> {
+	const loginResp = await fetch(`${remoteBaseURL}/auth/login`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ login: 'e2eadmin', password: 'adminpassword123' })
+	});
+	if (!loginResp.ok) {
+		throw new Error(`Failed to login admin on remote: ${await loginResp.text()}`);
+	}
+	const loginData = await loginResp.json();
+	if (!loginData.token) {
+		throw new Error(`No token returned from remote admin login: ${JSON.stringify(loginData)}`);
+	}
+
+	const meResp = await fetch(`${remoteBaseURL}/api/graphql`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			'X-REQUEST-TYPE': 'GraphQL',
+			Authorization: `Bearer ${loginData.token}`
+		},
+		body: JSON.stringify({ query: `query { me { id } }` })
+	});
+	const meData = await meResp.json();
+	const userId = meData.data?.me?.id;
+	if (!userId) {
+		throw new Error(`No userId returned from remote me query: ${JSON.stringify(meData)}`);
+	}
+	return { token: loginData.token, userId };
+}
+
+/**
+ * Updates the MOTD on a remote server via the admin GraphQL mutation.
+ * The token must belong to a user with admin/owner permission.
+ */
+export async function setMotdOnRemote(
+	remoteBaseURL: string,
+	token: string,
+	motd: string
+): Promise<void> {
+	const resp = await fetch(`${remoteBaseURL}/api/graphql`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			'X-REQUEST-TYPE': 'GraphQL',
+			Authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify({
+			query: `
+				mutation SetMotd($input: UpdateInstanceConfigInput!) {
+					admin {
+						updateInstanceConfig(input: $input) { motd }
+					}
+				}
+			`,
+			variables: { input: { motd } }
+		})
+	});
+	if (!resp.ok) {
+		throw new Error(`Failed to set MOTD on remote: ${await resp.text()}`);
+	}
+	const data = await resp.json();
+	if (data.errors) {
+		throw new Error(`updateInstanceConfig on remote returned errors: ${JSON.stringify(data.errors)}`);
+	}
+}
+
+/**
  * Drives the real Add-Server dialog → /oauth/authorize → /instances/callback
  * flow to add `remoteServer` as a connected instance, while bypassing the
  * human OAuth login form. The remote's `/oauth/authorize` request is

--- a/frontend/e2e/motd-multi-instance.test.ts
+++ b/frontend/e2e/motd-multi-instance.test.ts
@@ -1,0 +1,67 @@
+import { expect } from '@playwright/test';
+import { test } from './setup';
+import { loginAsAdmin, verifyAdminEmail } from './fixtures/testUser';
+import {
+	startSecondServer,
+	stopSecondServer,
+	loginAdminOnRemote,
+	setMotdOnRemote,
+	connectRemoteInstance
+} from './fixtures/multiInstance';
+import type { ServerInfo } from './fixtures/server';
+
+/**
+ * Returns the remote server's base URL using 127.0.0.1 instead of localhost so
+ * the SPA resolves it as a distinct instance hostname.
+ */
+function remoteBaseURL(server: ServerInfo): string {
+	return server.baseURL.replace('localhost', '127.0.0.1');
+}
+
+/**
+ * The header MOTD is bound to the URL-resolved active instance. With multiple
+ * registered servers, navigating between them must flip the header text to
+ * reflect the currently-viewed server's MOTD.
+ */
+test.describe('Multi-instance MOTD', () => {
+	let remoteServer: ServerInfo;
+
+	test.beforeEach(async ({}, testInfo) => {
+		remoteServer = await startSecondServer(testInfo);
+	});
+
+	test.afterEach(async ({}, testInfo) => {
+		if (remoteServer) {
+			await stopSecondServer(remoteServer, testInfo);
+		}
+	});
+
+	test('header MOTD reflects the currently-viewed server', async ({ page, adminPage }) => {
+		// Origin: log in as admin and set MOTD via the admin UI.
+		const adminUser = await loginAsAdmin(page);
+		await verifyAdminEmail(page, adminUser.id!);
+		await adminPage.gotoInstanceSettings();
+		await adminPage.fillInstanceSettings({ motd: 'ORIGIN MOTD' });
+		await adminPage.saveInstanceSettings();
+
+		// Remote: set a different MOTD via the admin GraphQL mutation.
+		const baseURL = remoteBaseURL(remoteServer);
+		const remoteAdmin = await loginAdminOnRemote(baseURL);
+		await setMotdOnRemote(baseURL, remoteAdmin.token, 'REMOTE MOTD');
+
+		// On the origin, the header should show the origin's MOTD.
+		await page.goto('/chat');
+		const motd = page.getByTestId('motd-content');
+		await expect(motd).toHaveText('ORIGIN MOTD');
+
+		// Connect the remote instance — connectRemoteInstance lands on
+		// /chat/<remote-host>/..., which should flip the header to the
+		// remote's MOTD.
+		await connectRemoteInstance(page, { ...remoteServer, baseURL }, remoteAdmin.userId);
+		await expect(motd).toHaveText('REMOTE MOTD');
+
+		// Navigate back to the origin — header should flip back.
+		await page.goto('/chat/-');
+		await expect(motd).toHaveText('ORIGIN MOTD');
+	});
+});

--- a/frontend/src/lib/SpaceList.svelte
+++ b/frontend/src/lib/SpaceList.svelte
@@ -23,8 +23,8 @@
   } = $props();
 
   const originInstanceId = $derived(instanceRegistry.originInstance?.id ?? '');
-  const getActiveInstanceId = getActiveInstance();
-  const activeInstanceId = $derived(getActiveInstanceId());
+  const getInstanceId = getActiveInstance();
+  const activeInstanceId = $derived(getInstanceId());
   // Get the current user for the active instance (reactive — updates on
   // avatar/name changes and when navigating between instances).
   // Falls back to context user for the origin instance (covers the setup

--- a/frontend/src/lib/SpaceList.svelte
+++ b/frontend/src/lib/SpaceList.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
-  import { page } from '$app/state';
   import { resolve } from '$app/paths';
-  import { instanceIdToSegment, segmentToInstanceId } from '$lib/navigation';
-
-  // SpaceList renders in the root layout (above [instanceId]),
-  // so it cannot use getActiveInstance(). Derive instance from URL.
-  const originInstanceId = $derived(instanceRegistry.originInstance?.id ?? '');
+  import { instanceIdToSegment } from '$lib/navigation';
   import { getCurrentUser } from '$lib/auth/currentUser.svelte';
   import { instanceRegistry } from '$lib/state/instance/registry.svelte';
+  import { getActiveInstance } from '$lib/state/activeInstance.svelte';
   import { getInstancePermissions, type InstancePermissions, type ViewerData } from '$lib/state/instance/permissions.svelte';
   import UserAvatar from './components/UserAvatar.svelte';
   import InstanceSpaceSection from './InstanceSpaceSection.svelte';
@@ -26,12 +22,9 @@
     onPermissionsLoaded?: (viewer: ViewerData) => void;
   } = $props();
 
-  // Derive the active instance from the URL. On instance-agnostic routes
-  // (e.g. /chat/spaces) falls back to the origin instance.
-  const activeInstanceId = $derived(
-    (page.params.instanceId ? segmentToInstanceId(page.params.instanceId) : null)
-    ?? originInstanceId
-  );
+  const originInstanceId = $derived(instanceRegistry.originInstance?.id ?? '');
+  const getActiveInstanceId = getActiveInstance();
+  const activeInstanceId = $derived(getActiveInstanceId());
   // Get the current user for the active instance (reactive — updates on
   // avatar/name changes and when navigating between instances).
   // Falls back to context user for the origin instance (covers the setup

--- a/frontend/src/lib/state/activeInstance.svelte.ts
+++ b/frontend/src/lib/state/activeInstance.svelte.ts
@@ -1,16 +1,31 @@
 import { createContext } from 'svelte';
+import { page } from '$app/state';
+import { segmentToInstanceId } from '$lib/navigation';
 import { instanceRegistry } from './instance/registry.svelte';
 
 /**
  * Svelte context for the active instance ID.
  *
- * Set by the [[instanceId=hostname]] layout to make the URL-derived
- * instance ID available to all child components.
- *
- * The value is a getter function — call it to get the current instance ID.
- * Must be called during component initialization (not in event handlers).
+ * Provided by the root layout via {@link provideActiveInstanceFromUrl} and
+ * available to every descendant. The value is a getter function — call it
+ * inside a reactive context ($derived / $effect / template) to track URL
+ * changes. Must be looked up during component initialization.
  */
 export const [getActiveInstance, setActiveInstance] = createContext<() => string>();
+
+/**
+ * Resolves the active instance ID from the URL and provides it via context.
+ * Origin segment ("-") and instance-agnostic routes both fall back to the
+ * origin instance.
+ */
+export function provideActiveInstanceFromUrl(): void {
+  setActiveInstance(
+    () =>
+      segmentToInstanceId(page.params.instanceId ?? '-') ??
+      instanceRegistry.originInstance?.id ??
+      ''
+  );
+}
 
 /**
  * Returns a getter for the active instance's primary space ID. Convenience

--- a/frontend/src/lib/ui/AppHeader.svelte
+++ b/frontend/src/lib/ui/AppHeader.svelte
@@ -11,14 +11,14 @@
 
   // MOTD follows the active instance; the connection-lost icon below stays
   // bound to the origin store since it reflects the SPA host's own connection.
-  const getActiveId = getActiveInstance();
-  const motd = $derived(instanceRegistry.tryGetStore(getActiveId())?.instance.motd);
+  const getInstanceId = getActiveInstance();
+  const motd = $derived(instanceRegistry.tryGetStore(getInstanceId())?.instance.motd);
   const originStore = $derived(
     instanceRegistry.tryGetStore(instanceRegistry.originInstance?.id ?? '')
   );
 
   // Aggregate notification count across all instances.
-  let totalNotificationCount = $derived(
+  const totalNotificationCount = $derived(
     instanceRegistry.instances.reduce(
       (sum, instance) => sum + instanceRegistry.getStore(instance.id).notifications.count,
       0
@@ -26,7 +26,7 @@
   );
 
   // Show sign-out button when any instance is registered
-  let hasInstances = $derived(instanceRegistry.instances.length > 0);
+  const hasInstances = $derived(instanceRegistry.instances.length > 0);
 
   function handleSignOut() {
     pushState('', { modal: { type: 'logout' } });

--- a/frontend/src/lib/ui/AppHeader.svelte
+++ b/frontend/src/lib/ui/AppHeader.svelte
@@ -3,16 +3,19 @@
   import { resolve } from '$app/paths';
   import { instanceRegistry } from '$lib/state/instance/registry.svelte';
   import { graphqlClientManager } from '$lib/state/instance/graphqlClient.svelte';
+  import { getActiveInstance } from '$lib/state/activeInstance.svelte';
   import { renderMarkdown } from '$lib/markdown';
   import { version } from '$app/environment';
   import { sidebarNav, quickSwitcher } from '$lib/state/globals.svelte';
   import UnreadDot from '$lib/ui/UnreadDot.svelte';
 
-  // AppHeader renders in the root layout (above [[instanceId=hostname]]),
-  // so it cannot use getActiveInstance(). Use the origin instance directly
-  // for instance-specific things like MOTD.
-  let originStores = $derived(instanceRegistry.originInstance ? instanceRegistry.getStore(instanceRegistry.originInstance.id) : undefined);
-  let motd = $derived(originStores?.instance.motd);
+  // MOTD follows the active instance; the connection-lost icon below stays
+  // bound to the origin store since it reflects the SPA host's own connection.
+  const getActiveId = getActiveInstance();
+  const motd = $derived(instanceRegistry.tryGetStore(getActiveId())?.instance.motd);
+  const originStore = $derived(
+    instanceRegistry.tryGetStore(instanceRegistry.originInstance?.id ?? '')
+  );
 
   // Aggregate notification count across all instances.
   let totalNotificationCount = $derived(
@@ -73,7 +76,7 @@
 
     <!-- Connection lost indicator: only show when an authenticated instance has lost connection.
          Skip the origin instance if the user isn't authenticated (no WebSocket expected). -->
-    {#if originStores?.currentUser.user && graphqlClientManager.originClient.showConnectionLostIcon}
+    {#if originStore?.currentUser.user && graphqlClientManager.originClient.showConnectionLostIcon}
       <span
         class={[
           'iconify text-lg uil--wifi-slash',

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -12,8 +12,7 @@
   import { usePageTitle, usePinchZoomPrevention, useVisualViewport } from '$lib/hooks';
   import { SIDEBAR_PANEL_WIDTH_PX, sidebarSwipe } from '$lib/hooks/useSidebarSwipe.svelte';
   import { sidebarNav } from '$lib/state/globals.svelte';
-  import { setActiveInstance } from '$lib/state/activeInstance.svelte';
-  import { segmentToInstanceId } from '$lib/navigation';
+  import { provideActiveInstanceFromUrl } from '$lib/state/activeInstance.svelte';
   import { instanceRegistry } from '$lib/state/instance/registry.svelte';
   import { useInstanceRegistry } from '$lib/state/instance/useInstanceRegistry.svelte';
   import { graphqlClientManager } from '$lib/state/instance/graphqlClient.svelte';
@@ -38,14 +37,10 @@
   // Contexts
   const updateInstancePermissions = createInstancePermissions();
 
-  // Resolve the active instance from the URL and provide it via context, so
-  // every descendant — including components rendered above [instanceId] like
-  // AppHeader, SpaceList, and ModalContainer — can use getActiveInstance().
-  // On routes without an instanceId param, falls back to the origin instance.
-  const activeInstanceId = $derived(
-    segmentToInstanceId(page.params.instanceId ?? '-') ?? instanceRegistry.originInstance?.id ?? ''
-  );
-  setActiveInstance(() => activeInstanceId);
+  // Provide the active instance ID via context so every descendant can use
+  // getActiveInstance(), including components rendered above [instanceId]
+  // (AppHeader, SpaceList, ModalContainer).
+  provideActiveInstanceFromUrl();
 
   // Provide a CurrentUserState via context so components that render outside
   // the chat tree (SpaceList, /setup, etc.) can still call getCurrentUser().

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -12,6 +12,8 @@
   import { usePageTitle, usePinchZoomPrevention, useVisualViewport } from '$lib/hooks';
   import { SIDEBAR_PANEL_WIDTH_PX, sidebarSwipe } from '$lib/hooks/useSidebarSwipe.svelte';
   import { sidebarNav } from '$lib/state/globals.svelte';
+  import { setActiveInstance } from '$lib/state/activeInstance.svelte';
+  import { segmentToInstanceId } from '$lib/navigation';
   import { instanceRegistry } from '$lib/state/instance/registry.svelte';
   import { useInstanceRegistry } from '$lib/state/instance/useInstanceRegistry.svelte';
   import { graphqlClientManager } from '$lib/state/instance/graphqlClient.svelte';
@@ -35,6 +37,15 @@
 
   // Contexts
   const updateInstancePermissions = createInstancePermissions();
+
+  // Resolve the active instance from the URL and provide it via context, so
+  // every descendant — including components rendered above [instanceId] like
+  // AppHeader, SpaceList, and ModalContainer — can use getActiveInstance().
+  // On routes without an instanceId param, falls back to the origin instance.
+  const activeInstanceId = $derived(
+    segmentToInstanceId(page.params.instanceId ?? '-') ?? instanceRegistry.originInstance?.id ?? ''
+  );
+  setActiveInstance(() => activeInstanceId);
 
   // Provide a CurrentUserState via context so components that render outside
   // the chat tree (SpaceList, /setup, etc.) can still call getCurrentUser().

--- a/frontend/src/routes/chat/ModalContainer.svelte
+++ b/frontend/src/routes/chat/ModalContainer.svelte
@@ -7,8 +7,8 @@
   import { graphqlClientManager } from '$lib/state/instance/graphqlClient.svelte';
   import { getActiveInstance } from '$lib/state/activeInstance.svelte';
 
-  const getActiveInstanceId = getActiveInstance();
-  const activeInstanceId = $derived(getActiveInstanceId());
+  const getInstanceId = getActiveInstance();
+  const activeInstanceId = $derived(getInstanceId());
   const instanceSegment = $derived(instanceIdToSegment(activeInstanceId));
   import Dialog from '$lib/ui/Dialog.svelte';
   import ConfirmDialog from '$lib/ui/ConfirmDialog.svelte';

--- a/frontend/src/routes/chat/ModalContainer.svelte
+++ b/frontend/src/routes/chat/ModalContainer.svelte
@@ -2,15 +2,13 @@
   import { page } from '$app/state';
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
-  import { instanceIdToSegment, segmentToInstanceId } from '$lib/navigation';
+  import { instanceIdToSegment } from '$lib/navigation';
   import { instanceRegistry } from '$lib/state/instance/registry.svelte';
   import { graphqlClientManager } from '$lib/state/instance/graphqlClient.svelte';
+  import { getActiveInstance } from '$lib/state/activeInstance.svelte';
 
-  // ModalContainer renders in chat/+layout.svelte (above [instanceId]),
-  // so it cannot use getActiveInstance(). Derive instance from the URL params instead.
-  const activeInstanceId = $derived(
-    segmentToInstanceId(page.params.instanceId ?? '-') ?? instanceRegistry.originInstance?.id ?? ''
-  );
+  const getActiveInstanceId = getActiveInstance();
+  const activeInstanceId = $derived(getActiveInstanceId());
   const instanceSegment = $derived(instanceIdToSegment(activeInstanceId));
   import Dialog from '$lib/ui/Dialog.svelte';
   import ConfirmDialog from '$lib/ui/ConfirmDialog.svelte';

--- a/frontend/src/routes/chat/[instanceId]/+layout.svelte
+++ b/frontend/src/routes/chat/[instanceId]/+layout.svelte
@@ -7,7 +7,6 @@
   import { instanceRegistry } from '$lib/state/instance/registry.svelte';
   import { graphqlClientManager } from '$lib/state/instance/graphqlClient.svelte';
   import { provideConnection } from '$lib/state/instance/connection.svelte';
-  import { setActiveInstance } from '$lib/state/activeInstance.svelte';
   import { segmentToInstanceId } from '$lib/navigation';
   import { provideInstanceEventBus } from '$lib/instanceEventBus.svelte';
 
@@ -46,13 +45,10 @@
     }
   });
 
-  // Provide the instance ID to all child components via Svelte context.
-  // This is the single source of truth for "which instance am I on".
-  setActiveInstance(() => instanceId);
-
-  // Override the parent's ConnectionProvider with the correct client for
-  // this instance. Home instance paths get the home client; remote
-  // hostname paths get that instance's client.
+  // The active instance context is provided by the root layout. We just
+  // override the parent's ConnectionProvider with the correct client for
+  // this instance — origin paths get the origin client; hostname paths get
+  // that instance's client.
   provideConnection(() => graphqlClientManager.getClient(instanceId));
 
   // Override getCurrentUser() context with the per-instance current user.

--- a/frontend/src/routes/chat/[instanceId]/+layout.svelte
+++ b/frontend/src/routes/chat/[instanceId]/+layout.svelte
@@ -7,16 +7,15 @@
   import { instanceRegistry } from '$lib/state/instance/registry.svelte';
   import { graphqlClientManager } from '$lib/state/instance/graphqlClient.svelte';
   import { provideConnection } from '$lib/state/instance/connection.svelte';
-  import { segmentToInstanceId } from '$lib/navigation';
+  import { getActiveInstance } from '$lib/state/activeInstance.svelte';
   import { provideInstanceEventBus } from '$lib/instanceEventBus.svelte';
 
   let { children } = $props();
 
-  // Derive the instance ID from the URL param.
-  // "-" → origin instance, hostname → look up matching remote instance.
-  const instanceId = $derived(
-    segmentToInstanceId(page.params.instanceId ?? '-') ?? instanceRegistry.originInstance?.id ?? ''
-  );
+  // The root layout resolves the active instance from the URL and provides
+  // it via context; we just consume it here.
+  const getInstanceId = getActiveInstance();
+  const instanceId = $derived(getInstanceId());
 
   // Guard: if the instance ID couldn't be resolved (e.g., "-" with no origin
   // instance registered), redirect to /chat. This happens when an unauthenticated


### PR DESCRIPTION
## Summary

- AppHeader's MOTD followed the origin server even after switching to a registered remote server; it now follows the active instance.
- Hoisted `setActiveInstance()` to the root layout so AppHeader, SpaceList, and ModalContainer can use `getActiveInstance()` like every other consumer, removing three "renders above [instanceId]" URL-derivation workarounds.
- `chat/[instanceId]/+layout.svelte` no longer re-provides the same context.

## Test plan

- [x] `mise test-frontend` (709/709 pass)
- [ ] Manual: register a remote server with a different MOTD, switch via the URL/quick switcher, confirm header MOTD updates; visit `/chat/notifications` and confirm fallback to origin MOTD.