### PR TITLE
refactor(graphql): require room group for room creation

### DIFF
--- a/cli/internal/graph/events.graphqls
+++ b/cli/internal/graph/events.graphqls
@@ -559,7 +559,7 @@ Event: The channel-room groups (ordering, names, or membership) were updated.
 Clients should refetch `Server.roomGroups` to get the new shape.
 """
 type RoomGroupsUpdatedEvent {
-  "Always true. Vestigial — clients only need the event arrival to trigger a refetch of the sets."
+  "Always true. Vestigial — clients only need the event arrival to trigger a refetch of room groups."
   changed: Boolean! @goField(forceResolver: true)
 }
 

--- a/cli/internal/graph/generated.go
+++ b/cli/internal/graph/generated.go
@@ -25806,7 +25806,7 @@ func (ec *executionContext) unmarshalInputCreateRoomInput(ctx context.Context, o
 			it.Description = data
 		case "groupId":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("groupId"))
-			data, err := ec.unmarshalOID2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNID2string(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/cli/internal/graph/model/models_gen.go
+++ b/cli/internal/graph/model/models_gen.go
@@ -78,10 +78,10 @@ type AdminQueries struct {
 	// Inspect runtime state and rough memory estimates for event-sourced projections.
 	Projections []*ProjectionState `json:"projections"`
 	// Resolve the explicit grants and denials configured for a role on a
-	// specific set. Returns empty arrays if neither side has any keys.
+	// specific room group. Returns empty arrays if neither side has any keys.
 	GroupRolePermissions *RoomGroupRolePermissions `json:"groupRolePermissions"`
 	// Resolve the explicit grants and denials configured for a user on a
-	// specific set (user-level overrides at set scope).
+	// specific room group (user-level overrides at room-group scope).
 	GroupUserPermissions *RoomGroupUserPermissions `json:"groupUserPermissions"`
 	// List all available server permission identifiers.
 	ServerPermissions []string `json:"serverPermissions"`
@@ -212,7 +212,7 @@ type CreateRoleInput struct {
 
 // Input for creating a new room group.
 type CreateRoomGroupInput struct {
-	// Display name for the new set (e.g., 'Engineering', 'Public').
+	// Display name for the new room group (e.g., 'Engineering', 'Public').
 	Name string `json:"name"`
 	// Optional operator-facing description.
 	Description *string `json:"description,omitempty"`
@@ -224,10 +224,10 @@ type CreateRoomInput struct {
 	Name string `json:"name"`
 	// Optional description of the room's purpose.
 	Description *string `json:"description,omitempty"`
-	// Optional room-set ID to place the new room in. Required once the
-	// room-sets feature is fully wired (see ADR-031); during the transition
-	// it may be omitted, in which case the room is created without a set.
-	GroupID *string `json:"groupId,omitempty"`
+	// Room group ID to place the new channel room in. Channel room creation
+	// requires an explicit group; DM rooms are created through the DM APIs and
+	// do not use this input.
+	GroupID string `json:"groupId"`
 }
 
 // Input for deleting an attachment from a message.
@@ -276,9 +276,9 @@ type DeleteRoleInput struct {
 	Name string `json:"name"`
 }
 
-// Input for deleting a room group. Fails if the set still contains any rooms.
+// Input for deleting a room group. Fails if the room group still contains any rooms.
 type DeleteRoomGroupInput struct {
-	// The set's ID.
+	// The room group's ID.
 	ID string `json:"id"`
 }
 
@@ -408,7 +408,7 @@ type GrantUserPermissionInput struct {
 // Input for granting a permission on a room group. The subject is either a role
 // (by name) or a user (by ID).
 type GroupPermissionInput struct {
-	// The set to scope the grant to.
+	// The room group to scope the grant to.
 	GroupID string `json:"groupId"`
 	// Role name or user ID. (Role names are lowercase letters; user IDs start with `U`.)
 	Subject string `json:"subject"`
@@ -490,12 +490,12 @@ type MarkThreadAsReadResult struct {
 	PreviousReadAt *timestamppb.Timestamp `json:"previousReadAt,omitempty"`
 }
 
-// Input for moving a room into a different set. Requires room.manage in
-// both the source and target set (ADR-031).
+// Input for moving a room into a different room group. Requires room.manage in
+// both the source and target room group (ADR-031).
 type MoveRoomToSetInput struct {
 	// The room to move.
 	RoomID string `json:"roomId"`
-	// The destination set.
+	// The destination room group.
 	GroupID string `json:"groupId"`
 }
 
@@ -722,9 +722,9 @@ type ReorderRolesInput struct {
 }
 
 // Input for reordering all room groups. The order must include every existing
-// set ID exactly once; partial or unknown lists are rejected.
+// room group ID exactly once; partial or unknown lists are rejected.
 type ReorderRoomGroupsInput struct {
-	// Set IDs in the desired display order, first to last.
+	// Room group IDs in the desired display order, first to last.
 	OrderedIds []string `json:"orderedIds"`
 }
 
@@ -856,30 +856,31 @@ type RoomEventsConnection struct {
 	HasNewer bool `json:"hasNewer"`
 }
 
-// Per-set role permission inspector. Returns the explicit grants and denials
-// configured on a set for a given role (no inheritance — to see the effective
-// permissions resolve per-room or per-user via the resolver instead).
+// Per-room-group role permission inspector. Returns the explicit grants and
+// denials configured on a room group for a given role (no inheritance — to
+// see the effective permissions resolve per-room or per-user via the resolver
+// instead).
 type RoomGroupRolePermissions struct {
-	// The set these permissions belong to.
+	// The room group these permissions belong to.
 	GroupID string `json:"groupId"`
 	// The role these permissions apply to.
 	RoleName string `json:"roleName"`
-	// Permissions explicitly granted to this role on this set.
+	// Permissions explicitly granted to this role on this room group.
 	Permissions []string `json:"permissions"`
-	// Permissions explicitly denied to this role on this set.
+	// Permissions explicitly denied to this role on this room group.
 	PermissionDenials []string `json:"permissionDenials"`
 }
 
-// Per-set user permission inspector. Mirrors RoomGroupRolePermissions for
-// direct user-level grants/denials.
+// Per-room-group user permission inspector. Mirrors RoomGroupRolePermissions
+// for direct user-level grants/denials.
 type RoomGroupUserPermissions struct {
-	// The set these permissions belong to.
+	// The room group these permissions belong to.
 	GroupID string `json:"groupId"`
 	// The user these permissions apply to.
 	UserID string `json:"userId"`
-	// Permissions explicitly granted to this user on this set.
+	// Permissions explicitly granted to this user on this room group.
 	Permissions []string `json:"permissions"`
-	// Permissions explicitly denied to this user on this set.
+	// Permissions explicitly denied to this user on this room group.
 	PermissionDenials []string `json:"permissionDenials"`
 }
 
@@ -1182,7 +1183,7 @@ type UpdateRoleInput struct {
 
 // Input for updating an existing room group.
 type UpdateRoomGroupInput struct {
-	// The set's ID.
+	// The room group's ID.
 	ID string `json:"id"`
 	// Display name.
 	Name string `json:"name"`

--- a/cli/internal/graph/mutation.graphqls
+++ b/cli/internal/graph/mutation.graphqls
@@ -190,11 +190,11 @@ input CreateRoomInput {
   "Optional description of the room's purpose."
   description: String
   """
