### PR TITLE
refactor(storage): typed StorageSlot abstraction + self-persisting CollapsibleGroup

### DIFF
--- a/frontend/src/lib/RoomList.svelte
+++ b/frontend/src/lib/RoomList.svelte
@@ -26,7 +26,6 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   } from '$lib/hooks';
   import { getCurrentUser } from '$lib/auth/currentUser.svelte';
   import { serverStorageKey } from '$lib/storage/serverStorage';
-  import { SvelteSet } from 'svelte/reactivity';
   import { useFragment } from './gql';
   import { RoomType, type PresenceStatus } from '$lib/gql/graphql';
   import UserAvatar, { UserAvatarFragment } from '$lib/components/UserAvatar.svelte';
@@ -50,43 +49,6 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   const roomsStore = getSpaceRoomsStore();
 
   let activeRoomId = $derived(page.params.roomId);
-
-  // --- Collapsed-section UI state (persisted to localStorage) ---
-
-  let collapsedSections = new SvelteSet<string>();
-
-  function collapsedSectionsKey(): string {
-    return serverStorageKey(getServerId(), `server:collapsed-sections`);
-  }
-
-  function loadCollapsedFromStorage() {
-    collapsedSections.clear();
-    try {
-      const json = localStorage.getItem(collapsedSectionsKey());
-      if (json) {
-        for (const id of JSON.parse(json)) {
-          collapsedSections.add(id);
-        }
-      }
-    } catch {
-      // ignore malformed localStorage data
-    }
-  }
-
-  function saveCollapsedSections() {
-    localStorage.setItem(collapsedSectionsKey(), JSON.stringify([...collapsedSections]));
-  }
-
-  function toggleSection(sectionId: string) {
-    if (collapsedSections.has(sectionId)) {
-      collapsedSections.delete(sectionId);
-    } else {
-      collapsedSections.add(sectionId);
-    }
-    saveCollapsedSections();
-  }
-
-  loadCollapsedFromStorage();
 
   // Load active call room IDs once on mount.
   if (instanceState.livekitUrl) activeCallRooms.load();
@@ -418,8 +380,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
         label={section.name}
         items={getSectionRooms(section)}
         item={roomLink}
-        collapsed={collapsedSections.has(section.id)}
-        onToggle={() => toggleSection(section.id)}
+        persistKey={serverStorageKey(getServerId(), `collapsible:section:${section.id}`)}
         keepVisibleWhenCollapsed={isHighlighted}
         class={i === 0 ? 'mt-4 first:mt-0' : 'mt-4'}
       />
@@ -431,8 +392,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
         label="Other"
         items={unsectionedRooms}
         item={roomLink}
-        collapsed={collapsedSections.has('__unsorted__')}
-        onToggle={() => toggleSection('__unsorted__')}
+        persistKey={serverStorageKey(getServerId(), 'collapsible:unsorted')}
         keepVisibleWhenCollapsed={isHighlighted}
         class="mt-4"
       />
@@ -445,8 +405,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
       label="Rooms"
       items={unsectionedRooms}
       item={roomLink}
-      collapsed={collapsedSections.has('__rooms__')}
-      onToggle={() => toggleSection('__rooms__')}
+      persistKey={serverStorageKey(getServerId(), 'collapsible:rooms')}
       keepVisibleWhenCollapsed={isHighlighted}
       class="mt-4 first:mt-0"
     />
@@ -456,8 +415,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
       label="Rooms"
       items={sortedRooms}
       item={roomLink}
-      collapsed={collapsedSections.has('__rooms__')}
-      onToggle={() => toggleSection('__rooms__')}
+      persistKey={serverStorageKey(getServerId(), 'collapsible:rooms')}
       keepVisibleWhenCollapsed={isHighlighted}
       class="mt-4 first:mt-0"
     />
@@ -468,8 +426,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
       label="Direct Messages"
       items={dmRooms}
       item={dmLink}
-      collapsed={collapsedSections.has('__dms__')}
-      onToggle={() => toggleSection('__dms__')}
+      persistKey={serverStorageKey(getServerId(), 'collapsible:dms')}
       keepVisibleWhenCollapsed={isHighlighted}
       class="mt-4"
     />

--- a/frontend/src/lib/state/recentEmojis.svelte.ts
+++ b/frontend/src/lib/state/recentEmojis.svelte.ts
@@ -7,7 +7,7 @@
  * - The message quick-reaction bar / context menu / mobile action sheet,
  *   which fill the trailing (non-pinned) slots with these recents.
  *
- * State is keyed by server ID via {@link serverStorageKey}; switching servers
+ * State is keyed by server ID via {@link serverSlot}; switching servers
  * shows a different recent list.
  */
 
@@ -16,40 +16,31 @@ import {
   QUICK_REACTIONS_COUNT,
   RECENT_REACTION_FALLBACKS
 } from '$lib/emoji';
-import { serverStorageKey } from '$lib/storage/serverStorage';
+import { Codecs, serverSlot, type StorageSlot } from '$lib/storage/slot';
 
 const STORAGE_SUFFIX = 'recentEmojis';
 export const MAX_RECENT_EMOJIS = 16;
 
