### PR TITLE
ci(release-please): lint PR title+body against the conventional-commits parser

### DIFF
--- a/.github/scripts/lint-pr-body.mjs
+++ b/.github/scripts/lint-pr-body.mjs
@@ -1,0 +1,61 @@
+// Validates that the commit message GitHub will produce when this PR
+// is squash-merged can be parsed by release-please's conventional-commits
+// parser.
+//
+// Why this exists: release-please uses @conventional-commits/parser to
+// drive version bumps and changelog entries. If the parser fails on a
+// commit, that commit is SILENTLY dropped from both — no warning, no
+// failed workflow, no missing version bump message. The release simply
+// never happens (or skips the real feat/fix that should have triggered
+// it). PR #595 hit this exact pattern: a `core.SpaceIDForKind(core.KindOfRoom(room))`
+// inside a backtick code span tripped the parser, the alpha PR never got
+// created, and we only noticed days later.
+//
+// See .claude/rules/commits.md for the rule that documents the failure
+// mode this check guards against.
+
+import { parser } from "@conventional-commits/parser";
+
+const title = process.env.PR_TITLE ?? "";
+const body = process.env.PR_BODY ?? "";
+const num = process.env.PR_NUMBER ?? "";
+
+if (!title) {
+  console.error("::error::PR_TITLE is empty");
+  process.exit(2);
+}
+
+// GitHub's squash-merge default builds the commit body as:
+//   "<PR title> (#<number>)\n\n<PR body>"
+// We construct the same string and feed it to the parser, so this check
+// reflects what release-please will actually see after merge.
+const message = `${title} (#${num})\n\n${body}`;
+
+try {
+  parser(message);
+  console.log("OK — release-please will be able to parse this commit.");
+} catch (err) {
+  const annotation = [
+    "release-please's conventional-commits parser cannot parse the",
+    "commit body that GitHub will produce when this PR is squash-merged.",
+    "",
+    "Most common cause: nested parens inside `backtick code spans` in the",
+    "PR description — e.g. `func(arg)` or `foo(bar.baz)`. The parser is",
+    "markdown-unaware and treats every '(' as the opening of a scope token.",
+    "",
+    "Workaround: rephrase the offending span. Use a fenced code block,",
+    "quoted prose, or drop the parens (e.g. 'the SpaceIDForKind helper'",
+    "instead of `SpaceIDForKind(room)`).",
+    "",
+    "See .claude/rules/commits.md for the full rule.",
+    "",
+    `Parser error: ${err.message}`,
+  ].join("%0A");
+
+  // GitHub Actions workflow command — turns this into a red annotation
+  // on the PR's Checks tab so the failure is visible without digging
+  // through the job log. Multi-line annotations require URL-encoded
+  // newlines (%0A), not literal '\n'.
+  console.error(`::error title=PR body would break release-please::${annotation}`);
+  process.exit(1);
+}

--- a/.github/workflows/lint-pr-body.yml
+++ b/.github/workflows/lint-pr-body.yml
@@ -1,0 +1,54 @@
+name: lint-pr-body
+
+# Runs release-please's conventional-commits parser against the commit body
+# GitHub will produce when this PR is squash-merged ("<title> (#<num>)\n\n<body>").
+# Fails the check if the parser can't read it.
+#
+# Without this check, release-please silently drops un-parseable commits
+# from version inference AND the changelog — no warning, no error, the
+# alpha just never cuts. Real example: PR #595 (see follow-up commit).
+#
+# See .claude/rules/commits.md and .github/scripts/lint-pr-body.mjs.
+
+on:
+  pull_request:
+    # Run on every change that affects the title or body, plus the synchronize
+    # event so the check moves out of "expected" once the PR is opened.
+    types: [opened, edited, synchronize, reopened]
+    branches:
+      # Branches release-please publishes from. PRs targeting anything else
+      # don't drive releases, so the check is unnecessary noise there.
+      - main
+      - next
+      - 'release-*'
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  parse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install parser
+        # @conventional-commits/parser is the same library release-please
+        # uses (verified against the v17 action). Pinning to a range that
+        # tracks release-please's own pin avoids drift.
+        run: npm install --no-save --no-package-lock @conventional-commits/[email protected]
+
+      - name: Validate PR title + body parse cleanly
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node .github/scripts/lint-pr-body.mjs


### PR DESCRIPTION
## Summary

PR #595 silently broke release-please on `next`: nested parens inside a backtick code span (`` `core.SpaceIDForKind(core.KindOfRoom(room))` ``) in the PR description tripped `@conventional-commits/parser`'s state machine, the whole commit was dropped from version inference + the changelog, and the alpha PR never cut. We only noticed days later.

This adds a CI check that runs the same parser release-please uses against the commit body GitHub will produce when this PR is squash-merged (`<title> (#<num>)\n\n<body>`). If it can't parse, the check fails before merge instead of silently after.

- New: `.github/scripts/lint-pr-body.mjs` — small Node script that wraps the parser and emits a GitHub-Actions-formatted annotation pointing at `.claude/rules/commits.md`.
- New: `.github/workflows/lint-pr-body.yml` — `pull_request` workflow that runs on PRs targeting `main`, `next`, or `release-*` (the branches release-please publishes from). Re-runs on title/body edits via `pull_request: types: [opened, edited, synchronize, reopened]`.
- Dependency is `@conventional-commits/parser` — the same library release-please v17 uses internally; pinned to `~0.4.1`.

## Test plan

- [x] Reproduced the original PR #595 failure mode locally — script exits 1 with the parser's `unexpected token '(' at line:col` error and a workflow annotation.
- [x] Verified a clean PR body (this one) parses to exit 0.
- [ ] Once merged, the next time someone writes a PR body that breaks release-please, the failure becomes a red CI check instead of a silent missed release.

## Forward-port

This lands on `next`. After merge, forward-port to `main` so PRs targeting `main` get the same protection.