### PR TITLE
refactor(core): store verified emails as per-email proto entries

### DIFF
--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -22,6 +22,7 @@ import (
 	"hmans.de/chatto/internal/core/rbac"
 	"hmans.de/chatto/internal/core/subjects"
 	"hmans.de/chatto/internal/encryption"
+	"hmans.de/chatto/internal/migrations"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
@@ -291,6 +292,13 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	storage, err := newStorage(js, ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize storage: %w", err)
+	}
+
+	// Run boot-time data migrations. Idempotent and cheap on subsequent
+	// boots (each migration short-circuits when no legacy data remains).
+	// See cli/internal/migrations for what's currently registered.
+	if err := migrations.RunAll(ctx, storage.serverKV, logger); err != nil {
+		return nil, fmt.Errorf("failed to run boot migrations: %w", err)
 	}
 
 	// Initialize encryption manager

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -999,11 +999,14 @@ func (c *ChattoCore) DeleteUser(ctx context.Context, actorID, userID string) err
 		}
 	}
 
-	// Delete email index entries
+	// Delete email index entries and per-email verified_email records.
 	for _, email := range verifiedEmails {
 		emailKey := userByEmailKey(email.Email)
 		if err := c.storage.serverKV.Delete(ctx, emailKey); err != nil {
 			c.logger.Warn("Failed to delete email index", "user_id", userID, "email", email.Email, "error", err)
+		}
+		if err := c.storage.serverKV.Delete(ctx, verifiedEmailKey(userID, email.Email)); err != nil {
+			c.logger.Warn("Failed to delete verified_email entry", "user_id", userID, "email", email.Email, "error", err)
 		}
 	}
 
