### PR TITLE
Fix room timeline projection read consistency

### DIFF
--- a/cli/internal/core/dm.go
+++ b/cli/internal/core/dm.go
@@ -274,6 +274,9 @@ func (c *ChattoCore) createDMRoom(ctx context.Context, roomID string, participan
 	if err := c.RoomMembershipProjector.WaitForSeq(ctx, seqs[len(seqs)-1]); err != nil {
 		c.logger.Warn("DM membership projection wait failed", "error", err, "room_id", roomID)
 	}
+	if err := c.RoomTimelineProjector.WaitForSeq(ctx, seqs[len(seqs)-1]); err != nil {
+		c.logger.Warn("DM room timeline projection wait failed", "error", err, "room_id", roomID)
+	}
 
 	// Per-participant non-batched side effects: initialise the
 	// read marker (so HasUnread distinguishes a fresh member from a

--- a/cli/internal/core/dm_test.go
+++ b/cli/internal/core/dm_test.go
@@ -236,6 +236,33 @@ func TestFindOrCreateDM(t *testing.T) {
 		if !isMember2 {
 			t.Error("user2 should be a member of the DM")
 		}
+
+		eventsResult, err := core.GetRoomEvents(ctx, KindDM, room.Id, 50, nil)
+		if err != nil {
+			t.Fatalf("GetRoomEvents for new DM: %v", err)
+		}
+		if len(eventsResult.Events) != 3 {
+			t.Fatalf("expected 3 DM lifecycle events (room created + 2 joins), got %d", len(eventsResult.Events))
+		}
+
+		createdCount := 0
+		joinedActors := map[string]bool{}
+		for _, event := range eventsResult.Events {
+			if created := event.GetRoomCreated(); created != nil && created.RoomId == room.Id {
+				createdCount++
+			}
+			if joined := event.GetUserJoinedRoom(); joined != nil && joined.RoomId == room.Id {
+				joinedActors[event.ActorId] = true
+			}
+		}
+		if createdCount != 1 {
+			t.Errorf("expected 1 DM RoomCreated event, got %d", createdCount)
+		}
+		for _, userID := range []string{user1, user2} {
+			if !joinedActors[userID] {
+				t.Errorf("expected DM UserJoinedRoom event for %s", userID)
+			}
+		}
 	})
 
 	t.Run("finds existing DM", func(t *testing.T) {

--- a/cli/internal/core/room_events_test.go
+++ b/cli/internal/core/room_events_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -127,6 +128,52 @@ func TestChattoCore_GetRoomEvents_JoinAndLeaveEvents(t *testing.T) {
 	if leaveCount != 1 {
 		t.Errorf("Expected 1 UserLeftRoom event, got %d", leaveCount)
 	}
+}
+
+func TestChattoCore_GetRoomEvents_RoomLifecycleCommandsAreImmediatelyVisible(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	room, err := core.CreateRoom(ctx, "test-user", KindChannel, "", "lifecycle-room", "Original description")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	assertLatestRoomEvent(t, core, ctx, KindChannel, room.Id, func(event *corev1.Event) bool {
+		created := event.GetRoomCreated()
+		return created != nil && created.RoomId == room.Id
+	})
+
+	if _, err := core.UpdateRoom(ctx, "test-user", KindChannel, room.Id, "renamed-lifecycle-room", "Updated description"); err != nil {
+		t.Fatalf("Failed to update room: %v", err)
+	}
+	assertLatestRoomEvent(t, core, ctx, KindChannel, room.Id, func(event *corev1.Event) bool {
+		updated := event.GetRoomUpdated()
+		return updated != nil && updated.RoomId == room.Id && updated.Name == "renamed-lifecycle-room"
+	})
+
+	if _, err := core.ArchiveRoom(ctx, "test-user", KindChannel, room.Id); err != nil {
+		t.Fatalf("Failed to archive room: %v", err)
+	}
+	assertLatestRoomEvent(t, core, ctx, KindChannel, room.Id, func(event *corev1.Event) bool {
+		archived := event.GetRoomArchived()
+		return archived != nil && archived.RoomId == room.Id
+	})
+
+	if _, err := core.UnarchiveRoom(ctx, "test-user", KindChannel, room.Id); err != nil {
+		t.Fatalf("Failed to unarchive room: %v", err)
+	}
+	assertLatestRoomEvent(t, core, ctx, KindChannel, room.Id, func(event *corev1.Event) bool {
+		unarchived := event.GetRoomUnarchived()
+		return unarchived != nil && unarchived.RoomId == room.Id
+	})
+
+	if err := core.DeleteRoom(ctx, "test-user", KindChannel, room.Id); err != nil {
+		t.Fatalf("Failed to delete room: %v", err)
+	}
+	assertLatestRoomEvent(t, core, ctx, KindChannel, room.Id, func(event *corev1.Event) bool {
+		deleted := event.GetRoomDeleted()
+		return deleted != nil && deleted.RoomId == room.Id
+	})
 }
 
 // TestChattoCore_GetRoomEvents_JoinAfterLastMessage verifies that join events
@@ -507,4 +554,28 @@ func TestChattoCore_GetRoomEventByEventID(t *testing.T) {
 			t.Error("Expected nil when looking up event in wrong room")
 		}
 	})
