### PR TITLE
fix: enforce core string length limits

### DIFF
--- a/cli/internal/core/config_manager.go
+++ b/cli/internal/core/config_manager.go
@@ -99,6 +99,9 @@ func (cm *ConfigManager) UpdateServerConfigFunc(
 		if updated == nil {
 			return nil, fmt.Errorf("update function returned nil config")
 		}
+		if err := validateServerConfig(updated); err != nil {
+			return nil, err
+		}
 
 		err = cm.service.appendEventsAt(ctx, agg, filter, expectedSeq, serverConfigEvents(actorID, baseline, updated))
 		if err == nil {
@@ -118,10 +121,40 @@ func (cm *ConfigManager) publish(ctx context.Context, actorID string, cfg *confi
 	if cm.service == nil {
 		return fmt.Errorf("config manager: event publisher/projector not configured")
 	}
+	if err := validateServerConfig(cfg); err != nil {
+		return err
+	}
 
 	return cm.service.updateSubject(ctx, ConfigSubjectServer, func(_ events.Aggregate, _ string, _ uint64) ([]*corev1.Event, error) {
 		return serverConfigEvents(actorID, cm.effectiveConfigForUpdate(), cfg), nil
 	})
+}
+
+func validateServerConfig(cfg *configv1.ServerConfig) error {
+	if cfg == nil {
+		return nil
+	}
+	if err := validateStringMaxLength("server name", cfg.GetServerName(), MaxServerNameLength); err != nil {
+		return err
+	}
+	if err := validateStringMaxLength("server description", cfg.GetDescription(), MaxServerDescriptionLength); err != nil {
+		return err
+	}
+	if err := validateStringMaxLength("server welcome message", cfg.GetWelcomeMessage(), MaxServerWelcomeMessageLength); err != nil {
+		return err
+	}
+	if err := validateStringMaxLength("server MOTD", cfg.GetMotd(), MaxServerMOTDLength); err != nil {
+		return err
+	}
+	if err := validateStringMaxLength("server blocked usernames", cfg.GetBlockedUsernames(), MaxServerBlockedUsernamesLength); err != nil {
+		return err
+	}
+	for _, blocked := range parseBlockedUsernames(cfg.GetBlockedUsernames()) {
+		if err := validateStringMaxLength("blocked username", blocked, MaxLoginLength); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (cm *ConfigManager) effectiveConfigForUpdate() *configv1.ServerConfig {

--- a/cli/internal/core/config_manager_test.go
+++ b/cli/internal/core/config_manager_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"errors"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -172,6 +173,81 @@ func TestConfigManager_UpdateServerConfigFunc(t *testing.T) {
 		if successCount.Load() == 0 {
 			t.Error("expected at least one successful update")
 		}
+	})
+}
+
+func TestConfigManager_ServerConfigStringLengthLimits(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	valid := &configv1.ServerConfig{
+		ServerName:       strings.Repeat("n", MaxServerNameLength),
+		Description:      strings.Repeat("d", MaxServerDescriptionLength),
+		WelcomeMessage:   strings.Repeat("w", MaxServerWelcomeMessageLength),
+		Motd:             strings.Repeat("m", MaxServerMOTDLength),
+		BlockedUsernames: strings.Repeat("u", MaxLoginLength),
+	}
+	if err := core.configManager.SetServerConfig(ctx, "test", valid); err != nil {
+		t.Fatalf("SetServerConfig at max lengths: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		cfg   *configv1.ServerConfig
+		field string
+		max   int
+	}{
+		{
+			name:  "server name",
+			cfg:   &configv1.ServerConfig{ServerName: strings.Repeat("n", MaxServerNameLength+1)},
+			field: "server name",
+			max:   MaxServerNameLength,
+		},
+		{
+			name:  "server description",
+			cfg:   &configv1.ServerConfig{Description: strings.Repeat("d", MaxServerDescriptionLength+1)},
+			field: "server description",
+			max:   MaxServerDescriptionLength,
+		},
+		{
+			name:  "server welcome message",
+			cfg:   &configv1.ServerConfig{WelcomeMessage: strings.Repeat("w", MaxServerWelcomeMessageLength+1)},
+			field: "server welcome message",
+			max:   MaxServerWelcomeMessageLength,
+		},
+		{
+			name:  "server MOTD",
+			cfg:   &configv1.ServerConfig{Motd: strings.Repeat("m", MaxServerMOTDLength+1)},
+			field: "server MOTD",
+			max:   MaxServerMOTDLength,
+		},
+		{
+			name:  "blocked usernames total",
+			cfg:   &configv1.ServerConfig{BlockedUsernames: strings.Repeat("u", MaxServerBlockedUsernamesLength+1)},
+			field: "server blocked usernames",
+			max:   MaxServerBlockedUsernamesLength,
+		},
+		{
+			name:  "blocked username entry",
+			cfg:   &configv1.ServerConfig{BlockedUsernames: strings.Repeat("u", MaxLoginLength+1)},
+			field: "blocked username",
+			max:   MaxLoginLength,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("set "+tt.name, func(t *testing.T) {
+			err := core.configManager.SetServerConfig(ctx, "test", tt.cfg)
+			assertStringLengthError(t, err, tt.field, tt.max)
+		})
+	}
+
+	t.Run("update rejects over-limit value", func(t *testing.T) {
+		_, err := core.configManager.UpdateServerConfigFunc(ctx, "test", func(current *configv1.ServerConfig) (*configv1.ServerConfig, error) {
+			current.ServerName = strings.Repeat("n", MaxServerNameLength+1)
+			return current, nil
+		})
+		assertStringLengthError(t, err, "server name", MaxServerNameLength)
 	})
 }
 

--- a/cli/internal/core/errors.go
+++ b/cli/internal/core/errors.go
@@ -119,7 +119,7 @@ var (
 	// reactions, or joining.
 	ErrRoomArchived = errors.New("room is archived")
 
-// ErrPasswordTooShort is returned when a password is shorter than MinPasswordLength.
+	// ErrPasswordTooShort is returned when a password is shorter than MinPasswordLength.
 	ErrPasswordTooShort = fmt.Errorf("password must be at least %d characters long", MinPasswordLength)
 
 	// ErrPasswordTooLong is returned when a password exceeds MaxPasswordLength.
@@ -166,4 +166,61 @@ const (
 	// surprising hash collisions on long passwords sharing the same prefix while
 	// still leaving room for passphrases.
 	MaxPasswordLength = 128
+
+	// MaxServerNameLength is the maximum length of a runtime-editable server name in bytes.
+	MaxServerNameLength = 80
+
+	// MaxServerDescriptionLength is the maximum length of a server description in bytes.
+	MaxServerDescriptionLength = 500
+
+	// MaxServerMOTDLength is the maximum length of a server message of the day in bytes.
+	MaxServerMOTDLength = 1000
+
+	// MaxServerWelcomeMessageLength is the maximum length of a server welcome message in bytes.
+	MaxServerWelcomeMessageLength = 10000
+
+	// MaxServerBlockedUsernamesLength is the maximum length of the blocked-username list in bytes.
+	MaxServerBlockedUsernamesLength = 10000
+
+	// MaxRoleDisplayNameLength is the maximum length of a server role display name in bytes.
+	MaxRoleDisplayNameLength = 80
+
+	// MaxRoleDescriptionLength is the maximum length of a server role description in bytes.
+	MaxRoleDescriptionLength = 500
+
+	// MaxRoomGroupNameLength is the maximum length of a room group display name in bytes.
+	MaxRoomGroupNameLength = 80
+
+	// MaxRoomGroupDescriptionLength is the maximum length of a room group description in bytes.
+	MaxRoomGroupDescriptionLength = 500
+
+	// MaxPushEndpointLength is the maximum length of a Push API endpoint URL in bytes.
+	MaxPushEndpointLength = 4096
+
+	// MaxPushKeyLength is the maximum length of a Push API p256dh public key in bytes.
+	MaxPushKeyLength = 256
+
+	// MaxPushAuthLength is the maximum length of a Push API auth secret in bytes.
+	MaxPushAuthLength = 128
+
+	// MaxPushUserAgentLength is the maximum length of a stored push user-agent string in bytes.
+	MaxPushUserAgentLength = 512
+
+	// MaxLinkPreviewURLLength is the maximum length of a client-provided link preview URL in bytes.
+	MaxLinkPreviewURLLength = 2048
+
+	// MaxLinkPreviewTitleLength is the maximum length of a client-provided link preview title in bytes.
+	MaxLinkPreviewTitleLength = 300
+
+	// MaxLinkPreviewDescriptionLength is the maximum length of a client-provided link preview description in bytes.
+	MaxLinkPreviewDescriptionLength = 1000
+
+	// MaxLinkPreviewSiteNameLength is the maximum length of a client-provided link preview site name in bytes.
+	MaxLinkPreviewSiteNameLength = 200
+
+	// MaxLinkPreviewEmbedTypeLength is the maximum length of a client-provided link preview embed type in bytes.
+	MaxLinkPreviewEmbedTypeLength = 64
+
+	// MaxLinkPreviewEmbedIDLength is the maximum length of a client-provided link preview embed ID in bytes.
+	MaxLinkPreviewEmbedIDLength = 256
 )

--- a/cli/internal/core/messages.go
+++ b/cli/internal/core/messages.go
@@ -218,6 +218,9 @@ func (c *ChattoCore) PostMessage(ctx context.Context, kind RoomKind, room_id, us
 	if len(body) > MaxMessageBodyLength {
 		return nil, ErrMessageTooLong
 	}
+	if err := validateLinkPreview(linkPreview); err != nil {
+		return nil, err
+	}
 
 	// Validate that message has either body or attachments.
 	// HasVisibleContent rejects messages with only invisible Unicode characters.
@@ -714,6 +717,10 @@ func (c *ChattoCore) DeleteMessage(ctx context.Context, actorID string, kind Roo
 //
 // Authorization: Caller must verify the actor is the author OR (CanManageOthersMessage AND OutranksAuthor) before calling.
 func (c *ChattoCore) EditMessage(ctx context.Context, actorID string, kind RoomKind, roomID, messageBodyKey, newBody string) error {
+	if len(newBody) > MaxMessageBodyLength {
+		return ErrMessageTooLong
+	}
+
 	// Block edits in archived rooms.
 	room, err := c.GetRoom(ctx, kind, roomID)
 	if err != nil {
@@ -884,6 +891,31 @@ func (c *ChattoCore) publishMessageEdit(ctx context.Context, actorID string, kin
 		return fmt.Errorf("publish MessageEditedEvent after %d attempts: %w", maxThreadCreateAppendAttempts, lastErr)
 	}
 	return fmt.Errorf("publish MessageEditedEvent: retry loop exited unexpectedly")
+}
+
+func validateLinkPreview(linkPreview *corev1.LinkPreview) error {
+	if linkPreview == nil {
+		return nil
+	}
+	if err := validateStringMaxLength("link preview URL", linkPreview.GetUrl(), MaxLinkPreviewURLLength); err != nil {
+		return err
+	}
+	if err := validateStringMaxLength("link preview title", linkPreview.GetTitle(), MaxLinkPreviewTitleLength); err != nil {
+		return err
+	}
+	if err := validateStringMaxLength("link preview description", linkPreview.GetDescription(), MaxLinkPreviewDescriptionLength); err != nil {
+		return err
+	}
+	if err := validateStringMaxLength("link preview site name", linkPreview.GetSiteName(), MaxLinkPreviewSiteNameLength); err != nil {
+		return err
+	}
+	if err := validateStringMaxLength("link preview embed type", linkPreview.GetEmbedType(), MaxLinkPreviewEmbedTypeLength); err != nil {
+		return err
+	}
+	if err := validateStringMaxLength("link preview embed ID", linkPreview.GetEmbedId(), MaxLinkPreviewEmbedIDLength); err != nil {
+		return err
+	}
+	return nil
 }
 
 // editEmbeddedBody is the shared engine behind partial-edit

--- a/cli/internal/core/messages_test.go
+++ b/cli/internal/core/messages_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -376,6 +377,108 @@ func TestChattoCore_PostMessage_BodyTooLong(t *testing.T) {
 			t.Errorf("Expected ErrMessageTooLong, got: %v", err)
 		}
 	})
+}
+
+func TestChattoCore_EditMessage_BodyTooLong(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	room, _ := core.CreateRoom(ctx, "test-user", KindChannel, "", "General", "General discussion")
+	user, _ := core.CreateUser(ctx, "system", "editlength", "editlength", "password123")
+	core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id)
+	posted, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "original", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage: %v", err)
+	}
+
+	t.Run("edit at max length succeeds", func(t *testing.T) {
+		if err := core.EditMessage(ctx, user.Id, KindChannel, room.Id, posted.Id, strings.Repeat("a", MaxMessageBodyLength)); err != nil {
+			t.Fatalf("EditMessage at max length: %v", err)
+		}
+	})
+
+	t.Run("edit over max length fails", func(t *testing.T) {
+		err := core.EditMessage(ctx, user.Id, KindChannel, room.Id, posted.Id, strings.Repeat("a", MaxMessageBodyLength+1))
+		if !errors.Is(err, ErrMessageTooLong) {
+			t.Fatalf("EditMessage error = %v, want ErrMessageTooLong", err)
+		}
+	})
+}
+
+func TestChattoCore_PostMessage_LinkPreviewLengthLimits(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	room, _ := core.CreateRoom(ctx, "test-user", KindChannel, "", "Previews", "Preview discussion")
+	user, _ := core.CreateUser(ctx, "system", "previewuser", "previewuser", "password123")
+	core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id)
+
+	t.Run("link preview at max lengths succeeds", func(t *testing.T) {
+		embedID := strings.Repeat("i", MaxLinkPreviewEmbedIDLength)
+		preview := &corev1.LinkPreview{
+			Url:         strings.Repeat("u", MaxLinkPreviewURLLength),
+			Title:       strings.Repeat("t", MaxLinkPreviewTitleLength),
+			Description: strings.Repeat("d", MaxLinkPreviewDescriptionLength),
+			SiteName:    strings.Repeat("s", MaxLinkPreviewSiteNameLength),
+			EmbedType:   strings.Repeat("e", MaxLinkPreviewEmbedTypeLength),
+			EmbedId:     &embedID,
+		}
+		if _, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "preview", nil, "", "", preview, false); err != nil {
+			t.Fatalf("PostMessage with max-length link preview: %v", err)
+		}
+	})
+
+	overLimitEmbedID := strings.Repeat("i", MaxLinkPreviewEmbedIDLength+1)
+	tests := []struct {
+		name    string
+		preview *corev1.LinkPreview
+		field   string
+		max     int
+	}{
+		{
+			name:    "URL",
+			preview: &corev1.LinkPreview{Url: strings.Repeat("u", MaxLinkPreviewURLLength+1)},
+			field:   "link preview URL",
+			max:     MaxLinkPreviewURLLength,
+		},
+		{
+			name:    "title",
+			preview: &corev1.LinkPreview{Title: strings.Repeat("t", MaxLinkPreviewTitleLength+1)},
+			field:   "link preview title",
+			max:     MaxLinkPreviewTitleLength,
+		},
+		{
+			name:    "description",
+			preview: &corev1.LinkPreview{Description: strings.Repeat("d", MaxLinkPreviewDescriptionLength+1)},
+			field:   "link preview description",
+			max:     MaxLinkPreviewDescriptionLength,
+		},
+		{
+			name:    "site name",
+			preview: &corev1.LinkPreview{SiteName: strings.Repeat("s", MaxLinkPreviewSiteNameLength+1)},
+			field:   "link preview site name",
+			max:     MaxLinkPreviewSiteNameLength,
+		},
+		{
+			name:    "embed type",
+			preview: &corev1.LinkPreview{EmbedType: strings.Repeat("e", MaxLinkPreviewEmbedTypeLength+1)},
+			field:   "link preview embed type",
+			max:     MaxLinkPreviewEmbedTypeLength,
+		},
+		{
+			name:    "embed ID",
+			preview: &corev1.LinkPreview{EmbedId: &overLimitEmbedID},
+			field:   "link preview embed ID",
+			max:     MaxLinkPreviewEmbedIDLength,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "preview", nil, "", "", tt.preview, false)
+			assertStringLengthError(t, err, tt.field, tt.max)
+		})
+	}
 }
 
 // TestChattoCore_PostMessage_InvisibleChars tests that messages with only invisible Unicode

