### PR TITLE
fix(admin): resolve viewer permissions against the active instance

### DIFF
--- a/frontend/src/lib/InstanceSpaceSection.svelte
+++ b/frontend/src/lib/InstanceSpaceSection.svelte
@@ -5,7 +5,6 @@
   import { instanceIdToSegment } from '$lib/navigation';
   import { instanceRegistry } from '$lib/state/instance/registry.svelte';
   import { graphqlClientManager } from '$lib/state/instance/graphqlClient.svelte';
-  import type { ViewerData } from '$lib/state/instance/permissions.svelte';
   import { createInstanceEventBusHandlerRegistrar } from '$lib/instanceEventBus.svelte';
   import { graphql } from './gql';
   import { notificationTarget } from '$lib/state/instance/notifications.svelte';
@@ -14,13 +13,10 @@
 
   let {
     instanceId,
-    currentUserId,
-    onPermissionsLoaded
+    currentUserId
   }: {
     instanceId: string;
     currentUserId?: string;
-    /** Callback to update instance permissions when the combined query completes (home instance only). */
-    onPermissionsLoaded?: (viewer: ViewerData) => void;
   } = $props();
 
   const instanceSegment = $derived(instanceIdToSegment(instanceId));
@@ -112,13 +108,8 @@
 
     const { instance, me, viewer } = initResult.data;
 
-    // Store viewer permissions on the per-instance store (all instances)
     if (viewer) {
       stores.setPermissions(viewer);
-      // Also update the context-based permissions (origin instance, for layouts)
-      if (onPermissionsLoaded) {
-        onPermissionsLoaded(viewer);
-      }
     }
 
     if (me) {

--- a/frontend/src/lib/SpaceList.svelte
+++ b/frontend/src/lib/SpaceList.svelte
@@ -4,7 +4,7 @@
   import { getCurrentUser } from '$lib/auth/currentUser.svelte';
   import { instanceRegistry } from '$lib/state/instance/registry.svelte';
   import { getActiveInstance } from '$lib/state/activeInstance.svelte';
-  import { getInstancePermissions, type InstancePermissions, type ViewerData } from '$lib/state/instance/permissions.svelte';
+  import type { InstancePermissions } from '$lib/state/instance/permissions.svelte';
   import UserAvatar from './components/UserAvatar.svelte';
   import InstanceSpaceSection from './InstanceSpaceSection.svelte';
   import AddInstanceDialog from './components/AddInstanceDialog.svelte';
@@ -14,13 +14,6 @@
   // currentUser isn't populated yet (e.g. immediately after login, before
   // the origin instance is fully registered in the store).
   const currentUserCtx = getCurrentUser();
-
-  let {
-    onPermissionsLoaded
-  }: {
-    /** Callback to update instance permissions when the combined query completes. */
-    onPermissionsLoaded?: (viewer: ViewerData) => void;
-  } = $props();
 
   const originInstanceId = $derived(instanceRegistry.originInstance?.id ?? '');
   const getInstanceId = getActiveInstance();
@@ -33,10 +26,6 @@
     instanceRegistry.tryGetStore(activeInstanceId)?.currentUser.user
     ?? (activeInstanceId === originInstanceId ? currentUserCtx.user : undefined)
   );
-
-  // Read permissions from centralized instance permissions context
-  const instancePerms = getInstancePermissions();
-  void instancePerms;
 
   // Check whether any authenticated instance grants a permission.
   // Optimistically returns true while permissions are still loading.
@@ -79,7 +68,6 @@
         <InstanceSpaceSection
           instanceId={instance.id}
           currentUserId={instanceUser?.id}
-          onPermissionsLoaded={isOrigin ? onPermissionsLoaded : undefined}
         />
       {/if}
     {/each}

--- a/frontend/src/lib/state/instance/__permissionsTestHarness.svelte
+++ b/frontend/src/lib/state/instance/__permissionsTestHarness.svelte
@@ -1,0 +1,23 @@
+<!--
+  Test-only harness for getInstancePermissions(). The function reads the
+  `getActiveInstance` Svelte context, which can only be set from a component
+  initializer — hence this tiny wrapper.
+-->
+<script lang="ts">
+  import { setActiveInstance } from '$lib/state/activeInstance.svelte';
+  import { getInstancePermissions, type InstancePermissions } from './permissions.svelte';
+
+  let {
+    instanceId,
+    expose
+  }: {
+    instanceId: string;
+    expose: (perms: { readonly current: InstancePermissions }) => void;
+  } = $props();
+
+  setActiveInstance(() => instanceId);
+  const perms = getInstancePermissions();
+  $effect(() => {
+    expose(perms);
+  });
+</script>

