### PR TITLE
docs(graphql): fix stale subject/subscription names in event docs

### DIFF
--- a/cli/internal/graph/events.graphqls
+++ b/cli/internal/graph/events.graphqls
@@ -6,7 +6,12 @@ Events are either:
 - Published to NATS Core for real-time updates — live events
 
 Authorization is determined by NATS subject:
-- Room events: room.{roomId}.> (JetStream) or live.room.{roomId}.> (NATS Core)
+- Persisted room events: `server.room.{kind}.{roomId}.>` (JetStream)
+- Live room events: `live.server.room.{kind}.{roomId}.>` (NATS Core; the
+  `SERVER_EVENTS` stream's RePublish also forwards persisted events here).
+
+`{kind}` is `channel` or `dm`. See `.claude/rules/nats-subjects.md` for the
+full subject taxonomy.
 """
 type RoomEvent {
   "Universal event identifier."
@@ -60,15 +65,15 @@ union RoomEventType =
   | CallParticipantLeftEvent
 
 """
-ServerEvent wraps any event delivered through the `myServerEvents`
-subscription. Two backend streams flow into this single envelope:
+ServerEvent wraps any event delivered through the `myEvents` subscription.
+Two backend streams flow into this single envelope:
 
 - Room-scoped events (messages, room lifecycle, typing, presence, reactions,
-  video processing, voice calls) — sourced from the SERVER_EVENTS JetStream
-  and the live.server.room.>/live.server.member.> NATS-Core subjects.
+  video processing, voice calls) — sourced from the `SERVER_EVENTS` JetStream
+  and the `live.server.room.>` / `live.server.member.>` NATS-Core subjects.
 - Deployment-scoped events (config changes, notifications, server lifecycle,
   thread-follow sync, session termination) — sourced from
-  live.server.{user,space,config}.>.
+  `live.server.{user,config,member}.>`.
 """
 type ServerEvent {
   "Universal event identifier."


### PR DESCRIPTION
## Summary

The `RoomEvent` and `ServerEvent` type-level docstrings in `events.graphqls` documented obsolete plumbing:

- `RoomEvent` listed pre-rename subjects (`room.{roomId}.>`, `live.room.{roomId}.>`). Actual patterns are `server.room.{kind}.{roomId}.>` and `live.server.room.{kind}.{roomId}.>`.
- `ServerEvent` referenced a `myServerEvents` subscription that doesn't exist — the live subscription is `myEvents` (see `subscription.graphqls`).
- `ServerEvent` also listed `live.server.{user,space,config}.>` as the scopes, but the resolver uses `{user,config,member}` (per `.claude/rules/backend.md` and `nats-subjects.md`).

Documentation-only change. Doesn't affect generated Go since type-level descriptions aren't surfaced in `models_gen.go`.

## Test plan

- [x] `go generate ./internal/graph/...` produces no further diff (type docstrings aren't emitted into Go)
- [x] CI green

Closes #545. Part of #533.