### PR TITLE
refactor(frontend): rename ServerRegistry Instance-era API → Server

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -56,14 +56,14 @@ When extending or styling these, keep visual alignment with the `.menu` utility 
 
 ```svelte
 // Synchronous: available to children during render
-for (const server of serverRegistry.instances) {
+for (const server of serverRegistry.servers) {
   eventBusManager.startBus(server.id, client);
 }
 
 // Reactive: handles additions/removals after initial render
 $effect(() => {
   // startBus is idempotent — no-op if already started
-  for (const server of serverRegistry.instances) {
+  for (const server of serverRegistry.servers) {
     if (!eventBusManager.getBus(server.id)) {
       eventBusManager.startBus(server.id, client);
     }
@@ -267,7 +267,7 @@ The `[serverId]/+layout.svelte` resolves the URL segment to a server ID via `seg
 There is no `isHome` flag. The origin server (the server serving the SPA) is detected by comparing the registered server's `url` against `window.location.origin`:
 
 - `serverRegistry.originServer` — finds the matching server (or `undefined`)
-- `serverRegistry.isOriginInstance(id)` — checks a specific server (method name is vestigial; the concept is "origin server")
+- `serverRegistry.isOriginServer(id)` — checks a specific server
 
 The origin uses cookie auth (`token: null`). Remote servers use bearer tokens (`token: string`).
 
@@ -333,7 +333,7 @@ Each `ServerStateStore` has a `permissions` field (`ServerPermissions`) loaded b
 
 ### Disconnect vs Sign Out
 
-- **Disconnect** (`removeInstance`): Removes one server. Cleans up event bus, store, and GraphQL client. If it's the origin, also revokes the cookie session and hard-reloads.
+- **Disconnect** (`removeServer`): Removes one server. Cleans up event bus, store, and GraphQL client. If it's the origin, also revokes the cookie session and hard-reloads.
 - **Sign Out** (`removeAll`): Removes ALL servers, revokes origin cookie, hard-reloads to `/`.
 
 ### CORS Boundary

