### PR TITLE
feat(frontend): auto-reload client on new version when user is idle

### DIFF
--- a/frontend/src/lib/components/IdleTracker.svelte
+++ b/frontend/src/lib/components/IdleTracker.svelte
@@ -1,0 +1,16 @@
+<!--
+@component
+
+Drives `idleState.isInputFocused` from document focus events. Mount once
+in the root layout. The rest of the heuristics for "is the user idle"
+live in `idleState` (see `$lib/state/idle.svelte`).
+-->
+<script lang="ts">
+  import { idleState, isEditableElement } from '$lib/state/idle.svelte';
+
+  function syncFocus() {
+    idleState.isInputFocused = isEditableElement(document.activeElement);
+  }
+</script>
+
+<svelte:document onfocusin={syncFocus} onfocusout={syncFocus} />

--- a/frontend/src/lib/components/UpdateNotifier.svelte
+++ b/frontend/src/lib/components/UpdateNotifier.svelte
@@ -1,25 +1,26 @@
 <!--
 @component
 
-Monitors for app updates and notifies the user via toast. When a new version
-is detected, shows a toast with a reload button and force-reconnects the
-WebSocket to recover real-time updates immediately. If the user dismisses the
-toast and navigates, the page reloads anyway to prevent stale chunk errors.
+Monitors for app updates and reloads the page automatically as soon as the
+user is idle (not typing, not in a call — see `idleState.canSafelyReload`).
+While the user is busy, a toast offers a manual reload. As a final fallback,
+the next navigation triggers a reload to avoid stale chunk errors.
 
 Include this component once at the root layout level.
 -->
 <script lang="ts">
   import { onNavigate } from '$app/navigation';
   import { updated } from '$app/state';
+  import { idleState } from '$lib/state/idle.svelte';
   import { graphqlClientManager } from '$lib/state/server/graphqlClient.svelte';
   import { toast } from '$lib/ui/toast';
 
-  // Track whether we've already shown the update toast
   let updateToastShown = false;
 
-  // Show a toast when a new version is detected
   $effect(() => {
-    if (updated.current && !updateToastShown) {
+    if (!updated.current) return;
+
+    if (!updateToastShown) {
       updateToastShown = true;
       toast.info('A new version is available', 0, {
         label: 'Reload',
@@ -29,6 +30,13 @@ Include this component once at the root layout level.
       // Force-reconnect the WebSocket — a deploy means the old connection
       // is stale even if the client thinks it's still connected
       graphqlClientManager.originClient.forceReconnect('app update detected');
+    }
+
+    // Auto-reload as soon as it's safe. The effect re-runs when the user
+    // blurs the composer / leaves a call, so a busy user just sees the
+    // toast until they idle out.
+    if (idleState.canSafelyReload) {
+      location.reload();
     }
   });
 

--- a/frontend/src/lib/state/idle.svelte.ts
+++ b/frontend/src/lib/state/idle.svelte.ts
@@ -1,0 +1,46 @@
+import { serverRegistry } from './server/registry.svelte';
+
+/**
+ * Tracks whether the user is "actively engaged" with the app, so callers
+ * (currently the auto-refresh path in `UpdateNotifier`) can pick a safe
+ * moment to take disruptive actions like reloading the page.
+ *
+ * "Safe to reload" means: the user is not typing into anything and is not
+ * in a voice/video call. Extend the heuristics here — keep this the single
+ * source of truth.
+ *
+ * Lifecycle: `isInputFocused` is driven by `<svelte:document>` listeners
+ * in the root layout, not by this store. The store is pure state.
+ */
+class IdleState {
+	/** True iff an editable element (input/textarea/contenteditable) has focus. */
+	isInputFocused = $state(false);
+
+	/** True iff the user is connected to any voice call on any registered server. */
+	get isInAnyCall(): boolean {
+		for (const server of serverRegistry.servers) {
+			const store = serverRegistry.tryGetStore(server.id);
+			if (store?.voiceCall.isInAnyCall) return true;
+		}
+		return false;
+	}
+
+	/**
+	 * True iff it's safe to disruptively reload the page right now. The
+	 * inverse of "user is actively engaged."
+	 */
+	get canSafelyReload(): boolean {
+		return !this.isInputFocused && !this.isInAnyCall;
+	}
+}
+
+/** Whether the given element is text-editable (input/textarea/contenteditable). */
+export function isEditableElement(target: Element | null): boolean {
+	if (!(target instanceof HTMLElement)) return false;
+	const tag = target.tagName;
+	if (tag === 'INPUT' || tag === 'TEXTAREA') return true;
+	if (target.isContentEditable) return true;
+	return false;
+}
+
+export const idleState = new IdleState();

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -6,6 +6,7 @@
   import ConnectionIndicator from '$lib/components/ConnectionIndicator.svelte';
   import ConnectionProvider from '$lib/components/ConnectionProvider.svelte';
   import GlobalKeyboardShortcuts from '$lib/components/GlobalKeyboardShortcuts.svelte';
+  import IdleTracker from '$lib/components/IdleTracker.svelte';
   import NotificationSync from '$lib/components/NotificationSync.svelte';
   import UpdateNotifier from '$lib/components/UpdateNotifier.svelte';
   import FullscreenVideoOverlay from '$lib/components/chat/FullscreenVideoOverlay.svelte';
@@ -135,6 +136,7 @@
 </style>
 
 <GlobalKeyboardShortcuts />
+<IdleTracker />
 <UpdateNotifier />
 <NotificationSync />
 


### PR DESCRIPTION
## Summary

- New `idleState` singleton (`$lib/state/idle.svelte`) — single source of truth for whether the user is actively engaged. Currently exposes `isInputFocused`, `isInAnyCall` (across all registered servers), and the unified `canSafelyReload` heuristic; add future signals (page visibility, drag in progress, etc.) here.
- New `IdleTracker.svelte` mounted in the root layout; uses `<svelte:document onfocusin onfocusout>` to drive `idleState.isInputFocused` from the actual `document.activeElement`.
- `UpdateNotifier` now calls `location.reload()` automatically when `updated.current && idleState.canSafelyReload`. The existing toast remains for busy users — they finish typing / leave the call, the effect re-runs, the reload happens.

## Test plan

- [ ] Verified `mise check` (svelte-check) is clean and the full frontend test suite passes locally.
- [ ] Manual verification on a real deploy: focus composer → bump version → confirm no reload until blur; idle tab → bump version → confirm auto-reload.