### PR TITLE
refactor(graphql)!: drop AdminQueries duplicates of Server role fields

### DIFF
--- a/cli/internal/graph/admin.resolvers.go
+++ b/cli/internal/graph/admin.resolvers.go
@@ -260,17 +260,6 @@ func (r *queryResolver) Admin(ctx context.Context) (*model.AdminQueries, error) 
 		Stats:      stats,
 	}
 
-	// Fetch roles
-	roles, err := r.core.ListServerRoles(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list roles: %w", err)
-	}
-	// Convert to pointer slice for GraphQL
-	roleModels := make([]*core.RoleWithPermissions, len(roles))
-	for i := range roles {
-		roleModels[i] = &roles[i]
-	}
-
 	// Fetch all permissions applicable at server scope
 	// This includes permissions like room.create, message.post that can have server-wide defaults
 	allPerms := core.PermissionsForScope(core.ScopeServer)
@@ -281,7 +270,6 @@ func (r *queryResolver) Admin(ctx context.Context) (*model.AdminQueries, error) 
 
 	return &model.AdminQueries{
 		SystemInfo:        systemInfo,
-		Roles:             roleModels,
 		ServerPermissions: serverPermissionsList,
 	}, nil
 }

--- a/cli/internal/graph/generated.go
+++ b/cli/internal/graph/generated.go
@@ -101,16 +101,11 @@ type ComplexityRoot struct {
 	}
 
 	AdminQueries struct {
-		GroupRolePermissions     func(childComplexity int, groupID string, roleName string) int
-		GroupUserPermissions     func(childComplexity int, groupID string, userID string) int
-		Role                     func(childComplexity int, name string) int
-		RoleUsers                func(childComplexity int, roleName string) int
-		Roles                    func(childComplexity int) int
-		ServerConfig             func(childComplexity int) int
-		ServerPermissions        func(childComplexity int) int
-		SystemInfo               func(childComplexity int) int
-		UserEffectiveDenials     func(childComplexity int, userID string) int
-		UserEffectivePermissions func(childComplexity int, userID string) int
+		GroupRolePermissions func(childComplexity int, groupID string, roleName string) int
+		GroupUserPermissions func(childComplexity int, groupID string, userID string) int
+		ServerConfig         func(childComplexity int) int
+		ServerPermissions    func(childComplexity int) int
+		SystemInfo           func(childComplexity int) int
 	}
 
 	AdminServerConfig struct {
@@ -824,12 +819,6 @@ type AdminQueriesResolver interface {
 	ServerConfig(ctx context.Context, obj *model.AdminQueries) (*model.AdminServerConfig, error)
 	GroupRolePermissions(ctx context.Context, obj *model.AdminQueries, groupID string, roleName string) (*model.RoomGroupRolePermissions, error)
 	GroupUserPermissions(ctx context.Context, obj *model.AdminQueries, groupID string, userID string) (*model.RoomGroupUserPermissions, error)
-
-	Role(ctx context.Context, obj *model.AdminQueries, name string) (*core.RoleWithPermissions, error)
-
-	RoleUsers(ctx context.Context, obj *model.AdminQueries, roleName string) ([]*corev1.User, error)
-	UserEffectivePermissions(ctx context.Context, obj *model.AdminQueries, userID string) ([]string, error)
-	UserEffectiveDenials(ctx context.Context, obj *model.AdminQueries, userID string) ([]string, error)
 }
 type AttachmentResolver interface {
 	Size(ctx context.Context, obj *corev1.Attachment) (int32, error)
@@ -1248,34 +1237,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.AdminQueries.GroupUserPermissions(childComplexity, args["groupId"].(string), args["userId"].(string)), true
-	case "AdminQueries.role":
-		if e.complexity.AdminQueries.Role == nil {
-			break
-		}
-
-		args, err := ec.field_AdminQueries_role_args(ctx, rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.AdminQueries.Role(childComplexity, args["name"].(string)), true
-	case "AdminQueries.roleUsers":
-		if e.complexity.AdminQueries.RoleUsers == nil {
-			break
-		}
-
-		args, err := ec.field_AdminQueries_roleUsers_args(ctx, rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.AdminQueries.RoleUsers(childComplexity, args["roleName"].(string)), true
-	case "AdminQueries.roles":
-		if e.complexity.AdminQueries.Roles == nil {
-			break
-		}
-
-		return e.complexity.AdminQueries.Roles(childComplexity), true
 	case "AdminQueries.serverConfig":
 		if e.complexity.AdminQueries.ServerConfig == nil {
 			break
@@ -1294,28 +1255,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.AdminQueries.SystemInfo(childComplexity), true
-	case "AdminQueries.userEffectiveDenials":
-		if e.complexity.AdminQueries.UserEffectiveDenials == nil {
-			break
-		}
-
-		args, err := ec.field_AdminQueries_userEffectiveDenials_args(ctx, rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.AdminQueries.UserEffectiveDenials(childComplexity, args["userId"].(string)), true
-	case "AdminQueries.userEffectivePermissions":
-		if e.complexity.AdminQueries.UserEffectivePermissions == nil {
-			break
-		}
-
-		args, err := ec.field_AdminQueries_userEffectivePermissions_args(ctx, rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.AdminQueries.UserEffectivePermissions(childComplexity, args["userId"].(string)), true
 
 	case "AdminServerConfig.blockedUsernames":
 		if e.complexity.AdminServerConfig.BlockedUsernames == nil {
@@ -4837,50 +4776,6 @@ func (ec *executionContext) field_AdminQueries_groupUserPermissions_args(ctx con
 	return args, nil
 }
 
-func (ec *executionContext) field_AdminQueries_roleUsers_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
-	var err error
-	args := map[string]any{}
-	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "roleName", ec.unmarshalNString2string)
-	if err != nil {
-		return nil, err
-	}
-	args["roleName"] = arg0
-	return args, nil
-}
-
-func (ec *executionContext) field_AdminQueries_role_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
-	var err error
-	args := map[string]any{}
-	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "name", ec.unmarshalNString2string)
-	if err != nil {
-		return nil, err
-	}
-	args["name"] = arg0
-	return args, nil
-}
-
-func (ec *executionContext) field_AdminQueries_userEffectiveDenials_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
-	var err error
-	args := map[string]any{}
-	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "userId", ec.unmarshalNID2string)
-	if err != nil {
-		return nil, err
-	}
-	args["userId"] = arg0
-	return args, nil
-}
-
-func (ec *executionContext) field_AdminQueries_userEffectivePermissions_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
-	var err error
-	args := map[string]any{}
-	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "userId", ec.unmarshalNID2string)
-	if err != nil {
-		return nil, err
-	}
-	args["userId"] = arg0
-	return args, nil
-}
-
 func (ec *executionContext) field_Attachment_thumbnailUrl_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -6607,108 +6502,6 @@ func (ec *executionContext) fieldContext_AdminQueries_groupUserPermissions(ctx c
 	return fc, nil
 }
 
