### PR TITLE
refactor(graphql): require auth for user lookups

### DIFF
--- a/cli/internal/graph/query.graphqls
+++ b/cli/internal/graph/query.graphqls
@@ -5,10 +5,10 @@ type Query {
   "Get a specific room by ID."
   room(roomId: ID!): Room
 
-  "Get a specific user by ID."
+  "Get a specific user by ID. Requires authentication."
   user(userId: ID!): User
 
-  "Get a specific user by login. Returns null if not found."
+  "Get a specific user by login. Requires authentication. Returns null if not found."
   userByLogin(login: String!): User
 
   """

--- a/cli/internal/graph/query.resolvers.go
+++ b/cli/internal/graph/query.resolvers.go
@@ -39,19 +39,23 @@ func (r *queryResolver) Room(ctx context.Context, roomID string) (*corev1.Room, 
 }
 
 // User is the resolver for the user field.
-// Note: User profiles are intentionally public within the server.
-// This is required for displaying message authors, member lists, etc.
-// Authentication is not required as user data is non-sensitive.
+// User profiles are visible to authenticated server users.
 func (r *queryResolver) User(ctx context.Context, userID string) (*corev1.User, error) {
-	// No authorization - public user profiles
+	if _, err := requireAuth(ctx); err != nil {
+		return nil, err
+	}
+
 	return r.core.GetUser(ctx, userID)
 }
 
 // UserByLogin is the resolver for the userByLogin field.
 // Returns the user with the given login name, or null if not found.
-// Note: User profiles are intentionally public within the server.
+// User profiles are visible to authenticated server users.
 func (r *queryResolver) UserByLogin(ctx context.Context, login string) (*corev1.User, error) {
-	// No authorization - public user profiles
+	if _, err := requireAuth(ctx); err != nil {
+		return nil, err
+	}
+
 	user, err := r.core.GetUserByLogin(ctx, login)
 	if err != nil {
 		// Return nil instead of error for "not found" cases

--- a/cli/internal/graph/query_test.go
+++ b/cli/internal/graph/query_test.go
@@ -129,7 +129,7 @@ func TestQueryResolver_User(t *testing.T) {
 	env := setupTestResolver(t)
 
 	t.Run("get existing user", func(t *testing.T) {
-		user, err := env.resolver.Query().User(env.ctx, env.testUser.Id)
+		user, err := env.resolver.Query().User(env.authContext(), env.testUser.Id)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -144,9 +144,61 @@ func TestQueryResolver_User(t *testing.T) {
 	})
 
 	t.Run("get non-existent user", func(t *testing.T) {
-		user, err := env.resolver.Query().User(env.ctx, "nonexistent")
+		user, err := env.resolver.Query().User(env.authContext(), "nonexistent")
 		if err == nil {
 			t.Fatal("Expected error for non-existent user")
+		}
+
+		if user != nil {
+			t.Errorf("Expected nil user, got %+v", user)
+		}
+	})
+
+	t.Run("requires authentication", func(t *testing.T) {
+		user, err := env.resolver.Query().User(env.unauthContext(), env.testUser.Id)
+		if !errors.Is(err, ErrNotAuthenticated) {
+			t.Errorf("Expected ErrNotAuthenticated, got %v", err)
+		}
+
+		if user != nil {
+			t.Errorf("Expected nil user, got %+v", user)
+		}
+	})
+}
+
+func TestQueryResolver_UserByLogin(t *testing.T) {
+	env := setupTestResolver(t)
+
+	t.Run("get existing user", func(t *testing.T) {
+		user, err := env.resolver.Query().UserByLogin(env.authContext(), env.testUser.Login)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if user == nil {
+			t.Fatal("Expected user, got nil")
+		}
+
+		if user.Id != env.testUser.Id {
+			t.Errorf("Expected user ID %s, got %s", env.testUser.Id, user.Id)
+		}
+	})
+
+	t.Run("get non-existent user returns nil", func(t *testing.T) {
+		user, err := env.resolver.Query().UserByLogin(env.authContext(), "nonexistent")
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if user != nil {
+			t.Errorf("Expected nil user, got %+v", user)
+		}
+	})
+
+	t.Run("requires authentication", func(t *testing.T) {
+		user, err := env.resolver.Query().UserByLogin(env.unauthContext(), env.testUser.Login)
+		if !errors.Is(err, ErrNotAuthenticated) {
+			t.Errorf("Expected ErrNotAuthenticated, got %v", err)
 		}
 
 		if user != nil {

--- a/cli/internal/graph/subscription.graphqls
+++ b/cli/internal/graph/subscription.graphqls
@@ -14,7 +14,8 @@ type Subscription {
     notifications, thread-follow sync, server membership, room layout
     changes, session termination) — scoped per event type:
     - Config events: delivered to all authenticated users.
-    - User profile updates: broadcast (profiles are public).
+    - User profile updates: broadcast to authenticated users (profiles are
+      public within the server).
     - Private user events (notification sync, preferences, session
       termination, server membership changes): delivered only to the target
       user. Powers cross-tab/cross-device sync.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -100,8 +100,8 @@ Note: there is no top-level `me` query — viewer-scoped state hangs off the `vi
 
 | Query                              | Description                                                                            |
 | ---------------------------------- | -------------------------------------------------------------------------------------- |
-| `user(userId)`                     | Get a user by ID.                                                                      |
-| `userByLogin(login)`               | Get a user by login (returns null if not found).                                       |
+| `user(userId)`                     | Authenticated lookup of a user by ID.                                                  |
+| `userByLogin(login)`               | Authenticated lookup of a user by login (returns null if not found).                   |
 | `users(search, limit, offset)`     | Paginated user directory (server admin only).                                          |
 | `userPermissionMatrix(userId)`     | Effective allow/deny matrix for a user (admin surface; `role.manage` + outrank gate).  |
 | `permissionExplanation(userId, …)` | Per-permission resolver explainer (self-inspection or admin).                          |

--- a/docs/fdr/FDR-025-user-search-and-member-directory.md
+++ b/docs/fdr/FDR-025-user-search-and-member-directory.md
@@ -1,7 +1,7 @@
 # FDR-025: User Search & Member Directory
 
 **Status:** Active
-**Last reviewed:** 2026-05-19
+**Last reviewed:** 2026-06-06
 
 ## Overview
 
@@ -14,6 +14,7 @@ Any authenticated user can browse the server's member directory — a paginated 
 - Pagination is offset-based: caller specifies `offset` and `limit`; the response also includes `totalCount` so the caller can compute whether there are more pages.
 - Default page size is 20; the maximum is 100. Requests larger than 100 are silently clamped down.
 - Results are sorted by `createdAt` ascending (oldest member first). Users created before the timestamp field existed sort to the end, alphabetically by login.
+- Direct lookups by user ID or login return the same public profile information as the directory and require authentication.
 
 ## Design Decisions
 
@@ -41,9 +42,9 @@ Any authenticated user can browse the server's member directory — a paginated 
 **Why:** "Oldest first" is a stable order that matches the admin mental model ("show me long-term members first; new signups at the end"). The alphabetical fallback for null timestamps keeps the order deterministic for legacy users without inventing a fake timestamp.
 **Tradeoff:** Sorting by recency (newest first) is occasionally what an admin wants when investigating a signup wave. Not exposed today; could be added as a sort parameter if needed.
 
-### 5. All authenticated users can browse the directory
+### 5. All authenticated users can browse member profiles
 
-**Decision:** No special permission required; any authenticated user can list members.
+**Decision:** No special permission required; any authenticated user can list members or look up a member by ID/login.
 **Why:** Chatto's privacy model treats user identity (login, display name, avatar) as public to other members. Hiding members from members would be incongruent — they'd see each other in messages anyway. Operators who want a fully private member list would need a different feature.
 **Tradeoff:** Bot accounts or system users (if introduced) would surface in normal listings. Not a current concern.
 

--- a/frontend/src/lib/gql/graphql.ts
+++ b/frontend/src/lib/gql/graphql.ts
@@ -2046,9 +2046,9 @@ export type Query = {
    * Passing both is rejected.
    */
   tierRoles?: Maybe<TierRoles>;
-  /** Get a specific user by ID. */
+  /** Get a specific user by ID. Requires authentication. */
   user?: Maybe<User>;
-  /** Get a specific user by login. Returns null if not found. */
+  /** Get a specific user by login. Requires authentication. Returns null if not found. */
   userByLogin?: Maybe<User>;
   /**
    * Permission matrix for a specific user. Authorization: viewer must
@@ -2365,15 +2365,17 @@ export type Room = {
   /** Fetch a single event in this room by event ID. Returns null if not found. */
   event?: Maybe<Event>;
   /**
-   * Fetch historical events for this room (default limit: 50). Use the
-   * opaque `before` cursor for backward pagination and `after` for forward
-   * pagination — pass the `startCursor` / `endCursor` from a previous
-   * `RoomEventsConnection` response. Cursors are opaque strings; clients
-   * must not attempt to parse them.
+   * Fetch historical events for this room (default limit: 50, max: 500;
+   * larger values are silently clamped). Use the opaque `before` cursor
+   * for backward pagination and `after` for forward pagination — pass the
+   * `startCursor` / `endCursor` from a previous `RoomEventsConnection`
+   * response. Cursors are opaque strings; clients must not attempt to
+   * parse them.
    */
   events: RoomEventsConnection;
   /**
-   * Fetch events in this room centered around a specific event.
+   * Fetch events in this room centered around a specific event (default
+   * limit: 50, max: 500; larger values are silently clamped).
    * Returns a window of events with the target event roughly in the middle.
    * Used for "jump to message" when clicking reply links to messages not in the loaded range.
    */
@@ -3031,7 +3033,8 @@ export type Subscription = {
    *   notifications, thread-follow sync, server membership, room layout
    *   changes, session termination) — scoped per event type:
    *   - Config events: delivered to all authenticated users.
-   *   - User profile updates: broadcast (profiles are public).
+   *   - User profile updates: broadcast to authenticated users (profiles are
+   *     public within the server).
    *   - Private user events (notification sync, preferences, session
    *     termination, server membership changes): delivered only to the target
    *     user. Powers cross-tab/cross-device sync.


### PR DESCRIPTION
Part of #24.
Fixes #745.

## Changes

- Require authentication for `Query.user` and `Query.userByLogin`.
- Add resolver coverage for unauthenticated direct user lookups and `userByLogin` not-found behavior.
- Update schema descriptions, generated frontend GraphQL docs, architecture docs, and FDR-025 to describe member profile visibility as authenticated-only.

## Verification

- `mise codegen-cli`
- `mise codegen-frontend`
- `mise x -- go test -tags test_endpoints ./internal/graph -run 'TestQueryResolver_User|TestQueryResolver_UserByLogin'`
- `mise test-cli`
- `mise test-frontend`
- `mise lint-frontend`
