### PR TITLE
fix: require mandatory SMTP TLS by default

### DIFF
--- a/cli/chatto.toml
+++ b/cli/chatto.toml
@@ -32,6 +32,7 @@ client_secret = 'iARXOaPkiIDxdNRX2N9uJmQf0aXIfwUE'
 enabled = true
 host = 'mailpit.chatto-tools.orb.local'
 port = 1025
+tls = 'opportunistic'
 from = 'Chatto Local Development <chatto@chatto.run>'
 
 [video]

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -337,14 +337,33 @@ func (c *OwnersConfig) IsServerOwnerEmail(email string) bool {
 	return false
 }
 
+// SMTPTLSPolicy controls how the SMTP client negotiates STARTTLS.
+type SMTPTLSPolicy string
+
+const (
+	SMTPTLSMandatory     SMTPTLSPolicy = "mandatory"
+	SMTPTLSOpportunistic SMTPTLSPolicy = "opportunistic"
+)
+
+// TLSPolicyOrDefault returns the configured SMTP TLS policy, defaulting to
+// mandatory STARTTLS so transactional email tokens are not sent in plaintext.
+func (c *SMTPConfig) TLSPolicyOrDefault() SMTPTLSPolicy {
+	policy := SMTPTLSPolicy(strings.ToLower(strings.TrimSpace(string(c.TLS))))
+	if policy == "" {
+		return SMTPTLSMandatory
+	}
+	return policy
+}
+
 // SMTPConfig contains settings for sending transactional emails.
 type SMTPConfig struct {
-	Enabled  bool   `toml:"enabled" env:"CHATTO_SMTP_ENABLED" comment:"Enable SMTP for sending transactional emails (verification, password reset, etc.)."`
-	Host     string `toml:"host" env:"CHATTO_SMTP_HOST" comment:"SMTP server hostname. Example: smtp.example.com"`
-	Port     int    `toml:"port" env:"CHATTO_SMTP_PORT" comment:"SMTP server port. Common values: 587 (TLS), 465 (SSL), 25 (unencrypted)."`
-	Username string `toml:"username" env:"CHATTO_SMTP_USERNAME" comment:"SMTP authentication username."`
-	Password string `toml:"password" env:"CHATTO_SMTP_PASSWORD" comment:"SMTP authentication password. NEVER SHARE THIS!"`
-	From     string `toml:"from" env:"CHATTO_SMTP_FROM" comment:"From address for outgoing emails. Example: noreply@example.com"`
+	Enabled  bool          `toml:"enabled" env:"CHATTO_SMTP_ENABLED" comment:"Enable SMTP for sending transactional emails (verification, password reset, etc.)."`
+	Host     string        `toml:"host" env:"CHATTO_SMTP_HOST" comment:"SMTP server hostname. Example: smtp.example.com"`
+	Port     int           `toml:"port" env:"CHATTO_SMTP_PORT" comment:"SMTP server port. Common value: 587 (STARTTLS)."`
+	TLS      SMTPTLSPolicy `toml:"tls,commented" env:"CHATTO_SMTP_TLS" comment:"SMTP TLS policy: mandatory (default) or opportunistic. Opportunistic allows plaintext fallback and should only be used when explicitly required."`
+	Username string        `toml:"username" env:"CHATTO_SMTP_USERNAME" comment:"SMTP authentication username."`
+	Password string        `toml:"password" env:"CHATTO_SMTP_PASSWORD" comment:"SMTP authentication password. NEVER SHARE THIS!"`
+	From     string        `toml:"from" env:"CHATTO_SMTP_FROM" comment:"From address for outgoing emails. Example: noreply@example.com"`
 }
 
 // PushConfig contains settings for Web Push notifications.
@@ -534,6 +553,11 @@ func (c *ChattoConfig) Validate() error {
 	}
 
 	// SMTP configuration
+	switch c.SMTP.TLSPolicyOrDefault() {
+	case SMTPTLSMandatory, SMTPTLSOpportunistic:
+	default:
+		errs = append(errs, "smtp.tls must be one of: mandatory, opportunistic")
+	}
 	if c.SMTP.Enabled {
 		if c.SMTP.Host == "" {
 			errs = append(errs, "smtp.host is required when SMTP is enabled")

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -126,6 +126,33 @@ signing_secret = "file-assets-secret"
 	}
 }
 
