### PR TITLE
refactor(frontend): drop hardcoded DM_PERMISSIONS in Room.svelte

### DIFF
--- a/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/Room.svelte
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/Room.svelte
@@ -62,19 +62,7 @@
   const unread = useRoomUnread(() => ({ roomId }));
 
   // Room permissions — derived reactively, no $effect needed
-  const DM_PERMISSIONS = {
-    canPostMessage: true,
-    canPostInThread: false,
-    canReply: true,
-    canReact: true,
-    canManageOthersMessage: false
-  } as const;
-
-  let permissions = $derived.by(() => {
-    if (room.isDM && room.dmData) return DM_PERMISSIONS;
-    if (room.roomData) return room.roomData;
-    return DEFAULT_ROOM_PERMISSIONS;
-  });
+  let permissions = $derived(room.roomData ?? DEFAULT_ROOM_PERMISSIONS);
 
   createRoomPermissions(() => permissions);
 


### PR DESCRIPTION
## Summary

- The server's `Room.viewerCan*` resolvers already return correct permissions for DM rooms — they call `core.Can*(…, KindForSpace(obj.SpaceId), …)`, and the permission resolver applies `dmBoundaryDeniedPermissions` (privacy + category-mismatch denies) for the DM kind.
- `useRoomData` already queries those fields for every room regardless of type, but `Room.svelte` was discarding them for DMs and substituting a hardcoded `DM_PERMISSIONS` object.
- This PR drops the hardcoded constant and the DM branch so DMs use the server-returned permissions like channel rooms do.

Closes #80.

## Test plan

- [x] `pnpm check` — 0 errors / 0 warnings
- [ ] Manual: post / reply / react in a DM still works; thread reply UI is correctly absent in DMs