### PR TITLE
chore(core): stop provisioning legacy import stores

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -15,12 +15,12 @@ paths: ["cli/**"]
 
 ## ⚠️ NATS IS THE PRIMARY DATA STORE — NOT A MESSAGE BUS ⚠️
 
-NATS JetStream KV buckets and event streams hold the source-of-truth state for Chatto. NATS is not "just" a pubsub layer, and it is not an "eventually-consistent cache in front of a real database." There is no other database. Treat NATS reads/writes with the same care you would treat a Postgres transaction.
+NATS JetStream KV buckets and event streams hold Chatto's persisted state. NATS is not "just" a pubsub layer, and it is not an "eventually-consistent cache in front of a real database." There is no other database. Treat NATS reads/writes with the same care you would treat a Postgres transaction.
 
 ## Architecture
 
 - `ChattoCore` handles all domain operations (spaces, users, rooms, messages)
-- KV buckets are source of truth; event streams provide audit trail
+- `EVT` is the durable source of truth for event-sourced domain state; `RUNTIME_STATE` holds persisted latest-value runtime state
 - IDs: 14-char NanoID via `helpers.NewID()` (~83.4 bits entropy)
 - When adding streams/KV buckets, update `docs/ARCHITECTURE.md` inventory
 
@@ -37,7 +37,7 @@ NATS JetStream KV buckets and event streams hold the source-of-truth state for C
   3. For new keys, use `kv.Create()` instead (fails if key exists)
   4. Retry on `jetstream.ErrKeyExists` up to a max attempts (e.g., 5 retries)
 - **Subject structure changes are high-risk**: Changes to NATS subject patterns cascade into stream configs, consumer filters, and query logic (e.g., `GetLastMsgForSubject`, `WithSubjectFilter`). They need careful end-to-end verification including e2e tests.
-- **Single unified event stream**: All room events (channels and DMs) live in `SERVER_EVENTS`, created up-front at boot. `getSpaceStream()` returns the same stream regardless of input — the `kind` segment in subjects (`server.room.channel.*` / `server.room.dm.*`) is what disambiguates. The pre-Phase-4 lazy per-space stream cache is gone.
+- **Single durable EVT stream**: Event-sourced domain facts live in `EVT`. Legacy `SERVER_EVENTS` is opened only when present for pre-ES imports and inspection; new runtime writes must not mirror to it.
 
 ## Room Event Query Behavior
 
@@ -58,9 +58,9 @@ Event subscriptions are unified in `StreamMyEvents`, which consumes NATS Core su
 
 `live.evt.>` is not UI-safe by itself. `StreamMyEvents` reads the republished JetStream sequence, waits for the relevant local projections, applies per-user authorization, and only then emits the GraphQL event.
 
-- **Durable legacy events**: For aggregates that have not moved to EVT yet, publish to `server.>` via `publishServerEvent()` / `publishServerEventWithAck()` / `publishServerEventWithOCC()`. `SERVER_EVENTS` is legacy storage/import infrastructure only and does not participate in live delivery.
+- **Durable legacy events**: Do not add new `server.>` publishers. `SERVER_EVENTS` is legacy storage/import infrastructure only and does not participate in live delivery.
 - **Durable EVT events**: For event-sourced aggregates, publish to `evt.>` via `EventPublisher`. JetStream republish automatically wires them into `live.evt.>`; `StreamMyEvents` is responsible for projection catch-up and authorization before GraphQL delivery.
-- **Transient events**: For real-time UI updates where KV/runtime state is source of truth (typing, notification sync, preference sync, user/config notifications). Publish a `corev1.LiveEvent` directly via NATS Core through `publishLiveEvent()` on `live.sync.>`. No stream storage.
+- **Transient events**: For real-time UI updates where latest-value runtime state is authoritative (typing, notification sync, preference sync, user/config notifications). Publish a `corev1.LiveEvent` directly via NATS Core through `publishLiveEvent()` on `live.sync.>`. No stream storage.
 - **Event-sourced room edits/retracts**: Message edits and retractions use the canonical durable `MessageEditedEvent` / `MessageRetractedEvent` shapes. `myEvents` receives them from `live.evt.>` after projection catch-up; do not synthesize legacy `MessageUpdatedEvent` / `MessageDeletedEvent` for new delivery.
 - **Do not publish from projectors**: Projectors run locally in every Chatto replica. Publishing live events from `Projection.Apply` would multiply one committed EVT event by the number of replicas. Use stream `RePublish` for the raw EVT feed and let `StreamMyEvents` handle readiness/auth.
 - **Do not double-publish.** Publishing the same conceptual event via BOTH `EventPublisher` and `publishLiveEvent` will deliver it twice to subscribers if the event is deliverable from `live.evt.>`. Durable facts belong in EVT; transient sync signals belong in LiveEvent.
