### PR TITLE
refactor(graphql)!: remove duplicate AdminQueries.userRoles

### DIFF
--- a/cli/internal/graph/generated.go
+++ b/cli/internal/graph/generated.go
@@ -111,7 +111,6 @@ type ComplexityRoot struct {
 		SystemInfo               func(childComplexity int) int
 		UserEffectiveDenials     func(childComplexity int, userID string) int
 		UserEffectivePermissions func(childComplexity int, userID string) int
-		UserRoles                func(childComplexity int, userID string) int
 	}
 
 	AdminServerConfig struct {
@@ -829,7 +828,6 @@ type AdminQueriesResolver interface {
 	Role(ctx context.Context, obj *model.AdminQueries, name string) (*core.RoleWithPermissions, error)
 
 	RoleUsers(ctx context.Context, obj *model.AdminQueries, roleName string) ([]*corev1.User, error)
-	UserRoles(ctx context.Context, obj *model.AdminQueries, userID string) ([]string, error)
 	UserEffectivePermissions(ctx context.Context, obj *model.AdminQueries, userID string) ([]string, error)
 	UserEffectiveDenials(ctx context.Context, obj *model.AdminQueries, userID string) ([]string, error)
 }
@@ -1318,17 +1316,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.AdminQueries.UserEffectivePermissions(childComplexity, args["userId"].(string)), true
-	case "AdminQueries.userRoles":
-		if e.complexity.AdminQueries.UserRoles == nil {
-			break
-		}
-
-		args, err := ec.field_AdminQueries_userRoles_args(ctx, rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.AdminQueries.UserRoles(childComplexity, args["userId"].(string)), true
 
 	case "AdminServerConfig.blockedUsernames":
 		if e.complexity.AdminServerConfig.BlockedUsernames == nil {
@@ -4894,17 +4881,6 @@ func (ec *executionContext) field_AdminQueries_userEffectivePermissions_args(ctx
 	return args, nil
 }
 
-func (ec *executionContext) field_AdminQueries_userRoles_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
-	var err error
-	args := map[string]any{}
-	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "userId", ec.unmarshalNID2string)
-	if err != nil {
-		return nil, err
-	}
-	args["userId"] = arg0
-	return args, nil
-}
-
 func (ec *executionContext) field_Attachment_thumbnailUrl_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -6827,47 +6803,6 @@ func (ec *executionContext) fieldContext_AdminQueries_roleUsers(ctx context.Cont
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_AdminQueries_roleUsers_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _AdminQueries_userRoles(ctx context.Context, field graphql.CollectedField, obj *model.AdminQueries) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		ec.fieldContext_AdminQueries_userRoles,
-		func(ctx context.Context) (any, error) {
-			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.AdminQueries().UserRoles(ctx, obj, fc.Args["userId"].(string))
-		},
-		nil,
-		ec.marshalNString2ᚕstringᚄ,
-		true,
-		true,
-	)
-}
-
-func (ec *executionContext) fieldContext_AdminQueries_userRoles(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "AdminQueries",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_AdminQueries_userRoles_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -14261,8 +14196,6 @@ func (ec *executionContext) fieldContext_Query_admin(_ context.Context, field gr
 				return ec.fieldContext_AdminQueries_serverPermissions(ctx, field)
 			case "roleUsers":
 				return ec.fieldContext_AdminQueries_roleUsers(ctx, field)
-			case "userRoles":
-				return ec.fieldContext_AdminQueries_userRoles(ctx, field)
 			case "userEffectivePermissions":
 				return ec.fieldContext_AdminQueries_userEffectivePermissions(ctx, field)
 			case "userEffectiveDenials":
@@ -28201,42 +28134,6 @@ func (ec *executionContext) _AdminQueries(ctx context.Context, sel ast.Selection
 					}
 				}()
 				res = ec._AdminQueries_roleUsers(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "userRoles":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._AdminQueries_userRoles(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/cli/internal/graph/model/models_gen.go
+++ b/cli/internal/graph/model/models_gen.go
@@ -92,8 +92,6 @@ type AdminQueries struct {
 	ServerPermissions []string `json:"serverPermissions"`
 	// Get users assigned to a specific server role.
 	RoleUsers []*corev1.User `json:"roleUsers"`
-	// Get server roles assigned to a specific user.
-	UserRoles []string `json:"userRoles"`
 	// Get a user's effective allowed permissions at server scope. Combines
 	// role-based grants with user-level overrides (`grantUserPermission` /
 	// `denyUserPermission`) — the same answer the authorization resolver

--- a/cli/internal/graph/server_rbac.graphqls
+++ b/cli/internal/graph/server_rbac.graphqls
@@ -83,9 +83,6 @@ extend type AdminQueries {
   "Get users assigned to a specific server role."
   roleUsers(roleName: String!): [User!]! @goField(forceResolver: true)
 
-  "Get server roles assigned to a specific user."
-  userRoles(userId: ID!): [String!]! @goField(forceResolver: true)
-
   """
   Get a user's effective allowed permissions at server scope. Combines
   role-based grants with user-level overrides (`grantUserPermission` /

--- a/cli/internal/graph/server_rbac.resolvers.go
+++ b/cli/internal/graph/server_rbac.resolvers.go
@@ -60,17 +60,6 @@ func (r *adminQueriesResolver) RoleUsers(ctx context.Context, obj *model.AdminQu
 	return users, nil
 }
 
-// UserRoles is the resolver for the userRoles field.
-func (r *adminQueriesResolver) UserRoles(ctx context.Context, obj *model.AdminQueries, userID string) ([]string, error) {
-	caller := auth.ForContext(ctx)
-	if caller == nil {
-		return nil, fmt.Errorf("authentication required")
-	}
-
-	// No additional authorization - admin context already verified by parent resolver
-	return r.core.GetUserRoles(ctx, userID)
-}
-
 // UserEffectivePermissions is the resolver for the userEffectivePermissions field.
 func (r *adminQueriesResolver) UserEffectivePermissions(ctx context.Context, obj *model.AdminQueries, userID string) ([]string, error) {
 	caller := auth.ForContext(ctx)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -245,7 +245,6 @@ There is no `adminAuditLogEvents` subscription — audit events arrive through `
 | `admin.role(name)`                               | Query     | Get a single role.                                                                           |
 | `admin.serverPermissions`                        | Query     | List every available server permission identifier (catalog).                                 |
 | `admin.roleUsers(roleName)`                      | Query     | List users assigned to a role.                                                               |
-| `admin.userRoles(userId)`                        | Query     | List roles assigned to a user.                                                               |
 | `admin.userEffectivePermissions(userId)`         | Query     | A user's effective allow set at server scope (roles + user overrides combined).              |
 | `admin.userEffectiveDenials(userId)`             | Query     | A user's effective deny set at server scope.                                                 |
 | `admin.groupRolePermissions(groupId, roleName)`  | Query     | Explicit grants and denials for a role on a specific room group.                             |

--- a/frontend/src/lib/gql/graphql.ts
+++ b/frontend/src/lib/gql/graphql.ts
@@ -122,8 +122,6 @@ export type AdminQueries = {
    * produces. For per-decision provenance use the permission explainer.
    */
   userEffectivePermissions: Array<Scalars['String']['output']>;
-  /** Get server roles assigned to a specific user. */
-  userRoles: Array<Scalars['String']['output']>;
 };
 
 
@@ -161,12 +159,6 @@ export type AdminQueriesUserEffectiveDenialsArgs = {
 
 /** Admin-only queries. Returns null if the user is not an server admin. */
 export type AdminQueriesUserEffectivePermissionsArgs = {
-  userId: Scalars['ID']['input'];
-};
-
-
-/** Admin-only queries. Returns null if the user is not an server admin. */
-export type AdminQueriesUserRolesArgs = {
   userId: Scalars['ID']['input'];
 };
 
@@ -928,9 +920,9 @@ export type Mutation = {
    * must move all rooms out first. Requires `role.manage`.
    */
   deleteRoomGroup: Scalars['Boolean']['output'];
-  /** Delete the server banner. Requires admin.instance.manage permission. */
+  /** Delete the server banner. Requires server.manage permission. */
   deleteServerBanner: Server;
-  /** Delete the server logo. Requires admin.instance.manage permission. */
+  /** Delete the server logo. Requires server.manage permission. */
   deleteServerLogo: Server;
   /** Deny a permission on a room group (role or user subject). Requires `role.manage`. */
   denyGroupPermission: Scalars['Boolean']['output'];
@@ -1143,7 +1135,7 @@ export type Mutation = {
   updateRoom: Room;
   /** Update a room group's name/description. Requires `role.manage`. */
   updateRoomGroup: RoomGroup;
-  /** Update the server's name. Requires admin.instance.manage permission. */
+  /** Update the server's name. Requires server.manage permission. */
   updateServer: Server;
   /**
    * Update a user's display settings. Authorization: caller is self, OR
@@ -1158,9 +1150,9 @@ export type Mutation = {
    * user by role hierarchy. Returns the updated user.
    */
   uploadAvatar: User;
-  /** Upload a banner for the server. Requires admin.instance.manage permission. */
+  /** Upload a banner for the server. Requires server.manage permission. */
   uploadServerBanner: Server;
-  /** Upload a logo for the server. Requires admin.instance.manage permission. */
+  /** Upload a logo for the server. Requires server.manage permission. */
   uploadServerLogo: Server;
 };
 
@@ -1568,7 +1560,7 @@ export type NotificationItem = DmMessageNotificationItem | MentionNotificationIt
 export enum NotificationLevel {
   /** Like NORMAL, plus a notification for every new root message. */
   AllMessages = 'ALL_MESSAGES',
-  /** Use inherited default (instance default for rooms, NORMAL for instance). */
+  /** Use inherited default (server-level default for rooms, NORMAL for the server). */
   Default = 'DEFAULT',
   /** Suppress all notifications and unread markers. */
   Muted = 'MUTED',
@@ -1667,7 +1659,7 @@ export type PostMessageInput = {
 /**
  * Event: A user's presence status changed.
  * The user whose presence changed is identified by the parent RoomEvent's actorId/actor.
- * Presence is instance-wide.
+ * Presence is server-wide.
  */
 export type PresenceChangedEvent = {
   __typename?: 'PresenceChangedEvent';
@@ -1992,7 +1984,7 @@ export type RoleAcrossTiers = {
   displayName: Scalars['String']['output'];
   /** Whether this is a system role and cannot be deleted. */
   isSystem: Scalars['Boolean']['output'];
-  /** Hierarchy position; lower means higher rank. */
+  /** Hierarchy position: higher = higher rank. Owner=1000, admin=900, moderator=100, custom roles in 1..99, everyone=0. */
   position: Scalars['Int']['output'];
   /** Internal role name (e.g. 'admin', 'moderator'). */
   roleName: Scalars['String']['output'];
@@ -2204,7 +2196,12 @@ export type RoomDeletedEvent = {
  * - Published to NATS Core for real-time updates — live events
  *
  * Authorization is determined by NATS subject:
- * - Room events: room.{roomId}.> (JetStream) or live.room.{roomId}.> (NATS Core)
+ * - Persisted room events: `server.room.{kind}.{roomId}.>` (JetStream)
+ * - Live room events: `live.server.room.{kind}.{roomId}.>` (NATS Core; the
+ *   `SERVER_EVENTS` stream's RePublish also forwards persisted events here).
+ *
+ * `{kind}` is `channel` or `dm`. See `.claude/rules/nats-subjects.md` for the
+ * full subject taxonomy.
  */
 export type RoomEvent = {
   __typename?: 'RoomEvent';
@@ -2641,7 +2638,7 @@ export type ServerConfigLogoUrlArgs = {
 
 /**
  * Event: Server configuration was updated.
- * Clients should refetch instance info to get the new values.
+ * Clients should refetch server info to get the new values.
  */
 export type ServerConfigUpdatedEvent = {
   __typename?: 'ServerConfigUpdatedEvent';
@@ -2649,22 +2646,22 @@ export type ServerConfigUpdatedEvent = {
   blockedUsernames?: Maybe<Scalars['String']['output']>;
   /** The updated MOTD (null if cleared). */
   motd?: Maybe<Scalars['String']['output']>;
-  /** The updated instance name. */
+  /** The updated server name. */
   serverName: Scalars['String']['output'];
   /** The updated welcome message (null if cleared). */
   welcomeMessage?: Maybe<Scalars['String']['output']>;
 };
 
 /**
- * ServerEvent wraps any event delivered through the `myServerEvents`
- * subscription. Two backend streams flow into this single envelope:
+ * ServerEvent wraps any event delivered through the `myEvents` subscription.
+ * Two backend streams flow into this single envelope:
  *
  * - Room-scoped events (messages, room lifecycle, typing, presence, reactions,
- *   video processing, voice calls) — sourced from the SERVER_EVENTS JetStream
- *   and the live.server.room.>/live.server.member.> NATS-Core subjects.
+ *   video processing, voice calls) — sourced from the `SERVER_EVENTS` JetStream
+ *   and the `live.server.room.>` / `live.server.member.>` NATS-Core subjects.
  * - Deployment-scoped events (config changes, notifications, server lifecycle,
  *   thread-follow sync, session termination) — sourced from
- *   live.server.{user,space,config}.>.
+ *   `live.server.{user,config,member}.>`.
  */
 export type ServerEvent = {
   __typename?: 'ServerEvent';
@@ -2694,7 +2691,7 @@ export type ServerMemberDeletedEvent = {
   userId: Scalars['ID']['output'];
 };
 
-/** Paginated list of instance members with metadata. */
+/** Paginated list of server members with metadata. */
 export type ServerMembersConnection = {
   __typename?: 'ServerMembersConnection';
   /** Whether there are more members beyond this page. */
@@ -2875,7 +2872,7 @@ export type TierRole = {
    * both be empty for a role with no override at this tier.
    */
   override: TierPermissions;
-  /** Hierarchy position; lower means higher rank. */
+  /** Hierarchy position: higher = higher rank. Owner=1000, admin=900, moderator=100, custom roles in 1..99, everyone=0. */
   position: Scalars['Int']['output'];
   /** Internal role name (e.g. 'admin', 'moderator'). */
   roleName: Scalars['String']['output'];
@@ -3309,9 +3306,13 @@ export type VideoProcessingCompletedEvent = {
 
 /** Status of video processing. */
 export enum VideoProcessingStatus {
+  /** Transcoding finished; at least one variant is available for playback. */
   Completed = 'COMPLETED',
+  /** Transcoding failed; `errorMessage` describes the failure and no variants are available. */
   Failed = 'FAILED',
+  /** Upload received and queued for processing; no transcoded variants yet. */
   Pending = 'PENDING',
+  /** Currently transcoding; the video is not yet playable. */
   Processing = 'PROCESSING'
 }
 


### PR DESCRIPTION
## Summary

`AdminQueries.userRoles(userId: ID!): [String!]!` returned the exact same data as `User.roles: [String!]!`, accessible through the standard `user(id:)` query — and `User.roles` is already visible to any authenticated user, so requiring the admin context for `userRoles` was redundant. No frontend or test currently calls `userRoles`.

Removed:

- The field from `cli/internal/graph/server_rbac.graphqls`.
- The `UserRoles` resolver from `cli/internal/graph/server_rbac.resolvers.go`.
- The corresponding row from `docs/ARCHITECTURE.md`.

Generated code (`models_gen.go`, `generated.go`, frontend `gql.ts` / `graphql.ts`) refreshed.

### BREAKING (theoretical only)

A client running

```graphql
query { admin { userRoles(userId: "U…") } }
```

must switch to

```graphql
query { user(id: "U…") { roles } }
```

The data shape is identical. Nothing in this repo was using `userRoles`.

## Test plan

- [x] `go build ./...`
- [x] `pnpm svelte-check` reports 0 errors
- [x] CI green

Closes #546. Part of #533.