### PR TITLE
feat: add ES rollout observability

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -159,13 +159,14 @@ type AssetsConfig struct {
 
 // CoreConfig contains settings for the Chatto core service.
 type CoreConfig struct {
-	SecretKey    string        `toml:"secret_key" env:"CHATTO_CORE_SECRET_KEY" comment:"Server-wide secret for deriving HMAC verifiers for bearer tokens and account-flow links. NEVER SHARE THIS!\nIf it changes, existing bearer tokens and pending registration, verification, password reset, account deletion, and OAuth authorization-code links become invalid."`
-	Assets       AssetsConfig  `toml:"assets"`
-	ESBootVerify bool          `toml:"es_boot_verify,commented" env:"CHATTO_CORE_ES_BOOT_VERIFY" comment:"Log event-sourcing import/projection verification during boot. Intended for local rollout dry-runs; scans EVT and legacy stores."`
-	AuthTokenTTL time.Duration `toml:"-" env:"-"` // Set by caller from AuthConfig.TokenTTLOrDefault()
-	Replicas     int           `toml:"-" env:"-"` // Set by caller from NATSConfig.ReplicasOrDefault()
-	Limits       LimitsConfig  `toml:"-" env:"-"` // Set by caller from ChattoConfig.Limits
-	Owners       OwnersConfig  `toml:"-" env:"-"` // Set by caller from ChattoConfig.Owners — used by core to auto-promote on email verification
+	SecretKey          string        `toml:"secret_key" env:"CHATTO_CORE_SECRET_KEY" comment:"Server-wide secret for deriving HMAC verifiers for bearer tokens and account-flow links. NEVER SHARE THIS!\nIf it changes, existing bearer tokens and pending registration, verification, password reset, account deletion, and OAuth authorization-code links become invalid."`
+	Assets             AssetsConfig  `toml:"assets"`
+	ESBootVerify       bool          `toml:"es_boot_verify,commented" env:"CHATTO_CORE_ES_BOOT_VERIFY" comment:"Log event-sourcing import/projection verification during boot. Intended for local rollout dry-runs; scans EVT and legacy stores."`
+	ESBootVerifyStrict bool          `toml:"es_boot_verify_strict,commented" env:"CHATTO_CORE_ES_BOOT_VERIFY_STRICT" comment:"Fail boot when event-sourcing import/projection verification reports problems. Intended for live cutover and rollout gates."`
+	AuthTokenTTL       time.Duration `toml:"-" env:"-"` // Set by caller from AuthConfig.TokenTTLOrDefault()
+	Replicas           int           `toml:"-" env:"-"` // Set by caller from NATSConfig.ReplicasOrDefault()
+	Limits             LimitsConfig  `toml:"-" env:"-"` // Set by caller from ChattoConfig.Limits
+	Owners             OwnersConfig  `toml:"-" env:"-"` // Set by caller from ChattoConfig.Owners — used by core to auto-promote on email verification
 }
 
 // OIDCConfig contains settings for a generic OIDC provider (e.g. Chatto Hub via Zitadel).

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -238,7 +238,12 @@ func (c *ChattoCore) Run(ctx context.Context) error {
 			if err := c.WaitForProjectionsCurrent(gctx); err != nil {
 				return fmt.Errorf("wait for projections current: %w", err)
 			}
-			c.logESBootVerification(gctx)
+			if err := c.logESBootVerification(gctx); err != nil {
+				if c.config.ESBootVerifyStrict {
+					return err
+				}
+				c.logger.Warn("ES boot verification reported problems", "error", err)
+			}
 		}
 		close(c.bootDone)
 		return nil

--- a/cli/internal/core/es_boot_verification.go
+++ b/cli/internal/core/es_boot_verification.go
@@ -70,12 +70,12 @@ type esProjectedCounts struct {
 // projectors. It is intentionally part of the main process: embedded-NATS
 // deployments cannot safely run a second verifier process over the same data
 // directory.
-func (c *ChattoCore) logESBootVerification(ctx context.Context) {
+func (c *ChattoCore) logESBootVerification(ctx context.Context) error {
 	startedAt := time.Now()
 	report, err := c.buildESBootVerificationReport(ctx)
 	if err != nil {
 		c.logger.Warn("ES boot verification failed to build report", "error", err)
-		return
+		return err
 	}
 
 	c.evaluateESBootVerificationReport(report)
@@ -137,7 +137,9 @@ func (c *ChattoCore) logESBootVerification(ctx context.Context) {
 	}
 	if len(report.problems) == 0 {
 		c.logger.Info("ES boot verification passed")
+		return nil
 	}
+	return fmt.Errorf("ES boot verification found %d problem(s)", len(report.problems))
 }
 
 func (c *ChattoCore) buildESBootVerificationReport(ctx context.Context) (*esBootVerificationReport, error) {

--- a/cli/internal/events/publisher.go
+++ b/cli/internal/events/publisher.go
@@ -66,6 +66,17 @@ func NewPublisher(js jetstream.JetStream, stream jetstream.Stream, logger Logger
 	return &Publisher{js: js, stream: stream, logger: logger}
 }
 
+// StreamUsage returns the current message and byte totals for the bound
+// stream. Rollout tooling uses this to report how many EVT records each
+// importer appended without making every importer expose bespoke counters.
+func (p *Publisher) StreamUsage(ctx context.Context) (messages, bytes uint64, err error) {
+	info, err := p.stream.Info(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+	return info.State.Msgs, info.State.Bytes, nil
+}
+
 const maxAppendRetries = 5
 
 // Append publishes an event to a subject, automatically computing the

--- a/cli/internal/migrations/migrations.go
+++ b/cli/internal/migrations/migrations.go
@@ -37,6 +37,7 @@ package migrations
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/charmbracelet/log"
 	"github.com/nats-io/nats.go/jetstream"
@@ -78,74 +79,187 @@ func RunAll(
 	publisher *events.Publisher,
 	logger *log.Logger,
 ) error {
-	if serverKV != nil {
-		if err := MigrateVerifiedEmailsToProto(ctx, serverKV, logger); err != nil {
-			return fmt.Errorf("verified_emails: %w", err)
-		}
-		if err := MigratePushSubscriptionsToRuntimeState(ctx, serverKV, runtimeStateKV, logger); err != nil {
-			return fmt.Errorf("push_subscriptions_runtime_state: %w", err)
-		}
-		if err := MigrateServerBrandingToES(ctx, serverKV, publisher, logger); err != nil {
-			return fmt.Errorf("server_branding_es: %w", err)
-		}
-		if err := MigrateUsersToES(ctx, serverKV, publisher, logger); err != nil {
-			return fmt.Errorf("users_es: %w", err)
-		}
-		if err := MigrateUserDisplayPreferencesToES(ctx, serverKV, publisher, logger); err != nil {
-			return fmt.Errorf("user_display_preferences_es: %w", err)
-		}
+	run := func(name string, legacySourcePresent bool, fn func() error) error {
+		return runMigrationStep(ctx, publisher, logger, name, legacySourcePresent, fn)
 	}
-	if serverConfigKV != nil {
-		if err := BackfillRoomKind(ctx, serverConfigKV, logger); err != nil {
-			return fmt.Errorf("room_kind: %w", err)
-		}
-		// Room metadata + memberships share the evt.room.{R} subject and
-		// must seed together — a RoomCreatedEvent first, then the
-		// chronologically-ordered UserJoinedRoomEvents. Atomic AppendBatch
-		// keeps that invariant on every observable sequence.
-		if err := MigrateRoomAggregateToES(ctx, serverConfigKV, publisher, logger); err != nil {
-			return fmt.Errorf("room_aggregate_es: %w", err)
-		}
-		if err := MigrateRoomGroupsToES(ctx, serverConfigKV, publisher, logger); err != nil {
-			return fmt.Errorf("room_groups_es: %w", err)
-		}
-		if err := MigrateRoomLayoutToES(ctx, serverConfigKV, publisher, logger); err != nil {
-			return fmt.Errorf("room_layout_es: %w", err)
-		}
-		if err := MigrateNotificationPreferencesToES(ctx, serverConfigKV, publisher, logger); err != nil {
-			return fmt.Errorf("notification_preferences_es: %w", err)
-		}
+
+	if err := run("verified_emails", serverKV != nil, func() error {
+		return MigrateVerifiedEmailsToProto(ctx, serverKV, logger)
+	}); err != nil {
+		return err
 	}
-	if serverBodiesKV != nil && serverRuntimeKV != nil {
-		if err := BackfillAttachmentLocatorData(ctx, serverBodiesKV, serverRuntimeKV, logger); err != nil {
-			return fmt.Errorf("attachment_locator_data: %w", err)
-		}
-		if err := DropLegacyAttachmentRecords(ctx, serverBodiesKV, serverRuntimeKV, logger); err != nil {
-			return fmt.Errorf("legacy_attachment_records: %w", err)
-		}
+	if err := run("push_subscriptions_runtime_state", serverKV != nil, func() error {
+		return MigratePushSubscriptionsToRuntimeState(ctx, serverKV, runtimeStateKV, logger)
+	}); err != nil {
+		return err
 	}
-	if serverRuntimeKV != nil {
-		if err := MigrateReadMarkersToRuntimeState(ctx, serverRuntimeKV, runtimeStateKV, logger); err != nil {
-			return fmt.Errorf("read_markers_runtime_state: %w", err)
-		}
-		if err := MigrateThreadFollowsToRuntimeState(ctx, serverRuntimeKV, runtimeStateKV, logger); err != nil {
-			return fmt.Errorf("thread_follows_runtime_state: %w", err)
-		}
+	if err := run("server_branding_es", serverKV != nil, func() error {
+		return MigrateServerBrandingToES(ctx, serverKV, publisher, logger)
+	}); err != nil {
+		return err
 	}
-	if runtimeConfigKV != nil {
-		if err := MigrateServerConfigToES(ctx, runtimeConfigKV, publisher, logger); err != nil {
-			return fmt.Errorf("server_config_es: %w", err)
-		}
+	if err := run("users_es", serverKV != nil, func() error {
+		return MigrateUsersToES(ctx, serverKV, publisher, logger)
+	}); err != nil {
+		return err
 	}
-	if serverEventsStream != nil {
-		if err := MigrateMessagesToES(ctx, serverEventsStream, serverBodiesKV, publisher, logger); err != nil {
-			return fmt.Errorf("messages_es: %w", err)
-		}
+	if err := run("user_display_preferences_es", serverKV != nil, func() error {
+		return MigrateUserDisplayPreferencesToES(ctx, serverKV, publisher, logger)
+	}); err != nil {
+		return err
 	}
-	if serverEventsStream != nil && serverReactionsKV != nil {
-		if err := MigrateReactionsToES(ctx, serverEventsStream, serverReactionsKV, publisher, logger); err != nil {
-			return fmt.Errorf("reactions_es: %w", err)
-		}
+
+	if err := run("room_kind", serverConfigKV != nil, func() error {
+		return BackfillRoomKind(ctx, serverConfigKV, logger)
+	}); err != nil {
+		return err
+	}
+	// Room metadata + memberships share the evt.room.{R} subject and must
+	// seed together: a RoomCreatedEvent first, then the chronologically
+	// ordered UserJoinedRoomEvents. Atomic AppendBatch keeps that invariant.
+	if err := run("room_aggregate_es", serverConfigKV != nil, func() error {
+		return MigrateRoomAggregateToES(ctx, serverConfigKV, publisher, logger)
+	}); err != nil {
+		return err
+	}
+	if err := run("room_groups_es", serverConfigKV != nil, func() error {
+		return MigrateRoomGroupsToES(ctx, serverConfigKV, publisher, logger)
+	}); err != nil {
+		return err
+	}
+	if err := run("room_layout_es", serverConfigKV != nil, func() error {
+		return MigrateRoomLayoutToES(ctx, serverConfigKV, publisher, logger)
+	}); err != nil {
+		return err
+	}
+	if err := run("notification_preferences_es", serverConfigKV != nil, func() error {
+		return MigrateNotificationPreferencesToES(ctx, serverConfigKV, publisher, logger)
+	}); err != nil {
+		return err
+	}
+
+	bodyRuntimeSourcePresent := serverBodiesKV != nil && serverRuntimeKV != nil
+	if err := run("attachment_locator_data", bodyRuntimeSourcePresent, func() error {
+		return BackfillAttachmentLocatorData(ctx, serverBodiesKV, serverRuntimeKV, logger)
+	}); err != nil {
+		return err
+	}
+	if err := run("legacy_attachment_records", bodyRuntimeSourcePresent, func() error {
+		return DropLegacyAttachmentRecords(ctx, serverBodiesKV, serverRuntimeKV, logger)
+	}); err != nil {
+		return err
+	}
+
+	if err := run("read_markers_runtime_state", serverRuntimeKV != nil, func() error {
+		return MigrateReadMarkersToRuntimeState(ctx, serverRuntimeKV, runtimeStateKV, logger)
+	}); err != nil {
+		return err
+	}
+	if err := run("thread_follows_runtime_state", serverRuntimeKV != nil, func() error {
+		return MigrateThreadFollowsToRuntimeState(ctx, serverRuntimeKV, runtimeStateKV, logger)
+	}); err != nil {
+		return err
+	}
+
+	if err := run("server_config_es", runtimeConfigKV != nil, func() error {
+		return MigrateServerConfigToES(ctx, runtimeConfigKV, publisher, logger)
+	}); err != nil {
+		return err
+	}
+	if err := run("messages_es", serverEventsStream != nil, func() error {
+		return MigrateMessagesToES(ctx, serverEventsStream, serverBodiesKV, publisher, logger)
+	}); err != nil {
+		return err
+	}
+	if err := run("reactions_es", serverEventsStream != nil && serverReactionsKV != nil, func() error {
+		return MigrateReactionsToES(ctx, serverEventsStream, serverReactionsKV, publisher, logger)
+	}); err != nil {
+		return err
 	}
 	return nil
+}
+
+func runMigrationStep(
+	ctx context.Context,
+	publisher *events.Publisher,
+	logger *log.Logger,
+	name string,
+	legacySourcePresent bool,
+	run func() error,
+) error {
+	if !legacySourcePresent {
+		logger.Info(
+			"ES boot migration step skipped",
+			"step", name,
+			"legacy_source_present", false,
+			"evt_messages_appended", 0,
+			"evt_bytes_appended", 0,
+			"duration_ms", 0,
+		)
+		return nil
+	}
+
+	startedAt := time.Now()
+	before := captureMigrationEVTUsage(ctx, publisher, logger, name, "before")
+	logger.Info("ES boot migration step started", "step", name, "legacy_source_present", true)
+
+	err := run()
+	durationMS := time.Since(startedAt).Milliseconds()
+	appended := before.delta(captureMigrationEVTUsage(ctx, publisher, logger, name, "after"))
+
+	if err != nil {
+		logger.Warn(
+			"ES boot migration step failed",
+			"step", name,
+			"legacy_source_present", true,
+			"evt_messages_appended", appended.messages,
+			"evt_bytes_appended", appended.bytes,
+			"duration_ms", durationMS,
+			"error", err,
+		)
+		return fmt.Errorf("%s: %w", name, err)
+	}
+
+	logger.Info(
+		"ES boot migration step completed",
+		"step", name,
+		"legacy_source_present", true,
+		"evt_messages_appended", appended.messages,
+		"evt_bytes_appended", appended.bytes,
+		"duration_ms", durationMS,
+	)
+	return nil
+}
+
+type migrationEVTUsage struct {
+	messages uint64
+	bytes    uint64
+	ok       bool
+}
+
+func captureMigrationEVTUsage(ctx context.Context, publisher *events.Publisher, logger *log.Logger, step, phase string) migrationEVTUsage {
+	if publisher == nil {
+		return migrationEVTUsage{}
+	}
+	messages, bytes, err := publisher.StreamUsage(ctx)
+	if err != nil {
+		logger.Warn("ES boot migration stream metrics unavailable", "step", step, "phase", phase, "error", err)
+		return migrationEVTUsage{}
+	}
+	return migrationEVTUsage{messages: messages, bytes: bytes, ok: true}
+}
+
+func (before migrationEVTUsage) delta(after migrationEVTUsage) migrationEVTUsage {
+	if !before.ok || !after.ok {
+		return migrationEVTUsage{}
+	}
+	var delta migrationEVTUsage
+	if after.messages >= before.messages {
+		delta.messages = after.messages - before.messages
+	}
+	if after.bytes >= before.bytes {
+		delta.bytes = after.bytes - before.bytes
+	}
+	delta.ok = true
+	return delta
 }

--- a/cli/internal/migrations/migrations_test.go
+++ b/cli/internal/migrations/migrations_test.go
@@ -1,0 +1,67 @@
+package migrations
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/log"
+)
+
+func TestRunMigrationStep_SkipsMissingLegacySource(t *testing.T) {
+	called := false
+	err := runMigrationStep(
+		context.Background(),
+		nil,
+		log.New(io.Discard),
+		"missing_source",
+		false,
+		func() error {
+			called = true
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("runMigrationStep returned error: %v", err)
+	}
+	if called {
+		t.Fatal("runMigrationStep called a skipped step")
+	}
+}
+
+func TestRunMigrationStep_WrapsStepError(t *testing.T) {
+	stepErr := errors.New("boom")
+	err := runMigrationStep(
+		context.Background(),
+		nil,
+		log.New(io.Discard),
+		"failing_step",
+		true,
+		func() error { return stepErr },
+	)
+	if !errors.Is(err, stepErr) {
+		t.Fatalf("runMigrationStep error = %v, want wrapped %v", err, stepErr)
+	}
+	if !strings.Contains(err.Error(), "failing_step") {
+		t.Fatalf("runMigrationStep error = %v, want step name", err)
+	}
+}
+
+func TestMigrationUsageDelta(t *testing.T) {
+	appended := (migrationEVTUsage{messages: 10, bytes: 100, ok: true}).delta(migrationEVTUsage{messages: 14, bytes: 175, ok: true})
+	if appended.messages != 4 || appended.bytes != 75 {
+		t.Fatalf("migrationEVTUsage.delta = (%d, %d), want (4, 75)", appended.messages, appended.bytes)
+	}
+
+	appended = (migrationEVTUsage{messages: 10, bytes: 100, ok: true}).delta(migrationEVTUsage{messages: 8, bytes: 90, ok: true})
+	if appended.messages != 0 || appended.bytes != 0 {
+		t.Fatalf("migrationEVTUsage.delta underflow = (%d, %d), want zeros", appended.messages, appended.bytes)
+	}
+
+	appended = (migrationEVTUsage{messages: 10, bytes: 100}).delta(migrationEVTUsage{messages: 14, bytes: 175, ok: true})
+	if appended.messages != 0 || appended.bytes != 0 {
+		t.Fatalf("migrationEVTUsage.delta without metrics = (%d, %d), want zeros", appended.messages, appended.bytes)
+	}
+}

--- a/docs/adr/ADR-035-per-aggregate-phased-migration.md
+++ b/docs/adr/ADR-035-per-aggregate-phased-migration.md
@@ -84,6 +84,20 @@ The always-OCC invariant from ADR-033 makes migration replayability automatic:
 - A second full run against an already-migrated subject fails the OCC check on the first event and aborts that subject's migration without writing duplicates.
 - A migration that crashed midway can resume: re-running iterates the same KV order, the already-emitted prefix is no-op'd by OCC, and the remainder appends.
 
+### Rollout observability
+
+Boot migrations emit one structured log marker per migration step, including
+whether the legacy source exists, whether the step completed/skipped/failed,
+duration, and the `EVT` stream message/byte delta appended by that step. This
+keeps no-op boots visible while making first-import runs auditable from logs.
+
+`core.es_boot_verify` enables the boot verifier: after projectors catch up, it
+logs legacy counts, projected counts, per-event-type `EVT` counts, decode
+errors, warnings, and problems. `core.es_boot_verify_strict` upgrades verifier
+problems into boot failure for cutover gates and scratch-restore dry runs. It is
+opt-in so normal production restarts do not fail on a diagnostic-only scan
+unless rollout explicitly asks for that behavior.
+
 Determinism is the migration command's responsibility: events for a given subject must be emitted in the same order across runs given the same KV state. This is a property of the iteration code, not of the framework.
 
 ### Why no dual-write


### PR DESCRIPTION
## Summary

- Add structured boot logs around every ES migration step, including skipped/failed/completed status, duration, and EVT message/byte deltas.
- Add an opt-in strict boot verification flag so ES verification problems can fail rollout/cutover boots.
- Document the rollout observability behavior in ADR-035 and cover the migration wrapper with focused tests.

## Test Plan

- `go test ./cmd ./internal/migrations ./internal/events ./internal/core ./internal/config -timeout 180s`
- `git diff --check`
