### PR TITLE
feat(frontend): add server overview entries to Cmd-K quick switcher

### DIFF
--- a/frontend/e2e/quick-switcher.test.ts
+++ b/frontend/e2e/quick-switcher.test.ts
@@ -255,6 +255,78 @@ test.describe('Quick Switcher (Cmd-K)', () => {
     }
   });
 
+  test('lists the server as a destination entry', async ({ page, chatPage }) => {
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+
+    const dialog = await openSwitcher(page);
+
+    // Wait for results to load
+    await expect(dialog.locator('.animate-spin')).not.toBeVisible({
+      timeout: TIMEOUTS.UI_STANDARD
+    });
+
+    // The bootstrap server's name (from e2e/fixtures/chatto.toml) should
+    // appear as a Server entry in the switcher.
+    await expect(
+      dialog.getByRole('button', { name: /E2E Test Server.*Server/ })
+    ).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+  });
+
+  test('fuzzy search surfaces the server overview by name', async ({ page, chatPage }) => {
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+
+    const dialog = await openSwitcher(page);
+    const input = switcherInput(dialog);
+
+    await expect(switcherResults(dialog).first()).toBeVisible({
+      timeout: TIMEOUTS.UI_STANDARD
+    });
+
+    // Typing the server name (or a fuzzy fragment of it) should keep the
+    // Server entry in the results. Excluding "·" filters out room entries,
+    // whose accessible name is "# {room} · {server}".
+    await input.fill('e2e test');
+    await expect(
+      switcherResults(dialog)
+        .filter({ hasText: 'E2E Test Server' })
+        .filter({ hasNotText: '·' })
+    ).toBeVisible();
+  });
+
+  test('selecting the server entry navigates to its overview page', async ({
+    page,
+    chatPage
+  }) => {
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    // Navigate into a room first so we're somewhere other than the overview.
+    await chatPage.createSpace();
+    await chatPage.createRoom();
+
+    const dialog = await openSwitcher(page);
+    const input = switcherInput(dialog);
+
+    await expect(switcherResults(dialog).first()).toBeVisible({
+      timeout: TIMEOUTS.UI_STANDARD
+    });
+
+    await input.fill('e2e test');
+    await switcherResults(dialog)
+      .filter({ hasText: 'E2E Test Server' })
+      .filter({ hasNotText: '·' })
+      .first()
+      .click();
+
+    await expect(dialog).not.toBeVisible({ timeout: TIMEOUTS.UI_FAST });
+
+    // The Overview page renders a "Overview" heading.
+    await expect(page.getByRole('heading', { name: 'Overview' })).toBeVisible({
+      timeout: TIMEOUTS.UI_STANDARD
+    });
+  });
+
   test('navigating to a space works', async ({ page, chatPage }) => {
     await createAndLoginTestUser(page);
     await chatPage.goto();

--- a/frontend/src/lib/components/QuickSwitcher.svelte
+++ b/frontend/src/lib/components/QuickSwitcher.svelte
@@ -20,7 +20,7 @@
   type SpaceLogo = { name: string; logoUrl?: string | null };
 
   type ResultItem = {
-    kind: 'room' | 'dm' | 'destination';
+    kind: 'room' | 'dm' | 'destination' | 'server';
     id: string;
     label: string;
     detail: string;
@@ -102,6 +102,18 @@
           logoUrl: serverResult?.data?.server?.config.logoUrl ?? null
         };
         const currentUserId = roomsResult?.data?.viewer?.user.id ?? undefined;
+
+        items.push({
+          kind: 'server',
+          id: `server-${instance.id}`,
+          label: logo.name,
+          detail: '',
+          serverId: instance.id,
+          serverName: logo.name,
+          spaceLogo: logo,
+          href: resolve('/chat/[serverId]', { serverId: serverIdToSegment(instance.id) }),
+          score: 0
+        });
 
         if (roomsResult?.data?.viewer?.user) {
           for (const room of roomsResult.data.viewer.user.rooms) {
@@ -202,7 +214,7 @@
       });
 
       // Sort rest by kind then alphabetically
-      const kindOrder: Record<ResultItem['kind'], number> = { destination: 0, room: 2, dm: 3 };
+      const kindOrder: Record<ResultItem['kind'], number> = { destination: 0, server: 1, room: 2, dm: 3 };
       rest.sort(
         (a, b) => kindOrder[a.kind] - kindOrder[b.kind] || a.label.localeCompare(b.label)
       );
@@ -264,7 +276,7 @@
   // --- Navigation ---
 
   function itemUrl(item: ResultItem): string | undefined {
-    if (item.kind === 'destination' && item.href) return item.href;
+    if ((item.kind === 'destination' || item.kind === 'server') && item.href) return item.href;
     if (item.kind === 'dm') return resolve('/chat/[serverId]/(chrome)/[roomId]', { serverId: serverIdToSegment(item.serverId), roomId: item.id });
     if (item.kind === 'room') return resolve('/chat/[serverId]/(chrome)/[roomId]', { serverId: serverIdToSegment(item.serverId), roomId: item.id });
     return undefined;
@@ -314,6 +326,7 @@
 
   const kindLabels: Record<ResultItem['kind'], string> = {
     destination: 'Go to',
+    server: 'Server',
     room: 'Room',
     dm: 'DM'
   };


### PR DESCRIPTION
## Summary

- Adds each registered server as a "Server" entry in the Cmd-K quick switcher, alongside rooms and DMs. Selecting an entry navigates to that server's overview page (`/chat/[serverId]`).
- Server entries reuse the server logo and canonical name, and participate in the existing multi-token fuzzy match so the server name is searchable. They rank above rooms/DMs in the empty-query view (destination=0, server=1, room=2, dm=3).
- Adds e2e tests covering presence in the list, fuzzy matching by server name, and navigation to the overview page.

## Test plan

- [x] `pnpm check` (svelte-check) — 0 errors
- [x] `pnpm test:unit --run src/lib/components/quickSwitcherSearch.test.ts` — all pass
- [x] `playwright test e2e/quick-switcher.test.ts` — 14/14 pass (11 existing + 3 new)