### PR TITLE
feat(core): reserve "here" and "all" as group names

### DIFF
--- a/cli/internal/core/groups.go
+++ b/cli/internal/core/groups.go
@@ -1,0 +1,19 @@
+package core
+
+// ReservedGroupNames lists names that cannot be used for custom groups.
+// These are reserved for built-in mention groups (e.g. @here, @all).
+var ReservedGroupNames = []string{
+	"here",
+	"all",
+}
+
+// IsReservedGroupName reports whether the given name is reserved and cannot
+// be used as a custom group name.
+func IsReservedGroupName(name string) bool {
+	for _, reserved := range ReservedGroupNames {
+		if name == reserved {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/internal/core/groups_test.go
+++ b/cli/internal/core/groups_test.go
@@ -1,0 +1,26 @@
+package core
+
+import "testing"
+
+func TestIsReservedGroupName(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"here", true},
+		{"all", true},
+		{"team", false},
+		{"frontend", false},
+		{"", false},
+		{"Here", false}, // case-sensitive
+		{"ALL", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsReservedGroupName(tt.name); got != tt.want {
+				t.Errorf("IsReservedGroupName(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `ReservedGroupNames` and `IsReservedGroupName` in `cli/internal/core/groups.go`, reserving `here` and `all` for future built-in mention groups.
- Match is exact/case-sensitive; includes unit tests covering reserved names, allowed names, the empty string, and case variants.

## Test plan
- [x] `go test ./internal/core/ -run TestIsReservedGroupName`