### PR TITLE
chore(conductor): rebuild images on run

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
     "scripts": {
-        "run": "docker compose up",
+        "run": "docker compose up --build",
         "archive": "docker compose down -v"
     }
 }


### PR DESCRIPTION
## Summary
- Update the Conductor `run` script to `docker compose up --build` so workspaces always rebuild instead of starting from a stale image.

## Test plan
- [ ] Launch a Conductor workspace and confirm images are rebuilt on start