### PR TITLE
refactor: use composite projectors

### DIFF
--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -87,15 +87,12 @@ type ChattoCore struct {
 	RoomDirectory *RoomDirectoryProjection
 
 	// RoomDirectoryProjector runs the consumer for RoomDirectory. The
-	// RoomCatalogProjector and RoomMembershipProjector fields alias this
-	// projector for existing read-your-writes call sites.
+	// room catalog and membership writer paths wait on this projector for
+	// read-your-writes.
 	RoomDirectoryProjector *events.Projector
 
 	// RoomMembership is the membership index inside RoomDirectory.
 	RoomMembership *RoomMembershipProjection
-
-	// RoomMembershipProjector aliases RoomDirectoryProjector.
-	RoomMembershipProjector *events.Projector
 
 	// ServerConfig is the projection holding current dynamic configuration
 	// rebuilt from EVT. The field name is retained for compatibility with
@@ -111,29 +108,20 @@ type ChattoCore struct {
 	// RoomCatalog is the room metadata index inside RoomDirectory.
 	RoomCatalog *RoomCatalogProjection
 
-	// RoomCatalogProjector aliases RoomDirectoryProjector.
-	RoomCatalogProjector *events.Projector
-
 	// RoomGroupLayout combines room-group state and sidebar ordering under one
 	// projector over evt.group.> plus evt.layout.>.
 	RoomGroupLayout *RoomGroupLayoutProjection
 
 	// RoomGroupLayoutProjector runs the consumer for RoomGroupLayout. The
-	// RoomGroupsProjector and RoomLayoutProjector fields alias this projector
-	// for existing read-your-writes call sites.
+	// room-group and layout writer paths wait on this projector for
+	// read-your-writes.
 	RoomGroupLayoutProjector *events.Projector
 
 	// RoomGroups is the group state index inside RoomGroupLayout.
 	RoomGroups *RoomGroupProjection
 
-	// RoomGroupsProjector aliases RoomGroupLayoutProjector.
-	RoomGroupsProjector *events.Projector
-
 	// RoomLayout is the sidebar ordering index inside RoomGroupLayout.
 	RoomLayout *RoomLayoutProjection
-
-	// RoomLayoutProjector aliases RoomGroupLayoutProjector.
-	RoomLayoutProjector *events.Projector
 
 	// RoomTimeline holds an append-only event log per room, derived
 	// from the full evt.room.> firehose (#597 phase 2). Source of
@@ -686,20 +674,16 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	roomDirectory := NewRoomDirectoryProjection()
 	roomDirectoryProjector := newProjector(roomDirectory, "Room Directory", roomDirectory.adminProjectionEstimate)
 	roomMembership := roomDirectory.Membership
-	roomMembershipProjector := roomDirectoryProjector
 
 	serverConfigProjection := NewConfigProjection()
 	serverConfigProjector := newProjector(serverConfigProjection, "Server Config", serverConfigProjection.adminProjectionEstimate)
 
 	roomCatalog := roomDirectory.Catalog
-	roomCatalogProjector := roomDirectoryProjector
 
 	roomGroupLayout := NewRoomGroupLayoutProjection()
 	roomGroupLayoutProjector := newProjector(roomGroupLayout, "Room Group Layout", roomGroupLayout.adminProjectionEstimate)
 	roomGroups := roomGroupLayout.Groups
-	roomGroupsProjector := roomGroupLayoutProjector
 	roomLayout := roomGroupLayout.Layout
-	roomLayoutProjector := roomGroupLayoutProjector
 
 	// Per-room event-log + per-thread event-log projections (#597
 	// phase 2). Both consume the full evt.room.> firehose; resolvers
@@ -739,17 +723,13 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 		RoomDirectory:            roomDirectory,
 		RoomDirectoryProjector:   roomDirectoryProjector,
 		RoomMembership:           roomMembership,
-		RoomMembershipProjector:  roomMembershipProjector,
 		ServerConfig:             serverConfigProjection,
 		ServerConfigProjector:    serverConfigProjector,
 		RoomCatalog:              roomCatalog,
-		RoomCatalogProjector:     roomCatalogProjector,
 		RoomGroupLayout:          roomGroupLayout,
 		RoomGroupLayoutProjector: roomGroupLayoutProjector,
 		RoomGroups:               roomGroups,
-		RoomGroupsProjector:      roomGroupsProjector,
 		RoomLayout:               roomLayout,
-		RoomLayoutProjector:      roomLayoutProjector,
 		RoomTimeline:             roomTimeline,
 		RoomTimelineProjector:    roomTimelineProjector,
 		Threads:                  threads,
@@ -1606,18 +1586,14 @@ func (c *ChattoCore) waitForLiveEVTRoomEvent(ctx context.Context, event *corev1.
 		}
 	}
 	switch event.GetEvent().(type) {
-	case *corev1.Event_UserJoinedRoom, *corev1.Event_UserLeftRoom, *corev1.Event_RoomDeleted:
-		if err := waitForSeqAll(ctx, seq, waitForProjection("room membership", c.RoomMembershipProjector)); err != nil {
-			return err
-		}
-	}
-	switch event.GetEvent().(type) {
-	case *corev1.Event_RoomCreated,
+	case *corev1.Event_UserJoinedRoom,
+		*corev1.Event_UserLeftRoom,
+		*corev1.Event_RoomCreated,
 		*corev1.Event_RoomUpdated,
 		*corev1.Event_RoomArchived,
 		*corev1.Event_RoomUnarchived,
 		*corev1.Event_RoomDeleted:
-		if err := waitForSeqAll(ctx, seq, waitForProjection("room catalog", c.RoomCatalogProjector)); err != nil {
+		if err := waitForSeqAll(ctx, seq, waitForProjection("room directory", c.RoomDirectoryProjector)); err != nil {
 			return err
 		}
 	}

--- a/cli/internal/core/dm.go
+++ b/cli/internal/core/dm.go
@@ -209,16 +209,11 @@ func (c *ChattoCore) createDMRoom(ctx context.Context, roomID string, participan
 		return nil, err
 	}
 
-	// Wait per-projector for a sequence covered by that projector's
-	// subscription. Room-derived projections subscribe to evt.room.>,
-	// so both the RoomCreated and UserJoinedRoom sequences are visible.
-	// seqs[0] is the RoomCreated (catalog); seqs[len-1] is the last
-	// UserJoinedRoom (membership and timeline).
-	if err := c.RoomCatalogProjector.WaitForSeq(ctx, seqs[0]); err != nil {
-		c.logger.Warn("DM room catalog projection wait failed", "error", err, "room_id", roomID)
-	}
-	if err := c.RoomMembershipProjector.WaitForSeq(ctx, seqs[len(seqs)-1]); err != nil {
-		c.logger.Warn("DM membership projection wait failed", "error", err, "room_id", roomID)
+	// Wait for the last batch sequence on projections that consume evt.room.>.
+	// Reaching the last UserJoinedRoom means the earlier RoomCreated has also
+	// landed in the room directory.
+	if err := c.RoomDirectoryProjector.WaitForSeq(ctx, seqs[len(seqs)-1]); err != nil {
+		c.logger.Warn("DM room directory projection wait failed", "error", err, "room_id", roomID)
 	}
 	if err := c.RoomTimelineProjector.WaitForSeq(ctx, seqs[len(seqs)-1]); err != nil {
 		c.logger.Warn("DM room timeline projection wait failed", "error", err, "room_id", roomID)

--- a/cli/internal/core/room_groups.go
+++ b/cli/internal/core/room_groups.go
@@ -70,7 +70,7 @@ func (c *ChattoCore) CreateRoomGroup(ctx context.Context, actorID, name, descrip
 			},
 		},
 	})
-	if _, err := c.RoomGroupsProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.GroupAggregate(group.Id), createdEvent); err != nil {
+	if _, err := c.RoomGroupLayoutProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.GroupAggregate(group.Id), createdEvent); err != nil {
 		return nil, fmt.Errorf("publish RoomGroupCreatedEvent: %w", err)
 	}
 
