### PR TITLE
feat(dev): restore frontend hot reload via separate Vite service

### DIFF
--- a/Dockerfile.frontend.compose
+++ b/Dockerfile.frontend.compose
@@ -1,0 +1,18 @@
+# Dev image for the frontend service in compose.yml.
+#
+# Bakes `pnpm install` into a layer keyed on package.json + pnpm-lock.yaml so
+# fresh Conductor worktrees don't have to re-link node_modules from the pnpm
+# store on every `compose up`. The empty per-project `node_modules` named
+# volume is pre-populated from the image's /app/node_modules on first mount.
+#
+# Build context: ./frontend
+
+FROM node:22-alpine
+RUN corepack enable pnpm
+WORKDIR /app
+
+# Deps layer — invalidated only when the lockfile or package.json changes.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+RUN pnpm install --frozen-lockfile
+
+# Source is bind-mounted at runtime; nothing to COPY here.

--- a/compose.yml
+++ b/compose.yml
@@ -3,9 +3,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.compose
-    labels:
-      dev.orbstack.http-port: 4000
-      dev.orbstack.domains: ${COMPOSE_PROJECT_NAME}.orb.local
     environment:
       CHATTO_WEBSERVER_URL: https://${COMPOSE_PROJECT_NAME}.orb.local
       # Shared dev infrastructure runs in OrbStack's Kubernetes (see the
@@ -23,5 +20,33 @@ services:
     volumes:
       - chatto-data:/app/data
 
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: ../Dockerfile.frontend.compose
+    working_dir: /app
+    labels:
+      dev.orbstack.http-port: 5173
+      dev.orbstack.domains: ${COMPOSE_PROJECT_NAME}.orb.local
+    # `pnpm install` is baked into the image (see Dockerfile.frontend.compose);
+    # the node_modules named volume is pre-populated from the image on first
+    # attach, so fresh worktrees don't re-link from the pnpm store at startup.
+    command: pnpm dev --host
+    environment:
+      CHATTO_BACKEND_URL: http://app:4000
+    volumes:
+      - ./frontend:/app
+      # node_modules stays per-project: it's branch-specific, unlike the pnpm store.
+      - node_modules:/app/node_modules
+      # Keep .svelte-kit colocated with node_modules in the container. If it
+      # lived on the host bind mount, the pnpm hash directories baked into
+      # .svelte-kit/generated/ would drift from the container's node_modules
+      # any time deps changed, breaking Vite HMR with "Failed to load url
+      # ../../../node_modules/.pnpm/..." errors.
+      - svelte-kit:/app/.svelte-kit
+      - ${HOME}/.cache/chatto-dev/pnpm-store:/pnpm-store
+
 volumes:
+  node_modules:
+  svelte-kit:
   chatto-data:


### PR DESCRIPTION
## Summary

- Re-adds a `frontend` compose service that runs `pnpm dev --host` against a bind-mounted source tree, restoring Vite HMR that was lost in #471 when the stack collapsed to a single production-binary container.
- OrbStack labels move from `app` to `frontend`; Vite proxies `/api` and `/playground` to the backend container at `app:4000`, and the backend stays as the production binary built by `Dockerfile.compose` (no hot reload there, by design).
- Recreates `Dockerfile.frontend.compose` so `pnpm install` is baked into a lockfile-keyed layer, with named volumes for `node_modules` / `.svelte-kit` and the shared host pnpm-store cache.

## Test plan

- [ ] `docker compose up --build` boots both services and `${COMPOSE_PROJECT_NAME}.orb.local` serves the Vite dev frontend.
- [ ] Editing a `.svelte` file under `frontend/src/` triggers HMR without a full page reload.
- [ ] `/api/graphql` and `/playground` continue to work through the Vite proxy.