### PR TITLE
fix(es): harden event-sourcing OCC behavior

### DIFF
--- a/cli/internal/core/config_manager.go
+++ b/cli/internal/core/config_manager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"hmans.de/chatto/internal/events"
 	configv1 "hmans.de/chatto/internal/pb/chatto/config/v1"
@@ -17,6 +18,8 @@ import (
 // without success. Callers can retry the whole UpdateServerConfigFunc
 // call.
 var ErrConfigConflict = errors.New("config was modified by another request")
+
+const maxConfigUpdateRetries = 5
 
 // ConfigManager handles runtime server configuration.
 //
@@ -77,35 +80,65 @@ func (cm *ConfigManager) SetServerConfig(ctx context.Context, actorID string, cf
 // UpdateServerConfigFunc atomically updates the server config using
 // optimistic concurrency control. The updateFn receives the current
 // projection snapshot (or nil if no config has been written yet) and
-// should return the updated config. OCC retries live inside the
-// publisher's Append loop — if the underlying publish exhausts retries,
-// this returns ErrConfigConflict. Returns the final config after a
-// successful write.
+// should return the updated config. On conflict, the whole compose step
+// is retried against the newer projection snapshot, so field-level edits
+// do not publish stale full-config replacements.
 func (cm *ConfigManager) UpdateServerConfigFunc(
 	ctx context.Context,
 	actorID string,
 	updateFn func(current *configv1.ServerConfig) (*configv1.ServerConfig, error),
 ) (*configv1.ServerConfig, error) {
-	// Read current projection state for the compose step. Clone is
-	// already returned by Projection.Get so updateFn may mutate the
-	// input freely.
-	current, _ := cm.projection.Get()
-
-	updated, err := updateFn(current)
-	if err != nil {
-		return nil, err
-	}
-	if updated == nil {
-		return nil, fmt.Errorf("update function returned nil config")
+	if cm.publisher == nil || cm.projector == nil {
+		return nil, fmt.Errorf("config manager: event publisher/projector not configured")
 	}
 
-	if err := cm.publish(ctx, actorID, updated); err != nil {
-		if errors.Is(err, events.ErrConflict) {
-			return nil, ErrConfigConflict
+	agg := events.ConfigAggregate()
+	subject := agg.Subject(events.EventServerConfigChanged)
+	for attempt := 0; attempt < maxConfigUpdateRetries; attempt++ {
+		expectedSeq, err := cm.publisher.LastSubjectSeq(ctx, subject)
+		if err != nil {
+			return nil, fmt.Errorf("read config OCC seq: %w", err)
 		}
-		return nil, err
+		if expectedSeq > 0 {
+			if err := cm.projector.WaitForSeq(ctx, expectedSeq); err != nil {
+				return nil, fmt.Errorf("wait for config projection: %w", err)
+			}
+		}
+
+		current, _ := cm.projection.Get()
+		updated, err := updateFn(current)
+		if err != nil {
+			return nil, err
+		}
+		if updated == nil {
+			return nil, fmt.Errorf("update function returned nil config")
+		}
+
+		event := newEvent(actorID, &corev1.Event{
+			Event: &corev1.Event_ServerConfigChanged{
+				ServerConfigChanged: &corev1.ServerConfigChangedEvent{
+					Config: updated,
+				},
+			},
+		})
+		seq, err := cm.publisher.AppendAt(ctx, subject, event, expectedSeq)
+		if err == nil {
+			if err := cm.projector.WaitForSeq(ctx, seq); err != nil {
+				return nil, fmt.Errorf("wait for config projection: %w", err)
+			}
+			return updated, nil
+		}
+		if !errors.Is(err, events.ErrConflict) {
+			return nil, err
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(time.Duration(1<<attempt) * time.Millisecond):
+		}
 	}
-	return updated, nil
+	return nil, ErrConfigConflict
 }
 
 // publish writes the server config by emitting a

--- a/cli/internal/core/config_manager_test.go
+++ b/cli/internal/core/config_manager_test.go
@@ -32,7 +32,7 @@ func TestConfigManager_GetServerConfig(t *testing.T) {
 
 	t.Run("returns config after SetServerConfig", func(t *testing.T) {
 		testCfg := &configv1.ServerConfig{
-			ServerName: "Test Instance",
+			ServerName:     "Test Instance",
 			WelcomeMessage: "Welcome!",
 			Motd:           "Message of the day",
 		}
@@ -89,7 +89,7 @@ func TestConfigManager_UpdateServerConfigFunc(t *testing.T) {
 		// Set initial config
 		core.configManager.SetServerConfig(ctx, "test", &configv1.ServerConfig{
 			ServerName: "Original Name",
-			Motd:         "Original MOTD",
+			Motd:       "Original MOTD",
 		})
 
 		cfg, err := core.configManager.UpdateServerConfigFunc(ctx, "test", func(current *configv1.ServerConfig) (*configv1.ServerConfig, error) {
@@ -175,6 +175,75 @@ func TestConfigManager_UpdateServerConfigFunc(t *testing.T) {
 			t.Error("expected at least one successful update")
 		}
 	})
+}
+
+func TestConfigManager_UpdateServerConfigFunc_RecomposesAfterConflict(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	if err := core.configManager.SetServerConfig(ctx, "test", &configv1.ServerConfig{
+		ServerName: "Initial",
+		Motd:       "Initial MOTD",
+	}); err != nil {
+		t.Fatalf("SetServerConfig: %v", err)
+	}
+
+	bothReadInitial := make(chan struct{})
+	release := make(chan struct{})
+	var reads atomic.Int32
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, err := core.configManager.UpdateServerConfigFunc(ctx, "actor-a", func(current *configv1.ServerConfig) (*configv1.ServerConfig, error) {
+			if current.GetServerName() == "Initial" && reads.Add(1) == 2 {
+				close(bothReadInitial)
+			}
+			<-release
+			current.ServerName = "Name A"
+			return current, nil
+		})
+		errs <- err
+	}()
+	go func() {
+		defer wg.Done()
+		_, err := core.configManager.UpdateServerConfigFunc(ctx, "actor-b", func(current *configv1.ServerConfig) (*configv1.ServerConfig, error) {
+			if current.GetServerName() == "Initial" && reads.Add(1) == 2 {
+				close(bothReadInitial)
+			}
+			<-release
+			current.Motd = "MOTD B"
+			return current, nil
+		})
+		errs <- err
+	}()
+
+	select {
+	case <-bothReadInitial:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for both updates to read initial config")
+	}
+	close(release)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("UpdateServerConfigFunc returned error: %v", err)
+		}
+	}
+
+	cfg, _, err := core.configManager.GetServerConfig(ctx)
+	if err != nil {
+		t.Fatalf("GetServerConfig: %v", err)
+	}
+	if cfg.GetServerName() != "Name A" {
+		t.Fatalf("ServerName = %q, want Name A", cfg.GetServerName())
+	}
+	if cfg.GetMotd() != "MOTD B" {
+		t.Fatalf("Motd = %q, want MOTD B", cfg.GetMotd())
+	}
 }
 
 func TestConfigManager_GetEffectiveWelcomeMessage(t *testing.T) {

--- a/cli/internal/core/messages.go
+++ b/cli/internal/core/messages.go
@@ -159,12 +159,13 @@ func (c *ChattoCore) PostMessage(ctx context.Context, kind RoomKind, room_id, us
 		}
 	}
 
-	// Publish to EVT. Pure append per #597's design ("message_posted
-	// is a pure append — no expected-last-seq needed"). AppendAndWait
-	// blocks until the RoomTimelineProjection has caught up, giving
-	// read-your-writes for subsequent reads from this request.
+	// Publish to EVT. MessagePosted is append-only per #597's design, so
+	// retrying the same payload after an OCC conflict is safe.
+	// AppendEventuallyAndWait blocks until the RoomTimelineProjection
+	// has caught up, giving read-your-writes for subsequent reads from
+	// this request.
 	agg := events.RoomAggregate(room_id)
-	sequenceID, err := c.RoomTimelineProjector.AppendAndWait(ctx, c.EventPublisher, agg, event)
+	sequenceID, err := c.RoomTimelineProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, agg, event)
 	if err != nil {
 		return nil, fmt.Errorf("failed to publish message event: %w", err)
 	}
@@ -333,7 +334,7 @@ func (c *ChattoCore) PostMessage(ctx context.Context, kind RoomKind, room_id, us
 		})
 		echoEvent.GetMessagePosted().MessageBodyId = echoEvent.Id
 
-		echoSequenceID, err := c.RoomTimelineProjector.AppendAndWait(ctx, c.EventPublisher, agg, echoEvent)
+		echoSequenceID, err := c.RoomTimelineProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, agg, echoEvent)
 		if err != nil {
 			c.logger.Warn("Failed to publish thread reply echo", "error", err, "thread_reply_event_id", event.Id)
 		} else {
@@ -577,7 +578,7 @@ func (c *ChattoCore) publishMessageRetract(ctx context.Context, actorID string, 
 			},
 		},
 	})