+func TestReadConfig_SMTPPolicyFromEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(originalDir) })
+
+	t.Setenv("CHATTO_WEBSERVER_PORT", "4000")
+	t.Setenv("CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET", "test-cookie-secret")
+	t.Setenv("CHATTO_CORE_SECRET_KEY", "test-core-secret")
+	t.Setenv("CHATTO_CORE_ASSETS_SIGNING_SECRET", "test-assets-secret")
+	t.Setenv("CHATTO_SMTP_TLS", "opportunistic")
+
+	cfg, err := ReadConfig("")
+	if err != nil {
+		t.Fatalf("ReadConfig() failed: %v", err)
+	}
+
+	if got := cfg.SMTP.TLSPolicyOrDefault(); got != SMTPTLSOpportunistic {
+		t.Errorf("expected SMTP TLS policy %q from env, got %q", SMTPTLSOpportunistic, got)
+	}
+}
+
 func TestTLSConfig_CacheDirOrDefault(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -708,6 +735,36 @@ func TestChattoConfig_Validate_SMTP(t *testing.T) {
 				c.SMTP.From = "noreply@example.com"
 			},
 			wantError: false,
+		},
+		{
+			name: "valid config with explicit mandatory SMTP TLS",
+			modify: func(c *ChattoConfig) {
+				c.SMTP.Enabled = true
+				c.SMTP.Host = "smtp.example.com"
+				c.SMTP.Port = 587
+				c.SMTP.TLS = SMTPTLSMandatory
+				c.SMTP.From = "noreply@example.com"
+			},
+			wantError: false,
+		},
+		{
+			name: "valid config with explicit opportunistic SMTP TLS",
+			modify: func(c *ChattoConfig) {
+				c.SMTP.Enabled = true
+				c.SMTP.Host = "smtp.example.com"
+				c.SMTP.Port = 587
+				c.SMTP.TLS = SMTPTLSOpportunistic
+				c.SMTP.From = "noreply@example.com"
+			},
+			wantError: false,
+		},
+		{
+			name: "invalid SMTP TLS policy fails",
+			modify: func(c *ChattoConfig) {
+				c.SMTP.TLS = "plaintext"
+			},
+			wantError: true,
+			errorMsg:  "smtp.tls must be one of: mandatory, opportunistic",
 		},
 		{
 			name: "SMTP enabled without host fails",

--- a/cli/internal/email/email.go
+++ b/cli/internal/email/email.go
@@ -67,7 +67,7 @@ func (m *Mailer) SendContext(ctx context.Context, msg Message) error {
 	// Build client options
 	opts := []mail.Option{
 		mail.WithPort(m.config.Port),
-		mail.WithTLSPortPolicy(mail.TLSOpportunistic),
+		mail.WithTLSPortPolicy(mailTLSPolicy(m.config)),
 		mail.WithHELO("localhost"), // Use consistent HELO domain across all environments
 	}
 
@@ -96,4 +96,13 @@ func (m *Mailer) SendContext(ctx context.Context, msg Message) error {
 // IsEnabled returns whether SMTP is configured and enabled.
 func (m *Mailer) IsEnabled() bool {
 	return m.config.Enabled
+}
+
+func mailTLSPolicy(cfg config.SMTPConfig) mail.TLSPolicy {
+	switch cfg.TLSPolicyOrDefault() {
+	case config.SMTPTLSOpportunistic:
+		return mail.TLSOpportunistic
+	default:
+		return mail.TLSMandatory
+	}
 }

--- a/cli/internal/email/email_integration_test.go
+++ b/cli/internal/email/email_integration_test.go
@@ -35,6 +35,7 @@ func TestMailer_Integration_SendSuccess(t *testing.T) {
 		Enabled: true,
 		Host:    "127.0.0.1",
 		Port:    server.PortNumber(),
+		TLS:     config.SMTPTLSOpportunistic,
 		From:    "sender@example.com",
 	})
 
@@ -85,6 +86,30 @@ func TestMailer_Integration_SendSuccess(t *testing.T) {
 	}
 }
 
+func TestMailer_Integration_DefaultTLSRejectsPlaintextServer(t *testing.T) {
+	server := startMockServer(t, smtpmock.ConfigurationAttr{})
+
+	mailer := email.NewMailer(config.SMTPConfig{
+		Enabled: true,
+		Host:    "127.0.0.1",
+		Port:    server.PortNumber(),
+		From:    "sender@example.com",
+	})
+
+	err := mailer.Send(email.Message{
+		To:      "recipient@example.com",
+		Subject: "Secure Test",
+		Body:    "Testing default TLS policy",
+	})
+	if err == nil {
+		t.Fatal("expected error when plaintext server does not support STARTTLS, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "STARTTLS") {
+		t.Errorf("expected STARTTLS-related error, got %q", err.Error())
+	}
+}
+
 func TestMailer_Integration_AuthNotSupported(t *testing.T) {
 	// go-smtp-mock does not support SMTP AUTH
 	// This test verifies that we get an appropriate error when auth is configured
@@ -95,6 +120,7 @@ func TestMailer_Integration_AuthNotSupported(t *testing.T) {
 		Enabled:  true,
 		Host:     "127.0.0.1",
 		Port:     server.PortNumber(),
+		TLS:      config.SMTPTLSOpportunistic,
 		From:     "sender@example.com",
 		Username: "testuser",
 		Password: "testpass",
@@ -171,6 +197,7 @@ func TestMailer_Integration_InvalidToAddress(t *testing.T) {
 		Enabled: true,
 		Host:    "127.0.0.1",
 		Port:    server.PortNumber(),
+		TLS:     config.SMTPTLSOpportunistic,
 		From:    "sender@example.com",
 	})
 
@@ -195,6 +222,7 @@ func TestMailer_Integration_MultipleMessages(t *testing.T) {
 		Enabled: true,
 		Host:    "127.0.0.1",
 		Port:    server.PortNumber(),
+		TLS:     config.SMTPTLSOpportunistic,
 		From:    "sender@example.com",
 	})
 
@@ -230,6 +258,7 @@ func TestMailer_Integration_BlacklistedRecipient(t *testing.T) {
 		Enabled: true,
 		Host:    "127.0.0.1",
 		Port:    server.PortNumber(),
+		TLS:     config.SMTPTLSOpportunistic,
 		From:    "sender@example.com",
 	})
 

--- a/cli/internal/email/email_test.go
+++ b/cli/internal/email/email_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/wneessen/go-mail"
+
 	"hmans.de/chatto/internal/config"
 )
 
