### PR TITLE
feat(messages): always render deleted messages as a tombstone

### DIFF
--- a/frontend/e2e/account-deletion.test.ts
+++ b/frontend/e2e/account-deletion.test.ts
@@ -131,10 +131,13 @@ test.describe('Account Deletion', () => {
         await page2.waitForURL(routes.patterns.chatRedirect, { timeout: TIMEOUTS.UI_STANDARD });
         await waitForRoomReady(page2, 'general');
 
-        // Message should be hidden entirely: body was crypto-shredded (no body, no reactions, no replies)
+        // Body was crypto-shredded; the message is now rendered as a tombstone.
         await expect(page2.getByText(messageText)).not.toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+        await expect(
+          page2.getByText('This message has been deleted').first()
+        ).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
 
-        // User A's original display name should no longer be visible (message is hidden)
+        // User A's clickable display-name button is gone (the actor is gone).
         await expect(
           page2.locator('[role="article"]').getByRole('button', { name: userA.displayName })
         ).not.toBeVisible();
@@ -189,18 +192,20 @@ test.describe('Account Deletion', () => {
         await accountPage.goto();
         await accountPage.deleteAccount();
 
-        // WITHOUT REFRESHING: User B should see the message disappear in real-time
-        // ServerMemberDeletedEvent triggers refetch → body is crypto-shredded → message hidden
-        // (no body, no reactions, no replies)
+        // WITHOUT REFRESHING: User B should see the body replaced by the tombstone
+        // in real-time — ServerMemberDeletedEvent triggers a refetch and the body
+        // has been crypto-shredded.
         await expect(page2.getByText(messageText)).not.toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
 
-        // User A's original display name should no longer be visible (message is hidden)
+        // User A's clickable display-name button is gone (the actor is gone).
         await expect(
           page2.locator('[role="article"]').getByRole('button', { name: userA.displayName })
         ).not.toBeVisible();
 
-        // Message is hidden entirely (no body, no reactions, no replies) — no placeholder shown
-        await expect(page2.getByText('[Message deleted]')).not.toBeVisible();
+        // The message renders as a tombstone now that bodies are always replaced rather than hidden.
+        await expect(
+          page2.getByText('This message has been deleted').first()
+        ).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
       } finally {
         await context2.close();
       }

--- a/frontend/e2e/messages.test.ts
+++ b/frontend/e2e/messages.test.ts
@@ -34,7 +34,7 @@ test('consecutive messages from same user are grouped', async ({ page, chatPage,
   await roomPage.expectMessageVisible(message3);
 });
 
-test('deleting first message in group re-shows avatar on next message', async ({
+test('deleting first message in group leaves a tombstone as the group leader', async ({
   page,
   chatPage,
   roomPage
@@ -52,6 +52,7 @@ test('deleting first message in group re-shows avatar on next message', async ({
   const message3 = `Third ${timestamp}`;
 
   const msg1 = await roomPage.sendMessage(message1);
+  const msg1EventId = await msg1.getEventId();
   await roomPage.sendMessage(message2);
   await roomPage.sendMessage(message3);
 
@@ -59,11 +60,14 @@ test('deleting first message in group re-shows avatar on next message', async ({
   await roomPage.expectAvatarCount(1);
   await roomPage.expectUserHeaderCount(testUser.displayName, 1);
 
-  // Delete the first message (the group leader)
+  // Delete the first message (the group leader). The tombstone takes its place
+  // and remains the group leader — avatar/header stay attached to it, so the
+  // count is unchanged.
   await msg1.delete();
-  await msg1.expectHidden();
+  if (msg1EventId) {
+    await roomPage.getMessageByEventId(msg1EventId).expectDeleted();
+  }
 
-  // The second message should now show the avatar/header since the group leader is gone
   await roomPage.expectAvatarCount(1);
   await roomPage.expectUserHeaderCount(testUser.displayName, 1);
 
@@ -277,11 +281,11 @@ test('user can delete their own message', async ({ page, chatPage, roomPage }) =
   // Delete the message
   await message.delete();
 
-  // Deleted message with no reactions/replies should be hidden entirely
+  // Deleted message should show the tombstone (original text gone, placeholder in place)
   await roomPage.expectMessageNotVisible(testMessage);
   if (eventId) {
     const deletedMessage = roomPage.getMessageByEventId(eventId);
-    await deletedMessage.expectHidden();
+    await deletedMessage.expectDeleted();
   }
 });
 
@@ -347,17 +351,22 @@ test('deleted message disappears for other connected clients in real-time', asyn
     // User 1: Delete the message
     await message1.delete();
 
-    // User 1: deleted message with no reactions/replies should be hidden
+    // User 1: deleted message should show the tombstone
     await roomPage.expectMessageNotVisible(testMessage);
     if (eventId) {
       const message1AfterDelete = roomPage.getMessageByEventId(eventId);
-      await message1AfterDelete.expectHidden();
+      await message1AfterDelete.expectDeleted();
     }
 
-    // User 2: should also see the message hidden via LiveEvent
+    // User 2: should also see the tombstone arrive via LiveEvent
     if (eventId) {
       const message2AfterDelete = page2.locator(`[data-event-id="${eventId}"]`);
-      await expect(message2AfterDelete).not.toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+      await expect(
+        message2AfterDelete.getByText('This message has been deleted')
+      ).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+      await expect(page2.getByText(testMessage)).not.toBeVisible({
+        timeout: TIMEOUTS.UI_STANDARD
+      });
     }
   } finally {
     await context2.close();
@@ -377,10 +386,10 @@ test('deleted attachment-only message shows placeholder', async ({ page, chatPag
   // Delete the message
   await message.delete();
 
-  // Deleted attachment-only message with no reactions/replies should be hidden
+  // Deleted attachment-only message should show the tombstone
   if (eventId) {
     const messageAfterDelete = roomPage.getMessageByEventId(eventId);
-    await messageAfterDelete.expectHidden();
+    await messageAfterDelete.expectDeleted();
   }
 });
 
@@ -407,10 +416,10 @@ test('deleting attachment-only message in group does not mark text message as ed
   // Delete the attachment-only message
   await attachmentMsg.delete();
 
-  // Deleted attachment-only message should be hidden
+  // Deleted attachment-only message should show the tombstone
   if (attachmentEventId) {
     const messageAfterDelete = roomPage.getMessageByEventId(attachmentEventId);
-    await messageAfterDelete.expectHidden();
+    await messageAfterDelete.expectDeleted();
   }
 
   // Verify the text message still exists and is NOT marked as edited
@@ -440,10 +449,10 @@ test('removing attachment from attachment-only message hides it', async ({
   // Remove the attachment (not delete the whole message)
   await message.deleteAttachment();
 
-  // Message with no body, no attachment, no reactions, no replies should be hidden
+  // Message with no body and no attachments should show the deleted-tombstone
   if (eventId) {
     const messageAfterRemove = roomPage.getMessageByEventId(eventId);
-    await messageAfterRemove.expectHidden();
+    await messageAfterRemove.expectDeleted();
   }
 });
 
@@ -464,7 +473,7 @@ test('deleted message with reactions remains visible', async ({ page, chatPage, 
   // Delete the message
   await message.delete();
 
-  // Message should still be visible with "[Message deleted]" because it has a reaction
+  // Message should still be visible with "This message has been deleted" because it has a reaction
   await roomPage.expectMessageNotVisible(testMessage);
   if (eventId) {
     const deletedMessage = roomPage.getMessageByEventId(eventId);
@@ -482,7 +491,7 @@ test('deletion of a reacted message shows placeholder for other connected client
 }) => {
   // User 1 posts a message; User 2 reacts to it; User 1 deletes it.
   // User 2 (already viewing the room) should see the original body replaced
-  // by the [Message deleted] placeholder while the reaction stays visible —
+  // by the "This message has been deleted" placeholder while the reaction stays visible —
   // this is the propagation case the single-user delete-with-reaction test
   // doesn't cover and that the previous refetch-only path failed silently on.
   await createAndLoginTestUser(page);
@@ -562,7 +571,7 @@ test('deleted message with thread replies remains visible', async ({
   // Delete the root message
   await message.delete();
 
-  // Message should still be visible with "[Message deleted]" because it has thread replies
+  // Message should still be visible with "This message has been deleted" because it has thread replies
   await roomPage.expectMessageNotVisible(testMessage);
   if (eventId) {
     const deletedMessage = roomPage.getMessageByEventId(eventId);

--- a/frontend/e2e/pages/MessageComponent.ts
+++ b/frontend/e2e/pages/MessageComponent.ts
@@ -405,18 +405,12 @@ export class MessageComponent {
   }
 
   /**
-   * Assert that the message shows the "[Message deleted]" placeholder.
+   * Assert that the message shows the "This message has been deleted" tombstone.
    */
   async expectDeleted(): Promise<void> {
-    await expect(this.locator.getByText('[Message deleted]')).toBeVisible();
-  }
-
-  /**
-   * Assert that the message is hidden (not rendered at all).
-   * Used for deleted messages with no reactions and no thread replies.
-   */
-  async expectHidden(): Promise<void> {
-    await expect(this.locator).not.toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+    await expect(this.locator.getByText('This message has been deleted.')).toBeVisible({
+      timeout: TIMEOUTS.REALTIME_EVENT
+    });
   }
 
   /**

--- a/frontend/e2e/thread-reply-echo.test.ts
+++ b/frontend/e2e/thread-reply-echo.test.ts
@@ -494,18 +494,19 @@ test.describe('Thread Reply Echo ("Also send to channel")', () => {
       await echo.delete();
     });
 
-    await test.step('Verify echo is hidden (no body, no reactions, no replies)', async () => {
+    await test.step('Verify echo shows the deleted tombstone', async () => {
       const echo = roomPage.getMessageByEventId(echoEventId!);
-      await echo.expectHidden();
+      await echo.expectDeleted();
     });
 
-    await test.step('Open thread and verify original is also hidden', async () => {
+    await test.step('Open thread and verify thread original also shows tombstone', async () => {
       await rootMessageComponent.openThread();
       await roomPage.expectThreadPaneVisible();
 
-      // The thread reply should also be hidden (no body, no reactions, no replies)
       await expect(roomPage.threadPane.getByText(replyMessage)).not.toBeVisible();
-      await expect(roomPage.threadPane.getByText('[Message deleted]')).not.toBeVisible();
+      await expect(
+        roomPage.threadPane.getByText('This message has been deleted').first()
+      ).toBeVisible();
     });
   });
 
@@ -537,17 +538,19 @@ test.describe('Thread Reply Echo ("Also send to channel")', () => {
       await threadReply.delete();
     });
 
-    await test.step('Verify thread reply is hidden (no body, no reactions, no replies)', async () => {
+    await test.step('Verify thread reply shows the deleted tombstone', async () => {
       await expect(roomPage.threadPane.getByText(replyMessage)).not.toBeVisible();
-      await expect(roomPage.threadPane.getByText('[Message deleted]')).not.toBeVisible();
+      await expect(
+        roomPage.threadPane.getByText('This message has been deleted').first()
+      ).toBeVisible();
     });
 
-    await test.step('Close thread and verify echo in main room is also hidden', async () => {
+    await test.step('Close thread and verify echo in main room also shows tombstone', async () => {
       await roomPage.closeThread();
       await roomPage.expectThreadRouteClosed();
 
-      // The echo should also be hidden (no body, no reactions, no replies)
       await expect(page.getByText(replyMessage)).not.toBeVisible();
+      await expect(page.getByText('This message has been deleted').first()).toBeVisible();
     });
   });
 

--- a/frontend/e2e/threading.test.ts
+++ b/frontend/e2e/threading.test.ts
@@ -185,17 +185,18 @@ test.describe('Message Threading', () => {
 
       // User B sees the reply that user A posted.
       await roomPage2.expectTextInThreadPane(replyText);
-      const replyForB = roomPage2.getThreadMessage(replyText);
 
       // User A deletes the reply.
       const replyForA = roomPage.getThreadMessage(replyText);
       await replyForA.delete();
 
-      // User B should see the reply vanish — without refresh.
-      await replyForB.expectHidden();
+      // User B should see the reply replaced by the tombstone — without refresh.
       await expect(roomPage2.threadPane.getByText(replyText)).not.toBeVisible({
         timeout: TIMEOUTS.REALTIME_EVENT
       });
+      await expect(
+        roomPage2.threadPane.getByText('This message has been deleted').first()
+      ).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
     } finally {
       await context2.close();
     }

--- a/frontend/src/lib/state/room/messages.svelte.ts
+++ b/frontend/src/lib/state/room/messages.svelte.ts
@@ -271,9 +271,8 @@ export abstract class MessageListStore {
    * Apply a deletion locally to any matching MessagePostedEvent in the buffer
    * (the original by id, plus any echo whose echoOfEventId points at it).
    * Mirrors the server's post-deletion state: body=null, attachments=[].
-   * Reactions and reply metadata are left intact — the [Message deleted]
-   * placeholder relies on them to decide between hiding the row entirely
-   * and showing a stub for messages that already have engagement.
+   * Reactions and reply metadata are left intact so the tombstone row keeps
+   * its existing engagement visible alongside the placeholder.
    */
   protected applyDeletion(messageEventId: string): void {
     for (let i = 0; i < this.events.length; i++) {

--- a/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/MessageEvent.svelte
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/MessageEvent.svelte
@@ -308,12 +308,11 @@
   // Check if message has attachments
   const hasAttachments = $derived((msg?.attachments?.length ?? 0) > 0);
 
-  // Message is "deleted" if it has no body AND no attachments
+  // Message is "deleted" if it has no body AND no attachments.
+  // Deleted messages always render as a tombstone — hiding them entirely opened up
+  // moderation-evading and inconsistency vectors (e.g. event numbering gaps, lost
+  // reply-attribution context, deleted-then-reacted-to messages disappearing).
   const isDeleted = $derived(!msg?.body && !hasAttachments);
-
-  // A deleted message with no reactions and no thread replies should be hidden entirely
-  const hasReactions = $derived((msg?.reactions?.length ?? 0) > 0);
-  const isHidden = $derived(isDeleted && !hasReactions && !hasReplies);
 
   // Reply preview: per-message fetch of the replied-to event.
   let replyTarget = $state<RoomEventViewFragment | null>(null);
@@ -505,7 +504,7 @@
   }
 </script>
 
-{#if msg && !isHidden}
+{#if msg}
   <div
     class={[
       'group relative hover:z-10',
@@ -646,7 +645,7 @@
         <!-- Message body - re-enable text selection on desktop (pointer-fine variant) -->
         {#if isDeleted}
           <!-- Message deleted or encryption key removed -->
-          <span class="text-muted/50">[Message deleted]</span>
+          <span class="text-muted/50 italic">This message has been deleted.</span>
         {:else if msg.body}
           <div class="pointer-fine:select-text">
             <MessageContent

--- a/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/messageGrouping.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/messageGrouping.spec.ts
@@ -220,13 +220,13 @@ describe('computeEventMetadata', () => {
       expect(result[2].isFirstInGroup).toBe(true); // reply breaks the group
     });
 
-    it('skips hidden deleted messages for grouping (next message becomes first in group)', () => {
+    it('groups deleted messages normally (deleted messages are rendered as tombstones)', () => {
       const events = [
         createMockEvent({
           id: 'evt_1',
           actorId: 'u_alice',
           createdAt: '2025-11-28T10:00:00Z',
-          body: null // deleted, no attachments/reactions/replies → hidden
+          body: null // deleted — still rendered as tombstone, still groups
         }),
         createMockEvent({
           id: 'evt_2',
@@ -239,60 +239,7 @@ describe('computeEventMetadata', () => {
       const result = computeEventMetadata(events, defaultSettings);
 
       expect(result[0].isFirstInGroup).toBe(true);
-      expect(result[1].isFirstInGroup).toBe(true); // hidden prev → starts new group
-    });
-
-    it('groups with visible deleted message that has reactions', () => {
-      const deletedWithReactions = createMockEvent({
-        id: 'evt_1',
-        actorId: 'u_alice',
-        createdAt: '2025-11-28T10:00:00Z',
-        body: null
-      });
-      // Add a reaction so it's visible (not hidden)
-      (deletedWithReactions.event as Extract<RoomEventViewFragment['event'], { __typename: 'MessagePostedEvent' }>).reactions = [
-        { emoji: '👍', count: 1, hasReacted: false, users: [] }
-      ];
-
-      const events = [
-        deletedWithReactions,
-        createMockEvent({
-          id: 'evt_2',
-          actorId: 'u_alice',
-          createdAt: '2025-11-28T10:01:00Z',
-          body: 'After deleted'
-        })
-      ];
-
-      const result = computeEventMetadata(events, defaultSettings);
-
-      expect(result[0].isFirstInGroup).toBe(true);
-      expect(result[1].isFirstInGroup).toBe(false); // visible deleted msg → groups normally
-    });
-
-    it('groups with visible deleted message that has replies', () => {
-      const deletedWithReplies = createMockEvent({
-        id: 'evt_1',
-        actorId: 'u_alice',
-        createdAt: '2025-11-28T10:00:00Z',
-        body: null
-      });
-      (deletedWithReplies.event as Extract<RoomEventViewFragment['event'], { __typename: 'MessagePostedEvent' }>).replyCount = 3;
-
-      const events = [
-        deletedWithReplies,
-        createMockEvent({
-          id: 'evt_2',
-          actorId: 'u_alice',
-          createdAt: '2025-11-28T10:01:00Z',
-          body: 'After deleted with thread'
-        })
-      ];
-
-      const result = computeEventMetadata(events, defaultSettings);
-
-      expect(result[0].isFirstInGroup).toBe(true);
-      expect(result[1].isFirstInGroup).toBe(false); // visible (has replies) → groups normally
+      expect(result[1].isFirstInGroup).toBe(false); // deleted tombstone groups like any other message
     });
   });
 
@@ -340,30 +287,6 @@ describe('computeEventMetadata', () => {
 
       expect(result[0].showDaySeparator).toBe(true);
       expect(result[1].showDaySeparator).toBe(false);
-    });
-
-    it('shows day separator on visible message after hidden ones from previous day', () => {
-      const events = [
-        createMockEvent({
-          id: 'evt_1',
-          actorId: 'u_alice',
-          createdAt: '2025-11-27T23:59:00Z',
-          body: null // hidden deleted message from yesterday
-        }),
-        createMockEvent({
-          id: 'evt_2',
-          actorId: 'u_alice',
-          createdAt: '2025-11-28T00:01:00Z',
-          body: 'First visible message today'
-        })
-      ];
-
-      const result = computeEventMetadata(events, defaultSettings);
-
-      // Hidden event still gets showDaySeparator (it won't be rendered by virtualItems)
-      expect(result[0].showDaySeparator).toBe(true);
-      // Visible event also gets showDaySeparator because its visible prevEvent is null
-      expect(result[1].showDaySeparator).toBe(true);
     });
 
     it('starts new group when day changes even if same user within 10 mins', () => {

--- a/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/messageGrouping.ts
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/messageGrouping.ts
@@ -4,24 +4,6 @@ import { isSameDay, formatDayLabel } from '$lib/utils/formatTime';
 
 const TEN_MINUTES_MS = 10 * 60 * 1000;
 
-/**
- * Mirrors the isHidden logic in MessageEvent.svelte: a deleted message
- * (no body, no attachments) with no reactions and no replies is hidden.
- */
-export function isEventHidden(event: RoomEventViewFragment): boolean {
-  const e = event.event;
-  if (!e) return false;
-  if (e.__typename !== 'MessagePostedEvent') return false;
-  const hasBody = !!e.body;
-  const hasAttachments = (e.attachments?.length ?? 0) > 0;
-  if (hasBody || hasAttachments) return false;
-  // Echoes don't have reactions/replyCount — if body+attachments are gone, always hidden.
-  if (e.echoOfEventId != null) return true;
-  const hasReactions = (e.reactions?.length ?? 0) > 0;
-  const hasReplies = (e.replyCount ?? 0) > 0;
-  return !hasReactions && !hasReplies;
-}
-
 export type EventWithMeta = {
   event: RoomEventViewFragment;
   isFirstInGroup: boolean;
@@ -37,15 +19,7 @@ export function computeEventMetadata(
 
   for (let i = 0; i < events.length; i++) {
     const event = events[i];
-
-    // Find the last visible previous event (skip hidden deleted messages)
-    let prevEvent: RoomEventViewFragment | null = null;
-    for (let j = i - 1; j >= 0; j--) {
-      if (!isEventHidden(events[j])) {
-        prevEvent = events[j];
-        break;
-      }
-    }
+    const prevEvent: RoomEventViewFragment | null = i > 0 ? events[i - 1] : null;
 
     const eventDate = new Date(event.createdAt);
     const prevEventDate = prevEvent ? new Date(prevEvent.createdAt) : null;

--- a/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/virtualItems.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/virtualItems.spec.ts
@@ -149,8 +149,8 @@ describe('buildVirtualItems', () => {
     expect(items.find((i) => i.type === 'unread-separator')).toBeUndefined();
   });
 
-  it('skips day-separator and unread-separator for hidden (deleted) events', () => {
-    const hidden = makeMessageEvent({
+  it('treats deleted messages like any other event (tombstone rendering, separators apply)', () => {
+    const deleted = makeMessageEvent({
       id: 'deleted',
       body: null,
       attachments: [],
@@ -162,14 +162,13 @@ describe('buildVirtualItems', () => {
       id: 'visible',
       createdAt: '2025-04-27T09:00:00Z'
     });
-    const items = buildVirtualItems(meta([hidden, visible]), 'deleted', false);
+    const items = buildVirtualItems(meta([deleted, visible]), 'deleted', false);
 
-    // The deleted event itself is still emitted (caller decides whether to render it),
-    // but no day or unread separator is attached to it.
-    expect(items.find((i) => i.type === 'unread-separator')).toBeUndefined();
-    // Only one day-separator (in front of the hidden event since it's the first).
-    // Verify that no second day-separator is wrongly inserted before the visible event.
-    expect(items.filter((i) => i.type === 'day-separator')).toHaveLength(1);
+    // Deleted message is rendered as a tombstone — it receives separators normally.
+    const unread = items.findIndex((i) => i.type === 'unread-separator');
+    expect(unread).toBeGreaterThan(-1);
+    const deletedIndex = items.findIndex((i) => i.type === 'event' && i.key === 'deleted');
+    expect(items[deletedIndex - 1]).toMatchObject({ type: 'unread-separator' });
   });
 
   it('passes isFirstInGroup through from event metadata', () => {

--- a/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/virtualItems.ts
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/virtualItems.ts
@@ -1,6 +1,5 @@
 import type { RoomEventViewFragment } from '$lib/gql/graphql';
 import type { EventWithMeta } from './messageGrouping';
-import { isEventHidden } from './messageGrouping';
 
 export type SystemGroupKind = 'join' | 'leave';
 
@@ -77,12 +76,10 @@ export function buildVirtualItems(
 
   for (const item of eventsWithMeta) {
     const { event, isFirstInGroup, showDaySeparator, dayLabel } = item;
-    const hidden = isEventHidden(event);
     const systemKind = getSystemGroupKind(event);
 
-    const hasDaySeparator = showDaySeparator && !hidden;
-    const hasUnreadSeparator =
-      firstUnreadEventId !== null && event.id === firstUnreadEventId && !hidden;
+    const hasDaySeparator = showDaySeparator;
+    const hasUnreadSeparator = firstUnreadEventId !== null && event.id === firstUnreadEventId;
 
     // Any separator or a mismatched / non-system event breaks an open group.
     if (


### PR DESCRIPTION
## Summary
- Stops hiding deleted messages — every deleted message (including attachment-only, thread echoes, and crypto-shredded messages from deleted accounts) now renders a faded, italic "This message has been deleted." placeholder in place, closing the moderation-evading and inconsistency vectors the hide-when-no-engagement branch opened up.
- Drops the dead `isEventHidden` / `isHidden` plumbing from `MessageEvent.svelte`, `messageGrouping.ts`, and `virtualItems.ts`; deleted messages now participate in grouping and day/unread separators like any other message, with the tombstone acting as the group leader when it was first.
- Updates e2e tests + `MessageComponent` page object (`expectHidden` → `expectDeleted`, new text matcher) and reworks the "delete first in group" test so the assertion reflects the new behavior (avatar count is unchanged because the tombstone stays as group leader).

## Test plan
- [x] `mise x -- pnpm run check` (0 errors, 0 warnings)
- [x] `pnpm test:unit --run` (730/730 pass, includes updated `messageGrouping.spec.ts` / `virtualItems.spec.ts`)
- [x] `playwright test e2e/messages.test.ts e2e/thread-reply-echo.test.ts e2e/threading.test.ts e2e/account-deletion.test.ts --retries=0`