### PR TITLE
feat(frontend): make member groups collapsible

### DIFF
--- a/frontend/e2e/pages/RoomPage.ts
+++ b/frontend/e2e/pages/RoomPage.ts
@@ -326,16 +326,18 @@ export class RoomPage {
 
   /**
    * Get the "Online (N)" section header in the member list.
+   * Uses getByRole so the accessible-name regex matches normalized text
+   * (the surrounding whitespace from the chevron span isn't included).
    */
   get onlineSectionHeader(): Locator {
-    return this.memberList.locator('button', { hasText: /^Online \(\d+\)$/ });
+    return this.memberList.getByRole('button', { name: /^Online \(\d+\)$/ });
   }
 
   /**
    * Get the "Offline (N)" section header in the member list.
    */
   get offlineSectionHeader(): Locator {
-    return this.memberList.locator('button', { hasText: /^Offline \(\d+\)$/ });
+    return this.memberList.getByRole('button', { name: /^Offline \(\d+\)$/ });
   }
 
   /**
@@ -392,8 +394,7 @@ export class RoomPage {
    * Returns an array of display name strings.
    */
   async getMemberDisplayNamesInOrder(): Promise<string[]> {
-    // Get all member list items (excluding section headers which have role="presentation")
-    const memberItems = this.memberList.locator('li:not([role="presentation"])');
+    const memberItems = this.memberList.locator('button.sidebar-item');
     const count = await memberItems.count();
     const displayNames: string[] = [];
 

--- a/frontend/e2e/pages/RoomPage.ts
+++ b/frontend/e2e/pages/RoomPage.ts
@@ -104,7 +104,7 @@ export class RoomPage {
    * Get a member's list item by their display name or login.
    */
   getMember(name: string): Locator {
-    return this.memberList.locator('li', { hasText: name });
+    return this.memberList.locator('button.sidebar-item', { hasText: name });
   }
 
   /**
@@ -328,14 +328,14 @@ export class RoomPage {
    * Get the "Online (N)" section header in the member list.
    */
   get onlineSectionHeader(): Locator {
-    return this.memberList.locator('li[role="presentation"]', { hasText: /^Online \(\d+\)$/ });
+    return this.memberList.locator('button', { hasText: /^Online \(\d+\)$/ });
   }
 
   /**
    * Get the "Offline (N)" section header in the member list.
    */
   get offlineSectionHeader(): Locator {
-    return this.memberList.locator('li[role="presentation"]', { hasText: /^Offline \(\d+\)$/ });
+    return this.memberList.locator('button', { hasText: /^Offline \(\d+\)$/ });
   }
 
   /**

--- a/frontend/src/lib/RoomList.svelte
+++ b/frontend/src/lib/RoomList.svelte
@@ -13,9 +13,8 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   import { page } from '$app/state';
   import { instanceIdToSegment } from '$lib/navigation';
   import { getActiveInstance } from '$lib/state/activeInstance.svelte';
-  import { type Snippet } from 'svelte';
-  import { slide } from 'svelte/transition';
   import { instanceRegistry } from '$lib/state/instance/registry.svelte';
+  import CollapsibleGroup from '$lib/ui/CollapsibleGroup.svelte';
   import type { CallRoomParticipant } from '$lib/state/instance/activeCallRooms.svelte';
   import {
     useSpaceEvent,
@@ -376,42 +375,6 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   </a>
 {/snippet}
 
-{#snippet collapsibleGroup(
-  groupId: string,
-  label: string,
-  rooms: SpaceRoom[],
-  link: Snippet<[SpaceRoom]>,
-  marginTopClass: string = 'mt-4'
-)}
-  {@const isCollapsed = collapsedSections.has(groupId)}
-  <div class={marginTopClass}>
-    <button
-      type="button"
-      onclick={() => toggleSection(groupId)}
-      class="hover:text-foreground flex w-full cursor-pointer items-center gap-2 px-3 py-1 text-xs font-semibold tracking-wider text-muted uppercase"
-    >
-      <span class="sidebar-icon">
-        <span
-          class={[
-            'iconify uil--angle-right-b transition-transform',
-            isCollapsed ? '' : 'rotate-90'
-          ]}
-        ></span>
-      </span>
-      {label}
-    </button>
-    <div class="sidebar-nav">
-      {#each rooms as room (room.id)}
-        {#if !isCollapsed || isHighlighted(room)}
-          <div transition:slide={{ duration: 150 }}>
-            {@render link(room)}
-          </div>
-        {/if}
-      {/each}
-    </div>
-  </div>
-{/snippet}
-
 {#snippet dmLink(room: SpaceRoom)}
   <a
     href={resolve('/chat/[instanceId]/(chrome)/[roomId]', { instanceId: instanceSegment, roomId: room.id })}
@@ -450,30 +413,64 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   {#if roomsStore.layoutSections && roomsStore.layoutSections.length > 0}
     <!-- Sectioned layout -->
     {#each visibleSections as section, i (section.id)}
-      {@render collapsibleGroup(
-        section.id,
-        section.name,
-        getSectionRooms(section),
-        roomLink,
-        i === 0 ? 'mt-4 first:mt-0' : 'mt-4'
-      )}
+      <CollapsibleGroup
+        label={section.name}
+        items={getSectionRooms(section)}
+        item={roomLink}
+        collapsed={collapsedSections.has(section.id)}
+        onToggle={() => toggleSection(section.id)}
+        keepVisibleWhenCollapsed={isHighlighted}
+        class={i === 0 ? 'mt-4 first:mt-0' : 'mt-4'}
+      />
     {/each}
 
     <!-- Unsectioned rooms (not in any section) -->
     {#if unsectionedRooms.length > 0}
-      {@render collapsibleGroup('__unsorted__', 'Other', unsectionedRooms, roomLink)}
+      <CollapsibleGroup
+        label="Other"
+        items={unsectionedRooms}
+        item={roomLink}
+        collapsed={collapsedSections.has('__unsorted__')}
+        onToggle={() => toggleSection('__unsorted__')}
+        keepVisibleWhenCollapsed={isHighlighted}
+        class="mt-4"
+      />
     {/if}
   {:else if unsectionedRooms.length > 0}
     <!-- Layout exists but defines no sections — render in the admin's saved
          order (unsectionedRoomIds), falling back to alphabetical for any new
          rooms added since the layout was last edited. -->
-    {@render collapsibleGroup('__rooms__', 'Rooms', unsectionedRooms, roomLink, 'mt-4 first:mt-0')}
+    <CollapsibleGroup
+      label="Rooms"
+      items={unsectionedRooms}
+      item={roomLink}
+      collapsed={collapsedSections.has('__rooms__')}
+      onToggle={() => toggleSection('__rooms__')}
+      keepVisibleWhenCollapsed={isHighlighted}
+      class="mt-4 first:mt-0"
+    />
   {:else if sortedRooms.length > 0}
     <!-- No layout configured at all — alphabetical fallback. -->
-    {@render collapsibleGroup('__rooms__', 'Rooms', sortedRooms, roomLink, 'mt-4 first:mt-0')}
+    <CollapsibleGroup
+      label="Rooms"
+      items={sortedRooms}
+      item={roomLink}
+      collapsed={collapsedSections.has('__rooms__')}
+      onToggle={() => toggleSection('__rooms__')}
+      keepVisibleWhenCollapsed={isHighlighted}
+      class="mt-4 first:mt-0"
+    />
   {/if}
 
   {#if dmRooms.length > 0}
-    {@render collapsibleGroup('__dms__', 'Direct Messages', dmRooms, dmLink)}
+    <CollapsibleGroup
+      label="Direct Messages"
+      items={dmRooms}
+      item={dmLink}
+      collapsed={collapsedSections.has('__dms__')}
+      onToggle={() => toggleSection('__dms__')}
+      keepVisibleWhenCollapsed={isHighlighted}
+      class="mt-4"
+    />
   {/if}
 </nav>

--- a/frontend/src/lib/ui/CollapsibleGroup.svelte
+++ b/frontend/src/lib/ui/CollapsibleGroup.svelte
@@ -1,0 +1,62 @@
+<!--
+@component
+
+A sidebar group with a collapsible header. The header is a button that toggles
+the `collapsed` state via `onToggle`; collapsed/expanded state is owned by the
+caller so it can persist (e.g. to localStorage).
+
+When collapsed, items are hidden unless `keepVisibleWhenCollapsed` returns true
+for them — useful for anchoring rows that demand attention (active, unread,
+mentions, …) so the user can always reach them.
+
+Used by `RoomList` (channels, DMs, layout sections) and `RoomInfo` (online /
+offline member groups).
+-->
+<script lang="ts" generics="T extends { id: string }">
+  import type { Snippet } from 'svelte';
+  import { slide } from 'svelte/transition';
+
+  interface Props {
+    label: string;
+    items: T[];
+    item: Snippet<[T]>;
+    collapsed: boolean;
+    onToggle: () => void;
+    keepVisibleWhenCollapsed?: (item: T) => boolean;
+    class?: string;
+  }
+
+  let {
+    label,
+    items,
+    item,
+    collapsed,
+    onToggle,
+    keepVisibleWhenCollapsed,
+    class: className
+  }: Props = $props();
+</script>
+
+<div class={className}>
+  <button
+    type="button"
+    onclick={onToggle}
+    class="flex w-full cursor-pointer items-center gap-2 px-3 py-1 text-xs font-semibold tracking-wider text-muted uppercase transition-colors hover:text-text"
+  >
+    <span class="sidebar-icon">
+      <span
+        class={['iconify uil--angle-right-b transition-transform', collapsed ? '' : 'rotate-90']}
+      ></span>
+    </span>
+    {label}
+  </button>
+  <div class="sidebar-nav">
+    {#each items as it (it.id)}
+      {#if !collapsed || keepVisibleWhenCollapsed?.(it)}
+        <div transition:slide={{ duration: 150 }}>
+          {@render item(it)}
+        </div>
+      {/if}
+    {/each}
+  </div>
+</div>

--- a/frontend/src/routes/chat/[instanceId]/(chrome)/[roomId]/RoomInfo.svelte
+++ b/frontend/src/routes/chat/[instanceId]/(chrome)/[roomId]/RoomInfo.svelte
@@ -11,10 +11,13 @@
   import { getLiveDisplayName, getLiveLogin } from '$lib/state/userProfiles.svelte';
   import { getServerPermissions } from '$lib/state/instance/permissions.svelte';
   import { getActiveInstance } from '$lib/state/activeInstance.svelte';
+  import CollapsibleGroup from '$lib/ui/CollapsibleGroup.svelte';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
   import ResizeHandle from '$lib/components/ResizeHandle.svelte';
   import { roomInfoWidth } from '$lib/state/roomInfoWidth.svelte';
   import { ROOM_INFO_MAX_WIDTH, ROOM_INFO_MIN_WIDTH } from '$lib/storage/roomInfoWidth';
+  import { instanceStorageKey } from '$lib/storage/instanceStorage';
+  import { SvelteSet } from 'svelte/reactivity';
 
   const getInstanceId = getActiveInstance();
 
@@ -58,28 +61,69 @@
     return status !== 'OFFLINE';
   }
 
-  // Sorted members: online first, then offline, alphabetically by display name within each group
-  // Note: We read presenceVersion to ensure $derived re-runs on any presence change.
-  // SvelteMap.size only changes when keys are added/removed, not when values change,
-  // so it missed updates like OFFLINE→ONLINE for users already in the map.
-  const sortedMembers = $derived(
-    (membersState.presenceVersion,
-    [...members].sort((a, b) => {
-      const aOnline = isOnlineStatus(getPresence(a));
-      const bOnline = isOnlineStatus(getPresence(b));
-      if (aOnline !== bOnline) return aOnline ? -1 : 1;
-      return getLiveDisplayName(a.id, a.displayName).localeCompare(
+  // Sort members alphabetically by display name within each presence group.
+  // Reading presenceVersion ensures $derived re-runs on any presence change —
+  // SvelteMap.size only changes when keys are added/removed, not when existing
+  // values change, so it would miss updates like OFFLINE→ONLINE.
+  function sortByName(list: RoomMember[]): RoomMember[] {
+    return [...list].sort((a, b) =>
+      getLiveDisplayName(a.id, a.displayName).localeCompare(
         getLiveDisplayName(b.id, b.displayName)
-      );
-    }))
+      )
+    );
+  }
+
+  const onlineMembers = $derived(
+    (membersState.presenceVersion,
+    sortByName(members.filter((m) => isOnlineStatus(getPresence(m)))))
+  );
+  const offlineMembers = $derived(
+    (membersState.presenceVersion,
+    sortByName(members.filter((m) => !isOnlineStatus(getPresence(m)))))
   );
 
-  // Count online/offline members (dependency on sortedMembers handles livePresence tracking)
-  const onlineCount = $derived(sortedMembers.filter((m) => isOnlineStatus(getPresence(m))).length);
-  const offlineCount = $derived(sortedMembers.length - onlineCount);
+  // --- Collapsed-group UI state (persisted to localStorage) ---
+
+  const ONLINE_GROUP = 'online';
+  const OFFLINE_GROUP = 'offline';
+
+  let collapsedGroups = new SvelteSet<string>();
+
+  function collapsedGroupsKey(): string {
+    return instanceStorageKey(getInstanceId(), 'room:collapsed-member-groups');
+  }
+
+  function loadCollapsedFromStorage() {
+    collapsedGroups.clear();
+    try {
+      const json = localStorage.getItem(collapsedGroupsKey());
+      if (json) {
+        for (const id of JSON.parse(json)) {
+          collapsedGroups.add(id);
+        }
+      }
+    } catch {
+      // ignore malformed localStorage data
+    }
+  }
+
+  function saveCollapsedGroups() {
+    localStorage.setItem(collapsedGroupsKey(), JSON.stringify([...collapsedGroups]));
+  }
+
+  function toggleGroup(groupId: string) {
+    if (collapsedGroups.has(groupId)) {
+      collapsedGroups.delete(groupId);
+    } else {
+      collapsedGroups.add(groupId);
+    }
+    saveCollapsedGroups();
+  }
+
+  loadCollapsedFromStorage();
 
   // Look up the selected member for the popover (rendered outside the {#each} loop
-  // to avoid Svelte reactivity cycles between the popover's $effect and sortedMembers' $derived)
+  // to avoid Svelte reactivity cycles between the popover's $effect and onlineMembers' $derived)
   const popoverMember = $derived(
     popoverMemberId ? (members.find((m) => m.id === popoverMemberId) ?? null) : null
   );
@@ -115,57 +159,26 @@
         {/each}
       </ul>
     {:else}
-      <ul role="list">
-        {#each sortedMembers as member, i (member.id)}
-          {@const isOnline = isOnlineStatus(getPresence(member))}
-          {@const prevMember = sortedMembers[i - 1]}
-          {@const isFirstOnline = isOnline && (i === 0 || !isOnlineStatus(getPresence(prevMember)))}
-          {@const isFirstOffline =
-            !isOnline && (i === 0 || isOnlineStatus(getPresence(prevMember)))}
+      {#if onlineMembers.length > 0}
+        <CollapsibleGroup
+          label="Online ({onlineMembers.length})"
+          items={onlineMembers}
+          item={memberRow}
+          collapsed={collapsedGroups.has(ONLINE_GROUP)}
+          onToggle={() => toggleGroup(ONLINE_GROUP)}
+        />
+      {/if}
 
-          {#if isFirstOnline && onlineCount > 0}
-            <li
-              class="px-2 pb-1 text-xs font-medium tracking-wide text-muted uppercase"
-              role="presentation"
-            >
-              Online ({onlineCount})
-            </li>
-          {/if}
-
-          {#if isFirstOffline && offlineCount > 0}
-            <li
-              class={[
-                'px-2 pb-1 text-xs font-medium tracking-wide text-muted uppercase',
-                i > 0 && 'pt-4'
-              ]}
-              role="presentation"
-            >
-              Offline ({offlineCount})
-            </li>
-          {/if}
-
-          <li>
-            <button
-              type="button"
-              class={['sidebar-item w-full cursor-pointer text-left', !isOnline && 'opacity-50']}
-              onclick={(e: MouseEvent) => togglePopover(member.id, e)}
-              oncontextmenu={(e: MouseEvent) => {
-                e.preventDefault();
-                togglePopover(member.id, e);
-              }}
-              title={`View profile of ${getLiveDisplayName(member.id, member.displayName)}`}
-            >
-              <UserAvatar user={member} size="sm" />
-              <div class="min-w-0 flex-1">
-                <div class="truncate">{getLiveDisplayName(member.id, member.displayName)}</div>
-                <div class="truncate text-xs text-muted">
-                  @{getLiveLogin(member.id, member.login)}
-                </div>
-              </div>
-            </button>
-          </li>
-        {/each}
-      </ul>
+      {#if offlineMembers.length > 0}
+        <CollapsibleGroup
+          label="Offline ({offlineMembers.length})"
+          items={offlineMembers}
+          item={memberRow}
+          collapsed={collapsedGroups.has(OFFLINE_GROUP)}
+          onToggle={() => toggleGroup(OFFLINE_GROUP)}
+          class="mt-4"
+        />
+      {/if}
     {/if}
 
     {#if popoverMember && popoverAnchorRect}
@@ -179,3 +192,25 @@
     {/if}
   </nav>
 </aside>
+
+{#snippet memberRow(member: RoomMember)}
+  {@const isOnline = isOnlineStatus(getPresence(member))}
+  <button
+    type="button"
+    class={['sidebar-item w-full cursor-pointer text-left', !isOnline && 'opacity-50']}
+    onclick={(e: MouseEvent) => togglePopover(member.id, e)}
+    oncontextmenu={(e: MouseEvent) => {
+      e.preventDefault();
+      togglePopover(member.id, e);
+    }}
+    title={`View profile of ${getLiveDisplayName(member.id, member.displayName)}`}
+  >
+    <UserAvatar user={member} size="sm" />
+    <div class="min-w-0 flex-1">
+      <div class="truncate">{getLiveDisplayName(member.id, member.displayName)}</div>
+      <div class="truncate text-xs text-muted">
+        @{getLiveLogin(member.id, member.login)}
+      </div>
+    </div>
+  </button>
+{/snippet}


### PR DESCRIPTION
## Summary

- Extract a shared `CollapsibleGroup` component (`$lib/ui/CollapsibleGroup.svelte`) for sidebar groups with a chevron header, slide animation, and an optional `keepVisibleWhenCollapsed` predicate.
- Use it in `RoomInfo.svelte` so the Online / Offline member groups are now collapsible, persisted per instance under `chatto:i:<instance>:room:collapsed-member-groups`.
- Refactor `RoomList.svelte` to consume the same component instead of its inline `collapsibleGroup` snippet — no behavior change for room sections / DMs.
- Fix the previously no-op `hover:text-foreground` on group headers (`--color-foreground` isn't defined in this theme): switch to `hover:text-text` with `transition-colors` for a real hover affordance on both rooms and members.
- Update e2e `RoomPage` selectors: section headers are now `<button>` (not `<li role="presentation">`) and member rows are `<button class="sidebar-item">` (not `<li>`).

## Test plan

- [ ] `mise x -- pnpm check` passes
- [ ] `mise x -- pnpm test:unit --run` passes
- [ ] Member pane: click Online / Offline headers — they collapse with slide, chevron rotates
- [ ] Reload — collapsed state persists per instance
- [ ] Live presence flips still re-bucket members (someone going online moves from Offline to Online)
- [ ] Room sidebar unchanged (channels, DMs, layout sections still collapse as before; highlighted rooms still pop through when collapsed)
- [ ] Hover over any group header — text shade subtly bumps from muted → text
- [ ] `mise test-e2e -g presence-indicators` and `account-deletion` still pass