### PR TITLE
refactor(assets): drop legacy `/assets/space/...` attachment URLs

### DIFF
--- a/cli/internal/core/attachments.go
+++ b/cli/internal/core/attachments.go
@@ -34,10 +34,11 @@ func (c *ChattoCore) GetAttachmentsStore(ctx context.Context) (jetstream.ObjectS
 // are generated on-the-fly via transforms. The storage backend (NATS or
 // S3) is determined by configuration.
 //
-// New attachments use the kind-less `attachments/{id}` S3 key (and the
-// `/assets/attachments/{id}` URL pattern). `Attachment.SpaceId` is left
-// empty on the returned proto — it's reserved for pre-ADR-030-Phase-4
-// records that are still stored at `spaces/{server|DM}/attachments/{id}`.
+// New attachments use the kind-less `attachments/{id}` S3 key.
+// `Attachment.SpaceId` is left empty on the returned proto — it's
+// reserved for pre-ADR-030-Phase-4 records whose S3 objects still live
+// at `spaces/{server|DM}/attachments/{id}` and is consulted only by the
+// S3-key fallback probe (`attachmentS3KeyCandidates`).
 func (c *ChattoCore) UploadAttachment(
 	ctx context.Context,
 	roomID string,
@@ -256,16 +257,6 @@ func attachmentS3KeyCandidates(spaceID, attachmentID string) []string {
 		S3KeySpaceAttachment(spaceID, attachmentID),
 		S3KeyAttachment(attachmentID),
 	}
-}
-
-// attachmentCachePrefix returns the resize-cache namespace component for an
-// attachment. Matches the cache prefix used by the HTTP transform handlers
-// so deletes and lookups land in the same namespace.
-func attachmentCachePrefix(spaceID string) string {
-	if spaceID == "" {
-		return AttachmentSignResource
-	}
-	return spaceID
 }
 
 // GetAttachmentFromAnyBackend retrieves an attachment by probing both NATS and S3 backends.
@@ -487,11 +478,10 @@ func (c *ChattoCore) DeleteAttachment(ctx context.Context, spaceID, attachmentID
 	}
 
 	// Delete any cached resizes for this attachment (best-effort, don't fail on error)
-	deletedCount, cacheErr := c.DeleteCachedResizesForAttachment(ctx, spaceID, attachmentID)
+	deletedCount, cacheErr := c.DeleteCachedResizesForAttachment(ctx, attachmentID)
 	if cacheErr != nil {
 		c.logger.Warn("Failed to delete cached resizes for attachment",
 			"attachment_id", attachmentID,
-			"space_id", spaceID,
 			"error", cacheErr)
 	} else if deletedCount > 0 {
 		c.logger.Debug("Deleted cached resizes for attachment",
@@ -581,61 +571,42 @@ func (c *ChattoCore) TryPresignedAttachmentURL(ctx context.Context, spaceID, att
 }
 
 // AttachmentSignResource is the first resource component fed to the
-// signed-URL signer for post-ADR-030-Phase-4 attachment transform URLs.
-// Stable so existing signatures continue to verify across deployments.
+// signed-URL signer for attachment transform URLs. Stable so existing
+// signatures continue to verify across deployments.
 const AttachmentSignResource = "attachment"
 
-// GetAttachmentURL returns the URL for accessing an attachment by its
-// canonical (legacy) identifier. New code should prefer
-// GetAttachmentURLFromStorage which routes new vs legacy paths based on
-// the Attachment record itself. A non-empty spaceID emits the legacy
-// `/assets/space/{spaceId}/attachments/{id}` URL; an empty spaceID emits
-// the new kind-less `/assets/attachments/{id}` URL.
-func (c *ChattoCore) GetAttachmentURL(spaceID, attachmentID string) string {
-	if spaceID == "" {
-		return c.assetURL(fmt.Sprintf("/assets/attachments/%s", attachmentID))
-	}
-	return c.assetURL(fmt.Sprintf("/assets/space/%s/attachments/%s", spaceID, attachmentID))
+// GetAttachmentURL returns the URL for accessing an attachment. All
+// attachments — including those whose S3 objects still live at the
+// pre-ADR-030-Phase-4 `spaces/{server|DM}/attachments/{id}` layout —
+// are served through the kind-less `/assets/attachments/{id}` URL.
+// The HTTP handler probes both storage layouts to resolve the binary.
+func (c *ChattoCore) GetAttachmentURL(attachmentID string) string {
+	return c.assetURL(fmt.Sprintf("/assets/attachments/%s", attachmentID))
 }
 
 // GetAttachmentURLFromStorage returns the URL for accessing an attachment.
-// Storage backend is an internal implementation detail that should not leak
-// into URLs. Legacy attachments (recorded with a `space_id` value before
-// ADR-030 Phase 4) keep their `/assets/space/{spaceId}/...` URL so the
-// existing S3 objects remain reachable; new uploads emit the kind-less
-// `/assets/attachments/{id}` URL.
+// Storage backend is an internal implementation detail that does not leak
+// into URLs.
 func (c *ChattoCore) GetAttachmentURLFromStorage(attachment *corev1.Attachment) string {
-	return c.GetAttachmentURL(attachment.SpaceId, attachment.Id)
+	return c.GetAttachmentURL(attachment.Id)
 }
 
 // GetTransformedAttachmentURL returns the URL for accessing a transformed
 // version of an attachment. The URL includes an HMAC signature to prevent
 // parameter tampering.
 //
-// Legacy format (spaceID non-empty):
-//
-//	/assets/space/{spaceId}/attachments/{attachmentId}/t/{params}.{signature}
-//
-// New format (spaceID empty):
-//
 //	/assets/attachments/{attachmentId}/t/{params}.{signature}
 //
 // {params} is base64url-encoded JSON: {"w":width,"h":height,"f":"fit"}.
-func (c *ChattoCore) GetTransformedAttachmentURL(spaceID, attachmentID string, width, height int, fit string) string {
-	if spaceID == "" {
-		signedPath := signedurl.SignedTransformPath(c.config.Assets.SigningSecret, AttachmentSignResource, attachmentID, width, height, fit)
-		return c.assetURL(fmt.Sprintf("/assets/attachments/%s/t/%s", attachmentID, signedPath))
-	}
-	signedPath := signedurl.SignedTransformPath(c.config.Assets.SigningSecret, spaceID, attachmentID, width, height, fit)
-	return c.assetURL(fmt.Sprintf("/assets/space/%s/attachments/%s/t/%s",
-		spaceID, attachmentID, signedPath))
+func (c *ChattoCore) GetTransformedAttachmentURL(attachmentID string, width, height int, fit string) string {
+	signedPath := signedurl.SignedTransformPath(c.config.Assets.SigningSecret, AttachmentSignResource, attachmentID, width, height, fit)
+	return c.assetURL(fmt.Sprintf("/assets/attachments/%s/t/%s", attachmentID, signedPath))
 }
 
-// GetTransformedAttachmentURLFromStorage routes new vs legacy attachment
-// transform URLs based on the Attachment record. See
-// GetAttachmentURLFromStorage for the new vs legacy rules.
+// GetTransformedAttachmentURLFromStorage returns a transform URL for an
+// attachment record.
 func (c *ChattoCore) GetTransformedAttachmentURLFromStorage(attachment *corev1.Attachment, width, height int, fit string) string {
-	return c.GetTransformedAttachmentURL(attachment.SpaceId, attachment.Id, width, height, fit)
+	return c.GetTransformedAttachmentURL(attachment.Id, width, height, fit)
 }
 
 // GetTransformedServerAssetURL returns the URL for accessing a transformed version of an server asset.
@@ -713,15 +684,13 @@ func (c *ChattoCore) StoreCachedResize(ctx context.Context, key string, data []b
 }
 
 // DeleteCachedResizesForAttachment deletes all cached resizes for an
-// attachment. Pass an empty spaceID for post-ADR-030-Phase-4 attachments;
-// the helper picks the matching cache namespace.
-// Returns the number of deleted cache entries and any error encountered.
-// Does nothing if the cache is disabled.
-func (c *ChattoCore) DeleteCachedResizesForAttachment(ctx context.Context, spaceID, attachmentID string) (int, error) {
-	// Cache keys follow the pattern: {prefix}.{attachmentId}.{paramsHash},
-	// where {prefix} matches what the transform handler used at insertion
-	// time (spaceID for legacy attachments, "attachment" for new ones).
-	return c.DeleteCachedResizesForKey(ctx, attachmentCachePrefix(spaceID), attachmentID)
+// attachment. Returns the number of deleted cache entries and any error
+// encountered. Does nothing if the cache is disabled. Pre-ADR-030-Phase-4
+// cache entries written under a {server|DM} prefix are not cleaned up
+// and are left to age out — the transform-URL signer always uses the
+// kind-less prefix now, so no lookups land on them.
+func (c *ChattoCore) DeleteCachedResizesForAttachment(ctx context.Context, attachmentID string) (int, error) {
+	return c.DeleteCachedResizesForKey(ctx, AttachmentSignResource, attachmentID)
 }
 
 // DeleteCachedResizesForKey deletes all cached resizes for a given prefix and asset key.

--- a/cli/internal/core/attachments_test.go
+++ b/cli/internal/core/attachments_test.go
@@ -335,9 +335,9 @@ func TestChattoCore_GetAttachmentURL(t *testing.T) {
 	core, _ := setupTestCore(t)
 
 	t.Run("generate basic attachment URL", func(t *testing.T) {
-		url := core.GetAttachmentURL("space123", "attachment456")
+		url := core.GetAttachmentURL("attachment456")
 
-		expected := "/assets/space/space123/attachments/attachment456"
+		expected := "/assets/attachments/attachment456"
 		if url != expected {
 			t.Errorf("Expected URL '%s', got '%s'", expected, url)
 		}
@@ -348,22 +348,22 @@ func TestChattoCore_GetTransformedAttachmentURL(t *testing.T) {
 	core, _ := setupTestCore(t)
 
 	t.Run("generate transform URL with dimensions", func(t *testing.T) {
-		url := core.GetTransformedAttachmentURL("space123", "attachment456", 200, 150, "contain")
+		url := core.GetTransformedAttachmentURL("attachment456", 200, 150, "contain")
 
 		// URL should contain the base path
-		if !bytes.Contains([]byte(url), []byte("/assets/space/space123/attachments/attachment456/t/")) {
+		if !bytes.Contains([]byte(url), []byte("/assets/attachments/attachment456/t/")) {
 			t.Errorf("URL doesn't contain expected base path: %s", url)
 		}
 
 		// URL should have a signed path component (non-empty after /t/)
-		if len(url) <= len("/assets/space/space123/attachments/attachment456/t/") {
+		if len(url) <= len("/assets/attachments/attachment456/t/") {
 			t.Error("URL missing signed path component")
 		}
 	})
 
 	t.Run("different dimensions produce different URLs", func(t *testing.T) {
-		url1 := core.GetTransformedAttachmentURL("space123", "attachment456", 200, 150, "contain")
-		url2 := core.GetTransformedAttachmentURL("space123", "attachment456", 400, 300, "contain")
+		url1 := core.GetTransformedAttachmentURL("attachment456", 200, 150, "contain")
+		url2 := core.GetTransformedAttachmentURL("attachment456", 400, 300, "contain")
 
 		if url1 == url2 {
 			t.Error("Different dimensions should produce different URLs")
@@ -371,8 +371,8 @@ func TestChattoCore_GetTransformedAttachmentURL(t *testing.T) {
 	})
 
 	t.Run("different fit modes produce different URLs", func(t *testing.T) {
-		url1 := core.GetTransformedAttachmentURL("space123", "attachment456", 200, 150, "contain")
-		url2 := core.GetTransformedAttachmentURL("space123", "attachment456", 200, 150, "cover")
+		url1 := core.GetTransformedAttachmentURL("attachment456", 200, 150, "contain")
+		url2 := core.GetTransformedAttachmentURL("attachment456", 200, 150, "cover")
 
 		if url1 == url2 {
 			t.Error("Different fit modes should produce different URLs")
@@ -389,9 +389,9 @@ func TestChattoCore_AssetBaseURL(t *testing.T) {
 
 	t.Run("GetAttachmentURL returns relative when AssetBaseURL is empty", func(t *testing.T) {
 		core.AssetBaseURL = ""
-		url := core.GetAttachmentURL("space123", "attachment456")
+		url := core.GetAttachmentURL("attachment456")
 
-		expected := "/assets/space/space123/attachments/attachment456"
+		expected := "/assets/attachments/attachment456"
 		if url != expected {
 			t.Errorf("Expected '%s', got '%s'", expected, url)
 		}
@@ -401,9 +401,9 @@ func TestChattoCore_AssetBaseURL(t *testing.T) {
 		core.AssetBaseURL = "https://chat.example.com"
 		defer func() { core.AssetBaseURL = "" }()
 
-		url := core.GetAttachmentURL("space123", "attachment456")
+		url := core.GetAttachmentURL("attachment456")
 
-		expected := "https://chat.example.com/assets/space/space123/attachments/attachment456"
+		expected := "https://chat.example.com/assets/attachments/attachment456"
 		if url != expected {
 			t.Errorf("Expected '%s', got '%s'", expected, url)
 		}
@@ -413,9 +413,9 @@ func TestChattoCore_AssetBaseURL(t *testing.T) {
 		core.AssetBaseURL = "https://chat.example.com"
 		defer func() { core.AssetBaseURL = "" }()
 
-		url := core.GetTransformedAttachmentURL("space123", "attachment456", 200, 150, "contain")
+		url := core.GetTransformedAttachmentURL("attachment456", 200, 150, "contain")
 
-		if !bytes.HasPrefix([]byte(url), []byte("https://chat.example.com/assets/space/")) {
+		if !bytes.HasPrefix([]byte(url), []byte("https://chat.example.com/assets/attachments/")) {
 			t.Errorf("Expected absolute URL with base, got '%s'", url)
 		}
 	})
@@ -521,7 +521,7 @@ func TestAttachment_FullLifecycle(t *testing.T) {
 	}
 
 	// 2. Verify URL generation
-	url := core.GetAttachmentURL(ServerSpaceID, attachment.Id)
+	url := core.GetAttachmentURL(attachment.Id)
 	if url == "" {
 		t.Error("URL generation failed")
 	}
@@ -857,10 +857,12 @@ func TestChattoCore_DeleteAttachment_CleansUpCache(t *testing.T) {
 		t.Fatalf("Failed to upload attachment: %v", err)
 	}
 
-	// Simulate cached resizes by storing them directly
-	cacheKey1 := ImageCacheKey(ServerSpaceID, attachment.Id, 200, 150, "contain")
-	cacheKey2 := ImageCacheKey(ServerSpaceID, attachment.Id, 400, 300, "cover")
-	cacheKey3 := ImageCacheKey(ServerSpaceID, attachment.Id, 100, 100, "contain")
+	// Simulate cached resizes by storing them directly. The HTTP handler
+	// signs transform URLs with AttachmentSignResource and the cache uses
+	// that same prefix.
+	cacheKey1 := ImageCacheKey(AttachmentSignResource, attachment.Id, 200, 150, "contain")
+	cacheKey2 := ImageCacheKey(AttachmentSignResource, attachment.Id, 400, 300, "cover")
+	cacheKey3 := ImageCacheKey(AttachmentSignResource, attachment.Id, 100, 100, "contain")
 
 	// Store fake cached data
 	fakeWebP := []byte("fake webp data")
@@ -916,8 +918,8 @@ func TestChattoCore_DeleteAttachment_DoesNotAffectOtherAttachmentCache(t *testin
 	attachment2, _ := core.UploadAttachment(ctx, room.Id, "image2.png", "image/png", bytes.NewReader(imageData))
 
 	// Cache entries for both attachments
-	key1 := ImageCacheKey(ServerSpaceID, attachment1.Id, 200, 150, "contain")
-	key2 := ImageCacheKey(ServerSpaceID, attachment2.Id, 200, 150, "contain")
+	key1 := ImageCacheKey(AttachmentSignResource, attachment1.Id, 200, 150, "contain")
+	key2 := ImageCacheKey(AttachmentSignResource, attachment2.Id, 200, 150, "contain")
 
 	fakeWebP := []byte("fake webp data")
 	core.StoreCachedResize(ctx, key1, fakeWebP)
@@ -948,7 +950,7 @@ func TestChattoCore_DeleteCachedResizesForAttachment_NoCacheEnabled(t *testing.T
 	ctx := testContext(t)
 
 	// Should not error when cache is disabled
-	deleted, err := core.DeleteCachedResizesForAttachment(ctx, "space", "attachment")
+	deleted, err := core.DeleteCachedResizesForAttachment(ctx, "attachment")
 	if err != nil {
 		t.Errorf("Should not error when cache is disabled: %v", err)
 	}
@@ -962,7 +964,7 @@ func TestChattoCore_DeleteCachedResizesForAttachment_EmptyCache(t *testing.T) {
 	ctx := testContext(t)
 
 	// Should handle empty cache gracefully
-	deleted, err := core.DeleteCachedResizesForAttachment(ctx, "space", "attachment")
+	deleted, err := core.DeleteCachedResizesForAttachment(ctx, "attachment")
 	if err != nil {
 		t.Errorf("Should not error on empty cache: %v", err)
 	}

--- a/cli/internal/core/s3_test.go
+++ b/cli/internal/core/s3_test.go
@@ -228,16 +228,23 @@ func TestStorageBackendEncapsulation_URLGeneration(t *testing.T) {
 		require.Equal(t, "/assets/server/abc123xyz", expectedURLPath)
 	})
 
-	t.Run("S3 asset keys use consistent format for space attachments", func(t *testing.T) {
-		// Space attachments use: spaces/{spaceId}/attachments/{attachmentId}
-		spaceID := "space456"
+	t.Run("S3 asset keys use consistent format for attachments", func(t *testing.T) {
+		// Attachments use: attachments/{attachmentId}
 		attachmentID := "attach789"
-		s3Key := core.S3KeySpaceAttachment(spaceID, attachmentID)
-		require.Equal(t, "spaces/space456/attachments/attach789", s3Key)
+		s3Key := core.S3KeyAttachment(attachmentID)
+		require.Equal(t, "attachments/attach789", s3Key)
 
-		// The URL format should be /assets/space/{spaceId}/attachments/{attachmentId}
-		expectedURLPath := fmt.Sprintf("/assets/space/%s/attachments/%s", spaceID, attachmentID)
-		require.Equal(t, "/assets/space/space456/attachments/attach789", expectedURLPath)
+		// The URL format is /assets/attachments/{attachmentId}
+		expectedURLPath := fmt.Sprintf("/assets/attachments/%s", attachmentID)
+		require.Equal(t, "/assets/attachments/attach789", expectedURLPath)
+	})
+
+	t.Run("legacy S3 key layout remains accessible via S3KeySpaceAttachment", func(t *testing.T) {
+		// Pre-ADR-030-Phase-4 attachments still live at
+		// spaces/{server|DM}/attachments/{id}. The legacy key constructor
+		// is retained so the S3-key fallback probe can find them.
+		s3Key := core.S3KeySpaceAttachment("server", "legacyAttach")
+		require.Equal(t, "spaces/server/attachments/legacyAttach", s3Key)
 	})
 
 	t.Run("S3Asset.Key stores only the asset ID for server assets", func(t *testing.T) {

--- a/cli/internal/graph/events.resolvers.go
+++ b/cli/internal/graph/events.resolvers.go
@@ -84,7 +84,6 @@ func (r *attachmentResolver) VideoProcessing(ctx context.Context, obj *corev1.At
 
 	result := &model.VideoProcessing{
 		Status:                status,
-		SpaceID:               obj.SpaceId,
 		ThumbnailAttachmentID: state.ThumbnailAttachmentId,
 	}
 
@@ -108,7 +107,6 @@ func (r *attachmentResolver) VideoProcessing(ctx context.Context, obj *corev1.At
 			Width:        v.Width,
 			Height:       v.Height,
 			Size:         v.Size,
-			SpaceID:      obj.SpaceId,
 			AttachmentID: v.AttachmentId,
 		})
 	}
@@ -526,7 +524,7 @@ func (r *videoProcessingResolver) ThumbnailURL(ctx context.Context, obj *model.V
 	if obj.ThumbnailAttachmentID == "" {
 		return nil, nil
 	}
-	url := r.core.GetAttachmentURL(obj.SpaceID, obj.ThumbnailAttachmentID)
+	url := r.core.GetAttachmentURL(obj.ThumbnailAttachmentID)
 	return &url, nil
 }
 
@@ -542,7 +540,7 @@ func (r *videoProcessingCompletedEventResolver) MessageEventID(ctx context.Conte
 
 // URL is the resolver for the url field.
 func (r *videoVariantResolver) URL(ctx context.Context, obj *model.VideoVariant) (string, error) {
-	return r.core.GetAttachmentURL(obj.SpaceID, obj.AttachmentID), nil
+	return r.core.GetAttachmentURL(obj.AttachmentID), nil
 }
 
 // Attachment returns AttachmentResolver implementation.

--- a/cli/internal/graph/model/video.go
+++ b/cli/internal/graph/model/video.go
@@ -1,7 +1,8 @@
 package model
 
 // VideoProcessing represents the processing state of a video attachment.
-// SpaceID and ThumbnailAttachmentID are internal fields used by field resolvers.
+// ThumbnailAttachmentID is an internal field used by the thumbnailUrl
+// resolver.
 type VideoProcessing struct {
 	Status                VideoProcessingStatus
 	DurationMs            *int64
@@ -9,17 +10,15 @@ type VideoProcessing struct {
 	Height                *int32
 	ErrorMessage          *string
 	Variants              []*VideoVariant
-	SpaceID               string // internal: for building URLs
 	ThumbnailAttachmentID string // internal: for thumbnailUrl resolver
 }
 
 // VideoVariant represents a transcoded quality variant of a video.
-// SpaceID and AttachmentID are internal fields used by field resolvers.
+// AttachmentID is an internal field used by the url resolver.
 type VideoVariant struct {
 	Quality      string
 	Width        int32
 	Height       int32
 	Size         int64
-	SpaceID      string // internal: for building URL
 	AttachmentID string // internal: for building URL
 }

--- a/cli/internal/http_server/assets.go
+++ b/cli/internal/http_server/assets.go
@@ -20,25 +20,24 @@ func (s *HTTPServer) setupAssetRoutes() {
 	// The serveServerAsset handler detects and routes transform requests appropriately
 	// These handlers probe both NATS and S3 backends automatically
 	s.router.GET("/assets/server/*path", s.serveServerAsset)
-	// Post-ADR-030-Phase-4 attachment routes (kind-less). New uploads use these.
+	// Attachment routes are kind-less. Both new uploads and legacy
+	// attachments (whose S3 objects still live at
+	// `spaces/{server|DM}/attachments/{id}`) are served through these
+	// routes; the storage layer probes both layouts transparently.
 	s.router.GET("/assets/attachments/:attachmentId", s.serveAttachment)
-	s.router.GET("/assets/attachments/:attachmentId/t/:signedPath", s.serveTransformedAttachmentByID)
-	// Legacy routes — kept for attachments uploaded before Phase 4 whose S3
-	// objects still live at `spaces/{server|DM}/attachments/{id}`.
-	s.router.GET("/assets/space/:spaceId/attachments/:attachmentId", s.serveSpaceAttachment)
-	s.router.GET("/assets/space/:spaceId/attachments/:attachmentId/t/:signedPath", s.serveTransformedAttachment)
+	s.router.GET("/assets/attachments/:attachmentId/t/:signedPath", s.serveTransformedAttachment)
 }
 
 // transformRequest holds the parameters for a transformed asset request.
 // This allows sharing the transformation logic between different asset types.
 type transformRequest struct {
 	// ResourceID1 and ResourceID2 are used for signing verification.
-	// For space attachments: (spaceID, attachmentID)
+	// For attachments: ("attachment", attachmentID)
 	// For server assets: ("server", key)
 	ResourceID1 string
 	ResourceID2 string
 	SignedPath  string
-	// CachePrefix distinguishes cache keys between asset types (e.g., "space", "server")
+	// CachePrefix distinguishes cache keys between asset types (e.g., "attachment", "server")
 	CachePrefix string
 	// AssetID is used for ETag generation and logging
 	AssetID string
@@ -103,42 +102,24 @@ func (s *HTTPServer) serveServerAsset(c *gin.Context) {
 	)
 }
 
-// serveSpaceAttachment serves an attachment from a space's storage (NATS or S3).
-//
-// Authorization runs off the canonical Attachment record in SERVER_BODIES:
-// we look up the record by ID, verify room membership, then redirect to a
-// presigned S3 URL (if applicable) or stream from NATS.
-func (s *HTTPServer) serveSpaceAttachment(c *gin.Context) {
-	spaceID := c.Param("spaceId")
-	attachmentID := c.Param("attachmentId")
-	ctx := c.Request.Context()
-
-	s.logger.Debug("Serving space attachment", "space_id", spaceID, "attachment_id", attachmentID)
-	s.serveAttachmentInner(c, spaceID, attachmentID, ctx)
-}
-
-// serveAttachment serves an attachment uploaded via the post-ADR-030-Phase-4
-// kind-less URL pattern (`/assets/attachments/{id}`). Mirrors
-// serveSpaceAttachment but passes an empty spaceID for the kind-less
-// S3 layout.
+// serveAttachment serves an attachment by ID. Authorization runs off
+// the canonical Attachment record in SERVER_BODIES: we look up the
+// record by ID, verify room membership, then redirect to a presigned
+// S3 URL (if applicable) or stream from NATS. The storage layer probes
+// both the post-ADR-030-Phase-4 kind-less S3 layout and the legacy
+// `spaces/{server|DM}/attachments/{id}` layout transparently.
 func (s *HTTPServer) serveAttachment(c *gin.Context) {
 	attachmentID := c.Param("attachmentId")
 	ctx := c.Request.Context()
 
 	s.logger.Debug("Serving attachment", "attachment_id", attachmentID)
-	s.serveAttachmentInner(c, "", attachmentID, ctx)
-}
 
-// serveAttachmentInner is the shared implementation for both attachment
-// URL shapes. Resolves the room ID via the canonical Attachment record,
-// authorizes membership, then serves the binary.
-func (s *HTTPServer) serveAttachmentInner(c *gin.Context, spaceID, attachmentID string, ctx context.Context) {
 	if !s.requireAttachmentAccess(c, ctx, attachmentID) {
 		return
 	}
 
 	// Try S3 presigned redirect first (zero-copy, full Range support).
-	if presignedURL, err := s.core.TryPresignedAttachmentURL(ctx, spaceID, attachmentID); err == nil {
+	if presignedURL, err := s.core.TryPresignedAttachmentURL(ctx, "", attachmentID); err == nil {
 		// Cache the redirect itself — the attachment URL is immutable
 		c.Header("Cache-Control", "public, max-age=3600")
 		c.Redirect(http.StatusFound, presignedURL)
@@ -147,9 +128,9 @@ func (s *HTTPServer) serveAttachmentInner(c *gin.Context, spaceID, attachmentID 
 
 	// Fall back to probing both NATS and S3 backends (handles transient S3 errors
 	// where the presigned URL fails but direct S3 fetch succeeds).
-	reader, info, err := s.core.GetAttachmentFromAnyBackend(ctx, spaceID, attachmentID)
+	reader, info, err := s.core.GetAttachmentFromAnyBackend(ctx, "", attachmentID)
 	if err != nil {
-		s.logger.Error("Failed to get attachment", "error", err, "space_id", spaceID, "attachment_id", attachmentID)
+		s.logger.Error("Failed to get attachment", "error", err, "attachment_id", attachmentID)
 		c.JSON(http.StatusNotFound, gin.H{"error": "Attachment not found"})
 		return
 	}
@@ -164,11 +145,7 @@ func (s *HTTPServer) serveAttachmentInner(c *gin.Context, spaceID, attachmentID 
 
 	// Immutable asset - cache forever
 	c.Header("Cache-Control", "public, max-age=31536000, immutable")
-	if spaceID != "" {
-		c.Header("ETag", fmt.Sprintf("\"%s-%s\"", spaceID, attachmentID))
-	} else {
-		c.Header("ETag", fmt.Sprintf("\"%s\"", attachmentID))
-	}
+	c.Header("ETag", fmt.Sprintf("\"%s\"", attachmentID))
 	c.Header("Vary", "Accept-Encoding")
 
 	// Stream directly — no io.ReadAll, no memory buffering
@@ -392,43 +369,10 @@ func (s *HTTPServer) serveTransformedServerAsset(c *gin.Context, key, signedPath
 }
 
 // serveTransformedAttachment serves a dynamically transformed version of an attachment.
-// URL format: /assets/space/{spaceId}/attachments/{attachmentId}/t/{signedPath}
+// URL format: /assets/attachments/{attachmentId}/t/{signedPath}
 // where signedPath is {base64params}.{signature}
 // Probes both NATS and S3 backends for the attachment.
 func (s *HTTPServer) serveTransformedAttachment(c *gin.Context) {
-	spaceID := c.Param("spaceId")
-	attachmentID := c.Param("attachmentId")
-	signedPath := c.Param("signedPath")
-
-	s.logger.Debug("Serving transformed attachment",
-		"space_id", spaceID,
-		"attachment_id", attachmentID)
-
-	s.serveTransformedAsset(c, transformRequest{
-		ResourceID1: spaceID,
-		ResourceID2: attachmentID,
-		SignedPath:  signedPath,
-		CachePrefix: spaceID,
-		AssetID:     attachmentID,
-		FetchAsset: func(ctx context.Context) (io.Reader, string, error) {
-			reader, info, err := s.core.GetAttachmentFromAnyBackend(ctx, spaceID, attachmentID)
-			if err != nil {
-				return nil, "", err
-			}
-			return reader, info.ContentType, nil
-		},
-		Authorize: func(c *gin.Context) bool {
-			return s.requireAttachmentAccess(c, c.Request.Context(), attachmentID)
-		},
-	})
-}
-
-// serveTransformedAttachmentByID serves a dynamically transformed version of
-// a post-ADR-030-Phase-4 attachment.
-// URL format: /assets/attachments/{attachmentId}/t/{signedPath}
-// Mirrors serveTransformedAttachment but signs with ("attachment", id)
-// instead of (spaceID, id), and uses the kind-less cache namespace.
-func (s *HTTPServer) serveTransformedAttachmentByID(c *gin.Context) {
 	attachmentID := c.Param("attachmentId")
 	signedPath := c.Param("signedPath")
 

--- a/cli/internal/pb/chatto/core/v1/models.pb.go
+++ b/cli/internal/pb/chatto/core/v1/models.pb.go
@@ -892,9 +892,11 @@ type Attachment struct {
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// Legacy "server"/"DM" discriminator; wire-frozen because it's
 	// embedded in the S3 key path (`spaces/{spaceId}/attachments/{id}`)
-	// and asset URL (`/assets/space/{spaceId}/attachments/{id}`) of
-	// existing attachments. Use Asset.S3Asset.key on `storage` instead
-	// for new attachments. See ADR-030.
+	// of existing attachments and consulted only by the S3-key fallback
+	// probe (`attachmentS3KeyCandidates`). New uploads leave this empty
+	// and store binaries under `attachments/{id}` instead. The URL
+	// namespace no longer carries this discriminator — all attachments
+	// are served from `/assets/attachments/{id}`. See ADR-030.
 	SpaceId string `protobuf:"bytes,2,opt,name=space_id,json=spaceId,proto3" json:"space_id,omitempty"`
 	// Room ID where this attachment was posted (for authorization)
 	RoomId string `protobuf:"bytes,3,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -636,11 +636,12 @@ Notes: Content-Type stored in object headers. S2 compression enabled. Assets ref
 
 **ASSET_CACHE keys:**
 
-| Key                                    | Description                                  |
-| -------------------------------------- | -------------------------------------------- |
-| `{spaceId}.{attachmentId}.{paramsHash}`| Cached WebP image at specific dimensions     |
+| Key                                       | Description                                  |
+| ----------------------------------------- | -------------------------------------------- |
+| `attachment.{attachmentId}.{paramsHash}`  | Cached WebP image at specific dimensions     |
+| `server.{assetId}.{paramsHash}`           | Cached WebP transform of a server asset      |
 
-Notes: Only created when `[core.assets.cache]` is enabled in config. Uses TTL for automatic expiration (default 7 days). `paramsHash` is first 16 hex chars of SHA256(`{width}x{height}_{fit}`). Animated GIFs are not cached (served directly). S2 compression enabled.
+Notes: Only created when `[core.assets.cache]` is enabled in config. Uses TTL for automatic expiration (default 7 days). `paramsHash` is first 16 hex chars of SHA256(`{width}x{height}_{fit}`). Animated GIFs are not cached (served directly). S2 compression enabled. Pre-ADR-030-Phase-4 entries written under a `{server|DM}.…` prefix are no longer looked up after the kind-less URL switchover and age out via TTL.
 
 **SERVER\_ASSETS keys (primary + DM, post phase 4e):**
 
@@ -658,13 +659,13 @@ Chatto supports on-the-fly image transformation for attachments, allowing client
 **URL Structure:**
 
 ```
-/assets/space/{spaceId}/attachments/{attachmentId}/t/{signedPath}
+/assets/attachments/{attachmentId}/t/{signedPath}
 ```
 
 Where `{signedPath}` is: `{base64params}.{signature}`
 
 - `{base64params}` - Base64URL-encoded JSON: `{"w":640,"h":512,"f":"contain"}`
-- `{signature}` - Truncated HMAC-SHA256 (32 hex chars) of `{spaceId}/{attachmentId}/{base64params}`
+- `{signature}` - Truncated HMAC-SHA256 (32 hex chars) of `attachment/{attachmentId}/{base64params}`
 
 **Transform Parameters:**
 

--- a/frontend/src/lib/components/chat/VideoPlayer.svelte
+++ b/frontend/src/lib/components/chat/VideoPlayer.svelte
@@ -70,8 +70,8 @@
 	);
 
 	// Vidstack auto-detects media type from URL extensions, but our attachment
-	// URLs have no extension (/assets/space/.../attachments/...). We must
-	// provide an explicit type so Vidstack recognizes it as video/mp4.
+	// URLs have no extension (/assets/attachments/...). We must provide an
+	// explicit type so Vidstack recognizes it as video/mp4.
 	const videoSrc = $derived(
 		selectedVariant ? { src: selectedVariant.url, type: 'video/mp4' } : undefined
 	);

--- a/proto/chatto/core/v1/models.proto
+++ b/proto/chatto/core/v1/models.proto
@@ -139,9 +139,11 @@ message Attachment {
 
   // Legacy "server"/"DM" discriminator; wire-frozen because it's
   // embedded in the S3 key path (`spaces/{spaceId}/attachments/{id}`)
-  // and asset URL (`/assets/space/{spaceId}/attachments/{id}`) of
-  // existing attachments. Use Asset.S3Asset.key on `storage` instead
-  // for new attachments. See ADR-030.
+  // of existing attachments and consulted only by the S3-key fallback
+  // probe (`attachmentS3KeyCandidates`). New uploads leave this empty
+  // and store binaries under `attachments/{id}` instead. The URL
+  // namespace no longer carries this discriminator — all attachments
+  // are served from `/assets/attachments/{id}`. See ADR-030.
   string space_id = 2;
 
   // Room ID where this attachment was posted (for authorization)


### PR DESCRIPTION
## Summary

The pre-ADR-030-Phase-4 attachment URL shape — `/assets/space/{spaceId}/attachments/{id}` where `spaceId` was the wire-frozen `"server"`/`"DM"` discriminator — produced visually confusing URLs like `/assets/space/server/attachments/{id}` and served no functional purpose. The URL is computed at GraphQL response time (not persisted), and the storage layer already probes both the new `attachments/{id}` and legacy `spaces/{server|DM}/attachments/{id}` S3 layouts when resolving by attachment ID.

This PR collapses the URL surface to just `/assets/attachments/{id}` for everything.

### What changes

- `GetAttachmentURL` / `GetTransformedAttachmentURL` always emit `/assets/attachments/{id}[...]`, regardless of `Attachment.SpaceId`.
- HTTP routes `GET /assets/space/...` are removed; the single `GET /assets/attachments/:id` handler serves both new and legacy attachments via the existing S3-key fallback probe.
- Signed transform URLs always sign with `AttachmentSignResource` (`"attachment"`).
- `Attachment.SpaceId` stays on the proto — still wire-frozen, still consulted by the S3-key fallback probe to find legacy objects. It just no longer leaks into URLs.
- `VideoProcessing` / `VideoVariant` GraphQL models lose their now-unused internal `SpaceID` field.

### What doesn't change

- Legacy S3 objects at `spaces/{server|DM}/attachments/{id}` are still reachable — `attachmentS3KeyCandidates` already probes both layouts when given an empty `spaceID`.
- The `Attachment.SpaceId` proto field is preserved (wire-frozen) for the fallback probe.
- `ServerSpaceID` / `DMSpaceID` constants stay.

### Acceptable losses

- Any signed transform URL already rendered in a live page load stops verifying — fine, they're regenerated on every GraphQL response.
- Resize cache entries written under a `{server|DM}.…` prefix are no longer looked up and age out via TTL.
- Externally pasted `/assets/space/...` links break, but they require auth anyway, so audience is essentially zero.

Net diff: −76 lines.

## Test plan

- [x] `mise test-cli` — full Go test suite passes (updated `attachments_test.go`, `s3_test.go` for new URL shape and cache prefix)
- [x] `mise test-frontend` — 756 frontend tests pass
- [ ] Manual smoke: upload a new attachment in a channel room, verify URL is `/assets/attachments/{id}`
- [ ] Manual smoke: load a page with a pre-Phase-4 attachment (with `space_id = "server"`), verify it loads via the new URL and the S3 fallback finds the legacy object
- [ ] Manual smoke: render a thumbnail (transform URL), verify it loads