### PR TITLE
feat(reactions): move reactions to event sourcing

### DIFF
--- a/.agents/skills/adr/SKILL.md
+++ b/.agents/skills/adr/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: adr
-description: Keep track of architectural decisions in a structured format using Architecture Decision Records (ADRs).
+name: "adr"
+description: "Keep track of architectural decisions in a structured format using Architecture Decision Records (ADRs)."
 ---
 
 # Architecture Decision Records (ADRs)

--- a/.agents/skills/chatto-architecture/SKILL.md
+++ b/.agents/skills/chatto-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: chatto-architecture
-description: Update docs/ARCHITECTURE.md to reflect the current state of the codebase by examining code and documentation.
+name: "chatto-architecture"
+description: "Update docs/ARCHITECTURE.md to reflect the current state of the codebase by examining code and documentation."
 ---
 
 # Update Architecture Documentation

--- a/.agents/skills/chatto-checkup/SKILL.md
+++ b/.agents/skills/chatto-checkup/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: chatto-checkup
-description: Run a documentation-focused maintenance checkup of the Chatto codebase. Fans out to /fdr, /adr, and /chatto-architecture, then compiles a single consolidated report. Always propose-only — no changes applied without explicit user approval. At the end, points the human at other maintenance skills (/update-project-dependencies, /chatto-security-review) they may want to run themselves.
+name: "chatto-checkup"
+description: "Run a documentation-focused maintenance checkup of the Chatto codebase. Fans out to /fdr, /adr, and /chatto-architecture, then compiles a single consolidated report. Always propose-only \u2014 no changes applied without explicit user approval. At the end, points the human at other maintenance skills (/update-project-dependencies, /chatto-security-review) they may want to run themselves."
 ---
 
 # Chatto Checkup

--- a/.agents/skills/chatto-debugging/SKILL.md
+++ b/.agents/skills/chatto-debugging/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: chatto-debugging
+name: "chatto-debugging"
 description: "Production debugging tools for NATS streams, KV buckets, and protobuf events. Covers nats CLI commands, stream inspection, protobuf decoding, and message iteration."
 ---
 

--- a/.agents/skills/chatto-dev-instance/SKILL.md
+++ b/.agents/skills/chatto-dev-instance/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: chatto-dev-instance
-description: Deploy a new version of Chatto to the dev instance Kubernetes server using Argo Rollouts.
+name: "chatto-dev-instance"
+description: "Deploy a new version of Chatto to the dev instance Kubernetes server using Argo Rollouts."
 ---
 
 # Deploy to Dev Server

--- a/.agents/skills/chatto-finalize-pr/SKILL.md
+++ b/.agents/skills/chatto-finalize-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: chatto-finalize-pr
-description: Pre-merge PR checklist that verifies FDRs and ADRs are up to date. Runs the fdr and adr audits against the current branch's changes to catch missing documentation updates before merging.
+name: "chatto-finalize-pr"
+description: "Pre-merge PR checklist that verifies FDRs and ADRs are up to date. Runs the fdr and adr audits against the current branch's changes to catch missing documentation updates before merging."
 ---
 
 # Finalize PR

--- a/.agents/skills/chatto-release-announcement/SKILL.md
+++ b/.agents/skills/chatto-release-announcement/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: chatto-release-announcement
-description: Generate user-facing release notes by comparing two git tags
+name: "chatto-release-announcement"
+description: "Generate user-facing release notes by comparing two git tags"
 ---
 
 Generate user-facing release notes for the latest release!

--- a/.agents/skills/chatto-security-review/SKILL.md
+++ b/.agents/skills/chatto-security-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: chatto-security-review
+name: "chatto-security-review"
 description: "Perform a comprehensive security review of the Chatto codebase. Launch multiple exploration agents in parallel to examine different security aspects, then have an adversarial reviewer verify and challenge the findings."
 ---
 

--- a/.agents/skills/fdr/SKILL.md
+++ b/.agents/skills/fdr/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: fdr
-description: Keep track of Chatto's features as Feature Decision Records (FDRs) — one structured document per feature capturing behavior, design decisions, and rationale. Replaces the older agent-docs/features/ system.
+name: "fdr"
+description: "Keep track of Chatto's features as Feature Decision Records (FDRs) \u2014 one structured document per feature capturing behavior, design decisions, and rationale. Replaces the older agent-docs/features/ system."
 ---
 
 # Feature Decision Records (FDRs)

--- a/.agents/skills/glossary/SKILL.md
+++ b/.agents/skills/glossary/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: glossary
-description: Maintain Chatto's glossary of terms in docs/GLOSSARY.md. Look up a term, add a new one, or audit the glossary against the codebase, FDRs, and ADRs for missing or stale entries.
+name: "glossary"
+description: "Maintain Chatto's glossary of terms in docs/GLOSSARY.md. Look up a term, add a new one, or audit the glossary against the codebase, FDRs, and ADRs for missing or stale entries."
 ---
 
 # Glossary

--- a/.agents/skills/source-command-chatto-overview/SKILL.md
+++ b/.agents/skills/source-command-chatto-overview/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: "source-command-chatto-overview"
+description: "Give a high-level overview of Chatto's GraphQL schema, NATS messaging, and frontend structure."
+---
+
+# source-command-chatto-overview
+
+Use this skill when the user asks for a high-level overview of the Chatto codebase, especially its GraphQL schema, NATS messaging layout, or frontend structure.
+
+## Command Template
+
+Please examine the codebase and give me a high-level overview of its structure and organization.
+
+Please sort it into the following sections, answering the noted questions:
+
+## GraphQL schema
+
+- What top-level queries, mutations and subscriptions are defined?
+- What do their resolvers do?
+- What are the most important types and relationships in the schema?
+
+# NATS messaging
+
+- What streams, KV buckets and object stores do we have defined?
+- What data do they hold, and how is that data structured?
+- What is the structure of the application's subject space?
+
+# Frontend
+
+- How is the frontend application structured?
+- What are the most important components and their responsibilities?
+- How do they interact with the backend?
+
+## Migration Note
+
+This was migrated from the Claude source command `chatto-overview`. The source command did not use arguments, file expansion, or shell interpolation, so no provider-specific runtime behavior needs to be preserved.

--- a/.agents/skills/source-command-high-level-review/SKILL.md
+++ b/.agents/skills/source-command-high-level-review/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: "source-command-high-level-review"
+description: "Perform a high-level architecture and structure review of the current Chatto codebase."
+---
+
+# source-command-high-level-review
+
+Use this skill when the user asks for a high-level review of the current Chatto codebase's architecture, structure, risks, or improvement opportunities.
+
+## Command Template
+
+Please perform a high-level review of the current codebase, using subagents as needed. Your focus is on overall architecture and structure. Please identify any potential issues or areas for improvement. Summarize your findings and recommendations in a concise report.
+
+## Migration Note
+
+This was migrated from the Claude source command `high-level-review`. The source command did not use arguments, file expansion, or shell interpolation, so no provider-specific runtime behavior needs to be preserved.

--- a/.agents/skills/svelte-docs/SKILL.md
+++ b/.agents/skills/svelte-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: svelte-docs
-description: Use this if you want to look up Svelte, SvelteKit, and Svelte CLI documentation.
+name: "svelte-docs"
+description: "Use this if you want to look up Svelte, SvelteKit, and Svelte CLI documentation."
 ---
 
 # Svelte Documentation Lookup

