### PR TITLE
refactor(cli): Phase 6 — rename live.instance.* NATS subjects to live.server.*

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -43,30 +43,34 @@ paths: ["cli/**"]
   - Publish to `live.` subject prefix via `publishLiveEvent()`
   - Bypasses JetStream storage entirely
 - **Adding new live event types** requires updates in TWO places:
-  1. Core handler: Add case in the `liveRoomMsgChan` switch inside `StreamMyServerEvents` (room-scoped) or in `StreamMyInstanceLiveEvents` (instance-scoped) — both in `core.go`
+  1. Core handler: Add case in the `liveRoomMsgChan` switch inside `StreamMyServerEvents` (room-scoped) or in `StreamMyLiveEvents` (deployment-wide user/space/config) — both in `core.go`
   2. GraphQL resolver: Add case in `liveEventResolver.Event` (`events.resolvers.go`)
   - Missing the resolver case causes events to silently fail at the GraphQL layer
 - **Avoid fan-out on publish**: When broadcasting events to multiple users (e.g., server updates), do NOT iterate through recipients and publish to each. Instead:
-  - Publish once to a scoped subject (e.g., `instance.space.{spaceId}.updated`)
+  - Publish once to a scoped subject (e.g., `live.server.space.{spaceId}.updated`)
   - Use server-side authorization filtering in the subscription handler
   - This scales to large numbers of users without N publish operations
 
-## Instance Event Authorization
+## Live Event Authorization
 
-Instance events use subject pattern `live.instance.{scope}.{id}.{eventType}` and are filtered by `isAuthorizedForInstanceEvent` in `core.go`:
+Deployment-wide live events use subject pattern `live.server.{scope}.{id}.{eventType}` and are filtered by `isAuthorizedForLiveEvent` in `core.go`:
 
-| Scope   | Subject Pattern                   | Delivered To                    |
-| ------- | --------------------------------- | ------------------------------- |
-| `user`  | `live.instance.user.{userId}.*`   | Only that user (private events) |
-| `space` | `live.instance.space.{spaceId}.*` | All space members               |
+| Scope    | Subject Pattern                  | Delivered To                                                       |
+| -------- | -------------------------------- | ------------------------------------------------------------------ |
+| `user`   | `live.server.user.{userId}.*`    | Only that user (private events; `profile_updated` is broadcast)    |
+| `space`  | `live.server.space.{spaceId}.*`  | All authenticated users (server membership is implicit)            |
+| `config` | `live.server.config.*`           | All authenticated users (server config is public)                  |
 
-**Adding a new instance event type:**
+Room/member live events use a separate root (`live.server.room.{kind}.>` and
+`live.server.member.>`) handled by `StreamMyServerEvents`.
+
+**Adding a new live event type:**
 
 1. Add protobuf message to `live_event.proto`
 2. Add to GraphQL schema in `events.graphqls` (type + union)
-3. Add `IsInstanceEventType()` method in `pb/chatto/core/v1/graphql.go`
-4. Add case in `unwrapInstanceEvent()` in `event_helpers.go`
-5. Publish using `subjects.InstanceUserEvent()` or `subjects.InstanceSpaceEvent()`
+3. Add `IsServerEventType()` method in `pb/chatto/core/v1/graphql.go`
+4. Add case in `unwrapServerEvent()` in `event_helpers.go`
+5. Publish using `subjects.LiveUserEvent()` or `subjects.LiveSpaceEvent()`
 6. Subscribe in frontend via `instanceEventBus.svelte.ts`
 
 **When to create a live event:** Any time a user action changes state that other tabs/devices or other UI components need to reflect in real-time. Common triggers:
@@ -76,7 +80,7 @@ Instance events use subject pattern `live.instance.{scope}.{id}.{eventType}` and
 
 If a mutation changes state visible in the UI and you don't publish a live event, the UI will be stale until refresh. Always consider: "Will other tabs or other components on the same page need to know about this change?"
 
