### PR TITLE
fix(graphql): widen event log total count

### DIFF
--- a/cli/internal/graph/admin.graphqls
+++ b/cli/internal/graph/admin.graphqls
@@ -216,8 +216,8 @@ type EventLogConnection {
   hasOlder: Boolean!
   "Pass as the next call's `before` to fetch the next (older) page. Null when there are no older entries."
   endCursor: String
-  "Total messages currently in EVT — an operational metric, not bounded by `limit`."
-  totalCount: Int!
+  "Total messages currently in EVT, serialized as Int64 so large event logs do not overflow GraphQL Int."
+  totalCount: Int64! @goField(type: "int64")
 }
 
 extend type AdminQueries {

--- a/cli/internal/graph/admin.resolvers.go
+++ b/cli/internal/graph/admin.resolvers.go
@@ -186,6 +186,10 @@ func (r *adminQueriesResolver) EventLog(ctx context.Context, obj *model.AdminQue
 	if err != nil {
 		return nil, fmt.Errorf("stream info: %w", err)
 	}
+	totalCount, err := eventLogTotalCount(info.State.Msgs)
+	if err != nil {
+		return nil, err
+	}
 
 	pageSize := defaultEventLogPageSize
 	if limit != nil {
@@ -210,7 +214,7 @@ func (r *adminQueriesResolver) EventLog(ctx context.Context, obj *model.AdminQue
 				Entries:    []*model.EventLogEntry{},
 				HasOlder:   false,
 				EndCursor:  nil,
-				TotalCount: int32(info.State.Msgs),
+				TotalCount: totalCount,
 			}, nil
 		}
 		startSeq = parsed - 1
@@ -223,7 +227,7 @@ func (r *adminQueriesResolver) EventLog(ctx context.Context, obj *model.AdminQue
 
 	conn := &model.EventLogConnection{
 		Entries:    entries,
-		TotalCount: int32(info.State.Msgs),
+		TotalCount: totalCount,
 	}
 	if len(entries) > 0 {
 		oldestSeq := entries[len(entries)-1].Sequence

--- a/cli/internal/graph/admin_event_log.go
+++ b/cli/internal/graph/admin_event_log.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -24,6 +25,13 @@ const (
 	defaultEventLogPageSize = 50
 	maxEventLogPageSize     = 200
 )
+
+func eventLogTotalCount(messages uint64) (int64, error) {
+	if messages > uint64(math.MaxInt64) {
+		return 0, fmt.Errorf("event log total count %d exceeds Int64 range", messages)
+	}
+	return int64(messages), nil
+}
 
 // fetchEventLogPage walks EVT backwards from startSeq (inclusive)
 // and returns up to `limit` entries newest-first. Stops early at the

--- a/cli/internal/graph/admin_event_log_test.go
+++ b/cli/internal/graph/admin_event_log_test.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"errors"
+	"math"
 	"strconv"
 	"testing"
 
@@ -126,6 +127,15 @@ func TestEventLog_AuthorizationDenied(t *testing.T) {
 
 	_, err = adminQ.EventLogEntry(ctx, nil, "1")
 	require.True(t, errors.Is(err, core.ErrPermissionDenied), "EventLogEntry should deny non-auditor, got: %v", err)
+}
+
+func TestEventLogTotalCountUsesWideInteger(t *testing.T) {
+	count, err := eventLogTotalCount(uint64(math.MaxInt32) + 1)
+	require.NoError(t, err)
+	require.Equal(t, int64(math.MaxInt32)+1, count)
+
+	_, err = eventLogTotalCount(uint64(math.MaxInt64) + 1)
+	require.Error(t, err)
 }
 
 func TestStreamMsgToEventLogEntryParsesAuthAggregate(t *testing.T) {

--- a/cli/internal/graph/generated.go
+++ b/cli/internal/graph/generated.go
@@ -10520,15 +10520,15 @@ func (ec *executionContext) _EventLogConnection_totalCount(ctx context.Context, 
 			return obj.TotalCount, nil
 		},
 		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v int32) graphql.Marshaler {
-			return ec.marshalNInt2int32(ctx, selections, v)
+		func(ctx context.Context, selections ast.SelectionSet, v int64) graphql.Marshaler {
+			return ec.marshalNInt642int64(ctx, selections, v)
 		},
 		true,
 		true,
 	)
 }
 func (ec *executionContext) fieldContext_EventLogConnection_totalCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("EventLogConnection", field, false, false, errors.New("field of type Int does not have child fields"))
+	return graphql.NewScalarFieldContext("EventLogConnection", field, false, false, errors.New("field of type Int64 does not have child fields"))
 }
 
 func (ec *executionContext) _EventLogEntry_sequence(ctx context.Context, field graphql.CollectedField, obj *model.EventLogEntry) (ret graphql.Marshaler) {

--- a/cli/internal/graph/model/models_gen.go
+++ b/cli/internal/graph/model/models_gen.go
@@ -327,8 +327,8 @@ type EventLogConnection struct {
 	HasOlder bool `json:"hasOlder"`
 	// Pass as the next call's `before` to fetch the next (older) page. Null when there are no older entries.
 	EndCursor *string `json:"endCursor,omitempty"`
-	// Total messages currently in EVT — an operational metric, not bounded by `limit`.
-	TotalCount int32 `json:"totalCount"`
+	// Total messages currently in EVT, serialized as Int64 so large event logs do not overflow GraphQL Int.
+	TotalCount int64 `json:"totalCount"`
 }
 
 // One entry in the event-sourcing log (EVT). Each entry corresponds to one durable domain event under ADR-033.

--- a/docs/fdr/FDR-021-admin-dashboard.md
+++ b/docs/fdr/FDR-021-admin-dashboard.md
@@ -1,7 +1,7 @@
 # FDR-021: Admin Dashboard & System Monitoring
 
 **Status:** Active
-**Last reviewed:** 2026-06-05
+**Last reviewed:** 2026-06-06
 
 ## Overview
 
@@ -13,6 +13,7 @@ The admin section gives owners and admins visibility into the server's operation
 - **Users page** — paginated list of all server members with login, email, roles, verification status. Admins can edit profiles, assign roles, suspend, or delete users (subject to outranking the target — see FDR-001).
 - **System Info page** — shows NATS connection status (server ID, version, round-trip latency), JetStream account limits and current usage, stream/consumer health, projection health (lag, entry counts, and rough memory estimates), and `ServerStats` (user count, channel room count, DM room count).
 - **Audit log page** — chronological list of significant admin actions (user deletions, role changes, server config edits, etc.) for forensic review.
+- The audit/event-log GraphQL connection returns `totalCount` as `Int64` because it reflects retained stream message counts, which can exceed GraphQL's 32-bit `Int` range on long-running servers.
 
 ## Design Decisions
 

--- a/frontend/src/lib/gql/graphql.ts
+++ b/frontend/src/lib/gql/graphql.ts
@@ -555,8 +555,8 @@ export type EventLogConnection = {
   entries: Array<EventLogEntry>;
   /** True if older entries exist beyond this page. */
   hasOlder: Scalars['Boolean']['output'];
-  /** Total messages currently in EVT — an operational metric, not bounded by `limit`. */
-  totalCount: Scalars['Int']['output'];
+  /** Total messages currently in EVT, serialized as Int64 so large event logs do not overflow GraphQL Int. */
+  totalCount: Scalars['Int64']['output'];
 };
 
 /** One entry in the event-sourcing log (EVT). Each entry corresponds to one durable domain event under ADR-033. */
@@ -2365,15 +2365,17 @@ export type Room = {
   /** Fetch a single event in this room by event ID. Returns null if not found. */
   event?: Maybe<Event>;
   /**
-   * Fetch historical events for this room (default limit: 50). Use the
-   * opaque `before` cursor for backward pagination and `after` for forward
-   * pagination — pass the `startCursor` / `endCursor` from a previous
-   * `RoomEventsConnection` response. Cursors are opaque strings; clients
-   * must not attempt to parse them.
+   * Fetch historical events for this room (default limit: 50, max: 500;
+   * larger values are silently clamped). Use the opaque `before` cursor
+   * for backward pagination and `after` for forward pagination — pass the
+   * `startCursor` / `endCursor` from a previous `RoomEventsConnection`
+   * response. Cursors are opaque strings; clients must not attempt to
+   * parse them.
    */
   events: RoomEventsConnection;
   /**
-   * Fetch events in this room centered around a specific event.
+   * Fetch events in this room centered around a specific event (default
+   * limit: 50, max: 500; larger values are silently clamped).
    * Returns a window of events with the target event roughly in the middle.
    * Used for "jump to message" when clicking reply links to messages not in the loaded range.
    */
@@ -4595,7 +4597,7 @@ export type AdminEventLogQueryVariables = Exact<{
 }>;
 
 
-export type AdminEventLogQuery = { __typename?: 'Query', admin?: { __typename?: 'AdminQueries', eventLog: { __typename?: 'EventLogConnection', hasOlder: boolean, endCursor?: string | null, totalCount: number, entries: Array<{ __typename?: 'EventLogEntry', sequence: string, subject: string, aggregateType: string, aggregateId: string, eventType: string, eventId: string, actorId: string, createdAt: any }> } } | null };
+export type AdminEventLogQuery = { __typename?: 'Query', admin?: { __typename?: 'AdminQueries', eventLog: { __typename?: 'EventLogConnection', hasOlder: boolean, endCursor?: string | null, totalCount: any, entries: Array<{ __typename?: 'EventLogEntry', sequence: string, subject: string, aggregateType: string, aggregateId: string, eventType: string, eventId: string, actorId: string, createdAt: any }> } } | null };
 
 export type AdminEventLogEntryQueryVariables = Exact<{
   sequence: Scalars['String']['input'];


### PR DESCRIPTION
Part of #24.
Fixes #747.

## Changes

- Change `EventLogConnection.totalCount` from GraphQL `Int!` to `Int64!`.
- Force the generated Go model field to `int64` and convert JetStream's `uint64` message count explicitly.
- Add coverage for counts beyond GraphQL's 32-bit `Int` range and document the stable representation in FDR-021.

## Verification

- `mise codegen-cli`
- `mise codegen-frontend`
- `mise x -- go test -tags test_endpoints ./internal/graph -run 'TestEventLog|TestStreamMsgToEventLogEntry'`
- `mise test-cli`
- `mise test-frontend`
- `mise lint-frontend`
