### PR TITLE
refactor: unify DM room listing

### DIFF
--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -1670,22 +1670,22 @@ func (c *ChattoCore) populateMemberRoomsCache(ctx context.Context, userID string
 	// whether they could re-join today (e.g. they joined while the room
 	// was open, then `room.join` was denied for everyone). The
 	// "leave the room" mutation is the only way to lose live events.
-	channelMemberships, err := c.GetUserRoomMemberships(ctx, KindChannel, userID)
+	channelRooms, err := c.ListMemberRooms(ctx, KindChannel, userID, MemberRoomListOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to get channel room memberships: %w", err)
+		return fmt.Errorf("failed to list channel member rooms: %w", err)
 	}
-	for _, m := range channelMemberships {
-		memberRooms[m.RoomId] = struct{}{}
+	for _, room := range channelRooms {
+		memberRooms[room.Id] = struct{}{}
 	}
 
-	dmMemberships, err := c.GetUserRoomMemberships(ctx, KindDM, userID)
+	dmRooms, err := c.ListMemberRooms(ctx, KindDM, userID, MemberRoomListOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to get DM room memberships: %w", err)
+		return fmt.Errorf("failed to list DM member rooms: %w", err)
 	}
 	// DM rooms surface via their own listing path; explicit
 	// membership is the visibility gate.
-	for _, m := range dmMemberships {
-		memberRooms[m.RoomId] = struct{}{}
+	for _, room := range dmRooms {
+		memberRooms[room.Id] = struct{}{}
 	}
 
 	return nil

--- a/cli/internal/core/dm.go
+++ b/cli/internal/core/dm.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"time"
 
 	"github.com/nats-io/nats.go/jetstream"
 
@@ -15,16 +14,6 @@ import (
 	"hmans.de/chatto/internal/events"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
-
-// LegacyDMSpaceID is the wire-frozen space_id value that older event payloads
-// and a few compatibility APIs still use to mean "DM room".
-const LegacyDMSpaceID = "DM"
-
-// ServerSpaceID is the kind discriminator for channel (non-DM) rooms.
-// Post-ADR-030 there's no longer a per-deployment Space record; this constant
-// is what every channel-scoped core call feeds into `KindForSpace` (which
-// returns "channel" for any non-DM value).
-const ServerSpaceID = "server"
 
 // MaxDMParticipants is the maximum number of participants allowed in a DM.
 // Beyond this, users should create a proper space/room with moderation.
@@ -41,35 +30,6 @@ const (
 	// KindDM is a direct-message room.
 	KindDM RoomKind = "dm"
 )
-
-// KindForSpace returns the room kind for a legacy wire-frozen
-// `space_id` value ("server" or "DM"). Still used at the proto
-// boundary for messages whose persisted shape (e.g.
-// MessagePostedEvent on the legacy SERVER_EVENTS stream) carries
-// `space_id` as a partition key. New code working with Room records
-// should call KindOfRoom (which reads Room.kind directly).
-func KindForSpace(spaceID string) RoomKind {
-	if spaceID == LegacyDMSpaceID {
-		return KindDM
-	}
-	return KindChannel
-}
-
-// SpaceIDForKind returns the legacy `space_id` string for a kind.
-// Used at the proto boundary where wire-format-frozen `space_id`
-// fields (still present on a handful of message-event payloads and
-// LiveKit/threads partition keys) need a value derived from kind.
-//
-// Not used by Room records anymore — Room.space_id was removed in
-// favor of Room.kind. Callers that previously read room.SpaceId
-// should now call SpaceIDForKind(room.kind) directly at the use
-// site rather than relying on a stamped field.
-func SpaceIDForKind(kind RoomKind) string {
-	if kind == KindDM {
-		return LegacyDMSpaceID
-	}
-	return ServerSpaceID
-}
 
 // ProtoKindForRoomKind maps the Go-side RoomKind string to the proto
 // enum stored on Room.kind.
@@ -283,58 +243,6 @@ func (c *ChattoCore) createDMRoom(ctx context.Context, roomID string, participan
 	}
 
 	return room, nil
-}
-
-// ListDMConversations returns DM rooms the user is a member of that have at least
-// one message. Empty DM rooms (created but never messaged) are excluded.
-// Rooms are sorted by last message time, newest first.
-func (c *ChattoCore) ListDMConversations(ctx context.Context, userID string) ([]*corev1.Room, error) {
-	memberships, err := c.GetUserRoomMemberships(ctx, KindDM, userID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get DM memberships: %w", err)
-	}
-
-	// Collect rooms with their last message timestamps
-	type roomWithTime struct {
-		room      *corev1.Room
-		lastMsgAt time.Time
-	}
-	roomsWithTime := make([]roomWithTime, 0, len(memberships))
-
-	for _, membership := range memberships {
-		room, err := c.GetRoom(ctx, KindDM, membership.RoomId)
-		if err != nil {
-			// Skip rooms that no longer exist (eventual consistency)
-			c.logger.Warn("DM room not found for membership", "room_id", membership.RoomId, "user_id", userID)
-			continue
-		}
-
-		lastMsgAt, err := c.GetRoomLastMessageAt(ctx, KindDM, room.Id)
-		if err != nil {
-			c.logger.Debug("No messages in DM room, skipping", "room_id", room.Id)
-			continue
-		}
-
-		// Skip empty conversations (no messages ever posted)
-		if lastMsgAt.IsZero() {
-			continue
-		}
-
-		roomsWithTime = append(roomsWithTime, roomWithTime{room: room, lastMsgAt: lastMsgAt})
-	}
-
-	// Sort by last message time, newest first
-	sort.Slice(roomsWithTime, func(i, j int) bool {
-		return roomsWithTime[i].lastMsgAt.After(roomsWithTime[j].lastMsgAt)
-	})
-
-	// Extract sorted rooms
-	rooms := make([]*corev1.Room, len(roomsWithTime))
-	for i, rwt := range roomsWithTime {
-		rooms[i] = rwt.room
-	}
-
-	return rooms, nil
 }
 
 // ensureInList ensures the given ID is in the list, adding it if not present.

--- a/cli/internal/core/dm_test.go
+++ b/cli/internal/core/dm_test.go
@@ -8,14 +8,15 @@ import (
 
 	"github.com/nats-io/nats.go"
 	"hmans.de/chatto/internal/core/subjects"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
-func TestKindForLegacySpaceID(t *testing.T) {
+func TestRoomKindFromLegacySpaceID(t *testing.T) {
 	tests := []struct {
 		spaceID string
 		want    RoomKind
 	}{
-		{LegacyDMSpaceID, KindDM},
+		{LegacyDMRoomSpaceID, KindDM},
 		{"DM", KindDM},
 		{"some-other-space", KindChannel},
 		{"", KindChannel},
@@ -25,9 +26,9 @@ func TestKindForLegacySpaceID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.spaceID, func(t *testing.T) {
-			got := KindForSpace(tt.spaceID)
+			got := RoomKindFromLegacySpaceID(tt.spaceID)
 			if got != tt.want {
-				t.Errorf("KindForSpace(%q) = %v, want %v", tt.spaceID, got, tt.want)
+				t.Errorf("RoomKindFromLegacySpaceID(%q) = %v, want %v", tt.spaceID, got, tt.want)
 			}
 		})
 	}
@@ -192,14 +193,14 @@ func TestDMRoomPermissionDefaults(t *testing.T) {
 
 	t.Run("CanSeeRoom returns false for DM rooms", func(t *testing.T) {
 		// DM rooms aren't surfaced through the channel room-list API; they
-		// use their own listing path (ListDMConversations). CanSeeRoom
+		// use the member-room listing path. CanSeeRoom
 		// short-circuits to false for KindDM.
 		can, err := core.CanSeeRoom(ctx, userID, KindDM, "R_dm_visibility_test")
 		if err != nil {
 			t.Fatalf("CanSeeRoom error: %v", err)
 		}
 		if can {
-			t.Error("CanSeeRoom should return false for DM rooms (use ListDMConversations)")
+			t.Error("CanSeeRoom should return false for DM rooms (use ListMemberRooms)")
 		}
 	})
 }
@@ -369,15 +370,24 @@ func TestFindOrCreateDM(t *testing.T) {
 	})
 }
 
-func TestListDMConversations(t *testing.T) {
+func listActiveDMRoomsForTest(t *testing.T, core *ChattoCore, ctx context.Context, userID string) []*corev1.Room {
+	t.Helper()
+	rooms, err := core.ListMemberRooms(ctx, KindDM, userID, MemberRoomListOptions{
+		RequireLastMessage:    true,
+		SortByLastMessageDesc: true,
+	})
+	if err != nil {
+		t.Fatalf("ListMemberRooms error: %v", err)
+	}
+	return rooms
+}
+
+func TestListMemberRooms_DMConversationPolicy(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
 	t.Run("returns empty list when no DMs", func(t *testing.T) {
-		rooms, err := core.ListDMConversations(ctx, "no-dms-user")
-		if err != nil {
-			t.Fatalf("ListDMConversations error: %v", err)
-		}
+		rooms := listActiveDMRoomsForTest(t, core, ctx, "no-dms-user")
 		if len(rooms) != 0 {
 			t.Errorf("Expected 0 DMs, got %d", len(rooms))
 		}
@@ -400,10 +410,7 @@ func TestListDMConversations(t *testing.T) {
 		}
 
 		// Empty DM should NOT appear in the list
-		rooms, err := core.ListDMConversations(ctx, user1.Id)
-		if err != nil {
-			t.Fatalf("ListDMConversations error: %v", err)
-		}
+		rooms := listActiveDMRoomsForTest(t, core, ctx, user1.Id)
 		if len(rooms) != 0 {
 			t.Errorf("Expected 0 DMs (empty DM should be filtered), got %d", len(rooms))
 		}
@@ -440,10 +447,7 @@ func TestListDMConversations(t *testing.T) {
 		}
 
 		// Only dm1 should appear (dm2 has no messages)
-		rooms, err := core.ListDMConversations(ctx, user1.Id)
-		if err != nil {
-			t.Fatalf("ListDMConversations error: %v", err)
-		}
+		rooms := listActiveDMRoomsForTest(t, core, ctx, user1.Id)
 		if len(rooms) != 1 {
 			t.Fatalf("Expected 1 DM, got %d", len(rooms))
 		}
@@ -458,17 +462,14 @@ func TestListDMConversations(t *testing.T) {
 		}
 
 		// Both should now appear
-		rooms, err = core.ListDMConversations(ctx, user1.Id)
-		if err != nil {
-			t.Fatalf("ListDMConversations error: %v", err)
-		}
+		rooms = listActiveDMRoomsForTest(t, core, ctx, user1.Id)
 		if len(rooms) != 2 {
 			t.Errorf("Expected 2 DMs after both have messages, got %d", len(rooms))
 		}
 	})
 }
 
-func TestListDMConversationsSortedByLastMessage(t *testing.T) {
+func TestListMemberRooms_DMConversationPolicySortedByLastMessage(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
@@ -509,10 +510,7 @@ func TestListDMConversationsSortedByLastMessage(t *testing.T) {
 	}
 
 	// List should have A-C first (more recent)
-	rooms, err := core.ListDMConversations(ctx, userA.Id)
-	if err != nil {
-		t.Fatalf("ListDMConversations error: %v", err)
-	}
+	rooms := listActiveDMRoomsForTest(t, core, ctx, userA.Id)
 	if len(rooms) != 2 {
 		t.Fatalf("Expected 2 DMs, got %d", len(rooms))
 	}
@@ -530,10 +528,7 @@ func TestListDMConversationsSortedByLastMessage(t *testing.T) {
 	}
 
 	// Now A-B should be first
-	rooms, err = core.ListDMConversations(ctx, userA.Id)
-	if err != nil {
-		t.Fatalf("ListDMConversations error: %v", err)
-	}
+	rooms = listActiveDMRoomsForTest(t, core, ctx, userA.Id)
 	if rooms[0].Id != dmAB.Id {
 		t.Errorf("Expected A-B first after new message, got %s", rooms[0].Id)
 	}

--- a/cli/internal/core/legacy_space_compat.go
+++ b/cli/internal/core/legacy_space_compat.go
@@ -1,0 +1,30 @@
+package core
+
+// LegacyDMRoomSpaceID is the wire-frozen space_id value that older event
+// payloads and a few compatibility APIs still use to mean "DM room".
+const LegacyDMRoomSpaceID = "DM"
+
+// LegacyServerSpaceID is the wire-frozen space_id value used by channel-room
+// payloads and compatibility APIs after the Space tier was retired.
+const LegacyServerSpaceID = "server"
+
+// RoomKindFromLegacySpaceID maps a wire-format-frozen `space_id` value to the
+// room kind it now represents. Use this only at compatibility boundaries where
+// persisted payloads or public APIs still carry `space_id`; code working with
+// Room records should read Room.kind via KindOfRoom.
+func RoomKindFromLegacySpaceID(spaceID string) RoomKind {
+	if spaceID == LegacyDMRoomSpaceID {
+		return KindDM
+	}
+	return KindChannel
+}
+
+// LegacySpaceIDForRoomKind returns the wire-format-frozen `space_id` value for
+// a room kind. Use this only when filling legacy payload fields or calling APIs
+// whose storage keys still include `space_id`.
+func LegacySpaceIDForRoomKind(kind RoomKind) string {
+	if kind == KindDM {
+		return LegacyDMRoomSpaceID
+	}
+	return LegacyServerSpaceID
+}

--- a/cli/internal/core/permission_explainer_test.go
+++ b/cli/internal/core/permission_explainer_test.go
@@ -79,7 +79,7 @@ func TestPermissionExplainer_AgreesWithHas(t *testing.T) {
 			s := s
 			t.Run(s.name, func(t *testing.T) {
 				for _, meta := range PermissionsForScope(ScopeRoom) {
-					assertAgreement(t, ctx, core, s.id, ServerSpaceID, room.Id, meta.Permission, ScopeRoom)
+					assertAgreement(t, ctx, core, s.id, LegacyServerSpaceID, room.Id, meta.Permission, ScopeRoom)
 				}
 			})
 		}
@@ -139,8 +139,8 @@ func assertAgreement(
 		hasResult, hasErr = core.permissionResolver.HasServerPermission(ctx, userID, perm)
 		exp, expErr = core.permissionResolver.ExplainServerPermission(ctx, userID, perm)
 	case ScopeRoom:
-		hasResult, hasErr = core.permissionResolver.HasRoomPermission(ctx, userID, KindForSpace(spaceID), roomID, perm)
-		exp, expErr = core.permissionResolver.ExplainRoomPermission(ctx, userID, KindForSpace(spaceID), roomID, perm)
+		hasResult, hasErr = core.permissionResolver.HasRoomPermission(ctx, userID, RoomKindFromLegacySpaceID(spaceID), roomID, perm)
+		exp, expErr = core.permissionResolver.ExplainRoomPermission(ctx, userID, RoomKindFromLegacySpaceID(spaceID), roomID, perm)
 	default:
 		t.Fatalf("unknown scope %v", scope)
 	}

--- a/cli/internal/core/rooms.go
+++ b/cli/internal/core/rooms.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -601,6 +602,63 @@ func (c *ChattoCore) ListRooms(ctx context.Context, kind RoomKind) ([]*corev1.Ro
 		if gid := c.RoomGroups.GroupForRoom(r.Id); gid != "" {
 			r.GroupId = gid
 		}
+	}
+	return rooms, nil
+}
+
+// MemberRoomListOptions controls optional filtering/sorting for ListMemberRooms.
+type MemberRoomListOptions struct {
+	// RequireLastMessage excludes rooms that have never received a message.
+	RequireLastMessage bool
+	// SortByLastMessageDesc sorts rooms by latest message time, newest first.
+	// Rooms without messages sort last when RequireLastMessage is false.
+	SortByLastMessageDesc bool
+}
+
+// ListMemberRooms retrieves rooms of the given kind that the user participates
+// in. It is the shared room-list primitive for member-scoped room surfaces;
+// callers layer product policy on top with MemberRoomListOptions.
+func (c *ChattoCore) ListMemberRooms(ctx context.Context, kind RoomKind, userID string, opts MemberRoomListOptions) ([]*corev1.Room, error) {
+	roomIDs := c.RoomMembership.Rooms(userID)
+
+	type listedRoom struct {
+		room          *corev1.Room
+		lastMessageAt time.Time
+	}
+	listed := make([]listedRoom, 0, len(roomIDs))
+
+	for _, roomID := range roomIDs {
+		room, err := c.GetRoom(ctx, kind, roomID)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			return nil, fmt.Errorf("lookup room %s: %w", roomID, err)
+		}
+
+		var lastMessageAt time.Time
+		if opts.RequireLastMessage || opts.SortByLastMessageDesc {
+			lastMessageAt, err = c.GetRoomLastMessageAt(ctx, kind, room.Id)
+			if err != nil {
+				return nil, fmt.Errorf("lookup last message for room %s: %w", room.Id, err)
+			}
+			if opts.RequireLastMessage && lastMessageAt.IsZero() {
+				continue
+			}
+		}
+
+		listed = append(listed, listedRoom{room: room, lastMessageAt: lastMessageAt})
+	}
+
+	if opts.SortByLastMessageDesc {
+		sort.SliceStable(listed, func(i, j int) bool {
+			return listed[i].lastMessageAt.After(listed[j].lastMessageAt)
+		})
+	}
+
+	rooms := make([]*corev1.Room, len(listed))
+	for i, r := range listed {
+		rooms[i] = r.room
 	}
 	return rooms, nil
 }

--- a/cli/internal/core/rooms_test.go
+++ b/cli/internal/core/rooms_test.go
@@ -630,6 +630,81 @@ func TestChattoCore_ListRoomsBySpace(t *testing.T) {
 	}
 }
 
+func TestChattoCore_ListMemberRooms(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	user, err := core.CreateUser(ctx, "actor1", "memberrooms", "Member Rooms", "password")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	other, err := core.CreateUser(ctx, "actor1", "memberrooms2", "Member Rooms 2", "password")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	room1, err := core.CreateRoom(ctx, user.Id, KindChannel, "", "member-room-1", "First")
+	if err != nil {
+		t.Fatalf("CreateRoom room1: %v", err)
+	}
+	room2, err := core.CreateRoom(ctx, user.Id, KindChannel, "", "member-room-2", "Second")
+	if err != nil {
+		t.Fatalf("CreateRoom room2: %v", err)
+	}
+	room3, err := core.CreateRoom(ctx, user.Id, KindChannel, "", "member-room-3", "Third")
+	if err != nil {
+		t.Fatalf("CreateRoom room3: %v", err)
+	}
+
+	if _, err := core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room1.Id); err != nil {
+		t.Fatalf("JoinRoom room1: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room2.Id); err != nil {
+		t.Fatalf("JoinRoom room2: %v", err)
+	}
+	if _, _, err := core.FindOrCreateDM(ctx, user.Id, []string{other.Id}); err != nil {
+		t.Fatalf("FindOrCreateDM: %v", err)
+	}
+
+	channelRooms, err := core.ListMemberRooms(ctx, KindChannel, user.Id, MemberRoomListOptions{})
+	if err != nil {
+		t.Fatalf("ListMemberRooms channel: %v", err)
+	}
+	if len(channelRooms) != 2 {
+		t.Fatalf("Expected 2 channel member rooms, got %d", len(channelRooms))
+	}
+	ids := make(map[string]bool, len(channelRooms))
+	for _, room := range channelRooms {
+		ids[room.Id] = true
+	}
+	if !ids[room1.Id] || !ids[room2.Id] || ids[room3.Id] {
+		t.Fatalf("ListMemberRooms returned wrong channel room set: %#v", ids)
+	}
+
+	dmRooms, err := core.ListMemberRooms(ctx, KindDM, user.Id, MemberRoomListOptions{})
+	if err != nil {
+		t.Fatalf("ListMemberRooms dm: %v", err)
+	}
+	if len(dmRooms) != 1 {
+		t.Fatalf("Expected 1 DM member room, got %d", len(dmRooms))
+	}
+
+	if _, err := core.PostMessage(ctx, KindChannel, room2.Id, user.Id, "newer", nil, "", "", nil, false); err != nil {
+		t.Fatalf("PostMessage room2: %v", err)
+	}
+
+	activeRooms, err := core.ListMemberRooms(ctx, KindChannel, user.Id, MemberRoomListOptions{
+		RequireLastMessage:    true,
+		SortByLastMessageDesc: true,
+	})
+	if err != nil {
+		t.Fatalf("ListMemberRooms active channel: %v", err)
+	}
+	if len(activeRooms) != 1 || activeRooms[0].Id != room2.Id {
+		t.Fatalf("Expected only room2 after RequireLastMessage, got %#v", activeRooms)
+	}
+}
+
 // ============================================================================
 // ArchiveRoom Tests
 // ============================================================================

--- a/cli/internal/core/server_branding.go
+++ b/cli/internal/core/server_branding.go
@@ -296,7 +296,7 @@ func (c *ChattoCore) PublishServerBrandingUpdate(ctx context.Context, actorID st
 	event := newLiveEvent(actorID, &corev1.LiveEvent{
 		Event: &corev1.LiveEvent_ServerUpdated{
 			ServerUpdated: &corev1.ServerUpdatedEvent{
-				ServerId:    ServerSpaceID,
+				ServerId:    LegacyServerSpaceID,
 				Name:        name,
 				Description: description,
 				LogoUrl:     logoURL,

--- a/cli/internal/core/threads.go
+++ b/cli/internal/core/threads.go
@@ -621,7 +621,7 @@ func (c *ChattoCore) ListFollowedThreads(ctx context.Context, userID string, spa
 	var allThreads []*FollowedThread
 
 	for _, spaceID := range spaceIDs {
-		threads, err := c.listFollowedThreadsInSpace(ctx, userID, KindForSpace(spaceID))
+		threads, err := c.listFollowedThreadsInSpace(ctx, userID, RoomKindFromLegacySpaceID(spaceID))
 		if err != nil {
 			c.logger.Warn("Failed to list followed threads for space", "space_id", spaceID, "error", err)
 			continue
@@ -687,7 +687,7 @@ func (c *ChattoCore) listFollowedThreadsInSpace(ctx context.Context, userID stri
 		}
 
 		result = append(result, &FollowedThread{
-			SpaceID:           SpaceIDForKind(kind),
+			SpaceID:           LegacySpaceIDForRoomKind(kind),
 			RoomID:            roomID,
 			ThreadRootEventID: threadRootEventID,
 			ReplyCount:        metadata.ReplyCount,

--- a/cli/internal/core/threads_test.go
+++ b/cli/internal/core/threads_test.go
@@ -570,7 +570,7 @@ func TestChattoCore_ListFollowedThreads(t *testing.T) {
 	core.JoinRoom(ctx, userB.Id, KindChannel, userB.Id, room2.Id)
 
 	t.Run("returns empty list when no threads are followed", func(t *testing.T) {
-		threads, err := core.ListFollowedThreads(ctx, userA.Id, []string{ServerSpaceID})
+		threads, err := core.ListFollowedThreads(ctx, userA.Id, []string{LegacyServerSpaceID})
 		if err != nil {
 			t.Fatalf("Failed to list followed threads: %v", err)
 		}
@@ -593,7 +593,7 @@ func TestChattoCore_ListFollowedThreads(t *testing.T) {
 
 	t.Run("returns followed threads sorted by last activity", func(t *testing.T) {
 		// User A auto-follows both threads (root author auto-follow on first reply)
-		threads, err := core.ListFollowedThreads(ctx, userA.Id, []string{ServerSpaceID})
+		threads, err := core.ListFollowedThreads(ctx, userA.Id, []string{LegacyServerSpaceID})
 		if err != nil {
 			t.Fatalf("Failed to list followed threads: %v", err)
 		}
@@ -611,7 +611,7 @@ func TestChattoCore_ListFollowedThreads(t *testing.T) {
 	})
 
 	t.Run("includes correct metadata", func(t *testing.T) {
-		threads, err := core.ListFollowedThreads(ctx, userA.Id, []string{ServerSpaceID})
+		threads, err := core.ListFollowedThreads(ctx, userA.Id, []string{LegacyServerSpaceID})
 		if err != nil {
 			t.Fatalf("Failed to list followed threads: %v", err)
 		}
@@ -624,7 +624,7 @@ func TestChattoCore_ListFollowedThreads(t *testing.T) {
 		if thread2.RoomID != room2.Id {
 			t.Errorf("Expected room2 ID, got %s", thread2.RoomID)
 		}
-		if thread2.SpaceID != SpaceIDForKind(KindChannel) {
+		if thread2.SpaceID != LegacySpaceIDForRoomKind(KindChannel) {
 			t.Errorf("Expected canonical space ID, got %s", thread2.SpaceID)
 		}
 		if thread2.LastReplyAt == nil {
@@ -639,7 +639,7 @@ func TestChattoCore_ListFollowedThreads(t *testing.T) {
 	})
 
 	t.Run("hasUnread is true when thread has activity after last opened", func(t *testing.T) {
-		threads, err := core.ListFollowedThreads(ctx, userA.Id, []string{ServerSpaceID})
+		threads, err := core.ListFollowedThreads(ctx, userA.Id, []string{LegacyServerSpaceID})
 		if err != nil {
 			t.Fatalf("Failed to list followed threads: %v", err)
 		}
@@ -662,7 +662,7 @@ func TestChattoCore_ListFollowedThreads(t *testing.T) {
 		// User A opens thread 2
 		core.SetThreadLastOpened(ctx, KindChannel, userA.Id, room2.Id, rootMsg2.Id)
 
-		threads, err := core.ListFollowedThreads(ctx, userA.Id, []string{ServerSpaceID})
+		threads, err := core.ListFollowedThreads(ctx, userA.Id, []string{LegacyServerSpaceID})
 		if err != nil {
 			t.Fatalf("Failed to list followed threads: %v", err)
 		}
@@ -684,7 +684,7 @@ func TestChattoCore_ListFollowedThreads(t *testing.T) {
 		// User A unfollows thread 1
 		core.UnfollowThread(ctx, KindChannel, userA.Id, room1.Id, rootMsg1.Id)
 
-		threads, err := core.ListFollowedThreads(ctx, userA.Id, []string{ServerSpaceID})
+		threads, err := core.ListFollowedThreads(ctx, userA.Id, []string{LegacyServerSpaceID})
 		if err != nil {
 			t.Fatalf("Failed to list followed threads: %v", err)
 		}
@@ -698,7 +698,7 @@ func TestChattoCore_ListFollowedThreads(t *testing.T) {
 
 	t.Run("only returns threads for the specified user", func(t *testing.T) {
 		// User B followed both threads (auto-follow from posting replies)
-		threadsB, err := core.ListFollowedThreads(ctx, userB.Id, []string{ServerSpaceID})
+		threadsB, err := core.ListFollowedThreads(ctx, userB.Id, []string{LegacyServerSpaceID})
 		if err != nil {
 			t.Fatalf("Failed to list followed threads for user B: %v", err)
 		}
@@ -707,7 +707,7 @@ func TestChattoCore_ListFollowedThreads(t *testing.T) {
 		}
 
 		// User A should still only have 1 (unfollowed thread 1 above)
-		threadsA, err := core.ListFollowedThreads(ctx, userA.Id, []string{ServerSpaceID})
+		threadsA, err := core.ListFollowedThreads(ctx, userA.Id, []string{LegacyServerSpaceID})
 		if err != nil {
 			t.Fatalf("Failed to list followed threads for user A: %v", err)
 		}
@@ -720,7 +720,7 @@ func TestChattoCore_ListFollowedThreads(t *testing.T) {
 		// Manually follow a thread that has no metadata (orphaned)
 		core.FollowThread(ctx, KindChannel, userA.Id, room1.Id, "nonexistent-thread-id")
 
-		threads, err := core.ListFollowedThreads(ctx, userA.Id, []string{ServerSpaceID})
+		threads, err := core.ListFollowedThreads(ctx, userA.Id, []string{LegacyServerSpaceID})
 		if err != nil {
 			t.Fatalf("Failed to list followed threads: %v", err)
 		}

--- a/cli/internal/core/voice.go
+++ b/cli/internal/core/voice.go
@@ -158,7 +158,7 @@ func (c *ChattoCore) HandleCallParticipantJoined(ctx context.Context, spaceID, r
 
 		err := c.writeCallState(ctx, key, &entry.state, entry.revision)
 		if err == nil {
-			return c.PublishCallParticipantJoined(ctx, userID, KindForSpace(spaceID), roomID)
+			return c.PublishCallParticipantJoined(ctx, userID, RoomKindFromLegacySpaceID(spaceID), roomID)
 		}
 		if !errors.Is(err, jetstream.ErrKeyExists) {
 			return fmt.Errorf("write call state: %w", err)
@@ -196,13 +196,13 @@ func (c *ChattoCore) HandleCallParticipantLeft(ctx context.Context, spaceID, roo
 		if len(filtered) == 0 {
 			// Call is now empty — delete the key
 			_ = c.storage.callStateKV.Delete(ctx, key)
-			return c.PublishCallParticipantLeft(ctx, userID, KindForSpace(spaceID), roomID)
+			return c.PublishCallParticipantLeft(ctx, userID, RoomKindFromLegacySpaceID(spaceID), roomID)
 		}
 
 		entry.state.Participants = filtered
 		err := c.writeCallState(ctx, key, &entry.state, entry.revision)
 		if err == nil {
-			return c.PublishCallParticipantLeft(ctx, userID, KindForSpace(spaceID), roomID)
+			return c.PublishCallParticipantLeft(ctx, userID, RoomKindFromLegacySpaceID(spaceID), roomID)
 		}
 		if !errors.Is(err, jetstream.ErrKeyExists) {
 			return fmt.Errorf("write call state: %w", err)
@@ -221,7 +221,7 @@ func (c *ChattoCore) HandleCallRoomFinished(ctx context.Context, spaceID, roomID
 
 	// Publish leave events for any remaining participants
 	for _, p := range entry.state.Participants {
-		_ = c.PublishCallParticipantLeft(ctx, p.UserID, KindForSpace(spaceID), roomID)
+		_ = c.PublishCallParticipantLeft(ctx, p.UserID, RoomKindFromLegacySpaceID(spaceID), roomID)
 	}
 
 	// Delete the key

--- a/cli/internal/graph/role_permissions_helpers.go
+++ b/cli/internal/graph/role_permissions_helpers.go
@@ -26,7 +26,7 @@ func (r *Resolver) authorizeRolePermissions(ctx context.Context, viewerID, space
 	if spaceID == "" {
 		return r.requireServerAdminOrErr(ctx, viewerID)
 	}
-	kind := core.KindForSpace(spaceID)
+	kind := core.RoomKindFromLegacySpaceID(spaceID)
 	if err := r.requireServerAdminOrErr(ctx, viewerID); err != nil {
 		hasRolesManage, hpErr := r.core.PermResolver().HasSpacePermission(ctx, viewerID, kind, core.PermRoleManage)
 		if hpErr != nil {

--- a/cli/internal/graph/room.resolvers.go
+++ b/cli/internal/graph/room.resolvers.go
@@ -294,7 +294,7 @@ func (r *roomResolver) VoiceCallToken(ctx context.Context, obj *corev1.Room) (*c
 	avatarSize := 96
 	avatarURL, _ := r.core.GetUserAvatarURL(ctx, user.Id, &avatarSize, &avatarSize)
 
-	roomName := core.LiveKitRoomName(r.livekitConfig.ServerID, core.SpaceIDForKind(core.KindOfRoom(obj)), obj.Id)
+	roomName := core.LiveKitRoomName(r.livekitConfig.ServerID, core.LegacySpaceIDForRoomKind(core.KindOfRoom(obj)), obj.Id)
 	token, err := core.GenerateVoiceCallToken(
 		r.livekitConfig.APIKey,
 		r.livekitConfig.APISecret,
@@ -323,7 +323,7 @@ func (r *roomResolver) CallParticipants(ctx context.Context, obj *corev1.Room) (
 		return []*model.CallParticipant{}, nil
 	}
 
-	participants, err := r.core.GetCallParticipants(ctx, core.SpaceIDForKind(core.KindOfRoom(obj)), obj.Id)
+	participants, err := r.core.GetCallParticipants(ctx, core.LegacySpaceIDForRoomKind(core.KindOfRoom(obj)), obj.Id)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/graph/server.resolvers.go
+++ b/cli/internal/graph/server.resolvers.go
@@ -216,12 +216,12 @@ func (r *serverResolver) ViewerHasUnreadRooms(ctx context.Context, obj *model.Se
 		return false, nil
 	}
 	kind := core.KindChannel
-	memberships, err := r.core.GetUserRoomMemberships(ctx, kind, user.Id)
+	rooms, err := r.core.ListMemberRooms(ctx, kind, user.Id, core.MemberRoomListOptions{})
 	if err != nil {
 		return false, err
 	}
-	for _, membership := range memberships {
-		hasUnread, err := r.core.HasUnread(ctx, kind, user.Id, membership.RoomId)
+	for _, room := range rooms {
+		hasUnread, err := r.core.HasUnread(ctx, kind, user.Id, room.Id)
 		if err != nil {
 			continue
 		}

--- a/cli/internal/graph/space_helpers.go
+++ b/cli/internal/graph/space_helpers.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"context"
 
+	"hmans.de/chatto/internal/core"
 	"hmans.de/chatto/internal/graph/model"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
@@ -14,15 +15,18 @@ func roomTypeIs(filter *model.RoomType, want model.RoomType) bool {
 	return filter == nil || *filter == want
 }
 
-// appendDMRoomsForServer appends the user's DM conversations to a channel
-// rooms list. No-op when the caller asked for channels only (`type: CHANNEL`).
-// The DM listing path is membership-filtered; there is no separate DM read
-// permission.
+// appendDMRoomsForServer appends the user's active DM rooms to a channel rooms
+// list. No-op when the caller asked for channels only (`type: CHANNEL`).
+// The DM listing path is the generic member-room list plus DM presentation
+// policy: hide empty conversations and sort by last message.
 func (r *Resolver) appendDMRoomsForServer(ctx context.Context, userID string, rooms []*corev1.Room, roomType *model.RoomType) ([]*corev1.Room, error) {
 	if !roomTypeIs(roomType, model.RoomTypeDm) {
 		return rooms, nil
 	}
-	dms, err := r.core.ListDMConversations(ctx, userID)
+	dms, err := r.core.ListMemberRooms(ctx, core.KindDM, userID, core.MemberRoomListOptions{
+		RequireLastMessage:    true,
+		SortByLastMessageDesc: true,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/graph/threads.resolvers.go
+++ b/cli/internal/graph/threads.resolvers.go
@@ -16,12 +16,12 @@ import (
 
 // Room is the resolver for the room field.
 func (r *followedThreadResolver) Room(ctx context.Context, obj *model.FollowedThread) (*corev1.Room, error) {
-	return r.core.GetRoom(ctx, core.KindForSpace(obj.SpaceID), obj.RoomID)
+	return r.core.GetRoom(ctx, core.RoomKindFromLegacySpaceID(obj.SpaceID), obj.RoomID)
 }
 
 // RootMessage is the resolver for the rootMessage field.
 func (r *followedThreadResolver) RootMessage(ctx context.Context, obj *model.FollowedThread) (*corev1.Event, error) {
-	return r.core.GetRoomEventByEventID(ctx, core.KindForSpace(obj.SpaceID), obj.RoomID, obj.ThreadRootEventID)
+	return r.core.GetRoomEventByEventID(ctx, core.RoomKindFromLegacySpaceID(obj.SpaceID), obj.RoomID, obj.ThreadRootEventID)
 }
 
 // ThreadParticipants is the resolver for the threadParticipants field.
@@ -65,7 +65,7 @@ func (r *viewerResolver) FollowedThreads(ctx context.Context, obj *model.Viewer)
 		return nil, err
 	}
 
-	threads, err := r.core.ListFollowedThreads(ctx, user.Id, []string{core.SpaceIDForKind(kind)})
+	threads, err := r.core.ListFollowedThreads(ctx, user.Id, []string{core.LegacySpaceIDForRoomKind(kind)})
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (r *viewerResolver) HasUnreadFollowedThreads(ctx context.Context, obj *mode
 		return false, err
 	}
 
-	threads, err := r.core.ListFollowedThreads(ctx, user.Id, []string{core.SpaceIDForKind(kind)})
+	threads, err := r.core.ListFollowedThreads(ctx, user.Id, []string{core.LegacySpaceIDForRoomKind(kind)})
 	if err != nil {
 		return false, err
 	}

--- a/cli/internal/graph/voice.resolvers.go
+++ b/cli/internal/graph/voice.resolvers.go
@@ -24,7 +24,7 @@ func (r *queryResolver) ActiveCallRoomIds(ctx context.Context) ([]string, error)
 		return []string{}, nil
 	}
 
-	activeIDs, err := r.core.GetActiveCallRoomIDs(ctx, core.SpaceIDForKind(kind))
+	activeIDs, err := r.core.GetActiveCallRoomIDs(ctx, core.LegacySpaceIDForRoomKind(kind))
 	if err != nil {
 		r.logger.Warn("Failed to get active call room IDs", "error", err)
 		return []string{}, nil

--- a/cli/internal/migrations/room_kind.go
+++ b/cli/internal/migrations/room_kind.go
@@ -23,7 +23,7 @@ import (
 // discriminator. Pre-existing rooms still have the field zero-valued
 // (ROOM_KIND_UNSPECIFIED). Backfilling at boot lets all read sites
 // assume `room.Kind != UNSPECIFIED` instead of falling back to
-// `KindForSpace(room.SpaceId)` on every access.
+// `RoomKindFromLegacySpaceID(room.SpaceId)` on every access.
 //
 // # Idempotency
 //
@@ -34,8 +34,7 @@ import (
 // # When this can be removed
 //
 // Once every live deployment has booted at least once on a version
-// that includes this migration AND the wire-compat fallback in
-// `KindOfRoom` has been removed.
+// that includes this migration.
 func BackfillRoomKind(ctx context.Context, configKV jetstream.KeyValue, logger *log.Logger) error {
 	keyLister, err := configKV.ListKeysFiltered(ctx, "room.channel.*", "room.dm.*")
 	if err != nil {

--- a/docs/adr/ADR-030-space-tier-retirement.md
+++ b/docs/adr/ADR-030-space-tier-retirement.md
@@ -17,7 +17,7 @@ The Space tier is therefore *behaviourally* retired, but its mechanical residue 
    - `cli/internal/graph/space_helpers.go` — thin GraphQL wrapper
    These are dead-end reads of stale data. Once they're removed, the persisted `space.{spaceId}` KV record becomes an orphan and can be left alone — one tiny entry per server, zero functional impact.
 
-2. **`spaceID` plumbing on the core API.** Roughly 80 functions across `cli/internal/core/*.go` still take a `spaceID string` parameter. Every one of them either ignores the value or feeds it into `KindForSpace(spaceID)` (in `cli/internal/core/dm.go`), which exists only to map the legacy wire value `space_id = "DM"` to `"dm"` and everything else to `"channel"`. The parameter is a one-bit DM flag dressed up as an ID.
+2. **`spaceID` plumbing on the core API.** Roughly 80 functions across `cli/internal/core/*.go` still take a `spaceID string` parameter. Every one of them either ignores the value or feeds it into a legacy compatibility mapping, which exists only to map the legacy wire value `space_id = "DM"` to `"dm"` and everything else to `"channel"`. The parameter is a one-bit DM flag dressed up as an ID.
 
 3. **DMs still have legacy hidden-space residue at the wire boundary.** ADR-015's "hidden DM space" predates the room-`kind` discriminator. With the `kind` field now baked into KV keys and NATS subjects, the DM scope is determined by `kind == "dm"` directly; the old `space_id = "DM"` value only survives where persisted payloads or compatibility APIs still carry a `space_id` field.
 
@@ -38,7 +38,7 @@ When a function previously took `spaceID` and the only thing it actually needed 
 - takes a `kind RoomKind` (or `kind string` for now, pending a typed enum), if the kind is what the caller wants to express; or
 - drops the parameter entirely if the function only needs the room ID (the kind is derivable from the room record).
 
-The DM sentinel is retired as a product/storage concept in favour of an explicit `kind == "dm"` check at call sites. A small legacy mapping may remain only at wire-format boundaries where persisted payloads still expose `space_id`.
+The DM sentinel is retired as a product/storage concept in favour of an explicit `kind == "dm"` check at call sites. A small `RoomKindFromLegacySpaceID` / `LegacySpaceIDForRoomKind` mapping may remain only at wire-format boundaries where persisted payloads or compatibility APIs still expose `space_id`.
 
 ### Scope
 
@@ -83,7 +83,7 @@ Each phase is shippable independently. Phases 1 and 2 are good candidates to com
 - The core Go API stops lying about its shape: signatures reflect what data they actually depend on.
 - New contributors don't have to learn the Space tier just to find it's not real.
 - `spaces.go` (1070 lines) goes away. The `Space` Go type and `Server.primarySpaceId` GraphQL bridge field go away.
-- The DM mechanism gets simpler: one `kind == "dm"` check instead of a sentinel-space + `kindForSpace` indirection.
+- The DM mechanism gets simpler: normal room code uses `kind == "dm"` directly, while the legacy `space_id` conversion is boxed into explicitly named compatibility helpers.
 - ADR-015 ("DMs as a hidden space") was already marked superseded by ADR-027 at the storage layer. This ADR finishes the job at the API layer.
 
 ### Negative / risks

--- a/frontend/e2e/dm.test.ts
+++ b/frontend/e2e/dm.test.ts
@@ -37,7 +37,7 @@ test.describe('Direct Messages (room-shaped)', () => {
       await createAndLoginTestUser(page2);
 
       // User B starts a DM with User A and seeds a message so the DM is in
-      // User A's merged sidebar (ListDMConversations filters empty rooms).
+      // User A's merged sidebar (the active DM-room list filters empty rooms).
       // The conversation ID is deterministic across the two users — pull it
       // from B's URL once the room loads.
       const dmPageB = new DMPage(page2);
@@ -84,8 +84,8 @@ test.describe('Direct Messages (room-shaped)', () => {
     try {
       const userB = await createAndLoginTestUser(page2);
 
-      // User B → User A: start DM and post so the DM survives the
-      // ListDMConversations empty-room filter.
+      // User B → User A: start DM and post so the DM survives the active
+      // DM-room empty-room filter.
       const dmPageB = new DMPage(page2);
       const roomB = await dmPageB.startConversation(userA.login);
       await roomB.sendMessage('seed');
@@ -366,7 +366,7 @@ test.describe('Direct Messages (room-shaped)', () => {
       const regularUser = await createAndLoginTestUser(regularPage);
 
       // Admin starts a DM with the regular user (via API) and seeds it so
-      // the conversation isn't filtered by ListDMConversations.
+      // the conversation isn't filtered by the active DM-room list.
       const startResp = await page.request.post('/api/graphql', {
         headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
         data: {

--- a/frontend/e2e/fixtures/graphqlHelpers.ts
+++ b/frontend/e2e/fixtures/graphqlHelpers.ts
@@ -208,8 +208,9 @@ export async function postThreadReplyViaAPI(
 
 /**
  * Extract roomId from the current URL (`/chat/-/{roomId}`). Post-ADR-030
- * the spaceId is just the kind discriminator constant — `core.ServerSpaceID`
- * on the backend, `SERVER_SPACE_ID` on the frontend.
+ * the spaceId is just the legacy kind discriminator constant —
+ * `core.LegacyServerSpaceID` on the backend, `SERVER_SPACE_ID` on the
+ * frontend.
  */
 export async function getIdsFromUrl(
   page: Page

--- a/frontend/e2e/jump-to-message.test.ts
+++ b/frontend/e2e/jump-to-message.test.ts
@@ -65,7 +65,7 @@ async function postMessageAndGetId(
 
 /**
  * Extract roomId from the current URL. Post-ADR-030 the spaceId is just the
- * kind discriminator constant (`core.ServerSpaceID`).
+ * kind discriminator constant (`core.LegacyServerSpaceID`).
  */
 async function getIdsFromUrl(page: Page): Promise<{ spaceId: string; roomId: string }> {
   const match = page.url().match(/\/chat\/-\/([^/]+)/);

--- a/frontend/e2e/pages/ChatPage.ts
+++ b/frontend/e2e/pages/ChatPage.ts
@@ -34,12 +34,12 @@ export class ChatPage {
 
   }
 
-  /**
-   * Return the kind-discriminator constant used as a spaceID by core methods.
-   * Post-ADR-030 every channel-scoped call uses this single deployment-wide
-   * value (`core.ServerSpaceID = "server"` on the backend).
-   */
-  async getSpaceId(): Promise<string> {
+	/**
+	 * Return the kind-discriminator constant used as a spaceID by core methods.
+	 * Post-ADR-030 every channel-scoped call uses this single deployment-wide
+	 * value (`core.LegacyServerSpaceID = "server"` on the backend).
+	 */
+	async getSpaceId(): Promise<string> {
     return 'server';
   }
 

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -4,7 +4,7 @@
 
 /**
  * Kind-discriminator string for non-DM rooms. Matches the backend
- * `core.ServerSpaceID = "server"` constant — see ADR-030.
+ * `core.LegacyServerSpaceID = "server"` constant — see ADR-030.
  *
  * Only test fixtures and a few legacy helpers need this; production code
  * paths don't construct spaceIDs anymore.

--- a/frontend/src/lib/state/space/rooms.svelte.ts
+++ b/frontend/src/lib/state/space/rooms.svelte.ts
@@ -193,8 +193,9 @@ export class RoomsStore {
    * Refresh the room list when membership or room metadata changes. Other
    * event types (messages, reactions, presence) are no-ops at this level
    * unless the message arrives for a room we don't yet know about — that's
-   * how a freshly-created empty DM (filtered from ListDMConversations until
-   * its first message lands) shows up in the sidebar without a manual reload.
+   * how a freshly-created empty DM (filtered from the active member-room DM
+   * list until its first message lands) shows up in the sidebar without a
+   * manual reload.
    */
   ingestServerEvent(serverEvent: { event?: { __typename?: string; roomId?: string } | null }): void {
     const event = serverEvent.event;

--- a/proto/chatto/core/v1/models.proto
+++ b/proto/chatto/core/v1/models.proto
@@ -26,7 +26,7 @@ message Room {
   // removed post-ADR-030 (replaced by `kind`), and the field was
   // kept around as a deprecated wire-compat hack longer than needed.
   // Removed entirely; callers that need the legacy partition key
-  // compute it on-demand via `core.SpaceIDForKind(kind)`.
+  // compute it on-demand via `core.LegacySpaceIDForRoomKind(kind)`.
   reserved 2;
   reserved "space_id";
   string name = 3;


### PR DESCRIPTION
Summary:
- Adds `ListMemberRooms` as the shared member-scoped room listing primitive and routes DM sidebar conversations through it with the existing active-DM policy.
- Removes the old `ListDMConversations` helper and updates live-event cache, unread checks, tests, and frontend comments to use the shared room-listing model.
- Boxes legacy `space_id` conversion into explicit compatibility helpers and updates ADR-030 plus related call sites.

Tests: `go test ./internal/core ./internal/graph ./internal/migrations`; `pnpm check`; focused DM Playwright sidebar/permission cases.
