### PR TITLE
feat: store link preview cache in runtime state

### DIFF
--- a/cli/cmd/backup.go
+++ b/cli/cmd/backup.go
@@ -73,7 +73,7 @@ var backupCmd = &cobra.Command{
 Excluded from backups by default:
 - Encryption keys (security: keeps backup data encrypted at rest)
 - User presence (ephemeral, memory-only)
-- Link preview cache (regeneratable)
+- Retired standalone link preview cache, if present (regeneratable)
 - Asset cache (regeneratable)
 
 Pass --include-keys to include KV_ENCRYPTION_KEYS in the archive. This

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -726,11 +726,7 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	core.permissionResolver = NewPermissionResolver(core)
 
 	// Initialize link preview cache and fetcher
-	linkPreviewCache, err := linkpreview.NewCache(ctx, js, cfg.Replicas)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create link preview cache: %w", err)
-	}
-	core.linkPreviewCache = linkPreviewCache
+	core.linkPreviewCache = linkpreview.NewCache(storage.runtimeStateKV)
 	assetsConfig := core.AssetsConfig()
 	core.linkPreviewFetcher = linkpreview.NewFetcher(storage.serverStore, &assetsConfig, NewAssetID)
 

--- a/cli/internal/core/linkpreview/cache.go
+++ b/cli/internal/core/linkpreview/cache.go
@@ -19,17 +19,15 @@ import (
 var ErrCachedFailure = fmt.Errorf("cached failure")
 
 const (
-	// CacheBucketName is the name of the KV bucket for link preview cache.
-	CacheBucketName = "LINK_PREVIEW_CACHE"
+	// RuntimeStateKeyPrefix is the RUNTIME_STATE key prefix for cached link
+	// preview metadata.
+	RuntimeStateKeyPrefix = "link_preview."
 
 	// SuccessTTL is how long successful previews are cached.
 	SuccessTTL = 24 * time.Hour
 
 	// FailureTTL is how long failed previews are cached.
 	FailureTTL = 1 * time.Hour
-
-	// BucketTTL is the bucket-level TTL (entries auto-expire).
-	BucketTTL = 48 * time.Hour
 )
 
 // Cache provides caching for link preview results.
@@ -37,26 +35,16 @@ type Cache struct {
 	kv jetstream.KeyValue
 }
 
-// NewCache creates or opens the link preview cache KV bucket.
-func NewCache(ctx context.Context, js jetstream.JetStream, replicas int) (*Cache, error) {
-	kv, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
-		Bucket:      CacheBucketName,
-		Description: "Cached link preview metadata",
-		Storage:     jetstream.FileStorage,
-		TTL:         BucketTTL,
-		Replicas:    replicas,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &Cache{kv: kv}, nil
+// NewCache creates a cache wrapper over RUNTIME_STATE.
+func NewCache(kv jetstream.KeyValue) *Cache {
+	return &Cache{kv: kv}
 }
 
 // cacheKey generates a cache key from a URL.
 func cacheKey(rawURL string) string {
 	normalized := NormalizeURLString(rawURL)
 	hash := sha256.Sum256([]byte(normalized))
-	return hex.EncodeToString(hash[:])
+	return RuntimeStateKeyPrefix + hex.EncodeToString(hash[:])
 }
 
 // Get retrieves a cached link preview.
@@ -110,8 +98,7 @@ func (c *Cache) Set(ctx context.Context, url string, preview *corev1.LinkPreview
 		return err
 	}
 
-	_, err = c.kv.Put(ctx, cacheKey(url), data)
-	return err
+	return c.setWithTTL(ctx, cacheKey(url), data, SuccessTTL)
 }
 
 // SetFailure stores a failed fetch in the cache (negative caching).
@@ -129,6 +116,23 @@ func (c *Cache) SetFailure(ctx context.Context, url string, reason string) error
 		return err
 	}
 
