### PR TITLE
fix(frontend): use base font size for username change notice

### DIFF
--- a/frontend/src/routes/chat/[serverId]/settings/+page.svelte
+++ b/frontend/src/routes/chat/[serverId]/settings/+page.svelte
@@ -425,7 +425,7 @@
   <p class="mb-2">
     Are you sure you want to change your username to <strong>@{pendingLogin}</strong>?
   </p>
-  <p class="mb-4 text-sm text-muted">You can only change your username once every 30 days.</p>
+  <p class="mb-4 text-muted">You can only change your username once every 30 days.</p>
 
   <div class="flex items-center gap-3">
     <Button onclick={confirmLoginChange}>


### PR DESCRIPTION
## Summary
- Drop `text-sm` from the 30-day cooldown notice in the Change Username confirmation dialog so it renders at the same size as the body text above it.

## Test plan
- [ ] Open Settings → trigger the Change Username confirmation dialog and verify the cooldown notice and the question text share the same font size.