### PR TITLE
fix(frontend): route per-server settings mutations to active server

### DIFF
--- a/frontend/src/routes/chat/[serverId]/settings/+page.svelte
+++ b/frontend/src/routes/chat/[serverId]/settings/+page.svelte
@@ -16,12 +16,17 @@
   } from '$lib/validation';
   import { getAvatarInitials } from '$lib/utils/initials';
 
-  // Capture the active server's CurrentUserState at init. The settings
-  // page is scoped to one server (it lives under `[serverId]/settings`),
-  // so we don't need the registry lookup to re-resolve reactively — and
-  // the captured CurrentUserState is itself a reactive class (`user` /
-  // `loading` are `$state`), so subsequent profile updates flow through.
-  const currentUser = serverRegistry.getStore(getActiveServer()).currentUser;
+  // Capture the active server's CurrentUserState and GraphQL client at
+  // init. The settings page is scoped to one server (it lives under
+  // `[serverId]/settings`), so we don't need the registry lookup to
+  // re-resolve reactively — and the captured CurrentUserState is itself
+  // a reactive class (`user` / `loading` are `$state`), so subsequent
+  // profile updates flow through. The client must point at the active
+  // server so profile/avatar mutations land on the right backend, not
+  // always the origin.
+  const activeServerId = getActiveServer();
+  const currentUser = serverRegistry.getStore(activeServerId).currentUser;
+  const gqlClient = graphqlClientManager.getClient(activeServerId).client;
 
   // Form state seeded once from the user's current profile. After init
   // these are local edit buffers; profile updates from elsewhere
@@ -66,7 +71,7 @@
 
   // Fetch last login change on mount
   $effect(() => {
-    graphqlClientManager.originClient.client
+    gqlClient
       .query(
         graphql(`
           query GetMyLastLoginChange {
@@ -112,7 +117,7 @@
     uploadingAvatar = true;
 
     try {
-      const result = await graphqlClientManager.originClient.client
+      const result = await gqlClient
         .mutation(
           graphql(`
             mutation UploadAvatar($input: UploadAvatarInput!) {
@@ -167,7 +172,7 @@
     deletingAvatar = true;
 
     try {
-      const result = await graphqlClientManager.originClient.client
+      const result = await gqlClient
         .mutation(
           graphql(`
             mutation DeleteAvatar($userId: ID!) {
@@ -264,7 +269,7 @@
     successMessage = '';
 
     try {
-      const result = await graphqlClientManager.originClient.client
+      const result = await gqlClient
         .mutation(
           graphql(`
             mutation UpdateProfile($input: UpdateProfileInput!) {

--- a/frontend/src/routes/chat/[serverId]/settings/account/+page.svelte
+++ b/frontend/src/routes/chat/[serverId]/settings/account/+page.svelte
@@ -9,6 +9,7 @@
   import { notifyLogout } from '$lib/auth/sessionChannel';
 
   const currentUser = $derived(serverRegistry.getStore(getActiveServer()).currentUser);
+  const gqlClient = $derived(graphqlClientManager.getClient(getActiveServer()).client);
 
   // Check if the user has permission to delete their own account
   const permQuery = useQuery(
@@ -53,7 +54,7 @@
 
     try {
       // Step 1: Request a confirmation token (XSS protection)
-      const tokenResult = await graphqlClientManager.originClient.client
+      const tokenResult = await gqlClient
         .mutation(
           graphql(`
             mutation RequestAccountDeletion {
@@ -76,7 +77,7 @@
       }
 
       // Step 2: Delete account with the confirmation token
-      const result = await graphqlClientManager.originClient.client
+      const result = await gqlClient
         .mutation(
           graphql(`
             mutation DeleteMyAccount($input: DeleteMyAccountInput!) {

--- a/frontend/src/routes/chat/[serverId]/settings/preferences/+page.svelte
+++ b/frontend/src/routes/chat/[serverId]/settings/preferences/+page.svelte
@@ -11,6 +11,7 @@
 
   const userSettings = getUserSettings();
   const currentUser = $derived(serverRegistry.getStore(getActiveServer()).currentUser);
+  const gqlClient = $derived(graphqlClientManager.getClient(getActiveServer()).client);
 
   // All available IANA timezone names
   const allTimezones = Intl.supportedValuesOf('timeZone');
@@ -128,7 +129,7 @@
     error = '';
 
     try {
-      const result = await graphqlClientManager.originClient.client
+      const result = await gqlClient
         .mutation(
           graphql(`
             mutation UpdateSettings($input: UpdateSettingsInput!) {


### PR DESCRIPTION
## Summary

- Settings pages under `routes/chat/[serverId]/settings/` were using `graphqlClientManager.originClient.client` for all mutations, so avatar upload, profile edits, preference changes, and account deletion always hit the origin (home) server — even when viewing a registered remote instance.
- Each page now resolves the GraphQL client from the active server via `graphqlClientManager.getClient(getActiveServer())`, so the mutations land on the backend that actually owns the account being edited.

## Test plan

- [ ] Open a registered remote instance's `/chat/<hostname>/settings`, upload an avatar, and confirm it appears for that user on the remote server (not the origin).
- [ ] Verify profile/display-name/username updates and preferences (timezone, time format) on a remote instance persist on that instance.
- [ ] Sanity check the same flows still work on the origin instance.