### PR TITLE
refactor(subscriptions): collapse onto a single live.> subscription

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -38,39 +38,37 @@ paths: ["cli/**"]
 
 ## Event Patterns
 
-- **JetStream events**: For data needing audit trail, ordering, or replay (messages, memberships)
-- **Live-only events**: For transient UI updates where KV is source of truth (reactions, typing indicators)
-  - Publish to `live.` subject prefix via `publishLiveEvent()`
-  - Bypasses JetStream storage entirely
-- **Adding new live event types** requires updates in TWO places:
-  1. Core handler: Add case in the `liveRoomMsgChan` switch inside `StreamMyEvents` (room-scoped) or in `StreamMyLiveEvents` (deployment-wide user/space/config) — both in `core.go`
-  2. GraphQL resolver: Add case in `unwrapEvent` (`event_helpers.go`) so the typed variant flows through `myEvents`
-  - Missing the unwrap case causes events to silently fail at the GraphQL layer
-- **Avoid fan-out on publish**: When broadcasting events to multiple users (e.g., server updates), do NOT iterate through recipients and publish to each. Instead:
-  - Publish once to a scoped subject (e.g., `live.server.space.{spaceId}.updated`)
-  - Use server-side authorization filtering in the subscription handler
-  - This scales to large numbers of users without N publish operations
+All event subscriptions are unified onto `live.server.>`. The `SERVER_EVENTS` stream's `RePublish` config forwards every accepted message from `server.>` to `live.server.>` after persistence, so `StreamMyEvents` in `core.go` only needs one `nc.ChanSubscribe("live.server.>")` to receive both durable (stream-stored) and transient (NATS Core) events. There is no per-connection JetStream consumer.
+
+- **Durable events**: For data needing audit trail, ordering, or replay (messages, thread replies, room meta, server-level member events). Publish to `server.>` via `publishServerEvent()` / `publishServerEventWithAck()` / `publishServerEventWithOCC()`. JetStream republish automatically wires them into `live.server.>` for live delivery.
+- **Transient events**: For real-time UI updates where KV is source of truth (reactions, typing, message edits/deletes, user/space/config notifications). Publish directly via NATS Core through `publishLiveServerEvent()` or `publishLiveEvent()`. No stream storage.
+- **Do not double-publish.** Publishing the same conceptual event via BOTH `publishServerEvent` and `publishLiveServerEvent` will deliver it twice to every subscriber, because the stream-republish already covers the live path.
+- **Adding new event types** requires:
+  1. Core: choose durable vs transient and publish to the appropriate subject family. No `StreamMyEvents` change needed — the unified `live.server.>` subscription delivers it automatically.
+  2. Authorization: room events are gated by membership in `filterLiveEvent`; user/space/config/member events go through `isAuthorizedForLiveEvent`. If your new event type fits neither, extend the appropriate switch.
+  3. GraphQL: add a case to `unwrapEvent` in `event_helpers.go` so the typed variant flows through `myEvents`. Missing this case causes the event to silently fail at the GraphQL layer.
+- **Avoid fan-out on publish**: When broadcasting to many users, do NOT iterate and publish per-recipient. Publish once to a scoped subject (e.g., `live.server.space.{spaceId}.updated`) and let `isAuthorizedForLiveEvent` filter on the subscriber side.
 
 ## Live Event Authorization
 
-Deployment-wide live events use subject pattern `live.server.{scope}.{id}.{eventType}` and are filtered by `isAuthorizedForLiveEvent` in `core.go`:
+Non-room live events use subject pattern `live.server.{scope}.…` and are filtered by `isAuthorizedForLiveEvent` in `core.go`:
 
 | Scope    | Subject Pattern                  | Delivered To                                                       |
 | -------- | -------------------------------- | ------------------------------------------------------------------ |
 | `user`   | `live.server.user.{userId}.*`    | Only that user (private events; `profile_updated` is broadcast)    |
 | `space`  | `live.server.space.{spaceId}.*`  | All authenticated users (server membership is implicit)            |
 | `config` | `live.server.config.*`           | All authenticated users (server config is public)                  |
+| `member` | `live.server.member.{verb}`      | All authenticated users (server-level membership lifecycle)        |
 
-Room/member live events use a separate root (`live.server.room.{kind}.>` and
-`live.server.member.>`) handled by `StreamMyEvents`.
+Room events (`live.server.room.{kind}.{roomId}.…`) are filtered separately in `filterLiveEvent` using the per-subscription `memberRooms` cache — they never reach `isAuthorizedForLiveEvent`.
 
-**Adding a new live event type:**
+**Adding a new event type:**
 
-1. Add protobuf message to `live_event.proto` and a oneof case to `event.proto` (`corev1.Event`)
+1. Add protobuf message to the appropriate `*.proto` file and a oneof case to `event.proto` (`corev1.Event`)
 2. Add to GraphQL schema in `events.graphqls` (type + `ServerEventType` union)
 3. Add `IsServerEventType()` method in `pb/chatto/core/v1/graphql.go`
 4. Add case in `unwrapEvent()` in `event_helpers.go`
-5. Publish using `subjects.LiveUserEvent()` or `subjects.LiveSpaceEvent()`
+5. Publish via one of `publishServerEvent` (durable) or `publishLiveEvent` / `publishLiveServerEvent` (transient) — choose ONE
 6. Subscribe in frontend via `eventBus.svelte.ts` (or a handler registered through `useEvent`)
 
 **When to create a live event:** Any time a user action changes state that other tabs/devices or other UI components need to reflect in real-time. Common triggers:

