### PR TITLE
docs(frontend): refresh stale event-bus rules + sweep comments

### DIFF
--- a/.claude/rules/frontend-conventions.md
+++ b/.claude/rules/frontend-conventions.md
@@ -43,37 +43,40 @@ Frontend TypeScript types for permission constants and other shared Go types are
   import type { SomeType } from "$lib/gql/graphql"; // For generated types
   ```
 
-## Event Buses
+## Event Bus
 
-Three buses, one for each event family:
+A single `myEvents` GraphQL subscription per connected server delivers
+every event the user can receive (deployment-wide + room-scoped). One
+`EventBus` per registered server, started by `eventBusManager.startBus`
+on registration and torn down by `removeServer`. See
+`frontend/src/lib/eventBus.svelte.ts` and
+`frontend/src/lib/state/server/eventBus.svelte.ts`.
 
-- **Instance events** (`instanceEventBus.svelte.ts`) — space/user-level changes. Subscribe via `onInstanceEvent()`.
-- **JetStream events** (`spaceEventBus.svelte.ts`) — messages, room events. Subscribe via `onSpaceEvent()`.
-- **Live events** (`spaceLiveEventBus.svelte.ts`) — reactions, typing. Subscribe via `onSpaceLiveEvent()`.
+Consumers register handlers in one of two ways:
 
-**Adding a new instance event handler** (e.g., for `UserProfileUpdatedEvent`):
+- **Active-server hooks** — `onEvent`, `onUserProfileUpdate`, `onMention`, etc. resolve the bus via Svelte context (`provideEventBus(getActiveServer)` in `ServerEventProvider`). The bus follows the active `[serverId]` reactively, so subscribers automatically migrate when the URL changes. Pair with `$effect` for teardown.
+- **Direct cross-server registrar** — `createEventBusHandlerRegistrar(serverId)` attaches handlers to a specific server's bus, bypassing context. Used by the sidebar wiring that tracks every connected server's notification dots, not just the focused one.
 
-1. Add the event fields to the subscription in `instanceEventBus.svelte.ts`.
-2. Create a typed handler hook (e.g., `onUserProfileUpdate`) that filters for that event type.
-3. Subscribe in components using `$effect(() => onUserProfileUpdate(...))` — the hook returns cleanup.
+**Adding a new typed event handler** (e.g., for `UserProfileUpdatedEvent`):
+
+1. Add the event fields to the `MyServerEvents` subscription in `eventBus.svelte.ts`.
+2. Add a typed handler hook next to the other `on*` helpers — use the `onTypedEvent` helper to keep boilerplate small.
+3. Subscribe in components with `$effect(() => onUserProfileUpdate(...))` — the hook returns cleanup.
 
 ```typescript
