### PR TITLE
style(admin): give panels a tinted header band, ridge, and lift

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -54,6 +54,13 @@
   --color-error: var(--color-red-600);
   --color-server: var(--color-indigo-600);
 
+  /* Panel header band tint + 1px inset highlight just under the divider.
+     Tint matches the outer app frame (`bg-surface-100`) so the header
+     reads as if cut from that surface. Highlight is tuned per theme
+     (bright in light, barely-there in dark) — see dark override. */
+  --color-panel-tint: var(--color-surface-100);
+  --color-panel-highlight: rgba(255, 255, 255, 0.7);
+
   /* Shimmer hover effect gradient */
   --shimmer-gradient: linear-gradient(
     120deg,
@@ -93,6 +100,8 @@
   --color-danger: var(--color-red-400);
   --color-error: var(--color-red-400);
   --color-server: var(--color-indigo-400);
+
+  --color-panel-highlight: rgba(255, 255, 255, 0.04);
 }
 
 @theme {
@@ -123,6 +132,25 @@
   --color-danger: var(--color-danger);
   --color-error: var(--color-error);
   --color-server: var(--color-server);
+
+  --color-panel-tint: var(--color-panel-tint);
+  --color-panel-highlight: var(--color-panel-highlight);
+}
+
+/* Panel header band — tinted background, hairline divider underneath, and
+ * a 1px inset highlight on whatever follows so the divider reads as an
+ * engraved ridge rather than a flat rule. The body inset is achieved via
+ * `box-shadow` on the *next* sibling (see `.panel-body`). Apply to the
+ * header element of any panel-like container (admin Panel, DataTable
+ * thead, hand-rolled room-group section).
+ */
+@utility panel-header {
+  background-color: var(--color-panel-tint);
+  border-bottom: 1px solid var(--color-border);
+}
+
+@utility panel-body {
+  box-shadow: inset 0 1px 0 var(--color-panel-highlight);
 }
 
 /* Button utilities — share the gradient + shadow visual language with

--- a/frontend/src/lib/components/admin/DataTable.svelte
+++ b/frontend/src/lib/components/admin/DataTable.svelte
@@ -40,7 +40,7 @@
 
 <table class="w-full">
   <thead>
-    <tr class="border-b border-border text-left text-sm text-muted">
+    <tr class="panel-header text-left text-sm text-muted">
       {@render header()}
     </tr>
   </thead>

--- a/frontend/src/lib/components/admin/Panel.svelte
+++ b/frontend/src/lib/components/admin/Panel.svelte
@@ -20,7 +20,12 @@
   } = $props();
 </script>
 
-<div class="overflow-hidden rounded-xl border border-border bg-background shadow-md">
+<div
+  class={[
+    'rounded-xl border border-border bg-background shadow-md',
+    noPadding && 'overflow-hidden'
+  ]}
+>
   {#if title}
     <div class="panel-header flex items-center justify-between gap-4 rounded-t-xl p-4">
       <div class="min-w-0">

--- a/frontend/src/lib/components/admin/Panel.svelte
+++ b/frontend/src/lib/components/admin/Panel.svelte
@@ -20,9 +20,9 @@
   } = $props();
 </script>
 
-<div class="rounded-xl border border-border bg-background">
+<div class="overflow-hidden rounded-xl border border-border bg-background shadow-md">
   {#if title}
-    <div class="flex items-center justify-between gap-4 border-b border-border p-4">
+    <div class="panel-header flex items-center justify-between gap-4 rounded-t-xl p-4">
       <div class="min-w-0">
         <h2 class="flex items-center gap-2 text-lg font-semibold">
           {#if icon}
@@ -44,7 +44,7 @@
       {/if}
     </div>
   {/if}
-  <div class={noPadding ? '' : 'p-6'}>
+  <div class={[noPadding ? '' : 'p-6', title && 'panel-body']}>
     {@render children()}
   </div>
 </div>

--- a/frontend/src/routes/chat/[serverId]/(chrome)/server-admin/rooms/+page.svelte
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/server-admin/rooms/+page.svelte
@@ -695,13 +695,13 @@
           <section
             animate:flip={{ duration: 200 }}
             class={[
-              'overflow-hidden rounded-xl border border-border bg-background transition-shadow',
+              'overflow-hidden rounded-xl border border-border bg-background shadow-md transition-shadow',
               draggingGroupId === group.id && 'shadow-lg ring-1 ring-accent/30'
             ]}
           >
             <!-- Set header -->
             <header
-              class="group-header flex items-center gap-3 border-b border-border px-4 py-3"
+              class="group-header panel-header flex items-center gap-3 px-4 py-3"
             >
               <span
                 role="button"


### PR DESCRIPTION
## Summary
- Admin/space-settings panels now read with a tinted header band (matching the outer app frame's `bg-surface-100`), a 1px inset "engraved" ridge under the divider, and a `shadow-md` lift so they feel like they're hovering off the page.
- Implemented via two new theme tokens (`--color-panel-tint`, `--color-panel-highlight`) and `.panel-header` / `.panel-body` utilities; applied to `Panel`, `DataTable` thead (so the users list gets the band too), and the room-group section in server-admin/rooms.
- Added `overflow-hidden` to `Panel` so the sticky first column in permission matrices stops poking sharp corners past the panel's rounded edges.

## Test plan
- [ ] Eyeball admin pages in light mode — panel headers should read as a subtle "shelf" tinted like the page background, with a faint white ridge under the divider and a soft drop shadow.
- [ ] Check dark mode — tint should be visible but quiet; ridge should be barely there (0.04 alpha) rather than a bright line.
- [ ] Open a permission matrix (e.g. server-admin/roles) and confirm the bottom-left corner of the sticky `Permission` column no longer pokes a sharp rectangle past the rounded panel corner.