### PR TITLE
fix(frontend): restore vertical separator between sidebars on mobile

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -210,7 +210,7 @@
           use:sidebarSwipe
           class={[
             'z-50 min-h-0 flex-col self-stretch bg-background',
-            'max-md:fixed max-md:top-11 max-md:bottom-0 max-md:left-0 max-md:touch-pan-y',
+            'max-md:fixed max-md:top-11 max-md:bottom-0 max-md:left-0 max-md:w-17 max-md:touch-pan-y',
             // Mobile: always rendered so we can animate transform.
             // Desktop: hide entirely when closed (no overlay; layout reflows).
             sidebarNav.isMobile ? 'flex' : sidebarNav.isOpen ? 'flex' : 'hidden',


### PR DESCRIPTION
## Summary

On mobile viewports, the responsive sidebar was missing the vertical separator line between the server-icons strip and the rooms sidebar.

The mobile SpaceList wrapper used `max-md:fixed` with no explicit width, so it shrank to content width — its `border-r` rendered short of the SecondarySidebar's `max-md:left-17` anchor (68px), leaving a gap with no visible divider. Adding `max-md:w-17` to the wrapper aligns the SpaceList's right edge flush with the SecondarySidebar's left edge, so the existing `border-r border-border` on `SpaceList` now reads as the separator.

## Test plan

- [ ] Verify the vertical separator is visible between the server-icons strip and the rooms sidebar on mobile-width viewports
- [ ] Verify desktop layout is unchanged