### PR TITLE
fix(frontend): avoid full reload when clicking push notifications

### DIFF
--- a/frontend/src/lib/notifications/pushNotifications.ts
+++ b/frontend/src/lib/notifications/pushNotifications.ts
@@ -214,3 +214,23 @@ export function onSubscriptionChange(callback: () => void): () => void {
   navigator.serviceWorker.addEventListener('message', handler);
   return () => navigator.serviceWorker.removeEventListener('message', handler);
 }
+
+/**
+ * Listen for notification-click messages from the service worker.
+ * The SW posts these instead of calling `WindowClient.navigate()` so the
+ * SPA can route via `goto()` (client-side navigation, no full reload).
+ */
+export function onNotificationClick(callback: (url: string) => void): () => void {
+  if (!('serviceWorker' in navigator)) {
+    return () => {};
+  }
+
+  const handler = (event: MessageEvent) => {
+    if (event.data?.type === 'notification-click' && typeof event.data.url === 'string') {
+      callback(event.data.url);
+    }
+  };
+
+  navigator.serviceWorker.addEventListener('message', handler);
+  return () => navigator.serviceWorker.removeEventListener('message', handler);
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  import { afterNavigate } from '$app/navigation';
+  import { afterNavigate, goto } from '$app/navigation';
   import { page } from '$app/state';
+  import { onNotificationClick } from '$lib/notifications/pushNotifications';
   import SpaceList from '$lib/SpaceList.svelte';
   import ConnectionIndicator from '$lib/components/ConnectionIndicator.svelte';
   import ConnectionProvider from '$lib/components/ConnectionProvider.svelte';
@@ -79,6 +80,21 @@
       }
     }
   });
+
+  // Route push-notification clicks via SvelteKit's client-side navigation
+  // instead of letting the SW do a full document navigation. Same-URL
+  // clicks become a no-op; cross-URL clicks just update the route.
+  $effect(() =>
+    onNotificationClick((url) => {
+      try {
+        const target = new URL(url);
+        if (target.origin !== window.location.origin) return;
+        void goto(target.pathname + target.search + target.hash);
+      } catch {
+        // Ignore malformed URLs from the SW.
+      }
+    })
+  );
 
   // Sidebar
   $effect(() => sidebarNav.initViewportTracking());

--- a/frontend/src/service-worker.ts
+++ b/frontend/src/service-worker.ts
@@ -81,7 +81,9 @@ self.addEventListener('push', (event) => {
 
 /**
  * Handle notification clicks.
- * Focus an existing window/tab or open a new one, then navigate to the notification's URL.
+ * Prefer postMessage to an already-open client so the SPA can route via
+ * `goto()` (no full reload). Fall back to `WindowClient.navigate()` or
+ * `openWindow()` when no client is open or messaging fails.
  */
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();
@@ -105,22 +107,32 @@ self.addEventListener('notificationclick', (event) => {
         includeUncontrolled: true
       });
 
-      // Try to focus an existing window and navigate
+      // Prefer postMessage to an existing client — the SPA listener handles
+      // navigation via goto(), avoiding a full document reload when the user
+      // is already on the target URL (or anywhere in the SPA).
       for (const client of clientList) {
         if ('focus' in client) {
           try {
             const focusedClient = await client.focus();
-            if (focusedClient && 'navigate' in focusedClient) {
-              const navigatedClient = await (focusedClient as WindowClient).navigate(url);
+            if (focusedClient) {
+              focusedClient.postMessage({ type: 'notification-click', url });
+              return;
+            }
+          } catch (err) {
+            console.warn('[SW] Failed to focus existing window:', err);
+          }
+          // Focus didn't yield a client — fall back to navigate().
+          try {
+            if ('navigate' in client) {
+              const navigatedClient = await (client as WindowClient).navigate(url);
               if (navigatedClient) {
-                return; // Success!
+                return;
               }
             }
           } catch (err) {
             console.warn('[SW] Failed to navigate existing window:', err);
-            // Continue to fallback
           }
-          break; // Only try the first focusable client
+          break;
         }
       }
 


### PR DESCRIPTION
## Summary

Clicking a push notification (e.g. for a DM) used to reload the entire SPA — even when the user was already on the target URL — because the service worker's `WindowClient.navigate(url)` always triggers a full document navigation.

The SW now `postMessage`s `{ type: 'notification-click', url }` to an existing client; the root layout listens and routes via SvelteKit's `goto()` for client-side navigation (same-URL clicks become a no-op). `WindowClient.navigate()` and `openWindow()` remain as fallbacks when no client is open or focus fails.

## Test plan

- [ ] Click a DM push notification while already viewing that DM — no reload, no UI flash
- [ ] Click a DM push notification while on another room — route changes client-side
- [ ] Click a push notification with the app fully closed — opens a new window at the target URL