### PR TITLE
fix(core): consolidate NATS asset storage

### DIFF
--- a/cli/cmd/backup_test.go
+++ b/cli/cmd/backup_test.go
@@ -39,7 +39,9 @@ func TestSkipReason(t *testing.T) {
 		{"KV_USER_PRESENCE", true, true, "ephemeral (memory storage)"},
 		{"KV_AUTH_TOKENS", true, true, "security (prevents token leakage)"},
 
-		// Should NOT be skipped regardless of includeKeys
+		// Should NOT be skipped regardless of includeKeys. OBJ_INSTANCE_ASSETS
+		// is legacy pre-0.1 data, but 0.0.x backups must preserve it so 0.1
+		// boot can copy those objects into SERVER_ASSETS.
 		{"KV_INSTANCE", false, false, ""},
 		{"KV_INSTANCE_RBAC", false, false, ""},
 		{"KV_INSTANCE_CONFIG", false, false, ""},

--- a/cli/internal/core/attachments.go
+++ b/cli/internal/core/attachments.go
@@ -27,7 +27,7 @@ import (
 // GetAttachmentsStore returns the ObjectStore for attachments.
 // Uses lazy-loading and caching for efficiency.
 func (c *ChattoCore) GetAttachmentsStore(ctx context.Context) (jetstream.ObjectStore, error) {
-	return c.storage.serverAttachments, nil
+	return c.storage.serverAssets, nil
 }
 
 // UploadAttachment uploads a file as an attachment and returns the
@@ -1021,7 +1021,7 @@ func LocatorForVideoOriginAttachment(roomID, videoOriginID, attachmentID string)
 }
 
 // GetTransformedServerAssetURL returns the URL for accessing a transformed version of an server asset.
-// Server assets include space logos, space banners, and user avatars stored in the server object store.
+// Server assets include server logos, server banners, and user avatars stored in SERVER_ASSETS.
 // The URL includes HMAC signature to prevent parameter tampering.
 // Format: /assets/server/{key}/t/{params}.{signature}
 // where {params} is base64url-encoded JSON: {"w":width,"h":height,"f":"fit"}

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -346,7 +347,7 @@ type encryptionManager struct {
 }
 
 func (c *ChattoCore) ServerStore() jetstream.ObjectStore {
-	return c.storage.serverStore
+	return c.storage.serverAssets
 }
 
 // KeyWrapper returns the key-only KMS boundary used by encryption operations.
@@ -513,12 +514,11 @@ type ServerAssetInfo struct {
 }
 
 // GetServerAssetFromAnyBackend retrieves a server asset by probing both NATS and S3 backends.
-// It tries NATS first (for backwards compatibility with existing assets), then S3.
+// It tries the canonical SERVER_ASSETS NATS object store first, then S3.
 // Returns a reader for the asset content and metadata.
 // The caller is responsible for closing the reader if it implements io.Closer.
 func (c *ChattoCore) GetServerAssetFromAnyBackend(ctx context.Context, assetID string) (io.Reader, *ServerAssetInfo, error) {
-	// Try NATS first (backwards compatibility)
-	obj, err := c.storage.serverStore.Get(ctx, assetID)
+	obj, err := c.storage.serverAssets.Get(ctx, assetID)
 	if err == nil {
 		info, _ := obj.Info()
 		return obj, &ServerAssetInfo{
@@ -554,7 +554,7 @@ func (c *ChattoCore) CleanupAsset(ctx context.Context, asset *corev1.DeprecatedA
 		return
 	}
 	if natsAsset := asset.GetNats(); natsAsset != nil {
-		if err := c.storage.serverStore.Delete(ctx, natsAsset.Key); err != nil {
+		if err := c.storage.serverAssets.Delete(ctx, natsAsset.Key); err != nil {
 			c.logger.Warn("Failed to clean up orphaned asset", "key", natsAsset.Key, "error", err)
 		} else {
 			c.logger.Info("Cleaned up orphaned asset", "key", natsAsset.Key)
@@ -580,7 +580,7 @@ func (c *ChattoCore) deleteAsset(ctx context.Context, asset *corev1.DeprecatedAs
 		return
 	}
 	if natsAsset := asset.GetNats(); natsAsset != nil {
-		if err := c.storage.serverStore.Delete(ctx, natsAsset.Key); err != nil {
+		if err := c.storage.serverAssets.Delete(ctx, natsAsset.Key); err != nil {
 			c.logger.Warn("Failed to delete old "+assetType, "owner_id", ownerID, "key", natsAsset.Key, "error", err)
 		} else {
 			c.logger.Info("Deleted old "+assetType, "owner_id", ownerID, "key", natsAsset.Key)
@@ -808,7 +808,7 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	// Initialize link preview cache and fetcher
 	core.linkPreviewCache = linkpreview.NewCache(storage.runtimeStateKV)
 	assetsConfig := core.AssetsConfig()
-	core.linkPreviewFetcher = linkpreview.NewFetcher(storage.serverStore, &assetsConfig, NewAssetID)
+	core.linkPreviewFetcher = linkpreview.NewFetcher(storage.serverAssets, &assetsConfig, NewAssetID)
 
 	// ensureChannelRoomsAreInAGroup is deferred to core.Run() — it
 	// needs the projectors to be live so its CreateRoomGroup /
@@ -840,7 +840,6 @@ func (c *ChattoCore) Subscribe(ctx context.Context, subject string, handler nats
 // resources are provisioned at startup; legacy import resources are opened only
 // when they already exist.
 type storage struct {
-	serverStore     jetstream.ObjectStore
 	encryptionKV    jetstream.KeyValue // Encryption keys (excluded from backups)
 	serverKV        jetstream.KeyValue // INSTANCE        - legacy user/config import source
 	runtimeConfigKV jetstream.KeyValue // INSTANCE_CONFIG - legacy runtime configuration import source
@@ -855,8 +854,8 @@ type storage struct {
 	serverReactionsKV  jetstream.KeyValue // SERVER_REACTIONS - legacy emoji reactions
 	serverEventsStream jetstream.Stream   // SERVER_EVENTS    - legacy event stream
 
-	serverAttachments jetstream.ObjectStore // SERVER_ASSETS    - message attachment binaries (#330 phase 4e)
-	serverEvtStream   jetstream.Stream      // EVT       - event-sourcing log (ADR-033/034).
+	serverAssets    jetstream.ObjectStore // SERVER_ASSETS - all NATS-backed asset binaries
+	serverEvtStream jetstream.Stream      // EVT       - event-sourcing log (ADR-033/034).
 
 	memoryCacheKV     jetstream.KeyValue    // MEMORY_CACHE - volatile, memory-backed runtime cache state
 	imageCacheStore   jetstream.ObjectStore // Optional: cached resized images (nil if disabled)
@@ -869,18 +868,6 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 	serverKV, err := openLegacyKeyValue(ctx, js, "INSTANCE")
 	if err != nil {
 		return nil, fmt.Errorf("failed to open legacy INSTANCE KV bucket: %w", err)
-	}
-
-	// Initialize server object store
-	serverStore, err := js.CreateOrUpdateObjectStore(ctx, jetstream.ObjectStoreConfig{
-		Bucket:      "INSTANCE_ASSETS",
-		Description: "Instance-level assets (user avatars, space icons, etc.)",
-		Storage:     jetstream.FileStorage,
-		Compression: true,
-		Replicas:    cfg.Replicas,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create INSTANCE object store: %w", err)
 	}
 
 	// Initialize encryption keys KV bucket (excluded from backups for security)
@@ -972,15 +959,18 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		return nil, fmt.Errorf("failed to open legacy SERVER_REACTIONS KV bucket: %w", err)
 	}
 
-	serverAttachments, err := js.CreateOrUpdateObjectStore(ctx, jetstream.ObjectStoreConfig{
+	serverAssets, err := js.CreateOrUpdateObjectStore(ctx, jetstream.ObjectStoreConfig{
 		Bucket:      "SERVER_ASSETS",
-		Description: "Server-level message attachments",
+		Description: "Server asset binaries (avatars, branding, link previews, attachments)",
 		Storage:     jetstream.FileStorage,
 		Compression: true,
 		Replicas:    cfg.Replicas,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SERVER_ASSETS object store: %w", err)
+	}
+	if err := migrateLegacyInstanceAssets(ctx, js, serverAssets); err != nil {
+		return nil, fmt.Errorf("failed to migrate legacy INSTANCE_ASSETS object store: %w", err)
 	}
 
 	serverEventsStream, err := openLegacyStream(ctx, js, "SERVER_EVENTS")
@@ -1017,7 +1007,6 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 	// Return initialized storage and whether RBAC bucket was newly created
 	return &storage{
 		serverKV:           serverKV,
-		serverStore:        serverStore,
 		encryptionKV:       encryptionKV,
 		runtimeConfigKV:    runtimeConfigKV,
 		runtimeStateKV:     runtimeStateKV,
@@ -1026,7 +1015,7 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		serverRuntimeKV:    serverRuntimeKV,
 		serverBodiesKV:     serverBodiesKV,
 		serverReactionsKV:  serverReactionsKV,
-		serverAttachments:  serverAttachments,
+		serverAssets:       serverAssets,
 		serverEventsStream: serverEventsStream,
 		serverEvtStream:    serverEvtStream,
 		memoryCacheKV:      memoryCacheKV,
@@ -1035,10 +1024,123 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 	}, nil
 }
 
+func migrateLegacyInstanceAssets(ctx context.Context, js jetstream.JetStream, target jetstream.ObjectStore) error {
+	legacy, err := openLegacyObjectStore(ctx, js, "INSTANCE_ASSETS")
+	if err != nil {
+		return err
+	}
+	if legacy == nil {
+		return nil
+	}
+
+	objects, err := legacy.List(ctx)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrBucketNotFound) {
+			return nil
+		}
+		if errors.Is(err, jetstream.ErrNoObjectsFound) {
+			return deleteLegacyInstanceAssetsStore(ctx, js)
+		}
+		return fmt.Errorf("list legacy objects: %w", err)
+	}
+
+	for _, info := range objects {
+		if info == nil || info.Deleted {
+			continue
+		}
+		if err := copyLegacyObject(ctx, legacy, target, info); err != nil {
+			return err
+		}
+	}
+
+	return deleteLegacyInstanceAssetsStore(ctx, js)
+}
+
+func deleteLegacyInstanceAssetsStore(ctx context.Context, js jetstream.JetStream) error {
+	if err := js.DeleteObjectStore(ctx, "INSTANCE_ASSETS"); err != nil {
+		if errors.Is(err, jetstream.ErrBucketNotFound) {
+			return nil
+		}
+		return fmt.Errorf("delete legacy INSTANCE_ASSETS object store: %w", err)
+	}
+	return nil
+}
+
+func copyLegacyObject(ctx context.Context, source, target jetstream.ObjectStore, info *jetstream.ObjectInfo) error {
+	if ok, err := legacyObjectAlreadyCopied(ctx, target, info); err != nil {
+		return err
+	} else if ok {
+		return nil
+	}
+
+	reader, err := source.Get(ctx, info.Name)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrBucketNotFound) || errors.Is(err, jetstream.ErrObjectNotFound) {
+			if ok, verifyErr := legacyObjectAlreadyCopied(ctx, target, info); verifyErr != nil {
+				return verifyErr
+			} else if ok {
+				return nil
+			}
+		}
+		return fmt.Errorf("read legacy INSTANCE_ASSETS object %q: %w", info.Name, err)
+	}
+	defer reader.Close()
+
+	if ok, err := legacyObjectAlreadyCopied(ctx, target, info); err != nil {
+		return err
+	} else if ok {
+		return nil
+	}
+
+	meta := jetstream.ObjectMeta{
+		Name:        info.Name,
+		Description: info.Description,
+		Headers:     info.Headers,
+		Metadata:    info.Metadata,
+	}
+	if _, err := target.Put(ctx, meta, reader); err != nil {
+		return fmt.Errorf("copy legacy INSTANCE_ASSETS object %q into SERVER_ASSETS: %w", info.Name, err)
+	}
+	return nil
+}
+
+func legacyObjectAlreadyCopied(ctx context.Context, target jetstream.ObjectStore, info *jetstream.ObjectInfo) (bool, error) {
+	existing, err := target.GetInfo(ctx, info.Name)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrObjectNotFound) {
+			return false, nil
+		}
+		return false, fmt.Errorf("check existing SERVER_ASSETS object %q: %w", info.Name, err)
+	}
+	if sameObjectContentAndMeta(existing, info) {
+		return true, nil
+	}
+	return false, fmt.Errorf("SERVER_ASSETS object %q already exists with different content", info.Name)
+}
+
+func sameObjectContentAndMeta(a, b *jetstream.ObjectInfo) bool {
+	return a.Digest == b.Digest &&
+		a.Size == b.Size &&
+		a.Description == b.Description &&
+		reflect.DeepEqual(a.Headers, b.Headers) &&
+		reflect.DeepEqual(a.Metadata, b.Metadata)
+}
+
 func openLegacyKeyValue(ctx context.Context, js jetstream.JetStream, bucket string) (jetstream.KeyValue, error) {
 	kv, err := js.KeyValue(ctx, bucket)
 	if err == nil {
 		return kv, nil
+	}
+	if errors.Is(err, jetstream.ErrBucketNotFound) {
+		return nil, nil
+	}
+	return nil, err
+}
+
+func openLegacyObjectStore(ctx context.Context, js jetstream.JetStream, bucket string) (jetstream.ObjectStore, error) {
+	store, err := js.ObjectStore(ctx, bucket)
+	if err == nil {
+		return store, nil
 	}
 	if errors.Is(err, jetstream.ErrBucketNotFound) {
 		return nil, nil

--- a/cli/internal/core/core_test.go
+++ b/cli/internal/core/core_test.go
@@ -176,6 +176,123 @@ func TestNewChattoCore_DoesNotProvisionLegacyImportResourcesOnFreshBoot(t *testi
 	if _, err := core.js.Stream(ctx, "SERVER_EVENTS"); !errors.Is(err, jetstream.ErrStreamNotFound) {
 		t.Fatalf("legacy stream SERVER_EVENTS lookup error = %v, want ErrStreamNotFound", err)
 	}
+	if _, err := core.js.ObjectStore(ctx, "INSTANCE_ASSETS"); !errors.Is(err, jetstream.ErrBucketNotFound) {
+		t.Fatalf("legacy object store INSTANCE_ASSETS lookup error = %v, want ErrBucketNotFound", err)
+	}
+	if _, err := core.js.ObjectStore(ctx, "SERVER_ASSETS"); err != nil {
+		t.Fatalf("SERVER_ASSETS lookup error = %v", err)
+	}
+}
+
+func TestNewChattoCore_MigratesLegacyInstanceAssetsToServerAssets(t *testing.T) {
+	_, nc := testutil.StartNATS(t)
+	ctx := testContext(t)
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatalf("jetstream: %v", err)
+	}
+
+	legacy, err := js.CreateOrUpdateObjectStore(ctx, jetstream.ObjectStoreConfig{
+		Bucket:      "INSTANCE_ASSETS",
+		Description: "Legacy instance assets",
+		Storage:     jetstream.FileStorage,
+		Compression: true,
+	})
+	if err != nil {
+		t.Fatalf("create legacy INSTANCE_ASSETS: %v", err)
+	}
+	if _, err := legacy.Put(ctx, jetstream.ObjectMeta{
+		Name: "avatar-asset",
+		Headers: nats.Header{
+			"Content-Type": {"image/webp"},
+		},
+		Metadata: map[string]string{"legacy": "true"},
+	}, strings.NewReader("legacy avatar bytes")); err != nil {
+		t.Fatalf("put legacy asset: %v", err)
+	}
+
+	core, err := NewChattoCore(ctx, nc, config.CoreConfig{
+		SecretKey: "test-core-secret",
+		Assets: config.AssetsConfig{
+			SigningSecret: "test-signing-secret",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewChattoCore: %v", err)
+	}
+
+	if _, err := core.js.ObjectStore(ctx, "INSTANCE_ASSETS"); !errors.Is(err, jetstream.ErrBucketNotFound) {
+		t.Fatalf("legacy object store INSTANCE_ASSETS lookup error = %v, want ErrBucketNotFound", err)
+	}
+	data, err := core.ServerStore().GetBytes(ctx, "avatar-asset")
+	if err != nil {
+		t.Fatalf("get copied asset: %v", err)
+	}
+	if string(data) != "legacy avatar bytes" {
+		t.Fatalf("copied asset data = %q", string(data))
+	}
+	info, err := core.ServerStore().GetInfo(ctx, "avatar-asset")
+	if err != nil {
+		t.Fatalf("copied asset info: %v", err)
+	}
+	if got := info.Headers.Get("Content-Type"); got != "image/webp" {
+		t.Fatalf("copied Content-Type = %q, want image/webp", got)
+	}
+	if got := info.Metadata["legacy"]; got != "true" {
+		t.Fatalf("copied metadata legacy = %q, want true", got)
+	}
+}
+
+func TestCopyLegacyObject_TreatsVanishedLegacyStoreAsDoneWhenTargetMatches(t *testing.T) {
+	_, nc := testutil.StartNATS(t)
+	ctx := testContext(t)
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatalf("jetstream: %v", err)
+	}
+
+	legacy, err := js.CreateOrUpdateObjectStore(ctx, jetstream.ObjectStoreConfig{
+		Bucket:  "INSTANCE_ASSETS",
+		Storage: jetstream.FileStorage,
+	})
+	if err != nil {
+		t.Fatalf("create legacy INSTANCE_ASSETS: %v", err)
+	}
+	target, err := js.CreateOrUpdateObjectStore(ctx, jetstream.ObjectStoreConfig{
+		Bucket:  "SERVER_ASSETS",
+		Storage: jetstream.FileStorage,
+	})
+	if err != nil {
+		t.Fatalf("create SERVER_ASSETS: %v", err)
+	}
+
+	meta := jetstream.ObjectMeta{
+		Name: "avatar-asset",
+		Headers: nats.Header{
+			"Content-Type": {"image/webp"},
+		},
+		Metadata: map[string]string{"legacy": "true"},
+	}
+	if _, err := legacy.Put(ctx, meta, strings.NewReader("legacy avatar bytes")); err != nil {
+		t.Fatalf("put legacy asset: %v", err)
+	}
+	infos, err := legacy.List(ctx)
+	if err != nil {
+		t.Fatalf("list legacy asset: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("legacy list len = %d, want 1", len(infos))
+	}
+	if _, err := target.Put(ctx, meta, strings.NewReader("legacy avatar bytes")); err != nil {
+		t.Fatalf("pre-copy target asset: %v", err)
+	}
+	if err := js.DeleteObjectStore(ctx, "INSTANCE_ASSETS"); err != nil {
+		t.Fatalf("delete legacy INSTANCE_ASSETS: %v", err)
+	}
+
+	if err := copyLegacyObject(ctx, legacy, target, infos[0]); err != nil {
+		t.Fatalf("copy after legacy store vanished: %v", err)
+	}
 }
 
 func TestNewChattoCore_CopiesLegacyCallStateToMemoryCache(t *testing.T) {

--- a/cli/internal/core/encryption_test.go
+++ b/cli/internal/core/encryption_test.go
@@ -439,7 +439,7 @@ func TestDeleteUser_CryptoShredEventTombstonesMessagesAndDeletesAssetGraph(t *te
 	deletedAvatar, err := core.GetUserAvatar(ctx, author.Id)
 	require.NoError(t, err)
 	require.Nil(t, deletedAvatar)
-	_, err = core.storage.serverStore.Get(ctx, avatar.Id)
+	_, err = core.storage.serverAssets.Get(ctx, avatar.Id)
 	require.Error(t, err, "avatar backing bytes should be deleted after key shred and account deletion")
 }
 

--- a/cli/internal/core/server_branding.go
+++ b/cli/internal/core/server_branding.go
@@ -85,7 +85,7 @@ func (c *ChattoCore) uploadServerAsset(ctx context.Context, webpData []byte, kin
 		Name:    assetID,
 		Headers: headers,
 	}
-	info, err := c.storage.serverStore.Put(ctx, meta, bytes.NewReader(webpData))
+	info, err := c.storage.serverAssets.Put(ctx, meta, bytes.NewReader(webpData))
 	if err != nil {
 		return nil, fmt.Errorf("failed to upload %s: %w", kind, err)
 	}

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -433,7 +433,7 @@ func (c *ChattoCore) UploadUserAvatar(ctx context.Context, userID string, reader
 			Name:    assetID,
 			Headers: headers,
 		}
-		info, err := c.storage.serverStore.Put(ctx, meta, bytes.NewReader(webpData))
+		info, err := c.storage.serverAssets.Put(ctx, meta, bytes.NewReader(webpData))
 		if err != nil {
 			return nil, fmt.Errorf("failed to upload avatar: %w", err)
 		}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -257,9 +257,8 @@ There is no `adminAuditLogEvents` subscription — audit events arrive through `
 | ------- | ----------------------------- | ------------------------------------------- |
 | KV      | `RUNTIME_STATE`               | Persisted latest-value runtime/user state, including pending notifications, push subscriptions, and auth/workflow tokens |
 | KV      | `MEMORY_CACHE`                | Volatile memory-backed cache state, including presence and active voice calls; excluded from backups |
-| Objects | `INSTANCE_ASSETS`             | Avatars, icons (bucket name retained from pre-rename) |
 | Objects | `ASSET_CACHE`                 | Cached resized images (optional, with TTL)  |
-| Objects | `SERVER_ASSETS`               | Message attachments                         |
+| Objects | `SERVER_ASSETS`               | Asset binaries (avatars, server branding, link previews, message attachments) |
 | Legacy import KV | `INSTANCE`          | Users, verified emails, branding, display preferences, and push subscriptions from pre-ES deployments |
 | Legacy import KV | `INSTANCE_CONFIG`   | Server configuration from pre-ES deployments |
 | Legacy import KV | `SERVER_CONFIG`     | Rooms, memberships, room groups/layout, and notification preferences from pre-ES deployments |
@@ -645,17 +644,10 @@ Notes: Legacy source for `MigrateReactionsToES`. Current reaction writes append 
 
 | Bucket                      | Description                                       |
 | --------------------------- | ------------------------------------------------- |
-| `INSTANCE_ASSETS`           | User avatars, server icon/banner (bucket name retained from pre-rename) |
 | `ASSET_CACHE`               | Cached resized images (optional)                  |
-| `SERVER_ASSETS`             | Message attachments                               |
+| `SERVER_ASSETS`             | Asset binaries (avatars, server icon/banner, link previews, message attachments) |
 
-**INSTANCE_ASSETS keys:**
-
-| Key          | Description                         |
-| ------------ | ----------------------------------- |
-| `{assetId}`  | User avatars, space icons, etc.     |
-
-Notes: Content-Type stored in object headers. S2 compression enabled. Server logo and banner bytes remain here when backed by the NATS object store; the current logo/banner pointers are imported into and updated through EVT config events.
+Pre-0.1 servers stored user avatars, server logo/banner, and link-preview images in `INSTANCE_ASSETS`. On 0.1 boot, Chatto copies those objects into `SERVER_ASSETS` with the same object names and headers before importing legacy pointers, then deletes the legacy `INSTANCE_ASSETS` object store. Fresh/current deployments do not create `INSTANCE_ASSETS`.
 
 **ASSET_CACHE keys:**
 
@@ -666,14 +658,13 @@ Notes: Content-Type stored in object headers. S2 compression enabled. Server log
 
 Notes: Only created when `[core.assets.cache]` is enabled in config. Uses TTL for automatic expiration (default 7 days). Current cache entries for deleted assets are also evicted from the active prefix (`attachment` or `server`) during binary cleanup. `paramsHash` is first 16 hex chars of SHA256(`{width}x{height}_{fit}`). Animated GIFs are not cached (served directly). S2 compression enabled. Pre-ADR-030-Phase-4 entries written under a `{server|DM}.…` prefix are no longer looked up after the kind-less URL switchover and age out via TTL.
 
-**SERVER\_ASSETS keys (primary + DM, post phase 4e):**
+**SERVER\_ASSETS keys:**
 
 | Key                   | Description                                     |
 | --------------------- | ----------------------------------------------- |
-| `{attachmentId}`      | Original attachment files (images, videos, etc.)|
-| `{attachmentId}_thumb`| WebP thumbnails (256px max dimension)           |
+| `{assetId}`           | User avatars, server branding images, link-preview images, original attachment files, and derivative binaries |
 
-Notes: Asset IDs are globally unique (NanoID), so no kind segment is needed. Channel and DM assets share the same flat keyspace. Content-Type and original filename stored in object headers. S2 compression enabled. Asset **metadata** (filename, dimensions, duration, storage pointer, …) is created in `AssetCreatedEvent`; ownership context lives on the event (`message`, `derivative`, `user_avatar`) rather than inside `Asset`. Future room or server asset owners should add explicit owner branches when those features start emitting asset events. Message-owned assets are also embedded as `Attachment` protos inside the owning `MessageBody` for message rendering and signed URL back-pointers. Processing events refer to created asset IDs. Message posting asks the process-local video service to spawn video/animated-GIF processing after appending asset creation and processing-started events; there is no transient NATS Core worker subject. Boot recovery derives missed work from the EVT projection and calls the same local path. Video processing success records thumbnail/variant asset IDs, while each derivative binary is separately declared with `AssetCreatedEvent` and an owner pointing at the original asset. `AssetProcessingFailedEvent.failure_code` records failed/unavailable outcomes. Account deletion follows the projected message asset graph and appends `AssetDeletedEvent` for source assets and derivative children before deleting backing bytes. Boot migrations backfill asset creation events from legacy message attachments and import legacy `SERVER_RUNTIME video.*` records into asset creation and processing events. The asset HTTP handler doesn't look up a separate index bucket; the body-or-video-manifest locator travels in the URL itself as a signed locator (see "Dynamic Image Transformation" below).
+Notes: Asset IDs are globally unique (NanoID), so no kind segment is needed. Channel and DM assets share the same flat keyspace. Content-Type and original filename stored in object headers where available. S2 compression enabled. Asset **metadata** (filename, dimensions, duration, storage pointer, …) is created in `AssetCreatedEvent`; ownership context lives on the event (`message`, `derivative`, `user_avatar`) rather than inside `Asset`. Future room or server asset owners should add explicit owner branches when those features start emitting asset events. Message-owned assets are also embedded as `Attachment` protos inside the owning `MessageBody` for message rendering and signed URL back-pointers. Processing events refer to created asset IDs. Message posting asks the process-local video service to spawn video/animated-GIF processing after appending asset creation and processing-started events; there is no transient NATS Core worker subject. Boot recovery derives missed work from the EVT projection and calls the same local path. Video processing success records thumbnail/variant asset IDs, while each derivative binary is separately declared with `AssetCreatedEvent` and an owner pointing at the original asset. `AssetProcessingFailedEvent.failure_code` records failed/unavailable outcomes. Account deletion follows the projected message asset graph and appends `AssetDeletedEvent` for source assets and derivative children before deleting backing bytes. Boot migrations copy pre-0.1 `INSTANCE_ASSETS` objects into `SERVER_ASSETS`, backfill asset creation events from legacy message attachments, and import legacy `SERVER_RUNTIME video.*` records into asset creation and processing events. The asset HTTP handler doesn't look up a separate index bucket; the body-or-video-manifest locator travels in the URL itself as a signed locator (see "Dynamic Image Transformation" below).
 
 ### Dynamic Image Transformation
 


### PR DESCRIPTION
- Consolidates NATS-backed avatars, branding, link previews, and message attachments into `SERVER_ASSETS` for 0.1 fresh boots.
- Migrates legacy pre-0.1 `INSTANCE_ASSETS` objects into `SERVER_ASSETS`, preserving headers/metadata and tolerating multi-replica boot races before deleting the legacy bucket.
- Updates backup test expectations and the architecture inventory to document 0.0.x backup import behavior.

Tests:
- `git diff --check`
- `mise x -- go test ./internal/core -run 'TestNewChattoCore_(DoesNotProvisionLegacyImportResourcesOnFreshBoot|MigratesLegacyInstanceAssetsToServerAssets)|TestCopyLegacyObject_TreatsVanishedLegacyStoreAsDoneWhenTargetMatches|TestLinkPreviewImageStorageAndRetrieval|TestDeleteUser_CryptoShredEventTombstonesMessagesAndDeletesAssetGraph' -timeout 60s`
- `mise x -- go test ./cmd -run 'TestSkipReason|TestClassifyStream' -timeout 30s`
