### PR TITLE
chore(dev): rename dev bootstrap owner to admin, set shared password

### DIFF
--- a/Dockerfile.compose
+++ b/Dockerfile.compose
@@ -1,6 +1,6 @@
 # Dev image for `docker compose up`. Builds the same production binary
 # `goreleaser` ships, but with the `bootstrap` tag so cli/chatto.toml's
-# [bootstrap] section seeds dev users (devuser / alice / bob) on startup.
+# [bootstrap] section seeds dev users (admin / alice / bob) on startup.
 #
 # Single container: the SvelteKit frontend is built and embedded into the
 # Go binary, so there's no separate dev server and no live reload.

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ https://instance-name.orb.local/
 
 Each instance is bootstrapped with the same dev credentials (configured in `compose.yml`):
 
-- **Login:** `devuser`
-- **Email:** `dev@dev.com`
-- **Password:** `devpassword`
+- **Login:** `admin`
+- **Email:** `admin@dev.com`
+- **Password:** `foobar123`
 
 ## Instructions for Coding Agents
 

--- a/cli/chatto.toml
+++ b/cli/chatto.toml
@@ -58,23 +58,23 @@ auth_token = 'd5ed70d13c4682609dfd0a4f65bf7e59ef22f3be8502762b501d3b7cf0b73b43'
 # entries that already exist are left alone. Plaintext passwords are fine
 # because release binaries don't compile this code path.
 [[bootstrap.users]]
-login = 'devuser'
-display_name = 'Dev User'
-email = 'dev@dev.com'
-password = 'devpassword'
+login = 'admin'
+display_name = 'Admin'
+email = 'admin@dev.com'
+password = 'foobar123'
 instance_role = 'owner'
 
 [[bootstrap.users]]
 login = 'alice'
 display_name = 'Alice'
 email = 'alice@example.com'
-password = 'devpassword'
+password = 'foobar123'
 
 [[bootstrap.users]]
 login = 'bob'
 display_name = 'Bob'
 email = 'bob@example.com'
-password = 'devpassword'
+password = 'foobar123'
 
 [bootstrap.instance]
 name = 'Local Development'

--- a/compose.yml
+++ b/compose.yml
@@ -13,7 +13,7 @@ services:
       CHATTO_LIVEKIT_URL: wss://livekit.k8s.orb.local
       CHATTO_LIVEKIT_API_KEY: devkey
       CHATTO_LIVEKIT_API_SECRET: devsecret
-      # Dev bootstrap (devuser, dev@dev.com, devpassword, plus alice/bob and
+      # Dev bootstrap (admin, admin@dev.com, foobar123, plus alice/bob and
       # the Local Development/Lounge spaces) is declared in cli/chatto.toml
       # under [bootstrap]. The image is built with `-tags bootstrap`, so the
       # binary applies it on startup; release binaries ignore the section.


### PR DESCRIPTION
## Summary

- Renames the bootstrapped owner user from `devuser` / `dev@dev.com` to `admin` / `admin@dev.com` in `cli/chatto.toml`.
- Sets the password for all three dev users (`admin`, `alice`, `bob`) to `foobar123`.
- Updates `README.md`, `compose.yml`, and `Dockerfile.compose` references to match.

Existing dev instances already seeded with `devuser` won't change — bootstrap is idempotent on existing logins, so wipe the `chatto-data` volume to re-seed.

## Test plan

- [ ] Fresh `docker compose up` lets you log in as `admin` / `foobar123`.
- [ ] `alice` and `bob` can log in with `foobar123`.