-**Broadcasting user events to everyone**: By default, user-scoped events are private (only delivered to that user). To broadcast an event to all authenticated users (e.g., profile updates since profiles are public), add an explicit check in `isAuthorizedForInstanceEvent`:
+**Broadcasting user events to everyone**: By default, user-scoped events are private (only delivered to that user). To broadcast an event to all authenticated users (e.g., profile updates since profiles are public), add an explicit check in `isAuthorizedForLiveEvent`:
 
 ```go
 case "user":

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -828,25 +828,26 @@ func (c *ChattoCore) publishLiveServerEvent(_ context.Context, subject string, e
 	return nil
 }
 
-// publishLiveEvent publishes an InstanceEvent directly to a live.instance.> subject, bypassing JetStream storage.
-// Use this for instance-scoped notifications (user events, space lifecycle, config updates).
-// The subject should already include the "live.instance." prefix.
+// publishLiveEvent publishes a LiveEvent directly to a live.server.> subject,
+// bypassing JetStream storage. Use this for deployment-wide notifications
+// (user events, space lifecycle, config updates). The subject should already
+// include the "live.server." prefix.
 func (c *ChattoCore) publishLiveEvent(_ context.Context, subject string, event *corev1.LiveEvent) error {
-	if err := validateInstanceEvent(event); err != nil {
+	if err := validateLiveEvent(event); err != nil {
 		return err
 	}
 
 	eventData, err := proto.Marshal(event)
 	if err != nil {
-		return fmt.Errorf("failed to marshal instance event: %w", err)
+		return fmt.Errorf("failed to marshal live event: %w", err)
 	}
 
 	if err := c.nc.Publish(subject, eventData); err != nil {
-		return fmt.Errorf("failed to publish instance event to %s: %w", subject, err)
+		return fmt.Errorf("failed to publish live event to %s: %w", subject, err)
 	}
 
 	if err := c.nc.FlushTimeout(natsPublishFlushTimeout); err != nil {
-		return fmt.Errorf("failed to flush instance event to %s: %w", subject, err)
+		return fmt.Errorf("failed to flush live event to %s: %w", subject, err)
 	}
 	return nil
 }
@@ -952,9 +953,9 @@ func validateSpaceEvent(event *corev1.ServerEvent) error {
 	return nil
 }
 
-func validateInstanceEvent(event *corev1.LiveEvent) error {
+func validateLiveEvent(event *corev1.LiveEvent) error {
 	if event == nil || event.Event == nil {
-		return fmt.Errorf("%w: instance event payload is nil or oneof field is unset", ErrInvalidEvent)
+		return fmt.Errorf("%w: live event payload is nil or oneof field is unset", ErrInvalidEvent)
 	}
 	return nil
 }
@@ -974,7 +975,7 @@ func newServerEvent(actorID string, event *corev1.ServerEvent) *corev1.ServerEve
 	return event
 }
 
-// newLiveEvent fills in the Id, ActorID, and CreatedAt fields of an InstanceEvent if they're not already set.
+// newLiveEvent fills in the Id, ActorID, and CreatedAt fields of a LiveEvent if they're not already set.
 // The caller provides the event with the concrete event type already set.
 func newLiveEvent(actorID string, event *corev1.LiveEvent) *corev1.LiveEvent {
 	if event.Id == "" {
@@ -1394,30 +1395,46 @@ func (c *ChattoCore) StreamMyServerEvents(ctx context.Context, userID string) (<
 	return eventChan, nil
 }
 
-// StreamMyLiveEvents creates a live stream of instance-level events
-// relevant to a specific user. Subscribes to live.instance.> and performs
-// server-side authorization filtering to deliver only events the user is
-// authorized to see:
-//   - User events (instance.user.{userId}.*): Only if userId matches subscriber
-//   - Space events (instance.space.{spaceId}.*): Only if user is a space member
+// StreamMyLiveEvents creates a live stream of deployment-wide events
+// relevant to a specific user. Subscribes to the user-, space-, and
+// config-scoped live subjects and performs server-side authorization
+// filtering to deliver only events the user is authorized to see:
+//   - User events (live.server.user.{userId}.*): Only if userId matches subscriber
+//   - Space events (live.server.space.{spaceId}.*): Delivered to all (every authed
+//     user is implicitly a server member)
+//   - Config events (live.server.config.*): Delivered to all authenticated users
+//
+// Three explicit wildcard subscriptions (rather than a single live.server.>)
+// keep this stream separate from the room/member subscriptions in
+// StreamMyServerEvents, which share the live.server.* root.
 //
 // Only delivers new events that occur after subscription starts.
 // The returned channel will be closed when the context is cancelled.
 func (c *ChattoCore) StreamMyLiveEvents(ctx context.Context, userID string) (<-chan *corev1.LiveEvent, error) {
-	// Subscribe to all live instance events via NATS Core
-	liveSubject := subjects.LiveInstanceAllEvents()
 	msgChan := make(chan *nats.Msg, 64)
-	sub, err := c.nc.ChanSubscribe(liveSubject, msgChan)
-	if err != nil {
-		return nil, fmt.Errorf("failed to subscribe to live instance events: %w", err)
+	wildcards := []string{
+		subjects.LiveUserScopedAllEvents(),
+		subjects.LiveSpaceScopedAllEvents(),
+		subjects.LiveConfigAllEvents(),
+	}
+	subs := make([]*nats.Subscription, 0, len(wildcards))
+	for _, subj := range wildcards {
+		s, err := c.nc.ChanSubscribe(subj, msgChan)
+		if err != nil {
+			for _, prior := range subs {
+				prior.Unsubscribe()
+			}
+			return nil, fmt.Errorf("failed to subscribe to %s: %w", subj, err)
+		}
+		subs = append(subs, s)
 	}
 
 	eventChan := make(chan *corev1.LiveEvent)
 
 	go func() {
-		c.logger.Debug("Starting instance event stream (NATS Core)", "user_id", userID, "subject", liveSubject)
+		c.logger.Debug("Starting live event stream", "user_id", userID, "subjects", wildcards)
 
-		// Set initial presence — subscribing to instance events means the client is online
+		// Set initial presence — subscribing to live events means the client is online
 		if err := c.SetPresence(ctx, userID, PresenceStatusOnline); err != nil {
 			c.logger.Warn("Failed to set initial presence", "error", err, "user_id", userID)
 		}
@@ -1427,8 +1444,10 @@ func (c *ChattoCore) StreamMyLiveEvents(ctx context.Context, userID string) (<-c
 		defer presenceTicker.Stop()
 
 		defer func() {
-			c.logger.Debug("Instance event stream closed", "user_id", userID)
-			sub.Unsubscribe()
+			c.logger.Debug("Live event stream closed", "user_id", userID)
+			for _, s := range subs {
+				s.Unsubscribe()
+			}
 			close(eventChan)
 		}()
 
@@ -1467,9 +1486,9 @@ func (c *ChattoCore) StreamMyLiveEvents(ctx context.Context, userID string) (<-c
 					}
 				} else if !c.isAuthorizedForLiveEvent(ctx, userID, msg.Subject) {
 					// Server-side authorization filtering based on subject pattern
-					// Subject format: live.instance.{type}.{id}.{eventType}
-					// - live.instance.user.{userId}.* → only forward to that user
-					// - live.instance.space.{spaceId}.* → only forward to space members
+					// Subject format: live.server.{type}.{id}.{eventType}
+					// - live.server.user.{userId}.* → only forward to that user
+					// - live.server.space.{spaceId}.* → only forward to space members
 					continue
 				}
 
@@ -1484,7 +1503,7 @@ func (c *ChattoCore) StreamMyLiveEvents(ctx context.Context, userID string) (<-c
 					// The frontend will receive the event and handle logout;
 					// closing the channel ensures the server also tears down the subscription.
 					if event.GetSessionTerminated() != nil {
-						c.logger.Info("Session terminated - closing instance event stream", "user_id", userID)
+						c.logger.Info("Session terminated - closing live event stream", "user_id", userID)
 						return
 					}
 				}
@@ -1495,17 +1514,17 @@ func (c *ChattoCore) StreamMyLiveEvents(ctx context.Context, userID string) (<-c
 	return eventChan, nil
 }
 
-// isAuthorizedForLiveEvent checks if a user is authorized to receive an instance event
-// based on the subject pattern:
-//   - live.instance.config.* → all authenticated users (instance config is public)
-//   - live.instance.user.{userId}.* → only the specific user (except profile_updated)
-//   - live.instance.user.{userId}.profile_updated → broadcast to all (profiles are public)
-//   - live.instance.space.{spaceId}.* → only space members
+// isAuthorizedForLiveEvent checks if a user is authorized to receive a live
+// event based on the subject pattern:
+//   - live.server.config.* → all authenticated users (server config is public)
+//   - live.server.user.{userId}.* → only the specific user (except profile_updated)
+//   - live.server.user.{userId}.profile_updated → broadcast to all (profiles are public)
+//   - live.server.space.{spaceId}.* → only space members
 func (c *ChattoCore) isAuthorizedForLiveEvent(ctx context.Context, userID, subject string) bool {
-	// Parse subject: live.instance.{type}.{id}.{eventType}
+	// Parse subject: live.server.{type}.{id}.{eventType}
 	parts := strings.Split(subject, ".")
-	if len(parts) < 4 || parts[0] != "live" || parts[1] != "instance" {
-		c.logger.Warn("Invalid instance event subject format", "subject", subject)
+	if len(parts) < 4 || parts[0] != "live" || parts[1] != "server" {
+		c.logger.Warn("Invalid live event subject format", "subject", subject)
 		return false
 	}
 
@@ -1518,7 +1537,7 @@ func (c *ChattoCore) isAuthorizedForLiveEvent(ctx context.Context, userID, subje
 
 	// For user/space scopes, we need at least 5 parts
 	if len(parts) < 5 {
-		c.logger.Warn("Invalid instance event subject format", "subject", subject)
+		c.logger.Warn("Invalid live event subject format", "subject", subject)
 		return false
 	}
 
@@ -1538,27 +1557,27 @@ func (c *ChattoCore) isAuthorizedForLiveEvent(ctx context.Context, userID, subje
 		// so deliver to anyone connected. The subscription itself is auth-gated.
 		return true
 	default:
-		c.logger.Warn("Unknown instance event scope", "scope", eventScope, "subject", subject)
+		c.logger.Warn("Unknown live event scope", "scope", eventScope, "subject", subject)
 		return false
 	}
 }
 
-// StreamMyServerConfigEvents streams transient instance-level events to the user.
-// These are fire-and-forget events that bypass JetStream (config changes, etc.).
+// StreamMyServerConfigEvents streams transient server-level config events
+// to the user. Fire-and-forget — bypasses JetStream.
 // The returned channel will be closed when the context is cancelled.
 func (c *ChattoCore) StreamMyServerConfigEvents(ctx context.Context, userID string) (<-chan *corev1.LiveEvent, error) {
-	// Subscribe to live instance config events via NATS Core
-	liveSubject := subjects.LiveInstanceConfigAllEvents()
+	// Subscribe to live server config events via NATS Core
+	liveSubject := subjects.LiveConfigAllEvents()
 	msgChan := make(chan *nats.Msg, 64)
 	sub, err := c.nc.ChanSubscribe(liveSubject, msgChan)
 	if err != nil {
-		return nil, fmt.Errorf("failed to subscribe to live instance config events: %w", err)
+		return nil, fmt.Errorf("failed to subscribe to live server config events: %w", err)
 	}
 
 	eventChan := make(chan *corev1.LiveEvent)
 
 	go func() {
-		c.logger.Debug("Starting instance live event stream", "user_id", userID, "subject", liveSubject)
+		c.logger.Debug("Starting live config event stream", "user_id", userID, "subject", liveSubject)
 
 		defer func() {
 			c.logger.Debug("Instance live event stream closed", "user_id", userID)
@@ -1606,7 +1625,7 @@ func (c *ChattoCore) PublishServerConfigUpdated(ctx context.Context, actorID str
 		},
 	})
 
-	return c.publishLiveEvent(ctx, subjects.LiveInstanceConfigUpdated(), event)
+	return c.publishLiveEvent(ctx, subjects.LiveConfigUpdated(), event)
 }
 
 // ============================================================================

--- a/cli/internal/core/core_test.go
+++ b/cli/internal/core/core_test.go
@@ -198,25 +198,25 @@ func TestChattoCore_isAuthorizedForLiveEvent(t *testing.T) {
 		{
 			name:       "user event - same user receives their own registration_completed",
 			userID:     userA.Id,
-			subject:    "live.instance.user." + userA.Id + ".registration_completed",
+			subject:    "live.server.user." + userA.Id + ".registration_completed",
 			wantResult: true,
 		},
 		{
 			name:       "user event - other user does NOT receive registration_completed",
 			userID:     userB.Id,
-			subject:    "live.instance.user." + userA.Id + ".registration_completed",
+			subject:    "live.server.user." + userA.Id + ".registration_completed",
 			wantResult: false,
 		},
 		{
 			name:       "user event - same user receives their own user_deleted",
 			userID:     userA.Id,
-			subject:    "live.instance.user." + userA.Id + ".user_deleted",
+			subject:    "live.server.user." + userA.Id + ".user_deleted",
 			wantResult: true,
 		},
 		{
 			name:       "user event - other user does NOT receive user_deleted",
 			userID:     userB.Id,
-			subject:    "live.instance.user." + userA.Id + ".user_deleted",
+			subject:    "live.server.user." + userA.Id + ".user_deleted",
 			wantResult: false,
 		},
 
@@ -224,13 +224,13 @@ func TestChattoCore_isAuthorizedForLiveEvent(t *testing.T) {
 		{
 			name:       "profile_updated - same user receives it",
 			userID:     userA.Id,
-			subject:    "live.instance.user." + userA.Id + ".profile_updated",
+			subject:    "live.server.user." + userA.Id + ".profile_updated",
 			wantResult: true,
 		},
 		{
 			name:       "profile_updated - other user ALSO receives it (broadcast)",
 			userID:     userB.Id,
-			subject:    "live.instance.user." + userA.Id + ".profile_updated",
+			subject:    "live.server.user." + userA.Id + ".profile_updated",
 			wantResult: true,
 		},
 
@@ -239,13 +239,13 @@ func TestChattoCore_isAuthorizedForLiveEvent(t *testing.T) {
 		{
 			name:       "space event - user A receives it",
 			userID:     userA.Id,
-			subject:    "live.instance.space." + space.Id + ".updated",
+			subject:    "live.server.space." + space.Id + ".updated",
 			wantResult: true,
 		},
 		{
 			name:       "space event - user B also receives it",
 			userID:     userB.Id,
-			subject:    "live.instance.space." + space.Id + ".updated",
+			subject:    "live.server.space." + space.Id + ".updated",
 			wantResult: true,
 		},
 
@@ -253,7 +253,7 @@ func TestChattoCore_isAuthorizedForLiveEvent(t *testing.T) {
 		{
 			name:       "invalid subject format - too few parts",
 			userID:     userA.Id,
-			subject:    "live.instance.user",
+			subject:    "live.server.user",
 			wantResult: false,
 		},
 		{
@@ -265,7 +265,7 @@ func TestChattoCore_isAuthorizedForLiveEvent(t *testing.T) {
 		{
 			name:       "unknown scope",
 			userID:     userA.Id,
-			subject:    "live.instance.unknown.someid.event",
+			subject:    "live.server.unknown.someid.event",
 			wantResult: false,
 		},
 	}

--- a/cli/internal/core/dm.go
+++ b/cli/internal/core/dm.go
@@ -397,7 +397,7 @@ func (c *ChattoCore) notifyDMParticipants(ctx context.Context, roomID, senderID,
 			},
 		}
 
-		subject := subjects.LiveInstanceUserEvent(participantID, "dm_message")
+		subject := subjects.LiveUserEvent(participantID, "dm_message")
 		if err := c.publishLiveEvent(ctx, subject, event); err != nil {
 			c.logger.Warn("Failed to publish DM live event",
 				"participant_id", participantID,

--- a/cli/internal/core/dm_test.go
+++ b/cli/internal/core/dm_test.go
@@ -721,7 +721,7 @@ func TestDMNotifications(t *testing.T) {
 	t.Run("DM message triggers notification to other participants", func(t *testing.T) {
 		// Subscribe to user2's notification subject
 		notificationReceived := make(chan bool, 1)
-		sub, err := nc.Subscribe("live.instance.user."+user2.Id+".dm_message", func(msg *nats.Msg) {
+		sub, err := nc.Subscribe("live.server.user."+user2.Id+".dm_message", func(msg *nats.Msg) {
 			notificationReceived <- true
 		})
 		if err != nil {
@@ -747,7 +747,7 @@ func TestDMNotifications(t *testing.T) {
 	t.Run("DM message does not notify sender", func(t *testing.T) {
 		// Subscribe to user1's notification subject (the sender)
 		notificationReceived := make(chan bool, 1)
-		sub, err := nc.Subscribe("live.instance.user."+user1.Id+".dm_message", func(msg *nats.Msg) {
+		sub, err := nc.Subscribe("live.server.user."+user1.Id+".dm_message", func(msg *nats.Msg) {
 			notificationReceived <- true
 		})
 		if err != nil {

--- a/cli/internal/core/event_publishing_test.go
+++ b/cli/internal/core/event_publishing_test.go
@@ -38,7 +38,7 @@ func TestEventPublishingHelpers_RejectInvalidEvents(t *testing.T) {
 	})
 
 	t.Run("publishLiveEvent rejects invalid payload", func(t *testing.T) {
-		err := core.publishLiveEvent(ctx, "live.instance.test", &corev1.LiveEvent{})
+		err := core.publishLiveEvent(ctx, "live.server.test", &corev1.LiveEvent{})
 		if !errors.Is(err, ErrInvalidEvent) {
 			t.Fatalf("expected ErrInvalidEvent, got: %v", err)
 		}

--- a/cli/internal/core/mentions.go
+++ b/cli/internal/core/mentions.go
@@ -111,7 +111,7 @@ func (c *ChattoCore) notifyMentionedUsers(ctx context.Context, spaceID, roomID, 
 				},
 			},
 		}
-		subject := subjects.LiveInstanceUserEvent(mentionedUserID, "mentioned")
+		subject := subjects.LiveUserEvent(mentionedUserID, "mentioned")
 		if err := c.publishLiveEvent(ctx, subject, mentionEvent); err != nil {
 			c.logger.Warn("Failed to publish mention live event",
 				"mentioned_user_id", mentionedUserID,

--- a/cli/internal/core/notification_level.go
+++ b/cli/internal/core/notification_level.go
@@ -311,7 +311,7 @@ func (c *ChattoCore) publishNotificationLevelChangedEvent(ctx context.Context, u
 		},
 	})
 
-	subject := subjects.LiveInstanceUserEvent(userID, "notification_level_changed")
+	subject := subjects.LiveUserEvent(userID, "notification_level_changed")
 	if err := c.publishLiveEvent(ctx, subject, event); err != nil {
 		c.logger.Warn("Failed to publish notification level changed event", "error", err, "user_id", userID, "space_id", spaceID)
 	}

--- a/cli/internal/core/notifications.go
+++ b/cli/internal/core/notifications.go
@@ -305,7 +305,7 @@ func (c *ChattoCore) publishNotificationCreatedEvent(ctx context.Context, notif 
 		},
 	}
 
-	subject := subjects.LiveInstanceUserEvent(notif.RecipientId, "notification_created")
+	subject := subjects.LiveUserEvent(notif.RecipientId, "notification_created")
 	if err := c.publishLiveEvent(ctx, subject, event); err != nil {
 		c.logger.Warn("Failed to publish notification created event",
 			"notification_id", notif.Id,
@@ -326,7 +326,7 @@ func (c *ChattoCore) publishNotificationDismissedEvent(ctx context.Context, user
 		},
 	}
 
-	subject := subjects.LiveInstanceUserEvent(userID, "notification_dismissed")
+	subject := subjects.LiveUserEvent(userID, "notification_dismissed")
 	if err := c.publishLiveEvent(ctx, subject, event); err != nil {
 		c.logger.Warn("Failed to publish notification dismissed event",
 			"notification_id", notificationID,

--- a/cli/internal/core/rooms.go
+++ b/cli/internal/core/rooms.go
@@ -1438,7 +1438,7 @@ func (c *ChattoCore) notifySpaceMembersOfNewMessage(ctx context.Context, spaceID
 		},
 	}
 
-	subject := subjects.LiveInstanceSpaceEvent(spaceID, "new_message")
+	subject := subjects.LiveSpaceEvent(spaceID, "new_message")
 	if err := c.publishLiveEvent(ctx, subject, event); err != nil {
 		c.logger.Warn("Failed to publish new message in space event",
 			"space_id", spaceID,
@@ -1517,7 +1517,7 @@ func (c *ChattoCore) NotifyRoomMarkedAsRead(ctx context.Context, userID, spaceID
 	}
 
 	// Publish to user's instance event stream (only they need to know)
-	subject := subjects.LiveInstanceUserEvent(userID, "room_read")
+	subject := subjects.LiveUserEvent(userID, "room_read")
 	if err := c.publishLiveEvent(ctx, subject, event); err != nil {
 		c.logger.Warn("Failed to publish room marked as read event",
 			"user_id", userID,
@@ -3339,7 +3339,7 @@ func (c *ChattoCore) publishThreadFollowChangedEvent(ctx context.Context, userID
 		},
 	}
 
-	subject := subjects.LiveInstanceUserEvent(userID, "thread_follow_changed")
+	subject := subjects.LiveUserEvent(userID, "thread_follow_changed")
 	if err := c.publishLiveEvent(ctx, subject, event); err != nil {
 		c.logger.Warn("Failed to publish thread follow changed event", "error", err, "user_id", userID, "thread_root_event_id", threadRootEventID)
 	}
@@ -3624,7 +3624,7 @@ func (c *ChattoCore) PublishRoomLayoutUpdated(ctx context.Context, actorID, spac
 		},
 	}
 
-	subject := subjects.LiveInstanceSpaceEvent(spaceID, "room_layout_updated")
+	subject := subjects.LiveSpaceEvent(spaceID, "room_layout_updated")
 	return c.publishLiveEvent(ctx, subject, event)
 }
 

--- a/cli/internal/core/rooms_test.go
+++ b/cli/internal/core/rooms_test.go
@@ -4073,7 +4073,7 @@ func TestChattoCore_PostMessage_EchoMentionNotification(t *testing.T) {
 	t.Run("echo with mention produces exactly one notification", func(t *testing.T) {
 		// Subscribe to live mention events for the target user
 		mentionCount := 0
-		sub, err := nc.Subscribe("live.instance.user."+target.Id+".mentioned", func(msg *nats.Msg) {
+		sub, err := nc.Subscribe("live.server.user."+target.Id+".mentioned", func(msg *nats.Msg) {
 			mentionCount++
 		})
 		if err != nil {

--- a/cli/internal/core/server_branding.go
+++ b/cli/internal/core/server_branding.go
@@ -321,7 +321,7 @@ func (c *ChattoCore) publishServerBrandingUpdate(ctx context.Context, actorID st
 		},
 	})
 
-	subject := subjects.LiveInstanceSpaceEvent(spaceID, "updated")
+	subject := subjects.LiveSpaceEvent(spaceID, "updated")
 	if err := c.publishLiveEvent(ctx, subject, event); err != nil {
 		c.logger.Warn("failed to publish server update event", "error", err)
 	}

--- a/cli/internal/core/sessions.go
+++ b/cli/internal/core/sessions.go
@@ -21,6 +21,6 @@ func (c *ChattoCore) PublishSessionTerminated(ctx context.Context, userID, reaso
 			},
 		},
 	})
-	subject := subjects.LiveInstanceUserEvent(userID, "session_terminated")
+	subject := subjects.LiveUserEvent(userID, "session_terminated")
 	return c.publishLiveEvent(ctx, subject, event)
 }

--- a/cli/internal/core/spaces.go
+++ b/cli/internal/core/spaces.go
@@ -127,7 +127,7 @@ func (c *ChattoCore) CreateSpace(ctx context.Context, actorID string, name strin
 			},
 		},
 	})
-	subject := subjects.LiveInstanceUserEvent(actorID, "space_created")
+	subject := subjects.LiveUserEvent(actorID, "space_created")
 	if err := c.publishLiveEvent(ctx, subject, event); err != nil {
 		c.logger.Error("failed to publish space created event", "error", err, "space_id", space.Id)
 	}
@@ -208,7 +208,7 @@ func (c *ChattoCore) DeleteSpace(ctx context.Context, actorID string, space_id s
 			},
 		},
 	})
-	subject := subjects.LiveInstanceUserEvent(actorID, "space_deleted")
+	subject := subjects.LiveUserEvent(actorID, "space_deleted")
 	if err := c.publishLiveEvent(ctx, subject, event); err != nil {
 		c.logger.Error("failed to publish space deleted event", "error", err, "space_id", space_id)
 	}
@@ -317,7 +317,7 @@ func (c *ChattoCore) publishSpaceUpdate(ctx context.Context, actorID, spaceID st
 		},
 	})
 
-	subject := subjects.LiveInstanceSpaceEvent(spaceID, "updated")
+	subject := subjects.LiveSpaceEvent(spaceID, "updated")
 	if err := c.publishLiveEvent(ctx, subject, event); err != nil {
 		c.logger.Warn("failed to publish space update event", "error", err, "space_id", spaceID)
 	}

--- a/cli/internal/core/subjects/subjects.go
+++ b/cli/internal/core/subjects/subjects.go
@@ -260,22 +260,22 @@ func splitSubject(subject string) []string {
 // Live subjects are used for transient events that bypass JetStream
 // storage. Same `server.>` namespace as the durable subjects above.
 
-// LiveInstanceAllEvents returns the live subject for all instance-level
-// events. Pattern: `live.instance.>`.
-func LiveInstanceAllEvents() string {
-	return "live.instance.>"
+// LiveUserAllEvents returns the live subject wildcard for all events
+// scoped to a specific user. Pattern: `live.server.user.{userId}.>`.
+func LiveUserAllEvents(userID string) string {
+	return fmt.Sprintf("live.server.user.%s.>", userID)
 }
 
-// LiveInstanceUserAllEvents returns the live subject for all events for a
-// specific user. Pattern: `live.instance.user.{userId}.>`.
-func LiveInstanceUserAllEvents(userID string) string {
-	return fmt.Sprintf("live.instance.user.%s.>", userID)
+// LiveUserScopedAllEvents returns the live subject wildcard for all
+// user-scoped events (any user). Pattern: `live.server.user.>`.
+func LiveUserScopedAllEvents() string {
+	return "live.server.user.>"
 }
 
-// LiveInstanceUserEvent returns the live subject for a specific user's
-// instance event. Pattern: `live.instance.user.{userId}.{eventType}`.
-func LiveInstanceUserEvent(userID, eventType string) string {
-	return fmt.Sprintf("live.instance.user.%s.%s", userID, eventType)
+// LiveUserEvent returns the live subject for a specific user's event.
+// Pattern: `live.server.user.{userId}.{eventType}`.
+func LiveUserEvent(userID, eventType string) string {
+	return fmt.Sprintf("live.server.user.%s.%s", userID, eventType)
 }
 
 // LiveAllEvents returns the live subject for all server-scoped live events.
@@ -316,27 +316,34 @@ func LiveRoomReactionEvents(kind string) string {
 	return fmt.Sprintf("live.server.room.%s.*.reaction_*", kind)
 }
 
-// ===== INSTANCE LIVE SUBJECT PATTERNS =====
-// For transient instance-level events that bypass JetStream (config
-// changes, etc.). Instance-scoped, unaffected by space/server routing.
+// ===== SERVER-SCOPED LIVE SUBJECT PATTERNS =====
+// For transient deployment-wide events that bypass JetStream (config
+// changes, space lifecycle, etc.). Fanout to all members; server-side
+// authorization filtering happens in the subscriber.
 
-// LiveInstanceConfigUpdated returns the subject for instance config update
-// events. Pattern: `live.instance.config.updated`.
-func LiveInstanceConfigUpdated() string {
-	return "live.instance.config.updated"
+// LiveConfigUpdated returns the subject for server config update events.
+// Pattern: `live.server.config.updated`.
+func LiveConfigUpdated() string {
+	return "live.server.config.updated"
 }
 
-// LiveInstanceConfigAllEvents returns the wildcard subject for all instance
-// config events. Pattern: `live.instance.config.>`.
-func LiveInstanceConfigAllEvents() string {
-	return "live.instance.config.>"
+// LiveConfigAllEvents returns the wildcard subject for all server config
+// events. Pattern: `live.server.config.>`.
+func LiveConfigAllEvents() string {
+	return "live.server.config.>"
 }
 
-// LiveInstanceSpaceEvent returns the live subject for a space-wide instance
-// event. Pattern: `live.instance.space.{spaceId}.{eventType}`.
+// LiveSpaceEvent returns the live subject for a space-wide event.
+// Pattern: `live.server.space.{spaceId}.{eventType}`.
 //
-// Instance-scoped (used for fanout to space members with server-side
-// authorization filtering); independent of the server/space data routing.
-func LiveInstanceSpaceEvent(spaceID, eventType string) string {
-	return fmt.Sprintf("live.instance.space.%s.%s", spaceID, eventType)
+// Fanout subject — every connected user receives these and the subscriber
+// applies authorization. Independent of the durable `server.>` routing.
+func LiveSpaceEvent(spaceID, eventType string) string {
+	return fmt.Sprintf("live.server.space.%s.%s", spaceID, eventType)
+}
+
+// LiveSpaceScopedAllEvents returns the wildcard subject for all space-
+// scoped live events. Pattern: `live.server.space.>`.
+func LiveSpaceScopedAllEvents() string {
+	return "live.server.space.>"
 }

--- a/cli/internal/core/user_preferences.go
+++ b/cli/internal/core/user_preferences.go
@@ -119,7 +119,7 @@ func (c *ChattoCore) publishInstanceUserPreferencesUpdatedEvent(ctx context.Cont
 		},
 	})
 
-	subject := subjects.LiveInstanceUserEvent(userID, "settings_updated")
+	subject := subjects.LiveUserEvent(userID, "settings_updated")
 	if err := c.publishLiveEvent(ctx, subject, event); err != nil {
 		c.logger.Warn("failed to publish user settings updated event", "error", err, "user_id", userID)
 	}

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -152,7 +152,7 @@ func (c *ChattoCore) CreateUser(ctx context.Context, actorID string, login, disp
 			},
 		},
 	})
-	subject := subjects.LiveInstanceUserEvent(userID, "created")
+	subject := subjects.LiveUserEvent(userID, "created")
 	if err := c.publishLiveEvent(ctx, subject, event); err != nil {
 		c.logger.Error("failed to publish user created event", "error", err, "user_id", userID)
 	}
@@ -543,9 +543,9 @@ func (c *ChattoCore) publishUserProfileUpdate(ctx context.Context, userID string
 		},
 	})
 
-	// Publish to live.instance.user.{userId}.profile_updated for real-time delivery
+	// Publish to live.server.user.{userId}.profile_updated for real-time delivery
 	// Profile updates are transient (no need for JetStream storage/replay)
-	subject := subjects.LiveInstanceUserEvent(userID, "profile_updated")
+	subject := subjects.LiveUserEvent(userID, "profile_updated")
 	if err := c.publishLiveEvent(ctx, subject, event); err != nil {
 		c.logger.Warn("failed to publish user profile update event", "error", err, "user_id", userID)
 	}
@@ -1055,7 +1055,7 @@ func (c *ChattoCore) DeleteUser(ctx context.Context, actorID, userID string) err
 			},
 		},
 	})
-	serverSubject := subjects.LiveInstanceUserEvent(userID, "user_deleted")
+	serverSubject := subjects.LiveUserEvent(userID, "user_deleted")
 	if err := c.publishLiveEvent(ctx, serverSubject, serverEvent); err != nil {
 		c.logger.Warn("Failed to publish UserDeletedEvent", "user_id", userID, "error", err)
 	}

--- a/cli/internal/graph/events.graphqls
+++ b/cli/internal/graph/events.graphqls
@@ -57,7 +57,7 @@ ServerEvent wraps all server-scoped events.
 
 All server events are live-only (published to NATS Core, never persisted).
 Authorization is determined by NATS subject:
-- Server events: live.instance.{scope}.{id}.{eventType}
+- Server events: live.server.{scope}.{id}.{eventType}
 """
 type ServerEvent {
   "Universal event identifier."


### PR DESCRIPTION
## Summary

Collapses the parallel `live.instance.*` NATS Core namespace into `live.server.*`, finishing the in-memory pubsub side of the Instance → Server terminology sweep. Per ADR-029, `live.*` subjects can rename freely (NATS Core only, no JetStream persistence, no migration needed). New shape: `live.server.user.{userId}.{evt}`, `live.server.space.{spaceId}.{evt}`, `live.server.config.{evt}`; room/member live events keep their existing `live.server.room.{kind}.>` / `live.server.member.>` roots, and `StreamMyLiveEvents` now subscribes to three explicit wildcards instead of a single `live.server.>` to stay separate from `StreamMyServerEvents`. Subject builders renamed (`LiveInstance{User,Space,Config}* → Live{User,Space,Config}*`), `validateInstanceEvent → validateLiveEvent`, comments/log messages updated, and `.claude/rules/backend.md` documents the new scheme.

## Test plan

- [x] `go build -tags 'bootstrap test_endpoints' ./...`
- [x] `go vet -tags 'test_endpoints' ./...`
- [x] `go test -tags test_endpoints ./internal/core/... ./internal/graph/... ./internal/http_server/...`
- [ ] Full CI green