### PR TITLE
feat(frontend): add hover highlight to app header icons

### DIFF
--- a/.claude/rules/storybook.md
+++ b/.claude/rules/storybook.md
@@ -15,8 +15,15 @@ components they document.
 - **Changed component prop API or visual variants** → update its story so
   the variants shown match the current API. The variant stories ("All
   tones", "Variants", "Sizes") are the documentation; keep them current.
-- **Changed design tokens or utility classes** in `src/app.css` → reflect
-  in the `Foundations/Colors` or `Foundations/Typography` stories.
+- **Changed design tokens** in `src/app.css` (CSS variables under
+  `@theme`) → reflect in the `Foundations/Colors` or
+  `Foundations/Typography` stories.
+- **New `@utility` class** in `src/app.css` that isn't tied to a single
+  component (e.g. `app-header-icon`, `sidebar-icon`, `space-list-item`)
+  → add or extend a story under `Foundations/Utilities`. Utilities that
+  are the visual contract of a specific component (e.g. `btn*` for
+  `Button`, `notification-dot` for `UnreadDot`) are documented by that
+  component's story instead — don't double up.
 
 ## addon-svelte-csf v5 conventions
 

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -311,6 +311,12 @@
   @apply inline-flex h-5 w-5 shrink-0 items-center justify-center text-base;
 }
 
+/* Icon button in the app header: 44px tap target, negative margin to keep
+   visual alignment tight, subtle hover/active feedback. */
+@utility app-header-icon {
+  @apply -m-2 flex h-11 w-11 cursor-pointer items-center justify-center rounded hover:text-text active:bg-surface-200;
+}
+
 /* Hide scrollbar while maintaining scroll functionality */
 @utility scrollbar-hide {
   -ms-overflow-style: none; /* IE and Edge */

--- a/frontend/src/lib/ui/AppHeader.svelte
+++ b/frontend/src/lib/ui/AppHeader.svelte
@@ -39,7 +39,7 @@
     <!-- Hamburger - 44px tap target for mobile accessibility -->
     <button
       type="button"
-      class="-m-2 flex h-11 w-11 cursor-pointer items-center justify-center rounded active:bg-surface-200"
+      class="app-header-icon"
       onclick={() => sidebarNav.toggle()}
       aria-label="Toggle sidebar"
       aria-expanded={sidebarNav.isOpen}
@@ -53,7 +53,7 @@
       href={resolve('/chat/notifications')}
       aria-label="Notifications"
       title="Notifications"
-      class="relative -m-2 flex h-11 w-11 cursor-pointer items-center justify-center rounded active:bg-surface-200"
+      class="app-header-icon relative"
     >
       <span class="iconify text-lg uil--bell"></span>
       {#if totalNotificationCount > 0}
@@ -65,7 +65,7 @@
     {#if hasInstances}
       <button
         type="button"
-        class="-m-2 flex h-11 w-11 cursor-pointer items-center justify-center rounded active:bg-surface-200"
+        class="app-header-icon"
         onclick={() => quickSwitcher.open()}
         aria-label="Open quick switcher"
         title="Quick switcher (⌘K)"

--- a/frontend/src/lib/ui/Utilities.stories.svelte
+++ b/frontend/src/lib/ui/Utilities.stories.svelte
@@ -1,0 +1,29 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  const { Story } = defineMeta({
+    title: 'Foundations/Utilities',
+    tags: ['autodocs']
+  });
+</script>
+
+<Story name="app-header-icon" asChild>
+  <div class="flex flex-col gap-3">
+    <p class="text-sm text-muted max-w-prose">
+      Icon button used in the global app header (hamburger, notifications, quick switcher).
+      44px tap target with a negative margin so the visual footprint stays tight, plus a
+      hover text-color shift and a subtle <code>active:bg-surface-200</code> press state.
+    </p>
+    <div class="flex items-center gap-3 rounded border border-input-border bg-surface p-2 text-muted">
+      <button type="button" class="app-header-icon" aria-label="Menu">
+        <span class="iconify text-xl uil--bars"></span>
+      </button>
+      <button type="button" class="app-header-icon relative" aria-label="Notifications">
+        <span class="iconify text-lg uil--bell"></span>
+      </button>
+      <button type="button" class="app-header-icon" aria-label="Quick switcher">
+        <span class="iconify text-lg uil--apps"></span>
+      </button>
+    </div>
+  </div>
+</Story>


### PR DESCRIPTION
## Summary
- Extract an `app-header-icon` utility in `app.css` and apply it to the hamburger, notifications, and quick switcher buttons in the global app header so they get the same hover/active feedback as the sign-out icon.
- Document the new utility under `Foundations/Utilities` in Storybook and update `.claude/rules/storybook.md` so future component-agnostic `@utility` additions get a story.

## Test plan
- [ ] Hover each icon in the app header (hamburger, bell, apps, sign-out) and confirm the text-color shift is consistent.
- [ ] Open Storybook → Foundations/Utilities → `app-header-icon` and confirm the three sample buttons render with the correct hover/active states in both light and dark themes.