### PR TITLE
docs(graphql): describe enum values

### DIFF
--- a/cli/internal/graph/model/models_gen.go
+++ b/cli/internal/graph/model/models_gen.go
@@ -1709,9 +1709,12 @@ func (e RoomType) MarshalJSON() ([]byte, error) {
 type UserPermissionDecision string
 
 const (
+	// The permission is explicitly granted.
 	UserPermissionDecisionAllow UserPermissionDecision = "ALLOW"
-	UserPermissionDecisionDeny  UserPermissionDecision = "DENY"
-	UserPermissionDecisionNone  UserPermissionDecision = "NONE"
+	// The permission is explicitly denied.
+	UserPermissionDecisionDeny UserPermissionDecision = "DENY"
+	// No explicit grant or denial applies at this scope.
+	UserPermissionDecisionNone UserPermissionDecision = "NONE"
 )
 
 var AllUserPermissionDecision = []UserPermissionDecision{

--- a/cli/internal/graph/user_permissions.graphqls
+++ b/cli/internal/graph/user_permissions.graphqls
@@ -71,8 +71,11 @@ type UserPermissionCell {
 Trinary decision used in the user-permission matrix.
 """
 enum UserPermissionDecision {
+  "The permission is explicitly granted."
   ALLOW
+  "The permission is explicitly denied."
   DENY
+  "No explicit grant or denial applies at this scope."
   NONE
 }
 

--- a/frontend/src/lib/gql/graphql.ts
+++ b/frontend/src/lib/gql/graphql.ts
@@ -2365,15 +2365,17 @@ export type Room = {
   /** Fetch a single event in this room by event ID. Returns null if not found. */
   event?: Maybe<Event>;
   /**
-   * Fetch historical events for this room (default limit: 50). Use the
-   * opaque `before` cursor for backward pagination and `after` for forward
-   * pagination — pass the `startCursor` / `endCursor` from a previous
-   * `RoomEventsConnection` response. Cursors are opaque strings; clients
-   * must not attempt to parse them.
+   * Fetch historical events for this room (default limit: 50, max: 500;
+   * larger values are silently clamped). Use the opaque `before` cursor
+   * for backward pagination and `after` for forward pagination — pass the
+   * `startCursor` / `endCursor` from a previous `RoomEventsConnection`
+   * response. Cursors are opaque strings; clients must not attempt to
+   * parse them.
    */
   events: RoomEventsConnection;
   /**
-   * Fetch events in this room centered around a specific event.
+   * Fetch events in this room centered around a specific event (default
+   * limit: 50, max: 500; larger values are silently clamped).
    * Returns a window of events with the target event roughly in the middle.
    * Used for "jump to message" when clicking reply links to messages not in the loaded range.
    */
@@ -3417,8 +3419,11 @@ export type UserPermissionCell = {
 
 /** Trinary decision used in the user-permission matrix. */
 export enum UserPermissionDecision {
+  /** The permission is explicitly granted. */
   Allow = 'ALLOW',
+  /** The permission is explicitly denied. */
   Deny = 'DENY',
+  /** No explicit grant or denial applies at this scope. */
   None = 'NONE'
 }
 


### PR DESCRIPTION
Part of #24.
Fixes #749.

## Changes

- Add descriptions for all `UserPermissionDecision` enum values.
- Regenerate Go and frontend GraphQL types so generated comments match the schema.
- Verified that all enum values in `cli/internal/graph/*.graphqls` now have descriptions.

## Verification

- `mise codegen-cli`
- `mise codegen-frontend`
- enum value description audit
- `mise test-cli`
- `mise test-frontend`
- `mise lint-frontend`
