### PR TITLE
style(frontend): refresh accent palette and tighten UI polish

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -43,11 +43,11 @@
   --color-input: var(--color-white);
   --color-input-border: var(--color-gray-300);
 
-  --color-accent: var(--color-violet-600);
+  --color-accent: var(--color-sky-600);
   --color-primary: #64748b;
   --color-primary-hover: #475569;
-  --color-link: var(--color-sky-600);
-  --color-link-hover: var(--color-sky-700);
+  --color-link: var(--color-accent);
+  --color-link-hover: color-mix(in srgb, var(--color-accent), black 20%);
   --color-success: var(--color-green-600);
   --color-warning: var(--color-amber-600);
   --color-danger: var(--color-red-600);
@@ -83,11 +83,11 @@
   --color-input: var(--color-neutral-950);
   --color-input-border: var(--color-neutral-700);
 
-  --color-accent: var(--color-violet-400);
+  --color-accent: var(--color-sky-400);
   --color-primary: var(--color-neutral-600);
   --color-primary-hover: var(--color-neutral-500);
-  --color-link: var(--color-sky-400);
-  --color-link-hover: var(--color-sky-300);
+  --color-link: var(--color-accent);
+  --color-link-hover: color-mix(in srgb, var(--color-accent), white 20%);
   --color-success: var(--color-green-500);
   --color-warning: var(--color-amber-500);
   --color-danger: var(--color-red-400);
@@ -134,7 +134,7 @@
  * via opacity.
  */
 @utility btn {
-  @apply inline-flex cursor-pointer items-center gap-1.5 rounded-lg px-4 py-2 font-medium;
+  @apply inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-lg px-4 py-2 font-medium;
   @apply transition-all duration-150;
   @apply disabled:cursor-not-allowed disabled:opacity-50;
 }
@@ -191,7 +191,7 @@
 
 /* Form input utilities */
 @utility input {
-  @apply w-full rounded-lg border border-input-border bg-input px-2 py-1 text-text;
+  @apply w-full rounded-lg border border-input-border bg-input px-3 py-2 text-text;
   @apply placeholder:text-muted/70;
   @apply transition-[border-color,box-shadow] duration-100;
   @apply focus:border-accent focus:ring-2 focus:ring-accent/30 focus:outline-none;
@@ -217,7 +217,7 @@
   @apply text-sm text-error;
 }
 
-/* Inline link — accent (violet) tint with hover underline. The `primary`
+/* Inline link — accent (sky) tint with hover underline. The `primary`
  * design token is slate/neutral and would render links indistinguishable
  * from body copy; accent is the canonical link color. */
 @utility link {

--- a/frontend/src/lib/ui/Dialog.svelte
+++ b/frontend/src/lib/ui/Dialog.svelte
@@ -146,7 +146,7 @@
           <button
             type="button"
             onclick={close}
-            class="-m-1 shrink-0 cursor-pointer rounded p-1 text-text/50 transition-colors hover:bg-surface-200 hover:text-text"
+            class="-m-1 shrink-0 cursor-pointer rounded p-1 text-text/50 transition-colors hover:text-text"
             aria-label="Close"
           >
             <span class="iconify text-xl uil--times"></span>

--- a/frontend/src/lib/ui/Utilities.stories.svelte
+++ b/frontend/src/lib/ui/Utilities.stories.svelte
@@ -11,7 +11,7 @@
   <div class="flex flex-col gap-3">
     <p class="text-sm text-muted max-w-prose">
       Inline link styling. <code>link</code> applies <code>text-accent hover:underline</code> —
-      violet (our accent tone) so links stand out against the slate/neutral body copy, with an
+      sky (our accent tone) so links stand out against the slate/neutral body copy, with an
       underline only on hover for a quiet resting state. Use this anywhere an <code>&lt;a&gt;</code>
       should read as a link in body or chrome text.
     </p>

--- a/frontend/src/lib/ui/form/Button.svelte
+++ b/frontend/src/lib/ui/form/Button.svelte
@@ -4,7 +4,7 @@
 
   let {
     type = 'button',
-    variant = 'primary',
+    variant = 'accent',
     size = 'md',
     loading = false,
     disabled = false,

--- a/frontend/src/lib/ui/form/FormField.svelte
+++ b/frontend/src/lib/ui/form/FormField.svelte
@@ -25,7 +25,11 @@
     so the label baseline aligns with the input's value text.
   -->
   <label for={id} class="px-2 text-sm font-medium text-muted">
-    {label}{#if required}<span class="ml-0.5 text-error">*</span>{/if}
+    {label}{#if required}<span
+        class="iconify uil--asterisk ml-1 align-middle text-[0.7em] text-accent"
+        aria-hidden="true"
+        title="Required"
+      ></span>{/if}
   </label>
 
   {@render children()}

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -159,11 +159,15 @@
       <!-- SSO providers -->
       {#if enabledProviders.includes('oidc')}
         <div class="flex flex-col gap-3">
-          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- /auth/oidc is a backend route, not a SvelteKit route -->
-          <a href="/auth/oidc?redirect={encodeURIComponent(data.redirectUrl)}" class="flex cursor-pointer items-center justify-center gap-3 rounded-lg border border-border bg-white px-4 py-3 font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700">
+          <Button
+            variant="secondary"
+            size="lg"
+            fullWidth
+            href="/auth/oidc?redirect={encodeURIComponent(data.redirectUrl)}"
+          >
             <span class="iconify text-lg mdi--shield-account"></span>
-            <span>Continue with Chatto Hub</span>
-          </a>
+            Continue with Chatto Hub
+          </Button>
 
           <Divider label="or" />
         </div>


### PR DESCRIPTION
## Summary

- Accent color: violet → sky. \`--color-link\` (and its hover) now derives from \`--color-accent\` via \`color-mix\`, so prose-link hover shading follows whatever accent is set.
- Form polish: input/textarea padding bumped from \`px-2 py-1\` to \`px-3 py-2\`; the required-field marker is now a \`uil-asterisk\` icon in the accent color instead of a typographic red asterisk.
- Button polish: default variant flipped from \`primary\` (grey) to \`accent\` so form submits use the brand color; \`.btn\` gets \`justify-center\` so \`fullWidth\` buttons center their content; the hand-rolled "Continue with Chatto Hub" markup on the login page now uses \`<Button variant="secondary">\` for design-token consistency.
- Dialog close button: dropped \`hover:bg-surface-200\` — color shift only now.

## Test plan

- [ ] Eyeball login, dialogs, forms, and prose links in both light and dark themes.
- [ ] \`mise test-frontend\`