### PR TITLE
fix(frontend): keep top margin on leading blockquote in messages

### DIFF
--- a/frontend/src/prose.css
+++ b/frontend/src/prose.css
@@ -29,6 +29,13 @@
     margin-top: 0;
   }
 
+  /* Blockquotes keep their top margin even as the first child, so the
+     left border has breathing room from whatever sits above (e.g. the
+     message header). */
+  & > blockquote:first-child {
+    margin-top: 0.25em;
+  }
+
   /* Links */
   & a {
     color: var(--color-link);


### PR DESCRIPTION
## Summary
- Preserve a small top margin on `blockquote` when it's the first child of a `.prose` block, so the left border has breathing room beneath the message header instead of butting up against it.

## Test plan
- [ ] Post a message that starts with a `> blockquote` and confirm the quote sits cleanly below the username/timestamp row.