### PR TITLE
chore(dev): drop blocked 'admin' bootstrap user, promote alice to owner

### DIFF
--- a/Dockerfile.compose
+++ b/Dockerfile.compose
@@ -1,6 +1,6 @@
 # Dev image for `docker compose up`. Builds the same production binary
 # `goreleaser` ships, but with the `bootstrap` tag so cli/chatto.toml's
-# [bootstrap] section seeds dev users (admin / alice / bob) on startup.
+# [bootstrap] section seeds dev users (alice / bob) on startup.
 #
 # Single container: the SvelteKit frontend is built and embedded into the
 # Go binary, so there's no separate dev server and no live reload.

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ https://instance-name.orb.local/
 
 Each instance is bootstrapped with the same dev credentials (configured in `compose.yml`):
 
-- **Login:** `admin`
-- **Email:** `admin@dev.com`
+- **Login:** `alice`
+- **Email:** `alice@example.com`
 - **Password:** `foobar123`
 
 ## Instructions for Coding Agents

--- a/cli/chatto.toml
+++ b/cli/chatto.toml
@@ -58,17 +58,11 @@ auth_token = 'd5ed70d13c4682609dfd0a4f65bf7e59ef22f3be8502762b501d3b7cf0b73b43'
 # entries that already exist are left alone. Plaintext passwords are fine
 # because release binaries don't compile this code path.
 [[bootstrap.users]]
-login = 'admin'
-display_name = 'Admin'
-email = 'admin@dev.com'
-password = 'foobar123'
-instance_role = 'owner'
-
-[[bootstrap.users]]
 login = 'alice'
 display_name = 'Alice'
 email = 'alice@example.com'
 password = 'foobar123'
+instance_role = 'owner'
 
 [[bootstrap.users]]
 login = 'bob'

--- a/compose.yml
+++ b/compose.yml
@@ -13,8 +13,8 @@ services:
       CHATTO_LIVEKIT_URL: wss://livekit.k8s.orb.local
       CHATTO_LIVEKIT_API_KEY: devkey
       CHATTO_LIVEKIT_API_SECRET: devsecret
-      # Dev bootstrap (admin, admin@dev.com, foobar123, plus alice/bob and
-      # the Local Development/Lounge spaces) is declared in cli/chatto.toml
+      # Dev bootstrap (alice as owner + bob, both with password foobar123,
+      # plus the Local Development/Lounge spaces) is declared in cli/chatto.toml
       # under [bootstrap]. The image is built with `-tags bootstrap`, so the
       # binary applies it on startup; release binaries ignore the section.
     volumes:


### PR DESCRIPTION
## Summary

#491 renamed the dev bootstrap owner to `admin`, but `admin` is in `DefaultBlockedUsernames` (`cli/internal/core/config_manager.go:216`), so `CreateUser` rejected it with `ErrUsernameBlocked` and the bootstrap silently logged-and-skipped — alice/bob seeded fine, but `admin` was never created. This PR drops the `admin` entry from `cli/chatto.toml` and promotes `alice` to `instance_role = 'owner'`, and updates the `README.md`, `compose.yml`, and `Dockerfile.compose` references to match.

Existing dev volumes don't need to be wiped — `applyBootstrapUser` re-applies the role to existing users, so a stack restart upgrades alice on the next boot.

## Test plan

- [ ] Fresh `docker compose up` lets you log in as `alice` / `foobar123` and reach the admin UI (owner-only).
- [ ] `bob` can log in with `foobar123`.
- [ ] On an existing dev volume (where alice was previously seeded as a plain member), restarting the stack promotes alice to owner without a `down -v`.