+// Codec only checks "is an array"; individual entries are filtered on read
+// so corrupt items don't invalidate the whole payload.
+const emojiListCodec = Codecs.json<string[]>((v): v is string[] => Array.isArray(v));
+
 export class RecentEmojisStore {
   recent = $state<string[]>([]);
-  private storageKey: string;
+  private storage: StorageSlot<string[]>;
 
   constructor(serverId: string) {
-    this.storageKey = serverStorageKey(serverId, STORAGE_SUFFIX);
-    if (typeof window === 'undefined') return;
-    try {
-      const stored = localStorage.getItem(this.storageKey);
-      if (!stored) return;
-      const parsed = JSON.parse(stored);
-      if (Array.isArray(parsed)) {
-        this.recent = parsed
-          .filter((e): e is string => typeof e === 'string')
-          .slice(0, MAX_RECENT_EMOJIS);
-      }
-    } catch {
-      // Ignore corrupt localStorage
-    }
+    this.storage = serverSlot(serverId, STORAGE_SUFFIX, [], emojiListCodec);
+    this.recent = this.storage
+      .get()
+      .filter((e): e is string => typeof e === 'string')
+      .slice(0, MAX_RECENT_EMOJIS);
   }
 
   record(emoji: string) {
     const filtered = this.recent.filter((e) => e !== emoji);
     this.recent = [emoji, ...filtered].slice(0, MAX_RECENT_EMOJIS);
-    try {
-      localStorage.setItem(this.storageKey, JSON.stringify(this.recent));
-    } catch {
-      // localStorage full or unavailable
-    }
+    this.storage.set(this.recent);
   }
 
   /**

--- a/frontend/src/lib/state/recentQuickSwitcher.svelte.ts
+++ b/frontend/src/lib/state/recentQuickSwitcher.svelte.ts
@@ -6,52 +6,40 @@
  * URLs already encode the instance segment, so no per-instance namespacing needed.
  */
 
-const STORAGE_KEY = 'chatto:quickSwitcherRecents';
+import { Codecs, globalSlot } from '$lib/storage/slot';
+
 const MAX_RECENTS = 15;
 
+const slot = globalSlot(
+  'quickSwitcherRecents',
+  [] as string[],
+  Codecs.json<string[]>((v): v is string[] => Array.isArray(v))
+);
+
 export class RecentQuickSwitcherState {
-	private recents = $state<string[]>([]);
+  // Filter on read: the codec only validates that we have an array, so
+  // individual corrupt entries are dropped here without invalidating the
+  // entire payload (matches the original loader's behaviour).
+  private recents = $state<string[]>(
+    slot.get().filter((e): e is string => typeof e === 'string')
+  );
 
-	constructor() {
-		if (typeof window !== 'undefined') {
-			try {
-				const stored = localStorage.getItem(STORAGE_KEY);
-				if (stored) {
-					const parsed = JSON.parse(stored);
-					if (Array.isArray(parsed)) {
-						this.recents = parsed.filter((e): e is string => typeof e === 'string');
-					}
-				}
-			} catch {
-				// Ignore corrupt localStorage
-			}
-		}
-	}
+  /** Ordered list of recent destination URLs, most recent first. */
+  get urls(): readonly string[] {
+    return this.recents;
+  }
 
-	/** Ordered list of recent destination URLs, most recent first. */
-	get urls(): readonly string[] {
-		return this.recents;
-	}
+  /** Record a destination URL as the most recently used. */
+  record(url: string) {
+    const filtered = this.recents.filter((u) => u !== url);
+    this.recents = [url, ...filtered].slice(0, MAX_RECENTS);
+    slot.set(this.recents);
+  }
 
-	/** Record a destination URL as the most recently used. */
-	record(url: string) {
-		const filtered = this.recents.filter((u) => u !== url);
-		this.recents = [url, ...filtered].slice(0, MAX_RECENTS);
-		this.persist();
-	}
-
-	/** Returns the recency index (0 = most recent) or -1 if not recent. */
-	indexOf(url: string): number {
-		return this.recents.indexOf(url);
-	}
-
-	private persist() {
-		try {
-			localStorage.setItem(STORAGE_KEY, JSON.stringify(this.recents));
-		} catch {
-			// localStorage full or unavailable
-		}
-	}
+  /** Returns the recency index (0 = most recent) or -1 if not recent. */
+  indexOf(url: string): number {
+    return this.recents.indexOf(url);
+  }
 }
 
 export const recentQuickSwitcher = new RecentQuickSwitcherState();

--- a/frontend/src/lib/state/server/registry.svelte.ts
+++ b/frontend/src/lib/state/server/registry.svelte.ts
@@ -2,8 +2,7 @@ import { SvelteMap } from 'svelte/reactivity';
 import { ServerStateStore } from './store.svelte';
 import { graphqlClientManager } from './graphqlClient.svelte';
 import { eventBusManager } from './eventBus.svelte';
-
-const STORAGE_KEY = 'chatto:instances';
+import { Codecs, globalSlot } from '$lib/storage/slot';
 
 /**
  * A registered Chatto instance in the multi-instance client.
@@ -58,36 +57,11 @@ export function generateInstanceId(url: string, existingIds: string[] = []): str
 	return `${base}-${suffix}`;
 }
 
-function loadInstances(): RegisteredInstance[] {
-	if (typeof localStorage === 'undefined') {
-		return [];
-	}
-
-	try {
-		const stored = localStorage.getItem(STORAGE_KEY);
-		if (stored) {
-			const parsed = JSON.parse(stored);
-			if (Array.isArray(parsed)) {
-				return parsed;
-			}
-		}
-	} catch {
-		// Ignore parse errors, start fresh
-	}
-	return [];
-}
-
-function saveInstances(instances: RegisteredInstance[]): void {
-	if (typeof localStorage === 'undefined') {
-		return;
-	}
-
-	try {
-		localStorage.setItem(STORAGE_KEY, JSON.stringify(instances));
-	} catch {
-		// Ignore storage errors (quota exceeded, etc.)
-	}
-}
+const instancesSlot = globalSlot(
+	'instances',
+	[] as RegisteredInstance[],
+	Codecs.json<RegisteredInstance[]>((v): v is RegisteredInstance[] => Array.isArray(v))
+);
 
 
 /**
@@ -106,7 +80,7 @@ function saveInstances(instances: RegisteredInstance[]): void {
  * and provided to components through Svelte context.
  */
 class ServerRegistry {
-	instances = $state<RegisteredInstance[]>(loadInstances());
+	instances = $state<RegisteredInstance[]>(instancesSlot.get());
 	#stores = new SvelteMap<string, ServerStateStore>();
 
 	/**
@@ -231,7 +205,7 @@ class ServerRegistry {
 			return; // Already exists
 		}
 		this.instances.push(instance);
-		saveInstances(this.instances);
+		instancesSlot.set(this.instances);
 		const store = this.#createStore(instance);
 
 		// Start the event bus eagerly for already-authenticated instances so
@@ -263,7 +237,7 @@ class ServerRegistry {
 		graphqlClientManager.destroyClient(id);
 
 		this.instances = this.instances.filter((i) => i.id !== id);
-		saveInstances(this.instances);
+		instancesSlot.set(this.instances);
 		return true;
 	}
 
@@ -277,7 +251,7 @@ class ServerRegistry {
 			graphqlClientManager.destroyClient(instance.id);
 		}
 		this.instances = [];
-		saveInstances(this.instances);
+		instancesSlot.set(this.instances);
 	}
 
 	/** Update fields on an existing instance. */
@@ -288,7 +262,7 @@ class ServerRegistry {
 		}
 
 		Object.assign(instance, data);
-		saveInstances(this.instances);
+		instancesSlot.set(this.instances);
 		return true;
 	}
 

--- a/frontend/src/lib/state/userPreferences.svelte.ts
+++ b/frontend/src/lib/state/userPreferences.svelte.ts
@@ -10,8 +10,7 @@ import {
   defaultSoundId,
   notificationSounds
 } from '$lib/audio/notificationSounds';
-
-const STORAGE_KEY = 'chatto:preferences';
+import { Codecs, globalSlot } from '$lib/storage/slot';
 
 interface Preferences {
   notificationSound: NotificationSoundId;
@@ -21,43 +20,18 @@ const defaultPreferences: Preferences = {
   notificationSound: defaultSoundId
 };
 
+const slot = globalSlot('preferences', defaultPreferences, Codecs.json<Preferences>());
+
 function loadPreferences(): Preferences {
-  if (typeof localStorage === 'undefined') {
-    return defaultPreferences;
-  }
-
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) {
-      const parsed = JSON.parse(stored);
-
-      // Validate that the stored sound ID is still valid
-      const soundId = parsed.notificationSound;
-      const isValidSound = notificationSounds.some((s) => s.id === soundId);
-
-      return {
-        ...defaultPreferences,
-        ...parsed,
-        // Fall back to default if stored sound is invalid
-        notificationSound: isValidSound ? soundId : defaultSoundId
-      };
-    }
-  } catch {
-    // Ignore parse errors, use defaults
-  }
-  return defaultPreferences;
-}
-
-function savePreferences(prefs: Preferences): void {
-  if (typeof localStorage === 'undefined') {
-    return;
-  }
-
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
-  } catch {
-    // Ignore storage errors (quota exceeded, etc.)
-  }
+  const stored = slot.get();
+  // Validate that the stored sound ID is still valid — silently fall back
+  // to the default if the user migrated away from a sound we no longer ship.
+  const isValidSound = notificationSounds.some((s) => s.id === stored.notificationSound);
+  return {
+    ...defaultPreferences,
+    ...stored,
+    notificationSound: isValidSound ? stored.notificationSound : defaultSoundId
+  };
 }
 
 export class UserPreferencesState {
@@ -69,7 +43,7 @@ export class UserPreferencesState {
 
   set notificationSound(value: NotificationSoundId) {
     this.#prefs.notificationSound = value;
-    savePreferences(this.#prefs);
+    slot.set(this.#prefs);
   }
 
   /**

--- a/frontend/src/lib/storage/lastRoom.ts
+++ b/frontend/src/lib/storage/lastRoom.ts
@@ -1,46 +1,32 @@
 /**
- * Per-instance "last visited room" memory. Used to redirect users back to
- * the room they were last in when they return to an instance.
- *
- * Keys are namespaced by instance ID. There is no per-space dimension
- * because the deployment has one server (the instance) — see #330.
+ * Per-server "last visited room" memory. Used to redirect users back to
+ * the room they were last in when they return to a server.
  */
 
 import { resolve } from '$app/paths';
 import { serverIdToSegment } from '$lib/navigation';
-import { serverStorageKey } from './serverStorage';
+import { Codecs, serverSlot } from './slot';
 
-const LAST_ROOM_SUFFIX = 'lastRoom';
+const SUFFIX = 'lastRoom';
 
-/** Get the last visited room for an instance, or null if none. */
+function slot(serverId: string) {
+  return serverSlot(serverId, SUFFIX, '', Codecs.string);
+}
+
 export function getLastRoom(serverId: string): string | null {
-  try {
-    return localStorage.getItem(serverStorageKey(serverId, LAST_ROOM_SUFFIX));
-  } catch {
-    return null;
-  }
+  return slot(serverId).get() || null;
 }
 
-/** Save the last visited room for an instance. */
 export function setLastRoom(serverId: string, roomId: string): void {
-  try {
-    localStorage.setItem(serverStorageKey(serverId, LAST_ROOM_SUFFIX), roomId);
-  } catch {
-    // Ignore storage errors (quota exceeded, etc.)
-  }
+  slot(serverId).set(roomId);
 }
 
-/** Clear the last visited room for an instance. */
 export function clearLastRoom(serverId: string): void {
-  try {
-    localStorage.removeItem(serverStorageKey(serverId, LAST_ROOM_SUFFIX));
-  } catch {
-    // Ignore storage errors
-  }
+  slot(serverId).remove();
 }
 
 /**
- * Resolve the last-visited path for an instance, or null if none.
+ * Resolve the last-visited path for a server, or null if none.
  * Enables single-hop navigation from index pages to the user's last room.
  */
 export function resolveLastPosition(serverId: string): string | null {

--- a/frontend/src/lib/storage/roomInfoWidth.ts
+++ b/frontend/src/lib/storage/roomInfoWidth.ts
@@ -1,37 +1,20 @@
-const STORAGE_KEY = 'chatto:roomInfoWidth';
+import { Codecs, globalSlot } from './slot';
 
 export const ROOM_INFO_DEFAULT_WIDTH = 256;
 export const ROOM_INFO_MIN_WIDTH = 200;
 export const ROOM_INFO_MAX_WIDTH = 480;
 
+const slot = globalSlot(
+  'roomInfoWidth',
+  ROOM_INFO_DEFAULT_WIDTH,
+  Codecs.number({ min: ROOM_INFO_MIN_WIDTH, max: ROOM_INFO_MAX_WIDTH })
+);
+
 export function getRoomInfoWidth(): number {
-  if (typeof localStorage === 'undefined') {
-    return ROOM_INFO_DEFAULT_WIDTH;
-  }
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) {
-      const value = parseFloat(stored);
-      if (
-        !isNaN(value) &&
-        value >= ROOM_INFO_MIN_WIDTH &&
-        value <= ROOM_INFO_MAX_WIDTH
-      ) {
-        return value;
-      }
-    }
-  } catch {
-    // Ignore storage errors
-  }
-  return ROOM_INFO_DEFAULT_WIDTH;
+  return slot.get();
 }
 
 export function setRoomInfoWidth(width: number): void {
   const clamped = Math.min(ROOM_INFO_MAX_WIDTH, Math.max(ROOM_INFO_MIN_WIDTH, width));
-  if (typeof localStorage === 'undefined') return;
-  try {
-    localStorage.setItem(STORAGE_KEY, String(clamped));
-  } catch {
-    // Ignore storage errors
-  }
+  slot.set(clamped);
 }

--- a/frontend/src/lib/storage/secondarySidebarWidth.ts
+++ b/frontend/src/lib/storage/secondarySidebarWidth.ts
@@ -1,29 +1,17 @@
-const STORAGE_KEY = 'chatto:secondarySidebarWidth';
+import { Codecs, globalSlot } from './slot';
 
 export const SECONDARY_SIDEBAR_DEFAULT_WIDTH = 256;
 export const SECONDARY_SIDEBAR_MIN_WIDTH = 200;
 export const SECONDARY_SIDEBAR_MAX_WIDTH = 480;
 
+const slot = globalSlot(
+  'secondarySidebarWidth',
+  SECONDARY_SIDEBAR_DEFAULT_WIDTH,
+  Codecs.number({ min: SECONDARY_SIDEBAR_MIN_WIDTH, max: SECONDARY_SIDEBAR_MAX_WIDTH })
+);
+
 export function getSecondarySidebarWidth(): number {
-  if (typeof localStorage === 'undefined') {
-    return SECONDARY_SIDEBAR_DEFAULT_WIDTH;
-  }
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) {
-      const value = parseFloat(stored);
-      if (
-        !isNaN(value) &&
-        value >= SECONDARY_SIDEBAR_MIN_WIDTH &&
-        value <= SECONDARY_SIDEBAR_MAX_WIDTH
-      ) {
-        return value;
-      }
-    }
-  } catch {
-    // Ignore storage errors
-  }
-  return SECONDARY_SIDEBAR_DEFAULT_WIDTH;
+  return slot.get();
 }
 
 export function setSecondarySidebarWidth(width: number): void {
@@ -31,10 +19,5 @@ export function setSecondarySidebarWidth(width: number): void {
     SECONDARY_SIDEBAR_MAX_WIDTH,
     Math.max(SECONDARY_SIDEBAR_MIN_WIDTH, width)
   );
-  if (typeof localStorage === 'undefined') return;
-  try {
-    localStorage.setItem(STORAGE_KEY, String(clamped));
-  } catch {
-    // Ignore storage errors
-  }
+  slot.set(clamped);
 }

--- a/frontend/src/lib/storage/slot.spec.ts
+++ b/frontend/src/lib/storage/slot.spec.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Codecs, StorageSlot, globalSlot, serverSlot } from './slot';
+
+const storage = new Map<string, string>();
+const localStorageMock: Storage = {
+  getItem: (key) => storage.get(key) ?? null,
+  setItem: (key, value) => storage.set(key, value),
+  removeItem: (key) => storage.delete(key),
+  clear: () => storage.clear(),
+  get length() {
+    return storage.size;
+  },
+  key: (index) => [...storage.keys()][index] ?? null
+};
+vi.stubGlobal('localStorage', localStorageMock);
+
+beforeEach(() => {
+  storage.clear();
+});
+
+describe('Codecs.number', () => {
+  it('round-trips finite numbers', () => {
+    const c = Codecs.number();
+    expect(c.parse(c.serialize(3.14))).toBe(3.14);
+  });
+
+  it('rejects NaN and infinity', () => {
+    const c = Codecs.number();
+    expect(c.parse('not-a-number')).toBeUndefined();
+    expect(c.parse('Infinity')).toBeUndefined();
+  });
+
+  it('rejects out-of-range values when bounds are set', () => {
+    const c = Codecs.number({ min: 10, max: 100 });
+    expect(c.parse('5')).toBeUndefined();
+    expect(c.parse('150')).toBeUndefined();
+    expect(c.parse('50')).toBe(50);
+  });
+});
+
+describe('Codecs.boolean', () => {
+  it('round-trips both states', () => {
+    expect(Codecs.boolean.parse(Codecs.boolean.serialize(true))).toBe(true);
+    expect(Codecs.boolean.parse(Codecs.boolean.serialize(false))).toBe(false);
+  });
+
+  it('accepts legacy "true"/"false" payloads', () => {
+    expect(Codecs.boolean.parse('true')).toBe(true);
+    expect(Codecs.boolean.parse('false')).toBe(false);
+  });
+
+  it('rejects unknown payloads', () => {
+    expect(Codecs.boolean.parse('yes')).toBeUndefined();
+  });
+});
+
+describe('Codecs.json', () => {
+  it('round-trips objects', () => {
+    const c = Codecs.json<{ a: number }>();
+    expect(c.parse(c.serialize({ a: 1 }))).toEqual({ a: 1 });
+  });
+
+  it('returns undefined for corrupt JSON', () => {
+    const c = Codecs.json();
+    expect(c.parse('{not-json')).toBeUndefined();
+  });
+
+  it('runs the optional validator', () => {
+    const c = Codecs.json<string[]>((v): v is string[] =>
+      Array.isArray(v) && v.every((x) => typeof x === 'string')
+    );
+    expect(c.parse('["a","b"]')).toEqual(['a', 'b']);
+    expect(c.parse('[1,2]')).toBeUndefined();
+    expect(c.parse('"not-array"')).toBeUndefined();
+  });
+});
+
+describe('StorageSlot', () => {
+  it('returns the default when the key is missing', () => {
+    const slot = new StorageSlot('test', 42, Codecs.number());
+    expect(slot.get()).toBe(42);
+  });
+
+  it('returns the default when the stored value is corrupt', () => {
+    storage.set('test', 'not-a-number');
+    const slot = new StorageSlot('test', 42, Codecs.number());
+    expect(slot.get()).toBe(42);
+  });
+
+  it('returns the default when the stored value is out of range', () => {
+    storage.set('test', '999');
+    const slot = new StorageSlot('test', 42, Codecs.number({ min: 0, max: 100 }));
+    expect(slot.get()).toBe(42);
+  });
+
+  it('reads and writes round-trip', () => {
+    const slot = new StorageSlot('test', 'fallback', Codecs.string);
+    slot.set('hello');
+    expect(slot.get()).toBe('hello');
+    expect(storage.get('test')).toBe('hello');
+  });
+
+  it('removes the underlying key', () => {
+    const slot = new StorageSlot('test', 'fallback', Codecs.string);
+    slot.set('hello');
+    slot.remove();
+    expect(storage.has('test')).toBe(false);
+    expect(slot.get()).toBe('fallback');
+  });
+});
+
+describe('namespacing factories', () => {
+  it('globalSlot prefixes with "chatto:"', () => {
+    const slot = globalSlot('foo', 0, Codecs.number());
+    expect(slot.key).toBe('chatto:foo');
+  });
+
+  it('serverSlot prefixes with "chatto:i:{serverId}:"', () => {
+    const slot = serverSlot('chat-example-com', 'lastRoom', '', Codecs.string);
+    expect(slot.key).toBe('chatto:i:chat-example-com:lastRoom');
+  });
+});