--- a/frontend/src/lib/state/instance/permissions.svelte.spec.ts
+++ b/frontend/src/lib/state/instance/permissions.svelte.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import Harness from './__permissionsTestHarness.svelte';
+import { instanceRegistry, type RegisteredInstance } from './registry.svelte';
+import type { InstancePermissions, ViewerData } from './permissions.svelte';
+
+const STORAGE_KEY = 'chatto:instances';
+
+function makeInstance(overrides: Partial<RegisteredInstance> = {}): RegisteredInstance {
+  return {
+    id: 'remote',
+    url: 'https://remote.example.com',
+    name: 'Remote',
+    iconUrl: null,
+    token: null,
+    userId: null,
+    userLogin: null,
+    userDisplayName: null,
+    userAvatarUrl: null,
+    addedAt: 0,
+    ...overrides
+  };
+}
+
+function makeViewer(overrides: Partial<ViewerData> = {}): ViewerData {
+  return {
+    canViewAdmin: false,
+    canViewDMs: false,
+    canWriteDMs: false,
+    canAdminViewUsers: false,
+    canAdminManageUsers: false,
+    canAdminViewRoles: false,
+    canAdminManageRoles: false,
+    canAdminViewSystem: false,
+    canAdminViewAudit: false,
+    ...overrides
+  };
+}
+
+function mount(instanceId: string): { readonly current: InstancePermissions } {
+  let perms: { readonly current: InstancePermissions } | undefined;
+  render(Harness, {
+    props: {
+      instanceId,
+      expose: (p) => {
+        perms = p;
+      }
+    }
+  });
+  if (!perms) throw new Error('harness did not expose perms');
+  return perms;
+}
+
+describe('getInstancePermissions', () => {
+  beforeEach(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    for (const instance of [...instanceRegistry.instances]) {
+      instanceRegistry.removeInstance(instance.id);
+    }
+  });
+
+  it('reads from the active instance store', () => {
+    instanceRegistry.addInstance(makeInstance({ id: 'remote' }));
+    instanceRegistry.getStore('remote').setPermissions(makeViewer({ canAdminViewRoles: true }));
+
+    const perms = mount('remote');
+
+    expect(perms.current.loaded).toBe(true);
+    expect(perms.current.canAdminViewRoles).toBe(true);
+  });
+
+  it('returns unloaded defaults when no store exists for the active instance', () => {
+    const perms = mount('not-registered');
+
+    expect(perms.current.loaded).toBe(false);
+    expect(perms.current.canAdminViewRoles).toBe(false);
+  });
+
+  it('reflects the active instance, not the origin', () => {
+    // Origin grants admin; remote does not.
+    instanceRegistry.addInstance(
+      makeInstance({ id: 'origin', url: window.location.origin, name: 'Origin' })
+    );
+    instanceRegistry.getStore('origin').setPermissions(makeViewer({ canAdminViewRoles: true }));
+
+    instanceRegistry.addInstance(makeInstance({ id: 'remote' }));
+    instanceRegistry.getStore('remote').setPermissions(makeViewer({ canAdminViewRoles: false }));
+
+    const perms = mount('remote');
+
+    // Bug we are guarding against: reading origin's permissions here would
+    // wrongly return true.
+    expect(perms.current.loaded).toBe(true);
+    expect(perms.current.canAdminViewRoles).toBe(false);
+  });
+});

--- a/frontend/src/lib/state/instance/permissions.svelte.ts
+++ b/frontend/src/lib/state/instance/permissions.svelte.ts
@@ -1,4 +1,6 @@
 import { createContext } from 'svelte';
+import { getActiveInstance } from '$lib/state/activeInstance.svelte';
+import { instanceRegistry } from './registry.svelte';
 
 /**
  * Viewer permissions data from the GraphQL `viewer` query.
@@ -17,19 +19,13 @@ export type ViewerData = {
 };
 
 /**
- * Instance-level permissions for the current user.
- * Set by the chat layout, consumed by child routes.
- *
- * Uses a reactive state object so the context can be set synchronously
- * during component initialization, then updated when the query completes.
+ * Instance-level permissions for the current user, plus a `loaded` flag.
+ * The underlying state lives on the per-instance `InstanceStateStore`
+ * (populated by `InstanceSpaceSection`'s viewer query).
  */
 export type InstancePermissions = ViewerData & {
   loaded: boolean;
 };
