### PR TITLE
fix: clean up cached asset derivatives on deletion

### DIFF
--- a/cli/internal/core/attachments.go
+++ b/cli/internal/core/attachments.go
@@ -595,12 +595,22 @@ func (c *ChattoCore) LookupAttachment(ctx context.Context, loc signedurl.Attachm
 }
 
 // DeleteAttachmentFromStorage deletes an attachment's binary and its
-// cached resizes. Requires `Storage` to be populated.
+// cached resizes. When Storage is missing for legacy imported derivatives,
+// it falls back to known backend key layouts by attachment ID.
 func (c *ChattoCore) DeleteAttachmentFromStorage(ctx context.Context, attachment *corev1.Attachment) error {
-	if attachment == nil || attachment.Storage == nil {
-		return fmt.Errorf("attachment has no storage info")
+	if attachment == nil {
+		return fmt.Errorf("attachment is nil")
 	}
 
+	deleteErr := c.deleteAttachmentBinary(ctx, attachment)
+	c.deleteCachedResizesForAttachment(ctx, attachment.Id)
+	return deleteErr
+}
+
+func (c *ChattoCore) deleteAttachmentBinary(ctx context.Context, attachment *corev1.Attachment) error {
+	if attachment.Storage == nil {
+		return c.deleteAttachmentBinaryByID(ctx, attachment.Id)
+	}
 	switch storage := attachment.Storage.Asset.(type) {
 	case *corev1.DeprecatedAsset_Nats:
 		store, err := c.GetAttachmentsStore(ctx)
@@ -622,19 +632,58 @@ func (c *ChattoCore) DeleteAttachmentFromStorage(ctx context.Context, attachment
 	default:
 		return fmt.Errorf("attachment %s has unknown storage backend", attachment.Id)
 	}
+	return nil
+}
 
-	deletedCount, cacheErr := c.DeleteCachedResizesForAttachment(ctx, attachment.Id)
+func (c *ChattoCore) deleteAttachmentBinaryByID(ctx context.Context, attachmentID string) error {
+	if attachmentID == "" {
+		return fmt.Errorf("attachment has no id")
+	}
+
+	var natsErr error
+	store, err := c.GetAttachmentsStore(ctx)
+	if err != nil {
+		natsErr = fmt.Errorf("failed to get attachments store: %w", err)
+	} else if err := store.Delete(ctx, attachmentID); err == nil {
+		c.logger.Debug("Deleted NATS attachment", "attachment_id", attachmentID, "key", attachmentID)
+		return nil
+	} else {
+		natsErr = fmt.Errorf("failed to delete attachment from NATS: %w", err)
+	}
+
+	if c.s3Client != nil {
+		var s3Err error
+		for _, s3Key := range legacyAttachmentS3KeyCandidates(attachmentID) {
+			if _, err := c.s3Client.StatObject(ctx, s3Key); err != nil {
+				s3Err = err
+				continue
+			}
+			if err := c.s3Client.DeleteObjectFromBucket(ctx, c.s3Client.Bucket(), s3Key); err != nil {
+				s3Err = err
+				continue
+			}
+			c.logger.Debug("Deleted S3 attachment", "attachment_id", attachmentID, "s3_key", s3Key)
+			return nil
+		}
+		if s3Err != nil {
+			return fmt.Errorf("failed to delete attachment %s from known backends: nats: %v; s3: %w", attachmentID, natsErr, s3Err)
+		}
+	}
+
+	return natsErr
+}
+
+func (c *ChattoCore) deleteCachedResizesForAttachment(ctx context.Context, attachmentID string) {
+	deletedCount, cacheErr := c.DeleteCachedResizesForAttachment(ctx, attachmentID)
 	if cacheErr != nil {
 		c.logger.Warn("Failed to delete cached resizes for attachment",
-			"attachment_id", attachment.Id,
+			"attachment_id", attachmentID,
 			"error", cacheErr)
 	} else if deletedCount > 0 {
 		c.logger.Debug("Deleted cached resizes for attachment",
-			"attachment_id", attachment.Id,
+			"attachment_id", attachmentID,
 			"deleted_count", deletedCount)
 	}
-
-	return nil
 }
 
 // DeleteVideoDerivativesForAttachment deletes generated thumbnail/variant
@@ -797,6 +846,12 @@ func (c *ChattoCore) probePresignedAttachmentURL(ctx context.Context, attachment
 // signed-URL signer for attachment transform URLs (after the locator).
 // Stable so existing signatures continue to verify across deployments.
 const AttachmentSignResource = "attachment"
+
+// ServerAssetSignResource is the first resource component fed to the
+// signed-URL signer for server asset transform URLs and the cache prefix for
+// transformed server assets (avatars, logos, banners, and similar public
+// server-scoped images).
+const ServerAssetSignResource = "server"
 
 // AttachmentURLTTL is how long an attachment URL stays valid after it's
 // signed. Short on purpose: the signed locator is a standalone capability
@@ -971,8 +1026,8 @@ func LocatorForVideoOriginAttachment(roomID, videoOriginID, attachmentID string)
 // Format: /assets/server/{key}/t/{params}.{signature}
 // where {params} is base64url-encoded JSON: {"w":width,"h":height,"f":"fit"}
 func (c *ChattoCore) GetTransformedServerAssetURL(key string, width, height int, fit string) string {
-	// Generate signed transform path component using "server" as the first resource ID
-	signedPath := signedurl.SignedTransformPath(c.config.Assets.SigningSecret, "server", key, width, height, fit)
+	// Generate signed transform path component using the server asset resource ID.
+	signedPath := signedurl.SignedTransformPath(c.config.Assets.SigningSecret, ServerAssetSignResource, key, width, height, fit)
 
 	// Return signed transform URL
 	return c.assetURL(fmt.Sprintf("/assets/server/%s/t/%s", key, signedPath))
@@ -1049,10 +1104,19 @@ func (c *ChattoCore) DeleteCachedResizesForAttachment(ctx context.Context, attac
 	return c.DeleteCachedResizesForKey(ctx, AttachmentSignResource, attachmentID)
 }
 
+// DeleteCachedResizesForServerAsset deletes all cached resizes for a server
+// asset such as a user avatar or server branding image.
+func (c *ChattoCore) DeleteCachedResizesForServerAsset(ctx context.Context, assetID string) (int, error) {
+	return c.DeleteCachedResizesForKey(ctx, ServerAssetSignResource, assetID)
+}
+
 // DeleteCachedResizesForKey deletes all cached resizes for a given prefix and asset key.
 // Returns the number of deleted cache entries and any error encountered.
 // Does nothing if the cache is disabled.
 func (c *ChattoCore) DeleteCachedResizesForKey(ctx context.Context, prefix, assetKey string) (int, error) {
+	if prefix == "" || assetKey == "" {
+		return 0, nil
+	}
 	if c.storage.imageCacheStore == nil {
 		return 0, nil
 	}

--- a/cli/internal/core/attachments_test.go
+++ b/cli/internal/core/attachments_test.go
@@ -975,6 +975,90 @@ func TestChattoCore_DeleteAttachment_DoesNotAffectOtherAttachmentCache(t *testin
 	}
 }
 
+func TestChattoCore_DeleteAttachment_CleansUpCacheWithoutStorageMetadata(t *testing.T) {
+	core, _ := setupTestCoreWithCache(t)
+	ctx := testContext(t)
+
+	room, err := core.CreateRoom(ctx, "test-user", KindChannel, "", "test-room", "Test room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+
+	attachment, err := core.UploadAttachment(ctx, SystemActorID, room.Id, "image.png", "image/png", bytes.NewReader(createTestPNG(100, 100)))
+	if err != nil {
+		t.Fatalf("Failed to upload attachment: %v", err)
+	}
+
+	cacheKey := ImageCacheKey(AttachmentSignResource, attachment.Id, 200, 150, "contain")
+	if err := core.StoreCachedResize(ctx, cacheKey, []byte("fake webp data")); err != nil {
+		t.Fatalf("Failed to store cached resize: %v", err)
+	}
+
+	storageLess := &corev1.Attachment{Id: attachment.Id, RoomId: room.Id}
+	if err := core.DeleteAttachmentFromStorage(ctx, storageLess); err != nil {
+		t.Fatalf("Failed to delete storage-less attachment: %v", err)
+	}
+
+	data, err := core.GetCachedResize(ctx, cacheKey)
+	if err != nil {
+		t.Fatalf("Unexpected error getting cached resize: %v", err)
+	}
+	if data != nil {
+		t.Fatal("Cache entry should be deleted for storage-less attachment")
+	}
+
+	if _, _, err := core.GetAttachment(ctx, attachment.Id); err == nil {
+		t.Fatal("Expected backing attachment binary to be deleted")
+	}
+}
+
+func TestChattoCore_DeleteMessageOwnedAssetsForUser_CleansUpDerivativeCaches(t *testing.T) {
+	core, _ := setupTestCoreWithCache(t)
+	ctx := testContext(t)
+
+	user, err := core.CreateUser(ctx, "system", "assetcleanup", "Asset Cleanup", "password123")
+	if err != nil {
+		t.Fatalf("Failed to create user: %v", err)
+	}
+	room, err := core.CreateRoom(ctx, user.Id, KindChannel, "", "test-room", "Test room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id); err != nil {
+		t.Fatalf("Failed to join room: %v", err)
+	}
+
+	original, err := core.UploadAttachment(ctx, user.Id, room.Id, "clip.mp4", "video/mp4", bytes.NewReader([]byte("fake video bytes")))
+	if err != nil {
+		t.Fatalf("Failed to upload original video: %v", err)
+	}
+	thumbnail, err := core.UploadDerivativeAttachment(ctx, original.Id, corev1.AssetDerivativeRole_ASSET_DERIVATIVE_ROLE_THUMBNAIL, room.Id, "thumb.png", "image/png", bytes.NewReader(createTestPNG(64, 64)))
+	if err != nil {
+		t.Fatalf("Failed to upload derivative thumbnail: %v", err)
+	}
+
+	thumbnailCacheKey := ImageCacheKey(AttachmentSignResource, thumbnail.Id, 128, 128, "cover")
+	if err := core.StoreCachedResize(ctx, thumbnailCacheKey, []byte("fake webp data")); err != nil {
+		t.Fatalf("Failed to store thumbnail cached resize: %v", err)
+	}
+
+	if _, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "video", []string{original.Id}, "", "", nil, false); err != nil {
+		t.Fatalf("Failed to post message: %v", err)
+	}
+
+	if deleted := core.DeleteMessageOwnedAssetsForUser(ctx, user.Id, user.Id); deleted != 2 {
+		t.Fatalf("Expected original and thumbnail assets to be deleted, got %d", deleted)
+	}
+
+	data, err := core.GetCachedResize(ctx, thumbnailCacheKey)
+	if err != nil {
+		t.Fatalf("Unexpected error getting thumbnail cached resize: %v", err)
+	}
+	if data != nil {
+		t.Fatal("Derivative thumbnail cache entry should be deleted")
+	}
+}
+
 func TestChattoCore_DeleteCachedResizesForAttachment_NoCacheEnabled(t *testing.T) {
 	// Use standard setup (no cache)
 	core, _ := setupTestCore(t)

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -568,6 +568,7 @@ func (c *ChattoCore) CleanupAsset(ctx context.Context, asset *corev1.DeprecatedA
 			c.logger.Info("Cleaned up orphaned S3 asset", "asset_id", s3Asset.Key, "s3_key", s3Key)
 		}
 	}
+	c.deleteCachedResizesForServerAsset(ctx, assetIDFromAsset(asset), "orphaned asset", "")
 }
 
 // deleteAsset deletes a server asset from its storage backend (NATS or S3).
@@ -593,6 +594,24 @@ func (c *ChattoCore) deleteAsset(ctx context.Context, asset *corev1.DeprecatedAs
 		} else {
 			c.logger.Info("Deleted old S3 "+assetType, "owner_id", ownerID, "asset_id", s3Asset.Key, "s3_key", s3Key)
 		}
+	}
+	c.deleteCachedResizesForServerAsset(ctx, assetIDFromAsset(asset), assetType, ownerID)
+}
+
+func (c *ChattoCore) deleteCachedResizesForServerAsset(ctx context.Context, assetID, assetType, ownerID string) {
+	deletedCount, cacheErr := c.DeleteCachedResizesForServerAsset(ctx, assetID)
+	if cacheErr != nil {
+		c.logger.Warn("Failed to delete cached resizes for server asset",
+			"asset_id", assetID,
+			"asset_type", assetType,
+			"owner_id", ownerID,
+			"error", cacheErr)
+	} else if deletedCount > 0 {
+		c.logger.Debug("Deleted cached resizes for server asset",
+			"asset_id", assetID,
+			"asset_type", assetType,
+			"owner_id", ownerID,
+			"deleted_count", deletedCount)
 	}
 }
 

--- a/cli/internal/core/server_branding_test.go
+++ b/cli/internal/core/server_branding_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"bytes"
 	"testing"
 
 	"google.golang.org/protobuf/proto"
@@ -57,5 +58,35 @@ func TestChattoCore_ServerBrandingUsesConfigEvents(t *testing.T) {
 	}
 	if got != nil {
 		t.Fatalf("expected logo to be cleared, got %+v", got)
+	}
+}
+
+func TestChattoCore_DeleteServerBranding_CleansUpCache(t *testing.T) {
+	core, _ := setupTestCoreWithCache(t)
+	ctx := testContext(t)
+
+	logo, err := core.UploadServerLogo(ctx, bytes.NewReader(createTestPNG(100, 100)))
+	if err != nil {
+		t.Fatalf("UploadServerLogo failed: %v", err)
+	}
+	if err := core.SetServerLogo(ctx, "admin", logo); err != nil {
+		t.Fatalf("SetServerLogo failed: %v", err)
+	}
+
+	cacheKey := ImageCacheKey(ServerAssetSignResource, assetIDFromAsset(logo), 64, 64, "cover")
+	if err := core.StoreCachedResize(ctx, cacheKey, []byte("fake webp data")); err != nil {
+		t.Fatalf("StoreCachedResize failed: %v", err)
+	}
+
+	if err := core.DeleteServerLogo(ctx, "admin"); err != nil {
+		t.Fatalf("DeleteServerLogo failed: %v", err)
+	}
+
+	data, err := core.GetCachedResize(ctx, cacheKey)
+	if err != nil {
+		t.Fatalf("GetCachedResize failed: %v", err)
+	}
+	if data != nil {
+		t.Fatal("Server branding cache entry should be deleted")
 	}
 }

