### PR TITLE
feat: add server-side cookie sessions

### DIFF
--- a/cli/internal/core/cookie_sessions_test.go
+++ b/cli/internal/core/cookie_sessions_test.go
@@ -1,0 +1,136 @@
+package core
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+func TestChattoCore_CreateAndValidateCookieSession(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := WithAuditRequestMetadata(testContext(t), &corev1.AuditRequestMetadata{
+		UserAgent: "cookie-session-test",
+		IpHash:    "hashed-ip",
+	})
+
+	user, err := core.CreateUser(ctx, SystemActorID, "cookie-session-user", "Cookie Session User", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	sessionID, created, err := core.CreateCookieSession(ctx, user.Id, "test_login")
+	if err != nil {
+		t.Fatalf("CreateCookieSession: %v", err)
+	}
+	if sessionID == "" {
+		t.Fatalf("expected session ID")
+	}
+	if created.GetUserId() != user.Id || created.GetSource() != "test_login" {
+		t.Fatalf("unexpected created session: %#v", created)
+	}
+	if created.GetRequest().GetUserAgent() != "cookie-session-test" || created.GetRequest().GetIpHash() != "hashed-ip" {
+		t.Fatalf("unexpected request metadata: %#v", created.GetRequest())
+	}
+
+	key := core.cookieSessionKey(user.Id, sessionID)
+	assertRuntimeKVHasTTL(t, core, key)
+	assertRawRuntimeTokenKeyAbsent(t, core, cookieSessionKeyPrefix+user.Id+"."+sessionID)
+
+	entry, err := core.storage.runtimeStateKV.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("get cookie session: %v", err)
+	}
+	var stored corev1.CookieSession
+	if err := proto.Unmarshal(entry.Value(), &stored); err != nil {
+		t.Fatalf("unmarshal cookie session: %v", err)
+	}
+	if stored.GetUserId() != user.Id || stored.GetExpiresAt() == nil {
+		t.Fatalf("unexpected stored session: %#v", &stored)
+	}
+
+	validated, err := core.ValidateCookieSession(ctx, user.Id, sessionID)
+	if err != nil {
+		t.Fatalf("ValidateCookieSession: %v", err)
+	}
+	if !proto.Equal(validated, &stored) {
+		t.Fatalf("validated session differs from stored session")
+	}
+}
+
+func TestChattoCore_CookieSessionRevocation(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	user, err := core.CreateUser(ctx, SystemActorID, "cookie-revoke-user", "Cookie Revoke User", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	session1, _, err := core.CreateCookieSession(ctx, user.Id, "test")
+	if err != nil {
+		t.Fatalf("CreateCookieSession 1: %v", err)
+	}
+	session2, _, err := core.CreateCookieSession(ctx, user.Id, "test")
+	if err != nil {
+		t.Fatalf("CreateCookieSession 2: %v", err)
+	}
+
+	if err := core.RevokeCookieSession(ctx, user.Id, session1); err != nil {
+		t.Fatalf("RevokeCookieSession: %v", err)
+	}
+	if _, err := core.ValidateCookieSession(ctx, user.Id, session1); !errors.Is(err, ErrCookieSessionNotFound) {
+		t.Fatalf("Validate revoked session err = %v, want ErrCookieSessionNotFound", err)
+	}
+	if _, err := core.ValidateCookieSession(ctx, user.Id, session2); err != nil {
+		t.Fatalf("second session should remain valid: %v", err)
+	}
+
+	deleted, err := core.RevokeCookieSessionsForUser(ctx, user.Id)
+	if err != nil {
+		t.Fatalf("RevokeCookieSessionsForUser: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1", deleted)
+	}
+	if _, err := core.ValidateCookieSession(ctx, user.Id, session2); !errors.Is(err, ErrCookieSessionNotFound) {
+		t.Fatalf("Validate user-revoked session err = %v, want ErrCookieSessionNotFound", err)
+	}
+}
+
+func TestChattoCore_ValidateCookieSessionRejectsExpiredPayload(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	user, err := core.CreateUser(ctx, SystemActorID, "cookie-expired-user", "Cookie Expired User", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	sessionID := NewCookieSessionID()
+	key := core.cookieSessionKey(user.Id, sessionID)
+	expired := &corev1.CookieSession{
+		UserId:    user.Id,
+		CreatedAt: timestamppb.New(time.Now().Add(-2 * time.Hour)),
+		ExpiresAt: timestamppb.New(time.Now().Add(-time.Hour)),
+		Source:    "test",
+	}
+	data, err := proto.Marshal(expired)
+	if err != nil {
+		t.Fatalf("marshal expired session: %v", err)
+	}
+	if _, err := core.storage.runtimeStateKV.Create(ctx, key, data, jetstream.KeyTTL(core.cookieSessionTTL())); err != nil {
+		t.Fatalf("store expired session: %v", err)
+	}
+
+	if _, err := core.ValidateCookieSession(ctx, user.Id, sessionID); !errors.Is(err, ErrCookieSessionNotFound) {
+		t.Fatalf("ValidateCookieSession err = %v, want ErrCookieSessionNotFound", err)
+	}
+	if _, err := core.storage.runtimeStateKV.Get(ctx, key); !errors.Is(err, jetstream.ErrKeyNotFound) {
+		t.Fatalf("expired session key lookup error = %v, want ErrKeyNotFound", err)
+	}
+}

--- a/cli/internal/core/ids.go
+++ b/cli/internal/core/ids.go
@@ -81,6 +81,11 @@ func NewAuthToken() string {
 	return "cht_" + newID("AT")
 }
 
+// NewCookieSessionID generates a new opaque cookie session ID with "cht_CS" prefix.
+func NewCookieSessionID() string {
+	return "cht_" + newID("CS")
+}
+
 // NewAuthCode generates a new OAuth authorization code with "cht_AC" prefix.
 func NewAuthCode() string {
 	return "cht_" + newID("AC")

--- a/cli/internal/core/password_reset.go
+++ b/cli/internal/core/password_reset.go
@@ -180,8 +180,14 @@ func (c *ChattoCore) ResetPassword(ctx context.Context, token string, newPasswor
 			Event:   passwordResetCompletedEvent(ctx, tokenData.UserID),
 		},
 	}
+	if _, err := c.RevokeCookieSessionsForUser(ctx, tokenData.UserID); err != nil {
+		return err
+	}
 	if _, err := c.appendUserBatch(ctx, tokenData.UserID, entries, "", nil); err != nil {
 		return fmt.Errorf("failed to update password: %w", err)
+	}
+	if err := c.PublishSessionTerminated(ctx, tokenData.UserID, "password_reset"); err != nil {
+		c.logger.Warn("Failed to publish SessionTerminatedEvent", "user_id", tokenData.UserID, "reason", "password_reset", "error", err)
 	}
 
 	return nil

--- a/cli/internal/core/sessions.go
+++ b/cli/internal/core/sessions.go
@@ -2,10 +2,146 @@ package core
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"time"
 
+	"github.com/nats-io/nats.go/jetstream"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"hmans.de/chatto/internal/core/subjects"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
+
+var (
+	// ErrCookieSessionNotFound is returned when a cookie session does not exist,
+	// has expired, is malformed, or does not belong to the supplied user.
+	ErrCookieSessionNotFound = errors.New("cookie session not found")
+)
+
+const cookieSessionKeyPrefix = "cookie_session."
+
+func (c *ChattoCore) cookieSessionTTL() time.Duration {
+	return c.authTokenTTL()
+}
+
+func cookieSessionUserKeyFilter(userID string) string {
+	return cookieSessionKeyPrefix + userID + ".*"
+}
+
+func (c *ChattoCore) cookieSessionKey(userID, sessionID string) string {
+	return c.runtimeTokenKey(cookieSessionKeyPrefix+userID+".", sessionID)
+}
+
+// CreateCookieSession creates a server-side cookie session record in
+// RUNTIME_STATE and returns the opaque session ID that should be stored in the
+// signed browser cookie.
+func (c *ChattoCore) CreateCookieSession(ctx context.Context, userID, source string) (string, *corev1.CookieSession, error) {
+	sessionID := NewCookieSessionID()
+	now := time.Now()
+	expiresAt := now.Add(c.cookieSessionTTL())
+
+	record := &corev1.CookieSession{
+		UserId:    userID,
+		CreatedAt: timestamppb.New(now),
+		ExpiresAt: timestamppb.New(expiresAt),
+		Source:    source,
+		Request:   auditRequestMetadata(ctx),
+	}
+
+	data, err := proto.Marshal(record)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to marshal cookie session: %w", err)
+	}
+
+	key := c.cookieSessionKey(userID, sessionID)
+	if _, err := c.storage.runtimeStateKV.Create(ctx, key, data, jetstream.KeyTTL(c.cookieSessionTTL())); err != nil {
+		return "", nil, fmt.Errorf("failed to store cookie session: %w", err)
+	}
+
+	return sessionID, record, nil
+}
+
+// ValidateCookieSession validates a cookie-backed server-side session and
+// returns its runtime-state record. Callers must still load the current user
+// projection before authenticating the request.
+func (c *ChattoCore) ValidateCookieSession(ctx context.Context, userID, sessionID string) (*corev1.CookieSession, error) {
+	if userID == "" || sessionID == "" {
+		return nil, ErrCookieSessionNotFound
+	}
+
+	key := c.cookieSessionKey(userID, sessionID)
+	entry, err := c.storage.runtimeStateKV.Get(ctx, key)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrKeyNotFound) {
+			return nil, ErrCookieSessionNotFound
+		}
+		return nil, fmt.Errorf("failed to get cookie session: %w", err)
+	}
+
+	var record corev1.CookieSession
+	if err := proto.Unmarshal(entry.Value(), &record); err != nil {
+		_ = c.storage.runtimeStateKV.Delete(ctx, key)
+		return nil, ErrCookieSessionNotFound
+	}
+	if record.GetUserId() != userID {
+		_ = c.storage.runtimeStateKV.Delete(ctx, key)
+		return nil, ErrCookieSessionNotFound
+	}
+	expiresAtPB := record.GetExpiresAt()
+	if expiresAtPB == nil || !time.Now().Before(expiresAtPB.AsTime()) {
+		_ = c.storage.runtimeStateKV.Delete(ctx, key)
+		return nil, ErrCookieSessionNotFound
+	}
+
+	return &record, nil
+}
+
+// RevokeCookieSession deletes one cookie session. It is idempotent.
+func (c *ChattoCore) RevokeCookieSession(ctx context.Context, userID, sessionID string) error {
+	if userID == "" || sessionID == "" {
+		return nil
+	}
+	err := c.storage.runtimeStateKV.Delete(ctx, c.cookieSessionKey(userID, sessionID))
+	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+		return fmt.Errorf("failed to revoke cookie session: %w", err)
+	}
+	return nil
+}
+
+// RevokeCookieSessionsForUser deletes all cookie sessions for a user. Used by
+// password changes/resets and account deletion flows that need immediate
+// revocation across browser sessions.
+func (c *ChattoCore) RevokeCookieSessionsForUser(ctx context.Context, userID string) (int, error) {
+	if userID == "" {
+		return 0, nil
+	}
+
+	lister, err := c.storage.runtimeStateKV.ListKeysFiltered(ctx, cookieSessionUserKeyFilter(userID))
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("failed to list cookie sessions: %w", err)
+	}
+
+	var keys []string
+	for key := range lister.Keys() {
+		keys = append(keys, key)
+	}
+
+	deleted := 0
+	for _, key := range keys {
+		if err := c.storage.runtimeStateKV.Delete(ctx, key); err != nil {
+			if !errors.Is(err, jetstream.ErrKeyNotFound) {
+				c.logger.Warn("Failed to revoke cookie session", "key", key, "error", err)
+			}
+			continue
+		}
+		deleted++
+	}
+	return deleted, nil
+}
 
 // PublishSessionTerminated publishes a SessionTerminatedEvent for the given user.
 // This notifies all of the user's active subscriptions (across tabs/devices) that

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -317,8 +317,16 @@ func (c *ChattoCore) SetPasswordHash(ctx context.Context, userID string, passwor
 			PasswordHash: hashedPassword,
 		},
 	}})