--- a/frontend/e2e/fixtures/multiServer.ts
+++ b/frontend/e2e/fixtures/multiServer.ts
@@ -382,7 +382,7 @@ export async function setMotdOnRemote(
  * test-only `/auth/test/oauth-authorize` endpoint to mint a real authorization
  * code, then fulfill the navigation with a 302 to the callback URL. From
  * there the origin's callback page runs unchanged: PKCE verifier exchange via
- * `/oauth/token`, real bearer token, real `serverRegistry.addInstance()`.
+ * `/oauth/token`, real bearer token, real `serverRegistry.addServer()`.
  *
  * The user identified by `userId` must already exist on the remote (use
  * `createUserOnRemote` to create one).
@@ -433,7 +433,7 @@ export async function connectRemoteInstance(
 
 	// Drive the real UI: open dialog from sidebar → URL → preview →
 	// would-redirect to /oauth/authorize (intercepted) → /servers/callback
-	// → token exchange → addInstance.
+	// → token exchange → addServer.
 	if (!/\/chat\//.test(page.url())) {
 		await page.goto('/chat/-');
 	}

--- a/frontend/src/lib/ServerGutter.svelte
+++ b/frontend/src/lib/ServerGutter.svelte
@@ -15,7 +15,7 @@ is connected to, plus the add-server button pinned to the bottom. See the
   // Optimistically returns true while permissions are still loading.
   // Unauthenticated servers are skipped entirely.
   function anyServerHasPermission(key: keyof ServerPermissions): boolean {
-    return serverRegistry.instances.some((s) => {
+    return serverRegistry.servers.some((s) => {
       const store = serverRegistry.tryGetStore(s.id);
       if (!store?.isAuthenticated) return false;
 
@@ -36,7 +36,7 @@ is connected to, plus the add-server button pinned to the bottom. See the
     data-sidebar-scroll
   >
     <!-- Per-server room sections (only for authenticated servers) -->
-    {#each serverRegistry.instances as server (server.id)}
+    {#each serverRegistry.servers as server (server.id)}
       {@const store = serverRegistry.tryGetStore(server.id)}
       {#if store?.isAuthenticated}
         <ServerSpaceSection

--- a/frontend/src/lib/components/AddServerDialog.svelte
+++ b/frontend/src/lib/components/AddServerDialog.svelte
@@ -128,7 +128,7 @@ ADR-027 — only user-facing copy says "server".
       return;
     }
 
-    const existing = serverRegistry.instances.find(
+    const existing = serverRegistry.servers.find(
       (i) => i.url.toLowerCase() === url.toLowerCase()
     );
     if (existing && (existing.token || existing.userId)) {

--- a/frontend/src/lib/components/AddServerDialog.svelte.spec.ts
+++ b/frontend/src/lib/components/AddServerDialog.svelte.spec.ts
@@ -18,7 +18,7 @@ describe('AddServerDialog', () => {
 
   beforeEach(() => {
     localStorage.removeItem(STORAGE_KEY);
-    serverRegistry.instances = [];
+    serverRegistry.servers = [];
     originalFetch = globalThis.fetch;
   });
 
@@ -152,7 +152,7 @@ describe('AddServerDialog', () => {
   });
 
   it('blocks adding a server that is already connected', async () => {
-    serverRegistry.instances = [
+    serverRegistry.servers = [
       {
         id: 'remote',
         url: 'https://chat.example.com',

--- a/frontend/src/lib/components/NotificationSync.svelte
+++ b/frontend/src/lib/components/NotificationSync.svelte
@@ -24,7 +24,7 @@ Include this component once in the chat layout (unconditionally).
   $effect(() => {
     const cleanups: (() => void)[] = [];
 
-    for (const instance of serverRegistry.instances) {
+    for (const instance of serverRegistry.servers) {
       const stores = serverRegistry.getStore(instance.id);
       if (!stores.isAuthenticated) continue;
 
@@ -57,7 +57,7 @@ Include this component once in the chat layout (unconditionally).
 
   // Aggregate notification count and unread state across all authenticated instances.
   let totalNotificationCount = $derived(
-    serverRegistry.instances.reduce((sum, instance) => {
+    serverRegistry.servers.reduce((sum, instance) => {
       const stores = serverRegistry.getStore(instance.id);
       if (!stores.isAuthenticated) return sum;
       return sum + stores.notifications.count;
@@ -65,7 +65,7 @@ Include this component once in the chat layout (unconditionally).
   );
 
   let hasAnyUnread = $derived(
-    serverRegistry.instances.some((instance) => {
+    serverRegistry.servers.some((instance) => {
       const stores = serverRegistry.getStore(instance.id);
       if (!stores.isAuthenticated) return false;
       return stores.roomUnread.hasAnyUnread;

--- a/frontend/src/lib/components/QuickSwitcher.svelte
+++ b/frontend/src/lib/components/QuickSwitcher.svelte
@@ -76,7 +76,7 @@
 
   async function loadAll() {
     loading = true;
-    const instances = serverRegistry.instances;
+    const instances = serverRegistry.servers;
     const multiInstance = instances.length > 1;
     const items: ResultItem[] = [];
     const opts = { requestPolicy: 'network-only' as const };

--- a/frontend/src/lib/components/ServerPill.svelte
+++ b/frontend/src/lib/components/ServerPill.svelte
@@ -25,25 +25,25 @@ network round trips are needed.
     serverId: string;
   } = $props();
 
-  const instance = $derived(serverRegistry.getInstance(serverId));
+  const server = $derived(serverRegistry.getServer(serverId));
   const store = $derived(serverRegistry.tryGetStore(serverId));
 
   // Hide globally when the client is only connected to a single server — the
   // pill carries no useful information in that case, and is just visual noise.
-  const visible = $derived(serverRegistry.instances.length > 1);
+  const visible = $derived(serverRegistry.servers.length > 1);
 
-  const name = $derived(instance?.name ?? '');
-  const iconUrl = $derived(store?.serverInfo.iconUrl ?? instance?.iconUrl ?? null);
+  const name = $derived(server?.name ?? '');
+  const iconUrl = $derived(store?.serverInfo.iconUrl ?? server?.iconUrl ?? null);
   const bannerUrl = $derived(store?.serverInfo.bannerUrl ?? null);
   const description = $derived(store?.serverInfo.description ?? null);
   const welcomeMessage = $derived(store?.serverInfo.welcomeMessage ?? null);
   const motd = $derived(store?.serverInfo.motd ?? null);
   const hostname = $derived.by(() => {
-    if (!instance) return '';
+    if (!server) return '';
     try {
-      return new URL(instance.url).hostname;
+      return new URL(server.url).hostname;
     } catch {
-      return instance.url;
+      return server.url;
     }
   });
 
@@ -106,7 +106,7 @@ network round trips are needed.
   </button>
 {/if}
 
-{#if visible && open && instance && anchor}
+{#if visible && open && server && anchor}
   <ContextMenu
     {anchor}
     role="dialog"

--- a/frontend/src/lib/components/ServerPill.svelte.spec.ts
+++ b/frontend/src/lib/components/ServerPill.svelte.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { q } from '$lib/test-utils';
 
-interface RegisteredInstanceMock {
+interface RegisteredServerMock {
   id: string;
   name: string;
   url: string;
@@ -19,25 +19,25 @@ interface StoreMock {
   };
 }
 
-const { mockInstances, mockStores } = vi.hoisted(() => ({
-  mockInstances: { current: [] as RegisteredInstanceMock[] },
+const { mockServers, mockStores } = vi.hoisted(() => ({
+  mockServers: { current: [] as RegisteredServerMock[] },
   mockStores: { current: new Map<string, StoreMock>() }
 }));
 
 vi.mock('$lib/state/server/registry.svelte', () => ({
   serverRegistry: {
-    get instances() {
-      return mockInstances.current;
+    get servers() {
+      return mockServers.current;
     },
-    getInstance: (id: string) =>
-      mockInstances.current.find((i) => i.id === id),
+    getServer: (id: string) =>
+      mockServers.current.find((s) => s.id === id),
     tryGetStore: (id: string) => mockStores.current.get(id)
   }
 }));
 
 import ServerPill from './ServerPill.svelte';
 
-function makeInstance(o: Partial<RegisteredInstanceMock> = {}): RegisteredInstanceMock {
+function makeServer(o: Partial<RegisteredServerMock> = {}): RegisteredServerMock {
   return {
     id: 'a',
     name: 'Server A',
@@ -61,7 +61,7 @@ function makeStore(o: Partial<StoreMock['instance']> = {}): StoreMock {
 }
 
 beforeEach(() => {
-  mockInstances.current = [];
+  mockServers.current = [];
   mockStores.current = new Map();
 });
 
@@ -73,7 +73,7 @@ describe('ServerPill', () => {
     });
 
     it('renders nothing when only a single instance is registered', () => {
-      mockInstances.current = [makeInstance({ id: 'a', name: 'Alpha' })];
+      mockServers.current = [makeServer({ id: 'a', name: 'Alpha' })];
       mockStores.current.set('a', makeStore());
 
       const { container } = render(ServerPill, { props: { serverId: 'a' } });
@@ -83,9 +83,9 @@ describe('ServerPill', () => {
     });
 
     it('renders the pill when more than one instance is registered', async () => {
-      mockInstances.current = [
-        makeInstance({ id: 'a', name: 'Alpha' }),
-        makeInstance({ id: 'b', name: 'Beta' })
+      mockServers.current = [
+        makeServer({ id: 'a', name: 'Alpha' }),
+        makeServer({ id: 'b', name: 'Beta' })
       ];
       mockStores.current.set('a', makeStore());
       mockStores.current.set('b', makeStore());
@@ -102,9 +102,9 @@ describe('ServerPill', () => {
   describe('rendering', () => {
     beforeEach(() => {
       // Two instances → pill is visible
-      mockInstances.current = [
-        makeInstance({ id: 'a', name: 'Alpha' }),
-        makeInstance({ id: 'b', name: 'Beta' })
+      mockServers.current = [
+        makeServer({ id: 'a', name: 'Alpha' }),
+        makeServer({ id: 'b', name: 'Beta' })
       ];
       mockStores.current.set('a', makeStore());
       mockStores.current.set('b', makeStore());

--- a/frontend/src/lib/components/chat/SpaceHeader.svelte
+++ b/frontend/src/lib/components/chat/SpaceHeader.svelte
@@ -4,7 +4,7 @@
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
 
-  const isOrigin = $derived(serverRegistry.isOriginInstance(getActiveServer()));
+  const isOrigin = $derived(serverRegistry.isOriginServer(getActiveServer()));
 
   let {
     spaceName,

--- a/frontend/src/lib/hooks/usePageTitle.svelte.ts
+++ b/frontend/src/lib/hooks/usePageTitle.svelte.ts
@@ -16,7 +16,7 @@ export function usePageTitle(): () => string {
       ? `${titleState.pageTitle} | ${serverName}`
       : serverName;
 
-    const totalCount = serverRegistry.instances.reduce((sum, instance) => {
+    const totalCount = serverRegistry.servers.reduce((sum, instance) => {
       const store = serverRegistry.getStore(instance.id);
       if (!store.isAuthenticated) return sum;
       return sum + store.notifications.count;

--- a/frontend/src/lib/messageLinks.ts
+++ b/frontend/src/lib/messageLinks.ts
@@ -9,9 +9,9 @@ import { serverRegistry } from '$lib/state/server/registry.svelte';
 import { serverIdToSegment, segmentToServerId } from '$lib/navigation';
 
 export interface MessageLink {
-  /** URL segment for the instance (`-` for origin, hostname for remote). */
+  /** URL segment for the server (`-` for origin, hostname for remote). */
   serverSegment: string;
-  /** Resolved instance ID, or null if the segment doesn't match a registered instance. */
+  /** Resolved server ID, or null if the segment doesn't match a registered server. */
   serverId: string | null;
   roomId: string;
   messageId: string;
@@ -37,10 +37,10 @@ export function buildMessageLinkURL(
 ): string {
   const path = buildMessageLinkPath(serverId, roomId, messageId);
 
-  const instance = serverRegistry.getInstance(serverId);
-  if (instance) {
+  const server = serverRegistry.getServer(serverId);
+  if (server) {
     try {
-      return new URL(path, instance.url).toString();
+      return new URL(path, server.url).toString();
     } catch {
       // fall through to window.location.origin
     }
@@ -57,8 +57,8 @@ export function buildMessageLinkURL(
  * Parse a URL (absolute or relative) and return message link details if it
  * matches the Chatto message link pattern. Returns null for any non-match.
  *
- * Resolves the instance segment against the registry when possible so the
- * caller can tell whether the link points at a known (reachable) instance.
+ * Resolves the server segment against the registry when possible so the
+ * caller can tell whether the link points at a known (reachable) server.
  */
 export function parseMessageLink(input: string): MessageLink | null {
   let pathname: string;

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -1,39 +1,39 @@
 import { serverRegistry } from '$lib/state/server/registry.svelte';
 
-/** URL segment used for the home (origin) instance. */
+/** URL segment used for the home (origin) server. */
 const HOME_SEGMENT = '-';
 
 /**
- * Convert an internal instance registry ID to a URL segment.
- * Origin instance → "-", remote → raw hostname from URL.
+ * Convert an internal server registry ID to a URL segment.
+ * Origin server → "-", remote → raw hostname from URL.
  */
 export function serverIdToSegment(serverId: string): string {
-	if (serverRegistry.isOriginInstance(serverId)) return HOME_SEGMENT;
+	if (serverRegistry.isOriginServer(serverId)) return HOME_SEGMENT;
 
-	const instance = serverRegistry.getInstance(serverId);
-	if (!instance) return HOME_SEGMENT;
+	const server = serverRegistry.getServer(serverId);
+	if (!server) return HOME_SEGMENT;
 
 	try {
-		return new URL(instance.url).hostname;
+		return new URL(server.url).hostname;
 	} catch {
 		return HOME_SEGMENT;
 	}
 }
 
 /**
- * Convert a URL segment back to an internal instance registry ID.
- * "-" → origin instance, hostname → find matching instance by URL.
+ * Convert a URL segment back to an internal server registry ID.
+ * "-" → origin server, hostname → find matching server by URL.
  */
 export function segmentToServerId(segment: string): string | null {
 	if (segment === HOME_SEGMENT) {
 		return serverRegistry.originServer?.id ?? null;
 	}
 
-	// Find instance whose URL hostname matches the segment
-	for (const instance of serverRegistry.instances) {
+	// Find the server whose URL hostname matches the segment
+	for (const server of serverRegistry.servers) {
 		try {
-			if (new URL(instance.url).hostname === segment) {
-				return instance.id;
+			if (new URL(server.url).hostname === segment) {
+				return server.id;
 			}
 		} catch {
 			continue;

--- a/frontend/src/lib/state/server/graphqlClient.svelte.spec.ts
+++ b/frontend/src/lib/state/server/graphqlClient.svelte.spec.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Declare mock values via vi.hoisted so they're available in vi.mock factories
-const { mockWsDispose, mockWsTerminate, mockWsSubscribe, mockInstances, clientConfigs, wsConfigs } =
+const { mockWsDispose, mockWsTerminate, mockWsSubscribe, mockServers, clientConfigs, wsConfigs } =
 	vi.hoisted(() => ({
 		mockWsDispose: vi.fn(),
 		mockWsTerminate: vi.fn(),
 		mockWsSubscribe: vi.fn(() => vi.fn()),
-		mockInstances: new Map<
+		mockServers: new Map<
 			string,
 			{ id: string; url: string; token: string | null }
 		>(),
@@ -42,8 +42,8 @@ vi.mock('@urql/svelte', () => ({
 
 vi.mock('./registry.svelte', () => ({
 	serverRegistry: {
-		getInstance: (id: string) => mockInstances.get(id),
-		isOriginInstance: (id: string) => mockInstances.get(id)?.token === null
+		getServer: (id: string) => mockServers.get(id),
+		isOriginServer: (id: string) => mockServers.get(id)?.token === null
 	}
 }));
 
@@ -254,7 +254,7 @@ describe('GraphQLClient', () => {
 describe('GraphQLClientManager', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		mockInstances.clear();
+		mockServers.clear();
 	});
 
 	// We can't easily test the manager singleton due to module-level instantiation
@@ -275,7 +275,7 @@ describe('GraphQLClientManager', () => {
 
 	it('getClient returns originClient for home instances', async () => {
 		const mod = await import('./graphqlClient.svelte');
-		mockInstances.set('my-home', {
+		mockServers.set('my-home', {
 			id: 'my-home',
 			url: 'http://localhost:4000',
 			token: null
@@ -294,7 +294,7 @@ describe('GraphQLClientManager', () => {
 
 	it('getClient creates and caches remote clients', async () => {
 		const mod = await import('./graphqlClient.svelte');
-		mockInstances.set('remote-1', {
+		mockServers.set('remote-1', {
 			id: 'remote-1',
 			url: 'https://remote.example.com',
 			token: 'remote-token'
@@ -308,7 +308,7 @@ describe('GraphQLClientManager', () => {
 
 	it('destroyClient disposes and removes remote clients', async () => {
 		const mod = await import('./graphqlClient.svelte');
-		mockInstances.set('remote-2', {
+		mockServers.set('remote-2', {
 			id: 'remote-2',
 			url: 'https://other.example.com',
 			token: 'token-2'

--- a/frontend/src/lib/state/server/graphqlClient.svelte.ts
+++ b/frontend/src/lib/state/server/graphqlClient.svelte.ts
@@ -384,23 +384,23 @@ class GraphQLClientManager {
 
 	/** Get or create a client for a registered instance. */
 	getClient(serverId: string): GraphQLClient {
-		if (serverRegistry.isOriginInstance(serverId)) {
+		if (serverRegistry.isOriginServer(serverId)) {
 			return this.#originClient;
 		}
 
 		const existing = this.#clients.get(serverId);
 		if (existing) return existing;
 
-		const instance = serverRegistry.getInstance(serverId);
-		if (!instance) {
+		const server = serverRegistry.getServer(serverId);
+		if (!server) {
 			throw new Error(`Server "${serverId}" not found in registry`);
 		}
 
-		const url = `${instance.url}/api/graphql`;
+		const url = `${server.url}/api/graphql`;
 		const client = new GraphQLClient({
 			url,
 			wsUrl: httpToWsUrl(url),
-			token: instance.token
+			token: server.token
 		});
 
 		this.#clients.set(serverId, client);

--- a/frontend/src/lib/state/server/permissions.svelte.spec.ts
+++ b/frontend/src/lib/state/server/permissions.svelte.spec.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { serverRegistry, type RegisteredInstance } from './registry.svelte';
+import { serverRegistry, type RegisteredServer } from './registry.svelte';
 import { getServerPermissions, type ServerPermissions, type ViewerData } from './permissions.svelte';
 
 const STORAGE_KEY = 'chatto:instances';
 
-function makeInstance(overrides: Partial<RegisteredInstance> = {}): RegisteredInstance {
+function makeServer(overrides: Partial<RegisteredServer> = {}): RegisteredServer {
   return {
     id: 'remote',
     url: 'https://remote.example.com',
@@ -42,13 +42,13 @@ function mount(serverId: string): { readonly current: ServerPermissions } {
 describe('getServerPermissions', () => {
   beforeEach(() => {
     localStorage.removeItem(STORAGE_KEY);
-    for (const instance of [...serverRegistry.instances]) {
-      serverRegistry.removeInstance(instance.id);
+    for (const server of [...serverRegistry.servers]) {
+      serverRegistry.removeServer(server.id);
     }
   });
 
   it('reads from the active instance store', () => {
-    serverRegistry.addInstance(makeInstance({ id: 'remote' }));
+    serverRegistry.addServer(makeServer({ id: 'remote' }));
     serverRegistry.getStore('remote').setPermissions(makeViewer({ canAdminViewRoles: true }));
 
     const perms = mount('remote');
@@ -66,12 +66,12 @@ describe('getServerPermissions', () => {
 
   it('reflects the active instance, not the origin', () => {
     // Origin grants admin; remote does not.
-    serverRegistry.addInstance(
-      makeInstance({ id: 'origin', url: window.location.origin, name: 'Origin' })
+    serverRegistry.addServer(
+      makeServer({ id: 'origin', url: window.location.origin, name: 'Origin' })
     );
     serverRegistry.getStore('origin').setPermissions(makeViewer({ canAdminViewRoles: true }));
 
-    serverRegistry.addInstance(makeInstance({ id: 'remote' }));
+    serverRegistry.addServer(makeServer({ id: 'remote' }));
     serverRegistry.getStore('remote').setPermissions(makeViewer({ canAdminViewRoles: false }));
 
     const perms = mount('remote');

--- a/frontend/src/lib/state/server/registry.svelte.spec.ts
+++ b/frontend/src/lib/state/server/registry.svelte.spec.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { generateInstanceId, type RegisteredInstance } from './registry.svelte';
+import { generateServerId, type RegisteredServer } from './registry.svelte';
 
 const STORAGE_KEY = 'chatto:instances';
 
-function makeInstance(overrides: Partial<RegisteredInstance> = {}): RegisteredInstance {
+function makeServer(overrides: Partial<RegisteredServer> = {}): RegisteredServer {
 	return {
 		id: 'test-instance',
 		url: 'https://test.example.com',
@@ -31,28 +31,28 @@ async function createRegistry() {
 	return mod.serverRegistry;
 }
 
-describe('generateInstanceId', () => {
+describe('generateServerId', () => {
 	it('extracts hostname and replaces dots with hyphens', () => {
-		expect(generateInstanceId('https://chat.example.com')).toBe('chat-example-com');
+		expect(generateServerId('https://chat.example.com')).toBe('chat-example-com');
 	});
 
 	it('handles localhost', () => {
-		expect(generateInstanceId('http://localhost')).toBe('localhost');
+		expect(generateServerId('http://localhost')).toBe('localhost');
 	});
 
 	it('handles URLs with ports', () => {
-		expect(generateInstanceId('http://localhost:4000')).toBe('localhost');
+		expect(generateServerId('http://localhost:4000')).toBe('localhost');
 	});
 
 	it('deduplicates when ID already exists', () => {
-		expect(generateInstanceId('https://chat.example.com', ['chat-example-com'])).toBe(
+		expect(generateServerId('https://chat.example.com', ['chat-example-com'])).toBe(
 			'chat-example-com-2'
 		);
 	});
 
 	it('increments suffix for multiple collisions', () => {
 		expect(
-			generateInstanceId('https://chat.example.com', [
+			generateServerId('https://chat.example.com', [
 				'chat-example-com',
 				'chat-example-com-2'
 			])
@@ -60,7 +60,7 @@ describe('generateInstanceId', () => {
 	});
 
 	it('handles invalid URLs gracefully', () => {
-		const id = generateInstanceId('not-a-url');
+		const id = generateServerId('not-a-url');
 		expect(id).toBeTruthy();
 		expect(id.length).toBeGreaterThan(0);
 	});
@@ -74,78 +74,78 @@ describe('ServerRegistry', () => {
 	it('exports the singleton', async () => {
 		const registry = await createRegistry();
 		expect(registry).toBeDefined();
-		expect(registry.instances).toBeDefined();
+		expect(registry.servers).toBeDefined();
 	});
 
 	describe('init', () => {
 		it('does not auto-register any instance', async () => {
 			const registry = await createRegistry();
-			registry.instances = [];
+			registry.servers = [];
 
 			registry.init();
 
-			expect(registry.instances).toHaveLength(0);
+			expect(registry.servers).toHaveLength(0);
 		});
 	});
 
 	describe('originServer', () => {
 		it('returns the instance matching window.location.origin', async () => {
 			const registry = await createRegistry();
-			registry.instances = [];
+			registry.servers = [];
 
-			registry.addInstance(makeInstance({ id: 'origin', url: window.location.origin, name: 'Origin' }));
-			registry.addInstance(makeInstance({ id: 'remote', url: 'https://remote.example.com', name: 'Remote' }));
+			registry.addServer(makeServer({ id: 'origin', url: window.location.origin, name: 'Origin' }));
+			registry.addServer(makeServer({ id: 'remote', url: 'https://remote.example.com', name: 'Remote' }));
 
 			expect(registry.originServer?.name).toBe('Origin');
 		});
 
 		it('returns undefined when no origin instance exists', async () => {
 			const registry = await createRegistry();
-			registry.instances = [];
+			registry.servers = [];
 
-			registry.addInstance(makeInstance({ id: 'a', url: 'https://remote.example.com' }));
+			registry.addServer(makeServer({ id: 'a', url: 'https://remote.example.com' }));
 
 			expect(registry.originServer).toBeUndefined();
 		});
 	});
 
-	describe('isOriginInstance', () => {
+	describe('isOriginServer', () => {
 		it('returns true for instance matching window.location.origin', async () => {
 			const registry = await createRegistry();
-			registry.instances = [];
+			registry.servers = [];
 
-			registry.addInstance(makeInstance({ id: 'origin', url: window.location.origin }));
+			registry.addServer(makeServer({ id: 'origin', url: window.location.origin }));
 
-			expect(registry.isOriginInstance('origin')).toBe(true);
+			expect(registry.isOriginServer('origin')).toBe(true);
 		});
 
 		it('returns false for remote instance', async () => {
 			const registry = await createRegistry();
-			registry.instances = [];
+			registry.servers = [];
 
-			registry.addInstance(makeInstance({ id: 'remote', url: 'https://remote.example.com' }));
+			registry.addServer(makeServer({ id: 'remote', url: 'https://remote.example.com' }));
 
-			expect(registry.isOriginInstance('remote')).toBe(false);
+			expect(registry.isOriginServer('remote')).toBe(false);
 		});
 	});
 
-	describe('addInstance', () => {
+	describe('addServer', () => {
 		it('adds an instance', async () => {
 			const registry = await createRegistry();
-			registry.instances = [];
+			registry.servers = [];
 
-			const instance = makeInstance();
-			registry.addInstance(instance);
+			const server = makeServer();
+			registry.addServer(server);
 
-			expect(registry.instances).toHaveLength(1);
-			expect(registry.instances[0].id).toBe('test-instance');
+			expect(registry.servers).toHaveLength(1);
+			expect(registry.servers[0].id).toBe('test-instance');
 		});
 
 		it('persists to localStorage', async () => {
 			const registry = await createRegistry();
-			registry.instances = [];
+			registry.servers = [];
 
-			registry.addInstance(makeInstance());
+			registry.addServer(makeServer());
 
 			const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
 			expect(stored).toHaveLength(1);
@@ -154,42 +154,42 @@ describe('ServerRegistry', () => {
 
 		it('skips duplicates', async () => {
 			const registry = await createRegistry();
-			registry.instances = [];
+			registry.servers = [];
 
-			const instance = makeInstance();
-			registry.addInstance(instance);
-			registry.addInstance(instance);
+			const server = makeServer();
+			registry.addServer(server);
+			registry.addServer(server);
 
-			expect(registry.instances).toHaveLength(1);
+			expect(registry.servers).toHaveLength(1);
 		});
 	});
 
-	describe('removeInstance', () => {
+	describe('removeServer', () => {
 		it('removes an instance by ID', async () => {
 			const registry = await createRegistry();
-			registry.instances = [];
+			registry.servers = [];
 
-			registry.addInstance(makeInstance({ id: 'a' }));
-			registry.addInstance(makeInstance({ id: 'b' }));
+			registry.addServer(makeServer({ id: 'a' }));
+			registry.addServer(makeServer({ id: 'b' }));
 
-			expect(registry.removeInstance('a')).toBe(true);
-			expect(registry.instances).toHaveLength(1);
-			expect(registry.instances[0].id).toBe('b');
+			expect(registry.removeServer('a')).toBe(true);
+			expect(registry.servers).toHaveLength(1);
+			expect(registry.servers[0].id).toBe('b');
 		});
 
 		it('returns false for nonexistent ID', async () => {
 			const registry = await createRegistry();
-			registry.instances = [];
+			registry.servers = [];
 
-			expect(registry.removeInstance('nope')).toBe(false);
+			expect(registry.removeServer('nope')).toBe(false);
 		});
 
 		it('persists removal to localStorage', async () => {
 			const registry = await createRegistry();
-			registry.instances = [];
+			registry.servers = [];
 
-			registry.addInstance(makeInstance({ id: 'a' }));
-			registry.removeInstance('a');
+			registry.addServer(makeServer({ id: 'a' }));
+			registry.removeServer('a');
 
 			const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
 			expect(stored).toHaveLength(0);
@@ -199,26 +199,26 @@ describe('ServerRegistry', () => {
 	describe('updateServer', () => {
 		it('updates fields on an existing instance', async () => {
 			const registry = await createRegistry();
-			registry.instances = [];
+			registry.servers = [];
 
-			registry.addInstance(makeInstance({ id: 'x', name: 'Old Name' }));
+			registry.addServer(makeServer({ id: 'x', name: 'Old Name' }));
 
 			expect(registry.updateServer('x', { name: 'New Name' })).toBe(true);
-			expect(registry.instances[0].name).toBe('New Name');
+			expect(registry.servers[0].name).toBe('New Name');
 		});
 
 		it('returns false for nonexistent ID', async () => {
 			const registry = await createRegistry();
-			registry.instances = [];
+			registry.servers = [];
 
 			expect(registry.updateServer('nope', { name: 'x' })).toBe(false);
 		});
 
 		it('persists update to localStorage', async () => {
 			const registry = await createRegistry();
-			registry.instances = [];
+			registry.servers = [];
 
-			registry.addInstance(makeInstance({ id: 'x', name: 'Old' }));
+			registry.addServer(makeServer({ id: 'x', name: 'Old' }));
 			registry.updateServer('x', { name: 'New' });
 
 			const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
@@ -226,28 +226,28 @@ describe('ServerRegistry', () => {
 		});
 	});
 
-	describe('getInstance', () => {
+	describe('getServer', () => {
 		it('returns instance by ID', async () => {
 			const registry = await createRegistry();
-			registry.instances = [];
+			registry.servers = [];
 
-			registry.addInstance(makeInstance({ id: 'foo', name: 'Foo' }));
+			registry.addServer(makeServer({ id: 'foo', name: 'Foo' }));
 
-			expect(registry.getInstance('foo')?.name).toBe('Foo');
+			expect(registry.getServer('foo')?.name).toBe('Foo');
 		});
 
 		it('returns undefined for nonexistent ID', async () => {
 			const registry = await createRegistry();
-			registry.instances = [];
+			registry.servers = [];
 
-			expect(registry.getInstance('nope')).toBeUndefined();
+			expect(registry.getServer('nope')).toBeUndefined();
 		});
 	});
 
 	describe('localStorage persistence', () => {
 		it('loads instances from localStorage on construction', async () => {
-			const instance = makeInstance({ id: 'persisted', name: 'Persisted' });
-			localStorage.setItem(STORAGE_KEY, JSON.stringify([instance]));
+			const server = makeServer({ id: 'persisted', name: 'Persisted' });
+			localStorage.setItem(STORAGE_KEY, JSON.stringify([server]));
 
 			const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
 			expect(stored).toHaveLength(1);

--- a/frontend/src/lib/state/server/registry.svelte.ts
+++ b/frontend/src/lib/state/server/registry.svelte.ts
@@ -5,9 +5,9 @@ import { eventBusManager } from './eventBus.svelte';
 import { Codecs, globalSlot } from '$lib/storage/slot';
 
 /**
- * A registered Chatto instance in the multi-instance client.
+ * A registered Chatto server in the multi-server client.
  */
-export interface RegisteredInstance {
+export interface RegisteredServer {
 	/** Local slug (derived from hostname, e.g., "chat-example-com") */
 	id: string;
 	/** Base URL (e.g., "https://chat.example.com") */
@@ -16,26 +16,26 @@ export interface RegisteredInstance {
 	name: string;
 	/** Server icon URL, or null if none */
 	iconUrl: string | null;
-	/** Bearer token for cross-origin auth, or null for origin instance (uses cookies) */
+	/** Bearer token for cross-origin auth, or null for origin server (uses cookies) */
 	token: string | null;
-	/** Authenticated user ID on this instance, or null if not yet authenticated */
+	/** Authenticated user ID on this server, or null if not yet authenticated */
 	userId: string | null;
-	/** Authenticated user's login on this instance */
+	/** Authenticated user's login on this server */
 	userLogin: string | null;
-	/** Authenticated user's display name on this instance */
+	/** Authenticated user's display name on this server */
 	userDisplayName: string | null;
-	/** Authenticated user's avatar URL on this instance */
+	/** Authenticated user's avatar URL on this server */
 	userAvatarUrl: string | null;
-	/** When this instance was added (epoch ms) */
+	/** When this server was added (epoch ms) */
 	addedAt: number;
 }
 
 /**
- * Generate a URL-safe instance ID from a base URL.
+ * Generate a URL-safe server ID from a base URL.
  * Extracts the hostname and replaces dots/colons with hyphens.
  * If the ID already exists in `existingIds`, appends a numeric suffix.
  */
-export function generateInstanceId(url: string, existingIds: string[] = []): string {
+export function generateServerId(url: string, existingIds: string[] = []): string {
 	let hostname: string;
 	try {
 		// eslint-disable-next-line svelte/prefer-svelte-reactivity -- extracting hostname string, URL not stored
@@ -57,50 +57,53 @@ export function generateInstanceId(url: string, existingIds: string[] = []): str
 	return `${base}-${suffix}`;
 }
 
-const instancesSlot = globalSlot(
+// Storage key intentionally stays as 'instances' — renaming would lose users'
+// multi-server registrations (including remote bearer tokens that can't be
+// regenerated). The in-code rename is purely cosmetic.
+const serversSlot = globalSlot(
 	'instances',
-	[] as RegisteredInstance[],
-	Codecs.json<RegisteredInstance[]>((v): v is RegisteredInstance[] => Array.isArray(v))
+	[] as RegisteredServer[],
+	Codecs.json<RegisteredServer[]>((v): v is RegisteredServer[] => Array.isArray(v))
 );
 
 
 /**
- * Client-side registry of connected Chatto instances.
- * Owns both registration data and per-instance state stores.
+ * Client-side registry of connected Chatto servers.
+ * Owns both registration data and per-server state stores.
  *
- * Registration and store creation are atomic — when an instance is added,
+ * Registration and store creation are atomic — when a server is added,
  * its store is created immediately. This eliminates race conditions where
- * $derived expressions see a registered instance but no store exists yet.
+ * $derived expressions see a registered server but no store exists yet.
  *
  * The store map uses SvelteMap so that getStore() lookups are reactive
  * in $derived expressions.
  *
- * The registry does NOT track which instance is "active".
- * The active instance is determined by the URL (via the [[serverId=hostname]] layout)
+ * The registry does NOT track which server is "active".
+ * The active server is determined by the URL (via the [[serverId=hostname]] layout)
  * and provided to components through Svelte context.
  */
 class ServerRegistry {
-	instances = $state<RegisteredInstance[]>(instancesSlot.get());
+	servers = $state<RegisteredServer[]>(serversSlot.get());
 	#stores = new SvelteMap<string, ServerStateStore>();
 
 	/**
 	 * Whether the async origin probe has completed (resolved or rejected).
-	 * When `probeOrigin(true)` is called (known instance), this is set immediately.
+	 * When `probeOrigin(true)` is called (known server), this is set immediately.
 	 * Use this to distinguish "probe in progress" from "no origin backend."
 	 */
 	originProbed = $state(false);
 
 	/**
-	 * The origin instance — the one serving the SPA.
-	 * Derived by matching registered instance URLs against window.location.origin.
+	 * The origin server — the one serving the SPA.
+	 * Derived by matching registered server URLs against window.location.origin.
 	 * Returns undefined if the origin server isn't registered.
 	 */
-	get originServer(): RegisteredInstance | undefined {
+	get originServer(): RegisteredServer | undefined {
 		if (typeof window === 'undefined') return undefined;
 		const origin = window.location.origin;
-		return this.instances.find((i) => {
+		return this.servers.find((s) => {
 			try {
-				return new URL(i.url).origin === origin;
+				return new URL(s.url).origin === origin;
 			} catch {
 				return false;
 			}
@@ -108,33 +111,33 @@ class ServerRegistry {
 	}
 
 	/**
-	 * Check whether a registered instance is the origin (the server serving the SPA).
+	 * Check whether a registered server is the origin (the server serving the SPA).
 	 * Uses URL comparison — no stored flag needed.
 	 */
-	isOriginInstance(serverId: string): boolean {
-		const instance = this.getInstance(serverId);
-		if (!instance || typeof window === 'undefined') return false;
+	isOriginServer(serverId: string): boolean {
+		const server = this.getServer(serverId);
+		if (!server || typeof window === 'undefined') return false;
 		try {
-			return new URL(instance.url).origin === window.location.origin;
+			return new URL(server.url).origin === window.location.origin;
 		} catch {
 			return false;
 		}
 	}
 
 	/**
-	 * Auto-register the origin server as a Chatto instance.
+	 * Auto-register the origin server as a Chatto server.
 	 *
-	 * When `knownInstance` is true (e.g., cookie-authenticated user), registers
+	 * When `knownServer` is true (e.g., cookie-authenticated user), registers
 	 * synchronously with a placeholder name — the store's serverInfo.init()
 	 * fetches the real name.
 	 *
-	 * When `knownInstance` is false, probes /api/server first. If it responds,
-	 * the origin is a Chatto instance — register it. If it fails (static hosting),
+	 * When `knownServer` is false, probes /api/server first. If it responds,
+	 * the origin is a Chatto server — register it. If it fails (static hosting),
 	 * nothing happens.
 	 *
 	 * No-ops if the origin is already registered (e.g., from localStorage).
 	 */
-	probeOrigin(knownInstance = false): void {
+	probeOrigin(knownServer = false): void {
 		if (typeof window === 'undefined') return;
 		if (this.originServer) {
 			this.originProbed = true;
@@ -143,15 +146,15 @@ class ServerRegistry {
 
 		const origin = window.location.origin;
 
-		if (knownInstance) {
-			// Synchronous registration — we already know it's a Chatto instance
-			const id = generateInstanceId(origin, this.instances.map((i) => i.id));
+		if (knownServer) {
+			// Synchronous registration — we already know it's a Chatto server
+			const id = generateServerId(origin, this.servers.map((s) => s.id));
 			this.#registerOrigin(id, origin, 'Chatto', null);
 			this.originProbed = true;
 			return;
 		}
 
-		// Async probe — detect if the origin is a Chatto instance
+		// Async probe — detect if the origin is a Chatto server
 		fetch(`${origin}/api/server`)
 			.then((r) => {
 				if (!r.ok) return;
@@ -161,11 +164,11 @@ class ServerRegistry {
 				if (!data) return;
 				if (this.originServer) return; // Registered while we were fetching
 
-				const id = generateInstanceId(origin, this.instances.map((i) => i.id));
+				const id = generateServerId(origin, this.servers.map((s) => s.id));
 				this.#registerOrigin(id, origin, data.name || 'Chatto', data.iconUrl ?? null);
 			})
 			.catch(() => {
-				// Not a Chatto instance — ignore
+				// Not a Chatto server — ignore
 			})
 			.finally(() => {
 				this.originProbed = true;
@@ -173,7 +176,7 @@ class ServerRegistry {
 	}
 
 	#registerOrigin(id: string, url: string, name: string, iconUrl: string | null): void {
-		this.addInstance({
+		this.addServer({
 			id,
 			url,
 			name,
@@ -188,41 +191,41 @@ class ServerRegistry {
 	}
 
 	/**
-	 * Bootstrap the registry: create stores for all registered instances.
+	 * Bootstrap the registry: create stores for all registered servers.
 	 * Call once from the root layout's script init (before any $derived reads stores).
 	 */
 	init(): void {
-		for (const instance of this.instances) {
-			if (!this.#stores.has(instance.id)) {
-				this.#createStore(instance);
+		for (const server of this.servers) {
+			if (!this.#stores.has(server.id)) {
+				this.#createStore(server);
 			}
 		}
 	}
 
-	/** Add an instance to the registry, create its state store, and start its event bus. */
-	addInstance(instance: RegisteredInstance): void {
-		if (this.instances.some((i) => i.id === instance.id)) {
+	/** Add a server to the registry, create its state store, and start its event bus. */
+	addServer(server: RegisteredServer): void {
+		if (this.servers.some((s) => s.id === server.id)) {
 			return; // Already exists
 		}
-		this.instances.push(instance);
-		instancesSlot.set(this.instances);
-		const store = this.#createStore(instance);
+		this.servers.push(server);
+		serversSlot.set(this.servers);
+		const store = this.#createStore(server);
 
-		// Start the event bus eagerly for already-authenticated instances so
+		// Start the event bus eagerly for already-authenticated servers so
 		// child components (ServerSpaceSection) can register handlers during
-		// their mount lifecycle. For cookie-auth instances the user is loaded
+		// their mount lifecycle. For cookie-auth servers the user is loaded
 		// asynchronously by AuthenticatedChatProvider, so the layout's $effect
 		// starts the bus once `isAuthenticated` flips true.
 		if (store.isAuthenticated) {
-			const gqlClient = graphqlClientManager.getClient(instance.id);
-			eventBusManager.startBus(instance.id, gqlClient.client);
+			const gqlClient = graphqlClientManager.getClient(server.id);
+			eventBusManager.startBus(server.id, gqlClient.client);
 		}
 	}
 
-	/** Remove an instance by ID. Disposes its event bus, store, and GraphQL client. */
-	removeInstance(id: string): boolean {
-		const instance = this.instances.find((i) => i.id === id);
-		if (!instance) {
+	/** Remove a server by ID. Disposes its event bus, store, and GraphQL client. */
+	removeServer(id: string): boolean {
+		const server = this.servers.find((s) => s.id === id);
+		if (!server) {
 			return false;
 		}
 
@@ -236,51 +239,51 @@ class ServerRegistry {
 		// Dispose GraphQL client
 		graphqlClientManager.destroyClient(id);
 
-		this.instances = this.instances.filter((i) => i.id !== id);
-		instancesSlot.set(this.instances);
+		this.servers = this.servers.filter((s) => s.id !== id);
+		serversSlot.set(this.servers);
 		return true;
 	}
 
-	/** Remove all instances. Used by the global sign-out flow.
+	/** Remove all servers. Used by the global sign-out flow.
 	 *  Clears dismissals so the origin can be re-discovered on next visit. */
 	removeAll(): void {
-		for (const instance of [...this.instances]) {
-			eventBusManager.stopBus(instance.id);
-			this.#stores.get(instance.id)?.dispose();
-			this.#stores.delete(instance.id);
-			graphqlClientManager.destroyClient(instance.id);
+		for (const server of [...this.servers]) {
+			eventBusManager.stopBus(server.id);
+			this.#stores.get(server.id)?.dispose();
+			this.#stores.delete(server.id);
+			graphqlClientManager.destroyClient(server.id);
 		}
-		this.instances = [];
-		instancesSlot.set(this.instances);
+		this.servers = [];
+		serversSlot.set(this.servers);
 	}
 
-	/** Update fields on an existing instance. */
-	updateServer(id: string, data: Partial<Omit<RegisteredInstance, 'id'>>): boolean {
-		const instance = this.instances.find((i) => i.id === id);
-		if (!instance) {
+	/** Update fields on an existing server. */
+	updateServer(id: string, data: Partial<Omit<RegisteredServer, 'id'>>): boolean {
+		const server = this.servers.find((s) => s.id === id);
+		if (!server) {
 			return false;
 		}
 
-		Object.assign(instance, data);
-		instancesSlot.set(this.instances);
+		Object.assign(server, data);
+		serversSlot.set(this.servers);
 		return true;
 	}
 
-	/** Get an instance by ID. */
-	getInstance(id: string): RegisteredInstance | undefined {
-		return this.instances.find((i) => i.id === id);
+	/** Get a server by ID. */
+	getServer(id: string): RegisteredServer | undefined {
+		return this.servers.find((s) => s.id === id);
 	}
 
 	/**
-	 * Get the state store for a registered instance.
+	 * Get the state store for a registered server.
 	 * Safe in $derived — stores are created atomically with registration,
-	 * so every registered instance always has a store.
+	 * so every registered server always has a store.
 	 */
 	getStore(serverId: string): ServerStateStore {
 		const store = this.#stores.get(serverId);
 		if (!store) {
 			throw new Error(
-				`No store for instance "${serverId}". Is it registered? ` +
+				`No store for server "${serverId}". Is it registered? ` +
 					`Call serverRegistry.init() before accessing stores.`
 			);
 		}
@@ -288,18 +291,18 @@ class ServerRegistry {
 	}
 
 	/**
-	 * Get the state store for a registered instance, or undefined if not found.
-	 * Use when the instance may not be registered (e.g., unresolved URL segments).
+	 * Get the state store for a registered server, or undefined if not found.
+	 * Use when the server may not be registered (e.g., unresolved URL segments).
 	 */
 	tryGetStore(serverId: string): ServerStateStore | undefined {
 		return this.#stores.get(serverId);
 	}
 
-	/** Create a state store for an instance and wire up remote user sync. */
-	#createStore(instance: RegisteredInstance): ServerStateStore {
-		const gqlClient = graphqlClientManager.getClient(instance.id);
-		const store = new ServerStateStore(instance, gqlClient);
-		this.#stores.set(instance.id, store);
+	/** Create a state store for a server and wire up remote user sync. */
+	#createStore(server: RegisteredServer): ServerStateStore {
+		const gqlClient = graphqlClientManager.getClient(server.id);
+		const store = new ServerStateStore(server, gqlClient);
+		this.#stores.set(server.id, store);
 
 		// Eagerly fetch server info (name, MOTD, upload limits, etc.).
 		// This is important for late-registered servers (e.g., origin registered
@@ -308,12 +311,12 @@ class ServerRegistry {
 		// any unexpected rejection so it can never become an unhandled rejection.
 		store.serverInfo.init().catch((err) => {
 			console.error(
-				`[server:${instance.url}] unexpected init() rejection`,
+				`[server:${server.url}] unexpected init() rejection`,
 				err
 			);
 		});
 
-		if (instance.token === null) {
+		if (server.token === null) {
 			// Cookie auth (origin) — the SvelteKit load function already determined
 			// auth state. AuthenticatedChatProvider will set the user if authenticated.
 			store.currentUser.loading = false;
@@ -326,7 +329,7 @@ class ServerRegistry {
 				.then(() => {
 					const user = store.currentUser.user;
 					if (user) {
-						this.updateServer(instance.id, {
+						this.updateServer(server.id, {
 							userId: user.id,
 							userLogin: user.login,
 							userDisplayName: user.displayName,
@@ -336,7 +339,7 @@ class ServerRegistry {
 				})
 				.catch((err) => {
 					console.error(
-						`[instance:${instance.url}] failed to load current user`,
+						`[server:${server.url}] failed to load current user`,
 						err
 					);
 					store.currentUser.loading = false;
@@ -346,7 +349,7 @@ class ServerRegistry {
 		return store;
 	}
 
-	/** Whether the instance has an authenticated user. False if not registered. */
+	/** Whether the server has an authenticated user. False if not registered. */
 	isAuthenticated(serverId: string): boolean {
 		return this.tryGetStore(serverId)?.isAuthenticated ?? false;
 	}

--- a/frontend/src/lib/state/server/store.svelte.ts
+++ b/frontend/src/lib/state/server/store.svelte.ts
@@ -18,7 +18,7 @@ import { RoomDirectoryStore } from '$lib/state/space/roomDirectory.svelte';
 import { eventBusManager } from './eventBus.svelte';
 import type { EventHandler } from '$lib/eventBus.svelte';
 import type { GraphQLClient } from './graphqlClient.svelte';
-import type { RegisteredInstance } from './registry.svelte';
+import type { RegisteredServer } from './registry.svelte';
 
 /**
  * What kind of indicator dot a space (or the DM area) should display.
@@ -63,12 +63,12 @@ export class ServerStateStore {
 	 * mutations (e.g. token refresh, name change) because the registry stores
 	 * servers in $state.
 	 */
-	readonly #registered: RegisteredInstance;
+	readonly #registered: RegisteredServer;
 
 	/** Disposer for the internal effect root that wires lifecycle reactivity. */
 	readonly #disposeEffects: () => void;
 
-	constructor(registered: RegisteredInstance, gqlClient: GraphQLClient) {
+	constructor(registered: RegisteredServer, gqlClient: GraphQLClient) {
 		this.serverId = registered.id;
 		this.#registered = registered;
 		const cookieAuth = this.#cookieAuth;

--- a/frontend/src/lib/ui/AppHeader.svelte
+++ b/frontend/src/lib/ui/AppHeader.svelte
@@ -18,14 +18,14 @@
 
   // Aggregate notification count across all servers.
   const totalNotificationCount = $derived(
-    serverRegistry.instances.reduce(
+    serverRegistry.servers.reduce(
       (sum, instance) => sum + serverRegistry.getStore(instance.id).notifications.count,
       0
     )
   );
 
   // Show sign-out button when any server is registered
-  const hasInstances = $derived(serverRegistry.instances.length > 0);
+  const hasInstances = $derived(serverRegistry.servers.length > 0);
 
   function handleSignOut() {
     pushState('', { modal: { type: 'logout' } });

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -49,7 +49,7 @@
   const presenceCache = createPresenceCache();
 
   // Start event buses for every authenticated instance (origin or remote).
-  // startBus is idempotent; cleanup is handled by removeInstance.
+  // startBus is idempotent; cleanup is handled by removeServer.
   //
   // We do this synchronously during script init AND in a $effect, because
   // child route layouts (e.g. /chat/[serverId]/+layout.svelte) call
@@ -59,23 +59,23 @@
   // to expose it via Svelte context, and any descendant calling
   // `useEvent` ends up subscribing to nothing (real-time updates
   // for cross-instance unread tracking get silently dropped).
-  for (const instance of serverRegistry.instances) {
-    const store = serverRegistry.tryGetStore(instance.id);
+  for (const server of serverRegistry.servers) {
+    const store = serverRegistry.tryGetStore(server.id);
     if (store?.isAuthenticated) {
       eventBusManager.startBus(
-        instance.id,
-        graphqlClientManager.getClient(instance.id).client
+        server.id,
+        graphqlClientManager.getClient(server.id).client
       );
     }
   }
   $effect(() => {
-    for (const instance of serverRegistry.instances) {
-      const store = serverRegistry.tryGetStore(instance.id);
+    for (const server of serverRegistry.servers) {
+      const store = serverRegistry.tryGetStore(server.id);
       if (store?.isAuthenticated) {
         // startBus is idempotent — no-op if already started above.
         eventBusManager.startBus(
-          instance.id,
-          graphqlClientManager.getClient(instance.id).client
+          server.id,
+          graphqlClientManager.getClient(server.id).client
         );
       }
     }

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -21,7 +21,7 @@
     if (!data.user) return;
     if (sessionStorage.getItem('returnUrl')) return;
 
-    if (serverRegistry.instances.length === 0) {
+    if (serverRegistry.servers.length === 0) {
       goto(resolve('/login'), { replaceState: true });
       return;
     }

--- a/frontend/src/routes/chat/AuthenticatedChatProvider.svelte
+++ b/frontend/src/routes/chat/AuthenticatedChatProvider.svelte
@@ -105,7 +105,7 @@
   // This works across all instances, not just origin.
   initPresenceTracking(
     () =>
-      serverRegistry.instances.map(
+      serverRegistry.servers.map(
         (i) => graphqlClientManager.getClient(i.id).client
       ),
     (status) => {

--- a/frontend/src/routes/chat/ModalContainer.svelte
+++ b/frontend/src/routes/chat/ModalContainer.svelte
@@ -71,7 +71,7 @@
     clearLastRoom(activeInstanceId);
 
     const leftInstanceId = activeInstanceId;
-    serverRegistry.removeInstance(leftInstanceId);
+    serverRegistry.removeServer(leftInstanceId);
 
     // Land on the origin instance if it exists, otherwise root.
     const originId = serverRegistry.originServer?.id;

--- a/frontend/src/routes/chat/notifications/+page.svelte
+++ b/frontend/src/routes/chat/notifications/+page.svelte
@@ -24,7 +24,7 @@
   let allNotifications = $derived.by(() => {
     const result: ServerNotification[] = [];
 
-    for (const instance of serverRegistry.instances) {
+    for (const instance of serverRegistry.servers) {
       const stores = serverRegistry.getStore(instance.id);
       if (!stores.isAuthenticated) continue;
 
@@ -65,7 +65,7 @@
     loading = true;
     const fetches: Promise<void>[] = [];
 
-    for (const instance of serverRegistry.instances) {
+    for (const instance of serverRegistry.servers) {
       const stores = serverRegistry.getStore(instance.id);
       if (!stores.isAuthenticated) continue;
       fetches.push(stores.notifications.fetch());
@@ -114,7 +114,7 @@
 
   async function handleClearAll() {
     const clears: Promise<number>[] = [];
-    for (const instance of serverRegistry.instances) {
+    for (const instance of serverRegistry.servers) {
       const stores = serverRegistry.getStore(instance.id);
       if (!stores.isAuthenticated) continue;
       clears.push(stores.notifications.dismissAll());

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -17,7 +17,7 @@
   let password = $state('');
   let error = $state('');
   let isLoading = $state(false);
-  let addInstanceDialogVisible = $state(false);
+  let addServerDialogVisible = $state(false);
 
   const canSubmit = $derived(identifier.trim() && password);
 
@@ -139,7 +139,7 @@
           Connect to a Chatto server to get started. You can connect to multiple
           servers and switch between them.
         </p>
-        <Button variant="accent" size="lg" fullWidth onclick={() => (addInstanceDialogVisible = true)}>
+        <Button variant="accent" size="lg" fullWidth onclick={() => (addServerDialogVisible = true)}>
           Add Server
         </Button>
       </div>
@@ -221,6 +221,6 @@
 {/if}
 
 <AddServerDialog
-  bind:visible={addInstanceDialogVisible}
-  onclose={() => (addInstanceDialogVisible = false)}
+  bind:visible={addServerDialogVisible}
+  onclose={() => (addServerDialogVisible = false)}
 />

--- a/frontend/src/routes/servers/callback/+page.svelte
+++ b/frontend/src/routes/servers/callback/+page.svelte
@@ -4,7 +4,7 @@
   import { resolve } from '$app/paths';
   import { onMount } from 'svelte';
   import { loadAndClearFlowState } from '$lib/oauth/pkce';
-  import { serverRegistry, generateInstanceId } from '$lib/state/server/registry.svelte';
+  import { serverRegistry, generateServerId } from '$lib/state/server/registry.svelte';
   import { serverIdToSegment } from '$lib/navigation';
   import PageTitle from '$lib/ui/PageTitle.svelte';
 
@@ -77,7 +77,7 @@
       }
 
       // Register or update the instance
-      const existing = serverRegistry.instances.find(
+      const existing = serverRegistry.servers.find(
         (i) => i.url.toLowerCase() === flow.remoteUrl.toLowerCase()
       );
 
@@ -94,12 +94,12 @@
         });
         serverId = existing.id;
       } else {
-        const id = generateInstanceId(
+        const id = generateServerId(
           flow.remoteUrl,
-          serverRegistry.instances.map((i) => i.id)
+          serverRegistry.servers.map((i) => i.id)
         );
 
-        serverRegistry.addInstance({
+        serverRegistry.addServer({
           id,
           url: flow.remoteUrl,
           name: flow.serverName ?? 'Chatto',


### PR DESCRIPTION
## Summary

Fourth and final pass of the post-glossary naming cleanup, finishing the [ADR-029](https://github.com/chattocorp/chatto/blob/main/docs/adr/ADR-029-instance-to-server-rename.md) Instance→Server rename on the frontend's `ServerRegistry` API surface: `RegisteredInstance` → `RegisteredServer`, `.instances` → `.servers`, `addInstance`/`removeInstance`/`getInstance`/`isOriginInstance` → `addServer`/`removeServer`/`getServer`/`isOriginServer`, `generateInstanceId` → `generateServerId`, plus matching renames in 5 mock/test helpers (`RegisteredInstanceMock`/`mockInstances`/`makeInstance` and a local `addInstanceDialogVisible` state). Touches 27 files; loop variables `instance` → `server` followed when a file was already being edited, and `.claude/rules/frontend.md` examples + the Disconnect doc bullet updated to match.

**Deliberately kept:** the localStorage key `'instances'` (renaming would wipe users' multi-server registrations including remote bearer tokens — storage is an implementation detail; noted in `registry.svelte.ts`), the GraphQL field `viewerCanManageInstance` (backend-owned), and `getInstanceRoleRow` in `SpaceRolesPage.ts` (different concept — the role-testing UI, deferred to its own pass).

## Test plan

- [ ] Visually confirm: open the app, connect a remote server, disconnect, sign out — all flows still work end-to-end against the renamed API.
- [ ] CI: lint baseline unchanged at 157 locally (all pre-existing on `main`); 755 frontend unit tests pass; e2e not run locally.