-func (ec *executionContext) _AdminQueries_roles(ctx context.Context, field graphql.CollectedField, obj *model.AdminQueries) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		ec.fieldContext_AdminQueries_roles,
-		func(ctx context.Context) (any, error) {
-			return obj.Roles, nil
-		},
-		nil,
-		ec.marshalNRole2ᚕᚖhmansᚗdeᚋchattoᚋinternalᚋcoreᚐRoleWithPermissionsᚄ,
-		true,
-		true,
-	)
-}
-
-func (ec *executionContext) fieldContext_AdminQueries_roles(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "AdminQueries",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "name":
-				return ec.fieldContext_Role_name(ctx, field)
-			case "displayName":
-				return ec.fieldContext_Role_displayName(ctx, field)
-			case "description":
-				return ec.fieldContext_Role_description(ctx, field)
-			case "permissions":
-				return ec.fieldContext_Role_permissions(ctx, field)
-			case "permissionDenials":
-				return ec.fieldContext_Role_permissionDenials(ctx, field)
-			case "isSystem":
-				return ec.fieldContext_Role_isSystem(ctx, field)
-			case "position":
-				return ec.fieldContext_Role_position(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Role", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _AdminQueries_role(ctx context.Context, field graphql.CollectedField, obj *model.AdminQueries) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		ec.fieldContext_AdminQueries_role,
-		func(ctx context.Context) (any, error) {
-			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.AdminQueries().Role(ctx, obj, fc.Args["name"].(string))
-		},
-		nil,
-		ec.marshalORole2ᚖhmansᚗdeᚋchattoᚋinternalᚋcoreᚐRoleWithPermissions,
-		true,
-		false,
-	)
-}
-
-func (ec *executionContext) fieldContext_AdminQueries_role(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "AdminQueries",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "name":
-				return ec.fieldContext_Role_name(ctx, field)
-			case "displayName":
-				return ec.fieldContext_Role_displayName(ctx, field)
-			case "description":
-				return ec.fieldContext_Role_description(ctx, field)
-			case "permissions":
-				return ec.fieldContext_Role_permissions(ctx, field)
-			case "permissionDenials":
-				return ec.fieldContext_Role_permissionDenials(ctx, field)
-			case "isSystem":
-				return ec.fieldContext_Role_isSystem(ctx, field)
-			case "position":
-				return ec.fieldContext_Role_position(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Role", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_AdminQueries_role_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _AdminQueries_serverPermissions(ctx context.Context, field graphql.CollectedField, obj *model.AdminQueries) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -6734,159 +6527,6 @@ func (ec *executionContext) fieldContext_AdminQueries_serverPermissions(_ contex
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
 		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _AdminQueries_roleUsers(ctx context.Context, field graphql.CollectedField, obj *model.AdminQueries) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		ec.fieldContext_AdminQueries_roleUsers,
-		func(ctx context.Context) (any, error) {
-			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.AdminQueries().RoleUsers(ctx, obj, fc.Args["roleName"].(string))
-		},
-		nil,
-		ec.marshalNUser2ᚕᚖhmansᚗdeᚋchattoᚋinternalᚋpbᚋchattoᚋcoreᚋv1ᚐUserᚄ,
-		true,
-		true,
-	)
-}
-
-func (ec *executionContext) fieldContext_AdminQueries_roleUsers(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "AdminQueries",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_User_id(ctx, field)
-			case "login":
-				return ec.fieldContext_User_login(ctx, field)
-			case "displayName":
-				return ec.fieldContext_User_displayName(ctx, field)
-			case "createdAt":
-				return ec.fieldContext_User_createdAt(ctx, field)
-			case "avatarUrl":
-				return ec.fieldContext_User_avatarUrl(ctx, field)
-			case "hasVerifiedEmail":
-				return ec.fieldContext_User_hasVerifiedEmail(ctx, field)
-			case "verifiedEmails":
-				return ec.fieldContext_User_verifiedEmails(ctx, field)
-			case "rooms":
-				return ec.fieldContext_User_rooms(ctx, field)
-			case "roles":
-				return ec.fieldContext_User_roles(ctx, field)
-			case "viewerCanDeleteAccount":
-				return ec.fieldContext_User_viewerCanDeleteAccount(ctx, field)
-			case "lastLoginChange":
-				return ec.fieldContext_User_lastLoginChange(ctx, field)
-			case "roomNotificationPreferences":
-				return ec.fieldContext_User_roomNotificationPreferences(ctx, field)
-			case "presenceStatus":
-				return ec.fieldContext_User_presenceStatus(ctx, field)
-			case "settings":
-				return ec.fieldContext_User_settings(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_AdminQueries_roleUsers_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _AdminQueries_userEffectivePermissions(ctx context.Context, field graphql.CollectedField, obj *model.AdminQueries) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		ec.fieldContext_AdminQueries_userEffectivePermissions,
-		func(ctx context.Context) (any, error) {
-			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.AdminQueries().UserEffectivePermissions(ctx, obj, fc.Args["userId"].(string))
-		},
-		nil,
-		ec.marshalNString2ᚕstringᚄ,
-		true,
-		true,
-	)
-}
-
-func (ec *executionContext) fieldContext_AdminQueries_userEffectivePermissions(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "AdminQueries",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_AdminQueries_userEffectivePermissions_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _AdminQueries_userEffectiveDenials(ctx context.Context, field graphql.CollectedField, obj *model.AdminQueries) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		ec.fieldContext_AdminQueries_userEffectiveDenials,
-		func(ctx context.Context) (any, error) {
-			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.AdminQueries().UserEffectiveDenials(ctx, obj, fc.Args["userId"].(string))
-		},
-		nil,
-		ec.marshalNString2ᚕstringᚄ,
-		true,
-		true,
-	)
-}
-
-func (ec *executionContext) fieldContext_AdminQueries_userEffectiveDenials(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "AdminQueries",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_AdminQueries_userEffectiveDenials_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
 	}
 	return fc, nil
 }
