### PR TITLE
refactor(graphql)!: rename role to roleName in permission inputs

### DIFF
--- a/cli/internal/graph/generated.go
+++ b/cli/internal/graph/generated.go
@@ -25413,20 +25413,20 @@ func (ec *executionContext) unmarshalInputClearPermissionStateInput(ctx context.
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"role", "permission"}
+	fieldsInOrder := [...]string{"roleName", "permission"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "role":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("role"))
+		case "roleName":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("roleName"))
 			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Role = data
+			it.RoleName = data
 		case "permission":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permission"))
 			data, err := ec.unmarshalNString2string(ctx, v)
@@ -25447,7 +25447,7 @@ func (ec *executionContext) unmarshalInputClearRoomPermissionInput(ctx context.C
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"roomId", "role", "permission"}
+	fieldsInOrder := [...]string{"roomId", "roleName", "permission"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -25461,13 +25461,13 @@ func (ec *executionContext) unmarshalInputClearRoomPermissionInput(ctx context.C
 				return it, err
 			}
 			it.RoomID = data
-		case "role":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("role"))
+		case "roleName":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("roleName"))
 			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Role = data
+			it.RoleName = data
 		case "permission":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permission"))
 			data, err := ec.unmarshalNString2string(ctx, v)
@@ -25849,20 +25849,20 @@ func (ec *executionContext) unmarshalInputDenyPermissionInput(ctx context.Contex
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"role", "permission"}
+	fieldsInOrder := [...]string{"roleName", "permission"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "role":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("role"))
+		case "roleName":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("roleName"))
 			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Role = data
+			it.RoleName = data
 		case "permission":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permission"))
 			data, err := ec.unmarshalNString2string(ctx, v)
@@ -25883,7 +25883,7 @@ func (ec *executionContext) unmarshalInputDenyRoomPermissionInput(ctx context.Co
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"roomId", "role", "permission"}
+	fieldsInOrder := [...]string{"roomId", "roleName", "permission"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -25897,13 +25897,13 @@ func (ec *executionContext) unmarshalInputDenyRoomPermissionInput(ctx context.Co
 				return it, err
 			}
 			it.RoomID = data
-		case "role":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("role"))
+		case "roleName":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("roleName"))
 			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Role = data
+			it.RoleName = data
 		case "permission":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permission"))
 			data, err := ec.unmarshalNString2string(ctx, v)
@@ -26074,20 +26074,20 @@ func (ec *executionContext) unmarshalInputGrantPermissionInput(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"role", "permission"}
+	fieldsInOrder := [...]string{"roleName", "permission"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "role":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("role"))
+		case "roleName":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("roleName"))
 			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Role = data
+			it.RoleName = data
 		case "permission":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permission"))
 			data, err := ec.unmarshalNString2string(ctx, v)
@@ -26108,7 +26108,7 @@ func (ec *executionContext) unmarshalInputGrantRoomPermissionInput(ctx context.C
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"roomId", "role", "permission"}
+	fieldsInOrder := [...]string{"roomId", "roleName", "permission"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -26122,13 +26122,13 @@ func (ec *executionContext) unmarshalInputGrantRoomPermissionInput(ctx context.C
 				return it, err
 			}
 			it.RoomID = data
-		case "role":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("role"))
+		case "roleName":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("roleName"))
 			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Role = data
+			it.RoleName = data
 		case "permission":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permission"))
 			data, err := ec.unmarshalNString2string(ctx, v)
@@ -26743,20 +26743,20 @@ func (ec *executionContext) unmarshalInputRevokePermissionInput(ctx context.Cont
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"role", "permission"}
+	fieldsInOrder := [...]string{"roleName", "permission"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "role":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("role"))
+		case "roleName":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("roleName"))
 			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Role = data
+			it.RoleName = data
 		case "permission":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permission"))
 			data, err := ec.unmarshalNString2string(ctx, v)