-	_, err = c.appendUserEvent(ctx, userID, event, "", nil)
-	return err
+	if _, err := c.RevokeCookieSessionsForUser(ctx, userID); err != nil {
+		return err
+	}
+	if _, err := c.appendUserEvent(ctx, userID, event, "", nil); err != nil {
+		return err
+	}
+	if err := c.PublishSessionTerminated(ctx, userID, "password_changed"); err != nil {
+		c.logger.Warn("Failed to publish SessionTerminatedEvent", "user_id", userID, "reason", "password_changed", "error", err)
+	}
+	return nil
 }
 
 // VerifyPassword verifies a user's password by login name or email and returns the user if valid.
@@ -956,6 +964,10 @@ func (c *ChattoCore) DeleteUser(ctx context.Context, actorID, userID string) err
 		c.logger.Warn("Failed to delete push subscriptions", "user_id", userID, "error", err)
 		// Continue - this is best-effort
 	}
+	if _, err := c.RevokeCookieSessionsForUser(ctx, userID); err != nil {
+		c.logger.Warn("Failed to revoke cookie sessions during deletion", "user_id", userID, "error", err)
+		// Continue - this is best-effort
+	}
 
 	// Delete avatar from object store if it exists
 	avatar, _ := c.GetUserAvatar(ctx, userID)
@@ -1001,6 +1013,9 @@ func (c *ChattoCore) DeleteUser(ctx context.Context, actorID, userID string) err
 	serverSubject := subjects.LiveSyncUserEvent(userID, "user_deleted")
 	if err := c.publishLiveEvent(ctx, serverSubject, serverEvent); err != nil {
 		c.logger.Warn("Failed to publish UserDeletedEvent", "user_id", userID, "error", err)
+	}
+	if err := c.PublishSessionTerminated(ctx, userID, "account_deleted"); err != nil {
+		c.logger.Warn("Failed to publish SessionTerminatedEvent", "user_id", userID, "error", err)
 	}
 
 	c.logger.Info("Deleted user account", "id", userID, "login", user.Login)

--- a/cli/internal/http_server/assets.go
+++ b/cli/internal/http_server/assets.go
@@ -337,7 +337,7 @@ func (s *HTTPServer) resolveStableAssetViewerID(c *gin.Context, assetID string, 
 		return "", false
 	}
 
-	reqWithUser := injectUserIntoContext(c, s.core)
+	reqWithUser := s.injectUserIntoContext(c)
 	user := auth.ForContext(reqWithUser.Context())
 	if user == nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})

--- a/cli/internal/http_server/auth.go
+++ b/cli/internal/http_server/auth.go
@@ -33,7 +33,7 @@ func (s *HTTPServer) setupAuthRoutes() {
 
 		// Read user ID before clearing session (needed for session terminated event)
 		session := sessions.Default(c)
-		userID, _ := session.Get("user_id").(string)
+		userID, cookieSessionID, _ := cookieSessionIDs(session)
 
 		// If authenticated via bearer token, revoke it
 		if authHeader := c.GetHeader("Authorization"); authHeader != "" {
@@ -42,6 +42,10 @@ func (s *HTTPServer) setupAuthRoutes() {
 					log.Warn("Failed to revoke bearer token on logout", "error", err)
 				}
 			}
+		}
+
+		if err := s.core.RevokeCookieSession(ctx, userID, cookieSessionID); err != nil {
+			log.Warn("Failed to revoke cookie session on logout", "error", err)
 		}
 
 		// Clear the session cookie
@@ -130,17 +134,17 @@ func (s *HTTPServer) setupAuthRoutes() {
 			return
 		}
 
