### PR TITLE
feat(natsauth): support TLS to NATS via CHATTO_NATS_CLIENT_CA_CERT

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -257,6 +257,7 @@ type NATSClientConfig struct {
 	Password        string         `toml:"password,commented" env:"CHATTO_NATS_CLIENT_PASSWORD" comment:"Password for userpass auth. NEVER SHARE THIS!"`
 	CredentialsFile string         `toml:"credentials_file,commented" env:"CHATTO_NATS_CLIENT_CREDENTIALS_FILE" comment:"Path to .creds file for credentials auth."`
 	NKeySeed        string         `toml:"nkey_seed,commented" env:"CHATTO_NATS_CLIENT_NKEY_SEED" comment:"NKey seed for nkey auth. NEVER SHARE THIS!"`
+	CACert          string         `toml:"ca_cert,commented" env:"CHATTO_NATS_CLIENT_CA_CERT" comment:"PEM-encoded CA certificate for verifying the NATS server's TLS cert. When set, the connection uses TLS."`
 }
 
 // NATSAuthConfig returns the auth configuration suitable for natsauth.ConnectOptions.
@@ -268,6 +269,7 @@ func (c *NATSClientConfig) NATSAuthConfig() natsauth.Config {
 		Password:        c.Password,
 		CredentialsFile: c.CredentialsFile,
 		NKeySeed:        c.NKeySeed,
+		CACert:          c.CACert,
 	}
 }
 

--- a/cli/pkg/natsauth/natsauth.go
+++ b/cli/pkg/natsauth/natsauth.go
@@ -1,8 +1,11 @@
 // Package natsauth provides authentication option builders for NATS connections.
-// It supports token, username/password, credentials file, and NKey authentication.
+// It supports token, username/password, credentials file, and NKey authentication,
+// plus optional TLS with a custom CA.
 package natsauth
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 
 	"github.com/nats-io/nats.go"
@@ -15,12 +18,12 @@ type AuthMethod string
 const (
 	AuthNone        AuthMethod = "none"        // No authentication
 	AuthToken       AuthMethod = "token"       // Simple bearer token
-	AuthUserPass    AuthMethod = "userpass"     // Username/password
+	AuthUserPass    AuthMethod = "userpass"    // Username/password
 	AuthCredentials AuthMethod = "credentials" // JWT credentials file
-	AuthNKey        AuthMethod = "nkey"         // NKey seed
+	AuthNKey        AuthMethod = "nkey"        // NKey seed
 )
 
-// Config holds the parameters needed to build NATS authentication options.
+// Config holds the parameters needed to build NATS authentication + TLS options.
 type Config struct {
 	AuthMethod      AuthMethod
 	Token           string
@@ -28,10 +31,34 @@ type Config struct {
 	Password        string
 	CredentialsFile string
 	NKeySeed        string
+
+	// CACert is a PEM-encoded CA certificate used to verify the NATS server's
+	// TLS certificate. When non-empty, a nats.Secure option is added to the
+	// connection. When empty, no TLS option is added — the connection uses
+	// system defaults (which kick in automatically if the URL is tls://).
+	CACert string
 }
 
-// ConnectOptions returns NATS connection options for the given auth configuration.
+// ConnectOptions returns NATS connection options for the given auth + TLS configuration.
 func ConnectOptions(cfg Config) ([]nats.Option, error) {
+	opts, err := authOptions(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.CACert != "" {
+		tlsOpt, err := tlsOption(cfg.CACert)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, tlsOpt)
+	}
+
+	return opts, nil
+}
+
+// authOptions returns the auth-method-specific connection options.
+func authOptions(cfg Config) ([]nats.Option, error) {
 	switch cfg.AuthMethod {
 	case AuthNone, "":
 		return nil, nil
@@ -67,6 +94,18 @@ func ConnectOptions(cfg Config) ([]nats.Option, error) {
 	default:
 		return nil, fmt.Errorf("nats auth: unknown method %q", cfg.AuthMethod)
 	}
+}
+
+// tlsOption builds a nats.Secure option from a PEM-encoded CA certificate.
+func tlsOption(caPEM string) (nats.Option, error) {
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM([]byte(caPEM)) {
+		return nil, fmt.Errorf("nats auth: parsing CA cert PEM")
+	}
+	return nats.Secure(&tls.Config{
+		RootCAs:    pool,
+		MinVersion: tls.VersionTLS12,
+	}), nil
 }
 
 // nkeyOption creates a NATS option for NKey authentication.

--- a/cli/pkg/natsauth/natsauth_test.go
+++ b/cli/pkg/natsauth/natsauth_test.go
@@ -1,9 +1,17 @@
 package natsauth_test
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"hmans.de/chatto/pkg/natsauth"
 )
@@ -140,6 +148,67 @@ func TestConnectOptions(t *testing.T) {
 			t.Fatal("expected error for unknown method")
 		}
 	})
