### PR TITLE
chore: trust mise in Conductor worktrees

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,5 +1,6 @@
 {
     "scripts": {
+        "setup": "mise trust",
         "run": "VITE_PORT=$CONDUCTOR_PORT CHATTO_WEBSERVER_PORT=$((CONDUCTOR_PORT+1)) CHATTO_WEBSERVER_URL=http://localhost:$CONDUCTOR_PORT CHATTO_NATS_EMBEDDED_PORT=$((CONDUCTOR_PORT+2)) mise dev"
     }
 }


### PR DESCRIPTION
Adds a Conductor setup script that runs `mise trust` whenever a new workspace is created. This lets new worktrees trust the repository's mise configuration before developers or agents run the existing `mise dev` run script. Validation: checked the PR diff against `origin/main`.