### PR TITLE
refactor: consolidate projection registry

### DIFF
--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -178,12 +178,11 @@ type ChattoCore struct {
 	// from role and permission writers.
 	RBACProjector *events.Projector
 
-	// projectors is the set of all event-sourcing projectors owned by
-	// this core. Each new aggregate migration (ADR-035) appends here
-	// during NewChattoCore; Run iterates the slice. Adding a projector
-	// is one line at construction and zero changes at call sites — see
-	// (*ChattoCore).Run.
-	projectors []*events.Projector
+	// projections is the set of all event-sourcing projections owned by
+	// this core. Each registration carries the runtime projector plus
+	// operator-facing diagnostics, so lifecycle and admin surfaces cannot
+	// drift into separate hand-maintained lists.
+	projections []projectionRegistration
 
 	// bootDone is closed by Run once all projectors are started AND
 	// boot-time mutations (ensureChannelRoomsAreInAGroup) have
@@ -202,14 +201,14 @@ type ChattoCore struct {
 // launch it in a bare goroutine with a per-test context that cleanup
 // cancels. Background services are not designed to be restarted.
 //
-// New projectors should be appended to c.projectors during NewChattoCore;
-// they are then started automatically here without any additional wiring.
+// New projectors should be registered during NewChattoCore; they are then
+// started automatically here without any additional wiring.
 func (c *ChattoCore) Run(ctx context.Context) error {
 	g, gctx := errgroup.WithContext(ctx)
 
-	for _, p := range c.projectors {
-		p := p
-		g.Go(func() error { return p.Run(gctx) })
+	for _, projection := range c.projections {
+		projector := projection.projector
+		g.Go(func() error { return projector.Run(gctx) })
 	}
 
 	// Block until every projector has entered Run before issuing
@@ -270,8 +269,8 @@ func (c *ChattoCore) Run(ctx context.Context) error {
 // background goroutines launched by Run aren't guaranteed to have
 // been scheduled the instant `go core.Run(ctx)` returns.
 func (c *ChattoCore) AllProjectorsStarted() bool {
-	for _, p := range c.projectors {
-		if !p.Started() {
+	for _, projection := range c.projections {
+		if !projection.projector.Started() {
 			return false
 		}
 	}
@@ -298,8 +297,8 @@ func (c *ChattoCore) WaitForBoot(ctx context.Context) error {
 // applied the latest stream message matching its filters as of this call.
 // Intended for boot/import diagnostics, not hot request paths.
 func (c *ChattoCore) WaitForProjectionsCurrent(ctx context.Context) error {
-	for _, p := range c.projectors {
-		if err := p.WaitForCurrent(ctx); err != nil {
+	for _, projection := range c.projections {
+		if err := projection.projector.WaitForCurrent(ctx); err != nil {
 			return err
 		}
 	}
@@ -453,13 +452,10 @@ func (c *ChattoCore) DeleteUserEncryptionKeyAs(ctx context.Context, actorID, use
 	if err != nil {
 		return fmt.Errorf("failed to record user key shred event: %w", err)
 	}
-	if err := c.RoomTimelineProjector.WaitForSeq(ctx, seq); err != nil {
-		return fmt.Errorf("wait for room timeline projection: %w", err)
-	}
-	if err := c.ThreadsProjector.WaitForSeq(ctx, seq); err != nil {
-		return fmt.Errorf("wait for thread projection: %w", err)
-	}
-	return nil
+	return waitForSeqAll(ctx, seq,
+		waitForProjection("room timeline", c.RoomTimelineProjector),
+		waitForProjection("thread", c.ThreadsProjector),
+	)
 }
 
 // AssetsConfig returns the assets configuration as an assets.Config.
@@ -669,53 +665,57 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	// projectors → managers that depend on them.
 	eventPublisher := events.NewPublisher(js, storage.serverEvtStream, logger)
 
-	// newProjector wraps the (projection, logger-prefix) → Projector
-	// construction so the per-aggregate wiring below stays one line per
-	// projection. Each projector also gets appended to the slice that
-	// (*ChattoCore).Run iterates.
-	var projectors []*events.Projector
-	newProjector := func(p events.Projection, name string) *events.Projector {
-		pr := events.NewProjector(js, storage.serverEvtStream, p, logger.WithPrefix("core."+name))
-		projectors = append(projectors, pr)
+	// newProjector wraps projection construction into one registration
+	// record. Runtime lifecycle and admin diagnostics both consume this
+	// same list, so adding a projection has a single wiring point.
+	var projections []projectionRegistration
+	newProjector := func(p events.Projection, name string, estimate func() (int64, int64, []ProjectionAdminMetric)) *events.Projector {
+		loggerName := strings.ReplaceAll(name, " ", "") + "Projector"
+		pr := events.NewProjector(js, storage.serverEvtStream, p, logger.WithPrefix("core."+loggerName))
+		projections = append(projections, projectionRegistration{
+			name:      name,
+			projector: pr,
+			estimate:  estimate,
+		})
 		return pr
 	}
 
 	roomMembership := NewRoomMembershipProjection()
-	roomMembershipProjector := newProjector(roomMembership, "RoomMembershipProjector")
+	roomMembershipProjector := newProjector(roomMembership, "Room Membership", roomMembership.adminProjectionEstimate)
 
 	serverConfigProjection := NewConfigProjection()
-	serverConfigProjector := newProjector(serverConfigProjection, "ServerConfigProjector")
+	serverConfigProjector := newProjector(serverConfigProjection, "Server Config", serverConfigProjection.adminProjectionEstimate)
 
 	roomCatalog := NewRoomCatalogProjection()
-	roomCatalogProjector := newProjector(roomCatalog, "RoomCatalogProjector")
+	roomCatalogProjector := newProjector(roomCatalog, "Room Catalog", roomCatalog.adminProjectionEstimate)
 
 	roomGroups := NewRoomGroupProjection()
-	roomGroupsProjector := newProjector(roomGroups, "RoomGroupsProjector")
+	roomGroupsProjector := newProjector(roomGroups, "Room Groups", roomGroups.adminProjectionEstimate)
 
 	roomLayout := NewRoomLayoutProjection()
-	roomLayoutProjector := newProjector(roomLayout, "RoomLayoutProjector")
+	roomLayoutProjector := newProjector(roomLayout, "Room Layout", roomLayout.adminProjectionEstimate)
 
 	// Per-room event-log + per-thread event-log projections (#597
 	// phase 2). Both consume the full evt.room.> firehose; resolvers
 	// do all filtering and rendering at query time. v1 shape — we
 	// iterate significantly on this once we observe read patterns.
 	roomTimeline := NewRoomTimelineProjection()
-	roomTimelineProjector := newProjector(roomTimeline, "RoomTimelineProjector")
+	roomTimelineProjector := newProjector(roomTimeline, "Room Timeline", roomTimeline.adminProjectionEstimate)
 
 	threads := NewThreadProjection()
-	threadsProjector := newProjector(threads, "ThreadsProjector")
+	threadsProjector := newProjector(threads, "Threads", threads.adminProjectionEstimate)
 
 	reactions := NewReactionProjection()
-	reactionsProjector := newProjector(reactions, "ReactionsProjector")
+	reactionsProjector := newProjector(reactions, "Reactions", reactions.adminProjectionEstimate)
 
 	users := NewUserProjection(encMgr.keyWrapper, encMgr.contentKeys)
-	usersProjector := newProjector(users, "UsersProjector")
+	usersProjector := newProjector(users, "Users", users.adminProjectionEstimate)
 
 	contentKeys := NewContentKeyProjection()
-	contentKeysProjector := newProjector(contentKeys, "ContentKeysProjector")
+	contentKeysProjector := newProjector(contentKeys, "Content Keys", contentKeys.adminProjectionEstimate)
 
 	rbac := NewRBACProjection()
-	rbacProjector := newProjector(rbac, "RBACProjector")
+	rbacProjector := newProjector(rbac, "RBAC", rbac.adminProjectionEstimate)
 
 	configService := NewConfigService(eventPublisher, serverConfigProjector, serverConfigProjection)
 	configMgr := NewConfigManager(configService, serverConfigProjection)
@@ -752,7 +752,7 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 		ContentKeysProjector:    contentKeysProjector,
 		RBAC:                    rbac,
 		RBACProjector:           rbacProjector,
-		projectors:              projectors,
+		projections:             projections,
 		bootDone:                make(chan struct{}),
 	}
 
@@ -1582,20 +1582,18 @@ func isDeliverableLiveEVTRoomEvent(event *corev1.Event) bool {
 }
 
 func (c *ChattoCore) waitForLiveEVTRoomEvent(ctx context.Context, event *corev1.Event, seq uint64) error {
-	if err := c.RoomTimelineProjector.WaitForSeq(ctx, seq); err != nil {
-		return fmt.Errorf("room timeline: %w", err)
-	}
-	if err := c.ThreadsProjector.WaitForSeq(ctx, seq); err != nil {
-		return fmt.Errorf("threads: %w", err)
-	}
-	if err := c.ReactionsProjector.WaitForSeq(ctx, seq); err != nil {
-		return fmt.Errorf("reactions: %w", err)
+	if err := waitForSeqAll(ctx, seq,
+		waitForProjection("room timeline", c.RoomTimelineProjector),
+		waitForProjection("threads", c.ThreadsProjector),
+		waitForProjection("reactions", c.ReactionsProjector),
+	); err != nil {
+		return err
 	}
 
 	switch event.GetEvent().(type) {
 	case *corev1.Event_UserJoinedRoom, *corev1.Event_UserLeftRoom, *corev1.Event_RoomDeleted:
-		if err := c.RoomMembershipProjector.WaitForSeq(ctx, seq); err != nil {
-			return fmt.Errorf("room membership: %w", err)
+		if err := waitForSeqAll(ctx, seq, waitForProjection("room membership", c.RoomMembershipProjector)); err != nil {
+			return err
 		}
 	}
 	switch event.GetEvent().(type) {
@@ -1604,8 +1602,8 @@ func (c *ChattoCore) waitForLiveEVTRoomEvent(ctx context.Context, event *corev1.
 		*corev1.Event_RoomArchived,
 		*corev1.Event_RoomUnarchived,
 		*corev1.Event_RoomDeleted:
-		if err := c.RoomCatalogProjector.WaitForSeq(ctx, seq); err != nil {
-			return fmt.Errorf("room catalog: %w", err)
+		if err := waitForSeqAll(ctx, seq, waitForProjection("room catalog", c.RoomCatalogProjector)); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/cli/internal/core/projection_admin.go
+++ b/cli/internal/core/projection_admin.go
@@ -45,7 +45,7 @@ func (c *ChattoCore) ProjectionAdminStates(ctx context.Context) ([]ProjectionAdm
 	}
 	streamLastSeq := info.State.LastSeq
 
-	states := make([]ProjectionAdminState, 0, 10)
+	states := make([]ProjectionAdminState, 0, len(c.projections))
 	add := func(name string, projector *events.Projector, entries int64, estimatedBytes int64, metrics []ProjectionAdminMetric) error {
 		targetSeq, err := projector.CurrentTargetSeq(ctx)
 		if err != nil {
@@ -76,49 +76,9 @@ func (c *ChattoCore) ProjectionAdminStates(ctx context.Context) ([]ProjectionAdm
 		return nil
 	}
 
-	for _, collect := range []func() error{
-		func() error {
-			entries, bytes, metrics := c.RoomCatalog.adminProjectionEstimate()
-			return add("Room Catalog", c.RoomCatalogProjector, entries, bytes, metrics)
-		},
-		func() error {
-			entries, bytes, metrics := c.RoomMembership.adminProjectionEstimate()
-			return add("Room Membership", c.RoomMembershipProjector, entries, bytes, metrics)
-		},
-		func() error {
-			entries, bytes, metrics := c.ServerConfig.adminProjectionEstimate()
-			return add("Server Config", c.ServerConfigProjector, entries, bytes, metrics)
-		},
-		func() error {
-			entries, bytes, metrics := c.RoomGroups.adminProjectionEstimate()
-			return add("Room Groups", c.RoomGroupsProjector, entries, bytes, metrics)
-		},
-		func() error {
-			entries, bytes, metrics := c.RoomLayout.adminProjectionEstimate()
-			return add("Room Layout", c.RoomLayoutProjector, entries, bytes, metrics)
-		},
-		func() error {
-			entries, bytes, metrics := c.RoomTimeline.adminProjectionEstimate()
-			return add("Room Timeline", c.RoomTimelineProjector, entries, bytes, metrics)
-		},
-		func() error {
-			entries, bytes, metrics := c.Threads.adminProjectionEstimate()
-			return add("Threads", c.ThreadsProjector, entries, bytes, metrics)
-		},
-		func() error {
-			entries, bytes, metrics := c.Reactions.adminProjectionEstimate()
-			return add("Reactions", c.ReactionsProjector, entries, bytes, metrics)
-		},
-		func() error {
-			entries, bytes, metrics := c.Users.adminProjectionEstimate()
-			return add("Users", c.UsersProjector, entries, bytes, metrics)
-		},
-		func() error {
-			entries, bytes, metrics := c.RBAC.adminProjectionEstimate()
-			return add("RBAC", c.RBACProjector, entries, bytes, metrics)
-		},
-	} {
-		if err := collect(); err != nil {
+	for _, projection := range c.projections {
+		entries, bytes, metrics := projection.estimate()
+		if err := add(projection.name, projection.projector, entries, bytes, metrics); err != nil {
 			return nil, err
 		}
 	}
@@ -445,6 +405,44 @@ func (p *UserProjection) adminProjectionEstimate() (int64, int64, []ProjectionAd
 		{Name: "login_index", Value: int64(len(p.loginIndex)), Bytes: loginBytes},
 		{Name: "email_index", Value: int64(len(p.emailIndex)), Bytes: emailBytes},
 		{Name: "oidc_index", Value: int64(len(p.oidcIndex)), Bytes: oidcBytes},
+		{Name: "seen_event_ids", Value: int64(len(p.eventIDSeen)), Bytes: seenBytes},
+	}
+}
+
+func (p *ContentKeyProjection) adminProjectionEstimate() (int64, int64, []ProjectionAdminMetric) {
+	p.RLock()
+	defer p.RUnlock()
+	var users, purposes, epochs, active, bytes int64
+	for userID, byPurpose := range p.byUserPurposeEpoch {
+		users++
+		bytes += projectionMapEntryOverhead + int64(len(userID))
+		for _, byEpoch := range byPurpose {
+			purposes++
+			bytes += projectionMapEntryOverhead
+			for _, event := range byEpoch {
+				epochs++
+				bytes += projectionMapEntryOverhead
+				if event != nil {
+					bytes += int64(proto.Size(event))
+				}
+			}
+		}
+	}
+	var activeBytes int64
+	for userID, byPurpose := range p.activeEpoch {
+		activeBytes += projectionMapEntryOverhead + int64(len(userID))
+		for range byPurpose {
+			active++
+			activeBytes += projectionMapEntryOverhead + 8
+		}
+	}
+	seenBytes := int64(len(p.eventIDSeen)) * projectionMapEntryOverhead
+	bytes += activeBytes + seenBytes
+	return epochs, bytes, []ProjectionAdminMetric{
+		{Name: "users", Value: users, Bytes: 0},
+		{Name: "purposes", Value: purposes, Bytes: 0},
+		{Name: "dek_epochs", Value: epochs, Bytes: bytes - activeBytes - seenBytes},
+		{Name: "active_epochs", Value: active, Bytes: activeBytes},
 		{Name: "seen_event_ids", Value: int64(len(p.eventIDSeen)), Bytes: seenBytes},
 	}
 }

--- a/cli/internal/core/projection_registry.go
+++ b/cli/internal/core/projection_registry.go
@@ -1,0 +1,32 @@
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"hmans.de/chatto/internal/events"
+)
+
+type projectionRegistration struct {
+	name      string
+	projector *events.Projector
+	estimate  func() (entries int64, estimatedBytes int64, metrics []ProjectionAdminMetric)
+}
+
+type projectionWaitTarget struct {
+	name      string
+	projector *events.Projector
+}
+
+func waitForProjection(name string, projector *events.Projector) projectionWaitTarget {
+	return projectionWaitTarget{name: name, projector: projector}
+}
+
+func waitForSeqAll(ctx context.Context, seq uint64, targets ...projectionWaitTarget) error {
+	for _, target := range targets {
+		if err := target.projector.WaitForSeq(ctx, seq); err != nil {
+			return fmt.Errorf("wait for %s projection: %w", target.name, err)
+		}
+	}
+	return nil
+}

--- a/cli/internal/core/projection_registry_test.go
+++ b/cli/internal/core/projection_registry_test.go
@@ -1,0 +1,49 @@
+package core
+
+import "testing"
+
+func TestProjectionRegistryDrivesAdminStates(t *testing.T) {
+	core, _ := setupTestCore(t)
+
+	if len(core.projections) != 11 {
+		t.Fatalf("registered projections = %d, want 11", len(core.projections))
+	}
+
+	registryNames := make(map[string]struct{}, len(core.projections))
+	for _, projection := range core.projections {
+		if projection.name == "" {
+			t.Fatal("registered projection has empty name")
+		}
+		if projection.projector == nil {
+			t.Fatalf("projection %q has nil projector", projection.name)
+		}
+		if projection.estimate == nil {
+			t.Fatalf("projection %q has nil estimate", projection.name)
+		}
+		if _, exists := registryNames[projection.name]; exists {
+			t.Fatalf("duplicate projection registration name %q", projection.name)
+		}
+		registryNames[projection.name] = struct{}{}
+	}
+
+	if _, ok := registryNames["Content Keys"]; !ok {
+		t.Fatal("Content Keys projection is not registered")
+	}
+
+	states, err := core.ProjectionAdminStates(testContext(t))
+	if err != nil {
+		t.Fatalf("ProjectionAdminStates: %v", err)
+	}
+	if len(states) != len(core.projections) {
+		t.Fatalf("admin states = %d, registered projections = %d", len(states), len(core.projections))
+	}
+	for _, state := range states {
+		if _, ok := registryNames[state.Name]; !ok {
+			t.Fatalf("admin state %q not found in projection registry", state.Name)
+		}
+		delete(registryNames, state.Name)
+	}
+	if len(registryNames) != 0 {
+		t.Fatalf("registered projections missing admin states: %v", registryNames)
+	}
+}

--- a/cli/internal/core/room_membership.go
+++ b/cli/internal/core/room_membership.go
@@ -92,11 +92,11 @@ func (c *ChattoCore) JoinRoom(ctx context.Context, actorID string, kind RoomKind
 
 		seq, err = c.EventPublisher.AppendAt(ctx, joinSubject, event, expectedSeq)
 		if err == nil {
-			if err := c.RoomMembershipProjector.WaitForSeq(ctx, seq); err != nil {
-				return nil, fmt.Errorf("wait for membership projection: %w", err)
-			}
-			if err := c.RoomTimelineProjector.WaitForSeq(ctx, seq); err != nil {
-				return nil, fmt.Errorf("wait for room timeline projection: %w", err)
+			if err := waitForSeqAll(ctx, seq,
+				waitForProjection("membership", c.RoomMembershipProjector),
+				waitForProjection("room timeline", c.RoomTimelineProjector),
+			); err != nil {
+				return nil, err
 			}
 			break
 		}
@@ -166,8 +166,8 @@ func (c *ChattoCore) LeaveRoom(ctx context.Context, actorID string, kind RoomKin
 	if err != nil {
 		return fmt.Errorf("publish UserLeftRoomEvent: %w", err)
 	}
-	if err := c.RoomTimelineProjector.WaitForSeq(ctx, seq); err != nil {
-		return fmt.Errorf("wait for room timeline projection: %w", err)
+	if err := waitForSeqAll(ctx, seq, waitForProjection("room timeline", c.RoomTimelineProjector)); err != nil {
+		return err
 	}
 
 	c.logger.Info("Deleted room membership", "user_id", user_id, "kind", kind, "room_id", room_id)

--- a/cli/internal/core/rooms.go
+++ b/cli/internal/core/rooms.go
@@ -199,11 +199,11 @@ func (c *ChattoCore) CreateRoom(ctx context.Context, actorID string, kind RoomKi
 		c.notifyRoomLayoutChanged(ctx, actorID, "create_room")
 	}
 
-	if err := c.RoomCatalogProjector.WaitForSeq(ctx, createdSeq); err != nil {
-		return nil, fmt.Errorf("wait for catalog projection: %w", err)
-	}
-	if err := c.RoomTimelineProjector.WaitForSeq(ctx, createdSeq); err != nil {
-		return nil, fmt.Errorf("wait for room timeline projection: %w", err)
+	if err := waitForSeqAll(ctx, createdSeq,
+		waitForProjection("catalog", c.RoomCatalogProjector),
+		waitForProjection("room timeline", c.RoomTimelineProjector),
+	); err != nil {
+		return nil, err
 	}
 	return room, nil
 }
@@ -329,11 +329,11 @@ func (c *ChattoCore) UpdateRoom(ctx context.Context, actorID string, kind RoomKi
 
 	c.logger.Info("Room updated", "kind", kind, "room_id", room_id, "name", name)
 
-	if err := c.RoomCatalogProjector.WaitForSeq(ctx, updatedSeq); err != nil {
-		return nil, fmt.Errorf("wait for catalog projection: %w", err)
-	}
-	if err := c.RoomTimelineProjector.WaitForSeq(ctx, updatedSeq); err != nil {
-		return nil, fmt.Errorf("wait for room timeline projection: %w", err)
+	if err := waitForSeqAll(ctx, updatedSeq,
+		waitForProjection("catalog", c.RoomCatalogProjector),
+		waitForProjection("room timeline", c.RoomTimelineProjector),
+	); err != nil {
+		return nil, err
 	}
 	return room, nil
 }
@@ -396,18 +396,16 @@ func (c *ChattoCore) DeleteRoom(ctx context.Context, actorID string, kind RoomKi
 
 	// Read-your-writes: every projection that needs to drop state
 	// must have applied its event before we return.
-	if err := c.RoomMembershipProjector.WaitForSeq(ctx, seq); err != nil {
-		return fmt.Errorf("wait for membership projection: %w", err)
-	}
-	if err := c.RoomCatalogProjector.WaitForSeq(ctx, seq); err != nil {
-		return fmt.Errorf("wait for catalog projection: %w", err)
-	}
-	if err := c.RoomTimelineProjector.WaitForSeq(ctx, seq); err != nil {
-		return fmt.Errorf("wait for room timeline projection: %w", err)
+	if err := waitForSeqAll(ctx, seq,
+		waitForProjection("membership", c.RoomMembershipProjector),
+		waitForProjection("catalog", c.RoomCatalogProjector),
+		waitForProjection("room timeline", c.RoomTimelineProjector),
+	); err != nil {
+		return err
 	}
 	if groupRemovedSeq > 0 {
-		if err := c.RoomGroupsProjector.WaitForSeq(ctx, groupRemovedSeq); err != nil {
-			return fmt.Errorf("wait for groups projection: %w", err)
+		if err := waitForSeqAll(ctx, groupRemovedSeq, waitForProjection("groups", c.RoomGroupsProjector)); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -436,8 +434,8 @@ func (c *ChattoCore) ArchiveRoom(ctx context.Context, actorID string, kind RoomK
 	if err != nil {
 		return nil, fmt.Errorf("publish RoomArchivedEvent: %w", err)
 	}
-	if err := c.RoomTimelineProjector.WaitForSeq(ctx, seq); err != nil {
-		return nil, fmt.Errorf("wait for room timeline projection: %w", err)
+	if err := waitForSeqAll(ctx, seq, waitForProjection("room timeline", c.RoomTimelineProjector)); err != nil {
+		return nil, err
 	}
 
 	if err := c.PublishRoomGroupsUpdated(ctx, actorID, kind); err != nil {
@@ -471,8 +469,8 @@ func (c *ChattoCore) UnarchiveRoom(ctx context.Context, actorID string, kind Roo
 	if err != nil {
 		return nil, fmt.Errorf("publish RoomUnarchivedEvent: %w", err)
 	}
-	if err := c.RoomTimelineProjector.WaitForSeq(ctx, seq); err != nil {
-		return nil, fmt.Errorf("wait for room timeline projection: %w", err)
+	if err := waitForSeqAll(ctx, seq, waitForProjection("room timeline", c.RoomTimelineProjector)); err != nil {
+		return nil, err
 	}
 
 	if err := c.PublishRoomGroupsUpdated(ctx, actorID, kind); err != nil {

--- a/cli/internal/graph/admin_projections_test.go
+++ b/cli/internal/graph/admin_projections_test.go
@@ -32,6 +32,7 @@ func TestAdminProjections_State(t *testing.T) {
 	require.True(t, byName["Room Timeline"])
 	require.True(t, byName["Threads"])
 	require.True(t, byName["Reactions"])
+	require.True(t, byName["Content Keys"])
 }
 
 func TestAdminProjections_AuthorizationDenied(t *testing.T) {


### PR DESCRIPTION
- Drive projection lifecycle and admin diagnostics from a single registry.
- Add Content Keys to projection admin diagnostics and cover registry/admin state sync in tests.
- Add a shared same-sequence projection wait helper for room lifecycle and live readiness paths.

Tests:
- `mise exec -- go test -tags test_endpoints ./internal/core ./internal/graph -run 'TestProjectionRegistry|TestAdminProjections|TestContentKeyProjection|TestRoomMembership|TestRoomCatalog|TestProjector'`