-
-const [getPermissionsState, setPermissionsState] = createContext<{
-  current: InstancePermissions;
-}>();
 
 const EMPTY_PERMISSIONS: InstancePermissions = {
   loaded: false,
@@ -45,36 +41,26 @@ const EMPTY_PERMISSIONS: InstancePermissions = {
 };
 
 /**
- * Creates and sets the instance permissions context.
- * Must be called synchronously during component initialization (chat layout).
- * Returns a function to update the permissions when the viewer query completes.
- */
-export function createInstancePermissions(): (viewer: ViewerData) => void {
-  const state = $state<{ current: InstancePermissions }>({
-    current: EMPTY_PERMISSIONS
-  });
-  setPermissionsState(state);
-
-  return (viewer: ViewerData) => {
-    state.current = {
-      ...viewer,
-      loaded: true
-    };
-  };
-}
-
-/**
- * Gets the reactive instance permissions state from context.
- * Returns the wrapper object so consumers can access `.current` reactively.
+ * Returns a reactive view of the active instance's viewer permissions.
  *
- * Usage in components:
+ * Reads always resolve against the *active* instance (per the URL), so
+ * navigating between instances reflects each instance's own permissions —
+ * no origin-only context. Must be called during component initialization so
+ * the underlying `getActiveInstance()` context lookup succeeds.
+ *
+ * Usage:
  * ```ts
  * const instancePerms = getInstancePermissions();
  * const canViewAdmin = $derived(instancePerms.current.canViewAdmin);
  * ```
  */
-export function getInstancePermissions(): { current: InstancePermissions } {
-  return getPermissionsState();
+export function getInstancePermissions(): { readonly current: InstancePermissions } {
+  const getActiveId = getActiveInstance();
+  return {
+    get current() {
+      return instanceRegistry.tryGetStore(getActiveId())?.permissions ?? EMPTY_PERMISSIONS;
+    }
+  };
 }
 
 /**

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -17,7 +17,6 @@
   import { useInstanceRegistry } from '$lib/state/instance/useInstanceRegistry.svelte';
   import { graphqlClientManager } from '$lib/state/instance/graphqlClient.svelte';
   import { instanceEventBusManager } from '$lib/state/instance/eventBus.svelte';
-  import { createInstancePermissions } from '$lib/state/instance/permissions.svelte';
   import { createPresenceCache } from '$lib/state/presenceCache.svelte';
   import { createUserProfileCache } from '$lib/state/userProfiles.svelte';
   import { UserSettingsState, setUserSettings } from '$lib/state/userSettings.svelte';
@@ -33,9 +32,6 @@
   useInstanceRegistry(() => data.user);
   useVisualViewport();
   usePinchZoomPrevention();
-
-  // Contexts
-  const updateInstancePermissions = createInstancePermissions();
 
   // Provide the active instance ID via context so every descendant can use
   // getActiveInstance(), including components rendered above [instanceId]
@@ -219,7 +215,7 @@
           ]}
           style:transform={sidebarNav.isMobile ? `translateX(${tx}px)` : undefined}
         >
-          <SpaceList onPermissionsLoaded={updateInstancePermissions} />
+          <SpaceList />
         </div>
 
         {@render children?.()}

--- a/frontend/src/routes/chat/[instanceId]/(chrome)/server-admin/+layout.svelte
+++ b/frontend/src/routes/chat/[instanceId]/(chrome)/server-admin/+layout.svelte
@@ -87,9 +87,15 @@
   }
 
   const hasPermission = $derived(getRoutePermissionCheck(page.url.pathname)());
+
+  const permissionsLoaded = $derived(
+    spacePermissions.current.loaded && instancePerms.current.loaded
+  );
 </script>
 
-{#if hasPermission}
+{#if !permissionsLoaded}
+  <!-- blank shell while permissions load; avoids an Access Denied flash -->
+{:else if hasPermission}
   {@render children?.()}
 {:else}
   <AccessDenied


### PR DESCRIPTION
## Summary

- `getInstancePermissions()` used to read from a context populated only for the origin instance, so remote-instance admin routes silently checked origin permissions and origin-bound load timing caused a brief "Access Denied" flash on cold navigation. It now resolves against the active instance's `InstanceStateStore.permissions` via the `getActiveInstance` context (the per-instance state already exists; only the consumer side was wrong).
- Drops the now-redundant `createInstancePermissions()` factory and the origin-only `onPermissionsLoaded` plumbing through `SpaceList` and `InstanceSpaceSection`.
- Server-admin layout gates `AccessDenied` on both `spacePermissions.current.loaded` and `instancePerms.current.loaded`, rendering a blank shell while permissions resolve instead of flashing denial.
- Adds `permissions.svelte.spec.ts` covering per-instance read, missing-store fallback, and active-vs-origin disambiguation.

## Test plan

- [x] `mise x -- pnpm check` (svelte-check) — clean
- [x] `mise test-frontend` — 705 / 705 pass (3 new)
- [ ] Manual: hard-reload `/chat/-/server-admin/roles` as admin — no Access Denied flash
- [ ] Manual: hard-reload same route as non-admin — Access Denied still renders after brief blank
- [ ] Manual on a remote-instance admin route (if a multi-instance setup is available) — checks the remote instance's permissions, not the origin's