### PR TITLE
fix(frontend): scale space banner correctly in Safari

### DIFF
--- a/frontend/src/routes/chat/[instanceId]/(chrome)/SpaceBanner.svelte
+++ b/frontend/src/routes/chat/[instanceId]/(chrome)/SpaceBanner.svelte
@@ -5,21 +5,17 @@
 </script>
 
 <div class="w-full p-2">
-  <div class="relative aspect-[1200/630] max-h-32 w-full">
-    <div class="absolute inset-0 overflow-hidden rounded-lg bg-surface-100">
-      <img
-        src={url}
-        alt=""
-        aria-hidden="true"
-        class="pointer-events-none h-full w-full scale-125 object-cover blur-2xl"
-      />
-    </div>
-    <div class="relative flex h-full w-full items-center justify-center">
-      <SkeletonImg
-        src={url}
-        alt="Server banner"
-        class="h-full w-auto rounded-lg shadow-lg"
-      />
-    </div>
+  <div class="relative h-32 w-full overflow-hidden rounded-lg bg-surface-100">
+    <img
+      src={url}
+      alt=""
+      aria-hidden="true"
+      class="pointer-events-none absolute inset-0 h-full w-full scale-125 object-cover blur-2xl"
+    />
+    <SkeletonImg
+      src={url}
+      alt="Server banner"
+      class="absolute inset-0 h-full w-full rounded-lg object-contain shadow-lg"
+    />
   </div>
 </div>


### PR DESCRIPTION
## Summary

The space banner in the chat sidebar was overflowing into the menu items below it in Safari, while rendering correctly in Chrome and Firefox.

The original layout combined `aspect-ratio` + `max-height` on the wrapper with a flex-centered `<img class="h-full w-auto">` foreground. Safari doesn't reliably resolve that chain — `max-height` wasn't capping the aspect-ratio-derived height, and the foreground image's percentage height didn't resolve, so it fell back near its intrinsic size and overflowed.

The fix gives the wrapper a definite `h-32`, and renders the blur and foreground as `absolute inset-0` siblings, with `object-contain` on the foreground for letterboxing. Visually identical in Chrome/Firefox; correct in Safari.

## Test plan

- [ ] Open a space with a banner in Safari and confirm the image is contained within the sidebar with blurred letterbox on the sides
- [ ] Confirm Chrome and Firefox still render as before
- [ ] Resize the sidebar and verify the banner stays within `h-32` and doesn't overlap the menu items below