### PR TITLE
refactor: sweep residual 'instance' terminology in Go backend

### DIFF
--- a/cli/cmd/bootstrap_apply.go
+++ b/cli/cmd/bootstrap_apply.go
@@ -15,8 +15,8 @@ import (
 )
 
 // applyBootstrap applies the [bootstrap] section from chatto.toml to the
-// running instance. Idempotent — entries that already exist (matched by login
-// for users, by presence of the primary space record for the instance) are
+// running server. Idempotent — entries that already exist (matched by login
+// for users, by presence of the primary space record for the server) are
 // left alone. Errors on individual entries are logged but don't abort the
 // rest, so the section behaves like "ensure this stuff exists" rather than
 // a transactional batch.
@@ -36,7 +36,7 @@ func applyBootstrap(ctx context.Context, c *core.ChattoCore, cfg config.Bootstra
 		return
 	}
 
-	logger.Info("Applying [bootstrap] section", "users", len(cfg.Users), "instance", hasServer)
+	logger.Info("Applying [bootstrap] section", "users", len(cfg.Users), "server", hasServer)
 
 	ownerID := ""
 	firstUserID := ""
@@ -67,7 +67,7 @@ func applyBootstrap(ctx context.Context, c *core.ChattoCore, cfg config.Bootstra
 	serverCreated := false
 	if hasServer {
 		if ownerID == "" {
-			logger.Error("[bootstrap] instance requires at least one user; skipping instance setup")
+			logger.Error("[bootstrap] instance requires at least one user; skipping server setup")
 		} else {
 			serverCreated = applyBootstrapServer(ctx, logger, c, *cfg.Server, ownerID)
 		}
@@ -81,7 +81,7 @@ func applyBootstrap(ctx context.Context, c *core.ChattoCore, cfg config.Bootstra
 }
 
 // applyBootstrapUser creates the user if missing, sets a verified email if the
-// section has one, and assigns an instance role if specified. Returns the
+// section has one, and assigns an role if specified. Returns the
 // resolved user ID (whether existing or newly created) and whether we created it.
 func applyBootstrapUser(ctx context.Context, logger *log.Logger, c *core.ChattoCore, u config.BootstrapUser) (string, bool) {
 	if u.Login == "" {
@@ -144,11 +144,11 @@ func assignBootstrapRole(ctx context.Context, logger *log.Logger, c *core.Chatto
 	}
 	// SystemActorID bypasses hierarchy checks — bootstrap operates as the system.
 	if err := c.AssignServerRole(ctx, core.SystemActorID, userID, roleName); err != nil {
-		logger.Warn("Failed to assign instance role for [bootstrap] user", "login", login, "role", role, "error", err)
+		logger.Warn("Failed to assign role for [bootstrap] user", "login", login, "role", role, "error", err)
 	}
 }
 
-// applyBootstrapServer seeds the instance's user-visible config (name)
+// applyBootstrapServer seeds the server's user-visible config (name)
 // and ensures the deployment's primary room group exists. The underlying
 // primary-space record is a transitional storage detail (per ADR-027 the
 // data model still routes through a Space until PR(c) collapses the RBAC
@@ -161,8 +161,8 @@ func applyBootstrapServer(ctx context.Context, logger *log.Logger, c *core.Chatt
 		return false
 	}
 
-	// Seed the runtime instance config (idempotent — only writes when the
-	// name field is unset, so an admin-edited instance name isn't clobbered
+	// Seed the runtime server config (idempotent — only writes when the
+	// name field is unset, so an admin-edited server name isn't clobbered
 	// on every dev restart).
 	if cm := c.ConfigManager(); cm != nil {
 		if _, err := cm.UpdateServerConfigFunc(ctx, func(current *configv1.ServerConfig) (*configv1.ServerConfig, error) {
@@ -174,7 +174,7 @@ func applyBootstrapServer(ctx context.Context, logger *log.Logger, c *core.Chatt
 			}
 			return current, nil
 		}); err != nil {
-			logger.Warn("Failed to seed instance config from [bootstrap.instance]", "error", err)
+			logger.Warn("Failed to seed server config from [bootstrap.instance]", "error", err)
 		}
 	}
 
@@ -215,7 +215,7 @@ func applyBootstrapServer(ctx context.Context, logger *log.Logger, c *core.Chatt
 	// behind a `bootstrap` build tag, so production binaries never run this
 	// code and `everyone` does not get room.create on real deployments.
 	if err := c.GrantServerPermission(ctx, core.RoleEveryone, core.PermRoomCreate); err != nil {
-		logger.Warn("Failed to grant room.create to everyone on bootstrap instance", "error", err)
+		logger.Warn("Failed to grant room.create to everyone on bootstrap server", "error", err)
 	}
 	return true
 }

--- a/cli/cmd/bootstrap_test.go
+++ b/cli/cmd/bootstrap_test.go
@@ -94,20 +94,20 @@ func TestApplyBootstrap_CreatesUsersAndServer(t *testing.T) {
 	}
 
 	if isOwner, err := c.IsServerOwner(ctx, alice.Id); err != nil || !isOwner {
-		t.Errorf("expected alice to have instance-owner role (err=%v)", err)
+		t.Errorf("expected alice to have owner role (err=%v)", err)
 	}
 
-	// The instance config should carry the bootstrap name.
+	// The server config should carry the bootstrap name.
 	cm := c.ConfigManager()
 	if cm == nil {
 		t.Fatal("expected ConfigManager to be available")
 	}
 	cfgServer, _, err := cm.GetServerConfig(ctx)
 	if err != nil {
-		t.Fatalf("get instance config: %v", err)
+		t.Fatalf("get server config: %v", err)
 	}
 	if cfgServer == nil || cfgServer.ServerName != "Engineering" {
-		t.Errorf("expected instance name 'Engineering', got %+v", cfgServer)
+		t.Errorf("expected server name 'Engineering', got %+v", cfgServer)
 	}
 
 	rooms, err := c.ListRooms(ctx, "channel")
@@ -169,7 +169,7 @@ func TestApplyBootstrap_EmptySectionIsNoOp(t *testing.T) {
 
 // Bootstrap users are auto-joined to the deployment's primary space so non-owner
 // users (alice/bob in the dev config) actually land on the server rather than
-// existing as orphan members of the instance.
+// existing as orphan members of the server.
 func TestApplyBootstrap_AutoJoinsServer(t *testing.T) {
 	c := setupCore(t)
 	ctx := context.Background()
@@ -211,7 +211,7 @@ func TestApplyBootstrap_AutoJoinsServer(t *testing.T) {
 	}
 }
 
-// When no user is marked as instance-role=owner, the bootstrap falls back to
+// When no user is marked as role=owner, the bootstrap falls back to
 // the first defined user as the underlying primary-space owner.
 func TestApplyBootstrap_DerivesOwnerFromFirstUser(t *testing.T) {
 	c := setupCore(t)

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -66,7 +66,7 @@ func (c *TLSConfig) HTTPPortOrDefault() int {
 type WebserverConfig struct {
 	URL                    string    `toml:"url" env:"CHATTO_WEBSERVER_URL" comment:"Public URL where the webserver is accessible. Used for generating absolute URLs."`
 	Port                   int       `toml:"port" env:"CHATTO_WEBSERVER_PORT" comment:"Port for the webserver to listen on."`
-	AllowedOrigins         []string  `toml:"allowed_origins" env:"CHATTO_WEBSERVER_ALLOWED_ORIGINS" comment:"Additional origins allowed for CORS and WebSocket connections. Defaults to wildcard (*) for multi-instance support. Set explicitly to restrict cross-origin access."`
+	AllowedOrigins         []string  `toml:"allowed_origins" env:"CHATTO_WEBSERVER_ALLOWED_ORIGINS" comment:"Additional origins allowed for CORS and WebSocket connections. Defaults to wildcard (*) for multi-server support. Set explicitly to restrict cross-origin access."`
 	WebSocketCompression   *bool     `toml:"websocket_compression" env:"CHATTO_WEBSERVER_WEBSOCKET_COMPRESSION" comment:"Enable WebSocket compression for GraphQL connections. Reduces bandwidth but uses more CPU. Default: true."`
 	RequestLogging         *bool     `toml:"request_logging" env:"CHATTO_WEBSERVER_REQUEST_LOGGING" comment:"Log HTTP requests. Useful for debugging but can be noisy in production. Default: false."`
 	CookieSigningSecret    string    `toml:"cookie_signing_secret" env:"CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET" comment:"Secret for signing session cookies. NEVER SHARE THIS!\nIf it leaks, change it immediately, but please note that all existing sessions will become invalid."`
@@ -287,7 +287,7 @@ func (c *NATSConfig) ReplicasOrDefault() int {
 	return c.Replicas
 }
 
-// LimitsConfig contains instance-wide resource limits. A value of -1 means unlimited
+// LimitsConfig contains server-wide resource limits. A value of -1 means unlimited
 // (the default when unset); 0 means no creation is allowed; any positive integer caps
 // the count at that value.
 //
@@ -311,7 +311,7 @@ func (c *LimitsConfig) MaxUsersOrDefault() int {
 // OwnersConfig declares the email addresses that confer owner status.
 // A user with a matching verified email is treated as having all instance
 // permissions (owner-level), which includes access to /admin routes. This is
-// the operator-driven mechanism for designating an instance owner — useful
+// the operator-driven mechanism for designating an server owner — useful
 // for both Chatto Cloud (the control plane writes the customer's email here at
 // provision time) and self-hosters (who set their own email here in chatto.toml).
 type OwnersConfig struct {
@@ -416,7 +416,7 @@ func (c *LiveKitConfig) IsConfigured() bool {
 	return c.Enabled && c.URL != "" && c.APIKey != "" && c.APISecret != ""
 }
 
-// BootstrapConfig declares users and the instance config to be auto-applied
+// BootstrapConfig declares users and the server config to be auto-applied
 // on startup, for fast iteration while developing and for E2E test fixtures.
 // ONLY honored by builds compiled with the `bootstrap` build tag — release
 // binaries parse the section but ignore its contents. Plaintext passwords
@@ -439,7 +439,7 @@ type BootstrapUser struct {
 // builds. Per ADR-027 there is no separate "space" concept any more — the
 // instance is the server. The bootstrap creates whatever underlying storage
 // records (notably a primary space) the data layer still needs, but those
-// are internal: operators only configure the instance's name.
+// are internal: operators only configure the server's name.
 type BootstrapServer struct {
 	Name  string   `toml:"name" comment:"Required. The instance's display name."`
 	Rooms []string `toml:"rooms,commented" comment:"Optional. Auto-join rooms created on the instance; defaults to announcements + general."`

--- a/cli/internal/core/attachments.go
+++ b/cli/internal/core/attachments.go
@@ -369,17 +369,17 @@ func (c *ChattoCore) GetTransformedAttachmentURLFromStorage(attachment *corev1.A
 	return c.GetTransformedAttachmentURL(attachment.SpaceId, attachment.Id, width, height, fit)
 }
 
-// GetTransformedServerAssetURL returns the URL for accessing a transformed version of an instance asset.
-// Instance assets include space logos, space banners, and user avatars stored in the instance object store.
+// GetTransformedServerAssetURL returns the URL for accessing a transformed version of an server asset.
+// Server assets include space logos, space banners, and user avatars stored in the server object store.
 // The URL includes HMAC signature to prevent parameter tampering.
-// Format: /assets/instance/{key}/t/{params}.{signature}
+// Format: /assets/server/{key}/t/{params}.{signature}
 // where {params} is base64url-encoded JSON: {"w":width,"h":height,"f":"fit"}
 func (c *ChattoCore) GetTransformedServerAssetURL(key string, width, height int, fit string) string {
-	// Generate signed transform path component using "instance" as the first resource ID
-	signedPath := signedurl.SignedTransformPath(c.config.Assets.SigningSecret, "instance", key, width, height, fit)
+	// Generate signed transform path component using "server" as the first resource ID
+	signedPath := signedurl.SignedTransformPath(c.config.Assets.SigningSecret, "server", key, width, height, fit)
 
 	// Return signed transform URL
-	return c.assetURL(fmt.Sprintf("/assets/instance/%s/t/%s", key, signedPath))
+	return c.assetURL(fmt.Sprintf("/assets/server/%s/t/%s", key, signedPath))
 }
 
 // ============================================================================

--- a/cli/internal/core/attachments_test.go
+++ b/cli/internal/core/attachments_test.go
@@ -429,7 +429,7 @@ func TestChattoCore_AssetBaseURL(t *testing.T) {
 
 		url := core.GetTransformedServerAssetURL("avatar-key", 100, 100, "cover")
 
-		if !bytes.HasPrefix([]byte(url), []byte("https://chat.example.com/assets/instance/")) {
+		if !bytes.HasPrefix([]byte(url), []byte("https://chat.example.com/assets/server/")) {
 			t.Errorf("Expected absolute URL with base, got '%s'", url)
 		}
 	})

--- a/cli/internal/core/can_test.go
+++ b/cli/internal/core/can_test.go
@@ -9,7 +9,7 @@ import (
 // ============================================================================
 
 // TestServerCanHelpers verifies that the semantic Can* helper functions
-// for instance-level permissions correctly wrap HasPermission.
+// for server-level permissions correctly wrap HasPermission.
 func TestServerCanHelpers(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
@@ -207,7 +207,7 @@ func TestCanDeleteUser(t *testing.T) {
 	})
 }
 
-// TestPermissionsWithCustomRoles tests that custom instance roles
+// TestPermissionsWithCustomRoles tests that custom roles
 // with specific permissions work correctly with the Can* helpers.
 func TestPermissionsWithCustomRoles(t *testing.T) {
 	core, _ := setupTestCore(t)

--- a/cli/internal/core/config_manager.go
+++ b/cli/internal/core/config_manager.go
@@ -36,7 +36,7 @@ const (
 // Instance Config
 // =============================================================================
 
-// GetServerConfig retrieves the instance configuration from KV.
+// GetServerConfig retrieves the server configuration from KV.
 // Returns (config, isConfigured, error) where isConfigured indicates if KV value exists.
 func (cm *ConfigManager) GetServerConfig(ctx context.Context) (*configv1.ServerConfig, bool, error) {
 	entry, err := cm.kv.Get(ctx, configKeyInstance)
@@ -44,28 +44,28 @@ func (cm *ConfigManager) GetServerConfig(ctx context.Context) (*configv1.ServerC
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return nil, false, nil
 		}
-		return nil, false, fmt.Errorf("failed to get instance config: %w", err)
+		return nil, false, fmt.Errorf("failed to get server config: %w", err)
 	}
 
 	cfg := &configv1.ServerConfig{}
 	if err := proto.Unmarshal(entry.Value(), cfg); err != nil {
-		return nil, false, fmt.Errorf("failed to unmarshal instance config: %w", err)
+		return nil, false, fmt.Errorf("failed to unmarshal server config: %w", err)
 	}
 
 	return cfg, true, nil
 }
 
-// SetServerConfig stores the instance configuration in KV.
+// SetServerConfig stores the server configuration in KV.
 // Deprecated: Use UpdateServerConfigFunc for concurrent-safe updates.
 func (cm *ConfigManager) SetServerConfig(ctx context.Context, cfg *configv1.ServerConfig) error {
 	data, err := proto.Marshal(cfg)
 	if err != nil {
-		return fmt.Errorf("failed to marshal instance config: %w", err)
+		return fmt.Errorf("failed to marshal server config: %w", err)
 	}
 
 	_, err = cm.kv.Put(ctx, configKeyInstance, data)
 	if err != nil {
-		return fmt.Errorf("failed to store instance config: %w", err)
+		return fmt.Errorf("failed to store server config: %w", err)
 	}
 
 	return nil
@@ -74,7 +74,7 @@ func (cm *ConfigManager) SetServerConfig(ctx context.Context, cfg *configv1.Serv
 // maxConfigRetries is the maximum number of retry attempts for OCC conflicts.
 const maxConfigRetries = 5
 
-// UpdateServerConfigFunc atomically updates the instance config using optimistic concurrency control.
+// UpdateServerConfigFunc atomically updates the server config using optimistic concurrency control.
 // The updateFn receives the current config (or nil if not configured) and should return the updated config.
 // If another concurrent update occurs, this will retry up to maxConfigRetries times.
 // Returns the final config after successful update.
@@ -88,7 +88,7 @@ func (cm *ConfigManager) UpdateServerConfigFunc(ctx context.Context, updateFn fu
 
 		if err != nil {
 			if !errors.Is(err, jetstream.ErrKeyNotFound) {
-				return nil, fmt.Errorf("failed to get instance config: %w", err)
+				return nil, fmt.Errorf("failed to get server config: %w", err)
 			}
 			// Key doesn't exist - will use Create
 			currentCfg = nil
@@ -97,7 +97,7 @@ func (cm *ConfigManager) UpdateServerConfigFunc(ctx context.Context, updateFn fu
 			// Key exists - unmarshal and get revision
 			currentCfg = &configv1.ServerConfig{}
 			if err := proto.Unmarshal(entry.Value(), currentCfg); err != nil {
-				return nil, fmt.Errorf("failed to unmarshal instance config: %w", err)
+				return nil, fmt.Errorf("failed to unmarshal server config: %w", err)
 			}
 			revision = entry.Revision()
 		}
@@ -111,7 +111,7 @@ func (cm *ConfigManager) UpdateServerConfigFunc(ctx context.Context, updateFn fu
 		// Marshal the updated config
 		data, err := proto.Marshal(updatedCfg)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal instance config: %w", err)
+			return nil, fmt.Errorf("failed to marshal server config: %w", err)
 		}
 
 		// Attempt atomic update
@@ -136,22 +136,22 @@ func (cm *ConfigManager) UpdateServerConfigFunc(ctx context.Context, updateFn fu
 		}
 
 		// Other error - fail immediately
-		return nil, fmt.Errorf("failed to store instance config: %w", err)
+		return nil, fmt.Errorf("failed to store server config: %w", err)
 	}
 
 	return nil, ErrConfigConflict
 }
 
-// ResetServerConfig removes the instance configuration from KV.
+// ResetServerConfig removes the server configuration from KV.
 func (cm *ConfigManager) ResetServerConfig(ctx context.Context) error {
 	err := cm.kv.Delete(ctx, configKeyInstance)
 	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
-		return fmt.Errorf("failed to reset instance config: %w", err)
+		return fmt.Errorf("failed to reset server config: %w", err)
 	}
 	return nil
 }
 
-// GetEffectiveWelcomeMessage returns the welcome message from instance config.
+// GetEffectiveWelcomeMessage returns the welcome message from server config.
 // Returns empty string if not configured.
 func (cm *ConfigManager) GetEffectiveWelcomeMessage(ctx context.Context) (string, error) {
 	cfg, _, err := cm.GetServerConfig(ctx)
@@ -164,7 +164,7 @@ func (cm *ConfigManager) GetEffectiveWelcomeMessage(ctx context.Context) (string
 	return "", nil
 }
 
-// GetEffectiveServerName returns the instance name from config.
+// GetEffectiveServerName returns the server name from config.
 // Returns "Chatto" as default if not configured.
 func (cm *ConfigManager) GetEffectiveServerName(ctx context.Context) (string, error) {
 	cfg, _, err := cm.GetServerConfig(ctx)
@@ -212,7 +212,7 @@ func (cm *ConfigManager) GetEffectiveDescription(ctx context.Context) (string, e
 // Blocked Usernames
 // =============================================================================
 
-// DefaultBlockedUsernames is the default list of blocked usernames for new instances.
+// DefaultBlockedUsernames is the default list of blocked usernames for new servers.
 const DefaultBlockedUsernames = "root\nadmin\nsuperuser\nop\noperator\nsupport"
 
 // GetEffectiveBlockedUsernames returns the blocked usernames string from config.

--- a/cli/internal/core/config_manager_test.go
+++ b/cli/internal/core/config_manager_test.go
@@ -23,10 +23,10 @@ func TestConfigManager_GetServerConfig(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if isConfigured {
-			t.Error("expected isConfigured to be false for fresh instance")
+			t.Error("expected isConfigured to be false for fresh server")
 		}
 		if cfg != nil {
-			t.Error("expected nil config for fresh instance")
+			t.Error("expected nil config for fresh server")
 		}
 	})
 
@@ -50,7 +50,7 @@ func TestConfigManager_GetServerConfig(t *testing.T) {
 			t.Error("expected isConfigured to be true")
 		}
 		if cfg.ServerName != "Test Instance" {
-			t.Errorf("expected instance name 'Test Instance', got '%s'", cfg.ServerName)
+			t.Errorf("expected server name 'Test Instance', got '%s'", cfg.ServerName)
 		}
 		if cfg.WelcomeMessage != "Welcome!" {
 			t.Errorf("expected welcome message 'Welcome!', got '%s'", cfg.WelcomeMessage)
@@ -71,7 +71,7 @@ func TestConfigManager_UpdateServerConfigFunc(t *testing.T) {
 
 		cfg, err := core.configManager.UpdateServerConfigFunc(ctx, func(current *configv1.ServerConfig) (*configv1.ServerConfig, error) {
 			if current != nil {
-				t.Error("expected nil current config for fresh instance")
+				t.Error("expected nil current config for fresh server")
 			}
 			return &configv1.ServerConfig{
 				ServerName: "Created via UpdateFunc",
@@ -82,7 +82,7 @@ func TestConfigManager_UpdateServerConfigFunc(t *testing.T) {
 			t.Fatalf("failed to update config: %v", err)
 		}
 		if cfg.ServerName != "Created via UpdateFunc" {
-			t.Errorf("expected instance name 'Created via UpdateFunc', got '%s'", cfg.ServerName)
+			t.Errorf("expected server name 'Created via UpdateFunc', got '%s'", cfg.ServerName)
 		}
 	})
 
@@ -98,7 +98,7 @@ func TestConfigManager_UpdateServerConfigFunc(t *testing.T) {
 				t.Error("expected non-nil current config")
 			}
 			if current.ServerName != "Original Name" {
-				t.Errorf("expected current instance name 'Original Name', got '%s'", current.ServerName)
+				t.Errorf("expected current server name 'Original Name', got '%s'", current.ServerName)
 			}
 			current.ServerName = "Updated Name"
 			return current, nil
@@ -108,7 +108,7 @@ func TestConfigManager_UpdateServerConfigFunc(t *testing.T) {
 			t.Fatalf("failed to update config: %v", err)
 		}
 		if cfg.ServerName != "Updated Name" {
-			t.Errorf("expected instance name 'Updated Name', got '%s'", cfg.ServerName)
+			t.Errorf("expected server name 'Updated Name', got '%s'", cfg.ServerName)
 		}
 		// Verify MOTD was preserved
 		if cfg.Motd != "Original MOTD" {
@@ -208,12 +208,12 @@ func TestConfigManager_ResetServerConfig(t *testing.T) {
 		}
 	})
 
-	t.Run("no error when resetting unconfigured instance", func(t *testing.T) {
+	t.Run("no error when resetting unconfigured server", func(t *testing.T) {
 		// Reset twice - should not error
 		core.configManager.ResetServerConfig(ctx)
 		err := core.configManager.ResetServerConfig(ctx)
 		if err != nil {
-			t.Errorf("reset should not error for unconfigured instance: %v", err)
+			t.Errorf("reset should not error for unconfigured server: %v", err)
 		}
 	})
 }
@@ -279,7 +279,7 @@ func TestConfigManager_GetEffectiveServerName(t *testing.T) {
 		}
 	})
 
-	t.Run("returns configured instance name", func(t *testing.T) {
+	t.Run("returns configured server name", func(t *testing.T) {
 		core.configManager.SetServerConfig(ctx, &configv1.ServerConfig{
 			ServerName: "My Custom Instance",
 		})

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -103,7 +103,7 @@ func (c *ChattoCore) ConfigManager() *ConfigManager {
 }
 
 // PermResolver returns the hierarchical permission resolver for permission checks.
-// This implements the instance < space < room specificity model.
+// This implements the server < space < room specificity model.
 func (c *ChattoCore) PermResolver() *PermissionResolver {
 	return c.permissionResolver
 }
@@ -174,13 +174,13 @@ func (c *ChattoCore) S3Client() *S3Client {
 	return c.s3Client
 }
 
-// ServerAssetInfo contains metadata about an instance asset.
+// ServerAssetInfo contains metadata about a server asset.
 type ServerAssetInfo struct {
 	Size        int64
 	ContentType string
 }
 
-// GetServerAssetFromAnyBackend retrieves an instance asset by probing both NATS and S3 backends.
+// GetServerAssetFromAnyBackend retrieves a server asset by probing both NATS and S3 backends.
 // It tries NATS first (for backwards compatibility with existing assets), then S3.
 // Returns a reader for the asset content and metadata.
 // The caller is responsible for closing the reader if it implements io.Closer.
@@ -215,7 +215,7 @@ func (c *ChattoCore) GetServerAssetFromAnyBackend(ctx context.Context, assetID s
 	return nil, nil, err
 }
 
-// CleanupAsset deletes an asset from the instance object store.
+// CleanupAsset deletes an asset from the server object store.
 // Used to clean up orphaned assets when subsequent operations fail.
 func (c *ChattoCore) CleanupAsset(ctx context.Context, asset *corev1.Asset) {
 	if asset == nil {
@@ -239,7 +239,7 @@ func (c *ChattoCore) CleanupAsset(ctx context.Context, asset *corev1.Asset) {
 	}
 }
 
-// deleteAsset deletes an instance asset from its storage backend (NATS or S3).
+// deleteAsset deletes a server asset from its storage backend (NATS or S3).
 // This is a helper for cleaning up old assets when they are replaced.
 // For S3, the assetID stored in S3Asset.Key is used to construct the full S3 path.
 // The assetType and ownerID are used for logging only.
@@ -366,9 +366,9 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	assetsConfig := core.AssetsConfig()
 	core.linkPreviewFetcher = linkpreview.NewFetcher(storage.serverStore, &assetsConfig, NewAssetID)
 
-	// Initialize instance-level RBAC (roles and permissions)
+	// Initialize server-level RBAC (roles and permissions)
 	if err := core.initServerRBAC(ctx); err != nil {
-		return nil, fmt.Errorf("failed to initialize instance RBAC: %w", err)
+		return nil, fmt.Errorf("failed to initialize server RBAC: %w", err)
 	}
 
 	// Seed the default room group and ensure every existing channel room
@@ -427,7 +427,7 @@ type storage struct {
 
 // newStorage initializes all JetStream KV buckets and streams.
 func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConfig) (*storage, error) {
-	// Initialize INSTANCE KV bucket for all instance-level data
+	// Initialize INSTANCE KV bucket for all server-level data
 	// Uses subject-based keys: user.{userId}, space.{spaceId}, space_membership.{spaceId}.{userId}, etc.
 	serverKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
 		Bucket:      "INSTANCE",
@@ -444,7 +444,7 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		return nil, fmt.Errorf("failed to create INSTANCE KV bucket: %w", err)
 	}
 
-	// Initialize instance object store
+	// Initialize server object store
 	serverStore, err := js.CreateOrUpdateObjectStore(ctx, jetstream.ObjectStoreConfig{
 		Bucket:      "INSTANCE_ASSETS",
 		Description: "Instance-level assets (user avatars, space icons, etc.)",
@@ -456,7 +456,7 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		return nil, fmt.Errorf("failed to create INSTANCE object store: %w", err)
 	}
 
-	// Initialize instance-level presence KV bucket (memory-based with TTL)
+	// Initialize server-level presence KV bucket (memory-based with TTL)
 	presenceKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
 		Bucket:         "USER_PRESENCE",
 		Description:    "Instance-level user presence status",
@@ -1268,8 +1268,8 @@ func (c *ChattoCore) filterLiveEvent(ctx context.Context, userID string, canDM b
 		}
 
 		// Skip own typing events — the sender doesn't need to see them.
-		// Critical for multi-instance clients where the frontend's
-		// currentUserId may differ from the remote instance user ID.
+		// Critical for multi-server clients where the frontend's
+		// currentUserId may differ from the remote server user ID.
 		if event.GetUserTyping() != nil && event.ActorId == userID {
 			return nil, false
 		}
@@ -1328,8 +1328,8 @@ func (c *ChattoCore) isAuthorizedForLiveEvent(_ context.Context, userID, subject
 	}
 }
 
-// PublishServerConfigUpdated publishes an instance config update event.
-// This notifies all connected clients that the instance configuration has changed.
+// PublishServerConfigUpdated publishes an server config update event.
+// This notifies all connected clients that the server configuration has changed.
 func (c *ChattoCore) PublishServerConfigUpdated(ctx context.Context, actorID string, serverName, motd, welcomeMessage, blockedUsernames string) error {
 	event := newEvent(actorID, &corev1.Event{
 		Event: &corev1.Event_ConfigUpdated{

--- a/cli/internal/core/core_test.go
+++ b/cli/internal/core/core_test.go
@@ -173,7 +173,7 @@ func TestChattoCore_FullWorkflow(t *testing.T) {
 // ============================================================================
 
 // TestChattoCore_isAuthorizedForLiveEvent verifies the authorization logic
-// for instance-level events based on subject patterns.
+// for server-level events based on subject patterns.
 func TestChattoCore_isAuthorizedForLiveEvent(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
@@ -346,7 +346,7 @@ func TestNewSpaceEvent_PopulatesCreatedAt(t *testing.T) {
 }
 
 // TestStreamMyEvents_ClosesOnSessionTerminated verifies that
-// the instance event stream closes after receiving a SessionTerminatedEvent,
+// the server event stream closes after receiving a SessionTerminatedEvent,
 // and that the event is delivered to the channel before it closes.
 func TestStreamMyEvents_ClosesOnSessionTerminated(t *testing.T) {
 	core, _ := setupTestCore(t)
@@ -354,7 +354,7 @@ func TestStreamMyEvents_ClosesOnSessionTerminated(t *testing.T) {
 
 	user, _ := core.CreateUser(ctx, "system", "sessionterm1", "Session Term User", "")
 
-	// Start streaming instance events
+	// Start streaming server events
 	subCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -407,8 +407,8 @@ func TestStreamMyEvents_ClosesOnSessionTerminated(t *testing.T) {
 
 // TestStreamMyEvents_FiltersOwnTypingEvents verifies that typing indicator
 // events are NOT delivered back to the user who published them. This is critical
-// for multi-instance clients where the frontend's currentUserId may differ from
-// the remote instance user ID, making client-side filtering unreliable.
+// for multi-server clients where the frontend's currentUserId may differ from
+// the remote server user ID, making client-side filtering unreliable.
 func TestStreamMyEvents_FiltersOwnTypingEvents(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)

--- a/cli/internal/core/linkpreview/fetcher.go
+++ b/cli/internal/core/linkpreview/fetcher.go
@@ -174,7 +174,7 @@ func truncate(s string, maxLen int) string {
 	return s[:maxLen] + "..."
 }
 
-// downloadAndStoreImage downloads an image and stores it as an instance asset.
+// downloadAndStoreImage downloads an image and stores it as an server asset.
 func (f *Fetcher) downloadAndStoreImage(ctx context.Context, imageURL string) (string, error) {
 	// Create request with context
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil)

--- a/cli/internal/core/permission_explainer_test.go
+++ b/cli/internal/core/permission_explainer_test.go
@@ -19,8 +19,8 @@ func TestPermissionExplainer_AgreesWithHas(t *testing.T) {
 
 	// Three subjects with distinct role configurations:
 	//   regular: just everyone
-	//   adminUser: instance admin role
-	//   denyUser: custom instance role denying space.list
+	//   adminUser: admin role
+	//   denyUser: custom role denying space.list
 	regular, _ := core.CreateUser(ctx, SystemActorID, "regular", "Regular", "password123")
 	adminUser, _ := core.CreateUser(ctx, SystemActorID, "adminuser", "Admin User", "password123")
 	if err := core.AssignServerRole(ctx, SystemActorID, adminUser.Id, RoleAdmin); err != nil {

--- a/cli/internal/core/permission_ops.go
+++ b/cli/internal/core/permission_ops.go
@@ -57,7 +57,7 @@ func (c *ChattoCore) GrantServerPermission(ctx context.Context, roleName string,
 	denyKey := rbac.DenyKey(roleName, parts.Verb, parts.ObjectType, rbac.ObjectIdAny)
 	_ = kv.Delete(ctx, denyKey) // Ignore not found error
 
-	c.logger.Debug("Granted unified instance role permission", "role", roleName, "permission", perm)
+	c.logger.Debug("Granted unified role permission", "role", roleName, "permission", perm)
 	return nil
 }
 
@@ -85,7 +85,7 @@ func (c *ChattoCore) DenyServerPermission(ctx context.Context, roleName string, 
 	grantKey := rbac.AllowKey(roleName, parts.Verb, parts.ObjectType, rbac.ObjectIdAny)
 	_ = kv.Delete(ctx, grantKey) // Ignore not found error
 
-	c.logger.Debug("Denied unified instance role permission", "role", roleName, "permission", perm)
+	c.logger.Debug("Denied unified role permission", "role", roleName, "permission", perm)
 	return nil
 }
 
@@ -108,7 +108,7 @@ func (c *ChattoCore) ClearServerPermissionState(ctx context.Context, roleName st
 		return fmt.Errorf("failed to clear denial: %w", err)
 	}
 
-	c.logger.Debug("Cleared unified instance role permission", "role", roleName, "permission", perm)
+	c.logger.Debug("Cleared unified role permission", "role", roleName, "permission", perm)
 	return nil
 }
 

--- a/cli/internal/core/permission_ops_test.go
+++ b/cli/internal/core/permission_ops_test.go
@@ -196,11 +196,11 @@ func TestGrantSpaceRolePermission(t *testing.T) {
 		}
 	})
 
-	t.Run("works for instance role override at space level", func(t *testing.T) {
+	t.Run("works for role override at space level", func(t *testing.T) {
 		// Instance role override at space level
 		err := core.GrantServerPermission(ctx, RoleModerator, PermRoomJoin)
 		if err != nil {
-			t.Fatalf("GrantSpaceRolePermission() for instance role error = %v", err)
+			t.Fatalf("GrantSpaceRolePermission() for role error = %v", err)
 		}
 	})
 
@@ -420,7 +420,7 @@ func TestInitServerDefaults(t *testing.T) {
 
 	// InitServerDefaults is called during setupTestCore, so we can verify its effects
 
-	t.Run("admin has every instance permission", func(t *testing.T) {
+	t.Run("admin has every server permission", func(t *testing.T) {
 		// Admin gets every server-scope permission enumerated. The
 		// distinction from owner is rank, not capabilities — admins
 		// cannot manage owners (rank check) and cannot revoke their own
@@ -466,7 +466,7 @@ func TestInitDefaultPermissions(t *testing.T) {
 
 	// InitDefaultPermissions is called at boot, so we can verify its effects here.
 
-	t.Run("owner has every instance permission enumerated", func(t *testing.T) {
+	t.Run("owner has every server permission enumerated", func(t *testing.T) {
 		// Owner gets the full server-scope permission set explicitly —
 		// the same set as admin. No "bypass" super-permission exists.
 		// Operator-configured denies apply uniformly, including to owners,

--- a/cli/internal/core/permission_resolver.go
+++ b/cli/internal/core/permission_resolver.go
@@ -562,11 +562,11 @@ func (r *PermissionResolver) keyExists(ctx context.Context, kv jetstream.KeyValu
 	return false, fmt.Errorf("failed to check key %s: %w", key, err)
 }
 
-// getUserServerRoles returns the user's instance roles (including implicit ones).
+// getUserServerRoles returns the user's roles (including implicit ones).
 func (r *PermissionResolver) getUserServerRoles(ctx context.Context, userID string) ([]string, error) {
 	roles, err := r.core.GetUserRoles(ctx, userID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get user instance roles: %w", err)
+		return nil, fmt.Errorf("failed to get user roles: %w", err)
 	}
 
 	// Always include "everyone" for authenticated users

--- a/cli/internal/core/permission_resolver_test.go
+++ b/cli/internal/core/permission_resolver_test.go
@@ -340,7 +340,7 @@ func TestPermissionResolver_HasSpacePermission_ServerRoleOverride(t *testing.T) 
 	// Create user and space
 	user, _ := core.CreateUser(ctx, "system", "testuser", "Test User", "password123")
 
-	t.Run("space can override instance role permissions", func(t *testing.T) {
+	t.Run("space can override role permissions", func(t *testing.T) {
 		// Grant permission to instance-everyone at space level (override)
 		err := core.GrantServerPermission(ctx, RoleEveryone, PermRoomManage)
 		if err != nil {
@@ -353,7 +353,7 @@ func TestPermissionResolver_HasSpacePermission_ServerRoleOverride(t *testing.T) 
 			t.Fatalf("HasSpacePermission() error = %v", err)
 		}
 		if !has {
-			t.Error("Expected space-level override for instance role to work")
+			t.Error("Expected space-level override for role to work")
 		}
 	})
 }
@@ -704,7 +704,7 @@ func TestPermissionResolver_HasRoomPermission_ServerRoleRoomDenial(t *testing.T)
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if has {
-		t.Error("Expected instance role room denial to block permission")
+		t.Error("Expected role room denial to block permission")
 	}
 }
 
@@ -727,7 +727,7 @@ func TestPermissionResolver_HasRoomPermission_ServerRoleRoomGrant(t *testing.T) 
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !has {
-		t.Error("Expected instance role room grant to give permission")
+		t.Error("Expected role room grant to give permission")
 	}
 }
 
@@ -1117,7 +1117,7 @@ func TestPermissionResolver_ServerAuthority(t *testing.T) {
 		// Grant at instance level for instance-everyone
 		err := core.GrantServerPermission(ctx, RoleEveryone, PermDMWrite)
 		if err != nil {
-			t.Fatalf("Failed to grant instance permission: %v", err)
+			t.Fatalf("Failed to grant server permission: %v", err)
 		}
 
 		// Instance grant should apply (no space-level decision)

--- a/cli/internal/core/rbac.go
+++ b/cli/internal/core/rbac.go
@@ -150,7 +150,7 @@ func (c *ChattoCore) CreateDefaultRoles(ctx context.Context) error {
 // Permission Checking
 // ============================================================================
 
-// HasServerPermission checks if a user has a specific instance permission.
+// HasServerPermission checks if a user has a specific server permission.
 // This delegates to the unified PermissionResolver which implements hierarchical resolution.
 //
 // Note: Config-based admin check (owners.emails) should be done separately
@@ -159,13 +159,13 @@ func (c *ChattoCore) HasServerPermission(ctx context.Context, userID string, per
 	return c.permissionResolver.HasServerPermission(ctx, userID, perm)
 }
 
-// IsServerAdmin checks if a user has the instance admin role via RBAC.
+// IsServerAdmin checks if a user has the admin role via RBAC.
 // Does NOT check config fallback (owners.emails) - caller should check that separately.
 func (c *ChattoCore) IsServerAdmin(ctx context.Context, userID string) (bool, error) {
 	return c.storage.serverRBACEngine.HasRole(ctx, userID, RoleAdmin)
 }
 
-// IsServerOwner checks if a user has the instance owner role via RBAC.
+// IsServerOwner checks if a user has the owner role via RBAC.
 func (c *ChattoCore) IsServerOwner(ctx context.Context, userID string) (bool, error) {
 	return c.storage.serverRBACEngine.HasRole(ctx, userID, RoleOwner)
 }
@@ -237,7 +237,7 @@ func (c *ChattoCore) AssignOwnerRole(ctx context.Context, userID string) error {
 	if err := c.storage.serverRBACEngine.AssignRole(ctx, userID, RoleOwner); err != nil {
 		return fmt.Errorf("failed to assign owner role: %w", err)
 	}
-	c.logger.Info("Assigned instance owner role", "user_id", userID)
+	c.logger.Info("Assigned owner role", "user_id", userID)
 	return nil
 }
 
@@ -246,7 +246,7 @@ func (c *ChattoCore) AssignAdminRole(ctx context.Context, userID string) error {
 	if err := c.storage.serverRBACEngine.AssignRole(ctx, userID, RoleAdmin); err != nil {
 		return fmt.Errorf("failed to assign admin role: %w", err)
 	}
-	c.logger.Info("Assigned instance admin role", "user_id", userID)
+	c.logger.Info("Assigned admin role", "user_id", userID)
 	return nil
 }
 
@@ -255,7 +255,7 @@ func (c *ChattoCore) RevokeAdminRole(ctx context.Context, userID string) error {
 	if err := c.storage.serverRBACEngine.RevokeRole(ctx, userID, RoleAdmin); err != nil {
 		return fmt.Errorf("failed to revoke admin role: %w", err)
 	}
-	c.logger.Info("Revoked instance admin role", "user_id", userID)
+	c.logger.Info("Revoked admin role", "user_id", userID)
 	return nil
 }
 
@@ -265,7 +265,7 @@ func (c *ChattoCore) ListAdmins(ctx context.Context) ([]string, error) {
 	return c.storage.serverRBACEngine.GetRoleUsers(ctx, RoleAdmin)
 }
 
-// AssignServerRole assigns any instance role to a user.
+// AssignServerRole assigns any role to a user.
 // The role must exist (system or custom). The everyone role cannot be assigned (it's implicit).
 // Pass SystemActorID as actorID to bypass hierarchy checks (for internal/bootstrap use).
 //
@@ -319,11 +319,11 @@ func (c *ChattoCore) AssignServerRole(ctx context.Context, actorID, userID, role
 		return err
 	}
 
-	c.logger.Info("Assigned instance role", "role", roleName, "user_id", userID, "actor_id", actorID)
+	c.logger.Info("Assigned role", "role", roleName, "user_id", userID, "actor_id", actorID)
 	return nil
 }
 
-// RevokeServerRole removes an instance role from a user.
+// RevokeServerRole removes an role from a user.
 // The role must exist (system or custom). The everyone role cannot be revoked (it's implicit).
 // Pass SystemActorID as actorID to bypass hierarchy and self-demote checks (for internal/bootstrap use).
 //
@@ -380,7 +380,7 @@ func (c *ChattoCore) RevokeServerRole(ctx context.Context, actorID, userID, role
 		return err
 	}
 
-	c.logger.Info("Revoked instance role", "role", roleName, "user_id", userID, "actor_id", actorID)
+	c.logger.Info("Revoked role", "role", roleName, "user_id", userID, "actor_id", actorID)
 	return nil
 }
 
@@ -436,11 +436,11 @@ func (c *ChattoCore) RevokeServerPermission(ctx context.Context, roleName string
 	if err := c.storage.serverRBACEngine.RevokeRolePermission(ctx, roleName, parts.Verb, parts.ObjectType, rbac.ObjectIdAny); err != nil {
 		return err
 	}
-	c.logger.Info("Revoked instance permission", "role", roleName, "permission", perm)
+	c.logger.Info("Revoked server permission", "role", roleName, "permission", perm)
 	return nil
 }
 
-// GetServerRolePermissions returns all permissions granted to an instance role.
+// GetServerRolePermissions returns all permissions granted to an role.
 // Note: Admin roles are NOT special-cased - permissions are explicitly stored in KV.
 func (c *ChattoCore) GetServerRolePermissions(ctx context.Context, roleName string) ([]Permission, error) {
 	perms, err := c.storage.serverRBACEngine.GetRolePermissions(ctx, roleName)
@@ -458,7 +458,7 @@ func (c *ChattoCore) GetServerRolePermissions(ctx context.Context, roleName stri
 	return result, nil
 }
 
-// GetServerRolePermissionDenials returns all permissions denied by an instance role.
+// GetServerRolePermissionDenials returns all permissions denied by an role.
 // Note: Admin roles are NOT special-cased - they can have denials like any other role.
 func (c *ChattoCore) GetServerRolePermissionDenials(ctx context.Context, roleName string) ([]Permission, error) {
 	perms, err := c.storage.serverRBACEngine.GetRolePermissionDenials(ctx, roleName)
@@ -476,7 +476,7 @@ func (c *ChattoCore) GetServerRolePermissionDenials(ctx context.Context, roleNam
 	return result, nil
 }
 
-// AllServerPermissions returns all defined instance permissions.
+// AllServerPermissions returns all defined server permissions.
 // Exposed as a method for consistency with other core APIs.
 func (c *ChattoCore) AllServerPermissions() []Permission {
 	perms := PermissionsForScope(ScopeServer)
@@ -487,7 +487,7 @@ func (c *ChattoCore) AllServerPermissions() []Permission {
 	return result
 }
 
-// GetUserServerPermissions returns all instance permissions the user has,
+// GetUserServerPermissions returns all server permissions the user has,
 // using the unified resolver.
 func (c *ChattoCore) GetUserServerPermissions(ctx context.Context, userID string) ([]Permission, error) {
 	var result []Permission
@@ -507,7 +507,7 @@ func (c *ChattoCore) GetUserServerPermissions(ctx context.Context, userID string
 // Server-tier Role CRUD
 // ============================================================================
 
-// ListServerRoles returns all instance roles with their permissions.
+// ListServerRoles returns all roles with their permissions.
 // Note: Admin roles are NOT special-cased - permissions are read from KV like any other role.
 func (c *ChattoCore) ListServerRoles(ctx context.Context) ([]RoleWithPermissions, error) {
 	roles, err := c.storage.serverRBACEngine.ListRoles(ctx)
@@ -557,7 +557,7 @@ func (c *ChattoCore) CreateServerRole(ctx context.Context, name, displayName, de
 		return nil, err
 	}
 
-	c.logger.Info("Created instance role", "name", name, "display_name", displayName, "position", role.Position)
+	c.logger.Info("Created role", "name", name, "display_name", displayName, "position", role.Position)
 
 	return &RoleWithPermissions{
 		Name:              role.Name,
@@ -581,7 +581,7 @@ func (c *ChattoCore) UpdateServerRole(ctx context.Context, name, displayName, de
 		return nil, err
 	}
 
-	c.logger.Info("Updated instance role", "name", name, "display_name", displayName)
+	c.logger.Info("Updated role", "name", name, "display_name", displayName)
 
 	perms, _ := c.GetServerRolePermissions(ctx, name)
 	denials, _ := c.GetServerRolePermissionDenials(ctx, name)
@@ -596,7 +596,7 @@ func (c *ChattoCore) UpdateServerRole(ctx context.Context, name, displayName, de
 	}, nil
 }
 
-// GetServerRole returns a single instance role by name.
+// GetServerRole returns a single role by name.
 // Note: Admin roles are NOT special-cased - permissions are read from KV like any other role.
 func (c *ChattoCore) GetServerRole(ctx context.Context, name string) (*RoleWithPermissions, error) {
 	role, err := c.storage.serverRBACEngine.GetRole(ctx, name)
@@ -639,11 +639,11 @@ func (c *ChattoCore) DeleteServerRole(ctx context.Context, name string) error {
 		return err
 	}
 
-	c.logger.Info("Deleted instance role", "role", name)
+	c.logger.Info("Deleted role", "role", name)
 	return nil
 }
 
-// ReorderServerRoles reorders custom instance roles.
+// ReorderServerRoles reorders custom roles.
 // System roles (owner, admin, moderator, everyone) maintain fixed positions and should not be included.
 // Positions are assigned based on array index (first role = position 3, second = 4, etc).
 // Note: Position 0 = owner, 1 = admin, 2 = moderator, position MAX = everyone.
@@ -676,7 +676,7 @@ func (c *ChattoCore) ReorderServerRoles(ctx context.Context, roleNames []string)
 		})
 	}
 
-	c.logger.Info("Reordered instance roles", "order", roleNames)
+	c.logger.Info("Reordered roles", "order", roleNames)
 	return result, nil
 }
 

--- a/cli/internal/core/rbac/doc.go
+++ b/cli/internal/core/rbac/doc.go
@@ -1,5 +1,4 @@
-// Package rbac provides a generic RBAC (Role-Based Access Control) engine
-// that can be used by both instance-level and space-level authorization systems.
+// Package rbac provides a generic RBAC (Role-Based Access Control) engine.
 //
 // The engine provides:
 //   - Role CRUD operations (create, get, list, update, delete)
@@ -7,6 +6,10 @@
 //   - Role assignments per user
 //   - Optional user-level permission overrides (grant/deny)
 //
-// Each system (instance or space) wraps the engine with an adapter that handles
-// scope-specific logic like implicit roles or storage bucket selection.
+// Designed as a generic two-tier-capable engine (instance + space) before
+// Phase 5 of #330 collapsed RBAC into a single server tier. Today only one
+// adapter remains — `core/rbac.go` wraps the engine for the unified
+// SERVER_RBAC bucket. The multi-tier abstraction is over-engineered for
+// the current single-consumer reality; a future cleanup could inline this
+// engine into `core/rbac.go`.
 package rbac

--- a/cli/internal/core/rbac_test.go
+++ b/cli/internal/core/rbac_test.go
@@ -2350,7 +2350,7 @@ func TestChattoCore_GetUserEffectiveSpacePermissions_ServerRoleGrants(t *testing
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	// Create a user with moderator instance role
+	// Create a user with moderator role
 	user, _ := core.CreateUser(ctx, SystemActorID, "staffuser", "Staff User", "password123")
 	core.AssignServerRole(ctx, SystemActorID, user.Id, RoleModerator)
 
@@ -2374,7 +2374,7 @@ func TestChattoCore_GetUserEffectiveSpacePermissions_ServerRoleGrants(t *testing
 		t.Fatalf("Failed to grant role permission: %v", err)
 	}
 
-	// Now user should have role.manage via instance role
+	// Now user should have role.manage via role
 	perms2, err := core.GetUserEffectiveSpacePermissions(ctx, KindChannel, user.Id)
 	if err != nil {
 		t.Fatalf("GetUserEffectiveSpacePermissions failed: %v", err)
@@ -2384,7 +2384,7 @@ func TestChattoCore_GetUserEffectiveSpacePermissions_ServerRoleGrants(t *testing
 		permSet2[string(p)] = true
 	}
 	if !permSet2["role.manage"] {
-		t.Error("User should have role.manage via instance role grant")
+		t.Error("User should have role.manage via role grant")
 	}
 }
 
@@ -2437,7 +2437,7 @@ func TestChattoCore_GetUserEffectiveSpacePermissions_ServerRoleDenialInSpace(t *
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	// Create a user with moderator instance role
+	// Create a user with moderator role
 	user, _ := core.CreateUser(ctx, SystemActorID, "verifieduser", "Verified User", "password123")
 	core.AssignServerRole(ctx, SystemActorID, user.Id, RoleModerator)
 
@@ -2460,7 +2460,7 @@ func TestChattoCore_GetUserEffectiveSpacePermissions_ServerRoleDenialInSpace(t *
 		t.Fatalf("Failed to deny role permission: %v", err)
 	}
 
-	// Now user should NOT have room.join (instance role denial wins)
+	// Now user should NOT have room.join (role denial wins)
 	perms2, err := core.GetUserEffectiveSpacePermissions(ctx, KindChannel, user.Id)
 	if err != nil {
 		t.Fatalf("GetUserEffectiveSpacePermissions failed: %v", err)
@@ -2470,7 +2470,7 @@ func TestChattoCore_GetUserEffectiveSpacePermissions_ServerRoleDenialInSpace(t *
 		permSet2[string(p)] = true
 	}
 	if permSet2["room.join"] {
-		t.Error("User should NOT have room.join after instance role denial")
+		t.Error("User should NOT have room.join after role denial")
 	}
 }
 

--- a/cli/internal/core/room_unread.go
+++ b/cli/internal/core/room_unread.go
@@ -43,7 +43,7 @@ func (c *ChattoCore) NotifyRoomMarkedAsRead(ctx context.Context, userID string, 
 		},
 	}
 
-	// Publish to user's instance event stream (only they need to know)
+	// Publish to user's server event stream (only they need to know)
 	subject := subjects.LiveUserEvent(userID, "room_read")
 	if err := c.publishLiveEvent(ctx, subject, event); err != nil {
 		c.logger.Warn("Failed to publish room marked as read event",

--- a/cli/internal/core/s3.go
+++ b/cli/internal/core/s3.go
@@ -188,7 +188,7 @@ func (s *S3Client) PresignedGetURL(ctx context.Context, key string, expiry time.
 }
 
 // S3 key helpers for organizing assets in S3.
-// Space attachments use hierarchical paths; instance assets use flat keys matching NATS.
+// Space attachments use hierarchical paths; server assets use flat keys matching NATS.
 
 // S3KeySpaceAttachment returns the S3 key for a space attachment.
 // Format: spaces/{spaceId}/attachments/{attachmentId}
@@ -197,7 +197,7 @@ func S3KeySpaceAttachment(spaceID, attachmentID string) string {
 	return fmt.Sprintf("spaces/%s/attachments/%s", spaceID, attachmentID)
 }
 
-// S3KeyServerAsset returns the S3 key for an instance asset (avatar, logo, banner).
+// S3KeyServerAsset returns the S3 key for an server asset (avatar, logo, banner).
 // Format: instance/{assetId}
 // This matches the NATS key format so HTTP handlers can probe both backends with the same key.
 func S3KeyServerAsset(assetID string) string {

--- a/cli/internal/core/s3_test.go
+++ b/cli/internal/core/s3_test.go
@@ -209,16 +209,16 @@ func TestS3Client_NilWhenNotConfigured(t *testing.T) {
 // standard formats regardless of storage backend. The storage backend should be an
 // internal implementation detail that is not exposed in URLs.
 func TestStorageBackendEncapsulation_URLGeneration(t *testing.T) {
-	t.Run("S3 asset keys use consistent format for instance assets", func(t *testing.T) {
+	t.Run("S3 asset keys use consistent format for server assets", func(t *testing.T) {
 		// Instance assets should all use the same key format: instance/{assetId}
 		assetID := "abc123xyz"
 		s3Key := core.S3KeyServerAsset(assetID)
 		require.Equal(t, "instance/abc123xyz", s3Key)
 
-		// The URL format should be /assets/instance/{assetId}
+		// The URL format should be /assets/server/{assetId}
 		// This is what the HTTP handler expects regardless of backend
-		expectedURLPath := fmt.Sprintf("/assets/instance/%s", assetID)
-		require.Equal(t, "/assets/instance/abc123xyz", expectedURLPath)
+		expectedURLPath := fmt.Sprintf("/assets/server/%s", assetID)
+		require.Equal(t, "/assets/server/abc123xyz", expectedURLPath)
 	})
 
 	t.Run("S3 asset keys use consistent format for space attachments", func(t *testing.T) {
@@ -233,7 +233,7 @@ func TestStorageBackendEncapsulation_URLGeneration(t *testing.T) {
 		require.Equal(t, "/assets/space/space456/attachments/attach789", expectedURLPath)
 	})
 
-	t.Run("S3Asset.Key stores only the asset ID for instance assets", func(t *testing.T) {
+	t.Run("S3Asset.Key stores only the asset ID for server assets", func(t *testing.T) {
 		// When storing an S3 asset, we should store only the assetID
 		// (same as NATS) so URL generation is consistent
 		assetID := "myasset123"

--- a/cli/internal/core/server_branding.go
+++ b/cli/internal/core/server_branding.go
@@ -16,7 +16,7 @@ import (
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
-// Instance branding lives on the instance, not the underlying primary-space
+// Instance branding lives on the server, not the underlying primary-space
 // record. The asset bytes still live in the same NATS object store / S3
 // bucket as space assets — only the KV pointer is keyed at the instance
 // level via these constants.
@@ -27,7 +27,7 @@ const (
 
 // UploadServerLogo processes a logo image (resize + WebP) and uploads the
 // bytes to the object store. Returns the asset reference. Use SetServerLogo
-// to atomically swap the instance's logo pointer (and clean up the prior
+// to atomically swap the server's logo pointer (and clean up the prior
 // asset).
 func (c *ChattoCore) UploadServerLogo(ctx context.Context, reader io.Reader) (*corev1.Asset, error) {
 	webpReader, err := assets.ProcessLogoImageWithConfig(reader, c.AssetsConfig())
@@ -43,7 +43,7 @@ func (c *ChattoCore) UploadServerLogo(ctx context.Context, reader io.Reader) (*c
 
 // UploadServerBanner processes a banner image (resize + WebP) and uploads
 // the bytes to the object store. Returns the asset reference. Use
-// SetServerBanner to atomically swap the instance's banner pointer (and
+// SetServerBanner to atomically swap the server's banner pointer (and
 // clean up the prior asset).
 //
 // Banners double as the OG link-preview image, so they're processed at the
@@ -62,7 +62,7 @@ func (c *ChattoCore) UploadServerBanner(ctx context.Context, reader io.Reader) (
 
 // uploadServerAsset routes processed image bytes to NATS or S3 based on
 // configuration and returns the resulting asset reference. Used by the
-// instance-level logo and banner upload paths.
+// server-level logo and banner upload paths.
 func (c *ChattoCore) uploadServerAsset(ctx context.Context, webpData []byte, kind string) (*corev1.Asset, error) {
 	assetID := NewAssetID()
 
@@ -71,7 +71,7 @@ func (c *ChattoCore) uploadServerAsset(ctx context.Context, webpData []byte, kin
 		if _, err := c.s3Client.PutObjectFromBytes(ctx, s3Key, webpData, "image/webp"); err != nil {
 			return nil, fmt.Errorf("failed to upload %s to S3: %w", kind, err)
 		}
-		c.logger.Info("Uploaded instance "+kind+" to S3", "asset_id", assetID, "size", len(webpData))
+		c.logger.Info("Uploaded server "+kind+" to S3", "asset_id", assetID, "size", len(webpData))
 		return &corev1.Asset{
 			Asset: &corev1.Asset_S3{
 				S3: &corev1.S3Asset{
@@ -92,7 +92,7 @@ func (c *ChattoCore) uploadServerAsset(ctx context.Context, webpData []byte, kin
 	if err != nil {
 		return nil, fmt.Errorf("failed to upload %s: %w", kind, err)
 	}
-	c.logger.Info("Uploaded instance "+kind, "asset_id", assetID, "size", info.Size)
+	c.logger.Info("Uploaded server "+kind, "asset_id", assetID, "size", info.Size)
 	return &corev1.Asset{
 		Asset: &corev1.Asset_Nats{
 			Nats: &corev1.NATSAsset{
@@ -150,10 +150,10 @@ func (c *ChattoCore) setServerBrandingAsset(ctx context.Context, actorID, key, k
 
 		if updateErr == nil {
 			if oldAsset != nil {
-				c.deleteAsset(ctx, oldAsset, kind, "instance")
+				c.deleteAsset(ctx, oldAsset, kind, "server")
 			}
 			c.PublishServerBrandingUpdate(ctx, actorID)
-			c.logger.Info("Updated instance "+kind, "asset_id", assetIDFromAsset(asset))
+			c.logger.Info("Updated server "+kind, "asset_id", assetIDFromAsset(asset))
 			return nil
 		}
 
@@ -168,13 +168,13 @@ func (c *ChattoCore) setServerBrandingAsset(ctx context.Context, actorID, key, k
 	return fmt.Errorf("failed to update %s after %d retries due to concurrent modifications", kind, maxRetries)
 }
 
-// GetServerLogo returns the asset reference for the instance's current
+// GetServerLogo returns the asset reference for the server's current
 // logo, or (nil, nil) if no logo is set.
 func (c *ChattoCore) GetServerLogo(ctx context.Context) (*corev1.Asset, error) {
 	return c.getServerBrandingAsset(ctx, serverLogoKey, "logo")
 }
 
-// GetServerBanner returns the asset reference for the instance's current
+// GetServerBanner returns the asset reference for the server's current
 // banner, or (nil, nil) if no banner is set.
 func (c *ChattoCore) GetServerBanner(ctx context.Context) (*corev1.Asset, error) {
 	return c.getServerBrandingAsset(ctx, serverBannerKey, "banner")
@@ -195,7 +195,7 @@ func (c *ChattoCore) getServerBrandingAsset(ctx context.Context, key, kind strin
 	return asset, nil
 }
 
-// GetServerLogoURL returns the URL for the instance's logo, optionally
+// GetServerLogoURL returns the URL for the server's logo, optionally
 // transformed to the given dimensions. Returns empty string when no logo
 // is set.
 func (c *ChattoCore) GetServerLogoURL(ctx context.Context, width, height *int) (string, error) {
@@ -206,7 +206,7 @@ func (c *ChattoCore) GetServerLogoURL(ctx context.Context, width, height *int) (
 	return c.serverAssetURL(logo, width, height), nil
 }
 
-// GetServerBannerURL returns the URL for the instance's banner, optionally
+// GetServerBannerURL returns the URL for the server's banner, optionally
 // transformed to the given dimensions. Returns empty string when no banner
 // is set.
 func (c *ChattoCore) GetServerBannerURL(ctx context.Context, width, height *int) (string, error) {
@@ -217,7 +217,7 @@ func (c *ChattoCore) GetServerBannerURL(ctx context.Context, width, height *int)
 	return c.serverAssetURL(banner, width, height), nil
 }
 
-// serverAssetURL builds the public URL for an instance-scoped asset,
+// serverAssetURL builds the public URL for an server-scoped asset,
 // optionally with transform parameters.
 func (c *ChattoCore) serverAssetURL(asset *corev1.Asset, width, height *int) string {
 	assetID := assetIDFromAsset(asset)
@@ -227,16 +227,16 @@ func (c *ChattoCore) serverAssetURL(asset *corev1.Asset, width, height *int) str
 	if width != nil && height != nil {
 		return c.GetTransformedServerAssetURL(assetID, *width, *height, "cover")
 	}
-	return c.assetURL(fmt.Sprintf("/assets/instance/%s", assetID))
+	return c.assetURL(fmt.Sprintf("/assets/server/%s", assetID))
 }
 
-// DeleteServerLogo clears the instance's logo (KV pointer + object-store
+// DeleteServerLogo clears the server's logo (KV pointer + object-store
 // asset). No-op when no logo is set.
 func (c *ChattoCore) DeleteServerLogo(ctx context.Context, actorID string) error {
 	return c.deleteServerBrandingAsset(ctx, actorID, serverLogoKey, "logo")
 }
 
-// DeleteServerBanner clears the instance's banner. No-op when no banner
+// DeleteServerBanner clears the server's banner. No-op when no banner
 // is set.
 func (c *ChattoCore) DeleteServerBanner(ctx context.Context, actorID string) error {
 	return c.deleteServerBrandingAsset(ctx, actorID, serverBannerKey, "banner")
@@ -261,9 +261,9 @@ func (c *ChattoCore) deleteServerBrandingAsset(ctx context.Context, actorID, key
 		}
 
 		if deleteErr := c.storage.serverKV.Delete(ctx, key, jetstream.LastRevision(revision)); deleteErr == nil {
-			c.deleteAsset(ctx, asset, kind, "instance")
+			c.deleteAsset(ctx, asset, kind, "server")
 			c.PublishServerBrandingUpdate(ctx, actorID)
-			c.logger.Info("Deleted instance " + kind)
+			c.logger.Info("Deleted server " + kind)
 			return nil
 		} else if errors.Is(deleteErr, jetstream.ErrKeyExists) {
 			c.logger.Debug(kind+" delete revision conflict, retrying", "attempt", attempt+1)
@@ -277,7 +277,7 @@ func (c *ChattoCore) deleteServerBrandingAsset(ctx context.Context, actorID, key
 }
 
 // PublishServerBrandingUpdate publishes a ServerUpdatedEvent carrying the
-// current name + logo + banner from instance-scoped storage. Best-effort: a
+// current name + logo + banner from server-scoped storage. Best-effort: a
 // publish failure does not roll back the underlying KV change.
 func (c *ChattoCore) PublishServerBrandingUpdate(ctx context.Context, actorID string) {
 	name := ""

--- a/cli/internal/core/user_preferences.go
+++ b/cli/internal/core/user_preferences.go
@@ -17,7 +17,7 @@ import (
 // User Settings Operations
 // ============================================================================
 
-// userPreferencesKey returns the KV key for a user's instance-level preferences.
+// userPreferencesKey returns the KV key for a user's server-level preferences.
 func userPreferencesKey(userID string) string {
 	return fmt.Sprintf("user_preferences.%s", userID)
 }

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -63,7 +63,7 @@ func (c *ChattoCore) CreateUser(ctx context.Context, actorID string, login, disp
 		return nil, ErrUsernameBlocked
 	}
 
-	// Enforce instance-wide user limit at signup as a UX gate so people don't sign up
+	// Enforce server-wide user limit at signup as a UX gate so people don't sign up
 	// only to be blocked at verification. The verification check (in addVerifiedEmail)
 	// remains the race-safe hard gate.
 	if max := c.config.Limits.MaxUsersOrDefault(); max >= 0 {
@@ -515,7 +515,7 @@ func (c *ChattoCore) DeleteUserAvatar(ctx context.Context, userID string) error 
 	return nil
 }
 
-// publishUserProfileUpdate publishes a UserProfileUpdatedEvent to the instance stream.
+// publishUserProfileUpdate publishes a UserProfileUpdatedEvent to the server stream.
 // This allows other users to see profile changes (avatar, display name) in real-time.
 func (c *ChattoCore) publishUserProfileUpdate(ctx context.Context, userID string) {
 	// Get current user data
@@ -614,11 +614,11 @@ func (c *ChattoCore) GetUserAvatarURL(ctx context.Context, userID string, width,
 		return "", fmt.Errorf("unknown asset type")
 	}
 
-	// Always use the standard instance asset URL format - storage backend is an internal detail
+	// Always use the standard server asset URL format - storage backend is an internal detail
 	if width != nil && height != nil {
 		return c.GetTransformedServerAssetURL(assetID, *width, *height, "cover"), nil
 	}
-	return c.assetURL(fmt.Sprintf("/assets/instance/%s", assetID)), nil
+	return c.assetURL(fmt.Sprintf("/assets/server/%s", assetID)), nil
 }
 
 // ============================================================================
@@ -1042,7 +1042,7 @@ func (c *ChattoCore) DeleteUser(ctx context.Context, actorID, userID string) err
 		c.logger.Warn("Failed to revoke user roles during deletion", "user_id", userID, "error", err)
 	}
 
-	// Publish instance-level UserDeletedEvent for audit logging and admin UI updates
+	// Publish server-level UserDeletedEvent for audit logging and admin UI updates
 	serverEvent := newEvent(userID, &corev1.Event{
 		Event: &corev1.Event_UserDeleted{
 			UserDeleted: &corev1.UserDeletedEvent{

--- a/cli/internal/core/users_test.go
+++ b/cli/internal/core/users_test.go
@@ -1232,8 +1232,8 @@ func TestChattoCore_GetUserAvatarURL_AbsoluteURL(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to get avatar URL: %v", err)
 		}
-		if !bytes.HasPrefix([]byte(url), []byte("/assets/instance/")) {
-			t.Errorf("Expected relative URL starting with /assets/instance/, got '%s'", url)
+		if !bytes.HasPrefix([]byte(url), []byte("/assets/server/")) {
+			t.Errorf("Expected relative URL starting with /assets/server/, got '%s'", url)
 		}
 	})
 
@@ -1245,7 +1245,7 @@ func TestChattoCore_GetUserAvatarURL_AbsoluteURL(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to get avatar URL: %v", err)
 		}
-		if !bytes.HasPrefix([]byte(url), []byte("https://chat.example.com/assets/instance/")) {
+		if !bytes.HasPrefix([]byte(url), []byte("https://chat.example.com/assets/server/")) {
 			t.Errorf("Expected absolute URL, got '%s'", url)
 		}
 	})
@@ -1259,7 +1259,7 @@ func TestChattoCore_GetUserAvatarURL_AbsoluteURL(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to get avatar URL: %v", err)
 		}
-		if !bytes.HasPrefix([]byte(url), []byte("https://chat.example.com/assets/instance/")) {
+		if !bytes.HasPrefix([]byte(url), []byte("https://chat.example.com/assets/server/")) {
 			t.Errorf("Expected absolute transformed URL, got '%s'", url)
 		}
 	})

--- a/cli/internal/core/voice.go
+++ b/cli/internal/core/voice.go
@@ -62,7 +62,7 @@ func callStateKey(spaceID, roomID string) string {
 
 // LiveKitRoomName constructs a deterministic LiveKit room name from space and room IDs.
 // When serverID is non-empty, the room name is prefixed with "{serverID}." so the
-// webhook bridge can route events to the correct Chatto instance in shared deployments.
+// webhook bridge can route events to the correct Chatto server in shared deployments.
 // Authorization: Caller must verify room membership before calling.
 func LiveKitRoomName(serverID, spaceID, roomID string) string {
 	base := spaceID + "_" + roomID
@@ -78,8 +78,8 @@ func LiveKitRoomName(serverID, spaceID, roomID string) string {
 func ParseLiveKitRoomName(lkRoomName string) (spaceID, roomID string) {
 	name := lkRoomName
 
-	// Strip instance ID prefix if present (dot separator).
-	// Safe because instance IDs (K8s names, UUIDs, NanoIDs) and space/room NanoIDs
+	// Strip server ID prefix if present (dot separator).
+	// Safe because server IDs (K8s names, UUIDs, NanoIDs) and space/room NanoIDs
 	// never contain dots.
 	if idx := strings.IndexByte(name, '.'); idx >= 0 {
 		name = name[idx+1:]
@@ -93,7 +93,7 @@ func ParseLiveKitRoomName(lkRoomName string) (spaceID, roomID string) {
 	return name[:idx], name[idx+1:]
 }
 
-// ParseLiveKitRoomServerID extracts just the instance ID prefix from a LiveKit room
+// ParseLiveKitRoomServerID extracts just the server ID prefix from a LiveKit room
 // name. Returns empty string if no prefix is present (unprefixed format).
 func ParseLiveKitRoomServerID(lkRoomName string) string {
 	idx := strings.IndexByte(lkRoomName, '.')

--- a/cli/internal/core/voice_test.go
+++ b/cli/internal/core/voice_test.go
@@ -16,13 +16,13 @@ func TestLiveKitRoomName(t *testing.T) {
 		want       string
 	}{
 		{
-			name:    "no instance ID",
+			name:    "no server ID",
 			spaceID: "space123",
 			roomID:  "room456",
 			want:    "space123_room456",
 		},
 		{
-			name:       "with instance ID",
+			name:       "with server ID",
 			serverID: "my-instance",
 			spaceID:    "space123",
 			roomID:     "room456",
@@ -42,7 +42,7 @@ func TestLiveKitRoomName(t *testing.T) {
 			want:       "prod-tenant-1.V1StGXR8_Z5jdHi6B-myT_xYz9Abc_def",
 		},
 		{
-			name:       "empty instance ID treated as no prefix",
+			name:       "empty server ID treated as no prefix",
 			serverID: "",
 			spaceID:    "space123",
 			roomID:     "room456",

--- a/cli/internal/graph/admin.resolvers.go
+++ b/cli/internal/graph/admin.resolvers.go
@@ -67,7 +67,7 @@ func (r *adminMutationsResolver) UpdateServerConfig(ctx context.Context, obj *mo
 		return cfg, nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to update instance config: %w", err)
+		return nil, fmt.Errorf("failed to update server config: %w", err)
 	}
 
 	// Get the effective values (with defaults) for broadcasting
@@ -79,7 +79,7 @@ func (r *adminMutationsResolver) UpdateServerConfig(ctx context.Context, obj *mo
 	// Publish live event to notify all connected clients
 	if err := r.core.PublishServerConfigUpdated(ctx, user.Id, effectiveName, cfg.Motd, cfg.WelcomeMessage, cfg.BlockedUsernames); err != nil {
 		// Log the error but don't fail the mutation - config was saved successfully
-		r.logger.Warn("Failed to publish instance config update event", "error", err)
+		r.logger.Warn("Failed to publish server config update event", "error", err)
 	}
 
 	// Return the updated config section
@@ -107,13 +107,13 @@ func (r *adminMutationsResolver) ResetServerConfig(ctx context.Context, obj *mod
 	configMgr := r.core.ConfigManager()
 
 	if err := configMgr.ResetServerConfig(ctx); err != nil {
-		return false, fmt.Errorf("failed to reset instance config: %w", err)
+		return false, fmt.Errorf("failed to reset server config: %w", err)
 	}
 
 	// Publish live event with default values to notify all connected clients
 	if err := r.core.PublishServerConfigUpdated(ctx, user.Id, "Chatto", "", "", core.DefaultBlockedUsernames); err != nil {
 		// Log the error but don't fail the mutation - config was reset successfully
-		r.logger.Warn("Failed to publish instance config reset event", "error", err)
+		r.logger.Warn("Failed to publish server config reset event", "error", err)
 	}
 
 	return true, nil
@@ -175,7 +175,7 @@ func (r *adminQueriesResolver) ServerConfig(ctx context.Context, obj *model.Admi
 
 	cfg, isConfigured, err := configMgr.GetServerConfig(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get instance config: %w", err)
+		return nil, fmt.Errorf("failed to get server config: %w", err)
 	}
 
 	return serverConfigToModel(cfg, isConfigured), nil
@@ -260,10 +260,10 @@ func (r *queryResolver) Admin(ctx context.Context) (*model.AdminQueries, error) 
 		Stats:      stats,
 	}
 
-	// Fetch instance roles
+	// Fetch roles
 	roles, err := r.core.ListServerRoles(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list instance roles: %w", err)
+		return nil, fmt.Errorf("failed to list roles: %w", err)
 	}
 	// Convert to pointer slice for GraphQL
 	roleModels := make([]*core.RoleWithPermissions, len(roles))
@@ -271,8 +271,8 @@ func (r *queryResolver) Admin(ctx context.Context) (*model.AdminQueries, error) 
 		roleModels[i] = &roles[i]
 	}
 
-	// Fetch all permissions applicable at instance scope
-	// This includes permissions like room.create, message.post that can have instance-wide defaults
+	// Fetch all permissions applicable at server scope
+	// This includes permissions like room.create, message.post that can have server-wide defaults
 	allPerms := core.PermissionsForScope(core.ScopeServer)
 	serverPermissionsList := make([]string, len(allPerms))
 	for i, p := range allPerms {

--- a/cli/internal/graph/admin_test.go
+++ b/cli/internal/graph/admin_test.go
@@ -96,7 +96,7 @@ func TestAdminMutations_Authorization(t *testing.T) {
 func TestUpdateServerConfig_Authorization(t *testing.T) {
 	env := setupTestResolverWithAdmin(t, []string{"testuser@example.com"})
 
-	t.Run("admin can update instance config", func(t *testing.T) {
+	t.Run("admin can update server config", func(t *testing.T) {
 		// First get the admin mutations object
 		adminMutations, err := env.resolver.Mutation().Admin(env.authContext())
 		if err != nil {
@@ -165,7 +165,7 @@ func TestUpdateServerConfig_Authorization(t *testing.T) {
 func TestResetServerConfig_Authorization(t *testing.T) {
 	env := setupTestResolverWithAdmin(t, []string{"testuser@example.com"})
 
-	t.Run("admin can reset instance config", func(t *testing.T) {
+	t.Run("admin can reset server config", func(t *testing.T) {
 		// First set some config
 		adminMutations, err := env.resolver.Mutation().Admin(env.authContext())
 		if err != nil {
@@ -265,7 +265,7 @@ func TestAdminUpdateUser_Authorization(t *testing.T) {
 	})
 
 	t.Run("rbac admin cannot edit owner (hierarchy enforcement)", func(t *testing.T) {
-		// testUser was created first → auto-promoted to instance owner.
+		// testUser was created first → auto-promoted to server owner.
 		// admin2 has the instance-admin role (rank 1) — outranked by owner (rank 0).
 		env := setupTestResolver(t)
 		admin2 := env.createVerifiedUser(t, "rbac-admin", "RBAC Admin", "password123")

--- a/cli/internal/graph/authz.go
+++ b/cli/internal/graph/authz.go
@@ -31,7 +31,7 @@ var (
 	ErrNotSpaceMember   = core.ErrNotSpaceMember
 	ErrNotRoomMember    = core.ErrNotRoomMember
 	ErrNotSelf          = errors.New("access denied: cannot access other users' data")
-	ErrNotServerAdmin = errors.New("access denied: instance admin required")
+	ErrNotServerAdmin = errors.New("access denied: server admin required")
 )
 
 // requireAuth extracts the authenticated user from context.

--- a/cli/internal/graph/authz_test.go
+++ b/cli/internal/graph/authz_test.go
@@ -177,7 +177,7 @@ func TestRequireServerAdmin(t *testing.T) {
 
 	t.Run("non-admin fails", func(t *testing.T) {
 		// Create a second user who is NOT an admin (the first user from setupTestResolver
-		// is auto-promoted to instance owner, so we need a fresh user)
+		// is auto-promoted to server owner, so we need a fresh user)
 		regularUser, err := env.core.CreateUser(env.ctx, "system", "regularuser", "Regular User", "password123")
 		if err != nil {
 			t.Fatalf("Failed to create regular user: %v", err)

--- a/cli/internal/graph/mutation.resolvers.go
+++ b/cli/internal/graph/mutation.resolvers.go
@@ -422,7 +422,7 @@ func (r *mutationResolver) UpdateServer(ctx context.Context, input model.UpdateS
 			return cfg, nil
 		})
 		if err != nil {
-			return nil, fmt.Errorf("save instance config: %w", err)
+			return nil, fmt.Errorf("save server config: %w", err)
 		}
 		// Live-update is best-effort; the config write already succeeded.
 		_ = r.core.PublishServerConfigUpdated(

--- a/cli/internal/graph/mutation_test.go
+++ b/cli/internal/graph/mutation_test.go
@@ -1046,7 +1046,7 @@ func TestDeleteServerLogo_Authorization(t *testing.T) {
 	})
 
 	t.Run("admin can delete logo (even if none exists)", func(t *testing.T) {
-		// testUser is the instance admin. Should succeed even if no logo exists - it's a no-op.
+		// testUser is the server admin. Should succeed even if no logo exists - it's a no-op.
 		instance, err := mutation.DeleteServerLogo(env.authContext())
 		if err != nil {
 			t.Fatalf("expected success, got error: %v", err)

--- a/cli/internal/graph/permission_inspector_helpers.go
+++ b/cli/internal/graph/permission_inspector_helpers.go
@@ -14,8 +14,8 @@ import (
 )
 
 // authorizePermissionExplanation enforces admin-only access for the
-// inspector. Instance scope requires instance admin; room scope requires
-// role.manage or instance admin. There is no self-inspection path — the
+// inspector. Instance scope requires server admin; room scope requires
+// role.manage or server admin. There is no self-inspection path — the
 // inspector is an admin tool.
 //
 // At room scope, roomID must exist in the corresponding CONFIG bucket.
@@ -50,12 +50,12 @@ func (r *Resolver) requireRoomExists(ctx context.Context, kind core.RoomKind, ro
 	return nil
 }
 
-// requireServerAdminOrErr returns nil if the viewer is an instance admin
+// requireServerAdminOrErr returns nil if the viewer is an server admin
 // (config-based, owner role, or admin role), otherwise core.ErrPermissionDenied.
 func (r *Resolver) requireServerAdminOrErr(ctx context.Context, viewerID string) error {
 	isAdmin, err := r.isServerAdmin(ctx, viewerID)
 	if err != nil {
-		return fmt.Errorf("failed to check instance admin: %w", err)
+		return fmt.Errorf("failed to check server admin: %w", err)
 	}
 	if !isAdmin {
 		return core.ErrPermissionDenied

--- a/cli/internal/graph/permission_inspector_test.go
+++ b/cli/internal/graph/permission_inspector_test.go
@@ -11,7 +11,7 @@ func TestPermissionExplanation_ServerAdminAtServerScope(t *testing.T) {
 	env := setupTestResolver(t)
 	query := env.resolver.Query()
 
-	// env.testUser is auto-promoted to instance owner.
+	// env.testUser is auto-promoted to server owner.
 	results, err := query.PermissionExplanation(env.authContext(), env.testUser.Id, nil)
 	if err != nil {
 		t.Fatalf("PermissionExplanation: %v", err)
@@ -52,7 +52,7 @@ func TestPermissionExplanation_NonAdminCannotInspectAnotherUser(t *testing.T) {
 	env := setupTestResolver(t)
 	query := env.resolver.Query()
 
-	// env.testUser is the bootstrap owner (auto-promoted instance owner) and so
+	// env.testUser is the bootstrap owner (auto-promoted server owner) and so
 	// has admin access. Use freshly-created users instead — neither is admin.
 	regular := env.createVerifiedUser(t, "regular", "Regular", "password123")
 	target := env.createVerifiedUser(t, "target2", "Target 2", "password123")

--- a/cli/internal/graph/query.resolvers.go
+++ b/cli/internal/graph/query.resolvers.go
@@ -36,7 +36,7 @@ func (r *queryResolver) Room(ctx context.Context, roomID string) (*corev1.Room, 
 }
 
 // User is the resolver for the user field.
-// Note: User profiles are intentionally public within the instance.
+// Note: User profiles are intentionally public within the server.
 // This is required for displaying message authors, member lists, etc.
 // Authentication is not required as user data is non-sensitive.
 func (r *queryResolver) User(ctx context.Context, id string) (*corev1.User, error) {
@@ -46,7 +46,7 @@ func (r *queryResolver) User(ctx context.Context, id string) (*corev1.User, erro
 
 // UserByLogin is the resolver for the userByLogin field.
 // Returns the user with the given login name, or null if not found.
-// Note: User profiles are intentionally public within the instance.
+// Note: User profiles are intentionally public within the server.
 func (r *queryResolver) UserByLogin(ctx context.Context, login string) (*corev1.User, error) {
 	// No authorization - public user profiles
 	user, err := r.core.GetUserByLogin(ctx, login)
@@ -64,7 +64,7 @@ func (r *queryResolver) Users(ctx context.Context) ([]*corev1.User, error) {
 		return nil, err
 	}
 
-	// Authorization: instance admin only (checks both RBAC and config-based admin)
+	// Authorization: server admin only (checks both RBAC and config-based admin)
 	isAdmin, err := r.isServerAdmin(ctx, user.Id)
 	if err != nil {
 		return nil, err

--- a/cli/internal/graph/query_test.go
+++ b/cli/internal/graph/query_test.go
@@ -81,7 +81,7 @@ func TestQueryResolver_Room(t *testing.T) {
 
 // Space Query/discovery resolvers were retired in PR(a); the type is gone from
 // the GraphQL surface. Public discovery now happens via the unauthenticated
-// `instance` query, which exposes the instance name, logo, banner, etc.
+// `instance` query, which exposes the server name, logo, banner, etc.
 
 // ============================================================================
 // User Query Resolver Tests
@@ -174,7 +174,7 @@ func TestQueryResolver_Users(t *testing.T) {
 
 	t.Run("user without admin.users.view permission is rejected", func(t *testing.T) {
 		// Create a second user who is NOT an admin (the first user from setupTestResolver
-		// is auto-promoted to instance owner, so we need a fresh user)
+		// is auto-promoted to server owner, so we need a fresh user)
 		regularUser, err := env.core.CreateUser(env.ctx, "system", "regularuser", "Regular User", "password123")
 		if err != nil {
 			t.Fatalf("Failed to create regular user: %v", err)
@@ -508,7 +508,7 @@ func TestQueryResolver_Viewer(t *testing.T) {
 	t.Run("non-admin viewer canViewAdmin is false", func(t *testing.T) {
 		env := setupTestResolver(t)
 		// Create a second user who is NOT an admin (the first user from setupTestResolver
-		// is auto-promoted to instance owner, so we need a fresh user)
+		// is auto-promoted to server owner, so we need a fresh user)
 		regularUser, err := env.core.CreateUser(env.ctx, "system", "regularuser", "Regular User", "password123")
 		if err != nil {
 			t.Fatalf("Failed to create regular user: %v", err)
@@ -568,7 +568,7 @@ func TestQueryResolver_Admin(t *testing.T) {
 	t.Run("non-admin returns nil", func(t *testing.T) {
 		env := setupTestResolver(t)
 		// Create a second user who is NOT an admin (the first user from setupTestResolver
-		// is auto-promoted to instance owner, so we need a fresh user)
+		// is auto-promoted to server owner, so we need a fresh user)
 		regularUser, err := env.core.CreateUser(env.ctx, "system", "regularuser", "Regular User", "password123")
 		if err != nil {
 			t.Fatalf("Failed to create regular user: %v", err)

--- a/cli/internal/graph/server_helpers.go
+++ b/cli/internal/graph/server_helpers.go
@@ -17,7 +17,7 @@ func (r *Resolver) resolveRoomKind(ctx context.Context, roomID string) (core.Roo
 }
 
 // serverModel constructs the singleton Instance value used as the receiver
-// for instance-scoped mutation results.
+// for server-scoped mutation results.
 func (r *mutationResolver) serverModel() *model.Server {
 	return &model.Server{
 		Version:              r.version,

--- a/cli/internal/graph/server_rbac.resolvers.go
+++ b/cli/internal/graph/server_rbac.resolvers.go
@@ -297,7 +297,7 @@ func (r *mutationResolver) RevokeRole(ctx context.Context, input model.RevokeRol
 	}
 
 	// Self-lockout prevention: users cannot revoke their own owner or admin role.
-	// Note: This check uses hardcoded role names. If new privileged instance roles are added,
+	// Note: This check uses hardcoded role names. If new privileged roles are added,
 	// they should be added here to prevent self-lockout. Consider using role hierarchy/position
 	// for a more robust solution in the future.
 	if caller.Id == input.UserID {

--- a/cli/internal/graph/test_helpers.go
+++ b/cli/internal/graph/test_helpers.go
@@ -159,7 +159,7 @@ func (e *testEnv) createVerifiedUser(t *testing.T, login, displayName, password 
 }
 
 // setupTestResolverWithAdmin creates a test environment with owners config so
-// users with matching verified emails are treated as instance owners.
+// users with matching verified emails are treated as server owners.
 func setupTestResolverWithAdmin(t *testing.T, ownerEmails []string) *testEnv {
 	t.Helper()
 

--- a/cli/internal/graph/user.resolvers.go
+++ b/cli/internal/graph/user.resolvers.go
@@ -139,7 +139,7 @@ func (r *userResolver) ViewerCanDeleteAccount(ctx context.Context, obj *corev1.U
 }
 
 // LastLoginChange is the resolver for the lastLoginChange field.
-// Visible to the user themselves and to instance admins (the latter so that
+// Visible to the user themselves and to server admins (the latter so that
 // the admin user-management UI can show whether a cooldown is active).
 func (r *userResolver) LastLoginChange(ctx context.Context, obj *corev1.User) (*timestamppb.Timestamp, error) {
 	caller := auth.ForContext(ctx)

--- a/cli/internal/http_server/assets.go
+++ b/cli/internal/http_server/assets.go
@@ -19,7 +19,7 @@ func (s *HTTPServer) setupAssetRoutes() {
 	// Instance assets use *path which catches everything including /t/signedPath for transforms
 	// The serveServerAsset handler detects and routes transform requests appropriately
 	// These handlers probe both NATS and S3 backends automatically
-	s.router.GET("/assets/instance/*path", s.serveServerAsset)
+	s.router.GET("/assets/server/*path", s.serveServerAsset)
 	s.router.GET("/assets/space/:spaceId/attachments/:attachmentId", s.serveSpaceAttachment)
 	s.router.GET("/assets/space/:spaceId/attachments/:attachmentId/t/:signedPath", s.serveTransformedAttachment)
 }
@@ -29,11 +29,11 @@ func (s *HTTPServer) setupAssetRoutes() {
 type transformRequest struct {
 	// ResourceID1 and ResourceID2 are used for signing verification.
 	// For space attachments: (spaceID, attachmentID)
-	// For instance assets: ("instance", key)
+	// For server assets: ("server", key)
 	ResourceID1 string
 	ResourceID2 string
 	SignedPath  string
-	// CachePrefix distinguishes cache keys between asset types (e.g., "space", "instance")
+	// CachePrefix distinguishes cache keys between asset types (e.g., "space", "server")
 	CachePrefix string
 	// AssetID is used for ETag generation and logging
 	AssetID string
@@ -64,12 +64,12 @@ func (s *HTTPServer) serveServerAsset(c *gin.Context) {
 		}
 	}
 
-	s.logger.Debug("Serving instance asset", "asset_id", path)
+	s.logger.Debug("Serving server asset", "asset_id", path)
 
 	// Probe both NATS and S3 backends
 	reader, info, err := s.core.GetServerAssetFromAnyBackend(c.Request.Context(), path)
 	if err != nil {
-		s.logger.Error("Failed to get instance asset", "error", err, "asset_id", path)
+		s.logger.Error("Failed to get server asset", "error", err, "asset_id", path)
 		c.JSON(http.StatusNotFound, gin.H{"error": "Asset not found"})
 		return
 	}
@@ -311,24 +311,24 @@ func (s *HTTPServer) serveTransformedAsset(c *gin.Context, req transformRequest)
 	c.Data(http.StatusOK, result.ContentType, transformedData)
 }
 
-// serveTransformedServerAsset serves a dynamically transformed version of an instance asset.
-// URL format: /assets/instance/{key}/t/{signedPath}
+// serveTransformedServerAsset serves a dynamically transformed version of an server asset.
+// URL format: /assets/server/{key}/t/{signedPath}
 // Called by serveServerAsset when it detects a transform pattern in the path.
 // Probes both NATS and S3 backends for the asset.
 func (s *HTTPServer) serveTransformedServerAsset(c *gin.Context, key, signedPath string) {
-	s.logger.Debug("Serving transformed instance asset", "asset_id", key, "signed_path", signedPath)
+	s.logger.Debug("Serving transformed server asset", "asset_id", key, "signed_path", signedPath)
 
 	s.serveTransformedAsset(c, transformRequest{
-		ResourceID1: "instance",
+		ResourceID1: "server",
 		ResourceID2: key,
 		SignedPath:  signedPath,
-		CachePrefix: "instance",
+		CachePrefix: "server",
 		AssetID:     key,
 		FetchAsset: func(ctx context.Context) (io.Reader, string, error) {
 			// Probe both NATS and S3 backends
 			reader, info, err := s.core.GetServerAssetFromAnyBackend(ctx, key)
 			if err != nil {
-				s.logger.Debug("Failed to fetch instance asset",
+				s.logger.Debug("Failed to fetch server asset",
 					"asset_id", key,
 					"error", err)
 				return nil, "", err
@@ -340,7 +340,7 @@ func (s *HTTPServer) serveTransformedServerAsset(c *gin.Context, key, signedPath
 					"asset_id", key,
 					"fallback_content_type", contentType)
 			}
-			s.logger.Debug("Fetched instance asset",
+			s.logger.Debug("Fetched server asset",
 				"asset_id", key,
 				"content_type", contentType,
 				"size", info.Size)

--- a/cli/internal/http_server/assets_test.go
+++ b/cli/internal/http_server/assets_test.go
@@ -637,7 +637,7 @@ func TestAsset_OriginalAttachment_HasCacheHeaders(t *testing.T) {
 func TestAsset_ServerAsset_HasCacheHeaders(t *testing.T) {
 	env := setupAssetTestServer(t)
 
-	// Create a user with an avatar (instance asset)
+	// Create a user with an avatar (server asset)
 	user, err := env.core.CreateUser(env.ctx, "system", "serverassetuser", "Instance Asset User", "password123")
 	if err != nil {
 		t.Fatalf("Failed to create user: %v", err)
@@ -653,10 +653,10 @@ func TestAsset_ServerAsset_HasCacheHeaders(t *testing.T) {
 		t.Fatalf("Failed to upload avatar: %v", err)
 	}
 
-	// Get the instance asset (avatars are public, no auth needed)
-	resp, err := env.client.Get(env.server.URL + "/assets/instance/" + avatarPath)
+	// Get the server asset (avatars are public, no auth needed)
+	resp, err := env.client.Get(env.server.URL + "/assets/server/" + avatarPath)
 	if err != nil {
-		t.Fatalf("Failed to get instance asset: %v", err)
+		t.Fatalf("Failed to get server asset: %v", err)
 	}
 	defer resp.Body.Close()
 

--- a/cli/internal/http_server/cors.go
+++ b/cli/internal/http_server/cors.go
@@ -29,7 +29,7 @@ func (s *HTTPServer) buildAllowedOrigins() []string {
 	origins = append(origins, listenOrigin)
 
 	// Tier 3: Explicit allow list from config, defaulting to wildcard for
-	// multi-instance support. Remote instances authenticate via Bearer tokens,
+	// multi-server support. Remote instances authenticate via Bearer tokens,
 	// not cookies, so wildcard is safe. The home origin (Tier 1) still gets
 	// explicit matching with credentials.
 	if len(s.config.Webserver.AllowedOrigins) > 0 {

--- a/cli/internal/http_server/graphql_test.go
+++ b/cli/internal/http_server/graphql_test.go
@@ -414,7 +414,7 @@ func TestGraphQL_Mutation_PostMessage_RequiresRoomMembership(t *testing.T) {
 func TestGraphQL_Query_Users_RequiresAdmin(t *testing.T) {
 	env := setupGraphQLTestServer(t)
 
-	// Create regular user (no instance role assigned).
+	// Create regular user (no role assigned).
 	env.createTestUser(t, "regular", "password123")
 	env.login(t, "regular", "password123")
 

--- a/cli/internal/http_server/opengraph.go
+++ b/cli/internal/http_server/opengraph.go
@@ -85,7 +85,7 @@ func (meta *OpenGraphMeta) generateTags() string {
 func (s *HTTPServer) getOpenGraphMeta(ctx context.Context, urlPath string) *OpenGraphMeta {
 	baseURL := strings.TrimSuffix(s.config.Webserver.URL, "/")
 
-	// Get instance name for both site_name and og:title — server identity
+	// Get server name for both site_name and og:title — server identity
 	// is the single source of truth for link previews.
 	serverName := "Chatto"
 	description := "Come join our community!"

--- a/cli/internal/http_server/opengraph_test.go
+++ b/cli/internal/http_server/opengraph_test.go
@@ -55,7 +55,7 @@ func TestOpenGraphMetaGenerateTags(t *testing.T) {
 			},
 		},
 		{
-			name: "with canonical URL for remote instance",
+			name: "with canonical URL for remote server",
 			meta: OpenGraphMeta{
 				Title:        "My Instance",
 				Description:  "Real-time chat application",

--- a/cli/internal/http_server/server.go
+++ b/cli/internal/http_server/server.go
@@ -100,7 +100,7 @@ func (s *HTTPServer) setupRoutes() error {
 		}
 		sessionStore = cookie.NewStore(authKey, encKey)
 	} else {
-		s.logger.Warn("webserver.cookie_encryption_secret is not set; session cookies are signed but NOT encrypted. Run `chatto init` on a fresh instance to generate one, or add a hex-encoded 32-byte value to chatto.toml.")
+		s.logger.Warn("webserver.cookie_encryption_secret is not set; session cookies are signed but NOT encrypted. Run `chatto init` on a fresh server to generate one, or add a hex-encoded 32-byte value to chatto.toml.")
 		sessionStore = cookie.NewStore(authKey)
 	}
 	sessionStore.Options(sessions.Options{

--- a/cli/internal/http_server/test_endpoints.go
+++ b/cli/internal/http_server/test_endpoints.go
@@ -80,7 +80,7 @@ func registerTestEndpoints(auth *gin.RouterGroup, s *HTTPServer) {
 	// email verification, and session creation. Replaces the production
 	// `createUser` GraphQL mutation that was removed for security (see #175):
 	// production `createUser` was unauthenticated and let any caller win the
-	// race to become instance owner. The test endpoint is gated behind the
+	// race to become server owner. The test endpoint is gated behind the
 	// `test_endpoints` build tag so it is never compiled into release
 	// binaries — same trust model as `/auth/test/verify-email` above.
 	auth.POST("test/create-user", func(c *gin.Context) {
@@ -210,7 +210,7 @@ func registerTestEndpoints(auth *gin.RouterGroup, s *HTTPServer) {
 	})
 
 	// Test-only endpoint to mint an OAuth authorization code for a known user
-	// without going through the login UI. Used by multi-instance E2E tests that
+	// without going through the login UI. Used by multi-server E2E tests that
 	// drive the real Add-Server dialog → /oauth/authorize → /instances/callback
 	// flow but bypass the human OAuth login form via Playwright route interception.
 	auth.POST("test/oauth-authorize", func(c *gin.Context) {

--- a/cli/internal/video/service.go
+++ b/cli/internal/video/service.go
@@ -81,7 +81,7 @@ func (s *Service) Run(ctx context.Context) error {
 	sem := make(chan struct{}, s.config.MaxConcurrentOrDefault())
 	var wg sync.WaitGroup
 
-	// Subscribe with queue group for future multi-instance support
+	// Subscribe with queue group for future multi-server support
 	sub, err := s.nc.QueueSubscribe(core.SubjectVideoProcess, "video-workers", func(msg *nats.Msg) {
 		var req ProcessRequest
 		if err := json.Unmarshal(msg.Data, &req); err != nil {


### PR DESCRIPTION
## Summary

Cosmetic cleanup of the lowercase 'instance' tokens left over after the Instance→Server rename (#528), plus a paired URL+signed-URL rename (`/assets/instance/` → `/assets/server/`), a couple of log field key changes (per the project's "log keys are fine" guidance), and an updated package doc for `cli/internal/core/rbac/` describing its now-vestigial multi-tier abstraction. The URL+signed-URL pair is changed in lockstep — the resource ID is part of the HMAC signature, so both `attachments.go` (sign side) and `http_server/assets.go` (verify side) updated together. Frontend doesn't hardcode this URL pattern (backend embeds it in API responses) so no frontend changes were needed. Intentionally left untouched: KV keys (`config.instance`, `instance.logo`), KV bucket names (`INSTANCE_CONFIG`), TOML section/field names (`[bootstrap.instance]`, `instance_id`), role-slug test fixtures in `core/rbac/`, "Go class instance" usages, Phase-5 historical-context comments, and generated files. Net +3 lines across 51 files; lowercase 'instance' Go tokens went from 368 → 161, with the remaining 161 all in the legitimate-keep categories.

## Test plan

- [ ] Visually confirm server logo / banner / user avatar URLs still load (they now use `/assets/server/` instead of `/assets/instance/`). Existing cached image URLs in browsers will 404 once until the next refresh — expected.
- [ ] CI: full `mise test-cli` green locally with `-count=1` (no cache); no frontend touched so frontend tests unchanged from main.