### PR TITLE
fix(ui): use mdi--login icon for sign-in buttons

### DIFF
--- a/frontend/src/lib/components/AddServerDialog.svelte
+++ b/frontend/src/lib/components/AddServerDialog.svelte
@@ -215,7 +215,7 @@ ADR-027 — only user-facing copy says "server".
   // it there would let a hostile server inject impersonation copy ("Sign
   // in to YourBank Login") into trusted UI chrome.
   const submitLabel = $derived(stage === 'preview' ? 'Sign in' : 'Connect');
-  const submitIcon = $derived(stage === 'preview' ? 'iconify uil--signin' : 'iconify uil--link');
+  const submitIcon = $derived(stage === 'preview' ? 'iconify mdi--login' : 'iconify uil--link');
   const submitLoadingText = $derived(stage === 'preview' ? 'Redirecting…' : 'Connecting…');
   const loading = $derived(probing || connecting);
   const disabled = $derived(stage === 'url' && !serverUrl.trim());

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -194,7 +194,7 @@
         <FormError {error} />
 
         <Button type="submit" size="lg" disabled={!canSubmit} loading={isLoading} loadingText="Signing in...">
-          <span class="iconify uil--signin"></span>
+          <span class="iconify mdi--login"></span>
           Sign In
         </Button>
       </form>


### PR DESCRIPTION
## Summary
The previous `uil--signin` icon displayed an arrow pointing left into a doorframe, which reads as "exiting" in Western LTR convention. Swapped it for `mdi--login` (arrow pointing right into a door) in both the standalone login page and the `AddServerDialog` preview stage.

## Test plan
- [ ] Visit `/login` — sign-in button shows the new icon
- [ ] Open the Add Server dialog, advance to the preview stage — submit button shows the new icon