-	if _, err := c.RoomTimelineProjector.AppendAndWait(ctx, c.EventPublisher, agg, event); err != nil {
+	if _, err := c.RoomTimelineProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, agg, event); err != nil {
 		return fmt.Errorf("publish MessageRetractedEvent: %w", err)
 	}
 
@@ -615,7 +616,7 @@ func (c *ChattoCore) publishMessageEdit(ctx context.Context, actorID string, kin
 			},
 		},
 	})
-	if _, err := c.RoomTimelineProjector.AppendAndWait(ctx, c.EventPublisher, agg, event); err != nil {
+	if _, err := c.RoomTimelineProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, agg, event); err != nil {
 		return fmt.Errorf("publish MessageEditedEvent: %w", err)
 	}
 

--- a/cli/internal/core/room_groups.go
+++ b/cli/internal/core/room_groups.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"hmans.de/chatto/internal/events"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
+
+const maxMoveRoomToGroupRetries = 5
 
 // room_groups.go is the API surface for channel-room groups (ADR-031).
 //
@@ -67,7 +70,7 @@ func (c *ChattoCore) CreateRoomGroup(ctx context.Context, actorID, name, descrip
 			},
 		},
 	})
-	if _, err := c.RoomGroupsProjector.AppendAndWait(ctx, c.EventPublisher, events.GroupAggregate(group.Id), createdEvent); err != nil {
+	if _, err := c.RoomGroupsProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.GroupAggregate(group.Id), createdEvent); err != nil {
 		return nil, fmt.Errorf("publish RoomGroupCreatedEvent: %w", err)
 	}
 
