### PR TITLE
fix: stabilize scroll fade overlays

### DIFF
--- a/frontend/e2e/virtualizer-stability.test.ts
+++ b/frontend/e2e/virtualizer-stability.test.ts
@@ -9,11 +9,7 @@ import * as routes from './routes';
 /**
  * Post messages via GraphQL API (much faster than UI-based posting).
  */
-async function postMessagesViaAPI(
-  page: Page,
-  roomId: string,
-  messages: string[]
-): Promise<void> {
+async function postMessagesViaAPI(page: Page, roomId: string, messages: string[]): Promise<void> {
   for (const body of messages) {
     await page.request.post('/api/graphql', {
       headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
@@ -35,7 +31,67 @@ function getRoomIdFromUrl(page: Page): string {
   return match[1];
 }
 
+async function getScrollFadeOpacities(page: Page): Promise<{ top: number; bottom: number }> {
+  return page.getByTestId('messages-container').evaluate((el) => {
+    const fades = Array.from(el.parentElement?.querySelectorAll('[aria-hidden="true"]') ?? []);
+    const topFade = fades[0];
+    const bottomFade = fades[1];
+    if (!(topFade instanceof HTMLElement) || !(bottomFade instanceof HTMLElement)) {
+      throw new Error('Scroll fades not found');
+    }
+    return {
+      top: Number(getComputedStyle(topFade).opacity),
+      bottom: Number(getComputedStyle(bottomFade).opacity)
+    };
+  });
+}
+
 test.describe('Virtualizer stability', () => {
+  test('scroll fades reset when switching from overflowing room to sparse room', async ({
+    page,
+    chatPage
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 500 });
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.createSpace();
+
+    await chatPage.enterRoom('general');
+    const generalRoomId = getRoomIdFromUrl(page);
+    const timestamp = Date.now();
+    const longText = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
+    const messages = Array.from(
+      { length: 25 },
+      (_, i) => `Fade reset message ${i + 1} - ${timestamp} - ${longText}`
+    );
+    await postMessagesViaAPI(page, generalRoomId, messages);
+    await expect(page.getByText(`Fade reset message 25 - ${timestamp}`)).toBeVisible({
+      timeout: TIMEOUTS.UI_STANDARD
+    });
+
+    await expect
+      .poll(() => getScrollFadeOpacities(page), { timeout: TIMEOUTS.UI_STANDARD })
+      .toMatchObject({ top: 1 });
+
+    const sparseRoomName = await chatPage.createRoom(`fade-sparse-${timestamp}`);
+    await expect(chatPage.getRoomHeader(sparseRoomName)).toBeVisible({
+      timeout: TIMEOUTS.UI_STANDARD
+    });
+
+    await expect
+      .poll(
+        () =>
+          page.getByTestId('messages-container').evaluate((el) => ({
+            overflows: el.scrollHeight > el.clientHeight + 1,
+            fades: Array.from(el.parentElement?.querySelectorAll('[aria-hidden="true"]') ?? []).map(
+              (fade) => Number(getComputedStyle(fade).opacity)
+            )
+          })),
+        { timeout: TIMEOUTS.UI_STANDARD }
+      )
+      .toEqual({ overflows: false, fades: [0, 0] });
+  });
+
   test('rapid room switching with different message counts does not cause JS errors', async ({
     page,
     chatPage,

--- a/frontend/src/lib/ui/ScrollFader.svelte
+++ b/frontend/src/lib/ui/ScrollFader.svelte
@@ -9,6 +9,8 @@ scroll container; children render inside the scroll container.
 - The scroll element is exposed via `bind:scrollEl` so callers can wire
   things that need it (virtua `scrollRef`, scroll-to-bottom logic,
   etc.).
+- A `refresh()` component method is exposed via `bind:this` for callers
+  that make external layout changes and need edge re-measurement.
 - Extra props (e.g. `data-testid`, `onwheel`, `ontouchmove`) are
   forwarded to the scroll container.
 -->
@@ -29,8 +31,6 @@ scroll container; children render inside the scroll container.
     scrollClass?: string;
     /** Bound to the inner scroll container so callers can reference it. */
     scrollEl?: HTMLDivElement;
-    /** Bump when external layout work should force edge re-measurement. */
-    refreshKey?: unknown;
     [key: string]: unknown;
   };
 
@@ -42,7 +42,6 @@ scroll container; children render inside the scroll container.
     class: className = '',
     scrollClass = '',
     scrollEl = $bindable(),
-    refreshKey,
     ...rest
   }: Props = $props();
 
@@ -50,8 +49,12 @@ scroll container; children render inside the scroll container.
   let scrolledFromBottom = $state(false);
 
   function updateScrollEdges(el: HTMLElement) {
-    scrolledFromTop = el.scrollTop > 1;
-    scrolledFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight > 1;
+    const maxScrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
+    const scrollTop = Math.min(Math.max(el.scrollTop, 0), maxScrollTop);
+    const canScroll = maxScrollTop > 1;
+
+    scrolledFromTop = canScroll && scrollTop > 1;
+    scrolledFromBottom = canScroll && maxScrollTop - scrollTop > 1;
   }
 
   function trackScrollEdges(el: HTMLElement) {
@@ -63,22 +66,32 @@ scroll container; children render inside the scroll container.
     el.addEventListener('scroll', update, { passive: true });
     const ro = new ResizeObserver(update);
     ro.observe(el);
+    for (const child of el.children) {
+      if (child instanceof HTMLElement) ro.observe(child);
+    }
+    const mo = new MutationObserver(() => {
+      ro.disconnect();
+      ro.observe(el);
+      for (const child of el.children) {
+        if (child instanceof HTMLElement) ro.observe(child);
+      }
+      update();
+    });
+    mo.observe(el, { childList: true });
     return () => {
       el.removeEventListener('scroll', update);
+      mo.disconnect();
       ro.disconnect();
     };
   }
 
-  $effect(() => {
-    void refreshKey;
+  export function refresh() {
     if (!scrollEl) return;
 
-    const frame = requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
       if (scrollEl) updateScrollEdges(scrollEl);
     });
-
-    return () => cancelAnimationFrame(frame);
-  });
+  }
 </script>
 
 <div class={['relative flex min-h-0 min-w-0 flex-1 flex-col', className]}>

--- a/frontend/src/lib/ui/ScrollFader.svelte.spec.ts
+++ b/frontend/src/lib/ui/ScrollFader.svelte.spec.ts
@@ -13,7 +13,7 @@ function getBottomFade(container: HTMLElement) {
 }
 
 describe('ScrollFader', () => {
-  it('recomputes bottom fade visibility when refreshKey changes without a scroll event', async () => {
+  it('recomputes bottom fade visibility when refreshed without a scroll event', async () => {
     const { container, component } = render(ScrollFaderTestHarness);
 
     const scrollEl = container.querySelector<HTMLElement>('[data-testid="scroll"]');
@@ -28,6 +28,48 @@ describe('ScrollFader', () => {
     component.refresh();
     flushSync();
     await nextFrame();
+    flushSync();
+
+    expect(getBottomFade(container).classList.contains('opacity-0')).toBe(true);
+  });
+
+  it('hides both fades when content no longer overflows', async () => {
+    const { container, component } = render(ScrollFaderTestHarness);
+
+    const scrollEl = container.querySelector<HTMLElement>('[data-testid="scroll"]');
+    if (!scrollEl) throw new Error('scroll container not rendered');
+
+    component.setScrollMetrics({ scrollTop: 50, scrollHeight: 300, clientHeight: 100 });
+    scrollEl.dispatchEvent(new Event('scroll'));
+    flushSync();
+    expect(getBottomFade(container).classList.contains('opacity-0')).toBe(false);
+
+    component.setScrollMetrics({ scrollTop: 50, scrollHeight: 100, clientHeight: 100 });
+    component.refresh();
+    flushSync();
+    await nextFrame();
+    flushSync();
+
+    const fades = container.querySelectorAll<HTMLElement>('[aria-hidden="true"]');
+    expect(fades[0].classList.contains('opacity-0')).toBe(true);
+    expect(fades[1].classList.contains('opacity-0')).toBe(true);
+  });
+
+  it('recomputes fade visibility when direct content children change', async () => {
+    const { container, component } = render(ScrollFaderTestHarness);
+
+    const scrollEl = container.querySelector<HTMLElement>('[data-testid="scroll"]');
+    if (!scrollEl) throw new Error('scroll container not rendered');
+
+    component.setScrollMetrics({ scrollTop: 50, scrollHeight: 300, clientHeight: 100 });
+    scrollEl.dispatchEvent(new Event('scroll'));
+    flushSync();
+    expect(getBottomFade(container).classList.contains('opacity-0')).toBe(false);
+
+    component.setScrollMetrics({ scrollTop: 0, scrollHeight: 100, clientHeight: 100 });
+    component.toggleExtraChild();
+    flushSync();
+    await Promise.resolve();
     flushSync();
 
     expect(getBottomFade(container).classList.contains('opacity-0')).toBe(true);

--- a/frontend/src/lib/ui/ScrollFaderTestHarness.svelte
+++ b/frontend/src/lib/ui/ScrollFaderTestHarness.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
   import ScrollFader from './ScrollFader.svelte';
 
-  let refreshKey = $state(0);
   let scrollEl = $state<HTMLDivElement>();
+  let scrollFader = $state<{ refresh: () => void }>();
+  let showExtraChild = $state(false);
 
   export function refresh() {
-    refreshKey++;
+    scrollFader?.refresh();
+  }
+
+  export function toggleExtraChild() {
+    showExtraChild = !showExtraChild;
   }
 
   export function setScrollMetrics(metrics: {
@@ -37,6 +42,9 @@
   }
 </script>
 
-<ScrollFader top bottom bind:scrollEl {refreshKey} data-testid="scroll">
+<ScrollFader top bottom bind:this={scrollFader} bind:scrollEl data-testid="scroll">
   <div data-testid="content">Message</div>
+  {#if showExtraChild}
+    <div data-testid="extra-content">Extra message</div>
+  {/if}
 </ScrollFader>

--- a/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -238,7 +238,7 @@
         if (scrollContainer && shouldScrollToBottom) {
           startScrollCorrection();
           scrollContainer.scrollTop = scrollContainer.scrollHeight;
-          refreshScrollFader();
+          scrollFader?.refresh();
         }
       });
     }
@@ -312,11 +312,7 @@
   // Scroll container and virtualizer handle
   let scrollContainer = $state<HTMLDivElement>();
   let virtualizerHandle = $state<VirtualizerHandle>();
-  let scrollFaderRefreshKey = $state(0);
-
-  function refreshScrollFader() {
-    scrollFaderRefreshKey++;
-  }
+  let scrollFader = $state<{ refresh: () => void }>();
 
   // Safely call scrollToIndex on the virtualizer. After a {#key roomId} transition,
   // the new Virtualizer's bind:this fires immediately but its onMount → tick() →
@@ -368,14 +364,14 @@
           if (!untrack(() => alwaysScrollToBottom || shouldScrollToBottom)) return;
           startScrollCorrection();
           safeScrollToIndex(virtualItems.length - 1, { align: 'end' });
-          refreshScrollFader();
+          scrollFader?.refresh();
           if (!untrack(() => initialScrollDone)) {
             // Give virtua time to measure actual item heights and settle the
             // scroll position. The skeleton overlay hides the content during
             // this window, so there's no visual cost to waiting.
             setTimeout(() => {
               safeScrollToIndex(virtualItems.length - 1, { align: 'end' });
-              refreshScrollFader();
+              scrollFader?.refresh();
               initialScrollDone = true;
             }, 80);
           }
@@ -390,7 +386,7 @@
     hasNewMessages = false;
     if (virtualizerHandle) {
       safeScrollToIndex(virtualItems.length - 1, { align: 'end' });
-      refreshScrollFader();
+      scrollFader?.refresh();
     }
   }
 
@@ -502,7 +498,7 @@
       scrollContainer
     ) {
       scrollContainer.scrollTop = scrollContainer.scrollHeight;
-      refreshScrollFader();
+      scrollFader?.refresh();
     }
 
     previousOffset = offset;
@@ -597,8 +593,8 @@
   <ScrollFader
     top
     bottom
+    bind:this={scrollFader}
     bind:scrollEl={scrollContainer}
-    refreshKey={scrollFaderRefreshKey}
     scrollClass="overscroll-y-contain"
     data-testid="messages-container"
     onwheel={markUserScrollIntent}


### PR DESCRIPTION
- Harden ScrollFader edge detection so non-scrollable content hides both fades and content mutations trigger remeasurement.
- Replace the refreshKey counter with a refresh() component method used after programmatic EventList scrolls.
- Add unit coverage plus a Playwright regression for switching from an overflowing room to a sparse room.
- Tests: `mise exec -- pnpm exec svelte-check --tsconfig ./tsconfig.json`; `mise exec -- pnpm exec vitest --run src/lib/ui/ScrollFader.svelte.spec.ts`; `mise exec -- pnpm exec playwright test e2e/virtualizer-stability.test.ts -g "scroll fades reset" --workers=1`.