### PR TITLE
refactor(assets): drop space_id from new attachment uploads (Phase 4)

### DIFF
--- a/cli/internal/core/attachments.go
+++ b/cli/internal/core/attachments.go
@@ -29,16 +29,17 @@ func (c *ChattoCore) GetAttachmentsStore(ctx context.Context) (jetstream.ObjectS
 	return c.storage.serverAttachments, nil
 }
 
-// UploadAttachment uploads a file as an attachment and returns the attachment metadata.
-// For images, it extracts dimensions. Thumbnails are generated on-the-fly via transforms.
-// The storage backend (NATS or S3) is determined by configuration.
+// UploadAttachment uploads a file as an attachment and returns the
+// attachment metadata. For images, it extracts dimensions. Thumbnails
+// are generated on-the-fly via transforms. The storage backend (NATS or
+// S3) is determined by configuration.
 //
-// `spaceID` is the persisted-shape space ID ("server" or "DM"). It's used for
-// the on-disk S3 key path (wire-frozen) and the Attachment.SpaceId proto field.
-// Callers with a kind in hand should convert via SpaceIDForKind first.
+// New attachments use the kind-less `attachments/{id}` S3 key (and the
+// `/assets/attachments/{id}` URL pattern). `Attachment.SpaceId` is left
+// empty on the returned proto — it's reserved for pre-ADR-030-Phase-4
+// records that are still stored at `spaces/{server|DM}/attachments/{id}`.
 func (c *ChattoCore) UploadAttachment(
 	ctx context.Context,
-	spaceID string,
 	roomID string,
 	filename string,
 	contentType string,
@@ -90,7 +91,7 @@ func (c *ChattoCore) UploadAttachment(
 	var storage *corev1.Asset
 	if c.ShouldUseS3() {
 		// Upload to S3
-		s3Key := S3KeySpaceAttachment(spaceID, attachmentID)
+		s3Key := S3KeyAttachment(attachmentID)
 		_, err := c.s3Client.PutObjectFromBytes(ctx, s3Key, content, contentType)
 		if err != nil {
 			return nil, fmt.Errorf("failed to upload attachment to S3: %w", err)
@@ -136,7 +137,6 @@ func (c *ChattoCore) UploadAttachment(
 
 	c.logger.Debug("Uploaded attachment",
 		"attachment_id", attachmentID,
-		"space_id", spaceID,
 		"room_id", roomID,
 		"filename", filename,
 		"content_type", contentType,
@@ -146,7 +146,6 @@ func (c *ChattoCore) UploadAttachment(
 
 	return &corev1.Attachment{
 		Id:          attachmentID,
-		SpaceId:     spaceID,
 		RoomId:      roomID,
 		Filename:    filename,
 		ContentType: contentType,
@@ -207,8 +206,52 @@ func (c *ChattoCore) GetS3Attachment(ctx context.Context, s3Key string) (io.Read
 	}, nil
 }
 
+// attachmentS3Key returns the preferred S3 key for an attachment. New
+// attachments (with no SpaceId) use the kind-less layout; legacy
+// attachments stay at their pre-ADR-030-Phase-4 layout
+// (`spaces/{server|DM}/attachments/{id}`).
+func attachmentS3Key(spaceID, attachmentID string) string {
+	if spaceID == "" {
+		return S3KeyAttachment(attachmentID)
+	}
+	return S3KeySpaceAttachment(spaceID, attachmentID)
+}
+
+// attachmentS3KeyCandidates returns the S3 key to try first plus any
+// fallbacks. We probe across layouts so layout mismatches between caller
+// hint and actual storage (e.g. a legacy in-flight video processing
+// request handled by a Phase-4 binary, or a new variant attached to a
+// legacy parent video) resolve transparently.
+func attachmentS3KeyCandidates(spaceID, attachmentID string) []string {
+	if spaceID == "" {
+		// Prefer the new layout but fall back to known legacy spaceIDs.
+		return []string{
+			S3KeyAttachment(attachmentID),
+			S3KeySpaceAttachment(ServerSpaceID, attachmentID),
+			S3KeySpaceAttachment(DMSpaceID, attachmentID),
+		}
+	}
+	// Prefer the requested legacy layout, fall back to the new one.
+	return []string{
+		S3KeySpaceAttachment(spaceID, attachmentID),
+		S3KeyAttachment(attachmentID),
+	}
+}
+
+// attachmentCachePrefix returns the resize-cache namespace component for an
+// attachment. Matches the cache prefix used by the HTTP transform handlers
+// so deletes and lookups land in the same namespace.
+func attachmentCachePrefix(spaceID string) string {
+	if spaceID == "" {
+		return AttachmentSignResource
+	}
+	return spaceID
+}
+
 // GetAttachmentFromAnyBackend retrieves an attachment by probing both NATS and S3 backends.
 // It tries NATS first (for backwards compatibility with existing attachments), then S3.
+// An empty spaceID selects the kind-less S3 layout used for new uploads;
+// a non-empty spaceID selects the legacy `spaces/{spaceId}/...` layout.
 // Returns a reader for the attachment content and metadata.
 // The caller is responsible for closing the reader if it implements io.Closer.
 func (c *ChattoCore) GetAttachmentFromAnyBackend(ctx context.Context, spaceID, attachmentID string) (io.Reader, *AttachmentInfo, error) {
@@ -223,19 +266,23 @@ func (c *ChattoCore) GetAttachmentFromAnyBackend(ctx context.Context, spaceID, a
 		}, nil
 	}
 
-	// If NATS failed and S3 is configured, try S3
+	// If NATS failed and S3 is configured, try S3. Probe across layouts
+	// so legacy-vs-new mismatches in the caller's hint resolve cleanly.
 	if c.s3Client != nil {
-		s3Key := S3KeySpaceAttachment(spaceID, attachmentID)
-		s3Reader, s3Info, s3Err := c.GetS3Attachment(ctx, s3Key)
-		if s3Err == nil {
-			return s3Reader, s3Info, nil
+		var lastS3Err error
+		for _, s3Key := range attachmentS3KeyCandidates(spaceID, attachmentID) {
+			s3Reader, s3Info, s3Err := c.GetS3Attachment(ctx, s3Key)
+			if s3Err == nil {
+				return s3Reader, s3Info, nil
+			}
+			lastS3Err = s3Err
 		}
-		// Log S3 error but return the original NATS error
+		// Log the last S3 error but return the original NATS error
 		c.logger.Debug("Attachment not found in either backend",
 			"space_id", spaceID,
 			"attachment_id", attachmentID,
 			"nats_error", err,
-			"s3_error", s3Err)
+			"s3_error", lastS3Err)
 	}
 
 	return nil, nil, err
@@ -311,61 +358,91 @@ func (c *ChattoCore) DeleteAttachmentFromStorage(ctx context.Context, attachment
 	}
 }
 
-// TryPresignedAttachmentURL attempts to generate a presigned S3 URL for an attachment.
-// Returns the URL string if the attachment exists in S3, or an error if S3 is not
-// configured or the attachment is not found in S3.
+// TryPresignedAttachmentURL attempts to generate a presigned S3 URL for an
+// attachment. Returns the URL string if the attachment exists in S3, or an
+// error if S3 is not configured or the attachment is not found in S3.
+// Pass an empty spaceID to prefer the post-ADR-030-Phase-4 kind-less layout;
+// the helper falls back to the legacy `spaces/{server|DM}/...` keys for
+// layout mismatches.
 func (c *ChattoCore) TryPresignedAttachmentURL(ctx context.Context, spaceID, attachmentID string) (string, error) {
 	if c.s3Client == nil {
 		return "", fmt.Errorf("S3 not configured")
 	}
 
-	s3Key := S3KeySpaceAttachment(spaceID, attachmentID)
-
-	// Stat to verify the object exists (presigned URLs don't check existence)
-	if _, err := c.s3Client.StatObject(ctx, s3Key); err != nil {
-		return "", err
+	var lastErr error
+	for _, s3Key := range attachmentS3KeyCandidates(spaceID, attachmentID) {
+		// Stat to verify the object exists (presigned URLs don't check existence)
+		if _, err := c.s3Client.StatObject(ctx, s3Key); err != nil {
+			lastErr = err
+			continue
+		}
+		presignedURL, err := c.s3Client.PresignedGetURL(ctx, s3Key, time.Hour)
+		if err != nil {
+			return "", fmt.Errorf("failed to generate presigned URL: %w", err)
+		}
+		return presignedURL.String(), nil
 	}
-
-	presignedURL, err := c.s3Client.PresignedGetURL(ctx, s3Key, time.Hour)
-	if err != nil {
-		return "", fmt.Errorf("failed to generate presigned URL: %w", err)
+	if lastErr == nil {
+		lastErr = fmt.Errorf("attachment not found")
 	}
-
-	return presignedURL.String(), nil
+	return "", lastErr
 }
 
-// GetAttachmentURL returns the URL for accessing an attachment.
-// For legacy attachments without storage info, defaults to NATS path.
+// AttachmentSignResource is the first resource component fed to the
+// signed-URL signer for post-ADR-030-Phase-4 attachment transform URLs.
+// Stable so existing signatures continue to verify across deployments.
+const AttachmentSignResource = "attachment"
+
+// GetAttachmentURL returns the URL for accessing an attachment by its
+// canonical (legacy) identifier. New code should prefer
+// GetAttachmentURLFromStorage which routes new vs legacy paths based on
+// the Attachment record itself. A non-empty spaceID emits the legacy
+// `/assets/space/{spaceId}/attachments/{id}` URL; an empty spaceID emits
+// the new kind-less `/assets/attachments/{id}` URL.
 func (c *ChattoCore) GetAttachmentURL(spaceID, attachmentID string) string {
+	if spaceID == "" {
+		return c.assetURL(fmt.Sprintf("/assets/attachments/%s", attachmentID))
+	}
 	return c.assetURL(fmt.Sprintf("/assets/space/%s/attachments/%s", spaceID, attachmentID))
 }
 
 // GetAttachmentURLFromStorage returns the URL for accessing an attachment.
-// The URL is always the standard attachment URL format regardless of storage backend.
-// Storage backend is an internal implementation detail that should not leak into URLs.
+// Storage backend is an internal implementation detail that should not leak
+// into URLs. Legacy attachments (recorded with a `space_id` value before
+// ADR-030 Phase 4) keep their `/assets/space/{spaceId}/...` URL so the
+// existing S3 objects remain reachable; new uploads emit the kind-less
+// `/assets/attachments/{id}` URL.
 func (c *ChattoCore) GetAttachmentURLFromStorage(attachment *corev1.Attachment) string {
-	// Always use the standard attachment URL - the HTTP handler will determine storage
 	return c.GetAttachmentURL(attachment.SpaceId, attachment.Id)
 }
 
-// GetTransformedAttachmentURL returns the URL for accessing a transformed version of an attachment.
-// The URL includes HMAC signature to prevent parameter tampering.
-// Format: /assets/space/{spaceId}/attachments/{attachmentId}/t/{params}.{signature}
-// where {params} is base64url-encoded JSON: {"w":width,"h":height,"f":"fit"}
+// GetTransformedAttachmentURL returns the URL for accessing a transformed
+// version of an attachment. The URL includes an HMAC signature to prevent
+// parameter tampering.
+//
+// Legacy format (spaceID non-empty):
+//
+//	/assets/space/{spaceId}/attachments/{attachmentId}/t/{params}.{signature}
+//
+// New format (spaceID empty):
+//
+//	/assets/attachments/{attachmentId}/t/{params}.{signature}
+//
+// {params} is base64url-encoded JSON: {"w":width,"h":height,"f":"fit"}.
 func (c *ChattoCore) GetTransformedAttachmentURL(spaceID, attachmentID string, width, height int, fit string) string {
-	// Generate signed transform path component
+	if spaceID == "" {
+		signedPath := signedurl.SignedTransformPath(c.config.Assets.SigningSecret, AttachmentSignResource, attachmentID, width, height, fit)
+		return c.assetURL(fmt.Sprintf("/assets/attachments/%s/t/%s", attachmentID, signedPath))
+	}
 	signedPath := signedurl.SignedTransformPath(c.config.Assets.SigningSecret, spaceID, attachmentID, width, height, fit)
-
-	// Return signed transform URL with base64 path
 	return c.assetURL(fmt.Sprintf("/assets/space/%s/attachments/%s/t/%s",
 		spaceID, attachmentID, signedPath))
 }
 
-// GetTransformedAttachmentURLFromStorage returns the URL for accessing a transformed version of an attachment.
-// The URL is always the standard transformed attachment URL format regardless of storage backend.
-// Storage backend is an internal implementation detail that should not leak into URLs.
+// GetTransformedAttachmentURLFromStorage routes new vs legacy attachment
+// transform URLs based on the Attachment record. See
+// GetAttachmentURLFromStorage for the new vs legacy rules.
 func (c *ChattoCore) GetTransformedAttachmentURLFromStorage(attachment *corev1.Attachment, width, height int, fit string) string {
-	// Always use the standard transformed attachment URL - the HTTP handler will determine storage
 	return c.GetTransformedAttachmentURL(attachment.SpaceId, attachment.Id, width, height, fit)
 }
 
@@ -443,12 +520,16 @@ func (c *ChattoCore) StoreCachedResize(ctx context.Context, key string, data []b
 	return nil
 }
 
-// DeleteCachedResizesForAttachment deletes all cached resizes for an attachment.
+// DeleteCachedResizesForAttachment deletes all cached resizes for an
+// attachment. Pass an empty spaceID for post-ADR-030-Phase-4 attachments;
+// the helper picks the matching cache namespace.
 // Returns the number of deleted cache entries and any error encountered.
 // Does nothing if the cache is disabled.
 func (c *ChattoCore) DeleteCachedResizesForAttachment(ctx context.Context, spaceID, attachmentID string) (int, error) {
-	// Cache keys follow the pattern: {spaceId}.{attachmentId}.{paramsHash}
-	return c.DeleteCachedResizesForKey(ctx, spaceID, attachmentID)
+	// Cache keys follow the pattern: {prefix}.{attachmentId}.{paramsHash},
+	// where {prefix} matches what the transform handler used at insertion
+	// time (spaceID for legacy attachments, "attachment" for new ones).
+	return c.DeleteCachedResizesForKey(ctx, attachmentCachePrefix(spaceID), attachmentID)
 }
 
 // DeleteCachedResizesForKey deletes all cached resizes for a given prefix and asset key.
@@ -549,16 +630,16 @@ func (c *ChattoCore) InitVideoProcessingState(ctx context.Context, attachmentID 
 }
 
 // PublishVideoProcessingRequest publishes a video processing request to NATS.
-// Call this AFTER PostMessage, once the messageBodyID is known.
-func (c *ChattoCore) PublishVideoProcessingRequest(ctx context.Context, spaceID, roomID, attachmentID, contentType, messageBodyID string) error {
+// Call this AFTER PostMessage, once the messageBodyID is known. The video
+// service consumes this subject via a transient (non-JetStream) subscription,
+// so the payload format can evolve freely.
+func (c *ChattoCore) PublishVideoProcessingRequest(ctx context.Context, roomID, attachmentID, contentType, messageBodyID string) error {
 	payload := struct {
-		SpaceID       string `json:"space_id"`
 		RoomID        string `json:"room_id"`
 		AttachmentID  string `json:"attachment_id"`
 		ContentType   string `json:"content_type"`
 		MessageBodyID string `json:"message_body_id"`
 	}{
-		SpaceID:       spaceID,
 		RoomID:        roomID,
 		AttachmentID:  attachmentID,
 		ContentType:   contentType,
@@ -575,7 +656,6 @@ func (c *ChattoCore) PublishVideoProcessingRequest(ctx context.Context, spaceID,
 	}
 
 	c.logger.Debug("Requested video processing",
-		"space_id", spaceID,
 		"attachment_id", attachmentID,
 	)
 
@@ -600,9 +680,12 @@ func (c *ChattoCore) PublishVideoProcessingCompleted(ctx context.Context, kind R
 	return c.publishLiveServerEvent(ctx, subject, event)
 }
 
-// DeleteAttachmentFromStorageByID deletes an attachment from storage by space ID and attachment ID.
-// This probes both NATS and S3 backends. Used by the video service to delete the original
-// after successful transcoding.
+// DeleteAttachmentFromStorageByID deletes an attachment from storage by
+// space ID and attachment ID. This probes both NATS and S3 backends. Used
+// by the video service to delete the original after successful transcoding.
+// Pass an empty spaceID to prefer the post-ADR-030-Phase-4 kind-less layout;
+// the helper probes all known S3 layouts so layout mismatches resolve
+// transparently.
 func (c *ChattoCore) DeleteAttachmentFromStorageByID(ctx context.Context, spaceID, attachmentID string) error {
 	// Try NATS first
 	err := c.DeleteAttachment(ctx, spaceID, attachmentID)
@@ -610,11 +693,12 @@ func (c *ChattoCore) DeleteAttachmentFromStorageByID(ctx context.Context, spaceI
 		return nil
 	}
 
-	// Try S3
+	// Try S3 across known layouts.
 	if c.s3Client != nil {
-		s3Key := S3KeySpaceAttachment(spaceID, attachmentID)
-		if s3Err := c.s3Client.DeleteObject(ctx, s3Key); s3Err == nil {
-			return nil
+		for _, s3Key := range attachmentS3KeyCandidates(spaceID, attachmentID) {
+			if s3Err := c.s3Client.DeleteObject(ctx, s3Key); s3Err == nil {
+				return nil
+			}
 		}
 	}
 

--- a/cli/internal/core/attachments_test.go
+++ b/cli/internal/core/attachments_test.go
@@ -51,7 +51,6 @@ func TestChattoCore_UploadAttachment(t *testing.T) {
 
 		attachment, err := core.UploadAttachment(
 			ctx,
-			ServerSpaceID,
 			room.Id,
 			"test-image.png",
 			"image/png",
@@ -78,8 +77,9 @@ func TestChattoCore_UploadAttachment(t *testing.T) {
 			t.Errorf("Expected content type 'image/png', got '%s'", attachment.ContentType)
 		}
 
-		if attachment.SpaceId != ServerSpaceID {
-			t.Errorf("Expected space ID '%s', got '%s'", ServerSpaceID, attachment.SpaceId)
+		// New uploads no longer carry a space_id (ADR-030 Phase 4).
+		if attachment.SpaceId != "" {
+			t.Errorf("Expected empty space_id on new upload, got '%s'", attachment.SpaceId)
 		}
 
 		if attachment.RoomId != room.Id {
@@ -109,7 +109,6 @@ func TestChattoCore_UploadAttachment(t *testing.T) {
 
 		attachment, err := core.UploadAttachment(
 			ctx,
-			ServerSpaceID,
 			room.Id,
 			"test-file.txt",
 			"text/plain",
@@ -159,7 +158,6 @@ func TestChattoCore_GetAttachment(t *testing.T) {
 	// Upload an attachment
 	attachment, err := core.UploadAttachment(
 		ctx,
-		ServerSpaceID,
 		room.Id,
 		"test-file.txt",
 		"text/plain",
@@ -221,7 +219,6 @@ func TestChattoCore_DeleteAttachment(t *testing.T) {
 	// Upload an attachment
 	attachment, err := core.UploadAttachment(
 		ctx,
-		ServerSpaceID,
 		room.Id,
 		"test-file.txt",
 		"text/plain",
@@ -274,7 +271,7 @@ func TestChattoCore_UploadAttachment_S3(t *testing.T) {
 		t.Fatalf("Failed to create room: %v", err)
 	}
 
-	attachment, err := core.UploadAttachment(ctx, ServerSpaceID, room.Id, "test.txt", "text/plain", bytes.NewReader([]byte("hello S3")))
+	attachment, err := core.UploadAttachment(ctx, room.Id, "test.txt", "text/plain", bytes.NewReader([]byte("hello S3")))
 	if err != nil {
 		t.Fatalf("Failed to upload attachment: %v", err)
 	}
@@ -304,7 +301,7 @@ func TestChattoCore_DeleteAttachmentFromStorage_S3(t *testing.T) {
 		t.Fatalf("Failed to create room: %v", err)
 	}
 
-	attachment, err := core.UploadAttachment(ctx, ServerSpaceID, room.Id, "test.txt", "text/plain", bytes.NewReader([]byte("delete me from S3")))
+	attachment, err := core.UploadAttachment(ctx, room.Id, "test.txt", "text/plain", bytes.NewReader([]byte("delete me from S3")))
 	if err != nil {
 		t.Fatalf("Failed to upload attachment: %v", err)
 	}
@@ -446,14 +443,15 @@ func TestChattoCore_AssetBaseURL(t *testing.T) {
 		}
 
 		imageData := createTestPNG(50, 50)
-		attachment, err := core.UploadAttachment(ctx, ServerSpaceID, room.Id, "test.png", "image/png", bytes.NewReader(imageData))
+		attachment, err := core.UploadAttachment(ctx, room.Id, "test.png", "image/png", bytes.NewReader(imageData))
 		if err != nil {
 			t.Fatalf("Failed to upload: %v", err)
 		}
 
 		url := core.GetAttachmentURLFromStorage(attachment)
-		if !bytes.HasPrefix([]byte(url), []byte("https://chat.example.com/assets/space/")) {
-			t.Errorf("Expected absolute URL, got '%s'", url)
+		// New uploads emit the kind-less `/assets/attachments/{id}` path.
+		if !bytes.HasPrefix([]byte(url), []byte("https://chat.example.com/assets/attachments/")) {
+			t.Errorf("Expected absolute URL with /assets/attachments/ prefix, got '%s'", url)
 		}
 	})
 }
@@ -513,7 +511,6 @@ func TestAttachment_FullLifecycle(t *testing.T) {
 	// 1. Upload
 	attachment, err := core.UploadAttachment(
 		ctx,
-		ServerSpaceID,
 		room.Id,
 		"lifecycle-test.txt",
 		"text/plain",
@@ -568,7 +565,6 @@ func TestAttachment_MultipleInSpace(t *testing.T) {
 		content := []byte("Attachment content " + string(rune('A'+i)))
 		att, err := core.UploadAttachment(
 			ctx,
-			ServerSpaceID,
 			room.Id,
 			"attachment"+string(rune('A'+i))+".txt",
 			"text/plain",
@@ -619,7 +615,6 @@ func TestAttachment_ImageDimensions(t *testing.T) {
 
 			attachment, err := core.UploadAttachment(
 				ctx,
-				ServerSpaceID,
 				room.Id,
 				tc.name+".png",
 				"image/png",
@@ -853,7 +848,6 @@ func TestChattoCore_DeleteAttachment_CleansUpCache(t *testing.T) {
 	imageData := createTestPNG(100, 100)
 	attachment, err := core.UploadAttachment(
 		ctx,
-		ServerSpaceID,
 		room.Id,
 		"test-image.png",
 		"image/png",
@@ -918,8 +912,8 @@ func TestChattoCore_DeleteAttachment_DoesNotAffectOtherAttachmentCache(t *testin
 
 	// Create two attachments
 	imageData := createTestPNG(100, 100)
-	attachment1, _ := core.UploadAttachment(ctx, ServerSpaceID, room.Id, "image1.png", "image/png", bytes.NewReader(imageData))
-	attachment2, _ := core.UploadAttachment(ctx, ServerSpaceID, room.Id, "image2.png", "image/png", bytes.NewReader(imageData))
+	attachment1, _ := core.UploadAttachment(ctx, room.Id, "image1.png", "image/png", bytes.NewReader(imageData))
+	attachment2, _ := core.UploadAttachment(ctx, room.Id, "image2.png", "image/png", bytes.NewReader(imageData))
 
 	// Cache entries for both attachments
 	key1 := ImageCacheKey(ServerSpaceID, attachment1.Id, 200, 150, "contain")

--- a/cli/internal/core/messages_test.go
+++ b/cli/internal/core/messages_test.go
@@ -344,7 +344,7 @@ func TestChattoCore_DeleteMessage_DeletesAttachments(t *testing.T) {
 
 	// Upload an attachment (using createTestPNG from attachments_test.go)
 	imageData := createTestPNG(100, 100)
-	attachment, err := core.UploadAttachment(ctx, ServerSpaceID, room.Id, "test.png", "image/png", bytes.NewReader(imageData))
+	attachment, err := core.UploadAttachment(ctx, room.Id, "test.png", "image/png", bytes.NewReader(imageData))
 	if err != nil {
 		t.Fatalf("Failed to upload attachment: %v", err)
 	}
@@ -406,11 +406,11 @@ func TestChattoCore_DeleteAttachmentFromMessage(t *testing.T) {
 
 	// Upload two attachments
 	imageData := createTestPNG(100, 100)
-	attachment1, err := core.UploadAttachment(ctx, ServerSpaceID, room.Id, "test1.png", "image/png", bytes.NewReader(imageData))
+	attachment1, err := core.UploadAttachment(ctx, room.Id, "test1.png", "image/png", bytes.NewReader(imageData))
 	if err != nil {
 		t.Fatalf("Failed to upload attachment 1: %v", err)
 	}
-	attachment2, err := core.UploadAttachment(ctx, ServerSpaceID, room.Id, "test2.png", "image/png", bytes.NewReader(imageData))
+	attachment2, err := core.UploadAttachment(ctx, room.Id, "test2.png", "image/png", bytes.NewReader(imageData))
 	if err != nil {
 		t.Fatalf("Failed to upload attachment 2: %v", err)
 	}
@@ -482,7 +482,7 @@ func TestChattoCore_DeleteAttachmentFromMessage_NotAuthor(t *testing.T) {
 
 	// Upload attachment and post message as author
 	imageData := createTestPNG(100, 100)
-	attachment, err := core.UploadAttachment(ctx, ServerSpaceID, room.Id, "test.png", "image/png", bytes.NewReader(imageData))
+	attachment, err := core.UploadAttachment(ctx, room.Id, "test.png", "image/png", bytes.NewReader(imageData))
 	if err != nil {
 		t.Fatalf("Failed to upload attachment: %v", err)
 	}
@@ -523,7 +523,7 @@ func TestChattoCore_DeleteMessage_DeletesS3Attachments(t *testing.T) {
 
 	// Upload attachment (stored in S3)
 	imageData := createTestPNG(100, 100)
-	attachment, err := core.UploadAttachment(ctx, ServerSpaceID, room.Id, "test.png", "image/png", bytes.NewReader(imageData))
+	attachment, err := core.UploadAttachment(ctx, room.Id, "test.png", "image/png", bytes.NewReader(imageData))
 	if err != nil {
 		t.Fatalf("Failed to upload attachment: %v", err)
 	}
@@ -567,11 +567,11 @@ func TestChattoCore_DeleteAttachmentFromMessage_S3(t *testing.T) {
 
 	// Upload two attachments (stored in S3)
 	imageData := createTestPNG(100, 100)
-	attachment1, err := core.UploadAttachment(ctx, ServerSpaceID, room.Id, "test1.png", "image/png", bytes.NewReader(imageData))
+	attachment1, err := core.UploadAttachment(ctx, room.Id, "test1.png", "image/png", bytes.NewReader(imageData))
 	if err != nil {
 		t.Fatalf("Failed to upload attachment 1: %v", err)
 	}
-	attachment2, err := core.UploadAttachment(ctx, ServerSpaceID, room.Id, "test2.png", "image/png", bytes.NewReader(imageData))
+	attachment2, err := core.UploadAttachment(ctx, room.Id, "test2.png", "image/png", bytes.NewReader(imageData))
 	if err != nil {
 		t.Fatalf("Failed to upload attachment 2: %v", err)
 	}

--- a/cli/internal/core/s3.go
+++ b/cli/internal/core/s3.go
@@ -188,11 +188,23 @@ func (s *S3Client) PresignedGetURL(ctx context.Context, key string, expiry time.
 }
 
 // S3 key helpers for organizing assets in S3.
-// Space attachments use hierarchical paths; server assets use flat keys matching NATS.
 
-// S3KeySpaceAttachment returns the S3 key for a space attachment.
+// S3KeyAttachment returns the S3 key for an attachment.
+// Format: attachments/{attachmentId}
+// This is the canonical post-ADR-030 layout — no kind segment. New uploads
+// use this key; existing attachments stay at their pre-existing
+// `spaces/{spaceId}/attachments/{id}` paths (see S3KeySpaceAttachment).
+func S3KeyAttachment(attachmentID string) string {
+	return fmt.Sprintf("attachments/%s", attachmentID)
+}
+
+// S3KeySpaceAttachment returns the legacy S3 key for an attachment uploaded
+// before ADR-030 Phase 4. Wire-frozen because changing it would require
+// copying every existing S3 object. New uploads use S3KeyAttachment;
+// `spaceId` here is always the literal "server" or "DM" recorded on the
+// attachment's `space_id` field.
+//
 // Format: spaces/{spaceId}/attachments/{attachmentId}
-// This format allows the HTTP handler to construct the key from URL parameters.
 func S3KeySpaceAttachment(spaceID, attachmentID string) string {
 	return fmt.Sprintf("spaces/%s/attachments/%s", spaceID, attachmentID)
 }

--- a/cli/internal/core/s3_test.go
+++ b/cli/internal/core/s3_test.go
@@ -174,6 +174,13 @@ func TestS3KeyHelpers(t *testing.T) {
 		expected string
 	}{
 		{
+			name: "Attachment",
+			function: func() string {
+				return core.S3KeyAttachment("attach456")
+			},
+			expected: "attachments/attach456",
+		},
+		{
 			name: "SpaceAttachment",
 			function: func() string {
 				return core.S3KeySpaceAttachment("space123", "attach456")
@@ -257,4 +264,3 @@ func TestStorageBackendEncapsulation_URLGeneration(t *testing.T) {
 		require.Equal(t, assetID, s3Asset.GetS3().Key)
 	})
 }
-

--- a/cli/internal/graph/mutation.resolvers.go
+++ b/cli/internal/graph/mutation.resolvers.go
@@ -253,7 +253,6 @@ func (r *mutationResolver) PostMessage(ctx context.Context, input model.PostMess
 
 			attachment, err := r.core.UploadAttachment(
 				ctx,
-				core.SpaceIDForKind(kind),
 				input.RoomID,
 				upload.Filename,
 				upload.ContentType,
@@ -348,7 +347,7 @@ func (r *mutationResolver) PostMessage(ctx context.Context, input model.PostMess
 		if msg := event.GetMessagePosted(); msg != nil {
 			for _, att := range attachments {
 				if strings.HasPrefix(att.ContentType, "video/") || animatedGIFs[att.Id] {
-					if err := r.core.PublishVideoProcessingRequest(ctx, core.SpaceIDForKind(kind), input.RoomID, att.Id, att.ContentType, msg.MessageBodyId); err != nil {
+					if err := r.core.PublishVideoProcessingRequest(ctx, input.RoomID, att.Id, att.ContentType, msg.MessageBodyId); err != nil {
 						r.logger.Warn("Failed to request video processing", "attachment_id", att.Id, "error", err)
 					}
 				}

--- a/cli/internal/http_server/assets.go
+++ b/cli/internal/http_server/assets.go
@@ -16,10 +16,15 @@ import (
 )
 
 func (s *HTTPServer) setupAssetRoutes() {
-	// Instance assets use *path which catches everything including /t/signedPath for transforms
+	// Server assets use *path which catches everything including /t/signedPath for transforms
 	// The serveServerAsset handler detects and routes transform requests appropriately
 	// These handlers probe both NATS and S3 backends automatically
 	s.router.GET("/assets/server/*path", s.serveServerAsset)
+	// Post-ADR-030-Phase-4 attachment routes (kind-less). New uploads use these.
+	s.router.GET("/assets/attachments/:attachmentId", s.serveAttachment)
+	s.router.GET("/assets/attachments/:attachmentId/t/:signedPath", s.serveTransformedAttachmentByID)
+	// Legacy routes — kept for attachments uploaded before Phase 4 whose S3
+	// objects still live at `spaces/{server|DM}/attachments/{id}`.
 	s.router.GET("/assets/space/:spaceId/attachments/:attachmentId", s.serveSpaceAttachment)
 	s.router.GET("/assets/space/:spaceId/attachments/:attachmentId/t/:signedPath", s.serveTransformedAttachment)
 }
@@ -117,7 +122,7 @@ func (s *HTTPServer) serveSpaceAttachment(c *gin.Context) {
 	if presignedURL, err := s.core.TryPresignedAttachmentURL(ctx, spaceID, attachmentID); err == nil {
 		// S3 attachments don't store roomID, so authorizeAttachmentAccess passes
 		// with empty roomID (same as the previous proxying behavior).
-		if !s.authorizeAttachmentAccess(c, spaceID, "") {
+		if !s.authorizeAttachmentAccess(c, "") {
 			return
 		}
 
@@ -139,7 +144,7 @@ func (s *HTTPServer) serveSpaceAttachment(c *gin.Context) {
 		defer closer.Close()
 	}
 
-	if !s.authorizeAttachmentAccess(c, spaceID, info.RoomID) {
+	if !s.authorizeAttachmentAccess(c, info.RoomID) {
 		return
 	}
 
@@ -157,9 +162,67 @@ func (s *HTTPServer) serveSpaceAttachment(c *gin.Context) {
 	c.DataFromReader(http.StatusOK, info.Size, contentType, reader, nil)
 }
 
+// serveAttachment serves an attachment uploaded via the post-ADR-030-Phase-4
+// kind-less URL pattern (`/assets/attachments/{id}`).
+//
+// Mirrors serveSpaceAttachment but passes an empty spaceID to the core
+// helpers, which picks the new `attachments/{id}` S3 layout for S3-stored
+// attachments. NATS-stored attachments use the same attachment ID regardless
+// of upload era.
+func (s *HTTPServer) serveAttachment(c *gin.Context) {
+	attachmentID := c.Param("attachmentId")
+	ctx := c.Request.Context()
+
+	s.logger.Debug("Serving attachment", "attachment_id", attachmentID)
+
+	// Try S3 presigned redirect first (zero-copy, full Range support)
+	if presignedURL, err := s.core.TryPresignedAttachmentURL(ctx, "", attachmentID); err == nil {
+		// S3 attachments don't store roomID, so authorizeAttachmentAccess passes
+		// with empty roomID (same as the legacy proxying behavior).
+		if !s.authorizeAttachmentAccess(c, "") {
+			return
+		}
+
+		// Cache the redirect itself — the attachment URL is immutable
+		c.Header("Cache-Control", "public, max-age=3600")
+		c.Redirect(http.StatusFound, presignedURL)
+		return
+	}
+
+	// Fall back to probing both NATS and S3 backends
+	reader, info, err := s.core.GetAttachmentFromAnyBackend(ctx, "", attachmentID)
+	if err != nil {
+		s.logger.Error("Failed to get attachment", "error", err, "attachment_id", attachmentID)
+		c.JSON(http.StatusNotFound, gin.H{"error": "Attachment not found"})
+		return
+	}
+	if closer, ok := reader.(io.Closer); ok {
+		defer closer.Close()
+	}
+
+	if !s.authorizeAttachmentAccess(c, info.RoomID) {
+		return
+	}
+
+	contentType := info.ContentType
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+
+	// Immutable asset - cache forever
+	c.Header("Cache-Control", "public, max-age=31536000, immutable")
+	c.Header("ETag", fmt.Sprintf("\"%s\"", attachmentID))
+	c.Header("Vary", "Accept-Encoding")
+
+	// Stream directly — no io.ReadAll, no memory buffering
+	c.DataFromReader(http.StatusOK, info.Size, contentType, reader, nil)
+}
+
 // authorizeAttachmentAccess checks if the current user can access an attachment.
 // Returns true if authorized, false if not (and sends appropriate error response).
-func (s *HTTPServer) authorizeAttachmentAccess(c *gin.Context, spaceID, roomID string) bool {
+// An empty roomID is treated as public (matches legacy S3 attachment behavior,
+// where the room ID isn't recoverable from the storage backend).
+func (s *HTTPServer) authorizeAttachmentAccess(c *gin.Context, roomID string) bool {
 	if roomID == "" {
 		return true
 	}
@@ -170,7 +233,14 @@ func (s *HTTPServer) authorizeAttachmentAccess(c *gin.Context, spaceID, roomID s
 		return false
 	}
 
-	isMember, err := s.core.RoomMembershipExists(c.Request.Context(), core.KindForSpace(spaceID), userID, roomID)
+	kind, err := s.core.FindRoomKind(c.Request.Context(), roomID)
+	if err != nil {
+		s.logger.Error("Failed to resolve room kind for attachment auth", "error", err, "room_id", roomID)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to verify access"})
+		return false
+	}
+
+	isMember, err := s.core.RoomMembershipExists(c.Request.Context(), kind, userID, roomID)
 	if err != nil {
 		s.logger.Error("Failed to check room membership", "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to verify access"})
@@ -397,7 +467,52 @@ func (s *HTTPServer) serveTransformedAttachment(c *gin.Context) {
 				cachedRoomID = info.RoomID
 				roomIDFetched = true
 			}
-			return s.authorizeAttachmentAccess(c, spaceID, cachedRoomID)
+			return s.authorizeAttachmentAccess(c, cachedRoomID)
+		},
+	})
+}
+
+// serveTransformedAttachmentByID serves a dynamically transformed version of
+// a post-ADR-030-Phase-4 attachment.
+// URL format: /assets/attachments/{attachmentId}/t/{signedPath}
+// Mirrors serveTransformedAttachment but signs with ("attachment", id)
+// instead of (spaceID, id), and uses the kind-less cache namespace.
+func (s *HTTPServer) serveTransformedAttachmentByID(c *gin.Context) {
+	attachmentID := c.Param("attachmentId")
+	signedPath := c.Param("signedPath")
+
+	s.logger.Debug("Serving transformed attachment", "attachment_id", attachmentID)
+
+	var cachedRoomID string
+	var roomIDFetched bool
+
+	s.serveTransformedAsset(c, transformRequest{
+		ResourceID1: core.AttachmentSignResource,
+		ResourceID2: attachmentID,
+		SignedPath:  signedPath,
+		CachePrefix: core.AttachmentSignResource,
+		AssetID:     attachmentID,
+		FetchAsset: func(ctx context.Context) (io.Reader, string, error) {
+			reader, info, err := s.core.GetAttachmentFromAnyBackend(ctx, "", attachmentID)
+			if err != nil {
+				return nil, "", err
+			}
+			cachedRoomID = info.RoomID
+			roomIDFetched = true
+			return reader, info.ContentType, nil
+		},
+		Authorize: func(c *gin.Context) bool {
+			if !roomIDFetched {
+				_, info, err := s.core.GetAttachmentFromAnyBackend(c.Request.Context(), "", attachmentID)
+				if err != nil {
+					s.logger.Error("Failed to get attachment for auth", "error", err)
+					c.JSON(http.StatusNotFound, gin.H{"error": "Attachment not found"})
+					return false
+				}
+				cachedRoomID = info.RoomID
+				roomIDFetched = true
+			}
+			return s.authorizeAttachmentAccess(c, cachedRoomID)
 		},
 	})
 }

--- a/cli/internal/video/processor.go
+++ b/cli/internal/video/processor.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"hmans.de/chatto/internal/core"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
@@ -217,7 +216,7 @@ func (s *Service) processVideo(ctx context.Context, req ProcessRequest) error {
 
 	// Download original from asset store
 	inputPath := filepath.Join(tmpDir, "input")
-	if err := s.downloadAttachment(ctx, req.SpaceID, req.AttachmentID, inputPath); err != nil {
+	if err := s.downloadAttachment(ctx, req.AttachmentID, inputPath); err != nil {
 		return s.failProcessing(ctx, req, fmt.Errorf("failed to download original: %w", err))
 	}
 
@@ -261,7 +260,7 @@ func (s *Service) processVideo(ctx context.Context, req ProcessRequest) error {
 	// Upload thumbnail as attachment
 	var thumbnailAttachmentID string
 	if thumbPath != "" {
-		thumbID, err := s.uploadFile(ctx, req.SpaceID, req.RoomID, "thumbnail.jpg", "image/jpeg", thumbPath)
+		thumbID, err := s.uploadFile(ctx, req.RoomID, "thumbnail.jpg", "image/jpeg", thumbPath)
 		if err != nil {
 			s.logger.Warn("Failed to upload thumbnail", "error", err)
 		} else {
@@ -296,7 +295,7 @@ func (s *Service) processVideo(ctx context.Context, req ProcessRequest) error {
 		// Upload variant as attachment
 		quality := fmt.Sprintf("%dp", h)
 		filename := fmt.Sprintf("%s_%s.mp4", strings.TrimSuffix(req.AttachmentID, filepath.Ext(req.AttachmentID)), quality)
-		variantID, err := s.uploadFile(ctx, req.SpaceID, req.RoomID, filename, "video/mp4", outputPath)
+		variantID, err := s.uploadFile(ctx, req.RoomID, filename, "video/mp4", outputPath)
 		if err != nil {
 			s.logger.Error("Failed to upload variant", "height", h, "error", err)
 			continue
@@ -335,14 +334,19 @@ func (s *Service) processVideo(ctx context.Context, req ProcessRequest) error {
 		return fmt.Errorf("failed to set completed state: %w", err)
 	}
 
-	// Delete the original attachment (save storage — variants replace it)
-	if err := s.core.DeleteAttachmentFromStorageByID(ctx, req.SpaceID, req.AttachmentID); err != nil {
+	// Delete the original attachment (save storage — variants replace it).
+	// Post-ADR-030-Phase-4 originals live at the kind-less S3 key
+	// (`attachments/{id}`); passing an empty spaceID picks that layout.
+	if err := s.core.DeleteAttachmentFromStorageByID(ctx, "", req.AttachmentID); err != nil {
 		s.logger.Warn("Failed to delete original after transcoding", "error", err)
 		// Non-fatal — the variants are already uploaded
 	}
 
 	// Publish live event
-	if err := s.core.PublishVideoProcessingCompleted(ctx, core.KindForSpace(req.SpaceID), req.RoomID, req.AttachmentID, req.MessageBodyID); err != nil {
+	kind, err := s.core.FindRoomKind(ctx, req.RoomID)
+	if err != nil {
+		s.logger.Warn("Failed to resolve room kind for video-completed event", "error", err)
+	} else if err := s.core.PublishVideoProcessingCompleted(ctx, kind, req.RoomID, req.AttachmentID, req.MessageBodyID); err != nil {
 		s.logger.Warn("Failed to publish video processing completed event", "error", err)
 	}
 
@@ -359,7 +363,6 @@ func (s *Service) failProcessing(ctx context.Context, req ProcessRequest, origin
 	// Log the full error for server-side debugging (may contain file paths, ffmpeg output, etc.)
 	s.logger.Error("Video processing failed",
 		"attachment_id", req.AttachmentID,
-		"space_id", req.SpaceID,
 		"error", originalErr)
 
 	state := &corev1.VideoProcessingState{
@@ -370,15 +373,19 @@ func (s *Service) failProcessing(ctx context.Context, req ProcessRequest, origin
 		s.logger.Error("Failed to set error state", "error", err)
 	}
 	// Publish live event even on failure so frontend can update
-	if err := s.core.PublishVideoProcessingCompleted(ctx, core.KindForSpace(req.SpaceID), req.RoomID, req.AttachmentID, req.MessageBodyID); err != nil {
+	kind, kindErr := s.core.FindRoomKind(ctx, req.RoomID)
+	if kindErr != nil {
+		s.logger.Warn("Failed to resolve room kind for video-failed event", "error", kindErr)
+	} else if err := s.core.PublishVideoProcessingCompleted(ctx, kind, req.RoomID, req.AttachmentID, req.MessageBodyID); err != nil {
 		s.logger.Warn("Failed to publish video processing failed event", "error", err)
 	}
 	return originalErr
 }
 
 // downloadAttachment downloads an attachment from the asset store to a local file.
-func (s *Service) downloadAttachment(ctx context.Context, spaceID, attachmentID, destPath string) error {
-	reader, _, err := s.core.GetAttachmentFromAnyBackend(ctx, spaceID, attachmentID)
+func (s *Service) downloadAttachment(ctx context.Context, attachmentID, destPath string) error {
+	// New uploads use the kind-less S3 layout (empty spaceID).
+	reader, _, err := s.core.GetAttachmentFromAnyBackend(ctx, "", attachmentID)
 	if err != nil {
 		return err
 	}
@@ -400,18 +407,17 @@ func (s *Service) downloadAttachment(ctx context.Context, spaceID, attachmentID,
 }
 
 // uploadFile uploads a local file as an attachment and returns the new attachment ID.
-func (s *Service) uploadFile(ctx context.Context, spaceID, roomID, filename, contentType, srcPath string) (string, error) {
+func (s *Service) uploadFile(ctx context.Context, roomID, filename, contentType, srcPath string) (string, error) {
 	f, err := os.Open(srcPath)
 	if err != nil {
 		return "", err
 	}
 	defer f.Close()
 
-	att, err := s.core.UploadAttachment(ctx, spaceID, roomID, filename, contentType, f)
+	att, err := s.core.UploadAttachment(ctx, roomID, filename, contentType, f)
 	if err != nil {
 		return "", err
 	}
 
 	return att.Id, nil
 }
-

--- a/cli/internal/video/service.go
+++ b/cli/internal/video/service.go
@@ -24,8 +24,14 @@ import (
 )
 
 // ProcessRequest is the payload published to request video processing.
+//
+// The video processing subject (`chatto.video.process`) is a NATS Core
+// subscription, not JetStream — there are no persisted requests to worry
+// about. The legacy `space_id` field was dropped in ADR-030 Phase 4; any
+// stale in-flight request from a pre-Phase-4 binary will simply have its
+// `space_id` ignored (unknown JSON fields are dropped silently) and the
+// downstream code paths handle the empty-spaceID case.
 type ProcessRequest struct {
-	SpaceID       string `json:"space_id"`
 	RoomID        string `json:"room_id"`
 	AttachmentID  string `json:"attachment_id"`
 	ContentType   string `json:"content_type"`
@@ -36,11 +42,11 @@ type ProcessRequest struct {
 // It subscribes to a NATS subject for processing requests and manages
 // a pool of concurrent ffmpeg workers.
 type Service struct {
-	core       *core.ChattoCore
-	nc         *nats.Conn
-	config     config.VideoConfig
-	logger     *log.Logger
-	ffmpegPath string
+	core        *core.ChattoCore
+	nc          *nats.Conn
+	config      config.VideoConfig
+	logger      *log.Logger
+	ffmpegPath  string
 	ffprobePath string
 }
 
@@ -90,7 +96,6 @@ func (s *Service) Run(ctx context.Context) error {
 		}
 
 		s.logger.Info("Received video processing request",
-			"space_id", req.SpaceID,
 			"attachment_id", req.AttachmentID,
 		)
 
@@ -108,7 +113,6 @@ func (s *Service) Run(ctx context.Context) error {
 
 			if err := s.processVideo(ctx, req); err != nil {
 				s.logger.Error("Video processing failed",
-					"space_id", req.SpaceID,
 					"attachment_id", req.AttachmentID,
 					"error", err,
 				)


### PR DESCRIPTION
## Summary

ADR-030 Phase 4: new attachments no longer carry a meaningless `server`/`DM` discriminator in their S3 keys, asset URLs, or proto field. New uploads land at S3 key `attachments/{id}` and URL `/assets/attachments/{id}` (+ `/t/{signedPath}` for transforms), with `Attachment.SpaceId` left empty; existing attachments stay exactly where they are — no S3 file moves — and continue to be served via the legacy `/assets/space/{spaceId}/...` routes. Helpers like `GetAttachmentFromAnyBackend`, `TryPresignedAttachmentURL`, and `DeleteAttachmentFromStorageByID` probe across all known S3 layouts so cross-deploy mismatches (e.g. a legacy in-flight video-processing request handled by a Phase-4 binary) resolve transparently. The HTTP authorization path now derives kind via `FindRoomKind` instead of reading the spaceID off the URL.

## Test plan

- [x] `mise codegen-cli` regenerates cleanly
- [x] `mise test-cli` passes (updated `attachments_test.go`, `messages_test.go`, `s3_test.go`)
- [ ] `mise test-e2e` — upload image / video attachments, verify thumbnails and transformed URLs render in the browser; verify legacy attachments (pre-PR) still serve correctly