### PR TITLE
fix: add HTTP server timeout hardening

### DIFF
--- a/cli/internal/http_server/server.go
+++ b/cli/internal/http_server/server.go
@@ -43,6 +43,11 @@ type HTTPServer struct {
 	logger     *log.Logger
 }
 
+const (
+	httpServerReadHeaderTimeout = 10 * time.Second
+	httpServerIdleTimeout       = 2 * time.Minute
+)
+
 // NewHTTPServer creates a new HTTP server with the provided dependencies.
 func NewHTTPServer(cfg HTTPServerConfig) (*HTTPServer, error) {
 	logger := log.WithPrefix("server.HTTP")
@@ -80,6 +85,15 @@ func NewHTTPServer(cfg HTTPServerConfig) (*HTTPServer, error) {
 	}
 
 	return s, nil
+}
+
+func newHTTPServer(addr string, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: httpServerReadHeaderTimeout,
+		IdleTimeout:       httpServerIdleTimeout,
+	}
 }
 
 func (s *HTTPServer) setupRoutes() error {
@@ -159,27 +173,18 @@ func (s *HTTPServer) Run(ctx context.Context) error {
 		}
 
 		// HTTPS server (started separately with ListenAndServeTLS)
-		tlsServer = &http.Server{
-			Addr:    s.addr,
-			Handler: s.router,
-			TLSConfig: &tls.Config{
-				GetCertificate: certManager.GetCertificate,
-				MinVersion:     tls.VersionTLS12,
-			},
+		tlsServer = newHTTPServer(s.addr, s.router)
+		tlsServer.TLSConfig = &tls.Config{
+			GetCertificate: certManager.GetCertificate,
+			MinVersion:     tls.VersionTLS12,
 		}
 
 		// HTTP server for ACME challenges and HTTPS redirect
 		httpAddr := fmt.Sprintf(":%d", tlsConfig.HTTPPortOrDefault())
-		servers = append(servers, &http.Server{
-			Addr:    httpAddr,
-			Handler: certManager.HTTPHandler(http.HandlerFunc(s.redirectToHTTPS)),
-		})
+		servers = append(servers, newHTTPServer(httpAddr, certManager.HTTPHandler(http.HandlerFunc(s.redirectToHTTPS))))
 	} else {
 		// Plain HTTP server
-		servers = append(servers, &http.Server{
-			Addr:    s.addr,
-			Handler: s.router,
-		})
+		servers = append(servers, newHTTPServer(s.addr, s.router))
 	}
 
 	serverErr := make(chan error, len(servers)+1)

--- a/cli/internal/http_server/server_test.go
+++ b/cli/internal/http_server/server_test.go
@@ -94,6 +94,31 @@ func testContext(t *testing.T) context.Context {
 	return ctx
 }
 
+func TestNewHTTPServerAppliesTimeouts(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	srv := newHTTPServer(":4000", handler)
+
+	if srv.Addr != ":4000" {
+		t.Fatalf("Addr = %q, want :4000", srv.Addr)
+	}
+	if srv.Handler == nil {
+		t.Fatal("Handler was not set")
+	}
+	if srv.ReadHeaderTimeout != httpServerReadHeaderTimeout {
+		t.Fatalf("ReadHeaderTimeout = %s, want %s", srv.ReadHeaderTimeout, httpServerReadHeaderTimeout)
+	}
+	if srv.IdleTimeout != httpServerIdleTimeout {
+		t.Fatalf("IdleTimeout = %s, want %s", srv.IdleTimeout, httpServerIdleTimeout)
+	}
+	if srv.ReadTimeout != 0 {
+		t.Fatalf("ReadTimeout = %s, want 0", srv.ReadTimeout)
+	}
+	if srv.WriteTimeout != 0 {
+		t.Fatalf("WriteTimeout = %s, want 0", srv.WriteTimeout)
+	}
+}
+
 // testHTTPServer creates an HTTPServer for testing with an embedded NATS server.
 // Returns the test server, a client with cookie jar, and ChattoCore.
 func setupTestHTTPServer(t *testing.T) (*httptest.Server, *http.Client, *core.ChattoCore) {


### PR DESCRIPTION
## Summary

- Adds shared `http.Server` construction with `ReadHeaderTimeout` and `IdleTimeout` defaults.
- Applies the timeout baseline to plain HTTP, automatic TLS, and ACME redirect servers.
- Adds regression coverage while keeping `ReadTimeout` and `WriteTimeout` unset for uploads and WebSocket subscriptions.

Fixes #5.

## Tests

- `mise exec -- go test -tags test_endpoints ./internal/http_server`
