### PR TITLE
feat(es): harden local rollout imports

### DIFF
--- a/.claude/rules/backup-restore.md
+++ b/.claude/rules/backup-restore.md
@@ -72,3 +72,24 @@ The export file format is version 2: an age-encrypted JSON payload containing a 
 - `--conflict=error` (default): Fail if any stream exists. Safe for fresh restores.
 - `--conflict=skip`: Skip existing streams. Useful for partial restore.
 - `--conflict=overwrite`: Delete and recreate. Destructive but complete.
+
+## Local ES Rollout Dry Run
+
+To test the event-sourcing upgrade against a production/community backup:
+
+1. Stop the local `chatto run` process for the target data directory.
+2. Restore the backup into that local data directory with `chatto restore --conflict=overwrite --config <local-chatto.toml> <backup>`.
+3. If the backup came from a clustered server, restore recreates streams with the target config's `nats.replicas` value. Embedded/local restores should use the default `1`.
+4. Restore/import encryption keys separately if the backup did not include `KV_ENCRYPTION_KEYS` and you need to read message bodies during smoke testing.
+5. Start the upgraded build normally with ES boot verification enabled:
+   `CHATTO_CORE_ES_BOOT_VERIFY=true chatto run --config <local-chatto.toml>`.
+6. Watch the boot logs for:
+   - `... ES migration: seeded ...` lines from each importer.
+   - `ES boot verification summary`.
+   - `ES boot verification event counts`.
+   - `ES boot verification warning` / `ES boot verification problem`.
+   - `ES boot verification passed` when no count mismatch was found.
+
+Do not run a separate verifier process against the same embedded NATS data
+directory while `chatto run` is active. Embedded NATS is owned by one
+process at a time; verification belongs in the normal boot logs.

