### PR TITLE
fix(assets): authorize attachment downloads via canonical Attachment records

### DIFF
--- a/cli/internal/core/attachments.go
+++ b/cli/internal/core/attachments.go
@@ -135,6 +135,31 @@ func (c *ChattoCore) UploadAttachment(
 		}
 	}
 
+	attachment := &corev1.Attachment{
+		Id:          attachmentID,
+		RoomId:      roomID,
+		Filename:    filename,
+		ContentType: contentType,
+		Size:        size,
+		Width:       width,
+		Height:      height,
+		Storage:     storage,
+	}
+
+	// Write the canonical Attachment record. The asset HTTP handler
+	// authorizes downloads off this record, so a failure here would
+	// strand the uploaded binary unreachable behind a 404. Best-effort
+	// delete the just-uploaded binary before surfacing the error, so
+	// we don't leak orphans into storage.
+	if err := c.recordAttachment(ctx, attachment); err != nil {
+		if cleanupErr := c.deleteAttachmentBinary(ctx, attachmentID, storage); cleanupErr != nil {
+			c.logger.Warn("Failed to clean up attachment binary after metadata write failure",
+				"attachment_id", attachmentID,
+				"error", cleanupErr)
+		}
+		return nil, fmt.Errorf("failed to record attachment metadata: %w", err)
+	}
+
 	c.logger.Debug("Uploaded attachment",
 		"attachment_id", attachmentID,
 		"room_id", roomID,
@@ -144,16 +169,7 @@ func (c *ChattoCore) UploadAttachment(
 		"storage_backend", c.config.Assets.StorageBackend,
 	)
 
-	return &corev1.Attachment{
-		Id:          attachmentID,
-		RoomId:      roomID,
-		Filename:    filename,
-		ContentType: contentType,
-		Size:        size,
-		Width:       width,
-		Height:      height,
-		Storage:     storage,
-	}, nil
+	return attachment, nil
 }
 
 // AttachmentInfo contains metadata about an attachment.
@@ -190,6 +206,10 @@ func (c *ChattoCore) GetAttachment(ctx context.Context, attachmentID string) (io
 // GetS3Attachment retrieves an attachment from S3 by its key.
 // Returns a reader for the attachment content and metadata.
 // The caller is responsible for closing the reader.
+//
+// AttachmentInfo.RoomID is NOT populated here — S3 has no equivalent of
+// the NATS `Room-Id` header. Callers that need authorization should
+// instead look up the canonical Attachment record via GetAttachmentRecord.
 func (c *ChattoCore) GetS3Attachment(ctx context.Context, s3Key string) (io.ReadCloser, *AttachmentInfo, error) {
 	if c.s3Client == nil {
 		return nil, nil, fmt.Errorf("S3 client not configured")
@@ -277,7 +297,6 @@ func (c *ChattoCore) GetAttachmentFromAnyBackend(ctx context.Context, spaceID, a
 			}
 			lastS3Err = s3Err
 		}
-		// Log the last S3 error but return the original NATS error
 		c.logger.Debug("Attachment not found in either backend",
 			"space_id", spaceID,
 			"attachment_id", attachmentID,
@@ -286,6 +305,156 @@ func (c *ChattoCore) GetAttachmentFromAnyBackend(ctx context.Context, spaceID, a
 	}
 
 	return nil, nil, err
+}
+
+// ============================================================================
+// Attachment Records
+// ============================================================================
+//
+// Attachment metadata records live in SERVER_BODIES alongside the
+// message bodies that reference them. They share the bucket because:
+//
+//   - The lifecycle is the same: an attachment is born with the body
+//     that posts it and dies when that body is deleted (incl. GDPR).
+//   - The write profile is the same (per-message churn), so we don't
+//     have to provision another replicated stream for an essentially
+//     identical workload.
+//
+// Two key shapes coexist in this bucket — they don't overlap because
+// body keys have two tokens and attachment-record keys have three:
+//
+//   - {userId}.{bodyId}                       → marshaled MessageBody
+//   - attachment.{roomId}.{attachmentId}      → marshaled Attachment
+//
+// Room ID lives in the key so the per-room attachment sidebar can
+// prefix-filter (`attachment.{roomId}.*`); by-ID lookup uses a
+// server-side wildcard filter (`attachment.*.{attachmentId}`).
+//
+// TODO: rename SERVER_BODIES → SERVER_CONTENT now that it hosts more
+// than bodies. Pending a separate migration since renaming a bucket
+// requires copying every key.
+
+// attachmentRecordKey returns the SERVER_BODIES key for an attachment
+// metadata record. The "attachment." literal prefix keeps these keys
+// out of the way of body keys (`{userId}.{bodyId}`).
+func attachmentRecordKey(roomID, attachmentID string) string {
+	return "attachment." + roomID + "." + attachmentID
+}
+
+// recordAttachment stores the canonical Attachment metadata record.
+func (c *ChattoCore) recordAttachment(ctx context.Context, attachment *corev1.Attachment) error {
+	if attachment == nil || attachment.Id == "" || attachment.RoomId == "" {
+		return fmt.Errorf("recordAttachment: missing id or room id")
+	}
+	data, err := proto.Marshal(attachment)
+	if err != nil {
+		return fmt.Errorf("marshal attachment: %w", err)
+	}
+	if _, err := c.storage.serverBodiesKV.Put(ctx, attachmentRecordKey(attachment.RoomId, attachment.Id), data); err != nil {
+		return fmt.Errorf("write attachment record: %w", err)
+	}
+	return nil
+}
+
+// GetAttachmentRecord returns the canonical Attachment metadata for the
+// given ID, or (nil, nil) if no record exists. Uses a server-side
+// wildcard filter on the key (`attachment.*.{attachmentId}`).
+func (c *ChattoCore) GetAttachmentRecord(ctx context.Context, attachmentID string) (*corev1.Attachment, error) {
+	if attachmentID == "" {
+		return nil, nil
+	}
+	lister, err := c.storage.serverBodiesKV.ListKeysFiltered(ctx, "attachment.*."+attachmentID)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("filter attachment keys: %w", err)
+	}
+	for key := range lister.Keys() {
+		entry, err := c.storage.serverBodiesKV.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			return nil, fmt.Errorf("get attachment record: %w", err)
+		}
+		var att corev1.Attachment
+		if err := proto.Unmarshal(entry.Value(), &att); err != nil {
+			return nil, fmt.Errorf("unmarshal attachment record: %w", err)
+		}
+		return &att, nil
+	}
+	return nil, nil
+}
+
+// ListRoomAttachments returns every Attachment metadata record posted
+// to the given room. Used by the per-room attachment sidebar. Reads
+// every matching record into memory — adequate for the expected
+// sidebar size; rooms with huge attachment counts will eventually want
+// a pagination cursor.
+func (c *ChattoCore) ListRoomAttachments(ctx context.Context, roomID string) ([]*corev1.Attachment, error) {
+	if roomID == "" {
+		return nil, nil
+	}
+	lister, err := c.storage.serverBodiesKV.ListKeysFiltered(ctx, "attachment."+roomID+".*")
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("list room attachments: %w", err)
+	}
+	var out []*corev1.Attachment
+	for key := range lister.Keys() {
+		entry, err := c.storage.serverBodiesKV.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			return nil, fmt.Errorf("get attachment record: %w", err)
+		}
+		var att corev1.Attachment
+		if err := proto.Unmarshal(entry.Value(), &att); err != nil {
+			c.logger.Warn("Skipping unparseable attachment record", "key", key, "error", err)
+			continue
+		}
+		out = append(out, &att)
+	}
+	return out, nil
+}
+
+// deleteAttachmentBinary removes the storage object for a freshly
+// uploaded attachment. Used to clean up after a metadata-write failure
+// in UploadAttachment so we don't strand orphans in storage.
+func (c *ChattoCore) deleteAttachmentBinary(ctx context.Context, attachmentID string, storage *corev1.Asset) error {
+	if storage == nil {
+		return nil
+	}
+	switch asset := storage.Asset.(type) {
+	case *corev1.Asset_S3:
+		if c.s3Client == nil {
+			return nil
+		}
+		return c.s3Client.DeleteObject(ctx, asset.S3.Key)
+	case *corev1.Asset_Nats:
+		store, err := c.GetAttachmentsStore(ctx)
+		if err != nil {
+			return err
+		}
+		return store.Delete(ctx, attachmentID)
+	}
+	return nil
+}
+
+// forgetAttachmentRecord removes the attachment metadata record.
+// Missing entries are not an error.
+func (c *ChattoCore) forgetAttachmentRecord(ctx context.Context, roomID, attachmentID string) error {
+	if roomID == "" || attachmentID == "" {
+		return nil
+	}
+	if err := c.storage.serverBodiesKV.Delete(ctx, attachmentRecordKey(roomID, attachmentID)); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+		return fmt.Errorf("delete attachment record: %w", err)
+	}
+	return nil
 }
 
 // DeleteAttachment deletes a NATS attachment and its cached resizes.
