### PR TITLE
feat(storage): move read markers to runtime state

### DIFF
--- a/cli/cmd/backup_test.go
+++ b/cli/cmd/backup_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
+	"hmans.de/chatto/internal/testutil"
 )
 
 func TestSkipReason(t *testing.T) {
@@ -182,37 +183,12 @@ func TestCreateAndExtractTarGz(t *testing.T) {
 func startTestNATS(t *testing.T) (*server.Server, *nats.Conn, jetstream.JetStream) {
 	t.Helper()
 
-	opts := &server.Options{
-		JetStream: true,
-		Port:      -1, // random port
-		StoreDir:  t.TempDir(),
-	}
-
-	ns, err := server.NewServer(opts)
-	if err != nil {
-		t.Fatalf("Failed to create NATS server: %v", err)
-	}
-
-	go ns.Start()
-	if !ns.ReadyForConnections(5 * time.Second) {
-		t.Fatal("NATS server not ready")
-	}
-
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		t.Fatalf("Failed to connect to NATS: %v", err)
-	}
+	ns, nc := testutil.StartNATS(t)
 
 	js, err := jetstream.New(nc)
 	if err != nil {
 		t.Fatalf("Failed to create JetStream context: %v", err)
 	}
-
-	t.Cleanup(func() {
-		nc.Close()
-		ns.Shutdown()
-		ns.WaitForShutdown()
-	})
 
 	return ns, nc, js
 }

--- a/cli/cmd/bootstrap_test.go
+++ b/cli/cmd/bootstrap_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/nats-server/v2/server"
-	"github.com/nats-io/nats.go"
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/core"
+	"hmans.de/chatto/internal/testutil"
 )
 
 // setupCore spins up an in-process NATS server + ChattoCore for cmd-layer tests.