--- a/cli/internal/core/users_test.go
+++ b/cli/internal/core/users_test.go
@@ -1387,6 +1387,41 @@ func TestChattoCore_DeleteUserAvatar(t *testing.T) {
 	}
 }
 
+func TestChattoCore_DeleteUser_CleansUpAvatarCache(t *testing.T) {
+	core, _ := setupTestCoreWithCache(t)
+	ctx := testContext(t)
+
+	user, err := core.CreateUser(ctx, "system", "avatarcacheuser", "Avatar Cache User", "password123")
+	if err != nil {
+		t.Fatalf("Failed to create user: %v", err)
+	}
+
+	asset, err := core.UploadUserAvatar(ctx, user.Id, bytes.NewReader(createTestPNG(100, 100)))
+	if err != nil {
+		t.Fatalf("Failed to upload avatar: %v", err)
+	}
+	if err := core.SetUserAvatar(ctx, user.Id, asset); err != nil {
+		t.Fatalf("Failed to set avatar: %v", err)
+	}
+
+	cacheKey := ImageCacheKey(ServerAssetSignResource, asset.Id, 64, 64, "cover")
+	if err := core.StoreCachedResize(ctx, cacheKey, []byte("fake webp data")); err != nil {
+		t.Fatalf("Failed to store avatar cached resize: %v", err)
+	}
+
+	if err := core.DeleteUser(ctx, user.Id, user.Id); err != nil {
+		t.Fatalf("Failed to delete user: %v", err)
+	}
+
+	data, err := core.GetCachedResize(ctx, cacheKey)
+	if err != nil {
+		t.Fatalf("Unexpected error getting avatar cached resize: %v", err)
+	}
+	if data != nil {
+		t.Fatal("Avatar cache entry should be deleted during account deletion")
+	}
+}
+
 func TestChattoCore_DeleteUserAvatar_NoAvatar(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)

