### PR TITLE
refactor: stop writing legacy server events

### DIFF
--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"math/rand"
 	"strconv"
 	"strings"
 	"time"
@@ -1146,34 +1145,6 @@ const natsPublishFlushTimeout = 5 * time.Second
 // subscription goroutine forever.
 const liveEVTProjectionWaitTimeout = 2 * time.Second
 
-// publishServerEvent publishes a legacy Event to NATS via the provided
-// server.> subject. Streams automatically capture events based on their
-// subject filters. Uses NATS Core publish (fire-and-forget) rather than
-// JetStream publish (which waits for acks).
-func (c *ChattoCore) publishServerEvent(_ context.Context, subject string, event *corev1.Event) error {
-	if err := validateEvent(event); err != nil {
-		return err
-	}
-
-	eventData, err := proto.Marshal(event)
-	if err != nil {
-		return fmt.Errorf("failed to marshal event: %w", err)
-	}
-
-	err = c.nc.Publish(subject, eventData)
-	if err != nil {
-		return fmt.Errorf("failed to publish event: %w", err)
-	}
-
-	// Flush to ensure the message reaches NATS immediately for stream capture.
-	err = c.nc.FlushTimeout(natsPublishFlushTimeout)
-	if err != nil {
-		return fmt.Errorf("failed to flush connection: %w", err)
-	}
-
-	return nil
-}
-
 // publishLiveEvent publishes a transient LiveEvent directly to a live.sync.>
 // subject, bypassing JetStream storage. The subject should already include
 // the "live.sync." prefix.
@@ -1195,100 +1166,6 @@ func (c *ChattoCore) publishLiveEvent(_ context.Context, subject string, event *
 		return fmt.Errorf("failed to flush live event to %s: %w", subject, err)
 	}
 	return nil
