### PR TITLE
refactor: store push subscriptions in runtime state

### DIFF
--- a/cli/internal/core/push.go
+++ b/cli/internal/core/push.go
@@ -64,7 +64,7 @@ func (c *ChattoCore) SavePushSubscription(
 	}
 
 	key := pushSubscriptionKey(userID, endpoint)
-	_, err = c.storage.serverKV.Put(ctx, key, data)
+	_, err = c.storage.runtimeStateKV.Put(ctx, key, data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to store push subscription: %w", err)
 	}
@@ -81,7 +81,7 @@ func (c *ChattoCore) SavePushSubscription(
 func (c *ChattoCore) DeletePushSubscription(ctx context.Context, userID, endpoint string) error {
 	key := pushSubscriptionKey(userID, endpoint)
 
-	err := c.storage.serverKV.Delete(ctx, key)
+	err := c.storage.runtimeStateKV.Delete(ctx, key)
 	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
 		return fmt.Errorf("failed to delete push subscription: %w", err)
 	}
@@ -97,7 +97,7 @@ func (c *ChattoCore) DeletePushSubscription(ctx context.Context, userID, endpoin
 // Authorization: Caller must verify userID matches authenticated user.
 func (c *ChattoCore) GetUserPushSubscriptions(ctx context.Context, userID string) ([]*corev1.PushSubscription, error) {
 	prefix := pushSubscriptionKeyFilter(userID)
-	lister, err := c.storage.serverKV.ListKeysFiltered(ctx, prefix)
+	lister, err := c.storage.runtimeStateKV.ListKeysFiltered(ctx, prefix)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrNoKeysFound) {
 			return []*corev1.PushSubscription{}, nil
@@ -107,7 +107,7 @@ func (c *ChattoCore) GetUserPushSubscriptions(ctx context.Context, userID string
 
 	var subscriptions []*corev1.PushSubscription
 	for key := range lister.Keys() {
-		entry, err := c.storage.serverKV.Get(ctx, key)
+		entry, err := c.storage.runtimeStateKV.Get(ctx, key)
 		if err != nil {
 			c.logger.Warn("Failed to get push subscription", "key", key, "error", err)
 			continue
@@ -129,7 +129,7 @@ func (c *ChattoCore) GetUserPushSubscriptions(ctx context.Context, userID string
 // Authorization: Internal use only - called from user deletion flow.
 func (c *ChattoCore) DeleteAllUserPushSubscriptions(ctx context.Context, userID string) (int, error) {
 	prefix := pushSubscriptionKeyFilter(userID)
-	lister, err := c.storage.serverKV.ListKeysFiltered(ctx, prefix)
+	lister, err := c.storage.runtimeStateKV.ListKeysFiltered(ctx, prefix)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrNoKeysFound) {
 			return 0, nil
@@ -145,7 +145,7 @@ func (c *ChattoCore) DeleteAllUserPushSubscriptions(ctx context.Context, userID 
 
 	deleted := 0
 	for _, key := range keys {
-		if err := c.storage.serverKV.Delete(ctx, key); err != nil {
+		if err := c.storage.runtimeStateKV.Delete(ctx, key); err != nil {
 			if !errors.Is(err, jetstream.ErrKeyNotFound) {
 				c.logger.Warn("Failed to delete push subscription", "key", key, "error", err)
 			}
@@ -167,8 +167,8 @@ func (c *ChattoCore) DeleteAllUserPushSubscriptions(ctx context.Context, userID 
 // NOTE: Currently unused. Reserved for future admin dashboard feature to list
 // all push subscriptions for monitoring/debugging purposes.
 func (c *ChattoCore) GetAllPushSubscriptions(ctx context.Context) ([]*PushSubscriptionWithUser, error) {
-	prefix := "push_subscription.*"
-	lister, err := c.storage.serverKV.ListKeysFiltered(ctx, prefix)
+	prefix := "push_subscription.>"
+	lister, err := c.storage.runtimeStateKV.ListKeysFiltered(ctx, prefix)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrNoKeysFound) {
 			return []*PushSubscriptionWithUser{}, nil
@@ -178,7 +178,7 @@ func (c *ChattoCore) GetAllPushSubscriptions(ctx context.Context) ([]*PushSubscr
 
 	var subscriptions []*PushSubscriptionWithUser
 	for key := range lister.Keys() {
-		entry, err := c.storage.serverKV.Get(ctx, key)
+		entry, err := c.storage.runtimeStateKV.Get(ctx, key)
 		if err != nil {
 			c.logger.Warn("Failed to get push subscription", "key", key, "error", err)
 			continue

--- a/cli/internal/core/push_test.go
+++ b/cli/internal/core/push_test.go
@@ -2,7 +2,10 @@ package core
 
 import (
 	"context"
+	"errors"
 	"testing"
+
+	"github.com/nats-io/nats.go/jetstream"
 )
 
 func TestPushSubscriptionKey(t *testing.T) {
@@ -131,6 +134,14 @@ func TestSavePushSubscription(t *testing.T) {
 		if sub.CreatedAt == nil {
 			t.Error("Expected CreatedAt to be set")
 		}
+
+		key := pushSubscriptionKey(userID, endpoint)
+		if _, err := core.storage.runtimeStateKV.Get(ctx, key); err != nil {
+			t.Fatalf("expected push subscription in RUNTIME_STATE: %v", err)
+		}
+		if _, err := core.storage.serverKV.Get(ctx, key); !errors.Is(err, jetstream.ErrKeyNotFound) {
+			t.Fatalf("legacy INSTANCE push subscription lookup error = %v, want ErrKeyNotFound", err)
+		}
 	})
 
 	t.Run("updates existing subscription with same endpoint", func(t *testing.T) {
@@ -149,6 +160,33 @@ func TestSavePushSubscription(t *testing.T) {
 			t.Errorf("Expected 1 subscription after update, got %d", len(subs))
 		}
 	})
+}
+
+func TestGetAllPushSubscriptions(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := context.Background()
+
+	_, err := core.SavePushSubscription(ctx, "push-user-all-a", "https://push.example.com/all-a", "key", "auth", "browser-a")
+	if err != nil {
+		t.Fatalf("SavePushSubscription user A error: %v", err)
+	}
+	_, err = core.SavePushSubscription(ctx, "push-user-all-b", "https://push.example.com/all-b", "key", "auth", "browser-b")
+	if err != nil {
+		t.Fatalf("SavePushSubscription user B error: %v", err)
+	}
+
+	subs, err := core.GetAllPushSubscriptions(ctx)
+	if err != nil {
+		t.Fatalf("GetAllPushSubscriptions error: %v", err)
+	}
+
+	seen := map[string]bool{}
+	for _, sub := range subs {
+		seen[sub.UserID] = true
+	}
+	if !seen["push-user-all-a"] || !seen["push-user-all-b"] {
+		t.Fatalf("GetAllPushSubscriptions missing users; got %#v", seen)
+	}
 }
 
 func TestGetUserPushSubscriptions(t *testing.T) {

--- a/cli/internal/migrations/migrations.go
+++ b/cli/internal/migrations/migrations.go
@@ -58,7 +58,7 @@ import (
 //   - `runtimeConfigKV`: INSTANCE_CONFIG (operator-editable server
 //     settings — name, MOTD, blocked usernames, etc.).
 //   - `runtimeStateKV`: RUNTIME_STATE (persisted latest-value runtime/user
-//     state such as read markers and thread follows).
+//     state such as read markers, thread follows, and push subscriptions).
 //   - `serverReactionsKV`: SERVER_REACTIONS (legacy current reaction
 //     state; retained until reaction ES migration cleanup).
 //
@@ -91,6 +91,9 @@ func RunAll(
 	}
 	if err := MigrateThreadFollowsToRuntimeState(ctx, serverRuntimeKV, runtimeStateKV, logger); err != nil {
 		return fmt.Errorf("thread_follows_runtime_state: %w", err)
+	}
+	if err := MigratePushSubscriptionsToRuntimeState(ctx, serverKV, runtimeStateKV, logger); err != nil {
+		return fmt.Errorf("push_subscriptions_runtime_state: %w", err)
 	}
 	// Room metadata + memberships share the evt.room.{R} subject and
 	// must seed together — a RoomCreatedEvent first, then the

--- a/cli/internal/migrations/push_subscriptions_runtime_state.go
+++ b/cli/internal/migrations/push_subscriptions_runtime_state.go
@@ -1,0 +1,34 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/charmbracelet/log"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+const legacyPushSubscriptionPrefix = "push_subscription."
+
+// MigratePushSubscriptionsToRuntimeState copies Web Push subscription records
+// from the legacy INSTANCE bucket into RUNTIME_STATE.
+//
+// Legacy and new keys use the same shape:
+//
+//	push_subscription.{userId}.{endpointHash}
+//
+// The old keys are intentionally retained for rollback and phase-7 cleanup.
+// Destination writes use Create so this migration never overwrites newer
+// RUNTIME_STATE subscriptions written by a previous boot or a live process.
+func MigratePushSubscriptionsToRuntimeState(ctx context.Context, serverKV, runtimeState jetstream.KeyValue, logger *log.Logger) error {
+	copied, skipped, err := copyRuntimeStatePrefix(ctx, serverKV, runtimeState, legacyPushSubscriptionPrefix, legacyPushSubscriptionPrefix)
+	if err != nil {
+		return fmt.Errorf("push subscriptions: %w", err)
+	}
+	if copied+skipped > 0 {
+		logger.Info("push subscription migration: copied legacy subscriptions into RUNTIME_STATE",
+			"copied", copied,
+			"skipped", skipped)
+	}
+	return nil
+}

--- a/cli/internal/migrations/push_subscriptions_runtime_state_test.go
+++ b/cli/internal/migrations/push_subscriptions_runtime_state_test.go
@@ -1,0 +1,125 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+	"hmans.de/chatto/internal/testutil"
+)
+
+func TestMigratePushSubscriptionsToRuntimeState(t *testing.T) {
+	ctx, legacy, runtimeState := setupPushSubscriptionMigrationKV(t)
+	subscription := &corev1.PushSubscription{
+		Endpoint:  "https://push.example.com/device1",
+		P256Dh:    "p256dh-key",
+		Auth:      "auth-secret",
+		CreatedAt: timestamppb.Now(),
+		UserAgent: "TestBrowser/1.0",
+	}
+	data, err := proto.Marshal(subscription)
+	if err != nil {
+		t.Fatalf("marshal subscription: %v", err)
+	}
+
+	if _, err := legacy.Put(ctx, "push_subscription.U1.abc123", data); err != nil {
+		t.Fatalf("put legacy subscription: %v", err)
+	}
+
+	if err := MigratePushSubscriptionsToRuntimeState(ctx, legacy, runtimeState, testLogger()); err != nil {
+		t.Fatalf("migrate push subscriptions: %v", err)
+	}
+
+	entry, err := runtimeState.Get(ctx, "push_subscription.U1.abc123")
+	if err != nil {
+		t.Fatalf("get migrated subscription: %v", err)
+	}
+	var migrated corev1.PushSubscription
+	if err := proto.Unmarshal(entry.Value(), &migrated); err != nil {
+		t.Fatalf("unmarshal migrated subscription: %v", err)
+	}
+	if migrated.GetEndpoint() != subscription.GetEndpoint() ||
+		migrated.GetP256Dh() != subscription.GetP256Dh() ||
+		migrated.GetAuth() != subscription.GetAuth() ||
+		migrated.GetUserAgent() != subscription.GetUserAgent() {
+		t.Fatalf("migrated subscription = %+v, want %+v", &migrated, subscription)
+	}
+
+	if _, err := legacy.Get(ctx, "push_subscription.U1.abc123"); err != nil {
+		t.Fatalf("legacy subscription should be retained for rollback: %v", err)
+	}
+}
+
+func TestMigratePushSubscriptionsToRuntimeState_DoesNotOverwriteRuntimeState(t *testing.T) {
+	ctx, legacy, runtimeState := setupPushSubscriptionMigrationKV(t)
+
+	legacySub := &corev1.PushSubscription{Endpoint: "https://push.example.com/legacy", P256Dh: "legacy-key", Auth: "legacy-auth"}
+	runtimeSub := &corev1.PushSubscription{Endpoint: "https://push.example.com/runtime", P256Dh: "runtime-key", Auth: "runtime-auth"}
+	legacyData, err := proto.Marshal(legacySub)
+	if err != nil {
+		t.Fatalf("marshal legacy subscription: %v", err)
+	}
+	runtimeData, err := proto.Marshal(runtimeSub)
+	if err != nil {
+		t.Fatalf("marshal runtime subscription: %v", err)
+	}
+
+	if _, err := legacy.Put(ctx, "push_subscription.U1.abc123", legacyData); err != nil {
+		t.Fatalf("put legacy subscription: %v", err)
+	}
+	if _, err := runtimeState.Put(ctx, "push_subscription.U1.abc123", runtimeData); err != nil {
+		t.Fatalf("put runtime subscription: %v", err)
+	}
+
+	if err := MigratePushSubscriptionsToRuntimeState(ctx, legacy, runtimeState, testLogger()); err != nil {
+		t.Fatalf("migrate push subscriptions: %v", err)
+	}
+
+	entry, err := runtimeState.Get(ctx, "push_subscription.U1.abc123")
+	if err != nil {
+		t.Fatalf("get runtime subscription: %v", err)
+	}
+	var got corev1.PushSubscription
+	if err := proto.Unmarshal(entry.Value(), &got); err != nil {
+		t.Fatalf("unmarshal runtime subscription: %v", err)
+	}
+	if got.GetEndpoint() != runtimeSub.GetEndpoint() {
+		t.Fatalf("runtime endpoint = %q, want %q", got.GetEndpoint(), runtimeSub.GetEndpoint())
+	}
+}
+
+func setupPushSubscriptionMigrationKV(t *testing.T) (context.Context, jetstream.KeyValue, jetstream.KeyValue) {
+	t.Helper()
+
+	_, nc := testutil.StartNATS(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatalf("jetstream: %v", err)
+	}
+
+	legacy, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:  "INSTANCE",
+		Storage: jetstream.MemoryStorage,
+	})
+	if err != nil {
+		t.Fatalf("create legacy KV: %v", err)
+	}
+	runtimeState, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:  "RUNTIME_STATE",
+		Storage: jetstream.MemoryStorage,
+		History: 1,
+	})
+	if err != nil {
+		t.Fatalf("create runtime state KV: %v", err)
+	}
+	return ctx, legacy, runtimeState
+}

--- a/cli/internal/pb/chatto/core/v1/push.pb.go
+++ b/cli/internal/pb/chatto/core/v1/push.pb.go
@@ -24,7 +24,7 @@ const (
 
 // PushSubscription stores the Web Push subscription data for a user's browser.
 //
-// Subscriptions are stored in the INSTANCE KV bucket with key format:
+// Subscriptions are stored in the RUNTIME_STATE KV bucket with key format:
 // push_subscription.{userId}.{subscriptionHash}
 //
 // The subscriptionHash is derived from the endpoint URL to allow multiple

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -259,7 +259,7 @@ There is no `adminAuditLogEvents` subscription — audit events arrive through `
 | KV      | `INSTANCE_CONFIG`             | Legacy server configuration import source   |
 | KV      | `USER_PRESENCE`               | Presence status (memory, TTL 60s)           |
 | KV      | `AUTH_TOKENS`                 | Legacy bearer auth tokens pending `RUNTIME_STATE` migration |
-| KV      | `RUNTIME_STATE`               | Persisted latest-value runtime/user state, including pending notifications |
+| KV      | `RUNTIME_STATE`               | Persisted latest-value runtime/user state, including pending notifications and push subscriptions |
 | KV      | `SERVER_CONFIG`               | Rooms (channel + DM), memberships           |
 | KV      | `SERVER_RBAC`                 | Legacy RBAC seed data read by the `EVT` boot migration |
 | KV      | `SERVER_RUNTIME`              | Legacy runtime state pending cleanup        |
@@ -467,7 +467,7 @@ The unified `myEvents` GraphQL subscription is backed by a single core stream (`
 | ----------------------------- | ------- | -------- | ----------------------------------------------- |
 | `INSTANCE`                    | File    | Yes      | Users, memberships (bucket name retained from pre-rename) |
 | `INSTANCE_CONFIG`             | File    | Yes      | Legacy server configuration import source       |
-| `RUNTIME_STATE`               | File    | Yes      | Persisted latest-value runtime/user state, including pending notifications |
+| `RUNTIME_STATE`               | File    | Yes      | Persisted latest-value runtime/user state, including pending notifications and push subscriptions |
 | `SERVER_CONFIG`               | File    | Yes      | Rooms (channel + DM), memberships               |
 | `SERVER_RBAC`                 | File    | Yes      | Legacy RBAC seed data read by the `EVT` boot migration |
 | `SERVER_RUNTIME`              | File    | Yes      | Legacy runtime state pending cleanup            |
@@ -580,6 +580,7 @@ survives restart but is not content/domain history. See
 | `read.room.{userId}.{roomId}`          | Last-read root message event ID (UTF-8 string, ~14 bytes). Empty value = "joined but no specific event read yet" (e.g. joined an empty room). Missing key triggers a one-time lazy init to the room's current last event ("caught up at first read post-deploy"). Legacy `SERVER_RUNTIME` `room_read_event.*` keys are copied here at boot; older `room_read_status.*` sequence keys are orphaned and ignored. |
 | `read.thread.{userId}.{roomId}.{threadRootEventId}` | Latest thread message event ID the user has seen. Values copied from legacy `thread_last_opened.*` may be 8-byte UnixNano timestamps until rewritten by a new read action. |
 | `notification.{userId}.{notificationId}` | Pending notification record (protobuf `Notification`) for DM messages, @mentions, replies, and all-message subscriptions. Uses per-key 90-day TTL. Live sync uses `NotificationCreatedEvent` / `NotificationDismissedEvent` on `live.sync.user.{userId}.*`. |
+| `push_subscription.{userId}.{endpointHash}` | Web Push subscription record (protobuf `PushSubscription`) for a user's browser/device. Legacy `INSTANCE` keys are copied here at boot; the endpoint hash keeps multiple devices per user while deduplicating the same browser subscription. |
 
 **SERVER\_RUNTIME keys:**
 

--- a/docs/adr/ADR-036-runtime-state-kv-boundary.md
+++ b/docs/adr/ADR-036-runtime-state-kv-boundary.md
@@ -56,6 +56,7 @@ Initial and planned occupants include:
 - Thread read cursors: `read.thread.{userId}.{roomId}.{threadRootEventId}`.
 - Pending notifications: `notification.{userId}.{notificationId}`, with per-key
   90-day TTL.
+- Web Push subscriptions: `push_subscription.{userId}.{endpointHash}`.
 - Auth, verification, reset, and revocation tokens after their migration from
   token-specific buckets.
 

--- a/docs/fdr/FDR-013-web-push-notifications.md
+++ b/docs/fdr/FDR-013-web-push-notifications.md
@@ -1,7 +1,7 @@
 # FDR-013: Web Push Notifications
 
 **Status:** Active
-**Last reviewed:** 2026-05-19
+**Last reviewed:** 2026-05-31
 
 ## Overview
 
@@ -29,7 +29,7 @@ Users can opt in to receive notifications through the browser's W3C Web Push sys
 
 ### 2. Per-device subscriptions, identified by endpoint hash
 
-**Decision:** Each browser subscription is stored as its own record, identified by a hash of the push endpoint URL.
+**Decision:** Each browser subscription is stored in `RUNTIME_STATE` as its own record, identified by a hash of the push endpoint URL.
 **Why:** The same user might be subscribed from a laptop and a phone, and pushing to both is the expected behavior. Hashing the endpoint URL avoids storing the raw URL as a key (which can be long and contains provider-specific structure).
 **Tradeoff:** No de-duplication if a single device somehow ends up with two subscriptions. Browsers don't typically allow that, so it's a non-issue in practice.
 

--- a/proto/chatto/core/v1/push.proto
+++ b/proto/chatto/core/v1/push.proto
@@ -9,7 +9,7 @@ option go_package = "hmans.de/chatto/internal/pb/chatto/core/v1;corev1";
 /*
    PushSubscription stores the Web Push subscription data for a user's browser.
 
-   Subscriptions are stored in the INSTANCE KV bucket with key format:
+   Subscriptions are stored in the RUNTIME_STATE KV bucket with key format:
    push_subscription.{userId}.{subscriptionHash}
 
    The subscriptionHash is derived from the endpoint URL to allow multiple
@@ -31,4 +31,3 @@ message PushSubscription {
   // User agent string (for debugging/device identification)
   string user_agent = 5;
 }
-


### PR DESCRIPTION
- Move Web Push subscription reads, writes, and deletes from INSTANCE to RUNTIME_STATE.\n- Add a boot migration that copies legacy push_subscription.* keys into RUNTIME_STATE without overwriting newer runtime-state values.\n- Add migration/core tests, including coverage for the all-subscriptions key filter.\n- Update ARCHITECTURE, ADR-036, FDR-013, and push proto comments to document the new runtime-state home.\n\nTests: mise x -- go test ./internal/migrations ./internal/core -count=1 -timeout 300s