### PR TITLE
refactor(cli): Phase 5 — sweep Go identifiers Instance* → Server*

### DIFF
--- a/cli/cmd/bootstrap_apply.go
+++ b/cli/cmd/bootstrap_apply.go
@@ -26,8 +26,8 @@ import (
 func applyBootstrap(ctx context.Context, c *core.ChattoCore, cfg config.BootstrapConfig) {
 	logger := log.WithPrefix("bootstrap")
 
-	hasInstance := cfg.Instance != nil
-	if len(cfg.Users) == 0 && !hasInstance {
+	hasServer := cfg.Server != nil
+	if len(cfg.Users) == 0 && !hasServer {
 		// Always log something so operators can confirm the bootstrap path ran.
 		// At debug level so a config without a [bootstrap] section doesn't add
 		// noise on every boot.
@@ -35,7 +35,7 @@ func applyBootstrap(ctx context.Context, c *core.ChattoCore, cfg config.Bootstra
 		return
 	}
 
-	logger.Info("Applying [bootstrap] section", "users", len(cfg.Users), "instance", hasInstance)
+	logger.Info("Applying [bootstrap] section", "users", len(cfg.Users), "instance", hasServer)
 
 	loginToUserID := map[string]string{}
 	ownerID := ""
@@ -50,7 +50,7 @@ func applyBootstrap(ctx context.Context, c *core.ChattoCore, cfg config.Bootstra
 		if firstUserID == "" {
 			firstUserID = userID
 		}
-		if ownerID == "" && u.InstanceRole == "owner" {
+		if ownerID == "" && u.ServerRole == "owner" {
 			ownerID = userID
 		}
 		if created {
@@ -65,12 +65,12 @@ func applyBootstrap(ctx context.Context, c *core.ChattoCore, cfg config.Bootstra
 		ownerID = firstUserID
 	}
 
-	instanceCreated := false
-	if hasInstance {
+	serverCreated := false
+	if hasServer {
 		if ownerID == "" {
 			logger.Error("[bootstrap] instance requires at least one user; skipping instance setup")
 		} else {
-			instanceCreated = applyBootstrapInstance(ctx, logger, c, *cfg.Instance, ownerID)
+			serverCreated = applyBootstrapServer(ctx, logger, c, *cfg.Server, ownerID)
 		}
 	}
 
@@ -86,7 +86,7 @@ func applyBootstrap(ctx context.Context, c *core.ChattoCore, cfg config.Bootstra
 	logger.Info("[bootstrap] apply complete",
 		"users_created", usersCreated,
 		"users_existing", usersExisting,
-		"instance_created", instanceCreated,
+		"instance_created", serverCreated,
 	)
 }
 
@@ -102,7 +102,7 @@ func applyBootstrapUser(ctx context.Context, logger *log.Logger, c *core.ChattoC
 	if existing, err := c.GetUserByLogin(ctx, u.Login); err == nil && existing != nil {
 		logger.Debug("[bootstrap] user already exists; skipping create", "login", u.Login)
 		// Still try to apply role + email below (idempotent).
-		assignBootstrapRole(ctx, logger, c, existing.Id, u.InstanceRole, u.Login)
+		assignBootstrapRole(ctx, logger, c, existing.Id, u.ServerRole, u.Login)
 		ensureBootstrapEmail(ctx, logger, c, existing.Id, u.Email, u.Login)
 		return existing.Id, false
 	}
@@ -119,7 +119,7 @@ func applyBootstrapUser(ctx context.Context, logger *log.Logger, c *core.ChattoC
 	}
 
 	ensureBootstrapEmail(ctx, logger, c, user.Id, u.Email, u.Login)
-	assignBootstrapRole(ctx, logger, c, user.Id, u.InstanceRole, u.Login)
+	assignBootstrapRole(ctx, logger, c, user.Id, u.ServerRole, u.Login)
 
 	return user.Id, true
 }
@@ -153,19 +153,19 @@ func assignBootstrapRole(ctx context.Context, logger *log.Logger, c *core.Chatto
 		return
 	}
 	// SystemActorID bypasses hierarchy checks — bootstrap operates as the system.
-	if err := c.AssignInstanceRole(ctx, core.SystemActorID, userID, roleName); err != nil {
+	if err := c.AssignServerRole(ctx, core.SystemActorID, userID, roleName); err != nil {
 		logger.Warn("Failed to assign instance role for [bootstrap] user", "login", login, "role", role, "error", err)
 	}
 }
 
-// applyBootstrapInstance seeds the instance's user-visible config (name)
+// applyBootstrapServer seeds the instance's user-visible config (name)
 // and ensures the deployment's primary room set exists. The underlying
 // primary-space record is a transitional storage detail (per ADR-027 the
 // data model still routes through a Space until PR(c) collapses the RBAC
 // engines) — operators don't configure or see it directly. Returns true if
 // a primary space was newly created, false otherwise (already-existing or
 // skipped).
-func applyBootstrapInstance(ctx context.Context, logger *log.Logger, c *core.ChattoCore, inst config.BootstrapInstance, ownerID string) bool {
+func applyBootstrapServer(ctx context.Context, logger *log.Logger, c *core.ChattoCore, inst config.BootstrapServer, ownerID string) bool {
 	if inst.Name == "" {
 		logger.Error("Skipping [bootstrap.instance] with empty name")
 		return false

--- a/cli/cmd/bootstrap_test.go
+++ b/cli/cmd/bootstrap_test.go
@@ -65,7 +65,7 @@ func TestApplyBootstrap_CreatesUsersAndInstance(t *testing.T) {
 				DisplayName:  "Alice",
 				Email:        "alice@example.com",
 				Password:     "devpassword",
-				InstanceRole: "owner",
+				ServerRole: "owner",
 			},
 			{
 				Login:    "bob",
@@ -73,10 +73,9 @@ func TestApplyBootstrap_CreatesUsersAndInstance(t *testing.T) {
 				Password: "devpassword",
 			},
 		},
-		Instance: &config.BootstrapInstance{
-			Name:        "Engineering",
-			Description: "Where things happen",
-			Rooms:       []string{"random", "qa"},
+		Server: &config.BootstrapServer{
+			Name:  "Engineering",
+			Rooms: []string{"random", "qa"},
 		},
 	}
 	applyBootstrap(ctx, c, cfg)
@@ -107,7 +106,7 @@ func TestApplyBootstrap_CreatesUsersAndInstance(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get instance config: %v", err)
 	}
-	if cfgInstance == nil || cfgInstance.InstanceName != "Engineering" {
+	if cfgInstance == nil || cfgInstance.ServerName != "Engineering" {
 		t.Errorf("expected instance name 'Engineering', got %+v", cfgInstance)
 	}
 
@@ -137,9 +136,9 @@ func TestApplyBootstrap_IsIdempotent(t *testing.T) {
 
 	cfg := config.BootstrapConfig{
 		Users: []config.BootstrapUser{
-			{Login: "alice", Email: "alice@example.com", Password: "devpassword", InstanceRole: "owner"},
+			{Login: "alice", Email: "alice@example.com", Password: "devpassword", ServerRole: "owner"},
 		},
-		Instance: &config.BootstrapInstance{Name: "OnlyOne"},
+		Server: &config.BootstrapServer{Name: "OnlyOne"},
 	}
 
 	applyBootstrap(ctx, c, cfg)
@@ -180,11 +179,11 @@ func TestApplyBootstrap_AutoJoinsServer(t *testing.T) {
 
 	cfg := config.BootstrapConfig{
 		Users: []config.BootstrapUser{
-			{Login: "devuser", Email: "dev@example.com", Password: "devpassword", InstanceRole: "owner"},
+			{Login: "devuser", Email: "dev@example.com", Password: "devpassword", ServerRole: "owner"},
 			{Login: "alice", Email: "alice@example.com", Password: "devpassword"},
 			{Login: "bob", Email: "bob@example.com", Password: "devpassword"},
 		},
-		Instance: &config.BootstrapInstance{Name: "Engineering"},
+		Server: &config.BootstrapServer{Name: "Engineering"},
 	}
 	applyBootstrap(ctx, c, cfg)
 
@@ -193,17 +192,29 @@ func TestApplyBootstrap_AutoJoinsServer(t *testing.T) {
 		t.Fatalf("expected a primary space to exist: id=%q err=%v", primaryID, err)
 	}
 
+	// Server "membership" itself is implicit post-#330 — every authenticated
+	// user counts as a member. Bootstrap's contribution is auto-joining the
+	// user to the default rooms.
+	rooms, err := c.ListRoomsBySpace(ctx, primaryID)
+	if err != nil {
+		t.Fatalf("ListRoomsBySpace: %v", err)
+	}
+	if len(rooms) == 0 {
+		t.Fatal("expected default rooms to exist after bootstrap")
+	}
+	defaultRoom := rooms[0]
+
 	for _, login := range []string{"alice", "bob"} {
 		u, err := c.GetUserByLogin(ctx, login)
 		if err != nil || u == nil {
 			t.Fatalf("expected %s to exist: %v", login, err)
 		}
-		isMember, err := c.SpaceMembershipExists(ctx, u.Id, primaryID)
+		isMember, err := c.RoomMembershipExists(ctx, primaryID, u.Id, defaultRoom.Id)
 		if err != nil {
-			t.Fatalf("SpaceMembershipExists(%s): %v", login, err)
+			t.Fatalf("RoomMembershipExists(%s): %v", login, err)
 		}
 		if !isMember {
-			t.Errorf("expected %s to be auto-joined to the server", login)
+			t.Errorf("expected %s to be auto-joined to default room %s", login, defaultRoom.Id)
 		}
 	}
 }
@@ -219,7 +230,7 @@ func TestApplyBootstrap_DerivesOwnerFromFirstUser(t *testing.T) {
 			{Login: "first", Email: "first@example.com", Password: "devpassword"},
 			{Login: "second", Email: "second@example.com", Password: "devpassword"},
 		},
-		Instance: &config.BootstrapInstance{Name: "Fallback"},
+		Server: &config.BootstrapServer{Name: "Fallback"},
 	}
 	applyBootstrap(ctx, c, cfg)
 

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -393,7 +393,7 @@ type LiveKitConfig struct {
 	APIKey           string `toml:"api_key" env:"CHATTO_LIVEKIT_API_KEY" comment:"LiveKit API key."`
 	APISecret        string `toml:"api_secret" env:"CHATTO_LIVEKIT_API_SECRET" comment:"LiveKit API secret. NEVER SHARE THIS!"`
 	WebhookURL       string `toml:"webhook_url" env:"CHATTO_LIVEKIT_WEBHOOK_URL" comment:"URL where LiveKit sends webhook events. Defaults to {webserver.url}/webhooks/livekit."`
-	InstanceID       string `toml:"instance_id,commented" env:"CHATTO_LIVEKIT_INSTANCE_ID" comment:"Unique identifier for this instance, prefixed to LiveKit room names. Required when multiple Chatto instances share the same LiveKit cluster."`
+	ServerID       string `toml:"instance_id,commented" env:"CHATTO_LIVEKIT_INSTANCE_ID" comment:"Unique identifier for this instance, prefixed to LiveKit room names. Required when multiple Chatto instances share the same LiveKit cluster."`
 	WebhookAPIKey    string `toml:"webhook_api_key,commented" env:"CHATTO_LIVEKIT_WEBHOOK_API_KEY" comment:"API key LiveKit uses to sign webhooks. Falls back to api_key if not set. Required when the webhook signing key differs from the per-instance API key."`
 	WebhookAPISecret string `toml:"webhook_api_secret,commented" env:"CHATTO_LIVEKIT_WEBHOOK_API_SECRET" comment:"API secret for webhook signature validation. Falls back to api_secret if not set."`
 }
@@ -421,7 +421,7 @@ func (c *LiveKitConfig) IsConfigured() bool {
 // are fine here for the same reason.
 type BootstrapConfig struct {
 	Users    []BootstrapUser    `toml:"users"`
-	Instance *BootstrapInstance `toml:"instance,commented" comment:"Seeds the instance config (name, description) and the deployment's primary room set on first boot."`
+	Server *BootstrapServer `toml:"instance,commented" comment:"Seeds the server config (name) and the deployment's primary room set on first boot."`
 }
 
 // BootstrapUser describes a user to create on startup in bootstrap-tag builds.
@@ -430,15 +430,15 @@ type BootstrapUser struct {
 	DisplayName  string `toml:"display_name,commented" comment:"Defaults to Login if empty."`
 	Email        string `toml:"email,commented" comment:"Optional. If set, added as a verified email."`
 	Password     string `toml:"password,commented" comment:"Optional. Required to log in via password; safe in plaintext because bootstrap-tag builds only."`
-	InstanceRole string `toml:"instance_role,commented" comment:"Optional: owner | admin | moderator."`
+	ServerRole string `toml:"instance_role,commented" comment:"Optional: owner | admin | moderator."`
 }
 
-// BootstrapInstance describes the instance to seed on startup in bootstrap-tag
+// BootstrapServer describes the instance to seed on startup in bootstrap-tag
 // builds. Per ADR-027 there is no separate "space" concept any more — the
 // instance is the server. The bootstrap creates whatever underlying storage
 // records (notably a primary space) the data layer still needs, but those
 // are internal: operators only configure the instance's name.
-type BootstrapInstance struct {
+type BootstrapServer struct {
 	Name  string   `toml:"name" comment:"Required. The instance's display name."`
 	Rooms []string `toml:"rooms,commented" comment:"Optional. Auto-join rooms created on the instance; defaults to announcements + general."`
 }

--- a/cli/internal/core/attachments.go
+++ b/cli/internal/core/attachments.go
@@ -365,12 +365,12 @@ func (c *ChattoCore) GetTransformedAttachmentURLFromStorage(attachment *corev1.A
 	return c.GetTransformedAttachmentURL(attachment.SpaceId, attachment.Id, width, height, fit)
 }
 
-// GetTransformedInstanceAssetURL returns the URL for accessing a transformed version of an instance asset.
+// GetTransformedServerAssetURL returns the URL for accessing a transformed version of an instance asset.
 // Instance assets include space logos, space banners, and user avatars stored in the instance object store.
 // The URL includes HMAC signature to prevent parameter tampering.
 // Format: /assets/instance/{key}/t/{params}.{signature}
 // where {params} is base64url-encoded JSON: {"w":width,"h":height,"f":"fit"}
-func (c *ChattoCore) GetTransformedInstanceAssetURL(key string, width, height int, fit string) string {
+func (c *ChattoCore) GetTransformedServerAssetURL(key string, width, height int, fit string) string {
 	// Generate signed transform path component using "instance" as the first resource ID
 	signedPath := signedurl.SignedTransformPath(c.config.Assets.SigningSecret, "instance", key, width, height, fit)
 

--- a/cli/internal/core/attachments_test.go
+++ b/cli/internal/core/attachments_test.go
@@ -437,11 +437,11 @@ func TestChattoCore_AssetBaseURL(t *testing.T) {
 		}
 	})
 
-	t.Run("GetTransformedInstanceAssetURL returns absolute when AssetBaseURL is set", func(t *testing.T) {
+	t.Run("GetTransformedServerAssetURL returns absolute when AssetBaseURL is set", func(t *testing.T) {
 		core.AssetBaseURL = "https://chat.example.com"
 		defer func() { core.AssetBaseURL = "" }()
 
-		url := core.GetTransformedInstanceAssetURL("avatar-key", 100, 100, "cover")
+		url := core.GetTransformedServerAssetURL("avatar-key", 100, 100, "cover")
 
 		if !bytes.HasPrefix([]byte(url), []byte("https://chat.example.com/assets/instance/")) {
 			t.Errorf("Expected absolute URL with base, got '%s'", url)

--- a/cli/internal/core/can_test.go
+++ b/cli/internal/core/can_test.go
@@ -236,7 +236,7 @@ func TestCanDeleteUser(t *testing.T) {
 
 	t.Run("self-deletion denied when user.delete.self permission is revoked", func(t *testing.T) {
 		// Create a custom role that denies self-deletion
-		if _, err := core.CreateInstanceRole(ctx, "noselfdelete", "No Self Delete", ""); err != nil {
+		if _, err := core.CreateServerRole(ctx, "noselfdelete", "No Self Delete", ""); err != nil {
 			t.Fatalf("failed to create role: %v", err)
 		}
 		if err := core.DenyInstancePermission(ctx, "noselfdelete", PermUserDeleteSelf); err != nil {
@@ -248,7 +248,7 @@ func TestCanDeleteUser(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to create user: %v", err)
 		}
-		if err := core.AssignInstanceRole(ctx, SystemActorID, blockedUser.Id, "noselfdelete"); err != nil {
+		if err := core.AssignServerRole(ctx, SystemActorID, blockedUser.Id, "noselfdelete"); err != nil {
 			t.Fatalf("failed to assign role: %v", err)
 		}
 
@@ -280,7 +280,7 @@ func TestPermissionsWithCustomRoles(t *testing.T) {
 	ctx := testContext(t)
 
 	// Create a custom role with limited admin permissions
-	customRole, err := core.CreateInstanceRole(ctx, "viewer", "Viewer Admin", "Can only view admin pages")
+	customRole, err := core.CreateServerRole(ctx, "viewer", "Viewer Admin", "Can only view admin pages")
 	if err != nil {
 		t.Fatalf("failed to create custom role: %v", err)
 	}
@@ -300,7 +300,7 @@ func TestPermissionsWithCustomRoles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create user: %v", err)
 	}
-	if err := core.AssignInstanceRole(ctx, SystemActorID, customUser.Id, customRole.Name); err != nil {
+	if err := core.AssignServerRole(ctx, SystemActorID, customUser.Id, customRole.Name); err != nil {
 		t.Fatalf("failed to assign role: %v", err)
 	}
 

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -86,8 +86,8 @@ type encryptionManager struct {
 	keyManager *encryption.KeyManager
 }
 
-func (c *ChattoCore) InstanceStore() jetstream.ObjectStore {
-	return c.storage.instanceStore
+func (c *ChattoCore) ServerStore() jetstream.ObjectStore {
+	return c.storage.serverStore
 }
 
 // KeyManager returns the encryption key manager.
@@ -174,22 +174,22 @@ func (c *ChattoCore) S3Client() *S3Client {
 	return c.s3Client
 }
 
-// InstanceAssetInfo contains metadata about an instance asset.
-type InstanceAssetInfo struct {
+// ServerAssetInfo contains metadata about an instance asset.
+type ServerAssetInfo struct {
 	Size        int64
 	ContentType string
 }
 
-// GetInstanceAssetFromAnyBackend retrieves an instance asset by probing both NATS and S3 backends.
+// GetServerAssetFromAnyBackend retrieves an instance asset by probing both NATS and S3 backends.
 // It tries NATS first (for backwards compatibility with existing assets), then S3.
 // Returns a reader for the asset content and metadata.
 // The caller is responsible for closing the reader if it implements io.Closer.
-func (c *ChattoCore) GetInstanceAssetFromAnyBackend(ctx context.Context, assetID string) (io.Reader, *InstanceAssetInfo, error) {
+func (c *ChattoCore) GetServerAssetFromAnyBackend(ctx context.Context, assetID string) (io.Reader, *ServerAssetInfo, error) {
 	// Try NATS first (backwards compatibility)
-	obj, err := c.storage.instanceStore.Get(ctx, assetID)
+	obj, err := c.storage.serverStore.Get(ctx, assetID)
 	if err == nil {
 		info, _ := obj.Info()
-		return obj, &InstanceAssetInfo{
+		return obj, &ServerAssetInfo{
 			Size:        int64(info.Size),
 			ContentType: info.Headers.Get("Content-Type"),
 		}, nil
@@ -197,10 +197,10 @@ func (c *ChattoCore) GetInstanceAssetFromAnyBackend(ctx context.Context, assetID
 
 	// If NATS failed and S3 is configured, try S3
 	if c.s3Client != nil {
-		s3Key := S3KeyInstanceAsset(assetID)
+		s3Key := S3KeyServerAsset(assetID)
 		reader, s3Info, s3Err := c.s3Client.GetObject(ctx, s3Key)
 		if s3Err == nil {
-			return reader, &InstanceAssetInfo{
+			return reader, &ServerAssetInfo{
 				Size:        s3Info.Size,
 				ContentType: s3Info.ContentType,
 			}, nil
@@ -222,7 +222,7 @@ func (c *ChattoCore) CleanupAsset(ctx context.Context, asset *corev1.Asset) {
 		return
 	}
 	if natsAsset := asset.GetNats(); natsAsset != nil {
-		if err := c.storage.instanceStore.Delete(ctx, natsAsset.Key); err != nil {
+		if err := c.storage.serverStore.Delete(ctx, natsAsset.Key); err != nil {
 			c.logger.Warn("Failed to clean up orphaned asset", "key", natsAsset.Key, "error", err)
 		} else {
 			c.logger.Info("Cleaned up orphaned asset", "key", natsAsset.Key)
@@ -230,7 +230,7 @@ func (c *ChattoCore) CleanupAsset(ctx context.Context, asset *corev1.Asset) {
 	}
 	if s3Asset := asset.GetS3(); s3Asset != nil && c.s3Client != nil {
 		// S3Asset.Key stores just the assetID; construct the full S3 path
-		s3Key := S3KeyInstanceAsset(s3Asset.Key)
+		s3Key := S3KeyServerAsset(s3Asset.Key)
 		if err := c.s3Client.DeleteObjectFromBucket(ctx, s3Asset.GetBucket(), s3Key); err != nil {
 			c.logger.Warn("Failed to clean up orphaned S3 asset", "asset_id", s3Asset.Key, "s3_key", s3Key, "error", err)
 		} else {
@@ -248,7 +248,7 @@ func (c *ChattoCore) deleteAsset(ctx context.Context, asset *corev1.Asset, asset
 		return
 	}
 	if natsAsset := asset.GetNats(); natsAsset != nil {
-		if err := c.storage.instanceStore.Delete(ctx, natsAsset.Key); err != nil {
+		if err := c.storage.serverStore.Delete(ctx, natsAsset.Key); err != nil {
 			c.logger.Warn("Failed to delete old "+assetType, "owner_id", ownerID, "key", natsAsset.Key, "error", err)
 		} else {
 			c.logger.Info("Deleted old "+assetType, "owner_id", ownerID, "key", natsAsset.Key)
@@ -256,7 +256,7 @@ func (c *ChattoCore) deleteAsset(ctx context.Context, asset *corev1.Asset, asset
 	}
 	if s3Asset := asset.GetS3(); s3Asset != nil && c.s3Client != nil {
 		// S3Asset.Key stores just the assetID; construct the full S3 path
-		s3Key := S3KeyInstanceAsset(s3Asset.Key)
+		s3Key := S3KeyServerAsset(s3Asset.Key)
 		if err := c.s3Client.DeleteObjectFromBucket(ctx, s3Asset.GetBucket(), s3Key); err != nil {
 			c.logger.Warn("Failed to delete old S3 "+assetType, "owner_id", ownerID, "asset_id", s3Asset.Key, "s3_key", s3Key, "error", err)
 		} else {
@@ -270,7 +270,7 @@ func (c *ChattoCore) deleteAsset(ctx context.Context, asset *corev1.Asset, asset
 // Used by the /readyz endpoint to verify the server can handle requests.
 func (c *ChattoCore) Ready(ctx context.Context) error {
 	// Check if JetStream is operational by getting the INSTANCE KV bucket status
-	_, err := c.storage.instanceKV.Status(ctx)
+	_, err := c.storage.serverKV.Status(ctx)
 	if err != nil {
 		return fmt.Errorf("JetStream not ready: %w", err)
 	}
@@ -317,7 +317,7 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	})
 
 	// Initialize config manager for runtime configuration
-	configMgr := NewConfigManager(storage.instanceConfigKV)
+	configMgr := NewConfigManager(storage.runtimeConfigKV)
 
 	// Initialize S3 client if S3 storage is configured
 	var s3Client *S3Client
@@ -357,7 +357,7 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	}
 	core.linkPreviewCache = linkPreviewCache
 	assetsConfig := core.AssetsConfig()
-	core.linkPreviewFetcher = linkpreview.NewFetcher(storage.instanceStore, &assetsConfig, NewAssetID)
+	core.linkPreviewFetcher = linkpreview.NewFetcher(storage.serverStore, &assetsConfig, NewAssetID)
 
 	// Initialize DM system space
 	if err := core.initDMSpace(ctx); err != nil {
@@ -391,10 +391,10 @@ func (c *ChattoCore) Subscribe(ctx context.Context, subject string, handler nats
 
 // storage encapsulates all JetStream KV buckets and streams used by Chatto Core.
 type storage struct {
-	instanceKV       jetstream.KeyValue
-	instanceStore    jetstream.ObjectStore
+	serverKV       jetstream.KeyValue
+	serverStore    jetstream.ObjectStore
 	encryptionKV     jetstream.KeyValue // Encryption keys (excluded from backups)
-	instanceConfigKV jetstream.KeyValue // Runtime configuration overrides
+	runtimeConfigKV  jetstream.KeyValue // INSTANCE_CONFIG - runtime configuration overrides
 
 	// Server-level KV buckets (#330 phase 4a, 4b, 4c, 4e) and event stream
 	// (#330 phase 4d). Shared by the primary and DM spaces; non-primary,
@@ -421,7 +421,7 @@ type storage struct {
 func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConfig) (*storage, error) {
 	// Initialize INSTANCE KV bucket for all instance-level data
 	// Uses subject-based keys: user.{userId}, space.{spaceId}, space_membership.{spaceId}.{userId}, etc.
-	instanceKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+	serverKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
 		Bucket:      "INSTANCE",
 		Description: "Instance-level data (users, spaces, memberships)",
 		Storage:     jetstream.FileStorage,
@@ -437,7 +437,7 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 	}
 
 	// Initialize instance object store
-	instanceStore, err := js.CreateOrUpdateObjectStore(ctx, jetstream.ObjectStoreConfig{
+	serverStore, err := js.CreateOrUpdateObjectStore(ctx, jetstream.ObjectStoreConfig{
 		Bucket:      "INSTANCE_ASSETS",
 		Description: "Instance-level assets (user avatars, space icons, etc.)",
 		Storage:     jetstream.FileStorage,
@@ -475,7 +475,7 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 	}
 
 	// Initialize runtime configuration KV bucket
-	instanceConfigKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+	runtimeConfigKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
 		Bucket:      "INSTANCE_CONFIG",
 		Description: "Runtime configuration overrides",
 		Storage:     jetstream.FileStorage,
@@ -641,10 +641,10 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 
 	// Return initialized storage and whether RBAC bucket was newly created
 	return &storage{
-		instanceKV:       instanceKV,
-		instanceStore:    instanceStore,
+		serverKV:       serverKV,
+		serverStore:    serverStore,
 		encryptionKV:     encryptionKV,
-		instanceConfigKV: instanceConfigKV,
+		runtimeConfigKV:    runtimeConfigKV,
 		serverConfigKV:     serverConfigKV,
 		serverRBACKV:       serverRBACKV,
 		serverRuntimeKV:    serverRuntimeKV,
@@ -1592,13 +1592,13 @@ func (c *ChattoCore) StreamMyServerConfigEvents(ctx context.Context, userID stri
 	return eventChan, nil
 }
 
-// PublishInstanceConfigUpdated publishes an instance config update event.
+// PublishServerConfigUpdated publishes an instance config update event.
 // This notifies all connected clients that the instance configuration has changed.
-func (c *ChattoCore) PublishInstanceConfigUpdated(ctx context.Context, actorID string, instanceName, motd, welcomeMessage, blockedUsernames string) error {
+func (c *ChattoCore) PublishServerConfigUpdated(ctx context.Context, actorID string, serverName, motd, welcomeMessage, blockedUsernames string) error {
 	event := newLiveEvent(actorID, &corev1.LiveEvent{
 		Event: &corev1.LiveEvent_ConfigUpdated{
 			ConfigUpdated: &corev1.ServerConfigUpdatedEvent{
-				ServerName:       instanceName,
+				ServerName:       serverName,
 				Motd:             motd,
 				WelcomeMessage:   welcomeMessage,
 				BlockedUsernames: blockedUsernames,
@@ -1613,8 +1613,8 @@ func (c *ChattoCore) PublishInstanceConfigUpdated(ctx context.Context, actorID s
 // Statistics
 // ============================================================================
 
-// InstanceStats contains aggregate statistics about the Chatto instance.
-type InstanceStats struct {
+// ServerStats contains aggregate statistics about the Chatto instance.
+type ServerStats struct {
 	UserCount    int
 	SpaceCount   int
 	RoomCount    int
@@ -1623,11 +1623,11 @@ type InstanceStats struct {
 
 // GetStats returns aggregate statistics for the Chatto instance.
 // This includes counts of users, spaces, rooms, and total room events across all spaces.
-func (c *ChattoCore) GetStats(ctx context.Context) (*InstanceStats, error) {
-	stats := &InstanceStats{}
+func (c *ChattoCore) GetStats(ctx context.Context) (*ServerStats, error) {
+	stats := &ServerStats{}
 
 	// Count users
-	userKeys, err := c.storage.instanceKV.ListKeysFiltered(ctx, "user.*")
+	userKeys, err := c.storage.serverKV.ListKeysFiltered(ctx, "user.*")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list user keys: %w", err)
 	}

--- a/cli/internal/core/errors.go
+++ b/cli/internal/core/errors.go
@@ -110,9 +110,9 @@ var (
 	// resource limit configured via [limits] (e.g. max_users).
 	ErrLimitExceeded = errors.New("instance limit reached")
 
-	// ErrInstanceNotBootstrapped is returned by API-layer helpers that need
+	// ErrServerNotBootstrapped is returned by API-layer helpers that need
 	// the deployment's primary space ID before its bootstrap has run.
-	ErrInstanceNotBootstrapped = errors.New("instance not bootstrapped")
+	ErrServerNotBootstrapped = errors.New("instance not bootstrapped")
 
 	// ErrPasswordTooShort is returned when a password is shorter than MinPasswordLength.
 	ErrPasswordTooShort = fmt.Errorf("password must be at least %d characters long", MinPasswordLength)

--- a/cli/internal/core/health.go
+++ b/cli/internal/core/health.go
@@ -61,7 +61,7 @@ func (c *ChattoCore) SpaceRBACHealthCheck(ctx context.Context) (*SpaceRBACHealth
 
 // listAllSpaceIDs returns all space IDs from the INSTANCE bucket.
 func (c *ChattoCore) listAllSpaceIDs(ctx context.Context) ([]string, error) {
-	keyLister, err := c.storage.instanceKV.ListKeysFiltered(ctx, "space.*")
+	keyLister, err := c.storage.serverKV.ListKeysFiltered(ctx, "space.*")
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/core/health_test.go
+++ b/cli/internal/core/health_test.go
@@ -55,7 +55,7 @@ func TestSpaceRBACHealthCheck(t *testing.T) {
 		}
 
 		// Verify owner role exists via public API
-		_, err = core.GetInstanceRole(ctx, RoleOwner)
+		_, err = core.GetServerRole(ctx, RoleOwner)
 		if err != nil {
 			t.Errorf("expected owner role to exist, got error: %v", err)
 		}
@@ -159,7 +159,7 @@ func TestSpaceRBACHealthCheck_InitializesUninitializedSpace(t *testing.T) {
 	}
 
 	// Verify owner role is gone
-	_, err = core.GetInstanceRole(ctx, RoleOwner)
+	_, err = core.GetServerRole(ctx, RoleOwner)
 	if err == nil {
 		t.Fatal("expected owner role to not exist after deletion")
 	}
@@ -181,7 +181,7 @@ func TestSpaceRBACHealthCheck_InitializesUninitializedSpace(t *testing.T) {
 	}
 
 	// Verify owner role now exists
-	_, err = core.GetInstanceRole(ctx, RoleOwner)
+	_, err = core.GetServerRole(ctx, RoleOwner)
 	if err != nil {
 		t.Errorf("expected owner role to exist after health check, got error: %v", err)
 	}

--- a/cli/internal/core/linkpreview_test.go
+++ b/cli/internal/core/linkpreview_test.go
@@ -28,8 +28,8 @@ func TestLinkPreviewImageStorageAndRetrieval(t *testing.T) {
 	require.NotEmpty(t, preview.GetImageAssetId(), "ImageAssetId should not be empty")
 
 	// Now try to retrieve the stored image
-	reader, info, err := core.GetInstanceAssetFromAnyBackend(ctx, preview.GetImageAssetId())
-	require.NoError(t, err, "GetInstanceAssetFromAnyBackend should succeed")
+	reader, info, err := core.GetServerAssetFromAnyBackend(ctx, preview.GetImageAssetId())
+	require.NoError(t, err, "GetServerAssetFromAnyBackend should succeed")
 	require.NotNil(t, reader, "Reader should not be nil")
 	
 	t.Logf("Content-Type: %s", info.ContentType)

--- a/cli/internal/core/oidc.go
+++ b/cli/internal/core/oidc.go
@@ -27,7 +27,7 @@ func userByOIDCSubjectKey(issuer, subject string) string {
 func (c *ChattoCore) GetUserByOIDCSubject(ctx context.Context, issuer, subject string) (*corev1.User, error) {
 	key := userByOIDCSubjectKey(issuer, subject)
 
-	entry, err := c.storage.instanceKV.Get(ctx, key)
+	entry, err := c.storage.serverKV.Get(ctx, key)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return nil, nil
@@ -44,10 +44,10 @@ func (c *ChattoCore) GetUserByOIDCSubject(ctx context.Context, issuer, subject s
 func (c *ChattoCore) LinkOIDCSubject(ctx context.Context, issuer, subject, userID string) error {
 	key := userByOIDCSubjectKey(issuer, subject)
 
-	_, err := c.storage.instanceKV.Create(ctx, key, []byte(userID))
+	_, err := c.storage.serverKV.Create(ctx, key, []byte(userID))
 	if err != nil {
 		// Already claimed — check if it's by the same user (idempotent)
-		entry, getErr := c.storage.instanceKV.Get(ctx, key)
+		entry, getErr := c.storage.serverKV.Get(ctx, key)
 		if getErr == nil && string(entry.Value()) == userID {
 			return nil // Already linked to this user
 		}

--- a/cli/internal/core/password_reset.go
+++ b/cli/internal/core/password_reset.go
@@ -85,7 +85,7 @@ func (c *ChattoCore) CreatePasswordResetToken(ctx context.Context, email string)
 		return "", fmt.Errorf("failed to marshal token: %w", err)
 	}
 
-	_, err = c.storage.instanceKV.Put(ctx, passwordResetTokenKey(token), data)
+	_, err = c.storage.serverKV.Put(ctx, passwordResetTokenKey(token), data)
 	if err != nil {
 		return "", fmt.Errorf("failed to store password reset token: %w", err)
 	}
@@ -96,7 +96,7 @@ func (c *ChattoCore) CreatePasswordResetToken(ctx context.Context, email string)
 // getPasswordResetToken retrieves and validates a password reset token.
 // Returns the token data including userID and email.
 func (c *ChattoCore) getPasswordResetToken(ctx context.Context, token string) (*PasswordResetToken, error) {
-	entry, err := c.storage.instanceKV.Get(ctx, passwordResetTokenKey(token))
+	entry, err := c.storage.serverKV.Get(ctx, passwordResetTokenKey(token))
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return nil, ErrPasswordResetTokenNotFound
@@ -112,7 +112,7 @@ func (c *ChattoCore) getPasswordResetToken(ctx context.Context, token string) (*
 	// Check if token has expired
 	if time.Since(tokenData.CreatedAt) > PasswordResetTokenTTL {
 		// Clean up expired token
-		c.storage.instanceKV.Delete(ctx, passwordResetTokenKey(token))
+		c.storage.serverKV.Delete(ctx, passwordResetTokenKey(token))
 		return nil, ErrPasswordResetTokenExpired
 	}
 
@@ -121,7 +121,7 @@ func (c *ChattoCore) getPasswordResetToken(ctx context.Context, token string) (*
 
 // deletePasswordResetToken removes a password reset token.
 func (c *ChattoCore) deletePasswordResetToken(ctx context.Context, token string) error {
-	err := c.storage.instanceKV.Delete(ctx, passwordResetTokenKey(token))
+	err := c.storage.serverKV.Delete(ctx, passwordResetTokenKey(token))
 	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
 		return fmt.Errorf("failed to delete password reset token: %w", err)
 	}
@@ -153,7 +153,7 @@ func (c *ChattoCore) ResetPassword(ctx context.Context, token string, newPasswor
 
 	// Update the password
 	passwordKey := fmt.Sprintf("auth.%s.password", tokenData.UserID)
-	_, err = c.storage.instanceKV.Put(ctx, passwordKey, []byte(newPasswordHash))
+	_, err = c.storage.serverKV.Put(ctx, passwordKey, []byte(newPasswordHash))
 	if err != nil {
 		return fmt.Errorf("failed to update password: %w", err)
 	}

--- a/cli/internal/core/permission_explainer_test.go
+++ b/cli/internal/core/permission_explainer_test.go
@@ -23,17 +23,17 @@ func TestPermissionExplainer_AgreesWithHas(t *testing.T) {
 	//   denyUser: custom instance role denying space.list
 	regular, _ := core.CreateUser(ctx, SystemActorID, "regular", "Regular", "password123")
 	adminUser, _ := core.CreateUser(ctx, SystemActorID, "adminuser", "Admin User", "password123")
-	if err := core.AssignInstanceRole(ctx, SystemActorID, adminUser.Id, RoleAdmin); err != nil {
+	if err := core.AssignServerRole(ctx, SystemActorID, adminUser.Id, RoleAdmin); err != nil {
 		t.Fatalf("assign admin role: %v", err)
 	}
 	denyUser, _ := core.CreateUser(ctx, SystemActorID, "denyuser", "Deny User", "password123")
-	if _, err := core.CreateInstanceRole(ctx, "denytest", "Deny dm.view", "Test deny role"); err != nil {
+	if _, err := core.CreateServerRole(ctx, "denytest", "Deny dm.view", "Test deny role"); err != nil {
 		t.Fatalf("create deny role: %v", err)
 	}
 	if err := core.DenyInstancePermission(ctx, "denytest", PermDMView); err != nil {
 		t.Fatalf("deny perm: %v", err)
 	}
-	if err := core.AssignInstanceRole(ctx, SystemActorID, denyUser.Id, "denytest"); err != nil {
+	if err := core.AssignServerRole(ctx, SystemActorID, denyUser.Id, "denytest"); err != nil {
 		t.Fatalf("assign deny role: %v", err)
 	}
 

--- a/cli/internal/core/permission_resolver.go
+++ b/cli/internal/core/permission_resolver.go
@@ -171,7 +171,7 @@ func (r *PermissionResolver) walkInstancePermission(
 		return nil
 	}
 
-	rolesWithPos, err := r.getUserInstanceRolesWithPositions(ctx, userID)
+	rolesWithPos, err := r.getUserServerRolesWithPositions(ctx, userID)
 	if err != nil {
 		return err
 	}
@@ -217,7 +217,7 @@ func (r *PermissionResolver) walkSpacePermission(
 		return nil
 	}
 
-	instanceRoles, err := r.getUserInstanceRoles(ctx, userID)
+	serverRoles, err := r.getUserServerRoles(ctx, userID)
 	if err != nil {
 		return err
 	}
@@ -225,14 +225,14 @@ func (r *PermissionResolver) walkSpacePermission(
 	if err != nil {
 		return err
 	}
-	instanceOnlyRoles := filterOutSpaceRoles(instanceRoles, spaceRoles)
+	serverOnlyRoles := excludeRoles(serverRoles, spaceRoles)
 
-	instanceKV := r.core.storage.serverRBACEngine.KV()
+	serverKV := r.core.storage.serverRBACEngine.KV()
 	spaceKV := r.core.storage.serverRBACKV
 
 	// Phase 1: denials across all levels.
-	for _, role := range instanceRoles {
-		denied, err := r.keyExists(ctx, instanceKV, rbac.DenyKey(role, parts.Verb, parts.ObjectType, rbac.ObjectIdAny))
+	for _, role := range serverRoles {
+		denied, err := r.keyExists(ctx, serverKV, rbac.DenyKey(role, parts.Verb, parts.ObjectType, rbac.ObjectIdAny))
 		if err != nil {
 			return err
 		}
@@ -255,7 +255,7 @@ func (r *PermissionResolver) walkSpacePermission(
 			}
 		}
 	}
-	for _, role := range instanceOnlyRoles {
+	for _, role := range serverOnlyRoles {
 		denied, err := r.keyExists(ctx, spaceKV, rbac.DenyKey(role, parts.Verb, parts.ObjectType, rbac.ObjectIdAny))
 		if err != nil {
 			return err
@@ -270,8 +270,8 @@ func (r *PermissionResolver) walkSpacePermission(
 
 	// Phase 2: grants in authority order (instance → space).
 	if PermissionAppliesAtScope(perm, ScopeServer) {
-		for _, role := range instanceRoles {
-			granted, err := r.keyExists(ctx, instanceKV, rbac.AllowKey(role, parts.Verb, parts.ObjectType, rbac.ObjectIdAny))
+		for _, role := range serverRoles {
+			granted, err := r.keyExists(ctx, serverKV, rbac.AllowKey(role, parts.Verb, parts.ObjectType, rbac.ObjectIdAny))
 			if err != nil {
 				return err
 			}
@@ -293,7 +293,7 @@ func (r *PermissionResolver) walkSpacePermission(
 			}
 		}
 	}
-	for _, role := range instanceOnlyRoles {
+	for _, role := range serverOnlyRoles {
 		granted, err := r.keyExists(ctx, spaceKV, rbac.AllowKey(role, parts.Verb, parts.ObjectType, rbac.ObjectIdAny))
 		if err != nil {
 			return err
@@ -320,7 +320,7 @@ func (r *PermissionResolver) walkRoomPermission(
 		return nil
 	}
 
-	instanceRoles, err := r.getUserInstanceRoles(ctx, userID)
+	serverRoles, err := r.getUserServerRoles(ctx, userID)
 	if err != nil {
 		return err
 	}
@@ -328,14 +328,14 @@ func (r *PermissionResolver) walkRoomPermission(
 	if err != nil {
 		return err
 	}
-	instanceOnlyRoles := filterOutSpaceRoles(instanceRoles, spaceRoles)
+	serverOnlyRoles := excludeRoles(serverRoles, spaceRoles)
 
-	instanceKV := r.core.storage.serverRBACEngine.KV()
+	serverKV := r.core.storage.serverRBACEngine.KV()
 	spaceKV := r.core.storage.serverRBACKV
 
 	// Phase 1: instance + space denials.
-	for _, role := range instanceRoles {
-		denied, err := r.keyExists(ctx, instanceKV, rbac.DenyKey(role, parts.Verb, parts.ObjectType, rbac.ObjectIdAny))
+	for _, role := range serverRoles {
+		denied, err := r.keyExists(ctx, serverKV, rbac.DenyKey(role, parts.Verb, parts.ObjectType, rbac.ObjectIdAny))
 		if err != nil {
 			return err
 		}
@@ -358,7 +358,7 @@ func (r *PermissionResolver) walkRoomPermission(
 			}
 		}
 	}
-	for _, role := range instanceOnlyRoles {
+	for _, role := range serverOnlyRoles {
 		denied, err := r.keyExists(ctx, spaceKV, rbac.DenyKey(role, parts.Verb, parts.ObjectType, rbac.ObjectIdAny))
 		if err != nil {
 			return err
@@ -403,7 +403,7 @@ func (r *PermissionResolver) walkRoomPermission(
 			}
 		}
 
-		for _, role := range instanceOnlyRoles {
+		for _, role := range serverOnlyRoles {
 			granted, err := r.keyExists(ctx, spaceKV, rbac.AllowKey(role, parts.Verb, parts.ObjectType, roomID))
 			if err != nil {
 				return err
@@ -431,8 +431,8 @@ func (r *PermissionResolver) walkRoomPermission(
 
 	// Phase 3: instance + space grants (fallback when no room-level decision).
 	if PermissionAppliesAtScope(perm, ScopeServer) {
-		for _, role := range instanceRoles {
-			granted, err := r.keyExists(ctx, instanceKV, rbac.AllowKey(role, parts.Verb, parts.ObjectType, rbac.ObjectIdAny))
+		for _, role := range serverRoles {
+			granted, err := r.keyExists(ctx, serverKV, rbac.AllowKey(role, parts.Verb, parts.ObjectType, rbac.ObjectIdAny))
 			if err != nil {
 				return err
 			}
@@ -455,7 +455,7 @@ func (r *PermissionResolver) walkRoomPermission(
 				}
 			}
 		}
-		for _, role := range instanceOnlyRoles {
+		for _, role := range serverOnlyRoles {
 			granted, err := r.keyExists(ctx, spaceKV, rbac.AllowKey(role, parts.Verb, parts.ObjectType, rbac.ObjectIdAny))
 			if err != nil {
 				return err
@@ -499,8 +499,8 @@ func (r *PermissionResolver) keyExists(ctx context.Context, kv jetstream.KeyValu
 	return false, fmt.Errorf("failed to check key %s: %w", key, err)
 }
 
-// getUserInstanceRoles returns the user's instance roles (including implicit ones).
-func (r *PermissionResolver) getUserInstanceRoles(ctx context.Context, userID string) ([]string, error) {
+// getUserServerRoles returns the user's instance roles (including implicit ones).
+func (r *PermissionResolver) getUserServerRoles(ctx context.Context, userID string) ([]string, error) {
 	roles, err := r.core.GetUserRoles(ctx, userID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user instance roles: %w", err)
@@ -514,16 +514,16 @@ func (r *PermissionResolver) getUserInstanceRoles(ctx context.Context, userID st
 	return roles, nil
 }
 
-// filterOutSpaceRoles returns instance roles that don't appear in spaceRoles.
+// excludeRoles returns instance roles that don't appear in spaceRoles.
 // Universal roles (everyone) appear in both lists; this avoids redundant
 // space KV lookups since they're already checked via the space roles loop.
-func filterOutSpaceRoles(instanceRoles, spaceRoles []string) []string {
+func excludeRoles(serverRoles, spaceRoles []string) []string {
 	spaceSet := make(map[string]struct{}, len(spaceRoles))
 	for _, r := range spaceRoles {
 		spaceSet[r] = struct{}{}
 	}
 	var result []string
-	for _, r := range instanceRoles {
+	for _, r := range serverRoles {
 		if _, ok := spaceSet[r]; !ok {
 			result = append(result, r)
 		}
@@ -575,10 +575,10 @@ func (r *PermissionResolver) getUserSpaceRolesWithPositions(ctx context.Context,
 	return result, nil
 }
 
-// getUserInstanceRolesWithPositions returns user's instance roles with positions, sorted by hierarchy.
+// getUserServerRolesWithPositions returns user's instance roles with positions, sorted by hierarchy.
 // Lower position = higher rank (checked first in permission resolution).
-func (r *PermissionResolver) getUserInstanceRolesWithPositions(ctx context.Context, userID string) ([]roleWithPosition, error) {
-	roleNames, err := r.getUserInstanceRoles(ctx, userID)
+func (r *PermissionResolver) getUserServerRolesWithPositions(ctx context.Context, userID string) ([]roleWithPosition, error) {
+	roleNames, err := r.getUserServerRoles(ctx, userID)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/core/permission_resolver_test.go
+++ b/cli/internal/core/permission_resolver_test.go
@@ -107,7 +107,7 @@ func TestPermissionResolver_HasInstancePermission_CustomDenyRole(t *testing.T) {
 	}
 
 	// Create a custom deny role (replicates the e2e test scenario)
-	denyRole, err := core.CreateInstanceRole(ctx, "denytest", "Deny space.list", "Test deny role")
+	denyRole, err := core.CreateServerRole(ctx, "denytest", "Deny space.list", "Test deny role")
 	if err != nil {
 		t.Fatalf("Failed to create deny role: %v", err)
 	}
@@ -120,7 +120,7 @@ func TestPermissionResolver_HasInstancePermission_CustomDenyRole(t *testing.T) {
 	}
 
 	// Assign deny role to user
-	err = core.AssignInstanceRole(ctx, SystemActorID, user.Id, "denytest")
+	err = core.AssignServerRole(ctx, SystemActorID, user.Id, "denytest")
 	if err != nil {
 		t.Fatalf("Failed to assign deny role: %v", err)
 	}
@@ -154,7 +154,7 @@ func TestPermissionResolver_HasInstancePermission_Hierarchy(t *testing.T) {
 
 	// Create a user and assign admin role
 	user, _ := core.CreateUser(ctx, "system", "testuser", "Test User", "password123")
-	_ = core.AssignInstanceRole(ctx, SystemActorID, user.Id, RoleAdmin)
+	_ = core.AssignServerRole(ctx, SystemActorID, user.Id, RoleAdmin)
 
 	t.Run("higher-ranked role grant beats lower-ranked role denial", func(t *testing.T) {
 		// Deny space.join for everyone (low rank, position MaxInt32)
@@ -340,7 +340,7 @@ func TestPermissionResolver_HasSpacePermission_DenyWins(t *testing.T) {
 }
 
 
-func TestPermissionResolver_HasSpacePermission_InstanceRoleOverride(t *testing.T) {
+func TestPermissionResolver_HasSpacePermission_ServerRoleOverride(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
@@ -512,7 +512,7 @@ func TestPermissionResolver_HasRoomPermission_DenyWins(t *testing.T) {
 		}
 
 		// Assign muted role to member
-		core.AssignInstanceRole(ctx, spaceAdmin.Id, member.Id, "muted")
+		core.AssignServerRole(ctx, spaceAdmin.Id, member.Id, "muted")
 
 		// Member should NOT have permission (higher-ranked muted denial wins over everyone grant)
 		has, err := core.permissionResolver.HasRoomPermission(ctx, member.Id, space.Id, room.Id, PermMessagePost)
@@ -623,7 +623,7 @@ func TestPermissionResolver_HasRoomPermission_ConflictingRoles(t *testing.T) {
 
 	member, _ := core.CreateUser(ctx, "system", "conflictrolemember", "Member", "password123")
 	// Create a custom role (gets position 3, higher rank than everyone at MaxInt32)
-	core.CreateInstanceRole(ctx, "poster", "Poster", "Can post")
+	core.CreateServerRole(ctx, "poster", "Poster", "Can post")
 
 	// Grant message.post to poster role at room level
 	core.GrantRoomPermission(ctx, room.Id, "poster", PermMessagePost)
@@ -632,7 +632,7 @@ func TestPermissionResolver_HasRoomPermission_ConflictingRoles(t *testing.T) {
 	core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
 
 	// Assign poster role to member (member now has: everyone + poster)
-	core.AssignInstanceRole(ctx, admin.Id, member.Id, "poster")
+	core.AssignServerRole(ctx, admin.Id, member.Id, "poster")
 
 	// Room-level uses hierarchy-wins: poster (position 3, higher rank) grant beats
 	// everyone (position MaxInt32, lower rank) deny. This enables patterns like
@@ -681,7 +681,7 @@ func TestPermissionResolver_HasRoomPermission_IsolationBetweenRooms(t *testing.T
 	}
 }
 
-func TestPermissionResolver_HasRoomPermission_InstanceRoleRoomDenial(t *testing.T) {
+func TestPermissionResolver_HasRoomPermission_ServerRoleRoomDenial(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
@@ -705,7 +705,7 @@ func TestPermissionResolver_HasRoomPermission_InstanceRoleRoomDenial(t *testing.
 	}
 }
 
-func TestPermissionResolver_HasRoomPermission_InstanceRoleRoomGrant(t *testing.T) {
+func TestPermissionResolver_HasRoomPermission_ServerRoleRoomGrant(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 

--- a/cli/internal/core/push.go
+++ b/cli/internal/core/push.go
@@ -64,7 +64,7 @@ func (c *ChattoCore) SavePushSubscription(
 	}
 
 	key := pushSubscriptionKey(userID, endpoint)
-	_, err = c.storage.instanceKV.Put(ctx, key, data)
+	_, err = c.storage.serverKV.Put(ctx, key, data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to store push subscription: %w", err)
 	}
@@ -81,7 +81,7 @@ func (c *ChattoCore) SavePushSubscription(
 func (c *ChattoCore) DeletePushSubscription(ctx context.Context, userID, endpoint string) error {
 	key := pushSubscriptionKey(userID, endpoint)
 
-	err := c.storage.instanceKV.Delete(ctx, key)
+	err := c.storage.serverKV.Delete(ctx, key)
 	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
 		return fmt.Errorf("failed to delete push subscription: %w", err)
 	}
@@ -97,7 +97,7 @@ func (c *ChattoCore) DeletePushSubscription(ctx context.Context, userID, endpoin
 // Authorization: Caller must verify userID matches authenticated user.
 func (c *ChattoCore) GetUserPushSubscriptions(ctx context.Context, userID string) ([]*corev1.PushSubscription, error) {
 	prefix := pushSubscriptionKeyFilter(userID)
-	lister, err := c.storage.instanceKV.ListKeysFiltered(ctx, prefix)
+	lister, err := c.storage.serverKV.ListKeysFiltered(ctx, prefix)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrNoKeysFound) {
 			return []*corev1.PushSubscription{}, nil
@@ -107,7 +107,7 @@ func (c *ChattoCore) GetUserPushSubscriptions(ctx context.Context, userID string
 
 	var subscriptions []*corev1.PushSubscription
 	for key := range lister.Keys() {
-		entry, err := c.storage.instanceKV.Get(ctx, key)
+		entry, err := c.storage.serverKV.Get(ctx, key)
 		if err != nil {
 			c.logger.Warn("Failed to get push subscription", "key", key, "error", err)
 			continue
@@ -129,7 +129,7 @@ func (c *ChattoCore) GetUserPushSubscriptions(ctx context.Context, userID string
 // Authorization: Internal use only - called from user deletion flow.
 func (c *ChattoCore) DeleteAllUserPushSubscriptions(ctx context.Context, userID string) (int, error) {
 	prefix := pushSubscriptionKeyFilter(userID)
-	lister, err := c.storage.instanceKV.ListKeysFiltered(ctx, prefix)
+	lister, err := c.storage.serverKV.ListKeysFiltered(ctx, prefix)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrNoKeysFound) {
 			return 0, nil
@@ -145,7 +145,7 @@ func (c *ChattoCore) DeleteAllUserPushSubscriptions(ctx context.Context, userID 
 
 	deleted := 0
 	for _, key := range keys {
-		if err := c.storage.instanceKV.Delete(ctx, key); err != nil {
+		if err := c.storage.serverKV.Delete(ctx, key); err != nil {
 			if !errors.Is(err, jetstream.ErrKeyNotFound) {
 				c.logger.Warn("Failed to delete push subscription", "key", key, "error", err)
 			}
@@ -168,7 +168,7 @@ func (c *ChattoCore) DeleteAllUserPushSubscriptions(ctx context.Context, userID 
 // all push subscriptions for monitoring/debugging purposes.
 func (c *ChattoCore) GetAllPushSubscriptions(ctx context.Context) ([]*PushSubscriptionWithUser, error) {
 	prefix := "push_subscription.*"
-	lister, err := c.storage.instanceKV.ListKeysFiltered(ctx, prefix)
+	lister, err := c.storage.serverKV.ListKeysFiltered(ctx, prefix)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrNoKeysFound) {
 			return []*PushSubscriptionWithUser{}, nil
@@ -178,7 +178,7 @@ func (c *ChattoCore) GetAllPushSubscriptions(ctx context.Context) ([]*PushSubscr
 
 	var subscriptions []*PushSubscriptionWithUser
 	for key := range lister.Keys() {
-		entry, err := c.storage.instanceKV.Get(ctx, key)
+		entry, err := c.storage.serverKV.Get(ctx, key)
 		if err != nil {
 			c.logger.Warn("Failed to get push subscription", "key", key, "error", err)
 			continue

--- a/cli/internal/core/rbac.go
+++ b/cli/internal/core/rbac.go
@@ -337,11 +337,11 @@ func (c *ChattoCore) ListInstanceAdmins(ctx context.Context) ([]string, error) {
 	return c.storage.serverRBACEngine.GetRoleUsers(ctx, RoleAdmin)
 }
 
-// AssignInstanceRole assigns any instance role to a user.
+// AssignServerRole assigns any instance role to a user.
 // The role must exist (system or custom). The everyone role cannot be assigned (it's implicit).
 // Pass SystemActorID as actorID to bypass hierarchy check (for internal/bootstrap use).
 // Hierarchy check: actor must outrank the role being assigned (actor's position < role's position).
-func (c *ChattoCore) AssignInstanceRole(ctx context.Context, actorID, userID, roleName string) error {
+func (c *ChattoCore) AssignServerRole(ctx context.Context, actorID, userID, roleName string) error {
 	if roleName == RoleEveryone {
 		return ErrImplicitRole
 	}
@@ -376,7 +376,7 @@ func (c *ChattoCore) AssignInstanceRole(ctx context.Context, actorID, userID, ro
 	return nil
 }
 
-// RevokeInstanceRole removes an instance role from a user.
+// RevokeServerRole removes an instance role from a user.
 // The role must exist (system or custom). The everyone role cannot be revoked (it's implicit).
 // Pass SystemActorID as actorID to bypass hierarchy and self-demote checks (for internal/bootstrap use).
 //
@@ -384,7 +384,7 @@ func (c *ChattoCore) AssignInstanceRole(ctx context.Context, actorID, userID, ro
 //   - Owners cannot revoke their own owner role (lockout prevention).
 //   - Actor must outrank the role being revoked (role-position hierarchy).
 //   - Actor must outrank the target user (user-position hierarchy) — peers cannot demote each other.
-func (c *ChattoCore) RevokeInstanceRole(ctx context.Context, actorID, userID, roleName string) error {
+func (c *ChattoCore) RevokeServerRole(ctx context.Context, actorID, userID, roleName string) error {
 	if roleName == RoleEveryone {
 		return ErrImplicitRole
 	}
@@ -493,9 +493,9 @@ func (c *ChattoCore) RevokeInstancePermission(ctx context.Context, roleName stri
 	return nil
 }
 
-// GetInstanceRolePermissions returns all permissions granted to an instance role.
+// GetServerRolePermissions returns all permissions granted to an instance role.
 // Note: Admin roles are NOT special-cased - permissions are explicitly stored in KV.
-func (c *ChattoCore) GetInstanceRolePermissions(ctx context.Context, roleName string) ([]Permission, error) {
+func (c *ChattoCore) GetServerRolePermissions(ctx context.Context, roleName string) ([]Permission, error) {
 	perms, err := c.storage.serverRBACEngine.GetRolePermissions(ctx, roleName)
 	if err != nil {
 		return nil, err
@@ -511,9 +511,9 @@ func (c *ChattoCore) GetInstanceRolePermissions(ctx context.Context, roleName st
 	return result, nil
 }
 
-// GetInstanceRolePermissionDenials returns all permissions denied by an instance role.
+// GetServerRolePermissionDenials returns all permissions denied by an instance role.
 // Note: Admin roles are NOT special-cased - they can have denials like any other role.
-func (c *ChattoCore) GetInstanceRolePermissionDenials(ctx context.Context, roleName string) ([]Permission, error) {
+func (c *ChattoCore) GetServerRolePermissionDenials(ctx context.Context, roleName string) ([]Permission, error) {
 	perms, err := c.storage.serverRBACEngine.GetRolePermissionDenials(ctx, roleName)
 	if err != nil {
 		return nil, err
@@ -562,9 +562,9 @@ func (c *ChattoCore) GetUserInstancePermissions(ctx context.Context, userID stri
 // Server-tier Role CRUD
 // ============================================================================
 
-// ListInstanceRoles returns all instance roles with their permissions.
+// ListServerRoles returns all instance roles with their permissions.
 // Note: Admin roles are NOT special-cased - permissions are read from KV like any other role.
-func (c *ChattoCore) ListInstanceRoles(ctx context.Context) ([]RoleWithPermissions, error) {
+func (c *ChattoCore) ListServerRoles(ctx context.Context) ([]RoleWithPermissions, error) {
 	roles, err := c.storage.serverRBACEngine.ListRoles(ctx)
 	if err != nil {
 		return nil, err
@@ -572,8 +572,8 @@ func (c *ChattoCore) ListInstanceRoles(ctx context.Context) ([]RoleWithPermissio
 
 	result := make([]RoleWithPermissions, 0, len(roles))
 	for _, role := range roles {
-		perms, _ := c.GetInstanceRolePermissions(ctx, role.Name)
-		denials, _ := c.GetInstanceRolePermissionDenials(ctx, role.Name)
+		perms, _ := c.GetServerRolePermissions(ctx, role.Name)
+		denials, _ := c.GetServerRolePermissionDenials(ctx, role.Name)
 
 		result = append(result, RoleWithPermissions{
 			Name:              role.Name,
@@ -589,10 +589,10 @@ func (c *ChattoCore) ListInstanceRoles(ctx context.Context) ([]RoleWithPermissio
 	return result, nil
 }
 
-// CreateInstanceRole creates a new custom server role.
+// CreateServerRole creates a new custom server role.
 // Role names must be lowercase letters only (e.g., "editor", "moderator").
 // System role names (owner, admin, moderator, everyone) are reserved.
-func (c *ChattoCore) CreateInstanceRole(ctx context.Context, name, displayName, description string) (*RoleWithPermissions, error) {
+func (c *ChattoCore) CreateServerRole(ctx context.Context, name, displayName, description string) (*RoleWithPermissions, error) {
 	if err := rbac.ValidateRoleName(name); err != nil {
 		return nil, ErrInvalidRoleName
 	}
@@ -625,9 +625,9 @@ func (c *ChattoCore) CreateInstanceRole(ctx context.Context, name, displayName, 
 	}, nil
 }
 
-// UpdateInstanceRole updates an existing role's metadata.
+// UpdateServerRole updates an existing role's metadata.
 // The role name cannot be changed.
-func (c *ChattoCore) UpdateInstanceRole(ctx context.Context, name, displayName, description string) (*RoleWithPermissions, error) {
+func (c *ChattoCore) UpdateServerRole(ctx context.Context, name, displayName, description string) (*RoleWithPermissions, error) {
 	role, err := c.storage.serverRBACEngine.UpdateRole(ctx, name, displayName, description)
 	if err != nil {
 		if errors.Is(err, rbac.ErrRoleNotFound) {
@@ -638,8 +638,8 @@ func (c *ChattoCore) UpdateInstanceRole(ctx context.Context, name, displayName, 
 
 	c.logger.Info("Updated instance role", "name", name, "display_name", displayName)
 
-	perms, _ := c.GetInstanceRolePermissions(ctx, name)
-	denials, _ := c.GetInstanceRolePermissionDenials(ctx, name)
+	perms, _ := c.GetServerRolePermissions(ctx, name)
+	denials, _ := c.GetServerRolePermissionDenials(ctx, name)
 	return &RoleWithPermissions{
 		Name:              role.Name,
 		DisplayName:       role.DisplayName,
@@ -651,9 +651,9 @@ func (c *ChattoCore) UpdateInstanceRole(ctx context.Context, name, displayName, 
 	}, nil
 }
 
-// GetInstanceRole returns a single instance role by name.
+// GetServerRole returns a single instance role by name.
 // Note: Admin roles are NOT special-cased - permissions are read from KV like any other role.
-func (c *ChattoCore) GetInstanceRole(ctx context.Context, name string) (*RoleWithPermissions, error) {
+func (c *ChattoCore) GetServerRole(ctx context.Context, name string) (*RoleWithPermissions, error) {
 	role, err := c.storage.serverRBACEngine.GetRole(ctx, name)
 	if err != nil {
 		if errors.Is(err, rbac.ErrRoleNotFound) {
@@ -662,8 +662,8 @@ func (c *ChattoCore) GetInstanceRole(ctx context.Context, name string) (*RoleWit
 		return nil, err
 	}
 
-	perms, _ := c.GetInstanceRolePermissions(ctx, name)
-	denials, _ := c.GetInstanceRolePermissionDenials(ctx, name)
+	perms, _ := c.GetServerRolePermissions(ctx, name)
+	denials, _ := c.GetServerRolePermissionDenials(ctx, name)
 
 	return &RoleWithPermissions{
 		Name:              role.Name,
@@ -676,10 +676,10 @@ func (c *ChattoCore) GetInstanceRole(ctx context.Context, name string) (*RoleWit
 	}, nil
 }
 
-// DeleteInstanceRole deletes a custom role and all its associated data.
+// DeleteServerRole deletes a custom role and all its associated data.
 // This includes: the role definition, all permission grants, and all user assignments.
 // System roles (owner, admin, moderator, everyone) cannot be deleted.
-func (c *ChattoCore) DeleteInstanceRole(ctx context.Context, name string) error {
+func (c *ChattoCore) DeleteServerRole(ctx context.Context, name string) error {
 	if IsSystemRole(name) {
 		return ErrCannotDeleteSystemRole
 	}
@@ -698,12 +698,12 @@ func (c *ChattoCore) DeleteInstanceRole(ctx context.Context, name string) error 
 	return nil
 }
 
-// ReorderInstanceRoles reorders custom instance roles.
+// ReorderServerRoles reorders custom instance roles.
 // System roles (owner, admin, moderator, everyone) maintain fixed positions and should not be included.
 // Positions are assigned based on array index (first role = position 3, second = 4, etc).
 // Note: Position 0 = owner, 1 = admin, 2 = moderator, position MAX = everyone.
 // Returns all roles sorted by position.
-func (c *ChattoCore) ReorderInstanceRoles(ctx context.Context, roleNames []string) ([]RoleWithPermissions, error) {
+func (c *ChattoCore) ReorderServerRoles(ctx context.Context, roleNames []string) ([]RoleWithPermissions, error) {
 	for _, name := range roleNames {
 		if IsSystemRole(name) {
 			return nil, fmt.Errorf("cannot reorder system role: %s", name)
@@ -717,8 +717,8 @@ func (c *ChattoCore) ReorderInstanceRoles(ctx context.Context, roleNames []strin
 
 	result := make([]RoleWithPermissions, 0, len(roles))
 	for _, role := range roles {
-		perms, _ := c.GetInstanceRolePermissions(ctx, role.Name)
-		denials, _ := c.GetInstanceRolePermissionDenials(ctx, role.Name)
+		perms, _ := c.GetServerRolePermissions(ctx, role.Name)
+		denials, _ := c.GetServerRolePermissionDenials(ctx, role.Name)
 
 		result = append(result, RoleWithPermissions{
 			Name:              role.Name,

--- a/cli/internal/core/rbac_test.go
+++ b/cli/internal/core/rbac_test.go
@@ -686,12 +686,12 @@ func TestChattoCore_HierarchyWins_OwnerBeatsEverythingElse(t *testing.T) {
 // Instance Role Creation Tests
 // ============================================================================
 
-func TestChattoCore_CreateInstanceRole(t *testing.T) {
+func TestChattoCore_CreateServerRole(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
 	t.Run("creates role successfully", func(t *testing.T) {
-		role, err := core.CreateInstanceRole(ctx, "customrole", "Custom Role", "A custom role")
+		role, err := core.CreateServerRole(ctx, "customrole", "Custom Role", "A custom role")
 		if err != nil {
 			t.Fatalf("Failed to create role: %v", err)
 		}
@@ -701,7 +701,7 @@ func TestChattoCore_CreateInstanceRole(t *testing.T) {
 	})
 
 	t.Run("rejects role name with dashes", func(t *testing.T) {
-		_, err := core.CreateInstanceRole(ctx, "custom-role", "Custom", "Should fail")
+		_, err := core.CreateServerRole(ctx, "custom-role", "Custom", "Should fail")
 		if err == nil {
 			t.Error("Expected error for role name with dashes")
 		}
@@ -711,7 +711,7 @@ func TestChattoCore_CreateInstanceRole(t *testing.T) {
 	})
 
 	t.Run("rejects role name with numbers", func(t *testing.T) {
-		_, err := core.CreateInstanceRole(ctx, "role2", "Role 2", "Should fail")
+		_, err := core.CreateServerRole(ctx, "role2", "Role 2", "Should fail")
 		if err == nil {
 			t.Error("Expected error for role name with numbers")
 		}
@@ -721,7 +721,7 @@ func TestChattoCore_CreateInstanceRole(t *testing.T) {
 	})
 
 	t.Run("rejects system role names", func(t *testing.T) {
-		_, err := core.CreateInstanceRole(ctx, RoleAdmin, "Admin", "Should fail")
+		_, err := core.CreateServerRole(ctx, RoleAdmin, "Admin", "Should fail")
 		if err == nil {
 			t.Error("Expected error for system role name")
 		}
@@ -732,14 +732,14 @@ func TestChattoCore_CreateInstanceRole(t *testing.T) {
 // Generic Role Assignment Tests
 // ============================================================================
 
-func TestChattoCore_AssignInstanceRole(t *testing.T) {
+func TestChattoCore_AssignServerRole(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
 	t.Run("assigns admin role", func(t *testing.T) {
 		userID := "assign-admin-test"
 
-		if err := core.AssignInstanceRole(ctx, SystemActorID, userID, RoleAdmin); err != nil {
+		if err := core.AssignServerRole(ctx, SystemActorID, userID, RoleAdmin); err != nil {
 			t.Fatalf("Failed to assign role: %v", err)
 		}
 
@@ -753,7 +753,7 @@ func TestChattoCore_AssignInstanceRole(t *testing.T) {
 	t.Run("rejects everyone role assignment", func(t *testing.T) {
 		userID := "assign-everyone-test"
 
-		err := core.AssignInstanceRole(ctx, SystemActorID, userID, RoleEveryone)
+		err := core.AssignServerRole(ctx, SystemActorID, userID, RoleEveryone)
 		if err == nil {
 			t.Error("Expected error when assigning everyone role")
 		}
@@ -762,7 +762,7 @@ func TestChattoCore_AssignInstanceRole(t *testing.T) {
 	t.Run("rejects non-existent role", func(t *testing.T) {
 		userID := "assign-nonexistent-test"
 
-		err := core.AssignInstanceRole(ctx, SystemActorID, userID, "nonexistent")
+		err := core.AssignServerRole(ctx, SystemActorID, userID, "nonexistent")
 		if !errors.Is(err, ErrRoleNotFound) {
 			t.Errorf("Expected ErrRoleNotFound, got %v", err)
 		}
@@ -772,17 +772,17 @@ func TestChattoCore_AssignInstanceRole(t *testing.T) {
 		userID := "assign-custom-test"
 
 		// Create a custom role first (must have instance- prefix)
-		_, err := core.CreateInstanceRole(ctx, "tester", "Tester", "QA tester")
+		_, err := core.CreateServerRole(ctx, "tester", "Tester", "QA tester")
 		if err != nil {
 			t.Fatalf("Failed to create role: %v", err)
 		}
 
 		// Assign the custom role
-		if err := core.AssignInstanceRole(ctx, SystemActorID, userID, "tester"); err != nil {
+		if err := core.AssignServerRole(ctx, SystemActorID, userID, "tester"); err != nil {
 			t.Fatalf("Failed to assign role: %v", err)
 		}
 
-		// Verify via GetUserInstanceRoles
+		// Verify via GetUserServerRoles
 		roles, _ := core.GetUserRoles(ctx, userID)
 		found := false
 		for _, r := range roles {
@@ -797,7 +797,7 @@ func TestChattoCore_AssignInstanceRole(t *testing.T) {
 	})
 }
 
-func TestChattoCore_RevokeInstanceRole(t *testing.T) {
+func TestChattoCore_RevokeServerRole(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
@@ -805,7 +805,7 @@ func TestChattoCore_RevokeInstanceRole(t *testing.T) {
 		userID := "revoke-admin-test"
 
 		// Assign first
-		core.AssignInstanceRole(ctx, SystemActorID, userID, RoleAdmin)
+		core.AssignServerRole(ctx, SystemActorID, userID, RoleAdmin)
 
 		// Verify assigned
 		isAdmin, _ := core.IsInstanceAdmin(ctx, userID)
@@ -814,7 +814,7 @@ func TestChattoCore_RevokeInstanceRole(t *testing.T) {
 		}
 
 		// Revoke
-		if err := core.RevokeInstanceRole(ctx, SystemActorID, userID, RoleAdmin); err != nil {
+		if err := core.RevokeServerRole(ctx, SystemActorID, userID, RoleAdmin); err != nil {
 			t.Fatalf("Failed to revoke role: %v", err)
 		}
 
@@ -828,7 +828,7 @@ func TestChattoCore_RevokeInstanceRole(t *testing.T) {
 	t.Run("rejects everyone role revocation", func(t *testing.T) {
 		userID := "revoke-everyone-test"
 
-		err := core.RevokeInstanceRole(ctx, SystemActorID, userID, RoleEveryone)
+		err := core.RevokeServerRole(ctx, SystemActorID, userID, RoleEveryone)
 		if err == nil {
 			t.Error("Expected error when revoking everyone role")
 		}
@@ -837,7 +837,7 @@ func TestChattoCore_RevokeInstanceRole(t *testing.T) {
 	t.Run("rejects non-existent role", func(t *testing.T) {
 		userID := "revoke-nonexistent-test"
 
-		err := core.RevokeInstanceRole(ctx, SystemActorID, userID, "nonexistent")
+		err := core.RevokeServerRole(ctx, SystemActorID, userID, "nonexistent")
 		if !errors.Is(err, ErrRoleNotFound) {
 			t.Errorf("Expected ErrRoleNotFound, got %v", err)
 		}
@@ -847,14 +847,14 @@ func TestChattoCore_RevokeInstanceRole(t *testing.T) {
 		userID := "revoke-unassigned-test"
 
 		// Revoke role user doesn't have - should not error
-		err := core.RevokeInstanceRole(ctx, SystemActorID, userID, RoleAdmin)
+		err := core.RevokeServerRole(ctx, SystemActorID, userID, RoleAdmin)
 		if err != nil {
 			t.Errorf("Expected no error for idempotent revoke: %v", err)
 		}
 	})
 }
 
-func TestChattoCore_ListInstanceRoleUsers(t *testing.T) {
+func TestChattoCore_ListServerRoleUsers(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
@@ -871,8 +871,8 @@ func TestChattoCore_ListInstanceRoleUsers(t *testing.T) {
 
 	t.Run("returns users with admin role", func(t *testing.T) {
 		// Assign some admins
-		core.AssignInstanceRole(ctx, SystemActorID, "list-admin1", RoleAdmin)
-		core.AssignInstanceRole(ctx, SystemActorID, "list-admin2", RoleAdmin)
+		core.AssignServerRole(ctx, SystemActorID, "list-admin1", RoleAdmin)
+		core.AssignServerRole(ctx, SystemActorID, "list-admin2", RoleAdmin)
 
 		users, err := core.GetRoleUsers(ctx, RoleAdmin)
 		if err != nil {
@@ -897,7 +897,7 @@ func TestChattoCore_ListInstanceRoleUsers(t *testing.T) {
 	})
 }
 
-func TestChattoCore_GetUserInstanceRoles(t *testing.T) {
+func TestChattoCore_GetUserServerRoles(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
@@ -908,7 +908,7 @@ func TestChattoCore_GetUserInstanceRoles(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to get roles: %v", err)
 		}
-		// Virtual roles (everyone) are not returned by GetUserInstanceRoles
+		// Virtual roles (everyone) are not returned by GetUserServerRoles
 		if len(roles) != 0 {
 			t.Errorf("Expected 0 roles for user with no explicit roles, got %d: %v", len(roles), roles)
 		}
@@ -917,7 +917,7 @@ func TestChattoCore_GetUserInstanceRoles(t *testing.T) {
 	t.Run("returns admin role when assigned", func(t *testing.T) {
 		userID := "admin-roles-user"
 
-		core.AssignInstanceRole(ctx, SystemActorID, userID, RoleAdmin)
+		core.AssignServerRole(ctx, SystemActorID, userID, RoleAdmin)
 
 		roles, err := core.GetUserRoles(ctx, userID)
 		if err != nil {
@@ -938,11 +938,11 @@ func TestChattoCore_GetUserInstanceRoles(t *testing.T) {
 		}
 
 		// Create custom role (must have instance- prefix)
-		core.CreateInstanceRole(ctx, "editor", "Editor", "Content editor")
+		core.CreateServerRole(ctx, "editor", "Editor", "Content editor")
 
 		// Assign multiple roles
-		core.AssignInstanceRole(ctx, SystemActorID, user.Id, RoleAdmin)
-		core.AssignInstanceRole(ctx, SystemActorID, user.Id, "editor")
+		core.AssignServerRole(ctx, SystemActorID, user.Id, RoleAdmin)
+		core.AssignServerRole(ctx, SystemActorID, user.Id, "editor")
 
 		roles, err := core.GetUserRoles(ctx, user.Id)
 		if err != nil {
@@ -967,7 +967,7 @@ func TestChattoCore_GetUserInstanceRoles(t *testing.T) {
 // Instance Role Assignment Hierarchy Tests
 // ============================================================================
 
-func TestChattoCore_AssignInstanceRole_HierarchyCheck(t *testing.T) {
+func TestChattoCore_AssignServerRole_HierarchyCheck(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
@@ -985,7 +985,7 @@ func TestChattoCore_AssignInstanceRole_HierarchyCheck(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create admin: %v", err)
 	}
-	if err := core.AssignInstanceRole(ctx, SystemActorID, admin.Id, RoleAdmin); err != nil {
+	if err := core.AssignServerRole(ctx, SystemActorID, admin.Id, RoleAdmin); err != nil {
 		t.Fatalf("Failed to assign admin role: %v", err)
 	}
 
@@ -996,7 +996,7 @@ func TestChattoCore_AssignInstanceRole_HierarchyCheck(t *testing.T) {
 	}
 
 	t.Run("admin cannot assign owner role (higher rank)", func(t *testing.T) {
-		err := core.AssignInstanceRole(ctx, admin.Id, target.Id, RoleOwner)
+		err := core.AssignServerRole(ctx, admin.Id, target.Id, RoleOwner)
 		if err == nil {
 			t.Error("Expected error: admin should not be able to assign owner role")
 		}
@@ -1006,7 +1006,7 @@ func TestChattoCore_AssignInstanceRole_HierarchyCheck(t *testing.T) {
 	})
 
 	t.Run("admin cannot assign admin role (equal rank)", func(t *testing.T) {
-		err := core.AssignInstanceRole(ctx, admin.Id, target.Id, RoleAdmin)
+		err := core.AssignServerRole(ctx, admin.Id, target.Id, RoleAdmin)
 		if err == nil {
 			t.Error("Expected error: admin should not be able to assign equal-rank role")
 		}
@@ -1016,21 +1016,21 @@ func TestChattoCore_AssignInstanceRole_HierarchyCheck(t *testing.T) {
 	})
 
 	t.Run("admin can assign moderator role (lower rank)", func(t *testing.T) {
-		err := core.AssignInstanceRole(ctx, admin.Id, target.Id, RoleModerator)
+		err := core.AssignServerRole(ctx, admin.Id, target.Id, RoleModerator)
 		if err != nil {
 			t.Fatalf("Expected admin to assign moderator role: %v", err)
 		}
 	})
 
 	t.Run("owner can assign admin role", func(t *testing.T) {
-		err := core.AssignInstanceRole(ctx, owner.Id, target.Id, RoleAdmin)
+		err := core.AssignServerRole(ctx, owner.Id, target.Id, RoleAdmin)
 		if err != nil {
 			t.Fatalf("Expected owner to assign admin role: %v", err)
 		}
 	})
 
 	t.Run("admin cannot self-escalate to owner", func(t *testing.T) {
-		err := core.AssignInstanceRole(ctx, admin.Id, admin.Id, RoleOwner)
+		err := core.AssignServerRole(ctx, admin.Id, admin.Id, RoleOwner)
 		if err == nil {
 			t.Error("Expected error: admin should not be able to self-escalate to owner")
 		}
@@ -1040,14 +1040,14 @@ func TestChattoCore_AssignInstanceRole_HierarchyCheck(t *testing.T) {
 	})
 
 	t.Run("system actor bypasses hierarchy check", func(t *testing.T) {
-		err := core.AssignInstanceRole(ctx, SystemActorID, target.Id, RoleOwner)
+		err := core.AssignServerRole(ctx, SystemActorID, target.Id, RoleOwner)
 		if err != nil {
 			t.Fatalf("Expected system actor to bypass hierarchy: %v", err)
 		}
 	})
 }
 
-func TestChattoCore_RevokeInstanceRole_HierarchyCheck(t *testing.T) {
+func TestChattoCore_RevokeServerRole_HierarchyCheck(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
@@ -1065,7 +1065,7 @@ func TestChattoCore_RevokeInstanceRole_HierarchyCheck(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create admin: %v", err)
 	}
-	if err := core.AssignInstanceRole(ctx, SystemActorID, admin.Id, RoleAdmin); err != nil {
+	if err := core.AssignServerRole(ctx, SystemActorID, admin.Id, RoleAdmin); err != nil {
 		t.Fatalf("Failed to assign admin role: %v", err)
 	}
 
@@ -1074,7 +1074,7 @@ func TestChattoCore_RevokeInstanceRole_HierarchyCheck(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create other admin: %v", err)
 	}
-	if err := core.AssignInstanceRole(ctx, SystemActorID, otherAdmin.Id, RoleAdmin); err != nil {
+	if err := core.AssignServerRole(ctx, SystemActorID, otherAdmin.Id, RoleAdmin); err != nil {
 		t.Fatalf("Failed to assign admin role: %v", err)
 	}
 
@@ -1083,33 +1083,33 @@ func TestChattoCore_RevokeInstanceRole_HierarchyCheck(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create target: %v", err)
 	}
-	if err := core.AssignInstanceRole(ctx, SystemActorID, target.Id, RoleModerator); err != nil {
+	if err := core.AssignServerRole(ctx, SystemActorID, target.Id, RoleModerator); err != nil {
 		t.Fatalf("Failed to assign moderator: %v", err)
 	}
 
 	t.Run("admin cannot revoke owner role (higher rank)", func(t *testing.T) {
-		err := core.RevokeInstanceRole(ctx, admin.Id, owner.Id, RoleOwner)
+		err := core.RevokeServerRole(ctx, admin.Id, owner.Id, RoleOwner)
 		if err == nil {
 			t.Error("Expected error: admin should not be able to revoke owner role")
 		}
 	})
 
 	t.Run("admin cannot revoke another admin's role (equal rank)", func(t *testing.T) {
-		err := core.RevokeInstanceRole(ctx, admin.Id, otherAdmin.Id, RoleAdmin)
+		err := core.RevokeServerRole(ctx, admin.Id, otherAdmin.Id, RoleAdmin)
 		if err == nil {
 			t.Error("Expected error: admin should not be able to revoke equal-rank role")
 		}
 	})
 
 	t.Run("admin can revoke moderator role (lower rank)", func(t *testing.T) {
-		err := core.RevokeInstanceRole(ctx, admin.Id, target.Id, RoleModerator)
+		err := core.RevokeServerRole(ctx, admin.Id, target.Id, RoleModerator)
 		if err != nil {
 			t.Fatalf("Expected admin to revoke moderator role: %v", err)
 		}
 	})
 
 	t.Run("owner can revoke admin role", func(t *testing.T) {
-		err := core.RevokeInstanceRole(ctx, owner.Id, admin.Id, RoleAdmin)
+		err := core.RevokeServerRole(ctx, owner.Id, admin.Id, RoleAdmin)
 		if err != nil {
 			t.Fatalf("Expected owner to revoke admin role: %v", err)
 		}
@@ -1117,10 +1117,10 @@ func TestChattoCore_RevokeInstanceRole_HierarchyCheck(t *testing.T) {
 
 	t.Run("system actor bypasses hierarchy check", func(t *testing.T) {
 		// Re-assign admin to test system bypass on revoke
-		if err := core.AssignInstanceRole(ctx, SystemActorID, admin.Id, RoleAdmin); err != nil {
+		if err := core.AssignServerRole(ctx, SystemActorID, admin.Id, RoleAdmin); err != nil {
 			t.Fatalf("Failed to re-assign admin: %v", err)
 		}
-		err := core.RevokeInstanceRole(ctx, SystemActorID, admin.Id, RoleAdmin)
+		err := core.RevokeServerRole(ctx, SystemActorID, admin.Id, RoleAdmin)
 		if err != nil {
 			t.Fatalf("Expected system actor to bypass hierarchy: %v", err)
 		}
@@ -1131,23 +1131,23 @@ func TestChattoCore_RevokeInstanceRole_HierarchyCheck(t *testing.T) {
 // Instance Role Position and Reordering Tests
 // ============================================================================
 
-func TestChattoCore_ReorderInstanceRoles(t *testing.T) {
+func TestChattoCore_ReorderServerRoles(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
 	t.Run("reorders custom roles", func(t *testing.T) {
 		// Create custom roles
-		_, err := core.CreateInstanceRole(ctx, "alpha", "Alpha", "First custom role")
+		_, err := core.CreateServerRole(ctx, "alpha", "Alpha", "First custom role")
 		if err != nil {
 			t.Fatalf("Failed to create alpha role: %v", err)
 		}
-		_, err = core.CreateInstanceRole(ctx, "beta", "Beta", "Second custom role")
+		_, err = core.CreateServerRole(ctx, "beta", "Beta", "Second custom role")
 		if err != nil {
 			t.Fatalf("Failed to create beta role: %v", err)
 		}
 
 		// Get initial positions
-		initialRoles, _ := core.ListInstanceRoles(ctx)
+		initialRoles, _ := core.ListServerRoles(ctx)
 		var alphaInitialPos, betaInitialPos int32
 		for _, r := range initialRoles {
 			if r.Name == "alpha" {
@@ -1160,7 +1160,7 @@ func TestChattoCore_ReorderInstanceRoles(t *testing.T) {
 		t.Logf("Initial positions: alpha=%d, beta=%d", alphaInitialPos, betaInitialPos)
 
 		// Reorder: put beta before alpha
-		reordered, err := core.ReorderInstanceRoles(ctx, []string{"beta", "alpha"})
+		reordered, err := core.ReorderServerRoles(ctx, []string{"beta", "alpha"})
 		if err != nil {
 			t.Fatalf("Failed to reorder: %v", err)
 		}
@@ -1184,14 +1184,14 @@ func TestChattoCore_ReorderInstanceRoles(t *testing.T) {
 
 	t.Run("rejects system role reordering", func(t *testing.T) {
 		// Try to include a system role in the reorder
-		_, err := core.ReorderInstanceRoles(ctx, []string{RoleAdmin, RoleModerator})
+		_, err := core.ReorderServerRoles(ctx, []string{RoleAdmin, RoleModerator})
 		if err == nil {
 			t.Error("Expected error when trying to reorder system roles")
 		}
 	})
 
 	t.Run("preserves system role positions", func(t *testing.T) {
-		roles, _ := core.ListInstanceRoles(ctx)
+		roles, _ := core.ListServerRoles(ctx)
 
 		var ownerPos, adminPos, modPos int32
 		for _, r := range roles {
@@ -1218,12 +1218,12 @@ func TestChattoCore_ReorderInstanceRoles(t *testing.T) {
 	})
 }
 
-func TestChattoCore_CreateInstanceRole_PositionAssignment(t *testing.T) {
+func TestChattoCore_CreateServerRole_PositionAssignment(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
 	t.Run("custom role gets position after system roles", func(t *testing.T) {
-		role, err := core.CreateInstanceRole(ctx, "reviewer", "Reviewer", "Code reviewer")
+		role, err := core.CreateServerRole(ctx, "reviewer", "Reviewer", "Code reviewer")
 		if err != nil {
 			t.Fatalf("Failed to create role: %v", err)
 		}
@@ -1241,14 +1241,14 @@ func TestChattoCore_CreateInstanceRole_PositionAssignment(t *testing.T) {
 
 	t.Run("position preserved after update", func(t *testing.T) {
 		// Create a role
-		role, err := core.CreateInstanceRole(ctx, "editor", "Editor", "Content editor")
+		role, err := core.CreateServerRole(ctx, "editor", "Editor", "Content editor")
 		if err != nil {
 			t.Fatalf("Failed to create role: %v", err)
 		}
 		originalPos := role.Position
 
 		// Update the display name
-		updated, err := core.UpdateInstanceRole(ctx, "editor", "Super Editor", "Super content editor")
+		updated, err := core.UpdateServerRole(ctx, "editor", "Super Editor", "Super content editor")
 		if err != nil {
 			t.Fatalf("Failed to update role: %v", err)
 		}
@@ -1261,14 +1261,14 @@ func TestChattoCore_CreateInstanceRole_PositionAssignment(t *testing.T) {
 	t.Run("multiple custom roles can be created", func(t *testing.T) {
 		roles := []string{"helper", "triage", "support"}
 		for _, name := range roles {
-			_, err := core.CreateInstanceRole(ctx, name, name, "Test role")
+			_, err := core.CreateServerRole(ctx, name, name, "Test role")
 			if err != nil {
 				t.Fatalf("Failed to create role %s: %v", name, err)
 			}
 		}
 
 		// Verify all exist
-		allRoles, _ := core.ListInstanceRoles(ctx)
+		allRoles, _ := core.ListServerRoles(ctx)
 		roleNames := make(map[string]bool)
 		for _, r := range allRoles {
 			roleNames[r.Name] = true
@@ -1341,7 +1341,7 @@ func TestChattoCore_CreateRole(t *testing.T) {
 	}
 
 	// Create a role
-	role, err := core.CreateInstanceRole(ctx, "testmod", "Test Mod", "Can moderate content")
+	role, err := core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate content")
 	if err != nil {
 		t.Fatalf("Failed to create role: %v", err)
 	}
@@ -1370,7 +1370,7 @@ func TestChattoCore_CreateRole_InvalidName(t *testing.T) {
 	core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
 
 	// Try to create role with invalid name
-	_, err := core.CreateInstanceRole(ctx, "Invalid-Name", "Invalid", "Should fail")
+	_, err := core.CreateServerRole(ctx, "Invalid-Name", "Invalid", "Should fail")
 	if err == nil {
 		t.Error("Expected error for invalid role name")
 	}
@@ -1386,13 +1386,13 @@ func TestChattoCore_CreateRole_Duplicate(t *testing.T) {
 	core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
 
 	// Create a role
-	_, err := core.CreateInstanceRole(ctx, "testmod", "Test Mod", "First")
+	_, err := core.CreateServerRole(ctx, "testmod", "Test Mod", "First")
 	if err != nil {
 		t.Fatalf("Failed to create first role: %v", err)
 	}
 
 	// Try to create same role again
-	_, err = core.CreateInstanceRole(ctx, "testmod", "Test Mod 2", "Second")
+	_, err = core.CreateServerRole(ctx, "testmod", "Test Mod 2", "Second")
 	if err == nil {
 		t.Error("Expected error for duplicate role")
 	}
@@ -1408,13 +1408,13 @@ func TestChattoCore_GetRole(t *testing.T) {
 	core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
 
 	// Create a role
-	_, err := core.CreateInstanceRole(ctx, "testmod", "Test Mod", "Can moderate content")
+	_, err := core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate content")
 	if err != nil {
 		t.Fatalf("Failed to create role: %v", err)
 	}
 
 	// Retrieve it
-	retrieved, err := core.GetInstanceRole(ctx, "testmod")
+	retrieved, err := core.GetServerRole(ctx, "testmod")
 	if err != nil {
 		t.Fatalf("Failed to get role: %v", err)
 	}
@@ -1435,7 +1435,7 @@ func TestChattoCore_GetRole_NotFound(t *testing.T) {
 	core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
 
 	// Try to get nonexistent role
-	_, err := core.GetInstanceRole(ctx, "nonexistent")
+	_, err := core.GetServerRole(ctx, "nonexistent")
 	if err == nil {
 		t.Error("Expected error when getting nonexistent role")
 	}
@@ -1452,7 +1452,7 @@ func TestChattoCore_ListRoles(t *testing.T) {
 	core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
 
 	// Initially should have 4 default roles (owner, admin, moderator, everyone) created by CreateSpace
-	roles, err := core.ListInstanceRoles(ctx)
+	roles, err := core.ListServerRoles(ctx)
 	if err != nil {
 		t.Fatalf("Failed to list roles: %v", err)
 	}
@@ -1461,11 +1461,11 @@ func TestChattoCore_ListRoles(t *testing.T) {
 	}
 
 	// Create some additional roles
-	core.CreateInstanceRole(ctx, "testmod", "Test Mod", "Test mod role")
-	core.CreateInstanceRole(ctx, "vip", "VIP", "VIP role")
+	core.CreateServerRole(ctx, "testmod", "Test Mod", "Test mod role")
+	core.CreateServerRole(ctx, "vip", "VIP", "VIP role")
 
 	// List again - should have 6 total (4 default + 2 custom)
-	roles, err = core.ListInstanceRoles(ctx)
+	roles, err = core.ListServerRoles(ctx)
 	if err != nil {
 		t.Fatalf("Failed to list roles: %v", err)
 	}
@@ -1481,13 +1481,13 @@ func TestChattoCore_UpdateRole(t *testing.T) {
 	core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
 
 	// Create a role
-	_, err := core.CreateInstanceRole(ctx, "testmod", "Test Mod", "Can moderate content")
+	_, err := core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate content")
 	if err != nil {
 		t.Fatalf("Failed to create role: %v", err)
 	}
 
 	// Update it
-	updated, err := core.UpdateInstanceRole(ctx, "testmod", "Super Moderator", "Enhanced moderation")
+	updated, err := core.UpdateServerRole(ctx, "testmod", "Super Moderator", "Enhanced moderation")
 	if err != nil {
 		t.Fatalf("Failed to update role: %v", err)
 	}
@@ -1505,7 +1505,7 @@ func TestChattoCore_UpdateRole(t *testing.T) {
 	}
 
 	// Verify persisted
-	retrieved, _ := core.GetInstanceRole(ctx, "testmod")
+	retrieved, _ := core.GetServerRole(ctx, "testmod")
 	if retrieved.DisplayName != "Super Moderator" {
 		t.Error("Update was not persisted")
 	}
@@ -1518,19 +1518,19 @@ func TestChattoCore_DeleteRole(t *testing.T) {
 	core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
 
 	// Create a role
-	_, err := core.CreateInstanceRole(ctx, "testmod", "Test Mod", "Can moderate content")
+	_, err := core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate content")
 	if err != nil {
 		t.Fatalf("Failed to create role: %v", err)
 	}
 
 	// Delete it
-	err = core.DeleteInstanceRole(ctx, "testmod")
+	err = core.DeleteServerRole(ctx, "testmod")
 	if err != nil {
 		t.Fatalf("Failed to delete role: %v", err)
 	}
 
 	// Verify it's gone
-	_, err = core.GetInstanceRole(ctx, "testmod")
+	_, err = core.GetServerRole(ctx, "testmod")
 	if !errors.Is(err, ErrRoleNotFound) {
 		t.Error("Role should not exist after deletion")
 	}
@@ -1544,13 +1544,13 @@ func TestChattoCore_DeleteRole_SystemRole(t *testing.T) {
 
 	// Admin role is automatically created by CreateSpace via CreateDefaultRoles
 	// Verify it exists
-	_, err := core.GetInstanceRole(ctx, RoleOwner)
+	_, err := core.GetServerRole(ctx, RoleOwner)
 	if err != nil {
 		t.Fatalf("Admin role should exist after CreateSpace: %v", err)
 	}
 
 	// Try to delete - should fail
-	err = core.DeleteInstanceRole(ctx, RoleOwner)
+	err = core.DeleteServerRole(ctx, RoleOwner)
 	if err == nil {
 		t.Error("Expected error when deleting system role")
 	}
@@ -1560,7 +1560,7 @@ func TestChattoCore_DeleteRole_SystemRole(t *testing.T) {
 	}
 
 	// Also test everyone role
-	err = core.DeleteInstanceRole(ctx, RoleEveryone)
+	err = core.DeleteServerRole(ctx, RoleEveryone)
 	if !errors.Is(err, ErrCannotDeleteSystemRole) {
 		t.Errorf("Expected ErrCannotDeleteSystemRole for everyone role, got %v", err)
 	}
@@ -1574,7 +1574,7 @@ func TestChattoCore_DeleteRole_CleansUpPermissionsAndAssignments(t *testing.T) {
 	core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
 
 	// Create a role, grant permissions, and assign to a user
-	_, err := core.CreateInstanceRole(ctx, "testmod", "Test Mod", "Can moderate")
+	_, err := core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
 	if err != nil {
 		t.Fatalf("Failed to create role: %v", err)
 	}
@@ -1584,10 +1584,10 @@ func TestChattoCore_DeleteRole_CleansUpPermissionsAndAssignments(t *testing.T) {
 	core.GrantInstancePermission(ctx, "testmod", PermRoomManage)
 
 	// Assign role to a user
-	core.AssignInstanceRole(ctx, "test-user", "test-user", "testmod")
+	core.AssignServerRole(ctx, "test-user", "test-user", "testmod")
 
 	// Verify permissions and assignment exist
-	perms, _ := core.GetInstanceRolePermissions(ctx, "testmod")
+	perms, _ := core.GetServerRolePermissions(ctx, "testmod")
 	if len(perms) != 2 {
 		t.Fatalf("Expected 2 permissions, got %d", len(perms))
 	}
@@ -1605,13 +1605,13 @@ func TestChattoCore_DeleteRole_CleansUpPermissionsAndAssignments(t *testing.T) {
 	}
 
 	// Delete the role
-	err = core.DeleteInstanceRole(ctx, "testmod")
+	err = core.DeleteServerRole(ctx, "testmod")
 	if err != nil {
 		t.Fatalf("Failed to delete role: %v", err)
 	}
 
 	// Verify permissions are cleaned up
-	perms, _ = core.GetInstanceRolePermissions(ctx, "testmod")
+	perms, _ = core.GetServerRolePermissions(ctx, "testmod")
 	if len(perms) != 0 {
 		t.Errorf("Expected 0 permissions after role deletion, got %d", len(perms))
 	}
@@ -1634,7 +1634,7 @@ func TestChattoCore_GrantRolePermission(t *testing.T) {
 	ctx := testContext(t)
 
 	core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
-	core.CreateInstanceRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
 
 	// Grant a permission
 	err := core.GrantInstancePermission(ctx, "testmod", PermRoleAssign)
@@ -1643,7 +1643,7 @@ func TestChattoCore_GrantRolePermission(t *testing.T) {
 	}
 
 	// Verify it was granted
-	perms, err := core.GetInstanceRolePermissions(ctx, "testmod")
+	perms, err := core.GetServerRolePermissions(ctx, "testmod")
 	if err != nil {
 		t.Fatalf("Failed to get permissions: %v", err)
 	}
@@ -1662,7 +1662,7 @@ func TestChattoCore_GrantRolePermission_Idempotent(t *testing.T) {
 	ctx := testContext(t)
 
 	core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
-	core.CreateInstanceRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
 
 	// Grant same permission twice
 	core.GrantInstancePermission(ctx, "testmod", PermRoleAssign)
@@ -1672,7 +1672,7 @@ func TestChattoCore_GrantRolePermission_Idempotent(t *testing.T) {
 	}
 
 	// Should still have only one permission
-	perms, _ := core.GetInstanceRolePermissions(ctx, "testmod")
+	perms, _ := core.GetServerRolePermissions(ctx, "testmod")
 	if len(perms) != 1 {
 		t.Errorf("Expected 1 permission after duplicate grant, got %d", len(perms))
 	}
@@ -1689,7 +1689,7 @@ func TestChattoCore_GrantRolePermission_InvalidPermission(t *testing.T) {
 	ctx := testContext(t)
 
 	core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
-	core.CreateInstanceRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
 
 	// Try to grant an invalid permission
 	err := core.GrantInstancePermission(ctx, "testmod", Permission("invalid_perm"))
@@ -1708,7 +1708,7 @@ func TestChattoCore_RevokeRolePermission(t *testing.T) {
 	ctx := testContext(t)
 
 	core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
-	core.CreateInstanceRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
 
 	// Grant then revoke
 	core.GrantInstancePermission(ctx, "testmod", PermRoleAssign)
@@ -1718,7 +1718,7 @@ func TestChattoCore_RevokeRolePermission(t *testing.T) {
 	}
 
 	// Verify it was revoked
-	perms, _ := core.GetInstanceRolePermissions(ctx, "testmod")
+	perms, _ := core.GetServerRolePermissions(ctx, "testmod")
 	if len(perms) != 0 {
 		t.Errorf("Expected 0 permissions after revoke, got %d", len(perms))
 	}
@@ -1729,7 +1729,7 @@ func TestChattoCore_RevokeRolePermission_Idempotent(t *testing.T) {
 	ctx := testContext(t)
 
 	core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
-	core.CreateInstanceRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
 
 	// Revoke permission that was never granted
 	err := core.RevokeInstancePermission(ctx, "testmod", PermRoleAssign)
@@ -1743,14 +1743,14 @@ func TestChattoCore_GetRolePermissions_Multiple(t *testing.T) {
 	ctx := testContext(t)
 
 	core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
-	core.CreateInstanceRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
 
 	// Grant multiple permissions
 	core.GrantInstancePermission(ctx, "testmod", PermRoomList)
 	core.GrantInstancePermission(ctx, "testmod", PermRoleAssign)
 	core.GrantInstancePermission(ctx, "testmod", PermRoomManage)
 
-	perms, err := core.GetInstanceRolePermissions(ctx, "testmod")
+	perms, err := core.GetServerRolePermissions(ctx, "testmod")
 	if err != nil {
 		t.Fatalf("Failed to get permissions: %v", err)
 	}
@@ -1781,10 +1781,10 @@ func TestChattoCore_GetRolePermissions_Empty(t *testing.T) {
 	ctx := testContext(t)
 
 	core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
-	core.CreateInstanceRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
 
 	// No permissions granted yet
-	perms, err := core.GetInstanceRolePermissions(ctx, "testmod")
+	perms, err := core.GetServerRolePermissions(ctx, "testmod")
 	if err != nil {
 		t.Fatalf("Failed to get permissions: %v", err)
 	}
@@ -1803,10 +1803,10 @@ func TestChattoCore_AssignRole(t *testing.T) {
 	ctx := testContext(t)
 
 	core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
-	core.CreateInstanceRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
 
 	// Assign role to user
-	err := core.AssignInstanceRole(ctx, "test-user", "user123", "testmod")
+	err := core.AssignServerRole(ctx, "test-user", "user123", "testmod")
 	if err != nil {
 		t.Fatalf("Failed to assign role: %v", err)
 	}
@@ -1831,11 +1831,11 @@ func TestChattoCore_AssignRole_Idempotent(t *testing.T) {
 	ctx := testContext(t)
 
 	core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
-	core.CreateInstanceRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
 
 	// Assign same role twice
-	core.AssignInstanceRole(ctx, "test-user", "user123", "testmod")
-	err := core.AssignInstanceRole(ctx, "test-user", "user123", "testmod")
+	core.AssignServerRole(ctx, "test-user", "user123", "testmod")
+	err := core.AssignServerRole(ctx, "test-user", "user123", "testmod")
 	if err != nil {
 		t.Fatalf("Second assign should not fail: %v", err)
 	}
@@ -1854,7 +1854,7 @@ func TestChattoCore_AssignRole_RoleNotFound(t *testing.T) {
 	core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
 
 	// Try to assign nonexistent role
-	err := core.AssignInstanceRole(ctx, "test-user", "user123", "nonexistent")
+	err := core.AssignServerRole(ctx, "test-user", "user123", "nonexistent")
 	if !errors.Is(err, ErrRoleNotFound) {
 		t.Errorf("Expected ErrRoleNotFound, got %v", err)
 	}
@@ -1865,11 +1865,11 @@ func TestChattoCore_RevokeRole(t *testing.T) {
 	ctx := testContext(t)
 
 	core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
-	core.CreateInstanceRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
 
 	// Assign then revoke
-	core.AssignInstanceRole(ctx, "test-user", "user123", "testmod")
-	err := core.RevokeInstanceRole(ctx, "test-user", "user123", "testmod")
+	core.AssignServerRole(ctx, "test-user", "user123", "testmod")
+	err := core.RevokeServerRole(ctx, "test-user", "user123", "testmod")
 	if err != nil {
 		t.Fatalf("Failed to revoke role: %v", err)
 	}
@@ -1886,10 +1886,10 @@ func TestChattoCore_RevokeRole_Idempotent(t *testing.T) {
 	ctx := testContext(t)
 
 	core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
-	core.CreateInstanceRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
 
 	// Revoke role that was never assigned
-	err := core.RevokeInstanceRole(ctx, "test-user", "user123", "testmod")
+	err := core.RevokeServerRole(ctx, "test-user", "user123", "testmod")
 	if err != nil {
 		t.Fatalf("Revoking non-assigned role should not fail: %v", err)
 	}
@@ -1904,13 +1904,13 @@ func TestChattoCore_RevokeRole_AdminCannotDemotePeerAdmin(t *testing.T) {
 	// Create two admins (must be space members for permission checks)
 	adminA := "admin-a"
 	adminB := "admin-b"
-	core.AssignInstanceRole(ctx, SystemActorID, adminA, RoleOwner)
-	core.AssignInstanceRole(ctx, SystemActorID, adminB, RoleOwner)
+	core.AssignServerRole(ctx, SystemActorID, adminA, RoleOwner)
+	core.AssignServerRole(ctx, SystemActorID, adminB, RoleOwner)
 
 	// Admin A should NOT be able to revoke admin role from Admin B (peer)
 	// Owner can manage the owner role (role hierarchy passes), but can't demote a peer
 	// (user hierarchy blocks it since both are at position 0)
-	err := core.RevokeInstanceRole(ctx, adminA, adminB, RoleOwner)
+	err := core.RevokeServerRole(ctx, adminA, adminB, RoleOwner)
 	if !errors.Is(err, ErrCannotManageHigherUser) {
 		t.Errorf("Expected ErrCannotManageHigherUser when owner tries to revoke peer's owner role, got: %v", err)
 	}
@@ -1938,14 +1938,14 @@ func TestChattoCore_RevokeRole_AdminCanDemoteLowerRankedUser(t *testing.T) {
 	// Create admin and moderator (must be space members for permission checks)
 	admin := "admin-user"
 	mod := "mod-user"
-	core.AssignInstanceRole(ctx, SystemActorID, admin, RoleOwner)
+	core.AssignServerRole(ctx, SystemActorID, admin, RoleOwner)
 	// moderator role is created by default with position 1
 
 	// Assign moderator role to mod user
-	core.AssignInstanceRole(ctx, SystemActorID, mod, "moderator")
+	core.AssignServerRole(ctx, SystemActorID, mod, "moderator")
 
 	// Admin SHOULD be able to revoke moderator role from the lower-ranked user
-	err := core.RevokeInstanceRole(ctx, admin, mod, "moderator")
+	err := core.RevokeServerRole(ctx, admin, mod, "moderator")
 	if err != nil {
 		t.Errorf("Admin should be able to revoke role from lower-ranked user, got: %v", err)
 	}
@@ -1964,12 +1964,12 @@ func TestChattoCore_GetUserRoles_Multiple(t *testing.T) {
 	ctx := testContext(t)
 
 	core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
-	core.CreateInstanceRole(ctx, "testmod", "Test Mod", "Can moderate")
-	core.CreateInstanceRole(ctx, "vip", "VIP", "VIP user")
+	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, "vip", "VIP", "VIP user")
 
 	// Assign multiple roles
-	core.AssignInstanceRole(ctx, "test-user", "user123", "testmod")
-	core.AssignInstanceRole(ctx, "test-user", "user123", "vip")
+	core.AssignServerRole(ctx, "test-user", "user123", "testmod")
+	core.AssignServerRole(ctx, "test-user", "user123", "vip")
 
 	roles, err := core.GetUserRoles(ctx, "user123")
 	if err != nil {
@@ -1999,12 +1999,12 @@ func TestChattoCore_GetRoleUsers(t *testing.T) {
 	ctx := testContext(t)
 
 	core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
-	core.CreateInstanceRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
 
 	// Assign role to multiple users
-	core.AssignInstanceRole(ctx, "test-user", "user1", "testmod")
-	core.AssignInstanceRole(ctx, "test-user", "user2", "testmod")
-	core.AssignInstanceRole(ctx, "test-user", "user3", "testmod")
+	core.AssignServerRole(ctx, "test-user", "user1", "testmod")
+	core.AssignServerRole(ctx, "test-user", "user2", "testmod")
+	core.AssignServerRole(ctx, "test-user", "user3", "testmod")
 
 	users, err := core.GetRoleUsers(ctx, "testmod")
 	if err != nil {
@@ -2031,7 +2031,7 @@ func TestChattoCore_GetRoleUsers_Empty(t *testing.T) {
 	ctx := testContext(t)
 
 	core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
-	core.CreateInstanceRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
 
 	// No users assigned yet
 	users, err := core.GetRoleUsers(ctx, "testmod")
@@ -2053,9 +2053,9 @@ func TestChattoCore_hasSpacePermission(t *testing.T) {
 	ctx := testContext(t)
 
 	space, _ := core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
-	core.CreateInstanceRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
 	core.GrantInstancePermission(ctx, "testmod", PermRoleAssign)
-	core.AssignInstanceRole(ctx, "test-user", "user123", "testmod")
+	core.AssignServerRole(ctx, "test-user", "user123", "testmod")
 
 	// User should have the permission
 	has, err := core.hasSpacePermission(ctx, space.Id, "user123", PermRoleAssign)
@@ -2084,15 +2084,15 @@ func TestChattoCore_hasSpacePermission_MultipleRoles(t *testing.T) {
 
 
 	// Create two roles with different permissions
-	core.CreateInstanceRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
 	core.GrantInstancePermission(ctx, "testmod", PermRoleAssign)
 
-	core.CreateInstanceRole(ctx, "admin", "Admin", "Full access")
+	core.CreateServerRole(ctx, "admin", "Admin", "Full access")
 	core.GrantInstancePermission(ctx, "admin", PermSpaceManage)
 
 	// Assign both roles to user
-	core.AssignInstanceRole(ctx, "test-user", "user123", "testmod")
-	core.AssignInstanceRole(ctx, "test-user", "user123", "admin")
+	core.AssignServerRole(ctx, "test-user", "user123", "testmod")
+	core.AssignServerRole(ctx, "test-user", "user123", "admin")
 
 	// User should have permissions from both roles
 	has, _ := core.hasSpacePermission(ctx, space.Id, "user123", PermRoleAssign)
@@ -2119,7 +2119,7 @@ func TestChattoCore_CreateDefaultRoles(t *testing.T) {
 	space, _ := core.CreateSpace(ctx, "test-user", "Test Space", "A test space")
 
 	// Verify admin role exists
-	adminRole, err := core.GetInstanceRole(ctx, RoleOwner)
+	adminRole, err := core.GetServerRole(ctx, RoleOwner)
 	if err != nil {
 		t.Fatalf("Failed to get admin role: %v", err)
 	}
@@ -2143,7 +2143,7 @@ func TestChattoCore_CreateDefaultRoles(t *testing.T) {
 	}
 
 	// Verify everyone role exists with explicit default permissions
-	everyoneRole, err := core.GetInstanceRole(ctx, RoleEveryone)
+	everyoneRole, err := core.GetServerRole(ctx, RoleEveryone)
 	if err != nil {
 		t.Fatalf("Failed to get everyone role: %v", err)
 	}
@@ -2151,7 +2151,7 @@ func TestChattoCore_CreateDefaultRoles(t *testing.T) {
 		t.Errorf("Expected everyone role name '%s', got '%s'", RoleEveryone, everyoneRole.Name)
 	}
 
-	everyonePerms, _ := core.GetInstanceRolePermissions(ctx, RoleEveryone)
+	everyonePerms, _ := core.GetServerRolePermissions(ctx, RoleEveryone)
 	// Post-Phase-5: instance + space defaults both seed against the same
 	// SERVER_RBAC bucket, so `everyone` ends up with the union of both
 	// default sets. We just sanity-check it's non-empty rather than pinning
@@ -2360,13 +2360,13 @@ func TestChattoCore_GetUserEffectiveSpacePermissions_SpaceRoles(t *testing.T) {
 	}
 }
 
-func TestChattoCore_GetUserEffectiveSpacePermissions_InstanceRoleGrants(t *testing.T) {
+func TestChattoCore_GetUserEffectiveSpacePermissions_ServerRoleGrants(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
 	// Create a user with moderator instance role
 	user, _ := core.CreateUser(ctx, SystemActorID, "staffuser", "Staff User", "password123")
-	core.AssignInstanceRole(ctx, SystemActorID, user.Id, RoleModerator)
+	core.AssignServerRole(ctx, SystemActorID, user.Id, RoleModerator)
 
 	// Create a space
 	creator, _ := core.CreateUser(ctx, SystemActorID, "creator2", "Creator", "password123")
@@ -2449,13 +2449,13 @@ func TestChattoCore_GetUserEffectiveSpacePermissions_DenyAlwaysWins(t *testing.T
 	}
 }
 
-func TestChattoCore_GetUserEffectiveSpacePermissions_InstanceRoleDenialInSpace(t *testing.T) {
+func TestChattoCore_GetUserEffectiveSpacePermissions_ServerRoleDenialInSpace(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
 	// Create a user with moderator instance role
 	user, _ := core.CreateUser(ctx, SystemActorID, "verifieduser", "Verified User", "password123")
-	core.AssignInstanceRole(ctx, SystemActorID, user.Id, RoleModerator)
+	core.AssignServerRole(ctx, SystemActorID, user.Id, RoleModerator)
 
 	// Create a space
 	creator, _ := core.CreateUser(ctx, SystemActorID, "creator4", "Creator", "password123")
@@ -2508,26 +2508,26 @@ func TestChattoCore_AssignRole_HierarchyEnforcement(t *testing.T) {
 	regular := "regular-user"
 
 	// Give owner the owner role (position 0) - owners have all permissions
-	core.AssignInstanceRole(ctx, SystemActorID, owner, RoleOwner)
+	core.AssignServerRole(ctx, SystemActorID, owner, RoleOwner)
 	// Give mod the moderator role (position ~1)
-	core.AssignInstanceRole(ctx, SystemActorID, mod, RoleModerator)
+	core.AssignServerRole(ctx, SystemActorID, mod, RoleModerator)
 
 	// Grant role assignment permission to moderator so we can test hierarchy
 	core.GrantInstancePermission(ctx, RoleModerator, PermRoleAssign)
 
 	t.Run("owner can assign moderator role", func(t *testing.T) {
 		// Owner (position 0) can assign moderator
-		err := core.AssignInstanceRole(ctx, owner, regular, RoleModerator)
+		err := core.AssignServerRole(ctx, owner, regular, RoleModerator)
 		if err != nil {
 			t.Errorf("Owner should be able to assign moderator role: %v", err)
 		}
 		// Cleanup
-		core.RevokeInstanceRole(ctx, owner, regular, RoleModerator)
+		core.RevokeServerRole(ctx, owner, regular, RoleModerator)
 	})
 
 	t.Run("moderator cannot assign owner role due to hierarchy", func(t *testing.T) {
 		// Moderator has permission but cannot assign owner (higher rank)
-		err := core.AssignInstanceRole(ctx, mod, regular, RoleOwner)
+		err := core.AssignServerRole(ctx, mod, regular, RoleOwner)
 		if !errors.Is(err, ErrCannotAssignHigherRole) {
 			t.Errorf("Expected ErrCannotAssignHigherRole, got: %v", err)
 		}
@@ -2535,11 +2535,11 @@ func TestChattoCore_AssignRole_HierarchyEnforcement(t *testing.T) {
 
 	t.Run("regular member without explicit roles is blocked by role hierarchy", func(t *testing.T) {
 		// Create a custom role
-		core.CreateInstanceRole(ctx, "helper", "Helper", "Can help")
+		core.CreateServerRole(ctx, "helper", "Helper", "Can help")
 
 		// Regular member only has the implicit "everyone" role (max position),
 		// which cannot manage any concrete role.
-		err := core.AssignInstanceRole(ctx, regular, mod, "helper")
+		err := core.AssignServerRole(ctx, regular, mod, "helper")
 		if !errors.Is(err, ErrCannotAssignHigherRole) {
 			t.Errorf("Expected ErrCannotAssignHigherRole for regular member, got: %v", err)
 		}
@@ -2547,7 +2547,7 @@ func TestChattoCore_AssignRole_HierarchyEnforcement(t *testing.T) {
 
 	t.Run("moderator can assign lower-ranked custom role", func(t *testing.T) {
 		// Create a custom role (will be lower rank than moderator)
-		role, _ := core.CreateInstanceRole(ctx, "editor", "Editor", "Can edit")
+		role, _ := core.CreateServerRole(ctx, "editor", "Editor", "Can edit")
 		// Verify the custom role has a position lower than moderator
 		// (position is higher number = lower rank)
 		if role.Position <= 2 { // moderator is at 2
@@ -2555,7 +2555,7 @@ func TestChattoCore_AssignRole_HierarchyEnforcement(t *testing.T) {
 		}
 
 		// Mod should be able to assign editor (lower rank)
-		err := core.AssignInstanceRole(ctx, mod, regular, "editor")
+		err := core.AssignServerRole(ctx, mod, regular, "editor")
 		if err != nil {
 			t.Errorf("Moderator should be able to assign lower-ranked role: %v", err)
 		}
@@ -2570,10 +2570,10 @@ func TestChattoCore_RevokeRole_CannotDemoteSelf(t *testing.T) {
 
 	// Setup user with owner role
 	owner := "owner-user"
-	core.AssignInstanceRole(ctx, SystemActorID, owner, RoleOwner)
+	core.AssignServerRole(ctx, SystemActorID, owner, RoleOwner)
 
 	// Owner cannot revoke their own owner role - there's a specific check for this
-	err := core.RevokeInstanceRole(ctx, owner, owner, RoleOwner)
+	err := core.RevokeServerRole(ctx, owner, owner, RoleOwner)
 	if !errors.Is(err, ErrCannotRevokeSelfAdmin) {
 		t.Errorf("Expected ErrCannotRevokeSelfAdmin when revoking own owner role, got: %v", err)
 	}
@@ -2601,8 +2601,8 @@ func TestChattoCore_RevokeRole_PeerProtection(t *testing.T) {
 	// Setup two moderators
 	modA := "mod-a"
 	modB := "mod-b"
-	core.AssignInstanceRole(ctx, SystemActorID, modA, RoleModerator)
-	core.AssignInstanceRole(ctx, SystemActorID, modB, RoleModerator)
+	core.AssignServerRole(ctx, SystemActorID, modA, RoleModerator)
+	core.AssignServerRole(ctx, SystemActorID, modB, RoleModerator)
 
 	// Grant role assignment permission to moderators so we can test hierarchy
 	core.GrantInstancePermission(ctx, RoleModerator, PermRoleAssign)
@@ -2611,7 +2611,7 @@ func TestChattoCore_RevokeRole_PeerProtection(t *testing.T) {
 		// Both are equal rank (moderator), so neither can demote the other
 		// First check is "can't revoke role higher than yours" - but they're equal
 		// So the check that should fail is the hierarchy check on the role itself
-		err := core.RevokeInstanceRole(ctx, modA, modB, RoleModerator)
+		err := core.RevokeServerRole(ctx, modA, modB, RoleModerator)
 		// Either ErrCannotRevokeHigherRole (role hierarchy) or ErrCannotManageHigherUser (user hierarchy)
 		if err == nil {
 			t.Error("Expected error for peer demotion")
@@ -2622,7 +2622,7 @@ func TestChattoCore_RevokeRole_PeerProtection(t *testing.T) {
 	})
 
 	t.Run("vice versa - B cannot demote A", func(t *testing.T) {
-		err := core.RevokeInstanceRole(ctx, modB, modA, RoleModerator)
+		err := core.RevokeServerRole(ctx, modB, modA, RoleModerator)
 		if err == nil {
 			t.Error("Expected error for peer demotion (reverse)")
 		}
@@ -2660,7 +2660,7 @@ func TestChattoCore_CreateRole_PositionAssignment(t *testing.T) {
 
 	t.Run("first custom role gets position after system roles", func(t *testing.T) {
 		// System roles: owner (0), moderator (2), member (MAX)
-		role, err := core.CreateInstanceRole(ctx, "editor", "Editor", "Can edit")
+		role, err := core.CreateServerRole(ctx, "editor", "Editor", "Can edit")
 		if err != nil {
 			t.Fatalf("CreateRole failed: %v", err)
 		}
@@ -2674,14 +2674,14 @@ func TestChattoCore_CreateRole_PositionAssignment(t *testing.T) {
 	})
 
 	t.Run("position preserved after display name update", func(t *testing.T) {
-		role, err := core.CreateInstanceRole(ctx, "contributor", "Contributor", "Can contribute")
+		role, err := core.CreateServerRole(ctx, "contributor", "Contributor", "Can contribute")
 		if err != nil {
 			t.Fatalf("CreateRole failed: %v", err)
 		}
 		originalPos := role.Position
 
 		// Update display name
-		updated, err := core.UpdateInstanceRole(ctx, "contributor", "Super Contributor", "Can contribute a lot")
+		updated, err := core.UpdateServerRole(ctx, "contributor", "Super Contributor", "Can contribute a lot")
 		if err != nil {
 			t.Fatalf("UpdateRole failed: %v", err)
 		}
@@ -2691,15 +2691,15 @@ func TestChattoCore_CreateRole_PositionAssignment(t *testing.T) {
 		}
 	})
 
-	t.Run("roles can be reordered via ReorderInstanceRoles", func(t *testing.T) {
+	t.Run("roles can be reordered via ReorderServerRoles", func(t *testing.T) {
 		// Create multiple custom roles
-		core.CreateInstanceRole(ctx, "alpha", "Alpha", "Alpha role")
-		core.CreateInstanceRole(ctx, "beta", "Beta", "Beta role")
+		core.CreateServerRole(ctx, "alpha", "Alpha", "Alpha role")
+		core.CreateServerRole(ctx, "beta", "Beta", "Beta role")
 
 		// Reorder them
-		roles, err := core.ReorderInstanceRoles(ctx, []string{"beta", "alpha"})
+		roles, err := core.ReorderServerRoles(ctx, []string{"beta", "alpha"})
 		if err != nil {
-			t.Fatalf("ReorderInstanceRoles failed: %v", err)
+			t.Fatalf("ReorderServerRoles failed: %v", err)
 		}
 
 		var alphaPos, betaPos int32
@@ -2731,8 +2731,8 @@ func TestChattoCore_CanManageUser(t *testing.T) {
 	mod := "mod-user"
 	member := "member-user"
 
-	core.AssignInstanceRole(ctx, SystemActorID, owner, RoleOwner)
-	core.AssignInstanceRole(ctx, SystemActorID, mod, RoleModerator)
+	core.AssignServerRole(ctx, SystemActorID, owner, RoleOwner)
+	core.AssignServerRole(ctx, SystemActorID, mod, RoleModerator)
 	// member has no explicit role, just the implicit member role
 
 	t.Run("owner can manage all", func(t *testing.T) {
@@ -2774,7 +2774,7 @@ func TestChattoCore_CanManageUser(t *testing.T) {
 	t.Run("peers at same level cannot manage each other", func(t *testing.T) {
 		// Create another moderator
 		mod2 := "mod-user-2"
-		core.AssignInstanceRole(ctx, SystemActorID, mod2, RoleModerator)
+		core.AssignServerRole(ctx, SystemActorID, mod2, RoleModerator)
 
 		canManage, _ := core.CanManageUser(ctx, mod, mod2)
 		if canManage {

--- a/cli/internal/core/registration.go
+++ b/cli/internal/core/registration.go
@@ -53,7 +53,7 @@ func registrationTokenKey(token string) string {
 // ============================================================================
 
 // CreateRegistrationToken creates a new registration token for an email address.
-// The token is stored in instanceKV and can be used to complete account creation.
+// The token is stored in serverKV and can be used to complete account creation.
 //
 // Email is expected to already be normalized (trimmed, lowercased) by the caller —
 // the HTTP handlers do this at the request boundary.
@@ -74,7 +74,7 @@ func (c *ChattoCore) CreateRegistrationToken(ctx context.Context, email string) 
 		return "", fmt.Errorf("failed to marshal registration token: %w", err)
 	}
 
-	_, err = c.storage.instanceKV.Create(ctx, registrationTokenKey(token), data, jetstream.KeyTTL(RegistrationTokenTTL))
+	_, err = c.storage.serverKV.Create(ctx, registrationTokenKey(token), data, jetstream.KeyTTL(RegistrationTokenTTL))
 	if err != nil {
 		return "", fmt.Errorf("failed to store registration token: %w", err)
 	}
@@ -85,7 +85,7 @@ func (c *ChattoCore) CreateRegistrationToken(ctx context.Context, email string) 
 // GetRegistrationToken retrieves and validates a registration token.
 // Returns the token data including the email address.
 func (c *ChattoCore) GetRegistrationToken(ctx context.Context, token string) (*RegistrationToken, error) {
-	entry, err := c.storage.instanceKV.Get(ctx, registrationTokenKey(token))
+	entry, err := c.storage.serverKV.Get(ctx, registrationTokenKey(token))
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return nil, ErrRegistrationTokenNotFound
@@ -101,7 +101,7 @@ func (c *ChattoCore) GetRegistrationToken(ctx context.Context, token string) (*R
 	// Check if token has expired
 	if time.Since(tokenData.CreatedAt) > RegistrationTokenTTL {
 		// Clean up expired token
-		c.storage.instanceKV.Delete(ctx, registrationTokenKey(token))
+		c.storage.serverKV.Delete(ctx, registrationTokenKey(token))
 		return nil, ErrRegistrationTokenExpired
 	}
 
@@ -110,7 +110,7 @@ func (c *ChattoCore) GetRegistrationToken(ctx context.Context, token string) (*R
 
 // DeleteRegistrationToken removes a registration token after successful account creation.
 func (c *ChattoCore) DeleteRegistrationToken(ctx context.Context, token string) error {
-	err := c.storage.instanceKV.Delete(ctx, registrationTokenKey(token))
+	err := c.storage.serverKV.Delete(ctx, registrationTokenKey(token))
 	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
 		return fmt.Errorf("failed to delete registration token: %w", err)
 	}

--- a/cli/internal/core/registration_test.go
+++ b/cli/internal/core/registration_test.go
@@ -143,7 +143,7 @@ func TestChattoCore_RegistrationTokenExpiration(t *testing.T) {
 			t.Fatalf("Failed to create token: %v", err)
 		}
 
-		entry, err := core.storage.instanceKV.Get(ctx, registrationTokenKey(token))
+		entry, err := core.storage.serverKV.Get(ctx, registrationTokenKey(token))
 		if err != nil {
 			t.Fatalf("Failed to fetch entry: %v", err)
 		}

--- a/cli/internal/core/s3.go
+++ b/cli/internal/core/s3.go
@@ -197,9 +197,9 @@ func S3KeySpaceAttachment(spaceID, attachmentID string) string {
 	return fmt.Sprintf("spaces/%s/attachments/%s", spaceID, attachmentID)
 }
 
-// S3KeyInstanceAsset returns the S3 key for an instance asset (avatar, logo, banner).
+// S3KeyServerAsset returns the S3 key for an instance asset (avatar, logo, banner).
 // Format: instance/{assetId}
 // This matches the NATS key format so HTTP handlers can probe both backends with the same key.
-func S3KeyInstanceAsset(assetID string) string {
+func S3KeyServerAsset(assetID string) string {
 	return fmt.Sprintf("instance/%s", assetID)
 }

--- a/cli/internal/core/s3_test.go
+++ b/cli/internal/core/s3_test.go
@@ -183,7 +183,7 @@ func TestS3KeyHelpers(t *testing.T) {
 		{
 			name: "InstanceAsset",
 			function: func() string {
-				return core.S3KeyInstanceAsset("asset789")
+				return core.S3KeyServerAsset("asset789")
 			},
 			expected: "instance/asset789",
 		},
@@ -212,7 +212,7 @@ func TestStorageBackendEncapsulation_URLGeneration(t *testing.T) {
 	t.Run("S3 asset keys use consistent format for instance assets", func(t *testing.T) {
 		// Instance assets should all use the same key format: instance/{assetId}
 		assetID := "abc123xyz"
-		s3Key := core.S3KeyInstanceAsset(assetID)
+		s3Key := core.S3KeyServerAsset(assetID)
 		require.Equal(t, "instance/abc123xyz", s3Key)
 
 		// The URL format should be /assets/instance/{assetId}

--- a/cli/internal/core/server_branding.go
+++ b/cli/internal/core/server_branding.go
@@ -21,15 +21,15 @@ import (
 // bucket as space assets — only the KV pointer is keyed at the instance
 // level via these constants.
 const (
-	instanceLogoKey   = "instance.logo"
-	instanceBannerKey = "instance.banner"
+	serverLogoKey   = "instance.logo"
+	serverBannerKey = "instance.banner"
 )
 
-// UploadInstanceLogo processes a logo image (resize + WebP) and uploads the
-// bytes to the object store. Returns the asset reference. Use SetInstanceLogo
+// UploadServerLogo processes a logo image (resize + WebP) and uploads the
+// bytes to the object store. Returns the asset reference. Use SetServerLogo
 // to atomically swap the instance's logo pointer (and clean up the prior
 // asset).
-func (c *ChattoCore) UploadInstanceLogo(ctx context.Context, reader io.Reader) (*corev1.Asset, error) {
+func (c *ChattoCore) UploadServerLogo(ctx context.Context, reader io.Reader) (*corev1.Asset, error) {
 	webpReader, err := assets.ProcessLogoImageWithConfig(reader, c.AssetsConfig())
 	if err != nil {
 		return nil, fmt.Errorf("failed to process logo image: %w", err)
@@ -38,17 +38,17 @@ func (c *ChattoCore) UploadInstanceLogo(ctx context.Context, reader io.Reader) (
 	if err != nil {
 		return nil, fmt.Errorf("failed to read processed logo: %w", err)
 	}
-	return c.uploadInstanceAsset(ctx, webpData, "logo")
+	return c.uploadServerAsset(ctx, webpData, "logo")
 }
 
-// UploadInstanceBanner processes a banner image (resize + WebP) and uploads
+// UploadServerBanner processes a banner image (resize + WebP) and uploads
 // the bytes to the object store. Returns the asset reference. Use
-// SetInstanceBanner to atomically swap the instance's banner pointer (and
+// SetServerBanner to atomically swap the instance's banner pointer (and
 // clean up the prior asset).
 //
 // Banners double as the OG link-preview image, so they're processed at the
 // canonical 1200x630 OG aspect rather than the older 4:3 sidebar shape.
-func (c *ChattoCore) UploadInstanceBanner(ctx context.Context, reader io.Reader) (*corev1.Asset, error) {
+func (c *ChattoCore) UploadServerBanner(ctx context.Context, reader io.Reader) (*corev1.Asset, error) {
 	webpReader, err := assets.ProcessLinkPreviewImageWithConfig(reader, c.AssetsConfig())
 	if err != nil {
 		return nil, fmt.Errorf("failed to process banner image: %w", err)
@@ -57,17 +57,17 @@ func (c *ChattoCore) UploadInstanceBanner(ctx context.Context, reader io.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read processed banner: %w", err)
 	}
-	return c.uploadInstanceAsset(ctx, webpData, "banner")
+	return c.uploadServerAsset(ctx, webpData, "banner")
 }
 
-// uploadInstanceAsset routes processed image bytes to NATS or S3 based on
+// uploadServerAsset routes processed image bytes to NATS or S3 based on
 // configuration and returns the resulting asset reference. Used by the
 // instance-level logo and banner upload paths.
-func (c *ChattoCore) uploadInstanceAsset(ctx context.Context, webpData []byte, kind string) (*corev1.Asset, error) {
+func (c *ChattoCore) uploadServerAsset(ctx context.Context, webpData []byte, kind string) (*corev1.Asset, error) {
 	assetID := NewAssetID()
 
 	if c.ShouldUseS3() {
-		s3Key := S3KeyInstanceAsset(assetID)
+		s3Key := S3KeyServerAsset(assetID)
 		if _, err := c.s3Client.PutObjectFromBytes(ctx, s3Key, webpData, "image/webp"); err != nil {
 			return nil, fmt.Errorf("failed to upload %s to S3: %w", kind, err)
 		}
@@ -88,7 +88,7 @@ func (c *ChattoCore) uploadInstanceAsset(ctx context.Context, webpData []byte, k
 		Name:    assetID,
 		Headers: headers,
 	}
-	info, err := c.storage.instanceStore.Put(ctx, meta, bytes.NewReader(webpData))
+	info, err := c.storage.serverStore.Put(ctx, meta, bytes.NewReader(webpData))
 	if err != nil {
 		return nil, fmt.Errorf("failed to upload %s: %w", kind, err)
 	}
@@ -102,22 +102,22 @@ func (c *ChattoCore) uploadInstanceAsset(ctx context.Context, webpData []byte, k
 	}, nil
 }
 
-// SetInstanceLogo atomically points the instance at a new logo asset using
+// SetServerLogo atomically points the instance at a new logo asset using
 // optimistic locking, and cleans up the prior asset on success.
-func (c *ChattoCore) SetInstanceLogo(ctx context.Context, actorID string, asset *corev1.Asset) error {
-	return c.setInstanceBrandingAsset(ctx, actorID, instanceLogoKey, "logo", asset)
+func (c *ChattoCore) SetServerLogo(ctx context.Context, actorID string, asset *corev1.Asset) error {
+	return c.setServerBrandingAsset(ctx, actorID, serverLogoKey, "logo", asset)
 }
 
-// SetInstanceBanner atomically points the instance at a new banner asset
+// SetServerBanner atomically points the instance at a new banner asset
 // using optimistic locking, and cleans up the prior asset on success.
-func (c *ChattoCore) SetInstanceBanner(ctx context.Context, actorID string, asset *corev1.Asset) error {
-	return c.setInstanceBrandingAsset(ctx, actorID, instanceBannerKey, "banner", asset)
+func (c *ChattoCore) SetServerBanner(ctx context.Context, actorID string, asset *corev1.Asset) error {
+	return c.setServerBrandingAsset(ctx, actorID, serverBannerKey, "banner", asset)
 }
 
-// setInstanceBrandingAsset is the shared OCC swap implementation backing
-// SetInstanceLogo / SetInstanceBanner. Publishes ServerUpdatedEvent on
+// setServerBrandingAsset is the shared OCC swap implementation backing
+// SetServerLogo / SetServerBanner. Publishes ServerUpdatedEvent on
 // success so subscribers can refetch the updated branding.
-func (c *ChattoCore) setInstanceBrandingAsset(ctx context.Context, actorID, key, kind string, asset *corev1.Asset) error {
+func (c *ChattoCore) setServerBrandingAsset(ctx context.Context, actorID, key, kind string, asset *corev1.Asset) error {
 	const maxRetries = 5
 
 	assetData, err := proto.Marshal(asset)
@@ -129,7 +129,7 @@ func (c *ChattoCore) setInstanceBrandingAsset(ctx context.Context, actorID, key,
 		var revision uint64
 		var oldAsset *corev1.Asset
 
-		entry, err := c.storage.instanceKV.Get(ctx, key)
+		entry, err := c.storage.serverKV.Get(ctx, key)
 		if err == nil {
 			revision = entry.Revision()
 			oldAsset = &corev1.Asset{}
@@ -143,9 +143,9 @@ func (c *ChattoCore) setInstanceBrandingAsset(ctx context.Context, actorID, key,
 
 		var updateErr error
 		if revision == 0 {
-			_, updateErr = c.storage.instanceKV.Create(ctx, key, assetData)
+			_, updateErr = c.storage.serverKV.Create(ctx, key, assetData)
 		} else {
-			_, updateErr = c.storage.instanceKV.Update(ctx, key, assetData, revision)
+			_, updateErr = c.storage.serverKV.Update(ctx, key, assetData, revision)
 		}
 
 		if updateErr == nil {
@@ -168,20 +168,20 @@ func (c *ChattoCore) setInstanceBrandingAsset(ctx context.Context, actorID, key,
 	return fmt.Errorf("failed to update %s after %d retries due to concurrent modifications", kind, maxRetries)
 }
 
-// GetInstanceLogo returns the asset reference for the instance's current
+// GetServerLogo returns the asset reference for the instance's current
 // logo, or (nil, nil) if no logo is set.
-func (c *ChattoCore) GetInstanceLogo(ctx context.Context) (*corev1.Asset, error) {
-	return c.getInstanceBrandingAsset(ctx, instanceLogoKey, "logo")
+func (c *ChattoCore) GetServerLogo(ctx context.Context) (*corev1.Asset, error) {
+	return c.getServerBrandingAsset(ctx, serverLogoKey, "logo")
 }
 
-// GetInstanceBanner returns the asset reference for the instance's current
+// GetServerBanner returns the asset reference for the instance's current
 // banner, or (nil, nil) if no banner is set.
-func (c *ChattoCore) GetInstanceBanner(ctx context.Context) (*corev1.Asset, error) {
-	return c.getInstanceBrandingAsset(ctx, instanceBannerKey, "banner")
+func (c *ChattoCore) GetServerBanner(ctx context.Context) (*corev1.Asset, error) {
+	return c.getServerBrandingAsset(ctx, serverBannerKey, "banner")
 }
 
-func (c *ChattoCore) getInstanceBrandingAsset(ctx context.Context, key, kind string) (*corev1.Asset, error) {
-	entry, err := c.storage.instanceKV.Get(ctx, key)
+func (c *ChattoCore) getServerBrandingAsset(ctx context.Context, key, kind string) (*corev1.Asset, error) {
+	entry, err := c.storage.serverKV.Get(ctx, key)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return nil, nil
@@ -195,58 +195,58 @@ func (c *ChattoCore) getInstanceBrandingAsset(ctx context.Context, key, kind str
 	return asset, nil
 }
 
-// GetInstanceLogoURL returns the URL for the instance's logo, optionally
+// GetServerLogoURL returns the URL for the instance's logo, optionally
 // transformed to the given dimensions. Returns empty string when no logo
 // is set.
-func (c *ChattoCore) GetInstanceLogoURL(ctx context.Context, width, height *int) (string, error) {
-	logo, err := c.GetInstanceLogo(ctx)
+func (c *ChattoCore) GetServerLogoURL(ctx context.Context, width, height *int) (string, error) {
+	logo, err := c.GetServerLogo(ctx)
 	if err != nil || logo == nil {
 		return "", err
 	}
-	return c.instanceAssetURL(logo, width, height), nil
+	return c.serverAssetURL(logo, width, height), nil
 }
 
-// GetInstanceBannerURL returns the URL for the instance's banner, optionally
+// GetServerBannerURL returns the URL for the instance's banner, optionally
 // transformed to the given dimensions. Returns empty string when no banner
 // is set.
-func (c *ChattoCore) GetInstanceBannerURL(ctx context.Context, width, height *int) (string, error) {
-	banner, err := c.GetInstanceBanner(ctx)
+func (c *ChattoCore) GetServerBannerURL(ctx context.Context, width, height *int) (string, error) {
+	banner, err := c.GetServerBanner(ctx)
 	if err != nil || banner == nil {
 		return "", err
 	}
-	return c.instanceAssetURL(banner, width, height), nil
+	return c.serverAssetURL(banner, width, height), nil
 }
 
-// instanceAssetURL builds the public URL for an instance-scoped asset,
+// serverAssetURL builds the public URL for an instance-scoped asset,
 // optionally with transform parameters.
-func (c *ChattoCore) instanceAssetURL(asset *corev1.Asset, width, height *int) string {
+func (c *ChattoCore) serverAssetURL(asset *corev1.Asset, width, height *int) string {
 	assetID := assetIDFromAsset(asset)
 	if assetID == "" {
 		return ""
 	}
 	if width != nil && height != nil {
-		return c.GetTransformedInstanceAssetURL(assetID, *width, *height, "cover")
+		return c.GetTransformedServerAssetURL(assetID, *width, *height, "cover")
 	}
 	return c.assetURL(fmt.Sprintf("/assets/instance/%s", assetID))
 }
 
-// DeleteInstanceLogo clears the instance's logo (KV pointer + object-store
+// DeleteServerLogo clears the instance's logo (KV pointer + object-store
 // asset). No-op when no logo is set.
-func (c *ChattoCore) DeleteInstanceLogo(ctx context.Context, actorID string) error {
-	return c.deleteInstanceBrandingAsset(ctx, actorID, instanceLogoKey, "logo")
+func (c *ChattoCore) DeleteServerLogo(ctx context.Context, actorID string) error {
+	return c.deleteServerBrandingAsset(ctx, actorID, serverLogoKey, "logo")
 }
 
-// DeleteInstanceBanner clears the instance's banner. No-op when no banner
+// DeleteServerBanner clears the instance's banner. No-op when no banner
 // is set.
-func (c *ChattoCore) DeleteInstanceBanner(ctx context.Context, actorID string) error {
-	return c.deleteInstanceBrandingAsset(ctx, actorID, instanceBannerKey, "banner")
+func (c *ChattoCore) DeleteServerBanner(ctx context.Context, actorID string) error {
+	return c.deleteServerBrandingAsset(ctx, actorID, serverBannerKey, "banner")
 }
 
-func (c *ChattoCore) deleteInstanceBrandingAsset(ctx context.Context, actorID, key, kind string) error {
+func (c *ChattoCore) deleteServerBrandingAsset(ctx context.Context, actorID, key, kind string) error {
 	const maxRetries = 5
 
 	for attempt := 0; attempt < maxRetries; attempt++ {
-		entry, err := c.storage.instanceKV.Get(ctx, key)
+		entry, err := c.storage.serverKV.Get(ctx, key)
 		if err != nil {
 			if errors.Is(err, jetstream.ErrKeyNotFound) {
 				return nil
@@ -260,7 +260,7 @@ func (c *ChattoCore) deleteInstanceBrandingAsset(ctx context.Context, actorID, k
 			c.logger.Warn("Failed to unmarshal "+kind+" asset for deletion", "error", unmarshalErr)
 		}
 
-		if deleteErr := c.storage.instanceKV.Delete(ctx, key, jetstream.LastRevision(revision)); deleteErr == nil {
+		if deleteErr := c.storage.serverKV.Delete(ctx, key, jetstream.LastRevision(revision)); deleteErr == nil {
 			c.deleteAsset(ctx, asset, kind, "instance")
 			c.publishServerBrandingUpdate(ctx, actorID)
 			c.logger.Info("Deleted instance " + kind)
@@ -298,12 +298,12 @@ func (c *ChattoCore) publishServerBrandingUpdate(ctx context.Context, actorID st
 		}
 	}
 
-	logoURL, err := c.GetInstanceLogoURL(ctx, nil, nil)
+	logoURL, err := c.GetServerLogoURL(ctx, nil, nil)
 	if err != nil {
 		c.logger.Warn("failed to get instance logo URL for update event", "error", err)
 		logoURL = ""
 	}
-	bannerURL, err := c.GetInstanceBannerURL(ctx, nil, nil)
+	bannerURL, err := c.GetServerBannerURL(ctx, nil, nil)
 	if err != nil {
 		c.logger.Warn("failed to get instance banner URL for update event", "error", err)
 		bannerURL = ""

--- a/cli/internal/core/spaces.go
+++ b/cli/internal/core/spaces.go
@@ -62,7 +62,7 @@ func (c *ChattoCore) storeSpaceAndCreateStream(ctx context.Context, space *corev
 	}
 
 	if atomic {
-		_, err = c.storage.instanceKV.Create(ctx, spaceKey(space.Id), spaceData)
+		_, err = c.storage.serverKV.Create(ctx, spaceKey(space.Id), spaceData)
 		if err != nil {
 			if errors.Is(err, jetstream.ErrKeyExists) {
 				return false, nil // Already exists, not an error
@@ -70,7 +70,7 @@ func (c *ChattoCore) storeSpaceAndCreateStream(ctx context.Context, space *corev
 			return false, fmt.Errorf("failed to store space: %w", err)
 		}
 	} else {
-		_, err = c.storage.instanceKV.Put(ctx, spaceKey(space.Id), spaceData)
+		_, err = c.storage.serverKV.Put(ctx, spaceKey(space.Id), spaceData)
 		if err != nil {
 			return false, fmt.Errorf("failed to store space: %w", err)
 		}
@@ -112,7 +112,7 @@ func (c *ChattoCore) CreateSpace(ctx context.Context, actorID string, name strin
 	c.AutoJoinDefaultRooms(ctx, space.Id, actorID)
 
 	// Assign owner role to creator (SystemActorID bypasses permission check - bootstrap mode)
-	if err := c.AssignInstanceRole(ctx, SystemActorID, actorID, RoleOwner); err != nil {
+	if err := c.AssignServerRole(ctx, SystemActorID, actorID, RoleOwner); err != nil {
 		return nil, fmt.Errorf("failed to assign owner role to creator: %w", err)
 	}
 
@@ -169,7 +169,7 @@ func (c *ChattoCore) UpdateSpace(ctx context.Context, actorID string, space_id s
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal space: %w", err)
 	}
-	_, err = c.storage.instanceKV.Put(ctx, spaceKey(space.Id), spaceData)
+	_, err = c.storage.serverKV.Put(ctx, spaceKey(space.Id), spaceData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update space: %w", err)
 	}
@@ -195,7 +195,7 @@ func (c *ChattoCore) DeleteSpace(ctx context.Context, actorID string, space_id s
 	// Delete from KV store (source of truth). All space data lives in the
 	// shared SERVER_* buckets, so there's no per-space resource cleanup to
 	// do here — the space record itself is the only artifact.
-	if err := c.storage.instanceKV.Delete(ctx, spaceKey(space_id)); err != nil {
+	if err := c.storage.serverKV.Delete(ctx, spaceKey(space_id)); err != nil {
 		return fmt.Errorf("failed to delete space: %w", err)
 	}
 
@@ -220,7 +220,7 @@ func (c *ChattoCore) DeleteSpace(ctx context.Context, actorID string, space_id s
 
 // GetSpace retrieves a space from the INSTANCE KV bucket.
 func (c *ChattoCore) GetSpace(ctx context.Context, space_id string) (*corev1.Space, error) {
-	entry, err := c.storage.instanceKV.Get(ctx, spaceKey(space_id))
+	entry, err := c.storage.serverKV.Get(ctx, spaceKey(space_id))
 	if err != nil {
 		return nil, fmt.Errorf("space not found: %w", err)
 	}
@@ -247,7 +247,7 @@ func (c *ChattoCore) GetSpace(ctx context.Context, space_id string) (*corev1.Spa
 // This is O(N) in the number of matching subjects (live + tombstoned), but only
 // metadata is sent — no values are fetched.
 func (c *ChattoCore) CountSpaces(ctx context.Context) (int, error) {
-	keyLister, err := c.storage.instanceKV.ListKeysFiltered(ctx, "space.*")
+	keyLister, err := c.storage.serverKV.ListKeysFiltered(ctx, "space.*")
 	if err != nil {
 		return 0, nil
 	}
@@ -260,14 +260,14 @@ func (c *ChattoCore) CountSpaces(ctx context.Context) (int, error) {
 
 // ListSpaces retrieves all spaces from the INSTANCE KV bucket.
 func (c *ChattoCore) ListSpaces(ctx context.Context) ([]*corev1.Space, error) {
-	keyLister, err := c.storage.instanceKV.ListKeysFiltered(ctx, "space.*")
+	keyLister, err := c.storage.serverKV.ListKeysFiltered(ctx, "space.*")
 	if err != nil {
 		return []*corev1.Space{}, nil
 	}
 
 	var spaces []*corev1.Space
 	for key := range keyLister.Keys() {
-		entry, err := c.storage.instanceKV.Get(ctx, key)
+		entry, err := c.storage.serverKV.Get(ctx, key)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get space %s: %w", key, err)
 		}
@@ -466,7 +466,7 @@ func (c *ChattoCore) UploadSpaceLogo(ctx context.Context, spaceID string, reader
 
 	if c.ShouldUseS3() {
 		// Upload to S3 - use the same assetID as NATS would use for the key
-		s3Key := S3KeyInstanceAsset(assetID)
+		s3Key := S3KeyServerAsset(assetID)
 		_, err := c.s3Client.PutObjectFromBytes(ctx, s3Key, webpData, "image/webp")
 		if err != nil {
 			return nil, fmt.Errorf("failed to upload logo to S3: %w", err)
@@ -489,7 +489,7 @@ func (c *ChattoCore) UploadSpaceLogo(ctx context.Context, spaceID string, reader
 			Name:    assetID,
 			Headers: headers,
 		}
-		info, err := c.storage.instanceStore.Put(ctx, meta, bytes.NewReader(webpData))
+		info, err := c.storage.serverStore.Put(ctx, meta, bytes.NewReader(webpData))
 		if err != nil {
 			return nil, fmt.Errorf("failed to upload logo: %w", err)
 		}
@@ -532,7 +532,7 @@ func (c *ChattoCore) SetSpaceLogo(ctx context.Context, actorID string, spaceID s
 		var revision uint64
 		var oldAsset *corev1.Asset
 
-		entry, err := c.storage.instanceKV.Get(ctx, key)
+		entry, err := c.storage.serverKV.Get(ctx, key)
 		if err == nil {
 			// Key exists - get revision and unmarshal old asset for cleanup
 			revision = entry.Revision()
@@ -550,10 +550,10 @@ func (c *ChattoCore) SetSpaceLogo(ctx context.Context, actorID string, spaceID s
 		var updateErr error
 		if revision == 0 {
 			// No existing key - use Create for atomic insert
-			_, updateErr = c.storage.instanceKV.Create(ctx, key, assetData)
+			_, updateErr = c.storage.serverKV.Create(ctx, key, assetData)
 		} else {
 			// Existing key - use Update with revision check
-			_, updateErr = c.storage.instanceKV.Update(ctx, key, assetData, revision)
+			_, updateErr = c.storage.serverKV.Update(ctx, key, assetData, revision)
 		}
 
 		if updateErr == nil {
@@ -585,7 +585,7 @@ func (c *ChattoCore) SetSpaceLogo(ctx context.Context, actorID string, spaceID s
 // GetSpaceLogo retrieves a space's logo asset reference from the KV store.
 // Returns (nil, nil) if the space has no logo set.
 func (c *ChattoCore) GetSpaceLogo(ctx context.Context, spaceID string) (*corev1.Asset, error) {
-	entry, err := c.storage.instanceKV.Get(ctx, spaceLogoKey(spaceID))
+	entry, err := c.storage.serverKV.Get(ctx, spaceLogoKey(spaceID))
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return nil, nil // No logo set is not an error
@@ -628,7 +628,7 @@ func (c *ChattoCore) GetSpaceLogoURL(ctx context.Context, spaceID string, width,
 
 	// Always use the standard instance asset URL format - storage backend is an internal detail
 	if width != nil && height != nil {
-		return c.GetTransformedInstanceAssetURL(assetID, *width, *height, "cover"), nil
+		return c.GetTransformedServerAssetURL(assetID, *width, *height, "cover"), nil
 	}
 	return c.assetURL(fmt.Sprintf("/assets/instance/%s", assetID)), nil
 }
@@ -649,7 +649,7 @@ func (c *ChattoCore) DeleteSpaceLogo(ctx context.Context, actorID string, spaceI
 	// Optimistic locking loop
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		// Get current entry with revision
-		entry, err := c.storage.instanceKV.Get(ctx, key)
+		entry, err := c.storage.serverKV.Get(ctx, key)
 		if err != nil {
 			if errors.Is(err, jetstream.ErrKeyNotFound) {
 				// No logo to delete
@@ -668,7 +668,7 @@ func (c *ChattoCore) DeleteSpaceLogo(ctx context.Context, actorID string, spaceI
 		}
 
 		// Try atomic delete with revision check
-		deleteErr := c.storage.instanceKV.Delete(ctx, key, jetstream.LastRevision(revision))
+		deleteErr := c.storage.serverKV.Delete(ctx, key, jetstream.LastRevision(revision))
 		if deleteErr == nil {
 			// Success! Now clean up the storage asset (NATS or S3)
 			c.deleteAsset(ctx, logo, "logo", spaceID)
@@ -726,7 +726,7 @@ func (c *ChattoCore) UploadSpaceBanner(ctx context.Context, spaceID string, read
 
 	if c.ShouldUseS3() {
 		// Upload to S3 - use the same assetID as NATS would use for the key
-		s3Key := S3KeyInstanceAsset(assetID)
+		s3Key := S3KeyServerAsset(assetID)
 		_, err := c.s3Client.PutObjectFromBytes(ctx, s3Key, webpData, "image/webp")
 		if err != nil {
 			return nil, fmt.Errorf("failed to upload banner to S3: %w", err)
@@ -749,7 +749,7 @@ func (c *ChattoCore) UploadSpaceBanner(ctx context.Context, spaceID string, read
 			Name:    assetID,
 			Headers: headers,
 		}
-		info, err := c.storage.instanceStore.Put(ctx, meta, bytes.NewReader(webpData))
+		info, err := c.storage.serverStore.Put(ctx, meta, bytes.NewReader(webpData))
 		if err != nil {
 			return nil, fmt.Errorf("failed to upload banner: %w", err)
 		}
@@ -792,7 +792,7 @@ func (c *ChattoCore) SetSpaceBanner(ctx context.Context, actorID string, spaceID
 		var revision uint64
 		var oldAsset *corev1.Asset
 
-		entry, err := c.storage.instanceKV.Get(ctx, key)
+		entry, err := c.storage.serverKV.Get(ctx, key)
 		if err == nil {
 			// Key exists - get revision and unmarshal old asset for cleanup
 			revision = entry.Revision()
@@ -810,10 +810,10 @@ func (c *ChattoCore) SetSpaceBanner(ctx context.Context, actorID string, spaceID
 		var updateErr error
 		if revision == 0 {
 			// No existing key - use Create for atomic insert
-			_, updateErr = c.storage.instanceKV.Create(ctx, key, assetData)
+			_, updateErr = c.storage.serverKV.Create(ctx, key, assetData)
 		} else {
 			// Existing key - use Update with revision check
-			_, updateErr = c.storage.instanceKV.Update(ctx, key, assetData, revision)
+			_, updateErr = c.storage.serverKV.Update(ctx, key, assetData, revision)
 		}
 
 		if updateErr == nil {
@@ -845,7 +845,7 @@ func (c *ChattoCore) SetSpaceBanner(ctx context.Context, actorID string, spaceID
 // GetSpaceBanner retrieves a space's banner asset reference from the KV store.
 // Returns (nil, nil) if the space has no banner set.
 func (c *ChattoCore) GetSpaceBanner(ctx context.Context, spaceID string) (*corev1.Asset, error) {
-	entry, err := c.storage.instanceKV.Get(ctx, spaceBannerKey(spaceID))
+	entry, err := c.storage.serverKV.Get(ctx, spaceBannerKey(spaceID))
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return nil, nil // No banner set is not an error
@@ -888,7 +888,7 @@ func (c *ChattoCore) GetSpaceBannerURL(ctx context.Context, spaceID string, widt
 
 	// Always use the standard instance asset URL format - storage backend is an internal detail
 	if width != nil && height != nil {
-		return c.GetTransformedInstanceAssetURL(assetID, *width, *height, "cover"), nil
+		return c.GetTransformedServerAssetURL(assetID, *width, *height, "cover"), nil
 	}
 	return c.assetURL(fmt.Sprintf("/assets/instance/%s", assetID)), nil
 }
@@ -909,7 +909,7 @@ func (c *ChattoCore) DeleteSpaceBanner(ctx context.Context, actorID string, spac
 	// Optimistic locking loop
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		// Get current entry with revision
-		entry, err := c.storage.instanceKV.Get(ctx, key)
+		entry, err := c.storage.serverKV.Get(ctx, key)
 		if err != nil {
 			if errors.Is(err, jetstream.ErrKeyNotFound) {
 				// No banner to delete
@@ -928,7 +928,7 @@ func (c *ChattoCore) DeleteSpaceBanner(ctx context.Context, actorID string, spac
 		}
 
 		// Try atomic delete with revision check
-		deleteErr := c.storage.instanceKV.Delete(ctx, key, jetstream.LastRevision(revision))
+		deleteErr := c.storage.serverKV.Delete(ctx, key, jetstream.LastRevision(revision))
 		if deleteErr == nil {
 			// Success! Now clean up the storage asset (NATS or S3)
 			c.deleteAsset(ctx, banner, "banner", spaceID)

--- a/cli/internal/core/user_preferences.go
+++ b/cli/internal/core/user_preferences.go
@@ -35,7 +35,7 @@ type UserSettingsInput struct {
 // Returns nil, nil if no settings have been saved yet (the user hasn't configured any).
 // Authorization: Caller must verify access (self-only in GraphQL layer).
 func (c *ChattoCore) GetUserSettings(ctx context.Context, userID string) (*corev1.ServerUserPreferences, error) {
-	entry, err := c.storage.instanceKV.Get(ctx, userPreferencesKey(userID))
+	entry, err := c.storage.serverKV.Get(ctx, userPreferencesKey(userID))
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return nil, nil
@@ -90,7 +90,7 @@ func (c *ChattoCore) UpdateUserSettings(ctx context.Context, userID string, inpu
 		return nil, fmt.Errorf("failed to marshal user settings: %w", err)
 	}
 
-	if _, err := c.storage.instanceKV.Put(ctx, userPreferencesKey(userID), data); err != nil {
+	if _, err := c.storage.serverKV.Put(ctx, userPreferencesKey(userID), data); err != nil {
 		return nil, fmt.Errorf("failed to store user settings: %w", err)
 	}
 
@@ -127,7 +127,7 @@ func (c *ChattoCore) publishInstanceUserPreferencesUpdatedEvent(ctx context.Cont
 
 // deleteUserSettings removes a user's settings. Called during account deletion.
 func (c *ChattoCore) deleteUserSettings(ctx context.Context, userID string) error {
-	if err := c.storage.instanceKV.Delete(ctx, userPreferencesKey(userID)); err != nil {
+	if err := c.storage.serverKV.Delete(ctx, userPreferencesKey(userID)); err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return nil // No settings to delete
 		}

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -81,7 +81,7 @@ func (c *ChattoCore) CreateUser(ctx context.Context, actorID string, login, disp
 
 	// Atomically claim login name (prevents race conditions)
 	loginKey := userByLoginKey(login)
-	_, err = c.storage.instanceKV.Create(ctx, loginKey, []byte(userID))
+	_, err = c.storage.serverKV.Create(ctx, loginKey, []byte(userID))
 	if err != nil {
 		// Login already exists or other error
 		return nil, ErrLoginAlreadyTaken
@@ -99,14 +99,14 @@ func (c *ChattoCore) CreateUser(ctx context.Context, actorID string, login, disp
 	userData, err := proto.Marshal(user)
 	if err != nil {
 		// Cleanup: remove login claim
-		c.storage.instanceKV.Delete(ctx, loginKey)
+		c.storage.serverKV.Delete(ctx, loginKey)
 		return nil, fmt.Errorf("failed to marshal user: %w", err)
 	}
 
-	_, err = c.storage.instanceKV.Put(ctx, userKey(user.Id), userData)
+	_, err = c.storage.serverKV.Put(ctx, userKey(user.Id), userData)
 	if err != nil {
 		// Cleanup: remove login claim
-		c.storage.instanceKV.Delete(ctx, loginKey)
+		c.storage.serverKV.Delete(ctx, loginKey)
 		return nil, fmt.Errorf("failed to store user: %w", err)
 	}
 
@@ -115,16 +115,16 @@ func (c *ChattoCore) CreateUser(ctx context.Context, actorID string, login, disp
 		hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 		if err != nil {
 			// Cleanup: remove user and login claim
-			c.storage.instanceKV.Delete(ctx, userKey(user.Id))
-			c.storage.instanceKV.Delete(ctx, loginKey)
+			c.storage.serverKV.Delete(ctx, userKey(user.Id))
+			c.storage.serverKV.Delete(ctx, loginKey)
 			return nil, fmt.Errorf("failed to hash password: %w", err)
 		}
 
-		_, err = c.storage.instanceKV.Put(ctx, userAuthPasswordKey(user.Id), hashedPassword)
+		_, err = c.storage.serverKV.Put(ctx, userAuthPasswordKey(user.Id), hashedPassword)
 		if err != nil {
 			// Cleanup: remove user and login claim
-			c.storage.instanceKV.Delete(ctx, userKey(user.Id))
-			c.storage.instanceKV.Delete(ctx, loginKey)
+			c.storage.serverKV.Delete(ctx, userKey(user.Id))
+			c.storage.serverKV.Delete(ctx, loginKey)
 			return nil, fmt.Errorf("failed to store password: %w", err)
 		}
 	}
@@ -134,9 +134,9 @@ func (c *ChattoCore) CreateUser(ctx context.Context, actorID string, login, disp
 	_, err = c.encryption.keyManager.CreateUserKey(ctx, userID)
 	if err != nil {
 		// Cleanup: remove user, login claim, and password
-		c.storage.instanceKV.Delete(ctx, userKey(user.Id))
-		c.storage.instanceKV.Delete(ctx, loginKey)
-		c.storage.instanceKV.Delete(ctx, userAuthPasswordKey(user.Id))
+		c.storage.serverKV.Delete(ctx, userKey(user.Id))
+		c.storage.serverKV.Delete(ctx, loginKey)
+		c.storage.serverKV.Delete(ctx, userAuthPasswordKey(user.Id))
 		return nil, fmt.Errorf("failed to create encryption key: %w", err)
 	}
 
@@ -193,7 +193,7 @@ func (c *ChattoCore) rollbackUserCreation(ctx context.Context, user *corev1.User
 		userAuthPasswordKey(user.Id),
 	}
 	for _, key := range keys {
-		if err := c.storage.instanceKV.Delete(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+		if err := c.storage.serverKV.Delete(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
 			c.logger.Warn("rollback delete failed", "key", key, "error", err)
 		}
 	}
@@ -204,7 +204,7 @@ func (c *ChattoCore) rollbackUserCreation(ctx context.Context, user *corev1.User
 
 // GetUser retrieves a user from the INSTANCE KV bucket.
 func (c *ChattoCore) GetUser(ctx context.Context, userID string) (*corev1.User, error) {
-	entry, err := c.storage.instanceKV.Get(ctx, userKey(userID))
+	entry, err := c.storage.serverKV.Get(ctx, userKey(userID))
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return nil, ErrNotFound
@@ -270,7 +270,7 @@ func (c *ChattoCore) GetUsers(ctx context.Context, userIDs []string) ([]*corev1.
 // GetUserByLogin retrieves a user by their login name using the login index.
 func (c *ChattoCore) GetUserByLogin(ctx context.Context, login string) (*corev1.User, error) {
 	loginKey := userByLoginKey(login)
-	entry, err := c.storage.instanceKV.Get(ctx, loginKey)
+	entry, err := c.storage.serverKV.Get(ctx, loginKey)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return nil, ErrNotFound
@@ -303,7 +303,7 @@ func (c *ChattoCore) SetPasswordHash(ctx context.Context, userID string, passwor
 	}
 
 	// Store password hash in separate KV key
-	_, err = c.storage.instanceKV.Put(ctx, userAuthPasswordKey(userID), hashedPassword)
+	_, err = c.storage.serverKV.Put(ctx, userAuthPasswordKey(userID), hashedPassword)
 	if err != nil {
 		return fmt.Errorf("failed to store password: %w", err)
 	}
@@ -342,7 +342,7 @@ func (c *ChattoCore) VerifyPassword(ctx context.Context, identifier string, pass
 func (c *ChattoCore) verifyUserPassword(ctx context.Context, user *corev1.User, password string, dummyHash []byte) (*corev1.User, error) {
 
 	// Retrieve password hash from separate KV storage
-	entry, err := c.storage.instanceKV.Get(ctx, userAuthPasswordKey(user.Id))
+	entry, err := c.storage.serverKV.Get(ctx, userAuthPasswordKey(user.Id))
 	if err != nil {
 		// No password set (OAuth-only user) - run dummy bcrypt to match timing
 		bcrypt.CompareHashAndPassword(dummyHash, []byte(password))
@@ -389,7 +389,7 @@ func (c *ChattoCore) UploadUserAvatar(ctx context.Context, userID string, reader
 	if c.ShouldUseS3() {
 		// Upload to S3 - use the same assetID as NATS would use for the key
 		// The S3 path is constructed from the assetID for consistency
-		s3Key := S3KeyInstanceAsset(assetID)
+		s3Key := S3KeyServerAsset(assetID)
 		_, err := c.s3Client.PutObjectFromBytes(ctx, s3Key, webpData, "image/webp")
 		if err != nil {
 			return nil, fmt.Errorf("failed to upload avatar to S3: %w", err)
@@ -412,7 +412,7 @@ func (c *ChattoCore) UploadUserAvatar(ctx context.Context, userID string, reader
 			Name:    assetID,
 			Headers: headers,
 		}
-		info, err := c.storage.instanceStore.Put(ctx, meta, bytes.NewReader(webpData))
+		info, err := c.storage.serverStore.Put(ctx, meta, bytes.NewReader(webpData))
 		if err != nil {
 			return nil, fmt.Errorf("failed to upload avatar: %w", err)
 		}
@@ -449,7 +449,7 @@ func (c *ChattoCore) SetUserAvatar(ctx context.Context, userID string, asset *co
 		return fmt.Errorf("failed to marshal avatar asset: %w", err)
 	}
 
-	_, err = c.storage.instanceKV.Put(ctx, userAvatarKey(userID), assetData)
+	_, err = c.storage.serverKV.Put(ctx, userAvatarKey(userID), assetData)
 	if err != nil {
 		return fmt.Errorf("failed to store avatar: %w", err)
 	}
@@ -465,7 +465,7 @@ func (c *ChattoCore) SetUserAvatar(ctx context.Context, userID string, asset *co
 // GetUserAvatar retrieves a user's avatar asset reference from the KV store.
 // Returns nil if the user has no avatar set.
 func (c *ChattoCore) GetUserAvatar(ctx context.Context, userID string) (*corev1.Asset, error) {
-	entry, err := c.storage.instanceKV.Get(ctx, userAvatarKey(userID))
+	entry, err := c.storage.serverKV.Get(ctx, userAvatarKey(userID))
 	if err != nil {
 		// No avatar set is not an error
 		return nil, nil
@@ -503,7 +503,7 @@ func (c *ChattoCore) DeleteUserAvatar(ctx context.Context, userID string) error 
 	c.deleteAsset(ctx, avatar, "avatar", userID)
 
 	// Delete the KV reference
-	if err := c.storage.instanceKV.Delete(ctx, userAvatarKey(userID)); err != nil {
+	if err := c.storage.serverKV.Delete(ctx, userAvatarKey(userID)); err != nil {
 		return fmt.Errorf("failed to delete avatar reference: %w", err)
 	}
 
@@ -554,7 +554,7 @@ func (c *ChattoCore) publishUserProfileUpdate(ctx context.Context, userID string
 // ListUsers retrieves all users from the INSTANCE KV bucket.
 // CountUsers returns the total number of users on the server. Key-only scan.
 func (c *ChattoCore) CountUsers(ctx context.Context) (int, error) {
-	keyLister, err := c.storage.instanceKV.ListKeysFiltered(ctx, "user.*")
+	keyLister, err := c.storage.serverKV.ListKeysFiltered(ctx, "user.*")
 	if err != nil {
 		return 0, fmt.Errorf("failed to list user keys: %w", err)
 	}
@@ -566,14 +566,14 @@ func (c *ChattoCore) CountUsers(ctx context.Context) (int, error) {
 }
 
 func (c *ChattoCore) ListUsers(ctx context.Context) ([]*corev1.User, error) {
-	keyLister, err := c.storage.instanceKV.ListKeysFiltered(ctx, "user.*")
+	keyLister, err := c.storage.serverKV.ListKeysFiltered(ctx, "user.*")
 	if err != nil {
 		return []*corev1.User{}, nil
 	}
 
 	var users []*corev1.User
 	for key := range keyLister.Keys() {
-		entry, err := c.storage.instanceKV.Get(ctx, key)
+		entry, err := c.storage.serverKV.Get(ctx, key)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get user %s: %w", key, err)
 		}
@@ -616,7 +616,7 @@ func (c *ChattoCore) GetUserAvatarURL(ctx context.Context, userID string, width,
 
 	// Always use the standard instance asset URL format - storage backend is an internal detail
 	if width != nil && height != nil {
-		return c.GetTransformedInstanceAssetURL(assetID, *width, *height, "cover"), nil
+		return c.GetTransformedServerAssetURL(assetID, *width, *height, "cover"), nil
 	}
 	return c.assetURL(fmt.Sprintf("/assets/instance/%s", assetID)), nil
 }
@@ -635,7 +635,7 @@ var ErrUsernameBlocked = fmt.Errorf("this username is not available")
 func (c *ChattoCore) CheckLoginExists(ctx context.Context, login string) (bool, error) {
 	login = strings.TrimSpace(login)
 	loginKey := userByLoginKey(login)
-	_, err := c.storage.instanceKV.Get(ctx, loginKey)
+	_, err := c.storage.serverKV.Get(ctx, loginKey)
 	if err != nil {
 		return false, nil
 	}
@@ -672,7 +672,7 @@ func (c *ChattoCore) UpdateUserDisplayName(ctx context.Context, userID, displayN
 		return nil, fmt.Errorf("failed to marshal user: %w", err)
 	}
 
-	_, err = c.storage.instanceKV.Put(ctx, userKey(userID), userData)
+	_, err = c.storage.serverKV.Put(ctx, userKey(userID), userData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to store user: %w", err)
 	}
@@ -755,7 +755,7 @@ func (c *ChattoCore) applyLoginChange(ctx context.Context, userID, newLogin stri
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal user: %w", err)
 		}
-		_, err = c.storage.instanceKV.Put(ctx, userKey(userID), userData)
+		_, err = c.storage.serverKV.Put(ctx, userKey(userID), userData)
 		if err != nil {
 			return nil, fmt.Errorf("failed to store user: %w", err)
 		}
@@ -790,7 +790,7 @@ func (c *ChattoCore) applyLoginChange(ctx context.Context, userID, newLogin stri
 	oldLoginKey := userByLoginKey(oldLogin)
 	newLoginKey := userByLoginKey(newLogin)
 
-	_, err = c.storage.instanceKV.Create(ctx, newLoginKey, []byte(userID))
+	_, err = c.storage.serverKV.Create(ctx, newLoginKey, []byte(userID))
 	if err != nil {
 		return nil, ErrLoginAlreadyTaken
 	}
@@ -800,26 +800,26 @@ func (c *ChattoCore) applyLoginChange(ctx context.Context, userID, newLogin stri
 	userData, err := proto.Marshal(user)
 	if err != nil {
 		// Rollback: remove new login claim
-		c.storage.instanceKV.Delete(ctx, newLoginKey)
+		c.storage.serverKV.Delete(ctx, newLoginKey)
 		return nil, fmt.Errorf("failed to marshal user: %w", err)
 	}
 
-	_, err = c.storage.instanceKV.Put(ctx, userKey(userID), userData)
+	_, err = c.storage.serverKV.Put(ctx, userKey(userID), userData)
 	if err != nil {
 		// Rollback: remove new login claim
-		c.storage.instanceKV.Delete(ctx, newLoginKey)
+		c.storage.serverKV.Delete(ctx, newLoginKey)
 		return nil, fmt.Errorf("failed to store user: %w", err)
 	}
 
 	// Delete old login index (best-effort)
-	if deleteErr := c.storage.instanceKV.Delete(ctx, oldLoginKey); deleteErr != nil {
+	if deleteErr := c.storage.serverKV.Delete(ctx, oldLoginKey); deleteErr != nil {
 		c.logger.Warn("Failed to delete old login index", "error", deleteErr, "old_login", oldLogin)
 	}
 
 	// Record change timestamp for cooldown (skipped on admin path)
 	if enforceCooldown {
 		now := time.Now().Format(time.RFC3339)
-		if _, putErr := c.storage.instanceKV.Put(ctx, userLoginChangedAtKey(userID), []byte(now)); putErr != nil {
+		if _, putErr := c.storage.serverKV.Put(ctx, userLoginChangedAtKey(userID), []byte(now)); putErr != nil {
 			c.logger.Warn("Failed to record login change timestamp", "error", putErr, "user_id", userID)
 		}
 	}
@@ -835,7 +835,7 @@ func (c *ChattoCore) applyLoginChange(ctx context.Context, userID, newLogin stri
 // GetLastLoginChange returns when the user last changed their login.
 // Returns zero time if the user has never changed their login.
 func (c *ChattoCore) GetLastLoginChange(ctx context.Context, userID string) (time.Time, error) {
-	entry, err := c.storage.instanceKV.Get(ctx, userLoginChangedAtKey(userID))
+	entry, err := c.storage.serverKV.Get(ctx, userLoginChangedAtKey(userID))
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return time.Time{}, nil
@@ -856,7 +856,7 @@ func (c *ChattoCore) GetLastLoginChange(ctx context.Context, userID string) (tim
 // already-clear cooldown is a no-op.
 // Authorization: Caller must verify admin privileges.
 func (c *ChattoCore) ClearLoginChangeCooldown(ctx context.Context, userID string) error {
-	err := c.storage.instanceKV.Delete(ctx, userLoginChangedAtKey(userID))
+	err := c.storage.serverKV.Delete(ctx, userLoginChangedAtKey(userID))
 	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
 		return fmt.Errorf("failed to clear login change cooldown: %w", err)
 	}
@@ -898,7 +898,7 @@ func (c *ChattoCore) CreateAccountDeletionToken(ctx context.Context, userID stri
 		return "", fmt.Errorf("failed to marshal token: %w", err)
 	}
 
-	_, err = c.storage.instanceKV.Put(ctx, accountDeletionTokenKey(token), data)
+	_, err = c.storage.serverKV.Put(ctx, accountDeletionTokenKey(token), data)
 	if err != nil {
 		return "", fmt.Errorf("failed to store account deletion token: %w", err)
 	}
@@ -913,7 +913,7 @@ func (c *ChattoCore) CreateAccountDeletionToken(ctx context.Context, userID stri
 func (c *ChattoCore) ValidateAccountDeletionToken(ctx context.Context, token, userID string) error {
 	key := accountDeletionTokenKey(token)
 
-	entry, err := c.storage.instanceKV.Get(ctx, key)
+	entry, err := c.storage.serverKV.Get(ctx, key)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return ErrTokenNotFound
@@ -928,7 +928,7 @@ func (c *ChattoCore) ValidateAccountDeletionToken(ctx context.Context, token, us
 
 	// Check if token has expired
 	if time.Since(tokenData.CreatedAt) > AccountDeletionTokenTTL {
-		c.storage.instanceKV.Delete(ctx, key) // Clean up expired token
+		c.storage.serverKV.Delete(ctx, key) // Clean up expired token
 		return ErrTokenExpired
 	}
 
@@ -938,7 +938,7 @@ func (c *ChattoCore) ValidateAccountDeletionToken(ctx context.Context, token, us
 	}
 
 	// Consume the token (delete it)
-	if err := c.storage.instanceKV.Delete(ctx, key); err != nil {
+	if err := c.storage.serverKV.Delete(ctx, key); err != nil {
 		c.logger.Warn("Failed to delete consumed account deletion token", "error", err)
 		// Continue anyway - the token was valid
 	}
@@ -1000,7 +1000,7 @@ func (c *ChattoCore) DeleteUser(ctx context.Context, actorID, userID string) err
 	avatar, _ := c.GetUserAvatar(ctx, userID)
 	if avatar != nil {
 		if natsAsset := avatar.GetNats(); natsAsset != nil {
-			if err := c.storage.instanceStore.Delete(ctx, natsAsset.Key); err != nil {
+			if err := c.storage.serverStore.Delete(ctx, natsAsset.Key); err != nil {
 				c.logger.Warn("Failed to delete avatar from object store", "user_id", userID, "key", natsAsset.Key, "error", err)
 			}
 		}
@@ -1009,7 +1009,7 @@ func (c *ChattoCore) DeleteUser(ctx context.Context, actorID, userID string) err
 	// Delete email index entries
 	for _, email := range verifiedEmails {
 		emailKey := userByEmailKey(email.Email)
-		if err := c.storage.instanceKV.Delete(ctx, emailKey); err != nil {
+		if err := c.storage.serverKV.Delete(ctx, emailKey); err != nil {
 			c.logger.Warn("Failed to delete email index", "user_id", userID, "email", email.Email, "error", err)
 		}
 	}
@@ -1027,7 +1027,7 @@ func (c *ChattoCore) DeleteUser(ctx context.Context, actorID, userID string) err
 	}
 
 	for _, key := range keysToDelete {
-		if err := c.storage.instanceKV.Delete(ctx, key); err != nil {
+		if err := c.storage.serverKV.Delete(ctx, key); err != nil {
 			// Log but don't fail - some keys may not exist (e.g., no password for OAuth users)
 			c.logger.Debug("Failed to delete key during user deletion", "key", key, "error", err)
 		}
@@ -1048,15 +1048,15 @@ func (c *ChattoCore) DeleteUser(ctx context.Context, actorID, userID string) err
 	}
 
 	// Publish instance-level UserDeletedEvent for audit logging and admin UI updates
-	instanceEvent := newLiveEvent(userID, &corev1.LiveEvent{
+	serverEvent := newLiveEvent(userID, &corev1.LiveEvent{
 		Event: &corev1.LiveEvent_UserDeleted{
 			UserDeleted: &corev1.UserDeletedEvent{
 				UserId: userID,
 			},
 		},
 	})
-	instanceSubject := subjects.LiveInstanceUserEvent(userID, "user_deleted")
-	if err := c.publishLiveEvent(ctx, instanceSubject, instanceEvent); err != nil {
+	serverSubject := subjects.LiveInstanceUserEvent(userID, "user_deleted")
+	if err := c.publishLiveEvent(ctx, serverSubject, serverEvent); err != nil {
 		c.logger.Warn("Failed to publish UserDeletedEvent", "user_id", userID, "error", err)
 	}
 

--- a/cli/internal/core/users_test.go
+++ b/cli/internal/core/users_test.go
@@ -1294,7 +1294,7 @@ func TestChattoCore_UploadUserAvatar_ReplacesOld(t *testing.T) {
 	}
 
 	// Old asset should be deleted from object store
-	_, err = core.InstanceStore().Get(ctx, oldKey)
+	_, err = core.ServerStore().Get(ctx, oldKey)
 	if err == nil {
 		t.Error("Expected old avatar to be deleted from object store")
 	}
@@ -1357,7 +1357,7 @@ func TestChattoCore_DeleteUserAvatar(t *testing.T) {
 	}
 
 	// Verify asset was removed from object store
-	_, err = core.InstanceStore().Get(ctx, asset.GetNats().Key)
+	_, err = core.ServerStore().Get(ctx, asset.GetNats().Key)
 	if err == nil {
 		t.Error("Expected asset to be deleted from object store")
 	}

--- a/cli/internal/core/users_verified_test.go
+++ b/cli/internal/core/users_verified_test.go
@@ -47,7 +47,7 @@ func TestCreateVerifiedUser_RollsBackOnEmailConflict(t *testing.T) {
 	}
 
 	// User record must NOT exist (rollback).
-	if _, err := core.storage.instanceKV.Get(ctx, userByLoginKey("second-user")); !errors.Is(err, jetstream.ErrKeyNotFound) {
+	if _, err := core.storage.serverKV.Get(ctx, userByLoginKey("second-user")); !errors.Is(err, jetstream.ErrKeyNotFound) {
 		t.Errorf("expected login claim to be rolled back, got err=%v", err)
 	}
 }

--- a/cli/internal/core/verified_emails.go
+++ b/cli/internal/core/verified_emails.go
@@ -94,7 +94,7 @@ func (c *ChattoCore) CreateEmailVerificationToken(ctx context.Context, userID, e
 		return "", fmt.Errorf("failed to marshal token: %w", err)
 	}
 
-	_, err = c.storage.instanceKV.Create(ctx, emailVerificationTokenKey(token), data, jetstream.KeyTTL(EmailVerificationTokenTTL))
+	_, err = c.storage.serverKV.Create(ctx, emailVerificationTokenKey(token), data, jetstream.KeyTTL(EmailVerificationTokenTTL))
 	if err != nil {
 		return "", fmt.Errorf("failed to store verification token: %w", err)
 	}
@@ -105,7 +105,7 @@ func (c *ChattoCore) CreateEmailVerificationToken(ctx context.Context, userID, e
 // getEmailVerificationToken retrieves and validates a verification token.
 // Returns the token data including userID and email.
 func (c *ChattoCore) getEmailVerificationToken(ctx context.Context, token string) (*EmailVerificationToken, error) {
-	entry, err := c.storage.instanceKV.Get(ctx, emailVerificationTokenKey(token))
+	entry, err := c.storage.serverKV.Get(ctx, emailVerificationTokenKey(token))
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return nil, ErrTokenNotFound
@@ -121,7 +121,7 @@ func (c *ChattoCore) getEmailVerificationToken(ctx context.Context, token string
 	// Check if token has expired
 	if time.Since(tokenData.CreatedAt) > EmailVerificationTokenTTL {
 		// Clean up expired token
-		c.storage.instanceKV.Delete(ctx, emailVerificationTokenKey(token))
+		c.storage.serverKV.Delete(ctx, emailVerificationTokenKey(token))
 		return nil, ErrTokenExpired
 	}
 
@@ -130,7 +130,7 @@ func (c *ChattoCore) getEmailVerificationToken(ctx context.Context, token string
 
 // deleteEmailVerificationToken removes a verification token.
 func (c *ChattoCore) deleteEmailVerificationToken(ctx context.Context, token string) error {
-	err := c.storage.instanceKV.Delete(ctx, emailVerificationTokenKey(token))
+	err := c.storage.serverKV.Delete(ctx, emailVerificationTokenKey(token))
 	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
 		return fmt.Errorf("failed to delete verification token: %w", err)
 	}
@@ -161,10 +161,10 @@ func (c *ChattoCore) VerifyEmail(ctx context.Context, token string) (userID stri
 
 	// Track whether we created the claim (for rollback purposes)
 	claimCreated := false
-	_, err = c.storage.instanceKV.Create(ctx, claimKey, []byte(tokenData.UserID))
+	_, err = c.storage.serverKV.Create(ctx, claimKey, []byte(tokenData.UserID))
 	if err != nil {
 		// Claim failed - check if it's already claimed by this same user (idempotent)
-		entry, getErr := c.storage.instanceKV.Get(ctx, claimKey)
+		entry, getErr := c.storage.serverKV.Get(ctx, claimKey)
 		if getErr != nil || string(entry.Value()) != tokenData.UserID {
 			// Email claimed by another user
 			return "", ErrEmailAlreadyVerified
@@ -178,7 +178,7 @@ func (c *ChattoCore) VerifyEmail(ctx context.Context, token string) (userID stri
 	if err := c.addVerifiedEmail(ctx, tokenData.UserID, tokenData.Email); err != nil {
 		// Only rollback if we just created the claim
 		if claimCreated {
-			c.storage.instanceKV.Delete(ctx, claimKey)
+			c.storage.serverKV.Delete(ctx, claimKey)
 		}
 		return "", err
 	}
@@ -219,7 +219,7 @@ func (c *ChattoCore) addVerifiedEmail(ctx context.Context, userID, email string)
 		return fmt.Errorf("failed to marshal verified emails: %w", err)
 	}
 
-	_, err = c.storage.instanceKV.Put(ctx, userVerifiedEmailsKey(userID), data)
+	_, err = c.storage.serverKV.Put(ctx, userVerifiedEmailsKey(userID), data)
 	if err != nil {
 		return fmt.Errorf("failed to store verified emails: %w", err)
 	}
@@ -243,7 +243,7 @@ func (c *ChattoCore) addVerifiedEmail(ctx context.Context, userID, email string)
 
 // GetVerifiedEmails returns all verified emails for a user.
 func (c *ChattoCore) GetVerifiedEmails(ctx context.Context, userID string) ([]VerifiedEmail, error) {
-	entry, err := c.storage.instanceKV.Get(ctx, userVerifiedEmailsKey(userID))
+	entry, err := c.storage.serverKV.Get(ctx, userVerifiedEmailsKey(userID))
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return []VerifiedEmail{}, nil
@@ -274,7 +274,7 @@ func (c *ChattoCore) IsEmailClaimed(ctx context.Context, email string) (bool, er
 	normalizedEmail := strings.ToLower(email)
 	claimKey := userByEmailKey(normalizedEmail)
 
-	_, err := c.storage.instanceKV.Get(ctx, claimKey)
+	_, err := c.storage.serverKV.Get(ctx, claimKey)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return false, nil // Email is not claimed
@@ -290,7 +290,7 @@ func (c *ChattoCore) GetUserByVerifiedEmail(ctx context.Context, email string) (
 	normalizedEmail := strings.ToLower(email)
 	claimKey := userByEmailKey(normalizedEmail)
 
-	entry, err := c.storage.instanceKV.Get(ctx, claimKey)
+	entry, err := c.storage.serverKV.Get(ctx, claimKey)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return nil, fmt.Errorf("no user found with verified email")
@@ -309,7 +309,7 @@ func (c *ChattoCore) GetUserByVerifiedEmail(ctx context.Context, email string) (
 // faster server-side stream.Info(WithSubjectFilter)) because the latter counts
 // tombstones from deleted users — see CountSpaces for the full reasoning.
 func (c *ChattoCore) CountVerifiedUsers(ctx context.Context) (int, error) {
-	keyLister, err := c.storage.instanceKV.ListKeysFiltered(ctx, "user.*.verified_emails")
+	keyLister, err := c.storage.serverKV.ListKeysFiltered(ctx, "user.*.verified_emails")
 	if err != nil {
 		return 0, nil
 	}
@@ -324,7 +324,7 @@ func (c *ChattoCore) CountVerifiedUsers(ctx context.Context) (int, error) {
 func (c *ChattoCore) ListUsersWithVerifiedEmail(ctx context.Context) ([]string, error) {
 	// List all keys matching user.*.verified_emails pattern
 	pattern := "user.*.verified_emails"
-	keyLister, err := c.storage.instanceKV.ListKeysFiltered(ctx, pattern)
+	keyLister, err := c.storage.serverKV.ListKeysFiltered(ctx, pattern)
 	if err != nil {
 		// No keys found is not an error
 		return []string{}, nil
@@ -355,10 +355,10 @@ func (c *ChattoCore) AddVerifiedEmailDirect(ctx context.Context, userID, email s
 	normalizedEmail := strings.ToLower(email)
 	claimKey := userByEmailKey(normalizedEmail)
 
-	_, err := c.storage.instanceKV.Create(ctx, claimKey, []byte(userID))
+	_, err := c.storage.serverKV.Create(ctx, claimKey, []byte(userID))
 	if err != nil {
 		// Email already claimed - check if it's by this user
-		entry, getErr := c.storage.instanceKV.Get(ctx, claimKey)
+		entry, getErr := c.storage.serverKV.Get(ctx, claimKey)
 		if getErr == nil && string(entry.Value()) == userID {
 			// Already verified by this user, nothing to do
 			return nil
@@ -370,7 +370,7 @@ func (c *ChattoCore) AddVerifiedEmailDirect(ctx context.Context, userID, email s
 	// Add to verified emails
 	if err := c.addVerifiedEmail(ctx, userID, email); err != nil {
 		// Rollback: delete the claim
-		c.storage.instanceKV.Delete(ctx, claimKey)
+		c.storage.serverKV.Delete(ctx, claimKey)
 		return err
 	}
 

--- a/cli/internal/core/voice.go
+++ b/cli/internal/core/voice.go
@@ -61,19 +61,19 @@ func callStateKey(spaceID, roomID string) string {
 }
 
 // LiveKitRoomName constructs a deterministic LiveKit room name from space and room IDs.
-// When instanceID is non-empty, the room name is prefixed with "{instanceID}." so the
+// When serverID is non-empty, the room name is prefixed with "{serverID}." so the
 // webhook bridge can route events to the correct Chatto instance in shared deployments.
 // Authorization: Caller must verify room membership before calling.
-func LiveKitRoomName(instanceID, spaceID, roomID string) string {
+func LiveKitRoomName(serverID, spaceID, roomID string) string {
 	base := spaceID + "_" + roomID
-	if instanceID != "" {
-		return instanceID + "." + base
+	if serverID != "" {
+		return serverID + "." + base
 	}
 	return base
 }
 
 // ParseLiveKitRoomName extracts the space ID and room ID from a LiveKit room name.
-// Handles both prefixed ("{instanceID}.{spaceID}_{roomID}") and unprefixed
+// Handles both prefixed ("{serverID}.{spaceID}_{roomID}") and unprefixed
 // ("{spaceID}_{roomID}") formats. Returns empty strings if the format is unexpected.
 func ParseLiveKitRoomName(lkRoomName string) (spaceID, roomID string) {
 	name := lkRoomName
@@ -93,9 +93,9 @@ func ParseLiveKitRoomName(lkRoomName string) (spaceID, roomID string) {
 	return name[:idx], name[idx+1:]
 }
 
-// ParseLiveKitRoomInstanceID extracts just the instance ID prefix from a LiveKit room
+// ParseLiveKitRoomServerID extracts just the instance ID prefix from a LiveKit room
 // name. Returns empty string if no prefix is present (unprefixed format).
-func ParseLiveKitRoomInstanceID(lkRoomName string) string {
+func ParseLiveKitRoomServerID(lkRoomName string) string {
 	idx := strings.IndexByte(lkRoomName, '.')
 	if idx < 0 {
 		return ""

--- a/cli/internal/core/voice_test.go
+++ b/cli/internal/core/voice_test.go
@@ -10,7 +10,7 @@ import (
 func TestLiveKitRoomName(t *testing.T) {
 	tests := []struct {
 		name       string
-		instanceID string
+		serverID string
 		spaceID    string
 		roomID     string
 		want       string
@@ -23,7 +23,7 @@ func TestLiveKitRoomName(t *testing.T) {
 		},
 		{
 			name:       "with instance ID",
-			instanceID: "my-instance",
+			serverID: "my-instance",
 			spaceID:    "space123",
 			roomID:     "room456",
 			want:       "my-instance.space123_room456",
@@ -36,14 +36,14 @@ func TestLiveKitRoomName(t *testing.T) {
 		},
 		{
 			name:       "nanoid-style IDs with instance",
-			instanceID: "prod-tenant-1",
+			serverID: "prod-tenant-1",
 			spaceID:    "V1StGXR8_Z5jdHi6B-myT",
 			roomID:     "xYz9Abc_def",
 			want:       "prod-tenant-1.V1StGXR8_Z5jdHi6B-myT_xYz9Abc_def",
 		},
 		{
 			name:       "empty instance ID treated as no prefix",
-			instanceID: "",
+			serverID: "",
 			spaceID:    "space123",
 			roomID:     "room456",
 			want:       "space123_room456",
@@ -52,9 +52,9 @@ func TestLiveKitRoomName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := LiveKitRoomName(tt.instanceID, tt.spaceID, tt.roomID)
+			got := LiveKitRoomName(tt.serverID, tt.spaceID, tt.roomID)
 			if got != tt.want {
-				t.Errorf("LiveKitRoomName(%q, %q, %q) = %q, want %q", tt.instanceID, tt.spaceID, tt.roomID, got, tt.want)
+				t.Errorf("LiveKitRoomName(%q, %q, %q) = %q, want %q", tt.serverID, tt.spaceID, tt.roomID, got, tt.want)
 			}
 		})
 	}
@@ -122,7 +122,7 @@ func TestParseLiveKitRoomName(t *testing.T) {
 	}
 }
 
-func TestParseLiveKitRoomInstanceID(t *testing.T) {
+func TestParseLiveKitRoomServerID(t *testing.T) {
 	tests := []struct {
 		name       string
 		lkRoomName string
@@ -152,9 +152,9 @@ func TestParseLiveKitRoomInstanceID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ParseLiveKitRoomInstanceID(tt.lkRoomName)
+			got := ParseLiveKitRoomServerID(tt.lkRoomName)
 			if got != tt.want {
-				t.Errorf("ParseLiveKitRoomInstanceID(%q) = %q, want %q", tt.lkRoomName, got, tt.want)
+				t.Errorf("ParseLiveKitRoomServerID(%q) = %q, want %q", tt.lkRoomName, got, tt.want)
 			}
 		})
 	}

--- a/cli/internal/graph/admin.resolvers.go
+++ b/cli/internal/graph/admin.resolvers.go
@@ -77,13 +77,13 @@ func (r *adminMutationsResolver) UpdateServerConfig(ctx context.Context, obj *mo
 	}
 
 	// Publish live event to notify all connected clients
-	if err := r.core.PublishInstanceConfigUpdated(ctx, user.Id, effectiveName, cfg.Motd, cfg.WelcomeMessage, cfg.BlockedUsernames); err != nil {
+	if err := r.core.PublishServerConfigUpdated(ctx, user.Id, effectiveName, cfg.Motd, cfg.WelcomeMessage, cfg.BlockedUsernames); err != nil {
 		// Log the error but don't fail the mutation - config was saved successfully
 		r.logger.Warn("Failed to publish instance config update event", "error", err)
 	}
 
 	// Return the updated config section
-	return instanceConfigToModel(cfg, true), nil
+	return serverConfigToModel(cfg, true), nil
 }
 
 // ResetServerConfig is the resolver for the resetServerConfig field.
@@ -114,7 +114,7 @@ func (r *adminMutationsResolver) ResetServerConfig(ctx context.Context, obj *mod
 	}
 
 	// Publish live event with default values to notify all connected clients
-	if err := r.core.PublishInstanceConfigUpdated(ctx, user.Id, "Chatto", "", "", core.DefaultBlockedUsernames); err != nil {
+	if err := r.core.PublishServerConfigUpdated(ctx, user.Id, "Chatto", "", "", core.DefaultBlockedUsernames); err != nil {
 		// Log the error but don't fail the mutation - config was reset successfully
 		r.logger.Warn("Failed to publish instance config reset event", "error", err)
 	}
@@ -210,7 +210,7 @@ func (r *adminQueriesResolver) ServerConfig(ctx context.Context, obj *model.Admi
 		return nil, fmt.Errorf("failed to get instance config: %w", err)
 	}
 
-	return instanceConfigToModel(cfg, isConfigured), nil
+	return serverConfigToModel(cfg, isConfigured), nil
 }
 
 // Admin is the resolver for the admin field.
@@ -293,7 +293,7 @@ func (r *queryResolver) Admin(ctx context.Context) (*model.AdminQueries, error) 
 	}
 
 	// Fetch instance roles
-	roles, err := r.core.ListInstanceRoles(ctx)
+	roles, err := r.core.ListServerRoles(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list instance roles: %w", err)
 	}
@@ -306,15 +306,15 @@ func (r *queryResolver) Admin(ctx context.Context) (*model.AdminQueries, error) 
 	// Fetch all permissions applicable at instance scope
 	// This includes permissions like room.create, message.post that can have instance-wide defaults
 	allPerms := core.PermissionsForScope(core.ScopeServer)
-	instancePermissions := make([]string, len(allPerms))
+	serverPermissionsList := make([]string, len(allPerms))
 	for i, p := range allPerms {
-		instancePermissions[i] = string(p.Permission)
+		serverPermissionsList[i] = string(p.Permission)
 	}
 
 	return &model.AdminQueries{
 		SystemInfo:        systemInfo,
 		Roles:             roleModels,
-		ServerPermissions: instancePermissions,
+		ServerPermissions: serverPermissionsList,
 	}, nil
 }
 

--- a/cli/internal/graph/authz.go
+++ b/cli/internal/graph/authz.go
@@ -131,8 +131,8 @@ func requireInstanceAdmin(ctx context.Context, c *core.ChattoCore) (*corev1.User
 	return nil, ErrNotInstanceAdmin
 }
 
-// canManageInstanceRoles checks the admin.manage-roles permission.
-func (r *Resolver) canManageInstanceRoles(ctx context.Context, userID string) (bool, error) {
+// canManageServerRoles checks the admin.manage-roles permission.
+func (r *Resolver) canManageServerRoles(ctx context.Context, userID string) (bool, error) {
 	return r.core.HasInstancePermission(ctx, userID, core.PermAdminRolesManage)
 }
 

--- a/cli/internal/graph/authz_test.go
+++ b/cli/internal/graph/authz_test.go
@@ -248,7 +248,7 @@ func TestRequireInstancePermission(t *testing.T) {
 		}
 
 		// Assign admin role
-		if err := env.core.AssignInstanceRole(env.ctx, core.SystemActorID, user.Id, core.RoleAdmin); err != nil {
+		if err := env.core.AssignServerRole(env.ctx, core.SystemActorID, user.Id, core.RoleAdmin); err != nil {
 			t.Fatalf("Failed to assign admin role: %v", err)
 		}
 

--- a/cli/internal/graph/config_helpers.go
+++ b/cli/internal/graph/config_helpers.go
@@ -6,8 +6,8 @@ import (
 	configv1 "hmans.de/chatto/internal/pb/chatto/config/v1"
 )
 
-// instanceConfigToModel converts a protobuf InstanceConfig to the GraphQL model.
-func instanceConfigToModel(cfg *configv1.ServerConfig, isConfigured bool) *model.AdminServerConfig {
+// serverConfigToModel converts a protobuf InstanceConfig to the GraphQL model.
+func serverConfigToModel(cfg *configv1.ServerConfig, isConfigured bool) *model.AdminServerConfig {
 	// Default blocked usernames for unconfigured instances
 	defaultBlocked := core.DefaultBlockedUsernames
 
@@ -19,9 +19,9 @@ func instanceConfigToModel(cfg *configv1.ServerConfig, isConfigured bool) *model
 		}
 	}
 
-	instanceName := cfg.ServerName
-	if instanceName == "" {
-		instanceName = "Chatto" // Default
+	serverName := cfg.ServerName
+	if serverName == "" {
+		serverName = "Chatto" // Default
 	}
 
 	var welcomeMessage *string
@@ -53,7 +53,7 @@ func instanceConfigToModel(cfg *configv1.ServerConfig, isConfigured bool) *model
 	return &model.AdminServerConfig{
 		IsConfigured:     isConfigured,
 		WelcomeMessage:   welcomeMessage,
-		ServerName: instanceName,
+		ServerName: serverName,
 		Motd:             motd,
 		BlockedUsernames: blockedUsernames,
 		Description:      description,

--- a/cli/internal/graph/dm_test.go
+++ b/cli/internal/graph/dm_test.go
@@ -82,13 +82,13 @@ func TestMutationResolver_StartDM(t *testing.T) {
 		}
 
 		// Create a restriction role, deny dms.write on it, and assign to user
-		if _, err := env.core.CreateInstanceRole(env.ctx, "dmblocked", "DM Blocked", ""); err != nil {
+		if _, err := env.core.CreateServerRole(env.ctx, "dmblocked", "DM Blocked", ""); err != nil {
 			t.Fatalf("failed to create role: %v", err)
 		}
 		if err := env.core.DenyInstancePermission(env.ctx, "dmblocked", core.PermDMWrite); err != nil {
 			t.Fatalf("failed to deny permission: %v", err)
 		}
-		if err := env.core.AssignInstanceRole(env.ctx, core.SystemActorID, blockedUser.Id, "dmblocked"); err != nil {
+		if err := env.core.AssignServerRole(env.ctx, core.SystemActorID, blockedUser.Id, "dmblocked"); err != nil {
 			t.Fatalf("failed to assign role: %v", err)
 		}
 

--- a/cli/internal/graph/linkpreview.resolvers.go
+++ b/cli/internal/graph/linkpreview.resolvers.go
@@ -23,12 +23,12 @@ func (r *linkPreviewResolver) ImageURL(ctx context.Context, obj *corev1.LinkPrev
 
 	if width != nil && height != nil && fit != nil {
 		fitLower := strings.ToLower(string(*fit))
-		url := r.core.GetTransformedInstanceAssetURL(imageAssetId, int(*width), int(*height), fitLower)
+		url := r.core.GetTransformedServerAssetURL(imageAssetId, int(*width), int(*height), fitLower)
 		return &url, nil
 	}
 
 	// Default: 400x400 contain for backwards compatibility
-	url := r.core.GetTransformedInstanceAssetURL(imageAssetId, 400, 400, "contain")
+	url := r.core.GetTransformedServerAssetURL(imageAssetId, 400, 400, "contain")
 	return &url, nil
 }
 

--- a/cli/internal/graph/mutation.resolvers.go
+++ b/cli/internal/graph/mutation.resolvers.go
@@ -516,7 +516,7 @@ func (r *mutationResolver) UpdateServer(ctx context.Context, input model.UpdateS
 			return nil, fmt.Errorf("save instance config: %w", err)
 		}
 		// Live-update is best-effort; the config write already succeeded.
-		_ = r.core.PublishInstanceConfigUpdated(
+		_ = r.core.PublishServerConfigUpdated(
 			ctx,
 			user.Id,
 			updated.ServerName,
@@ -526,7 +526,7 @@ func (r *mutationResolver) UpdateServer(ctx context.Context, input model.UpdateS
 		)
 	}
 
-	return r.instanceModel(), nil
+	return r.serverModel(), nil
 }
 
 // UploadServerLogo is the resolver for the uploadServerLogo field.
@@ -536,17 +536,17 @@ func (r *mutationResolver) UploadServerLogo(ctx context.Context, input model.Upl
 		return nil, err
 	}
 
-	asset, err := r.core.UploadInstanceLogo(ctx, input.File.File)
+	asset, err := r.core.UploadServerLogo(ctx, input.File.File)
 	if err != nil {
 		return nil, fmt.Errorf("failed to upload logo: %w", err)
 	}
 
-	if err := r.core.SetInstanceLogo(ctx, user.Id, asset); err != nil {
+	if err := r.core.SetServerLogo(ctx, user.Id, asset); err != nil {
 		r.core.CleanupAsset(ctx, asset)
 		return nil, fmt.Errorf("failed to save logo: %w", err)
 	}
 
-	return r.instanceModel(), nil
+	return r.serverModel(), nil
 }
 
 // DeleteServerLogo is the resolver for the deleteServerLogo field.
@@ -556,11 +556,11 @@ func (r *mutationResolver) DeleteServerLogo(ctx context.Context) (*model.Server,
 		return nil, err
 	}
 
-	if err := r.core.DeleteInstanceLogo(ctx, user.Id); err != nil {
+	if err := r.core.DeleteServerLogo(ctx, user.Id); err != nil {
 		return nil, fmt.Errorf("failed to delete logo: %w", err)
 	}
 
-	return r.instanceModel(), nil
+	return r.serverModel(), nil
 }
 
 // UploadServerBanner is the resolver for the uploadServerBanner field.
@@ -570,17 +570,17 @@ func (r *mutationResolver) UploadServerBanner(ctx context.Context, input model.U
 		return nil, err
 	}
 
-	asset, err := r.core.UploadInstanceBanner(ctx, input.File.File)
+	asset, err := r.core.UploadServerBanner(ctx, input.File.File)
 	if err != nil {
 		return nil, fmt.Errorf("failed to upload banner: %w", err)
 	}
 
-	if err := r.core.SetInstanceBanner(ctx, user.Id, asset); err != nil {
+	if err := r.core.SetServerBanner(ctx, user.Id, asset); err != nil {
 		r.core.CleanupAsset(ctx, asset)
 		return nil, fmt.Errorf("failed to save banner: %w", err)
 	}
 
-	return r.instanceModel(), nil
+	return r.serverModel(), nil
 }
 
 // DeleteServerBanner is the resolver for the deleteServerBanner field.
@@ -590,11 +590,11 @@ func (r *mutationResolver) DeleteServerBanner(ctx context.Context) (*model.Serve
 		return nil, err
 	}
 
-	if err := r.core.DeleteInstanceBanner(ctx, user.Id); err != nil {
+	if err := r.core.DeleteServerBanner(ctx, user.Id); err != nil {
 		return nil, fmt.Errorf("failed to delete banner: %w", err)
 	}
 
-	return r.instanceModel(), nil
+	return r.serverModel(), nil
 }
 
 // JoinRoom is the resolver for the joinRoom field.

--- a/cli/internal/graph/mutation_test.go
+++ b/cli/internal/graph/mutation_test.go
@@ -798,10 +798,10 @@ func TestMarkThreadAsOpened_Authorization(t *testing.T) {
 }
 
 // ============================================================================
-// DeleteInstanceLogo Authorization Tests
+// DeleteServerLogo Authorization Tests
 // ============================================================================
 
-func TestDeleteInstanceLogo_Authorization(t *testing.T) {
+func TestDeleteServerLogo_Authorization(t *testing.T) {
 	env := setupTestResolver(t)
 	mutation := env.resolver.Mutation()
 

--- a/cli/internal/graph/query_test.go
+++ b/cli/internal/graph/query_test.go
@@ -645,13 +645,13 @@ func TestQueryResolver_Instance(t *testing.T) {
 
 		// Get the config from the instance
 		configResolver := resolver.ServerConfig()
-		instanceConfig, err := resolver.Server().Config(context.Background(), instance)
+		serverConfig, err := resolver.Server().Config(context.Background(), instance)
 		if err != nil {
 			t.Fatalf("Unexpected error getting config: %v", err)
 		}
 
 		// Check welcome message is nil when core is not initialized
-		welcomeMsg, err := configResolver.WelcomeMessage(context.Background(), instanceConfig)
+		welcomeMsg, err := configResolver.WelcomeMessage(context.Background(), serverConfig)
 		if err != nil {
 			t.Fatalf("Unexpected error getting welcome message: %v", err)
 		}

--- a/cli/internal/graph/role_permissions_helpers.go
+++ b/cli/internal/graph/role_permissions_helpers.go
@@ -40,7 +40,7 @@ func (r *Resolver) buildRoleAcrossTiers(
 	roleName string,
 	spaceID, roomID string,
 ) (*model.RoleAcrossTiers, error) {
-	role, err := r.core.GetInstanceRole(ctx, roleName)
+	role, err := r.core.GetServerRole(ctx, roleName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load role: %w", err)
 	}
@@ -60,11 +60,11 @@ func (r *Resolver) buildRoleAcrossTiers(
 		out.ApplicablePermissions = append(out.ApplicablePermissions, string(meta.Permission))
 	}
 
-	grants, err := r.core.GetInstanceRolePermissions(ctx, roleName)
+	grants, err := r.core.GetServerRolePermissions(ctx, roleName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load grants: %w", err)
 	}
-	denials, err := r.core.GetInstanceRolePermissionDenials(ctx, roleName)
+	denials, err := r.core.GetServerRolePermissionDenials(ctx, roleName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load denials: %w", err)
 	}
@@ -92,7 +92,7 @@ func (r *Resolver) buildTierRoles(ctx context.Context, spaceID, roomID string) (
 		out.ApplicablePermissions = append(out.ApplicablePermissions, string(meta.Permission))
 	}
 
-	roles, err := r.core.ListInstanceRoles(ctx)
+	roles, err := r.core.ListServerRoles(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list roles: %w", err)
 	}
@@ -132,11 +132,11 @@ func (r *Resolver) buildTierRole(
 		Position:    role.Position,
 	}
 
-	serverGrants, err := r.core.GetInstanceRolePermissions(ctx, role.Name)
+	serverGrants, err := r.core.GetServerRolePermissions(ctx, role.Name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load server grants: %w", err)
 	}
-	serverDenials, err := r.core.GetInstanceRolePermissionDenials(ctx, role.Name)
+	serverDenials, err := r.core.GetServerRolePermissionDenials(ctx, role.Name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load server denials: %w", err)
 	}

--- a/cli/internal/graph/server.resolvers.go
+++ b/cli/internal/graph/server.resolvers.go
@@ -303,7 +303,7 @@ func (r *serverConfigResolver) LogoURL(ctx context.Context, obj *model.ServerCon
 		wv, hv := int(*width), int(*height)
 		w, h = &wv, &hv
 	}
-	url, err := r.core.GetInstanceLogoURL(ctx, w, h)
+	url, err := r.core.GetServerLogoURL(ctx, w, h)
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +320,7 @@ func (r *serverConfigResolver) BannerURL(ctx context.Context, obj *model.ServerC
 		wv, hv := int(*width), int(*height)
 		w, h = &wv, &hv
 	}
-	url, err := r.core.GetInstanceBannerURL(ctx, w, h)
+	url, err := r.core.GetServerBannerURL(ctx, w, h)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/graph/server_helpers.go
+++ b/cli/internal/graph/server_helpers.go
@@ -27,7 +27,7 @@ func (r *Resolver) requireServerSpaceID(ctx context.Context) (string, error) {
 		return "", err
 	}
 	if id == "" {
-		return "", core.ErrInstanceNotBootstrapped
+		return "", core.ErrServerNotBootstrapped
 	}
 	return id, nil
 }
@@ -41,9 +41,9 @@ func (r *Resolver) resolveRoomSpaceID(ctx context.Context, roomID string) (strin
 	return r.core.FindRoomSpaceID(ctx, roomID)
 }
 
-// instanceModel constructs the singleton Instance value used as the receiver
+// serverModel constructs the singleton Instance value used as the receiver
 // for instance-scoped mutation results.
-func (r *mutationResolver) instanceModel() *model.Server {
+func (r *mutationResolver) serverModel() *model.Server {
 	return &model.Server{
 		Version:              r.version,
 		EnabledAuthProviders: r.authConfig.EnabledProviders(),

--- a/cli/internal/graph/server_rbac.resolvers.go
+++ b/cli/internal/graph/server_rbac.resolvers.go
@@ -23,7 +23,7 @@ func (r *adminQueriesResolver) Role(ctx context.Context, obj *model.AdminQueries
 	}
 
 	// No additional authorization - admin context already verified by parent resolver
-	role, err := r.core.GetInstanceRole(ctx, name)
+	role, err := r.core.GetServerRole(ctx, name)
 	if err != nil {
 		if err == core.ErrRoleNotFound {
 			return nil, nil
@@ -129,7 +129,7 @@ func (r *mutationResolver) GrantServerPermission(ctx context.Context, input mode
 	}
 
 	// Authorization: config admin or admin.manage-roles permission
-	can, err := r.canManageInstanceRoles(ctx, user.Id)
+	can, err := r.canManageServerRoles(ctx, user.Id)
 	if err != nil {
 		return false, err
 	}
@@ -151,7 +151,7 @@ func (r *mutationResolver) RevokeServerPermission(ctx context.Context, input mod
 	}
 
 	// Authorization: config admin or admin.manage-roles permission
-	can, err := r.canManageInstanceRoles(ctx, user.Id)
+	can, err := r.canManageServerRoles(ctx, user.Id)
 	if err != nil {
 		return false, err
 	}
@@ -173,7 +173,7 @@ func (r *mutationResolver) DenyServerPermission(ctx context.Context, input model
 	}
 
 	// Authorization: config admin or admin.manage-roles permission
-	can, err := r.canManageInstanceRoles(ctx, user.Id)
+	can, err := r.canManageServerRoles(ctx, user.Id)
 	if err != nil {
 		return false, err
 	}
@@ -195,7 +195,7 @@ func (r *mutationResolver) ClearServerPermissionState(ctx context.Context, input
 	}
 
 	// Authorization: config admin or admin.manage-roles permission
-	can, err := r.canManageInstanceRoles(ctx, user.Id)
+	can, err := r.canManageServerRoles(ctx, user.Id)
 	if err != nil {
 		return false, err
 	}
@@ -217,7 +217,7 @@ func (r *mutationResolver) CreateRole(ctx context.Context, input model.CreateRol
 	}
 
 	// Authorization: config admin or admin.manage-roles permission
-	can, err := r.canManageInstanceRoles(ctx, user.Id)
+	can, err := r.canManageServerRoles(ctx, user.Id)
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +225,7 @@ func (r *mutationResolver) CreateRole(ctx context.Context, input model.CreateRol
 		return nil, core.ErrPermissionDenied
 	}
 
-	role, err := r.core.CreateInstanceRole(ctx, input.Name, input.DisplayName, input.Description)
+	role, err := r.core.CreateServerRole(ctx, input.Name, input.DisplayName, input.Description)
 	if err != nil {
 		return nil, err
 	}
@@ -240,7 +240,7 @@ func (r *mutationResolver) UpdateRole(ctx context.Context, input model.UpdateRol
 	}
 
 	// Authorization: config admin or admin.manage-roles permission
-	can, err := r.canManageInstanceRoles(ctx, user.Id)
+	can, err := r.canManageServerRoles(ctx, user.Id)
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +248,7 @@ func (r *mutationResolver) UpdateRole(ctx context.Context, input model.UpdateRol
 		return nil, core.ErrPermissionDenied
 	}
 
-	role, err := r.core.UpdateInstanceRole(ctx, input.Name, input.DisplayName, input.Description)
+	role, err := r.core.UpdateServerRole(ctx, input.Name, input.DisplayName, input.Description)
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +263,7 @@ func (r *mutationResolver) DeleteRole(ctx context.Context, input model.DeleteRol
 	}
 
 	// Authorization: config admin or admin.manage-roles permission
-	can, err := r.canManageInstanceRoles(ctx, user.Id)
+	can, err := r.canManageServerRoles(ctx, user.Id)
 	if err != nil {
 		return false, err
 	}
@@ -271,7 +271,7 @@ func (r *mutationResolver) DeleteRole(ctx context.Context, input model.DeleteRol
 		return false, core.ErrPermissionDenied
 	}
 
-	if err := r.core.DeleteInstanceRole(ctx, input.Name); err != nil {
+	if err := r.core.DeleteServerRole(ctx, input.Name); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -293,7 +293,7 @@ func (r *mutationResolver) AssignRole(ctx context.Context, input model.AssignRol
 		return false, core.ErrPermissionDenied
 	}
 
-	if err := r.core.AssignInstanceRole(ctx, caller.Id, input.UserID, input.RoleName); err != nil {
+	if err := r.core.AssignServerRole(ctx, caller.Id, input.UserID, input.RoleName); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -328,7 +328,7 @@ func (r *mutationResolver) RevokeRole(ctx context.Context, input model.RevokeRol
 		}
 	}
 
-	if err := r.core.RevokeInstanceRole(ctx, caller.Id, input.UserID, input.RoleName); err != nil {
+	if err := r.core.RevokeServerRole(ctx, caller.Id, input.UserID, input.RoleName); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -342,7 +342,7 @@ func (r *mutationResolver) ReorderRoles(ctx context.Context, input model.Reorder
 	}
 
 	// Authorization: config admin or admin.roles.manage permission
-	can, err := r.canManageInstanceRoles(ctx, caller.Id)
+	can, err := r.canManageServerRoles(ctx, caller.Id)
 	if err != nil {
 		return nil, err
 	}
@@ -350,7 +350,7 @@ func (r *mutationResolver) ReorderRoles(ctx context.Context, input model.Reorder
 		return nil, core.ErrPermissionDenied
 	}
 
-	roles, err := r.core.ReorderInstanceRoles(ctx, input.RoleNames)
+	roles, err := r.core.ReorderServerRoles(ctx, input.RoleNames)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/graph/server_rbac_extra.resolvers.go
+++ b/cli/internal/graph/server_rbac_extra.resolvers.go
@@ -90,7 +90,7 @@ func (r *roomResolver) RoomPermissionOverrides(ctx context.Context, obj *corev1.
 		return nil, core.ErrPermissionDenied
 	}
 
-	roles, err := r.core.ListInstanceRoles(ctx)
+	roles, err := r.core.ListServerRoles(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +146,7 @@ func (r *serverResolver) Roles(ctx context.Context, obj *model.Server) ([]*core.
 		return nil, err
 	}
 
-	roles, err := r.core.ListInstanceRoles(ctx)
+	roles, err := r.core.ListServerRoles(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +168,7 @@ func (r *serverResolver) Role(ctx context.Context, obj *model.Server, name strin
 		return nil, err
 	}
 
-	role, err := r.core.GetInstanceRole(ctx, name)
+	role, err := r.core.GetServerRole(ctx, name)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/graph/voice.resolvers.go
+++ b/cli/internal/graph/voice.resolvers.go
@@ -33,7 +33,7 @@ func (r *queryResolver) VoiceCallToken(ctx context.Context, roomID string) (*cor
 	avatarSize := 96
 	avatarURL, _ := r.core.GetUserAvatarURL(ctx, user.Id, &avatarSize, &avatarSize)
 
-	roomName := core.LiveKitRoomName(r.livekitConfig.InstanceID, spaceID, roomID)
+	roomName := core.LiveKitRoomName(r.livekitConfig.ServerID, spaceID, roomID)
 	token, err := core.GenerateVoiceCallToken(
 		r.livekitConfig.APIKey,
 		r.livekitConfig.APISecret,

--- a/cli/internal/http_server/assets.go
+++ b/cli/internal/http_server/assets.go
@@ -67,7 +67,7 @@ func (s *HTTPServer) serveInstanceAsset(c *gin.Context) {
 	s.logger.Debug("Serving instance asset", "asset_id", path)
 
 	// Probe both NATS and S3 backends
-	reader, info, err := s.core.GetInstanceAssetFromAnyBackend(c.Request.Context(), path)
+	reader, info, err := s.core.GetServerAssetFromAnyBackend(c.Request.Context(), path)
 	if err != nil {
 		s.logger.Error("Failed to get instance asset", "error", err, "asset_id", path)
 		c.JSON(http.StatusNotFound, gin.H{"error": "Asset not found"})
@@ -326,7 +326,7 @@ func (s *HTTPServer) serveTransformedInstanceAsset(c *gin.Context, key, signedPa
 		AssetID:     key,
 		FetchAsset: func(ctx context.Context) (io.Reader, string, error) {
 			// Probe both NATS and S3 backends
-			reader, info, err := s.core.GetInstanceAssetFromAnyBackend(ctx, key)
+			reader, info, err := s.core.GetServerAssetFromAnyBackend(ctx, key)
 			if err != nil {
 				s.logger.Debug("Failed to fetch instance asset",
 					"asset_id", key,

--- a/cli/internal/http_server/assets_test.go
+++ b/cli/internal/http_server/assets_test.go
@@ -651,7 +651,7 @@ func TestAsset_InstanceAsset_HasCacheHeaders(t *testing.T) {
 	avatarData := createAssetTestPNG(t, 200, 200)
 	avatarPath := fmt.Sprintf("avatar/%s.png", user.Id)
 
-	store := env.core.InstanceStore()
+	store := env.core.ServerStore()
 	_, err = store.PutBytes(env.ctx, avatarPath, avatarData)
 	if err != nil {
 		t.Fatalf("Failed to upload avatar: %v", err)

--- a/cli/internal/http_server/opengraph.go
+++ b/cli/internal/http_server/opengraph.go
@@ -127,11 +127,11 @@ func (s *HTTPServer) getOpenGraphMeta(ctx context.Context, urlPath string) *Open
 
 	// Get instance name for both site_name and og:title — server identity
 	// is the single source of truth for link previews.
-	instanceName := "Chatto"
+	serverName := "Chatto"
 	description := "Real-time chat application"
 	if s.core != nil && s.core.ConfigManager() != nil {
 		if name, err := s.core.ConfigManager().GetEffectiveInstanceName(ctx); err == nil && name != "" {
-			instanceName = name
+			serverName = name
 		}
 		if desc, err := s.core.ConfigManager().GetEffectiveDescription(ctx); err == nil && desc != "" {
 			description = desc
@@ -142,7 +142,7 @@ func (s *HTTPServer) getOpenGraphMeta(ctx context.Context, urlPath string) *Open
 	var defaultImage string
 	if s.core != nil {
 		width, height := 1200, 630
-		bannerURL, err := s.core.GetInstanceBannerURL(ctx, &width, &height)
+		bannerURL, err := s.core.GetServerBannerURL(ctx, &width, &height)
 		if err == nil && bannerURL != "" {
 			defaultImage = bannerURL
 		}
@@ -150,18 +150,18 @@ func (s *HTTPServer) getOpenGraphMeta(ctx context.Context, urlPath string) *Open
 
 	// Default metadata (for /, /login, /register, etc.)
 	defaultMeta := &OpenGraphMeta{
-		Title:       instanceName,
+		Title:       serverName,
 		Description: description,
 		Image:       defaultImage,
 		URL:         baseURL + urlPath,
 		Type:        "website",
-		SiteName:    instanceName,
+		SiteName:    serverName,
 	}
 
-	// Check for space routes: /chat/{instanceSegment}/{spaceId}/*
-	var instanceSegment, spaceID string
+	// Check for space routes: /chat/{serverSegment}/{spaceId}/*
+	var serverSegment, spaceID string
 	if matches := spaceRoutePattern.FindStringSubmatch(urlPath); len(matches) > 2 {
-		instanceSegment = matches[1]
+		serverSegment = matches[1]
 		spaceID = matches[2]
 	}
 
@@ -169,14 +169,14 @@ func (s *HTTPServer) getOpenGraphMeta(ctx context.Context, urlPath string) *Open
 	if spaceID != "" && !isSpecialRoute(spaceID) {
 		// Remote instance: we can't look up the space locally, but we can
 		// point crawlers to the canonical URL on the instance that owns it.
-		if instanceSegment != "" && instanceSegment != "-" {
-			canonicalURL := fmt.Sprintf("https://%s/chat/-/%s", instanceSegment, spaceID)
+		if serverSegment != "" && serverSegment != "-" {
+			canonicalURL := fmt.Sprintf("https://%s/chat/-/%s", serverSegment, spaceID)
 			defaultMeta.CanonicalURL = canonicalURL
 			defaultMeta.URL = canonicalURL
 			return defaultMeta
 		}
 
-		if meta := s.getSpaceOpenGraphMeta(ctx, spaceID, urlPath, baseURL, instanceName); meta != nil {
+		if meta := s.getSpaceOpenGraphMeta(ctx, spaceID, urlPath, baseURL, serverName); meta != nil {
 			return meta
 		}
 	}
@@ -196,7 +196,7 @@ func isSpecialRoute(segment string) bool {
 }
 
 // getSpaceOpenGraphMeta fetches space-specific metadata with caching.
-func (s *HTTPServer) getSpaceOpenGraphMeta(ctx context.Context, spaceID, urlPath, baseURL, instanceName string) *OpenGraphMeta {
+func (s *HTTPServer) getSpaceOpenGraphMeta(ctx context.Context, spaceID, urlPath, baseURL, serverName string) *OpenGraphMeta {
 	// Check cache first
 	cacheKey := "space:" + spaceID
 	if cached, ok := s.ogCache.get(cacheKey); ok {
@@ -214,13 +214,13 @@ func (s *HTTPServer) getSpaceOpenGraphMeta(ctx context.Context, spaceID, urlPath
 
 	// Build metadata
 	title := space.Name
-	if instanceName != "" && instanceName != space.Name {
-		title = space.Name + " | " + instanceName
+	if serverName != "" && serverName != space.Name {
+		title = space.Name + " | " + serverName
 	}
 
 	description := space.Description
 	if description == "" {
-		description = fmt.Sprintf("Join %s on %s", space.Name, instanceName)
+		description = fmt.Sprintf("Join %s on %s", space.Name, serverName)
 	}
 
 	// Get space banner for og:image (1200x630 is optimal for social sharing),
@@ -243,7 +243,7 @@ func (s *HTTPServer) getSpaceOpenGraphMeta(ctx context.Context, spaceID, urlPath
 		Image:       imageURL,
 		URL:         baseURL + urlPath,
 		Type:        "website",
-		SiteName:    instanceName,
+		SiteName:    serverName,
 	}
 
 	// Cache the result (without URL, as that changes per-path)

--- a/cli/internal/http_server/opengraph_test.go
+++ b/cli/internal/http_server/opengraph_test.go
@@ -125,7 +125,7 @@ func TestOpenGraphMetaGenerateTags(t *testing.T) {
 func TestRoutePatternMatching(t *testing.T) {
 	tests := []struct {
 		path              string
-		expectInstanceSeg string
+		expectServerSeg string
 		expectSpaceID     string
 	}{
 		{"/chat/-/abc123", "-", "abc123"},
@@ -143,15 +143,15 @@ func TestRoutePatternMatching(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {
-			var instanceSeg, spaceID string
+			var serverSeg, spaceID string
 
 			if matches := spaceRoutePattern.FindStringSubmatch(tt.path); len(matches) > 2 {
-				instanceSeg = matches[1]
+				serverSeg = matches[1]
 				spaceID = matches[2]
 			}
 
-			if instanceSeg != tt.expectInstanceSeg {
-				t.Errorf("path %q: got instanceSeg %q, want %q", tt.path, instanceSeg, tt.expectInstanceSeg)
+			if serverSeg != tt.expectServerSeg {
+				t.Errorf("path %q: got serverSeg %q, want %q", tt.path, serverSeg, tt.expectServerSeg)
 			}
 			if spaceID != tt.expectSpaceID {
 				t.Errorf("path %q: got spaceID %q, want %q", tt.path, spaceID, tt.expectSpaceID)

--- a/cli/internal/http_server/server_info.go
+++ b/cli/internal/http_server/server_info.go
@@ -7,8 +7,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// instanceInfoResponse is the JSON response for GET /api/instance.
-type instanceInfoResponse struct {
+// serverInfoResponse is the JSON response for GET /api/instance.
+type serverInfoResponse struct {
 	Name             string   `json:"name"`
 	Version          string   `json:"version"`
 	AuthMethods      []string `json:"authMethods"`
@@ -85,16 +85,16 @@ func (s *HTTPServer) handleInstanceInfo(c *gin.Context) {
 	var bannerURL, iconURL string
 	if s.core != nil {
 		bw, bh := 1200, 630
-		if u, err := s.core.GetInstanceBannerURL(ctx, &bw, &bh); err == nil {
+		if u, err := s.core.GetServerBannerURL(ctx, &bw, &bh); err == nil {
 			bannerURL = absolutizeAssetURL(c, u)
 		}
 		lw, lh := 256, 256
-		if u, err := s.core.GetInstanceLogoURL(ctx, &lw, &lh); err == nil {
+		if u, err := s.core.GetServerLogoURL(ctx, &lw, &lh); err == nil {
 			iconURL = absolutizeAssetURL(c, u)
 		}
 	}
 
-	c.JSON(http.StatusOK, instanceInfoResponse{
+	c.JSON(http.StatusOK, serverInfoResponse{
 		Name:             name,
 		Version:          s.version,
 		AuthMethods:      authMethods,

--- a/cli/internal/http_server/server_info_test.go
+++ b/cli/internal/http_server/server_info_test.go
@@ -100,7 +100,7 @@ func TestInstanceInfo(t *testing.T) {
 			t.Fatalf("expected 200, got %d", w.Code)
 		}
 
-		var resp instanceInfoResponse
+		var resp serverInfoResponse
 		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 			t.Fatalf("failed to parse response: %v", err)
 		}
@@ -123,7 +123,7 @@ func TestInstanceInfo(t *testing.T) {
 		w := httptest.NewRecorder()
 		s.router.ServeHTTP(w, req)
 
-		var resp instanceInfoResponse
+		var resp serverInfoResponse
 		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 			t.Fatalf("failed to parse response: %v", err)
 		}
@@ -143,7 +143,7 @@ func TestInstanceInfo(t *testing.T) {
 		w := httptest.NewRecorder()
 		s.router.ServeHTTP(w, req)
 
-		var resp instanceInfoResponse
+		var resp serverInfoResponse
 		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 			t.Fatalf("failed to parse response: %v", err)
 		}
@@ -184,7 +184,7 @@ func TestInstanceInfo(t *testing.T) {
 		w := httptest.NewRecorder()
 		s.router.ServeHTTP(w, req)
 
-		var resp instanceInfoResponse
+		var resp serverInfoResponse
 		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 			t.Fatalf("failed to parse response: %v", err)
 		}
@@ -229,11 +229,11 @@ func TestInstanceInfo(t *testing.T) {
 		// (the case in this test), so we exercise the http_server's
 		// absolutize path.
 		ctx := testContext(t)
-		asset, err := s.core.UploadInstanceBanner(ctx, bannerImageBytes(t))
+		asset, err := s.core.UploadServerBanner(ctx, bannerImageBytes(t))
 		if err != nil {
 			t.Fatalf("upload banner: %v", err)
 		}
-		if err := s.core.SetInstanceBanner(ctx, "test-admin", asset); err != nil {
+		if err := s.core.SetServerBanner(ctx, "test-admin", asset); err != nil {
 			t.Fatalf("set banner: %v", err)
 		}
 
@@ -243,7 +243,7 @@ func TestInstanceInfo(t *testing.T) {
 		w := httptest.NewRecorder()
 		s.router.ServeHTTP(w, req)
 
-		var resp instanceInfoResponse
+		var resp serverInfoResponse
 		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 			t.Fatalf("failed to parse response: %v", err)
 		}
@@ -257,11 +257,11 @@ func TestInstanceInfo(t *testing.T) {
 		s := setupInstanceInfoServer(t, config.AuthConfig{})
 
 		ctx := testContext(t)
-		asset, err := s.core.UploadInstanceBanner(ctx, bannerImageBytes(t))
+		asset, err := s.core.UploadServerBanner(ctx, bannerImageBytes(t))
 		if err != nil {
 			t.Fatalf("upload banner: %v", err)
 		}
-		if err := s.core.SetInstanceBanner(ctx, "test-admin", asset); err != nil {
+		if err := s.core.SetServerBanner(ctx, "test-admin", asset); err != nil {
 			t.Fatalf("set banner: %v", err)
 		}
 
@@ -271,7 +271,7 @@ func TestInstanceInfo(t *testing.T) {
 		w := httptest.NewRecorder()
 		s.router.ServeHTTP(w, req)
 
-		var resp instanceInfoResponse
+		var resp serverInfoResponse
 		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 			t.Fatalf("failed to parse response: %v", err)
 		}
@@ -287,11 +287,11 @@ func TestInstanceInfo(t *testing.T) {
 		s.core.AssetBaseURL = "https://chat.example.com"
 
 		ctx := testContext(t)
-		asset, err := s.core.UploadInstanceBanner(ctx, bannerImageBytes(t))
+		asset, err := s.core.UploadServerBanner(ctx, bannerImageBytes(t))
 		if err != nil {
 			t.Fatalf("upload banner: %v", err)
 		}
-		if err := s.core.SetInstanceBanner(ctx, "test-admin", asset); err != nil {
+		if err := s.core.SetServerBanner(ctx, "test-admin", asset); err != nil {
 			t.Fatalf("set banner: %v", err)
 		}
 
@@ -300,7 +300,7 @@ func TestInstanceInfo(t *testing.T) {
 		w := httptest.NewRecorder()
 		s.router.ServeHTTP(w, req)
 
-		var resp instanceInfoResponse
+		var resp serverInfoResponse
 		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 			t.Fatalf("failed to parse response: %v", err)
 		}


### PR DESCRIPTION
## Summary

Mechanical Go-side cleanup matching the GraphQL schema rename in #416. No behavior change — per ADR-029, persisted names (NATS bucket strings, TOML config keys, asset URL paths) stay; only Go identifiers move. Renamed ChattoCore methods/types/errors/storage fields/locals/comments from `Instance*` to `Server*` (e.g. `AssignInstanceRole` → `AssignServerRole`, `UploadInstanceLogo` → `UploadServerLogo`, `InstanceAssetInfo` → `ServerAssetInfo`, `instanceConfigKV` → `runtimeConfigKV` to disambiguate from the unrelated `SERVER_CONFIG` bucket), `git mv`'d `instance_branding.go`/`instance_info{,_test}.go` to `server_*`, and renamed `BootstrapUser.InstanceRole` / `BootstrapConfig.Instance` / `LiveKitConfig.InstanceID` to their `Server*` counterparts (TOML tags preserved). Subject-string-tied helpers (`LiveInstance{User,Space}Event`, `StreamMyInstanceLiveEvents`, `isAuthorizedForInstanceEvent`) are intentionally left for Phase 6.

## Test plan

- [x] `go build -tags 'bootstrap test_endpoints' ./...`
- [x] `go vet -tags 'bootstrap test_endpoints' ./...`
- [x] `go test -tags test_endpoints ./internal/core/... ./internal/graph/... ./internal/http_server/...`
- [ ] Full CI green