### PR TITLE
ci: switch back to Ubicloud runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-frontend-unit:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubicloud-standard-4
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -44,7 +44,7 @@ jobs:
         run: cd frontend && pnpm vitest --run
 
   test-cli:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubicloud-standard-4
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -59,7 +59,7 @@ jobs:
         run: cd cli && go test -tags test_endpoints ./...
 
   test-e2e:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubicloud-standard-4
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -98,7 +98,7 @@ jobs:
   release:
     needs: [test-cli, test-e2e, test-frontend-unit]
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubicloud-standard-4
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -141,7 +141,7 @@ jobs:
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push frontend Docker image
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile.frontend


### PR DESCRIPTION
- Replace Blacksmith runner labels with `ubicloud-standard-4` for frontend, CLI, e2e, and release jobs.
- Switch the frontend image publish step back to `docker/build-push-action@v6`.
- Verified workflow YAML parses and `git diff --check` passes.