### PR TITLE
refactor: remove legacy server threads bucket

### DIFF
--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -791,7 +791,6 @@ type storage struct {
 	serverRBACEngine   *Engine               // Engine wrapping serverRBACKV
 	serverBodiesKV     jetstream.KeyValue    // SERVER_BODIES    - message bodies + attachment metadata records (#330 phase 4c). TODO: rename → SERVER_CONTENT now that it hosts more than bodies.
 	serverReactionsKV  jetstream.KeyValue    // SERVER_REACTIONS - emoji reactions (#330 phase 4c)
-	serverThreadsKV    jetstream.KeyValue    // SERVER_THREADS   - thread metadata (#330 phase 4c)
 	serverAttachments  jetstream.ObjectStore // SERVER_ASSETS    - message attachment binaries (#330 phase 4e)
 	serverEventsStream jetstream.Stream      // SERVER_EVENTS    - event stream (#330 phase 4d)
 	serverEvtStream    jetstream.Stream      // EVT       - event-sourcing log (ADR-033/034). Coexists with SERVER_EVENTS during migration.
@@ -963,16 +962,6 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		return nil, fmt.Errorf("failed to create SERVER_REACTIONS KV bucket: %w", err)
 	}
 
-	serverThreadsKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
-		Bucket:      "SERVER_THREADS",
-		Description: "Server-level thread metadata",
-		Storage:     jetstream.FileStorage,
-		Replicas:    cfg.Replicas,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create SERVER_THREADS KV bucket: %w", err)
-	}
-
 	serverAttachments, err := js.CreateOrUpdateObjectStore(ctx, jetstream.ObjectStoreConfig{
 		Bucket:      "SERVER_ASSETS",
 		Description: "Server-level message attachments",
@@ -1047,7 +1036,6 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		serverRuntimeKV:    serverRuntimeKV,
 		serverBodiesKV:     serverBodiesKV,
 		serverReactionsKV:  serverReactionsKV,
-		serverThreadsKV:    serverThreadsKV,
 		serverAttachments:  serverAttachments,
 		serverEventsStream: serverEventsStream,
 		serverEvtStream:    serverEvtStream,

--- a/cli/internal/core/threads.go
+++ b/cli/internal/core/threads.go
@@ -10,8 +10,6 @@ import (
 	"time"
 
 	"github.com/nats-io/nats.go/jetstream"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"hmans.de/chatto/internal/core/subjects"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
@@ -70,130 +68,6 @@ func (c *ChattoCore) GetThreadEvents(ctx context.Context, kind RoomKind, room_id
 		events = append(events, r.Event)
 	}
 	return events, nil
-}
-
-// threadMetadataKey returns the KV key for thread metadata: {roomId}.{rootEventId}
-func threadMetadataKey(roomID string, rootEventId string) string {
-	return fmt.Sprintf("%s.%s", roomID, rootEventId)
-}
-
-// updateThreadMetadata updates the thread metadata in KV with optimistic locking.
-// Called when a reply is posted to a thread. Tracks reply count, last reply time, and participants.
-// The rootAuthorID is the author of the thread root message - they're included as the first participant.
-func (c *ChattoCore) updateThreadMetadata(ctx context.Context, kind RoomKind, roomID string, rootEventId string, rootAuthorID, replyAuthorID string, replyTime time.Time) error {
-	const maxRetries = 5
-
-	bucket := c.storage.serverThreadsKV
-
-	key := threadMetadataKey(roomID, rootEventId)
-
-	for attempt := 0; attempt < maxRetries; attempt++ {
-		// Get current entry (if any) with its revision
-		var revision uint64
-		var metadata *corev1.ThreadMetadata
-
-		entry, err := bucket.Get(ctx, key)
-		if err == nil {
-			// Key exists - unmarshal and get revision
-			revision = entry.Revision()
-			metadata = &corev1.ThreadMetadata{}
-			if unmarshalErr := proto.Unmarshal(entry.Value(), metadata); unmarshalErr != nil {
-				c.logger.Warn("Failed to unmarshal thread metadata, creating new", "error", unmarshalErr)
-				metadata = nil
-			}
-		} else if !errors.Is(err, jetstream.ErrKeyNotFound) {
-			return fmt.Errorf("failed to get thread metadata: %w", err)
-		}
-
-		// Create or update metadata
-		if metadata == nil {
-			// First reply to this thread - initialize participant list with root author first
-			participants := []string{}
-			if rootAuthorID != "" {
-				participants = append(participants, rootAuthorID)
-			}
-			// Add reply author if different from root author
-			if replyAuthorID != rootAuthorID {
-				participants = append(participants, replyAuthorID)
-			}
-			metadata = &corev1.ThreadMetadata{
-				RootEventId:    rootEventId,
-				ReplyCount:     1,
-				LastReplyAt:    timestamppb.New(replyTime),
-				ParticipantIds: participants,
-			}
-		} else {
-			metadata.ReplyCount++
-			metadata.LastReplyAt = timestamppb.New(replyTime)
-
-			// Ensure root author is in participants (for backward compatibility with existing threads)
-			if rootAuthorID != "" {
-				rootAuthorExists := false
-				for _, pid := range metadata.ParticipantIds {
-					if pid == rootAuthorID {
-						rootAuthorExists = true
-						break
-					}
-				}
-				if !rootAuthorExists && len(metadata.ParticipantIds) < maxThreadParticipants {
-					// Insert root author at the beginning
-					metadata.ParticipantIds = append([]string{rootAuthorID}, metadata.ParticipantIds...)
-				}
-			}
-
-			// Add reply author if not already present and under cap
-			replyAuthorExists := false
-			for _, pid := range metadata.ParticipantIds {
-				if pid == replyAuthorID {
-					replyAuthorExists = true
-					break
-				}
-			}
-			if !replyAuthorExists && len(metadata.ParticipantIds) < maxThreadParticipants {
-				metadata.ParticipantIds = append(metadata.ParticipantIds, replyAuthorID)
-			}
-		}
-
-		// Marshal and store
-		data, err := proto.Marshal(metadata)
-		if err != nil {
-			return fmt.Errorf("failed to marshal thread metadata: %w", err)
-		}
-
-		// Try atomic update
-		var updateErr error
-		if revision == 0 {
-			// No existing key - use Create for atomic insert
-			_, updateErr = bucket.Create(ctx, key, data)
-		} else {
-			// Existing key - use Update with revision check
-			_, updateErr = bucket.Update(ctx, key, data, revision)
-		}
-
-		if updateErr == nil {
-			c.logger.Debug("Updated thread metadata",
-				"kind", kind,
-				"room_id", roomID,
-				"root_event_id", rootEventId,
-				"reply_count", metadata.ReplyCount,
-				"participants", len(metadata.ParticipantIds))
-			return nil
-		}
-
-		// Check if it's a revision conflict (concurrent update)
-		if errors.Is(updateErr, jetstream.ErrKeyExists) {
-			c.logger.Debug("Thread metadata revision conflict, retrying",
-				"room_id", roomID,
-				"root_event_id", rootEventId,
-				"attempt", attempt+1)
-			continue
-		}
-
-		// Some other error
-		return fmt.Errorf("failed to store thread metadata: %w", updateErr)
-	}
-
-	return fmt.Errorf("failed to update thread metadata after %d retries due to concurrent modifications", maxRetries)
 }
 
 // notifyThreadFollowers creates persistent notifications for all thread followers when someone replies.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -264,7 +264,6 @@ There is no `adminAuditLogEvents` subscription — audit events arrive through `
 | KV      | `SERVER_RUNTIME`              | Legacy runtime state pending cleanup        |
 | KV      | `SERVER_BODIES`               | Message bodies (GDPR-compliant) + standalone attachment metadata records — TODO: rename → `SERVER_CONTENT` |
 | KV      | `SERVER_REACTIONS`            | Legacy emoji reactions source for boot migration only |
-| KV      | `SERVER_THREADS`              | Thread metadata (reply count, participants) |
 | Objects | `INSTANCE_ASSETS`             | Avatars, icons (bucket name retained from pre-rename) |
 | Objects | `ASSET_CACHE`                 | Cached resized images (optional, with TTL)  |
 | Objects | `SERVER_ASSETS`               | Message attachments                         |
@@ -473,7 +472,6 @@ The unified `myEvents` GraphQL subscription is backed by a single core stream (`
 | `SERVER_RUNTIME`              | File    | Yes      | Legacy runtime state pending cleanup            |
 | `SERVER_BODIES`               | File    | Yes      | Message bodies (GDPR-compliant) + standalone attachment metadata records — TODO: rename → `SERVER_CONTENT` |
 | `SERVER_REACTIONS`            | File    | Yes      | Legacy emoji reactions, read only by the EVT boot migration |
-| `SERVER_THREADS`              | File    | Yes      | Thread metadata (reply count, participants)     |
 | `USER_PRESENCE`               | Memory  | No       | User presence status (TTL 60s)                  |
 | `CALL_STATE`                  | Memory  | No       | Active voice call participants, keyed `{spaceId}.{roomId}` (repopulated by LiveKit webhooks after restart) |
 | `ENCRYPTION_KEYS`             | File    | **No**   | User encryption keys (excluded for security)    |
@@ -616,8 +614,15 @@ Notes: Memory-based storage (not persisted). 60-second TTL with 30-second client
 | Key                    | Description                                              |
 | ---------------------- | -------------------------------------------------------- |
 | `{userId}.{eventId}`   | Message body keyed by user ID and event ID               |
+| `{userId}.{bodyId}`    | Older naming for the same legacy body record shape       |
 
 Notes: The compound key format `{userId}.{eventId}` enables efficient prefix-based deletion for GDPR compliance (delete all messages for a user via prefix scan). Separated from metadata for performance and operational flexibility. No `kind` segment — both IDs are globally unique NanoIDs.
+
+A transitional `attachment.{roomId}.{attachmentId}` key shape existed
+in this bucket between #575 and #581 as a per-attachment authz index;
+it was retired by the signed-locator URL scheme (ADR-032) and any
+leftover entries are swept at boot by the `DropLegacyAttachmentRecords`
+migration. New code should not write to `attachment.*` keys here.
 
 **SERVER\_REACTIONS keys:**
 
@@ -626,24 +631,6 @@ Notes: The compound key format `{userId}.{eventId}` enables efficient prefix-bas
 | `{messageEventId}.{emojiName}.{userId}` | Reaction tracking (empty value = reacted; value stores nanosecond timestamp for "added at" ordering) |
 
 Notes: Legacy source for `MigrateReactionsToES`. Current reaction writes append durable `ReactionAdded` / `ReactionRemoved` events to `evt.room.{roomId}.reaction_added` and `evt.room.{roomId}.reaction_removed`; current reaction state is derived by an in-memory projection keyed by message event ID, emoji shortcode, and actor/user ID. The bucket remains so old deployments can be imported and will be removed in the later cleanup phase.
-
-**SERVER\_THREADS keys:**
-
-| Key                       | Description                                              |
-| ------------------------- | -------------------------------------------------------- |
-| `{roomId}.{rootEventId}`  | ThreadMetadata proto (reply count, last reply, participants) |
-
-Notes: Updated on each thread reply via optimistic locking. Tracks up to 50 participant IDs. Used for thread previews in channel view.
-
-| Key                                          | Description                                                                              |
-| -------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `{userId}.{bodyId}`                          | Marshaled `corev1.MessageBody` proto (encrypted text, attachments slice, link preview)   |
-
-A transitional `attachment.{roomId}.{attachmentId}` key shape existed
-in this bucket between #575 and #581 as a per-attachment authz index;
-it was retired by the signed-locator URL scheme (ADR-032) and any
-leftover entries are swept at boot by the `DropLegacyAttachmentRecords`
-migration. New code should not write to `attachment.*` keys here.
 
 ### Object Store Buckets
 
@@ -777,7 +764,7 @@ Messages are persisted as durable `EVT` facts with encrypted message bodies embe
 - `in_reply_to` field stores the event ID of the parent message (empty for top-level messages)
 - `in_thread` field stores the event ID of the thread root (empty for top-level messages)
 - Thread replies are ordinary `MessagePostedEvent` facts on `evt.room.{roomId}.message_posted` with `in_thread` set to the root event ID.
-- Thread reply lists, reply counts, participants, and last-reply timestamps are derived from the `ThreadProjection`; `SERVER_THREADS` is legacy import/storage evidence only.
+- Thread reply lists, reply counts, participants, and last-reply timestamps are derived from the `ThreadProjection`.
 
 **@Mentions:**
 


### PR DESCRIPTION
## Summary
- Stop creating and storing the unused SERVER_THREADS KV bucket in core storage.
- Remove the unreachable legacy thread metadata writer; threading metadata remains derived from EVT via ThreadProjection.
- Update ARCHITECTURE to remove SERVER_THREADS from the active JetStream inventory.

## Tests
- mise x -- go test ./internal/core -run 'TestThread|TestChattoCore_.*Thread|TestDM.*Thread|TestMessagePostedEvent|TestGetThread|TestStreamMyEvents_DeliversThread' -count=1 -timeout 60s
- mise x -- go test ./internal/graph -run 'TestMessagePostedEventResolver|TestThread|TestMutation_PostMessage|TestFollowedThreads' -count=1 -timeout 60s
- mise x -- go test ./internal/core -count=1 -timeout 120s
- git diff --check