### PR TITLE
fix(assets): probe storage backends when Attachment.Storage is missing

### DIFF
--- a/cli/internal/core/attachments.go
+++ b/cli/internal/core/attachments.go
@@ -215,11 +215,16 @@ func (c *ChattoCore) GetS3Attachment(ctx context.Context, s3Key string) (io.Read
 // metadata. The caller is responsible for closing the reader if it
 // implements io.Closer.
 //
-// Returns an error if `attachment.Storage` is unset or points at an
-// unknown backend kind.
+// When `Storage` is nil, falls back to probing known backend layouts
+// for the binary by attachment ID — this handles pre-locator video
+// variants and thumbnails whose backfilled Attachment protos came from
+// minimal standalone records that lacked a `Storage` field.
 func (c *ChattoCore) GetAttachmentReader(ctx context.Context, attachment *corev1.Attachment) (io.Reader, *AttachmentInfo, error) {
-	if attachment == nil || attachment.Storage == nil {
-		return nil, nil, fmt.Errorf("attachment has no storage info")
+	if attachment == nil {
+		return nil, nil, fmt.Errorf("attachment is nil")
+	}
+	if attachment.Storage == nil {
+		return c.probeAttachmentReaderByID(ctx, attachment.Id)
 	}
 	switch asset := attachment.Storage.Asset.(type) {
 	case *corev1.Asset_Nats:
@@ -240,6 +245,50 @@ func (c *ChattoCore) GetAttachmentReader(ctx context.Context, attachment *corev1
 		return c.GetS3Attachment(ctx, asset.S3.Key)
 	default:
 		return nil, nil, fmt.Errorf("attachment %s has unknown storage backend", attachment.Id)
+	}
+}
+
+// probeAttachmentReaderByID is the fallback when an Attachment's
+// `Storage` field isn't populated. Tries NATS ObjectStore first (where
+// pre-S3 uploads landed), then S3 across the post-Phase-4 kind-less
+// key and the pre-Phase-4 server/DM-prefixed legacy keys. Whichever
+// backend has the binary wins.
+//
+// This is load-bearing for pre-locator video variants and thumbnails:
+// `BackfillAttachmentRecords` (long-since deleted) wrote minimal
+// `Attachment{Id, RoomId}` records for those, and
+// `BackfillAttachmentLocatorData` copied those minimal records into
+// `VideoProcessingState.{ThumbnailAttachment, Variants[i].Attachment}`.
+// They have no Storage, so we probe.
+func (c *ChattoCore) probeAttachmentReaderByID(ctx context.Context, attachmentID string) (io.Reader, *AttachmentInfo, error) {
+	reader, natsInfo, err := c.GetAttachment(ctx, attachmentID)
+	if err == nil {
+		return reader, &AttachmentInfo{
+			Size:        int64(natsInfo.Size),
+			ContentType: natsInfo.Headers.Get("Content-Type"),
+			Filename:    natsInfo.Headers.Get("Filename"),
+			RoomID:      natsInfo.Headers.Get("Room-Id"),
+		}, nil
+	}
+	if c.s3Client != nil {
+		for _, s3Key := range legacyAttachmentS3KeyCandidates(attachmentID) {
+			s3Reader, s3Info, s3Err := c.GetS3Attachment(ctx, s3Key)
+			if s3Err == nil {
+				return s3Reader, s3Info, nil
+			}
+		}
+	}
+	return nil, nil, fmt.Errorf("attachment not found: %s", attachmentID)
+}
+
+// legacyAttachmentS3KeyCandidates returns the S3 keys to try when we
+// don't know an attachment's storage layout: post-Phase-4 first, then
+// the wire-frozen pre-Phase-4 server/DM prefixes.
+func legacyAttachmentS3KeyCandidates(attachmentID string) []string {
+	return []string{
+		S3KeyAttachment(attachmentID),
+		"spaces/server/attachments/" + attachmentID,
+		"spaces/DM/attachments/" + attachmentID,
 	}
 }
 
@@ -357,17 +406,23 @@ func (c *ChattoCore) DeleteAttachmentFromStorage(ctx context.Context, attachment
 }
 
 // TryPresignedAttachmentURL generates a presigned S3 URL for an
-// attachment. Returns an error if S3 is not configured or the attachment
-// is not stored in S3 (e.g. it's a NATS-stored legacy attachment, in
-// which case the caller should fall back to GetAttachmentReader).
+// attachment. Returns an error if S3 isn't configured, the attachment
+// isn't stored in S3 (e.g. NATS), or no S3 key can be found (in any of
+// which cases the caller should fall back to GetAttachmentReader).
+//
+// When `Storage` is nil, falls back to stat-probing known S3 key
+// layouts. See `GetAttachmentReader` for why this exists.
 //
 // Authorization is the caller's responsibility.
 func (c *ChattoCore) TryPresignedAttachmentURL(ctx context.Context, attachment *corev1.Attachment) (string, error) {
 	if c.s3Client == nil {
 		return "", fmt.Errorf("S3 not configured")
 	}
-	if attachment == nil || attachment.Storage == nil {
-		return "", fmt.Errorf("attachment has no storage info")
+	if attachment == nil {
+		return "", fmt.Errorf("attachment is nil")
+	}
+	if attachment.Storage == nil {
+		return c.probePresignedAttachmentURL(ctx, attachment.Id)
 	}
 	s3, ok := attachment.Storage.Asset.(*corev1.Asset_S3)
 	if !ok {
@@ -378,6 +433,23 @@ func (c *ChattoCore) TryPresignedAttachmentURL(ctx context.Context, attachment *
 		return "", fmt.Errorf("failed to generate presigned URL: %w", err)
 	}
 	return presignedURL.String(), nil
+}
+
+// probePresignedAttachmentURL is the fallback when an Attachment's
+// `Storage` field isn't populated and the binary might live in S3.
+// Stats the known key layouts; presigns the first hit.
+func (c *ChattoCore) probePresignedAttachmentURL(ctx context.Context, attachmentID string) (string, error) {
+	for _, s3Key := range legacyAttachmentS3KeyCandidates(attachmentID) {
+		if _, err := c.s3Client.StatObject(ctx, s3Key); err != nil {
+			continue
+		}
+		presignedURL, err := c.s3Client.PresignedGetURL(ctx, s3Key, time.Hour)
+		if err != nil {
+			return "", fmt.Errorf("failed to generate presigned URL: %w", err)
+		}
+		return presignedURL.String(), nil
+	}
+	return "", fmt.Errorf("attachment %s not found in S3", attachmentID)
 }
 
 // AttachmentSignResource is the first resource component fed to the

--- a/cli/internal/core/attachments_test.go
+++ b/cli/internal/core/attachments_test.go
@@ -341,6 +341,75 @@ func bodyLocator(t *testing.T) signedurl.AttachmentLocator {
 	}
 }
 
+// TestGetAttachmentReader_ProbesWhenStorageMissing covers the
+// fallback path GetAttachmentReader takes when handed an Attachment
+// whose `Storage` field is nil — the situation produced by
+// BackfillAttachmentLocatorData copying minimal pre-locator standalone
+// records into VideoProcessingState entries.
+func TestGetAttachmentReader_ProbesWhenStorageMissing(t *testing.T) {
+	t.Run("falls back to NATS by attachment ID", func(t *testing.T) {
+		core, _ := setupTestCore(t)
+		ctx := testContext(t)
+
+		room, _ := core.CreateRoom(ctx, "test-user", KindChannel, "", "r", "r")
+		attachment, err := core.UploadAttachment(ctx, room.Id, "x.txt", "text/plain", bytes.NewReader([]byte("nats-binary")))
+		if err != nil {
+			t.Fatalf("UploadAttachment: %v", err)
+		}
+
+		// Pre-locator migration would have produced this shape:
+		// Id + RoomId but no Storage. Verify GetAttachmentReader
+		// can still find the binary by probing.
+		minimal := &corev1.Attachment{Id: attachment.Id, RoomId: room.Id}
+		reader, info, err := core.GetAttachmentReader(ctx, minimal)
+		if err != nil {
+			t.Fatalf("GetAttachmentReader with Storage-less attachment: %v", err)
+		}
+		data, _ := io.ReadAll(reader)
+		if string(data) != "nats-binary" {
+			t.Errorf("expected 'nats-binary', got %q", data)
+		}
+		if info.ContentType != "text/plain" {
+			t.Errorf("expected content type 'text/plain', got %q", info.ContentType)
+		}
+	})
+
+	t.Run("falls back to S3 across known layouts", func(t *testing.T) {
+		core, _, _ := setupTestCoreWithS3(t)
+		ctx := testContext(t)
+
+		room, _ := core.CreateRoom(ctx, "test-user", KindChannel, "", "r", "r")
+		attachment, err := core.UploadAttachment(ctx, room.Id, "y.txt", "text/plain", bytes.NewReader([]byte("s3-binary")))
+		if err != nil {
+			t.Fatalf("UploadAttachment: %v", err)
+		}
+
+		// Same shape as above but the binary now lives in S3.
+		minimal := &corev1.Attachment{Id: attachment.Id, RoomId: room.Id}
+		reader, _, err := core.GetAttachmentReader(ctx, minimal)
+		if err != nil {
+			t.Fatalf("GetAttachmentReader with Storage-less S3 attachment: %v", err)
+		}
+		if closer, ok := reader.(io.Closer); ok {
+			defer closer.Close()
+		}
+		data, _ := io.ReadAll(reader)
+		if string(data) != "s3-binary" {
+			t.Errorf("expected 's3-binary', got %q", data)
+		}
+	})
+
+	t.Run("returns error when binary is nowhere", func(t *testing.T) {
+		core, _ := setupTestCore(t)
+		ctx := testContext(t)
+
+		minimal := &corev1.Attachment{Id: "Aghost", RoomId: "Rghost"}
+		if _, _, err := core.GetAttachmentReader(ctx, minimal); err == nil {
+			t.Error("expected error for missing binary, got nil")
+		}
+	})
+}
+
 func TestChattoCore_GetAttachmentURL(t *testing.T) {
 	core, _ := setupTestCore(t)
 


### PR DESCRIPTION
## The bug

Pre-existing video variants and thumbnails 404 on the deployed locator URL handler. Images and freshly-uploaded videos work fine.

## Root cause

A three-step chain across three prior PRs:

1. The original \`BackfillAttachmentRecords\` migration (long since deleted) wrote **minimal** standalone records for video variants and thumbnails — \`Attachment{Id, RoomId}\` with no \`Storage\` field. The old HTTP handler only needed \`RoomId\` from the record for authz; actual binary fetch went through an S3-key candidate probe, so \`Storage\` wasn't load-bearing.

2. \`BackfillAttachmentLocatorData\` (in #581) copied those minimal records verbatim into \`VideoProcessingState.{ThumbnailAttachment, Variants[i].Attachment}\`. They still have no \`Storage\`.

3. The new \`GetAttachmentReader\` / \`TryPresignedAttachmentURL\` (also #581) require \`Storage\` and error out when it's nil. The HTTP handler 404s.

New videos posted after #581 populate \`Storage\` directly in the embedded VPS protos at transcode time (the processor writes \`v.Attachment = variant\` with the full proto), so they're unaffected. Only the pre-existing entries that came through the migration backfill are broken.

## Fix

Restore backend probing as a **targeted fallback** in the Storage-nil case:

- \`GetAttachmentReader(*Attachment)\` — if \`Storage == nil\`, probe NATS by attachment ID, then S3 across the known key layouts (\`attachments/{id}\`, \`spaces/server/attachments/{id}\`, \`spaces/DM/attachments/{id}\`). First hit wins.
- \`TryPresignedAttachmentURL(*Attachment)\` — same probe restricted to S3 layouts.

The fallback path is only entered when \`Storage\` is missing, so the common case (post-#581 attachments) is unchanged. Both probe helpers are private and inlined into the relevant API.

## Notes

- A more thorough fix would be a new migration that probes storage and writes proper \`Storage\` fields into the embedded VPS protos, then we could drop the runtime fallback. That's a follow-up; this PR unblocks production now.
- The S3 candidate list (\`attachments/{id}\`, \`spaces/server/...\`, \`spaces/DM/...\`) is the same list the old \`attachmentS3KeyCandidates\` produced before #581 deleted it.

## Test plan

- [x] \`mise test-cli\` — full Go suite passes (one unrelated flake on \`TestUpload_ServerLogo_DeleteLogo\`, passes 3/3 in isolation)
- [x] New \`TestGetAttachmentReader_ProbesWhenStorageMissing\` covers the NATS-fallback, S3-fallback, and not-found paths
- [ ] Manual smoke on dev instance: load a room with pre-existing videos, confirm they play
- [ ] Manual smoke: post a new video, confirm it still works (the common path)