### PR TITLE
fix: deduplicate room join events

### DIFF
--- a/cli/internal/core/room_membership.go
+++ b/cli/internal/core/room_membership.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/nats-io/nats.go/jetstream"
 
@@ -11,6 +12,8 @@ import (
 	"hmans.de/chatto/internal/events"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
+
+const maxJoinRoomRetries = 5
 
 // GetRoomMembership retrieves a room membership for a user in a specific room.
 // Reads from the RoomMembership projection (ADR-035 phase 5 cutover).
@@ -61,14 +64,6 @@ func (c *ChattoCore) JoinRoom(ctx context.Context, actorID string, kind RoomKind
 		RoomId: room_id,
 	}
 
-	// Idempotency check via projection. There's a tiny race window if two
-	// callers IsMember-check before either publishes — both would emit a
-	// duplicate UserJoinedRoom. That's fine: the projection's Apply is
-	// idempotent on already-present (room, user) pairs.
-	if c.RoomMembership.IsMember(room_id, user_id) {
-		return membership, nil
-	}
-
 	event := newEvent(actorID, &corev1.Event{
 		Event: &corev1.Event_UserJoinedRoom{
 			UserJoinedRoom: &corev1.UserJoinedRoomEvent{
@@ -77,12 +72,48 @@ func (c *ChattoCore) JoinRoom(ctx context.Context, actorID string, kind RoomKind
 		},
 	})
 
-	seq, err := c.RoomMembershipProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.RoomAggregate(room_id), event)
-	if err != nil {
-		return nil, fmt.Errorf("publish UserJoinedRoomEvent: %w", err)
+	joinSubject := events.RoomAggregate(room_id).SubjectFor(event)
+	var seq uint64
+	for attempt := 0; attempt < maxJoinRoomRetries; attempt++ {
+		if c.RoomMembership.IsMember(room_id, user_id) {
+			return membership, nil
+		}
+
+		expectedSeq, err := c.EventPublisher.LastSubjectSeq(ctx, joinSubject)
+		if err != nil {
+			return nil, fmt.Errorf("read UserJoinedRoomEvent OCC seq: %w", err)
+		}
+		if expectedSeq > 0 {
+			if err := c.RoomMembershipProjector.WaitForSeq(ctx, expectedSeq); err != nil {
+				return nil, fmt.Errorf("wait for membership projection before join: %w", err)
+			}
+			if c.RoomMembership.IsMember(room_id, user_id) {
+				return membership, nil
+			}
+		}
+
+		seq, err = c.EventPublisher.AppendAt(ctx, joinSubject, event, expectedSeq)
+		if err == nil {
+			if err := c.RoomMembershipProjector.WaitForSeq(ctx, seq); err != nil {
+				return nil, fmt.Errorf("wait for membership projection: %w", err)
+			}
+			if err := c.RoomTimelineProjector.WaitForSeq(ctx, seq); err != nil {
+				return nil, fmt.Errorf("wait for room timeline projection: %w", err)
+			}
+			break
+		}
+		if !errors.Is(err, events.ErrConflict) {
+			return nil, fmt.Errorf("publish UserJoinedRoomEvent: %w", err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(time.Duration(1<<attempt) * time.Millisecond):
+		}
 	}
-	if err := c.RoomTimelineProjector.WaitForSeq(ctx, seq); err != nil {
-		return nil, fmt.Errorf("wait for room timeline projection: %w", err)
+	if seq == 0 {
+		return nil, fmt.Errorf("publish UserJoinedRoomEvent retry exhausted after %d attempts: %w", maxJoinRoomRetries, events.ErrConflict)
 	}
 
 	// Legacy publish — feeds live.server.> for the frontend's

--- a/cli/internal/core/room_membership_test.go
+++ b/cli/internal/core/room_membership_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 )
 
@@ -77,6 +78,53 @@ func TestRoomMemberships_CreateOrUpdate_Idempotent(t *testing.T) {
 	// Both should have the same data
 	if first.UserId != second.UserId || first.RoomId != second.RoomId {
 		t.Error("Repeated CreateOrUpdate should return same membership data")
+	}
+}
+
+func TestRoomMemberships_ConcurrentJoinPublishesSingleEvent(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	user, _ := core.CreateUser(ctx, "actor1", "testuser", "Test User", "password")
+	room, _ := core.CreateRoom(ctx, "actor1", KindChannel, "", "test-room", "test-room Desc")
+
+	const joiners = 12
+	start := make(chan struct{})
+	errs := make(chan error, joiners)
+	var wg sync.WaitGroup
+	wg.Add(joiners)
+	for range joiners {
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id)
+			errs <- err
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("JoinRoom: %v", err)
+		}
+	}
+
+	eventsResult, err := core.GetRoomEvents(ctx, KindChannel, room.Id, 50, nil)
+	if err != nil {
+		t.Fatalf("GetRoomEvents: %v", err)
+	}
+
+	joinCount := 0
+	for _, event := range eventsResult.Events {
+		if event.GetUserJoinedRoom() != nil && event.ActorId == user.Id {
+			joinCount++
+		}
+	}
+	if joinCount != 1 {
+		t.Fatalf("expected exactly one UserJoinedRoom event, got %d", joinCount)
 	}
 }
 

--- a/frontend/src/lib/state/space/rooms.svelte.ts
+++ b/frontend/src/lib/state/space/rooms.svelte.ts
@@ -57,6 +57,15 @@ const MyRoomsQuery = graphql(`
   }
 `);
 
+function uniqueById<T extends { id: string }>(items: T[]): T[] {
+  const seen: Record<string, true> = Object.create(null);
+  return items.filter((item) => {
+    if (seen[item.id]) return false;
+    seen[item.id] = true;
+    return true;
+  });
+}
+
 /**
  * Reactive store for a server's joined-room list, layout, and per-room
  * unread/mention state. One instance per registered server, owned by
@@ -103,7 +112,7 @@ export class RoomsStore {
 
     if (result.data?.viewer?.user) {
       this.currentUserId = result.data.viewer.user.id;
-      const allRooms = result.data.viewer.user.rooms;
+      const allRooms = uniqueById(result.data.viewer.user.rooms);
 
       for (const room of allRooms) {
         const pref = room.viewerNotificationPreference;
@@ -128,7 +137,7 @@ export class RoomsStore {
       this.roomGroups = result.data.server.roomGroups.map((s: SetT) => ({
         id: s.id,
         name: s.name,
-        roomIds: s.rooms.map((r: SetT['rooms'][number]) => r.id)
+        roomIds: uniqueById(s.rooms).map((r: SetT['rooms'][number]) => r.id)
       }));
     } else {
       this.roomGroups = null;


### PR DESCRIPTION
- Prevent duplicate user-joined room events by using publish-time OCC and projection rechecks for concurrent joins.
- Add a concurrent join regression test that verifies only one joined event is emitted for the same user and room.
- Deduplicate room and group IDs in the sidebar room store so old duplicated data cannot render repeated rows.