--- a/frontend/src/lib/storage/slot.ts
+++ b/frontend/src/lib/storage/slot.ts
@@ -1,0 +1,140 @@
+/**
+ * Typed `localStorage` accessors.
+ *
+ * `StorageSlot<T>` wraps a single localStorage entry: serialize/parse via a
+ * `Codec<T>`, fall back to a typed default on missing/corrupt data, and
+ * swallow SSR (`localStorage === undefined`) and quota errors at the edge.
+ *
+ * Build items through the factories, which encode Chatto's namespacing:
+ *
+ * - `globalSlot('foo', …)` → `chatto:foo`
+ * - `serverSlot(serverId, 'foo', …)` → `chatto:i:{serverId}:foo`
+ *
+ * Use `globalSlot` for things that are meaningful regardless of which server
+ * the user is looking at (sidebar widths, UI preferences, the server registry
+ * itself). Use `serverSlot` for things scoped to a specific connected server
+ * (last visited room, recent emojis on that server, room-info collapse state).
+ */
+
+import { serverStorageKey } from './serverStorage';
+
+/** Serialize/parse pair for a typed localStorage value. */
+export interface Codec<T> {
+  serialize(value: T): string;
+  /**
+   * Return `undefined` when the stored payload is missing or invalid; the
+   * caller falls back to the slot's default.
+   */
+  parse(raw: string): T | undefined;
+}
+
+/** Built-in codecs for the common shapes. */
+export const Codecs = {
+  string: {
+    serialize: (v: string) => v,
+    parse: (raw: string) => raw
+  } satisfies Codec<string>,
+
+  /**
+   * Number codec with optional clamping. Out-of-range or non-finite stored
+   * values parse as `undefined` so the consumer falls back to the default.
+   */
+  number(opts: { min?: number; max?: number } = {}): Codec<number> {
+    return {
+      serialize: (v) => String(v),
+      parse: (raw) => {
+        const n = parseFloat(raw);
+        if (!Number.isFinite(n)) return undefined;
+        if (opts.min !== undefined && n < opts.min) return undefined;
+        if (opts.max !== undefined && n > opts.max) return undefined;
+        return n;
+      }
+    };
+  },
+
+  boolean: {
+    serialize: (v: boolean) => (v ? '1' : '0'),
+    parse: (raw: string) =>
+      raw === '1' || raw === 'true' ? true : raw === '0' || raw === 'false' ? false : undefined
+  } satisfies Codec<boolean>,
+
+  /**
+   * JSON codec with an optional runtime validator. Parse failures and
+   * validator rejections both return `undefined` so corrupt data falls back
+   * to the default cleanly.
+   */
+  json<T>(validate?: (value: unknown) => value is T): Codec<T> {
+    return {
+      serialize: (v) => JSON.stringify(v),
+      parse: (raw) => {
+        try {
+          const parsed: unknown = JSON.parse(raw);
+          if (validate && !validate(parsed)) return undefined;
+          return parsed as T;
+        } catch {
+          return undefined;
+        }
+      }
+    };
+  }
+};
+
+/** A single localStorage entry with a typed default and corruption-safe IO. */
+export class StorageSlot<T> {
+  constructor(
+    public readonly key: string,
+    public readonly defaultValue: T,
+    private readonly codec: Codec<T>
+  ) {}
+
+  /** Read the stored value, or the default if missing / invalid / unavailable. */
+  get(): T {
+    if (typeof localStorage === 'undefined') return this.defaultValue;
+    try {
+      const raw = localStorage.getItem(this.key);
+      if (raw === null) return this.defaultValue;
+      const parsed = this.codec.parse(raw);
+      return parsed !== undefined ? parsed : this.defaultValue;
+    } catch {
+      return this.defaultValue;
+    }
+  }
+
+  /** Persist a value. Silently no-ops if storage is unavailable / full. */
+  set(value: T): void {
+    if (typeof localStorage === 'undefined') return;
+    try {
+      localStorage.setItem(this.key, this.codec.serialize(value));
+    } catch {
+      // Ignore quota / privacy-mode failures.
+    }
+  }
+
+  remove(): void {
+    if (typeof localStorage === 'undefined') return;
+    try {
+      localStorage.removeItem(this.key);
+    } catch {
+      // Ignore.
+    }
+  }
+}
+
+/** Build a globally-scoped `StorageSlot<T>` at `chatto:{suffix}`. */
+export function globalSlot<T>(
+  suffix: string,
+  defaultValue: T,
+  codec: Codec<T>
+): StorageSlot<T> {
+  return new StorageSlot(`chatto:${suffix}`, defaultValue, codec);
+}
+
+/** Build a per-server `StorageSlot<T>` at `chatto:i:{serverId}:{suffix}`. */
+export function serverSlot<T>(
+  serverId: string,
+  suffix: string,
+  defaultValue: T,
+  codec: Codec<T>
+): StorageSlot<T> {
+  return new StorageSlot(serverStorageKey(serverId, suffix), defaultValue, codec);
+}