@@ -88,7 +88,7 @@ Room events (`live.sync.room.{kind}.{roomId}.…` plus deliverable EVT room fact
 2. Add to GraphQL schema in `events.graphqls` (type + `ServerEventType` union)
 3. Add `IsServerEventType()` method in `pb/chatto/core/v1/graphql.go`
 4. Add case in `unwrapEvent()` in `event_helpers.go`
-5. Publish via `EventPublisher` for durable EVT facts, `publishServerEvent` only for remaining legacy storage/import paths, or `publishLiveEvent` for transient LiveEvent signals — choose ONE conceptual delivery path
+5. Publish via `EventPublisher` for durable EVT facts or `publishLiveEvent` for transient LiveEvent signals — choose ONE conceptual delivery path
 6. Subscribe in frontend via `eventBus.svelte.ts` (or a handler registered through `useEvent`)
 
 **When to create a live event:** Any time a user action changes state that other tabs/devices or other UI components need to reflect in real-time. Common triggers:

--- a/cli/internal/core/asset_creation_migration.go
+++ b/cli/internal/core/asset_creation_migration.go
@@ -177,6 +177,9 @@ func (c *ChattoCore) adoptLegacyRuntimeMigrationSentinel(ctx context.Context, ke
 		return fmt.Errorf("get migration sentinel %s: %w", key, err)
 	}
 
+	if c.storage.serverRuntimeKV == nil {
+		return nil
+	}
 	entry, err := c.storage.serverRuntimeKV.Get(ctx, key)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
@@ -196,6 +199,9 @@ func (c *ChattoCore) adoptLegacyRuntimeMigrationSentinel(ctx context.Context, ke
 }
 
 func (c *ChattoCore) waitRuntimeMigrationDoneIn(ctx context.Context, bucket jetstream.KeyValue, key string) error {
+	if bucket == nil {
+		return nil
+	}
 	waitCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 	ticker := time.NewTicker(250 * time.Millisecond)

--- a/cli/internal/core/asset_creation_migration_test.go
+++ b/cli/internal/core/asset_creation_migration_test.go
@@ -12,9 +12,10 @@ import (
 func TestAssetCreationMigration_BackfillsMessageAttachments(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
+	legacyRuntime := ensureLegacyServerRuntimeKV(t, core)
 
 	_ = core.storage.runtimeStateKV.Delete(ctx, assetCreationESMigrationKey)
-	_ = core.storage.serverRuntimeKV.Delete(ctx, assetCreationESMigrationKey)
+	_ = legacyRuntime.Delete(ctx, assetCreationESMigrationKey)
 	room, err := core.CreateRoom(ctx, "test-user", KindChannel, "", "Files", "Files room")
 	if err != nil {
 		t.Fatalf("create room: %v", err)
@@ -90,9 +91,10 @@ func TestAssetCreationMigration_BackfillsMessageAttachments(t *testing.T) {
 func TestRuntimeMigrationClaim_WaitsForAtomicOwner(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
+	legacyRuntime := ensureLegacyServerRuntimeKV(t, core)
 	key := "test.migration.claim"
 	_ = core.storage.runtimeStateKV.Delete(ctx, key)
-	_ = core.storage.serverRuntimeKV.Delete(ctx, key)
+	_ = legacyRuntime.Delete(ctx, key)
 
 	revision, claimed, err := core.claimRuntimeMigration(ctx, key)
 	if err != nil {
@@ -138,11 +140,12 @@ func TestRuntimeMigrationClaim_WaitsForAtomicOwner(t *testing.T) {
 func TestRuntimeMigrationClaim_AdoptsLegacyDoneSentinel(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
+	legacyRuntime := ensureLegacyServerRuntimeKV(t, core)
 	key := "test.migration.legacy.done"
 	_ = core.storage.runtimeStateKV.Delete(ctx, key)
-	_ = core.storage.serverRuntimeKV.Delete(ctx, key)
+	_ = legacyRuntime.Delete(ctx, key)
 
-	if _, err := core.storage.serverRuntimeKV.Put(ctx, key, []byte(runtimeMigrationDone)); err != nil {
+	if _, err := legacyRuntime.Put(ctx, key, []byte(runtimeMigrationDone)); err != nil {
 		t.Fatalf("put legacy sentinel: %v", err)
 	}
 

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -31,7 +31,7 @@ import (
 
 // ChattoCore is the central hub for all Chatto operations.
 // It provides a unified API for spaces, users, rooms, and messages,
-// managing all KV buckets and event streams internally.
+// managing current JetStream resources and legacy import handles internally.
 type ChattoCore struct {
 	nc                 *nats.Conn
 	js                 jetstream.JetStream
@@ -548,14 +548,15 @@ func (c *ChattoCore) deleteAsset(ctx context.Context, asset *corev1.DeprecatedAs
 	}
 }
 
-// Ready checks if the core is fully initialized and JetStream resources are accessible.
+// Ready checks if the core is fully initialized and current persistent resources are accessible.
 // Returns nil if ready, or an error describing what's not ready.
 // Used by the /readyz endpoint to verify the server can handle requests.
 func (c *ChattoCore) Ready(ctx context.Context) error {
-	// Check if JetStream is operational by getting the INSTANCE KV bucket status
-	_, err := c.storage.serverKV.Status(ctx)
-	if err != nil {
-		return fmt.Errorf("JetStream not ready: %w", err)
+	if _, err := c.storage.runtimeStateKV.Status(ctx); err != nil {
+		return fmt.Errorf("RUNTIME_STATE not ready: %w", err)
+	}
+	if _, err := c.storage.serverEvtStream.Info(ctx); err != nil {
+		return fmt.Errorf("EVT not ready: %w", err)
 	}
 	return nil
 }
@@ -571,7 +572,7 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 		return nil, fmt.Errorf("failed to create JetStream context: %w", err)
 	}
 
-	// Initialize storage (KV buckets)
+	// Initialize storage (current resources plus optional legacy import sources).
 	storage, err := newStorage(js, ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize storage: %w", err)
@@ -755,45 +756,39 @@ func (c *ChattoCore) Subscribe(ctx context.Context, subject string, handler nats
 // Storage
 // ============================================================================
 
-// storage encapsulates all JetStream KV buckets and streams used by Chatto Core.
+// storage encapsulates JetStream resources used by Chatto Core. Current
+// resources are provisioned at startup; legacy import resources are opened only
+// when they already exist.
 type storage struct {
-	serverKV        jetstream.KeyValue
 	serverStore     jetstream.ObjectStore
 	encryptionKV    jetstream.KeyValue // Encryption keys (excluded from backups)
-	runtimeConfigKV jetstream.KeyValue // INSTANCE_CONFIG - runtime configuration overrides
+	serverKV        jetstream.KeyValue // INSTANCE        - legacy user/config import source
+	runtimeConfigKV jetstream.KeyValue // INSTANCE_CONFIG - legacy runtime configuration import source
 	runtimeStateKV  jetstream.KeyValue // RUNTIME_STATE  - persisted latest-value runtime/user state
 
-	// Server-level KV buckets (#330 phase 4a, 4b, 4c, 4e) and event stream
-	// (#330 phase 4d). Shared by channel and DM rooms after the Space tier
-	// retirement; legacy non-primary spaces (test-created only in practice)
-	// keep their per-space lazycaches below.
-	serverConfigKV     jetstream.KeyValue    // SERVER_CONFIG    - rooms, memberships
-	serverRuntimeKV    jetstream.KeyValue    // SERVER_RUNTIME   - sequences, timestamps, read state
-	serverRBACKV       jetstream.KeyValue    // SERVER_RBAC      - legacy RBAC import source
-	serverBodiesKV     jetstream.KeyValue    // SERVER_BODIES    - message bodies + attachment metadata records (#330 phase 4c). TODO: rename → SERVER_CONTENT now that it hosts more than bodies.
-	serverReactionsKV  jetstream.KeyValue    // SERVER_REACTIONS - emoji reactions (#330 phase 4c)
-	serverAttachments  jetstream.ObjectStore // SERVER_ASSETS    - message attachment binaries (#330 phase 4e)
-	serverEventsStream jetstream.Stream      // SERVER_EVENTS    - event stream (#330 phase 4d)
-	serverEvtStream    jetstream.Stream      // EVT       - event-sourcing log (ADR-033/034). Coexists with SERVER_EVENTS during migration.
+	// Legacy import resources. Fresh ES-only deployments do not create these;
+	// boot importers treat nil handles as empty sources.
+	serverConfigKV     jetstream.KeyValue // SERVER_CONFIG    - legacy rooms, memberships
+	serverRuntimeKV    jetstream.KeyValue // SERVER_RUNTIME   - legacy sequences, timestamps, read state
+	serverRBACKV       jetstream.KeyValue // SERVER_RBAC      - legacy RBAC import source
+	serverBodiesKV     jetstream.KeyValue // SERVER_BODIES    - legacy message bodies + attachment metadata records
+	serverReactionsKV  jetstream.KeyValue // SERVER_REACTIONS - legacy emoji reactions
+	serverEventsStream jetstream.Stream   // SERVER_EVENTS    - legacy event stream
+
+	serverAttachments jetstream.ObjectStore // SERVER_ASSETS    - message attachment binaries (#330 phase 4e)
+	serverEvtStream   jetstream.Stream      // EVT       - event-sourcing log (ADR-033/034).
 
 	presenceKV      jetstream.KeyValue    // Instance-level presence bucket
 	imageCacheStore jetstream.ObjectStore // Optional: cached resized images (nil if disabled)
 	callStateKV     jetstream.KeyValue    // Active voice call participants (ephemeral, memory-backed)
 }
 
-// newStorage initializes all JetStream KV buckets and streams.
+// newStorage initializes current JetStream resources and opens existing legacy
+// import resources.
 func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConfig) (*storage, error) {
-	// Initialize INSTANCE KV bucket for all server-level data
-	// Uses subject-based keys: user.{userId}, space.{spaceId}, space_membership.{spaceId}.{userId}, etc.
-	serverKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
-		Bucket:         "INSTANCE",
-		Description:    "Instance-level data (users, spaces, memberships)",
-		Storage:        jetstream.FileStorage,
-		Replicas:       cfg.Replicas,
-		LimitMarkerTTL: 24 * time.Hour,
-	})
+	serverKV, err := openLegacyKeyValue(ctx, js, "INSTANCE")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create INSTANCE KV bucket: %w", err)
+		return nil, fmt.Errorf("failed to open legacy INSTANCE KV bucket: %w", err)
 	}
 
 	// Initialize server object store
@@ -834,15 +829,9 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		return nil, fmt.Errorf("failed to create ENCRYPTION_KEYS KV bucket: %w", err)
 	}
 
-	// Initialize runtime configuration KV bucket
-	runtimeConfigKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
-		Bucket:      "INSTANCE_CONFIG",
-		Description: "Runtime configuration overrides",
-		Storage:     jetstream.FileStorage,
-		Replicas:    cfg.Replicas,
-	})
+	runtimeConfigKV, err := openLegacyKeyValue(ctx, js, "INSTANCE_CONFIG")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create INSTANCE_CONFIG KV bucket: %w", err)
+		return nil, fmt.Errorf("failed to open legacy INSTANCE_CONFIG KV bucket: %w", err)
 	}
 
 	runtimeStateKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
@@ -889,58 +878,29 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		return nil, fmt.Errorf("failed to create CALL_STATE KV bucket: %w", err)
 	}
 
-	// Initialize server-level KV buckets (#330 phase 4a, 4b, 4c). These hold
-	// deployment-wide channel and DM room data. Legacy non-primary spaces
-	// (test-created only in practice) keep their per-space SPACE_{id}_*
-	// buckets.
-	serverConfigKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
-		Bucket:      "SERVER_CONFIG",
-		Description: "Server-level configuration (rooms, memberships)",
-		Storage:     jetstream.FileStorage,
-		Replicas:    cfg.Replicas,
-	})
+	serverConfigKV, err := openLegacyKeyValue(ctx, js, "SERVER_CONFIG")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create SERVER_CONFIG KV bucket: %w", err)
+		return nil, fmt.Errorf("failed to open legacy SERVER_CONFIG KV bucket: %w", err)
 	}
 
-	serverRBACKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
-		Bucket:      "SERVER_RBAC",
-		Description: "Server-level RBAC (roles, permissions, assignments)",
-		Storage:     jetstream.FileStorage,
-		Replicas:    cfg.Replicas,
-	})
+	serverRBACKV, err := openLegacyKeyValue(ctx, js, "SERVER_RBAC")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create SERVER_RBAC KV bucket: %w", err)
+		return nil, fmt.Errorf("failed to open legacy SERVER_RBAC KV bucket: %w", err)
 	}
 