@@ -14188,18 +13828,8 @@ func (ec *executionContext) fieldContext_Query_admin(_ context.Context, field gr
 				return ec.fieldContext_AdminQueries_groupRolePermissions(ctx, field)
 			case "groupUserPermissions":
 				return ec.fieldContext_AdminQueries_groupUserPermissions(ctx, field)
-			case "roles":
-				return ec.fieldContext_AdminQueries_roles(ctx, field)
-			case "role":
-				return ec.fieldContext_AdminQueries_role(ctx, field)
 			case "serverPermissions":
 				return ec.fieldContext_AdminQueries_serverPermissions(ctx, field)
-			case "roleUsers":
-				return ec.fieldContext_AdminQueries_roleUsers(ctx, field)
-			case "userEffectivePermissions":
-				return ec.fieldContext_AdminQueries_userEffectivePermissions(ctx, field)
-			case "userEffectiveDenials":
-				return ec.fieldContext_AdminQueries_userEffectiveDenials(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type AdminQueries", field.Name)
 		},
@@ -28081,157 +27711,11 @@ func (ec *executionContext) _AdminQueries(ctx context.Context, sel ast.Selection
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "roles":
-			out.Values[i] = ec._AdminQueries_roles(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
-		case "role":
-			field := field
-
-			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._AdminQueries_role(ctx, field, obj)
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "serverPermissions":
 			out.Values[i] = ec._AdminQueries_serverPermissions(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
-		case "roleUsers":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._AdminQueries_roleUsers(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "userEffectivePermissions":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._AdminQueries_userEffectivePermissions(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "userEffectiveDenials":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._AdminQueries_userEffectiveDenials(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/cli/internal/graph/model/models_gen.go
+++ b/cli/internal/graph/model/models_gen.go
@@ -84,23 +84,8 @@ type AdminQueries struct {
 	// Resolve the explicit grants and denials configured for a user on a
 	// specific set (user-level overrides at set scope).
 	GroupUserPermissions *RoomGroupUserPermissions `json:"groupUserPermissions"`
-	// List all server roles with their permissions.
-	Roles []*core.RoleWithPermissions `json:"roles"`
-	// Get a single server role by name.
-	Role *core.RoleWithPermissions `json:"role,omitempty"`
 	// List all available server permission identifiers.
 	ServerPermissions []string `json:"serverPermissions"`
-	// Get users assigned to a specific server role.
-	RoleUsers []*corev1.User `json:"roleUsers"`
-	// Get a user's effective allowed permissions at server scope. Combines
-	// role-based grants with user-level overrides (`grantUserPermission` /
-	// `denyUserPermission`) — the same answer the authorization resolver
-	// produces. For per-decision provenance use the permission explainer.
-	UserEffectivePermissions []string `json:"userEffectivePermissions"`
-	// Get a user's effective denied permissions at server scope. Mirrors
-	// `userEffectivePermissions` but lists permissions whose first decision
-	// is a deny. Used in admin UIs to surface where a permission is blocked.
-	UserEffectiveDenials []string `json:"userEffectiveDenials"`
 }
 
 // Server configuration section.

--- a/cli/internal/graph/notifications.resolvers.go
+++ b/cli/internal/graph/notifications.resolvers.go
@@ -138,18 +138,3 @@ func (r *Resolver) ReplyNotificationItem() ReplyNotificationItemResolver {
 type dMMessageNotificationItemResolver struct{ *Resolver }
 type mentionNotificationItemResolver struct{ *Resolver }
 type replyNotificationItemResolver struct{ *Resolver }
-
-// !!! WARNING !!!
-// The code below was going to be deleted when updating resolvers. It has been copied here so you have
-// one last chance to move it out of harms way if you want. There are two reasons this happens:
-//  - When renaming or deleting a resolver the old code will be put in here. You can safely delete
-//    it when you're done.
-//  - You have helper methods in this file. Move them out to keep these resolver files clean.
-/*
-	func (r *mentionNotificationItemResolver) ThreadRootEventID(ctx context.Context, obj *model.MentionNotificationItem) (*string, error) {
-	panic(fmt.Errorf("not implemented: ThreadRootEventID - threadRootEventId"))
-}
-func (r *replyNotificationItemResolver) ThreadRootEventID(ctx context.Context, obj *model.ReplyNotificationItem) (*string, error) {
-	panic(fmt.Errorf("not implemented: ThreadRootEventID - threadRootEventId"))
-}
-*/

--- a/cli/internal/graph/server_rbac.graphqls
+++ b/cli/internal/graph/server_rbac.graphqls
@@ -71,32 +71,8 @@ extend type Query {
 }
 
 extend type AdminQueries {
-  "List all server roles with their permissions."
-  roles: [Role!]!
-
-  "Get a single server role by name."
-  role(name: String!): Role @goField(forceResolver: true)
-
   "List all available server permission identifiers."
   serverPermissions: [String!]!
-
-  "Get users assigned to a specific server role."
-  roleUsers(roleName: String!): [User!]! @goField(forceResolver: true)
-
-  """
-  Get a user's effective allowed permissions at server scope. Combines
-  role-based grants with user-level overrides (`grantUserPermission` /
-  `denyUserPermission`) — the same answer the authorization resolver
-  produces. For per-decision provenance use the permission explainer.
-  """
-  userEffectivePermissions(userId: ID!): [String!]! @goField(forceResolver: true)
-
-  """
-  Get a user's effective denied permissions at server scope. Mirrors
-  `userEffectivePermissions` but lists permissions whose first decision
-  is a deny. Used in admin UIs to surface where a permission is blocked.
-  """
-  userEffectiveDenials(userId: ID!): [String!]! @goField(forceResolver: true)
 }
 
 extend type Mutation {

--- a/cli/internal/graph/server_rbac.resolvers.go
+++ b/cli/internal/graph/server_rbac.resolvers.go
@@ -15,94 +15,6 @@ import (
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
-// Role is the resolver for the role field.
-func (r *adminQueriesResolver) Role(ctx context.Context, obj *model.AdminQueries, name string) (*core.RoleWithPermissions, error) {
-	user := auth.ForContext(ctx)
-	if user == nil {
-		return nil, fmt.Errorf("authentication required")
-	}
-
-	// No additional authorization - admin context already verified by parent resolver
-	role, err := r.core.GetServerRole(ctx, name)
-	if err != nil {
-		if err == core.ErrRoleNotFound {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("failed to get role: %w", err)
-	}
-	return role, nil
-}
-
-// RoleUsers is the resolver for the roleUsers field.
-func (r *adminQueriesResolver) RoleUsers(ctx context.Context, obj *model.AdminQueries, roleName string) ([]*corev1.User, error) {
-	caller := auth.ForContext(ctx)
-	if caller == nil {
-		return nil, fmt.Errorf("authentication required")
-	}
-
-	// No additional authorization - admin context already verified by parent resolver
-	userIDs, err := r.core.GetRoleUsers(ctx, roleName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list role users: %w", err)
-	}
-
-	// Fetch user objects
-	users := make([]*corev1.User, 0, len(userIDs))
-	for _, userID := range userIDs {
-		user, err := r.core.GetUser(ctx, userID)
-		if err != nil {
-			// Skip users that no longer exist
-			continue
-		}
-		users = append(users, user)
-	}
-
-	return users, nil
-}
-
-// UserEffectivePermissions is the resolver for the userEffectivePermissions field.
-func (r *adminQueriesResolver) UserEffectivePermissions(ctx context.Context, obj *model.AdminQueries, userID string) ([]string, error) {
-	caller := auth.ForContext(ctx)
-	if caller == nil {
-		return nil, fmt.Errorf("authentication required")
-	}
-
-	// Iterate through all permissions and bucket them by the unified
-	// resolver's decision. Single source of truth — matches what the
-	// authorizer enforces, including user-level overrides.
-	var allowed []string
-	for _, perm := range r.core.AllServerPermissions() {
-		decision, err := r.core.ResolveUserPermission(ctx, userID, core.KindChannel, "", perm)
-		if err != nil {
-			return nil, fmt.Errorf("failed to resolve permission: %w", err)
-		}
-		if decision == core.DecisionAllow {
-			allowed = append(allowed, string(perm))
-		}
-	}
-	return allowed, nil
-}
-
-// UserEffectiveDenials is the resolver for the userEffectiveDenials field.
-func (r *adminQueriesResolver) UserEffectiveDenials(ctx context.Context, obj *model.AdminQueries, userID string) ([]string, error) {
-	caller := auth.ForContext(ctx)
-	if caller == nil {
-		return nil, fmt.Errorf("authentication required")
-	}
-
-	var denied []string
-	for _, perm := range r.core.AllServerPermissions() {
-		decision, err := r.core.ResolveUserPermission(ctx, userID, core.KindChannel, "", perm)
-		if err != nil {
-			return nil, fmt.Errorf("failed to resolve permission: %w", err)
-		}
-		if decision == core.DecisionDeny {
-			denied = append(denied, string(perm))
-		}
-	}
-	return denied, nil
-}
-
 // GrantPermission is the resolver for the grantPermission field.
 func (r *mutationResolver) GrantPermission(ctx context.Context, input model.GrantPermissionInput) (bool, error) {
 	user, err := requireAuth(ctx)
@@ -509,3 +421,4 @@ func (r *Resolver) Viewer() ViewerResolver { return &viewerResolver{r} }
 
 type roleResolver struct{ *Resolver }
 type viewerResolver struct{ *Resolver }
+

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -241,12 +241,7 @@ There is no `adminAuditLogEvents` subscription — audit events arrive through `
 | ------------------------------------------------ | --------- | -------------------------------------------------------------------------------------------- |
 | `admin.systemInfo`                               | Query     | Aggregate operational metrics: NATS connection + JetStream account usage totals.            |
 | `admin.serverConfig`                             | Query     | Server configuration overrides (welcome message, MOTD, blocked usernames, OG description).  |
-| `admin.roles`                                    | Query     | List all server roles with their permissions.                                                |
-| `admin.role(name)`                               | Query     | Get a single role.                                                                           |
 | `admin.serverPermissions`                        | Query     | List every available server permission identifier (catalog).                                 |
-| `admin.roleUsers(roleName)`                      | Query     | List users assigned to a role.                                                               |
-| `admin.userEffectivePermissions(userId)`         | Query     | A user's effective allow set at server scope (roles + user overrides combined).              |
-| `admin.userEffectiveDenials(userId)`             | Query     | A user's effective deny set at server scope.                                                 |
 | `admin.groupRolePermissions(groupId, roleName)`  | Query     | Explicit grants and denials for a role on a specific room group.                             |
 | `admin.groupUserPermissions(groupId, userId)`    | Query     | Explicit grants and denials for a user on a specific room group.                             |
 | `admin.updateServerConfig(input)`                | Mutation  | Update server configuration.                                                                 |

--- a/frontend/e2e/admin.test.ts
+++ b/frontend/e2e/admin.test.ts
@@ -756,7 +756,7 @@ test.describe('Instance Role Permission Denials', () => {
       data: {
         query: `
 					query GetRole($name: String!) {
-						admin {
+						server {
 							role(name: $name) {
 								name
 								permissions
@@ -770,8 +770,8 @@ test.describe('Instance Role Permission Denials', () => {
     });
     expect(queryRoleResponse.ok()).toBeTruthy();
     const queryRoleData = await queryRoleResponse.json();
-    expect(queryRoleData.data?.admin?.role).toBeTruthy();
-    expect(queryRoleData.data.admin.role.permissionDenials).toContain('dm.write');
+    expect(queryRoleData.data?.server?.role).toBeTruthy();
+    expect(queryRoleData.data.server.role.permissionDenials).toContain('dm.write');
 
     // Clean up - delete the role
     await page.request.post('/api/graphql', {


### PR DESCRIPTION
## Summary

`AdminQueries` exposed five fields that are also present on `Server`:

- `roles: [Role!]!`
- `role(name: String!): Role`
- `roleUsers(roleName: String!): [User!]!`
- `userEffectivePermissions(userId: ID!): [String!]!`
- `userEffectiveDenials(userId: ID!): [String!]!`

The frontend reads these from `server.*` everywhere (verified by grep across `frontend/src`). The `admin.*` versions were dead duplicates. Removed them along with the orphaned resolvers and matching `docs/ARCHITECTURE.md` rows.

After this PR, `AdminQueries` keeps `systemInfo`, `serverConfig`, `serverPermissions`, `groupRolePermissions`, `groupUserPermissions` — the queries it uniquely owns.

Also drops a leftover gqlgen warning block from #544 (the `ThreadRootEventID` resolver scaffolding that was ready to be deleted).

### BREAKING

External clients selecting `admin.roles` / `admin.role(name)` / `admin.roleUsers(roleName)` / `admin.userEffectivePermissions(userId)` / `admin.userEffectiveDenials(userId)` must switch to the same field on `server`. Data shape is identical.

## Test plan

- [x] `go build ./...` passes.
- [x] `go test -tags test_endpoints ./internal/graph/` passes (~20s).
- [x] No frontend file under `frontend/src/routes` references `admin.roles` etc. (grep clean).
- [x] CI green.

Closes #538. Part of #533.