### PR TITLE
feat(rooms): seed announcements and general on fresh server boot

### DIFF
--- a/cli/cmd/bootstrap_apply.go
+++ b/cli/cmd/bootstrap_apply.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"context"
 	"errors"
-	"strings"
 
 	"github.com/charmbracelet/log"
 	configv1 "hmans.de/chatto/internal/pb/chatto/config/v1"
@@ -178,21 +177,18 @@ func applyBootstrapServer(ctx context.Context, logger *log.Logger, c *core.Chatt
 		}
 	}
 
-	// Seed default rooms (idempotent — CreateRoom fails with
-	// ErrRoomNameExists if the room name is already claimed). The bootstrap
-	// owner auto-joins each room afterwards so the dev/e2e admin lands in
-	// the same state a real operator would expect after creating their own
-	// room (and so e2e tests that count members of `general` see the admin).
-	wanted := buildBootstrapRoomList(inst.Rooms)
-	wantedNames := make(map[string]struct{}, len(wanted))
-	for _, r := range wanted {
-		if _, err := c.CreateRoom(ctx, ownerID, core.KindChannel, "", r.Name, r.Description); err != nil {
+	// Create operator-specified extra rooms (if any). The default rooms
+	// (`announcements`, `general`) are seeded by `SeedDefaultRooms` during
+	// startup — bootstrap no longer duplicates that. Owner auto-joins
+	// every existing channel room so the dev/e2e admin lands ready to use
+	// the server (and so e2e tests that count members of `general` see
+	// the admin).
+	for _, name := range inst.Rooms {
+		if _, err := c.CreateRoom(ctx, ownerID, core.KindChannel, "", name, ""); err != nil {
 			if !errors.Is(err, core.ErrRoomNameExists) {
-				logger.Warn("Failed to create [bootstrap] room", "room", r.Name, "error", err)
-				continue
+				logger.Warn("Failed to create [bootstrap] room", "room", name, "error", err)
 			}
 		}
-		wantedNames[strings.ToLower(strings.TrimSpace(r.Name))] = struct{}{}
 	}
 
 	existing, err := c.ListRooms(ctx, core.KindChannel)
@@ -200,9 +196,6 @@ func applyBootstrapServer(ctx context.Context, logger *log.Logger, c *core.Chatt
 		logger.Warn("Failed to list rooms for bootstrap owner auto-join", "error", err)
 	}
 	for _, room := range existing {
-		if _, want := wantedNames[strings.ToLower(strings.TrimSpace(room.Name))]; !want {
-			continue
-		}
 		if _, err := c.JoinRoom(ctx, ownerID, core.KindChannel, ownerID, room.Id); err != nil {
 			logger.Warn("Failed to auto-join bootstrap owner to room",
 				"room", room.Name, "error", err)
@@ -220,18 +213,4 @@ func applyBootstrapServer(ctx context.Context, logger *log.Logger, c *core.Chatt
 	return true
 }
 
-// buildBootstrapRoomList returns the rooms to create in a bootstrap space. If
-// the operator specified an explicit list, those are used as-is (with empty
-// descriptions). Otherwise we fall back to the same default rooms a fresh
-// user-created space gets.
-func buildBootstrapRoomList(specified []string) []core.DefaultGlobalRoom {
-	if len(specified) == 0 {
-		return core.DefaultGlobalRooms
-	}
-	out := make([]core.DefaultGlobalRoom, 0, len(specified))
-	for _, name := range specified {
-		out = append(out, core.DefaultGlobalRoom{Name: name})
-	}
-	return out
-}
 

--- a/cli/cmd/bootstrap_test.go
+++ b/cli/cmd/bootstrap_test.go
@@ -47,6 +47,12 @@ func setupCore(t *testing.T) *core.ChattoCore {
 		t.Fatalf("new core: %v", err)
 	}
 
+	// Production `run.go` calls SeedDefaultRooms after NewChattoCore; mirror
+	// that here so bootstrap tests see the same starting state.
+	if err := c.SeedDefaultRooms(ctx); err != nil {
+		t.Fatalf("seed default rooms: %v", err)
+	}
+
 	hubCtx, hubCancel := context.WithCancel(context.Background())
 	go c.PresenceHub.Run(hubCtx)
 	t.Cleanup(hubCancel)

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -105,6 +105,12 @@ func runServer(configPath string) {
 		log.Fatal("Failed to create Chatto core", "error", err)
 	}
 
+	// Seed `announcements` + `general` on first boot of a fresh server.
+	// Idempotent — no-op once any channel room exists.
+	if err := chattoCore.SeedDefaultRooms(ctx); err != nil {
+		log.Fatal("Failed to seed default rooms", "error", err)
+	}
+
 	// Set asset base URL for absolute asset URLs (required for cross-origin clients)
 	if cfg.Webserver.URL != "" {
 		if parsed, err := url.Parse(cfg.Webserver.URL); err == nil {

--- a/cli/internal/core/spaces.go
+++ b/cli/internal/core/spaces.go
@@ -14,18 +14,50 @@ import (
 )
 
 // DefaultGlobalRoom describes a channel that ships with a fresh
-// deployment. The bootstrap owner is auto-joined; other users join
-// explicitly via `joinRoom` (or the room directory's "Join all").
+// deployment. Users join explicitly via `joinRoom` (or the room
+// directory's "Join all").
 type DefaultGlobalRoom struct {
 	Name        string
 	Description string
 }
 
 // DefaultGlobalRooms is the list of channel rooms seeded on a fresh
-// deployment. Each lands in the seed "Lobby" group.
+// deployment. Each lands in the seed "Lobby" group. The "announcements"
+// room has `message.post` denied for `everyone` via
+// `SetupAnnouncementsRoomPermissions` (auto-applied by `CreateRoom`).
 var DefaultGlobalRooms = []DefaultGlobalRoom{
-	{Name: "announcements", Description: "Announcements and News"},
+	{Name: AnnouncementsRoomName, Description: "Announcements and news"},
 	{Name: "general", Description: "General discussion"},
+}
+
+// SeedDefaultRooms creates the default channel rooms
+// (`announcements`, `general`) on a fresh server. Idempotent — returns
+// nil without creating anything once any channel room exists, so an
+// operator can delete the defaults without seeing them reappear on the
+// next boot (as long as at least one channel room remains).
+//
+// Relies on `ensureChannelRoomsAreInAGroup` having run first so the
+// seed "Lobby" group is already in the layout; `CreateRoom` with an
+// empty groupID then auto-routes each new room into it.
+func (c *ChattoCore) SeedDefaultRooms(ctx context.Context) error {
+	existing, err := c.ListRooms(ctx, KindChannel)
+	if err != nil {
+		return fmt.Errorf("list channel rooms: %w", err)
+	}
+	if len(existing) > 0 {
+		return nil
+	}
+
+	for _, r := range DefaultGlobalRooms {
+		if _, err := c.CreateRoom(ctx, SystemActorID, KindChannel, "", r.Name, r.Description); err != nil {
+			if errors.Is(err, ErrRoomNameExists) {
+				continue
+			}
+			return fmt.Errorf("create default room %q: %w", r.Name, err)
+		}
+		c.logger.Info("Seeded default channel room", "name", r.Name)
+	}
+	return nil
 }
 
 // ============================================================================

--- a/cli/internal/core/spaces_test.go
+++ b/cli/internal/core/spaces_test.go
@@ -1,0 +1,122 @@
+package core
+
+import (
+	"testing"
+)
+
+func TestSeedDefaultRooms(t *testing.T) {
+	t.Run("creates announcements and general in the seed Lobby group", func(t *testing.T) {
+		c, _ := setupTestCore(t)
+		ctx := testContext(t)
+
+		if err := c.SeedDefaultRooms(ctx); err != nil {
+			t.Fatalf("SeedDefaultRooms failed: %v", err)
+		}
+
+		rooms, err := c.ListRooms(ctx, KindChannel)
+		if err != nil {
+			t.Fatalf("ListRooms failed: %v", err)
+		}
+		names := map[string]string{}
+		for _, r := range rooms {
+			names[r.Name] = r.GroupId
+		}
+		for _, want := range []string{"announcements", "general"} {
+			if _, ok := names[want]; !ok {
+				t.Errorf("expected room %q after seeding, got %v", want, names)
+			}
+		}
+
+		groups, err := c.ListRoomGroupsOrdered(ctx, KindChannel)
+		if err != nil {
+			t.Fatalf("ListRoomGroupsOrdered failed: %v", err)
+		}
+		if len(groups) != 1 || groups[0].Name != SeedDefaultRoomGroupName {
+			t.Fatalf("expected single seed Lobby group, got %+v", groups)
+		}
+		lobbyID := groups[0].Id
+		for name, gid := range names {
+			if gid != lobbyID {
+				t.Errorf("room %q is in group %q, expected Lobby %q", name, gid, lobbyID)
+			}
+		}
+	})
+
+	t.Run("announcements room denies message.post to everyone", func(t *testing.T) {
+		c, _ := setupTestCore(t)
+		ctx := testContext(t)
+
+		if err := c.SeedDefaultRooms(ctx); err != nil {
+			t.Fatalf("SeedDefaultRooms failed: %v", err)
+		}
+
+		rooms, _ := c.ListRooms(ctx, KindChannel)
+		var announcementsID string
+		for _, r := range rooms {
+			if r.Name == AnnouncementsRoomName {
+				announcementsID = r.Id
+				break
+			}
+		}
+		if announcementsID == "" {
+			t.Fatal("announcements room not found")
+		}
+
+		// Create a regular member and verify they cannot post root messages.
+		user, err := c.CreateUser(ctx, "system", "member", "Member", "password123")
+		if err != nil {
+			t.Fatalf("CreateUser failed: %v", err)
+		}
+		can, err := c.CanPostMessage(ctx, user.Id, KindChannel, announcementsID)
+		if err != nil {
+			t.Fatalf("CanPostMessage failed: %v", err)
+		}
+		if can {
+			t.Error("regular member should NOT be able to post root messages in announcements")
+		}
+
+		// And they CAN still post in threads.
+		canThread, err := c.CanPostInThread(ctx, user.Id, KindChannel, announcementsID)
+		if err != nil {
+			t.Fatalf("CanPostInThread failed: %v", err)
+		}
+		if !canThread {
+			t.Error("regular member SHOULD be able to post in threads in announcements")
+		}
+	})
+
+	t.Run("idempotent — no-op when channel rooms already exist", func(t *testing.T) {
+		c, _ := setupTestCore(t)
+		ctx := testContext(t)
+
+		if _, err := c.CreateRoom(ctx, "test-user", KindChannel, "", "existing", ""); err != nil {
+			t.Fatalf("CreateRoom failed: %v", err)
+		}
+
+		if err := c.SeedDefaultRooms(ctx); err != nil {
+			t.Fatalf("SeedDefaultRooms failed: %v", err)
+		}
+
+		rooms, _ := c.ListRooms(ctx, KindChannel)
+		if len(rooms) != 1 {
+			t.Errorf("expected SeedDefaultRooms to be a no-op when rooms exist; got %d rooms", len(rooms))
+		}
+	})
+
+	t.Run("safe to call twice", func(t *testing.T) {
+		c, _ := setupTestCore(t)
+		ctx := testContext(t)
+
+		if err := c.SeedDefaultRooms(ctx); err != nil {
+			t.Fatalf("first SeedDefaultRooms failed: %v", err)
+		}
+		if err := c.SeedDefaultRooms(ctx); err != nil {
+			t.Fatalf("second SeedDefaultRooms failed: %v", err)
+		}
+
+		rooms, _ := c.ListRooms(ctx, KindChannel)
+		if len(rooms) != len(DefaultGlobalRooms) {
+			t.Errorf("expected %d rooms after double-seed, got %d", len(DefaultGlobalRooms), len(rooms))
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `core.SeedDefaultRooms`, called from `run.go` after `NewChattoCore`, so fresh production servers boot with `announcements` + `general` channels inside the seed Lobby group (idempotent — operator deletions stick across restarts).
- `announcements` ships with `message.post` denied for `everyone`; thread replies remain allowed via the existing `SetupAnnouncementsRoomPermissions` hook that `CreateRoom` auto-applies.
- Strips the duplicate seeding from `bootstrap_apply.go`; bootstrap now only creates operator-listed extra rooms and auto-joins the owner to every existing channel.

## Context

ADR-030 retired the `CreateSpace` entry point that used to seed default rooms; only the bootstrap path (`//go:build bootstrap`) carried the logic forward, so non-bootstrap binaries shipped a Lobby group with no channels in it.

## Test plan

- [x] \`mise x -- go test ./internal/core/ ./internal/graph/... ./internal/http_server/\` (clean)
- [x] New \`TestSeedDefaultRooms\` covers Lobby placement, announcements permission boundary (root denied, thread allowed), and idempotency.
- [ ] Manual: fresh production-tagged boot shows Lobby with both default channels and announcements-permission applied.