--- a/frontend/src/lib/storage/threadPaneWidth.ts
+++ b/frontend/src/lib/storage/threadPaneWidth.ts
@@ -1,29 +1,20 @@
-const STORAGE_KEY = 'chatto:threadPaneWidth';
-const DEFAULT_WIDTH = 50; // percentage
+import { Codecs, globalSlot } from './slot';
 
 export const THREAD_PANE_MIN_WIDTH = 25;
 export const THREAD_PANE_MAX_WIDTH = 75;
+const DEFAULT_WIDTH = 50; // percentage
+
+const slot = globalSlot(
+  'threadPaneWidth',
+  DEFAULT_WIDTH,
+  Codecs.number({ min: THREAD_PANE_MIN_WIDTH, max: THREAD_PANE_MAX_WIDTH })
+);
 
 export function getThreadPaneWidth(): number {
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) {
-      const value = parseFloat(stored);
-      if (!isNaN(value) && value >= THREAD_PANE_MIN_WIDTH && value <= THREAD_PANE_MAX_WIDTH) {
-        return value;
-      }
-    }
-  } catch {
-    // Ignore storage errors
-  }
-  return DEFAULT_WIDTH;
+  return slot.get();
 }
 
 export function setThreadPaneWidth(width: number): void {
   const clamped = Math.min(THREAD_PANE_MAX_WIDTH, Math.max(THREAD_PANE_MIN_WIDTH, width));
-  try {
-    localStorage.setItem(STORAGE_KEY, String(clamped));
-  } catch {
-    // Ignore storage errors
-  }
+  slot.set(clamped);
 }

