### PR TITLE
docs: add GLOSSARY.md and /glossary skill

### DIFF
--- a/.claude/skills/glossary/SKILL.md
+++ b/.claude/skills/glossary/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: glossary
+description: Maintain Chatto's glossary of terms in docs/GLOSSARY.md. Look up a term, add a new one, or audit the glossary against the codebase, FDRs, and ADRs for missing or stale entries.
+---
+
+# Glossary
+
+The canonical vocabulary for Chatto. Lives at `docs/GLOSSARY.md`, organised into four sections — UI, Product, Authorization, Backend — siblings of [FDRs](../../../docs/fdr/INDEX.md) and [ADRs](../../../docs/adr/INDEX.md).
+
+## What the Glossary Is
+
+- A **reference** for what a word means in Chatto's context — internal jargon, product nouns, renamed concepts, acronyms.
+- A **naming surface**: when there's a thing-without-a-name, we add it here first. The glossary leads, the code follows. If a file or component disagrees with the glossary, the file is what should rename.
+- One line per entry, occasionally one short paragraph. Longer concepts link to the FDR/ADR/rules file that owns them.
+
+## What the Glossary Is NOT
+
+- **NOT** a tutorial. Don't explain *how* something works — FDRs, ADRs, and `docs/ARCHITECTURE.md` are for that.
+- **NOT** an API reference. No function signatures, no GraphQL types, no proto fields.
+- **NOT** a dictionary of standard tech terms. Define "Republish" (a Chatto-specific use of a JetStream feature). Don't define "PostgreSQL" or "WebSocket".
+- **NOT** a changelog. When a term is renamed, rewrite the entry. Don't append "previously known as…" unless old names still appear in stable identifiers (stream names, KV keys, config keys).
+
+## Sections
+
+1. **UI** — visible surfaces and component groupings (Server Gutter, Server Sidebar, Room View, Room Sidebar, Composer, Pane Header, etc.).
+2. **Product** — user-facing concepts. If a user might say the word, it goes here (Server, Space, Room, DM, Thread, Mention, Reaction, …).
+3. **Authorization** — RBAC vocabulary. Roles, permissions, ranks, scopes (Role, Permission, Position, Rank, Outranking, Owner/Admin/Moderator/Everyone, Scope, DM Privacy Boundary).
+4. **Backend** — infrastructure jargon. If only contributors say the word, it goes here (ChattoCore, NATS, JetStream, Stream, KV, Subject, Live Event, OCC, Nanoid, Crypto-shredding).
+
+### Where does a term go?
+
+Rule of thumb: **section by who-uses-the-word.**
+
+- Users say it → Product or UI.
+- Only contributors say it → Backend or Authorization.
+- It names a visible thing → UI.
+
+Apply the rule once and don't re-litigate. A term lives in one section. Cross-reference within an entry's body if useful (e.g. *Echo* in Product references the `message.echo` permission, which lives in Authorization implicitly).
+
+## Within a section: conceptual order, not alphabetical
+
+Order foundational terms first, derivatives after. Reader builds up the model in the order it makes sense.
+
+- **Authorization** opens with RBAC → Role → Permission → Position → Rank → Outranking. Then the named roles (Owner, Admin, Moderator, Everyone). Then edge concepts (Scope, User-level override, DM Privacy Boundary).
+- **Product** opens with the structural nouns (Server → Space → Room → Room Group → DM), then content (Message, Thread, Echo, Reaction, Mention, Attachment, …), then ambient features (Presence, Typing Indicator, …).
+- **UI** opens with the named sidebars in left-to-right reading order (Server Gutter → Server Sidebar → Room View → Room Sidebar), then in-pane elements (Composer, Pane Header), then secondary surfaces (Quick Switcher, Slideover, Hint, Panel).
+- **Backend** opens with ChattoCore (the API/core boundary), then NATS/JetStream/Stream/KV/Subject (the storage substrate), then derived concepts (Event, Live Event, Republish, OCC, Nanoid, Crypto-shredding).
+
+When adding a new entry: insert at the position its dependencies suggest, not alphabetically.
+
+## Entry Format
+
+```markdown
+**Term** — One-line definition. Link to the relevant FDR/ADR/rules file if there is one.
+```
+
+- Bold the term itself.
+- For acronyms, expand on first mention: `**FDR (Feature Decision Record)** — …`.
+- Cross-link rather than re-explain: `[FDR-007](fdr/FDR-007-direct-messages.md)`, `[ADR-005](adr/ADR-005-hierarchy-wins-rbac.md)`, `` `.claude/rules/authorization.md` ``.
+
+## How To Run
+
+### Mode 1: Look up a term
+
+When invoked with one or more terms (e.g. `/glossary echo` or `/glossary echo, primary space`):
+
+1. Search `docs/GLOSSARY.md` for each term (case-insensitive).
+2. Print the matching entries verbatim, along with the section they belong to.
+3. If a term isn't found, suggest the closest existing entries and offer to add one.
+
+### Mode 2: Add a term
+
+When invoked with `add <term>` (e.g. `/glossary add room sharding`):
+
+1. Confirm the term doesn't already exist. A near-duplicate is worth flagging — propose updating the existing entry instead.
+2. Research the term in the codebase, FDRs, ADRs, and `.claude/rules/` so the definition is grounded.
+3. Draft a one-line definition. Decide which section it belongs in using the rule-of-thumb above. Offer both to the user for approval before writing.
+4. Insert in conceptual order within the chosen section. Cross-link any related FDR/ADR/rules file.
+
+### Mode 3: Audit (default, no args)
+
+When invoked without arguments:
+
+1. Read `docs/GLOSSARY.md` end-to-end.
+2. Cross-reference each entry against its cited FDR/ADR/rules file — flag dead links or claims that no longer hold.
+3. Scan `docs/fdr/INDEX.md`, `docs/adr/INDEX.md`, `.claude/rules/`, and recent commits for terms used as jargon but not in the glossary (heuristic: capitalised nouns, hyphenated phrases, repeated quoted strings). Limit the proposal list to ~10 strongest candidates.
+4. Report:
+   - **Stale entries** — definitions contradicted by current code/docs.
+   - **Dead links** — references to renamed or removed files.
+   - **Misplaced entries** — terms that belong in a different section per the rule-of-thumb.
+   - **Missing terms** — top candidates worth adding, with a section + one-line draft for each.
+5. **Propose-only**: don't apply edits without user approval.
+
+## Audit Heuristics
+
+When scouting for missing terms:
+
+- Words that **changed meaning** recently (e.g. *Server* used to be *Instance*) almost always deserve an entry.
+- Words that appear across **multiple FDRs/ADRs** with assumed shared meaning are strong candidates.
+- Acronyms and abbreviations (RBAC, OCC, DM, KV, FDR/ADR, …).
+- Words a reviewer asked about in PR review — if one human had to ask, others will.
+- Things-without-names: a recurring noun phrase ("the right pane", "the small column on the left") signals a name is overdue. Naming such things is one of the glossary's jobs.
+
+When *not* to add:
+
+- Standard tech terms with no Chatto-specific meaning ("PostgreSQL", "WebSocket").
+- Type names, function names, file paths — those belong in code, not a glossary.
+- Anything one Google search would answer.
+
+## Workflow Notes
+
+- **Before any edits**: read the existing `docs/GLOSSARY.md`. The file is short enough to load entirely.
+- **Cross-link aggressively**: a glossary entry is most useful as a jumping-off point. If there's an FDR or ADR for the term, link it.
+- **One entry per concept**, even with multiple names. Pick the canonical name as the heading; mention aliases in the body if useful (e.g. `**Server** — Top-level Chatto deployment. Formerly called *Instance* in the codebase.`).
+- **Glossary > code on naming**: when an entry contradicts a component or file name in the codebase, note "(pending rename)" in the entry. The follow-up is to rename the code, not the entry.