-	serverRuntimeKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
-		Bucket:      "SERVER_RUNTIME",
-		Description: "Server-level runtime state (sequences, read status)",
-		Storage:     jetstream.FileStorage,
-		Replicas:    cfg.Replicas,
-	})
+	serverRuntimeKV, err := openLegacyKeyValue(ctx, js, "SERVER_RUNTIME")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create SERVER_RUNTIME KV bucket: %w", err)
+		return nil, fmt.Errorf("failed to open legacy SERVER_RUNTIME KV bucket: %w", err)
 	}
 
-	serverBodiesKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
-		Bucket:      "SERVER_BODIES",
-		Description: "Server-level message bodies",
-		Storage:     jetstream.FileStorage,
-		Replicas:    cfg.Replicas,
-	})
+	serverBodiesKV, err := openLegacyKeyValue(ctx, js, "SERVER_BODIES")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create SERVER_BODIES KV bucket: %w", err)
+		return nil, fmt.Errorf("failed to open legacy SERVER_BODIES KV bucket: %w", err)
 	}
 
-	serverReactionsKV, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
-		Bucket:      "SERVER_REACTIONS",
-		Description: "Server-level emoji reactions",
-		Storage:     jetstream.FileStorage,
-		Replicas:    cfg.Replicas,
-	})
+	serverReactionsKV, err := openLegacyKeyValue(ctx, js, "SERVER_REACTIONS")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create SERVER_REACTIONS KV bucket: %w", err)
+		return nil, fmt.Errorf("failed to open legacy SERVER_REACTIONS KV bucket: %w", err)
 	}
 
 	serverAttachments, err := js.CreateOrUpdateObjectStore(ctx, jetstream.ObjectStoreConfig{
@@ -954,35 +914,15 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		return nil, fmt.Errorf("failed to create SERVER_ASSETS object store: %w", err)
 	}
 
-	// Initialize the deployment-wide events stream (#330 phase 4d). Holds all
-	// JetStream events for channel and DM rooms; legacy non-primary spaces
-	// (test-created only in production) keep their per-space SPACE_{id}_EVENTS
-	// streams.
-	serverEventsStream, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
-		Name:               "SERVER_EVENTS",
-		Description:        "Server-level event stream (channel + DM rooms)",
-		Subjects:           []string{"server.>"},
-		Storage:            jetstream.FileStorage,
-		Compression:        jetstream.S2Compression,
-		AllowAtomicPublish: true,
-		Replicas:           cfg.Replicas,
-	})
+	serverEventsStream, err := openLegacyStream(ctx, js, "SERVER_EVENTS")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create SERVER_EVENTS stream: %w", err)
+		return nil, fmt.Errorf("failed to open legacy SERVER_EVENTS stream: %w", err)
 	}
 
-	// EVT — the event-sourcing log (ADR-033/034). Coexists with
-	// SERVER_EVENTS during the per-aggregate migration (ADR-035).
+	// EVT — the event-sourcing log (ADR-033/034).
 	// Subjects are evt.{aggregateType}.{aggregateId}; live.evt.> is
 	// the republish target so projections and live subscribers consume
 	// from a single NATS Core path.
-	//
-	// We deliberately do NOT nest under server.> here — the legacy
-	// SERVER_EVENTS stream claims server.> as its subject root, and NATS
-	// won't allow two streams to share an overlapping subject space.
-	// During the migration window we keep them in separate top-level
-	// roots; once SERVER_EVENTS is decommissioned we can revisit the
-	// naming if we want to consolidate.
 	serverEvtStream, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
 		Name:        "EVT",
 		Description: "Event-sourcing log (ADR-033)",
@@ -1024,6 +964,28 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		imageCacheStore:    imageCacheStore,
 		callStateKV:        callStateKV,
 	}, nil
+}
+
+func openLegacyKeyValue(ctx context.Context, js jetstream.JetStream, bucket string) (jetstream.KeyValue, error) {
+	kv, err := js.KeyValue(ctx, bucket)
+	if err == nil {
+		return kv, nil
+	}
+	if errors.Is(err, jetstream.ErrBucketNotFound) {
+		return nil, nil
+	}
+	return nil, err
+}
+
+func openLegacyStream(ctx context.Context, js jetstream.JetStream, streamName string) (jetstream.Stream, error) {
+	stream, err := js.Stream(ctx, streamName)
+	if err == nil {
+		return stream, nil
+	}
+	if errors.Is(err, jetstream.ErrStreamNotFound) {
+		return nil, nil
+	}
+	return nil, err
 }
 
 // ============================================================================