-	_, err = c.kv.Put(ctx, cacheKey(url), data)
-	return err
+	return c.setWithTTL(ctx, cacheKey(url), data, FailureTTL)
+}
+
+func (c *Cache) setWithTTL(ctx context.Context, key string, data []byte, ttl time.Duration) error {
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		if _, err := c.kv.Create(ctx, key, data, jetstream.KeyTTL(ttl)); err == nil {
+			return nil
+		} else if !errors.Is(err, jetstream.ErrKeyExists) {
+			return err
+		} else {
+			lastErr = err
+		}
+
+		if err := c.kv.Purge(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+			return err
+		}
+	}
+	return fmt.Errorf("replace cached link preview: %w", lastErr)
 }

--- a/cli/internal/core/linkpreview/cache_test.go
+++ b/cli/internal/core/linkpreview/cache_test.go
@@ -1,0 +1,102 @@
+package linkpreview
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+	"hmans.de/chatto/internal/testutil"
+)
+
+func TestCacheStoresSuccessfulPreviewInRuntimeStateWithTTL(t *testing.T) {
+	ctx, js, kv := setupRuntimeStateKV(t)
+	cache := NewCache(kv)
+	url := "https://example.com/article"
+
+	err := cache.Set(ctx, url, &corev1.LinkPreview{
+		Url:   url,
+		Title: "Example",
+	})
+	require.NoError(t, err)
+
+	got, err := cache.Get(ctx, url)
+	require.NoError(t, err)
+	require.Equal(t, "Example", got.GetTitle())
+	assertRuntimeStateCacheTTL(t, ctx, js, kv, cacheKey(url))
+}
+
+func TestCacheStoresFailedPreviewInRuntimeStateWithTTL(t *testing.T) {
+	ctx, js, kv := setupRuntimeStateKV(t)
+	cache := NewCache(kv)
+	url := "https://example.com/failure"
+
+	err := cache.SetFailure(ctx, url, "no preview")
+	require.NoError(t, err)
+
+	got, err := cache.Get(ctx, url)
+	require.Nil(t, got)
+	require.True(t, errors.Is(err, ErrCachedFailure), "got %v", err)
+	assertRuntimeStateCacheTTL(t, ctx, js, kv, cacheKey(url))
+}
+
+func TestCacheReplacesExistingPreviewInRuntimeStateWithTTL(t *testing.T) {
+	ctx, js, kv := setupRuntimeStateKV(t)
+	cache := NewCache(kv)
+	url := "https://example.com/change"
+
+	err := cache.Set(ctx, url, &corev1.LinkPreview{Url: url, Title: "old"})
+	require.NoError(t, err)
+	err = cache.Set(ctx, url, &corev1.LinkPreview{Url: url, Title: "new"})
+	require.NoError(t, err)
+
+	got, err := cache.Get(ctx, url)
+	require.NoError(t, err)
+	require.Equal(t, "new", got.GetTitle())
+	assertRuntimeStateCacheTTL(t, ctx, js, kv, cacheKey(url))
+}
+
+func TestCacheKeyUsesRuntimeStatePrefix(t *testing.T) {
+	key := cacheKey("https://example.com/article")
+	require.True(t, strings.HasPrefix(key, RuntimeStateKeyPrefix), "key %q should use runtime-state prefix", key)
+	require.NotContains(t, key, "example.com")
+}
+
+func setupRuntimeStateKV(t *testing.T) (context.Context, jetstream.JetStream, jetstream.KeyValue) {
+	t.Helper()
+
+	_, nc := testutil.StartNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	kv, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:         "RUNTIME_STATE",
+		Storage:        jetstream.FileStorage,
+		History:        1,
+		LimitMarkerTTL: 24 * time.Hour,
+	})
+	require.NoError(t, err)
+
+	return ctx, js, kv
+}
+
+func assertRuntimeStateCacheTTL(t *testing.T, ctx context.Context, js jetstream.JetStream, kv jetstream.KeyValue, key string) {
+	t.Helper()
+
+	entry, err := kv.Get(ctx, key)
+	require.NoError(t, err)
+
+	stream, err := js.Stream(ctx, "KV_RUNTIME_STATE")
+	require.NoError(t, err)
+	msg, err := stream.GetMsg(ctx, entry.Revision())
+	require.NoError(t, err)
+	require.NotEmpty(t, msg.Header.Get("Nats-TTL"), "expected %s to carry per-key TTL", key)
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -452,7 +452,7 @@ The unified `myEvents` GraphQL subscription is backed by a single core stream (`
 | `RUNTIME_STATE`               | File    | Yes      | Persisted latest-value runtime/user state, including pending notifications, push subscriptions, and auth/workflow tokens |
 | `MEMORY_CACHE`                | Memory  | No       | Volatile cache state; presence keyed `presence.{userId}` with per-key TTL, active voice calls keyed `call.{spaceId}.{roomId}` |
 | `ENCRYPTION_KEYS`             | File    | **No**   | User encryption keys (excluded for security)    |
-| `LINK_PREVIEW_CACHE`          | File    | No       | Cached link preview metadata (48h TTL)          |
+| `LINK_PREVIEW_CACHE`          | File    | No       | Legacy retired standalone link-preview cache; current entries live in `RUNTIME_STATE` |
 | `USER_PRESENCE`               | Memory  | No       | Legacy retired presence bucket; not provisioned on fresh boot |
 | `CALL_STATE`                  | Memory  | No       | Legacy retired active-call bucket; copied best-effort into `MEMORY_CACHE` on boot if present, not provisioned on fresh boot |
 | `INSTANCE`                    | File    | Yes      | Legacy import source for users, verified emails, branding, display preferences, and push subscriptions; not provisioned on fresh boot |
@@ -579,6 +579,7 @@ survives restart but is not content/domain history. See
 | `account_deletion_token.{hmac}` | Account deletion confirmation token JSON. Uses per-key 15-minute TTL. |
 | `session.{hmac}` | Opaque bearer auth token JSON. Uses per-key `auth.token_ttl` (default 90 days); successful validation refreshes the key with a new per-key TTL for sliding-window expiry. |
 | `grant.{hmac}` | OAuth authorization code JSON. Uses per-key 5-minute TTL and is deleted on exchange attempt. |
+| `link_preview.{urlHash}` | Cached link preview metadata (protobuf `CachedLinkPreview`) keyed by SHA-256 of the normalized URL. Successful previews use per-key 24-hour TTL; failed fetches use per-key 1-hour TTL. |
 
 Token HMAC keys are derived with `[core].secret_key` and the token family as a domain separator. Backups include `RUNTIME_STATE`, so sessions and pending links survive restore only when the same `core.secret_key` is kept; backup archives do not contain raw bearer tokens or raw link/code values.
 

--- a/docs/adr/ADR-036-runtime-state-kv-boundary.md
+++ b/docs/adr/ADR-036-runtime-state-kv-boundary.md
@@ -66,6 +66,8 @@ Current occupants include:
   `email_verification.{hmac}`, `password_reset.{hmac}`, and
   `account_deletion_token.{hmac}`, with per-key TTLs appropriate to each
   workflow.
+- Link-preview cache entries: `link_preview.{urlHash}`, with per-key 24-hour
+  TTL for successful previews and 1-hour TTL for failed fetches.
 
 The HMAC keys for bearer tokens, OAuth codes, and account workflow tokens are
 derived with `[core].secret_key` from the raw token/code plus a per-flow scope


### PR DESCRIPTION
Refs #596 and #603.

- Moves link preview cache entries out of the standalone `LINK_PREVIEW_CACHE` KV bucket and into `RUNTIME_STATE` under `link_preview.{urlHash}`.
- Adds per-key TTLs: 24 hours for successful previews and 1 hour for failed fetches.
- Updates storage docs and backup help text while keeping old `KV_LINK_PREVIEW_CACHE` skipped if it exists from older deployments.
- Adds focused cache tests covering runtime-state storage, TTL headers, replacement, and hashed key shape.

Verification: `go test ./internal/core/linkpreview -timeout 120s`, `go test ./internal/core -timeout 180s`, `go test ./cmd -run 'Test.*Backup|TestSkipReason|TestClassifyStream' -timeout 120s`, and `git diff --check`.
