### PR TITLE
docs(graphql): describe VideoProcessingStatus enum values

### DIFF
--- a/cli/internal/graph/events.graphqls
+++ b/cli/internal/graph/events.graphqls
@@ -655,8 +655,12 @@ type VideoVariant {
 
 "Status of video processing."
 enum VideoProcessingStatus {
+  "Upload received and queued for processing; no transcoded variants yet."
   PENDING
+  "Currently transcoding; the video is not yet playable."
   PROCESSING
+  "Transcoding finished; at least one variant is available for playback."
   COMPLETED
+  "Transcoding failed; `errorMessage` describes the failure and no variants are available."
   FAILED
 }

--- a/cli/internal/graph/model/models_gen.go
+++ b/cli/internal/graph/model/models_gen.go
@@ -1576,10 +1576,14 @@ func (e UserPermissionScopeKind) MarshalJSON() ([]byte, error) {
 type VideoProcessingStatus string
 
 const (
-	VideoProcessingStatusPending    VideoProcessingStatus = "PENDING"
+	// Upload received and queued for processing; no transcoded variants yet.
+	VideoProcessingStatusPending VideoProcessingStatus = "PENDING"
+	// Currently transcoding; the video is not yet playable.
 	VideoProcessingStatusProcessing VideoProcessingStatus = "PROCESSING"
-	VideoProcessingStatusCompleted  VideoProcessingStatus = "COMPLETED"
-	VideoProcessingStatusFailed     VideoProcessingStatus = "FAILED"
+	// Transcoding finished; at least one variant is available for playback.
+	VideoProcessingStatusCompleted VideoProcessingStatus = "COMPLETED"
+	// Transcoding failed; `errorMessage` describes the failure and no variants are available.
+	VideoProcessingStatusFailed VideoProcessingStatus = "FAILED"
 )
 
 var AllVideoProcessingStatus = []VideoProcessingStatus{


### PR DESCRIPTION
## Summary

`VideoProcessingStatus` was the only enum in the schema with undocumented values. Per `.claude/rules/graphql.md`, every enum value must have a description. Added one-sentence descriptions to PENDING / PROCESSING / COMPLETED / FAILED.

## Test plan

- [x] `go generate ./internal/graph/...` regenerates only the matching Go const doc-comments
- [x] `go build ./...` passes
- [x] CI green

Closes #547. Part of #533.