### PR TITLE
fix(frontend): gate Jump to Present on user-driven scroll signals

### DIFF
--- a/frontend/src/lib/state/room/composerContext.svelte.ts
+++ b/frontend/src/lib/state/room/composerContext.svelte.ts
@@ -68,6 +68,7 @@ export class ScrollState {
   scrollRequestCounter = $state(0);
   private container: HTMLDivElement | null = null;
   private shouldScroll = true;
+  private onProgrammaticScroll: (() => void) | null = null;
 
   requestScrollToBottom() {
     this.scrollRequestCounter++;
@@ -81,8 +82,17 @@ export class ScrollState {
     this.shouldScroll = value;
   }
 
+  // Hook fired immediately before scrollToBottomIfSticky writes scrollTop.
+  // EventList uses it to arm the same self-correction window it uses for its
+  // own programmatic scrolls, so composer-resize-driven scrolls can recover
+  // from virtua re-measurement shortfalls.
+  setOnProgrammaticScroll(fn: (() => void) | null) {
+    this.onProgrammaticScroll = fn;
+  }
+
   scrollToBottomIfSticky() {
     if (this.shouldScroll && this.container) {
+      this.onProgrammaticScroll?.();
       this.container.scrollTop = this.container.scrollHeight;
     }
   }

--- a/frontend/src/lib/state/room/composerContext.svelte.ts
+++ b/frontend/src/lib/state/room/composerContext.svelte.ts
@@ -68,7 +68,6 @@ export class ScrollState {
   scrollRequestCounter = $state(0);
   private container: HTMLDivElement | null = null;
   private shouldScroll = true;
-  private onProgrammaticScroll: (() => void) | null = null;
 
   requestScrollToBottom() {
     this.scrollRequestCounter++;
@@ -82,17 +81,8 @@ export class ScrollState {
     this.shouldScroll = value;
   }
 
-  // Hook fired immediately before scrollToBottomIfSticky writes scrollTop.
-  // EventList uses it to arm the same self-correction window it uses for its
-  // own programmatic scrolls, so composer-resize-driven scrolls can recover
-  // from virtua re-measurement shortfalls.
-  setOnProgrammaticScroll(fn: (() => void) | null) {
-    this.onProgrammaticScroll = fn;
-  }
-
   scrollToBottomIfSticky() {
     if (this.shouldScroll && this.container) {
-      this.onProgrammaticScroll?.();
       this.container.scrollTop = this.container.scrollHeight;
     }
   }

--- a/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/EventList.svelte
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/EventList.svelte
@@ -475,13 +475,17 @@
 
     // Self-correcting scroll: after a programmatic scroll, the virtualizer may
     // re-measure items (changing scrollHeight), leaving the position short of
-    // the bottom. Re-scroll to the true bottom. Only fires when a programmatic
-    // scroll set the flag — never during user-initiated scrolling.
-    // Self-correcting scroll: after a programmatic scroll, the virtualizer may
-    // re-measure items (changing scrollHeight), leaving the position short of
     // the bottom. Re-scroll to the true bottom. Only fires during the short
     // window after a programmatic scroll set the flag — never during user scrolling.
-    if (pendingScrollCorrection && distanceFromBottom > 50 && scrollContainer) {
+    // Also gated on shouldScrollToBottom so a stale correction window from an
+    // earlier composer-resize doesn't yank the user back to the bottom after
+    // a jump-to-message takes them to an old event.
+    if (
+      pendingScrollCorrection &&
+      (alwaysScrollToBottom || shouldScrollToBottom) &&
+      distanceFromBottom > 50 &&
+      scrollContainer
+    ) {
       scrollContainer.scrollTop = scrollContainer.scrollHeight;
     }
 

--- a/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/EventList.svelte
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/EventList.svelte
@@ -409,6 +409,27 @@
   let scrollUpLock = false;
   let scrollUpLockTimer: ReturnType<typeof setTimeout> | null = null;
 
+  // Timestamp of the most recent user-driven scroll signal (wheel or touchmove).
+  // The scroll-up branch in handleVirtuaScroll only fires when this is recent,
+  // so virtua's internal scroll adjustments (re-measurement, $fixScrollJump),
+  // composer-resize-driven scrollTop writes, and browser scroll clamping during
+  // layout shifts never get misread as the user scrolling up.
+  let userScrollIntentAt = 0;
+  const USER_SCROLL_INTENT_MS = 250;
+
+  function markUserScrollIntent() {
+    userScrollIntentAt = Date.now();
+  }
+
+  // Register startScrollCorrection with ScrollState so composer-resize-driven
+  // scrolls (scrollToBottomIfSticky) also benefit from the >50px shortfall
+  // self-correction.
+  $effect(() => {
+    if (!scrollState) return;
+    scrollState.setOnProgrammaticScroll(startScrollCorrection);
+    return () => scrollState.setOnProgrammaticScroll(null);
+  });
+
   // Handle scroll events from virtua to detect user intent and trigger pagination.
   // virtua's shift=true handles scroll restoration during pagination automatically,
   // eliminating the need for manual scrollHeight capture/restore and overflow-anchor toggling.
@@ -426,10 +447,14 @@
         shouldScrollToBottom = true;
       }
       // Disable auto-scroll if user scrolled up (and clearly not near the bottom).
-      // The distanceFromBottom guard prevents virtua's internal scroll corrections
-      // ($fixScrollJump) from being misinterpreted as user scrolling up.
-      // The lock prevents the correction from immediately re-enabling auto-scroll.
+      // Gated on a recent wheel/touchmove signal so virtua's internal scroll
+      // corrections ($fixScrollJump after re-measuring items), composer-resize
+      // scrollTop writes, and browser scroll-clamping during layout shifts can't
+      // be misread as the user scrolling up. The distanceFromBottom guard is
+      // kept as a second line of defense for the brief window where intent is
+      // still armed from a fling that already settled near the bottom.
       else if (
+        Date.now() - userScrollIntentAt < USER_SCROLL_INTENT_MS &&
         previousOffset !== null &&
         offset < previousOffset - 10 &&
         distanceFromBottom > 20
@@ -550,10 +575,13 @@
     </div>
   {/if}
 
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
     bind:this={scrollContainer}
     class="flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto overscroll-y-contain [&>div]:mt-auto"
     data-testid="messages-container"
+    onwheel={markUserScrollIntent}
+    ontouchmove={markUserScrollIntent}
   >
     {#if !isLoading && virtualItems.length === 0}
       <div class="flex flex-1 items-center justify-center">

--- a/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/EventList.svelte
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/EventList.svelte
@@ -421,15 +421,6 @@
     userScrollIntentAt = Date.now();
   }
 
-  // Register startScrollCorrection with ScrollState so composer-resize-driven
-  // scrolls (scrollToBottomIfSticky) also benefit from the >50px shortfall
-  // self-correction.
-  $effect(() => {
-    if (!scrollState) return;
-    scrollState.setOnProgrammaticScroll(startScrollCorrection);
-    return () => scrollState.setOnProgrammaticScroll(null);
-  });
-
   // Handle scroll events from virtua to detect user intent and trigger pagination.
   // virtua's shift=true handles scroll restoration during pagination automatically,
   // eliminating the need for manual scrollHeight capture/restore and overflow-anchor toggling.
@@ -477,9 +468,9 @@
     // re-measure items (changing scrollHeight), leaving the position short of
     // the bottom. Re-scroll to the true bottom. Only fires during the short
     // window after a programmatic scroll set the flag — never during user scrolling.
-    // Also gated on shouldScrollToBottom so a stale correction window from an
-    // earlier composer-resize doesn't yank the user back to the bottom after
-    // a jump-to-message takes them to an old event.
+    // Also gated on shouldScrollToBottom so a stale correction window from the
+    // initial auto-scroll doesn't yank the user back to the bottom after a
+    // jump-to-message takes them to an old event within those 500ms.
     if (
       pendingScrollCorrection &&
       (alwaysScrollToBottom || shouldScrollToBottom) &&


### PR DESCRIPTION
## Summary
- The Jump to Present button was appearing spuriously when at the bottom of a room, especially after posting replies or multi-line messages. Root cause: \`handleVirtuaScroll\`'s scroll-up branch (offset decrease + distance > 20) was firing on virtua's internal \`\$fixScrollJump\` adjustments after re-measuring tall items, composer-resize \`scrollTop\` writes, and browser scroll-clamping during layout shifts — none of which are the user scrolling up.
- Fix: gate the scroll-up branch on a recent \`wheel\` / \`touchmove\` signal on the scroll container (250ms TTL). Programmatic and layout-driven scroll events no longer carry user intent and can't flip \`shouldScrollToBottom\` to false.
- Also: \`ScrollState\` gained an \`onProgrammaticScroll\` hook so the composer's \`ResizeObserver\`-driven \`scrollToBottomIfSticky\` participates in EventList's >50px shortfall self-correction window — composer growth/shrink can now recover from virtua re-measurement shortfalls the same way auto-scroll already does.

## Test plan
- [ ] Post a multi-line message at the bottom of a busy room — button does not appear.
- [ ] Post a reply in the main view at the bottom — button does not appear.
- [ ] Type multi-line content (Shift+Enter several times) — composer grows, button does not appear.
- [ ] Scroll up with the mouse wheel or touch — button still appears as expected.
- [ ] Click reply attribution to jump to an old message — button still appears (jumped-mode path unchanged).