### PR TITLE
docs(graphql): document the three pagination shapes

### DIFF
--- a/.claude/rules/graphql.md
+++ b/.claude/rules/graphql.md
@@ -89,6 +89,24 @@ query {
 }
 ```
 
+## Pagination
+
+The schema uses three pagination shapes today, each chosen for its access pattern. Match the shape to the use case rather than reaching for one universal style:
+
+| Shape | Arguments | When to use | Example |
+| --- | --- | --- | --- |
+| **Opaque cursors** | `limit: Int`, `before: String`, `after: String` | Long, append-only timelines where the client needs to walk both directions. Returns a `*Connection` type with `startCursor` / `endCursor` / `hasOlder` / `hasNewer`. | `Room.events`, `Room.eventsAround` |
+| **Offset + total** | `search: String`, `limit: Int`, `offset: Int` | Admin/directory listings where the total count drives UI (`N members · page 2 of 4`). Returns a `*Connection` type with `totalCount` and `hasMore`. | `Server.members` |
+| **First-N preview** | `first: Int` only | Capped previews that never paginate ("first 5 thread participants", "first 3 reactions"). Returns a bare list; no cursor or count. | `FollowedThread.threadParticipants`, `MessagePostedEvent.threadParticipants` |
+
+**Heuristic when adding a new paginated field:**
+
+1. Is the client ever going to display the total? → offset + total.
+2. Is the underlying source append-only and potentially long (event streams)? → cursors.
+3. Is this a small fixed-size preview the client will never page past? → `first` only.
+
+Don't introduce a fourth shape without weighing this list first. If a use case genuinely doesn't fit, add the new shape here so the rule keeps reflecting reality.
+
 ## Custom Model Files
 
 When gqlgen's auto-binding doesn't work (e.g., types needing internal fields for resolvers), create custom models in `cli/internal/graph/model/`. Keep these minimal:


### PR DESCRIPTION
## Summary

Closes #543 by ruling rather than refactoring. The three pagination shapes in the schema today were flagged in the API review (#533) as inconsistent, but on closer look each serves a different access pattern, and the schema is well-served by keeping them distinct:

| Shape | Where | Why |
| --- | --- | --- |
| Opaque cursors (`limit`/`before`/`after`) | `Room.events`, `Room.eventsAround` | Append-only event timelines that need bidirectional walking through history. |
| Offset + total (`search`/`limit`/`offset`) | `Server.members` | Admin/directory listings where the UI shows a total ("N members · page 2 of 4"). |
| First-only preview (`first`) | `threadParticipants` on `FollowedThread` and `MessagePostedEvent` | Capped previews that never paginate. |

Added a "Pagination" section to `.claude/rules/graphql.md` with a heuristic for adding new paginated fields, so contributors pick the right shape rather than introducing a fourth.

No code changes. Closes #543. Part of #533.