+
+	t.Run("ca cert with token method returns auth + tls options", func(t *testing.T) {
+		opts, err := natsauth.ConnectOptions(natsauth.Config{
+			AuthMethod: natsauth.AuthToken,
+			Token:      "tok",
+			CACert:     makeCAPEM(t),
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(opts) != 2 {
+			t.Errorf("expected 2 options (auth + tls), got %d", len(opts))
+		}
+	})
+
+	t.Run("ca cert without auth returns tls option only", func(t *testing.T) {
+		opts, err := natsauth.ConnectOptions(natsauth.Config{
+			CACert: makeCAPEM(t),
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(opts) != 1 {
+			t.Errorf("expected 1 option (tls only), got %d", len(opts))
+		}
+	})
+
+	t.Run("invalid ca cert pem returns error", func(t *testing.T) {
+		_, err := natsauth.ConnectOptions(natsauth.Config{
+			CACert: "not a real pem",
+		})
+		if err == nil {
+			t.Fatal("expected error for invalid PEM")
+		}
+	})
+}
+
+// makeCAPEM returns a self-signed PEM-encoded CA certificate for use in TLS tests.
+// AppendCertsFromPEM only does basic PEM-decode + ASN.1 parsing, so the cert's
+// trust chain / expiry is irrelevant here — we're testing that natsauth wires
+// the CA into a nats.Secure option, not that TLS actually validates against it.
+func makeCAPEM(t *testing.T) string {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
 }
 
 func TestGenerateUserNKey(t *testing.T) {


### PR DESCRIPTION
## What

Adds optional TLS support to the chatto NATS client via a new `CHATTO_NATS_CLIENT_CA_CERT` env var (PEM content). When set, `natsauth.ConnectOptions` appends a `nats.Secure(*tls.Config{RootCAs: pool, MinVersion: TLS12})` option to the connection.

All existing call sites (`backup.go`, `keys.go`, `reset.go`, `restore.go`, `run.go`) work unchanged — they all route through `natsauth.ConnectOptions(cfg.NATS.Client.NATSAuthConfig())`, so they pick up the TLS option automatically when the env var is set.

## Why

The new `chattocorp/chatto-eu1` production cluster runs a shared NATS cluster in operator/JWT mode with TLS termination on the server. `chatto-operator` (post-refactor) writes the CA cert into each tenant's config secret as `CHATTO_NATS_CLIENT_CA_CERT`. Without this change, chatto pods on that cluster can't verify the server's certificate.

## Backward compatibility

Purely additive:

- `CACert` is a new optional field on `NATSClientConfig` and `natsauth.Config`, defaulting to the empty string.
- When empty (e.g. the existing dev cluster, embedded-NATS deployments, any chatto.toml without `ca_cert`), `ConnectOptions` returns the exact same options as before — the `if cfg.CACert != ""` branch is the only new code path.
- No fields renamed, no fields removed. Old `chatto.toml` files and existing env-var sets work unchanged.

## Verification

`mise test-cli` green across 16 packages (~65s total). New subtests in `cli/pkg/natsauth/natsauth_test.go`:

- `ca cert with token method returns auth + tls options` — exercises the combined path.
- `ca cert without auth returns tls option only` — TLS without auth.
- `invalid ca cert pem returns error` — error path.

A small `makeCAPEM(t)` helper generates a self-signed ECDSA cert at runtime so the test isn't bound to an expiring hardcoded PEM.
