### PR TITLE
docs(graphql): correct contradictory position docstrings

### DIFF
--- a/cli/internal/graph/model/models_gen.go
+++ b/cli/internal/graph/model/models_gen.go
@@ -610,7 +610,7 @@ type RoleAcrossTiers struct {
 	Description string `json:"description"`
 	// Whether this is a system role and cannot be deleted.
 	IsSystem bool `json:"isSystem"`
-	// Hierarchy position; lower means higher rank.
+	// Hierarchy position: higher = higher rank. Owner=1000, admin=900, moderator=100, custom roles in 1..99, everyone=0.
 	Position int32 `json:"position"`
 	// Permissions configurable at the deepest requested scope. Use this as the
 	// set of permissions to render in a permission editor for this scope.
@@ -931,7 +931,7 @@ type TierRole struct {
 	Description string `json:"description"`
 	// Whether this is a system role and cannot be deleted.
 	IsSystem bool `json:"isSystem"`
-	// Hierarchy position; lower means higher rank.
+	// Hierarchy position: higher = higher rank. Owner=1000, admin=900, moderator=100, custom roles in 1..99, everyone=0.
 	Position int32 `json:"position"`
 	// Explicit allow/deny at the requested tier. Allow and deny lists may
 	// both be empty for a role with no override at this tier.

--- a/cli/internal/graph/role_permissions.graphqls
+++ b/cli/internal/graph/role_permissions.graphqls
@@ -25,7 +25,7 @@ type RoleAcrossTiers {
   description: String!
   "Whether this is a system role and cannot be deleted."
   isSystem: Boolean!
-  "Hierarchy position; lower means higher rank."
+  "Hierarchy position: higher = higher rank. Owner=1000, admin=900, moderator=100, custom roles in 1..99, everyone=0."
   position: Int!
   """
   Permissions configurable at the deepest requested scope. Use this as the
@@ -53,7 +53,7 @@ type TierRole {
   description: String!
   "Whether this is a system role and cannot be deleted."
   isSystem: Boolean!
-  "Hierarchy position; lower means higher rank."
+  "Hierarchy position: higher = higher rank. Owner=1000, admin=900, moderator=100, custom roles in 1..99, everyone=0."
   position: Int!
   """
   Explicit allow/deny at the requested tier. Allow and deny lists may


### PR DESCRIPTION
## Summary

`RoleAcrossTiers.position` and `TierRole.position` in `role_permissions.graphqls` documented the field as "lower means higher rank", contradicting both `Role.position` in `server_rbac.graphqls` and the resolver (which uses higher = higher rank: `owner=1000`, `admin=900`, …, `everyone=0`).

Aligned both docstrings with the canonical wording.

## Test plan

- [x] `go generate ./internal/graph/...` regenerates only the matching Go doc-comments in `models_gen.go`
- [x] `go build ./...` passes
- [x] CI green

Closes #534. Part of #533.