### PR TITLE
refactor(rbac): drop room-permission wrappers, move auth to resolvers

### DIFF
--- a/cli/internal/core/can_test.go
+++ b/cli/internal/core/can_test.go
@@ -612,7 +612,7 @@ func TestCanHelpers_RoomOverrides(t *testing.T) {
 		core.GrantInstancePermission(ctx, RoleEveryone, PermMessagePost)
 
 		// Deny at room level
-		core.denyRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessagePost)
+		core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
 
 		can, err := core.CanPostMessage(ctx, member.Id, space.Id, room.Id)
 		if err != nil {
@@ -623,7 +623,7 @@ func TestCanHelpers_RoomOverrides(t *testing.T) {
 		}
 
 		// Cleanup
-		core.clearRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessagePost)
+		core.ClearRoomPermissionState(ctx, room.Id, RoleEveryone, PermMessagePost)
 	})
 
 	t.Run("CanPostInThread respects room-level denial", func(t *testing.T) {
@@ -631,7 +631,7 @@ func TestCanHelpers_RoomOverrides(t *testing.T) {
 		core.GrantInstancePermission(ctx, RoleEveryone, PermMessagePostInThread)
 
 		// Deny at room level
-		core.denyRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessagePostInThread)
+		core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePostInThread)
 
 		can, err := core.CanPostInThread(ctx, member.Id, space.Id, room.Id)
 		if err != nil {
@@ -642,13 +642,13 @@ func TestCanHelpers_RoomOverrides(t *testing.T) {
 		}
 
 		// Cleanup
-		core.clearRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessagePostInThread)
+		core.ClearRoomPermissionState(ctx, room.Id, RoleEveryone, PermMessagePostInThread)
 	})
 
 	t.Run("CanReply respects room-level denial", func(t *testing.T) {
 		core.GrantInstancePermission(ctx, RoleEveryone, PermMessageReply)
 
-		core.denyRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessageReply)
+		core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessageReply)
 
 		can, err := core.CanReply(ctx, member.Id, space.Id, room.Id)
 		if err != nil {
@@ -659,13 +659,13 @@ func TestCanHelpers_RoomOverrides(t *testing.T) {
 		}
 
 		// Cleanup
-		core.clearRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessageReply)
+		core.ClearRoomPermissionState(ctx, room.Id, RoleEveryone, PermMessageReply)
 	})
 
 	t.Run("CanReplyInThread respects room-level denial", func(t *testing.T) {
 		core.GrantInstancePermission(ctx, RoleEveryone, PermMessageReplyInThread)
 
-		core.denyRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessageReplyInThread)
+		core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessageReplyInThread)
 
 		can, err := core.CanReplyInThread(ctx, member.Id, space.Id, room.Id)
 		if err != nil {
@@ -676,11 +676,11 @@ func TestCanHelpers_RoomOverrides(t *testing.T) {
 		}
 
 		// Cleanup
-		core.clearRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessageReplyInThread)
+		core.ClearRoomPermissionState(ctx, room.Id, RoleEveryone, PermMessageReplyInThread)
 	})
 
 	t.Run("CanReply is independent of CanPostMessage", func(t *testing.T) {
-		core.denyRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessagePost)
+		core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
 
 		canPost, err := core.CanPostMessage(ctx, member.Id, space.Id, room.Id)
 		if err != nil {
@@ -699,7 +699,7 @@ func TestCanHelpers_RoomOverrides(t *testing.T) {
 		}
 
 		// Cleanup
-		core.clearRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessagePost)
+		core.ClearRoomPermissionState(ctx, room.Id, RoleEveryone, PermMessagePost)
 	})
 
 	t.Run("CanReactToMessage respects room-level grant", func(t *testing.T) {
@@ -707,7 +707,7 @@ func TestCanHelpers_RoomOverrides(t *testing.T) {
 		core.ClearInstancePermissionState(ctx, RoleEveryone, PermMessageReact)
 
 		// Grant at room level
-		core.grantRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessageReact)
+		core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessageReact)
 
 		can, err := core.CanReactToMessage(ctx, member.Id, space.Id, room.Id)
 		if err != nil {
@@ -718,7 +718,7 @@ func TestCanHelpers_RoomOverrides(t *testing.T) {
 		}
 
 		// Cleanup
-		core.clearRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessageReact)
+		core.ClearRoomPermissionState(ctx, room.Id, RoleEveryone, PermMessageReact)
 	})
 
 	t.Run("CanEditOwnMessage respects room-level denial", func(t *testing.T) {
@@ -726,7 +726,7 @@ func TestCanHelpers_RoomOverrides(t *testing.T) {
 		core.GrantInstancePermission(ctx, RoleEveryone, PermMessageEditOwn)
 
 		// Deny at room level
-		core.denyRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessageEditOwn)
+		core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessageEditOwn)
 
 		can, err := core.CanEditOwnMessage(ctx, member.Id, space.Id, room.Id)
 		if err != nil {
@@ -737,13 +737,13 @@ func TestCanHelpers_RoomOverrides(t *testing.T) {
 		}
 
 		// Cleanup
-		core.clearRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessageEditOwn)
+		core.ClearRoomPermissionState(ctx, room.Id, RoleEveryone, PermMessageEditOwn)
 	})
 
 	t.Run("CanDeleteAnyMessage respects room-level grant", func(t *testing.T) {
 		// Ensure no space-level grant for message.delete-any (it's not default)
 		// Grant at room level
-		core.grantRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessageDeleteAny)
+		core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessageDeleteAny)
 
 		can, err := core.CanDeleteAnyMessage(ctx, member.Id, space.Id, room.Id)
 		if err != nil {
@@ -754,7 +754,7 @@ func TestCanHelpers_RoomOverrides(t *testing.T) {
 		}
 
 		// Cleanup
-		core.clearRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessageDeleteAny)
+		core.ClearRoomPermissionState(ctx, room.Id, RoleEveryone, PermMessageDeleteAny)
 	})
 }
 

