### PR TITLE
refactor(frontend): use useConnection() in per-server settings pages

### DIFF
--- a/frontend/src/routes/chat/[serverId]/settings/+page.svelte
+++ b/frontend/src/routes/chat/[serverId]/settings/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
-  import { graphqlClientManager } from '$lib/state/server/graphqlClient.svelte';
+  import { useConnection } from '$lib/state/server/connection.svelte';
   import { graphql } from '$lib/gql';
   import { PaneHeader, FormSection, Dialog } from '$lib/ui';
   import { TextInput, Button, FormError } from '$lib/ui/form';
@@ -16,17 +16,15 @@
   } from '$lib/validation';
   import { getAvatarInitials } from '$lib/utils/initials';
 
-  // Capture the active server's CurrentUserState and GraphQL client at
-  // init. The settings page is scoped to one server (it lives under
-  // `[serverId]/settings`), so we don't need the registry lookup to
-  // re-resolve reactively — and the captured CurrentUserState is itself
-  // a reactive class (`user` / `loading` are `$state`), so subsequent
-  // profile updates flow through. The client must point at the active
-  // server so profile/avatar mutations land on the right backend, not
-  // always the origin.
-  const activeServerId = getActiveServer();
-  const currentUser = serverRegistry.getStore(activeServerId).currentUser;
-  const gqlClient = graphqlClientManager.getClient(activeServerId).client;
+  // Capture the active server's CurrentUserState at init. The settings
+  // page is scoped to one server (it lives under `[serverId]/settings`),
+  // so we don't need the registry lookup to re-resolve reactively — and
+  // the captured CurrentUserState is itself a reactive class (`user` /
+  // `loading` are `$state`), so subsequent profile updates flow through.
+  // The connection getter resolves to the active server's GraphQL client,
+  // so profile/avatar mutations land on the right backend.
+  const currentUser = serverRegistry.getStore(getActiveServer()).currentUser;
+  const connection = useConnection();
 
   // Form state seeded once from the user's current profile. After init
   // these are local edit buffers; profile updates from elsewhere
@@ -71,7 +69,7 @@
 
   // Fetch last login change on mount
   $effect(() => {
-    gqlClient
+    connection().client
       .query(
         graphql(`
           query GetMyLastLoginChange {
@@ -117,7 +115,7 @@
     uploadingAvatar = true;
 
     try {
-      const result = await gqlClient
+      const result = await connection().client
         .mutation(
           graphql(`
             mutation UploadAvatar($input: UploadAvatarInput!) {
@@ -172,7 +170,7 @@
     deletingAvatar = true;
 
     try {
-      const result = await gqlClient
+      const result = await connection().client
         .mutation(
           graphql(`
             mutation DeleteAvatar($userId: ID!) {
@@ -269,7 +267,7 @@
     successMessage = '';
 
     try {
-      const result = await gqlClient
+      const result = await connection().client
         .mutation(
           graphql(`
             mutation UpdateProfile($input: UpdateProfileInput!) {

--- a/frontend/src/routes/chat/[serverId]/settings/account/+page.svelte
+++ b/frontend/src/routes/chat/[serverId]/settings/account/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
-  import { graphqlClientManager } from '$lib/state/server/graphqlClient.svelte';
+  import { useConnection } from '$lib/state/server/connection.svelte';
   import { graphql } from '$lib/gql';
   import { PaneHeader, Dialog, FormSection, Hint } from '$lib/ui';
   import { TextInput, Button, FormError } from '$lib/ui/form';
@@ -9,7 +9,7 @@
   import { notifyLogout } from '$lib/auth/sessionChannel';
 
   const currentUser = $derived(serverRegistry.getStore(getActiveServer()).currentUser);
-  const gqlClient = $derived(graphqlClientManager.getClient(getActiveServer()).client);
+  const connection = useConnection();
 
   // Check if the user has permission to delete their own account
   const permQuery = useQuery(
@@ -54,7 +54,7 @@
 
     try {
       // Step 1: Request a confirmation token (XSS protection)
-      const tokenResult = await gqlClient
+      const tokenResult = await connection().client
         .mutation(
           graphql(`
             mutation RequestAccountDeletion {
@@ -77,7 +77,7 @@
       }
 
       // Step 2: Delete account with the confirmation token
-      const result = await gqlClient
+      const result = await connection().client
         .mutation(
           graphql(`
             mutation DeleteMyAccount($input: DeleteMyAccountInput!) {

--- a/frontend/src/routes/chat/[serverId]/settings/preferences/+page.svelte
+++ b/frontend/src/routes/chat/[serverId]/settings/preferences/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { graphqlClientManager } from '$lib/state/server/graphqlClient.svelte';
+  import { useConnection } from '$lib/state/server/connection.svelte';
   import { graphql } from '$lib/gql';
   import { TimeFormat } from '$lib/gql/graphql';
   import { getUserSettings } from '$lib/state/userSettings.svelte';
@@ -11,7 +11,7 @@
 
   const userSettings = getUserSettings();
   const currentUser = $derived(serverRegistry.getStore(getActiveServer()).currentUser);
-  const gqlClient = $derived(graphqlClientManager.getClient(getActiveServer()).client);
+  const connection = useConnection();
 
   // All available IANA timezone names
   const allTimezones = Intl.supportedValuesOf('timeZone');
@@ -129,7 +129,7 @@
     error = '';
 
     try {
-      const result = await gqlClient
+      const result = await connection().client
         .mutation(
           graphql(`
             mutation UpdateSettings($input: UpdateSettingsInput!) {


### PR DESCRIPTION
## Summary

- The profile/account/preferences pages under \`routes/chat/[serverId]/settings/\` were the only consumers inside the \`[serverId]\` tree still reaching into \`graphqlClientManager.getClient(...)\` directly.
- Switched them to the existing \`useConnection()\` context getter (provided by \`[serverId]/+layout.svelte\`), matching the convention used everywhere else in this route tree and removing the duplicated active-server-client boilerplate.

## Test plan

- [ ] Avatar upload, profile edits, preferences, and account deletion still work on the origin instance.
- [ ] Same flows still work on a registered remote instance and target the correct backend.