--- a/cli/internal/http_server/assets.go
+++ b/cli/internal/http_server/assets.go
@@ -531,10 +531,10 @@ func (s *HTTPServer) serveTransformedServerAsset(c *gin.Context, key, signedPath
 	s.logger.Debug("Serving transformed server asset", "asset_id", key, "signed_path", signedPath)
 
 	s.serveTransformedAsset(c, transformRequest{
-		ResourceID1: "server",
+		ResourceID1: core.ServerAssetSignResource,
 		ResourceID2: key,
 		SignedPath:  signedPath,
-		CachePrefix: "server",
+		CachePrefix: core.ServerAssetSignResource,
 		AssetID:     key,
 		FetchAsset: func(ctx context.Context) (io.Reader, string, error) {
 			// Probe both NATS and S3 backends

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -663,7 +663,7 @@ Notes: Content-Type stored in object headers. S2 compression enabled. Server log
 | `attachment.{attachmentId}.{paramsHash}`  | Cached WebP image at specific dimensions     |
 | `server.{assetId}.{paramsHash}`           | Cached WebP transform of a server asset      |
 
-Notes: Only created when `[core.assets.cache]` is enabled in config. Uses TTL for automatic expiration (default 7 days). `paramsHash` is first 16 hex chars of SHA256(`{width}x{height}_{fit}`). Animated GIFs are not cached (served directly). S2 compression enabled. Pre-ADR-030-Phase-4 entries written under a `{server|DM}.…` prefix are no longer looked up after the kind-less URL switchover and age out via TTL.
+Notes: Only created when `[core.assets.cache]` is enabled in config. Uses TTL for automatic expiration (default 7 days). Current cache entries for deleted assets are also evicted from the active prefix (`attachment` or `server`) during binary cleanup. `paramsHash` is first 16 hex chars of SHA256(`{width}x{height}_{fit}`). Animated GIFs are not cached (served directly). S2 compression enabled. Pre-ADR-030-Phase-4 entries written under a `{server|DM}.…` prefix are no longer looked up after the kind-less URL switchover and age out via TTL.
 
 **SERVER\_ASSETS keys (primary + DM, post phase 4e):**
 


### PR DESCRIPTION
## Changes

- Evicts `ASSET_CACHE` entries when attachment and server-asset binaries are deleted, including avatars, logo/banner images, and video thumbnail derivatives.
- Supports cache cleanup for legacy storage-less attachment records by probing known NATS/S3 layouts before returning deletion errors.
- Documents active cache eviction in `docs/ARCHITECTURE.md`.

Addresses the cache-cleanup part of #218; broader cache storage research is tracked in #765.

## Tests

- `mise x -- go test ./internal/core -run 'TestChattoCore_DeleteAttachment_CleansUpCache|TestChattoCore_DeleteAttachment_DoesNotAffectOtherAttachmentCache|TestChattoCore_DeleteCachedResizesForAttachment|TestChattoCore_DeleteMessageOwnedAssetsForUser_CleansUpDerivativeCaches|TestChattoCore_DeleteUser_CleansUpAvatarCache|TestChattoCore_DeleteServerBranding_CleansUpCache|TestChattoCore_DeleteUserAvatar|TestChattoCore_UploadUserAvatar_ReplacesOld' -timeout 60s`
- `mise x -- go test -tags test_endpoints ./internal/http_server -run 'TestAsset' -timeout 60s`
- `mise x -- go test ./internal/core -timeout 90s`
