### PR TITLE
ci: downsize test-cli and test-e2e to 4vcpu runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: cd frontend && pnpm vitest --run
 
   test-cli:
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -53,7 +53,7 @@ jobs:
         run: cd cli && go test -tags test_endpoints ./...
 
   test-e2e:
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Switch `test-cli` and `test-e2e` from `blacksmith-8vcpu-ubuntu-2404` to `blacksmith-4vcpu-ubuntu-2404` to measure how test durations compare on smaller runners.
- `release` stays on 8vcpu; `test-frontend-unit` was already on 4vcpu.

## Test plan
- [ ] Compare CI wall-clock times for `test-cli` and `test-e2e` against recent main runs.