### PR TITLE
fix: autofocus login identifier field

### DIFF
--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -182,6 +182,7 @@
           disabled={isLoading}
           required
           autocomplete="username"
+          autofocus
         />
 
         <TextInput


### PR DESCRIPTION
## Changes

- Autofocuses the username/email field on the login form so users can start typing immediately.

## Verification

- `npx @sveltejs/mcp svelte-autofixer ./src/routes/login/+page.svelte --svelte-version 5`
- `mise x -- pnpm check`
