### PR TITLE
fix(frontend): keep bottom sheet open on Android keyboard cancel event

### DIFF
--- a/frontend/src/lib/ui/BottomSheet.svelte
+++ b/frontend/src/lib/ui/BottomSheet.svelte
@@ -62,8 +62,15 @@
   onclose={handleNativeClose}
   oncancel={(e) => {
     e.preventDefault();
-    // On Android, the virtual keyboard appearance can fire a spurious cancel event.
-    // Don't close if an input/textarea inside the dialog currently has focus.
+    // On Android Chrome, the virtual keyboard appearance fires a spurious
+    // cancel event on the dialog. If the most recent pointerdown landed inside
+    // the sheet content (e.g. the user just tapped an input), this cancel is
+    // the keyboard race — not a real dismiss intent. The focus check below
+    // isn't enough on its own because the cancel arrives before focus has
+    // transferred to the tapped input.
+    if (pointerDownInsideContent) return;
+    // Also keep the focus-based guard for the Escape-key path with an input
+    // already focused inside the sheet (external keyboard, or stale flag).
     const active = document.activeElement;
     if (active && dialogEl?.contains(active) && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA')) {
       return;


### PR DESCRIPTION
## Summary
- Fixes the residual mobile bug where tapping the emoji picker's search input still closed the bottom sheet, even after #525.
- #525 only patched the backdrop-click path; the sheet's other close path — the `<dialog>`'s native `cancel` event, which Android Chrome fires when the soft keyboard appears — was untouched. The existing `activeElement` guard there fails because the `cancel` event arrives before focus transfers to the tapped input.
- Reuses the `pointerDownInsideContent` flag from #525 inside `oncancel`: a recent pointerdown inside the sheet content means this `cancel` is the keyboard race, not a dismiss intent.

## Test plan
- [ ] Mobile Chrome PWA (Android): open the full emoji picker, tap the search input — sheet stays open, keyboard appears, search works.
- [ ] Mobile: tap the backdrop above the sheet — sheet closes.
- [ ] Mobile: drag handle / swipe-down dismiss still works.
- [ ] Desktop: no regression.