### PR TITLE
fix(frontend): keep failed server icons visible

### DIFF
--- a/frontend/src/lib/ServerSpaceSection.svelte
+++ b/frontend/src/lib/ServerSpaceSection.svelte
@@ -29,6 +29,10 @@
   const notificationStore = stores.notifications;
   const roomUnreadStore = stores.roomUnread;
   const notificationLevelStore = stores.notificationLevels;
+  // eslint-disable-next-line svelte/no-unused-svelte-ignore -- Svelte compiler warning, not ESLint
+  // svelte-ignore state_referenced_locally - serverId is stable per component lifetime (keyed by instance.id)
+  const gqlClient = graphqlClientManager.getClient(serverId);
+  const registeredServer = $derived(serverRegistry.getServer(serverId));
 
   // After the URL collapse (ADR-027), "this instance is active" simply means
   // the URL's instance segment matches this one — and since each instance
@@ -39,6 +43,18 @@
   let logoUrl = $state<string | null>(null);
   let loaded = $state(false);
 
+  const iconSpace = $derived.by(() => {
+    const refreshedName = stores.serverInfo.name !== 'Chatto' ? stores.serverInfo.name : undefined;
+    return {
+      name: displayName || refreshedName || registeredServer?.name || stores.serverInfo.name,
+      logoUrl: loaded ? logoUrl : (stores.serverInfo.iconUrl ?? registeredServer?.iconUrl)
+    };
+  });
+  const iconDimmed = $derived(!loaded || gqlClient.showConnectionLostIcon);
+  const iconTitle = $derived(
+    iconDimmed ? `${iconSpace.name} (connection unavailable)` : iconSpace.name
+  );
+
   // Single dispatcher for icon clicks — kind comes from spaceIndicator()
   // so the two paths can't drift out of sync with what was rendered.
   function handleSpaceIndicatorClick(kind: 'notification' | 'unread') {
@@ -48,7 +64,7 @@
 
   // Get the GraphQL client for this instance
   function getClient() {
-    return graphqlClientManager.getClient(serverId).client;
+    return gqlClient.client;
   }
 
   // Single combined query for instance icon, unread status, notification prefs, and viewer permissions.
@@ -94,51 +110,60 @@
   `);
 
   async function loadAll() {
-    const client = getClient();
+    try {
+      const client = getClient();
 
-    const [initResult] = await Promise.all([
-      client.query(InstanceInitQuery, {}).toPromise(),
-      notificationStore.fetch()
-    ]);
+      const [initResult] = await Promise.all([
+        client.query(InstanceInitQuery, {}).toPromise(),
+        notificationStore.fetch()
+      ]);
 
-    if (!initResult.data) return;
-
-    const { server, viewer } = initResult.data;
-
-    if (viewer) {
-      stores.setPermissions(viewer);
-      // Populate room-level notification preferences first.
-      for (const pref of viewer.user.roomNotificationPreferences) {
-        notificationLevelStore.setRoomPreference(pref.roomId, pref.level, pref.effectiveLevel);
+      if (initResult.error) {
+        console.error(`[server:${serverId}] failed to load sidebar icon data`, initResult.error);
+        return;
       }
-    }
 
-    if (server) {
-      // Populate server-level notification preference and unread state.
-      const pref = server.viewerNotificationPreference;
-      if (pref) {
-        notificationLevelStore.setServerPreference(pref.level, pref.effectiveLevel);
-      }
-      roomUnreadStore.clear();
-      roomUnreadStore.setServerHasUnread(server.viewerHasUnreadRooms);
+      if (!initResult.data) return;
 
-      // Populate DM unread status and notification preferences. Channel
-      // and DM rooms now share the same per-room unread map.
-      for (const room of server.rooms) {
-        const roomPref = room.viewerNotificationPreference;
-        if (roomPref) {
-          notificationLevelStore.setRoomPreference(room.id, roomPref.level, roomPref.effectiveLevel);
-        }
-        if (room.hasUnread) {
-          roomUnreadStore.setRoomUnread(room.id, true);
+      const { server, viewer } = initResult.data;
+
+      if (viewer) {
+        stores.setPermissions(viewer);
+        // Populate room-level notification preferences first.
+        for (const pref of viewer.user.roomNotificationPreferences) {
+          notificationLevelStore.setRoomPreference(pref.roomId, pref.level, pref.effectiveLevel);
         }
       }
-    }
 
-    if (server) {
-      displayName = server.profile.name;
-      logoUrl = server.profile.logoUrl ?? null;
-      loaded = true;
+      if (server) {
+        // Populate server-level notification preference and unread state.
+        const pref = server.viewerNotificationPreference;
+        if (pref) {
+          notificationLevelStore.setServerPreference(pref.level, pref.effectiveLevel);
+        }
+        roomUnreadStore.clear();
+        roomUnreadStore.setServerHasUnread(server.viewerHasUnreadRooms);
+
+        // Populate DM unread status and notification preferences. Channel
+        // and DM rooms now share the same per-room unread map.
+        for (const room of server.rooms) {
+          const roomPref = room.viewerNotificationPreference;
+          if (roomPref) {
+            notificationLevelStore.setRoomPreference(room.id, roomPref.level, roomPref.effectiveLevel);
+          }
+          if (room.hasUnread) {
+            roomUnreadStore.setRoomUnread(room.id, true);
+          }
+        }
+      }
+
+      if (server) {
+        displayName = server.profile.name;
+        logoUrl = server.profile.logoUrl ?? null;
+        loaded = true;
+      }
+    } catch (err) {
+      console.error(`[server:${serverId}] failed to load sidebar icon data`, err);
     }
   }
 
@@ -168,7 +193,7 @@
   }
 
   // Load on mount and tab resume
-  useTabResumeCallback(() => loadAll());
+  useTabResumeCallback(() => void loadAll());
 
   // Subscribe to instance events. Use $effect (not onMount) so that if the
   // event bus isn't started yet on first run — possible when this component
@@ -307,12 +332,12 @@
 </script>
 
 <!-- One icon per instance (server = instance post-#330). -->
-{#if loaded}
-  <SpaceIcon
-    space={{ name: displayName, logoUrl }}
-    href={resolve('/chat/[serverId]', { serverId: serverSegment })}
-    selected={isActiveServer}
-    indicator={stores.spaceIndicator()}
-    onIndicatorClick={handleSpaceIndicatorClick}
-  />
-{/if}
+<SpaceIcon
+  space={iconSpace}
+  href={resolve('/chat/[serverId]', { serverId: serverSegment })}
+  selected={isActiveServer}
+  indicator={stores.spaceIndicator()}
+  onIndicatorClick={handleSpaceIndicatorClick}
+  title={iconTitle}
+  dimmed={iconDimmed}
+/>

--- a/frontend/src/lib/ServerSpaceSection.svelte.spec.ts
+++ b/frontend/src/lib/ServerSpaceSection.svelte.spec.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { q } from '$lib/test-utils';
+
+const { mocks } = vi.hoisted(() => {
+	const client = {
+		query: vi.fn()
+	};
+
+	return {
+		mocks: {
+			client,
+			showConnectionLostIcon: false,
+			server: {
+				id: 'remote',
+				url: 'https://remote.example.com',
+				name: 'Remote Chatto',
+				iconUrl: null,
+				token: 'token',
+				userId: 'user-1',
+				userLogin: 'alice',
+				userDisplayName: 'Alice',
+				userAvatarUrl: null,
+				addedAt: 0
+			},
+			store: {
+				notifications: { fetch: vi.fn().mockResolvedValue(undefined) },
+				roomUnread: {
+					clear: vi.fn(),
+					setServerHasUnread: vi.fn(),
+					setRoomUnread: vi.fn(),
+					getFirstUnreadRoomId: vi.fn().mockReturnValue(null)
+				},
+				notificationLevels: {
+					setServerPreference: vi.fn(),
+					setRoomPreference: vi.fn(),
+					isRoomMuted: vi.fn().mockReturnValue(false),
+					isServerMuted: vi.fn().mockReturnValue(false)
+				},
+				pendingHighlights: { set: vi.fn() },
+				serverInfo: {
+					name: 'Chatto',
+					iconUrl: null
+				},
+				setPermissions: vi.fn(),
+				spaceIndicator: vi.fn().mockReturnValue(null)
+			}
+		}
+	};
+});
+
+vi.mock('$app/state', () => ({
+	page: {
+		params: {
+			serverId: 'other-server',
+			roomId: undefined
+		}
+	}
+}));
+
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn()
+}));
+
+vi.mock('$app/paths', () => ({
+	resolve: (path: string, params?: Record<string, string>) =>
+		path
+			.replace('[serverId]', params?.serverId ?? '')
+			.replace('[roomId]', params?.roomId ?? '')
+}));
+
+vi.mock('$lib/hooks', () => ({
+	useTabResumeCallback: (callback: () => void) => {
+		void callback();
+	}
+}));
+
+vi.mock('$lib/eventBus.svelte', () => ({
+	createEventBusHandlerRegistrar: vi.fn(() => undefined)
+}));
+
+vi.mock('$lib/state/server/graphqlClient.svelte', () => ({
+	graphqlClientManager: {
+		getClient: vi.fn(() => ({
+			get showConnectionLostIcon() {
+				return mocks.showConnectionLostIcon;
+			},
+			client: mocks.client
+		}))
+	}
+}));
+
+vi.mock('$lib/state/server/registry.svelte', () => ({
+	serverRegistry: {
+		isOriginServer: vi.fn(() => false),
+		getServer: vi.fn(() => mocks.server),
+		getStore: vi.fn(() => mocks.store)
+	}
+}));
+
+import ServerSpaceSection from './ServerSpaceSection.svelte';
+
+describe('ServerSpaceSection', () => {
+	let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		consoleErrorSpy?.mockRestore();
+		consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		mocks.showConnectionLostIcon = false;
+		mocks.client.query.mockReset();
+		mocks.store.notifications.fetch.mockClear();
+		mocks.store.spaceIndicator.mockReturnValue(null);
+		mocks.store.serverInfo.name = 'Chatto';
+		mocks.store.serverInfo.iconUrl = null;
+	});
+
+	afterEach(() => {
+		consoleErrorSpy.mockRestore();
+	});
+
+	it('keeps a failed server in the gutter as a dimmed icon', async () => {
+		mocks.client.query.mockReturnValue({
+			toPromise: vi.fn().mockResolvedValue({
+				data: null,
+				error: new Error('connection refused')
+			})
+		});
+
+		const { container } = render(ServerSpaceSection, {
+			props: {
+				serverId: 'remote',
+				currentUserId: 'user-1'
+			}
+		});
+
+		await vi.waitFor(() => {
+			expect(mocks.client.query).toHaveBeenCalled();
+		});
+
+		const icon = q(container, '[data-testid="space-icon"]');
+		await expect.element(icon).toBeInTheDocument();
+		await expect.element(icon).toHaveClass('opacity-40');
+		await expect.element(icon).toHaveAttribute(
+			'title',
+			'Remote Chatto (connection unavailable)'
+		);
+		expect(container.textContent).toContain('R');
+	});
+
+	it('removes the dimmed state after sidebar init succeeds', async () => {
+		mocks.client.query.mockReturnValue({
+			toPromise: vi.fn().mockResolvedValue({
+				data: {
+					server: {
+						profile: {
+							name: 'Loaded Remote',
+							logoUrl: null
+						},
+						viewerNotificationPreference: null,
+						viewerHasUnreadRooms: false,
+						rooms: []
+					},
+					viewer: null
+				},
+				error: null
+			})
+		});
+
+		const { container } = render(ServerSpaceSection, {
+			props: {
+				serverId: 'remote',
+				currentUserId: 'user-1'
+			}
+		});
+
+		const icon = q(container, '[data-testid="space-icon"]');
+		await expect.element(icon).toBeInTheDocument();
+		await expect.element(icon).not.toHaveClass('opacity-40');
+		await expect.element(icon).toHaveAttribute('title', 'Loaded Remote');
+		expect(container.textContent).toContain('L');
+	});
+});

--- a/frontend/src/lib/SpaceIcon.svelte
+++ b/frontend/src/lib/SpaceIcon.svelte
@@ -11,7 +11,8 @@
     selected = false,
     indicator = null,
     onIndicatorClick,
-    title
+    title,
+    dimmed = false
   }: {
     /** Display data for the icon (instance name + optional logo). */
     space?: { name: string; logoUrl?: string | null };
@@ -24,6 +25,8 @@
     /** Click handler for the indicator dot. Receives the indicator kind. */
     onIndicatorClick?: (kind: 'notification' | 'unread', event: MouseEvent) => void;
     title?: string;
+    /** Render as unavailable/degraded while keeping the icon in the gutter. */
+    dimmed?: boolean;
   } = $props();
 </script>
 
@@ -32,7 +35,11 @@
     {href}
     {title}
     aria-label={title ?? space?.name}
-    class={['space-icon server-gutter-item cursor-pointer', selected && 'server-gutter-item-active']}
+    class={[
+      'space-icon server-gutter-item cursor-pointer',
+      selected && 'server-gutter-item-active',
+      dimmed && 'opacity-40 grayscale'
+    ]}
     data-testid={space ? 'space-icon' : icon ? 'nav-icon' : undefined}
   >
     {#if space}


### PR DESCRIPTION
## Changes

- Keep registered server gutter icons visible when sidebar init data fails to load, using cached/registered server metadata as a fallback.
- Dim unavailable server icons while init data is missing or the WebSocket is disconnected.
- Add browser component coverage for failed and successful server sidebar init states.

## Verification

- `mise run lint-frontend`
- `mise run test-frontend`
