### PR TITLE
refactor: consolidate projection consumers

### DIFF
--- a/cli/internal/core/config_projection.go
+++ b/cli/internal/core/config_projection.go
@@ -52,24 +52,7 @@ func NewServerConfigProjection() *ConfigProjection {
 
 func (p *ConfigProjection) Subjects() []string {
 	return []string{
-		events.ConfigEventTypeFilter(events.EventServerConfigChanged),
-		events.ConfigEventTypeFilter(events.EventServerNameChanged),
-		events.ConfigEventTypeFilter(events.EventServerDescriptionChanged),
-		events.ConfigEventTypeFilter(events.EventServerWelcomeMessageChanged),
-		events.ConfigEventTypeFilter(events.EventServerMotdChanged),
-		events.ConfigEventTypeFilter(events.EventServerBlockedUsernamesChanged),
-		events.ConfigEventTypeFilter(events.EventServerLogoSet),
-		events.ConfigEventTypeFilter(events.EventServerLogoCleared),
-		events.ConfigEventTypeFilter(events.EventServerBannerSet),
-		events.ConfigEventTypeFilter(events.EventServerBannerCleared),
-		events.ConfigEventTypeFilter(events.EventUserTimezoneChanged),
-		events.ConfigEventTypeFilter(events.EventUserTimezoneCleared),
-		events.ConfigEventTypeFilter(events.EventUserTimeFormatChanged),
-		events.ConfigEventTypeFilter(events.EventUserTimeFormatCleared),
-		events.ConfigEventTypeFilter(events.EventUserServerNotificationLevelSet),
-		events.ConfigEventTypeFilter(events.EventUserServerNotificationLevelCleared),
-		events.ConfigEventTypeFilter(events.EventUserRoomNotificationLevelSet),
-		events.ConfigEventTypeFilter(events.EventUserRoomNotificationLevelCleared),
+		events.ConfigSubjectFilter(),
 		events.UserEventTypeFilter(events.EventUserServerPreferencesChanged),
 		events.UserEventTypeFilter(events.EventUserAccountDeleted),
 	}

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -82,14 +82,19 @@ type ChattoCore struct {
 	// higher-level helpers as aggregates migrate.
 	EventPublisher *events.Publisher
 
-	// RoomMembership is the first event-sourced projection (ADR-033 POC).
-	// Populated by RoomMembershipProjector; not yet read by any
-	// user-facing resolver. Inspectable via an admin endpoint.
+	// RoomDirectory combines the room catalog and membership read models under
+	// one evt.room.> projector.
+	RoomDirectory *RoomDirectoryProjection
+
+	// RoomDirectoryProjector runs the consumer for RoomDirectory. The
+	// RoomCatalogProjector and RoomMembershipProjector fields alias this
+	// projector for existing read-your-writes call sites.
+	RoomDirectoryProjector *events.Projector
+
+	// RoomMembership is the membership index inside RoomDirectory.
 	RoomMembership *RoomMembershipProjection
 
-	// RoomMembershipProjector runs the consumer + apply loop that keeps
-	// RoomMembership current. Started by (*ChattoCore).Run; exposed here
-	// so writers can call WaitForSeq for read-your-writes.
+	// RoomMembershipProjector aliases RoomDirectoryProjector.
 	RoomMembershipProjector *events.Projector
 
 	// ServerConfig is the projection holding current dynamic configuration
@@ -103,29 +108,31 @@ type ChattoCore struct {
 	// so writers (ConfigManager mutations) can call WaitForSeq.
 	ServerConfigProjector *events.Projector
 
-	// RoomCatalog is the projection holding per-room metadata
-	// (id/name/description/kind/archived) derived from evt.room.>.
-	// Coexists with RoomMembership on the same subject family.
+	// RoomCatalog is the room metadata index inside RoomDirectory.
 	RoomCatalog *RoomCatalogProjection
 
-	// RoomCatalogProjector runs the consumer for RoomCatalog. Exposed
-	// for WaitForSeq from room-metadata writers.
+	// RoomCatalogProjector aliases RoomDirectoryProjector.
 	RoomCatalogProjector *events.Projector
 
-	// RoomGroups is the projection holding per-group metadata and
-	// ordered room membership, derived from evt.group.>.
+	// RoomGroupLayout combines room-group state and sidebar ordering under one
+	// projector over evt.group.> plus evt.layout.>.
+	RoomGroupLayout *RoomGroupLayoutProjection
+
+	// RoomGroupLayoutProjector runs the consumer for RoomGroupLayout. The
+	// RoomGroupsProjector and RoomLayoutProjector fields alias this projector
+	// for existing read-your-writes call sites.
+	RoomGroupLayoutProjector *events.Projector
+
+	// RoomGroups is the group state index inside RoomGroupLayout.
 	RoomGroups *RoomGroupProjection
 
-	// RoomGroupsProjector runs the consumer for RoomGroups. Exposed
-	// for WaitForSeq from group writers.
+	// RoomGroupsProjector aliases RoomGroupLayoutProjector.
 	RoomGroupsProjector *events.Projector
 
-	// RoomLayout holds the operator-defined inter-group ordering for
-	// the sidebar, derived from evt.layout.> events.
+	// RoomLayout is the sidebar ordering index inside RoomGroupLayout.
 	RoomLayout *RoomLayoutProjection
 
-	// RoomLayoutProjector runs the consumer for RoomLayout. Exposed
-	// for WaitForSeq from layout writers.
+	// RoomLayoutProjector aliases RoomGroupLayoutProjector.
 	RoomLayoutProjector *events.Projector
 
 	// RoomTimeline holds an append-only event log per room, derived
@@ -676,20 +683,23 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 		return pr
 	}
 
-	roomMembership := NewRoomMembershipProjection()
-	roomMembershipProjector := newProjector(roomMembership, "Room Membership", roomMembership.adminProjectionEstimate)
+	roomDirectory := NewRoomDirectoryProjection()
+	roomDirectoryProjector := newProjector(roomDirectory, "Room Directory", roomDirectory.adminProjectionEstimate)
+	roomMembership := roomDirectory.Membership
+	roomMembershipProjector := roomDirectoryProjector
 
 	serverConfigProjection := NewConfigProjection()
 	serverConfigProjector := newProjector(serverConfigProjection, "Server Config", serverConfigProjection.adminProjectionEstimate)
 
-	roomCatalog := NewRoomCatalogProjection()
-	roomCatalogProjector := newProjector(roomCatalog, "Room Catalog", roomCatalog.adminProjectionEstimate)
+	roomCatalog := roomDirectory.Catalog
+	roomCatalogProjector := roomDirectoryProjector
 
-	roomGroups := NewRoomGroupProjection()
-	roomGroupsProjector := newProjector(roomGroups, "Room Groups", roomGroups.adminProjectionEstimate)
-
-	roomLayout := NewRoomLayoutProjection()
-	roomLayoutProjector := newProjector(roomLayout, "Room Layout", roomLayout.adminProjectionEstimate)
+	roomGroupLayout := NewRoomGroupLayoutProjection()
+	roomGroupLayoutProjector := newProjector(roomGroupLayout, "Room Group Layout", roomGroupLayout.adminProjectionEstimate)
+	roomGroups := roomGroupLayout.Groups
+	roomGroupsProjector := roomGroupLayoutProjector
+	roomLayout := roomGroupLayout.Layout
+	roomLayoutProjector := roomGroupLayoutProjector
 
 	// Per-room event-log + per-thread event-log projections (#597
 	// phase 2). Both consume the full evt.room.> firehose; resolvers
@@ -717,39 +727,43 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	configMgr := NewConfigManager(configService, serverConfigProjection)
 
 	core := &ChattoCore{
-		nc:                      nc,
-		js:                      js,
-		logger:                  logger,
-		storage:                 storage,
-		config:                  cfg,
-		encryption:              encMgr,
-		configManager:           configMgr,
-		s3Client:                s3Client,
-		EventPublisher:          eventPublisher,
-		RoomMembership:          roomMembership,
-		RoomMembershipProjector: roomMembershipProjector,
-		ServerConfig:            serverConfigProjection,
-		ServerConfigProjector:   serverConfigProjector,
-		RoomCatalog:             roomCatalog,
-		RoomCatalogProjector:    roomCatalogProjector,
-		RoomGroups:              roomGroups,
-		RoomGroupsProjector:     roomGroupsProjector,
-		RoomLayout:              roomLayout,
-		RoomLayoutProjector:     roomLayoutProjector,
-		RoomTimeline:            roomTimeline,
-		RoomTimelineProjector:   roomTimelineProjector,
-		Threads:                 threads,
-		ThreadsProjector:        threadsProjector,
-		Reactions:               reactions,
-		ReactionsProjector:      reactionsProjector,
-		Users:                   users,
-		UsersProjector:          usersProjector,
-		ContentKeys:             contentKeys,
-		ContentKeysProjector:    contentKeysProjector,
-		RBAC:                    rbac,
-		RBACProjector:           rbacProjector,
-		projections:             projections,
-		bootDone:                make(chan struct{}),
+		nc:                       nc,
+		js:                       js,
+		logger:                   logger,
+		storage:                  storage,
+		config:                   cfg,
+		encryption:               encMgr,
+		configManager:            configMgr,
+		s3Client:                 s3Client,
+		EventPublisher:           eventPublisher,
+		RoomDirectory:            roomDirectory,
+		RoomDirectoryProjector:   roomDirectoryProjector,
+		RoomMembership:           roomMembership,
+		RoomMembershipProjector:  roomMembershipProjector,
+		ServerConfig:             serverConfigProjection,
+		ServerConfigProjector:    serverConfigProjector,
+		RoomCatalog:              roomCatalog,
+		RoomCatalogProjector:     roomCatalogProjector,
+		RoomGroupLayout:          roomGroupLayout,
+		RoomGroupLayoutProjector: roomGroupLayoutProjector,
+		RoomGroups:               roomGroups,
+		RoomGroupsProjector:      roomGroupsProjector,
+		RoomLayout:               roomLayout,
+		RoomLayoutProjector:      roomLayoutProjector,
+		RoomTimeline:             roomTimeline,
+		RoomTimelineProjector:    roomTimelineProjector,
+		Threads:                  threads,
+		ThreadsProjector:         threadsProjector,
+		Reactions:                reactions,
+		ReactionsProjector:       reactionsProjector,
+		Users:                    users,
+		UsersProjector:           usersProjector,
+		ContentKeys:              contentKeys,
+		ContentKeysProjector:     contentKeysProjector,
+		RBAC:                     rbac,
+		RBACProjector:            rbacProjector,
+		projections:              projections,
+		bootDone:                 make(chan struct{}),
 	}
 
 	if err := core.migrateLegacyCallStateToMemoryCache(ctx); err != nil {

--- a/cli/internal/core/dm.go
+++ b/cli/internal/core/dm.go
@@ -209,12 +209,11 @@ func (c *ChattoCore) createDMRoom(ctx context.Context, roomID string, participan
 		return nil, err
 	}
 
-	// Wait per-projector for the seq of the last event each
-	// actually consumes. Projectors subscribe to narrow event-type
-	// filters now — waiting on a seq that doesn't match the filter
-	// blocks forever (the LastSeq only advances on filter-matching
-	// events). seqs[0] is the RoomCreated (catalog); seqs[len-1] is
-	// the last UserJoinedRoom (membership).
+	// Wait per-projector for a sequence covered by that projector's
+	// subscription. Room-derived projections subscribe to evt.room.>,
+	// so both the RoomCreated and UserJoinedRoom sequences are visible.
+	// seqs[0] is the RoomCreated (catalog); seqs[len-1] is the last
+	// UserJoinedRoom (membership and timeline).
 	if err := c.RoomCatalogProjector.WaitForSeq(ctx, seqs[0]); err != nil {
 		c.logger.Warn("DM room catalog projection wait failed", "error", err, "room_id", roomID)
 	}

--- a/cli/internal/core/projection_admin.go
+++ b/cli/internal/core/projection_admin.go
@@ -128,6 +128,21 @@ func (p *RoomMembershipProjection) adminProjectionEstimate() (int64, int64, []Pr
 	}
 }
 
+func (p *RoomDirectoryProjection) adminProjectionEstimate() (int64, int64, []ProjectionAdminMetric) {
+	catalogEntries, catalogBytes, catalogMetrics := p.Catalog.adminProjectionEstimate()
+	membershipEntries, membershipBytes, membershipMetrics := p.Membership.adminProjectionEstimate()
+	metrics := make([]ProjectionAdminMetric, 0, len(catalogMetrics)+len(membershipMetrics))
+	for _, metric := range catalogMetrics {
+		metric.Name = "catalog_" + metric.Name
+		metrics = append(metrics, metric)
+	}
+	for _, metric := range membershipMetrics {
+		metric.Name = "membership_" + metric.Name
+		metrics = append(metrics, metric)
+	}
+	return catalogEntries + membershipEntries, catalogBytes + membershipBytes, metrics
+}
+
 func (p *ConfigProjection) adminProjectionEstimate() (int64, int64, []ProjectionAdminMetric) {
 	p.RLock()
 	defer p.RUnlock()
@@ -241,6 +256,21 @@ func (p *RoomLayoutProjection) adminProjectionEstimate() (int64, int64, []Projec
 	return int64(len(p.groupIDs)), bytes, []ProjectionAdminMetric{
 		{Name: "ordered_groups", Value: int64(len(p.groupIDs)), Bytes: bytes},
 	}
+}
+
+func (p *RoomGroupLayoutProjection) adminProjectionEstimate() (int64, int64, []ProjectionAdminMetric) {
+	groupEntries, groupBytes, groupMetrics := p.Groups.adminProjectionEstimate()
+	layoutEntries, layoutBytes, layoutMetrics := p.Layout.adminProjectionEstimate()
+	metrics := make([]ProjectionAdminMetric, 0, len(groupMetrics)+len(layoutMetrics))
+	for _, metric := range groupMetrics {
+		metric.Name = "groups_" + metric.Name
+		metrics = append(metrics, metric)
+	}
+	for _, metric := range layoutMetrics {
+		metric.Name = "layout_" + metric.Name
+		metrics = append(metrics, metric)
+	}
+	return groupEntries + layoutEntries, groupBytes + layoutBytes, metrics
 }
 
 func (p *RoomTimelineProjection) adminProjectionEstimate() (int64, int64, []ProjectionAdminMetric) {

--- a/cli/internal/core/projection_registry_test.go
+++ b/cli/internal/core/projection_registry_test.go
@@ -5,8 +5,8 @@ import "testing"
 func TestProjectionRegistryDrivesAdminStates(t *testing.T) {
 	core, _ := setupTestCore(t)
 
-	if len(core.projections) != 11 {
-		t.Fatalf("registered projections = %d, want 11", len(core.projections))
+	if len(core.projections) != 9 {
+		t.Fatalf("registered projections = %d, want 9", len(core.projections))
 	}
 
 	registryNames := make(map[string]struct{}, len(core.projections))
@@ -28,6 +28,12 @@ func TestProjectionRegistryDrivesAdminStates(t *testing.T) {
 
 	if _, ok := registryNames["Content Keys"]; !ok {
 		t.Fatal("Content Keys projection is not registered")
+	}
+	if _, ok := registryNames["Room Directory"]; !ok {
+		t.Fatal("Room Directory projection is not registered")
+	}
+	if _, ok := registryNames["Room Group Layout"]; !ok {
+		t.Fatal("Room Group Layout projection is not registered")
 	}
 
 	states, err := core.ProjectionAdminStates(testContext(t))

--- a/cli/internal/core/projection_subjects_test.go
+++ b/cli/internal/core/projection_subjects_test.go
@@ -7,14 +7,48 @@ import (
 	"hmans.de/chatto/internal/events"
 )
 
-func TestNarrowProjectionSubjectFilters(t *testing.T) {
+func TestProjectionSubjectPolicy(t *testing.T) {
 	cases := []struct {
 		name string
 		got  []string
 		want []string
 	}{
 		{
-			name: "reactions",
+			name: "room directory uses room aggregate namespace",
+			got:  NewRoomDirectoryProjection().Subjects(),
+			want: []string{events.RoomSubjectFilter()},
+		},
+		{
+			name: "room membership uses room aggregate namespace",
+			got:  NewRoomMembershipProjection().Subjects(),
+			want: []string{events.RoomSubjectFilter()},
+		},
+		{
+			name: "room catalog uses room aggregate namespace",
+			got:  NewRoomCatalogProjection().Subjects(),
+			want: []string{events.RoomSubjectFilter()},
+		},
+		{
+			name: "room group layout uses group namespace plus layout namespace",
+			got:  NewRoomGroupLayoutProjection().Subjects(),
+			want: []string{events.GroupSubjectFilter(), events.LayoutSubjectFilter()},
+		},
+		{
+			name: "room groups use group aggregate namespace",
+			got:  NewRoomGroupProjection().Subjects(),
+			want: []string{events.GroupSubjectFilter()},
+		},
+		{
+			name: "config uses config aggregate namespace plus user extras",
+			got:  NewConfigProjection().Subjects(),
+			want: []string{
+				events.ConfigSubjectFilter(),
+				events.UserEventTypeFilter(events.EventUserServerPreferencesChanged),
+				events.UserEventTypeFilter(events.EventUserAccountDeleted),
+			},
+		},
+		{
+			name: "reactions remain focused",
 			got:  NewReactionProjection().Subjects(),
 			want: []string{
 				events.RoomEventTypeFilter(events.EventReactionAdded),
@@ -22,48 +56,30 @@ func TestNarrowProjectionSubjectFilters(t *testing.T) {
 			},
 		},
 		{
-			name: "content keys",
+			name: "content keys remain focused",
 			got:  NewContentKeyProjection().Subjects(),
 			want: []string{
 				events.UserEventTypeFilter(events.EventUserDEKGenerated),
 				events.UserEventTypeFilter(events.EventUserKeyShredded),
 			},
 		},
-		{
-			name: "config user cleanup",
-			got:  NewConfigProjection().Subjects(),
-			want: []string{
-				events.UserEventTypeFilter(events.EventUserServerPreferencesChanged),
-				events.UserEventTypeFilter(events.EventUserAccountDeleted),
-			},
-		},
-		{
-			name: "config server settings",
-			got:  NewConfigProjection().Subjects(),
-			want: []string{
-				events.ConfigEventTypeFilter(events.EventServerNameChanged),
-				events.ConfigEventTypeFilter(events.EventServerDescriptionChanged),
-				events.ConfigEventTypeFilter(events.EventUserRoomNotificationLevelSet),
-			},
-		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			for _, want := range tc.want {
-				if !slices.Contains(tc.got, want) {
-					t.Fatalf("Subjects() = %v, missing %q", tc.got, want)
-				}
+			if !slices.Equal(tc.got, tc.want) {
+				t.Fatalf("Subjects() = %v, want %v", tc.got, tc.want)
 			}
 		})
 	}
+}
 
+func TestFocusedProjectionsDoNotUseAggregateNamespaceFilters(t *testing.T) {
 	for name, subjects := range map[string][]string{
 		"reactions":    NewReactionProjection().Subjects(),
 		"content keys": NewContentKeyProjection().Subjects(),
-		"config":       NewConfigProjection().Subjects(),
 	} {
-		t.Run(name+" no firehose", func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			for _, broad := range []string{events.RoomSubjectFilter(), events.UserSubjectFilter(), events.ConfigSubjectFilter()} {
 				if slices.Contains(subjects, broad) {
 					t.Fatalf("Subjects() = %v, should not include broad filter %q", subjects, broad)

--- a/cli/internal/core/room_catalog_projection.go
+++ b/cli/internal/core/room_catalog_projection.go
@@ -41,17 +41,11 @@ func NewRoomCatalogProjection() *RoomCatalogProjection {
 	}
 }
 
-// Subjects implements events.Projection. Narrow filters — only the
-// event types this projection actually handles. Membership events on
-// evt.room.> never reach this consumer.
+// Subjects implements events.Projection. The catalog is a room-derived read
+// model, so it subscribes to the room aggregate namespace and ignores room
+// events it does not handle.
 func (p *RoomCatalogProjection) Subjects() []string {
-	return []string{
-		events.RoomEventTypeFilter(events.EventRoomCreated),
-		events.RoomEventTypeFilter(events.EventRoomUpdated),
-		events.RoomEventTypeFilter(events.EventRoomArchived),
-		events.RoomEventTypeFilter(events.EventRoomUnarchived),
-		events.RoomEventTypeFilter(events.EventRoomDeleted),
-	}
+	return []string{events.RoomSubjectFilter()}
 }
 
 // Apply implements events.Projection.

--- a/cli/internal/core/room_directory_projection.go
+++ b/cli/internal/core/room_directory_projection.go
@@ -1,0 +1,34 @@
+package core
+
+import (
+	"hmans.de/chatto/internal/events"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+// RoomDirectoryProjection combines the room aggregate's structural read models:
+// catalog metadata and membership indexes. Keeping them under one projector
+// avoids duplicate evt.room.> consumers while preserving the smaller read-model
+// APIs used by callers.
+type RoomDirectoryProjection struct {
+	events.MemoryProjection
+	Catalog    *RoomCatalogProjection
+	Membership *RoomMembershipProjection
+}
+
+func NewRoomDirectoryProjection() *RoomDirectoryProjection {
+	return &RoomDirectoryProjection{
+		Catalog:    NewRoomCatalogProjection(),
+		Membership: NewRoomMembershipProjection(),
+	}
+}
+
+func (p *RoomDirectoryProjection) Subjects() []string {
+	return []string{events.RoomSubjectFilter()}
+}
+
+func (p *RoomDirectoryProjection) Apply(event *corev1.Event, seq uint64) error {
+	if err := p.Catalog.Apply(event, seq); err != nil {
+		return err
+	}
+	return p.Membership.Apply(event, seq)
+}

--- a/cli/internal/core/room_group_layout_projection.go
+++ b/cli/internal/core/room_group_layout_projection.go
@@ -1,0 +1,33 @@
+package core
+
+import (
+	"hmans.de/chatto/internal/events"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+// RoomGroupLayoutProjection combines room-group state and explicit sidebar
+// ordering. The read APIs remain split between RoomGroups and RoomLayout, but a
+// single projector now tracks the group aggregate plus the layout aggregate.
+type RoomGroupLayoutProjection struct {
+	events.MemoryProjection
+	Groups *RoomGroupProjection
+	Layout *RoomLayoutProjection
+}
+
+func NewRoomGroupLayoutProjection() *RoomGroupLayoutProjection {
+	return &RoomGroupLayoutProjection{
+		Groups: NewRoomGroupProjection(),
+		Layout: NewRoomLayoutProjection(),
+	}
+}
+
+func (p *RoomGroupLayoutProjection) Subjects() []string {
+	return []string{events.GroupSubjectFilter(), events.LayoutSubjectFilter()}
+}
+
+func (p *RoomGroupLayoutProjection) Apply(event *corev1.Event, seq uint64) error {
+	if err := p.Groups.Apply(event, seq); err != nil {
+		return err
+	}
+	return p.Layout.Apply(event, seq)
+}

--- a/cli/internal/core/room_group_projection.go
+++ b/cli/internal/core/room_group_projection.go
@@ -34,21 +34,11 @@ func NewRoomGroupProjection() *RoomGroupProjection {
 	}
 }
 
-// Subjects implements events.Projection. Narrow filters covering
-// every event type the projection handles. New event types added to
-// evt.group.> won't reach this consumer until they're listed here —
-// matches the "apply what you understand, ignore the rest" rule, but
-// makes the "ignore" cheaper (server-side filter, not in-process
-// switch).
+// Subjects implements events.Projection. Room groups are a group-derived read
+// model, so the projection subscribes to the group aggregate namespace and
+// ignores group events it does not handle.
 func (p *RoomGroupProjection) Subjects() []string {
-	return []string{
-		events.GroupEventTypeFilter(events.EventRoomGroupCreated),
-		events.GroupEventTypeFilter(events.EventRoomGroupUpdated),
-		events.GroupEventTypeFilter(events.EventRoomGroupDeleted),
-		events.GroupEventTypeFilter(events.EventRoomAddedToGroup),
-		events.GroupEventTypeFilter(events.EventRoomRemovedFromGroup),
-		events.GroupEventTypeFilter(events.EventRoomsInGroupReordered),
-	}
+	return []string{events.GroupSubjectFilter()}
 }
 
 // Apply implements events.Projection. Recognised events:

--- a/cli/internal/core/room_groups.go
+++ b/cli/internal/core/room_groups.go
@@ -24,9 +24,9 @@ const maxMoveRoomToGroupRetries = 5
 // populated from pre-phase-6 history and the boot-time migrations,
 // kept around solely to allow a rollback to a pre-phase-6 binary.
 //
-// Reads compose three projections:
-//   - RoomGroups: per-group metadata + ordered room_ids (evt.group.>)
-//   - RoomLayout: operator-defined ordering of group IDs (evt.layout.>)
+// Reads compose three read-model indexes:
+//   - RoomGroups: per-group metadata + ordered room_ids
+//   - RoomLayout: operator-defined ordering of group IDs
 //   - RoomCatalog: room metadata, used for the final reconciliation
 //
 // `ListRoomGroupsOrdered` walks the layout's ordering, drops stale

--- a/cli/internal/core/room_membership_projection.go
+++ b/cli/internal/core/room_membership_projection.go
@@ -40,17 +40,11 @@ func NewRoomMembershipProjection() *RoomMembershipProjection {
 	}
 }
 
-// Subjects implements events.Projection. Narrow filters — this
-// projection only cares about three event types, so subscribing to
-// just those subjects keeps the per-projection consumer's delivery
-// volume proportional to membership churn rather than total room
-// activity.
+// Subjects implements events.Projection. Room membership is a room-derived
+// read model, so it follows the projection policy of subscribing to the
+// owning aggregate namespace and ignoring room events it does not handle.
 func (p *RoomMembershipProjection) Subjects() []string {
-	return []string{
-		events.RoomEventTypeFilter(events.EventUserJoinedRoom),
-		events.RoomEventTypeFilter(events.EventUserLeftRoom),
-		events.RoomEventTypeFilter(events.EventRoomDeleted),
-	}
+	return []string{events.RoomSubjectFilter()}
 }
 
 // Apply implements events.Projection. Apply runs from a single

--- a/cli/internal/core/rooms.go
+++ b/cli/internal/core/rooms.go
@@ -215,11 +215,9 @@ func (c *ChattoCore) CreateRoom(ctx context.Context, actorID string, kind RoomKi
 // The flow per attempt:
 //  1. Check the catalog for the desired `name`; if any other room
 //     holds it, return ErrRoomNameExists immediately.
-//  2. Read the stream's actual last seq for the OCC filter directly
-//     (NOT from the catalog projector — that subscribes to a narrower
-//     set of subjects than `evt.room.>` and its LastSeq would fall
-//     permanently behind, deterministically failing every retry on a
-//     server that's had any joins/leaves since the last catalog write).
+//  2. Read the stream's actual last seq for the OCC filter directly.
+//     This keeps the uniqueness check tied to JetStream's aggregate
+//     scope rather than to any projection's local catch-up state.
 //  3. Publish the event with the freshly-read filter seq. JetStream
 //     rejects with ErrConflict if any evt.room.> message landed in the
 //     read-publish window — backoff briefly and retry.


### PR DESCRIPTION
- Consolidates room catalog + membership under a `RoomDirectoryProjection` consumer and room groups + layout under a `RoomGroupLayoutProjection` consumer.
- Aligns aggregate-owned projections with broad aggregate namespace subscriptions while keeping focused projections on exact subjects.
- Updates projection admin metrics, registry expectations, subject policy tests, and comments for the new consumer shape.

Tests: `mise exec -- go test -tags test_endpoints ./internal/events ./internal/core`
