### PR TITLE
feat(docker): ship nats CLI in production image, pre-wired to chatto's NATS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,3 +18,6 @@
 !cli/
 cli/data/
 cli/bin/
+
+# Entrypoint for the release image (Dockerfile.goreleaser).
+!docker-entrypoint.sh

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,6 +41,8 @@ dockers:
   - image_templates:
       - "ghcr.io/chattocorp/chatto:{{ .Version }}-amd64"
     dockerfile: Dockerfile.goreleaser
+    extra_files:
+      - docker-entrypoint.sh
     build_flag_templates:
       - "--pull"
       - "--platform=linux/amd64"
@@ -53,6 +55,8 @@ dockers:
   - image_templates:
       - "ghcr.io/chattocorp/chatto:{{ .Version }}-arm64"
     dockerfile: Dockerfile.goreleaser
+    extra_files:
+      - docker-entrypoint.sh
     build_flag_templates:
       - "--pull"
       - "--platform=linux/arm64"

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,10 +1,34 @@
 FROM alpine:latest
+
+ARG NATS_CLI_VERSION=0.4.0
+ARG TARGETARCH
+
 RUN apk add --no-cache ca-certificates tzdata ffmpeg \
+ && apk add --no-cache --virtual .build-deps curl unzip \
+ && case "$TARGETARCH" in \
+      amd64) arch=amd64 ;; \
+      arm64) arch=arm64 ;; \
+      *) echo "unsupported arch: $TARGETARCH" >&2; exit 1 ;; \
+    esac \
+ && curl -fsSL -o /tmp/nats.zip \
+      "https://github.com/nats-io/natscli/releases/download/v${NATS_CLI_VERSION}/nats-${NATS_CLI_VERSION}-linux-${arch}.zip" \
+ && unzip -j /tmp/nats.zip "*/nats" -d /usr/local/bin/ \
+ && chmod +x /usr/local/bin/nats \
+ && rm /tmp/nats.zip \
+ && apk del .build-deps \
  && addgroup -g 10001 chatto \
  && adduser -D -u 10001 -G chatto -h /home/chatto -s /sbin/nologin chatto
+
 COPY chatto /usr/local/bin/chatto
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Tell the nats CLI which context to use by default. The file itself is
+# written at container start by docker-entrypoint.sh.
+ENV NATS_CONTEXT=chatto
+
 WORKDIR /home/chatto
 USER chatto:chatto
 EXPOSE 4000
-ENTRYPOINT ["chatto"]
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["start"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Materialize a nats CLI context from Chatto's env vars so that
+# `docker exec <container> nats ...` connects to the same NATS that chatto
+# itself is using. Runs once per container start.
+set -eu
+
+if [ -n "${CHATTO_NATS_CLIENT_URL:-}" ]; then
+    ctx_dir="${HOME:-/home/chatto}/.config/nats/context"
+    mkdir -p "$ctx_dir"
+
+    # jq isn't in the image; build the JSON by hand. Values come from
+    # operator-controlled env vars and Chatto's own config validation
+    # rejects malformed URLs, so plain interpolation is acceptable here.
+    {
+        printf '{\n'
+        printf '  "description": "chatto runtime",\n'
+        printf '  "url": "%s"' "$CHATTO_NATS_CLIENT_URL"
+        if [ -n "${CHATTO_NATS_CLIENT_CREDENTIALS_FILE:-}" ]; then
+            printf ',\n  "creds": "%s"' "$CHATTO_NATS_CLIENT_CREDENTIALS_FILE"
+        fi
+        printf '\n}\n'
+    } > "$ctx_dir/chatto.json"
+fi
+
+exec chatto "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,8 +5,8 @@
 set -eu
 
 if [ -n "${CHATTO_NATS_CLIENT_URL:-}" ]; then
-    ctx_dir="${HOME:-/home/chatto}/.config/nats/context"
-    mkdir -p "$ctx_dir"
+    nats_dir="${HOME:-/home/chatto}/.config/nats"
+    mkdir -p "$nats_dir/context"
 
     # jq isn't in the image; build the JSON by hand. Values come from
     # operator-controlled env vars and Chatto's own config validation
@@ -19,7 +19,12 @@ if [ -n "${CHATTO_NATS_CLIENT_URL:-}" ]; then
             printf ',\n  "creds": "%s"' "$CHATTO_NATS_CLIENT_CREDENTIALS_FILE"
         fi
         printf '\n}\n'
-    } > "$ctx_dir/chatto.json"
+    } > "$nats_dir/context/chatto.json"
+
+    # Mark chatto as the default context so `nats <cmd>` works without
+    # also needing $NATS_CONTEXT (e.g. `nats context info`, which is a
+    # context-management command and ignores the env var).
+    printf 'chatto\n' > "$nats_dir/context.txt"
 fi
 
 exec chatto "$@"


### PR DESCRIPTION
## Summary

Operators debugging a running Chatto deployment previously had to sidecar a separate image and re-paste connection settings. This change ships the `nats` CLI (v0.4.0, arch-aware) in `Dockerfile.goreleaser` and adds a `docker-entrypoint.sh` that materializes a `nats` context JSON at startup from `CHATTO_NATS_CLIENT_URL` / `CHATTO_NATS_CLIENT_CREDENTIALS_FILE`, then `exec`s `chatto`. With `ENV NATS_CONTEXT=chatto` baked into the image, `docker exec <container> nats stream ls` Just Works against the same NATS the chatto binary is using — no shim around the `nats` binary, no Go-code changes, no extra deployment env vars.

## Test plan

- [ ] `goreleaser release --snapshot --clean --skip=publish` builds locally for the host arch
- [ ] `docker exec <ct> cat /home/chatto/.config/nats/context/chatto.json` shows the expected url/creds
- [ ] `docker exec <ct> nats context info` reports current context `chatto`
- [ ] `docker exec <ct> nats server check connection` succeeds against embedded NATS
- [ ] `docker exec -e NATS_URL=nats://other.invalid:4222 <ct> nats server check connection` proves the context is a default, not a lockout
- [ ] `docker buildx build --platform linux/arm64 -f Dockerfile.goreleaser --build-arg TARGETARCH=arm64 .` succeeds (cross-arch sanity)