-// In instanceEventBus.svelte.ts
-export function onUserProfileUpdate(handler: UserProfileHandler): () => void {
-  const bus = getContext<InstanceEventBus | undefined>(INSTANCE_EVENT_BUS_KEY);
-  if (!bus) return () => {}; // Graceful fallback if bus not initialized
+// In $lib/eventBus.svelte.ts
+export type UserProfileUpdate = { userId: string; displayName: string; avatarUrl: string; login: string };
 
-  const wrapper: EventHandler = (event) => {
-    if (!event.event) return; // Skip unknown event types
-    if (event.event.__typename === "UserProfileUpdatedEvent") {
-      handler({ userId: event.event.userId, avatarUrl: event.event.avatarUrl });
-    }
-  };
-  bus.handlers.add(wrapper);
-  return () => bus.handlers.delete(wrapper);
+export function onUserProfileUpdate(handler: (update: UserProfileUpdate) => void): () => void {
+  return onTypedEvent('UserProfileUpdatedEvent', (_env, e) => ({
+    userId: e.userId,
+    displayName: e.displayName,
+    avatarUrl: e.avatarUrl,
+    login: e.login
+  }), handler);
 }
 
-// In component
+// In a component
 $effect(() =>
   onUserProfileUpdate((update) => {
     if (update.userId === user.id) liveAvatarUrl = update.avatarUrl;
@@ -81,9 +84,9 @@ $effect(() =>
 );
 ```
 
-**Whitelist cacheable events in SpaceEventProvider**: when routing subscription events to the message cache, use an explicit whitelist of displayable event types — not a blacklist.
+**Whitelist cacheable events in `ServerEventProvider`**: when routing subscription events to the message cache, use an explicit whitelist of displayable event types — not a blacklist.
 
-**Event handler null checks**: always check for `event.event` being null before accessing properties.
+**Event handler null checks**: `event.event` can be `null` for event types the client doesn't yet know about (forward compatibility). Always null-check before reading `__typename` or fields.
 
 ## Real-time Update Patterns
 

--- a/.claude/rules/testing-frontend.md
+++ b/.claude/rules/testing-frontend.md
@@ -122,7 +122,7 @@ If a test hangs or times out without a clear assertion failure, look at `fronten
 
 ## E2E gotchas worth remembering
 
-- **`page.waitForLoadState('networkidle')` will hang on a flapping WebSocket.** When the backend rejects a graphql-ws subscription (e.g. permission denied), the client retries forever and `networkidle` never fires. Don't gate assertions on `networkidle` after a permission change; assert directly on the DOM. And on the client side: gate subscription *creation* on the relevant permission so the loop never starts (see `SpaceEventProvider.svelte`'s `dm.view` guard).
+- **`page.waitForLoadState('networkidle')` will hang on a flapping WebSocket.** When the backend rejects a graphql-ws subscription (e.g. permission denied), the client retries forever and `networkidle` never fires. Don't gate assertions on `networkidle` after a permission change; assert directly on the DOM. And on the client side: gate subscription *creation* on the relevant permission so the loop never starts (see `ServerEventProvider.svelte`'s `dm.view` guard).
 
 - **Test message bodies must be unique.** `getByText('hi')` collides with empty-room boilerplate ("You've reached the very beginning of this conversation.") and trips strict-mode. Use `${Date.now()}` or `crypto.randomUUID().slice(0, 8)` in any string the test then asserts on.
 

--- a/frontend/e2e/dm.test.ts
+++ b/frontend/e2e/dm.test.ts
@@ -50,8 +50,8 @@ test.describe('Direct Messages (room-shaped)', () => {
       await page.goto(routes.room(conversationId));
       await page.waitForURL(routes.patterns.anyRoom);
 
-      // Bug #1 (the silent post): the SpaceEventProvider must subscribe to
-      // DM-space events too, so MessagePostedEvent reaches RoomEventsPane
+      // Bug #1 (the silent post): the ServerEventProvider must subscribe to
+      // DM events too, so MessagePostedEvent reaches RoomEventsPane
       // and the new message renders without a reload.
       const roomA = new RoomPage(page);
       const postedBody = `dm round-trip ${Date.now()}`;

--- a/frontend/e2e/fixtures/realtimeSync.ts
+++ b/frontend/e2e/fixtures/realtimeSync.ts
@@ -70,11 +70,11 @@ export async function waitForRoomReady(page: Page, roomName?: string): Promise<v
   // if the user doesn't have posting permission (e.g., announcements room).
   await expect(page.getByTestId('message-input')).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
 
-  // Wait for SpaceEventProvider to have mounted and initiated the subscription.
+  // Wait for ServerEventProvider to have mounted and initiated the subscription.
   // The hidden marker element proves the component rendered, and since
-  // startSpaceSubscription runs in the first $effect cycle after render,
-  // the subscription request has been sent by the time this resolves.
-  await expect(page.getByTestId('space-subscription-active')).toBeAttached({
+  // the `myEvents` subscription is started in the first $effect cycle after
+  // render, the subscription request has been sent by the time this resolves.
+  await expect(page.getByTestId('server-subscription-active')).toBeAttached({
     timeout: TIMEOUTS.UI_STANDARD
   });
 }

--- a/frontend/src/lib/components/chat/ServerEventProvider.svelte
+++ b/frontend/src/lib/components/chat/ServerEventProvider.svelte
@@ -37,5 +37,5 @@
   });
 </script>
 
-<div data-testid="space-subscription-active" class="hidden"></div>
+<div data-testid="server-subscription-active" class="hidden"></div>
 {@render children()}

--- a/frontend/src/lib/eventBus.svelte.ts
+++ b/frontend/src/lib/eventBus.svelte.ts
@@ -1,7 +1,7 @@
 /**
- * Single GraphQL subscription per connected server. Replaces the previous
- * pair (`MyInstanceEvents` deployment-wide + `EventBusSubscription`
- * room-scoped) with one stream covering everything the user can receive.
+ * Single GraphQL subscription per connected server, covering everything
+ * the user can receive (deployment-wide events and room-scoped events
+ * over one stream).
  *
  * The manager keeps one bus per registered server. Consumers register
  * handlers either via Svelte context (current active server) or directly
@@ -463,7 +463,7 @@ export function onSessionTerminated(handler: (reason: string) => void): () => vo
 }
 
 // ---------------------------------------------------------------------------
-// Room-scoped helpers (moved here from the former spaceEventBus)
+// Room-scoped helpers
 // ---------------------------------------------------------------------------
 
 type PresenceHandler = (userId: string, status: PresenceStatus) => void;

--- a/frontend/src/lib/state/server/eventBus.svelte.ts
+++ b/frontend/src/lib/state/server/eventBus.svelte.ts
@@ -39,8 +39,8 @@ class EventBusManager {
 	#watchdogs = new Map<string, () => void>();
 
 	/**
-	 * Start an event bus for the given instance. Creates the subscription and
-	 * stores the bus. If a bus already exists for this instance, returns a
+	 * Start an event bus for the given server. Creates the subscription and
+	 * stores the bus. If a bus already exists for this server, returns a
 	 * cleanup function without creating a duplicate.
 	 *
 	 * A watchdog re-subscribes if no event (real or heartbeat) is received
@@ -132,7 +132,7 @@ class EventBusManager {
 		return () => this.stopBus(serverId);
 	}
 
-	/** Stop and remove the event bus for the given instance. */
+	/** Stop and remove the event bus for the given server. */
 	stopBus(serverId: string): void {
 		const stopWatchdog = this.#watchdogs.get(serverId);
 		if (stopWatchdog) {
@@ -147,7 +147,7 @@ class EventBusManager {
 		this.#buses.delete(serverId);
 	}
 
-	/** Get the event bus for an instance, or undefined if not started. */
+	/** Get the event bus for a server, or undefined if not started. */
 	getBus(serverId: string): EventBus | undefined {
 		return this.#buses.get(serverId);
 	}


### PR DESCRIPTION
## Summary

The original drift audit flagged the `instanceEventBus` subsystem for renaming, but a fresh look found those files no longer exist — they were consolidated into a single `myEvents`-per-server subscription. The remaining drift was entirely in documentation and comments: rewrote the stale "Event Buses" section of `frontend-conventions.md` to describe the actual unified architecture (one bus per server, active-server-via-context vs direct cross-server registrar), fixed `SpaceEventProvider` → `ServerEventProvider` in `testing-frontend.md` and an `e2e/dm.test.ts` comment, trimmed historical changelog comments in `lib/eventBus.svelte.ts`, updated stale "instance" → "server" JSDoc in `state/server/eventBus.svelte.ts`, and renamed `data-testid="space-subscription-active"` → `"server-subscription-active"` (+ matching e2e fixture). ADR-010 and ADR-014 are intentionally left alone since they're historical records.

## Test plan

- [ ] CI: lint baseline unchanged at 157 locally (all pre-existing on `main`); 755 frontend unit tests pass; e2e not run locally.