### PR TITLE
Run CI for next PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: ci
 
 on:
   push:
-    branches: [main]
+    branches: [main, next]
     tags: ["*"]
   pull_request:
-    branches: [main]
+    branches: [main, next]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- include `next` in the active CI workflow push and pull_request branch filters
- keeps `main` coverage unchanged while allowing PRs targeting `next` to enqueue checks

## Tests
- git diff --check