@@ -108,7 +108,7 @@ func (c *ChattoCore) UpdateRoomGroup(ctx context.Context, actorID, groupID, name
 			},
 		},
 	})
-	if _, err := c.RoomGroupsProjector.AppendAndWait(ctx, c.EventPublisher, events.GroupAggregate(groupID), updatedEvent); err != nil {
+	if _, err := c.RoomGroupLayoutProjector.AppendAndWait(ctx, c.EventPublisher, events.GroupAggregate(groupID), updatedEvent); err != nil {
 		return nil, fmt.Errorf("publish RoomGroupUpdatedEvent: %w", err)
 	}
 
@@ -150,7 +150,7 @@ func (c *ChattoCore) DeleteRoomGroup(ctx context.Context, actorID, groupID strin
 			},
 		},
 	})
-	if _, err := c.RoomGroupsProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.GroupAggregate(groupID), deletedEvent); err != nil {
+	if _, err := c.RoomGroupLayoutProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.GroupAggregate(groupID), deletedEvent); err != nil {
 		return fmt.Errorf("publish RoomGroupDeletedEvent: %w", err)
 	}
 
@@ -181,8 +181,8 @@ func (c *ChattoCore) MoveRoomToGroup(ctx context.Context, actorID, roomID, targe
 			return fmt.Errorf("read room-group OCC seq: %w", err)
 		}
 		if filterSeq > 0 {
-			if err := c.RoomGroupsProjector.WaitForSeq(ctx, filterSeq); err != nil {
-				return fmt.Errorf("wait for groups projection: %w", err)
+			if err := c.RoomGroupLayoutProjector.WaitForSeq(ctx, filterSeq); err != nil {
+				return fmt.Errorf("wait for room group layout projection: %w", err)
 			}
 		}
 
@@ -249,8 +249,8 @@ func (c *ChattoCore) MoveRoomToGroup(ctx context.Context, actorID, roomID, targe
 			// Wait on the final seq — the projector applies in stream order
 			// so reaching the last batch entry's seq implies every earlier
 			// entry's Apply has also landed.
-			if err := c.RoomGroupsProjector.WaitForSeq(ctx, seqs[len(seqs)-1]); err != nil {
-				return fmt.Errorf("wait for groups projection: %w", err)
+			if err := c.RoomGroupLayoutProjector.WaitForSeq(ctx, seqs[len(seqs)-1]); err != nil {
+				return fmt.Errorf("wait for room group layout projection: %w", err)
 			}
 			return nil
 		}
@@ -340,7 +340,7 @@ func (c *ChattoCore) ReorderRoomsInGroup(ctx context.Context, actorID, groupID s
 			},
 		},
 	})