@@ -147,7 +150,7 @@ func (c *ChattoCore) DeleteRoomGroup(ctx context.Context, actorID, groupID strin
 			},
 		},
 	})
-	if _, err := c.RoomGroupsProjector.AppendAndWait(ctx, c.EventPublisher, events.GroupAggregate(groupID), deletedEvent); err != nil {
+	if _, err := c.RoomGroupsProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.GroupAggregate(groupID), deletedEvent); err != nil {
 		return fmt.Errorf("publish RoomGroupDeletedEvent: %w", err)
 	}
 
@@ -171,68 +174,97 @@ func (c *ChattoCore) DeleteRoomGroup(ctx context.Context, actorID, groupID strin
 // Authorization for the source and target groups must be checked by
 // the caller — see ADR-031's two-group rule.
 func (c *ChattoCore) MoveRoomToGroup(ctx context.Context, actorID, roomID, targetGroupID string) error {
-	if !c.RoomGroups.Exists(targetGroupID) {
-		return ErrRoomGroupNotFound
-	}
+	occFilter := events.GroupSubjectFilter()
+	for attempt := 0; attempt < maxMoveRoomToGroupRetries; attempt++ {
+		filterSeq, err := c.EventPublisher.LastSubjectSeq(ctx, occFilter)
+		if err != nil {
+			return fmt.Errorf("read room-group OCC seq: %w", err)
+		}
+		if filterSeq > 0 {
+			if err := c.RoomGroupsProjector.WaitForSeq(ctx, filterSeq); err != nil {
+				return fmt.Errorf("wait for groups projection: %w", err)
+			}
+		}
 
-	sourceGroupID := c.RoomGroups.GroupForRoom(roomID)
-	if sourceGroupID == targetGroupID {
-		// Already in the target group; idempotent no-op.
-		return nil
-	}
+		if !c.RoomGroups.Exists(targetGroupID) {
+			return ErrRoomGroupNotFound
+		}
 
-	// Build the move as an atomic batch (ADR-034 Approach A): the
-	// RoomRemovedFromGroup on the source and the RoomAddedToGroup on
-	// the target land adjacently in stream order. The "every room
-	// belongs to exactly one group" invariant therefore holds at
-	// every observable sequence — including across crashes, since
-	// the batch is all-or-nothing.
-	added := newEvent(actorID, &corev1.Event{
-		Event: &corev1.Event_RoomAddedToGroup{
-			RoomAddedToGroup: &corev1.RoomAddedToGroupEvent{
-				GroupId: targetGroupID,
-				RoomId:  roomID,
-			},
-		},
-	})
+		sourceGroupID := c.RoomGroups.GroupForRoom(roomID)
+		if sourceGroupID == targetGroupID {
+			// Already in the target group; idempotent no-op.
+			return nil
+		}
 
-	var entries []events.BatchEntry
-	if sourceGroupID != "" {
-		removed := newEvent(actorID, &corev1.Event{
-			Event: &corev1.Event_RoomRemovedFromGroup{
-				RoomRemovedFromGroup: &corev1.RoomRemovedFromGroupEvent{
-					GroupId: sourceGroupID,
+		// Build the move as an atomic batch (ADR-034 Approach A): the
+		// RoomRemovedFromGroup on the source and the RoomAddedToGroup on
+		// the target land adjacently in stream order. The first entry
+		// carries wildcard OCC over evt.group.>, so a concurrent move that
+		// changes any group membership forces a retry and a fresh source
+		// lookup before we publish.
+		added := newEvent(actorID, &corev1.Event{
+			Event: &corev1.Event_RoomAddedToGroup{
+				RoomAddedToGroup: &corev1.RoomAddedToGroupEvent{
+					GroupId: targetGroupID,
 					RoomId:  roomID,
 				},
 			},
 		})
-		sourceAgg := events.GroupAggregate(sourceGroupID)
+
+		var entries []events.BatchEntry
+		if sourceGroupID != "" {
+			removed := newEvent(actorID, &corev1.Event{
+				Event: &corev1.Event_RoomRemovedFromGroup{
+					RoomRemovedFromGroup: &corev1.RoomRemovedFromGroupEvent{
+						GroupId: sourceGroupID,
+						RoomId:  roomID,
+					},
+				},
+			})
+			sourceAgg := events.GroupAggregate(sourceGroupID)
+			entries = append(entries, events.BatchEntry{
+				Subject:       sourceAgg.SubjectFor(removed),
+				Event:         removed,
+				HasOCC:        true,
+				ExpectedSeq:   filterSeq,
+				FilterSubject: occFilter,
+			})
+		}
+		targetAgg := events.GroupAggregate(targetGroupID)
 		entries = append(entries, events.BatchEntry{
-			Subject: sourceAgg.SubjectFor(removed),
-			Event:   removed,
+			Subject: targetAgg.SubjectFor(added),
+			Event:   added,
 		})
-	}
-	targetAgg := events.GroupAggregate(targetGroupID)
-	entries = append(entries, events.BatchEntry{
-		Subject: targetAgg.SubjectFor(added),
-		Event:   added,
-	})
+		if !entries[0].HasOCC {
+			entries[0].HasOCC = true
+			entries[0].ExpectedSeq = filterSeq
+			entries[0].FilterSubject = occFilter
+		}
 
-	seqs, err := c.EventPublisher.AppendBatch(ctx, entries)
-	if err != nil {
-		return fmt.Errorf("publish move-room batch: %w", err)
-	}
+		seqs, err := c.EventPublisher.AppendBatch(ctx, entries)
+		if err == nil {
+			c.logger.Info("Moved room to group", "room_id", roomID, "group_id", targetGroupID, "actor_id", actorID)
+			c.notifyRoomLayoutChanged(ctx, actorID, "move_room")
 
-	c.logger.Info("Moved room to group", "room_id", roomID, "group_id", targetGroupID, "actor_id", actorID)
-	c.notifyRoomLayoutChanged(ctx, actorID, "move_room")
+			// Wait on the final seq — the projector applies in stream order
+			// so reaching the last batch entry's seq implies every earlier
+			// entry's Apply has also landed.
+			if err := c.RoomGroupsProjector.WaitForSeq(ctx, seqs[len(seqs)-1]); err != nil {
+				return fmt.Errorf("wait for groups projection: %w", err)
+			}
+			return nil
+		}
+		if !errors.Is(err, events.ErrConflict) {
+			return fmt.Errorf("publish move-room batch: %w", err)
+		}
 
-	// Wait on the final seq — the projector applies in stream order
-	// so reaching the last batch entry's seq implies every earlier
-	// entry's Apply has also landed.
-	if err := c.RoomGroupsProjector.WaitForSeq(ctx, seqs[len(seqs)-1]); err != nil {
-		return fmt.Errorf("wait for groups projection: %w", err)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Duration(1<<attempt) * time.Millisecond):
+		}
 	}
-	return nil
+	return fmt.Errorf("move-room OCC retry exhausted after %d attempts: %w", maxMoveRoomToGroupRetries, events.ErrConflict)
 }
 
 // ReorderRoomGroups publishes a RoomGroupsReorderedEvent with the

--- a/cli/internal/core/room_groups_test.go
+++ b/cli/internal/core/room_groups_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"errors"
+	"sync"
 	"testing"
 )
 
@@ -208,6 +209,57 @@ func TestMoveRoomToSet_Idempotent(t *testing.T) {
 	got, _ := core.GetRoomGroup(ctx, set.Id)
 	if len(got.RoomIds) != 1 {
 		t.Errorf("Room appears %d times in set, want exactly 1", len(got.RoomIds))
+	}
+}
+
+func TestMoveRoomToSet_ConcurrentMovesLeaveSingleAssignment(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	setA, _ := core.CreateRoomGroup(ctx, "actor", "A", "")
+	setB, _ := core.CreateRoomGroup(ctx, "actor", "B", "")
+	room, _ := core.CreateRoom(ctx, "actor", KindChannel, "", "general", "")
+
+	for i := 0; i < 25; i++ {
+		if err := core.MoveRoomToGroup(ctx, "actor", room.Id, setA.Id); err != nil {
+			t.Fatalf("reset move to A failed: %v", err)
+		}
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		errs := make(chan error, 2)
+		for _, target := range []string{setB.Id, setA.Id} {
+			wg.Add(1)
+			go func(target string) {
+				defer wg.Done()
+				<-start
+				errs <- core.MoveRoomToGroup(ctx, "actor", room.Id, target)
+			}(target)
+		}
+		close(start)
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			if err != nil {
+				t.Fatalf("concurrent MoveRoomToGroup failed: %v", err)
+			}
+		}
+
+		groups, err := core.ListRoomGroupsOrdered(ctx, KindChannel)
+		if err != nil {
+			t.Fatalf("ListRoomGroupsOrdered: %v", err)
+		}
+		assignments := 0
+		for _, group := range groups {
+			for _, roomID := range group.RoomIds {
+				if roomID == room.Id {
+					assignments++
+				}
+			}
+		}
+		if assignments != 1 {
+			t.Fatalf("iteration %d: room has %d group assignments, want exactly 1", i, assignments)
+		}
 	}
 }
 

--- a/cli/internal/core/room_membership.go
+++ b/cli/internal/core/room_membership.go
@@ -76,7 +76,7 @@ func (c *ChattoCore) JoinRoom(ctx context.Context, actorID string, kind RoomKind
 		},
 	})
 