@@ -1249,9 +1211,9 @@ func liveEventAsEvent(live *corev1.LiveEvent) *corev1.Event {
 // Stream Management
 // ============================================================================
 
-// createSpaceResources is now a no-op: all data lives in the deployment-wide
-// SERVER_* buckets (eager-created in newStorage). Kept as a stub so callers
-// don't have to be edited until the broader Space-retirement pass.
+// createSpaceResources is now a no-op: room/user domain state lives in EVT and
+// deployment-wide projections. Kept as a stub so callers don't have to be
+// edited until the broader Space-retirement pass.
 func (c *ChattoCore) createSpaceResources(_ context.Context, _ string) error {
 	return nil
 }
@@ -1751,14 +1713,7 @@ type ServerStats struct {
 // DM rooms. Per-space breakdowns went away with the Space tier (ADR-030).
 func (c *ChattoCore) GetStats(ctx context.Context) (*ServerStats, error) {
 	stats := &ServerStats{}
-
-	userKeys, err := c.storage.serverKV.ListKeysFiltered(ctx, "user.*")
-	if err != nil {
-		return nil, fmt.Errorf("failed to list user keys: %w", err)
-	}
-	for range userKeys.Keys() {
-		stats.UserCount++
-	}
+	stats.UserCount, _, _ = c.Users.Stats()
 
 	channelRooms, err := c.ListRooms(ctx, KindChannel)
 	if err != nil {

--- a/cli/internal/core/core_test.go
+++ b/cli/internal/core/core_test.go
@@ -2,11 +2,13 @@ package core
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
 	"hmans.de/chatto/internal/config"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 	"hmans.de/chatto/internal/testutil"
@@ -97,6 +99,77 @@ func eventStreamMsgCount(t *testing.T, core *ChattoCore) uint64 {
 		t.Fatalf("event stream info: %v", err)
 	}
 	return info.State.Msgs
+}
+
+func ensureLegacyKeyValue(t *testing.T, core *ChattoCore, bucket string) jetstream.KeyValue {
+	t.Helper()
+	ctx := testContext(t)
+	kv, err := core.js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:  bucket,
+		Storage: jetstream.FileStorage,
+	})
+	if err != nil {
+		t.Fatalf("create legacy %s KV: %v", bucket, err)
+	}
+	return kv
+}
+
+func ensureLegacyServerRuntimeKV(t *testing.T, core *ChattoCore) jetstream.KeyValue {
+	t.Helper()
+	kv := ensureLegacyKeyValue(t, core, "SERVER_RUNTIME")
+	core.storage.serverRuntimeKV = kv
+	return kv
+}
+
+func ensureLegacyServerConfigKV(t *testing.T, core *ChattoCore) jetstream.KeyValue {
+	t.Helper()
+	kv := ensureLegacyKeyValue(t, core, "SERVER_CONFIG")
+	core.storage.serverConfigKV = kv
+	return kv
+}
+
+func assertLegacyKeyAbsent(t *testing.T, kv jetstream.KeyValue, key, label string) {
+	t.Helper()
+	if kv == nil {
+		return
+	}
+	ctx := testContext(t)
+	if _, err := kv.Get(ctx, key); !errors.Is(err, jetstream.ErrKeyNotFound) {
+		t.Fatalf("%s lookup error = %v, want ErrKeyNotFound", label, err)
+	}
+}
+
+func TestNewChattoCore_DoesNotProvisionLegacyImportResourcesOnFreshBoot(t *testing.T) {
+	_, nc := testutil.StartNATS(t)
+	ctx := testContext(t)
+	cfg := config.CoreConfig{
+		SecretKey: "test-core-secret",
+		Assets: config.AssetsConfig{
+			SigningSecret: "test-signing-secret",
+		},
+	}
+
+	core, err := NewChattoCore(ctx, nc, cfg)
+	if err != nil {
+		t.Fatalf("NewChattoCore: %v", err)
+	}
+
+	for _, bucket := range []string{
+		"INSTANCE",
+		"INSTANCE_CONFIG",
+		"SERVER_CONFIG",
+		"SERVER_RBAC",
+		"SERVER_RUNTIME",
+		"SERVER_BODIES",
+		"SERVER_REACTIONS",
+	} {
+		if _, err := core.js.KeyValue(ctx, bucket); !errors.Is(err, jetstream.ErrBucketNotFound) {
+			t.Fatalf("legacy bucket %s lookup error = %v, want ErrBucketNotFound", bucket, err)
+		}
+	}
+	if _, err := core.js.Stream(ctx, "SERVER_EVENTS"); !errors.Is(err, jetstream.ErrStreamNotFound) {
+		t.Fatalf("legacy stream SERVER_EVENTS lookup error = %v, want ErrStreamNotFound", err)
+	}
 }
 
 // ============================================================================

--- a/cli/internal/core/es_boot_verification.go
+++ b/cli/internal/core/es_boot_verification.go
@@ -195,15 +195,15 @@ func (c *ChattoCore) collectLegacyESCounts(ctx context.Context) (esLegacyCounts,
 	if err != nil {
 		return counts, warnings, fmt.Errorf("count legacy reactions: %w", err)
 	}
-	counts.users, err = countLegacyUserRecords(ctx, c.storage.serverConfigKV)
+	counts.users, err = countLegacyUserRecords(ctx, c.storage.serverKV)
 	if err != nil {
 		return counts, warnings, fmt.Errorf("count legacy users: %w", err)
 	}
-	counts.verifiedEmails, err = countKVKeys(ctx, c.storage.serverConfigKV, "verified_emails.*.*")
+	counts.verifiedEmails, err = countKVKeys(ctx, c.storage.serverKV, "verified_emails.*.*")
 	if err != nil {
 		return counts, warnings, fmt.Errorf("count legacy verified emails: %w", err)
 	}
-	counts.oidcSubjects, err = countKVKeys(ctx, c.storage.serverConfigKV, "user_by_oidc.*")
+	counts.oidcSubjects, err = countKVKeys(ctx, c.storage.serverKV, "user_by_oidc.*")
 	if err != nil {
 		return counts, warnings, fmt.Errorf("count legacy OIDC subjects: %w", err)
 	}
@@ -363,6 +363,9 @@ func (c *ChattoCore) logESEventCounts(counts map[string]int) {
 }
 
 func countKVKeys(ctx context.Context, kv jetstream.KeyValue, filters ...string) (int, error) {
+	if kv == nil {
+		return 0, nil
+	}
 	var lister jetstream.KeyLister
 	var err error
 	if len(filters) == 0 {
@@ -384,6 +387,9 @@ func countKVKeys(ctx context.Context, kv jetstream.KeyValue, filters ...string) 
 }
 
 func countLegacyUserRecords(ctx context.Context, kv jetstream.KeyValue) (int, error) {
+	if kv == nil {
+		return 0, nil
+	}
 	lister, err := kv.ListKeysFiltered(ctx, "user.*")
 	if err != nil {
 		if errors.Is(err, jetstream.ErrNoKeysFound) {
@@ -401,6 +407,9 @@ func countLegacyUserRecords(ctx context.Context, kv jetstream.KeyValue) (int, er
 }
 
 func kvKeyExists(ctx context.Context, kv jetstream.KeyValue, key string) (bool, error) {
+	if kv == nil {
+		return false, nil
+	}
 	_, err := kv.Get(ctx, key)
 	if err == nil {
 		return true, nil
@@ -412,6 +421,9 @@ func kvKeyExists(ctx context.Context, kv jetstream.KeyValue, key string) (bool, 
 }
 
 func countStreamMessages(ctx context.Context, stream jetstream.Stream, filters []string) (int, error) {
+	if stream == nil {
+		return 0, nil
+	}
 	consumer, err := stream.CreateConsumer(ctx, jetstream.ConsumerConfig{
 		FilterSubjects:    filters,
 		DeliverPolicy:     jetstream.DeliverAllPolicy,

--- a/cli/internal/core/mentions_test.go
+++ b/cli/internal/core/mentions_test.go
@@ -1,10 +1,7 @@
 package core
 
 import (
-	"errors"
 	"testing"
-
-	"github.com/nats-io/nats.go/jetstream"
 )
 
 func TestExtractMentionUsernames(t *testing.T) {
@@ -272,7 +269,5 @@ func TestChattoCore_MentionCreatesNotificationWithoutMentionStatus(t *testing.T)
 	}
 
 	legacyKey := "room_mention_status." + mentioned.Id + "." + room.Id
-	if _, err := core.storage.serverRuntimeKV.Get(ctx, legacyKey); !errors.Is(err, jetstream.ErrKeyNotFound) {
-		t.Fatalf("legacy mention status key lookup error = %v, want ErrKeyNotFound", err)
-	}
+	assertLegacyKeyAbsent(t, core.storage.serverRuntimeKV, legacyKey, "legacy mention status key")
 }

--- a/cli/internal/core/message_body.go
+++ b/cli/internal/core/message_body.go
@@ -155,6 +155,9 @@ func (c *ChattoCore) decryptMessageBody(ctx context.Context, msg *corev1.Message
 // Returns the number of legacy body entries deleted.
 func (c *ChattoCore) deleteUserMessageBodiesInSpace(ctx context.Context, userID string, kind RoomKind) (int, error) {
 	bucket := c.storage.serverBodiesKV
+	if bucket == nil {
+		return 0, nil
+	}
 
 	lister, err := bucket.ListKeysFiltered(ctx, userID+".>")
 	if err != nil {

--- a/cli/internal/core/push_test.go
+++ b/cli/internal/core/push_test.go
@@ -2,10 +2,7 @@ package core
 
 import (
 	"context"
-	"errors"
 	"testing"
-
-	"github.com/nats-io/nats.go/jetstream"
 )
 
 func TestPushSubscriptionKey(t *testing.T) {
@@ -139,9 +136,7 @@ func TestSavePushSubscription(t *testing.T) {
 		if _, err := core.storage.runtimeStateKV.Get(ctx, key); err != nil {
 			t.Fatalf("expected push subscription in RUNTIME_STATE: %v", err)
 		}
-		if _, err := core.storage.serverKV.Get(ctx, key); !errors.Is(err, jetstream.ErrKeyNotFound) {
-			t.Fatalf("legacy INSTANCE push subscription lookup error = %v, want ErrKeyNotFound", err)
-		}
+		assertLegacyKeyAbsent(t, core.storage.serverKV, key, "legacy INSTANCE push subscription")
 	})
 
 	t.Run("updates existing subscription with same endpoint", func(t *testing.T) {

--- a/cli/internal/core/rbac_es_migration.go
+++ b/cli/internal/core/rbac_es_migration.go
@@ -61,9 +61,13 @@ func (c *ChattoCore) migrateRBACToES(ctx context.Context) error {
 }
 
 func (c *ChattoCore) buildRBACMigrationEntries(ctx context.Context) ([]events.BatchEntry, int, error) {
-	keys, err := listSortedKeysFromKV(ctx, c.storage.serverRBACKV)
-	if err != nil {
-		return nil, 0, fmt.Errorf("list SERVER_RBAC keys: %w", err)
+	var keys []string
+	if c.storage.serverRBACKV != nil {
+		var err error
+		keys, err = listSortedKeysFromKV(ctx, c.storage.serverRBACKV)
+		if err != nil {
+			return nil, 0, fmt.Errorf("list SERVER_RBAC keys: %w", err)
+		}
 	}
 
 	roles := defaultRBACRoles()

--- a/cli/internal/core/room_layout_reconcile_test.go
+++ b/cli/internal/core/room_layout_reconcile_test.go
@@ -30,11 +30,12 @@ func equalStrings(a, b []string) bool {
 func writeRawLayoutOrder(t *testing.T, core *ChattoCore, groupIDs []string) {
 	t.Helper()
 	ctx := testContext(t)
+	legacyConfig := ensureLegacyServerConfigKV(t, core)
 	data, err := proto.Marshal(&corev1.RoomLayout{GroupIds: groupIDs})
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	if _, err := core.storage.serverConfigKV.Put(ctx, roomLayoutKey, data); err != nil {
+	if _, err := legacyConfig.Put(ctx, roomLayoutKey, data); err != nil {
 		t.Fatalf("put layout: %v", err)
 	}
 }

--- a/cli/internal/core/runtime_token_storage_test.go
+++ b/cli/internal/core/runtime_token_storage_test.go
@@ -51,13 +51,9 @@ func assertRuntimeTokenOnly(t *testing.T, core *ChattoCore, key, rawKey string) 
 		t.Fatalf("expected %s in RUNTIME_STATE: %v", key, err)
 	}
 	assertRuntimeKVHasTTL(t, core, key)
-	if _, err := core.storage.serverKV.Get(ctx, key); !errors.Is(err, jetstream.ErrKeyNotFound) {
-		t.Fatalf("legacy INSTANCE lookup for %s error = %v, want ErrKeyNotFound", key, err)
-	}
+	assertLegacyKeyAbsent(t, core.storage.serverKV, key, "legacy INSTANCE token key")
 	assertRawRuntimeTokenKeyAbsent(t, core, rawKey)
-	if _, err := core.storage.serverKV.Get(ctx, rawKey); !errors.Is(err, jetstream.ErrKeyNotFound) {
-		t.Fatalf("raw legacy INSTANCE lookup for %s error = %v, want ErrKeyNotFound", rawKey, err)
-	}
+	assertLegacyKeyAbsent(t, core.storage.serverKV, rawKey, "raw legacy INSTANCE token key")
 }
 
 func assertRuntimeKVHasTTL(t *testing.T, core *ChattoCore, key string) {

--- a/cli/internal/core/server_branding_test.go
+++ b/cli/internal/core/server_branding_test.go
@@ -1,10 +1,8 @@
 package core
 
 import (
-	"errors"
 	"testing"
 
-	"github.com/nats-io/nats.go/jetstream"
 	"google.golang.org/protobuf/proto"
 
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
@@ -26,9 +24,7 @@ func TestChattoCore_ServerBrandingUsesConfigEvents(t *testing.T) {
 	if !proto.Equal(logo, got) {
 		t.Fatalf("GetServerLogo = %+v, want %+v", got, logo)
 	}
-	if _, err := core.storage.serverKV.Get(ctx, serverLogoKey); !errors.Is(err, jetstream.ErrKeyNotFound) {
-		t.Fatalf("legacy logo KV key exists or failed unexpectedly: %v", err)
-	}
+	assertLegacyKeyAbsent(t, core.storage.serverKV, serverLogoKey, "legacy logo KV key")
 	cfg, err := core.ConfigManager().GetServerConfig(ctx)
 	if err != nil {
 		t.Fatalf("GetServerConfig after logo failed: %v", err)

--- a/cli/internal/core/system_test.go
+++ b/cli/internal/core/system_test.go
@@ -63,10 +63,9 @@ func TestChattoCore_GetAccountInfo(t *testing.T) {
 	})
 
 	t.Run("returns positive numbers for storage usage", func(t *testing.T) {
-		// All chat data lives in the SERVER_* buckets, eager-created at
-		// boot. Creating a Space record (or rooms within it) doesn't add
-		// streams; what's there at boot is what's there. We just check the
-		// numbers look sensible.
+		// Current storage is deployment-wide and created at boot. Creating a
+		// Space record (or rooms within it) doesn't add streams; what's there
+		// at boot is what's there. We just check the numbers look sensible.
 		info, err := core.GetAccountInfo(ctx)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)

--- a/cli/internal/core/threads_test.go
+++ b/cli/internal/core/threads_test.go
@@ -2,13 +2,11 @@ package core
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/nats-io/nats.go"
-	"github.com/nats-io/nats.go/jetstream"
 	"hmans.de/chatto/internal/core/subjects"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
@@ -458,9 +456,7 @@ func TestChattoCore_ThreadFollow(t *testing.T) {
 		if _, err := core.storage.runtimeStateKV.Get(ctx, key); err != nil {
 			t.Fatalf("Expected thread follow in RUNTIME_STATE: %v", err)
 		}
-		if _, err := core.storage.serverRuntimeKV.Get(ctx, key); !errors.Is(err, jetstream.ErrKeyNotFound) {
-			t.Fatalf("legacy SERVER_RUNTIME follow lookup error = %v, want ErrKeyNotFound", err)
-		}
+		assertLegacyKeyAbsent(t, core.storage.serverRuntimeKV, key, "legacy SERVER_RUNTIME follow")
 
 		isFollowing, err := core.IsFollowingThread(ctx, KindChannel, user.Id, room.Id, threadRootEventId)
 		if err != nil {

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -177,7 +177,7 @@ func (c *ChattoCore) CreateVerifiedUser(ctx context.Context, actorID, login, dis
 	return user, nil
 }
 
-// rollbackUserCreation undoes the KV writes performed by CreateUser. Best-effort —
+// rollbackUserCreation undoes the persisted writes performed by CreateUser. Best-effort —
 // failures are logged but not returned, since the caller is already in an error path.
 func (c *ChattoCore) rollbackUserCreation(ctx context.Context, user *corev1.User) {
 	c.logger.Warn("rolling back user creation", "user_id", user.Id, "login", user.Login)
@@ -195,7 +195,7 @@ func (c *ChattoCore) GetUser(ctx context.Context, userID string) (*corev1.User, 
 	return nil, ErrNotFound
 }
 
-// GetUsers retrieves multiple users by ID from the INSTANCE KV bucket.
+// GetUsers retrieves multiple users by ID from the user projection.
 // Returns users in the same order as userIDs. nil entries indicate not-found users.
 // More efficient than calling GetUser() in a loop for batched operations.
 func (c *ChattoCore) GetUsers(ctx context.Context, userIDs []string) ([]*corev1.User, error) {

--- a/cli/internal/core/users_verified_test.go
+++ b/cli/internal/core/users_verified_test.go
@@ -3,8 +3,6 @@ package core
 import (
 	"errors"
 	"testing"
-
-	"github.com/nats-io/nats.go/jetstream"
 )
 
 func TestCreateVerifiedUser_HappyPath(t *testing.T) {
@@ -47,9 +45,7 @@ func TestCreateVerifiedUser_RollsBackOnEmailConflict(t *testing.T) {
 	}
 
 	// User record must NOT exist (rollback).
-	if _, err := core.storage.serverKV.Get(ctx, userByLoginKey("second-user")); !errors.Is(err, jetstream.ErrKeyNotFound) {
-		t.Errorf("expected login claim to be rolled back, got err=%v", err)
-	}
+	assertLegacyKeyAbsent(t, core.storage.serverKV, userByLoginKey("second-user"), "rolled-back legacy login claim")
 }
 
 func TestCreateVerifiedUser_LoginCanBeReusedAfterRollback(t *testing.T) {

--- a/cli/internal/core/video_manifest_migration.go
+++ b/cli/internal/core/video_manifest_migration.go
@@ -167,6 +167,9 @@ func (c *ChattoCore) migrateVideoManifestsToES(ctx context.Context) (retErr erro
 }
 
 func (c *ChattoCore) listLegacyVideoStateKeys(ctx context.Context) ([]string, error) {
+	if c.storage.serverRuntimeKV == nil {
+		return nil, nil
+	}
 	lister, err := c.storage.serverRuntimeKV.ListKeys(ctx)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrNoKeysFound) {

--- a/cli/internal/core/video_manifest_migration_test.go
+++ b/cli/internal/core/video_manifest_migration_test.go
@@ -128,11 +128,12 @@ func TestVideoManifestMigration_UntrackedMissingOriginalImportsUnavailable(t *te
 func createPostedVideoAttachment(t *testing.T, core *ChattoCore) (*corev1.Room, *corev1.User, *corev1.Attachment) {
 	t.Helper()
 	ctx := testContext(t)
+	legacyRuntime := ensureLegacyServerRuntimeKV(t, core)
 
 	_ = core.storage.runtimeStateKV.Delete(ctx, videoManifestESMigrationKey)
 	_ = core.storage.runtimeStateKV.Delete(ctx, assetCreationESMigrationKey)
-	_ = core.storage.serverRuntimeKV.Delete(ctx, videoManifestESMigrationKey)
-	_ = core.storage.serverRuntimeKV.Delete(ctx, assetCreationESMigrationKey)
+	_ = legacyRuntime.Delete(ctx, videoManifestESMigrationKey)
+	_ = legacyRuntime.Delete(ctx, assetCreationESMigrationKey)
 	room, err := core.CreateRoom(ctx, "test-user", KindChannel, "", "Video", "Video room")
 	if err != nil {
 		t.Fatalf("create room: %v", err)
@@ -182,12 +183,13 @@ func createPostedVideoAttachment(t *testing.T, core *ChattoCore) (*corev1.Room, 
 func writeLegacyVideoState(t *testing.T, core *ChattoCore, attachmentID string, state *corev1.VideoProcessingState) {
 	t.Helper()
 	ctx := testContext(t)
+	legacyRuntime := ensureLegacyServerRuntimeKV(t, core)
 
 	data, err := proto.Marshal(state)
 	if err != nil {
 		t.Fatalf("marshal video state: %v", err)
 	}
-	if _, err := core.storage.serverRuntimeKV.Put(ctx, videoProcessingKey(attachmentID), data); err != nil {
+	if _, err := legacyRuntime.Put(ctx, videoProcessingKey(attachmentID), data); err != nil {
 		t.Fatalf("put legacy video state: %v", err)
 	}
 }

--- a/cli/internal/migrations/messages_es.go
+++ b/cli/internal/migrations/messages_es.go
@@ -156,19 +156,23 @@ func MigrateMessagesToES(
 		// Import with body=nil.
 		var body *corev1.MessageBody
 		if bodyKey := posted.GetMessageBodyId(); bodyKey != "" {
-			entry, getErr := serverBodiesKV.Get(ctx, bodyKey)
-			switch {
-			case getErr == nil:
-				var mb corev1.MessageBody
-				if err := proto.Unmarshal(entry.Value(), &mb); err != nil {
-					logger.Warn("messages ES migration: skipping unparseable body", "body_key", bodyKey, "error", err)
-				} else {
-					body = &mb
-				}
-			case errors.Is(getErr, jetstream.ErrKeyNotFound):
+			if serverBodiesKV == nil {
 				bodyMissing++
-			default:
-				logger.Warn("messages ES migration: failed to fetch body", "body_key", bodyKey, "error", getErr)
+			} else {
+				entry, getErr := serverBodiesKV.Get(ctx, bodyKey)
+				switch {
+				case getErr == nil:
+					var mb corev1.MessageBody
+					if err := proto.Unmarshal(entry.Value(), &mb); err != nil {
+						logger.Warn("messages ES migration: skipping unparseable body", "body_key", bodyKey, "error", err)
+					} else {
+						body = &mb
+					}
+				case errors.Is(getErr, jetstream.ErrKeyNotFound):
+					bodyMissing++
+				default:
+					logger.Warn("messages ES migration: failed to fetch body", "body_key", bodyKey, "error", getErr)
+				}
 			}
 		}
 

--- a/cli/internal/migrations/migrations.go
+++ b/cli/internal/migrations/migrations.go
@@ -47,8 +47,11 @@ import (
 // RunAll runs every active migration in order, stopping at the first
 // error.
 //
+// Legacy source handles may be nil on fresh ES-only deployments; RunAll treats
+// nil as an empty import source. Current target handles are required.
+//
 // KV buckets:
-//   - `serverKV`: INSTANCE bucket (user data).
+//   - `serverKV`: INSTANCE bucket (legacy user data and related indexes).
 //   - `serverConfigKV`: SERVER_CONFIG (rooms, room memberships,
 //     notification levels, …).
 //   - `serverBodiesKV`: SERVER_BODIES (message content + standalone
@@ -60,8 +63,8 @@ import (
 //   - `runtimeStateKV`: RUNTIME_STATE (persisted latest-value runtime/user
 //     state such as read markers, thread follows, push subscriptions, and
 //     HMAC-keyed auth/workflow tokens).
-//   - `serverReactionsKV`: SERVER_REACTIONS (legacy current reaction
-//     state; retained until reaction ES migration cleanup).
+//   - `serverReactionsKV`: SERVER_REACTIONS (legacy current reaction state).
+//   - `serverEventsStream`: SERVER_EVENTS (legacy room/member event log).
 //
 // `publisher` writes to the EVT event-sourcing stream and is
 // used by the ES migrations (ADR-035 phase 3 per aggregate) that seed
@@ -75,60 +78,74 @@ func RunAll(
 	publisher *events.Publisher,
 	logger *log.Logger,
 ) error {
-	if err := MigrateVerifiedEmailsToProto(ctx, serverKV, logger); err != nil {
-		return fmt.Errorf("verified_emails: %w", err)
+	if serverKV != nil {
+		if err := MigrateVerifiedEmailsToProto(ctx, serverKV, logger); err != nil {
+			return fmt.Errorf("verified_emails: %w", err)
+		}
+		if err := MigratePushSubscriptionsToRuntimeState(ctx, serverKV, runtimeStateKV, logger); err != nil {
+			return fmt.Errorf("push_subscriptions_runtime_state: %w", err)
+		}
+		if err := MigrateServerBrandingToES(ctx, serverKV, publisher, logger); err != nil {
+			return fmt.Errorf("server_branding_es: %w", err)
+		}
+		if err := MigrateUsersToES(ctx, serverKV, publisher, logger); err != nil {
+			return fmt.Errorf("users_es: %w", err)
+		}
+		if err := MigrateUserDisplayPreferencesToES(ctx, serverKV, publisher, logger); err != nil {
+			return fmt.Errorf("user_display_preferences_es: %w", err)
+		}
 	}
-	if err := BackfillRoomKind(ctx, serverConfigKV, logger); err != nil {
-		return fmt.Errorf("room_kind: %w", err)
+	if serverConfigKV != nil {
+		if err := BackfillRoomKind(ctx, serverConfigKV, logger); err != nil {
+			return fmt.Errorf("room_kind: %w", err)
+		}
+		// Room metadata + memberships share the evt.room.{R} subject and
+		// must seed together — a RoomCreatedEvent first, then the
+		// chronologically-ordered UserJoinedRoomEvents. Atomic AppendBatch
+		// keeps that invariant on every observable sequence.
+		if err := MigrateRoomAggregateToES(ctx, serverConfigKV, publisher, logger); err != nil {
+			return fmt.Errorf("room_aggregate_es: %w", err)
+		}
+		if err := MigrateRoomGroupsToES(ctx, serverConfigKV, publisher, logger); err != nil {
+			return fmt.Errorf("room_groups_es: %w", err)
+		}
+		if err := MigrateRoomLayoutToES(ctx, serverConfigKV, publisher, logger); err != nil {
+			return fmt.Errorf("room_layout_es: %w", err)
+		}
+		if err := MigrateNotificationPreferencesToES(ctx, serverConfigKV, publisher, logger); err != nil {
+			return fmt.Errorf("notification_preferences_es: %w", err)
+		}
 	}
-	if err := BackfillAttachmentLocatorData(ctx, serverBodiesKV, serverRuntimeKV, logger); err != nil {
-		return fmt.Errorf("attachment_locator_data: %w", err)
+	if serverBodiesKV != nil && serverRuntimeKV != nil {
+		if err := BackfillAttachmentLocatorData(ctx, serverBodiesKV, serverRuntimeKV, logger); err != nil {
+			return fmt.Errorf("attachment_locator_data: %w", err)
+		}
+		if err := DropLegacyAttachmentRecords(ctx, serverBodiesKV, serverRuntimeKV, logger); err != nil {
+			return fmt.Errorf("legacy_attachment_records: %w", err)
+		}
 	}
-	if err := DropLegacyAttachmentRecords(ctx, serverBodiesKV, serverRuntimeKV, logger); err != nil {
-		return fmt.Errorf("legacy_attachment_records: %w", err)
+	if serverRuntimeKV != nil {
+		if err := MigrateReadMarkersToRuntimeState(ctx, serverRuntimeKV, runtimeStateKV, logger); err != nil {
+			return fmt.Errorf("read_markers_runtime_state: %w", err)
+		}
+		if err := MigrateThreadFollowsToRuntimeState(ctx, serverRuntimeKV, runtimeStateKV, logger); err != nil {
+			return fmt.Errorf("thread_follows_runtime_state: %w", err)
+		}
 	}
-	if err := MigrateReadMarkersToRuntimeState(ctx, serverRuntimeKV, runtimeStateKV, logger); err != nil {
-		return fmt.Errorf("read_markers_runtime_state: %w", err)
+	if runtimeConfigKV != nil {
+		if err := MigrateServerConfigToES(ctx, runtimeConfigKV, publisher, logger); err != nil {
+			return fmt.Errorf("server_config_es: %w", err)
+		}
 	}
-	if err := MigrateThreadFollowsToRuntimeState(ctx, serverRuntimeKV, runtimeStateKV, logger); err != nil {
-		return fmt.Errorf("thread_follows_runtime_state: %w", err)
+	if serverEventsStream != nil {
+		if err := MigrateMessagesToES(ctx, serverEventsStream, serverBodiesKV, publisher, logger); err != nil {
+			return fmt.Errorf("messages_es: %w", err)
+		}
 	}
-	if err := MigratePushSubscriptionsToRuntimeState(ctx, serverKV, runtimeStateKV, logger); err != nil {
-		return fmt.Errorf("push_subscriptions_runtime_state: %w", err)
-	}
-	// Room metadata + memberships share the evt.room.{R} subject and
-	// must seed together — a RoomCreatedEvent first, then the
-	// chronologically-ordered UserJoinedRoomEvents. Atomic AppendBatch
-	// keeps that invariant on every observable sequence.
-	if err := MigrateRoomAggregateToES(ctx, serverConfigKV, publisher, logger); err != nil {
-		return fmt.Errorf("room_aggregate_es: %w", err)
-	}
-	if err := MigrateRoomGroupsToES(ctx, serverConfigKV, publisher, logger); err != nil {
-		return fmt.Errorf("room_groups_es: %w", err)
-	}
-	if err := MigrateRoomLayoutToES(ctx, serverConfigKV, publisher, logger); err != nil {
-		return fmt.Errorf("room_layout_es: %w", err)
-	}
-	if err := MigrateServerConfigToES(ctx, runtimeConfigKV, publisher, logger); err != nil {
-		return fmt.Errorf("server_config_es: %w", err)
-	}
-	if err := MigrateServerBrandingToES(ctx, serverKV, publisher, logger); err != nil {
-		return fmt.Errorf("server_branding_es: %w", err)
-	}
-	if err := MigrateNotificationPreferencesToES(ctx, serverConfigKV, publisher, logger); err != nil {
-		return fmt.Errorf("notification_preferences_es: %w", err)
-	}
-	if err := MigrateMessagesToES(ctx, serverEventsStream, serverBodiesKV, publisher, logger); err != nil {
-		return fmt.Errorf("messages_es: %w", err)
-	}
-	if err := MigrateReactionsToES(ctx, serverEventsStream, serverReactionsKV, publisher, logger); err != nil {
-		return fmt.Errorf("reactions_es: %w", err)
-	}
-	if err := MigrateUsersToES(ctx, serverKV, publisher, logger); err != nil {
-		return fmt.Errorf("users_es: %w", err)
-	}
-	if err := MigrateUserDisplayPreferencesToES(ctx, serverKV, publisher, logger); err != nil {
-		return fmt.Errorf("user_display_preferences_es: %w", err)
+	if serverEventsStream != nil && serverReactionsKV != nil {
+		if err := MigrateReactionsToES(ctx, serverEventsStream, serverReactionsKV, publisher, logger); err != nil {
+			return fmt.Errorf("reactions_es: %w", err)
+		}
 	}
 	return nil
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,13 +33,13 @@ For *why* a particular design decision was made:
 
 ## Overview
 
-Chatto is a real-time chat application with a GraphQL gateway and NATS/JetStream backend. The architecture uses **KV buckets as the source of truth** for data storage, with **event streams providing audit trails** and real-time pub/sub capabilities.
+Chatto is a real-time chat application with a GraphQL gateway and NATS/JetStream backend. Durable domain state is event-sourced in the `EVT` stream and served from projections; `RUNTIME_STATE` holds persisted latest-value runtime state such as notifications, push subscriptions, and auth tokens. Legacy KV buckets and `SERVER_EVENTS` are opened only when present so boot importers can seed `EVT` from pre-ES deployments.
 
 ### Core Concepts
 
 - **Server**: A deployment of Chatto, consisting of 1-n application processes connected to the same NATS system and account. ("Instance" is the older name for this concept and persists in a handful of vestigial places — the `INSTANCE*` KV bucket names and the internal `RegisteredInstance`/`isInstanceAdmin` identifiers. Treat them as a rename-in-progress.)
 - **Rooms**: Communication channels on the server. Can be named (`general`) or direct messages between users; differentiated by a `kind` field (`channel` / `dm`).
-- **Users**: Global to the deployment, with server membership tracked centrally and per-room membership managed in `SERVER_CONFIG`.
+- **Users**: Global to the deployment, with account/profile state and per-room membership projected from `EVT`.
 
 ## NATS Authentication
 
@@ -255,47 +255,41 @@ There is no `adminAuditLogEvents` subscription — audit events arrive through `
 
 | Type    | Resource                      | Purpose                                     |
 | ------- | ----------------------------- | ------------------------------------------- |
-| KV      | `INSTANCE`                    | Users, memberships (bucket name retained from pre-rename) |
-| KV      | `INSTANCE_CONFIG`             | Legacy server configuration import source   |
 | KV      | `USER_PRESENCE`               | Presence status (memory, TTL 60s)           |
 | KV      | `RUNTIME_STATE`               | Persisted latest-value runtime/user state, including pending notifications, push subscriptions, and auth/workflow tokens |
-| KV      | `SERVER_CONFIG`               | Rooms (channel + DM), memberships           |
-| KV      | `SERVER_RBAC`                 | Legacy RBAC seed data read by the `EVT` boot migration |
-| KV      | `SERVER_RUNTIME`              | Legacy runtime state pending cleanup        |
-| KV      | `SERVER_BODIES`               | Message bodies (GDPR-compliant) + standalone attachment metadata records — TODO: rename → `SERVER_CONTENT` |
-| KV      | `SERVER_REACTIONS`            | Legacy emoji reactions source for boot migration only |
 | Objects | `INSTANCE_ASSETS`             | Avatars, icons (bucket name retained from pre-rename) |
 | Objects | `ASSET_CACHE`                 | Cached resized images (optional, with TTL)  |
 | Objects | `SERVER_ASSETS`               | Message attachments                         |
+| Legacy import KV | `INSTANCE`          | Users, verified emails, branding, display preferences, and push subscriptions from pre-ES deployments |
+| Legacy import KV | `INSTANCE_CONFIG`   | Server configuration from pre-ES deployments |
+| Legacy import KV | `SERVER_CONFIG`     | Rooms, memberships, room sets/layout, and notification preferences from pre-ES deployments |
+| Legacy import KV | `SERVER_RBAC`       | RBAC seed data from pre-ES deployments |
+| Legacy import KV | `SERVER_RUNTIME`    | Read markers, thread follows, migration sentinels, and video processing state from pre-ES deployments |
+| Legacy import KV | `SERVER_BODIES`     | Pre-ES message bodies and attachment metadata |
+| Legacy import KV | `SERVER_REACTIONS`  | Emoji reactions from pre-ES deployments |
 | Stream  | `SERVER_EVENTS`               | Legacy room event import source; no new runtime writes |
 
 See [NATS Resource Inventory](#nats-resource-inventory) for detailed key patterns and subjects.
 
-**Important:** Event publishing is best-effort only for aggregates that
-still use the legacy CRUD + audit-log pattern. If event publishing fails
-there, the operation can still succeed because the KV store is the source
-of truth and the event is additive.
-
-**Exception:** Aggregates migrated to event sourcing require successful
-`EVT` publishing because `EVT` is their source of truth and reads come
-from in-memory projections. If event publishing fails, the write fails.
-Current migrated aggregates include room membership/metadata,
-room groups/layout, server config, users, messages/threads, reactions, RBAC,
-and auth workflow audit facts.
+`EVT` publishing is mandatory for event-sourced domain facts because `EVT`
+is the source of truth and reads come from in-memory projections. If event
+publishing fails, the write fails. Current migrated aggregates include room
+membership/metadata, room groups/layout, server config, users,
+messages/threads, reactions, RBAC, and auth workflow audit facts.
 
 ### Consistency Model
 
-**Legacy CRUD aggregates:**
+**Latest-value KV/runtime state:**
 
-- Strong consistency for KV operations (source of truth)
+- Strong consistency for KV operations
 - Read-your-writes guaranteed via immediate KV updates
-- Event streams provide audit trail with best-effort delivery
-- No store-mirroring problem: KV is source of truth, events are additive
+- Per-key TTLs are used for expiring records such as notifications and auth/workflow tokens
+- These records are operational state, not durable domain history
 
 **Migrated event-sourced aggregates:**
 
 - `EVT` is the source of truth.
-- Boot importers seed `EVT` from pre-ES KV/`SERVER_EVENTS` data.
+- Boot importers seed `EVT` from pre-ES KV/`SERVER_EVENTS` data when those resources exist.
 - Reads come from in-memory projections rebuilt from `EVT`.
 - Writes append to `EVT` only; legacy KV/stream data is not maintained as a mirror.
 - Read-your-writes is provided by waiting for the local projector to reach the append sequence.
@@ -303,17 +297,9 @@ and auth workflow audit facts.
 **Future (Clustered NATS - Multi-Process):**
 
 - KV buckets remain strongly consistent (NATS JetStream R3 replication)
-- Event streams continue providing audit trail and pub/sub
-- Configurable retention policies on legacy `SERVER_EVENTS` only where events remain additive; `EVT` retention is effectively forever until snapshot/archival policy is designed.
-- Can rebuild/migrate KV stores from current state exports (not from events)
-
-**Benefits of the legacy CRUD approach:**
-
-- Simple to understand and debug (CRUD operations with event logging)
-- Can safely age out old events based on retention policy
-- No complex event replay or projection rebuilding required
-- Storage costs scale with active data, not infinite history
-- Still provides full audit trail for compliance/debugging (until retention expires)
+- `EVT` provides durable audit/history and projection replay; transient live events provide UI sync.
+- `EVT` retention is effectively forever until snapshot/archival policy is designed.
+- `RUNTIME_STATE` can be rebuilt only from current operational exports or fresh user action, not from `EVT`, by design.
 
 ## Roles, Permissions, and Direct Messages
 
@@ -464,20 +450,22 @@ The unified `myEvents` GraphQL subscription is backed by a single core stream (`
 
 | Bucket                        | Storage | Backup   | Description                                     |
 | ----------------------------- | ------- | -------- | ----------------------------------------------- |
-| `INSTANCE`                    | File    | Yes      | Users, memberships (bucket name retained from pre-rename) |
-| `INSTANCE_CONFIG`             | File    | Yes      | Legacy server configuration import source       |
 | `RUNTIME_STATE`               | File    | Yes      | Persisted latest-value runtime/user state, including pending notifications, push subscriptions, and auth/workflow tokens |
-| `SERVER_CONFIG`               | File    | Yes      | Rooms (channel + DM), memberships               |
-| `SERVER_RBAC`                 | File    | Yes      | Legacy RBAC seed data read by the `EVT` boot migration |
-| `SERVER_RUNTIME`              | File    | Yes      | Legacy runtime state pending cleanup            |
-| `SERVER_BODIES`               | File    | Yes      | Message bodies (GDPR-compliant) + standalone attachment metadata records — TODO: rename → `SERVER_CONTENT` |
-| `SERVER_REACTIONS`            | File    | Yes      | Legacy emoji reactions, read only by the EVT boot migration |
 | `USER_PRESENCE`               | Memory  | No       | User presence status (TTL 60s)                  |
 | `CALL_STATE`                  | Memory  | No       | Active voice call participants, keyed `{spaceId}.{roomId}` (repopulated by LiveKit webhooks after restart) |
 | `ENCRYPTION_KEYS`             | File    | **No**   | User encryption keys (excluded for security)    |
 | `LINK_PREVIEW_CACHE`          | File    | No       | Cached link preview metadata (48h TTL)          |
+| `INSTANCE`                    | File    | Yes      | Legacy import source for users, verified emails, branding, display preferences, and push subscriptions; not provisioned on fresh boot |
+| `INSTANCE_CONFIG`             | File    | Yes      | Legacy server configuration import source; not provisioned on fresh boot |
+| `SERVER_CONFIG`               | File    | Yes      | Legacy rooms, memberships, room sets/layout, and notification preferences import source; not provisioned on fresh boot |
+| `SERVER_RBAC`                 | File    | Yes      | Legacy RBAC seed data import source; not provisioned on fresh boot |
+| `SERVER_RUNTIME`              | File    | Yes      | Legacy read markers, thread follows, migration sentinels, and video processing state import source; not provisioned on fresh boot |
+| `SERVER_BODIES`               | File    | Yes      | Legacy message bodies and attachment metadata import source; not provisioned on fresh boot |
+| `SERVER_REACTIONS`            | File    | Yes      | Legacy emoji reactions import source; not provisioned on fresh boot |
 
-All room data — channels and DMs alike — lives in the unified `SERVER_*` buckets. Per-space buckets (`SPACE_{spaceId}_*`) and the old hidden-DM-space storage model are gone after the Phase 4 migration (#354): rooms are differentiated by a `kind` segment in their KV keys (e.g. `room.channel.{roomId}` vs `room.dm.{roomId}`), and storage code never branches on `kind`.
+Fresh deployments create only current resources (`EVT`, projections' consumers, `RUNTIME_STATE`, live/runtime buckets, and object stores). Legacy KV buckets are opened opportunistically when present so boot importers can copy pre-ES state into `EVT` or `RUNTIME_STATE`; the application does not create or maintain them as mirrors.
+
+Pre-ES room data — channels and DMs alike — lived in the unified `SERVER_*` buckets. Per-space buckets (`SPACE_{spaceId}_*`) and the old hidden-DM-space storage model are gone after the Phase 4 migration (#354): rooms were differentiated by a `kind` segment in their KV keys (e.g. `room.channel.{roomId}` vs `room.dm.{roomId}`). Current room state is projected from `EVT`.
 
 **INSTANCE keys:**
 
@@ -495,7 +483,7 @@ All room data — channels and DMs alike — lives in the unified `SERVER_*` buc
 | `space_membership.{spaceId}.{userId}`  | User-server membership tracking (vestigial slot) |
 | `user_preferences.{userId}`            | User display preferences (timezone, time format) |
 
-Notes: Email verification uses SHA256 hashing for claim keys to ensure valid NATS subject characters and case-insensitive uniqueness. The claim key is created atomically when an email is verified, preventing race conditions where two users try to verify the same email. Verification, registration, password-reset, account-deletion, bearer-session, and OAuth authorization-code token verifiers live in `RUNTIME_STATE` under HMAC-derived keys.
+Notes: `INSTANCE` is legacy import-only. Current user/account/profile state is projected from `EVT`; verification, registration, password-reset, account-deletion, bearer-session, and OAuth authorization-code token verifiers live in `RUNTIME_STATE` under HMAC-derived keys. Email verification claim facts use hashed email identifiers in `EVT` to preserve case-insensitive uniqueness without storing raw email values in audit events.
 
 **EVT auth audit subjects:**
 
@@ -517,7 +505,7 @@ These audit payloads include only safe request metadata: capped user agent and a
 | ----------------- | ---------------------------------------------------------------------------- |
 | `config.instance` | Legacy server configuration import source (proto message; key + proto name retained) |
 
-Notes: Server configuration now lives in EVT config events and is served from the in-memory config projection. This bucket is retained as a boot-import source for pre-ES deployments. The TOML file remains reserved for operational settings (ports, secrets, NATS config).
+Notes: Server configuration now lives in EVT config events and is served from the in-memory config projection. This bucket is retained as a boot-import source for pre-ES deployments and is not created on fresh boot. The TOML file remains reserved for operational settings (ports, secrets, NATS config).
 
 **ENCRYPTION_KEYS keys:**
 
@@ -529,7 +517,7 @@ Notes: Excluded from backups so backup archives contain only encrypted data, not
 
 **SERVER\_CONFIG keys:**
 
-Room and membership keys carry a `kind` segment (`channel` or `dm`) so listing operations can prefix-filter without loading and deserializing every record. The kind isn't a field on the `Room` proto — the storage layout is the canonical source of truth.
+Room and membership keys in this legacy import bucket carry a `kind` segment (`channel` or `dm`) so listing operations can prefix-filter without loading and deserializing every record. Current room and membership state is projected from `EVT`; `SERVER_CONFIG` is not created on fresh boot.
 
 | Key                                                  | Description                                      |
 | ---------------------------------------------------- | ------------------------------------------------ |
@@ -786,6 +774,6 @@ Messages are persisted as durable `EVT` facts with encrypted message bodies embe
 - **Unified Event Subscriptions**: The `myEvents` subscription merges EVT republish (`live.evt.>`), transient sync (`live.sync.>`), and PresenceHub updates into one authorized user stream.
 - **Compression**: The `EVT` and legacy `SERVER_EVENTS` streams use S2 compression to reduce storage costs
 - **GDPR Compliance**: Message bodies are encrypted per author; deletion is represented by EVT retraction/shred facts and projections refuse to render shredded or retracted content.
-- **Unified Server Storage**: Channels and DMs share the same `SERVER_*` buckets; the `kind` segment in keys (`room.channel.*` / `room.dm.*`) disambiguates without per-space isolation
+- **Unified Event-Sourced Rooms**: Channels and DMs share `evt.room.{roomId}.>` subjects and room projections; legacy `SERVER_*` buckets are import-only.
 - **Legacy Body Store**: `SERVER_BODIES` is retained for pre-ES imports and legacy backup restores; new message bodies are encrypted into `MessagePostedEvent.body` and projected from `EVT`.
-- **Eager Server Resource Initialization**: The unified `SERVER_*` buckets (stream, KV buckets, object store) are created up-front at boot, not lazily on first use. The Phase 4 migration (#354) retired the legacy lazycache fallback that briefly accommodated the per-space storage shape.
+- **Current Resource Initialization**: Current resources are created up front at boot. Legacy import resources (`INSTANCE`, `INSTANCE_CONFIG`, `SERVER_CONFIG`, `SERVER_RBAC`, `SERVER_RUNTIME`, `SERVER_BODIES`, `SERVER_REACTIONS`, `SERVER_EVENTS`) are opened only if they already exist.


### PR DESCRIPTION
- Treat legacy KV buckets and SERVER_EVENTS as optional import-only resources instead of provisioning them on fresh boot.
- Keep boot migrations, ES verification, readiness, stats, and legacy-focused tests working when those handles are absent.
- Update architecture docs and backend rules to describe EVT/RUNTIME_STATE as current storage and legacy stores as import-only.

Tests: `mise x -- go test -count=1 ./internal/core ./internal/migrations -timeout 180s`; `git diff --check`.