### PR TITLE
fix(migrations): backfill records for video variants and thumbnails

### DIFF
--- a/cli/internal/migrations/attachment_records.go
+++ b/cli/internal/migrations/attachment_records.go
@@ -13,10 +13,16 @@ import (
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
-// BackfillAttachmentRecords promotes every Attachment proto embedded
-// in a MessageBody into a standalone metadata record so the asset HTTP
-// handler can authorize downloads by attachment ID without scanning
-// every body.
+// BackfillAttachmentRecords populates standalone Attachment metadata
+// records in `SERVER_BODIES` so the asset HTTP handler can authorize
+// downloads by attachment ID. Two sources are walked:
+//
+//  1. Embedded `Attachment` protos inside each `MessageBody` in
+//     SERVER_BODIES (covers user-posted attachments).
+//  2. Variant + thumbnail attachment IDs referenced by each
+//     `VideoProcessingState` in SERVER_RUNTIME (covers the transcoded
+//     outputs the video service uploads on the side, which never appear
+//     in any MessageBody and therefore aren't reachable from pass 1).
 //
 // # Why
 //
@@ -28,20 +34,27 @@ import (
 // `attachment.{roomId}.{attachmentId}` records gives the handler an
 // O(1) lookup.
 //
+// Pass 2 fixes a regression in the original migration: video variants
+// and thumbnails uploaded by the video service are never embedded in a
+// MessageBody, so they had no records after the v1 migration and were
+// served as 404 by the new auth gate.
+//
 // # Layout
 //
 // Both record kinds live in `SERVER_BODIES`. Their key shapes don't
 // overlap:
 //
 //	{userId}.{bodyId}                   → MessageBody  (existing)
-//	attachment.{roomId}.{attachmentId}  → Attachment   (new, this migration)
+//	attachment.{roomId}.{attachmentId}  → Attachment   (this migration)
 //
 // # Idempotency
 //
 // Safe to re-run. Every record is written via Put, so re-running on
 // an already-populated bucket is a series of no-op overwrites with
-// identical values. A sentinel key (`attachment_records.backfilled`)
-// in SERVER_RUNTIME short-circuits repeat boots.
+// identical values. A sentinel key (`attachment_records.backfilled.v2`)
+// in SERVER_RUNTIME short-circuits repeat boots. The v2 suffix forces
+// instances that already ran the v1 pass to re-run and pick up the
+// video-variant records.
 //
 // # When this can be removed
 //
@@ -49,7 +62,7 @@ import (
 // that includes this migration. Operators can verify by inspecting
 // SERVER_RUNTIME for the sentinel key.
 func BackfillAttachmentRecords(ctx context.Context, bodiesKV, runtimeKV jetstream.KeyValue, logger *log.Logger) error {
-	const flagKey = "attachment_records.backfilled"
+	const flagKey = "attachment_records.backfilled.v2"
 
 	if entry, err := runtimeKV.Get(ctx, flagKey); err == nil && entry != nil {
 		return nil
@@ -57,15 +70,52 @@ func BackfillAttachmentRecords(ctx context.Context, bodiesKV, runtimeKV jetstrea
 		return fmt.Errorf("get backfill flag: %w", err)
 	}
 
+	// Pass 1: scan message bodies, write records for embedded
+	// attachments. Returns a map of attachmentID → roomID so pass 2
+	// can resolve the room for a video's variant/thumbnail attachments
+	// (which only know about themselves via their original's ID).
+	roomByAttachmentID, bodiesScanned, indexed, err := backfillFromBodies(ctx, bodiesKV, logger)
+	if err != nil {
+		return err
+	}
+
+	// Pass 2: scan video processing state, write records for variant
+	// and thumbnail attachments. Returns a count of additional records
+	// for logging.
+	videoIndexed, err := backfillFromVideoState(ctx, bodiesKV, runtimeKV, roomByAttachmentID, logger)
+	if err != nil {
+		return err
+	}
+
+	if _, err := runtimeKV.Put(ctx, flagKey, []byte("1")); err != nil {
+		return fmt.Errorf("set backfill flag: %w", err)
+	}
+
+	if indexed > 0 || videoIndexed > 0 || bodiesScanned > 0 {
+		logger.Info("attachment_records migration: indexed attachment metadata records",
+			"bodies_scanned", bodiesScanned,
+			"attachments_indexed", indexed,
+			"video_outputs_indexed", videoIndexed)
+	}
+	return nil
+}
+
+// backfillFromBodies walks SERVER_BODIES and writes a metadata record
+// for every attachment embedded in a MessageBody. Returns the
+// attachmentID → roomID map (used by pass 2) plus counters.
+func backfillFromBodies(
+	ctx context.Context,
+	bodiesKV jetstream.KeyValue,
+	logger *log.Logger,
+) (roomByAttachmentID map[string]string, bodiesScanned, indexed int, err error) {
+	roomByAttachmentID = map[string]string{}
+
 	lister, err := bodiesKV.ListKeys(ctx)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrNoKeysFound) {
-			if _, putErr := runtimeKV.Put(ctx, flagKey, []byte("1")); putErr != nil {
-				return fmt.Errorf("set backfill flag on empty bucket: %w", putErr)
-			}
-			return nil
+			return roomByAttachmentID, 0, 0, nil
 		}
-		return fmt.Errorf("list message body keys: %w", err)
+		return nil, 0, 0, fmt.Errorf("list message body keys: %w", err)
 	}
 
 	// Collect keys first so writes don't reshape the iterator's view of
@@ -80,14 +130,13 @@ func BackfillAttachmentRecords(ctx context.Context, bodiesKV, runtimeKV jetstrea
 		bodyKeys = append(bodyKeys, key)
 	}
 
-	indexed := 0
 	for _, key := range bodyKeys {
 		entry, err := bodiesKV.Get(ctx, key)
 		if err != nil {
 			if errors.Is(err, jetstream.ErrKeyNotFound) {
 				continue
 			}
-			return fmt.Errorf("get message body %s: %w", key, err)
+			return nil, 0, 0, fmt.Errorf("get message body %s: %w", key, err)
 		}
 
 		var body corev1.MessageBody
@@ -101,25 +150,108 @@ func BackfillAttachmentRecords(ctx context.Context, bodiesKV, runtimeKV jetstrea
 			if att == nil || att.Id == "" || att.RoomId == "" {
 				continue
 			}
+			roomByAttachmentID[att.Id] = att.RoomId
 			recordKey := "attachment." + att.RoomId + "." + att.Id
 			marshaled, err := proto.Marshal(att)
 			if err != nil {
-				return fmt.Errorf("marshal attachment record for %s: %w", att.Id, err)
+				return nil, 0, 0, fmt.Errorf("marshal attachment record for %s: %w", att.Id, err)
 			}
 			if _, err := bodiesKV.Put(ctx, recordKey, marshaled); err != nil {
-				return fmt.Errorf("write attachment record %s: %w", recordKey, err)
+				return nil, 0, 0, fmt.Errorf("write attachment record %s: %w", recordKey, err)
 			}
 			indexed++
 		}
 	}
 
-	if _, err := runtimeKV.Put(ctx, flagKey, []byte("1")); err != nil {
-		return fmt.Errorf("set backfill flag: %w", err)
+	return roomByAttachmentID, len(bodyKeys), indexed, nil
+}
+
+// backfillFromVideoState walks SERVER_RUNTIME `video.*` keys and
+// writes minimal Attachment records for every variant and thumbnail
+// attachment referenced by a VideoProcessingState. The room ID is
+// inherited from the original video attachment (which the body pass
+// already indexed). Existing video pipelines uploaded variants and
+// thumbnails via UploadAttachment without ever embedding them in a
+// MessageBody, so they have no other on-disk source we can use.
+func backfillFromVideoState(
+	ctx context.Context,
+	bodiesKV, runtimeKV jetstream.KeyValue,
+	roomByAttachmentID map[string]string,
+	logger *log.Logger,
+) (int, error) {
+	lister, err := runtimeKV.ListKeysFiltered(ctx, "video.*")
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("list video state keys: %w", err)
 	}
 
-	if indexed > 0 || len(bodyKeys) > 0 {
-		logger.Info("attachment_records migration: indexed attachments from message bodies",
-			"bodies_scanned", len(bodyKeys), "attachments_indexed", indexed)
+	var videoKeys []string
+	for k := range lister.Keys() {
+		videoKeys = append(videoKeys, k)
 	}
-	return nil
+
+	indexed := 0
+	for _, key := range videoKeys {
+		entry, err := runtimeKV.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			return 0, fmt.Errorf("get video state %s: %w", key, err)
+		}
+
+		var state corev1.VideoProcessingState
+		if err := proto.Unmarshal(entry.Value(), &state); err != nil {
+			logger.Warn("attachment_records: skipping unparseable video state",
+				"key", key, "error", err)
+			continue
+		}
+
+		// The key shape is `video.{originalAttachmentID}` — pull the
+		// original ID back out so we can ask the body-pass map what
+		// room it lived in.
+		originalID := strings.TrimPrefix(key, "video.")
+		roomID := roomByAttachmentID[originalID]
+		if roomID == "" {
+			// Original wasn't found in any body — most likely GDPR-
+			// deleted. Without a room we can't authorize the outputs;
+			// they remain unreachable. Acceptable in this degenerate
+			// case (the user content driving access is gone too).
+			logger.Warn("attachment_records: no room found for video outputs",
+				"original_attachment_id", originalID)
+			continue
+		}
+
+		referenced := make([]string, 0, len(state.Variants)+1)
+		if state.ThumbnailAttachmentId != "" {
+			referenced = append(referenced, state.ThumbnailAttachmentId)
+		}
+		for _, v := range state.Variants {
+			if v != nil && v.AttachmentId != "" {
+				referenced = append(referenced, v.AttachmentId)
+			}
+		}
+
+		for _, attID := range referenced {
+			// A minimal record is enough to gate authorization: the
+			// HTTP handler only reads `RoomId`. Storage / filename /
+			// dimensions stay zero-valued for these legacy outputs;
+			// new uploads going forward write the full proto via
+			// UploadAttachment, so the gap is bounded in time.
+			rec := &corev1.Attachment{Id: attID, RoomId: roomID}
+			marshaled, err := proto.Marshal(rec)
+			if err != nil {
+				return 0, fmt.Errorf("marshal video output record for %s: %w", attID, err)
+			}
+			recordKey := "attachment." + roomID + "." + attID
+			if _, err := bodiesKV.Put(ctx, recordKey, marshaled); err != nil {
+				return 0, fmt.Errorf("write video output record %s: %w", recordKey, err)
+			}
+			indexed++
+		}
+	}
+
+	return indexed, nil
 }

--- a/cli/internal/migrations/attachment_records_test.go
+++ b/cli/internal/migrations/attachment_records_test.go
@@ -110,7 +110,7 @@ func TestBackfillAttachmentRecords_CopiesAttachmentsFromBodies(t *testing.T) {
 		}
 	}
 
-	if _, err := runtime.Get(ctx, "attachment_records.backfilled"); err != nil {
+	if _, err := runtime.Get(ctx, "attachment_records.backfilled.v2"); err != nil {
 		t.Errorf("expected backfill sentinel set: %v", err)
 	}
 }
@@ -154,7 +154,7 @@ func TestBackfillAttachmentRecords_EmptyBodiesSetsSentinel(t *testing.T) {
 		t.Fatalf("BackfillAttachmentRecords: %v", err)
 	}
 
-	if _, err := runtime.Get(ctx, "attachment_records.backfilled"); err != nil {
+	if _, err := runtime.Get(ctx, "attachment_records.backfilled.v2"); err != nil {
 		t.Errorf("expected backfill sentinel set on empty bucket: %v", err)
 	}
 }
@@ -220,5 +220,96 @@ func TestBackfillAttachmentRecords_IgnoresExistingAttachmentRecords(t *testing.T
 	}
 	if got.Filename != "p.png" {
 		t.Errorf("preexisting record clobbered: filename=%q", got.Filename)
+	}
+}
+
+// TestBackfillAttachmentRecords_IndexesVideoVariantsAndThumbnail covers
+// the regression that triggered v2: the video service uploads variants
+// and thumbnails as separate attachments referenced only via the
+// VideoProcessingState in SERVER_RUNTIME, never embedded in any
+// MessageBody. v1 missed them and they 404'd after upgrade.
+func TestBackfillAttachmentRecords_IndexesVideoVariantsAndThumbnail(t *testing.T) {
+	ctx, bodies, runtime := setupBodiesAndRuntime(t)
+
+	// Seed a body containing the original video attachment so the
+	// migration's pass 1 captures its room ID.
+	body := &corev1.MessageBody{
+		AuthorId: "user-1",
+		Attachments: []*corev1.Attachment{
+			{Id: "video-orig", RoomId: "room-x", Filename: "clip.mp4", ContentType: "video/mp4"},
+		},
+	}
+	bodyRaw, _ := proto.Marshal(body)
+	if _, err := bodies.Put(ctx, "user-1.body-1", bodyRaw); err != nil {
+		t.Fatalf("seed body: %v", err)
+	}
+
+	// Seed a VideoProcessingState pointing at thumbnail + variants.
+	state := &corev1.VideoProcessingState{
+		Status:                corev1.VideoStatus_VIDEO_STATUS_COMPLETED,
+		ThumbnailAttachmentId: "video-thumb",
+		Variants: []*corev1.VideoVariant{
+			{AttachmentId: "video-360p", Quality: "360p"},
+			{AttachmentId: "video-720p", Quality: "720p"},
+		},
+	}
+	stateRaw, _ := proto.Marshal(state)
+	if _, err := runtime.Put(ctx, "video.video-orig", stateRaw); err != nil {
+		t.Fatalf("seed video state: %v", err)
+	}
+
+	if err := BackfillAttachmentRecords(ctx, bodies, runtime, log.New(nil)); err != nil {
+		t.Fatalf("BackfillAttachmentRecords: %v", err)
+	}
+
+	// All three output records exist under the original's room.
+	for _, id := range []string{"video-thumb", "video-360p", "video-720p"} {
+		entry, err := bodies.Get(ctx, "attachment.room-x."+id)
+		if err != nil {
+			t.Errorf("expected record for %s: %v", id, err)
+			continue
+		}
+		var att corev1.Attachment
+		if err := proto.Unmarshal(entry.Value(), &att); err != nil {
+			t.Errorf("unmarshal %s: %v", id, err)
+			continue
+		}
+		if att.Id != id {
+			t.Errorf("%s: record id=%q, want %q", id, att.Id, id)
+		}
+		if att.RoomId != "room-x" {
+			t.Errorf("%s: record roomId=%q, want room-x", id, att.RoomId)
+		}
+	}
+}
+
+// TestBackfillAttachmentRecords_SkipsVideoOutputsForOrphanedOriginal
+// guards against panics when the original video attachment is no
+// longer in any body (e.g. GDPR-deleted) while its processing state
+// still exists. The variants stay unindexed — acceptable given the
+// content driving access is also gone.
+func TestBackfillAttachmentRecords_SkipsVideoOutputsForOrphanedOriginal(t *testing.T) {
+	ctx, bodies, runtime := setupBodiesAndRuntime(t)
+
+	state := &corev1.VideoProcessingState{
+		Status:                corev1.VideoStatus_VIDEO_STATUS_COMPLETED,
+		ThumbnailAttachmentId: "orphan-thumb",
+		Variants:              []*corev1.VideoVariant{{AttachmentId: "orphan-720p"}},
+	}
+	raw, _ := proto.Marshal(state)
+	if _, err := runtime.Put(ctx, "video.orphan-original", raw); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := BackfillAttachmentRecords(ctx, bodies, runtime, log.New(nil)); err != nil {
+		t.Fatalf("BackfillAttachmentRecords: %v", err)
+	}
+
+	// No records written under any room for the orphan outputs.
+	lister, err := bodies.ListKeysFiltered(ctx, "attachment.*.orphan-thumb")
+	if err == nil {
+		for k := range lister.Keys() {
+			t.Errorf("unexpected record key %q for orphan-thumb", k)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

The initial \`BackfillAttachmentRecords\` migration only walked \`SERVER_BODIES\`, but video variants and thumbnails are uploaded by the video service as standalone attachments referenced exclusively via \`VideoProcessingState\` in \`SERVER_RUNTIME\`. After upgrade, those legacy outputs had no metadata records, so the new auth gate served them as 404 and broke video embeds on already-deployed instances.

This adds a second pass to the migration: walk \`video.*\` keys, resolve the original's room from the body-pass attachmentID→roomID map, and write minimal records (\`{Id, RoomId}\` — enough to authorize) for each variant + thumbnail. The sentinel is bumped to \`attachment_records.backfilled.v2\` so instances that already ran v1 re-execute and pick up the missing video records. Pass 1 re-running is idempotent (no-op Puts with identical values).

## Test plan

- [x] \`mise test-cli\` — new tests cover the video-output indexing path and the orphaned-original edge case
- [ ] Deploy to an instance whose v1 migration ran on data containing transcoded videos and confirm video embeds load (no 404s in console)