--- a/frontend/src/lib/ui/CollapsibleGroup.svelte
+++ b/frontend/src/lib/ui/CollapsibleGroup.svelte
@@ -1,17 +1,38 @@
 <!--
 @component
 
-A sidebar group with a collapsible header. The header is a button that toggles
-the `collapsed` state via `onToggle`; collapsed/expanded state is owned by the
-caller so it can persist (e.g. to localStorage).
+A sidebar group with a collapsible header. Collapsed/expanded state is
+persisted to `localStorage` under `persistKey`; callers needing per-server
+scoping should build the key with `serverStorageKey()`.
 
-When collapsed, items are hidden unless `keepVisibleWhenCollapsed` returns true
-for them — useful for anchoring rows that demand attention (active, unread,
-mentions, …) so the user can always reach them.
+When collapsed, items are hidden unless `keepVisibleWhenCollapsed` returns
+true for them — useful for anchoring rows that demand attention (active,
+unread, mentions, …) so the user can always reach them.
 
 Used by `RoomList` (channels, DMs, layout sections) and `RoomInfo` (online /
 offline member groups).
 -->
+<script module lang="ts">
+  import { SvelteMap } from 'svelte/reactivity';
+  import { Codecs, StorageSlot } from '$lib/storage/slot';
+
+  // Module-level reactive cache, write-through to localStorage. Groups
+  // that share a `persistKey` stay in sync automatically (no shared key
+  // pairs exist today — this just falls out of the pattern).
+  const cache = new SvelteMap<string, boolean>();
+
+  function loadCollapsed(key: string, fallback: boolean): boolean {
+    const cached = cache.get(key);
+    if (cached !== undefined) return cached;
+    return new StorageSlot(key, fallback, Codecs.boolean).get();
+  }
+
+  function saveCollapsed(key: string, value: boolean): void {
+    cache.set(key, value);
+    new StorageSlot(key, value, Codecs.boolean).set(value);
+  }
+</script>
+
 <script lang="ts" generics="T extends { id: string }">
   import type { Snippet } from 'svelte';
   import { slide } from 'svelte/transition';
