### PR TITLE
refactor(frontend): retire DM_SPACE_ID-as-discriminator leftovers

### DIFF
--- a/frontend/src/lib/InstanceSpaceSection.svelte
+++ b/frontend/src/lib/InstanceSpaceSection.svelte
@@ -12,8 +12,6 @@
   import SpaceIcon from './SpaceIcon.svelte';
   import { useTabResumeCallback } from '$lib/hooks';
 
-  const DM_SPACE_ID = 'DM';
-
   let {
     instanceId,
     currentUserId,

--- a/frontend/src/lib/RoomList.svelte
+++ b/frontend/src/lib/RoomList.svelte
@@ -13,7 +13,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   import { page } from '$app/state';
   import { instanceIdToSegment } from '$lib/navigation';
   import { getActiveInstance } from '$lib/state/activeInstance.svelte';
-  import { untrack, type Snippet } from 'svelte';
+  import { type Snippet } from 'svelte';
   import { slide } from 'svelte/transition';
   import { instanceRegistry } from '$lib/state/instance/registry.svelte';
   import type { CallRoomParticipant } from '$lib/state/instance/activeCallRooms.svelte';
@@ -29,7 +29,6 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   import { SvelteSet } from 'svelte/reactivity';
   import { useFragment } from './gql';
   import { RoomType, type PresenceStatus } from '$lib/gql/graphql';
-  import { DM_SPACE_ID } from '$lib/constants';
   import UserAvatar, { UserAvatarFragment } from '$lib/components/UserAvatar.svelte';
   import UnreadDot from '$lib/ui/UnreadDot.svelte';
   import { notificationTarget } from '$lib/state/instance/notifications.svelte';

--- a/frontend/src/lib/hooks/useRoomData.svelte.ts
+++ b/frontend/src/lib/hooks/useRoomData.svelte.ts
@@ -1,9 +1,8 @@
 import { graphql } from '$lib/gql';
-import type { PresenceStatus } from '$lib/gql/graphql';
+import { RoomType, type PresenceStatus } from '$lib/gql/graphql';
 import { useReconnectTrigger } from '$lib/hooks/useReconnectCallback.svelte';
 import { useConnection } from '$lib/state/instance/connection.svelte';
 import type { RoomMember } from '$lib/state/room';
-import { DM_SPACE_ID } from '$lib/constants';
 import { untrack } from 'svelte';
 
 export type RoomData = {
@@ -56,7 +55,7 @@ export function useRoomData(getProps: () => { roomId: string }) {
 
   // Post-PR(b) we tell channel vs DM via `Room.type` (the resolver returns
   // `RoomType.DM` for DM rooms and `CHANNEL` for everything else).
-  const isDM = $derived(roomData?.room.type === 'DM');
+  const isDM = $derived(roomData?.room.type === RoomType.Dm);
   const isRoomLoading = $derived(roomData === undefined);
 
   // Load room data when roomId or reconnect changes

--- a/frontend/src/lib/state/instance/store.svelte.ts
+++ b/frontend/src/lib/state/instance/store.svelte.ts
@@ -24,8 +24,6 @@ import type { RegisteredInstance } from './registry.svelte';
  */
 export type SpaceIndicator = 'notification' | 'unread' | null;
 
-const DM_SPACE_ID = 'DM';
-
 const EMPTY_PERMISSIONS: InstancePermissions = {
 	loaded: false,
 	canViewAdmin: false,

--- a/frontend/src/routes/chat/[instanceId]/(chrome)/[roomId]/m/[messageId]/+page.svelte
+++ b/frontend/src/routes/chat/[instanceId]/(chrome)/[roomId]/m/[messageId]/+page.svelte
@@ -86,9 +86,9 @@
   const getInstanceId = getActiveInstance();
   const stores = $derived(instanceRegistry.getStore(getInstanceId()));
 
-  // Resolve the room's actual storage space (DM rooms live in DM_SPACE_ID even
-  // though the URL only carries roomId). Returns null while the rooms store
-  // is loading — the effect below skips until it settles.
+  // Used as a "rooms store ready" gate — returns null while loading. We only
+  // need the room ID for the resolve query, so the resolved space ID itself
+  // is never read; we just wait for the store to settle before redirecting.
   const effective = useEffectiveSpaceId(() => page.params.roomId);
 
   $effect(() => {


### PR DESCRIPTION
## Summary

The schema work for #387 (`Room.type`, `Instance.rooms(type:)`, `User.rooms(type:)`) already shipped, and the admin Rooms page is already on `instance.rooms(type: CHANNEL)`. What remained was the consumer-side cleanup the issue called for — retiring the `DM_SPACE_ID`-as-discriminator leftovers from the era when frontend code inferred channel-vs-DM via `spaceId === "DM"`.

- Removed dead local `DM_SPACE_ID` consts in `store.svelte.ts` and `InstanceSpaceSection.svelte`.
- Removed dead `DM_SPACE_ID` imports in `RoomList.svelte` and `useRoomData.svelte.ts`.
- Replaced stringly-typed `room.type === 'DM'` with `RoomType.Dm` in `useRoomData`.
- Refreshed the stale comment in `m/[messageId]/+page.svelte` — the resolved space ID is unused there; the hook is just a "rooms store ready" gate.
- Bonus: dropped a pre-existing unused `untrack` import in `RoomList.svelte`.

The `DM_SPACE_ID` export in `$lib/constants` survives for `useEffectiveSpaceId`, where it's a real return value (the space ID a DM room belongs to), not a discriminator — so callers that route a DM into the DM-space subtree still have a single named constant to use.

Closes #387.

## Test plan

- [x] `mise lint-frontend` — no new errors in touched files
- [x] `mise test-frontend` — 709/709 passing
- [ ] CI passes