@@ -40,6 +42,43 @@ func TestMailer_IsEnabled(t *testing.T) {
 			mailer := NewMailer(cfg)
 			if got := mailer.IsEnabled(); got != tt.expected {
 				t.Errorf("IsEnabled() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMailTLSPolicy(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  config.SMTPConfig
+		want mail.TLSPolicy
+	}{
+		{
+			name: "defaults to mandatory",
+			cfg:  config.SMTPConfig{},
+			want: mail.TLSMandatory,
+		},
+		{
+			name: "mandatory",
+			cfg:  config.SMTPConfig{TLS: config.SMTPTLSMandatory},
+			want: mail.TLSMandatory,
+		},
+		{
+			name: "opportunistic",
+			cfg:  config.SMTPConfig{TLS: config.SMTPTLSOpportunistic},
+			want: mail.TLSOpportunistic,
+		},
+		{
+			name: "unknown falls back to mandatory",
+			cfg:  config.SMTPConfig{TLS: "unexpected"},
+			want: mail.TLSMandatory,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mailTLSPolicy(tt.cfg); got != tt.want {
+				t.Errorf("mailTLSPolicy() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/docs-website/src/content/docs/guides/dockercompose.mdx
+++ b/docs-website/src/content/docs/guides/dockercompose.mdx
@@ -237,6 +237,7 @@ Required for email verification and password reset. Add to `.env`:
 CHATTO_SMTP_ENABLED=true
 CHATTO_SMTP_HOST=smtp.example.com
 CHATTO_SMTP_PORT=587
+CHATTO_SMTP_TLS=mandatory
 CHATTO_SMTP_USERNAME=your-username
 CHATTO_SMTP_PASSWORD=your-password
 CHATTO_SMTP_FROM=noreply@example.com

--- a/docs-website/src/content/docs/reference/environment-variables.mdx
+++ b/docs-website/src/content/docs/reference/environment-variables.mdx
@@ -230,7 +230,11 @@ Only used when `storage_backend` is set to `s3`. See the [S3 Storage guide](/gui
 </EnvVar>
 
 <EnvVar name="CHATTO_SMTP_PORT" toml="smtp.port">
-  SMTP port. Common values: `587` (TLS), `465` (SSL), `25` (unencrypted).
+  SMTP port. Common value: `587` (STARTTLS).
+</EnvVar>
+
+<EnvVar name="CHATTO_SMTP_TLS" toml="smtp.tls" default="mandatory">
+  SMTP TLS policy. Use `mandatory` to require STARTTLS. Use `opportunistic` only when the SMTP server cannot support mandatory STARTTLS and plaintext fallback is explicitly acceptable.
 </EnvVar>
 
 <EnvVar name="CHATTO_SMTP_USERNAME" toml="smtp.username">

--- a/examples/dockercompose/.env.example
+++ b/examples/dockercompose/.env.example
@@ -29,6 +29,7 @@ CHATTO_LIVEKIT_API_SECRET=your-api-secret
 # CHATTO_SMTP_ENABLED=true
 # CHATTO_SMTP_HOST=smtp.example.com
 # CHATTO_SMTP_PORT=587
+# CHATTO_SMTP_TLS=mandatory
 # CHATTO_SMTP_USERNAME=your-smtp-username
 # CHATTO_SMTP_PASSWORD=your-smtp-password
 # CHATTO_SMTP_FROM=noreply@example.com

--- a/examples/k8s/secrets.yaml
+++ b/examples/k8s/secrets.yaml
@@ -34,6 +34,7 @@ stringData:
   # CHATTO_SMTP_ENABLED: "true"
   # CHATTO_SMTP_HOST: "smtp.example.com"
   # CHATTO_SMTP_PORT: "587"
+  # CHATTO_SMTP_TLS: "mandatory"
   # CHATTO_SMTP_USERNAME: "your-smtp-username"
   # CHATTO_SMTP_PASSWORD: "your-smtp-password"
   # CHATTO_SMTP_FROM: "noreply@example.com"


### PR DESCRIPTION
- Require mandatory STARTTLS by default for SMTP email and add `smtp.tls` / `CHATTO_SMTP_TLS` with explicit `opportunistic` opt-in.
- Update the local Mailpit dev config plus Docker Compose, Kubernetes, and docs examples to document the TLS policy.
- Add config and mailer coverage for TLS policy validation, env parsing, default mapping, and plaintext-server rejection.

Fixes #226

Tests:
- `mise x -- go test ./internal/config ./internal/email -timeout 60s`
