### PR TITLE
fix(frontend): re-check Jump to Present visibility on tab resume

### DIFF
--- a/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/EventList.svelte
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/EventList.svelte
@@ -17,6 +17,7 @@
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { getUserSettings } from '$lib/state/userSettings.svelte';
   import { formatDayLabel } from '$lib/utils/formatTime';
+  import { useTabResumeCallback } from '$lib/hooks/useTabResumeCallback.svelte';
 
   let {
     roomId,
@@ -420,6 +421,17 @@
   function markUserScrollIntent() {
     userScrollIntentAt = Date.now();
   }
+
+  // Re-evaluate "are we at the bottom?" when the tab regains visibility — the
+  // browser may have throttled virtua's measurements or our auto-scroll effect
+  // while hidden, leaving shouldScrollToBottom=true even though the scroll has
+  // drifted off the bottom (which would suppress the Jump to Present button).
+  useTabResumeCallback(() => {
+    if (alwaysScrollToBottom || !shouldScrollToBottom || !initialScrollDone) return;
+    if (!virtualizerHandle) return;
+    const dist = virtualizerHandle.getScrollSize() - virtualizerHandle.getScrollOffset() - virtualizerHandle.getViewportSize();
+    if (dist > 50) shouldScrollToBottom = false;
+  });
 
   // Handle scroll events from virtua to detect user intent and trigger pagination.
   // virtua's shift=true handles scroll restoration during pagination automatically,


### PR DESCRIPTION
## Summary

When tabbing back into a Chatto tab whose message list had drifted off the bottom while hidden, the Jump to Present button wouldn't appear because `shouldScrollToBottom` only updates inside virtua's scroll callback — no scroll event fires on tab focus. This hooks `EventList` into the existing `useTabResumeCallback` helper to re-evaluate the at-bottom condition on visibility return, flipping the flag off only when the list is genuinely >50px from the bottom.

## Test plan

- [ ] Open a busy room, scroll to bottom, switch to another tab while new content arrives, switch back — Jump to Present should appear if no longer at the bottom.
- [ ] Confirm the at-bottom case still hides the button after tab resume (no false positives).