### PR TITLE
fix(frontend): keep dialog open when drag starts inside and ends outside

### DIFF
--- a/frontend/src/lib/ui/Dialog.svelte
+++ b/frontend/src/lib/ui/Dialog.svelte
@@ -23,6 +23,9 @@
 
   let dialogEl: HTMLDialogElement | undefined = $state();
   let closing = $state(false);
+  // True when the current press started inside the content. Prevents a drag
+  // that began inside (e.g. text selection) from closing on release outside.
+  let pressStartedInside = false;
 
   // Stable per-instance id for the title (so screen readers announce it
   // when the dialog opens). $props.id() is hydration-safe.
@@ -94,12 +97,15 @@
     e.preventDefault();
     close();
   }}
+  onpointerdown={(e) => {
+    pressStartedInside = e.target !== dialogEl;
+  }}
   onclick={(e) => {
     // Synthetic clicks (Enter/Space on a focused button, programmatic
     // .click(), implicit form submission) have detail=0 and clientX/Y=0,
     // which would otherwise be misread as a click on the backdrop. Only
     // real pointer clicks should dismiss the dialog.
-    if (e.detail === 0) return;
+    if (e.detail === 0 || pressStartedInside) return;
     // Use coordinate check instead of e.target to handle mobile keyboard viewport shifts
     const content = dialogEl?.firstElementChild as HTMLElement | null;
     if (!content) return;

--- a/frontend/src/lib/ui/Dialog.svelte.spec.ts
+++ b/frontend/src/lib/ui/Dialog.svelte.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from 'vitest-browser-svelte';
+import { flushSync } from 'svelte';
 import Dialog from './Dialog.svelte';
 import { q, testSnippet } from '$lib/test-utils';
 
@@ -215,6 +216,86 @@ describe('Dialog', () => {
       expect(dialog.open).toBe(true);
       // And no exit animation should have started.
       expect(dialog.classList.contains('closing')).toBe(false);
+    });
+
+    it('does not close when pointerdown is inside but pointerup is on the backdrop', async () => {
+      // Reproduces the text-selection drag: user presses inside the dialog
+      // (e.g. starting a selection on a label), drags out, and releases on
+      // the backdrop. The native `click` fires on mouseup with backdrop
+      // coordinates — but it should not close the dialog.
+      const { container } = renderDialog({
+        visible: true,
+        children: testSnippet('<span data-testid="label">Hello there</span>')
+      });
+
+      const dialog = q(container, 'dialog') as HTMLDialogElement;
+      const label = q(container, '[data-testid="label"]') as HTMLElement;
+      const content = dialog.firstElementChild as HTMLElement;
+      const rect = content.getBoundingClientRect();
+      // Past the right/bottom edges is reliably "outside" regardless of where
+      // the dialog ends up positioned in the test viewport.
+      const outsideX = rect.right + 20;
+      const outsideY = rect.bottom + 20;
+
+      expect(dialog.open).toBe(true);
+
+      // pointerdown fires on the inner element the user pressed on (in real
+      // usage that's the source of truth for "where the press started").
+      label.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+      dialog.dispatchEvent(
+        new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+          detail: 1,
+          clientX: outsideX,
+          clientY: outsideY
+        })
+      );
+
+      await new Promise((r) => setTimeout(r, 200));
+
+      expect(dialog.open).toBe(true);
+      expect(dialog.classList.contains('closing')).toBe(false);
+    });
+
+    it('closes when both pointerdown and click are on the backdrop', async () => {
+      const { container } = renderDialog({
+        visible: true,
+        children: testSnippet('<span>Content</span>')
+      });
+
+      const dialog = q(container, 'dialog') as HTMLDialogElement;
+      const content = dialog.firstElementChild as HTMLElement;
+      const rect = content.getBoundingClientRect();
+      const outsideX = rect.right + 20;
+      const outsideY = rect.bottom + 20;
+
+      expect(dialog.open).toBe(true);
+
+      dialog.dispatchEvent(
+        new PointerEvent('pointerdown', {
+          bubbles: true,
+          cancelable: true,
+          clientX: outsideX,
+          clientY: outsideY
+        })
+      );
+      dialog.dispatchEvent(
+        new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+          detail: 1,
+          clientX: outsideX,
+          clientY: outsideY
+        })
+      );
+
+      // Flush so the `closing` $state mutation reaches the DOM before we
+      // assert on the class. The actual close fires after a 100ms animation.
+      flushSync();
+      expect(dialog.classList.contains('closing')).toBe(true);
+      await new Promise((r) => setTimeout(r, 200));
+      expect(dialog.open).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

Marking text inside a dialog and releasing the mouse over the backdrop was misread as a backdrop click and closed the dialog. The dialog now tracks whether the press started inside (via `pointerdown`) and skips the close path on the resulting `click`. Real backdrop clicks (press *and* release on the backdrop) still dismiss as before.

## Test plan

- [x] `Dialog.svelte.spec.ts` covers both the new "drag started inside, released outside" case and the unchanged "real backdrop click closes" case
- [ ] Manually verify in-browser: select text in a dialog and release outside → dialog stays open; click empty backdrop → dialog closes