### PR TITLE
fix(ci): stop release-please runaway PR loop

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,7 +26,13 @@ on:
   push:
     branches:
       - main
-      - 'release-*'
+      # Maintenance branches like `release-0.0.x`. The leading digit class is
+      # important: a bare `release-*` glob also matches release-please's own
+      # PR branches (`release-please--branches--...`), which causes a runaway
+      # loop — each push to a PR branch re-triggers the workflow with that
+      # branch as `target-branch`, spawning a new nested PR. See incident on
+      # 2026-05-25 (PRs #618–#621).
+      - 'release-[0-9]*'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- The `release-*` branch glob added in #594 also matches release-please's own PR branches (`release-please--branches--...`), so each push to one of those branches re-triggers the workflow with that branch as `target-branch`. The result is exponentially-nested Release PRs (see #618–#621 from today).
- Tighten the pattern to `release-[0-9]*` so only real maintenance branches like `release-0.0.x` qualify. Backport support is preserved.

## Test plan
- [ ] After merge, confirm no new nested `release-please--branches--release-please--...` PRs are created.
- [ ] Confirm the normal Release PR targeting `main` still updates on subsequent conventional commits.