### PR TITLE
feat: event-source user accounts

### DIFF
--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -149,6 +149,14 @@ type ChattoCore struct {
 	// for WaitForSeq from reaction writers.
 	ReactionsProjector *events.Projector
 
+	// Users holds current user/account/profile/auth lookup state derived
+	// from durable user-aggregate events.
+	Users *UserProjection
+
+	// UsersProjector runs the consumer for Users. Exposed for
+	// WaitForSeq from user/account writers.
+	UsersProjector *events.Projector
+
 	// projectors is the set of all event-sourcing projectors owned by
 	// this core. Each new aggregate migration (ADR-035) appends here
 	// during NewChattoCore; Run iterates the slice. Adding a projector
@@ -592,6 +600,9 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	reactions := NewReactionProjection()
 	reactionsProjector := newProjector(reactions, "ReactionsProjector")
 
+	users := NewUserProjection()
+	usersProjector := newProjector(users, "UsersProjector")
+
 	// ConfigManager owns event-only server-config writes; it needs the
 	// publisher (for ServerConfigChangedEvent), the projector
 	// (WaitForSeq for read-your-writes), and the projection (for reads).
@@ -623,6 +634,8 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 		ThreadsProjector:        threadsProjector,
 		Reactions:               reactions,
 		ReactionsProjector:      reactionsProjector,
+		Users:                   users,
+		UsersProjector:          usersProjector,
 		projectors:              projectors,
 		bootDone:                make(chan struct{}),
 	}

--- a/cli/internal/core/es_boot_verification.go
+++ b/cli/internal/core/es_boot_verification.go
@@ -32,6 +32,9 @@ type esLegacyCounts struct {
 	serverConfigPresent bool
 	messages            int
 	reactions           int
+	users               int
+	verifiedEmails      int
+	oidcSubjects        int
 	encryptionKeys      int
 }
 
@@ -52,6 +55,9 @@ type esProjectedCounts struct {
 	threadReplies          int
 	reactionMessages       int
 	activeReactions        int
+	users                  int
+	verifiedEmails         int
+	oidcSubjects           int
 }
 
 // logESBootVerification emits a structured summary of the ES import and
