### PR TITLE
feat(graphql): clean up schema hygiene

### DIFF
--- a/cli/internal/core/server_branding.go
+++ b/cli/internal/core/server_branding.go
@@ -188,34 +188,37 @@ func (c *ChattoCore) projectedServerBrandingAsset(kind string) *corev1.Deprecate
 // GetServerLogoURL returns the URL for the server's logo, optionally
 // transformed to the given dimensions. Returns empty string when no logo
 // is set.
-func (c *ChattoCore) GetServerLogoURL(ctx context.Context, width, height *int) (string, error) {
+func (c *ChattoCore) GetServerLogoURL(ctx context.Context, width, height *int, fit string) (string, error) {
 	logo, err := c.GetServerLogo(ctx)
 	if err != nil || logo == nil {
 		return "", err
 	}
-	return c.serverAssetURL(logo, width, height), nil
+	return c.serverAssetURL(logo, width, height, fit), nil
 }
 
 // GetServerBannerURL returns the URL for the server's banner, optionally
 // transformed to the given dimensions. Returns empty string when no banner
 // is set.
-func (c *ChattoCore) GetServerBannerURL(ctx context.Context, width, height *int) (string, error) {
+func (c *ChattoCore) GetServerBannerURL(ctx context.Context, width, height *int, fit string) (string, error) {
 	banner, err := c.GetServerBanner(ctx)
 	if err != nil || banner == nil {
 		return "", err
 	}
-	return c.serverAssetURL(banner, width, height), nil
+	return c.serverAssetURL(banner, width, height, fit), nil
 }
 
 // serverAssetURL builds the public URL for an server-scoped asset,
 // optionally with transform parameters.
-func (c *ChattoCore) serverAssetURL(asset *corev1.DeprecatedAsset, width, height *int) string {
+func (c *ChattoCore) serverAssetURL(asset *corev1.DeprecatedAsset, width, height *int, fit string) string {
 	assetID := assetIDFromAsset(asset)
 	if assetID == "" {
 		return ""
 	}
 	if width != nil && height != nil {
-		return c.GetTransformedServerAssetURL(assetID, *width, *height, "cover")
+		if fit == "" {
+			fit = "cover"
+		}
+		return c.GetTransformedServerAssetURL(assetID, *width, *height, fit)
 	}
 	return c.assetURL(fmt.Sprintf("/assets/server/%s", assetID))
 }
@@ -282,12 +285,12 @@ func (c *ChattoCore) PublishServerBrandingUpdate(ctx context.Context, actorID st
 		}
 	}
 
-	logoURL, err := c.GetServerLogoURL(ctx, nil, nil)
+	logoURL, err := c.GetServerLogoURL(ctx, nil, nil, "")
 	if err != nil {
 		c.logger.Warn("failed to get instance logo URL for update event", "error", err)
 		logoURL = ""
 	}
-	bannerURL, err := c.GetServerBannerURL(ctx, nil, nil)
+	bannerURL, err := c.GetServerBannerURL(ctx, nil, nil, "")
 	if err != nil {
 		c.logger.Warn("failed to get instance banner URL for update event", "error", err)
 		bannerURL = ""

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -545,7 +545,7 @@ func (c *ChattoCore) publishUserProfileUpdate(ctx context.Context, userID string
 	}
 
 	// Get current avatar URL (full resolution for events)
-	avatarURL, err := c.GetUserAvatarURL(ctx, userID, nil, nil)
+	avatarURL, err := c.GetUserAvatarURL(ctx, userID, nil, nil, "")
 	if err != nil {
 		c.logger.Warn("failed to get avatar URL for profile update event", "error", err, "user_id", userID)
 		avatarURL = ""
@@ -583,7 +583,7 @@ func (c *ChattoCore) ListUsers(ctx context.Context) ([]*corev1.User, error) {
 // GetUserAvatarURL returns the URL for a user's avatar.
 // If width and height are provided (non-nil), returns a URL to a resized version.
 // Returns empty string if no avatar is set.
-func (c *ChattoCore) GetUserAvatarURL(ctx context.Context, userID string, width, height *int) (string, error) {
+func (c *ChattoCore) GetUserAvatarURL(ctx context.Context, userID string, width, height *int, fit string) (string, error) {
 	avatar, err := c.GetUserAvatar(ctx, userID)
 	if err != nil {
 		return "", err
@@ -607,7 +607,10 @@ func (c *ChattoCore) GetUserAvatarURL(ctx context.Context, userID string, width,
 
 	// Always use the standard server asset URL format - storage backend is an internal detail
 	if width != nil && height != nil {
-		return c.GetTransformedServerAssetURL(assetID, *width, *height, "cover"), nil
+		if fit == "" {
+			fit = "cover"
+		}
+		return c.GetTransformedServerAssetURL(assetID, *width, *height, fit), nil
 	}
 	return c.assetURL(fmt.Sprintf("/assets/server/%s", assetID)), nil
 }

--- a/cli/internal/core/users_test.go
+++ b/cli/internal/core/users_test.go
@@ -1209,7 +1209,7 @@ func TestChattoCore_GetUserAvatarURL(t *testing.T) {
 	}
 
 	// No avatar initially - should return empty string
-	url, err := core.GetUserAvatarURL(ctx, user.Id, nil, nil)
+	url, err := core.GetUserAvatarURL(ctx, user.Id, nil, nil, "")
 	if err != nil {
 		t.Fatalf("Failed to get avatar URL: %v", err)
 	}
@@ -1223,7 +1223,7 @@ func TestChattoCore_GetUserAvatarURL(t *testing.T) {
 	core.SetUserAvatar(ctx, user.Id, asset)
 
 	// Now should return URL
-	url, err = core.GetUserAvatarURL(ctx, user.Id, nil, nil)
+	url, err = core.GetUserAvatarURL(ctx, user.Id, nil, nil, "")
 	if err != nil {
 		t.Fatalf("Failed to get avatar URL: %v", err)
 	}
@@ -1252,7 +1252,7 @@ func TestChattoCore_GetUserAvatarURL_AbsoluteURL(t *testing.T) {
 
 	t.Run("returns relative URL when AssetBaseURL is empty", func(t *testing.T) {
 		core.AssetBaseURL = ""
-		url, err := core.GetUserAvatarURL(ctx, user.Id, nil, nil)
+		url, err := core.GetUserAvatarURL(ctx, user.Id, nil, nil, "")
 		if err != nil {
 			t.Fatalf("Failed to get avatar URL: %v", err)
 		}
@@ -1265,7 +1265,7 @@ func TestChattoCore_GetUserAvatarURL_AbsoluteURL(t *testing.T) {
 		core.AssetBaseURL = "https://chat.example.com"
 		defer func() { core.AssetBaseURL = "" }()
 
-		url, err := core.GetUserAvatarURL(ctx, user.Id, nil, nil)
+		url, err := core.GetUserAvatarURL(ctx, user.Id, nil, nil, "")
 		if err != nil {
 			t.Fatalf("Failed to get avatar URL: %v", err)
 		}
@@ -1279,7 +1279,7 @@ func TestChattoCore_GetUserAvatarURL_AbsoluteURL(t *testing.T) {
 		defer func() { core.AssetBaseURL = "" }()
 
 		w, h := 64, 64
-		url, err := core.GetUserAvatarURL(ctx, user.Id, &w, &h)
+		url, err := core.GetUserAvatarURL(ctx, user.Id, &w, &h, "cover")
 		if err != nil {
 			t.Fatalf("Failed to get avatar URL: %v", err)
 		}
@@ -1357,7 +1357,7 @@ func TestChattoCore_DeleteUserAvatar(t *testing.T) {
 	}
 
 	// Verify avatar is set
-	url, err := core.GetUserAvatarURL(ctx, user.Id, nil, nil)
+	url, err := core.GetUserAvatarURL(ctx, user.Id, nil, nil, "")
 	if err != nil {
 		t.Fatalf("Failed to get avatar URL: %v", err)
 	}
@@ -1372,7 +1372,7 @@ func TestChattoCore_DeleteUserAvatar(t *testing.T) {
 	}
 
 	// Verify avatar is gone
-	url, err = core.GetUserAvatarURL(ctx, user.Id, nil, nil)
+	url, err = core.GetUserAvatarURL(ctx, user.Id, nil, nil, "")
 	if err != nil {
 		t.Fatalf("Failed to get avatar URL after deletion: %v", err)
 	}
@@ -1404,7 +1404,7 @@ func TestChattoCore_DeleteUserAvatar_NoAvatar(t *testing.T) {
 	}
 
 	// Verify still no avatar
-	url, err := core.GetUserAvatarURL(ctx, user.Id, nil, nil)
+	url, err := core.GetUserAvatarURL(ctx, user.Id, nil, nil, "")
 	if err != nil {
 		t.Fatalf("Failed to get avatar URL: %v", err)
 	}

--- a/cli/internal/graph/generated.go
+++ b/cli/internal/graph/generated.go
@@ -708,9 +708,9 @@ type ComplexityRoot struct {
 	}
 
 	ServerConfig struct {
-		BannerURL      func(childComplexity int, width *int32, height *int32) int
+		BannerURL      func(childComplexity int, width *int32, height *int32, fit *model.FitMode) int
 		Description    func(childComplexity int) int
-		LogoURL        func(childComplexity int, width *int32, height *int32) int
+		LogoURL        func(childComplexity int, width *int32, height *int32, fit *model.FitMode) int
 		Motd           func(childComplexity int) int
 		ServerName     func(childComplexity int) int
 		WelcomeMessage func(childComplexity int) int
@@ -794,7 +794,7 @@ type ComplexityRoot struct {
 	}
 
 	User struct {
-		AvatarURL                   func(childComplexity int, width *int32, height *int32) int
+		AvatarURL                   func(childComplexity int, width *int32, height *int32, fit *model.FitMode) int
 		CreatedAt                   func(childComplexity int) int
 		DisplayName                 func(childComplexity int) int
 		HasVerifiedEmail            func(childComplexity int) int
@@ -1193,8 +1193,8 @@ type ServerResolver interface {
 }
 type ServerConfigResolver interface {
 	ServerName(ctx context.Context, obj *model.ServerConfig) (string, error)
-	LogoURL(ctx context.Context, obj *model.ServerConfig, width *int32, height *int32) (*string, error)
-	BannerURL(ctx context.Context, obj *model.ServerConfig, width *int32, height *int32) (*string, error)
+	LogoURL(ctx context.Context, obj *model.ServerConfig, width *int32, height *int32, fit *model.FitMode) (*string, error)
+	BannerURL(ctx context.Context, obj *model.ServerConfig, width *int32, height *int32, fit *model.FitMode) (*string, error)
 	WelcomeMessage(ctx context.Context, obj *model.ServerConfig) (*string, error)
 	Motd(ctx context.Context, obj *model.ServerConfig) (*string, error)
 	Description(ctx context.Context, obj *model.ServerConfig) (*string, error)
@@ -1206,7 +1206,7 @@ type SubscriptionResolver interface {
 	MyEvents(ctx context.Context) (<-chan core.EventEnvelope, error)
 }
 type UserResolver interface {
-	AvatarURL(ctx context.Context, obj *corev1.User, width *int32, height *int32) (*string, error)
+	AvatarURL(ctx context.Context, obj *corev1.User, width *int32, height *int32, fit *model.FitMode) (*string, error)
 	HasVerifiedEmail(ctx context.Context, obj *corev1.User) (bool, error)
 	VerifiedEmails(ctx context.Context, obj *corev1.User) ([]string, error)
 	Rooms(ctx context.Context, obj *corev1.User, typeArg *model.RoomType) ([]*corev1.Room, error)
@@ -4387,7 +4387,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.ComplexityRoot.ServerConfig.BannerURL(childComplexity, args["width"].(*int32), args["height"].(*int32)), true
+		return e.ComplexityRoot.ServerConfig.BannerURL(childComplexity, args["width"].(*int32), args["height"].(*int32), args["fit"].(*model.FitMode)), true
 	case "ServerConfig.description":
 		if e.ComplexityRoot.ServerConfig.Description == nil {
 			break
@@ -4404,7 +4404,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.ComplexityRoot.ServerConfig.LogoURL(childComplexity, args["width"].(*int32), args["height"].(*int32)), true
+		return e.ComplexityRoot.ServerConfig.LogoURL(childComplexity, args["width"].(*int32), args["height"].(*int32), args["fit"].(*model.FitMode)), true
 	case "ServerConfig.motd":
 		if e.ComplexityRoot.ServerConfig.Motd == nil {
 			break
@@ -4675,7 +4675,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.ComplexityRoot.User.AvatarURL(childComplexity, args["width"].(*int32), args["height"].(*int32)), true
+		return e.ComplexityRoot.User.AvatarURL(childComplexity, args["width"].(*int32), args["height"].(*int32), args["fit"].(*model.FitMode)), true
 	case "User.createdAt":
 		if e.ComplexityRoot.User.CreatedAt == nil {
 			break
@@ -7829,6 +7829,14 @@ func (ec *executionContext) field_ServerConfig_bannerUrl_args(ctx context.Contex
 		return nil, err
 	}
 	args["height"] = arg1
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "fit",
+		func(ctx context.Context, v any) (*model.FitMode, error) {
+			return ec.unmarshalOFitMode2ᚖhmansᚗdeᚋchattoᚋinternalᚋgraphᚋmodelᚐFitMode(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["fit"] = arg2
 	return args, nil
 }
 
@@ -7851,6 +7859,14 @@ func (ec *executionContext) field_ServerConfig_logoUrl_args(ctx context.Context,
 		return nil, err
 	}
 	args["height"] = arg1
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "fit",
+		func(ctx context.Context, v any) (*model.FitMode, error) {
+			return ec.unmarshalOFitMode2ᚖhmansᚗdeᚋchattoᚋinternalᚋgraphᚋmodelᚐFitMode(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["fit"] = arg2
 	return args, nil
 }
 
@@ -8001,6 +8017,14 @@ func (ec *executionContext) field_User_avatarUrl_args(ctx context.Context, rawAr
 		return nil, err
 	}
 	args["height"] = arg1
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "fit",
+		func(ctx context.Context, v any) (*model.FitMode, error) {
+			return ec.unmarshalOFitMode2ᚖhmansᚗdeᚋchattoᚋinternalᚋgraphᚋmodelᚐFitMode(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["fit"] = arg2
 	return args, nil
 }
 
@@ -20534,7 +20558,7 @@ func (ec *executionContext) _ServerConfig_logoUrl(ctx context.Context, field gra
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.Resolvers.ServerConfig().LogoURL(ctx, obj, fc.Args["width"].(*int32), fc.Args["height"].(*int32))
+			return ec.Resolvers.ServerConfig().LogoURL(ctx, obj, fc.Args["width"].(*int32), fc.Args["height"].(*int32), fc.Args["fit"].(*model.FitMode))
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
@@ -20578,7 +20602,7 @@ func (ec *executionContext) _ServerConfig_bannerUrl(ctx context.Context, field g
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.Resolvers.ServerConfig().BannerURL(ctx, obj, fc.Args["width"].(*int32), fc.Args["height"].(*int32))
+			return ec.Resolvers.ServerConfig().BannerURL(ctx, obj, fc.Args["width"].(*int32), fc.Args["height"].(*int32), fc.Args["fit"].(*model.FitMode))
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
@@ -21729,7 +21753,7 @@ func (ec *executionContext) _User_avatarUrl(ctx context.Context, field graphql.C
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.Resolvers.User().AvatarURL(ctx, obj, fc.Args["width"].(*int32), fc.Args["height"].(*int32))
+			return ec.Resolvers.User().AvatarURL(ctx, obj, fc.Args["width"].(*int32), fc.Args["height"].(*int32), fc.Args["fit"].(*model.FitMode))
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
@@ -26486,7 +26510,7 @@ func (ec *executionContext) unmarshalInputUpdateMyPresenceInput(ctx context.Cont
 		switch k {
 		case "status":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("status"))
-			data, err := ec.unmarshalNPresenceStatus2hmansᚗdeᚋchattoᚋinternalᚋgraphᚋmodelᚐPresenceStatus(ctx, v)
+			data, err := ec.unmarshalNPresenceStatusInput2hmansᚗdeᚋchattoᚋinternalᚋgraphᚋmodelᚐPresenceStatusInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -39417,6 +39441,16 @@ func (ec *executionContext) unmarshalNPresenceStatus2hmansᚗdeᚋchattoᚋinter
 }
 
 func (ec *executionContext) marshalNPresenceStatus2hmansᚗdeᚋchattoᚋinternalᚋgraphᚋmodelᚐPresenceStatus(ctx context.Context, sel ast.SelectionSet, v model.PresenceStatus) graphql.Marshaler {
+	return v
+}
+
+func (ec *executionContext) unmarshalNPresenceStatusInput2hmansᚗdeᚋchattoᚋinternalᚋgraphᚋmodelᚐPresenceStatusInput(ctx context.Context, v any) (model.PresenceStatusInput, error) {
+	var res model.PresenceStatusInput
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNPresenceStatusInput2hmansᚗdeᚋchattoᚋinternalᚋgraphᚋmodelᚐPresenceStatusInput(ctx context.Context, sel ast.SelectionSet, v model.PresenceStatusInput) graphql.Marshaler {
 	return v
 }
 

--- a/cli/internal/graph/image_fit.go
+++ b/cli/internal/graph/image_fit.go
@@ -1,0 +1,14 @@
+package graph
+
+import (
+	"strings"
+
+	"hmans.de/chatto/internal/graph/model"
+)
+
+func fitModeString(fit *model.FitMode) string {
+	if fit == nil {
+		return "cover"
+	}
+	return strings.ToLower(string(*fit))
+}

--- a/cli/internal/graph/model/models_gen.go
+++ b/cli/internal/graph/model/models_gen.go
@@ -980,9 +980,9 @@ type Server struct {
 type ServerConfig struct {
 	// Server name, displayed in page titles. Defaults to 'Chatto'.
 	ServerName string `json:"serverName"`
-	// URL to the server logo, if set. Pass width and height for a resized thumbnail.
+	// URL to the server logo, if set. Pass width, height, and fit for a resized thumbnail.
 	LogoURL *string `json:"logoUrl,omitempty"`
-	// URL to the server banner image, if set. Pass width and height for a resized thumbnail.
+	// URL to the server banner image, if set. Pass width, height, and fit for a resized thumbnail.
 	BannerURL *string `json:"bannerUrl,omitempty"`
 	// Welcome message to display on the login screen (Markdown). Null if not configured.
 	WelcomeMessage *string `json:"welcomeMessage,omitempty"`
@@ -1127,7 +1127,7 @@ type UpdateMessageInput struct {
 // Input for updating the current user's presence status.
 type UpdateMyPresenceInput struct {
 	// The presence status to set.
-	Status PresenceStatus `json:"status"`
+	Status PresenceStatusInput `json:"status"`
 }
 
 // Input for updating a user's profile.
@@ -1203,7 +1203,7 @@ type UpdateSettingsInput struct {
 	UserID string `json:"userId"`
 	// IANA timezone name. Set to null to clear (revert to browser default).
 	Timezone *string `json:"timezone,omitempty"`
-	// Time display format. Set to UNSPECIFIED to use browser locale default.
+	// Time display format. Set to AUTO to use browser locale default.
 	TimeFormat *TimeFormat `json:"timeFormat,omitempty"`
 }
 
@@ -1539,6 +1539,68 @@ func (e *PresenceStatus) UnmarshalJSON(b []byte) error {
 }
 
 func (e PresenceStatus) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
+// Presence statuses clients may explicitly set. Going offline is represented by
+// disconnecting and waiting for presence TTL expiry, not by sending OFFLINE.
+type PresenceStatusInput string
+
+const (
+	// User is actively connected.
+	PresenceStatusInputOnline PresenceStatusInput = "ONLINE"
+	// User is connected but idle or inactive.
+	PresenceStatusInputAway PresenceStatusInput = "AWAY"
+	// User has enabled do-not-disturb mode.
+	PresenceStatusInputDoNotDisturb PresenceStatusInput = "DO_NOT_DISTURB"
+)
+
+var AllPresenceStatusInput = []PresenceStatusInput{
+	PresenceStatusInputOnline,
+	PresenceStatusInputAway,
+	PresenceStatusInputDoNotDisturb,
+}
+
+func (e PresenceStatusInput) IsValid() bool {
+	switch e {
+	case PresenceStatusInputOnline, PresenceStatusInputAway, PresenceStatusInputDoNotDisturb:
+		return true
+	}
+	return false
+}
+
+func (e PresenceStatusInput) String() string {
+	return string(e)
+}
+
+func (e *PresenceStatusInput) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = PresenceStatusInput(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid PresenceStatusInput", str)
+	}
+	return nil
+}
+
+func (e PresenceStatusInput) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *PresenceStatusInput) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e PresenceStatusInput) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
 	e.MarshalGQL(&buf)
 	return buf.Bytes(), nil

--- a/cli/internal/graph/model/user_settings.go
+++ b/cli/internal/graph/model/user_settings.go
@@ -10,20 +10,20 @@ import (
 type TimeFormat string
 
 const (
-	TimeFormatUnspecified     TimeFormat = "UNSPECIFIED"
-	TimeFormatTwelveHour      TimeFormat = "TWELVE_HOUR"
-	TimeFormatTwentyFourHour  TimeFormat = "TWENTY_FOUR_HOUR"
+	TimeFormatAuto           TimeFormat = "AUTO"
+	TimeFormatTwelveHour     TimeFormat = "TWELVE_HOUR"
+	TimeFormatTwentyFourHour TimeFormat = "TWENTY_FOUR_HOUR"
 )
 
 var AllTimeFormat = []TimeFormat{
-	TimeFormatUnspecified,
+	TimeFormatAuto,
 	TimeFormatTwelveHour,
 	TimeFormatTwentyFourHour,
 }
 
 func (e TimeFormat) IsValid() bool {
 	switch e {
-	case TimeFormatUnspecified, TimeFormatTwelveHour, TimeFormatTwentyFourHour:
+	case TimeFormatAuto, TimeFormatTwelveHour, TimeFormatTwentyFourHour:
 		return true
 	}
 	return false

--- a/cli/internal/graph/presence.graphqls
+++ b/cli/internal/graph/presence.graphqls
@@ -12,6 +12,19 @@ enum PresenceStatus {
   DO_NOT_DISTURB
 }
 
+"""
+Presence statuses clients may explicitly set. Going offline is represented by
+disconnecting and waiting for presence TTL expiry, not by sending OFFLINE.
+"""
+enum PresenceStatusInput {
+  "User is actively connected."
+  ONLINE
+  "User is connected but idle or inactive."
+  AWAY
+  "User has enabled do-not-disturb mode."
+  DO_NOT_DISTURB
+}
+
 extend type User {
   "Get user's presence status. Returns OFFLINE if not present."
   presenceStatus: PresenceStatus! @goField(forceResolver: true)
@@ -31,5 +44,5 @@ Input for updating the current user's presence status.
 """
 input UpdateMyPresenceInput {
   "The presence status to set."
-  status: PresenceStatus!
+  status: PresenceStatusInput!
 }

--- a/cli/internal/graph/presence.resolvers.go
+++ b/cli/internal/graph/presence.resolvers.go
@@ -7,7 +7,6 @@ package graph
 
 import (
 	"context"
-	"fmt"
 
 	"hmans.de/chatto/internal/graph/model"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
@@ -18,11 +17,6 @@ func (r *mutationResolver) UpdateMyPresence(ctx context.Context, input model.Upd
 	user, err := requireAuth(ctx)
 	if err != nil {
 		return false, err
-	}
-
-	// OFFLINE is not a valid input — going offline means disconnecting (TTL expiry)
-	if input.Status == model.PresenceStatusOffline {
-		return false, fmt.Errorf("cannot set presence to OFFLINE; disconnect instead")
 	}
 
 	if err := r.core.SetPresence(ctx, user.Id, string(input.Status)); err != nil {

--- a/cli/internal/graph/room.resolvers.go
+++ b/cli/internal/graph/room.resolvers.go
@@ -296,7 +296,7 @@ func (r *roomResolver) VoiceCallToken(ctx context.Context, obj *corev1.Room) (*c
 	}
 
 	avatarSize := 96
-	avatarURL, _ := r.core.GetUserAvatarURL(ctx, user.Id, &avatarSize, &avatarSize)
+	avatarURL, _ := r.core.GetUserAvatarURL(ctx, user.Id, &avatarSize, &avatarSize, "cover")
 
 	roomName := core.LiveKitRoomName(r.livekitConfig.ServerID, core.LegacySpaceIDForRoomKind(core.KindOfRoom(obj)), obj.Id)
 	token, err := core.GenerateVoiceCallToken(

--- a/cli/internal/graph/server.graphqls
+++ b/cli/internal/graph/server.graphqls
@@ -6,11 +6,11 @@ type ServerConfig {
   "Server name, displayed in page titles. Defaults to 'Chatto'."
   serverName: String! @goField(forceResolver: true)
 
-  "URL to the server logo, if set. Pass width and height for a resized thumbnail."
-  logoUrl(width: Int, height: Int): String @goField(forceResolver: true)
+  "URL to the server logo, if set. Pass width, height, and fit for a resized thumbnail."
+  logoUrl(width: Int, height: Int, fit: FitMode): String @goField(forceResolver: true)
 
-  "URL to the server banner image, if set. Pass width and height for a resized thumbnail."
-  bannerUrl(width: Int, height: Int): String @goField(forceResolver: true)
+  "URL to the server banner image, if set. Pass width, height, and fit for a resized thumbnail."
+  bannerUrl(width: Int, height: Int, fit: FitMode): String @goField(forceResolver: true)
 
   "Welcome message to display on the login screen (Markdown). Null if not configured."
   welcomeMessage: String @goField(forceResolver: true)

--- a/cli/internal/graph/server.resolvers.go
+++ b/cli/internal/graph/server.resolvers.go
@@ -250,13 +250,13 @@ func (r *serverConfigResolver) ServerName(ctx context.Context, obj *model.Server
 }
 
 // LogoURL is the resolver for the logoUrl field.
-func (r *serverConfigResolver) LogoURL(ctx context.Context, obj *model.ServerConfig, width *int32, height *int32) (*string, error) {
+func (r *serverConfigResolver) LogoURL(ctx context.Context, obj *model.ServerConfig, width *int32, height *int32, fit *model.FitMode) (*string, error) {
 	var w, h *int
 	if width != nil && height != nil {
 		wv, hv := int(*width), int(*height)
 		w, h = &wv, &hv
 	}
-	url, err := r.core.GetServerLogoURL(ctx, w, h)
+	url, err := r.core.GetServerLogoURL(ctx, w, h, fitModeString(fit))
 	if err != nil {
 		return nil, err
 	}
@@ -267,13 +267,13 @@ func (r *serverConfigResolver) LogoURL(ctx context.Context, obj *model.ServerCon
 }
 
 // BannerURL is the resolver for the bannerUrl field.
-func (r *serverConfigResolver) BannerURL(ctx context.Context, obj *model.ServerConfig, width *int32, height *int32) (*string, error) {
+func (r *serverConfigResolver) BannerURL(ctx context.Context, obj *model.ServerConfig, width *int32, height *int32, fit *model.FitMode) (*string, error) {
 	var w, h *int
 	if width != nil && height != nil {
 		wv, hv := int(*width), int(*height)
 		w, h = &wv, &hv
 	}
-	url, err := r.core.GetServerBannerURL(ctx, w, h)
+	url, err := r.core.GetServerBannerURL(ctx, w, h, fitModeString(fit))
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/graph/user.graphqls
+++ b/cli/internal/graph/user.graphqls
@@ -10,8 +10,8 @@ type User {
   displayName: String!
   "When the user account was created. Null for users created before this field was added."
   createdAt: Time
-  "URL to the user's avatar image. Pass width and height for a resized thumbnail."
-  avatarUrl(width: Int, height: Int): String @goField(forceResolver: true)
+  "URL to the user's avatar image. Pass width, height, and fit for a resized thumbnail."
+  avatarUrl(width: Int, height: Int, fit: FitMode): String @goField(forceResolver: true)
   "Whether this user has at least one verified email address."
   hasVerifiedEmail: Boolean! @goField(forceResolver: true)
   """

--- a/cli/internal/graph/user.resolvers.go
+++ b/cli/internal/graph/user.resolvers.go
@@ -16,13 +16,13 @@ import (
 )
 
 // AvatarURL is the resolver for the avatarURL field.
-func (r *userResolver) AvatarURL(ctx context.Context, obj *corev1.User, width *int32, height *int32) (*string, error) {
+func (r *userResolver) AvatarURL(ctx context.Context, obj *corev1.User, width *int32, height *int32, fit *model.FitMode) (*string, error) {
 	var w, h *int
 	if width != nil && height != nil {
 		wv, hv := int(*width), int(*height)
 		w, h = &wv, &hv
 	}
-	url, err := r.core.GetUserAvatarURL(ctx, obj.Id, w, h)
+	url, err := r.core.GetUserAvatarURL(ctx, obj.Id, w, h, fitModeString(fit))
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/graph/user_preferences.graphqls
+++ b/cli/internal/graph/user_preferences.graphqls
@@ -14,7 +14,7 @@ Time display format preference.
 """
 enum TimeFormat {
   "Use browser/locale default."
-  UNSPECIFIED
+  AUTO
   "12-hour format (e.g., 2:30 PM)."
   TWELVE_HOUR
   "24-hour format (e.g., 14:30)."
@@ -30,7 +30,7 @@ input UpdateSettingsInput {
   userId: ID!
   "IANA timezone name. Set to null to clear (revert to browser default)."
   timezone: String
-  "Time display format. Set to UNSPECIFIED to use browser locale default."
+  "Time display format. Set to AUTO to use browser locale default."
   timeFormat: TimeFormat
 }
 

--- a/cli/internal/graph/user_preferences.resolvers.go
+++ b/cli/internal/graph/user_preferences.resolvers.go
@@ -53,7 +53,7 @@ func (r *userResolver) Settings(ctx context.Context, obj *corev1.User) (*model.U
 	// Return default settings if none saved yet
 	if settings == nil {
 		return &model.UserSettings{
-			TimeFormat: model.TimeFormatUnspecified,
+			TimeFormat: model.TimeFormatAuto,
 		}, nil
 	}
 

--- a/cli/internal/graph/user_preferences_helpers.go
+++ b/cli/internal/graph/user_preferences_helpers.go
@@ -25,7 +25,7 @@ func protoTimeFormatToGQL(tf corev1.TimeFormat) model.TimeFormat {
 	case corev1.TimeFormat_TIME_FORMAT_24H:
 		return model.TimeFormatTwentyFourHour
 	default:
-		return model.TimeFormatUnspecified
+		return model.TimeFormatAuto
 	}
 }
 

--- a/cli/internal/graph/user_test.go
+++ b/cli/internal/graph/user_test.go
@@ -70,7 +70,7 @@ func TestUserResolver_AvatarURL(t *testing.T) {
 	resolver := env.resolver.User()
 
 	t.Run("returns nil when no avatar set", func(t *testing.T) {
-		url, err := resolver.AvatarURL(env.ctx, env.testUser, nil, nil)
+		url, err := resolver.AvatarURL(env.ctx, env.testUser, nil, nil, nil)
 		if err != nil {
 			t.Fatalf("expected success, got error: %v", err)
 		}
@@ -80,7 +80,7 @@ func TestUserResolver_AvatarURL(t *testing.T) {
 	})
 
 	t.Run("works without auth context (public field)", func(t *testing.T) {
-		url, err := resolver.AvatarURL(env.unauthContext(), env.testUser, nil, nil)
+		url, err := resolver.AvatarURL(env.unauthContext(), env.testUser, nil, nil, nil)
 		if err != nil {
 			t.Fatalf("expected success, got error: %v", err)
 		}
@@ -91,7 +91,7 @@ func TestUserResolver_AvatarURL(t *testing.T) {
 
 	t.Run("accepts width and height parameters", func(t *testing.T) {
 		w, h := int32(100), int32(100)
-		url, err := resolver.AvatarURL(env.ctx, env.testUser, &w, &h)
+		url, err := resolver.AvatarURL(env.ctx, env.testUser, &w, &h, nil)
 		if err != nil {
 			t.Fatalf("expected success, got error: %v", err)
 		}
@@ -432,7 +432,7 @@ func TestMutation_UpdateMyPresence(t *testing.T) {
 	mutation := env.resolver.Mutation()
 
 	t.Run("authenticated user can set online", func(t *testing.T) {
-		result, err := mutation.UpdateMyPresence(env.authContext(), model.UpdateMyPresenceInput{Status: model.PresenceStatusOnline})
+		result, err := mutation.UpdateMyPresence(env.authContext(), model.UpdateMyPresenceInput{Status: model.PresenceStatusInputOnline})
 		if err != nil {
 			t.Fatalf("expected success, got error: %v", err)
 		}
@@ -442,7 +442,7 @@ func TestMutation_UpdateMyPresence(t *testing.T) {
 	})
 
 	t.Run("authenticated user can set away", func(t *testing.T) {
-		result, err := mutation.UpdateMyPresence(env.authContext(), model.UpdateMyPresenceInput{Status: model.PresenceStatusAway})
+		result, err := mutation.UpdateMyPresence(env.authContext(), model.UpdateMyPresenceInput{Status: model.PresenceStatusInputAway})
 		if err != nil {
 			t.Fatalf("expected success, got error: %v", err)
 		}
@@ -451,15 +451,8 @@ func TestMutation_UpdateMyPresence(t *testing.T) {
 		}
 	})
 
-	t.Run("cannot set offline status", func(t *testing.T) {
-		_, err := mutation.UpdateMyPresence(env.authContext(), model.UpdateMyPresenceInput{Status: model.PresenceStatusOffline})
-		if err == nil {
-			t.Error("expected error when setting OFFLINE status")
-		}
-	})
-
 	t.Run("unauthenticated request fails", func(t *testing.T) {
-		_, err := mutation.UpdateMyPresence(env.unauthContext(), model.UpdateMyPresenceInput{Status: model.PresenceStatusOnline})
+		_, err := mutation.UpdateMyPresence(env.unauthContext(), model.UpdateMyPresenceInput{Status: model.PresenceStatusInputOnline})
 		if !errors.Is(err, ErrNotAuthenticated) {
 			t.Errorf("expected ErrNotAuthenticated, got %v", err)
 		}

--- a/cli/internal/http_server/opengraph.go
+++ b/cli/internal/http_server/opengraph.go
@@ -102,7 +102,7 @@ func (s *HTTPServer) getOpenGraphMeta(ctx context.Context, urlPath string) *Open
 	var defaultImage string
 	if s.core != nil {
 		width, height := 1200, 630
-		bannerURL, err := s.core.GetServerBannerURL(ctx, &width, &height)
+		bannerURL, err := s.core.GetServerBannerURL(ctx, &width, &height, "cover")
 		if err == nil && bannerURL != "" {
 			defaultImage = bannerURL
 		}

--- a/cli/internal/http_server/server_info.go
+++ b/cli/internal/http_server/server_info.go
@@ -85,11 +85,11 @@ func (s *HTTPServer) handleServerInfo(c *gin.Context) {
 	var bannerURL, iconURL string
 	if s.core != nil {
 		bw, bh := 1200, 630
-		if u, err := s.core.GetServerBannerURL(ctx, &bw, &bh); err == nil {
+		if u, err := s.core.GetServerBannerURL(ctx, &bw, &bh, "cover"); err == nil {
 			bannerURL = absolutizeAssetURL(c, u)
 		}
 		lw, lh := 256, 256
-		if u, err := s.core.GetServerLogoURL(ctx, &lw, &lh); err == nil {
+		if u, err := s.core.GetServerLogoURL(ctx, &lw, &lh, "cover"); err == nil {
 			iconURL = absolutizeAssetURL(c, u)
 		}
 	}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -664,7 +664,7 @@ Notes: Asset IDs are globally unique (NanoID), so no kind segment is needed. Cha
 
 ### Dynamic Image Transformation
 
-Chatto supports on-the-fly image transformation for attachments, allowing clients to request images at specific dimensions without pre-generating all possible sizes.
+Chatto supports on-the-fly image transformation for attachments, user avatars, and server branding images, allowing clients to request images at specific dimensions without pre-generating all possible sizes.
 
 **URL Structure:**
 
@@ -710,12 +710,21 @@ URLs are signed with HMAC-SHA256 using a dedicated `signing_secret` (configured 
 
 **GraphQL Integration:**
 
-The `Attachment` type exposes transform parameters as field arguments:
+The `Attachment`, `User`, and `ServerConfig` image fields expose transform parameters as field arguments:
 
 ```graphql
 type Attachment {
   url(width: Int, height: Int, fit: FitMode): String!
   thumbnailUrl(width: Int, height: Int, fit: FitMode): String
+}
+
+type User {
+  avatarUrl(width: Int, height: Int, fit: FitMode): String
+}
+
+type ServerConfig {
+  logoUrl(width: Int, height: Int, fit: FitMode): String
+  bannerUrl(width: Int, height: Int, fit: FitMode): String
 }
 
 enum FitMode {

--- a/docs/fdr/FDR-008-file-attachments-and-video.md
+++ b/docs/fdr/FDR-008-file-attachments-and-video.md
@@ -1,7 +1,7 @@
 # FDR-008: File Attachments & Video Processing
 
 **Status:** Active
-**Last reviewed:** 2026-06-01
+**Last reviewed:** 2026-06-05
 
 ## Overview
 
@@ -13,7 +13,7 @@ Users can attach files to messages — images, videos, documents — via drag-an
 - Draft attachments persist across room switches inside the same session.
 - Default upload size limits: 25 MB for general files, 100 MB for videos when video processing is enabled.
 - Video uploads require server-side video processing to be enabled. When it is disabled, the composer rejects `video/*` files immediately and the GraphQL mutation rejects them before storage.
-- Images are inspected for dimensions at upload time and can be resized at render time via URL parameters (width, height, fit mode).
+- Images are inspected for dimensions at upload time and can be resized at render time via URL parameters (width, height, fit mode). GraphQL exposes the same transform parameters for attachments, user avatars, and server branding images.
 - When enabled, videos and animated GIFs are processed by the current server process after asset creation and message submission scheduling. This is best-effort and intentionally simple until a real durable worker queue exists.
 - Processing status: durable COMPLETED / FAILED outcomes are stored as room events. There is no new runtime KV state for video progress; failed videos still show the original message, and the UI falls back to the original upload when it is available.
 - A thumbnail is generated from an early video frame.

--- a/docs/fdr/FDR-022-user-profile.md
+++ b/docs/fdr/FDR-022-user-profile.md
@@ -1,7 +1,7 @@
 # FDR-022: User Profile
 
 **Status:** Active
-**Last reviewed:** 2026-06-02
+**Last reviewed:** 2026-06-05
 
 ## Overview
 
@@ -13,7 +13,7 @@ A user's profile carries the public identity they present to the rest of the ser
 - **Login (username)** — editable by the user with a 30-day cooldown between changes. Each successful change records a timestamp; subsequent changes within the window are rejected with a clear error message.
 - **Case-only changes** (e.g., `alice` → `Alice`) bypass the cooldown.
 - **Avatar** — users upload an image; the server resizes to 256×256 max and stores it as lossless WebP. The old avatar is deleted after the new one is committed. Users can also delete their avatar (falling back to an initial-letter placeholder).
-- **Settings** — currently timezone (IANA name, e.g., `Europe/Berlin`) and time format (12-hour / 24-hour). Stored server-side so they sync across devices. If not set, the frontend uses the browser timezone.
+- **Settings** — currently timezone (IANA name, e.g., `Europe/Berlin`) and time format (browser default / 12-hour / 24-hour). Stored server-side so they sync across devices. If not set, the frontend uses the browser timezone and locale time-format default.
 - **Admin overrides** — operators with the right permissions can update other users' profiles, bypass the login cooldown, clear the cooldown so the user can change again before the 30 days expire, and force-delete an avatar.
 
 ## Design Decisions

--- a/frontend/src/lib/gql/graphql.ts
+++ b/frontend/src/lib/gql/graphql.ts
@@ -1896,6 +1896,19 @@ export enum PresenceStatus {
   Online = 'ONLINE'
 }
 
+/**
+ * Presence statuses clients may explicitly set. Going offline is represented by
+ * disconnecting and waiting for presence TTL expiry, not by sending OFFLINE.
+ */
+export enum PresenceStatusInput {
+  /** User is connected but idle or inactive. */
+  Away = 'AWAY',
+  /** User has enabled do-not-disturb mode. */
+  DoNotDisturb = 'DO_NOT_DISTURB',
+  /** User is actively connected. */
+  Online = 'ONLINE'
+}
+
 /** One named diagnostic count/byte bucket for a projection. */
 export type ProjectionMetric = {
   __typename?: 'ProjectionMetric';
@@ -2812,11 +2825,11 @@ export type ServerViewerCanManageUserArgs = {
  */
 export type ServerConfig = {
   __typename?: 'ServerConfig';
-  /** URL to the server banner image, if set. Pass width and height for a resized thumbnail. */
+  /** URL to the server banner image, if set. Pass width, height, and fit for a resized thumbnail. */
   bannerUrl?: Maybe<Scalars['String']['output']>;
   /** Short description of this server, used for OG link-preview metadata and the welcome card. Null if not configured. */
   description?: Maybe<Scalars['String']['output']>;
-  /** URL to the server logo, if set. Pass width and height for a resized thumbnail. */
+  /** URL to the server logo, if set. Pass width, height, and fit for a resized thumbnail. */
   logoUrl?: Maybe<Scalars['String']['output']>;
   /** Message of the Day, displayed in the header bar. Null if not configured. */
   motd?: Maybe<Scalars['String']['output']>;
@@ -2832,6 +2845,7 @@ export type ServerConfig = {
  * These are settings that can be changed by admins at runtime.
  */
 export type ServerConfigBannerUrlArgs = {
+  fit?: InputMaybe<FitMode>;
   height?: InputMaybe<Scalars['Int']['input']>;
   width?: InputMaybe<Scalars['Int']['input']>;
 };
@@ -2842,6 +2856,7 @@ export type ServerConfigBannerUrlArgs = {
  * These are settings that can be changed by admins at runtime.
  */
 export type ServerConfigLogoUrlArgs = {
+  fit?: InputMaybe<FitMode>;
   height?: InputMaybe<Scalars['Int']['input']>;
   width?: InputMaybe<Scalars['Int']['input']>;
 };
@@ -3076,12 +3091,12 @@ export type TierRoles = {
 
 /** Time display format preference. */
 export enum TimeFormat {
+  /** Use browser/locale default. */
+  Auto = 'AUTO',
   /** 12-hour format (e.g., 2:30 PM). */
   TwelveHour = 'TWELVE_HOUR',
   /** 24-hour format (e.g., 14:30). */
-  TwentyFourHour = 'TWENTY_FOUR_HOUR',
-  /** Use browser/locale default. */
-  Unspecified = 'UNSPECIFIED'
+  TwentyFourHour = 'TWENTY_FOUR_HOUR'
 }
 
 /** Input for unarchiving a room. */
@@ -3117,7 +3132,7 @@ export type UpdateMessageInput = {
 /** Input for updating the current user's presence status. */
 export type UpdateMyPresenceInput = {
   /** The presence status to set. */
-  status: PresenceStatus;
+  status: PresenceStatusInput;
 };
 
 /** Input for updating a user's profile. */
@@ -3191,7 +3206,7 @@ export type UpdateServerInput = {
  * Only provided fields will be updated; omitted fields are left unchanged.
  */
 export type UpdateSettingsInput = {
-  /** Time display format. Set to UNSPECIFIED to use browser locale default. */
+  /** Time display format. Set to AUTO to use browser locale default. */
   timeFormat?: InputMaybe<TimeFormat>;
   /** IANA timezone name. Set to null to clear (revert to browser default). */
   timezone?: InputMaybe<Scalars['String']['input']>;
@@ -3222,7 +3237,7 @@ export type UploadServerLogoInput = {
 /** A Chatto User. */
 export type User = {
   __typename?: 'User';
-  /** URL to the user's avatar image. Pass width and height for a resized thumbnail. */
+  /** URL to the user's avatar image. Pass width, height, and fit for a resized thumbnail. */
   avatarUrl?: Maybe<Scalars['String']['output']>;
   /** When the user account was created. Null for users created before this field was added. */
   createdAt?: Maybe<Scalars['Time']['output']>;
@@ -3270,6 +3285,7 @@ export type User = {
 
 /** A Chatto User. */
 export type UserAvatarUrlArgs = {
+  fit?: InputMaybe<FitMode>;
   height?: InputMaybe<Scalars['Int']['input']>;
   width?: InputMaybe<Scalars['Int']['input']>;
 };

--- a/frontend/src/lib/presenceTracking.ts
+++ b/frontend/src/lib/presenceTracking.ts
@@ -1,6 +1,6 @@
 import type { Client } from '@urql/svelte';
 import { graphql } from './gql';
-import { PresenceStatus } from './gql/graphql';
+import { PresenceStatus, PresenceStatusInput } from './gql/graphql';
 
 const UpdateMyPresenceDoc = graphql(`
   mutation UpdateMyPresence($input: UpdateMyPresenceInput!) {
@@ -15,6 +15,17 @@ type ActivityState = 'active' | 'idle' | 'hidden';
 
 // Module-level singleton to prevent duplicate tracking
 let initialized = false;
+
+function presenceInputToStatus(status: PresenceStatusInput): PresenceStatus {
+  switch (status) {
+    case PresenceStatusInput.Online:
+      return PresenceStatus.Online;
+    case PresenceStatusInput.Away:
+      return PresenceStatus.Away;
+    case PresenceStatusInput.DoNotDisturb:
+      return PresenceStatus.DoNotDisturb;
+  }
+}
 
 /**
  * Initialize presence tracking. Uses idle detection and page visibility
@@ -36,8 +47,8 @@ export function initPresenceTracking(
   let idleTimer: ReturnType<typeof setTimeout> | null = null;
   let hiddenTimer: ReturnType<typeof setTimeout> | null = null;
 
-  function setPresenceStatus(status: PresenceStatus) {
-    onStatusChange?.(status);
+  function setPresenceStatus(status: PresenceStatusInput) {
+    onStatusChange?.(presenceInputToStatus(status));
     for (const client of getClients()) {
       client
         .mutation(UpdateMyPresenceDoc, { input: { status } })
@@ -56,11 +67,11 @@ export function initPresenceTracking(
     currentState = newState;
 
     if (newState === 'active') {
-      setPresenceStatus(PresenceStatus.Online);
+      setPresenceStatus(PresenceStatusInput.Online);
       resetIdleTimer();
     } else {
       // idle or hidden
-      setPresenceStatus(PresenceStatus.Away);
+      setPresenceStatus(PresenceStatusInput.Away);
     }
   }
 

--- a/frontend/src/lib/state/userSettings.svelte.ts
+++ b/frontend/src/lib/state/userSettings.svelte.ts
@@ -13,7 +13,7 @@ export class UserSettingsState {
   timezone = $state<string | null>(null);
 
   /** Time display format preference. */
-  timeFormat = $state<TimeFormat>(TimeFormat.Unspecified);
+  timeFormat = $state<TimeFormat>(TimeFormat.Auto);
 
   /**
    * Effective timezone for Intl.DateTimeFormat.
@@ -42,7 +42,7 @@ export class UserSettingsState {
       this.timeFormat = settings.timeFormat;
     } else {
       this.timezone = null;
-      this.timeFormat = TimeFormat.Unspecified;
+      this.timeFormat = TimeFormat.Auto;
     }
   }
 }

--- a/frontend/src/routes/chat/[serverId]/settings/preferences/+page.svelte
+++ b/frontend/src/routes/chat/[serverId]/settings/preferences/+page.svelte
@@ -171,7 +171,7 @@
 
   const timeFormatOptions = [
     {
-      value: TimeFormat.Unspecified,
+      value: TimeFormat.Auto,
       label: 'Browser default',
       description: 'Use your browser locale to determine 12h or 24h format'
     },


### PR DESCRIPTION
Fixes #81.

- Renames the public GraphQL time-format default from `UNSPECIFIED` to `AUTO`.
- Adds `PresenceStatusInput` so `updateMyPresence` cannot accept `OFFLINE`.
- Adds `fit: FitMode` to `User.avatarUrl`, `ServerConfig.logoUrl`, and `ServerConfig.bannerUrl`, preserving `cover` as the default.
- Updates generated GraphQL artifacts plus [FDR-008](docs/fdr/FDR-008-file-attachments-and-video.md), [FDR-022](docs/fdr/FDR-022-user-profile.md), and [ARCHITECTURE](docs/ARCHITECTURE.md).

Verified with `mise run codegen-cli`, `mise run codegen-frontend`, `mise exec -- pnpm check`, `mise exec -- go test ./internal/graph ./internal/core`, and `mise exec -- go test -tags test_endpoints ./internal/http_server`.
