### PR TITLE
fix(frontend): scroll autocomplete popup selection into view

### DIFF
--- a/frontend/src/lib/components/composer/AutocompletePopup.svelte
+++ b/frontend/src/lib/components/composer/AutocompletePopup.svelte
@@ -88,6 +88,10 @@ configurable selection keys, and customizable item rendering via snippets.
             class={['menu-item', index === selectedIndex && 'menu-item-active']}
             onmouseenter={() => (selectedIndex = index)}
             onclick={() => onSelect(entry, 'click')}
+            {@attach (el) => {
+              // Keep the selected item in view during keyboard navigation
+              if (index === selectedIndex) el.scrollIntoView({ block: 'nearest' });
+            }}
           >
             {@render item({ item: entry, selected: index === selectedIndex })}
           </button>

--- a/frontend/src/lib/components/composer/AutocompletePopup.svelte.spec.ts
+++ b/frontend/src/lib/components/composer/AutocompletePopup.svelte.spec.ts
@@ -155,6 +155,29 @@ describe('AutocompletePopup', () => {
     });
   });
 
+  describe('scroll into view', () => {
+    // The popup's max-h-80 overflow lives in app.css (not loaded in component
+    // tests), so assert the behaviour directly: the selected item's element
+    // gets scrollIntoView called on it whenever the selection moves.
+    it('scrolls the newly selected item into view on keyboard navigation', () => {
+      const spy = vi.spyOn(HTMLElement.prototype, 'scrollIntoView');
+      try {
+        const { container, component } = renderPopup({ items: items('a', 'b', 'c') });
+        spy.mockClear(); // ignore the mount-time call on the initial selection
+
+        press(component, 'ArrowDown'); // -> b
+
+        const active = container.querySelector<HTMLElement>('.menu-item-active');
+        expect(activeLabel(container)).toBe('b');
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy.mock.instances[0]).toBe(active);
+        expect(spy).toHaveBeenCalledWith({ block: 'nearest' });
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+
   describe('items reactivity', () => {
     it('resets the active index to 0 when items change', async () => {
       const { container, rerender, component } = renderPopup({ items: items('a', 'b', 'c') });


### PR DESCRIPTION
The `:emoji` / `@mention` autocomplete popup is a `max-h-80` scroll container, but arrow-key navigation only moved the active highlight — with a long list (e.g. `:top`) the selection walked off the bottom of the visible area. This adds an attachment to each item button that calls `scrollIntoView({ block: 'nearest' })` when it becomes selected, keeping the highlighted item visible during keyboard navigation. A component test spying on `scrollIntoView` verifies the selected element is scrolled into view on keyboard nav.

Reported by Felix (repro: type `:top` and arrow down). Component-test layer only — worth a quick manual browser check since the real `max-h-80` overflow geometry isn't exercised by component tests.