### PR TITLE
docs(graphql): replace stale "instance" vocabulary with "server"

### DIFF
--- a/cli/internal/graph/events.graphqls
+++ b/cli/internal/graph/events.graphqls
@@ -140,15 +140,15 @@ union ServerEventType =
   | HeartbeatEvent
 
 # ==============================================================================
-# INSTANCE CONFIG EVENTS
+# SERVER CONFIG EVENTS
 # ==============================================================================
 
 """
 Event: Server configuration was updated.
-Clients should refetch instance info to get the new values.
+Clients should refetch server info to get the new values.
 """
 type ServerConfigUpdatedEvent {
-  "The updated instance name."
+  "The updated server name."
   serverName: String!
   "The updated MOTD (null if cleared)."
   motd: String
@@ -452,7 +452,7 @@ type VideoProcessingCompletedEvent {
 """
 Event: A user's presence status changed.
 The user whose presence changed is identified by the parent RoomEvent's actorId/actor.
-Presence is instance-wide.
+Presence is server-wide.
 """
 type PresenceChangedEvent {
   "The user's new presence status."

--- a/cli/internal/graph/model/models_gen.go
+++ b/cli/internal/graph/model/models_gen.go
@@ -854,7 +854,7 @@ type ServerConfig struct {
 	Description *string `json:"description,omitempty"`
 }
 
-// Paginated list of instance members with metadata.
+// Paginated list of server members with metadata.
 type ServerMembersConnection struct {
 	// The users who are members of this server.
 	Users []*corev1.User `json:"users"`

--- a/cli/internal/graph/mutation.graphqls
+++ b/cli/internal/graph/mutation.graphqls
@@ -25,19 +25,19 @@ type Mutation {
   "Post a message to a room. Automatically marks the room as read since the user is viewing it."
   postMessage(input: PostMessageInput!): RoomEvent!
 
-  "Update the server's name. Requires admin.instance.manage permission."
+  "Update the server's name. Requires server.manage permission."
   updateServer(input: UpdateServerInput!): Server!
 
-  "Upload a logo for the server. Requires admin.instance.manage permission."
+  "Upload a logo for the server. Requires server.manage permission."
   uploadServerLogo(input: UploadServerLogoInput!): Server!
 
-  "Delete the server logo. Requires admin.instance.manage permission."
+  "Delete the server logo. Requires server.manage permission."
   deleteServerLogo: Server!
 
-  "Upload a banner for the server. Requires admin.instance.manage permission."
+  "Upload a banner for the server. Requires server.manage permission."
   uploadServerBanner(input: UploadServerBannerInput!): Server!
 
-  "Delete the server banner. Requires admin.instance.manage permission."
+  "Delete the server banner. Requires server.manage permission."
   deleteServerBanner: Server!
 
   "Join the specified room."

--- a/cli/internal/graph/notification_level.graphqls
+++ b/cli/internal/graph/notification_level.graphqls
@@ -1,14 +1,14 @@
 # ============================================================================
 # Notification Level Settings
 #
-# Per-instance and per-room notification preferences for users.
+# Per-server and per-room notification preferences for users.
 # ============================================================================
 
 """
 Controls how a user receives notifications for the server or a room.
 """
 enum NotificationLevel {
-  "Use inherited default (instance default for rooms, NORMAL for instance)."
+  "Use inherited default (server-level default for rooms, NORMAL for the server)."
   DEFAULT
   "Suppress all notifications and unread markers."
   MUTED

--- a/cli/internal/graph/server_members.graphqls
+++ b/cli/internal/graph/server_members.graphqls
@@ -1,4 +1,4 @@
-"Paginated list of instance members with metadata."
+"Paginated list of server members with metadata."
 type ServerMembersConnection {
   "The users who are members of this server."
   users: [User!]!


### PR DESCRIPTION
## Summary

Several `*.graphqls` docstrings still referenced the pre-rename "instance" concept and the obsolete `admin.instance.manage` permission name. Replaced them with the current wording.

Notable: the four logo/banner mutations in `mutation.graphqls` documented `admin.instance.manage` as their required permission, but the resolver actually checks `server.manage` (see `cli/internal/core/permission.go:42`, `cli/internal/graph/admin.resolvers.go`). Docstring-only change — behaviour was already correct.

Other touched files:
- `notification_level.graphqls` — header banner + `NotificationLevel.DEFAULT` description.
- `server_members.graphqls` — `ServerMembersConnection` description.
- `events.graphqls` — `ServerConfigUpdatedEvent` description and field docs; `PresenceChangedEvent` wording; SERVER CONFIG EVENTS banner.

## Test plan

- [x] `go generate ./internal/graph/...` regenerates only the matching doc-comment in `models_gen.go`
- [x] `go build ./...` passes
- [x] CI green

Closes #550. Part of #533.