@@ -1011,12 +1014,11 @@ func (c *ChattoCore) DeleteUser(ctx context.Context, actorID, userID string) err
 	// This ensures that when SpaceMemberDeletedEvent is published and clients refetch,
 	// the user record is already gone and they see "Deleted User".
 	keysToDelete := []string{
-		userKey(userID),               // user profile
-		userAuthPasswordKey(userID),   // password hash
-		userAvatarKey(userID),         // avatar reference
-		userVerifiedEmailsKey(userID), // verified emails list
-		userByLoginKey(user.Login),    // login index
-		userPreferencesKey(userID),    // user preferences
+		userKey(userID),             // user profile
+		userAuthPasswordKey(userID), // password hash
+		userAvatarKey(userID),       // avatar reference
+		userByLoginKey(user.Login),  // login index
+		userPreferencesKey(userID),  // user preferences
 	}
 
 	for _, key := range keysToDelete {

--- a/cli/internal/core/verified_emails.go
+++ b/cli/internal/core/verified_emails.go
@@ -11,6 +11,9 @@ import (
 	"time"
 
 	"github.com/nats-io/nats.go/jetstream"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
@@ -39,13 +42,17 @@ var (
 // ============================================================================
 
 // EmailVerificationToken represents a token used to verify an email address.
+// Stored as JSON (short-lived, auto-expires via KV TTL — not worth proto).
 type EmailVerificationToken struct {
 	UserID    string    `json:"user_id"`
 	Email     string    `json:"email"`
 	CreatedAt time.Time `json:"created_at"`
 }
 
-// VerifiedEmail represents a verified email address attached to a user.
+// VerifiedEmail is the in-memory shape returned by GetVerifiedEmails.
+// On disk each entry lives in its own KV key as a proto-encoded
+// corev1.VerifiedEmail; this Go struct exists for back-compat with the
+// callers that already use it.
 type VerifiedEmail struct {
 	Email      string    `json:"email"`
 	VerifiedAt time.Time `json:"verified_at"`
@@ -61,17 +68,35 @@ func emailVerificationTokenKey(token string) string {
 	return fmt.Sprintf("email_verification.%s", token)
 }
 
-// userVerifiedEmailsKey returns the KV key for a user's verified emails.
-func userVerifiedEmailsKey(userID string) string {
-	return fmt.Sprintf("user.%s.verified_emails", userID)
+// emailHash returns the stable lowercase-SHA256 hex digest used in both
+// the per-email key and the user_by_email index. Centralised so the
+// index and the per-email entries can never drift apart.
+func emailHash(email string) string {
+	sum := sha256.Sum256([]byte(strings.ToLower(email)))
+	return hex.EncodeToString(sum[:])
+}
+
+// verifiedEmailKey returns the KV key for a single verified email.
+// Format: verified_emails.{userID}.{sha256(lowercase(email))}
+//
+// One entry per (user, email) pair lets us add a new email with a single
+// Put (no read-modify-write), list a user's emails with a prefix scan
+// (`verified_emails.{userID}.*`), and decode only the entries we need.
+func verifiedEmailKey(userID, email string) string {
+	return fmt.Sprintf("verified_emails.%s.%s", userID, emailHash(email))
+}
+
+// verifiedEmailPrefix returns the prefix-scan pattern for one user's
+// verified emails.
+func verifiedEmailPrefix(userID string) string {
+	return fmt.Sprintf("verified_emails.%s.*", userID)
 }
 
 // userByEmailKey returns the KV key for the email-to-user index.
 // Uses SHA256 hash of the lowercase email to ensure valid NATS subject characters
 // and case-insensitive uniqueness. Created when an email is verified.
 func userByEmailKey(email string) string {
-	hash := sha256.Sum256([]byte(strings.ToLower(email)))
-	return fmt.Sprintf("user_by_email.%s", hex.EncodeToString(hash[:]))
+	return fmt.Sprintf("user_by_email.%s", emailHash(email))
 }
 
 // ============================================================================
@@ -189,39 +214,20 @@ func (c *ChattoCore) VerifyEmail(ctx context.Context, token string) (userID stri
 	return tokenData.UserID, nil
 }
 
-// addVerifiedEmail adds an email to a user's verified emails list.
-// Idempotent - won't add duplicates.
+// addVerifiedEmail writes a single per-email proto entry for the user.
+// Idempotent: rewriting the same (user, email) pair just overwrites the
+// existing entry with identical content.
 func (c *ChattoCore) addVerifiedEmail(ctx context.Context, userID, email string) error {
-	// Get existing verified emails
-	emails, err := c.GetVerifiedEmails(ctx, userID)
-	if err != nil {
-		return err
-	}
-
-	// Check if email already exists (case-insensitive)
-	normalizedEmail := strings.ToLower(email)
-	for _, e := range emails {
-		if strings.ToLower(e.Email) == normalizedEmail {
-			// Already in list, nothing to do
-			return nil
-		}
-	}
-
-	// Add new email
-	emails = append(emails, VerifiedEmail{
+	data, err := proto.Marshal(&corev1.VerifiedEmail{
 		Email:      email,
-		VerifiedAt: time.Now(),
+		VerifiedAt: timestamppb.New(time.Now()),
 	})
-
-	// Store updated list
-	data, err := json.Marshal(emails)
 	if err != nil {
-		return fmt.Errorf("failed to marshal verified emails: %w", err)
+		return fmt.Errorf("failed to marshal verified email: %w", err)
 	}
 
-	_, err = c.storage.serverKV.Put(ctx, userVerifiedEmailsKey(userID), data)
-	if err != nil {
-		return fmt.Errorf("failed to store verified emails: %w", err)
+	if _, err := c.storage.serverKV.Put(ctx, verifiedEmailKey(userID, email), data); err != nil {
+		return fmt.Errorf("failed to store verified email: %w", err)
 	}
 
 	// Auto-promote on config-owner email match. This is what closes the
@@ -242,30 +248,47 @@ func (c *ChattoCore) addVerifiedEmail(ctx context.Context, userID, email string)
 }
 
 // GetVerifiedEmails returns all verified emails for a user.
+//
+// One KV entry per email under `verified_emails.{userID}.*`, so this is
+// a prefix scan plus an O(N) decode of just this user's entries.
 func (c *ChattoCore) GetVerifiedEmails(ctx context.Context, userID string) ([]VerifiedEmail, error) {
-	entry, err := c.storage.serverKV.Get(ctx, userVerifiedEmailsKey(userID))
+	keyLister, err := c.storage.serverKV.ListKeysFiltered(ctx, verifiedEmailPrefix(userID))
 	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			return []VerifiedEmail{}, nil
-		}
-		return nil, fmt.Errorf("failed to get verified emails: %w", err)
+		// No matching keys.
+		return []VerifiedEmail{}, nil
 	}
 
 	var emails []VerifiedEmail
-	if err := json.Unmarshal(entry.Value(), &emails); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal verified emails: %w", err)
+	for key := range keyLister.Keys() {
+		entry, err := c.storage.serverKV.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			return nil, fmt.Errorf("failed to get verified email entry: %w", err)
+		}
+		ve := &corev1.VerifiedEmail{}
+		if err := proto.Unmarshal(entry.Value(), ve); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal verified email: %w", err)
+		}
+		emails = append(emails, VerifiedEmail{
+			Email:      ve.Email,
+			VerifiedAt: ve.VerifiedAt.AsTime(),
+		})
 	}
-
 	return emails, nil
 }
 
 // HasVerifiedEmail checks if a user has at least one verified email.
 func (c *ChattoCore) HasVerifiedEmail(ctx context.Context, userID string) (bool, error) {
-	emails, err := c.GetVerifiedEmails(ctx, userID)
+	keyLister, err := c.storage.serverKV.ListKeysFiltered(ctx, verifiedEmailPrefix(userID))
 	if err != nil {
-		return false, err
+		return false, nil
 	}
-	return len(emails) > 0, nil
+	for range keyLister.Keys() {
+		return true, nil
+	}
+	return false, nil
 }
 
 // IsEmailClaimed checks if an email address is already verified by any user.
@@ -302,53 +325,57 @@ func (c *ChattoCore) GetUserByVerifiedEmail(ctx context.Context, email string) (
 	return c.GetUser(ctx, userID)
 }
 
-// CountVerifiedUsers returns the number of users with at least one verified email.
+// CountVerifiedUsers returns the number of distinct users with at least
+// one verified email.
 //
-// One KV entry exists per user under user.{userID}.verified_emails, so this is a
-// key scan without value fetches. ListKeysFiltered is used (rather than the
-// faster server-side stream.Info(WithSubjectFilter)) because the latter counts
-// tombstones from deleted users: kv.Delete writes a 0-byte tombstone message
-// rather than removing the subject, and with the default History=1 the tombstone
-// simply replaces the live value. The subject still has 1 message, so
-// len(State.Subjects) and NumSubjects both inflate by every historical deletion
-// until the tombstone is purged. ListKeysFiltered is the only API that filters
-// tombstones (via the KV-Operation: DEL header on each message).
+// Implemented by listing the email-to-user index (`user_by_email.*`),
+// which has one entry per verified email — not per user — and
+// deduplicating the userIDs in the values. This is the only path that
+// gives a tombstone-free count; see the comment on ListKeysFiltered in
+// the older version of this file for the JetStream subject-count
+// pitfall.
 func (c *ChattoCore) CountVerifiedUsers(ctx context.Context) (int, error) {
-	keyLister, err := c.storage.serverKV.ListKeysFiltered(ctx, "user.*.verified_emails")
+	keyLister, err := c.storage.serverKV.ListKeysFiltered(ctx, "user_by_email.*")
 	if err != nil {
 		return 0, nil
 	}
-	count := 0
-	for range keyLister.Keys() {
-		count++
+	users := map[string]struct{}{}
+	for key := range keyLister.Keys() {
+		entry, err := c.storage.serverKV.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			return 0, fmt.Errorf("failed to read user_by_email entry: %w", err)
+		}
+		users[string(entry.Value())] = struct{}{}
 	}
-	return count, nil
+	return len(users), nil
 }
 
 // ListUsersWithVerifiedEmail returns all user IDs that have at least one verified email.
 func (c *ChattoCore) ListUsersWithVerifiedEmail(ctx context.Context) ([]string, error) {
-	// List all keys matching user.*.verified_emails pattern
-	pattern := "user.*.verified_emails"
-	keyLister, err := c.storage.serverKV.ListKeysFiltered(ctx, pattern)
+	keyLister, err := c.storage.serverKV.ListKeysFiltered(ctx, "user_by_email.*")
 	if err != nil {
-		// No keys found is not an error
 		return []string{}, nil
 	}
 
-	const prefix = "user."
-	const suffix = ".verified_emails"
-
-	var users []string
-	// Keys have format: user.{userID}.verified_emails
+	seen := map[string]struct{}{}
+	users := []string{}
 	for key := range keyLister.Keys() {
-		// Extract userID from key using TrimPrefix/TrimSuffix for clarity
-		if strings.HasPrefix(key, prefix) && strings.HasSuffix(key, suffix) {
-			userID := strings.TrimPrefix(key, prefix)
-			userID = strings.TrimSuffix(userID, suffix)
-			if userID != "" {
-				users = append(users, userID)
+		entry, err := c.storage.serverKV.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
 			}
+			return nil, fmt.Errorf("failed to read user_by_email entry: %w", err)
 		}
+		userID := string(entry.Value())
+		if _, ok := seen[userID]; ok {
+			continue
+		}
+		seen[userID] = struct{}{}
+		users = append(users, userID)
 	}
 	return users, nil
 }

--- a/cli/internal/migrations/migrations.go
+++ b/cli/internal/migrations/migrations.go
@@ -1,0 +1,52 @@
+// Package migrations holds one-shot data migrations that run at boot.
+//
+// # Why this package exists
+//
+// Chatto's storage layer evolves over time, and occasionally the shape of
+// data already persisted in NATS KV needs to change (e.g. JSON → proto,
+// one-blob-per-user → one-entry-per-thing). Each such transition has a
+// migration function in this package that:
+//
+//  1. Runs idempotently at boot from ChattoCore initialisation.
+//  2. Scans for legacy storage keys, converts them to the new shape, and
+//     deletes the legacy entries.
+//  3. Short-circuits when no legacy keys remain, so it costs essentially
+//     nothing on subsequent boots.
+//
+// Migrations live here, not next to the feature code, so there is a
+// single place to audit "what code do we keep around purely to convert
+// legacy data?". When a migration's legacy data is known to have been
+// drained from all live deployments, the migration can be deleted in
+// one tightly scoped PR.
+//
+// # Adding a migration
+//
+//  1. Add a file `xxx.go` in this package with a function taking
+//     whatever it needs (typically a KV bucket and a logger). Document
+//     the legacy shape, the new shape, and the reason for the change in
+//     a doc comment.
+//  2. Call it from [RunAll].
+//
+// # Removing a migration
+//
+// Once the legacy data has been confirmed drained on every live
+// deployment that will ever boot this code, delete the file and the
+// corresponding call in [RunAll].
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/charmbracelet/log"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// RunAll runs every active migration in order, stopping at the first
+// error.
+func RunAll(ctx context.Context, kv jetstream.KeyValue, logger *log.Logger) error {
+	if err := MigrateVerifiedEmailsToProto(ctx, kv, logger); err != nil {
+		return fmt.Errorf("verified_emails: %w", err)
+	}
+	return nil
+}

--- a/cli/internal/migrations/verified_emails.go
+++ b/cli/internal/migrations/verified_emails.go
@@ -1,0 +1,135 @@
+package migrations
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/log"
+	"github.com/nats-io/nats.go/jetstream"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+// MigrateVerifiedEmailsToProto converts verified-emails storage from a
+// single JSON blob per user to a per-email proto entry.
+//
+// # Legacy layout
+//
+//	key:   user.{userID}.verified_emails
+//	value: JSON []{ "email": ..., "verified_at": ... }
+//
+// # New layout
+//
+//	key:   verified_emails.{userID}.{sha256(lowercase(email))}
+//	value: proto-encoded corev1.VerifiedEmail
+//
+// The companion email-to-user index (`user_by_email.{hash}`) is left
+// untouched — it was already shaped for O(1) reverse lookups and is
+// orthogonal to this change.
+//
+// # Why
+//
+// The legacy shape required a read-modify-write to append an email, which
+// is racy between concurrent verifications for the same user and forces
+// the full list to be unmarshalled on every read. The new shape is also
+// consistent with the rest of the project (proto everywhere except
+// short-TTL token records).
+//
+// # Idempotency
+//
+// Safe to re-run. Per-email keys are deterministic in (userID, email);
+// re-writing them with the same content is a no-op. The legacy key is
+// only deleted after every per-email entry has been written, so a crash
+// mid-migration just leaves the user's record to be re-converted on the
+// next boot.
+//
+// # When this can be removed
+//
+// Once every live deployment has booted at least once on a version that
+// includes this migration. Operators can verify by inspecting the
+// INSTANCE bucket for any remaining `user.*.verified_emails` keys.
+func MigrateVerifiedEmailsToProto(ctx context.Context, kv jetstream.KeyValue, logger *log.Logger) error {
+	const (
+		legacyKeyPrefix = "user."
+		legacyKeySuffix = ".verified_emails"
+	)
+
+	keyLister, err := kv.ListKeysFiltered(ctx, "user.*.verified_emails")
+	if err != nil {
+		// NATS returns an error when no keys match the filter. That's
+		// the steady-state "nothing to migrate" case, not a failure.
+		return nil
+	}
+
+	type legacyEntry struct {
+		Email      string    `json:"email"`
+		VerifiedAt time.Time `json:"verified_at"`
+	}
+
+	convertedUsers := 0
+	convertedEmails := 0
+
+	for legacyKey := range keyLister.Keys() {
+		if !strings.HasPrefix(legacyKey, legacyKeyPrefix) || !strings.HasSuffix(legacyKey, legacyKeySuffix) {
+			// Defensive: ListKeysFiltered should only yield matching
+			// keys, but the wildcard `*` is unanchored so we double-check.
+			continue
+		}
+		userID := strings.TrimSuffix(strings.TrimPrefix(legacyKey, legacyKeyPrefix), legacyKeySuffix)
+		if userID == "" {
+			continue
+		}
+
+		entry, err := kv.Get(ctx, legacyKey)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				// Concurrent deletion; nothing to do.
+				continue
+			}
+			return fmt.Errorf("get legacy verified_emails for %s: %w", userID, err)
+		}
+
+		var emails []legacyEntry
+		if err := json.Unmarshal(entry.Value(), &emails); err != nil {
+			return fmt.Errorf("unmarshal legacy verified_emails for %s: %w", userID, err)
+		}
+
+		for _, le := range emails {
+			if le.Email == "" {
+				continue
+			}
+			hash := sha256.Sum256([]byte(strings.ToLower(le.Email)))
+			newKey := fmt.Sprintf("verified_emails.%s.%s", userID, hex.EncodeToString(hash[:]))
+			data, err := proto.Marshal(&corev1.VerifiedEmail{
+				Email:      le.Email,
+				VerifiedAt: timestamppb.New(le.VerifiedAt),
+			})
+			if err != nil {
+				return fmt.Errorf("marshal verified_email for %s/%s: %w", userID, le.Email, err)
+			}
+			if _, err := kv.Put(ctx, newKey, data); err != nil {
+				return fmt.Errorf("put verified_email for %s/%s: %w", userID, le.Email, err)
+			}
+			convertedEmails++
+		}
+
+		if err := kv.Delete(ctx, legacyKey); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+			return fmt.Errorf("delete legacy verified_emails for %s: %w", userID, err)
+		}
+		convertedUsers++
+	}
+
+	if convertedUsers > 0 {
+		logger.Info("verified_emails migration: converted JSON blobs to per-email proto entries",
+			"users", convertedUsers, "emails", convertedEmails)
+	}
+	return nil
+}

--- a/cli/internal/migrations/verified_emails_test.go
+++ b/cli/internal/migrations/verified_emails_test.go
@@ -1,0 +1,163 @@
+package migrations
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/log"
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"google.golang.org/protobuf/proto"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+// setupTestKV stands up an embedded NATS server with JetStream and
+// returns a single KV bucket plus a logger for the migration to work
+// against. Mirrors the pattern in cli/internal/core/core_test.go but
+// strips out everything except the KV.
+func setupTestKV(t *testing.T) (context.Context, jetstream.KeyValue) {
+	t.Helper()
+
+	ns, err := server.NewServer(&server.Options{
+		JetStream: true,
+		Port:      -1,
+		StoreDir:  t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("create NATS server: %v", err)
+	}
+	go ns.Start()
+	if !ns.ReadyForConnections(5 * time.Second) {
+		t.Fatal("NATS server not ready")
+	}
+
+	nc, err := nats.Connect(ns.ClientURL())
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() {
+		nc.Close()
+		ns.Shutdown()
+		ns.WaitForShutdown()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatalf("jetstream: %v", err)
+	}
+	kv, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket: "TEST",
+	})
+	if err != nil {
+		t.Fatalf("create KV: %v", err)
+	}
+
+	return ctx, kv
+}
+
+// emailHash mirrors the production helper for test setup.
+func testEmailHash(email string) string {
+	sum := sha256.Sum256([]byte(strings.ToLower(email)))
+	return hex.EncodeToString(sum[:])
+}
+
+func TestMigrateVerifiedEmailsToProto_ConvertsLegacyJSONBlob(t *testing.T) {
+	ctx, kv := setupTestKV(t)
+
+	type legacy struct {
+		Email      string    `json:"email"`
+		VerifiedAt time.Time `json:"verified_at"`
+	}
+	verifiedAt := time.Now().UTC().Truncate(time.Second)
+	blob, _ := json.Marshal([]legacy{
+		{Email: "Alice@Example.com", VerifiedAt: verifiedAt},
+		{Email: "alice-alt@example.com", VerifiedAt: verifiedAt},
+	})
+	const userID = "user123"
+	if _, err := kv.Put(ctx, fmt.Sprintf("user.%s.verified_emails", userID), blob); err != nil {
+		t.Fatalf("seed legacy key: %v", err)
+	}
+
+	if err := MigrateVerifiedEmailsToProto(ctx, kv, log.New(nil)); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	// Legacy key gone.
+	if _, err := kv.Get(ctx, fmt.Sprintf("user.%s.verified_emails", userID)); !errors.Is(err, jetstream.ErrKeyNotFound) {
+		t.Errorf("expected legacy key to be deleted, got err=%v", err)
+	}
+
+	// New per-email keys exist with correct proto content. Hash uses
+	// lowercase email, so the mixed-case input must resolve correctly.
+	for _, email := range []string{"Alice@Example.com", "alice-alt@example.com"} {
+		key := fmt.Sprintf("verified_emails.%s.%s", userID, testEmailHash(email))
+		entry, err := kv.Get(ctx, key)
+		if err != nil {
+			t.Errorf("expected new key %s, got err=%v", key, err)
+			continue
+		}
+		ve := &corev1.VerifiedEmail{}
+		if err := proto.Unmarshal(entry.Value(), ve); err != nil {
+			t.Errorf("unmarshal %s: %v", email, err)
+			continue
+		}
+		if ve.Email != email {
+			t.Errorf("email round-trip: want %q, got %q", email, ve.Email)
+		}
+		if !ve.VerifiedAt.AsTime().Equal(verifiedAt) {
+			t.Errorf("verified_at round-trip for %q: want %v, got %v", email, verifiedAt, ve.VerifiedAt.AsTime())
+		}
+	}
+}
+
+func TestMigrateVerifiedEmailsToProto_NoLegacyKeys(t *testing.T) {
+	ctx, kv := setupTestKV(t)
+	// Empty bucket — must be a no-op without errors.
+	if err := MigrateVerifiedEmailsToProto(ctx, kv, log.New(nil)); err != nil {
+		t.Fatalf("expected no-op, got %v", err)
+	}
+}
+
+func TestMigrateVerifiedEmailsToProto_Idempotent(t *testing.T) {
+	ctx, kv := setupTestKV(t)
+
+	type legacy struct {
+		Email      string    `json:"email"`
+		VerifiedAt time.Time `json:"verified_at"`
+	}
+	blob, _ := json.Marshal([]legacy{
+		{Email: "bob@example.com", VerifiedAt: time.Now()},
+	})
+	if _, err := kv.Put(ctx, "user.bobid.verified_emails", blob); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	logger := log.New(nil)
+
+	// First run: converts.
+	if err := MigrateVerifiedEmailsToProto(ctx, kv, logger); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	// Second run: must be a no-op (legacy key already drained).
+	if err := MigrateVerifiedEmailsToProto(ctx, kv, logger); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+
+	// Per-email entry still present.
+	key := fmt.Sprintf("verified_emails.bobid.%s", testEmailHash("bob@example.com"))
+	if _, err := kv.Get(ctx, key); err != nil {
+		t.Errorf("expected per-email key intact, got err=%v", err)
+	}
+}

