### PR TITLE
feat: hmac runtime token storage

### DIFF
--- a/cli/chatto.toml
+++ b/cli/chatto.toml
@@ -9,6 +9,9 @@ port = 4000
 allowed_origins = []
 cookie_signing_secret = '3ad5f5f911b6865b1a729335f4544d102a99a2847a3d5076431ed43877dd6bd9'
 
+[core]
+secret_key = '7f3e0d39031f4ee7e2078aafc785f1969b8f1d4a4ea178a4732cb2096fe7f3bb'
+
 [core.assets]
 signing_secret = 'd4fac8f5c710d419dbb05c00381ca1d0fbbeb007d8da4367d00cbfa212758fc1'
 max_upload_size = '25MB'

--- a/cli/cmd/backup.go
+++ b/cli/cmd/backup.go
@@ -75,7 +75,6 @@ Excluded from backups by default:
 - User presence (ephemeral, memory-only)
 - Link preview cache (regeneratable)
 - Asset cache (regeneratable)
-- Auth tokens (security: prevents token leakage via backups)
 
 Pass --include-keys to include KV_ENCRYPTION_KEYS in the archive. This
 makes the backup self-contained (encrypted message bodies become

--- a/cli/cmd/bootstrap_test.go
+++ b/cli/cmd/bootstrap_test.go
@@ -22,7 +22,10 @@ func setupCore(t *testing.T) *core.ChattoCore {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)
 
-	cfg := config.CoreConfig{Assets: config.AssetsConfig{SigningSecret: "test-secret"}}
+	cfg := config.CoreConfig{
+		SecretKey: "test-core-secret",
+		Assets:    config.AssetsConfig{SigningSecret: "test-secret"},
+	}
 	c, err := core.NewChattoCore(ctx, nc, cfg)
 	if err != nil {
 		t.Fatalf("new core: %v", err)

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -53,6 +53,13 @@ var initCmd = &cobra.Command{
 		}
 		signingSecretString := hex.EncodeToString(signingSecret)
 
+		// Generate a random server-wide core secret for token verifiers.
+		coreSecret := make([]byte, 32)
+		if _, err := rand.Read(coreSecret); err != nil {
+			log.Fatal("Failed to generate core secret", "error", err)
+		}
+		coreSecretString := hex.EncodeToString(coreSecret)
+
 		// Generate a random auth token for NATS connections (32 bytes = 256 bits)
 		authToken := make([]byte, 32)
 		if _, err := rand.Read(authToken); err != nil {
@@ -80,6 +87,7 @@ var initCmd = &cobra.Command{
 				CookieEncryptionSecret: cookieEncryptionSecretString,
 			},
 			Core: config.CoreConfig{
+				SecretKey: coreSecretString,
 				Assets: config.AssetsConfig{
 					SigningSecret: signingSecretString,
 					MaxUploadSize: 25 * datasize.MB,

--- a/cli/cmd/init_test.go
+++ b/cli/cmd/init_test.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"hmans.de/chatto/internal/config"
+)
+
+func TestInitGeneratesCoreSecret(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("change working directory: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(originalDir) })
+
+	originalConfigFile := initConfigFile
+	initConfigFile = ""
+	t.Cleanup(func() { initConfigFile = originalConfigFile })
+
+	initCmd.Run(initCmd, nil)
+
+	cfg, err := config.ReadConfig(filepath.Join(tmpDir, "chatto.toml"))
+	if err != nil {
+		t.Fatalf("read generated config: %v", err)
+	}
+	if len(cfg.Core.SecretKey) != 64 {
+		t.Fatalf("generated core secret length = %d, want 64", len(cfg.Core.SecretKey))
+	}
+	if _, err := hex.DecodeString(cfg.Core.SecretKey); err != nil {
+		t.Fatalf("generated core secret should be hex: %v", err)
+	}
+}

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -159,6 +159,7 @@ type AssetsConfig struct {
 
 // CoreConfig contains settings for the Chatto core service.
 type CoreConfig struct {
+	SecretKey    string        `toml:"secret_key" env:"CHATTO_CORE_SECRET_KEY" comment:"Server-wide secret for deriving HMAC verifiers for bearer tokens and account-flow links. NEVER SHARE THIS!\nIf it changes, existing bearer tokens and pending registration, verification, password reset, account deletion, and OAuth authorization-code links become invalid."`
 	Assets       AssetsConfig  `toml:"assets"`
 	ESBootVerify bool          `toml:"es_boot_verify,commented" env:"CHATTO_CORE_ES_BOOT_VERIFY" comment:"Log event-sourcing import/projection verification during boot. Intended for local rollout dry-runs; scans EVT and legacy stores."`
 	AuthTokenTTL time.Duration `toml:"-" env:"-"` // Set by caller from AuthConfig.TokenTTLOrDefault()
@@ -396,7 +397,7 @@ type LiveKitConfig struct {
 	APIKey           string `toml:"api_key" env:"CHATTO_LIVEKIT_API_KEY" comment:"LiveKit API key."`
 	APISecret        string `toml:"api_secret" env:"CHATTO_LIVEKIT_API_SECRET" comment:"LiveKit API secret. NEVER SHARE THIS!"`
 	WebhookURL       string `toml:"webhook_url" env:"CHATTO_LIVEKIT_WEBHOOK_URL" comment:"URL where LiveKit sends webhook events. Defaults to {webserver.url}/webhooks/livekit."`
-	ServerID       string `toml:"instance_id,commented" env:"CHATTO_LIVEKIT_INSTANCE_ID" comment:"Unique identifier for this instance, prefixed to LiveKit room names. Required when multiple Chatto instances share the same LiveKit cluster."`
+	ServerID         string `toml:"instance_id,commented" env:"CHATTO_LIVEKIT_INSTANCE_ID" comment:"Unique identifier for this instance, prefixed to LiveKit room names. Required when multiple Chatto instances share the same LiveKit cluster."`
 	WebhookAPIKey    string `toml:"webhook_api_key,commented" env:"CHATTO_LIVEKIT_WEBHOOK_API_KEY" comment:"API key LiveKit uses to sign webhooks. Falls back to api_key if not set. Required when the webhook signing key differs from the per-instance API key."`
 	WebhookAPISecret string `toml:"webhook_api_secret,commented" env:"CHATTO_LIVEKIT_WEBHOOK_API_SECRET" comment:"API secret for webhook signature validation. Falls back to api_secret if not set."`
 }
@@ -423,17 +424,17 @@ func (c *LiveKitConfig) IsConfigured() bool {
 // binaries parse the section but ignore its contents. Plaintext passwords
 // are fine here for the same reason.
 type BootstrapConfig struct {
-	Users    []BootstrapUser    `toml:"users"`
+	Users  []BootstrapUser  `toml:"users"`
 	Server *BootstrapServer `toml:"instance,commented" comment:"Seeds the server config (name) and the deployment's primary room group on first boot."`
 }
 
 // BootstrapUser describes a user to create on startup in bootstrap-tag builds.
 type BootstrapUser struct {
-	Login        string `toml:"login" comment:"Required. The user's login (username)."`
-	DisplayName  string `toml:"display_name,commented" comment:"Defaults to Login if empty."`
-	Email        string `toml:"email,commented" comment:"Optional. If set, added as a verified email."`
-	Password     string `toml:"password,commented" comment:"Optional. Required to log in via password; safe in plaintext because bootstrap-tag builds only."`
-	ServerRole string `toml:"instance_role,commented" comment:"Optional: owner | admin | moderator."`
+	Login       string `toml:"login" comment:"Required. The user's login (username)."`
+	DisplayName string `toml:"display_name,commented" comment:"Defaults to Login if empty."`
+	Email       string `toml:"email,commented" comment:"Optional. If set, added as a verified email."`
+	Password    string `toml:"password,commented" comment:"Optional. Required to log in via password; safe in plaintext because bootstrap-tag builds only."`
+	ServerRole  string `toml:"instance_role,commented" comment:"Optional: owner | admin | moderator."`
 }
 
 // BootstrapServer describes the instance to seed on startup in bootstrap-tag
@@ -447,18 +448,18 @@ type BootstrapServer struct {
 }
 
 type ChattoConfig struct {
-	General      GeneralConfig      `toml:"general"`
-	Webserver    WebserverConfig    `toml:"webserver"`
-	Core         CoreConfig         `toml:"core" comment:"Core service configuration."`
-	Auth         AuthConfig         `toml:"auth" comment:"Authentication configuration."`
-	Owners       OwnersConfig       `toml:"owners" comment:"Email addresses that confer owner status."`
-	Limits       LimitsConfig       `toml:"limits,commented" comment:"Instance-wide resource limits. Use -1 for unlimited."`
-	SMTP         SMTPConfig         `toml:"smtp" comment:"SMTP configuration for transactional emails."`
-	Push         PushConfig         `toml:"push,commented" comment:"Web Push notification configuration."`
-	Video        VideoConfig        `toml:"video,commented" comment:"Video processing configuration. Requires ffmpeg."`
-	LiveKit      LiveKitConfig      `toml:"livekit,commented" comment:"LiveKit voice call configuration."`
-	NATS         NATSConfig         `toml:"nats"`
-	Bootstrap    BootstrapConfig    `toml:"bootstrap,commented" comment:"Dev/E2E-only: users and spaces auto-created on startup. ONLY honored by builds compiled with the 'bootstrap' build tag; release binaries ignore this section entirely."`
+	General   GeneralConfig   `toml:"general"`
+	Webserver WebserverConfig `toml:"webserver"`
+	Core      CoreConfig      `toml:"core" comment:"Core service configuration."`
+	Auth      AuthConfig      `toml:"auth" comment:"Authentication configuration."`
+	Owners    OwnersConfig    `toml:"owners" comment:"Email addresses that confer owner status."`
+	Limits    LimitsConfig    `toml:"limits,commented" comment:"Instance-wide resource limits. Use -1 for unlimited."`
+	SMTP      SMTPConfig      `toml:"smtp" comment:"SMTP configuration for transactional emails."`
+	Push      PushConfig      `toml:"push,commented" comment:"Web Push notification configuration."`
+	Video     VideoConfig     `toml:"video,commented" comment:"Video processing configuration. Requires ffmpeg."`
+	LiveKit   LiveKitConfig   `toml:"livekit,commented" comment:"LiveKit voice call configuration."`
+	NATS      NATSConfig      `toml:"nats"`
+	Bootstrap BootstrapConfig `toml:"bootstrap,commented" comment:"Dev/E2E-only: users and spaces auto-created on startup. ONLY honored by builds compiled with the 'bootstrap' build tag; release binaries ignore this section entirely."`
 }
 
 // Validate checks the configuration for errors and returns a descriptive error if any are found.
@@ -471,6 +472,9 @@ func (c *ChattoConfig) Validate() error {
 	}
 	if c.Core.Assets.SigningSecret == "" {
 		errs = append(errs, "core.assets.signing_secret is required")
+	}
+	if c.Core.SecretKey == "" {
+		errs = append(errs, "core.secret_key is required")
 	}
 
 	// Port ranges (port 0 is allowed when TLS is enabled, as it defaults to 443)

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -23,6 +23,7 @@ func TestReadConfig_WithoutConfigFile(t *testing.T) {
 	// Set required env vars
 	t.Setenv("CHATTO_WEBSERVER_PORT", "4000")
 	t.Setenv("CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET", "test-cookie-secret")
+	t.Setenv("CHATTO_CORE_SECRET_KEY", "test-core-secret")
 	t.Setenv("CHATTO_CORE_ASSETS_SIGNING_SECRET", "test-assets-secret")
 
 	// ReadConfig should succeed even without chatto.toml
@@ -37,6 +38,9 @@ func TestReadConfig_WithoutConfigFile(t *testing.T) {
 	}
 	if cfg.Webserver.CookieSigningSecret != "test-cookie-secret" {
 		t.Errorf("expected cookie secret to be set from env var")
+	}
+	if cfg.Core.SecretKey != "test-core-secret" {
+		t.Errorf("expected core secret to be set from env var")
 	}
 }
 
@@ -57,6 +61,9 @@ func TestReadConfig_WithConfigFile(t *testing.T) {
 [webserver]
 port = 5000
 cookie_signing_secret = "file-cookie-secret"
+
+[core]
+secret_key = "file-core-secret"
 
 [core.assets]
 signing_secret = "file-assets-secret"
@@ -94,6 +101,9 @@ func TestReadConfig_EnvOverridesFile(t *testing.T) {
 [webserver]
 port = 5000
 cookie_signing_secret = "file-cookie-secret"
+
+[core]
+secret_key = "file-core-secret"
 
 [core.assets]
 signing_secret = "file-assets-secret"
@@ -259,6 +269,55 @@ func intPtr(i int) *int {
 	return &i
 }
 
+func TestChattoConfig_Validate_RequiredSecrets(t *testing.T) {
+	base := ChattoConfig{
+		Webserver: WebserverConfig{Port: 4000, CookieSigningSecret: "web-secret"},
+		Core: CoreConfig{
+			SecretKey: "core-secret",
+			Assets:    AssetsConfig{SigningSecret: "asset-secret"},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		modify   func(*ChattoConfig)
+		errorMsg string
+	}{
+		{
+			name: "missing core secret",
+			modify: func(c *ChattoConfig) {
+				c.Core.SecretKey = ""
+			},
+			errorMsg: "core.secret_key is required",
+		},
+		{
+			name: "missing webserver cookie secret",
+			modify: func(c *ChattoConfig) {
+				c.Webserver.CookieSigningSecret = ""
+			},
+			errorMsg: "webserver.cookie_signing_secret is required",
+		},
+		{
+			name: "missing asset signing secret",
+			modify: func(c *ChattoConfig) {
+				c.Core.Assets.SigningSecret = ""
+			},
+			errorMsg: "core.assets.signing_secret is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := base
+			tt.modify(&cfg)
+			err := cfg.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.errorMsg) {
+				t.Fatalf("Validate() error = %v, want to contain %q", err, tt.errorMsg)
+			}
+		})
+	}
+}
+
 func TestLimitsConfig_Defaults(t *testing.T) {
 	c := &LimitsConfig{}
 	if got := c.MaxUsersOrDefault(); got != -1 {
@@ -290,6 +349,9 @@ func TestReadConfig_LimitsFromTOML(t *testing.T) {
 port = 4000
 cookie_signing_secret = "x"
 
+[core]
+secret_key = "z"
+
 [core.assets]
 signing_secret = "y"
 
@@ -319,6 +381,7 @@ func TestReadConfig_LimitsFromEnv(t *testing.T) {
 
 	t.Setenv("CHATTO_WEBSERVER_PORT", "4000")
 	t.Setenv("CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET", "x")
+	t.Setenv("CHATTO_CORE_SECRET_KEY", "z")
 	t.Setenv("CHATTO_CORE_ASSETS_SIGNING_SECRET", "y")
 	t.Setenv("CHATTO_LIMITS_MAX_USERS", "0")
 
@@ -335,7 +398,7 @@ func TestChattoConfig_Validate_Limits(t *testing.T) {
 	base := func() ChattoConfig {
 		return ChattoConfig{
 			Webserver: WebserverConfig{Port: 4000, CookieSigningSecret: "x"},
-			Core:      CoreConfig{Assets: AssetsConfig{SigningSecret: "y"}},
+			Core:      CoreConfig{SecretKey: "z", Assets: AssetsConfig{SigningSecret: "y"}},
 		}
 	}
 
@@ -366,6 +429,7 @@ func TestChattoConfig_Validate_TLS(t *testing.T) {
 				CookieSigningSecret: "test-secret",
 			},
 			Core: CoreConfig{
+				SecretKey: "test-core-secret",
 				Assets: AssetsConfig{
 					SigningSecret: "test-asset-secret",
 				},
@@ -488,6 +552,7 @@ func TestChattoConfig_Validate_EmbeddedNATS(t *testing.T) {
 				CookieSigningSecret: "test-secret",
 			},
 			Core: CoreConfig{
+				SecretKey: "test-core-secret",
 				Assets: AssetsConfig{
 					SigningSecret: "test-asset-secret",
 				},
@@ -615,6 +680,7 @@ func TestChattoConfig_Validate_SMTP(t *testing.T) {
 				CookieSigningSecret: "test-secret",
 			},
 			Core: CoreConfig{
+				SecretKey: "test-core-secret",
 				Assets: AssetsConfig{
 					SigningSecret: "test-asset-secret",
 				},
@@ -715,6 +781,7 @@ func TestChattoConfig_Validate_S3(t *testing.T) {
 				CookieSigningSecret: "test-secret",
 			},
 			Core: CoreConfig{
+				SecretKey: "test-core-secret",
 				Assets: AssetsConfig{
 					SigningSecret: "test-asset-secret",
 				},
@@ -955,6 +1022,7 @@ func TestChattoConfig_Validate_Push(t *testing.T) {
 				CookieSigningSecret: "test-secret",
 			},
 			Core: CoreConfig{
+				SecretKey: "test-core-secret",
 				Assets: AssetsConfig{
 					SigningSecret: "test-asset-secret",
 				},

--- a/cli/internal/core/attachments_test.go
+++ b/cli/internal/core/attachments_test.go
@@ -801,6 +801,7 @@ func setupTestCoreWithS3(t *testing.T) (*ChattoCore, *nats.Conn, *S3Client) {
 	pathStyle := true
 
 	cfg := config.CoreConfig{
+		SecretKey: "test-core-secret",
 		Assets: config.AssetsConfig{
 			SigningSecret:  "test-signing-secret",
 			StorageBackend: config.StorageBackendS3,
@@ -841,6 +842,7 @@ func setupTestCoreWithCache(t *testing.T) (*ChattoCore, *nats.Conn) {
 
 	// Create ChattoCore with caching enabled
 	cfg := config.CoreConfig{
+		SecretKey: "test-core-secret",
 		Assets: config.AssetsConfig{
 			SigningSecret: "test-signing-secret",
 			Cache: config.AssetsCacheConfig{

--- a/cli/internal/core/auth_audit_test.go
+++ b/cli/internal/core/auth_audit_test.go
@@ -248,7 +248,7 @@ func TestChattoCore_AuditAppendFailureCleansNewRegistrationToken(t *testing.T) {
 	if token != "" {
 		t.Fatalf("expected no token on failure, got %q", token)
 	}
-	count, err := countKVKeys(ctx, core.storage.serverKV, "registration.*")
+	count, err := countKVKeys(ctx, core.storage.runtimeStateKV, "registration.*")
 	if err != nil {
 		t.Fatalf("count registration keys: %v", err)
 	}

--- a/cli/internal/core/auth_codes.go
+++ b/cli/internal/core/auth_codes.go
@@ -35,21 +35,25 @@ var (
 // exchanged within this window are automatically purged by NATS KV per-key TTL.
 const authCodeTTL = 5 * time.Minute
 
-// authCodeKeyPrefix is the KV key prefix that distinguishes authorization codes
-// from bearer tokens in the shared AUTH_TOKENS bucket.
+// authCodeKeyPrefix is the RUNTIME_STATE key prefix that distinguishes
+// authorization codes from bearer tokens.
 const authCodeKeyPrefix = "grant."
+
+func (c *ChattoCore) authCodeKey(code string) string {
+	return c.runtimeTokenKey(authCodeKeyPrefix, code)
+}
 
 // ============================================================================
 // Auth Code Types
 // ============================================================================
 
-// AuthCodeData is the JSON value stored in the AUTH_TOKENS KV bucket for authorization codes.
+// AuthCodeData is the JSON value stored in RUNTIME_STATE for authorization codes.
 type AuthCodeData struct {
-	UserID               string    `json:"user_id"`
-	RedirectURI          string    `json:"redirect_uri"`
-	CodeChallenge        string    `json:"code_challenge"`
-	CodeChallengeMethod  string    `json:"code_challenge_method"`
-	CreatedAt            time.Time `json:"created_at"`
+	UserID              string    `json:"user_id"`
+	RedirectURI         string    `json:"redirect_uri"`
+	CodeChallenge       string    `json:"code_challenge"`
+	CodeChallengeMethod string    `json:"code_challenge_method"`
+	CreatedAt           time.Time `json:"created_at"`
 }
 
 // ============================================================================
@@ -57,7 +61,7 @@ type AuthCodeData struct {
 // ============================================================================
 
 // CreateAuthCode generates a new OAuth authorization code for the given user.
-// The code is stored in the AUTH_TOKENS KV bucket with a "grant." key prefix
+// The code is stored in RUNTIME_STATE with a "grant." key prefix
 // and a 5-minute per-key TTL. The code is single-use — it must be exchanged
 // via ExchangeAuthCode and is deleted on successful exchange.
 func (c *ChattoCore) CreateAuthCode(ctx context.Context, userID, redirectURI, codeChallenge, codeChallengeMethod string) (string, error) {
@@ -78,7 +82,7 @@ func (c *ChattoCore) CreateAuthCode(ctx context.Context, userID, redirectURI, co
 		return "", fmt.Errorf("failed to marshal auth code: %w", err)
 	}
 
-	_, err = c.storage.authTokensKV.Create(ctx, authCodeKeyPrefix+code, data, jetstream.KeyTTL(authCodeTTL))
+	_, err = c.storage.runtimeStateKV.Create(ctx, c.authCodeKey(code), data, jetstream.KeyTTL(authCodeTTL))
 	if err != nil {
 		return "", fmt.Errorf("failed to store auth code: %w", err)
 	}
@@ -94,9 +98,9 @@ func (c *ChattoCore) CreateAuthCode(ctx context.Context, userID, redirectURI, co
 //  2. redirect_uri matches the one used during authorization
 //  3. SHA256(code_verifier) == code_challenge (PKCE S256)
 func (c *ChattoCore) ExchangeAuthCode(ctx context.Context, code, codeVerifier, redirectURI string) (string, string, error) {
-	key := authCodeKeyPrefix + code
+	key := c.authCodeKey(code)
 
-	entry, err := c.storage.authTokensKV.Get(ctx, key)
+	entry, err := c.storage.runtimeStateKV.Get(ctx, key)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return "", "", ErrAuthCodeNotFound
@@ -106,7 +110,7 @@ func (c *ChattoCore) ExchangeAuthCode(ctx context.Context, code, codeVerifier, r
 
 	// Delete immediately (single-use). Even if subsequent validation fails,
 	// the code should not be reusable.
-	_ = c.storage.authTokensKV.Delete(ctx, key)
+	_ = c.storage.runtimeStateKV.Delete(ctx, key)
 
 	var codeData AuthCodeData
 	if err := json.Unmarshal(entry.Value(), &codeData); err != nil {

--- a/cli/internal/core/auth_codes_test.go
+++ b/cli/internal/core/auth_codes_test.go
@@ -30,6 +30,13 @@ func TestChattoCore_CreateAuthCode(t *testing.T) {
 	if len(code) != 20 {
 		t.Errorf("Code length is %d, want 20", len(code))
 	}
+
+	key := core.authCodeKey(code)
+	if _, err := core.storage.runtimeStateKV.Get(ctx, key); err != nil {
+		t.Fatalf("expected auth code in RUNTIME_STATE: %v", err)
+	}
+	assertRuntimeKVHasTTL(t, core, key)
+	assertRawRuntimeTokenKeyAbsent(t, core, authCodeKeyPrefix+code)
 }
 
 func TestChattoCore_ExchangeAuthCode_HappyPath(t *testing.T) {

--- a/cli/internal/core/auth_tokens.go
+++ b/cli/internal/core/auth_tokens.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -26,7 +27,7 @@ const authTokenKeyPrefix = "session."
 // Auth Token Types
 // ============================================================================
 
-// AuthTokenData is the JSON value stored in the AUTH_TOKENS KV bucket.
+// AuthTokenData is the JSON value stored in RUNTIME_STATE for bearer tokens.
 type AuthTokenData struct {
 	UserID    string    `json:"user_id"`
 	CreatedAt time.Time `json:"created_at"`
@@ -36,8 +37,19 @@ type AuthTokenData struct {
 // Auth Token Operations
 // ============================================================================
 
+func (c *ChattoCore) authTokenTTL() time.Duration {
+	if c.config.AuthTokenTTL != 0 {
+		return c.config.AuthTokenTTL
+	}
+	return 90 * 24 * time.Hour
+}
+
+func (c *ChattoCore) authTokenKey(token string) string {
+	return c.runtimeTokenKey(authTokenKeyPrefix, token)
+}
+
 // CreateAuthToken creates a new opaque bearer token for the given user.
-// The token is stored in the AUTH_TOKENS KV bucket and can be used for API authentication.
+// The token is stored in RUNTIME_STATE and can be used for API authentication.
 // Token expiry is handled by NATS KV TTL.
 func (c *ChattoCore) CreateAuthToken(ctx context.Context, userID string) (string, error) {
 	token := NewAuthToken()
@@ -50,7 +62,7 @@ func (c *ChattoCore) CreateAuthToken(ctx context.Context, userID string) (string
 		return "", fmt.Errorf("failed to marshal auth token: %w", err)
 	}
 
-	_, err = c.storage.authTokensKV.Put(ctx, authTokenKeyPrefix+token, data)
+	_, err = c.storage.runtimeStateKV.Create(ctx, c.authTokenKey(token), data, jetstream.KeyTTL(c.authTokenTTL()))
 	if err != nil {
 		return "", fmt.Errorf("failed to store auth token: %w", err)
 	}
@@ -61,20 +73,15 @@ func (c *ChattoCore) CreateAuthToken(ctx context.Context, userID string) (string
 // ValidateAuthToken checks if a bearer token is valid and returns the associated user ID.
 // Returns ErrAuthTokenNotFound if the token doesn't exist (or has expired via NATS TTL).
 //
-// Sliding window: each successful validation re-puts the entry to reset the NATS KV TTL.
+// Sliding window: each successful validation rewrites the entry to reset the NATS KV TTL.
 // This means the token only expires after the configured TTL of *inactivity* — active
 // users are never logged out.
 func (c *ChattoCore) ValidateAuthToken(ctx context.Context, token string) (string, error) {
-	key := authTokenKeyPrefix + token
-	entry, err := c.storage.authTokensKV.Get(ctx, key)
+	key := c.authTokenKey(token)
+	entry, err := c.storage.runtimeStateKV.Get(ctx, key)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			// MIGRATION: Try the legacy unprefixed key for tokens created before
-			// the "session." prefix was added. On success, migrate the token to the
-			// new key format so subsequent validations use the prefixed key.
-			// TODO: Remove this fallback once all active sessions have expired or
-			// after a reasonable migration window (e.g. 2 releases).
-			return c.validateLegacyToken(ctx, token)
+			return "", ErrAuthTokenNotFound
 		}
 		return "", fmt.Errorf("failed to get auth token: %w", err)
 	}
@@ -84,36 +91,9 @@ func (c *ChattoCore) ValidateAuthToken(ctx context.Context, token string) (strin
 		return "", fmt.Errorf("failed to unmarshal auth token: %w", err)
 	}
 
-	// Re-put to reset TTL (sliding window expiry).
+	// Rewrite to reset TTL (sliding window expiry).
 	// Fire-and-forget — validation succeeds even if the re-put fails.
-	_, _ = c.storage.authTokensKV.Put(ctx, key, entry.Value())
-
-	return tokenData.UserID, nil
-}
-
-// validateLegacyToken checks for a token stored under the old unprefixed key format.
-// If found, it migrates the token to the new "session." prefixed key and deletes the old one.
-//
-// MIGRATION: Added when bearer tokens moved from raw keys to "session." prefixed keys.
-// TODO: Remove after all active sessions have naturally expired (controlled by KV TTL).
-func (c *ChattoCore) validateLegacyToken(ctx context.Context, token string) (string, error) {
-	entry, err := c.storage.authTokensKV.Get(ctx, token)
-	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			return "", ErrAuthTokenNotFound
-		}
-		return "", fmt.Errorf("failed to get legacy auth token: %w", err)
-	}
-
-	var tokenData AuthTokenData
-	if err := json.Unmarshal(entry.Value(), &tokenData); err != nil {
-		return "", fmt.Errorf("failed to unmarshal legacy auth token: %w", err)
-	}
-
-	// Migrate: write to new prefixed key and delete the old one.
-	// Both are fire-and-forget — validation succeeds even if migration fails.
-	_, _ = c.storage.authTokensKV.Put(ctx, authTokenKeyPrefix+token, entry.Value())
-	_ = c.storage.authTokensKV.Delete(ctx, token)
+	_, _ = c.updateRuntimeStateTokenTTL(ctx, key, entry.Value(), entry.Revision(), c.authTokenTTL())
 
 	return tokenData.UserID, nil
 }
@@ -121,9 +101,22 @@ func (c *ChattoCore) validateLegacyToken(ctx context.Context, token string) (str
 // RevokeAuthToken deletes a bearer token, immediately invalidating it.
 // This is idempotent — revoking a non-existent token is not an error.
 func (c *ChattoCore) RevokeAuthToken(ctx context.Context, token string) error {
-	err := c.storage.authTokensKV.Delete(ctx, authTokenKeyPrefix+token)
+	err := c.storage.runtimeStateKV.Delete(ctx, c.authTokenKey(token))
 	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
 		return fmt.Errorf("failed to revoke auth token: %w", err)
 	}
 	return nil
+}
+
+func (c *ChattoCore) updateRuntimeStateTokenTTL(ctx context.Context, key string, value []byte, revision uint64, ttl time.Duration) (uint64, error) {
+	msg := nats.NewMsg("$KV.RUNTIME_STATE." + key)
+	msg.Data = value
+	ack, err := c.js.PublishMsg(ctx, msg,
+		jetstream.WithExpectLastSequencePerSubject(revision),
+		jetstream.WithMsgTTL(ttl),
+	)
+	if err != nil {
+		return 0, err
+	}
+	return ack.Sequence, nil
 }

--- a/cli/internal/core/auth_tokens_test.go
+++ b/cli/internal/core/auth_tokens_test.go
@@ -29,6 +29,13 @@ func TestChattoCore_CreateAuthToken(t *testing.T) {
 	if userID != user.Id {
 		t.Errorf("ValidateAuthToken returned userID %q, want %q", userID, user.Id)
 	}
+
+	key := core.authTokenKey(token)
+	if _, err := core.storage.runtimeStateKV.Get(ctx, key); err != nil {
+		t.Fatalf("expected auth token in RUNTIME_STATE: %v", err)
+	}
+	assertRuntimeKVHasTTL(t, core, key)
+	assertRawRuntimeTokenKeyAbsent(t, core, authTokenKeyPrefix+token)
 }
 
 func TestChattoCore_ValidateAuthToken_NotFound(t *testing.T) {

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -800,7 +800,6 @@ type storage struct {
 	presenceKV      jetstream.KeyValue    // Instance-level presence bucket
 	imageCacheStore jetstream.ObjectStore // Optional: cached resized images (nil if disabled)
 	callStateKV     jetstream.KeyValue    // Active voice call participants (ephemeral, memory-backed)
-	authTokensKV    jetstream.KeyValue    // Bearer auth tokens with TTL
 }
 
 // newStorage initializes all JetStream KV buckets and streams.
@@ -808,14 +807,10 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 	// Initialize INSTANCE KV bucket for all server-level data
 	// Uses subject-based keys: user.{userId}, space.{spaceId}, space_membership.{spaceId}.{userId}, etc.
 	serverKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
-		Bucket:      "INSTANCE",
-		Description: "Instance-level data (users, spaces, memberships)",
-		Storage:     jetstream.FileStorage,
-		Replicas:    cfg.Replicas,
-		// Enables per-key TTL via jetstream.KeyTTL(...) on Create. Used for short-lived
-		// entries like registration tokens and email-verification tokens so they leave
-		// the bucket automatically. The duration is how long delete markers from
-		// TTL-expiry are kept before purging.
+		Bucket:         "INSTANCE",
+		Description:    "Instance-level data (users, spaces, memberships)",
+		Storage:        jetstream.FileStorage,
+		Replicas:       cfg.Replicas,
 		LimitMarkerTTL: 24 * time.Hour,
 	})
 	if err != nil {
@@ -1041,25 +1036,6 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		return nil, fmt.Errorf("failed to create EVT stream: %w", err)
 	}
 
-	// Initialize auth tokens KV bucket with configurable TTL
-	// Stores opaque bearer tokens for cross-origin API authentication.
-	// NATS TTL handles automatic token expiry.
-	authTokenTTL := cfg.AuthTokenTTL
-	if authTokenTTL == 0 {
-		authTokenTTL = 90 * 24 * time.Hour // Default 90 days
-	}
-	authTokensKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
-		Bucket:         "AUTH_TOKENS",
-		Description:    "Bearer tokens and OAuth authorization codes",
-		Storage:        jetstream.FileStorage,
-		TTL:            authTokenTTL,
-		Replicas:       cfg.Replicas,
-		LimitMarkerTTL: time.Minute, // Required for per-key TTL (used by authorization codes)
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create AUTH_TOKENS KV bucket: %w", err)
-	}
-
 	// Return initialized storage and whether RBAC bucket was newly created
 	return &storage{
 		serverKV:           serverKV,
@@ -1081,7 +1057,6 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		presenceKV:      presenceKV,
 		imageCacheStore: imageCacheStore,
 		callStateKV:     callStateKV,
-		authTokensKV:    authTokensKV,
 	}, nil
 }
 

--- a/cli/internal/core/core_test.go
+++ b/cli/internal/core/core_test.go
@@ -36,6 +36,7 @@ func setupTestCore(t *testing.T) (*ChattoCore, *nats.Conn) {
 
 	// Create ChattoCore
 	cfg := config.CoreConfig{
+		SecretKey: "test-core-secret",
 		Assets: config.AssetsConfig{
 			SigningSecret: "test-signing-secret",
 		},
@@ -105,6 +106,7 @@ func eventStreamMsgCount(t *testing.T, core *ChattoCore) uint64 {
 func TestChattoCore_RunReplaysProjectionsBeforeBootEnsures(t *testing.T) {
 	_, nc := testutil.StartNATS(t)
 	cfg := config.CoreConfig{
+		SecretKey: "test-core-secret",
 		Assets: config.AssetsConfig{
 			SigningSecret: "test-signing-secret",
 		},
@@ -166,6 +168,7 @@ func TestChattoCore_RunReplaysProjectionsBeforeBootEnsures(t *testing.T) {
 func TestChattoCore_RunAppliesConfigOwnersToExistingVerifiedUsers(t *testing.T) {
 	_, nc := testutil.StartNATS(t)
 	cfg := config.CoreConfig{
+		SecretKey: "test-core-secret",
 		Assets: config.AssetsConfig{
 			SigningSecret: "test-signing-secret",
 		},

--- a/cli/internal/core/encryption_test.go
+++ b/cli/internal/core/encryption_test.go
@@ -24,6 +24,7 @@ func setupTestCoreWithEncryption(t *testing.T) *ChattoCore {
 	t.Cleanup(cancel)
 
 	cfg := config.CoreConfig{
+		SecretKey: "test-core-secret",
 		Assets: config.AssetsConfig{
 			SigningSecret: "test-signing-secret",
 		},

--- a/cli/internal/core/password_reset.go
+++ b/cli/internal/core/password_reset.go
@@ -46,10 +46,11 @@ type PasswordResetToken struct {
 // KV Key Functions
 // ============================================================================
 
-// passwordResetTokenKey returns the KV key for a password reset token.
-// Format: password_reset.{token}
-func passwordResetTokenKey(token string) string {
-	return fmt.Sprintf("password_reset.%s", token)
+const passwordResetTokenKeyPrefix = "password_reset."
+
+// passwordResetTokenKey returns the HMAC-derived KV key for a password reset token.
+func (c *ChattoCore) passwordResetTokenKey(token string) string {
+	return c.runtimeTokenKey(passwordResetTokenKeyPrefix, token)
 }
 
 // ============================================================================
@@ -89,7 +90,7 @@ func (c *ChattoCore) CreatePasswordResetToken(ctx context.Context, email string)
 		return "", fmt.Errorf("failed to marshal token: %w", err)
 	}
 
-	_, err = c.storage.serverKV.Put(ctx, passwordResetTokenKey(token), data)
+	_, err = c.storage.runtimeStateKV.Create(ctx, c.passwordResetTokenKey(token), data, jetstream.KeyTTL(PasswordResetTokenTTL))
 	if err != nil {
 		return "", fmt.Errorf("failed to store password reset token: %w", err)
 	}
@@ -105,7 +106,8 @@ func (c *ChattoCore) CreatePasswordResetToken(ctx context.Context, email string)
 // getPasswordResetToken retrieves and validates a password reset token.
 // Returns the token data including userID and email.
 func (c *ChattoCore) getPasswordResetToken(ctx context.Context, token string) (*PasswordResetToken, error) {
-	entry, err := c.storage.serverKV.Get(ctx, passwordResetTokenKey(token))
+	key := c.passwordResetTokenKey(token)
+	entry, err := c.storage.runtimeStateKV.Get(ctx, key)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return nil, ErrPasswordResetTokenNotFound
@@ -121,7 +123,7 @@ func (c *ChattoCore) getPasswordResetToken(ctx context.Context, token string) (*
 	// Check if token has expired
 	if time.Since(tokenData.CreatedAt) > PasswordResetTokenTTL {
 		// Clean up expired token
-		c.storage.serverKV.Delete(ctx, passwordResetTokenKey(token))
+		_ = c.storage.runtimeStateKV.Delete(ctx, key)
 		return nil, ErrPasswordResetTokenExpired
 	}
 
@@ -130,7 +132,8 @@ func (c *ChattoCore) getPasswordResetToken(ctx context.Context, token string) (*
 
 // deletePasswordResetToken removes a password reset token.
 func (c *ChattoCore) deletePasswordResetToken(ctx context.Context, token string) error {
-	err := c.storage.serverKV.Delete(ctx, passwordResetTokenKey(token))
+	key := c.passwordResetTokenKey(token)
+	err := c.storage.runtimeStateKV.Delete(ctx, key)
 	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
 		return fmt.Errorf("failed to delete password reset token: %w", err)
 	}

--- a/cli/internal/core/rbac_test.go
+++ b/cli/internal/core/rbac_test.go
@@ -139,6 +139,7 @@ func TestChattoCore_initServerRBAC_PreservesPermissionChanges(t *testing.T) {
 	_, nc := testutil.StartNATS(t)
 
 	cfg := config.CoreConfig{
+		SecretKey: "test-core-secret",
 		Assets: config.AssetsConfig{
 			SigningSecret: "test-signing-secret",
 		},

--- a/cli/internal/core/registration.go
+++ b/cli/internal/core/registration.go
@@ -42,10 +42,11 @@ type RegistrationToken struct {
 // KV Key Functions
 // ============================================================================
 
-// registrationTokenKey returns the KV key for a registration token.
-// Format: registration.{token}
-func registrationTokenKey(token string) string {
-	return fmt.Sprintf("registration.%s", token)
+const registrationTokenKeyPrefix = "registration."
+
+// registrationTokenKey returns the HMAC-derived KV key for a registration token.
+func (c *ChattoCore) registrationTokenKey(token string) string {
+	return c.runtimeTokenKey(registrationTokenKeyPrefix, token)
 }
 
 // ============================================================================
@@ -53,7 +54,7 @@ func registrationTokenKey(token string) string {
 // ============================================================================
 
 // CreateRegistrationToken creates a new registration token for an email address.
-// The token is stored in serverKV and can be used to complete account creation.
+// The token is stored in RUNTIME_STATE and can be used to complete account creation.
 //
 // Email is expected to already be normalized (trimmed, lowercased) by the caller —
 // the HTTP handlers do this at the request boundary.
@@ -75,7 +76,7 @@ func (c *ChattoCore) CreateRegistrationToken(ctx context.Context, email string) 
 		return "", fmt.Errorf("failed to marshal registration token: %w", err)
 	}
 
-	_, err = c.storage.serverKV.Create(ctx, registrationTokenKey(token), data, jetstream.KeyTTL(RegistrationTokenTTL))
+	_, err = c.storage.runtimeStateKV.Create(ctx, c.registrationTokenKey(token), data, jetstream.KeyTTL(RegistrationTokenTTL))
 	if err != nil {
 		return "", fmt.Errorf("failed to store registration token: %w", err)
 	}
@@ -91,7 +92,8 @@ func (c *ChattoCore) CreateRegistrationToken(ctx context.Context, email string) 
 // GetRegistrationToken retrieves and validates a registration token.
 // Returns the token data including the email address.
 func (c *ChattoCore) GetRegistrationToken(ctx context.Context, token string) (*RegistrationToken, error) {
-	entry, err := c.storage.serverKV.Get(ctx, registrationTokenKey(token))
+	key := c.registrationTokenKey(token)
+	entry, err := c.storage.runtimeStateKV.Get(ctx, key)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return nil, ErrRegistrationTokenNotFound
@@ -107,7 +109,7 @@ func (c *ChattoCore) GetRegistrationToken(ctx context.Context, token string) (*R
 	// Check if token has expired
 	if time.Since(tokenData.CreatedAt) > RegistrationTokenTTL {
 		// Clean up expired token
-		c.storage.serverKV.Delete(ctx, registrationTokenKey(token))
+		_ = c.storage.runtimeStateKV.Delete(ctx, key)
 		return nil, ErrRegistrationTokenExpired
 	}
 
@@ -116,7 +118,8 @@ func (c *ChattoCore) GetRegistrationToken(ctx context.Context, token string) (*R
 
 // DeleteRegistrationToken removes a registration token after successful account creation.
 func (c *ChattoCore) DeleteRegistrationToken(ctx context.Context, token string) error {
-	err := c.storage.serverKV.Delete(ctx, registrationTokenKey(token))
+	key := c.registrationTokenKey(token)
+	err := c.storage.runtimeStateKV.Delete(ctx, key)
 	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
 		return fmt.Errorf("failed to delete registration token: %w", err)
 	}

--- a/cli/internal/core/registration_test.go
+++ b/cli/internal/core/registration_test.go
@@ -143,14 +143,14 @@ func TestChattoCore_RegistrationTokenExpiration(t *testing.T) {
 			t.Fatalf("Failed to create token: %v", err)
 		}
 
-		entry, err := core.storage.serverKV.Get(ctx, registrationTokenKey(token))
+		entry, err := core.storage.runtimeStateKV.Get(ctx, core.registrationTokenKey(token))
 		if err != nil {
 			t.Fatalf("Failed to fetch entry: %v", err)
 		}
 
 		// Verify the underlying KV message carries a per-key TTL header.
 		// The Nats-TTL header is what NATS uses to enforce per-message expiry.
-		rawMsg, err := core.js.Stream(ctx, "KV_INSTANCE")
+		rawMsg, err := core.js.Stream(ctx, "KV_RUNTIME_STATE")
 		if err != nil {
 			t.Fatalf("Failed to get stream: %v", err)
 		}

--- a/cli/internal/core/runtime_token_keys.go
+++ b/cli/internal/core/runtime_token_keys.go
@@ -1,0 +1,17 @@
+package core
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+func (c *ChattoCore) runtimeTokenKey(prefix, token string) string {
+	scope := strings.TrimSuffix(prefix, ".")
+	mac := hmac.New(sha256.New, []byte(c.config.SecretKey))
+	_, _ = mac.Write([]byte(scope))
+	_, _ = mac.Write([]byte{0})
+	_, _ = mac.Write([]byte(token))
+	return prefix + hex.EncodeToString(mac.Sum(nil))
+}

--- a/cli/internal/core/runtime_token_storage_test.go
+++ b/cli/internal/core/runtime_token_storage_test.go
@@ -1,0 +1,90 @@
+package core
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func TestChattoCore_WorkflowTokensUseRuntimeState(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	user, err := core.CreateUser(ctx, SystemActorID, "runtime-token-user", "Runtime Token User", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if err := core.AddVerifiedEmailDirect(ctx, user.Id, "runtime-token@example.com"); err != nil {
+		t.Fatalf("AddVerifiedEmailDirect: %v", err)
+	}
+
+	registrationToken, err := core.CreateRegistrationToken(ctx, "runtime-registration@example.com")
+	if err != nil {
+		t.Fatalf("CreateRegistrationToken: %v", err)
+	}
+	assertRuntimeTokenOnly(t, core, core.registrationTokenKey(registrationToken), registrationTokenKeyPrefix+registrationToken)
+
+	emailToken, err := core.CreateEmailVerificationToken(ctx, user.Id, "runtime-verify@example.com")
+	if err != nil {
+		t.Fatalf("CreateEmailVerificationToken: %v", err)
+	}
+	assertRuntimeTokenOnly(t, core, core.emailVerificationTokenKey(emailToken), emailVerificationTokenKeyPrefix+emailToken)
+
+	resetToken, err := core.CreatePasswordResetToken(ctx, "runtime-token@example.com")
+	if err != nil {
+		t.Fatalf("CreatePasswordResetToken: %v", err)
+	}
+	assertRuntimeTokenOnly(t, core, core.passwordResetTokenKey(resetToken), passwordResetTokenKeyPrefix+resetToken)
+
+	deletionToken, err := core.CreateAccountDeletionToken(ctx, user.Id)
+	if err != nil {
+		t.Fatalf("CreateAccountDeletionToken: %v", err)
+	}
+	assertRuntimeTokenOnly(t, core, core.accountDeletionTokenKey(deletionToken), accountDeletionTokenKeyPrefix+deletionToken)
+}
+
+func assertRuntimeTokenOnly(t *testing.T, core *ChattoCore, key, rawKey string) {
+	t.Helper()
+	ctx := testContext(t)
+	if _, err := core.storage.runtimeStateKV.Get(ctx, key); err != nil {
+		t.Fatalf("expected %s in RUNTIME_STATE: %v", key, err)
+	}
+	assertRuntimeKVHasTTL(t, core, key)
+	if _, err := core.storage.serverKV.Get(ctx, key); !errors.Is(err, jetstream.ErrKeyNotFound) {
+		t.Fatalf("legacy INSTANCE lookup for %s error = %v, want ErrKeyNotFound", key, err)
+	}
+	assertRawRuntimeTokenKeyAbsent(t, core, rawKey)
+	if _, err := core.storage.serverKV.Get(ctx, rawKey); !errors.Is(err, jetstream.ErrKeyNotFound) {
+		t.Fatalf("raw legacy INSTANCE lookup for %s error = %v, want ErrKeyNotFound", rawKey, err)
+	}
+}
+
+func assertRuntimeKVHasTTL(t *testing.T, core *ChattoCore, key string) {
+	t.Helper()
+	ctx := testContext(t)
+
+	entry, err := core.storage.runtimeStateKV.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("get runtime state key %s: %v", key, err)
+	}
+	stream, err := core.js.Stream(ctx, "KV_RUNTIME_STATE")
+	if err != nil {
+		t.Fatalf("get RUNTIME_STATE stream: %v", err)
+	}
+	msg, err := stream.GetMsg(ctx, entry.Revision())
+	if err != nil {
+		t.Fatalf("get raw runtime state message for %s: %v", key, err)
+	}
+	if msg.Header.Get("Nats-TTL") == "" {
+		t.Fatalf("expected %s to carry per-key TTL, got headers: %v", key, msg.Header)
+	}
+}
+
+func assertRawRuntimeTokenKeyAbsent(t *testing.T, core *ChattoCore, rawKey string) {
+	t.Helper()
+	ctx := testContext(t)
+	if _, err := core.storage.runtimeStateKV.Get(ctx, rawKey); !errors.Is(err, jetstream.ErrKeyNotFound) {
+		t.Fatalf("raw runtime token key %s lookup error = %v, want ErrKeyNotFound", rawKey, err)
+	}
+}

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -765,9 +765,11 @@ func (c *ChattoCore) ClearLoginChangeCooldown(ctx context.Context, userID string
 // Account Deletion Token Operations
 // ============================================================================
 
-// accountDeletionTokenKey returns the KV key for an account deletion token.
-func accountDeletionTokenKey(token string) string {
-	return "account_deletion_token." + token
+const accountDeletionTokenKeyPrefix = "account_deletion_token."
+
+// accountDeletionTokenKey returns the HMAC-derived KV key for an account deletion token.
+func (c *ChattoCore) accountDeletionTokenKey(token string) string {
+	return c.runtimeTokenKey(accountDeletionTokenKeyPrefix, token)
 }
 
 // AccountDeletionTokenTTL is how long an account deletion token is valid.
@@ -780,7 +782,7 @@ type AccountDeletionToken struct {
 }
 
 // CreateAccountDeletionToken generates a confirmation token for account deletion.
-// The token is stored in KV and must be provided to DeleteUser within the TTL.
+// The token is stored in RUNTIME_STATE and must be provided to DeleteUser within the TTL.
 func (c *ChattoCore) CreateAccountDeletionToken(ctx context.Context, userID string) (string, error) {
 	token := NewAccountDeletionToken()
 	createdAt := time.Now()
@@ -795,13 +797,13 @@ func (c *ChattoCore) CreateAccountDeletionToken(ctx context.Context, userID stri
 		return "", fmt.Errorf("failed to marshal token: %w", err)
 	}
 
-	_, err = c.storage.serverKV.Put(ctx, accountDeletionTokenKey(token), data)
+	_, err = c.storage.runtimeStateKV.Create(ctx, c.accountDeletionTokenKey(token), data, jetstream.KeyTTL(AccountDeletionTokenTTL))
 	if err != nil {
 		return "", fmt.Errorf("failed to store account deletion token: %w", err)
 	}
 
 	if err := c.recordAccountDeletionConfirmationIssued(ctx, userID, createdAt); err != nil {
-		_ = c.storage.serverKV.Delete(ctx, accountDeletionTokenKey(token))
+		_ = c.storage.runtimeStateKV.Delete(ctx, c.accountDeletionTokenKey(token))
 		return "", err
 	}
 
@@ -813,9 +815,9 @@ func (c *ChattoCore) CreateAccountDeletionToken(ctx context.Context, userID stri
 // If valid, the token is consumed (deleted) to prevent reuse.
 // Returns an error if the token is invalid, expired, or doesn't belong to the user.
 func (c *ChattoCore) ValidateAccountDeletionToken(ctx context.Context, token, userID string) error {
-	key := accountDeletionTokenKey(token)
+	key := c.accountDeletionTokenKey(token)
 
-	entry, err := c.storage.serverKV.Get(ctx, key)
+	entry, err := c.storage.runtimeStateKV.Get(ctx, key)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return ErrTokenNotFound
@@ -830,7 +832,7 @@ func (c *ChattoCore) ValidateAccountDeletionToken(ctx context.Context, token, us
 
 	// Check if token has expired
 	if time.Since(tokenData.CreatedAt) > AccountDeletionTokenTTL {
-		c.storage.serverKV.Delete(ctx, key) // Clean up expired token
+		_ = c.storage.runtimeStateKV.Delete(ctx, key) // Clean up expired token
 		return ErrTokenExpired
 	}
 
@@ -840,7 +842,7 @@ func (c *ChattoCore) ValidateAccountDeletionToken(ctx context.Context, token, us
 	}
 
 	// Consume the token (delete it)
-	if err := c.storage.serverKV.Delete(ctx, key); err != nil {
+	if err := c.storage.runtimeStateKV.Delete(ctx, key); err != nil {
 		c.logger.Warn("Failed to delete consumed account deletion token", "error", err)
 		// Continue anyway - the token was valid
 	}

--- a/cli/internal/core/verified_emails.go
+++ b/cli/internal/core/verified_emails.go
@@ -63,10 +63,11 @@ type VerifiedEmail struct {
 // KV Key Functions
 // ============================================================================
 
-// emailVerificationTokenKey returns the KV key for an email verification token.
-// Format: email_verification.{token}
-func emailVerificationTokenKey(token string) string {
-	return fmt.Sprintf("email_verification.%s", token)
+const emailVerificationTokenKeyPrefix = "email_verification."
+
+// emailVerificationTokenKey returns the HMAC-derived KV key for an email verification token.
+func (c *ChattoCore) emailVerificationTokenKey(token string) string {
+	return c.runtimeTokenKey(emailVerificationTokenKeyPrefix, token)
 }
 
 // emailHash returns the stable lowercase-SHA256 hex digest used in both
@@ -121,7 +122,7 @@ func (c *ChattoCore) CreateEmailVerificationToken(ctx context.Context, userID, e
 		return "", fmt.Errorf("failed to marshal token: %w", err)
 	}
 
-	_, err = c.storage.serverKV.Create(ctx, emailVerificationTokenKey(token), data, jetstream.KeyTTL(EmailVerificationTokenTTL))
+	_, err = c.storage.runtimeStateKV.Create(ctx, c.emailVerificationTokenKey(token), data, jetstream.KeyTTL(EmailVerificationTokenTTL))
 	if err != nil {
 		return "", fmt.Errorf("failed to store verification token: %w", err)
 	}
@@ -137,7 +138,8 @@ func (c *ChattoCore) CreateEmailVerificationToken(ctx context.Context, userID, e
 // getEmailVerificationToken retrieves and validates a verification token.
 // Returns the token data including userID and email.
 func (c *ChattoCore) getEmailVerificationToken(ctx context.Context, token string) (*EmailVerificationToken, error) {
-	entry, err := c.storage.serverKV.Get(ctx, emailVerificationTokenKey(token))
+	key := c.emailVerificationTokenKey(token)
+	entry, err := c.storage.runtimeStateKV.Get(ctx, key)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return nil, ErrTokenNotFound
@@ -153,7 +155,7 @@ func (c *ChattoCore) getEmailVerificationToken(ctx context.Context, token string
 	// Check if token has expired
 	if time.Since(tokenData.CreatedAt) > EmailVerificationTokenTTL {
 		// Clean up expired token
-		c.storage.serverKV.Delete(ctx, emailVerificationTokenKey(token))
+		_ = c.storage.runtimeStateKV.Delete(ctx, key)
 		return nil, ErrTokenExpired
 	}
 
@@ -162,7 +164,8 @@ func (c *ChattoCore) getEmailVerificationToken(ctx context.Context, token string
 
 // deleteEmailVerificationToken removes a verification token.
 func (c *ChattoCore) deleteEmailVerificationToken(ctx context.Context, token string) error {
-	err := c.storage.serverKV.Delete(ctx, emailVerificationTokenKey(token))
+	key := c.emailVerificationTokenKey(token)
+	err := c.storage.runtimeStateKV.Delete(ctx, key)
 	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
 		return fmt.Errorf("failed to delete verification token: %w", err)
 	}

--- a/cli/internal/migrations/migrations.go
+++ b/cli/internal/migrations/migrations.go
@@ -48,7 +48,7 @@ import (
 // error.
 //
 // KV buckets:
-//   - `serverKV`: INSTANCE bucket (user data, auth tokens, etc.).
+//   - `serverKV`: INSTANCE bucket (user data).
 //   - `serverConfigKV`: SERVER_CONFIG (rooms, room memberships,
 //     notification levels, …).
 //   - `serverBodiesKV`: SERVER_BODIES (message content + standalone
@@ -58,7 +58,8 @@ import (
 //   - `runtimeConfigKV`: INSTANCE_CONFIG (operator-editable server
 //     settings — name, MOTD, blocked usernames, etc.).
 //   - `runtimeStateKV`: RUNTIME_STATE (persisted latest-value runtime/user
-//     state such as read markers, thread follows, and push subscriptions).
+//     state such as read markers, thread follows, push subscriptions, and
+//     HMAC-keyed auth/workflow tokens).
 //   - `serverReactionsKV`: SERVER_REACTIONS (legacy current reaction
 //     state; retained until reaction ES migration cleanup).
 //

--- a/docs-website/src/content/docs/getting-started/quick-start.mdx
+++ b/docs-website/src/content/docs/getting-started/quick-start.mdx
@@ -72,7 +72,7 @@ To keep your configuration and data across container restarts, use a bind mount:
    chatto init
    ```
 
-   This creates a `chatto.toml` with random secrets for cookie signing, asset signing, and NATS authentication.
+   This creates a `chatto.toml` with random secrets for cookie signing, runtime-token verifiers, asset signing, and NATS authentication.
 
 3. **Start the server:**
 
@@ -96,6 +96,9 @@ port = 4000
 url = "http://localhost:4000"
 cookie_signing_secret = "<generated>"
 
+[core]
+secret_key = "<generated>"
+
 [core.assets]
 signing_secret = "<generated>"
 max_upload_size = "25 MB"
@@ -113,4 +116,3 @@ url = "nats://localhost:4222"
 auth_method = "token"
 token = "<generated>"
 ```
-

--- a/docs-website/src/content/docs/guides/backup-restore.mdx
+++ b/docs-website/src/content/docs/guides/backup-restore.mdx
@@ -25,10 +25,13 @@ Certain streams are intentionally excluded:
 | Call state | Ephemeral (memory-only), reconstructed by LiveKit webhooks |
 | Link preview cache | Regeneratable on demand |
 | Asset cache | Regeneratable (resized image variants) |
-| Auth tokens | Security: prevents session token leakage via backup files |
 
 <Aside type="caution">
   Encryption keys are excluded from backups by design. Chatto always encrypts message bodies, so the encrypted content in the backup cannot be decrypted without the keys. See [Encryption key backup](#encryption-key-backup) below.
+</Aside>
+
+<Aside type="note">
+  `RUNTIME_STATE` is included in backups. Active sessions and pending registration, email-verification, password-reset, account-deletion, and OAuth-code flows can survive a restore when the restored server uses the same `core.secret_key`. Backup archives contain HMAC verifier keys, not raw bearer tokens, links, or OAuth codes; changing `core.secret_key` intentionally invalidates those credentials.
 </Aside>
 
 ## Creating a backup
@@ -66,6 +69,10 @@ vault kv get -field=passphrase secret/chatto | chatto backup -c chatto.toml --en
 
 <Aside type="caution">
   Make sure Chatto is **not running** before restoring. For embedded NATS setups, the restore command starts its own temporary NATS server. For external NATS, stop the Chatto application but keep NATS running.
+</Aside>
+
+<Aside type="tip">
+  Keep the same `core.secret_key` in `chatto.toml` when restoring if you want existing bearer sessions and pending account-flow links to remain valid. Using a new value is a clean way to invalidate them during disaster recovery.
 </Aside>
 
 <Steps>

--- a/docs-website/src/content/docs/guides/binary.mdx
+++ b/docs-website/src/content/docs/guides/binary.mdx
@@ -49,6 +49,9 @@ By the end of this section, your deployment directory will look like this:
    domain = "chat.example.com"
    email = "admin@example.com"
 
+   [core]
+   secret_key = "<generate-me>"
+
    [core.assets]
    signing_secret = "<generate-me>"
    ```

--- a/docs-website/src/content/docs/guides/dockercompose.mdx
+++ b/docs-website/src/content/docs/guides/dockercompose.mdx
@@ -169,6 +169,7 @@ By the end of this section, your project directory will look like this:
    CHATTO_WEBSERVER_URL=https://chat.example.com
    CHATTO_WEBSERVER_PORT=4000
    CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET=<generate-me>
+   CHATTO_CORE_SECRET_KEY=<generate-me>
    CHATTO_CORE_ASSETS_SIGNING_SECRET=<generate-me>
    CHATTO_LOG_LEVEL=info
 

--- a/docs-website/src/content/docs/guides/horizontal-scaling.mdx
+++ b/docs-website/src/content/docs/guides/horizontal-scaling.mdx
@@ -26,7 +26,7 @@ Because there's no local state, any server process can handle any request. No se
 
 - An **external NATS cluster** (embedded NATS only supports a single server process)
 - A **load balancer** in front of the Chatto replicas (Caddy, nginx, Traefik, etc.)
-- The **same secrets** across all server processes (cookie signing, asset signing)
+- The **same secrets** across all server processes (cookie signing, core token verifier key, asset signing)
 
 ## Configuring Chatto for Multiple Replicas
 
@@ -45,6 +45,7 @@ CHATTO_NATS_CLIENT_TOKEN=your-shared-token
 
 # These MUST be identical across all server processes
 CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET=your-cookie-secret
+CHATTO_CORE_SECRET_KEY=your-core-secret
 CHATTO_CORE_ASSETS_SIGNING_SECRET=your-assets-secret
 ```
 </TabItem>
@@ -62,7 +63,7 @@ token = "your-shared-token"
 </Tabs>
 
 <Aside type="caution">
-  All server processes **must** share the same `cookie_signing_secret` and `assets_signing_secret`. If they differ, cookies and asset URLs signed by one server process won't validate on another.
+  All server processes **must** share the same `cookie_signing_secret`, `core.secret_key`, and `core.assets.signing_secret`. If they differ, cookies, bearer tokens, account-flow links, or asset URLs created by one server process won't validate on another.
 </Aside>
 
 ## Health Checks
@@ -143,7 +144,8 @@ The [Docker Compose deployment guide](/guides/dockercompose/) includes a Caddy c
 |---------|-------------------------------------|-------|
 | NATS client URL & credentials | Yes | All connect to the same cluster |
 | `cookie_signing_secret` | Yes | Cookie validation |
-| `assets_signing_secret` | Yes | Asset URL signing |
+| `core.secret_key` | Yes | Bearer-token and account-flow verifier keys |
+| `core.assets.signing_secret` | Yes | Asset URL signing |
 | `webserver.url` | Yes | Public URL for absolute links |
 | `livekit.instance_id` | **No** — must be unique | Webhook routing |
 

--- a/docs-website/src/content/docs/guides/security.mdx
+++ b/docs-website/src/content/docs/guides/security.mdx
@@ -21,7 +21,7 @@ Login comparison runs bcrypt against a dummy hash for unknown users and OAuth-on
 
 ### Sessions and tokens
 
-Chatto issues **opaque bearer tokens**, not JWTs. Tokens are stored in a NATS KV bucket with a sliding TTL: every successful validation re-puts the entry, extending its expiry. Revocation is a single KV delete — there is no signed-but-still-valid window to worry about.
+Chatto issues **opaque bearer tokens**, not JWTs. Token verifiers are stored in `RUNTIME_STATE` under HMAC-derived keys, with a sliding TTL: every successful validation re-puts the entry, extending its expiry. Revocation is a single KV delete — there is no signed-but-still-valid window to worry about.
 
 Browser sessions use signed cookies with the following options:
 
@@ -109,10 +109,11 @@ TLS is **not required**. Chatto can also run plain HTTP, which is useful for loc
 
 ## Backup security
 
-Backups encrypt with [age](https://age-encryption.org) (passphrase-based scrypt) when you pass `--encrypt`. Two buckets are **deliberately excluded** from backups for security reasons:
+Backups encrypt with [age](https://age-encryption.org) (passphrase-based scrypt) when you pass `--encrypt`. `KV_ENCRYPTION_KEYS` is **deliberately excluded** from backups for security reasons:
 
 - `KV_ENCRYPTION_KEYS` — keeps backup archives unable to decrypt their own message bodies if leaked.
-- `KV_AUTH_TOKENS` — prevents session-token exfiltration via stolen backup files.
+
+`RUNTIME_STATE` is included in backups so active sessions and pending registration, email-verification, password-reset, account-deletion, and OAuth-code flows can survive a restore. Credential entries in that bucket use HMAC-derived keys, so backup archives do not contain redeemable raw bearer tokens, links, or OAuth codes. Restoring with a different `core.secret_key` intentionally invalidates those credentials.
 
 Encryption keys are exported and imported separately with `chatto keys export` / `chatto keys import`, again age-encrypted. The same passphrase format means a standalone `age` CLI can inspect or re-encrypt any Chatto archive.
 
@@ -168,7 +169,9 @@ For HSTS, CSP, and other policy headers, add them at your reverse proxy.
 | Secret                              | Storage                                     | Backed up?     |
 | ----------------------------------- | ------------------------------------------- | -------------- |
 | User encryption keys                | `KV_ENCRYPTION_KEYS` (NATS KV)              | No (export separately) |
-| Bearer auth tokens                  | `KV_AUTH_TOKENS` (NATS KV, with TTL)        | No             |
+| Bearer/session token verifiers      | `KV_RUNTIME_STATE` (HMAC-keyed, with TTL)   | Yes (not raw tokens) |
+| Account-flow link/code verifiers    | `KV_RUNTIME_STATE` (HMAC-keyed, with TTL)   | Yes (not raw links/codes) |
+| Core secret key                     | `chatto.toml` (`core.secret_key`)           | n/a            |
 | Cookie signing secret               | `chatto.toml` (`webserver.cookie_signing_secret`) | n/a       |
 | Cookie encryption secret (optional) | `chatto.toml` (`webserver.cookie_encryption_secret`) | n/a    |
 | TLS certificates                    | Disk cache directory (`autocert`)           | n/a            |

--- a/docs-website/src/content/docs/reference/environment-variables.mdx
+++ b/docs-website/src/content/docs/reference/environment-variables.mdx
@@ -63,6 +63,12 @@ Built-in automatic TLS via Let's Encrypt. When enabled, Chatto handles certifica
   Port for the HTTP server (ACME challenges and HTTPS redirect). Use a higher port if running without elevated privileges.
 </EnvVar>
 
+## Core
+
+<EnvVar name="CHATTO_CORE_SECRET_KEY" toml="core.secret_key" required>
+  256-bit hex secret for HMAC-derived bearer-token and account-flow link verifiers. Generate with `openssl rand -hex 32`. Keep this stable across restores if you want sessions and pending links to survive.
+</EnvVar>
+
 ## Assets
 
 <EnvVar name="CHATTO_CORE_ASSETS_SIGNING_SECRET" toml="core.assets.signing_secret" required>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -258,8 +258,7 @@ There is no `adminAuditLogEvents` subscription — audit events arrive through `
 | KV      | `INSTANCE`                    | Users, memberships (bucket name retained from pre-rename) |
 | KV      | `INSTANCE_CONFIG`             | Legacy server configuration import source   |
 | KV      | `USER_PRESENCE`               | Presence status (memory, TTL 60s)           |
-| KV      | `AUTH_TOKENS`                 | Legacy bearer auth tokens pending `RUNTIME_STATE` migration |
-| KV      | `RUNTIME_STATE`               | Persisted latest-value runtime/user state, including pending notifications and push subscriptions |
+| KV      | `RUNTIME_STATE`               | Persisted latest-value runtime/user state, including pending notifications, push subscriptions, and auth/workflow tokens |
 | KV      | `SERVER_CONFIG`               | Rooms (channel + DM), memberships           |
 | KV      | `SERVER_RBAC`                 | Legacy RBAC seed data read by the `EVT` boot migration |
 | KV      | `SERVER_RUNTIME`              | Legacy runtime state pending cleanup        |
@@ -468,14 +467,13 @@ The unified `myEvents` GraphQL subscription is backed by a single core stream (`
 | ----------------------------- | ------- | -------- | ----------------------------------------------- |
 | `INSTANCE`                    | File    | Yes      | Users, memberships (bucket name retained from pre-rename) |
 | `INSTANCE_CONFIG`             | File    | Yes      | Legacy server configuration import source       |
-| `RUNTIME_STATE`               | File    | Yes      | Persisted latest-value runtime/user state, including pending notifications and push subscriptions |
+| `RUNTIME_STATE`               | File    | Yes      | Persisted latest-value runtime/user state, including pending notifications, push subscriptions, and auth/workflow tokens |
 | `SERVER_CONFIG`               | File    | Yes      | Rooms (channel + DM), memberships               |
 | `SERVER_RBAC`                 | File    | Yes      | Legacy RBAC seed data read by the `EVT` boot migration |
 | `SERVER_RUNTIME`              | File    | Yes      | Legacy runtime state pending cleanup            |
 | `SERVER_BODIES`               | File    | Yes      | Message bodies (GDPR-compliant) + standalone attachment metadata records — TODO: rename → `SERVER_CONTENT` |
 | `SERVER_REACTIONS`            | File    | Yes      | Legacy emoji reactions, read only by the EVT boot migration |
 | `SERVER_THREADS`              | File    | Yes      | Thread metadata (reply count, participants)     |
-| `AUTH_TOKENS`                 | File    | No       | Legacy bearer auth tokens pending `RUNTIME_STATE` migration |
 | `USER_PRESENCE`               | Memory  | No       | User presence status (TTL 60s)                  |
 | `CALL_STATE`                  | Memory  | No       | Active voice call participants, keyed `{spaceId}.{roomId}` (repopulated by LiveKit webhooks after restart) |
 | `ENCRYPTION_KEYS`             | File    | **No**   | User encryption keys (excluded for security)    |
@@ -492,17 +490,14 @@ All room data — channels and DMs alike — lives in the unified `SERVER_*` buc
 | `auth.{userId}.password`               | Password hash (stored separately)                |
 | `user.{userId}.avatar`                 | User avatar asset reference                      |
 | `verified_emails.{userId}.{sha256(email)}` | One verified email per entry (proto `VerifiedEmail`) |
-| `email_verification.{token}`           | Verification token with userId/email (24h TTL)   |
 | `user_by_email.{sha256(email)}`        | Email-to-userId index (created on verification)  |
-| `password_reset.{token}`               | Password reset token                             |
-| `account_deletion.{token}`             | Account deletion confirmation token              |
 | `space.{spaceId}`                      | Vestigial primary-space record (key retained from pre-rename) |
 | `instance.logo`                        | Legacy server logo asset reference, imported into EVT config events |
 | `instance.banner`                      | Legacy server banner asset reference, imported into EVT config events |
 | `space_membership.{spaceId}.{userId}`  | User-server membership tracking (vestigial slot) |
 | `user_preferences.{userId}`            | User display preferences (timezone, time format) |
 
-Notes: Email verification uses SHA256 hashing for claim keys to ensure valid NATS subject characters and case-insensitive uniqueness. The claim key is created atomically when an email is verified, preventing race conditions where two users try to verify the same email. Verification tokens store userId and email in the JSON value for O(1) lookup by token.
+Notes: Email verification uses SHA256 hashing for claim keys to ensure valid NATS subject characters and case-insensitive uniqueness. The claim key is created atomically when an email is verified, preventing race conditions where two users try to verify the same email. Verification, registration, password-reset, account-deletion, bearer-session, and OAuth authorization-code token verifiers live in `RUNTIME_STATE` under HMAC-derived keys.
 
 **EVT auth audit subjects:**
 
@@ -525,14 +520,6 @@ These audit payloads include only safe request metadata: capped user agent and a
 | `config.instance` | Legacy server configuration import source (proto message; key + proto name retained) |
 
 Notes: Server configuration now lives in EVT config events and is served from the in-memory config projection. This bucket is retained as a boot-import source for pre-ES deployments. The TOML file remains reserved for operational settings (ports, secrets, NATS config).
-
-**AUTH_TOKENS keys:**
-
-| Key       | Description                                           |
-| --------- | ----------------------------------------------------- |
-| `{token}` | JSON with user ID and creation time                   |
-
-Notes: Tokens are opaque strings (`cht_AT` + 14-char NanoID). Used for `Authorization: Bearer <token>` header authentication, enabling cross-origin clients. TTL-based auto-expiry (default 90 days, configurable via `auth.token_ttl`). Excluded from backups in the legacy `AUTH_TOKENS` bucket since tokens are ephemeral credentials; ADR-036 targets durable token state for `RUNTIME_STATE` so TTL policy can be managed through the shared runtime-state bucket. Tokens are issued on login, registration, bootstrap, and OAuth callback.
 
 **ENCRYPTION_KEYS keys:**
 
@@ -596,6 +583,14 @@ survives restart but is not content/domain history. See
 | `read.thread.{userId}.{roomId}.{threadRootEventId}` | Latest thread message event ID the user has seen. Values copied from legacy `thread_last_opened.*` may be 8-byte UnixNano timestamps until rewritten by a new read action. |
 | `notification.{userId}.{notificationId}` | Pending notification record (protobuf `Notification`) for DM messages, @mentions, replies, and all-message subscriptions. Uses per-key 90-day TTL. Live sync uses `NotificationCreatedEvent` / `NotificationDismissedEvent` on `live.sync.user.{userId}.*`. |
 | `push_subscription.{userId}.{endpointHash}` | Web Push subscription record (protobuf `PushSubscription`) for a user's browser/device. Legacy `INSTANCE` keys are copied here at boot; the endpoint hash keeps multiple devices per user while deduplicating the same browser subscription. |
+| `registration.{hmac}` | Email-first registration token JSON. Uses per-key 24-hour TTL. |
+| `email_verification.{hmac}` | Email verification token JSON with user ID and email. Uses per-key 24-hour TTL. |
+| `password_reset.{hmac}` | Password reset token JSON. Uses per-key 1-hour TTL. |
+| `account_deletion_token.{hmac}` | Account deletion confirmation token JSON. Uses per-key 15-minute TTL. |
+| `session.{hmac}` | Opaque bearer auth token JSON. Uses per-key `auth.token_ttl` (default 90 days); successful validation refreshes the key with a new per-key TTL for sliding-window expiry. |
+| `grant.{hmac}` | OAuth authorization code JSON. Uses per-key 5-minute TTL and is deleted on exchange attempt. |
+
+Token HMAC keys are derived with `[core].secret_key` and the token family as a domain separator. Backups include `RUNTIME_STATE`, so sessions and pending links survive restore only when the same `core.secret_key` is kept; backup archives do not contain raw bearer tokens or raw link/code values.
 
 **SERVER\_RUNTIME keys:**
 

--- a/docs/adr/ADR-024-opaque-bearer-tokens-for-cross-origin-auth.md
+++ b/docs/adr/ADR-024-opaque-bearer-tokens-for-cross-origin-auth.md
@@ -31,15 +31,17 @@ To enable a multi-instance client — where a single frontend connects to multip
 
 ## Decision
 
-Use opaque bearer tokens stored in a `AUTH_TOKENS` NATS KV bucket. Tokens are issued alongside existing cookie sessions (not replacing them) on all authentication endpoints. Clients authenticate via the `Authorization: Bearer <token>` HTTP header for GraphQL queries/mutations, and via `connectionParams.token` in the graphql-ws `connection_init` payload for WebSocket subscriptions.
+Use opaque bearer tokens stored in NATS KV. Tokens are issued alongside existing cookie sessions (not replacing them) on all authentication endpoints. Clients authenticate via the `Authorization: Bearer <token>` HTTP header for GraphQL queries/mutations, and via `connectionParams.token` in the graphql-ws `connection_init` payload for WebSocket subscriptions.
+
+**2026-05 update:** bearer token records now live in `RUNTIME_STATE` under HMAC-derived `session.{hmac}` keys with per-key TTL. The HMAC input is `session\0{token}` keyed by `[core].secret_key`, so backups can preserve sessions without containing raw bearer-token values.
 
 **Token format:** `cht_AT` prefix + 14-character NanoID (20 characters total, e.g. `cht_ATa1B2c3D4e5F6G7`). The `cht_` prefix makes tokens recognizable in logs and password managers; the `AT` type prefix follows the existing NanoID convention from ADR-022.
 
 **Token lifecycle:**
 - Created on login, registration, bootstrap, and OAuth callback
-- Validated by looking up the token key in `AUTH_TOKENS` KV and reading the stored user ID
+- Validated by looking up the HMAC-derived `session.{hmac}` key in `RUNTIME_STATE` and reading the stored user ID
 - Revoked by deleting the key (idempotent)
-- Auto-expired via NATS KV TTL (default 90 days, configurable via `auth.token_ttl`)
+- Auto-expired via NATS KV per-key TTL (default 90 days, configurable via `auth.token_ttl`)
 
 **Auth middleware priority:**
 1. Check `Authorization: Bearer <token>` header → validate token → load user
@@ -51,6 +53,6 @@ Use opaque bearer tokens stored in a `AUTH_TOKENS` NATS KV bucket. Tokens are is
 - **Cookie auth is unchanged**: The embedded SPA continues to work exactly as before. No migration needed for existing deployments.
 - **No token refresh complexity**: Long-lived tokens with server-side TTL are simple. If a token expires, the client re-authenticates. No refresh token dance.
 - **Instant revocation**: Deleting a KV key immediately invalidates the token. No blocklist management or "wait for JWT expiry" window.
-- **One KV lookup per request**: Token validation requires a `Get` on the `AUTH_TOKENS` bucket, but this is negligible given we already do a `Get` on `INSTANCE` to load the user.
+- **One KV lookup per request**: Token validation requires a `Get` on `RUNTIME_STATE`, but this is negligible given we already do a user load per authenticated request.
 - **No reverse index**: v1 does not support "revoke all tokens for user". This keeps the implementation simple. If needed later, a prefix-scan or secondary index can be added.
 - **OAuth token delivery**: OAuth callbacks append `?token=...` to the redirect URL. This is simple but means the token briefly appears in browser history and server logs. For v1 this is acceptable; a more secure code-exchange flow can be added later if needed.

--- a/docs/adr/ADR-036-runtime-state-kv-boundary.md
+++ b/docs/adr/ADR-036-runtime-state-kv-boundary.md
@@ -50,15 +50,28 @@ The storage boundary is:
 - Compression enabled.
 - Per-key TTL support enabled via a limit-marker TTL; no global TTL is applied.
 
-Initial and planned occupants include:
+Current occupants include:
 
 - Room read cursors: `read.room.{userId}.{roomId}`.
 - Thread read cursors: `read.thread.{userId}.{roomId}.{threadRootEventId}`.
 - Pending notifications: `notification.{userId}.{notificationId}`, with per-key
   90-day TTL.
 - Web Push subscriptions: `push_subscription.{userId}.{endpointHash}`.
-- Auth, verification, reset, and revocation tokens after their migration from
-  token-specific buckets.
+- Bearer auth token verifiers: `session.{hmac}`, with per-key
+  `auth.token_ttl` sliding-window expiry.
+- OAuth authorization-code verifiers: `grant.{hmac}`, with per-key 5-minute
+  TTL.
+- Account workflow token verifiers: `registration.{hmac}`,
+  `email_verification.{hmac}`, `password_reset.{hmac}`, and
+  `account_deletion_token.{hmac}`, with per-key TTLs appropriate to each
+  workflow.
+
+The HMAC keys for bearer tokens, OAuth codes, and account workflow tokens are
+derived with `[core].secret_key` from the raw token/code plus a per-flow scope
+string. `RUNTIME_STATE` is included in backups, so active sessions and pending
+flows survive restore when the same secret is used; restoring with a different
+secret intentionally invalidates those credentials. Backup archives do not
+contain raw bearer tokens, links, or OAuth codes.
 
 Attachment declarations and video derivative manifests are not a `RUNTIME_STATE`
 target. Uploaded assets are content and are declared with `AssetCreatedEvent`;
@@ -81,6 +94,8 @@ canonical state.
 - Runtime values in `RUNTIME_STATE` are not replayable from `EVT`; backup and
   restore procedures must include this bucket when preserving user/runtime
   continuity matters.
+- Runtime credential records can be backed up without storing redeemable raw
+  tokens, because their keys are HMAC-derived from `[core].secret_key`.
 - Per-key TTL becomes available for tokens and similar runtime values without
   splitting each feature into its own bucket.
 - Security-sensitive exceptions remain explicit. In particular,

--- a/docs/fdr/FDR-018-account-lifecycle.md
+++ b/docs/fdr/FDR-018-account-lifecycle.md
@@ -1,7 +1,7 @@
 # FDR-018: Account Lifecycle
 
 **Status:** Active
-**Last reviewed:** 2026-05-19
+**Last reviewed:** 2026-05-31
 
 ## Overview
 
@@ -13,6 +13,7 @@ This FDR covers the user account from registration through deletion: signup, ema
 
 - A user signs up with a login, email, and password. The login must pass uniqueness and format checks; emails are checked against the server's blocked-usernames list.
 - After signup, an email is sent to the address with a verification link.
+- Registration and verification links are backed by `RUNTIME_STATE` HMAC-derived token records with 24-hour per-key TTLs. Raw token/link values are never written to `EVT` or backup archives.
 - Until the email is verified, the account has limited capabilities (configurable per server) — typically read-only or some restricted set defined by what the `verified` role grants.
 - Clicking the verification link marks the email as verified. The user gains the `verified` implicit role and the full set of permissions that role grants.
 - If the verified email matches an entry in `owners.emails` in the server config, the user is auto-assigned the `owner` role on verification.
@@ -29,6 +30,7 @@ This FDR covers the user account from registration through deletion: signup, ema
 - The user requests deletion via Account Settings.
 - A two-step confirmation flow asks the user to type a confirmation string before the deletion executes.
 - Account deletion confirmation-token issuance is recorded in the EVT audit log with expiry and safe request metadata; the raw token is not recorded.
+- The account deletion confirmation token itself lives in `RUNTIME_STATE` under an HMAC-derived key with a 15-minute per-key TTL.
 - On deletion, the server: removes the user's profile data, deletes their avatar, removes their per-user encryption key from the `ENCRYPTION_KEYS` KV bucket, records `UserKeyShreddedEvent` on the user aggregate, deletes message-owned assets and derivatives, and revokes all their sessions and bearer tokens.
 - After deletion, all messages the user ever posted are tombstoned by projection before decryption and cryptographically unreadable — the encrypted bytes are still on disk in JetStream, but without the key they decrypt to noise.
 - The login is freed up for re-use.
@@ -46,6 +48,12 @@ This FDR covers the user account from registration through deletion: signup, ema
 **Decision:** A user can attach multiple verified email addresses. Any of them count for owner-email matching, password resets, and identity correlation.
 **Why:** People have work and personal addresses, change jobs, or have an alias. Single-email accounts force needless friction during transitions. Multiple-emails also helps the `owners.emails` config — operators can list either an old or new email and the right user gets owner status.
 **Tradeoff:** The data model and resolvers have to handle a list, not a scalar. Minor extra complexity in exchange for real flexibility.
+
+### 2a. Workflow tokens in runtime state
+
+**Decision:** Registration, email-verification, password-reset, and account-deletion confirmation tokens are stored in `RUNTIME_STATE` under HMAC-derived keys with per-key TTLs. The HMAC input is scoped by workflow and keyed by `[core].secret_key`.
+**Why:** These values are raw credentials or credential-adjacent workflow state. They need restart and restore survival, but they are not reconstructable account history and should not become event-log or backup secrets. The audit value is captured separately in safe EVT facts.
+**Tradeoff:** Operators must keep `[core].secret_key` stable across restores if pending links should continue working. Changing it intentionally invalidates outstanding registration, email-verification, password-reset, and account-deletion links.
 
 ### 3. Two-step deletion confirmation
 

--- a/docs/fdr/FDR-023-authentication-and-sessions.md
+++ b/docs/fdr/FDR-023-authentication-and-sessions.md
@@ -1,7 +1,7 @@
 # FDR-023: Authentication & Sessions
 
 **Status:** Active
-**Last reviewed:** 2026-05-19
+**Last reviewed:** 2026-05-31
 
 ## Overview
 
@@ -12,10 +12,11 @@ Chatto authenticates users via two parallel mechanisms: HTTP-only cookie session
 - **Login** — users sign in with login + password on a `/login` page. The page is also used for redirect-after-signup.
 - **OAuth login** — operators can configure OAuth providers (e.g., Google). The login page shows provider buttons; clicking takes the user through the standard authorization-code flow.
 - **Cookie session** — on successful auth from the embedded SPA, the server issues an HTTP-only, SameSite=Lax cookie with a 90-day expiry. The cookie carries the user ID; the server loads the user from KV per request.
-- **Bearer token** — every authentication endpoint also issues an opaque token (format: `cht_AT` + 14-char NanoID). Cross-origin clients store it (usually in `localStorage`) and send it as `Authorization: Bearer …` on HTTP requests and `connectionParams.token` on graphql-ws upgrades.
+- **Bearer token** — every authentication endpoint also issues an opaque token (format: `cht_AT` + 14-char NanoID). Cross-origin clients store it (usually in `localStorage`) and send it as `Authorization: Bearer …` on HTTP requests and `connectionParams.token` on graphql-ws upgrades. The token record lives in `RUNTIME_STATE` as an HMAC-derived `session.{hmac}` key with a per-key TTL.
 - **WebSocket auth** — for the embedded SPA, the cookie is automatically attached to the WebSocket upgrade and the user is authenticated before the WS handshake completes. For cross-origin clients, the token in `connectionParams` is checked at upgrade time.
 - **Logout** — for cookie sessions: the server clears the session and the SPA does a hard reload. For tokens: the client removes the token from `localStorage`; optionally the server revokes the token by deleting its KV key.
-- **Session refresh** — the cookie TTL gets refreshed as the user actively uses the app (including on static file requests). Bearer tokens follow a sliding-window TTL — each successful validation re-puts the KV entry to extend the TTL.
+- **Session refresh** — the cookie TTL gets refreshed as the user actively uses the app (including on static file requests). Bearer tokens follow a sliding-window TTL — each successful validation rewrites the `RUNTIME_STATE` entry with a fresh per-key TTL.
+- **Password reset tokens** — reset links are backed by `RUNTIME_STATE` HMAC-derived `password_reset.{hmac}` records with a 1-hour per-key TTL. Raw reset tokens and links are never written to `EVT` or backup archives.
 - **Server version handshake** — the WebSocket `connection_ack` payload includes the server's version. The frontend uses this to detect deployed-version drift and prompt the user to refresh.
 - **Auth audit facts** — successful cookie logins, failed password login attempts, logout completion, registration-link issuance, password-reset link issuance, and password-reset completion are appended to `EVT` for admin audit-log inspection. Payloads carry safe request metadata only: capped user agent, HMAC-hashed IP, and hashed identifiers where needed.
 
@@ -29,13 +30,13 @@ Chatto authenticates users via two parallel mechanisms: HTTP-only cookie session
 
 ### 2. Bearer tokens for cross-origin
 
-**Decision:** Cross-origin clients (multi-instance frontend, CLI tools) authenticate via opaque bearer tokens stored in NATS KV. Tokens are validated by KV lookup; revocation is one delete.
+**Decision:** Cross-origin clients (multi-instance frontend, CLI tools) authenticate via opaque bearer tokens stored in `RUNTIME_STATE` under HMAC-derived `session.{hmac}` keys. Tokens are validated by KV lookup; revocation is one delete.
 **Why:** Cookies are scoped to one origin and `SameSite=Lax` blocks them on cross-origin requests. Tokens are origin-agnostic. We chose opaque tokens over JWTs because Chatto already does a per-request KV lookup to load the user — JWT's "stateless validation" advantage gives nothing here, while opaque tokens give instant revocation and natural TTL via KV's built-in expiry. See ADR-024.
-**Tradeoff:** Tokens stored in `localStorage` are vulnerable to XSS; cookie sessions are not. Cross-origin clients accept this tradeoff in exchange for being able to authenticate at all.
+**Tradeoff:** Tokens stored in `localStorage` are vulnerable to XSS; cookie sessions are not. Cross-origin clients accept this tradeoff in exchange for being able to authenticate at all. Operators must keep `[core].secret_key` stable across restores to preserve active bearer-token sessions.
 
 ### 3. Sliding-window TTL for tokens (and cookies)
 
-**Decision:** Each successful token validation re-puts the KV entry to refresh its TTL (default 90 days). Cookies are similarly refreshed on every static-file request.
+**Decision:** Each successful token validation rewrites the runtime-state entry with a fresh per-key TTL (default 90 days). Cookies are similarly refreshed on every static-file request.
 **Why:** Time-from-creation expiry would surprise users — "you've been logged in for 90 days, time to re-auth, even though you've been using the app daily". Sliding-window means active users stay logged in indefinitely; only genuinely inactive sessions expire.
 **Tradeoff:** A long-stolen token stays valid until it lapses or gets explicitly revoked. Operators concerned about this can lower the TTL or implement a "revoke all tokens for user" action (not currently exposed — see ADR-024).
 
@@ -74,6 +75,12 @@ Chatto authenticates users via two parallel mechanisms: HTTP-only cookie session
 **Decision:** Authentication workflows append durable audit facts to `EVT`, but token bodies, links, passwords, auth codes, raw IP addresses, and raw login/email identifiers stay out of the event log. Successful user-scoped facts live on `evt.user.{userId}`; anonymous/server-wide facts such as registration-link issuance and failed login attempts live on `evt.auth.server`.
 **Why:** `EVT` is Chatto's durable audit trail as well as the event-sourcing stream. Operators need to answer "what happened?" for sensitive workflows, but the audit log must not become a secondary secret store.
 **Tradeoff:** Failed-login events intentionally do not reveal whether the submitted identifier matched an account. Admins get timing, request metadata, and a stable identifier hash for correlation, not raw credential guesses.
+
+### 10. Short-lived auth codes in runtime state
+
+**Decision:** OAuth authorization codes live in `RUNTIME_STATE` as HMAC-derived `grant.{hmac}` records with a 5-minute per-key TTL and are deleted on exchange attempt.
+**Why:** Authorization codes are short-lived, single-use runtime credentials. They need restart survival and TTL enforcement, but they are not domain history and must not be copied into `EVT`.
+**Tradeoff:** The returned authorization code remains opaque and unchanged for clients, but the stored key is not human-recoverable from a backup without `[core].secret_key`.
 
 ## Permissions
 

--- a/examples/dockercompose/.env.example
+++ b/examples/dockercompose/.env.example
@@ -15,6 +15,7 @@ CHATTO_NATS_CLIENT_TOKEN=your-secure-token-here
 CHATTO_WEBSERVER_URL=https://chat.example.com
 CHATTO_WEBSERVER_PORT=4000
 CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET=your-cookie-secret-here
+CHATTO_CORE_SECRET_KEY=your-core-secret-here
 CHATTO_CORE_ASSETS_SIGNING_SECRET=your-assets-secret-here
 CHATTO_LOG_LEVEL=info
 

--- a/examples/dockercompose/README.md
+++ b/examples/dockercompose/README.md
@@ -32,6 +32,7 @@ This example deploys a clustered Chatto setup with:
    - `PUBLIC_URL` - Your domain (e.g., `chat.example.com`)
    - `NATS_TOKEN` and `CHATTO_NATS_CLIENT_TOKEN` - Must match (shared auth token)
    - `CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET` - Session cookie signing
+   - `CHATTO_CORE_SECRET_KEY` - Bearer-token and account-flow verifier key
    - `CHATTO_CORE_ASSETS_SIGNING_SECRET` - Asset URL signing
    - `CHATTO_LIVEKIT_API_KEY` / `CHATTO_LIVEKIT_API_SECRET` - Must match the keys in `livekit.yaml`
 

--- a/examples/k8s/README.md
+++ b/examples/k8s/README.md
@@ -109,6 +109,7 @@ Update these values (generate secrets with `openssl rand -hex 32`):
 - `NATS_TOKEN` and `CHATTO_NATS_CLIENT_TOKEN` - Must match
 - `CHATTO_WEBSERVER_URL` - Your domain (e.g., `https://chat.example.com`)
 - `CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET` - Session signing secret
+- `CHATTO_CORE_SECRET_KEY` - Bearer-token and account-flow verifier key
 - `CHATTO_CORE_ASSETS_SIGNING_SECRET` - Asset URL signing secret
 
 ### ingress.local.yaml

--- a/examples/k8s/secrets.yaml
+++ b/examples/k8s/secrets.yaml
@@ -26,6 +26,7 @@ stringData:
   CHATTO_WEBSERVER_URL: "https://chat.example.com"
   CHATTO_WEBSERVER_PORT: "4000"
   CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET: "your-cookie-secret-here"
+  CHATTO_CORE_SECRET_KEY: "your-core-secret-here"
   CHATTO_CORE_ASSETS_SIGNING_SECRET: "your-assets-secret-here"
   CHATTO_LOG_LEVEL: "info"
 

--- a/frontend/e2e/fixtures/chatto.toml
+++ b/frontend/e2e/fixtures/chatto.toml
@@ -19,6 +19,7 @@ cookie_signing_secret = '327201ce7e1a01980daac57c941f754a0fde9f08180d5e72599054d
 
 # Core service configuration.
 [core]
+secret_key = 'e2e-test-core-secret-do-not-use-in-production'
 
 [core.assets]
 signing_secret = 'e2e-test-signing-secret-do-not-use-in-production'


### PR DESCRIPTION
## Summary
- Add required core.secret_key / CHATTO_CORE_SECRET_KEY and generate it from chatto init.
- Store bearer sessions, OAuth codes, and account-flow tokens under HMAC-derived RUNTIME_STATE keys while keeping returned tokens unchanged.
- Remove the new raw-token compatibility migration path and update CLI configs, tests, repo docs, and docs-website guidance for backup/restore continuity.

## Tests
- mise x -- go test ./internal/config ./internal/core ./internal/migrations ./cmd -timeout 120s
- pnpm -C docs-website build