-	if _, err := c.RoomMembershipProjector.AppendAndWait(ctx, c.EventPublisher, events.RoomAggregate(room_id), event); err != nil {
+	if _, err := c.RoomMembershipProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.RoomAggregate(room_id), event); err != nil {
 		return nil, fmt.Errorf("publish UserJoinedRoomEvent: %w", err)
 	}
 
@@ -136,7 +136,7 @@ func (c *ChattoCore) LeaveRoom(ctx context.Context, actorID string, kind RoomKin
 		},
 	})
 
-	if _, err := c.RoomMembershipProjector.AppendAndWait(ctx, c.EventPublisher, events.RoomAggregate(room_id), event); err != nil {
+	if _, err := c.RoomMembershipProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.RoomAggregate(room_id), event); err != nil {
 		return fmt.Errorf("publish UserLeftRoomEvent: %w", err)
 	}
 
@@ -232,7 +232,7 @@ func (c *ChattoCore) deleteUserRoomMembershipsInSpace(ctx context.Context, user_
 			},
 		})
 
-		seq, err := c.EventPublisher.Append(ctx, events.RoomAggregate(entry.roomID).SubjectFor(event), event)
+		seq, err := c.EventPublisher.AppendEventually(ctx, events.RoomAggregate(entry.roomID).SubjectFor(event), event)
 		if err != nil {
 			c.logger.Warn("Failed to publish UserLeftRoomEvent to EVT", "room_id", entry.roomID, "error", err)
 			continue

--- a/cli/internal/core/rooms.go
+++ b/cli/internal/core/rooms.go
@@ -268,9 +268,11 @@ func (c *ChattoCore) publishRoomEventWithNameOCC(ctx context.Context, name strin
 	// all target the per-room aggregate subject; this doesn't change
 	// across retries.
 	var roomID string
+	retrySamePayload := false
 	switch e := event.GetEvent().(type) {
 	case *corev1.Event_RoomCreated:
 		roomID = e.RoomCreated.GetRoomId()
+		retrySamePayload = true
 	case *corev1.Event_RoomUpdated:
 		roomID = e.RoomUpdated.GetRoomId()
 	default:
@@ -294,6 +296,9 @@ func (c *ChattoCore) publishRoomEventWithNameOCC(ctx context.Context, name strin
 			return seq, nil
 		}
 		if !errors.Is(err, events.ErrConflict) {
+			return 0, err
+		}
+		if !retrySamePayload {
 			return 0, err
 		}
 
@@ -397,7 +402,7 @@ func (c *ChattoCore) DeleteRoom(ctx context.Context, actorID string, kind RoomKi
 			},
 		},
 	})
