### PR TITLE
fix(rooms): drive read-marker off user presence (focus + visibility)

### DIFF
--- a/cli/internal/core/rooms.go
+++ b/cli/internal/core/rooms.go
@@ -3212,14 +3212,13 @@ func (c *ChattoCore) GetThreadLastOpened(ctx context.Context, kind RoomKind, use
 	return time.Unix(0, nanos), nil
 }
 
-// SetThreadLastOpened stores the current timestamp as when the user last opened a thread.
+// SetThreadLastOpenedAt stores ts as the user's last-opened time for a
+// thread, but only if ts is newer than the existing marker (advance-only).
 // Returns the previous last-opened time (zero if never opened before).
-func (c *ChattoCore) SetThreadLastOpened(ctx context.Context, kind RoomKind, userID, roomID, threadRootEventID string) (time.Time, error) {
+func (c *ChattoCore) SetThreadLastOpenedAt(ctx context.Context, kind RoomKind, userID, roomID, threadRootEventID string, ts time.Time) (time.Time, error) {
 	bucket := c.storage.serverRuntimeKV
-
 	key := threadLastOpenedKey(userID, roomID, threadRootEventID)
 
-	// Get previous value first
 	var previousTime time.Time
 	entry, err := bucket.Get(ctx, key)
 	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
@@ -3230,18 +3229,26 @@ func (c *ChattoCore) SetThreadLastOpened(ctx context.Context, kind RoomKind, use
 		previousTime = time.Unix(0, nanos)
 	}
 
-	// Store current time
-	now := time.Now()
-	buf := make([]byte, 8)
-	binary.BigEndian.PutUint64(buf, uint64(now.UnixNano()))
+	if !ts.After(previousTime) {
+		return previousTime, nil
+	}
 
-	_, err = bucket.Put(ctx, key, buf)
-	if err != nil {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, uint64(ts.UnixNano()))
+
+	if _, err = bucket.Put(ctx, key, buf); err != nil {
 		return time.Time{}, fmt.Errorf("failed to set thread last opened: %w", err)
 	}
 
-	c.logger.Debug("Set thread last opened", "user_id", userID, "room_id", roomID, "thread_root_event_id", threadRootEventID, "previous", previousTime, "now", now)
+	c.logger.Debug("Set thread last opened", "user_id", userID, "room_id", roomID, "thread_root_event_id", threadRootEventID, "previous", previousTime, "at", ts)
 	return previousTime, nil
+}
+
+// SetThreadLastOpened records the current wall-clock time as the user's
+// last-opened time for a thread. Returns the previous last-opened time
+// (zero if never opened before).
+func (c *ChattoCore) SetThreadLastOpened(ctx context.Context, kind RoomKind, userID, roomID, threadRootEventID string) (time.Time, error) {
+	return c.SetThreadLastOpenedAt(ctx, kind, userID, roomID, threadRootEventID, time.Now())
 }
 
 // threadFollowKey returns the KV key for tracking whether a user is following a thread.

--- a/cli/internal/graph/generated.go
+++ b/cli/internal/graph/generated.go
@@ -24552,7 +24552,7 @@ func (ec *executionContext) unmarshalInputMarkRoomAsReadInput(ctx context.Contex
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"roomId"}
+	fieldsInOrder := [...]string{"roomId", "upToEventId"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -24566,6 +24566,13 @@ func (ec *executionContext) unmarshalInputMarkRoomAsReadInput(ctx context.Contex
 				return it, err
 			}
 			it.RoomID = data
+		case "upToEventId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("upToEventId"))
+			data, err := ec.unmarshalOID2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.UpToEventID = data
 		}
 	}
 
@@ -24579,7 +24586,7 @@ func (ec *executionContext) unmarshalInputMarkThreadAsReadInput(ctx context.Cont
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"roomId", "threadRootEventId"}
+	fieldsInOrder := [...]string{"roomId", "threadRootEventId", "upToEventId"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -24600,6 +24607,13 @@ func (ec *executionContext) unmarshalInputMarkThreadAsReadInput(ctx context.Cont
 				return it, err
 			}
 			it.ThreadRootEventID = data
+		case "upToEventId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("upToEventId"))
+			data, err := ec.unmarshalOID2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.UpToEventID = data
 		}
 	}
 

