### PR TITLE
docs: clarify post-time mention resolution

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -775,8 +775,9 @@ Messages are persisted as durable `EVT` facts. Public timeline facts (`MessagePo
 **@Mentions:**
 
 - `@username` patterns in message body are extracted via regex (ASCII alphanumeric, underscore, hyphen)
-- Usernames are resolved to user IDs; only space members are included (non-members silently ignored)
+- Usernames are resolved to user IDs; only server members are included (non-members silently ignored)
 - `MessagePostedEvent.mentioned_user_ids` contains resolved user IDs
+- Mention resolution is post-time only; later `MessageEditedEvent` facts update body content but do not add, remove, dismiss, or re-send mention notifications
 - Pending mention state is a notification record in `RUNTIME_STATE` (`notification.{userId}.{notificationId}`); sidebar orange dots derive from pending notifications, not a separate mention flag.
 - Live notification published to `live.sync.user.{userId}.mentioned` for toast display
 - Mention notifications are dismissed when the user views the relevant room or thread, or explicitly dismisses them from the notification center.

--- a/docs/fdr/FDR-004-message-editing-and-deletion.md
+++ b/docs/fdr/FDR-004-message-editing-and-deletion.md
@@ -13,6 +13,7 @@ Authors can edit and delete their own messages; moderators with the right permis
 - Only the message body text can be edited. Attachments aren't editable as text but can be removed individually.
 - Deletions remove the message body and all attachments and replace the rendered message with a "[Message deleted]" placeholder.
 - Deleting an already-deleted message is a no-op.
+- Editing a message does not re-resolve mentions. Mentions and mention notifications remain tied to the original posted message.
 - Editing or deleting a thread reply that was echoed to the channel propagates to both visible artifacts automatically through the echo's `echoOfEventId` link.
 - Deleting the echo artifact itself hides only the room-timeline echo. The original thread reply remains readable inside the thread.
 - Individual attachments and link previews can be removed from a message by the author without deleting the whole message.
@@ -37,13 +38,19 @@ Authors can edit and delete their own messages; moderators with the right permis
 **Why:** A non-OCC update would risk silently overwriting concurrent edits — particularly bad when a moderator and the author both edit a message at once. See ADR-016.
 **Tradeoff:** Clients need retry logic. In practice, conflicts are rare enough that a single retry almost always succeeds.
 
-### 4. Echo propagation
+### 4. Edits don't re-resolve mentions
+
+**Decision:** Editing a message changes the visible body but does not add, remove, dismiss, or re-send mention notifications.
+**Why:** Mentions are post-time attention facts, not mutable properties of the latest body. This prevents retroactive pings and keeps edit replay independent from mutable usernames and private body payload retention. See FDR-006.
+**Tradeoff:** If an author needs to notify someone they forgot, they must send a new message. If they remove an `@name` while editing, the original notification still reflects that the mention happened.
+
+### 5. Echo propagation
 
 **Decision:** Thread replies and their channel echoes are separate message events linked by `echoOfEventId`. An edit or delete targeting the original reply is applied to both visible artifacts by the read model. A delete targeting the echo's own event ID hides only the echo artifact from the room timeline.
 **Why:** Message identity belongs to the EVT envelope, and `MessagePostedEvent` remains payload-only. The link preserves the user-facing "same reply shown twice" behavior without duplicating envelope metadata into payload fields. See FDR-003.
 **Tradeoff:** Frontend has to distinguish direct echo deletes from original-reply deletes: direct echo deletes remove the echo row, while original deletes tombstone any loaded echoes.
 
-### 5. Delete physically removes the body payload, not just hides it
+### 6. Delete physically removes the body payload, not just hides it
 
 **Decision:** Message body content is stored in private body payload events separate from public post/edit facts. Delete appends the public retraction fact, removes attachments from storage, and securely deletes body payload events where the storage backend supports it. Only the placeholder rendering remains.
 **Why:** GDPR. Soft-delete leaves user-generated content in the database, which is the wrong default for an open-source chat app where users expect "delete" to mean delete. Separating public message facts from body payloads preserves the conversation audit trail while allowing body material to be removed. See ADR-007.
@@ -57,4 +64,4 @@ Authors can edit and delete their own messages; moderators with the right permis
 ## Related
 
 - **ADRs:** ADR-007 (per-user encryption with crypto-shredding), ADR-011 (message body/event split), ADR-016 (OCC for message publishing), ADR-033 (event-sourced state), ADR-034 (single event stream), ADR-038 (room-owned thread state)
-- **FDRs:** FDR-002 (Replies & Threads), FDR-003 (Thread Reply Echo)
+- **FDRs:** FDR-002 (Replies & Threads), FDR-003 (Thread Reply Echo), FDR-006 (@Mentions)

--- a/docs/fdr/FDR-006-mentions.md
+++ b/docs/fdr/FDR-006-mentions.md
@@ -1,7 +1,7 @@
 # FDR-006: @Mentions
 
 **Status:** Active
-**Last reviewed:** 2026-05-27
+**Last reviewed:** 2026-06-05
 
 ## Overview
 
@@ -16,6 +16,7 @@ Users can mention each other in messages with `@username` syntax. A mention noti
 - Mentions inside code blocks, pre-formatted text, and blockquotes are not styled — they render as plain text.
 - Mentioning yourself does not produce a notification.
 - Mentioning a user who isn't a member of the server leaves the `@name` as plain text — the mention is not delivered.
+- Mentions are resolved when a message is first posted. Editing a message later does not add, remove, dismiss, or re-send mention notifications.
 
 ## Design Decisions
 
@@ -31,19 +32,25 @@ Users can mention each other in messages with `@username` syntax. A mention noti
 **Why:** Broadcast mentions are a common source of noise and abuse in chat apps. Without them, the cost of mentioning is bounded.
 **Tradeoff:** Operators who want a "shout into the room" mechanism have to use room-wide notifications (see FDR-012, `ALL_MESSAGES` notification level) — which is opt-in per user per room and lower-stakes.
 
-### 3. Echo events carry mentions but don't re-notify
+### 3. Mentions are post-time facts
+
+**Decision:** Mention delivery is decided when the message is posted. Later edits may change the visible message body, but they do not re-resolve mentions or change who was notified by the original post.
+**Why:** A mention notification is an attention event that already happened. Re-resolving mentions on edit would allow quiet retroactive pings, would make notifications depend on mutable usernames and edited body text, and would complicate replay now that message bodies are private payload facts.
+**Tradeoff:** An author who forgot to mention someone must send a new message rather than editing the old one to ping them. Removing an `@name` from the edited body also does not revoke an already-created notification.
+
+### 4. Echo events carry mentions but don't re-notify
 
 **Decision:** When a thread reply is echoed to the channel, `mentionedUserIds` is copied to the echo. The echo doesn't fire a second notification — the original reply already did.
 **Why:** The echo's mention rendering (highlight, link to profile) needs the field present, but the user shouldn't get notified twice. See FDR-003.
 **Tradeoff:** The frontend has to know that echo mentions don't trigger room-level mention indicators twice. The backend skips the notification on echo events.
 
-### 4. Mute trumps mention
+### 5. Mute trumps mention
 
 **Decision:** If the recipient has muted the room, the mention is rendered but does not produce a notification.
 **Why:** Mute is the user's strongest signal that they don't want pings from this room. Honoring it for everything except mentions would create surprise notifications.
 **Tradeoff:** Users in muted rooms might miss directed pings. The mute affordance is loud enough that this is a reasonable default; users who want differently shouldn't mute.
 
-### 5. Mention attention state is a notification
+### 6. Mention attention state is a notification
 
 **Decision:** A delivered mention creates a pending notification. Sidebar mention dots derive from pending notifications, not from a separate room-level mention-status key.
 **Why:** Mention attention state has the same lifecycle as other notifications: it is pending until the user views or dismisses it, syncs across devices, and expires with notification retention. Keeping it in the notification model avoids duplicated state.

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -13,9 +13,9 @@ See [`.claude/skills/fdr/SKILL.md`](../../.claude/skills/fdr/SKILL.md) for the F
 | [FDR-001](FDR-001-roles-and-permissions.md) | Roles & Permissions (RBAC) | Active | 2026-05-31 |
 | [FDR-002](FDR-002-replies-and-threads.md) | Replies & Threads | Active | 2026-05-19 |
 | [FDR-003](FDR-003-thread-reply-echo.md) | Thread Reply Echo | Active | 2026-06-01 |
-| [FDR-004](FDR-004-message-editing-and-deletion.md) | Message Editing & Deletion | Active | 2026-06-01 |
+| [FDR-004](FDR-004-message-editing-and-deletion.md) | Message Editing & Deletion | Active | 2026-06-05 |
 | [FDR-005](FDR-005-reactions.md) | Reactions | Active | 2026-05-19 |
-| [FDR-006](FDR-006-mentions.md) | @Mentions | Active | 2026-05-19 |
+| [FDR-006](FDR-006-mentions.md) | @Mentions | Active | 2026-06-05 |
 | [FDR-007](FDR-007-direct-messages.md) | Direct Messages | Active | 2026-05-31 |
 | [FDR-008](FDR-008-file-attachments-and-video.md) | File Attachments & Video Processing | Active | 2026-05-19 |
 | [FDR-009](FDR-009-link-previews.md) | Link Previews | Active | 2026-05-19 |


### PR DESCRIPTION
- Clarifies in FDR-006 that mentions are resolved when a message is posted, and edits do not add, remove, dismiss, or re-send mention notifications.
- Documents the same edit behavior in FDR-004 and links message editing back to the mentions FDR.
- Updates the architecture inventory and FDR index review dates for the clarified mention behavior.

Verification: `git diff --check`.