@@ -80,6 +86,12 @@ func (c *ChattoCore) logESBootVerification(ctx context.Context) {
 		"projected_message_posts", report.projected.messagePosts,
 		"legacy_reactions", report.legacy.reactions,
 		"projected_active_reactions", report.projected.activeReactions,
+		"legacy_users", report.legacy.users,
+		"projected_users", report.projected.users,
+		"legacy_verified_emails", report.legacy.verifiedEmails,
+		"projected_verified_emails", report.projected.verifiedEmails,
+		"legacy_oidc_subjects", report.legacy.oidcSubjects,
+		"projected_oidc_subjects", report.projected.oidcSubjects,
 		"server_config_legacy", report.legacy.serverConfigPresent,
 		"server_config_projected", report.projected.serverConfigConfigured,
 		"room_layout_legacy", report.legacy.roomLayoutPresent,
@@ -101,6 +113,8 @@ func (c *ChattoCore) logESBootVerification(ctx context.Context) {
 		"thread_entries", report.projected.threadEntries,
 		"thread_replies", report.projected.threadReplies,
 		"reaction_messages", report.projected.reactionMessages,
+		"verified_emails", report.projected.verifiedEmails,
+		"oidc_subjects", report.projected.oidcSubjects,
 	)
 
 	c.logESEventCounts(report.eventCounts)
@@ -166,6 +180,18 @@ func (c *ChattoCore) collectLegacyESCounts(ctx context.Context) (esLegacyCounts,
 	if err != nil {
 		return counts, warnings, fmt.Errorf("count legacy reactions: %w", err)
 	}
+	counts.users, err = countLegacyUserRecords(ctx, c.storage.serverConfigKV)
+	if err != nil {
+		return counts, warnings, fmt.Errorf("count legacy users: %w", err)
+	}
+	counts.verifiedEmails, err = countKVKeys(ctx, c.storage.serverConfigKV, "verified_emails.*.*")
+	if err != nil {
+		return counts, warnings, fmt.Errorf("count legacy verified emails: %w", err)
+	}
+	counts.oidcSubjects, err = countKVKeys(ctx, c.storage.serverConfigKV, "user_by_oidc.*")
+	if err != nil {
+		return counts, warnings, fmt.Errorf("count legacy OIDC subjects: %w", err)
+	}
 	counts.encryptionKeys, err = countKVKeys(ctx, c.storage.encryptionKV)
 	if err != nil {
 		return counts, warnings, fmt.Errorf("count encryption keys: %w", err)
@@ -181,6 +207,7 @@ func (c *ChattoCore) collectProjectedESCounts() esProjectedCounts {
 	timelineRooms, timelineEntries, messagePosts := c.RoomTimeline.Stats()
 	threads, threadEntries, threadReplies := c.Threads.Stats()
 	reactionMessages, activeReactions := c.Reactions.Stats()
+	users, verifiedEmails, oidcSubjects := c.Users.Stats()
 	_, serverConfigConfigured := c.ServerConfig.Get()
 
 	return esProjectedCounts{
@@ -200,6 +227,9 @@ func (c *ChattoCore) collectProjectedESCounts() esProjectedCounts {
 		threadReplies:          threadReplies,
 		reactionMessages:       reactionMessages,
 		activeReactions:        activeReactions,
+		users:                  users,
+		verifiedEmails:         verifiedEmails,
+		oidcSubjects:           oidcSubjects,
 	}
 }
 
@@ -214,6 +244,9 @@ func (c *ChattoCore) evaluateESBootVerificationReport(r *esBootVerificationRepor
 	compareAtLeast("room groups", r.legacy.roomGroups, r.projected.roomGroups)
 	compareAtLeast("messages", r.legacy.messages, r.projected.messagePosts)
 	compareAtLeast("reactions", r.legacy.reactions, r.projected.activeReactions)
+	compareAtLeast("users", r.legacy.users, r.projected.users)
+	compareAtLeast("verified emails", r.legacy.verifiedEmails, r.projected.verifiedEmails)
+	compareAtLeast("OIDC subjects", r.legacy.oidcSubjects, r.projected.oidcSubjects)
 
 	if r.legacy.serverConfigPresent && !r.projected.serverConfigConfigured {
 		r.problems = append(r.problems, "server config: legacy config.instance exists but projection is not configured")
@@ -316,6 +349,23 @@ func countKVKeys(ctx context.Context, kv jetstream.KeyValue, filters ...string) 
 	var count int
 	for range lister.Keys() {
 		count++
+	}
+	return count, nil
+}
+
+func countLegacyUserRecords(ctx context.Context, kv jetstream.KeyValue) (int, error) {
+	lister, err := kv.ListKeysFiltered(ctx, "user.*")
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	var count int
+	for key := range lister.Keys() {
+		if len(strings.Split(key, ".")) == 2 {
+			count++
+		}
 	}
 	return count, nil
 }

--- a/cli/internal/core/oidc.go
+++ b/cli/internal/core/oidc.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/nats-io/nats.go/jetstream"
+	"hmans.de/chatto/internal/events"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
@@ -19,40 +19,39 @@ var (
 // userByOIDCSubjectKey returns the KV key for the OIDC subject-to-user index.
 // Uses SHA256 hash of "issuer:subject" to ensure valid NATS subject characters.
 func userByOIDCSubjectKey(issuer, subject string) string {
+	return fmt.Sprintf("user_by_oidc.%s", oidcSubjectHash(issuer, subject))
+}
+
+func oidcSubjectHash(issuer, subject string) string {
 	hash := sha256.Sum256([]byte(issuer + ":" + subject))
-	return fmt.Sprintf("user_by_oidc.%s", hex.EncodeToString(hash[:]))
+	return hex.EncodeToString(hash[:])
 }
 
 // GetUserByOIDCSubject looks up a user by their OIDC issuer and subject.
 func (c *ChattoCore) GetUserByOIDCSubject(ctx context.Context, issuer, subject string) (*corev1.User, error) {
-	key := userByOIDCSubjectKey(issuer, subject)
-
-	entry, err := c.storage.serverKV.Get(ctx, key)
-	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("failed to lookup user by OIDC subject: %w", err)
+	if user, ok := c.Users.GetByOIDCSubject(issuer, subject); ok {
+		return user, nil
 	}
-
-	userID := string(entry.Value())
-	return c.GetUser(ctx, userID)
+	return nil, nil
 }
 
 // LinkOIDCSubject links an OIDC subject to a Chatto user. Uses atomic create
 // to prevent race conditions. Idempotent if already linked to the same user.
 func (c *ChattoCore) LinkOIDCSubject(ctx context.Context, issuer, subject, userID string) error {
-	key := userByOIDCSubjectKey(issuer, subject)
-
-	_, err := c.storage.serverKV.Create(ctx, key, []byte(userID))
-	if err != nil {
-		// Already claimed — check if it's by the same user (idempotent)
-		entry, getErr := c.storage.serverKV.Get(ctx, key)
-		if getErr == nil && string(entry.Value()) == userID {
-			return nil // Already linked to this user
+	event := newEvent(userID, &corev1.Event{Event: &corev1.Event_UserOidcSubjectLinked{
+		UserOidcSubjectLinked: &corev1.UserOIDCSubjectLinkedEvent{
+			UserId:      userID,
+			Issuer:      issuer,
+			Subject:     subject,
+			SubjectHash: oidcSubjectHash(issuer, subject),
+		},
+	}})
+	_, err := c.appendUserEvent(ctx, userID, event, events.UserSubjectFilter(), func() error {
+		existing, ok := c.Users.GetByOIDCSubject(issuer, subject)
+		if ok && existing.GetId() != userID {
+			return ErrOIDCSubjectAlreadyClaimed
 		}
-		return ErrOIDCSubjectAlreadyClaimed
-	}
-
-	return nil
+		return nil
+	})
+	return err
 }

--- a/cli/internal/core/password_reset.go
+++ b/cli/internal/core/password_reset.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/nats-io/nats.go/jetstream"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
 // ============================================================================
@@ -151,10 +153,13 @@ func (c *ChattoCore) ResetPassword(ctx context.Context, token string, newPasswor
 	// Delete token immediately to prevent reuse (even if password update fails)
 	defer c.deletePasswordResetToken(ctx, token)
 
-	// Update the password
-	passwordKey := fmt.Sprintf("auth.%s.password", tokenData.UserID)
-	_, err = c.storage.serverKV.Put(ctx, passwordKey, []byte(newPasswordHash))
-	if err != nil {
+	event := newEvent(tokenData.UserID, &corev1.Event{Event: &corev1.Event_UserPasswordHashChanged{
+		UserPasswordHashChanged: &corev1.UserPasswordHashChangedEvent{
+			UserId:       tokenData.UserID,
+			PasswordHash: []byte(newPasswordHash),
+		},
+	}})
+	if _, err := c.appendUserEvent(ctx, tokenData.UserID, event, "", nil); err != nil {
 		return fmt.Errorf("failed to update password: %w", err)
 	}
 

--- a/cli/internal/core/projection_admin.go
+++ b/cli/internal/core/projection_admin.go
@@ -45,7 +45,7 @@ func (c *ChattoCore) ProjectionAdminStates(ctx context.Context) ([]ProjectionAdm
 	}
 	streamLastSeq := info.State.LastSeq
 
-	states := make([]ProjectionAdminState, 0, 8)
+	states := make([]ProjectionAdminState, 0, 9)
 	add := func(name string, projector *events.Projector, entries int64, estimatedBytes int64, metrics []ProjectionAdminMetric) error {
 		targetSeq, err := projector.CurrentTargetSeq(ctx)
 		if err != nil {
@@ -108,6 +108,10 @@ func (c *ChattoCore) ProjectionAdminStates(ctx context.Context) ([]ProjectionAdm
 		func() error {
 			entries, bytes, metrics := c.Reactions.adminProjectionEstimate()
 			return add("Reactions", c.ReactionsProjector, entries, bytes, metrics)
+		},
+		func() error {
+			entries, bytes, metrics := c.Users.adminProjectionEstimate()
+			return add("Users", c.UsersProjector, entries, bytes, metrics)
 		},
 	} {
 		if err := collect(); err != nil {
@@ -308,6 +312,64 @@ func (p *ReactionProjection) adminProjectionEstimate() (int64, int64, []Projecti
 		{Name: "emoji_groups", Value: emojiGroups, Bytes: 0},
 		{Name: "active_reactions", Value: active, Bytes: bytes - seenBytes},
 		{Name: "seen_event_ids", Value: int64(len(p.seen)), Bytes: seenBytes},
+	}
+}
+
+func (p *UserProjection) adminProjectionEstimate() (int64, int64, []ProjectionAdminMetric) {
+	p.RLock()
+	defer p.RUnlock()
+	var users, deleted, verifiedEmails, bytes int64
+	for userID, user := range p.users {
+		userBytes := projectionMapEntryOverhead + int64(len(userID))
+		if user == nil {
+			bytes += userBytes
+			continue
+		}
+		if user.deleted {
+			deleted++
+		} else if user.user != nil {
+			users++
+		}
+		if user.user != nil {
+			userBytes += int64(proto.Size(user.user))
+		}
+		if user.avatar != nil {
+			userBytes += int64(proto.Size(user.avatar))
+		}
+		if len(user.passwordHash) > 0 {
+			userBytes += projectionSliceEntryOverhead + int64(len(user.passwordHash))
+		}
+		for hash, email := range user.verifiedEmail {
+			verifiedEmails++
+			userBytes += projectionMapEntryOverhead + int64(len(hash)+len(email.Email)) + 8
+		}
+		if user.preferences != nil {
+			userBytes += int64(proto.Size(user.preferences))
+		}
+		bytes += userBytes
+	}
+	loginBytes := int64(len(p.loginIndex)) * projectionMapEntryOverhead
+	for login, userID := range p.loginIndex {
+		loginBytes += int64(len(login) + len(userID))
+	}
+	emailBytes := int64(len(p.emailIndex)) * projectionMapEntryOverhead
+	for hash, userID := range p.emailIndex {
+		emailBytes += int64(len(hash) + len(userID))
+	}
+	oidcBytes := int64(len(p.oidcIndex)) * projectionMapEntryOverhead
+	for hash, userID := range p.oidcIndex {
+		oidcBytes += int64(len(hash) + len(userID))
+	}
+	seenBytes := int64(len(p.eventIDSeen)) * projectionMapEntryOverhead
+	bytes += loginBytes + emailBytes + oidcBytes + seenBytes
+	return users, bytes, []ProjectionAdminMetric{
+		{Name: "users", Value: users, Bytes: 0},
+		{Name: "deleted_users", Value: deleted, Bytes: 0},
+		{Name: "verified_emails", Value: verifiedEmails, Bytes: 0},
+		{Name: "login_index", Value: int64(len(p.loginIndex)), Bytes: loginBytes},
+		{Name: "email_index", Value: int64(len(p.emailIndex)), Bytes: emailBytes},
+		{Name: "oidc_index", Value: int64(len(p.oidcIndex)), Bytes: oidcBytes},
+		{Name: "seen_event_ids", Value: int64(len(p.eventIDSeen)), Bytes: seenBytes},
 	}
 }
 

--- a/cli/internal/core/rbac_test.go
+++ b/cli/internal/core/rbac_test.go
@@ -176,6 +176,7 @@ func TestChattoCore_initServerRBAC_PreservesPermissionChanges(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create first ChattoCore: %v", err)
 	}
+	startCoreServices(t, core1)
 
 	// Create a user
 	user, err := core1.CreateUser(ctx, "", "testuser", "Test User", "password123")
@@ -213,6 +214,7 @@ func TestChattoCore_initServerRBAC_PreservesPermissionChanges(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create second ChattoCore: %v", err)
 	}
+	startCoreServices(t, core2)
 
 	// Step 4: Verify the permission change was preserved
 	hasPerm, err = core2.HasServerPermission(ctx, user.Id, PermDMWrite)
@@ -1344,7 +1346,6 @@ func TestChattoCore_CreateRole_InvalidName(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-
 	// Try to create role with invalid name
 	_, err := core.CreateServerRole(ctx, "Invalid-Name", "Invalid", "Should fail")
 	if err == nil {
@@ -1358,7 +1359,6 @@ func TestChattoCore_CreateRole_InvalidName(t *testing.T) {
 func TestChattoCore_CreateRole_Duplicate(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
-
 
 	// Create a role
 	_, err := core.CreateServerRole(ctx, "testmod", "Test Mod", "First")
@@ -1379,7 +1379,6 @@ func TestChattoCore_CreateRole_Duplicate(t *testing.T) {
 func TestChattoCore_GetRole(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
-
 
 	// Create a role
 	_, err := core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate content")
@@ -1406,7 +1405,6 @@ func TestChattoCore_GetRole_NotFound(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-
 	// Try to get nonexistent role
 	_, err := core.GetServerRole(ctx, "nonexistent")
 	if err == nil {
@@ -1421,7 +1419,6 @@ func TestChattoCore_GetRole_NotFound(t *testing.T) {
 func TestChattoCore_ListRoles(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
-
 
 	// Initially should have 4 default roles (owner, admin, moderator, everyone) created by CreateSpace
 	roles, err := core.ListServerRoles(ctx)
@@ -1449,7 +1446,6 @@ func TestChattoCore_ListRoles(t *testing.T) {
 func TestChattoCore_UpdateRole(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
-
 
 	// Create a role
 	_, err := core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate content")
@@ -1486,7 +1482,6 @@ func TestChattoCore_DeleteRole(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-
 	// Create a role
 	_, err := core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate content")
 	if err != nil {
@@ -1509,7 +1504,6 @@ func TestChattoCore_DeleteRole(t *testing.T) {
 func TestChattoCore_DeleteRole_SystemRole(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
-
 
 	// Admin role is automatically created by CreateSpace via CreateDefaultRoles
 	// Verify it exists
@@ -1538,7 +1532,6 @@ func TestChattoCore_DeleteRole_SystemRole(t *testing.T) {
 func TestChattoCore_DeleteRole_CleansUpPermissionsAndAssignments(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
-
 
 	// Create a role, grant permissions, and assign to a user
 	_, err := core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
@@ -1809,7 +1802,6 @@ func TestChattoCore_AssignRole_RoleNotFound(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-
 	// Try to assign nonexistent role
 	err := core.AssignServerRole(ctx, SystemActorID, "user123", "nonexistent")
 	if !errors.Is(err, ErrRoleNotFound) {
@@ -1854,7 +1846,6 @@ func TestChattoCore_RevokeRole_AdminCannotDemotePeerAdmin(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-
 	// Create two admins (must be space members for permission checks)
 	adminA := "admin-a"
 	adminB := "admin-b"
@@ -1886,7 +1877,6 @@ func TestChattoCore_RevokeRole_AdminCannotDemotePeerAdmin(t *testing.T) {
 func TestChattoCore_RevokeRole_AdminCanDemoteLowerRankedUser(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
-
 
 	// Create admin and moderator (must be space members for permission checks)
 	admin := "admin-user"
@@ -2028,7 +2018,6 @@ func TestChattoCore_hasSpacePermission(t *testing.T) {
 func TestChattoCore_hasSpacePermission_MultipleRoles(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
-
 
 	// Create two roles with different permissions
 	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
@@ -2438,7 +2427,6 @@ func TestChattoCore_AssignRole_HierarchyEnforcement(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-
 	// Setup users
 	owner := "owner-user"
 	mod := "mod-user"
@@ -2503,7 +2491,6 @@ func TestChattoCore_RevokeRole_CannotDemoteSelf(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-
 	// Setup user with owner role
 	owner := "owner-user"
 	core.AssignServerRole(ctx, SystemActorID, owner, RoleOwner)
@@ -2531,7 +2518,6 @@ func TestChattoCore_RevokeRole_CannotDemoteSelf(t *testing.T) {
 func TestChattoCore_RevokeRole_PeerProtection(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
-
 
 	// Setup two moderators
 	modA := "mod-a"
@@ -2590,7 +2576,6 @@ func TestChattoCore_RevokeRole_PeerProtection(t *testing.T) {
 func TestChattoCore_CreateRole_PositionAssignment(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
-
 
 	t.Run("first custom role gets position after system roles", func(t *testing.T) {
 		// System roles: owner (0), moderator (2), member (MAX)
@@ -2655,7 +2640,6 @@ func TestChattoCore_CreateRole_PositionAssignment(t *testing.T) {
 func TestChattoCore_OutranksUser(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
-
 
 	// Setup hierarchy using system roles: owner > moderator > member
 	// Note: Custom roles currently get position MaxInt32 (same as member),

--- a/cli/internal/core/user_events.go
+++ b/cli/internal/core/user_events.go
@@ -1,0 +1,101 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"hmans.de/chatto/internal/events"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+const maxUserMutationRetries = 5
+
+func (c *ChattoCore) appendUserEvent(ctx context.Context, userID string, event *corev1.Event, filter string, check func() error) (uint64, error) {
+	if filter == "" {
+		filter = events.UserAggregate(userID).AllEventsFilter()
+	}
+	subject := events.UserAggregate(userID).SubjectFor(event)
+
+	for attempt := 0; attempt < maxUserMutationRetries; attempt++ {
+		filterSeq, err := c.EventPublisher.LastSubjectSeq(ctx, filter)
+		if err != nil {
+			return 0, fmt.Errorf("read user OCC filter seq: %w", err)
+		}
+		if err := c.UsersProjector.WaitForSeq(ctx, filterSeq); err != nil {
+			return 0, fmt.Errorf("wait for user projection: %w", err)
+		}
+		if check != nil {
+			if err := check(); err != nil {
+				return 0, err
+			}
+		}
+
+		seq, err := c.EventPublisher.AppendAtFilter(ctx, subject, event, filter, filterSeq)
+		if err == nil {
+			if err := c.UsersProjector.WaitForSeq(ctx, seq); err != nil {
+				return 0, fmt.Errorf("wait for user projection: %w", err)
+			}
+			return seq, nil
+		}
+		if !errors.Is(err, events.ErrConflict) {
+			return 0, err
+		}
+
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-time.After(time.Duration(1<<attempt) * time.Millisecond):
+		}
+	}
+	return 0, fmt.Errorf("user OCC retry exhausted after %d attempts: %w", maxUserMutationRetries, events.ErrConflict)
+}
+
+func (c *ChattoCore) appendUserBatch(ctx context.Context, userID string, entries []events.BatchEntry, filter string, check func() error) (uint64, error) {
+	if len(entries) == 0 {
+		return 0, nil
+	}
+	if filter == "" {
+		filter = events.UserAggregate(userID).AllEventsFilter()
+	}
+
+	for attempt := 0; attempt < maxUserMutationRetries; attempt++ {
+		filterSeq, err := c.EventPublisher.LastSubjectSeq(ctx, filter)
+		if err != nil {
+			return 0, fmt.Errorf("read user OCC filter seq: %w", err)
+		}
+		if err := c.UsersProjector.WaitForSeq(ctx, filterSeq); err != nil {
+			return 0, fmt.Errorf("wait for user projection: %w", err)
+		}
+		if check != nil {
+			if err := check(); err != nil {
+				return 0, err
+			}
+		}
+
+		chunk := append([]events.BatchEntry(nil), entries...)
+		chunk[0].HasOCC = true
+		chunk[0].ExpectedSeq = filterSeq
+		chunk[0].FilterSubject = filter
+
+		seqs, err := c.EventPublisher.AppendBatch(ctx, chunk)
+		if err == nil {
+			lastSeq := seqs[len(seqs)-1]
+			if err := c.UsersProjector.WaitForSeq(ctx, lastSeq); err != nil {
+				return 0, fmt.Errorf("wait for user projection: %w", err)
+			}
+			return lastSeq, nil
+		}
+		if !errors.Is(err, events.ErrConflict) {
+			return 0, err
+		}
+
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-time.After(time.Duration(1<<attempt) * time.Millisecond):
+		}
+	}
+	return 0, fmt.Errorf("user batch OCC retry exhausted after %d attempts: %w", maxUserMutationRetries, events.ErrConflict)
+}

--- a/cli/internal/core/user_preferences.go
+++ b/cli/internal/core/user_preferences.go
@@ -2,12 +2,8 @@ package core
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
-
-	"github.com/nats-io/nats.go/jetstream"
-	"google.golang.org/protobuf/proto"
 
 	"hmans.de/chatto/internal/core/subjects"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
@@ -31,24 +27,14 @@ type UserSettingsInput struct {
 	TimeFormat *corev1.TimeFormat
 }
 
-// GetUserSettings retrieves a user's settings from the INSTANCE KV bucket.
+// GetUserSettings retrieves a user's settings from the user projection.
 // Returns nil, nil if no settings have been saved yet (the user hasn't configured any).
 // Authorization: Caller must verify access (self-only in GraphQL layer).
 func (c *ChattoCore) GetUserSettings(ctx context.Context, userID string) (*corev1.ServerUserPreferences, error) {
-	entry, err := c.storage.serverKV.Get(ctx, userPreferencesKey(userID))
-	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("failed to get user settings: %w", err)
+	if settings, ok := c.Users.Preferences(userID); ok {
+		return settings, nil
 	}
-
-	settings := &corev1.ServerUserPreferences{}
-	if err := proto.Unmarshal(entry.Value(), settings); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal user settings: %w", err)
-	}
-
-	return settings, nil
+	return nil, nil
 }
 
 // UpdateUserSettings merges the provided fields into the user's existing settings.
@@ -84,13 +70,13 @@ func (c *ChattoCore) UpdateUserSettings(ctx context.Context, userID string, inpu
 		settings.TimeFormat = *input.TimeFormat
 	}
 
-	// Persist
-	data, err := proto.Marshal(settings)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal user settings: %w", err)
-	}
-
-	if _, err := c.storage.serverKV.Put(ctx, userPreferencesKey(userID), data); err != nil {
+	event := newEvent(userID, &corev1.Event{Event: &corev1.Event_UserServerPreferencesChanged{
+		UserServerPreferencesChanged: &corev1.UserServerPreferencesChangedEvent{
+			UserId:      userID,
+			Preferences: settings,
+		},
+	}})
+	if _, err := c.appendUserEvent(ctx, userID, event, "", nil); err != nil {
 		return nil, fmt.Errorf("failed to store user settings: %w", err)
 	}
 
@@ -127,11 +113,5 @@ func (c *ChattoCore) publishServerUserPreferencesUpdatedEvent(ctx context.Contex
 
 // deleteUserSettings removes a user's settings. Called during account deletion.
 func (c *ChattoCore) deleteUserSettings(ctx context.Context, userID string) error {
-	if err := c.storage.serverKV.Delete(ctx, userPreferencesKey(userID)); err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			return nil // No settings to delete
-		}
-		return fmt.Errorf("failed to delete user settings: %w", err)
-	}
 	return nil
 }

--- a/cli/internal/core/user_projection.go
+++ b/cli/internal/core/user_projection.go
@@ -1,0 +1,425 @@
+package core
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"hmans.de/chatto/internal/events"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+// UserProjection derives current account/profile/auth lookup state from
+// durable evt.user.{userID} events.
+type UserProjection struct {
+	events.MemoryProjection
+	users       map[string]*projectedUser
+	loginIndex  map[string]string
+	emailIndex  map[string]string
+	oidcIndex   map[string]string
+	eventIDSeen map[string]struct{}
+}
+
+type projectedUser struct {
+	user          *corev1.User
+	deleted       bool
+	avatar        *corev1.Asset
+	passwordHash  []byte
+	verifiedEmail map[string]VerifiedEmail
+	preferences   *corev1.ServerUserPreferences
+	loginChanged  time.Time
+}
+
+func NewUserProjection() *UserProjection {
+	return &UserProjection{
+		users:       make(map[string]*projectedUser),
+		loginIndex:  make(map[string]string),
+		emailIndex:  make(map[string]string),
+		oidcIndex:   make(map[string]string),
+		eventIDSeen: make(map[string]struct{}),
+	}
+}
+
+func (p *UserProjection) Subjects() []string {
+	return []string{events.UserSubjectFilter()}
+}
+
+func (p *UserProjection) Apply(event *corev1.Event, _ uint64) error {
+	if event == nil {
+		return nil
+	}
+	if id := event.GetId(); id != "" {
+		p.Lock()
+		if _, ok := p.eventIDSeen[id]; ok {
+			p.Unlock()
+			return nil
+		}
+		p.eventIDSeen[id] = struct{}{}
+		p.Unlock()
+	}
+
+	p.Lock()
+	defer p.Unlock()
+
+	switch e := event.GetEvent().(type) {
+	case *corev1.Event_UserAccountCreated:
+		p.applyAccountCreated(e.UserAccountCreated, event.GetCreatedAt())
+	case *corev1.Event_UserLoginChanged:
+		p.applyLoginChanged(e.UserLoginChanged, event.GetCreatedAt())
+	case *corev1.Event_UserDisplayNameChanged:
+		p.applyDisplayNameChanged(e.UserDisplayNameChanged)
+	case *corev1.Event_UserAvatarSet:
+		p.applyAvatarSet(e.UserAvatarSet)
+	case *corev1.Event_UserAvatarCleared:
+		p.applyAvatarCleared(e.UserAvatarCleared)
+	case *corev1.Event_UserVerifiedEmailAdded:
+		p.applyVerifiedEmailAdded(e.UserVerifiedEmailAdded, event.GetCreatedAt())
+	case *corev1.Event_UserPasswordHashChanged:
+		p.applyPasswordHashChanged(e.UserPasswordHashChanged)
+	case *corev1.Event_UserOidcSubjectLinked:
+		p.applyOIDCSubjectLinked(e.UserOidcSubjectLinked)
+	case *corev1.Event_UserServerPreferencesChanged:
+		p.applyServerPreferencesChanged(e.UserServerPreferencesChanged)
+	case *corev1.Event_UserLoginCooldownCleared:
+		p.applyLoginCooldownCleared(e.UserLoginCooldownCleared)
+	case *corev1.Event_UserAccountDeleted:
+		p.applyAccountDeleted(e.UserAccountDeleted)
+	}
+	return nil
+}
+
+func (p *UserProjection) ensureUserLocked(userID string) *projectedUser {
+	u := p.users[userID]
+	if u == nil {
+		u = &projectedUser{verifiedEmail: make(map[string]VerifiedEmail)}
+		p.users[userID] = u
+	}
+	if u.verifiedEmail == nil {
+		u.verifiedEmail = make(map[string]VerifiedEmail)
+	}
+	return u
+}
+
+func (p *UserProjection) applyAccountCreated(e *corev1.UserAccountCreatedEvent, envelopeCreatedAt *timestamppb.Timestamp) {
+	if e == nil || e.GetUserId() == "" {
+		return
+	}
+	u := p.ensureUserLocked(e.GetUserId())
+	u.user = &corev1.User{
+		Id:          e.GetUserId(),
+		Login:       e.GetLogin(),
+		DisplayName: e.GetDisplayName(),
+		CreatedAt:   envelopeCreatedAt,
+	}
+	u.deleted = false
+	if e.GetLogin() != "" {
+		p.loginIndex[strings.ToLower(e.GetLogin())] = e.GetUserId()
+	}
+}
+
+func (p *UserProjection) applyLoginChanged(e *corev1.UserLoginChangedEvent, envelopeCreatedAt *timestamppb.Timestamp) {
+	if e == nil || e.GetUserId() == "" || e.GetLogin() == "" {
+		return
+	}
+	u := p.ensureUserLocked(e.GetUserId())
+	if u.user == nil {
+		u.user = &corev1.User{Id: e.GetUserId(), CreatedAt: envelopeCreatedAt}
+	}
+	if old := u.user.GetLogin(); old != "" {
+		delete(p.loginIndex, strings.ToLower(old))
+	}
+	u.user.Login = e.GetLogin()
+	p.loginIndex[strings.ToLower(e.GetLogin())] = e.GetUserId()
+	if e.GetAdvancesCooldown() && envelopeCreatedAt != nil {
+		u.loginChanged = envelopeCreatedAt.AsTime()
+	}
+}
+
+func (p *UserProjection) applyDisplayNameChanged(e *corev1.UserDisplayNameChangedEvent) {
+	if e == nil || e.GetUserId() == "" {
+		return
+	}
+	u := p.ensureUserLocked(e.GetUserId())
+	if u.user == nil {
+		u.user = &corev1.User{Id: e.GetUserId()}
+	}
+	u.user.DisplayName = e.GetDisplayName()
+}
+
+func (p *UserProjection) applyAvatarSet(e *corev1.UserAvatarSetEvent) {
+	if e == nil || e.GetUserId() == "" {
+		return
+	}
+	u := p.ensureUserLocked(e.GetUserId())
+	if e.GetAvatar() == nil {
+		return
+	}
+	u.avatar = proto.Clone(e.GetAvatar()).(*corev1.Asset)
+}
+
+func (p *UserProjection) applyAvatarCleared(e *corev1.UserAvatarClearedEvent) {
+	if e == nil || e.GetUserId() == "" {
+		return
+	}
+	u := p.ensureUserLocked(e.GetUserId())
+	u.avatar = nil
+}
+
+func (p *UserProjection) applyVerifiedEmailAdded(e *corev1.UserVerifiedEmailAddedEvent, envelopeCreatedAt *timestamppb.Timestamp) {
+	if e == nil || e.GetUserId() == "" || e.GetEmail() == "" {
+		return
+	}
+	u := p.ensureUserLocked(e.GetUserId())
+	verifiedAt := time.Now()
+	if envelopeCreatedAt != nil {
+		verifiedAt = envelopeCreatedAt.AsTime()
+	}
+	hash := emailHash(e.GetEmail())
+	u.verifiedEmail[hash] = VerifiedEmail{Email: e.GetEmail(), VerifiedAt: verifiedAt}
+	p.emailIndex[hash] = e.GetUserId()
+}
+
+func (p *UserProjection) applyPasswordHashChanged(e *corev1.UserPasswordHashChangedEvent) {
+	if e == nil || e.GetUserId() == "" {
+		return
+	}
+	u := p.ensureUserLocked(e.GetUserId())
+	u.passwordHash = append(u.passwordHash[:0], e.GetPasswordHash()...)
+}
+
+func (p *UserProjection) applyOIDCSubjectLinked(e *corev1.UserOIDCSubjectLinkedEvent) {
+	if e == nil || e.GetUserId() == "" {
+		return
+	}
+	hash := e.GetSubjectHash()
+	if hash == "" && e.GetIssuer() != "" && e.GetSubject() != "" {
+		hash = oidcSubjectHash(e.GetIssuer(), e.GetSubject())
+	}
+	if hash == "" {
+		return
+	}
+	p.oidcIndex[hash] = e.GetUserId()
+}
+
+func (p *UserProjection) applyServerPreferencesChanged(e *corev1.UserServerPreferencesChangedEvent) {
+	if e == nil || e.GetUserId() == "" {
+		return
+	}
+	u := p.ensureUserLocked(e.GetUserId())
+	if e.GetPreferences() == nil {
+		u.preferences = nil
+		return
+	}
+	u.preferences = proto.Clone(e.GetPreferences()).(*corev1.ServerUserPreferences)
+}
+
+func (p *UserProjection) applyLoginCooldownCleared(e *corev1.UserLoginCooldownClearedEvent) {
+	if e == nil || e.GetUserId() == "" {
+		return
+	}
+	u := p.ensureUserLocked(e.GetUserId())
+	u.loginChanged = time.Time{}
+}
+
+func (p *UserProjection) applyAccountDeleted(e *corev1.UserAccountDeletedEvent) {
+	if e == nil || e.GetUserId() == "" {
+		return
+	}
+	u := p.ensureUserLocked(e.GetUserId())
+	u.deleted = true
+	if u.user != nil && u.user.GetLogin() != "" {
+		delete(p.loginIndex, strings.ToLower(u.user.GetLogin()))
+	}
+	for hash, userID := range p.emailIndex {
+		if userID == e.GetUserId() {
+			delete(p.emailIndex, hash)
+		}
+	}
+	for hash, userID := range p.oidcIndex {
+		if userID == e.GetUserId() {
+			delete(p.oidcIndex, hash)
+		}
+	}
+	u.avatar = nil
+	u.passwordHash = nil
+	u.preferences = nil
+	u.verifiedEmail = make(map[string]VerifiedEmail)
+	u.loginChanged = time.Time{}
+}
+
+func (p *UserProjection) Get(userID string) (*corev1.User, bool) {
+	p.RLock()
+	defer p.RUnlock()
+	u := p.users[userID]
+	if u == nil || u.deleted || u.user == nil {
+		return nil, false
+	}
+	return proto.Clone(u.user).(*corev1.User), true
+}
+
+func (p *UserProjection) GetByLogin(login string) (*corev1.User, bool) {
+	p.RLock()
+	userID := p.loginIndex[strings.ToLower(strings.TrimSpace(login))]
+	p.RUnlock()
+	if userID == "" {
+		return nil, false
+	}
+	return p.Get(userID)
+}
+
+func (p *UserProjection) GetByEmail(email string) (*corev1.User, bool) {
+	p.RLock()
+	userID := p.emailIndex[emailHash(email)]
+	p.RUnlock()
+	if userID == "" {
+		return nil, false
+	}
+	return p.Get(userID)
+}
+
+func (p *UserProjection) GetByOIDCSubject(issuer, subject string) (*corev1.User, bool) {
+	p.RLock()
+	userID := p.oidcIndex[oidcSubjectHash(issuer, subject)]
+	p.RUnlock()
+	if userID == "" {
+		return nil, false
+	}
+	return p.Get(userID)
+}
+
+func (p *UserProjection) LoginExists(login string) bool {
+	p.RLock()
+	defer p.RUnlock()
+	_, ok := p.loginIndex[strings.ToLower(strings.TrimSpace(login))]
+	return ok
+}
+
+func (p *UserProjection) EmailClaimed(email string) bool {
+	p.RLock()
+	defer p.RUnlock()
+	_, ok := p.emailIndex[emailHash(email)]
+	return ok
+}
+
+func (p *UserProjection) PasswordHash(userID string) ([]byte, bool) {
+	p.RLock()
+	defer p.RUnlock()
+	u := p.users[userID]
+	if u == nil || u.deleted || len(u.passwordHash) == 0 {
+		return nil, false
+	}
+	return append([]byte(nil), u.passwordHash...), true
+}
+
+func (p *UserProjection) Avatar(userID string) (*corev1.Asset, bool) {
+	p.RLock()
+	defer p.RUnlock()
+	u := p.users[userID]
+	if u == nil || u.deleted || u.avatar == nil {
+		return nil, false
+	}
+	return proto.Clone(u.avatar).(*corev1.Asset), true
+}
+
+func (p *UserProjection) Preferences(userID string) (*corev1.ServerUserPreferences, bool) {
+	p.RLock()
+	defer p.RUnlock()
+	u := p.users[userID]
+	if u == nil || u.deleted || u.preferences == nil {
+		return nil, false
+	}
+	return proto.Clone(u.preferences).(*corev1.ServerUserPreferences), true
+}
+
+func (p *UserProjection) VerifiedEmails(userID string) []VerifiedEmail {
+	p.RLock()
+	defer p.RUnlock()
+	u := p.users[userID]
+	if u == nil || u.deleted || len(u.verifiedEmail) == 0 {
+		return nil
+	}
+	out := make([]VerifiedEmail, 0, len(u.verifiedEmail))
+	for _, email := range u.verifiedEmail {
+		out = append(out, email)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].VerifiedAt.Equal(out[j].VerifiedAt) {
+			return out[i].VerifiedAt.Before(out[j].VerifiedAt)
+		}
+		return strings.ToLower(out[i].Email) < strings.ToLower(out[j].Email)
+	})
+	return out
+}
+
+func (p *UserProjection) HasVerifiedEmail(userID string) bool {
+	return len(p.VerifiedEmails(userID)) > 0
+}
+
+func (p *UserProjection) LoginChangedAt(userID string) time.Time {
+	p.RLock()
+	defer p.RUnlock()
+	u := p.users[userID]
+	if u == nil || u.deleted {
+		return time.Time{}
+	}
+	return u.loginChanged
+}
+
+func (p *UserProjection) Users() []*corev1.User {
+	p.RLock()
+	defer p.RUnlock()
+	out := make([]*corev1.User, 0, len(p.users))
+	for _, u := range p.users {
+		if u == nil || u.deleted || u.user == nil {
+			continue
+		}
+		out = append(out, proto.Clone(u.user).(*corev1.User))
+	}
+	return out
+}
+
+func (p *UserProjection) VerifiedUserIDs() []string {
+	p.RLock()
+	defer p.RUnlock()
+	seen := map[string]struct{}{}
+	for _, userID := range p.emailIndex {
+		if u := p.users[userID]; u != nil && !u.deleted {
+			seen[userID] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for userID := range seen {
+		out = append(out, userID)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (p *UserProjection) Count() int {
+	p.RLock()
+	defer p.RUnlock()
+	var count int
+	for _, u := range p.users {
+		if u != nil && !u.deleted && u.user != nil {
+			count++
+		}
+	}
+	return count
+}
+
+func (p *UserProjection) Stats() (users int, verifiedEmails int, oidcSubjects int) {
+	p.RLock()
+	defer p.RUnlock()
+	for _, u := range p.users {
+		if u == nil || u.deleted || u.user == nil {
+			continue
+		}
+		users++
+		verifiedEmails += len(u.verifiedEmail)
+	}
+	oidcSubjects = len(p.oidcIndex)
+	return users, verifiedEmails, oidcSubjects
+}

--- a/cli/internal/core/user_projection.go
+++ b/cli/internal/core/user_projection.go
@@ -83,6 +83,8 @@ func (p *UserProjection) Apply(event *corev1.Event, _ uint64) error {
 		p.applyOIDCSubjectLinked(e.UserOidcSubjectLinked)
 	case *corev1.Event_UserServerPreferencesChanged:
 		p.applyServerPreferencesChanged(e.UserServerPreferencesChanged)
+	case *corev1.Event_UserLoginCooldownStarted:
+		p.applyLoginCooldownStarted(e.UserLoginCooldownStarted, event.GetCreatedAt())
 	case *corev1.Event_UserLoginCooldownCleared:
 		p.applyLoginCooldownCleared(e.UserLoginCooldownCleared)
 	case *corev1.Event_UserAccountDeleted:
@@ -133,9 +135,6 @@ func (p *UserProjection) applyLoginChanged(e *corev1.UserLoginChangedEvent, enve
 	}
 	u.user.Login = e.GetLogin()
 	p.loginIndex[strings.ToLower(e.GetLogin())] = e.GetUserId()
-	if e.GetAdvancesCooldown() && envelopeCreatedAt != nil {
-		u.loginChanged = envelopeCreatedAt.AsTime()
-	}
 }
 
 func (p *UserProjection) applyDisplayNameChanged(e *corev1.UserDisplayNameChangedEvent) {
@@ -214,6 +213,14 @@ func (p *UserProjection) applyServerPreferencesChanged(e *corev1.UserServerPrefe
 		return
 	}
 	u.preferences = proto.Clone(e.GetPreferences()).(*corev1.ServerUserPreferences)
+}
+
+func (p *UserProjection) applyLoginCooldownStarted(e *corev1.UserLoginCooldownStartedEvent, envelopeCreatedAt *timestamppb.Timestamp) {
+	if e == nil || e.GetUserId() == "" || envelopeCreatedAt == nil {
+		return
+	}
+	u := p.ensureUserLocked(e.GetUserId())
+	u.loginChanged = envelopeCreatedAt.AsTime()
 }
 
 func (p *UserProjection) applyLoginCooldownCleared(e *corev1.UserLoginCooldownClearedEvent) {

--- a/cli/internal/core/user_projection_test.go
+++ b/cli/internal/core/user_projection_test.go
@@ -1,0 +1,142 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+func userEvent(id string, ts time.Time, event *corev1.Event) *corev1.Event {
+	event.Id = id
+	event.CreatedAt = timestamppb.New(ts)
+	return event
+}
+
+func accountCreated(userID, login, displayName string) *corev1.Event {
+	return &corev1.Event{Event: &corev1.Event_UserAccountCreated{UserAccountCreated: &corev1.UserAccountCreatedEvent{
+		UserId:      userID,
+		Login:       login,
+		DisplayName: displayName,
+	}}}
+}
+
+func loginChanged(userID, login string, advancesCooldown bool) *corev1.Event {
+	return &corev1.Event{Event: &corev1.Event_UserLoginChanged{UserLoginChanged: &corev1.UserLoginChangedEvent{
+		UserId:           userID,
+		Login:            login,
+		AdvancesCooldown: advancesCooldown,
+	}}}
+}
+
+func displayNameChanged(userID, displayName string) *corev1.Event {
+	return &corev1.Event{Event: &corev1.Event_UserDisplayNameChanged{UserDisplayNameChanged: &corev1.UserDisplayNameChangedEvent{
+		UserId:      userID,
+		DisplayName: displayName,
+	}}}
+}
+
+func TestUserProjection_AccountProfileAndLogin(t *testing.T) {
+	p := NewUserProjection()
+	createdAt := time.Date(2026, 5, 26, 10, 0, 0, 0, time.UTC)
+
+	require.NoError(t, p.Apply(userEvent("E1", createdAt, accountCreated("U1", "Alice", "Alice A.")), 1))
+
+	got, ok := p.Get("U1")
+	require.True(t, ok)
+	require.Equal(t, "U1", got.GetId())
+	require.Equal(t, "Alice", got.GetLogin())
+	require.Equal(t, "Alice A.", got.GetDisplayName())
+	require.True(t, got.GetCreatedAt().AsTime().Equal(createdAt))
+
+	byLogin, ok := p.GetByLogin("alice")
+	require.True(t, ok)
+	require.Equal(t, "U1", byLogin.GetId())
+	require.Equal(t, 1, p.Count())
+}
+
+func TestUserProjection_LoginCooldownUsesEnvelopeTime(t *testing.T) {
+	p := NewUserProjection()
+	createdAt := time.Date(2026, 5, 26, 10, 0, 0, 0, time.UTC)
+	changedAt := createdAt.Add(5 * time.Minute)
+
+	require.NoError(t, p.Apply(userEvent("E1", createdAt, accountCreated("U1", "Alice", "Alice A.")), 1))
+	require.True(t, p.LoginChangedAt("U1").IsZero())
+
+	require.NoError(t, p.Apply(userEvent("E3", changedAt, loginChanged("U1", "Alice2", true)), 3))
+	require.True(t, p.LoginChangedAt("U1").Equal(changedAt))
+	require.False(t, p.LoginExists("Alice"))
+	require.True(t, p.LoginExists("alice2"))
+
+	require.NoError(t, p.Apply(&corev1.Event{
+		Id:    "E4",
+		Event: &corev1.Event_UserLoginCooldownCleared{UserLoginCooldownCleared: &corev1.UserLoginCooldownClearedEvent{UserId: "U1"}},
+	}, 4))
+	require.True(t, p.LoginChangedAt("U1").IsZero())
+}
+
+func TestUserProjection_VerifiedEmailAvatarOIDCAndDelete(t *testing.T) {
+	p := NewUserProjection()
+	createdAt := time.Date(2026, 5, 26, 10, 0, 0, 0, time.UTC)
+	verifiedAt := createdAt.Add(time.Hour)
+
+	require.NoError(t, p.Apply(userEvent("E1", createdAt, accountCreated("U1", "Alice", "Alice A.")), 1))
+	require.NoError(t, p.Apply(&corev1.Event{
+		Id:        "E3",
+		CreatedAt: timestamppb.New(verifiedAt),
+		Event: &corev1.Event_UserVerifiedEmailAdded{UserVerifiedEmailAdded: &corev1.UserVerifiedEmailAddedEvent{
+			UserId: "U1",
+			Email:  "Alice@Example.com",
+		}},
+	}, 3))
+	require.NoError(t, p.Apply(&corev1.Event{
+		Id: "E4",
+		Event: &corev1.Event_UserAvatarSet{UserAvatarSet: &corev1.UserAvatarSetEvent{
+			UserId: "U1",
+			Avatar: &corev1.Asset{Asset: &corev1.Asset_S3{S3: &corev1.S3Asset{Key: "avatars/U1"}}},
+		}},
+	}, 4))
+	require.NoError(t, p.Apply(&corev1.Event{
+		Id: "E5",
+		Event: &corev1.Event_UserOidcSubjectLinked{UserOidcSubjectLinked: &corev1.UserOIDCSubjectLinkedEvent{
+			UserId:  "U1",
+			Issuer:  "https://issuer.example",
+			Subject: "subject-1",
+		}},
+	}, 5))
+
+	emails := p.VerifiedEmails("U1")
+	require.Len(t, emails, 1)
+	require.Equal(t, "Alice@Example.com", emails[0].Email)
+	require.True(t, emails[0].VerifiedAt.Equal(verifiedAt))
+	byEmail, ok := p.GetByEmail("alice@example.com")
+	require.True(t, ok)
+	require.Equal(t, "U1", byEmail.GetId())
+	byOIDC, ok := p.GetByOIDCSubject("https://issuer.example", "subject-1")
+	require.True(t, ok)
+	require.Equal(t, "U1", byOIDC.GetId())
+	avatar, ok := p.Avatar("U1")
+	require.True(t, ok)
+	require.Equal(t, "avatars/U1", avatar.GetS3().GetKey())
+
+	require.NoError(t, p.Apply(&corev1.Event{
+		Id:    "E6",
+		Event: &corev1.Event_UserAvatarCleared{UserAvatarCleared: &corev1.UserAvatarClearedEvent{UserId: "U1"}},
+	}, 6))
+	_, ok = p.Avatar("U1")
+	require.False(t, ok)
+
+	require.NoError(t, p.Apply(&corev1.Event{
+		Id:    "E7",
+		Event: &corev1.Event_UserAccountDeleted{UserAccountDeleted: &corev1.UserAccountDeletedEvent{UserId: "U1"}},
+	}, 7))
+	_, ok = p.Get("U1")
+	require.False(t, ok)
+	require.False(t, p.LoginExists("alice"))
+	require.False(t, p.EmailClaimed("Alice@Example.com"))
+	_, ok = p.GetByOIDCSubject("https://issuer.example", "subject-1")
+	require.False(t, ok)
+}

--- a/cli/internal/core/user_projection_test.go
+++ b/cli/internal/core/user_projection_test.go
@@ -24,11 +24,16 @@ func accountCreated(userID, login, displayName string) *corev1.Event {
 	}}}
 }
 
-func loginChanged(userID, login string, advancesCooldown bool) *corev1.Event {
+func loginChanged(userID, login string) *corev1.Event {
 	return &corev1.Event{Event: &corev1.Event_UserLoginChanged{UserLoginChanged: &corev1.UserLoginChangedEvent{
-		UserId:           userID,
-		Login:            login,
-		AdvancesCooldown: advancesCooldown,
+		UserId: userID,
+		Login:  login,
+	}}}
+}
+
+func loginCooldownStarted(userID string) *corev1.Event {
+	return &corev1.Event{Event: &corev1.Event_UserLoginCooldownStarted{UserLoginCooldownStarted: &corev1.UserLoginCooldownStartedEvent{
+		UserId: userID,
 	}}}
 }
 
@@ -66,15 +71,18 @@ func TestUserProjection_LoginCooldownUsesEnvelopeTime(t *testing.T) {
 	require.NoError(t, p.Apply(userEvent("E1", createdAt, accountCreated("U1", "Alice", "Alice A.")), 1))
 	require.True(t, p.LoginChangedAt("U1").IsZero())
 
-	require.NoError(t, p.Apply(userEvent("E3", changedAt, loginChanged("U1", "Alice2", true)), 3))
-	require.True(t, p.LoginChangedAt("U1").Equal(changedAt))
+	require.NoError(t, p.Apply(userEvent("E3", changedAt, loginChanged("U1", "Alice2")), 3))
+	require.True(t, p.LoginChangedAt("U1").IsZero())
 	require.False(t, p.LoginExists("Alice"))
 	require.True(t, p.LoginExists("alice2"))
 
+	require.NoError(t, p.Apply(userEvent("E4", changedAt, loginCooldownStarted("U1")), 4))
+	require.True(t, p.LoginChangedAt("U1").Equal(changedAt))
+
 	require.NoError(t, p.Apply(&corev1.Event{
-		Id:    "E4",
+		Id:    "E5",
 		Event: &corev1.Event_UserLoginCooldownCleared{UserLoginCooldownCleared: &corev1.UserLoginCooldownClearedEvent{UserId: "U1"}},
-	}, 4))
+	}, 5))
 	require.True(t, p.LoginChangedAt("U1").IsZero())
 }
 

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -680,14 +680,28 @@ func (c *ChattoCore) applyLoginChange(ctx context.Context, userID, newLogin stri
 		}
 	}
 
-	event := newEvent(userID, &corev1.Event{Event: &corev1.Event_UserLoginChanged{
+	loginChanged := newEvent(userID, &corev1.Event{Event: &corev1.Event_UserLoginChanged{
 		UserLoginChanged: &corev1.UserLoginChangedEvent{
-			UserId:           userID,
-			Login:            newLogin,
-			AdvancesCooldown: enforceCooldown && !caseOnly,
+			UserId: userID,
+			Login:  newLogin,
 		},
 	}})
-	if _, err := c.appendUserEvent(ctx, userID, event, events.UserSubjectFilter(), func() error {
+	agg := events.UserAggregate(userID)
+	entries := []events.BatchEntry{{
+		Subject: agg.SubjectFor(loginChanged),
+		Event:   loginChanged,
+	}}
+	if enforceCooldown && !caseOnly {
+		cooldownStarted := newEvent(userID, &corev1.Event{Event: &corev1.Event_UserLoginCooldownStarted{
+			UserLoginCooldownStarted: &corev1.UserLoginCooldownStartedEvent{UserId: userID},
+		}})
+		cooldownStarted.CreatedAt = loginChanged.GetCreatedAt()
+		entries = append(entries, events.BatchEntry{
+			Subject: agg.SubjectFor(cooldownStarted),
+			Event:   cooldownStarted,
+		})
+	}
+	if _, err := c.appendUserBatch(ctx, userID, entries, events.UserSubjectFilter(), func() error {
 		if !caseOnly && c.Users.LoginExists(newLogin) {
 			return ErrLoginAlreadyTaken
 		}

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -20,6 +19,7 @@ import (
 
 	"hmans.de/chatto/internal/assets"
 	"hmans.de/chatto/internal/core/subjects"
+	"hmans.de/chatto/internal/events"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
@@ -79,65 +79,60 @@ func (c *ChattoCore) CreateUser(ctx context.Context, actorID string, login, disp
 	// Generate user ID upfront
 	userID := NewUserID()
 
-	// Atomically claim login name (prevents race conditions)
-	loginKey := userByLoginKey(login)
-	_, err = c.storage.serverKV.Create(ctx, loginKey, []byte(userID))
-	if err != nil {
-		// Login already exists or other error
-		return nil, ErrLoginAlreadyTaken
-	}
-
-	// Create user entity (without password hash)
+	now := timestamppb.Now()
 	user := &corev1.User{
 		Id:          userID,
 		Login:       login,
 		DisplayName: displayName,
-		CreatedAt:   timestamppb.Now(),
+		CreatedAt:   now,
 	}
 
-	// Write user to KV store (source of truth)
-	userData, err := proto.Marshal(user)
-	if err != nil {
-		// Cleanup: remove login claim
-		c.storage.serverKV.Delete(ctx, loginKey)
-		return nil, fmt.Errorf("failed to marshal user: %w", err)
+	agg := events.UserAggregate(userID)
+	entries := []events.BatchEntry{{
+		Subject: agg.Subject(events.EventUserAccountCreated),
+		Event: newEvent(userID, &corev1.Event{Event: &corev1.Event_UserAccountCreated{
+			UserAccountCreated: &corev1.UserAccountCreatedEvent{
+				UserId:      userID,
+				Login:       login,
+				DisplayName: displayName,
+			},
+		}}),
+	}}
+	for _, entry := range entries {
+		entry.Event.CreatedAt = now
 	}
 
-	_, err = c.storage.serverKV.Put(ctx, userKey(user.Id), userData)
-	if err != nil {
-		// Cleanup: remove login claim
-		c.storage.serverKV.Delete(ctx, loginKey)
-		return nil, fmt.Errorf("failed to store user: %w", err)
-	}
-
-	// Store password hash separately if password is provided
 	if password != "" {
 		hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 		if err != nil {
-			// Cleanup: remove user and login claim
-			c.storage.serverKV.Delete(ctx, userKey(user.Id))
-			c.storage.serverKV.Delete(ctx, loginKey)
 			return nil, fmt.Errorf("failed to hash password: %w", err)
 		}
-
-		_, err = c.storage.serverKV.Put(ctx, userAuthPasswordKey(user.Id), hashedPassword)
-		if err != nil {
-			// Cleanup: remove user and login claim
-			c.storage.serverKV.Delete(ctx, userKey(user.Id))
-			c.storage.serverKV.Delete(ctx, loginKey)
-			return nil, fmt.Errorf("failed to store password: %w", err)
-		}
+		entries = append(entries, events.BatchEntry{
+			Subject: agg.Subject(events.EventUserPasswordHashChanged),
+			Event: newEvent(userID, &corev1.Event{Event: &corev1.Event_UserPasswordHashChanged{
+				UserPasswordHashChanged: &corev1.UserPasswordHashChangedEvent{
+					UserId:       userID,
+					PasswordHash: hashedPassword,
+				},
+			}}),
+		})
 	}
 
 	// Create encryption key for this user
 	// Keys are always created so they exist if encryption is enabled later
 	_, err = c.encryption.keyManager.CreateUserKey(ctx, userID)
 	if err != nil {
-		// Cleanup: remove user, login claim, and password
-		c.storage.serverKV.Delete(ctx, userKey(user.Id))
-		c.storage.serverKV.Delete(ctx, loginKey)
-		c.storage.serverKV.Delete(ctx, userAuthPasswordKey(user.Id))
 		return nil, fmt.Errorf("failed to create encryption key: %w", err)
+	}
+
+	if _, err := c.appendUserBatch(ctx, userID, entries, events.UserSubjectFilter(), func() error {
+		if c.Users.LoginExists(login) {
+			return ErrLoginAlreadyTaken
+		}
+		return nil
+	}); err != nil {
+		_ = c.DeleteUserEncryptionKey(ctx, userID)
+		return nil, err
 	}
 
 	// Create and publish audit event (best-effort)
@@ -186,38 +181,18 @@ func (c *ChattoCore) CreateVerifiedUser(ctx context.Context, actorID, login, dis
 // failures are logged but not returned, since the caller is already in an error path.
 func (c *ChattoCore) rollbackUserCreation(ctx context.Context, user *corev1.User) {
 	c.logger.Warn("rolling back user creation", "user_id", user.Id, "login", user.Login)
-
-	keys := []string{
-		userKey(user.Id),
-		userByLoginKey(user.Login),
-		userAuthPasswordKey(user.Id),
-	}
-	for _, key := range keys {
-		if err := c.storage.serverKV.Delete(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
-			c.logger.Warn("rollback delete failed", "key", key, "error", err)
-		}
-	}
 	if err := c.DeleteUserEncryptionKey(ctx, user.Id); err != nil {
 		c.logger.Warn("rollback encryption key delete failed", "user_id", user.Id, "error", err)
 	}
+	_ = c.DeleteUser(ctx, "system:rollback", user.Id)
 }
 
-// GetUser retrieves a user from the INSTANCE KV bucket.
+// GetUser retrieves a user from the user projection.
 func (c *ChattoCore) GetUser(ctx context.Context, userID string) (*corev1.User, error) {
-	entry, err := c.storage.serverKV.Get(ctx, userKey(userID))
-	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("failed to get user: %w", err)
+	if user, ok := c.Users.Get(userID); ok {
+		return user, nil
 	}
-
-	user := &corev1.User{}
-	if err := proto.Unmarshal(entry.Value(), user); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal user: %w", err)
-	}
-
-	return user, nil
+	return nil, ErrNotFound
 }
 
 // GetUsers retrieves multiple users by ID from the INSTANCE KV bucket.
@@ -238,25 +213,12 @@ func (c *ChattoCore) GetUsers(ctx context.Context, userIDs []string) ([]*corev1.
 		}
 	}
 
-	// Fetch all users concurrently (NATS KV doesn't have multi-get)
 	userMap := make(map[string]*corev1.User, len(uniqueIDs))
-	var mu sync.Mutex
-	var wg sync.WaitGroup
-
 	for _, id := range uniqueIDs {
-		wg.Add(1)
-		go func(userID string) {
-			defer wg.Done()
-			user, err := c.GetUser(ctx, userID)
-			if err == nil {
-				mu.Lock()
-				userMap[userID] = user
-				mu.Unlock()
-			}
-			// Silently ignore not-found errors (user may have been deleted)
-		}(id)
+		if user, ok := c.Users.Get(id); ok {
+			userMap[id] = user
+		}
 	}
-	wg.Wait()
 
 	// Return in original order (nil for not-found users)
 	result := make([]*corev1.User, len(userIDs))
@@ -269,21 +231,14 @@ func (c *ChattoCore) GetUsers(ctx context.Context, userIDs []string) ([]*corev1.
 
 // GetUserByLogin retrieves a user by their login name using the login index.
 func (c *ChattoCore) GetUserByLogin(ctx context.Context, login string) (*corev1.User, error) {
-	loginKey := userByLoginKey(login)
-	entry, err := c.storage.serverKV.Get(ctx, loginKey)
-	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("failed to get user by login: %w", err)
+	if user, ok := c.Users.GetByLogin(login); ok {
+		return user, nil
 	}
-
-	userID := string(entry.Value())
-	return c.GetUser(ctx, userID)
+	return nil, ErrNotFound
 }
 
 // SetPasswordHash hashes and stores a password for a user.
-// Password hashes are stored separately from user profile data and are not published to event streams.
+// Password hashes are stored separately from user profile data in the user event stream.
 func (c *ChattoCore) SetPasswordHash(ctx context.Context, userID string, password string) error {
 	// Validate password strength
 	if err := ValidatePassword(password); err != nil {
@@ -302,13 +257,14 @@ func (c *ChattoCore) SetPasswordHash(ctx context.Context, userID string, passwor
 		return fmt.Errorf("failed to hash password: %w", err)
 	}
 
-	// Store password hash in separate KV key
-	_, err = c.storage.serverKV.Put(ctx, userAuthPasswordKey(userID), hashedPassword)
-	if err != nil {
-		return fmt.Errorf("failed to store password: %w", err)
-	}
-
-	return nil
+	event := newEvent(userID, &corev1.Event{Event: &corev1.Event_UserPasswordHashChanged{
+		UserPasswordHashChanged: &corev1.UserPasswordHashChangedEvent{
+			UserId:       userID,
+			PasswordHash: hashedPassword,
+		},
+	}})
+	_, err = c.appendUserEvent(ctx, userID, event, "", nil)
+	return err
 }
 
 // VerifyPassword verifies a user's password by login name or email and returns the user if valid.
@@ -342,14 +298,14 @@ func (c *ChattoCore) VerifyPassword(ctx context.Context, identifier string, pass
 func (c *ChattoCore) verifyUserPassword(ctx context.Context, user *corev1.User, password string, dummyHash []byte) (*corev1.User, error) {
 
 	// Retrieve password hash from separate KV storage
-	entry, err := c.storage.serverKV.Get(ctx, userAuthPasswordKey(user.Id))
-	if err != nil {
+	passwordHash, ok := c.Users.PasswordHash(user.Id)
+	if !ok {
 		// No password set (OAuth-only user) - run dummy bcrypt to match timing
 		bcrypt.CompareHashAndPassword(dummyHash, []byte(password))
 		return nil, fmt.Errorf("password not set for this user")
 	}
 
-	err = bcrypt.CompareHashAndPassword(entry.Value(), []byte(password))
+	err := bcrypt.CompareHashAndPassword(passwordHash, []byte(password))
 	if err != nil {
 		return nil, fmt.Errorf("invalid credentials")
 	}
@@ -434,8 +390,7 @@ func (c *ChattoCore) UploadUserAvatar(ctx context.Context, userID string, reader
 	return asset, nil
 }
 
-// SetUserAvatar stores the user's avatar asset reference in a separate KV key.
-// This avoids overwriting the entire user record when the avatar changes.
+// SetUserAvatar stores the user's avatar asset reference through the user aggregate.
 func (c *ChattoCore) SetUserAvatar(ctx context.Context, userID string, asset *corev1.Asset) error {
 	// Verify user exists
 	_, err := c.GetUser(ctx, userID)
@@ -443,14 +398,13 @@ func (c *ChattoCore) SetUserAvatar(ctx context.Context, userID string, asset *co
 		return fmt.Errorf("user not found: %w", err)
 	}
 
-	// Marshal and store the asset at the scoped key
-	assetData, err := proto.Marshal(asset)
-	if err != nil {
-		return fmt.Errorf("failed to marshal avatar asset: %w", err)
-	}
-
-	_, err = c.storage.serverKV.Put(ctx, userAvatarKey(userID), assetData)
-	if err != nil {
+	event := newEvent(userID, &corev1.Event{Event: &corev1.Event_UserAvatarSet{
+		UserAvatarSet: &corev1.UserAvatarSetEvent{
+			UserId: userID,
+			Avatar: asset,
+		},
+	}})
+	if _, err := c.appendUserEvent(ctx, userID, event, "", nil); err != nil {
 		return fmt.Errorf("failed to store avatar: %w", err)
 	}
 
@@ -462,21 +416,13 @@ func (c *ChattoCore) SetUserAvatar(ctx context.Context, userID string, asset *co
 	return nil
 }
 
-// GetUserAvatar retrieves a user's avatar asset reference from the KV store.
+// GetUserAvatar retrieves a user's avatar asset reference from the user projection.
 // Returns nil if the user has no avatar set.
 func (c *ChattoCore) GetUserAvatar(ctx context.Context, userID string) (*corev1.Asset, error) {
-	entry, err := c.storage.serverKV.Get(ctx, userAvatarKey(userID))
-	if err != nil {
-		// No avatar set is not an error
-		return nil, nil
+	if asset, ok := c.Users.Avatar(userID); ok {
+		return asset, nil
 	}
-
-	asset := &corev1.Asset{}
-	if err := proto.Unmarshal(entry.Value(), asset); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal avatar asset: %w", err)
-	}
-
-	return asset, nil
+	return nil, nil
 }
 
 // DeleteUserAvatar removes a user's avatar from storage (NATS or S3).
@@ -502,8 +448,10 @@ func (c *ChattoCore) DeleteUserAvatar(ctx context.Context, userID string) error 
 	// Delete the asset from storage (NATS or S3)
 	c.deleteAsset(ctx, avatar, "avatar", userID)
 
-	// Delete the KV reference
-	if err := c.storage.serverKV.Delete(ctx, userAvatarKey(userID)); err != nil {
+	event := newEvent(userID, &corev1.Event{Event: &corev1.Event_UserAvatarCleared{
+		UserAvatarCleared: &corev1.UserAvatarClearedEvent{UserId: userID},
+	}})
+	if _, err := c.appendUserEvent(ctx, userID, event, "", nil); err != nil {
 		return fmt.Errorf("failed to delete avatar reference: %w", err)
 	}
 
@@ -551,42 +499,14 @@ func (c *ChattoCore) publishUserProfileUpdate(ctx context.Context, userID string
 	}
 }
 
-// ListUsers retrieves all users from the INSTANCE KV bucket.
-// CountUsers returns the total number of users on the server. Key-only scan.
+// ListUsers retrieves all users from the user projection.
+// CountUsers returns the total number of users on the server.
 func (c *ChattoCore) CountUsers(ctx context.Context) (int, error) {
-	keyLister, err := c.storage.serverKV.ListKeysFiltered(ctx, "user.*")
-	if err != nil {
-		return 0, fmt.Errorf("failed to list user keys: %w", err)
-	}
-	count := 0
-	for range keyLister.Keys() {
-		count++
-	}
-	return count, nil
+	return c.Users.Count(), nil
 }
 
 func (c *ChattoCore) ListUsers(ctx context.Context) ([]*corev1.User, error) {
-	keyLister, err := c.storage.serverKV.ListKeysFiltered(ctx, "user.*")
-	if err != nil {
-		return []*corev1.User{}, nil
-	}
-
-	var users []*corev1.User
-	for key := range keyLister.Keys() {
-		entry, err := c.storage.serverKV.Get(ctx, key)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get user %s: %w", key, err)
-		}
-
-		user := &corev1.User{}
-		if err := proto.Unmarshal(entry.Value(), user); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal user %s: %w", key, err)
-		}
-
-		users = append(users, user)
-	}
-
-	return users, nil
+	return c.Users.Users(), nil
 }
 
 // GetUserAvatarURL returns the URL for a user's avatar.
@@ -633,13 +553,7 @@ var ErrUsernameBlocked = fmt.Errorf("this username is not available")
 
 // CheckLoginExists checks if a login name is already taken.
 func (c *ChattoCore) CheckLoginExists(ctx context.Context, login string) (bool, error) {
-	login = strings.TrimSpace(login)
-	loginKey := userByLoginKey(login)
-	_, err := c.storage.serverKV.Get(ctx, loginKey)
-	if err != nil {
-		return false, nil
-	}
-	return true, nil
+	return c.Users.LoginExists(login), nil
 }
 
 // UpdateUserDisplayName updates a user's display name.
@@ -663,19 +577,16 @@ func (c *ChattoCore) UpdateUserDisplayName(ctx context.Context, userID, displayN
 		return nil, fmt.Errorf("user not found: %w", err)
 	}
 
-	// Update display name
-	user.DisplayName = displayName
-
-	// Write updated user to KV store
-	userData, err := proto.Marshal(user)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal user: %w", err)
-	}
-
-	_, err = c.storage.serverKV.Put(ctx, userKey(userID), userData)
-	if err != nil {
+	event := newEvent(userID, &corev1.Event{Event: &corev1.Event_UserDisplayNameChanged{
+		UserDisplayNameChanged: &corev1.UserDisplayNameChangedEvent{
+			UserId:      userID,
+			DisplayName: displayName,
+		},
+	}})
+	if _, err := c.appendUserEvent(ctx, userID, event, "", nil); err != nil {
 		return nil, fmt.Errorf("failed to store user: %w", err)
 	}
+	user.DisplayName = displayName
 
 	c.logger.Info("Updated user display name", "id", userID, "displayName", displayName)
 
@@ -747,35 +658,19 @@ func (c *ChattoCore) applyLoginChange(ctx context.Context, userID, newLogin stri
 		return user, nil // No-op, return current user
 	}
 
-	// Case-only change (e.g., "alice" → "Alice") — same KV key, just update the proto record.
-	// No cooldown, no blocked-name check (the name itself hasn't changed), no index swap needed.
-	if strings.EqualFold(user.Login, newLogin) {
-		user.Login = newLogin
-		userData, err := proto.Marshal(user)
+	caseOnly := strings.EqualFold(user.Login, newLogin)
+	if !caseOnly {
+		isBlocked, err := c.configManager.IsUsernameBlocked(ctx, newLogin)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal user: %w", err)
+			return nil, fmt.Errorf("failed to check blocked usernames: %w", err)
 		}
-		_, err = c.storage.serverKV.Put(ctx, userKey(userID), userData)
-		if err != nil {
-			return nil, fmt.Errorf("failed to store user: %w", err)
+		if isBlocked {
+			return nil, ErrUsernameBlocked
 		}
-
-		c.logger.Info("Updated user login casing", "id", userID, "new_login", newLogin)
-		c.publishUserProfileUpdate(ctx, userID)
-		return user, nil
-	}
-
-	// Check blocked list
-	isBlocked, err := c.configManager.IsUsernameBlocked(ctx, newLogin)
-	if err != nil {
-		return nil, fmt.Errorf("failed to check blocked usernames: %w", err)
-	}
-	if isBlocked {
-		return nil, ErrUsernameBlocked
 	}
 
 	// Check cooldown (skipped on admin path)
-	if enforceCooldown {
+	if enforceCooldown && !caseOnly {
 		lastChange, err := c.GetLastLoginChange(ctx, userID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check login change cooldown: %w", err)
@@ -785,44 +680,25 @@ func (c *ChattoCore) applyLoginChange(ctx context.Context, userID, newLogin stri
 		}
 	}
 
-	// Atomic index swap: claim new login first
-	oldLogin := user.Login
-	oldLoginKey := userByLoginKey(oldLogin)
-	newLoginKey := userByLoginKey(newLogin)
-
-	_, err = c.storage.serverKV.Create(ctx, newLoginKey, []byte(userID))
-	if err != nil {
-		return nil, ErrLoginAlreadyTaken
-	}
-
-	// Update user record
-	user.Login = newLogin
-	userData, err := proto.Marshal(user)
-	if err != nil {
-		// Rollback: remove new login claim
-		c.storage.serverKV.Delete(ctx, newLoginKey)
-		return nil, fmt.Errorf("failed to marshal user: %w", err)
-	}
-
-	_, err = c.storage.serverKV.Put(ctx, userKey(userID), userData)
-	if err != nil {
-		// Rollback: remove new login claim
-		c.storage.serverKV.Delete(ctx, newLoginKey)
+	event := newEvent(userID, &corev1.Event{Event: &corev1.Event_UserLoginChanged{
+		UserLoginChanged: &corev1.UserLoginChangedEvent{
+			UserId:           userID,
+			Login:            newLogin,
+			AdvancesCooldown: enforceCooldown && !caseOnly,
+		},
+	}})
+	if _, err := c.appendUserEvent(ctx, userID, event, events.UserSubjectFilter(), func() error {
+		if !caseOnly && c.Users.LoginExists(newLogin) {
+			return ErrLoginAlreadyTaken
+		}
+		return nil
+	}); err != nil {
+		if errors.Is(err, ErrLoginAlreadyTaken) {
+			return nil, ErrLoginAlreadyTaken
+		}
 		return nil, fmt.Errorf("failed to store user: %w", err)
 	}
-
-	// Delete old login index (best-effort)
-	if deleteErr := c.storage.serverKV.Delete(ctx, oldLoginKey); deleteErr != nil {
-		c.logger.Warn("Failed to delete old login index", "error", deleteErr, "old_login", oldLogin)
-	}
-
-	// Record change timestamp for cooldown (skipped on admin path)
-	if enforceCooldown {
-		now := time.Now().Format(time.RFC3339)
-		if _, putErr := c.storage.serverKV.Put(ctx, userLoginChangedAtKey(userID), []byte(now)); putErr != nil {
-			c.logger.Warn("Failed to record login change timestamp", "error", putErr, "user_id", userID)
-		}
-	}
+	user.Login = newLogin
 
 	c.logger.Info("Updated user login", "id", userID, "new_login", newLogin)
 
@@ -835,20 +711,7 @@ func (c *ChattoCore) applyLoginChange(ctx context.Context, userID, newLogin stri
 // GetLastLoginChange returns when the user last changed their login.
 // Returns zero time if the user has never changed their login.
 func (c *ChattoCore) GetLastLoginChange(ctx context.Context, userID string) (time.Time, error) {
-	entry, err := c.storage.serverKV.Get(ctx, userLoginChangedAtKey(userID))
-	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			return time.Time{}, nil
-		}
-		return time.Time{}, fmt.Errorf("failed to get last login change: %w", err)
-	}
-
-	t, err := time.Parse(time.RFC3339, string(entry.Value()))
-	if err != nil {
-		return time.Time{}, fmt.Errorf("failed to parse login change timestamp: %w", err)
-	}
-
-	return t, nil
+	return c.Users.LoginChangedAt(userID), nil
 }
 
 // ClearLoginChangeCooldown removes the cooldown timestamp for a user, allowing
@@ -856,8 +719,10 @@ func (c *ChattoCore) GetLastLoginChange(ctx context.Context, userID string) (tim
 // already-clear cooldown is a no-op.
 // Authorization: Caller must verify admin privileges.
 func (c *ChattoCore) ClearLoginChangeCooldown(ctx context.Context, userID string) error {
-	err := c.storage.serverKV.Delete(ctx, userLoginChangedAtKey(userID))
-	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+	event := newEvent(userID, &corev1.Event{Event: &corev1.Event_UserLoginCooldownCleared{
+		UserLoginCooldownCleared: &corev1.UserLoginCooldownClearedEvent{UserId: userID},
+	}})
+	if _, err := c.appendUserEvent(ctx, userID, event, "", nil); err != nil {
 		return fmt.Errorf("failed to clear login change cooldown: %w", err)
 	}
 	c.logger.Info("Cleared user login change cooldown", "id", userID)
@@ -956,13 +821,6 @@ func (c *ChattoCore) DeleteUser(ctx context.Context, actorID, userID string) err
 		return fmt.Errorf("user not found: %w", err)
 	}
 
-	// Get verified emails before deletion (for index cleanup)
-	verifiedEmails, err := c.GetVerifiedEmails(ctx, userID)
-	if err != nil {
-		c.logger.Warn("Failed to get verified emails for deletion", "user_id", userID, "error", err)
-		verifiedEmails = []VerifiedEmail{} // Continue anyway
-	}
-
 	// Post-ADR-030 there are two implicit scopes — channel and DM — and
 	// cleanup iterates each kind.
 	allKinds := []RoomKind{KindChannel, KindDM}
@@ -999,38 +857,16 @@ func (c *ChattoCore) DeleteUser(ctx context.Context, actorID, userID string) err
 		}
 	}
 
-	// Delete email index entries and per-email verified_email records.
-	for _, email := range verifiedEmails {
-		emailKey := userByEmailKey(email.Email)
-		if err := c.storage.serverKV.Delete(ctx, emailKey); err != nil {
-			c.logger.Warn("Failed to delete email index", "user_id", userID, "email", email.Email, "error", err)
-		}
-		if err := c.storage.serverKV.Delete(ctx, verifiedEmailKey(userID, email.Email)); err != nil {
-			c.logger.Warn("Failed to delete verified_email entry", "user_id", userID, "email", email.Email, "error", err)
-		}
+	deletedEvent := newEvent(actorID, &corev1.Event{Event: &corev1.Event_UserAccountDeleted{
+		UserAccountDeleted: &corev1.UserAccountDeletedEvent{UserId: userID},
+	}})
+	if _, err := c.appendUserEvent(ctx, userID, deletedEvent, "", nil); err != nil {
+		return fmt.Errorf("failed to mark user deleted: %w", err)
 	}
 
-	// Delete user KV entries BEFORE leaving spaces.
-	// This ensures that when SpaceMemberDeletedEvent is published and clients refetch,
-	// the user record is already gone and they see "Deleted User".
-	keysToDelete := []string{
-		userKey(userID),             // user profile
-		userAuthPasswordKey(userID), // password hash
-		userAvatarKey(userID),       // avatar reference
-		userByLoginKey(user.Login),  // login index
-		userPreferencesKey(userID),  // user preferences
-	}
-
-	for _, key := range keysToDelete {
-		if err := c.storage.serverKV.Delete(ctx, key); err != nil {
-			// Log but don't fail - some keys may not exist (e.g., no password for OAuth users)
-			c.logger.Debug("Failed to delete key during user deletion", "key", key, "error", err)
-		}
-	}
-
-	// Clean per-kind user artifacts AFTER the user record is deleted, so the
-	// SpaceMemberDeletedEvent triggered inside lands when client refetches
-	// already see "Deleted User".
+	// Clean per-kind user artifacts AFTER the user projection marks the
+	// account deleted, so SpaceMemberDeletedEvent refetches already see
+	// "Deleted User".
 	for _, kind := range allKinds {
 		if err := c.CleanupUserState(ctx, userID, kind, true); err != nil {
 			c.logger.Warn("Failed to clean up user state during deletion", "user_id", userID, "kind", kind, "error", err)

--- a/cli/internal/core/users_test.go
+++ b/cli/internal/core/users_test.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/nats-io/nats.go/jetstream"
 )
 
 func TestChattoCore_CreateUser(t *testing.T) {
@@ -1119,32 +1117,15 @@ func TestChattoCore_SetUserAvatar(t *testing.T) {
 	}
 }
 
-func TestChattoCore_SetUserAvatar_DoesNotModifyUserRecord(t *testing.T) {
-	core, nc := setupTestCore(t)
+func TestChattoCore_SetUserAvatar_DoesNotModifyUserProfile(t *testing.T) {
+	core, _ := setupTestCore(t)
 	ctx := testContext(t)
-
-	// Get JetStream context and KV bucket for verification
-	js, err := jetstream.New(nc)
-	if err != nil {
-		t.Fatalf("Failed to create JetStream context: %v", err)
-	}
-	kv, err := js.KeyValue(ctx, "INSTANCE")
-	if err != nil {
-		t.Fatalf("Failed to get INSTANCE KV bucket: %v", err)
-	}
 
 	// Create a user
 	user, err := core.CreateUser(ctx, "system", "avataruser", "Avatar User", "")
 	if err != nil {
 		t.Fatalf("Failed to create user: %v", err)
 	}
-
-	// Get the initial user record revision
-	entry1, err := kv.Get(ctx, "user."+user.Id)
-	if err != nil {
-		t.Fatalf("Failed to get user entry: %v", err)
-	}
-	initialRevision := entry1.Revision()
 
 	// Upload and set avatar
 	testImage := createTestImage(100, 100)
@@ -1154,23 +1135,20 @@ func TestChattoCore_SetUserAvatar_DoesNotModifyUserRecord(t *testing.T) {
 		t.Fatalf("Failed to set avatar: %v", err)
 	}
 
-	// User record revision should be unchanged (avatar is stored separately)
-	entry2, err := kv.Get(ctx, "user."+user.Id)
+	updated, err := core.GetUser(ctx, user.Id)
 	if err != nil {
-		t.Fatalf("Failed to get user entry: %v", err)
+		t.Fatalf("Failed to get user: %v", err)
+	}
+	if updated.Login != user.Login || updated.DisplayName != user.DisplayName {
+		t.Error("User profile fields were modified when avatar changed")
 	}
 
-	if entry2.Revision() != initialRevision {
-		t.Error("User record was modified when avatar changed - expected no modification")
-	}
-
-	// Verify avatar is stored at the correct scoped key
-	avatarEntry, err := kv.Get(ctx, "user."+user.Id+".avatar")
+	avatar, err := core.GetUserAvatar(ctx, user.Id)
 	if err != nil {
-		t.Fatalf("Expected avatar to be stored at scoped key: %v", err)
+		t.Fatalf("Failed to get avatar: %v", err)
 	}
-	if avatarEntry == nil {
-		t.Error("Expected avatar entry to exist")
+	if avatar == nil || avatar.GetNats().GetKey() != asset.GetNats().GetKey() {
+		t.Error("Expected avatar projection to contain the uploaded avatar")
 	}
 }
 
@@ -1481,7 +1459,6 @@ func TestChattoCore_DeleteUser_PreservesSpaceAndPurgesUser(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create user: %v", err)
 	}
-
 
 	if err := core.DeleteUser(ctx, user.Id, user.Id); err != nil {
 		t.Fatalf("Failed to delete user: %v", err)

--- a/cli/internal/core/verified_emails.go
+++ b/cli/internal/core/verified_emails.go
@@ -11,9 +11,8 @@ import (
 	"time"
 
 	"github.com/nats-io/nats.go/jetstream"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"hmans.de/chatto/internal/events"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
@@ -180,31 +179,8 @@ func (c *ChattoCore) VerifyEmail(ctx context.Context, token string) (userID stri
 		return "", err
 	}
 
-	// Try to claim the email (atomic operation to prevent duplicates)
-	normalizedEmail := strings.ToLower(tokenData.Email)
-	claimKey := userByEmailKey(normalizedEmail)
-
-	// Track whether we created the claim (for rollback purposes)
-	claimCreated := false
-	_, err = c.storage.serverKV.Create(ctx, claimKey, []byte(tokenData.UserID))
-	if err != nil {
-		// Claim failed - check if it's already claimed by this same user (idempotent)
-		entry, getErr := c.storage.serverKV.Get(ctx, claimKey)
-		if getErr != nil || string(entry.Value()) != tokenData.UserID {
-			// Email claimed by another user
-			return "", ErrEmailAlreadyVerified
-		}
-		// Claim exists for this user - continue to ensure email is in verified list
-	} else {
-		claimCreated = true
-	}
-
 	// Add to user's verified emails (idempotent - won't duplicate)
 	if err := c.addVerifiedEmail(ctx, tokenData.UserID, tokenData.Email); err != nil {
-		// Only rollback if we just created the claim
-		if claimCreated {
-			c.storage.serverKV.Delete(ctx, claimKey)
-		}
 		return "", err
 	}
 
@@ -214,19 +190,25 @@ func (c *ChattoCore) VerifyEmail(ctx context.Context, token string) (userID stri
 	return tokenData.UserID, nil
 }
 
-// addVerifiedEmail writes a single per-email proto entry for the user.
+// addVerifiedEmail appends a durable verified-email event for the user.
 // Idempotent: rewriting the same (user, email) pair just overwrites the
 // existing entry with identical content.
 func (c *ChattoCore) addVerifiedEmail(ctx context.Context, userID, email string) error {
-	data, err := proto.Marshal(&corev1.VerifiedEmail{
-		Email:      email,
-		VerifiedAt: timestamppb.New(time.Now()),
-	})
-	if err != nil {
-		return fmt.Errorf("failed to marshal verified email: %w", err)
-	}
-
-	if _, err := c.storage.serverKV.Put(ctx, verifiedEmailKey(userID, email), data); err != nil {
+	event := newEvent(userID, &corev1.Event{Event: &corev1.Event_UserVerifiedEmailAdded{
+		UserVerifiedEmailAdded: &corev1.UserVerifiedEmailAddedEvent{
+			UserId: userID,
+			Email:  email,
+		},
+	}})
+	if _, err := c.appendUserEvent(ctx, userID, event, events.UserSubjectFilter(), func() error {
+		if user, ok := c.Users.GetByEmail(email); ok && user.GetId() != userID {
+			return ErrEmailAlreadyVerified
+		}
+		return nil
+	}); err != nil {
+		if errors.Is(err, ErrEmailAlreadyVerified) {
+			return ErrEmailAlreadyVerified
+		}
 		return fmt.Errorf("failed to store verified email: %w", err)
 	}
 
@@ -247,82 +229,29 @@ func (c *ChattoCore) addVerifiedEmail(ctx context.Context, userID, email string)
 	return nil
 }
 
-// GetVerifiedEmails returns all verified emails for a user.
-//
-// One KV entry per email under `verified_emails.{userID}.*`, so this is
-// a prefix scan plus an O(N) decode of just this user's entries.
+// GetVerifiedEmails returns all verified emails for a user from the user projection.
 func (c *ChattoCore) GetVerifiedEmails(ctx context.Context, userID string) ([]VerifiedEmail, error) {
-	keyLister, err := c.storage.serverKV.ListKeysFiltered(ctx, verifiedEmailPrefix(userID))
-	if err != nil {
-		// No matching keys.
-		return []VerifiedEmail{}, nil
-	}
-
-	var emails []VerifiedEmail
-	for key := range keyLister.Keys() {
-		entry, err := c.storage.serverKV.Get(ctx, key)
-		if err != nil {
-			if errors.Is(err, jetstream.ErrKeyNotFound) {
-				continue
-			}
-			return nil, fmt.Errorf("failed to get verified email entry: %w", err)
-		}
-		ve := &corev1.VerifiedEmail{}
-		if err := proto.Unmarshal(entry.Value(), ve); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal verified email: %w", err)
-		}
-		emails = append(emails, VerifiedEmail{
-			Email:      ve.Email,
-			VerifiedAt: ve.VerifiedAt.AsTime(),
-		})
-	}
-	return emails, nil
+	return c.Users.VerifiedEmails(userID), nil
 }
 
 // HasVerifiedEmail checks if a user has at least one verified email.
 func (c *ChattoCore) HasVerifiedEmail(ctx context.Context, userID string) (bool, error) {
-	keyLister, err := c.storage.serverKV.ListKeysFiltered(ctx, verifiedEmailPrefix(userID))
-	if err != nil {
-		return false, nil
-	}
-	for range keyLister.Keys() {
-		return true, nil
-	}
-	return false, nil
+	return c.Users.HasVerifiedEmail(userID), nil
 }
 
 // IsEmailClaimed checks if an email address is already verified by any user.
 // Used to prevent registration with an email that's already in use.
 func (c *ChattoCore) IsEmailClaimed(ctx context.Context, email string) (bool, error) {
-	normalizedEmail := strings.ToLower(email)
-	claimKey := userByEmailKey(normalizedEmail)
-
-	_, err := c.storage.serverKV.Get(ctx, claimKey)
-	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			return false, nil // Email is not claimed
-		}
-		return false, fmt.Errorf("failed to check email claim: %w", err)
-	}
-	return true, nil // Email is claimed
+	return c.Users.EmailClaimed(email), nil
 }
 
 // GetUserByVerifiedEmail looks up a user by their verified email address.
 // Returns the user if found, or an error if not found.
 func (c *ChattoCore) GetUserByVerifiedEmail(ctx context.Context, email string) (*corev1.User, error) {
-	normalizedEmail := strings.ToLower(email)
-	claimKey := userByEmailKey(normalizedEmail)
-
-	entry, err := c.storage.serverKV.Get(ctx, claimKey)
-	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			return nil, fmt.Errorf("no user found with verified email")
-		}
-		return nil, fmt.Errorf("failed to lookup user by email: %w", err)
+	if user, ok := c.Users.GetByEmail(email); ok {
+		return user, nil
 	}
-
-	userID := string(entry.Value())
-	return c.GetUser(ctx, userID)
+	return nil, fmt.Errorf("no user found with verified email")
 }
 
 // CountVerifiedUsers returns the number of distinct users with at least
@@ -335,76 +264,16 @@ func (c *ChattoCore) GetUserByVerifiedEmail(ctx context.Context, email string) (
 // the older version of this file for the JetStream subject-count
 // pitfall.
 func (c *ChattoCore) CountVerifiedUsers(ctx context.Context) (int, error) {
-	keyLister, err := c.storage.serverKV.ListKeysFiltered(ctx, "user_by_email.*")
-	if err != nil {
-		return 0, nil
-	}
-	users := map[string]struct{}{}
-	for key := range keyLister.Keys() {
-		entry, err := c.storage.serverKV.Get(ctx, key)
-		if err != nil {
-			if errors.Is(err, jetstream.ErrKeyNotFound) {
-				continue
-			}
-			return 0, fmt.Errorf("failed to read user_by_email entry: %w", err)
-		}
-		users[string(entry.Value())] = struct{}{}
-	}
-	return len(users), nil
+	return len(c.Users.VerifiedUserIDs()), nil
 }
 
 // ListUsersWithVerifiedEmail returns all user IDs that have at least one verified email.
 func (c *ChattoCore) ListUsersWithVerifiedEmail(ctx context.Context) ([]string, error) {
-	keyLister, err := c.storage.serverKV.ListKeysFiltered(ctx, "user_by_email.*")
-	if err != nil {
-		return []string{}, nil
-	}
-
-	seen := map[string]struct{}{}
-	users := []string{}
-	for key := range keyLister.Keys() {
-		entry, err := c.storage.serverKV.Get(ctx, key)
-		if err != nil {
-			if errors.Is(err, jetstream.ErrKeyNotFound) {
-				continue
-			}
-			return nil, fmt.Errorf("failed to read user_by_email entry: %w", err)
-		}
-		userID := string(entry.Value())
-		if _, ok := seen[userID]; ok {
-			continue
-		}
-		seen[userID] = struct{}{}
-		users = append(users, userID)
-	}
-	return users, nil
+	return c.Users.VerifiedUserIDs(), nil
 }
 
 // AddVerifiedEmailDirect adds an email as verified without requiring token verification.
 // Used for OAuth flows where the email is already verified by the provider.
 func (c *ChattoCore) AddVerifiedEmailDirect(ctx context.Context, userID, email string) error {
-	// Try to claim the email
-	normalizedEmail := strings.ToLower(email)
-	claimKey := userByEmailKey(normalizedEmail)
-
-	_, err := c.storage.serverKV.Create(ctx, claimKey, []byte(userID))
-	if err != nil {
-		// Email already claimed - check if it's by this user
-		entry, getErr := c.storage.serverKV.Get(ctx, claimKey)
-		if getErr == nil && string(entry.Value()) == userID {
-			// Already verified by this user, nothing to do
-			return nil
-		}
-		// Claimed by another user
-		return ErrEmailAlreadyVerified
-	}
-
-	// Add to verified emails
-	if err := c.addVerifiedEmail(ctx, userID, email); err != nil {
-		// Rollback: delete the claim
-		c.storage.serverKV.Delete(ctx, claimKey)
-		return err
-	}
-
-	return nil
+	return c.addVerifiedEmail(ctx, userID, email)
 }

--- a/cli/internal/events/subjects.go
+++ b/cli/internal/events/subjects.go
@@ -25,6 +25,7 @@ const (
 	AggregateConfig = "config"
 	AggregateGroup  = "group"
 	AggregateLayout = "layout"
+	AggregateUser   = "user"
 )
 
 // ConfigSingletonID is the sentinel aggregate ID for server-wide config
@@ -81,6 +82,19 @@ const (
 
 	// Config aggregate (singleton)
 	EventServerConfigChanged = "config_changed"
+
+	// User aggregate
+	EventUserAccountCreated           = "account_created"
+	EventUserLoginChanged             = "login_changed"
+	EventUserDisplayNameChanged       = "display_name_changed"
+	EventUserAvatarSet                = "avatar_set"
+	EventUserAvatarCleared            = "avatar_cleared"
+	EventUserVerifiedEmailAdded       = "verified_email_added"
+	EventUserPasswordHashChanged      = "password_hash_changed"
+	EventUserOIDCSubjectLinked        = "oidc_subject_linked"
+	EventUserServerPreferencesChanged = "server_preferences_changed"
+	EventUserLoginCooldownCleared     = "login_cooldown_cleared"
+	EventUserAccountDeleted           = "account_deleted"
 )
 
 // EventTypeOf returns the canonical NATS subject token for an event's
@@ -139,6 +153,29 @@ func EventTypeOf(e *corev1.Event) string {
 
 	case *corev1.Event_ServerConfigChanged:
 		return EventServerConfigChanged
+
+	case *corev1.Event_UserAccountCreated:
+		return EventUserAccountCreated
+	case *corev1.Event_UserLoginChanged:
+		return EventUserLoginChanged
+	case *corev1.Event_UserDisplayNameChanged:
+		return EventUserDisplayNameChanged
+	case *corev1.Event_UserAvatarSet:
+		return EventUserAvatarSet
+	case *corev1.Event_UserAvatarCleared:
+		return EventUserAvatarCleared
+	case *corev1.Event_UserVerifiedEmailAdded:
+		return EventUserVerifiedEmailAdded
+	case *corev1.Event_UserPasswordHashChanged:
+		return EventUserPasswordHashChanged
+	case *corev1.Event_UserOidcSubjectLinked:
+		return EventUserOIDCSubjectLinked
+	case *corev1.Event_UserServerPreferencesChanged:
+		return EventUserServerPreferencesChanged
+	case *corev1.Event_UserLoginCooldownCleared:
+		return EventUserLoginCooldownCleared
+	case *corev1.Event_UserAccountDeleted:
+		return EventUserAccountDeleted
 	}
 	return ""
 }
@@ -208,6 +245,13 @@ func ConfigAggregate() Aggregate {
 	return Aggregate{Type: AggregateConfig, ID: ConfigSingletonID}
 }
 
+// UserAggregate is the typed constructor for a user aggregate. It owns
+// identity/profile state, verified-email indexes, password auth state,
+// OIDC subject links, server preferences, and account deletion.
+func UserAggregate(userID string) Aggregate {
+	return Aggregate{Type: AggregateUser, ID: userID}
+}
+
 // RoomSubjectFilter returns the wildcard filter matching every event of
 // every room aggregate, across all event types.
 // Pattern: evt.room.>
@@ -227,6 +271,11 @@ func LayoutSubjectFilter() string { return SubjectRoot + AggregateLayout + ".>" 
 // of the singleton config aggregate.
 // Pattern: evt.config.>
 func ConfigSubjectFilter() string { return SubjectRoot + AggregateConfig + ".>" }
+
+// UserSubjectFilter returns the wildcard filter matching every user
+// aggregate event.
+// Pattern: evt.user.>
+func UserSubjectFilter() string { return SubjectRoot + AggregateUser + ".>" }
 
 // RoomEventTypeFilter returns a cross-aggregate, event-type-narrow
 // filter — every event of the given type across every room. Used by
@@ -255,6 +304,12 @@ func ParseRoomSubject(subject string) (roomID string, ok bool) {
 // subject. Accepts durable and republished live forms.
 func ParseGroupSubject(subject string) (groupID string, ok bool) {
 	return parseAggregateSubject(subject, AggregateGroup)
+}
+
+// ParseUserSubject extracts the userID from a user-aggregate event
+// subject. Accepts durable and republished live forms.
+func ParseUserSubject(subject string) (userID string, ok bool) {
+	return parseAggregateSubject(subject, AggregateUser)
 }
 
 // parseAggregateSubject extracts the aggregate ID from a subject of the

--- a/cli/internal/events/subjects.go
+++ b/cli/internal/events/subjects.go
@@ -93,6 +93,7 @@ const (
 	EventUserPasswordHashChanged      = "password_hash_changed"
 	EventUserOIDCSubjectLinked        = "oidc_subject_linked"
 	EventUserServerPreferencesChanged = "server_preferences_changed"
+	EventUserLoginCooldownStarted     = "login_cooldown_started"
 	EventUserLoginCooldownCleared     = "login_cooldown_cleared"
 	EventUserAccountDeleted           = "account_deleted"
 )
@@ -172,6 +173,8 @@ func EventTypeOf(e *corev1.Event) string {
 		return EventUserOIDCSubjectLinked
 	case *corev1.Event_UserServerPreferencesChanged:
 		return EventUserServerPreferencesChanged
+	case *corev1.Event_UserLoginCooldownStarted:
+		return EventUserLoginCooldownStarted
 	case *corev1.Event_UserLoginCooldownCleared:
 		return EventUserLoginCooldownCleared
 	case *corev1.Event_UserAccountDeleted:

--- a/cli/internal/graph/dataloader/user_loader_test.go
+++ b/cli/internal/graph/dataloader/user_loader_test.go
@@ -57,6 +57,16 @@ func setupTestCore(t *testing.T) *core.ChattoCore {
 		t.Fatalf("Failed to create ChattoCore: %v", err)
 	}
 
+	runCtx, runCancel := context.WithCancel(context.Background())
+	go func() { _ = c.Run(runCtx) }()
+	t.Cleanup(runCancel)
+
+	bootCtx, bootCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer bootCancel()
+	if err := c.WaitForBoot(bootCtx); err != nil {
+		t.Fatalf("WaitForBoot: %v", err)
+	}
+
 	return c
 }
 

--- a/cli/internal/migrations/migrations.go
+++ b/cli/internal/migrations/migrations.go
@@ -105,5 +105,8 @@ func RunAll(
 	if err := MigrateReactionsToES(ctx, serverEventsStream, serverReactionsKV, publisher, logger); err != nil {
 		return fmt.Errorf("reactions_es: %w", err)
 	}
+	if err := MigrateUsersToES(ctx, serverKV, publisher, logger); err != nil {
+		return fmt.Errorf("users_es: %w", err)
+	}
 	return nil
 }

--- a/cli/internal/migrations/users_es.go
+++ b/cli/internal/migrations/users_es.go
@@ -1,0 +1,424 @@
+package migrations
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/log"
+	"github.com/nats-io/nats.go/jetstream"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"hmans.de/chatto/internal/events"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+// MigrateUsersToES seeds EVT from the legacy INSTANCE user/account keys
+// for issue #643:
+//
+//   - user.{id}
+//   - auth.{id}.password
+//   - user.{id}.avatar
+//   - verified_emails.{id}.{emailHash}
+//   - user_preferences.{id}
+//   - user_login_changed_at.{id}
+//   - user_by_oidc.{issuerSubjectHash}
+//
+// Login and email indexes are not imported as their own events; they are
+// reconstructed by the projection from user-created / verified-email-added
+// events. OIDC index keys are one-way hashes, so legacy imports preserve the
+// hash directly.
+func MigrateUsersToES(
+	ctx context.Context,
+	serverKV jetstream.KeyValue,
+	publisher *events.Publisher,
+	logger *log.Logger,
+) error {
+	userKeys, err := listLegacyUserRecordKeys(ctx, serverKV)
+	if err != nil {
+		return err
+	}
+	if len(userKeys) == 0 {
+		return nil
+	}
+
+	oidcByUser, err := loadOIDCSubjectHashesByUser(ctx, serverKV)
+	if err != nil {
+		return err
+	}
+
+	var imported, skipped int
+	startedAt := time.Now()
+	for _, key := range userKeys {
+		entry, err := serverKV.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			return fmt.Errorf("get user record %s: %w", key, err)
+		}
+
+		var user corev1.User
+		if err := proto.Unmarshal(entry.Value(), &user); err != nil {
+			logger.Warn("users ES migration: skipping unmarshalable user", "key", key, "error", err)
+			continue
+		}
+		if user.GetId() == "" {
+			logger.Warn("users ES migration: skipping user without id", "key", key)
+			continue
+		}
+
+		entries, err := buildUserMigrationEntries(ctx, serverKV, &user, entry.Created(), oidcByUser[user.GetId()], logger)
+		if err != nil {
+			return fmt.Errorf("build user migration events for %s: %w", user.GetId(), err)
+		}
+
+		userImported, userSkipped, err := publishUserMigration(ctx, publisher, user.GetId(), entries, logger)
+		if err != nil {
+			return fmt.Errorf("publish user migration for %s: %w", user.GetId(), err)
+		}
+		imported += userImported
+		skipped += userSkipped
+	}
+
+	if imported > 0 || skipped > 0 {
+		logger.Info(
+			"users ES migration: seeded events from legacy INSTANCE KV",
+			"user_events_imported", imported,
+			"user_events_skipped", skipped,
+			"users_processed", len(userKeys),
+			"duration_ms", time.Since(startedAt).Milliseconds(),
+		)
+	}
+	return nil
+}
+
+func listLegacyUserRecordKeys(ctx context.Context, kv jetstream.KeyValue) ([]string, error) {
+	keys, err := listSortedKeys(ctx, kv, "user.*")
+	if err != nil {
+		return nil, fmt.Errorf("list user keys: %w", err)
+	}
+	out := keys[:0]
+	for _, key := range keys {
+		parts := strings.Split(key, ".")
+		if len(parts) == 2 {
+			out = append(out, key)
+		}
+	}
+	return out, nil
+}
+
+func buildUserMigrationEntries(
+	ctx context.Context,
+	kv jetstream.KeyValue,
+	user *corev1.User,
+	legacyCreatedAt time.Time,
+	oidcSubjectHashes []string,
+	logger *log.Logger,
+) ([]events.BatchEntry, error) {
+	agg := events.UserAggregate(user.GetId())
+	createdAt := user.GetCreatedAt()
+	if createdAt == nil {
+		createdAt = timestamppb.New(legacyCreatedAt)
+	}
+
+	created := stamp(&corev1.Event{Event: &corev1.Event_UserAccountCreated{
+		UserAccountCreated: &corev1.UserAccountCreatedEvent{
+			UserId:      user.GetId(),
+			Login:       user.GetLogin(),
+			DisplayName: user.GetDisplayName(),
+		},
+	}}, "system:migration", createdAt)
+
+	entries := []events.BatchEntry{{
+		Subject: agg.SubjectFor(created),
+		Event:   created,
+	}}
+
+	if passwordHash, ok, err := getLegacyBytes(ctx, kv, "auth."+user.GetId()+".password"); err != nil {
+		return nil, err
+	} else if ok {
+		event := stamp(&corev1.Event{Event: &corev1.Event_UserPasswordHashChanged{
+			UserPasswordHashChanged: &corev1.UserPasswordHashChangedEvent{
+				UserId:       user.GetId(),
+				PasswordHash: passwordHash,
+			},
+		}}, "system:migration", createdAt)
+		entries = append(entries, events.BatchEntry{Subject: agg.SubjectFor(event), Event: event})
+	}
+
+	if avatar, ok, err := getLegacyAvatar(ctx, kv, "user."+user.GetId()+".avatar"); err != nil {
+		return nil, err
+	} else if ok {
+		event := stamp(&corev1.Event{Event: &corev1.Event_UserAvatarSet{
+			UserAvatarSet: &corev1.UserAvatarSetEvent{
+				UserId: user.GetId(),
+				Avatar: avatar,
+			},
+		}}, "system:migration", createdAt)
+		entries = append(entries, events.BatchEntry{Subject: agg.SubjectFor(event), Event: event})
+	}
+
+	emailEntries, err := getLegacyVerifiedEmailEvents(ctx, kv, user.GetId(), createdAt, logger)
+	if err != nil {
+		return nil, err
+	}
+	for _, event := range emailEntries {
+		entries = append(entries, events.BatchEntry{Subject: agg.SubjectFor(event), Event: event})
+	}
+
+	sort.Strings(oidcSubjectHashes)
+	for _, hash := range oidcSubjectHashes {
+		event := stamp(&corev1.Event{Event: &corev1.Event_UserOidcSubjectLinked{
+			UserOidcSubjectLinked: &corev1.UserOIDCSubjectLinkedEvent{
+				UserId:      user.GetId(),
+				SubjectHash: hash,
+			},
+		}}, "system:migration", createdAt)
+		entries = append(entries, events.BatchEntry{Subject: agg.SubjectFor(event), Event: event})
+	}
+
+	if prefs, ok, err := getLegacyPreferences(ctx, kv, "user_preferences."+user.GetId()); err != nil {
+		return nil, err
+	} else if ok {
+		event := stamp(&corev1.Event{Event: &corev1.Event_UserServerPreferencesChanged{
+			UserServerPreferencesChanged: &corev1.UserServerPreferencesChangedEvent{
+				UserId:      user.GetId(),
+				Preferences: prefs,
+			},
+		}}, "system:migration", createdAt)
+		entries = append(entries, events.BatchEntry{Subject: agg.SubjectFor(event), Event: event})
+	}
+
+	if changedAt, ok, err := getLegacyLoginChangedAt(ctx, kv, "user_login_changed_at."+user.GetId()); err != nil {
+		return nil, err
+	} else if ok {
+		event := stamp(&corev1.Event{Event: &corev1.Event_UserLoginChanged{
+			UserLoginChanged: &corev1.UserLoginChangedEvent{
+				UserId:           user.GetId(),
+				Login:            user.GetLogin(),
+				AdvancesCooldown: true,
+			},
+		}}, "system:migration", timestamppb.New(changedAt))
+		entries = append(entries, events.BatchEntry{Subject: agg.SubjectFor(event), Event: event})
+	}
+
+	return entries, nil
+}
+
+func getLegacyBytes(ctx context.Context, kv jetstream.KeyValue, key string) ([]byte, bool, error) {
+	entry, err := kv.Get(ctx, key)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrKeyNotFound) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("get %s: %w", key, err)
+	}
+	return append([]byte(nil), entry.Value()...), true, nil
+}
+
+func getLegacyAvatar(ctx context.Context, kv jetstream.KeyValue, key string) (*corev1.Asset, bool, error) {
+	value, ok, err := getLegacyBytes(ctx, kv, key)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+	asset := &corev1.Asset{}
+	if err := proto.Unmarshal(value, asset); err != nil {
+		return nil, false, fmt.Errorf("unmarshal %s: %w", key, err)
+	}
+	return asset, true, nil
+}
+
+func getLegacyPreferences(ctx context.Context, kv jetstream.KeyValue, key string) (*corev1.ServerUserPreferences, bool, error) {
+	value, ok, err := getLegacyBytes(ctx, kv, key)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+	prefs := &corev1.ServerUserPreferences{}
+	if err := proto.Unmarshal(value, prefs); err != nil {
+		return nil, false, fmt.Errorf("unmarshal %s: %w", key, err)
+	}
+	return prefs, true, nil
+}
+
+func getLegacyLoginChangedAt(ctx context.Context, kv jetstream.KeyValue, key string) (time.Time, bool, error) {
+	value, ok, err := getLegacyBytes(ctx, kv, key)
+	if err != nil || !ok {
+		return time.Time{}, ok, err
+	}
+	t, err := time.Parse(time.RFC3339, string(value))
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("parse %s: %w", key, err)
+	}
+	return t, true, nil
+}
+
+func getLegacyVerifiedEmailEvents(
+	ctx context.Context,
+	kv jetstream.KeyValue,
+	userID string,
+	fallbackCreatedAt *timestamppb.Timestamp,
+	logger *log.Logger,
+) ([]*corev1.Event, error) {
+	keys, err := listSortedKeys(ctx, kv, "verified_emails."+userID+".*")
+	if err != nil {
+		return nil, fmt.Errorf("list verified emails for %s: %w", userID, err)
+	}
+	out := make([]*corev1.Event, 0, len(keys))
+	for _, key := range keys {
+		entry, err := kv.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			return nil, fmt.Errorf("get %s: %w", key, err)
+		}
+		var ve corev1.VerifiedEmail
+		if err := proto.Unmarshal(entry.Value(), &ve); err != nil {
+			logger.Warn("users ES migration: skipping unmarshalable verified email", "key", key, "error", err)
+			continue
+		}
+		verifiedAt := ve.GetVerifiedAt()
+		if verifiedAt == nil {
+			verifiedAt = timestamppb.New(entry.Created())
+		}
+		if verifiedAt == nil {
+			verifiedAt = fallbackCreatedAt
+		}
+		event := stamp(&corev1.Event{Event: &corev1.Event_UserVerifiedEmailAdded{
+			UserVerifiedEmailAdded: &corev1.UserVerifiedEmailAddedEvent{
+				UserId: userID,
+				Email:  ve.GetEmail(),
+			},
+		}}, "system:migration", verifiedAt)
+		out = append(out, event)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		a := out[i].GetUserVerifiedEmailAdded()
+		b := out[j].GetUserVerifiedEmailAdded()
+		if out[i].GetCreatedAt() != nil && out[j].GetCreatedAt() != nil && !out[i].GetCreatedAt().AsTime().Equal(out[j].GetCreatedAt().AsTime()) {
+			return out[i].GetCreatedAt().AsTime().Before(out[j].GetCreatedAt().AsTime())
+		}
+		return strings.ToLower(a.GetEmail()) < strings.ToLower(b.GetEmail())
+	})
+	return out, nil
+}
+
+func loadOIDCSubjectHashesByUser(ctx context.Context, kv jetstream.KeyValue) (map[string][]string, error) {
+	keys, err := listSortedKeys(ctx, kv, "user_by_oidc.*")
+	if err != nil {
+		return nil, fmt.Errorf("list OIDC indexes: %w", err)
+	}
+	out := make(map[string][]string)
+	for _, key := range keys {
+		entry, err := kv.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			return nil, fmt.Errorf("get %s: %w", key, err)
+		}
+		hash := strings.TrimPrefix(key, "user_by_oidc.")
+		out[string(entry.Value())] = append(out[string(entry.Value())], hash)
+	}
+	return out, nil
+}
+
+func publishUserMigration(
+	ctx context.Context,
+	publisher *events.Publisher,
+	userID string,
+	entries []events.BatchEntry,
+	logger *log.Logger,
+) (imported int, skipped int, err error) {
+	if len(entries) == 0 {
+		return 0, 0, nil
+	}
+
+	agg := events.UserAggregate(userID)
+	existingEvents, expectedSeq, err := publisher.SubjectEvents(ctx, agg.AllEventsFilter())
+	if err != nil {
+		return 0, 0, fmt.Errorf("read existing user events: %w", err)
+	}
+	if len(existingEvents) > len(entries) {
+		logger.Warn(
+			"users ES migration: skipping user with more existing events than legacy events",
+			"user_id", userID,
+			"existing_events", len(existingEvents),
+			"legacy_events", len(entries),
+		)
+		return 0, len(entries), nil
+	}
+	for i, existing := range existingEvents {
+		if userMigrationIdentity(existing) != userMigrationIdentity(entries[i].Event) {
+			logger.Warn(
+				"users ES migration: skipping user with non-matching existing event prefix",
+				"user_id", userID,
+				"index", i,
+				"existing_event", userMigrationIdentity(existing),
+				"legacy_event", userMigrationIdentity(entries[i].Event),
+			)
+			return 0, len(entries), nil
+		}
+	}
+	if len(existingEvents) == len(entries) {
+		return 0, len(entries), nil
+	}
+
+	pending := entries[len(existingEvents):]
+	for start := 0; start < len(pending); start += messageMigrationBatchSize {
+		end := start + messageMigrationBatchSize
+		if end > len(pending) {
+			end = len(pending)
+		}
+
+		chunk := append([]events.BatchEntry(nil), pending[start:end]...)
+		chunk[0].HasOCC = true
+		chunk[0].ExpectedSeq = expectedSeq
+		chunk[0].FilterSubject = agg.AllEventsFilter()
+
+		seqs, err := publisher.AppendBatch(ctx, chunk)
+		if err != nil {
+			if errors.Is(err, events.ErrConflict) {
+				return imported, skipped, fmt.Errorf("user chunk OCC conflict after resume point %d: %w", len(existingEvents)+imported, err)
+			}
+			return imported, skipped, err
+		}
+		expectedSeq = seqs[len(seqs)-1]
+		imported += len(chunk)
+	}
+	return imported, len(existingEvents), nil
+}
+
+func userMigrationIdentity(event *corev1.Event) string {
+	switch e := event.GetEvent().(type) {
+	case *corev1.Event_UserAccountCreated:
+		return strings.Join([]string{events.EventUserAccountCreated, e.UserAccountCreated.GetUserId(), strings.ToLower(e.UserAccountCreated.GetLogin()), e.UserAccountCreated.GetDisplayName()}, "\x00")
+	case *corev1.Event_UserDisplayNameChanged:
+		return events.EventUserDisplayNameChanged + "\x00" + e.UserDisplayNameChanged.GetUserId() + "\x00" + e.UserDisplayNameChanged.GetDisplayName()
+	case *corev1.Event_UserPasswordHashChanged:
+		return events.EventUserPasswordHashChanged + "\x00" + e.UserPasswordHashChanged.GetUserId() + "\x00" + string(e.UserPasswordHashChanged.GetPasswordHash())
+	case *corev1.Event_UserAvatarSet:
+		data, _ := proto.Marshal(e.UserAvatarSet.GetAvatar())
+		return events.EventUserAvatarSet + "\x00" + e.UserAvatarSet.GetUserId() + "\x00" + hex.EncodeToString(data)
+	case *corev1.Event_UserAvatarCleared:
+		return events.EventUserAvatarCleared + "\x00" + e.UserAvatarCleared.GetUserId()
+	case *corev1.Event_UserVerifiedEmailAdded:
+		return events.EventUserVerifiedEmailAdded + "\x00" + e.UserVerifiedEmailAdded.GetUserId() + "\x00" + strings.ToLower(e.UserVerifiedEmailAdded.GetEmail())
+	case *corev1.Event_UserOidcSubjectLinked:
+		return events.EventUserOIDCSubjectLinked + "\x00" + e.UserOidcSubjectLinked.GetUserId() + "\x00" + e.UserOidcSubjectLinked.GetSubjectHash()
+	case *corev1.Event_UserServerPreferencesChanged:
+		data, _ := proto.Marshal(e.UserServerPreferencesChanged.GetPreferences())
+		return events.EventUserServerPreferencesChanged + "\x00" + e.UserServerPreferencesChanged.GetUserId() + "\x00" + hex.EncodeToString(data)
+	case *corev1.Event_UserLoginChanged:
+		return events.EventUserLoginChanged + "\x00" + e.UserLoginChanged.GetUserId() + "\x00" + strings.ToLower(e.UserLoginChanged.GetLogin()) + "\x00" + fmt.Sprint(e.UserLoginChanged.GetAdvancesCooldown())
+	case *corev1.Event_UserLoginCooldownCleared:
+		return events.EventUserLoginCooldownCleared + "\x00" + e.UserLoginCooldownCleared.GetUserId()
+	}
+	return events.EventTypeOf(event)
+}

--- a/cli/internal/migrations/users_es.go
+++ b/cli/internal/migrations/users_es.go
@@ -198,11 +198,9 @@ func buildUserMigrationEntries(
 	if changedAt, ok, err := getLegacyLoginChangedAt(ctx, kv, "user_login_changed_at."+user.GetId()); err != nil {
 		return nil, err
 	} else if ok {
-		event := stamp(&corev1.Event{Event: &corev1.Event_UserLoginChanged{
-			UserLoginChanged: &corev1.UserLoginChangedEvent{
-				UserId:           user.GetId(),
-				Login:            user.GetLogin(),
-				AdvancesCooldown: true,
+		event := stamp(&corev1.Event{Event: &corev1.Event_UserLoginCooldownStarted{
+			UserLoginCooldownStarted: &corev1.UserLoginCooldownStartedEvent{
+				UserId: user.GetId(),
 			},
 		}}, "system:migration", timestamppb.New(changedAt))
 		entries = append(entries, events.BatchEntry{Subject: agg.SubjectFor(event), Event: event})
@@ -416,7 +414,9 @@ func userMigrationIdentity(event *corev1.Event) string {
 		data, _ := proto.Marshal(e.UserServerPreferencesChanged.GetPreferences())
 		return events.EventUserServerPreferencesChanged + "\x00" + e.UserServerPreferencesChanged.GetUserId() + "\x00" + hex.EncodeToString(data)
 	case *corev1.Event_UserLoginChanged:
-		return events.EventUserLoginChanged + "\x00" + e.UserLoginChanged.GetUserId() + "\x00" + strings.ToLower(e.UserLoginChanged.GetLogin()) + "\x00" + fmt.Sprint(e.UserLoginChanged.GetAdvancesCooldown())
+		return events.EventUserLoginChanged + "\x00" + e.UserLoginChanged.GetUserId() + "\x00" + strings.ToLower(e.UserLoginChanged.GetLogin())
+	case *corev1.Event_UserLoginCooldownStarted:
+		return events.EventUserLoginCooldownStarted + "\x00" + e.UserLoginCooldownStarted.GetUserId()
 	case *corev1.Event_UserLoginCooldownCleared:
 		return events.EventUserLoginCooldownCleared + "\x00" + e.UserLoginCooldownCleared.GetUserId()
 	}

--- a/cli/internal/migrations/users_es_test.go
+++ b/cli/internal/migrations/users_es_test.go
@@ -64,7 +64,7 @@ func TestMigrateUsersToES_SeedsUserAggregateAndReplays(t *testing.T) {
 	require.IsType(t, &corev1.Event_UserVerifiedEmailAdded{}, eventsBySeq[3].GetEvent())
 	require.IsType(t, &corev1.Event_UserOidcSubjectLinked{}, eventsBySeq[4].GetEvent())
 	require.IsType(t, &corev1.Event_UserServerPreferencesChanged{}, eventsBySeq[5].GetEvent())
-	require.IsType(t, &corev1.Event_UserLoginChanged{}, eventsBySeq[6].GetEvent())
+	require.IsType(t, &corev1.Event_UserLoginCooldownStarted{}, eventsBySeq[6].GetEvent())
 
 	require.Equal(t, "U1", eventsBySeq[0].GetUserAccountCreated().GetUserId())
 	require.Equal(t, "Alice", eventsBySeq[0].GetUserAccountCreated().GetLogin())
@@ -72,8 +72,7 @@ func TestMigrateUsersToES_SeedsUserAggregateAndReplays(t *testing.T) {
 	require.Equal(t, "Alice@Example.com", eventsBySeq[3].GetUserVerifiedEmailAdded().GetEmail())
 	require.True(t, eventsBySeq[3].GetCreatedAt().AsTime().Equal(verifiedAt))
 	require.Equal(t, "subjecthash", eventsBySeq[4].GetUserOidcSubjectLinked().GetSubjectHash())
-	require.Equal(t, "Alice", eventsBySeq[6].GetUserLoginChanged().GetLogin())
-	require.True(t, eventsBySeq[6].GetUserLoginChanged().GetAdvancesCooldown())
+	require.Equal(t, "U1", eventsBySeq[6].GetUserLoginCooldownStarted().GetUserId())
 	require.True(t, eventsBySeq[6].GetCreatedAt().AsTime().Equal(loginChangedAt))
 
 	msg, err := stream.GetLastMsgForSubject(ctx, events.UserAggregate("U1").AllEventsFilter())

--- a/cli/internal/migrations/users_es_test.go
+++ b/cli/internal/migrations/users_es_test.go
@@ -1,0 +1,108 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"hmans.de/chatto/internal/events"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+func TestMigrateUsersToES_EmptyKV(t *testing.T) {
+	ctx, kv, _, publisher := setupTestES(t)
+	require.NoError(t, MigrateUsersToES(ctx, kv, publisher, testLogger()))
+}
+
+func TestMigrateUsersToES_SeedsUserAggregateAndReplays(t *testing.T) {
+	ctx, kv, stream, publisher := setupTestES(t)
+
+	createdAt := time.Date(2026, 5, 26, 10, 0, 0, 0, time.UTC)
+	verifiedAt := createdAt.Add(time.Hour)
+	loginChangedAt := createdAt.Add(2 * time.Hour)
+	user := &corev1.User{
+		Id:          "U1",
+		Login:       "Alice",
+		DisplayName: "Alice A.",
+		CreatedAt:   timestamppb.New(createdAt),
+	}
+	putProtoKV(t, ctx, kv, "user.U1", user)
+	_, err := kv.Put(ctx, "auth.U1.password", []byte("hash"))
+	require.NoError(t, err)
+	putProtoKV(t, ctx, kv, "user.U1.avatar", &corev1.Asset{
+		Asset: &corev1.Asset_S3{S3: &corev1.S3Asset{Key: "avatars/U1"}},
+	})
+	putProtoKV(t, ctx, kv, "verified_emails.U1.emailhash", &corev1.VerifiedEmail{
+		Email:      "Alice@Example.com",
+		VerifiedAt: timestamppb.New(verifiedAt),
+	})
+	tz := "Europe/Berlin"
+	putProtoKV(t, ctx, kv, "user_preferences.U1", &corev1.ServerUserPreferences{
+		Timezone:   proto.String(tz),
+		TimeFormat: corev1.TimeFormat_TIME_FORMAT_24H,
+	})
+	_, err = kv.Put(ctx, "user_login_changed_at.U1", []byte(loginChangedAt.Format(time.RFC3339)))
+	require.NoError(t, err)
+	_, err = kv.Put(ctx, "user_by_oidc.subjecthash", []byte("U1"))
+	require.NoError(t, err)
+
+	require.NoError(t, MigrateUsersToES(ctx, kv, publisher, testLogger()))
+
+	info, err := stream.Info(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, 7, info.State.Msgs)
+
+	eventsBySeq := readUserMigrationEvents(t, ctx, stream, 7)
+	require.IsType(t, &corev1.Event_UserAccountCreated{}, eventsBySeq[0].GetEvent())
+	require.IsType(t, &corev1.Event_UserPasswordHashChanged{}, eventsBySeq[1].GetEvent())
+	require.IsType(t, &corev1.Event_UserAvatarSet{}, eventsBySeq[2].GetEvent())
+	require.IsType(t, &corev1.Event_UserVerifiedEmailAdded{}, eventsBySeq[3].GetEvent())
+	require.IsType(t, &corev1.Event_UserOidcSubjectLinked{}, eventsBySeq[4].GetEvent())
+	require.IsType(t, &corev1.Event_UserServerPreferencesChanged{}, eventsBySeq[5].GetEvent())
+	require.IsType(t, &corev1.Event_UserLoginChanged{}, eventsBySeq[6].GetEvent())
+
+	require.Equal(t, "U1", eventsBySeq[0].GetUserAccountCreated().GetUserId())
+	require.Equal(t, "Alice", eventsBySeq[0].GetUserAccountCreated().GetLogin())
+	require.Equal(t, "Alice A.", eventsBySeq[0].GetUserAccountCreated().GetDisplayName())
+	require.Equal(t, "Alice@Example.com", eventsBySeq[3].GetUserVerifiedEmailAdded().GetEmail())
+	require.True(t, eventsBySeq[3].GetCreatedAt().AsTime().Equal(verifiedAt))
+	require.Equal(t, "subjecthash", eventsBySeq[4].GetUserOidcSubjectLinked().GetSubjectHash())
+	require.Equal(t, "Alice", eventsBySeq[6].GetUserLoginChanged().GetLogin())
+	require.True(t, eventsBySeq[6].GetUserLoginChanged().GetAdvancesCooldown())
+	require.True(t, eventsBySeq[6].GetCreatedAt().AsTime().Equal(loginChangedAt))
+
+	msg, err := stream.GetLastMsgForSubject(ctx, events.UserAggregate("U1").AllEventsFilter())
+	require.NoError(t, err)
+	require.EqualValues(t, 7, msg.Sequence)
+
+	require.NoError(t, MigrateUsersToES(ctx, kv, publisher, testLogger()))
+	infoReplay, err := stream.Info(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, 7, infoReplay.State.Msgs)
+}
+
+func putProtoKV(t *testing.T, ctx context.Context, kv jetstream.KeyValue, key string, msg proto.Message) {
+	t.Helper()
+	data, err := proto.Marshal(msg)
+	require.NoError(t, err)
+	_, err = kv.Put(ctx, key, data)
+	require.NoError(t, err)
+}
+
+func readUserMigrationEvents(t *testing.T, ctx context.Context, stream jetstream.Stream, count int) []*corev1.Event {
+	t.Helper()
+	out := make([]*corev1.Event, 0, count)
+	for seq := uint64(1); seq <= uint64(count); seq++ {
+		msg, err := stream.GetMsg(ctx, seq)
+		require.NoError(t, err)
+		var event corev1.Event
+		require.NoError(t, proto.Unmarshal(msg.Data, &event))
+		out = append(out, &event)
+	}
+	return out
+}

--- a/cli/internal/pb/chatto/core/v1/event.pb.go
+++ b/cli/internal/pb/chatto/core/v1/event.pb.go
@@ -93,6 +93,7 @@ type Event struct {
 	//	*Event_UserServerPreferencesChanged
 	//	*Event_UserLoginCooldownCleared
 	//	*Event_UserAccountDeleted
+	//	*Event_UserLoginCooldownStarted
 	//	*Event_ConfigUpdated
 	//	*Event_UserCreated
 	//	*Event_UserDeleted
@@ -449,6 +450,15 @@ func (x *Event) GetUserAccountDeleted() *UserAccountDeletedEvent {
 	if x != nil {
 		if x, ok := x.Event.(*Event_UserAccountDeleted); ok {
 			return x.UserAccountDeleted
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetUserLoginCooldownStarted() *UserLoginCooldownStartedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_UserLoginCooldownStarted); ok {
+			return x.UserLoginCooldownStarted
 		}
 	}
 	return nil
@@ -857,6 +867,10 @@ type Event_UserAccountDeleted struct {
 	UserAccountDeleted *UserAccountDeletedEvent `protobuf:"bytes,710,opt,name=user_account_deleted,json=userAccountDeleted,proto3,oneof"`
 }
 
+type Event_UserLoginCooldownStarted struct {
+	UserLoginCooldownStarted *UserLoginCooldownStartedEvent `protobuf:"bytes,711,opt,name=user_login_cooldown_started,json=userLoginCooldownStarted,proto3,oneof"`
+}
+
 type Event_ConfigUpdated struct {
 	// ----- Server config (1000-1009) -----
 	ConfigUpdated *ServerConfigUpdatedEvent `protobuf:"bytes,1000,opt,name=config_updated,json=configUpdated,proto3,oneof"`
@@ -1049,6 +1063,8 @@ func (*Event_UserServerPreferencesChanged) isEvent_Event() {}
 func (*Event_UserLoginCooldownCleared) isEvent_Event() {}
 
 func (*Event_UserAccountDeleted) isEvent_Event() {}
+
+func (*Event_UserLoginCooldownStarted) isEvent_Event() {}
 
 func (*Event_ConfigUpdated) isEvent_Event() {}
 
@@ -2489,14 +2505,11 @@ func (x *UserAccountCreatedEvent) GetDisplayName() string {
 }
 
 type UserLoginChangedEvent struct {
-	state  protoimpl.MessageState `protogen:"open.v1"`
-	UserId string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
-	Login  string                 `protobuf:"bytes,2,opt,name=login,proto3" json:"login,omitempty"`
-	// True when this user-initiated login change advances the cooldown.
-	// The cooldown timestamp is the envelope created_at.
-	AdvancesCooldown bool `protobuf:"varint,3,opt,name=advances_cooldown,json=advancesCooldown,proto3" json:"advances_cooldown,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	Login         string                 `protobuf:"bytes,2,opt,name=login,proto3" json:"login,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *UserLoginChangedEvent) Reset() {
@@ -2541,13 +2554,6 @@ func (x *UserLoginChangedEvent) GetLogin() string {
 		return x.Login
 	}
 	return ""
-}
-
-func (x *UserLoginChangedEvent) GetAdvancesCooldown() bool {
-	if x != nil {
-		return x.AdvancesCooldown
-	}
-	return false
 }
 
 type UserDisplayNameChangedEvent struct {
@@ -2924,6 +2930,50 @@ func (x *UserServerPreferencesChangedEvent) GetPreferences() *ServerUserPreferen
 	return nil
 }
 
+type UserLoginCooldownStartedEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UserLoginCooldownStartedEvent) Reset() {
+	*x = UserLoginCooldownStartedEvent{}
+	mi := &file_chatto_core_v1_event_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserLoginCooldownStartedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserLoginCooldownStartedEvent) ProtoMessage() {}
+
+func (x *UserLoginCooldownStartedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_event_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UserLoginCooldownStartedEvent.ProtoReflect.Descriptor instead.
+func (*UserLoginCooldownStartedEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *UserLoginCooldownStartedEvent) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
 type UserLoginCooldownClearedEvent struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
@@ -2933,7 +2983,7 @@ type UserLoginCooldownClearedEvent struct {
 
 func (x *UserLoginCooldownClearedEvent) Reset() {
 	*x = UserLoginCooldownClearedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[33]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2945,7 +2995,7 @@ func (x *UserLoginCooldownClearedEvent) String() string {
 func (*UserLoginCooldownClearedEvent) ProtoMessage() {}
 
 func (x *UserLoginCooldownClearedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[33]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2958,7 +3008,7 @@ func (x *UserLoginCooldownClearedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserLoginCooldownClearedEvent.ProtoReflect.Descriptor instead.
 func (*UserLoginCooldownClearedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{33}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *UserLoginCooldownClearedEvent) GetUserId() string {
@@ -2977,7 +3027,7 @@ type UserAccountDeletedEvent struct {
 
 func (x *UserAccountDeletedEvent) Reset() {
 	*x = UserAccountDeletedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[34]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2989,7 +3039,7 @@ func (x *UserAccountDeletedEvent) String() string {
 func (*UserAccountDeletedEvent) ProtoMessage() {}
 
 func (x *UserAccountDeletedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[34]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3002,7 +3052,7 @@ func (x *UserAccountDeletedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserAccountDeletedEvent.ProtoReflect.Descriptor instead.
 func (*UserAccountDeletedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{34}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *UserAccountDeletedEvent) GetUserId() string {
@@ -3029,7 +3079,7 @@ type NotificationLevelChangedEvent struct {
 
 func (x *NotificationLevelChangedEvent) Reset() {
 	*x = NotificationLevelChangedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[35]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3041,7 +3091,7 @@ func (x *NotificationLevelChangedEvent) String() string {
 func (*NotificationLevelChangedEvent) ProtoMessage() {}
 
 func (x *NotificationLevelChangedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[35]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3054,7 +3104,7 @@ func (x *NotificationLevelChangedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NotificationLevelChangedEvent.ProtoReflect.Descriptor instead.
 func (*NotificationLevelChangedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{35}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *NotificationLevelChangedEvent) GetRoomId() string {
@@ -3089,7 +3139,7 @@ type ServerCreatedEvent struct {
 
 func (x *ServerCreatedEvent) Reset() {
 	*x = ServerCreatedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[36]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3101,7 +3151,7 @@ func (x *ServerCreatedEvent) String() string {
 func (*ServerCreatedEvent) ProtoMessage() {}
 
 func (x *ServerCreatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[36]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3114,7 +3164,7 @@ func (x *ServerCreatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerCreatedEvent.ProtoReflect.Descriptor instead.
 func (*ServerCreatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{36}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *ServerCreatedEvent) GetServerId() string {
@@ -3153,7 +3203,7 @@ type ServerUpdatedEvent struct {
 
 func (x *ServerUpdatedEvent) Reset() {
 	*x = ServerUpdatedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[37]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3165,7 +3215,7 @@ func (x *ServerUpdatedEvent) String() string {
 func (*ServerUpdatedEvent) ProtoMessage() {}
 
 func (x *ServerUpdatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[37]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3178,7 +3228,7 @@ func (x *ServerUpdatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerUpdatedEvent.ProtoReflect.Descriptor instead.
 func (*ServerUpdatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{37}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *ServerUpdatedEvent) GetServerId() string {
@@ -3225,7 +3275,7 @@ type ServerDeletedEvent struct {
 
 func (x *ServerDeletedEvent) Reset() {
 	*x = ServerDeletedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[38]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3237,7 +3287,7 @@ func (x *ServerDeletedEvent) String() string {
 func (*ServerDeletedEvent) ProtoMessage() {}
 
 func (x *ServerDeletedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[38]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3250,7 +3300,7 @@ func (x *ServerDeletedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerDeletedEvent.ProtoReflect.Descriptor instead.
 func (*ServerDeletedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{38}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *ServerDeletedEvent) GetServerId() string {
@@ -3280,7 +3330,7 @@ type MessageEditedEvent struct {
 
 func (x *MessageEditedEvent) Reset() {
 	*x = MessageEditedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[39]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3292,7 +3342,7 @@ func (x *MessageEditedEvent) String() string {
 func (*MessageEditedEvent) ProtoMessage() {}
 
 func (x *MessageEditedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[39]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3305,7 +3355,7 @@ func (x *MessageEditedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageEditedEvent.ProtoReflect.Descriptor instead.
 func (*MessageEditedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{39}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *MessageEditedEvent) GetRoomId() string {
@@ -3350,7 +3400,7 @@ type MessageRetractedEvent struct {
 
 func (x *MessageRetractedEvent) Reset() {
 	*x = MessageRetractedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[40]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3362,7 +3412,7 @@ func (x *MessageRetractedEvent) String() string {
 func (*MessageRetractedEvent) ProtoMessage() {}
 
 func (x *MessageRetractedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[40]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3375,7 +3425,7 @@ func (x *MessageRetractedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageRetractedEvent.ProtoReflect.Descriptor instead.
 func (*MessageRetractedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{40}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *MessageRetractedEvent) GetRoomId() string {
@@ -3422,7 +3472,7 @@ type MessageUpdatedEvent struct {
 
 func (x *MessageUpdatedEvent) Reset() {
 	*x = MessageUpdatedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[41]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3434,7 +3484,7 @@ func (x *MessageUpdatedEvent) String() string {
 func (*MessageUpdatedEvent) ProtoMessage() {}
 
 func (x *MessageUpdatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[41]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3447,7 +3497,7 @@ func (x *MessageUpdatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageUpdatedEvent.ProtoReflect.Descriptor instead.
 func (*MessageUpdatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{41}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *MessageUpdatedEvent) GetRoomId() string {
@@ -3508,7 +3558,7 @@ type MessageDeletedEvent struct {
 
 func (x *MessageDeletedEvent) Reset() {
 	*x = MessageDeletedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[42]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3520,7 +3570,7 @@ func (x *MessageDeletedEvent) String() string {
 func (*MessageDeletedEvent) ProtoMessage() {}
 
 func (x *MessageDeletedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[42]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3533,7 +3583,7 @@ func (x *MessageDeletedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageDeletedEvent.ProtoReflect.Descriptor instead.
 func (*MessageDeletedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{42}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *MessageDeletedEvent) GetRoomId() string {
@@ -3571,7 +3621,7 @@ type ReactionAddedEvent struct {
 
 func (x *ReactionAddedEvent) Reset() {
 	*x = ReactionAddedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[43]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3583,7 +3633,7 @@ func (x *ReactionAddedEvent) String() string {
 func (*ReactionAddedEvent) ProtoMessage() {}
 
 func (x *ReactionAddedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[43]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3596,7 +3646,7 @@ func (x *ReactionAddedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReactionAddedEvent.ProtoReflect.Descriptor instead.
 func (*ReactionAddedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{43}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *ReactionAddedEvent) GetRoomId() string {
@@ -3634,7 +3684,7 @@ type ReactionRemovedEvent struct {
 
 func (x *ReactionRemovedEvent) Reset() {
 	*x = ReactionRemovedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[44]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3646,7 +3696,7 @@ func (x *ReactionRemovedEvent) String() string {
 func (*ReactionRemovedEvent) ProtoMessage() {}
 
 func (x *ReactionRemovedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[44]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3659,7 +3709,7 @@ func (x *ReactionRemovedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReactionRemovedEvent.ProtoReflect.Descriptor instead.
 func (*ReactionRemovedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{44}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *ReactionRemovedEvent) GetRoomId() string {
@@ -3699,7 +3749,7 @@ type UserTypingEvent struct {
 
 func (x *UserTypingEvent) Reset() {
 	*x = UserTypingEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[45]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3711,7 +3761,7 @@ func (x *UserTypingEvent) String() string {
 func (*UserTypingEvent) ProtoMessage() {}
 
 func (x *UserTypingEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[45]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3724,7 +3774,7 @@ func (x *UserTypingEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserTypingEvent.ProtoReflect.Descriptor instead.
 func (*UserTypingEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{45}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *UserTypingEvent) GetRoomId() string {
@@ -3755,7 +3805,7 @@ type PresenceChangedEvent struct {
 
 func (x *PresenceChangedEvent) Reset() {
 	*x = PresenceChangedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[46]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3767,7 +3817,7 @@ func (x *PresenceChangedEvent) String() string {
 func (*PresenceChangedEvent) ProtoMessage() {}
 
 func (x *PresenceChangedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[46]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3780,7 +3830,7 @@ func (x *PresenceChangedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PresenceChangedEvent.ProtoReflect.Descriptor instead.
 func (*PresenceChangedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{46}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *PresenceChangedEvent) GetStatus() string {
@@ -3805,7 +3855,7 @@ type MentionNotificationEvent struct {
 
 func (x *MentionNotificationEvent) Reset() {
 	*x = MentionNotificationEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[47]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3817,7 +3867,7 @@ func (x *MentionNotificationEvent) String() string {
 func (*MentionNotificationEvent) ProtoMessage() {}
 
 func (x *MentionNotificationEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[47]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3830,7 +3880,7 @@ func (x *MentionNotificationEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MentionNotificationEvent.ProtoReflect.Descriptor instead.
 func (*MentionNotificationEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{47}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *MentionNotificationEvent) GetRoomId() string {
@@ -3862,7 +3912,7 @@ type NewDirectMessageNotificationEvent struct {
 
 func (x *NewDirectMessageNotificationEvent) Reset() {
 	*x = NewDirectMessageNotificationEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[48]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3874,7 +3924,7 @@ func (x *NewDirectMessageNotificationEvent) String() string {
 func (*NewDirectMessageNotificationEvent) ProtoMessage() {}
 
 func (x *NewDirectMessageNotificationEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[48]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3887,7 +3937,7 @@ func (x *NewDirectMessageNotificationEvent) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use NewDirectMessageNotificationEvent.ProtoReflect.Descriptor instead.
 func (*NewDirectMessageNotificationEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{48}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *NewDirectMessageNotificationEvent) GetRoomId() string {
@@ -3920,7 +3970,7 @@ type NotificationCreatedEvent struct {
 
 func (x *NotificationCreatedEvent) Reset() {
 	*x = NotificationCreatedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[49]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3932,7 +3982,7 @@ func (x *NotificationCreatedEvent) String() string {
 func (*NotificationCreatedEvent) ProtoMessage() {}
 
 func (x *NotificationCreatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[49]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3945,7 +3995,7 @@ func (x *NotificationCreatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NotificationCreatedEvent.ProtoReflect.Descriptor instead.
 func (*NotificationCreatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{49}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *NotificationCreatedEvent) GetNotificationId() string {
@@ -3988,7 +4038,7 @@ type NotificationDismissedEvent struct {
 
 func (x *NotificationDismissedEvent) Reset() {
 	*x = NotificationDismissedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[50]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4000,7 +4050,7 @@ func (x *NotificationDismissedEvent) String() string {
 func (*NotificationDismissedEvent) ProtoMessage() {}
 
 func (x *NotificationDismissedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[50]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4013,7 +4063,7 @@ func (x *NotificationDismissedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NotificationDismissedEvent.ProtoReflect.Descriptor instead.
 func (*NotificationDismissedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{50}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *NotificationDismissedEvent) GetNotificationId() string {
@@ -4040,7 +4090,7 @@ type ThreadFollowChangedEvent struct {
 
 func (x *ThreadFollowChangedEvent) Reset() {
 	*x = ThreadFollowChangedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[51]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4052,7 +4102,7 @@ func (x *ThreadFollowChangedEvent) String() string {
 func (*ThreadFollowChangedEvent) ProtoMessage() {}
 
 func (x *ThreadFollowChangedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[51]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4065,7 +4115,7 @@ func (x *ThreadFollowChangedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ThreadFollowChangedEvent.ProtoReflect.Descriptor instead.
 func (*ThreadFollowChangedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{51}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *ThreadFollowChangedEvent) GetRoomId() string {
@@ -4101,7 +4151,7 @@ type RoomMarkedAsReadEvent struct {
 
 func (x *RoomMarkedAsReadEvent) Reset() {
 	*x = RoomMarkedAsReadEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[52]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4113,7 +4163,7 @@ func (x *RoomMarkedAsReadEvent) String() string {
 func (*RoomMarkedAsReadEvent) ProtoMessage() {}
 
 func (x *RoomMarkedAsReadEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[52]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4126,7 +4176,7 @@ func (x *RoomMarkedAsReadEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomMarkedAsReadEvent.ProtoReflect.Descriptor instead.
 func (*RoomMarkedAsReadEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{52}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *RoomMarkedAsReadEvent) GetRoomId() string {
@@ -4151,7 +4201,7 @@ type MentionStatusClearedEvent struct {
 
 func (x *MentionStatusClearedEvent) Reset() {
 	*x = MentionStatusClearedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[53]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4163,7 +4213,7 @@ func (x *MentionStatusClearedEvent) String() string {
 func (*MentionStatusClearedEvent) ProtoMessage() {}
 
 func (x *MentionStatusClearedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[53]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4176,7 +4226,7 @@ func (x *MentionStatusClearedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MentionStatusClearedEvent.ProtoReflect.Descriptor instead.
 func (*MentionStatusClearedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{53}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *MentionStatusClearedEvent) GetRoomId() string {
@@ -4197,7 +4247,7 @@ type RoomGroupsUpdatedEvent struct {
 
 func (x *RoomGroupsUpdatedEvent) Reset() {
 	*x = RoomGroupsUpdatedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[54]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4209,7 +4259,7 @@ func (x *RoomGroupsUpdatedEvent) String() string {
 func (*RoomGroupsUpdatedEvent) ProtoMessage() {}
 
 func (x *RoomGroupsUpdatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[54]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4222,7 +4272,7 @@ func (x *RoomGroupsUpdatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomGroupsUpdatedEvent.ProtoReflect.Descriptor instead.
 func (*RoomGroupsUpdatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{54}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{55}
 }
 
 // Notifies a user that their session has been terminated.
@@ -4239,7 +4289,7 @@ type SessionTerminatedEvent struct {
 
 func (x *SessionTerminatedEvent) Reset() {
 	*x = SessionTerminatedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[55]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4251,7 +4301,7 @@ func (x *SessionTerminatedEvent) String() string {
 func (*SessionTerminatedEvent) ProtoMessage() {}
 
 func (x *SessionTerminatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[55]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4264,7 +4314,7 @@ func (x *SessionTerminatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionTerminatedEvent.ProtoReflect.Descriptor instead.
 func (*SessionTerminatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{55}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *SessionTerminatedEvent) GetReason() string {
@@ -4293,7 +4343,7 @@ type VideoProcessingCompletedEvent struct {
 
 func (x *VideoProcessingCompletedEvent) Reset() {
 	*x = VideoProcessingCompletedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[56]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4305,7 +4355,7 @@ func (x *VideoProcessingCompletedEvent) String() string {
 func (*VideoProcessingCompletedEvent) ProtoMessage() {}
 
 func (x *VideoProcessingCompletedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[56]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4318,7 +4368,7 @@ func (x *VideoProcessingCompletedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VideoProcessingCompletedEvent.ProtoReflect.Descriptor instead.
 func (*VideoProcessingCompletedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{56}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *VideoProcessingCompletedEvent) GetRoomId() string {
@@ -4360,7 +4410,7 @@ type CallParticipantJoinedEvent struct {
 
 func (x *CallParticipantJoinedEvent) Reset() {
 	*x = CallParticipantJoinedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[57]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4372,7 +4422,7 @@ func (x *CallParticipantJoinedEvent) String() string {
 func (*CallParticipantJoinedEvent) ProtoMessage() {}
 
 func (x *CallParticipantJoinedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[57]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4385,7 +4435,7 @@ func (x *CallParticipantJoinedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CallParticipantJoinedEvent.ProtoReflect.Descriptor instead.
 func (*CallParticipantJoinedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{57}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *CallParticipantJoinedEvent) GetRoomId() string {
@@ -4406,7 +4456,7 @@ type CallParticipantLeftEvent struct {
 
 func (x *CallParticipantLeftEvent) Reset() {
 	*x = CallParticipantLeftEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[58]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4418,7 +4468,7 @@ func (x *CallParticipantLeftEvent) String() string {
 func (*CallParticipantLeftEvent) ProtoMessage() {}
 
 func (x *CallParticipantLeftEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[58]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4431,7 +4481,7 @@ func (x *CallParticipantLeftEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CallParticipantLeftEvent.ProtoReflect.Descriptor instead.
 func (*CallParticipantLeftEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{58}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *CallParticipantLeftEvent) GetRoomId() string {
@@ -4445,7 +4495,7 @@ var File_chatto_core_v1_event_proto protoreflect.FileDescriptor
 
 const file_chatto_core_v1_event_proto_rawDesc = "" +
 	"\n" +
-	"\x1achatto/core/v1/event.proto\x12\x0echatto.core.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1dchatto/config/v1/config.proto\x1a\x1bchatto/core/v1/models.proto\x1a%chatto/core/v1/user_preferences.proto\"\x8e*\n" +
+	"\x1achatto/core/v1/event.proto\x12\x0echatto.core.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1dchatto/config/v1/config.proto\x1a\x1bchatto/core/v1/models.proto\x1a%chatto/core/v1/user_preferences.proto\"\xff*\n" +
 	"\x05Event\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x129\n" +
 	"\n" +
@@ -4480,7 +4530,8 @@ const file_chatto_core_v1_event_proto_rawDesc = "" +
 	"\x18user_oidc_subject_linked\x18\xc3\x05 \x01(\v2*.chatto.core.v1.UserOIDCSubjectLinkedEventH\x00R\x15userOidcSubjectLinked\x12{\n" +
 	"\x1fuser_server_preferences_changed\x18\xc4\x05 \x01(\v21.chatto.core.v1.UserServerPreferencesChangedEventH\x00R\x1cuserServerPreferencesChanged\x12o\n" +
 	"\x1buser_login_cooldown_cleared\x18\xc5\x05 \x01(\v2-.chatto.core.v1.UserLoginCooldownClearedEventH\x00R\x18userLoginCooldownCleared\x12\\\n" +
-	"\x14user_account_deleted\x18\xc6\x05 \x01(\v2'.chatto.core.v1.UserAccountDeletedEventH\x00R\x12userAccountDeleted\x12R\n" +
+	"\x14user_account_deleted\x18\xc6\x05 \x01(\v2'.chatto.core.v1.UserAccountDeletedEventH\x00R\x12userAccountDeleted\x12o\n" +
+	"\x1buser_login_cooldown_started\x18\xc7\x05 \x01(\v2-.chatto.core.v1.UserLoginCooldownStartedEventH\x00R\x18userLoginCooldownStarted\x12R\n" +
 	"\x0econfig_updated\x18\xe8\a \x01(\v2(.chatto.core.v1.ServerConfigUpdatedEventH\x00R\rconfigUpdated\x12F\n" +
 	"\fuser_created\x18\xf2\a \x01(\v2 .chatto.core.v1.UserCreatedEventH\x00R\vuserCreated\x12F\n" +
 	"\fuser_deleted\x18\xf3\a \x01(\v2 .chatto.core.v1.UserDeletedEventH\x00R\vuserDeleted\x12\\\n" +
@@ -4591,11 +4642,10 @@ const file_chatto_core_v1_event_proto_rawDesc = "" +
 	"\x17UserAccountCreatedEvent\x12\x17\n" +
 	"\auser_id\x18\x01 \x01(\tR\x06userId\x12\x14\n" +
 	"\x05login\x18\x02 \x01(\tR\x05login\x12!\n" +
-	"\fdisplay_name\x18\x03 \x01(\tR\vdisplayName\"s\n" +
+	"\fdisplay_name\x18\x03 \x01(\tR\vdisplayName\"F\n" +
 	"\x15UserLoginChangedEvent\x12\x17\n" +
 	"\auser_id\x18\x01 \x01(\tR\x06userId\x12\x14\n" +
-	"\x05login\x18\x02 \x01(\tR\x05login\x12+\n" +
-	"\x11advances_cooldown\x18\x03 \x01(\bR\x10advancesCooldown\"Y\n" +
+	"\x05login\x18\x02 \x01(\tR\x05login\"Y\n" +
 	"\x1bUserDisplayNameChangedEvent\x12\x17\n" +
 	"\auser_id\x18\x01 \x01(\tR\x06userId\x12!\n" +
 	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\"\\\n" +
@@ -4618,6 +4668,8 @@ const file_chatto_core_v1_event_proto_rawDesc = "" +
 	"!UserServerPreferencesChangedEvent\x12\x17\n" +
 	"\auser_id\x18\x01 \x01(\tR\x06userId\x12G\n" +
 	"\vpreferences\x18\x02 \x01(\v2%.chatto.core.v1.ServerUserPreferencesR\vpreferences\"8\n" +
+	"\x1dUserLoginCooldownStartedEvent\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\"8\n" +
 	"\x1dUserLoginCooldownClearedEvent\x12\x17\n" +
 	"\auser_id\x18\x01 \x01(\tR\x06userId\"2\n" +
 	"\x17UserAccountDeletedEvent\x12\x17\n" +
@@ -4720,7 +4772,7 @@ func file_chatto_core_v1_event_proto_rawDescGZIP() []byte {
 	return file_chatto_core_v1_event_proto_rawDescData
 }
 
-var file_chatto_core_v1_event_proto_msgTypes = make([]protoimpl.MessageInfo, 59)
+var file_chatto_core_v1_event_proto_msgTypes = make([]protoimpl.MessageInfo, 60)
 var file_chatto_core_v1_event_proto_goTypes = []any{
 	(*Event)(nil),                             // 0: chatto.core.v1.Event
 	(*HeartbeatEvent)(nil),                    // 1: chatto.core.v1.HeartbeatEvent
@@ -4755,43 +4807,44 @@ var file_chatto_core_v1_event_proto_goTypes = []any{
 	(*UserPasswordHashChangedEvent)(nil),      // 30: chatto.core.v1.UserPasswordHashChangedEvent
 	(*UserOIDCSubjectLinkedEvent)(nil),        // 31: chatto.core.v1.UserOIDCSubjectLinkedEvent
 	(*UserServerPreferencesChangedEvent)(nil), // 32: chatto.core.v1.UserServerPreferencesChangedEvent
-	(*UserLoginCooldownClearedEvent)(nil),     // 33: chatto.core.v1.UserLoginCooldownClearedEvent
-	(*UserAccountDeletedEvent)(nil),           // 34: chatto.core.v1.UserAccountDeletedEvent
-	(*NotificationLevelChangedEvent)(nil),     // 35: chatto.core.v1.NotificationLevelChangedEvent
-	(*ServerCreatedEvent)(nil),                // 36: chatto.core.v1.ServerCreatedEvent
-	(*ServerUpdatedEvent)(nil),                // 37: chatto.core.v1.ServerUpdatedEvent
-	(*ServerDeletedEvent)(nil),                // 38: chatto.core.v1.ServerDeletedEvent
-	(*MessageEditedEvent)(nil),                // 39: chatto.core.v1.MessageEditedEvent
-	(*MessageRetractedEvent)(nil),             // 40: chatto.core.v1.MessageRetractedEvent
-	(*MessageUpdatedEvent)(nil),               // 41: chatto.core.v1.MessageUpdatedEvent
-	(*MessageDeletedEvent)(nil),               // 42: chatto.core.v1.MessageDeletedEvent
-	(*ReactionAddedEvent)(nil),                // 43: chatto.core.v1.ReactionAddedEvent
-	(*ReactionRemovedEvent)(nil),              // 44: chatto.core.v1.ReactionRemovedEvent
-	(*UserTypingEvent)(nil),                   // 45: chatto.core.v1.UserTypingEvent
-	(*PresenceChangedEvent)(nil),              // 46: chatto.core.v1.PresenceChangedEvent
-	(*MentionNotificationEvent)(nil),          // 47: chatto.core.v1.MentionNotificationEvent
-	(*NewDirectMessageNotificationEvent)(nil), // 48: chatto.core.v1.NewDirectMessageNotificationEvent
-	(*NotificationCreatedEvent)(nil),          // 49: chatto.core.v1.NotificationCreatedEvent
-	(*NotificationDismissedEvent)(nil),        // 50: chatto.core.v1.NotificationDismissedEvent
-	(*ThreadFollowChangedEvent)(nil),          // 51: chatto.core.v1.ThreadFollowChangedEvent
-	(*RoomMarkedAsReadEvent)(nil),             // 52: chatto.core.v1.RoomMarkedAsReadEvent
-	(*MentionStatusClearedEvent)(nil),         // 53: chatto.core.v1.MentionStatusClearedEvent
-	(*RoomGroupsUpdatedEvent)(nil),            // 54: chatto.core.v1.RoomGroupsUpdatedEvent
-	(*SessionTerminatedEvent)(nil),            // 55: chatto.core.v1.SessionTerminatedEvent
-	(*VideoProcessingCompletedEvent)(nil),     // 56: chatto.core.v1.VideoProcessingCompletedEvent
-	(*CallParticipantJoinedEvent)(nil),        // 57: chatto.core.v1.CallParticipantJoinedEvent
-	(*CallParticipantLeftEvent)(nil),          // 58: chatto.core.v1.CallParticipantLeftEvent
-	(*timestamppb.Timestamp)(nil),             // 59: google.protobuf.Timestamp
-	(RoomKind)(0),                             // 60: chatto.core.v1.RoomKind
-	(*MessageBody)(nil),                       // 61: chatto.core.v1.MessageBody
-	(*v1.ServerConfig)(nil),                   // 62: chatto.config.v1.ServerConfig
-	(TimeFormat)(0),                           // 63: chatto.core.v1.TimeFormat
-	(*Asset)(nil),                             // 64: chatto.core.v1.Asset
-	(*ServerUserPreferences)(nil),             // 65: chatto.core.v1.ServerUserPreferences
-	(NotificationLevel)(0),                    // 66: chatto.core.v1.NotificationLevel
+	(*UserLoginCooldownStartedEvent)(nil),     // 33: chatto.core.v1.UserLoginCooldownStartedEvent
+	(*UserLoginCooldownClearedEvent)(nil),     // 34: chatto.core.v1.UserLoginCooldownClearedEvent
+	(*UserAccountDeletedEvent)(nil),           // 35: chatto.core.v1.UserAccountDeletedEvent
+	(*NotificationLevelChangedEvent)(nil),     // 36: chatto.core.v1.NotificationLevelChangedEvent
+	(*ServerCreatedEvent)(nil),                // 37: chatto.core.v1.ServerCreatedEvent
+	(*ServerUpdatedEvent)(nil),                // 38: chatto.core.v1.ServerUpdatedEvent
+	(*ServerDeletedEvent)(nil),                // 39: chatto.core.v1.ServerDeletedEvent
+	(*MessageEditedEvent)(nil),                // 40: chatto.core.v1.MessageEditedEvent
+	(*MessageRetractedEvent)(nil),             // 41: chatto.core.v1.MessageRetractedEvent
+	(*MessageUpdatedEvent)(nil),               // 42: chatto.core.v1.MessageUpdatedEvent
+	(*MessageDeletedEvent)(nil),               // 43: chatto.core.v1.MessageDeletedEvent
+	(*ReactionAddedEvent)(nil),                // 44: chatto.core.v1.ReactionAddedEvent
+	(*ReactionRemovedEvent)(nil),              // 45: chatto.core.v1.ReactionRemovedEvent
+	(*UserTypingEvent)(nil),                   // 46: chatto.core.v1.UserTypingEvent
+	(*PresenceChangedEvent)(nil),              // 47: chatto.core.v1.PresenceChangedEvent
+	(*MentionNotificationEvent)(nil),          // 48: chatto.core.v1.MentionNotificationEvent
+	(*NewDirectMessageNotificationEvent)(nil), // 49: chatto.core.v1.NewDirectMessageNotificationEvent
+	(*NotificationCreatedEvent)(nil),          // 50: chatto.core.v1.NotificationCreatedEvent
+	(*NotificationDismissedEvent)(nil),        // 51: chatto.core.v1.NotificationDismissedEvent
+	(*ThreadFollowChangedEvent)(nil),          // 52: chatto.core.v1.ThreadFollowChangedEvent
+	(*RoomMarkedAsReadEvent)(nil),             // 53: chatto.core.v1.RoomMarkedAsReadEvent
+	(*MentionStatusClearedEvent)(nil),         // 54: chatto.core.v1.MentionStatusClearedEvent
+	(*RoomGroupsUpdatedEvent)(nil),            // 55: chatto.core.v1.RoomGroupsUpdatedEvent
+	(*SessionTerminatedEvent)(nil),            // 56: chatto.core.v1.SessionTerminatedEvent
+	(*VideoProcessingCompletedEvent)(nil),     // 57: chatto.core.v1.VideoProcessingCompletedEvent
+	(*CallParticipantJoinedEvent)(nil),        // 58: chatto.core.v1.CallParticipantJoinedEvent
+	(*CallParticipantLeftEvent)(nil),          // 59: chatto.core.v1.CallParticipantLeftEvent
+	(*timestamppb.Timestamp)(nil),             // 60: google.protobuf.Timestamp
+	(RoomKind)(0),                             // 61: chatto.core.v1.RoomKind
+	(*MessageBody)(nil),                       // 62: chatto.core.v1.MessageBody
+	(*v1.ServerConfig)(nil),                   // 63: chatto.config.v1.ServerConfig
+	(TimeFormat)(0),                           // 64: chatto.core.v1.TimeFormat
+	(*Asset)(nil),                             // 65: chatto.core.v1.Asset
+	(*ServerUserPreferences)(nil),             // 66: chatto.core.v1.ServerUserPreferences
+	(NotificationLevel)(0),                    // 67: chatto.core.v1.NotificationLevel
 }
 var file_chatto_core_v1_event_proto_depIdxs = []int32{
-	59, // 0: chatto.core.v1.Event.created_at:type_name -> google.protobuf.Timestamp
+	60, // 0: chatto.core.v1.Event.created_at:type_name -> google.protobuf.Timestamp
 	2,  // 1: chatto.core.v1.Event.room_created:type_name -> chatto.core.v1.RoomCreatedEvent
 	3,  // 2: chatto.core.v1.Event.room_updated:type_name -> chatto.core.v1.RoomUpdatedEvent
 	4,  // 3: chatto.core.v1.Event.room_deleted:type_name -> chatto.core.v1.RoomDeletedEvent
@@ -4801,8 +4854,8 @@ var file_chatto_core_v1_event_proto_depIdxs = []int32{
 	8,  // 7: chatto.core.v1.Event.user_left_room:type_name -> chatto.core.v1.UserLeftRoomEvent
 	9,  // 8: chatto.core.v1.Event.space_member_deleted:type_name -> chatto.core.v1.SpaceMemberDeletedEvent
 	10, // 9: chatto.core.v1.Event.message_posted:type_name -> chatto.core.v1.MessagePostedEvent
-	39, // 10: chatto.core.v1.Event.message_edited:type_name -> chatto.core.v1.MessageEditedEvent
-	40, // 11: chatto.core.v1.Event.message_retracted:type_name -> chatto.core.v1.MessageRetractedEvent
+	40, // 10: chatto.core.v1.Event.message_edited:type_name -> chatto.core.v1.MessageEditedEvent
+	41, // 11: chatto.core.v1.Event.message_retracted:type_name -> chatto.core.v1.MessageRetractedEvent
 	11, // 12: chatto.core.v1.Event.server_config_changed:type_name -> chatto.core.v1.ServerConfigChangedEvent
 	12, // 13: chatto.core.v1.Event.room_group_created:type_name -> chatto.core.v1.RoomGroupCreatedEvent
 	13, // 14: chatto.core.v1.Event.room_group_updated:type_name -> chatto.core.v1.RoomGroupUpdatedEvent
@@ -4820,50 +4873,51 @@ var file_chatto_core_v1_event_proto_depIdxs = []int32{
 	30, // 26: chatto.core.v1.Event.user_password_hash_changed:type_name -> chatto.core.v1.UserPasswordHashChangedEvent
 	31, // 27: chatto.core.v1.Event.user_oidc_subject_linked:type_name -> chatto.core.v1.UserOIDCSubjectLinkedEvent
 	32, // 28: chatto.core.v1.Event.user_server_preferences_changed:type_name -> chatto.core.v1.UserServerPreferencesChangedEvent
-	33, // 29: chatto.core.v1.Event.user_login_cooldown_cleared:type_name -> chatto.core.v1.UserLoginCooldownClearedEvent
-	34, // 30: chatto.core.v1.Event.user_account_deleted:type_name -> chatto.core.v1.UserAccountDeletedEvent
-	19, // 31: chatto.core.v1.Event.config_updated:type_name -> chatto.core.v1.ServerConfigUpdatedEvent
-	20, // 32: chatto.core.v1.Event.user_created:type_name -> chatto.core.v1.UserCreatedEvent
-	21, // 33: chatto.core.v1.Event.user_deleted:type_name -> chatto.core.v1.UserDeletedEvent
-	22, // 34: chatto.core.v1.Event.user_profile_updated:type_name -> chatto.core.v1.UserProfileUpdatedEvent
-	23, // 35: chatto.core.v1.Event.server_user_preferences_updated:type_name -> chatto.core.v1.ServerUserPreferencesUpdatedEvent
-	35, // 36: chatto.core.v1.Event.notification_level_changed:type_name -> chatto.core.v1.NotificationLevelChangedEvent
-	51, // 37: chatto.core.v1.Event.thread_follow_changed:type_name -> chatto.core.v1.ThreadFollowChangedEvent
-	36, // 38: chatto.core.v1.Event.server_created:type_name -> chatto.core.v1.ServerCreatedEvent
-	37, // 39: chatto.core.v1.Event.server_updated:type_name -> chatto.core.v1.ServerUpdatedEvent
-	38, // 40: chatto.core.v1.Event.server_deleted:type_name -> chatto.core.v1.ServerDeletedEvent
-	41, // 41: chatto.core.v1.Event.message_updated:type_name -> chatto.core.v1.MessageUpdatedEvent
-	42, // 42: chatto.core.v1.Event.message_deleted:type_name -> chatto.core.v1.MessageDeletedEvent
-	43, // 43: chatto.core.v1.Event.reaction_added:type_name -> chatto.core.v1.ReactionAddedEvent
-	44, // 44: chatto.core.v1.Event.reaction_removed:type_name -> chatto.core.v1.ReactionRemovedEvent
-	45, // 45: chatto.core.v1.Event.user_typing:type_name -> chatto.core.v1.UserTypingEvent
-	56, // 46: chatto.core.v1.Event.video_processing_completed:type_name -> chatto.core.v1.VideoProcessingCompletedEvent
-	46, // 47: chatto.core.v1.Event.presence_changed:type_name -> chatto.core.v1.PresenceChangedEvent
-	47, // 48: chatto.core.v1.Event.mention_notification:type_name -> chatto.core.v1.MentionNotificationEvent
-	48, // 49: chatto.core.v1.Event.new_direct_message_notification:type_name -> chatto.core.v1.NewDirectMessageNotificationEvent
-	57, // 50: chatto.core.v1.Event.call_participant_joined:type_name -> chatto.core.v1.CallParticipantJoinedEvent
-	58, // 51: chatto.core.v1.Event.call_participant_left:type_name -> chatto.core.v1.CallParticipantLeftEvent
-	49, // 52: chatto.core.v1.Event.notification_created:type_name -> chatto.core.v1.NotificationCreatedEvent
-	50, // 53: chatto.core.v1.Event.notification_dismissed:type_name -> chatto.core.v1.NotificationDismissedEvent
-	52, // 54: chatto.core.v1.Event.room_marked_as_read:type_name -> chatto.core.v1.RoomMarkedAsReadEvent
-	53, // 55: chatto.core.v1.Event.mention_status_cleared:type_name -> chatto.core.v1.MentionStatusClearedEvent
-	54, // 56: chatto.core.v1.Event.room_groups_updated:type_name -> chatto.core.v1.RoomGroupsUpdatedEvent
-	55, // 57: chatto.core.v1.Event.session_terminated:type_name -> chatto.core.v1.SessionTerminatedEvent
-	1,  // 58: chatto.core.v1.Event.heartbeat:type_name -> chatto.core.v1.HeartbeatEvent
-	60, // 59: chatto.core.v1.RoomCreatedEvent.kind:type_name -> chatto.core.v1.RoomKind
-	61, // 60: chatto.core.v1.MessagePostedEvent.body:type_name -> chatto.core.v1.MessageBody
-	62, // 61: chatto.core.v1.ServerConfigChangedEvent.config:type_name -> chatto.config.v1.ServerConfig
-	63, // 62: chatto.core.v1.ServerUserPreferencesUpdatedEvent.time_format:type_name -> chatto.core.v1.TimeFormat
-	64, // 63: chatto.core.v1.UserAvatarSetEvent.avatar:type_name -> chatto.core.v1.Asset
-	65, // 64: chatto.core.v1.UserServerPreferencesChangedEvent.preferences:type_name -> chatto.core.v1.ServerUserPreferences
-	66, // 65: chatto.core.v1.NotificationLevelChangedEvent.level:type_name -> chatto.core.v1.NotificationLevel
-	66, // 66: chatto.core.v1.NotificationLevelChangedEvent.effective_level:type_name -> chatto.core.v1.NotificationLevel
-	61, // 67: chatto.core.v1.MessageEditedEvent.body:type_name -> chatto.core.v1.MessageBody
-	68, // [68:68] is the sub-list for method output_type
-	68, // [68:68] is the sub-list for method input_type
-	68, // [68:68] is the sub-list for extension type_name
-	68, // [68:68] is the sub-list for extension extendee
-	0,  // [0:68] is the sub-list for field type_name
+	34, // 29: chatto.core.v1.Event.user_login_cooldown_cleared:type_name -> chatto.core.v1.UserLoginCooldownClearedEvent
+	35, // 30: chatto.core.v1.Event.user_account_deleted:type_name -> chatto.core.v1.UserAccountDeletedEvent
+	33, // 31: chatto.core.v1.Event.user_login_cooldown_started:type_name -> chatto.core.v1.UserLoginCooldownStartedEvent
+	19, // 32: chatto.core.v1.Event.config_updated:type_name -> chatto.core.v1.ServerConfigUpdatedEvent
+	20, // 33: chatto.core.v1.Event.user_created:type_name -> chatto.core.v1.UserCreatedEvent
+	21, // 34: chatto.core.v1.Event.user_deleted:type_name -> chatto.core.v1.UserDeletedEvent
+	22, // 35: chatto.core.v1.Event.user_profile_updated:type_name -> chatto.core.v1.UserProfileUpdatedEvent
+	23, // 36: chatto.core.v1.Event.server_user_preferences_updated:type_name -> chatto.core.v1.ServerUserPreferencesUpdatedEvent
+	36, // 37: chatto.core.v1.Event.notification_level_changed:type_name -> chatto.core.v1.NotificationLevelChangedEvent
+	52, // 38: chatto.core.v1.Event.thread_follow_changed:type_name -> chatto.core.v1.ThreadFollowChangedEvent
+	37, // 39: chatto.core.v1.Event.server_created:type_name -> chatto.core.v1.ServerCreatedEvent
+	38, // 40: chatto.core.v1.Event.server_updated:type_name -> chatto.core.v1.ServerUpdatedEvent
+	39, // 41: chatto.core.v1.Event.server_deleted:type_name -> chatto.core.v1.ServerDeletedEvent
+	42, // 42: chatto.core.v1.Event.message_updated:type_name -> chatto.core.v1.MessageUpdatedEvent
+	43, // 43: chatto.core.v1.Event.message_deleted:type_name -> chatto.core.v1.MessageDeletedEvent
+	44, // 44: chatto.core.v1.Event.reaction_added:type_name -> chatto.core.v1.ReactionAddedEvent
+	45, // 45: chatto.core.v1.Event.reaction_removed:type_name -> chatto.core.v1.ReactionRemovedEvent
+	46, // 46: chatto.core.v1.Event.user_typing:type_name -> chatto.core.v1.UserTypingEvent
+	57, // 47: chatto.core.v1.Event.video_processing_completed:type_name -> chatto.core.v1.VideoProcessingCompletedEvent
+	47, // 48: chatto.core.v1.Event.presence_changed:type_name -> chatto.core.v1.PresenceChangedEvent
+	48, // 49: chatto.core.v1.Event.mention_notification:type_name -> chatto.core.v1.MentionNotificationEvent
+	49, // 50: chatto.core.v1.Event.new_direct_message_notification:type_name -> chatto.core.v1.NewDirectMessageNotificationEvent
+	58, // 51: chatto.core.v1.Event.call_participant_joined:type_name -> chatto.core.v1.CallParticipantJoinedEvent
+	59, // 52: chatto.core.v1.Event.call_participant_left:type_name -> chatto.core.v1.CallParticipantLeftEvent
+	50, // 53: chatto.core.v1.Event.notification_created:type_name -> chatto.core.v1.NotificationCreatedEvent
+	51, // 54: chatto.core.v1.Event.notification_dismissed:type_name -> chatto.core.v1.NotificationDismissedEvent
+	53, // 55: chatto.core.v1.Event.room_marked_as_read:type_name -> chatto.core.v1.RoomMarkedAsReadEvent
+	54, // 56: chatto.core.v1.Event.mention_status_cleared:type_name -> chatto.core.v1.MentionStatusClearedEvent
+	55, // 57: chatto.core.v1.Event.room_groups_updated:type_name -> chatto.core.v1.RoomGroupsUpdatedEvent
+	56, // 58: chatto.core.v1.Event.session_terminated:type_name -> chatto.core.v1.SessionTerminatedEvent
+	1,  // 59: chatto.core.v1.Event.heartbeat:type_name -> chatto.core.v1.HeartbeatEvent
+	61, // 60: chatto.core.v1.RoomCreatedEvent.kind:type_name -> chatto.core.v1.RoomKind
+	62, // 61: chatto.core.v1.MessagePostedEvent.body:type_name -> chatto.core.v1.MessageBody
+	63, // 62: chatto.core.v1.ServerConfigChangedEvent.config:type_name -> chatto.config.v1.ServerConfig
+	64, // 63: chatto.core.v1.ServerUserPreferencesUpdatedEvent.time_format:type_name -> chatto.core.v1.TimeFormat
+	65, // 64: chatto.core.v1.UserAvatarSetEvent.avatar:type_name -> chatto.core.v1.Asset
+	66, // 65: chatto.core.v1.UserServerPreferencesChangedEvent.preferences:type_name -> chatto.core.v1.ServerUserPreferences
+	67, // 66: chatto.core.v1.NotificationLevelChangedEvent.level:type_name -> chatto.core.v1.NotificationLevel
+	67, // 67: chatto.core.v1.NotificationLevelChangedEvent.effective_level:type_name -> chatto.core.v1.NotificationLevel
+	62, // 68: chatto.core.v1.MessageEditedEvent.body:type_name -> chatto.core.v1.MessageBody
+	69, // [69:69] is the sub-list for method output_type
+	69, // [69:69] is the sub-list for method input_type
+	69, // [69:69] is the sub-list for extension type_name
+	69, // [69:69] is the sub-list for extension extendee
+	0,  // [0:69] is the sub-list for field type_name
 }
 
 func init() { file_chatto_core_v1_event_proto_init() }
@@ -4904,6 +4958,7 @@ func file_chatto_core_v1_event_proto_init() {
 		(*Event_UserServerPreferencesChanged)(nil),
 		(*Event_UserLoginCooldownCleared)(nil),
 		(*Event_UserAccountDeleted)(nil),
+		(*Event_UserLoginCooldownStarted)(nil),
 		(*Event_ConfigUpdated)(nil),
 		(*Event_UserCreated)(nil),
 		(*Event_UserDeleted)(nil),
@@ -4933,14 +4988,14 @@ func file_chatto_core_v1_event_proto_init() {
 		(*Event_SessionTerminated)(nil),
 		(*Event_Heartbeat)(nil),
 	}
-	file_chatto_core_v1_event_proto_msgTypes[45].OneofWrappers = []any{}
+	file_chatto_core_v1_event_proto_msgTypes[46].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_core_v1_event_proto_rawDesc), len(file_chatto_core_v1_event_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   59,
+			NumMessages:   60,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/cli/internal/pb/chatto/core/v1/event.pb.go
+++ b/cli/internal/pb/chatto/core/v1/event.pb.go
@@ -82,6 +82,17 @@ type Event struct {
 	//	*Event_RoomRemovedFromGroup
 	//	*Event_RoomsInGroupReordered
 	//	*Event_RoomGroupsReordered
+	//	*Event_UserAccountCreated
+	//	*Event_UserLoginChanged
+	//	*Event_UserDisplayNameChanged
+	//	*Event_UserAvatarSet
+	//	*Event_UserAvatarCleared
+	//	*Event_UserVerifiedEmailAdded
+	//	*Event_UserPasswordHashChanged
+	//	*Event_UserOidcSubjectLinked
+	//	*Event_UserServerPreferencesChanged
+	//	*Event_UserLoginCooldownCleared
+	//	*Event_UserAccountDeleted
 	//	*Event_ConfigUpdated
 	//	*Event_UserCreated
 	//	*Event_UserDeleted
@@ -339,6 +350,105 @@ func (x *Event) GetRoomGroupsReordered() *RoomGroupsReorderedEvent {
 	if x != nil {
 		if x, ok := x.Event.(*Event_RoomGroupsReordered); ok {
 			return x.RoomGroupsReordered
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetUserAccountCreated() *UserAccountCreatedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_UserAccountCreated); ok {
+			return x.UserAccountCreated
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetUserLoginChanged() *UserLoginChangedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_UserLoginChanged); ok {
+			return x.UserLoginChanged
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetUserDisplayNameChanged() *UserDisplayNameChangedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_UserDisplayNameChanged); ok {
+			return x.UserDisplayNameChanged
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetUserAvatarSet() *UserAvatarSetEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_UserAvatarSet); ok {
+			return x.UserAvatarSet
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetUserAvatarCleared() *UserAvatarClearedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_UserAvatarCleared); ok {
+			return x.UserAvatarCleared
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetUserVerifiedEmailAdded() *UserVerifiedEmailAddedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_UserVerifiedEmailAdded); ok {
+			return x.UserVerifiedEmailAdded
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetUserPasswordHashChanged() *UserPasswordHashChangedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_UserPasswordHashChanged); ok {
+			return x.UserPasswordHashChanged
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetUserOidcSubjectLinked() *UserOIDCSubjectLinkedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_UserOidcSubjectLinked); ok {
+			return x.UserOidcSubjectLinked
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetUserServerPreferencesChanged() *UserServerPreferencesChangedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_UserServerPreferencesChanged); ok {
+			return x.UserServerPreferencesChanged
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetUserLoginCooldownCleared() *UserLoginCooldownClearedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_UserLoginCooldownCleared); ok {
+			return x.UserLoginCooldownCleared
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetUserAccountDeleted() *UserAccountDeletedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_UserAccountDeleted); ok {
+			return x.UserAccountDeleted
 		}
 	}
 	return nil
@@ -702,6 +812,51 @@ type Event_RoomGroupsReordered struct {
 	RoomGroupsReordered *RoomGroupsReorderedEvent `protobuf:"bytes,650,opt,name=room_groups_reordered,json=roomGroupsReordered,proto3,oneof"`
 }
 
+type Event_UserAccountCreated struct {
+	// ----- Users (700-719, durable, evt.user.{userId}) -----
+	UserAccountCreated *UserAccountCreatedEvent `protobuf:"bytes,700,opt,name=user_account_created,json=userAccountCreated,proto3,oneof"`
+}
+
+type Event_UserLoginChanged struct {
+	UserLoginChanged *UserLoginChangedEvent `protobuf:"bytes,701,opt,name=user_login_changed,json=userLoginChanged,proto3,oneof"`
+}
+
+type Event_UserDisplayNameChanged struct {
+	UserDisplayNameChanged *UserDisplayNameChangedEvent `protobuf:"bytes,702,opt,name=user_display_name_changed,json=userDisplayNameChanged,proto3,oneof"`
+}
+
+type Event_UserAvatarSet struct {
+	UserAvatarSet *UserAvatarSetEvent `protobuf:"bytes,703,opt,name=user_avatar_set,json=userAvatarSet,proto3,oneof"`
+}
+
+type Event_UserAvatarCleared struct {
+	UserAvatarCleared *UserAvatarClearedEvent `protobuf:"bytes,704,opt,name=user_avatar_cleared,json=userAvatarCleared,proto3,oneof"`
+}
+
+type Event_UserVerifiedEmailAdded struct {
+	UserVerifiedEmailAdded *UserVerifiedEmailAddedEvent `protobuf:"bytes,705,opt,name=user_verified_email_added,json=userVerifiedEmailAdded,proto3,oneof"`
+}
+
+type Event_UserPasswordHashChanged struct {
+	UserPasswordHashChanged *UserPasswordHashChangedEvent `protobuf:"bytes,706,opt,name=user_password_hash_changed,json=userPasswordHashChanged,proto3,oneof"`
+}
+
+type Event_UserOidcSubjectLinked struct {
+	UserOidcSubjectLinked *UserOIDCSubjectLinkedEvent `protobuf:"bytes,707,opt,name=user_oidc_subject_linked,json=userOidcSubjectLinked,proto3,oneof"`
+}
+
+type Event_UserServerPreferencesChanged struct {
+	UserServerPreferencesChanged *UserServerPreferencesChangedEvent `protobuf:"bytes,708,opt,name=user_server_preferences_changed,json=userServerPreferencesChanged,proto3,oneof"`
+}
+
+type Event_UserLoginCooldownCleared struct {
+	UserLoginCooldownCleared *UserLoginCooldownClearedEvent `protobuf:"bytes,709,opt,name=user_login_cooldown_cleared,json=userLoginCooldownCleared,proto3,oneof"`
+}
+
+type Event_UserAccountDeleted struct {
+	UserAccountDeleted *UserAccountDeletedEvent `protobuf:"bytes,710,opt,name=user_account_deleted,json=userAccountDeleted,proto3,oneof"`
+}
+
 type Event_ConfigUpdated struct {
 	// ----- Server config (1000-1009) -----
 	ConfigUpdated *ServerConfigUpdatedEvent `protobuf:"bytes,1000,opt,name=config_updated,json=configUpdated,proto3,oneof"`
@@ -872,6 +1027,28 @@ func (*Event_RoomRemovedFromGroup) isEvent_Event() {}
 func (*Event_RoomsInGroupReordered) isEvent_Event() {}
 
 func (*Event_RoomGroupsReordered) isEvent_Event() {}
+
+func (*Event_UserAccountCreated) isEvent_Event() {}
+
+func (*Event_UserLoginChanged) isEvent_Event() {}
+
+func (*Event_UserDisplayNameChanged) isEvent_Event() {}
+
+func (*Event_UserAvatarSet) isEvent_Event() {}
+
+func (*Event_UserAvatarCleared) isEvent_Event() {}
+
+func (*Event_UserVerifiedEmailAdded) isEvent_Event() {}
+
+func (*Event_UserPasswordHashChanged) isEvent_Event() {}
+
+func (*Event_UserOidcSubjectLinked) isEvent_Event() {}
+
+func (*Event_UserServerPreferencesChanged) isEvent_Event() {}
+
+func (*Event_UserLoginCooldownCleared) isEvent_Event() {}
+
+func (*Event_UserAccountDeleted) isEvent_Event() {}
 
 func (*Event_ConfigUpdated) isEvent_Event() {}
 
@@ -2251,6 +2428,590 @@ func (x *ServerUserPreferencesUpdatedEvent) GetTimeFormat() TimeFormat {
 	return TimeFormat_TIME_FORMAT_UNSPECIFIED
 }
 
+type UserAccountCreatedEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	Login         string                 `protobuf:"bytes,2,opt,name=login,proto3" json:"login,omitempty"`
+	DisplayName   string                 `protobuf:"bytes,3,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UserAccountCreatedEvent) Reset() {
+	*x = UserAccountCreatedEvent{}
+	mi := &file_chatto_core_v1_event_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserAccountCreatedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserAccountCreatedEvent) ProtoMessage() {}
+
+func (x *UserAccountCreatedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_event_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UserAccountCreatedEvent.ProtoReflect.Descriptor instead.
+func (*UserAccountCreatedEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *UserAccountCreatedEvent) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+func (x *UserAccountCreatedEvent) GetLogin() string {
+	if x != nil {
+		return x.Login
+	}
+	return ""
+}
+
+func (x *UserAccountCreatedEvent) GetDisplayName() string {
+	if x != nil {
+		return x.DisplayName
+	}
+	return ""
+}
+
+type UserLoginChangedEvent struct {
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	UserId string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	Login  string                 `protobuf:"bytes,2,opt,name=login,proto3" json:"login,omitempty"`
+	// True when this user-initiated login change advances the cooldown.
+	// The cooldown timestamp is the envelope created_at.
+	AdvancesCooldown bool `protobuf:"varint,3,opt,name=advances_cooldown,json=advancesCooldown,proto3" json:"advances_cooldown,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *UserLoginChangedEvent) Reset() {
+	*x = UserLoginChangedEvent{}
+	mi := &file_chatto_core_v1_event_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserLoginChangedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserLoginChangedEvent) ProtoMessage() {}
+
+func (x *UserLoginChangedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_event_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UserLoginChangedEvent.ProtoReflect.Descriptor instead.
+func (*UserLoginChangedEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *UserLoginChangedEvent) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+func (x *UserLoginChangedEvent) GetLogin() string {
+	if x != nil {
+		return x.Login
+	}
+	return ""
+}
+
+func (x *UserLoginChangedEvent) GetAdvancesCooldown() bool {
+	if x != nil {
+		return x.AdvancesCooldown
+	}
+	return false
+}
+
+type UserDisplayNameChangedEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	DisplayName   string                 `protobuf:"bytes,2,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UserDisplayNameChangedEvent) Reset() {
+	*x = UserDisplayNameChangedEvent{}
+	mi := &file_chatto_core_v1_event_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserDisplayNameChangedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserDisplayNameChangedEvent) ProtoMessage() {}
+
+func (x *UserDisplayNameChangedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_event_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UserDisplayNameChangedEvent.ProtoReflect.Descriptor instead.
+func (*UserDisplayNameChangedEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *UserDisplayNameChangedEvent) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+func (x *UserDisplayNameChangedEvent) GetDisplayName() string {
+	if x != nil {
+		return x.DisplayName
+	}
+	return ""
+}
+
+type UserAvatarSetEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	Avatar        *Asset                 `protobuf:"bytes,2,opt,name=avatar,proto3" json:"avatar,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UserAvatarSetEvent) Reset() {
+	*x = UserAvatarSetEvent{}
+	mi := &file_chatto_core_v1_event_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserAvatarSetEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserAvatarSetEvent) ProtoMessage() {}
+
+func (x *UserAvatarSetEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_event_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UserAvatarSetEvent.ProtoReflect.Descriptor instead.
+func (*UserAvatarSetEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *UserAvatarSetEvent) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+func (x *UserAvatarSetEvent) GetAvatar() *Asset {
+	if x != nil {
+		return x.Avatar
+	}
+	return nil
+}
+
+type UserAvatarClearedEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UserAvatarClearedEvent) Reset() {
+	*x = UserAvatarClearedEvent{}
+	mi := &file_chatto_core_v1_event_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserAvatarClearedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserAvatarClearedEvent) ProtoMessage() {}
+
+func (x *UserAvatarClearedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_event_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UserAvatarClearedEvent.ProtoReflect.Descriptor instead.
+func (*UserAvatarClearedEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *UserAvatarClearedEvent) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+type UserVerifiedEmailAddedEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	Email         string                 `protobuf:"bytes,2,opt,name=email,proto3" json:"email,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UserVerifiedEmailAddedEvent) Reset() {
+	*x = UserVerifiedEmailAddedEvent{}
+	mi := &file_chatto_core_v1_event_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserVerifiedEmailAddedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserVerifiedEmailAddedEvent) ProtoMessage() {}
+
+func (x *UserVerifiedEmailAddedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_event_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UserVerifiedEmailAddedEvent.ProtoReflect.Descriptor instead.
+func (*UserVerifiedEmailAddedEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *UserVerifiedEmailAddedEvent) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+func (x *UserVerifiedEmailAddedEvent) GetEmail() string {
+	if x != nil {
+		return x.Email
+	}
+	return ""
+}
+
+type UserPasswordHashChangedEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	PasswordHash  []byte                 `protobuf:"bytes,2,opt,name=password_hash,json=passwordHash,proto3" json:"password_hash,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UserPasswordHashChangedEvent) Reset() {
+	*x = UserPasswordHashChangedEvent{}
+	mi := &file_chatto_core_v1_event_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserPasswordHashChangedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserPasswordHashChangedEvent) ProtoMessage() {}
+
+func (x *UserPasswordHashChangedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_event_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UserPasswordHashChangedEvent.ProtoReflect.Descriptor instead.
+func (*UserPasswordHashChangedEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *UserPasswordHashChangedEvent) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+func (x *UserPasswordHashChangedEvent) GetPasswordHash() []byte {
+	if x != nil {
+		return x.PasswordHash
+	}
+	return nil
+}
+
+type UserOIDCSubjectLinkedEvent struct {
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	UserId string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	// New writes include issuer/subject so the event is inspectable. Legacy
+	// imports may only have the hash, because the old KV index key is one-way.
+	Issuer        string `protobuf:"bytes,2,opt,name=issuer,proto3" json:"issuer,omitempty"`
+	Subject       string `protobuf:"bytes,3,opt,name=subject,proto3" json:"subject,omitempty"`
+	SubjectHash   string `protobuf:"bytes,4,opt,name=subject_hash,json=subjectHash,proto3" json:"subject_hash,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UserOIDCSubjectLinkedEvent) Reset() {
+	*x = UserOIDCSubjectLinkedEvent{}
+	mi := &file_chatto_core_v1_event_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserOIDCSubjectLinkedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserOIDCSubjectLinkedEvent) ProtoMessage() {}
+
+func (x *UserOIDCSubjectLinkedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_event_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UserOIDCSubjectLinkedEvent.ProtoReflect.Descriptor instead.
+func (*UserOIDCSubjectLinkedEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *UserOIDCSubjectLinkedEvent) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+func (x *UserOIDCSubjectLinkedEvent) GetIssuer() string {
+	if x != nil {
+		return x.Issuer
+	}
+	return ""
+}
+
+func (x *UserOIDCSubjectLinkedEvent) GetSubject() string {
+	if x != nil {
+		return x.Subject
+	}
+	return ""
+}
+
+func (x *UserOIDCSubjectLinkedEvent) GetSubjectHash() string {
+	if x != nil {
+		return x.SubjectHash
+	}
+	return ""
+}
+
+type UserServerPreferencesChangedEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	Preferences   *ServerUserPreferences `protobuf:"bytes,2,opt,name=preferences,proto3" json:"preferences,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UserServerPreferencesChangedEvent) Reset() {
+	*x = UserServerPreferencesChangedEvent{}
+	mi := &file_chatto_core_v1_event_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserServerPreferencesChangedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserServerPreferencesChangedEvent) ProtoMessage() {}
+
+func (x *UserServerPreferencesChangedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_event_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UserServerPreferencesChangedEvent.ProtoReflect.Descriptor instead.
+func (*UserServerPreferencesChangedEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *UserServerPreferencesChangedEvent) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+func (x *UserServerPreferencesChangedEvent) GetPreferences() *ServerUserPreferences {
+	if x != nil {
+		return x.Preferences
+	}
+	return nil
+}
+
+type UserLoginCooldownClearedEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UserLoginCooldownClearedEvent) Reset() {
+	*x = UserLoginCooldownClearedEvent{}
+	mi := &file_chatto_core_v1_event_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserLoginCooldownClearedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserLoginCooldownClearedEvent) ProtoMessage() {}
+
+func (x *UserLoginCooldownClearedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_event_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UserLoginCooldownClearedEvent.ProtoReflect.Descriptor instead.
+func (*UserLoginCooldownClearedEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *UserLoginCooldownClearedEvent) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+type UserAccountDeletedEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UserAccountDeletedEvent) Reset() {
+	*x = UserAccountDeletedEvent{}
+	mi := &file_chatto_core_v1_event_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserAccountDeletedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserAccountDeletedEvent) ProtoMessage() {}
+
+func (x *UserAccountDeletedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_event_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UserAccountDeletedEvent.ProtoReflect.Descriptor instead.
+func (*UserAccountDeletedEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *UserAccountDeletedEvent) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
 // NotificationLevelChangedEvent is published when a user changes their notification
 // level for the server or a specific room. User-scoped: only delivered to the user
 // who changed it.
@@ -2268,7 +3029,7 @@ type NotificationLevelChangedEvent struct {
 
 func (x *NotificationLevelChangedEvent) Reset() {
 	*x = NotificationLevelChangedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[24]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2280,7 +3041,7 @@ func (x *NotificationLevelChangedEvent) String() string {
 func (*NotificationLevelChangedEvent) ProtoMessage() {}
 
 func (x *NotificationLevelChangedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[24]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2293,7 +3054,7 @@ func (x *NotificationLevelChangedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NotificationLevelChangedEvent.ProtoReflect.Descriptor instead.
 func (*NotificationLevelChangedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{24}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *NotificationLevelChangedEvent) GetRoomId() string {
@@ -2328,7 +3089,7 @@ type ServerCreatedEvent struct {
 
 func (x *ServerCreatedEvent) Reset() {
 	*x = ServerCreatedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[25]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2340,7 +3101,7 @@ func (x *ServerCreatedEvent) String() string {
 func (*ServerCreatedEvent) ProtoMessage() {}
 
 func (x *ServerCreatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[25]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2353,7 +3114,7 @@ func (x *ServerCreatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerCreatedEvent.ProtoReflect.Descriptor instead.
 func (*ServerCreatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{25}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *ServerCreatedEvent) GetServerId() string {
@@ -2392,7 +3153,7 @@ type ServerUpdatedEvent struct {
 
 func (x *ServerUpdatedEvent) Reset() {
 	*x = ServerUpdatedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[26]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2404,7 +3165,7 @@ func (x *ServerUpdatedEvent) String() string {
 func (*ServerUpdatedEvent) ProtoMessage() {}
 
 func (x *ServerUpdatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[26]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2417,7 +3178,7 @@ func (x *ServerUpdatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerUpdatedEvent.ProtoReflect.Descriptor instead.
 func (*ServerUpdatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{26}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *ServerUpdatedEvent) GetServerId() string {
@@ -2464,7 +3225,7 @@ type ServerDeletedEvent struct {
 
 func (x *ServerDeletedEvent) Reset() {
 	*x = ServerDeletedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[27]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2476,7 +3237,7 @@ func (x *ServerDeletedEvent) String() string {
 func (*ServerDeletedEvent) ProtoMessage() {}
 
 func (x *ServerDeletedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[27]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2489,7 +3250,7 @@ func (x *ServerDeletedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerDeletedEvent.ProtoReflect.Descriptor instead.
 func (*ServerDeletedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{27}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *ServerDeletedEvent) GetServerId() string {
@@ -2519,7 +3280,7 @@ type MessageEditedEvent struct {
 
 func (x *MessageEditedEvent) Reset() {
 	*x = MessageEditedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[28]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2531,7 +3292,7 @@ func (x *MessageEditedEvent) String() string {
 func (*MessageEditedEvent) ProtoMessage() {}
 
 func (x *MessageEditedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[28]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2544,7 +3305,7 @@ func (x *MessageEditedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageEditedEvent.ProtoReflect.Descriptor instead.
 func (*MessageEditedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{28}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *MessageEditedEvent) GetRoomId() string {
@@ -2589,7 +3350,7 @@ type MessageRetractedEvent struct {
 
 func (x *MessageRetractedEvent) Reset() {
 	*x = MessageRetractedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[29]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2601,7 +3362,7 @@ func (x *MessageRetractedEvent) String() string {
 func (*MessageRetractedEvent) ProtoMessage() {}
 
 func (x *MessageRetractedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[29]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2614,7 +3375,7 @@ func (x *MessageRetractedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageRetractedEvent.ProtoReflect.Descriptor instead.
 func (*MessageRetractedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{29}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *MessageRetractedEvent) GetRoomId() string {
@@ -2661,7 +3422,7 @@ type MessageUpdatedEvent struct {
 
 func (x *MessageUpdatedEvent) Reset() {
 	*x = MessageUpdatedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[30]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2673,7 +3434,7 @@ func (x *MessageUpdatedEvent) String() string {
 func (*MessageUpdatedEvent) ProtoMessage() {}
 
 func (x *MessageUpdatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[30]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2686,7 +3447,7 @@ func (x *MessageUpdatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageUpdatedEvent.ProtoReflect.Descriptor instead.
 func (*MessageUpdatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{30}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *MessageUpdatedEvent) GetRoomId() string {
@@ -2747,7 +3508,7 @@ type MessageDeletedEvent struct {
 
 func (x *MessageDeletedEvent) Reset() {
 	*x = MessageDeletedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[31]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2759,7 +3520,7 @@ func (x *MessageDeletedEvent) String() string {
 func (*MessageDeletedEvent) ProtoMessage() {}
 
 func (x *MessageDeletedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[31]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2772,7 +3533,7 @@ func (x *MessageDeletedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageDeletedEvent.ProtoReflect.Descriptor instead.
 func (*MessageDeletedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{31}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *MessageDeletedEvent) GetRoomId() string {
@@ -2810,7 +3571,7 @@ type ReactionAddedEvent struct {
 
 func (x *ReactionAddedEvent) Reset() {
 	*x = ReactionAddedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[32]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2822,7 +3583,7 @@ func (x *ReactionAddedEvent) String() string {
 func (*ReactionAddedEvent) ProtoMessage() {}
 
 func (x *ReactionAddedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[32]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2835,7 +3596,7 @@ func (x *ReactionAddedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReactionAddedEvent.ProtoReflect.Descriptor instead.
 func (*ReactionAddedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{32}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *ReactionAddedEvent) GetRoomId() string {
@@ -2873,7 +3634,7 @@ type ReactionRemovedEvent struct {
 
 func (x *ReactionRemovedEvent) Reset() {
 	*x = ReactionRemovedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[33]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2885,7 +3646,7 @@ func (x *ReactionRemovedEvent) String() string {
 func (*ReactionRemovedEvent) ProtoMessage() {}
 
 func (x *ReactionRemovedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[33]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2898,7 +3659,7 @@ func (x *ReactionRemovedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReactionRemovedEvent.ProtoReflect.Descriptor instead.
 func (*ReactionRemovedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{33}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *ReactionRemovedEvent) GetRoomId() string {
@@ -2938,7 +3699,7 @@ type UserTypingEvent struct {
 
 func (x *UserTypingEvent) Reset() {
 	*x = UserTypingEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[34]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2950,7 +3711,7 @@ func (x *UserTypingEvent) String() string {
 func (*UserTypingEvent) ProtoMessage() {}
 
 func (x *UserTypingEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[34]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2963,7 +3724,7 @@ func (x *UserTypingEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserTypingEvent.ProtoReflect.Descriptor instead.
 func (*UserTypingEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{34}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *UserTypingEvent) GetRoomId() string {
@@ -2994,7 +3755,7 @@ type PresenceChangedEvent struct {
 
 func (x *PresenceChangedEvent) Reset() {
 	*x = PresenceChangedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[35]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3006,7 +3767,7 @@ func (x *PresenceChangedEvent) String() string {
 func (*PresenceChangedEvent) ProtoMessage() {}
 
 func (x *PresenceChangedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[35]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3019,7 +3780,7 @@ func (x *PresenceChangedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PresenceChangedEvent.ProtoReflect.Descriptor instead.
 func (*PresenceChangedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{35}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *PresenceChangedEvent) GetStatus() string {
@@ -3044,7 +3805,7 @@ type MentionNotificationEvent struct {
 
 func (x *MentionNotificationEvent) Reset() {
 	*x = MentionNotificationEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[36]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3056,7 +3817,7 @@ func (x *MentionNotificationEvent) String() string {
 func (*MentionNotificationEvent) ProtoMessage() {}
 
 func (x *MentionNotificationEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[36]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3069,7 +3830,7 @@ func (x *MentionNotificationEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MentionNotificationEvent.ProtoReflect.Descriptor instead.
 func (*MentionNotificationEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{36}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *MentionNotificationEvent) GetRoomId() string {
@@ -3101,7 +3862,7 @@ type NewDirectMessageNotificationEvent struct {
 
 func (x *NewDirectMessageNotificationEvent) Reset() {
 	*x = NewDirectMessageNotificationEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[37]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3113,7 +3874,7 @@ func (x *NewDirectMessageNotificationEvent) String() string {
 func (*NewDirectMessageNotificationEvent) ProtoMessage() {}
 
 func (x *NewDirectMessageNotificationEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[37]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3126,7 +3887,7 @@ func (x *NewDirectMessageNotificationEvent) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use NewDirectMessageNotificationEvent.ProtoReflect.Descriptor instead.
 func (*NewDirectMessageNotificationEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{37}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *NewDirectMessageNotificationEvent) GetRoomId() string {
@@ -3159,7 +3920,7 @@ type NotificationCreatedEvent struct {
 
 func (x *NotificationCreatedEvent) Reset() {
 	*x = NotificationCreatedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[38]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3171,7 +3932,7 @@ func (x *NotificationCreatedEvent) String() string {
 func (*NotificationCreatedEvent) ProtoMessage() {}
 
 func (x *NotificationCreatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[38]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3184,7 +3945,7 @@ func (x *NotificationCreatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NotificationCreatedEvent.ProtoReflect.Descriptor instead.
 func (*NotificationCreatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{38}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *NotificationCreatedEvent) GetNotificationId() string {
@@ -3227,7 +3988,7 @@ type NotificationDismissedEvent struct {
 
 func (x *NotificationDismissedEvent) Reset() {
 	*x = NotificationDismissedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[39]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3239,7 +4000,7 @@ func (x *NotificationDismissedEvent) String() string {
 func (*NotificationDismissedEvent) ProtoMessage() {}
 
 func (x *NotificationDismissedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[39]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3252,7 +4013,7 @@ func (x *NotificationDismissedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NotificationDismissedEvent.ProtoReflect.Descriptor instead.
 func (*NotificationDismissedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{39}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *NotificationDismissedEvent) GetNotificationId() string {
@@ -3279,7 +4040,7 @@ type ThreadFollowChangedEvent struct {
 
 func (x *ThreadFollowChangedEvent) Reset() {
 	*x = ThreadFollowChangedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[40]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3291,7 +4052,7 @@ func (x *ThreadFollowChangedEvent) String() string {
 func (*ThreadFollowChangedEvent) ProtoMessage() {}
 
 func (x *ThreadFollowChangedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[40]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3304,7 +4065,7 @@ func (x *ThreadFollowChangedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ThreadFollowChangedEvent.ProtoReflect.Descriptor instead.
 func (*ThreadFollowChangedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{40}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *ThreadFollowChangedEvent) GetRoomId() string {
@@ -3340,7 +4101,7 @@ type RoomMarkedAsReadEvent struct {
 
 func (x *RoomMarkedAsReadEvent) Reset() {
 	*x = RoomMarkedAsReadEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[41]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3352,7 +4113,7 @@ func (x *RoomMarkedAsReadEvent) String() string {
 func (*RoomMarkedAsReadEvent) ProtoMessage() {}
 
 func (x *RoomMarkedAsReadEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[41]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3365,7 +4126,7 @@ func (x *RoomMarkedAsReadEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomMarkedAsReadEvent.ProtoReflect.Descriptor instead.
 func (*RoomMarkedAsReadEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{41}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *RoomMarkedAsReadEvent) GetRoomId() string {
@@ -3390,7 +4151,7 @@ type MentionStatusClearedEvent struct {
 
 func (x *MentionStatusClearedEvent) Reset() {
 	*x = MentionStatusClearedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[42]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3402,7 +4163,7 @@ func (x *MentionStatusClearedEvent) String() string {
 func (*MentionStatusClearedEvent) ProtoMessage() {}
 
 func (x *MentionStatusClearedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[42]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3415,7 +4176,7 @@ func (x *MentionStatusClearedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MentionStatusClearedEvent.ProtoReflect.Descriptor instead.
 func (*MentionStatusClearedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{42}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *MentionStatusClearedEvent) GetRoomId() string {
@@ -3436,7 +4197,7 @@ type RoomGroupsUpdatedEvent struct {
 
 func (x *RoomGroupsUpdatedEvent) Reset() {
 	*x = RoomGroupsUpdatedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[43]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3448,7 +4209,7 @@ func (x *RoomGroupsUpdatedEvent) String() string {
 func (*RoomGroupsUpdatedEvent) ProtoMessage() {}
 
 func (x *RoomGroupsUpdatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[43]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3461,7 +4222,7 @@ func (x *RoomGroupsUpdatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomGroupsUpdatedEvent.ProtoReflect.Descriptor instead.
 func (*RoomGroupsUpdatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{43}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{54}
 }
 
 // Notifies a user that their session has been terminated.
@@ -3478,7 +4239,7 @@ type SessionTerminatedEvent struct {
 
 func (x *SessionTerminatedEvent) Reset() {
 	*x = SessionTerminatedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[44]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3490,7 +4251,7 @@ func (x *SessionTerminatedEvent) String() string {
 func (*SessionTerminatedEvent) ProtoMessage() {}
 
 func (x *SessionTerminatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[44]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3503,7 +4264,7 @@ func (x *SessionTerminatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionTerminatedEvent.ProtoReflect.Descriptor instead.
 func (*SessionTerminatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{44}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *SessionTerminatedEvent) GetReason() string {
@@ -3532,7 +4293,7 @@ type VideoProcessingCompletedEvent struct {
 
 func (x *VideoProcessingCompletedEvent) Reset() {
 	*x = VideoProcessingCompletedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[45]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3544,7 +4305,7 @@ func (x *VideoProcessingCompletedEvent) String() string {
 func (*VideoProcessingCompletedEvent) ProtoMessage() {}
 
 func (x *VideoProcessingCompletedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[45]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3557,7 +4318,7 @@ func (x *VideoProcessingCompletedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VideoProcessingCompletedEvent.ProtoReflect.Descriptor instead.
 func (*VideoProcessingCompletedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{45}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *VideoProcessingCompletedEvent) GetRoomId() string {
@@ -3599,7 +4360,7 @@ type CallParticipantJoinedEvent struct {
 
 func (x *CallParticipantJoinedEvent) Reset() {
 	*x = CallParticipantJoinedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[46]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3611,7 +4372,7 @@ func (x *CallParticipantJoinedEvent) String() string {
 func (*CallParticipantJoinedEvent) ProtoMessage() {}
 
 func (x *CallParticipantJoinedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[46]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3624,7 +4385,7 @@ func (x *CallParticipantJoinedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CallParticipantJoinedEvent.ProtoReflect.Descriptor instead.
 func (*CallParticipantJoinedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{46}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *CallParticipantJoinedEvent) GetRoomId() string {
@@ -3645,7 +4406,7 @@ type CallParticipantLeftEvent struct {
 
 func (x *CallParticipantLeftEvent) Reset() {
 	*x = CallParticipantLeftEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[47]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3657,7 +4418,7 @@ func (x *CallParticipantLeftEvent) String() string {
 func (*CallParticipantLeftEvent) ProtoMessage() {}
 
 func (x *CallParticipantLeftEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[47]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3670,7 +4431,7 @@ func (x *CallParticipantLeftEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CallParticipantLeftEvent.ProtoReflect.Descriptor instead.
 func (*CallParticipantLeftEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{47}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *CallParticipantLeftEvent) GetRoomId() string {
@@ -3684,7 +4445,7 @@ var File_chatto_core_v1_event_proto protoreflect.FileDescriptor
 
 const file_chatto_core_v1_event_proto_rawDesc = "" +
 	"\n" +
-	"\x1achatto/core/v1/event.proto\x12\x0echatto.core.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1dchatto/config/v1/config.proto\x1a\x1bchatto/core/v1/models.proto\x1a%chatto/core/v1/user_preferences.proto\"\xb6!\n" +
+	"\x1achatto/core/v1/event.proto\x12\x0echatto.core.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1dchatto/config/v1/config.proto\x1a\x1bchatto/core/v1/models.proto\x1a%chatto/core/v1/user_preferences.proto\"\x8e*\n" +
 	"\x05Event\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x129\n" +
 	"\n" +
@@ -3708,7 +4469,18 @@ const file_chatto_core_v1_event_proto_rawDesc = "" +
 	"\x13room_added_to_group\x18\xdb\x04 \x01(\v2%.chatto.core.v1.RoomAddedToGroupEventH\x00R\x10roomAddedToGroup\x12c\n" +
 	"\x17room_removed_from_group\x18\xdc\x04 \x01(\v2).chatto.core.v1.RoomRemovedFromGroupEventH\x00R\x14roomRemovedFromGroup\x12f\n" +
 	"\x18rooms_in_group_reordered\x18\xdd\x04 \x01(\v2*.chatto.core.v1.RoomsInGroupReorderedEventH\x00R\x15roomsInGroupReordered\x12_\n" +
-	"\x15room_groups_reordered\x18\x8a\x05 \x01(\v2(.chatto.core.v1.RoomGroupsReorderedEventH\x00R\x13roomGroupsReordered\x12R\n" +
+	"\x15room_groups_reordered\x18\x8a\x05 \x01(\v2(.chatto.core.v1.RoomGroupsReorderedEventH\x00R\x13roomGroupsReordered\x12\\\n" +
+	"\x14user_account_created\x18\xbc\x05 \x01(\v2'.chatto.core.v1.UserAccountCreatedEventH\x00R\x12userAccountCreated\x12V\n" +
+	"\x12user_login_changed\x18\xbd\x05 \x01(\v2%.chatto.core.v1.UserLoginChangedEventH\x00R\x10userLoginChanged\x12i\n" +
+	"\x19user_display_name_changed\x18\xbe\x05 \x01(\v2+.chatto.core.v1.UserDisplayNameChangedEventH\x00R\x16userDisplayNameChanged\x12M\n" +
+	"\x0fuser_avatar_set\x18\xbf\x05 \x01(\v2\".chatto.core.v1.UserAvatarSetEventH\x00R\ruserAvatarSet\x12Y\n" +
+	"\x13user_avatar_cleared\x18\xc0\x05 \x01(\v2&.chatto.core.v1.UserAvatarClearedEventH\x00R\x11userAvatarCleared\x12i\n" +
+	"\x19user_verified_email_added\x18\xc1\x05 \x01(\v2+.chatto.core.v1.UserVerifiedEmailAddedEventH\x00R\x16userVerifiedEmailAdded\x12l\n" +
+	"\x1auser_password_hash_changed\x18\xc2\x05 \x01(\v2,.chatto.core.v1.UserPasswordHashChangedEventH\x00R\x17userPasswordHashChanged\x12f\n" +
+	"\x18user_oidc_subject_linked\x18\xc3\x05 \x01(\v2*.chatto.core.v1.UserOIDCSubjectLinkedEventH\x00R\x15userOidcSubjectLinked\x12{\n" +
+	"\x1fuser_server_preferences_changed\x18\xc4\x05 \x01(\v21.chatto.core.v1.UserServerPreferencesChangedEventH\x00R\x1cuserServerPreferencesChanged\x12o\n" +
+	"\x1buser_login_cooldown_cleared\x18\xc5\x05 \x01(\v2-.chatto.core.v1.UserLoginCooldownClearedEventH\x00R\x18userLoginCooldownCleared\x12\\\n" +
+	"\x14user_account_deleted\x18\xc6\x05 \x01(\v2'.chatto.core.v1.UserAccountDeletedEventH\x00R\x12userAccountDeleted\x12R\n" +
 	"\x0econfig_updated\x18\xe8\a \x01(\v2(.chatto.core.v1.ServerConfigUpdatedEventH\x00R\rconfigUpdated\x12F\n" +
 	"\fuser_created\x18\xf2\a \x01(\v2 .chatto.core.v1.UserCreatedEventH\x00R\vuserCreated\x12F\n" +
 	"\fuser_deleted\x18\xf3\a \x01(\v2 .chatto.core.v1.UserDeletedEventH\x00R\vuserDeleted\x12\\\n" +
@@ -3815,7 +4587,41 @@ const file_chatto_core_v1_event_proto_rawDesc = "" +
 	"!ServerUserPreferencesUpdatedEvent\x12\x1a\n" +
 	"\btimezone\x18\x01 \x01(\tR\btimezone\x12;\n" +
 	"\vtime_format\x18\x02 \x01(\x0e2\x1a.chatto.core.v1.TimeFormatR\n" +
-	"timeFormat\"\xcd\x01\n" +
+	"timeFormat\"k\n" +
+	"\x17UserAccountCreatedEvent\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\x12\x14\n" +
+	"\x05login\x18\x02 \x01(\tR\x05login\x12!\n" +
+	"\fdisplay_name\x18\x03 \x01(\tR\vdisplayName\"s\n" +
+	"\x15UserLoginChangedEvent\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\x12\x14\n" +
+	"\x05login\x18\x02 \x01(\tR\x05login\x12+\n" +
+	"\x11advances_cooldown\x18\x03 \x01(\bR\x10advancesCooldown\"Y\n" +
+	"\x1bUserDisplayNameChangedEvent\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\x12!\n" +
+	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\"\\\n" +
+	"\x12UserAvatarSetEvent\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\x12-\n" +
+	"\x06avatar\x18\x02 \x01(\v2\x15.chatto.core.v1.AssetR\x06avatar\"1\n" +
+	"\x16UserAvatarClearedEvent\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\"L\n" +
+	"\x1bUserVerifiedEmailAddedEvent\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\x12\x14\n" +
+	"\x05email\x18\x02 \x01(\tR\x05email\"\\\n" +
+	"\x1cUserPasswordHashChangedEvent\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\x12#\n" +
+	"\rpassword_hash\x18\x02 \x01(\fR\fpasswordHash\"\x8a\x01\n" +
+	"\x1aUserOIDCSubjectLinkedEvent\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\x12\x16\n" +
+	"\x06issuer\x18\x02 \x01(\tR\x06issuer\x12\x18\n" +
+	"\asubject\x18\x03 \x01(\tR\asubject\x12!\n" +
+	"\fsubject_hash\x18\x04 \x01(\tR\vsubjectHash\"\x85\x01\n" +
+	"!UserServerPreferencesChangedEvent\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\x12G\n" +
+	"\vpreferences\x18\x02 \x01(\v2%.chatto.core.v1.ServerUserPreferencesR\vpreferences\"8\n" +
+	"\x1dUserLoginCooldownClearedEvent\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\"2\n" +
+	"\x17UserAccountDeletedEvent\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\"\xcd\x01\n" +
 	"\x1dNotificationLevelChangedEvent\x12\x17\n" +
 	"\aroom_id\x18\x02 \x01(\tR\x06roomId\x127\n" +
 	"\x05level\x18\x03 \x01(\x0e2!.chatto.core.v1.NotificationLevelR\x05level\x12J\n" +
@@ -3914,7 +4720,7 @@ func file_chatto_core_v1_event_proto_rawDescGZIP() []byte {
 	return file_chatto_core_v1_event_proto_rawDescData
 }
 
-var file_chatto_core_v1_event_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
+var file_chatto_core_v1_event_proto_msgTypes = make([]protoimpl.MessageInfo, 59)
 var file_chatto_core_v1_event_proto_goTypes = []any{
 	(*Event)(nil),                             // 0: chatto.core.v1.Event
 	(*HeartbeatEvent)(nil),                    // 1: chatto.core.v1.HeartbeatEvent
@@ -3940,39 +4746,52 @@ var file_chatto_core_v1_event_proto_goTypes = []any{
 	(*UserDeletedEvent)(nil),                  // 21: chatto.core.v1.UserDeletedEvent
 	(*UserProfileUpdatedEvent)(nil),           // 22: chatto.core.v1.UserProfileUpdatedEvent
 	(*ServerUserPreferencesUpdatedEvent)(nil), // 23: chatto.core.v1.ServerUserPreferencesUpdatedEvent
-	(*NotificationLevelChangedEvent)(nil),     // 24: chatto.core.v1.NotificationLevelChangedEvent
-	(*ServerCreatedEvent)(nil),                // 25: chatto.core.v1.ServerCreatedEvent
-	(*ServerUpdatedEvent)(nil),                // 26: chatto.core.v1.ServerUpdatedEvent
-	(*ServerDeletedEvent)(nil),                // 27: chatto.core.v1.ServerDeletedEvent
-	(*MessageEditedEvent)(nil),                // 28: chatto.core.v1.MessageEditedEvent
-	(*MessageRetractedEvent)(nil),             // 29: chatto.core.v1.MessageRetractedEvent
-	(*MessageUpdatedEvent)(nil),               // 30: chatto.core.v1.MessageUpdatedEvent
-	(*MessageDeletedEvent)(nil),               // 31: chatto.core.v1.MessageDeletedEvent
-	(*ReactionAddedEvent)(nil),                // 32: chatto.core.v1.ReactionAddedEvent
-	(*ReactionRemovedEvent)(nil),              // 33: chatto.core.v1.ReactionRemovedEvent
-	(*UserTypingEvent)(nil),                   // 34: chatto.core.v1.UserTypingEvent
-	(*PresenceChangedEvent)(nil),              // 35: chatto.core.v1.PresenceChangedEvent
-	(*MentionNotificationEvent)(nil),          // 36: chatto.core.v1.MentionNotificationEvent
-	(*NewDirectMessageNotificationEvent)(nil), // 37: chatto.core.v1.NewDirectMessageNotificationEvent
-	(*NotificationCreatedEvent)(nil),          // 38: chatto.core.v1.NotificationCreatedEvent
-	(*NotificationDismissedEvent)(nil),        // 39: chatto.core.v1.NotificationDismissedEvent
-	(*ThreadFollowChangedEvent)(nil),          // 40: chatto.core.v1.ThreadFollowChangedEvent
-	(*RoomMarkedAsReadEvent)(nil),             // 41: chatto.core.v1.RoomMarkedAsReadEvent
-	(*MentionStatusClearedEvent)(nil),         // 42: chatto.core.v1.MentionStatusClearedEvent
-	(*RoomGroupsUpdatedEvent)(nil),            // 43: chatto.core.v1.RoomGroupsUpdatedEvent
-	(*SessionTerminatedEvent)(nil),            // 44: chatto.core.v1.SessionTerminatedEvent
-	(*VideoProcessingCompletedEvent)(nil),     // 45: chatto.core.v1.VideoProcessingCompletedEvent
-	(*CallParticipantJoinedEvent)(nil),        // 46: chatto.core.v1.CallParticipantJoinedEvent
-	(*CallParticipantLeftEvent)(nil),          // 47: chatto.core.v1.CallParticipantLeftEvent
-	(*timestamppb.Timestamp)(nil),             // 48: google.protobuf.Timestamp
-	(RoomKind)(0),                             // 49: chatto.core.v1.RoomKind
-	(*MessageBody)(nil),                       // 50: chatto.core.v1.MessageBody
-	(*v1.ServerConfig)(nil),                   // 51: chatto.config.v1.ServerConfig
-	(TimeFormat)(0),                           // 52: chatto.core.v1.TimeFormat
-	(NotificationLevel)(0),                    // 53: chatto.core.v1.NotificationLevel
+	(*UserAccountCreatedEvent)(nil),           // 24: chatto.core.v1.UserAccountCreatedEvent
+	(*UserLoginChangedEvent)(nil),             // 25: chatto.core.v1.UserLoginChangedEvent
+	(*UserDisplayNameChangedEvent)(nil),       // 26: chatto.core.v1.UserDisplayNameChangedEvent
+	(*UserAvatarSetEvent)(nil),                // 27: chatto.core.v1.UserAvatarSetEvent
+	(*UserAvatarClearedEvent)(nil),            // 28: chatto.core.v1.UserAvatarClearedEvent
+	(*UserVerifiedEmailAddedEvent)(nil),       // 29: chatto.core.v1.UserVerifiedEmailAddedEvent
+	(*UserPasswordHashChangedEvent)(nil),      // 30: chatto.core.v1.UserPasswordHashChangedEvent
+	(*UserOIDCSubjectLinkedEvent)(nil),        // 31: chatto.core.v1.UserOIDCSubjectLinkedEvent
+	(*UserServerPreferencesChangedEvent)(nil), // 32: chatto.core.v1.UserServerPreferencesChangedEvent
+	(*UserLoginCooldownClearedEvent)(nil),     // 33: chatto.core.v1.UserLoginCooldownClearedEvent
+	(*UserAccountDeletedEvent)(nil),           // 34: chatto.core.v1.UserAccountDeletedEvent
+	(*NotificationLevelChangedEvent)(nil),     // 35: chatto.core.v1.NotificationLevelChangedEvent
+	(*ServerCreatedEvent)(nil),                // 36: chatto.core.v1.ServerCreatedEvent
+	(*ServerUpdatedEvent)(nil),                // 37: chatto.core.v1.ServerUpdatedEvent
+	(*ServerDeletedEvent)(nil),                // 38: chatto.core.v1.ServerDeletedEvent
+	(*MessageEditedEvent)(nil),                // 39: chatto.core.v1.MessageEditedEvent
+	(*MessageRetractedEvent)(nil),             // 40: chatto.core.v1.MessageRetractedEvent
+	(*MessageUpdatedEvent)(nil),               // 41: chatto.core.v1.MessageUpdatedEvent
+	(*MessageDeletedEvent)(nil),               // 42: chatto.core.v1.MessageDeletedEvent
+	(*ReactionAddedEvent)(nil),                // 43: chatto.core.v1.ReactionAddedEvent
+	(*ReactionRemovedEvent)(nil),              // 44: chatto.core.v1.ReactionRemovedEvent
+	(*UserTypingEvent)(nil),                   // 45: chatto.core.v1.UserTypingEvent
+	(*PresenceChangedEvent)(nil),              // 46: chatto.core.v1.PresenceChangedEvent
+	(*MentionNotificationEvent)(nil),          // 47: chatto.core.v1.MentionNotificationEvent
+	(*NewDirectMessageNotificationEvent)(nil), // 48: chatto.core.v1.NewDirectMessageNotificationEvent
+	(*NotificationCreatedEvent)(nil),          // 49: chatto.core.v1.NotificationCreatedEvent
+	(*NotificationDismissedEvent)(nil),        // 50: chatto.core.v1.NotificationDismissedEvent
+	(*ThreadFollowChangedEvent)(nil),          // 51: chatto.core.v1.ThreadFollowChangedEvent
+	(*RoomMarkedAsReadEvent)(nil),             // 52: chatto.core.v1.RoomMarkedAsReadEvent
+	(*MentionStatusClearedEvent)(nil),         // 53: chatto.core.v1.MentionStatusClearedEvent
+	(*RoomGroupsUpdatedEvent)(nil),            // 54: chatto.core.v1.RoomGroupsUpdatedEvent
+	(*SessionTerminatedEvent)(nil),            // 55: chatto.core.v1.SessionTerminatedEvent
+	(*VideoProcessingCompletedEvent)(nil),     // 56: chatto.core.v1.VideoProcessingCompletedEvent
+	(*CallParticipantJoinedEvent)(nil),        // 57: chatto.core.v1.CallParticipantJoinedEvent
+	(*CallParticipantLeftEvent)(nil),          // 58: chatto.core.v1.CallParticipantLeftEvent
+	(*timestamppb.Timestamp)(nil),             // 59: google.protobuf.Timestamp
+	(RoomKind)(0),                             // 60: chatto.core.v1.RoomKind
+	(*MessageBody)(nil),                       // 61: chatto.core.v1.MessageBody
+	(*v1.ServerConfig)(nil),                   // 62: chatto.config.v1.ServerConfig
+	(TimeFormat)(0),                           // 63: chatto.core.v1.TimeFormat
+	(*Asset)(nil),                             // 64: chatto.core.v1.Asset
+	(*ServerUserPreferences)(nil),             // 65: chatto.core.v1.ServerUserPreferences
+	(NotificationLevel)(0),                    // 66: chatto.core.v1.NotificationLevel
 }
 var file_chatto_core_v1_event_proto_depIdxs = []int32{
-	48, // 0: chatto.core.v1.Event.created_at:type_name -> google.protobuf.Timestamp
+	59, // 0: chatto.core.v1.Event.created_at:type_name -> google.protobuf.Timestamp
 	2,  // 1: chatto.core.v1.Event.room_created:type_name -> chatto.core.v1.RoomCreatedEvent
 	3,  // 2: chatto.core.v1.Event.room_updated:type_name -> chatto.core.v1.RoomUpdatedEvent
 	4,  // 3: chatto.core.v1.Event.room_deleted:type_name -> chatto.core.v1.RoomDeletedEvent
@@ -3982,8 +4801,8 @@ var file_chatto_core_v1_event_proto_depIdxs = []int32{
 	8,  // 7: chatto.core.v1.Event.user_left_room:type_name -> chatto.core.v1.UserLeftRoomEvent
 	9,  // 8: chatto.core.v1.Event.space_member_deleted:type_name -> chatto.core.v1.SpaceMemberDeletedEvent
 	10, // 9: chatto.core.v1.Event.message_posted:type_name -> chatto.core.v1.MessagePostedEvent
-	28, // 10: chatto.core.v1.Event.message_edited:type_name -> chatto.core.v1.MessageEditedEvent
-	29, // 11: chatto.core.v1.Event.message_retracted:type_name -> chatto.core.v1.MessageRetractedEvent
+	39, // 10: chatto.core.v1.Event.message_edited:type_name -> chatto.core.v1.MessageEditedEvent
+	40, // 11: chatto.core.v1.Event.message_retracted:type_name -> chatto.core.v1.MessageRetractedEvent
 	11, // 12: chatto.core.v1.Event.server_config_changed:type_name -> chatto.core.v1.ServerConfigChangedEvent
 	12, // 13: chatto.core.v1.Event.room_group_created:type_name -> chatto.core.v1.RoomGroupCreatedEvent
 	13, // 14: chatto.core.v1.Event.room_group_updated:type_name -> chatto.core.v1.RoomGroupUpdatedEvent
@@ -3992,46 +4811,59 @@ var file_chatto_core_v1_event_proto_depIdxs = []int32{
 	16, // 17: chatto.core.v1.Event.room_removed_from_group:type_name -> chatto.core.v1.RoomRemovedFromGroupEvent
 	17, // 18: chatto.core.v1.Event.rooms_in_group_reordered:type_name -> chatto.core.v1.RoomsInGroupReorderedEvent
 	18, // 19: chatto.core.v1.Event.room_groups_reordered:type_name -> chatto.core.v1.RoomGroupsReorderedEvent
-	19, // 20: chatto.core.v1.Event.config_updated:type_name -> chatto.core.v1.ServerConfigUpdatedEvent
-	20, // 21: chatto.core.v1.Event.user_created:type_name -> chatto.core.v1.UserCreatedEvent
-	21, // 22: chatto.core.v1.Event.user_deleted:type_name -> chatto.core.v1.UserDeletedEvent
-	22, // 23: chatto.core.v1.Event.user_profile_updated:type_name -> chatto.core.v1.UserProfileUpdatedEvent
-	23, // 24: chatto.core.v1.Event.server_user_preferences_updated:type_name -> chatto.core.v1.ServerUserPreferencesUpdatedEvent
-	24, // 25: chatto.core.v1.Event.notification_level_changed:type_name -> chatto.core.v1.NotificationLevelChangedEvent
-	40, // 26: chatto.core.v1.Event.thread_follow_changed:type_name -> chatto.core.v1.ThreadFollowChangedEvent
-	25, // 27: chatto.core.v1.Event.server_created:type_name -> chatto.core.v1.ServerCreatedEvent
-	26, // 28: chatto.core.v1.Event.server_updated:type_name -> chatto.core.v1.ServerUpdatedEvent
-	27, // 29: chatto.core.v1.Event.server_deleted:type_name -> chatto.core.v1.ServerDeletedEvent
-	30, // 30: chatto.core.v1.Event.message_updated:type_name -> chatto.core.v1.MessageUpdatedEvent
-	31, // 31: chatto.core.v1.Event.message_deleted:type_name -> chatto.core.v1.MessageDeletedEvent
-	32, // 32: chatto.core.v1.Event.reaction_added:type_name -> chatto.core.v1.ReactionAddedEvent
-	33, // 33: chatto.core.v1.Event.reaction_removed:type_name -> chatto.core.v1.ReactionRemovedEvent
-	34, // 34: chatto.core.v1.Event.user_typing:type_name -> chatto.core.v1.UserTypingEvent
-	45, // 35: chatto.core.v1.Event.video_processing_completed:type_name -> chatto.core.v1.VideoProcessingCompletedEvent
-	35, // 36: chatto.core.v1.Event.presence_changed:type_name -> chatto.core.v1.PresenceChangedEvent
-	36, // 37: chatto.core.v1.Event.mention_notification:type_name -> chatto.core.v1.MentionNotificationEvent
-	37, // 38: chatto.core.v1.Event.new_direct_message_notification:type_name -> chatto.core.v1.NewDirectMessageNotificationEvent
-	46, // 39: chatto.core.v1.Event.call_participant_joined:type_name -> chatto.core.v1.CallParticipantJoinedEvent
-	47, // 40: chatto.core.v1.Event.call_participant_left:type_name -> chatto.core.v1.CallParticipantLeftEvent
-	38, // 41: chatto.core.v1.Event.notification_created:type_name -> chatto.core.v1.NotificationCreatedEvent
-	39, // 42: chatto.core.v1.Event.notification_dismissed:type_name -> chatto.core.v1.NotificationDismissedEvent
-	41, // 43: chatto.core.v1.Event.room_marked_as_read:type_name -> chatto.core.v1.RoomMarkedAsReadEvent
-	42, // 44: chatto.core.v1.Event.mention_status_cleared:type_name -> chatto.core.v1.MentionStatusClearedEvent
-	43, // 45: chatto.core.v1.Event.room_groups_updated:type_name -> chatto.core.v1.RoomGroupsUpdatedEvent
-	44, // 46: chatto.core.v1.Event.session_terminated:type_name -> chatto.core.v1.SessionTerminatedEvent
-	1,  // 47: chatto.core.v1.Event.heartbeat:type_name -> chatto.core.v1.HeartbeatEvent
-	49, // 48: chatto.core.v1.RoomCreatedEvent.kind:type_name -> chatto.core.v1.RoomKind
-	50, // 49: chatto.core.v1.MessagePostedEvent.body:type_name -> chatto.core.v1.MessageBody
-	51, // 50: chatto.core.v1.ServerConfigChangedEvent.config:type_name -> chatto.config.v1.ServerConfig
-	52, // 51: chatto.core.v1.ServerUserPreferencesUpdatedEvent.time_format:type_name -> chatto.core.v1.TimeFormat
-	53, // 52: chatto.core.v1.NotificationLevelChangedEvent.level:type_name -> chatto.core.v1.NotificationLevel
-	53, // 53: chatto.core.v1.NotificationLevelChangedEvent.effective_level:type_name -> chatto.core.v1.NotificationLevel
-	50, // 54: chatto.core.v1.MessageEditedEvent.body:type_name -> chatto.core.v1.MessageBody
-	55, // [55:55] is the sub-list for method output_type
-	55, // [55:55] is the sub-list for method input_type
-	55, // [55:55] is the sub-list for extension type_name
-	55, // [55:55] is the sub-list for extension extendee
-	0,  // [0:55] is the sub-list for field type_name
+	24, // 20: chatto.core.v1.Event.user_account_created:type_name -> chatto.core.v1.UserAccountCreatedEvent
+	25, // 21: chatto.core.v1.Event.user_login_changed:type_name -> chatto.core.v1.UserLoginChangedEvent
+	26, // 22: chatto.core.v1.Event.user_display_name_changed:type_name -> chatto.core.v1.UserDisplayNameChangedEvent
+	27, // 23: chatto.core.v1.Event.user_avatar_set:type_name -> chatto.core.v1.UserAvatarSetEvent
+	28, // 24: chatto.core.v1.Event.user_avatar_cleared:type_name -> chatto.core.v1.UserAvatarClearedEvent
+	29, // 25: chatto.core.v1.Event.user_verified_email_added:type_name -> chatto.core.v1.UserVerifiedEmailAddedEvent
+	30, // 26: chatto.core.v1.Event.user_password_hash_changed:type_name -> chatto.core.v1.UserPasswordHashChangedEvent
+	31, // 27: chatto.core.v1.Event.user_oidc_subject_linked:type_name -> chatto.core.v1.UserOIDCSubjectLinkedEvent
+	32, // 28: chatto.core.v1.Event.user_server_preferences_changed:type_name -> chatto.core.v1.UserServerPreferencesChangedEvent
+	33, // 29: chatto.core.v1.Event.user_login_cooldown_cleared:type_name -> chatto.core.v1.UserLoginCooldownClearedEvent
+	34, // 30: chatto.core.v1.Event.user_account_deleted:type_name -> chatto.core.v1.UserAccountDeletedEvent
+	19, // 31: chatto.core.v1.Event.config_updated:type_name -> chatto.core.v1.ServerConfigUpdatedEvent
+	20, // 32: chatto.core.v1.Event.user_created:type_name -> chatto.core.v1.UserCreatedEvent
+	21, // 33: chatto.core.v1.Event.user_deleted:type_name -> chatto.core.v1.UserDeletedEvent
+	22, // 34: chatto.core.v1.Event.user_profile_updated:type_name -> chatto.core.v1.UserProfileUpdatedEvent
+	23, // 35: chatto.core.v1.Event.server_user_preferences_updated:type_name -> chatto.core.v1.ServerUserPreferencesUpdatedEvent
+	35, // 36: chatto.core.v1.Event.notification_level_changed:type_name -> chatto.core.v1.NotificationLevelChangedEvent
+	51, // 37: chatto.core.v1.Event.thread_follow_changed:type_name -> chatto.core.v1.ThreadFollowChangedEvent
+	36, // 38: chatto.core.v1.Event.server_created:type_name -> chatto.core.v1.ServerCreatedEvent
+	37, // 39: chatto.core.v1.Event.server_updated:type_name -> chatto.core.v1.ServerUpdatedEvent
+	38, // 40: chatto.core.v1.Event.server_deleted:type_name -> chatto.core.v1.ServerDeletedEvent
+	41, // 41: chatto.core.v1.Event.message_updated:type_name -> chatto.core.v1.MessageUpdatedEvent
+	42, // 42: chatto.core.v1.Event.message_deleted:type_name -> chatto.core.v1.MessageDeletedEvent
+	43, // 43: chatto.core.v1.Event.reaction_added:type_name -> chatto.core.v1.ReactionAddedEvent
+	44, // 44: chatto.core.v1.Event.reaction_removed:type_name -> chatto.core.v1.ReactionRemovedEvent
+	45, // 45: chatto.core.v1.Event.user_typing:type_name -> chatto.core.v1.UserTypingEvent
+	56, // 46: chatto.core.v1.Event.video_processing_completed:type_name -> chatto.core.v1.VideoProcessingCompletedEvent
+	46, // 47: chatto.core.v1.Event.presence_changed:type_name -> chatto.core.v1.PresenceChangedEvent
+	47, // 48: chatto.core.v1.Event.mention_notification:type_name -> chatto.core.v1.MentionNotificationEvent
+	48, // 49: chatto.core.v1.Event.new_direct_message_notification:type_name -> chatto.core.v1.NewDirectMessageNotificationEvent
+	57, // 50: chatto.core.v1.Event.call_participant_joined:type_name -> chatto.core.v1.CallParticipantJoinedEvent
+	58, // 51: chatto.core.v1.Event.call_participant_left:type_name -> chatto.core.v1.CallParticipantLeftEvent
+	49, // 52: chatto.core.v1.Event.notification_created:type_name -> chatto.core.v1.NotificationCreatedEvent
+	50, // 53: chatto.core.v1.Event.notification_dismissed:type_name -> chatto.core.v1.NotificationDismissedEvent
+	52, // 54: chatto.core.v1.Event.room_marked_as_read:type_name -> chatto.core.v1.RoomMarkedAsReadEvent
+	53, // 55: chatto.core.v1.Event.mention_status_cleared:type_name -> chatto.core.v1.MentionStatusClearedEvent
+	54, // 56: chatto.core.v1.Event.room_groups_updated:type_name -> chatto.core.v1.RoomGroupsUpdatedEvent
+	55, // 57: chatto.core.v1.Event.session_terminated:type_name -> chatto.core.v1.SessionTerminatedEvent
+	1,  // 58: chatto.core.v1.Event.heartbeat:type_name -> chatto.core.v1.HeartbeatEvent
+	60, // 59: chatto.core.v1.RoomCreatedEvent.kind:type_name -> chatto.core.v1.RoomKind
+	61, // 60: chatto.core.v1.MessagePostedEvent.body:type_name -> chatto.core.v1.MessageBody
+	62, // 61: chatto.core.v1.ServerConfigChangedEvent.config:type_name -> chatto.config.v1.ServerConfig
+	63, // 62: chatto.core.v1.ServerUserPreferencesUpdatedEvent.time_format:type_name -> chatto.core.v1.TimeFormat
+	64, // 63: chatto.core.v1.UserAvatarSetEvent.avatar:type_name -> chatto.core.v1.Asset
+	65, // 64: chatto.core.v1.UserServerPreferencesChangedEvent.preferences:type_name -> chatto.core.v1.ServerUserPreferences
+	66, // 65: chatto.core.v1.NotificationLevelChangedEvent.level:type_name -> chatto.core.v1.NotificationLevel
+	66, // 66: chatto.core.v1.NotificationLevelChangedEvent.effective_level:type_name -> chatto.core.v1.NotificationLevel
+	61, // 67: chatto.core.v1.MessageEditedEvent.body:type_name -> chatto.core.v1.MessageBody
+	68, // [68:68] is the sub-list for method output_type
+	68, // [68:68] is the sub-list for method input_type
+	68, // [68:68] is the sub-list for extension type_name
+	68, // [68:68] is the sub-list for extension extendee
+	0,  // [0:68] is the sub-list for field type_name
 }
 
 func init() { file_chatto_core_v1_event_proto_init() }
@@ -4061,6 +4893,17 @@ func file_chatto_core_v1_event_proto_init() {
 		(*Event_RoomRemovedFromGroup)(nil),
 		(*Event_RoomsInGroupReordered)(nil),
 		(*Event_RoomGroupsReordered)(nil),
+		(*Event_UserAccountCreated)(nil),
+		(*Event_UserLoginChanged)(nil),
+		(*Event_UserDisplayNameChanged)(nil),
+		(*Event_UserAvatarSet)(nil),
+		(*Event_UserAvatarCleared)(nil),
+		(*Event_UserVerifiedEmailAdded)(nil),
+		(*Event_UserPasswordHashChanged)(nil),
+		(*Event_UserOidcSubjectLinked)(nil),
+		(*Event_UserServerPreferencesChanged)(nil),
+		(*Event_UserLoginCooldownCleared)(nil),
+		(*Event_UserAccountDeleted)(nil),
 		(*Event_ConfigUpdated)(nil),
 		(*Event_UserCreated)(nil),
 		(*Event_UserDeleted)(nil),
@@ -4090,14 +4933,14 @@ func file_chatto_core_v1_event_proto_init() {
 		(*Event_SessionTerminated)(nil),
 		(*Event_Heartbeat)(nil),
 	}
-	file_chatto_core_v1_event_proto_msgTypes[34].OneofWrappers = []any{}
+	file_chatto_core_v1_event_proto_msgTypes[45].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_core_v1_event_proto_rawDesc), len(file_chatto_core_v1_event_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   48,
+			NumMessages:   59,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/chatto/core/v1/event.proto
+++ b/proto/chatto/core/v1/event.proto
@@ -126,6 +126,7 @@ message Event {
     UserServerPreferencesChangedEvent user_server_preferences_changed = 708;
     UserLoginCooldownClearedEvent user_login_cooldown_cleared = 709;
     UserAccountDeletedEvent user_account_deleted = 710;
+    UserLoginCooldownStartedEvent user_login_cooldown_started = 711;
 
     // =================================================================
     // LIVE-ONLY VARIANTS (>= 1000) — never persisted.
@@ -502,9 +503,6 @@ message UserAccountCreatedEvent {
 message UserLoginChangedEvent {
   string user_id = 1;
   string login = 2;
-  // True when this user-initiated login change advances the cooldown.
-  // The cooldown timestamp is the envelope created_at.
-  bool advances_cooldown = 3;
 }
 
 message UserDisplayNameChangedEvent {
@@ -543,6 +541,10 @@ message UserOIDCSubjectLinkedEvent {
 message UserServerPreferencesChangedEvent {
   string user_id = 1;
   ServerUserPreferences preferences = 2;
+}
+
+message UserLoginCooldownStartedEvent {
+  string user_id = 1;
 }
 
 message UserLoginCooldownClearedEvent {

--- a/proto/chatto/core/v1/event.proto
+++ b/proto/chatto/core/v1/event.proto
@@ -114,6 +114,19 @@ message Event {
     // tracks explicit reorders.
     RoomGroupsReorderedEvent room_groups_reordered = 650;
 
+    // ----- Users (700-719, durable, evt.user.{userId}) -----
+    UserAccountCreatedEvent user_account_created = 700;
+    UserLoginChangedEvent user_login_changed = 701;
+    UserDisplayNameChangedEvent user_display_name_changed = 702;
+    UserAvatarSetEvent user_avatar_set = 703;
+    UserAvatarClearedEvent user_avatar_cleared = 704;
+    UserVerifiedEmailAddedEvent user_verified_email_added = 705;
+    UserPasswordHashChangedEvent user_password_hash_changed = 706;
+    UserOIDCSubjectLinkedEvent user_oidc_subject_linked = 707;
+    UserServerPreferencesChangedEvent user_server_preferences_changed = 708;
+    UserLoginCooldownClearedEvent user_login_cooldown_cleared = 709;
+    UserAccountDeletedEvent user_account_deleted = 710;
+
     // =================================================================
     // LIVE-ONLY VARIANTS (>= 1000) — never persisted.
     // These ride NATS Core only; field numbers can be renumbered
@@ -474,6 +487,70 @@ message ServerUserPreferencesUpdatedEvent {
   string timezone = 1;
   // Time display format preference.
   TimeFormat time_format = 2;
+}
+
+// ============================================================================
+// DURABLE USER EVENTS (evt.user.{userId})
+// ============================================================================
+
+message UserAccountCreatedEvent {
+  string user_id = 1;
+  string login = 2;
+  string display_name = 3;
+}
+
+message UserLoginChangedEvent {
+  string user_id = 1;
+  string login = 2;
+  // True when this user-initiated login change advances the cooldown.
+  // The cooldown timestamp is the envelope created_at.
+  bool advances_cooldown = 3;
+}
+
+message UserDisplayNameChangedEvent {
+  string user_id = 1;
+  string display_name = 2;
+}
+
+message UserAvatarSetEvent {
+  string user_id = 1;
+  Asset avatar = 2;
+}
+
+message UserAvatarClearedEvent {
+  string user_id = 1;
+}
+
+message UserVerifiedEmailAddedEvent {
+  string user_id = 1;
+  string email = 2;
+}
+
+message UserPasswordHashChangedEvent {
+  string user_id = 1;
+  bytes password_hash = 2;
+}
+
+message UserOIDCSubjectLinkedEvent {
+  string user_id = 1;
+  // New writes include issuer/subject so the event is inspectable. Legacy
+  // imports may only have the hash, because the old KV index key is one-way.
+  string issuer = 2;
+  string subject = 3;
+  string subject_hash = 4;
+}
+
+message UserServerPreferencesChangedEvent {
+  string user_id = 1;
+  ServerUserPreferences preferences = 2;
+}
+
+message UserLoginCooldownClearedEvent {
+  string user_id = 1;
+}
+
+message UserAccountDeletedEvent {
+  string user_id = 1;
 }
 
 // NotificationLevelChangedEvent is published when a user changes their notification


### PR DESCRIPTION
Migrates user account state to the event-sourced EVT stream with a UserProjection-backed read model. Adds protobuf user account/profile/auth events, event subjects, boot-time import from legacy user KV state, and projection boot verification. Updates user mutations for login, display name, avatar, preferences, emails, OIDC links, password changes, and deletion to append durable events instead of maintaining legacy user state. Splits user login changes from login cooldown starts so the cooldown is represented as its own event while preserving envelope timestamps.