@@ -20,8 +41,10 @@ offline member groups).
     label: string;
     items: T[];
     item: Snippet<[T]>;
-    collapsed: boolean;
-    onToggle: () => void;
+    /** Unique localStorage key for persisting collapsed state. */
+    persistKey: string;
+    /** Collapsed state when no preference is stored. */
+    defaultCollapsed?: boolean;
     keepVisibleWhenCollapsed?: (item: T) => boolean;
     class?: string;
   }
@@ -30,17 +53,23 @@ offline member groups).
     label,
     items,
     item,
-    collapsed,
-    onToggle,
+    persistKey,
+    defaultCollapsed = false,
     keepVisibleWhenCollapsed,
     class: className
   }: Props = $props();
+
+  const collapsed = $derived(loadCollapsed(persistKey, defaultCollapsed));
+
+  function toggle() {
+    saveCollapsed(persistKey, !collapsed);
+  }
 </script>
 
 <div class={className}>
   <button
     type="button"
-    onclick={onToggle}
+    onclick={toggle}
     class="flex w-full cursor-pointer items-center gap-2 px-3 py-1 text-xs font-semibold tracking-wider text-muted uppercase transition-colors hover:text-text"
   >
     <span class="sidebar-icon">

--- a/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/RoomInfo.svelte
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/RoomInfo.svelte
@@ -17,7 +17,6 @@
   import { roomInfoWidth } from '$lib/state/roomInfoWidth.svelte';
   import { ROOM_INFO_MAX_WIDTH, ROOM_INFO_MIN_WIDTH } from '$lib/storage/roomInfoWidth';
   import { serverStorageKey } from '$lib/storage/serverStorage';