-		// Create session
-		session := sessions.Default(c)
-		session.Set("user_id", user.Id)
-		err = session.Save()
-		if err != nil {
+		// Create server-side cookie session
+		if err := s.createCookieSession(c, user.Id, "password_login"); err != nil {
 			log.Error("Failed to save session", "error", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create session"})
 			return
 		}
 		if err := s.core.RecordLoginSucceeded(ctx, user.Id, login); err != nil {
 			log.Error("Failed to append login audit event", "userId", user.Id, "error", err)
+			session := sessions.Default(c)
+			cookieUserID, cookieSessionID, _ := cookieSessionIDs(session)
+			_ = s.core.RevokeCookieSession(ctx, cookieUserID, cookieSessionID)
 			session.Clear()
 			_ = session.Save()
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create session"})
@@ -343,10 +347,8 @@ func (s *HTTPServer) setupAuthRoutes() {
 			// Don't fail — user was created successfully
 		}
 
-		// Create session
-		session := sessions.Default(c)
-		session.Set("user_id", user.Id)
-		if err := session.Save(); err != nil {
+		// Create server-side cookie session
+		if err := s.createCookieSession(c, user.Id, "registration_complete"); err != nil {
 			log.Error("Failed to save session", "error", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create session"})
 			return

--- a/cli/internal/http_server/cookie_sessions.go
+++ b/cli/internal/http_server/cookie_sessions.go
@@ -1,0 +1,114 @@
+package http_server
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/charmbracelet/log"
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-gonic/gin"
+	"hmans.de/chatto/internal/core"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+const (
+	sessionKeyUserID          = "user_id"
+	sessionKeyCookieSessionID = "cookie_session_id"
+)
+
+func (s *HTTPServer) createCookieSession(c *gin.Context, userID, source string) error {
+	sessionID, _, err := s.core.CreateCookieSession(c.Request.Context(), userID, source)
+	if err != nil {
+		return err
+	}
+
+	session := sessions.Default(c)
+	session.Set(sessionKeyUserID, userID)
+	session.Set(sessionKeyCookieSessionID, sessionID)
+	return session.Save()
+}
+
+func clearCookieSessionAuth(session sessions.Session) {
+	if session == nil {
+		return
+	}
+	session.Delete(sessionKeyUserID)
+	session.Delete(sessionKeyCookieSessionID)
+	_ = session.Save()
+}
+
+func cookieSessionIDs(session sessions.Session) (string, string, bool) {
+	if session == nil {
+		return "", "", false
+	}
+	userID, _ := session.Get(sessionKeyUserID).(string)
+	sessionID, _ := session.Get(sessionKeyCookieSessionID).(string)
+	return userID, sessionID, userID != "" && sessionID != ""
+}
+
+func (s *HTTPServer) validateCookieSession(c *gin.Context) (string, string, *corev1.CookieSession, bool) {
+	session := sessions.Default(c)
+	userID, sessionID, ok := cookieSessionIDs(session)
+	if !ok {
+		if userID != "" || sessionID != "" {
+			clearCookieSessionAuth(session)
+		}
+		return "", "", nil, false
+	}
+
+	record, err := s.core.ValidateCookieSession(c.Request.Context(), userID, sessionID)
+	if err != nil {
+		if err != core.ErrCookieSessionNotFound {
+			log.Warn("Failed to validate cookie session", "userId", userID, "error", err)
+		}
+		clearCookieSessionAuth(session)
+		return "", "", nil, false
+	}
+
+	return userID, sessionID, record, true
+}
+
+func (s *HTTPServer) rotateCookieSessionIfNeeded(c *gin.Context, userID, oldSessionID string, record *corev1.CookieSession) {
+	if record == nil || record.GetExpiresAt() == nil {
+		return
+	}
+	if !shouldRotateCookieSession(record, s.config.Auth.TokenTTLOrDefault()) {
+		return
+	}
+
+	newSessionID, _, err := s.core.CreateCookieSession(c.Request.Context(), userID, "session_rotation")
+	if err != nil {
+		log.Warn("Failed to rotate cookie session", "userId", userID, "error", err)
+		return
+	}
+
+	session := sessions.Default(c)
+	session.Set(sessionKeyUserID, userID)
+	session.Set(sessionKeyCookieSessionID, newSessionID)
+	if err := session.Save(); err != nil {
+		log.Warn("Failed to save rotated cookie session", "userId", userID, "error", err)
+		_ = s.core.RevokeCookieSession(c.Request.Context(), userID, newSessionID)
+		return
+	}
+
+	if err := s.core.RevokeCookieSession(c.Request.Context(), userID, oldSessionID); err != nil {
+		log.Warn("Failed to revoke old rotated cookie session", "userId", userID, "error", err)
+	}
+}
+
+func shouldRotateCookieSession(record *corev1.CookieSession, ttl time.Duration) bool {
+	if record == nil || record.GetExpiresAt() == nil || ttl <= 0 {
+		return false
+	}
+	return time.Until(record.GetExpiresAt().AsTime()) <= ttl/4
+}
+
+func cookieSessionOptions(cfgTTL time.Duration, secure bool) sessions.Options {
+	return sessions.Options{
+		MaxAge:   int(cfgTTL.Seconds()),
+		HttpOnly: true,
+		Secure:   secure,
+		Path:     "/",
+		SameSite: http.SameSiteLaxMode,
+	}
+}

--- a/cli/internal/http_server/frontend.go
+++ b/cli/internal/http_server/frontend.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/charmbracelet/log"
-	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 )
 
@@ -188,15 +187,14 @@ func (s *HTTPServer) setupFrontendRoutes() error {
 		c.Next()
 	})
 
-	// refreshSessionIfAuthenticated extends the session cookie lifetime for authenticated users.
-	// This prevents session expiration while the user is actively using the app.
-	// Note: We must call Set() before Save() because gin-contrib/sessions only saves
-	// if the session has been "written" to. Get() alone doesn't mark it as modified.
+	// refreshSessionIfAuthenticated validates and rotates authenticated
+	// cookie-session records for active SPA browsing. KV TTL is set only when
+	// a session is created, so near-expiry sessions are rotated instead of
+	// "touched" in place.
 	refreshSessionIfAuthenticated := func(c *gin.Context) {
-		session := sessions.Default(c)
-		if userID := session.Get("user_id"); userID != nil {
-			session.Set("user_id", userID) // Mark session as modified
-			session.Save()                 // Now actually saves and refreshes cookie
+		userID, sessionID, cookieSession, ok := s.validateCookieSession(c)
+		if ok {
+			s.rotateCookieSessionIfNeeded(c, userID, sessionID, cookieSession)
 		}
 	}
 

--- a/cli/internal/http_server/graphql.go
+++ b/cli/internal/http_server/graphql.go
@@ -196,23 +196,19 @@ func (s *HTTPServer) setupGraphQLAPI(allowedOrigins []string) {
 	s.router.Any("/api/graphql", func(c *gin.Context) {
 		s.requestContextWithAuditMetadata(c)
 
-		// Refresh session cookie for authenticated users to prevent expiration.
-		// Note: We must call Set() before Save() because gin-contrib/sessions only saves
-		// if the session has been "written" to. Get() alone doesn't mark it as modified.
 		session := sessions.Default(c)
-		if userID := session.Get("user_id"); userID != nil {
-			session.Set("user_id", userID)
-			session.Save()
-		} else {
+		if userID, _, ok := cookieSessionIDs(session); !ok {
 			// Log unauthenticated requests to help diagnose cookie/session issues
 			// (e.g., reverse proxy stripping Set-Cookie headers)
 			s.logger.Debug("GraphQL request without session",
 				"host", c.Request.Host,
 				"hasCookie", c.Request.Header.Get("Cookie") != "")
+		} else if userID == "" {
+			clearCookieSessionAuth(session)
 		}
 
 		// Inject authenticated user into request context
-		r := injectUserIntoContext(c, s.core)
+		r := s.injectUserIntoContext(c)
 		// Inject dataloaders for this request
 		r = injectDataloadersIntoContext(r, s.core)
 		h.ServeHTTP(c.Writer, r)

--- a/cli/internal/http_server/graphql_auth.go
+++ b/cli/internal/http_server/graphql_auth.go
@@ -16,16 +16,16 @@ import (
 // or the Gin session cookie, and returns an updated http.Request with the user
 // injected into its context.
 // Returns the original request if no user is authenticated (allowing unauthenticated requests).
-func injectUserIntoContext(c *gin.Context, chattoCore *core.ChattoCore) *http.Request {
+func (s *HTTPServer) injectUserIntoContext(c *gin.Context) *http.Request {
 	ctx := c.Request.Context()
 
 	// 1. Check Authorization: Bearer <token> header first (cross-origin clients)
 	if authHeader := c.GetHeader("Authorization"); authHeader != "" {
 		if token, ok := strings.CutPrefix(authHeader, "Bearer "); ok && strings.TrimSpace(token) != "" {
 			token = strings.TrimSpace(token)
-			userID, err := chattoCore.ValidateAuthToken(ctx, token)
+			userID, err := s.core.ValidateAuthToken(ctx, token)
 			if err == nil {
-				user, err := chattoCore.GetUser(ctx, userID)
+				user, err := s.core.GetUser(ctx, userID)
 				if err == nil {
 					ctx = auth.WithUser(ctx, user)
 					return c.Request.WithContext(ctx)
@@ -37,26 +37,19 @@ func injectUserIntoContext(c *gin.Context, chattoCore *core.ChattoCore) *http.Re
 	}
 
 	// 2. Fall back to session cookie (embedded SPA clients)
-	session := sessions.Default(c)
-	if session == nil {
+	userID, sessionID, cookieSession, ok := s.validateCookieSession(c)
+	if !ok {
 		return c.Request
 	}
 
-	userIdRaw := session.Get("user_id")
-	if userIdRaw == nil {
-		return c.Request
-	}
-
-	userId, ok := userIdRaw.(string)
-	if !ok || userId == "" {
-		return c.Request
-	}
-
-	user, err := chattoCore.GetUser(ctx, userId)
+	user, err := s.core.GetUser(ctx, userID)
 	if err != nil {
-		log.Warn("Failed to load user from session", "userId", userId, "error", err)
+		log.Warn("Failed to load user from session", "userId", userID, "error", err)
+		clearCookieSessionAuth(sessions.Default(c))
 		return c.Request
 	}
+
+	s.rotateCookieSessionIfNeeded(c, userID, sessionID, cookieSession)
 
 	ctx = auth.WithUser(ctx, user)
 	return c.Request.WithContext(ctx)

--- a/cli/internal/http_server/graphql_test.go
+++ b/cli/internal/http_server/graphql_test.go
@@ -300,6 +300,58 @@ func TestGraphQL_Query_Viewer_Authenticated(t *testing.T) {
 	}
 }
 
+func TestGraphQL_Query_Viewer_CookieSessionRevoked(t *testing.T) {
+	env := setupGraphQLTestServer(t)
+
+	login := "graphqlrevoked"
+	password := "password123"
+	userID := env.createTestUser(t, login, password)
+
+	if !env.login(t, login, password) {
+		t.Fatal("Login failed")
+	}
+
+	resp := env.doGraphQL(t, `query { viewer { user { id login } } }`, nil)
+	if len(resp.Errors) > 0 {
+		t.Fatalf("Expected no errors before revocation, got: %v", resp.Errors)
+	}
+	var before struct {
+		Viewer *struct {
+			User struct {
+				ID string `json:"id"`
+			} `json:"user"`
+		} `json:"viewer"`
+	}
+	if err := json.Unmarshal(resp.Data, &before); err != nil {
+		t.Fatalf("Failed to unmarshal pre-revocation response: %v", err)
+	}
+	if before.Viewer == nil {
+		t.Fatal("Expected authenticated viewer before revocation")
+	}
+
+	if _, err := env.core.RevokeCookieSessionsForUser(env.ctx, userID); err != nil {
+		t.Fatalf("RevokeCookieSessionsForUser: %v", err)
+	}
+
+	resp = env.doGraphQL(t, `query { viewer { user { id login } } }`, nil)
+	if len(resp.Errors) > 0 {
+		t.Fatalf("Expected no errors after revocation, got: %v", resp.Errors)
+	}
+	var after struct {
+		Viewer *struct {
+			User struct {
+				ID string `json:"id"`
+			} `json:"user"`
+		} `json:"viewer"`
+	}
+	if err := json.Unmarshal(resp.Data, &after); err != nil {
+		t.Fatalf("Failed to unmarshal post-revocation response: %v", err)
+	}
+	if after.Viewer != nil {
+		t.Fatal("Expected viewer to be null after cookie session revocation")
+	}
+}
+
 // TestGraphQL_Query_Spaces_PublicDiscovery tests that the spaces query is public
 // PR(a) retired Query.spaces / Query.space(id). Unauthenticated discovery now
 // happens via the `instance` query, which exposes the deployment's name, logo,

--- a/cli/internal/http_server/oauth.go
+++ b/cli/internal/http_server/oauth.go
@@ -37,7 +37,8 @@ func (s *HTTPServer) setupOAuthRoutes() {
 		// If user is already authenticated and has pending OAuth params from
 		// a previous /oauth/authorize visit (e.g., after login on the login page),
 		// generate the code immediately without re-validating query params.
-		if userID, ok := session.Get("user_id").(string); ok && userID != "" {
+		if userID, sessionID, cookieSession, ok := s.validateCookieSession(c); ok {
+			s.rotateCookieSessionIfNeeded(c, userID, sessionID, cookieSession)
 			if hasPendingOAuthAuthorize(session) {
 				s.completeOAuthAuthorize(c, userID)
 				return
@@ -99,7 +100,8 @@ func (s *HTTPServer) setupOAuthRoutes() {
 		session.Save()
 
 		// If user is already authenticated, generate code immediately
-		if userID, ok := session.Get("user_id").(string); ok && userID != "" {
+		if userID, sessionID, cookieSession, ok := s.validateCookieSession(c); ok {
+			s.rotateCookieSessionIfNeeded(c, userID, sessionID, cookieSession)
 			s.completeOAuthAuthorize(c, userID)
 			return
 		}

--- a/cli/internal/http_server/oidc.go
+++ b/cli/internal/http_server/oidc.go
@@ -294,15 +294,17 @@ func (s *HTTPServer) setupOIDCRoutes() {
 			}
 		}
 
-		// Create session
-		session.Set("user_id", user.Id)
-		if err := session.Save(); err != nil {
+		// Create server-side cookie session
+		if err := s.createCookieSession(c, user.Id, "oidc_login"); err != nil {
 			log.Error("Failed to save session", "error", err)
 			c.Redirect(http.StatusTemporaryRedirect, "/login?error=oidc_failed")
 			return
 		}
 		if err := s.core.RecordLoginSucceeded(ctx, user.Id, claims.Email); err != nil {
 			log.Error("Failed to append OIDC login audit event", "userId", user.Id, "error", err)
+			session = sessions.Default(c)
+			cookieUserID, cookieSessionID, _ := cookieSessionIDs(session)
+			_ = s.core.RevokeCookieSession(ctx, cookieUserID, cookieSessionID)
 			session.Clear()
 			_ = session.Save()
 			c.Redirect(http.StatusTemporaryRedirect, "/login?error=oidc_failed")

--- a/cli/internal/http_server/server.go
+++ b/cli/internal/http_server/server.go
@@ -117,13 +117,7 @@ func (s *HTTPServer) setupRoutes() error {
 		s.logger.Warn("webserver.cookie_encryption_secret is not set; session cookies are signed but NOT encrypted. Run `chatto init` on a fresh server to generate one, or add a hex-encoded 32-byte value to chatto.toml.")
 		sessionStore = cookie.NewStore(authKey)
 	}
-	sessionStore.Options(sessions.Options{
-		MaxAge:   60 * 60 * 24 * 90, // 90 days
-		HttpOnly: true,
-		Secure:   strings.HasPrefix(s.config.Webserver.URL, "https"),
-		Path:     "/",
-		SameSite: http.SameSiteLaxMode,
-	})
+	sessionStore.Options(cookieSessionOptions(s.config.Auth.TokenTTLOrDefault(), strings.HasPrefix(s.config.Webserver.URL, "https")))
 	s.router.Use(sessions.Sessions("chatto_session", sessionStore))
 
 	// Build allowed origins list once and share between CORS middleware and WebSocket CheckOrigin

--- a/cli/internal/http_server/server_test.go
+++ b/cli/internal/http_server/server_test.go
@@ -452,7 +452,7 @@ func TestAuthRoutes_Logout(t *testing.T) {
 	// Create and login a test user
 	login := "logoutuser"
 	password := "password123"
-	_, err := chattoCore.CreateUser(ctx, "system", login, "Test User", password)
+	user, err := chattoCore.CreateUser(ctx, "system", login, "Test User", password)
 	if err != nil {
 		t.Fatalf("Failed to create user: %v", err)
 	}
@@ -474,6 +474,23 @@ func TestAuthRoutes_Logout(t *testing.T) {
 		t.Fatalf("Login failed with status %d", loginResp.StatusCode)
 	}
 
+	deleted, err := chattoCore.RevokeCookieSessionsForUser(ctx, user.Id)
+	if err != nil {
+		t.Fatalf("Failed to inspect cookie session after login: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("Login created %d cookie sessions, want 1", deleted)
+	}
+
+	loginResp, err = client.Post(ts.URL+"/auth/login", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("Failed to login again: %v", err)
+	}
+	loginResp.Body.Close()
+	if loginResp.StatusCode != http.StatusOK {
+		t.Fatalf("Second login failed with status %d", loginResp.StatusCode)
+	}
+
 	// Now logout
 	logoutResp, err := client.Post(ts.URL+"/auth/logout", "application/json", nil)
 	if err != nil {
@@ -492,6 +509,14 @@ func TestAuthRoutes_Logout(t *testing.T) {
 
 	if result["success"] != true {
 		t.Error("Expected success: true in response")
+	}
+
+	deleted, err = chattoCore.RevokeCookieSessionsForUser(ctx, user.Id)
+	if err != nil {
+		t.Fatalf("Failed to inspect cookie session after logout: %v", err)
+	}
+	if deleted != 0 {
+		t.Fatalf("Logout left %d cookie sessions behind, want 0", deleted)
 	}
 }
 

--- a/cli/internal/http_server/test_endpoints.go
+++ b/cli/internal/http_server/test_endpoints.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 
 	"github.com/charmbracelet/log"
-	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/email"
@@ -172,10 +171,8 @@ func registerTestEndpoints(auth *gin.RouterGroup, s *HTTPServer) {
 				}
 			}
 
-			// Create session
-			session := sessions.Default(c)
-			session.Set("user_id", newUser.Id)
-			if err := session.Save(); err != nil {
+			// Create server-side cookie session
+			if err := s.createCookieSession(c, newUser.Id, "test_oauth"); err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save session"})
 				return
 			}
@@ -191,10 +188,8 @@ func registerTestEndpoints(auth *gin.RouterGroup, s *HTTPServer) {
 			return
 		}
 
-		// Create session for existing user
-		session := sessions.Default(c)
-		session.Set("user_id", existingUser.Id)
-		if err := session.Save(); err != nil {
+		// Create server-side cookie session for existing user
+		if err := s.createCookieSession(c, existingUser.Id, "test_oauth"); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save session"})
 			return
 		}

--- a/cli/internal/pb/chatto/core/v1/auth_events.pb.go
+++ b/cli/internal/pb/chatto/core/v1/auth_events.pb.go
@@ -22,60 +22,6 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// AuditRequestMetadata captures request details that are safe to persist in
-// the durable audit log. Raw IP addresses, links, and tokens never belong here.
-type AuditRequestMetadata struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	UserAgent     string                 `protobuf:"bytes,1,opt,name=user_agent,json=userAgent,proto3" json:"user_agent,omitempty"`
-	IpHash        string                 `protobuf:"bytes,2,opt,name=ip_hash,json=ipHash,proto3" json:"ip_hash,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *AuditRequestMetadata) Reset() {
-	*x = AuditRequestMetadata{}
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[0]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *AuditRequestMetadata) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*AuditRequestMetadata) ProtoMessage() {}
-
-func (x *AuditRequestMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[0]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use AuditRequestMetadata.ProtoReflect.Descriptor instead.
-func (*AuditRequestMetadata) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{0}
-}
-
-func (x *AuditRequestMetadata) GetUserAgent() string {
-	if x != nil {
-		return x.UserAgent
-	}
-	return ""
-}
-
-func (x *AuditRequestMetadata) GetIpHash() string {
-	if x != nil {
-		return x.IpHash
-	}
-	return ""
-}
-
 type RegistrationLinkIssuedEvent struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	EmailHash     string                 `protobuf:"bytes,1,opt,name=email_hash,json=emailHash,proto3" json:"email_hash,omitempty"`
@@ -87,7 +33,7 @@ type RegistrationLinkIssuedEvent struct {
 
 func (x *RegistrationLinkIssuedEvent) Reset() {
 	*x = RegistrationLinkIssuedEvent{}
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[1]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -99,7 +45,7 @@ func (x *RegistrationLinkIssuedEvent) String() string {
 func (*RegistrationLinkIssuedEvent) ProtoMessage() {}
 
 func (x *RegistrationLinkIssuedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[1]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -112,7 +58,7 @@ func (x *RegistrationLinkIssuedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RegistrationLinkIssuedEvent.ProtoReflect.Descriptor instead.
 func (*RegistrationLinkIssuedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{1}
+	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *RegistrationLinkIssuedEvent) GetEmailHash() string {
@@ -148,7 +94,7 @@ type EmailVerificationLinkIssuedEvent struct {
 
 func (x *EmailVerificationLinkIssuedEvent) Reset() {
 	*x = EmailVerificationLinkIssuedEvent{}
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[2]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -160,7 +106,7 @@ func (x *EmailVerificationLinkIssuedEvent) String() string {
 func (*EmailVerificationLinkIssuedEvent) ProtoMessage() {}
 
 func (x *EmailVerificationLinkIssuedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[2]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -173,7 +119,7 @@ func (x *EmailVerificationLinkIssuedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EmailVerificationLinkIssuedEvent.ProtoReflect.Descriptor instead.
 func (*EmailVerificationLinkIssuedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{2}
+	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *EmailVerificationLinkIssuedEvent) GetUserId() string {
@@ -216,7 +162,7 @@ type PasswordResetLinkIssuedEvent struct {
 
 func (x *PasswordResetLinkIssuedEvent) Reset() {
 	*x = PasswordResetLinkIssuedEvent{}
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[3]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -228,7 +174,7 @@ func (x *PasswordResetLinkIssuedEvent) String() string {
 func (*PasswordResetLinkIssuedEvent) ProtoMessage() {}
 
 func (x *PasswordResetLinkIssuedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[3]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -241,7 +187,7 @@ func (x *PasswordResetLinkIssuedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PasswordResetLinkIssuedEvent.ProtoReflect.Descriptor instead.
 func (*PasswordResetLinkIssuedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{3}
+	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *PasswordResetLinkIssuedEvent) GetUserId() string {
@@ -283,7 +229,7 @@ type AccountDeletionConfirmationIssuedEvent struct {
 
 func (x *AccountDeletionConfirmationIssuedEvent) Reset() {
 	*x = AccountDeletionConfirmationIssuedEvent{}
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[4]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -295,7 +241,7 @@ func (x *AccountDeletionConfirmationIssuedEvent) String() string {
 func (*AccountDeletionConfirmationIssuedEvent) ProtoMessage() {}
 
 func (x *AccountDeletionConfirmationIssuedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[4]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -308,7 +254,7 @@ func (x *AccountDeletionConfirmationIssuedEvent) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use AccountDeletionConfirmationIssuedEvent.ProtoReflect.Descriptor instead.
 func (*AccountDeletionConfirmationIssuedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{4}
+	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *AccountDeletionConfirmationIssuedEvent) GetUserId() string {
@@ -342,7 +288,7 @@ type PasswordResetCompletedEvent struct {
 
 func (x *PasswordResetCompletedEvent) Reset() {
 	*x = PasswordResetCompletedEvent{}
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[5]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -354,7 +300,7 @@ func (x *PasswordResetCompletedEvent) String() string {
 func (*PasswordResetCompletedEvent) ProtoMessage() {}
 
 func (x *PasswordResetCompletedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[5]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -367,7 +313,7 @@ func (x *PasswordResetCompletedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PasswordResetCompletedEvent.ProtoReflect.Descriptor instead.
 func (*PasswordResetCompletedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{5}
+	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *PasswordResetCompletedEvent) GetUserId() string {
@@ -395,7 +341,7 @@ type LoginSucceededEvent struct {
 
 func (x *LoginSucceededEvent) Reset() {
 	*x = LoginSucceededEvent{}
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[6]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -407,7 +353,7 @@ func (x *LoginSucceededEvent) String() string {
 func (*LoginSucceededEvent) ProtoMessage() {}
 
 func (x *LoginSucceededEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[6]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -420,7 +366,7 @@ func (x *LoginSucceededEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoginSucceededEvent.ProtoReflect.Descriptor instead.
 func (*LoginSucceededEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{6}
+	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *LoginSucceededEvent) GetUserId() string {
@@ -454,7 +400,7 @@ type LoginFailedEvent struct {
 
 func (x *LoginFailedEvent) Reset() {
 	*x = LoginFailedEvent{}
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[7]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -466,7 +412,7 @@ func (x *LoginFailedEvent) String() string {
 func (*LoginFailedEvent) ProtoMessage() {}
 
 func (x *LoginFailedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[7]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -479,7 +425,7 @@ func (x *LoginFailedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoginFailedEvent.ProtoReflect.Descriptor instead.
 func (*LoginFailedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{7}
+	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *LoginFailedEvent) GetIdentifierHash() string {
@@ -506,7 +452,7 @@ type LogoutSucceededEvent struct {
 
 func (x *LogoutSucceededEvent) Reset() {
 	*x = LogoutSucceededEvent{}
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[8]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -518,7 +464,7 @@ func (x *LogoutSucceededEvent) String() string {
 func (*LogoutSucceededEvent) ProtoMessage() {}
 
 func (x *LogoutSucceededEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[8]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -531,7 +477,7 @@ func (x *LogoutSucceededEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogoutSucceededEvent.ProtoReflect.Descriptor instead.
 func (*LogoutSucceededEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{8}
+	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *LogoutSucceededEvent) GetUserId() string {
@@ -560,7 +506,7 @@ type AuthCodeIssuedEvent struct {
 
 func (x *AuthCodeIssuedEvent) Reset() {
 	*x = AuthCodeIssuedEvent{}
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[9]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -572,7 +518,7 @@ func (x *AuthCodeIssuedEvent) String() string {
 func (*AuthCodeIssuedEvent) ProtoMessage() {}
 
 func (x *AuthCodeIssuedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[9]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -585,7 +531,7 @@ func (x *AuthCodeIssuedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthCodeIssuedEvent.ProtoReflect.Descriptor instead.
 func (*AuthCodeIssuedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{9}
+	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *AuthCodeIssuedEvent) GetUserId() string {
@@ -627,7 +573,7 @@ type AuthCodeExchangeSucceededEvent struct {
 
 func (x *AuthCodeExchangeSucceededEvent) Reset() {
 	*x = AuthCodeExchangeSucceededEvent{}
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[10]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -639,7 +585,7 @@ func (x *AuthCodeExchangeSucceededEvent) String() string {
 func (*AuthCodeExchangeSucceededEvent) ProtoMessage() {}
 
 func (x *AuthCodeExchangeSucceededEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[10]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -652,7 +598,7 @@ func (x *AuthCodeExchangeSucceededEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthCodeExchangeSucceededEvent.ProtoReflect.Descriptor instead.
 func (*AuthCodeExchangeSucceededEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{10}
+	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *AuthCodeExchangeSucceededEvent) GetUserId() string {
@@ -688,7 +634,7 @@ type AuthCodeExchangeFailedEvent struct {
 
 func (x *AuthCodeExchangeFailedEvent) Reset() {
 	*x = AuthCodeExchangeFailedEvent{}
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[11]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -700,7 +646,7 @@ func (x *AuthCodeExchangeFailedEvent) String() string {
 func (*AuthCodeExchangeFailedEvent) ProtoMessage() {}
 
 func (x *AuthCodeExchangeFailedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[11]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -713,7 +659,7 @@ func (x *AuthCodeExchangeFailedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthCodeExchangeFailedEvent.ProtoReflect.Descriptor instead.
 func (*AuthCodeExchangeFailedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{11}
+	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *AuthCodeExchangeFailedEvent) GetUserId() string {
@@ -756,7 +702,7 @@ type BearerTokenIssuedEvent struct {
 
 func (x *BearerTokenIssuedEvent) Reset() {
 	*x = BearerTokenIssuedEvent{}
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[12]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -768,7 +714,7 @@ func (x *BearerTokenIssuedEvent) String() string {
 func (*BearerTokenIssuedEvent) ProtoMessage() {}
 
 func (x *BearerTokenIssuedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[12]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -781,7 +727,7 @@ func (x *BearerTokenIssuedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BearerTokenIssuedEvent.ProtoReflect.Descriptor instead.
 func (*BearerTokenIssuedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{12}
+	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *BearerTokenIssuedEvent) GetUserId() string {
@@ -823,7 +769,7 @@ type BearerTokenRevokedEvent struct {
 
 func (x *BearerTokenRevokedEvent) Reset() {
 	*x = BearerTokenRevokedEvent{}
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[13]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -835,7 +781,7 @@ func (x *BearerTokenRevokedEvent) String() string {
 func (*BearerTokenRevokedEvent) ProtoMessage() {}
 
 func (x *BearerTokenRevokedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[13]
+	mi := &file_chatto_core_v1_auth_events_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -848,7 +794,7 @@ func (x *BearerTokenRevokedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BearerTokenRevokedEvent.ProtoReflect.Descriptor instead.
 func (*BearerTokenRevokedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{13}
+	return file_chatto_core_v1_auth_events_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *BearerTokenRevokedEvent) GetUserId() string {
@@ -876,11 +822,7 @@ var File_chatto_core_v1_auth_events_proto protoreflect.FileDescriptor
 
 const file_chatto_core_v1_auth_events_proto_rawDesc = "" +
 	"\n" +
-	" chatto/core/v1/auth_events.proto\x12\x0echatto.core.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"N\n" +
-	"\x14AuditRequestMetadata\x12\x1d\n" +
-	"\n" +
-	"user_agent\x18\x01 \x01(\tR\tuserAgent\x12\x17\n" +
-	"\aip_hash\x18\x02 \x01(\tR\x06ipHash\"\xb7\x01\n" +
+	" chatto/core/v1/auth_events.proto\x12\x0echatto.core.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1bchatto/core/v1/models.proto\"\xb7\x01\n" +
 	"\x1bRegistrationLinkIssuedEvent\x12\x1d\n" +
 	"\n" +
 	"email_hash\x18\x01 \x01(\tR\temailHash\x129\n" +
@@ -958,44 +900,44 @@ func file_chatto_core_v1_auth_events_proto_rawDescGZIP() []byte {
 	return file_chatto_core_v1_auth_events_proto_rawDescData
 }
 
-var file_chatto_core_v1_auth_events_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
+var file_chatto_core_v1_auth_events_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_chatto_core_v1_auth_events_proto_goTypes = []any{
-	(*AuditRequestMetadata)(nil),                   // 0: chatto.core.v1.AuditRequestMetadata
-	(*RegistrationLinkIssuedEvent)(nil),            // 1: chatto.core.v1.RegistrationLinkIssuedEvent
-	(*EmailVerificationLinkIssuedEvent)(nil),       // 2: chatto.core.v1.EmailVerificationLinkIssuedEvent
-	(*PasswordResetLinkIssuedEvent)(nil),           // 3: chatto.core.v1.PasswordResetLinkIssuedEvent
-	(*AccountDeletionConfirmationIssuedEvent)(nil), // 4: chatto.core.v1.AccountDeletionConfirmationIssuedEvent
-	(*PasswordResetCompletedEvent)(nil),            // 5: chatto.core.v1.PasswordResetCompletedEvent
-	(*LoginSucceededEvent)(nil),                    // 6: chatto.core.v1.LoginSucceededEvent
-	(*LoginFailedEvent)(nil),                       // 7: chatto.core.v1.LoginFailedEvent
-	(*LogoutSucceededEvent)(nil),                   // 8: chatto.core.v1.LogoutSucceededEvent
-	(*AuthCodeIssuedEvent)(nil),                    // 9: chatto.core.v1.AuthCodeIssuedEvent
-	(*AuthCodeExchangeSucceededEvent)(nil),         // 10: chatto.core.v1.AuthCodeExchangeSucceededEvent
-	(*AuthCodeExchangeFailedEvent)(nil),            // 11: chatto.core.v1.AuthCodeExchangeFailedEvent
-	(*BearerTokenIssuedEvent)(nil),                 // 12: chatto.core.v1.BearerTokenIssuedEvent
-	(*BearerTokenRevokedEvent)(nil),                // 13: chatto.core.v1.BearerTokenRevokedEvent
-	(*timestamppb.Timestamp)(nil),                  // 14: google.protobuf.Timestamp
+	(*RegistrationLinkIssuedEvent)(nil),            // 0: chatto.core.v1.RegistrationLinkIssuedEvent
+	(*EmailVerificationLinkIssuedEvent)(nil),       // 1: chatto.core.v1.EmailVerificationLinkIssuedEvent
+	(*PasswordResetLinkIssuedEvent)(nil),           // 2: chatto.core.v1.PasswordResetLinkIssuedEvent
+	(*AccountDeletionConfirmationIssuedEvent)(nil), // 3: chatto.core.v1.AccountDeletionConfirmationIssuedEvent
+	(*PasswordResetCompletedEvent)(nil),            // 4: chatto.core.v1.PasswordResetCompletedEvent
+	(*LoginSucceededEvent)(nil),                    // 5: chatto.core.v1.LoginSucceededEvent
+	(*LoginFailedEvent)(nil),                       // 6: chatto.core.v1.LoginFailedEvent
+	(*LogoutSucceededEvent)(nil),                   // 7: chatto.core.v1.LogoutSucceededEvent
+	(*AuthCodeIssuedEvent)(nil),                    // 8: chatto.core.v1.AuthCodeIssuedEvent
+	(*AuthCodeExchangeSucceededEvent)(nil),         // 9: chatto.core.v1.AuthCodeExchangeSucceededEvent
+	(*AuthCodeExchangeFailedEvent)(nil),            // 10: chatto.core.v1.AuthCodeExchangeFailedEvent
+	(*BearerTokenIssuedEvent)(nil),                 // 11: chatto.core.v1.BearerTokenIssuedEvent
+	(*BearerTokenRevokedEvent)(nil),                // 12: chatto.core.v1.BearerTokenRevokedEvent
+	(*timestamppb.Timestamp)(nil),                  // 13: google.protobuf.Timestamp
+	(*AuditRequestMetadata)(nil),                   // 14: chatto.core.v1.AuditRequestMetadata
 }
 var file_chatto_core_v1_auth_events_proto_depIdxs = []int32{
-	14, // 0: chatto.core.v1.RegistrationLinkIssuedEvent.expires_at:type_name -> google.protobuf.Timestamp
-	0,  // 1: chatto.core.v1.RegistrationLinkIssuedEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
-	14, // 2: chatto.core.v1.EmailVerificationLinkIssuedEvent.expires_at:type_name -> google.protobuf.Timestamp
-	0,  // 3: chatto.core.v1.EmailVerificationLinkIssuedEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
-	14, // 4: chatto.core.v1.PasswordResetLinkIssuedEvent.expires_at:type_name -> google.protobuf.Timestamp
-	0,  // 5: chatto.core.v1.PasswordResetLinkIssuedEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
-	14, // 6: chatto.core.v1.AccountDeletionConfirmationIssuedEvent.expires_at:type_name -> google.protobuf.Timestamp
-	0,  // 7: chatto.core.v1.AccountDeletionConfirmationIssuedEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
-	0,  // 8: chatto.core.v1.PasswordResetCompletedEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
-	0,  // 9: chatto.core.v1.LoginSucceededEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
-	0,  // 10: chatto.core.v1.LoginFailedEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
-	0,  // 11: chatto.core.v1.LogoutSucceededEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
-	14, // 12: chatto.core.v1.AuthCodeIssuedEvent.expires_at:type_name -> google.protobuf.Timestamp
-	0,  // 13: chatto.core.v1.AuthCodeIssuedEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
-	0,  // 14: chatto.core.v1.AuthCodeExchangeSucceededEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
-	0,  // 15: chatto.core.v1.AuthCodeExchangeFailedEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
-	14, // 16: chatto.core.v1.BearerTokenIssuedEvent.expires_at:type_name -> google.protobuf.Timestamp
-	0,  // 17: chatto.core.v1.BearerTokenIssuedEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
-	0,  // 18: chatto.core.v1.BearerTokenRevokedEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
+	13, // 0: chatto.core.v1.RegistrationLinkIssuedEvent.expires_at:type_name -> google.protobuf.Timestamp
+	14, // 1: chatto.core.v1.RegistrationLinkIssuedEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
+	13, // 2: chatto.core.v1.EmailVerificationLinkIssuedEvent.expires_at:type_name -> google.protobuf.Timestamp
+	14, // 3: chatto.core.v1.EmailVerificationLinkIssuedEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
+	13, // 4: chatto.core.v1.PasswordResetLinkIssuedEvent.expires_at:type_name -> google.protobuf.Timestamp
+	14, // 5: chatto.core.v1.PasswordResetLinkIssuedEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
+	13, // 6: chatto.core.v1.AccountDeletionConfirmationIssuedEvent.expires_at:type_name -> google.protobuf.Timestamp
+	14, // 7: chatto.core.v1.AccountDeletionConfirmationIssuedEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
+	14, // 8: chatto.core.v1.PasswordResetCompletedEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
+	14, // 9: chatto.core.v1.LoginSucceededEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
+	14, // 10: chatto.core.v1.LoginFailedEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
+	14, // 11: chatto.core.v1.LogoutSucceededEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
+	13, // 12: chatto.core.v1.AuthCodeIssuedEvent.expires_at:type_name -> google.protobuf.Timestamp
+	14, // 13: chatto.core.v1.AuthCodeIssuedEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
+	14, // 14: chatto.core.v1.AuthCodeExchangeSucceededEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
+	14, // 15: chatto.core.v1.AuthCodeExchangeFailedEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
+	13, // 16: chatto.core.v1.BearerTokenIssuedEvent.expires_at:type_name -> google.protobuf.Timestamp
+	14, // 17: chatto.core.v1.BearerTokenIssuedEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
+	14, // 18: chatto.core.v1.BearerTokenRevokedEvent.request:type_name -> chatto.core.v1.AuditRequestMetadata
 	19, // [19:19] is the sub-list for method output_type
 	19, // [19:19] is the sub-list for method input_type
 	19, // [19:19] is the sub-list for extension type_name
@@ -1008,13 +950,14 @@ func file_chatto_core_v1_auth_events_proto_init() {
 	if File_chatto_core_v1_auth_events_proto != nil {
 		return
 	}
+	file_chatto_core_v1_models_proto_init()
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_core_v1_auth_events_proto_rawDesc), len(file_chatto_core_v1_auth_events_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   14,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/cli/internal/pb/chatto/core/v1/models.pb.go
+++ b/cli/internal/pb/chatto/core/v1/models.pb.go
@@ -397,6 +397,140 @@ func (x *VerifiedEmail) GetVerifiedAt() *timestamppb.Timestamp {
 	return nil
 }
 
+// AuditRequestMetadata captures request details that are safe to persist in
+// auth audit facts and auth-adjacent runtime records. Raw IP addresses, links,
+// and tokens never belong here.
+type AuditRequestMetadata struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserAgent     string                 `protobuf:"bytes,1,opt,name=user_agent,json=userAgent,proto3" json:"user_agent,omitempty"`
+	IpHash        string                 `protobuf:"bytes,2,opt,name=ip_hash,json=ipHash,proto3" json:"ip_hash,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AuditRequestMetadata) Reset() {
+	*x = AuditRequestMetadata{}
+	mi := &file_chatto_core_v1_models_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AuditRequestMetadata) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AuditRequestMetadata) ProtoMessage() {}
+
+func (x *AuditRequestMetadata) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_models_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AuditRequestMetadata.ProtoReflect.Descriptor instead.
+func (*AuditRequestMetadata) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *AuditRequestMetadata) GetUserAgent() string {
+	if x != nil {
+		return x.UserAgent
+	}
+	return ""
+}
+
+func (x *AuditRequestMetadata) GetIpHash() string {
+	if x != nil {
+		return x.IpHash
+	}
+	return ""
+}
+
+// CookieSession is the server-side runtime-state record for the embedded SPA's
+// HTTP cookie session. The raw session ID is never stored in this payload; it is
+// represented only by the HMAC-derived RUNTIME_STATE key.
+type CookieSession struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	CreatedAt     *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	ExpiresAt     *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"`
+	Source        string                 `protobuf:"bytes,4,opt,name=source,proto3" json:"source,omitempty"`
+	Request       *AuditRequestMetadata  `protobuf:"bytes,5,opt,name=request,proto3" json:"request,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CookieSession) Reset() {
+	*x = CookieSession{}
+	mi := &file_chatto_core_v1_models_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CookieSession) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CookieSession) ProtoMessage() {}
+
+func (x *CookieSession) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_models_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CookieSession.ProtoReflect.Descriptor instead.
+func (*CookieSession) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *CookieSession) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+func (x *CookieSession) GetCreatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return nil
+}
+
+func (x *CookieSession) GetExpiresAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ExpiresAt
+	}
+	return nil
+}
+
+func (x *CookieSession) GetSource() string {
+	if x != nil {
+		return x.Source
+	}
+	return ""
+}
+
+func (x *CookieSession) GetRequest() *AuditRequestMetadata {
+	if x != nil {
+		return x.Request
+	}
+	return nil
+}
+
 // DeprecatedAsset is the storage-pointer-only proto used for legacy values:
 // branding KV entries, avatar pointers on UserAvatarSetEvent, and the
 // Storage field on legacy embedded Attachment protos. Wire format matches
@@ -416,7 +550,7 @@ type DeprecatedAsset struct {
 
 func (x *DeprecatedAsset) Reset() {
 	*x = DeprecatedAsset{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[3]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -428,7 +562,7 @@ func (x *DeprecatedAsset) String() string {
 func (*DeprecatedAsset) ProtoMessage() {}
 
 func (x *DeprecatedAsset) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[3]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -441,7 +575,7 @@ func (x *DeprecatedAsset) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeprecatedAsset.ProtoReflect.Descriptor instead.
 func (*DeprecatedAsset) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{3}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *DeprecatedAsset) GetAsset() isDeprecatedAsset_Asset {
@@ -495,7 +629,7 @@ type S3Asset struct {
 
 func (x *S3Asset) Reset() {
 	*x = S3Asset{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[4]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -507,7 +641,7 @@ func (x *S3Asset) String() string {
 func (*S3Asset) ProtoMessage() {}
 
 func (x *S3Asset) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[4]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -520,7 +654,7 @@ func (x *S3Asset) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use S3Asset.ProtoReflect.Descriptor instead.
 func (*S3Asset) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{4}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *S3Asset) GetKey() string {
@@ -546,7 +680,7 @@ type NATSAsset struct {
 
 func (x *NATSAsset) Reset() {
 	*x = NATSAsset{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[5]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -558,7 +692,7 @@ func (x *NATSAsset) String() string {
 func (*NATSAsset) ProtoMessage() {}
 
 func (x *NATSAsset) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[5]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -571,7 +705,7 @@ func (x *NATSAsset) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NATSAsset.ProtoReflect.Descriptor instead.
 func (*NATSAsset) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{5}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *NATSAsset) GetKey() string {
@@ -614,7 +748,7 @@ type AssetRecord struct {
 
 func (x *AssetRecord) Reset() {
 	*x = AssetRecord{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[6]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -626,7 +760,7 @@ func (x *AssetRecord) String() string {
 func (*AssetRecord) ProtoMessage() {}
 
 func (x *AssetRecord) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[6]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -639,7 +773,7 @@ func (x *AssetRecord) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssetRecord.ProtoReflect.Descriptor instead.
 func (*AssetRecord) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{6}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *AssetRecord) GetId() string {
@@ -749,7 +883,7 @@ type RoomMembership struct {
 
 func (x *RoomMembership) Reset() {
 	*x = RoomMembership{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[7]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -761,7 +895,7 @@ func (x *RoomMembership) String() string {
 func (*RoomMembership) ProtoMessage() {}
 
 func (x *RoomMembership) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[7]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -774,7 +908,7 @@ func (x *RoomMembership) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomMembership.ProtoReflect.Descriptor instead.
 func (*RoomMembership) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{7}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *RoomMembership) GetUserId() string {
@@ -804,7 +938,7 @@ type Role struct {
 
 func (x *Role) Reset() {
 	*x = Role{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[8]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -816,7 +950,7 @@ func (x *Role) String() string {
 func (*Role) ProtoMessage() {}
 
 func (x *Role) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[8]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -829,7 +963,7 @@ func (x *Role) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Role.ProtoReflect.Descriptor instead.
 func (*Role) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{8}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *Role) GetName() string {
@@ -871,7 +1005,7 @@ type UserPresence struct {
 
 func (x *UserPresence) Reset() {
 	*x = UserPresence{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[9]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -883,7 +1017,7 @@ func (x *UserPresence) String() string {
 func (*UserPresence) ProtoMessage() {}
 
 func (x *UserPresence) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[9]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -896,7 +1030,7 @@ func (x *UserPresence) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserPresence.ProtoReflect.Descriptor instead.
 func (*UserPresence) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{9}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *UserPresence) GetStatus() UserPresenceStatus {
@@ -918,7 +1052,7 @@ type PresenceChange struct {
 
 func (x *PresenceChange) Reset() {
 	*x = PresenceChange{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[10]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -930,7 +1064,7 @@ func (x *PresenceChange) String() string {
 func (*PresenceChange) ProtoMessage() {}
 
 func (x *PresenceChange) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[10]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -943,7 +1077,7 @@ func (x *PresenceChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PresenceChange.ProtoReflect.Descriptor instead.
 func (*PresenceChange) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{10}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *PresenceChange) GetUserId() string {
@@ -979,7 +1113,7 @@ type ThreadMetadata struct {
 
 func (x *ThreadMetadata) Reset() {
 	*x = ThreadMetadata{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[11]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -991,7 +1125,7 @@ func (x *ThreadMetadata) String() string {
 func (*ThreadMetadata) ProtoMessage() {}
 
 func (x *ThreadMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[11]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1004,7 +1138,7 @@ func (x *ThreadMetadata) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ThreadMetadata.ProtoReflect.Descriptor instead.
 func (*ThreadMetadata) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{11}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ThreadMetadata) GetRootEventId() string {
@@ -1073,7 +1207,7 @@ type Attachment struct {
 
 func (x *Attachment) Reset() {
 	*x = Attachment{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[12]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1085,7 +1219,7 @@ func (x *Attachment) String() string {
 func (*Attachment) ProtoMessage() {}
 
 func (x *Attachment) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[12]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1098,7 +1232,7 @@ func (x *Attachment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Attachment.ProtoReflect.Descriptor instead.
 func (*Attachment) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{12}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *Attachment) GetId() string {
@@ -1210,7 +1344,7 @@ type MessageBody struct {
 
 func (x *MessageBody) Reset() {
 	*x = MessageBody{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[13]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1222,7 +1356,7 @@ func (x *MessageBody) String() string {
 func (*MessageBody) ProtoMessage() {}
 
 func (x *MessageBody) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[13]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1235,7 +1369,7 @@ func (x *MessageBody) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageBody.ProtoReflect.Descriptor instead.
 func (*MessageBody) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{13}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *MessageBody) GetAuthorId() string {
@@ -1329,7 +1463,7 @@ type LinkPreview struct {
 
 func (x *LinkPreview) Reset() {
 	*x = LinkPreview{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[14]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1341,7 +1475,7 @@ func (x *LinkPreview) String() string {
 func (*LinkPreview) ProtoMessage() {}
 
 func (x *LinkPreview) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[14]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1354,7 +1488,7 @@ func (x *LinkPreview) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LinkPreview.ProtoReflect.Descriptor instead.
 func (*LinkPreview) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{14}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *LinkPreview) GetUrl() string {
@@ -1426,7 +1560,7 @@ type CachedLinkPreview struct {
 
 func (x *CachedLinkPreview) Reset() {
 	*x = CachedLinkPreview{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[15]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1438,7 +1572,7 @@ func (x *CachedLinkPreview) String() string {
 func (*CachedLinkPreview) ProtoMessage() {}
 
 func (x *CachedLinkPreview) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[15]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1451,7 +1585,7 @@ func (x *CachedLinkPreview) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CachedLinkPreview.ProtoReflect.Descriptor instead.
 func (*CachedLinkPreview) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{15}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *CachedLinkPreview) GetUrl() string {
@@ -1533,7 +1667,7 @@ type RoomLayout struct {
 
 func (x *RoomLayout) Reset() {
 	*x = RoomLayout{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[16]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1545,7 +1679,7 @@ func (x *RoomLayout) String() string {
 func (*RoomLayout) ProtoMessage() {}
 
 func (x *RoomLayout) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[16]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1558,7 +1692,7 @@ func (x *RoomLayout) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomLayout.ProtoReflect.Descriptor instead.
 func (*RoomLayout) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{16}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{18}
 }
 
 // Deprecated: Marked as deprecated in chatto/core/v1/models.proto.
@@ -1600,7 +1734,7 @@ type RoomGroup struct {
 
 func (x *RoomGroup) Reset() {
 	*x = RoomGroup{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[17]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1612,7 +1746,7 @@ func (x *RoomGroup) String() string {
 func (*RoomGroup) ProtoMessage() {}
 
 func (x *RoomGroup) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[17]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1625,7 +1759,7 @@ func (x *RoomGroup) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomGroup.ProtoReflect.Descriptor instead.
 func (*RoomGroup) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{17}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *RoomGroup) GetId() string {
@@ -1686,7 +1820,7 @@ type VideoProcessingState struct {
 
 func (x *VideoProcessingState) Reset() {
 	*x = VideoProcessingState{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[18]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1698,7 +1832,7 @@ func (x *VideoProcessingState) String() string {
 func (*VideoProcessingState) ProtoMessage() {}
 
 func (x *VideoProcessingState) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[18]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1711,7 +1845,7 @@ func (x *VideoProcessingState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VideoProcessingState.ProtoReflect.Descriptor instead.
 func (*VideoProcessingState) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{18}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *VideoProcessingState) GetStatus() VideoStatus {
@@ -1792,7 +1926,7 @@ type VideoVariant struct {
 
 func (x *VideoVariant) Reset() {
 	*x = VideoVariant{}
-	mi := &file_chatto_core_v1_models_proto_msgTypes[19]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1804,7 +1938,7 @@ func (x *VideoVariant) String() string {
 func (*VideoVariant) ProtoMessage() {}
 
 func (x *VideoVariant) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_models_proto_msgTypes[19]
+	mi := &file_chatto_core_v1_models_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1817,7 +1951,7 @@ func (x *VideoVariant) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VideoVariant.ProtoReflect.Descriptor instead.
 func (*VideoVariant) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{19}
+	return file_chatto_core_v1_models_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *VideoVariant) GetAttachmentId() string {
@@ -1883,7 +2017,19 @@ const file_chatto_core_v1_models_proto_rawDesc = "" +
 	"\rVerifiedEmail\x12\x14\n" +
 	"\x05email\x18\x01 \x01(\tR\x05email\x12;\n" +
 	"\vverified_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
-	"verifiedAt\"v\n" +
+	"verifiedAt\"N\n" +
+	"\x14AuditRequestMetadata\x12\x1d\n" +
+	"\n" +
+	"user_agent\x18\x01 \x01(\tR\tuserAgent\x12\x17\n" +
+	"\aip_hash\x18\x02 \x01(\tR\x06ipHash\"\xf6\x01\n" +
+	"\rCookieSession\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\x129\n" +
+	"\n" +
+	"created_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x129\n" +
+	"\n" +
+	"expires_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\x12\x16\n" +
+	"\x06source\x18\x04 \x01(\tR\x06source\x12>\n" +
+	"\arequest\x18\x05 \x01(\v2$.chatto.core.v1.AuditRequestMetadataR\arequest\"v\n" +
 	"\x0fDeprecatedAsset\x12/\n" +
 	"\x04nats\x18\x02 \x01(\v2\x19.chatto.core.v1.NATSAssetH\x00R\x04nats\x12)\n" +
 	"\x02s3\x18\x01 \x01(\v2\x17.chatto.core.v1.S3AssetH\x00R\x02s3B\a\n" +
@@ -2026,7 +2172,7 @@ func file_chatto_core_v1_models_proto_rawDescGZIP() []byte {
 }
 
 var file_chatto_core_v1_models_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_chatto_core_v1_models_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
+var file_chatto_core_v1_models_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
 var file_chatto_core_v1_models_proto_goTypes = []any{
 	(RoomKind)(0),                 // 0: chatto.core.v1.RoomKind
 	(UserPresenceStatus)(0),       // 1: chatto.core.v1.UserPresenceStatus
@@ -2034,51 +2180,56 @@ var file_chatto_core_v1_models_proto_goTypes = []any{
 	(*Room)(nil),                  // 3: chatto.core.v1.Room
 	(*User)(nil),                  // 4: chatto.core.v1.User
 	(*VerifiedEmail)(nil),         // 5: chatto.core.v1.VerifiedEmail
-	(*DeprecatedAsset)(nil),       // 6: chatto.core.v1.DeprecatedAsset
-	(*S3Asset)(nil),               // 7: chatto.core.v1.S3Asset
-	(*NATSAsset)(nil),             // 8: chatto.core.v1.NATSAsset
-	(*AssetRecord)(nil),           // 9: chatto.core.v1.AssetRecord
-	(*RoomMembership)(nil),        // 10: chatto.core.v1.RoomMembership
-	(*Role)(nil),                  // 11: chatto.core.v1.Role
-	(*UserPresence)(nil),          // 12: chatto.core.v1.UserPresence
-	(*PresenceChange)(nil),        // 13: chatto.core.v1.PresenceChange
-	(*ThreadMetadata)(nil),        // 14: chatto.core.v1.ThreadMetadata
-	(*Attachment)(nil),            // 15: chatto.core.v1.Attachment
-	(*MessageBody)(nil),           // 16: chatto.core.v1.MessageBody
-	(*LinkPreview)(nil),           // 17: chatto.core.v1.LinkPreview
-	(*CachedLinkPreview)(nil),     // 18: chatto.core.v1.CachedLinkPreview
-	(*RoomLayout)(nil),            // 19: chatto.core.v1.RoomLayout
-	(*RoomGroup)(nil),             // 20: chatto.core.v1.RoomGroup
-	(*VideoProcessingState)(nil),  // 21: chatto.core.v1.VideoProcessingState
-	(*VideoVariant)(nil),          // 22: chatto.core.v1.VideoVariant
-	(*timestamppb.Timestamp)(nil), // 23: google.protobuf.Timestamp
+	(*AuditRequestMetadata)(nil),  // 6: chatto.core.v1.AuditRequestMetadata
+	(*CookieSession)(nil),         // 7: chatto.core.v1.CookieSession
+	(*DeprecatedAsset)(nil),       // 8: chatto.core.v1.DeprecatedAsset
+	(*S3Asset)(nil),               // 9: chatto.core.v1.S3Asset
+	(*NATSAsset)(nil),             // 10: chatto.core.v1.NATSAsset
+	(*AssetRecord)(nil),           // 11: chatto.core.v1.AssetRecord
+	(*RoomMembership)(nil),        // 12: chatto.core.v1.RoomMembership
+	(*Role)(nil),                  // 13: chatto.core.v1.Role
+	(*UserPresence)(nil),          // 14: chatto.core.v1.UserPresence
+	(*PresenceChange)(nil),        // 15: chatto.core.v1.PresenceChange
+	(*ThreadMetadata)(nil),        // 16: chatto.core.v1.ThreadMetadata
+	(*Attachment)(nil),            // 17: chatto.core.v1.Attachment
+	(*MessageBody)(nil),           // 18: chatto.core.v1.MessageBody
+	(*LinkPreview)(nil),           // 19: chatto.core.v1.LinkPreview
+	(*CachedLinkPreview)(nil),     // 20: chatto.core.v1.CachedLinkPreview
+	(*RoomLayout)(nil),            // 21: chatto.core.v1.RoomLayout
+	(*RoomGroup)(nil),             // 22: chatto.core.v1.RoomGroup
+	(*VideoProcessingState)(nil),  // 23: chatto.core.v1.VideoProcessingState
+	(*VideoVariant)(nil),          // 24: chatto.core.v1.VideoVariant
+	(*timestamppb.Timestamp)(nil), // 25: google.protobuf.Timestamp
 }
 var file_chatto_core_v1_models_proto_depIdxs = []int32{
 	0,  // 0: chatto.core.v1.Room.kind:type_name -> chatto.core.v1.RoomKind
-	23, // 1: chatto.core.v1.User.created_at:type_name -> google.protobuf.Timestamp
-	23, // 2: chatto.core.v1.VerifiedEmail.verified_at:type_name -> google.protobuf.Timestamp
-	8,  // 3: chatto.core.v1.DeprecatedAsset.nats:type_name -> chatto.core.v1.NATSAsset
-	7,  // 4: chatto.core.v1.DeprecatedAsset.s3:type_name -> chatto.core.v1.S3Asset
-	8,  // 5: chatto.core.v1.AssetRecord.nats:type_name -> chatto.core.v1.NATSAsset
-	7,  // 6: chatto.core.v1.AssetRecord.s3:type_name -> chatto.core.v1.S3Asset
-	1,  // 7: chatto.core.v1.UserPresence.status:type_name -> chatto.core.v1.UserPresenceStatus
-	23, // 8: chatto.core.v1.ThreadMetadata.last_reply_at:type_name -> google.protobuf.Timestamp
-	6,  // 9: chatto.core.v1.Attachment.storage:type_name -> chatto.core.v1.DeprecatedAsset
-	23, // 10: chatto.core.v1.MessageBody.created_at:type_name -> google.protobuf.Timestamp
-	23, // 11: chatto.core.v1.MessageBody.updated_at:type_name -> google.protobuf.Timestamp
-	15, // 12: chatto.core.v1.MessageBody.attachments:type_name -> chatto.core.v1.Attachment
-	17, // 13: chatto.core.v1.MessageBody.link_preview:type_name -> chatto.core.v1.LinkPreview
-	17, // 14: chatto.core.v1.CachedLinkPreview.preview:type_name -> chatto.core.v1.LinkPreview
-	20, // 15: chatto.core.v1.RoomLayout.legacy_sections:type_name -> chatto.core.v1.RoomGroup
-	2,  // 16: chatto.core.v1.VideoProcessingState.status:type_name -> chatto.core.v1.VideoStatus
-	22, // 17: chatto.core.v1.VideoProcessingState.variants:type_name -> chatto.core.v1.VideoVariant
-	15, // 18: chatto.core.v1.VideoProcessingState.thumbnail_attachment:type_name -> chatto.core.v1.Attachment
-	15, // 19: chatto.core.v1.VideoVariant.attachment:type_name -> chatto.core.v1.Attachment
-	20, // [20:20] is the sub-list for method output_type
-	20, // [20:20] is the sub-list for method input_type
-	20, // [20:20] is the sub-list for extension type_name
-	20, // [20:20] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	25, // 1: chatto.core.v1.User.created_at:type_name -> google.protobuf.Timestamp
+	25, // 2: chatto.core.v1.VerifiedEmail.verified_at:type_name -> google.protobuf.Timestamp
+	25, // 3: chatto.core.v1.CookieSession.created_at:type_name -> google.protobuf.Timestamp
+	25, // 4: chatto.core.v1.CookieSession.expires_at:type_name -> google.protobuf.Timestamp
+	6,  // 5: chatto.core.v1.CookieSession.request:type_name -> chatto.core.v1.AuditRequestMetadata
+	10, // 6: chatto.core.v1.DeprecatedAsset.nats:type_name -> chatto.core.v1.NATSAsset
+	9,  // 7: chatto.core.v1.DeprecatedAsset.s3:type_name -> chatto.core.v1.S3Asset
+	10, // 8: chatto.core.v1.AssetRecord.nats:type_name -> chatto.core.v1.NATSAsset
+	9,  // 9: chatto.core.v1.AssetRecord.s3:type_name -> chatto.core.v1.S3Asset
+	1,  // 10: chatto.core.v1.UserPresence.status:type_name -> chatto.core.v1.UserPresenceStatus
+	25, // 11: chatto.core.v1.ThreadMetadata.last_reply_at:type_name -> google.protobuf.Timestamp
+	8,  // 12: chatto.core.v1.Attachment.storage:type_name -> chatto.core.v1.DeprecatedAsset
+	25, // 13: chatto.core.v1.MessageBody.created_at:type_name -> google.protobuf.Timestamp
+	25, // 14: chatto.core.v1.MessageBody.updated_at:type_name -> google.protobuf.Timestamp
+	17, // 15: chatto.core.v1.MessageBody.attachments:type_name -> chatto.core.v1.Attachment
+	19, // 16: chatto.core.v1.MessageBody.link_preview:type_name -> chatto.core.v1.LinkPreview
+	19, // 17: chatto.core.v1.CachedLinkPreview.preview:type_name -> chatto.core.v1.LinkPreview
+	22, // 18: chatto.core.v1.RoomLayout.legacy_sections:type_name -> chatto.core.v1.RoomGroup
+	2,  // 19: chatto.core.v1.VideoProcessingState.status:type_name -> chatto.core.v1.VideoStatus
+	24, // 20: chatto.core.v1.VideoProcessingState.variants:type_name -> chatto.core.v1.VideoVariant
+	17, // 21: chatto.core.v1.VideoProcessingState.thumbnail_attachment:type_name -> chatto.core.v1.Attachment
+	17, // 22: chatto.core.v1.VideoVariant.attachment:type_name -> chatto.core.v1.Attachment
+	23, // [23:23] is the sub-list for method output_type
+	23, // [23:23] is the sub-list for method input_type
+	23, // [23:23] is the sub-list for extension type_name
+	23, // [23:23] is the sub-list for extension extendee
+	0,  // [0:23] is the sub-list for field type_name
 }
 
 func init() { file_chatto_core_v1_models_proto_init() }
@@ -2086,23 +2237,23 @@ func file_chatto_core_v1_models_proto_init() {
 	if File_chatto_core_v1_models_proto != nil {
 		return
 	}
-	file_chatto_core_v1_models_proto_msgTypes[3].OneofWrappers = []any{
+	file_chatto_core_v1_models_proto_msgTypes[5].OneofWrappers = []any{
 		(*DeprecatedAsset_Nats)(nil),
 		(*DeprecatedAsset_S3)(nil),
 	}
-	file_chatto_core_v1_models_proto_msgTypes[4].OneofWrappers = []any{}
-	file_chatto_core_v1_models_proto_msgTypes[6].OneofWrappers = []any{
+	file_chatto_core_v1_models_proto_msgTypes[6].OneofWrappers = []any{}
+	file_chatto_core_v1_models_proto_msgTypes[8].OneofWrappers = []any{
 		(*AssetRecord_Nats)(nil),
 		(*AssetRecord_S3)(nil),
 	}
-	file_chatto_core_v1_models_proto_msgTypes[14].OneofWrappers = []any{}
+	file_chatto_core_v1_models_proto_msgTypes[16].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_core_v1_models_proto_rawDesc), len(file_chatto_core_v1_models_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   20,
+			NumMessages:   22,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -483,7 +483,19 @@ Pre-ES room data — channels and DMs alike — lived in the unified `SERVER_*` 
 | `space_membership.{spaceId}.{userId}`  | User-server membership tracking (vestigial slot) |
 | `user_preferences.{userId}`            | User display preferences (timezone, time format) |
 
-Notes: `INSTANCE` is legacy import-only. Current user/account/profile state is projected from `EVT`; legacy KV user records are imported into encrypted durable user events for login, display name, and verified email payloads using the user's active user-PII DEK epoch. Verification, registration, password-reset, account-deletion, bearer-session, and OAuth authorization-code token verifiers live in `RUNTIME_STATE` under HMAC-derived keys. Email verification claim facts use hashed email identifiers in `EVT` to preserve case-insensitive uniqueness without storing raw email values in audit events.
+Notes: `INSTANCE` is legacy import-only. Current user/account/profile state is projected from `EVT`; legacy KV user records are imported into encrypted durable user events for login, display name, and verified email payloads using the user's active user-PII DEK epoch. Cookie-session records plus verification, registration, password-reset, account-deletion, bearer-session, and OAuth authorization-code token verifiers live in `RUNTIME_STATE` under HMAC-derived keys. Email verification claim facts use hashed email identifiers in `EVT` to preserve case-insensitive uniqueness without storing raw email values in audit events.
+
+**RUNTIME_STATE auth/session keys:**
+
+| Key                                           | Description |
+| --------------------------------------------- | ----------- |
+| `cookie_session.{userId}.{sessionHmac}`       | Server-side embedded-SPA cookie session record (proto `CookieSession`) with per-key TTL |
+| `session.{hmac}`                              | Opaque bearer-token verifier with per-key TTL |
+| `grant.{hmac}`                                | OAuth authorization-code verifier with 5-minute per-key TTL |
+| `registration.{hmac}`                         | Email-first registration token verifier |
+| `email_verification.{hmac}`                   | Email verification token verifier |
+| `password_reset.{hmac}`                       | Password reset token verifier |
+| `account_deletion_token.{hmac}`               | Account deletion confirmation token verifier |
 
 **EVT auth audit subjects:**
 

--- a/docs/adr/ADR-036-runtime-state-kv-boundary.md
+++ b/docs/adr/ADR-036-runtime-state-kv-boundary.md
@@ -58,6 +58,10 @@ Current occupants include:
 - Pending notifications: `notification.{userId}.{notificationId}`, with per-key
   90-day TTL.
 - Web Push subscriptions: `push_subscription.{userId}.{endpointHash}`.
+- Embedded-SPA cookie-session records: `cookie_session.{userId}.{sessionHmac}`,
+  with per-key `auth.token_ttl` expiry. The value is a `CookieSession`
+  protobuf containing `user_id`, `created_at`, `expires_at`, source, and safe
+  request metadata.
 - Bearer auth token verifiers: `session.{hmac}`, with per-key
   `auth.token_ttl` sliding-window expiry.
 - OAuth authorization-code verifiers: `grant.{hmac}`, with per-key 5-minute
@@ -69,12 +73,12 @@ Current occupants include:
 - Link-preview cache entries: `link_preview.{urlHash}`, with per-key 24-hour
   TTL for successful previews and 1-hour TTL for failed fetches.
 
-The HMAC keys for bearer tokens, OAuth codes, and account workflow tokens are
+The HMAC keys for cookie sessions, bearer tokens, OAuth codes, and account workflow tokens are
 derived with `[core].secret_key` from the raw token/code plus a per-flow scope
 string. `RUNTIME_STATE` is included in backups, so active sessions and pending
 flows survive restore when the same secret is used; restoring with a different
 secret intentionally invalidates those credentials. Backup archives do not
-contain raw bearer tokens, links, or OAuth codes.
+contain raw cookie session IDs, bearer tokens, links, or OAuth codes.
 
 Attachment declarations and video derivative manifests are not a `RUNTIME_STATE`
 target. Uploaded assets are content and are declared with `AssetCreatedEvent`;

--- a/docs/fdr/FDR-023-authentication-and-sessions.md
+++ b/docs/fdr/FDR-023-authentication-and-sessions.md
@@ -1,7 +1,7 @@
 # FDR-023: Authentication & Sessions
 
 **Status:** Active
-**Last reviewed:** 2026-06-02
+**Last reviewed:** 2026-06-05
 
 ## Overview
 
@@ -11,11 +11,11 @@ Chatto authenticates users via two parallel mechanisms: HTTP-only cookie session
 
 - **Login** — users sign in with login + password on a `/login` page. The page is also used for redirect-after-signup.
 - **OAuth login** — operators can configure OAuth providers (e.g., Google). The login page shows provider buttons; clicking takes the user through the standard authorization-code flow.
-- **Cookie session** — on successful auth from the embedded SPA, the server issues an HTTP-only, SameSite=Lax cookie with a 90-day expiry. The cookie carries the user ID; the server resolves the current user from projections per request.
+- **Cookie session** — on successful auth from the embedded SPA, the server issues an HTTP-only, SameSite=Lax cookie with a 90-day expiry. The cookie carries an opaque session ID plus the user ID needed to derive the lookup key; the authoritative `CookieSession` protobuf record lives in `RUNTIME_STATE` under `cookie_session.{userId}.{hmac}` with a per-key TTL. The server validates the KV record and resolves the current user from projections per request.
 - **Bearer token** — every authentication endpoint also issues an opaque token (format: `cht_AT` + 14-char NanoID). Cross-origin clients store it (usually in `localStorage`) and send it as `Authorization: Bearer …` on HTTP requests and `connectionParams.token` on graphql-ws upgrades. The token record lives in `RUNTIME_STATE` as an HMAC-derived `session.{hmac}` key with a per-key TTL.
 - **WebSocket auth** — for the embedded SPA, the cookie is automatically attached to the WebSocket upgrade and the user is authenticated before the WS handshake completes. For cross-origin clients, the token in `connectionParams` is checked at upgrade time.
-- **Logout** — for cookie sessions: the server clears the session and the SPA does a hard reload. For tokens: the client removes the token from `localStorage`; optionally the server revokes the token by deleting its KV key.
-- **Session refresh** — the cookie TTL gets refreshed as the user actively uses the app (including on static file requests). Bearer tokens follow a sliding-window TTL — each successful validation rewrites the `RUNTIME_STATE` entry with a fresh per-key TTL.
+- **Logout** — for cookie sessions: the server deletes the current cookie-session KV record, clears the cookie, and the SPA does a hard reload. For tokens: the client removes the token from `localStorage`; optionally the server revokes the token by deleting its KV key.
+- **Session refresh** — cookie-session KV TTL cannot be touched in place, so active sessions are rotated near expiry: the server creates a replacement `CookieSession` record with a fresh TTL, updates the browser cookie, and deletes the old record best-effort. Bearer tokens follow a sliding-window TTL — each successful validation rewrites the `RUNTIME_STATE` entry with a fresh per-key TTL.
 - **Password reset tokens** — reset links are backed by `RUNTIME_STATE` HMAC-derived `password_reset.{hmac}` records with a 1-hour per-key TTL. Raw reset tokens and links are never written to `EVT` or backup archives.
 - **Server version handshake** — the WebSocket `connection_ack` payload includes the server's version. The frontend uses this to detect deployed-version drift and prompt the user to refresh.
 - **Auth audit facts** — successful cookie logins, failed password login attempts, logout completion, bearer-token issuance/revocation, OAuth authorization-code issuance/exchange, registration-link issuance, password-reset link issuance, and password-reset completion are appended to `EVT` for admin audit-log inspection. Payloads carry safe request metadata only: capped user agent, HMAC-hashed IP, and hashed identifiers where needed.
@@ -24,8 +24,8 @@ Chatto authenticates users via two parallel mechanisms: HTTP-only cookie session
 
 ### 1. Cookie-based sessions for same-origin
 
-**Decision:** The embedded SPA authenticates via HTTP-only `SameSite=Lax` cookies. The session stores only the user ID; the current user record is resolved from projections per request.
-**Why:** Cookies are the simplest mechanism for browser SPAs — the browser handles attachment, expiry, and HttpOnly protects against XSS-extracted tokens. WebSocket auth comes for free because the browser sends the cookie with the upgrade request. See ADR-017.
+**Decision:** The embedded SPA authenticates via HTTP-only `SameSite=Lax` cookies. The cookie stores an opaque session ID and user ID, while the authoritative `CookieSession` protobuf record lives in `RUNTIME_STATE` with per-key TTL and safe request metadata. The current user record is resolved from projections per request.
+**Why:** Cookies are the simplest mechanism for browser SPAs — the browser handles attachment, expiry, and HttpOnly protects against XSS-extracted tokens. Storing the server-side session record in `RUNTIME_STATE` adds revocation for logout, password changes/resets, and account deletion while staying within Chatto's NATS-backed runtime-state model. WebSocket auth comes from the browser sending the cookie with the upgrade request. See ADR-017 and ADR-036.
 **Tradeoff:** Non-browser clients can't use cookies. The bearer token path exists for them.
 
 ### 2. Bearer tokens for cross-origin
@@ -36,7 +36,7 @@ Chatto authenticates users via two parallel mechanisms: HTTP-only cookie session
 
 ### 3. Sliding-window TTL for tokens (and cookies)
 
-**Decision:** Each successful token validation rewrites the runtime-state entry with a fresh per-key TTL (default 90 days). Cookies are similarly refreshed on every static-file request.
+**Decision:** Each successful token validation rewrites the runtime-state entry with a fresh per-key TTL (default 90 days). Cookie sessions use the same inactivity window but rotate near expiry instead of touching TTL in place.
 **Why:** Time-from-creation expiry would surprise users — "you've been logged in for 90 days, time to re-auth, even though you've been using the app daily". Sliding-window means active users stay logged in indefinitely; only genuinely inactive sessions expire.
 **Tradeoff:** A long-stolen token stays valid until it lapses or gets explicitly revoked. Operators concerned about this can lower the TTL or implement a "revoke all tokens for user" action (not currently exposed — see ADR-024).
 

--- a/proto/chatto/core/v1/auth_events.proto
+++ b/proto/chatto/core/v1/auth_events.proto
@@ -3,15 +3,9 @@ syntax = "proto3";
 package chatto.core.v1;
 
 import "google/protobuf/timestamp.proto";
+import "chatto/core/v1/models.proto";
 
 option go_package = "hmans.de/chatto/internal/pb/chatto/core/v1;corev1";
-
-// AuditRequestMetadata captures request details that are safe to persist in
-// the durable audit log. Raw IP addresses, links, and tokens never belong here.
-message AuditRequestMetadata {
-  string user_agent = 1;
-  string ip_hash = 2;
-}
 
 message RegistrationLinkIssuedEvent {
   string email_hash = 1;

--- a/proto/chatto/core/v1/models.proto
+++ b/proto/chatto/core/v1/models.proto
@@ -64,6 +64,25 @@ message VerifiedEmail {
   google.protobuf.Timestamp verified_at = 2;
 }
 
+// AuditRequestMetadata captures request details that are safe to persist in
+// auth audit facts and auth-adjacent runtime records. Raw IP addresses, links,
+// and tokens never belong here.
+message AuditRequestMetadata {
+  string user_agent = 1;
+  string ip_hash = 2;
+}
+
+// CookieSession is the server-side runtime-state record for the embedded SPA's
+// HTTP cookie session. The raw session ID is never stored in this payload; it is
+// represented only by the HMAC-derived RUNTIME_STATE key.
+message CookieSession {
+  string user_id = 1;
+  google.protobuf.Timestamp created_at = 2;
+  google.protobuf.Timestamp expires_at = 3;
+  string source = 4;
+  AuditRequestMetadata request = 5;
+}
+
 // DeprecatedAsset is the storage-pointer-only proto used for legacy values:
 // branding KV entries, avatar pointers on UserAvatarSetEvent, and the
 // Storage field on legacy embedded Attachment protos. Wire format matches


### PR DESCRIPTION
- Store embedded SPA cookie sessions as `CookieSession` protobuf records in `RUNTIME_STATE` with per-user HMAC-derived keys, explicit expiry validation, and near-expiry rotation.
- Validate cookie sessions across GraphQL, asset, OAuth, OIDC, and frontend routes; revoke them on logout, password change/reset, and account deletion.
- Update FDR-023, ADR-036, and the architecture inventory, with focused core and HTTP coverage for revocation and signout.

Fixes #11
