### PR TITLE
ci(test-cli): make Go build/test cache actually persist across runs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -27,8 +27,16 @@ runs:
         path: |
           ~/go/pkg/mod
           ~/.cache/go-build
-        key: go-${{ runner.os }}-${{ hashFiles('cli/go.sum') }}
+        # Rolling key (includes run_id) so every run is a primary-key
+        # miss and therefore saves a fresh cache at end of job. Without
+        # this, actions/cache skips saving on primary hit and the
+        # go-build cache freezes at whatever state existed when go.sum
+        # last changed — meaning `go test` never sees cache hits across
+        # runs. Restore-keys fall back to the most recent prior cache so
+        # restores stay warm.
+        key: go-${{ runner.os }}-${{ hashFiles('cli/go.sum') }}-${{ github.run_id }}
         restore-keys: |
+          go-${{ runner.os }}-${{ hashFiles('cli/go.sum') }}-
           go-${{ runner.os }}-
 
     - name: Install ffmpeg (required for video processing e2e tests)


### PR DESCRIPTION
## Summary

The Go cache key in `.github/actions/setup/action.yml` was `go-${runner.os}-${hashFiles('cli/go.sum')}`. Because `go.sum` rarely changes, almost every CI run hit the primary key — and `actions/cache@v5` deliberately skips saving when the primary key already exists. That froze `~/.cache/go-build` at whatever state existed when `go.sum` last changed, so `go test` never reported `(cached)` packages across runs (confirmed by zero `(cached)` markers in recent test-cli logs).

This adds `${{ github.run_id }}` to the primary key so every run is a miss and saves a fresh cache at end of job. `restore-keys` fall back to the most recent prior cache, so restores stay warm and unchanged packages should start hitting `go test`'s result cache.

## Test plan

- [ ] First CI run after merge: cache misses on primary, restore-key falls back to existing stale cache, save runs at end of job (~5–30s upload).
- [ ] Second CI run: restore-key hits the *fresh* cache from run 1, `go test` log shows `(cached)` markers on unchanged packages, "Run Go tests" step duration drops on no-Go-change runs.