### PR TITLE
refactor(graph): drop space-tier leftovers from inspector + server resolvers

### DIFF
--- a/cli/internal/graph/mutation.resolvers.go
+++ b/cli/internal/graph/mutation.resolvers.go
@@ -61,7 +61,6 @@ func (r *mutationResolver) UpdateRoom(ctx context.Context, input model.UpdateRoo
 		desc = *input.Description
 	}
 
-	// Authorization: check CanAdminRoomsManage permission
 	can, err := r.core.CanManageAnyRoom(ctx, user.Id)
 	if err != nil {
 		return nil, err
@@ -198,7 +197,7 @@ func (r *mutationResolver) UpdateRoomLayout(ctx context.Context, input model.Upd
 
 	// Publish live event (best-effort)
 	if pubErr := r.core.PublishRoomLayoutUpdated(ctx, user.Id, kind); pubErr != nil {
-		r.logger.Warn("Failed to publish room layout updated event", "error", pubErr, "space_id", kind)
+		r.logger.Warn("Failed to publish room layout updated event", "error", pubErr, "kind", kind)
 	}
 
 	// For the mutation response, fetch all rooms so the response can resolve section rooms.

--- a/cli/internal/graph/permission_inspector_helpers.go
+++ b/cli/internal/graph/permission_inspector_helpers.go
@@ -14,13 +14,11 @@ import (
 )
 
 // authorizePermissionExplanation enforces admin-only access for the
-// inspector. Instance scope requires instance admin; space and room scopes
-// require role.manage in spaceID or instance admin. There is no
-// self-inspection path — the inspector is an admin tool.
+// inspector. Instance scope requires instance admin; room scope requires
+// role.manage or instance admin. There is no self-inspection path — the
+// inspector is an admin tool.
 //
-// At space scope, the target user must be a member of spaceID — querying
-// arbitrary instance users would let a space admin probe membership status
-// of users outside their space. At room scope, roomID must belong to spaceID.
+// At room scope, roomID must exist in the corresponding CONFIG bucket.
 func (r *Resolver) authorizePermissionExplanation(ctx context.Context, viewerID, targetID string, kind core.RoomKind, roomID string) error {
 	if kind == "" {
 		return r.requireInstanceAdminOrErr(ctx, viewerID)
@@ -34,18 +32,14 @@ func (r *Resolver) authorizePermissionExplanation(ctx context.Context, viewerID,
 			return core.ErrPermissionDenied
 		}
 	}
-	if err := r.requireRoomBelongsToSpace(ctx, kind, roomID); err != nil {
-		return err
-	}
-	return r.requireSpaceMembership(ctx, targetID, kind)
+	return r.requireRoomExists(ctx, kind, roomID)
 }
 
-// requireRoomBelongsToSpace returns nil if roomID is empty or if the room
-// exists in spaceID's CONFIG bucket. Otherwise returns ErrPermissionDenied.
-// We map the "room not found" error to a permission error rather than a
-// 404-shaped error to avoid letting callers probe for room existence in
-// spaces they shouldn't be querying.
-func (r *Resolver) requireRoomBelongsToSpace(ctx context.Context, kind core.RoomKind, roomID string) error {
+// requireRoomExists returns nil if roomID is empty or if the room exists in
+// the kind's CONFIG bucket. Otherwise returns ErrPermissionDenied — we map
+// "room not found" to a permission error rather than a 404 to avoid letting
+// callers probe for room existence.
+func (r *Resolver) requireRoomExists(ctx context.Context, kind core.RoomKind, roomID string) error {
 	if roomID == "" {
 		return nil
 	}
@@ -53,15 +47,6 @@ func (r *Resolver) requireRoomBelongsToSpace(ctx context.Context, kind core.Room
 	if err != nil || room == nil {
 		return core.ErrPermissionDenied
 	}
-	return nil
-}
-
-// requireSpaceMembership returns nil if userID is a member of spaceID. The
-// inspector exposes "what role-derived permissions does this user have in
-// this space" — that's only meaningful for members, and accepting arbitrary
-// userIDs here would let a space admin enumerate non-membership across the
-// instance via empty traces.
-func (r *Resolver) requireSpaceMembership(ctx context.Context, userID string, kind core.RoomKind) error {
 	return nil
 }
 

--- a/cli/internal/graph/role_permissions_helpers.go
+++ b/cli/internal/graph/role_permissions_helpers.go
@@ -29,7 +29,7 @@ func (r *Resolver) authorizeRolePermissions(ctx context.Context, viewerID, space
 			return core.ErrPermissionDenied
 		}
 	}
-	return r.requireRoomBelongsToSpace(ctx, core.KindForSpace(spaceID), roomID)
+	return r.requireRoomExists(ctx, core.KindForSpace(spaceID), roomID)
 }
 
 // buildRoleAcrossTiers gathers metadata + per-tier grants/denials for the role.

--- a/cli/internal/graph/server.resolvers.go
+++ b/cli/internal/graph/server.resolvers.go
@@ -81,18 +81,17 @@ func (r *serverResolver) Rooms(ctx context.Context, obj *model.Server, typeArg *
 	if err != nil {
 		return nil, err
 	}
-	kind := core.KindChannel
 	var rooms []*corev1.Room
-	if kind != "" && roomTypeIs(typeArg, model.RoomTypeChannel) {
+	if roomTypeIs(typeArg, model.RoomTypeChannel) {
 		// Authorization: check rooms.browse permission.
-		can, err := r.core.CanBrowseRooms(ctx, user.Id, kind)
+		can, err := r.core.CanBrowseRooms(ctx, user.Id, core.KindChannel)
 		if err != nil {
 			return nil, err
 		}
 		if !can {
 			return nil, core.ErrPermissionDenied
 		}
-		rooms, err = r.core.ListRooms(ctx, kind)
+		rooms, err = r.core.ListRooms(ctx, core.KindChannel)
 		if err != nil {
 			return nil, err
 		}
@@ -106,12 +105,7 @@ func (r *serverResolver) RoomLayout(ctx context.Context, obj *model.Server) (*mo
 	if err != nil {
 		return nil, err
 	}
-	kind := core.KindChannel
-	if kind == "" {
-		return nil, nil
-	}
-
-	can, err := r.core.CanBrowseRooms(ctx, user.Id, kind)
+	can, err := r.core.CanBrowseRooms(ctx, user.Id, core.KindChannel)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +113,7 @@ func (r *serverResolver) RoomLayout(ctx context.Context, obj *model.Server) (*mo
 		return nil, core.ErrPermissionDenied
 	}
 
-	layout, err := r.core.GetRoomLayout(ctx, kind)
+	layout, err := r.core.GetRoomLayout(ctx, core.KindChannel)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +121,7 @@ func (r *serverResolver) RoomLayout(ctx context.Context, obj *model.Server) (*mo
 		return nil, nil
 	}
 
-	allRooms, err := r.core.ListRooms(ctx, kind)
+	allRooms, err := r.core.ListRooms(ctx, core.KindChannel)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Remove the no-op `requireSpaceMembership` and its misleading comment in `permission_inspector_helpers.go`, and rename `requireRoomBelongsToSpace` → `requireRoomExists` to match the post-ADR-030 reality.
- Drop dead `kind != ""` / `kind == ""` branches in `server.Rooms` / `server.RoomLayout` left over from the `requireServerSpaceID` removal.
- Fix a `space_id` log key in `UpdateRoomLayout` that was logging a `RoomKind` value, and remove a stale `CanAdminRoomsManage` comment in `UpdateRoom`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/graph/...`