-  import { SvelteSet } from 'svelte/reactivity';
 
   const getServerId = getActiveServer();
 
@@ -82,46 +81,6 @@
     sortByName(members.filter((m) => !isOnlineStatus(getPresence(m)))))
   );
 
-  // --- Collapsed-group UI state (persisted to localStorage) ---
-
-  const ONLINE_GROUP = 'online';
-  const OFFLINE_GROUP = 'offline';
-
-  let collapsedGroups = new SvelteSet<string>();
-
-  function collapsedGroupsKey(): string {
-    return serverStorageKey(getServerId(), 'room:collapsed-member-groups');
-  }
-
-  function loadCollapsedFromStorage() {
-    collapsedGroups.clear();
-    try {
-      const json = localStorage.getItem(collapsedGroupsKey());
-      if (json) {
-        for (const id of JSON.parse(json)) {
-          collapsedGroups.add(id);
-        }
-      }
-    } catch {
-      // ignore malformed localStorage data
-    }
-  }
-
-  function saveCollapsedGroups() {
-    localStorage.setItem(collapsedGroupsKey(), JSON.stringify([...collapsedGroups]));
-  }
-
-  function toggleGroup(groupId: string) {
-    if (collapsedGroups.has(groupId)) {
-      collapsedGroups.delete(groupId);
-    } else {
-      collapsedGroups.add(groupId);
-    }
-    saveCollapsedGroups();
-  }
-
-  loadCollapsedFromStorage();
-
   // Look up the selected member for the popover (rendered outside the {#each} loop
   // to avoid Svelte reactivity cycles between the popover's $effect and onlineMembers' $derived)
   const popoverMember = $derived(
@@ -164,8 +123,7 @@
           label="Online ({onlineMembers.length})"
           items={onlineMembers}
           item={memberRow}
-          collapsed={collapsedGroups.has(ONLINE_GROUP)}
-          onToggle={() => toggleGroup(ONLINE_GROUP)}
+          persistKey={serverStorageKey(getServerId(), 'collapsible:room-members:online')}
         />
       {/if}
 
@@ -174,8 +132,8 @@
           label="Offline ({offlineMembers.length})"
           items={offlineMembers}
           item={memberRow}
-          collapsed={collapsedGroups.has(OFFLINE_GROUP)}
-          onToggle={() => toggleGroup(OFFLINE_GROUP)}
+          persistKey={serverStorageKey(getServerId(), 'collapsible:room-members:offline')}
+          defaultCollapsed
           class="mt-4"
         />
       {/if}


### PR DESCRIPTION
## Summary

Introduces a typed `StorageSlot<T>` abstraction for every `localStorage` use, and refactors `CollapsibleGroup` to own its own persistence so the Members panel can declaratively default the "Offline" group to collapsed.

`$lib/storage/slot.ts` ships `StorageSlot<T>` with four codecs (`string`, `number({ min, max })`, `boolean`, `json<T>(validator?)`) plus two Chatto-aware factories: `globalSlot('foo')` → `chatto:foo` and `serverSlot(serverId, 'foo')` → `chatto:i:{serverId}:foo`. Every existing `localStorage` call site is migrated — widths, `lastRoom`, `userPreferences`, `recentEmojis`, `recentQuickSwitcher`, the server registry, and the new `CollapsibleGroup` persistence — with all stored keys preserved unchanged.

`CollapsibleGroup` now takes `persistKey` and `defaultCollapsed`, replacing the duplicated `SvelteSet` + load/save/toggle boilerplate that lived in both `RoomInfo` and `RoomList` (net –186 lines across those two callers).

## Test plan

- [x] `mise test-frontend` — 729/729 pass, including new `slot.spec.ts` (16 tests)
- [x] `mise run lint-frontend` — unchanged 168-error baseline; no new errors in touched files
- [x] Svelte autofixer clean on `CollapsibleGroup.svelte`
- [ ] Manual: verify Offline group defaults to collapsed in a fresh browser profile, and that toggling persists across reloads / server switches