-	if _, err := c.RoomGroupsProjector.AppendAndWait(ctx, c.EventPublisher, events.GroupAggregate(groupID), reorderedEvent); err != nil {
+	if _, err := c.RoomGroupLayoutProjector.AppendAndWait(ctx, c.EventPublisher, events.GroupAggregate(groupID), reorderedEvent); err != nil {
 		return fmt.Errorf("publish RoomsInGroupReorderedEvent: %w", err)
 	}
 
@@ -407,7 +407,7 @@ func (c *ChattoCore) GetRoomLayoutOrder(_ context.Context) ([]string, error) {
 // ----------------------------------------------------------------------
 
 // publishLayoutOrdering writes a RoomGroupsReorderedEvent on the
-// singleton layout aggregate and waits for the layout projection.
+// singleton layout aggregate and waits for the group/layout projection.
 func (c *ChattoCore) publishLayoutOrdering(ctx context.Context, actorID string, groupIDs []string) error {
 	event := newEvent(actorID, &corev1.Event{
 		Event: &corev1.Event_RoomGroupsReordered{
@@ -416,7 +416,7 @@ func (c *ChattoCore) publishLayoutOrdering(ctx context.Context, actorID string, 
 			},
 		},
 	})
-	if _, err := c.RoomLayoutProjector.AppendAndWait(ctx, c.EventPublisher, events.LayoutAggregate(), event); err != nil {
+	if _, err := c.RoomGroupLayoutProjector.AppendAndWait(ctx, c.EventPublisher, events.LayoutAggregate(), event); err != nil {
 		return fmt.Errorf("publish RoomGroupsReorderedEvent: %w", err)
 	}
 	return nil

--- a/cli/internal/core/room_membership.go
+++ b/cli/internal/core/room_membership.go
@@ -82,8 +82,8 @@ func (c *ChattoCore) JoinRoom(ctx context.Context, actorID string, kind RoomKind
 			return nil, fmt.Errorf("read UserJoinedRoomEvent OCC seq: %w", err)
 		}
 		if expectedSeq > 0 {
-			if err := c.RoomMembershipProjector.WaitForSeq(ctx, expectedSeq); err != nil {
-				return nil, fmt.Errorf("wait for membership projection before join: %w", err)
+			if err := c.RoomDirectoryProjector.WaitForSeq(ctx, expectedSeq); err != nil {
+				return nil, fmt.Errorf("wait for room directory projection before join: %w", err)
 			}
 			if c.RoomMembership.IsMember(room_id, user_id) {
 				return membership, nil
@@ -93,7 +93,7 @@ func (c *ChattoCore) JoinRoom(ctx context.Context, actorID string, kind RoomKind
 		seq, err = c.EventPublisher.AppendAt(ctx, joinSubject, event, expectedSeq)
 		if err == nil {
 			if err := waitForSeqAll(ctx, seq,
-				waitForProjection("membership", c.RoomMembershipProjector),
+				waitForProjection("room directory", c.RoomDirectoryProjector),
 				waitForProjection("room timeline", c.RoomTimelineProjector),
 			); err != nil {
 				return nil, err
@@ -162,7 +162,7 @@ func (c *ChattoCore) LeaveRoom(ctx context.Context, actorID string, kind RoomKin
 		},
 	})
 
-	seq, err := c.RoomMembershipProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.RoomAggregate(room_id), event)
+	seq, err := c.RoomDirectoryProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.RoomAggregate(room_id), event)
 	if err != nil {
 		return fmt.Errorf("publish UserLeftRoomEvent: %w", err)
 	}
@@ -272,8 +272,8 @@ func (c *ChattoCore) deleteUserRoomMembershipsInSpace(ctx context.Context, user_
 	}
 
 	if lastSeq > 0 {
-		if err := c.RoomMembershipProjector.WaitForSeq(ctx, lastSeq); err != nil {
-			return fmt.Errorf("wait for membership projection after membership cleanup: %w", err)
+		if err := c.RoomDirectoryProjector.WaitForSeq(ctx, lastSeq); err != nil {
+			return fmt.Errorf("wait for room directory projection after membership cleanup: %w", err)
 		}
 		if err := c.RoomTimelineProjector.WaitForSeq(ctx, lastSeq); err != nil {
 			return fmt.Errorf("wait for room timeline projection after membership cleanup: %w", err)

--- a/cli/internal/core/rooms.go
+++ b/cli/internal/core/rooms.go
@@ -200,7 +200,7 @@ func (c *ChattoCore) CreateRoom(ctx context.Context, actorID string, kind RoomKi
 	}
 
 	if err := waitForSeqAll(ctx, createdSeq,
-		waitForProjection("catalog", c.RoomCatalogProjector),
+		waitForProjection("room directory", c.RoomDirectoryProjector),
 		waitForProjection("room timeline", c.RoomTimelineProjector),
 	); err != nil {
 		return nil, err
@@ -328,7 +328,7 @@ func (c *ChattoCore) UpdateRoom(ctx context.Context, actorID string, kind RoomKi
 	c.logger.Info("Room updated", "kind", kind, "room_id", room_id, "name", name)
 
 	if err := waitForSeqAll(ctx, updatedSeq,
-		waitForProjection("catalog", c.RoomCatalogProjector),
+		waitForProjection("room directory", c.RoomDirectoryProjector),
 		waitForProjection("room timeline", c.RoomTimelineProjector),
 	); err != nil {
 		return nil, err
@@ -339,8 +339,8 @@ func (c *ChattoCore) UpdateRoom(ctx context.Context, actorID string, kind RoomKi
 // DeleteRoom deletes a room.
 // Authorization: Caller must verify CanManageAnyRoom before calling.
 //
-// ADR-035 phase 6: event-only. Publishes RoomDeletedEvent (which both
-// the catalog and membership projections apply as a drop) and, for
+// ADR-035 phase 6: event-only. Publishes RoomDeletedEvent (which the
+// room directory applies to both catalog and membership indexes) and, for
 // channel rooms in a group, a RoomRemovedFromGroupEvent cascade per
 // ADR-034 Approach A. Historical room events are retained in EVT; the
 // legacy KV room record is no longer touched here.
@@ -395,14 +395,13 @@ func (c *ChattoCore) DeleteRoom(ctx context.Context, actorID string, kind RoomKi
 	// Read-your-writes: every projection that needs to drop state
 	// must have applied its event before we return.
 	if err := waitForSeqAll(ctx, seq,
-		waitForProjection("membership", c.RoomMembershipProjector),
-		waitForProjection("catalog", c.RoomCatalogProjector),
+		waitForProjection("room directory", c.RoomDirectoryProjector),
 		waitForProjection("room timeline", c.RoomTimelineProjector),
 	); err != nil {
 		return err
 	}
 	if groupRemovedSeq > 0 {
-		if err := waitForSeqAll(ctx, groupRemovedSeq, waitForProjection("groups", c.RoomGroupsProjector)); err != nil {
+		if err := waitForSeqAll(ctx, groupRemovedSeq, waitForProjection("room group layout", c.RoomGroupLayoutProjector)); err != nil {
 			return err
 		}
 	}
@@ -428,7 +427,7 @@ func (c *ChattoCore) ArchiveRoom(ctx context.Context, actorID string, kind RoomK
 			},
 		},
 	})
-	seq, err := c.RoomCatalogProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.RoomAggregate(roomID), archivedEvent)
+	seq, err := c.RoomDirectoryProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.RoomAggregate(roomID), archivedEvent)
 	if err != nil {
 		return nil, fmt.Errorf("publish RoomArchivedEvent: %w", err)
 	}
@@ -463,7 +462,7 @@ func (c *ChattoCore) UnarchiveRoom(ctx context.Context, actorID string, kind Roo
 			},
 		},
 	})
-	seq, err := c.RoomCatalogProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.RoomAggregate(roomID), unarchivedEvent)
+	seq, err := c.RoomDirectoryProjector.AppendEventuallyAndWait(ctx, c.EventPublisher, events.RoomAggregate(roomID), unarchivedEvent)
 	if err != nil {
 		return nil, fmt.Errorf("publish RoomUnarchivedEvent: %w", err)
 	}


### PR DESCRIPTION
- Removes obsolete projector alias fields from `ChattoCore`.
- Switches room directory and group/layout writer paths to wait on the composite projectors directly.
- Collapses duplicate waits in DM creation, room deletion, and live EVT readiness.

Tests: `mise exec -- go test -tags test_endpoints ./internal/events ./internal/core`
