### PR TITLE
fix(rooms): key system-groups by newest event to stabilize scroll-up

### DIFF
--- a/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/virtualItems.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/virtualItems.spec.ts
@@ -325,8 +325,10 @@ describe('buildVirtualItems', () => {
       const items = buildVirtualItems(meta(events), null, false);
       const keys = items.map((i) => i.key);
       expect(new Set(keys).size).toBe(keys.length);
-      expect(keys).toContain('system-group-j1');
-      expect(keys).toContain('system-group-l1');
+      // Keyed by the newest event in the group so the key stays stable when
+      // pagination prepends older events that merge into the group.
+      expect(keys).toContain('system-group-j2');
+      expect(keys).toContain('system-group-l2');
     });
   });
 });

--- a/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/virtualItems.ts
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/virtualItems.ts
@@ -53,14 +53,18 @@ export function buildVirtualItems(
   let openGroup: {
     kind: SystemGroupKind;
     events: RoomEventViewFragment[];
-    firstId: string;
   } | null = null;
 
   const flushGroup = () => {
     if (!openGroup) return;
+    // Key by the newest event in the group. When pagination prepends older
+    // events that merge into this group, the newest event stays the same —
+    // virtua keeps the cached height measurement and uses its scroll-shift
+    // mechanism instead of treating the merged group as a brand new item.
+    const lastId = openGroup.events[openGroup.events.length - 1].id;
     items.push({
       type: 'system-group',
-      key: `system-group-${openGroup.firstId}`,
+      key: `system-group-${lastId}`,
       kind: openGroup.kind,
       events: openGroup.events
     });
@@ -105,7 +109,7 @@ export function buildVirtualItems(
 
     if (systemKind) {
       if (!openGroup) {
-        openGroup = { kind: systemKind, events: [], firstId: event.id };
+        openGroup = { kind: systemKind, events: [] };
       }
       openGroup.events.push(event);
       continue;


### PR DESCRIPTION
## Summary
Consecutive join/leave events are coalesced into a `system-group` virtual item. Previously the item's key was derived from the **oldest** event in the group. When pagination prepended older join/leave events that merged into an existing group, the merged group's `firstId` changed — virtua saw a brand-new item, fell back to the `itemSize={60}` estimate, then remeasured to the real (larger) height, producing the occasional scroll-up jumps.

This PR keys the group by the **newest** event instead. The newest ID is stable across merges from prepended older events, so virtua keeps the cached height measurement and lets its `shift={isLoadingMore}` scroll-restoration do its job.

## Test plan
- [x] `pnpm test:unit --run` (updated `virtualItems.spec.ts`, all tests green)
- [ ] Manual smoke: scroll up through a room with lots of join/leave traffic and confirm the jumps are gone