### PR TITLE
Event-source RBAC state

### DIFF
--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -157,6 +157,14 @@ type ChattoCore struct {
 	// WaitForSeq from user/account writers.
 	UsersProjector *events.Projector
 
+	// RBAC holds current role, assignment, and permission state derived
+	// from durable RBAC aggregate events.
+	RBAC *RBACProjection
+
+	// RBACProjector runs the consumer for RBAC. Exposed for WaitForSeq
+	// from role and permission writers.
+	RBACProjector *events.Projector
+
 	// projectors is the set of all event-sourcing projectors owned by
 	// this core. Each new aggregate migration (ADR-035) appends here
 	// during NewChattoCore; Run iterates the slice. Adding a projector
@@ -603,6 +611,9 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	users := NewUserProjection()
 	usersProjector := newProjector(users, "UsersProjector")
 
+	rbac := NewRBACProjection()
+	rbacProjector := newProjector(rbac, "RBACProjector")
+
 	// ConfigManager owns event-only server-config writes; it needs the
 	// publisher (for ServerConfigChangedEvent), the projector
 	// (WaitForSeq for read-your-writes), and the projection (for reads).
@@ -636,8 +647,14 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 		ReactionsProjector:      reactionsProjector,
 		Users:                   users,
 		UsersProjector:          usersProjector,
+		RBAC:                    rbac,
+		RBACProjector:           rbacProjector,
 		projectors:              projectors,
 		bootDone:                make(chan struct{}),
+	}
+
+	if err := core.migrateRBACToES(ctx); err != nil {
+		return nil, fmt.Errorf("failed to migrate RBAC to ES: %w", err)
 	}
 
 	// Run boot-time data migrations. Idempotent and cheap on subsequent
@@ -670,11 +687,6 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	core.linkPreviewCache = linkPreviewCache
 	assetsConfig := core.AssetsConfig()
 	core.linkPreviewFetcher = linkpreview.NewFetcher(storage.serverStore, &assetsConfig, NewAssetID)
-
-	// Initialize server-level RBAC (roles and permissions)
-	if err := core.initServerRBAC(ctx); err != nil {
-		return nil, fmt.Errorf("failed to initialize server RBAC: %w", err)
-	}
 
 	// ensureChannelRoomsAreInAGroup is deferred to core.Run() — it
 	// needs the projectors to be live so its CreateRoomGroup /

--- a/cli/internal/core/es_boot_verification.go
+++ b/cli/internal/core/es_boot_verification.go
@@ -37,6 +37,7 @@ type esLegacyCounts struct {
 	verifiedEmails      int
 	oidcSubjects        int
 	encryptionKeys      int
+	rbacKeys            int
 }
 
 type esProjectedCounts struct {
@@ -59,6 +60,9 @@ type esProjectedCounts struct {
 	users                  int
 	verifiedEmails         int
 	oidcSubjects           int
+	rbacRoles              int
+	rbacAssignments        int
+	rbacDecisions          int
 }
 
 // logESBootVerification emits a structured summary of the ES import and
@@ -95,6 +99,10 @@ func (c *ChattoCore) logESBootVerification(ctx context.Context) {
 		"projected_verified_emails", report.projected.verifiedEmails,
 		"legacy_oidc_subjects", report.legacy.oidcSubjects,
 		"projected_oidc_subjects", report.projected.oidcSubjects,
+		"legacy_rbac_keys", report.legacy.rbacKeys,
+		"projected_rbac_roles", report.projected.rbacRoles,
+		"projected_rbac_assignments", report.projected.rbacAssignments,
+		"projected_rbac_decisions", report.projected.rbacDecisions,
 		"server_config_legacy", report.legacy.serverConfigPresent,
 		"server_config_projected", report.projected.serverConfigConfigured,
 		"room_layout_legacy", report.legacy.roomLayoutPresent,
@@ -203,6 +211,10 @@ func (c *ChattoCore) collectLegacyESCounts(ctx context.Context) (esLegacyCounts,
 	if err != nil {
 		return counts, warnings, fmt.Errorf("count encryption keys: %w", err)
 	}
+	counts.rbacKeys, err = countKVKeys(ctx, c.storage.serverRBACKV)
+	if err != nil {
+		return counts, warnings, fmt.Errorf("count legacy RBAC keys: %w", err)
+	}
 	if counts.encryptionKeys == 0 {
 		warnings = append(warnings, "ENCRYPTION_KEYS is empty; encrypted message bodies will not decrypt in local smoke tests")
 	}
@@ -215,6 +227,7 @@ func (c *ChattoCore) collectProjectedESCounts() esProjectedCounts {
 	threads, threadEntries, threadReplies := c.Threads.Stats()
 	reactionMessages, activeReactions := c.Reactions.Stats()
 	users, verifiedEmails, oidcSubjects := c.Users.Stats()
+	rbacRoles, rbacAssignments, rbacDecisions := c.RBAC.CountStats()
 	_, serverConfigConfigured := c.ServerConfig.Get()
 
 	return esProjectedCounts{
@@ -237,6 +250,9 @@ func (c *ChattoCore) collectProjectedESCounts() esProjectedCounts {
 		users:                  users,
 		verifiedEmails:         verifiedEmails,
 		oidcSubjects:           oidcSubjects,
+		rbacRoles:              rbacRoles,
+		rbacAssignments:        rbacAssignments,
+		rbacDecisions:          rbacDecisions,
 	}
 }
 
@@ -261,6 +277,12 @@ func (c *ChattoCore) evaluateESBootVerificationReport(r *esBootVerificationRepor
 	}
 	if r.legacy.roomLayoutPresent && r.projected.roomGroups > 0 && r.projected.roomLayoutGroups == 0 {
 		r.problems = append(r.problems, "room layout: legacy room_layout exists but projected layout ordering is empty")
+	}
+	if r.legacy.rbacKeys > 0 && r.projected.rbacRoles == 0 {
+		r.problems = append(r.problems, "RBAC: projection has no roles")
+	}
+	if r.legacy.rbacKeys > 0 && r.projected.rbacDecisions == 0 {
+		r.problems = append(r.problems, "RBAC: projection has no permission decisions")
 	}
 	if r.decodeErrors > 0 {
 		r.problems = append(r.problems, fmt.Sprintf("EVT contains %d decode errors", r.decodeErrors))

--- a/cli/internal/core/permission_ops.go
+++ b/cli/internal/core/permission_ops.go
@@ -2,10 +2,9 @@ package core
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
-	"github.com/nats-io/nats.go/jetstream"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
 // ============================================================================
@@ -31,7 +30,11 @@ func (c *ChattoCore) GrantServerPermission(ctx context.Context, roleName string,
 	if err := ValidatePermission(perm); err != nil {
 		return err
 	}
-	return c.storage.serverRBACEngine.Grant(ctx, ScopeServer, "", roleName, perm)
+	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionGranted{
+		RbacPermissionGranted: rbacPermissionGrantedEvent(ScopeServer, "", roleName, perm),
+	}})
+	_, err := c.appendRBACEvent(ctx, event, nil)
+	return err
 }
 
 // DenyServerPermission denies a permission at a role's server-level default.
@@ -39,20 +42,28 @@ func (c *ChattoCore) DenyServerPermission(ctx context.Context, roleName string, 
 	if err := ValidatePermission(perm); err != nil {
 		return err
 	}
-	return c.storage.serverRBACEngine.Deny(ctx, ScopeServer, "", roleName, perm)
+	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionDenied{
+		RbacPermissionDenied: rbacPermissionDeniedEvent(ScopeServer, "", roleName, perm),
+	}})
+	_, err := c.appendRBACEvent(ctx, event, nil)
+	return err
 }
 
 // ClearServerPermissionState clears both grant and denial for a permission.
 func (c *ChattoCore) ClearServerPermissionState(ctx context.Context, roleName string, perm Permission) error {
-	return c.storage.serverRBACEngine.Clear(ctx, ScopeServer, "", roleName, perm)
+	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionCleared{
+		RbacPermissionCleared: rbacPermissionClearedEvent(ScopeServer, "", roleName, perm),
+	}})
+	_, err := c.appendRBACEvent(ctx, event, nil)
+	return err
 }
 
 // ----------------------------------------------------------------------------
 // User-level overrides
 // ----------------------------------------------------------------------------
 //
-// User-level grants/denies sit alongside role-based grants in the same KV.
-// The walker consults user-level decisions FIRST (before any role), so an
+// User-level grants/denies sit alongside role-based decisions in the RBAC
+// projection. The walker consults user-level decisions FIRST (before any role), so an
 // explicit user-deny blocks the action even for owners and an explicit
 // user-grant allows it even when no role grants it.
 
@@ -61,7 +72,11 @@ func (c *ChattoCore) GrantUserPermission(ctx context.Context, userID string, per
 	if err := ValidatePermission(perm); err != nil {
 		return err
 	}
-	return c.storage.serverRBACEngine.Grant(ctx, ScopeServer, "", userID, perm)
+	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionGranted{
+		RbacPermissionGranted: rbacPermissionGrantedEvent(ScopeServer, "", userID, perm),
+	}})
+	_, err := c.appendRBACEvent(ctx, event, nil)
+	return err
 }
 
 // DenyUserPermission denies a permission directly to a user at server scope.
@@ -69,13 +84,21 @@ func (c *ChattoCore) DenyUserPermission(ctx context.Context, userID string, perm
 	if err := ValidatePermission(perm); err != nil {
 		return err
 	}
-	return c.storage.serverRBACEngine.Deny(ctx, ScopeServer, "", userID, perm)
+	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionDenied{
+		RbacPermissionDenied: rbacPermissionDeniedEvent(ScopeServer, "", userID, perm),
+	}})
+	_, err := c.appendRBACEvent(ctx, event, nil)
+	return err
 }
 
 // ClearUserPermissionState clears both the grant and denial for a user-level
 // permission at server scope.
 func (c *ChattoCore) ClearUserPermissionState(ctx context.Context, userID string, perm Permission) error {
-	return c.storage.serverRBACEngine.Clear(ctx, ScopeServer, "", userID, perm)
+	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionCleared{
+		RbacPermissionCleared: rbacPermissionClearedEvent(ScopeServer, "", userID, perm),
+	}})
+	_, err := c.appendRBACEvent(ctx, event, nil)
+	return err
 }
 
 // GrantUserRoomPermission grants a permission directly to a user for a specific room.
@@ -83,7 +106,11 @@ func (c *ChattoCore) GrantUserRoomPermission(ctx context.Context, roomID, userID
 	if !PermissionAppliesAtScope(perm, ScopeRoom) {
 		return fmt.Errorf("permission %s does not apply at room scope", perm)
 	}
-	return c.storage.serverRBACEngine.Grant(ctx, ScopeRoom, roomID, userID, perm)
+	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionGranted{
+		RbacPermissionGranted: rbacPermissionGrantedEvent(ScopeRoom, roomID, userID, perm),
+	}})
+	_, err := c.appendRBACEvent(ctx, event, nil)
+	return err
 }
 
 // DenyUserRoomPermission denies a permission directly to a user for a specific room.
@@ -91,13 +118,21 @@ func (c *ChattoCore) DenyUserRoomPermission(ctx context.Context, roomID, userID 
 	if !PermissionAppliesAtScope(perm, ScopeRoom) {
 		return fmt.Errorf("permission %s does not apply at room scope", perm)
 	}
-	return c.storage.serverRBACEngine.Deny(ctx, ScopeRoom, roomID, userID, perm)
+	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionDenied{
+		RbacPermissionDenied: rbacPermissionDeniedEvent(ScopeRoom, roomID, userID, perm),
+	}})
+	_, err := c.appendRBACEvent(ctx, event, nil)
+	return err
 }
 
 // ClearUserRoomPermissionState clears both the grant and denial for a
 // user-level permission for a specific room.
 func (c *ChattoCore) ClearUserRoomPermissionState(ctx context.Context, roomID, userID string, perm Permission) error {
-	return c.storage.serverRBACEngine.Clear(ctx, ScopeRoom, roomID, userID, perm)
+	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionCleared{
+		RbacPermissionCleared: rbacPermissionClearedEvent(ScopeRoom, roomID, userID, perm),
+	}})
+	_, err := c.appendRBACEvent(ctx, event, nil)
+	return err
 }
 
 // GrantUserGroupPermission grants a permission directly to a user at a room
@@ -106,7 +141,11 @@ func (c *ChattoCore) GrantUserGroupPermission(ctx context.Context, groupID, user
 	if !PermissionAppliesAtScope(perm, ScopeGroup) && !PermissionAppliesAtScope(perm, ScopeRoom) {
 		return fmt.Errorf("permission %s does not apply at group scope", perm)
 	}
-	return c.storage.serverRBACEngine.Grant(ctx, ScopeGroup, groupID, userID, perm)
+	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionGranted{
+		RbacPermissionGranted: rbacPermissionGrantedEvent(ScopeGroup, groupID, userID, perm),
+	}})
+	_, err := c.appendRBACEvent(ctx, event, nil)
+	return err
 }
 
 // DenyUserGroupPermission denies a permission directly to a user at a room
@@ -115,13 +154,21 @@ func (c *ChattoCore) DenyUserGroupPermission(ctx context.Context, groupID, userI
 	if !PermissionAppliesAtScope(perm, ScopeGroup) && !PermissionAppliesAtScope(perm, ScopeRoom) {
 		return fmt.Errorf("permission %s does not apply at group scope", perm)
 	}
-	return c.storage.serverRBACEngine.Deny(ctx, ScopeGroup, groupID, userID, perm)
+	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionDenied{
+		RbacPermissionDenied: rbacPermissionDeniedEvent(ScopeGroup, groupID, userID, perm),
+	}})
+	_, err := c.appendRBACEvent(ctx, event, nil)
+	return err
 }
 
 // ClearUserGroupPermissionState clears both the grant and denial for a
 // user-level permission at a specific room group's scope.
 func (c *ChattoCore) ClearUserGroupPermissionState(ctx context.Context, groupID, userID string, perm Permission) error {
-	return c.storage.serverRBACEngine.Clear(ctx, ScopeGroup, groupID, userID, perm)
+	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionCleared{
+		RbacPermissionCleared: rbacPermissionClearedEvent(ScopeGroup, groupID, userID, perm),
+	}})
+	_, err := c.appendRBACEvent(ctx, event, nil)
+	return err
 }
 
 // ----------------------------------------------------------------------------
@@ -133,7 +180,11 @@ func (c *ChattoCore) GrantRoomPermission(ctx context.Context, roomID, roleName s
 	if !PermissionAppliesAtScope(perm, ScopeRoom) {
 		return fmt.Errorf("permission %s does not apply at room scope", perm)
 	}
-	return c.storage.serverRBACEngine.Grant(ctx, ScopeRoom, roomID, roleName, perm)
+	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionGranted{
+		RbacPermissionGranted: rbacPermissionGrantedEvent(ScopeRoom, roomID, roleName, perm),
+	}})
+	_, err := c.appendRBACEvent(ctx, event, nil)
+	return err
 }
 
 // DenyRoomPermission denies a permission for a role at a specific room.
@@ -141,13 +192,21 @@ func (c *ChattoCore) DenyRoomPermission(ctx context.Context, roomID, roleName st
 	if !PermissionAppliesAtScope(perm, ScopeRoom) {
 		return fmt.Errorf("permission %s does not apply at room scope", perm)
 	}
-	return c.storage.serverRBACEngine.Deny(ctx, ScopeRoom, roomID, roleName, perm)
+	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionDenied{
+		RbacPermissionDenied: rbacPermissionDeniedEvent(ScopeRoom, roomID, roleName, perm),
+	}})
+	_, err := c.appendRBACEvent(ctx, event, nil)
+	return err
 }
 
 // ClearRoomPermissionState removes both grant and denial for a permission at
 // room level.
 func (c *ChattoCore) ClearRoomPermissionState(ctx context.Context, roomID, roleName string, perm Permission) error {
-	return c.storage.serverRBACEngine.Clear(ctx, ScopeRoom, roomID, roleName, perm)
+	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionCleared{
+		RbacPermissionCleared: rbacPermissionClearedEvent(ScopeRoom, roomID, roleName, perm),
+	}})
+	_, err := c.appendRBACEvent(ctx, event, nil)
+	return err
 }
 
 // ----------------------------------------------------------------------------