--- a/cli/internal/migrations/verified_emails_test.go
+++ b/cli/internal/migrations/verified_emails_test.go
@@ -30,7 +30,10 @@ func setupTestKV(t *testing.T) (context.Context, jetstream.KeyValue) {
 	ns, err := server.NewServer(&server.Options{
 		JetStream: true,
 		Port:      -1,
-		StoreDir:  t.TempDir(),
+		// JetStream still wants a StoreDir for its own metadata even
+		// when every stream/KV is memory-backed. t.TempDir auto-cleans
+		// so it stays out of the way.
+		StoreDir: t.TempDir(),
 	})
 	if err != nil {
 		t.Fatalf("create NATS server: %v", err)
@@ -58,7 +61,8 @@ func setupTestKV(t *testing.T) (context.Context, jetstream.KeyValue) {
 		t.Fatalf("jetstream: %v", err)
 	}
 	kv, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
-		Bucket: "TEST",
+		Bucket:  "TEST",
+		Storage: jetstream.MemoryStorage,
 	})
 	if err != nil {
 		t.Fatalf("create KV: %v", err)

--- a/cli/internal/pb/chatto/core/v1/models.pb.go
+++ b/cli/internal/pb/chatto/core/v1/models.pb.go
@@ -284,6 +284,64 @@ func (x *User) GetCreatedAt() *timestamppb.Timestamp {
 	return nil
 }
 
+// VerifiedEmail represents a single email address that has been verified
+// for a user. Stored in the INSTANCE KV bucket with key
+// "verified_emails.{userId}.{sha256(lowercase(email))}", one entry per
+// (user, email) pair. The hash in the key keeps emails representable in
+// NATS subject tokens and provides case-insensitive uniqueness; the
+// raw address is preserved in the value for display.
+type VerifiedEmail struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Email         string                 `protobuf:"bytes,1,opt,name=email,proto3" json:"email,omitempty"`
+	VerifiedAt    *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=verified_at,json=verifiedAt,proto3" json:"verified_at,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *VerifiedEmail) Reset() {
+	*x = VerifiedEmail{}
+	mi := &file_chatto_core_v1_models_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *VerifiedEmail) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*VerifiedEmail) ProtoMessage() {}
+
+func (x *VerifiedEmail) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_models_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use VerifiedEmail.ProtoReflect.Descriptor instead.
+func (*VerifiedEmail) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *VerifiedEmail) GetEmail() string {
+	if x != nil {
+		return x.Email
+	}
+	return ""
+}
+
+func (x *VerifiedEmail) GetVerifiedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.VerifiedAt
+	}
+	return nil
+}
+
 type Asset struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Asset:
@@ -297,7 +355,7 @@ type Asset struct {
 
 func (x *Asset) Reset() {
 	*x = Asset{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[2]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -309,7 +367,7 @@ func (x *Asset) String() string {
 func (*Asset) ProtoMessage() {}
 
 func (x *Asset) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[2]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -322,7 +380,7 @@ func (x *Asset) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Asset.ProtoReflect.Descriptor instead.
 func (*Asset) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{2}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *Asset) GetAsset() isAsset_Asset {
@@ -376,7 +434,7 @@ type S3Asset struct {
 
 func (x *S3Asset) Reset() {
 	*x = S3Asset{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[3]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -388,7 +446,7 @@ func (x *S3Asset) String() string {
 func (*S3Asset) ProtoMessage() {}
 
 func (x *S3Asset) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[3]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -401,7 +459,7 @@ func (x *S3Asset) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use S3Asset.ProtoReflect.Descriptor instead.
 func (*S3Asset) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{3}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *S3Asset) GetKey() string {
@@ -427,7 +485,7 @@ type NATSAsset struct {
 
 func (x *NATSAsset) Reset() {
 	*x = NATSAsset{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[4]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -439,7 +497,7 @@ func (x *NATSAsset) String() string {
 func (*NATSAsset) ProtoMessage() {}
 
 func (x *NATSAsset) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[4]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -452,7 +510,7 @@ func (x *NATSAsset) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NATSAsset.ProtoReflect.Descriptor instead.
 func (*NATSAsset) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{4}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *NATSAsset) GetKey() string {
@@ -472,7 +530,7 @@ type RoomMembership struct {
 
 func (x *RoomMembership) Reset() {
 	*x = RoomMembership{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[5]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -484,7 +542,7 @@ func (x *RoomMembership) String() string {
 func (*RoomMembership) ProtoMessage() {}
 
 func (x *RoomMembership) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[5]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -497,7 +555,7 @@ func (x *RoomMembership) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomMembership.ProtoReflect.Descriptor instead.
 func (*RoomMembership) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{5}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *RoomMembership) GetUserId() string {
@@ -527,7 +585,7 @@ type Role struct {
 
 func (x *Role) Reset() {
 	*x = Role{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[6]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -539,7 +597,7 @@ func (x *Role) String() string {
 func (*Role) ProtoMessage() {}
 
 func (x *Role) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[6]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -552,7 +610,7 @@ func (x *Role) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Role.ProtoReflect.Descriptor instead.
 func (*Role) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{6}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *Role) GetName() string {
@@ -594,7 +652,7 @@ type UserPresence struct {
 
 func (x *UserPresence) Reset() {
 	*x = UserPresence{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[7]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -606,7 +664,7 @@ func (x *UserPresence) String() string {
 func (*UserPresence) ProtoMessage() {}
 
 func (x *UserPresence) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[7]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -619,7 +677,7 @@ func (x *UserPresence) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserPresence.ProtoReflect.Descriptor instead.
 func (*UserPresence) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{7}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *UserPresence) GetStatus() UserPresenceStatus {
@@ -641,7 +699,7 @@ type PresenceChange struct {
 
 func (x *PresenceChange) Reset() {
 	*x = PresenceChange{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[8]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -653,7 +711,7 @@ func (x *PresenceChange) String() string {
 func (*PresenceChange) ProtoMessage() {}
 
 func (x *PresenceChange) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[8]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -666,7 +724,7 @@ func (x *PresenceChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PresenceChange.ProtoReflect.Descriptor instead.
 func (*PresenceChange) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{8}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *PresenceChange) GetUserId() string {
@@ -702,7 +760,7 @@ type ThreadMetadata struct {
 
 func (x *ThreadMetadata) Reset() {
 	*x = ThreadMetadata{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[9]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -714,7 +772,7 @@ func (x *ThreadMetadata) String() string {
 func (*ThreadMetadata) ProtoMessage() {}
 
 func (x *ThreadMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[9]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -727,7 +785,7 @@ func (x *ThreadMetadata) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ThreadMetadata.ProtoReflect.Descriptor instead.
 func (*ThreadMetadata) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{9}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ThreadMetadata) GetRootEventId() string {
@@ -787,7 +845,7 @@ type Attachment struct {
 
 func (x *Attachment) Reset() {
 	*x = Attachment{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[10]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -799,7 +857,7 @@ func (x *Attachment) String() string {
 func (*Attachment) ProtoMessage() {}
 
 func (x *Attachment) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[10]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -812,7 +870,7 @@ func (x *Attachment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Attachment.ProtoReflect.Descriptor instead.
 func (*Attachment) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{10}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *Attachment) GetId() string {
@@ -902,7 +960,7 @@ type MessageBody struct {
 
 func (x *MessageBody) Reset() {
 	*x = MessageBody{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[11]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -914,7 +972,7 @@ func (x *MessageBody) String() string {
 func (*MessageBody) ProtoMessage() {}
 
 func (x *MessageBody) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[11]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -927,7 +985,7 @@ func (x *MessageBody) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageBody.ProtoReflect.Descriptor instead.
 func (*MessageBody) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{11}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *MessageBody) GetAuthorId() string {
@@ -1000,7 +1058,7 @@ type LinkPreview struct {
 
 func (x *LinkPreview) Reset() {
 	*x = LinkPreview{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[12]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1012,7 +1070,7 @@ func (x *LinkPreview) String() string {
 func (*LinkPreview) ProtoMessage() {}
 
 func (x *LinkPreview) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[12]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1025,7 +1083,7 @@ func (x *LinkPreview) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LinkPreview.ProtoReflect.Descriptor instead.
 func (*LinkPreview) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{12}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *LinkPreview) GetUrl() string {
@@ -1097,7 +1155,7 @@ type CachedLinkPreview struct {
 
 func (x *CachedLinkPreview) Reset() {
 	*x = CachedLinkPreview{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[13]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1109,7 +1167,7 @@ func (x *CachedLinkPreview) String() string {
 func (*CachedLinkPreview) ProtoMessage() {}
 
 func (x *CachedLinkPreview) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[13]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1122,7 +1180,7 @@ func (x *CachedLinkPreview) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CachedLinkPreview.ProtoReflect.Descriptor instead.
 func (*CachedLinkPreview) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{13}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *CachedLinkPreview) GetUrl() string {
@@ -1204,7 +1262,7 @@ type RoomLayout struct {
 
 func (x *RoomLayout) Reset() {
 	*x = RoomLayout{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[14]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1216,7 +1274,7 @@ func (x *RoomLayout) String() string {
 func (*RoomLayout) ProtoMessage() {}
 
 func (x *RoomLayout) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[14]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1229,7 +1287,7 @@ func (x *RoomLayout) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomLayout.ProtoReflect.Descriptor instead.
 func (*RoomLayout) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{14}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{15}
 }
 
 // Deprecated: Marked as deprecated in chatto/core/v1/models.proto.
@@ -1271,7 +1329,7 @@ type RoomGroup struct {
 
 func (x *RoomGroup) Reset() {
 	*x = RoomGroup{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[15]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1283,7 +1341,7 @@ func (x *RoomGroup) String() string {
 func (*RoomGroup) ProtoMessage() {}
 
 func (x *RoomGroup) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[15]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1296,7 +1354,7 @@ func (x *RoomGroup) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomGroup.ProtoReflect.Descriptor instead.
 func (*RoomGroup) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{15}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *RoomGroup) GetId() string {
@@ -1352,7 +1410,7 @@ type VideoProcessingState struct {
 
 func (x *VideoProcessingState) Reset() {
 	*x = VideoProcessingState{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[16]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1364,7 +1422,7 @@ func (x *VideoProcessingState) String() string {
 func (*VideoProcessingState) ProtoMessage() {}
 
 func (x *VideoProcessingState) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[16]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1377,7 +1435,7 @@ func (x *VideoProcessingState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VideoProcessingState.ProtoReflect.Descriptor instead.
 func (*VideoProcessingState) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{16}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *VideoProcessingState) GetStatus() VideoStatus {
@@ -1446,7 +1504,7 @@ type VideoVariant struct {
 
 func (x *VideoVariant) Reset() {
 	*x = VideoVariant{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[17]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1458,7 +1516,7 @@ func (x *VideoVariant) String() string {
 func (*VideoVariant) ProtoMessage() {}
 
 func (x *VideoVariant) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[17]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1471,7 +1529,7 @@ func (x *VideoVariant) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VideoVariant.ProtoReflect.Descriptor instead.
 func (*VideoVariant) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{17}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *VideoVariant) GetAttachmentId() string {
@@ -1526,7 +1584,11 @@ const file_chatto_core_v1_models_proto_rawDesc = "" +
 	"\x05login\x18\x02 \x01(\tR\x05login\x12!\n" +
 	"\fdisplay_name\x18\x03 \x01(\tR\vdisplayName\x129\n" +
 	"\n" +
-	"created_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\"l\n" +
+	"created_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\"b\n" +
+	"\rVerifiedEmail\x12\x14\n" +
+	"\x05email\x18\x01 \x01(\tR\x05email\x12;\n" +
+	"\vverified_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"verifiedAt\"l\n" +
 	"\x05Asset\x12/\n" +
 	"\x04nats\x18\x02 \x01(\v2\x19.chatto.core.v1.NATSAssetH\x00R\x04nats\x12)\n" +
 	"\x02s3\x18\x01 \x01(\v2\x17.chatto.core.v1.S3AssetH\x00R\x02s3B\a\n" +
@@ -1643,50 +1705,52 @@ func file_chatto_core_v1_models_proto_rawDescGZIP() []byte {
 }
 
 var file_chatto_core_v1_models_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_chatto_core_v1_models_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
+var file_chatto_core_v1_models_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
 var file_chatto_core_v1_models_proto_goTypes = []any{
 	(UserPresenceStatus)(0),       // 0: chatto.core.v1.UserPresenceStatus
 	(VideoStatus)(0),              // 1: chatto.core.v1.VideoStatus
 	(*Room)(nil),                  // 2: chatto.core.v1.Room
 	(*User)(nil),                  // 3: chatto.core.v1.User
-	(*Asset)(nil),                 // 4: chatto.core.v1.Asset
-	(*S3Asset)(nil),               // 5: chatto.core.v1.S3Asset
-	(*NATSAsset)(nil),             // 6: chatto.core.v1.NATSAsset
-	(*RoomMembership)(nil),        // 7: chatto.core.v1.RoomMembership
-	(*Role)(nil),                  // 8: chatto.core.v1.Role
-	(*UserPresence)(nil),          // 9: chatto.core.v1.UserPresence
-	(*PresenceChange)(nil),        // 10: chatto.core.v1.PresenceChange
-	(*ThreadMetadata)(nil),        // 11: chatto.core.v1.ThreadMetadata
-	(*Attachment)(nil),            // 12: chatto.core.v1.Attachment
-	(*MessageBody)(nil),           // 13: chatto.core.v1.MessageBody
-	(*LinkPreview)(nil),           // 14: chatto.core.v1.LinkPreview
-	(*CachedLinkPreview)(nil),     // 15: chatto.core.v1.CachedLinkPreview
-	(*RoomLayout)(nil),            // 16: chatto.core.v1.RoomLayout
-	(*RoomGroup)(nil),             // 17: chatto.core.v1.RoomGroup
-	(*VideoProcessingState)(nil),  // 18: chatto.core.v1.VideoProcessingState
-	(*VideoVariant)(nil),          // 19: chatto.core.v1.VideoVariant
-	(*timestamppb.Timestamp)(nil), // 20: google.protobuf.Timestamp
+	(*VerifiedEmail)(nil),         // 4: chatto.core.v1.VerifiedEmail
+	(*Asset)(nil),                 // 5: chatto.core.v1.Asset
+	(*S3Asset)(nil),               // 6: chatto.core.v1.S3Asset
+	(*NATSAsset)(nil),             // 7: chatto.core.v1.NATSAsset
+	(*RoomMembership)(nil),        // 8: chatto.core.v1.RoomMembership
+	(*Role)(nil),                  // 9: chatto.core.v1.Role
+	(*UserPresence)(nil),          // 10: chatto.core.v1.UserPresence
+	(*PresenceChange)(nil),        // 11: chatto.core.v1.PresenceChange
+	(*ThreadMetadata)(nil),        // 12: chatto.core.v1.ThreadMetadata
+	(*Attachment)(nil),            // 13: chatto.core.v1.Attachment
+	(*MessageBody)(nil),           // 14: chatto.core.v1.MessageBody
+	(*LinkPreview)(nil),           // 15: chatto.core.v1.LinkPreview
+	(*CachedLinkPreview)(nil),     // 16: chatto.core.v1.CachedLinkPreview
+	(*RoomLayout)(nil),            // 17: chatto.core.v1.RoomLayout
+	(*RoomGroup)(nil),             // 18: chatto.core.v1.RoomGroup
+	(*VideoProcessingState)(nil),  // 19: chatto.core.v1.VideoProcessingState
+	(*VideoVariant)(nil),          // 20: chatto.core.v1.VideoVariant
+	(*timestamppb.Timestamp)(nil), // 21: google.protobuf.Timestamp
 }
 var file_chatto_core_v1_models_proto_depIdxs = []int32{
-	20, // 0: chatto.core.v1.User.created_at:type_name -> google.protobuf.Timestamp
-	6,  // 1: chatto.core.v1.Asset.nats:type_name -> chatto.core.v1.NATSAsset
-	5,  // 2: chatto.core.v1.Asset.s3:type_name -> chatto.core.v1.S3Asset
-	0,  // 3: chatto.core.v1.UserPresence.status:type_name -> chatto.core.v1.UserPresenceStatus
-	20, // 4: chatto.core.v1.ThreadMetadata.last_reply_at:type_name -> google.protobuf.Timestamp
-	4,  // 5: chatto.core.v1.Attachment.storage:type_name -> chatto.core.v1.Asset
-	20, // 6: chatto.core.v1.MessageBody.created_at:type_name -> google.protobuf.Timestamp
-	20, // 7: chatto.core.v1.MessageBody.updated_at:type_name -> google.protobuf.Timestamp
-	12, // 8: chatto.core.v1.MessageBody.attachments:type_name -> chatto.core.v1.Attachment
-	14, // 9: chatto.core.v1.MessageBody.link_preview:type_name -> chatto.core.v1.LinkPreview
-	14, // 10: chatto.core.v1.CachedLinkPreview.preview:type_name -> chatto.core.v1.LinkPreview
-	17, // 11: chatto.core.v1.RoomLayout.legacy_sections:type_name -> chatto.core.v1.RoomGroup
-	1,  // 12: chatto.core.v1.VideoProcessingState.status:type_name -> chatto.core.v1.VideoStatus
-	19, // 13: chatto.core.v1.VideoProcessingState.variants:type_name -> chatto.core.v1.VideoVariant
-	14, // [14:14] is the sub-list for method output_type
-	14, // [14:14] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	21, // 0: chatto.core.v1.User.created_at:type_name -> google.protobuf.Timestamp
+	21, // 1: chatto.core.v1.VerifiedEmail.verified_at:type_name -> google.protobuf.Timestamp
+	7,  // 2: chatto.core.v1.Asset.nats:type_name -> chatto.core.v1.NATSAsset
+	6,  // 3: chatto.core.v1.Asset.s3:type_name -> chatto.core.v1.S3Asset
+	0,  // 4: chatto.core.v1.UserPresence.status:type_name -> chatto.core.v1.UserPresenceStatus
+	21, // 5: chatto.core.v1.ThreadMetadata.last_reply_at:type_name -> google.protobuf.Timestamp
+	5,  // 6: chatto.core.v1.Attachment.storage:type_name -> chatto.core.v1.Asset
+	21, // 7: chatto.core.v1.MessageBody.created_at:type_name -> google.protobuf.Timestamp
+	21, // 8: chatto.core.v1.MessageBody.updated_at:type_name -> google.protobuf.Timestamp
+	13, // 9: chatto.core.v1.MessageBody.attachments:type_name -> chatto.core.v1.Attachment
+	15, // 10: chatto.core.v1.MessageBody.link_preview:type_name -> chatto.core.v1.LinkPreview
+	15, // 11: chatto.core.v1.CachedLinkPreview.preview:type_name -> chatto.core.v1.LinkPreview
+	18, // 12: chatto.core.v1.RoomLayout.legacy_sections:type_name -> chatto.core.v1.RoomGroup
+	1,  // 13: chatto.core.v1.VideoProcessingState.status:type_name -> chatto.core.v1.VideoStatus
+	20, // 14: chatto.core.v1.VideoProcessingState.variants:type_name -> chatto.core.v1.VideoVariant
+	15, // [15:15] is the sub-list for method output_type
+	15, // [15:15] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_chatto_core_v1_models_proto_init() }
@@ -1694,19 +1758,19 @@ func file_chatto_core_v1_models_proto_init() {
 	if File_chatto_core_v1_models_proto != nil {
 		return
 	}
-	file_chatto_core_v1_models_proto_msgTypes[2].OneofWrappers = []any{
+	file_chatto_core_v1_models_proto_msgTypes[3].OneofWrappers = []any{
 		(*Asset_Nats)(nil),
 		(*Asset_S3)(nil),
 	}
-	file_chatto_core_v1_models_proto_msgTypes[3].OneofWrappers = []any{}
-	file_chatto_core_v1_models_proto_msgTypes[12].OneofWrappers = []any{}
+	file_chatto_core_v1_models_proto_msgTypes[4].OneofWrappers = []any{}
+	file_chatto_core_v1_models_proto_msgTypes[13].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_core_v1_models_proto_rawDesc), len(file_chatto_core_v1_models_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   18,
+			NumMessages:   19,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -523,7 +523,7 @@ All room data — channels and DMs alike — lives in the unified `SERVER_*` buc
 | `user_by_login.{lowercase(login)}`     | Login-to-UserID index (case-insensitive)         |
 | `auth.{userId}.password`               | Password hash (stored separately)                |
 | `user.{userId}.avatar`                 | User avatar asset reference                      |
-| `user.{userId}.verified_emails`        | List of verified emails (JSON array)             |
+| `verified_emails.{userId}.{sha256(email)}` | One verified email per entry (proto `VerifiedEmail`) |
 | `email_verification.{token}`           | Verification token with userId/email (24h TTL)   |
 | `user_by_email.{sha256(email)}`        | Email-to-userId index (created on verification)  |
 | `password_reset.{token}`               | Password reset token                             |

--- a/proto/chatto/core/v1/models.proto
+++ b/proto/chatto/core/v1/models.proto
@@ -33,6 +33,17 @@ message User {
   google.protobuf.Timestamp created_at = 4; // When the user was created (null for users created before this field was added)
 }
 
+// VerifiedEmail represents a single email address that has been verified
+// for a user. Stored in the INSTANCE KV bucket with key
+// "verified_emails.{userId}.{sha256(lowercase(email))}", one entry per
+// (user, email) pair. The hash in the key keeps emails representable in
+// NATS subject tokens and provides case-insensitive uniqueness; the
+// raw address is preserved in the value for display.
+message VerifiedEmail {
+  string email = 1;
+  google.protobuf.Timestamp verified_at = 2;
+}
+
 message Asset {
   oneof asset {
     NATSAsset nats = 2;


### PR DESCRIPTION
## Summary

Most Chatto data is stored as protobuf, but the per-user verified-emails list lived as a JSON blob under `user.{userId}.verified_emails` — racy on append and inconsistent with the rest of the codebase. This PR moves verified emails to per-email proto entries keyed `verified_emails.{userId}.{sha256(email)}`, removing the read-modify-write tax on add and unblocking direct per-email operations. It also introduces a new `cli/internal/migrations` package as a central home for one-shot boot-time data migrations, with a package-level doc explaining the deprecation workflow so we can audit and retire legacy-data code over time. The verified-emails conversion runs idempotently at boot via `migrations.RunAll`; an unrelated `user_by_email.{sha256}` index continues to handle O(1) email→user lookups.

## Test plan

- [x] `mise test-cli` green (includes new migration tests: legacy conversion, empty-bucket no-op, idempotency)
- [ ] Manual: boot a server with pre-existing `user.*.verified_emails` JSON keys and confirm they're drained on first boot