-	seq, err := c.EventPublisher.Append(ctx, events.RoomAggregate(room_id).SubjectFor(event), event)
+	seq, err := c.EventPublisher.AppendEventually(ctx, events.RoomAggregate(room_id).SubjectFor(event), event)
 	if err != nil {
 		return fmt.Errorf("publish RoomDeletedEvent: %w", err)
 	}
@@ -415,7 +420,7 @@ func (c *ChattoCore) DeleteRoom(ctx context.Context, actorID string, kind RoomKi
 				},
 			},
 		})
-		groupRemovedSeq, err = c.EventPublisher.Append(ctx, events.GroupAggregate(room.GetGroupId()).SubjectFor(removed), removed)
+		groupRemovedSeq, err = c.EventPublisher.AppendEventually(ctx, events.GroupAggregate(room.GetGroupId()).SubjectFor(removed), removed)
 		if err != nil {
 			c.logger.Error("failed to publish RoomRemovedFromGroupEvent for delete cascade", "error", err, "room_id", room_id, "group_id", room.GetGroupId())
 		}
@@ -478,7 +483,7 @@ func (c *ChattoCore) ArchiveRoom(ctx context.Context, actorID string, kind RoomK
 			},
 		},
 	})
-	if _, err := c.RoomCatalogProjector.AppendAndWait(ctx, c.EventPublisher, events.RoomAggregate(roomID), archivedEvent); err != nil {
+	if _, err := c.RoomCatalogProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.RoomAggregate(roomID), archivedEvent); err != nil {
 		return nil, fmt.Errorf("publish RoomArchivedEvent: %w", err)
 	}
 
@@ -513,7 +518,7 @@ func (c *ChattoCore) UnarchiveRoom(ctx context.Context, actorID string, kind Roo
 			},
 		},
 	})
-	if _, err := c.RoomCatalogProjector.AppendAndWait(ctx, c.EventPublisher, events.RoomAggregate(roomID), unarchivedEvent); err != nil {
+	if _, err := c.RoomCatalogProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.RoomAggregate(roomID), unarchivedEvent); err != nil {
 		return nil, fmt.Errorf("publish RoomUnarchivedEvent: %w", err)
 	}
 