@@ -18,25 +17,7 @@ import (
 func setupCore(t *testing.T) *core.ChattoCore {
 	t.Helper()
 
-	opts := &server.Options{JetStream: true, Port: -1, StoreDir: t.TempDir()}
-	ns, err := server.NewServer(opts)
-	if err != nil {
-		t.Fatalf("nats server: %v", err)
-	}
-	go ns.Start()
-	if !ns.ReadyForConnections(5 * time.Second) {
-		t.Fatal("nats not ready")
-	}
-
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		t.Fatalf("nats connect: %v", err)
-	}
-	t.Cleanup(func() {
-		nc.Close()
-		ns.Shutdown()
-		ns.WaitForShutdown()
-	})
+	_, nc := testutil.StartNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)
@@ -51,8 +32,16 @@ func setupCore(t *testing.T) *core.ChattoCore {
 	// same set cmd/run.go boots via c.Run. Membership mutations need the
 	// projector loops to advance so WaitForSeq returns.
 	servicesCtx, servicesCancel := context.WithCancel(context.Background())
-	go func() { _ = c.Run(servicesCtx) }()
-	t.Cleanup(servicesCancel)
+	servicesDone := make(chan error, 1)
+	go func() { servicesDone <- c.Run(servicesCtx) }()
+	t.Cleanup(func() {
+		servicesCancel()
+		select {
+		case <-servicesDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("core.Run did not stop within timeout")
+		}
+	})
 	bootCtx, bootCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer bootCancel()
 	if err := c.WaitForBoot(bootCtx); err != nil {
@@ -76,11 +65,11 @@ func TestApplyBootstrap_CreatesUsersAndServer(t *testing.T) {
 	cfg := config.BootstrapConfig{
 		Users: []config.BootstrapUser{
 			{
-				Login:        "alice",
-				DisplayName:  "Alice",
-				Email:        "alice@example.com",
-				Password:     "devpassword",
-				ServerRole: "owner",
+				Login:       "alice",
+				DisplayName: "Alice",
+				Email:       "alice@example.com",
+				Password:    "devpassword",
+				ServerRole:  "owner",
 			},
 			{
 				Login:    "bob",

--- a/cli/internal/core/attachments_test.go
+++ b/cli/internal/core/attachments_test.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/johannesboyne/gofakes3"
 	"github.com/johannesboyne/gofakes3/backend/s3mem"
-	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"hmans.de/chatto/internal/config"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+	"hmans.de/chatto/internal/testutil"
 	"hmans.de/chatto/pkg/signedurl"
 )
 
@@ -785,33 +785,7 @@ func setupTestCoreWithS3(t *testing.T) (*ChattoCore, *nats.Conn, *S3Client) {
 
 	endpointHost := s3Server.URL[7:] // Remove "http://"
 
-	// Start embedded NATS server
-	opts := &server.Options{
-		JetStream: true,
-		Port:      -1,
-		StoreDir:  t.TempDir(),
-	}
-
-	ns, err := server.NewServer(opts)
-	if err != nil {
-		t.Fatalf("Failed to create NATS server: %v", err)
-	}
-
-	go ns.Start()
-	if !ns.ReadyForConnections(5 * 1e9) {
-		t.Fatal("NATS server not ready")
-	}
-
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		t.Fatalf("Failed to connect to NATS: %v", err)
-	}
-
-	t.Cleanup(func() {
-		nc.Close()
-		ns.Shutdown()
-		ns.WaitForShutdown()
-	})
+	_, nc := testutil.StartNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)
@@ -853,33 +827,7 @@ func setupTestCoreWithS3(t *testing.T) (*ChattoCore, *nats.Conn, *S3Client) {
 func setupTestCoreWithCache(t *testing.T) (*ChattoCore, *nats.Conn) {
 	t.Helper()
 
-	// Start embedded NATS server
-	opts := &server.Options{
-		JetStream: true,
-		Port:      -1,
-		StoreDir:  t.TempDir(),
-	}
-
-	ns, err := server.NewServer(opts)
-	if err != nil {
-		t.Fatalf("Failed to create NATS server: %v", err)
-	}
-
-	go ns.Start()
-	if !ns.ReadyForConnections(5 * 1e9) {
-		t.Fatal("NATS server not ready")
-	}
-
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		t.Fatalf("Failed to connect to NATS: %v", err)
-	}
-
-	t.Cleanup(func() {
-		nc.Close()
-		ns.Shutdown()
-		ns.WaitForShutdown()
-	})
+	_, nc := testutil.StartNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -669,6 +669,7 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	if err := migrations.RunAll(
 		ctx,
 		storage.serverKV, storage.serverConfigKV, storage.serverBodiesKV, storage.serverRuntimeKV, storage.runtimeConfigKV,
+		storage.runtimeStateKV,
 		storage.serverEventsStream, storage.serverReactionsKV,
 		eventPublisher,
 		logger,
@@ -720,6 +721,7 @@ type storage struct {
 	serverStore     jetstream.ObjectStore
 	encryptionKV    jetstream.KeyValue // Encryption keys (excluded from backups)
 	runtimeConfigKV jetstream.KeyValue // INSTANCE_CONFIG - runtime configuration overrides
+	runtimeStateKV  jetstream.KeyValue // RUNTIME_STATE  - persisted latest-value runtime/user state
 
 	// Server-level KV buckets (#330 phase 4a, 4b, 4c, 4e) and event stream
 	// (#330 phase 4d). Shared by the primary and DM spaces; non-primary,
@@ -809,6 +811,19 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create INSTANCE_CONFIG KV bucket: %w", err)
+	}
+
+	runtimeStateKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:         "RUNTIME_STATE",
+		Description:    "Persisted latest-value runtime/user state",
+		Storage:        jetstream.FileStorage,
+		History:        1,
+		Compression:    true,
+		Replicas:       cfg.Replicas,
+		LimitMarkerTTL: 24 * time.Hour,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create RUNTIME_STATE KV bucket: %w", err)
 	}
 
 	// Initialize image cache object store (optional, only when enabled)
@@ -1014,6 +1029,7 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		serverStore:        serverStore,
 		encryptionKV:       encryptionKV,
 		runtimeConfigKV:    runtimeConfigKV,
+		runtimeStateKV:     runtimeStateKV,
 		serverConfigKV:     serverConfigKV,
 		serverRBACKV:       serverRBACKV,
 		serverRuntimeKV:    serverRuntimeKV,

--- a/cli/internal/core/core_test.go
+++ b/cli/internal/core/core_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"hmans.de/chatto/internal/config"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+	"hmans.de/chatto/internal/testutil"
 )
 
 // ============================================================================
@@ -30,33 +30,7 @@ func testContext(t *testing.T) context.Context {
 func setupTestCore(t *testing.T) (*ChattoCore, *nats.Conn) {
 	t.Helper()
 
-	// Start embedded NATS server
-	opts := &server.Options{
-		JetStream: true,
-		Port:      -1,
-		StoreDir:  t.TempDir(),
-	}
-
-	ns, err := server.NewServer(opts)
-	if err != nil {
-		t.Fatalf("Failed to create NATS server: %v", err)
-	}
-
-	go ns.Start()
-	if !ns.ReadyForConnections(5 * 1e9) {
-		t.Fatal("NATS server not ready")
-	}
-
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		t.Fatalf("Failed to connect to NATS: %v", err)
-	}
-
-	t.Cleanup(func() {
-		nc.Close()
-		ns.Shutdown()
-		ns.WaitForShutdown()
-	})
+	_, nc := testutil.StartNATS(t)
 
 	ctx := testContext(t)
 
@@ -86,8 +60,16 @@ func setupTestCore(t *testing.T) (*ChattoCore, *nats.Conn) {
 func startCoreServices(t *testing.T, core *ChattoCore) {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
-	go func() { _ = core.Run(ctx) }()
-	t.Cleanup(cancel)
+	done := make(chan error, 1)
+	go func() { done <- core.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("core.Run did not stop within timeout")
+		}
+	})
 	// Block until Run's boot phase is complete — projectors started
 	// AND ensureChannelRoomsAreInAGroup has run. Without this the
 	// test thread races ahead and issues reads against an empty

--- a/cli/internal/core/encryption_test.go
+++ b/cli/internal/core/encryption_test.go
@@ -5,37 +5,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/nats-server/v2/server"
-	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/require"
 	"hmans.de/chatto/internal/config"
+	"hmans.de/chatto/internal/testutil"
 )
 
 // setupTestCoreWithEncryption creates a ChattoCore for encryption tests.
 func setupTestCoreWithEncryption(t *testing.T) *ChattoCore {
 	t.Helper()
 
-	// Start embedded NATS server
-	opts := &server.Options{
-		JetStream: true,
-		Port:      -1,
-		StoreDir:  t.TempDir(),
-	}
-
-	ns, err := server.NewServer(opts)
-	require.NoError(t, err)
-
-	go ns.Start()
-	require.True(t, ns.ReadyForConnections(5*time.Second))
-
-	nc, err := nats.Connect(ns.ClientURL())
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		nc.Close()
-		ns.Shutdown()
-		ns.WaitForShutdown()
-	})
+	_, nc := testutil.StartNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)

--- a/cli/internal/core/message_body.go
+++ b/cli/internal/core/message_body.go
@@ -156,7 +156,7 @@ func (c *ChattoCore) decryptMessageBody(ctx context.Context, msg *corev1.Message
 func (c *ChattoCore) deleteUserMessageBodiesInSpace(ctx context.Context, userID string, kind RoomKind) (int, error) {
 	bucket := c.storage.serverBodiesKV
 
-	lister, err := bucket.ListKeysFiltered(ctx, userID+".")
+	lister, err := bucket.ListKeysFiltered(ctx, userID+".>")
 	if err != nil {
 		if errors.Is(err, jetstream.ErrNoKeysFound) {
 			return 0, nil

--- a/cli/internal/core/messages.go
+++ b/cli/internal/core/messages.go
@@ -232,9 +232,9 @@ func (c *ChattoCore) PostMessage(ctx context.Context, kind RoomKind, room_id, us
 			rootAuthorID = rootEvent.ActorId
 		}
 
-		// Update the poster's "last opened" timestamp for this thread.
+		// Update the poster's thread read marker to the reply they just wrote.
 		// This ensures that on page reload, their own message won't show as "unread".
-		if _, err := c.SetThreadLastOpened(ctx, kind, user_id, room_id, inThread); err != nil {
+		if _, err := c.SetThreadLastReadEventID(ctx, kind, user_id, room_id, inThread, event.Id); err != nil {
 			c.logger.Warn("Failed to update thread last opened for poster", "error", err, "thread_root_event_id", inThread)
 			// Continue anyway - this is best-effort
 		}

--- a/cli/internal/core/rbac_engine_test.go
+++ b/cli/internal/core/rbac_engine_test.go
@@ -4,46 +4,20 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
-	"github.com/nats-io/nats-server/v2/server"
-	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
-
+	"hmans.de/chatto/internal/testutil"
 )
 
 // setupTestEngine creates an embedded NATS server, KV bucket, and RBAC engine for testing.
 func setupTestEngine(t *testing.T, config Config) (*Engine, func()) {
 	t.Helper()
 
-	// Start embedded NATS server with JetStream
-	opts := &server.Options{
-		Port:      -1, // Random available port
-		JetStream: true,
-		StoreDir:  t.TempDir(),
-	}
-	ns, err := server.NewServer(opts)
-	if err != nil {
-		t.Fatalf("Failed to create NATS server: %v", err)
-	}
-	ns.Start()
-
-	if !ns.ReadyForConnections(5 * time.Second) {
-		t.Fatal("NATS server not ready")
-	}
-
-	// Connect to the server
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		ns.Shutdown()
-		t.Fatalf("Failed to connect to NATS: %v", err)
-	}
+	_, nc := testutil.StartNATS(t)
 
 	// Create JetStream context
 	js, err := jetstream.New(nc)
 	if err != nil {
-		nc.Close()
-		ns.Shutdown()
 		t.Fatalf("Failed to create JetStream context: %v", err)
 	}
 
@@ -53,19 +27,12 @@ func setupTestEngine(t *testing.T, config Config) (*Engine, func()) {
 		Bucket: "TEST_RBAC",
 	})
 	if err != nil {
-		nc.Close()
-		ns.Shutdown()
 		t.Fatalf("Failed to create KV bucket: %v", err)
 	}
 
 	engine := NewEngine(kv, config)
 
-	cleanup := func() {
-		nc.Close()
-		ns.Shutdown()
-	}
-
-	return engine, cleanup
+	return engine, func() {}
 }
 
 // Default test config without user overrides
@@ -76,13 +43,13 @@ func defaultTestConfig() Config {
 		ValidateVerbObjectType: func(verb, objectType string) error {
 			// Valid verb+objectType combinations for tests
 			validCombos := map[string]bool{
-				"create.room":     true,
-				"post.message":    true,
+				"create.room":        true,
+				"post.message":       true,
 				"delete-any.message": true,
-				"manage.space":    true,
-				"create.space":    true,
-				"access.admin":    true,
-				"delete.room":     true,
+				"manage.space":       true,
+				"create.space":       true,
+				"access.admin":       true,
+				"delete.room":        true,
 			}
 			key := verb + "." + objectType
 			if !validCombos[key] {
@@ -873,9 +840,9 @@ func TestParseKeyFunctions(t *testing.T) {
 			{"allow.moderator.access.admin.any", "moderator", "access", "admin", "any"},
 			{"allow.U9mP2qR5tYz3wK.create.room.any", "U9mP2qR5tYz3wK", "create", "room", "any"},
 			{"allow.everyone.post.message.Rabc456", "everyone", "post", "message", "Rabc456"},
-			{"deny.admin.create.room.any", "", "", "", ""},  // Wrong prefix
-			{"allow.admin.create", "", "", "", ""},          // Missing parts
-			{"invalid", "", "", "", ""},                     // Completely invalid
+			{"deny.admin.create.room.any", "", "", "", ""}, // Wrong prefix
+			{"allow.admin.create", "", "", "", ""},         // Missing parts
+			{"invalid", "", "", "", ""},                    // Completely invalid
 		}
 
 		for _, tt := range tests {

--- a/cli/internal/core/rbac_test.go
+++ b/cli/internal/core/rbac_test.go
@@ -4,9 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/nats-io/nats-server/v2/server"
-	"github.com/nats-io/nats.go"
 	"hmans.de/chatto/internal/config"
+	"hmans.de/chatto/internal/testutil"
 )
 
 // ============================================================================
@@ -137,33 +136,7 @@ func TestChattoCore_initServerRBAC_PreservesPermissionChanges(t *testing.T) {
 
 	ctx := testContext(t)
 
-	// Start embedded NATS server that persists across both cores
-	opts := &server.Options{
-		JetStream: true,
-		Port:      -1,
-		StoreDir:  t.TempDir(),
-	}
-
-	ns, err := server.NewServer(opts)
-	if err != nil {
-		t.Fatalf("Failed to create NATS server: %v", err)
-	}
-
-	go ns.Start()
-	if !ns.ReadyForConnections(5 * 1e9) {
-		t.Fatal("NATS server not ready")
-	}
-
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		t.Fatalf("Failed to connect to NATS: %v", err)
-	}
-
-	t.Cleanup(func() {
-		nc.Close()
-		ns.Shutdown()
-		ns.WaitForShutdown()
-	})
+	_, nc := testutil.StartNATS(t)
 
 	cfg := config.CoreConfig{
 		Assets: config.AssetsConfig{

--- a/cli/internal/core/room_unread.go
+++ b/cli/internal/core/room_unread.go
@@ -24,8 +24,8 @@ import (
 // for rationale.
 //
 // The legacy `room_read_status.*` keys (uint64 sequence numbers) are orphaned
-// and ignored. Users with no `room_read_event.*` key are lazy-initialized to
-// the room's current last root event on first read — the "caught up at deploy
+// and ignored. Users with no `read.room.*` key are lazy-initialized to the
+// room's current last root event on first read — the "caught up at deploy
 // time" semantic.
 
 // NotifyRoomMarkedAsRead publishes a live event to notify the user that they marked

--- a/cli/internal/core/room_unread.go
+++ b/cli/internal/core/room_unread.go
@@ -17,10 +17,11 @@ import (
 // Unread Message Tracking
 // ============================================================================
 //
-// Per-user, per-room read state is keyed on the last-read root message's stable
-// event ID (14-char NanoID, see ADR-026), not on the (volatile) JetStream
-// sequence number. Event IDs are embedded in NATS subjects, so they survive
-// stream renumbering and rebuilds. See docs/adr/ADR-028 for rationale.
+// Per-user, per-room read state lives in RUNTIME_STATE and is keyed on the
+// last-read root message's stable event ID (14-char NanoID, see ADR-026), not
+// on the (volatile) JetStream sequence number. Event IDs are embedded in NATS
+// subjects, so they survive stream renumbering and rebuilds. See docs/adr/ADR-028
+// for rationale.
 //
 // The legacy `room_read_status.*` keys (uint64 sequence numbers) are orphaned
 // and ignored. Users with no `room_read_event.*` key are lazy-initialized to
@@ -73,10 +74,10 @@ func (c *ChattoCore) GetRoomLastEvent(ctx context.Context, kind RoomKind, roomID
 	return ev.GetId(), createdAt, true, nil
 }
 
-// roomReadEventKey returns the KV key for tracking the user's last-read root
-// event ID in a room.
+// roomReadEventKey returns the RUNTIME_STATE key for tracking the user's
+// last-read root event ID in a room.
 func roomReadEventKey(userID, roomID string) string {
-	return fmt.Sprintf("room_read_event.%s.%s", userID, roomID)
+	return fmt.Sprintf("read.room.%s.%s", userID, roomID)
 }
 
 // GetLastReadEventID returns the user's last-read root-message event ID for a
@@ -84,7 +85,7 @@ func roomReadEventKey(userID, roomID string) string {
 // current last root event ("caught up at deploy time"); if the room has no
 // messages, it returns "".
 func (c *ChattoCore) GetLastReadEventID(ctx context.Context, kind RoomKind, userID, roomID string) (string, error) {
-	bucket := c.storage.serverRuntimeKV
+	bucket := c.storage.runtimeStateKV
 
 	key := roomReadEventKey(userID, roomID)
 	entry, err := bucket.Get(ctx, key)
@@ -122,12 +123,11 @@ func (c *ChattoCore) GetLastReadEventID(ctx context.Context, kind RoomKind, user
 
 // SetLastReadEventID stores the user's last-read root-message event ID.
 //
-// Callers MUST pass either a root message event ID (one published with subject
-// `space.{s}.room.{r}.msg.{eventId}`) or the empty string. Thread-reply event
-// IDs would not resolve via GetEventTimestamp's root-subject lookup and would
-// keep the room permanently flagged as unread.
+// Callers MUST pass either a root message event ID or the empty string. Thread
+// reply event IDs are tracked separately by the thread read marker; using one
+// here would make room-level unread comparisons point at the wrong timeline.
 func (c *ChattoCore) SetLastReadEventID(ctx context.Context, kind RoomKind, userID, roomID, eventID string) error {
-	bucket := c.storage.serverRuntimeKV
+	bucket := c.storage.runtimeStateKV
 	if _, err := bucket.Put(ctx, roomReadEventKey(userID, roomID), []byte(eventID)); err != nil {
 		return fmt.Errorf("failed to set read marker: %w", err)
 	}

--- a/cli/internal/core/room_unread_test.go
+++ b/cli/internal/core/room_unread_test.go
@@ -456,7 +456,7 @@ func TestChattoCore_LastReadEventID_LazyInitRespectsExistingMarker(t *testing.T)
 	// the stranger never wrote, simulating a concurrent winner.
 	stranger, _ := core.CreateUser(ctx, "system", "race-stranger", "race-stranger", "password123")
 	const concurrentWinner = "Eraceconcurwin"
-	bucket := core.storage.serverRuntimeKV
+	bucket := core.storage.runtimeStateKV
 	if _, err := bucket.Put(ctx, roomReadEventKey(stranger.Id, room.Id), []byte(concurrentWinner)); err != nil {
 		t.Fatalf("seed marker error: %v", err)
 	}

--- a/cli/internal/core/threads.go
+++ b/cli/internal/core/threads.go
@@ -382,17 +382,20 @@ func (c *ChattoCore) GetThreadMetadata(ctx context.Context, kind RoomKind, roomI
 	return metadata, nil
 }
 
-// threadLastOpenedKey returns the KV key for tracking when a user last opened a thread.
+// threadLastOpenedKey returns the RUNTIME_STATE key for tracking the latest
+// thread message the user has seen.
 func threadLastOpenedKey(userID, roomID, threadRootEventID string) string {
-	return fmt.Sprintf("thread_last_opened.%s.%s.%s", userID, roomID, threadRootEventID)
+	return fmt.Sprintf("read.thread.%s.%s.%s", userID, roomID, threadRootEventID)
 }
 
-// GetThreadLastOpened retrieves the timestamp when a user last opened a thread.
-// Returns zero time if the thread has never been opened.
+// GetThreadLastOpened retrieves the timestamp of the latest thread message the
+// user has seen. Returns zero time if the thread has never been opened.
+//
+// New RUNTIME_STATE markers store the seen message event ID. Values migrated
+// from SERVER_RUNTIME may still be the legacy 8-byte UnixNano timestamp; those
+// are decoded here so existing read state survives the rollout.
 func (c *ChattoCore) GetThreadLastOpened(ctx context.Context, kind RoomKind, userID, roomID, threadRootEventID string) (time.Time, error) {
-	bucket := c.storage.serverRuntimeKV
-
-	entry, err := bucket.Get(ctx, threadLastOpenedKey(userID, roomID, threadRootEventID))
+	entry, err := c.storage.runtimeStateKV.Get(ctx, threadLastOpenedKey(userID, roomID, threadRootEventID))
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return time.Time{}, nil // Never opened
@@ -400,19 +403,14 @@ func (c *ChattoCore) GetThreadLastOpened(ctx context.Context, kind RoomKind, use
 		return time.Time{}, fmt.Errorf("failed to get thread last opened: %w", err)
 	}
 
-	// Decode int64 (Unix nano) from bytes using binary.BigEndian
-	if len(entry.Value()) != 8 {
-		return time.Time{}, fmt.Errorf("invalid thread last opened value")
-	}
-	nanos := int64(binary.BigEndian.Uint64(entry.Value()))
-	return time.Unix(0, nanos), nil
+	return c.threadReadMarkerTime(ctx, kind, roomID, entry.Value())
 }
 
-// SetThreadLastOpenedAt stores ts as the user's last-opened time for a
-// thread, but only if ts is newer than the existing marker (advance-only).
-// Returns the previous last-opened time (zero if never opened before).
-func (c *ChattoCore) SetThreadLastOpenedAt(ctx context.Context, kind RoomKind, userID, roomID, threadRootEventID string, ts time.Time) (time.Time, error) {
-	bucket := c.storage.serverRuntimeKV
+// SetThreadLastReadEventID stores eventID as the latest thread message the user
+// has seen, but only if it is newer than the existing marker (advance-only).
+// Returns the previous marker time (zero if never opened before).
+func (c *ChattoCore) SetThreadLastReadEventID(ctx context.Context, kind RoomKind, userID, roomID, threadRootEventID, eventID string) (time.Time, error) {
+	bucket := c.storage.runtimeStateKV
 	key := threadLastOpenedKey(userID, roomID, threadRootEventID)
 
 	var previousTime time.Time
@@ -420,9 +418,50 @@ func (c *ChattoCore) SetThreadLastOpenedAt(ctx context.Context, kind RoomKind, u
 	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
 		return time.Time{}, fmt.Errorf("failed to get previous thread last opened: %w", err)
 	}
-	if err == nil && len(entry.Value()) == 8 {
-		nanos := int64(binary.BigEndian.Uint64(entry.Value()))
-		previousTime = time.Unix(0, nanos)
+	if err == nil {
+		previousTime, err = c.threadReadMarkerTime(ctx, kind, roomID, entry.Value())
+		if err != nil {
+			return time.Time{}, err
+		}
+	}
+
+	nextTime, err := c.GetEventTimestamp(ctx, kind, roomID, eventID)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if nextTime.IsZero() {
+		return previousTime, nil
+	}
+
+	if !nextTime.After(previousTime) {
+		return previousTime, nil
+	}
+
+	if _, err = bucket.Put(ctx, key, []byte(eventID)); err != nil {
+		return time.Time{}, fmt.Errorf("failed to set thread last opened: %w", err)
+	}
+
+	c.logger.Debug("Set thread last read event", "user_id", userID, "room_id", roomID, "thread_root_event_id", threadRootEventID, "previous", previousTime, "event_id", eventID)
+	return previousTime, nil
+}
+
+// SetThreadLastOpenedAt is retained for timestamp-based callers/tests. It
+// stores a legacy timestamp marker in RUNTIME_STATE and should not be used for
+// new code when a concrete event ID is available.
+func (c *ChattoCore) SetThreadLastOpenedAt(ctx context.Context, kind RoomKind, userID, roomID, threadRootEventID string, ts time.Time) (time.Time, error) {
+	bucket := c.storage.runtimeStateKV
+	key := threadLastOpenedKey(userID, roomID, threadRootEventID)
+
+	var previousTime time.Time
+	entry, err := bucket.Get(ctx, key)
+	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+		return time.Time{}, fmt.Errorf("failed to get previous thread last opened: %w", err)
+	}
+	if err == nil {
+		previousTime, err = c.threadReadMarkerTime(ctx, kind, roomID, entry.Value())
+		if err != nil {
+			return time.Time{}, err
+		}
 	}
 
 	if !ts.After(previousTime) {
@@ -431,20 +470,50 @@ func (c *ChattoCore) SetThreadLastOpenedAt(ctx context.Context, kind RoomKind, u
 
 	buf := make([]byte, 8)
 	binary.BigEndian.PutUint64(buf, uint64(ts.UnixNano()))
-
 	if _, err = bucket.Put(ctx, key, buf); err != nil {
 		return time.Time{}, fmt.Errorf("failed to set thread last opened: %w", err)
 	}
-
-	c.logger.Debug("Set thread last opened", "user_id", userID, "room_id", roomID, "thread_root_event_id", threadRootEventID, "previous", previousTime, "at", ts)
+	c.logger.Debug("Set legacy thread last opened timestamp", "user_id", userID, "room_id", roomID, "thread_root_event_id", threadRootEventID, "previous", previousTime, "at", ts)
 	return previousTime, nil
 }
 
-// SetThreadLastOpened records the current wall-clock time as the user's
-// last-opened time for a thread. Returns the previous last-opened time
-// (zero if never opened before).
+// SetThreadLastOpened records the latest current reply in the thread as read.
+// Returns the previous marker time (zero if never opened before).
 func (c *ChattoCore) SetThreadLastOpened(ctx context.Context, kind RoomKind, userID, roomID, threadRootEventID string) (time.Time, error) {
-	return c.SetThreadLastOpenedAt(ctx, kind, userID, roomID, threadRootEventID, time.Now())
+	latestID := c.latestThreadMessageEventID(threadRootEventID)
+	if latestID == "" {
+		return time.Time{}, nil
+	}
+	return c.SetThreadLastReadEventID(ctx, kind, userID, roomID, threadRootEventID, latestID)
+}
+
+func (c *ChattoCore) threadReadMarkerTime(ctx context.Context, kind RoomKind, roomID string, value []byte) (time.Time, error) {
+	if len(value) == 8 {
+		nanos := int64(binary.BigEndian.Uint64(value))
+		return time.Unix(0, nanos), nil
+	}
+	eventID := string(value)
+	if eventID == "" {
+		return time.Time{}, nil
+	}
+	return c.GetEventTimestamp(ctx, kind, roomID, eventID)
+}
+
+func (c *ChattoCore) latestThreadMessageEventID(threadRootEventID string) string {
+	entries := c.Threads.ThreadEvents(threadRootEventID)
+	for i := len(entries) - 1; i >= 0; i-- {
+		event := entries[i].Event
+		if event == nil || event.GetMessagePosted() == nil {
+			continue
+		}
+		if id := event.GetId(); id != "" {
+			return id
+		}
+		if id := event.GetMessagePosted().GetEventId(); id != "" {
+			return id
+		}
+	}
+	return threadRootEventID
 }
 
 // threadFollowKey returns the KV key for tracking whether a user is following a thread.

--- a/cli/internal/core/threads_test.go
+++ b/cli/internal/core/threads_test.go
@@ -339,7 +339,12 @@ func TestChattoCore_ThreadLastOpened(t *testing.T) {
 	// Setup
 	room, _ := core.CreateRoom(ctx, "test-user", KindChannel, "", "General", "General discussion")
 	user, _ := core.CreateUser(ctx, "system", "testuser", "testuser", "password123")
-	threadRootEventId := "test-thread-root-123"
+	core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id)
+	root, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "Root message", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("Failed to post root message: %v", err)
+	}
+	threadRootEventId := root.Id
 
 	// Initially should return zero time (never opened)
 	lastOpened, err := core.GetThreadLastOpened(ctx, KindChannel, user.Id, room.Id, threadRootEventId)

--- a/cli/internal/events/events_test.go
+++ b/cli/internal/events/events_test.go
@@ -9,13 +9,12 @@ import (
 	"time"
 
 	"github.com/charmbracelet/log"
-	"github.com/nats-io/nats-server/v2/server"
-	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+	"hmans.de/chatto/internal/testutil"
 )
 
 // ============================================================================
@@ -39,29 +38,7 @@ func testLogger() Logger {
 func setupTestStream(t *testing.T) (jetstream.JetStream, jetstream.Stream) {
 	t.Helper()
 
-	opts := &server.Options{
-		JetStream: true,
-		Port:      -1,
-		StoreDir:  t.TempDir(),
-	}
-	ns, err := server.NewServer(opts)
-	if err != nil {
-		t.Fatalf("create NATS server: %v", err)
-	}
-	go ns.Start()
-	if !ns.ReadyForConnections(5 * time.Second) {
-		t.Fatal("NATS server not ready")
-	}
-
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		t.Fatalf("connect NATS: %v", err)
-	}
-	t.Cleanup(func() {
-		nc.Close()
-		ns.Shutdown()
-		ns.WaitForShutdown()
-	})
+	_, nc := testutil.StartNATS(t)
 
 	js, err := jetstream.New(nc)
 	if err != nil {

--- a/cli/internal/graph/dataloader/user_loader_test.go
+++ b/cli/internal/graph/dataloader/user_loader_test.go
@@ -6,43 +6,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/nats-server/v2/server"
-	"github.com/nats-io/nats.go"
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/core"
 	"hmans.de/chatto/internal/graph/dataloader"
+	"hmans.de/chatto/internal/testutil"
 )
 
 // setupTestCore creates a ChattoCore with an embedded NATS server for testing.
 func setupTestCore(t *testing.T) *core.ChattoCore {
 	t.Helper()
 
-	opts := &server.Options{
-		JetStream: true,
-		Port:      -1,
-		StoreDir:  t.TempDir(),
-	}
-
-	ns, err := server.NewServer(opts)
-	if err != nil {
-		t.Fatalf("Failed to create NATS server: %v", err)
-	}
-
-	go ns.Start()
-	if !ns.ReadyForConnections(5 * 1e9) {
-		t.Fatal("NATS server not ready")
-	}
-
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		t.Fatalf("Failed to connect to NATS: %v", err)
-	}
-
-	t.Cleanup(func() {
-		nc.Close()
-		ns.Shutdown()
-		ns.WaitForShutdown()
-	})
+	_, nc := testutil.StartNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)
@@ -58,8 +32,16 @@ func setupTestCore(t *testing.T) *core.ChattoCore {
 	}
 
 	runCtx, runCancel := context.WithCancel(context.Background())
-	go func() { _ = c.Run(runCtx) }()
-	t.Cleanup(runCancel)
+	runDone := make(chan error, 1)
+	go func() { runDone <- c.Run(runCtx) }()
+	t.Cleanup(func() {
+		runCancel()
+		select {
+		case <-runDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("core.Run did not stop within timeout")
+		}
+	})
 
 	bootCtx, bootCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer bootCancel()

--- a/cli/internal/graph/mutation.resolvers.go
+++ b/cli/internal/graph/mutation.resolvers.go
@@ -670,22 +670,33 @@ func (r *mutationResolver) MarkThreadAsRead(ctx context.Context, input model.Mar
 		return nil, core.ErrNotRoomMember
 	}
 
-	// Anchor the read cursor at a specific event's timestamp if the client
-	// provided one. This avoids the race where new replies arrive between
-	// the subscription delivery and the mutation hitting the server. Falls
-	// back to wall-clock "now" when no explicit anchor is supplied.
-	markerTime := time.Now()
+	// Anchor the read cursor at a specific event ID if the client provided
+	// one. This avoids the race where new replies arrive between subscription
+	// delivery and the mutation hitting the server. Otherwise, mark the latest
+	// currently visible message in the thread.
+	markerEventID := ""
 	if input.UpToEventID != nil && *input.UpToEventID != "" {
 		event, eerr := r.core.GetRoomEventByEventID(ctx, kind, input.RoomID, *input.UpToEventID)
 		if eerr != nil {
 			return nil, eerr
 		}
-		if event != nil && event.CreatedAt != nil {
-			markerTime = event.CreatedAt.AsTime()
+		if event != nil {
+			markerEventID = event.Id
+		}
+	} else {
+		events, eerr := r.core.GetThreadEvents(ctx, kind, input.RoomID, input.ThreadRootEventID)
+		if eerr != nil {
+			return nil, eerr
+		}
+		for i := len(events) - 1; i >= 0; i-- {
+			if events[i] != nil && events[i].GetMessagePosted() != nil {
+				markerEventID = events[i].Id
+				break
+			}
 		}
 	}
 
-	previousReadAt, err := r.core.SetThreadLastOpenedAt(ctx, kind, user.Id, input.RoomID, input.ThreadRootEventID, markerTime)
+	previousReadAt, err := r.core.SetThreadLastReadEventID(ctx, kind, user.Id, input.RoomID, input.ThreadRootEventID, markerEventID)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/graph/test_helpers.go
+++ b/cli/internal/graph/test_helpers.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/core"
 	"hmans.de/chatto/internal/graph/auth"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+	"hmans.de/chatto/internal/testutil"
 )
 
 // testEnv holds all test dependencies for GraphQL resolver tests
@@ -28,27 +28,7 @@ type testEnv struct {
 func setupTestResolver(t *testing.T) *testEnv {
 	t.Helper()
 
-	// Start embedded NATS server
-	opts := &server.Options{
-		JetStream: true,
-		Port:      -1,
-		StoreDir:  t.TempDir(),
-	}
-
-	ns, err := server.NewServer(opts)
-	if err != nil {
-		t.Fatalf("Failed to create NATS server: %v", err)
-	}
-
-	go ns.Start()
-	if !ns.ReadyForConnections(5 * 1e9) {
-		t.Fatal("NATS server not ready")
-	}
-
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		t.Fatalf("Failed to connect to NATS: %v", err)
-	}
+	_, nc := testutil.StartNATS(t)
 
 	// Use a context with timeout for setup
 	setupCtx, setupCancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -69,13 +49,16 @@ func setupTestResolver(t *testing.T) *testEnv {
 	// lifetime of the test. StreamMyEvents needs PresenceHub; membership
 	// mutations need the projector loops to advance so WaitForSeq returns.
 	servicesCtx, servicesCancel := context.WithCancel(context.Background())
-	go func() { _ = chattoCore.Run(servicesCtx) }()
+	servicesDone := make(chan error, 1)
+	go func() { servicesDone <- chattoCore.Run(servicesCtx) }()
 
 	t.Cleanup(func() {
 		servicesCancel()
-		nc.Close()
-		ns.Shutdown()
-		ns.WaitForShutdown()
+		select {
+		case <-servicesDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("core.Run did not stop within timeout")
+		}
 	})
 
 	// Wait for Run's boot phase before letting the test issue reads
@@ -174,27 +157,7 @@ func (e *testEnv) createVerifiedUser(t *testing.T, login, displayName, password 
 func setupTestResolverWithAdmin(t *testing.T, ownerEmails []string) *testEnv {
 	t.Helper()
 
-	// Start embedded NATS server
-	opts := &server.Options{
-		JetStream: true,
-		Port:      -1,
-		StoreDir:  t.TempDir(),
-	}
-
-	ns, err := server.NewServer(opts)
-	if err != nil {
-		t.Fatalf("Failed to create NATS server: %v", err)
-	}
-
-	go ns.Start()
-	if !ns.ReadyForConnections(5 * 1e9) {
-		t.Fatal("NATS server not ready")
-	}
-
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		t.Fatalf("Failed to connect to NATS: %v", err)
-	}
+	_, nc := testutil.StartNATS(t)
 
 	// Use a context with timeout for setup
 	setupCtx, setupCancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -220,13 +183,16 @@ func setupTestResolverWithAdmin(t *testing.T, ownerEmails []string) *testEnv {
 	// lifetime of the test. StreamMyEvents needs PresenceHub; membership
 	// mutations need the projector loops to advance so WaitForSeq returns.
 	servicesCtx, servicesCancel := context.WithCancel(context.Background())
-	go func() { _ = chattoCore.Run(servicesCtx) }()
+	servicesDone := make(chan error, 1)
+	go func() { servicesDone <- chattoCore.Run(servicesCtx) }()
 
 	t.Cleanup(func() {
 		servicesCancel()
-		nc.Close()
-		ns.Shutdown()
-		ns.WaitForShutdown()
+		select {
+		case <-servicesDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("core.Run did not stop within timeout")
+		}
 	})
 
 	// Wait for Run's boot phase before letting the test issue reads

--- a/cli/internal/http_server/assets_test.go
+++ b/cli/internal/http_server/assets_test.go
@@ -24,11 +24,10 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/johannesboyne/gofakes3"
 	"github.com/johannesboyne/gofakes3/backend/s3mem"
-	"github.com/nats-io/nats-server/v2/server"
-	"github.com/nats-io/nats.go"
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/core"
 	"hmans.de/chatto/internal/email"
+	"hmans.de/chatto/internal/testutil"
 )
 
 // ============================================================================
@@ -60,29 +59,7 @@ func setupAssetTestServerWithConfig(t *testing.T, useS3 bool) *assetTestEnv {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	// Start embedded NATS server
-	opts := &server.Options{
-		JetStream: true,
-		Port:      -1,
-		StoreDir:  t.TempDir(),
-	}
-
-	ns, err := server.NewServer(opts)
-	if err != nil {
-		t.Fatalf("Failed to create NATS server: %v", err)
-	}
-
-	go ns.Start()
-	if !ns.ReadyForConnections(5 * 1e9) {
-		t.Fatal("NATS server not ready")
-	}
-	t.Cleanup(func() { ns.Shutdown() })
-
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		t.Fatalf("Failed to connect to NATS: %v", err)
-	}
-	t.Cleanup(func() { nc.Close() })
+	_, nc := testutil.StartNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)

--- a/cli/internal/http_server/core_services_test_helper_test.go
+++ b/cli/internal/http_server/core_services_test_helper_test.go
@@ -19,8 +19,16 @@ import (
 func startCoreServices(t *testing.T, c *core.ChattoCore) {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
-	go func() { _ = c.Run(ctx) }()
-	t.Cleanup(cancel)
+	done := make(chan error, 1)
+	go func() { done <- c.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("core.Run did not stop within timeout")
+		}
+	})
 	bootCtx, bootCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer bootCancel()
 	if err := c.WaitForBoot(bootCtx); err != nil {

--- a/cli/internal/http_server/graphql_test.go
+++ b/cli/internal/http_server/graphql_test.go
@@ -13,11 +13,10 @@ import (
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-gonic/gin"
-	"github.com/nats-io/nats-server/v2/server"
-	"github.com/nats-io/nats.go"
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/core"
 	"hmans.de/chatto/internal/email"
+	"hmans.de/chatto/internal/testutil"
 )
 
 // ============================================================================
@@ -63,29 +62,7 @@ func setupGraphQLTestServerFull(t *testing.T, ownersConfig config.OwnersConfig, 
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	// Start embedded NATS server
-	opts := &server.Options{
-		JetStream: true,
-		Port:      -1,
-		StoreDir:  t.TempDir(),
-	}
-
-	ns, err := server.NewServer(opts)
-	if err != nil {
-		t.Fatalf("Failed to create NATS server: %v", err)
-	}
-
-	go ns.Start()
-	if !ns.ReadyForConnections(5 * 1e9) {
-		t.Fatal("NATS server not ready")
-	}
-	t.Cleanup(func() { ns.Shutdown() })
-
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		t.Fatalf("Failed to connect to NATS: %v", err)
-	}
-	t.Cleanup(func() { nc.Close() })
+	_, nc := testutil.StartNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)
@@ -126,7 +103,7 @@ func setupGraphQLTestServerFull(t *testing.T, ownersConfig config.OwnersConfig, 
 				CookieSigningSecret: "test-secret-key-32-bytes-long!!",
 			},
 			Owners: ownersConfig,
-			Core:  coreConfig,
+			Core:   coreConfig,
 		},
 		nc:     nc,
 		router: router,
@@ -346,7 +323,6 @@ func TestGraphQL_Query_Room_RequiresMembership(t *testing.T) {
 	// Create user, space, and room
 	userID := env.createTestUser(t, "roomowner", "password123")
 
-
 	room, err := env.core.CreateRoom(env.ctx, userID, "channel", "", "private-room", "")
 	if err != nil {
 		t.Fatalf("Failed to create room: %v", err)
@@ -360,7 +336,7 @@ func TestGraphQL_Query_Room_RequiresMembership(t *testing.T) {
 	resp := env.doGraphQL(t, `query($roomId: ID!) {
 		room(roomId: $roomId) { id name }
 	}`, map[string]any{
-		"roomId":  room.Id,
+		"roomId": room.Id,
 	})
 
 	// Should get an error
@@ -397,8 +373,8 @@ func TestGraphQL_Mutation_PostMessage_RequiresRoomMembership(t *testing.T) {
 		}
 	}`, map[string]any{
 		"input": map[string]any{
-			"roomId":  room.Id,
-			"body":    "Hello!",
+			"roomId": room.Id,
+			"body":   "Hello!",
 		},
 	})
 
@@ -549,7 +525,7 @@ func TestGraphQL_Variables(t *testing.T) {
 	resp := env.doGraphQL(t, `query GetRoom($roomId: ID!) {
 		room(roomId: $roomId) { id name }
 	}`, map[string]any{
-		"roomId":  room.Id,
+		"roomId": room.Id,
 	})
 
 	if len(resp.Errors) > 0 {
@@ -581,7 +557,6 @@ func TestGraphQL_CryptoShredding_MessageBodyBecomesNull(t *testing.T) {
 	// Create user, space, and room
 	userID := env.createTestUser(t, "alice", "password123")
 
-
 	room, err := env.core.CreateRoom(env.ctx, userID, "channel", "", "general", "")
 	if err != nil {
 		t.Fatalf("Failed to create room: %v", err)
@@ -612,8 +587,8 @@ func TestGraphQL_CryptoShredding_MessageBodyBecomesNull(t *testing.T) {
 		}
 	`, map[string]any{
 		"input": map[string]any{
-			"roomId":  room.Id,
-			"body":    "This is a secret message",
+			"roomId": room.Id,
+			"body":   "This is a secret message",
 		},
 	})
 
@@ -805,7 +780,9 @@ func TestBearerToken_RevokedTokenFails(t *testing.T) {
 	resp := env.doGraphQLWithToken(t, token, `{ viewer { user { id } } }`)
 	var data struct {
 		Viewer *struct {
-			User struct{ ID string `json:"id"` } `json:"user"`
+			User struct {
+				ID string `json:"id"`
+			} `json:"user"`
 		} `json:"viewer"`
 	}
 	json.Unmarshal(resp.Data, &data)

--- a/cli/internal/http_server/health_test.go
+++ b/cli/internal/http_server/health_test.go
@@ -7,35 +7,14 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
+	"hmans.de/chatto/internal/testutil"
 )
 
 func TestHealthEndpoints(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	// Start embedded NATS server for testing
-	opts := &server.Options{
-		Host: "127.0.0.1",
-		Port: -1, // Random available port
-	}
-	ns, err := server.NewServer(opts)
-	if err != nil {
-		t.Fatalf("failed to create NATS server: %v", err)
-	}
-	go ns.Start()
-	defer ns.Shutdown()
-
-	if !ns.ReadyForConnections(5 * 1e9) {
-		t.Fatal("NATS server not ready")
-	}
-
-	// Connect to NATS
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		t.Fatalf("failed to connect to NATS: %v", err)
-	}
-	defer nc.Close()
+	_, nc := testutil.StartNATS(t)
 
 	t.Run("healthz returns ok", func(t *testing.T) {
 		router := gin.New()

--- a/cli/internal/http_server/oauth_test.go
+++ b/cli/internal/http_server/oauth_test.go
@@ -13,10 +13,9 @@ import (
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-gonic/gin"
-	"github.com/nats-io/nats-server/v2/server"
-	"github.com/nats-io/nats.go"
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/core"
+	"hmans.de/chatto/internal/testutil"
 )
 
 // setupOAuthServer creates a minimal HTTPServer with session middleware and OAuth endpoints.
@@ -24,27 +23,7 @@ func setupOAuthServer(t *testing.T) *HTTPServer {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	// Start embedded NATS
-	opts := &server.Options{
-		JetStream: true,
-		Port:      -1,
-		StoreDir:  t.TempDir(),
-	}
-	ns, err := server.NewServer(opts)
-	if err != nil {
-		t.Fatalf("Failed to create NATS server: %v", err)
-	}
-	go ns.Start()
-	if !ns.ReadyForConnections(5 * 1e9) {
-		t.Fatal("NATS server not ready")
-	}
-	t.Cleanup(func() { ns.Shutdown() })
-
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		t.Fatalf("Failed to connect to NATS: %v", err)
-	}
-	t.Cleanup(func() { nc.Close() })
+	_, nc := testutil.StartNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)

--- a/cli/internal/http_server/server_info_test.go
+++ b/cli/internal/http_server/server_info_test.go
@@ -15,10 +15,9 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/nats-io/nats-server/v2/server"
-	"github.com/nats-io/nats.go"
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/core"
+	"hmans.de/chatto/internal/testutil"
 )
 
 // bannerImageBytes returns an in-memory PNG suitable as a banner upload.
@@ -43,27 +42,7 @@ func setupServerInfoServer(t *testing.T, authConfig config.AuthConfig) *HTTPServ
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	// Start embedded NATS server with JetStream
-	opts := &server.Options{
-		JetStream: true,
-		Port:      -1,
-		StoreDir:  t.TempDir(),
-	}
-	ns, err := server.NewServer(opts)
-	if err != nil {
-		t.Fatalf("Failed to create NATS server: %v", err)
-	}
-	go ns.Start()
-	if !ns.ReadyForConnections(5 * 1e9) {
-		t.Fatal("NATS server not ready")
-	}
-	t.Cleanup(func() { ns.Shutdown() })
-
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		t.Fatalf("Failed to connect to NATS: %v", err)
-	}
-	t.Cleanup(func() { nc.Close() })
+	_, nc := testutil.StartNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)

--- a/cli/internal/http_server/server_test.go
+++ b/cli/internal/http_server/server_test.go
@@ -16,11 +16,10 @@ import (
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-gonic/gin"
-	"github.com/nats-io/nats-server/v2/server"
-	"github.com/nats-io/nats.go"
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/core"
 	"hmans.de/chatto/internal/email"
+	"hmans.de/chatto/internal/testutil"
 )
 
 // ============================================================================
@@ -101,29 +100,7 @@ func setupTestHTTPServer(t *testing.T) (*httptest.Server, *http.Client, *core.Ch
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	// Start embedded NATS server
-	opts := &server.Options{
-		JetStream: true,
-		Port:      -1,
-		StoreDir:  t.TempDir(),
-	}
-
-	ns, err := server.NewServer(opts)
-	if err != nil {
-		t.Fatalf("Failed to create NATS server: %v", err)
-	}
-
-	go ns.Start()
-	if !ns.ReadyForConnections(5 * 1e9) {
-		t.Fatal("NATS server not ready")
-	}
-	t.Cleanup(func() { ns.Shutdown() })
-
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		t.Fatalf("Failed to connect to NATS: %v", err)
-	}
-	t.Cleanup(func() { nc.Close() })
+	_, nc := testutil.StartNATS(t)
 
 	ctx := testContext(t)
 
@@ -188,29 +165,7 @@ func setupTestHTTPServerWithMailer(t *testing.T) (*httptest.Server, *http.Client
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	// Start embedded NATS server
-	opts := &server.Options{
-		JetStream: true,
-		Port:      -1,
-		StoreDir:  t.TempDir(),
-	}
-
-	ns, err := server.NewServer(opts)
-	if err != nil {
-		t.Fatalf("Failed to create NATS server: %v", err)
-	}
-
-	go ns.Start()
-	if !ns.ReadyForConnections(5 * 1e9) {
-		t.Fatal("NATS server not ready")
-	}
-	t.Cleanup(func() { ns.Shutdown() })
-
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		t.Fatalf("Failed to connect to NATS: %v", err)
-	}
-	t.Cleanup(func() { nc.Close() })
+	_, nc := testutil.StartNATS(t)
 
 	ctx := testContext(t)
 
@@ -926,28 +881,7 @@ func setupTestHTTPServerWithRegistrationDisabled(t *testing.T) (*httptest.Server
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	opts := &server.Options{
-		JetStream: true,
-		Port:      -1,
-		StoreDir:  t.TempDir(),
-	}
-
-	ns, err := server.NewServer(opts)
-	if err != nil {
-		t.Fatalf("Failed to create NATS server: %v", err)
-	}
-
-	go ns.Start()
-	if !ns.ReadyForConnections(5 * 1e9) {
-		t.Fatal("NATS server not ready")
-	}
-	t.Cleanup(func() { ns.Shutdown() })
-
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		t.Fatalf("Failed to connect to NATS: %v", err)
-	}
-	t.Cleanup(func() { nc.Close() })
+	_, nc := testutil.StartNATS(t)
 
 	ctx := testContext(t)
 

--- a/cli/internal/http_server/upload_test.go
+++ b/cli/internal/http_server/upload_test.go
@@ -20,11 +20,10 @@ import (
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-gonic/gin"
-	"github.com/nats-io/nats-server/v2/server"
-	"github.com/nats-io/nats.go"
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/core"
 	"hmans.de/chatto/internal/email"
+	"hmans.de/chatto/internal/testutil"
 )
 
 // ============================================================================
@@ -44,29 +43,7 @@ func setupUploadTestServer(t *testing.T) *uploadTestEnv {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	// Start embedded NATS server
-	opts := &server.Options{
-		JetStream: true,
-		Port:      -1,
-		StoreDir:  t.TempDir(),
-	}
-
-	ns, err := server.NewServer(opts)
-	if err != nil {
-		t.Fatalf("Failed to create NATS server: %v", err)
-	}
-
-	go ns.Start()
-	if !ns.ReadyForConnections(5 * 1e9) {
-		t.Fatal("NATS server not ready")
-	}
-	t.Cleanup(func() { ns.Shutdown() })
-
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		t.Fatalf("Failed to connect to NATS: %v", err)
-	}
-	t.Cleanup(func() { nc.Close() })
+	_, nc := testutil.StartNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)

--- a/cli/internal/http_server/websocket_test.go
+++ b/cli/internal/http_server/websocket_test.go
@@ -16,11 +16,10 @@ import (
 	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
-	"github.com/nats-io/nats-server/v2/server"
-	"github.com/nats-io/nats.go"
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/core"
 	"hmans.de/chatto/internal/email"
+	"hmans.de/chatto/internal/testutil"
 )
 
 // ============================================================================
@@ -41,29 +40,7 @@ func setupWebSocketTestServer(t *testing.T) *wsTestEnv {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	// Start embedded NATS server
-	opts := &server.Options{
-		JetStream: true,
-		Port:      -1,
-		StoreDir:  t.TempDir(),
-	}
-
-	ns, err := server.NewServer(opts)
-	if err != nil {
-		t.Fatalf("Failed to create NATS server: %v", err)
-	}
-
-	go ns.Start()
-	if !ns.ReadyForConnections(5 * 1e9) {
-		t.Fatal("NATS server not ready")
-	}
-	t.Cleanup(func() { ns.Shutdown() })
-
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		t.Fatalf("Failed to connect to NATS: %v", err)
-	}
-	t.Cleanup(func() { nc.Close() })
+	_, nc := testutil.StartNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	t.Cleanup(cancel)
@@ -273,8 +250,6 @@ func TestWebSocket_Subscription_Authenticated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create user: %v", err)
 	}
-
-
 
 	room, err := env.core.CreateRoom(env.ctx, user.Id, "channel", "", "sub-room", "")
 	if err != nil {

--- a/cli/internal/migrations/es_test_helpers_test.go
+++ b/cli/internal/migrations/es_test_helpers_test.go
@@ -7,11 +7,10 @@ import (
 	"time"
 
 	"github.com/charmbracelet/log"
-	"github.com/nats-io/nats-server/v2/server"
-	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 
 	"hmans.de/chatto/internal/events"
+	"hmans.de/chatto/internal/testutil"
 )
 
 // setupTestES stands up an embedded NATS server with JetStream and
@@ -30,28 +29,7 @@ func setupTestES(t *testing.T) (
 ) {
 	t.Helper()
 
-	ns, err := server.NewServer(&server.Options{
-		JetStream: true,
-		Port:      -1,
-		StoreDir:  t.TempDir(),
-	})
-	if err != nil {
-		t.Fatalf("create NATS server: %v", err)
-	}
-	go ns.Start()
-	if !ns.ReadyForConnections(5 * time.Second) {
-		t.Fatal("NATS server not ready")
-	}
-
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		t.Fatalf("connect: %v", err)
-	}
-	t.Cleanup(func() {
-		nc.Close()
-		ns.Shutdown()
-		ns.WaitForShutdown()
-	})
+	_, nc := testutil.StartNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)

--- a/cli/internal/migrations/messages_es_test.go
+++ b/cli/internal/migrations/messages_es_test.go
@@ -7,14 +7,13 @@ import (
 	"time"
 
 	"github.com/charmbracelet/log"
-	"github.com/nats-io/nats-server/v2/server"
-	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"hmans.de/chatto/internal/events"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+	"hmans.de/chatto/internal/testutil"
 )
 
 // =============================================================================
@@ -37,28 +36,7 @@ type messagesTestRig struct {
 func setupMessagesRig(t *testing.T) *messagesTestRig {
 	t.Helper()
 
-	ns, err := server.NewServer(&server.Options{
-		JetStream: true,
-		Port:      -1,
-		StoreDir:  t.TempDir(),
-	})
-	if err != nil {
-		t.Fatalf("create NATS server: %v", err)
-	}
-	go ns.Start()
-	if !ns.ReadyForConnections(5 * time.Second) {
-		t.Fatal("NATS server not ready")
-	}
-
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		t.Fatalf("connect: %v", err)
-	}
-	t.Cleanup(func() {
-		nc.Close()
-		ns.Shutdown()
-		ns.WaitForShutdown()
-	})
+	_, nc := testutil.StartNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)

--- a/cli/internal/migrations/migrations.go
+++ b/cli/internal/migrations/migrations.go
@@ -57,6 +57,8 @@ import (
 //     recomputable state).
 //   - `runtimeConfigKV`: INSTANCE_CONFIG (operator-editable server
 //     settings — name, MOTD, blocked usernames, etc.).
+//   - `runtimeStateKV`: RUNTIME_STATE (persisted latest-value runtime/user
+//     state such as read markers).
 //   - `serverReactionsKV`: SERVER_REACTIONS (legacy current reaction
 //     state; retained until reaction ES migration cleanup).
 //
@@ -66,6 +68,7 @@ import (
 func RunAll(
 	ctx context.Context,
 	serverKV, serverConfigKV, serverBodiesKV, serverRuntimeKV, runtimeConfigKV jetstream.KeyValue,
+	runtimeStateKV jetstream.KeyValue,
 	serverEventsStream jetstream.Stream,
 	serverReactionsKV jetstream.KeyValue,
 	publisher *events.Publisher,
@@ -82,6 +85,9 @@ func RunAll(
 	}
 	if err := DropLegacyAttachmentRecords(ctx, serverBodiesKV, serverRuntimeKV, logger); err != nil {
 		return fmt.Errorf("legacy_attachment_records: %w", err)
+	}
+	if err := MigrateReadMarkersToRuntimeState(ctx, serverRuntimeKV, runtimeStateKV, logger); err != nil {
+		return fmt.Errorf("read_markers_runtime_state: %w", err)
 	}
 	// Room metadata + memberships share the evt.room.{R} subject and
 	// must seed together — a RoomCreatedEvent first, then the

--- a/cli/internal/migrations/read_markers_runtime_state.go
+++ b/cli/internal/migrations/read_markers_runtime_state.go
@@ -1,0 +1,82 @@
+package migrations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/log"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+const (
+	legacyRoomReadPrefix     = "room_read_event."
+	legacyThreadOpenedPrefix = "thread_last_opened."
+)
+
+// MigrateReadMarkersToRuntimeState copies legacy read cursors from
+// SERVER_RUNTIME into RUNTIME_STATE.
+//
+// Legacy keys:
+//   - room_read_event.{userId}.{roomId} -> read.room.{userId}.{roomId}
+//   - thread_last_opened.{userId}.{roomId}.{threadRootEventId}
+//     -> read.thread.{userId}.{roomId}.{threadRootEventId}
+//
+// The old keys are intentionally retained for rollback and phase-7 cleanup.
+// Destination writes use Create so this migration never overwrites newer
+// RUNTIME_STATE markers written by a previous boot or a live process.
+func MigrateReadMarkersToRuntimeState(ctx context.Context, legacyRuntime, runtimeState jetstream.KeyValue, logger *log.Logger) error {
+	roomCopied, roomSkipped, err := copyReadMarkerPrefix(ctx, legacyRuntime, runtimeState, legacyRoomReadPrefix, "read.room.")
+	if err != nil {
+		return fmt.Errorf("room read markers: %w", err)
+	}
+	threadCopied, threadSkipped, err := copyReadMarkerPrefix(ctx, legacyRuntime, runtimeState, legacyThreadOpenedPrefix, "read.thread.")
+	if err != nil {
+		return fmt.Errorf("thread read markers: %w", err)
+	}
+
+	if roomCopied+roomSkipped+threadCopied+threadSkipped > 0 {
+		logger.Info("read marker migration: copied legacy markers into RUNTIME_STATE",
+			"room_copied", roomCopied,
+			"room_skipped", roomSkipped,
+			"thread_copied", threadCopied,
+			"thread_skipped", threadSkipped)
+	}
+	return nil
+}
+
+func copyReadMarkerPrefix(ctx context.Context, src, dst jetstream.KeyValue, oldPrefix, newPrefix string) (copied, skipped int, err error) {
+	lister, err := src.ListKeysFiltered(ctx, oldPrefix+">")
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return 0, 0, nil
+		}
+		return 0, 0, err
+	}
+
+	for key := range lister.Keys() {
+		entry, err := src.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			return copied, skipped, fmt.Errorf("get %s: %w", key, err)
+		}
+
+		suffix := strings.TrimPrefix(key, oldPrefix)
+		if suffix == key || suffix == "" {
+			skipped++
+			continue
+		}
+		if _, err := dst.Create(ctx, newPrefix+suffix, entry.Value()); err != nil {
+			if errors.Is(err, jetstream.ErrKeyExists) {
+				skipped++
+				continue
+			}
+			return copied, skipped, fmt.Errorf("create %s%s: %w", newPrefix, suffix, err)
+		}
+		copied++
+	}
+	return copied, skipped, nil
+}

--- a/cli/internal/migrations/read_markers_runtime_state_test.go
+++ b/cli/internal/migrations/read_markers_runtime_state_test.go
@@ -1,0 +1,96 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"hmans.de/chatto/internal/testutil"
+)
+
+func TestMigrateReadMarkersToRuntimeState(t *testing.T) {
+	ctx, legacy, runtimeState := setupReadMarkerMigrationKV(t)
+
+	if _, err := legacy.Put(ctx, "room_read_event.U1.R1", []byte("Eroot1")); err != nil {
+		t.Fatalf("put room marker: %v", err)
+	}
+	legacyThreadValue := []byte{0, 0, 0, 0, 0, 0, 0, 42}
+	if _, err := legacy.Put(ctx, "thread_last_opened.U1.R1.Ethread1", legacyThreadValue); err != nil {
+		t.Fatalf("put thread marker: %v", err)
+	}
+
+	if err := MigrateReadMarkersToRuntimeState(ctx, legacy, runtimeState, testLogger()); err != nil {
+		t.Fatalf("migrate read markers: %v", err)
+	}
+
+	roomEntry, err := runtimeState.Get(ctx, "read.room.U1.R1")
+	if err != nil {
+		t.Fatalf("get migrated room marker: %v", err)
+	}
+	if got := string(roomEntry.Value()); got != "Eroot1" {
+		t.Fatalf("room marker = %q, want Eroot1", got)
+	}
+
+	threadEntry, err := runtimeState.Get(ctx, "read.thread.U1.R1.Ethread1")
+	if err != nil {
+		t.Fatalf("get migrated thread marker: %v", err)
+	}
+	if got := string(threadEntry.Value()); got != string(legacyThreadValue) {
+		t.Fatalf("thread marker bytes = %v, want %v", threadEntry.Value(), legacyThreadValue)
+	}
+}
+
+func TestMigrateReadMarkersToRuntimeState_DoesNotOverwriteRuntimeState(t *testing.T) {
+	ctx, legacy, runtimeState := setupReadMarkerMigrationKV(t)
+
+	if _, err := legacy.Put(ctx, "room_read_event.U1.R1", []byte("legacy")); err != nil {
+		t.Fatalf("put legacy marker: %v", err)
+	}
+	if _, err := runtimeState.Put(ctx, "read.room.U1.R1", []byte("newer")); err != nil {
+		t.Fatalf("put runtime marker: %v", err)
+	}
+
+	if err := MigrateReadMarkersToRuntimeState(ctx, legacy, runtimeState, testLogger()); err != nil {
+		t.Fatalf("migrate read markers: %v", err)
+	}
+
+	entry, err := runtimeState.Get(ctx, "read.room.U1.R1")
+	if err != nil {
+		t.Fatalf("get runtime marker: %v", err)
+	}
+	if got := string(entry.Value()); got != "newer" {
+		t.Fatalf("runtime marker = %q, want newer", got)
+	}
+}
+
+func setupReadMarkerMigrationKV(t *testing.T) (context.Context, jetstream.KeyValue, jetstream.KeyValue) {
+	t.Helper()
+
+	_, nc := testutil.StartNATS(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatalf("jetstream: %v", err)
+	}
+
+	legacy, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:  "SERVER_RUNTIME",
+		Storage: jetstream.MemoryStorage,
+	})
+	if err != nil {
+		t.Fatalf("create legacy KV: %v", err)
+	}
+	runtimeState, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:  "RUNTIME_STATE",
+		Storage: jetstream.MemoryStorage,
+		History: 1,
+	})
+	if err != nil {
+		t.Fatalf("create runtime state KV: %v", err)
+	}
+	return ctx, legacy, runtimeState
+}

--- a/cli/internal/migrations/verified_emails_test.go
+++ b/cli/internal/migrations/verified_emails_test.go
@@ -12,12 +12,11 @@ import (
 	"time"
 
 	"github.com/charmbracelet/log"
-	"github.com/nats-io/nats-server/v2/server"
-	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	"google.golang.org/protobuf/proto"
 
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+	"hmans.de/chatto/internal/testutil"
 )
 
 // setupTestKV stands up an embedded NATS server with JetStream and
@@ -27,31 +26,7 @@ import (
 func setupTestKV(t *testing.T) (context.Context, jetstream.KeyValue) {
 	t.Helper()
 
-	ns, err := server.NewServer(&server.Options{
-		JetStream: true,
-		Port:      -1,
-		// JetStream still wants a StoreDir for its own metadata even
-		// when every stream/KV is memory-backed. t.TempDir auto-cleans
-		// so it stays out of the way.
-		StoreDir: t.TempDir(),
-	})
-	if err != nil {
-		t.Fatalf("create NATS server: %v", err)
-	}
-	go ns.Start()
-	if !ns.ReadyForConnections(5 * time.Second) {
-		t.Fatal("NATS server not ready")
-	}
-
-	nc, err := nats.Connect(ns.ClientURL())
-	if err != nil {
-		t.Fatalf("connect: %v", err)
-	}
-	t.Cleanup(func() {
-		nc.Close()
-		ns.Shutdown()
-		ns.WaitForShutdown()
-	})
+	_, nc := testutil.StartNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)

--- a/cli/internal/testutil/nats.go
+++ b/cli/internal/testutil/nats.go
@@ -1,0 +1,43 @@
+package testutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+)
+
+// StartNATS starts an embedded JetStream-enabled NATS server for tests and
+// connects to it in-process. It intentionally does not open a TCP listener.
+func StartNATS(t testing.TB) (*server.Server, *nats.Conn) {
+	t.Helper()
+
+	ns, err := server.NewServer(&server.Options{
+		JetStream:  true,
+		DontListen: true,
+		StoreDir:   t.TempDir(),
+		NoSigs:     true,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create NATS server: %v", err)
+	}
+
+	ns.Start()
+	if !ns.ReadyForConnections(5 * time.Second) {
+		t.Fatal("NATS server not ready")
+	}
+
+	nc, err := nats.Connect(nats.DefaultURL, nats.InProcessServer(ns))
+	if err != nil {
+		t.Fatalf("Failed to connect to NATS: %v", err)
+	}
+
+	t.Cleanup(func() {
+		nc.Close()
+		ns.Shutdown()
+		ns.WaitForShutdown()
+	})
+
+	return ns, nc
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -259,10 +259,11 @@ There is no `adminAuditLogEvents` subscription — audit events arrive through `
 | KV      | `INSTANCE_CONFIG`             | Server runtime configuration overrides      |
 | KV      | `USER_PRESENCE`               | Presence status (memory, TTL 60s)           |
 | KV      | `NOTIFICATIONS`               | User notifications (90-day TTL)             |
-| KV      | `AUTH_TOKENS`                 | Bearer auth tokens (configurable TTL)       |
+| KV      | `AUTH_TOKENS`                 | Legacy bearer auth tokens pending `RUNTIME_STATE` migration |
+| KV      | `RUNTIME_STATE`               | Persisted latest-value runtime/user state   |
 | KV      | `SERVER_CONFIG`               | Rooms (channel + DM), memberships           |
 | KV      | `SERVER_RBAC`                 | Legacy RBAC seed data read by the `EVT` boot migration |
-| KV      | `SERVER_RUNTIME`              | Read status, mention tracking               |
+| KV      | `SERVER_RUNTIME`              | Legacy runtime state pending cleanup        |
 | KV      | `SERVER_BODIES`               | Message bodies (GDPR-compliant) + standalone attachment metadata records — TODO: rename → `SERVER_CONTENT` |
 | KV      | `SERVER_REACTIONS`            | Legacy emoji reactions source for boot migration only |
 | KV      | `SERVER_THREADS`              | Thread metadata (reply count, participants) |
@@ -483,14 +484,15 @@ The unified `myEvents` GraphQL subscription is backed by a single core stream (`
 | ----------------------------- | ------- | -------- | ----------------------------------------------- |
 | `INSTANCE`                    | File    | Yes      | Users, memberships (bucket name retained from pre-rename) |
 | `INSTANCE_CONFIG`             | File    | Yes      | Server runtime configuration overrides          |
+| `RUNTIME_STATE`               | File    | Yes      | Persisted latest-value runtime/user state       |
 | `SERVER_CONFIG`               | File    | Yes      | Rooms (channel + DM), memberships               |
 | `SERVER_RBAC`                 | File    | Yes      | Legacy RBAC seed data read by the `EVT` boot migration |
-| `SERVER_RUNTIME`              | File    | Yes      | Read state, mention tracking                    |
+| `SERVER_RUNTIME`              | File    | Yes      | Legacy runtime state pending cleanup            |
 | `SERVER_BODIES`               | File    | Yes      | Message bodies (GDPR-compliant) + standalone attachment metadata records — TODO: rename → `SERVER_CONTENT` |
 | `SERVER_REACTIONS`            | File    | Yes      | Legacy emoji reactions, read only by the EVT boot migration |
 | `SERVER_THREADS`              | File    | Yes      | Thread metadata (reply count, participants)     |
 | `NOTIFICATIONS`               | File    | Yes      | User notifications (90-day TTL)                 |
-| `AUTH_TOKENS`                 | File    | No       | Bearer auth tokens (configurable TTL, default 90d) |
+| `AUTH_TOKENS`                 | File    | No       | Legacy bearer auth tokens pending `RUNTIME_STATE` migration |
 | `USER_PRESENCE`               | Memory  | No       | User presence status (TTL 60s)                  |
 | `CALL_STATE`                  | Memory  | No       | Active voice call participants, keyed `{spaceId}.{roomId}` (repopulated by LiveKit webhooks after restart) |
 | `ENCRYPTION_KEYS`             | File    | **No**   | User encryption keys (excluded for security)    |
@@ -541,7 +543,7 @@ Notes: 90-day TTL for automatic cleanup. Notifications are created for DM messag
 | --------- | ----------------------------------------------------- |
 | `{token}` | JSON with user ID and creation time                   |
 
-Notes: Tokens are opaque strings (`cht_AT` + 14-char NanoID). Used for `Authorization: Bearer <token>` header authentication, enabling cross-origin clients. TTL-based auto-expiry (default 90 days, configurable via `auth.token_ttl`). Excluded from backups since tokens are ephemeral credentials. Tokens are issued on login, registration, bootstrap, and OAuth callback.
+Notes: Tokens are opaque strings (`cht_AT` + 14-char NanoID). Used for `Authorization: Bearer <token>` header authentication, enabling cross-origin clients. TTL-based auto-expiry (default 90 days, configurable via `auth.token_ttl`). Excluded from backups in the legacy `AUTH_TOKENS` bucket since tokens are ephemeral credentials; ADR-036 targets durable token state for `RUNTIME_STATE` so TTL policy can be managed through the shared runtime-state bucket. Tokens are issued on login, registration, bootstrap, and OAuth callback.
 
 **ENCRYPTION_KEYS keys:**
 
@@ -593,11 +595,21 @@ cleanup phase. The RBAC boot importer reads historical `role.*`, `member.*`,
 `room_deny.*` keys into `EVT` using OCC so repeated boots skip an already seeded
 RBAC subject family.
 
+**RUNTIME\_STATE keys:**
+
+`RUNTIME_STATE` is the persisted home for latest-value runtime state that
+survives restart but is not content/domain history. See
+[ADR-036](adr/ADR-036-runtime-state-kv-boundary.md).
+
+| Key                                    | Description                                                       |
+| -------------------------------------- | ----------------------------------------------------------------- |
+| `read.room.{userId}.{roomId}`          | Last-read root message event ID (UTF-8 string, ~14 bytes). Empty value = "joined but no specific event read yet" (e.g. joined an empty room). Missing key triggers a one-time lazy init to the room's current last event ("caught up at first read post-deploy"). Legacy `SERVER_RUNTIME` `room_read_event.*` keys are copied here at boot; older `room_read_status.*` sequence keys are orphaned and ignored. |
+| `read.thread.{userId}.{roomId}.{threadRootEventId}` | Latest thread message event ID the user has seen. Values copied from legacy `thread_last_opened.*` may be 8-byte UnixNano timestamps until rewritten by a new read action. |
+
 **SERVER\_RUNTIME keys:**
 
 | Key                                    | Description                                                       |
 | -------------------------------------- | ----------------------------------------------------------------- |
-| `room_read_event.{userId}.{roomId}`    | Last-read root message event ID (UTF-8 string, ~14 bytes). Empty value = "joined but no specific event read yet" (e.g. joined an empty room). Missing key triggers a one-time lazy init to the room's current last event ("caught up at first read post-deploy"). The legacy `room_read_status.*` keys (8-byte uint64 sequences) are orphaned and ignored. |
 | `room_mention_status.{userId}.{roomId}`| Unread mention indicator (boolean — key presence means unread)    |
 | `room_last_msg_at.{roomId}`            | Last message timestamp (per-room, used for sidebar sort)          |
 | `video.{attachmentId}`                 | Video processing state for an attachment                          |
@@ -679,7 +691,7 @@ Notes: Only created when `[core.assets.cache]` is enabled in config. Uses TTL fo
 | `{attachmentId}`      | Original attachment files (images, videos, etc.)|
 | `{attachmentId}_thumb`| WebP thumbnails (256px max dimension)           |
 
-Notes: Attachment IDs are globally unique (NanoID), so no kind segment is needed. Channel and DM attachments share the same flat keyspace. Content-Type and original filename stored in object headers. S2 compression enabled. Attachment **metadata** (room ID, filename, dimensions, storage pointer, …) lives embedded inside its owning `MessageBody` proto in `SERVER_BODIES` (`{userId}.{bodyId}`) — that's the only source of truth. Variant + thumbnail attachments generated by the video pipeline are embedded inside the relevant `VideoProcessingState` proto in `SERVER_RUNTIME` instead. The asset HTTP handler doesn't look up a separate metadata bucket; the body-or-VPS key travels in the URL itself as a signed locator (see "Dynamic Image Transformation" below).
+Notes: Attachment IDs are globally unique (NanoID), so no kind segment is needed. Channel and DM attachments share the same flat keyspace. Content-Type and original filename stored in object headers. S2 compression enabled. Attachment **metadata** (room ID, filename, dimensions, storage pointer, …) lives embedded inside its owning `MessageBody` proto in `SERVER_BODIES` (`{userId}.{bodyId}`) — that's the only source of truth. Variant + thumbnail attachments generated by the video pipeline are currently embedded inside the relevant `VideoProcessingState` proto in legacy `SERVER_RUNTIME`; ADR-036 makes asset processing state a `RUNTIME_STATE` target. The asset HTTP handler doesn't look up a separate metadata bucket; the body-or-VPS key travels in the URL itself as a signed locator (see "Dynamic Image Transformation" below).
 
 ### Dynamic Image Transformation
 
@@ -787,7 +799,7 @@ Messages use a store-then-publish pattern optimized for reliability and GDPR com
 - `@username` patterns in message body are extracted via regex (ASCII alphanumeric, underscore, hyphen)
 - Usernames are resolved to user IDs; only space members are included (non-members silently ignored)
 - `MessagePostedEvent.mentioned_user_ids` contains resolved user IDs
-- Mention status stored in RUNTIME bucket (`room_mention_status.{userId}.{roomId}`)
+- Mention status currently stored in legacy `SERVER_RUNTIME` (`room_mention_status.{userId}.{roomId}`); #660 tracks folding this into the notification model instead of migrating it to `RUNTIME_STATE`.
 - Live notification published to `live.server.user.{userId}.mentioned` for toast display
 - Mention indicator cleared when user calls `markRoomAsRead`
 - Self-mentions are filtered out (no notification to message author)

--- a/docs/adr/ADR-028-event-id-keyed-read-state.md
+++ b/docs/adr/ADR-028-event-id-keyed-read-state.md
@@ -8,7 +8,7 @@
 
 **Related:** [ADR-026](ADR-026-event-identity-via-nanoid.md), [ADR-027](ADR-027-instance-space-server-consolidation.md), [ADR-029](ADR-029-instance-to-server-rename.md), [ADR-030](ADR-030-space-tier-retirement.md)
 
-**Naming note:** This ADR was written during the consolidation work and refers to subjects like `space.{s}.room.{r}.msg.*` and the legacy `SPACE_{id}_RUNTIME` KV bucket. Post-ADR-029/030, the subject is `server.room.{kind}.{roomId}.msg.*` and the bucket is the unified `SERVER_RUNTIME`. The event-ID keying pattern (`room_read_event.{userId}.{roomId}` holding a 14-char NanoID) is unchanged and lives in `SERVER_RUNTIME` today.
+**Naming note:** This ADR was written during the consolidation work and refers to subjects like `space.{s}.room.{r}.msg.*` and the legacy `SPACE_{id}_RUNTIME` KV bucket. Post-ADR-029/030, the subject became `server.room.{kind}.{roomId}.msg.*`; post-#596 read markers live in `RUNTIME_STATE` as `read.room.{userId}.{roomId}`. The core event-ID keying decision is unchanged.
 
 ## Context
 

--- a/docs/adr/ADR-033-event-sourced-state-with-projections.md
+++ b/docs/adr/ADR-033-event-sourced-state-with-projections.md
@@ -29,7 +29,7 @@ Adopt event sourcing as the storage pattern for domain state.
 - **All writes use optimistic concurrency control.** Every event publish carries a `Nats-Expected-Last-Subject-Sequence` header. The framework offers no "publish without OCC" primitive. This guarantees that per-subject (per-aggregate) history is a serialized sequence with no race-induced gaps. The same invariant makes migration replayable and makes uniqueness claims expressible as ordered subject sequences.
 - **Read-your-writes via wait-for-seq.** Successful publish returns a stream sequence number. The actor's next read against the projection blocks (briefly) until the projection consumer position has reached that sequence. Reads from other actors see the new state on the projection's natural consumer cadence — typically sub-millisecond, never coordinated.
 - **Snapshots are deferred but accommodated.** The projection interface includes `Snapshot()` and `Restore()` methods from day one. No snapshot orchestration ships initially — startup replays from the beginning of the stream. We add snapshot persistence when stream length makes startup time unacceptable, without changing the projection contract.
-- **Ephemeral state stays out.** Presence, typing indicators, link-preview cache, auth tokens, image cache, and similar TTL-driven or content-addressed state continue to use plain NATS KV / Object Store. They are not part of the event log.
+- **Runtime state stays out.** Presence, typing indicators, link-preview cache, auth tokens, image cache, and similar TTL-driven or content-addressed state are not part of the event log. Durable latest-value runtime state uses `RUNTIME_STATE` per [ADR-036](ADR-036-runtime-state-kv-boundary.md); purely transient state can remain memory-backed, and binary/object data stays in object stores.
 - **A thin internal Go package owns the abstractions.** No third-party event-sourcing framework is adopted. The package exposes `Publish`, a `Projection` interface, a `Projector` (consumer + apply loop), and `WaitForSeq`. Estimated size: ~1000–1500 lines, fully under our control.
 
 This ADR supersedes ADR-006.
@@ -52,6 +52,7 @@ This ADR supersedes ADR-006.
 
 - The shape of the event log itself (one stream vs. many) — see [ADR-034](ADR-034-single-event-stream.md).
 - The migration strategy from today's CRUD+log model — see [ADR-035](ADR-035-per-aggregate-phased-migration.md).
+- The runtime-state storage boundary — see [ADR-036](ADR-036-runtime-state-kv-boundary.md).
 - Snapshot persistence and projection bootstrapping from snapshots — interface is committed here; mechanism is deferred to a future ADR when stream length forces the issue.
 - Long-term retention, archival, cold storage — also deferred.
 - Multi-process coordination beyond "every process maintains its own projection." If we ever want a single authoritative projection across processes, that is a separate decision.

--- a/docs/adr/ADR-036-runtime-state-kv-boundary.md
+++ b/docs/adr/ADR-036-runtime-state-kv-boundary.md
@@ -1,0 +1,87 @@
+# ADR-036: Persist Runtime State in RUNTIME_STATE
+
+**Date:** 2026-05-27
+
+## Context
+
+[ADR-033](ADR-033-event-sourced-state-with-projections.md) moves Chatto's
+content and domain state to `EVT`, with projections derived from that event
+history. Not every durable value belongs in that log. Some state is operational
+or user-runtime state: it needs to survive process restarts, but it is a
+latest-value cursor, token, job status, cache marker, or runtime preference
+rather than reconstructable Chatto content.
+
+Historically these values have lived in a mix of buckets:
+
+- `SERVER_RUNTIME` for read cursors, mention flags, per-room runtime indexes,
+  and video processing state.
+- `AUTH_TOKENS` for bearer tokens.
+- Feature-specific KV buckets or object stores for caches and processing
+  metadata.
+
+That spread makes the event-sourcing boundary fuzzy. It also keeps
+`SERVER_RUNTIME` as an architectural name even though "server" is a
+user-facing product concept, not a useful storage category.
+
+## Decision
+
+Persist all non-content runtime state in one JetStream KV bucket named
+`RUNTIME_STATE`.
+
+The storage boundary is:
+
+- If a value is needed to reconstruct Chatto content or domain state, it belongs
+  in `EVT`.
+- If a value is durable latest-value runtime/user/operational state, it belongs
+  in `RUNTIME_STATE`.
+- If a value is purely transient process state, it can remain in memory or a
+  memory-backed KV bucket.
+- If a value is binary/object data, it belongs in the appropriate object store.
+- Administrator-managed configuration stays in the existing configuration
+  buckets because it is configuration, not runtime state.
+- User encryption keys stay in `ENCRYPTION_KEYS` because their backup and
+  security rules are intentionally different from ordinary runtime state.
+
+`RUNTIME_STATE` is persisted and configured for latest-value use:
+
+- File storage.
+- One version per key (`History: 1`).
+- Replicated with the deployment's configured replica count.
+- Compression enabled.
+- Per-key TTL support enabled via a limit-marker TTL; no global TTL is applied.
+
+Initial and planned occupants include:
+
+- Room read cursors: `read.room.{userId}.{roomId}`.
+- Thread read cursors: `read.thread.{userId}.{roomId}.{threadRootEventId}`.
+- Auth, verification, reset, and revocation tokens after their migration from
+  token-specific buckets.
+- Asset and video processing state after its migration from `SERVER_RUNTIME`.
+- Other notification-adjacent latest-value state after the notification model
+  refactor.
+
+Mention flags are not a target runtime-state model. The notification refactor
+tracked by #660 should make orange-dot behavior derive from the notification
+model instead of preserving `room_mention_status.*` as canonical state.
+
+## Consequences
+
+- `EVT` remains focused on reconstructable content and domain history.
+- Runtime state has one persisted operational home with uniform backup, TTL,
+  and history semantics.
+- The old `SERVER_RUNTIME` bucket becomes a legacy migration source, not a
+  place for new state.
+- Runtime values in `RUNTIME_STATE` are not replayable from `EVT`; backup and
+  restore procedures must include this bucket when preserving user/runtime
+  continuity matters.
+- Per-key TTL becomes available for tokens, processing records, and similar
+  values without splitting each feature into its own bucket.
+- Security-sensitive exceptions remain explicit. In particular,
+  `ENCRYPTION_KEYS` is not folded into this bucket.
+
+## Related
+
+- [ADR-033](ADR-033-event-sourced-state-with-projections.md) — defines the
+  event-sourced content/domain boundary.
+- [ADR-028](ADR-028-event-id-keyed-read-state.md) — defines the read-cursor
+  shape that now lives in `RUNTIME_STATE`.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -43,3 +43,4 @@ For more about ADRs, see [Michael Nygard's article](https://cognitect.com/blog/2
 | [ADR-033](ADR-033-event-sourced-state-with-projections.md) | Event-Sourced State with Derived Projections (supersedes ADR-006) | 2026-05-24 |
 | [ADR-034](ADR-034-single-event-stream.md) | Single Event Stream, Subject-Per-Aggregate | 2026-05-24 |
 | [ADR-035](ADR-035-per-aggregate-phased-migration.md) | Per-Aggregate Phased Migration to Event Sourcing | 2026-05-24 |
+| [ADR-036](ADR-036-runtime-state-kv-boundary.md) | Persist Runtime State in RUNTIME_STATE | 2026-05-27 |

--- a/docs/fdr/FDR-008-file-attachments-and-video.md
+++ b/docs/fdr/FDR-008-file-attachments-and-video.md
@@ -62,5 +62,5 @@ No separate upload permission. Posting an attachment requires room membership an
 
 ## Related
 
-- **ADRs:** ADR-021 (dual asset storage), ADR-023 (HMAC-signed image transform URLs), ADR-032 (self-describing signed attachment URLs)
+- **ADRs:** ADR-021 (dual asset storage), ADR-023 (HMAC-signed image transform URLs), ADR-032 (self-describing signed attachment URLs), ADR-036 (runtime state in `RUNTIME_STATE`)
 - **FDRs:** FDR-002 (Replies & Threads), FDR-004 (Message Editing & Deletion)

--- a/docs/fdr/FDR-012-notifications.md
+++ b/docs/fdr/FDR-012-notifications.md
@@ -75,5 +75,5 @@ Notification preferences are user-scoped and don't require special permissions t
 
 ## Related
 
-- **ADRs:** ADR-012 (two-tier real-time events), ADR-028 (event-ID-keyed read state)
+- **ADRs:** ADR-012 (two-tier real-time events), ADR-028 (event-ID-keyed read state), ADR-036 (runtime state in `RUNTIME_STATE`)
 - **FDRs:** FDR-006 (@Mentions), FDR-007 (Direct Messages), FDR-013 (Web Push Notifications)

--- a/docs/fdr/FDR-023-authentication-and-sessions.md
+++ b/docs/fdr/FDR-023-authentication-and-sessions.md
@@ -74,7 +74,7 @@ Authentication itself doesn't have a permission gate (you're either authenticate
 
 ## Related
 
-- **ADRs:** ADR-017 (cookie-session auth for WebSocket), ADR-024 (opaque bearer tokens for cross-origin auth), ADR-025 (multi-instance client architecture)
+- **ADRs:** ADR-017 (cookie-session auth for WebSocket), ADR-024 (opaque bearer tokens for cross-origin auth), ADR-025 (multi-instance client architecture), ADR-036 (runtime state in `RUNTIME_STATE`)
 - **FDRs:** FDR-001 (Roles & Permissions), FDR-018 (Account Lifecycle)
 
 ## Open Questions

--- a/frontend/e2e/fixtures/server.ts
+++ b/frontend/e2e/fixtures/server.ts
@@ -10,15 +10,14 @@ const __dirname = path.dirname(__filename);
 export interface ServerInfo {
   baseURL: string;
   port: number;
-  natsPort: number;
   process: ChildProcess;
 }
 
-const PORT_STRIDE = 10;
+const PORT_STRIDE = 1;
 
 // Random offset for this test suite run to avoid port collisions
 // when running multiple test suites simultaneously.
-// Each suite needs ~100 ports (10 workers × 10 stride).
+// Each suite needs ~100 ports (10 workers × 10 parallel tests).
 // Range 4040-30000 gives ~260 slots, making collisions very unlikely.
 const SUITE_PORT_RANGE = 100;
 const MIN_PORT = 4040;
@@ -36,13 +35,11 @@ const BASE_PORT = process.env.E2E_BASE_PORT
  * parallelIndex is unique within a worker for parallel tests.
  */
 function getPortsForTest(workerIndex: number, parallelIndex: number) {
-  // With 10 workers max and 10 parallel tests per worker max,
-  // this gives us 100 unique port ranges starting from BASE_PORT
-  const base = BASE_PORT + (workerIndex * 10 + parallelIndex) * PORT_STRIDE;
+  // With 10 workers max and 10 parallel tests per worker max, this gives us
+  // 100 unique web ports starting from BASE_PORT.
+  const webserver = BASE_PORT + (workerIndex * 10 + parallelIndex) * PORT_STRIDE;
   return {
-    webserver: base,
-    nats: base + 2,
-    natsHttp: base + 3
+    webserver
   };
 }
 
@@ -93,20 +90,24 @@ export async function startServer(
   mkdirSync(dataDir, { recursive: true });
 
   // chatto.toml seeds the e2eadmin user via [bootstrap] on every server start.
-  const serverProcess = spawn(path.join(__dirname, 'bin', 'chatto'), ['start', '-c', 'chatto.toml'], {
-    cwd: __dirname,
-    env: {
-      ...process.env,
-      ...options.env,
-      CHATTO_WEBSERVER_PORT: String(ports.webserver),
-      CHATTO_WEBSERVER_URL: `http://localhost:${ports.webserver}`,
-      CHATTO_NATS_EMBEDDED_PORT: String(ports.nats),
-      CHATTO_NATS_EMBEDDED_HTTP_PORT: String(ports.natsHttp),
-      CHATTO_NATS_EMBEDDED_DATA_DIR: dataDir,
-      CHATTO_TEST_EMAIL_ENDPOINT: 'true' // Enable test email endpoint for E2E tests
-    },
-    stdio: ['ignore', 'pipe', 'pipe']
-  });
+  const serverProcess = spawn(
+    path.join(__dirname, 'bin', 'chatto'),
+    ['start', '-c', 'chatto.toml'],
+    {
+      cwd: __dirname,
+      env: {
+        ...process.env,
+        ...options.env,
+        CHATTO_WEBSERVER_PORT: String(ports.webserver),
+        CHATTO_WEBSERVER_URL: `http://localhost:${ports.webserver}`,
+        CHATTO_NATS_EMBEDDED_PORT: '0',
+        CHATTO_NATS_EMBEDDED_HTTP_PORT: '0',
+        CHATTO_NATS_EMBEDDED_DATA_DIR: dataDir,
+        CHATTO_TEST_EMAIL_ENDPOINT: 'true' // Enable test email endpoint for E2E tests
+      },
+      stdio: ['ignore', 'pipe', 'pipe']
+    }
+  );
 
   // Log server output for debugging (prefix with test title)
   const prefix = `[${testInfo.title}]`;
@@ -129,7 +130,6 @@ export async function startServer(
   return {
     baseURL: `http://localhost:${ports.webserver}`,
     port: ports.webserver,
-    natsPort: ports.nats,
     process: serverProcess
   };
 }


### PR DESCRIPTION
- Move room and thread read markers into the persisted RUNTIME_STATE JetStream KV bucket.
- Add a boot migration that copies legacy SERVER_RUNTIME read marker keys into the new runtime-state key shape without overwriting newer markers.
- Store new thread read markers as event IDs while still decoding migrated legacy timestamp values.
- Add ADR-036 and update architecture/FDR references for the RUNTIME_STATE storage boundary.
- Replace random TCP NATS listeners in Go tests with in-process embedded NATS connections.
- Run e2e backend servers with embedded NATS ports disabled; the published NATS port remains a development-only convenience.