### PR TITLE
chore(dev): skip frontend build for embedded backend in dev mode

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -135,7 +135,10 @@ hide = true
 
 [tasks.dev-app]
 description = "Run the application in development mode (with file watching)"
-depends = "build-frontend"
+# No `build-frontend` dependency: dev traffic goes through Vite at
+# $CONDUCTOR_PORT, which proxies /api/* to this backend. The .gitkeep
+# in cli/internal/http_server/.client/ is enough for `//go:embed` to
+# compile.
 run = "mise watch _app-server --restart"
 
 [tasks.dev-frontend]
@@ -162,7 +165,7 @@ run = { task = "dev-*" }
 
 [tasks.chatto]
 description = "Runs the CLI app with the given arguments"
-depends = ["deps-cli", "build-frontend"]
+depends = ["deps-cli"]
 dir = "cli"
 run = "go run -tags bootstrap . ${@}"
 


### PR DESCRIPTION
## Summary

- Drops the `build-frontend` dependency from the `dev-app` and `chatto` mise tasks so cold-start dev no longer waits on a full SvelteKit build.
- In dev, the browser talks to the Vite dev server at `$CONDUCTOR_PORT`, which proxies `/api/*` to the backend — the backend's embedded SPA is never requested. The existing `.gitkeep` in `cli/internal/http_server/.client/` is enough for the `//go:embed all:.client` directive to compile.
- `mise build` / `mise build-frontend` are unchanged and still produce the full embedded bundle for production / e2e.

## Test plan

- [ ] `mise dev` starts up without running the SvelteKit build
- [ ] Browser loads the app via Vite and GraphQL/WebSocket traffic reaches the backend
- [ ] `mise build` still produces a binary with the embedded frontend