--- a/cli/internal/core/push.go
+++ b/cli/internal/core/push.go
@@ -50,6 +50,10 @@ func (c *ChattoCore) SavePushSubscription(
 	userID string,
 	endpoint, p256dh, auth, userAgent string,
 ) (*corev1.PushSubscription, error) {
+	if err := validatePushSubscription(endpoint, p256dh, auth, userAgent); err != nil {
+		return nil, err
+	}
+
 	subscription := &corev1.PushSubscription{
 		Endpoint:  endpoint,
 		P256Dh:    p256dh,
@@ -74,6 +78,22 @@ func (c *ChattoCore) SavePushSubscription(
 		"endpoint_hash", hashEndpoint(endpoint))
 
 	return subscription, nil
+}
+
+func validatePushSubscription(endpoint, p256dh, auth, userAgent string) error {
+	if err := validateStringMaxLength("push endpoint", endpoint, MaxPushEndpointLength); err != nil {
+		return err
+	}
+	if err := validateStringMaxLength("push p256dh key", p256dh, MaxPushKeyLength); err != nil {
+		return err
+	}
+	if err := validateStringMaxLength("push auth secret", auth, MaxPushAuthLength); err != nil {
+		return err
+	}
+	if err := validateStringMaxLength("push user agent", userAgent, MaxPushUserAgentLength); err != nil {
+		return err
+	}
+	return nil
 }
 
 // DeletePushSubscription removes a push subscription by endpoint.

--- a/cli/internal/core/push_test.go
+++ b/cli/internal/core/push_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -155,6 +156,77 @@ func TestSavePushSubscription(t *testing.T) {
 			t.Errorf("Expected 1 subscription after update, got %d", len(subs))
 		}
 	})