--- a/.agents/skills/update-project-dependencies/SKILL.md
+++ b/.agents/skills/update-project-dependencies/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: update-project-dependencies
-description: Use this if you want to update all project dependencies while respecting semver compatibility.
+name: "update-project-dependencies"
+description: "Use this if you want to update all project dependencies while respecting semver compatibility."
 ---
 
 # Skill: Update Project Dependencies

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,17 +1,7 @@
 {
-  "extraKnownMarketplaces": {
-    "chattocorp-plugins": {
-      "source": {
-        "source": "github",
-        "repo": "chattocorp/agents"
-      }
-    }
-  },
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
     "feature-dev@claude-plugins-official": true,
-    "code-simplifier@claude-plugins-official": true,
-    "chattocorp-org@chattocorp-plugins": true,
-    "chattocorp-rules@chattocorp-plugins": true
+    "code-simplifier@claude-plugins-official": true
   }
 }

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,4 @@
-README.md
+# Instructions for Agents
+
+Please refer to this repository's README.md for information and instructions.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-README.md
+AGENTS.md

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -34,17 +34,17 @@ import (
 // It provides a unified API for spaces, users, rooms, and messages,
 // managing all KV buckets and event streams internally.
 type ChattoCore struct {
-	nc                      *nats.Conn
-	js                      jetstream.JetStream
-	logger                  *log.Logger
-	storage                 *storage
-	config                  config.CoreConfig
-	encryption              *encryptionManager
-	configManager           *ConfigManager
-	s3Client                *S3Client            // Optional S3 client for S3-compatible storage
-	permissionResolver      *PermissionResolver  // Hierarchical permission resolver
-	linkPreviewCache        *linkpreview.Cache   // Cache for link preview metadata
-	linkPreviewFetcher      *linkpreview.Fetcher // Fetcher for link preview metadata
+	nc                 *nats.Conn
+	js                 jetstream.JetStream
+	logger             *log.Logger
+	storage            *storage
+	config             config.CoreConfig
+	encryption         *encryptionManager
+	configManager      *ConfigManager
+	s3Client           *S3Client            // Optional S3 client for S3-compatible storage
+	permissionResolver *PermissionResolver  // Hierarchical permission resolver
+	linkPreviewCache   *linkpreview.Cache   // Cache for link preview metadata
+	linkPreviewFetcher *linkpreview.Fetcher // Fetcher for link preview metadata
 
 	// VideoMaxUploadSize is the maximum size for video uploads in bytes.
 	// When set (> 0), video attachments use this limit instead of the asset limit.
@@ -140,6 +140,14 @@ type ChattoCore struct {
 	// ThreadsProjector runs the consumer for Threads. Exposed for
 	// WaitForSeq from message writers that touch threads.
 	ThreadsProjector *events.Projector
+
+	// Reactions holds current per-message reaction state derived
+	// from durable room-aggregate reaction events.
+	Reactions *ReactionProjection
+
+	// ReactionsProjector runs the consumer for Reactions. Exposed
+	// for WaitForSeq from reaction writers.
+	ReactionsProjector *events.Projector
 
 	// projectors is the set of all event-sourcing projectors owned by
 	// this core. Each new aggregate migration (ADR-035) appends here
@@ -563,6 +571,9 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	threads := NewThreadProjection()
 	threadsProjector := newProjector(threads, "ThreadsProjector")
 
+	reactions := NewReactionProjection()
+	reactionsProjector := newProjector(reactions, "ReactionsProjector")
+
 	// ConfigManager owns server-config dual-writes; it needs the
 	// publisher (for ServerConfigChangedEvent), the projector
 	// (WaitForSeq for read-your-writes), and the projection (for reads).
@@ -592,6 +603,8 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 		RoomTimelineProjector:   roomTimelineProjector,
 		Threads:                 threads,
 		ThreadsProjector:        threadsProjector,
+		Reactions:               reactions,
+		ReactionsProjector:      reactionsProjector,
 		projectors:              projectors,
 		bootDone:                make(chan struct{}),
 	}
@@ -608,7 +621,7 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	if err := migrations.RunAll(
 		ctx,
 		storage.serverKV, storage.serverConfigKV, storage.serverBodiesKV, storage.serverRuntimeKV, storage.runtimeConfigKV,
-		storage.serverEventsStream,
+		storage.serverEventsStream, storage.serverReactionsKV,
 		eventPublisher,
 		logger,
 	); err != nil {

--- a/cli/internal/core/reaction_projection.go
+++ b/cli/internal/core/reaction_projection.go
@@ -1,0 +1,180 @@
+package core
+
+import (
+	"slices"
+	"sort"
+	"time"
+
+	"hmans.de/chatto/internal/events"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+// ReactionProjection derives current reaction state from durable
+// room-aggregate reaction events. v1 intentionally keeps the whole
+// current reaction set in RAM; bounded/windowed variants can build on
+// this once real access patterns are known.
+type ReactionProjection struct {
+	events.MemoryProjection
+	byMessage map[string]map[string]map[string]int64 // message event ID -> emoji -> user ID -> added timestamp
+	seen      map[string]struct{}
+}
+
+func NewReactionProjection() *ReactionProjection {
+	return &ReactionProjection{
+		byMessage: make(map[string]map[string]map[string]int64),
+		seen:      make(map[string]struct{}),
+	}
+}
+
+func (p *ReactionProjection) Subjects() []string {
+	return []string{events.RoomSubjectFilter()}
+}
+
+func (p *ReactionProjection) Apply(event *corev1.Event, _ uint64) error {
+	if event == nil {
+		return nil
+	}
+	payload := event.GetEvent()
+	switch payload.(type) {
+	case *corev1.Event_ReactionAdded, *corev1.Event_ReactionRemoved:
+	default:
+		return nil
+	}
+
+	p.Lock()
+	defer p.Unlock()
+
+	if id := event.GetId(); id != "" {
+		if _, ok := p.seen[id]; ok {
+			return nil
+		}
+		p.seen[id] = struct{}{}
+	}
+
+	switch e := payload.(type) {
+	case *corev1.Event_ReactionAdded:
+		p.applyAdded(e.ReactionAdded, event.GetActorId(), eventCreatedNanos(event))
+	case *corev1.Event_ReactionRemoved:
+		p.applyRemoved(e.ReactionRemoved, event.GetActorId())
+	}
+	return nil
+}
+
+func (p *ReactionProjection) applyAdded(e *corev1.ReactionAddedEvent, userID string, nanos int64) {
+	if e == nil || userID == "" || e.GetMessageEventId() == "" || e.GetEmoji() == "" {
+		return
+	}
+	byEmoji := p.byMessage[e.GetMessageEventId()]
+	if byEmoji == nil {
+		byEmoji = make(map[string]map[string]int64)
+		p.byMessage[e.GetMessageEventId()] = byEmoji
+	}
+	byUser := byEmoji[e.GetEmoji()]
+	if byUser == nil {
+		byUser = make(map[string]int64)
+		byEmoji[e.GetEmoji()] = byUser
+	}
+	if _, exists := byUser[userID]; !exists {
+		byUser[userID] = nanos
+	}
+}
+
+func (p *ReactionProjection) applyRemoved(e *corev1.ReactionRemovedEvent, userID string) {
+	if e == nil || userID == "" || e.GetMessageEventId() == "" || e.GetEmoji() == "" {
+		return
+	}
+	byEmoji := p.byMessage[e.GetMessageEventId()]
+	if byEmoji == nil {
+		return
+	}
+	byUser := byEmoji[e.GetEmoji()]
+	if byUser == nil {
+		return
+	}
+	delete(byUser, userID)
+	if len(byUser) == 0 {
+		delete(byEmoji, e.GetEmoji())
+	}
+	if len(byEmoji) == 0 {
+		delete(p.byMessage, e.GetMessageEventId())
+	}
+}
+
+func eventCreatedNanos(event *corev1.Event) int64 {
+	if ts := event.GetCreatedAt(); ts != nil {
+		return ts.AsTime().UnixNano()
+	}
+	return time.Now().UnixNano()
+}
+
+func (p *ReactionProjection) HasReaction(messageEventID, emoji, userID string) bool {
+	p.RLock()
+	defer p.RUnlock()
+
+	byEmoji := p.byMessage[messageEventID]
+	if byEmoji == nil {
+		return false
+	}
+	byUser := byEmoji[emoji]
+	if byUser == nil {
+		return false
+	}
+	_, ok := byUser[userID]
+	return ok
+}
+
+func (p *ReactionProjection) Reactions(messageEventID string) []ReactionSummary {
+	p.RLock()
+	defer p.RUnlock()
+	return reactionSummariesForMessage(p.byMessage[messageEventID])
+}
+
+func (p *ReactionProjection) ReactionsBatch(messageEventIDs []string) map[string][]ReactionSummary {
+	p.RLock()
+	defer p.RUnlock()
+
+	result := make(map[string][]ReactionSummary, len(messageEventIDs))
+	for _, eventID := range messageEventIDs {
+		if byEmoji := p.byMessage[eventID]; byEmoji != nil {
+			result[eventID] = reactionSummariesForMessage(byEmoji)
+		}
+	}
+	return result
+}
+
+func reactionSummariesForMessage(byEmoji map[string]map[string]int64) []ReactionSummary {
+	if len(byEmoji) == 0 {
+		return nil
+	}
+	type group struct {
+		summary       ReactionSummary
+		earliestNanos int64
+	}
+	groups := make([]group, 0, len(byEmoji))
+	for emoji, byUser := range byEmoji {
+		userIDs := make([]string, 0, len(byUser))
+		var earliest int64
+		for userID, nanos := range byUser {
+			userIDs = append(userIDs, userID)
+			if earliest == 0 || nanos < earliest {
+				earliest = nanos
+			}
+		}
+		slices.Sort(userIDs)
+		groups = append(groups, group{
+			summary:       ReactionSummary{Emoji: emoji, UserIDs: userIDs},
+			earliestNanos: earliest,
+		})
+	}
+	sort.Slice(groups, func(i, j int) bool {
+		if groups[i].earliestNanos != groups[j].earliestNanos {
+			return groups[i].earliestNanos < groups[j].earliestNanos
+		}
+		return groups[i].summary.Emoji < groups[j].summary.Emoji
+	})
+	result := make([]ReactionSummary, len(groups))
+	for i, g := range groups {
+		result[i] = g.summary
+	}
+	return result
+}

--- a/cli/internal/core/reactions.go
+++ b/cli/internal/core/reactions.go
@@ -2,16 +2,13 @@ package core
 
 import (
 	"context"
-	"encoding/binary"
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 
-	"github.com/nats-io/nats.go/jetstream"
-
 	"hmans.de/chatto/internal/core/subjects"
+	"hmans.de/chatto/internal/events"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
@@ -70,7 +67,7 @@ func (c *ChattoCore) resolveReactionTarget(ctx context.Context, kind RoomKind, r
 // AddReaction adds an emoji reaction to a message.
 // Accepts an emoji shortcode name (e.g., "thumbsup", "heart").
 // Returns true if the reaction was added, false if it already existed.
-// Publishes a ReactionAddedEvent after successful KV write.
+// Publishes a durable ReactionAddedEvent after successful OCC write.
 // If the target message is an echo, the reaction is stored against the original message.
 func (c *ChattoCore) AddReaction(ctx context.Context, kind RoomKind, roomID, messageEventID, emojiInput, userID string) (bool, error) {
 	emojiName, err := resolveEmojiInput(emojiInput)
@@ -93,25 +90,14 @@ func (c *ChattoCore) AddReaction(ctx context.Context, kind RoomKind, roomID, mes
 		return false, err
 	}
 
-	kv := c.storage.serverReactionsKV
-
-	key := reactionKey(canonicalEventID, emojiName, userID)
-
-	// Store timestamp as value for ordering reactions by time added
-	timestamp := make([]byte, 8)
-	binary.BigEndian.PutUint64(timestamp, uint64(time.Now().UnixNano()))
-
-	_, err = kv.Create(ctx, key, timestamp)
-	if errors.Is(err, jetstream.ErrKeyExists) {
-		return false, nil // Already reacted
-	}
+	event := newReactionAddedEvent(userID, roomID, canonicalEventID, emojiName)
+	added, err := c.publishReactionMutation(ctx, kind, roomID, canonicalEventID, emojiName, userID, event)
 	if err != nil {
 		return false, fmt.Errorf("failed to add reaction: %w", err)
 	}
-
-	// Publish event with the canonical (original) event ID so both
-	// channel view and thread view can match and refetch reactions.
-	c.publishReactionAddedEvent(ctx, kind, roomID, canonicalEventID, emojiName, userID)
+	if !added {
+		return false, nil
+	}
 
 	c.logger.Debug("Reaction added",
 		"kind", kind,
@@ -127,7 +113,7 @@ func (c *ChattoCore) AddReaction(ctx context.Context, kind RoomKind, roomID, mes
 // RemoveReaction removes an emoji reaction from a message.
 // Accepts an emoji shortcode name (e.g., "thumbsup", "heart").
 // Returns true if the reaction was removed, false if it didn't exist.
-// Publishes a ReactionRemovedEvent after successful KV delete.
+// Publishes a durable ReactionRemovedEvent after successful OCC write.
 // If the target message is an echo, the reaction is removed from the original message.
 func (c *ChattoCore) RemoveReaction(ctx context.Context, kind RoomKind, roomID, messageEventID, emojiInput, userID string) (bool, error) {
 	emojiName, err := resolveEmojiInput(emojiInput)
@@ -141,27 +127,14 @@ func (c *ChattoCore) RemoveReaction(ctx context.Context, kind RoomKind, roomID, 
 		return false, err
 	}
 
-	kv := c.storage.serverReactionsKV
-
-	key := reactionKey(canonicalEventID, emojiName, userID)
-
-	// Check if the reaction exists first (KV Delete doesn't error on non-existent keys)
-	_, err = kv.Get(ctx, key)
-	if errors.Is(err, jetstream.ErrKeyNotFound) {
-		return false, nil // Reaction didn't exist
-	}
-	if err != nil {
-		return false, fmt.Errorf("failed to check reaction: %w", err)
-	}
-
-	// Delete the reaction
-	err = kv.Delete(ctx, key)
+	event := newReactionRemovedEvent(userID, roomID, canonicalEventID, emojiName)
+	removed, err := c.publishReactionMutation(ctx, kind, roomID, canonicalEventID, emojiName, userID, event)
 	if err != nil {
 		return false, fmt.Errorf("failed to remove reaction: %w", err)
 	}
-
-	// Publish event with the canonical (original) event ID
-	c.publishReactionRemovedEvent(ctx, kind, roomID, canonicalEventID, emojiName, userID)
+	if !removed {
+		return false, nil
+	}
 
 	c.logger.Debug("Reaction removed",
 		"kind", kind,
@@ -184,131 +157,26 @@ type ReactionSummary struct {
 // Returns a slice of ReactionSummary, each containing the shortcode name and list of user IDs.
 // Results are ordered by the time each emoji was first added (earliest first).
 func (c *ChattoCore) GetReactions(ctx context.Context, messageEventID string) ([]ReactionSummary, error) {
-	result, err := c.GetReactionsBatch(ctx, []string{messageEventID})
-	if err != nil {
-		return nil, err
-	}
-	return result[messageEventID], nil
+	return c.Reactions.Reactions(messageEventID), nil
 }
 
 // GetReactionsBatch returns reactions for multiple messages in a single pass.
-// Uses ListKeysFiltered with per-message subject filters to avoid scanning the entire bucket.
 // Returns a map from messageEventID to sorted ReactionSummary slices.
 func (c *ChattoCore) GetReactionsBatch(ctx context.Context, eventIDs []string) (map[string][]ReactionSummary, error) {
 	if len(eventIDs) == 0 {
 		return make(map[string][]ReactionSummary), nil
 	}
-
-	kv := c.storage.serverReactionsKV
-
-	// Build NATS subject filters for all event IDs (e.g., "eventId1.>", "eventId2.>")
-	filters := make([]string, len(eventIDs))
-	for i, eventID := range eventIDs {
-		filters[i] = eventID + ".>"
-	}
-
-	lister, err := kv.ListKeysFiltered(ctx, filters...)
-	if err != nil {
-		if errors.Is(err, jetstream.ErrNoKeysFound) {
-			return make(map[string][]ReactionSummary), nil
-		}
-		return nil, fmt.Errorf("failed to list reaction keys: %w", err)
-	}
-
-	// Collect all matching keys
-	var matchedKeys []string
-	for key := range lister.Keys() {
-		matchedKeys = append(matchedKeys, key)
-	}
-
-	// Parse keys and fetch timestamps, grouped by event ID
-	type emojiData struct {
-		userIDs       []string
-		earliestNanos uint64
-	}
-	// eventID -> emojiName -> emojiData
-	reactionsByEvent := make(map[string]map[string]*emojiData)
-
-	for _, key := range matchedKeys {
-		eventID, emojiName, userID, err := parseReactionKey(key)
-		if err != nil {
-			c.logger.Warn("Invalid reaction key", "key", key, "error", err)
-			continue
-		}
-
-		entry, err := kv.Get(ctx, key)
-		if err != nil {
-			c.logger.Warn("Failed to get reaction entry", "key", key, "error", err)
-			continue
-		}
-
-		// Parse timestamp from value (8-byte big-endian uint64)
-		var timestamp uint64
-		if len(entry.Value()) >= 8 {
-			timestamp = binary.BigEndian.Uint64(entry.Value())
-		}
-
-		if reactionsByEvent[eventID] == nil {
-			reactionsByEvent[eventID] = make(map[string]*emojiData)
-		}
-
-		data, exists := reactionsByEvent[eventID][emojiName]
-		if !exists {
-			data = &emojiData{earliestNanos: timestamp}
-			reactionsByEvent[eventID][emojiName] = data
-		} else if timestamp > 0 && (data.earliestNanos == 0 || timestamp < data.earliestNanos) {
-			data.earliestNanos = timestamp
-		}
-		data.userIDs = append(data.userIDs, userID)
-	}
-
-	// Convert to result map with sorted summaries per event
-	result := make(map[string][]ReactionSummary, len(reactionsByEvent))
-	for eventID, byEmoji := range reactionsByEvent {
-		type sortableReaction struct {
-			summary       ReactionSummary
-			earliestNanos uint64
-		}
-		sortable := make([]sortableReaction, 0, len(byEmoji))
-
-		for emojiName, data := range byEmoji {
-			sortable = append(sortable, sortableReaction{
-				summary: ReactionSummary{
-					Emoji:   emojiName,
-					UserIDs: data.userIDs,
-				},
-				earliestNanos: data.earliestNanos,
-			})
-		}
-
-		slices.SortFunc(sortable, func(a, b sortableReaction) int {
-			if a.earliestNanos < b.earliestNanos {
-				return -1
-			}
-			if a.earliestNanos > b.earliestNanos {
-				return 1
-			}
-			return strings.Compare(a.summary.Emoji, b.summary.Emoji)
-		})
-
-		summaries := make([]ReactionSummary, len(sortable))
-		for i, s := range sortable {
-			summaries[i] = s.summary
-		}
-		result[eventID] = summaries
-	}
-
-	return result, nil
+	return c.Reactions.ReactionsBatch(eventIDs), nil
 }
 
 // ============================================================================
 // Event Publishing
 // ============================================================================
 
-// publishReactionAddedEvent publishes a ReactionAddedEvent directly to the live subject space.
-// Reactions are transient UI updates that don't need JetStream storage - the KV bucket is the source of truth.
-func (c *ChattoCore) publishReactionAddedEvent(ctx context.Context, kind RoomKind, roomID, messageEventID, emoji, userID string) {
-	event := newEvent(userID, &corev1.Event{
+const maxReactionMutationRetries = 5
+
+func newReactionAddedEvent(userID, roomID, messageEventID, emoji string) *corev1.Event {
+	return newEvent(userID, &corev1.Event{
 		Event: &corev1.Event_ReactionAdded{
 			ReactionAdded: &corev1.ReactionAddedEvent{
 				RoomId:         roomID,
@@ -317,18 +185,10 @@ func (c *ChattoCore) publishReactionAddedEvent(ctx context.Context, kind RoomKin
 			},
 		},
 	})
-
-	// Publish directly to live subject (bypass JetStream)
-	subject := subjects.LiveRoomEvent(string(kind), roomID, "reaction_added")
-	if err := c.publishLiveServerEvent(ctx, subject, event); err != nil {
-		c.logger.Warn("Failed to publish reaction added event", "error", err)
-	}
 }
 
-// publishReactionRemovedEvent publishes a ReactionRemovedEvent directly to the live subject space.
-// Reactions are transient UI updates that don't need JetStream storage - the KV bucket is the source of truth.
-func (c *ChattoCore) publishReactionRemovedEvent(ctx context.Context, kind RoomKind, roomID, messageEventID, emoji, userID string) {
-	event := newEvent(userID, &corev1.Event{
+func newReactionRemovedEvent(userID, roomID, messageEventID, emoji string) *corev1.Event {
+	return newEvent(userID, &corev1.Event{
 		Event: &corev1.Event_ReactionRemoved{
 			ReactionRemoved: &corev1.ReactionRemovedEvent{
 				RoomId:         roomID,
@@ -337,10 +197,69 @@ func (c *ChattoCore) publishReactionRemovedEvent(ctx context.Context, kind RoomK
 			},
 		},
 	})
+}
 
-	// Publish directly to live subject (bypass JetStream)
-	subject := subjects.LiveRoomEvent(string(kind), roomID, "reaction_removed")
+func (c *ChattoCore) publishReactionMutation(ctx context.Context, kind RoomKind, roomID, messageEventID, emoji, userID string, event *corev1.Event) (bool, error) {
+	add := event.GetReactionAdded() != nil
+	remove := event.GetReactionRemoved() != nil
+	if !add && !remove {
+		return false, fmt.Errorf("unsupported reaction event %T", event.GetEvent())
+	}
+
+	agg := events.RoomAggregate(roomID)
+	publishSubject := agg.SubjectFor(event)
+	occFilter := agg.AllEventsFilter()
+
+	for attempt := 0; attempt < maxReactionMutationRetries; attempt++ {
+		filterSeq, err := c.EventPublisher.LastSubjectSeq(ctx, occFilter)
+		if err != nil {
+			return false, fmt.Errorf("read OCC filter seq: %w", err)
+		}
+		if err := c.ReactionsProjector.WaitForSeq(ctx, filterSeq); err != nil {
+			return false, fmt.Errorf("wait for reactions projection: %w", err)
+		}
+
+		exists := c.Reactions.HasReaction(messageEventID, emoji, userID)
+		if add && exists {
+			return false, nil
+		}
+		if remove && !exists {
+			return false, nil
+		}
+
+		seq, err := c.EventPublisher.AppendAtFilter(ctx, publishSubject, event, occFilter, filterSeq)
+		if err == nil {
+			if err := c.ReactionsProjector.WaitForSeq(ctx, seq); err != nil {
+				return false, fmt.Errorf("wait for reactions projection: %w", err)
+			}
+			c.publishReactionLiveMirror(ctx, kind, roomID, event)
+			return true, nil
+		}
+		if !errors.Is(err, events.ErrConflict) {
+			return false, err
+		}
+
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-time.After(time.Duration(1<<attempt) * time.Millisecond):
+		}
+	}
+	return false, fmt.Errorf("reaction OCC retry exhausted after %d attempts: %w", maxReactionMutationRetries, events.ErrConflict)
+}
+
+func (c *ChattoCore) publishReactionLiveMirror(ctx context.Context, kind RoomKind, roomID string, event *corev1.Event) {
+	var eventType string
+	switch event.GetEvent().(type) {
+	case *corev1.Event_ReactionAdded:
+		eventType = "reaction_added"
+	case *corev1.Event_ReactionRemoved:
+		eventType = "reaction_removed"
+	default:
+		return
+	}
+	subject := subjects.LiveRoomEvent(string(kind), roomID, eventType)
 	if err := c.publishLiveServerEvent(ctx, subject, event); err != nil {
-		c.logger.Warn("Failed to publish reaction removed event", "error", err)
+		c.logger.Warn("Failed to publish reaction live mirror", "error", err, "subject", subject)
 	}
 }

--- a/cli/internal/core/reactions_test.go
+++ b/cli/internal/core/reactions_test.go
@@ -1,7 +1,12 @@
 package core
 
 import (
+	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
 func TestChattoCore_AddReaction(t *testing.T) {
@@ -81,6 +86,42 @@ func TestChattoCore_AddReaction(t *testing.T) {
 			t.Error("Expected error for invalid emoji input")
 		}
 	})
+}
+
+func TestChattoCore_AddReactionConcurrentDuplicate(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	user, room, eventID := setupReactionTest(t, core, ctx)
+
+	var addedCount atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			added, err := core.AddReaction(ctx, KindChannel, room.Id, eventID, "thumbsup", user.Id)
+			if err != nil {
+				t.Errorf("AddReaction failed: %v", err)
+				return
+			}
+			if added {
+				addedCount.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := addedCount.Load(); got != 1 {
+		t.Fatalf("concurrent duplicate adds returned %d successes, want 1", got)
+	}
+	reactions, err := core.GetReactions(ctx, eventID)
+	if err != nil {
+		t.Fatalf("GetReactions failed: %v", err)
+	}
+	if len(reactions) != 1 || reactions[0].Emoji != "thumbsup" || len(reactions[0].UserIDs) != 1 || reactions[0].UserIDs[0] != user.Id {
+		t.Fatalf("unexpected reactions after concurrent duplicate add: %+v", reactions)
+	}
 }
 
 func TestChattoCore_RemoveReaction(t *testing.T) {
@@ -526,4 +567,24 @@ func TestEmoji(t *testing.T) {
 			t.Error("Expected error for invalid input")
 		}
 	})
+}
+
+func setupReactionTest(t *testing.T, core *ChattoCore, ctx context.Context) (*corev1.User, *corev1.Room, string) {
+	t.Helper()
+	user, err := core.CreateUser(ctx, "system", "testuser", "Test User", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser failed: %v", err)
+	}
+	room, err := core.CreateRoom(ctx, user.Id, KindChannel, "", "test-room", "Test room")
+	if err != nil {
+		t.Fatalf("CreateRoom failed: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom failed: %v", err)
+	}
+	event, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "Hello world", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage failed: %v", err)
+	}
+	return user, room, event.Id
 }

--- a/cli/internal/core/room_events.go
+++ b/cli/internal/core/room_events.go
@@ -237,6 +237,8 @@ func (c *ChattoCore) GetEventSequence(ctx context.Context, kind RoomKind, roomID
 //   - MessageEditedEvent / MessageRetractedEvent — folded onto the
 //     original post via projection.LatestBody; not surfaced as
 //     separate timeline entries.
+//   - ReactionAddedEvent / ReactionRemovedEvent — folded into the
+//     reaction projection.
 //
 // Visible: root messages, room lifecycle (created/updated/archived/
 // unarchived/deleted), memberships (user_joined / user_left).
@@ -247,7 +249,8 @@ func isVisibleRoomTimelineEntry(event *corev1.Event) bool {
 	switch e := event.GetEvent().(type) {
 	case *corev1.Event_MessagePosted:
 		return e.MessagePosted.GetInThread() == ""
-	case *corev1.Event_MessageEdited, *corev1.Event_MessageRetracted:
+	case *corev1.Event_MessageEdited, *corev1.Event_MessageRetracted,
+		*corev1.Event_ReactionAdded, *corev1.Event_ReactionRemoved:
 		return false
 	}
 	return true

--- a/cli/internal/core/room_timeline_projection.go
+++ b/cli/internal/core/room_timeline_projection.go
@@ -379,6 +379,10 @@ func roomIDOfEvent(event *corev1.Event) string {
 		return e.MessageEdited.GetRoomId()
 	case *corev1.Event_MessageRetracted:
 		return e.MessageRetracted.GetRoomId()
+	case *corev1.Event_ReactionAdded:
+		return e.ReactionAdded.GetRoomId()
+	case *corev1.Event_ReactionRemoved:
+		return e.ReactionRemoved.GetRoomId()
 	}
 	return ""
 }

--- a/cli/internal/core/subjects/subjects.go
+++ b/cli/internal/core/subjects/subjects.go
@@ -320,8 +320,8 @@ func LiveRoomAllEvents(kind string) string {
 	return fmt.Sprintf("live.server.room.%s.>", kind)
 }
 
-// LiveRoomReactionEvents returns the subscription subject for all live-only
-// reaction events of a given kind.
+// LiveRoomReactionEvents returns the subscription subject for all reaction
+// live mirrors of a given kind.
 // Pattern: `live.server.room.{kind}.*.reaction_*`.
 func LiveRoomReactionEvents(kind string) string {
 	return fmt.Sprintf("live.server.room.%s.*.reaction_*", kind)

--- a/cli/internal/events/subjects.go
+++ b/cli/internal/events/subjects.go
@@ -63,6 +63,11 @@ const (
 	EventMessageEdited    = "message_edited"
 	EventMessageRetracted = "message_retracted"
 
+	// Reactions (also under the room aggregate). Reaction state is
+	// derived from these durable events by the reaction projection.
+	EventReactionAdded   = "reaction_added"
+	EventReactionRemoved = "reaction_removed"
+
 	// Group aggregate
 	EventRoomGroupCreated      = "group_created"
 	EventRoomGroupUpdated      = "group_updated"
@@ -110,6 +115,11 @@ func EventTypeOf(e *corev1.Event) string {
 		return EventMessageEdited
 	case *corev1.Event_MessageRetracted:
 		return EventMessageRetracted
+
+	case *corev1.Event_ReactionAdded:
+		return EventReactionAdded
+	case *corev1.Event_ReactionRemoved:
+		return EventReactionRemoved
 
 	case *corev1.Event_RoomGroupCreated:
 		return EventRoomGroupCreated

--- a/cli/internal/graph/events.graphqls
+++ b/cli/internal/graph/events.graphqls
@@ -389,7 +389,7 @@ type MessageDeletedEvent {
 }
 
 # ==============================================================================
-# REACTION EVENTS (Live-only - KV bucket is source of truth)
+# REACTION EVENTS (durable in EVT; delivered live via live.server mirror)
 # ==============================================================================
 
 """

--- a/cli/internal/migrations/migrations.go
+++ b/cli/internal/migrations/migrations.go
@@ -57,6 +57,8 @@ import (
 //     recomputable state).
 //   - `runtimeConfigKV`: INSTANCE_CONFIG (operator-editable server
 //     settings — name, MOTD, blocked usernames, etc.).
+//   - `serverReactionsKV`: SERVER_REACTIONS (legacy current reaction
+//     state; retained until reaction ES migration cleanup).
 //
 // `publisher` writes to the EVT event-sourcing stream and is
 // used by the ES migrations (ADR-035 phase 3 per aggregate) that seed
@@ -65,6 +67,7 @@ func RunAll(
 	ctx context.Context,
 	serverKV, serverConfigKV, serverBodiesKV, serverRuntimeKV, runtimeConfigKV jetstream.KeyValue,
 	serverEventsStream jetstream.Stream,
+	serverReactionsKV jetstream.KeyValue,
 	publisher *events.Publisher,
 	logger *log.Logger,
 ) error {
@@ -98,6 +101,9 @@ func RunAll(
 	}
 	if err := MigrateMessagesToES(ctx, serverEventsStream, serverBodiesKV, publisher, logger); err != nil {
 		return fmt.Errorf("messages_es: %w", err)
+	}
+	if err := MigrateReactionsToES(ctx, serverEventsStream, serverReactionsKV, publisher, logger); err != nil {
+		return fmt.Errorf("reactions_es: %w", err)
 	}
 	return nil
 }

--- a/cli/internal/migrations/reactions_es.go
+++ b/cli/internal/migrations/reactions_es.go
@@ -1,0 +1,225 @@
+package migrations
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/log"
+	"github.com/nats-io/nats.go/jetstream"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"hmans.de/chatto/internal/events"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+// MigrateReactionsToES seeds EVT with the current reaction state from
+// the legacy SERVER_REACTIONS KV bucket.
+//
+// # Source of truth before
+//
+// SERVER_REACTIONS stores one key per active reaction:
+// `{messageEventId}.{emojiName}.{userId}`. The value is an 8-byte
+// big-endian Unix-nano timestamp used to order reaction groups. Add/remove
+// history was not durable; only the current set survives.
+//
+// # Source of truth after
+//
+// Each active legacy reaction becomes a durable ReactionAddedEvent on
+// `evt.room.{roomId}.reaction_added`. The reacting user is the event
+// actor. The message-to-room mapping is recovered from legacy
+// SERVER_EVENTS message envelopes.
+//
+// # Idempotency and crash-safety
+//
+// Reactions are grouped by room and emitted via one atomic AppendBatch
+// per room. The first entry carries subject-level OCC against
+// `evt.room.{roomId}.reaction_added` expecting an empty subject; on
+// replay, the conflict skips the whole room.
+func MigrateReactionsToES(
+	ctx context.Context,
+	serverEventsStream jetstream.Stream,
+	serverReactionsKV jetstream.KeyValue,
+	publisher *events.Publisher,
+	logger *log.Logger,
+) error {
+	reactionKeys, err := listLegacyReactionKeys(ctx, serverReactionsKV)
+	if err != nil {
+		return err
+	}
+	if len(reactionKeys) == 0 {
+		return nil
+	}
+
+	messageRooms, err := legacyMessageRooms(ctx, serverEventsStream, logger)
+	if err != nil {
+		return err
+	}
+
+	type roomBatch struct {
+		entries []events.BatchEntry
+	}
+	roomBatches := make(map[string]*roomBatch)
+	var roomOrder []string
+	var skippedMissingRoom int
+
+	for _, key := range reactionKeys {
+		messageEventID, emoji, userID, err := parseLegacyReactionKey(key)
+		if err != nil {
+			logger.Warn("reactions ES migration: skipping invalid key", "key", key, "error", err)
+			continue
+		}
+		roomID := messageRooms[messageEventID]
+		if roomID == "" {
+			skippedMissingRoom++
+			logger.Warn("reactions ES migration: skipping reaction for unknown message", "key", key, "message_event_id", messageEventID)
+			continue
+		}
+
+		entry, err := serverReactionsKV.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			return fmt.Errorf("get reaction key %s: %w", key, err)
+		}
+
+		event := stamp(&corev1.Event{
+			Event: &corev1.Event_ReactionAdded{
+				ReactionAdded: &corev1.ReactionAddedEvent{
+					RoomId:         roomID,
+					MessageEventId: messageEventID,
+					Emoji:          emoji,
+				},
+			},
+		}, userID, reactionTimestamp(entry.Value()))
+
+		agg := events.RoomAggregate(roomID)
+		batch := roomBatches[roomID]
+		if batch == nil {
+			batch = &roomBatch{}
+			roomBatches[roomID] = batch
+			roomOrder = append(roomOrder, roomID)
+		}
+		batch.entries = append(batch.entries, events.BatchEntry{
+			Subject: agg.Subject(events.EventReactionAdded),
+			Event:   event,
+		})
+	}
+
+	var imported, skipped int
+	startedAt := time.Now()
+	for _, roomID := range roomOrder {
+		batch := roomBatches[roomID]
+		if len(batch.entries) == 0 {
+			continue
+		}
+		batch.entries[0].HasOCC = true
+		batch.entries[0].ExpectedSeq = 0
+
+		if _, err := publisher.AppendBatch(ctx, batch.entries); err != nil {
+			if errors.Is(err, events.ErrConflict) {
+				skipped += len(batch.entries)
+				continue
+			}
+			return fmt.Errorf("publish migrated reactions (room=%s): %w", roomID, err)
+		}
+		imported += len(batch.entries)
+	}
+
+	if imported > 0 || skipped > 0 || skippedMissingRoom > 0 {
+		logger.Info(
+			"reactions ES migration: seeded events from legacy SERVER_REACTIONS",
+			"reactions_imported", imported,
+			"reactions_skipped", skipped,
+			"missing_room_skipped", skippedMissingRoom,
+			"rooms_processed", len(roomBatches),
+			"duration_ms", time.Since(startedAt).Milliseconds(),
+		)
+	}
+	return nil
+}
+
+func listLegacyReactionKeys(ctx context.Context, kv jetstream.KeyValue) ([]string, error) {
+	lister, err := kv.ListKeys(ctx)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("list reaction keys: %w", err)
+	}
+	var keys []string
+	for key := range lister.Keys() {
+		keys = append(keys, key)
+	}
+	return keys, nil
+}
+
+func parseLegacyReactionKey(key string) (messageEventID, emoji, userID string, err error) {
+	parts := strings.SplitN(key, ".", 3)
+	if len(parts) != 3 {
+		return "", "", "", fmt.Errorf("invalid reaction key format")
+	}
+	return parts[0], parts[1], parts[2], nil
+}
+
+func reactionTimestamp(value []byte) *timestamppb.Timestamp {
+	if len(value) >= 8 {
+		return timestamppb.New(time.Unix(0, int64(binary.BigEndian.Uint64(value))))
+	}
+	return timestamppb.Now()
+}
+
+func legacyMessageRooms(ctx context.Context, stream jetstream.Stream, logger *log.Logger) (map[string]string, error) {
+	consumer, err := stream.CreateConsumer(ctx, jetstream.ConsumerConfig{
+		FilterSubjects:    []string{"server.room.*.*.msg.>"},
+		DeliverPolicy:     jetstream.DeliverAllPolicy,
+		AckPolicy:         jetstream.AckNonePolicy,
+		MemoryStorage:     true,
+		InactiveThreshold: 30 * time.Second,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create reaction migration consumer on SERVER_EVENTS: %w", err)
+	}
+	defer stream.DeleteConsumer(context.Background(), consumer.CachedInfo().Name)
+
+	info, err := consumer.Info(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get reaction migration consumer info: %w", err)
+	}
+	messageRooms := make(map[string]string, int(info.NumPending))
+	if info.NumPending == 0 {
+		return messageRooms, nil
+	}
+
+	msgs, err := consumer.Fetch(int(info.NumPending), jetstream.FetchMaxWait(60*time.Second))
+	if err != nil && !errors.Is(err, jetstream.ErrNoMessages) {
+		return nil, fmt.Errorf("fetch legacy message rooms: %w", err)
+	}
+	if msgs == nil {
+		return messageRooms, nil
+	}
+	for msg := range msgs.Messages() {
+		var event corev1.Event
+		if err := proto.Unmarshal(msg.Data(), &event); err != nil {
+			logger.Warn("reactions ES migration: skipping unmarshalable message event", "subject", msg.Subject(), "error", err)
+			continue
+		}
+		posted := event.GetMessagePosted()
+		if posted == nil || posted.GetRoomId() == "" {
+			continue
+		}
+		eventID := posted.GetEventId()
+		if eventID == "" {
+			eventID = event.GetId()
+		}
+		if eventID != "" {
+			messageRooms[eventID] = posted.GetRoomId()
+		}
+	}
+	return messageRooms, nil
+}

--- a/cli/internal/migrations/reactions_es_test.go
+++ b/cli/internal/migrations/reactions_es_test.go
@@ -1,0 +1,99 @@
+package migrations
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/log"
+	"github.com/nats-io/nats.go/jetstream"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+func TestMigrateReactionsToES_EmptyKV(t *testing.T) {
+	rig := setupMessagesRig(t)
+	reactionsKV := rig.reactionsKV(t)
+
+	if err := MigrateReactionsToES(rig.ctx, rig.srcStream, reactionsKV, rig.publisher, log.New(io.Discard)); err != nil {
+		t.Fatalf("migration: %v", err)
+	}
+	info, err := rig.evtStream.Info(rig.ctx)
+	if err != nil {
+		t.Fatalf("evt info: %v", err)
+	}
+	if info.State.Msgs != 0 {
+		t.Errorf("EVT should be empty after empty reaction migration, got %d msgs", info.State.Msgs)
+	}
+}
+
+func TestMigrateReactionsToES_ImportsCurrentStateAndReplays(t *testing.T) {
+	rig := setupMessagesRig(t)
+	reactionsKV := rig.reactionsKV(t)
+
+	rig.publishLegacy(t, "server.room.channel.R1.msg.M1", &corev1.Event{
+		Id:        "M1",
+		ActorId:   "U1",
+		CreatedAt: timestamppb.Now(),
+		Event: &corev1.Event_MessagePosted{
+			MessagePosted: &corev1.MessagePostedEvent{RoomId: "R1", EventId: "M1"},
+		},
+	})
+	putReaction(t, rig.ctx, reactionsKV, "M1.thumbsup.U2", time.Unix(1700000000, 123))
+	putReaction(t, rig.ctx, reactionsKV, "M1.heart.U3", time.Unix(1700000001, 456))
+
+	if err := MigrateReactionsToES(rig.ctx, rig.srcStream, reactionsKV, rig.publisher, log.New(io.Discard)); err != nil {
+		t.Fatalf("migration: %v", err)
+	}
+	info, err := rig.evtStream.Info(rig.ctx)
+	if err != nil {
+		t.Fatalf("evt info: %v", err)
+	}
+	if info.State.Msgs != 2 {
+		t.Fatalf("EVT messages after first migration = %d, want 2", info.State.Msgs)
+	}
+
+	ev := rig.readEvent(t, 1)
+	added := ev.GetReactionAdded()
+	if added == nil {
+		t.Fatalf("event 1 type = %T, want ReactionAdded", ev.GetEvent())
+	}
+	if added.GetRoomId() != "R1" || added.GetMessageEventId() != "M1" || ev.GetActorId() == "" || added.GetEmoji() == "" {
+		t.Fatalf("unexpected migrated reaction event: actor=%q payload=%+v", ev.GetActorId(), added)
+	}
+
+	if err := MigrateReactionsToES(rig.ctx, rig.srcStream, reactionsKV, rig.publisher, log.New(io.Discard)); err != nil {
+		t.Fatalf("replay migration: %v", err)
+	}
+	info, err = rig.evtStream.Info(rig.ctx)
+	if err != nil {
+		t.Fatalf("evt info after replay: %v", err)
+	}
+	if info.State.Msgs != 2 {
+		t.Fatalf("EVT messages after replay = %d, want 2", info.State.Msgs)
+	}
+}
+
+func (r *messagesTestRig) reactionsKV(t *testing.T) jetstream.KeyValue {
+	t.Helper()
+	kv, err := r.js.CreateOrUpdateKeyValue(r.ctx, jetstream.KeyValueConfig{
+		Bucket:  "SERVER_REACTIONS_TEST",
+		Storage: jetstream.MemoryStorage,
+	})
+	if err != nil {
+		t.Fatalf("create SERVER_REACTIONS bucket: %v", err)
+	}
+	return kv
+}
+
+func putReaction(t *testing.T, ctx context.Context, kv jetstream.KeyValue, key string, ts time.Time) {
+	t.Helper()
+	value := make([]byte, 8)
+	binary.BigEndian.PutUint64(value, uint64(ts.UnixNano()))
+	if _, err := kv.Put(ctx, key, value); err != nil {
+		t.Fatalf("put reaction %s: %v", key, err)
+	}
+}

--- a/cli/internal/pb/chatto/core/v1/event.pb.go
+++ b/cli/internal/pb/chatto/core/v1/event.pb.go
@@ -755,7 +755,7 @@ type Event_MessageDeleted struct {
 }
 
 type Event_ReactionAdded struct {
-	// ----- Reactions (1050-1059) — KV is source of truth -----
+	// ----- Reactions (1050-1059) — EVT/projection is source of truth -----
 	ReactionAdded *ReactionAddedEvent `protobuf:"bytes,1050,opt,name=reaction_added,json=reactionAdded,proto3,oneof"`
 }
 
@@ -2802,7 +2802,7 @@ type ReactionAddedEvent struct {
 	RoomId string `protobuf:"bytes,2,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
 	// Event ID of the message being reacted to (NanoID)
 	MessageEventId string `protobuf:"bytes,3,opt,name=message_event_id,json=messageEventId,proto3" json:"message_event_id,omitempty"`
-	// The emoji used for the reaction (Unicode emoji string)
+	// The emoji used for the reaction (shortcode name)
 	Emoji         string `protobuf:"bytes,4,opt,name=emoji,proto3" json:"emoji,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -2865,7 +2865,7 @@ type ReactionRemovedEvent struct {
 	RoomId string `protobuf:"bytes,2,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
 	// Event ID of the message the reaction was removed from (NanoID)
 	MessageEventId string `protobuf:"bytes,3,opt,name=message_event_id,json=messageEventId,proto3" json:"message_event_id,omitempty"`
-	// The emoji that was removed
+	// The emoji shortcode that was removed
 	Emoji         string `protobuf:"bytes,4,opt,name=emoji,proto3" json:"emoji,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -264,7 +264,7 @@ There is no `adminAuditLogEvents` subscription — audit events arrive through `
 | KV      | `SERVER_RBAC`                 | Roles, permissions, assignments (single flat tier — owner/admin/moderator/everyone) |
 | KV      | `SERVER_RUNTIME`              | Read status, mention tracking               |
 | KV      | `SERVER_BODIES`               | Message bodies (GDPR-compliant) + standalone attachment metadata records — TODO: rename → `SERVER_CONTENT` |
-| KV      | `SERVER_REACTIONS`            | Emoji reactions                             |
+| KV      | `SERVER_REACTIONS`            | Legacy emoji reactions source for boot migration only |
 | KV      | `SERVER_THREADS`              | Thread metadata (reply count, participants) |
 | Objects | `INSTANCE_ASSETS`             | Avatars, icons (bucket name retained from pre-rename) |
 | Objects | `ASSET_CACHE`                 | Cached resized images (optional, with TTL)  |
@@ -275,7 +275,7 @@ See [NATS Resource Inventory](#nats-resource-inventory) for detailed key pattern
 
 **Important:** Event publishing is best-effort for most operations. If event publishing fails for spaces, users, or rooms, the operation still succeeds because the KV store (source of truth) was updated successfully. Event publishing failures are logged but do not block operations.
 
-**Exception:** Message posting requires successful event publishing because messages are stored only in event streams (see Messages section below). If event publishing fails for a message, the entire post operation fails.
+**Exception:** Message and reaction writes require successful event publishing because they are stored in EVT and read through in-memory projections. If event publishing fails, the write fails.
 
 ### Consistency Model
 
@@ -337,8 +337,8 @@ Both files share `package chatto.core.v1` and generate into the same Go package.
 
 | Category                    | Storage    | Examples                                                    | Purpose                                                        |
 | --------------------------- | ---------- | ----------------------------------------------------------- | -------------------------------------------------------------- |
-| JetStream-stored (room)     | Stream     | RoomCreated, MessagePosted, UserJoinedRoom                  | Ordering guarantees, historical replay, audit trail            |
-| Room live-only              | NATS Core  | ReactionAdded, ReactionRemoved, MessageDeleted, MessageUpdated, PresenceChanged, UserTyping | Ephemeral room notifications where KV bucket is source of truth |
+| JetStream-stored (room)     | Stream     | RoomCreated, MessagePosted, ReactionAdded, ReactionRemoved, UserJoinedRoom | Ordering guarantees, historical replay, projection source of truth |
+| Room live-only              | NATS Core  | MessageDeleted, MessageUpdated, PresenceChanged, UserTyping | Ephemeral room notifications where another store/projection is source of truth |
 | Deployment live (user/space/config) | NATS Core  | UserCreated, SpaceUpdated, ConfigUpdated, MentionNotification, NotificationCreated | Cross-tab sync, notifications, server lifecycle |
 
 The distinction between stored and live-only events is based on how they're published (JetStream vs NATS Core). All variants share the single `corev1.Event` envelope; GraphQL exposes them through one `ServerEvent` wrapping union with the typed payloads as members of the `ServerEventType` union.
@@ -356,8 +356,8 @@ Every event eventually lands on `live.server.>` so a subscriber needs only one N
 
 1. **Primary Stream** (persistent):
    - `SERVER_EVENTS` (subjects `server.>`) holds room messages, thread replies, room meta lifecycle, and server-level member events. A stream-level `RePublish` config forwards every accepted message onto `live.server.>` (same suffix, new prefix). The republish fires after persistence, so a subscriber cannot observe an event that didn't durably store.
-2. **Direct Live Publish** (transient):
-   - Reactions, typing, message edits/deletes, user/space/config notifications publish directly via NATS Core to `live.server.>` — no stream storage. KV buckets are the source of truth for the state these reflect.
+2. **Direct Live Publish** (transient/mirror):
+   - Typing, legacy message edits/deletes, user/space/config notifications publish directly via NATS Core to `live.server.>` — no stream storage. EVT-backed messages and reactions also publish non-durable mirrors on `live.server.>` so the existing `myEvents` subscription path keeps one subject root while the durable source lives in EVT.
 
 The two paths share the same subject root; leaf tokens disambiguate (`.msg.{id}`, `.meta`, `.{verb}` for republished stream events; `.reaction_added`, `.user_typing`, `.profile_updated`, etc. for direct publishes). The `myEvents` GraphQL subscription is backed by one core stream (`StreamMyEvents`) that wraps a single `ChanSubscribe("live.server.>")` plus per-event authorization. There is no per-connection JetStream consumer.
 
@@ -366,7 +366,7 @@ The two paths share the same subject root; leaf tokens disambiguate (`.msg.{id}`
 | Stream                       | Wrapper          | Scope      | Description                                      |
 | ---------------------------- | ---------------- | ---------- | ------------------------------------------------ |
 | `SERVER_EVENTS`              | `corev1.Event`   | Server     | All JetStream-stored events for the legacy CRUD+log pattern; republishes onto `live.server.>` |
-| `EVT`                 | `corev1.Event`   | Server     | Event-sourcing log ([ADR-033](adr/ADR-033-event-sourced-state-with-projections.md) / [ADR-034](adr/ADR-034-single-event-stream.md)). Subjects `evt.{aggregateType}.{aggregateId}`; republishes onto `live.evt.>`. Currently fed by per-aggregate migrations ([ADR-035](adr/ADR-035-per-aggregate-phased-migration.md)); the room-membership aggregate is the first migrated. |
+| `EVT`                 | `corev1.Event`   | Server     | Event-sourcing log ([ADR-033](adr/ADR-033-event-sourced-state-with-projections.md) / [ADR-034](adr/ADR-034-single-event-stream.md)). Subjects `evt.{aggregateType}.{aggregateId}.{eventType}`; republishes onto `live.evt.>`. Currently fed by per-aggregate migrations ([ADR-035](adr/ADR-035-per-aggregate-phased-migration.md)); migrated aggregates include room membership/metadata, groups/layout, server config, messages/threads, and reactions. |
 | Live Events                  | `corev1.Event`   | Transient  | `live.server.>` (NATS Core, fed by `SERVER_EVENTS` republish + direct publishes) and `live.evt.>` (fed by `EVT` republish). The two roots coexist during the migration window. |
 
 **SERVER\_EVENTS subjects:**
@@ -412,7 +412,7 @@ Pattern: `live.server.{scope}.{subject}` — the single subscription root for re
 - `SERVER_EVENTS` RePublish (`server.>` → `live.server.>`): every accepted stream message is re-emitted onto a NATS Core subject after persistence. Subscribers don't need a JetStream consumer to receive room messages, thread replies, room meta, or server-level member events.
 - Direct NATS Core publishes (`publishLiveUserEvent()`, `publishLiveDeploymentEvent()`, `publishLiveConfigEvent()`, `publishLiveRoomEvent()`, `publishLiveMemberEvent()`): transient events with no stream storage.
 
-Subject leaf tokens never collide between the two paths — republished events end in `.msg.{id}` / `.meta` / `.{member_verb}`, direct publishes use event-type tokens (`.reaction_added`, `.user_typing`, `.profile_updated`, etc.).
+Subject leaf tokens never collide between the two paths — republished legacy events end in `.msg.{id}` / `.meta` / `.{member_verb}`, direct publishes use event-type tokens (`.reaction_added`, `.user_typing`, `.profile_updated`, etc.). For EVT-backed reactions, `.reaction_added` and `.reaction_removed` are live mirrors of durable `evt.room.{roomId}.reaction_*` events.
 
 **Deployment-wide live events** (`live.server.{user,config}.>`):
 
@@ -472,7 +472,7 @@ The unified `myEvents` GraphQL subscription is backed by a single core stream (`
 | `SERVER_RBAC`                 | File    | Yes      | Roles, permissions, assignments (single flat tier) |
 | `SERVER_RUNTIME`              | File    | Yes      | Read state, mention tracking                    |
 | `SERVER_BODIES`               | File    | Yes      | Message bodies (GDPR-compliant) + standalone attachment metadata records — TODO: rename → `SERVER_CONTENT` |
-| `SERVER_REACTIONS`            | File    | Yes      | Emoji reactions on messages                     |
+| `SERVER_REACTIONS`            | File    | Yes      | Legacy emoji reactions, read only by the EVT boot migration |
 | `SERVER_THREADS`              | File    | Yes      | Thread metadata (reply count, participants)     |
 | `NOTIFICATIONS`               | File    | Yes      | User notifications (90-day TTL)                 |
 | `AUTH_TOKENS`                 | File    | No       | Bearer auth tokens (configurable TTL, default 90d) |
@@ -598,7 +598,7 @@ Notes: The compound key format `{userId}.{eventId}` enables efficient prefix-bas
 | --------------------------------------- | ---------------------------------------------- |
 | `{messageEventId}.{emojiName}.{userId}` | Reaction tracking (empty value = reacted; value stores nanosecond timestamp for "added at" ordering) |
 
-Notes: Emoji stored as name (e.g., "thumbsup") for NATS KV key compatibility. Separated for load isolation (high-volume). Events are live-only (not stored in JetStream). KV bucket is source of truth. Keyed by event ID (not the volatile JetStream sequence) so reactions survive any future stream re-publishing.
+Notes: Legacy source for `MigrateReactionsToES`. Current reaction writes append durable `ReactionAdded` / `ReactionRemoved` events to `evt.room.{roomId}.reaction_added` and `evt.room.{roomId}.reaction_removed`; current reaction state is derived by an in-memory projection keyed by message event ID, emoji shortcode, and actor/user ID. The bucket remains so old deployments can be imported and will be removed in the later cleanup phase.
 
 **SERVER\_THREADS keys:**
 

--- a/docs/fdr/FDR-005-reactions.md
+++ b/docs/fdr/FDR-005-reactions.md
@@ -1,7 +1,7 @@
 # FDR-005: Reactions
 
 **Status:** Active
-**Last reviewed:** 2026-05-19
+**Last reviewed:** 2026-05-26
 
 ## Overview
 
@@ -17,11 +17,11 @@ Users can react to a message with emoji. Reactions are aggregated into pills sho
 
 ## Design Decisions
 
-### 1. Reactions key on event ID, not message body ID
+### 1. Reactions key on canonical message event ID
 
-**Decision:** A reaction is keyed by the event it was added to. A thread reply and its channel echo therefore accumulate reactions independently.
-**Why:** Reacting in the channel is a different social signal from reacting inside the thread. Combining them would mute one of those signals. See FDR-003.
-**Tradeoff:** The total reaction count across a reply-and-echo pair is split between two events. No single canonical number. Matches user intuition.
+**Decision:** A reaction is keyed by message event ID. When the user reacts to a channel echo of a thread reply, the backend canonicalizes the target to the original thread reply event ID, so the echo and original share reaction state.
+**Why:** This preserves current product behavior while reactions move into the event-sourced architecture. Both surfaces represent the same underlying reply, and a shared reaction count avoids divergent state between the channel and thread views.
+**Tradeoff:** The channel echo is not an independent social surface for reactions. If we want split reactions later, that should be a deliberate behavior change rather than a storage migration side effect.
 
 ### 2. Shortcodes, not raw Unicode
 
@@ -29,11 +29,11 @@ Users can react to a message with emoji. Reactions are aggregated into pills sho
 **Why:** NATS KV keys can't contain arbitrary Unicode, and storing the codepoint as a key would also lock us into one particular Unicode version's normalization rules. Shortcodes are stable, portable, and human-readable in storage.
 **Tradeoff:** Emojis outside the gemoji set can't be used. The set is large enough that this rarely matters.
 
-### 3. Live-only events, KV is source of truth
+### 3. Durable events, in-memory projection is source of truth
 
-**Decision:** Reaction add/remove changes publish as transient live events; the KV bucket holds the authoritative state. Live events just trigger the frontend to refetch.
-**Why:** A reaction event has no audit value (the current count is what matters; the history doesn't). Persisting them to JetStream would multiply event volume for no gain. See ADR-006 and ADR-012.
-**Tradeoff:** A client that misses the live event briefly shows stale counts until it next refetches. Acceptable given the visual stakes.
+**Decision:** Reaction add/remove changes append durable room-aggregate events to EVT (`evt.room.{roomId}.reaction_added` / `reaction_removed`). Current reaction state is derived by an in-memory projection keyed by message event ID, emoji shortcode, and actor/user ID. A non-durable `live.server.room...reaction_*` mirror is still published for the existing subscription pipeline.
+**Why:** Reactions are part of the event-sourcing migration tracked by #596. Keeping them in the room stream makes add/remove ordering explicit, gives replayable state, and removes the KV bucket from the hot read/write path.
+**Tradeoff:** The first projection version keeps all current reaction state in RAM. That is simple and correct; bounded or demand-loaded projections can follow once the rest of the event-sourcing architecture is in place and real access patterns are measured.
 
 ### 4. Quick-reaction recents are per-device, not per-user
 
@@ -47,5 +47,5 @@ Users can react to a message with emoji. Reactions are aggregated into pills sho
 
 ## Related
 
-- **ADRs:** ADR-006 (KV as source of truth, streams as audit logs), ADR-012 (two-tier real-time events), ADR-026 (event identity via NanoID)
+- **ADRs:** ADR-026 (event identity via NanoID), ADR-033 (event-sourced state with projections), ADR-034 (single event stream), ADR-035 (per-aggregate migration)
 - **FDRs:** FDR-003 (Thread Reply Echo)

--- a/proto/chatto/core/v1/event.proto
+++ b/proto/chatto/core/v1/event.proto
@@ -145,7 +145,7 @@ message Event {
     MessageUpdatedEvent message_updated = 1040;
     MessageDeletedEvent message_deleted = 1041;
 
-    // ----- Reactions (1050-1059) — KV is source of truth -----
+    // ----- Reactions (1050-1059) — EVT/projection is source of truth -----
     ReactionAddedEvent reaction_added = 1050;
     ReactionRemovedEvent reaction_removed = 1051;
 
@@ -611,7 +611,7 @@ message MessageDeletedEvent {
 }
 
 // ============================================================================
-// REACTION EVENTS (room-scoped — KV bucket is source of truth)
+// REACTION EVENTS (room-scoped, durable in EVT)
 // ============================================================================
 
 message ReactionAddedEvent {
@@ -624,7 +624,7 @@ message ReactionAddedEvent {
   // Event ID of the message being reacted to (NanoID)
   string message_event_id = 3;
 
-  // The emoji used for the reaction (Unicode emoji string)
+  // The emoji used for the reaction (shortcode name)
   string emoji = 4;
 }
 
@@ -638,7 +638,7 @@ message ReactionRemovedEvent {
   // Event ID of the message the reaction was removed from (NanoID)
   string message_event_id = 3;
 
-  // The emoji that was removed
+  // The emoji shortcode that was removed
   string emoji = 4;
 }
 


### PR DESCRIPTION
## Summary
- store reaction add/remove changes as durable room-aggregate EVT events
- add an in-memory reaction projection and cut reaction reads/writes over from SERVER_REACTIONS
- import legacy SERVER_REACTIONS state at boot and update architecture/FDR docs

## Tests
- mise x -- go test ./internal/core ./internal/migrations -timeout 120s
- mise test-cli
- mise test-frontend
- mise test-e2e (576 passed, 49 skipped, 3 flaky passed on retry)