### PR TITLE
fix(frontend): land scroll at true bottom on room entry

### DIFF
--- a/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -562,7 +562,7 @@
   }
 </script>
 
-<div class="relative flex min-h-0 min-w-0 flex-1 flex-col">
+<div class="relative flex min-h-0 min-w-0 flex-1 flex-col pb-2">
   <!-- Gradient fade overlay at top -->
   <div
     class="pointer-events-none absolute inset-x-0 top-0 z-10 h-8 bg-linear-to-b from-background/60 to-transparent"
@@ -593,7 +593,7 @@
     onwheel={markUserScrollIntent}
     ontouchmove={markUserScrollIntent}
   >
-    <div class="mt-auto pb-2">
+    <div class="mt-auto">
       {#if !isLoading && virtualItems.length === 0}
         <div class="flex flex-1 items-center justify-center">
           <div class="py-4 text-sm text-muted/40">{emptyMessage}</div>


### PR DESCRIPTION
## Summary

- Moves the `pb-2` breathing room above the composer from inside the message scroll container to EventList's outer wrapper, so it no longer adds 8px to virtua's `scrollHeight`.

## Context

After #524 (scroll fade overlays), entering or switching rooms left the message list ~8px short of the true scroll bottom, causing the bottom fade to appear spuriously and confusing sticky-scroll heuristics. The cause was the `pb-2` living *inside* the scroller: virtua's `scrollToIndex(last, { align: 'end' })` aligns the last item's bottom with the viewport, leaving the 8px of padding past virtua's tracked content as residual scrollable space, which then tripped `ScrollFader`'s 1px "at bottom" threshold. Moving the padding outside preserves the visual breathing room while letting virtua land at the true bottom.

## Test plan

- [ ] Enter a room cold — bottom fade should not appear and there should be no visible offset above the composer's top edge.
- [ ] Switch between rooms — same.
- [ ] Post a message while at the bottom — fade stays hidden, new-message arrival doesn't flash the fade.