--- a/cli/internal/graph/model/models_gen.go
+++ b/cli/internal/graph/model/models_gen.go
@@ -338,6 +338,10 @@ type LinkPreviewInput struct {
 type MarkRoomAsReadInput struct {
 	// The ID of the room to mark as read.
 	RoomID string `json:"roomId"`
+	// Optional event ID to mark as the read cursor. If provided, the marker is
+	// set to this event (advance-only — never regresses past a more recent
+	// marker). If omitted, the server uses the room's current latest event.
+	UpToEventID *string `json:"upToEventId,omitempty"`
 }
 
 // Result of marking a room as read.
@@ -354,6 +358,10 @@ type MarkThreadAsReadInput struct {
 	RoomID string `json:"roomId"`
 	// The event ID of the thread root message.
 	ThreadRootEventID string `json:"threadRootEventId"`
+	// Optional event ID (root or reply) to anchor the read cursor at. If
+	// provided, the server records that event's timestamp (advance-only). If
+	// omitted, the server records the current wall-clock time.
+	UpToEventID *string `json:"upToEventId,omitempty"`
 }
 
 // Result of marking a thread as read.

--- a/cli/internal/graph/mutation.graphqls
+++ b/cli/internal/graph/mutation.graphqls
@@ -398,6 +398,12 @@ Input for marking a room as read.
 input MarkRoomAsReadInput {
   "The ID of the room to mark as read."
   roomId: ID!
+  """
+  Optional event ID to mark as the read cursor. If provided, the marker is
+  set to this event (advance-only — never regresses past a more recent
+  marker). If omitted, the server uses the room's current latest event.
+  """
+  upToEventId: ID
 }
 
 """
@@ -408,6 +414,12 @@ input MarkThreadAsReadInput {
   roomId: ID!
   "The event ID of the thread root message."
   threadRootEventId: ID!
+  """
+  Optional event ID (root or reply) to anchor the read cursor at. If
+  provided, the server records that event's timestamp (advance-only). If
+  omitted, the server records the current wall-clock time.
+  """
+  upToEventId: ID
 }
 
 """

--- a/cli/internal/graph/mutation.resolvers.go
+++ b/cli/internal/graph/mutation.resolvers.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"hmans.de/chatto/internal/assets"
@@ -644,15 +645,50 @@ func (r *mutationResolver) MarkRoomAsRead(ctx context.Context, input model.MarkR
 		return nil, err
 	}
 
-	// Get the room's current last root event to mark as read
-	lastEventID, lastTime, hasLast, err := r.core.GetRoomLastEvent(ctx, kind, input.RoomID)
-	if err != nil {
-		return nil, err
+	// Resolve the target event ID for the new marker. If the client passed
+	// an explicit upToEventId (i.e. "I've read up to this event"), prefer
+	// that — it avoids the race where messages land between subscription
+	// delivery and mutation processing on the server. Otherwise fall back
+	// to whatever the room's current latest root event is.
+	var (
+		lastEventID string
+		lastTime    time.Time
+		hasLast     bool
+	)
+	if input.UpToEventID != nil && *input.UpToEventID != "" {
+		targetTime, terr := r.core.GetEventTimestamp(ctx, kind, input.RoomID, *input.UpToEventID)
+		if terr != nil {
+			return nil, terr
+		}
+		if !targetTime.IsZero() {
+			lastEventID = *input.UpToEventID
+			lastTime = targetTime
+			hasLast = true
+		}
+	}
+	if !hasLast {
+		lastEventID, lastTime, hasLast, err = r.core.GetRoomLastEvent(ctx, kind, input.RoomID)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if hasLast {
-		if err := r.core.SetLastReadEventID(ctx, kind, user.Id, input.RoomID, lastEventID); err != nil {
-			return nil, err
+		// Advance-only: don't regress the marker if the client passed a
+		// stale upToEventId (e.g. another tab/device is further ahead).
+		shouldWrite := true
+		if previousEventID != "" && previousEventID != lastEventID {
+			prevTime, perr := r.core.GetEventTimestamp(ctx, kind, input.RoomID, previousEventID)
+			if perr == nil && !prevTime.IsZero() && !lastTime.After(prevTime) {
+				shouldWrite = false
+				lastEventID = previousEventID
+				lastTime = prevTime
+			}
+		}
+		if shouldWrite {
+			if err := r.core.SetLastReadEventID(ctx, kind, user.Id, input.RoomID, lastEventID); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -699,7 +735,22 @@ func (r *mutationResolver) MarkThreadAsRead(ctx context.Context, input model.Mar
 		return nil, core.ErrNotRoomMember
 	}
 
-	previousReadAt, err := r.core.SetThreadLastOpened(ctx, kind, user.Id, input.RoomID, input.ThreadRootEventID)
+	// Anchor the read cursor at a specific event's timestamp if the client
+	// provided one. This avoids the race where new replies arrive between
+	// the subscription delivery and the mutation hitting the server. Falls
+	// back to wall-clock "now" when no explicit anchor is supplied.
+	markerTime := time.Now()
+	if input.UpToEventID != nil && *input.UpToEventID != "" {
+		event, eerr := r.core.GetRoomEventByEventID(ctx, kind, input.RoomID, *input.UpToEventID)
+		if eerr != nil {
+			return nil, eerr
+		}
+		if event != nil && event.CreatedAt != nil {
+			markerTime = event.CreatedAt.AsTime()
+		}
+	}
+
+	previousReadAt, err := r.core.SetThreadLastOpenedAt(ctx, kind, user.Id, input.RoomID, input.ThreadRootEventID, markerTime)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/graph/mutation_test.go
+++ b/cli/internal/graph/mutation_test.go
@@ -700,6 +700,127 @@ func TestMarkRoomAsRead_Authorization(t *testing.T) {
 }
 
 // ============================================================================
+// MarkRoomAsRead UpToEventId Tests
+// ============================================================================
+
+func TestMarkRoomAsRead_UpToEventId(t *testing.T) {
+	env := setupTestResolver(t)
+	mutation := env.resolver.Mutation()
+
+	// Create a second user (the "reader") who joins the room as a member
+	// but never posts — that way PostMessage's auto-advance of the poster's
+	// read marker doesn't interfere with what this test wants to observe.
+	reader, err := env.core.CreateUser(env.ctx, "system", "reader-uptoevent", "Reader", "password123")
+	if err != nil {
+		t.Fatalf("create reader: %v", err)
+	}
+	if _, err := env.core.JoinRoom(env.ctx, reader.Id, core.KindChannel, reader.Id, env.testRoom.Id); err != nil {
+		t.Fatalf("add reader to room: %v", err)
+	}
+
+	// testUser posts three messages so we have explicit event IDs to anchor
+	// against. The reader stays at the empty/initial marker.
+	e1, err := env.core.PostMessage(env.ctx, core.KindChannel, env.testRoom.Id, env.testUser.Id, "first", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("post e1: %v", err)
+	}
+	// Seed the reader's marker at e1 so the test starts from a known baseline.
+	if err := env.core.SetLastReadEventID(env.ctx, core.KindChannel, reader.Id, env.testRoom.Id, e1.Id); err != nil {
+		t.Fatalf("seed marker at e1: %v", err)
+	}
+	e2, err := env.core.PostMessage(env.ctx, core.KindChannel, env.testRoom.Id, env.testUser.Id, "second", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("post e2: %v", err)
+	}
+	e3, err := env.core.PostMessage(env.ctx, core.KindChannel, env.testRoom.Id, env.testUser.Id, "third", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("post e3: %v", err)
+	}
+
+	readerCtx := env.authContextForUser(reader)
+
+	t.Run("explicit upToEventId anchors marker at that event (not latest)", func(t *testing.T) {
+		// Reader's marker is at e1 (seeded above). Advance to e2 — even
+		// though e3 also exists. The marker should land on e2.
+		result, err := mutation.MarkRoomAsRead(readerCtx, model.MarkRoomAsReadInput{
+			RoomID:      env.testRoom.Id,
+			UpToEventID: &e2.Id,
+		})
+		if err != nil {
+			t.Fatalf("mark with upToEventId: %v", err)
+		}
+		if result.LastReadAt == nil {
+			t.Fatal("expected LastReadAt to be set")
+		}
+
+		got, err := env.core.GetLastReadEventID(env.ctx, core.KindChannel, reader.Id, env.testRoom.Id)
+		if err != nil {
+			t.Fatalf("get marker: %v", err)
+		}
+		if got != e2.Id {
+			t.Errorf("expected marker = %s (e2), got %s", e2.Id, got)
+		}
+	})
+
+	t.Run("advance-only: stale upToEventId does not regress marker", func(t *testing.T) {
+		// Currently at e2. Try to regress to e1 — should be ignored.
+		_, err := mutation.MarkRoomAsRead(readerCtx, model.MarkRoomAsReadInput{
+			RoomID:      env.testRoom.Id,
+			UpToEventID: &e1.Id,
+		})
+		if err != nil {
+			t.Fatalf("mark with stale upToEventId: %v", err)
+		}
+
+		got, err := env.core.GetLastReadEventID(env.ctx, core.KindChannel, reader.Id, env.testRoom.Id)
+		if err != nil {
+			t.Fatalf("get marker: %v", err)
+		}
+		if got != e2.Id {
+			t.Errorf("expected marker to stay at e2 (%s), got %s", e2.Id, got)
+		}
+	})
+
+	t.Run("advance with a newer upToEventId moves the marker forward", func(t *testing.T) {
+		_, err := mutation.MarkRoomAsRead(readerCtx, model.MarkRoomAsReadInput{
+			RoomID:      env.testRoom.Id,
+			UpToEventID: &e3.Id,
+		})
+		if err != nil {
+			t.Fatalf("mark advance to e3: %v", err)
+		}
+
+		got, err := env.core.GetLastReadEventID(env.ctx, core.KindChannel, reader.Id, env.testRoom.Id)
+		if err != nil {
+			t.Fatalf("get marker: %v", err)
+		}
+		if got != e3.Id {
+			t.Errorf("expected marker = e3 (%s), got %s", e3.Id, got)
+		}
+	})
+
+	t.Run("unknown upToEventId falls back to room's latest event", func(t *testing.T) {
+		bogus := "EDoesNotExist00"
+		_, err := mutation.MarkRoomAsRead(readerCtx, model.MarkRoomAsReadInput{
+			RoomID:      env.testRoom.Id,
+			UpToEventID: &bogus,
+		})
+		if err != nil {
+			t.Fatalf("mark with bogus id: %v", err)
+		}
+		// Marker should remain at e3 (it's the latest event; the bogus
+		// upToEventId can't anchor anything newer).
+		got, err := env.core.GetLastReadEventID(env.ctx, core.KindChannel, reader.Id, env.testRoom.Id)
+		if err != nil {
+			t.Fatalf("get marker: %v", err)
+		}
+		if got != e3.Id {
+			t.Errorf("expected marker = e3 (%s) after bogus upToEventId, got %s", e3.Id, got)
+		}
+	})
+}
+
+// ============================================================================
 // MarkThreadAsRead Authorization Tests
 // ============================================================================
 
@@ -793,6 +914,95 @@ func TestMarkThreadAsRead_Authorization(t *testing.T) {
 		}
 		if result.PreviousReadAt == nil {
 			t.Error("expected non-nil previous time on second open")
+		}
+	})
+
+	// A separate "reader" user who joins the room but never posts. This
+	// avoids PostMessage's side-effect of auto-advancing the poster's thread
+	// marker to time.Now(), which would otherwise mask the upToEventId
+	// timestamp the test is trying to observe.
+	threadReader, err := env.core.CreateUser(env.ctx, "system", "reader-thread-upto", "Thread Reader", "password123")
+	if err != nil {
+		t.Fatalf("create thread reader: %v", err)
+	}
+	if _, err := env.core.JoinRoom(env.ctx, threadReader.Id, core.KindChannel, threadReader.Id, env.testRoom.Id); err != nil {
+		t.Fatalf("add reader to room: %v", err)
+	}
+	readerCtx := env.authContextForUser(threadReader)
+
+	t.Run("upToEventId anchors thread marker at that event's timestamp", func(t *testing.T) {
+		root, err := env.core.PostMessage(env.ctx, core.KindChannel, env.testRoom.Id, env.testUser.Id, "thread-root", nil, "", "", nil, false)
+		if err != nil {
+			t.Fatalf("post thread root: %v", err)
+		}
+		reply1, err := env.core.PostMessage(env.ctx, core.KindChannel, env.testRoom.Id, env.testUser.Id, "reply-1", nil, root.Id, "", nil, false)
+		if err != nil {
+			t.Fatalf("post reply1: %v", err)
+		}
+		reply2, err := env.core.PostMessage(env.ctx, core.KindChannel, env.testRoom.Id, env.testUser.Id, "reply-2", nil, root.Id, "", nil, false)
+		if err != nil {
+			t.Fatalf("post reply2: %v", err)
+		}
+
+		// Anchor reader's marker at reply1 even though reply2 also exists.
+		// Marker should land at reply1's CreatedAt, not "now".
+		_, err = mutation.MarkThreadAsRead(readerCtx, model.MarkThreadAsReadInput{
+			RoomID:            env.testRoom.Id,
+			ThreadRootEventID: root.Id,
+			UpToEventID:       &reply1.Id,
+		})
+		if err != nil {
+			t.Fatalf("mark with upToEventId: %v", err)
+		}
+
+		marker, err := env.core.GetThreadLastOpened(env.ctx, core.KindChannel, threadReader.Id, env.testRoom.Id, root.Id)
+		if err != nil {
+			t.Fatalf("GetThreadLastOpened: %v", err)
+		}
+		reply2Event, err := env.core.GetRoomEventByEventID(env.ctx, core.KindChannel, env.testRoom.Id, reply2.Id)
+		if err != nil || reply2Event == nil {
+			t.Fatalf("lookup reply2: %v", err)
+		}
+		if !marker.Before(reply2Event.CreatedAt.AsTime()) {
+			t.Errorf("expected marker (%v) to be before reply2's CreatedAt (%v)", marker, reply2Event.CreatedAt.AsTime())
+		}
+	})
+
+	t.Run("thread upToEventId is advance-only", func(t *testing.T) {
+		root, err := env.core.PostMessage(env.ctx, core.KindChannel, env.testRoom.Id, env.testUser.Id, "advance-root", nil, "", "", nil, false)
+		if err != nil {
+			t.Fatalf("post thread root: %v", err)
+		}
+		reply1, err := env.core.PostMessage(env.ctx, core.KindChannel, env.testRoom.Id, env.testUser.Id, "reply-a", nil, root.Id, "", nil, false)
+		if err != nil {
+			t.Fatalf("post reply1: %v", err)
+		}
+		reply2, err := env.core.PostMessage(env.ctx, core.KindChannel, env.testRoom.Id, env.testUser.Id, "reply-b", nil, root.Id, "", nil, false)
+		if err != nil {
+			t.Fatalf("post reply2: %v", err)
+		}
+
+		// Set reader's marker to reply2's time.
+		if _, err := mutation.MarkThreadAsRead(readerCtx, model.MarkThreadAsReadInput{
+			RoomID:            env.testRoom.Id,
+			ThreadRootEventID: root.Id,
+			UpToEventID:       &reply2.Id,
+		}); err != nil {
+			t.Fatalf("mark up to reply2: %v", err)
+		}
+		marker2, _ := env.core.GetThreadLastOpened(env.ctx, core.KindChannel, threadReader.Id, env.testRoom.Id, root.Id)
+
+		// Try to regress to reply1 — should be ignored.
+		if _, err := mutation.MarkThreadAsRead(readerCtx, model.MarkThreadAsReadInput{
+			RoomID:            env.testRoom.Id,
+			ThreadRootEventID: root.Id,
+			UpToEventID:       &reply1.Id,
+		}); err != nil {
+			t.Fatalf("mark up to reply1: %v", err)
+		}
+		markerAfter, _ := env.core.GetThreadLastOpened(env.ctx, core.KindChannel, threadReader.Id, env.testRoom.Id, root.Id)
+		if !markerAfter.Equal(marker2) {
+			t.Errorf("expected marker to stay at reply2's time (%v), got %v", marker2, markerAfter)
 		}
 	})
 }

--- a/frontend/src/lib/RoomList.svelte
+++ b/frontend/src/lib/RoomList.svelte
@@ -30,6 +30,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   import UserAvatar, { UserAvatarFragment } from '$lib/components/UserAvatar.svelte';
   import UnreadDot from '$lib/ui/UnreadDot.svelte';
   import { notificationTarget } from '$lib/state/server/notifications.svelte';
+  import { appState } from '$lib/state/globals.svelte';
   import { getLiveDisplayName } from '$lib/state/userProfiles.svelte';
   import { type RoomsListItem, type RoomsListSection } from '$lib/state/space';
 
@@ -160,10 +161,13 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
 
   // --- Real-time event handlers ---
 
-  // Clear unread/mention when entering a room. Notification dismissal is
-  // handled by Room.svelte when it mounts.
+  // Clear unread/mention when entering a room while present. Navigation
+  // alone (e.g. clicking a notification while the tab is hidden) isn't
+  // enough — we wait until the user can actually see the room. The
+  // cross-tab `useRoomMarkedAsRead` handler below also clears the dot when
+  // useRoomUnread fires its mutation on presence-true.
   $effect(() => {
-    if (activeRoomId) roomsStore.markRead(activeRoomId);
+    if (activeRoomId && appState.isPresent) roomsStore.markRead(activeRoomId);
   });
 
   // Handle space events that this component cares about beyond the store
@@ -210,8 +214,11 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     roomsStore.bumpRoom(event.roomId);
 
     // Unread bookkeeping is suppressed for the viewer's own messages and
-    // for the room they're currently in.
-    if (event.roomId === activeRoomId) return;
+    // for the room they're currently present on. "Present" requires the
+    // window to be focused AND the tab visible — if the URL matches but
+    // the user is on another app / tab, the dot should still light up so
+    // they see the signal when they return.
+    if (event.roomId === activeRoomId && appState.isPresent) return;
     if (serverEvent.actorId === currentUserState.user?.id) return;
     if (notificationLevelStore.isRoomMuted(event.roomId)) return;
     roomsStore.setUnread(event.roomId);

--- a/frontend/src/lib/ServerSpaceSection.svelte
+++ b/frontend/src/lib/ServerSpaceSection.svelte
@@ -8,6 +8,7 @@
   import { createEventBusHandlerRegistrar } from '$lib/eventBus.svelte';
   import { graphql } from './gql';
   import { notificationTarget } from '$lib/state/server/notifications.svelte';
+  import { appState } from '$lib/state/globals.svelte';
   import SpaceIcon from './SpaceIcon.svelte';
   import { useTabResumeCallback } from '$lib/hooks';
 
@@ -200,11 +201,14 @@
           const eventRoomId = event.roomId;
           const isFromSelf = actorId === currentUserId;
 
-          // The viewer is "in" a room when the URL's roomId matches and they're
-          // on this instance's segment.
+          // The viewer is "in" a room when the URL matches AND they're
+          // actually present (window focused + tab visible). A URL-only
+          // match while the tab is hidden should still mark the room as
+          // unread so the dot lights up when they return.
           const isViewingRoom =
             page.params.serverId === serverSegment &&
-            page.params.roomId === eventRoomId;
+            page.params.roomId === eventRoomId &&
+            appState.isPresent;
 
           if (
             !isFromSelf &&

--- a/frontend/src/lib/gql/graphql.ts
+++ b/frontend/src/lib/gql/graphql.ts
@@ -553,6 +553,12 @@ export type LinkPreviewInput = {
 export type MarkRoomAsReadInput = {
   /** The ID of the room to mark as read. */
   roomId: Scalars['ID']['input'];
+  /**
+   * Optional event ID to mark as the read cursor. If provided, the marker is
+   * set to this event (advance-only — never regresses past a more recent
+   * marker). If omitted, the server uses the room's current latest event.
+   */
+  upToEventId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 /** Result of marking a room as read. */
@@ -570,6 +576,12 @@ export type MarkThreadAsReadInput = {
   roomId: Scalars['ID']['input'];
   /** The event ID of the thread root message. */
   threadRootEventId: Scalars['ID']['input'];
+  /**
+   * Optional event ID (root or reply) to anchor the read cursor at. If
+   * provided, the server records that event's timestamp (advance-only). If
+   * omitted, the server records the current wall-clock time.
+   */
+  upToEventId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 /** Result of marking a thread as read. */

--- a/frontend/src/lib/hooks/useRoomUnread.svelte.ts
+++ b/frontend/src/lib/hooks/useRoomUnread.svelte.ts
@@ -5,8 +5,10 @@ import { getActiveServer } from '$lib/state/activeServer.svelte';
 import { appState } from '$lib/state/globals.svelte';
 
 /**
- * Manages room unread state: marks the room as read on entry and when new
- * messages arrive from other users. Tracks the unread separator position.
+ * Manages room unread state: marks the room as read on entry and every time
+ * the user transitions back to "present" on the room (window refocus, tab
+ * reveal). Tracks the unread separator position so a refocus shows what
+ * arrived while the user was away.
  *
  * Must be called during component initialization (uses context).
  */
@@ -17,7 +19,7 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
   let unreadAfterTime = $state<string | null>(null);
   let unreadBeforeTime = $state<string | null>(null);
 
-  async function markRoomAsRead(targetRoomId: string) {
+  async function markRoomAsRead(targetRoomId: string, upToEventId?: string) {
     roomUnreadStore.setRoomUnread(targetRoomId, false);
 
     try {
@@ -31,7 +33,7 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
               }
             }
           `),
-          { input: { roomId: targetRoomId } }
+          { input: { roomId: targetRoomId, upToEventId } }
         )
         .toPromise();
 
@@ -42,18 +44,30 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
     }
   }
 
-  let previousRoomId: string | undefined;
+  // Fire markRoomAsRead on every presence-true edge (fresh entry OR
+  // refocus/tab-reveal) and on room changes while present. The mutation
+  // result drives the unread separator so a refocus shows what arrived
+  // while the user was away. Presence-out leaves the existing separator
+  // in place — it's the "you were away" boundary the user needs to see
+  // when they come back.
+  let lastFiredRoomId = '';
+  let wasPresent = false;
 
-  // Mark as read when entering the room
   $effect(() => {
     const { roomId } = getProps();
+    const present = appState.isPresent;
+
+    if (!present) {
+      wasPresent = false;
+      return;
+    }
+
+    if (wasPresent && lastFiredRoomId === roomId) return;
+    wasPresent = true;
+    lastFiredRoomId = roomId;
 
     unreadAfterTime = null;
     unreadBeforeTime = null;
-
-    if (!appState.isFocused) return;
-    if (previousRoomId === roomId) return;
-    previousRoomId = roomId;
 
     markRoomAsRead(roomId).then((result) => {
       const current = getProps();

--- a/frontend/src/lib/state/globals.svelte.ts
+++ b/frontend/src/lib/state/globals.svelte.ts
@@ -11,6 +11,19 @@
 
 class AppState {
   isFocused = $state(typeof document !== 'undefined' ? document.hasFocus() : true);
+  isVisible = $state(
+    typeof document !== 'undefined' ? document.visibilityState === 'visible' : true
+  );
+
+  /**
+   * True when the user is actually present at the app: window focused AND
+   * tab visible. Drives read-cursor advancement — we only mark messages
+   * read while the user can actually see them. A blur or tab-hide flips
+   * this false; refocus / re-show flips it back.
+   */
+  get isPresent(): boolean {
+    return this.isFocused && this.isVisible;
+  }
 
   constructor() {
     if (typeof window !== 'undefined') {
@@ -19,6 +32,11 @@ class AppState {
       });
       window.addEventListener('blur', () => {
         this.isFocused = false;
+      });
+    }
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', () => {
+        this.isVisible = document.visibilityState === 'visible';
       });
     }
   }

--- a/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/Room.svelte
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/Room.svelte
@@ -186,7 +186,10 @@
     }
   }
 
-  // Mark as read when new messages arrive from OTHER users
+  // Mark as read when new messages arrive from OTHER users while the user
+  // is actually present (focused + visible). The mutation passes the event
+  // ID explicitly so the server cursor matches what the client has rendered
+  // — no server-time race.
   useEvent((event) => {
     if (!event.event) return;
 
@@ -195,8 +198,13 @@
         typingIndicator.removeTypingUser(event.actorId);
       }
 
-      if (currentUser.user && event.actorId !== currentUser.user.id && appState.isFocused) {
-        unread.markRoomAsRead(roomId);
+      if (
+        !event.event.inThread &&
+        currentUser.user &&
+        event.actorId !== currentUser.user.id &&
+        appState.isPresent
+      ) {
+        unread.markRoomAsRead(roomId, event.id);
       }
     }
   });

--- a/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/ThreadPane.svelte
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/ThreadPane.svelte
@@ -104,8 +104,9 @@
     jumpState.jumpToMessage(highlightEventId);
   });
 
-  // Subscribe to server events: clear typing indicator on a thread reply
-  // (component-level concern), then forward to the store.
+  // Subscribe to server events: clear typing indicator on a thread reply,
+  // forward to the store, and mark the thread as read (with explicit event
+  // ID) for replies arriving from other users while the user is present.
   useEvent((serverEvent) => {
     const eventData = serverEvent.event;
     if (!eventData) return;
@@ -116,6 +117,14 @@
       eventData.inThread === threadRootEventId
     ) {
       typingIndicator.removeTypingUser(serverEvent.actorId);
+
+      if (
+        currentUser.user &&
+        serverEvent.actorId !== currentUser.user.id &&
+        appState.isPresent
+      ) {
+        void markThreadAsRead(threadRootEventId, serverEvent.id);
+      }
     }
 
     store.ingestServerEvent(serverEvent);
@@ -197,19 +206,9 @@
     notificationStore.dismissThreadNotifications(threadId);
   });
 
-  // Mark thread as opened and capture previous timestamp for unread separator
-  $effect(() => {
-    const currentThreadId = threadRootEventId;
-
-    // Reset unread markers when switching threads
-    unreadAfterTime = null;
-    unreadBeforeTime = null;
-
-    // Capture the time when we opened - messages after this shouldn't show separator
-    const openedAt = new Date();
-
-    connection().client
-      .mutation(
+  async function markThreadAsRead(currentThreadId: string, upToEventId?: string) {
+    const result = await connection()
+      .client.mutation(
         graphql(`
           mutation MarkThreadAsRead($input: MarkThreadAsReadInput!) {
             markThreadAsRead(input: $input) {
@@ -217,18 +216,46 @@
             }
           }
         `),
-        { input: { roomId, threadRootEventId: currentThreadId } }
+        { input: { roomId, threadRootEventId: currentThreadId, upToEventId } }
       )
-      .toPromise()
-      .then((result) => {
-        if (result.error) {
-          console.error('Failed to mark thread as read:', result.error);
-          return;
-        }
-        const prevTime = result.data?.markThreadAsRead.previousReadAt;
-        unreadAfterTime = prevTime ? new Date(prevTime) : null;
-        unreadBeforeTime = openedAt;
-      });
+      .toPromise();
+
+    if (result.error) {
+      console.error('Failed to mark thread as read:', result.error);
+    }
+    return result.data?.markThreadAsRead ?? null;
+  }
+
+  // Fire mark-thread-as-read on every presence-true edge (fresh open or
+  // refocus/tab-reveal) and on thread changes while present. The result
+  // drives the unread separator so a refocus shows what arrived during
+  // the away period.
+  let lastFiredThreadId = '';
+  let wasPresentThread = false;
+
+  $effect(() => {
+    const currentThreadId = threadRootEventId;
+    const present = appState.isPresent;
+
+    if (!present) {
+      wasPresentThread = false;
+      return;
+    }
+
+    if (wasPresentThread && lastFiredThreadId === currentThreadId) return;
+    wasPresentThread = true;
+    lastFiredThreadId = currentThreadId;
+
+    unreadAfterTime = null;
+    unreadBeforeTime = null;
+
+    const openedAt = new Date();
+    markThreadAsRead(currentThreadId).then((data) => {
+      if (!data) return;
+      const prevTime = data.previousReadAt;
+      unreadAfterTime = prevTime ? new Date(prevTime) : null;
+      unreadBeforeTime = openedAt;
+    });
   });
 </script>
 


### PR DESCRIPTION
## Summary

Fixes a class of bugs where a room (or thread) the user was just viewing would re-appear as unread after navigating away. Root cause: per-message `markRoomAsRead` mutations raced with new arrivals, and the focus-gated handler short-circuited whenever the window lost focus — so the server's read cursor drifted out of sync with what the user actually saw.

The new model treats **presence** (window focused + tab visible) as the source of truth: the read cursor advances only while present, and the mark-as-read mutations now accept an explicit `upToEventId` so the marker is anchored at a known-rendered event with **advance-only** semantics. The unread separator re-renders on every presence-true edge (entry, refocus, tab reveal), showing exactly what arrived while the user was away. Sidebar skip predicates were tightened to require presence too, so dots correctly light up when the URL matches but the user isn't actually looking. Threads also gain the previously-missing useEvent handler that marks the thread as read on incoming replies.

## Test plan
- [ ] Sit in room A with window focused → messages arrive → navigate to B; A should stay read (no dot).
- [ ] Sit in room A, blur the window or hide the tab; messages arrive; refocus → unread separator appears above the missed messages.
- [ ] URL is room A but the tab is hidden; a message arrives → sidebar dot lights up; focus tab → dot clears and separator appears.
- [ ] Repeat the three above for an open thread (open thread, blur, replies arrive, refocus → separator).
- [ ] Two tabs / devices: marker should never regress (covered by `TestMarkRoomAsRead_UpToEventId/advance-only` and the thread equivalent).
- [ ] `mise test-cli` (passes locally aside from the pre-existing `TestAuthRoutes_TestEmailEndpoint` known flake) and `mise test-frontend` (733/733).