### PR TITLE
refactor(frontend): drop "instance role" terminology + dead UI section

### DIFF
--- a/frontend/e2e/admin.test.ts
+++ b/frontend/e2e/admin.test.ts
@@ -13,7 +13,7 @@ import {
   type TestUser
 } from './fixtures/testUser';
 
-async function createInstanceRoleViaAPI(
+async function createRoleViaAPI(
   page: Page,
   name: string,
   displayName: string
@@ -28,7 +28,7 @@ async function createInstanceRoleViaAPI(
   expect(resp.ok()).toBeTruthy();
 }
 
-async function assignInstanceRoleViaAPI(
+async function assignRoleViaAPI(
   page: Page,
   userId: string,
   roleName: string
@@ -43,7 +43,7 @@ async function assignInstanceRoleViaAPI(
   expect(resp.ok()).toBeTruthy();
 }
 
-async function revokeInstanceRoleViaAPI(
+async function revokeRoleViaAPI(
   page: Page,
   userId: string,
   roleName: string
@@ -469,16 +469,16 @@ test.describe('User Permission Management', () => {
 
     // Create a role with admin.access and assign it to the user (via API as admin)
     const roleName = generateRoleName('grant');
-    await createInstanceRoleViaAPI(page, roleName, 'Grant Admin');
+    await createRoleViaAPI(page, roleName, 'Grant Admin');
     await grantPermission(page, roleName, 'admin.access');
-    await assignInstanceRoleViaAPI(page, regularUser.id!, roleName);
+    await assignRoleViaAPI(page, regularUser.id!, roleName);
 
     // Regular user should now have admin access
     await regularPage.reload();
     await regularAdminPage.expectDashboardVisible();
 
     // Clean up
-    await revokeInstanceRoleViaAPI(page, regularUser.id!, roleName);
+    await revokeRoleViaAPI(page, regularUser.id!, roleName);
     await regularContext.close();
   });
 

--- a/frontend/e2e/fixtures/testUser.ts
+++ b/frontend/e2e/fixtures/testUser.ts
@@ -16,7 +16,7 @@ const ADMIN_EMAIL = 'admin@e2e-test.example.com';
 /**
  * Logs in as the bootstrap admin user.
  * The admin user is created during server startup via the [bootstrap]
- * section in fixtures/chatto.toml, which assigns the instance owner role.
+ * section in fixtures/chatto.toml, which assigns the owner role.
  *
  * Note: You must also verify the admin email to get config-based admin access
  * (for admin panel). Use verifyAdminEmail() after calling this if needed.
@@ -101,7 +101,7 @@ export async function verifyAdminEmail(page: Page, userId: string): Promise<void
 }
 
 /**
- * Grants an instance permission to a role (admin-only operation).
+ * Grants a permission to a role (admin-only operation).
  * Must be called while logged in as an admin user.
  */
 export async function grantPermission(
@@ -129,7 +129,7 @@ export async function grantPermission(
 }
 
 /**
- * Revokes an instance permission from a role (admin-only operation).
+ * Revokes a permission from a role (admin-only operation).
  * Must be called while logged in as an admin user.
  */
 export async function revokePermission(
@@ -157,7 +157,7 @@ export async function revokePermission(
 }
 
 /**
- * Denies an instance permission on a role (admin-only operation).
+ * Denies a permission on a role (admin-only operation).
  * This adds the permission to the role's permissionDenials list.
  * Must be called while logged in as an admin user.
  */
@@ -228,7 +228,7 @@ function numberToLetters(n: number): string {
 }
 
 /**
- * Creates a custom instance role that denies a permission, then assigns it to a user.
+ * Creates a custom role that denies a permission, then assigns it to a user.
  * Returns the role name so it can be revoked later.
  * Must be called while logged in as an admin user.
  */

--- a/frontend/e2e/pages/SpaceRolesPage.ts
+++ b/frontend/e2e/pages/SpaceRolesPage.ts
@@ -461,40 +461,30 @@ export class SpaceRolesPage {
     // intentionally empty
   }
 
-  // --- Instance Roles ---
+  // --- Permission Matrix column headers (per-role) ---
 
   /**
-   * Get an instance-role row in the unified "Roles applicable in this space"
-   * table by its internal name (e.g. "admin"). Instance and space
-   * roles share one table now, with a Scope pill on each row.
+   * Resolve the matrix column header for a role by its slug (e.g. "admin").
+   * The header text is `@${roleName}` and the `<th>` carries `data-role`.
+   * Per-category duplication means the same role appears in multiple
+   * category panels — take the first match.
    */
-  /**
-   * Resolve the matrix column header for an instance role by its slug
-   * (e.g. "admin"). The header text is `@${roleName}` and the
-   * `<th>` carries `data-role`. Same per-category duplication as
-   * `getRoleRow` — take the first match.
-   */
-  getInstanceRoleRow(name: string): Locator {
+  getRoleColumnHeader(name: string): Locator {
     return this.page.locator(`th[data-role="${name}"]`).first();
   }
 
   /**
-   * Click into the per-space configuration of an instance role. The merged
-   * roles table dispatches between space role and instance-role detail pages
-   * based on the row, so we click the row's Edit button (or the row itself).
+   * Click the matrix column header for a role — the header itself is the
+   * configure affordance, routing to the role's detail page.
    */
-  async clickConfigureInstanceRole(name: string): Promise<void> {
-    // The matrix's column header itself is the configure affordance.
-    // Clicking it routes to the instance role's detail page.
-    await this.getInstanceRoleRow(name).locator('button').click();
+  async clickRoleColumnHeader(name: string): Promise<void> {
+    await this.getRoleColumnHeader(name).locator('button').click();
   }
 
   /**
-   * Navigate to instance role permission editing. The dedicated
-   * /admin/roles/instance/[name] page no longer exists — instance role
-   * permissions are now configured at space scope via the matrix on the
-   * roles list. We navigate there and remember the role so subsequent
-   * permission helpers target the right column.
+   * Navigate to role permission editing — permissions are configured at
+   * space scope via the matrix on the roles list. Records the role so
+   * subsequent permission helpers target the right matrix column.
    */
   async gotoRoleDetail(spaceId: string, roleName: string): Promise<void> {
     this.currentRoleName = roleName;
@@ -503,28 +493,24 @@ export class SpaceRolesPage {
   }
 
   /**
-   * Assert the Instance Roles panel is visible.
+   * Assert the unified roles matrix is visible. The always-present admin
+   * column header is a reliable proof that the matrix rendered.
    */
   async expectRolesPanelVisible(): Promise<void> {
-    // Instance roles now share the unified "Roles applicable in this space"
-    // table; there's no separate panel. Asserting that the always-present
-    // admin row exists is a strict superset of the original check.
-    await expect(this.getInstanceRoleRow('admin')).toBeVisible();
+    await expect(this.getRoleColumnHeader('admin')).toBeVisible();
   }
 
-  /**
-   * Assert an instance role is listed.
-   */
+  /** Assert a role is listed in the matrix. */
   async expectRoleInList(name: string): Promise<void> {
-    await expect(this.getInstanceRoleRow(name)).toBeVisible();
+    await expect(this.getRoleColumnHeader(name)).toBeVisible();
   }
 
   /**
-   * Clicking an instance-role column header at space scope routes to the
-   * instance-scope role detail page (`/admin/roles/[name]`), which carries
-   * "Edit Role" + the role slug as a `<code>` value.
+   * Clicking a role's column header at space scope routes to the role
+   * detail page (`/admin/roles/[name]`), which carries "Edit Role" + the
+   * role slug as a `<code>` value.
    */
-  async expectInstanceRoleDetailPage(roleName: string): Promise<void> {
+  async expectRoleDetailPage(roleName: string): Promise<void> {
     await expect(this.page.getByRole('heading', { name: 'Edit Role' })).toBeVisible();
     await expect(this.page.locator(`code:text-is("${roleName}")`)).toBeVisible();
   }

--- a/frontend/e2e/space-roles.test.ts
+++ b/frontend/e2e/space-roles.test.ts
@@ -526,9 +526,9 @@ test.describe.skip('Space Roles Management', () => {
   });
 });
 
-test.describe.skip('Instance Roles Management', () => {
-  test.describe('Instance Roles List', () => {
-    test('space admin can see instance roles in roles list', async ({ spaceRolesPage }) => {
+test.describe.skip('Roles Management', () => {
+  test.describe('Roles List', () => {
+    test('space admin can see roles in roles list', async ({ spaceRolesPage }) => {
       const { page } = spaceRolesPage;
 
       await createAndLoginTestUser(page);
@@ -536,24 +536,24 @@ test.describe.skip('Instance Roles Management', () => {
 
       await spaceRolesPage.gotoRolesList(space.id);
 
-      // Should see Instance Roles panel
+      // The unified roles matrix should be visible
       await spaceRolesPage.expectRolesPanelVisible();
 
-      // Should see instance-specific roles (not universal roles like everyone)
+      // Should see system roles (not universal roles like `everyone`)
       await spaceRolesPage.expectRoleInList('admin');
     });
 
-    // Removed: "space admin can navigate to instance role detail page".
-    // The matrix gates instance-role column-header clicks on
-    // admin.manage-roles (instance admin), so a non-admin space
-    // admin sees the header as plain text — there's nothing to click. The
+    // Removed: "space admin can navigate to role detail page".
+    // The matrix gates role column-header clicks on
+    // admin.manage-roles, so a non-admin space admin sees the header
+    // as plain text — there's nothing to click. The
     // unit specs cover the onRoleClick wiring; the navigation flow itself
     // is exercised end-to-end by `admin can deny a permission on a role
     // via UI and it persists` in admin.test.ts.
   });
 
-  test.describe('Instance Role Permissions', () => {
-    test('space admin can grant permission to instance role', async ({ spaceRolesPage }) => {
+  test.describe('Role Permissions', () => {
+    test('space admin can grant permission to role', async ({ spaceRolesPage }) => {
       const { page } = spaceRolesPage;
 
       await createAndLoginTestUser(page);
@@ -574,7 +574,7 @@ test.describe.skip('Instance Roles Management', () => {
       await spaceRolesPage.expectPermissionGranted('role.manage');
     });
 
-    test('space admin can deny permission for instance role', async ({ spaceRolesPage }) => {
+    test('space admin can deny permission for role', async ({ spaceRolesPage }) => {
       const { page } = spaceRolesPage;
 
       await createAndLoginTestUser(page);
@@ -592,7 +592,7 @@ test.describe.skip('Instance Roles Management', () => {
       await spaceRolesPage.expectPermissionDenied('room.list');
     });
 
-    test('space admin can clear permission from instance role', async ({ spaceRolesPage }) => {
+    test('space admin can clear permission from role', async ({ spaceRolesPage }) => {
       const { page } = spaceRolesPage;
 
       await createAndLoginTestUser(page);

--- a/frontend/src/routes/chat/[serverId]/server-admin/members/[userId]/+page.svelte
+++ b/frontend/src/routes/chat/[serverId]/server-admin/members/[userId]/+page.svelte
@@ -54,7 +54,6 @@
   let allRoles = $state<Role[]>([]);
   let viewerRoles = $state<string[]>([]);
   let memberSpaceRoles = $state<string[]>([]); // Member's space roles (separate from member object)
-  let memberInstanceRoles = $state<string[]>([]); // Member's instance roles (separate from member object)
   let availablePermissions = $state<string[]>([]);
   let canAssignRoles = $state(false);
   let canManageRoles = $state(false);
@@ -131,7 +130,6 @@
     availablePermissions = resp.data.server.availablePermissions ?? [];
     viewerRoles = resp.data.viewer?.user.roles ?? [];
     memberSpaceRoles = resp.data.server.member?.roles ?? [];
-    memberInstanceRoles = [];
     canAssignRoles = resp.data.server.viewerCanAssignRoles;
     canManageRoles = resp.data.server.viewerCanManageRoles;
     editLogin = resp.data.server.member?.login ?? '';
@@ -261,17 +259,6 @@
     return role?.position ?? Number.MAX_SAFE_INTEGER;
   }
 
-  // Sort instance roles: admin first, then alphabetically
-  function sortInstanceRoles(roles: string[]): string[] {
-    const order: Record<string, number> = { admin: 0 };
-    return [...roles].sort((a, b) => {
-      const posA = order[a] ?? 1;
-      const posB = order[b] ?? 1;
-      if (posA !== posB) return posA - posB;
-      return a.localeCompare(b); // Alphabetical for same position
-    });
-  }
-
   // All roles the member effectively has (explicit + implicit everyone role)
   const effectiveSpaceRoles = $derived(
     memberSpaceRoles.includes('everyone') ? memberSpaceRoles : [...memberSpaceRoles, 'everyone']
@@ -286,9 +273,6 @@
       .filter((r) => r !== 'everyone')
       .sort((a, b) => getRolePosition(a) - getRolePosition(b))
   );
-
-  // Sorted instance roles
-  const sortedInstanceRoles = $derived(sortInstanceRoles(memberInstanceRoles));
 
   async function toggleRole(roleName: string, currentlyHas: boolean) {
     if (!member) return;
@@ -389,20 +373,6 @@
                   <Pill>{getRoleDisplayName(roleName)}</Pill>
                 {/each}
                 <Pill>Member</Pill>
-              </div>
-            </div>
-            <div>
-              <div class="text-sm text-muted">Server Roles</div>
-              <div class="flex flex-wrap gap-1">
-                {#if sortedInstanceRoles.length === 0}
-                  <span class="text-xs text-muted">None</span>
-                {:else}
-                  {#each sortedInstanceRoles as roleName (roleName)}
-                    <Pill>
-                      <span class="capitalize">{roleName}</span>
-                    </Pill>
-                  {/each}
-                {/if}
               </div>
             </div>
             <div>


### PR DESCRIPTION
## Summary

Phase 5 of ADR-027 collapsed RBAC into a single flat tier of server roles, but the frontend still carried the old two-tier shape. This PR drops the `InstanceRole` identifiers from the e2e tests / page object / fixtures, retitles a few `.skip`-ped test describe blocks, and removes a real piece of dead code in the member admin page: a `memberInstanceRoles = []` state that was set empty after every GraphQL load, the `sortInstanceRoles` / `sortedInstanceRoles` helpers that only operated on it, and the "Server Roles" UI section that always rendered "None". Notably, `getInstanceRoleRow` became `getRoleColumnHeader` rather than `getRoleRow` — it resolves a permission-matrix column header, not a list-table row, and a separate `getRoleRow` already exists for the latter. Out of scope: `memberSpaceRoles` and the "Space Roles" UI label (bound to ADR-027 Space → Server consolidation), the `PermissionMatrix.svelte` `@component` scope table (may be inaccurate post-collapse but verifying needs more than a rename), and two intentional "Removed:" historical comments. Net -44 lines.

## Test plan

- [ ] Visually confirm the member admin page (`/chat/[serverId]/server-admin/members/[userId]`) still renders correctly without the removed "Server Roles" section.
- [ ] CI: lint baseline unchanged at 157 locally; 755 frontend unit tests pass; e2e not run locally.