+}
+
+func TestSavePushSubscription_StringLengthLimits(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := context.Background()
+	userID := "push-user-limits"
+
+	t.Run("accepts values at max length", func(t *testing.T) {
+		_, err := core.SavePushSubscription(
+			ctx,
+			userID,
+			strings.Repeat("e", MaxPushEndpointLength),
+			strings.Repeat("p", MaxPushKeyLength),
+			strings.Repeat("a", MaxPushAuthLength),
+			strings.Repeat("u", MaxPushUserAgentLength),
+		)
+		if err != nil {
+			t.Fatalf("SavePushSubscription at max lengths: %v", err)
+		}
+	})
+
+	tests := []struct {
+		name      string
+		endpoint  string
+		p256dh    string
+		auth      string
+		userAgent string
+		field     string
+		max       int
+	}{
+		{
+			name:     "endpoint",
+			endpoint: strings.Repeat("e", MaxPushEndpointLength+1),
+			p256dh:   "key",
+			auth:     "auth",
+			field:    "push endpoint",
+			max:      MaxPushEndpointLength,
+		},
+		{
+			name:     "p256dh",
+			endpoint: "https://push.example.com/limits-p256dh",
+			p256dh:   strings.Repeat("p", MaxPushKeyLength+1),
+			auth:     "auth",
+			field:    "push p256dh key",
+			max:      MaxPushKeyLength,
+		},
+		{
+			name:     "auth",
+			endpoint: "https://push.example.com/limits-auth",
+			p256dh:   "key",
+			auth:     strings.Repeat("a", MaxPushAuthLength+1),
+			field:    "push auth secret",
+			max:      MaxPushAuthLength,
+		},
+		{
+			name:      "user agent",
+			endpoint:  "https://push.example.com/limits-user-agent",
+			p256dh:    "key",
+			auth:      "auth",
+			userAgent: strings.Repeat("u", MaxPushUserAgentLength+1),
+			field:     "push user agent",
+			max:       MaxPushUserAgentLength,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := core.SavePushSubscription(ctx, userID, tt.endpoint, tt.p256dh, tt.auth, tt.userAgent)
+			assertStringLengthError(t, err, tt.field, tt.max)
+		})
+	}
 }
 
 func TestGetAllPushSubscriptions(t *testing.T) {

--- a/cli/internal/core/rbac.go
+++ b/cli/internal/core/rbac.go
@@ -431,6 +431,9 @@ func (c *ChattoCore) CreateServerRole(ctx context.Context, name, displayName, de
 	if err := ValidateRoleName(name); err != nil {
 		return nil, ErrInvalidRoleName
 	}
+	if err := validateRoleMetadata(displayName, description); err != nil {
+		return nil, err
+	}
 	if IsSystemRole(name) {
 		return nil, ErrRoleAlreadyExists
 	}
@@ -476,6 +479,10 @@ func (c *ChattoCore) CreateServerRole(ctx context.Context, name, displayName, de
 // UpdateServerRole updates an existing role's metadata.
 // The role name cannot be changed.
 func (c *ChattoCore) UpdateServerRole(ctx context.Context, name, displayName, description string) (*RoleWithPermissions, error) {
+	if err := validateRoleMetadata(displayName, description); err != nil {
+		return nil, err
+	}
+
 	var updated *corev1.Role
 	if _, err := c.appendRBACEvent(ctx, newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacRoleDisplayNameChanged{
 		RbacRoleDisplayNameChanged: &corev1.RbacRoleDisplayNameChangedEvent{RoleName: name, DisplayName: displayName},

--- a/cli/internal/core/rbac_test.go
+++ b/cli/internal/core/rbac_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"hmans.de/chatto/internal/config"
@@ -1349,6 +1350,44 @@ func TestChattoCore_CreateRole_InvalidName(t *testing.T) {
 	if !errors.Is(err, ErrInvalidRoleName) {
 		t.Errorf("Expected ErrInvalidRoleName, got %v", err)
 	}
+}
+
+func TestChattoCore_RoleMetadataLengthLimits(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	t.Run("create accepts values at max length", func(t *testing.T) {
+		role, err := core.CreateServerRole(
+			ctx,
+			"maxrole",
+			strings.Repeat("d", MaxRoleDisplayNameLength),
+			strings.Repeat("x", MaxRoleDescriptionLength),
+		)
+		if err != nil {
+			t.Fatalf("CreateServerRole at max lengths: %v", err)
+		}
+		if len(role.DisplayName) != MaxRoleDisplayNameLength || len(role.Description) != MaxRoleDescriptionLength {
+			t.Fatalf("role lengths = displayName:%d description:%d", len(role.DisplayName), len(role.Description))
+		}
+	})
+
+	t.Run("create rejects over-limit display name", func(t *testing.T) {
+		_, err := core.CreateServerRole(ctx, "longdisplay", strings.Repeat("d", MaxRoleDisplayNameLength+1), "")
+		assertStringLengthError(t, err, "role display name", MaxRoleDisplayNameLength)
+	})
+
+	t.Run("create rejects over-limit description", func(t *testing.T) {
+		_, err := core.CreateServerRole(ctx, "longdescription", "Role", strings.Repeat("d", MaxRoleDescriptionLength+1))
+		assertStringLengthError(t, err, "role description", MaxRoleDescriptionLength)
+	})
+
+	t.Run("update rejects over-limit metadata", func(t *testing.T) {
+		if _, err := core.CreateServerRole(ctx, "editable", "Editable", ""); err != nil {
+			t.Fatalf("CreateServerRole: %v", err)
+		}
+		_, err := core.UpdateServerRole(ctx, "editable", strings.Repeat("d", MaxRoleDisplayNameLength+1), "")
+		assertStringLengthError(t, err, "role display name", MaxRoleDisplayNameLength)
+	})
 }
 
 func TestChattoCore_CreateRole_Duplicate(t *testing.T) {

--- a/cli/internal/core/rbac_validation.go
+++ b/cli/internal/core/rbac_validation.go
@@ -33,3 +33,13 @@ func ValidateRoleName(name string) error {
 	}
 	return nil
 }
+
+func validateRoleMetadata(displayName, description string) error {
+	if err := validateStringMaxLength("role display name", displayName, MaxRoleDisplayNameLength); err != nil {
+		return err
+	}
+	if err := validateStringMaxLength("role description", description, MaxRoleDescriptionLength); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cli/internal/core/room_groups.go
+++ b/cli/internal/core/room_groups.go
@@ -51,8 +51,8 @@ var (
 // Name is trimmed; description may be empty.
 func (c *ChattoCore) CreateRoomGroup(ctx context.Context, actorID, name, description string) (*corev1.RoomGroup, error) {
 	name = strings.TrimSpace(name)
-	if name == "" {
-		return nil, ErrRoomGroupNameEmpty
+	if err := validateRoomGroupMetadata(name, description); err != nil {
+		return nil, err
 	}
 
 	group := &corev1.RoomGroup{
@@ -91,8 +91,8 @@ func (c *ChattoCore) CreateRoomGroup(ctx context.Context, actorID, name, descrip
 // is untouched; only metadata changes.
 func (c *ChattoCore) UpdateRoomGroup(ctx context.Context, actorID, groupID, name, description string) (*corev1.RoomGroup, error) {
 	name = strings.TrimSpace(name)
-	if name == "" {
-		return nil, ErrRoomGroupNameEmpty
+	if err := validateRoomGroupMetadata(name, description); err != nil {
+		return nil, err
 	}
 
 	if !c.RoomGroups.Exists(groupID) {
@@ -117,6 +117,19 @@ func (c *ChattoCore) UpdateRoomGroup(ctx context.Context, actorID, groupID, name
 
 	updated, _ := c.RoomGroups.Get(groupID)
 	return updated, nil
+}
+
+func validateRoomGroupMetadata(name, description string) error {
+	if name == "" {
+		return ErrRoomGroupNameEmpty
+	}
+	if err := validateStringMaxLength("room group name", name, MaxRoomGroupNameLength); err != nil {
+		return err
+	}
+	if err := validateStringMaxLength("room group description", description, MaxRoomGroupDescriptionLength); err != nil {
+		return err
+	}
+	return nil
 }
 
 // GetRoomGroup reads a single group from the RoomGroups projection.

--- a/cli/internal/core/room_groups_test.go
+++ b/cli/internal/core/room_groups_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -65,6 +66,45 @@ func TestCreateRoomGroup_EmptyNameRejected(t *testing.T) {
 			t.Errorf("CreateRoomGroup(%q) error = %v, want ErrRoomGroupNameEmpty", name, err)
 		}
 	}
+}
+
+func TestRoomGroupMetadataLengthLimits(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	t.Run("create accepts values at max length", func(t *testing.T) {
+		set, err := core.CreateRoomGroup(
+			ctx,
+			"actor",
+			strings.Repeat("n", MaxRoomGroupNameLength),
+			strings.Repeat("d", MaxRoomGroupDescriptionLength),
+		)
+		if err != nil {
+			t.Fatalf("CreateRoomGroup at max lengths: %v", err)
+		}
+		if len(set.Name) != MaxRoomGroupNameLength || len(set.Description) != MaxRoomGroupDescriptionLength {
+			t.Fatalf("created group lengths = name:%d description:%d", len(set.Name), len(set.Description))
+		}
+	})
+
+	t.Run("create rejects over-limit name", func(t *testing.T) {
+		_, err := core.CreateRoomGroup(ctx, "actor", strings.Repeat("n", MaxRoomGroupNameLength+1), "")
+		assertStringLengthError(t, err, "room group name", MaxRoomGroupNameLength)
+	})
+
+	t.Run("create rejects over-limit description", func(t *testing.T) {
+		_, err := core.CreateRoomGroup(ctx, "actor", "Group", strings.Repeat("d", MaxRoomGroupDescriptionLength+1))
+		assertStringLengthError(t, err, "room group description", MaxRoomGroupDescriptionLength)
+	})
+
+	t.Run("update rejects over-limit metadata", func(t *testing.T) {
+		set, err := core.CreateRoomGroup(ctx, "actor", "Short", "")
+		if err != nil {
+			t.Fatalf("CreateRoomGroup: %v", err)
+		}
+		_, err = core.UpdateRoomGroup(ctx, "actor", set.Id, "Short", strings.Repeat("d", MaxRoomGroupDescriptionLength+1))
+		assertStringLengthError(t, err, "room group description", MaxRoomGroupDescriptionLength)
+	})
 }
 
 func TestUpdateRoomGroup(t *testing.T) {

--- a/cli/internal/core/validation.go
+++ b/cli/internal/core/validation.go
@@ -1,9 +1,28 @@
 package core
 
 import (
+	"fmt"
 	"strings"
 	"unicode"
 )
+
+// StringLengthError is returned when a persisted user-controlled string exceeds
+// the field's durable storage limit.
+type StringLengthError struct {
+	Field string
+	Max   int
+}
+
+func (e *StringLengthError) Error() string {
+	return fmt.Sprintf("%s cannot exceed %d bytes", e.Field, e.Max)
+}
+
+func validateStringMaxLength(field, value string, max int) error {
+	if len(value) > max {
+		return &StringLengthError{Field: field, Max: max}
+	}
+	return nil
+}
 
 // ValidateDisplayName validates a display name for allowed characters.
 // Allowed: letters (any script), digits, marks (diacritics), emoji/symbols,

--- a/cli/internal/core/validation_test.go
+++ b/cli/internal/core/validation_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -285,5 +286,16 @@ func TestHasVisibleContent(t *testing.T) {
 				t.Errorf("HasVisibleContent(%q) = %v, want %v", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func assertStringLengthError(t *testing.T, err error, field string, max int) {
+	t.Helper()
+	var lengthErr *StringLengthError
+	if !errors.As(err, &lengthErr) {
+		t.Fatalf("error = %v, want *StringLengthError", err)
+	}
+	if lengthErr.Field != field || lengthErr.Max != max {
+		t.Fatalf("StringLengthError = {Field:%q Max:%d}, want {Field:%q Max:%d}", lengthErr.Field, lengthErr.Max, field, max)
 	}
 }

--- a/docs/fdr/FDR-001-roles-and-permissions.md
+++ b/docs/fdr/FDR-001-roles-and-permissions.md
@@ -1,7 +1,7 @@
 # FDR-001: Roles & Permissions (RBAC)
 
 **Status:** Active
-**Last reviewed:** 2026-05-31
+**Last reviewed:** 2026-06-06
 
 ## Overview
 
@@ -15,6 +15,7 @@ Chatto controls who can do what through role-based access control. Every authent
 - Permission grants/denies can be configured at three scopes: per-server (the role default), per room-group, and per room. The most specific scope wins.
 - Permissions gate capabilities, not every form of visibility. For example, DM read access comes from room membership, while `message.post` gates starting DMs and sending root DM messages.
 - Server admins can drag-and-drop to reorder custom roles. System roles are fixed in rank.
+- Custom role display names are limited to 80 bytes; descriptions are limited to 500 bytes.
 - Owners pass every permission check because the `owner` role is seeded with every server-scope permission — not because the resolver special-cases them. Owners are not above the rules; they hold the rules.
 - Operators can designate owners via `owners.emails` in `chatto.toml`. Matching users are auto-assigned the `owner` role when their email is verified, and already-verified matching users are assigned the role on server boot.
 

--- a/docs/fdr/FDR-004-message-editing-and-deletion.md
+++ b/docs/fdr/FDR-004-message-editing-and-deletion.md
@@ -1,7 +1,7 @@
 # FDR-004: Message Editing & Deletion
 
 **Status:** Active
-**Last reviewed:** 2026-06-05
+**Last reviewed:** 2026-06-06
 
 ## Overview
 
@@ -11,6 +11,7 @@ Authors can edit and delete their own messages; moderators with the right permis
 
 - Authors can edit their own messages within a 3-hour window from posting time. After the window closes, only moderators can edit. The window value is queryable via `Server.messageEditWindowSeconds` so the frontend can show countdown timers and disable the edit affordance at exactly the right moment.
 - Only the message body text can be edited. Attachments aren't editable as text but can be removed individually.
+- Edited message bodies are capped at the same 10,000-byte limit as newly posted message bodies.
 - Deletions remove the message body and all attachments and replace the rendered message with a "[Message deleted]" placeholder.
 - Deleting an already-deleted message is a no-op.
 - Editing a message does not re-resolve mentions. Mentions and mention notifications remain tied to the original posted message.

--- a/docs/fdr/FDR-009-link-previews.md
+++ b/docs/fdr/FDR-009-link-previews.md
@@ -1,7 +1,7 @@
 # FDR-009: Link Previews
 
 **Status:** Active
-**Last reviewed:** 2026-05-19
+**Last reviewed:** 2026-06-06
 
 ## Overview
 
@@ -14,6 +14,7 @@ When a message contains a URL, Chatto can attach a preview card with the page's 
 - YouTube URLs get a specialized embed-ready card without scraping the page.
 - A preview shows up in the composer with a dismiss button. Dismissing the preview prevents it from being attached to the sent message, and the dismissal is remembered for that URL during the composition session.
 - When the message is sent, the preview data ships with it and is stored as part of the message body.
+- Client-provided preview metadata is size-limited before storage: URL 2,048 bytes, title 300 bytes, description 1,000 bytes, site name 200 bytes, embed type 64 bytes, and embed ID 256 bytes.
 - After posting, the message author can delete the preview from the message without deleting the message.
 
 ## Design Decisions
@@ -47,6 +48,12 @@ When a message contains a URL, Chatto can attach a preview card with the page's 
 **Decision:** Preview images are fetched once, resized to 1200×630 max, converted to WebP, and stored as assets on the Chatto server.
 **Why:** Hot-linking preview images from third-party sites means broken previews when those sites change URLs, plus a privacy leak (the third party sees every Chatto user's fetch). Storing locally fixes both.
 **Tradeoff:** Per-server storage cost. Acceptable given asset deduplication and the small fixed size cap.
+
+### 6. Stored preview metadata is bounded
+
+**Decision:** Preview metadata attached to a sent message is accepted only within generous per-field size limits.
+**Why:** Preview data is client-provided at send time and stored with the message body. Bounding it keeps a single message from carrying arbitrarily large URL metadata.
+**Tradeoff:** A page with unusually large metadata requires the client to trim or omit the preview before sending.
 
 ## Permissions
 

--- a/docs/fdr/FDR-013-web-push-notifications.md
+++ b/docs/fdr/FDR-013-web-push-notifications.md
@@ -1,7 +1,7 @@
 # FDR-013: Web Push Notifications
 
 **Status:** Active
-**Last reviewed:** 2026-05-31
+**Last reviewed:** 2026-06-06
 
 ## Overview
 
@@ -11,6 +11,7 @@ Users can opt in to receive notifications through the browser's W3C Web Push sys
 
 - The browser prompts the user for notification permission when they enable push.
 - On granting permission, the browser creates a subscription using the server's VAPID public key. The subscription details (endpoint URL, keys) are sent to the server and stored.
+- Stored subscription fields are bounded: endpoint 4,096 bytes, public key 256 bytes, auth secret 128 bytes, and user agent 512 bytes.
 - A user can have multiple devices subscribed simultaneously — every device receives every push.
 - Push payloads include a title, a truncated message preview (max 100 chars, broken at word boundaries), and a navigation URL.
 - Clicking a push notification navigates to the relevant room, thread, or DM.

--- a/docs/fdr/FDR-017-room-groups-and-sidebar-layout.md
+++ b/docs/fdr/FDR-017-room-groups-and-sidebar-layout.md
@@ -1,7 +1,7 @@
 # FDR-017: Room Groups & Sidebar Layout
 
 **Status:** Active
-**Last reviewed:** 2026-05-31
+**Last reviewed:** 2026-06-06
 
 ## Overview
 
@@ -11,6 +11,7 @@ Channel rooms are organized into **room groups** — named, ordered containers t
 
 - The sidebar shows rooms grouped under their group's name in operator-defined order. Groups can be collapsed/expanded.
 - Server admins can create, rename, reorder, and delete groups via the admin UI.
+- Group names are limited to 80 bytes; group descriptions are limited to 500 bytes.
 - Every channel room belongs to exactly one group. There's no "uncategorized" branch — room creation requires a group.
 - A freshly bootstrapped server has one group named "Lobby" containing the auto-created `announcements` and `general` rooms. Operators can rename it, reorder it, or replace it like any other group.
 - Deleting a group is rejected while rooms still live in it. Operators move rooms out first.

--- a/docs/fdr/FDR-020-server-branding-and-configuration.md
+++ b/docs/fdr/FDR-020-server-branding-and-configuration.md
@@ -1,7 +1,7 @@
 # FDR-020: Server Branding & Configuration
 
 **Status:** Active
-**Last reviewed:** 2026-05-30
+**Last reviewed:** 2026-06-06
 
 ## Overview
 
@@ -16,6 +16,7 @@ Operators can customize how their Chatto server presents itself. The server's na
 - **Logo** — shown in the chat header, login page, and OG image fallback. Uploaded as an image; resized variants served via signed URLs.
 - **Banner** — shown on the login page and in OG previews. Same upload/serve pipeline as the logo.
 - **Blocked usernames** — newline-separated list checked at signup. Matches are rejected before account creation.
+- Text configuration is bounded before storage: server name 80 bytes, description 500 bytes, MOTD 1,000 bytes, welcome message 10,000 bytes, blocked-usernames field 10,000 bytes, and each blocked username no longer than a normal username.
 
 ## Design Decisions
 
@@ -55,7 +56,13 @@ Operators can customize how their Chatto server presents itself. The server's na
 **Why:** Few operators will blocklist many usernames. A separate "blocked usernames" admin page with add/remove operations would be overkill for the volume. A text area is the smallest viable UI.
 **Tradeoff:** Large lists could become awkward to edit. None of the live deployments have lists big enough for this to matter.
 
-### 7. Edit window is a constant exposed via GraphQL, not a config field
+### 7. Runtime text config has fixed size caps
+
+**Decision:** Runtime-editable server text fields have fixed server-side size limits rather than operator-tunable limits.
+**Why:** These values are public presentation/configuration text, not bulk content. Fixed limits keep event payloads and admin forms bounded while preserving enough room for normal operator usage.
+**Tradeoff:** Operators who want unusually large welcome copy or blocklists have to shorten the content instead of raising a config value.
+
+### 8. Edit window is a constant exposed via GraphQL, not a config field
 
 **Decision:** `Server.messageEditWindowSeconds` is queryable but read-only. The value comes from a Go constant (`core.MessageEditWindow = 3 * time.Hour`); the GraphQL schema doesn't include it in `UpdateServerConfigInput`.
 **Why:** The frontend needs to know the window to render countdown timers and disable the edit affordance at the right moment, so exposing it via GraphQL is necessary. But making it operator-tunable opens space for inconsistent UX across servers without clear benefit — and the value isn't sensitive enough to need server-by-server control.

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -10,26 +10,26 @@ See [`.claude/skills/fdr/SKILL.md`](../../.claude/skills/fdr/SKILL.md) for the F
 
 | # | Feature | Status | Last reviewed |
 |---|---------|--------|---------------|
-| [FDR-001](FDR-001-roles-and-permissions.md) | Roles & Permissions (RBAC) | Active | 2026-05-31 |
+| [FDR-001](FDR-001-roles-and-permissions.md) | Roles & Permissions (RBAC) | Active | 2026-06-06 |
 | [FDR-002](FDR-002-replies-and-threads.md) | Replies & Threads | Active | 2026-05-19 |
 | [FDR-003](FDR-003-thread-reply-echo.md) | Thread Reply Echo | Active | 2026-06-01 |
-| [FDR-004](FDR-004-message-editing-and-deletion.md) | Message Editing & Deletion | Active | 2026-06-05 |
+| [FDR-004](FDR-004-message-editing-and-deletion.md) | Message Editing & Deletion | Active | 2026-06-06 |
 | [FDR-005](FDR-005-reactions.md) | Reactions | Active | 2026-05-19 |
 | [FDR-006](FDR-006-mentions.md) | @Mentions | Active | 2026-06-05 |
 | [FDR-007](FDR-007-direct-messages.md) | Direct Messages | Active | 2026-05-31 |
 | [FDR-008](FDR-008-file-attachments-and-video.md) | File Attachments & Video Processing | Active | 2026-05-19 |
-| [FDR-009](FDR-009-link-previews.md) | Link Previews | Active | 2026-05-19 |
+| [FDR-009](FDR-009-link-previews.md) | Link Previews | Active | 2026-06-06 |
 | [FDR-010](FDR-010-typing-indicators.md) | Typing Indicators | Active | 2026-05-19 |
 | [FDR-011](FDR-011-user-presence.md) | User Presence | Active | 2026-05-19 |
 | [FDR-012](FDR-012-notifications.md) | Notifications | Active | 2026-05-19 |
-| [FDR-013](FDR-013-web-push-notifications.md) | Web Push Notifications | Active | 2026-05-19 |
+| [FDR-013](FDR-013-web-push-notifications.md) | Web Push Notifications | Active | 2026-06-06 |
 | [FDR-014](FDR-014-jump-to-present.md) | Jump to Present | Active | 2026-05-19 |
 | [FDR-015](FDR-015-quick-switcher.md) | Quick Switcher (Cmd-K) | Active | 2026-05-31 |
 | [FDR-016](FDR-016-voice-calls.md) | Voice Calls | Active | 2026-05-19 |
-| [FDR-017](FDR-017-room-groups-and-sidebar-layout.md) | Room Groups & Sidebar Layout | Active | 2026-05-31 |
+| [FDR-017](FDR-017-room-groups-and-sidebar-layout.md) | Room Groups & Sidebar Layout | Active | 2026-06-06 |
 | [FDR-018](FDR-018-account-lifecycle.md) | Account Lifecycle | Active | 2026-06-03 |
 | [FDR-019](FDR-019-room-lifecycle.md) | Room Lifecycle | Active | 2026-05-19 |
-| [FDR-020](FDR-020-server-branding-and-configuration.md) | Server Branding & Configuration | Active | 2026-05-30 |
+| [FDR-020](FDR-020-server-branding-and-configuration.md) | Server Branding & Configuration | Active | 2026-06-06 |
 | [FDR-021](FDR-021-admin-dashboard.md) | Admin Dashboard & System Monitoring | Active | 2026-06-05 |
 | [FDR-022](FDR-022-user-profile.md) | User Profile | Active | 2026-06-02 |
 | [FDR-023](FDR-023-authentication-and-sessions.md) | Authentication & Sessions | Active | 2026-06-02 |


### PR DESCRIPTION
## Summary
- Enforce fixed core max-length validation for persisted mutation strings: message edits, link previews, server config, role metadata, room group metadata, and push subscriptions.
- Add typed length errors plus accepted-at-limit and rejected-over-limit tests for the affected core write paths.
- Update FDR-001, FDR-004, FDR-009, FDR-013, FDR-017, FDR-020, and the FDR index to document the new limits.
- Leave IDs, cursors, permission names, emoji names, and other lookup/format-validated strings on their existing validation paths.

## Tests
- `mise x -- go test ./internal/core -run 'TestConfigManager_ServerConfigStringLengthLimits|TestRoomGroupMetadataLengthLimits|TestChattoCore_RoleMetadataLengthLimits|TestChattoCore_PostMessage_BodyTooLong|TestChattoCore_EditMessage_BodyTooLong|TestChattoCore_PostMessage_LinkPreviewLengthLimits|TestSavePushSubscription_StringLengthLimits|TestValidateRoleName|TestValidateLogin' -count=1 -timeout 90s`
- `mise x -- go test ./internal/core -count=1 -timeout 120s`

Fixes #737
