### PR TITLE
refactor(proto): add Room.kind enum; switch room resolvers off space_id

### DIFF
--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -296,7 +296,7 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	// Run boot-time data migrations. Idempotent and cheap on subsequent
 	// boots (each migration short-circuits when no legacy data remains).
 	// See cli/internal/migrations for what's currently registered.
-	if err := migrations.RunAll(ctx, storage.serverKV, logger); err != nil {
+	if err := migrations.RunAll(ctx, storage.serverKV, storage.serverConfigKV, logger); err != nil {
 		return nil, fmt.Errorf("failed to run boot migrations: %w", err)
 	}
 

--- a/cli/internal/core/dm.go
+++ b/cli/internal/core/dm.go
@@ -52,8 +52,12 @@ func IsDMSpace(spaceID string) bool {
 	return spaceID == DMSpaceID
 }
 
-// KindForSpace returns the room kind for a persisted SpaceId value:
-// KindDM for the DM system space, KindChannel for everything else.
+// KindForSpace returns the room kind for a legacy wire-frozen SpaceId
+// value ("server" or "DM"). Use this when reading from a persisted
+// shape that still carries `space_id` (e.g. MessagePostedEvent in the
+// JetStream backlog). For `*Room` records, prefer KindOfRoom — it
+// reads the new `kind` field first and only falls back here for
+// pre-backfill rooms. See ADR-030.
 func KindForSpace(spaceID string) RoomKind {
 	if IsDMSpace(spaceID) {
 		return KindDM
@@ -61,14 +65,38 @@ func KindForSpace(spaceID string) RoomKind {
 	return KindChannel
 }
 
-// SpaceIDForKind is the inverse of KindForSpace: returns DMSpaceID for
-// KindDM, ServerSpaceID otherwise. Used only at the proto boundary where
-// wire-format-frozen `space_id` fields still need a value written.
+// SpaceIDForKind is the inverse of KindForSpace: returns the legacy
+// SpaceId string for a kind. Used at the proto boundary where
+// wire-format-frozen `space_id` fields still need a value written
+// alongside the new `kind` field.
 func SpaceIDForKind(kind RoomKind) string {
 	if kind == KindDM {
 		return DMSpaceID
 	}
 	return ServerSpaceID
+}
+
+// ProtoKindForRoomKind maps the Go-side RoomKind string to the proto
+// enum stored on Room.kind. Writers populate both `space_id` (wire-frozen)
+// and `kind`; readers prefer `kind` (see RoomKind helper below).
+func ProtoKindForRoomKind(kind RoomKind) corev1.RoomKind {
+	if kind == KindDM {
+		return corev1.RoomKind_ROOM_KIND_DM
+	}
+	return corev1.RoomKind_ROOM_KIND_CHANNEL
+}
+
+// KindOfRoom returns the canonical RoomKind for a Room, preferring the
+// new `kind` field and falling back to `space_id` for legacy records that
+// predate the field (until the boot-time backfill rewrites them).
+func KindOfRoom(room *corev1.Room) RoomKind {
+	switch room.Kind {
+	case corev1.RoomKind_ROOM_KIND_DM:
+		return KindDM
+	case corev1.RoomKind_ROOM_KIND_CHANNEL:
+		return KindChannel
+	}
+	return KindForSpace(room.SpaceId)
 }
 
 // DMRoomID generates a deterministic room ID from participant IDs.
@@ -164,6 +192,7 @@ func (c *ChattoCore) createDMRoom(ctx context.Context, roomID string, participan
 	room := &corev1.Room{
 		Id:      roomID,
 		SpaceId: DMSpaceID,
+		Kind:    corev1.RoomKind_ROOM_KIND_DM,
 		Name:    "", // DMs don't have names - derived from participants in UI
 	}
 

--- a/cli/internal/core/rooms.go
+++ b/cli/internal/core/rooms.go
@@ -194,6 +194,7 @@ func (c *ChattoCore) CreateRoom(ctx context.Context, actorID string, kind RoomKi
 	room := &corev1.Room{
 		Id:          room_id,
 		SpaceId:     SpaceIDForKind(kind),
+		Kind:        ProtoKindForRoomKind(kind),
 		Name:        name,
 		Description: description,
 		GroupId:     groupID,
@@ -542,7 +543,7 @@ func (c *ChattoCore) FindRoomKind(ctx context.Context, room_id string) (RoomKind
 	if err != nil {
 		return "", err
 	}
-	return KindForSpace(room.SpaceId), nil
+	return KindOfRoom(room), nil
 }
 
 // ListRooms retrieves all rooms of the given kind from the CONFIG bucket.

--- a/cli/internal/graph/room.resolvers.go
+++ b/cli/internal/graph/room.resolvers.go
@@ -17,13 +17,11 @@ import (
 
 // Type is the resolver for the type field.
 //
-// Derived from `IsDMSpace(obj.SpaceId)` — the kind discriminator is the
-// room's space membership (DM rooms live in the DM system space), which
-// matches the kind segment the storage layer uses in `SERVER_CONFIG` keys
-// (`room.channel.{id}` vs `room.dm.{id}`). The Room proto doesn't carry a
-// kind field of its own; `SpaceId` is the canonical source.
+// Derived from `Room.kind` — the canonical kind discriminator since
+// ADR-030 Phase 2. Falls back to the legacy `space_id` via
+// `KindOfRoom` for pre-backfill records (single boot transient).
 func (r *roomResolver) Type(ctx context.Context, obj *corev1.Room) (model.RoomType, error) {
-	if core.IsDMSpace(obj.SpaceId) {
+	if core.KindOfRoom(obj) == core.KindDM {
 		return model.RoomTypeDm, nil
 	}
 	return model.RoomTypeChannel, nil
@@ -36,16 +34,16 @@ func (r *roomResolver) Members(ctx context.Context, obj *corev1.Room) ([]*corev1
 		return nil, err
 	}
 
+	kind := core.KindOfRoom(obj)
+
 	// Authorization: require room membership
-	isMember, err := r.core.RoomMembershipExists(ctx, core.KindForSpace(obj.SpaceId), user.Id, obj.Id)
+	isMember, err := r.core.RoomMembershipExists(ctx, kind, user.Id, obj.Id)
 	if err != nil {
 		return nil, err
 	}
 	if !isMember {
 		return nil, core.ErrNotRoomMember
 	}
-
-	kind := core.KindForSpace(obj.SpaceId)
 
 	// Membership is strictly explicit: a user is a member iff they have
 	// a `room_membership` record. Auto-join is gone, so there's no
@@ -76,7 +74,7 @@ func (r *roomResolver) HasUnread(ctx context.Context, obj *corev1.Room) (bool, e
 	}
 
 	// Authorization: require room membership
-	isMember, err := r.core.RoomMembershipExists(ctx, core.KindForSpace(obj.SpaceId), user.Id, obj.Id)
+	isMember, err := r.core.RoomMembershipExists(ctx, core.KindOfRoom(obj), user.Id, obj.Id)
 	if err != nil {
 		return false, nil // Silently return false if we can't check
 	}
@@ -84,7 +82,7 @@ func (r *roomResolver) HasUnread(ctx context.Context, obj *corev1.Room) (bool, e
 		return false, nil
 	}
 
-	return r.core.HasUnread(ctx, core.KindForSpace(obj.SpaceId), user.Id, obj.Id)
+	return r.core.HasUnread(ctx, core.KindOfRoom(obj), user.Id, obj.Id)
 }
 
 // HasMention is the resolver for the hasMention field.
@@ -104,7 +102,7 @@ func (r *roomResolver) ViewerCanPostMessage(ctx context.Context, obj *corev1.Roo
 	if user == nil {
 		return false, nil
 	}
-	return r.core.CanPostMessage(ctx, user.Id, core.KindForSpace(obj.SpaceId), obj.Id)
+	return r.core.CanPostMessage(ctx, user.Id, core.KindOfRoom(obj), obj.Id)
 }
 
 // ViewerCanPostInThread is the resolver for the viewerCanPostInThread field.
@@ -113,7 +111,7 @@ func (r *roomResolver) ViewerCanPostInThread(ctx context.Context, obj *corev1.Ro
 	if user == nil {
 		return false, nil
 	}
-	return r.core.CanPostInThread(ctx, user.Id, core.KindForSpace(obj.SpaceId), obj.Id)
+	return r.core.CanPostInThread(ctx, user.Id, core.KindOfRoom(obj), obj.Id)
 }
 
 // ViewerCanReact is the resolver for the viewerCanReact field.
@@ -122,7 +120,7 @@ func (r *roomResolver) ViewerCanReact(ctx context.Context, obj *corev1.Room) (bo
 	if user == nil {
 		return false, nil
 	}
-	return r.core.CanReactToMessage(ctx, user.Id, core.KindForSpace(obj.SpaceId), obj.Id)
+	return r.core.CanReactToMessage(ctx, user.Id, core.KindOfRoom(obj), obj.Id)
 }
 
 // ViewerCanManageOthersMessage is the resolver for the viewerCanManageOthersMessage field.
@@ -131,7 +129,7 @@ func (r *roomResolver) ViewerCanManageOthersMessage(ctx context.Context, obj *co
 	if user == nil {
 		return false, nil
 	}
-	return r.core.CanManageOthersMessage(ctx, user.Id, core.KindForSpace(obj.SpaceId), obj.Id)
+	return r.core.CanManageOthersMessage(ctx, user.Id, core.KindOfRoom(obj), obj.Id)
 }
 
 // ViewerCanListRoom is the resolver for the viewerCanListRoom field.
@@ -144,7 +142,7 @@ func (r *roomResolver) ViewerCanListRoom(ctx context.Context, obj *corev1.Room) 
 	if user == nil {
 		return false, nil
 	}
-	return r.core.CanSeeRoom(ctx, user.Id, core.KindForSpace(obj.SpaceId), obj.Id)
+	return r.core.CanSeeRoom(ctx, user.Id, core.KindOfRoom(obj), obj.Id)
 }
 
 // ViewerCanJoinRoom is the resolver for the viewerCanJoinRoom field.
@@ -156,7 +154,7 @@ func (r *roomResolver) ViewerCanJoinRoom(ctx context.Context, obj *corev1.Room) 
 	if user == nil {
 		return false, nil
 	}
-	return r.core.CanJoinRoomAt(ctx, user.Id, core.KindForSpace(obj.SpaceId), obj.Id)
+	return r.core.CanJoinRoomAt(ctx, user.Id, core.KindOfRoom(obj), obj.Id)
 }
 
 // ViewerCanEchoMessage is the resolver for the viewerCanEchoMessage field.
@@ -165,7 +163,7 @@ func (r *roomResolver) ViewerCanEchoMessage(ctx context.Context, obj *corev1.Roo
 	if user == nil {
 		return false, nil
 	}
-	return r.core.CanEchoMessage(ctx, user.Id, core.KindForSpace(obj.SpaceId), obj.Id)
+	return r.core.CanEchoMessage(ctx, user.Id, core.KindOfRoom(obj), obj.Id)
 }
 
 // ViewerCanManageRoom is the resolver for the viewerCanManageRoom field.
@@ -174,7 +172,7 @@ func (r *roomResolver) ViewerCanManageRoom(ctx context.Context, obj *corev1.Room
 	if user == nil {
 		return false, nil
 	}
-	return r.core.PermResolver().HasRoomPermission(ctx, user.Id, core.KindForSpace(obj.SpaceId), obj.Id, core.PermRoomManage)
+	return r.core.PermResolver().HasRoomPermission(ctx, user.Id, core.KindOfRoom(obj), obj.Id, core.PermRoomManage)
 }
 
 // Events is the resolver for the events field.
@@ -184,7 +182,7 @@ func (r *roomResolver) Events(ctx context.Context, obj *corev1.Room, limit *int3
 		return nil, err
 	}
 
-	isMember, err := r.core.RoomMembershipExists(ctx, core.KindForSpace(obj.SpaceId), user.Id, obj.Id)
+	isMember, err := r.core.RoomMembershipExists(ctx, core.KindOfRoom(obj), user.Id, obj.Id)
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +201,7 @@ func (r *roomResolver) Events(ctx context.Context, obj *corev1.Room, limit *int3
 		if err != nil {
 			return nil, fmt.Errorf("invalid after cursor: %w", err)
 		}
-		result, err = r.core.GetRoomEventsAfter(ctx, core.KindForSpace(obj.SpaceId), obj.Id, afterSeq, int(fetchLimit))
+		result, err = r.core.GetRoomEventsAfter(ctx, core.KindOfRoom(obj), obj.Id, afterSeq, int(fetchLimit))
 		if err != nil {
 			return nil, err
 		}
@@ -216,7 +214,7 @@ func (r *roomResolver) Events(ctx context.Context, obj *corev1.Room, limit *int3
 			}
 			beforeSeq = &seq
 		}
-		result, err = r.core.GetRoomEvents(ctx, core.KindForSpace(obj.SpaceId), obj.Id, int(fetchLimit), beforeSeq)
+		result, err = r.core.GetRoomEvents(ctx, core.KindOfRoom(obj), obj.Id, int(fetchLimit), beforeSeq)
 		if err != nil {
 			return nil, err
 		}
@@ -233,7 +231,7 @@ func (r *roomResolver) Event(ctx context.Context, obj *corev1.Room, eventID stri
 		return nil, err
 	}
 
-	isMember, err := r.core.RoomMembershipExists(ctx, core.KindForSpace(obj.SpaceId), user.Id, obj.Id)
+	isMember, err := r.core.RoomMembershipExists(ctx, core.KindOfRoom(obj), user.Id, obj.Id)
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +239,7 @@ func (r *roomResolver) Event(ctx context.Context, obj *corev1.Room, eventID stri
 		return nil, core.ErrNotRoomMember
 	}
 
-	return r.core.GetRoomEventByEventID(ctx, core.KindForSpace(obj.SpaceId), obj.Id, eventID)
+	return r.core.GetRoomEventByEventID(ctx, core.KindOfRoom(obj), obj.Id, eventID)
 }
 
 // EventsAround is the resolver for the eventsAround field.
@@ -252,7 +250,7 @@ func (r *roomResolver) EventsAround(ctx context.Context, obj *corev1.Room, event
 		return nil, err
 	}
 
-	isMember, err := r.core.RoomMembershipExists(ctx, core.KindForSpace(obj.SpaceId), user.Id, obj.Id)
+	isMember, err := r.core.RoomMembershipExists(ctx, core.KindOfRoom(obj), user.Id, obj.Id)
 	if err != nil {
 		return nil, err
 	}
@@ -265,7 +263,7 @@ func (r *roomResolver) EventsAround(ctx context.Context, obj *corev1.Room, event
 		fetchLimit = int(*limit)
 	}
 
-	result, err := r.core.GetRoomEventsAround(ctx, core.KindForSpace(obj.SpaceId), obj.Id, eventID, fetchLimit)
+	result, err := r.core.GetRoomEventsAround(ctx, core.KindOfRoom(obj), obj.Id, eventID, fetchLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -295,7 +293,7 @@ func (r *roomResolver) EventsAround(ctx context.Context, obj *corev1.Room, event
 // Generates a LiveKit JWT for joining a voice call.
 // Returns null if LiveKit is not configured. Requires room membership.
 func (r *roomResolver) VoiceCallToken(ctx context.Context, obj *corev1.Room) (*core.VoiceCallToken, error) {
-	user, err := requireRoomMember(ctx, r.core, core.KindForSpace(obj.SpaceId), obj.Id)
+	user, err := requireRoomMember(ctx, r.core, core.KindOfRoom(obj), obj.Id)
 	if err != nil {
 		return nil, err
 	}
@@ -328,7 +326,7 @@ func (r *roomResolver) VoiceCallToken(ctx context.Context, obj *corev1.Room) (*c
 // Returns participants currently in this room's voice call.
 // Returns empty list if no call is active or LiveKit is not configured. Requires room membership.
 func (r *roomResolver) CallParticipants(ctx context.Context, obj *corev1.Room) ([]*model.CallParticipant, error) {
-	if _, err := requireRoomMember(ctx, r.core, core.KindForSpace(obj.SpaceId), obj.Id); err != nil {
+	if _, err := requireRoomMember(ctx, r.core, core.KindOfRoom(obj), obj.Id); err != nil {
 		return nil, err
 	}
 

--- a/cli/internal/migrations/migrations.go
+++ b/cli/internal/migrations/migrations.go
@@ -44,9 +44,16 @@ import (
 
 // RunAll runs every active migration in order, stopping at the first
 // error.
-func RunAll(ctx context.Context, kv jetstream.KeyValue, logger *log.Logger) error {
-	if err := MigrateVerifiedEmailsToProto(ctx, kv, logger); err != nil {
+//
+// `serverKV` is the INSTANCE bucket (user data, auth tokens, etc.);
+// `serverConfigKV` is SERVER_CONFIG (rooms, room memberships,
+// notification levels, …).
+func RunAll(ctx context.Context, serverKV, serverConfigKV jetstream.KeyValue, logger *log.Logger) error {
+	if err := MigrateVerifiedEmailsToProto(ctx, serverKV, logger); err != nil {
 		return fmt.Errorf("verified_emails: %w", err)
+	}
+	if err := BackfillRoomKind(ctx, serverConfigKV, logger); err != nil {
+		return fmt.Errorf("room_kind: %w", err)
 	}
 	return nil
 }

--- a/cli/internal/migrations/room_kind.go
+++ b/cli/internal/migrations/room_kind.go
@@ -1,0 +1,99 @@
+package migrations
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/charmbracelet/log"
+	"github.com/nats-io/nats.go/jetstream"
+	"google.golang.org/protobuf/proto"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+// BackfillRoomKind populates the new Room.kind enum on existing room
+// records that predate the field. Rooms are stored in SERVER_CONFIG
+// under keys "room.channel.{roomId}" and "room.dm.{roomId}", and the
+// kind segment of the key is the authoritative source for backfill.
+//
+// # Why
+//
+// ADR-030 Phase 2 introduced Room.kind as the canonical kind
+// discriminator. Pre-existing rooms still have the field zero-valued
+// (ROOM_KIND_UNSPECIFIED). Backfilling at boot lets all read sites
+// assume `room.Kind != UNSPECIFIED` instead of falling back to
+// `KindForSpace(room.SpaceId)` on every access.
+//
+// # Idempotency
+//
+// Safe to re-run. Rooms with `Kind` already set are skipped without a
+// write. A crash mid-migration just leaves unmigrated rooms to be
+// picked up on the next boot.
+//
+// # When this can be removed
+//
+// Once every live deployment has booted at least once on a version
+// that includes this migration AND the wire-compat fallback in
+// `KindOfRoom` has been removed.
+func BackfillRoomKind(ctx context.Context, configKV jetstream.KeyValue, logger *log.Logger) error {
+	keyLister, err := configKV.ListKeysFiltered(ctx, "room.channel.*", "room.dm.*")
+	if err != nil {
+		// "no keys match" is the steady-state empty case, not a failure.
+		return nil
+	}
+
+	converted := 0
+	for key := range keyLister.Keys() {
+		// Derive the wanted kind from the key prefix; that's the
+		// authoritative source even when the proto field is unset.
+		var wantKind corev1.RoomKind
+		switch {
+		case strings.HasPrefix(key, "room.channel."):
+			wantKind = corev1.RoomKind_ROOM_KIND_CHANNEL
+		case strings.HasPrefix(key, "room.dm."):
+			wantKind = corev1.RoomKind_ROOM_KIND_DM
+		default:
+			continue
+		}
+
+		entry, err := configKV.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			logger.Warn("room_kind backfill: get failed", "key", key, "error", err)
+			continue
+		}
+
+		var room corev1.Room
+		if err := proto.Unmarshal(entry.Value(), &room); err != nil {
+			logger.Warn("room_kind backfill: unmarshal failed", "key", key, "error", err)
+			continue
+		}
+
+		if room.Kind == wantKind {
+			continue
+		}
+
+		room.Kind = wantKind
+		data, err := proto.Marshal(&room)
+		if err != nil {
+			logger.Warn("room_kind backfill: marshal failed", "key", key, "error", err)
+			continue
+		}
+
+		if _, err := configKV.Update(ctx, key, data, entry.Revision()); err != nil {
+			// Another writer raced us; the new writer will have set Kind
+			// itself, so this room is fine — move on.
+			logger.Debug("room_kind backfill: update raced, skipping", "key", key, "error", err)
+			continue
+		}
+		converted++
+	}
+
+	if converted > 0 {
+		logger.Info("room_kind backfill: populated Room.kind on legacy records", "count", converted)
+	}
+	return nil
+}

--- a/cli/internal/migrations/room_kind_test.go
+++ b/cli/internal/migrations/room_kind_test.go
@@ -1,0 +1,121 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/charmbracelet/log"
+	"github.com/nats-io/nats.go/jetstream"
+	"google.golang.org/protobuf/proto"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+func getRoom(t *testing.T, ctx context.Context, kv jetstream.KeyValue, key string) *corev1.Room {
+	t.Helper()
+	entry, err := kv.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("get %s: %v", key, err)
+	}
+	var room corev1.Room
+	if err := proto.Unmarshal(entry.Value(), &room); err != nil {
+		t.Fatalf("unmarshal %s: %v", key, err)
+	}
+	return &room
+}
+
+func TestBackfillRoomKind_BackfillsLegacyRoomsFromKeyPrefix(t *testing.T) {
+	ctx, kv := setupTestKV(t)
+
+	// Legacy channel room: Kind is UNSPECIFIED (zero), SpaceId carries
+	// the discriminator from before the field existed.
+	channel := &corev1.Room{Id: "Rchan", SpaceId: "server", Name: "general"}
+	channelData, err := proto.Marshal(channel)
+	if err != nil {
+		t.Fatalf("marshal channel: %v", err)
+	}
+	if _, err := kv.Put(ctx, "room.channel.Rchan", channelData); err != nil {
+		t.Fatalf("put channel: %v", err)
+	}
+
+	// Legacy DM room.
+	dm := &corev1.Room{Id: "Rdm", SpaceId: "DM"}
+	dmData, err := proto.Marshal(dm)
+	if err != nil {
+		t.Fatalf("marshal dm: %v", err)
+	}
+	if _, err := kv.Put(ctx, "room.dm.Rdm", dmData); err != nil {
+		t.Fatalf("put dm: %v", err)
+	}
+
+	// Already-migrated channel room: Kind is set; migration must not
+	// touch it.
+	migrated := &corev1.Room{Id: "Rmig", SpaceId: "server", Kind: corev1.RoomKind_ROOM_KIND_CHANNEL}
+	migratedData, err := proto.Marshal(migrated)
+	if err != nil {
+		t.Fatalf("marshal migrated: %v", err)
+	}
+	if _, err := kv.Put(ctx, "room.channel.Rmig", migratedData); err != nil {
+		t.Fatalf("put migrated: %v", err)
+	}
+	before, err := kv.Get(ctx, "room.channel.Rmig")
+	if err != nil {
+		t.Fatalf("get migrated before: %v", err)
+	}
+	migratedRev := before.Revision()
+
+	logger := log.New(nil)
+	if err := BackfillRoomKind(ctx, kv, logger); err != nil {
+		t.Fatalf("BackfillRoomKind: %v", err)
+	}
+
+	if got := getRoom(t, ctx, kv, "room.channel.Rchan"); got.Kind != corev1.RoomKind_ROOM_KIND_CHANNEL {
+		t.Errorf("channel.Kind = %v, want CHANNEL", got.Kind)
+	}
+	if got := getRoom(t, ctx, kv, "room.dm.Rdm"); got.Kind != corev1.RoomKind_ROOM_KIND_DM {
+		t.Errorf("dm.Kind = %v, want DM", got.Kind)
+	}
+
+	after, err := kv.Get(ctx, "room.channel.Rmig")
+	if err != nil {
+		t.Fatalf("get migrated after: %v", err)
+	}
+	if after.Revision() != migratedRev {
+		t.Errorf("already-migrated room was rewritten (rev %d -> %d)", migratedRev, after.Revision())
+	}
+}
+
+func TestBackfillRoomKind_IsIdempotent(t *testing.T) {
+	ctx, kv := setupTestKV(t)
+
+	room := &corev1.Room{Id: "Rchan", SpaceId: "server"}
+	data, err := proto.Marshal(room)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := kv.Put(ctx, "room.channel.Rchan", data); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	logger := log.New(nil)
+	if err := BackfillRoomKind(ctx, kv, logger); err != nil {
+		t.Fatalf("first pass: %v", err)
+	}
+	afterFirst, err := kv.Get(ctx, "room.channel.Rchan")
+	if err != nil {
+		t.Fatalf("get after first: %v", err)
+	}
+	revAfterFirst := afterFirst.Revision()
+
+	if err := BackfillRoomKind(ctx, kv, logger); err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	afterSecond, err := kv.Get(ctx, "room.channel.Rchan")
+	if err != nil {
+		t.Fatalf("get after second: %v", err)
+	}
+	if afterSecond.Revision() != revAfterFirst {
+		t.Errorf("second pass rewrote the record (rev %d -> %d) — not idempotent",
+			revAfterFirst, afterSecond.Revision())
+	}
+}

--- a/cli/internal/pb/chatto/core/v1/models.pb.go
+++ b/cli/internal/pb/chatto/core/v1/models.pb.go
@@ -22,6 +22,60 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// RoomKind discriminates between channel rooms and direct-message rooms.
+// Determines KV partitioning (room.channel.* vs room.dm.*) and NATS
+// subject routing (server.room.channel.* vs server.room.dm.*).
+type RoomKind int32
+
+const (
+	// Default for legacy rooms written before the field existed. Treat as
+	// CHANNEL after boot-time backfill (see ADR-030).
+	RoomKind_ROOM_KIND_UNSPECIFIED RoomKind = 0
+	RoomKind_ROOM_KIND_CHANNEL     RoomKind = 1
+	RoomKind_ROOM_KIND_DM          RoomKind = 2
+)
+
+// Enum value maps for RoomKind.
+var (
+	RoomKind_name = map[int32]string{
+		0: "ROOM_KIND_UNSPECIFIED",
+		1: "ROOM_KIND_CHANNEL",
+		2: "ROOM_KIND_DM",
+	}
+	RoomKind_value = map[string]int32{
+		"ROOM_KIND_UNSPECIFIED": 0,
+		"ROOM_KIND_CHANNEL":     1,
+		"ROOM_KIND_DM":          2,
+	}
+)
+
+func (x RoomKind) Enum() *RoomKind {
+	p := new(RoomKind)
+	*p = x
+	return p
+}
+
+func (x RoomKind) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (RoomKind) Descriptor() protoreflect.EnumDescriptor {
+	return file_chatto_core_v1_models_proto_enumTypes[0].Descriptor()
+}
+
+func (RoomKind) Type() protoreflect.EnumType {
+	return &file_chatto_core_v1_models_proto_enumTypes[0]
+}
+
+func (x RoomKind) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use RoomKind.Descriptor instead.
+func (RoomKind) EnumDescriptor() ([]byte, []int) {
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{0}
+}
+
 // UserPresenceStatus indicates a user's online presence status.
 // Named to avoid conflict with the GraphQL PresenceStatus enum.
 // Note: OFFLINE is not stored - absence of a key means offline.
@@ -58,11 +112,11 @@ func (x UserPresenceStatus) String() string {
 }
 
 func (UserPresenceStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_chatto_core_v1_models_proto_enumTypes[0].Descriptor()
+	return file_chatto_core_v1_models_proto_enumTypes[1].Descriptor()
 }
 
 func (UserPresenceStatus) Type() protoreflect.EnumType {
-	return &file_chatto_core_v1_models_proto_enumTypes[0]
+	return &file_chatto_core_v1_models_proto_enumTypes[1]
 }
 
 func (x UserPresenceStatus) Number() protoreflect.EnumNumber {
@@ -71,7 +125,7 @@ func (x UserPresenceStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use UserPresenceStatus.Descriptor instead.
 func (UserPresenceStatus) EnumDescriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{0}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{1}
 }
 
 type VideoStatus int32
@@ -110,11 +164,11 @@ func (x VideoStatus) String() string {
 }
 
 func (VideoStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_chatto_core_v1_models_proto_enumTypes[1].Descriptor()
+	return file_chatto_core_v1_models_proto_enumTypes[2].Descriptor()
 }
 
 func (VideoStatus) Type() protoreflect.EnumType {
-	return &file_chatto_core_v1_models_proto_enumTypes[1]
+	return &file_chatto_core_v1_models_proto_enumTypes[2]
 }
 
 func (x VideoStatus) Number() protoreflect.EnumNumber {
@@ -123,21 +177,27 @@ func (x VideoStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use VideoStatus.Descriptor instead.
 func (VideoStatus) EnumDescriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{1}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{2}
 }
 
-// Room represents a chat room within a space.
+// Room represents a chat room on the server.
 // For channel rooms, group_id MUST point to a RoomGroup; DM rooms leave it empty.
 type Room struct {
-	state       protoimpl.MessageState `protogen:"open.v1"`
-	Id          string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	SpaceId     string                 `protobuf:"bytes,2,opt,name=space_id,json=spaceId,proto3" json:"space_id,omitempty"`
-	Name        string                 `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
-	Description string                 `protobuf:"bytes,4,opt,name=description,proto3" json:"description,omitempty"`
-	Archived    bool                   `protobuf:"varint,5,opt,name=archived,proto3" json:"archived,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Id    string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// Legacy kind discriminator ("server"/"DM"); wire-frozen for KV-stored
+	// bytes. New code reads `kind` (field 8); writers populate both. See
+	// ADR-030.
+	SpaceId     string `protobuf:"bytes,2,opt,name=space_id,json=spaceId,proto3" json:"space_id,omitempty"`
+	Name        string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
+	Description string `protobuf:"bytes,4,opt,name=description,proto3" json:"description,omitempty"`
+	Archived    bool   `protobuf:"varint,5,opt,name=archived,proto3" json:"archived,omitempty"`
 	// group_id is the RoomGroup this room belongs to. Required for channel
 	// rooms, empty for DM rooms. See ADR-031.
-	GroupId       string `protobuf:"bytes,7,opt,name=group_id,json=groupId,proto3" json:"group_id,omitempty"`
+	GroupId string `protobuf:"bytes,7,opt,name=group_id,json=groupId,proto3" json:"group_id,omitempty"`
+	// Canonical kind discriminator. Populated by all writers post-ADR-030;
+	// existing KV records are backfilled at boot from `space_id`.
+	Kind          RoomKind `protobuf:"varint,8,opt,name=kind,proto3,enum=chatto.core.v1.RoomKind" json:"kind,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -212,6 +272,13 @@ func (x *Room) GetGroupId() string {
 		return x.GroupId
 	}
 	return ""
+}
+
+func (x *Room) GetKind() RoomKind {
+	if x != nil {
+		return x.Kind
+	}
+	return RoomKind_ROOM_KIND_UNSPECIFIED
 }
 
 // User represents a user account
@@ -1571,14 +1638,15 @@ var File_chatto_core_v1_models_proto protoreflect.FileDescriptor
 
 const file_chatto_core_v1_models_proto_rawDesc = "" +
 	"\n" +
-	"\x1bchatto/core/v1/models.proto\x12\x0echatto.core.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xaf\x01\n" +
+	"\x1bchatto/core/v1/models.proto\x12\x0echatto.core.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xdd\x01\n" +
 	"\x04Room\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x19\n" +
 	"\bspace_id\x18\x02 \x01(\tR\aspaceId\x12\x12\n" +
 	"\x04name\x18\x03 \x01(\tR\x04name\x12 \n" +
 	"\vdescription\x18\x04 \x01(\tR\vdescription\x12\x1a\n" +
 	"\barchived\x18\x05 \x01(\bR\barchived\x12\x19\n" +
-	"\bgroup_id\x18\a \x01(\tR\agroupIdJ\x04\b\x06\x10\aR\tauto_join\"\x8a\x01\n" +
+	"\bgroup_id\x18\a \x01(\tR\agroupId\x12,\n" +
+	"\x04kind\x18\b \x01(\x0e2\x18.chatto.core.v1.RoomKindR\x04kindJ\x04\b\x06\x10\aR\tauto_join\"\x8a\x01\n" +
 	"\x04User\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
 	"\x05login\x18\x02 \x01(\tR\x05login\x12!\n" +
@@ -1680,7 +1748,11 @@ const file_chatto_core_v1_models_proto_rawDesc = "" +
 	"\aquality\x18\x02 \x01(\tR\aquality\x12\x14\n" +
 	"\x05width\x18\x03 \x01(\x05R\x05width\x12\x16\n" +
 	"\x06height\x18\x04 \x01(\x05R\x06height\x12\x12\n" +
-	"\x04size\x18\x05 \x01(\x03R\x04size*}\n" +
+	"\x04size\x18\x05 \x01(\x03R\x04size*N\n" +
+	"\bRoomKind\x12\x19\n" +
+	"\x15ROOM_KIND_UNSPECIFIED\x10\x00\x12\x15\n" +
+	"\x11ROOM_KIND_CHANNEL\x10\x01\x12\x10\n" +
+	"\fROOM_KIND_DM\x10\x02*}\n" +
 	"\x12UserPresenceStatus\x12\x1f\n" +
 	"\x1bUSER_PRESENCE_STATUS_ONLINE\x10\x00\x12\x1d\n" +
 	"\x19USER_PRESENCE_STATUS_AWAY\x10\x01\x12'\n" +
@@ -1704,53 +1776,55 @@ func file_chatto_core_v1_models_proto_rawDescGZIP() []byte {
 	return file_chatto_core_v1_models_proto_rawDescData
 }
 
-var file_chatto_core_v1_models_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_chatto_core_v1_models_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
 var file_chatto_core_v1_models_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
 var file_chatto_core_v1_models_proto_goTypes = []any{
-	(UserPresenceStatus)(0),       // 0: chatto.core.v1.UserPresenceStatus
-	(VideoStatus)(0),              // 1: chatto.core.v1.VideoStatus
-	(*Room)(nil),                  // 2: chatto.core.v1.Room
-	(*User)(nil),                  // 3: chatto.core.v1.User
-	(*VerifiedEmail)(nil),         // 4: chatto.core.v1.VerifiedEmail
-	(*Asset)(nil),                 // 5: chatto.core.v1.Asset
-	(*S3Asset)(nil),               // 6: chatto.core.v1.S3Asset
-	(*NATSAsset)(nil),             // 7: chatto.core.v1.NATSAsset
-	(*RoomMembership)(nil),        // 8: chatto.core.v1.RoomMembership
-	(*Role)(nil),                  // 9: chatto.core.v1.Role
-	(*UserPresence)(nil),          // 10: chatto.core.v1.UserPresence
-	(*PresenceChange)(nil),        // 11: chatto.core.v1.PresenceChange
-	(*ThreadMetadata)(nil),        // 12: chatto.core.v1.ThreadMetadata
-	(*Attachment)(nil),            // 13: chatto.core.v1.Attachment
-	(*MessageBody)(nil),           // 14: chatto.core.v1.MessageBody
-	(*LinkPreview)(nil),           // 15: chatto.core.v1.LinkPreview
-	(*CachedLinkPreview)(nil),     // 16: chatto.core.v1.CachedLinkPreview
-	(*RoomLayout)(nil),            // 17: chatto.core.v1.RoomLayout
-	(*RoomGroup)(nil),             // 18: chatto.core.v1.RoomGroup
-	(*VideoProcessingState)(nil),  // 19: chatto.core.v1.VideoProcessingState
-	(*VideoVariant)(nil),          // 20: chatto.core.v1.VideoVariant
-	(*timestamppb.Timestamp)(nil), // 21: google.protobuf.Timestamp
+	(RoomKind)(0),                 // 0: chatto.core.v1.RoomKind
+	(UserPresenceStatus)(0),       // 1: chatto.core.v1.UserPresenceStatus
+	(VideoStatus)(0),              // 2: chatto.core.v1.VideoStatus
+	(*Room)(nil),                  // 3: chatto.core.v1.Room
+	(*User)(nil),                  // 4: chatto.core.v1.User
+	(*VerifiedEmail)(nil),         // 5: chatto.core.v1.VerifiedEmail
+	(*Asset)(nil),                 // 6: chatto.core.v1.Asset
+	(*S3Asset)(nil),               // 7: chatto.core.v1.S3Asset
+	(*NATSAsset)(nil),             // 8: chatto.core.v1.NATSAsset
+	(*RoomMembership)(nil),        // 9: chatto.core.v1.RoomMembership
+	(*Role)(nil),                  // 10: chatto.core.v1.Role
+	(*UserPresence)(nil),          // 11: chatto.core.v1.UserPresence
+	(*PresenceChange)(nil),        // 12: chatto.core.v1.PresenceChange
+	(*ThreadMetadata)(nil),        // 13: chatto.core.v1.ThreadMetadata
+	(*Attachment)(nil),            // 14: chatto.core.v1.Attachment
+	(*MessageBody)(nil),           // 15: chatto.core.v1.MessageBody
+	(*LinkPreview)(nil),           // 16: chatto.core.v1.LinkPreview
+	(*CachedLinkPreview)(nil),     // 17: chatto.core.v1.CachedLinkPreview
+	(*RoomLayout)(nil),            // 18: chatto.core.v1.RoomLayout
+	(*RoomGroup)(nil),             // 19: chatto.core.v1.RoomGroup
+	(*VideoProcessingState)(nil),  // 20: chatto.core.v1.VideoProcessingState
+	(*VideoVariant)(nil),          // 21: chatto.core.v1.VideoVariant
+	(*timestamppb.Timestamp)(nil), // 22: google.protobuf.Timestamp
 }
 var file_chatto_core_v1_models_proto_depIdxs = []int32{
-	21, // 0: chatto.core.v1.User.created_at:type_name -> google.protobuf.Timestamp
-	21, // 1: chatto.core.v1.VerifiedEmail.verified_at:type_name -> google.protobuf.Timestamp
-	7,  // 2: chatto.core.v1.Asset.nats:type_name -> chatto.core.v1.NATSAsset
-	6,  // 3: chatto.core.v1.Asset.s3:type_name -> chatto.core.v1.S3Asset
-	0,  // 4: chatto.core.v1.UserPresence.status:type_name -> chatto.core.v1.UserPresenceStatus
-	21, // 5: chatto.core.v1.ThreadMetadata.last_reply_at:type_name -> google.protobuf.Timestamp
-	5,  // 6: chatto.core.v1.Attachment.storage:type_name -> chatto.core.v1.Asset
-	21, // 7: chatto.core.v1.MessageBody.created_at:type_name -> google.protobuf.Timestamp
-	21, // 8: chatto.core.v1.MessageBody.updated_at:type_name -> google.protobuf.Timestamp
-	13, // 9: chatto.core.v1.MessageBody.attachments:type_name -> chatto.core.v1.Attachment
-	15, // 10: chatto.core.v1.MessageBody.link_preview:type_name -> chatto.core.v1.LinkPreview
-	15, // 11: chatto.core.v1.CachedLinkPreview.preview:type_name -> chatto.core.v1.LinkPreview
-	18, // 12: chatto.core.v1.RoomLayout.legacy_sections:type_name -> chatto.core.v1.RoomGroup
-	1,  // 13: chatto.core.v1.VideoProcessingState.status:type_name -> chatto.core.v1.VideoStatus
-	20, // 14: chatto.core.v1.VideoProcessingState.variants:type_name -> chatto.core.v1.VideoVariant
-	15, // [15:15] is the sub-list for method output_type
-	15, // [15:15] is the sub-list for method input_type
-	15, // [15:15] is the sub-list for extension type_name
-	15, // [15:15] is the sub-list for extension extendee
-	0,  // [0:15] is the sub-list for field type_name
+	0,  // 0: chatto.core.v1.Room.kind:type_name -> chatto.core.v1.RoomKind
+	22, // 1: chatto.core.v1.User.created_at:type_name -> google.protobuf.Timestamp
+	22, // 2: chatto.core.v1.VerifiedEmail.verified_at:type_name -> google.protobuf.Timestamp
+	8,  // 3: chatto.core.v1.Asset.nats:type_name -> chatto.core.v1.NATSAsset
+	7,  // 4: chatto.core.v1.Asset.s3:type_name -> chatto.core.v1.S3Asset
+	1,  // 5: chatto.core.v1.UserPresence.status:type_name -> chatto.core.v1.UserPresenceStatus
+	22, // 6: chatto.core.v1.ThreadMetadata.last_reply_at:type_name -> google.protobuf.Timestamp
+	6,  // 7: chatto.core.v1.Attachment.storage:type_name -> chatto.core.v1.Asset
+	22, // 8: chatto.core.v1.MessageBody.created_at:type_name -> google.protobuf.Timestamp
+	22, // 9: chatto.core.v1.MessageBody.updated_at:type_name -> google.protobuf.Timestamp
+	14, // 10: chatto.core.v1.MessageBody.attachments:type_name -> chatto.core.v1.Attachment
+	16, // 11: chatto.core.v1.MessageBody.link_preview:type_name -> chatto.core.v1.LinkPreview
+	16, // 12: chatto.core.v1.CachedLinkPreview.preview:type_name -> chatto.core.v1.LinkPreview
+	19, // 13: chatto.core.v1.RoomLayout.legacy_sections:type_name -> chatto.core.v1.RoomGroup
+	2,  // 14: chatto.core.v1.VideoProcessingState.status:type_name -> chatto.core.v1.VideoStatus
+	21, // 15: chatto.core.v1.VideoProcessingState.variants:type_name -> chatto.core.v1.VideoVariant
+	16, // [16:16] is the sub-list for method output_type
+	16, // [16:16] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_chatto_core_v1_models_proto_init() }
@@ -1769,7 +1843,7 @@ func file_chatto_core_v1_models_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_core_v1_models_proto_rawDesc), len(file_chatto_core_v1_models_proto_rawDesc)),
-			NumEnums:      2,
+			NumEnums:      3,
 			NumMessages:   19,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/proto/chatto/core/v1/models.proto
+++ b/proto/chatto/core/v1/models.proto
@@ -6,10 +6,24 @@ import "google/protobuf/timestamp.proto";
 
 option go_package = "hmans.de/chatto/internal/pb/chatto/core/v1;corev1";
 
-// Room represents a chat room within a space.
+// RoomKind discriminates between channel rooms and direct-message rooms.
+// Determines KV partitioning (room.channel.* vs room.dm.*) and NATS
+// subject routing (server.room.channel.* vs server.room.dm.*).
+enum RoomKind {
+  // Default for legacy rooms written before the field existed. Treat as
+  // CHANNEL after boot-time backfill (see ADR-030).
+  ROOM_KIND_UNSPECIFIED = 0;
+  ROOM_KIND_CHANNEL = 1;
+  ROOM_KIND_DM = 2;
+}
+
+// Room represents a chat room on the server.
 // For channel rooms, group_id MUST point to a RoomGroup; DM rooms leave it empty.
 message Room {
   string id = 1;
+  // Legacy kind discriminator ("server"/"DM"); wire-frozen for KV-stored
+  // bytes. New code reads `kind` (field 8); writers populate both. See
+  // ADR-030.
   string space_id = 2;
   string name = 3;
   string description = 4;
@@ -22,6 +36,9 @@ message Room {
   // group_id is the RoomGroup this room belongs to. Required for channel
   // rooms, empty for DM rooms. See ADR-031.
   string group_id = 7;
+  // Canonical kind discriminator. Populated by all writers post-ADR-030;
+  // existing KV records are backfilled at boot from `space_id`.
+  RoomKind kind = 8;
 }
 
 // User represents a user account


### PR DESCRIPTION
## Summary

ADR-030 Phase 2: introduces an explicit `RoomKind` enum on the `Room` proto so the GraphQL room resolvers stop using `space_id` as a kind discriminator. `space_id` remains wire-frozen on persisted bytes (still load-bearing for the JetStream backlog of persisted events); the new `kind` field is the canonical reader for `*Room`. Writers dual-write both fields, and a new boot-time backfill (`BackfillRoomKind`) populates `kind` on legacy `SERVER_CONFIG` `room.*` records by deriving from the key prefix — OCC-safe and idempotent. 25 `core.KindForSpace(obj.SpaceId)` reads in `room.resolvers.go` switch to a new `core.KindOfRoom(obj)` helper that prefers `Room.kind` and falls back to `KindForSpace` only for pre-backfill records.

## Test plan

- [x] `mise codegen-cli`
- [x] `mise test-cli` (incl. 2 new migration tests covering backfill correctness + idempotency)
- [ ] `mise test-e2e` — verify room creation, DM creation, room listings, permission checks, voice call wiring still resolve via `Room.kind`