--- a/cli/internal/core/permission_explainer_test.go
+++ b/cli/internal/core/permission_explainer_test.go
@@ -54,7 +54,7 @@ func TestPermissionExplainer_AgreesWithHas(t *testing.T) {
 
 	// Room-level override: deny message.post for the everyone space role in this
 	// room. Higher-rank roles (owner) should still post via the hierarchy walk.
-	if err := core.DenyRoomRolePermission(ctx, adminUser.Id, space.Id, room.Id, "everyone", PermMessagePost); err != nil {
+	if err := core.DenyRoomPermission(ctx, room.Id, "everyone", PermMessagePost); err != nil {
 		t.Fatalf("deny room perm: %v", err)
 	}
 

--- a/cli/internal/core/permission_ops.go
+++ b/cli/internal/core/permission_ops.go
@@ -33,7 +33,7 @@ import (
 
 // GrantInstancePermission grants a permission to a role's server-level
 // default. Accepts any valid permission — server- and space-scope grants
-// share the same KV row post-#330. Use GrantRoomRolePermission for
+// share the same KV row post-#330. Use GrantRoomPermission for
 // per-room overrides.
 // Uses key format: allow.{roleName}.{verb}.{objectType}.any
 func (c *ChattoCore) GrantInstancePermission(ctx context.Context, roleName string, perm Permission) error {
@@ -116,9 +116,9 @@ func (c *ChattoCore) ClearInstancePermissionState(ctx context.Context, roleName 
 // Room-Level Operations
 // ============================================================================
 
-// GrantRoomRolePermission grants a permission to a role at the room level.
+// GrantRoomPermission grants a permission to a role for a specific room.
 // Uses key format: allow.{roleName}.{verb}.{objectType}.{roomID}
-func (c *ChattoCore) grantRoomRolePermissionInternal(ctx context.Context, spaceID, roomID, roleName string, perm Permission) error {
+func (c *ChattoCore) GrantRoomPermission(ctx context.Context, roomID, roleName string, perm Permission) error {
 	if !PermissionAppliesAtScope(perm, ScopeRoom) {
 		return fmt.Errorf("permission %s does not apply at room scope", perm)
 	}
@@ -136,18 +136,16 @@ func (c *ChattoCore) grantRoomRolePermissionInternal(ctx context.Context, spaceI
 		return fmt.Errorf("failed to grant permission: %w", err)
 	}
 
-	// Remove any denial for this permission
 	denyKey := rbac.DenyKey(roleName, parts.Verb, parts.ObjectType, roomID)
-	_ = kv.Delete(ctx, denyKey) // Ignore not found error
+	_ = kv.Delete(ctx, denyKey)
 
-	c.logger.Debug("Granted room role permission",
-		"space", spaceID, "room", roomID, "role", roleName, "permission", perm)
+	c.logger.Debug("Granted room role permission", "room", roomID, "role", roleName, "permission", perm)
 	return nil
 }
 
-// DenyRoomRolePermission denies a permission for a role at the room level.
+// DenyRoomPermission denies a permission for a role at a specific room.
 // Uses key format: deny.{roleName}.{verb}.{objectType}.{roomID}
-func (c *ChattoCore) denyRoomRolePermissionInternal(ctx context.Context, spaceID, roomID, roleName string, perm Permission) error {
+func (c *ChattoCore) DenyRoomPermission(ctx context.Context, roomID, roleName string, perm Permission) error {
 	if !PermissionAppliesAtScope(perm, ScopeRoom) {
 		return fmt.Errorf("permission %s does not apply at room scope", perm)
 	}
@@ -165,17 +163,15 @@ func (c *ChattoCore) denyRoomRolePermissionInternal(ctx context.Context, spaceID
 		return fmt.Errorf("failed to deny permission: %w", err)
 	}
 
-	// Remove any grant for this permission
 	grantKey := rbac.AllowKey(roleName, parts.Verb, parts.ObjectType, roomID)
-	_ = kv.Delete(ctx, grantKey) // Ignore not found error
+	_ = kv.Delete(ctx, grantKey)
 
-	c.logger.Debug("Denied room role permission",
-		"space", spaceID, "room", roomID, "role", roleName, "permission", perm)
+	c.logger.Debug("Denied room role permission", "room", roomID, "role", roleName, "permission", perm)
 	return nil
 }
 
-// ClearRoomRolePermission clears both grant and denial for a permission at room level.
-func (c *ChattoCore) clearRoomRolePermissionInternal(ctx context.Context, spaceID, roomID, roleName string, perm Permission) error {
+// ClearRoomPermissionState removes both grant and denial for a permission at room level.
+func (c *ChattoCore) ClearRoomPermissionState(ctx context.Context, roomID, roleName string, perm Permission) error {
 	parts := perm.KeyParts()
 	if parts.Verb == "" || parts.ObjectType == "" {
 		return fmt.Errorf("invalid permission: %s", perm)
@@ -193,8 +189,7 @@ func (c *ChattoCore) clearRoomRolePermissionInternal(ctx context.Context, spaceI
 		return fmt.Errorf("failed to clear denial: %w", err)
 	}
 
-	c.logger.Debug("Cleared room role permission",
-		"space", spaceID, "room", roomID, "role", roleName, "permission", perm)
+	c.logger.Debug("Cleared room role permission", "room", roomID, "role", roleName, "permission", perm)
 	return nil
 }
 
@@ -210,14 +205,12 @@ const AnnouncementsRoomName = "announcements"
 // Everyone else can read and post in threads, but cannot start new conversations.
 // This is idempotent and safe to call multiple times.
 func (c *ChattoCore) SetupAnnouncementsRoomPermissions(ctx context.Context, spaceID, roomID string) error {
-	// Deny message.post to everyone at room level
-	if err := c.denyRoomRolePermissionInternal(ctx, spaceID, roomID, RoleEveryone, PermMessagePost); err != nil {
+	if err := c.DenyRoomPermission(ctx, roomID, RoleEveryone, PermMessagePost); err != nil {
 		return fmt.Errorf("failed to deny %s for everyone: %w", PermMessagePost, err)
 	}
 
-	// Grant message.post to owner, admin, and moderator at room level
 	for _, roleName := range []string{RoleOwner, RoleAdmin, RoleModerator} {
-		if err := c.grantRoomRolePermissionInternal(ctx, spaceID, roomID, roleName, PermMessagePost); err != nil {
+		if err := c.GrantRoomPermission(ctx, roomID, roleName, PermMessagePost); err != nil {
 			return fmt.Errorf("failed to grant %s for %s: %w", PermMessagePost, roleName, err)
 		}
 	}

--- a/cli/internal/core/permission_ops_test.go
+++ b/cli/internal/core/permission_ops_test.go
@@ -263,7 +263,7 @@ func TestGrantRoomRolePermission(t *testing.T) {
 	room, _ := core.CreateRoom(ctx, user.Id, space.Id, "General", "General chat")
 
 	t.Run("creates correct KV key for room-level permission", func(t *testing.T) {
-		err := core.grantRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessagePost)
+		err := core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
 		if err != nil {
 			t.Fatalf("GrantRoomRolePermission() error = %v", err)
 		}
@@ -279,7 +279,7 @@ func TestGrantRoomRolePermission(t *testing.T) {
 
 	t.Run("rejects permission that does not apply at room scope", func(t *testing.T) {
 		// space.create only applies at instance scope
-		err := core.grantRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermDMWrite)
+		err := core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermDMWrite)
 		if err == nil {
 			t.Error("Expected error for permission that doesn't apply at room scope")
 		}
@@ -295,7 +295,7 @@ func TestDenyRoomRolePermission(t *testing.T) {
 	room, _ := core.CreateRoom(ctx, user.Id, space.Id, "General", "General chat")
 
 	t.Run("creates deny key at room level", func(t *testing.T) {
-		err := core.denyRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessagePost)
+		err := core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
 		if err != nil {
 			t.Fatalf("DenyRoomRolePermission() error = %v", err)
 		}
@@ -310,7 +310,7 @@ func TestDenyRoomRolePermission(t *testing.T) {
 	})
 
 	t.Run("rejects permission that does not apply at room scope", func(t *testing.T) {
-		err := core.denyRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermAdminAccess)
+		err := core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermAdminAccess)
 		if err == nil {
 			t.Error("Expected error for permission that doesn't apply at room scope")
 		}
@@ -327,9 +327,9 @@ func TestClearRoomRolePermission(t *testing.T) {
 
 	t.Run("clears both grant and denial at room level", func(t *testing.T) {
 		// Grant then clear
-		_ = core.grantRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermRoomJoin)
+		_ = core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermRoomJoin)
 
-		err := core.clearRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermRoomJoin)
+		err := core.ClearRoomPermissionState(ctx, room.Id, RoleEveryone, PermRoomJoin)
 		if err != nil {
 			t.Fatalf("ClearRoomRolePermission() error = %v", err)
 		}

--- a/cli/internal/core/permission_resolver_test.go
+++ b/cli/internal/core/permission_resolver_test.go
@@ -421,7 +421,7 @@ func TestPermissionResolver_HasRoomPermission(t *testing.T) {
 
 	t.Run("returns true when user has permission at room level", func(t *testing.T) {
 		// Grant permission at room level
-		err := core.grantRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleOwner, PermMessagePost)
+		err := core.GrantRoomPermission(ctx, room.Id, RoleOwner, PermMessagePost)
 		if err != nil {
 			t.Fatalf("Failed to grant room permission: %v", err)
 		}
@@ -464,7 +464,7 @@ func TestPermissionResolver_HasRoomPermission_AdminRoleDenials(t *testing.T) {
 
 	t.Run("admin role is subject to room-level denials like any other role", func(t *testing.T) {
 		// Deny permission at room level for admin role
-		err := core.denyRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleOwner, PermMessagePost)
+		err := core.DenyRoomPermission(ctx, room.Id, RoleOwner, PermMessagePost)
 		if err != nil {
 			t.Fatalf("Failed to deny room permission: %v", err)
 		}
@@ -496,7 +496,7 @@ func TestPermissionResolver_HasRoomPermission_DenyWins(t *testing.T) {
 
 	t.Run("higher-ranked role denial wins at room level", func(t *testing.T) {
 		// Grant permission to everyone at room level
-		err := core.grantRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessagePost)
+		err := core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
 		if err != nil {
 			t.Fatalf("Failed to grant room permission: %v", err)
 		}
@@ -508,7 +508,7 @@ func TestPermissionResolver_HasRoomPermission_DenyWins(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create muted role: %v", err)
 		}
-		err = core.denyRoomRolePermissionInternal(ctx, space.Id, room.Id, "muted", PermMessagePost)
+		err = core.DenyRoomPermission(ctx, room.Id, "muted", PermMessagePost)
 		if err != nil {
 			t.Fatalf("Failed to deny room permission: %v", err)
 		}
@@ -555,7 +555,7 @@ func TestPermissionResolver_HasRoomPermission_RoomGrantOverridesAbsentSpaceGrant
 	}
 
 	// Grant at room level
-	err = core.grantRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessageReact)
+	err = core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessageReact)
 	if err != nil {
 		t.Fatalf("Failed to grant room permission: %v", err)
 	}
@@ -584,7 +584,7 @@ func TestPermissionResolver_HasRoomPermission_RoomDenialOverridesSpaceGrant(t *t
 	core.GrantInstancePermission(ctx, RoleEveryone, PermMessagePost)
 
 	// Deny at room level
-	core.denyRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessagePost)
+	core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
 
 	has, err := core.permissionResolver.HasRoomPermission(ctx, member.Id, space.Id, room.Id, PermMessagePost)
 	if err != nil {
@@ -610,7 +610,7 @@ func TestPermissionResolver_HasRoomPermission_RoomGrantCannotOverrideSpaceDenial
 	core.DenyInstancePermission(ctx, RoleEveryone, PermMessagePost)
 
 	// Grant at room level
-	core.grantRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessagePost)
+	core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
 
 	has, err := core.permissionResolver.HasRoomPermission(ctx, member.Id, space.Id, room.Id, PermMessagePost)
 	if err != nil {
@@ -636,10 +636,10 @@ func TestPermissionResolver_HasRoomPermission_ConflictingRoles(t *testing.T) {
 	core.CreateInstanceRole(ctx, "poster", "Poster", "Can post")
 
 	// Grant message.post to poster role at room level
-	core.grantRoomRolePermissionInternal(ctx, space.Id, room.Id, "poster", PermMessagePost)
+	core.GrantRoomPermission(ctx, room.Id, "poster", PermMessagePost)
 
 	// Deny message.post for everyone role at room level
-	core.denyRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessagePost)
+	core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
 
 	// Assign poster role to member (member now has: everyone + poster)
 	core.AssignInstanceRole(ctx, admin.Id, member.Id, "poster")
@@ -672,7 +672,7 @@ func TestPermissionResolver_HasRoomPermission_IsolationBetweenRooms(t *testing.T
 	core.GrantInstancePermission(ctx, RoleEveryone, PermMessagePost)
 
 	// Deny message.post only in room A
-	core.denyRoomRolePermissionInternal(ctx, space.Id, roomA.Id, RoleEveryone, PermMessagePost)
+	core.DenyRoomPermission(ctx, roomA.Id, RoleEveryone, PermMessagePost)
 
 	// Room A: denied
 	hasA, err := core.permissionResolver.HasRoomPermission(ctx, member.Id, space.Id, roomA.Id, PermMessagePost)
@@ -708,7 +708,7 @@ func TestPermissionResolver_HasRoomPermission_InstanceRoleRoomDenial(t *testing.
 	core.GrantInstancePermission(ctx, RoleEveryone, PermMessagePost)
 
 	// Deny message.post for instance-everyone at room level
-	core.denyRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessagePost)
+	core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
 
 	has, err := core.permissionResolver.HasRoomPermission(ctx, member.Id, space.Id, room.Id, PermMessagePost)
 	if err != nil {
@@ -734,7 +734,7 @@ func TestPermissionResolver_HasRoomPermission_InstanceRoleRoomGrant(t *testing.T
 	core.ClearInstancePermissionState(ctx, RoleEveryone, PermMessageReact)
 
 	// Grant message.react to instance-everyone at room level
-	core.grantRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessageReact)
+	core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessageReact)
 
 	has, err := core.permissionResolver.HasRoomPermission(ctx, member.Id, space.Id, room.Id, PermMessageReact)
 	if err != nil {
@@ -760,7 +760,7 @@ func TestPermissionResolver_HasRoomPermission_ClearFallsBackToSpace(t *testing.T
 	core.GrantInstancePermission(ctx, RoleEveryone, PermMessagePost)
 
 	// Deny at room level
-	core.denyRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessagePost)
+	core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
 
 	// Verify denied
 	has, _ := core.permissionResolver.HasRoomPermission(ctx, member.Id, space.Id, room.Id, PermMessagePost)
@@ -769,7 +769,7 @@ func TestPermissionResolver_HasRoomPermission_ClearFallsBackToSpace(t *testing.T
 	}
 
 	// Clear room override
-	core.clearRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessagePost)
+	core.ClearRoomPermissionState(ctx, room.Id, RoleEveryone, PermMessagePost)
 
 	// Should fall back to space grant
 	has, err := core.permissionResolver.HasRoomPermission(ctx, member.Id, space.Id, room.Id, PermMessagePost)
@@ -793,8 +793,8 @@ func TestPermissionResolver_HasRoomPermission_MultiplePermissionsPerRoom(t *test
 	core.JoinSpace(ctx, member.Id, space.Id)
 
 	// Grant message.post at room level, deny message.react at room level
-	core.grantRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessagePost)
-	core.denyRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessageReact)
+	core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
+	core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessageReact)
 
 	hasPost, err := core.permissionResolver.HasRoomPermission(ctx, member.Id, space.Id, room.Id, PermMessagePost)
 	if err != nil {
@@ -837,7 +837,7 @@ func TestPermissionResolver_DenyAlwaysWins(t *testing.T) {
 		}
 
 		// Grant at room level
-		err = core.grantRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessageReact)
+		err = core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessageReact)
 		if err != nil {
 			t.Fatalf("Failed to grant room permission: %v", err)
 		}
@@ -864,7 +864,7 @@ func TestPermissionResolver_DenyAlwaysWins(t *testing.T) {
 		}
 
 		// Grant at room level
-		err = core.grantRoomRolePermissionInternal(ctx, space.Id, room.Id, RoleEveryone, PermMessagePost)
+		err = core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
 		if err != nil {
 			t.Fatalf("Failed to grant room permission: %v", err)
 		}

--- a/cli/internal/core/rbac.go
+++ b/cli/internal/core/rbac.go
@@ -276,22 +276,6 @@ func (c *ChattoCore) hasRoomPermission(ctx context.Context, spaceID, roomID, use
 	return c.permissionResolver.HasRoomPermission(ctx, userID, spaceID, roomID, perm)
 }
 
-// requireSpacePermission checks if a user has a specific permission and returns
-// ErrPermissionDenied if not. This is an internal helper for core operations.
-//
-// Prefer using Can* functions for authorization checks, as they may include
-// additional business logic beyond simple permission checks.
-func (c *ChattoCore) requireSpacePermission(ctx context.Context, spaceID, userID string, perm Permission) error {
-	has, err := c.hasSpacePermission(ctx, spaceID, userID, perm)
-	if err != nil {
-		return err
-	}
-	if !has {
-		return ErrPermissionDenied
-	}
-	return nil
-}
-
 // HasSpaceUserPermissionViaRoles is a thin wrapper around HasUserPermissionViaRoles
 // that special-cases the DM system space (its permissions are static). Both
 // scopes share the unified SERVER_RBAC store; the hierarchy-wins resolution
@@ -750,39 +734,8 @@ func (c *ChattoCore) ReorderInstanceRoles(ctx context.Context, roleNames []strin
 	return result, nil
 }
 
-// ============================================================================
-// Room-Level Permission Wrappers (with authorization)
-// ============================================================================
-
-// GrantRoomRolePermission grants a permission to a role at the room level.
-// Authorization: Caller must have PermRoleManage in the space.
-func (c *ChattoCore) GrantRoomRolePermission(ctx context.Context, actorID, spaceID, roomID, roleName string, perm Permission) error {
-	if err := c.requireSpacePermission(ctx, spaceID, actorID, PermRoleManage); err != nil {
-		return err
-	}
-	return c.grantRoomRolePermissionInternal(ctx, spaceID, roomID, roleName, perm)
-}
-
-// DenyRoomRolePermission denies a permission for a role at the room level.
-// Authorization: Caller must have PermRoleManage in the space.
-func (c *ChattoCore) DenyRoomRolePermission(ctx context.Context, actorID, spaceID, roomID, roleName string, perm Permission) error {
-	if err := c.requireSpacePermission(ctx, spaceID, actorID, PermRoleManage); err != nil {
-		return err
-	}
-	return c.denyRoomRolePermissionInternal(ctx, spaceID, roomID, roleName, perm)
-}
-
-// ClearRoomRolePermission clears both grant and denial for a permission at room level.
-// Authorization: Caller must have PermRoleManage in the space.
-func (c *ChattoCore) ClearRoomRolePermission(ctx context.Context, actorID, spaceID, roomID, roleName string, perm Permission) error {
-	if err := c.requireSpacePermission(ctx, spaceID, actorID, PermRoleManage); err != nil {
-		return err
-	}
-	return c.clearRoomRolePermissionInternal(ctx, spaceID, roomID, roleName, perm)
-}
-
-// GetRoleRoomPermissions returns the room-level grants and denials for a role in a specific room.
-func (c *ChattoCore) GetRoleRoomPermissions(ctx context.Context, spaceID, roomID, roleName string) (grants []Permission, denials []Permission, err error) {
+// GetRoomRolePermissions returns the room-level grants and denials for a role in a specific room.
+func (c *ChattoCore) GetRoomRolePermissions(ctx context.Context, roomID, roleName string) (grants []Permission, denials []Permission, err error) {
 	kv := c.storage.serverRBACKV
 
 	allowKeys, err := listKeysWithPattern(ctx, kv, rbac.AllowPatternForSubject(roleName))

--- a/cli/internal/core/rbac_test.go
+++ b/cli/internal/core/rbac_test.go
@@ -2128,29 +2128,6 @@ func TestChattoCore_hasSpacePermission_NoRoles(t *testing.T) {
 	}
 }
 
-func TestChattoCore_requireSpacePermission(t *testing.T) {
-	core, _ := setupTestCore(t)
-	ctx := testContext(t)
-
-	space, _ := core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
-	core.JoinSpace(ctx, "user123", space.Id) // Must be a member for space permission checks
-	core.CreateInstanceRole(ctx, "testmod", "Test Mod", "Can moderate")
-	core.GrantInstancePermission(ctx, "testmod", PermRoleAssign)
-	core.AssignInstanceRole(ctx, "test-user", "user123", "testmod")
-
-	// Should succeed for granted permission
-	err := core.requireSpacePermission(ctx, space.Id, "user123", PermRoleAssign)
-	if err != nil {
-		t.Errorf("Expected no error, got %v", err)
-	}
-
-	// Should fail for non-granted permission
-	err = core.requireSpacePermission(ctx, space.Id, "user123", PermSpaceManage)
-	if !errors.Is(err, ErrPermissionDenied) {
-		t.Errorf("Expected ErrPermissionDenied, got %v", err)
-	}
-}
-
 // ============================================================================
 // Default Roles Tests
 // ============================================================================
@@ -2224,13 +2201,13 @@ func TestChattoCore_GrantRoomRolePermission(t *testing.T) {
 	room, _ := core.CreateRoom(ctx, "test-user", space.Id, "test-room", "Test channel")
 
 	// Grant message.post at room level for member role
-	err := core.GrantRoomRolePermission(ctx, "test-user", space.Id, room.Id, RoleEveryone, PermMessagePost)
+	err := core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
 	if err != nil {
 		t.Fatalf("Failed to grant room permission: %v", err)
 	}
 
 	// Verify via GetRoleRoomPermissions
-	grants, denials, err := core.GetRoleRoomPermissions(ctx, space.Id, room.Id, RoleEveryone)
+	grants, denials, err := core.GetRoomRolePermissions(ctx, room.Id, RoleEveryone)
 	if err != nil {
 		t.Fatalf("Failed to get room permissions: %v", err)
 	}
@@ -2250,12 +2227,12 @@ func TestChattoCore_DenyRoomRolePermission(t *testing.T) {
 	room, _ := core.CreateRoom(ctx, "test-user", space.Id, "test-room", "Test channel")
 
 	// Deny message.post at room level
-	err := core.DenyRoomRolePermission(ctx, "test-user", space.Id, room.Id, RoleEveryone, PermMessagePost)
+	err := core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
 	if err != nil {
 		t.Fatalf("Failed to deny room permission: %v", err)
 	}
 
-	grants, denials, err := core.GetRoleRoomPermissions(ctx, space.Id, room.Id, RoleEveryone)
+	grants, denials, err := core.GetRoomRolePermissions(ctx, room.Id, RoleEveryone)
 	if err != nil {
 		t.Fatalf("Failed to get room permissions: %v", err)
 	}
@@ -2275,13 +2252,13 @@ func TestChattoCore_ClearRoomRolePermission(t *testing.T) {
 	room, _ := core.CreateRoom(ctx, "test-user", space.Id, "test-room", "Test channel")
 
 	// Grant, then clear
-	core.GrantRoomRolePermission(ctx, "test-user", space.Id, room.Id, RoleEveryone, PermMessagePost)
-	err := core.ClearRoomRolePermission(ctx, "test-user", space.Id, room.Id, RoleEveryone, PermMessagePost)
+	core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
+	err := core.ClearRoomPermissionState(ctx, room.Id, RoleEveryone, PermMessagePost)
 	if err != nil {
 		t.Fatalf("Failed to clear room permission: %v", err)
 	}
 
-	grants, denials, err := core.GetRoleRoomPermissions(ctx, space.Id, room.Id, RoleEveryone)
+	grants, denials, err := core.GetRoomRolePermissions(ctx, room.Id, RoleEveryone)
 	if err != nil {
 		t.Fatalf("Failed to get room permissions: %v", err)
 	}
@@ -2301,7 +2278,7 @@ func TestChattoCore_GrantRoomRolePermission_InvalidScope(t *testing.T) {
 	room, _ := core.CreateRoom(ctx, "test-user", space.Id, "general", "General")
 
 	// space.manage is not room-scoped — should fail
-	err := core.GrantRoomRolePermission(ctx, "test-user", space.Id, room.Id, RoleEveryone, PermSpaceManage)
+	err := core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermSpaceManage)
 	if err == nil {
 		t.Error("Expected error for non-room-scoped permission, got nil")
 	}
@@ -2316,10 +2293,10 @@ func TestChattoCore_RoomPermissions_PerRoomIsolation(t *testing.T) {
 	room2, _ := core.CreateRoom(ctx, "test-user", space.Id, "room-beta", "Room Beta")
 
 	// Deny message.post only in room1
-	core.DenyRoomRolePermission(ctx, "test-user", space.Id, room1.Id, RoleEveryone, PermMessagePost)
+	core.DenyRoomPermission(ctx, room1.Id, RoleEveryone, PermMessagePost)
 
 	// Room1 should have the denial
-	grants1, denials1, _ := core.GetRoleRoomPermissions(ctx, space.Id, room1.Id, RoleEveryone)
+	grants1, denials1, _ := core.GetRoomRolePermissions(ctx, room1.Id, RoleEveryone)
 	if len(denials1) != 1 {
 		t.Errorf("Room1: expected 1 denial, got %d", len(denials1))
 	}
@@ -2328,28 +2305,16 @@ func TestChattoCore_RoomPermissions_PerRoomIsolation(t *testing.T) {
 	}
 
 	// Room2 should have no overrides
-	grants2, denials2, _ := core.GetRoleRoomPermissions(ctx, space.Id, room2.Id, RoleEveryone)
+	grants2, denials2, _ := core.GetRoomRolePermissions(ctx, room2.Id, RoleEveryone)
 	if len(grants2) != 0 || len(denials2) != 0 {
 		t.Errorf("Room2: expected no overrides, got grants=%v denials=%v", grants2, denials2)
 	}
 }
 
-func TestChattoCore_RoomPermissions_AuthorizationRequired(t *testing.T) {
-	core, _ := setupTestCore(t)
-	ctx := testContext(t)
-
-	space, _ := core.CreateSpace(ctx, "admin-user", "Test Space", "A test space")
-	room, _ := core.CreateRoom(ctx, "admin-user", space.Id, "general", "General")
-
-	// Create a non-admin user as a space member
-	core.JoinSpace(ctx, "regular-user", space.Id)
-
-	// Regular user should not be able to grant room permissions
-	err := core.GrantRoomRolePermission(ctx, "regular-user", space.Id, room.Id, RoleEveryone, PermMessagePost)
-	if !errors.Is(err, ErrPermissionDenied) {
-		t.Errorf("Expected ErrPermissionDenied, got %v", err)
-	}
-}
+// Authorization for room-level permission mutations now lives at the GraphQL
+// boundary (Resolver.requireRoomManageAuth → CanSpaceRolesManage). The previous
+// in-core gate that this test exercised has been retired; the resolver-level
+// equivalent is covered by mutation_test.go.
 
 func TestChattoCore_GrantRoomRolePermission_GrantClearsDenial(t *testing.T) {
 	core, _ := setupTestCore(t)
@@ -2359,10 +2324,10 @@ func TestChattoCore_GrantRoomRolePermission_GrantClearsDenial(t *testing.T) {
 	room, _ := core.CreateRoom(ctx, "test-user", space.Id, "general", "General")
 
 	// Deny, then grant — should clear the denial
-	core.DenyRoomRolePermission(ctx, "test-user", space.Id, room.Id, RoleEveryone, PermMessagePost)
-	core.GrantRoomRolePermission(ctx, "test-user", space.Id, room.Id, RoleEveryone, PermMessagePost)
+	core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
+	core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
 
-	grants, denials, _ := core.GetRoleRoomPermissions(ctx, space.Id, room.Id, RoleEveryone)
+	grants, denials, _ := core.GetRoomRolePermissions(ctx, room.Id, RoleEveryone)
 	if len(grants) != 1 || grants[0] != PermMessagePost {
 		t.Errorf("Expected [message.post] grant, got %v", grants)
 	}

--- a/cli/internal/graph/authz.go
+++ b/cli/internal/graph/authz.go
@@ -150,6 +150,19 @@ func (r *Resolver) canManageInstanceUsers(ctx context.Context, userID string) (b
 	return r.core.HasInstancePermission(ctx, userID, core.PermAdminUsersManage)
 }
 
+// requireRoomManageAuth gates room-level permission mutations on PermRoleManage
+// in the relevant space (formerly enforced inside the core wrappers).
+func (r *Resolver) requireRoomManageAuth(ctx context.Context, userID, spaceID string) error {
+	can, err := r.core.CanSpaceRolesManage(ctx, userID, spaceID)
+	if err != nil {
+		return err
+	}
+	if !can {
+		return core.ErrPermissionDenied
+	}
+	return nil
+}
+
 // isInstanceAdmin returns true when the user has the owner or admin role.
 func (r *Resolver) isInstanceAdmin(ctx context.Context, userID string) (bool, error) {
 	isOwner, err := r.core.IsInstanceOwner(ctx, userID)

--- a/cli/internal/graph/instance_rbac_extra.resolvers.go
+++ b/cli/internal/graph/instance_rbac_extra.resolvers.go
@@ -262,8 +262,11 @@ func (r *mutationResolver) GrantRoomPermission(ctx context.Context, input model.
 	if err != nil {
 		return false, err
 	}
+	if err := r.requireRoomManageAuth(ctx, user.Id, spaceID); err != nil {
+		return false, err
+	}
 
-	if err := r.core.GrantRoomRolePermission(ctx, user.Id, spaceID, input.RoomID, input.Role, core.Permission(input.Permission)); err != nil {
+	if err := r.core.GrantRoomPermission(ctx, input.RoomID, input.Role, core.Permission(input.Permission)); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -279,8 +282,11 @@ func (r *mutationResolver) DenyRoomPermission(ctx context.Context, input model.D
 	if err != nil {
 		return false, err
 	}
+	if err := r.requireRoomManageAuth(ctx, user.Id, spaceID); err != nil {
+		return false, err
+	}
 
-	if err := r.core.DenyRoomRolePermission(ctx, user.Id, spaceID, input.RoomID, input.Role, core.Permission(input.Permission)); err != nil {
+	if err := r.core.DenyRoomPermission(ctx, input.RoomID, input.Role, core.Permission(input.Permission)); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -296,8 +302,11 @@ func (r *mutationResolver) ClearRoomPermission(ctx context.Context, input model.
 	if err != nil {
 		return false, err
 	}
+	if err := r.requireRoomManageAuth(ctx, user.Id, spaceID); err != nil {
+		return false, err
+	}
 
-	if err := r.core.ClearRoomRolePermission(ctx, user.Id, spaceID, input.RoomID, input.Role, core.Permission(input.Permission)); err != nil {
+	if err := r.core.ClearRoomPermissionState(ctx, input.RoomID, input.Role, core.Permission(input.Permission)); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -328,7 +337,7 @@ func (r *roomResolver) RoomPermissionOverrides(ctx context.Context, obj *corev1.
 		if role.Name == core.RoleEveryone {
 			continue
 		}
-		grants, denials, err := r.core.GetRoleRoomPermissions(ctx, obj.SpaceId, obj.Id, role.Name)
+		grants, denials, err := r.core.GetRoomRolePermissions(ctx, obj.Id, role.Name)
 		if err != nil {
 			return nil, err
 		}

--- a/cli/internal/graph/mutation_test.go
+++ b/cli/internal/graph/mutation_test.go
@@ -1140,7 +1140,7 @@ func TestPostMessage_EchoPermission(t *testing.T) {
 		}
 
 		// Deny echo at room level for everyone role (testUser is space owner, has roles.manage)
-		err = env.core.DenyRoomRolePermission(env.ctx, env.testUser.Id, env.testSpace.Id, env.testRoom.Id, core.RoleEveryone, core.PermMessageEcho)
+		err = env.core.DenyRoomPermission(env.ctx, env.testRoom.Id, core.RoleEveryone, core.PermMessageEcho)
 		if err != nil {
 			t.Fatalf("failed to deny permission: %v", err)
 		}
@@ -1175,7 +1175,7 @@ func TestPostMessage_EchoPermission(t *testing.T) {
 		}
 
 		// Deny message.post at room level for everyone role
-		err = env.core.DenyRoomRolePermission(env.ctx, env.testUser.Id, env.testSpace.Id, env.testRoom.Id, core.RoleEveryone, core.PermMessagePost)
+		err = env.core.DenyRoomPermission(env.ctx, env.testRoom.Id, core.RoleEveryone, core.PermMessagePost)
 		if err != nil {
 			t.Fatalf("failed to deny permission: %v", err)
 		}

--- a/cli/internal/graph/role_permissions_helpers.go
+++ b/cli/internal/graph/role_permissions_helpers.go
@@ -71,7 +71,7 @@ func (r *Resolver) buildRoleAcrossTiers(
 	out.Server = newTierPermissions(grants, denials)
 
 	if roomID != "" {
-		grants, denials, err := r.core.GetRoleRoomPermissions(ctx, spaceID, roomID, roleName)
+		grants, denials, err := r.core.GetRoomRolePermissions(ctx, roomID, roleName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load room overrides: %w", err)
 		}
@@ -147,7 +147,7 @@ func (r *Resolver) buildTierRole(
 		// state is the override; nothing is inherited.
 		out.Override = newTierPermissions(serverGrants, serverDenials)
 	case core.ScopeRoom:
-		grants, denials, err := r.core.GetRoleRoomPermissions(ctx, spaceID, roomID, role.Name)
+		grants, denials, err := r.core.GetRoomRolePermissions(ctx, roomID, role.Name)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load room overrides: %w", err)
 		}


### PR DESCRIPTION
## Summary

Continues #411 with the same playbook for the room-level permission methods. The public wrappers `GrantRoomRolePermission` / `DenyRoomRolePermission` / `ClearRoomRolePermission` only added a `requireSpacePermission(PermRoleManage)` gate around private `*Internal` helpers — auth that per \`.claude/rules/authorization.md\` belongs at the GraphQL boundary, not in core.

- Promote the internals to public `GrantRoomPermission` / `DenyRoomPermission` / `ClearRoomPermissionState`, drop the unused \`spaceID\` parameter, simplify log lines.
- Add \`Resolver.requireRoomManageAuth(ctx, userID, spaceID)\` in \`authz.go\` and call it from the three room-permission mutations in \`instance_rbac_extra.resolvers.go\` before invoking core. Auth contract unchanged: \`CanSpaceRolesManage\` → \`PermRoleManage\`.
- Rename \`GetRoleRoomPermissions(ctx, spaceID, roomID, role)\` → \`GetRoomRolePermissions(ctx, roomID, role)\`; \`spaceID\` was never consulted.
- Drop the now-orphaned \`requireSpacePermission\` helper and its unit test. \`hasSpacePermission\` stays — \`can.go\`'s \`Can*\` family still uses it.
- Retire \`TestChattoCore_RoomPermissions_AuthorizationRequired\` — it exercised the in-core gate that's gone; resolver-level coverage lives in \`mutation_test.go\`.

Net: **11 files, +105 / -172**.

## Test plan

- [x] \`mise x -- go build ./...\`
- [x] \`mise x -- go vet ./...\` — clean (only pre-existing protobuf-by-value warnings on \`generated.go\`).
- [x] \`mise x -- go test ./internal/core/... ./internal/graph/... ./cmd/...\` — all green.
- [x] \`mise x -- pnpm -C frontend run check\` — 0 errors / 0 warnings.
- [ ] CI: full e2e suite.
- [ ] CI: lint + frontend unit.
- Note: \`TestAuthRoutes_TestEmailEndpoint\` continues to fail locally per \`.claude/rules/backend.md\` — pre-existing flake unrelated to this PR.

Plan: \`.context/plans/room-permission-wrappers-dedupe.md\`.