### PR TITLE
feat(frontend): anchor the unread separator when the tab loses focus

### DIFF
--- a/frontend/e2e/threading.test.ts
+++ b/frontend/e2e/threading.test.ts
@@ -945,6 +945,76 @@ test.describe('Message Threading', () => {
     }
   });
 
+  test('thread unread separator appears in real time while the tab is hidden', async ({
+    page,
+    chatPage,
+    roomPage,
+    browser,
+    serverURL
+  }) => {
+    // User A: Create space, post a root message.
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.createSpace();
+    await chatPage.enterRoom('general');
+
+    const rootMessage = `Hidden-tab thread root ${Date.now()}`;
+    const message1 = await roomPage.sendMessage(rootMessage);
+    await message1.openThread();
+    await roomPage.expectThreadPaneVisible();
+
+    // User B: Create account, join space, open the same thread — present and
+    // caught up, staying in the thread the whole time.
+    const context2 = await browser!.newContext({ baseURL: serverURL });
+    const page2 = await context2.newPage();
+
+    try {
+      await createAndLoginTestUser(page2);
+      await joinSpace(page2);
+      await page2.goto(routes.space());
+
+      const chatPage2 = new ChatPage(page2);
+      const roomPage2 = new RoomPage(page2);
+
+      await chatPage2.enterRoom('general');
+      await waitForRoomReady(page2, 'general');
+      await roomPage2.expectMessageVisible(rootMessage);
+
+      const message2 = roomPage2.getMessage(rootMessage);
+      await message2.openThread();
+      await roomPage2.expectThreadPaneVisible();
+      await roomPage2.expectTextInThreadPane(rootMessage);
+
+      // Wait for markThreadAsRead to settle — no separator yet.
+      await expect(async () => {
+        await roomPage2.expectNoUnreadSeparatorInThreadPane();
+      }).toPass({ timeout: TIMEOUTS.UI_STANDARD, intervals: [100, 250, 500, 1000] });
+
+      // User B's tab goes to the background. They stay in the thread; presence
+      // just drops, which anchors the unread separator at "now".
+      await page2.evaluate(() => {
+        Object.defineProperty(document, 'visibilityState', {
+          value: 'hidden',
+          writable: true,
+          configurable: true
+        });
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+
+      // User A posts a reply while User B's tab is still hidden.
+      const replyMessage = `Reply while hidden ${Date.now()}`;
+      await roomPage.postThreadReply(replyMessage);
+
+      // The reply streams in over the live subscription, and because the
+      // separator was anchored the moment presence dropped, it shows up
+      // immediately — without User B re-opening the thread.
+      await roomPage2.expectTextInThreadPane(replyMessage);
+      await roomPage2.expectUnreadSeparatorInThreadPane();
+    } finally {
+      await context2.close();
+    }
+  });
+
   test('no unread separator after posting a message and reloading', async ({
     page,
     chatPage,

--- a/frontend/e2e/unread-indicators.test.ts
+++ b/frontend/e2e/unread-indicators.test.ts
@@ -492,6 +492,159 @@ test.describe('Room unread separator', () => {
     }
   });
 
+  test('unread separator appears in real time while the tab is hidden', async ({
+    page,
+    chatPage,
+    roomPage,
+    browser,
+    serverURL
+  }) => {
+    test.setTimeout(60000); // Multi-user test with real-time events needs more time
+
+    // User A: Create account and space, post an initial message in general.
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.createSpace('Hidden Tab Separator Test');
+    const spaceId = await chatPage.getSpaceId();
+
+    await chatPage.enterRoom('general');
+    await waitForRoomReady(page, 'general');
+    await roomPage.sendMessage('Initial message');
+
+    const generalRoomId = await getRoomIdByName(page, 'general');
+
+    // User B: Create account, join space, and sit in general — present and
+    // caught up, never navigating away.
+    const context2 = await browser!.newContext({ baseURL: serverURL });
+    const page2 = await context2.newPage();
+
+    try {
+      await createAndLoginTestUser(page2);
+      await joinSpace(page2);
+      await page2.goto(routes.space());
+      await page2.waitForURL(routes.patterns.anySpace);
+
+      const chatPage2 = new ChatPage(page2);
+      const roomPage2 = new RoomPage(page2);
+
+      await chatPage2.enterRoom('general');
+      await waitForRoomReady(page2, 'general');
+      await roomPage2.expectMessageVisible('Initial message');
+      await waitForRoomRead(page2, generalRoomId);
+
+      // No separator yet — User B has read everything.
+      await roomPage2.expectNoUnreadSeparator();
+
+      // User B's tab goes to the background. They stay in the room; presence
+      // just drops, which anchors the unread separator at the read cursor.
+      await page2.evaluate(() => {
+        Object.defineProperty(document, 'visibilityState', {
+          value: 'hidden',
+          writable: true,
+          configurable: true
+        });
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+
+      // User A posts while User B's tab is still hidden.
+      const awayMessage = `Posted while hidden ${Date.now()}`;
+      await roomPage.sendMessage(awayMessage);
+
+      // The message streams in over the live subscription, and because the
+      // separator was anchored the moment presence dropped, it shows up
+      // immediately — without User B having to navigate away and back.
+      await roomPage2.expectMessageVisible(awayMessage);
+      await roomPage2.expectUnreadSeparator();
+
+      // Re-focusing the tab refines the separator (clamps its upper bound)
+      // but must not blink it out — the anchor already matches the server's
+      // previousLastReadAt, so the marker stays put across the transition.
+      await page2.evaluate(() => {
+        Object.defineProperty(document, 'visibilityState', {
+          value: 'visible',
+          writable: true,
+          configurable: true
+        });
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+
+      await expect(async () => {
+        await roomPage2.expectUnreadSeparator();
+      }).toPass({ timeout: TIMEOUTS.UI_STANDARD, intervals: POLLING_INTERVALS });
+    } finally {
+      await context2.close();
+    }
+  });
+
+  test('backgrounding the tab does not strand the user own latest message below the separator', async ({
+    page,
+    chatPage,
+    roomPage,
+    browser,
+    serverURL
+  }) => {
+    test.setTimeout(60000); // Multi-user test needs more time
+
+    // User A: Create account and space, post an existing message in general.
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.createSpace('Own Message Hidden Tab Test');
+    const spaceId = await chatPage.getSpaceId();
+
+    await chatPage.enterRoom('general');
+    await waitForRoomReady(page, 'general');
+    await roomPage.sendMessage('Existing message from User A');
+
+    const generalRoomId = await getRoomIdByName(page, 'general');
+
+    // User B: Create account, join space, enter the (non-empty) room — this
+    // gives User B a real read cursor — then post their own message and
+    // background the tab.
+    const context2 = await browser!.newContext({ baseURL: serverURL });
+    const page2 = await context2.newPage();
+
+    try {
+      await createAndLoginTestUser(page2);
+      await joinSpace(page2);
+      await page2.goto(routes.space());
+      await page2.waitForURL(routes.patterns.anySpace);
+
+      const chatPage2 = new ChatPage(page2);
+      const roomPage2 = new RoomPage(page2);
+
+      await chatPage2.enterRoom('general');
+      await waitForRoomReady(page2, 'general');
+      await roomPage2.expectMessageVisible('Existing message from User A');
+      await waitForRoomRead(page2, generalRoomId);
+
+      // User B posts their own message. Posting auto-advances the read cursor
+      // server-side, so the client cursor must follow.
+      const ownMessage = `User B own message ${Date.now()}`;
+      await roomPage2.sendMessage(ownMessage);
+      await roomPage2.expectMessageVisible(ownMessage);
+      await waitForRoomRead(page2, generalRoomId);
+      await roomPage2.expectNoUnreadSeparator();
+
+      // User B's tab goes to the background — still in the room.
+      await page2.evaluate(() => {
+        Object.defineProperty(document, 'visibilityState', {
+          value: 'hidden',
+          writable: true,
+          configurable: true
+        });
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+
+      // The separator must not appear above User B's own latest message.
+      // Negative assertion — give events time to settle before asserting absence.
+      await expect(async () => {
+        await roomPage2.expectNoUnreadSeparator();
+      }).toPass({ timeout: TIMEOUTS.UI_STANDARD, intervals: POLLING_INTERVALS });
+    } finally {
+      await context2.close();
+    }
+  });
+
   test('no unread separator for own messages after posting and reloading', async ({
     page,
     chatPage,

--- a/frontend/src/lib/hooks/useRoomUnread.svelte.ts
+++ b/frontend/src/lib/hooks/useRoomUnread.svelte.ts
@@ -19,6 +19,11 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
   let unreadAfterTime = $state<string | null>(null);
   let unreadBeforeTime = $state<string | null>(null);
 
+  // The server's most recent read cursor (`lastReadAt`) for this room.
+  // Updated from every markRoomAsRead result; used to anchor the unread
+  // separator the instant the user leaves (see the presence-false edge).
+  let lastCursor: string | null = null;
+
   async function markRoomAsRead(targetRoomId: string, upToEventId?: string) {
     roomUnreadStore.setRoomUnread(targetRoomId, false);
 
@@ -37,19 +42,47 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
         )
         .toPromise();
 
-      return result.data?.markRoomAsRead ?? null;
+      const data = result.data?.markRoomAsRead ?? null;
+      if (data?.lastReadAt && getProps().roomId === targetRoomId) {
+        lastCursor = data.lastReadAt;
+      }
+      return data;
     } catch (err) {
       console.error('Failed to mark room as read:', err);
       return null;
     }
   }
 
+  /**
+   * Advance the tracked read cursor without issuing a mutation. Used when
+   * the read cursor moves server-side without a markRoomAsRead call from
+   * this hook — notably when the user posts their own message, since
+   * PostMessage auto-marks the room read on the server. Keeps the
+   * presence-false anchor accurate so backgrounding the tab doesn't strand
+   * the user's own latest message below the "new messages" separator.
+   */
+  function noteReadCursor(timestamp: string) {
+    const ts = new Date(timestamp).getTime();
+    if (lastCursor && ts <= new Date(lastCursor).getTime()) return;
+    lastCursor = timestamp;
+
+    // If this lands while the user is away — e.g. their own message's
+    // subscription event arrives just after they backgrounded the tab — the
+    // presence-false anchor was already set from a now-stale cursor. Advance
+    // it too, so their own message isn't stranded below the separator.
+    if (
+      !appState.isPresent &&
+      unreadAfterTime !== null &&
+      ts > new Date(unreadAfterTime).getTime()
+    ) {
+      unreadAfterTime = timestamp;
+    }
+  }
+
   // Fire markRoomAsRead on every presence-true edge (fresh entry OR
   // refocus/tab-reveal) and on room changes while present. The mutation
   // result drives the unread separator so a refocus shows what arrived
-  // while the user was away. Presence-out leaves the existing separator
-  // in place — it's the "you were away" boundary the user needs to see
-  // when they come back.
+  // while the user was away.
   let lastFiredRoomId = '';
   let wasPresent = false;
 
@@ -58,16 +91,36 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
     const present = appState.isPresent;
 
     if (!present) {
+      // Presence-false edge: anchor the unread separator at the current
+      // read cursor with no upper bound, so messages arriving while the
+      // user is away pile up below the marker in real time — it's already
+      // there the moment the tab comes back on-screen (or right away if
+      // the window is visible but unfocused). The presence-true edge below
+      // refines it on return.
+      if (wasPresent && lastCursor) {
+        unreadAfterTime = lastCursor;
+        unreadBeforeTime = null;
+      }
       wasPresent = false;
       return;
     }
 
     if (wasPresent && lastFiredRoomId === roomId) return;
+
+    const isRoomChange = lastFiredRoomId !== roomId;
     wasPresent = true;
     lastFiredRoomId = roomId;
 
-    unreadAfterTime = null;
-    unreadBeforeTime = null;
+    // On a room change, clear the previous room's separator so it can't
+    // flash in the new room while the mutation below is in flight. On a
+    // refocus of the *same* room, leave the existing separator in place —
+    // it was anchored on the presence-false edge and the mutation only
+    // refines its upper bound (previousLastReadAt matches the anchor), so
+    // clearing it here would blink the marker out and back in.
+    if (isRoomChange) {
+      unreadAfterTime = null;
+      unreadBeforeTime = null;
+    }
 
     markRoomAsRead(roomId).then((result) => {
       const current = getProps();
@@ -87,6 +140,7 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
     get unreadBeforeTime() {
       return unreadBeforeTime;
     },
-    markRoomAsRead
+    markRoomAsRead,
+    noteReadCursor
   };
 }

--- a/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/Room.svelte
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/Room.svelte
@@ -186,10 +186,14 @@
     }
   }
 
-  // Mark as read when new messages arrive from OTHER users while the user
-  // is actually present (focused + visible). The mutation passes the event
-  // ID explicitly so the server cursor matches what the client has rendered
-  // — no server-time race.
+  // Keep the read cursor in sync with incoming root messages:
+  // - Other users' messages mark the room read (with explicit event ID, so
+  //   the server cursor matches what the client rendered) while the user is
+  //   actually present (focused + visible).
+  // - The user's own posts already auto-mark the room read server-side, so
+  //   we just mirror that onto the local cursor — without it, backgrounding
+  //   the tab would strand the user's own latest message below the unread
+  //   separator.
   useEvent((event) => {
     if (!event.event) return;
 
@@ -198,13 +202,12 @@
         typingIndicator.removeTypingUser(event.actorId);
       }
 
-      if (
-        !event.event.inThread &&
-        currentUser.user &&
-        event.actorId !== currentUser.user.id &&
-        appState.isPresent
-      ) {
-        unread.markRoomAsRead(roomId, event.id);
+      if (!event.event.inThread && currentUser.user) {
+        if (event.actorId === currentUser.user.id) {
+          unread.noteReadCursor(event.createdAt);
+        } else if (appState.isPresent) {
+          unread.markRoomAsRead(roomId, event.id);
+        }
       }
     }
   });

--- a/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/ThreadPane.svelte
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/ThreadPane.svelte
@@ -238,6 +238,14 @@
     const present = appState.isPresent;
 
     if (!present) {
+      // Presence-false edge: anchor the unread separator at "now" with no
+      // upper bound so replies arriving while the user is away show up
+      // below the marker in real time, rather than only on return. The
+      // presence-true edge below refines it when the user comes back.
+      if (wasPresentThread) {
+        unreadAfterTime = new Date();
+        unreadBeforeTime = null;
+      }
       wasPresentThread = false;
       return;
     }


### PR DESCRIPTION
## What

Makes the **"New messages" separator** appear the instant you leave a room or thread — not when you come back.

## Why

The separator used to be a "welcome back" affordance: it only materialized once you re-focused the tab. But the natural mental model is the opposite — the line should already be drawn the moment you look away, so anything that arrives lands cleanly *below* it. If your window is just sitting unfocused on a second monitor, you now watch new messages stack up under the marker in real time.

## How

- **Anchor on the presence-false edge.** `useRoomUnread` now tracks the server read cursor; when the window blurs or the tab hides, it pins the separator there with no upper bound. `ThreadPane` mirrors the same behaviour for thread replies.
- **Keep the cursor honest for your own posts.** Posting a message auto-marks the room read server-side, but the client wasn't mirroring that — so backgrounding the tab right after sending would strand *your own* latest message below the separator. A new `noteReadCursor()` advances the cursor on own posts to fix this.
- **No more blink on refocus.** The separator is now only cleared on an actual room change, not on a same-room refocus — previously it flickered out and back in while the refresh mutation was in flight.

## Tests

New e2e coverage: the separator shows up while the tab is hidden (room **and** thread), survives refocus without blinking, and never strands your own message. All CI green.