### PR TITLE
fix(frontend): keep unread separator stable across tab refocus

### DIFF
--- a/frontend/e2e/unread-indicators.test.ts
+++ b/frontend/e2e/unread-indicators.test.ts
@@ -576,6 +576,131 @@ test.describe('Room unread separator', () => {
     }
   });
 
+  test('refocus keeps the separator stable when only non-message events arrived while hidden', async ({
+    page,
+    chatPage,
+    roomPage,
+    browser,
+    serverURL
+  }) => {
+    test.setTimeout(60000); // Multi-user test with real-time events needs more time
+
+    // Regression test for the bug where the "New messages" separator would
+    // flicker out on tab refocus when the only thing that arrived while the
+    // tab was hidden was a non-message room event (join, leave). The server-
+    // side read cursor only tracks root messages, so a refocus mutation
+    // round-trip returned previousLastReadAt === lastReadAt and the bounded
+    // window collapsed to empty — making the marker disappear on focus and
+    // reappear on every blur.
+    //
+    // The fix in useRoomUnread no longer overwrites bounds on a same-room
+    // refocus; this test exercises the exact path that used to break.
+
+    // User A: Create account, space, enter general, post the initial message
+    // so User B has a real read cursor anchored on a root message.
+    const userA = await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.createSpace('Non-Message Hidden Tab Test');
+
+    await chatPage.enterRoom('general');
+    await waitForRoomReady(page, 'general');
+    await roomPage.sendMessage('Anchor message from User A');
+
+    const generalRoomId = await getRoomIdByName(page, 'general');
+
+    // User B: Join space, enter general, read the anchor message — caught
+    // up, no separator yet.
+    const context2 = await browser!.newContext({ baseURL: serverURL });
+    const page2 = await context2.newPage();
+
+    try {
+      await createAndLoginTestUser(page2);
+      await joinSpace(page2);
+      await page2.goto(routes.space());
+      await page2.waitForURL(routes.patterns.anySpace);
+
+      const chatPage2 = new ChatPage(page2);
+      const roomPage2 = new RoomPage(page2);
+
+      await chatPage2.enterRoom('general');
+      await waitForRoomReady(page2, 'general');
+      await roomPage2.expectMessageVisible('Anchor message from User A');
+      await waitForRoomRead(page2, generalRoomId);
+      await roomPage2.expectNoUnreadSeparator();
+
+      // User B's tab goes hidden — presence drops, anchoring the unread
+      // separator at the server read cursor with an open upper bound.
+      await page2.evaluate(() => {
+        Object.defineProperty(document, 'visibilityState', {
+          value: 'hidden',
+          writable: true,
+          configurable: true
+        });
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+
+      // User A leaves general. The "User A left the room" event is a non-
+      // message room event — it does NOT advance the server's root-message
+      // read cursor.
+      await page.getByTitle('Leave room').click();
+      await page.getByRole('dialog').getByRole('button', { name: 'Leave Room' }).click();
+
+      // User B (still hidden) receives the leave event over the live
+      // subscription. The separator anchors above it.
+      await expect(
+        page2.getByText(`${userA.displayName} left the room`)
+      ).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+      await roomPage2.expectUnreadSeparator();
+
+      // User B's tab returns to the foreground. With the bug, this refocus
+      // would fire markRoomAsRead which returns previousLastReadAt ===
+      // lastReadAt (server cursor never moved), the .then() would overwrite
+      // the bounds with that empty window, and the separator would blink out.
+      // The fix preserves the unfocus-edge anchor on a same-room refocus.
+      await page2.evaluate(() => {
+        Object.defineProperty(document, 'visibilityState', {
+          value: 'visible',
+          writable: true,
+          configurable: true
+        });
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+
+      // Separator must remain visible across the focus transition — it
+      // shouldn't toggle just because the user came back to the tab.
+      await expect(async () => {
+        await roomPage2.expectUnreadSeparator();
+      }).toPass({ timeout: TIMEOUTS.UI_STANDARD, intervals: POLLING_INTERVALS });
+
+      // A second hide/show cycle to be sure: with the old code the marker
+      // would reappear on blur and vanish again on focus, so a second
+      // refocus must also leave it in place.
+      await page2.evaluate(() => {
+        Object.defineProperty(document, 'visibilityState', {
+          value: 'hidden',
+          writable: true,
+          configurable: true
+        });
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+      await roomPage2.expectUnreadSeparator();
+
+      await page2.evaluate(() => {
+        Object.defineProperty(document, 'visibilityState', {
+          value: 'visible',
+          writable: true,
+          configurable: true
+        });
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+      await expect(async () => {
+        await roomPage2.expectUnreadSeparator();
+      }).toPass({ timeout: TIMEOUTS.UI_STANDARD, intervals: POLLING_INTERVALS });
+    } finally {
+      await context2.close();
+    }
+  });
+
   test('backgrounding the tab does not strand the user own latest message below the separator', async ({
     page,
     chatPage,

--- a/frontend/src/lib/hooks/useRoomUnread.svelte.ts
+++ b/frontend/src/lib/hooks/useRoomUnread.svelte.ts
@@ -114,9 +114,8 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
     // On a room change, clear the previous room's separator so it can't
     // flash in the new room while the mutation below is in flight. On a
     // refocus of the *same* room, leave the existing separator in place —
-    // it was anchored on the presence-false edge and the mutation only
-    // refines its upper bound (previousLastReadAt matches the anchor), so
-    // clearing it here would blink the marker out and back in.
+    // it was anchored on the presence-false edge and the mutation result
+    // is deliberately ignored below so the marker stays stable.
     if (isRoomChange) {
       unreadAfterTime = null;
       unreadBeforeTime = null;
@@ -125,7 +124,14 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
     markRoomAsRead(roomId).then((result) => {
       const current = getProps();
       if (current.roomId === roomId && result) {
-        if (result.previousLastReadAt && result.lastReadAt) {
+        // Only adopt the server's (previousLastReadAt, lastReadAt] window on
+        // a fresh room entry. On a same-room refocus the separator was just
+        // anchored on the presence-false edge against `lastCursor` with an
+        // open upper bound — overwriting it here collapses the window to
+        // empty whenever the server cursor hasn't moved (e.g. only non-
+        // message events like joins/leaves arrived while away), making the
+        // separator vanish on focus and reappear on every blur.
+        if (isRoomChange && result.previousLastReadAt && result.lastReadAt) {
           unreadAfterTime = result.previousLastReadAt;
           unreadBeforeTime = result.lastReadAt;
         }


### PR DESCRIPTION
## Summary

- Fixes a flicker where the "New messages" separator would disappear on tab refocus and reappear on every blur whenever the only events that arrived while the tab was hidden were non-message room events (join/leave). The server's read cursor only tracks root messages, so the refocus `markRoomAsRead` returned `previousLastReadAt === lastReadAt` and the `.then()` collapsed the bounded window to empty.
- `useRoomUnread` now ignores the mutation result on a same-room refocus; the mutation still fires to clear the server-side unread dot, but the anchor set on the presence-false edge stays put. Fresh room entries still adopt `(previousLastReadAt, lastReadAt]` as before.
- Adds an e2e regression test in `unread-indicators.test.ts` that triggers a leave event during a hidden-tab window and cycles visibility twice to assert the separator no longer oscillates — covers the gap the existing "tab hidden" test missed (it only exercised the message-arrival path where the server cursor does advance).

## Test plan

- [ ] `mise test-e2e e2e/unread-indicators.test.ts`
- [ ] Manual: open a room as user B, have another user join/leave while B's tab is unfocused, alt-tab back and forth — separator should stay anchored, not flip with focus.