--- a/README.md
+++ b/README.md
@@ -40,12 +40,13 @@ Each instance is bootstrapped with the same dev credentials (configured in `cli/
 
 ## Instructions for Coding Agents
 
-This codebase keeps agent-relevant context in four places. Read the one that fits your task:
+This codebase keeps agent-relevant context in five places. Read the one that fits your task:
 
 - **`.claude/rules/**`** — always-on coding, testing, and review conventions, mostly path-scoped (`frontend.md` and `frontend-conventions.md` for SvelteKit work, `backend.md` for Go, `testing-frontend.md` / `testing-backend.md` for tests, `authorization.md` for permission changes, etc.). Start here for "how do we do things in this repo?"
 - **`docs/fdr/INDEX.md`** — **Feature** Decision Records, one per feature. They describe what a feature does *and* why it's designed that way. Read the relevant FDR before changing user-facing behavior.
 - **`docs/adr/INDEX.md`** — **Architecture** Decision Records. Cross-cutting choices like "NATS as primary data store" or "per-user encryption keys with crypto-shredding". Read when touching architectural seams.
 - **`docs/ARCHITECTURE.md`** — inventory of what currently exists (streams, KV buckets, subject patterns, GraphQL operations). Use when you need to know *what's where*, not *why*.
+- **`docs/GLOSSARY.md`** — one-line definitions of Chatto-specific terms (Server, Space, Echo, OCC, etc.). Skim when you encounter a word you don't recognize.
 
 ### Maintenance slash commands
 
@@ -57,6 +58,7 @@ Periodic codebase upkeep — all propose-only unless noted:
 | `/chatto-finalize-pr` | Pre-merge check on the current branch — runs `/fdr` + `/adr`. |
 | `/fdr [feature]` | Audit Feature Decision Records against the code, or create a new one. |
 | `/adr` | Audit Architecture Decision Records, or create a new one. |
+| `/glossary [term \| add <term>]` | Look up, add, or audit terms in `docs/GLOSSARY.md`. |
 | `/chatto-architecture` | Refresh `docs/ARCHITECTURE.md` inventory. |
 | `/chatto-security-review` | Multi-agent security audit. |
 | `/update-project-dependencies` | Bump deps within semver, run tests. |

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,131 @@
+# Glossary
+
+The canonical vocabulary for Chatto: UI surfaces, product concepts, authorization terms, and backend infrastructure. One line per entry (occasionally one short paragraph) — just enough to recognize the word and know where to read more.
+
+This document is **also a naming surface**: when we need a name for a thing we're building, we add it here first. That's how vocabulary stays consistent across code, UI, docs, and conversation.
+
+This is **not** a tutorial, design doc, or API reference. If a concept needs more than a paragraph, link to the relevant [FDR](fdr/INDEX.md), [ADR](adr/INDEX.md), `.claude/rules/*`, or [ARCHITECTURE.md](ARCHITECTURE.md) rather than inlining.
+
+Entries within each section are ordered by **conceptual flow** — foundational terms first, derivatives after — not alphabetically. See [`.claude/skills/glossary/SKILL.md`](../.claude/skills/glossary/SKILL.md) for the maintenance workflow.
+
+## UI
+
+Names for visible surfaces and component groupings. When a name here disagrees with a file or component name in the codebase, the glossary wins — the file is the one that should rename.
+
+**Server Gutter** — Narrow leftmost column listing the user's servers, with the add-server button at the bottom. Metaphor borrowed from the gutter in a text editor: a thin marginal strip. Currently implemented as `frontend/src/lib/SpaceList.svelte` (pending rename).
+
+**Server Sidebar** — The wider sidebar to the right of the Server Gutter, scoped to a single server. Contains the server banner, the server menu, the room list, and the current user card. Currently composed of `SpaceBanner` + `SpaceHeader` + `RoomList` inside a generic `SecondarySidebar` component (pending rename / consolidation).
+
+**Room View** — The main central area showing the current room: message list plus the composer at the bottom. Not "the chat area" — *Room View* is the canonical name.
+
+**Room Sidebar** — Right-hand pane scoped to the current room. Currently shows the member list; will grow to host other room-scoped surfaces (pinned messages, files, etc.). Currently implemented as `RoomInfo.svelte` (pending rename).
+
+**Composer** — The message input at the bottom of the Room View. Includes text input, attachment picker, emoji picker, mentions autocomplete.
+
+**Pane Header** — The top bar of a content pane (Room View, settings page, admin page, etc.). Carries the title, optional subtitle, optional back arrow, and icon-only action buttons via the `actions` snippet. Chunky labelled buttons belong in the body, not here. See `.claude/rules/general.md`.
+
+**Quick Switcher** — Cmd-K / Ctrl-K palette for jumping between rooms, DMs, servers, and admin pages. Distinct from the Server Gutter — both let you change server, but the Quick Switcher is keyboard-first and searchable. See [FDR-015](fdr/FDR-015-quick-switcher.md).
+
+**Slideover** — A pane that slides in over existing content (e.g. settings, thread view on mobile). Distinct from a modal: dismissable by navigation, not by an explicit close.
+
+**Hint** — Inline informational callout used in admin/settings panels to introduce or contextualise a control. Use instead of nesting an outer Panel around a self-contained matrix.
+
+**Panel** — Bordered card used across instance-admin (`/chat/[serverId]/admin/*`) and per-server settings pages. Shared visual chrome for administrative interfaces. See `.claude/rules/admin.md`.
+
+## Product
+
+User-facing concepts. If a user might say the word, it goes here.
+
+**Server** — Top-level Chatto deployment: one process, one NATS account, one membership boundary. Formerly called *Instance* in the codebase. See [ADR-029](adr/ADR-029-instance-to-server-rename.md).
+
+**Space** — Legacy tier between server and room. Being consolidated into the server concept; in most deployments there is exactly one space per server (the *primary space*). See [ADR-027](adr/ADR-027-instance-space-server-consolidation.md).
+
+**Primary Space** — Transitional config-designated "the one space that matters" within a server. Bridge construct used while Instance + Space collapse into Server. See [ADR-027](adr/ADR-027-instance-space-server-consolidation.md).
+
+**Room** — A channel or DM. Where messages live. Identified by `(serverId, roomId)`.
+
+**Room Group** — Named collection of rooms within a server, with its own per-group permission overrides. See [ADR-031](adr/ADR-031-room-group-centric-acl.md) and [FDR-017](fdr/FDR-017-room-groups-and-sidebar-layout.md).
+
+**DM (Direct Message)** — Private conversation between users, modelled as a room with `kind: dm`. See [FDR-007](fdr/FDR-007-direct-messages.md).
+
+**Message** — A user-posted entry in a room. Root messages live at the top level; thread replies hang off a root.
+
+**Thread** — Reply chain rooted at a message. See [FDR-002](fdr/FDR-002-replies-and-threads.md).
+
+**Echo** — Reposting a thread reply back to its parent channel so non-thread participants see it. Gated by `message.echo`. See [FDR-003](fdr/FDR-003-thread-reply-echo.md).
+
+**Reaction** — Emoji attached to a message by a user. See [FDR-005](fdr/FDR-005-reactions.md).
+
+**Mention** — `@user` syntax in a message that notifies the referenced user. See [FDR-006](fdr/FDR-006-mentions.md).
+
+**Attachment** — File (image, document, video) uploaded alongside a message. See [FDR-008](fdr/FDR-008-file-attachments-and-video.md).
+
+**Link Preview** — Auto-generated preview card for URLs in messages. See [FDR-009](fdr/FDR-009-link-previews.md).
+
+**Typing Indicator** — Ephemeral "X is typing…" signal. Published as a live event, never persisted. See [FDR-010](fdr/FDR-010-typing-indicators.md).
+
+**Presence** — A user's online/away/offline state. See [FDR-011](fdr/FDR-011-user-presence.md).
+
+**Voice Call** — Real-time audio call attached to a room. See [FDR-016](fdr/FDR-016-voice-calls.md).
+
+**Jump to Present** — UI affordance that returns the Room View to the latest message after scrolling back through history. See [FDR-014](fdr/FDR-014-jump-to-present.md).
+
+**Last-Room Memory** — The system that remembers which room a user was last in per-server. See [FDR-026](fdr/FDR-026-last-room-memory.md).
+
+## Authorization
+
+Chatto's RBAC model. Read top-to-bottom — terms build on each other.
+
+**RBAC (Role-Based Access Control)** — The model: roles bundle permissions, users hold roles. See [ADR-005](adr/ADR-005-hierarchy-wins-rbac.md).
+
+**Role** — Named bundle of permissions, assignable to users. System roles are seeded; custom roles can be created.
+
+**Permission** — Named capability gate, e.g. `message.post`, `role.assign`. Strings use hyphens, never underscores. The full list lives in `cli/internal/core/permissions.go`.
+
+**Position** — Numeric rank of a role. Higher = more power. `everyone` = 0, `moderator` = 100, `admin` = 900, `owner` = 1000. Custom roles slot in the gaps.
+
+**Rank** — Comparison between two users' highest role positions. Answers a hierarchy question ("does A outrank B?"), not a capability question.
+
+**Outranking** — Hierarchy check: actor's highest role position must be strictly greater than the target's. Required *alongside* the relevant permission for any mutation targeting another user. See `.claude/rules/authorization.md`.
+
+**Owner** — Top system role (position 1000). Conferred via `owners.emails` in `chatto.toml` or by another owner.
+
+**Admin** — System role (position 900). Full administrative reach except over `owner`-rank users.
+
+**Moderator** — System role (position 100). Moderation permissions, no administrative reach.
+
+**Everyone** — Implicit virtual role (position 0) held by every authenticated user. Default-permission grants attach here.
+
+**Scope** — Tier at which a permission is configured: `server`, `group`, or `room`. Resolution: room > group > server (first explicit decision wins). See `.claude/rules/authorization.md`.
+
+**User-level override** — Permission grant or deny attached directly to a user, not via a role. Outranks every role grant. Used for suspensions and ad-hoc grants.
+
+**DM Privacy Boundary** — Static set of permissions (`message.manage`, `message.echo`, `room.manage`, …) unconditionally denied inside DM rooms regardless of role grants. Owners can't moderate DM contents.
+
+## Backend
+
+Infrastructure jargon. If only contributors say the word, it goes here.
+
+**ChattoCore** — Go package (`cli/internal/core`) that holds low-level domain logic and talks to NATS. Takes an `actorID` but performs no authorization — that lives in the GraphQL layer. See [ADR-004](adr/ADR-004-authorization-at-api-boundary.md).
+
+**NATS** — Messaging system Chatto uses for pubsub and persistence. Runs embedded in the single binary by default.
+
+**JetStream** — NATS's persistence layer (streams + KV buckets). Chatto's primary data store. See [ADR-001](adr/ADR-001-nats-jetstream-as-primary-data-store.md).
+
+**Stream** — JetStream append-only log. Chatto's primary stream is `SERVER_EVENTS`. Streams act as the audit log.
+
+**KV (Key-Value Bucket)** — JetStream-backed key/value store. Chatto uses several (`SERVER_CONFIG`, `SERVER_RBAC`, `KV_INSTANCE`, …). KV is the source of truth; streams are the audit log. See [ADR-006](adr/ADR-006-kv-source-of-truth-streams-audit-log.md).
+
+**Subject** — NATS message topic. Chatto's subject conventions (`server.room.{kind}.{r}.msg.{id}`, `live.server.…`) are documented in `.claude/rules/nats-subjects.md`.
+
+**Event** — Durable record on the `SERVER_EVENTS` stream (message posted, room created, member joined, etc.). Contrast with *Live Event*.
+
+**Live Event** — Transient event published on `live.server.>` (typing, reactions, presence). Either republished from a durable event, or published directly via NATS Core. See [ADR-012](adr/ADR-012-two-tier-realtime-events.md).
+
+**Republish** — JetStream feature that mirrors every accepted `server.>` message onto `live.server.>` automatically. Keeps subscribers on one logical pipe without holding a JetStream consumer. See `.claude/rules/nats-subjects.md`.
+
+**OCC (Optimistic Concurrency Control)** — Publishing with an expected stream sequence so concurrent writers don't clobber each other. Used for message posting. See [ADR-016](adr/ADR-016-occ-for-message-publishing.md).
+
+**Nanoid** — Short URL-safe unique ID format. All Chatto entities are prefixed (`usr_…`, `rm_…`, `srv_…`). See [ADR-022](adr/ADR-022-nanoid-with-entity-prefixes.md).
+
+**Crypto-shredding** — Deleting a user's data by destroying their per-user encryption key rather than mutating storage. See [ADR-007](adr/ADR-007-per-user-encryption-with-crypto-shredding.md).


### PR DESCRIPTION
## Summary

- Adds `docs/GLOSSARY.md` as the canonical Chatto vocabulary, organised into UI / Product / Authorization / Backend sections with conceptual (not alphabetical) ordering.
- Names the four previously-unnamed UI surfaces — **Server Gutter**, **Server Sidebar**, **Room View**, **Room Sidebar** — and flags pending component renames (`SpaceList` → `ServerGutter`, `RoomInfo` → `RoomSidebar`) where the glossary now leads the code.
- Adds `.claude/skills/glossary/SKILL.md` (lookup / add / audit modes, propose-only) mirroring the `/fdr` and `/adr` skill shape, and updates `README.md` so the glossary appears in the agent-context list and the maintenance commands table.

## Test plan

- [ ] Skim `docs/GLOSSARY.md` end-to-end for any wrong claims about positions / file paths / ADR numbers.
- [ ] Run `/glossary` in audit mode after merge to surface anything I missed.