--- a/.claude/rules/nats-subjects.md
+++ b/.claude/rules/nats-subjects.md
@@ -43,7 +43,22 @@ msg.{rootId}.replies.{eventId}
 thread.{rootId}.{eventId}
 ```
 
-### 4. Encode Filter Discriminators in the Key Prefix
+### 4. One Pipe for Live Delivery — Republish Durable Subjects
+
+The `SERVER_EVENTS` stream's `RePublish` config rewrites every accepted message from `server.>` to `live.server.>` after persistence. Subscribers wanting room messages, thread replies, room meta, or server-level member events do not hold a JetStream consumer — they take a NATS Core sub on `live.server.>` and the stream feeds them automatically.
+
+This gives one logical pipe (`live.server.>`) with two physical publishers:
+
+- Persistent events (room messages, thread replies, room meta, server member lifecycle) write to `server.>` via `publishServerEvent` / `publishServerEventWithAck` / `publishServerEventWithOCC`, then republish onto `live.server.>` automatically.
+- Transient events (reactions, typing, edits, deletes, user/space/config notifications) publish directly via NATS Core on `live.server.>` through `publishLiveServerEvent` / `publishLiveEvent`.
+
+Subject leaf tokens disambiguate the two paths so a subscriber on `live.server.>` cannot receive the same event twice. Republished events always end in `.msg.{id}`, `.meta`, or `.{member_verb}` (mirroring the stream subject shape); direct publishes use event-type tokens like `.reaction_added`, `.user_typing`, `.profile_updated`.
+
+**Anti-pattern: do not double-publish.** Calling both `publishServerEvent(..., subjects.X(...))` *and* `publishLiveServerEvent(..., subjects.LiveX(...))` for the same conceptual event will deliver it twice to every subscriber, because the stream-republish already covers the live path. Choose one based on whether the event is part of durable history.
+
+When extending the subject parsers (`subjects.go`), accept both shapes via the `stripLivePrefix` helper so durable (`server.>`) and republished/live (`live.server.>`) subjects share one canonical form. New parsers should follow the existing pattern (`ParseRoomIDFromSubject`, `IsThreadSubject`, etc.).
+
+### 5. Encode Filter Discriminators in the Key Prefix
 
 When a single bucket (or stream) holds records of multiple kinds, put the kind in the key prefix so listing operations can prefix-filter without loading and deserializing every record. This applies to KV keys (which are subjects under the hood) just as much as stream subjects.
 

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -615,6 +615,15 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		Compression:        jetstream.S2Compression,
 		AllowAtomicPublish: true,
 		Replicas:           cfg.Replicas,
+		// Republish every accepted stream message onto a NATS Core
+		// subject so subscribers can listen for room events without
+		// holding a per-connection JetStream consumer. The republish
+		// fires after persistence, so consumers cannot observe an
+		// event that didn't durably land on the stream.
+		RePublish: &jetstream.RePublish{
+			Source:      "server.>",
+			Destination: "live.server.>",
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SERVER_EVENTS stream: %w", err)
@@ -1017,34 +1026,40 @@ func isTerminalIteratorError(err error) bool {
 	return false
 }
 
-// StreamMyEvents creates a unified stream of all events on this
-// deployment that are relevant to a specific user. Sources from the
-// single SERVER_EVENTS stream (no per-space scoping); per-room
-// authorization is applied per event.
+// StreamMyEvents creates a unified stream of every event on this
+// deployment that is relevant to a specific user.
 //
-// Includes:
-//   - Server-level live events (member_deleted) via NATS Core
-//   - Room events (messages, meta) via a JetStream ordered consumer
-//   - Transient room events (reactions, typing, message updates) via NATS Core
-//   - Presence changes via the per-process PresenceHub
+// All events arrive via a single NATS Core subscription on
+// `live.server.>`. JetStream-stored events (room messages, thread
+// replies, meta lifecycle, server-level member events) are republished
+// onto the same subject root by the SERVER_EVENTS stream's RePublish
+// config; transient events (reactions, typing, edits, deletes, user/
+// space/config notifications) publish directly via NATS Core. The
+// subject prefix is what disambiguates the two — payload-wise they're
+// identical `corev1.Event` wire protos.
 //
 // Authorization:
-//   - Room events are delivered only for rooms where the user is a
-//     member. The membership set is pre-loaded across both kinds
-//     (channel + dm) and updated as join/leave events arrive.
-//   - DM-kind events are additionally gated by the user's `dm.view`
-//     permission, fetched once at subscription start.
-//   - Presence updates are deployment-wide.
+//   - Room events (live.server.room.>) are delivered only for rooms
+//     where the user is a member. The membership set is pre-loaded
+//     across both kinds (channel + dm) and updated as join/leave/
+//     room-deleted events arrive.
+//   - DM-kind events are additionally gated on `dm.view`.
+//   - User/space/config/member subjects are filtered by
+//     isAuthorizedForLiveEvent.
+//   - NewMessageInSpace events authorize on per-room membership rather
+//     than subject pattern (DM rooms have no space membership).
+//   - Presence updates from the per-process PresenceHub are deployment-
+//     wide; the hub dedups status flapping.
 //
-// The returned channel closes when the context is cancelled or after
-// unrecoverable errors. Transient JetStream errors retry with backoff;
-// terminal errors (connection closed, consumer deleted) close the channel.
+// The subscription also tracks presence liveness: subscribing implies
+// the user is online, and a ticker refreshes the KV TTL while the
+// connection lives. A synthetic Heartbeat is emitted every 25s so
+// clients can detect a dead subscription on an otherwise-healthy
+// WebSocket.
+//
+// The returned channel closes when the context is cancelled or when a
+// SessionTerminatedEvent is delivered to the user.
 func (c *ChattoCore) StreamMyEvents(ctx context.Context, userID string) (<-chan *corev1.Event, error) {
-	stream := c.storage.serverEventsStream
-
-	// Resolve dm.view once. DM-kind events are dropped for users without it,
-	// and we skip pre-loading DM memberships entirely so the membership cache
-	// stays consistent across the lifetime of the subscription.
 	canDM, err := c.HasInstancePermission(ctx, userID, PermDMView)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check dm.view permission: %w", err)
@@ -1068,322 +1083,110 @@ func (c *ChattoCore) StreamMyEvents(ctx context.Context, userID string) (<-chan 
 		}
 	}
 
-	// Subscribe to live server-level events via NATS Core (member_deleted)
-	liveSubject := subjects.LiveMemberAllEvents()
-	liveMsgChan := make(chan *nats.Msg, 64)
-	liveSub, err := c.nc.ChanSubscribe(liveSubject, liveMsgChan)
+	// Single live-subject subscription. The 256-message buffer absorbs
+	// reaction/typing bursts; if it overruns, NATS Core drops on the
+	// floor and the client's catch-up-on-reconnect path repairs gaps.
+	msgChan := make(chan *nats.Msg, 256)
+	liveSub, err := c.nc.ChanSubscribe(subjects.LiveAllEvents(), msgChan)
 	if err != nil {
-		return nil, fmt.Errorf("failed to subscribe to live server events: %w", err)
+		return nil, fmt.Errorf("failed to subscribe to live events: %w", err)
 	}
 
-	// Ordered consumer over the unified SERVER_EVENTS stream covering both
-	// channel- and dm-kind subjects. Per-event authorization happens below.
-	roomFilterSubjects := subjects.AllRoomEventsFiltersAnyKind()
-	cons, err := stream.OrderedConsumer(ctx, jetstream.OrderedConsumerConfig{
-		FilterSubjects:    roomFilterSubjects,
-		DeliverPolicy:     jetstream.DeliverNewPolicy,
-		InactiveThreshold: 30 * time.Second,
-	})
-	if err != nil {
-		liveSub.Unsubscribe()
-		return nil, fmt.Errorf("failed to create ordered consumer: %w", err)
-	}
-
-	// Subscribe to live room events via NATS Core (reactions, message updates/deletes, typing)
-	liveRoomSubject := subjects.LiveRoomAllEventsAnyKind()
-	liveRoomMsgChan := make(chan *nats.Msg, 64)
-	liveRoomSub, err := c.nc.ChanSubscribe(liveRoomSubject, liveRoomMsgChan)
-	if err != nil {
-		liveSub.Unsubscribe()
-		return nil, fmt.Errorf("failed to subscribe to live room events: %w", err)
-	}
-
-	// Subscribe to the per-process presence hub instead of creating a per-subscription KV watcher.
 	presenceSub, err := c.PresenceHub.Subscribe(ctx)
 	if err != nil {
 		liveSub.Unsubscribe()
-		liveRoomSub.Unsubscribe()
 		return nil, fmt.Errorf("failed to subscribe to presence hub: %w", err)
 	}
 
 	eventChan := make(chan *corev1.Event)
 
 	go func() {
-		c.logger.Debug("Starting server event stream", "user_id", userID, "can_dm", canDM,
-			"live_subject", liveSubject, "room_subjects", roomFilterSubjects, "live_room_subject", liveRoomSubject)
+		c.logger.Debug("Server event stream started", "user_id", userID, "can_dm", canDM, "member_rooms", len(memberRooms))
 
-		defer func() {
-			c.logger.Debug("Server event stream closed", "user_id", userID)
-			liveSub.Unsubscribe()
-			liveRoomSub.Unsubscribe()
+		// Subscribing implies the user is online; refresh on a ticker
+		// so the KV TTL doesn't expire while the connection is open.
+		if err := c.SetPresence(ctx, userID, PresenceStatusOnline); err != nil {
+			c.logger.Warn("Failed to set initial presence", "error", err, "user_id", userID)
+		}
+		presenceTicker := time.NewTicker(PresenceRefreshInterval)
+		defer presenceTicker.Stop()
 
-			// Unsubscribe from presence hub
-			c.PresenceHub.Unsubscribe(presenceSub)
-
-			close(eventChan)
-		}()
-
-		// Create a channel for room events from JetStream
-		roomMsgChan := make(chan jetstream.Msg, 64)
-		jsReaderDone := make(chan struct{})
-
-		// Track current iterator for cleanup
-		var currentIter jetstream.MessagesContext
-		var iterMu sync.Mutex
-
-		// Start goroutine to read from JetStream with retry logic
-		go func() {
-			defer close(jsReaderDone)
-
-			const maxRetries = 3
-			retryCount := 0
-
-			for {
-				iter, err := cons.Messages()
-				if err != nil {
-					if ctx.Err() != nil {
-						return
-					}
-					c.logger.Error("Failed to get message iterator", "error", err)
-					return
-				}
-
-				// Store iterator reference for external cleanup
-				iterMu.Lock()
-				currentIter = iter
-				iterMu.Unlock()
-
-				// Read messages until error
-				for {
-					msg, err := iter.Next()
-					if err != nil {
-						iter.Stop()
-
-						if ctx.Err() != nil {
-							return
-						}
-
-						// Terminal errors - cannot recover
-						if isTerminalIteratorError(err) {
-							c.logger.Debug("Iterator terminated", "error", err)
-							return
-						}
-
-						// Recoverable error - retry with backoff
-						retryCount++
-						if retryCount > maxRetries {
-							c.logger.Warn("Max retries exceeded for room message iterator", "error", err, "retries", retryCount)
-							return
-						}
-
-						c.logger.Debug("Iterator error, retrying", "error", err, "retry", retryCount)
-						select {
-						case <-ctx.Done():
-							return
-						case <-time.After(time.Duration(retryCount) * 100 * time.Millisecond):
-							// Continue to outer loop to create new iterator
-						}
-						break
-					}
-
-					// Success - reset retry count
-					retryCount = 0
-
-					select {
-					case <-ctx.Done():
-						iter.Stop()
-						return
-					case roomMsgChan <- msg:
-					}
-				}
-			}
-		}()
-
-		// Goroutine to stop the iterator when context is cancelled
-		go func() {
-			<-ctx.Done()
-			iterMu.Lock()
-			if currentIter != nil {
-				currentIter.Stop()
-			}
-			iterMu.Unlock()
-		}()
-
-		c.logger.Debug("Server subscription active", "user_id", userID, "member_rooms", len(memberRooms))
-
-		// Synthetic heartbeat so clients can detect a dead subscription on
-		// an otherwise-healthy WebSocket. Pure in-process — never touches
-		// NATS or JetStream.
 		heartbeatTicker := time.NewTicker(25 * time.Second)
 		defer heartbeatTicker.Stop()
 
-		// Initialize dedup map from hub snapshot (contains current presence state at subscribe time)
 		lastKnownPresence := make(map[string]string, len(presenceSub.Snapshot))
 		for k, v := range presenceSub.Snapshot {
 			lastKnownPresence[k] = v
 		}
 
+		defer func() {
+			c.logger.Debug("Server event stream closed", "user_id", userID)
+			liveSub.Unsubscribe()
+			c.PresenceHub.Unsubscribe(presenceSub)
+			close(eventChan)
+		}()
+
+		send := func(event *corev1.Event) bool {
+			select {
+			case <-ctx.Done():
+				return false
+			case eventChan <- event:
+				return true
+			}
+		}
+
 		for {
 			select {
 			case <-ctx.Done():
 				return
 
+			case <-presenceTicker.C:
+				if err := c.refreshPresence(ctx, userID); err != nil {
+					c.logger.Warn("Failed to refresh presence", "error", err, "user_id", userID)
+				}
+
 			case <-heartbeatTicker.C:
-				heartbeat := &corev1.Event{
+				if !send(&corev1.Event{
 					Id:        NewEventID(),
 					CreatedAt: timestamppb.Now(),
 					Event:     &corev1.Event_Heartbeat{Heartbeat: &corev1.HeartbeatEvent{}},
-				}
-				select {
-				case <-ctx.Done():
+				}) {
 					return
-				case eventChan <- heartbeat:
 				}
 
-			case msg := <-liveMsgChan:
-				// Server-level live event (member_deleted).
-				// Room events (join/leave/create/delete) come through roomMsgChan (JetStream).
-				var event corev1.Event
-				if err := proto.Unmarshal(msg.Data, &event); err != nil {
-					c.logger.Warn("Failed to unmarshal live event", "error", err)
+			case msg := <-msgChan:
+				event, ok := c.filterLiveEvent(ctx, userID, canDM, memberRooms, msg)
+				if !ok {
 					continue
 				}
-
-				select {
-				case <-ctx.Done():
+				if !send(event) {
 					return
-				case eventChan <- &event:
 				}
-
-			case msg := <-roomMsgChan:
-				// Room event from JetStream (messages, etc.)
-				if !canDM && subjects.ParseKindFromRoomSubject(msg.Subject()) == "dm" {
-					continue
-				}
-
-				var event corev1.Event
-				if err := proto.Unmarshal(msg.Data(), &event); err != nil {
-					c.logger.Warn("Failed to unmarshal room event", "error", err)
-					continue
-				}
-
-				// Extract room ID and check membership
-				roomID := subjects.ParseRoomIDFromSubject(msg.Subject())
-				if roomID == "" {
-					continue // Shouldn't happen, but skip if we can't parse
-				}
-
-				_, isMember := memberRooms[roomID]
-
-				// Update membership cache for join/leave events targeting this user
-				switch event.Event.(type) {
-				case *corev1.Event_UserJoinedRoom:
-					if event.ActorId == userID {
-						memberRooms[roomID] = struct{}{}
-						isMember = true
-					}
-				case *corev1.Event_UserLeftRoom:
-					if event.ActorId == userID {
-						delete(memberRooms, roomID)
-						// Still deliver the leave event
-					}
-				case *corev1.Event_RoomDeleted:
-					delete(memberRooms, roomID)
-				}
-
-				if isMember {
-					select {
-					case <-ctx.Done():
-						return
-					case eventChan <- &event:
-					}
-				}
-
-			case msg := <-liveRoomMsgChan:
-				// Live room event from NATS Core (reactions, message updates/deletes)
-				// These events are published directly via publishLiveServerEvent(), bypassing JetStream.
-				if !canDM && subjects.ParseKindFromRoomSubject(msg.Subject) == "dm" {
-					continue
-				}
-
-				var event corev1.Event
-				if err := proto.Unmarshal(msg.Data, &event); err != nil {
-					c.logger.Warn("Failed to unmarshal live room event", "error", err)
-					continue
-				}
-
-				// Extract room ID from the event
-				var roomID string
-				switch e := event.Event.(type) {
-				case *corev1.Event_ReactionAdded:
-					roomID = e.ReactionAdded.RoomId
-				case *corev1.Event_ReactionRemoved:
-					roomID = e.ReactionRemoved.RoomId
-				case *corev1.Event_MessageDeleted:
-					roomID = e.MessageDeleted.RoomId
-				case *corev1.Event_MessageUpdated:
-					roomID = e.MessageUpdated.RoomId
-				case *corev1.Event_UserTyping:
-					// Skip own typing events — the sender doesn't need to see them.
-					// Critical for multi-instance clients where the frontend's
-					// currentUserId may differ from the remote instance user ID.
-					if event.ActorId == userID {
-						continue
-					}
-					roomID = e.UserTyping.RoomId
-				case *corev1.Event_VideoProcessingCompleted:
-					roomID = e.VideoProcessingCompleted.RoomId
-				case *corev1.Event_CallParticipantJoined:
-					roomID = e.CallParticipantJoined.RoomId
-				case *corev1.Event_CallParticipantLeft:
-					roomID = e.CallParticipantLeft.RoomId
-				}
-
-				if roomID == "" {
-					continue // Skip if we can't get room ID
-				}
-
-				// Check room membership via cache
-				_, isMember := memberRooms[roomID]
-				if isMember {
-					select {
-					case <-ctx.Done():
-						return
-					case eventChan <- &event:
-					}
+				// Session termination tears down the subscription.
+				// The frontend handles logout on receipt; closing
+				// the channel ensures the server tears down too.
+				if event.GetSessionTerminated() != nil {
+					c.logger.Info("Session terminated - closing event stream", "user_id", userID)
+					return
 				}
 
 			case update := <-presenceSub.C:
-				// Single-server deployment: every authenticated user is a member.
-				// No per-space membership filter is needed.
-
-				// Skip if status hasn't changed (dedup heartbeat refreshes)
-				if lastStatus, exists := lastKnownPresence[update.UserID]; exists && lastStatus == update.Status {
+				if last, exists := lastKnownPresence[update.UserID]; exists && last == update.Status {
 					continue
 				}
-
-				// Update tracking map
 				if update.Status == PresenceStatusOffline {
 					delete(lastKnownPresence, update.UserID)
 				} else {
 					lastKnownPresence[update.UserID] = update.Status
 				}
-
-				// Create PresenceChangedEvent
-				presenceEvent := &corev1.Event{
+				if !send(&corev1.Event{
 					CreatedAt: timestamppb.Now(),
 					ActorId:   update.UserID,
 					Event: &corev1.Event_PresenceChanged{
-						PresenceChanged: &corev1.PresenceChangedEvent{
-							Status: update.Status,
-						},
+						PresenceChanged: &corev1.PresenceChangedEvent{Status: update.Status},
 					},
-				}
-
-				select {
-				case <-ctx.Done():
+				}) {
 					return
-				case eventChan <- presenceEvent:
 				}
 			}
 		}
@@ -1392,220 +1195,127 @@ func (c *ChattoCore) StreamMyEvents(ctx context.Context, userID string) (<-chan 
 	return eventChan, nil
 }
 
-// StreamMyLiveEvents creates a live stream of deployment-wide events
-// relevant to a specific user. Subscribes to the user-, space-, and
-// config-scoped live subjects and performs server-side authorization
-// filtering to deliver only events the user is authorized to see:
-//   - User events (live.server.user.{userId}.*): Only if userId matches subscriber
-//   - Space events (live.server.space.{spaceId}.*): Delivered to all (every authed
-//     user is implicitly a server member)
-//   - Config events (live.server.config.*): Delivered to all authenticated users
+// filterLiveEvent unmarshals a message from the unified live.> stream
+// and applies per-user authorization. Returns the event and true if it
+// should be delivered. Mutates memberRooms when the subscriber
+// themselves joins/leaves a room or when a room is deleted.
 //
-// Three explicit wildcard subscriptions (rather than a single live.server.>)
-// keep this stream separate from the room/member subscriptions in
-// StreamMyEvents, which share the live.server.* root.
+// Three routing paths:
 //
-// Only delivers new events that occur after subscription starts.
-// The returned channel will be closed when the context is cancelled.
-func (c *ChattoCore) StreamMyLiveEvents(ctx context.Context, userID string) (<-chan *corev1.Event, error) {
-	msgChan := make(chan *nats.Msg, 64)
-	wildcards := []string{
-		subjects.LiveUserScopedAllEvents(),
-		subjects.LiveSpaceScopedAllEvents(),
-		subjects.LiveConfigAllEvents(),
+//  1. Room subjects (live.server.room.{kind}.{roomId}.…):
+//     gated on room membership and (for DM-kind) dm.view permission.
+//  2. NewMessageInSpace events: gated on per-room membership, not by
+//     subject pattern, since DM rooms have no space membership.
+//  3. Everything else: delegated to isAuthorizedForLiveEvent.
+func (c *ChattoCore) filterLiveEvent(ctx context.Context, userID string, canDM bool, memberRooms map[string]struct{}, msg *nats.Msg) (*corev1.Event, bool) {
+	var event corev1.Event
+	if err := proto.Unmarshal(msg.Data, &event); err != nil {
+		c.logger.Warn("Failed to unmarshal live event", "subject", msg.Subject, "error", err)
+		return nil, false
 	}
-	subs := make([]*nats.Subscription, 0, len(wildcards))
-	for _, subj := range wildcards {
-		s, err := c.nc.ChanSubscribe(subj, msgChan)
+
+	// Path 1: room-scoped events. Both JetStream republishes (msg, meta)
+	// and direct live publishes (reactions, typing, edits) share the
+	// `live.server.room.{kind}.{roomId}.…` shape, so a single membership
+	// check covers both.
+	if kind := subjects.ParseKindFromRoomSubject(msg.Subject); kind != "" {
+		if !canDM && kind == "dm" {
+			return nil, false
+		}
+		roomID := subjects.ParseRoomIDFromSubject(msg.Subject)
+		if roomID == "" {
+			return nil, false
+		}
+
+		// Update membership cache from the subscriber's own
+		// join/leave/room-deleted events. A self-join makes the user a
+		// member for that same event; a self-leave is still delivered
+		// (so the client sees the transition) but evicts the cache.
+		switch event.Event.(type) {
+		case *corev1.Event_UserJoinedRoom:
+			if event.ActorId == userID {
+				memberRooms[roomID] = struct{}{}
+			}
+		case *corev1.Event_UserLeftRoom:
+			if event.ActorId == userID {
+				delete(memberRooms, roomID)
+				return &event, true
+			}
+		case *corev1.Event_RoomDeleted:
+			delete(memberRooms, roomID)
+		}
+
+		// Skip own typing events — the sender doesn't need to see them.
+		// Critical for multi-instance clients where the frontend's
+		// currentUserId may differ from the remote instance user ID.
+		if event.GetUserTyping() != nil && event.ActorId == userID {
+			return nil, false
+		}
+
+		if _, isMember := memberRooms[roomID]; !isMember {
+			return nil, false
+		}
+		return &event, true
+	}
+
+	// Path 2: NewMessageInSpace — room membership rather than subject.
+	if newMsg := event.GetNewMessageInSpace(); newMsg != nil {
+		isMember, err := c.RoomMembershipExists(ctx, newMsg.SpaceId, userID, newMsg.RoomId)
 		if err != nil {
-			for _, prior := range subs {
-				prior.Unsubscribe()
-			}
-			return nil, fmt.Errorf("failed to subscribe to %s: %w", subj, err)
+			c.logger.Warn("Room-membership check failed for NewMessageInSpace",
+				"error", err, "user_id", userID, "room_id", newMsg.RoomId)
+			return nil, false
 		}
-		subs = append(subs, s)
+		if !isMember {
+			return nil, false
+		}
+		return &event, true
 	}
 
-	eventChan := make(chan *corev1.Event)
-
-	go func() {
-		c.logger.Debug("Starting live event stream", "user_id", userID, "subjects", wildcards)
-
-		// Set initial presence — subscribing to live events means the client is online
-		if err := c.SetPresence(ctx, userID, PresenceStatusOnline); err != nil {
-			c.logger.Warn("Failed to set initial presence", "error", err, "user_id", userID)
-		}
-
-		// Presence refresh ticker: refresh every 30s to maintain the 60s TTL
-		presenceTicker := time.NewTicker(PresenceRefreshInterval)
-		defer presenceTicker.Stop()
-
-		defer func() {
-			c.logger.Debug("Live event stream closed", "user_id", userID)
-			for _, s := range subs {
-				s.Unsubscribe()
-			}
-			close(eventChan)
-		}()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-presenceTicker.C:
-				// Refresh presence TTL, preserving whatever status the client set via updateMyPresence
-				if err := c.refreshPresence(ctx, userID); err != nil {
-					c.logger.Warn("Failed to refresh presence", "error", err, "user_id", userID)
-				}
-			case msg := <-msgChan:
-				var event corev1.Event
-				if err := proto.Unmarshal(msg.Data, &event); err != nil {
-					c.logger.Warn("Failed to unmarshal event", "error", err)
-					continue
-				}
-
-				// NewMessageInSpaceEvent authorizes on ROOM membership instead of
-				// space membership. This is the correct check for both regular space
-				// rooms (room membership implies relevance) and DM rooms (whose
-				// participants have a room membership but no space membership of the
-				// hidden DM space — so the subject-based space-membership filter
-				// below would otherwise drop these events). Treat the room-membership
-				// check as the auth decision and skip the subject filter.
-				if newMsg := event.GetNewMessageInSpace(); newMsg != nil {
-					isMember, err := c.RoomMembershipExists(ctx, newMsg.SpaceId, userID, newMsg.RoomId)
-					if err != nil {
-						c.logger.Warn("Failed to check room membership for event filtering",
-							"error", err, "user_id", userID, "room_id", newMsg.RoomId)
-						continue
-					}
-					if !isMember {
-						continue // Skip - user is not a room member
-					}
-				} else if !c.isAuthorizedForLiveEvent(ctx, userID, msg.Subject) {
-					// Server-side authorization filtering based on subject pattern
-					// Subject format: live.server.{type}.{id}.{eventType}
-					// - live.server.user.{userId}.* → only forward to that user
-					// - live.server.space.{spaceId}.* → only forward to space members
-					continue
-				}
-
-				// Note: No sequence ID available from NATS Core messages
-				// The event may already have a sequence ID from the original publish
-
-				select {
-				case <-ctx.Done():
-					return
-				case eventChan <- &event:
-					// If this was a session termination event, close the stream.
-					// The frontend will receive the event and handle logout;
-					// closing the channel ensures the server also tears down the subscription.
-					if event.GetSessionTerminated() != nil {
-						c.logger.Info("Session terminated - closing live event stream", "user_id", userID)
-						return
-					}
-				}
-			}
-		}
-	}()
-
-	return eventChan, nil
+	// Path 3: user/space/config/member subjects.
+	if !c.isAuthorizedForLiveEvent(ctx, userID, msg.Subject) {
+		return nil, false
+	}
+	return &event, true
 }
 
-// isAuthorizedForLiveEvent checks if a user is authorized to receive a live
-// event based on the subject pattern:
+// isAuthorizedForLiveEvent checks if a user is authorized to receive a
+// non-room live event based on the subject pattern:
+//
 //   - live.server.config.* → all authenticated users (server config is public)
-//   - live.server.user.{userId}.* → only the specific user (except profile_updated)
-//   - live.server.user.{userId}.profile_updated → broadcast to all (profiles are public)
-//   - live.server.space.{spaceId}.* → only space members
-func (c *ChattoCore) isAuthorizedForLiveEvent(ctx context.Context, userID, subject string) bool {
-	// Parse subject: live.server.{type}.{id}.{eventType}
+//   - live.server.member.* → all authenticated users (single-server membership)
+//   - live.server.space.{spaceId}.* → all authenticated users (every user is a member)
+//   - live.server.user.{userId}.* → only the target user, except
+//     live.server.user.{userId}.profile_updated which is broadcast.
+//
+// Room events (`live.server.room.>`) are filtered separately via the
+// per-user room-membership cache and never reach this function.
+func (c *ChattoCore) isAuthorizedForLiveEvent(_ context.Context, userID, subject string) bool {
 	parts := strings.Split(subject, ".")
-	if len(parts) < 4 || parts[0] != "live" || parts[1] != "server" {
+	if len(parts) < 3 || parts[0] != "live" || parts[1] != "server" {
 		c.logger.Warn("Invalid live event subject format", "subject", subject)
 		return false
 	}
 
-	eventScope := parts[2] // "user", "space", or "config"
-
-	// Config events are visible to all authenticated users
-	if eventScope == "config" {
+	switch parts[2] {
+	case "config", "member", "space":
 		return true
-	}
-
-	// For user/space scopes, we need at least 5 parts
-	if len(parts) < 5 {
-		c.logger.Warn("Invalid live event subject format", "subject", subject)
-		return false
-	}
-
-	scopeID := parts[3]   // userId or spaceId
-	eventType := parts[4] // e.g., "profile_updated", "registration_completed"
-
-	switch eventScope {
 	case "user":
-		// Profile updates are broadcast to all authenticated users (profiles are public)
-		if eventType == "profile_updated" {
+		if len(parts) < 5 {
+			c.logger.Warn("Invalid user-scoped live event subject", "subject", subject)
+			return false
+		}
+		if parts[4] == "profile_updated" {
 			return true
 		}
-		// Other user events: only forward to the target user
-		return scopeID == userID
-	case "space":
-		// Space events: every authenticated user is implicitly a server member,
-		// so deliver to anyone connected. The subscription itself is auth-gated.
-		return true
+		return parts[3] == userID
+	case "room":
+		c.logger.Warn("Room subject reached isAuthorizedForLiveEvent — should be filtered upstream", "subject", subject)
+		return false
 	default:
-		c.logger.Warn("Unknown live event scope", "scope", eventScope, "subject", subject)
+		c.logger.Warn("Unknown live event scope", "scope", parts[2], "subject", subject)
 		return false
 	}
-}
-
-// StreamMyServerConfigEvents streams transient server-level config events
-// to the user. Fire-and-forget — bypasses JetStream.
-// The returned channel will be closed when the context is cancelled.
-func (c *ChattoCore) StreamMyServerConfigEvents(ctx context.Context, userID string) (<-chan *corev1.Event, error) {
-	// Subscribe to live server config events via NATS Core
-	liveSubject := subjects.LiveConfigAllEvents()
-	msgChan := make(chan *nats.Msg, 64)
-	sub, err := c.nc.ChanSubscribe(liveSubject, msgChan)
-	if err != nil {
-		return nil, fmt.Errorf("failed to subscribe to live server config events: %w", err)
-	}
-
-	eventChan := make(chan *corev1.Event)
-
-	go func() {
-		c.logger.Debug("Starting live config event stream", "user_id", userID, "subject", liveSubject)
-
-		defer func() {
-			c.logger.Debug("Instance live event stream closed", "user_id", userID)
-			sub.Unsubscribe()
-			close(eventChan)
-		}()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case msg := <-msgChan:
-				var event corev1.Event
-				if err := proto.Unmarshal(msg.Data, &event); err != nil {
-					c.logger.Warn("Failed to unmarshal instance live event", "error", err)
-					continue
-				}
-
-				// Instance config events are visible to all authenticated users
-				// No additional authorization filtering needed
-
-				select {
-				case <-ctx.Done():
-					return
-				case eventChan <- &event:
-				}
-			}
-		}
-	}()
-
-	return eventChan, nil
 }
 
 // PublishServerConfigUpdated publishes an instance config update event.

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -1243,19 +1243,20 @@ func (c *ChattoCore) filterLiveEvent(ctx context.Context, userID string, canDM b
 			return nil, false
 		}
 
-		// Update membership cache from the subscriber's own
-		// join/leave/room-deleted events. A self-join makes the user a
-		// member for that same event; a self-leave is still delivered
-		// (so the client sees the transition) but evicts the cache.
+		// Capture membership before mutating the cache so transition
+		// events (self-leave, room-deleted) still reach the member who
+		// is transitioning out.
+		_, isMember := memberRooms[roomID]
+
 		switch event.Event.(type) {
 		case *corev1.Event_UserJoinedRoom:
 			if event.ActorId == userID {
 				memberRooms[roomID] = struct{}{}
+				isMember = true
 			}
 		case *corev1.Event_UserLeftRoom:
 			if event.ActorId == userID {
 				delete(memberRooms, roomID)
-				return &event, true
 			}
 		case *corev1.Event_RoomDeleted:
 			delete(memberRooms, roomID)
@@ -1268,7 +1269,7 @@ func (c *ChattoCore) filterLiveEvent(ctx context.Context, userID string, canDM b
 			return nil, false
 		}
 
-		if _, isMember := memberRooms[roomID]; !isMember {
+		if !isMember {
 			return nil, false
 		}
 		return &event, true

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -1084,13 +1084,17 @@ func (c *ChattoCore) StreamMyEvents(ctx context.Context, userID string) (<-chan 
 	}
 
 	// Single live-subject subscription. The 256-message buffer absorbs
-	// reaction/typing bursts; if it overruns, NATS Core drops on the
-	// floor and the client's catch-up-on-reconnect path repairs gaps.
+	// reaction/typing bursts; on overflow NATS Core drops messages and
+	// transitions the subscription to SlowConsumer state — slowConsumerCh
+	// below catches that and tears the resolver down so the client can
+	// re-subscribe (and pick up missed history via the GraphQL catch-up
+	// path) rather than silently miss events.
 	msgChan := make(chan *nats.Msg, 256)
 	liveSub, err := c.nc.ChanSubscribe(subjects.LiveAllEvents(), msgChan)
 	if err != nil {
 		return nil, fmt.Errorf("failed to subscribe to live events: %w", err)
 	}
+	slowConsumerCh := liveSub.StatusChanged(nats.SubscriptionSlowConsumer)
 
 	presenceSub, err := c.PresenceHub.Subscribe(ctx)
 	if err != nil {
@@ -1138,6 +1142,18 @@ func (c *ChattoCore) StreamMyEvents(ctx context.Context, userID string) (<-chan 
 		for {
 			select {
 			case <-ctx.Done():
+				return
+
+			case <-slowConsumerCh:
+				// The NATS Core subscription's buffer overflowed and
+				// messages were dropped. Continuing would silently
+				// hide missing events, so tear down — the client's
+				// eventBus watchdog will re-subscribe (and any UI
+				// state that depends on missed messages will be
+				// repaired via the usual GraphQL refetch paths).
+				dropped, _ := liveSub.Dropped()
+				c.logger.Warn("Slow consumer on live events subscription — tearing down",
+					"user_id", userID, "dropped", dropped)
 				return
 
 			case <-presenceTicker.C:

--- a/cli/internal/core/core_test.go
+++ b/cli/internal/core/core_test.go
@@ -352,13 +352,13 @@ func TestNewSpaceEvent_PopulatesCreatedAt(t *testing.T) {
 }
 
 // ============================================================================
-// StreamMyLiveEvents Tests
+// StreamMyEvents Tests
 // ============================================================================
 
-// TestStreamMyLiveEvents_FiltersNewMessageByRoomMembership verifies that
+// TestStreamMyEvents_FiltersNewMessageByRoomMembership verifies that
 // NewMessageInSpaceEvent is only delivered to users who are room members,
 // not just space members.
-func TestStreamMyLiveEvents_FiltersNewMessageByRoomMembership(t *testing.T) {
+func TestStreamMyEvents_FiltersNewMessageByRoomMembership(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
@@ -384,9 +384,9 @@ func TestStreamMyLiveEvents_FiltersNewMessageByRoomMembership(t *testing.T) {
 	subCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	eventChan, err := core.StreamMyLiveEvents(subCtx, user2.Id)
+	eventChan, err := core.StreamMyEvents(subCtx, user2.Id)
 	if err != nil {
-		t.Fatalf("StreamMyLiveEvents failed: %v", err)
+		t.Fatalf("StreamMyEvents failed: %v", err)
 	}
 
 	// Give subscription time to establish
@@ -439,10 +439,10 @@ func TestStreamMyLiveEvents_FiltersNewMessageByRoomMembership(t *testing.T) {
 	}
 }
 
-// TestStreamMyLiveEvents_ClosesOnSessionTerminated verifies that
+// TestStreamMyEvents_ClosesOnSessionTerminated verifies that
 // the instance event stream closes after receiving a SessionTerminatedEvent,
 // and that the event is delivered to the channel before it closes.
-func TestStreamMyLiveEvents_ClosesOnSessionTerminated(t *testing.T) {
+func TestStreamMyEvents_ClosesOnSessionTerminated(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
@@ -452,9 +452,9 @@ func TestStreamMyLiveEvents_ClosesOnSessionTerminated(t *testing.T) {
 	subCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	eventChan, err := core.StreamMyLiveEvents(subCtx, user.Id)
+	eventChan, err := core.StreamMyEvents(subCtx, user.Id)
 	if err != nil {
-		t.Fatalf("StreamMyLiveEvents failed: %v", err)
+		t.Fatalf("StreamMyEvents failed: %v", err)
 	}
 
 	// Give subscription time to establish

--- a/cli/internal/core/spaces.go
+++ b/cli/internal/core/spaces.go
@@ -287,9 +287,10 @@ func (c *ChattoCore) ListSpaces(ctx context.Context) ([]*corev1.Space, error) {
 // Space Event Broadcasting
 // ============================================================================
 
-// publishSpaceUpdate publishes a SpaceUpdatedEvent to the instance stream.
-// The event is published to instance.space.{spaceId}.updated and delivered
-// to all space members via server-side authorization filtering in StreamMyLiveEvents.
+// publishSpaceUpdate publishes a SpaceUpdatedEvent on the live space
+// subject. Server-side authorization filtering in StreamMyEvents
+// (via isAuthorizedForLiveEvent) delivers it to every authenticated
+// user.
 func (c *ChattoCore) publishSpaceUpdate(ctx context.Context, actorID, spaceID string, space *corev1.Space) {
 	// Fetch current logo URL to include in the event (full resolution for events)
 	logoURL, err := c.GetSpaceLogoURL(ctx, spaceID, nil, nil)
@@ -352,13 +353,12 @@ func (c *ChattoCore) CleanupUserStateInSpace(ctx context.Context, userID, spaceI
 				},
 			},
 		})
+		// SERVER_EVENTS' RePublish forwards the persisted event onto
+		// live.server.member.deleted automatically — no manual live
+		// publish needed.
 		subject := subjects.Member("member_deleted")
 		if err := c.publishServerEvent(ctx, subject, memberDeletedEvent); err != nil {
 			c.logger.Warn("Failed to publish SpaceMemberDeletedEvent", "user_id", userID, "space_id", spaceID, "error", err)
-		}
-		liveSubject := subjects.LiveMember("member_deleted")
-		if err := c.publishLiveServerEvent(ctx, liveSubject, memberDeletedEvent); err != nil {
-			c.logger.Warn("Failed to publish live SpaceMemberDeletedEvent", "user_id", userID, "space_id", spaceID, "error", err)
 		}
 	}
 

--- a/cli/internal/core/subjects/subjects.go
+++ b/cli/internal/core/subjects/subjects.go
@@ -160,11 +160,15 @@ func LiveRoomAllEventsAnyKind() string {
 //	server.room.{kind}.{roomId}.msg.{eventId}                            (root)
 //	server.room.{kind}.{roomId}.msg.{rootEventId}.replies.{eventId}      (thread)
 //	server.room.{kind}.{roomId}.meta                                     (meta)
+//
+// JetStream republish (`server.>` → `live.server.>`) means the same
+// subjects also arrive with a leading `live` segment. Parsers normalize
+// via stripLivePrefix so both shapes share one set of length checks.
 
 // ParseRoomIDFromSubject extracts the room ID from a room event subject.
 // Returns "" for non-room subjects or unrecognized shapes.
 func ParseRoomIDFromSubject(subject string) string {
-	parts := splitSubject(subject)
+	parts := stripLivePrefix(splitSubject(subject))
 	if len(parts) >= 5 && isRoomEventSubject(parts) {
 		return parts[3]
 	}
@@ -175,12 +179,9 @@ func ParseRoomIDFromSubject(subject string) string {
 // room-event subject — durable (`server.room.{kind}.>`) or live
 // (`live.server.room.{kind}.>`). Returns "" for non-room subjects.
 func ParseKindFromRoomSubject(subject string) string {
-	parts := splitSubject(subject)
+	parts := stripLivePrefix(splitSubject(subject))
 	if len(parts) >= 3 && parts[0] == "server" && parts[1] == "room" {
 		return parts[2]
-	}
-	if len(parts) >= 4 && parts[0] == "live" && parts[1] == "server" && parts[2] == "room" {
-		return parts[3]
 	}
 	return ""
 }
@@ -188,7 +189,7 @@ func ParseKindFromRoomSubject(subject string) string {
 // ParseThreadRootEventIDFromSubject extracts the root event ID from a
 // thread reply subject. Returns ("", false) for non-thread subjects.
 func ParseThreadRootEventIDFromSubject(subject string) (string, bool) {
-	parts := splitSubject(subject)
+	parts := stripLivePrefix(splitSubject(subject))
 	if len(parts) == 8 && isRoomEventSubject(parts) && parts[4] == "msg" && parts[6] == "replies" {
 		return parts[5], true
 	}
@@ -198,28 +199,28 @@ func ParseThreadRootEventIDFromSubject(subject string) (string, bool) {
 // IsRootMessageSubject reports whether a subject is for a top-level (root)
 // message — 6 segments with `msg` at index 4.
 func IsRootMessageSubject(subject string) bool {
-	parts := splitSubject(subject)
+	parts := stripLivePrefix(splitSubject(subject))
 	return len(parts) == 6 && isRoomEventSubject(parts) && parts[4] == "msg"
 }
 
 // IsMetaSubject reports whether a subject is for a meta event — 5
 // segments with `meta` at index 4.
 func IsMetaSubject(subject string) bool {
-	parts := splitSubject(subject)
+	parts := stripLivePrefix(splitSubject(subject))
 	return len(parts) == 5 && isRoomEventSubject(parts) && parts[4] == "meta"
 }
 
 // IsThreadSubject reports whether a subject is for a thread reply — 8
 // segments with `msg` at index 4 and `replies` at index 6.
 func IsThreadSubject(subject string) bool {
-	parts := splitSubject(subject)
+	parts := stripLivePrefix(splitSubject(subject))
 	return len(parts) == 8 && isRoomEventSubject(parts) && parts[4] == "msg" && parts[6] == "replies"
 }
 
 // ParseEventIDFromSubject extracts the event ID from a message subject.
 // Returns "" for non-message subjects.
 func ParseEventIDFromSubject(subject string) string {
-	parts := splitSubject(subject)
+	parts := stripLivePrefix(splitSubject(subject))
 	if len(parts) < 5 || !isRoomEventSubject(parts) {
 		return ""
 	}
@@ -230,6 +231,16 @@ func ParseEventIDFromSubject(subject string) string {
 		return parts[7]
 	}
 	return ""
+}
+
+// stripLivePrefix removes a leading `live` segment so that durable
+// (`server.>`) and republished/live (`live.server.>`) subjects share
+// one canonical shape. Returns the original slice if not prefixed.
+func stripLivePrefix(parts []string) []string {
+	if len(parts) > 0 && parts[0] == "live" {
+		return parts[1:]
+	}
+	return parts
 }
 
 // isRoomEventSubject reports whether the dot-split segments belong to a

--- a/cli/internal/core/subjects/subjects_test.go
+++ b/cli/internal/core/subjects/subjects_test.go
@@ -195,6 +195,21 @@ func TestParseRoomIDFromSubject(t *testing.T) {
 			expected: "R1",
 		},
 		{
+			name:     "live-republished root message",
+			subject:  "live.server.room.channel.R1.msg.evt123",
+			expected: "R1",
+		},
+		{
+			name:     "live-republished thread reply",
+			subject:  "live.server.room.channel.R1.msg.evt123.replies.evt456",
+			expected: "R1",
+		},
+		{
+			name:     "live transient room event",
+			subject:  "live.server.room.dm.R1.reaction_added",
+			expected: "R1",
+		},
+		{
 			name:     "member event (not a room)",
 			subject:  "server.member.joined",
 			expected: "",
@@ -230,6 +245,12 @@ func TestParseThreadRootEventIDFromSubject(t *testing.T) {
 			expectedOK:      true,
 		},
 		{
+			name:            "live-republished thread reply",
+			subject:         "live.server.room.channel.R1.msg.Eroot.replies.Eevt",
+			expectedEventID: "Eroot",
+			expectedOK:      true,
+		},
+		{
 			name:            "root message",
 			subject:         "server.room.channel.R1.msg.evt123",
 			expectedEventID: "",
@@ -260,7 +281,9 @@ func TestIsRootMessageSubject(t *testing.T) {
 		expected bool
 	}{
 		{name: "root message", subject: "server.room.channel.R1.msg.evt123", expected: true},
+		{name: "live-republished root message", subject: "live.server.room.channel.R1.msg.evt123", expected: true},
 		{name: "thread reply", subject: "server.room.channel.R1.msg.evt123.replies.evt456", expected: false},
+		{name: "live-republished thread reply", subject: "live.server.room.channel.R1.msg.evt123.replies.evt456", expected: false},
 		{name: "meta event", subject: "server.room.channel.R1.meta", expected: false},
 	}
 
@@ -281,6 +304,7 @@ func TestIsMetaSubject(t *testing.T) {
 		expected bool
 	}{
 		{name: "meta event", subject: "server.room.channel.R1.meta", expected: true},
+		{name: "live-republished meta event", subject: "live.server.room.channel.R1.meta", expected: true},
 		{name: "root message", subject: "server.room.channel.R1.msg.evt123", expected: false},
 		{name: "thread reply", subject: "server.room.channel.R1.msg.evt123.replies.evt456", expected: false},
 	}
@@ -302,6 +326,7 @@ func TestIsThreadSubject(t *testing.T) {
 		expected bool
 	}{
 		{name: "thread reply", subject: "server.room.channel.R1.msg.evt123.replies.evt456", expected: true},
+		{name: "live-republished thread reply", subject: "live.server.room.channel.R1.msg.evt123.replies.evt456", expected: true},
 		{name: "root message", subject: "server.room.channel.R1.msg.evt123", expected: false},
 		{name: "meta event", subject: "server.room.channel.R1.meta", expected: false},
 	}
@@ -323,7 +348,9 @@ func TestParseEventIDFromSubject(t *testing.T) {
 		expected string
 	}{
 		{name: "root message", subject: "server.room.channel.R1.msg.evt123", expected: "evt123"},
+		{name: "live-republished root message", subject: "live.server.room.channel.R1.msg.evt123", expected: "evt123"},
 		{name: "thread reply", subject: "server.room.channel.R1.msg.evt123.replies.evt456", expected: "evt456"},
+		{name: "live-republished thread reply", subject: "live.server.room.channel.R1.msg.evt123.replies.evt456", expected: "evt456"},
 		{name: "meta event (no event ID)", subject: "server.room.channel.R1.meta", expected: ""},
 		{name: "member event", subject: "server.member.joined", expected: ""},
 	}

--- a/cli/internal/graph/subscription.resolvers.go
+++ b/cli/internal/graph/subscription.resolvers.go
@@ -14,69 +14,21 @@ import (
 
 // MyEvents is the resolver for the myServerEvents field.
 //
-// Fans in the two core streams — room-scoped (StreamMyEvents) and
-// deployment-scoped (StreamMyLiveEvents) — onto a single output channel.
-// Both streams already emit the same proto type, so there's nothing to
-// transform; the multiplex just merges them.
+// Backed by a single core stream (StreamMyEvents) that consumes the
+// unified `live.server.>` subject root — room events from the
+// SERVER_EVENTS republish, transient room/user/space/config events from
+// direct NATS Core publishes, plus presence and heartbeats.
 func (r *subscriptionResolver) MyEvents(ctx context.Context) (<-chan *corev1.Event, error) {
 	user, err := requireAuth(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// Derive a ctx we can cancel on early-return so a partial subscribe
-	// (room ok, live failed) doesn't leak the room-stream goroutine.
-	streamCtx, cancelStreams := context.WithCancel(ctx)
-
-	roomCh, err := r.core.StreamMyEvents(streamCtx, user.Id)
+	events, err := r.core.StreamMyEvents(ctx, user.Id)
 	if err != nil {
-		cancelStreams()
-		return nil, fmt.Errorf("subscribe room events: %w", err)
+		return nil, fmt.Errorf("subscribe events: %w", err)
 	}
-	liveCh, err := r.core.StreamMyLiveEvents(streamCtx, user.Id)
-	if err != nil {
-		cancelStreams()
-		return nil, fmt.Errorf("subscribe live events: %w", err)
-	}
-
-	out := make(chan *corev1.Event)
-	go func() {
-		defer close(out)
-		defer cancelStreams()
-		for {
-			select {
-			case <-streamCtx.Done():
-				return
-			case e, ok := <-roomCh:
-				if !ok {
-					roomCh = nil
-					if liveCh == nil {
-						return
-					}
-					continue
-				}
-				select {
-				case out <- e:
-				case <-streamCtx.Done():
-					return
-				}
-			case e, ok := <-liveCh:
-				if !ok {
-					liveCh = nil
-					if roomCh == nil {
-						return
-					}
-					continue
-				}
-				select {
-				case out <- e:
-				case <-streamCtx.Done():
-					return
-				}
-			}
-		}
-	}()
-	return out, nil
+	return events, nil
 }
 
 // Subscription returns SubscriptionResolver implementation.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -366,23 +366,21 @@ The distinction between stored and live-only events is based on how they're publ
 
 **Event Publishing Strategy:**
 
-Events are published to two types of destinations:
+Every event eventually lands on `live.server.>` so a subscriber needs only one NATS Core subscription to see all of them:
 
-1. **Primary Streams** (persistent):
-   - `SERVER_EVENTS` stream for room-scoped events (room lifecycle, messages, room membership)
-2. **Live Events** (transient, NATS Core):
-   - All live events publish under the `live.server.>` root:
-     - Deployment-wide user/space/config events: `live.server.{user,space,config}.>`
-     - Room/member live events: `live.server.room.{kind}.>`, `live.server.member.>`
-   - Not persisted in JetStream — fire-and-forget for real-time delivery only
+1. **Primary Stream** (persistent):
+   - `SERVER_EVENTS` (subjects `server.>`) holds room messages, thread replies, room meta lifecycle, and server-level member events. A stream-level `RePublish` config forwards every accepted message onto `live.server.>` (same suffix, new prefix). The republish fires after persistence, so a subscriber cannot observe an event that didn't durably store.
+2. **Direct Live Publish** (transient):
+   - Reactions, typing, message edits/deletes, user/space/config notifications publish directly via NATS Core to `live.server.>` — no stream storage. KV buckets are the source of truth for the state these reflect.
+
+The two paths share the same subject root; leaf tokens disambiguate (`.msg.{id}`, `.meta`, `.{verb}` for republished stream events; `.reaction_added`, `.user_typing`, `.profile_updated`, etc. for direct publishes). The `myEvents` GraphQL subscription is backed by one core stream (`StreamMyEvents`) that wraps a single `ChanSubscribe("live.server.>")` plus per-event authorization. There is no per-connection JetStream consumer.
 
 ### Event Streams
 
 | Stream                       | Wrapper          | Scope      | Description                                      |
 | ---------------------------- | ---------------- | ---------- | ------------------------------------------------ |
-| `SERVER_EVENTS`              | `corev1.Event`   | Server     | All JetStream-stored events                      |
-| Live Deployment Events       | `corev1.Event`   | Transient  | `live.server.{user,space,config}.*` (NATS Core)  |
-| Live Room/Member Events      | `corev1.Event`   | Transient  | `live.server.room.{kind}.*` / `live.server.member.*` (NATS Core) |
+| `SERVER_EVENTS`              | `corev1.Event`   | Server     | All JetStream-stored events; republishes onto `live.server.>` |
+| Live Events                  | `corev1.Event`   | Transient  | `live.server.>` (NATS Core) — also the unified subscription root for republished stream events |
 
 **SERVER\_EVENTS subjects:**
 
@@ -420,9 +418,14 @@ Note: Event type (created, joined, etc.) is determined by the event payload, not
 - Powers real-time notifications and user-centric subscriptions
 - Events are dual-published: to primary stream (audit trail) and user stream (notifications)
 
-**Live Subject Space** (transient):
+**Live Subject Space**:
 
-Pattern: `live.server.{scope}.{subject}` — for real-time delivery of transient events. All live events publish under a single `live.server.>` root via `publishLiveUserEvent()`, `publishLiveSpaceEvent()`, `publishLiveConfigEvent()`, `publishLiveRoomEvent()`, and `publishLiveMemberEvent()` (all NATS Core, no JetStream storage):
+Pattern: `live.server.{scope}.{subject}` — the single subscription root for real-time delivery. Two publishers feed it:
+
+- `SERVER_EVENTS` RePublish (`server.>` → `live.server.>`): every accepted stream message is re-emitted onto a NATS Core subject after persistence. Subscribers don't need a JetStream consumer to receive room messages, thread replies, room meta, or server-level member events.
+- Direct NATS Core publishes (`publishLiveUserEvent()`, `publishLiveSpaceEvent()`, `publishLiveConfigEvent()`, `publishLiveRoomEvent()`, `publishLiveMemberEvent()`): transient events with no stream storage.
+
+Subject leaf tokens never collide between the two paths — republished events end in `.msg.{id}` / `.meta` / `.{member_verb}`, direct publishes use event-type tokens (`.reaction_added`, `.user_typing`, `.profile_updated`, etc.).
 
 **Deployment-wide live events** (`live.server.{user,space,config}.>`):
 
@@ -445,21 +448,30 @@ Pattern: `live.server.{scope}.{subject}` — for real-time delivery of transient
 | `live.server.user.{userId}.room_read`                    | Room marked as read          |
 | `live.server.space.{spaceId}.new_message`                | New message in space         |
 
-**Room/member live events** (`live.server.room.>` / `live.server.member.>`):
+**Republished from `SERVER_EVENTS`** (durable, available via `live.server.>` after stream write):
+
+| Subject                                                                       | Description                  |
+| ----------------------------------------------------------------------------- | ---------------------------- |
+| `live.server.room.{kind}.{roomId}.msg.{eventId}`                              | Root message posted          |
+| `live.server.room.{kind}.{roomId}.msg.{rootEventId}.replies.{eventId}`        | Thread reply posted          |
+| `live.server.room.{kind}.{roomId}.meta`                                       | Room lifecycle + membership  |
+| `live.server.member.joined` / `.left` / `.deleted`                            | Server-level membership      |
+
+**Direct live publishes** (transient, never stored):
 
 | Subject                                                  | Description                  |
 | -------------------------------------------------------- | ---------------------------- |
-| `live.server.member.deleted`                             | User removed from space      |
 | `live.server.room.{kind}.{roomId}.reaction_added`        | Reaction added to message    |
 | `live.server.room.{kind}.{roomId}.reaction_removed`      | Reaction removed from message|
 | `live.server.room.{kind}.{roomId}.message_deleted`       | Message deleted              |
 | `live.server.room.{kind}.{roomId}.message_updated`       | Message edited               |
+| `live.server.room.{kind}.{roomId}.user_typing`           | User typing in a room        |
 
-All live events bypass JetStream entirely — KV buckets are the source of truth. Every event is delivered through the unified `myEvents` GraphQL subscription, which fans in:
+The unified `myEvents` GraphQL subscription is backed by a single core stream (`StreamMyEvents`) that combines:
 
-- The JetStream consumer for stored room events (messages, room lifecycle)
-- A NATS Core subscription to `live.server.>` (room, member, user, space, config — all gated per event by `isAuthorizedForLiveEvent`)
-- The PresenceHub (single per-process KV watcher on `presence.>` fanning out to all subscribers, filtered by space membership)
+- One `ChanSubscribe("live.server.>")` (covers republished stream events and direct live publishes alike) with authorization applied per event: room membership for `live.server.room.>`, `isAuthorizedForLiveEvent` for everything else.
+- The PresenceHub (single per-process KV watcher on `presence.>` fanning out to all subscribers).
+- An in-process heartbeat ticker (synthetic `Heartbeat` event every 25s for client-side liveness detection).
 
 ### KV Buckets (backed by streams)
 

--- a/frontend/src/lib/state/room/messages.svelte.ts
+++ b/frontend/src/lib/state/room/messages.svelte.ts
@@ -311,19 +311,14 @@ export abstract class MessageListStore {
     return newOnes.length;
   }
 
-  /** Replace the buffer wholesale (typical fresh-load flow). */
-  protected replaceWithFetched(rawEvents: readonly RawEvent[]): void {
-    const fetched = unmask(rawEvents);
-    const newSeen = new SvelteSet<string>();
-    for (const e of fetched) newSeen.add(e.id);
-    this.events = fetched;
-    this.seenIds = newSeen;
-  }
-
   /**
    * Replace the buffer with fetched events but preserve any subscription
-   * events that arrived during the in-flight query. Use when the initial
-   * fetch races with the subscription (typical for thread loads).
+   * events that arrived during the in-flight query. Always the right
+   * choice when a paginated query result replaces the timeline — the
+   * eventBus subscription has been live since layout mount, so any
+   * MessagePostedEvent for this room that lands while the query is in
+   * flight has already been added to {@link events} via
+   * {@link ingestServerEvent} and must not be wiped by the result.
    */
   protected replaceMergingExisting(rawEvents: readonly RawEvent[]): void {
     const fetched = unmask(rawEvents);
@@ -670,13 +665,13 @@ export class RoomMessagesStore extends MessageListStore {
       });
   }
 
-  /** Wrap replaceWithFetched with cursor maintenance. */
+  /** Replace via merge (preserves mid-query subscription events) and update cursors. */
   private replaceWithFetchedAndUpdateCursors(connection: {
     events: readonly RawEvent[];
     startCursor?: string | null;
     endCursor?: string | null;
   }): void {
-    this.replaceWithFetched(connection.events);
+    this.replaceMergingExisting(connection.events);
     this.oldestCursor = connection.startCursor ?? undefined;
     this.newestCursor = connection.endCursor ?? undefined;
     this.hasReachedStart = false;


### PR DESCRIPTION
## Summary

- Replaces the per-connection JetStream ordered consumer in `StreamMyEvents` with a single NATS Core subscription on `live.server.>`. The `SERVER_EVENTS` stream now declares `RePublish{Source: "server.>", Destination: "live.server.>"}`, so every accepted stream message is automatically re-emitted onto the live namespace after persistence.
- Subscribers see durable events (room messages, thread replies, room meta, server-level member events) and direct live publishes (reactions, typing, edits, deletes, user/space/config notifications) through one channel. Leaf tokens disambiguate the two paths (`.msg.{id}` / `.meta` / `.{verb}` for republished stream events; `.reaction_added` / `.user_typing` / etc. for direct publishes).
- Folds `StreamMyLiveEvents` into `StreamMyEvents` and updates the `myEvents` resolver to consume the single channel directly. Removes the unused `StreamMyServerConfigEvents`.
- Subscribes to the live subscription's `StatusChanged(SubscriptionSlowConsumer)` channel and tears the resolver down on buffer overflow so missed events surface as a re-subscription rather than silent loss.
- Frontend: routes `RoomMessagesStore.fetchLatest` (and the `catchUpForward` `hasNewer` branch) through `replaceMergingExisting` so subscription events that arrive while the room-history query is in flight aren't wiped by the result.

## Background — the bug this fixes

The dead-subscription watchdog landed in #423 catches the case where the whole subscription resolver dies (heartbeats stop). But the old `StreamMyEvents` ran the JetStream reader as a *separate inner goroutine* with three silent-exit paths (terminal iterator error, max retries exceeded, get-iterator error). When the inner reader returned, the outer goroutine — which owns the heartbeat ticker and the live/presence subscriptions — kept running. Heartbeats arrived every 25s and reset `lastEventAt`, so the client-side watchdog never fired even though no room messages were being delivered. Users saw a "connected" WebSocket with stale rooms, typically after a mobile PWA wake from long sleep.

With republish there is no JetStream iterator and no inner goroutine; the failure mode is structurally impossible. Authorization moves into a single `filterLiveEvent` function with three routing paths:

1. Room subjects (`live.server.room.>`) — gated by membership cache + `dm.view`
2. `NewMessageInSpace` events — gated by per-room membership (DM rooms have no space membership)
3. Everything else — `isAuthorizedForLiveEvent` on the subject pattern

## Notable correctness changes

- Subject parsers (`ParseRoomIDFromSubject`, `IsThreadSubject`, `IsRootMessageSubject`, `IsMetaSubject`, `ParseEventIDFromSubject`, `ParseThreadRootEventIDFromSubject`) accept both `server.>` and `live.server.>` shapes via a new `stripLivePrefix` helper. New test cases cover the live shape.
- `isAuthorizedForLiveEvent` now handles the `member` scope (republished `live.server.member.{verb}` from `server.member.{verb}` — server-level member events visible to all authenticated users).
- Removes the duplicate manual `publishLiveServerEvent` for `member_deleted` in `CleanupUserStateInSpace`. RePublish now covers that delivery — the manual publish would have delivered the same event twice.
- New `live.server.>` subscription buffer is 256 (vs 64 for the previous three split subs). On overflow, NATS transitions the sub to SlowConsumer; `StatusChanged(SubscriptionSlowConsumer)` triggers a teardown so the client re-subscribes (and any UI state that depends on missed messages is repaired via the usual GraphQL refetch paths — `useTabResumeCallback`, room queries on focus/visibility).
- `RoomMessagesStore`'s `replaceWithFetchedAndUpdateCursors` now merges into the existing buffer (`replaceMergingExisting`) instead of wiping it. The eventBus subscription is live since layout mount, so a `MessagePostedEvent` for the current room can arrive between `resetState()` and the `fetchLatest` query response; the old wipe-and-replace silently dropped it whenever the server snapshot was taken just before the new message was indexed. `seenIds` dedupes anything that appears in both, and `ingestServerEvent` already filters by `this.roomId` so room switches stay clean.

## Diff stats

```
10 files changed, 343 insertions(+), 607 deletions(-)
```

Net **−264 lines**.

## Test plan

- [x] `mise test-cli` — all packages pass (includes the previously-named `TestStreamMyLiveEvents_*` tests, renamed to `TestStreamMyEvents_*` since the function merged)
- [x] `mise test-frontend` — 713/713 pass
- [x] `mise x -- pnpm check` — 0 errors, 0 warnings (1265 files)
- [x] e2e `messages.test.ts` + `threading.test.ts` + `jump-to-message.test.ts` (65 pass) — covers initial room load, room switch, thread load, and the catch-up/jump-to-present paths that route through the cursor helper
- [x] e2e `dm.test.ts` + `reactions.test.ts` (17 pass) — DM-kind room events + reaction direct-publishes
- [x] e2e `presence-indicators.test.ts` (44 pass with threading) — PresenceHub fanout
- [x] e2e `notifications.test.ts` + `cross-tab-signout.test.ts` + `cross-server-dots.test.ts` + `account-deletion.test.ts` (43/44 pass; the 1 fail is a pre-existing route-navigation flake — passes on retry in isolation, unrelated to subscription changes)
- [ ] Manual smoke: kill the WS mid-session and confirm heartbeats + catch-up restore state
- [ ] Manual smoke: mobile PWA — confirm the original stale-on-wake symptom is gone