### PR TITLE
fix(frontend): keep Add Server dialog open on mobile

### DIFF
--- a/frontend/src/lib/ui/Dialog.svelte
+++ b/frontend/src/lib/ui/Dialog.svelte
@@ -25,7 +25,12 @@
   let closing = $state(false);
   // True when the current press started inside the content. Prevents a drag
   // that began inside (e.g. text selection) from closing on release outside.
-  let pressStartedInside = false;
+  // Defaults to `true` so a click that reaches the dialog without an observed
+  // pointerdown is treated as "not a backdrop click" and ignored — only a
+  // real pointerdown on the backdrop arms the close path. Required on mobile,
+  // where the sidebar's tap-forwarding (`useSidebarSwipe`) can synthesize a
+  // stray click that bubbles to the dialog right as it opens.
+  let pressStartedInside = true;
 
   // Stable per-instance id for the title (so screen readers announce it
   // when the dialog opens). $props.id() is hydration-safe.
@@ -41,6 +46,7 @@
   $effect(() => {
     if (visible) {
       closing = false;
+      pressStartedInside = true;
       dialogEl?.showModal();
       // showModal() naturally focuses the first focusable element, which
       // for our layout is the Close (X) button in the header — not what

--- a/frontend/src/lib/ui/Dialog.svelte.spec.ts
+++ b/frontend/src/lib/ui/Dialog.svelte.spec.ts
@@ -258,6 +258,41 @@ describe('Dialog', () => {
       expect(dialog.classList.contains('closing')).toBe(false);
     });
 
+    it('ignores a click that arrives without any preceding pointerdown', async () => {
+      // Reproduces the mobile-sidebar tap-forwarding bug (`useSidebarSwipe`):
+      // a click event reaches the dialog right after `showModal()` without a
+      // pointerdown ever hitting the dialog. Default `pressStartedInside =
+      // true` means we treat it as "not a backdrop click" and stay open.
+      const { container } = renderDialog({
+        visible: true,
+        children: testSnippet('<span>Content</span>')
+      });
+
+      const dialog = q(container, 'dialog') as HTMLDialogElement;
+      const content = dialog.firstElementChild as HTMLElement;
+      const rect = content.getBoundingClientRect();
+      const outsideX = rect.right + 20;
+      const outsideY = rect.bottom + 20;
+
+      expect(dialog.open).toBe(true);
+
+      // Click only — no preceding pointerdown anywhere.
+      dialog.dispatchEvent(
+        new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+          detail: 1,
+          clientX: outsideX,
+          clientY: outsideY
+        })
+      );
+
+      await new Promise((r) => setTimeout(r, 200));
+
+      expect(dialog.open).toBe(true);
+      expect(dialog.classList.contains('closing')).toBe(false);
+    });
+
     it('closes when both pointerdown and click are on the backdrop', async () => {
       const { container } = renderDialog({
         visible: true,


### PR DESCRIPTION
## Summary

On mobile, tapping the **Add Server** button briefly opened the dialog and then immediately closed it. The sidebar's tap-forwarding (`useSidebarSwipe` → `panGesture` → `forwardTap`) synthesizes a click chain that reaches the `<dialog>` element right as `showModal()` runs, without any `pointerdown` ever hitting the dialog — which the backdrop-dismiss logic misread as a backdrop click. Defaulting `pressStartedInside` to `true` (and resetting it on open) means only an *observed* pointerdown on the backdrop arms the close path; real backdrop-tap-to-dismiss still works.

## Test plan

- [x] New unit test: dialog stays open when a click arrives without a preceding pointerdown
- [x] Existing Dialog tests still pass (drag-out-of-dialog, real backdrop click, synthetic `detail=0`)
- [x] Manually verified on mobile by the author — Add Server dialog now stays open