-  Optional room-set ID to place the new room in. Required once the
-  room-sets feature is fully wired (see ADR-031); during the transition
-  it may be omitted, in which case the room is created without a set.
+  Room group ID to place the new channel room in. Channel room creation
+  requires an explicit group; DM rooms are created through the DM APIs and
+  do not use this input.
   """
-  groupId: ID
+  groupId: ID!
 }
 
 """

--- a/cli/internal/graph/mutation.resolvers.go
+++ b/cli/internal/graph/mutation.resolvers.go
@@ -34,10 +34,7 @@ func (r *mutationResolver) CreateRoom(ctx context.Context, input model.CreateRoo
 		desc = *input.Description
 	}
 
-	groupID := ""
-	if input.GroupID != nil {
-		groupID = *input.GroupID
-	}
+	groupID := input.GroupID
 
 	// Authorization: check CanCreateRoom permission, scoped to the target
 	// group when one is specified. A role granted room.create at server

--- a/cli/internal/graph/mutation_test.go
+++ b/cli/internal/graph/mutation_test.go
@@ -24,9 +24,11 @@ func ptr(s string) *string {
 func TestCreateRoom_Authorization(t *testing.T) {
 	env := setupTestResolver(t)
 	mutation := env.resolver.Mutation()
+	groupID := env.testRoom.GroupId
 
 	input := model.CreateRoomInput{
-		Name: "new-room",
+		Name:    "new-room",
+		GroupID: groupID,
 	}
 
 	t.Run("unauthenticated user is rejected", func(t *testing.T) {
@@ -51,7 +53,8 @@ func TestCreateRoom_Authorization(t *testing.T) {
 	t.Run("space admin can create room", func(t *testing.T) {
 		// testUser is the space creator (admin)
 		room, err := mutation.CreateRoom(env.authContext(), model.CreateRoomInput{
-			Name: "admin-created-room",
+			Name:    "admin-created-room",
+			GroupID: groupID,
 		})
 		if err != nil {
 			t.Fatalf("expected success, got error: %v", err)
@@ -72,7 +75,8 @@ func TestCreateRoom_Authorization(t *testing.T) {
 
 		// room.create is not granted to everyone role by default
 		_, err = mutation.CreateRoom(env.authContextForUser(member), model.CreateRoomInput{
-			Name: "member-created-room",
+			Name:    "member-created-room",
+			GroupID: groupID,
 		})
 		if !errors.Is(err, core.ErrPermissionDenied) {
 			t.Errorf("expected ErrPermissionDenied, got %v", err)
@@ -92,7 +96,8 @@ func TestCreateRoom_Authorization(t *testing.T) {
 		}
 
 		room, err := mutation.CreateRoom(env.authContextForUser(member), model.CreateRoomInput{
-			Name: "member-created-room-granted",
+			Name:    "member-created-room-granted",
+			GroupID: groupID,
 		})
 		if err != nil {
 			t.Fatalf("expected success, got error: %v", err)

--- a/cli/internal/graph/role_permissions.graphqls
+++ b/cli/internal/graph/role_permissions.graphqls
@@ -106,14 +106,15 @@ extend type Query {
   rolePermissions.
 
   Pass `roomId` for per-room override editing (inherits from the room's
-  set), `groupId` for set-scope editing (no inheritance — sets are
-  top-level for channel-room permissions). Pass neither for server scope.
+  room group), `groupId` for room-group-scope editing (no inheritance —
+  room groups are top-level for channel-room permissions). Pass neither
+  for server scope.
   Passing both is rejected.
   """
   tierRoles(
     "Optional room scope."
     roomId: ID
-    "Optional set scope (ADR-031)."
+    "Optional room-group scope (ADR-031)."
     groupId: ID
   ): TierRoles @goField(forceResolver: true)
 }

--- a/cli/internal/graph/room.graphqls
+++ b/cli/internal/graph/room.graphqls
@@ -63,8 +63,8 @@ type Room {
   archived: Boolean!
   """
   Channel rooms belong to exactly one RoomGroup; this field identifies which
-  one. Empty string for DM rooms — those don't participate in the set
-  layout (see ADR-031).
+  one. DM rooms return an empty string sentinel because they do not
+  participate in room-group layout or ACLs (see ADR-031).
   """
   groupId: ID!
 

--- a/cli/internal/graph/room_groups.graphqls
+++ b/cli/internal/graph/room_groups.graphqls
@@ -1,45 +1,46 @@
 """
-Per-set role permission inspector. Returns the explicit grants and denials
-configured on a set for a given role (no inheritance — to see the effective
-permissions resolve per-room or per-user via the resolver instead).
+Per-room-group role permission inspector. Returns the explicit grants and
+denials configured on a room group for a given role (no inheritance — to
+see the effective permissions resolve per-room or per-user via the resolver
+instead).
 """
 type RoomGroupRolePermissions {
-  "The set these permissions belong to."
+  "The room group these permissions belong to."
   groupId: ID!
   "The role these permissions apply to."
   roleName: String!
-  "Permissions explicitly granted to this role on this set."
+  "Permissions explicitly granted to this role on this room group."
   permissions: [String!]!
-  "Permissions explicitly denied to this role on this set."
+  "Permissions explicitly denied to this role on this room group."
   permissionDenials: [String!]!
 }
 
 """
-Per-set user permission inspector. Mirrors RoomGroupRolePermissions for
-direct user-level grants/denials.
+Per-room-group user permission inspector. Mirrors RoomGroupRolePermissions
+for direct user-level grants/denials.
 """
 type RoomGroupUserPermissions {
-  "The set these permissions belong to."
+  "The room group these permissions belong to."
   groupId: ID!
   "The user these permissions apply to."
   userId: ID!
-  "Permissions explicitly granted to this user on this set."
+  "Permissions explicitly granted to this user on this room group."
   permissions: [String!]!
-  "Permissions explicitly denied to this user on this set."
+  "Permissions explicitly denied to this user on this room group."
   permissionDenials: [String!]!
 }
 
 extend type AdminQueries {
   """
   Resolve the explicit grants and denials configured for a role on a
-  specific set. Returns empty arrays if neither side has any keys.
+  specific room group. Returns empty arrays if neither side has any keys.
   """
   groupRolePermissions(groupId: ID!, roleName: String!): RoomGroupRolePermissions!
     @goField(forceResolver: true)
 
   """
   Resolve the explicit grants and denials configured for a user on a
-  specific set (user-level overrides at set scope).
+  specific room group (user-level overrides at room-group scope).
   """
   groupUserPermissions(groupId: ID!, userId: ID!): RoomGroupUserPermissions!
     @goField(forceResolver: true)
@@ -49,7 +50,7 @@ extend type AdminQueries {
 Input for creating a new room group.
 """
 input CreateRoomGroupInput {
-  "Display name for the new set (e.g., 'Engineering', 'Public')."
+  "Display name for the new room group (e.g., 'Engineering', 'Public')."
   name: String! @length(max: 80)
   "Optional operator-facing description."
   description: String @length(max: 500)
@@ -59,7 +60,7 @@ input CreateRoomGroupInput {
 Input for updating an existing room group.
 """
 input UpdateRoomGroupInput {
-  "The set's ID."
+  "The room group's ID."
   id: ID!
   "Display name."
   name: String! @length(max: 80)
@@ -68,30 +69,30 @@ input UpdateRoomGroupInput {
 }
 
 """
-Input for deleting a room group. Fails if the set still contains any rooms.
+Input for deleting a room group. Fails if the room group still contains any rooms.
 """
 input DeleteRoomGroupInput {
-  "The set's ID."
+  "The room group's ID."
   id: ID!
 }
 
 """
 Input for reordering all room groups. The order must include every existing
-set ID exactly once; partial or unknown lists are rejected.
+room group ID exactly once; partial or unknown lists are rejected.
 """
 input ReorderRoomGroupsInput {
-  "Set IDs in the desired display order, first to last."
+  "Room group IDs in the desired display order, first to last."
   orderedIds: [ID!]!
 }
 
 """
-Input for moving a room into a different set. Requires room.manage in
-both the source and target set (ADR-031).
+Input for moving a room into a different room group. Requires room.manage in
+both the source and target room group (ADR-031).
 """
 input MoveRoomToSetInput {
   "The room to move."
   roomId: ID!
-  "The destination set."
+  "The destination room group."
   groupId: ID!
 }
 
@@ -112,7 +113,7 @@ Input for granting a permission on a room group. The subject is either a role
 (by name) or a user (by ID).
 """
 input GroupPermissionInput {
-  "The set to scope the grant to."
+  "The room group to scope the grant to."
   groupId: ID!
   "Role name or user ID. (Role names are lowercase letters; user IDs start with `U`.)"
   subject: String!
@@ -128,21 +129,21 @@ extend type Mutation {
   updateRoomGroup(input: UpdateRoomGroupInput!): RoomGroup!
 
   """
-  Delete a room group. Rejected if the set still contains rooms — operators
-  must move all rooms out first. Requires `role.manage`.
+  Delete a room group. Rejected if the room group still contains rooms —
+  operators must move all rooms out first. Requires `role.manage`.
   """
   deleteRoomGroup(input: DeleteRoomGroupInput!): Boolean!
 
   """
   Reorder all room groups. The provided ID list must contain every existing
-  set exactly once. Requires `role.manage`.
+  room group exactly once. Requires `role.manage`.
   """
   reorderRoomGroups(input: ReorderRoomGroupsInput!): [RoomGroup!]!
 
   """
-  Move a room into a different set. The caller must have `room.manage`
-  in both the source set and the target set (ADR-031). Permission overrides
-  on the room itself are preserved.
+  Move a room into a different room group. The caller must have
+  `room.manage` in both the source room group and the target room group
+  (ADR-031). Permission overrides on the room itself are preserved.
   """
   moveRoomToSet(input: MoveRoomToSetInput!): Room!
 

--- a/cli/internal/graph/room_layout.graphqls
+++ b/cli/internal/graph/room_layout.graphqls
@@ -4,12 +4,12 @@ a permission container — each room group has its own ACL, with individual
 rooms able to override on a per (role, permission) basis (see ADR-031).
 """
 type RoomGroup {
-  "Unique ID for this set."
+  "Unique ID for this room group."
   id: ID!
-  "Display name for this set (e.g., 'General', 'Projects')."
+  "Display name for this room group (e.g., 'General', 'Projects')."
   name: String!
   "Operator-facing description; may be empty."
   description: String!
-  "Ordered list of rooms in this set."
+  "Ordered list of channel rooms in this room group."
   rooms: [Room!]! @goField(forceResolver: true)
 }

--- a/cli/internal/http_server/graphql_test.go
+++ b/cli/internal/http_server/graphql_test.go
@@ -790,6 +790,21 @@ func TestGraphQL_ErrorFormat(t *testing.T) {
 	}
 }
 
+func TestGraphQL_CreateRoom_RequiresGroupID(t *testing.T) {
+	env := setupGraphQLTestServer(t)
+
+	resp := env.doGraphQL(t, `mutation {
+		createRoom(input: { name: "missing-group" }) { id }
+	}`, nil)
+
+	if len(resp.Errors) == 0 {
+		t.Fatal("Expected validation error for missing groupId")
+	}
+	if !strings.Contains(resp.Errors[0].Message, "groupId") {
+		t.Fatalf("Expected missing groupId error, got: %v", resp.Errors)
+	}
+}
+
 func TestGraphQL_Variables(t *testing.T) {
 	env := setupGraphQLTestServer(t)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -262,7 +262,7 @@ There is no `adminAuditLogEvents` subscription — audit events arrive through `
 | Objects | `SERVER_ASSETS`               | Message attachments                         |
 | Legacy import KV | `INSTANCE`          | Users, verified emails, branding, display preferences, and push subscriptions from pre-ES deployments |
 | Legacy import KV | `INSTANCE_CONFIG`   | Server configuration from pre-ES deployments |
-| Legacy import KV | `SERVER_CONFIG`     | Rooms, memberships, room sets/layout, and notification preferences from pre-ES deployments |
+| Legacy import KV | `SERVER_CONFIG`     | Rooms, memberships, room groups/layout, and notification preferences from pre-ES deployments |
 | Legacy import KV | `SERVER_RBAC`       | RBAC seed data from pre-ES deployments |
 | Legacy import KV | `SERVER_RUNTIME`    | Read markers, thread follows, migration sentinels, and video processing state from pre-ES deployments |
 | Legacy import KV | `SERVER_BODIES`     | Pre-ES message bodies and attachment metadata |
@@ -458,7 +458,7 @@ The unified `myEvents` GraphQL subscription is backed by a single core stream (`
 | `CALL_STATE`                  | Memory  | No       | Legacy retired active-call bucket; copied best-effort into `MEMORY_CACHE` on boot if present, not provisioned on fresh boot |
 | `INSTANCE`                    | File    | Yes      | Legacy import source for users, verified emails, branding, display preferences, and push subscriptions; not provisioned on fresh boot |
 | `INSTANCE_CONFIG`             | File    | Yes      | Legacy server configuration import source; not provisioned on fresh boot |
-| `SERVER_CONFIG`               | File    | Yes      | Legacy rooms, memberships, room sets/layout, and notification preferences import source; not provisioned on fresh boot |
+| `SERVER_CONFIG`               | File    | Yes      | Legacy rooms, memberships, room groups/layout, and notification preferences import source; not provisioned on fresh boot |
 | `SERVER_RBAC`                 | File    | Yes      | Legacy RBAC seed data import source; not provisioned on fresh boot |
 | `SERVER_RUNTIME`              | File    | Yes      | Legacy read markers, thread follows, migration sentinels, and video processing state import source; not provisioned on fresh boot |
 | `SERVER_BODIES`               | File    | Yes      | Legacy message bodies and attachment metadata import source; not provisioned on fresh boot |
@@ -540,12 +540,12 @@ Room and membership keys in this legacy import bucket carry a `kind` segment (`c
 
 | Key                                                  | Description                                      |
 | ---------------------------------------------------- | ------------------------------------------------ |
-| `room.channel.{roomId}`                              | Channel-style room. The Room proto carries `set_id` referencing its `RoomSet` (ADR-031). |
-| `room.dm.{roomId}`                                   | Direct-message room (no `set_id` — DMs aren't part of any room set). |
+| `room.channel.{roomId}`                              | Channel-style room. The Room proto carries `group_id` referencing its room group (ADR-031). |
+| `room.dm.{roomId}`                                   | Direct-message room (no `group_id` — DMs aren't part of any room group). |
 | `room_name_index.{lowercaseName}`                    | Atomic name claim → room ID. Channels only; DMs have empty names. Enforces case-insensitive uniqueness without a read-then-write race. |
 | `room_membership.channel.{roomId}.{userId}`          | Channel membership (room-first ordering matches `room.{kind}.{X}`)  |
 | `room_membership.dm.{roomId}.{userId}`               | DM membership                                    |
-| `room_layout`                                        | Single proto holding the ordered list of `RoomSet`s (and each set's ordered room IDs). Updated atomically with OCC. |
+| `room_layout`                                        | Single proto holding the ordered list of room groups (and each group's ordered room IDs). Updated atomically with OCC. |
 
 Useful filter patterns:
 

--- a/docs/adr/ADR-031-room-group-centric-acl.md
+++ b/docs/adr/ADR-031-room-group-centric-acl.md
@@ -35,12 +35,12 @@ This work evolves the existing `RoomLayout` / `RoomLayoutSection` storage (`prot
 ### Membership and structural invariants
 
 - **Every channel room belongs to exactly one group.** No nullable `groupID`, no "uncategorized" branch in the resolver. (DM rooms do not belong to a group.)
-- **Sets are operator-managed, not system-protected.** On first boot, one group named "Lobby" is seeded; the auto-created `announcements` and `general` channels go into it. The operator can rename, reorder, or delete this group like any other.
-- **Set deletion is rejected while rooms exist.** Operators must move all rooms out first. No "delete and reassign" cascade — the rejection is deliberate to avoid surprise.
-- **Room creation requires a group.** When no set is implied by UI context, the API requires one explicitly. There is no implicit fallback group; the seed "Lobby" group only matters at first-boot.
-- **Set membership is stored on the room record** (one `groupID` field per room).
+- **Room groups are operator-managed, not system-protected.** On first boot, one group named "Lobby" is seeded; the auto-created `announcements` and `general` channels go into it. The operator can rename, reorder, or delete this group like any other.
+- **Room group deletion is rejected while rooms exist.** Operators must move all rooms out first. No "delete and reassign" cascade — the rejection is deliberate to avoid surprise.
+- **Room creation requires a group.** When no room group is implied by UI context, the GraphQL API requires one explicitly. Lower-level bootstrap/import paths may still use the seed "Lobby" group while constructing first-boot state.
+- **Room group membership is stored on the room record** (one `groupID` field per room).
 - **Moving a room between groups requires `room.manage` in BOTH the source and target group.** The action changes the room's effective ACL overnight, so the caller must be authorized in both ends of the move.
-- **Sets are ordered.** Set order, like room order within a group, is captured in the layout proto (same atomic-OCC pattern as today's `RoomLayout`).
+- **Room groups are ordered.** Room group order, like room order within a group, is captured in the layout proto (same atomic-OCC pattern as today's `RoomLayout`).
 
 ### Resolution
 

--- a/docs/fdr/FDR-019-room-lifecycle.md
+++ b/docs/fdr/FDR-019-room-lifecycle.md
@@ -1,7 +1,7 @@
 # FDR-019: Room Lifecycle
 
 **Status:** Active
-**Last reviewed:** 2026-05-31
+**Last reviewed:** 2026-06-06
 
 ## Overview
 
@@ -26,7 +26,7 @@ A channel room goes through a lifecycle of create, edit, archive, unarchive, and
 
 ### 2. Every channel room belongs to exactly one group
 
-**Decision:** `groupID` is non-nullable on channel rooms. Creation without an explicit group falls back to the server's seed group ("Lobby") only at first boot; afterwards the API requires an explicit group.
+**Decision:** `groupID` is non-nullable on channel rooms. The GraphQL `createRoom` API requires an explicit `groupId`; lower-level bootstrap/import paths may still pass an empty group ID to fall back to the seed room group while constructing first-boot state.
 **Why:** Optional grouping means an "unsorted" branch in the permission resolver and sidebar layout — extra cases that nobody actually wants. Requiring a group simplifies the resolver and gives operators a consistent unit of permission scope. See ADR-031 and FDR-017.
 **Tradeoff:** Bulk room creation tools need to know which group to drop rooms into. The API surfaces a clear error if `groupID` is missing.
 

--- a/frontend/e2e/pages/ChatPage.ts
+++ b/frontend/e2e/pages/ChatPage.ts
@@ -168,18 +168,25 @@ export class ChatPage {
    */
   async createRoom(name?: string, description?: string): Promise<string> {
     const roomName = name ?? `test-room-${Date.now()}`;
-    const spaceId = await this.getSpaceId();
+    const groupData = await graphqlQuery<{ server: { roomGroups: { id: string }[] } }>(
+      this.page,
+      `query { server { roomGroups { id } } }`
+    );
+    const groupId = groupData.server.roomGroups[0]?.id;
+    if (!groupId) {
+      throw new Error('No room group available for e2e room creation');
+    }
 
     // Create and join room via API
     const result = await this.page.evaluate(
-      async ({ spaceId, roomName, description }) => {
+      async ({ roomName, description, groupId }) => {
         const createRes = await fetch('/api/graphql', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
           credentials: 'include',
           body: JSON.stringify({
             query: `mutation($input: CreateRoomInput!) { createRoom(input: $input) { id name } }`,
-            variables: { input: { name: roomName, description: description || undefined } }
+            variables: { input: { name: roomName, description: description || undefined, groupId } }
           })
         });
         const createData = await createRes.json();
@@ -201,7 +208,7 @@ export class ChatPage {
 
         return { roomId };
       },
-      { spaceId, roomName, description }
+      { roomName, description, groupId }
     );
 
     // Navigate to the new room

--- a/frontend/e2e/room-layout.test.ts
+++ b/frontend/e2e/room-layout.test.ts
@@ -52,10 +52,17 @@ async function createSpaceViaAPI(page: Page, _name?: string): Promise<TestSpace>
 }
 
 async function createRoomViaAPI(page: Page, name: string): Promise<string> {
+  const groupData = await gqlRequest<{ server: { roomGroups: { id: string }[] } }>(
+    page,
+    `query { server { roomGroups { id } } }`
+  );
+  const groupId = groupData.server.roomGroups[0]?.id;
+  if (!groupId) throw new Error('No room group available for e2e room creation');
+
   const data = await gqlRequest<{ createRoom: { id: string; name: string } }>(
     page,
     `mutation($input: CreateRoomInput!) { createRoom(input: $input) { id name } }`,
-    { input: { name } }
+    { input: { name, groupId } }
   );
   return data.createRoom.id;
 }

--- a/frontend/e2e/room-permissions.test.ts
+++ b/frontend/e2e/room-permissions.test.ts
@@ -67,11 +67,22 @@ async function joinSpaceViaAPI(_page: Page, _spaceId: string): Promise<void> {
 
 async function createRoomViaAPI(page: Page, name?: string): Promise<string> {
   const roomName = name ?? `room${Date.now()}`;
+  const groupResp = await page.request.post('/api/graphql', {
+    headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
+    data: { query: `query { server { roomGroups { id } } }` }
+  });
+  expect(groupResp.ok()).toBeTruthy();
+  const groupData = await groupResp.json();
+  const groupId = groupData.data?.server?.roomGroups?.[0]?.id;
+  if (!groupId) {
+    throw new Error(`No room group available for e2e room creation: ${JSON.stringify(groupData)}`);
+  }
+
   const resp = await page.request.post('/api/graphql', {
     headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
     data: {
       query: `mutation($input: CreateRoomInput!) { createRoom(input: $input) { id name } }`,
-      variables: { input: { name: roomName } }
+      variables: { input: { name: roomName, groupId } }
     }
   });
   expect(resp.ok()).toBeTruthy();

--- a/frontend/e2e/space-navigation-race.test.ts
+++ b/frontend/e2e/space-navigation-race.test.ts
@@ -20,6 +20,20 @@ async function createSpaceViaAPI(page: Page, name: string): Promise<TestSpace> {
  * Creates a room in a space via GraphQL API and joins it.
  */
 async function createRoomViaAPI(page: Page, _spaceId: string, name: string): Promise<string> {
+  const groupResponse = await page.request.post('/api/graphql', {
+    headers: {
+      'Content-Type': 'application/json',
+      'X-REQUEST-TYPE': 'GraphQL'
+    },
+    data: { query: `query { server { roomGroups { id } } }` }
+  });
+  expect(groupResponse.ok()).toBeTruthy();
+  const groupData = await groupResponse.json();
+  const groupId = groupData.data?.server?.roomGroups?.[0]?.id;
+  if (!groupId) {
+    throw new Error(`No room group available for e2e room creation: ${JSON.stringify(groupData)}`);
+  }
+
   // Create the room
   const createResponse = await page.request.post('/api/graphql', {
     headers: {
@@ -34,7 +48,7 @@ async function createRoomViaAPI(page: Page, _spaceId: string, name: string): Pro
 					}
 				}
 			`,
-      variables: { input: { name } }
+      variables: { input: { name, groupId } }
     }
   });
 

--- a/frontend/e2e/space-roles.test.ts
+++ b/frontend/e2e/space-roles.test.ts
@@ -97,6 +97,7 @@ async function createRoomViaAPI(
     maybeName ??
     (spaceIdOrName && spaceIdOrName !== 'server' ? spaceIdOrName : undefined) ??
     `testroom${Date.now()}`;
+  const groupId = await getDefaultRoomGroupId(page);
   const response = await page.request.post('/api/graphql', {
     headers: {
       'Content-Type': 'application/json',
@@ -108,13 +109,30 @@ async function createRoomViaAPI(
 					createRoom(input: $input) { id name }
 				}
 			`,
-      variables: { input: { name: roomName } }
+      variables: { input: { name: roomName, groupId } }
     }
   });
   expect(response.ok()).toBeTruthy();
   const data = await response.json();
   expect(data.data?.createRoom).toBeTruthy();
   return data.data.createRoom.id;
+}
+
+async function getDefaultRoomGroupId(page: Page): Promise<string> {
+  const response = await page.request.post('/api/graphql', {
+    headers: {
+      'Content-Type': 'application/json',
+      'X-REQUEST-TYPE': 'GraphQL'
+    },
+    data: { query: `query { server { roomGroups { id } } }` }
+  });
+  expect(response.ok()).toBeTruthy();
+  const data = await response.json();
+  const groupId = data.data?.server?.roomGroups?.[0]?.id;
+  if (!groupId) {
+    throw new Error(`No room group available for e2e room creation: ${JSON.stringify(data)}`);
+  }
+  return groupId;
 }
 
 /**
@@ -864,6 +882,7 @@ test.describe('Space Permission Enforcement', () => {
       // Create admin user and space
       await createAndLoginTestUser(page);
       const space = await createSpaceViaAPI(page);
+      const groupId = await getDefaultRoomGroupId(page);
 
       // Create a room (admin has room.create by default)
       const roomResponse = await page.request.post('/api/graphql', {
@@ -878,7 +897,7 @@ test.describe('Space Permission Enforcement', () => {
 						}
 					`,
           variables: {
-            input: { name: `testroom${Date.now()}` }
+            input: { name: `testroom${Date.now()}`, groupId }
           }
         }
       });
@@ -921,6 +940,7 @@ test.describe('Space Permission Enforcement', () => {
       // Create admin user and space
       await createAndLoginTestUser(page);
       const space = await createSpaceViaAPI(page);
+      const groupId = await getDefaultRoomGroupId(page);
 
       // Create a room (admin has room.create by default)
       const roomResponse = await page.request.post('/api/graphql', {
@@ -935,7 +955,7 @@ test.describe('Space Permission Enforcement', () => {
 						}
 					`,
           variables: {
-            input: { name: `testroom${Date.now()}` }
+            input: { name: `testroom${Date.now()}`, groupId }
           }
         }
       });
@@ -981,6 +1001,7 @@ test.describe('Space Permission Enforcement', () => {
       // Admin creates space and room
       await createAndLoginTestUser(page);
       const space = await createSpaceViaAPI(page);
+      const groupId = await getDefaultRoomGroupId(page);
 
       const roomResponse = await page.request.post('/api/graphql', {
         headers: {
@@ -994,7 +1015,7 @@ test.describe('Space Permission Enforcement', () => {
 						}
 					`,
           variables: {
-            input: { name: `testroom${Date.now()}` }
+            input: { name: `testroom${Date.now()}`, groupId }
           }
         }
       });

--- a/frontend/src/lib/CreateRoom.svelte
+++ b/frontend/src/lib/CreateRoom.svelte
@@ -7,7 +7,7 @@
     groupId,
     onroomcreated
   }: {
-    /** When provided, the new room is placed into this set. */
+    /** The room group the new channel room is placed into. */
     groupId?: string;
     onroomcreated?: (roomId: string) => void;
   } = $props();
@@ -37,6 +37,12 @@
     submitError = '';
 
     try {
+      const targetGroupId = groupId;
+      if (!targetGroupId) {
+        submitError = 'Choose a room group before creating a room.';
+        return;
+      }
+
       const result = await connection()
         .client.mutation(
           graphql(`
@@ -52,7 +58,7 @@
             input: {
               name: values.name.trim(),
               description: values.description.trim() || undefined,
-              groupId: groupId ?? undefined
+              groupId: targetGroupId
             }
           }
         )

--- a/frontend/src/lib/gql/graphql.ts
+++ b/frontend/src/lib/gql/graphql.ts
@@ -91,12 +91,12 @@ export type AdminQueries = {
   eventLogEntry?: Maybe<EventLogEntry>;
   /**
    * Resolve the explicit grants and denials configured for a role on a
-   * specific set. Returns empty arrays if neither side has any keys.
+   * specific room group. Returns empty arrays if neither side has any keys.
    */
   groupRolePermissions: RoomGroupRolePermissions;
   /**
    * Resolve the explicit grants and denials configured for a user on a
-   * specific set (user-level overrides at set scope).
+   * specific room group (user-level overrides at room-group scope).
    */
   groupUserPermissions: RoomGroupUserPermissions;
   /** Inspect runtime state and rough memory estimates for event-sourced projections. */
@@ -397,7 +397,7 @@ export type CreateRoleInput = {
 export type CreateRoomGroupInput = {
   /** Optional operator-facing description. */
   description?: InputMaybe<Scalars['String']['input']>;
-  /** Display name for the new set (e.g., 'Engineering', 'Public'). */
+  /** Display name for the new room group (e.g., 'Engineering', 'Public'). */
   name: Scalars['String']['input'];
 };
 
@@ -406,11 +406,11 @@ export type CreateRoomInput = {
   /** Optional description of the room's purpose. */
   description?: InputMaybe<Scalars['String']['input']>;
   /**
-   * Optional room-set ID to place the new room in. Required once the
-   * room-sets feature is fully wired (see ADR-031); during the transition
-   * it may be omitted, in which case the room is created without a set.
+   * Room group ID to place the new channel room in. Channel room creation
+   * requires an explicit group; DM rooms are created through the DM APIs and
+   * do not use this input.
    */
-  groupId?: InputMaybe<Scalars['ID']['input']>;
+  groupId: Scalars['ID']['input'];
   /** The name of the new room. */
   name: Scalars['String']['input'];
 };
@@ -479,9 +479,9 @@ export type DeleteRoleInput = {
   name: Scalars['String']['input'];
 };
 
-/** Input for deleting a room group. Fails if the set still contains any rooms. */
+/** Input for deleting a room group. Fails if the room group still contains any rooms. */
 export type DeleteRoomGroupInput = {
-  /** The set's ID. */
+  /** The room group's ID. */
   id: Scalars['ID']['input'];
 };
 
@@ -692,7 +692,7 @@ export type GrantUserPermissionInput = {
  * (by name) or a user (by ID).
  */
 export type GroupPermissionInput = {
-  /** The set to scope the grant to. */
+  /** The room group to scope the grant to. */
   groupId: Scalars['ID']['input'];
   /** Permission identifier (e.g., 'message.post'). */
   permission: Scalars['String']['input'];
@@ -950,11 +950,11 @@ export type MessageRetractedEvent = {
 };
 
 /**
- * Input for moving a room into a different set. Requires room.manage in
- * both the source and target set (ADR-031).
+ * Input for moving a room into a different room group. Requires room.manage in
+ * both the source and target room group (ADR-031).
  */
 export type MoveRoomToSetInput = {
-  /** The destination set. */
+  /** The destination room group. */
   groupId: Scalars['ID']['input'];
   /** The room to move. */
   roomId: Scalars['ID']['input'];
@@ -1063,8 +1063,8 @@ export type Mutation = {
    */
   deleteRole: Scalars['Boolean']['output'];
   /**
-   * Delete a room group. Rejected if the set still contains rooms — operators
-   * must move all rooms out first. Requires `role.manage`.
+   * Delete a room group. Rejected if the room group still contains rooms —
+   * operators must move all rooms out first. Requires `role.manage`.
    */
   deleteRoomGroup: Scalars['Boolean']['output'];
   /** Delete the server banner. Requires server.manage permission. */
@@ -1158,9 +1158,9 @@ export type Mutation = {
    */
   markThreadAsRead: MarkThreadAsReadResult;
   /**
-   * Move a room into a different set. The caller must have `room.manage`
-   * in both the source set and the target set (ADR-031). Permission overrides
-   * on the room itself are preserved.
+   * Move a room into a different room group. The caller must have
+   * `room.manage` in both the source room group and the target room group
+   * (ADR-031). Permission overrides on the room itself are preserved.
    */
   moveRoomToSet: Room;
   /** Post a message to a room. Automatically marks the room as read since the user is viewing it. */
@@ -1181,7 +1181,7 @@ export type Mutation = {
   reorderRoles: Array<Role>;
   /**
    * Reorder all room groups. The provided ID list must contain every existing
-   * set exactly once. Requires `role.manage`.
+   * room group exactly once. Requires `role.manage`.
    */
   reorderRoomGroups: Array<RoomGroup>;
   /**
@@ -2041,8 +2041,9 @@ export type Query = {
    * rolePermissions.
    *
    * Pass `roomId` for per-room override editing (inherits from the room's
-   * set), `groupId` for set-scope editing (no inheritance — sets are
-   * top-level for channel-room permissions). Pass neither for server scope.
+   * room group), `groupId` for room-group-scope editing (no inheritance —
+   * room groups are top-level for channel-room permissions). Pass neither
+   * for server scope.
    * Passing both is rejected.
    */
   tierRoles?: Maybe<TierRoles>;
@@ -2188,10 +2189,10 @@ export type ReorderRolesInput = {
 
 /**
  * Input for reordering all room groups. The order must include every existing
- * set ID exactly once; partial or unknown lists are rejected.
+ * room group ID exactly once; partial or unknown lists are rejected.
  */
 export type ReorderRoomGroupsInput = {
-  /** Set IDs in the desired display order, first to last. */
+  /** Room group IDs in the desired display order, first to last. */
   orderedIds: Array<Scalars['ID']['input']>;
 };
 
@@ -2365,23 +2366,25 @@ export type Room = {
   /** Fetch a single event in this room by event ID. Returns null if not found. */
   event?: Maybe<Event>;
   /**
-   * Fetch historical events for this room (default limit: 50). Use the
-   * opaque `before` cursor for backward pagination and `after` for forward
-   * pagination — pass the `startCursor` / `endCursor` from a previous
-   * `RoomEventsConnection` response. Cursors are opaque strings; clients
-   * must not attempt to parse them.
+   * Fetch historical events for this room (default limit: 50, max: 500;
+   * larger values are silently clamped). Use the opaque `before` cursor
+   * for backward pagination and `after` for forward pagination — pass the
+   * `startCursor` / `endCursor` from a previous `RoomEventsConnection`
+   * response. Cursors are opaque strings; clients must not attempt to
+   * parse them.
    */
   events: RoomEventsConnection;
   /**
-   * Fetch events in this room centered around a specific event.
+   * Fetch events in this room centered around a specific event (default
+   * limit: 50, max: 500; larger values are silently clamped).
    * Returns a window of events with the target event roughly in the middle.
    * Used for "jump to message" when clicking reply links to messages not in the loaded range.
    */
   eventsAround: RoomEventsAroundResult;
   /**
    * Channel rooms belong to exactly one RoomGroup; this field identifies which
-   * one. Empty string for DM rooms — those don't participate in the set
-   * layout (see ADR-031).
+   * one. DM rooms return an empty string sentinel because they do not
+   * participate in room-group layout or ACLs (see ADR-031).
    */
   groupId: Scalars['ID']['output'];
   /**
@@ -2539,42 +2542,43 @@ export type RoomGroup = {
   __typename?: 'RoomGroup';
   /** Operator-facing description; may be empty. */
   description: Scalars['String']['output'];
-  /** Unique ID for this set. */
+  /** Unique ID for this room group. */
   id: Scalars['ID']['output'];
-  /** Display name for this set (e.g., 'General', 'Projects'). */
+  /** Display name for this room group (e.g., 'General', 'Projects'). */
   name: Scalars['String']['output'];
-  /** Ordered list of rooms in this set. */
+  /** Ordered list of channel rooms in this room group. */
   rooms: Array<Room>;
 };
 
 /**
- * Per-set role permission inspector. Returns the explicit grants and denials
- * configured on a set for a given role (no inheritance — to see the effective
- * permissions resolve per-room or per-user via the resolver instead).
+ * Per-room-group role permission inspector. Returns the explicit grants and
+ * denials configured on a room group for a given role (no inheritance — to
+ * see the effective permissions resolve per-room or per-user via the resolver
+ * instead).
  */
 export type RoomGroupRolePermissions = {
   __typename?: 'RoomGroupRolePermissions';
-  /** The set these permissions belong to. */
+  /** The room group these permissions belong to. */
   groupId: Scalars['ID']['output'];
-  /** Permissions explicitly denied to this role on this set. */
+  /** Permissions explicitly denied to this role on this room group. */
   permissionDenials: Array<Scalars['String']['output']>;
-  /** Permissions explicitly granted to this role on this set. */
+  /** Permissions explicitly granted to this role on this room group. */
   permissions: Array<Scalars['String']['output']>;
   /** The role these permissions apply to. */
   roleName: Scalars['String']['output'];
 };
 
 /**
- * Per-set user permission inspector. Mirrors RoomGroupRolePermissions for
- * direct user-level grants/denials.
+ * Per-room-group user permission inspector. Mirrors RoomGroupRolePermissions
+ * for direct user-level grants/denials.
  */
 export type RoomGroupUserPermissions = {
   __typename?: 'RoomGroupUserPermissions';
-  /** The set these permissions belong to. */
+  /** The room group these permissions belong to. */
   groupId: Scalars['ID']['output'];
-  /** Permissions explicitly denied to this user on this set. */
+  /** Permissions explicitly denied to this user on this room group. */
   permissionDenials: Array<Scalars['String']['output']>;
-  /** Permissions explicitly granted to this user on this set. */
+  /** Permissions explicitly granted to this user on this room group. */
   permissions: Array<Scalars['String']['output']>;
   /** The user these permissions apply to. */
   userId: Scalars['ID']['output'];
@@ -2586,7 +2590,7 @@ export type RoomGroupUserPermissions = {
  */
 export type RoomGroupsUpdatedEvent = {
   __typename?: 'RoomGroupsUpdatedEvent';
-  /** Always true. Vestigial — clients only need the event arrival to trigger a refetch of the sets. */
+  /** Always true. Vestigial — clients only need the event arrival to trigger a refetch of room groups. */
   changed: Scalars['Boolean']['output'];
 };
 
@@ -3219,7 +3223,7 @@ export type UpdateRoleInput = {
 export type UpdateRoomGroupInput = {
   /** Optional description. */
   description?: InputMaybe<Scalars['String']['input']>;
-  /** The set's ID. */
+  /** The room group's ID. */
   id: Scalars['ID']['input'];
   /** Display name. */
   name: Scalars['String']['input'];


### PR DESCRIPTION
Part of #24.
Fixes #744.

## Changes

- Makes `CreateRoomInput.groupId` required in GraphQL so channel room creation always targets an explicit room group.
- Keeps `Room.groupId` non-null and documents the DM empty-string sentinel.
- Replaces stale public “set” / “room-set” wording with “room group” across schema descriptions, generated docs, FDR-019, ADR-031, and the architecture inventory.
- Adds a GraphQL integration test that omitted `groupId` is rejected, and keeps the create-room UI from submitting without group context.

## Verification

- `mise codegen-cli`
- `mise codegen-frontend`
- `npx @sveltejs/mcp svelte-autofixer ./frontend/src/lib/CreateRoom.svelte --svelte-version 5`
- `mise x -- go test -tags test_endpoints ./internal/graph -run 'TestCreateRoom_Authorization'`
- `mise x -- go test -tags test_endpoints ./internal/http_server -run 'TestGraphQL_CreateRoom_RequiresGroupID|TestGraphQL_Variables' -count=1`
- `mise test-cli`
- `mise lint-frontend`
- `mise test-frontend`
- `mise x -- pnpm exec playwright test e2e/auto-scroll.test.ts e2e/composer.test.ts e2e/jump-to-message.test.ts`
- `mise x -- pnpm exec playwright test e2e/room-layout.test.ts e2e/room-permissions.test.ts e2e/space-navigation-race.test.ts e2e/space-roles.test.ts` (first run exposed one missing local `groupId`; fixed, then `e2e/space-roles.test.ts` passed)