@@ -158,45 +217,19 @@ func (c *ChattoCore) ClearRoomPermissionState(ctx context.Context, roomID, roleN
 // allow/deny at server scope for the given permission, or DecisionNone when
 // there's no user-level override.
 func (c *ChattoCore) GetUserExplicitServerOverride(ctx context.Context, userID string, perm Permission) (DecisionKind, error) {
-	return c.probeUserExplicit(ctx,
-		AllowKey(userID, perm.KeyParts().Verb, perm.KeyParts().ObjectType, ObjectIdAny),
-		DenyKey(userID, perm.KeyParts().Verb, perm.KeyParts().ObjectType, ObjectIdAny))
+	return c.RBAC.GetDecision(ScopeServer, "", userID, perm), nil
 }
 
 // GetUserExplicitGroupOverride returns the user's explicit user-level
 // allow/deny at the given room group's scope, or DecisionNone.
 func (c *ChattoCore) GetUserExplicitGroupOverride(ctx context.Context, groupID, userID string, perm Permission) (DecisionKind, error) {
-	return c.probeUserExplicit(ctx,
-		GroupAllowKey(groupID, userID, perm.KeyParts().Verb, perm.KeyParts().ObjectType),
-		GroupDenyKey(groupID, userID, perm.KeyParts().Verb, perm.KeyParts().ObjectType))
+	return c.RBAC.GetDecision(ScopeGroup, groupID, userID, perm), nil
 }
 
 // GetUserExplicitRoomOverride returns the user's explicit user-level
 // allow/deny at the given room's scope, or DecisionNone.
 func (c *ChattoCore) GetUserExplicitRoomOverride(ctx context.Context, roomID, userID string, perm Permission) (DecisionKind, error) {
-	return c.probeUserExplicit(ctx,
-		RoomAllowKey(roomID, userID, perm.KeyParts().Verb, perm.KeyParts().ObjectType),
-		RoomDenyKey(roomID, userID, perm.KeyParts().Verb, perm.KeyParts().ObjectType))
-}
-
-// probeUserExplicit checks an (allow, deny) key pair on SERVER_RBAC and
-// returns DecisionAllow / DecisionDeny / DecisionNone. The allow key is
-// preferred when both are somehow present — the write path keeps them
-// mutually exclusive, so that should never happen, but choosing
-// deterministically here keeps the read side robust.
-func (c *ChattoCore) probeUserExplicit(ctx context.Context, allowKey, denyKey string) (DecisionKind, error) {
-	kv := c.storage.serverRBACEngine.KV()
-	if _, err := kv.Get(ctx, allowKey); err == nil {
-		return DecisionAllow, nil
-	} else if !errors.Is(err, jetstream.ErrKeyNotFound) {
-		return DecisionNone, fmt.Errorf("probe allow %s: %w", allowKey, err)
-	}
-	if _, err := kv.Get(ctx, denyKey); err == nil {
-		return DecisionDeny, nil
-	} else if !errors.Is(err, jetstream.ErrKeyNotFound) {
-		return DecisionNone, fmt.Errorf("probe deny %s: %w", denyKey, err)
-	}
-	return DecisionNone, nil
+	return c.RBAC.GetDecision(ScopeRoom, roomID, userID, perm), nil
 }
 
 // ============================================================================
@@ -229,7 +262,7 @@ func (c *ChattoCore) SetupAnnouncementsRoomPermissions(ctx context.Context, room
 // ============================================================================
 
 // InitDefaultPermissions seeds the system roles with their default permission
-// grants in SERVER_RBAC. Idempotent — safe to call on every boot.
+// grants through RBAC events. Idempotent at the projection level.
 //
 // Owner and Admin receive the same enumerated permission set
 // (`DefaultOwnerPermissions` / `DefaultAdminPermissions`). They are
@@ -314,23 +347,8 @@ func (c *ChattoCore) grantSetPermissionIfMissing(ctx context.Context, groupID, r
 	if parts.Verb == "" || parts.ObjectType == "" {
 		return fmt.Errorf("invalid permission: %s", perm)
 	}
-	kv := c.storage.serverRBACEngine.KV()
-
-	allowKey := GroupAllowKey(groupID, roleName, parts.Verb, parts.ObjectType)
-	denyKey := GroupDenyKey(groupID, roleName, parts.Verb, parts.ObjectType)
-
-	// If a deny already exists, leave the operator's choice alone.
-	if _, err := kv.Get(ctx, denyKey); err == nil {
+	if c.RBAC.GetDecision(ScopeGroup, groupID, roleName, perm) != DecisionNone {
 		return nil
-	} else if !errors.Is(err, jetstream.ErrKeyNotFound) {
-		return fmt.Errorf("check existing deny: %w", err)
 	}
-
-	// kv.Create fails if the allow key already exists — that's the
-	// idempotency boundary; we don't overwrite operator edits.
-	_, err := kv.Create(ctx, allowKey, []byte("1"))
-	if err != nil && !errors.Is(err, jetstream.ErrKeyExists) {
-		return fmt.Errorf("create allow: %w", err)
-	}
-	return nil
+	return c.GrantGroupPermission(ctx, groupID, roleName, perm)
 }

--- a/cli/internal/core/permission_ops_test.go
+++ b/cli/internal/core/permission_ops_test.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"testing"
-
 )
 
 // Helper to construct expected allow key from permission
@@ -38,18 +37,14 @@ func TestGrantServerPermission(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	t.Run("creates correct KV key for valid permission", func(t *testing.T) {
+	t.Run("creates allow decision for valid permission", func(t *testing.T) {
 		err := core.GrantServerPermission(ctx, RoleModerator, PermDMWrite)
 		if err != nil {
 			t.Fatalf("GrantServerPermission() error = %v", err)
 		}
 
-		// Verify key was created
-		kv := core.storage.serverRBACEngine.KV()
-		expectedKey := expectedAllowKey(RoleModerator, PermDMWrite, ObjectIdAny)
-		_, err = kv.Get(ctx, expectedKey)
-		if err != nil {
-			t.Errorf("Expected KV key %s to exist, got error: %v", expectedKey, err)
+		if got := core.RBAC.GetDecision(ScopeServer, "", RoleModerator, PermDMWrite); got != DecisionAllow {
+			t.Errorf("decision = %s, want %s", got, DecisionAllow)
 		}
 	})
 
@@ -66,12 +61,8 @@ func TestGrantServerPermission(t *testing.T) {
 			t.Fatalf("GrantServerPermission() error = %v", err)
 		}
 
-		// Verify denial was removed
-		kv := core.storage.serverRBACEngine.KV()
-		denyKey := expectedDenyKey(RoleModerator, PermDMView, ObjectIdAny)
-		_, err = kv.Get(ctx, denyKey)
-		if err == nil {
-			t.Error("Expected denial key to be removed after grant")
+		if got := core.RBAC.GetDecision(ScopeServer, "", RoleModerator, PermDMView); got != DecisionAllow {
+			t.Errorf("decision = %s, want %s", got, DecisionAllow)
 		}
 	})
 
@@ -87,18 +78,14 @@ func TestDenyServerPermission(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	t.Run("creates deny key", func(t *testing.T) {
+	t.Run("creates deny decision", func(t *testing.T) {
 		err := core.DenyServerPermission(ctx, RoleEveryone, PermDMWrite)
 		if err != nil {
 			t.Fatalf("DenyServerPermission() error = %v", err)
 		}
 
-		// Verify deny key was created
-		kv := core.storage.serverRBACEngine.KV()
-		expectedKey := expectedDenyKey(RoleEveryone, PermDMWrite, ObjectIdAny)
-		_, err = kv.Get(ctx, expectedKey)
-		if err != nil {
-			t.Errorf("Expected deny key %s to exist, got error: %v", expectedKey, err)
+		if got := core.RBAC.GetDecision(ScopeServer, "", RoleEveryone, PermDMWrite); got != DecisionDeny {
+			t.Errorf("decision = %s, want %s", got, DecisionDeny)
 		}
 	})
 
@@ -115,12 +102,8 @@ func TestDenyServerPermission(t *testing.T) {
 			t.Fatalf("DenyServerPermission() error = %v", err)
 		}
 
-		// Verify grant was removed
-		kv := core.storage.serverRBACEngine.KV()
-		grantKey := expectedAllowKey(RoleEveryone, PermDMWrite, ObjectIdAny)
-		_, err = kv.Get(ctx, grantKey)
-		if err == nil {
-			t.Error("Expected grant key to be removed after denial")
+		if got := core.RBAC.GetDecision(ScopeServer, "", RoleEveryone, PermDMWrite); got != DecisionDeny {
+			t.Errorf("decision = %s, want %s", got, DecisionDeny)
 		}
 	})
 
@@ -149,16 +132,8 @@ func TestClearServerPermissionState(t *testing.T) {
 			t.Fatalf("ClearServerPermissionState() error = %v", err)
 		}
 
-		// Verify both keys are gone
-		kv := core.storage.serverRBACEngine.KV()
-		grantKey := expectedAllowKey(RoleModerator, PermDMView, ObjectIdAny)
-		denyKey := expectedDenyKey(RoleModerator, PermDMView, ObjectIdAny)
-
-		if _, err := kv.Get(ctx, grantKey); err == nil {
-			t.Error("Expected grant key to be cleared")
-		}
-		if _, err := kv.Get(ctx, denyKey); err == nil {
-			t.Error("Expected deny key to be cleared")
+		if got := core.RBAC.GetDecision(ScopeServer, "", RoleModerator, PermDMView); got != DecisionNone {
+			t.Errorf("decision = %s, want %s", got, DecisionNone)
 		}
 	})
 
@@ -180,18 +155,14 @@ func TestGrantSpaceRolePermission(t *testing.T) {
 
 	_, _ = core.CreateUser(ctx, "system", "testuser", "Test User", "password123")
 
-	t.Run("creates correct KV key for space role", func(t *testing.T) {
+	t.Run("creates allow decision for server role", func(t *testing.T) {
 		err := core.GrantServerPermission(ctx, RoleEveryone, PermRoomCreate)
 		if err != nil {
 			t.Fatalf("GrantSpaceRolePermission() error = %v", err)
 		}
 
-		// Verify key was created in space RBAC KV
-		kv := core.storage.serverRBACKV
-		expectedKey := expectedAllowKey(RoleEveryone, PermRoomCreate, ObjectIdAny)
-		_, err = kv.Get(ctx, expectedKey)
-		if err != nil {
-			t.Errorf("Expected space KV key to exist, got error: %v", err)
+		if got := core.RBAC.GetDecision(ScopeServer, "", RoleEveryone, PermRoomCreate); got != DecisionAllow {
+			t.Errorf("decision = %s, want %s", got, DecisionAllow)
 		}
 	})
 
@@ -218,18 +189,14 @@ func TestDenySpaceRolePermission(t *testing.T) {
 
 	_, _ = core.CreateUser(ctx, "system", "testuser", "Test User", "password123")
 
-	t.Run("creates deny key in space RBAC", func(t *testing.T) {
+	t.Run("creates deny decision in server RBAC", func(t *testing.T) {
 		err := core.DenyServerPermission(ctx, RoleEveryone, PermMessagePost)
 		if err != nil {
 			t.Fatalf("DenySpaceRolePermission() error = %v", err)
 		}
 
-		// Verify deny key was created
-		kv := core.storage.serverRBACKV
-		expectedKey := expectedDenyKey(RoleEveryone, PermMessagePost, ObjectIdAny)
-		_, err = kv.Get(ctx, expectedKey)
-		if err != nil {
-			t.Errorf("Expected space deny key to exist, got error: %v", err)
+		if got := core.RBAC.GetDecision(ScopeServer, "", RoleEveryone, PermMessagePost); got != DecisionDeny {
+			t.Errorf("decision = %s, want %s", got, DecisionDeny)
 		}
 	})
 }
@@ -249,11 +216,8 @@ func TestClearSpaceRolePermission(t *testing.T) {
 			t.Fatalf("ClearSpaceRolePermission() error = %v", err)
 		}
 
-		// Verify keys are gone
-		kv := core.storage.serverRBACKV
-		grantKey := expectedAllowKey(RoleEveryone, PermRoomJoin, ObjectIdAny)
-		if _, err := kv.Get(ctx, grantKey); err == nil {
-			t.Error("Expected grant key to be cleared")
+		if got := core.RBAC.GetDecision(ScopeServer, "", RoleEveryone, PermRoomJoin); got != DecisionNone {
+			t.Errorf("decision = %s, want %s", got, DecisionNone)
 		}
 	})
 }
@@ -269,18 +233,14 @@ func TestGrantRoomRolePermission(t *testing.T) {
 	user, _ := core.CreateUser(ctx, "system", "testuser", "Test User", "password123")
 	room, _ := core.CreateRoom(ctx, user.Id, KindChannel, "", "General", "General chat")
 
-	t.Run("creates correct KV key for room-level permission", func(t *testing.T) {
+	t.Run("creates allow decision for room-level permission", func(t *testing.T) {
 		err := core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
 		if err != nil {
 			t.Fatalf("GrantRoomRolePermission() error = %v", err)
 		}
 
-		// Verify the per-room override key was created (ADR-031 shape).
-		kv := core.storage.serverRBACKV
-		expectedKey := expectedRoomAllowKey(room.Id, RoleEveryone, PermMessagePost)
-		_, err = kv.Get(ctx, expectedKey)
-		if err != nil {
-			t.Errorf("Expected room grant key to exist, got error: %v", err)
+		if got := core.RBAC.GetDecision(ScopeRoom, room.Id, RoleEveryone, PermMessagePost); got != DecisionAllow {
+			t.Errorf("decision = %s, want %s", got, DecisionAllow)
 		}
 	})
 
@@ -300,18 +260,14 @@ func TestDenyRoomRolePermission(t *testing.T) {
 	user, _ := core.CreateUser(ctx, "system", "testuser", "Test User", "password123")
 	room, _ := core.CreateRoom(ctx, user.Id, KindChannel, "", "General", "General chat")
 
-	t.Run("creates deny key at room level", func(t *testing.T) {
+	t.Run("creates deny decision at room level", func(t *testing.T) {
 		err := core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
 		if err != nil {
 			t.Fatalf("DenyRoomRolePermission() error = %v", err)
 		}
 
-		// Verify the per-room override deny key was created (ADR-031 shape).
-		kv := core.storage.serverRBACKV
-		expectedKey := expectedRoomDenyKey(room.Id, RoleEveryone, PermMessagePost)
-		_, err = kv.Get(ctx, expectedKey)
-		if err != nil {
-			t.Errorf("Expected room deny key to exist, got error: %v", err)
+		if got := core.RBAC.GetDecision(ScopeRoom, room.Id, RoleEveryone, PermMessagePost); got != DecisionDeny {
+			t.Errorf("decision = %s, want %s", got, DecisionDeny)
 		}
 	})
 
@@ -339,11 +295,8 @@ func TestClearRoomRolePermission(t *testing.T) {
 			t.Fatalf("ClearRoomRolePermission() error = %v", err)
 		}
 
-		// Verify key was removed
-		kv := core.storage.serverRBACKV
-		grantKey := expectedAllowKey(RoleEveryone, PermRoomJoin, room.Id)
-		if _, err := kv.Get(ctx, grantKey); err == nil {
-			t.Error("Expected grant key to be cleared")
+		if got := core.RBAC.GetDecision(ScopeRoom, room.Id, RoleEveryone, PermRoomJoin); got != DecisionNone {
+			t.Errorf("decision = %s, want %s", got, DecisionNone)
 		}
 	})
 }
@@ -395,16 +348,8 @@ func TestPermissionOpsIdempotency(t *testing.T) {
 			t.Fatalf("Deny failed: %v", err)
 		}
 
-		// Verify grant is gone and deny exists
-		kv := core.storage.serverRBACEngine.KV()
-		grantKey := expectedAllowKey(RoleEveryone, perm, ObjectIdAny)
-		denyKey := expectedDenyKey(RoleEveryone, perm, ObjectIdAny)
-
-		if _, err := kv.Get(ctx, grantKey); err == nil {
-			t.Error("Grant key should be removed after deny")
-		}
-		if _, err := kv.Get(ctx, denyKey); err != nil {
-			t.Error("Deny key should exist")
+		if got := core.RBAC.GetDecision(ScopeServer, "", RoleEveryone, perm); got != DecisionDeny {
+			t.Errorf("decision = %s, want %s", got, DecisionDeny)
 		}
 	})
 }
@@ -415,7 +360,6 @@ func TestPermissionOpsIdempotency(t *testing.T) {
 
 func TestInitServerDefaults(t *testing.T) {
 	core, _ := setupTestCore(t)
-	ctx := testContext(t)
 
 	// InitServerDefaults is called during setupTestCore, so we can verify its effects
 
@@ -426,32 +370,23 @@ func TestInitServerDefaults(t *testing.T) {
 		// role (self-lockout prevention), but the permission grid is
 		// identical to owner.
 		for _, perm := range PermissionsForScope(ScopeServer) {
-			kv := core.storage.serverRBACEngine.KV()
-			key := expectedAllowKey(RoleAdmin, perm.Permission, ObjectIdAny)
-			_, err := kv.Get(ctx, key)
-			if err != nil {
-				t.Errorf("Expected admin to have permission %s, but key not found", perm.Permission)
+			if got := core.RBAC.GetDecision(ScopeServer, "", RoleAdmin, perm.Permission); got != DecisionAllow {
+				t.Errorf("admin decision for %s = %s, want %s", perm.Permission, got, DecisionAllow)
 			}
 		}
 	})
 
 	t.Run("everyone has dm.view permission", func(t *testing.T) {
-		kv := core.storage.serverRBACEngine.KV()
-		key := expectedAllowKey(RoleEveryone, PermDMView, ObjectIdAny)
-		_, err := kv.Get(ctx, key)
-		if err != nil {
-			t.Error("Expected instance-everyone to have dm.view permission")
+		if got := core.RBAC.GetDecision(ScopeServer, "", RoleEveryone, PermDMView); got != DecisionAllow {
+			t.Errorf("everyone decision for %s = %s, want %s", PermDMView, got, DecisionAllow)
 		}
 	})
 
 	t.Run("everyone has expected permissions", func(t *testing.T) {
-		kv := core.storage.serverRBACEngine.KV()
 		expectedPerms := []Permission{PermDMView, PermDMWrite, PermUserDeleteSelf}
 		for _, perm := range expectedPerms {
-			key := expectedAllowKey(RoleEveryone, perm, ObjectIdAny)
-			_, err := kv.Get(ctx, key)
-			if err != nil {
-				t.Errorf("Expected instance-everyone to have permission %s, but key not found", perm)
+			if got := core.RBAC.GetDecision(ScopeServer, "", RoleEveryone, perm); got != DecisionAllow {
+				t.Errorf("everyone decision for %s = %s, want %s", perm, got, DecisionAllow)
 			}
 		}
 	})
@@ -471,11 +406,9 @@ func TestInitDefaultPermissions(t *testing.T) {
 		// Operator-configured denies apply uniformly, including to owners,
 		// because the resolver walks roles for owners just like everyone
 		// else.
-		kv := core.storage.serverRBACKV
 		for _, perm := range PermissionsForScope(ScopeServer) {
-			key := expectedAllowKey(RoleOwner, perm.Permission, ObjectIdAny)
-			if _, err := kv.Get(ctx, key); err != nil {
-				t.Errorf("Expected owner to have permission %s, but key not found", perm.Permission)
+			if got := core.RBAC.GetDecision(ScopeServer, "", RoleOwner, perm.Permission); got != DecisionAllow {
+				t.Errorf("owner decision for %s = %s, want %s", perm.Permission, got, DecisionAllow)
 			}
 		}
 	})
@@ -503,22 +436,18 @@ func TestInitDefaultPermissions(t *testing.T) {
 	})
 
 	t.Run("everyone has default member permissions", func(t *testing.T) {
-		kv := core.storage.serverRBACKV
 		for _, perm := range DefaultEveryonePermissions() {
-			key := expectedAllowKey(RoleEveryone, perm, ObjectIdAny)
-			if _, err := kv.Get(ctx, key); err != nil {
-				t.Errorf("Expected everyone to have permission %s, but key not found", perm)
+			if got := core.RBAC.GetDecision(ScopeServer, "", RoleEveryone, perm); got != DecisionAllow {
+				t.Errorf("everyone decision for %s = %s, want %s", perm, got, DecisionAllow)
 			}
 		}
 	})
 
 	t.Run("moderator has moderation permissions", func(t *testing.T) {
-		kv := core.storage.serverRBACKV
 		moderatorPerms := []Permission{PermMessageManage}
 		for _, perm := range moderatorPerms {
-			key := expectedAllowKey("moderator", perm, ObjectIdAny)
-			if _, err := kv.Get(ctx, key); err != nil {
-				t.Errorf("Expected moderator to have permission %s, but key not found", perm)
+			if got := core.RBAC.GetDecision(ScopeServer, "", RoleModerator, perm); got != DecisionAllow {
+				t.Errorf("moderator decision for %s = %s, want %s", perm, got, DecisionAllow)
 			}
 		}
 	})
@@ -572,35 +501,24 @@ func TestSetupAnnouncementsRoomPermissions(t *testing.T) {
 	}
 
 	t.Run("announcements room denies message.post to everyone", func(t *testing.T) {
-		kv := core.storage.serverRBACKV
-		denyKey := expectedRoomDenyKey(annRoom.Id, RoleEveryone, PermMessagePost)
-		_, err := kv.Get(ctx, denyKey)
-		if err != nil {
-			t.Errorf("Expected deny key %s to exist for announcements room", denyKey)
+		if got := core.RBAC.GetDecision(ScopeRoom, annRoom.Id, RoleEveryone, PermMessagePost); got != DecisionDeny {
+			t.Errorf("decision = %s, want %s", got, DecisionDeny)
 		}
 	})
 
 	t.Run("announcements room does not need explicit grants for higher-ranked roles", func(t *testing.T) {
-		kv := core.storage.serverRBACKV
-
 		// Higher-ranked roles (owner/admin/moderator) inherit message.post
 		// from their server-scope defaults; the resolver hits those grants
 		// before descending to the everyone-role deny.
 		for _, roleName := range []string{RoleOwner, RoleAdmin, RoleModerator} {
-			grantKey := expectedRoomAllowKey(annRoom.Id, roleName, PermMessagePost)
-			if _, err := kv.Get(ctx, grantKey); err == nil {
-				t.Errorf("Did not expect grant key %s for %s in announcements room", grantKey, roleName)
+			if got := core.RBAC.GetDecision(ScopeRoom, annRoom.Id, roleName, PermMessagePost); got != DecisionNone {
+				t.Errorf("room decision for %s = %s, want %s", roleName, got, DecisionNone)
 			}
 		}
 	})
 
 	t.Run("regular room does not have announcements permissions", func(t *testing.T) {
-		kv := core.storage.serverRBACKV
-
-		// Regular room should NOT have the everyone denial for message.post
-		denyKey := expectedRoomDenyKey(regularRoom.Id, RoleEveryone, PermMessagePost)
-		_, err := kv.Get(ctx, denyKey)
-		if err == nil {
+		if got := core.RBAC.GetDecision(ScopeRoom, regularRoom.Id, RoleEveryone, PermMessagePost); got == DecisionDeny {
 			t.Errorf("Regular room should not have %s denial for everyone", PermMessagePost)
 		}
 	})

--- a/cli/internal/core/permission_resolver.go
+++ b/cli/internal/core/permission_resolver.go
@@ -2,13 +2,11 @@ package core
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"slices"
-	"sort"
+	"strings"
 
 	"github.com/nats-io/nats.go/jetstream"
-
 )
 
 // PermissionResolver handles permission resolution using a single
@@ -16,10 +14,10 @@ import (
 //
 // For each role assigned to the user, in hierarchy order (highest rank
 // first), check for an explicit decision in this priority order:
-//   1. room-level allow (if a room context was provided)
-//   2. room-level deny  (if a room context was provided)
-//   3. server-level allow
-//   4. server-level deny
+//  1. room-level allow (if a room context was provided)
+//  2. room-level deny  (if a room context was provided)
+//  3. server-level allow
+//  4. server-level deny
 //
 // The first decision encountered is the answer; lower-ranked roles are
 // not consulted further. If no role has any decision the result is
@@ -332,13 +330,13 @@ func permissionMetadataHasScope(meta PermissionMetadata, scope PermissionScope) 
 // walker runs.
 //
 // Resolution priority (the first emitted decision wins):
-//   1. User-level overrides — checked before any role:
-//      a. room-level allow / deny (only when roomID != "")
-//      b. server-level allow / deny
-//   2. Role-level decisions — for each role assigned to the user, sorted by
-//      hierarchy (highest rank first):
-//      a. room-level allow / deny (only when roomID != "")
-//      b. server-level allow / deny
+//  1. User-level overrides — checked before any role:
+//     a. room-level allow / deny (only when roomID != "")
+//     b. server-level allow / deny
+//  2. Role-level decisions — for each role assigned to the user, sorted by
+//     hierarchy (highest rank first):
+//     a. room-level allow / deny (only when roomID != "")
+//     b. server-level allow / deny
 //
 // User-level overrides "outrank" every role grant: an explicit user-deny
 // blocks the action even for owners, and an explicit user-grant allows it
@@ -551,14 +549,40 @@ func dmBoundaryDenies(perm Permission) bool {
 
 // keyExists checks if a key exists in a KV bucket.
 func (r *PermissionResolver) keyExists(ctx context.Context, kv jetstream.KeyValue, key string) (bool, error) {
-	_, err := kv.Get(ctx, key)
-	if err == nil {
-		return true, nil
-	}
-	if errors.Is(err, jetstream.ErrKeyNotFound) {
+	switch {
+	case strings.HasPrefix(key, AllowKeyPrefix):
+		parts := ParseAllowKey(key)
+		perm := ReconstructPermission(parts.Verb, parts.ObjectType)
+		return parts.Subject != "" && perm != "" &&
+			r.core.RBAC.GetDecision(ScopeServer, "", parts.Subject, perm) == DecisionAllow, nil
+	case strings.HasPrefix(key, DenyKeyPrefix):
+		parts := ParseDenyKey(key)
+		perm := ReconstructPermission(parts.Verb, parts.ObjectType)
+		return parts.Subject != "" && perm != "" &&
+			r.core.RBAC.GetDecision(ScopeServer, "", parts.Subject, perm) == DecisionDeny, nil
+	case strings.HasPrefix(key, GroupAllowKeyPrefix):
+		parts := ParseSetAllowKey(key)
+		perm := ReconstructPermission(parts.Verb, parts.ObjectType)
+		return parts.ScopeID != "" && parts.Subject != "" && perm != "" &&
+			r.core.RBAC.GetDecision(ScopeGroup, parts.ScopeID, parts.Subject, perm) == DecisionAllow, nil
+	case strings.HasPrefix(key, GroupDenyKeyPrefix):
+		parts := ParseSetDenyKey(key)
+		perm := ReconstructPermission(parts.Verb, parts.ObjectType)
+		return parts.ScopeID != "" && parts.Subject != "" && perm != "" &&
+			r.core.RBAC.GetDecision(ScopeGroup, parts.ScopeID, parts.Subject, perm) == DecisionDeny, nil
+	case strings.HasPrefix(key, RoomAllowKeyPrefix):
+		parts := ParseRoomAllowKey(key)
+		perm := ReconstructPermission(parts.Verb, parts.ObjectType)
+		return parts.ScopeID != "" && parts.Subject != "" && perm != "" &&
+			r.core.RBAC.GetDecision(ScopeRoom, parts.ScopeID, parts.Subject, perm) == DecisionAllow, nil
+	case strings.HasPrefix(key, RoomDenyKeyPrefix):
+		parts := ParseRoomDenyKey(key)
+		perm := ReconstructPermission(parts.Verb, parts.ObjectType)
+		return parts.ScopeID != "" && parts.Subject != "" && perm != "" &&
+			r.core.RBAC.GetDecision(ScopeRoom, parts.ScopeID, parts.Subject, perm) == DecisionDeny, nil
+	default:
 		return false, nil
 	}
-	return false, fmt.Errorf("failed to check key %s: %w", key, err)
 }
 
 // getUserServerRoles returns the user's roles (including implicit ones).
@@ -584,34 +608,5 @@ type roleWithPosition struct {
 
 // getUserServerRolesWithPositions returns the user's roles with positions, sorted by hierarchy.
 func (r *PermissionResolver) getUserServerRolesWithPositions(ctx context.Context, userID string) ([]roleWithPosition, error) {
-	roleNames, err := r.getUserServerRoles(ctx, userID)
-	if err != nil {
-		return nil, err
-	}
-
-	engine := r.core.storage.serverRBACEngine
-
-	result := make([]roleWithPosition, 0, len(roleNames))
-	for _, name := range roleNames {
-		pos := PositionEveryone // Default for virtual roles or if lookup fails
-		if role, err := engine.GetRole(ctx, name); err == nil && role != nil {
-			pos = role.Position
-		}
-		result = append(result, roleWithPosition{name: name, position: pos})
-	}
-
-	// Sort by position descending (higher = higher rank = checked first).
-	// Use sort.SliceStable + role name as a deterministic secondary key so
-	// two roles at the same position always resolve in the same order
-	// across calls. Otherwise position collisions would let the walker's
-	// "first decision wins" depend on map iteration order — a real
-	// security risk.
-	sort.SliceStable(result, func(i, j int) bool {
-		if result[i].position != result[j].position {
-			return result[i].position > result[j].position
-		}
-		return result[i].name < result[j].name
-	})
-
-	return result, nil
+	return r.core.RBAC.RolesWithPositionsForUser(userID), nil
 }

--- a/cli/internal/core/permission_resolver_test.go
+++ b/cli/internal/core/permission_resolver_test.go
@@ -496,10 +496,8 @@ func TestPermissionResolver_HasRoomPermission_DenyWins(t *testing.T) {
 			t.Fatalf("Failed to grant room permission: %v", err)
 		}
 
-		// Create a "muted" role with explicit position LOWER than everyone (higher rank).
-		// Position 100 is between moderator (2) and everyone (MaxInt32), so muted's
-		// denial will be checked before everyone's grant in hierarchy order.
-		_, err = core.storage.serverRBACEngine.CreateRoleWithPosition(ctx, "muted", "Muted", "Cannot post", 100)
+		// Create a "muted" role, which ranks above the implicit everyone role.
+		_, err = core.CreateServerRole(ctx, "muted", "Muted", "Cannot post")
 		if err != nil {
 			t.Fatalf("Failed to create muted role: %v", err)
 		}

--- a/cli/internal/core/projection_admin.go
+++ b/cli/internal/core/projection_admin.go
@@ -45,7 +45,7 @@ func (c *ChattoCore) ProjectionAdminStates(ctx context.Context) ([]ProjectionAdm
 	}
 	streamLastSeq := info.State.LastSeq
 
-	states := make([]ProjectionAdminState, 0, 9)
+	states := make([]ProjectionAdminState, 0, 10)
 	add := func(name string, projector *events.Projector, entries int64, estimatedBytes int64, metrics []ProjectionAdminMetric) error {
 		targetSeq, err := projector.CurrentTargetSeq(ctx)
 		if err != nil {
@@ -113,6 +113,10 @@ func (c *ChattoCore) ProjectionAdminStates(ctx context.Context) ([]ProjectionAdm
 			entries, bytes, metrics := c.Users.adminProjectionEstimate()
 			return add("Users", c.UsersProjector, entries, bytes, metrics)
 		},
+		func() error {
+			entries, bytes, metrics := c.RBAC.adminProjectionEstimate()
+			return add("RBAC", c.RBACProjector, entries, bytes, metrics)
+		},
 	} {
 		if err := collect(); err != nil {
 			return nil, err
@@ -175,6 +179,37 @@ func (p *ServerConfigProjection) adminProjectionEstimate() (int64, int64, []Proj
 		bytes = int64(proto.Size(p.cfg)) + projectionMapEntryOverhead
 	}
 	return 1, bytes, []ProjectionAdminMetric{{Name: "configured", Value: 1, Bytes: bytes}}
+}
+
+func (p *RBACProjection) adminProjectionEstimate() (int64, int64, []ProjectionAdminMetric) {
+	p.RLock()
+	defer p.RUnlock()
+	var roleBytes int64
+	for name, role := range p.roles {
+		roleBytes += projectionMapEntryOverhead + int64(len(name))
+		if role != nil {
+			roleBytes += int64(proto.Size(role))
+		}
+	}
+	var assignmentBytes, assignments int64
+	for userID, roles := range p.assignments {
+		assignmentBytes += projectionMapEntryOverhead + int64(len(userID))
+		for roleName := range roles {
+			assignments++
+			assignmentBytes += projectionMapEntryOverhead + int64(len(roleName))
+		}
+	}
+	var decisionBytes int64
+	for key := range p.decisions {
+		decisionBytes += projectionMapEntryOverhead + int64(len(key.scope)+len(key.scopeID)+len(key.subject)+len(key.permission))
+	}
+	totalEntries := int64(len(p.roles)) + assignments + int64(len(p.decisions))
+	totalBytes := roleBytes + assignmentBytes + decisionBytes
+	return totalEntries, totalBytes, []ProjectionAdminMetric{
+		{Name: "roles", Value: int64(len(p.roles)), Bytes: roleBytes},
+		{Name: "assignments", Value: assignments, Bytes: assignmentBytes},
+		{Name: "permission_decisions", Value: int64(len(p.decisions)), Bytes: decisionBytes},
+	}
 }
 
 func (p *RoomGroupProjection) adminProjectionEstimate() (int64, int64, []ProjectionAdminMetric) {

--- a/cli/internal/core/projection_admin.go
+++ b/cli/internal/core/projection_admin.go
@@ -200,8 +200,8 @@ func (p *RBACProjection) adminProjectionEstimate() (int64, int64, []ProjectionAd
 		}
 	}
 	var decisionBytes int64
-	for key := range p.decisions {
-		decisionBytes += projectionMapEntryOverhead + int64(len(key.scope)+len(key.scopeID)+len(key.subject)+len(key.permission))
+	for key, decision := range p.decisions {
+		decisionBytes += projectionMapEntryOverhead + int64(len(key.scope)+len(key.scopeID)+len(key.subject)+len(key.permission)+len(decision))
 	}
 	totalEntries := int64(len(p.roles)) + assignments + int64(len(p.decisions))
 	totalBytes := roleBytes + assignmentBytes + decisionBytes

--- a/cli/internal/core/rbac.go
+++ b/cli/internal/core/rbac.go
@@ -2,14 +2,12 @@ package core
 
 // rbac.go is the unified RBAC surface on ChattoCore. It used to live in
 // instance_rbac.go (server-tier) and space_rbac.go (space-tier); after Phase
-// 5 of #330 there is only one tier — every role and grant lives in
-// SERVER_RBAC — so the two files have been merged here.
+// 5 of #330 there is only one tier. Role and permission state is now derived
+// from the RBAC event-sourced aggregate.
 //
 // The remaining naming drift (Instance- vs Space-prefixed methods, spaceID
 // parameters that the engine ignores) is preserved deliberately to keep the
-// public API stable for resolvers, tests, and bootstrap. Each pair shares
-// the same engine; the only difference is the auth gate the wrapper applies
-// before delegating.
+// public API stable for resolvers, tests, and bootstrap.
 
 import (
 	"context"
@@ -17,6 +15,9 @@ import (
 	"fmt"
 
 	"github.com/nats-io/nats.go/jetstream"
+
+	"hmans.de/chatto/internal/events"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
 // SystemActorID is used for internal/bootstrap operations that bypass permission checks.
@@ -46,7 +47,7 @@ type RoleWithPermissions struct {
 	Permissions       []Permission // Permissions granted (allowed) by this role
 	PermissionDenials []Permission // Permissions denied by this role
 	IsSystem          bool
-	Position          int32 // Lower = higher rank. Owner=0, Everyone=MAX
+	Position          int32 // Higher = higher rank. Everyone=0, Owner=1000
 }
 
 // listKeysWithPattern returns all keys matching a pattern from a KV bucket.
@@ -69,77 +70,18 @@ func listKeysWithPattern(ctx context.Context, kv jetstream.KeyValue, pattern str
 
 const rbacDefaultsSentinel = "defaults_initialized"
 
-// initServerRBAC creates the system roles and grants default permissions.
-// Owner, admin, and moderator roles are explicitly created in KV.
-// The everyone role remains virtual (not stored in KV).
-// Called during ChattoCore initialization. Idempotent - safe to call multiple times.
-// Uses a sentinel key to detect whether defaults have been fully written,
-// which correctly handles the case where a previous boot was interrupted
-// after creating the bucket but before writing all defaults.
+// initServerRBAC exists for older tests and tools that explicitly ask for the
+// historical bootstrap step. NewChattoCore seeds RBAC through migrateRBACToES.
 func (c *ChattoCore) initServerRBAC(ctx context.Context) error {
-	engine := c.storage.serverRBACEngine
-
-	if _, err := engine.CreateRoleWithPosition(ctx, RoleOwner, "Owner", "Full server control", PositionOwner); err != nil {
-		if !errors.Is(err, ErrRoleAlreadyExists) {
-			return fmt.Errorf("failed to create owner role: %w", err)
-		}
-	}
-	if _, err := engine.CreateRoleWithPosition(ctx, RoleAdmin, "Admin", "Full administrative access to the server", PositionAdmin); err != nil {
-		if !errors.Is(err, ErrRoleAlreadyExists) {
-			return fmt.Errorf("failed to create admin role: %w", err)
-		}
-	}
-	if _, err := engine.CreateRoleWithPosition(ctx, RoleModerator, "Moderator", "View access to admin panels without management permissions", PositionModerator); err != nil {
-		if !errors.Is(err, ErrRoleAlreadyExists) {
-			return fmt.Errorf("failed to create moderator role: %w", err)
-		}
-	}
-
-	_, err := c.storage.serverRBACKV.Get(ctx, rbacDefaultsSentinel)
-	if errors.Is(err, jetstream.ErrKeyNotFound) {
-		if err := c.InitDefaultPermissions(ctx); err != nil {
-			return fmt.Errorf("failed to initialize default permissions: %w", err)
-		}
-		if _, err := c.storage.serverRBACKV.Put(ctx, rbacDefaultsSentinel, []byte("1")); err != nil {
-			return fmt.Errorf("failed to write RBAC sentinel key: %w", err)
-		}
-		c.logger.Info("Initialized server RBAC with default permissions")
-	} else if err != nil {
-		return fmt.Errorf("failed to check RBAC sentinel key: %w", err)
-	} else {
-		c.logger.Info("Server RBAC already configured, skipping default initialization")
-	}
-
-	return nil
+	return c.CreateDefaultRoles(ctx)
 }
 
-// CreateDefaultRoles creates the default roles and permissions.
-// Owner, admin, and moderator are explicitly created in KV.
-// Everyone role is virtual (not stored in KV).
-// This should be called when bootstrapping the server.
+// CreateDefaultRoles appends the system roles and their default permissions to
+// the RBAC aggregate. It is idempotent at the projection level.
 func (c *ChattoCore) CreateDefaultRoles(ctx context.Context) error {
-	engine := c.storage.serverRBACEngine
-
-	if _, err := engine.CreateRoleWithPosition(ctx, RoleOwner, "Owner", "Full server control", PositionOwner); err != nil {
-		if !errors.Is(err, ErrRoleAlreadyExists) {
-			return fmt.Errorf("failed to create owner role: %w", err)
-		}
+	if _, err := c.appendRBACBatch(ctx, rbacSeedEntries(defaultRBACRoles(), nil, defaultRBACDecisions()), nil); err != nil {
+		return fmt.Errorf("seed default RBAC roles: %w", err)
 	}
-	if _, err := engine.CreateRoleWithPosition(ctx, RoleAdmin, "Admin", "Can manage server settings, roles, and members", PositionAdmin); err != nil {
-		if !errors.Is(err, ErrRoleAlreadyExists) {
-			return fmt.Errorf("failed to create admin role: %w", err)
-		}
-	}
-	if _, err := engine.CreateRoleWithPosition(ctx, RoleModerator, "Moderator", "Can manage rooms and remove members", PositionModerator); err != nil {
-		if !errors.Is(err, ErrRoleAlreadyExists) {
-			return fmt.Errorf("failed to create moderator role: %w", err)
-		}
-	}
-
-	if err := c.InitDefaultPermissions(ctx); err != nil {
-		return fmt.Errorf("failed to initialize default permissions: %w", err)
-	}
-
 	c.logger.Info("Created default roles")
 	return nil
 }
@@ -160,12 +102,12 @@ func (c *ChattoCore) HasServerPermission(ctx context.Context, userID string, per
 // IsServerAdmin checks if a user has the admin role via RBAC.
 // Does NOT check config fallback (owners.emails) - caller should check that separately.
 func (c *ChattoCore) IsServerAdmin(ctx context.Context, userID string) (bool, error) {
-	return c.storage.serverRBACEngine.HasRole(ctx, userID, RoleAdmin)
+	return c.RBAC.HasRole(userID, RoleAdmin), nil
 }
 
 // IsServerOwner checks if a user has the owner role via RBAC.
 func (c *ChattoCore) IsServerOwner(ctx context.Context, userID string) (bool, error) {
-	return c.storage.serverRBACEngine.HasRole(ctx, userID, RoleOwner)
+	return c.RBAC.HasRole(userID, RoleOwner), nil
 }
 
 // ResolveUserPermission returns the walker's decision (allow / deny / none)
@@ -232,35 +174,23 @@ func (c *ChattoCore) hasGroupPermission(ctx context.Context, kind RoomKind, grou
 
 // AssignOwnerRole assigns the owner role to a user.
 func (c *ChattoCore) AssignOwnerRole(ctx context.Context, userID string) error {
-	if err := c.storage.serverRBACEngine.AssignRole(ctx, userID, RoleOwner); err != nil {
-		return fmt.Errorf("failed to assign owner role: %w", err)
-	}
-	c.logger.Info("Assigned owner role", "user_id", userID)
-	return nil
+	return c.AssignServerRole(ctx, SystemActorID, userID, RoleOwner)
 }
 
 // AssignAdminRole assigns the admin role to a user.
 func (c *ChattoCore) AssignAdminRole(ctx context.Context, userID string) error {
-	if err := c.storage.serverRBACEngine.AssignRole(ctx, userID, RoleAdmin); err != nil {
-		return fmt.Errorf("failed to assign admin role: %w", err)
-	}
-	c.logger.Info("Assigned admin role", "user_id", userID)
-	return nil
+	return c.AssignServerRole(ctx, SystemActorID, userID, RoleAdmin)
 }
 
 // RevokeAdminRole removes the admin role from a user.
 func (c *ChattoCore) RevokeAdminRole(ctx context.Context, userID string) error {
-	if err := c.storage.serverRBACEngine.RevokeRole(ctx, userID, RoleAdmin); err != nil {
-		return fmt.Errorf("failed to revoke admin role: %w", err)
-	}
-	c.logger.Info("Revoked admin role", "user_id", userID)
-	return nil
+	return c.RevokeServerRole(ctx, SystemActorID, userID, RoleAdmin)
 }
 
 // ListAdmins returns all user IDs with the admin role assigned via RBAC.
 // Does NOT include config-based admins (owners.emails).
 func (c *ChattoCore) ListAdmins(ctx context.Context) ([]string, error) {
-	return c.storage.serverRBACEngine.GetRoleUsers(ctx, RoleAdmin)
+	return c.RBAC.GetRoleUsers(RoleAdmin), nil
 }
 
 // AssignServerRole assigns any role to a user.
@@ -277,43 +207,28 @@ func (c *ChattoCore) AssignServerRole(ctx context.Context, actorID, userID, role
 		return ErrImplicitRole
 	}
 
-	engine := c.storage.serverRBACEngine
+	event := newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacRoleAssigned{
+		RbacRoleAssigned: &corev1.RbacRoleAssignedEvent{UserId: userID, RoleName: roleName},
+	}})
 
-	if actorID != SystemActorID {
-		role, err := engine.GetRole(ctx, roleName)
-		if err != nil {
-			if errors.Is(err, ErrRoleNotFound) {
-				return ErrRoleNotFound
-			}
-			return err
-		}
-		canManage, err := engine.CanUserManageRole(ctx, actorID, role.Position)
-		if err != nil {
-			return err
-		}
-		if !canManage {
-			return ErrCannotAssignHigherRole
-		}
-
-		if actorID != userID {
-			actorPos, err := engine.GetUserHighestPosition(ctx, actorID)
-			if err != nil {
-				return err
-			}
-			targetPos, err := engine.GetUserHighestPosition(ctx, userID)
-			if err != nil {
-				return err
-			}
-			if actorPos <= targetPos {
-				return ErrCannotManageHigherUser
-			}
-		}
-	}
-
-	if err := engine.AssignRole(ctx, userID, roleName); err != nil {
-		if errors.Is(err, ErrRoleNotFound) {
+	if _, err := c.appendRBACEvent(ctx, event, func() error {
+		role, ok := c.RBAC.GetRole(roleName)
+		if !ok {
 			return ErrRoleNotFound
 		}
+		if actorID != SystemActorID {
+			canManage := c.RBAC.GetUserHighestPosition(actorID) == PositionOwner || c.RBAC.GetUserHighestPosition(actorID) > role.GetPosition()
+			if !canManage {
+				return ErrCannotAssignHigherRole
+			}
+			if actorID != userID {
+				if c.RBAC.GetUserHighestPosition(actorID) <= c.RBAC.GetUserHighestPosition(userID) {
+					return ErrCannotManageHigherUser
+				}
+			}
+		}
+		return nil
+	}); err != nil {
 		return err
 	}
 
@@ -334,47 +249,31 @@ func (c *ChattoCore) RevokeServerRole(ctx context.Context, actorID, userID, role
 		return ErrImplicitRole
 	}
 
-	engine := c.storage.serverRBACEngine
+	event := newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacRoleRevoked{
+		RbacRoleRevoked: &corev1.RbacRoleRevokedEvent{UserId: userID, RoleName: roleName},
+	}})
 
-	if actorID != SystemActorID {
+	if _, err := c.appendRBACEvent(ctx, event, func() error {
 		if roleName == RoleOwner && actorID == userID {
 			return ErrCannotRevokeSelfAdmin
 		}
-
-		role, err := engine.GetRole(ctx, roleName)
-		if err != nil {
-			if errors.Is(err, ErrRoleNotFound) {
-				return ErrRoleNotFound
-			}
-			return err
-		}
-		canManage, err := engine.CanUserManageRole(ctx, actorID, role.Position)
-		if err != nil {
-			return err
-		}
-		if !canManage {
-			return ErrCannotRevokeHigherRole
-		}
-
-		if actorID != userID {
-			actorPos, err := engine.GetUserHighestPosition(ctx, actorID)
-			if err != nil {
-				return err
-			}
-			targetPos, err := engine.GetUserHighestPosition(ctx, userID)
-			if err != nil {
-				return err
-			}
-			if actorPos <= targetPos {
-				return ErrCannotManageHigherUser
-			}
-		}
-	}
-
-	if err := engine.RevokeRole(ctx, userID, roleName); err != nil {
-		if errors.Is(err, ErrRoleNotFound) {
+		role, ok := c.RBAC.GetRole(roleName)
+		if !ok {
 			return ErrRoleNotFound
 		}
+		if actorID != SystemActorID {
+			canManage := c.RBAC.GetUserHighestPosition(actorID) == PositionOwner || c.RBAC.GetUserHighestPosition(actorID) > role.GetPosition()
+			if !canManage {
+				return ErrCannotRevokeHigherRole
+			}
+			if actorID != userID {
+				if c.RBAC.GetUserHighestPosition(actorID) <= c.RBAC.GetUserHighestPosition(userID) {
+					return ErrCannotManageHigherUser
+				}
+			}
+		}
+		return nil
+	}); err != nil {
 		return err
 	}
 
@@ -388,26 +287,17 @@ func (c *ChattoCore) GetRoleUsers(ctx context.Context, roleName string) ([]strin
 	if roleName == RoleEveryone {
 		return []string{}, nil
 	}
-
-	users, err := c.storage.serverRBACEngine.GetRoleUsers(ctx, roleName)
-	if err != nil {
-		if errors.Is(err, ErrRoleNotFound) {
-			return nil, ErrRoleNotFound
-		}
-		return nil, err
+	if !c.RBAC.RoleExists(roleName) {
+		return nil, ErrRoleNotFound
 	}
-	return users, nil
+	return c.RBAC.GetRoleUsers(roleName), nil
 }
 
 // GetUserRoles returns the explicit role assignments for a user. The implicit
 // `everyone` role is omitted — callers that need it can prepend it themselves
 // based on the relevant scope (e.g. space membership).
 func (c *ChattoCore) GetUserRoles(ctx context.Context, userID string) ([]string, error) {
-	assignedRoles, err := c.storage.serverRBACEngine.GetUserRoles(ctx, userID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get user roles: %w", err)
-	}
-
+	assignedRoles := c.RBAC.GetUserRoles(userID)
 	result := make([]string, 0, len(assignedRoles))
 	for _, role := range assignedRoles {
 		if role != RoleEveryone {
@@ -430,8 +320,24 @@ func (c *ChattoCore) GetUserRoles(ctx context.Context, userID string) ([]string,
 // ClearServerPermissionState live in permission_ops.go, alongside the
 // space-tier and room-tier counterparts.)
 func (c *ChattoCore) RevokeServerPermission(ctx context.Context, roleName string, perm Permission) error {
-	parts := perm.KeyParts()
-	if err := c.storage.serverRBACEngine.RevokeRolePermission(ctx, roleName, parts.Verb, parts.ObjectType, ObjectIdAny); err != nil {
+	if err := ValidatePermission(perm); err != nil {
+		return err
+	}
+	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionCleared{
+		RbacPermissionCleared: rbacPermissionClearedEvent(ScopeServer, "", roleName, perm),
+	}})
+	if _, err := c.appendRBACEvent(ctx, event, func() error {
+		if !c.RBAC.RoleExists(roleName) {
+			return ErrRoleNotFound
+		}
+		if c.RBAC.GetDecision(ScopeServer, "", roleName, perm) != DecisionAllow {
+			return errRBACNoop
+		}
+		return nil
+	}); err != nil {
+		if errors.Is(err, errRBACNoop) {
+			return nil
+		}
 		return err
 	}
 	c.logger.Info("Revoked server permission", "role", roleName, "permission", perm)
@@ -439,39 +345,23 @@ func (c *ChattoCore) RevokeServerPermission(ctx context.Context, roleName string
 }
 
 // GetServerRolePermissions returns all permissions granted to an role.
-// Note: Admin roles are NOT special-cased - permissions are explicitly stored in KV.
+// Note: Admin roles are NOT special-cased - permissions are materialized in the RBAC projection.
 func (c *ChattoCore) GetServerRolePermissions(ctx context.Context, roleName string) ([]Permission, error) {
-	perms, err := c.storage.serverRBACEngine.GetRolePermissions(ctx, roleName)
-	if err != nil {
-		return nil, err
+	if !c.RBAC.RoleExists(roleName) {
+		return nil, ErrRoleNotFound
 	}
-
-	var result []Permission
-	for _, p := range perms {
-		perm := ReconstructPermission(p.Verb, p.ObjectType)
-		if perm != "" {
-			result = append(result, perm)
-		}
-	}
-	return result, nil
+	grants, _ := c.RBAC.DecisionsForRoleServer(roleName)
+	return grants, nil
 }
 
 // GetServerRolePermissionDenials returns all permissions denied by an role.
 // Note: Admin roles are NOT special-cased - they can have denials like any other role.
 func (c *ChattoCore) GetServerRolePermissionDenials(ctx context.Context, roleName string) ([]Permission, error) {
-	perms, err := c.storage.serverRBACEngine.GetRolePermissionDenials(ctx, roleName)
-	if err != nil {
-		return nil, err
+	if !c.RBAC.RoleExists(roleName) {
+		return nil, ErrRoleNotFound
 	}
-
-	var result []Permission
-	for _, p := range perms {
-		perm := ReconstructPermission(p.Verb, p.ObjectType)
-		if perm != "" {
-			result = append(result, perm)
-		}
-	}
-	return result, nil
+	_, denials := c.RBAC.DecisionsForRoleServer(roleName)
+	return denials, nil
 }
 
 // AllServerPermissions returns all defined server permissions.
@@ -506,13 +396,9 @@ func (c *ChattoCore) GetUserServerPermissions(ctx context.Context, userID string
 // ============================================================================
 
 // ListServerRoles returns all roles with their permissions.
-// Note: Admin roles are NOT special-cased - permissions are read from KV like any other role.
+// Note: Admin roles are NOT special-cased - permissions are read from the RBAC projection.
 func (c *ChattoCore) ListServerRoles(ctx context.Context) ([]RoleWithPermissions, error) {
-	roles, err := c.storage.serverRBACEngine.ListRoles(ctx)
-	if err != nil {
-		return nil, err
-	}
-
+	roles := c.RBAC.ListRoles()
 	result := make([]RoleWithPermissions, 0, len(roles))
 	for _, role := range roles {
 		perms, _ := c.GetServerRolePermissions(ctx, role.Name)
@@ -539,44 +425,106 @@ func (c *ChattoCore) CreateServerRole(ctx context.Context, name, displayName, de
 	if err := ValidateRoleName(name); err != nil {
 		return nil, ErrInvalidRoleName
 	}
-
 	if IsSystemRole(name) {
 		return nil, ErrRoleAlreadyExists
 	}
 
-	role, err := c.storage.serverRBACEngine.CreateRole(ctx, name, displayName, description)
-	if err != nil {
-		if errors.Is(err, ErrRoleAlreadyExists) {
-			return nil, ErrRoleAlreadyExists
+	var role *corev1.Role
+	event := newEvent(SystemActorID, &corev1.Event{})
+	if _, err := c.appendRBACEvent(ctx, event, func() error {
+		if c.RBAC.RoleExists(name) {
+			return ErrRoleAlreadyExists
 		}
-		if errors.Is(err, ErrInvalidRoleName) {
-			return nil, ErrInvalidRoleName
+		role = &corev1.Role{
+			Name:        name,
+			DisplayName: displayName,
+			Description: description,
+			Position:    c.RBAC.NextAvailablePosition(),
 		}
+		event.Event = &corev1.Event_RbacRoleCreated{
+			RbacRoleCreated: &corev1.RbacRoleCreatedEvent{
+				RoleName:    role.GetName(),
+				DisplayName: role.GetDisplayName(),
+				Description: role.GetDescription(),
+				Rank:        role.GetPosition(),
+			},
+		}
+		return nil
+	}); err != nil {
 		return nil, err
 	}
 
-	c.logger.Info("Created role", "name", name, "display_name", displayName, "position", role.Position)
+	c.logger.Info("Created role", "name", name, "display_name", displayName, "position", role.GetPosition())
 
 	return &RoleWithPermissions{
-		Name:              role.Name,
-		DisplayName:       role.DisplayName,
-		Description:       role.Description,
+		Name:              role.GetName(),
+		DisplayName:       role.GetDisplayName(),
+		Description:       role.GetDescription(),
 		Permissions:       []Permission{},
 		PermissionDenials: []Permission{},
 		IsSystem:          false,
-		Position:          role.Position,
+		Position:          role.GetPosition(),
 	}, nil
 }
 
 // UpdateServerRole updates an existing role's metadata.
 // The role name cannot be changed.
 func (c *ChattoCore) UpdateServerRole(ctx context.Context, name, displayName, description string) (*RoleWithPermissions, error) {
-	role, err := c.storage.serverRBACEngine.UpdateRole(ctx, name, displayName, description)
-	if err != nil {
-		if errors.Is(err, ErrRoleNotFound) {
+	var updated *corev1.Role
+	if _, err := c.appendRBACEvent(ctx, newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacRoleDisplayNameChanged{
+		RbacRoleDisplayNameChanged: &corev1.RbacRoleDisplayNameChangedEvent{RoleName: name, DisplayName: displayName},
+	}}), func() error {
+		existing, ok := c.RBAC.GetRole(name)
+		if !ok {
+			return ErrRoleNotFound
+		}
+		if existing.GetDisplayName() == displayName {
+			updated = existing
+			return errRBACNoop
+		}
+		updated = &corev1.Role{
+			Name:        existing.GetName(),
+			DisplayName: displayName,
+			Description: existing.GetDescription(),
+			Position:    existing.GetPosition(),
+		}
+		return nil
+	}); err != nil {
+		if !errors.Is(err, errRBACNoop) {
+			return nil, err
+		}
+	}
+
+	if _, err := c.appendRBACEvent(ctx, newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacRoleDescriptionChanged{
+		RbacRoleDescriptionChanged: &corev1.RbacRoleDescriptionChangedEvent{RoleName: name, Description: description},
+	}}), func() error {
+		existing, ok := c.RBAC.GetRole(name)
+		if !ok {
+			return ErrRoleNotFound
+		}
+		if existing.GetDescription() == description {
+			updated = existing
+			return errRBACNoop
+		}
+		updated = &corev1.Role{
+			Name:        existing.GetName(),
+			DisplayName: existing.GetDisplayName(),
+			Description: description,
+			Position:    existing.GetPosition(),
+		}
+		return nil
+	}); err != nil {
+		if !errors.Is(err, errRBACNoop) {
+			return nil, err
+		}
+	}
+
+	if updated == nil {
+		existing, ok := c.RBAC.GetRole(name)
+		if !ok {
 			return nil, ErrRoleNotFound
 		}
-		return nil, err
+		updated = existing
 	}
 
 	c.logger.Info("Updated role", "name", name, "display_name", displayName)
@@ -584,25 +532,22 @@ func (c *ChattoCore) UpdateServerRole(ctx context.Context, name, displayName, de
 	perms, _ := c.GetServerRolePermissions(ctx, name)
 	denials, _ := c.GetServerRolePermissionDenials(ctx, name)
 	return &RoleWithPermissions{
-		Name:              role.Name,
-		DisplayName:       role.DisplayName,
-		Description:       role.Description,
+		Name:              updated.Name,
+		DisplayName:       updated.DisplayName,
+		Description:       updated.Description,
 		Permissions:       perms,
 		PermissionDenials: denials,
 		IsSystem:          IsSystemRole(name),
-		Position:          role.Position,
+		Position:          updated.Position,
 	}, nil
 }
 
 // GetServerRole returns a single role by name.
-// Note: Admin roles are NOT special-cased - permissions are read from KV like any other role.
+// Note: Admin roles are NOT special-cased - permissions are read from the RBAC projection.
 func (c *ChattoCore) GetServerRole(ctx context.Context, name string) (*RoleWithPermissions, error) {
-	role, err := c.storage.serverRBACEngine.GetRole(ctx, name)
-	if err != nil {
-		if errors.Is(err, ErrRoleNotFound) {
-			return nil, ErrRoleNotFound
-		}
-		return nil, err
+	role, ok := c.RBAC.GetRole(name)
+	if !ok {
+		return nil, ErrRoleNotFound
 	}
 
 	perms, _ := c.GetServerRolePermissions(ctx, name)
@@ -627,13 +572,15 @@ func (c *ChattoCore) DeleteServerRole(ctx context.Context, name string) error {
 		return ErrCannotDeleteSystemRole
 	}
 
-	if err := c.storage.serverRBACEngine.DeleteRole(ctx, name); err != nil {
-		if errors.Is(err, ErrRoleNotFound) {
+	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacRoleDeleted{
+		RbacRoleDeleted: &corev1.RbacRoleDeletedEvent{RoleName: name},
+	}})
+	if _, err := c.appendRBACEvent(ctx, event, func() error {
+		if !c.RBAC.RoleExists(name) {
 			return ErrRoleNotFound
 		}
-		if errors.Is(err, ErrCannotDeleteSystemRole) {
-			return ErrCannotDeleteSystemRole
-		}
+		return nil
+	}); err != nil {
 		return err
 	}
 
@@ -653,13 +600,47 @@ func (c *ChattoCore) ReorderServerRoles(ctx context.Context, roleNames []string)
 		}
 	}
 
-	roles, err := c.storage.serverRBACEngine.ReorderRoles(ctx, roleNames)
-	if err != nil {
+	event := newEvent(SystemActorID, &corev1.Event{})
+	if _, err := c.appendRBACEvent(ctx, event, func() error {
+		customRoles := make(map[string]struct{})
+		for _, role := range c.RBAC.ListRoles() {
+			if role.GetName() == "" || IsSystemRole(role.GetName()) {
+				continue
+			}
+			customRoles[role.GetName()] = struct{}{}
+		}
+		if len(roleNames) != len(customRoles) {
+			return fmt.Errorf("role reorder must include every custom role exactly once")
+		}
+
+		position := PositionCustomFirst
+		var reordered []string
+		seen := make(map[string]struct{}, len(roleNames))
+		for _, name := range roleNames {
+			if _, ok := seen[name]; ok {
+				return fmt.Errorf("duplicate role in reorder: %s", name)
+			}
+			seen[name] = struct{}{}
+			if _, ok := customRoles[name]; !ok {
+				return fmt.Errorf("role %s: %w", name, ErrRoleNotFound)
+			}
+			for isSystemPosition(position) {
+				position++
+			}
+			reordered = append(reordered, name)
+			position++
+		}
+		event.Event = &corev1.Event_RbacRolesReordered{
+			RbacRolesReordered: &corev1.RbacRolesReorderedEvent{RoleNames: reordered},
+		}
+		return nil
+	}); err != nil {
 		return nil, err
 	}
 
-	result := make([]RoleWithPermissions, 0, len(roles))
-	for _, role := range roles {
+	allRoles := c.RBAC.ListRoles()
+	result := make([]RoleWithPermissions, 0, len(allRoles))
+	for _, role := range allRoles {
 		perms, _ := c.GetServerRolePermissions(ctx, role.Name)
 		denials, _ := c.GetServerRolePermissionDenials(ctx, role.Name)
 
@@ -682,72 +663,14 @@ func (c *ChattoCore) ReorderServerRoles(ctx context.Context, roleNames []string)
 // for a role in a specific room. Reads ADR-031's room_allow / room_deny
 // key families.
 func (c *ChattoCore) GetRoomRolePermissions(ctx context.Context, roomID, roleName string) (grants []Permission, denials []Permission, err error) {
-	kv := c.storage.serverRBACKV
-
-	allowKeys, err := listKeysWithPattern(ctx, kv, RoomAllowPatternForRoom(roomID))
-	if err != nil {
-		return nil, nil, err
-	}
-	for _, key := range allowKeys {
-		parts := ParseRoomAllowKey(key)
-		if parts.Subject == roleName {
-			perm := ReconstructPermission(parts.Verb, parts.ObjectType)
-			if perm != "" {
-				grants = append(grants, perm)
-			}
-		}
-	}
-
-	denyKeys, err := listKeysWithPattern(ctx, kv, RoomDenyPatternForRoom(roomID))
-	if err != nil {
-		return nil, nil, err
-	}
-	for _, key := range denyKeys {
-		parts := ParseRoomDenyKey(key)
-		if parts.Subject == roleName {
-			perm := ReconstructPermission(parts.Verb, parts.ObjectType)
-			if perm != "" {
-				denials = append(denials, perm)
-			}
-		}
-	}
-
+	grants, denials = c.RBAC.DecisionsFor(ScopeRoom, roomID, roleName)
 	return grants, denials, nil
 }
 
 // GetGroupRolePermissions returns the set-scope grants and denials for a role
 // in a specific room group (ADR-031).
 func (c *ChattoCore) GetGroupRolePermissions(ctx context.Context, groupID, roleName string) (grants []Permission, denials []Permission, err error) {
-	kv := c.storage.serverRBACKV
-
-	allowKeys, err := listKeysWithPattern(ctx, kv, GroupAllowPatternForGroup(groupID))
-	if err != nil {
-		return nil, nil, err
-	}
-	for _, key := range allowKeys {
-		parts := ParseSetAllowKey(key)
-		if parts.Subject == roleName {
-			perm := ReconstructPermission(parts.Verb, parts.ObjectType)
-			if perm != "" {
-				grants = append(grants, perm)
-			}
-		}
-	}
-
-	denyKeys, err := listKeysWithPattern(ctx, kv, GroupDenyPatternForGroup(groupID))
-	if err != nil {
-		return nil, nil, err
-	}
-	for _, key := range denyKeys {
-		parts := ParseSetDenyKey(key)
-		if parts.Subject == roleName {
-			perm := ReconstructPermission(parts.Verb, parts.ObjectType)
-			if perm != "" {
-				denials = append(denials, perm)
-			}
-		}
-	}
-
+	grants, denials = c.RBAC.DecisionsFor(ScopeGroup, groupID, roleName)
 	return grants, denials, nil
 }
 
@@ -756,7 +679,11 @@ func (c *ChattoCore) GrantGroupPermission(ctx context.Context, groupID, roleName
 	if !PermissionAppliesAtScope(perm, ScopeGroup) && !PermissionAppliesAtScope(perm, ScopeRoom) {
 		return fmt.Errorf("permission %s does not apply at group scope", perm)
 	}
-	return c.storage.serverRBACEngine.Grant(ctx, ScopeGroup, groupID, roleName, perm)
+	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionGranted{
+		RbacPermissionGranted: rbacPermissionGrantedEvent(ScopeGroup, groupID, roleName, perm),
+	}})
+	_, err := c.appendRBACEvent(ctx, event, nil)
+	return err
 }
 
 // DenyGroupPermission writes a group-scope deny for a role on a specific room group.
@@ -764,16 +691,24 @@ func (c *ChattoCore) DenyGroupPermission(ctx context.Context, groupID, roleName 
 	if !PermissionAppliesAtScope(perm, ScopeGroup) && !PermissionAppliesAtScope(perm, ScopeRoom) {
 		return fmt.Errorf("permission %s does not apply at group scope", perm)
 	}
-	return c.storage.serverRBACEngine.Deny(ctx, ScopeGroup, groupID, roleName, perm)
+	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionDenied{
+		RbacPermissionDenied: rbacPermissionDeniedEvent(ScopeGroup, groupID, roleName, perm),
+	}})
+	_, err := c.appendRBACEvent(ctx, event, nil)
+	return err
 }
 
 // ClearGroupPermissionState removes both allow and deny for a role on a set.
 func (c *ChattoCore) ClearGroupPermissionState(ctx context.Context, groupID, roleName string, perm Permission) error {
-	return c.storage.serverRBACEngine.Clear(ctx, ScopeGroup, groupID, roleName, perm)
+	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionCleared{
+		RbacPermissionCleared: rbacPermissionClearedEvent(ScopeGroup, groupID, roleName, perm),
+	}})
+	_, err := c.appendRBACEvent(ctx, event, nil)
+	return err
 }
 
 // OutranksUser reports whether actor outranks target by role-hierarchy
-// position (lower position = higher rank). Users with no explicit roles
+// position (higher position = higher rank). Users with no explicit roles
 // fall back to PositionEveryone.
 //
 // This is a HIERARCHY CHECK, not an authorization check. To gate an
@@ -781,7 +716,7 @@ func (c *ChattoCore) ClearGroupPermissionState(ctx context.Context, groupID, rol
 // permission. See .claude/rules/authorization.md (`permission AND
 // OutranksUser`).
 func (c *ChattoCore) OutranksUser(ctx context.Context, actorID, targetID string) (bool, error) {
-	return c.storage.serverRBACEngine.OutranksUser(ctx, actorID, targetID)
+	return c.RBAC.GetUserHighestPosition(actorID) > c.RBAC.GetUserHighestPosition(targetID), nil
 }
 
 // GetUserEffectiveSpacePermissions returns all permissions the user effectively has for a
@@ -817,7 +752,15 @@ func (c *ChattoCore) GetUserEffectiveSpacePermissions(ctx context.Context, kind 
 // Used during LeaveSpace cleanup and account deletion.
 // Authorization: Internal use only (no permission check needed).
 func (c *ChattoCore) RevokeAllUserRoles(ctx context.Context, userID string) error {
-	if err := c.storage.serverRBACEngine.RevokeAllUserRoles(ctx, userID); err != nil {
+	roles := c.RBAC.GetUserRoles(userID)
+	entries := make([]events.BatchEntry, 0, len(roles))
+	for _, roleName := range roles {
+		event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacRoleRevoked{
+			RbacRoleRevoked: &corev1.RbacRoleRevokedEvent{UserId: userID, RoleName: roleName},
+		}})
+		entries = append(entries, events.BatchEntry{Subject: rbacSubjectForEvent(event), Event: event})
+	}
+	if _, err := c.appendRBACBatch(ctx, entries, nil); err != nil {
 		return fmt.Errorf("failed to revoke user roles: %w", err)
 	}
 

--- a/cli/internal/core/rbac.go
+++ b/cli/internal/core/rbac.go
@@ -613,8 +613,6 @@ func (c *ChattoCore) ReorderServerRoles(ctx context.Context, roleNames []string)
 			return fmt.Errorf("role reorder must include every custom role exactly once")
 		}
 
-		position := PositionCustomFirst
-		var reordered []string
 		seen := make(map[string]struct{}, len(roleNames))
 		for _, name := range roleNames {
 			if _, ok := seen[name]; ok {
@@ -624,14 +622,9 @@ func (c *ChattoCore) ReorderServerRoles(ctx context.Context, roleNames []string)
 			if _, ok := customRoles[name]; !ok {
 				return fmt.Errorf("role %s: %w", name, ErrRoleNotFound)
 			}
-			for isSystemPosition(position) {
-				position++
-			}
-			reordered = append(reordered, name)
-			position++
 		}
 		event.Event = &corev1.Event_RbacRolesReordered{
-			RbacRolesReordered: &corev1.RbacRolesReorderedEvent{RoleNames: reordered},
+			RbacRolesReordered: &corev1.RbacRolesReorderedEvent{RoleNames: roleNames},
 		}
 		return nil
 	}); err != nil {

--- a/cli/internal/core/rbac_es_migration.go
+++ b/cli/internal/core/rbac_es_migration.go
@@ -1,0 +1,315 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"hmans.de/chatto/internal/events"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+type rbacSeedDecision struct {
+	scope      PermissionScope
+	scopeID    string
+	subject    string
+	permission Permission
+	decision   DecisionKind
+}
+
+type rbacSeedAssignment struct {
+	userID   string
+	roleName string
+}
+
+func (c *ChattoCore) migrateRBACToES(ctx context.Context) error {
+	entries, legacyKeys, err := c.buildRBACMigrationEntries(ctx)
+	if err != nil {
+		return err
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+
+	entries[0].HasOCC = true
+	entries[0].ExpectedSeq = 0
+	entries[0].FilterSubject = events.RBACSubjectFilter()
+
+	startedAt := time.Now()
+	if _, err := c.EventPublisher.AppendBatch(ctx, entries); err != nil {
+		if errors.Is(err, events.ErrConflict) {
+			c.logger.Info("RBAC ES migration: EVT already seeded, skipping", "legacy_keys", legacyKeys)
+			return nil
+		}
+		return fmt.Errorf("publish RBAC migration events: %w", err)
+	}
+
+	c.logger.Info(
+		"RBAC ES migration: seeded events",
+		"events_imported", len(entries),
+		"legacy_keys", legacyKeys,
+		"duration_ms", time.Since(startedAt).Milliseconds(),
+	)
+	return nil
+}
+
+func (c *ChattoCore) buildRBACMigrationEntries(ctx context.Context) ([]events.BatchEntry, int, error) {
+	keys, err := listSortedKeysFromKV(ctx, c.storage.serverRBACKV)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list SERVER_RBAC keys: %w", err)
+	}
+
+	roles := defaultRBACRoles()
+	assignments := []rbacSeedAssignment{}
+	decisions := []rbacSeedDecision{}
+
+	legacyKeys := 0
+	for _, key := range keys {
+		if key == rbacDefaultsSentinel {
+			continue
+		}
+		legacyKeys++
+		switch {
+		case strings.HasPrefix(key, RoleKeyPrefix):
+			entry, err := c.storage.serverRBACKV.Get(ctx, key)
+			if err != nil {
+				if errors.Is(err, jetstream.ErrKeyNotFound) {
+					continue
+				}
+				return nil, 0, fmt.Errorf("get %s: %w", key, err)
+			}
+			var role corev1.Role
+			if err := proto.Unmarshal(entry.Value(), &role); err != nil {
+				c.logger.Warn("RBAC ES migration: skipping unmarshalable role", "key", key, "error", err)
+				continue
+			}
+			if role.GetName() != "" {
+				roles[role.GetName()] = proto.Clone(&role).(*corev1.Role)
+			}
+		case strings.HasPrefix(key, MemberKeyPrefix):
+			roleName, userID := ParseMemberKey(key)
+			if roleName != "" && userID != "" && roleName != RoleEveryone {
+				assignments = append(assignments, rbacSeedAssignment{userID: userID, roleName: roleName})
+			}
+		case strings.HasPrefix(key, AllowKeyPrefix):
+			if decision, ok := seedDecisionFromAllowKey(key); ok {
+				decisions = append(decisions, decision)
+			}
+		case strings.HasPrefix(key, DenyKeyPrefix):
+			if decision, ok := seedDecisionFromDenyKey(key); ok {
+				decisions = append(decisions, decision)
+			}
+		case strings.HasPrefix(key, GroupAllowKeyPrefix):
+			if decision, ok := seedDecisionFromScopedKey(key, ScopeGroup, DecisionAllow); ok {
+				decisions = append(decisions, decision)
+			}
+		case strings.HasPrefix(key, GroupDenyKeyPrefix):
+			if decision, ok := seedDecisionFromScopedKey(key, ScopeGroup, DecisionDeny); ok {
+				decisions = append(decisions, decision)
+			}
+		case strings.HasPrefix(key, RoomAllowKeyPrefix):
+			if decision, ok := seedDecisionFromScopedKey(key, ScopeRoom, DecisionAllow); ok {
+				decisions = append(decisions, decision)
+			}
+		case strings.HasPrefix(key, RoomDenyKeyPrefix):
+			if decision, ok := seedDecisionFromScopedKey(key, ScopeRoom, DecisionDeny); ok {
+				decisions = append(decisions, decision)
+			}
+		}
+	}
+
+	if legacyKeys == 0 {
+		decisions = append(decisions, defaultRBACDecisions()...)
+	}
+
+	return rbacSeedEntries(roles, assignments, decisions), legacyKeys, nil
+}
+
+func listSortedKeysFromKV(ctx context.Context, kv jetstream.KeyValue) ([]string, error) {
+	lister, err := kv.ListKeys(ctx)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var keys []string
+	for key := range lister.Keys() {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys, nil
+}
+
+func defaultRBACRoles() map[string]*corev1.Role {
+	return map[string]*corev1.Role{
+		RoleOwner: {
+			Name:        RoleOwner,
+			DisplayName: "Owner",
+			Description: "Full server control",
+			Position:    PositionOwner,
+		},
+		RoleAdmin: {
+			Name:        RoleAdmin,
+			DisplayName: "Admin",
+			Description: "Full administrative access to the server",
+			Position:    PositionAdmin,
+		},
+		RoleModerator: {
+			Name:        RoleModerator,
+			DisplayName: "Moderator",
+			Description: "View access to admin panels without management permissions",
+			Position:    PositionModerator,
+		},
+		RoleEveryone: {
+			Name:        RoleEveryone,
+			DisplayName: "Everyone",
+			Description: "All authenticated users",
+			Position:    PositionEveryone,
+		},
+	}
+}
+
+func defaultRBACDecisions() []rbacSeedDecision {
+	roleDefaults := []struct {
+		role  string
+		perms []Permission
+	}{
+		{RoleOwner, DefaultOwnerPermissions()},
+		{RoleAdmin, DefaultAdminPermissions()},
+		{RoleModerator, DefaultModeratorPermissions()},
+		{RoleEveryone, DefaultEveryonePermissions()},
+	}
+	var decisions []rbacSeedDecision
+	for _, spec := range roleDefaults {
+		for _, perm := range spec.perms {
+			if PermissionAppliesAtScope(perm, ScopeServer) {
+				decisions = append(decisions, rbacSeedDecision{
+					scope:      ScopeServer,
+					subject:    spec.role,
+					permission: perm,
+					decision:   DecisionAllow,
+				})
+			}
+		}
+	}
+	return decisions
+}
+
+func seedDecisionFromAllowKey(key string) (rbacSeedDecision, bool) {
+	parts := ParseAllowKey(key)
+	perm := ReconstructPermission(parts.Verb, parts.ObjectType)
+	if parts.Subject == "" || perm == "" {
+		return rbacSeedDecision{}, false
+	}
+	return rbacSeedDecision{scope: ScopeServer, subject: parts.Subject, permission: perm, decision: DecisionAllow}, true
+}
+
+func seedDecisionFromDenyKey(key string) (rbacSeedDecision, bool) {
+	parts := ParseDenyKey(key)
+	perm := ReconstructPermission(parts.Verb, parts.ObjectType)
+	if parts.Subject == "" || perm == "" {
+		return rbacSeedDecision{}, false
+	}
+	return rbacSeedDecision{scope: ScopeServer, subject: parts.Subject, permission: perm, decision: DecisionDeny}, true
+}
+
+func seedDecisionFromScopedKey(key string, scope PermissionScope, decision DecisionKind) (rbacSeedDecision, bool) {
+	var parts ScopedRBACKeyParts
+	switch {
+	case scope == ScopeGroup && decision == DecisionAllow:
+		parts = ParseSetAllowKey(key)
+	case scope == ScopeGroup && decision == DecisionDeny:
+		parts = ParseSetDenyKey(key)
+	case scope == ScopeRoom && decision == DecisionAllow:
+		parts = ParseRoomAllowKey(key)
+	case scope == ScopeRoom && decision == DecisionDeny:
+		parts = ParseRoomDenyKey(key)
+	}
+	perm := ReconstructPermission(parts.Verb, parts.ObjectType)
+	if parts.ScopeID == "" || parts.Subject == "" || perm == "" {
+		return rbacSeedDecision{}, false
+	}
+	return rbacSeedDecision{
+		scope:      scope,
+		scopeID:    parts.ScopeID,
+		subject:    parts.Subject,
+		permission: perm,
+		decision:   decision,
+	}, true
+}
+
+func rbacSeedEntries(roles map[string]*corev1.Role, assignments []rbacSeedAssignment, decisions []rbacSeedDecision) []events.BatchEntry {
+	createdAt := timestamppb.Now()
+	var entries []events.BatchEntry
+
+	roleNames := make([]string, 0, len(roles))
+	for name := range roles {
+		roleNames = append(roleNames, name)
+	}
+	sort.Strings(roleNames)
+	for _, name := range roleNames {
+		role := roles[name]
+		event := newEvent("system:migration", &corev1.Event{CreatedAt: createdAt, Event: &corev1.Event_RbacRoleCreated{
+			RbacRoleCreated: &corev1.RbacRoleCreatedEvent{
+				RoleName:    role.GetName(),
+				DisplayName: role.GetDisplayName(),
+				Description: role.GetDescription(),
+				Rank:        role.GetPosition(),
+			},
+		}})
+		entries = append(entries, events.BatchEntry{Subject: rbacSubjectForEvent(event), Event: event})
+	}
+
+	sort.Slice(assignments, func(i, j int) bool {
+		if assignments[i].userID != assignments[j].userID {
+			return assignments[i].userID < assignments[j].userID
+		}
+		return assignments[i].roleName < assignments[j].roleName
+	})
+	for _, assignment := range assignments {
+		event := newEvent("system:migration", &corev1.Event{CreatedAt: createdAt, Event: &corev1.Event_RbacRoleAssigned{
+			RbacRoleAssigned: &corev1.RbacRoleAssignedEvent{UserId: assignment.userID, RoleName: assignment.roleName},
+		}})
+		entries = append(entries, events.BatchEntry{Subject: rbacSubjectForEvent(event), Event: event})
+	}
+
+	sort.Slice(decisions, func(i, j int) bool {
+		a, b := decisions[i], decisions[j]
+		if a.scope != b.scope {
+			return a.scope < b.scope
+		}
+		if a.scopeID != b.scopeID {
+			return a.scopeID < b.scopeID
+		}
+		if a.subject != b.subject {
+			return a.subject < b.subject
+		}
+		if a.permission != b.permission {
+			return a.permission < b.permission
+		}
+		return a.decision < b.decision
+	})
+	for _, decision := range decisions {
+		var event *corev1.Event
+		if decision.decision == DecisionDeny {
+			event = newEvent("system:migration", &corev1.Event{CreatedAt: createdAt, Event: &corev1.Event_RbacPermissionDenied{
+				RbacPermissionDenied: rbacPermissionDeniedEvent(decision.scope, decision.scopeID, decision.subject, decision.permission),
+			}})
+		} else {
+			event = newEvent("system:migration", &corev1.Event{CreatedAt: createdAt, Event: &corev1.Event_RbacPermissionGranted{
+				RbacPermissionGranted: rbacPermissionGrantedEvent(decision.scope, decision.scopeID, decision.subject, decision.permission),
+			}})
+		}
+		entries = append(entries, events.BatchEntry{Subject: rbacSubjectForEvent(event), Event: event})
+	}
+
+	return entries
+}

--- a/cli/internal/core/rbac_events.go
+++ b/cli/internal/core/rbac_events.go
@@ -1,0 +1,157 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"hmans.de/chatto/internal/events"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+const maxRBACMutationRetries = 5
+
+var errRBACNoop = errors.New("rbac mutation is a no-op")
+
+func rbacPermissionGrantedEvent(scope PermissionScope, scopeID, subject string, perm Permission) *corev1.RbacPermissionGrantedEvent {
+	return &corev1.RbacPermissionGrantedEvent{
+		Location:   rbacPermissionLocation(scope, scopeID),
+		Subject:    subject,
+		Permission: string(perm),
+	}
+}
+
+func rbacPermissionDeniedEvent(scope PermissionScope, scopeID, subject string, perm Permission) *corev1.RbacPermissionDeniedEvent {
+	return &corev1.RbacPermissionDeniedEvent{
+		Location:   rbacPermissionLocation(scope, scopeID),
+		Subject:    subject,
+		Permission: string(perm),
+	}
+}
+
+func rbacPermissionClearedEvent(scope PermissionScope, scopeID, subject string, perm Permission) *corev1.RbacPermissionClearedEvent {
+	return &corev1.RbacPermissionClearedEvent{
+		Location:   rbacPermissionLocation(scope, scopeID),
+		Subject:    subject,
+		Permission: string(perm),
+	}
+}
+
+func rbacPermissionLocation(scope PermissionScope, scopeID string) string {
+	if scope == ScopeServer {
+		return string(ScopeServer)
+	}
+	return scopeID
+}
+
+func rbacSubjectForEvent(event *corev1.Event) string {
+	return rbacAggregateForEvent(event).SubjectFor(event)
+}
+
+func rbacAggregateForEvent(event *corev1.Event) events.Aggregate {
+	if event == nil {
+		return events.RBACServerAggregate()
+	}
+	switch e := event.GetEvent().(type) {
+	case *corev1.Event_RbacPermissionGranted:
+		return rbacAggregateForPermissionLocation(e.RbacPermissionGranted.GetLocation())
+	case *corev1.Event_RbacPermissionDenied:
+		return rbacAggregateForPermissionLocation(e.RbacPermissionDenied.GetLocation())
+	case *corev1.Event_RbacPermissionCleared:
+		return rbacAggregateForPermissionLocation(e.RbacPermissionCleared.GetLocation())
+	default:
+		return events.RBACServerAggregate()
+	}
+}
+
+func rbacAggregateForPermissionLocation(location string) events.Aggregate {
+	if location == "" || location == string(ScopeServer) {
+		return events.RBACServerAggregate()
+	}
+	return events.RBACScopedAggregate(location)
+}
+
+func (c *ChattoCore) appendRBACEvent(ctx context.Context, event *corev1.Event, check func() error) (uint64, error) {
+	filter := events.RBACSubjectFilter()
+
+	for attempt := 0; attempt < maxRBACMutationRetries; attempt++ {
+		filterSeq, err := c.EventPublisher.LastSubjectSeq(ctx, filter)
+		if err != nil {
+			return 0, fmt.Errorf("read RBAC OCC filter seq: %w", err)
+		}
+		if err := c.RBACProjector.WaitForSeq(ctx, filterSeq); err != nil {
+			return 0, fmt.Errorf("wait for RBAC projection: %w", err)
+		}
+		if check != nil {
+			if err := check(); err != nil {
+				return 0, err
+			}
+		}
+		subject := rbacSubjectForEvent(event)
+
+		seq, err := c.EventPublisher.AppendAtFilter(ctx, subject, event, filter, filterSeq)
+		if err == nil {
+			if err := c.RBACProjector.WaitForSeq(ctx, seq); err != nil {
+				return 0, fmt.Errorf("wait for RBAC projection: %w", err)
+			}
+			return seq, nil
+		}
+		if !errors.Is(err, events.ErrConflict) {
+			return 0, err
+		}
+
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-time.After(time.Duration(1<<attempt) * time.Millisecond):
+		}
+	}
+	return 0, fmt.Errorf("RBAC OCC retry exhausted after %d attempts: %w", maxRBACMutationRetries, events.ErrConflict)
+}
+
+func (c *ChattoCore) appendRBACBatch(ctx context.Context, entries []events.BatchEntry, check func() error) (uint64, error) {
+	if len(entries) == 0 {
+		return 0, nil
+	}
+	filter := events.RBACAggregate().AllEventsFilter()
+
+	for attempt := 0; attempt < maxRBACMutationRetries; attempt++ {
+		filterSeq, err := c.EventPublisher.LastSubjectSeq(ctx, filter)
+		if err != nil {
+			return 0, fmt.Errorf("read RBAC OCC filter seq: %w", err)
+		}
+		if err := c.RBACProjector.WaitForSeq(ctx, filterSeq); err != nil {
+			return 0, fmt.Errorf("wait for RBAC projection: %w", err)
+		}
+		if check != nil {
+			if err := check(); err != nil {
+				return 0, err
+			}
+		}
+
+		chunk := append([]events.BatchEntry(nil), entries...)
+		chunk[0].HasOCC = true
+		chunk[0].ExpectedSeq = filterSeq
+		chunk[0].FilterSubject = filter
+
+		seqs, err := c.EventPublisher.AppendBatch(ctx, chunk)
+		if err == nil {
+			lastSeq := seqs[len(seqs)-1]
+			if err := c.RBACProjector.WaitForSeq(ctx, lastSeq); err != nil {
+				return 0, fmt.Errorf("wait for RBAC projection: %w", err)
+			}
+			return lastSeq, nil
+		}
+		if !errors.Is(err, events.ErrConflict) {
+			return 0, err
+		}
+
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-time.After(time.Duration(1<<attempt) * time.Millisecond):
+		}
+	}
+	return 0, fmt.Errorf("RBAC batch OCC retry exhausted after %d attempts: %w", maxRBACMutationRetries, events.ErrConflict)
+}

--- a/cli/internal/core/rbac_events.go
+++ b/cli/internal/core/rbac_events.go
@@ -114,7 +114,7 @@ func (c *ChattoCore) appendRBACBatch(ctx context.Context, entries []events.Batch
 	if len(entries) == 0 {
 		return 0, nil
 	}
-	filter := events.RBACAggregate().AllEventsFilter()
+	filter := events.RBACSubjectFilter()
 
 	for attempt := 0; attempt < maxRBACMutationRetries; attempt++ {
 		filterSeq, err := c.EventPublisher.LastSubjectSeq(ctx, filter)

--- a/cli/internal/core/rbac_projection.go
+++ b/cli/internal/core/rbac_projection.go
@@ -1,0 +1,475 @@
+package core
+
+import (
+	"sort"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+
+	"hmans.de/chatto/internal/events"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+// RBACProjection derives deployment-wide roles, role assignments, and
+// explicit permission decisions from durable evt.rbac.> events.
+type RBACProjection struct {
+	events.MemoryProjection
+	roles       map[string]*corev1.Role
+	assignments map[string]map[string]struct{} // userID -> roleName set
+	decisions   map[rbacDecisionKey]DecisionKind
+	eventIDSeen map[string]struct{}
+}
+
+type rbacDecisionKey struct {
+	scope      PermissionScope
+	scopeID    string
+	subject    string
+	permission Permission
+}
+
+func NewRBACProjection() *RBACProjection {
+	return &RBACProjection{
+		roles:       make(map[string]*corev1.Role),
+		assignments: make(map[string]map[string]struct{}),
+		decisions:   make(map[rbacDecisionKey]DecisionKind),
+		eventIDSeen: make(map[string]struct{}),
+	}
+}
+
+func (p *RBACProjection) Subjects() []string {
+	return []string{events.RBACSubjectFilter()}
+}
+
+func (p *RBACProjection) Apply(event *corev1.Event, _ uint64) error {
+	if event == nil {
+		return nil
+	}
+	if id := event.GetId(); id != "" {
+		p.Lock()
+		if _, ok := p.eventIDSeen[id]; ok {
+			p.Unlock()
+			return nil
+		}
+		p.eventIDSeen[id] = struct{}{}
+		p.Unlock()
+	}
+
+	p.Lock()
+	defer p.Unlock()
+
+	switch e := event.GetEvent().(type) {
+	case *corev1.Event_RbacRoleCreated:
+		p.applyRoleUpsert(rbacRoleFromCreated(e.RbacRoleCreated))
+	case *corev1.Event_RbacRoleDisplayNameChanged:
+		p.applyRoleDisplayNameChanged(e.RbacRoleDisplayNameChanged.GetRoleName(), e.RbacRoleDisplayNameChanged.GetDisplayName())
+	case *corev1.Event_RbacRoleDescriptionChanged:
+		p.applyRoleDescriptionChanged(e.RbacRoleDescriptionChanged.GetRoleName(), e.RbacRoleDescriptionChanged.GetDescription())
+	case *corev1.Event_RbacRoleDeleted:
+		p.applyRoleDeleted(e.RbacRoleDeleted.GetRoleName())
+	case *corev1.Event_RbacRolesReordered:
+		p.applyRolesReordered(e.RbacRolesReordered.GetRoleNames())
+	case *corev1.Event_RbacRoleAssigned:
+		p.applyRoleAssigned(e.RbacRoleAssigned.GetUserId(), e.RbacRoleAssigned.GetRoleName())
+	case *corev1.Event_RbacRoleRevoked:
+		p.applyRoleRevoked(e.RbacRoleRevoked.GetUserId(), e.RbacRoleRevoked.GetRoleName())
+	case *corev1.Event_RbacPermissionGranted:
+		p.applyPermissionDecision(
+			e.RbacPermissionGranted.GetLocation(),
+			e.RbacPermissionGranted.GetSubject(),
+			e.RbacPermissionGranted.GetPermission(),
+			DecisionAllow,
+		)
+	case *corev1.Event_RbacPermissionDenied:
+		p.applyPermissionDecision(
+			e.RbacPermissionDenied.GetLocation(),
+			e.RbacPermissionDenied.GetSubject(),
+			e.RbacPermissionDenied.GetPermission(),
+			DecisionDeny,
+		)
+	case *corev1.Event_RbacPermissionCleared:
+		p.applyPermissionCleared(
+			e.RbacPermissionCleared.GetLocation(),
+			e.RbacPermissionCleared.GetSubject(),
+			e.RbacPermissionCleared.GetPermission(),
+		)
+	}
+	return nil
+}
+
+func rbacRoleFromCreated(event *corev1.RbacRoleCreatedEvent) *corev1.Role {
+	if event == nil {
+		return nil
+	}
+	return &corev1.Role{
+		Name:        event.GetRoleName(),
+		DisplayName: event.GetDisplayName(),
+		Description: event.GetDescription(),
+		Position:    event.GetRank(),
+	}
+}
+
+func (p *RBACProjection) applyRoleUpsert(role *corev1.Role) {
+	if role == nil || role.GetName() == "" {
+		return
+	}
+	p.roles[role.GetName()] = proto.Clone(role).(*corev1.Role)
+}
+
+func (p *RBACProjection) applyRoleDisplayNameChanged(roleName, displayName string) {
+	if roleName == "" {
+		return
+	}
+	role := p.roles[roleName]
+	if role == nil {
+		return
+	}
+	updated := proto.Clone(role).(*corev1.Role)
+	updated.DisplayName = displayName
+	p.roles[roleName] = updated
+}
+
+func (p *RBACProjection) applyRoleDescriptionChanged(roleName, description string) {
+	if roleName == "" {
+		return
+	}
+	role := p.roles[roleName]
+	if role == nil {
+		return
+	}
+	updated := proto.Clone(role).(*corev1.Role)
+	updated.Description = description
+	p.roles[roleName] = updated
+}
+
+func (p *RBACProjection) applyRolesReordered(roleNames []string) {
+	position := PositionCustomFirst
+	for _, roleName := range roleNames {
+		role := p.roles[roleName]
+		if role == nil || IsSystemRole(roleName) {
+			continue
+		}
+		for isSystemPosition(position) {
+			position++
+		}
+		updated := proto.Clone(role).(*corev1.Role)
+		updated.Position = position
+		p.roles[roleName] = updated
+		position++
+	}
+}
+
+func (p *RBACProjection) applyRoleDeleted(roleName string) {
+	if roleName == "" {
+		return
+	}
+	delete(p.roles, roleName)
+	for userID, roles := range p.assignments {
+		delete(roles, roleName)
+		if len(roles) == 0 {
+			delete(p.assignments, userID)
+		}
+	}
+	for key := range p.decisions {
+		if key.subject == roleName {
+			delete(p.decisions, key)
+		}
+	}
+}
+
+func (p *RBACProjection) applyRoleAssigned(userID, roleName string) {
+	if userID == "" || roleName == "" {
+		return
+	}
+	if p.assignments[userID] == nil {
+		p.assignments[userID] = make(map[string]struct{})
+	}
+	p.assignments[userID][roleName] = struct{}{}
+}
+
+func (p *RBACProjection) applyRoleRevoked(userID, roleName string) {
+	if userID == "" || roleName == "" {
+		return
+	}
+	delete(p.assignments[userID], roleName)
+	if len(p.assignments[userID]) == 0 {
+		delete(p.assignments, userID)
+	}
+}
+
+func (p *RBACProjection) applyPermissionDecision(location, subject, permission string, decision DecisionKind) {
+	key, ok := rbacDecisionKeyFromFields(location, subject, permission)
+	if !ok {
+		return
+	}
+	p.decisions[key] = decision
+}
+
+func (p *RBACProjection) applyPermissionCleared(location, subject, permission string) {
+	key, ok := rbacDecisionKeyFromFields(location, subject, permission)
+	if !ok {
+		return
+	}
+	delete(p.decisions, key)
+}
+
+func rbacDecisionKeyFromFields(location, subject, permission string) (rbacDecisionKey, bool) {
+	if subject == "" || permission == "" {
+		return rbacDecisionKey{}, false
+	}
+	if location == string(ScopeServer) {
+		return rbacDecisionKey{scope: ScopeServer, subject: subject, permission: Permission(permission)}, true
+	}
+	scope, ok := rbacScopeFromLocation(location)
+	if !ok {
+		return rbacDecisionKey{}, false
+	}
+	return rbacDecisionKey{scope: scope, scopeID: location, subject: subject, permission: Permission(permission)}, true
+}
+
+func rbacScopeFromLocation(location string) (PermissionScope, bool) {
+	if location == "" {
+		return "", false
+	}
+	switch location[0] {
+	case 'R':
+		return ScopeRoom, true
+	case 'G':
+		return ScopeGroup, true
+	default:
+		return "", false
+	}
+}
+
+func rbacDecisionKeyFor(scope PermissionScope, scopeID, subject string, perm Permission) rbacDecisionKey {
+	if scope == ScopeServer {
+		scopeID = ""
+	}
+	return rbacDecisionKey{scope: scope, scopeID: scopeID, subject: subject, permission: perm}
+}
+
+func (p *RBACProjection) GetRole(name string) (*corev1.Role, bool) {
+	p.RLock()
+	defer p.RUnlock()
+	role := p.roles[name]
+	if role == nil {
+		return nil, false
+	}
+	return proto.Clone(role).(*corev1.Role), true
+}
+
+func (p *RBACProjection) RoleExists(name string) bool {
+	p.RLock()
+	defer p.RUnlock()
+	return p.roles[name] != nil
+}
+
+func (p *RBACProjection) ListRoles() []*corev1.Role {
+	p.RLock()
+	defer p.RUnlock()
+	roles := make([]*corev1.Role, 0, len(p.roles))
+	for _, role := range p.roles {
+		roles = append(roles, proto.Clone(role).(*corev1.Role))
+	}
+	sort.SliceStable(roles, func(i, j int) bool {
+		if roles[i].GetPosition() != roles[j].GetPosition() {
+			return roles[i].GetPosition() < roles[j].GetPosition()
+		}
+		return roles[i].GetName() < roles[j].GetName()
+	})
+	return roles
+}
+
+func (p *RBACProjection) GetUserRoles(userID string) []string {
+	p.RLock()
+	defer p.RUnlock()
+	roles := make([]string, 0, len(p.assignments[userID]))
+	for roleName := range p.assignments[userID] {
+		roles = append(roles, roleName)
+	}
+	sort.Strings(roles)
+	return roles
+}
+
+func (p *RBACProjection) HasRole(userID, roleName string) bool {
+	p.RLock()
+	defer p.RUnlock()
+	_, ok := p.assignments[userID][roleName]
+	return ok
+}
+
+func (p *RBACProjection) GetRoleUsers(roleName string) []string {
+	p.RLock()
+	defer p.RUnlock()
+	users := make([]string, 0)
+	for userID, roles := range p.assignments {
+		if _, ok := roles[roleName]; ok {
+			users = append(users, userID)
+		}
+	}
+	sort.Strings(users)
+	return users
+}
+
+func (p *RBACProjection) Assignments() []rbacSeedAssignment {
+	p.RLock()
+	defer p.RUnlock()
+	assignments := make([]rbacSeedAssignment, 0)
+	for userID, roles := range p.assignments {
+		for roleName := range roles {
+			assignments = append(assignments, rbacSeedAssignment{userID: userID, roleName: roleName})
+		}
+	}
+	sort.Slice(assignments, func(i, j int) bool {
+		if assignments[i].userID != assignments[j].userID {
+			return assignments[i].userID < assignments[j].userID
+		}
+		return assignments[i].roleName < assignments[j].roleName
+	})
+	return assignments
+}
+
+func (p *RBACProjection) Decisions() []rbacSeedDecision {
+	p.RLock()
+	defer p.RUnlock()
+	decisions := make([]rbacSeedDecision, 0, len(p.decisions))
+	for key, decision := range p.decisions {
+		decisions = append(decisions, rbacSeedDecision{
+			scope:      key.scope,
+			scopeID:    key.scopeID,
+			subject:    key.subject,
+			permission: key.permission,
+			decision:   decision,
+		})
+	}
+	sort.Slice(decisions, func(i, j int) bool {
+		a, b := decisions[i], decisions[j]
+		if a.scope != b.scope {
+			return a.scope < b.scope
+		}
+		if a.scopeID != b.scopeID {
+			return a.scopeID < b.scopeID
+		}
+		if a.subject != b.subject {
+			return a.subject < b.subject
+		}
+		if a.permission != b.permission {
+			return a.permission < b.permission
+		}
+		return a.decision < b.decision
+	})
+	return decisions
+}
+
+func (p *RBACProjection) GetDecision(scope PermissionScope, scopeID, subject string, perm Permission) DecisionKind {
+	p.RLock()
+	defer p.RUnlock()
+	if decision, ok := p.decisions[rbacDecisionKeyFor(scope, scopeID, subject, perm)]; ok {
+		return decision
+	}
+	return DecisionNone
+}
+
+func (p *RBACProjection) DecisionsFor(scope PermissionScope, scopeID, subject string) (grants []Permission, denials []Permission) {
+	p.RLock()
+	defer p.RUnlock()
+	for key, decision := range p.decisions {
+		if key.scope != scope || key.scopeID != scopeID || key.subject != subject {
+			continue
+		}
+		switch decision {
+		case DecisionAllow:
+			grants = append(grants, key.permission)
+		case DecisionDeny:
+			denials = append(denials, key.permission)
+		}
+	}
+	sortPermissions(grants)
+	sortPermissions(denials)
+	return grants, denials
+}
+
+func (p *RBACProjection) DecisionsForRoleServer(roleName string) (grants []Permission, denials []Permission) {
+	return p.DecisionsFor(ScopeServer, "", roleName)
+}
+
+func (p *RBACProjection) RolePosition(roleName string) (int32, bool) {
+	p.RLock()
+	defer p.RUnlock()
+	role := p.roles[roleName]
+	if role == nil {
+		return PositionEveryone, false
+	}
+	return role.GetPosition(), true
+}
+
+func (p *RBACProjection) GetUserHighestPosition(userID string) int32 {
+	p.RLock()
+	defer p.RUnlock()
+	maxPos := PositionEveryone
+	for roleName := range p.assignments[userID] {
+		if role := p.roles[roleName]; role != nil && role.GetPosition() > maxPos {
+			maxPos = role.GetPosition()
+		}
+	}
+	return maxPos
+}
+
+func (p *RBACProjection) RolesWithPositionsForUser(userID string) []roleWithPosition {
+	p.RLock()
+	defer p.RUnlock()
+	result := make([]roleWithPosition, 0, len(p.assignments[userID])+1)
+	for roleName := range p.assignments[userID] {
+		pos := PositionEveryone
+		if role := p.roles[roleName]; role != nil {
+			pos = role.GetPosition()
+		}
+		result = append(result, roleWithPosition{name: roleName, position: pos})
+	}
+	if _, ok := p.assignments[userID][RoleEveryone]; !ok {
+		result = append(result, roleWithPosition{name: RoleEveryone, position: PositionEveryone})
+	}
+	sort.SliceStable(result, func(i, j int) bool {
+		if result[i].position != result[j].position {
+			return result[i].position > result[j].position
+		}
+		return result[i].name < result[j].name
+	})
+	return result
+}
+
+func (p *RBACProjection) NextAvailablePosition() int32 {
+	p.RLock()
+	defer p.RUnlock()
+	maxCustom := PositionEveryone
+	for _, role := range p.roles {
+		if role == nil || IsSystemRole(role.GetName()) {
+			continue
+		}
+		if role.GetPosition() > maxCustom {
+			maxCustom = role.GetPosition()
+		}
+	}
+	next := maxCustom + 1
+	for isSystemPosition(next) {
+		next++
+	}
+	return next
+}
+
+func (p *RBACProjection) CountStats() (roles int, assignments int, decisions int) {
+	p.RLock()
+	defer p.RUnlock()
+	for name := range p.roles {
+		if strings.TrimSpace(name) != "" {
+			roles++
+		}
+	}
+	for _, roleSet := range p.assignments {
+		assignments += len(roleSet)
+	}
+	return roles, assignments, len(p.decisions)
+}
+
+func sortPermissions(perms []Permission) {
+	sort.Slice(perms, func(i, j int) bool { return perms[i] < perms[j] })
+}

--- a/cli/internal/core/rbac_projection_test.go
+++ b/cli/internal/core/rbac_projection_test.go
@@ -1,0 +1,186 @@
+package core
+
+import (
+	"testing"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+func TestRBACProjection_RoleMetadataAndReorder(t *testing.T) {
+	p := NewRBACProjection()
+
+	applyRBACProjectionEvent(t, p, &corev1.Event{Event: &corev1.Event_RbacRoleCreated{
+		RbacRoleCreated: &corev1.RbacRoleCreatedEvent{
+			RoleName:    "alpha",
+			DisplayName: "Alpha",
+			Description: "First",
+			Rank:        10,
+		},
+	}})
+	applyRBACProjectionEvent(t, p, &corev1.Event{Event: &corev1.Event_RbacRoleCreated{
+		RbacRoleCreated: &corev1.RbacRoleCreatedEvent{
+			RoleName:    "beta",
+			DisplayName: "Beta",
+			Description: "Second",
+			Rank:        20,
+		},
+	}})
+	applyRBACProjectionEvent(t, p, &corev1.Event{Event: &corev1.Event_RbacRoleDisplayNameChanged{
+		RbacRoleDisplayNameChanged: &corev1.RbacRoleDisplayNameChangedEvent{
+			RoleName:    "alpha",
+			DisplayName: "Alpha Prime",
+		},
+	}})
+	applyRBACProjectionEvent(t, p, &corev1.Event{Event: &corev1.Event_RbacRoleDescriptionChanged{
+		RbacRoleDescriptionChanged: &corev1.RbacRoleDescriptionChangedEvent{
+			RoleName:    "alpha",
+			Description: "Renamed first",
+		},
+	}})
+	applyRBACProjectionEvent(t, p, &corev1.Event{Event: &corev1.Event_RbacRolesReordered{
+		RbacRolesReordered: &corev1.RbacRolesReorderedEvent{
+			RoleNames: []string{"beta", "alpha"},
+		},
+	}})
+
+	alpha, ok := p.GetRole("alpha")
+	if !ok {
+		t.Fatal("alpha role missing")
+	}
+	if alpha.GetDisplayName() != "Alpha Prime" {
+		t.Fatalf("alpha display name = %q, want Alpha Prime", alpha.GetDisplayName())
+	}
+	if alpha.GetDescription() != "Renamed first" {
+		t.Fatalf("alpha description = %q, want Renamed first", alpha.GetDescription())
+	}
+	if alpha.GetPosition() != PositionCustomFirst+1 {
+		t.Fatalf("alpha position = %d, want %d", alpha.GetPosition(), PositionCustomFirst+1)
+	}
+
+	beta, ok := p.GetRole("beta")
+	if !ok {
+		t.Fatal("beta role missing")
+	}
+	if beta.GetPosition() != PositionCustomFirst {
+		t.Fatalf("beta position = %d, want %d", beta.GetPosition(), PositionCustomFirst)
+	}
+}
+
+func TestRBACProjection_AssignRevokeAndDeleteRole(t *testing.T) {
+	p := NewRBACProjection()
+
+	applyRBACProjectionEvent(t, p, &corev1.Event{Event: &corev1.Event_RbacRoleCreated{
+		RbacRoleCreated: &corev1.RbacRoleCreatedEvent{RoleName: "editor", Rank: PositionCustomFirst},
+	}})
+	applyRBACProjectionEvent(t, p, &corev1.Event{Event: &corev1.Event_RbacRoleAssigned{
+		RbacRoleAssigned: &corev1.RbacRoleAssignedEvent{UserId: "U123", RoleName: "editor"},
+	}})
+
+	if !p.HasRole("U123", "editor") {
+		t.Fatal("expected assigned role")
+	}
+
+	applyRBACProjectionEvent(t, p, &corev1.Event{Event: &corev1.Event_RbacRoleRevoked{
+		RbacRoleRevoked: &corev1.RbacRoleRevokedEvent{UserId: "U123", RoleName: "editor"},
+	}})
+	if p.HasRole("U123", "editor") {
+		t.Fatal("expected revoked role")
+	}
+
+	applyRBACProjectionEvent(t, p, &corev1.Event{Event: &corev1.Event_RbacRoleAssigned{
+		RbacRoleAssigned: &corev1.RbacRoleAssignedEvent{UserId: "U123", RoleName: "editor"},
+	}})
+	applyRBACProjectionEvent(t, p, &corev1.Event{Event: &corev1.Event_RbacPermissionGranted{
+		RbacPermissionGranted: &corev1.RbacPermissionGrantedEvent{
+			Location:   string(ScopeServer),
+			Subject:    "editor",
+			Permission: string(PermMessagePost),
+		},
+	}})
+
+	applyRBACProjectionEvent(t, p, &corev1.Event{Event: &corev1.Event_RbacRoleDeleted{
+		RbacRoleDeleted: &corev1.RbacRoleDeletedEvent{RoleName: "editor"},
+	}})
+	if p.RoleExists("editor") {
+		t.Fatal("expected deleted role")
+	}
+	if p.HasRole("U123", "editor") {
+		t.Fatal("expected role assignment removed after role delete")
+	}
+	if got := p.GetDecision(ScopeServer, "", "editor", PermMessagePost); got != DecisionNone {
+		t.Fatalf("deleted role decision = %v, want DecisionNone", got)
+	}
+}
+
+func TestRBACProjection_PermissionLocations(t *testing.T) {
+	p := NewRBACProjection()
+
+	applyRBACProjectionEvent(t, p, &corev1.Event{Event: &corev1.Event_RbacPermissionGranted{
+		RbacPermissionGranted: &corev1.RbacPermissionGrantedEvent{
+			Location:   string(ScopeServer),
+			Subject:    "admin",
+			Permission: string(PermMessagePost),
+		},
+	}})
+	applyRBACProjectionEvent(t, p, &corev1.Event{Event: &corev1.Event_RbacPermissionDenied{
+		RbacPermissionDenied: &corev1.RbacPermissionDeniedEvent{
+			Location:   "Rabc123",
+			Subject:    "U123",
+			Permission: string(PermMessagePost),
+		},
+	}})
+	applyRBACProjectionEvent(t, p, &corev1.Event{Event: &corev1.Event_RbacPermissionGranted{
+		RbacPermissionGranted: &corev1.RbacPermissionGrantedEvent{
+			Location:   "Gabc123",
+			Subject:    "moderator",
+			Permission: string(PermRoomJoin),
+		},
+	}})
+
+	if got := p.GetDecision(ScopeServer, "", "admin", PermMessagePost); got != DecisionAllow {
+		t.Fatalf("server decision = %v, want DecisionAllow", got)
+	}
+	if got := p.GetDecision(ScopeRoom, "Rabc123", "U123", PermMessagePost); got != DecisionDeny {
+		t.Fatalf("room decision = %v, want DecisionDeny", got)
+	}
+	if got := p.GetDecision(ScopeGroup, "Gabc123", "moderator", PermRoomJoin); got != DecisionAllow {
+		t.Fatalf("group decision = %v, want DecisionAllow", got)
+	}
+
+	applyRBACProjectionEvent(t, p, &corev1.Event{Event: &corev1.Event_RbacPermissionCleared{
+		RbacPermissionCleared: &corev1.RbacPermissionClearedEvent{
+			Location:   "Rabc123",
+			Subject:    "U123",
+			Permission: string(PermMessagePost),
+		},
+	}})
+	if got := p.GetDecision(ScopeRoom, "Rabc123", "U123", PermMessagePost); got != DecisionNone {
+		t.Fatalf("cleared room decision = %v, want DecisionNone", got)
+	}
+}
+
+func TestRBACProjection_IgnoresDuplicateEventID(t *testing.T) {
+	p := NewRBACProjection()
+
+	applyRBACProjectionEvent(t, p, &corev1.Event{Id: "evt-1", Event: &corev1.Event_RbacRoleCreated{
+		RbacRoleCreated: &corev1.RbacRoleCreatedEvent{RoleName: "alpha", DisplayName: "Alpha", Rank: 1},
+	}})
+	applyRBACProjectionEvent(t, p, &corev1.Event{Id: "evt-1", Event: &corev1.Event_RbacRoleDisplayNameChanged{
+		RbacRoleDisplayNameChanged: &corev1.RbacRoleDisplayNameChangedEvent{RoleName: "alpha", DisplayName: "Changed"},
+	}})
+
+	role, ok := p.GetRole("alpha")
+	if !ok {
+		t.Fatal("alpha role missing")
+	}
+	if role.GetDisplayName() != "Alpha" {
+		t.Fatalf("display name after duplicate event = %q, want Alpha", role.GetDisplayName())
+	}
+}
+
+func applyRBACProjectionEvent(t *testing.T, p *RBACProjection, event *corev1.Event) {
+	t.Helper()
+	if err := p.Apply(event, 0); err != nil {
+		t.Fatalf("apply event: %v", err)
+	}
+}

--- a/cli/internal/core/rbac_reset.go
+++ b/cli/internal/core/rbac_reset.go
@@ -2,15 +2,16 @@ package core
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
-	"github.com/nats-io/nats.go/jetstream"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"hmans.de/chatto/internal/config"
+	"hmans.de/chatto/internal/events"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
-// ResetRBAC wipes the SERVER_RBAC bucket, re-seeds the system roles plus
+// ResetRBAC resets the RBAC event-sourced aggregate, re-seeds the system roles plus
 // default permissions from code, and assigns the `owner` role to every user
 // whose verified email matches `owners.emails` in the supplied config.
 //
@@ -19,64 +20,17 @@ import (
 // Phase-5 server-RBAC layout. Idempotent: running it twice produces the
 // same result.
 //
-// Wiping is intentionally aggressive — every key in SERVER_RBAC is deleted,
-// including custom roles and any room-level permission overrides. Rebuild
-// those after the reset.
+// Resetting is intentionally aggressive: custom roles, assignments, and
+// explicit permission overrides are removed from the projection by appended
+// reset events. Rebuild those after the reset.
 func (c *ChattoCore) ResetRBAC(ctx context.Context, ownersCfg config.OwnersConfig) error {
-	kv := c.storage.serverRBACKV
-
-	// Drain all keys.
-	keyLister, err := kv.ListKeys(ctx)
-	if err != nil {
-		return fmt.Errorf("list SERVER_RBAC keys: %w", err)
-	}
-	deleted := 0
-	for key := range keyLister.Keys() {
-		if err := kv.Purge(ctx, key); err != nil {
-			return fmt.Errorf("purge key %q: %w", key, err)
-		}
-		deleted++
-	}
-	c.logger.Info("Wiped SERVER_RBAC", "keys_deleted", deleted)
-
-	// Re-create the system roles. The everyone role stays virtual.
-	engine := c.storage.serverRBACEngine
-	roleSpecs := []struct {
-		name        string
-		displayName string
-		description string
-		position    int32
-	}{
-		{RoleOwner, "Owner", "Full server control", PositionOwner},
-		{RoleAdmin, "Admin", "Full administrative access", PositionAdmin},
-		{RoleModerator, "Moderator", "Moderation permissions without administrative reach", PositionModerator},
-	}
-	for _, spec := range roleSpecs {
-		if _, err := engine.CreateRoleWithPosition(ctx, spec.name, spec.displayName, spec.description, spec.position); err != nil {
-			if !errors.Is(err, ErrRoleAlreadyExists) {
-				return fmt.Errorf("create role %q: %w", spec.name, err)
-			}
-		}
-	}
-
-	// Seed default permissions. Owner gets everything; admin / moderator /
-	// everyone get the documented default sets.
-	if err := c.InitDefaultPermissions(ctx); err != nil {
-		return fmt.Errorf("seed default permissions: %w", err)
-	}
-
-	// Re-write the sentinel so the boot-time guard skips re-seeding next start.
-	if _, err := kv.Put(ctx, rbacDefaultsSentinel, []byte("1")); err != nil {
-		return fmt.Errorf("write sentinel: %w", err)
-	}
-
 	// Auto-promote config owners. Every user whose verified email matches
 	// owners.emails in chatto.toml gets the `owner` role.
 	users, err := c.ListUsers(ctx)
 	if err != nil {
 		return fmt.Errorf("list users: %w", err)
 	}
-	promoted := 0
+	promotions := []rbacSeedAssignment{}
 	for _, user := range users {
 		emails, err := c.GetVerifiedEmails(ctx, user.Id)
 		if err != nil {
@@ -94,19 +48,58 @@ func (c *ChattoCore) ResetRBAC(ctx context.Context, ownersCfg config.OwnersConfi
 		if !matched {
 			continue
 		}
-		if err := engine.AssignRole(ctx, user.Id, RoleOwner); err != nil {
-			if errors.Is(err, jetstream.ErrKeyExists) {
-				continue
-			}
-			return fmt.Errorf("assign owner role to %s: %w", user.Id, err)
-		}
-		c.logger.Info("Promoted config owner to owner role",
-			"user_id", user.Id, "login", user.Login)
-		promoted++
+		promotions = append(promotions, rbacSeedAssignment{userID: user.Id, roleName: RoleOwner})
 	}
 
+	entries := c.rbacResetEntries(promotions)
+	if _, err := c.appendRBACBatch(ctx, entries, nil); err != nil {
+		return fmt.Errorf("publish RBAC reset events: %w", err)
+	}
+
+	for _, promotion := range promotions {
+		c.logger.Info("Promoted config owner to owner role", "user_id", promotion.userID)
+	}
 	c.logger.Info("RBAC reset complete",
-		"roles_seeded", len(roleSpecs),
-		"owners_promoted", promoted)
+		"events_published", len(entries),
+		"owners_promoted", len(promotions))
 	return nil
+}
+
+func (c *ChattoCore) rbacResetEntries(promotions []rbacSeedAssignment) []events.BatchEntry {
+	createdAt := timestamppb.Now()
+	var entries []events.BatchEntry
+
+	roles := c.RBAC.ListRoles()
+	for _, role := range roles {
+		if role.GetName() == "" || IsSystemRole(role.GetName()) {
+			continue
+		}
+		event := newEvent(SystemActorID, &corev1.Event{CreatedAt: createdAt, Event: &corev1.Event_RbacRoleDeleted{
+			RbacRoleDeleted: &corev1.RbacRoleDeletedEvent{RoleName: role.GetName()},
+		}})
+		entries = append(entries, events.BatchEntry{Subject: rbacSubjectForEvent(event), Event: event})
+	}
+
+	revokedUsers := make(map[string]struct{})
+	for _, assignment := range c.RBAC.Assignments() {
+		key := assignment.userID + "|" + assignment.roleName
+		if _, ok := revokedUsers[key]; ok {
+			continue
+		}
+		revokedUsers[key] = struct{}{}
+		event := newEvent(SystemActorID, &corev1.Event{CreatedAt: createdAt, Event: &corev1.Event_RbacRoleRevoked{
+			RbacRoleRevoked: &corev1.RbacRoleRevokedEvent{UserId: assignment.userID, RoleName: assignment.roleName},
+		}})
+		entries = append(entries, events.BatchEntry{Subject: rbacSubjectForEvent(event), Event: event})
+	}
+
+	for _, decision := range c.RBAC.Decisions() {
+		event := newEvent(SystemActorID, &corev1.Event{CreatedAt: createdAt, Event: &corev1.Event_RbacPermissionCleared{
+			RbacPermissionCleared: rbacPermissionClearedEvent(decision.scope, decision.scopeID, decision.subject, decision.permission),
+		}})
+		entries = append(entries, events.BatchEntry{Subject: rbacSubjectForEvent(event), Event: event})
+	}
+
+	entries = append(entries, rbacSeedEntries(defaultRBACRoles(), promotions, defaultRBACDecisions())...)
+	return entries
 }

--- a/cli/internal/core/rbac_test.go
+++ b/cli/internal/core/rbac_test.go
@@ -1216,6 +1216,27 @@ func TestChattoCore_ReorderServerRoles(t *testing.T) {
 		}
 	})
 
+	t.Run("rejects incomplete custom role list", func(t *testing.T) {
+		_, err := core.ReorderServerRoles(ctx, []string{"alpha"})
+		if err == nil {
+			t.Error("Expected error when reorder omits a custom role")
+		}
+	})
+
+	t.Run("rejects duplicate custom roles", func(t *testing.T) {
+		_, err := core.ReorderServerRoles(ctx, []string{"alpha", "alpha"})
+		if err == nil {
+			t.Error("Expected error when reorder includes a duplicate role")
+		}
+	})
+
+	t.Run("rejects unknown custom role", func(t *testing.T) {
+		_, err := core.ReorderServerRoles(ctx, []string{"alpha", "gamma"})
+		if !errors.Is(err, ErrRoleNotFound) {
+			t.Fatalf("Expected ErrRoleNotFound, got %v", err)
+		}
+	})
+
 	t.Run("preserves system role positions", func(t *testing.T) {
 		roles, _ := core.ListServerRoles(ctx)
 
@@ -2615,8 +2636,10 @@ func TestChattoCore_CreateRole_PositionAssignment(t *testing.T) {
 		core.CreateServerRole(ctx, "alpha", "Alpha", "Alpha role")
 		core.CreateServerRole(ctx, "beta", "Beta", "Beta role")
 
-		// Reorder them
-		roles, err := core.ReorderServerRoles(ctx, []string{"beta", "alpha"})
+		// Reorder all custom roles. ReorderServerRoles requires a complete
+		// custom-role list so clients cannot accidentally drop roles from the
+		// authoritative ordering event.
+		roles, err := core.ReorderServerRoles(ctx, []string{"editor", "contributor", "beta", "alpha"})
 		if err != nil {
 			t.Fatalf("ReorderServerRoles failed: %v", err)
 		}

--- a/cli/internal/core/reaction_projection_test.go
+++ b/cli/internal/core/reaction_projection_test.go
@@ -1,0 +1,135 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+func TestReactionProjection_AddRemoveAndBatch(t *testing.T) {
+	p := NewReactionProjection()
+
+	applyReactionProjectionEvent(t, p, reactionAddedProjectionEvent("E1", "M1", "U2", "heart", 2))
+	applyReactionProjectionEvent(t, p, reactionAddedProjectionEvent("E2", "M1", "U1", "heart", 3))
+	applyReactionProjectionEvent(t, p, reactionAddedProjectionEvent("E3", "M1", "U3", "thumbsup", 1))
+	applyReactionProjectionEvent(t, p, reactionAddedProjectionEvent("E4", "M2", "U1", "tada", 4))
+
+	if !p.HasReaction("M1", "heart", "U1") {
+		t.Fatal("expected U1 heart reaction on M1")
+	}
+
+	summaries := p.Reactions("M1")
+	if len(summaries) != 2 {
+		t.Fatalf("Reactions(M1) len = %d, want 2", len(summaries))
+	}
+	if summaries[0].Emoji != "thumbsup" {
+		t.Fatalf("first summary emoji = %q, want thumbsup", summaries[0].Emoji)
+	}
+	if summaries[1].Emoji != "heart" {
+		t.Fatalf("second summary emoji = %q, want heart", summaries[1].Emoji)
+	}
+	if got := summaries[1].UserIDs; len(got) != 2 || got[0] != "U1" || got[1] != "U2" {
+		t.Fatalf("heart users = %v, want [U1 U2]", got)
+	}
+
+	batch := p.ReactionsBatch([]string{"M1", "M2", "M3"})
+	if len(batch["M1"]) != 2 {
+		t.Fatalf("batch[M1] len = %d, want 2", len(batch["M1"]))
+	}
+	if len(batch["M2"]) != 1 || batch["M2"][0].Emoji != "tada" {
+		t.Fatalf("batch[M2] = %+v, want tada", batch["M2"])
+	}
+	if _, ok := batch["M3"]; ok {
+		t.Fatalf("batch contains M3 with no reactions: %+v", batch["M3"])
+	}
+
+	applyReactionProjectionEvent(t, p, reactionRemovedProjectionEvent("E5", "M1", "U1", "heart"))
+	if p.HasReaction("M1", "heart", "U1") {
+		t.Fatal("expected removed U1 heart reaction")
+	}
+	if p.HasReaction("M1", "heart", "U2") == false {
+		t.Fatal("expected U2 heart reaction to remain")
+	}
+}
+
+func TestReactionProjection_IgnoresDuplicateEventID(t *testing.T) {
+	p := NewReactionProjection()
+
+	applyReactionProjectionEvent(t, p, reactionAddedProjectionEvent("E1", "M1", "U1", "heart", 1))
+	applyReactionProjectionEvent(t, p, reactionRemovedProjectionEvent("E1", "M1", "U1", "heart"))
+
+	if !p.HasReaction("M1", "heart", "U1") {
+		t.Fatal("duplicate event id should have been ignored")
+	}
+}
+
+func TestRoomLayoutProjection_ReorderCloneAndIgnore(t *testing.T) {
+	p := NewRoomLayoutProjection()
+
+	if got := p.Order(); len(got) != 0 {
+		t.Fatalf("fresh order = %v, want empty", got)
+	}
+
+	if err := p.Apply(&corev1.Event{Event: &corev1.Event_RoomGroupsReordered{
+		RoomGroupsReordered: &corev1.RoomGroupsReorderedEvent{GroupIds: []string{"G1", "G2"}},
+	}}, 1); err != nil {
+		t.Fatalf("apply reorder: %v", err)
+	}
+
+	order := p.Order()
+	if len(order) != 2 || order[0] != "G1" || order[1] != "G2" {
+		t.Fatalf("order = %v, want [G1 G2]", order)
+	}
+	order[0] = "mutated"
+	if got := p.Order(); got[0] != "G1" {
+		t.Fatalf("projection order mutated through returned slice: %v", got)
+	}
+
+	if err := p.Apply(&corev1.Event{Event: &corev1.Event_RoomGroupCreated{
+		RoomGroupCreated: &corev1.RoomGroupCreatedEvent{GroupId: "G3"},
+	}}, 2); err != nil {
+		t.Fatalf("apply unrelated event: %v", err)
+	}
+	if got := p.Order(); len(got) != 2 || got[0] != "G1" || got[1] != "G2" {
+		t.Fatalf("order after unrelated event = %v, want [G1 G2]", got)
+	}
+}
+
+func reactionAddedProjectionEvent(id, messageID, actorID, emoji string, second int) *corev1.Event {
+	return &corev1.Event{
+		Id:        id,
+		ActorId:   actorID,
+		CreatedAt: timestamppb.New(time.Date(2026, 5, 26, 12, 0, second, 0, time.UTC)),
+		Event: &corev1.Event_ReactionAdded{
+			ReactionAdded: &corev1.ReactionAddedEvent{
+				RoomId:         "R1",
+				MessageEventId: messageID,
+				Emoji:          emoji,
+			},
+		},
+	}
+}
+
+func reactionRemovedProjectionEvent(id, messageID, actorID, emoji string) *corev1.Event {
+	return &corev1.Event{
+		Id:      id,
+		ActorId: actorID,
+		Event: &corev1.Event_ReactionRemoved{
+			ReactionRemoved: &corev1.ReactionRemovedEvent{
+				RoomId:         "R1",
+				MessageEventId: messageID,
+				Emoji:          emoji,
+			},
+		},
+	}
+}
+
+func applyReactionProjectionEvent(t *testing.T, p *ReactionProjection, event *corev1.Event) {
+	t.Helper()
+	if err := p.Apply(event, 0); err != nil {
+		t.Fatalf("apply event: %v", err)
+	}
+}

--- a/cli/internal/core/verified_emails.go
+++ b/cli/internal/core/verified_emails.go
@@ -217,7 +217,7 @@ func (c *ChattoCore) addVerifiedEmail(ctx context.Context, userID, email string)
 	// account verifies their email, they pick up the `owner` role without
 	// requiring a server restart or `chatto reset rbac` run.
 	if c.config.Owners.IsServerOwnerEmail(email) {
-		if err := c.storage.serverRBACEngine.AssignRole(ctx, userID, RoleOwner); err != nil {
+		if err := c.AssignServerRole(ctx, SystemActorID, userID, RoleOwner); err != nil {
 			c.logger.Warn("Failed to auto-assign owner role on email verification",
 				"user_id", userID, "email", email, "error", err)
 		} else {

--- a/cli/internal/events/subjects.go
+++ b/cli/internal/events/subjects.go
@@ -26,6 +26,7 @@ const (
 	AggregateGroup  = "group"
 	AggregateLayout = "layout"
 	AggregateUser   = "user"
+	AggregateRBAC   = "rbac"
 )
 
 // ConfigSingletonID is the sentinel aggregate ID for server-wide config
@@ -36,6 +37,11 @@ const ConfigSingletonID = "server"
 // LayoutSingletonID is the sentinel aggregate ID for the singleton
 // sidebar layout. Same convention as ConfigSingletonID.
 const LayoutSingletonID = "default"
+
+// RBACServerID is the aggregate ID for server-scoped RBAC state: role catalog,
+// role order, assignments, and server-scoped permission decisions. Room and
+// group scoped decisions use their room/group ID directly as the aggregate ID.
+const RBACServerID = "server"
 
 // Event-type tokens. NATS-idiomatic snake_case; the trailing segment of
 // every event subject. Stable identifiers — once written, never renamed.
@@ -96,6 +102,18 @@ const (
 	EventUserLoginCooldownStarted     = "login_cooldown_started"
 	EventUserLoginCooldownCleared     = "login_cooldown_cleared"
 	EventUserAccountDeleted           = "account_deleted"
+
+	// RBAC aggregate
+	EventRBACRoleCreated            = "role_created"
+	EventRBACRoleDisplayNameChanged = "role_display_name_changed"
+	EventRBACRoleDescriptionChanged = "role_description_changed"
+	EventRBACRoleDeleted            = "role_deleted"
+	EventRBACRolesReordered         = "roles_reordered"
+	EventRBACRoleAssigned           = "role_assigned"
+	EventRBACRoleRevoked            = "role_revoked"
+	EventRBACPermissionGranted      = "permission_granted"
+	EventRBACPermissionDenied       = "permission_denied"
+	EventRBACPermissionCleared      = "permission_cleared"
 )
 
 // EventTypeOf returns the canonical NATS subject token for an event's
@@ -179,6 +197,27 @@ func EventTypeOf(e *corev1.Event) string {
 		return EventUserLoginCooldownCleared
 	case *corev1.Event_UserAccountDeleted:
 		return EventUserAccountDeleted
+
+	case *corev1.Event_RbacRoleCreated:
+		return EventRBACRoleCreated
+	case *corev1.Event_RbacRoleDisplayNameChanged:
+		return EventRBACRoleDisplayNameChanged
+	case *corev1.Event_RbacRoleDescriptionChanged:
+		return EventRBACRoleDescriptionChanged
+	case *corev1.Event_RbacRoleDeleted:
+		return EventRBACRoleDeleted
+	case *corev1.Event_RbacRolesReordered:
+		return EventRBACRolesReordered
+	case *corev1.Event_RbacRoleAssigned:
+		return EventRBACRoleAssigned
+	case *corev1.Event_RbacRoleRevoked:
+		return EventRBACRoleRevoked
+	case *corev1.Event_RbacPermissionGranted:
+		return EventRBACPermissionGranted
+	case *corev1.Event_RbacPermissionDenied:
+		return EventRBACPermissionDenied
+	case *corev1.Event_RbacPermissionCleared:
+		return EventRBACPermissionCleared
 	}
 	return ""
 }
@@ -255,6 +294,27 @@ func UserAggregate(userID string) Aggregate {
 	return Aggregate{Type: AggregateUser, ID: userID}
 }
 
+// RBACAggregate is the typed constructor for server-level RBAC events:
+// role definitions/order and server-scoped permission decisions.
+func RBACAggregate() Aggregate {
+	return RBACServerAggregate()
+}
+
+// RBACServerAggregate is the typed constructor for server-level RBAC events.
+func RBACServerAggregate() Aggregate {
+	return Aggregate{Type: AggregateRBAC, ID: RBACServerID}
+}
+
+// RBACScopedAggregate is the typed constructor for scoped RBAC decisions. The
+// scope ID is a Chatto entity ID, whose prefix already encodes whether it is a
+// room (R...) or group (G...).
+func RBACScopedAggregate(scopeID string) Aggregate {
+	if scopeID == "" {
+		return RBACServerAggregate()
+	}
+	return Aggregate{Type: AggregateRBAC, ID: scopeID}
+}
+
 // RoomSubjectFilter returns the wildcard filter matching every event of
 // every room aggregate, across all event types.
 // Pattern: evt.room.>
@@ -279,6 +339,11 @@ func ConfigSubjectFilter() string { return SubjectRoot + AggregateConfig + ".>" 
 // aggregate event.
 // Pattern: evt.user.>
 func UserSubjectFilter() string { return SubjectRoot + AggregateUser + ".>" }
+
+// RBACSubjectFilter returns the wildcard filter matching every RBAC aggregate
+// event.
+// Pattern: evt.rbac.>
+func RBACSubjectFilter() string { return SubjectRoot + AggregateRBAC + ".>" }
 
 // RoomEventTypeFilter returns a cross-aggregate, event-type-narrow
 // filter — every event of the given type across every room. Used by

--- a/cli/internal/pb/chatto/core/v1/event.pb.go
+++ b/cli/internal/pb/chatto/core/v1/event.pb.go
@@ -94,6 +94,16 @@ type Event struct {
 	//	*Event_UserLoginCooldownCleared
 	//	*Event_UserAccountDeleted
 	//	*Event_UserLoginCooldownStarted
+	//	*Event_RbacRoleCreated
+	//	*Event_RbacRoleDisplayNameChanged
+	//	*Event_RbacRoleDescriptionChanged
+	//	*Event_RbacRoleDeleted
+	//	*Event_RbacRolesReordered
+	//	*Event_RbacRoleAssigned
+	//	*Event_RbacRoleRevoked
+	//	*Event_RbacPermissionGranted
+	//	*Event_RbacPermissionDenied
+	//	*Event_RbacPermissionCleared
 	//	*Event_ConfigUpdated
 	//	*Event_UserCreated
 	//	*Event_UserDeleted
@@ -464,6 +474,96 @@ func (x *Event) GetUserLoginCooldownStarted() *UserLoginCooldownStartedEvent {
 	return nil
 }
 
+func (x *Event) GetRbacRoleCreated() *RbacRoleCreatedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_RbacRoleCreated); ok {
+			return x.RbacRoleCreated
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetRbacRoleDisplayNameChanged() *RbacRoleDisplayNameChangedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_RbacRoleDisplayNameChanged); ok {
+			return x.RbacRoleDisplayNameChanged
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetRbacRoleDescriptionChanged() *RbacRoleDescriptionChangedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_RbacRoleDescriptionChanged); ok {
+			return x.RbacRoleDescriptionChanged
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetRbacRoleDeleted() *RbacRoleDeletedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_RbacRoleDeleted); ok {
+			return x.RbacRoleDeleted
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetRbacRolesReordered() *RbacRolesReorderedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_RbacRolesReordered); ok {
+			return x.RbacRolesReordered
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetRbacRoleAssigned() *RbacRoleAssignedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_RbacRoleAssigned); ok {
+			return x.RbacRoleAssigned
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetRbacRoleRevoked() *RbacRoleRevokedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_RbacRoleRevoked); ok {
+			return x.RbacRoleRevoked
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetRbacPermissionGranted() *RbacPermissionGrantedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_RbacPermissionGranted); ok {
+			return x.RbacPermissionGranted
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetRbacPermissionDenied() *RbacPermissionDeniedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_RbacPermissionDenied); ok {
+			return x.RbacPermissionDenied
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetRbacPermissionCleared() *RbacPermissionClearedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_RbacPermissionCleared); ok {
+			return x.RbacPermissionCleared
+		}
+	}
+	return nil
+}
+
 func (x *Event) GetConfigUpdated() *ServerConfigUpdatedEvent {
 	if x != nil {
 		if x, ok := x.Event.(*Event_ConfigUpdated); ok {
@@ -823,7 +923,7 @@ type Event_RoomGroupsReordered struct {
 }
 
 type Event_UserAccountCreated struct {
-	// ----- Users (700-719, durable, evt.user.{userId}) -----
+	// ----- Users (700-799, durable, evt.user.{userId}) -----
 	UserAccountCreated *UserAccountCreatedEvent `protobuf:"bytes,700,opt,name=user_account_created,json=userAccountCreated,proto3,oneof"`
 }
 
@@ -869,6 +969,47 @@ type Event_UserAccountDeleted struct {
 
 type Event_UserLoginCooldownStarted struct {
 	UserLoginCooldownStarted *UserLoginCooldownStartedEvent `protobuf:"bytes,711,opt,name=user_login_cooldown_started,json=userLoginCooldownStarted,proto3,oneof"`
+}
+
+type Event_RbacRoleCreated struct {
+	// ----- RBAC (800-839, durable, evt.rbac.>) -----
+	RbacRoleCreated *RbacRoleCreatedEvent `protobuf:"bytes,800,opt,name=rbac_role_created,json=rbacRoleCreated,proto3,oneof"`
+}
+
+type Event_RbacRoleDisplayNameChanged struct {
+	RbacRoleDisplayNameChanged *RbacRoleDisplayNameChangedEvent `protobuf:"bytes,801,opt,name=rbac_role_display_name_changed,json=rbacRoleDisplayNameChanged,proto3,oneof"`
+}
+
+type Event_RbacRoleDescriptionChanged struct {
+	RbacRoleDescriptionChanged *RbacRoleDescriptionChangedEvent `protobuf:"bytes,802,opt,name=rbac_role_description_changed,json=rbacRoleDescriptionChanged,proto3,oneof"`
+}
+
+type Event_RbacRoleDeleted struct {
+	RbacRoleDeleted *RbacRoleDeletedEvent `protobuf:"bytes,803,opt,name=rbac_role_deleted,json=rbacRoleDeleted,proto3,oneof"`
+}
+
+type Event_RbacRolesReordered struct {
+	RbacRolesReordered *RbacRolesReorderedEvent `protobuf:"bytes,804,opt,name=rbac_roles_reordered,json=rbacRolesReordered,proto3,oneof"`
+}
+
+type Event_RbacRoleAssigned struct {
+	RbacRoleAssigned *RbacRoleAssignedEvent `protobuf:"bytes,805,opt,name=rbac_role_assigned,json=rbacRoleAssigned,proto3,oneof"`
+}
+
+type Event_RbacRoleRevoked struct {
+	RbacRoleRevoked *RbacRoleRevokedEvent `protobuf:"bytes,806,opt,name=rbac_role_revoked,json=rbacRoleRevoked,proto3,oneof"`
+}
+
+type Event_RbacPermissionGranted struct {
+	RbacPermissionGranted *RbacPermissionGrantedEvent `protobuf:"bytes,810,opt,name=rbac_permission_granted,json=rbacPermissionGranted,proto3,oneof"`
+}
+
+type Event_RbacPermissionDenied struct {
+	RbacPermissionDenied *RbacPermissionDeniedEvent `protobuf:"bytes,811,opt,name=rbac_permission_denied,json=rbacPermissionDenied,proto3,oneof"`
+}
+
+type Event_RbacPermissionCleared struct {
+	RbacPermissionCleared *RbacPermissionClearedEvent `protobuf:"bytes,812,opt,name=rbac_permission_cleared,json=rbacPermissionCleared,proto3,oneof"`
 }
 
 type Event_ConfigUpdated struct {
@@ -1065,6 +1206,26 @@ func (*Event_UserLoginCooldownCleared) isEvent_Event() {}
 func (*Event_UserAccountDeleted) isEvent_Event() {}
 
 func (*Event_UserLoginCooldownStarted) isEvent_Event() {}
+
+func (*Event_RbacRoleCreated) isEvent_Event() {}
+
+func (*Event_RbacRoleDisplayNameChanged) isEvent_Event() {}
+
+func (*Event_RbacRoleDescriptionChanged) isEvent_Event() {}
+
+func (*Event_RbacRoleDeleted) isEvent_Event() {}
+
+func (*Event_RbacRolesReordered) isEvent_Event() {}
+
+func (*Event_RbacRoleAssigned) isEvent_Event() {}
+
+func (*Event_RbacRoleRevoked) isEvent_Event() {}
+
+func (*Event_RbacPermissionGranted) isEvent_Event() {}
+
+func (*Event_RbacPermissionDenied) isEvent_Event() {}
+
+func (*Event_RbacPermissionCleared) isEvent_Event() {}
 
 func (*Event_ConfigUpdated) isEvent_Event() {}
 
@@ -3062,6 +3223,551 @@ func (x *UserAccountDeletedEvent) GetUserId() string {
 	return ""
 }
 
+type RbacRoleCreatedEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RoleName      string                 `protobuf:"bytes,1,opt,name=role_name,json=roleName,proto3" json:"role_name,omitempty"`
+	DisplayName   string                 `protobuf:"bytes,2,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	Description   string                 `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
+	Rank          int32                  `protobuf:"varint,4,opt,name=rank,proto3" json:"rank,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RbacRoleCreatedEvent) Reset() {
+	*x = RbacRoleCreatedEvent{}
+	mi := &file_chatto_core_v1_event_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RbacRoleCreatedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RbacRoleCreatedEvent) ProtoMessage() {}
+
+func (x *RbacRoleCreatedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_event_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RbacRoleCreatedEvent.ProtoReflect.Descriptor instead.
+func (*RbacRoleCreatedEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *RbacRoleCreatedEvent) GetRoleName() string {
+	if x != nil {
+		return x.RoleName
+	}
+	return ""
+}
+
+func (x *RbacRoleCreatedEvent) GetDisplayName() string {
+	if x != nil {
+		return x.DisplayName
+	}
+	return ""
+}
+
+func (x *RbacRoleCreatedEvent) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *RbacRoleCreatedEvent) GetRank() int32 {
+	if x != nil {
+		return x.Rank
+	}
+	return 0
+}
+
+type RbacRoleDisplayNameChangedEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RoleName      string                 `protobuf:"bytes,1,opt,name=role_name,json=roleName,proto3" json:"role_name,omitempty"`
+	DisplayName   string                 `protobuf:"bytes,2,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RbacRoleDisplayNameChangedEvent) Reset() {
+	*x = RbacRoleDisplayNameChangedEvent{}
+	mi := &file_chatto_core_v1_event_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RbacRoleDisplayNameChangedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RbacRoleDisplayNameChangedEvent) ProtoMessage() {}
+
+func (x *RbacRoleDisplayNameChangedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_event_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RbacRoleDisplayNameChangedEvent.ProtoReflect.Descriptor instead.
+func (*RbacRoleDisplayNameChangedEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *RbacRoleDisplayNameChangedEvent) GetRoleName() string {
+	if x != nil {
+		return x.RoleName
+	}
+	return ""
+}
+
+func (x *RbacRoleDisplayNameChangedEvent) GetDisplayName() string {
+	if x != nil {
+		return x.DisplayName
+	}
+	return ""
+}
+
+type RbacRoleDescriptionChangedEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RoleName      string                 `protobuf:"bytes,1,opt,name=role_name,json=roleName,proto3" json:"role_name,omitempty"`
+	Description   string                 `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RbacRoleDescriptionChangedEvent) Reset() {
+	*x = RbacRoleDescriptionChangedEvent{}
+	mi := &file_chatto_core_v1_event_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RbacRoleDescriptionChangedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RbacRoleDescriptionChangedEvent) ProtoMessage() {}
+
+func (x *RbacRoleDescriptionChangedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_event_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RbacRoleDescriptionChangedEvent.ProtoReflect.Descriptor instead.
+func (*RbacRoleDescriptionChangedEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{38}
+}
+
+func (x *RbacRoleDescriptionChangedEvent) GetRoleName() string {
+	if x != nil {
+		return x.RoleName
+	}
+	return ""
+}
+
+func (x *RbacRoleDescriptionChangedEvent) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+type RbacRoleDeletedEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RoleName      string                 `protobuf:"bytes,1,opt,name=role_name,json=roleName,proto3" json:"role_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RbacRoleDeletedEvent) Reset() {
+	*x = RbacRoleDeletedEvent{}
+	mi := &file_chatto_core_v1_event_proto_msgTypes[39]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RbacRoleDeletedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RbacRoleDeletedEvent) ProtoMessage() {}
+
+func (x *RbacRoleDeletedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_event_proto_msgTypes[39]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RbacRoleDeletedEvent.ProtoReflect.Descriptor instead.
+func (*RbacRoleDeletedEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{39}
+}
+
+func (x *RbacRoleDeletedEvent) GetRoleName() string {
+	if x != nil {
+		return x.RoleName
+	}
+	return ""
+}
+
+type RbacRolesReorderedEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RoleNames     []string               `protobuf:"bytes,1,rep,name=role_names,json=roleNames,proto3" json:"role_names,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RbacRolesReorderedEvent) Reset() {
+	*x = RbacRolesReorderedEvent{}
+	mi := &file_chatto_core_v1_event_proto_msgTypes[40]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RbacRolesReorderedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RbacRolesReorderedEvent) ProtoMessage() {}
+
+func (x *RbacRolesReorderedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_event_proto_msgTypes[40]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RbacRolesReorderedEvent.ProtoReflect.Descriptor instead.
+func (*RbacRolesReorderedEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{40}
+}
+
+func (x *RbacRolesReorderedEvent) GetRoleNames() []string {
+	if x != nil {
+		return x.RoleNames
+	}
+	return nil
+}
+
+type RbacRoleAssignedEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	RoleName      string                 `protobuf:"bytes,2,opt,name=role_name,json=roleName,proto3" json:"role_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RbacRoleAssignedEvent) Reset() {
+	*x = RbacRoleAssignedEvent{}
+	mi := &file_chatto_core_v1_event_proto_msgTypes[41]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RbacRoleAssignedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RbacRoleAssignedEvent) ProtoMessage() {}
+
+func (x *RbacRoleAssignedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_event_proto_msgTypes[41]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RbacRoleAssignedEvent.ProtoReflect.Descriptor instead.
+func (*RbacRoleAssignedEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{41}
+}
+
+func (x *RbacRoleAssignedEvent) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+func (x *RbacRoleAssignedEvent) GetRoleName() string {
+	if x != nil {
+		return x.RoleName
+	}
+	return ""
+}
+
+type RbacRoleRevokedEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	RoleName      string                 `protobuf:"bytes,2,opt,name=role_name,json=roleName,proto3" json:"role_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RbacRoleRevokedEvent) Reset() {
+	*x = RbacRoleRevokedEvent{}
+	mi := &file_chatto_core_v1_event_proto_msgTypes[42]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RbacRoleRevokedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RbacRoleRevokedEvent) ProtoMessage() {}
+
+func (x *RbacRoleRevokedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_event_proto_msgTypes[42]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RbacRoleRevokedEvent.ProtoReflect.Descriptor instead.
+func (*RbacRoleRevokedEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{42}
+}
+
+func (x *RbacRoleRevokedEvent) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+func (x *RbacRoleRevokedEvent) GetRoleName() string {
+	if x != nil {
+		return x.RoleName
+	}
+	return ""
+}
+
+type RbacPermissionGrantedEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Location      string                 `protobuf:"bytes,1,opt,name=location,proto3" json:"location,omitempty"` // "server", room ID, or group ID.
+	Subject       string                 `protobuf:"bytes,2,opt,name=subject,proto3" json:"subject,omitempty"`
+	Permission    string                 `protobuf:"bytes,3,opt,name=permission,proto3" json:"permission,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RbacPermissionGrantedEvent) Reset() {
+	*x = RbacPermissionGrantedEvent{}
+	mi := &file_chatto_core_v1_event_proto_msgTypes[43]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RbacPermissionGrantedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RbacPermissionGrantedEvent) ProtoMessage() {}
+
+func (x *RbacPermissionGrantedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_event_proto_msgTypes[43]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RbacPermissionGrantedEvent.ProtoReflect.Descriptor instead.
+func (*RbacPermissionGrantedEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{43}
+}
+
+func (x *RbacPermissionGrantedEvent) GetLocation() string {
+	if x != nil {
+		return x.Location
+	}
+	return ""
+}
+
+func (x *RbacPermissionGrantedEvent) GetSubject() string {
+	if x != nil {
+		return x.Subject
+	}
+	return ""
+}
+
+func (x *RbacPermissionGrantedEvent) GetPermission() string {
+	if x != nil {
+		return x.Permission
+	}
+	return ""
+}
+
+type RbacPermissionDeniedEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Location      string                 `protobuf:"bytes,1,opt,name=location,proto3" json:"location,omitempty"` // "server", room ID, or group ID.
+	Subject       string                 `protobuf:"bytes,2,opt,name=subject,proto3" json:"subject,omitempty"`
+	Permission    string                 `protobuf:"bytes,3,opt,name=permission,proto3" json:"permission,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RbacPermissionDeniedEvent) Reset() {
+	*x = RbacPermissionDeniedEvent{}
+	mi := &file_chatto_core_v1_event_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RbacPermissionDeniedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RbacPermissionDeniedEvent) ProtoMessage() {}
+
+func (x *RbacPermissionDeniedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_event_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RbacPermissionDeniedEvent.ProtoReflect.Descriptor instead.
+func (*RbacPermissionDeniedEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{44}
+}
+
+func (x *RbacPermissionDeniedEvent) GetLocation() string {
+	if x != nil {
+		return x.Location
+	}
+	return ""
+}
+
+func (x *RbacPermissionDeniedEvent) GetSubject() string {
+	if x != nil {
+		return x.Subject
+	}
+	return ""
+}
+
+func (x *RbacPermissionDeniedEvent) GetPermission() string {
+	if x != nil {
+		return x.Permission
+	}
+	return ""
+}
+
+// Removes any explicit allow or deny, returning this permission to inherited/no-decision state.
+type RbacPermissionClearedEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Location      string                 `protobuf:"bytes,1,opt,name=location,proto3" json:"location,omitempty"` // "server", room ID, or group ID.
+	Subject       string                 `protobuf:"bytes,2,opt,name=subject,proto3" json:"subject,omitempty"`
+	Permission    string                 `protobuf:"bytes,3,opt,name=permission,proto3" json:"permission,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RbacPermissionClearedEvent) Reset() {
+	*x = RbacPermissionClearedEvent{}
+	mi := &file_chatto_core_v1_event_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RbacPermissionClearedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RbacPermissionClearedEvent) ProtoMessage() {}
+
+func (x *RbacPermissionClearedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_event_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RbacPermissionClearedEvent.ProtoReflect.Descriptor instead.
+func (*RbacPermissionClearedEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *RbacPermissionClearedEvent) GetLocation() string {
+	if x != nil {
+		return x.Location
+	}
+	return ""
+}
+
+func (x *RbacPermissionClearedEvent) GetSubject() string {
+	if x != nil {
+		return x.Subject
+	}
+	return ""
+}
+
+func (x *RbacPermissionClearedEvent) GetPermission() string {
+	if x != nil {
+		return x.Permission
+	}
+	return ""
+}
+
 // NotificationLevelChangedEvent is published when a user changes their notification
 // level for the server or a specific room. User-scoped: only delivered to the user
 // who changed it.
@@ -3079,7 +3785,7 @@ type NotificationLevelChangedEvent struct {
 
 func (x *NotificationLevelChangedEvent) Reset() {
 	*x = NotificationLevelChangedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[36]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3091,7 +3797,7 @@ func (x *NotificationLevelChangedEvent) String() string {
 func (*NotificationLevelChangedEvent) ProtoMessage() {}
 
 func (x *NotificationLevelChangedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[36]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3104,7 +3810,7 @@ func (x *NotificationLevelChangedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NotificationLevelChangedEvent.ProtoReflect.Descriptor instead.
 func (*NotificationLevelChangedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{36}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *NotificationLevelChangedEvent) GetRoomId() string {
@@ -3139,7 +3845,7 @@ type ServerCreatedEvent struct {
 
 func (x *ServerCreatedEvent) Reset() {
 	*x = ServerCreatedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[37]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3151,7 +3857,7 @@ func (x *ServerCreatedEvent) String() string {
 func (*ServerCreatedEvent) ProtoMessage() {}
 
 func (x *ServerCreatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[37]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3164,7 +3870,7 @@ func (x *ServerCreatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerCreatedEvent.ProtoReflect.Descriptor instead.
 func (*ServerCreatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{37}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *ServerCreatedEvent) GetServerId() string {
@@ -3203,7 +3909,7 @@ type ServerUpdatedEvent struct {
 
 func (x *ServerUpdatedEvent) Reset() {
 	*x = ServerUpdatedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[38]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3215,7 +3921,7 @@ func (x *ServerUpdatedEvent) String() string {
 func (*ServerUpdatedEvent) ProtoMessage() {}
 
 func (x *ServerUpdatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[38]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3228,7 +3934,7 @@ func (x *ServerUpdatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerUpdatedEvent.ProtoReflect.Descriptor instead.
 func (*ServerUpdatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{38}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *ServerUpdatedEvent) GetServerId() string {
@@ -3275,7 +3981,7 @@ type ServerDeletedEvent struct {
 
 func (x *ServerDeletedEvent) Reset() {
 	*x = ServerDeletedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[39]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3287,7 +3993,7 @@ func (x *ServerDeletedEvent) String() string {
 func (*ServerDeletedEvent) ProtoMessage() {}
 
 func (x *ServerDeletedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[39]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3300,7 +4006,7 @@ func (x *ServerDeletedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerDeletedEvent.ProtoReflect.Descriptor instead.
 func (*ServerDeletedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{39}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *ServerDeletedEvent) GetServerId() string {
@@ -3330,7 +4036,7 @@ type MessageEditedEvent struct {
 
 func (x *MessageEditedEvent) Reset() {
 	*x = MessageEditedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[40]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3342,7 +4048,7 @@ func (x *MessageEditedEvent) String() string {
 func (*MessageEditedEvent) ProtoMessage() {}
 
 func (x *MessageEditedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[40]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3355,7 +4061,7 @@ func (x *MessageEditedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageEditedEvent.ProtoReflect.Descriptor instead.
 func (*MessageEditedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{40}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *MessageEditedEvent) GetRoomId() string {
@@ -3400,7 +4106,7 @@ type MessageRetractedEvent struct {
 
 func (x *MessageRetractedEvent) Reset() {
 	*x = MessageRetractedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[41]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3412,7 +4118,7 @@ func (x *MessageRetractedEvent) String() string {
 func (*MessageRetractedEvent) ProtoMessage() {}
 
 func (x *MessageRetractedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[41]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3425,7 +4131,7 @@ func (x *MessageRetractedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageRetractedEvent.ProtoReflect.Descriptor instead.
 func (*MessageRetractedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{41}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *MessageRetractedEvent) GetRoomId() string {
@@ -3472,7 +4178,7 @@ type MessageUpdatedEvent struct {
 
 func (x *MessageUpdatedEvent) Reset() {
 	*x = MessageUpdatedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[42]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3484,7 +4190,7 @@ func (x *MessageUpdatedEvent) String() string {
 func (*MessageUpdatedEvent) ProtoMessage() {}
 
 func (x *MessageUpdatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[42]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3497,7 +4203,7 @@ func (x *MessageUpdatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageUpdatedEvent.ProtoReflect.Descriptor instead.
 func (*MessageUpdatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{42}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *MessageUpdatedEvent) GetRoomId() string {
@@ -3558,7 +4264,7 @@ type MessageDeletedEvent struct {
 
 func (x *MessageDeletedEvent) Reset() {
 	*x = MessageDeletedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[43]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3570,7 +4276,7 @@ func (x *MessageDeletedEvent) String() string {
 func (*MessageDeletedEvent) ProtoMessage() {}
 
 func (x *MessageDeletedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[43]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3583,7 +4289,7 @@ func (x *MessageDeletedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageDeletedEvent.ProtoReflect.Descriptor instead.
 func (*MessageDeletedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{43}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *MessageDeletedEvent) GetRoomId() string {
@@ -3621,7 +4327,7 @@ type ReactionAddedEvent struct {
 
 func (x *ReactionAddedEvent) Reset() {
 	*x = ReactionAddedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[44]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3633,7 +4339,7 @@ func (x *ReactionAddedEvent) String() string {
 func (*ReactionAddedEvent) ProtoMessage() {}
 
 func (x *ReactionAddedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[44]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3646,7 +4352,7 @@ func (x *ReactionAddedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReactionAddedEvent.ProtoReflect.Descriptor instead.
 func (*ReactionAddedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{44}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *ReactionAddedEvent) GetRoomId() string {
@@ -3684,7 +4390,7 @@ type ReactionRemovedEvent struct {
 
 func (x *ReactionRemovedEvent) Reset() {
 	*x = ReactionRemovedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[45]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3696,7 +4402,7 @@ func (x *ReactionRemovedEvent) String() string {
 func (*ReactionRemovedEvent) ProtoMessage() {}
 
 func (x *ReactionRemovedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[45]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3709,7 +4415,7 @@ func (x *ReactionRemovedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReactionRemovedEvent.ProtoReflect.Descriptor instead.
 func (*ReactionRemovedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{45}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *ReactionRemovedEvent) GetRoomId() string {
@@ -3749,7 +4455,7 @@ type UserTypingEvent struct {
 
 func (x *UserTypingEvent) Reset() {
 	*x = UserTypingEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[46]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3761,7 +4467,7 @@ func (x *UserTypingEvent) String() string {
 func (*UserTypingEvent) ProtoMessage() {}
 
 func (x *UserTypingEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[46]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3774,7 +4480,7 @@ func (x *UserTypingEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserTypingEvent.ProtoReflect.Descriptor instead.
 func (*UserTypingEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{46}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *UserTypingEvent) GetRoomId() string {
@@ -3805,7 +4511,7 @@ type PresenceChangedEvent struct {
 
 func (x *PresenceChangedEvent) Reset() {
 	*x = PresenceChangedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[47]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3817,7 +4523,7 @@ func (x *PresenceChangedEvent) String() string {
 func (*PresenceChangedEvent) ProtoMessage() {}
 
 func (x *PresenceChangedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[47]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3830,7 +4536,7 @@ func (x *PresenceChangedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PresenceChangedEvent.ProtoReflect.Descriptor instead.
 func (*PresenceChangedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{47}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *PresenceChangedEvent) GetStatus() string {
@@ -3855,7 +4561,7 @@ type MentionNotificationEvent struct {
 
 func (x *MentionNotificationEvent) Reset() {
 	*x = MentionNotificationEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[48]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3867,7 +4573,7 @@ func (x *MentionNotificationEvent) String() string {
 func (*MentionNotificationEvent) ProtoMessage() {}
 
 func (x *MentionNotificationEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[48]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3880,7 +4586,7 @@ func (x *MentionNotificationEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MentionNotificationEvent.ProtoReflect.Descriptor instead.
 func (*MentionNotificationEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{48}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *MentionNotificationEvent) GetRoomId() string {
@@ -3912,7 +4618,7 @@ type NewDirectMessageNotificationEvent struct {
 
 func (x *NewDirectMessageNotificationEvent) Reset() {
 	*x = NewDirectMessageNotificationEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[49]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3924,7 +4630,7 @@ func (x *NewDirectMessageNotificationEvent) String() string {
 func (*NewDirectMessageNotificationEvent) ProtoMessage() {}
 
 func (x *NewDirectMessageNotificationEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[49]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3937,7 +4643,7 @@ func (x *NewDirectMessageNotificationEvent) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use NewDirectMessageNotificationEvent.ProtoReflect.Descriptor instead.
 func (*NewDirectMessageNotificationEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{49}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *NewDirectMessageNotificationEvent) GetRoomId() string {
@@ -3970,7 +4676,7 @@ type NotificationCreatedEvent struct {
 
 func (x *NotificationCreatedEvent) Reset() {
 	*x = NotificationCreatedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[50]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3982,7 +4688,7 @@ func (x *NotificationCreatedEvent) String() string {
 func (*NotificationCreatedEvent) ProtoMessage() {}
 
 func (x *NotificationCreatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[50]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3995,7 +4701,7 @@ func (x *NotificationCreatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NotificationCreatedEvent.ProtoReflect.Descriptor instead.
 func (*NotificationCreatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{50}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *NotificationCreatedEvent) GetNotificationId() string {
@@ -4038,7 +4744,7 @@ type NotificationDismissedEvent struct {
 
 func (x *NotificationDismissedEvent) Reset() {
 	*x = NotificationDismissedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[51]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4050,7 +4756,7 @@ func (x *NotificationDismissedEvent) String() string {
 func (*NotificationDismissedEvent) ProtoMessage() {}
 
 func (x *NotificationDismissedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[51]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4063,7 +4769,7 @@ func (x *NotificationDismissedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NotificationDismissedEvent.ProtoReflect.Descriptor instead.
 func (*NotificationDismissedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{51}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *NotificationDismissedEvent) GetNotificationId() string {
@@ -4090,7 +4796,7 @@ type ThreadFollowChangedEvent struct {
 
 func (x *ThreadFollowChangedEvent) Reset() {
 	*x = ThreadFollowChangedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[52]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4102,7 +4808,7 @@ func (x *ThreadFollowChangedEvent) String() string {
 func (*ThreadFollowChangedEvent) ProtoMessage() {}
 
 func (x *ThreadFollowChangedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[52]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4115,7 +4821,7 @@ func (x *ThreadFollowChangedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ThreadFollowChangedEvent.ProtoReflect.Descriptor instead.
 func (*ThreadFollowChangedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{52}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *ThreadFollowChangedEvent) GetRoomId() string {
@@ -4151,7 +4857,7 @@ type RoomMarkedAsReadEvent struct {
 
 func (x *RoomMarkedAsReadEvent) Reset() {
 	*x = RoomMarkedAsReadEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[53]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4163,7 +4869,7 @@ func (x *RoomMarkedAsReadEvent) String() string {
 func (*RoomMarkedAsReadEvent) ProtoMessage() {}
 
 func (x *RoomMarkedAsReadEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[53]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4176,7 +4882,7 @@ func (x *RoomMarkedAsReadEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomMarkedAsReadEvent.ProtoReflect.Descriptor instead.
 func (*RoomMarkedAsReadEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{53}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *RoomMarkedAsReadEvent) GetRoomId() string {
@@ -4201,7 +4907,7 @@ type MentionStatusClearedEvent struct {
 
 func (x *MentionStatusClearedEvent) Reset() {
 	*x = MentionStatusClearedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[54]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4213,7 +4919,7 @@ func (x *MentionStatusClearedEvent) String() string {
 func (*MentionStatusClearedEvent) ProtoMessage() {}
 
 func (x *MentionStatusClearedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[54]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4226,7 +4932,7 @@ func (x *MentionStatusClearedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MentionStatusClearedEvent.ProtoReflect.Descriptor instead.
 func (*MentionStatusClearedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{54}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *MentionStatusClearedEvent) GetRoomId() string {
@@ -4247,7 +4953,7 @@ type RoomGroupsUpdatedEvent struct {
 
 func (x *RoomGroupsUpdatedEvent) Reset() {
 	*x = RoomGroupsUpdatedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[55]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4259,7 +4965,7 @@ func (x *RoomGroupsUpdatedEvent) String() string {
 func (*RoomGroupsUpdatedEvent) ProtoMessage() {}
 
 func (x *RoomGroupsUpdatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[55]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4272,7 +4978,7 @@ func (x *RoomGroupsUpdatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomGroupsUpdatedEvent.ProtoReflect.Descriptor instead.
 func (*RoomGroupsUpdatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{55}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{65}
 }
 
 // Notifies a user that their session has been terminated.
@@ -4289,7 +4995,7 @@ type SessionTerminatedEvent struct {
 
 func (x *SessionTerminatedEvent) Reset() {
 	*x = SessionTerminatedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[56]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4301,7 +5007,7 @@ func (x *SessionTerminatedEvent) String() string {
 func (*SessionTerminatedEvent) ProtoMessage() {}
 
 func (x *SessionTerminatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[56]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4314,7 +5020,7 @@ func (x *SessionTerminatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionTerminatedEvent.ProtoReflect.Descriptor instead.
 func (*SessionTerminatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{56}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *SessionTerminatedEvent) GetReason() string {
@@ -4343,7 +5049,7 @@ type VideoProcessingCompletedEvent struct {
 
 func (x *VideoProcessingCompletedEvent) Reset() {
 	*x = VideoProcessingCompletedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[57]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4355,7 +5061,7 @@ func (x *VideoProcessingCompletedEvent) String() string {
 func (*VideoProcessingCompletedEvent) ProtoMessage() {}
 
 func (x *VideoProcessingCompletedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[57]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4368,7 +5074,7 @@ func (x *VideoProcessingCompletedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VideoProcessingCompletedEvent.ProtoReflect.Descriptor instead.
 func (*VideoProcessingCompletedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{57}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *VideoProcessingCompletedEvent) GetRoomId() string {
@@ -4410,7 +5116,7 @@ type CallParticipantJoinedEvent struct {
 
 func (x *CallParticipantJoinedEvent) Reset() {
 	*x = CallParticipantJoinedEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[58]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4422,7 +5128,7 @@ func (x *CallParticipantJoinedEvent) String() string {
 func (*CallParticipantJoinedEvent) ProtoMessage() {}
 
 func (x *CallParticipantJoinedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[58]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4435,7 +5141,7 @@ func (x *CallParticipantJoinedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CallParticipantJoinedEvent.ProtoReflect.Descriptor instead.
 func (*CallParticipantJoinedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{58}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *CallParticipantJoinedEvent) GetRoomId() string {
@@ -4456,7 +5162,7 @@ type CallParticipantLeftEvent struct {
 
 func (x *CallParticipantLeftEvent) Reset() {
 	*x = CallParticipantLeftEvent{}
-	mi := &file_chatto_core_v1_event_proto_msgTypes[59]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4468,7 +5174,7 @@ func (x *CallParticipantLeftEvent) String() string {
 func (*CallParticipantLeftEvent) ProtoMessage() {}
 
 func (x *CallParticipantLeftEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_event_proto_msgTypes[59]
+	mi := &file_chatto_core_v1_event_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4481,7 +5187,7 @@ func (x *CallParticipantLeftEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CallParticipantLeftEvent.ProtoReflect.Descriptor instead.
 func (*CallParticipantLeftEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{59}
+	return file_chatto_core_v1_event_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *CallParticipantLeftEvent) GetRoomId() string {
@@ -4495,7 +5201,7 @@ var File_chatto_core_v1_event_proto protoreflect.FileDescriptor
 
 const file_chatto_core_v1_event_proto_rawDesc = "" +
 	"\n" +
-	"\x1achatto/core/v1/event.proto\x12\x0echatto.core.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1dchatto/config/v1/config.proto\x1a\x1bchatto/core/v1/models.proto\x1a%chatto/core/v1/user_preferences.proto\"\xff*\n" +
+	"\x1achatto/core/v1/event.proto\x12\x0echatto.core.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1dchatto/config/v1/config.proto\x1a\x1bchatto/core/v1/models.proto\x1a%chatto/core/v1/user_preferences.proto\"\xd52\n" +
 	"\x05Event\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x129\n" +
 	"\n" +
@@ -4531,7 +5237,17 @@ const file_chatto_core_v1_event_proto_rawDesc = "" +
 	"\x1fuser_server_preferences_changed\x18\xc4\x05 \x01(\v21.chatto.core.v1.UserServerPreferencesChangedEventH\x00R\x1cuserServerPreferencesChanged\x12o\n" +
 	"\x1buser_login_cooldown_cleared\x18\xc5\x05 \x01(\v2-.chatto.core.v1.UserLoginCooldownClearedEventH\x00R\x18userLoginCooldownCleared\x12\\\n" +
 	"\x14user_account_deleted\x18\xc6\x05 \x01(\v2'.chatto.core.v1.UserAccountDeletedEventH\x00R\x12userAccountDeleted\x12o\n" +
-	"\x1buser_login_cooldown_started\x18\xc7\x05 \x01(\v2-.chatto.core.v1.UserLoginCooldownStartedEventH\x00R\x18userLoginCooldownStarted\x12R\n" +
+	"\x1buser_login_cooldown_started\x18\xc7\x05 \x01(\v2-.chatto.core.v1.UserLoginCooldownStartedEventH\x00R\x18userLoginCooldownStarted\x12S\n" +
+	"\x11rbac_role_created\x18\xa0\x06 \x01(\v2$.chatto.core.v1.RbacRoleCreatedEventH\x00R\x0frbacRoleCreated\x12v\n" +
+	"\x1erbac_role_display_name_changed\x18\xa1\x06 \x01(\v2/.chatto.core.v1.RbacRoleDisplayNameChangedEventH\x00R\x1arbacRoleDisplayNameChanged\x12u\n" +
+	"\x1drbac_role_description_changed\x18\xa2\x06 \x01(\v2/.chatto.core.v1.RbacRoleDescriptionChangedEventH\x00R\x1arbacRoleDescriptionChanged\x12S\n" +
+	"\x11rbac_role_deleted\x18\xa3\x06 \x01(\v2$.chatto.core.v1.RbacRoleDeletedEventH\x00R\x0frbacRoleDeleted\x12\\\n" +
+	"\x14rbac_roles_reordered\x18\xa4\x06 \x01(\v2'.chatto.core.v1.RbacRolesReorderedEventH\x00R\x12rbacRolesReordered\x12V\n" +
+	"\x12rbac_role_assigned\x18\xa5\x06 \x01(\v2%.chatto.core.v1.RbacRoleAssignedEventH\x00R\x10rbacRoleAssigned\x12S\n" +
+	"\x11rbac_role_revoked\x18\xa6\x06 \x01(\v2$.chatto.core.v1.RbacRoleRevokedEventH\x00R\x0frbacRoleRevoked\x12e\n" +
+	"\x17rbac_permission_granted\x18\xaa\x06 \x01(\v2*.chatto.core.v1.RbacPermissionGrantedEventH\x00R\x15rbacPermissionGranted\x12b\n" +
+	"\x16rbac_permission_denied\x18\xab\x06 \x01(\v2).chatto.core.v1.RbacPermissionDeniedEventH\x00R\x14rbacPermissionDenied\x12e\n" +
+	"\x17rbac_permission_cleared\x18\xac\x06 \x01(\v2*.chatto.core.v1.RbacPermissionClearedEventH\x00R\x15rbacPermissionCleared\x12R\n" +
 	"\x0econfig_updated\x18\xe8\a \x01(\v2(.chatto.core.v1.ServerConfigUpdatedEventH\x00R\rconfigUpdated\x12F\n" +
 	"\fuser_created\x18\xf2\a \x01(\v2 .chatto.core.v1.UserCreatedEventH\x00R\vuserCreated\x12F\n" +
 	"\fuser_deleted\x18\xf3\a \x01(\v2 .chatto.core.v1.UserDeletedEventH\x00R\vuserDeleted\x12\\\n" +
@@ -4673,7 +5389,47 @@ const file_chatto_core_v1_event_proto_rawDesc = "" +
 	"\x1dUserLoginCooldownClearedEvent\x12\x17\n" +
 	"\auser_id\x18\x01 \x01(\tR\x06userId\"2\n" +
 	"\x17UserAccountDeletedEvent\x12\x17\n" +
-	"\auser_id\x18\x01 \x01(\tR\x06userId\"\xcd\x01\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\"\x8c\x01\n" +
+	"\x14RbacRoleCreatedEvent\x12\x1b\n" +
+	"\trole_name\x18\x01 \x01(\tR\broleName\x12!\n" +
+	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\x12 \n" +
+	"\vdescription\x18\x03 \x01(\tR\vdescription\x12\x12\n" +
+	"\x04rank\x18\x04 \x01(\x05R\x04rank\"a\n" +
+	"\x1fRbacRoleDisplayNameChangedEvent\x12\x1b\n" +
+	"\trole_name\x18\x01 \x01(\tR\broleName\x12!\n" +
+	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\"`\n" +
+	"\x1fRbacRoleDescriptionChangedEvent\x12\x1b\n" +
+	"\trole_name\x18\x01 \x01(\tR\broleName\x12 \n" +
+	"\vdescription\x18\x02 \x01(\tR\vdescription\"3\n" +
+	"\x14RbacRoleDeletedEvent\x12\x1b\n" +
+	"\trole_name\x18\x01 \x01(\tR\broleName\"8\n" +
+	"\x17RbacRolesReorderedEvent\x12\x1d\n" +
+	"\n" +
+	"role_names\x18\x01 \x03(\tR\troleNames\"M\n" +
+	"\x15RbacRoleAssignedEvent\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\x12\x1b\n" +
+	"\trole_name\x18\x02 \x01(\tR\broleName\"L\n" +
+	"\x14RbacRoleRevokedEvent\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\x12\x1b\n" +
+	"\trole_name\x18\x02 \x01(\tR\broleName\"r\n" +
+	"\x1aRbacPermissionGrantedEvent\x12\x1a\n" +
+	"\blocation\x18\x01 \x01(\tR\blocation\x12\x18\n" +
+	"\asubject\x18\x02 \x01(\tR\asubject\x12\x1e\n" +
+	"\n" +
+	"permission\x18\x03 \x01(\tR\n" +
+	"permission\"q\n" +
+	"\x19RbacPermissionDeniedEvent\x12\x1a\n" +
+	"\blocation\x18\x01 \x01(\tR\blocation\x12\x18\n" +
+	"\asubject\x18\x02 \x01(\tR\asubject\x12\x1e\n" +
+	"\n" +
+	"permission\x18\x03 \x01(\tR\n" +
+	"permission\"r\n" +
+	"\x1aRbacPermissionClearedEvent\x12\x1a\n" +
+	"\blocation\x18\x01 \x01(\tR\blocation\x12\x18\n" +
+	"\asubject\x18\x02 \x01(\tR\asubject\x12\x1e\n" +
+	"\n" +
+	"permission\x18\x03 \x01(\tR\n" +
+	"permission\"\xcd\x01\n" +
 	"\x1dNotificationLevelChangedEvent\x12\x17\n" +
 	"\aroom_id\x18\x02 \x01(\tR\x06roomId\x127\n" +
 	"\x05level\x18\x03 \x01(\x0e2!.chatto.core.v1.NotificationLevelR\x05level\x12J\n" +
@@ -4772,7 +5528,7 @@ func file_chatto_core_v1_event_proto_rawDescGZIP() []byte {
 	return file_chatto_core_v1_event_proto_rawDescData
 }
 
-var file_chatto_core_v1_event_proto_msgTypes = make([]protoimpl.MessageInfo, 60)
+var file_chatto_core_v1_event_proto_msgTypes = make([]protoimpl.MessageInfo, 70)
 var file_chatto_core_v1_event_proto_goTypes = []any{
 	(*Event)(nil),                             // 0: chatto.core.v1.Event
 	(*HeartbeatEvent)(nil),                    // 1: chatto.core.v1.HeartbeatEvent
@@ -4810,41 +5566,51 @@ var file_chatto_core_v1_event_proto_goTypes = []any{
 	(*UserLoginCooldownStartedEvent)(nil),     // 33: chatto.core.v1.UserLoginCooldownStartedEvent
 	(*UserLoginCooldownClearedEvent)(nil),     // 34: chatto.core.v1.UserLoginCooldownClearedEvent
 	(*UserAccountDeletedEvent)(nil),           // 35: chatto.core.v1.UserAccountDeletedEvent
-	(*NotificationLevelChangedEvent)(nil),     // 36: chatto.core.v1.NotificationLevelChangedEvent
-	(*ServerCreatedEvent)(nil),                // 37: chatto.core.v1.ServerCreatedEvent
-	(*ServerUpdatedEvent)(nil),                // 38: chatto.core.v1.ServerUpdatedEvent
-	(*ServerDeletedEvent)(nil),                // 39: chatto.core.v1.ServerDeletedEvent
-	(*MessageEditedEvent)(nil),                // 40: chatto.core.v1.MessageEditedEvent
-	(*MessageRetractedEvent)(nil),             // 41: chatto.core.v1.MessageRetractedEvent
-	(*MessageUpdatedEvent)(nil),               // 42: chatto.core.v1.MessageUpdatedEvent
-	(*MessageDeletedEvent)(nil),               // 43: chatto.core.v1.MessageDeletedEvent
-	(*ReactionAddedEvent)(nil),                // 44: chatto.core.v1.ReactionAddedEvent
-	(*ReactionRemovedEvent)(nil),              // 45: chatto.core.v1.ReactionRemovedEvent
-	(*UserTypingEvent)(nil),                   // 46: chatto.core.v1.UserTypingEvent
-	(*PresenceChangedEvent)(nil),              // 47: chatto.core.v1.PresenceChangedEvent
-	(*MentionNotificationEvent)(nil),          // 48: chatto.core.v1.MentionNotificationEvent
-	(*NewDirectMessageNotificationEvent)(nil), // 49: chatto.core.v1.NewDirectMessageNotificationEvent
-	(*NotificationCreatedEvent)(nil),          // 50: chatto.core.v1.NotificationCreatedEvent
-	(*NotificationDismissedEvent)(nil),        // 51: chatto.core.v1.NotificationDismissedEvent
-	(*ThreadFollowChangedEvent)(nil),          // 52: chatto.core.v1.ThreadFollowChangedEvent
-	(*RoomMarkedAsReadEvent)(nil),             // 53: chatto.core.v1.RoomMarkedAsReadEvent
-	(*MentionStatusClearedEvent)(nil),         // 54: chatto.core.v1.MentionStatusClearedEvent
-	(*RoomGroupsUpdatedEvent)(nil),            // 55: chatto.core.v1.RoomGroupsUpdatedEvent
-	(*SessionTerminatedEvent)(nil),            // 56: chatto.core.v1.SessionTerminatedEvent
-	(*VideoProcessingCompletedEvent)(nil),     // 57: chatto.core.v1.VideoProcessingCompletedEvent
-	(*CallParticipantJoinedEvent)(nil),        // 58: chatto.core.v1.CallParticipantJoinedEvent
-	(*CallParticipantLeftEvent)(nil),          // 59: chatto.core.v1.CallParticipantLeftEvent
-	(*timestamppb.Timestamp)(nil),             // 60: google.protobuf.Timestamp
-	(RoomKind)(0),                             // 61: chatto.core.v1.RoomKind
-	(*MessageBody)(nil),                       // 62: chatto.core.v1.MessageBody
-	(*v1.ServerConfig)(nil),                   // 63: chatto.config.v1.ServerConfig
-	(TimeFormat)(0),                           // 64: chatto.core.v1.TimeFormat
-	(*Asset)(nil),                             // 65: chatto.core.v1.Asset
-	(*ServerUserPreferences)(nil),             // 66: chatto.core.v1.ServerUserPreferences
-	(NotificationLevel)(0),                    // 67: chatto.core.v1.NotificationLevel
+	(*RbacRoleCreatedEvent)(nil),              // 36: chatto.core.v1.RbacRoleCreatedEvent
+	(*RbacRoleDisplayNameChangedEvent)(nil),   // 37: chatto.core.v1.RbacRoleDisplayNameChangedEvent
+	(*RbacRoleDescriptionChangedEvent)(nil),   // 38: chatto.core.v1.RbacRoleDescriptionChangedEvent
+	(*RbacRoleDeletedEvent)(nil),              // 39: chatto.core.v1.RbacRoleDeletedEvent
+	(*RbacRolesReorderedEvent)(nil),           // 40: chatto.core.v1.RbacRolesReorderedEvent
+	(*RbacRoleAssignedEvent)(nil),             // 41: chatto.core.v1.RbacRoleAssignedEvent
+	(*RbacRoleRevokedEvent)(nil),              // 42: chatto.core.v1.RbacRoleRevokedEvent
+	(*RbacPermissionGrantedEvent)(nil),        // 43: chatto.core.v1.RbacPermissionGrantedEvent
+	(*RbacPermissionDeniedEvent)(nil),         // 44: chatto.core.v1.RbacPermissionDeniedEvent
+	(*RbacPermissionClearedEvent)(nil),        // 45: chatto.core.v1.RbacPermissionClearedEvent
+	(*NotificationLevelChangedEvent)(nil),     // 46: chatto.core.v1.NotificationLevelChangedEvent
+	(*ServerCreatedEvent)(nil),                // 47: chatto.core.v1.ServerCreatedEvent
+	(*ServerUpdatedEvent)(nil),                // 48: chatto.core.v1.ServerUpdatedEvent
+	(*ServerDeletedEvent)(nil),                // 49: chatto.core.v1.ServerDeletedEvent
+	(*MessageEditedEvent)(nil),                // 50: chatto.core.v1.MessageEditedEvent
+	(*MessageRetractedEvent)(nil),             // 51: chatto.core.v1.MessageRetractedEvent
+	(*MessageUpdatedEvent)(nil),               // 52: chatto.core.v1.MessageUpdatedEvent
+	(*MessageDeletedEvent)(nil),               // 53: chatto.core.v1.MessageDeletedEvent
+	(*ReactionAddedEvent)(nil),                // 54: chatto.core.v1.ReactionAddedEvent
+	(*ReactionRemovedEvent)(nil),              // 55: chatto.core.v1.ReactionRemovedEvent
+	(*UserTypingEvent)(nil),                   // 56: chatto.core.v1.UserTypingEvent
+	(*PresenceChangedEvent)(nil),              // 57: chatto.core.v1.PresenceChangedEvent
+	(*MentionNotificationEvent)(nil),          // 58: chatto.core.v1.MentionNotificationEvent
+	(*NewDirectMessageNotificationEvent)(nil), // 59: chatto.core.v1.NewDirectMessageNotificationEvent
+	(*NotificationCreatedEvent)(nil),          // 60: chatto.core.v1.NotificationCreatedEvent
+	(*NotificationDismissedEvent)(nil),        // 61: chatto.core.v1.NotificationDismissedEvent
+	(*ThreadFollowChangedEvent)(nil),          // 62: chatto.core.v1.ThreadFollowChangedEvent
+	(*RoomMarkedAsReadEvent)(nil),             // 63: chatto.core.v1.RoomMarkedAsReadEvent
+	(*MentionStatusClearedEvent)(nil),         // 64: chatto.core.v1.MentionStatusClearedEvent
+	(*RoomGroupsUpdatedEvent)(nil),            // 65: chatto.core.v1.RoomGroupsUpdatedEvent
+	(*SessionTerminatedEvent)(nil),            // 66: chatto.core.v1.SessionTerminatedEvent
+	(*VideoProcessingCompletedEvent)(nil),     // 67: chatto.core.v1.VideoProcessingCompletedEvent
+	(*CallParticipantJoinedEvent)(nil),        // 68: chatto.core.v1.CallParticipantJoinedEvent
+	(*CallParticipantLeftEvent)(nil),          // 69: chatto.core.v1.CallParticipantLeftEvent
+	(*timestamppb.Timestamp)(nil),             // 70: google.protobuf.Timestamp
+	(RoomKind)(0),                             // 71: chatto.core.v1.RoomKind
+	(*MessageBody)(nil),                       // 72: chatto.core.v1.MessageBody
+	(*v1.ServerConfig)(nil),                   // 73: chatto.config.v1.ServerConfig
+	(TimeFormat)(0),                           // 74: chatto.core.v1.TimeFormat
+	(*Asset)(nil),                             // 75: chatto.core.v1.Asset
+	(*ServerUserPreferences)(nil),             // 76: chatto.core.v1.ServerUserPreferences
+	(NotificationLevel)(0),                    // 77: chatto.core.v1.NotificationLevel
 }
 var file_chatto_core_v1_event_proto_depIdxs = []int32{
-	60, // 0: chatto.core.v1.Event.created_at:type_name -> google.protobuf.Timestamp
+	70, // 0: chatto.core.v1.Event.created_at:type_name -> google.protobuf.Timestamp
 	2,  // 1: chatto.core.v1.Event.room_created:type_name -> chatto.core.v1.RoomCreatedEvent
 	3,  // 2: chatto.core.v1.Event.room_updated:type_name -> chatto.core.v1.RoomUpdatedEvent
 	4,  // 3: chatto.core.v1.Event.room_deleted:type_name -> chatto.core.v1.RoomDeletedEvent
@@ -4854,8 +5620,8 @@ var file_chatto_core_v1_event_proto_depIdxs = []int32{
 	8,  // 7: chatto.core.v1.Event.user_left_room:type_name -> chatto.core.v1.UserLeftRoomEvent
 	9,  // 8: chatto.core.v1.Event.space_member_deleted:type_name -> chatto.core.v1.SpaceMemberDeletedEvent
 	10, // 9: chatto.core.v1.Event.message_posted:type_name -> chatto.core.v1.MessagePostedEvent
-	40, // 10: chatto.core.v1.Event.message_edited:type_name -> chatto.core.v1.MessageEditedEvent
-	41, // 11: chatto.core.v1.Event.message_retracted:type_name -> chatto.core.v1.MessageRetractedEvent
+	50, // 10: chatto.core.v1.Event.message_edited:type_name -> chatto.core.v1.MessageEditedEvent
+	51, // 11: chatto.core.v1.Event.message_retracted:type_name -> chatto.core.v1.MessageRetractedEvent
 	11, // 12: chatto.core.v1.Event.server_config_changed:type_name -> chatto.core.v1.ServerConfigChangedEvent
 	12, // 13: chatto.core.v1.Event.room_group_created:type_name -> chatto.core.v1.RoomGroupCreatedEvent
 	13, // 14: chatto.core.v1.Event.room_group_updated:type_name -> chatto.core.v1.RoomGroupUpdatedEvent
@@ -4876,48 +5642,58 @@ var file_chatto_core_v1_event_proto_depIdxs = []int32{
 	34, // 29: chatto.core.v1.Event.user_login_cooldown_cleared:type_name -> chatto.core.v1.UserLoginCooldownClearedEvent
 	35, // 30: chatto.core.v1.Event.user_account_deleted:type_name -> chatto.core.v1.UserAccountDeletedEvent
 	33, // 31: chatto.core.v1.Event.user_login_cooldown_started:type_name -> chatto.core.v1.UserLoginCooldownStartedEvent
-	19, // 32: chatto.core.v1.Event.config_updated:type_name -> chatto.core.v1.ServerConfigUpdatedEvent
-	20, // 33: chatto.core.v1.Event.user_created:type_name -> chatto.core.v1.UserCreatedEvent
-	21, // 34: chatto.core.v1.Event.user_deleted:type_name -> chatto.core.v1.UserDeletedEvent
-	22, // 35: chatto.core.v1.Event.user_profile_updated:type_name -> chatto.core.v1.UserProfileUpdatedEvent
-	23, // 36: chatto.core.v1.Event.server_user_preferences_updated:type_name -> chatto.core.v1.ServerUserPreferencesUpdatedEvent
-	36, // 37: chatto.core.v1.Event.notification_level_changed:type_name -> chatto.core.v1.NotificationLevelChangedEvent
-	52, // 38: chatto.core.v1.Event.thread_follow_changed:type_name -> chatto.core.v1.ThreadFollowChangedEvent
-	37, // 39: chatto.core.v1.Event.server_created:type_name -> chatto.core.v1.ServerCreatedEvent
-	38, // 40: chatto.core.v1.Event.server_updated:type_name -> chatto.core.v1.ServerUpdatedEvent
-	39, // 41: chatto.core.v1.Event.server_deleted:type_name -> chatto.core.v1.ServerDeletedEvent
-	42, // 42: chatto.core.v1.Event.message_updated:type_name -> chatto.core.v1.MessageUpdatedEvent
-	43, // 43: chatto.core.v1.Event.message_deleted:type_name -> chatto.core.v1.MessageDeletedEvent
-	44, // 44: chatto.core.v1.Event.reaction_added:type_name -> chatto.core.v1.ReactionAddedEvent
-	45, // 45: chatto.core.v1.Event.reaction_removed:type_name -> chatto.core.v1.ReactionRemovedEvent
-	46, // 46: chatto.core.v1.Event.user_typing:type_name -> chatto.core.v1.UserTypingEvent
-	57, // 47: chatto.core.v1.Event.video_processing_completed:type_name -> chatto.core.v1.VideoProcessingCompletedEvent
-	47, // 48: chatto.core.v1.Event.presence_changed:type_name -> chatto.core.v1.PresenceChangedEvent
-	48, // 49: chatto.core.v1.Event.mention_notification:type_name -> chatto.core.v1.MentionNotificationEvent
-	49, // 50: chatto.core.v1.Event.new_direct_message_notification:type_name -> chatto.core.v1.NewDirectMessageNotificationEvent
-	58, // 51: chatto.core.v1.Event.call_participant_joined:type_name -> chatto.core.v1.CallParticipantJoinedEvent
-	59, // 52: chatto.core.v1.Event.call_participant_left:type_name -> chatto.core.v1.CallParticipantLeftEvent
-	50, // 53: chatto.core.v1.Event.notification_created:type_name -> chatto.core.v1.NotificationCreatedEvent
-	51, // 54: chatto.core.v1.Event.notification_dismissed:type_name -> chatto.core.v1.NotificationDismissedEvent
-	53, // 55: chatto.core.v1.Event.room_marked_as_read:type_name -> chatto.core.v1.RoomMarkedAsReadEvent
-	54, // 56: chatto.core.v1.Event.mention_status_cleared:type_name -> chatto.core.v1.MentionStatusClearedEvent
-	55, // 57: chatto.core.v1.Event.room_groups_updated:type_name -> chatto.core.v1.RoomGroupsUpdatedEvent
-	56, // 58: chatto.core.v1.Event.session_terminated:type_name -> chatto.core.v1.SessionTerminatedEvent
-	1,  // 59: chatto.core.v1.Event.heartbeat:type_name -> chatto.core.v1.HeartbeatEvent
-	61, // 60: chatto.core.v1.RoomCreatedEvent.kind:type_name -> chatto.core.v1.RoomKind
-	62, // 61: chatto.core.v1.MessagePostedEvent.body:type_name -> chatto.core.v1.MessageBody
-	63, // 62: chatto.core.v1.ServerConfigChangedEvent.config:type_name -> chatto.config.v1.ServerConfig
-	64, // 63: chatto.core.v1.ServerUserPreferencesUpdatedEvent.time_format:type_name -> chatto.core.v1.TimeFormat
-	65, // 64: chatto.core.v1.UserAvatarSetEvent.avatar:type_name -> chatto.core.v1.Asset
-	66, // 65: chatto.core.v1.UserServerPreferencesChangedEvent.preferences:type_name -> chatto.core.v1.ServerUserPreferences
-	67, // 66: chatto.core.v1.NotificationLevelChangedEvent.level:type_name -> chatto.core.v1.NotificationLevel
-	67, // 67: chatto.core.v1.NotificationLevelChangedEvent.effective_level:type_name -> chatto.core.v1.NotificationLevel
-	62, // 68: chatto.core.v1.MessageEditedEvent.body:type_name -> chatto.core.v1.MessageBody
-	69, // [69:69] is the sub-list for method output_type
-	69, // [69:69] is the sub-list for method input_type
-	69, // [69:69] is the sub-list for extension type_name
-	69, // [69:69] is the sub-list for extension extendee
-	0,  // [0:69] is the sub-list for field type_name
+	36, // 32: chatto.core.v1.Event.rbac_role_created:type_name -> chatto.core.v1.RbacRoleCreatedEvent
+	37, // 33: chatto.core.v1.Event.rbac_role_display_name_changed:type_name -> chatto.core.v1.RbacRoleDisplayNameChangedEvent
+	38, // 34: chatto.core.v1.Event.rbac_role_description_changed:type_name -> chatto.core.v1.RbacRoleDescriptionChangedEvent
+	39, // 35: chatto.core.v1.Event.rbac_role_deleted:type_name -> chatto.core.v1.RbacRoleDeletedEvent
+	40, // 36: chatto.core.v1.Event.rbac_roles_reordered:type_name -> chatto.core.v1.RbacRolesReorderedEvent
+	41, // 37: chatto.core.v1.Event.rbac_role_assigned:type_name -> chatto.core.v1.RbacRoleAssignedEvent
+	42, // 38: chatto.core.v1.Event.rbac_role_revoked:type_name -> chatto.core.v1.RbacRoleRevokedEvent
+	43, // 39: chatto.core.v1.Event.rbac_permission_granted:type_name -> chatto.core.v1.RbacPermissionGrantedEvent
+	44, // 40: chatto.core.v1.Event.rbac_permission_denied:type_name -> chatto.core.v1.RbacPermissionDeniedEvent
+	45, // 41: chatto.core.v1.Event.rbac_permission_cleared:type_name -> chatto.core.v1.RbacPermissionClearedEvent
+	19, // 42: chatto.core.v1.Event.config_updated:type_name -> chatto.core.v1.ServerConfigUpdatedEvent
+	20, // 43: chatto.core.v1.Event.user_created:type_name -> chatto.core.v1.UserCreatedEvent
+	21, // 44: chatto.core.v1.Event.user_deleted:type_name -> chatto.core.v1.UserDeletedEvent
+	22, // 45: chatto.core.v1.Event.user_profile_updated:type_name -> chatto.core.v1.UserProfileUpdatedEvent
+	23, // 46: chatto.core.v1.Event.server_user_preferences_updated:type_name -> chatto.core.v1.ServerUserPreferencesUpdatedEvent
+	46, // 47: chatto.core.v1.Event.notification_level_changed:type_name -> chatto.core.v1.NotificationLevelChangedEvent
+	62, // 48: chatto.core.v1.Event.thread_follow_changed:type_name -> chatto.core.v1.ThreadFollowChangedEvent
+	47, // 49: chatto.core.v1.Event.server_created:type_name -> chatto.core.v1.ServerCreatedEvent
+	48, // 50: chatto.core.v1.Event.server_updated:type_name -> chatto.core.v1.ServerUpdatedEvent
+	49, // 51: chatto.core.v1.Event.server_deleted:type_name -> chatto.core.v1.ServerDeletedEvent
+	52, // 52: chatto.core.v1.Event.message_updated:type_name -> chatto.core.v1.MessageUpdatedEvent
+	53, // 53: chatto.core.v1.Event.message_deleted:type_name -> chatto.core.v1.MessageDeletedEvent
+	54, // 54: chatto.core.v1.Event.reaction_added:type_name -> chatto.core.v1.ReactionAddedEvent
+	55, // 55: chatto.core.v1.Event.reaction_removed:type_name -> chatto.core.v1.ReactionRemovedEvent
+	56, // 56: chatto.core.v1.Event.user_typing:type_name -> chatto.core.v1.UserTypingEvent
+	67, // 57: chatto.core.v1.Event.video_processing_completed:type_name -> chatto.core.v1.VideoProcessingCompletedEvent
+	57, // 58: chatto.core.v1.Event.presence_changed:type_name -> chatto.core.v1.PresenceChangedEvent
+	58, // 59: chatto.core.v1.Event.mention_notification:type_name -> chatto.core.v1.MentionNotificationEvent
+	59, // 60: chatto.core.v1.Event.new_direct_message_notification:type_name -> chatto.core.v1.NewDirectMessageNotificationEvent
+	68, // 61: chatto.core.v1.Event.call_participant_joined:type_name -> chatto.core.v1.CallParticipantJoinedEvent
+	69, // 62: chatto.core.v1.Event.call_participant_left:type_name -> chatto.core.v1.CallParticipantLeftEvent
+	60, // 63: chatto.core.v1.Event.notification_created:type_name -> chatto.core.v1.NotificationCreatedEvent
+	61, // 64: chatto.core.v1.Event.notification_dismissed:type_name -> chatto.core.v1.NotificationDismissedEvent
+	63, // 65: chatto.core.v1.Event.room_marked_as_read:type_name -> chatto.core.v1.RoomMarkedAsReadEvent
+	64, // 66: chatto.core.v1.Event.mention_status_cleared:type_name -> chatto.core.v1.MentionStatusClearedEvent
+	65, // 67: chatto.core.v1.Event.room_groups_updated:type_name -> chatto.core.v1.RoomGroupsUpdatedEvent
+	66, // 68: chatto.core.v1.Event.session_terminated:type_name -> chatto.core.v1.SessionTerminatedEvent
+	1,  // 69: chatto.core.v1.Event.heartbeat:type_name -> chatto.core.v1.HeartbeatEvent
+	71, // 70: chatto.core.v1.RoomCreatedEvent.kind:type_name -> chatto.core.v1.RoomKind
+	72, // 71: chatto.core.v1.MessagePostedEvent.body:type_name -> chatto.core.v1.MessageBody
+	73, // 72: chatto.core.v1.ServerConfigChangedEvent.config:type_name -> chatto.config.v1.ServerConfig
+	74, // 73: chatto.core.v1.ServerUserPreferencesUpdatedEvent.time_format:type_name -> chatto.core.v1.TimeFormat
+	75, // 74: chatto.core.v1.UserAvatarSetEvent.avatar:type_name -> chatto.core.v1.Asset
+	76, // 75: chatto.core.v1.UserServerPreferencesChangedEvent.preferences:type_name -> chatto.core.v1.ServerUserPreferences
+	77, // 76: chatto.core.v1.NotificationLevelChangedEvent.level:type_name -> chatto.core.v1.NotificationLevel
+	77, // 77: chatto.core.v1.NotificationLevelChangedEvent.effective_level:type_name -> chatto.core.v1.NotificationLevel
+	72, // 78: chatto.core.v1.MessageEditedEvent.body:type_name -> chatto.core.v1.MessageBody
+	79, // [79:79] is the sub-list for method output_type
+	79, // [79:79] is the sub-list for method input_type
+	79, // [79:79] is the sub-list for extension type_name
+	79, // [79:79] is the sub-list for extension extendee
+	0,  // [0:79] is the sub-list for field type_name
 }
 
 func init() { file_chatto_core_v1_event_proto_init() }
@@ -4959,6 +5735,16 @@ func file_chatto_core_v1_event_proto_init() {
 		(*Event_UserLoginCooldownCleared)(nil),
 		(*Event_UserAccountDeleted)(nil),
 		(*Event_UserLoginCooldownStarted)(nil),
+		(*Event_RbacRoleCreated)(nil),
+		(*Event_RbacRoleDisplayNameChanged)(nil),
+		(*Event_RbacRoleDescriptionChanged)(nil),
+		(*Event_RbacRoleDeleted)(nil),
+		(*Event_RbacRolesReordered)(nil),
+		(*Event_RbacRoleAssigned)(nil),
+		(*Event_RbacRoleRevoked)(nil),
+		(*Event_RbacPermissionGranted)(nil),
+		(*Event_RbacPermissionDenied)(nil),
+		(*Event_RbacPermissionCleared)(nil),
 		(*Event_ConfigUpdated)(nil),
 		(*Event_UserCreated)(nil),
 		(*Event_UserDeleted)(nil),
@@ -4988,14 +5774,14 @@ func file_chatto_core_v1_event_proto_init() {
 		(*Event_SessionTerminated)(nil),
 		(*Event_Heartbeat)(nil),
 	}
-	file_chatto_core_v1_event_proto_msgTypes[46].OneofWrappers = []any{}
+	file_chatto_core_v1_event_proto_msgTypes[56].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_core_v1_event_proto_rawDesc), len(file_chatto_core_v1_event_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   60,
+			NumMessages:   70,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -261,7 +261,7 @@ There is no `adminAuditLogEvents` subscription — audit events arrive through `
 | KV      | `NOTIFICATIONS`               | User notifications (90-day TTL)             |
 | KV      | `AUTH_TOKENS`                 | Bearer auth tokens (configurable TTL)       |
 | KV      | `SERVER_CONFIG`               | Rooms (channel + DM), memberships           |
-| KV      | `SERVER_RBAC`                 | Roles, permissions, assignments (single flat tier — owner/admin/moderator/everyone) |
+| KV      | `SERVER_RBAC`                 | Legacy RBAC seed data read by the `EVT` boot migration |
 | KV      | `SERVER_RUNTIME`              | Read status, mention tracking               |
 | KV      | `SERVER_BODIES`               | Message bodies (GDPR-compliant) + standalone attachment metadata records — TODO: rename → `SERVER_CONTENT` |
 | KV      | `SERVER_REACTIONS`            | Legacy emoji reactions source for boot migration only |
@@ -282,7 +282,7 @@ of truth and the event is additive.
 `EVT` publishing because `EVT` is their source of truth and reads come
 from in-memory projections. If event publishing fails, the write fails.
 Current migrated aggregates include room membership/metadata,
-room groups/layout, server config, messages/threads, and reactions.
+room groups/layout, server config, messages/threads, reactions, and RBAC.
 
 ### Consistency Model
 
@@ -381,7 +381,7 @@ The two paths share the same subject root; leaf tokens disambiguate (`.msg.{id}`
 | Stream                       | Wrapper          | Scope      | Description                                      |
 | ---------------------------- | ---------------- | ---------- | ------------------------------------------------ |
 | `SERVER_EVENTS`              | `corev1.Event`   | Server     | All JetStream-stored events for the legacy CRUD+log pattern; republishes onto `live.server.>` |
-| `EVT`                 | `corev1.Event`   | Server     | Event-sourcing log ([ADR-033](adr/ADR-033-event-sourced-state-with-projections.md) / [ADR-034](adr/ADR-034-single-event-stream.md)). Subjects `evt.{aggregateType}.{aggregateId}.{eventType}`; republishes onto `live.evt.>` for future/direct consumers. Currently fed by per-aggregate boot imports ([ADR-035](adr/ADR-035-per-aggregate-phased-migration.md)); migrated aggregates include room membership/metadata, groups/layout, server config, messages/threads, and reactions. |
+| `EVT`                 | `corev1.Event`   | Server     | Event-sourcing log ([ADR-033](adr/ADR-033-event-sourced-state-with-projections.md) / [ADR-034](adr/ADR-034-single-event-stream.md)). Subjects `evt.{aggregateType}.{aggregateId}.{eventType}`; republishes onto `live.evt.>` for future/direct consumers. Currently fed by per-aggregate boot imports ([ADR-035](adr/ADR-035-per-aggregate-phased-migration.md)); migrated aggregates include room membership/metadata, groups/layout, server config, messages/threads, reactions, and RBAC. |
 | Live Events                  | `corev1.Event`   | Transient  | `live.server.>` is the active GraphQL subscription root. `SERVER_EVENTS` republishes into it, and migrated `EVT` aggregates publish non-durable compatibility mirrors into it. `live.evt.>` is fed by `EVT` republish but is not the active `myEvents` path during the migration window. |
 
 **SERVER\_EVENTS subjects:**
@@ -484,7 +484,7 @@ The unified `myEvents` GraphQL subscription is backed by a single core stream (`
 | `INSTANCE`                    | File    | Yes      | Users, memberships (bucket name retained from pre-rename) |
 | `INSTANCE_CONFIG`             | File    | Yes      | Server runtime configuration overrides          |
 | `SERVER_CONFIG`               | File    | Yes      | Rooms (channel + DM), memberships               |
-| `SERVER_RBAC`                 | File    | Yes      | Roles, permissions, assignments (single flat tier) |
+| `SERVER_RBAC`                 | File    | Yes      | Legacy RBAC seed data read by the `EVT` boot migration |
 | `SERVER_RUNTIME`              | File    | Yes      | Read state, mention tracking                    |
 | `SERVER_BODIES`               | File    | Yes      | Message bodies (GDPR-compliant) + standalone attachment metadata records — TODO: rename → `SERVER_CONTENT` |
 | `SERVER_REACTIONS`            | File    | Yes      | Legacy emoji reactions, read only by the EVT boot migration |
@@ -577,7 +577,21 @@ Useful filter patterns:
 
 **SERVER\_RBAC keys:**
 
-Keys: `role.*`, `role_permission.*`, `role_assignment.*`, `user_permission.*`, `user_permission_denied.*`.
+RBAC is event-sourced under `evt.rbac.>`. Role CRUD/reorder, role assignment,
+direct user overrides, and server-scoped permission decisions use
+`evt.rbac.server.*`; room and group scoped decisions use
+`evt.rbac.{roomId}.*` and `evt.rbac.{groupId}.*` with the Chatto entity ID
+directly as the aggregate ID. All RBAC writes share `evt.rbac.>` as their OCC
+domain, so those subject partitions are descriptive labels, not independent
+consistency boundaries. Permission checks, admin role/permission reads,
+permission inspector traces, and hierarchy/outrank checks read from the
+in-memory RBAC projection.
+
+`SERVER_RBAC` is retained only as legacy import evidence until the aggregate
+cleanup phase. The RBAC boot importer reads historical `role.*`, `member.*`,
+`allow.*`, `deny.*`, `group_allow.*`, `group_deny.*`, `room_allow.*`, and
+`room_deny.*` keys into `EVT` using OCC so repeated boots skip an already seeded
+RBAC subject family.
 
 **SERVER\_RUNTIME keys:**
 

--- a/docs/fdr/FDR-001-roles-and-permissions.md
+++ b/docs/fdr/FDR-001-roles-and-permissions.md
@@ -1,7 +1,7 @@
 # FDR-001: Roles & Permissions (RBAC)
 
 **Status:** Active
-**Last reviewed:** 2026-05-19
+**Last reviewed:** 2026-05-26
 
 ## Overview
 
@@ -35,7 +35,7 @@ Chatto controls who can do what through role-based access control. Every authent
 
 **Decision:** Permissions resolve room → group → server. The most specific scope wins.
 **Why:** Operators want both "system-wide defaults" and "this one channel works differently" without modelling them as separate role systems. See ADR-031.
-**Tradeoff:** A given permission decision now requires checking up to three KV lookups per role. Acceptable given resolution happens in-process.
+**Tradeoff:** A given permission decision now checks up to three scopes per role. This is acceptable because current RBAC state is kept in an in-memory projection.
 
 ### 4. Owner privileges materialize as role grants, not bypass
 
@@ -55,6 +55,12 @@ Chatto controls who can do what through role-based access control. Every authent
 **Why:** Otherwise a rogue moderator with `role.assign` could rename the owner. Permission asks "can this role do X at all?"; rank asks "does the actor outrank this specific target?". Both are needed.
 **Tradeoff:** Two-step checks are more code than a single permission lookup, and easy to forget when adding new mutations. Helpers (`requireUserAdminTarget`, `requireUserPermissionTarget`) exist to keep call sites uniform.
 
+### 7. RBAC state is event-sourced
+
+**Decision:** Role definitions, role order, assignments, and explicit permission decisions are durable events, with reads served from an in-memory RBAC projection.
+**Why:** This aligns RBAC with the rest of Chatto's event-sourced migration and makes authorization reads rebuildable from the deployment event log. See ADR-033 and ADR-035.
+**Tradeoff:** Writes must append events and wait for local projection catch-up before returning, so mutation paths need optimistic concurrency handling instead of direct state writes.
+
 ## Permissions
 
 The full permission catalog is in `cli/internal/core/permission.go`. Key permissions that gate RBAC management itself:
@@ -65,5 +71,5 @@ The full permission catalog is in `cli/internal/core/permission.go`. Key permiss
 
 ## Related
 
-- **ADRs:** ADR-004 (authorization at API boundary), ADR-005 (hierarchy-wins RBAC), ADR-027 (instance/space consolidation), ADR-030 (space tier retirement), ADR-031 (room-group-centric ACL)
+- **ADRs:** ADR-004 (authorization at API boundary), ADR-005 (hierarchy-wins RBAC), ADR-027 (instance/space consolidation), ADR-030 (space tier retirement), ADR-031 (room-group-centric ACL), ADR-033 (event-sourced state), ADR-035 (per-aggregate migration)
 - **FDRs:** Every FDR that mentions a permission depends on this one.

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -10,7 +10,7 @@ See [`.claude/skills/fdr/SKILL.md`](../../.claude/skills/fdr/SKILL.md) for the F
 
 | # | Feature | Status | Last reviewed |
 |---|---------|--------|---------------|
-| [FDR-001](FDR-001-roles-and-permissions.md) | Roles & Permissions (RBAC) | Active | 2026-05-19 |
+| [FDR-001](FDR-001-roles-and-permissions.md) | Roles & Permissions (RBAC) | Active | 2026-05-26 |
 | [FDR-002](FDR-002-replies-and-threads.md) | Replies & Threads | Active | 2026-05-19 |
 | [FDR-003](FDR-003-thread-reply-echo.md) | Thread Reply Echo | Active | 2026-05-19 |
 | [FDR-004](FDR-004-message-editing-and-deletion.md) | Message Editing & Deletion | Active | 2026-05-19 |

--- a/proto/chatto/core/v1/event.proto
+++ b/proto/chatto/core/v1/event.proto
@@ -114,7 +114,7 @@ message Event {
     // tracks explicit reorders.
     RoomGroupsReorderedEvent room_groups_reordered = 650;
 
-    // ----- Users (700-719, durable, evt.user.{userId}) -----
+    // ----- Users (700-799, durable, evt.user.{userId}) -----
     UserAccountCreatedEvent user_account_created = 700;
     UserLoginChangedEvent user_login_changed = 701;
     UserDisplayNameChangedEvent user_display_name_changed = 702;
@@ -127,6 +127,18 @@ message Event {
     UserLoginCooldownClearedEvent user_login_cooldown_cleared = 709;
     UserAccountDeletedEvent user_account_deleted = 710;
     UserLoginCooldownStartedEvent user_login_cooldown_started = 711;
+
+    // ----- RBAC (800-839, durable, evt.rbac.>) -----
+    RbacRoleCreatedEvent rbac_role_created = 800;
+    RbacRoleDisplayNameChangedEvent rbac_role_display_name_changed = 801;
+    RbacRoleDescriptionChangedEvent rbac_role_description_changed = 802;
+    RbacRoleDeletedEvent rbac_role_deleted = 803;
+    RbacRolesReorderedEvent rbac_roles_reordered = 804;
+    RbacRoleAssignedEvent rbac_role_assigned = 805;
+    RbacRoleRevokedEvent rbac_role_revoked = 806;
+    RbacPermissionGrantedEvent rbac_permission_granted = 810;
+    RbacPermissionDeniedEvent rbac_permission_denied = 811;
+    RbacPermissionClearedEvent rbac_permission_cleared = 812;
 
     // =================================================================
     // LIVE-ONLY VARIANTS (>= 1000) — never persisted.
@@ -553,6 +565,64 @@ message UserLoginCooldownClearedEvent {
 
 message UserAccountDeletedEvent {
   string user_id = 1;
+}
+
+// ============================================================================
+// DURABLE RBAC EVENTS (evt.rbac.>)
+// ============================================================================
+
+message RbacRoleCreatedEvent {
+  string role_name = 1;
+  string display_name = 2;
+  string description = 3;
+  int32 rank = 4;
+}
+
+message RbacRoleDisplayNameChangedEvent {
+  string role_name = 1;
+  string display_name = 2;
+}
+
+message RbacRoleDescriptionChangedEvent {
+  string role_name = 1;
+  string description = 2;
+}
+
+message RbacRoleDeletedEvent {
+  string role_name = 1;
+}
+
+message RbacRolesReorderedEvent {
+  repeated string role_names = 1;
+}
+
+message RbacRoleAssignedEvent {
+  string user_id = 1;
+  string role_name = 2;
+}
+
+message RbacRoleRevokedEvent {
+  string user_id = 1;
+  string role_name = 2;
+}
+
+message RbacPermissionGrantedEvent {
+  string location = 1; // "server", room ID, or group ID.
+  string subject = 2;
+  string permission = 3;
+}
+
+message RbacPermissionDeniedEvent {
+  string location = 1; // "server", room ID, or group ID.
+  string subject = 2;
+  string permission = 3;
+}
+
+// Removes any explicit allow or deny, returning this permission to inherited/no-decision state.
+message RbacPermissionClearedEvent {
+  string location = 1; // "server", room ID, or group ID.
+  string subject = 2;
+  string permission = 3;
 }
 
 // NotificationLevelChangedEvent is published when a user changes their notification


### PR DESCRIPTION
## Summary

Event-sources RBAC roles, role order, assignments, and explicit permission decisions under evt.rbac.>, with boot import from legacy SERVER_RBAC and projection-backed reads. Adds RBAC event subjects/protobufs, OCC-protected writes, reset/import helpers, and direct projection coverage for RBAC plus nearby reaction/layout projection gaps. Updates architecture and FDR-001 to document RBAC as an EVT-backed aggregate.

## Verification

- mise x -- go test ./internal/core -run 'TestRBACProjection|TestReactionProjection|TestRoomLayoutProjection' -count=1 -timeout 120s
- mise x -- go test ./internal/core ./internal/events -count=1 -timeout 240s
- mise x -- go test ./internal/events -count=1 -timeout 120s
- mise x -- go test ./internal/graph ./internal/migrations -count=1 -timeout 180s

Closes #644.