--- a/cli/internal/core/rooms.go
+++ b/cli/internal/core/rooms.go
@@ -268,11 +268,9 @@ func (c *ChattoCore) publishRoomEventWithNameOCC(ctx context.Context, name strin
 	// all target the per-room aggregate subject; this doesn't change
 	// across retries.
 	var roomID string
-	retrySamePayload := false
 	switch e := event.GetEvent().(type) {
 	case *corev1.Event_RoomCreated:
 		roomID = e.RoomCreated.GetRoomId()
-		retrySamePayload = true
 	case *corev1.Event_RoomUpdated:
 		roomID = e.RoomUpdated.GetRoomId()
 	default:
@@ -296,9 +294,6 @@ func (c *ChattoCore) publishRoomEventWithNameOCC(ctx context.Context, name strin
 			return seq, nil
 		}
 		if !errors.Is(err, events.ErrConflict) {
-			return 0, err
-		}
-		if !retrySamePayload {
 			return 0, err
 		}
 

--- a/cli/internal/events/events_test.go
+++ b/cli/internal/events/events_test.go
@@ -147,10 +147,10 @@ func TestPublisher_Append_RejectsInvalidEvent(t *testing.T) {
 	}
 }
 
-func TestPublisher_Append_ConcurrentWrites(t *testing.T) {
+func TestPublisher_AppendEventually_ConcurrentWrites(t *testing.T) {
 	// Multiple goroutines append to the same subject. Each should succeed
-	// (Append retries on OCC conflict); the final per-subject seq should
-	// equal the number of writes.
+	// (AppendEventually retries on OCC conflict); the final per-subject
+	// seq should equal the number of writes.
 	js, stream := setupTestStream(t)
 	pub := NewPublisher(js, stream, testLogger())
 	ctx := testContext(t)
@@ -164,7 +164,7 @@ func TestPublisher_Append_ConcurrentWrites(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			_, err := pub.Append(ctx, subject, makeEvent("R1", "U"+itoa(i)))
+			_, err := pub.AppendEventually(ctx, subject, makeEvent("R1", "U"+itoa(i)))
 			if err != nil {
 				errCh <- err
 			}
@@ -256,7 +256,7 @@ func TestPublisher_AppendBatch_LandsContiguouslyAtomic(t *testing.T) {
 	}
 
 	entries := []BatchEntry{
-		{Subject: GroupAggregate("GA").Subject(EventUserJoinedRoom), Event: makeEvent("RA", "U1")},
+		{Subject: GroupAggregate("GA").Subject(EventUserJoinedRoom), Event: makeEvent("RA", "U1"), HasOCC: true, ExpectedSeq: 0},
 		{Subject: GroupAggregate("GB").Subject(EventUserJoinedRoom), Event: makeEvent("RB", "U2")},
 		{Subject: GroupAggregate("GC").Subject(EventUserJoinedRoom), Event: makeEvent("RC", "U3")},
 	}
@@ -281,6 +281,21 @@ func TestPublisher_AppendBatch_LandsContiguouslyAtomic(t *testing.T) {
 		if got != seqs[i] {
 			t.Errorf("subject %s last seq = %d, want %d", e.Subject, got, seqs[i])
 		}
+	}
+}
+
+func TestPublisher_AppendBatch_RejectsUnguardedBatch(t *testing.T) {
+	js, stream := setupTestStream(t)
+	pub := NewPublisher(js, stream, testLogger())
+
+	entries := []BatchEntry{
+		{Subject: GroupAggregate("GA").Subject(EventUserJoinedRoom), Event: makeEvent("RA", "U1")},
+		{Subject: GroupAggregate("GB").Subject(EventUserJoinedRoom), Event: makeEvent("RB", "U2")},
+	}
+
+	_, err := pub.AppendBatch(testContext(t), entries)
+	if !errors.Is(err, ErrMissingOCC) {
+		t.Fatalf("want ErrMissingOCC, got %v", err)
 	}
 }
 
@@ -487,6 +502,47 @@ func TestProjector_WaitForSeq_HonoursContextCancel(t *testing.T) {
 	defer cancel()
 	if err := projector.WaitForSeq(ctx, 9999); !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("want DeadlineExceeded, got %v", err)
+	}
+}
+
+type failingProjection struct {
+	*trackingProjection
+	err error
+}
+
+func (p *failingProjection) Apply(_ *corev1.Event, _ uint64) error {
+	return p.err
+}
+
+func TestProjector_WaitForSeq_ReturnsProjectionError(t *testing.T) {
+	js, stream := setupTestStream(t)
+	pub := NewPublisher(js, stream, testLogger())
+	applyErr := errors.New("apply failed")
+	proj := &failingProjection{
+		trackingProjection: newTrackingProjection(RoomSubjectFilter()),
+		err:                applyErr,
+	}
+	projector := NewProjector(js, stream, proj, testLogger())
+
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	t.Cleanup(cancelRun)
+	go func() { _ = projector.Run(runCtx) }()
+
+	ctx := testContext(t)
+	seq, err := pub.Append(ctx, RoomAggregate("R1").Subject(EventUserJoinedRoom), makeEvent("R1", "U1"))
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	err = projector.WaitForSeq(ctx, seq)
+	if !errors.Is(err, ErrProjectionFailed) {
+		t.Fatalf("want ErrProjectionFailed, got %v", err)
+	}
+	if !errors.Is(err, applyErr) {
+		t.Fatalf("want wrapped apply error, got %v", err)
+	}
+	if got := projector.LastSeq(); got >= seq {
+		t.Fatalf("LastSeq=%d, want less than failed seq %d", got, seq)
 	}
 }
 

--- a/cli/internal/events/projector.go
+++ b/cli/internal/events/projector.go
@@ -14,6 +14,10 @@ import (
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
+// ErrProjectionFailed marks a projector that stopped applying events
+// because its Projection.Apply returned an error.
+var ErrProjectionFailed = errors.New("projection failed")
+
 // MemoryProjection is an embeddable base for projections whose state
 // lives entirely in process memory. It contributes a sync.RWMutex that
 // subclasses use for read/write coordination, plus no-op
@@ -76,9 +80,11 @@ type Projector struct {
 	proj   Projection
 	logger Logger
 
-	mu      sync.Mutex
-	lastSeq uint64
-	waiters []seqWaiter
+	mu        sync.Mutex
+	lastSeq   uint64
+	waiters   []seqWaiter
+	failedSeq uint64
+	failedErr error
 	// started flips true the first time Run is invoked and stays true
 	// for the projector's lifetime. WaitForSeq uses this to short-
 	// circuit during boot-time mutations that happen before
@@ -132,9 +138,9 @@ func (p *Projector) Subjects() []string {
 // `agg.SubjectFor(event)`, so the caller cannot accidentally publish an
 // event onto the wrong subject for its payload.
 //
-// This is the canonical "publish-then read-your-writes" primitive —
-// every caller that needs to read its own write through the projection
-// should use this rather than hand-rolling Append + WaitForSeq.
+// This is the single-shot "publish-then read-your-writes" primitive.
+// If it returns ErrConflict, state-replacement callers must re-read and
+// re-compose before retrying.
 //
 // Returns the stream sequence the publish landed at, plus any error.
 // On a publish failure the sequence is 0; on a wait failure (most
@@ -143,6 +149,20 @@ func (p *Projector) Subjects() []string {
 // hasn't caught up.
 func (p *Projector) AppendAndWait(ctx context.Context, pub *Publisher, agg Aggregate, event *corev1.Event) (uint64, error) {
 	seq, err := pub.Append(ctx, agg.SubjectFor(event), event)
+	if err != nil {
+		return 0, err
+	}
+	if err := p.WaitForSeq(ctx, seq); err != nil {
+		return seq, err
+	}
+	return seq, nil
+}
+
+// AppendEventuallyAndWait is AppendAndWait for append-only events that can
+// safely retry the same payload after an OCC conflict. See
+// Publisher.AppendEventually for the safety rule.
+func (p *Projector) AppendEventuallyAndWait(ctx context.Context, pub *Publisher, agg Aggregate, event *corev1.Event) (uint64, error) {
+	seq, err := pub.AppendEventually(ctx, agg.SubjectFor(event), event)
 	if err != nil {
 		return 0, err
 	}
@@ -170,6 +190,11 @@ func (p *Projector) AppendAndWait(ctx context.Context, pub *Publisher, agg Aggre
 // out of sync with the KV write and produces orphan-room bugs.
 func (p *Projector) WaitForSeq(ctx context.Context, seq uint64) error {
 	p.mu.Lock()
+	if p.failedErr != nil && seq >= p.failedSeq {
+		err := p.failedErr
+		p.mu.Unlock()
+		return err
+	}
 	if p.lastSeq >= seq {
 		p.mu.Unlock()
 		return nil
@@ -185,6 +210,13 @@ func (p *Projector) WaitForSeq(ctx context.Context, seq uint64) error {
 
 	select {
 	case <-ch:
+		p.mu.Lock()
+		err := p.failedErr
+		failedSeq := p.failedSeq
+		p.mu.Unlock()
+		if err != nil && seq >= failedSeq {
+			return err
+		}
 		return nil
 	case <-ctx.Done():
 		// Drop our waiter so we don't leak. The advance path tolerates
@@ -259,6 +291,19 @@ func (p *Projector) advance(seq uint64) {
 	}
 }
 
+func (p *Projector) fail(seq uint64, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.failedErr == nil {
+		p.failedSeq = seq
+		p.failedErr = fmt.Errorf("%w at seq %d: %w", ErrProjectionFailed, seq, err)
+	}
+	for _, w := range p.waiters {
+		close(w.ch)
+	}
+	p.waiters = nil
+}
+
 // Run starts the consumer + apply loop. Blocks until ctx is cancelled.
 // Returns the context's error on shutdown.
 //
@@ -306,10 +351,17 @@ func (p *Projector) Run(ctx context.Context) error {
 // Consume handler. It is invoked from a single goroutine the SDK owns, in
 // stream order — matching the Projection.Apply concurrency contract.
 //
-// Errors from the projection's Apply are logged and swallowed per
-// ADR-033's "a projection bug shouldn't stall the consumer" rule. Stream
-// sequence is advanced regardless so WaitForSeq waiters unblock.
+// Errors from the projection's Apply mark the projector as failed. Waiters
+// for the failed sequence (or later) return ErrProjectionFailed instead of
+// reporting read-your-writes success against state that did not apply.
 func (p *Projector) handleMessage(msg jetstream.Msg) {
+	p.mu.Lock()
+	failed := p.failedErr != nil
+	p.mu.Unlock()
+	if failed {
+		return
+	}
+
 	meta, err := msg.Metadata()
 	if err != nil {
 		p.logger.Warn("Skipping event with no metadata", "subject", msg.Subject(), "error", err)
@@ -332,6 +384,8 @@ func (p *Projector) handleMessage(msg jetstream.Msg) {
 			"seq", meta.Sequence.Stream,
 			"event_id", event.GetId(),
 			"error", err)
+		p.fail(meta.Sequence.Stream, err)
+		return
 	}
 
 	p.advance(meta.Sequence.Stream)

--- a/cli/internal/events/publisher.go
+++ b/cli/internal/events/publisher.go
@@ -46,6 +46,11 @@ var ErrConflict = errors.New("expected-last-subject-sequence mismatch")
 // not well-formed before publish.
 var ErrInvalidEvent = errors.New("invalid event")
 
+// ErrMissingOCC is returned when an atomic batch contains no optimistic
+// concurrency guard. Every batch needs at least one guard so there is no
+// accidental "publish without OCC" path through the framework.
+var ErrMissingOCC = errors.New("missing optimistic concurrency guard")
+
 // Publisher writes events to a JetStream stream with optimistic concurrency
 // control. The stream is expected to be the EVT stream; the Publisher
 // itself doesn't enforce that — it operates on whatever stream is passed in,
@@ -64,14 +69,37 @@ func NewPublisher(js jetstream.JetStream, stream jetstream.Stream, logger Logger
 const maxAppendRetries = 5
 
 // Append publishes an event to a subject, automatically computing the
-// expected last subject sequence from the stream and retrying on conflict.
-// Returns the new stream sequence on success.
+// expected last subject sequence from the stream. Returns the new stream
+// sequence on success.
 //
 // This is the bread-and-butter mutation primitive: read state, decide the
-// write, call Append, get a seq back. The OCC retry handles concurrent
-// writers transparently. For deterministic-sequence callers (migrations),
-// use AppendAt instead.
+// write, call Append, get a seq back. Conflicts are returned to the caller
+// so state-replacement mutations can re-read and re-compose before retrying.
+// For deterministic-sequence callers (migrations), use AppendAt instead.
 func (p *Publisher) Append(ctx context.Context, subject string, event *corev1.Event) (uint64, error) {
+	if err := validateEvent(event); err != nil {
+		return 0, err
+	}
+
+	data, err := proto.Marshal(event)
+	if err != nil {
+		return 0, fmt.Errorf("marshal event: %w", err)
+	}
+
+	expectedSeq, err := p.lastSubjectSeq(ctx, subject)
+	if err != nil {
+		return 0, err
+	}
+	return p.publishAt(ctx, subject, data, expectedSeq, "")
+}
+
+// AppendEventually is the append-only variant of Append: it retries OCC
+// conflicts with the same event payload. Use it only for event types where
+// retrying the exact same fact is safe after an intervening write, such as
+// message posts, membership joins/leaves, and tombstone-style lifecycle
+// events. State-replacement events should use Append or AppendAt and
+// re-compose from the latest projection state on conflict.
+func (p *Publisher) AppendEventually(ctx context.Context, subject string, event *corev1.Event) (uint64, error) {
 	if err := validateEvent(event); err != nil {
 		return 0, err
 	}
@@ -246,6 +274,16 @@ func (p *Publisher) AppendBatch(ctx context.Context, entries []BatchEntry) ([]ui
 		if err := validateEvent(e.Event); err != nil {
 			return nil, fmt.Errorf("batch entry %d: %w", i, err)
 		}
+	}
+	hasOCC := false
+	for _, e := range entries {
+		if e.HasOCC {
+			hasOCC = true
+			break
+		}
+	}
+	if !hasOCC {
+		return nil, ErrMissingOCC
 	}
 
 	batchID, err := newBatchID()


### PR DESCRIPTION
Harden ES publisher/projector semantics so single-shot writes do not retry stale payloads, append-only writes opt into retries, and unguarded atomic batches are rejected.

Fix config updates and room group moves to recompose or retry from fresh projection state under OCC, and surface projection apply failures through WaitForSeq.

Tests: go test ./internal/events; go test ./internal/migrations; go test ./internal/core