### PR TITLE
fix: add GraphQL length validation

### DIFF
--- a/cli/internal/core/errors.go
+++ b/cli/internal/core/errors.go
@@ -223,4 +223,7 @@ const (
 
 	// MaxLinkPreviewEmbedIDLength is the maximum length of a client-provided link preview embed ID in bytes.
 	MaxLinkPreviewEmbedIDLength = 256
+
+	// MaxLinkPreviewImageAssetIDLength is the maximum length of a client-provided link preview image asset ID in bytes.
+	MaxLinkPreviewImageAssetIDLength = 15
 )

--- a/cli/internal/core/messages.go
+++ b/cli/internal/core/messages.go
@@ -906,6 +906,9 @@ func validateLinkPreview(linkPreview *corev1.LinkPreview) error {
 	if err := validateStringMaxLength("link preview description", linkPreview.GetDescription(), MaxLinkPreviewDescriptionLength); err != nil {
 		return err
 	}
+	if err := validateStringMaxLength("link preview image asset ID", linkPreview.GetImageAssetId(), MaxLinkPreviewImageAssetIDLength); err != nil {
+		return err
+	}
 	if err := validateStringMaxLength("link preview site name", linkPreview.GetSiteName(), MaxLinkPreviewSiteNameLength); err != nil {
 		return err
 	}

--- a/cli/internal/core/messages_test.go
+++ b/cli/internal/core/messages_test.go
@@ -415,13 +415,15 @@ func TestChattoCore_PostMessage_LinkPreviewLengthLimits(t *testing.T) {
 
 	t.Run("link preview at max lengths succeeds", func(t *testing.T) {
 		embedID := strings.Repeat("i", MaxLinkPreviewEmbedIDLength)
+		imageAssetID := strings.Repeat("a", MaxLinkPreviewImageAssetIDLength)
 		preview := &corev1.LinkPreview{
-			Url:         strings.Repeat("u", MaxLinkPreviewURLLength),
-			Title:       strings.Repeat("t", MaxLinkPreviewTitleLength),
-			Description: strings.Repeat("d", MaxLinkPreviewDescriptionLength),
-			SiteName:    strings.Repeat("s", MaxLinkPreviewSiteNameLength),
-			EmbedType:   strings.Repeat("e", MaxLinkPreviewEmbedTypeLength),
-			EmbedId:     &embedID,
+			Url:          strings.Repeat("u", MaxLinkPreviewURLLength),
+			Title:        strings.Repeat("t", MaxLinkPreviewTitleLength),
+			Description:  strings.Repeat("d", MaxLinkPreviewDescriptionLength),
+			ImageAssetId: &imageAssetID,
+			SiteName:     strings.Repeat("s", MaxLinkPreviewSiteNameLength),
+			EmbedType:    strings.Repeat("e", MaxLinkPreviewEmbedTypeLength),
+			EmbedId:      &embedID,
 		}
 		if _, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "preview", nil, "", "", preview, false); err != nil {
 			t.Fatalf("PostMessage with max-length link preview: %v", err)
@@ -429,6 +431,7 @@ func TestChattoCore_PostMessage_LinkPreviewLengthLimits(t *testing.T) {
 	})
 
 	overLimitEmbedID := strings.Repeat("i", MaxLinkPreviewEmbedIDLength+1)
+	overLimitImageAssetID := strings.Repeat("a", MaxLinkPreviewImageAssetIDLength+1)
 	tests := []struct {
 		name    string
 		preview *corev1.LinkPreview
@@ -452,6 +455,12 @@ func TestChattoCore_PostMessage_LinkPreviewLengthLimits(t *testing.T) {
 			preview: &corev1.LinkPreview{Description: strings.Repeat("d", MaxLinkPreviewDescriptionLength+1)},
 			field:   "link preview description",
 			max:     MaxLinkPreviewDescriptionLength,
+		},
+		{
+			name:    "image asset ID",
+			preview: &corev1.LinkPreview{ImageAssetId: &overLimitImageAssetID},
+			field:   "link preview image asset ID",
+			max:     MaxLinkPreviewImageAssetIDLength,
 		},
 		{
 			name:    "site name",

--- a/cli/internal/graph/admin.graphqls
+++ b/cli/internal/graph/admin.graphqls
@@ -166,15 +166,15 @@ type AdminServerConfig {
 "Input for updating server configuration."
 input UpdateServerConfigInput {
   "Welcome message shown on the login page. Set to empty string to clear."
-  welcomeMessage: String
+  welcomeMessage: String @length(max: 10000)
   "Server name for page titles. Set to empty string to use default."
-  serverName: String
+  serverName: String @length(max: 80)
   "Message of the Day for the header. Set to empty string to clear."
-  motd: String
+  motd: String @length(max: 1000)
   "Blocked usernames (newline-separated). Set to empty string to clear."
-  blockedUsernames: String
+  blockedUsernames: String @length(max: 10000)
   "Short server description for OG link-preview metadata. Set to empty string to clear."
-  description: String
+  description: String @length(max: 500)
 }
 
 extend type AdminQueries {

--- a/cli/internal/graph/config.go
+++ b/cli/internal/graph/config.go
@@ -1,0 +1,10 @@
+package graph
+
+func NewConfig(resolver ResolverRoot) Config {
+	return Config{
+		Resolvers: resolver,
+		Directives: DirectiveRoot{
+			Length: lengthDirective,
+		},
+	}
+}

--- a/cli/internal/graph/directives.go
+++ b/cli/internal/graph/directives.go
@@ -1,0 +1,55 @@
+package graph
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/99designs/gqlgen/graphql"
+)
+
+func lengthDirective(ctx context.Context, obj any, next graphql.Resolver, min *int32, max int32, message *string) (any, error) {
+	res, err := next(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	value, ok := stringDirectiveValue(res)
+	if !ok {
+		return res, nil
+	}
+
+	if min != nil && max < *min {
+		return nil, fmt.Errorf("invalid length directive configuration: min %d exceeds max %d", *min, max)
+	}
+	if min != nil && len(value) < int(*min) {
+		return nil, lengthDirectiveError(message, "must be at least %d bytes", *min)
+	}
+	if len(value) > int(max) {
+		return nil, lengthDirectiveError(message, "must be at most %d bytes", max)
+	}
+
+	return res, nil
+}
+
+func stringDirectiveValue(value any) (string, bool) {
+	switch v := value.(type) {
+	case nil:
+		return "", false
+	case string:
+		return v, true
+	case *string:
+		if v == nil {
+			return "", false
+		}
+		return *v, true
+	default:
+		return "", false
+	}
+}
+
+func lengthDirectiveError(message *string, fallback string, args ...any) error {
+	if message != nil && *message != "" {
+		return fmt.Errorf("%s", *message)
+	}
+	return fmt.Errorf(fallback, args...)
+}

--- a/cli/internal/graph/directives.graphqls
+++ b/cli/internal/graph/directives.graphqls
@@ -24,6 +24,12 @@ directive @goExtraField(
 ) repeatable on OBJECT | INPUT_OBJECT
 
 """
+Validates the UTF-8 byte length of a string argument or input field.
+Null and omitted nullable values are allowed; core validation remains authoritative.
+"""
+directive @length(min: Int, max: Int!, message: String) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+
+"""
 Custom scalar for date/time values, formatted as RFC3339.
 """
 scalar Time @goModel(model: "hmans.de/chatto/internal/graph.Time")

--- a/cli/internal/graph/generated.go
+++ b/cli/internal/graph/generated.go
@@ -72,6 +72,7 @@ type ResolverRoot interface {
 }
 
 type DirectiveRoot struct {
+	Length func(ctx context.Context, obj any, next graphql.Resolver, min *int32, max int32, message *string) (res any, err error)
 }
 
 type ComplexityRoot struct {
@@ -6640,6 +6641,36 @@ func (ec *executionContext) childFields___Type(ctx context.Context, field graphq
 
 // region    ***************************** args.gotpl *****************************
 
+func (ec *executionContext) dir_length_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "min",
+		func(ctx context.Context, v any) (*int32, error) {
+			return ec.unmarshalOInt2ᚖint32(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["min"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "max",
+		func(ctx context.Context, v any) (int32, error) {
+			return ec.unmarshalNInt2int32(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["max"] = arg1
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "message",
+		func(ctx context.Context, v any) (*string, error) {
+			return ec.unmarshalOString2ᚖstring(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["message"] = arg2
+	return args, nil
+}
+
 func (ec *executionContext) field_AdminMutations_clearUsernameCooldown_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -7783,15 +7814,53 @@ func (ec *executionContext) field_Query___type_args(ctx context.Context, rawArgs
 func (ec *executionContext) field_Query_linkPreview_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
-	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "url",
-		func(ctx context.Context, v any) (string, error) {
-			return ec.unmarshalNString2string(ctx, v)
-		})
+
+	arg0, err := ec.field_Query_linkPreview_argsURL(ctx, rawArgs)
 	if err != nil {
 		return nil, err
 	}
 	args["url"] = arg0
 	return args, nil
+}
+
+func (ec *executionContext) field_Query_linkPreview_argsURL(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (string, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("url"))
+	directive0 := func(ctx context.Context) (any, error) {
+		tmp, ok := rawArgs["url"]
+		if !ok {
+			var zeroVal string
+			return zeroVal, nil
+		}
+		return ec.unmarshalNString2string(ctx, tmp)
+	}
+
+	directive1 := func(ctx context.Context) (any, error) {
+		max, err := ec.unmarshalNInt2int32(ctx, 2048)
+		if err != nil {
+			var zeroVal string
+			return zeroVal, err
+		}
+		if ec.Directives.Length == nil {
+			var zeroVal string
+			return zeroVal, errors.New("directive length is not implemented")
+		}
+		return ec.Directives.Length(ctx, rawArgs, directive0, nil, max, nil)
+	}
+
+	tmp, err := directive1(ctx)
+	if err != nil {
+		var zeroVal string
+		return zeroVal, graphql.ErrorOnPath(ctx, err)
+	}
+	if data, ok := tmp.(string); ok {
+		return data, nil
+	} else {
+		var zeroVal string
+		return zeroVal, graphql.ErrorOnPath(ctx, fmt.Errorf(`unexpected type %T from directive, should be string`, tmp))
+	}
 }
 
 func (ec *executionContext) field_Query_permissionExplanation_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
@@ -25567,18 +25636,58 @@ func (ec *executionContext) unmarshalInputCreateRoleInput(ctx context.Context, o
 			it.Name = data
 		case "displayName":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("displayName"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalNString2string(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 80)
+				if err != nil {
+					var zeroVal string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.DisplayName = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(string); ok {
+				it.DisplayName = data
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "description":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalNString2string(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 500)
+				if err != nil {
+					var zeroVal string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.Description = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(string); ok {
+				it.Description = data
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		}
 	}
 	return it, nil
@@ -25604,18 +25713,60 @@ func (ec *executionContext) unmarshalInputCreateRoomGroupInput(ctx context.Conte
 		switch k {
 		case "name":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalNString2string(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 80)
+				if err != nil {
+					var zeroVal string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.Name = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(string); ok {
+				it.Name = data
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "description":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalOString2ᚖstring(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 500)
+				if err != nil {
+					var zeroVal *string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal *string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.Description = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(*string); ok {
+				it.Description = data
+			} else if tmp == nil {
+				it.Description = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		}
 	}
 	return it, nil
@@ -26395,53 +26546,205 @@ func (ec *executionContext) unmarshalInputLinkPreviewInput(ctx context.Context, 
 		switch k {
 		case "url":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("url"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalNString2string(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 2048)
+				if err != nil {
+					var zeroVal string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.URL = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(string); ok {
+				it.URL = data
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "title":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("title"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalOString2ᚖstring(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 300)
+				if err != nil {
+					var zeroVal *string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal *string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.Title = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(*string); ok {
+				it.Title = data
+			} else if tmp == nil {
+				it.Title = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "description":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalOString2ᚖstring(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 1000)
+				if err != nil {
+					var zeroVal *string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal *string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.Description = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(*string); ok {
+				it.Description = data
+			} else if tmp == nil {
+				it.Description = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "imageAssetId":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("imageAssetId"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalOString2ᚖstring(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 15)
+				if err != nil {
+					var zeroVal *string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal *string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.ImageAssetID = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(*string); ok {
+				it.ImageAssetID = data
+			} else if tmp == nil {
+				it.ImageAssetID = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "siteName":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("siteName"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalOString2ᚖstring(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 200)
+				if err != nil {
+					var zeroVal *string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal *string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.SiteName = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(*string); ok {
+				it.SiteName = data
+			} else if tmp == nil {
+				it.SiteName = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "embedType":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("embedType"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalOString2ᚖstring(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 64)
+				if err != nil {
+					var zeroVal *string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal *string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.EmbedType = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(*string); ok {
+				it.EmbedType = data
+			} else if tmp == nil {
+				it.EmbedType = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "embedId":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("embedId"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalOString2ᚖstring(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 256)
+				if err != nil {
+					var zeroVal *string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal *string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.EmbedID = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(*string); ok {
+				it.EmbedID = data
+			} else if tmp == nil {
+				it.EmbedID = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		}
 	}
 	return it, nil
@@ -26592,11 +26895,33 @@ func (ec *executionContext) unmarshalInputPostMessageInput(ctx context.Context, 
 			it.RoomID = data
 		case "body":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("body"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalOString2ᚖstring(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 10000)
+				if err != nil {
+					var zeroVal *string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal *string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.Body = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(*string); ok {
+				it.Body = data
+			} else if tmp == nil {
+				it.Body = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "attachments":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("attachments"))
 			data, err := ec.unmarshalOUpload2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUploadᚄ(ctx, v)
@@ -26657,32 +26982,114 @@ func (ec *executionContext) unmarshalInputPushSubscriptionInput(ctx context.Cont
 		switch k {
 		case "endpoint":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("endpoint"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalNString2string(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 4096)
+				if err != nil {
+					var zeroVal string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.Endpoint = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(string); ok {
+				it.Endpoint = data
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "p256dh":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("p256dh"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalNString2string(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 256)
+				if err != nil {
+					var zeroVal string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.P256dh = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(string); ok {
+				it.P256dh = data
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "auth":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("auth"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalNString2string(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 128)
+				if err != nil {
+					var zeroVal string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.Auth = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(string); ok {
+				it.Auth = data
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "userAgent":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("userAgent"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalOString2ᚖstring(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 512)
+				if err != nil {
+					var zeroVal *string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal *string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.UserAgent = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(*string); ok {
+				it.UserAgent = data
+			} else if tmp == nil {
+				it.UserAgent = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		}
 	}
 	return it, nil
@@ -27168,11 +27575,31 @@ func (ec *executionContext) unmarshalInputUpdateMessageInput(ctx context.Context
 			it.EventID = data
 		case "body":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("body"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalNString2string(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 10000)
+				if err != nil {
+					var zeroVal string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.Body = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(string); ok {
+				it.Body = data
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		}
 	}
 	return it, nil
@@ -27279,18 +27706,58 @@ func (ec *executionContext) unmarshalInputUpdateRoleInput(ctx context.Context, o
 			it.Name = data
 		case "displayName":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("displayName"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalNString2string(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 80)
+				if err != nil {
+					var zeroVal string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.DisplayName = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(string); ok {
+				it.DisplayName = data
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "description":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalNString2string(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 500)
+				if err != nil {
+					var zeroVal string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.Description = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(string); ok {
+				it.Description = data
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		}
 	}
 	return it, nil
@@ -27323,18 +27790,60 @@ func (ec *executionContext) unmarshalInputUpdateRoomGroupInput(ctx context.Conte
 			it.ID = data
 		case "name":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalNString2string(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 80)
+				if err != nil {
+					var zeroVal string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.Name = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(string); ok {
+				it.Name = data
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "description":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalOString2ᚖstring(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 500)
+				if err != nil {
+					var zeroVal *string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal *string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.Description = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(*string); ok {
+				it.Description = data
+			} else if tmp == nil {
+				it.Description = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		}
 	}
 	return it, nil
@@ -27404,39 +27913,149 @@ func (ec *executionContext) unmarshalInputUpdateServerConfigInput(ctx context.Co
 		switch k {
 		case "welcomeMessage":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("welcomeMessage"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalOString2ᚖstring(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 10000)
+				if err != nil {
+					var zeroVal *string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal *string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.WelcomeMessage = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(*string); ok {
+				it.WelcomeMessage = data
+			} else if tmp == nil {
+				it.WelcomeMessage = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "serverName":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("serverName"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalOString2ᚖstring(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 80)
+				if err != nil {
+					var zeroVal *string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal *string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.ServerName = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(*string); ok {
+				it.ServerName = data
+			} else if tmp == nil {
+				it.ServerName = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "motd":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("motd"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalOString2ᚖstring(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 1000)
+				if err != nil {
+					var zeroVal *string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal *string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.Motd = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(*string); ok {
+				it.Motd = data
+			} else if tmp == nil {
+				it.Motd = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "blockedUsernames":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("blockedUsernames"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalOString2ᚖstring(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 10000)
+				if err != nil {
+					var zeroVal *string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal *string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.BlockedUsernames = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(*string); ok {
+				it.BlockedUsernames = data
+			} else if tmp == nil {
+				it.BlockedUsernames = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "description":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalOString2ᚖstring(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 500)
+				if err != nil {
+					var zeroVal *string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal *string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.Description = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(*string); ok {
+				it.Description = data
+			} else if tmp == nil {
+				it.Description = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		}
 	}
 	return it, nil
@@ -27462,32 +28081,118 @@ func (ec *executionContext) unmarshalInputUpdateServerInput(ctx context.Context,
 		switch k {
 		case "name":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalNString2string(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 80)
+				if err != nil {
+					var zeroVal string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.Name = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(string); ok {
+				it.Name = data
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "description":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalOString2ᚖstring(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 500)
+				if err != nil {
+					var zeroVal *string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal *string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.Description = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(*string); ok {
+				it.Description = data
+			} else if tmp == nil {
+				it.Description = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "motd":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("motd"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalOString2ᚖstring(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 1000)
+				if err != nil {
+					var zeroVal *string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal *string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.Motd = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(*string); ok {
+				it.Motd = data
+			} else if tmp == nil {
+				it.Motd = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "welcomeMessage":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("welcomeMessage"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalOString2ᚖstring(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				max, err := ec.unmarshalNInt2int32(ctx, 10000)
+				if err != nil {
+					var zeroVal *string
+					return zeroVal, err
+				}
+				if ec.Directives.Length == nil {
+					var zeroVal *string
+					return zeroVal, errors.New("directive length is not implemented")
+				}
+				return ec.Directives.Length(ctx, obj, directive0, nil, max, nil)
 			}
-			it.WelcomeMessage = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(*string); ok {
+				it.WelcomeMessage = data
+			} else if tmp == nil {
+				it.WelcomeMessage = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		}
 	}
 	return it, nil

--- a/cli/internal/graph/linkpreview.graphqls
+++ b/cli/internal/graph/linkpreview.graphqls
@@ -27,19 +27,19 @@ the data in the postMessage mutation so it can be attached to the message.
 """
 input LinkPreviewInput {
   "The URL that was previewed."
-  url: String!
+  url: String! @length(max: 2048)
   "The page title."
-  title: String
+  title: String @length(max: 300)
   "The page description."
-  description: String
+  description: String @length(max: 1000)
   "Asset ID of the preview image (from the linkPreview query response)."
-  imageAssetId: String
+  imageAssetId: String @length(max: 15)
   "The site name."
-  siteName: String
+  siteName: String @length(max: 200)
   "Type of embed: 'generic', 'youtube', 'vimeo', etc."
-  embedType: String
+  embedType: String @length(max: 64)
   "Embed ID for rich embeds (e.g., YouTube video ID)."
-  embedId: String
+  embedId: String @length(max: 256)
 }
 
 extend type Query {
@@ -48,7 +48,7 @@ extend type Query {
   Returns null if the URL cannot be previewed.
   Requires authentication.
   """
-  linkPreview(url: String!): LinkPreview
+  linkPreview(url: String! @length(max: 2048)): LinkPreview
 }
 
 extend type MessagePostedEvent {

--- a/cli/internal/graph/mutation.graphqls
+++ b/cli/internal/graph/mutation.graphqls
@@ -214,13 +214,13 @@ Input for updating the server.
 """
 input UpdateServerInput {
   "The new name for the server."
-  name: String!
+  name: String! @length(max: 80)
   "The new description for the server. Set to empty string to clear."
-  description: String
+  description: String @length(max: 500)
   "Message of the Day, displayed in the chat header. Set to empty string to clear."
-  motd: String
+  motd: String @length(max: 1000)
   "Welcome message shown on the login page (markdown supported). Set to empty string to clear."
-  welcomeMessage: String
+  welcomeMessage: String @length(max: 10000)
 }
 
 """
@@ -230,7 +230,7 @@ input PostMessageInput {
   "The ID of the room to post to."
   roomId: ID!
   "The message content. Optional if attachments are provided."
-  body: String
+  body: String @length(max: 10000)
   "Optional file attachments (images, videos, etc.)."
   attachments: [Upload!]
   "Event ID of the thread root message. Determines thread membership and controls permission check (message.start_thread vs message.post_in_thread vs message.post)."
@@ -296,7 +296,7 @@ input UpdateMessageInput {
   "The event ID of the message to update."
   eventId: ID!
   "The new message content."
-  body: String!
+  body: String! @length(max: 10000)
 }
 
 """

--- a/cli/internal/graph/push.graphqls
+++ b/cli/internal/graph/push.graphqls
@@ -4,16 +4,16 @@ All fields come from the PushSubscription object returned by the browser's Push 
 """
 input PushSubscriptionInput {
   "The push service endpoint URL (from PushSubscription.endpoint)"
-  endpoint: String!
+  endpoint: String! @length(max: 4096)
 
   "The client's P-256 ECDH public key for message encryption (from PushSubscription.keys.p256dh)"
-  p256dh: String!
+  p256dh: String! @length(max: 256)
 
   "Authentication secret for message encryption (from PushSubscription.keys.auth)"
-  auth: String!
+  auth: String! @length(max: 128)
 
   "Optional user agent string for device identification"
-  userAgent: String
+  userAgent: String @length(max: 512)
 }
 
 extend type Mutation {

--- a/cli/internal/graph/room.resolvers.go
+++ b/cli/internal/graph/room.resolvers.go
@@ -17,11 +17,6 @@ import (
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
-const (
-	defaultRoomEventsLimit = 50
-	maxRoomEventsLimit     = 500
-)
-
 // Type is the resolver for the type field.
 //
 // Derived from `Room.kind` — the canonical kind discriminator since
@@ -369,8 +364,3 @@ func (r *roomResolver) CallParticipants(ctx context.Context, obj *corev1.Room) (
 func (r *Resolver) Room() RoomResolver { return &roomResolver{r} }
 
 type roomResolver struct{ *Resolver }
-
-func roomEventsLimit(limit *int32) int {
-	limitVal, _ := paginationArgs(limit, nil, defaultRoomEventsLimit, maxRoomEventsLimit)
-	return limitVal
-}

--- a/cli/internal/graph/room_events_limit.go
+++ b/cli/internal/graph/room_events_limit.go
@@ -1,0 +1,11 @@
+package graph
+
+const (
+	defaultRoomEventsLimit = 50
+	maxRoomEventsLimit     = 500
+)
+
+func roomEventsLimit(limit *int32) int {
+	limitVal, _ := paginationArgs(limit, nil, defaultRoomEventsLimit, maxRoomEventsLimit)
+	return limitVal
+}

--- a/cli/internal/graph/room_groups.graphqls
+++ b/cli/internal/graph/room_groups.graphqls
@@ -50,9 +50,9 @@ Input for creating a new room group.
 """
 input CreateRoomGroupInput {
   "Display name for the new set (e.g., 'Engineering', 'Public')."
-  name: String!
+  name: String! @length(max: 80)
   "Optional operator-facing description."
-  description: String
+  description: String @length(max: 500)
 }
 
 """
@@ -62,9 +62,9 @@ input UpdateRoomGroupInput {
   "The set's ID."
   id: ID!
   "Display name."
-  name: String!
+  name: String! @length(max: 80)
   "Optional description."
-  description: String
+  description: String @length(max: 500)
 }
 
 """

--- a/cli/internal/graph/server_rbac.graphqls
+++ b/cli/internal/graph/server_rbac.graphqls
@@ -22,9 +22,9 @@ input CreateRoleInput {
   "Role identifier (lowercase alphanumeric + underscores, max 32 chars)."
   name: String!
   "Human-readable display name."
-  displayName: String!
+  displayName: String! @length(max: 80)
   "Role description."
-  description: String!
+  description: String! @length(max: 500)
 }
 
 "Input for updating an existing role."
@@ -32,9 +32,9 @@ input UpdateRoleInput {
   "Role identifier of the role to update."
   name: String!
   "Human-readable display name."
-  displayName: String!
+  displayName: String! @length(max: 80)
   "Role description."
-  description: String!
+  description: String! @length(max: 500)
 }
 
 """

--- a/cli/internal/http_server/graphql.go
+++ b/cli/internal/http_server/graphql.go
@@ -39,9 +39,7 @@ func (s *HTTPServer) setupGraphQLAPI(allowedOrigins []string) {
 	// Configure GraphQL server with injected dependencies
 	resolver := graph.NewResolver(s.core, s.config.Owners, s.config.Auth, s.config.Push, s.config.Video, s.config.LiveKit, s.version)
 
-	config := graph.Config{
-		Resolvers: resolver,
-	}
+	config := graph.NewConfig(resolver)
 
 	h := handler.New(graph.NewExecutableSchema(config))
 

--- a/cli/internal/http_server/graphql_test.go
+++ b/cli/internal/http_server/graphql_test.go
@@ -532,7 +532,7 @@ func TestGraphQL_Mutation_PostMessage_RequiresRoomMembership(t *testing.T) {
 	// Try to post a message
 	resp := env.doGraphQL(t, `mutation($input: PostMessageInput!) {
 		postMessage(input: $input) {
-			event { id }
+			id
 		}
 	}`, map[string]any{
 		"input": map[string]any{
@@ -545,6 +545,117 @@ func TestGraphQL_Mutation_PostMessage_RequiresRoomMembership(t *testing.T) {
 	if len(resp.Errors) == 0 {
 		t.Error("Expected error for non-member posting message")
 	}
+}
+
+func TestGraphQL_LengthDirective_RejectsOverlongNestedInputField(t *testing.T) {
+	env := setupGraphQLTestServer(t)
+
+	resp := env.doGraphQL(t, `mutation($input: PostMessageInput!) {
+		postMessage(input: $input) {
+			id
+		}
+	}`, map[string]any{
+		"input": map[string]any{
+			"roomId": "Rtest",
+			"body":   "hello",
+			"linkPreview": map[string]any{
+				"url":   "https://example.com",
+				"title": strings.Repeat("t", core.MaxLinkPreviewTitleLength+1),
+			},
+		},
+	})
+
+	if len(resp.Errors) != 1 {
+		t.Fatalf("Expected one GraphQL validation error, got %d: %#v", len(resp.Errors), resp.Errors)
+	}
+	if !graphQLErrorPathContains(resp.Errors[0].Path, "linkPreview") || !graphQLErrorPathContains(resp.Errors[0].Path, "title") {
+		t.Fatalf("Expected error path to include nested input field, got message=%q path=%#v", resp.Errors[0].Message, resp.Errors[0].Path)
+	}
+	if !strings.Contains(resp.Errors[0].Message, "must be at most 300 bytes") {
+		t.Fatalf("Expected length validation message, got %q", resp.Errors[0].Message)
+	}
+}
+
+func TestGraphQL_LengthDirective_RejectsOverlongLinkPreviewImageAssetID(t *testing.T) {
+	env := setupGraphQLTestServer(t)
+
+	resp := env.doGraphQL(t, `mutation($input: PostMessageInput!) {
+		postMessage(input: $input) {
+			id
+		}
+	}`, map[string]any{
+		"input": map[string]any{
+			"roomId": "Rtest",
+			"body":   "hello",
+			"linkPreview": map[string]any{
+				"url":          "https://example.com",
+				"imageAssetId": strings.Repeat("a", core.MaxLinkPreviewImageAssetIDLength+1),
+			},
+		},
+	})
+
+	if len(resp.Errors) != 1 {
+		t.Fatalf("Expected one GraphQL validation error, got %d: %#v", len(resp.Errors), resp.Errors)
+	}
+	if !graphQLErrorPathContains(resp.Errors[0].Path, "linkPreview") || !graphQLErrorPathContains(resp.Errors[0].Path, "imageAssetId") {
+		t.Fatalf("Expected error path to include imageAssetId input field, got message=%q path=%#v", resp.Errors[0].Message, resp.Errors[0].Path)
+	}
+	if !strings.Contains(resp.Errors[0].Message, "must be at most 15 bytes") {
+		t.Fatalf("Expected length validation message, got %q", resp.Errors[0].Message)
+	}
+}
+
+func TestGraphQL_LengthDirective_RejectsOverlongLinkPreviewQueryURL(t *testing.T) {
+	env := setupGraphQLTestServer(t)
+
+	resp := env.doGraphQL(t, `query($url: String!) {
+		linkPreview(url: $url) {
+			url
+		}
+	}`, map[string]any{
+		"url": strings.Repeat("u", core.MaxLinkPreviewURLLength+1),
+	})
+
+	if len(resp.Errors) != 1 {
+		t.Fatalf("Expected one GraphQL validation error, got %d: %#v", len(resp.Errors), resp.Errors)
+	}
+	if !graphQLErrorPathContains(resp.Errors[0].Path, "linkPreview") || !graphQLErrorPathContains(resp.Errors[0].Path, "url") {
+		t.Fatalf("Expected error path to include linkPreview url argument, got message=%q path=%#v", resp.Errors[0].Message, resp.Errors[0].Path)
+	}
+	if !strings.Contains(resp.Errors[0].Message, "must be at most 2048 bytes") {
+		t.Fatalf("Expected length validation message, got %q", resp.Errors[0].Message)
+	}
+}
+
+func TestGraphQL_LengthDirective_AllowsNullNullableInputField(t *testing.T) {
+	env := setupGraphQLTestServer(t)
+
+	resp := env.doGraphQL(t, `mutation($input: UpdateServerInput!) {
+		updateServer(input: $input) {
+			config { serverName }
+		}
+	}`, map[string]any{
+		"input": map[string]any{
+			"name":        "Test Server",
+			"description": nil,
+		},
+	})
+
+	if len(resp.Errors) == 0 {
+		t.Fatal("Expected resolver authentication error")
+	}
+	if strings.Contains(resp.Errors[0].Message, "must be at most") {
+		t.Fatalf("Expected null nullable field to bypass length validation, got %q", resp.Errors[0].Message)
+	}
+}
+
+func graphQLErrorPathContains(path []any, want string) bool {
+	for _, segment := range path {
+		if segment == want {
+			return true
+		}
+	}
+	return false
 }
 
 // ============================================================================

--- a/docs/fdr/FDR-009-link-previews.md
+++ b/docs/fdr/FDR-009-link-previews.md
@@ -14,7 +14,7 @@ When a message contains a URL, Chatto can attach a preview card with the page's 
 - YouTube URLs get a specialized embed-ready card without scraping the page.
 - A preview shows up in the composer with a dismiss button. Dismissing the preview prevents it from being attached to the sent message, and the dismissal is remembered for that URL during the composition session.
 - When the message is sent, the preview data ships with it and is stored as part of the message body.
-- Client-provided preview metadata is size-limited before storage: URL 2,048 bytes, title 300 bytes, description 1,000 bytes, site name 200 bytes, embed type 64 bytes, and embed ID 256 bytes.
+- Client-provided preview metadata is size-limited before storage: URL 2,048 bytes, title 300 bytes, description 1,000 bytes, image asset ID 15 bytes, site name 200 bytes, embed type 64 bytes, and embed ID 256 bytes.
 - After posting, the message author can delete the preview from the message without deleting the message.
 
 ## Design Decisions


### PR DESCRIPTION
Fixes #738.

- Adds a gqlgen `@length` directive and wires it into the GraphQL server config.
- Annotates selected byte-limited string inputs and arguments for messages, link previews, server config, roles, room groups, and push subscriptions.
- Adds core validation for stored link-preview image asset IDs.
- Adds GraphQL HTTP tests for nested field-path errors, query-argument validation, and nullable input handling.
- Updates FDR-009 for the stored link-preview image asset ID limit; ADRs, glossary, architecture inventory, and docs website need no update.

Validation: `mise codegen-cli`; `mise x -- go test -tags test_endpoints ./internal/http_server -run 'TestGraphQL_(JSONRequestBodyLimit|LengthDirective|Mutation_PostMessage_RequiresRoomMembership|Query_Viewer)' -timeout 60s`; `mise x -- go test ./internal/graph -run 'TestRoomEventsLimit|Test.*' -timeout 60s`; `mise x -- go test ./internal/core -run 'TestChattoCore_PostMessage_LinkPreviewLengthLimits' -timeout 60s`; `git diff --check`.

Note: full `go test ./internal/http_server -count=1` still fails in unrelated `TestAuthRoutes_TestEmailEndpoint` with expected 200, got 404.