--- a/cli/cmd/restore.go
+++ b/cli/cmd/restore.go
@@ -12,6 +12,7 @@ import (
 	"filippo.io/age"
 	"github.com/charmbracelet/log"
 	"github.com/nats-io/jsm.go"
+	"github.com/nats-io/jsm.go/api"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
@@ -171,6 +172,7 @@ func runRestore(cmd *cobra.Command, args []string) {
 
 	// Restore each stream from the manifest
 	streamsDir := filepath.Join(backupDir, "streams")
+	targetReplicas := cfg.NATS.ReplicasOrDefault()
 	var restored, skipped, failed int
 
 	for i, streamInfo := range manifest.Streams {
@@ -212,7 +214,23 @@ func runRestore(cmd *cobra.Command, args []string) {
 
 		log.Info(fmt.Sprintf("%s Restoring %s (%s, %d messages)", prefix, streamInfo.Name, streamInfo.Type, streamInfo.Messages))
 
-		_, _, err := mgr.RestoreSnapshotFromDirectory(ctx, streamInfo.Name, streamDir)
+		var restoreOpts []jsm.SnapshotOption
+		override, err := restoreConfigForTarget(streamDir, streamInfo.Name, targetReplicas)
+		if err != nil {
+			log.Error("Failed to read restore metadata", "name", streamInfo.Name, "error", err)
+			failed++
+			continue
+		}
+		if override != nil {
+			log.Info("Adjusting stream replicas for restore target",
+				"name", streamInfo.Name,
+				"backup_replicas", override.backupReplicas,
+				"restore_replicas", override.config.Replicas,
+			)
+			restoreOpts = append(restoreOpts, jsm.RestoreConfiguration(override.config))
+		}
+
+		_, _, err = mgr.RestoreSnapshotFromDirectory(ctx, streamInfo.Name, streamDir, restoreOpts...)
 		if err != nil {
 			log.Error("Failed to restore stream", "name", streamInfo.Name, "error", err)
 			failed++
@@ -243,6 +261,42 @@ func runRestore(cmd *cobra.Command, args []string) {
 			"Encrypted message bodies cannot be decrypted without them — restore your " +
 			"encryption keys separately, or recreate the backup with --include-keys.")
 	}
+}
+
+type restoreConfigOverride struct {
+	config         api.StreamConfig
+	backupReplicas int
+}
+
+func restoreConfigForTarget(streamDir, streamName string, targetReplicas int) (*restoreConfigOverride, error) {
+	if targetReplicas <= 0 {
+		targetReplicas = 1
+	}
+
+	metaPath := filepath.Join(streamDir, "backup.json")
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var req api.JSApiStreamRestoreRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return nil, err
+	}
+	if req.Config.Name != streamName {
+		return nil, fmt.Errorf("snapshot metadata stream name %q does not match manifest name %q", req.Config.Name, streamName)
+	}
+
+	if req.Config.Replicas == targetReplicas {
+		return nil, nil
+	}
+
+	backupReplicas := req.Config.Replicas
+	req.Config.Replicas = targetReplicas
+	return &restoreConfigOverride{
+		config:         req.Config,
+		backupReplicas: backupReplicas,
+	}, nil
 }
 
 // manifestIncludesEncryptionKeys reports whether KV_ENCRYPTION_KEYS was actually

--- a/cli/cmd/restore_test.go
+++ b/cli/cmd/restore_test.go
@@ -1,6 +1,13 @@
 package cmd
 
-import "testing"
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nats-io/jsm.go/api"
+)
 
 func TestManifestIncludesEncryptionKeys(t *testing.T) {
 	tests := []struct {
@@ -48,5 +55,58 @@ func TestManifestIncludesEncryptionKeys(t *testing.T) {
 				t.Errorf("manifestIncludesEncryptionKeys() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestRestoreConfigForTargetOverridesReplicas(t *testing.T) {
+	streamDir := t.TempDir()
+	writeRestoreMetadata(t, streamDir, api.JSApiStreamRestoreRequest{
+		Config: api.StreamConfig{
+			Name:     "KV_INSTANCE",
+			Replicas: 3,
+		},
+	})
+
+	override, err := restoreConfigForTarget(streamDir, "KV_INSTANCE", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if override == nil {
+		t.Fatal("override = nil, want replica override")
+	}
+	if override.backupReplicas != 3 {
+		t.Errorf("backupReplicas = %d, want 3", override.backupReplicas)
+	}
+	if override.config.Replicas != 1 {
+		t.Errorf("config.Replicas = %d, want 1", override.config.Replicas)
+	}
+}
+
+func TestRestoreConfigForTargetKeepsMatchingReplicas(t *testing.T) {
+	streamDir := t.TempDir()
+	writeRestoreMetadata(t, streamDir, api.JSApiStreamRestoreRequest{
+		Config: api.StreamConfig{
+			Name:     "KV_INSTANCE",
+			Replicas: 1,
+		},
+	})
+
+	override, err := restoreConfigForTarget(streamDir, "KV_INSTANCE", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if override != nil {
+		t.Fatalf("override = %#v, want nil", override)
+	}
+}
+
+func writeRestoreMetadata(t *testing.T, streamDir string, req api.JSApiStreamRestoreRequest) {
+	t.Helper()
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(streamDir, "backup.json"), data, 0644); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -160,6 +160,7 @@ type AssetsConfig struct {
 // CoreConfig contains settings for the Chatto core service.
 type CoreConfig struct {
 	Assets       AssetsConfig  `toml:"assets"`
+	ESBootVerify bool          `toml:"es_boot_verify,commented" env:"CHATTO_CORE_ES_BOOT_VERIFY" comment:"Log event-sourcing import/projection verification during boot. Intended for local rollout dry-runs; scans EVT and legacy stores."`
 	AuthTokenTTL time.Duration `toml:"-" env:"-"` // Set by caller from AuthConfig.TokenTTLOrDefault()
 	Replicas     int           `toml:"-" env:"-"` // Set by caller from NATSConfig.ReplicasOrDefault()
 	Limits       LimitsConfig  `toml:"-" env:"-"` // Set by caller from ChattoConfig.Limits

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -200,6 +200,12 @@ func (c *ChattoCore) Run(ctx context.Context) error {
 		if err := c.ensureChannelRoomsAreInAGroup(gctx); err != nil {
 			return fmt.Errorf("ensure channel rooms in a group: %w", err)
 		}
+		if c.config.ESBootVerify {
+			if err := c.WaitForProjectionsCurrent(gctx); err != nil {
+				return fmt.Errorf("wait for projections current: %w", err)
+			}
+			c.logESBootVerification(gctx)
+		}
 		close(c.bootDone)
 		return nil
 	})
@@ -238,6 +244,18 @@ func (c *ChattoCore) WaitForBoot(ctx context.Context) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+// WaitForProjectionsCurrent blocks until every registered projection has
+// applied the latest stream message matching its filters as of this call.
+// Intended for boot/import diagnostics, not hot request paths.
+func (c *ChattoCore) WaitForProjectionsCurrent(ctx context.Context) error {
+	for _, p := range c.projectors {
+		if err := p.WaitForCurrent(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // waitForProjectorsStarted polls AllProjectorsStarted with a short

--- a/cli/internal/core/es_boot_verification.go
+++ b/cli/internal/core/es_boot_verification.go
@@ -1,0 +1,352 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"google.golang.org/protobuf/proto"
+
+	"hmans.de/chatto/internal/events"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+type esBootVerificationReport struct {
+	legacy       esLegacyCounts
+	projected    esProjectedCounts
+	eventCounts  map[string]int
+	decodeErrors int
+	warnings     []string
+	problems     []string
+}
+
+type esLegacyCounts struct {
+	rooms               int
+	memberships         int
+	roomGroups          int
+	roomLayoutPresent   bool
+	serverConfigPresent bool
+	messages            int
+	reactions           int
+	encryptionKeys      int
+}
+
+type esProjectedCounts struct {
+	rooms                  int
+	channelRooms           int
+	dmRooms                int
+	membershipRooms        int
+	memberships            int
+	roomGroups             int
+	roomLayoutGroups       int
+	serverConfigConfigured bool
+	timelineRooms          int
+	timelineEntries        int
+	messagePosts           int
+	threads                int
+	threadEntries          int
+	threadReplies          int
+	reactionMessages       int
+	activeReactions        int
+}
+
+// logESBootVerification emits a structured summary of the ES import and
+// projection state after the normal chatto run boot path has started
+// projectors. It is intentionally part of the main process: embedded-NATS
+// deployments cannot safely run a second verifier process over the same data
+// directory.
+func (c *ChattoCore) logESBootVerification(ctx context.Context) {
+	startedAt := time.Now()
+	report, err := c.buildESBootVerificationReport(ctx)
+	if err != nil {
+		c.logger.Warn("ES boot verification failed to build report", "error", err)
+		return
+	}
+
+	c.evaluateESBootVerificationReport(report)
+	c.logger.Info(
+		"ES boot verification summary",
+		"legacy_rooms", report.legacy.rooms,
+		"projected_rooms", report.projected.rooms,
+		"legacy_memberships", report.legacy.memberships,
+		"projected_memberships", report.projected.memberships,
+		"legacy_room_groups", report.legacy.roomGroups,
+		"projected_room_groups", report.projected.roomGroups,
+		"legacy_messages", report.legacy.messages,
+		"projected_message_posts", report.projected.messagePosts,
+		"legacy_reactions", report.legacy.reactions,
+		"projected_active_reactions", report.projected.activeReactions,
+		"server_config_legacy", report.legacy.serverConfigPresent,
+		"server_config_projected", report.projected.serverConfigConfigured,
+		"room_layout_legacy", report.legacy.roomLayoutPresent,
+		"projected_room_layout_groups", report.projected.roomLayoutGroups,
+		"evt_decode_errors", report.decodeErrors,
+		"problem_count", len(report.problems),
+		"warning_count", len(report.warnings),
+		"duration_ms", time.Since(startedAt).Milliseconds(),
+	)
+
+	c.logger.Info(
+		"ES boot verification projection detail",
+		"channel_rooms", report.projected.channelRooms,
+		"dm_rooms", report.projected.dmRooms,
+		"membership_rooms", report.projected.membershipRooms,
+		"timeline_rooms", report.projected.timelineRooms,
+		"timeline_entries", report.projected.timelineEntries,
+		"threads", report.projected.threads,
+		"thread_entries", report.projected.threadEntries,
+		"thread_replies", report.projected.threadReplies,
+		"reaction_messages", report.projected.reactionMessages,
+	)
+
+	c.logESEventCounts(report.eventCounts)
+	for _, warning := range report.warnings {
+		c.logger.Warn("ES boot verification warning", "warning", warning)
+	}
+	for _, problem := range report.problems {
+		c.logger.Warn("ES boot verification problem", "problem", problem)
+	}
+	if len(report.problems) == 0 {
+		c.logger.Info("ES boot verification passed")
+	}
+}
+
+func (c *ChattoCore) buildESBootVerificationReport(ctx context.Context) (*esBootVerificationReport, error) {
+	eventCounts, decodeErrors, err := c.countEVTEvents(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("count EVT events: %w", err)
+	}
+	legacy, warnings, err := c.collectLegacyESCounts(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &esBootVerificationReport{
+		legacy:       legacy,
+		projected:    c.collectProjectedESCounts(),
+		eventCounts:  eventCounts,
+		decodeErrors: decodeErrors,
+		warnings:     warnings,
+	}, nil
+}
+
+func (c *ChattoCore) collectLegacyESCounts(ctx context.Context) (esLegacyCounts, []string, error) {
+	var counts esLegacyCounts
+	var warnings []string
+	var err error
+
+	counts.rooms, err = countKVKeys(ctx, c.storage.serverConfigKV, "room.channel.*", "room.dm.*")
+	if err != nil {
+		return counts, warnings, fmt.Errorf("count legacy rooms: %w", err)
+	}
+	counts.memberships, err = countKVKeys(ctx, c.storage.serverConfigKV, "room_membership.>")
+	if err != nil {
+		return counts, warnings, fmt.Errorf("count legacy memberships: %w", err)
+	}
+	counts.roomGroups, err = countKVKeys(ctx, c.storage.serverConfigKV, "room_group.*")
+	if err != nil {
+		return counts, warnings, fmt.Errorf("count legacy room groups: %w", err)
+	}
+	counts.roomLayoutPresent, err = kvKeyExists(ctx, c.storage.serverConfigKV, "room_layout")
+	if err != nil {
+		return counts, warnings, fmt.Errorf("check legacy room layout: %w", err)
+	}
+	counts.serverConfigPresent, err = kvKeyExists(ctx, c.storage.runtimeConfigKV, "config.instance")
+	if err != nil {
+		return counts, warnings, fmt.Errorf("check legacy server config: %w", err)
+	}
+	counts.messages, err = countStreamMessages(ctx, c.storage.serverEventsStream, []string{"server.room.*.*.msg.>"})
+	if err != nil {
+		return counts, warnings, fmt.Errorf("count legacy messages: %w", err)
+	}
+	counts.reactions, err = countKVKeys(ctx, c.storage.serverReactionsKV)
+	if err != nil {
+		return counts, warnings, fmt.Errorf("count legacy reactions: %w", err)
+	}
+	counts.encryptionKeys, err = countKVKeys(ctx, c.storage.encryptionKV)
+	if err != nil {
+		return counts, warnings, fmt.Errorf("count encryption keys: %w", err)
+	}
+	if counts.encryptionKeys == 0 {
+		warnings = append(warnings, "ENCRYPTION_KEYS is empty; encrypted message bodies will not decrypt in local smoke tests")
+	}
+	return counts, warnings, nil
+}
+
+func (c *ChattoCore) collectProjectedESCounts() esProjectedCounts {
+	membershipRooms, memberships := c.RoomMembership.Stats()
+	timelineRooms, timelineEntries, messagePosts := c.RoomTimeline.Stats()
+	threads, threadEntries, threadReplies := c.Threads.Stats()
+	reactionMessages, activeReactions := c.Reactions.Stats()
+	_, serverConfigConfigured := c.ServerConfig.Get()
+
+	return esProjectedCounts{
+		rooms:                  c.RoomCatalog.Count(),
+		channelRooms:           len(c.RoomCatalog.AllByKind(corev1.RoomKind_ROOM_KIND_CHANNEL)),
+		dmRooms:                len(c.RoomCatalog.AllByKind(corev1.RoomKind_ROOM_KIND_DM)),
+		membershipRooms:        membershipRooms,
+		memberships:            memberships,
+		roomGroups:             c.RoomGroups.Count(),
+		roomLayoutGroups:       len(c.RoomLayout.Order()),
+		serverConfigConfigured: serverConfigConfigured,
+		timelineRooms:          timelineRooms,
+		timelineEntries:        timelineEntries,
+		messagePosts:           messagePosts,
+		threads:                threads,
+		threadEntries:          threadEntries,
+		threadReplies:          threadReplies,
+		reactionMessages:       reactionMessages,
+		activeReactions:        activeReactions,
+	}
+}
+
+func (c *ChattoCore) evaluateESBootVerificationReport(r *esBootVerificationReport) {
+	compareAtLeast := func(name string, legacy, projected int) {
+		if projected < legacy {
+			r.problems = append(r.problems, fmt.Sprintf("%s: projected %d < legacy %d", name, projected, legacy))
+		}
+	}
+	compareAtLeast("rooms", r.legacy.rooms, r.projected.rooms)
+	compareAtLeast("memberships", r.legacy.memberships, r.projected.memberships)
+	compareAtLeast("room groups", r.legacy.roomGroups, r.projected.roomGroups)
+	compareAtLeast("messages", r.legacy.messages, r.projected.messagePosts)
+	compareAtLeast("reactions", r.legacy.reactions, r.projected.activeReactions)
+
+	if r.legacy.serverConfigPresent && !r.projected.serverConfigConfigured {
+		r.problems = append(r.problems, "server config: legacy config.instance exists but projection is not configured")
+	}
+	if r.legacy.roomLayoutPresent && r.projected.roomGroups > 0 && r.projected.roomLayoutGroups == 0 {
+		r.problems = append(r.problems, "room layout: legacy room_layout exists but projected layout ordering is empty")
+	}
+	if r.decodeErrors > 0 {
+		r.problems = append(r.problems, fmt.Sprintf("EVT contains %d decode errors", r.decodeErrors))
+	}
+	sort.Strings(r.problems)
+}
+
+func (c *ChattoCore) countEVTEvents(ctx context.Context) (map[string]int, int, error) {
+	consumer, err := c.storage.serverEvtStream.CreateConsumer(ctx, jetstream.ConsumerConfig{
+		FilterSubjects:    []string{"evt.>"},
+		DeliverPolicy:     jetstream.DeliverAllPolicy,
+		AckPolicy:         jetstream.AckNonePolicy,
+		MemoryStorage:     true,
+		InactiveThreshold: 30 * time.Second,
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	defer c.storage.serverEvtStream.DeleteConsumer(context.Background(), consumer.CachedInfo().Name)
+
+	info, err := consumer.Info(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	remaining := int(info.NumPending)
+	counts := make(map[string]int)
+	var decodeErrors int
+	for remaining > 0 {
+		batchSize := remaining
+		if batchSize > 500 {
+			batchSize = 500
+		}
+		msgs, err := consumer.Fetch(batchSize, jetstream.FetchMaxWait(10*time.Second))
+		if err != nil {
+			if errors.Is(err, jetstream.ErrNoMessages) {
+				break
+			}
+			return nil, 0, err
+		}
+		fetched := 0
+		for msg := range msgs.Messages() {
+			fetched++
+			var event corev1.Event
+			if err := proto.Unmarshal(msg.Data(), &event); err != nil {
+				decodeErrors++
+				continue
+			}
+			eventType := events.EventTypeOf(&event)
+			if eventType == "" {
+				eventType = "unknown"
+			}
+			counts[eventType]++
+		}
+		if fetched == 0 {
+			break
+		}
+		remaining -= fetched
+	}
+	return counts, decodeErrors, nil
+}
+
+func (c *ChattoCore) logESEventCounts(counts map[string]int) {
+	if len(counts) == 0 {
+		c.logger.Info("ES boot verification event counts", "counts", "none")
+		return
+	}
+	keys := make([]string, 0, len(counts))
+	for key := range counts {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, key+"="+fmt.Sprint(counts[key]))
+	}
+	c.logger.Info("ES boot verification event counts", "counts", strings.Join(parts, " "))
+}
+
+func countKVKeys(ctx context.Context, kv jetstream.KeyValue, filters ...string) (int, error) {
+	var lister jetstream.KeyLister
+	var err error
+	if len(filters) == 0 {
+		lister, err = kv.ListKeys(ctx)
+	} else {
+		lister, err = kv.ListKeysFiltered(ctx, filters...)
+	}
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	var count int
+	for range lister.Keys() {
+		count++
+	}
+	return count, nil
+}
+
+func kvKeyExists(ctx context.Context, kv jetstream.KeyValue, key string) (bool, error) {
+	_, err := kv.Get(ctx, key)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, jetstream.ErrKeyNotFound) {
+		return false, nil
+	}
+	return false, err
+}
+
+func countStreamMessages(ctx context.Context, stream jetstream.Stream, filters []string) (int, error) {
+	consumer, err := stream.CreateConsumer(ctx, jetstream.ConsumerConfig{
+		FilterSubjects:    filters,
+		DeliverPolicy:     jetstream.DeliverAllPolicy,
+		AckPolicy:         jetstream.AckNonePolicy,
+		MemoryStorage:     true,
+		InactiveThreshold: 30 * time.Second,
+	})
+	if err != nil {
+		return 0, err
+	}
+	defer stream.DeleteConsumer(context.Background(), consumer.CachedInfo().Name)
+
+	info, err := consumer.Info(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return int(info.NumPending), nil
+}

--- a/cli/internal/core/es_boot_verification_test.go
+++ b/cli/internal/core/es_boot_verification_test.go
@@ -1,0 +1,75 @@
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEvaluateESBootVerificationReportDetectsCountRegressions(t *testing.T) {
+	report := &esBootVerificationReport{
+		legacy: esLegacyCounts{
+			rooms:               3,
+			memberships:         7,
+			roomGroups:          2,
+			roomLayoutPresent:   true,
+			serverConfigPresent: true,
+			messages:            9,
+			reactions:           4,
+		},
+		projected: esProjectedCounts{
+			rooms:                  3,
+			memberships:            6,
+			roomGroups:             2,
+			roomLayoutGroups:       0,
+			serverConfigConfigured: false,
+			messagePosts:           8,
+			activeReactions:        4,
+		},
+		decodeErrors: 1,
+	}
+
+	var core ChattoCore
+	core.evaluateESBootVerificationReport(report)
+
+	assertProblemContains(t, report.problems, "memberships")
+	assertProblemContains(t, report.problems, "messages")
+	assertProblemContains(t, report.problems, "server config")
+	assertProblemContains(t, report.problems, "room layout")
+	assertProblemContains(t, report.problems, "decode errors")
+}
+
+func TestEvaluateESBootVerificationReportAllowsProjectedSuperset(t *testing.T) {
+	report := &esBootVerificationReport{
+		legacy: esLegacyCounts{
+			rooms:       2,
+			memberships: 3,
+			roomGroups:  1,
+			messages:    5,
+			reactions:   1,
+		},
+		projected: esProjectedCounts{
+			rooms:           3,
+			memberships:     4,
+			roomGroups:      2,
+			messagePosts:    6,
+			activeReactions: 1,
+		},
+	}
+
+	var core ChattoCore
+	core.evaluateESBootVerificationReport(report)
+
+	if len(report.problems) != 0 {
+		t.Fatalf("problems = %v, want none", report.problems)
+	}
+}
+
+func assertProblemContains(t *testing.T, problems []string, needle string) {
+	t.Helper()
+	for _, problem := range problems {
+		if strings.Contains(problem, needle) {
+			return
+		}
+	}
+	t.Fatalf("problems %v did not contain %q", problems, needle)
+}

--- a/cli/internal/core/reaction_projection.go
+++ b/cli/internal/core/reaction_projection.go
@@ -142,6 +142,19 @@ func (p *ReactionProjection) ReactionsBatch(messageEventIDs []string) map[string
 	return result
 }
 
+// Stats returns aggregate counts useful for import/rollout diagnostics.
+func (p *ReactionProjection) Stats() (messages int, activeReactions int) {
+	p.RLock()
+	defer p.RUnlock()
+	messages = len(p.byMessage)
+	for _, byEmoji := range p.byMessage {
+		for _, byUser := range byEmoji {
+			activeReactions += len(byUser)
+		}
+	}
+	return messages, activeReactions
+}
+
 func reactionSummariesForMessage(byEmoji map[string]map[string]int64) []ReactionSummary {
 	if len(byEmoji) == 0 {
 		return nil

--- a/cli/internal/core/room_timeline_projection.go
+++ b/cli/internal/core/room_timeline_projection.go
@@ -174,6 +174,22 @@ func (p *RoomTimelineProjection) RoomEventCount(roomID string) int {
 	return len(p.byRoom[roomID])
 }
 
+// Stats returns aggregate counts useful for import/rollout diagnostics.
+func (p *RoomTimelineProjection) Stats() (rooms int, entries int, messagePosts int) {
+	p.RLock()
+	defer p.RUnlock()
+	rooms = len(p.byRoom)
+	for _, roomEntries := range p.byRoom {
+		entries += len(roomEntries)
+		for _, entry := range roomEntries {
+			if entry != nil && entry.Event.GetMessagePosted() != nil {
+				messagePosts++
+			}
+		}
+	}
+	return rooms, entries, messagePosts
+}
+
 // Get returns a single timeline entry by its envelope id, or
 // (nil, false) if no such event has been projected.
 func (p *RoomTimelineProjection) Get(eventID string) (*TimelineEntry, bool) {

--- a/cli/internal/core/thread_projection.go
+++ b/cli/internal/core/thread_projection.go
@@ -148,3 +148,19 @@ func (p *ThreadProjection) ThreadCount() int {
 	defer p.RUnlock()
 	return len(p.byThread)
 }
+
+// Stats returns aggregate counts useful for import/rollout diagnostics.
+func (p *ThreadProjection) Stats() (threads int, entries int, replies int) {
+	p.RLock()
+	defer p.RUnlock()
+	threads = len(p.byThread)
+	for _, threadEntries := range p.byThread {
+		entries += len(threadEntries)
+		for _, entry := range threadEntries {
+			if entry != nil && entry.Event.GetMessagePosted() != nil {
+				replies++
+			}
+		}
+	}
+	return threads, entries, replies
+}

--- a/cli/internal/events/projector.go
+++ b/cli/internal/events/projector.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -193,6 +194,30 @@ func (p *Projector) WaitForSeq(ctx context.Context, seq uint64) error {
 		p.mu.Unlock()
 		return ctx.Err()
 	}
+}
+
+// WaitForCurrent blocks until the projection has applied the latest
+// stream message currently matching its subject filters. It is intended
+// for diagnostics and boot verification: call it after the projector is
+// running to ensure projection reads reflect the stream as of this call.
+func (p *Projector) WaitForCurrent(ctx context.Context) error {
+	var target uint64
+	for _, subject := range p.proj.Subjects() {
+		msg, err := p.stream.GetLastMsgForSubject(ctx, subject)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrMsgNotFound) {
+				continue
+			}
+			return fmt.Errorf("last msg for subject %q: %w", subject, err)
+		}
+		if msg.Sequence > target {
+			target = msg.Sequence
+		}
+	}
+	if target == 0 {
+		return nil
+	}
+	return p.WaitForSeq(ctx, target)
 }
 
 // advance updates lastSeq and releases any waiters that have now been

--- a/cli/internal/events/publisher.go
+++ b/cli/internal/events/publisher.go
@@ -382,6 +382,81 @@ func (p *Publisher) LastSubjectSeq(ctx context.Context, subjectOrFilter string) 
 	return p.lastSubjectSeq(ctx, subjectOrFilter)
 }
 
+// SubjectEvents returns events currently published on a subject, in stream
+// order, plus the stream sequence of the last matching event. Migration code
+// uses this to resume imports without duplicating events after a crash or
+// failed boot.
+func (p *Publisher) SubjectEvents(ctx context.Context, subject string) ([]*corev1.Event, uint64, error) {
+	consumer, err := p.stream.CreateConsumer(ctx, jetstream.ConsumerConfig{
+		FilterSubjects:    []string{subject},
+		DeliverPolicy:     jetstream.DeliverAllPolicy,
+		AckPolicy:         jetstream.AckNonePolicy,
+		MemoryStorage:     true,
+		InactiveThreshold: 30 * time.Second,
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	defer p.stream.DeleteConsumer(context.Background(), consumer.CachedInfo().Name)
+
+	info, err := consumer.Info(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	remaining := int(info.NumPending)
+	events := make([]*corev1.Event, 0, remaining)
+	var lastSeq uint64
+	for remaining > 0 {
+		batchSize := remaining
+		if batchSize > 500 {
+			batchSize = 500
+		}
+		msgs, err := consumer.Fetch(batchSize, jetstream.FetchMaxWait(10*time.Second))
+		if err != nil {
+			if errors.Is(err, jetstream.ErrNoMessages) {
+				break
+			}
+			return nil, 0, err
+		}
+
+		fetched := 0
+		for msg := range msgs.Messages() {
+			fetched++
+			meta, err := msg.Metadata()
+			if err != nil {
+				return nil, 0, fmt.Errorf("message metadata: %w", err)
+			}
+			lastSeq = meta.Sequence.Stream
+
+			var event corev1.Event
+			if err := proto.Unmarshal(msg.Data(), &event); err != nil {
+				return nil, 0, fmt.Errorf("unmarshal event at seq %d: %w", lastSeq, err)
+			}
+			events = append(events, &event)
+		}
+		if fetched == 0 {
+			break
+		}
+		remaining -= fetched
+	}
+	return events, lastSeq, nil
+}
+
+// SubjectEventIDs returns the envelope IDs currently published on a subject,
+// in stream order, plus the stream sequence of the last matching event.
+func (p *Publisher) SubjectEventIDs(ctx context.Context, subject string) ([]string, uint64, error) {
+	events, lastSeq, err := p.SubjectEvents(ctx, subject)
+	if err != nil {
+		return nil, 0, err
+	}
+	ids := make([]string, 0, len(events))
+	for _, event := range events {
+		ids = append(ids, event.GetId())
+	}
+	return ids, lastSeq, nil
+}
+
 // lastSubjectSeq returns the current last sequence for a subject (or
 // wildcard subject filter), or 0 if no matching messages exist.
 func (p *Publisher) lastSubjectSeq(ctx context.Context, subject string) (uint64, error) {

--- a/cli/internal/migrations/messages_es.go
+++ b/cli/internal/migrations/messages_es.go
@@ -55,15 +55,13 @@ import (
 //
 // # Idempotency and crash-safety
 //
-// Per-room: all migrated message events for a room are emitted as a
-// single atomic AppendBatch. The first entry carries subject-level OCC
-// against `evt.room.{R}.message_posted` with ExpectedSeq=0; subsequent
-// entries in the same batch do not carry dependent OCC because JetStream
-// evaluates every batch entry against the committed pre-batch state.
-// On re-run, the first entry conflicts and the whole room is skipped.
-// If the process crashes while importing a room, the batch either lands
-// completely or not at all, so a replay cannot leave a partially
-// imported room behind.
+// Per-room: migrated message events are emitted in bounded atomic
+// chunks. Each chunk's first entry carries subject-level OCC against
+// `evt.room.{R}.message_posted`; subsequent entries in the same chunk do
+// not carry dependent OCC because JetStream evaluates every batch entry
+// against the committed pre-batch state. On re-run, the importer reads
+// existing event IDs for the subject, verifies they match the legacy
+// prefix, and resumes at the first missing event.
 //
 // # When this can be removed
 //
@@ -219,17 +217,13 @@ func MigrateMessagesToES(
 		if len(batch.entries) == 0 {
 			continue
 		}
-		batch.entries[0].HasOCC = true
-		batch.entries[0].ExpectedSeq = 0
 
-		if _, err := publisher.AppendBatch(ctx, batch.entries); err != nil {
-			if errors.Is(err, events.ErrConflict) {
-				skipped += len(batch.entries)
-				continue
-			}
+		roomImported, roomSkipped, err := publishMessageMigrationRoom(ctx, publisher, roomID, batch.entries, logger)
+		if err != nil {
 			return fmt.Errorf("publish migrated messages (room=%s): %w", roomID, err)
 		}
-		imported += len(batch.entries)
+		imported += roomImported
+		skipped += roomSkipped
 	}
 
 	if imported > 0 || skipped > 0 {
@@ -243,6 +237,73 @@ func MigrateMessagesToES(
 		)
 	}
 	return nil
+}
+
+const messageMigrationBatchSize = 500
+
+func publishMessageMigrationRoom(
+	ctx context.Context,
+	publisher *events.Publisher,
+	roomID string,
+	entries []events.BatchEntry,
+	logger *log.Logger,
+) (imported int, skipped int, err error) {
+	if len(entries) == 0 {
+		return 0, 0, nil
+	}
+
+	subject := entries[0].Subject
+	existingIDs, expectedSeq, err := publisher.SubjectEventIDs(ctx, subject)
+	if err != nil {
+		return 0, 0, fmt.Errorf("read existing message events: %w", err)
+	}
+	if len(existingIDs) > len(entries) {
+		logger.Warn(
+			"messages ES migration: skipping room with more projected messages than legacy messages",
+			"room_id", roomID,
+			"existing_messages", len(existingIDs),
+			"legacy_messages", len(entries),
+		)
+		return 0, len(entries), nil
+	}
+	for i, existingID := range existingIDs {
+		if entries[i].Event.GetId() != existingID {
+			logger.Warn(
+				"messages ES migration: skipping room with non-matching existing message prefix",
+				"room_id", roomID,
+				"index", i,
+				"existing_event_id", existingID,
+				"legacy_event_id", entries[i].Event.GetId(),
+			)
+			return 0, len(entries), nil
+		}
+	}
+	if len(existingIDs) == len(entries) {
+		return 0, len(entries), nil
+	}
+
+	pending := entries[len(existingIDs):]
+	for start := 0; start < len(pending); start += messageMigrationBatchSize {
+		end := start + messageMigrationBatchSize
+		if end > len(pending) {
+			end = len(pending)
+		}
+
+		chunk := append([]events.BatchEntry(nil), pending[start:end]...)
+		chunk[0].HasOCC = true
+		chunk[0].ExpectedSeq = expectedSeq
+
+		seqs, err := publisher.AppendBatch(ctx, chunk)
+		if err != nil {
+			if errors.Is(err, events.ErrConflict) {
+				return imported, skipped, fmt.Errorf("message chunk OCC conflict after resume point %d: %w", len(existingIDs)+imported, err)
+			}
+			return imported, skipped, err
+		}
+		expectedSeq = seqs[len(seqs)-1]
+		imported += len(chunk)
+	}
+	return imported, len(existingIDs), nil
 }
 
 // preserveTimestamp returns the original timestamp if non-nil, or a

--- a/cli/internal/migrations/messages_es_test.go
+++ b/cli/internal/migrations/messages_es_test.go
@@ -376,7 +376,7 @@ func TestMigrateMessagesToES_ReplayIsIdempotent(t *testing.T) {
 	}
 }
 
-func TestMigrateMessagesToES_ConflictSkipsRoomAtomically(t *testing.T) {
+func TestMigrateMessagesToES_ResumesPartiallyImportedRoom(t *testing.T) {
 	rig := setupMessagesRig(t)
 	rig.putBody(t, "U1.M1-BODY", &corev1.MessageBody{AuthorId: "U1", EncryptedBody: []byte("one")})
 	rig.putBody(t, "U1.M2-BODY", &corev1.MessageBody{AuthorId: "U1", EncryptedBody: []byte("two")})
@@ -398,8 +398,8 @@ func TestMigrateMessagesToES_ConflictSkipsRoomAtomically(t *testing.T) {
 		},
 	})
 
-	// Simulate a previously imported room. The migration should conflict
-	// on the first batch entry and skip the whole room, not append M2.
+	// Simulate a previously imported first chunk. The migration should
+	// verify the existing event ID prefix and resume at M2.
 	if _, err := rig.publisher.Append(rig.ctx, "evt.room.R1.message_posted", &corev1.Event{
 		Id:        "M1",
 		ActorId:   "U1",
@@ -419,8 +419,80 @@ func TestMigrateMessagesToES_ConflictSkipsRoomAtomically(t *testing.T) {
 	if err != nil {
 		t.Fatalf("evt info: %v", err)
 	}
+	if info.State.Msgs != 2 {
+		t.Errorf("EVT msg count = %d, want 2 (resumed after M1)", info.State.Msgs)
+	}
+}
+
+func TestMigrateMessagesToES_MismatchedExistingPrefixSkipsRoom(t *testing.T) {
+	rig := setupMessagesRig(t)
+	rig.publishLegacy(t, "server.room.channel.R1.msg.M1", &corev1.Event{
+		Id:        "M1",
+		ActorId:   "U1",
+		CreatedAt: timestamppb.Now(),
+		Event: &corev1.Event_MessagePosted{
+			MessagePosted: &corev1.MessagePostedEvent{RoomId: "R1", EventId: "M1"},
+		},
+	})
+	rig.publishLegacy(t, "server.room.channel.R1.msg.M2", &corev1.Event{
+		Id:        "M2",
+		ActorId:   "U1",
+		CreatedAt: timestamppb.Now(),
+		Event: &corev1.Event_MessagePosted{
+			MessagePosted: &corev1.MessagePostedEvent{RoomId: "R1", EventId: "M2"},
+		},
+	})
+
+	if _, err := rig.publisher.Append(rig.ctx, "evt.room.R1.message_posted", &corev1.Event{
+		Id:        "DIFFERENT",
+		ActorId:   "U1",
+		CreatedAt: timestamppb.Now(),
+		Event: &corev1.Event_MessagePosted{
+			MessagePosted: &corev1.MessagePostedEvent{RoomId: "R1", EventId: "DIFFERENT", MessageBodyId: "DIFFERENT"},
+		},
+	}); err != nil {
+		t.Fatalf("seed target event: %v", err)
+	}
+
+	if err := MigrateMessagesToES(rig.ctx, rig.srcStream, rig.bodiesKV, rig.publisher, log.New(io.Discard)); err != nil {
+		t.Fatalf("migration: %v", err)
+	}
+
+	info, err := rig.evtStream.Info(rig.ctx)
+	if err != nil {
+		t.Fatalf("evt info: %v", err)
+	}
 	if info.State.Msgs != 1 {
-		t.Errorf("EVT msg count = %d, want 1 (room skipped atomically)", info.State.Msgs)
+		t.Errorf("EVT msg count = %d, want 1 (mismatched room skipped)", info.State.Msgs)
+	}
+}
+
+func TestMigrateMessagesToES_ChunksLargeRoom(t *testing.T) {
+	rig := setupMessagesRig(t)
+	const total = messageMigrationBatchSize + 3
+
+	for i := 0; i < total; i++ {
+		eventID := "M" + time.Unix(int64(i), 0).Format("150405")
+		rig.publishLegacy(t, "server.room.channel.R1.msg."+eventID, &corev1.Event{
+			Id:        eventID,
+			ActorId:   "U1",
+			CreatedAt: timestamppb.New(time.Unix(int64(i), 0)),
+			Event: &corev1.Event_MessagePosted{
+				MessagePosted: &corev1.MessagePostedEvent{RoomId: "R1", EventId: eventID},
+			},
+		})
+	}
+
+	if err := MigrateMessagesToES(rig.ctx, rig.srcStream, rig.bodiesKV, rig.publisher, log.New(io.Discard)); err != nil {
+		t.Fatalf("migration: %v", err)
+	}
+
+	info, err := rig.evtStream.Info(rig.ctx)
+	if err != nil {
+		t.Fatalf("evt info: %v", err)
+	}
+	if info.State.Msgs != total {
+		t.Errorf("EVT msg count = %d, want %d", info.State.Msgs, total)
 	}
 }
 

--- a/cli/internal/migrations/reactions_es.go
+++ b/cli/internal/migrations/reactions_es.go
@@ -36,10 +36,11 @@ import (
 //
 // # Idempotency and crash-safety
 //
-// Reactions are grouped by room and emitted via one atomic AppendBatch
-// per room. The first entry carries subject-level OCC against
-// `evt.room.{roomId}.reaction_added` expecting an empty subject; on
-// replay, the conflict skips the whole room.
+// Reactions are grouped by room and emitted in bounded atomic chunks.
+// The first entry in each chunk carries subject-level OCC against
+// `evt.room.{roomId}.reaction_added`. On replay, the importer reads the
+// existing reaction identities, verifies they match the legacy prefix, and
+// resumes at the first missing reaction.
 func MigrateReactionsToES(
 	ctx context.Context,
 	serverEventsStream jetstream.Stream,
@@ -118,17 +119,13 @@ func MigrateReactionsToES(
 		if len(batch.entries) == 0 {
 			continue
 		}
-		batch.entries[0].HasOCC = true
-		batch.entries[0].ExpectedSeq = 0
 
-		if _, err := publisher.AppendBatch(ctx, batch.entries); err != nil {
-			if errors.Is(err, events.ErrConflict) {
-				skipped += len(batch.entries)
-				continue
-			}
+		roomImported, roomSkipped, err := publishReactionMigrationRoom(ctx, publisher, roomID, batch.entries, logger)
+		if err != nil {
 			return fmt.Errorf("publish migrated reactions (room=%s): %w", roomID, err)
 		}
-		imported += len(batch.entries)
+		imported += roomImported
+		skipped += roomSkipped
 	}
 
 	if imported > 0 || skipped > 0 || skippedMissingRoom > 0 {
@@ -142,6 +139,79 @@ func MigrateReactionsToES(
 		)
 	}
 	return nil
+}
+
+func publishReactionMigrationRoom(
+	ctx context.Context,
+	publisher *events.Publisher,
+	roomID string,
+	entries []events.BatchEntry,
+	logger *log.Logger,
+) (imported int, skipped int, err error) {
+	if len(entries) == 0 {
+		return 0, 0, nil
+	}
+
+	subject := entries[0].Subject
+	existingEvents, expectedSeq, err := publisher.SubjectEvents(ctx, subject)
+	if err != nil {
+		return 0, 0, fmt.Errorf("read existing reaction events: %w", err)
+	}
+	if len(existingEvents) > len(entries) {
+		logger.Warn(
+			"reactions ES migration: skipping room with more projected reactions than legacy reactions",
+			"room_id", roomID,
+			"existing_reactions", len(existingEvents),
+			"legacy_reactions", len(entries),
+		)
+		return 0, len(entries), nil
+	}
+	for i, existing := range existingEvents {
+		if reactionIdentity(existing) != reactionIdentity(entries[i].Event) {
+			logger.Warn(
+				"reactions ES migration: skipping room with non-matching existing reaction prefix",
+				"room_id", roomID,
+				"index", i,
+				"existing_reaction", reactionIdentity(existing),
+				"legacy_reaction", reactionIdentity(entries[i].Event),
+			)
+			return 0, len(entries), nil
+		}
+	}
+	if len(existingEvents) == len(entries) {
+		return 0, len(entries), nil
+	}
+
+	pending := entries[len(existingEvents):]
+	for start := 0; start < len(pending); start += messageMigrationBatchSize {
+		end := start + messageMigrationBatchSize
+		if end > len(pending) {
+			end = len(pending)
+		}
+
+		chunk := append([]events.BatchEntry(nil), pending[start:end]...)
+		chunk[0].HasOCC = true
+		chunk[0].ExpectedSeq = expectedSeq
+
+		seqs, err := publisher.AppendBatch(ctx, chunk)
+		if err != nil {
+			if errors.Is(err, events.ErrConflict) {
+				return imported, skipped, fmt.Errorf("reaction chunk OCC conflict after resume point %d: %w", len(existingEvents)+imported, err)
+			}
+			return imported, skipped, err
+		}
+		expectedSeq = seqs[len(seqs)-1]
+		imported += len(chunk)
+	}
+	return imported, len(existingEvents), nil
+}
+
+func reactionIdentity(event *corev1.Event) string {
+	added := event.GetReactionAdded()
+	if added == nil {
+		return ""
+	}
+	return added.GetMessageEventId() + "\x00" + added.GetEmoji() + "\x00" + event.GetActorId()
 }
 
 func listLegacyReactionKeys(ctx context.Context, kv jetstream.KeyValue) ([]string, error) {

--- a/cli/internal/migrations/reactions_es_test.go
+++ b/cli/internal/migrations/reactions_es_test.go
@@ -3,6 +3,7 @@ package migrations
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -74,6 +75,80 @@ func TestMigrateReactionsToES_ImportsCurrentStateAndReplays(t *testing.T) {
 	}
 	if info.State.Msgs != 2 {
 		t.Fatalf("EVT messages after replay = %d, want 2", info.State.Msgs)
+	}
+}
+
+func TestMigrateReactionsToES_ChunksLargeRoom(t *testing.T) {
+	rig := setupMessagesRig(t)
+	reactionsKV := rig.reactionsKV(t)
+
+	rig.publishLegacy(t, "server.room.channel.R1.msg.M1", &corev1.Event{
+		Id:        "M1",
+		ActorId:   "U1",
+		CreatedAt: timestamppb.Now(),
+		Event: &corev1.Event_MessagePosted{
+			MessagePosted: &corev1.MessagePostedEvent{RoomId: "R1", EventId: "M1"},
+		},
+	})
+
+	const total = messageMigrationBatchSize + 3
+	for i := 0; i < total; i++ {
+		putReaction(t, rig.ctx, reactionsKV, fmt.Sprintf("M1.emoji%d.U%d", i, i), time.Unix(1700000000+int64(i), 0))
+	}
+
+	if err := MigrateReactionsToES(rig.ctx, rig.srcStream, reactionsKV, rig.publisher, log.New(io.Discard)); err != nil {
+		t.Fatalf("migration: %v", err)
+	}
+
+	info, err := rig.evtStream.Info(rig.ctx)
+	if err != nil {
+		t.Fatalf("evt info: %v", err)
+	}
+	if info.State.Msgs != total {
+		t.Fatalf("EVT messages = %d, want %d", info.State.Msgs, total)
+	}
+}
+
+func TestMigrateReactionsToES_ResumesPartiallyImportedRoom(t *testing.T) {
+	rig := setupMessagesRig(t)
+	reactionsKV := rig.reactionsKV(t)
+
+	rig.publishLegacy(t, "server.room.channel.R1.msg.M1", &corev1.Event{
+		Id:        "M1",
+		ActorId:   "U1",
+		CreatedAt: timestamppb.Now(),
+		Event: &corev1.Event_MessagePosted{
+			MessagePosted: &corev1.MessagePostedEvent{RoomId: "R1", EventId: "M1"},
+		},
+	})
+	putReaction(t, rig.ctx, reactionsKV, "M1.heart.U2", time.Unix(1700000000, 0))
+	putReaction(t, rig.ctx, reactionsKV, "M1.thumbsup.U3", time.Unix(1700000001, 0))
+
+	if _, err := rig.publisher.Append(rig.ctx, "evt.room.R1.reaction_added", &corev1.Event{
+		Id:        "seed",
+		ActorId:   "U2",
+		CreatedAt: timestamppb.Now(),
+		Event: &corev1.Event_ReactionAdded{
+			ReactionAdded: &corev1.ReactionAddedEvent{
+				RoomId:         "R1",
+				MessageEventId: "M1",
+				Emoji:          "heart",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("seed reaction: %v", err)
+	}
+
+	if err := MigrateReactionsToES(rig.ctx, rig.srcStream, reactionsKV, rig.publisher, log.New(io.Discard)); err != nil {
+		t.Fatalf("migration: %v", err)
+	}
+
+	info, err := rig.evtStream.Info(rig.ctx)
+	if err != nil {
+		t.Fatalf("evt info: %v", err)
+	}
+	if info.State.Msgs != 2 {
+		t.Fatalf("EVT messages = %d, want 2", info.State.Msgs)
 	}
 }
 

--- a/cli/internal/migrations/room_aggregate_es.go
+++ b/cli/internal/migrations/room_aggregate_es.go
@@ -19,8 +19,10 @@ import (
 )
 
 // MigrateRoomAggregateToES seeds the EVT stream from the existing
-// `room.{kind}.{roomID}` and `room_membership.{kind}.{roomID}.{userID}`
-// keys in SERVER_CONFIG (ADR-035 phase 3 for the room aggregate).
+// `room.{kind}.{roomID}` keys and both known room membership key shapes
+// in SERVER_CONFIG (ADR-035 phase 3 for the room aggregate):
+// `room_membership.{kind}.{roomID}.{userID}` and the older
+// `room_membership.{userID}.{roomID}`.
 //
 // Room metadata and membership share one event subject — `evt.room.{R}` —
 // so they must seed together: a `RoomCreatedEvent` must always be the
@@ -33,8 +35,10 @@ import (
 // # Idempotency
 //
 // Each batch's first entry uses `HasOCC: true` + `ExpectedSeq: 0`. On
-// re-run, the publish fails with events.ErrConflict and the room is
-// skipped wholesale — we don't try to "catch up" partial state.
+// re-run, the publish fails with events.ErrConflict. The room metadata is
+// then treated as already seeded, but missing membership events are
+// backfilled so older membership key shapes discovered after a failed boot
+// are not stranded.
 //
 // # When this can be removed
 //
@@ -57,7 +61,7 @@ func MigrateRoomAggregateToES(
 		return fmt.Errorf("load memberships: %w", err)
 	}
 
-	var migrated, skipped, archivedEvents, memberEvents int
+	var migrated, skipped, archivedEvents, memberEvents, memberBackfillEvents int
 	for _, key := range roomKeys {
 		entry, err := serverConfigKV.Get(ctx, key)
 		if err != nil {
@@ -125,6 +129,11 @@ func MigrateRoomAggregateToES(
 
 		if _, err := publisher.AppendBatch(ctx, batch); err != nil {
 			if errors.Is(err, events.ErrConflict) {
+				backfilled, backfillErr := backfillMissingRoomMemberships(ctx, publisher, room.GetId(), memberships[room.GetId()])
+				if backfillErr != nil {
+					return fmt.Errorf("backfill room memberships for %s: %w", room.GetId(), backfillErr)
+				}
+				memberBackfillEvents += backfilled
 				skipped++
 				continue
 			}
@@ -145,9 +154,55 @@ func MigrateRoomAggregateToES(
 			"rooms_skipped", skipped,
 			"archived_events", archivedEvents,
 			"member_events", memberEvents,
+			"member_backfill_events", memberBackfillEvents,
 		)
 	}
 	return nil
+}
+
+func backfillMissingRoomMemberships(
+	ctx context.Context,
+	publisher *events.Publisher,
+	roomID string,
+	memberships []membershipEntry,
+) (int, error) {
+	if len(memberships) == 0 {
+		return 0, nil
+	}
+
+	agg := events.RoomAggregate(roomID)
+	subject := agg.Subject(events.EventUserJoinedRoom)
+	existingEvents, expectedSeq, err := publisher.SubjectEvents(ctx, subject)
+	if err != nil {
+		return 0, fmt.Errorf("read existing membership events: %w", err)
+	}
+
+	existing := make(map[string]bool, len(existingEvents))
+	for _, event := range existingEvents {
+		if event.GetUserJoinedRoom() == nil {
+			continue
+		}
+		existing[event.GetActorId()] = true
+	}
+
+	var imported int
+	for _, membership := range memberships {
+		if existing[membership.userID] {
+			continue
+		}
+
+		event := stamp(&corev1.Event{Event: &corev1.Event_UserJoinedRoom{
+			UserJoinedRoom: &corev1.UserJoinedRoomEvent{RoomId: roomID},
+		}}, membership.userID, timestamppb.New(membership.createdAt))
+
+		seq, err := publisher.AppendAt(ctx, subject, event, expectedSeq)
+		if err != nil {
+			return imported, err
+		}
+		expectedSeq = seq
+		imported++
+	}
+	return imported, nil
 }
 
 // membershipEntry pairs a userID with the KV-recorded creation time of
@@ -160,8 +215,9 @@ type membershipEntry struct {
 
 // loadMembershipsByRoom reads every `room_membership.>` key and groups
 // the entries by roomID, sorted chronologically (with userID as a
-// deterministic tiebreaker). Orphan memberships whose key is malformed
-// are logged and skipped.
+// deterministic tiebreaker). It accepts both the current
+// `room_membership.{kind}.{roomID}.{userID}` shape and the old
+// `room_membership.{userID}.{roomID}` shape.
 func loadMembershipsByRoom(
 	ctx context.Context,
 	serverConfigKV jetstream.KeyValue,
@@ -174,13 +230,11 @@ func loadMembershipsByRoom(
 
 	byRoom := make(map[string][]membershipEntry)
 	for _, key := range keys {
-		// Key shape: room_membership.{kind}.{roomID}.{userID}.
-		parts := strings.Split(key, ".")
-		if len(parts) != 4 {
+		roomID, userID, ok := parseRoomMembershipKey(key)
+		if !ok {
 			logger.Warn("room_aggregate ES migration: skipping malformed membership key", "key", key)
 			continue
 		}
-		roomID, userID := parts[2], parts[3]
 
 		entry, err := serverConfigKV.Get(ctx, key)
 		if err != nil {
@@ -200,6 +254,24 @@ func loadMembershipsByRoom(
 		byRoom[roomID] = ms
 	}
 	return byRoom, nil
+}
+
+func parseRoomMembershipKey(key string) (roomID string, userID string, ok bool) {
+	parts := strings.Split(key, ".")
+	switch len(parts) {
+	case 4:
+		if parts[0] != "room_membership" {
+			return "", "", false
+		}
+		return parts[2], parts[3], true
+	case 3:
+		if parts[0] != "room_membership" {
+			return "", "", false
+		}
+		return parts[2], parts[1], true
+	default:
+		return "", "", false
+	}
 }
 
 // listSortedKeys returns the union of keys matching the given filters,

--- a/cli/internal/migrations/room_aggregate_es_test.go
+++ b/cli/internal/migrations/room_aggregate_es_test.go
@@ -31,6 +31,15 @@ func seedMembership(t *testing.T, kv jetstream.KeyValue, kind, roomID, userID st
 	require.NoError(t, err)
 }
 
+func seedOldMembership(t *testing.T, kv jetstream.KeyValue, roomID, userID string) {
+	t.Helper()
+	m := &corev1.RoomMembership{UserId: userID, RoomId: roomID}
+	data, err := proto.Marshal(m)
+	require.NoError(t, err)
+	_, err = kv.Put(t.Context(), "room_membership."+userID+"."+roomID, data)
+	require.NoError(t, err)
+}
+
 func TestMigrateRoomAggregateToES_EmptyKV(t *testing.T) {
 	ctx, kv, stream, publisher := setupTestES(t)
 	require.NoError(t, MigrateRoomAggregateToES(ctx, kv, publisher, testLogger()))
@@ -94,6 +103,56 @@ func TestMigrateRoomAggregateToES_SeedsRoomThenMembers(t *testing.T) {
 	require.NoError(t, proto.Unmarshal(lastMsgR2.Data, &archivedEv))
 	_, isArchive := archivedEv.GetEvent().(*corev1.Event_RoomArchived)
 	require.True(t, isArchive, "expected last event on R2.room_archived to be RoomArchived")
+}
+
+func TestMigrateRoomAggregateToES_AcceptsOldMembershipKeyShape(t *testing.T) {
+	ctx, kv, stream, publisher := setupTestES(t)
+
+	seedRoom(t, kv, "channel", &corev1.Room{
+		Id:   "R1",
+		Name: "general",
+		Kind: corev1.RoomKind_ROOM_KIND_CHANNEL,
+	})
+	seedOldMembership(t, kv, "R1", "U1")
+
+	require.NoError(t, MigrateRoomAggregateToES(ctx, kv, publisher, testLogger()))
+
+	info, err := stream.Info(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, info.State.Msgs)
+
+	msg, err := stream.GetMsg(ctx, 2)
+	require.NoError(t, err)
+	var ev corev1.Event
+	require.NoError(t, proto.Unmarshal(msg.Data, &ev))
+	require.Equal(t, "U1", ev.GetActorId())
+	require.Equal(t, "R1", ev.GetUserJoinedRoom().GetRoomId())
+}
+
+func TestMigrateRoomAggregateToES_BackfillsMissingMemberships(t *testing.T) {
+	ctx, kv, stream, publisher := setupTestES(t)
+
+	seedRoom(t, kv, "channel", &corev1.Room{
+		Id:   "R1",
+		Name: "general",
+		Kind: corev1.RoomKind_ROOM_KIND_CHANNEL,
+	})
+	seedMembership(t, kv, "channel", "R1", "U1")
+	require.NoError(t, MigrateRoomAggregateToES(ctx, kv, publisher, testLogger()))
+
+	seedOldMembership(t, kv, "R1", "U2")
+	require.NoError(t, MigrateRoomAggregateToES(ctx, kv, publisher, testLogger()))
+
+	info, err := stream.Info(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, 3, info.State.Msgs)
+
+	msg, err := stream.GetMsg(ctx, 3)
+	require.NoError(t, err)
+	var ev corev1.Event
+	require.NoError(t, proto.Unmarshal(msg.Data, &ev))
+	require.Equal(t, "U2", ev.GetActorId())
+	require.Equal(t, "R1", ev.GetUserJoinedRoom().GetRoomId())
 }
 
 func TestMigrateRoomAggregateToES_Replay(t *testing.T) {


### PR DESCRIPTION
Adds opt-in ES boot verification logs for local rollout dry runs, including legacy/projected count checks and EVT event counts. Makes backup restore rewrite snapshot replica counts to the target config so clustered backups can restore into local embedded NATS. Hardens room/message/reaction ES imports for production-like data by supporting old membership key shapes and chunking/resuming large message and reaction imports. Tested with `go test -count=1 ./cmd ./internal/migrations ./internal/events ./internal/core ./internal/config -timeout 180s` and `git diff --check`.