-}
-
-// publishServerEventWithAck publishes a legacy Event using JetStream and returns the sequence ID.
-// This uses synchronous JetStream publish (waits for ack) to get the sequence ID from the PubAck.
-// Use this when you need to know the sequence ID immediately (e.g., for message body storage).
-func (c *ChattoCore) publishServerEventWithAck(ctx context.Context, subject string, event *corev1.Event) (uint64, error) {
-	if err := validateEvent(event); err != nil {
-		return 0, err
-	}
-
-	eventData, err := proto.Marshal(event)
-	if err != nil {
-		return 0, fmt.Errorf("failed to marshal event: %w", err)
-	}
-
-	ack, err := c.js.Publish(ctx, subject, eventData)
-	if err != nil {
-		return 0, fmt.Errorf("failed to publish event: %w", err)
-	}
-
-	return ack.Sequence, nil
-}
-
-const maxOCCRetries = 5
-
-// publishServerEventWithOCC publishes a legacy Event to SERVER_EVENTS using Optimistic Concurrency Control.
-// It uses the Nats-Expected-Last-Subject-Sequence header to ensure that:
-// 1. We know the current state of the subject before publishing
-// 2. Concurrent publishes to the same subject are detected and retried
-//
-// This provides reliable message posting that handles race conditions gracefully.
-// The function retries up to 5 times on sequence mismatch errors with exponential backoff.
-func (c *ChattoCore) publishServerEventWithOCC(ctx context.Context, subject string, event *corev1.Event) (uint64, error) {
-	if err := validateEvent(event); err != nil {
-		return 0, err
-	}
-
-	eventData, err := proto.Marshal(event)
-	if err != nil {
-		return 0, fmt.Errorf("failed to marshal event: %w", err)
-	}
-
-	stream := c.storage.serverEventsStream
-
-	var lastErr error
-	for attempt := 1; attempt <= maxOCCRetries; attempt++ {
-		// Get the current last sequence for this subject
-		var expectedSeq uint64
-		msg, err := stream.GetLastMsgForSubject(ctx, subject)
-		if err != nil {
-			if !errors.Is(err, jetstream.ErrMsgNotFound) {
-				return 0, fmt.Errorf("failed to get last message for subject: %w", err)
-			}
-			// No messages yet for this subject - expect sequence 0
-			expectedSeq = 0
-		} else {
-			expectedSeq = msg.Sequence
-		}
-
-		// Publish with expected last subject sequence
-		ack, err := c.js.Publish(ctx, subject, eventData,
-			jetstream.WithExpectLastSequencePerSubject(expectedSeq))
-		if err == nil {
-			return ack.Sequence, nil
-		}
-
-		// Check if this is a sequence mismatch error (concurrent publish)
-		var jsErr *jetstream.APIError
-		if errors.As(err, &jsErr) && jsErr.ErrorCode == jetstream.JSErrCodeStreamWrongLastSequence {
-			c.logger.Debug("Sequence mismatch, retrying publish",
-				"subject", subject,
-				"expected_seq", expectedSeq,
-				"attempt", attempt,
-				"max_attempts", maxOCCRetries)
-			lastErr = err
-
-			// Exponential backoff with jitter to avoid thundering herd
-			// Base delay: 1ms, 2ms, 4ms, 8ms, 16ms for attempts 1-5
-			// Plus random jitter of 0-5ms to spread out concurrent retries
-			baseDelay := time.Duration(1<<(attempt-1)) * time.Millisecond
-			jitter := time.Duration(rand.Int63n(int64(5 * time.Millisecond)))
-			select {
-			case <-ctx.Done():
-				return 0, ctx.Err()
-			case <-time.After(baseDelay + jitter):
-			}
-			continue
-		}
-
-		// For any other error, fail immediately
-		return 0, fmt.Errorf("failed to publish event: %w", err)
-	}
-
-	return 0, fmt.Errorf("failed to publish event after %d attempts due to concurrent modifications: %w", maxOCCRetries, lastErr)
 }
 
 func validateEvent(event *corev1.Event) error {
@@ -1409,22 +1286,6 @@ func liveEventAsEvent(live *corev1.LiveEvent) *corev1.Event {
 // SERVER_* buckets (eager-created in newStorage). Kept as a stub so callers
 // don't have to be edited until the broader Space-retirement pass.
 func (c *ChattoCore) createSpaceResources(_ context.Context, _ string) error {
-	return nil
-}
-
-// purgeRoomEvents removes all events for a specific room from the server stream.
-// This is called when a room is deleted to clean up the room's event history.
-func (c *ChattoCore) purgeRoomEvents(ctx context.Context, kind RoomKind, roomID string) error {
-	stream := c.storage.serverEventsStream
-
-	// Purge all events matching the room's subject pattern
-	subjectFilter := subjects.RoomAllEvents(string(kind), roomID)
-	if err := stream.Purge(ctx, jetstream.WithPurgeSubject(subjectFilter)); err != nil {
-		return fmt.Errorf("failed to purge room events for %s (subject: %s): %w", roomID, subjectFilter, err)
-	}
-
-	c.logger.Debug("Purged room events from server stream", "kind", kind, "room_id", roomID, "subject_filter", subjectFilter)
-
 	return nil
 }
 

--- a/cli/internal/core/dm.go
+++ b/cli/internal/core/dm.go
@@ -152,9 +152,8 @@ func (c *ChattoCore) FindOrCreateDM(ctx context.Context, creatorID string, parti
 // this DM (same hashed roomID) is rejected with events.ErrConflict
 // — the caller (FindOrCreateDM) re-fetches.
 //
-// Post-batch side effects (per-participant read markers, legacy
-// live publishes) happen after the batch acks, since they're
-// outside the durable event log.
+// Post-batch side effects (per-participant read markers) happen after the
+// batch acks, since they're outside the durable event log.
 func (c *ChattoCore) createDMRoom(ctx context.Context, roomID string, participantIDs []string) (*corev1.Room, error) {
 	room := &corev1.Room{
 		Id:   roomID,
@@ -191,14 +190,12 @@ func (c *ChattoCore) createDMRoom(ctx context.Context, roomID string, participan
 			FilterSubject: agg.AllEventsFilter(),
 		},
 	}
-	joinEvents := make(map[string]*corev1.Event, len(participantIDs))
 	for _, pid := range participantIDs {
 		joinEvent := newEvent(pid, &corev1.Event{
 			Event: &corev1.Event_UserJoinedRoom{
 				UserJoinedRoom: &corev1.UserJoinedRoomEvent{RoomId: roomID},
 			},
 		})
-		joinEvents[pid] = joinEvent
 		entries = append(entries, events.BatchEntry{
 			Subject: agg.SubjectFor(joinEvent),
 			Event:   joinEvent,
@@ -228,17 +225,12 @@ func (c *ChattoCore) createDMRoom(ctx context.Context, roomID string, participan
 		c.logger.Warn("DM room timeline projection wait failed", "error", err, "room_id", roomID)
 	}
 
-	// Per-participant non-batched side effects: initialise the
-	// read marker (so HasUnread distinguishes a fresh member from a
-	// deploy-era user; see GetLastReadEventID), and write legacy
-	// SERVER_EVENTS copies for migration/import tooling.
-	legacySubject := subjects.RoomMeta(string(KindDM), roomID)
+	// Per-participant non-batched side effects: initialise the read marker so
+	// HasUnread distinguishes a fresh member from a deploy-era user; see
+	// GetLastReadEventID.
 	for _, pid := range participantIDs {
 		if err := c.SetLastReadEventID(ctx, KindDM, pid, roomID, ""); err != nil {
 			c.logger.Warn("Failed to initialize DM read marker", "error", err, "user_id", pid, "room_id", roomID)
-		}
-		if err := c.publishServerEvent(ctx, legacySubject, joinEvents[pid]); err != nil {
-			c.logger.Error("failed to publish UserJoinedRoomEvent for DM (legacy)", "error", err, "user_id", pid, "room_id", roomID)
 		}
 	}
 

--- a/cli/internal/core/event_publishing_test.go
+++ b/cli/internal/core/event_publishing_test.go
@@ -14,46 +14,57 @@ func TestEventPublishingHelpers_RejectInvalidEvents(t *testing.T) {
 	core := &ChattoCore{}
 	ctx := testContext(t)
 
-	t.Run("publishServerEvent rejects nil pointer", func(t *testing.T) {
-		err := core.publishServerEvent(ctx, "space.test", nil)
-		if !errors.Is(err, ErrInvalidEvent) {
-			t.Fatalf("expected ErrInvalidEvent, got: %v", err)
-		}
-	})
-
-	t.Run("publishServerEvent rejects unset oneof payload", func(t *testing.T) {
-		err := core.publishServerEvent(ctx, "space.test", &corev1.Event{})
-		if !errors.Is(err, ErrInvalidEvent) {
-			t.Fatalf("expected ErrInvalidEvent, got: %v", err)
-		}
-	})
-
 	t.Run("publishLiveEvent rejects invalid payload", func(t *testing.T) {
 		err := core.publishLiveEvent(ctx, "live.sync.test", &corev1.LiveEvent{})
 		if !errors.Is(err, ErrInvalidEvent) {
 			t.Fatalf("expected ErrInvalidEvent, got: %v", err)
 		}
 	})
+}
 
-	t.Run("publishServerEventWithAck rejects invalid payload", func(t *testing.T) {
-		seq, err := core.publishServerEventWithAck(ctx, "space.test", &corev1.Event{})
-		if seq != 0 {
-			t.Fatalf("expected sequence 0 on error, got: %d", seq)
-		}
-		if !errors.Is(err, ErrInvalidEvent) {
-			t.Fatalf("expected ErrInvalidEvent, got: %v", err)
-		}
-	})
+func TestRoomMutationsDoNotWriteServerEvents(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
 
-	t.Run("publishServerEventWithOCC rejects invalid payload", func(t *testing.T) {
-		seq, err := core.publishServerEventWithOCC(ctx, "space.test", &corev1.Event{})
-		if seq != 0 {
-			t.Fatalf("expected sequence 0 on error, got: %d", seq)
-		}
-		if !errors.Is(err, ErrInvalidEvent) {
-			t.Fatalf("expected ErrInvalidEvent, got: %v", err)
-		}
-	})
+	user, err := core.CreateUser(ctx, "system", "serverevents-user", "Server Events User", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	other, err := core.CreateUser(ctx, "system", "serverevents-other", "Server Events Other", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser other: %v", err)
+	}
+
+	room, err := core.CreateRoom(ctx, user.Id, KindChannel, "", "serverevents_room", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom: %v", err)
+	}
+	if _, err := core.UpdateRoom(ctx, user.Id, KindChannel, room.Id, "serverevents_room_2", "updated"); err != nil {
+		t.Fatalf("UpdateRoom: %v", err)
+	}
+	if _, err := core.ArchiveRoom(ctx, user.Id, KindChannel, room.Id); err != nil {
+		t.Fatalf("ArchiveRoom: %v", err)
+	}
+	if _, err := core.UnarchiveRoom(ctx, user.Id, KindChannel, room.Id); err != nil {
+		t.Fatalf("UnarchiveRoom: %v", err)
+	}
+	if _, _, err := core.FindOrCreateDM(ctx, user.Id, []string{other.Id}); err != nil {
+		t.Fatalf("FindOrCreateDM: %v", err)
+	}
+	if err := core.DeleteRoom(ctx, user.Id, KindChannel, room.Id); err != nil {
+		t.Fatalf("DeleteRoom: %v", err)
+	}
+
+	count, err := countStreamMessages(ctx, core.storage.serverEventsStream, []string{"server.>"})
+	if err != nil {
+		t.Fatalf("count SERVER_EVENTS messages: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("SERVER_EVENTS got %d runtime messages, want 0", count)
+	}
 }
 
 // setupRoomWithMessage creates a user, a room, joins the user, and posts one

--- a/cli/internal/core/room_membership.go
+++ b/cli/internal/core/room_membership.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/nats-io/nats.go/jetstream"
 
-	"hmans.de/chatto/internal/core/subjects"
 	"hmans.de/chatto/internal/events"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
@@ -44,11 +43,10 @@ func (c *ChattoCore) RoomMembershipExists(ctx context.Context, kind RoomKind, us
 // pairs, and we early-out via IsMember).
 // Authorization: Caller must verify CanJoinRoom before calling.
 //
-// ADR-035 phase 6: event-only. Publishes UserJoinedRoomEvent to EVT, writes
-// a legacy SERVER_EVENTS copy for migration/import tooling, then WaitForSeq
-// on the projections that serve membership and room history reads. The
-// room_membership KV bucket is no longer written to (retained as pre-ES
-// import evidence).
+// ADR-035 phase 6: event-only. Publishes UserJoinedRoomEvent to EVT, then
+// WaitForSeq on the projections that serve membership and room history reads.
+// The room_membership KV bucket and SERVER_EVENTS mirrors are no longer
+// written to (retained as pre-ES import evidence).
 func (c *ChattoCore) JoinRoom(ctx context.Context, actorID string, kind RoomKind, user_id, room_id string) (*corev1.RoomMembership, error) {
 	// Verify room exists and is not archived
 	room, err := c.GetRoom(ctx, kind, room_id)
@@ -116,13 +114,6 @@ func (c *ChattoCore) JoinRoom(ctx context.Context, actorID string, kind RoomKind
 		return nil, fmt.Errorf("publish UserJoinedRoomEvent retry exhausted after %d attempts: %w", maxJoinRoomRetries, events.ErrConflict)
 	}
 
-	// Legacy SERVER_EVENTS copy retained for migration/import tooling.
-	// Best-effort; failures are logged but don't roll back the join.
-	legacySubject := subjects.RoomMeta(string(kind), room_id)
-	if err := c.publishServerEvent(ctx, legacySubject, event); err != nil {
-		c.logger.Error("failed to publish UserJoinedRoomEvent (legacy)", "error", err, "user_id", user_id, "room_id", room_id)
-	}
-
 	c.logger.Info("Created room membership", "user_id", user_id, "kind", kind, "room_id", room_id)
 
 	// Initialize the read marker for new members. For non-empty rooms, mark
@@ -152,9 +143,8 @@ func (c *ChattoCore) JoinRoom(ctx context.Context, actorID string, kind RoomKind
 //   - Global rooms grant implicit membership to every server member and
 //     cannot be left (users can mute them via notification preferences).
 //
-// ADR-035 phase 6: event-only. Publishes UserLeftRoomEvent, legacy
-// mirror, then WaitForSeq on the projections that serve membership
-// and room history reads.
+// ADR-035 phase 6: event-only. Publishes UserLeftRoomEvent, then WaitForSeq on
+// the projections that serve membership and room history reads.
 func (c *ChattoCore) LeaveRoom(ctx context.Context, actorID string, kind RoomKind, user_id, room_id string) error {
 	if kind == KindDM {
 		return ErrCannotLeaveDMConversation
@@ -178,11 +168,6 @@ func (c *ChattoCore) LeaveRoom(ctx context.Context, actorID string, kind RoomKin
 	}
 	if err := c.RoomTimelineProjector.WaitForSeq(ctx, seq); err != nil {
 		return fmt.Errorf("wait for room timeline projection: %w", err)
-	}
-
-	legacySubject := subjects.RoomMeta(string(kind), room_id)
-	if err := c.publishServerEvent(ctx, legacySubject, event); err != nil {
-		c.logger.Error("failed to publish UserLeftRoomEvent (legacy)", "error", err, "user_id", user_id, "room_id", room_id)
 	}
 
 	c.logger.Info("Deleted room membership", "user_id", user_id, "kind", kind, "room_id", room_id)
@@ -280,10 +265,6 @@ func (c *ChattoCore) deleteUserRoomMembershipsInSpace(ctx context.Context, user_
 			lastSeq = seq
 		}
 
-		subject := subjects.RoomMeta(string(kind), entry.roomID)
-		if err := c.publishServerEvent(ctx, subject, event); err != nil {
-			c.logger.Warn("Failed to publish UserLeftRoomEvent (legacy)", "room_id", entry.roomID, "error", err)
-		}
 	}
 
 	if len(entries) > 0 {

--- a/cli/internal/core/rooms.go
+++ b/cli/internal/core/rooms.go
@@ -344,8 +344,8 @@ func (c *ChattoCore) UpdateRoom(ctx context.Context, actorID string, kind RoomKi
 // ADR-035 phase 6: event-only. Publishes RoomDeletedEvent (which both
 // the catalog and membership projections apply as a drop) and, for
 // channel rooms in a group, a RoomRemovedFromGroupEvent cascade per
-// ADR-034 Approach A. Stream events are purged after the projections
-// catch up; the legacy KV room record is no longer touched here.
+// ADR-034 Approach A. Historical room events are retained in EVT; the
+// legacy KV room record is no longer touched here.
 func (c *ChattoCore) DeleteRoom(ctx context.Context, actorID string, kind RoomKind, room_id string) error {
 	room, err := c.GetRoom(ctx, kind, room_id)
 	if err != nil {

--- a/cli/internal/core/rooms.go
+++ b/cli/internal/core/rooms.go
@@ -10,27 +10,10 @@ import (
 	"time"
 
 	"github.com/nats-io/nats.go/jetstream"
-	"google.golang.org/protobuf/proto"
 
-	"hmans.de/chatto/internal/core/subjects"
 	"hmans.de/chatto/internal/events"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
-
-// getRoomLastMessage fetches the last message in a room directly from JetStream.
-// Returns nil if no messages exist for this room yet.
-func (c *ChattoCore) getRoomLastMessage(ctx context.Context, kind RoomKind, roomID string) (*jetstream.RawStreamMsg, error) {
-	stream := c.storage.serverEventsStream
-
-	msg, err := stream.GetLastMsgForSubject(ctx, subjects.RoomAllMessages(string(kind), roomID))
-	if err != nil {
-		if errors.Is(err, jetstream.ErrMsgNotFound) {
-			return nil, nil // No messages yet
-		}
-		return nil, fmt.Errorf("failed to get last message for room: %w", err)
-	}
-	return msg, nil
-}
 
 // getRoomLastRootEvent returns the most recent root MessagePostedEvent
 // (excluding thread replies) in a room, or nil if none have been
@@ -71,21 +54,6 @@ func (c *ChattoCore) GetRoomLastMessageAt(ctx context.Context, kind RoomKind, ro
 		return time.Time{}, nil
 	}
 	return ev.GetCreatedAt().AsTime(), nil
-}
-
-// rawMsgEventCreatedAt unmarshals a JetStream message as a SpaceEvent and
-// returns its `created_at` time. Returns zero time + nil error if the
-// message has no proto-level timestamp (defensive — every event we
-// publish carries one).
-func rawMsgEventCreatedAt(msg *jetstream.RawStreamMsg) (time.Time, error) {
-	var event corev1.Event
-	if err := proto.Unmarshal(msg.Data, &event); err != nil {
-		return time.Time{}, fmt.Errorf("unmarshal event for timestamp: %w", err)
-	}
-	if event.CreatedAt == nil {
-		return time.Time{}, nil
-	}
-	return event.CreatedAt.AsTime(), nil
 }
 
 // Room name validation constants
@@ -217,13 +185,6 @@ func (c *ChattoCore) CreateRoom(ctx context.Context, actorID string, kind RoomKi
 			c.logger.Warn("Failed to add new room to set layout",
 				"error", err, "room_id", room_id, "group_id", groupID)
 		}
-	}
-
-	// Legacy SERVER_EVENTS copy retained for migration/import tooling.
-	// SERVER_EVENTS no longer participates in live delivery.
-	subject := subjects.RoomMeta(string(kind), room_id)
-	if _, err := c.publishServerEventWithAck(ctx, subject, createdEvent); err != nil {
-		c.logger.Error("failed to publish room created event (legacy)", "error", err, "room_id", room_id)
 	}
 
 	if strings.EqualFold(name, AnnouncementsRoomName) {
@@ -366,11 +327,6 @@ func (c *ChattoCore) UpdateRoom(ctx context.Context, actorID string, kind RoomKi
 		}
 	}
 
-	subject := subjects.RoomMeta(string(kind), room_id)
-	if err := c.publishServerEvent(ctx, subject, updatedEvent); err != nil {
-		c.logger.Error("failed to publish room updated event (legacy)", "error", err, "room_id", room_id)
-	}
-
 	c.logger.Info("Room updated", "kind", kind, "room_id", room_id, "name", name)
 
 	if err := c.RoomCatalogProjector.WaitForSeq(ctx, updatedSeq); err != nil {
@@ -425,17 +381,6 @@ func (c *ChattoCore) DeleteRoom(ctx context.Context, actorID string, kind RoomKi
 		if err != nil {
 			c.logger.Error("failed to publish RoomRemovedFromGroupEvent for delete cascade", "error", err, "room_id", room_id, "group_id", room.GetGroupId())
 		}
-	}
-
-	subject := subjects.RoomMeta(string(kind), room_id)
-	if err := c.publishServerEvent(ctx, subject, event); err != nil {
-		c.logger.Error("failed to publish room deleted event (legacy)", "error", err, "room_id", room_id)
-	}
-
-	// Purge room events from the space stream (best-effort — orphan
-	// events can be cleaned up manually if this fails).
-	if err := c.purgeRoomEvents(ctx, kind, room_id); err != nil {
-		c.logger.Error("failed to purge room events", "error", err, "kind", kind, "room_id", room_id)
 	}
 
 	// (Phase-6 note: pre-phase-6 we had to walk room_group docs to
@@ -495,10 +440,6 @@ func (c *ChattoCore) ArchiveRoom(ctx context.Context, actorID string, kind RoomK
 		return nil, fmt.Errorf("wait for room timeline projection: %w", err)
 	}
 
-	subject := subjects.RoomMeta(string(kind), roomID)
-	if err := c.publishServerEvent(ctx, subject, archivedEvent); err != nil {
-		c.logger.Error("failed to publish room archived event (legacy)", "error", err, "room_id", roomID)
-	}
 	if err := c.PublishRoomGroupsUpdated(ctx, actorID, kind); err != nil {
 		c.logger.Error("failed to publish room layout updated event after archive", "error", err)
 	}
@@ -534,10 +475,6 @@ func (c *ChattoCore) UnarchiveRoom(ctx context.Context, actorID string, kind Roo
 		return nil, fmt.Errorf("wait for room timeline projection: %w", err)
 	}
 
-	subject := subjects.RoomMeta(string(kind), roomID)
-	if err := c.publishServerEvent(ctx, subject, unarchivedEvent); err != nil {
-		c.logger.Error("failed to publish room unarchived event (legacy)", "error", err, "room_id", roomID)
-	}
 	if err := c.PublishRoomGroupsUpdated(ctx, actorID, kind); err != nil {
 		c.logger.Error("failed to publish room layout updated event after unarchive", "error", err)
 	}

--- a/cli/internal/migrations/messages_es_test.go
+++ b/cli/internal/migrations/messages_es_test.go
@@ -86,8 +86,8 @@ func setupMessagesRig(t *testing.T) *messagesTestRig {
 }
 
 // publishLegacy publishes a *corev1.Event onto the legacy
-// SERVER_EVENTS-shaped stream at the given subject. Mirrors what
-// publishServerEventWithAck does in production.
+// SERVER_EVENTS-shaped stream at the given subject. This simulates pre-ES
+// legacy events for the import migration.
 func (r *messagesTestRig) publishLegacy(t *testing.T, subject string, ev *corev1.Event) {
 	t.Helper()
 	data, err := proto.Marshal(ev)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -800,5 +800,5 @@ Messages are persisted as durable `EVT` facts with encrypted message bodies embe
 - **Compression**: The `EVT` and legacy `SERVER_EVENTS` streams use S2 compression to reduce storage costs
 - **GDPR Compliance**: Message bodies are encrypted per author; deletion is represented by EVT retraction/shred facts and projections refuse to render shredded or retracted content.
 - **Unified Server Storage**: Channels and DMs share the same `SERVER_*` buckets; the `kind` segment in keys (`room.channel.*` / `room.dm.*`) disambiguates without per-space isolation
-- **Out-of-Band Data Pattern**: High-volume content (message bodies) separated into dedicated `SERVER_BODIES` to avoid contention with metadata operations, enable independent scaling, and support future optimizations (compression, different storage backends)
+- **Legacy Body Store**: `SERVER_BODIES` is retained for pre-ES imports and legacy backup restores; new message bodies are encrypted into `MessagePostedEvent.body` and projected from `EVT`.
 - **Eager Server Resource Initialization**: The unified `SERVER_*` buckets (stream, KV buckets, object store) are created up-front at boot, not lazily on first use. The Phase 4 migration (#354) retired the legacy lazycache fallback that briefly accommodated the per-space storage shape.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -268,7 +268,7 @@ There is no `adminAuditLogEvents` subscription — audit events arrive through `
 | Objects | `INSTANCE_ASSETS`             | Avatars, icons (bucket name retained from pre-rename) |
 | Objects | `ASSET_CACHE`                 | Cached resized images (optional, with TTL)  |
 | Objects | `SERVER_ASSETS`               | Message attachments                         |
-| Stream  | `SERVER_EVENTS`               | Room/membership events                      |
+| Stream  | `SERVER_EVENTS`               | Legacy room event import source; no new runtime writes |
 
 See [NATS Resource Inventory](#nats-resource-inventory) for detailed key patterns and subjects.
 
@@ -370,7 +370,7 @@ The distinction between stored and live-only events is based on how they're publ
 User-facing live delivery is built from two internal NATS Core subject roots:
 
 1. **Primary Stream** (persistent):
-   - `SERVER_EVENTS` (subjects `server.>`) holds legacy room messages, thread replies, room meta lifecycle, and server-level member events for migration/import tooling. It no longer participates in live delivery.
+   - `SERVER_EVENTS` (subjects `server.>`) holds pre-ES room messages, thread replies, room meta lifecycle, and server-level member events for migration/import tooling. Runtime mutations no longer write it, and it no longer participates in live delivery.
    - `EVT` (subjects `evt.>`) holds event-sourced domain state. Its stream-level `RePublish` config forwards every committed event once onto `live.evt.>`. This is a raw committed-event feed, not a client contract.
 2. **Direct Live Publish** (transient):
    - Transient UI sync signals publish as `corev1.LiveEvent` via NATS Core to `live.sync.>` — no stream storage.
@@ -381,13 +381,13 @@ The `myEvents` GraphQL subscription is backed by one core stream (`StreamMyEvent
 
 | Stream                       | Wrapper          | Scope      | Description                                      |
 | ---------------------------- | ---------------- | ---------- | ------------------------------------------------ |
-| `SERVER_EVENTS`              | `corev1.Event`   | Server     | JetStream-stored events for the legacy CRUD+log pattern; retained for migration/import tooling and no longer part of live delivery. |
+| `SERVER_EVENTS`              | `corev1.Event`   | Server     | Pre-ES room/member event log retained for boot imports and inspection; no new runtime writes and no live delivery. |
 | `EVT`                        | `corev1.Event`   | Server     | Event-sourcing log ([ADR-033](adr/ADR-033-event-sourced-state-with-projections.md) / [ADR-034](adr/ADR-034-single-event-stream.md)). Subjects `evt.{aggregateType}.{aggregateId}.{eventType}`; republishes onto `live.evt.>` as the raw committed-event feed. Currently fed by per-aggregate boot imports ([ADR-035](adr/ADR-035-per-aggregate-phased-migration.md)); migrated aggregates include room membership/metadata, groups/layout, server config, users, messages/threads, reactions, RBAC, and auth workflow audit facts. |
 | Live Sync                    | `corev1.LiveEvent` | Transient  | Direct NATS Core pubsub on `live.sync.>` for transient UI sync signals. `myEvents` authorizes and adapts these messages into GraphQL events; they are never projection input. |
 
-**SERVER\_EVENTS subjects:**
+**SERVER\_EVENTS subjects (legacy import source):**
 
-Room events include event IDs in subjects for O(1) lookups via `GetLastMsgForSubject`. The `{kind}` segment (`channel` or `dm`) lets a single subject namespace serve both server-space rooms and DM rooms.
+Pre-ES room events included event IDs in subjects for O(1) lookups via `GetLastMsgForSubject`. Current runtime reads use `EVT` projections instead; these subjects are documented so migrations and debugging tools can interpret historical data. The `{kind}` segment (`channel` or `dm`) lets a single subject namespace serve both server-space rooms and DM rooms.
 
 | Subject                                                                       | Description                                    |
 | ----------------------------------------------------------------------------- | ---------------------------------------------- |
@@ -396,7 +396,7 @@ Room events include event IDs in subjects for O(1) lookups via `GetLastMsgForSub
 | `server.room.{kind}.{roomId}.msg.{rootEventId}.replies.{eventId}`             | Thread reply posted                            |
 | `server.room.{kind}.{roomId}.meta`                                            | Room lifecycle + membership                    |
 
-The event ID in message subjects enables O(1) lookup (52µs) instead of O(n) scanning. Memory overhead is ~500 bytes per unique subject, which is bounded by TTL-based retention.
+The old event ID in message subjects enabled O(1) lookup (52µs) instead of O(n) scanning. Runtime message lookup now comes from `RoomTimelineProjection` rebuilt from `EVT`.
 
 Filtering examples:
 
@@ -428,7 +428,7 @@ Patterns: `live.sync.>` for transient `LiveEvent` pubsub and `live.evt.>` for ra
 - Direct NATS Core publishes (`publishLiveEvent()`): transient `corev1.LiveEvent` messages on `live.sync.>` with no stream storage.
 - `EVT` RePublish (`evt.>` → `live.evt.>`): every committed event-sourced fact is re-emitted once by JetStream. Chatto replicas must wait for local projection readiness and authorize before exposing deliverable room events to clients.
 
-`SERVER_EVENTS` no longer has a `RePublish` live path. Remaining legacy `server.>` writes are for storage/import compatibility while aggregates finish migrating to EVT.
+`SERVER_EVENTS` no longer has a `RePublish` live path and runtime code no longer writes legacy `server.>` mirrors. Remaining use is boot-import/read-only inspection of pre-ES data.
 
 **Transient live sync events** (`live.sync.{user,config,room}.>`):
 
@@ -758,28 +758,26 @@ All transformed images are encoded as WebP for optimal compression and quality.
 
 ### Messages
 
-Messages use a store-then-publish pattern optimized for reliability and GDPR compliance:
+Messages are persisted as durable `EVT` facts with encrypted message bodies embedded in `MessagePostedEvent.body`. The older `SERVER_EVENTS` + `SERVER_BODIES` store-then-publish shape is retained only as import evidence and for legacy backup restores.
 
 **Message Identifiers:**
 
-- **Event ID**: NanoID (e.g., `E...`) used for event identification, body storage, and lookups via O(1) subject matching
-- **Body Key**: Compound key `{userId}.{eventId}` stored in `MessagePostedEvent.message_body_id`
+- **Event ID**: NanoID (e.g., `E...`) used for event identification, message-body identity, and projection lookup
+- **Body Key**: `MessagePostedEvent.message_body_id` is now an alias for the event ID; older imported messages may still reference the legacy `{userId}.{eventId}` compound key
 
 **Write Path:**
 
 1. Generate event with event ID
-2. Construct body key as `{userId}.{eventId}` and store body in BODIES bucket
-3. Publish event to room stream
-4. `PublishAck.Sequence` is captured and added to the event for resolvers
-5. Body exists before event is delivered - no race conditions
+2. Encrypt and embed the message body in `MessagePostedEvent.body`
+3. Append the event to `evt.room.{roomId}.message_posted`
+4. Wait for local projections to reach the append sequence before serving read-your-writes
 
 **Threading:**
 
 - `in_reply_to` field stores the event ID of the parent message (empty for top-level messages)
 - `in_thread` field stores the event ID of the thread root (empty for top-level messages)
-- Thread subject pattern: `server.room.{kind}.{roomId}.msg.{rootEventId}.replies.{eventId}`
-- Enables O(1) lookup of thread replies via wildcard pattern: `msg.*.replies.{eventId}`
-- Thread metadata (reply count, participants) stored in THREADS bucket keyed by `{roomId}.{rootEventId}`
+- Thread replies are ordinary `MessagePostedEvent` facts on `evt.room.{roomId}.message_posted` with `in_thread` set to the root event ID.
+- Thread reply lists, reply counts, participants, and last-reply timestamps are derived from the `ThreadProjection`; `SERVER_THREADS` is legacy import/storage evidence only.
 
 **@Mentions:**
 
@@ -793,15 +791,14 @@ Messages use a store-then-publish pattern optimized for reliability and GDPR com
 
 **GDPR Deletion:**
 
-- Delete only removes the KV entry in BODIES bucket using the compound key
-- Event remains in stream as audit record with empty body
-- `GetMessageBody` returns empty string for deleted messages
+- Delete appends `MessageRetractedEvent` to `EVT`; projections tombstone the message body before rendering.
+- Attachment bytes are deleted from backing object storage best-effort and corresponding asset deletion facts are appended.
 
 ### Key Patterns
 
-- **Unified Event Subscriptions**: The `myEvents` subscription merges multiple event sources into a single stream: a JetStream ordered consumer (using `DeliverNewPolicy` for real-time delivery), NATS Core subscriptions for live-only events, and a PresenceHub subscription for presence updates.
-- **Compression**: The `SERVER_EVENTS` stream uses S2 compression to reduce storage costs
-- **GDPR Compliance**: Message bodies stored separately in `SERVER_BODIES` for compliant deletion while preserving audit trail
+- **Unified Event Subscriptions**: The `myEvents` subscription merges EVT republish (`live.evt.>`), transient sync (`live.sync.>`), and PresenceHub updates into one authorized user stream.
+- **Compression**: The `EVT` and legacy `SERVER_EVENTS` streams use S2 compression to reduce storage costs
+- **GDPR Compliance**: Message bodies are encrypted per author; deletion is represented by EVT retraction/shred facts and projections refuse to render shredded or retracted content.
 - **Unified Server Storage**: Channels and DMs share the same `SERVER_*` buckets; the `kind` segment in keys (`room.channel.*` / `room.dm.*`) disambiguates without per-space isolation
 - **Out-of-Band Data Pattern**: High-volume content (message bodies) separated into dedicated `SERVER_BODIES` to avoid contention with metadata operations, enable independent scaling, and support future optimizations (compression, different storage backends)
 - **Eager Server Resource Initialization**: The unified `SERVER_*` buckets (stream, KV buckets, object store) are created up-front at boot, not lazily on first use. The Phase 4 migration (#354) retired the legacy lazycache fallback that briefly accommodated the per-space storage shape.

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -112,7 +112,7 @@ Infrastructure jargon. If only contributors say the word, it goes here.
 
 **JetStream** — NATS's persistence layer (streams + KV buckets). Chatto's primary data store. See [ADR-001](adr/ADR-001-nats-jetstream-as-primary-data-store.md).
 
-**Stream** — JetStream append-only log. Chatto's event-sourcing stream is `EVT`; the older `SERVER_EVENTS` stream remains during migration for legacy CRUD/log data and import tooling.
+**Stream** — JetStream append-only log. Chatto's event-sourcing stream is `EVT`; the older `SERVER_EVENTS` stream remains as pre-ES import evidence and for legacy restore/debugging tools, but runtime mutations no longer write it.
 
 **KV (Key-Value Bucket)** — JetStream-backed key/value store. Chatto uses several (`SERVER_CONFIG`, `SERVER_RBAC`, `KV_INSTANCE`, …). KV is the source of truth; streams are the audit log. See [ADR-006](adr/ADR-006-kv-source-of-truth-streams-audit-log.md).
 

--- a/docs/fdr/FDR-019-room-lifecycle.md
+++ b/docs/fdr/FDR-019-room-lifecycle.md
@@ -1,7 +1,7 @@
 # FDR-019: Room Lifecycle
 
 **Status:** Active
-**Last reviewed:** 2026-05-19
+**Last reviewed:** 2026-05-31
 
 ## Overview
 
@@ -13,16 +13,16 @@ A channel room goes through a lifecycle of create, edit, archive, unarchive, and
 - **Edit** — `room.manage` holders can change the name, description, and group of an existing room.
 - **Archive** — `room.manage` toggles an `archived` flag on the room. Archived rooms vanish from the sidebar, the Browse Rooms page, and search results, but members stay joined and history is intact. The owner can still navigate to the room directly.
 - **Unarchive** — same permission, flips the flag back. The room reappears in the sidebar and discovery surfaces.
-- **Delete** — `room.manage` permanently removes the room: the KV record, the name claim, the stream events filtered by the room's subject namespace, and the membership records.
+- **Delete** — `room.manage` appends `RoomDeletedEvent` to `EVT`, releases the room from its group layout, and causes projections to remove the room, its name claim, and its memberships.
 - Moving a room between groups requires `room.manage` in both groups (see FDR-017).
 
 ## Design Decisions
 
-### 1. Room name uniqueness via atomic KV claim
+### 1. Room name uniqueness via EVT projection and OCC
 
-**Decision:** Room names are unique server-wide (case-insensitive). Uniqueness is enforced by `kv.Create()` on a `room_name_index.*` key — atomic with the room record creation. Read-then-write would race; the create-claim doesn't.
-**Why:** Race-tolerant name claiming is the only way to safely handle two operators creating the same-named room at the same moment. The KV `Create` semantics (fails if key exists) give us atomicity for free.
-**Tradeoff:** Renames are a delete-claim-then-recreate dance — slightly more complex than a simple update. The name index also has to be kept in sync with the room record, but the operations live in one transaction.
+**Decision:** Room names are unique server-wide (case-insensitive). Uniqueness is enforced by checking the room catalog projection and appending name-changing room events with wildcard OCC against the room aggregate event set.
+**Why:** Race-tolerant name claiming is the only way to safely handle two operators creating the same-named room at the same moment. EVT OCC lets the event log remain the source of truth without maintaining a legacy KV name mirror.
+**Tradeoff:** Renames must coordinate through the event log and projection readiness instead of a single KV claim. The payoff is no dual-write divergence.
 
 ### 2. Every channel room belongs to exactly one group
 
@@ -36,11 +36,11 @@ A channel room goes through a lifecycle of create, edit, archive, unarchive, and
 **Why:** Archive's purpose is "stop showing this room everywhere, but don't lose the history". A full archived-rooms-elsewhere migration would mean different code paths for archived rooms, divergent reads, and a hard road back to active state. A flag is enough.
 **Tradeoff:** Every "show me rooms" query needs to remember to filter on `archived`. Centralised in the resolver layer.
 
-### 4. Delete is destructive and scoped to the room's subjects
+### 4. Delete is a durable tombstone
 
-**Decision:** Deleting a room publishes an audit event first, then deletes the room record, releases the name claim, and purges all JetStream events under the room's subject prefix (`server.room.{kind}.{roomId}.*`).
-**Why:** Half-deleted rooms — record gone but events still in the stream — are worse than no deletion at all. They show up in event queries as orphans. Scoped purging is the only way to actually be done.
-**Tradeoff:** The purge is a non-trivial JetStream operation. We log progress and treat partial failure as an incident; in practice it's reliable.
+**Decision:** Deleting a room appends a durable `RoomDeletedEvent` to `EVT`. Projections remove the room from user-visible catalogs and membership state; historical facts remain in the event log.
+**Why:** `EVT` is both source of truth and audit log. Purging the room's event history would destroy the forensic trail and make replay semantics dependent on destructive stream operations.
+**Tradeoff:** Deleted-room history still consumes storage. User-visible reads must consistently respect the tombstone.
 
 ### 5. Membership survives archive
 
@@ -62,5 +62,5 @@ A channel room goes through a lifecycle of create, edit, archive, unarchive, and
 
 ## Related
 
-- **ADRs:** ADR-006 (KV as source of truth), ADR-031 (room-group-centric ACL)
+- **ADRs:** ADR-031 (room-group-centric ACL), ADR-033 (event-sourced state with projections), ADR-035 (per-aggregate phased migration)
 - **FDRs:** FDR-001 (Roles & Permissions), FDR-007 (Direct Messages), FDR-017 (Room Groups & Sidebar Layout)


### PR DESCRIPTION
## Summary
- Remove runtime SERVER_EVENTS mirror publishing and room-event purging from room, membership, and DM mutations.
- Keep room reads on EVT projections and add coverage that room mutations do not write legacy server events.
- Update ARCHITECTURE, GLOSSARY, and FDR-019 to describe SERVER_EVENTS as legacy import/debug evidence only.

## Tests
- mise x -- go test ./internal/core ./internal/migrations -count=1
- mise x -- go test ./internal/graph ./internal/events -count=1
- mise x -- go test -tags test_endpoints ./internal/http_server -run 'TestAuthRoutes|TestOAuth|TestPassword|TestRegistration|TestForgot|TestReset|TestGraphQL|TestAsset|TestWebSocket' -count=1
- git diff --check