### PR TITLE
Document event proto tag ownership

### DIFF
--- a/cli/internal/pb/chatto/core/v1/event.pb.go
+++ b/cli/internal/pb/chatto/core/v1/event.pb.go
@@ -38,13 +38,17 @@ const (
 // field number is part of the on-disk wire format. **Don't change
 // or reuse these numbers** — old stream bytes have to decode.
 //
-// - **>= 1000**: live-only variants. NATS Core only, never written
-// to disk. Field numbers are less durable than persisted tags, but
-// still shouldn't be reused casually because mixed-version processes
-// can coexist during deploys.
+// - **1050-1051**: durable reaction variants that kept their legacy
+// live tags during the EVT cutover. Treat them like persisted tags.
 //
-// The numeric boundary makes it obvious at a glance whether a given
-// variant is durable or ephemeral.
+// - **>= 1000, except 1050-1051**: live-only variants. NATS Core only,
+// never written to disk. Field numbers are less durable than persisted
+// tags, but still shouldn't be reused casually because mixed-version
+// processes can coexist during deploys.
+//
+// Category ownership for the top-level oneof tags is documented in the
+// sibling *_events.proto files. The top-level tag is the durable/event
+// envelope ID; message-internal field numbers remain local to that message.
 //
 // Authorization is determined by NATS subject, not by the wrapper:
 // - Room-scoped: server.room.{kind}.{roomId}.> (JetStream) or
@@ -1140,7 +1144,10 @@ type Event_MessageDeleted struct {
 }
 
 type Event_ReactionAdded struct {
-	// ----- Reactions (1050-1059) — EVT/projection is source of truth -----
+	// ----- Reactions (1050-1059) — durable legacy-tag exception -----
+	// Reaction events are stored on EVT today. They kept the legacy
+	// 1050/1051 tags during the cutover, so treat these two tags as
+	// frozen durable IDs even though they sit in the >=1000 range.
 	ReactionAdded *ReactionAddedEvent `protobuf:"bytes,1050,opt,name=reaction_added,json=reactionAdded,proto3,oneof"`
 }
 

--- a/proto/chatto/core/v1/asset_events.proto
+++ b/proto/chatto/core/v1/asset_events.proto
@@ -6,6 +6,17 @@ import "chatto/core/v1/models.proto";
 
 option go_package = "hmans.de/chatto/internal/pb/chatto/core/v1;corev1";
 
+// ============================================================================
+// ASSET EVENTS
+//
+// Top-level Event oneof tags owned by this file:
+//   - 450-454: durable asset lifecycle and processing events on evt.room.* or
+//     evt.user.*, depending on owner scope
+//
+// Keep these tags coordinated with event.proto. Message-internal field numbers
+// are local to each message and do not consume top-level Event tag space.
+// ============================================================================
+
 // AssetCreatedEvent records durable content identity for one uploaded or
 // generated binary. Emitted at the moment the binary lands in storage, NOT
 // at message-post time — the asset is its own aggregate, and messages

--- a/proto/chatto/core/v1/event.proto
+++ b/proto/chatto/core/v1/event.proto
@@ -32,13 +32,17 @@ option go_package = "hmans.de/chatto/internal/pb/chatto/core/v1;corev1";
        field number is part of the on-disk wire format. **Don't change
        or reuse these numbers** — old stream bytes have to decode.
 
-     - **>= 1000**: live-only variants. NATS Core only, never written
-       to disk. Field numbers are less durable than persisted tags, but
-       still shouldn't be reused casually because mixed-version processes
-       can coexist during deploys.
+     - **1050-1051**: durable reaction variants that kept their legacy
+       live tags during the EVT cutover. Treat them like persisted tags.
 
-   The numeric boundary makes it obvious at a glance whether a given
-   variant is durable or ephemeral.
+     - **>= 1000, except 1050-1051**: live-only variants. NATS Core only,
+       never written to disk. Field numbers are less durable than persisted
+       tags, but still shouldn't be reused casually because mixed-version
+       processes can coexist during deploys.
+
+   Category ownership for the top-level oneof tags is documented in the
+   sibling *_events.proto files. The top-level tag is the durable/event
+   envelope ID; message-internal field numbers remain local to that message.
 
    Authorization is determined by NATS subject, not by the wrapper:
    - Room-scoped: server.room.{kind}.{roomId}.> (JetStream) or
@@ -157,7 +161,8 @@ message Event {
     RbacPermissionClearedEvent rbac_permission_cleared = 812;
 
     // =================================================================
-    // LIVE-ONLY VARIANTS (>= 1000) — never persisted.
+    // LIVE-ONLY VARIANTS (>= 1000) — never persisted, except the
+    // reaction legacy-tag exception noted below.
     // These ride NATS Core only. Field numbers are less durable than
     // persisted tags, but still avoid reuse during mixed-version deploys.
     // =================================================================
@@ -186,7 +191,10 @@ message Event {
     MessageUpdatedEvent message_updated = 1040;
     MessageDeletedEvent message_deleted = 1041;
 
-    // ----- Reactions (1050-1059) — EVT/projection is source of truth -----
+    // ----- Reactions (1050-1059) — durable legacy-tag exception -----
+    // Reaction events are stored on EVT today. They kept the legacy
+    // 1050/1051 tags during the cutover, so treat these two tags as
+    // frozen durable IDs even though they sit in the >=1000 range.
     ReactionAddedEvent reaction_added = 1050;
     ReactionRemovedEvent reaction_removed = 1051;
 

--- a/proto/chatto/core/v1/live_events.proto
+++ b/proto/chatto/core/v1/live_events.proto
@@ -7,6 +7,26 @@ import "chatto/core/v1/user_preferences.proto";
 option go_package = "hmans.de/chatto/internal/pb/chatto/core/v1;corev1";
 
 // ============================================================================
+// LIVE-ONLY EVENT DEFINITIONS
+//
+// Top-level Event oneof tags owned by this file:
+//   - 1030-1032: live-only server lifecycle broadcasts
+//   - 1060: live-only typing indicator
+//   - 1070: live-only video processing compatibility event
+//   - 1080: live-only presence event
+//   - 1090-1091: live-only notification nudges
+//   - 1100-1101: live-only voice call presence events
+//   - 1110-1111: live-only notification sync events
+//   - 1121-1122: live-only unread/mention sync events
+//   - 1130: live-only room-layout invalidation event
+//   - 1140: live-only session termination event
+//   - 1200: synthetic in-process subscription heartbeat
+//
+// Keep these tags coordinated with event.proto. Message-internal field numbers
+// are local to each message and do not consume top-level Event tag space.
+// ============================================================================
+
+// ============================================================================
 // SUBSCRIPTION LIVENESS
 // ============================================================================
 

--- a/proto/chatto/core/v1/message_events.proto
+++ b/proto/chatto/core/v1/message_events.proto
@@ -8,6 +8,13 @@ option go_package = "hmans.de/chatto/internal/pb/chatto/core/v1;corev1";
 
 // ============================================================================
 // MESSAGE EVENTS
+//
+// Top-level Event oneof tags owned by this file:
+//   - 400-402: durable message timeline events on evt.room.{roomId}.*
+//   - 1040-1041: legacy live-only message mutation events
+//
+// Keep these tags coordinated with event.proto. Message-internal field numbers
+// are local to each message and do not consume top-level Event tag space.
 // ============================================================================
 
 message MessagePostedEvent {

--- a/proto/chatto/core/v1/rbac_events.proto
+++ b/proto/chatto/core/v1/rbac_events.proto
@@ -6,6 +6,12 @@ option go_package = "hmans.de/chatto/internal/pb/chatto/core/v1;corev1";
 
 // ============================================================================
 // DURABLE RBAC EVENTS (evt.rbac.>)
+//
+// Top-level Event oneof tags owned by this file:
+//   - 800-812: durable RBAC role, assignment, and permission events
+//
+// Keep these tags coordinated with event.proto. Message-internal field numbers
+// are local to each message and do not consume top-level Event tag space.
 // ============================================================================
 
 message RbacRoleCreatedEvent {

--- a/proto/chatto/core/v1/reaction_events.proto
+++ b/proto/chatto/core/v1/reaction_events.proto
@@ -6,6 +6,15 @@ option go_package = "hmans.de/chatto/internal/pb/chatto/core/v1;corev1";
 
 // ============================================================================
 // REACTION EVENTS (room-scoped, durable in EVT)
+//
+// Top-level Event oneof tags owned by this file:
+//   - 1050-1051: durable reaction events on evt.room.{roomId}.* that kept
+//     their legacy live-event tags during the EVT cutover
+//
+// These tags are the exception to the usual "<1000 is durable" convention.
+// Treat them as frozen persisted tags, not reusable live-only space.
+// Message-internal field numbers are local to each message and do not consume
+// top-level Event tag space.
 // ============================================================================
 
 message ReactionAddedEvent {

--- a/proto/chatto/core/v1/room_events.proto
+++ b/proto/chatto/core/v1/room_events.proto
@@ -9,6 +9,14 @@ option go_package = "hmans.de/chatto/internal/pb/chatto/core/v1;corev1";
 // ============================================================================
 // PERSISTED EVENT MESSAGE DEFINITIONS
 // Changing field numbers or structure below affects JetStream-stored data.
+//
+// Top-level Event oneof tags owned by this file:
+//   - 300-304: room lifecycle on evt.room.{roomId}.*
+//   - 310-311: room membership on evt.room.{roomId}.*
+//   - 320: server-wide account deletion fan-out
+//
+// Keep these tags coordinated with event.proto. Message-internal field numbers
+// are local to each message and do not consume top-level Event tag space.
 // ============================================================================
 
 // ============================================================================

--- a/proto/chatto/core/v1/room_group_events.proto
+++ b/proto/chatto/core/v1/room_group_events.proto
@@ -6,6 +6,13 @@ option go_package = "hmans.de/chatto/internal/pb/chatto/core/v1;corev1";
 
 // ============================================================================
 // ROOM GROUP EVENTS (group aggregate, evt.group.{groupId})
+//
+// Top-level Event oneof tags owned by this file:
+//   - 600-605: durable group aggregate events on evt.group.{groupId}.*
+//   - 650: durable singleton room-layout event on evt.layout.default
+//
+// Keep these tags coordinated with event.proto. Message-internal field numbers
+// are local to each message and do not consume top-level Event tag space.
 // ============================================================================
 //
 // Groups own their room-membership and room-ordering. Move-room and

--- a/proto/chatto/core/v1/server_config_events.proto
+++ b/proto/chatto/core/v1/server_config_events.proto
@@ -6,6 +6,17 @@ import "chatto/config/v1/config.proto";
 
 option go_package = "hmans.de/chatto/internal/pb/chatto/core/v1;corev1";
 
+// ============================================================================
+// SERVER CONFIG EVENTS
+//
+// Top-level Event oneof tags owned by this file:
+//   - 500: durable config snapshot event on evt.config.server
+//   - 1000: legacy live-only config broadcast
+//
+// Keep these tags coordinated with event.proto. Message-internal field numbers
+// are local to each message and do not consume top-level Event tag space.
+// ============================================================================
+
 // Durable server-config event for the EVT log. Carries the
 // complete ServerConfig snapshot after the change so projections and
 // the audit log can reconstruct state without reaching back to KV.

--- a/proto/chatto/core/v1/user_events.proto
+++ b/proto/chatto/core/v1/user_events.proto
@@ -9,6 +9,13 @@ option go_package = "hmans.de/chatto/internal/pb/chatto/core/v1;corev1";
 
 // ============================================================================
 // USER LIFECYCLE EVENTS (server-scoped)
+//
+// Top-level Event oneof tags owned by this file:
+//   - 700-711: durable user aggregate events on evt.user.{userId}.*
+//   - 1010-1015: live-only user lifecycle and preference broadcasts
+//
+// Keep these tags coordinated with event.proto. Message-internal field numbers
+// are local to each message and do not consume top-level Event tag space.
 // ============================================================================
 
 message UserCreatedEvent {


### PR DESCRIPTION
Documents which top-level Event oneof tag ranges are owned by each split event proto file. Clarifies that message-internal field numbers do not consume envelope tag space. Calls out reaction events as durable EVT facts that kept their legacy 1050/1051 tags, so those tags are frozen despite living in the live-only range.