### PR TITLE
fix(es): preserve imported thread replies

### DIFF
--- a/cli/internal/core/es_boot_verification.go
+++ b/cli/internal/core/es_boot_verification.go
@@ -31,6 +31,7 @@ type esLegacyCounts struct {
 	roomLayoutPresent   bool
 	serverConfigPresent bool
 	messages            int
+	threadReplies       int
 	reactions           int
 	encryptionKeys      int
 }
@@ -78,6 +79,8 @@ func (c *ChattoCore) logESBootVerification(ctx context.Context) {
 		"projected_room_groups", report.projected.roomGroups,
 		"legacy_messages", report.legacy.messages,
 		"projected_message_posts", report.projected.messagePosts,
+		"legacy_thread_replies", report.legacy.threadReplies,
+		"projected_thread_replies", report.projected.threadReplies,
 		"legacy_reactions", report.legacy.reactions,
 		"projected_active_reactions", report.projected.activeReactions,
 		"server_config_legacy", report.legacy.serverConfigPresent,
@@ -162,6 +165,10 @@ func (c *ChattoCore) collectLegacyESCounts(ctx context.Context) (esLegacyCounts,
 	if err != nil {
 		return counts, warnings, fmt.Errorf("count legacy messages: %w", err)
 	}
+	counts.threadReplies, err = countStreamMessages(ctx, c.storage.serverEventsStream, []string{"server.room.*.*.msg.*.replies.>"})
+	if err != nil {
+		return counts, warnings, fmt.Errorf("count legacy thread replies: %w", err)
+	}
 	counts.reactions, err = countKVKeys(ctx, c.storage.serverReactionsKV)
 	if err != nil {
 		return counts, warnings, fmt.Errorf("count legacy reactions: %w", err)
@@ -213,6 +220,7 @@ func (c *ChattoCore) evaluateESBootVerificationReport(r *esBootVerificationRepor
 	compareAtLeast("memberships", r.legacy.memberships, r.projected.memberships)
 	compareAtLeast("room groups", r.legacy.roomGroups, r.projected.roomGroups)
 	compareAtLeast("messages", r.legacy.messages, r.projected.messagePosts)
+	compareAtLeast("thread replies", r.legacy.threadReplies, r.projected.threadReplies)
 	compareAtLeast("reactions", r.legacy.reactions, r.projected.activeReactions)
 
 	if r.legacy.serverConfigPresent && !r.projected.serverConfigConfigured {

--- a/cli/internal/core/es_boot_verification_test.go
+++ b/cli/internal/core/es_boot_verification_test.go
@@ -14,6 +14,7 @@ func TestEvaluateESBootVerificationReportDetectsCountRegressions(t *testing.T) {
 			roomLayoutPresent:   true,
 			serverConfigPresent: true,
 			messages:            9,
+			threadReplies:       2,
 			reactions:           4,
 		},
 		projected: esProjectedCounts{
@@ -23,6 +24,7 @@ func TestEvaluateESBootVerificationReportDetectsCountRegressions(t *testing.T) {
 			roomLayoutGroups:       0,
 			serverConfigConfigured: false,
 			messagePosts:           8,
+			threadReplies:          0,
 			activeReactions:        4,
 		},
 		decodeErrors: 1,
@@ -33,6 +35,7 @@ func TestEvaluateESBootVerificationReportDetectsCountRegressions(t *testing.T) {
 
 	assertProblemContains(t, report.problems, "memberships")
 	assertProblemContains(t, report.problems, "messages")
+	assertProblemContains(t, report.problems, "thread replies")
 	assertProblemContains(t, report.problems, "server config")
 	assertProblemContains(t, report.problems, "room layout")
 	assertProblemContains(t, report.problems, "decode errors")
@@ -41,17 +44,19 @@ func TestEvaluateESBootVerificationReportDetectsCountRegressions(t *testing.T) {
 func TestEvaluateESBootVerificationReportAllowsProjectedSuperset(t *testing.T) {
 	report := &esBootVerificationReport{
 		legacy: esLegacyCounts{
-			rooms:       2,
-			memberships: 3,
-			roomGroups:  1,
-			messages:    5,
-			reactions:   1,
+			rooms:         2,
+			memberships:   3,
+			roomGroups:    1,
+			messages:      5,
+			threadReplies: 2,
+			reactions:     1,
 		},
 		projected: esProjectedCounts{
 			rooms:           3,
 			memberships:     4,
 			roomGroups:      2,
 			messagePosts:    6,
+			threadReplies:   2,
 			activeReactions: 1,
 		},
 	}

--- a/cli/internal/core/messages.go
+++ b/cli/internal/core/messages.go
@@ -141,14 +141,13 @@ func (c *ChattoCore) PostMessage(ctx context.Context, kind RoomKind, room_id, us
 			},
 		},
 	})
-	// Set EventId AND MessageBodyId both to the envelope id. Post-#597
-	// cutover, MessageBodyId is no longer a {userId}.{bodyId} compound
+	// Set MessageBodyId to the envelope id. Post-#597 cutover,
+	// MessageBodyId is no longer a {userId}.{bodyId} compound
 	// key — it's just an alias for event_id, kept on the proto so
 	// legacy code paths that pass MessageBodyId around (resolvers,
 	// attachment signed URLs) keep working without changes.
 	// eventIDFromBodyKey treats no-dot keys as event_ids, so the
 	// projection lookup picks the right entry.
-	event.GetMessagePosted().EventId = event.Id
 	event.GetMessagePosted().MessageBodyId = event.Id
 
 	// Stamp the event_id onto each attachment so signed attachment
@@ -332,7 +331,6 @@ func (c *ChattoCore) PostMessage(ctx context.Context, kind RoomKind, room_id, us
 				},
 			},
 		})
-		echoEvent.GetMessagePosted().EventId = echoEvent.Id
 		echoEvent.GetMessagePosted().MessageBodyId = echoEvent.Id
 
 		echoSequenceID, err := c.RoomTimelineProjector.AppendAndWait(ctx, c.EventPublisher, agg, echoEvent)

--- a/cli/internal/core/thread_projection.go
+++ b/cli/internal/core/thread_projection.go
@@ -86,6 +86,9 @@ func (p *ThreadProjection) Apply(event *corev1.Event, seq uint64) error {
 		}
 		replyID := m.GetEventId()
 		if replyID == "" {
+			replyID = event.GetId()
+		}
+		if replyID == "" {
 			return nil
 		}
 		p.byThread[threadRoot] = append(p.byThread[threadRoot], &TimelineEntry{StreamSeq: seq, Event: event})

--- a/cli/internal/core/thread_projection_test.go
+++ b/cli/internal/core/thread_projection_test.go
@@ -57,6 +57,26 @@ func TestThreadProjection_RepliesAppended(t *testing.T) {
 	}
 }
 
+func TestThreadProjection_ReplyWithLegacyEmptyPayloadEventID(t *testing.T) {
+	p := NewThreadProjection()
+	applyAll(t, p, []*corev1.Event{
+		postedEvent(postedOpts{envelopeID: "ROOT", eventID: "ROOT", roomID: "R1", actorID: "U1", at: 1}),
+		postedEvent(postedOpts{envelopeID: "REPLY1", roomID: "R1", actorID: "U2", inThread: "ROOT", body: "legacy reply", at: 2}),
+		editedEvent("EDIT-REPLY1", "REPLY1", "R1", "U2", "edited legacy reply", 3),
+	})
+
+	entries := p.ThreadEvents("ROOT")
+	if len(entries) != 2 {
+		t.Fatalf("ThreadEvents(ROOT) len = %d, want 2", len(entries))
+	}
+	if got := p.ReplyCount("ROOT"); got != 1 {
+		t.Errorf("ReplyCount = %d, want 1", got)
+	}
+	if entries[1].Event.GetMessageEdited() == nil {
+		t.Error("expected edit to route through envelope-id fallback")
+	}
+}
+
 func TestThreadProjection_EditOfReplyAppendedToThread(t *testing.T) {
 	p := NewThreadProjection()
 	applyAll(t, p, []*corev1.Event{

--- a/cli/internal/migrations/messages_es.go
+++ b/cli/internal/migrations/messages_es.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"hmans.de/chatto/internal/core/subjects"
 	"hmans.de/chatto/internal/events"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
@@ -174,22 +175,48 @@ func MigrateMessagesToES(
 		// Build the migrated event. Preserve the original envelope
 		// metadata (id, actor, created_at) so the timeline order and
 		// audit trail are preserved. Body is embedded; message_body_id
-		// is repurposed post-cutover as an alias for event_id (same
-		// value as the EventId field), so legacy resolver code paths
+		// is repurposed post-cutover as an alias for the envelope id,
+		// so legacy resolver code paths
 		// that pass MessageBodyId around continue to resolve through
 		// eventIDFromBodyKey.
+		//
+		// Legacy MessagePostedEvent.event_id was a read-time helper, not
+		// persisted by PostMessage. Recover it from the envelope id or,
+		// as a last resort, the legacy subject.
 		eventID := posted.GetEventId()
+		if eventID == "" {
+			eventID = legacyEvent.GetId()
+		}
+		if eventID == "" {
+			eventID = subjects.ParseEventIDFromSubject(msg.Subject())
+		}
+		if eventID == "" {
+			logger.Warn("messages ES migration: skipping post without event id", "subject", msg.Subject())
+			continue
+		}
+
+		envelopeID := legacyEvent.GetId()
+		if envelopeID == "" {
+			envelopeID = eventID
+		}
+
+		inThread := posted.GetInThread()
+		if inThread == "" {
+			if rootID, ok := subjects.ParseThreadRootEventIDFromSubject(msg.Subject()); ok {
+				inThread = rootID
+			}
+		}
+
 		newEvent := &corev1.Event{
-			Id:        legacyEvent.GetId(),
+			Id:        envelopeID,
 			ActorId:   legacyEvent.GetActorId(),
 			CreatedAt: preserveTimestamp(legacyEvent.GetCreatedAt()),
 			Event: &corev1.Event_MessagePosted{
 				MessagePosted: &corev1.MessagePostedEvent{
 					RoomId:                    roomID,
-					EventId:                   eventID,
 					MessageBodyId:             eventID,
 					InReplyTo:                 posted.GetInReplyTo(),
-					InThread:                  posted.GetInThread(),
+					InThread:                  inThread,
 					MentionedUserIds:          posted.GetMentionedUserIds(),
 					EchoOfEventId:             posted.GetEchoOfEventId(),
 					EchoFromThreadRootEventId: posted.GetEchoFromThreadRootEventId(),

--- a/cli/internal/migrations/messages_es_test.go
+++ b/cli/internal/migrations/messages_es_test.go
@@ -314,6 +314,58 @@ func TestMigrateMessagesToES_ImportsThreadReplies(t *testing.T) {
 	}
 }
 
+func TestMigrateMessagesToES_BackfillsLegacyEventIDAndThreadRootFromSubject(t *testing.T) {
+	rig := setupMessagesRig(t)
+
+	rig.putBody(t, "U1.ROOT-BODY", &corev1.MessageBody{AuthorId: "U1", EncryptedBody: []byte("root")})
+	rig.putBody(t, "U2.REPLY-BODY", &corev1.MessageBody{AuthorId: "U2", EncryptedBody: []byte("reply")})
+
+	// Legacy PostMessage did not persist MessagePostedEvent.EventId; it
+	// lived on the envelope and subject. This is the real pre-ES shape
+	// imported from production-like data.
+	rig.publishLegacy(t, "server.room.channel.R1.msg.ROOT", &corev1.Event{
+		Id:        "ROOT",
+		ActorId:   "U1",
+		CreatedAt: timestamppb.Now(),
+		Event: &corev1.Event_MessagePosted{
+			MessagePosted: &corev1.MessagePostedEvent{
+				RoomId:        "R1",
+				MessageBodyId: "U1.ROOT-BODY",
+			},
+		},
+	})
+
+	// Be defensive for even older/broken imports: if InThread is absent,
+	// the legacy thread subject still carries the root event id.
+	rig.publishLegacy(t, "server.room.channel.R1.msg.ROOT.replies.REPLY1", &corev1.Event{
+		Id:        "REPLY1",
+		ActorId:   "U2",
+		CreatedAt: timestamppb.Now(),
+		Event: &corev1.Event_MessagePosted{
+			MessagePosted: &corev1.MessagePostedEvent{
+				RoomId:        "R1",
+				MessageBodyId: "U2.REPLY-BODY",
+			},
+		},
+	})
+
+	if err := MigrateMessagesToES(rig.ctx, rig.srcStream, rig.bodiesKV, rig.publisher, log.New(io.Discard)); err != nil {
+		t.Fatalf("migration: %v", err)
+	}
+
+	root := rig.readEvent(t, 1)
+	checkImportedMessage(t, root, "ROOT", "U1", "root")
+	if got := root.GetMessagePosted().GetInThread(); got != "" {
+		t.Errorf("root in_thread = %q, want empty", got)
+	}
+
+	reply := rig.readEvent(t, 2)
+	checkImportedMessage(t, reply, "REPLY1", "U2", "reply")
+	if got := reply.GetMessagePosted().GetInThread(); got != "ROOT" {
+		t.Errorf("reply in_thread = %q, want ROOT", got)
+	}
+}
+
 func TestMigrateMessagesToES_MissingBodyImportsAsNil(t *testing.T) {
 	// Legacy hard-delete: body wiped from SERVER_BODIES, post envelope
 	// still in SERVER_EVENTS. Migration imports the envelope with
@@ -540,9 +592,10 @@ func TestMigrateMessagesToES_MultipleRoomsIsolated(t *testing.T) {
 // =============================================================================
 
 // checkImportedMessage asserts that an event is a MessagePostedEvent
-// for the given eventID, on the right room subject, with embedded
-// body matching the expected ciphertext, and no legacy
-// message_body_id pointer.
+// with the given envelope ID, embedded body matching the expected
+// ciphertext, and post-cutover message_body_id alias. The payload's
+// EventId field is intentionally not persisted; GraphQL populates it
+// at read time from the envelope.
 func checkImportedMessage(t *testing.T, ev *corev1.Event, wantEventID, wantActor, wantCiphertext string) {
 	t.Helper()
 	if ev.GetId() != wantEventID {
@@ -555,8 +608,8 @@ func checkImportedMessage(t *testing.T, ev *corev1.Event, wantEventID, wantActor
 	if posted == nil {
 		t.Fatal("expected MessagePostedEvent payload")
 	}
-	if posted.GetEventId() != wantEventID {
-		t.Errorf("posted event_id = %q, want %q", posted.GetEventId(), wantEventID)
+	if posted.GetEventId() != "" {
+		t.Errorf("posted event_id should not be persisted, got %q", posted.GetEventId())
 	}
 	if posted.GetMessageBodyId() != wantEventID {
 		t.Errorf("posted message_body_id should alias event_id post-cutover, got %q want %q", posted.GetMessageBodyId(), wantEventID)


### PR DESCRIPTION
Fixes the message ES importer so legacy message IDs and thread roots are recovered from the event envelope or legacy subject instead of relying on transient payload fields. Keeps MessagePostedEvent.event_id out of persisted EVT writes, while allowing the thread projection to fall back to the envelope ID for already-seeded events. Adds boot verification for legacy vs projected thread-reply counts and tests for the production-shaped import path.