### PR TITLE
feat(frontend): link joined rooms on the Overview page

### DIFF
--- a/frontend/src/lib/RoomDirectory.svelte
+++ b/frontend/src/lib/RoomDirectory.svelte
@@ -15,6 +15,7 @@ testable without context stubs and decoupled from the multi-server
 registry.
 -->
 <script lang="ts">
+  import { resolve } from '$app/paths';
   import { toast } from '$lib/ui/toast';
   import { Button } from '$lib/ui/form';
   import Dialog from '$lib/ui/Dialog.svelte';
@@ -26,8 +27,13 @@ registry.
 
   let {
     directory,
-    roomsStore
-  }: { directory: RoomDirectoryStore; roomsStore: RoomsStore } = $props();
+    roomsStore,
+    serverSegment
+  }: {
+    directory: RoomDirectoryStore;
+    roomsStore: RoomsStore;
+    serverSegment: string;
+  } = $props();
 
   let searchQuery = $state('');
   let leaveConfirmVisible = $state(false);
@@ -189,8 +195,16 @@ registry.
   -->
   {@const joinedGhost = `btn border-border bg-background text-muted hover:!border-danger hover:!bg-danger hover:!text-white ${sizing}`}
   {@const restrictedSoft = `btn border-border bg-background text-muted/70 !cursor-default opacity-80 ${sizing}`}
-  <li class="flex items-center gap-3 rounded px-3 py-1.5">
-    <div class="min-w-0 flex-1">
+  {@const roomHref = resolve('/chat/[serverId]/(chrome)/[roomId]', {
+    serverId: serverSegment,
+    roomId: room.id
+  })}
+  <li
+    class="flex items-center gap-3 rounded px-3 py-1.5 transition-colors {joined
+      ? 'hover:bg-surface-200'
+      : ''}"
+  >
+    {#snippet roomLabel()}
       <div class="flex min-w-0 items-baseline gap-1 font-medium">
         <span class="text-muted/60">#</span>
         <span class="truncate">{room.name}</span>
@@ -198,7 +212,16 @@ registry.
       {#if room.description}
         <div class="truncate text-xs text-muted/80">{room.description}</div>
       {/if}
-    </div>
+    {/snippet}
+    {#if joined}
+      <a href={roomHref} class="min-w-0 flex-1">
+        {@render roomLabel()}
+      </a>
+    {:else}
+      <div class="min-w-0 flex-1">
+        {@render roomLabel()}
+      </div>
+    {/if}
 
     {#if joined}
       <button

--- a/frontend/src/lib/RoomDirectory.svelte.spec.ts
+++ b/frontend/src/lib/RoomDirectory.svelte.spec.ts
@@ -75,6 +75,30 @@ describe('RoomDirectory', () => {
     expect(container.textContent).toContain('Join');
   });
 
+  it('links joined rooms to their room route and leaves non-joined rooms as non-links', () => {
+    const { container } = render(Harness, {
+      props: {
+        initialRooms: [room('r1'), room('r2')],
+        joinedRooms: [joined('r1')],
+        roomGroups: null
+      }
+    });
+    flushSync();
+
+    const items = [...container.querySelectorAll('li')];
+    const joinedItem = items.find((li) => li.textContent?.includes('r1'))!;
+    const unjoinedItem = items.find((li) => li.textContent?.includes('r2'))!;
+
+    // Joined row: name is rendered inside an <a> pointing at the room route.
+    const link = joinedItem.querySelector('a');
+    expect(link).not.toBeNull();
+    expect(link!.getAttribute('href')).toBe('/chat/-/r1');
+    expect(link!.textContent).toContain('r1');
+
+    // Non-joined row: no link wrapping the label.
+    expect(unjoinedItem.querySelector('a')).toBeNull();
+  });
+
   it('renders "Restricted" for rooms the viewer cannot join', () => {
     const { container } = render(Harness, {
       props: {

--- a/frontend/src/lib/RoomDirectoryTestHarness.svelte
+++ b/frontend/src/lib/RoomDirectoryTestHarness.svelte
@@ -49,4 +49,4 @@ chat-event tree or registering a server in the global registry.
   } as unknown as RoomsStore;
 </script>
 
-<RoomDirectory {directory} roomsStore={roomsStoreStub} />
+<RoomDirectory {directory} roomsStore={roomsStoreStub} serverSegment="-" />

--- a/frontend/src/routes/chat/[serverId]/(chrome)/+page.svelte
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { getActiveServer } from '$lib/state/activeServer.svelte';
+  import { serverIdToSegment } from '$lib/navigation';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import RoomDirectory from '$lib/RoomDirectory.svelte';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
@@ -12,6 +13,7 @@
   const stores = $derived(serverRegistry.getStore(getActiveServer()));
   const directory = $derived(stores.roomDirectory);
   const roomsStore = $derived(stores.rooms);
+  const serverSegment = $derived(serverIdToSegment(getActiveServer()));
 </script>
 
 <PageTitle title="Overview" />
@@ -23,7 +25,7 @@
     <div class="mx-auto flex max-w-6xl flex-col gap-8 p-6">
       <section class="flex flex-col gap-3">
         <h2 class="text-lg font-semibold">Rooms</h2>
-        <RoomDirectory {directory} {roomsStore} />
+        <RoomDirectory {directory} {roomsStore} {serverSegment} />
       </section>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- In the Overview page's `RoomDirectory`, wrap the room name/description in an `<a>` to `/chat/[serverId]/[roomId]` for rooms the viewer has joined; non-joined rows stay non-links.
- Add a subtle `hover:bg-surface-200` row tint (gated on `joined`) so the clickable rows visibly react on hover, without underlines.
- Thread a `serverSegment` prop through `RoomDirectory`, the Overview page, and the test harness, and add a spec asserting the link href / absence behavior.

## Test plan
- [x] `pnpm exec vitest run --project client src/lib/RoomDirectory.svelte.spec.ts`
- [x] `pnpm run check`
- [ ] Manual: visit `/chat/-` Overview, hover a joined room (bg tints, no underline), click it, land on that room. Non-joined rooms still show Join button only.