### PR TITLE
fix: move thread follow state to runtime state

### DIFF
--- a/cli/internal/core/asset_creation_migration.go
+++ b/cli/internal/core/asset_creation_migration.go
@@ -127,7 +127,11 @@ func (c *ChattoCore) migrateAssetCreationsToES(ctx context.Context) (retErr erro
 }
 
 func (c *ChattoCore) claimRuntimeMigration(ctx context.Context, key string) (uint64, bool, error) {
-	revision, err := c.storage.serverRuntimeKV.Create(ctx, key, []byte(runtimeMigrationRunning))
+	if err := c.adoptLegacyRuntimeMigrationSentinel(ctx, key); err != nil {
+		return 0, false, err
+	}
+
+	revision, err := c.storage.runtimeStateKV.Create(ctx, key, []byte(runtimeMigrationRunning))
 	if err == nil {
 		return revision, true, nil
 	}
@@ -141,7 +145,7 @@ func (c *ChattoCore) claimRuntimeMigration(ctx context.Context, key string) (uin
 }
 
 func (c *ChattoCore) completeRuntimeMigration(ctx context.Context, key string, revision uint64) error {
-	if _, err := c.storage.serverRuntimeKV.Update(ctx, key, []byte(runtimeMigrationDone), revision); err != nil {
+	if _, err := c.storage.runtimeStateKV.Update(ctx, key, []byte(runtimeMigrationDone), revision); err != nil {
 		return fmt.Errorf("complete migration sentinel %s: %w", key, err)
 	}
 	return nil
@@ -154,7 +158,7 @@ func (c *ChattoCore) completeRuntimeMigration(ctx context.Context, key string, r
 func (c *ChattoCore) releaseRuntimeMigrationOnFailure(key string, revision uint64, cause error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	if err := c.storage.serverRuntimeKV.Delete(ctx, key, jetstream.LastRevision(revision)); err != nil {
+	if err := c.storage.runtimeStateKV.Delete(ctx, key, jetstream.LastRevision(revision)); err != nil {
 		c.logger.Warn("Failed to release migration sentinel after failure",
 			"key", key,
 			"original_error", cause,
@@ -163,12 +167,41 @@ func (c *ChattoCore) releaseRuntimeMigrationOnFailure(key string, revision uint6
 }
 
 func (c *ChattoCore) waitRuntimeMigrationDone(ctx context.Context, key string) error {
+	return c.waitRuntimeMigrationDoneIn(ctx, c.storage.runtimeStateKV, key)
+}
+
+func (c *ChattoCore) adoptLegacyRuntimeMigrationSentinel(ctx context.Context, key string) error {
+	if _, err := c.storage.runtimeStateKV.Get(ctx, key); err == nil {
+		return nil
+	} else if !errors.Is(err, jetstream.ErrKeyNotFound) {
+		return fmt.Errorf("get migration sentinel %s: %w", key, err)
+	}
+
+	entry, err := c.storage.serverRuntimeKV.Get(ctx, key)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrKeyNotFound) {
+			return nil
+		}
+		return fmt.Errorf("get legacy migration sentinel %s: %w", key, err)
+	}
+	if string(entry.Value()) == runtimeMigrationRunning {
+		if err := c.waitRuntimeMigrationDoneIn(ctx, c.storage.serverRuntimeKV, key); err != nil {
+			return err
+		}
+	}
+	if _, err := c.storage.runtimeStateKV.Create(ctx, key, []byte(runtimeMigrationDone)); err != nil && !errors.Is(err, jetstream.ErrKeyExists) {
+		return fmt.Errorf("adopt legacy migration sentinel %s: %w", key, err)
+	}
+	return nil
+}
+
+func (c *ChattoCore) waitRuntimeMigrationDoneIn(ctx context.Context, bucket jetstream.KeyValue, key string) error {
 	waitCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 	ticker := time.NewTicker(250 * time.Millisecond)
 	defer ticker.Stop()
 	for {
-		entry, err := c.storage.serverRuntimeKV.Get(waitCtx, key)
+		entry, err := bucket.Get(waitCtx, key)
 		if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
 			return fmt.Errorf("wait for migration sentinel %s: %w", key, err)
 		}

--- a/cli/internal/core/asset_creation_migration_test.go
+++ b/cli/internal/core/asset_creation_migration_test.go
@@ -13,9 +13,8 @@ func TestAssetCreationMigration_BackfillsMessageAttachments(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	if err := core.storage.serverRuntimeKV.Delete(ctx, assetCreationESMigrationKey); err != nil {
-		t.Fatalf("delete migration sentinel: %v", err)
-	}
+	_ = core.storage.runtimeStateKV.Delete(ctx, assetCreationESMigrationKey)
+	_ = core.storage.serverRuntimeKV.Delete(ctx, assetCreationESMigrationKey)
 	room, err := core.CreateRoom(ctx, "test-user", KindChannel, "", "Files", "Files room")
 	if err != nil {
 		t.Fatalf("create room: %v", err)
@@ -92,6 +91,7 @@ func TestRuntimeMigrationClaim_WaitsForAtomicOwner(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 	key := "test.migration.claim"
+	_ = core.storage.runtimeStateKV.Delete(ctx, key)
 	_ = core.storage.serverRuntimeKV.Delete(ctx, key)
 
 	revision, claimed, err := core.claimRuntimeMigration(ctx, key)
@@ -132,6 +132,34 @@ func TestRuntimeMigrationClaim_WaitsForAtomicOwner(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("second claimant did not observe migration completion")
+	}
+}
+
+func TestRuntimeMigrationClaim_AdoptsLegacyDoneSentinel(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+	key := "test.migration.legacy.done"
+	_ = core.storage.runtimeStateKV.Delete(ctx, key)
+	_ = core.storage.serverRuntimeKV.Delete(ctx, key)
+
+	if _, err := core.storage.serverRuntimeKV.Put(ctx, key, []byte(runtimeMigrationDone)); err != nil {
+		t.Fatalf("put legacy sentinel: %v", err)
+	}
+
+	_, claimed, err := core.claimRuntimeMigration(ctx, key)
+	if err != nil {
+		t.Fatalf("claim migration: %v", err)
+	}
+	if claimed {
+		t.Fatal("claim acquired migration despite legacy done sentinel")
+	}
+
+	entry, err := core.storage.runtimeStateKV.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("get adopted sentinel: %v", err)
+	}
+	if got := string(entry.Value()); got != runtimeMigrationDone {
+		t.Fatalf("adopted sentinel = %q, want %q", got, runtimeMigrationDone)
 	}
 }
 

--- a/cli/internal/core/threads.go
+++ b/cli/internal/core/threads.go
@@ -530,10 +530,10 @@ func threadFollowKey(userID, roomID, threadRootEventID string) string {
 }
 
 // FollowThread marks a user as following a thread so they receive reply notifications.
-// Stores a single byte in the RUNTIME KV bucket. Idempotent.
+// Stores a single byte in RUNTIME_STATE. Idempotent.
 // Publishes a ThreadFollowChangedEvent for multi-tab sync.
 func (c *ChattoCore) FollowThread(ctx context.Context, kind RoomKind, userID, roomID, threadRootEventID string) error {
-	bucket := c.storage.serverRuntimeKV
+	bucket := c.storage.runtimeStateKV
 
 	if _, err := bucket.Put(ctx, threadFollowKey(userID, roomID, threadRootEventID), []byte{0x01}); err != nil {
 		return fmt.Errorf("failed to follow thread: %w", err)
@@ -547,7 +547,7 @@ func (c *ChattoCore) FollowThread(ctx context.Context, kind RoomKind, userID, ro
 // Idempotent - calling when not following is a no-op.
 // Publishes a ThreadFollowChangedEvent for multi-tab sync.
 func (c *ChattoCore) UnfollowThread(ctx context.Context, kind RoomKind, userID, roomID, threadRootEventID string) error {
-	bucket := c.storage.serverRuntimeKV
+	bucket := c.storage.runtimeStateKV
 
 	if err := bucket.Delete(ctx, threadFollowKey(userID, roomID, threadRootEventID)); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
 		return fmt.Errorf("failed to unfollow thread: %w", err)
@@ -578,7 +578,7 @@ func (c *ChattoCore) publishThreadFollowChangedEvent(ctx context.Context, userID
 
 // IsFollowingThread checks if a user is following a thread.
 func (c *ChattoCore) IsFollowingThread(ctx context.Context, kind RoomKind, userID, roomID, threadRootEventID string) (bool, error) {
-	bucket := c.storage.serverRuntimeKV
+	bucket := c.storage.runtimeStateKV
 
 	if _, err := bucket.Get(ctx, threadFollowKey(userID, roomID, threadRootEventID)); err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
@@ -592,7 +592,7 @@ func (c *ChattoCore) IsFollowingThread(ctx context.Context, kind RoomKind, userI
 // GetThreadFollowers returns all user IDs following a specific thread.
 // Uses ListKeysFiltered to scan for thread_follow.*.{roomID}.{threadRootEventID} keys.
 func (c *ChattoCore) GetThreadFollowers(ctx context.Context, kind RoomKind, roomID, threadRootEventID string) ([]string, error) {
-	bucket := c.storage.serverRuntimeKV
+	bucket := c.storage.runtimeStateKV
 
 	pattern := fmt.Sprintf("thread_follow.*.%s.%s", roomID, threadRootEventID)
 	lister, err := bucket.ListKeysFiltered(ctx, pattern)
@@ -645,7 +645,7 @@ func (c *ChattoCore) ListFollowedThreads(ctx context.Context, userID string, spa
 
 // listFollowedThreadsInSpace returns all threads followed by the user in a single space.
 func (c *ChattoCore) listFollowedThreadsInSpace(ctx context.Context, userID string, kind RoomKind) ([]*FollowedThread, error) {
-	bucket := c.storage.serverRuntimeKV
+	bucket := c.storage.runtimeStateKV
 
 	// List all thread_follow keys for this user across all rooms
 	// Use ">" to match remaining parts: thread_follow.{userId}.{roomId}.{threadRootEventId}

--- a/cli/internal/core/threads_test.go
+++ b/cli/internal/core/threads_test.go
@@ -2,11 +2,13 @@ package core
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
 	"hmans.de/chatto/internal/core/subjects"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
@@ -450,6 +452,14 @@ func TestChattoCore_ThreadFollow(t *testing.T) {
 		err := core.FollowThread(ctx, KindChannel, user.Id, room.Id, threadRootEventId)
 		if err != nil {
 			t.Fatalf("Failed to follow thread: %v", err)
+		}
+
+		key := threadFollowKey(user.Id, room.Id, threadRootEventId)
+		if _, err := core.storage.runtimeStateKV.Get(ctx, key); err != nil {
+			t.Fatalf("Expected thread follow in RUNTIME_STATE: %v", err)
+		}
+		if _, err := core.storage.serverRuntimeKV.Get(ctx, key); !errors.Is(err, jetstream.ErrKeyNotFound) {
+			t.Fatalf("legacy SERVER_RUNTIME follow lookup error = %v, want ErrKeyNotFound", err)
 		}
 
 		isFollowing, err := core.IsFollowingThread(ctx, KindChannel, user.Id, room.Id, threadRootEventId)

--- a/cli/internal/core/video_manifest_migration_test.go
+++ b/cli/internal/core/video_manifest_migration_test.go
@@ -129,12 +129,10 @@ func createPostedVideoAttachment(t *testing.T, core *ChattoCore) (*corev1.Room, 
 	t.Helper()
 	ctx := testContext(t)
 
-	if err := core.storage.serverRuntimeKV.Delete(ctx, videoManifestESMigrationKey); err != nil {
-		t.Fatalf("delete migration sentinel: %v", err)
-	}
-	if err := core.storage.serverRuntimeKV.Delete(ctx, assetCreationESMigrationKey); err != nil {
-		t.Fatalf("delete asset creation migration sentinel: %v", err)
-	}
+	_ = core.storage.runtimeStateKV.Delete(ctx, videoManifestESMigrationKey)
+	_ = core.storage.runtimeStateKV.Delete(ctx, assetCreationESMigrationKey)
+	_ = core.storage.serverRuntimeKV.Delete(ctx, videoManifestESMigrationKey)
+	_ = core.storage.serverRuntimeKV.Delete(ctx, assetCreationESMigrationKey)
 	room, err := core.CreateRoom(ctx, "test-user", KindChannel, "", "Video", "Video room")
 	if err != nil {
 		t.Fatalf("create room: %v", err)

--- a/cli/internal/migrations/migrations.go
+++ b/cli/internal/migrations/migrations.go
@@ -58,7 +58,7 @@ import (
 //   - `runtimeConfigKV`: INSTANCE_CONFIG (operator-editable server
 //     settings — name, MOTD, blocked usernames, etc.).
 //   - `runtimeStateKV`: RUNTIME_STATE (persisted latest-value runtime/user
-//     state such as read markers).
+//     state such as read markers and thread follows).
 //   - `serverReactionsKV`: SERVER_REACTIONS (legacy current reaction
 //     state; retained until reaction ES migration cleanup).
 //
@@ -88,6 +88,9 @@ func RunAll(
 	}
 	if err := MigrateReadMarkersToRuntimeState(ctx, serverRuntimeKV, runtimeStateKV, logger); err != nil {
 		return fmt.Errorf("read_markers_runtime_state: %w", err)
+	}
+	if err := MigrateThreadFollowsToRuntimeState(ctx, serverRuntimeKV, runtimeStateKV, logger); err != nil {
+		return fmt.Errorf("thread_follows_runtime_state: %w", err)
 	}
 	// Room metadata + memberships share the evt.room.{R} subject and
 	// must seed together — a RoomCreatedEvent first, then the

--- a/cli/internal/migrations/read_markers_runtime_state.go
+++ b/cli/internal/migrations/read_markers_runtime_state.go
@@ -13,6 +13,7 @@ import (
 const (
 	legacyRoomReadPrefix     = "room_read_event."
 	legacyThreadOpenedPrefix = "thread_last_opened."
+	legacyThreadFollowPrefix = "thread_follow."
 )
 
 // MigrateReadMarkersToRuntimeState copies legacy read cursors from
@@ -27,11 +28,11 @@ const (
 // Destination writes use Create so this migration never overwrites newer
 // RUNTIME_STATE markers written by a previous boot or a live process.
 func MigrateReadMarkersToRuntimeState(ctx context.Context, legacyRuntime, runtimeState jetstream.KeyValue, logger *log.Logger) error {
-	roomCopied, roomSkipped, err := copyReadMarkerPrefix(ctx, legacyRuntime, runtimeState, legacyRoomReadPrefix, "read.room.")
+	roomCopied, roomSkipped, err := copyRuntimeStatePrefix(ctx, legacyRuntime, runtimeState, legacyRoomReadPrefix, "read.room.")
 	if err != nil {
 		return fmt.Errorf("room read markers: %w", err)
 	}
-	threadCopied, threadSkipped, err := copyReadMarkerPrefix(ctx, legacyRuntime, runtimeState, legacyThreadOpenedPrefix, "read.thread.")
+	threadCopied, threadSkipped, err := copyRuntimeStatePrefix(ctx, legacyRuntime, runtimeState, legacyThreadOpenedPrefix, "read.thread.")
 	if err != nil {
 		return fmt.Errorf("thread read markers: %w", err)
 	}
@@ -46,7 +47,30 @@ func MigrateReadMarkersToRuntimeState(ctx context.Context, legacyRuntime, runtim
 	return nil
 }
 
-func copyReadMarkerPrefix(ctx context.Context, src, dst jetstream.KeyValue, oldPrefix, newPrefix string) (copied, skipped int, err error) {
+// MigrateThreadFollowsToRuntimeState copies legacy thread follow state from
+// SERVER_RUNTIME into RUNTIME_STATE.
+//
+// Legacy and new keys use the same shape:
+//
+//	thread_follow.{userId}.{roomId}.{threadRootEventId}
+//
+// The old keys are intentionally retained for rollback and phase-7 cleanup.
+// Destination writes use Create so this migration never overwrites newer
+// RUNTIME_STATE follows written by a previous boot or a live process.
+func MigrateThreadFollowsToRuntimeState(ctx context.Context, legacyRuntime, runtimeState jetstream.KeyValue, logger *log.Logger) error {
+	copied, skipped, err := copyRuntimeStatePrefix(ctx, legacyRuntime, runtimeState, legacyThreadFollowPrefix, legacyThreadFollowPrefix)
+	if err != nil {
+		return fmt.Errorf("thread follows: %w", err)
+	}
+	if copied+skipped > 0 {
+		logger.Info("thread follow migration: copied legacy follows into RUNTIME_STATE",
+			"copied", copied,
+			"skipped", skipped)
+	}
+	return nil
+}
+
+func copyRuntimeStatePrefix(ctx context.Context, src, dst jetstream.KeyValue, oldPrefix, newPrefix string) (copied, skipped int, err error) {
 	lister, err := src.ListKeysFiltered(ctx, oldPrefix+">")
 	if err != nil {
 		if errors.Is(err, jetstream.ErrNoKeysFound) {

--- a/cli/internal/migrations/read_markers_runtime_state_test.go
+++ b/cli/internal/migrations/read_markers_runtime_state_test.go
@@ -64,6 +64,53 @@ func TestMigrateReadMarkersToRuntimeState_DoesNotOverwriteRuntimeState(t *testin
 	}
 }
 
+func TestMigrateThreadFollowsToRuntimeState(t *testing.T) {
+	ctx, legacy, runtimeState := setupReadMarkerMigrationKV(t)
+
+	if _, err := legacy.Put(ctx, "thread_follow.U1.R1.Ethread1", []byte{0x01}); err != nil {
+		t.Fatalf("put legacy follow: %v", err)
+	}
+
+	if err := MigrateThreadFollowsToRuntimeState(ctx, legacy, runtimeState, testLogger()); err != nil {
+		t.Fatalf("migrate thread follows: %v", err)
+	}
+
+	entry, err := runtimeState.Get(ctx, "thread_follow.U1.R1.Ethread1")
+	if err != nil {
+		t.Fatalf("get migrated follow: %v", err)
+	}
+	if got := entry.Value(); string(got) != string([]byte{0x01}) {
+		t.Fatalf("thread follow bytes = %v, want [1]", got)
+	}
+
+	if _, err := legacy.Get(ctx, "thread_follow.U1.R1.Ethread1"); err != nil {
+		t.Fatalf("legacy follow should be retained for rollback: %v", err)
+	}
+}
+
+func TestMigrateThreadFollowsToRuntimeState_DoesNotOverwriteRuntimeState(t *testing.T) {
+	ctx, legacy, runtimeState := setupReadMarkerMigrationKV(t)
+
+	if _, err := legacy.Put(ctx, "thread_follow.U1.R1.Ethread1", []byte{0x01}); err != nil {
+		t.Fatalf("put legacy follow: %v", err)
+	}
+	if _, err := runtimeState.Put(ctx, "thread_follow.U1.R1.Ethread1", []byte{0x02}); err != nil {
+		t.Fatalf("put runtime follow: %v", err)
+	}
+
+	if err := MigrateThreadFollowsToRuntimeState(ctx, legacy, runtimeState, testLogger()); err != nil {
+		t.Fatalf("migrate thread follows: %v", err)
+	}
+
+	entry, err := runtimeState.Get(ctx, "thread_follow.U1.R1.Ethread1")
+	if err != nil {
+		t.Fatalf("get runtime follow: %v", err)
+	}
+	if got := entry.Value(); string(got) != string([]byte{0x02}) {
+		t.Fatalf("runtime follow bytes = %v, want [2]", got)
+	}
+}
+
 func setupReadMarkerMigrationKV(t *testing.T) (context.Context, jetstream.KeyValue, jetstream.KeyValue) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- Move thread follow state reads and writes from legacy SERVER_RUNTIME to RUNTIME_STATE.
- Add a boot migration that copies existing thread_follow.* keys into RUNTIME_STATE without overwriting newer values.
- Move asset/video ES migration sentinels to RUNTIME_STATE while honoring legacy SERVER_RUNTIME sentinels during rollout.

## Tests
- mise x -- go test ./internal/migrations ./internal/core -count=1 -timeout 300s