### PR TITLE
fix(dev): colocate .svelte-kit with node_modules in compose stack

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -49,6 +49,12 @@ services:
       - ./frontend:/app
       # node_modules stays per-project: it's branch-specific, unlike the pnpm store.
       - node_modules:/app/node_modules
+      # Keep .svelte-kit colocated with node_modules in the container. If it
+      # lived on the host bind mount, the pnpm hash directories baked into
+      # .svelte-kit/generated/ would drift from the container's node_modules
+      # any time deps changed, breaking Vite HMR with "Failed to load url
+      # ../../../node_modules/.pnpm/..." errors.
+      - svelte-kit:/app/.svelte-kit
       - ${HOME}/.cache/chatto-dev/pnpm-store:/pnpm-store
 
 # We bind-mount the Go module cache, Go build cache, and pnpm store from
@@ -62,4 +68,5 @@ services:
 # host directories on first run.
 volumes:
   node_modules:
+  svelte-kit:
   chatto-data:


### PR DESCRIPTION
## Summary

Mounts a named volume at `/app/.svelte-kit` in the frontend service so the SvelteKit generated directory lives in the container next to `node_modules` instead of on the host bind mount.

## Context

When `.svelte-kit/generated/` sits on the host bind mount but `node_modules` lives in a container volume, the pnpm hash directories baked into `.svelte-kit/generated/server/internal.js` drift from the container's `node_modules` whenever deps change — Vite then fails HMR with `Failed to load url ../../../node_modules/.pnpm/...` pointing at a stale hash path. Colocating the two volumes prevents the drift entirely.

## Test plan

- [ ] `docker compose down && docker compose up` in a workspace and confirm the frontend starts cleanly.
- [ ] Make a backend or frontend change that previously triggered the stale-module error and verify HMR still works.