### PR TITLE
fix(ui): cleaner space-banner bleed using mirrored copies

### DIFF
--- a/frontend/src/routes/chat/[serverId]/(chrome)/SpaceBanner.svelte
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/SpaceBanner.svelte
@@ -6,12 +6,14 @@
 
 <div class="w-full p-2">
   <div class="relative aspect-[1200/630] max-h-32 w-full overflow-hidden rounded-lg bg-surface-100">
-    <img
-      src={url}
-      alt=""
+    <div
       aria-hidden="true"
-      class="pointer-events-none absolute inset-0 h-full w-full scale-125 object-cover blur-2xl"
-    />
+      class="pointer-events-none absolute inset-y-0 left-1/2 flex -translate-x-1/2 items-center blur-lg"
+    >
+      <img src={url} alt="" class="h-full w-auto max-w-none shrink-0 -scale-x-100" />
+      <img src={url} alt="" class="h-full w-auto max-w-none shrink-0" />
+      <img src={url} alt="" class="h-full w-auto max-w-none shrink-0 -scale-x-100" />
+    </div>
     <SkeletonImg
       src={url}
       alt="Server banner"


### PR DESCRIPTION
## Summary
- The space banner's blurred background used a single scaled+blurred copy of the image, which sampled the image's center (the logo / focal point) and produced a washed-out grey bleed.
- Replaced with a 3-copy mirrored strip (mirror | original | mirror) so adjacent edges share colors and the bleed picks up the banner's actual left/right edge colors.
- Reduced blur from `blur-2xl` (40px) to `blur-lg` (16px) for a less smudgy look.

## Test plan
- [ ] Visual check on a server with a banner image — bleeds on either side should match the colors at the image's edges, not the center.
- [ ] Check on narrow and wide viewports that no grey gaps appear at the far edges.