--- a/cli/internal/graph/message_authorship_test.go
+++ b/cli/internal/graph/message_authorship_test.go
@@ -122,7 +122,7 @@ func TestRoomManageOpensPerRoomPermissionEditor(t *testing.T) {
 	input := func(roomID string) model.GrantRoomPermissionInput {
 		return model.GrantRoomPermissionInput{
 			RoomID:     roomID,
-			Role:       core.RoleEveryone,
+			RoleName:   core.RoleEveryone,
 			Permission: string(core.PermMessageReact),
 		}
 	}

--- a/cli/internal/graph/model/models_gen.go
+++ b/cli/internal/graph/model/models_gen.go
@@ -163,7 +163,7 @@ type CallParticipant struct {
 // Input for clearing permission state on a role.
 type ClearPermissionStateInput struct {
 	// The role to clear permission state for.
-	Role string `json:"role"`
+	RoleName string `json:"roleName"`
 	// The permission identifier to clear.
 	Permission string `json:"permission"`
 }
@@ -173,7 +173,7 @@ type ClearRoomPermissionInput struct {
 	// The ID of the room.
 	RoomID string `json:"roomId"`
 	// The role to clear the permission for.
-	Role string `json:"role"`
+	RoleName string `json:"roleName"`
 	// The permission identifier to clear.
 	Permission string `json:"permission"`
 }
@@ -286,7 +286,7 @@ type DeleteRoomGroupInput struct {
 // Input for denying a permission for a role.
 type DenyPermissionInput struct {
 	// The role to deny the permission for.
-	Role string `json:"role"`
+	RoleName string `json:"roleName"`
 	// The permission identifier to deny.
 	Permission string `json:"permission"`
 }
@@ -296,7 +296,7 @@ type DenyRoomPermissionInput struct {
 	// The ID of the room.
 	RoomID string `json:"roomId"`
 	// The role to deny the permission for.
-	Role string `json:"role"`
+	RoleName string `json:"roleName"`
 	// The permission identifier to deny.
 	Permission string `json:"permission"`
 }
@@ -341,7 +341,7 @@ type FollowThreadInput struct {
 // Input for granting a permission to a role.
 type GrantPermissionInput struct {
 	// The role to grant the permission to.
-	Role string `json:"role"`
+	RoleName string `json:"roleName"`
 	// The permission identifier to grant.
 	Permission string `json:"permission"`
 }
@@ -351,7 +351,7 @@ type GrantRoomPermissionInput struct {
 	// The ID of the room.
 	RoomID string `json:"roomId"`
 	// The role to grant the permission to.
-	Role string `json:"role"`
+	RoleName string `json:"roleName"`
 	// The permission identifier to grant.
 	Permission string `json:"permission"`
 }
@@ -584,7 +584,7 @@ type ReorderRoomsInGroupInput struct {
 // Input for revoking a permission from a role.
 type RevokePermissionInput struct {
 	// The role to revoke the permission from.
-	Role string `json:"role"`
+	RoleName string `json:"roleName"`
 	// The permission identifier to revoke.
 	Permission string `json:"permission"`
 }

--- a/cli/internal/graph/server_rbac.graphqls
+++ b/cli/internal/graph/server_rbac.graphqls
@@ -235,7 +235,7 @@ Input for granting a permission to a role.
 """
 input GrantPermissionInput {
   "The role to grant the permission to."
-  role: String!
+  roleName: String!
   "The permission identifier to grant."
   permission: String!
 }
@@ -245,7 +245,7 @@ Input for revoking a permission from a role.
 """
 input RevokePermissionInput {
   "The role to revoke the permission from."
-  role: String!
+  roleName: String!
   "The permission identifier to revoke."
   permission: String!
 }
@@ -255,7 +255,7 @@ Input for denying a permission for a role.
 """
 input DenyPermissionInput {
   "The role to deny the permission for."
-  role: String!
+  roleName: String!
   "The permission identifier to deny."
   permission: String!
 }
@@ -265,7 +265,7 @@ Input for clearing permission state on a role.
 """
 input ClearPermissionStateInput {
   "The role to clear permission state for."
-  role: String!
+  roleName: String!
   "The permission identifier to clear."
   permission: String!
 }

--- a/cli/internal/graph/server_rbac.resolvers.go
+++ b/cli/internal/graph/server_rbac.resolvers.go
@@ -127,7 +127,7 @@ func (r *mutationResolver) GrantPermission(ctx context.Context, input model.Gran
 	if !can {
 		return false, core.ErrPermissionDenied
 	}
-	if err := r.core.GrantServerPermission(ctx, input.Role, core.Permission(input.Permission)); err != nil {
+	if err := r.core.GrantServerPermission(ctx, input.RoleName, core.Permission(input.Permission)); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -146,7 +146,7 @@ func (r *mutationResolver) RevokePermission(ctx context.Context, input model.Rev
 	if !can {
 		return false, core.ErrPermissionDenied
 	}
-	if err := r.core.RevokeServerPermission(ctx, input.Role, core.Permission(input.Permission)); err != nil {
+	if err := r.core.RevokeServerPermission(ctx, input.RoleName, core.Permission(input.Permission)); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -165,7 +165,7 @@ func (r *mutationResolver) DenyPermission(ctx context.Context, input model.DenyP
 	if !can {
 		return false, core.ErrPermissionDenied
 	}
-	if err := r.core.DenyServerPermission(ctx, input.Role, core.Permission(input.Permission)); err != nil {
+	if err := r.core.DenyServerPermission(ctx, input.RoleName, core.Permission(input.Permission)); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -184,7 +184,7 @@ func (r *mutationResolver) ClearPermissionState(ctx context.Context, input model
 	if !can {
 		return false, core.ErrPermissionDenied
 	}
-	if err := r.core.ClearServerPermissionState(ctx, input.Role, core.Permission(input.Permission)); err != nil {
+	if err := r.core.ClearServerPermissionState(ctx, input.RoleName, core.Permission(input.Permission)); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/cli/internal/graph/server_rbac_extra.graphqls
+++ b/cli/internal/graph/server_rbac_extra.graphqls
@@ -110,7 +110,7 @@ input GrantRoomPermissionInput {
   "The ID of the room."
   roomId: ID!
   "The role to grant the permission to."
-  role: String!
+  roleName: String!
   "The permission identifier to grant."
   permission: String!
 }
@@ -122,7 +122,7 @@ input DenyRoomPermissionInput {
   "The ID of the room."
   roomId: ID!
   "The role to deny the permission for."
-  role: String!
+  roleName: String!
   "The permission identifier to deny."
   permission: String!
 }
@@ -134,7 +134,7 @@ input ClearRoomPermissionInput {
   "The ID of the room."
   roomId: ID!
   "The role to clear the permission for."
-  role: String!
+  roleName: String!
   "The permission identifier to clear."
   permission: String!
 }

--- a/cli/internal/graph/server_rbac_extra.resolvers.go
+++ b/cli/internal/graph/server_rbac_extra.resolvers.go
@@ -25,7 +25,7 @@ func (r *mutationResolver) GrantRoomPermission(ctx context.Context, input model.
 		return false, err
 	}
 
-	if err := r.core.GrantRoomPermission(ctx, input.RoomID, input.Role, core.Permission(input.Permission)); err != nil {
+	if err := r.core.GrantRoomPermission(ctx, input.RoomID, input.RoleName, core.Permission(input.Permission)); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -41,7 +41,7 @@ func (r *mutationResolver) DenyRoomPermission(ctx context.Context, input model.D
 		return false, err
 	}
 
-	if err := r.core.DenyRoomPermission(ctx, input.RoomID, input.Role, core.Permission(input.Permission)); err != nil {
+	if err := r.core.DenyRoomPermission(ctx, input.RoomID, input.RoleName, core.Permission(input.Permission)); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -57,7 +57,7 @@ func (r *mutationResolver) ClearRoomPermission(ctx context.Context, input model.
 		return false, err
 	}
 
-	if err := r.core.ClearRoomPermissionState(ctx, input.RoomID, input.Role, core.Permission(input.Permission)); err != nil {
+	if err := r.core.ClearRoomPermissionState(ctx, input.RoomID, input.RoleName, core.Permission(input.Permission)); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/frontend/e2e/admin.test.ts
+++ b/frontend/e2e/admin.test.ts
@@ -223,7 +223,7 @@ test.describe('Admin Granular Permissions', () => {
         await page.request.post('/api/graphql', {
           headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
           data: {
-            query: `mutation { revokePermission(input: {role: "everyone", permission: "${permission}"}) }`
+            query: `mutation { revokePermission(input: {roleName: "everyone", permission: "${permission}"}) }`
           }
         });
       } catch {
@@ -743,7 +743,7 @@ test.describe('Instance Role Permission Denials', () => {
 					mutation DenyInstancePermission($input: DenyPermissionInput!) { denyPermission(input: $input)
 					}
 				`,
-        variables: { input: { role: roleName, permission: 'dm.write' } }
+        variables: { input: { roleName, permission: 'dm.write' } }
       }
     });
     expect(denyResponse.ok()).toBeTruthy();

--- a/frontend/e2e/fixtures/testUser.ts
+++ b/frontend/e2e/fixtures/testUser.ts
@@ -119,7 +119,7 @@ export async function grantPermission(
 				mutation GrantInstancePermission($input: GrantPermissionInput!) { grantPermission(input: $input)
 				}
 			`,
-      variables: { input: { role, permission } }
+      variables: { input: { roleName: role, permission } }
     }
   });
 
@@ -147,7 +147,7 @@ export async function revokePermission(
 				mutation RevokeInstancePermission($input: RevokePermissionInput!) { revokePermission(input: $input)
 				}
 			`,
-      variables: { input: { role, permission } }
+      variables: { input: { roleName: role, permission } }
     }
   });
 
@@ -176,7 +176,7 @@ export async function denyPermission(
 				mutation DenyInstancePermission($input: DenyPermissionInput!) { denyPermission(input: $input)
 				}
 			`,
-      variables: { input: { role, permission } }
+      variables: { input: { roleName: role, permission } }
     }
   });
 
@@ -205,7 +205,7 @@ export async function clearInstancePermissionState(
 				mutation ClearServerPermissionState($input: ClearPermissionStateInput!) { clearPermissionState(input: $input)
 				}
 			`,
-      variables: { input: { role, permission } }
+      variables: { input: { roleName: role, permission } }
     }
   });
 

--- a/frontend/e2e/room-permissions.test.ts
+++ b/frontend/e2e/room-permissions.test.ts
@@ -123,7 +123,7 @@ async function denyPermission(
     headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
     data: {
       query: `mutation($input: DenyPermissionInput!) { denyPermission(input: $input) }`,
-      variables: { input: { role, permission } }
+      variables: { input: { roleName: role, permission } }
     }
   });
   expect(resp.ok()).toBeTruthy();
@@ -139,7 +139,7 @@ async function revokePermission(
     headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
     data: {
       query: `mutation($input: RevokePermissionInput!) { revokePermission(input: $input) }`,
-      variables: { input: { role, permission } }
+      variables: { input: { roleName: role, permission } }
     }
   });
   expect(resp.ok()).toBeTruthy();
@@ -158,7 +158,7 @@ async function grantRoomPermission(
       query: `mutation($input: GrantRoomPermissionInput!) {
 				grantRoomPermission(input: $input)
 			}`,
-      variables: { input: { roomId, role, permission } }
+      variables: { input: { roomId, roleName: role, permission } }
     }
   });
   expect(resp.ok()).toBeTruthy();
@@ -177,7 +177,7 @@ async function denyRoomPermission(
       query: `mutation($input: DenyRoomPermissionInput!) {
 				denyRoomPermission(input: $input)
 			}`,
-      variables: { input: { roomId, role, permission } }
+      variables: { input: { roomId, roleName: role, permission } }
     }
   });
   expect(resp.ok()).toBeTruthy();

--- a/frontend/e2e/space-roles.test.ts
+++ b/frontend/e2e/space-roles.test.ts
@@ -181,7 +181,7 @@ async function grantPermission(
 					grantPermission(input: $input)
 				}
 			`,
-      variables: { input: { role, permission } }
+      variables: { input: { roleName: role, permission } }
     }
   });
 
@@ -209,7 +209,7 @@ async function _revokePermission(
 					revokePermission(input: $input)
 				}
 			`,
-      variables: { input: { role, permission } }
+      variables: { input: { roleName: role, permission } }
     }
   });
 
@@ -238,7 +238,7 @@ async function denyPermission(
 					denyPermission(input: $input)
 				}
 			`,
-      variables: { input: { role, permission } }
+      variables: { input: { roleName: role, permission } }
     }
   });
 

--- a/frontend/e2e/space-settings-nav.test.ts
+++ b/frontend/e2e/space-settings-nav.test.ts
@@ -105,7 +105,7 @@ async function grantPermission(
 					grantPermission(input: $input)
 				}
 			`,
-      variables: { input: { role, permission } }
+      variables: { input: { roleName: role, permission } }
     }
   });
 

--- a/frontend/src/lib/components/rbac/permissionMutations.ts
+++ b/frontend/src/lib/components/rbac/permissionMutations.ts
@@ -64,7 +64,7 @@ export async function setRolePermission(
   if (scope.tier === 'room') {
     const input = {
       roomId: scope.roomId,
-      role: scope.roleName,
+      roleName: scope.roleName,
       permission
     };
     if (newState === 'allow') {
@@ -101,7 +101,7 @@ export async function setRolePermission(
   }
 
   // Server scope.
-  const input = { role: scope.roleName, permission };
+  const input = { roleName: scope.roleName, permission };
   if (newState === 'allow') {
     const r = await client.mutation(
       graphql(`

--- a/frontend/src/lib/gql/graphql.ts
+++ b/frontend/src/lib/gql/graphql.ts
@@ -295,7 +295,7 @@ export type ClearPermissionStateInput = {
   /** The permission identifier to clear. */
   permission: Scalars['String']['input'];
   /** The role to clear permission state for. */
-  role: Scalars['String']['input'];
+  roleName: Scalars['String']['input'];
 };
 
 /** Input for clearing a room-level permission override. */
@@ -303,7 +303,7 @@ export type ClearRoomPermissionInput = {
   /** The permission identifier to clear. */
   permission: Scalars['String']['input'];
   /** The role to clear the permission for. */
-  role: Scalars['String']['input'];
+  roleName: Scalars['String']['input'];
   /** The ID of the room. */
   roomId: Scalars['ID']['input'];
 };
@@ -441,7 +441,7 @@ export type DenyPermissionInput = {
   /** The permission identifier to deny. */
   permission: Scalars['String']['input'];
   /** The role to deny the permission for. */
-  role: Scalars['String']['input'];
+  roleName: Scalars['String']['input'];
 };
 
 /** Input for denying a room-level permission for a role. */
@@ -449,7 +449,7 @@ export type DenyRoomPermissionInput = {
   /** The permission identifier to deny. */
   permission: Scalars['String']['input'];
   /** The role to deny the permission for. */
-  role: Scalars['String']['input'];
+  roleName: Scalars['String']['input'];
   /** The ID of the room. */
   roomId: Scalars['ID']['input'];
 };
@@ -541,7 +541,7 @@ export type GrantPermissionInput = {
   /** The permission identifier to grant. */
   permission: Scalars['String']['input'];
   /** The role to grant the permission to. */
-  role: Scalars['String']['input'];
+  roleName: Scalars['String']['input'];
 };
 
 /** Input for granting a room-level permission to a role. */
@@ -549,7 +549,7 @@ export type GrantRoomPermissionInput = {
   /** The permission identifier to grant. */
   permission: Scalars['String']['input'];
   /** The role to grant the permission to. */
-  role: Scalars['String']['input'];
+  roleName: Scalars['String']['input'];
   /** The ID of the room. */
   roomId: Scalars['ID']['input'];
 };
@@ -1943,7 +1943,7 @@ export type RevokePermissionInput = {
   /** The permission identifier to revoke. */
   permission: Scalars['String']['input'];
   /** The role to revoke the permission from. */
-  role: Scalars['String']['input'];
+  roleName: Scalars['String']['input'];
 };
 
 /** Input for revoking an server role from a user. */
@@ -1992,7 +1992,7 @@ export type RoleAcrossTiers = {
   displayName: Scalars['String']['output'];
   /** Whether this is a system role and cannot be deleted. */
   isSystem: Scalars['Boolean']['output'];
-  /** Hierarchy position; lower means higher rank. */
+  /** Hierarchy position: higher = higher rank. Owner=1000, admin=900, moderator=100, custom roles in 1..99, everyone=0. */
   position: Scalars['Int']['output'];
   /** Internal role name (e.g. 'admin', 'moderator'). */
   roleName: Scalars['String']['output'];
@@ -2875,7 +2875,7 @@ export type TierRole = {
    * both be empty for a role with no override at this tier.
    */
   override: TierPermissions;
-  /** Hierarchy position; lower means higher rank. */
+  /** Hierarchy position: higher = higher rank. Owner=1000, admin=900, moderator=100, custom roles in 1..99, everyone=0. */
   position: Scalars['Int']['output'];
   /** Internal role name (e.g. 'admin', 'moderator'). */
   roleName: Scalars['String']['output'];
@@ -3309,9 +3309,13 @@ export type VideoProcessingCompletedEvent = {
 
 /** Status of video processing. */
 export enum VideoProcessingStatus {
+  /** Transcoding finished; at least one variant is available for playback. */
   Completed = 'COMPLETED',
+  /** Transcoding failed; `errorMessage` describes the failure and no variants are available. */
   Failed = 'FAILED',
+  /** Upload received and queued for processing; no transcoded variants yet. */
   Pending = 'PENDING',
+  /** Currently transcoding; the video is not yet playable. */
   Processing = 'PROCESSING'
 }
 


### PR DESCRIPTION
## Summary

Permission input objects used `role: String!`, but adjacent role-related inputs (`AssignRoleInput`, `RevokeRoleInput`, `AdminQueries.groupRolePermissions(roleName:)`) already used the clearer `roleName: String!`. Standardized on `roleName` everywhere.

Server-scope inputs (`cli/internal/graph/server_rbac.graphqls`):
- `GrantPermissionInput`, `RevokePermissionInput`, `DenyPermissionInput`, `ClearPermissionStateInput`

Room-scope inputs (`cli/internal/graph/server_rbac_extra.graphqls`):
- `GrantRoomPermissionInput`, `DenyRoomPermissionInput`, `ClearRoomPermissionInput`

Resolvers (`server_rbac.resolvers.go`, `server_rbac_extra.resolvers.go`) updated to read `input.RoleName`. Frontend `permissionMutations.ts` updated to send `roleName` in the matrix-cell mutations. One resolver-level test that constructs these inputs (`TestRoomManageOpensPerRoomPermissionEditor`) updated and re-verified locally.

### BREAKING

Any client sending `role` to `grantPermission` / `revokePermission` / `denyPermission` / `clearPermissionState` / `grantRoomPermission` / `denyRoomPermission` / `clearRoomPermission` must switch to `roleName`. Only the admin RBAC UI is affected.

## Test plan

- [x] `go build ./...`
- [x] `go test -tags test_endpoints -run TestRoomManageOpensPerRoomPermissionEditor` passes
- [x] `pnpm svelte-check` reports 0 errors
- [x] CI green

Closes #549. Part of #533.