### PR TITLE
refactor(rbac): drop vestigial spaceID params and IsSpaceAdmin wrapper

### DIFF
--- a/cli/internal/core/rbac.go
+++ b/cli/internal/core/rbac.go
@@ -769,11 +769,12 @@ func (c *ChattoCore) GetRoomRolePermissions(ctx context.Context, roomID, roleNam
 	return grants, denials, nil
 }
 
-// CanManageSpaceUser checks if actor can manage target based on role hierarchy.
-// Returns true if actor's highest role position < target's highest role position.
-// This is used for operations like kick, mute, etc. Callers must verify space
-// membership first; members with no explicit roles fall back to PositionEveryone.
-func (c *ChattoCore) CanManageSpaceUser(ctx context.Context, spaceID, actorID, targetID string) (bool, error) {
+// CanManageUser checks whether actor outranks target by role-hierarchy
+// position. Returns true if actor's highest position < target's highest
+// position (lower position = higher rank). Used for kick/mute/role-assignment
+// gates. Callers must verify space membership separately if relevant; users
+// with no explicit roles fall back to PositionEveryone.
+func (c *ChattoCore) CanManageUser(ctx context.Context, actorID, targetID string) (bool, error) {
 	engine := c.storage.serverRBACEngine
 
 	actorPos, err := engine.GetUserHighestPosition(ctx, actorID)
@@ -859,31 +860,15 @@ func (c *ChattoCore) GetRoleUsers(ctx context.Context, spaceID, roleName string)
 	return users, nil
 }
 
-// IsSpaceAdmin checks if a user has the admin role in a space.
-func (c *ChattoCore) IsSpaceAdmin(ctx context.Context, spaceID, userID string) (bool, error) {
-	if IsDMSpace(spaceID) {
-		return false, nil
-	}
-
-	engine := c.storage.serverRBACEngine
-
-	return engine.HasUserAdmin(ctx, userID)
-}
-
-// RevokeAllUserRoles removes all role assignments for a user in a space.
-// This is called during cleanup when a user leaves a space.
+// RevokeAllUserRoles removes every role assignment for a user. Post-#330
+// roles are server-wide, so this clears the user from every role they hold.
+// Used during LeaveSpace cleanup and account deletion.
 // Authorization: Internal use only (no permission check needed).
-func (c *ChattoCore) RevokeAllUserRoles(ctx context.Context, spaceID, userID string) error {
-	if IsDMSpace(spaceID) {
-		return nil
-	}
-
-	engine := c.storage.serverRBACEngine
-
-	if err := engine.RevokeAllUserRoles(ctx, userID); err != nil {
+func (c *ChattoCore) RevokeAllUserRoles(ctx context.Context, userID string) error {
+	if err := c.storage.serverRBACEngine.RevokeAllUserRoles(ctx, userID); err != nil {
 		return fmt.Errorf("failed to revoke user roles: %w", err)
 	}
 
-	c.logger.Debug("Revoked all roles for user in space", "user_id", userID, "space_id", spaceID)
+	c.logger.Debug("Revoked all roles for user", "user_id", userID)
 	return nil
 }

--- a/cli/internal/core/rbac_test.go
+++ b/cli/internal/core/rbac_test.go
@@ -2755,7 +2755,7 @@ func TestChattoCore_CreateRole_PositionAssignment(t *testing.T) {
 	})
 }
 
-func TestChattoCore_CanManageSpaceUser(t *testing.T) {
+func TestChattoCore_CanManageUser(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
@@ -2777,8 +2777,8 @@ func TestChattoCore_CanManageSpaceUser(t *testing.T) {
 	// member has no explicit role, just the implicit member role
 
 	t.Run("owner can manage all", func(t *testing.T) {
-		canMod, _ := core.CanManageSpaceUser(ctx, space.Id, owner, mod)
-		canMember, _ := core.CanManageSpaceUser(ctx, space.Id, owner, member)
+		canMod, _ := core.CanManageUser(ctx, owner, mod)
+		canMember, _ := core.CanManageUser(ctx, owner, member)
 
 		if !canMod {
 			t.Error("Owner should be able to manage moderator")
@@ -2789,8 +2789,8 @@ func TestChattoCore_CanManageSpaceUser(t *testing.T) {
 	})
 
 	t.Run("moderator can manage member but not owner", func(t *testing.T) {
-		canOwner, _ := core.CanManageSpaceUser(ctx, space.Id, mod, owner)
-		canMember, _ := core.CanManageSpaceUser(ctx, space.Id, mod, member)
+		canOwner, _ := core.CanManageUser(ctx, mod, owner)
+		canMember, _ := core.CanManageUser(ctx, mod, member)
 
 		if canOwner {
 			t.Error("Moderator should NOT be able to manage owner")
@@ -2801,8 +2801,8 @@ func TestChattoCore_CanManageSpaceUser(t *testing.T) {
 	})
 
 	t.Run("member cannot manage anyone with a role", func(t *testing.T) {
-		canOwner, _ := core.CanManageSpaceUser(ctx, space.Id, member, owner)
-		canMod, _ := core.CanManageSpaceUser(ctx, space.Id, member, mod)
+		canOwner, _ := core.CanManageUser(ctx, member, owner)
+		canMod, _ := core.CanManageUser(ctx, member, mod)
 
 		if canOwner {
 			t.Error("Member should NOT be able to manage owner")
@@ -2818,12 +2818,12 @@ func TestChattoCore_CanManageSpaceUser(t *testing.T) {
 		core.JoinSpace(ctx, mod2, space.Id)
 		core.AssignInstanceRole(ctx, SystemActorID, mod2, RoleModerator)
 
-		canManage, _ := core.CanManageSpaceUser(ctx, space.Id, mod, mod2)
+		canManage, _ := core.CanManageUser(ctx, mod, mod2)
 		if canManage {
 			t.Error("Moderator should NOT be able to manage another moderator (same rank)")
 		}
 
-		canManageReverse, _ := core.CanManageSpaceUser(ctx, space.Id, mod2, mod)
+		canManageReverse, _ := core.CanManageUser(ctx, mod2, mod)
 		if canManageReverse {
 			t.Error("Moderator should NOT be able to manage another moderator (reverse)")
 		}

--- a/cli/internal/core/spaces.go
+++ b/cli/internal/core/spaces.go
@@ -441,12 +441,11 @@ func (c *ChattoCore) LeaveSpace(ctx context.Context, user_id, space_id string, i
 		return nil
 	}
 
-	// Business rule: Space admins cannot leave (unless it's account deletion)
+	// Business rule: server admins cannot leave a space (they have implicit
+	// management rights server-wide). Skipped during account deletion.
 	if !isAccountDeletion {
-		isAdmin, err := c.IsSpaceAdmin(ctx, space_id, user_id)
+		isAdmin, err := c.IsInstanceAdmin(ctx, user_id)
 		if err != nil {
-			// If we can't check admin status (e.g., space doesn't fully exist),
-			// allow the leave operation to proceed
 			c.logger.Warn("Failed to check admin status during LeaveSpace, proceeding", "user_id", user_id, "space_id", space_id, "error", err)
 		} else if isAdmin {
 			return ErrAdminCannotLeaveSpace
@@ -459,8 +458,8 @@ func (c *ChattoCore) LeaveSpace(ctx context.Context, user_id, space_id string, i
 		// Continue with space membership deletion - this is best-effort cleanup
 	}
 
-	// Delete all role assignments for this user in this space (best-effort cleanup)
-	if err := c.RevokeAllUserRoles(ctx, space_id, user_id); err != nil {
+	// Delete all role assignments for this user (best-effort cleanup)
+	if err := c.RevokeAllUserRoles(ctx, user_id); err != nil {
 		c.logger.Warn("Failed to delete role assignments during leave space", "user_id", user_id, "space_id", space_id, "error", err)
 		// Continue with space membership deletion - this is best-effort cleanup
 	}

--- a/cli/internal/graph/instance_rbac_extra.resolvers.go
+++ b/cli/internal/graph/instance_rbac_extra.resolvers.go
@@ -143,7 +143,7 @@ func (r *instanceResolver) ViewerCanManageUser(ctx context.Context, obj *model.I
 	if err != nil || spaceID == "" {
 		return false, err
 	}
-	return r.core.CanManageSpaceUser(ctx, spaceID, user.Id, userID)
+	return r.core.CanManageUser(ctx, user.Id, userID)
 }
 
 // RoleUsers is the resolver for the roleUsers field.


### PR DESCRIPTION
## Summary

Three small cleanups to \`ChattoCore\` RBAC methods that carry \`spaceID\` parameters they don't (post-#330 / #411 / #412) actually use. Same instinct as #411 / #412: when a parameter looks like it scopes a call but doesn't, callers can't reason about what they're really calling.

- \`CanManageSpaceUser(ctx, spaceID, actorID, targetID)\` → \`CanManageUser(ctx, actorID, targetID)\`. The implementation only consults role positions; \`spaceID\` was never read.
- \`RevokeAllUserRoles(ctx, spaceID, userID)\` → \`RevokeAllUserRoles(ctx, userID)\`. Drops the defensive \`IsDMSpace(spaceID)\` short-circuit — \`LeaveSpace\` is the only caller and is never invoked with a DM space id. Comments now reflect that roles are server-wide post-#330.
- \`IsSpaceAdmin(ctx, spaceID, userID)\` deleted; the one caller in \`LeaveSpace\` switches to the existing \`IsInstanceAdmin(ctx, userID)\`. Same underlying engine call; the DM short-circuit was unreachable.

\`GetUserEffectiveSpacePermissions(ctx, spaceID, userID)\` was audited and **left untouched**: \`PermissionResolver.HasSpacePermission\` legitimately consumes \`spaceID\` for the DM short-circuit, membership lookup, and the space-scoped permission walk.

Net: **4 files, +27 / -43**.

## Test plan

- [x] \`mise x -- go build ./...\`
- [x] \`mise x -- go vet ./...\` clean (only pre-existing protobuf-by-value warnings on \`generated.go\`).
- [x] \`mise x -- go test ./internal/core/... ./internal/graph/... ./cmd/...\` all green.
- [x] \`mise x -- pnpm -C frontend run check\` 0 errors / 0 warnings.
- [ ] CI: full e2e suite.
- [ ] CI: lint + frontend unit.

Plan: \`.context/plans/vestigial-spaceid-params.md\`.