### PR TITLE
fix(ci): start the prerelease line on 0.1.0-alpha.0

### DIFF
--- a/.release-please-config-prerelease.json
+++ b/.release-please-config-prerelease.json
@@ -2,7 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
   "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true,
   "include-component-in-tag": false,
   "include-v-in-tag": true,
   "packages": {
@@ -11,6 +10,7 @@
       "changelog-path": "CHANGELOG.md",
       "prerelease": true,
       "prerelease-type": "alpha",
+      "release-as": "0.1.0-alpha.0",
       "extra-files": [
         {
           "type": "generic",


### PR DESCRIPTION
## Summary

The prerelease config has two issues that cause it to produce `0.0.190` (no prerelease suffix) instead of the intended `0.1.0-alpha.N` documented in `.github/workflows/release-please.yml`. Both fixed here.

### 1. `bump-patch-for-minor-pre-major: true` kept us on the 0.0.x track

That flag was copy-pasted from the stable config where it correctly pins `main` to patch bumps on `0.0.x`. On the prerelease config it had the same effect for the wrong reason — kept `next` patching `0.0.x` instead of stepping up to `0.1.0`.

Removed. With only `bump-minor-pre-major: true` remaining, a `feat:` commit will bump the minor digit (`0.0.189 -> 0.1.0`).

### 2. `prerelease: true` alone doesn't add a suffix from a clean version

release-please's prerelease suffix handling only activates when the *current* manifest version already carries a prerelease suffix. Bumping from a clean `0.0.189` doesn't get wrapped — explains why the alpha suffix didn't appear in PR #608.

To bootstrap the line, this PR adds `release-as: "0.1.0-alpha.0"` as a one-time explicit override. After that release exists in the manifest, subsequent prereleases inherit the alpha suffix via inference and `release-as` can be removed.

### Expected effect

After this PR merges to `next`:

1. `release-please.yml` workflow fires.
2. release-please reads the new config, sees `release-as: "0.1.0-alpha.0"`, and **updates the existing PR #608** with the new version (title becomes `chore(next): release 0.1.0-alpha.0`, manifest + `cli/version.go` + `frontend/package.json` all bump to `0.1.0-alpha.0`).
3. You review and merge #608. The `v0.1.0-alpha.0` tag gets cut, GoReleaser publishes the prerelease + `:next` Docker tag.

### Follow-up

After `v0.1.0-alpha.0` is tagged, open another small PR that removes the `release-as` line. From that point release-please will bump alpha versions via inference (`feat -> 0.2.0-alpha.0`, `fix -> 0.1.0-alpha.1`, …) on each merge to `next`.

I'll open that follow-up automatically once #608 is merged, unless you'd rather do it yourself.

## Related

- Diagnoses the issue noticed after merging #606.
- Companion to the trigger-glob fix in `03dea0f2` (closed the runaway-loop hole that the `release-*` glob created).