### PR TITLE
ci: run frontend typecheck in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
         run: cd frontend && pnpm exec playwright install chromium --with-deps
         timeout-minutes: 5
 
+      - name: Run frontend typecheck
+        run: cd frontend && pnpm check
+
       - name: Run frontend unit tests
         run: cd frontend && pnpm vitest --run
 


### PR DESCRIPTION
## Summary
- Add a frontend typecheck step to the CI frontend unit-test job before Vitest runs.
- This uses the existing `pnpm check` script so Svelte and TypeScript diagnostics are enforced in PR CI.

## Verification
- Ran `mise x -- pnpm --dir frontend check` successfully; it reported 0 errors and 4 existing warnings in `Utilities.stories.svelte`.