@@ -297,9 +466,24 @@ func (c *ChattoCore) DeleteAttachment(ctx context.Context, spaceID, attachmentID
 		return fmt.Errorf("failed to get attachments store: %w", err)
 	}
 
+	// Resolve the room ID via the canonical record before we delete the
+	// underlying object, so we can also drop the metadata entry. If no
+	// record exists (legacy orphan), we still proceed with the storage
+	// delete — the record cleanup is best-effort and silently no-ops.
+	var roomID string
+	if rec, recErr := c.GetAttachmentRecord(ctx, attachmentID); recErr == nil && rec != nil {
+		roomID = rec.RoomId
+	}
+
 	err = store.Delete(ctx, attachmentID)
 	if err != nil {
 		return fmt.Errorf("failed to delete attachment: %w", err)
+	}
+
+	if recErr := c.forgetAttachmentRecord(ctx, roomID, attachmentID); recErr != nil {
+		c.logger.Warn("Failed to forget attachment record",
+			"attachment_id", attachmentID,
+			"error", recErr)
 	}
 
 	// Delete any cached resizes for this attachment (best-effort, don't fail on error)
@@ -340,6 +524,11 @@ func (c *ChattoCore) DeleteAttachmentFromStorage(ctx context.Context, attachment
 		if err := c.s3Client.DeleteObjectFromBucket(ctx, storage.S3.GetBucket(), storage.S3.Key); err != nil {
 			return fmt.Errorf("failed to delete S3 attachment: %w", err)
 		}
+		if recErr := c.forgetAttachmentRecord(ctx, attachment.RoomId, attachment.Id); recErr != nil {
+			c.logger.Warn("Failed to forget attachment record",
+				"attachment_id", attachment.Id,
+				"error", recErr)
+		}
 		// Delete any cached resizes (S3 attachments use the S3 key as cache prefix)
 		deletedCount, cacheErr := c.DeleteCachedResizesForKey(ctx, "s3", storage.S3.Key)
 		if cacheErr != nil {
@@ -364,6 +553,9 @@ func (c *ChattoCore) DeleteAttachmentFromStorage(ctx context.Context, attachment
 // Pass an empty spaceID to prefer the post-ADR-030-Phase-4 kind-less layout;
 // the helper falls back to the legacy `spaces/{server|DM}/...` keys for
 // layout mismatches.
+//
+// Authorization is the caller's responsibility — the room ID comes from
+// the canonical Attachment record (see GetAttachmentRecord), not from S3.
 func (c *ChattoCore) TryPresignedAttachmentURL(ctx context.Context, spaceID, attachmentID string) (string, error) {
 	if c.s3Client == nil {
 		return "", fmt.Errorf("S3 not configured")
@@ -695,8 +887,19 @@ func (c *ChattoCore) DeleteAttachmentFromStorageByID(ctx context.Context, spaceI
 
 	// Try S3 across known layouts.
 	if c.s3Client != nil {
+		// Resolve the room ID via the canonical record so we can clean
+		// up the metadata entry alongside the storage object.
+		var roomID string
+		if rec, recErr := c.GetAttachmentRecord(ctx, attachmentID); recErr == nil && rec != nil {
+			roomID = rec.RoomId
+		}
 		for _, s3Key := range attachmentS3KeyCandidates(spaceID, attachmentID) {
 			if s3Err := c.s3Client.DeleteObject(ctx, s3Key); s3Err == nil {
+				if recErr := c.forgetAttachmentRecord(ctx, roomID, attachmentID); recErr != nil {
+					c.logger.Warn("Failed to forget attachment record",
+						"attachment_id", attachmentID,
+						"error", recErr)
+				}
 				return nil
 			}
 		}

--- a/cli/internal/core/attachments_test.go
+++ b/cli/internal/core/attachments_test.go
@@ -970,3 +970,135 @@ func TestChattoCore_DeleteCachedResizesForAttachment_EmptyCache(t *testing.T) {
 		t.Errorf("Should return 0 deleted on empty cache, got %d", deleted)
 	}
 }
+
+// ============================================================================
+// Attachment Record Tests (SERVER_BODIES)
+// ============================================================================
+
+// TestUploadAttachment_WritesRecord verifies that every new upload
+// produces a lookup-able Attachment record in SERVER_BODIES. The
+// asset HTTP handler authorizes off this record, so its presence after
+// upload is auth-critical.
+func TestUploadAttachment_WritesRecord(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	room, err := core.CreateRoom(ctx, "test-user", KindChannel, "", "test-room", "Test room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+
+	attachment, err := core.UploadAttachment(ctx, room.Id, "test.txt", "text/plain", bytes.NewReader([]byte("hello")))
+	if err != nil {
+		t.Fatalf("Failed to upload attachment: %v", err)
+	}
+
+	got, err := core.GetAttachmentRecord(ctx, attachment.Id)
+	if err != nil {
+		t.Fatalf("GetAttachmentRecord error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Expected attachment record, got nil")
+	}
+	if got.Id != attachment.Id {
+		t.Errorf("Expected record id %q, got %q", attachment.Id, got.Id)
+	}
+	if got.RoomId != room.Id {
+		t.Errorf("Expected record room id %q, got %q", room.Id, got.RoomId)
+	}
+	if got.Filename != "test.txt" {
+		t.Errorf("Expected filename test.txt, got %q", got.Filename)
+	}
+}
+
+// TestGetAttachmentRecord_MissingReturnsNil makes sure that a request
+// for an unknown attachment yields (nil, nil) — the HTTP handler relies
+// on this to render a 404 (not a 500) for orphans.
+func TestGetAttachmentRecord_MissingReturnsNil(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	got, err := core.GetAttachmentRecord(ctx, "no-such-attachment")
+	if err != nil {
+		t.Fatalf("Expected nil error for missing record, got: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Expected nil record for missing id, got %+v", got)
+	}
+}
+
+// TestListRoomAttachments_ReturnsAllAttachmentsInRoom drives the upcoming
+// per-room sidebar use case: uploads in two different rooms should list
+// independently and not bleed across rooms.
+func TestListRoomAttachments_ReturnsAllAttachmentsInRoom(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	roomA, err := core.CreateRoom(ctx, "test-user", KindChannel, "", "room-a", "Room A")
+	if err != nil {
+		t.Fatalf("Failed to create room A: %v", err)
+	}
+	roomB, err := core.CreateRoom(ctx, "test-user", KindChannel, "", "room-b", "Room B")
+	if err != nil {
+		t.Fatalf("Failed to create room B: %v", err)
+	}
+
+	a1, _ := core.UploadAttachment(ctx, roomA.Id, "a1.txt", "text/plain", bytes.NewReader([]byte("a1")))
+	a2, _ := core.UploadAttachment(ctx, roomA.Id, "a2.txt", "text/plain", bytes.NewReader([]byte("a2")))
+	b1, _ := core.UploadAttachment(ctx, roomB.Id, "b1.txt", "text/plain", bytes.NewReader([]byte("b1")))
+
+	gotA, err := core.ListRoomAttachments(ctx, roomA.Id)
+	if err != nil {
+		t.Fatalf("ListRoomAttachments(roomA): %v", err)
+	}
+	if len(gotA) != 2 {
+		t.Errorf("Expected 2 attachments in room A, got %d", len(gotA))
+	}
+	gotIDs := map[string]bool{}
+	for _, att := range gotA {
+		gotIDs[att.Id] = true
+		if att.RoomId != roomA.Id {
+			t.Errorf("Attachment %s leaked from another room: roomId=%q", att.Id, att.RoomId)
+		}
+	}
+	if !gotIDs[a1.Id] || !gotIDs[a2.Id] {
+		t.Errorf("Expected a1 and a2 in room A list, got ids=%v", gotIDs)
+	}
+
+	gotB, err := core.ListRoomAttachments(ctx, roomB.Id)
+	if err != nil {
+		t.Fatalf("ListRoomAttachments(roomB): %v", err)
+	}
+	if len(gotB) != 1 || gotB[0].Id != b1.Id {
+		t.Errorf("Expected only b1 in room B, got %+v", gotB)
+	}
+}
+
+// TestDeleteAttachment_ForgetsRecord confirms that deletion drops the
+// canonical record so subsequent authz lookups fail cleanly (404).
+func TestDeleteAttachment_ForgetsRecord(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	room, err := core.CreateRoom(ctx, "test-user", KindChannel, "", "test-room", "Test room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+
+	attachment, err := core.UploadAttachment(ctx, room.Id, "test.txt", "text/plain", bytes.NewReader([]byte("delete me")))
+	if err != nil {
+		t.Fatalf("Failed to upload attachment: %v", err)
+	}
+
+	if err := core.DeleteAttachment(ctx, "", attachment.Id); err != nil {
+		t.Fatalf("DeleteAttachment failed: %v", err)
+	}
+
+	got, err := core.GetAttachmentRecord(ctx, attachment.Id)
+	if err != nil {
+		t.Fatalf("GetAttachmentRecord error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Expected nil record after delete, got %+v", got)
+	}
+}

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -296,7 +296,7 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	// Run boot-time data migrations. Idempotent and cheap on subsequent
 	// boots (each migration short-circuits when no legacy data remains).
 	// See cli/internal/migrations for what's currently registered.
-	if err := migrations.RunAll(ctx, storage.serverKV, storage.serverConfigKV, logger); err != nil {
+	if err := migrations.RunAll(ctx, storage.serverKV, storage.serverConfigKV, storage.serverBodiesKV, storage.serverRuntimeKV, logger); err != nil {
 		return nil, fmt.Errorf("failed to run boot migrations: %w", err)
 	}
 
@@ -411,10 +411,10 @@ type storage struct {
 	serverRuntimeKV    jetstream.KeyValue    // SERVER_RUNTIME   - sequences, timestamps, read state
 	serverRBACKV       jetstream.KeyValue    // SERVER_RBAC      - roles, permissions, assignments
 	serverRBACEngine   *Engine               // Engine wrapping serverRBACKV
-	serverBodiesKV     jetstream.KeyValue    // SERVER_BODIES    - message bodies (#330 phase 4c)
+	serverBodiesKV     jetstream.KeyValue    // SERVER_BODIES    - message bodies + attachment metadata records (#330 phase 4c). TODO: rename → SERVER_CONTENT now that it hosts more than bodies.
 	serverReactionsKV  jetstream.KeyValue    // SERVER_REACTIONS - emoji reactions (#330 phase 4c)
 	serverThreadsKV    jetstream.KeyValue    // SERVER_THREADS   - thread metadata (#330 phase 4c)
-	serverAttachments  jetstream.ObjectStore // SERVER_ASSETS    - message attachments (#330 phase 4e)
+	serverAttachments  jetstream.ObjectStore // SERVER_ASSETS    - message attachment binaries (#330 phase 4e)
 	serverEventsStream jetstream.Stream      // SERVER_EVENTS    - event stream (#330 phase 4d)
 
 	presenceKV      jetstream.KeyValue    // Instance-level presence bucket

--- a/cli/internal/http_server/assets.go
+++ b/cli/internal/http_server/assets.go
@@ -105,27 +105,40 @@ func (s *HTTPServer) serveServerAsset(c *gin.Context) {
 
 // serveSpaceAttachment serves an attachment from a space's storage (NATS or S3).
 //
-// For S3-stored attachments: redirects to a presigned S3 URL. The browser talks
-// directly to S3, with full Range request support. Zero memory/CPU on the Go process.
-//
-// For NATS-stored attachments: streams directly from NATS ObjectStore without
-// buffering the entire file into memory. Progressive playback works (faststart),
-// but seeking to unbuffered positions requires waiting for the buffer to catch up.
+// Authorization runs off the canonical Attachment record in SERVER_BODIES:
+// we look up the record by ID, verify room membership, then redirect to a
+// presigned S3 URL (if applicable) or stream from NATS.
 func (s *HTTPServer) serveSpaceAttachment(c *gin.Context) {
 	spaceID := c.Param("spaceId")
 	attachmentID := c.Param("attachmentId")
 	ctx := c.Request.Context()
 
 	s.logger.Debug("Serving space attachment", "space_id", spaceID, "attachment_id", attachmentID)
+	s.serveAttachmentInner(c, spaceID, attachmentID, ctx)
+}
 
-	// Try S3 presigned redirect first (zero-copy, full Range support)
+// serveAttachment serves an attachment uploaded via the post-ADR-030-Phase-4
+// kind-less URL pattern (`/assets/attachments/{id}`). Mirrors
+// serveSpaceAttachment but passes an empty spaceID for the kind-less
+// S3 layout.
+func (s *HTTPServer) serveAttachment(c *gin.Context) {
+	attachmentID := c.Param("attachmentId")
+	ctx := c.Request.Context()
+
+	s.logger.Debug("Serving attachment", "attachment_id", attachmentID)
+	s.serveAttachmentInner(c, "", attachmentID, ctx)
+}
+
+// serveAttachmentInner is the shared implementation for both attachment
+// URL shapes. Resolves the room ID via the canonical Attachment record,
+// authorizes membership, then serves the binary.
+func (s *HTTPServer) serveAttachmentInner(c *gin.Context, spaceID, attachmentID string, ctx context.Context) {
+	if !s.requireAttachmentAccess(c, ctx, attachmentID) {
+		return
+	}
+
+	// Try S3 presigned redirect first (zero-copy, full Range support).
 	if presignedURL, err := s.core.TryPresignedAttachmentURL(ctx, spaceID, attachmentID); err == nil {
-		// S3 attachments don't store roomID, so authorizeAttachmentAccess passes
-		// with empty roomID (same as the previous proxying behavior).
-		if !s.authorizeAttachmentAccess(c, "") {
-			return
-		}
-
 		// Cache the redirect itself — the attachment URL is immutable
 		c.Header("Cache-Control", "public, max-age=3600")
 		c.Redirect(http.StatusFound, presignedURL)
@@ -133,7 +146,7 @@ func (s *HTTPServer) serveSpaceAttachment(c *gin.Context) {
 	}
 
 	// Fall back to probing both NATS and S3 backends (handles transient S3 errors
-	// where the presigned URL fails but direct S3 fetch succeeds)
+	// where the presigned URL fails but direct S3 fetch succeeds).
 	reader, info, err := s.core.GetAttachmentFromAnyBackend(ctx, spaceID, attachmentID)
 	if err != nil {
 		s.logger.Error("Failed to get attachment", "error", err, "space_id", spaceID, "attachment_id", attachmentID)
@@ -144,10 +157,6 @@ func (s *HTTPServer) serveSpaceAttachment(c *gin.Context) {
 		defer closer.Close()
 	}
 
-	if !s.authorizeAttachmentAccess(c, info.RoomID) {
-		return
-	}
-
 	contentType := info.ContentType
 	if contentType == "" {
 		contentType = "application/octet-stream"
@@ -155,92 +164,54 @@ func (s *HTTPServer) serveSpaceAttachment(c *gin.Context) {
 
 	// Immutable asset - cache forever
 	c.Header("Cache-Control", "public, max-age=31536000, immutable")
-	c.Header("ETag", fmt.Sprintf("\"%s-%s\"", spaceID, attachmentID))
+	if spaceID != "" {
+		c.Header("ETag", fmt.Sprintf("\"%s-%s\"", spaceID, attachmentID))
+	} else {
+		c.Header("ETag", fmt.Sprintf("\"%s\"", attachmentID))
+	}
 	c.Header("Vary", "Accept-Encoding")
 
 	// Stream directly — no io.ReadAll, no memory buffering
 	c.DataFromReader(http.StatusOK, info.Size, contentType, reader, nil)
 }
 
-// serveAttachment serves an attachment uploaded via the post-ADR-030-Phase-4
-// kind-less URL pattern (`/assets/attachments/{id}`).
+// requireAttachmentAccess gates an attachment HTTP request. Looks up
+// the canonical Attachment record in SERVER_BODIES, then verifies
+// the caller is a member of that record's room. Returns true if the
+// request may proceed; writes the appropriate error response and
+// returns false otherwise.
 //
-// Mirrors serveSpaceAttachment but passes an empty spaceID to the core
-// helpers, which picks the new `attachments/{id}` S3 layout for S3-stored
-// attachments. NATS-stored attachments use the same attachment ID regardless
-// of upload era.
-func (s *HTTPServer) serveAttachment(c *gin.Context) {
-	attachmentID := c.Param("attachmentId")
-	ctx := c.Request.Context()
-
-	s.logger.Debug("Serving attachment", "attachment_id", attachmentID)
-
-	// Try S3 presigned redirect first (zero-copy, full Range support)
-	if presignedURL, err := s.core.TryPresignedAttachmentURL(ctx, "", attachmentID); err == nil {
-		// S3 attachments don't store roomID, so authorizeAttachmentAccess passes
-		// with empty roomID (same as the legacy proxying behavior).
-		if !s.authorizeAttachmentAccess(c, "") {
-			return
-		}
-
-		// Cache the redirect itself — the attachment URL is immutable
-		c.Header("Cache-Control", "public, max-age=3600")
-		c.Redirect(http.StatusFound, presignedURL)
-		return
-	}
-
-	// Fall back to probing both NATS and S3 backends
-	reader, info, err := s.core.GetAttachmentFromAnyBackend(ctx, "", attachmentID)
-	if err != nil {
-		s.logger.Error("Failed to get attachment", "error", err, "attachment_id", attachmentID)
-		c.JSON(http.StatusNotFound, gin.H{"error": "Attachment not found"})
-		return
-	}
-	if closer, ok := reader.(io.Closer); ok {
-		defer closer.Close()
-	}
-
-	if !s.authorizeAttachmentAccess(c, info.RoomID) {
-		return
-	}
-
-	contentType := info.ContentType
-	if contentType == "" {
-		contentType = "application/octet-stream"
-	}
-
-	// Immutable asset - cache forever
-	c.Header("Cache-Control", "public, max-age=31536000, immutable")
-	c.Header("ETag", fmt.Sprintf("\"%s\"", attachmentID))
-	c.Header("Vary", "Accept-Encoding")
-
-	// Stream directly — no io.ReadAll, no memory buffering
-	c.DataFromReader(http.StatusOK, info.Size, contentType, reader, nil)
-}
-
-// authorizeAttachmentAccess checks if the current user can access an attachment.
-// Returns true if authorized, false if not (and sends appropriate error response).
-// An empty roomID is treated as public (matches legacy S3 attachment behavior,
-// where the room ID isn't recoverable from the storage backend).
-func (s *HTTPServer) authorizeAttachmentAccess(c *gin.Context, roomID string) bool {
-	if roomID == "" {
-		return true
-	}
-
+// A missing record (e.g. an orphan binary in S3 left over from a
+// pre-record-bucket upload that the boot migration hasn't touched
+// yet) is treated as not-found — we refuse to authorize a download
+// we can't attribute to a room.
+func (s *HTTPServer) requireAttachmentAccess(c *gin.Context, ctx context.Context, attachmentID string) bool {
 	userID := s.getUserIDFromSession(c)
 	if userID == "" {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
 		return false
 	}
 
-	kind, err := s.core.FindRoomKind(c.Request.Context(), roomID)
+	record, err := s.core.GetAttachmentRecord(ctx, attachmentID)
 	if err != nil {
-		s.logger.Error("Failed to resolve room kind for attachment auth", "error", err, "room_id", roomID)
+		s.logger.Error("Failed to look up attachment record", "attachment_id", attachmentID, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to verify access"})
+		return false
+	}
+	if record == nil || record.RoomId == "" {
+		s.logger.Warn("Attachment access denied: no metadata record", "attachment_id", attachmentID, "user_id", userID)
+		c.JSON(http.StatusNotFound, gin.H{"error": "Attachment not found"})
+		return false
+	}
+
+	kind, err := s.core.FindRoomKind(ctx, record.RoomId)
+	if err != nil {
+		s.logger.Error("Failed to resolve room kind for attachment auth", "error", err, "room_id", record.RoomId)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to verify access"})
 		return false
 	}
 
-	isMember, err := s.core.RoomMembershipExists(c.Request.Context(), kind, userID, roomID)
+	isMember, err := s.core.RoomMembershipExists(ctx, kind, userID, record.RoomId)
 	if err != nil {
 		s.logger.Error("Failed to check room membership", "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to verify access"})
@@ -433,11 +404,6 @@ func (s *HTTPServer) serveTransformedAttachment(c *gin.Context) {
 		"space_id", spaceID,
 		"attachment_id", attachmentID)
 
-	// We need to fetch the attachment info for authorization, and cache the room ID
-	// since we may need it both for the authorize callback and for FetchAsset
-	var cachedRoomID string
-	var roomIDFetched bool
-
 	s.serveTransformedAsset(c, transformRequest{
 		ResourceID1: spaceID,
 		ResourceID2: attachmentID,
@@ -445,29 +411,14 @@ func (s *HTTPServer) serveTransformedAttachment(c *gin.Context) {
 		CachePrefix: spaceID,
 		AssetID:     attachmentID,
 		FetchAsset: func(ctx context.Context) (io.Reader, string, error) {
-			// Probe both NATS and S3 backends
 			reader, info, err := s.core.GetAttachmentFromAnyBackend(ctx, spaceID, attachmentID)
 			if err != nil {
 				return nil, "", err
 			}
-			// Cache the room ID for authorization
-			cachedRoomID = info.RoomID
-			roomIDFetched = true
 			return reader, info.ContentType, nil
 		},
 		Authorize: func(c *gin.Context) bool {
-			// If we haven't fetched the room ID yet, we need to fetch it for authorization
-			if !roomIDFetched {
-				_, info, err := s.core.GetAttachmentFromAnyBackend(c.Request.Context(), spaceID, attachmentID)
-				if err != nil {
-					s.logger.Error("Failed to get attachment for auth", "error", err)
-					c.JSON(http.StatusNotFound, gin.H{"error": "Attachment not found"})
-					return false
-				}
-				cachedRoomID = info.RoomID
-				roomIDFetched = true
-			}
-			return s.authorizeAttachmentAccess(c, cachedRoomID)
+			return s.requireAttachmentAccess(c, c.Request.Context(), attachmentID)
 		},
 	})
 }
@@ -483,9 +434,6 @@ func (s *HTTPServer) serveTransformedAttachmentByID(c *gin.Context) {
 
 	s.logger.Debug("Serving transformed attachment", "attachment_id", attachmentID)
 
-	var cachedRoomID string
-	var roomIDFetched bool
-
 	s.serveTransformedAsset(c, transformRequest{
 		ResourceID1: core.AttachmentSignResource,
 		ResourceID2: attachmentID,
@@ -497,22 +445,10 @@ func (s *HTTPServer) serveTransformedAttachmentByID(c *gin.Context) {
 			if err != nil {
 				return nil, "", err
 			}
-			cachedRoomID = info.RoomID
-			roomIDFetched = true
 			return reader, info.ContentType, nil
 		},
 		Authorize: func(c *gin.Context) bool {
-			if !roomIDFetched {
-				_, info, err := s.core.GetAttachmentFromAnyBackend(c.Request.Context(), "", attachmentID)
-				if err != nil {
-					s.logger.Error("Failed to get attachment for auth", "error", err)
-					c.JSON(http.StatusNotFound, gin.H{"error": "Attachment not found"})
-					return false
-				}
-				cachedRoomID = info.RoomID
-				roomIDFetched = true
-			}
-			return s.authorizeAttachmentAccess(c, cachedRoomID)
+			return s.requireAttachmentAccess(c, c.Request.Context(), attachmentID)
 		},
 	})
 }

--- a/cli/internal/http_server/assets_test.go
+++ b/cli/internal/http_server/assets_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-gonic/gin"
+	"github.com/johannesboyne/gofakes3"
+	"github.com/johannesboyne/gofakes3/backend/s3mem"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"hmans.de/chatto/internal/config"
@@ -42,6 +44,18 @@ type assetTestEnv struct {
 
 // setupAssetTestServer creates a test server for asset testing with caching enabled.
 func setupAssetTestServer(t *testing.T) *assetTestEnv {
+	return setupAssetTestServerWithConfig(t, false)
+}
+
+// setupAssetTestServerWithS3 mirrors setupAssetTestServer but routes
+// attachments through an in-memory fake S3 server. Use this to test the
+// S3 presigned-redirect code path in the asset handlers (the path that
+// previously contained an authorization bypass on empty room ID).
+func setupAssetTestServerWithS3(t *testing.T) *assetTestEnv {
+	return setupAssetTestServerWithConfig(t, true)
+}
+
+func setupAssetTestServerWithConfig(t *testing.T, useS3 bool) *assetTestEnv {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
@@ -72,16 +86,34 @@ func setupAssetTestServer(t *testing.T) *assetTestEnv {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)
 
-	// Create ChattoCore with assets config and caching enabled
-	coreConfig := config.CoreConfig{
-		Assets: config.AssetsConfig{
-			SigningSecret: "test-signing-secret-32-bytes-!!",
-			MaxUploadSize: 10 * 1024 * 1024, // 10MB
-			Cache: config.AssetsCacheConfig{
-				Enabled: true,
-				TTL:     config.Duration(7 * 24 * time.Hour), // 7 days
-			},
+	assetsCfg := config.AssetsConfig{
+		SigningSecret: "test-signing-secret-32-bytes-!!",
+		MaxUploadSize: 10 * 1024 * 1024, // 10MB
+		Cache: config.AssetsCacheConfig{
+			Enabled: true,
+			TTL:     config.Duration(7 * 24 * time.Hour), // 7 days
 		},
+	}
+	if useS3 {
+		backend := s3mem.New()
+		faker := gofakes3.New(backend)
+		s3Server := httptest.NewServer(faker.Server())
+		t.Cleanup(s3Server.Close)
+
+		useSSL := false
+		pathStyle := true
+		assetsCfg.StorageBackend = config.StorageBackendS3
+		assetsCfg.S3 = config.S3Config{
+			Endpoint:        s3Server.URL[len("http://"):],
+			Bucket:          "test-bucket",
+			AccessKeyID:     "test-key",
+			SecretAccessKey: "test-secret",
+			UseSSL:          &useSSL,
+			PathStyle:       &pathStyle,
+		}
+	}
+	coreConfig := config.CoreConfig{
+		Assets: assetsCfg,
 	}
 	chattoCore, err := core.NewChattoCore(ctx, nc, coreConfig)
 	if err != nil {
@@ -763,5 +795,157 @@ func TestAsset_UnauthenticatedAccess_Denied(t *testing.T) {
 
 	if transformResp.StatusCode != http.StatusUnauthorized {
 		t.Errorf("Expected 401 Unauthorized for unauthenticated transform access, got %d", transformResp.StatusCode)
+	}
+}
+
+// TestAsset_UnauthenticatedAccess_DeniedOnS3 exercises the S3 presigned
+// redirect path of /assets/attachments/{id}. Previously, this path used a
+// `roomID == "" → allow` shortcut because the room ID couldn't be
+// recovered from S3 metadata, which let unauthenticated browser tabs
+// download any attachment whose ID they knew. The fix stamps the room
+// ID onto the S3 object at upload time and pulls it back via Stat so the
+// regular auth path runs.
+func TestAsset_UnauthenticatedAccess_DeniedOnS3(t *testing.T) {
+	env := setupAssetTestServerWithS3(t)
+
+	user, err := env.core.CreateUser(env.ctx, "system", "s3authuser", "S3 Auth User", "password123")
+	if err != nil {
+		t.Fatalf("Failed to create user: %v", err)
+	}
+	room, err := env.core.CreateRoom(env.ctx, user.Id, "channel", "", "s3testroom", "S3 Test Room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	if _, err := env.core.JoinRoom(env.ctx, user.Id, "channel", user.Id, room.Id); err != nil {
+		t.Fatalf("Failed to join room: %v", err)
+	}
+
+	env.login(t, "s3authuser", "password123")
+
+	imageData := createAssetTestPNG(t, 400, 300)
+	operations := fmt.Sprintf(`{
+		"query": "mutation($roomId: ID!, $body: String!, $file: Upload!) { postMessage(input: { roomId: $roomId, body: $body, attachments: [$file] }) { event { ... on MessagePostedEvent { attachments { id url thumbnailUrl(width: 200, height: 200, fit: CONTAIN) } } } } }",
+		"variables": { "roomId": "%s", "body": "Test S3 message", "file": null }
+	}`, room.Id)
+
+	resp := env.doAssetMultipartUpload(t, operations, imageData, "s3-auth-test.png")
+	if len(resp.Errors) > 0 {
+		t.Fatalf("Failed to post message: %v", resp.Errors)
+	}
+
+	var data struct {
+		PostMessage struct {
+			Event struct {
+				Attachments []struct {
+					URL          string `json:"url"`
+					ThumbnailURL string `json:"thumbnailUrl"`
+				} `json:"attachments"`
+			} `json:"event"`
+		} `json:"postMessage"`
+	}
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+	if len(data.PostMessage.Event.Attachments) == 0 {
+		t.Fatal("Expected one attachment in S3-backed upload")
+	}
+	attachment := data.PostMessage.Event.Attachments[0]
+
+	// Anonymous client — the bug was that this would happily redirect to
+	// a presigned S3 URL despite no session.
+	unauthClient := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	originalResp, err := unauthClient.Get(env.server.URL + attachment.URL)
+	if err != nil {
+		t.Fatalf("Failed to make request: %v", err)
+	}
+	originalResp.Body.Close()
+	if originalResp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("S3 attachment URL: expected 401 for unauthenticated request, got %d", originalResp.StatusCode)
+	}
+
+	transformResp, err := unauthClient.Get(env.server.URL + attachment.ThumbnailURL)
+	if err != nil {
+		t.Fatalf("Failed to make request: %v", err)
+	}
+	transformResp.Body.Close()
+	if transformResp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("S3 transform URL: expected 401 for unauthenticated request, got %d", transformResp.StatusCode)
+	}
+}
+
+// TestAsset_NonMemberAccess_DeniedOnS3 verifies that the S3 presigned
+// path correctly resolves the attachment's room ID and rejects an
+// authenticated user who is not a member of the room.
+func TestAsset_NonMemberAccess_DeniedOnS3(t *testing.T) {
+	env := setupAssetTestServerWithS3(t)
+
+	owner, err := env.core.CreateUser(env.ctx, "system", "owner", "Owner", "password123")
+	if err != nil {
+		t.Fatalf("Failed to create owner: %v", err)
+	}
+	if _, err := env.core.CreateUser(env.ctx, "system", "outsider", "Outsider", "password123"); err != nil {
+		t.Fatalf("Failed to create outsider: %v", err)
+	}
+	room, err := env.core.CreateRoom(env.ctx, owner.Id, "channel", "", "private-room", "Private Room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	if _, err := env.core.JoinRoom(env.ctx, owner.Id, "channel", owner.Id, room.Id); err != nil {
+		t.Fatalf("Failed to join room: %v", err)
+	}
+
+	// Owner uploads.
+	env.login(t, "owner", "password123")
+	imageData := createAssetTestPNG(t, 400, 300)
+	operations := fmt.Sprintf(`{
+		"query": "mutation($roomId: ID!, $body: String!, $file: Upload!) { postMessage(input: { roomId: $roomId, body: $body, attachments: [$file] }) { event { ... on MessagePostedEvent { attachments { id url } } } } }",
+		"variables": { "roomId": "%s", "body": "private", "file": null }
+	}`, room.Id)
+	resp := env.doAssetMultipartUpload(t, operations, imageData, "private.png")
+	if len(resp.Errors) > 0 {
+		t.Fatalf("Failed to post: %v", resp.Errors)
+	}
+	var data struct {
+		PostMessage struct {
+			Event struct {
+				Attachments []struct {
+					URL string `json:"url"`
+				} `json:"attachments"`
+			} `json:"event"`
+		} `json:"postMessage"`
+	}
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(data.PostMessage.Event.Attachments) == 0 {
+		t.Fatal("Expected one attachment")
+	}
+	attachmentURL := data.PostMessage.Event.Attachments[0].URL
+
+	// Log the owner out and have the outsider try to access.
+	outsiderJar, _ := cookiejar.New(nil)
+	outsiderClient := &http.Client{
+		Jar: outsiderJar,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	loginBody := `{"login":"outsider","password":"password123"}`
+	if _, err := outsiderClient.Post(env.server.URL+"/auth/login", "application/json", bytes.NewReader([]byte(loginBody))); err != nil {
+		t.Fatalf("outsider login: %v", err)
+	}
+
+	r, err := outsiderClient.Get(env.server.URL + attachmentURL)
+	if err != nil {
+		t.Fatalf("outsider GET: %v", err)
+	}
+	r.Body.Close()
+	if r.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403 for outsider, got %d", r.StatusCode)
 	}
 }

--- a/cli/internal/migrations/attachment_records.go
+++ b/cli/internal/migrations/attachment_records.go
@@ -1,0 +1,125 @@
+package migrations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/log"
+	"github.com/nats-io/nats.go/jetstream"
+	"google.golang.org/protobuf/proto"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+// BackfillAttachmentRecords promotes every Attachment proto embedded
+// in a MessageBody into a standalone metadata record so the asset HTTP
+// handler can authorize downloads by attachment ID without scanning
+// every body.
+//
+// # Why
+//
+// Attachment metadata used to live exclusively inside `MessageBody`
+// records, which meant the only way to answer "what room does this
+// attachment belong to?" was to scan every body. The asset HTTP handler
+// previously avoided the scan by trusting an unauthenticated URL on the
+// S3 fast path — a real authorization bug. This migration plus the new
+// `attachment.{roomId}.{attachmentId}` records gives the handler an
+// O(1) lookup.
+//
+// # Layout
+//
+// Both record kinds live in `SERVER_BODIES`. Their key shapes don't
+// overlap:
+//
+//	{userId}.{bodyId}                   → MessageBody  (existing)
+//	attachment.{roomId}.{attachmentId}  → Attachment   (new, this migration)
+//
+// # Idempotency
+//
+// Safe to re-run. Every record is written via Put, so re-running on
+// an already-populated bucket is a series of no-op overwrites with
+// identical values. A sentinel key (`attachment_records.backfilled`)
+// in SERVER_RUNTIME short-circuits repeat boots.
+//
+// # When this can be removed
+//
+// Once every live deployment has booted at least once on a version
+// that includes this migration. Operators can verify by inspecting
+// SERVER_RUNTIME for the sentinel key.
+func BackfillAttachmentRecords(ctx context.Context, bodiesKV, runtimeKV jetstream.KeyValue, logger *log.Logger) error {
+	const flagKey = "attachment_records.backfilled"
+
+	if entry, err := runtimeKV.Get(ctx, flagKey); err == nil && entry != nil {
+		return nil
+	} else if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+		return fmt.Errorf("get backfill flag: %w", err)
+	}
+
+	lister, err := bodiesKV.ListKeys(ctx)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			if _, putErr := runtimeKV.Put(ctx, flagKey, []byte("1")); putErr != nil {
+				return fmt.Errorf("set backfill flag on empty bucket: %w", putErr)
+			}
+			return nil
+		}
+		return fmt.Errorf("list message body keys: %w", err)
+	}
+
+	// Collect keys first so writes don't reshape the iterator's view of
+	// the bucket. Also lets us pre-filter to body-shape keys
+	// (`{userId}.{bodyId}` — two segments) and ignore the attachment
+	// records we may be writing in this very pass.
+	var bodyKeys []string
+	for key := range lister.Keys() {
+		if strings.HasPrefix(key, "attachment.") {
+			continue
+		}
+		bodyKeys = append(bodyKeys, key)
+	}
+
+	indexed := 0
+	for _, key := range bodyKeys {
+		entry, err := bodiesKV.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			return fmt.Errorf("get message body %s: %w", key, err)
+		}
+
+		var body corev1.MessageBody
+		if err := proto.Unmarshal(entry.Value(), &body); err != nil {
+			logger.Warn("attachment_records: skipping unparseable message body",
+				"key", key, "error", err)
+			continue
+		}
+
+		for _, att := range body.Attachments {
+			if att == nil || att.Id == "" || att.RoomId == "" {
+				continue
+			}
+			recordKey := "attachment." + att.RoomId + "." + att.Id
+			marshaled, err := proto.Marshal(att)
+			if err != nil {
+				return fmt.Errorf("marshal attachment record for %s: %w", att.Id, err)
+			}
+			if _, err := bodiesKV.Put(ctx, recordKey, marshaled); err != nil {
+				return fmt.Errorf("write attachment record %s: %w", recordKey, err)
+			}
+			indexed++
+		}
+	}
+
+	if _, err := runtimeKV.Put(ctx, flagKey, []byte("1")); err != nil {
+		return fmt.Errorf("set backfill flag: %w", err)
+	}
+
+	if indexed > 0 || len(bodyKeys) > 0 {
+		logger.Info("attachment_records migration: indexed attachments from message bodies",
+			"bodies_scanned", len(bodyKeys), "attachments_indexed", indexed)
+	}
+	return nil
+}

--- a/cli/internal/migrations/attachment_records_test.go
+++ b/cli/internal/migrations/attachment_records_test.go
@@ -1,0 +1,224 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/log"
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"google.golang.org/protobuf/proto"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+// setupBodiesAndRuntime stands up an embedded NATS server and returns
+// the two KV buckets the BackfillAttachmentRecords migration touches:
+// bodies (source AND destination — attachment records co-locate with
+// message bodies in this bucket) and runtime (sentinel store).
+func setupBodiesAndRuntime(t *testing.T) (context.Context, jetstream.KeyValue, jetstream.KeyValue) {
+	t.Helper()
+
+	ns, err := server.NewServer(&server.Options{
+		JetStream: true,
+		Port:      -1,
+		StoreDir:  t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("create NATS server: %v", err)
+	}
+	go ns.Start()
+	if !ns.ReadyForConnections(5 * time.Second) {
+		t.Fatal("NATS server not ready")
+	}
+
+	nc, err := nats.Connect(ns.ClientURL())
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() {
+		nc.Close()
+		ns.Shutdown()
+		ns.WaitForShutdown()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatalf("jetstream: %v", err)
+	}
+	bodies, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "BODIES", Storage: jetstream.MemoryStorage})
+	if err != nil {
+		t.Fatalf("create bodies KV: %v", err)
+	}
+	runtime, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "RUNTIME", Storage: jetstream.MemoryStorage})
+	if err != nil {
+		t.Fatalf("create runtime KV: %v", err)
+	}
+
+	return ctx, bodies, runtime
+}
+
+func TestBackfillAttachmentRecords_CopiesAttachmentsFromBodies(t *testing.T) {
+	ctx, bodies, runtime := setupBodiesAndRuntime(t)
+
+	body := &corev1.MessageBody{
+		AuthorId: "user-1",
+		Attachments: []*corev1.Attachment{
+			{Id: "att-a", RoomId: "room-x", Filename: "a.png"},
+			{Id: "att-b", RoomId: "room-y", Filename: "b.png"},
+		},
+	}
+	raw, err := proto.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	if _, err := bodies.Put(ctx, "user-1.body-1", raw); err != nil {
+		t.Fatalf("seed bodies: %v", err)
+	}
+
+	if err := BackfillAttachmentRecords(ctx, bodies, runtime, log.New(nil)); err != nil {
+		t.Fatalf("BackfillAttachmentRecords: %v", err)
+	}
+
+	cases := []struct {
+		key      string
+		wantRoom string
+		wantName string
+	}{
+		{"attachment.room-x.att-a", "room-x", "a.png"},
+		{"attachment.room-y.att-b", "room-y", "b.png"},
+	}
+	for _, tc := range cases {
+		entry, err := bodies.Get(ctx, tc.key)
+		if err != nil {
+			t.Fatalf("read %s: %v", tc.key, err)
+		}
+		var att corev1.Attachment
+		if err := proto.Unmarshal(entry.Value(), &att); err != nil {
+			t.Fatalf("unmarshal %s: %v", tc.key, err)
+		}
+		if att.RoomId != tc.wantRoom {
+			t.Errorf("%s: roomId=%q, want %q", tc.key, att.RoomId, tc.wantRoom)
+		}
+		if att.Filename != tc.wantName {
+			t.Errorf("%s: filename=%q, want %q", tc.key, att.Filename, tc.wantName)
+		}
+	}
+
+	if _, err := runtime.Get(ctx, "attachment_records.backfilled"); err != nil {
+		t.Errorf("expected backfill sentinel set: %v", err)
+	}
+}
+
+func TestBackfillAttachmentRecords_Idempotent(t *testing.T) {
+	ctx, bodies, runtime := setupBodiesAndRuntime(t)
+
+	body := &corev1.MessageBody{
+		AuthorId:    "user-1",
+		Attachments: []*corev1.Attachment{{Id: "att-a", RoomId: "room-x", Filename: "a.png"}},
+	}
+	raw, _ := proto.Marshal(body)
+	if _, err := bodies.Put(ctx, "user-1.body-1", raw); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := BackfillAttachmentRecords(ctx, bodies, runtime, log.New(nil)); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	if err := BackfillAttachmentRecords(ctx, bodies, runtime, log.New(nil)); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+
+	entry, err := bodies.Get(ctx, "attachment.room-x.att-a")
+	if err != nil {
+		t.Fatalf("read record: %v", err)
+	}
+	var att corev1.Attachment
+	if err := proto.Unmarshal(entry.Value(), &att); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if att.Filename != "a.png" {
+		t.Errorf("filename: got %q, want %q", att.Filename, "a.png")
+	}
+}
+
+func TestBackfillAttachmentRecords_EmptyBodiesSetsSentinel(t *testing.T) {
+	ctx, bodies, runtime := setupBodiesAndRuntime(t)
+
+	if err := BackfillAttachmentRecords(ctx, bodies, runtime, log.New(nil)); err != nil {
+		t.Fatalf("BackfillAttachmentRecords: %v", err)
+	}
+
+	if _, err := runtime.Get(ctx, "attachment_records.backfilled"); err != nil {
+		t.Errorf("expected backfill sentinel set on empty bucket: %v", err)
+	}
+}
+
+func TestBackfillAttachmentRecords_SkipsAttachmentWithoutRoomID(t *testing.T) {
+	ctx, bodies, runtime := setupBodiesAndRuntime(t)
+
+	body := &corev1.MessageBody{
+		AuthorId: "user-1",
+		Attachments: []*corev1.Attachment{
+			{Id: "att-good", RoomId: "room-x"},
+			{Id: "att-stray"}, // no RoomId — should be skipped
+		},
+	}
+	raw, _ := proto.Marshal(body)
+	if _, err := bodies.Put(ctx, "user-1.body-1", raw); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := BackfillAttachmentRecords(ctx, bodies, runtime, log.New(nil)); err != nil {
+		t.Fatalf("BackfillAttachmentRecords: %v", err)
+	}
+
+	if _, err := bodies.Get(ctx, "attachment.room-x.att-good"); err != nil {
+		t.Errorf("expected record for att-good: %v", err)
+	}
+	// att-stray has no roomId so we wouldn't know what key to write.
+	// Verify no orphan key got written under a wildcard.
+	lister, err := bodies.ListKeysFiltered(ctx, "attachment.*.att-stray")
+	if err == nil {
+		for k := range lister.Keys() {
+			t.Errorf("unexpected record key %q for att-stray", k)
+		}
+	}
+}
+
+// TestBackfillAttachmentRecords_IgnoresExistingAttachmentRecords is the
+// "don't loop on yourself" check: since the migration writes attachment
+// records into the same bucket it scans, a second pass must not try to
+// unmarshal those keys as MessageBody and fail.
+func TestBackfillAttachmentRecords_IgnoresExistingAttachmentRecords(t *testing.T) {
+	ctx, bodies, runtime := setupBodiesAndRuntime(t)
+
+	// Pre-populate an attachment record as if a previous boot wrote one.
+	preexisting := &corev1.Attachment{Id: "preexisting", RoomId: "room-x", Filename: "p.png"}
+	raw, _ := proto.Marshal(preexisting)
+	if _, err := bodies.Put(ctx, "attachment.room-x.preexisting", raw); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := BackfillAttachmentRecords(ctx, bodies, runtime, log.New(nil)); err != nil {
+		t.Fatalf("BackfillAttachmentRecords: %v", err)
+	}
+
+	// Preexisting record untouched.
+	entry, err := bodies.Get(ctx, "attachment.room-x.preexisting")
+	if err != nil {
+		t.Fatalf("read preexisting record: %v", err)
+	}
+	var got corev1.Attachment
+	if err := proto.Unmarshal(entry.Value(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Filename != "p.png" {
+		t.Errorf("preexisting record clobbered: filename=%q", got.Filename)
+	}
+}

--- a/cli/internal/migrations/migrations.go
+++ b/cli/internal/migrations/migrations.go
@@ -47,13 +47,18 @@ import (
 //
 // `serverKV` is the INSTANCE bucket (user data, auth tokens, etc.);
 // `serverConfigKV` is SERVER_CONFIG (rooms, room memberships,
-// notification levels, …).
-func RunAll(ctx context.Context, serverKV, serverConfigKV jetstream.KeyValue, logger *log.Logger) error {
+// notification levels, …); `serverBodiesKV` is SERVER_BODIES (message
+// content + standalone attachment metadata records); `serverRuntimeKV`
+// is SERVER_RUNTIME (sequences, sentinels, recomputable state).
+func RunAll(ctx context.Context, serverKV, serverConfigKV, serverBodiesKV, serverRuntimeKV jetstream.KeyValue, logger *log.Logger) error {
 	if err := MigrateVerifiedEmailsToProto(ctx, serverKV, logger); err != nil {
 		return fmt.Errorf("verified_emails: %w", err)
 	}
 	if err := BackfillRoomKind(ctx, serverConfigKV, logger); err != nil {
 		return fmt.Errorf("room_kind: %w", err)
+	}
+	if err := BackfillAttachmentRecords(ctx, serverBodiesKV, serverRuntimeKV, logger); err != nil {
+		return fmt.Errorf("attachment_records: %w", err)
 	}
 	return nil
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -263,7 +263,7 @@ There is no `adminAuditLogEvents` subscription — audit events arrive through `
 | KV      | `SERVER_CONFIG`               | Rooms (channel + DM), memberships           |
 | KV      | `SERVER_RBAC`                 | Roles, permissions, assignments (single flat tier — owner/admin/moderator/everyone) |
 | KV      | `SERVER_RUNTIME`              | Read status, mention tracking               |
-| KV      | `SERVER_BODIES`               | Message bodies (GDPR-compliant)             |
+| KV      | `SERVER_BODIES`               | Message bodies (GDPR-compliant) + standalone attachment metadata records — TODO: rename → `SERVER_CONTENT` |
 | KV      | `SERVER_REACTIONS`            | Emoji reactions                             |
 | KV      | `SERVER_THREADS`              | Thread metadata (reply count, participants) |
 | Objects | `INSTANCE_ASSETS`             | Avatars, icons (bucket name retained from pre-rename) |
@@ -470,7 +470,7 @@ The unified `myEvents` GraphQL subscription is backed by a single core stream (`
 | `SERVER_CONFIG`               | File    | Yes      | Rooms (channel + DM), memberships               |
 | `SERVER_RBAC`                 | File    | Yes      | Roles, permissions, assignments (single flat tier) |
 | `SERVER_RUNTIME`              | File    | Yes      | Read state, mention tracking                    |
-| `SERVER_BODIES`               | File    | Yes      | Message bodies (GDPR-compliant)                 |
+| `SERVER_BODIES`               | File    | Yes      | Message bodies (GDPR-compliant) + standalone attachment metadata records — TODO: rename → `SERVER_CONTENT` |
 | `SERVER_REACTIONS`            | File    | Yes      | Emoji reactions on messages                     |
 | `SERVER_THREADS`              | File    | Yes      | Thread metadata (reply count, participants)     |
 | `NOTIFICATIONS`               | File    | Yes      | User notifications (90-day TTL)                 |
@@ -571,6 +571,7 @@ Keys: `role.*`, `role_permission.*`, `role_assignment.*`, `user_permission.*`, `
 | `room_mention_status.{userId}.{roomId}`| Unread mention indicator (boolean — key presence means unread)    |
 | `room_last_msg_at.{roomId}`            | Last message timestamp (per-room, used for sidebar sort)          |
 | `video.{attachmentId}`                 | Video processing state for an attachment                          |
+| `attachment_records.backfilled`        | Sentinel set after the `BackfillAttachmentRecords` boot migration completes; short-circuits the scan on subsequent boots. |
 
 These keys don't carry a kind segment — `roomId` is globally unique, so direct lookup works for DM and channel rooms alike.
 
@@ -606,6 +607,17 @@ Notes: Emoji stored as name (e.g., "thumbsup") for NATS KV key compatibility. Se
 
 Notes: Updated on each thread reply via optimistic locking. Tracks up to 50 participant IDs. Used for thread previews in channel view.
 
+**SERVER\_BODIES** also hosts standalone attachment metadata records. The two record kinds share the bucket because they share a lifecycle (an attachment is born with the body that posts it and dies when that body is GDPR-deleted) and a churn profile. Their key shapes don't collide — body keys are two tokens, attachment-record keys are three:
+
+| Key                                          | Description                                                                              |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `{userId}.{bodyId}`                          | Marshaled `corev1.MessageBody` proto (encrypted text, attachments slice, link preview)   |
+| `attachment.{roomId}.{attachmentId}`         | Marshaled `corev1.Attachment` proto — standalone metadata used for authz + per-room listing |
+
+The asset HTTP handler authorizes by-ID via a server-side wildcard filter `attachment.*.{attachmentId}`. The per-room attachment sidebar reads via prefix filter `attachment.{roomId}.*`. Records are written by `UploadAttachment` at upload time and removed by the delete paths. Attachments uploaded before standalone records existed are populated by the `BackfillAttachmentRecords` boot migration, which scans the body keys in the same bucket.
+
+> **TODO**: rename `SERVER_BODIES` → `SERVER_CONTENT` to reflect the wider scope. Pending a separate migration since renaming a NATS KV bucket requires copying every key.
+
 ### Object Store Buckets
 
 | Bucket                      | Description                                       |
@@ -637,7 +649,7 @@ Notes: Only created when `[core.assets.cache]` is enabled in config. Uses TTL fo
 | `{attachmentId}`      | Original attachment files (images, videos, etc.)|
 | `{attachmentId}_thumb`| WebP thumbnails (256px max dimension)           |
 
-Notes: Attachment IDs are globally unique (NanoID), so no kind segment is needed. Channel and DM attachments share the same flat keyspace. Content-Type and original filename stored in object headers. S2 compression enabled. Attachment metadata stored in `MessageBody` proto in `SERVER_BODIES`.
+Notes: Attachment IDs are globally unique (NanoID), so no kind segment is needed. Channel and DM attachments share the same flat keyspace. Content-Type and original filename stored in object headers. S2 compression enabled. Attachment **metadata** (room ID, filename, dimensions, storage pointer, …) lives in `SERVER_BODIES` keyed by `attachment.{roomId}.{attachmentId}` — that's the source of truth the asset HTTP handler uses for authorization, and the keyspace the upcoming per-room attachment sidebar will list from. Attachments are also embedded inside `MessageBody` protos in the same bucket (keyed by `{userId}.{bodyId}`) for compatibility with the existing message-fetch path.
 
 ### Dynamic Image Transformation
 


### PR DESCRIPTION
## Summary

The asset HTTP handler had an authorization bypass on the S3 presigned-redirect path: when the room ID couldn't be recovered from the storage backend (always the case for S3-stored attachments), the handler treated the attachment as public — anyone with an attachment ID could fetch the file unauthenticated.

This change promotes \`Attachment\` metadata to standalone records, co-located with message bodies in \`SERVER_BODIES\` under \`attachment.{roomId}.{attachmentId}\`, and makes the HTTP handler authorize off the canonical \`record.RoomId\` (404 on missing record, no \`roomID == "" → allow\` shortcut). The same key shape supports the upcoming per-room attachment sidebar via \`attachment.{roomId}.*\` prefix-listing. A boot migration backfills records from existing message bodies so legacy attachments remain reachable after upgrade. A TODO is recorded to eventually rename \`SERVER_BODIES\` → \`SERVER_CONTENT\` in a follow-up PR.

## Test plan

- [x] \`mise test-cli\` — full Go test suite (incl. new tests in \`internal/core\`, \`internal/migrations\`, and \`internal/http_server\` exercising the S3 unauth-denied and non-member-denied paths)
- [ ] Manual smoke: upload an attachment, fetch it logged in (200), fetch it from a private tab (401)
- [ ] Manual smoke: per-room sidebar query (when wired up in frontend) lists only that room's attachments
- [ ] Migration sanity on a non-empty deployment: first boot logs \`attachment_records migration: indexed attachments…\`, subsequent boots no-op