+}
+
+func assertLatestRoomEvent(
+	t *testing.T,
+	core *ChattoCore,
+	ctx context.Context,
+	kind RoomKind,
+	roomID string,
+	matches func(*corev1.Event) bool,
+) {
+	t.Helper()
+
+	result, err := core.GetRoomEvents(ctx, kind, roomID, 50, nil)
+	if err != nil {
+		t.Fatalf("GetRoomEvents: %v", err)
+	}
+	if len(result.Events) == 0 {
+		t.Fatal("expected at least one room event")
+	}
+
+	latest := result.Events[len(result.Events)-1]
+	if !matches(latest.Event) {
+		t.Fatalf("latest event = %T, want requested lifecycle event", latest.Event.GetEvent())
+	}
 }

--- a/cli/internal/core/room_membership.go
+++ b/cli/internal/core/room_membership.go
@@ -43,8 +43,9 @@ func (c *ChattoCore) RoomMembershipExists(ctx context.Context, kind RoomKind, us
 //
 // ADR-035 phase 6: event-only. Publishes UserJoinedRoomEvent to EVT,
 // mirrors to the legacy live subject for frontend myEvents delivery,
-// then WaitForSeq for read-your-writes. The room_membership KV bucket
-// is no longer written to (retained as pre-ES import evidence).
+// then WaitForSeq on the projections that serve membership and room
+// history reads. The room_membership KV bucket is no longer written
+// to (retained as pre-ES import evidence).
 func (c *ChattoCore) JoinRoom(ctx context.Context, actorID string, kind RoomKind, user_id, room_id string) (*corev1.RoomMembership, error) {
 	// Verify room exists and is not archived
 	room, err := c.GetRoom(ctx, kind, room_id)
@@ -76,8 +77,12 @@ func (c *ChattoCore) JoinRoom(ctx context.Context, actorID string, kind RoomKind
 		},
 	})
 
-	if _, err := c.RoomMembershipProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.RoomAggregate(room_id), event); err != nil {
+	seq, err := c.RoomMembershipProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.RoomAggregate(room_id), event)
+	if err != nil {
 		return nil, fmt.Errorf("publish UserJoinedRoomEvent: %w", err)
+	}
+	if err := c.RoomTimelineProjector.WaitForSeq(ctx, seq); err != nil {
+		return nil, fmt.Errorf("wait for room timeline projection: %w", err)
 	}
 
 	// Legacy publish — feeds live.server.> for the frontend's
@@ -118,7 +123,8 @@ func (c *ChattoCore) JoinRoom(ctx context.Context, actorID string, kind RoomKind
 //     cannot be left (users can mute them via notification preferences).
 //
 // ADR-035 phase 6: event-only. Publishes UserLeftRoomEvent, legacy
-// mirror, then WaitForSeq.
+// mirror, then WaitForSeq on the projections that serve membership
+// and room history reads.
 func (c *ChattoCore) LeaveRoom(ctx context.Context, actorID string, kind RoomKind, user_id, room_id string) error {
 	if kind == KindDM {
 		return ErrCannotLeaveDMConversation
@@ -136,8 +142,12 @@ func (c *ChattoCore) LeaveRoom(ctx context.Context, actorID string, kind RoomKin
 		},
 	})
 
-	if _, err := c.RoomMembershipProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.RoomAggregate(room_id), event); err != nil {
+	seq, err := c.RoomMembershipProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.RoomAggregate(room_id), event)
+	if err != nil {
 		return fmt.Errorf("publish UserLeftRoomEvent: %w", err)
+	}
+	if err := c.RoomTimelineProjector.WaitForSeq(ctx, seq); err != nil {
+		return fmt.Errorf("wait for room timeline projection: %w", err)
 	}
 
 	legacySubject := subjects.RoomMeta(string(kind), room_id)
