### PR TITLE
chore: snappier default server description for OG previews

### DIFF
--- a/cli/internal/core/config_manager.go
+++ b/cli/internal/core/config_manager.go
@@ -193,7 +193,7 @@ func (cm *ConfigManager) GetEffectiveMOTD(ctx context.Context) (string, error) {
 // DefaultDescription is the fallback server description used when no
 // admin-configured description is set. Surfaced via OG meta tags and the
 // /api/instance discovery endpoint.
-const DefaultDescription = "Real-time chat application"
+const DefaultDescription = "Come join our community!"
 
 // GetEffectiveDescription returns the server description from config,
 // falling back to DefaultDescription if unset.

--- a/cli/internal/http_server/opengraph.go
+++ b/cli/internal/http_server/opengraph.go
@@ -128,7 +128,7 @@ func (s *HTTPServer) getOpenGraphMeta(ctx context.Context, urlPath string) *Open
 	// Get instance name for both site_name and og:title — server identity
 	// is the single source of truth for link previews.
 	serverName := "Chatto"
-	description := "Real-time chat application"
+	description := "Come join our community!"
 	if s.core != nil && s.core.ConfigManager() != nil {
 		if name, err := s.core.ConfigManager().GetEffectiveInstanceName(ctx); err == nil && name != "" {
 			serverName = name


### PR DESCRIPTION
## Summary
- Changes the default per-server description (used in OG link previews and \`/api/instance\`) from the generic \"Real-time chat application\" to the inviting \"Come join our community!\" — applies only when the server admin hasn't configured a custom description.
- Updates both the canonical \`core.DefaultDescription\` constant and the nil-guard fallback in \`opengraph.go\`.

## Test plan
- [ ] Fresh server with no admin-set description shows \"Come join our community!\" in OG meta and \`/api/instance\`
- [ ] Server with an admin-set description still shows the custom value