### PR TITLE
fix(frontend): restore per-server last-room memory on server re-entry

### DIFF
--- a/docs/fdr/FDR-026-last-room-memory.md
+++ b/docs/fdr/FDR-026-last-room-memory.md
@@ -1,0 +1,59 @@
+# FDR-026: Last-Room Memory
+
+**Status:** Active
+**Last reviewed:** 2026-05-19
+
+## Overview
+
+The frontend remembers, per connected server, the last channel room the user was in. When the user re-enters a server — by clicking its icon in the sidebar, by landing on the app after sign-in, or by hitting any link that points at the server root — they're taken back to that room instead of an intermediate landing page. The mechanic is local to the device and lightweight; if no last room is known, the user falls through to the server's Overview page.
+
+## Behavior
+
+- Visiting a channel room records it as the server's last room. The record is per-server, not global.
+- Visiting `/chat/{server}` (the server root) redirects to the recorded last room. If none is stored, it falls through to the server's Overview page at `/chat/{server}/overview`.
+- Visiting `/` (the app root) after sign-in redirects to the home server's last room when one exists. Otherwise it lands on the home server's root, which itself falls through to Overview.
+- The Overview page is reachable directly at `/chat/{server}/overview` — typing that URL, or clicking the sidebar "Overview" entry, never bounces to the last room.
+- DM rooms are deliberately not recorded. Only channel rooms qualify as a "last room".
+- The record is cleared when:
+  - The room becomes inaccessible (deleted, the user lost access, or the server says it can't be loaded). The user is redirected back to the server root, which then falls through to Overview.
+  - The server is removed from the client (disconnect or sign out).
+  - The user no longer has access to the server itself (validation fails).
+- Each connected server has its own record. Switching servers in a multi-server setup lands on that server's own last room.
+- The Cmd-K Quick Switcher's "Server" entry navigates to Overview, not to the last room. (See FDR-015.)
+
+## Design Decisions
+
+### 1. Per-server, not global
+
+**Decision:** The last-room record is keyed by server ID. Each connected server has its own slot.
+**Why:** In a multi-server setup, the user's mental model is "I was in room X on server A". A single global last-room would jump them to the wrong server's room when they switch icons. See ADR-025.
+**Tradeoff:** Storage scales linearly with the number of connected servers. In practice that's a handful of bytes per server.
+
+### 2. Server root is a redirector, Overview lives at its own URL
+
+**Decision:** `/chat/{server}` is a redirect-only route. The actual Overview page is rendered at `/chat/{server}/overview`.
+**Why:** Re-entering a server you've been using should land you in the room you were last in — that's the dominant case. But the Overview must still be reachable on demand (sidebar nav, Cmd-K, the empty-state link in the room list). Splitting the routes makes the URL itself the source of truth: one URL means "take me back where I was", the other means "show me the Overview".
+**Tradeoff:** Two URLs for what was previously one. Worth it; the alternative (querystring flags or shallow state) would couple the page to its callers.
+
+### 3. Channels only — never DMs
+
+**Decision:** Only channel rooms are recorded. Entering a DM does not update the last-room slot.
+**Why:** DMs are conversation-driven, not place-driven. Auto-landing in a DM the user opened a week ago is surprising and easily wrong (the conversation may be stale, the user may not want it surfaced first). Channels are the implicit "where I work" destination.
+**Tradeoff:** A user whose primary use of a server is DMs gets the Overview as a landing page until they visit a channel. Acceptable; the Overview is a usable starting point.
+
+### 4. Stored on-device in `localStorage`
+
+**Decision:** The record lives in browser `localStorage`, namespaced per server. Not synced to the backend, not synced across devices.
+**Why:** "The last room I was in" is contextual to the device and session — what's relevant on your laptop usually isn't relevant on your phone. Local storage is also free and instant; a server-synced version would need a write on every room entry. The same rationale applies to Quick Switcher recents (FDR-015).
+**Tradeoff:** The record doesn't survive a cache clear or a switch to a fresh browser profile. The user falls back to Overview, which is harmless.
+
+### 5. Cleared on access failure, not just on sign-out
+
+**Decision:** When a room can't be loaded (deleted, lost access, server says no), the record is cleared and the user is redirected to the server root.
+**Why:** Without this, the redirect would loop: server root → last room → access denied → server root → … A stale record is the most likely cause of a "I keep landing in a broken place" experience, and clearing it costs nothing.
+**Tradeoff:** If the inaccessibility is transient (a network blip mid-load), the record is wiped and the user falls through to Overview on the next visit. The server validation flow distinguishes transient errors from genuine access denials, so this only fires on the latter.
+
+## Related
+
+- **ADRs:** ADR-025 (multi-instance client architecture)
+- **FDRs:** FDR-015 (Quick Switcher), FDR-019 (Room Lifecycle)

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -35,3 +35,4 @@ See [`.claude/skills/fdr/SKILL.md`](../../.claude/skills/fdr/SKILL.md) for the F
 | [FDR-023](FDR-023-authentication-and-sessions.md) | Authentication & Sessions | Active | 2026-05-19 |
 | [FDR-024](FDR-024-permission-inspection-tool.md) | Permission Inspection Tool | Active | 2026-05-19 |
 | [FDR-025](FDR-025-user-search-and-member-directory.md) | User Search & Member Directory | Active | 2026-05-19 |
+| [FDR-026](FDR-026-last-room-memory.md) | Last-Room Memory | Active | 2026-05-19 |

--- a/frontend/e2e/audio-player.test.ts
+++ b/frontend/e2e/audio-player.test.ts
@@ -39,7 +39,7 @@ test.describe('audio player', () => {
       // User 2 joins the space via Explore, then enters the room
       const explorePage2 = new ExplorePage(page2);
       await page2.goto(routes.spaces);
-      await page2.waitForURL(routes.spaces);
+      await page2.waitForURL(routes.patterns.spaceOrRoom);
       await explorePage2.joinSpace(testSpaceName);
       await chatPage2.enterRoom('general');
 

--- a/frontend/e2e/browse-rooms-direct-nav.test.ts
+++ b/frontend/e2e/browse-rooms-direct-nav.test.ts
@@ -44,7 +44,7 @@ test.describe('Browse Rooms direct navigation', () => {
     // Click the Overview link in the sidebar (which hosts the room
     // directory now that Browse Rooms has been folded in).
     await page.getByRole('link', { name: 'Overview' }).click();
-    await page.waitForURL(/\/chat\/-$/);
+    await page.waitForURL(/\/chat\/-\/overview$/);
 
     // Should show the Browse Rooms heading
     await expect(page.getByRole('heading', { name: 'Overview' })).toBeVisible();

--- a/frontend/e2e/gif-to-video.test.ts
+++ b/frontend/e2e/gif-to-video.test.ts
@@ -41,7 +41,7 @@ test.describe('animated GIF to video conversion', () => {
 
 			const explorePage2 = new ExplorePage(page2);
 			await page2.goto(routes.spaces);
-			await page2.waitForURL(routes.spaces);
+			await page2.waitForURL(routes.patterns.spaceOrRoom);
 			await explorePage2.joinSpace(testSpaceName);
 			await chatPage2.enterRoom('general');
 

--- a/frontend/e2e/pages/ExplorePage.ts
+++ b/frontend/e2e/pages/ExplorePage.ts
@@ -13,8 +13,10 @@ export class ExplorePage {
    * Navigate to the explore spaces page.
    */
   async goto(): Promise<void> {
+    // `routes.spaces` (the server root) now redirects to either the user's
+    // last room or the Overview page, so wait for whichever it landed on.
     await this.page.goto(routes.spaces);
-    await this.page.waitForURL(routes.spaces);
+    await this.page.waitForURL(routes.patterns.spaceOrRoom);
   }
 
   /**

--- a/frontend/e2e/routes.ts
+++ b/frontend/e2e/routes.ts
@@ -53,9 +53,9 @@ export const messageLink = (roomId: string, messageId: string) =>
 export const spaces = `/chat/${HOME}`;
 
 // Browse Rooms was retired; its functionality is folded into the server
-// Overview page at `/chat/{server}`. The export name is kept as an alias
-// so existing tests don't need to be renamed in a single sweep.
-export const browseRooms = `/chat/${HOME}`;
+// Overview page at `/chat/{server}/overview`. The export name is kept as
+// an alias so existing tests don't need to be renamed in a single sweep.
+export const browseRooms = `/chat/${HOME}/overview`;
 export const threads = `/chat/${HOME}/threads`;
 export const preferences = `/chat/${HOME}/preferences`;
 
@@ -127,8 +127,8 @@ export const patterns = {
 	chatRootOrRoomWithQuery: /\/chat\/-(?:\/[a-zA-Z0-9]+)?(?:\?.*)?$/,
 	/** Any room with query params (e.g. ?highlight=) */
 	anyRoomWithQuery: /\/chat\/-\/[a-zA-Z0-9]+/,
-	/** Browse rooms — folded into the server overview at /chat/- */
-	browseRooms: /\/chat\/-$/,
+	/** Browse rooms — folded into the server overview at /chat/-/overview */
+	browseRooms: /\/chat\/-\/overview$/,
 	/** Email verified redirect */
 	emailVerified: /\?email_verified=true/,
 

--- a/frontend/e2e/server-flows.test.ts
+++ b/frontend/e2e/server-flows.test.ts
@@ -51,6 +51,57 @@ test.describe('Landing Page', () => {
 	});
 });
 
+test.describe('Last-Room Memory', () => {
+	test('navigating to /chat/- redirects to the last visited room', async ({
+		page,
+		chatPage
+	}) => {
+		await createAndLoginTestUser(page);
+		await chatPage.goto();
+
+		// Create and enter a room. `createRoom` waits for the room header to
+		// render, which means Room.svelte has mounted and the `setLastRoom`
+		// effect has fired.
+		const roomName = await chatPage.createRoom();
+		const roomUrl = page.url();
+
+		// Navigate to the server root — should redirect back to the room.
+		await page.goto(routes.chat);
+		await expect(page).toHaveURL(roomUrl);
+		await expect(chatPage.getRoomHeader(roomName)).toBeVisible();
+	});
+
+	test('/chat/- falls through to Overview when no last room is stored', async ({
+		page,
+		chatPage
+	}) => {
+		await createAndLoginTestUser(page);
+		await chatPage.goto();
+
+		// Fresh login, no room visited yet — `/chat/-` should land on Overview.
+		await page.goto(routes.chat);
+		await page.waitForURL(/\/chat\/-\/overview$/);
+		await expect(page.getByRole('heading', { name: 'Overview' })).toBeVisible();
+	});
+
+	test('Overview page is reachable directly even when a last room is stored', async ({
+		page,
+		chatPage
+	}) => {
+		await createAndLoginTestUser(page);
+		await chatPage.goto();
+
+		// Visit a room so a last-room is stored.
+		await chatPage.createRoom();
+
+		// Navigating directly to the Overview URL should stay on Overview,
+		// not bounce to the last room.
+		await page.goto('/chat/-/overview');
+		await expect(page).toHaveURL(/\/chat\/-\/overview$/);
+		await expect(page.getByRole('heading', { name: 'Overview' })).toBeVisible();
+	});
+});
+
 test.describe('Origin Auto-Registration', () => {
 	test('origin instance is registered in localStorage after probe', async ({ page, chatPage }) => {
 		await createAndLoginTestUser(page);

--- a/frontend/e2e/video-player.test.ts
+++ b/frontend/e2e/video-player.test.ts
@@ -44,7 +44,7 @@ test.describe('video player', () => {
 			// User 2 joins the space via Explore, then enters the room.
 			const explorePage2 = new ExplorePage(page2);
 			await page2.goto(routes.spaces);
-			await page2.waitForURL(routes.spaces);
+			await page2.waitForURL(routes.patterns.spaceOrRoom);
 			await explorePage2.joinSpace(testSpaceName);
 			await chatPage2.enterRoom('general');
 

--- a/frontend/src/lib/RoomList.svelte
+++ b/frontend/src/lib/RoomList.svelte
@@ -366,7 +366,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   <EmptyState icon="uil--comments" title="No rooms yet">
     You haven't joined any rooms on this server. Head to the
     <a
-      href={resolve('/chat/[serverId]', { serverId: serverSegment })}
+      href={resolve('/chat/[serverId]/(chrome)/overview', { serverId: serverSegment })}
       class="link">Overview</a
     >
     to browse the directory and join the ones you're interested in.

--- a/frontend/src/lib/components/QuickSwitcher.svelte
+++ b/frontend/src/lib/components/QuickSwitcher.svelte
@@ -111,7 +111,7 @@
           serverId: instance.id,
           serverName: logo.name,
           spaceLogo: logo,
-          href: resolve('/chat/[serverId]', { serverId: serverIdToSegment(instance.id) }),
+          href: resolve('/chat/[serverId]/(chrome)/overview', { serverId: serverIdToSegment(instance.id) }),
           score: 0
         });
 

--- a/frontend/src/routes/chat/[serverId]/(chrome)/+layout.svelte
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/+layout.svelte
@@ -33,7 +33,7 @@
 
   // Detect if we're on the server Overview page
   const isHomeActive = $derived(
-    page.url.pathname === resolve('/chat/[serverId]', { serverId: serverSegment })
+    page.url.pathname === resolve('/chat/[serverId]/(chrome)/overview', { serverId: serverSegment })
   );
 
   // Detect if we're on the My Threads page
@@ -336,7 +336,7 @@
 
               <nav class="sidebar-nav p-2">
                 <a
-                  href={resolve('/chat/[serverId]', { serverId: serverSegment })}
+                  href={resolve('/chat/[serverId]/(chrome)/overview', { serverId: serverSegment })}
                   class={['sidebar-item', isHomeActive ? 'bg-surface-100' : 'text-muted']}
                 >
                   <span class="sidebar-icon iconify uil--estate"></span>

--- a/frontend/src/routes/chat/[serverId]/(chrome)/+page.svelte
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/+page.svelte
@@ -1,32 +1,25 @@
 <script lang="ts">
+  import { goto } from '$app/navigation';
+  import { resolve } from '$app/paths';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { serverIdToSegment } from '$lib/navigation';
-  import { serverRegistry } from '$lib/state/server/registry.svelte';
-  import RoomDirectory from '$lib/RoomDirectory.svelte';
-  import PaneHeader from '$lib/ui/PaneHeader.svelte';
-  import PageTitle from '$lib/ui/PageTitle.svelte';
+  import { resolveLastPosition } from '$lib/storage/lastRoom';
 
-  // Active-server stores. Both substores self-manage refresh and
-  // live-event ingestion from inside `ServerStateStore`, so this page
-  // just reads them. Re-derives reactively when the URL `[serverId]`
-  // changes.
-  const stores = $derived(serverRegistry.getStore(getActiveServer()));
-  const directory = $derived(stores.roomDirectory);
-  const roomsStore = $derived(stores.rooms);
-  const serverSegment = $derived(serverIdToSegment(getActiveServer()));
+  // Re-entry into a server lands on the user's last visited room when one
+  // is known; otherwise it falls through to the Overview page. Keeps the
+  // Overview itself reachable via its own URL.
+  $effect(() => {
+    const serverId = getActiveServer();
+    const lastPos = resolveLastPosition(serverId);
+    if (lastPos) {
+      // eslint-disable-next-line svelte/no-navigation-without-resolve -- lastPos from resolveLastPosition() is already resolved
+      goto(lastPos, { replaceState: true });
+      return;
+    }
+    goto(resolve('/chat/[serverId]/(chrome)/overview', { serverId: serverIdToSegment(serverId) }), {
+      replaceState: true
+    });
+  });
 </script>
 
-<PageTitle title="Overview" />
-
-<div class="flex min-h-0 min-w-0 flex-1 flex-col">
-  <PaneHeader title="Overview" showMobileNav />
-
-  <div class="flex-1 overflow-auto">
-    <div class="mx-auto flex max-w-6xl flex-col gap-8 p-6">
-      <section class="flex flex-col gap-3">
-        <h2 class="text-lg font-semibold">Rooms</h2>
-        <RoomDirectory {directory} {roomsStore} {serverSegment} />
-      </section>
-    </div>
-  </div>
-</div>
+<!-- Redirect in progress -->

--- a/frontend/src/routes/chat/[serverId]/(chrome)/overview/+page.svelte
+++ b/frontend/src/routes/chat/[serverId]/(chrome)/overview/+page.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { getActiveServer } from '$lib/state/activeServer.svelte';
+  import { serverIdToSegment } from '$lib/navigation';
+  import { serverRegistry } from '$lib/state/server/registry.svelte';
+  import RoomDirectory from '$lib/RoomDirectory.svelte';
+  import PaneHeader from '$lib/ui/PaneHeader.svelte';
+  import PageTitle from '$lib/ui/PageTitle.svelte';
+
+  // Active-server stores. Both substores self-manage refresh and
+  // live-event ingestion from inside `ServerStateStore`, so this page
+  // just reads them. Re-derives reactively when the URL `[serverId]`
+  // changes.
+  const stores = $derived(serverRegistry.getStore(getActiveServer()));
+  const directory = $derived(stores.roomDirectory);
+  const roomsStore = $derived(stores.rooms);
+  const serverSegment = $derived(serverIdToSegment(getActiveServer()));
+</script>
+
+<PageTitle title="Overview" />
+
+<div class="flex min-h-0 min-w-0 flex-1 flex-col">
+  <PaneHeader title="Overview" showMobileNav />
+
+  <div class="flex-1 overflow-auto">
+    <div class="mx-auto flex max-w-6xl flex-col gap-8 p-6">
+      <section class="flex flex-col gap-3">
+        <h2 class="text-lg font-semibold">Rooms</h2>
+        <RoomDirectory {directory} {roomsStore} {serverSegment} />
+      </section>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

The Overview page introduced in #496 / #506 replaced the previous "redirect to last visited room" behavior at \`/chat/[serverId]\`, so switching servers via the SpaceList icon (and other links to the server root) always landed users on Overview instead of the room they were last in.

This restores the last-room memory by splitting the route: \`/chat/[serverId]\` is now a redirect (last room → otherwise Overview), and the Overview content lives at \`/chat/[serverId]/(chrome)/overview\`. Sidebar Overview link, RoomList empty-state link, and the Cmd-K "Server" entry are updated to point at the new Overview path, preserving #506's intent of routing the QuickSwitcher entry to Overview.

## Test plan

- [x] Login with no last-room → lands on \`/chat/-/overview\`
- [x] Visit a room, navigate to \`/chat/-\` → redirects to that room
- [x] Click sidebar "Overview" → goes to Overview
- [x] Click server icon in SpaceList → redirects to last room
- [x] Cmd-K "Server: …" entry → goes to Overview
- [x] \`pnpm check\` clean