### PR TITLE
Fix bootstrap first-boot semantics

### DIFF
--- a/cli/chatto.toml
+++ b/cli/chatto.toml
@@ -53,10 +53,9 @@ port = 4555
 data_dir = './data'
 auth_token = 'd5ed70d13c4682609dfd0a4f65bf7e59ef22f3be8502762b501d3b7cf0b73b43'
 
-# Dev-only bootstrap. Creates these users + spaces on every dev-build startup
-# so iteration doesn't require re-registering through the UI. Idempotent —
-# entries that already exist are left alone. Plaintext passwords are fine
-# because release binaries don't compile this code path.
+# Dev-only bootstrap. Creates these users + the initial instance only when the
+# server is otherwise empty. Plaintext passwords are fine because release
+# binaries don't compile this code path.
 [[bootstrap.users]]
 login = 'alice'
 display_name = 'Alice'

--- a/cli/cmd/bootstrap.go
+++ b/cli/cmd/bootstrap.go
@@ -11,7 +11,7 @@ import (
 
 func init() {
 	// Register the bootstrap hook. Reads the [bootstrap] section from
-	// chatto.toml and applies it on every startup.
+	// chatto.toml and applies it on first boot of an otherwise empty server.
 	devStartupHook = func(ctx context.Context, c *core.ChattoCore, cfg config.ChattoConfig) {
 		applyBootstrap(ctx, c, cfg.Bootstrap)
 	}

--- a/cli/cmd/bootstrap_apply.go
+++ b/cli/cmd/bootstrap_apply.go
@@ -13,12 +13,10 @@ import (
 	"hmans.de/chatto/internal/core"
 )
 
-// applyBootstrap applies the [bootstrap] section from chatto.toml to the
-// running server. Idempotent — entries that already exist (matched by login
-// for users, by presence of the primary space record for the server) are
-// left alone. Errors on individual entries are logged but don't abort the
-// rest, so the section behaves like "ensure this stuff exists" rather than
-// a transactional batch.
+// applyBootstrap applies the [bootstrap] section from chatto.toml to an empty
+// server. It is first-boot provisioning, not a recurring reconciliation loop:
+// once application data exists, the section is ignored on later starts.
+// Errors on individual entries are logged but don't abort the rest.
 //
 // Only compiled into builds with the `bootstrap` tag; release binaries replace
 // this with a no-op so the [bootstrap] section in chatto.toml is parsed but
@@ -37,14 +35,24 @@ func applyBootstrap(ctx context.Context, c *core.ChattoCore, cfg config.Bootstra
 
 	logger.Info("Applying [bootstrap] section", "users", len(cfg.Users), "server", hasServer)
 
+	if empty, err := serverDataEmptyForBootstrap(ctx, c); err != nil {
+		logger.Warn("Could not determine whether server is empty; skipping [bootstrap]", "error", err)
+		return
+	} else if !empty {
+		logger.Debug("Server already has data; skipping [bootstrap]")
+		return
+	}
+
 	ownerID := ""
 	firstUserID := ""
+	var bootstrapUserIDs []string
 	usersCreated, usersExisting := 0, 0
 	for _, u := range cfg.Users {
 		userID, created := applyBootstrapUser(ctx, logger, c, u)
 		if userID == "" {
 			continue
 		}
+		bootstrapUserIDs = append(bootstrapUserIDs, userID)
 		if firstUserID == "" {
 			firstUserID = userID
 		}
@@ -68,7 +76,7 @@ func applyBootstrap(ctx context.Context, c *core.ChattoCore, cfg config.Bootstra
 		if ownerID == "" {
 			logger.Error("[bootstrap] instance requires at least one user; skipping server setup")
 		} else {
-			serverCreated = applyBootstrapServer(ctx, logger, c, *cfg.Server, ownerID)
+			serverCreated = applyBootstrapServer(ctx, logger, c, *cfg.Server, ownerID, bootstrapUserIDs)
 		}
 	}
 
@@ -77,6 +85,53 @@ func applyBootstrap(ctx context.Context, c *core.ChattoCore, cfg config.Bootstra
 		"users_existing", usersExisting,
 		"instance_created", serverCreated,
 	)
+}
+
+// serverDataEmptyForBootstrap returns true when only built-in first-boot
+// scaffolding exists. core.Run creates the seed Lobby group and SeedDefaultRooms
+// creates announcements/general before the dev bootstrap hook fires, so those
+// system-owned defaults do not count as data that should block bootstrap.
+func serverDataEmptyForBootstrap(ctx context.Context, c *core.ChattoCore) (bool, error) {
+	userCount, err := c.CountUsers(ctx)
+	if err != nil {
+		return false, err
+	}
+	if userCount > 0 {
+		return false, nil
+	}
+
+	if cm := c.ConfigManager(); cm != nil {
+		if cfg, configured, err := cm.GetServerConfig(ctx); err != nil {
+			return false, err
+		} else if configured || cfg != nil {
+			return false, nil
+		}
+	}
+
+	rooms, err := c.ListRooms(ctx, core.KindChannel)
+	if err != nil {
+		return false, err
+	}
+	defaultRoomNames := map[string]struct{}{}
+	for _, room := range core.DefaultGlobalRooms {
+		defaultRoomNames[room.Name] = struct{}{}
+	}
+	for _, room := range rooms {
+		if _, ok := defaultRoomNames[room.Name]; !ok {
+			return false, nil
+		}
+	}
+
+	groups, err := c.ListRoomGroupsOrdered(ctx, core.KindChannel)
+	if err != nil {
+		return false, err
+	}
+	for _, group := range groups {
+		if group.Name != core.SeedDefaultRoomGroupName {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 // applyBootstrapUser creates the user if missing, sets a verified email if the
@@ -154,7 +209,7 @@ func assignBootstrapRole(ctx context.Context, logger *log.Logger, c *core.Chatto
 // engines) — operators don't configure or see it directly. Returns true if
 // a primary space was newly created, false otherwise (already-existing or
 // skipped).
-func applyBootstrapServer(ctx context.Context, logger *log.Logger, c *core.ChattoCore, inst config.BootstrapServer, ownerID string) bool {
+func applyBootstrapServer(ctx context.Context, logger *log.Logger, c *core.ChattoCore, inst config.BootstrapServer, ownerID string, bootstrapUserIDs []string) bool {
 	if inst.Name == "" {
 		logger.Error("Skipping [bootstrap.instance] with empty name")
 		return false
@@ -164,25 +219,29 @@ func applyBootstrapServer(ctx context.Context, logger *log.Logger, c *core.Chatt
 	// name field is unset, so an admin-edited server name isn't clobbered
 	// on every dev restart).
 	if cm := c.ConfigManager(); cm != nil {
-		if _, err := cm.UpdateServerConfigFunc(ctx, "system:bootstrap", func(current *configv1.ServerConfig) (*configv1.ServerConfig, error) {
-			if current == nil {
-				return &configv1.ServerConfig{ServerName: inst.Name}, nil
+		current, _, err := cm.GetServerConfig(ctx)
+		if err != nil {
+			logger.Warn("Failed to read server config before [bootstrap.instance] seed", "error", err)
+		} else if current == nil || current.ServerName == "" {
+			if _, err := cm.UpdateServerConfigFunc(ctx, "system:bootstrap", func(current *configv1.ServerConfig) (*configv1.ServerConfig, error) {
+				if current == nil {
+					return &configv1.ServerConfig{ServerName: inst.Name}, nil
+				}
+				if current.ServerName == "" {
+					current.ServerName = inst.Name
+				}
+				return current, nil
+			}); err != nil {
+				logger.Warn("Failed to seed server config from [bootstrap.instance]", "error", err)
 			}
-			if current.ServerName == "" {
-				current.ServerName = inst.Name
-			}
-			return current, nil
-		}); err != nil {
-			logger.Warn("Failed to seed server config from [bootstrap.instance]", "error", err)
 		}
 	}
 
 	// Create operator-specified extra rooms (if any). The default rooms
 	// (`announcements`, `general`) are seeded by `SeedDefaultRooms` during
 	// startup — bootstrap no longer duplicates that. Owner auto-joins
-	// every existing channel room so the dev/e2e admin lands ready to use
-	// the server (and so e2e tests that count members of `general` see
-	// the admin).
+	// every existing channel room so dev/e2e users land ready to use the
+	// server.
 	for _, name := range inst.Rooms {
 		if _, err := c.CreateRoom(ctx, ownerID, core.KindChannel, "", name, ""); err != nil {
 			if !errors.Is(err, core.ErrRoomNameExists) {
@@ -195,10 +254,12 @@ func applyBootstrapServer(ctx context.Context, logger *log.Logger, c *core.Chatt
 	if err != nil {
 		logger.Warn("Failed to list rooms for bootstrap owner auto-join", "error", err)
 	}
-	for _, room := range existing {
-		if _, err := c.JoinRoom(ctx, ownerID, core.KindChannel, ownerID, room.Id); err != nil {
-			logger.Warn("Failed to auto-join bootstrap owner to room",
-				"room", room.Name, "error", err)
+	for _, userID := range bootstrapUserIDs {
+		for _, room := range existing {
+			if _, err := c.JoinRoom(ctx, userID, core.KindChannel, userID, room.Id); err != nil {
+				logger.Warn("Failed to auto-join bootstrap user to room",
+					"user_id", userID, "room", room.Name, "error", err)
+			}
 		}
 	}
 
@@ -212,5 +273,3 @@ func applyBootstrapServer(ctx context.Context, logger *log.Logger, c *core.Chatt
 	}
 	return true
 }
-
-

--- a/cli/cmd/bootstrap_test.go
+++ b/cli/cmd/bootstrap_test.go
@@ -58,6 +58,21 @@ func setupCore(t *testing.T) *core.ChattoCore {
 	return c
 }
 
+func eventCount(t *testing.T, c *core.ChattoCore) uint64 {
+	t.Helper()
+
+	ctx := context.Background()
+	stream, err := c.EventStreamForDebug(ctx)
+	if err != nil {
+		t.Fatalf("event stream: %v", err)
+	}
+	info, err := stream.Info(ctx)
+	if err != nil {
+		t.Fatalf("event stream info: %v", err)
+	}
+	return info.State.Msgs
+}
+
 func TestApplyBootstrap_CreatesUsersAndServer(t *testing.T) {
 	c := setupCore(t)
 	ctx := context.Background()
@@ -141,7 +156,13 @@ func TestApplyBootstrap_IsIdempotent(t *testing.T) {
 	}
 
 	applyBootstrap(ctx, c, cfg)
+	eventsAfterFirstRun := eventCount(t, c)
 	applyBootstrap(ctx, c, cfg) // second run should be a no-op for the same entries
+	eventsAfterSecondRun := eventCount(t, c)
+
+	if eventsAfterSecondRun != eventsAfterFirstRun {
+		t.Fatalf("expected second bootstrap to append no events, got %d -> %d", eventsAfterFirstRun, eventsAfterSecondRun)
+	}
 
 	// Bootstrap is idempotent at the room level: re-running shouldn't
 	// duplicate the default rooms (CreateRoom fails ErrRoomNameExists).
@@ -157,6 +178,32 @@ func TestApplyBootstrap_IsIdempotent(t *testing.T) {
 		if count > 1 {
 			t.Errorf("expected exactly one room named %q, got %d", name, count)
 		}
+	}
+}
+
+func TestApplyBootstrap_SkipsWhenServerHasData(t *testing.T) {
+	c := setupCore(t)
+	ctx := context.Background()
+
+	if _, err := c.CreateUser(ctx, "system", "existing", "Existing User", "devpassword"); err != nil {
+		t.Fatalf("create existing user: %v", err)
+	}
+	eventsBeforeBootstrap := eventCount(t, c)
+
+	cfg := config.BootstrapConfig{
+		Users: []config.BootstrapUser{
+			{Login: "alice", Email: "alice@example.com", Password: "devpassword", ServerRole: "owner"},
+		},
+		Server: &config.BootstrapServer{Name: "Should Not Apply", Rooms: []string{"random"}},
+	}
+	applyBootstrap(ctx, c, cfg)
+	eventsAfterBootstrap := eventCount(t, c)
+
+	if eventsAfterBootstrap != eventsBeforeBootstrap {
+		t.Fatalf("expected bootstrap to append no events on non-empty server, got %d -> %d", eventsBeforeBootstrap, eventsAfterBootstrap)
+	}
+	if user, err := c.GetUserByLogin(ctx, "alice"); err == nil && user != nil {
+		t.Fatal("expected bootstrap user not to be created on non-empty server")
 	}
 }
 

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -208,11 +208,18 @@ func (c *ChattoCore) Run(ctx context.Context) error {
 		if err := c.waitForProjectorsStarted(gctx, 5*time.Second); err != nil {
 			return fmt.Errorf("wait for projectors: %w", err)
 		}
+		// Before issuing boot-time "ensure" mutations, let every
+		// projection replay the durable stream as it exists now. A
+		// started-but-cold projection would otherwise look empty and
+		// append duplicate seed facts on every process restart.
+		if err := c.WaitForProjectionsCurrent(gctx); err != nil {
+			return fmt.Errorf("wait for projections current: %w", err)
+		}
 		// Seed the default room group and ensure every existing
 		// channel room belongs to a set (ADR-031). Idempotent —
 		// runs on every boot. Has to happen AFTER projectors are
-		// running because it both reads the RoomGroups projection
-		// and depends on WaitForSeq actually waiting.
+		// running and caught up because it reads the RoomGroups
+		// projection and depends on WaitForSeq actually waiting.
 		if err := c.ensureChannelRoomsAreInAGroup(gctx); err != nil {
 			return fmt.Errorf("ensure channel rooms in a group: %w", err)
 		}

--- a/cli/internal/core/core_test.go
+++ b/cli/internal/core/core_test.go
@@ -83,9 +83,85 @@ func startCoreServices(t *testing.T, core *ChattoCore) {
 	}
 }
 
+func eventStreamMsgCount(t *testing.T, core *ChattoCore) uint64 {
+	t.Helper()
+
+	ctx := testContext(t)
+	stream, err := core.EventStreamForDebug(ctx)
+	if err != nil {
+		t.Fatalf("event stream: %v", err)
+	}
+	info, err := stream.Info(ctx)
+	if err != nil {
+		t.Fatalf("event stream info: %v", err)
+	}
+	return info.State.Msgs
+}
+
 // ============================================================================
 // Integration Tests
 // ============================================================================
+
+func TestChattoCore_RunReplaysProjectionsBeforeBootEnsures(t *testing.T) {
+	_, nc := testutil.StartNATS(t)
+	cfg := config.CoreConfig{
+		Assets: config.AssetsConfig{
+			SigningSecret: "test-signing-secret",
+		},
+	}
+
+	start := func(t *testing.T, core *ChattoCore) func() {
+		t.Helper()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() { done <- core.Run(ctx) }()
+
+		bootCtx, bootCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer bootCancel()
+		if err := core.WaitForBoot(bootCtx); err != nil {
+			cancel()
+			t.Fatalf("WaitForBoot: %v", err)
+		}
+
+		return func() {
+			cancel()
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Fatal("core.Run did not stop within timeout")
+			}
+		}
+	}
+
+	ctx := testContext(t)
+	first, err := NewChattoCore(ctx, nc, cfg)
+	if err != nil {
+		t.Fatalf("first core: %v", err)
+	}
+	stopFirst := start(t, first)
+	if err := first.SeedDefaultRooms(ctx); err != nil {
+		stopFirst()
+		t.Fatalf("seed default rooms: %v", err)
+	}
+	eventsAfterFirstBoot := eventStreamMsgCount(t, first)
+	stopFirst()
+
+	second, err := NewChattoCore(ctx, nc, cfg)
+	if err != nil {
+		t.Fatalf("second core: %v", err)
+	}
+	stopSecond := start(t, second)
+	defer stopSecond()
+	if err := second.SeedDefaultRooms(ctx); err != nil {
+		t.Fatalf("seed default rooms after restart: %v", err)
+	}
+	eventsAfterSecondBoot := eventStreamMsgCount(t, second)
+
+	if eventsAfterSecondBoot != eventsAfterFirstBoot {
+		t.Fatalf("expected restart boot to append no events, got %d -> %d", eventsAfterFirstBoot, eventsAfterSecondBoot)
+	}
+}
 
 // TestChattoCore_FullWorkflow tests an end-to-end workflow demonstrating
 // all core functionality working together.

--- a/cli/internal/core/permission_ops.go
+++ b/cli/internal/core/permission_ops.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
@@ -33,7 +34,15 @@ func (c *ChattoCore) GrantServerPermission(ctx context.Context, roleName string,
 	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionGranted{
 		RbacPermissionGranted: rbacPermissionGrantedEvent(ScopeServer, "", roleName, perm),
 	}})
-	_, err := c.appendRBACEvent(ctx, event, nil)
+	_, err := c.appendRBACEvent(ctx, event, func() error {
+		if c.RBAC.GetDecision(ScopeServer, "", roleName, perm) == DecisionAllow {
+			return errRBACNoop
+		}
+		return nil
+	})
+	if errors.Is(err, errRBACNoop) {
+		return nil
+	}
 	return err
 }
 

--- a/cli/internal/core/rbac.go
+++ b/cli/internal/core/rbac.go
@@ -227,8 +227,14 @@ func (c *ChattoCore) AssignServerRole(ctx context.Context, actorID, userID, role
 				}
 			}
 		}
+		if c.RBAC.HasRole(userID, roleName) {
+			return errRBACNoop
+		}
 		return nil
 	}); err != nil {
+		if errors.Is(err, errRBACNoop) {
+			return nil
+		}
 		return err
 	}
 

--- a/cli/internal/core/verified_emails.go
+++ b/cli/internal/core/verified_emails.go
@@ -34,6 +34,8 @@ var (
 
 	// ErrEmailAlreadyVerified is returned when trying to verify an email that's already verified by another user.
 	ErrEmailAlreadyVerified = errors.New("email address is already verified by another account")
+
+	errVerifiedEmailNoop = errors.New("verified email mutation is a no-op")
 )
 
 // ============================================================================
@@ -201,15 +203,22 @@ func (c *ChattoCore) addVerifiedEmail(ctx context.Context, userID, email string)
 		},
 	}})
 	if _, err := c.appendUserEvent(ctx, userID, event, events.UserSubjectFilter(), func() error {
-		if user, ok := c.Users.GetByEmail(email); ok && user.GetId() != userID {
+		if user, ok := c.Users.GetByEmail(email); ok {
+			if user.GetId() == userID {
+				return errVerifiedEmailNoop
+			}
 			return ErrEmailAlreadyVerified
 		}
 		return nil
 	}); err != nil {
-		if errors.Is(err, ErrEmailAlreadyVerified) {
+		if errors.Is(err, errVerifiedEmailNoop) {
+			// Already verified for this user. Keep going so owner-email
+			// auto-promotion below still catches config changes.
+		} else if errors.Is(err, ErrEmailAlreadyVerified) {
 			return ErrEmailAlreadyVerified
+		} else {
+			return fmt.Errorf("failed to store verified email: %w", err)
 		}
-		return fmt.Errorf("failed to store verified email: %w", err)
 	}
 
 	// Auto-promote on config-owner email match. This is what closes the

--- a/frontend/e2e/fixtures/chatto.toml
+++ b/frontend/e2e/fixtures/chatto.toml
@@ -46,8 +46,8 @@ data_dir = './data'
 auth_token = '4af4a8a477cea0d613359f4f0546c7b3841bfe613742b4f762b4987e65e955c4'
 
 # Dev-only bootstrap for E2E. Creates the admin user that loginAsAdmin() in
-# fixtures/testUser.ts logs in as. Applied on every server start by the
-# bootstrap-tagged binary (see mise build-e2e-server).
+# fixtures/testUser.ts logs in as. Applied by the bootstrap-tagged binary
+# only when the server is otherwise empty (see mise build-e2e-server).
 [[bootstrap.users]]
 login = 'e2eadmin'
 display_name = 'Admin User'

--- a/frontend/e2e/fixtures/server.ts
+++ b/frontend/e2e/fixtures/server.ts
@@ -89,7 +89,7 @@ export async function startServer(
   }
   mkdirSync(dataDir, { recursive: true });
 
-  // chatto.toml seeds the e2eadmin user via [bootstrap] on every server start.
+  // chatto.toml seeds the e2eadmin user via [bootstrap] for each fresh data dir.
   const serverProcess = spawn(
     path.join(__dirname, 'bin', 'chatto'),
     ['start', '-c', 'chatto.toml'],


### PR DESCRIPTION
Treat dev bootstrap as first-boot provisioning instead of a recurring reconciliation pass. Startup now waits for ES projections to replay before boot-time seed checks, and bootstrap skips once real server data exists while ignoring built-in defaults. Duplicate verified-email, role assignment, and permission grant writes now no-op at the event layer. Added regression coverage for restart/bootstrap paths and updated dev/E2E comments to match the new behavior.