### PR TITLE
feat(rooms): group consecutive join/leave events in the timeline

### DIFF
--- a/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/EventList.svelte
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/EventList.svelte
@@ -6,6 +6,7 @@
   import type { RoomMember } from '$lib/state/room';
   import { getComposerContext } from '$lib/state/room';
   import RoomEvent from './RoomEvent.svelte';
+  import SystemEventGroup from './SystemEventGroup.svelte';
   import MessageEventSkeleton from './MessageEventSkeleton.svelte';
   import DaySeparator from './DaySeparator.svelte';
   import UnreadSeparator from './UnreadSeparator.svelte';
@@ -585,6 +586,15 @@
             <DaySeparator label={item.label} />
           {:else if item.type === 'unread-separator'}
             <UnreadSeparator />
+          {:else if item.type === 'system-group'}
+            <!-- Same guard pattern as the event branch below — virtua may re-invoke
+                 the snippet with a stale item reference during data transitions
+                 (e.g. switching rooms or servers). -->
+            {@const groupEvents = item?.events}
+            {@const groupKind = item?.kind}
+            {#if groupEvents && groupKind && groupEvents.length > 0}
+              <SystemEventGroup events={groupEvents} kind={groupKind} />
+            {/if}
           {:else}
             <!--
               Use {@const} with optional chaining to snapshot the event and guard

--- a/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/SystemEventGroup.svelte
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/SystemEventGroup.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+  import type { RoomEventViewFragment, UserAvatarUserFragment } from '$lib/gql/graphql';
+  import type { SystemGroupKind } from './virtualItems';
+  import UserAvatar, { UserAvatarFragment } from '$lib/components/UserAvatar.svelte';
+  import { useFragment } from '$lib/gql/fragment-masking';
+  import { getLiveDisplayName } from '$lib/state/userProfiles.svelte';
+
+  let {
+    events,
+    kind
+  }: {
+    events: RoomEventViewFragment[];
+    kind: SystemGroupKind;
+  } = $props();
+
+  const action = $derived(kind === 'join' ? 'joined the room' : 'left the room');
+
+  type Actor = {
+    id: string;
+    name: string;
+    user: UserAvatarUserFragment | null;
+  };
+
+  // Deduplicate by actor so a user appearing twice in a row (rare, but possible)
+  // doesn't get listed twice. Preserves first-seen order.
+  const actors = $derived.by<Actor[]>(() => {
+    const result: Actor[] = [];
+    for (const event of events) {
+      const user = event?.actor ? useFragment(UserAvatarFragment, event.actor) : null;
+      const id = user?.id ?? `__deleted_${event.actorId ?? 'unknown'}`;
+      if (result.some((a) => a.id === id)) continue;
+      const name = user
+        ? getLiveDisplayName(user.id, user.displayName || user.login)
+        : 'Deleted User';
+      result.push({ id, name, user });
+    }
+    return result;
+  });
+
+  const MAX_AVATARS = 3;
+  const NAMES_BEFORE_TRUNCATION = 3;
+  const visibleAvatars = $derived(actors.slice(0, MAX_AVATARS));
+  const isTruncatable = $derived(actors.length > NAMES_BEFORE_TRUNCATION + 1);
+
+  let expanded = $state(false);
+
+  function joinNames(names: string[]): string {
+    if (names.length === 0) return '';
+    if (names.length === 1) return names[0];
+    if (names.length === 2) return `${names[0]} and ${names[1]}`;
+    return `${names.slice(0, -1).join(', ')}, and ${names[names.length - 1]}`;
+  }
+
+  const allNames = $derived(joinNames(actors.map((a) => a.name)));
+  const headNames = $derived(actors.slice(0, NAMES_BEFORE_TRUNCATION).map((a) => a.name).join(', '));
+  const extraCount = $derived(Math.max(actors.length - NAMES_BEFORE_TRUNCATION, 0));
+</script>
+
+{#if actors.length > 0}
+  <div class="mt-4 flex items-center gap-4 px-2 md:px-4">
+    <!-- Avatar column (w-11 matches MessageEvent avatar width) -->
+    <div class="flex w-11 shrink-0 items-center justify-end">
+      <div class="flex -space-x-1.5">
+        {#each visibleAvatars as actor (actor.id)}
+          {#if actor.user}
+            <UserAvatar user={actor.user} size="xs" showPresence={false} />
+          {:else}
+            <div
+              class="flex h-5 w-5 items-center justify-center rounded-full bg-surface-200 text-muted ring-1 ring-background"
+            >
+              <span class="iconify text-xs uil--user-times"></span>
+            </div>
+          {/if}
+        {/each}
+      </div>
+    </div>
+
+    <span class="text-sm text-muted">
+      {#if !isTruncatable || expanded}
+        {allNames} {action}
+        {#if isTruncatable}
+          <button
+            type="button"
+            class="ml-1 cursor-pointer underline decoration-dotted underline-offset-2 hover:text-text"
+            onclick={() => (expanded = false)}
+          >
+            show less
+          </button>
+        {/if}
+      {:else}
+        {headNames}, and <button
+          type="button"
+          class="cursor-pointer underline decoration-dotted underline-offset-2 hover:text-text"
+          onclick={() => (expanded = true)}
+        >{extraCount} {extraCount === 1 ? 'other' : 'others'}</button>
+        {action}
+      {/if}
+    </span>
+  </div>
+{/if}

--- a/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/virtualItems.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/virtualItems.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { buildVirtualItems } from './virtualItems';
+import { buildVirtualItems, type VirtualItem } from './virtualItems';
 import { computeEventMetadata, type EventWithMeta } from './messageGrouping';
 import type { RoomEventViewFragment } from '$lib/gql/graphql';
 import type { UserSettingsState } from '$lib/state/userSettings.svelte';
@@ -45,6 +45,26 @@ function makeMessageEvent(
       threadParticipants: [],
       viewerIsFollowingThread: null,
       echoOfEventId: overrides.echoOfEventId ?? null
+    }
+  } as unknown as RoomEventViewFragment;
+}
+
+function makeSystemEvent(
+  typename: 'UserJoinedRoomEvent' | 'UserLeftRoomEvent',
+  overrides: Partial<{
+    id: string;
+    actorId: string;
+    createdAt: string;
+  }> = {}
+): RoomEventViewFragment {
+  return {
+    id: overrides.id ?? 'evt_' + Math.random().toString(36).slice(2),
+    createdAt: overrides.createdAt ?? '2025-04-27T12:00:00Z',
+    actorId: overrides.actorId ?? 'u_user1',
+    actor: { id: overrides.actorId ?? 'u_user1', login: 'tester', avatarUrl: null },
+    event: {
+      __typename: typename,
+      roomId: 'r_test'
     }
   } as unknown as RoomEventViewFragment;
 }
@@ -170,5 +190,143 @@ describe('buildVirtualItems', () => {
     const items = buildVirtualItems(meta(events), 'e2', true);
     const keys = items.map((i) => i.key);
     expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  describe('system event grouping (join/leave)', () => {
+    it('coalesces consecutive joins into a single system-group', () => {
+      const events = [
+        makeSystemEvent('UserJoinedRoomEvent', {
+          id: 'j1',
+          actorId: 'u_a',
+          createdAt: '2025-04-27T12:00:00Z'
+        }),
+        makeSystemEvent('UserJoinedRoomEvent', {
+          id: 'j2',
+          actorId: 'u_b',
+          createdAt: '2025-04-27T12:00:10Z'
+        }),
+        makeSystemEvent('UserJoinedRoomEvent', {
+          id: 'j3',
+          actorId: 'u_c',
+          createdAt: '2025-04-27T12:00:20Z'
+        })
+      ];
+
+      const items = buildVirtualItems(meta(events), null, false);
+      const groups = items.filter((i) => i.type === 'system-group');
+      expect(groups).toHaveLength(1);
+      expect(groups[0]).toMatchObject({ kind: 'join' });
+      expect((groups[0] as Extract<VirtualItem, { type: 'system-group' }>).events).toHaveLength(3);
+      expect(items.find((i) => i.type === 'event')).toBeUndefined();
+    });
+
+    it('splits joins and leaves into separate groups', () => {
+      const events = [
+        makeSystemEvent('UserJoinedRoomEvent', { id: 'j1', actorId: 'u_a' }),
+        makeSystemEvent('UserJoinedRoomEvent', { id: 'j2', actorId: 'u_b' }),
+        makeSystemEvent('UserLeftRoomEvent', { id: 'l1', actorId: 'u_c' }),
+        makeSystemEvent('UserJoinedRoomEvent', { id: 'j3', actorId: 'u_d' }),
+        makeSystemEvent('UserJoinedRoomEvent', { id: 'j4', actorId: 'u_e' })
+      ];
+
+      const items = buildVirtualItems(meta(events), null, false);
+      const groups = items.filter(
+        (i): i is Extract<VirtualItem, { type: 'system-group' }> => i.type === 'system-group'
+      );
+      expect(groups.map((g) => ({ kind: g.kind, count: g.events.length }))).toEqual([
+        { kind: 'join', count: 2 },
+        { kind: 'leave', count: 1 },
+        { kind: 'join', count: 2 }
+      ]);
+    });
+
+    it('breaks the group when interrupted by a normal message', () => {
+      const events = [
+        makeSystemEvent('UserJoinedRoomEvent', { id: 'j1', actorId: 'u_a' }),
+        makeSystemEvent('UserJoinedRoomEvent', { id: 'j2', actorId: 'u_b' }),
+        makeMessageEvent({ id: 'm1', actorId: 'u_a' }),
+        makeSystemEvent('UserJoinedRoomEvent', { id: 'j3', actorId: 'u_c' })
+      ];
+
+      const items = buildVirtualItems(meta(events), null, false);
+      const groups = items.filter(
+        (i): i is Extract<VirtualItem, { type: 'system-group' }> => i.type === 'system-group'
+      );
+      expect(groups).toHaveLength(2);
+      expect(groups[0].events).toHaveLength(2);
+      expect(groups[1].events).toHaveLength(1);
+    });
+
+    it('breaks the group at a day boundary', () => {
+      const events = [
+        makeSystemEvent('UserJoinedRoomEvent', {
+          id: 'j1',
+          actorId: 'u_a',
+          createdAt: '2025-04-26T23:00:00Z'
+        }),
+        makeSystemEvent('UserJoinedRoomEvent', {
+          id: 'j2',
+          actorId: 'u_b',
+          createdAt: '2025-04-27T00:30:00Z'
+        })
+      ];
+
+      const items = buildVirtualItems(meta(events), null, false);
+      const groups = items.filter(
+        (i): i is Extract<VirtualItem, { type: 'system-group' }> => i.type === 'system-group'
+      );
+      expect(groups).toHaveLength(2);
+      // Day separator should appear before each group's leading event
+      expect(items.filter((i) => i.type === 'day-separator')).toHaveLength(2);
+    });
+
+    it('breaks the group at the unread separator', () => {
+      const events = [
+        makeSystemEvent('UserJoinedRoomEvent', { id: 'j1', actorId: 'u_a' }),
+        makeSystemEvent('UserJoinedRoomEvent', { id: 'j2', actorId: 'u_b' }),
+        makeSystemEvent('UserJoinedRoomEvent', { id: 'j3', actorId: 'u_c' })
+      ];
+
+      const items = buildVirtualItems(meta(events), 'j2', false);
+      const groups = items.filter(
+        (i): i is Extract<VirtualItem, { type: 'system-group' }> => i.type === 'system-group'
+      );
+      expect(groups).toHaveLength(2);
+      expect(groups[0].events.map((e) => e.id)).toEqual(['j1']);
+      expect(groups[1].events.map((e) => e.id)).toEqual(['j2', 'j3']);
+
+      // Unread separator should sit between the two groups
+      const idxUnread = items.findIndex((i) => i.type === 'unread-separator');
+      const idxFirstGroup = items.findIndex((i) => i.type === 'system-group');
+      expect(idxUnread).toBeGreaterThan(idxFirstGroup);
+    });
+
+    it('still emits non-grouped system events (archive/unarchive) as plain events', () => {
+      const archive: RoomEventViewFragment = {
+        id: 'a1',
+        createdAt: '2025-04-27T12:00:00Z',
+        actorId: 'u_a',
+        actor: { id: 'u_a', login: 'tester', avatarUrl: null },
+        event: { __typename: 'RoomArchivedEvent', roomId: 'r_test' }
+      } as unknown as RoomEventViewFragment;
+
+      const items = buildVirtualItems(meta([archive]), null, false);
+      expect(items.find((i) => i.type === 'system-group')).toBeUndefined();
+      expect(items.find((i) => i.type === 'event')).toMatchObject({ key: 'a1' });
+    });
+
+    it('uses a stable, unique key for system-groups', () => {
+      const events = [
+        makeSystemEvent('UserJoinedRoomEvent', { id: 'j1' }),
+        makeSystemEvent('UserJoinedRoomEvent', { id: 'j2' }),
+        makeSystemEvent('UserLeftRoomEvent', { id: 'l1' }),
+        makeSystemEvent('UserLeftRoomEvent', { id: 'l2' })
+      ];
+      const items = buildVirtualItems(meta(events), null, false);
+      const keys = items.map((i) => i.key);
+      expect(new Set(keys).size).toBe(keys.length);
+      expect(keys).toContain('system-group-j1');
+      expect(keys).toContain('system-group-l1');
+    });
   });
 });

--- a/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/virtualItems.ts
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/virtualItems.ts
@@ -2,6 +2,8 @@ import type { RoomEventViewFragment } from '$lib/gql/graphql';
 import type { EventWithMeta } from './messageGrouping';
 import { isEventHidden } from './messageGrouping';
 
+export type SystemGroupKind = 'join' | 'leave';
+
 /**
  * A discriminated union representing items in the virtual list.
  * Day separators, unread separators, and the start-of-conversation marker
@@ -12,12 +14,34 @@ export type VirtualItem =
   | { type: 'start-marker'; key: string }
   | { type: 'day-separator'; key: string; label: string }
   | { type: 'unread-separator'; key: string }
-  | { type: 'event'; key: string; event: RoomEventViewFragment; isFirstInGroup: boolean };
+  | { type: 'event'; key: string; event: RoomEventViewFragment; isFirstInGroup: boolean }
+  | {
+      type: 'system-group';
+      key: string;
+      kind: SystemGroupKind;
+      events: RoomEventViewFragment[];
+    };
+
+function getSystemGroupKind(event: RoomEventViewFragment): SystemGroupKind | null {
+  switch (event.event?.__typename) {
+    case 'UserJoinedRoomEvent':
+      return 'join';
+    case 'UserLeftRoomEvent':
+      return 'leave';
+    default:
+      return null;
+  }
+}
 
 /**
  * Transform grouped event metadata into a flat array for the virtualizer.
  * Inserts the start-of-conversation marker, day separators, and the unread
  * separator as their own items.
+ *
+ * Consecutive `UserJoinedRoomEvent` (or consecutive `UserLeftRoomEvent`)
+ * are coalesced into a single `system-group` item. The grouping breaks
+ * on: a different event kind, a day separator (timezone-aware via
+ * `showDaySeparator`), or the unread separator.
  */
 export function buildVirtualItems(
   eventsWithMeta: EventWithMeta[],
@@ -26,6 +50,23 @@ export function buildVirtualItems(
 ): VirtualItem[] {
   const items: VirtualItem[] = [];
 
+  let openGroup: {
+    kind: SystemGroupKind;
+    events: RoomEventViewFragment[];
+    firstId: string;
+  } | null = null;
+
+  const flushGroup = () => {
+    if (!openGroup) return;
+    items.push({
+      type: 'system-group',
+      key: `system-group-${openGroup.firstId}`,
+      kind: openGroup.kind,
+      events: openGroup.events
+    });
+    openGroup = null;
+  };
+
   if (hasReachedStart && eventsWithMeta.length > 0) {
     items.push({ type: 'start-marker', key: 'start-marker' });
   }
@@ -33,9 +74,21 @@ export function buildVirtualItems(
   for (const item of eventsWithMeta) {
     const { event, isFirstInGroup, showDaySeparator, dayLabel } = item;
     const hidden = isEventHidden(event);
+    const systemKind = getSystemGroupKind(event);
 
-    // Don't emit day/unread separators for hidden (deleted) events
-    if (showDaySeparator && !hidden) {
+    const hasDaySeparator = showDaySeparator && !hidden;
+    const hasUnreadSeparator =
+      firstUnreadEventId !== null && event.id === firstUnreadEventId && !hidden;
+
+    // Any separator or a mismatched / non-system event breaks an open group.
+    if (
+      openGroup &&
+      (systemKind !== openGroup.kind || hasDaySeparator || hasUnreadSeparator)
+    ) {
+      flushGroup();
+    }
+
+    if (hasDaySeparator) {
       items.push({
         type: 'day-separator',
         key: `day-${event.id}`,
@@ -43,11 +96,19 @@ export function buildVirtualItems(
       });
     }
 
-    if (firstUnreadEventId !== null && event.id === firstUnreadEventId && !hidden) {
+    if (hasUnreadSeparator) {
       items.push({
         type: 'unread-separator',
         key: 'unread-separator'
       });
+    }
+
+    if (systemKind) {
+      if (!openGroup) {
+        openGroup = { kind: systemKind, events: [], firstId: event.id };
+      }
+      openGroup.events.push(event);
+      continue;
     }
 
     items.push({
@@ -57,6 +118,8 @@ export function buildVirtualItems(
       isFirstInGroup
     });
   }
+
+  flushGroup();
 
   return items;
 }


### PR DESCRIPTION
## Summary
- Coalesces consecutive `UserJoinedRoomEvent` / `UserLeftRoomEvent` rows in the room timeline into a single grouped entry, breaking the run on a different kind, a day boundary (timezone-aware), the unread separator, or any interrupting message.
- New `SystemEventGroup` component renders a stacked avatar set + a comma-joined name list; groups of 5+ collapse the tail to a clickable "N others" toggle that expands inline to the full list.
- Grouping lives in `buildVirtualItems` and is covered by 7 new specs; lint, type-check, and the full 720-test frontend suite are green.

## Test plan
- [x] `mise x -- pnpm test:unit --run` (720 tests)
- [x] `mise x -- pnpm check` (svelte-check, 0 errors)
- [x] `mise x -- pnpm exec eslint` on the touched files
- [ ] Manual smoke: confirm grouped joins/leaves render with avatars + expandable "N others" toggle