@@ -253,7 +263,10 @@ func (c *ChattoCore) deleteUserRoomMembershipsInSpace(ctx context.Context, user_
 
 	if lastSeq > 0 {
 		if err := c.RoomMembershipProjector.WaitForSeq(ctx, lastSeq); err != nil {
-			return fmt.Errorf("wait for projection after membership cleanup: %w", err)
+			return fmt.Errorf("wait for membership projection after membership cleanup: %w", err)
+		}
+		if err := c.RoomTimelineProjector.WaitForSeq(ctx, lastSeq); err != nil {
+			return fmt.Errorf("wait for room timeline projection after membership cleanup: %w", err)
 		}
 	}
 	return nil

--- a/cli/internal/core/rooms.go
+++ b/cli/internal/core/rooms.go
@@ -241,6 +241,9 @@ func (c *ChattoCore) CreateRoom(ctx context.Context, actorID string, kind RoomKi
 	if err := c.RoomCatalogProjector.WaitForSeq(ctx, createdSeq); err != nil {
 		return nil, fmt.Errorf("wait for catalog projection: %w", err)
 	}
+	if err := c.RoomTimelineProjector.WaitForSeq(ctx, createdSeq); err != nil {
+		return nil, fmt.Errorf("wait for room timeline projection: %w", err)
+	}
 	return room, nil
 }
 
@@ -373,6 +376,9 @@ func (c *ChattoCore) UpdateRoom(ctx context.Context, actorID string, kind RoomKi
 	if err := c.RoomCatalogProjector.WaitForSeq(ctx, updatedSeq); err != nil {
 		return nil, fmt.Errorf("wait for catalog projection: %w", err)
 	}
+	if err := c.RoomTimelineProjector.WaitForSeq(ctx, updatedSeq); err != nil {
+		return nil, fmt.Errorf("wait for room timeline projection: %w", err)
+	}
 	return room, nil
 }
 
@@ -451,6 +457,9 @@ func (c *ChattoCore) DeleteRoom(ctx context.Context, actorID string, kind RoomKi
 	if err := c.RoomCatalogProjector.WaitForSeq(ctx, seq); err != nil {
 		return fmt.Errorf("wait for catalog projection: %w", err)
 	}
+	if err := c.RoomTimelineProjector.WaitForSeq(ctx, seq); err != nil {
+		return fmt.Errorf("wait for room timeline projection: %w", err)
+	}
 	if groupRemovedSeq > 0 {
 		if err := c.RoomGroupsProjector.WaitForSeq(ctx, groupRemovedSeq); err != nil {
 			return fmt.Errorf("wait for groups projection: %w", err)
@@ -478,8 +487,12 @@ func (c *ChattoCore) ArchiveRoom(ctx context.Context, actorID string, kind RoomK
 			},
 		},
 	})
-	if _, err := c.RoomCatalogProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.RoomAggregate(roomID), archivedEvent); err != nil {
+	seq, err := c.RoomCatalogProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.RoomAggregate(roomID), archivedEvent)
+	if err != nil {
 		return nil, fmt.Errorf("publish RoomArchivedEvent: %w", err)
+	}
+	if err := c.RoomTimelineProjector.WaitForSeq(ctx, seq); err != nil {
+		return nil, fmt.Errorf("wait for room timeline projection: %w", err)
 	}
 
 	subject := subjects.RoomMeta(string(kind), roomID)
@@ -513,8 +526,12 @@ func (c *ChattoCore) UnarchiveRoom(ctx context.Context, actorID string, kind Roo
 			},
 		},
 	})
-	if _, err := c.RoomCatalogProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.RoomAggregate(roomID), unarchivedEvent); err != nil {
+	seq, err := c.RoomCatalogProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.RoomAggregate(roomID), unarchivedEvent)
+	if err != nil {
 		return nil, fmt.Errorf("publish RoomUnarchivedEvent: %w", err)
+	}
+	if err := c.RoomTimelineProjector.WaitForSeq(ctx, seq); err != nil {
+		return nil, fmt.Errorf("wait for room timeline projection: %w", err)
 	}
 
 	subject := subjects.RoomMeta(string(kind), roomID)


### PR DESCRIPTION
## Summary
- wait for the room timeline projection after room lifecycle and membership writes that are visible in room history
- cover immediate room-history reads for channel lifecycle events and freshly-created DMs

## Tests
- mise test-cli