### PR TITLE
fix(frontend): align avatars, icons, and text across rows

### DIFF
--- a/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -863,7 +863,7 @@
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
   bind:this={composerEl}
-  class="mt-2 flex flex-col gap-2 p-2"
+  class="mt-2 flex flex-col gap-2 p-2 md:px-4"
   onclick={(e) => {
     if (!(e.target as HTMLElement).closest('button, a, input, label, .tiptap')) {
       editorApi?.focus();
@@ -966,7 +966,7 @@
         type="button"
         onclick={() => fileInputElement?.click()}
         disabled={inputDisabled}
-        class="flex h-8 w-12 shrink-0 cursor-pointer items-center justify-center rounded text-muted transition-colors duration-100 enabled:hover:text-text disabled:cursor-not-allowed"
+        class="flex h-8 w-11 shrink-0 cursor-pointer items-center justify-center rounded text-muted transition-colors duration-100 enabled:hover:text-text disabled:cursor-not-allowed"
         title="Attach file"
       >
         <span class="iconify text-xl uil--image-upload"></span>

--- a/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/SystemEvent.svelte
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/SystemEvent.svelte
@@ -33,7 +33,7 @@
 {#if action}
   <div class="mt-4 flex items-center gap-4 px-2 md:px-4">
     <!-- Avatar column (w-11 matches MessageEvent avatar width) -->
-    <div class="flex w-11 shrink-0 items-center justify-end">
+    <div class="flex w-11 shrink-0 items-center justify-center">
       {#if actor}
         <UserAvatar user={actor} size="xs" showPresence={false} />
       {:else}

--- a/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/SystemEventGroup.svelte
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/[roomId]/SystemEventGroup.svelte
@@ -59,7 +59,7 @@
 {#if actors.length > 0}
   <div class="mt-4 flex items-center gap-4 px-2 md:px-4">
     <!-- Avatar column (w-11 matches MessageEvent avatar width) -->
-    <div class="flex w-11 shrink-0 items-center justify-end">
+    <div class="flex w-11 shrink-0 items-center justify-center">
       <div class="flex -space-x-1.5">
         {#each visibleAvatars as actor (actor.id)}
           {#if actor.user}


### PR DESCRIPTION
## Summary
- System event rows (single and grouped) center their avatars in the `w-11` column instead of right-aligning, matching the visual position of `MessageEvent` avatars.
- `MessageComposer` outer padding bumps to `md:px-4` and the attach button shrinks to `w-11`, so the upload icon center and editor text-start line up with the message rows above.

## Test plan
- [ ] Visually inspect a room with join/leave system events — avatars sit at the same x as message avatars on mobile and desktop.
- [ ] Composer upload icon and "Type a message…" placeholder align with the system event avatar and text above.