### PR TITLE
ci: trim release platforms to linux + darwin/arm64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,10 +12,12 @@ builds:
     goos:
       - linux
       - darwin
-      - windows
     goarch:
       - amd64
       - arm64
+    ignore:
+      - goos: darwin
+        goarch: amd64
     ldflags:
       - -s -w
 
@@ -29,10 +31,6 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-    # use zip for windows archives
-    format_overrides:
-      - goos: windows
-        formats: [zip]
 
 changelog:
   # release-please now owns the changelog (CHANGELOG.md + the GitHub


### PR DESCRIPTION
## Summary

- Drop Windows builds (amd64 + arm64) and `darwin/amd64` from `.goreleaser.yml`.
- Release matrix goes from 6 targets to 3: `linux/amd64`, `linux/arm64`, `darwin/arm64`.
- Remove the now-unused Windows zip archive override.

Chatto is primarily a self-hosted server (Linux), and modern Macs are arm64 — these targets see little real-world use and slow tag-CI down. Docker images (`linux/amd64` + `linux/arm64`) are unaffected.

## Test plan

- [ ] Tag-triggered CI release job completes successfully on next release.