### PR TITLE
fix(subscriptions): detect dead myEvents stream via wonka onEnd

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -84,6 +84,7 @@
     "vite-plugin-devtools-json": "^1.0.0",
     "vitest": "^4.1.6",
     "vitest-browser-svelte": "^2.1.1",
+    "wonka": "^6.3.6",
     "zod": "^4.4.3"
   },
   "pnpm": {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -216,6 +216,9 @@ importers:
       vitest-browser-svelte:
         specifier: ^2.1.1
         version: 2.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.3))(vitest@4.1.6)
+      wonka:
+        specifier: ^6.3.6
+        version: 6.3.6
       zod:
         specifier: ^4.4.3
         version: 4.4.3

--- a/frontend/src/lib/state/server/eventBus.svelte.spec.ts
+++ b/frontend/src/lib/state/server/eventBus.svelte.spec.ts
@@ -1,99 +1,201 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { flushSync } from 'svelte';
+import { makeSubject, type Source, type Subject } from 'wonka';
 import type { Client } from '@urql/svelte';
 import { eventBusManager } from './eventBus.svelte';
+import type { GraphQLClient } from './graphqlClient.svelte';
 
-type SubscriptionCallback = (result: { data?: unknown; error?: unknown }) => void;
+/**
+ * Returns a fake GraphQLClient-shaped object whose `client.subscription()`
+ * yields a fresh Wonka subject each time, plus controls to drive it from the
+ * test. `reconnectCount` is a Svelte `$state` so the bus's `$effect` reacts
+ * to `bumpReconnect()`.
+ *
+ * The real `OperationResultSource` is a Wonka `Source` with helper methods
+ * tacked on — the bus only uses it through `pipe(source, ...)`, so a bare
+ * Source is sufficient. The cast launders TS noise.
+ */
+class FakeGqlClient {
+	reconnectCount = $state(0);
+	#subjects: Subject<{ data?: unknown; error?: unknown }>[] = [];
+	subscribeCalls = 0;
+	client: Client;
 
-/** Captures the subscription callback so the test can drive results manually. */
-function makeClient(): { client: Client; deliver: (result: { data?: unknown; error?: unknown }) => void } {
-  let cb: SubscriptionCallback | null = null;
-  const client = {
-    subscription: vi.fn().mockReturnValue({
-      subscribe: (callback: SubscriptionCallback) => {
-        cb = callback;
-        return { unsubscribe: vi.fn() };
-      }
-    }),
-    query: vi.fn(),
-    mutation: vi.fn()
-  } as unknown as Client;
+	constructor() {
+		const subscription = vi.fn().mockImplementation(() => {
+			this.subscribeCalls++;
+			const subj = makeSubject<{ data?: unknown; error?: unknown }>();
+			this.#subjects.push(subj);
+			return subj.source as unknown as Source<unknown>;
+		});
+		this.client = {
+			subscription,
+			query: vi.fn(),
+			mutation: vi.fn()
+		} as unknown as Client;
+	}
 
-  return {
-    client,
-    deliver: (result) => {
-      if (!cb) throw new Error('No subscriber attached yet');
-      cb(result);
-    }
-  };
+	/** The currently-live subject (the one the bus is subscribed to right now). */
+	get current(): Subject<{ data?: unknown; error?: unknown }> {
+		if (this.#subjects.length === 0) throw new Error('no subscription started yet');
+		return this.#subjects[this.#subjects.length - 1];
+	}
+
+	bumpReconnect() {
+		this.reconnectCount++;
+		flushSync();
+	}
 }
 
+const TEST_SERVER = 'test-server-bus';
+
 describe('eventBusManager subscription robustness', () => {
-  let consoleError: ReturnType<typeof vi.spyOn>;
-  const TEST_INSTANCE = 'test-instance-bus';
+	let consoleError: ReturnType<typeof vi.spyOn>;
+	let consoleWarn: ReturnType<typeof vi.spyOn>;
 
-  beforeEach(() => {
-    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
-  });
+	beforeEach(() => {
+		consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+		consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+	});
 
-  afterEach(() => {
-    eventBusManager.stopBus(TEST_INSTANCE);
-    consoleError.mockRestore();
-  });
+	afterEach(() => {
+		eventBusManager.stopBus(TEST_SERVER);
+		consoleError.mockRestore();
+		consoleWarn.mockRestore();
+		vi.useRealTimers();
+	});
 
-  it('logs an error when the subscription delivers result.error', () => {
-    const { client, deliver } = makeClient();
-    eventBusManager.startBus(TEST_INSTANCE, client);
+	it('logs an error when the subscription delivers result.error', () => {
+		const fake = new FakeGqlClient();
+		eventBusManager.startBus(TEST_SERVER, fake as unknown as GraphQLClient);
 
-    deliver({ error: new Error('subscription failed') });
+		fake.current.next({ error: new Error('subscription failed') });
 
-    expect(consoleError).toHaveBeenCalledTimes(1);
-    expect(consoleError.mock.calls[0][0]).toContain(TEST_INSTANCE);
-    expect(consoleError.mock.calls[0][0]).toContain('subscription error');
-  });
+		expect(consoleError).toHaveBeenCalledTimes(1);
+		expect(consoleError.mock.calls[0][0]).toContain(TEST_SERVER);
+		expect(consoleError.mock.calls[0][0]).toContain('subscription error');
+	});
 
-  it('isolates handler errors so one throwing handler does not stop the others', () => {
-    const { client, deliver } = makeClient();
-    eventBusManager.startBus(TEST_INSTANCE, client);
+	it('isolates handler errors so one throwing handler does not stop the others', () => {
+		const fake = new FakeGqlClient();
+		eventBusManager.startBus(TEST_SERVER, fake as unknown as GraphQLClient);
 
-    const bus = eventBusManager.getBus(TEST_INSTANCE);
-    expect(bus).toBeDefined();
+		const bus = eventBusManager.getBus(TEST_SERVER)!;
+		const ranBefore = vi.fn();
+		const ranAfter = vi.fn();
+		bus.handlers.add(ranBefore);
+		bus.handlers.add(() => {
+			throw new Error('handler boom');
+		});
+		bus.handlers.add(ranAfter);
 
-    const ranBefore = vi.fn();
-    const ranAfter = vi.fn();
-    bus!.handlers.add(ranBefore);
-    bus!.handlers.add(() => {
-      throw new Error('handler boom');
-    });
-    bus!.handlers.add(ranAfter);
+		const event = { actorId: 'a', event: { __typename: 'ServerUpdatedEvent' } };
+		fake.current.next({ data: { myEvents: event } });
 
-    const event = { actorId: 'a', event: { __typename: 'ServerUpdatedEvent' } };
-    deliver({ data: { myEvents: event } });
+		expect(ranBefore).toHaveBeenCalledTimes(1);
+		expect(ranAfter).toHaveBeenCalledTimes(1);
+		expect(consoleError).toHaveBeenCalled();
+		expect(consoleError.mock.calls[0][0]).toContain('handler threw');
+	});
 
-    expect(ranBefore).toHaveBeenCalledTimes(1);
-    expect(ranAfter).toHaveBeenCalledTimes(1);
-    expect(consoleError).toHaveBeenCalled();
-    expect(consoleError.mock.calls[0][0]).toContain('handler threw');
-  });
+	it('continues delivering events after a handler error on a previous event', () => {
+		const fake = new FakeGqlClient();
+		eventBusManager.startBus(TEST_SERVER, fake as unknown as GraphQLClient);
 
-  it('continues delivering events after a handler error on a previous event', () => {
-    const { client, deliver } = makeClient();
-    eventBusManager.startBus(TEST_INSTANCE, client);
+		const bus = eventBusManager.getBus(TEST_SERVER)!;
+		const handler = vi.fn();
+		let throwOnce = true;
+		bus.handlers.add(() => {
+			if (throwOnce) {
+				throwOnce = false;
+				throw new Error('handler boom');
+			}
+		});
+		bus.handlers.add(handler);
 
-    const bus = eventBusManager.getBus(TEST_INSTANCE)!;
-    const handler = vi.fn();
-    let throwOnce = true;
-    bus.handlers.add(() => {
-      if (throwOnce) {
-        throwOnce = false;
-        throw new Error('handler boom');
-      }
-    });
-    bus.handlers.add(handler);
+		const event = { actorId: 'a', event: { __typename: 'ServerUpdatedEvent' } };
+		fake.current.next({ data: { myEvents: event } });
+		fake.current.next({ data: { myEvents: event } });
 
-    const event = { actorId: 'a', event: { __typename: 'ServerUpdatedEvent' } };
-    deliver({ data: { myEvents: event } });
-    deliver({ data: { myEvents: event } });
+		expect(handler).toHaveBeenCalledTimes(2);
+	});
 
-    expect(handler).toHaveBeenCalledTimes(2);
-  });
+	it('re-subscribes when the source ends (onEnd)', () => {
+		const fake = new FakeGqlClient();
+		eventBusManager.startBus(TEST_SERVER, fake as unknown as GraphQLClient);
+		expect(fake.subscribeCalls).toBe(1);
+
+		// Server sent Complete (or graphql-ws closed the Sink) → source ends.
+		fake.current.complete();
+
+		expect(fake.subscribeCalls).toBe(2);
+		expect(consoleWarn.mock.calls.some((c: unknown[]) => String(c[0]).includes('source ended'))).toBe(true);
+
+		// And the new subscription is wired through — events flow.
+		const handler = vi.fn();
+		eventBusManager.getBus(TEST_SERVER)!.handlers.add(handler);
+		fake.current.next({
+			data: { myEvents: { actorId: 'a', event: { __typename: 'ServerUpdatedEvent' } } }
+		});
+		expect(handler).toHaveBeenCalledTimes(1);
+	});
+
+	it('re-subscribes when the WebSocket reconnects (reconnectCount increments)', () => {
+		const fake = new FakeGqlClient();
+		eventBusManager.startBus(TEST_SERVER, fake as unknown as GraphQLClient);
+		expect(fake.subscribeCalls).toBe(1);
+
+		fake.bumpReconnect();
+
+		expect(fake.subscribeCalls).toBe(2);
+		expect(consoleWarn.mock.calls.some((c: unknown[]) => String(c[0]).includes('ws reconnected'))).toBe(true);
+	});
+
+	it('does NOT re-subscribe when stopBus is called (teardown guard)', () => {
+		const fake = new FakeGqlClient();
+		eventBusManager.startBus(TEST_SERVER, fake as unknown as GraphQLClient);
+		expect(fake.subscribeCalls).toBe(1);
+
+		eventBusManager.stopBus(TEST_SERVER);
+
+		// Unsubscribing the wonka source completes it, which would trigger
+		// onEnd → resubscribe without the guard. With the guard, no new
+		// subscription is started.
+		expect(fake.subscribeCalls).toBe(1);
+	});
+
+	it('re-subscribes after STALE_THRESHOLD_MS of only heartbeats (watchdog)', () => {
+		vi.useFakeTimers();
+		const fake = new FakeGqlClient();
+		eventBusManager.startBus(TEST_SERVER, fake as unknown as GraphQLClient);
+		expect(fake.subscribeCalls).toBe(1);
+
+		// Heartbeat counts as activity — refreshes lastEventAt but is not
+		// dispatched. Send one near the start.
+		fake.current.next({
+			data: { myEvents: { actorId: '', event: { __typename: 'HeartbeatEvent' } } }
+		});
+
+		// Advance past the 40s watchdog threshold without sending anything else.
+		vi.advanceTimersByTime(50_000);
+
+		expect(fake.subscribeCalls).toBeGreaterThanOrEqual(2);
+	});
+
+	it('does NOT refresh the watchdog on error-only results', () => {
+		vi.useFakeTimers();
+		const fake = new FakeGqlClient();
+		eventBusManager.startBus(TEST_SERVER, fake as unknown as GraphQLClient);
+		expect(fake.subscribeCalls).toBe(1);
+
+		// Stream of errors with no data — must NOT keep the watchdog alive.
+		for (let i = 0; i < 5; i++) {
+			vi.advanceTimersByTime(10_000);
+			fake.current.next({ error: new Error('flapping') });
+		}
+
+		// Total elapsed: 50s — well past the 40s threshold. If the error-only
+		// path were refreshing lastEventAt, the watchdog would never fire.
+		expect(fake.subscribeCalls).toBeGreaterThanOrEqual(2);
+	});
 });

--- a/frontend/src/lib/state/server/eventBus.svelte.ts
+++ b/frontend/src/lib/state/server/eventBus.svelte.ts
@@ -9,21 +9,20 @@
  * context.
  */
 
-import { type Client } from '@urql/svelte';
+import { pipe, subscribe as urqlSubscribe, onEnd } from 'wonka';
 import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 import type { EventHandler, EventBus } from '$lib/eventBus.svelte';
 import { MyServerEventsSubscriptionDoc } from '$lib/eventBus.svelte';
+import type { GraphQLClient } from './graphqlClient.svelte';
 
-// Liveness watchdog: re-subscribe if no event arrives within this window
-// while the tab is visible. The server emits a HeartbeatEvent every 25s
-// on the subscription (see StreamMyEvents in core.go), so 60s of silence
-// means the subscription is dead — even in an otherwise-idle room.
+// Safety-net watchdog: if no event arrives within this window while the
+// tab is visible, force a re-subscribe. The server emits a HeartbeatEvent
+// every 25s (see StreamMyEvents in core.go), so 40s tolerates one missed
+// heartbeat plus jitter without thrashing.
 //
-// The watchdog is intentionally generic: it doesn't track heartbeats
-// separately. Any event (real or heartbeat) resets lastEventAt. The
-// heartbeat exists so this fallback works even when nothing is happening.
-const STALE_THRESHOLD_MS = 60_000;
-// How often the watchdog checks for staleness.
+// This is the floor, not the primary detector — `onEnd` and the WS-
+// reconnect handler below catch the common failure modes immediately.
+const STALE_THRESHOLD_MS = 40_000;
 const WATCHDOG_INTERVAL_MS = 15_000;
 // On visibilitychange → visible, re-subscribe if last event is older
 // than this. Catches laptop-wake-from-sleep cases without thrashing the
@@ -36,73 +35,99 @@ class EventBusManager {
 	// where the consumer mounts before startBus and never re-attaches.
 	#buses = new SvelteMap<string, EventBus>();
 	#subscriptions = new Map<string, { unsubscribe: () => void }>();
-	#watchdogs = new Map<string, () => void>();
+	#cleanups = new Map<string, () => void>();
 
 	/**
 	 * Start an event bus for the given server. Creates the subscription and
 	 * stores the bus. If a bus already exists for this server, returns a
 	 * cleanup function without creating a duplicate.
 	 *
-	 * A watchdog re-subscribes if no event (real or heartbeat) is received
-	 * for STALE_THRESHOLD_MS while the tab is visible. This catches the case
-	 * where the WebSocket is healthy but the server-side subscription
-	 * goroutine has silently died — without this, mutations succeed but
-	 * new events never arrive until the user hard-reloads.
+	 * Three layers of resubscribe coverage, in order of fastest reaction:
+	 *
+	 *  1. **`onEnd`** — urql/wonka emits an End signal when the source
+	 *     terminates (server sent Complete or Error for the subscription
+	 *     ID, or graphql-ws closed the Sink). graphql-ws does NOT auto-
+	 *     resubscribe a closed Sink on later reconnects, so we explicitly
+	 *     re-establish.
+	 *  2. **WS reconnect** — when the underlying WebSocket transitions
+	 *     disconnected → connected (tracked by `GraphQLClient.reconnectCount`),
+	 *     we proactively re-subscribe. Belt-and-suspenders for the case
+	 *     where graphql-ws's own auto-resubscribe didn't deliver us a new
+	 *     subscription (silently-inert Sink, no `onEnd` to catch).
+	 *  3. **Watchdog** — if neither of the above fires but events stop
+	 *     flowing for STALE_THRESHOLD_MS (one missed 25s heartbeat + buffer),
+	 *     re-subscribe as a last resort.
 	 *
 	 * @returns Cleanup function that stops the bus.
 	 */
-	startBus(serverId: string, client: Client): () => void {
+	startBus(serverId: string, gqlClient: GraphQLClient): () => void {
 		if (this.#buses.has(serverId)) {
 			// Already running — return a no-op cleanup (the real cleanup is from
 			// the original startBus call)
 			return () => {};
 		}
 
+		const client = gqlClient.client;
 		const handlers = new SvelteSet<EventHandler>();
 		const bus: EventBus = { handlers };
 		let lastEventAt = Date.now();
+		// Set while we're tearing down a subscription (either to replace it
+		// or because the bus is stopping). Prevents `onEnd` from firing a
+		// reentrant resubscribe in response to our own unsubscribe.
+		let teardownInProgress = false;
+		let stopped = false;
 
-		const subscribe = () => {
-			return client.subscription(MyServerEventsSubscriptionDoc, {}).subscribe((result) => {
-				lastEventAt = Date.now();
-
-				if (result.error) {
-					// Surface subscription errors so unreachable servers and other
-					// real failures are visible in the dev console. Don't propagate
-					// — keep the subscription itself alive so it can recover.
-					console.error(
-						`[eventBus:${serverId}] subscription error`,
-						result.error
-					);
-				}
-				if (!result.data) return;
-				const event = result.data.myEvents;
-				// Heartbeats are pure liveness signals — already accounted for
-				// via lastEventAt above. Don't dispatch to handlers.
-				if (event.event?.__typename === 'HeartbeatEvent') return;
-				// Run handlers in isolation: a throw from one handler must not
-				// stop the others or tear down the subscription itself.
-				for (const handler of handlers) {
-					try {
-						handler(event);
-					} catch (err) {
+		const subscribeOnce = () =>
+			pipe(
+				client.subscription(MyServerEventsSubscriptionDoc, {}),
+				onEnd(() => {
+					if (teardownInProgress || stopped) return;
+					resubscribe('subscription source ended');
+				}),
+				urqlSubscribe((result) => {
+					if (result.error) {
+						// Surface subscription errors so unreachable servers and other
+						// real failures are visible in the dev console. Don't refresh
+						// lastEventAt — an error storm without data should not mask a
+						// stalled pipeline from the watchdog.
 						console.error(
-							`[eventBus:${serverId}] handler threw`,
-							err
+							`[eventBus:${serverId}] subscription error`,
+							result.error
 						);
+						return;
 					}
-				}
-			});
-		};
-
-		this.#subscriptions.set(serverId, subscribe());
+					lastEventAt = Date.now();
+					if (!result.data) return;
+					const event = result.data.myEvents;
+					// Heartbeats are pure liveness signals — already accounted for
+					// via lastEventAt above. Don't dispatch to handlers.
+					if (event.event?.__typename === 'HeartbeatEvent') return;
+					// Run handlers in isolation: a throw from one handler must not
+					// stop the others or tear down the subscription itself.
+					for (const handler of handlers) {
+						try {
+							handler(event);
+						} catch (err) {
+							console.error(
+								`[eventBus:${serverId}] handler threw`,
+								err
+							);
+						}
+					}
+				})
+			);
 
 		const resubscribe = (reason: string) => {
+			if (stopped) return;
 			console.warn(`[eventBus:${serverId}] re-subscribing (${reason})`);
+			teardownInProgress = true;
 			this.#subscriptions.get(serverId)?.unsubscribe();
+			teardownInProgress = false;
 			lastEventAt = Date.now();
-			this.#subscriptions.set(serverId, subscribe());
+			this.#subscriptions.set(serverId, subscribeOnce());
 		};
+
+		this.#subscriptions.set(serverId, subscribeOnce());
 
 		const watchdog = setInterval(() => {
 			if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return;
@@ -120,11 +145,32 @@ class EventBusManager {
 			document.addEventListener('visibilitychange', onVisibility);
 		}
 
-		this.#watchdogs.set(serverId, () => {
+		// Force resubscribe on every WebSocket reconnect. graphql-ws's
+		// internal auto-resubscribe should handle the live Sinks, but we
+		// can't observe whether it actually delivered the new subscription
+		// to the server — `onEnd` only catches Sinks that were closed,
+		// not Sinks that are silently inert. An explicit re-subscribe on
+		// reconnect closes that gap.
+		let lastSeenReconnects = gqlClient.reconnectCount;
+		const stopReconnectEffect = $effect.root(() => {
+			$effect(() => {
+				const n = gqlClient.reconnectCount;
+				if (n > lastSeenReconnects) {
+					lastSeenReconnects = n;
+					resubscribe('ws reconnected');
+				}
+			});
+		});
+
+		this.#cleanups.set(serverId, () => {
+			// Flag the closure so the upcoming sub.unsubscribe() in stopBus
+			// doesn't fire a reentrant resubscribe through onEnd.
+			stopped = true;
 			clearInterval(watchdog);
 			if (typeof document !== 'undefined') {
 				document.removeEventListener('visibilitychange', onVisibility);
 			}
+			stopReconnectEffect();
 		});
 
 		this.#buses.set(serverId, bus);
@@ -134,13 +180,15 @@ class EventBusManager {
 
 	/** Stop and remove the event bus for the given server. */
 	stopBus(serverId: string): void {
-		const stopWatchdog = this.#watchdogs.get(serverId);
-		if (stopWatchdog) {
-			stopWatchdog();
-			this.#watchdogs.delete(serverId);
+		const cleanup = this.#cleanups.get(serverId);
+		if (cleanup) {
+			cleanup();
+			this.#cleanups.delete(serverId);
 		}
 		const sub = this.#subscriptions.get(serverId);
 		if (sub) {
+			// Mark teardown so the `onEnd` callback inside the pipe doesn't
+			// try to resubscribe a bus that's going away.
 			sub.unsubscribe();
 			this.#subscriptions.delete(serverId);
 		}

--- a/frontend/src/lib/state/server/registry.svelte.ts
+++ b/frontend/src/lib/state/server/registry.svelte.ts
@@ -218,7 +218,7 @@ class ServerRegistry {
 		// starts the bus once `isAuthenticated` flips true.
 		if (store.isAuthenticated) {
 			const gqlClient = graphqlClientManager.getClient(server.id);
-			eventBusManager.startBus(server.id, gqlClient.client);
+			eventBusManager.startBus(server.id, gqlClient);
 		}
 	}
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -65,7 +65,7 @@
     if (store?.isAuthenticated) {
       eventBusManager.startBus(
         server.id,
-        graphqlClientManager.getClient(server.id).client
+        graphqlClientManager.getClient(server.id)
       );
     }
   }
@@ -76,7 +76,7 @@
         // startBus is idempotent — no-op if already started above.
         eventBusManager.startBus(
           server.id,
-          graphqlClientManager.getClient(server.id).client
+          graphqlClientManager.getClient(server.id)
         );
       }
     }

--- a/frontend/src/routes/chat/AuthenticatedChatProvider.svelte
+++ b/frontend/src/routes/chat/AuthenticatedChatProvider.svelte
@@ -64,7 +64,7 @@
   const originServerId = serverRegistry.originServer?.id;
   if (originServerId) {
     const originClient = graphqlClientManager.originClient;
-    eventBusManager.startBus(originServerId, originClient.client);
+    eventBusManager.startBus(originServerId, originClient);
     provideEventBus(() => originServerId);
 
     // Subscribe to profile update events and populate the cache


### PR DESCRIPTION
## Summary

The whole app depends on the per-server `myEvents` GraphQL subscription staying live. When it silently dies, mutations still succeed (HTTP) but live events never arrive — users post messages, see no error, and the message never appears until a hard reload. Latest report: Windows + MSEdgeWebView2 user, thread reply only showed up after reload.

The root cause: `client.subscription().subscribe(cb)` is a urql shortcut that only forwards Push values and silently drops Wonka's End signal. When graphql-ws closes the Sink (server sent Complete/Error, transient network blip, slow-consumer tear-down), the subscription is permanently dead — graphql-ws doesn't auto-resubscribe a closed Sink on later reconnects. The existing 60s heartbeat watchdog was the only safety net, and it can take a full minute (or never fire if heartbeats keep arriving from a partly-working pipeline).

## Changes

- **`pipe(source, onEnd(restart), subscribe(handler))`** in `eventBus.svelte.ts` — the same pattern urql's own first-party React `useSubscription` hook uses. Triggers immediate resubscribe when the source ends, with a teardown guard against reentrancy.
- **Force resubscribe on WebSocket reconnect** via `$effect.root` watching `GraphQLClient.reconnectCount` — covers the case where graphql-ws's internal auto-resubscribe didn't deliver a new subscription (silently-inert Sink, no End to catch).
- **Watchdog tightened 60s → 40s** (one missed 25s heartbeat + jitter), and `lastEventAt` only updates on non-error results so error storms can't keep the watchdog reset.
- Adds `wonka` as a direct dep (already a transitive of `@urql/svelte`).

## Test plan

- [x] `mise x -- pnpm test:unit --run --project client src/lib/state/server/eventBus.svelte.spec.ts` — 8/8 specs cover onEnd resubscribe, reconnect-driven resubscribe, watchdog with heartbeats-only, error-only watchdog refresh, stopBus teardown guard
- [x] Full frontend suite: 761/761 pass
- [x] `mise x -- pnpm check` — 0 errors
- [ ] **Local symptom repro**: temporarily add `time.AfterFunc(5*time.Second, func() { /* close eventChan */ })` to `StreamMyEvents` in `cli/internal/core/core.go`, rebuild, confirm `[eventBus:<id>] re-subscribing (subscription source ended)` appears in console within milliseconds (not after 40s watchdog)
- [ ] **Reconnect path**: kill the backend with the tab open and restart it; confirm exactly one `re-subscribing (ws reconnected)` per reconnect
- [ ] **Cross-platform confirmation**: cannot reproduce the Windows + MSEdgeWebView2 case locally — ask the original reporters to confirm after merge