### PR TITLE
fix(rbac): rename PermissionLevel to SERVER/GROUP/ROOM, fix group mislabel

### DIFF
--- a/cli/internal/core/permission_explainer.go
+++ b/cli/internal/core/permission_explainer.go
@@ -19,22 +19,22 @@ type PermissionExplanation struct {
 	Trace         []TraceEntry
 }
 
-// ExplainInstancePermission resolves a server-only permission (no room
+// ExplainServerPermission resolves a server-only permission (no room
 // context) and returns the full decision trace.
-func (r *PermissionResolver) ExplainInstancePermission(ctx context.Context, userID string, perm Permission) (PermissionExplanation, error) {
+func (r *PermissionResolver) ExplainServerPermission(ctx context.Context, userID string, perm Permission) (PermissionExplanation, error) {
 	exp := PermissionExplanation{Permission: perm, State: DecisionNone}
 
 	if meta, known := GetPermissionMetadata(perm); known && !permissionMetadataHasScope(meta, ScopeServer) {
-		return exp, fmt.Errorf("permission %s does not apply at instance scope", perm)
+		return exp, fmt.Errorf("permission %s does not apply at server scope", perm)
 	}
 
 	err := r.collectFullTrace(ctx, userID, KindChannel, "", perm, &exp)
 	return exp, err
 }
 
-// ExplainSpacePermission is the legacy server-scope explainer kept for the
-// inspector UI until callers migrate to ExplainInstancePermission.
-func (r *PermissionResolver) ExplainSpacePermission(ctx context.Context, userID string, kind RoomKind, perm Permission) (PermissionExplanation, error) {
+// ExplainServerKindPermission is the kind-aware server-scope explainer used by
+// the inspector UI to apply DM boundary rules for DM-kind callers.
+func (r *PermissionResolver) ExplainServerKindPermission(ctx context.Context, userID string, kind RoomKind, perm Permission) (PermissionExplanation, error) {
 	exp := PermissionExplanation{Permission: perm, State: DecisionNone}
 
 	if meta, known := GetPermissionMetadata(perm); known {
@@ -44,7 +44,7 @@ func (r *PermissionResolver) ExplainSpacePermission(ctx context.Context, userID 
 	}
 
 	if kind == KindDM && dmBoundaryDenies(perm) {
-		exp.applyDMBoundaryDeny(LevelInstance)
+		exp.applyDMBoundaryDeny(LevelServer)
 		return exp, nil
 	}
 
@@ -140,9 +140,9 @@ func (r *PermissionResolver) ExplainAllPermissions(ctx context.Context, userID s
 		case roomID != "":
 			exp, err = r.ExplainRoomPermission(ctx, userID, kind, roomID, meta.Permission)
 		case kind != "":
-			exp, err = r.ExplainSpacePermission(ctx, userID, kind, meta.Permission)
+			exp, err = r.ExplainServerKindPermission(ctx, userID, kind, meta.Permission)
 		default:
-			exp, err = r.ExplainInstancePermission(ctx, userID, meta.Permission)
+			exp, err = r.ExplainServerPermission(ctx, userID, meta.Permission)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("explain %s: %w", meta.Permission, err)
@@ -171,8 +171,8 @@ func (exp *PermissionExplanation) collect() visitFunc {
 // unconditionally denied by the DM privacy boundary. The trace is synthesized
 // as a single pseudo-entry attributed to "@dm-policy" so the inspector UI can
 // clearly indicate that DM rules (not RBAC) decided this. The level passed
-// in matches the caller (LevelRoom from ExplainRoomPermission, LevelInstance
-// from ExplainSpacePermission) so the inspector shows the right scope.
+// in matches the caller (LevelRoom from ExplainRoomPermission, LevelServer
+// from ExplainServerKindPermission) so the inspector shows the right scope.
 func (exp *PermissionExplanation) applyDMBoundaryDeny(level PermissionLevel) {
 	exp.State = DecisionDeny
 	exp.DecidedAt = level

--- a/cli/internal/core/permission_explainer_test.go
+++ b/cli/internal/core/permission_explainer_test.go
@@ -137,7 +137,7 @@ func assertAgreement(
 	switch scope {
 	case ScopeServer:
 		hasResult, hasErr = core.permissionResolver.HasInstancePermission(ctx, userID, perm)
-		exp, expErr = core.permissionResolver.ExplainInstancePermission(ctx, userID, perm)
+		exp, expErr = core.permissionResolver.ExplainServerPermission(ctx, userID, perm)
 	case ScopeRoom:
 		hasResult, hasErr = core.permissionResolver.HasRoomPermission(ctx, userID, KindForSpace(spaceID), roomID, perm)
 		exp, expErr = core.permissionResolver.ExplainRoomPermission(ctx, userID, KindForSpace(spaceID), roomID, perm)
@@ -203,9 +203,9 @@ func TestPermissionExplainer_UserLevelTrace(t *testing.T) {
 		if err := core.GrantUserPermission(ctx, user.Id, PermAdminAccess); err != nil {
 			t.Fatalf("GrantUserPermission: %v", err)
 		}
-		exp, err := core.permissionResolver.ExplainInstancePermission(ctx, user.Id, PermAdminAccess)
+		exp, err := core.permissionResolver.ExplainServerPermission(ctx, user.Id, PermAdminAccess)
 		if err != nil {
-			t.Fatalf("ExplainInstancePermission: %v", err)
+			t.Fatalf("ExplainServerPermission: %v", err)
 		}
 		if exp.State != DecisionAllow {
 			t.Errorf("expected DecisionAllow, got %s", exp.State)
@@ -227,9 +227,9 @@ func TestPermissionExplainer_UserLevelTrace(t *testing.T) {
 		if err := core.DenyUserPermission(ctx, other.Id, PermMessagePost); err != nil {
 			t.Fatalf("DenyUserPermission: %v", err)
 		}
-		exp, err := core.permissionResolver.ExplainInstancePermission(ctx, other.Id, PermMessagePost)
+		exp, err := core.permissionResolver.ExplainServerPermission(ctx, other.Id, PermMessagePost)
 		if err != nil {
-			t.Fatalf("ExplainInstancePermission: %v", err)
+			t.Fatalf("ExplainServerPermission: %v", err)
 		}
 		if exp.State != DecisionDeny {
 			t.Errorf("expected DecisionDeny, got %s", exp.State)

--- a/cli/internal/core/permission_resolver.go
+++ b/cli/internal/core/permission_resolver.go
@@ -53,10 +53,9 @@ func NewPermissionResolver(core *ChattoCore) *PermissionResolver {
 type PermissionLevel string
 
 const (
-	LevelInstance PermissionLevel = "instance"
-	LevelSpace    PermissionLevel = "space"
-	LevelRoom     PermissionLevel = "room"
-	LevelSet      PermissionLevel = "set"
+	LevelServer PermissionLevel = "server"
+	LevelGroup  PermissionLevel = "group"
+	LevelRoom   PermissionLevel = "room"
 )
 
 // DecisionKind is the kind of decision a role contributed.
@@ -75,7 +74,7 @@ type TraceEntry struct {
 	Level    PermissionLevel
 	RoleName string
 	Decision DecisionKind // Allow or Deny only
-	ObjectID string       // "any" for instance/space scope; roomID for room overrides
+	ObjectID string       // "any" for server scope; groupID for group scope; roomID for room overrides
 }
 
 // visitOutcome is returned by a visitFunc to control walker iteration.
@@ -463,14 +462,14 @@ func (r *PermissionResolver) probeServer(
 		return false, false, err
 	}
 	if granted {
-		return true, visit(TraceEntry{Level: LevelInstance, RoleName: rp.name, Decision: DecisionAllow, ObjectID: rbac.ObjectIdAny}) == visitStop, nil
+		return true, visit(TraceEntry{Level: LevelServer, RoleName: rp.name, Decision: DecisionAllow, ObjectID: rbac.ObjectIdAny}) == visitStop, nil
 	}
 	denied, err := r.keyExists(ctx, kv, rbac.DenyKey(rp.name, parts.Verb, parts.ObjectType, rbac.ObjectIdAny))
 	if err != nil {
 		return false, false, err
 	}
 	if denied {
-		return true, visit(TraceEntry{Level: LevelInstance, RoleName: rp.name, Decision: DecisionDeny, ObjectID: rbac.ObjectIdAny}) == visitStop, nil
+		return true, visit(TraceEntry{Level: LevelServer, RoleName: rp.name, Decision: DecisionDeny, ObjectID: rbac.ObjectIdAny}) == visitStop, nil
 	}
 	return false, false, nil
 }
@@ -509,14 +508,14 @@ func (r *PermissionResolver) probeSet(
 		return false, false, err
 	}
 	if granted {
-		return true, visit(TraceEntry{Level: LevelSet, RoleName: rp.name, Decision: DecisionAllow, ObjectID: groupID}) == visitStop, nil
+		return true, visit(TraceEntry{Level: LevelGroup, RoleName: rp.name, Decision: DecisionAllow, ObjectID: groupID}) == visitStop, nil
 	}
 	denied, err := r.keyExists(ctx, kv, rbac.GroupDenyKey(groupID, rp.name, parts.Verb, parts.ObjectType))
 	if err != nil {
 		return false, false, err
 	}
 	if denied {
-		return true, visit(TraceEntry{Level: LevelSet, RoleName: rp.name, Decision: DecisionDeny, ObjectID: groupID}) == visitStop, nil
+		return true, visit(TraceEntry{Level: LevelGroup, RoleName: rp.name, Decision: DecisionDeny, ObjectID: groupID}) == visitStop, nil
 	}
 	return false, false, nil
 }

--- a/cli/internal/graph/model/models_gen.go
+++ b/cli/internal/graph/model/models_gen.go
@@ -471,8 +471,8 @@ type Mutation struct {
 }
 
 // The complete explanation for one permission for one user at one scope.
-// Mirrors the algorithm of HasInstance/Space/RoomPermission: the first trace
-// entry is the winning decision; subsequent entries are also-saw context.
+// Mirrors the algorithm of the permission resolver: the first trace entry
+// is the winning decision; subsequent entries are also-saw context.
 type PermissionExplanation struct {
 	// The permission identifier (e.g., 'message.post').
 	Permission string `json:"permission"`
@@ -1273,23 +1273,23 @@ func (e PermissionDecisionKind) MarshalJSON() ([]byte, error) {
 type PermissionLevel string
 
 const (
-	// Decision came from an server role acting in the server KV bucket.
-	PermissionLevelInstance PermissionLevel = "INSTANCE"
-	// Decision came from a role acting at space scope (objectId='any').
-	PermissionLevelSpace PermissionLevel = "SPACE"
+	// Decision came from a role acting at server scope (objectId='any').
+	PermissionLevelServer PermissionLevel = "SERVER"
+	// Decision came from a per-room-group override (objectId=groupId).
+	PermissionLevelGroup PermissionLevel = "GROUP"
 	// Decision came from a per-room override (objectId=roomId).
 	PermissionLevelRoom PermissionLevel = "ROOM"
 )
 
 var AllPermissionLevel = []PermissionLevel{
-	PermissionLevelInstance,
-	PermissionLevelSpace,
+	PermissionLevelServer,
+	PermissionLevelGroup,
 	PermissionLevelRoom,
 }
 
 func (e PermissionLevel) IsValid() bool {
 	switch e {
-	case PermissionLevelInstance, PermissionLevelSpace, PermissionLevelRoom:
+	case PermissionLevelServer, PermissionLevelGroup, PermissionLevelRoom:
 		return true
 	}
 	return false

--- a/cli/internal/graph/permission_inspector.graphqls
+++ b/cli/internal/graph/permission_inspector.graphqls
@@ -1,9 +1,9 @@
 "The level at which a permission decision was reached during resolution."
 enum PermissionLevel {
-  "Decision came from an server role acting in the server KV bucket."
-  INSTANCE
-  "Decision came from a role acting at space scope (objectId='any')."
-  SPACE
+  "Decision came from a role acting at server scope (objectId='any')."
+  SERVER
+  "Decision came from a per-room-group override (objectId=groupId)."
+  GROUP
   "Decision came from a per-room override (objectId=roomId)."
   ROOM
 }
@@ -36,8 +36,8 @@ type PermissionTraceEntry {
 
 """
 The complete explanation for one permission for one user at one scope.
-Mirrors the algorithm of HasInstance/Space/RoomPermission: the first trace
-entry is the winning decision; subsequent entries are also-saw context.
+Mirrors the algorithm of the permission resolver: the first trace entry
+is the winning decision; subsequent entries are also-saw context.
 """
 type PermissionExplanation {
   "The permission identifier (e.g., 'message.post')."

--- a/cli/internal/graph/permission_inspector_helpers.go
+++ b/cli/internal/graph/permission_inspector_helpers.go
@@ -91,14 +91,14 @@ func toModelExplanation(exp core.PermissionExplanation) *model.PermissionExplana
 
 func toModelLevel(l core.PermissionLevel) model.PermissionLevel {
 	switch l {
-	case core.LevelInstance:
-		return model.PermissionLevelInstance
-	case core.LevelSpace:
-		return model.PermissionLevelSpace
+	case core.LevelServer:
+		return model.PermissionLevelServer
+	case core.LevelGroup:
+		return model.PermissionLevelGroup
 	case core.LevelRoom:
 		return model.PermissionLevelRoom
 	default:
-		return model.PermissionLevelInstance
+		return model.PermissionLevelServer
 	}
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -426,17 +426,18 @@ Subject leaf tokens never collide between the two paths — republished events e
 | `live.server.user.{userId}.created`                      | User registration completed  |
 | `live.server.user.{userId}.profile_updated`              | User profile changed (broadcast) |
 | `live.server.user.{userId}.user_deleted`                 | User account deleted         |
-| `live.server.user.{userId}.joined_space`                 | User joined the server       |
-| `live.server.user.{userId}.left_space`                   | User left the server         |
 | `live.server.config.updated`                             | Server config (name/MOTD/welcome) changed |
 | `live.server.config.server_updated`                      | Server branding (name/logo/banner/description) changed |
-| `live.server.config.room_layout_updated`                 | Admin reordered the room sidebar |
+| `live.server.config.room_groups_updated`                 | Admin reordered the room sidebar / room-group layout |
 | `live.server.user.{userId}.mentioned`                    | User was @mentioned          |
 | `live.server.user.{userId}.dm_message`                   | New DM message received      |
 | `live.server.user.{userId}.notification_created`         | New notification created     |
 | `live.server.user.{userId}.notification_dismissed`       | Notification dismissed       |
+| `live.server.user.{userId}.notification_level_changed`   | Viewer's server/room notification level changed |
+| `live.server.user.{userId}.thread_follow_changed`        | Viewer's thread follow/unfollow toggled |
 | `live.server.user.{userId}.settings_updated`             | User preferences changed     |
 | `live.server.user.{userId}.room_read`                    | Room marked as read          |
+| `live.server.user.{userId}.session_terminated`           | Active session revoked (logout-other-devices, account deletion) |
 
 **Republished from `SERVER_EVENTS`** (durable, available via `live.server.>` after stream write):
 
@@ -456,6 +457,9 @@ Subject leaf tokens never collide between the two paths — republished events e
 | `live.server.room.{kind}.{roomId}.message_deleted`       | Message deleted              |
 | `live.server.room.{kind}.{roomId}.message_updated`       | Message edited               |
 | `live.server.room.{kind}.{roomId}.user_typing`           | User typing in a room        |
+| `live.server.room.{kind}.{roomId}.call_joined`           | Participant joined the LiveKit voice call |
+| `live.server.room.{kind}.{roomId}.call_left`             | Participant left the LiveKit voice call |
+| `live.server.room.{kind}.{roomId}.video_processed`       | Video attachment finished transcoding |
 
 The unified `myEvents` GraphQL subscription is backed by a single core stream (`StreamMyEvents`) that combines:
 

--- a/docs/adr/ADR-011-message-body-event-split.md
+++ b/docs/adr/ADR-011-message-body-event-split.md
@@ -2,6 +2,8 @@
 
 **Date:** 2026-03-01
 
+**Naming note:** This ADR refers to per-space buckets `SPACE_{id}_EVENTS` and `SPACE_{id}_BODIES`. Those were consolidated into the unified `SERVER_EVENTS` stream and `SERVER_BODIES` KV bucket by ADR-030 (Retire the Space tier); the body key is now `{userId}.{eventId}` directly in `SERVER_BODIES`. The body/event split decision itself — write-body-then-publish-event, mutable KV body keyed by event ID, GDPR shredding via per-user prefix — still holds.
+
 ## Context
 
 Chat messages have two fundamentally different lifecycles: the *event* (who posted, when, in which room, in reply to what) is immutable, but the *content* (body text, attachments, link previews) is mutable — users can edit and delete messages. JetStream streams are append-only logs; updating a message in-place would require rewriting the stream.

--- a/docs/adr/ADR-012-two-tier-realtime-events.md
+++ b/docs/adr/ADR-012-two-tier-realtime-events.md
@@ -2,6 +2,8 @@
 
 **Date:** 2026-03-01
 
+**Naming note:** This ADR refers to `space.{id}.>` and `live.space.{id}.>` subject patterns and the `StreamMySpaceEvents` fan-in function. After ADR-029 (Instance → Server rename) and ADR-030 (Space tier retired), the equivalents are `server.>` / `live.server.>` and `StreamMyEvents`, and the `SERVER_EVENTS` stream's `RePublish` config now forwards every accepted message onto `live.server.>` so a subscriber needs only one NATS Core sub to receive both durable and transient events. The two-tier split itself (durable JetStream vs. transient NATS Core) and the per-event-type channel decision are unchanged.
+
 ## Context
 
 Chatto's real-time events span a wide spectrum of persistence and frequency requirements. Messages, joins, and room lifecycle events must be durably stored and replayable. Typing indicators, reactions, presence changes, and message update notifications are ephemeral — they matter for the current moment but have no audit or replay value.

--- a/docs/adr/ADR-013-per-space-stream-sharding.md
+++ b/docs/adr/ADR-013-per-space-stream-sharding.md
@@ -2,6 +2,8 @@
 
 **Date:** 2026-03-01
 
+**Status:** Superseded by ADR-030 (Retire the Space tier). The per-space stream and KV bucket family (`SPACE_{id}_EVENTS`, `SPACE_{id}_CONFIG`, etc.) was collapsed into the unified `SERVER_*` resources by the Phase-4 migration (#354); the `kind` segment in subjects (`server.room.channel.*` / `server.room.dm.*`) now disambiguates what space-sharding used to. The decision recorded here is preserved as historical context.
+
 ## Context
 
 Chatto needs to store ordered event logs for room messages and space lifecycle events. A single global stream would require all consumers to scan all messages across all spaces, creating contention. Per-room streams would create too many JetStream streams for large instances with thousands of rooms.

--- a/docs/adr/ADR-014-single-subscription-per-space.md
+++ b/docs/adr/ADR-014-single-subscription-per-space.md
@@ -2,6 +2,8 @@
 
 **Date:** 2026-03-01
 
+**Status:** Superseded by ADR-030 (Retire the Space tier). The "per-space" framing is obsolete now that the Space tier is gone; the GraphQL surface is the single deployment-wide `myEvents` subscription backed by one `live.server.>` NATS Core sub plus per-event authorization (see ARCHITECTURE.md). The pattern — one multiplexed subscription with server-side membership filtering — survives, but at server scope rather than space scope. The decision recorded here is preserved as historical context.
+
 ## Context
 
 The frontend needs real-time updates for all activity in a space: messages from all joined rooms, presence changes, typing indicators, reactions, room lifecycle events. The options are:

--- a/docs/adr/ADR-025-multi-instance-client-architecture.md
+++ b/docs/adr/ADR-025-multi-instance-client-architecture.md
@@ -16,7 +16,7 @@ Users wanted to connect to multiple Chatto instances from a single client (simil
 
 The frontend is instance-agnostic by default. It doesn't assume it's served by a Chatto instance. Instead:
 
-1. **Probe-based origin detection**: On init, fetch `/api/instance` on the current origin. If it responds, auto-register the origin as an instance. If it fails (static hosting), skip.
+1. **Probe-based origin detection**: On init, fetch `/api/server` on the current origin. If it responds, auto-register the origin as an instance. If it fails (static hosting), skip.
 2. **No `isHome` flag**: The origin instance is identified by comparing `instance.url` to `window.location.origin` at runtime — no stored flag.
 3. **Dual auth**: Origin uses cookie auth (HttpOnly, SameSite). Remote instances use opaque bearer tokens stored in `localStorage`.
 
@@ -53,7 +53,7 @@ Bearer tokens use NATS KV TTL (default 90 days). Each successful `ValidateAuthTo
 ### Negative
 
 - Remote instance bearer tokens in `localStorage` are vulnerable to XSS (cookie auth is not)
-- `/api/instance` is the only cross-origin endpoint (wildcard CORS) — rich data needed pre-registration must go there, not in GraphQL
+- `/api/server` is the only cross-origin endpoint (wildcard CORS) — rich data needed pre-registration must go there, not in GraphQL
 - The probe is async for unauthenticated users, so the origin may not be registered by the time the first render completes
 
 ### Trade-offs

--- a/docs/adr/ADR-028-event-id-keyed-read-state.md
+++ b/docs/adr/ADR-028-event-id-keyed-read-state.md
@@ -6,7 +6,9 @@
 
 **Tracking issue:** [#330](https://github.com/chattocorp/chatto/issues/330)
 
-**Related:** [ADR-026](ADR-026-event-identity-via-nanoid.md), [ADR-027](ADR-027-instance-space-server-consolidation.md)
+**Related:** [ADR-026](ADR-026-event-identity-via-nanoid.md), [ADR-027](ADR-027-instance-space-server-consolidation.md), [ADR-029](ADR-029-instance-to-server-rename.md), [ADR-030](ADR-030-space-tier-retirement.md)
+
+**Naming note:** This ADR was written during the consolidation work and refers to subjects like `space.{s}.room.{r}.msg.*` and the legacy `SPACE_{id}_RUNTIME` KV bucket. Post-ADR-029/030, the subject is `server.room.{kind}.{roomId}.msg.*` and the bucket is the unified `SERVER_RUNTIME`. The event-ID keying pattern (`room_read_event.{userId}.{roomId}` holding a 14-char NanoID) is unchanged and lives in `SERVER_RUNTIME` today.
 
 ## Context
 

--- a/docs/fdr/FDR-024-permission-inspection-tool.md
+++ b/docs/fdr/FDR-024-permission-inspection-tool.md
@@ -1,7 +1,7 @@
 # FDR-024: Permission Inspection Tool
 
 **Status:** Active
-**Last reviewed:** 2026-05-19
+**Last reviewed:** 2026-05-19 (scope label rename to SERVER/GROUP/ROOM)
 
 ## Overview
 
@@ -42,9 +42,9 @@ Admins can inspect why a specific user has (or doesn't have) a permission, at se
 
 ### 5. Trace surfaces scope tokens that match the UI
 
-**Decision:** Trace entries label scopes as `INSTANCE` (= server), `SPACE` (legacy term for the room-group scope), and `ROOM`, mirroring what the admin UI displays.
+**Decision:** Trace entries label scopes as `SERVER`, `GROUP`, and `ROOM`, mirroring what the admin UI displays and the `PermissionScope` constants used by the resolver.
 **Why:** Operators reading the trace shouldn't have to translate between internal vocabulary (e.g., "phase 2 of the resolver", "object ID 'any'") and what they see in the admin UI. The labels match the buttons.
-**Tradeoff:** The `SPACE` label survives from the pre-Phase-5 tier model and is a vocabulary inconsistency. Renaming it everywhere is tracked but not yet done.
+**Tradeoff:** None — the GraphQL `PermissionLevel` enum, the Go `Level*` constants, and the inspector UI use the same three tokens.
 
 ## Permissions
 

--- a/frontend/src/lib/components/rbac/PermissionExplanationTable.svelte
+++ b/frontend/src/lib/components/rbac/PermissionExplanationTable.svelte
@@ -4,7 +4,7 @@
   import { getPermissionDescription } from '$lib/permissions';
 
   type DecisionKind = 'ALLOW' | 'DENY' | 'NONE';
-  type Level = 'INSTANCE' | 'SPACE' | 'ROOM';
+  type Level = 'SERVER' | 'GROUP' | 'ROOM';
 
   type TraceEntry = {
     level: Level;
@@ -35,10 +35,10 @@
 
   function levelLabel(level: Level): string {
     switch (level) {
-      case 'INSTANCE':
-        return 'Instance';
-      case 'SPACE':
-        return 'Space';
+      case 'SERVER':
+        return 'Server';
+      case 'GROUP':
+        return 'Group';
       case 'ROOM':
         return 'Room';
     }

--- a/frontend/src/lib/components/rbac/PermissionExplanationTable.svelte.spec.ts
+++ b/frontend/src/lib/components/rbac/PermissionExplanationTable.svelte.spec.ts
@@ -5,7 +5,7 @@ import PermissionExplanationTable from './PermissionExplanationTable.svelte';
 import { q } from '$lib/test-utils';
 
 type DecisionKind = 'ALLOW' | 'DENY' | 'NONE';
-type Level = 'INSTANCE' | 'SPACE' | 'ROOM';
+type Level = 'SERVER' | 'GROUP' | 'ROOM';
 
 type Explanation = {
   permission: string;
@@ -56,9 +56,9 @@ describe('PermissionExplanationTable', () => {
 
   it('renders the granting role and level when state is ALLOW', () => {
     const { container } = render(PermissionExplanationTable, {
-      props: { explanations: [granted('admin', 'SPACE')] }
+      props: { explanations: [granted('admin', 'GROUP')] }
     });
-    expect(container.textContent).toContain('Space');
+    expect(container.textContent).toContain('Group');
     expect(container.textContent).toContain('admin');
   });
 
@@ -71,7 +71,7 @@ describe('PermissionExplanationTable', () => {
 
   it('shows the deny role when state is DENY', () => {
     const { container } = render(PermissionExplanationTable, {
-      props: { explanations: [denied('moderator', 'SPACE')] }
+      props: { explanations: [denied('moderator', 'GROUP')] }
     });
     expect(container.textContent).toContain('moderator');
   });
@@ -80,11 +80,11 @@ describe('PermissionExplanationTable', () => {
     const exp: Explanation = {
       permission: 'message.post',
       state: 'ALLOW',
-      decidedAt: 'INSTANCE',
+      decidedAt: 'SERVER',
       decidedByRole: 'admin',
       trace: [
-        { level: 'INSTANCE', roleName: 'admin', decision: 'ALLOW', applied: true },
-        { level: 'SPACE', roleName: 'everyone', decision: 'DENY', applied: false }
+        { level: 'SERVER', roleName: 'admin', decision: 'ALLOW', applied: true },
+        { level: 'GROUP', roleName: 'everyone', decision: 'DENY', applied: false }
       ]
     };
     const { container } = render(PermissionExplanationTable, {

--- a/frontend/src/lib/gql/graphql.ts
+++ b/frontend/src/lib/gql/graphql.ts
@@ -1602,8 +1602,8 @@ export enum PermissionDecisionKind {
 
 /**
  * The complete explanation for one permission for one user at one scope.
- * Mirrors the algorithm of HasInstance/Space/RoomPermission: the first trace
- * entry is the winning decision; subsequent entries are also-saw context.
+ * Mirrors the algorithm of the permission resolver: the first trace entry
+ * is the winning decision; subsequent entries are also-saw context.
  */
 export type PermissionExplanation = {
   __typename?: 'PermissionExplanation';
@@ -1621,12 +1621,12 @@ export type PermissionExplanation = {
 
 /** The level at which a permission decision was reached during resolution. */
 export enum PermissionLevel {
-  /** Decision came from an server role acting in the server KV bucket. */
-  Instance = 'INSTANCE',
+  /** Decision came from a per-room-group override (objectId=groupId). */
+  Group = 'GROUP',
   /** Decision came from a per-room override (objectId=roomId). */
   Room = 'ROOM',
-  /** Decision came from a role acting at space scope (objectId='any'). */
-  Space = 'SPACE'
+  /** Decision came from a role acting at server scope (objectId='any'). */
+  Server = 'SERVER'
 }
 
 /**


### PR DESCRIPTION
## Summary

The GraphQL `PermissionLevel` enum had stale tokens (`INSTANCE`/`SPACE`/`ROOM`) left over from before ADR-027/029/030. While renaming them to match current vocabulary, found a real bug: `toModelLevel` had no mapping for `LevelSet` (group-scope decisions from ADR-031), so every group-scope decision was silently falling through to the `INSTANCE` default — the permission inspector has been mislabeling group decisions as Server decisions in production. The dead `LevelSpace` constant was never emitted by the resolver.

Surfaced this during a `/chatto-checkup` pass, which also turned up doc drift in 7 ADRs and `ARCHITECTURE.md` that's bundled in here.

## Changes

- **Code fix**: enum is now `SERVER`/`GROUP`/`ROOM`; core constants `LevelServer`/`LevelGroup`/`LevelRoom`; mapping helper correctly converts each; explainer entrypoints renamed.
- **Frontend**: `PermissionExplanationTable.svelte` + spec updated; `graphql.ts` regenerated.
- **Docs**: ADR-013/014 marked Superseded by ADR-030; ADR-011/012/025/028 got naming notes for the ADR-029/030 renames; FDR-024 design decision 5 reflects the now-consistent naming; `ARCHITECTURE.md` live-event tables refreshed against the code.

## Test plan

- [x] `mise codegen-cli` clean
- [x] `mise codegen-frontend` clean
- [x] `mise x -- go test -tags test_endpoints -count=1 ./...` (all packages pass)
- [x] `mise test-frontend` — 754/754 vitest pass
- [x] `svelte-check` — 0 errors
- [ ] Manually verify the Permission Explainer in the admin UI now shows "Group" for group-scope decisions instead of "Instance"