### PR TITLE
fix(frontend): disable composer submit while attachments stage

### DIFF
--- a/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -260,6 +260,7 @@
   let fileInputElement = $state<HTMLInputElement>();
 
   let filesWithUrls = $state<FileWithUrl[]>([]);
+  let pendingAttachmentCount = $state(0);
 
   // Derive just the files for posting
   let selectedFiles = $derived(filesWithUrls.map((f) => f.file));
@@ -297,6 +298,7 @@
   let canSubmit = $derived(
     !loading &&
       !inputDisabled &&
+      pendingAttachmentCount === 0 &&
       (hasVisibleContent(message) || selectedFiles.length > 0 || isEditing)
   );
 
@@ -561,16 +563,35 @@
     return accepted;
   }
 
-  async function handleFileSelect(event: Event) {
+  function filesToPreviewItems(files: File[]): FileWithUrl[] {
+    return files.map((file) => ({
+      file,
+      url: URL.createObjectURL(file)
+    }));
+  }
+
+  async function stageFiles(files: File[]) {
+    const validFiles = validateFileSizes(files);
+    if (validFiles.length === 0) return;
+
+    pendingAttachmentCount += validFiles.length;
+    try {
+      const prepared = await prepareFiles(validFiles);
+      if (prepared.length > 0) {
+        filesWithUrls = [...filesWithUrls, ...filesToPreviewItems(prepared)];
+      }
+    } catch (err) {
+      console.error('Error preparing attachment files:', err);
+      toast.error('Failed to prepare attachment');
+    } finally {
+      pendingAttachmentCount -= validFiles.length;
+    }
+  }
+
+  function handleFileSelect(event: Event) {
     const target = event.target as HTMLInputElement;
     if (target.files) {
-      const validFiles = validateFileSizes(Array.from(target.files));
-      const prepared = await prepareFiles(validFiles);
-      const newFiles = prepared.map((file) => ({
-        file,
-        url: URL.createObjectURL(file)
-      }));
-      filesWithUrls = [...filesWithUrls, ...newFiles];
+      void stageFiles(Array.from(target.files));
     }
     // Reset input so same file can be selected again
     target.value = '';
@@ -589,13 +610,7 @@
    * Creates object URLs for preview and adds to the attachment list.
    */
   async function addFiles(files: File[]) {
-    const validFiles = validateFileSizes(files);
-    const prepared = await prepareFiles(validFiles);
-    const newFiles = prepared.map((file) => ({
-      file,
-      url: URL.createObjectURL(file)
-    }));
-    filesWithUrls = [...filesWithUrls, ...newFiles];
+    await stageFiles(files);
   }
 
   // Focus the input programmatically (e.g., when opening thread from mobile action sheet)
@@ -629,12 +644,7 @@
     }
 
     if (pastedFiles.length > 0) {
-      const validFiles = validateFileSizes(pastedFiles);
-      // Fire-and-forget: convert HEIC files asynchronously, then add to list
-      prepareFiles(validFiles).then((prepared) => {
-        const newFiles = prepared.map((file) => ({ file, url: URL.createObjectURL(file) }));
-        filesWithUrls = [...filesWithUrls, ...newFiles];
-      });
+      void stageFiles(pastedFiles);
       return true; // Prevent TipTap from processing the paste
     }
     return false; // Let TipTap handle text pastes
@@ -704,7 +714,7 @@
         message = bodyToSend;
         editorApi?.setContent(bodyToSend);
         if (filesToSend) {
-          filesWithUrls = filesToSend.map((f) => ({ file: f, url: URL.createObjectURL(f) }));
+          filesWithUrls = filesToPreviewItems(filesToSend);
         }
       } else {
         // Scroll the enclosing pane to the user's new message. The composer
@@ -758,7 +768,9 @@
   }
 
   async function handleSubmit() {
-    if (loading) return; // Guard against double-sends while editor stays editable
+    // Guard against double-sends while editor stays editable, and against
+    // submitting before pasted/dropped/selected files have finished staging.
+    if (loading || inputDisabled || pendingAttachmentCount > 0) return;
     if (isEditing) {
       await editMessage();
     } else {

--- a/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -1,15 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from 'vitest-browser-svelte';
-import { Client } from '@urql/svelte';
 import MessageComposer from './MessageComposer.svelte';
-import { createMockConnection, createMockGraphqlClient, q } from '$lib/test-utils';
+import { createMockGraphqlClient, q } from '$lib/test-utils';
 
 const mutationData = { postMessage: { id: 'msg_123' } };
+const prepareFilesMock = vi.hoisted(() => vi.fn());
+const mutationMock = vi.hoisted(() => vi.fn());
+const queryMock = vi.hoisted(() => vi.fn());
 
 // Mock instance state
 const mockInstanceStores = {
   currentUser: { user: { id: 'test-user', login: 'testuser' }, loading: false },
-  instance: {
+  serverInfo: {
     maxUploadSize: 25 * 1024 * 1024,
     maxVideoUploadSize: 25 * 1024 * 1024
   },
@@ -19,7 +21,19 @@ const mockInstanceStores = {
 };
 
 vi.mock('$lib/state/server/connection.svelte', () => ({
-  useConnection: () => () => createMockConnection({ mutationData })
+  useConnection: () => () => ({
+    isConnected: true,
+    showConnectionLostBanner: false,
+    client: {
+      query: queryMock,
+      mutation: mutationMock,
+      subscription: vi.fn()
+    }
+  })
+}));
+
+vi.mock('$lib/attachments/prepareFiles', () => ({
+  prepareFiles: prepareFilesMock
 }));
 
 vi.mock('$lib/state/server/registry.svelte', () => ({
@@ -53,18 +67,54 @@ vi.mock('$lib/state/room', () => ({
   })
 }));
 
-function renderMessageComposer(
-  props: { roomId: string },
-  context: Map<string, unknown>
-) {
+function renderMessageComposer(props: { roomId: string }, context: Map<string, unknown>) {
   return render(MessageComposer, { props, context });
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function imageFile(name = 'paste.png'): File {
+  return new File([new Uint8Array([1, 2, 3])], name, { type: 'image/png' });
+}
+
+function pasteFile(target: HTMLElement, file: File) {
+  const dataTransfer = new DataTransfer();
+  dataTransfer.items.add(file);
+  target.dispatchEvent(
+    new ClipboardEvent('paste', {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: dataTransfer
+    })
+  );
+}
+
+async function typeInEditor(editor: HTMLElement, text: string) {
+  editor.focus();
+  document.execCommand('insertText', false, text);
+  await vi.waitFor(() => expect(editor.textContent).toBe(text));
+}
+
 describe('MessageComposer', () => {
-  let mockClient: Client;
+  let mockClient: ReturnType<typeof createMockGraphqlClient>;
 
   beforeEach(() => {
     mockClient = createMockGraphqlClient({ mutationData });
+    prepareFilesMock.mockReset();
+    prepareFilesMock.mockImplementation(async (files: File[]) => files);
+    mutationMock.mockReset();
+    mutationMock.mockResolvedValue({ data: mutationData, error: null });
+    queryMock.mockReset();
+    queryMock.mockResolvedValue({ data: null, error: null });
+    sessionStorage.clear();
     vi.clearAllMocks();
   });
 
@@ -194,6 +244,92 @@ describe('MessageComposer', () => {
       const sendButton = q(container, 'button[title="Send message"]');
       const icon = sendButton?.querySelector('.uil--telegram-alt');
       expect(icon).not.toBeNull();
+    });
+  });
+
+  describe('pasted attachments', () => {
+    it('disables sending typed text while a pasted image is preparing', async () => {
+      const file = imageFile();
+      const pendingPreparation = deferred<File[]>();
+      prepareFilesMock.mockReturnValueOnce(pendingPreparation.promise);
+      const { container } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = q(container, '[data-testid="message-input"]')!;
+
+      pasteFile(editor, file);
+      await typeInEditor(editor, 'message with image');
+      const sendButton = q(container, 'button[title="Send message"]')! as HTMLButtonElement;
+      await expect.element(sendButton).toBeDisabled();
+
+      editor.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+      );
+      expect(mutationMock).not.toHaveBeenCalled();
+
+      pendingPreparation.resolve([file]);
+
+      await expect.element(sendButton).not.toBeDisabled();
+      sendButton.click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({
+        roomId: 'room_456',
+        body: 'message with image',
+        attachments: [file]
+      });
+    });
+
+    it('disables image-only send until a pasted image preview appears', async () => {
+      const file = imageFile();
+      const pendingPreparation = deferred<File[]>();
+      prepareFilesMock.mockReturnValueOnce(pendingPreparation.promise);
+      const { container } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = q(container, '[data-testid="message-input"]')!;
+      const sendButton = q(container, 'button[title="Send message"]')! as HTMLButtonElement;
+
+      pasteFile(editor, file);
+      await expect.element(sendButton).toBeDisabled();
+      sendButton.click();
+
+      expect(mutationMock).not.toHaveBeenCalled();
+
+      pendingPreparation.resolve([file]);
+
+      await expect.element(sendButton).not.toBeDisabled();
+      sendButton.click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({
+        roomId: 'room_456',
+        body: null,
+        attachments: [file]
+      });
+    });
+
+    it('clears disabled send state when pasted image preparation fails', async () => {
+      const pendingPreparation = deferred<File[]>();
+      prepareFilesMock.mockReturnValueOnce(pendingPreparation.promise);
+      const { container } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = q(container, '[data-testid="message-input"]')!;
+      const sendButton = q(container, 'button[title="Send message"]')! as HTMLButtonElement;
+
+      pasteFile(editor, imageFile());
+      await expect.element(sendButton).toBeDisabled();
+      sendButton.click();
+
+      pendingPreparation.reject(new Error('prepare failed'));
+
+      await vi.waitFor(() => expect(mutationMock).not.toHaveBeenCalled());
+      await expect.element(sendButton).toBeDisabled();
+      expect(container.querySelector('.sending')).toBeNull();
     });
   });
 


### PR DESCRIPTION
- Disable composer submit while pasted, dropped, or selected attachments are still being prepared.\n- Share attachment staging logic across paste, file picker, and drag/drop paths.\n- Add browser component coverage for pasted attachment staging, Enter/click submit blocking, and preparation failure cleanup.\n\nVerified with `mise x -- pnpm test:unit --run --project client src/lib/components/composer/MessageComposer.svelte.spec.ts` and `mise lint-frontend`.