### PR TITLE
refactor: narrow projection subject filters

### DIFF
--- a/cli/internal/core/config_projection.go
+++ b/cli/internal/core/config_projection.go
@@ -51,7 +51,28 @@ func NewServerConfigProjection() *ConfigProjection {
 }
 
 func (p *ConfigProjection) Subjects() []string {
-	return []string{events.ConfigSubjectFilter(), events.UserSubjectFilter()}
+	return []string{
+		events.ConfigEventTypeFilter(events.EventServerConfigChanged),
+		events.ConfigEventTypeFilter(events.EventServerNameChanged),
+		events.ConfigEventTypeFilter(events.EventServerDescriptionChanged),
+		events.ConfigEventTypeFilter(events.EventServerWelcomeMessageChanged),
+		events.ConfigEventTypeFilter(events.EventServerMotdChanged),
+		events.ConfigEventTypeFilter(events.EventServerBlockedUsernamesChanged),
+		events.ConfigEventTypeFilter(events.EventServerLogoSet),
+		events.ConfigEventTypeFilter(events.EventServerLogoCleared),
+		events.ConfigEventTypeFilter(events.EventServerBannerSet),
+		events.ConfigEventTypeFilter(events.EventServerBannerCleared),
+		events.ConfigEventTypeFilter(events.EventUserTimezoneChanged),
+		events.ConfigEventTypeFilter(events.EventUserTimezoneCleared),
+		events.ConfigEventTypeFilter(events.EventUserTimeFormatChanged),
+		events.ConfigEventTypeFilter(events.EventUserTimeFormatCleared),
+		events.ConfigEventTypeFilter(events.EventUserServerNotificationLevelSet),
+		events.ConfigEventTypeFilter(events.EventUserServerNotificationLevelCleared),
+		events.ConfigEventTypeFilter(events.EventUserRoomNotificationLevelSet),
+		events.ConfigEventTypeFilter(events.EventUserRoomNotificationLevelCleared),
+		events.UserEventTypeFilter(events.EventUserServerPreferencesChanged),
+		events.UserEventTypeFilter(events.EventUserAccountDeleted),
+	}
 }
 
 func (p *ConfigProjection) Apply(event *corev1.Event, _ uint64) error {

--- a/cli/internal/core/content_key_projection.go
+++ b/cli/internal/core/content_key_projection.go
@@ -25,7 +25,10 @@ func NewContentKeyProjection() *ContentKeyProjection {
 }
 
 func (p *ContentKeyProjection) Subjects() []string {
-	return []string{events.UserSubjectFilter()}
+	return []string{
+		events.UserEventTypeFilter(events.EventUserDEKGenerated),
+		events.UserEventTypeFilter(events.EventUserKeyShredded),
+	}
 }
 
 func (p *ContentKeyProjection) Apply(event *corev1.Event, _ uint64) error {

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -389,12 +389,8 @@ func (c *ChattoCore) DeleteUserEncryptionKeyAs(ctx context.Context, actorID, use
 		return nil // Encryption not configured
 	}
 
-	filterSeq, err := c.EventPublisher.LastSubjectSeq(ctx, events.UserAggregate(userID).AllEventsFilter())
-	if err != nil {
-		return fmt.Errorf("read content key projection target seq: %w", err)
-	}
-	if err := c.ContentKeysProjector.WaitForSeq(ctx, filterSeq); err != nil {
-		return fmt.Errorf("wait for content key projection: %w", err)
+	if err := c.waitForUserContentKeysCurrent(ctx, userID); err != nil {
+		return err
 	}
 
 	contentKeyRefs := c.ContentKeys.ContentKeyRefs(userID)
@@ -1585,11 +1581,16 @@ func (c *ChattoCore) waitForLiveEVTRoomEvent(ctx context.Context, event *corev1.
 	if err := waitForSeqAll(ctx, seq,
 		waitForProjection("room timeline", c.RoomTimelineProjector),
 		waitForProjection("threads", c.ThreadsProjector),
-		waitForProjection("reactions", c.ReactionsProjector),
 	); err != nil {
 		return err
 	}
 
+	switch event.GetEvent().(type) {
+	case *corev1.Event_ReactionAdded, *corev1.Event_ReactionRemoved:
+		if err := waitForSeqAll(ctx, seq, waitForProjection("reactions", c.ReactionsProjector)); err != nil {
+			return err
+		}
+	}
 	switch event.GetEvent().(type) {
 	case *corev1.Event_UserJoinedRoom, *corev1.Event_UserLeftRoom, *corev1.Event_RoomDeleted:
 		if err := waitForSeqAll(ctx, seq, waitForProjection("room membership", c.RoomMembershipProjector)); err != nil {

--- a/cli/internal/core/message_crypto.go
+++ b/cli/internal/core/message_crypto.go
@@ -128,8 +128,8 @@ func (c *ChattoCore) generateInitialUserDEK(ctx context.Context, userID string, 
 		if err != nil {
 			return nil, fmt.Errorf("read DEK OCC filter seq: %w", err)
 		}
-		if err := c.ContentKeysProjector.WaitForSeq(ctx, filterSeq); err != nil {
-			return nil, fmt.Errorf("wait for DEK projection: %w", err)
+		if err := c.waitForUserContentKeysCurrent(ctx, userID); err != nil {
+			return nil, err
 		}
 		if event, ok := c.ContentKeys.Active(userID, purpose); ok {
 			return c.unwrapUserDEK(ctx, event, purpose)

--- a/cli/internal/core/projection_registry.go
+++ b/cli/internal/core/projection_registry.go
@@ -30,3 +30,39 @@ func waitForSeqAll(ctx context.Context, seq uint64, targets ...projectionWaitTar
 	}
 	return nil
 }
+
+func (c *ChattoCore) waitForProjectionSubjectsCurrent(ctx context.Context, name string, projector *events.Projector, subjects ...string) error {
+	var target uint64
+	for _, subject := range subjects {
+		seq, err := c.EventPublisher.LastSubjectSeq(ctx, subject)
+		if err != nil {
+			return fmt.Errorf("read %s projection target seq: %w", name, err)
+		}
+		if seq > target {
+			target = seq
+		}
+	}
+	if target == 0 {
+		return nil
+	}
+	if err := projector.WaitForSeq(ctx, target); err != nil {
+		return fmt.Errorf("wait for %s projection: %w", name, err)
+	}
+	return nil
+}
+
+func (c *ChattoCore) waitForUserContentKeysCurrent(ctx context.Context, userID string) error {
+	agg := events.UserAggregate(userID)
+	return c.waitForProjectionSubjectsCurrent(ctx, "content key", c.ContentKeysProjector,
+		agg.Subject(events.EventUserDEKGenerated),
+		agg.Subject(events.EventUserKeyShredded),
+	)
+}
+
+func (c *ChattoCore) waitForRoomReactionsCurrent(ctx context.Context, roomID string) error {
+	agg := events.RoomAggregate(roomID)
+	return c.waitForProjectionSubjectsCurrent(ctx, "reactions", c.ReactionsProjector,
+		agg.Subject(events.EventReactionAdded),
+		agg.Subject(events.EventReactionRemoved),
+	)
+}

--- a/cli/internal/core/projection_subjects_test.go
+++ b/cli/internal/core/projection_subjects_test.go
@@ -1,0 +1,74 @@
+package core
+
+import (
+	"slices"
+	"testing"
+
+	"hmans.de/chatto/internal/events"
+)
+
+func TestNarrowProjectionSubjectFilters(t *testing.T) {
+	cases := []struct {
+		name string
+		got  []string
+		want []string
+	}{
+		{
+			name: "reactions",
+			got:  NewReactionProjection().Subjects(),
+			want: []string{
+				events.RoomEventTypeFilter(events.EventReactionAdded),
+				events.RoomEventTypeFilter(events.EventReactionRemoved),
+			},
+		},
+		{
+			name: "content keys",
+			got:  NewContentKeyProjection().Subjects(),
+			want: []string{
+				events.UserEventTypeFilter(events.EventUserDEKGenerated),
+				events.UserEventTypeFilter(events.EventUserKeyShredded),
+			},
+		},
+		{
+			name: "config user cleanup",
+			got:  NewConfigProjection().Subjects(),
+			want: []string{
+				events.UserEventTypeFilter(events.EventUserServerPreferencesChanged),
+				events.UserEventTypeFilter(events.EventUserAccountDeleted),
+			},
+		},
+		{
+			name: "config server settings",
+			got:  NewConfigProjection().Subjects(),
+			want: []string{
+				events.ConfigEventTypeFilter(events.EventServerNameChanged),
+				events.ConfigEventTypeFilter(events.EventServerDescriptionChanged),
+				events.ConfigEventTypeFilter(events.EventUserRoomNotificationLevelSet),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, want := range tc.want {
+				if !slices.Contains(tc.got, want) {
+					t.Fatalf("Subjects() = %v, missing %q", tc.got, want)
+				}
+			}
+		})
+	}
+
+	for name, subjects := range map[string][]string{
+		"reactions":    NewReactionProjection().Subjects(),
+		"content keys": NewContentKeyProjection().Subjects(),
+		"config":       NewConfigProjection().Subjects(),
+	} {
+		t.Run(name+" no firehose", func(t *testing.T) {
+			for _, broad := range []string{events.RoomSubjectFilter(), events.UserSubjectFilter(), events.ConfigSubjectFilter()} {
+				if slices.Contains(subjects, broad) {
+					t.Fatalf("Subjects() = %v, should not include broad filter %q", subjects, broad)
+				}
+			}
+		})
+	}
+}

--- a/cli/internal/core/reaction_projection.go
+++ b/cli/internal/core/reaction_projection.go
@@ -27,7 +27,10 @@ func NewReactionProjection() *ReactionProjection {
 }
 
 func (p *ReactionProjection) Subjects() []string {
-	return []string{events.RoomSubjectFilter()}
+	return []string{
+		events.RoomEventTypeFilter(events.EventReactionAdded),
+		events.RoomEventTypeFilter(events.EventReactionRemoved),
+	}
 }
 
 func (p *ReactionProjection) Apply(event *corev1.Event, _ uint64) error {

--- a/cli/internal/core/reactions.go
+++ b/cli/internal/core/reactions.go
@@ -180,8 +180,8 @@ func (c *ChattoCore) publishReactionMutation(ctx context.Context, kind RoomKind,
 		if err != nil {
 			return false, fmt.Errorf("read OCC filter seq: %w", err)
 		}
-		if err := c.ReactionsProjector.WaitForSeq(ctx, filterSeq); err != nil {
-			return false, fmt.Errorf("wait for reactions projection: %w", err)
+		if err := c.waitForRoomReactionsCurrent(ctx, roomID); err != nil {
+			return false, err
 		}
 
 		exists := c.Reactions.HasReaction(messageEventID, emoji, userID)

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -170,7 +170,7 @@ func (c *ChattoCore) CreateUser(ctx context.Context, actorID string, login, disp
 		})
 	}
 
-	seq, err := c.appendUserBatch(ctx, userID, entries, events.UserSubjectFilter(), func() error {
+	_, err = c.appendUserBatch(ctx, userID, entries, events.UserSubjectFilter(), func() error {
 		if c.Users.LoginExists(login) {
 			return ErrLoginAlreadyTaken
 		}
@@ -180,8 +180,8 @@ func (c *ChattoCore) CreateUser(ctx context.Context, actorID string, login, disp
 		return nil, err
 	}
 	cleanupEncryptionKey = false
-	if err := c.ContentKeysProjector.WaitForSeq(ctx, seq); err != nil {
-		return nil, fmt.Errorf("wait for content key projection: %w", err)
+	if err := c.waitForUserContentKeysCurrent(ctx, userID); err != nil {
+		return nil, err
 	}
 
 	// Create and publish audit event (best-effort)

--- a/cli/internal/events/events_test.go
+++ b/cli/internal/events/events_test.go
@@ -630,6 +630,30 @@ func TestSubjectHelpers(t *testing.T) {
 		}
 	})
 
+	t.Run("AggregateEventTypeFilter", func(t *testing.T) {
+		got := AggregateEventTypeFilter(AggregateUser, EventUserDEKGenerated)
+		want := "evt.user.*.dek_generated"
+		if got != want {
+			t.Errorf("AggregateEventTypeFilter: got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("ConfigEventTypeFilter", func(t *testing.T) {
+		got := ConfigEventTypeFilter(EventServerNameChanged)
+		want := "evt.config.*.server_name_changed"
+		if got != want {
+			t.Errorf("ConfigEventTypeFilter: got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("UserEventTypeFilter", func(t *testing.T) {
+		got := UserEventTypeFilter(EventUserKeyShredded)
+		want := "evt.user.*.user_key_shredded"
+		if got != want {
+			t.Errorf("UserEventTypeFilter: got %q, want %q", got, want)
+		}
+	})
+
 	t.Run("ParseRoomSubject", func(t *testing.T) {
 		cases := []struct {
 			subject string

--- a/cli/internal/events/subjects.go
+++ b/cli/internal/events/subjects.go
@@ -481,19 +481,44 @@ func RBACSubjectFilter() string { return SubjectRoot + AggregateRBAC + ".>" }
 // Pattern: evt.auth.>
 func AuthSubjectFilter() string { return SubjectRoot + AggregateAuth + ".>" }
 
+// AggregateEventTypeFilter returns a cross-aggregate, event-type-narrow
+// filter — every event of the given type across every aggregate instance.
+// Used by projections that only care about a subset of event types and don't
+// want to receive the full evt.{aggregate}.> firehose.
+// Pattern: evt.{aggregateType}.*.{eventType}
+func AggregateEventTypeFilter(aggregateType, eventType string) string {
+	return SubjectRoot + aggregateType + ".*." + eventType
+}
+
 // RoomEventTypeFilter returns a cross-aggregate, event-type-narrow
-// filter — every event of the given type across every room. Used by
-// projections that only care about a subset of event types and don't
-// want to receive the full evt.room.> firehose.
+// filter for room aggregates.
 // Pattern: evt.room.*.{eventType}
 func RoomEventTypeFilter(eventType string) string {
-	return SubjectRoot + AggregateRoom + ".*." + eventType
+	return AggregateEventTypeFilter(AggregateRoom, eventType)
 }
 
 // GroupEventTypeFilter is the group analogue of RoomEventTypeFilter.
 // Pattern: evt.group.*.{eventType}
 func GroupEventTypeFilter(eventType string) string {
-	return SubjectRoot + AggregateGroup + ".*." + eventType
+	return AggregateEventTypeFilter(AggregateGroup, eventType)
+}
+
+// ConfigEventTypeFilter is the config analogue of RoomEventTypeFilter.
+// Pattern: evt.config.*.{eventType}
+func ConfigEventTypeFilter(eventType string) string {
+	return AggregateEventTypeFilter(AggregateConfig, eventType)
+}
+
+// UserEventTypeFilter is the user analogue of RoomEventTypeFilter.
+// Pattern: evt.user.*.{eventType}
+func UserEventTypeFilter(eventType string) string {
+	return AggregateEventTypeFilter(AggregateUser, eventType)
+}
+
+// RBACEventTypeFilter is the RBAC analogue of RoomEventTypeFilter.
+// Pattern: evt.rbac.*.{eventType}
+func RBACEventTypeFilter(eventType string) string {
+	return AggregateEventTypeFilter(AggregateRBAC, eventType)
 }
 
 // ParseRoomSubject extracts the roomID from a room-aggregate event


### PR DESCRIPTION
- Narrows config, content-key, and reaction projection subscriptions to the event types they consume.
- Adds projection-specific wait helpers so narrowed projectors are only waited on for relevant subject tails.
- Updates live EVT readiness and adds subject filter tests to prevent broad firehose subscriptions from returning.

Tests: `mise exec -- go test -tags test_endpoints ./internal/events ./internal/core`
