### PR TITLE
refactor(assets): read storage layout from Attachment record, drop S3-key probing

### DIFF
--- a/cli/internal/core/attachments.go
+++ b/cli/internal/core/attachments.go
@@ -35,10 +35,10 @@ func (c *ChattoCore) GetAttachmentsStore(ctx context.Context) (jetstream.ObjectS
 // S3) is determined by configuration.
 //
 // New attachments use the kind-less `attachments/{id}` S3 key.
-// `Attachment.SpaceId` is left empty on the returned proto — it's
-// reserved for pre-ADR-030-Phase-4 records whose S3 objects still live
-// at `spaces/{server|DM}/attachments/{id}` and is consulted only by the
-// S3-key fallback probe (`attachmentS3KeyCandidates`).
+// `Attachment.SpaceId` is left empty on the returned proto — it's a
+// vestigial field reserved for pre-ADR-030-Phase-4 records and is no
+// longer consulted by anything; the canonical `Storage` field carries
+// the exact key for both new uploads and migrated legacy records.
 func (c *ChattoCore) UploadAttachment(
 	ctx context.Context,
 	roomID string,
@@ -227,75 +227,46 @@ func (c *ChattoCore) GetS3Attachment(ctx context.Context, s3Key string) (io.Read
 	}, nil
 }
 
-// attachmentS3Key returns the preferred S3 key for an attachment. New
-// attachments (with no SpaceId) use the kind-less layout; legacy
-// attachments stay at their pre-ADR-030-Phase-4 layout
-// (`spaces/{server|DM}/attachments/{id}`).
-func attachmentS3Key(spaceID, attachmentID string) string {
-	if spaceID == "" {
-		return S3KeyAttachment(attachmentID)
+// GetAttachmentFromAnyBackend retrieves an attachment's binary content
+// by looking up its canonical metadata record and reading from the exact
+// backend recorded on `Attachment.Storage`. Returns a reader for the
+// attachment content and metadata. The caller is responsible for closing
+// the reader if it implements io.Closer.
+//
+// Returns an error if no metadata record exists for the given ID — the
+// boot migration backfills records for every legacy attachment, so a
+// missing record at this point indicates either an orphaned binary
+// (uploaded outside a message body) or a corrupted state, neither of
+// which we serve.
+func (c *ChattoCore) GetAttachmentFromAnyBackend(ctx context.Context, attachmentID string) (io.Reader, *AttachmentInfo, error) {
+	record, err := c.GetAttachmentRecord(ctx, attachmentID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("look up attachment record: %w", err)
 	}
-	return S3KeySpaceAttachment(spaceID, attachmentID)
-}
+	if record == nil || record.Storage == nil {
+		return nil, nil, fmt.Errorf("attachment not found: %s", attachmentID)
+	}
 
-// attachmentS3KeyCandidates returns the S3 key to try first plus any
-// fallbacks. We probe across layouts so layout mismatches between caller
-// hint and actual storage (e.g. a legacy in-flight video processing
-// request handled by a Phase-4 binary, or a new variant attached to a
-// legacy parent video) resolve transparently.
-func attachmentS3KeyCandidates(spaceID, attachmentID string) []string {
-	if spaceID == "" {
-		// Prefer the new layout but fall back to known legacy spaceIDs.
-		return []string{
-			S3KeyAttachment(attachmentID),
-			S3KeySpaceAttachment(ServerSpaceID, attachmentID),
-			S3KeySpaceAttachment(DMSpaceID, attachmentID),
+	switch asset := record.Storage.Asset.(type) {
+	case *corev1.Asset_Nats:
+		reader, info, err := c.GetAttachment(ctx, asset.Nats.Key)
+		if err != nil {
+			return nil, nil, err
 		}
-	}
-	// Prefer the requested legacy layout, fall back to the new one.
-	return []string{
-		S3KeySpaceAttachment(spaceID, attachmentID),
-		S3KeyAttachment(attachmentID),
-	}
-}
-
-// GetAttachmentFromAnyBackend retrieves an attachment by probing both NATS and S3 backends.
-// It tries NATS first (for backwards compatibility with existing attachments), then S3.
-// An empty spaceID selects the kind-less S3 layout used for new uploads;
-// a non-empty spaceID selects the legacy `spaces/{spaceId}/...` layout.
-// Returns a reader for the attachment content and metadata.
-// The caller is responsible for closing the reader if it implements io.Closer.
-func (c *ChattoCore) GetAttachmentFromAnyBackend(ctx context.Context, spaceID, attachmentID string) (io.Reader, *AttachmentInfo, error) {
-	// Try NATS first (backwards compatibility)
-	reader, info, err := c.GetAttachment(ctx, attachmentID)
-	if err == nil {
 		return reader, &AttachmentInfo{
 			Size:        int64(info.Size),
 			ContentType: info.Headers.Get("Content-Type"),
 			Filename:    info.Headers.Get("Filename"),
 			RoomID:      info.Headers.Get("Room-Id"),
 		}, nil
-	}
-
-	// If NATS failed and S3 is configured, try S3. Probe across layouts
-	// so legacy-vs-new mismatches in the caller's hint resolve cleanly.
-	if c.s3Client != nil {
-		var lastS3Err error
-		for _, s3Key := range attachmentS3KeyCandidates(spaceID, attachmentID) {
-			s3Reader, s3Info, s3Err := c.GetS3Attachment(ctx, s3Key)
-			if s3Err == nil {
-				return s3Reader, s3Info, nil
-			}
-			lastS3Err = s3Err
+	case *corev1.Asset_S3:
+		if c.s3Client == nil {
+			return nil, nil, fmt.Errorf("S3 client not configured")
 		}
-		c.logger.Debug("Attachment not found in either backend",
-			"space_id", spaceID,
-			"attachment_id", attachmentID,
-			"nats_error", err,
-			"s3_error", lastS3Err)
+		return c.GetS3Attachment(ctx, asset.S3.Key)
+	default:
+		return nil, nil, fmt.Errorf("unknown storage backend for attachment %s", attachmentID)
 	}
-
-	return nil, nil, err
 }
 
 // ============================================================================
@@ -448,126 +419,107 @@ func (c *ChattoCore) forgetAttachmentRecord(ctx context.Context, roomID, attachm
 	return nil
 }
 
-// DeleteAttachment deletes a NATS attachment and its cached resizes.
-// This is the legacy path for attachments stored in NATS ObjectStore.
-// Use DeleteAttachmentFromStorage for attachments with known storage type.
-func (c *ChattoCore) DeleteAttachment(ctx context.Context, spaceID, attachmentID string) error {
-	store, err := c.GetAttachmentsStore(ctx)
+// DeleteAttachment removes an attachment's binary, metadata record, and
+// cached resizes by ID. Looks up the canonical record to find the
+// storage backend, then dispatches to DeleteAttachmentFromStorage.
+//
+// If no record exists, falls back to a best-effort cache cleanup and
+// returns nil — the binary is presumed already gone (or never existed)
+// and there's nothing left to do.
+func (c *ChattoCore) DeleteAttachment(ctx context.Context, attachmentID string) error {
+	record, err := c.GetAttachmentRecord(ctx, attachmentID)
 	if err != nil {
-		return fmt.Errorf("failed to get attachments store: %w", err)
+		return fmt.Errorf("look up attachment record: %w", err)
 	}
-
-	// Resolve the room ID via the canonical record before we delete the
-	// underlying object, so we can also drop the metadata entry. If no
-	// record exists (legacy orphan), we still proceed with the storage
-	// delete — the record cleanup is best-effort and silently no-ops.
-	var roomID string
-	if rec, recErr := c.GetAttachmentRecord(ctx, attachmentID); recErr == nil && rec != nil {
-		roomID = rec.RoomId
+	if record == nil {
+		// Best-effort cache cleanup for any orphaned resize entries.
+		_, _ = c.DeleteCachedResizesForAttachment(ctx, attachmentID)
+		return nil
 	}
-
-	err = store.Delete(ctx, attachmentID)
-	if err != nil {
-		return fmt.Errorf("failed to delete attachment: %w", err)
-	}
-
-	if recErr := c.forgetAttachmentRecord(ctx, roomID, attachmentID); recErr != nil {
-		c.logger.Warn("Failed to forget attachment record",
-			"attachment_id", attachmentID,
-			"error", recErr)
-	}
-
-	// Delete any cached resizes for this attachment (best-effort, don't fail on error)
-	deletedCount, cacheErr := c.DeleteCachedResizesForAttachment(ctx, attachmentID)
-	if cacheErr != nil {
-		c.logger.Warn("Failed to delete cached resizes for attachment",
-			"attachment_id", attachmentID,
-			"error", cacheErr)
-	} else if deletedCount > 0 {
-		c.logger.Debug("Deleted cached resizes for attachment",
-			"attachment_id", attachmentID,
-			"space_id", spaceID,
-			"deleted_count", deletedCount)
-	}
-
-	c.logger.Debug("Deleted attachment", "attachment_id", attachmentID, "space_id", spaceID)
-
-	return nil
+	return c.DeleteAttachmentFromStorage(ctx, record)
 }
 
-// DeleteAttachmentFromStorage deletes an attachment based on its storage type.
-// Handles both NATS ObjectStore and S3 storage.
+// DeleteAttachmentFromStorage deletes an attachment's binary (from the
+// backend recorded on `Storage`), its metadata record, and its cached
+// resizes. Errors out if the attachment record has no Storage info —
+// every record persisted post-Phase-4 (incl. backfilled legacy records)
+// should have it populated.
 func (c *ChattoCore) DeleteAttachmentFromStorage(ctx context.Context, attachment *corev1.Attachment) error {
-	// Check storage type - if nil or NATS, use legacy deletion
 	if attachment.Storage == nil {
-		return c.DeleteAttachment(ctx, attachment.SpaceId, attachment.Id)
+		return fmt.Errorf("attachment %s has no storage info", attachment.Id)
 	}
 
 	switch storage := attachment.Storage.Asset.(type) {
 	case *corev1.Asset_Nats:
-		return c.DeleteAttachment(ctx, attachment.SpaceId, attachment.Id)
+		store, err := c.GetAttachmentsStore(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get attachments store: %w", err)
+		}
+		if err := store.Delete(ctx, storage.Nats.Key); err != nil {
+			return fmt.Errorf("failed to delete attachment from NATS: %w", err)
+		}
+		c.logger.Debug("Deleted NATS attachment", "attachment_id", attachment.Id, "key", storage.Nats.Key)
 	case *corev1.Asset_S3:
-		// Delete from S3
 		if c.s3Client == nil {
 			return fmt.Errorf("S3 client not configured")
 		}
 		if err := c.s3Client.DeleteObjectFromBucket(ctx, storage.S3.GetBucket(), storage.S3.Key); err != nil {
 			return fmt.Errorf("failed to delete S3 attachment: %w", err)
 		}
-		if recErr := c.forgetAttachmentRecord(ctx, attachment.RoomId, attachment.Id); recErr != nil {
-			c.logger.Warn("Failed to forget attachment record",
-				"attachment_id", attachment.Id,
-				"error", recErr)
-		}
-		// Delete any cached resizes (S3 attachments use the S3 key as cache prefix)
-		deletedCount, cacheErr := c.DeleteCachedResizesForKey(ctx, "s3", storage.S3.Key)
-		if cacheErr != nil {
-			c.logger.Warn("Failed to delete cached resizes for S3 attachment",
-				"s3_key", storage.S3.Key,
-				"error", cacheErr)
-		} else if deletedCount > 0 {
-			c.logger.Debug("Deleted cached resizes for S3 attachment",
-				"s3_key", storage.S3.Key,
-				"deleted_count", deletedCount)
-		}
-		c.logger.Debug("Deleted S3 attachment", "s3_key", storage.S3.Key)
-		return nil
+		c.logger.Debug("Deleted S3 attachment", "attachment_id", attachment.Id, "s3_key", storage.S3.Key)
 	default:
-		return c.DeleteAttachment(ctx, attachment.SpaceId, attachment.Id)
+		return fmt.Errorf("attachment %s has unknown storage backend", attachment.Id)
 	}
+
+	if recErr := c.forgetAttachmentRecord(ctx, attachment.RoomId, attachment.Id); recErr != nil {
+		c.logger.Warn("Failed to forget attachment record",
+			"attachment_id", attachment.Id,
+			"error", recErr)
+	}
+
+	deletedCount, cacheErr := c.DeleteCachedResizesForAttachment(ctx, attachment.Id)
+	if cacheErr != nil {
+		c.logger.Warn("Failed to delete cached resizes for attachment",
+			"attachment_id", attachment.Id,
+			"error", cacheErr)
+	} else if deletedCount > 0 {
+		c.logger.Debug("Deleted cached resizes for attachment",
+			"attachment_id", attachment.Id,
+			"deleted_count", deletedCount)
+	}
+
+	return nil
 }
 
 // TryPresignedAttachmentURL attempts to generate a presigned S3 URL for an
 // attachment. Returns the URL string if the attachment exists in S3, or an
-// error if S3 is not configured or the attachment is not found in S3.
-// Pass an empty spaceID to prefer the post-ADR-030-Phase-4 kind-less layout;
-// the helper falls back to the legacy `spaces/{server|DM}/...` keys for
-// layout mismatches.
+// error if the record is missing, the backend is NATS, or S3 isn't
+// configured.
 //
 // Authorization is the caller's responsibility — the room ID comes from
 // the canonical Attachment record (see GetAttachmentRecord), not from S3.
-func (c *ChattoCore) TryPresignedAttachmentURL(ctx context.Context, spaceID, attachmentID string) (string, error) {
+func (c *ChattoCore) TryPresignedAttachmentURL(ctx context.Context, attachmentID string) (string, error) {
 	if c.s3Client == nil {
 		return "", fmt.Errorf("S3 not configured")
 	}
 
-	var lastErr error
-	for _, s3Key := range attachmentS3KeyCandidates(spaceID, attachmentID) {
-		// Stat to verify the object exists (presigned URLs don't check existence)
-		if _, err := c.s3Client.StatObject(ctx, s3Key); err != nil {
-			lastErr = err
-			continue
-		}
-		presignedURL, err := c.s3Client.PresignedGetURL(ctx, s3Key, time.Hour)
-		if err != nil {
-			return "", fmt.Errorf("failed to generate presigned URL: %w", err)
-		}
-		return presignedURL.String(), nil
+	record, err := c.GetAttachmentRecord(ctx, attachmentID)
+	if err != nil {
+		return "", fmt.Errorf("look up attachment record: %w", err)
 	}
-	if lastErr == nil {
-		lastErr = fmt.Errorf("attachment not found")
+	if record == nil || record.Storage == nil {
+		return "", fmt.Errorf("attachment not found: %s", attachmentID)
 	}
-	return "", lastErr
+	s3, ok := record.Storage.Asset.(*corev1.Asset_S3)
+	if !ok {
+		return "", fmt.Errorf("attachment %s is not stored in S3", attachmentID)
+	}
+
+	presignedURL, err := c.s3Client.PresignedGetURL(ctx, s3.S3.Key, time.Hour)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate presigned URL: %w", err)
+	}
+	return presignedURL.String(), nil
 }
 
 // AttachmentSignResource is the first resource component fed to the
@@ -841,38 +793,3 @@ func (c *ChattoCore) PublishVideoProcessingCompleted(ctx context.Context, kind R
 	return c.publishLiveServerEvent(ctx, subject, event)
 }
 
-// DeleteAttachmentFromStorageByID deletes an attachment from storage by
-// space ID and attachment ID. This probes both NATS and S3 backends. Used
-// by the video service to delete the original after successful transcoding.
-// Pass an empty spaceID to prefer the post-ADR-030-Phase-4 kind-less layout;
-// the helper probes all known S3 layouts so layout mismatches resolve
-// transparently.
-func (c *ChattoCore) DeleteAttachmentFromStorageByID(ctx context.Context, spaceID, attachmentID string) error {
-	// Try NATS first
-	err := c.DeleteAttachment(ctx, spaceID, attachmentID)
-	if err == nil {
-		return nil
-	}
-
-	// Try S3 across known layouts.
-	if c.s3Client != nil {
-		// Resolve the room ID via the canonical record so we can clean
-		// up the metadata entry alongside the storage object.
-		var roomID string
-		if rec, recErr := c.GetAttachmentRecord(ctx, attachmentID); recErr == nil && rec != nil {
-			roomID = rec.RoomId
-		}
-		for _, s3Key := range attachmentS3KeyCandidates(spaceID, attachmentID) {
-			if s3Err := c.s3Client.DeleteObject(ctx, s3Key); s3Err == nil {
-				if recErr := c.forgetAttachmentRecord(ctx, roomID, attachmentID); recErr != nil {
-					c.logger.Warn("Failed to forget attachment record",
-						"attachment_id", attachmentID,
-						"error", recErr)
-				}
-				return nil
-			}
-		}
-	}
-
-	return err
-}

--- a/cli/internal/core/attachments_test.go
+++ b/cli/internal/core/attachments_test.go
@@ -236,7 +236,7 @@ func TestChattoCore_DeleteAttachment(t *testing.T) {
 		}
 
 		// Delete it
-		err = core.DeleteAttachment(ctx, ServerSpaceID, attachment.Id)
+		err = core.DeleteAttachment(ctx, attachment.Id)
 		if err != nil {
 			t.Fatalf("Failed to delete attachment: %v", err)
 		}
@@ -249,7 +249,7 @@ func TestChattoCore_DeleteAttachment(t *testing.T) {
 	})
 
 	t.Run("delete non-existent attachment", func(t *testing.T) {
-		err := core.DeleteAttachment(ctx, ServerSpaceID, "nonexistent-attachment-id")
+		err := core.DeleteAttachment(ctx, "nonexistent-attachment-id")
 		// Deletion of non-existent item may or may not error depending on implementation
 		// This test documents the current behavior
 		if err != nil {
@@ -538,7 +538,7 @@ func TestAttachment_FullLifecycle(t *testing.T) {
 	}
 
 	// 4. Delete
-	err = core.DeleteAttachment(ctx, ServerSpaceID, attachment.Id)
+	err = core.DeleteAttachment(ctx, attachment.Id)
 	if err != nil {
 		t.Fatalf("Deletion failed: %v", err)
 	}
@@ -888,7 +888,7 @@ func TestChattoCore_DeleteAttachment_CleansUpCache(t *testing.T) {
 	}
 
 	// Delete the attachment (should also clean up cache)
-	err = core.DeleteAttachment(ctx, ServerSpaceID, attachment.Id)
+	err = core.DeleteAttachment(ctx, attachment.Id)
 	if err != nil {
 		t.Fatalf("Failed to delete attachment: %v", err)
 	}
@@ -926,7 +926,7 @@ func TestChattoCore_DeleteAttachment_DoesNotAffectOtherAttachmentCache(t *testin
 	core.StoreCachedResize(ctx, key2, fakeWebP)
 
 	// Delete attachment1
-	err := core.DeleteAttachment(ctx, ServerSpaceID, attachment1.Id)
+	err := core.DeleteAttachment(ctx, attachment1.Id)
 	if err != nil {
 		t.Fatalf("Failed to delete attachment1: %v", err)
 	}
@@ -1092,7 +1092,7 @@ func TestDeleteAttachment_ForgetsRecord(t *testing.T) {
 		t.Fatalf("Failed to upload attachment: %v", err)
 	}
 
-	if err := core.DeleteAttachment(ctx, "", attachment.Id); err != nil {
+	if err := core.DeleteAttachment(ctx, attachment.Id); err != nil {
 		t.Fatalf("DeleteAttachment failed: %v", err)
 	}
 

--- a/cli/internal/core/s3.go
+++ b/cli/internal/core/s3.go
@@ -189,24 +189,13 @@ func (s *S3Client) PresignedGetURL(ctx context.Context, key string, expiry time.
 
 // S3 key helpers for organizing assets in S3.
 
-// S3KeyAttachment returns the S3 key for an attachment.
-// Format: attachments/{attachmentId}
-// This is the canonical post-ADR-030 layout — no kind segment. New uploads
-// use this key; existing attachments stay at their pre-existing
-// `spaces/{spaceId}/attachments/{id}` paths (see S3KeySpaceAttachment).
+// S3KeyAttachment returns the S3 key for an attachment uploaded after
+// ADR-030 Phase 4. Format: attachments/{attachmentId}. Pre-Phase-4
+// attachments live at `spaces/{server|DM}/attachments/{id}`; that
+// layout is no longer constructed by Go code — the canonical key
+// comes from `Attachment.Storage.S3.Key` on the metadata record.
 func S3KeyAttachment(attachmentID string) string {
 	return fmt.Sprintf("attachments/%s", attachmentID)
-}
-
-// S3KeySpaceAttachment returns the legacy S3 key for an attachment uploaded
-// before ADR-030 Phase 4. Wire-frozen because changing it would require
-// copying every existing S3 object. New uploads use S3KeyAttachment;
-// `spaceId` here is always the literal "server" or "DM" recorded on the
-// attachment's `space_id` field.
-//
-// Format: spaces/{spaceId}/attachments/{attachmentId}
-func S3KeySpaceAttachment(spaceID, attachmentID string) string {
-	return fmt.Sprintf("spaces/%s/attachments/%s", spaceID, attachmentID)
 }
 
 // S3KeyServerAsset returns the S3 key for an server asset (avatar, logo, banner).

--- a/cli/internal/core/s3_test.go
+++ b/cli/internal/core/s3_test.go
@@ -181,13 +181,6 @@ func TestS3KeyHelpers(t *testing.T) {
 			expected: "attachments/attach456",
 		},
 		{
-			name: "SpaceAttachment",
-			function: func() string {
-				return core.S3KeySpaceAttachment("space123", "attach456")
-			},
-			expected: "spaces/space123/attachments/attach456",
-		},
-		{
 			name: "ServerAsset",
 			function: func() string {
 				return core.S3KeyServerAsset("asset789")
@@ -239,13 +232,6 @@ func TestStorageBackendEncapsulation_URLGeneration(t *testing.T) {
 		require.Equal(t, "/assets/attachments/attach789", expectedURLPath)
 	})
 
-	t.Run("legacy S3 key layout remains accessible via S3KeySpaceAttachment", func(t *testing.T) {
-		// Pre-ADR-030-Phase-4 attachments still live at
-		// spaces/{server|DM}/attachments/{id}. The legacy key constructor
-		// is retained so the S3-key fallback probe can find them.
-		s3Key := core.S3KeySpaceAttachment("server", "legacyAttach")
-		require.Equal(t, "spaces/server/attachments/legacyAttach", s3Key)
-	})
 
 	t.Run("S3Asset.Key stores only the asset ID for server assets", func(t *testing.T) {
 		// When storing an S3 asset, we should store only the assetID

--- a/cli/internal/http_server/assets.go
+++ b/cli/internal/http_server/assets.go
@@ -105,9 +105,9 @@ func (s *HTTPServer) serveServerAsset(c *gin.Context) {
 // serveAttachment serves an attachment by ID. Authorization runs off
 // the canonical Attachment record in SERVER_BODIES: we look up the
 // record by ID, verify room membership, then redirect to a presigned
-// S3 URL (if applicable) or stream from NATS. The storage layer probes
-// both the post-ADR-030-Phase-4 kind-less S3 layout and the legacy
-// `spaces/{server|DM}/attachments/{id}` layout transparently.
+// S3 URL (if applicable) or stream the binary directly. The exact
+// storage location comes from `Attachment.Storage` on the canonical
+// record — no key probing needed.
 func (s *HTTPServer) serveAttachment(c *gin.Context) {
 	attachmentID := c.Param("attachmentId")
 	ctx := c.Request.Context()
@@ -119,16 +119,16 @@ func (s *HTTPServer) serveAttachment(c *gin.Context) {
 	}
 
 	// Try S3 presigned redirect first (zero-copy, full Range support).
-	if presignedURL, err := s.core.TryPresignedAttachmentURL(ctx, "", attachmentID); err == nil {
+	if presignedURL, err := s.core.TryPresignedAttachmentURL(ctx, attachmentID); err == nil {
 		// Cache the redirect itself — the attachment URL is immutable
 		c.Header("Cache-Control", "public, max-age=3600")
 		c.Redirect(http.StatusFound, presignedURL)
 		return
 	}
 
-	// Fall back to probing both NATS and S3 backends (handles transient S3 errors
-	// where the presigned URL fails but direct S3 fetch succeeds).
-	reader, info, err := s.core.GetAttachmentFromAnyBackend(ctx, "", attachmentID)
+	// Stream from the recorded backend (handles NATS-stored attachments,
+	// and S3 fallback for transient presigning failures).
+	reader, info, err := s.core.GetAttachmentFromAnyBackend(ctx, attachmentID)
 	if err != nil {
 		s.logger.Error("Failed to get attachment", "error", err, "attachment_id", attachmentID)
 		c.JSON(http.StatusNotFound, gin.H{"error": "Attachment not found"})
@@ -371,7 +371,7 @@ func (s *HTTPServer) serveTransformedServerAsset(c *gin.Context, key, signedPath
 // serveTransformedAttachment serves a dynamically transformed version of an attachment.
 // URL format: /assets/attachments/{attachmentId}/t/{signedPath}
 // where signedPath is {base64params}.{signature}
-// Probes both NATS and S3 backends for the attachment.
+// Reads the binary from the backend recorded on the Attachment metadata.
 func (s *HTTPServer) serveTransformedAttachment(c *gin.Context) {
 	attachmentID := c.Param("attachmentId")
 	signedPath := c.Param("signedPath")
@@ -385,7 +385,7 @@ func (s *HTTPServer) serveTransformedAttachment(c *gin.Context) {
 		CachePrefix: core.AttachmentSignResource,
 		AssetID:     attachmentID,
 		FetchAsset: func(ctx context.Context) (io.Reader, string, error) {
-			reader, info, err := s.core.GetAttachmentFromAnyBackend(ctx, "", attachmentID)
+			reader, info, err := s.core.GetAttachmentFromAnyBackend(ctx, attachmentID)
 			if err != nil {
 				return nil, "", err
 			}

--- a/cli/internal/pb/chatto/core/v1/models.pb.go
+++ b/cli/internal/pb/chatto/core/v1/models.pb.go
@@ -890,13 +890,10 @@ type Attachment struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Unique identifier for this attachment (NanoID)
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	// Legacy "server"/"DM" discriminator; wire-frozen because it's
-	// embedded in the S3 key path (`spaces/{spaceId}/attachments/{id}`)
-	// of existing attachments and consulted only by the S3-key fallback
-	// probe (`attachmentS3KeyCandidates`). New uploads leave this empty
-	// and store binaries under `attachments/{id}` instead. The URL
-	// namespace no longer carries this discriminator — all attachments
-	// are served from `/assets/attachments/{id}`. See ADR-030.
+	// Vestigial "server"/"DM" discriminator from the pre-ADR-030-Phase-4
+	// S3 key layout. Wire-frozen but no longer read by any code: the
+	// canonical S3 key for every attachment (new or legacy-migrated) now
+	// lives on the `storage` field below. New uploads leave this empty.
 	SpaceId string `protobuf:"bytes,2,opt,name=space_id,json=spaceId,proto3" json:"space_id,omitempty"`
 	// Room ID where this attachment was posted (for authorization)
 	RoomId string `protobuf:"bytes,3,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`

--- a/cli/internal/video/processor.go
+++ b/cli/internal/video/processor.go
@@ -335,9 +335,7 @@ func (s *Service) processVideo(ctx context.Context, req ProcessRequest) error {
 	}
 
 	// Delete the original attachment (save storage — variants replace it).
-	// Post-ADR-030-Phase-4 originals live at the kind-less S3 key
-	// (`attachments/{id}`); passing an empty spaceID picks that layout.
-	if err := s.core.DeleteAttachmentFromStorageByID(ctx, "", req.AttachmentID); err != nil {
+	if err := s.core.DeleteAttachment(ctx, req.AttachmentID); err != nil {
 		s.logger.Warn("Failed to delete original after transcoding", "error", err)
 		// Non-fatal — the variants are already uploaded
 	}
@@ -384,8 +382,7 @@ func (s *Service) failProcessing(ctx context.Context, req ProcessRequest, origin
 
 // downloadAttachment downloads an attachment from the asset store to a local file.
 func (s *Service) downloadAttachment(ctx context.Context, attachmentID, destPath string) error {
-	// New uploads use the kind-less S3 layout (empty spaceID).
-	reader, _, err := s.core.GetAttachmentFromAnyBackend(ctx, "", attachmentID)
+	reader, _, err := s.core.GetAttachmentFromAnyBackend(ctx, attachmentID)
 	if err != nil {
 		return err
 	}

--- a/proto/chatto/core/v1/models.proto
+++ b/proto/chatto/core/v1/models.proto
@@ -137,13 +137,10 @@ message Attachment {
   // Unique identifier for this attachment (NanoID)
   string id = 1;
 
-  // Legacy "server"/"DM" discriminator; wire-frozen because it's
-  // embedded in the S3 key path (`spaces/{spaceId}/attachments/{id}`)
-  // of existing attachments and consulted only by the S3-key fallback
-  // probe (`attachmentS3KeyCandidates`). New uploads leave this empty
-  // and store binaries under `attachments/{id}` instead. The URL
-  // namespace no longer carries this discriminator — all attachments
-  // are served from `/assets/attachments/{id}`. See ADR-030.
+  // Vestigial "server"/"DM" discriminator from the pre-ADR-030-Phase-4
+  // S3 key layout. Wire-frozen but no longer read by any code: the
+  // canonical S3 key for every attachment (new or legacy-migrated) now
+  // lives on the `storage` field below. New uploads leave this empty.
   string space_id = 2;
 
   // Room ID where this attachment was posted (for authorization)


### PR DESCRIPTION
## Summary

Every Attachment metadata record in `SERVER_BODIES` carries a populated `Storage` field pointing at the exact key — true for both post-ADR-030-Phase-4 uploads and for legacy records backfilled by the migration in #575. That migration has now run on every live instance, so the S3-key candidate probe (`attachmentS3KeyCandidates`) that we kept around for layout-mismatch safety is no longer load-bearing. We can just read \`record.Storage\` and fetch from the exact location.

## What changes

- **\`GetAttachmentFromAnyBackend(ctx, attachmentID)\`** — looks up the record, branches on \`Storage\` (NATS vs S3), reads from the exact key. Drops the \`spaceID\` parameter, the NATS-then-S3 probing, and the multi-layout S3 candidates.
- **\`TryPresignedAttachmentURL(ctx, attachmentID)\`** — reads \`record.Storage.S3.Key\` directly. Drops the \`spaceID\` parameter and the candidate stat-then-presign loop.
- **\`DeleteAttachment(ctx, attachmentID)\`** — resolves the record then dispatches to \`DeleteAttachmentFromStorage(record)\`. The unified delete helper now requires \`Storage\` to be populated and branches on its type.
- **\`DeleteAttachmentFromStorageByID\` gone** — duplicates what \`DeleteAttachment(id)\` now does.
- **\`attachmentS3Key\`, \`attachmentS3KeyCandidates\`, \`S3KeySpaceAttachment\` deleted.** No remaining callers.
- HTTP handler (\`serveAttachment\`, \`serveTransformedAttachment\`) and video processor updated to the new signatures.

## What doesn't change

- \`Attachment.SpaceId\` proto field stays — still wire-frozen, but the comment now reflects that no code reads it anymore. A future PR can drop the field outright.
- Legacy S3 objects at \`spaces/{server|DM}/attachments/{id}\` remain reachable — their canonical key now comes from the record's \`Storage.S3.Key\`, which was populated either at upload time (always) or by the migration backfill.

## Why this is safe

Both code paths that fetch the binary (HTTP handler, video processor) previously called functions that probed multiple S3 layouts. After this change they read the exact key from the record. The only way this regresses is if a record exists with no \`Storage\` field — which would require either (a) an upload path that never set \`Storage\` (the initial repo import already sets it on both NATS and S3 paths), or (b) a backfilled record from a \`MessageBody.Attachment\` proto that had no \`Storage\` (same: \`Storage\` has been populated on every embedded attachment since the initial import).

## Net change

-117 lines.

## Test plan

- [x] \`mise test-cli\` — full Go test suite passes (\`TestEngine_UpdateRolePosition\` flaked once on first run, passed 3/3 in isolation and on the second full run — unrelated to this change)
- [ ] Manual smoke: upload a new attachment, fetch it (200), verify it streams from S3 (presigned redirect)
- [ ] Manual smoke: load a thumbnail (transform URL), verify it renders
- [ ] Manual smoke on a deployment with pre-Phase-4 attachments: load a page with one of those attachments and verify it still loads (validates the \`Storage\` field on backfilled records)