### PR TITLE
feat(frontend): polish service worker shell caching

### DIFF
--- a/.claude/rules/frontend-conventions.md
+++ b/.claude/rules/frontend-conventions.md
@@ -190,6 +190,7 @@ For `truncate` to work in flexbox, **every flex ancestor** needs `min-w-0`. (See
 - Manifest at `static/manifest.webmanifest`, linked from `app.html`.
 - Icons in `static/icons/`.
 - Use `sharp` dev dependency + `scripts/generate-icons.mjs` to regenerate icons from SVG.
+- The service worker is shell-only: cache SvelteKit/static PWA assets and the SPA fallback, but keep API/auth/live-event/uploaded-asset requests network-only. See `docs/fdr/FDR-027-pwa-shell-and-service-worker.md`.
 
 ---
 

--- a/docs/fdr/FDR-027-pwa-shell-and-service-worker.md
+++ b/docs/fdr/FDR-027-pwa-shell-and-service-worker.md
@@ -1,0 +1,45 @@
+# FDR-027: PWA Shell & Service Worker
+
+**Status:** Active
+**Last reviewed:** 2026-06-08
+
+## Overview
+
+Chatto ships a service worker so the installed web app can launch reliably and handle push notifications. The worker caches the versioned frontend shell and static PWA assets, but deliberately does not cache chat data, API responses, uploaded media, or live-event traffic.
+
+Offline support means the app can open and show its normal disconnected state instead of the browser's generic offline page. It does not mean offline message history, offline search, or an outbox for composing messages while disconnected.
+
+## Behavior
+
+- The service worker is registered by SvelteKit in production builds.
+- On install, the worker caches SvelteKit build assets, static PWA assets, and the SPA fallback shell.
+- On activate, old Chatto shell caches are deleted and the new worker claims open clients.
+- Known shell assets are served cache-first from the versioned cache.
+- Same-origin navigations are network-first, falling back to the cached SPA shell only when the network fails.
+- API, auth, webhook, uploaded asset, non-GET, and cross-origin requests are network-only.
+- Push notifications continue to display native OS notifications and route notification clicks into the SPA.
+- Push dismiss payloads still close matching visible notifications on the device.
+
+## Design Decisions
+
+### 1. Shell-only caching
+
+**Decision:** Cache only the app shell and static PWA assets.
+**Why:** Chatto is a real-time chat app. Serving stale messages, permissions, assets, or notification state as if they were live would be worse than showing the disconnected state.
+**Tradeoff:** Offline launches do not show recent rooms or messages unless the live app already has that state in memory. This keeps the data model honest.
+
+### 2. Versioned cache names
+
+**Decision:** Shell caches include the SvelteKit app version in their name.
+**Why:** A deploy can replace hashed JavaScript and CSS chunks. Versioned cache names let the new worker populate the new shell and delete older shell caches during activation.
+**Tradeoff:** A user briefly stores two shell versions during update. The cached asset set is small, so this is acceptable.
+
+### 3. SvelteKit owns registration
+
+**Decision:** The frontend relies on SvelteKit's production service-worker registration instead of registering manually from the push-notification setup component.
+**Why:** The service worker is now useful even when Web Push is not enabled. Registration should be tied to the PWA shell, not to push settings.
+**Tradeoff:** Production users get the service worker whenever the app includes one. The worker's fetch policy is conservative to make that safe.
+
+## Related
+
+- **FDRs:** FDR-012 (Notifications), FDR-013 (Web Push Notifications)

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -36,3 +36,4 @@ See [`.claude/skills/fdr/SKILL.md`](../../.claude/skills/fdr/SKILL.md) for the F
 | [FDR-024](FDR-024-permission-inspection-tool.md) | Permission Inspection Tool | Active | 2026-05-19 |
 | [FDR-025](FDR-025-user-search-and-member-directory.md) | User Search & Member Directory | Active | 2026-05-19 |
 | [FDR-026](FDR-026-last-room-memory.md) | Last-Room Memory | Active | 2026-05-19 |
+| [FDR-027](FDR-027-pwa-shell-and-service-worker.md) | PWA Shell & Service Worker | Active | 2026-06-08 |

--- a/frontend/src/lib/components/PushNotificationSetup.svelte
+++ b/frontend/src/lib/components/PushNotificationSetup.svelte
@@ -1,14 +1,13 @@
 <!--
 @component
 
-Registers the service worker for push notifications and handles automatic
-re-subscription when the browser renews or invalidates subscriptions.
+Handles automatic Web Push re-subscription when the browser renews or
+invalidates subscriptions. SvelteKit registers the service worker in production.
 
 Only active when push notifications are enabled in the server config.
 Include this component once in the authenticated layout.
 -->
 <script lang="ts">
-  import { dev } from '$app/environment';
   import {
     onSubscriptionChange,
     subscribe,
@@ -22,13 +21,6 @@ Include this component once in the authenticated layout.
   $effect(() => {
     if (!originServerInfo?.pushNotificationsEnabled) return;
     if (!('serviceWorker' in navigator)) return;
-    // SvelteKit doesn't bundle the service worker in dev mode
-    if (dev) return;
-
-    // Register the service worker
-    navigator.serviceWorker.register('/service-worker.js').catch((error) => {
-      console.error('Service worker registration failed:', error);
-    });
 
     // Listen for subscription changes (e.g., when browser renews subscription)
     // and attempt automatic re-subscription

--- a/frontend/src/lib/pwa/serviceWorkerPolicy.spec.ts
+++ b/frontend/src/lib/pwa/serviceWorkerPolicy.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyServiceWorkerRequest,
+  normalizeSameOriginUrl,
+  shouldUseOfflineShellFallback
+} from './serviceWorkerPolicy';
+
+const ORIGIN = 'https://chatto.example';
+const SHELL_ASSETS = new Set(['/manifest.webmanifest', '/icons/icon-192.png', '/_app/immutable/app.js']);
+
+function request(method: string, mode: RequestMode = 'same-origin') {
+  return {
+    method,
+    mode,
+    destination: ''
+  } satisfies Pick<Request, 'method' | 'mode' | 'destination'>;
+}
+
+function classify(pathOrUrl: string, method = 'GET', mode: RequestMode = 'same-origin') {
+  const url = pathOrUrl.startsWith('http') ? pathOrUrl : `${ORIGIN}${pathOrUrl}`;
+  return classifyServiceWorkerRequest(request(method, mode), url, SHELL_ASSETS, ORIGIN);
+}
+
+describe('classifyServiceWorkerRequest', () => {
+  it('marks same-origin app shell assets as cacheable', () => {
+    expect(classify('/manifest.webmanifest')).toEqual({
+      cacheableShellAsset: true,
+      navigationRequest: false,
+      networkOnly: false
+    });
+    expect(classify('/_app/immutable/app.js')).toMatchObject({
+      cacheableShellAsset: true,
+      networkOnly: false
+    });
+  });
+
+  it.each(['/api/graphql', '/auth/login', '/assets/avatar.png', '/webhooks/livekit', '/graphql'])(
+    'keeps %s network-only',
+    (path) => {
+      expect(classify(path)).toMatchObject({
+        cacheableShellAsset: false,
+        navigationRequest: false,
+        networkOnly: true
+      });
+    }
+  );
+
+  it('keeps cross-origin and non-GET requests network-only', () => {
+    expect(classify('https://other.example/manifest.webmanifest')).toMatchObject({
+      cacheableShellAsset: false,
+      networkOnly: true
+    });
+    expect(classify('/manifest.webmanifest', 'POST')).toMatchObject({
+      cacheableShellAsset: false,
+      networkOnly: true
+    });
+  });
+
+  it('classifies same-origin navigations for network-first offline-shell fallback', () => {
+    const policy = classify('/chat/server/room', 'GET', 'navigate');
+
+    expect(policy).toEqual({
+      cacheableShellAsset: false,
+      navigationRequest: true,
+      networkOnly: false
+    });
+    expect(shouldUseOfflineShellFallback(policy, true)).toBe(true);
+    expect(shouldUseOfflineShellFallback(policy, false)).toBe(false);
+  });
+});
+
+describe('normalizeSameOriginUrl', () => {
+  it('resolves missing and relative notification URLs to the same origin', () => {
+    expect(normalizeSameOriginUrl(undefined, ORIGIN)).toBe(`${ORIGIN}/chat`);
+    expect(normalizeSameOriginUrl('/chat/s1/r1?highlight=m1', ORIGIN)).toBe(
+      `${ORIGIN}/chat/s1/r1?highlight=m1`
+    );
+  });
+
+  it('rejects cross-origin and malformed notification URLs', () => {
+    expect(normalizeSameOriginUrl('https://other.example/chat', ORIGIN)).toBeNull();
+    expect(normalizeSameOriginUrl('http://[', ORIGIN)).toBeNull();
+  });
+});

--- a/frontend/src/lib/pwa/serviceWorkerPolicy.ts
+++ b/frontend/src/lib/pwa/serviceWorkerPolicy.ts
@@ -1,0 +1,49 @@
+export const OFFLINE_SHELL_PATH = '/200.html';
+
+const NETWORK_ONLY_PREFIXES = ['/api', '/auth', '/assets', '/webhooks'];
+const NETWORK_ONLY_PATHS = new Set(['/graphql']);
+
+export interface ServiceWorkerPolicy {
+  cacheableShellAsset: boolean;
+  navigationRequest: boolean;
+  networkOnly: boolean;
+}
+
+export function normalizeSameOriginUrl(value: string | undefined, origin: string): string | null {
+  try {
+    const url = new URL(value ?? '/chat', origin);
+    return url.origin === origin ? url.href : null;
+  } catch {
+    return null;
+  }
+}
+
+export function classifyServiceWorkerRequest(
+  request: Pick<Request, 'method' | 'mode' | 'destination'>,
+  requestUrl: string,
+  shellAssetPaths: ReadonlySet<string>,
+  origin: string
+): ServiceWorkerPolicy {
+  const url = new URL(requestUrl);
+  const sameOrigin = url.origin === origin;
+  const networkOnly =
+    request.method !== 'GET' ||
+    !sameOrigin ||
+    NETWORK_ONLY_PATHS.has(url.pathname) ||
+    NETWORK_ONLY_PREFIXES.some(
+      (prefix) => url.pathname === prefix || url.pathname.startsWith(`${prefix}/`)
+    );
+
+  return {
+    cacheableShellAsset: !networkOnly && shellAssetPaths.has(url.pathname),
+    navigationRequest: !networkOnly && request.mode === 'navigate',
+    networkOnly
+  };
+}
+
+export function shouldUseOfflineShellFallback(
+  policy: Pick<ServiceWorkerPolicy, 'navigationRequest'>,
+  networkFailed: boolean
+): boolean {
+  return policy.navigationRequest && networkFailed;
+}

--- a/frontend/src/service-worker.ts
+++ b/frontend/src/service-worker.ts
@@ -1,26 +1,119 @@
 /// <reference lib="webworker" />
+/// <reference types="@sveltejs/kit" />
 
 /**
- * Service Worker for push notifications.
+ * Service Worker for Chatto's PWA shell and push notifications.
  *
- * Handles push events from the browser vendor's push service and displays
- * native OS notifications. Also handles notification clicks to navigate
- * to the relevant content.
+ * Keeps the app shell available during offline launches while leaving live
+ * Chatto data on the network. It also handles Web Push notifications and
+ * notification-click navigation.
  */
 
+import { build, files, version } from '$service-worker';
+import {
+  OFFLINE_SHELL_PATH,
+  classifyServiceWorkerRequest,
+  normalizeSameOriginUrl
+} from '$lib/pwa/serviceWorkerPolicy';
+
 declare const self: ServiceWorkerGlobalScope;
+
+const CACHE_PREFIX = 'chatto-shell';
+const CACHE_NAME = `${CACHE_PREFIX}-${version}`;
+const SHELL_ASSETS = new Set([...build, ...files, OFFLINE_SHELL_PATH]);
+const PRECACHE_ASSETS = Array.from(new Set([...SHELL_ASSETS, '/']));
+
+type BadgeCapableNavigator = Navigator & {
+  setAppBadge?: (contents?: number) => Promise<void>;
+  clearAppBadge?: () => Promise<void>;
+};
 
 /**
  * Immediately activate new service worker versions.
  * Without this, users must close all tabs before updates take effect.
  */
-self.addEventListener('install', () => {
+self.addEventListener('install', (event) => {
   self.skipWaiting();
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => Promise.all(PRECACHE_ASSETS.map((path) => cacheShellAsset(cache, path))))
+  );
 });
 
 self.addEventListener('activate', (event) => {
-  event.waitUntil(self.clients.claim());
+  event.waitUntil(
+    (async () => {
+      const cacheNames = await caches.keys();
+      await Promise.all(
+        cacheNames
+          .filter((cacheName) => cacheName.startsWith(`${CACHE_PREFIX}-`) && cacheName !== CACHE_NAME)
+          .map((cacheName) => caches.delete(cacheName))
+      );
+      await self.clients.claim();
+    })()
+  );
 });
+
+/**
+ * Serve known app-shell assets from the versioned cache. For navigations, try
+ * the network first and fall back to the cached SPA shell only when offline.
+ *
+ * Chat data, API responses, auth endpoints, uploaded assets, and cross-origin
+ * requests stay network-only so stale data never masquerades as live state.
+ */
+self.addEventListener('fetch', (event) => {
+  const policy = classifyServiceWorkerRequest(
+    event.request,
+    event.request.url,
+    SHELL_ASSETS,
+    self.location.origin
+  );
+
+  if (policy.networkOnly) return;
+
+  if (policy.cacheableShellAsset) {
+    event.respondWith(
+      (async () => {
+        const cache = await caches.open(CACHE_NAME);
+        const url = new URL(event.request.url);
+        const cached = await cache.match(url.pathname);
+        return cached ?? fetch(event.request);
+      })()
+    );
+    return;
+  }
+
+  if (policy.navigationRequest) {
+    event.respondWith(
+      (async () => {
+        try {
+          return await fetch(event.request);
+        } catch (err) {
+          const cache = await caches.open(CACHE_NAME);
+          const shell = await getCachedOfflineShell(cache);
+          if (shell) return shell;
+          throw err;
+        }
+      })()
+    );
+  }
+});
+
+async function cacheShellAsset(cache: Cache, path: string): Promise<void> {
+  try {
+    const response = await fetch(path, { cache: 'reload' });
+    if (!response.ok) return;
+    await cache.put(path, response);
+  } catch {
+    // A missing static fallback in local preview must not invalidate the whole
+    // service worker. Production nginx serves the same shell through /200.html.
+  }
+}
+
+async function getCachedOfflineShell(cache: Cache): Promise<Response | undefined> {
+  return (await cache.match(OFFLINE_SHELL_PATH)) ?? cache.match('/');
+}
 
 // Type for push notification payload from server
 interface PushPayload {
@@ -33,6 +126,19 @@ interface PushPayload {
   url?: string;
   // "dismiss" action is used to close notifications on other devices
   action?: 'dismiss';
+}
+
+function setFlagBadge(): Promise<void> {
+  const badgeNavigator = navigator as BadgeCapableNavigator;
+  return badgeNavigator.setAppBadge?.().catch(() => {}) ?? Promise.resolve();
+}
+
+async function clearBadgeIfNoNotificationsRemain(): Promise<void> {
+  const notifications = await self.registration.getNotifications();
+  if (notifications.length > 0) return;
+
+  const badgeNavigator = navigator as BadgeCapableNavigator;
+  await (badgeNavigator.clearAppBadge?.().catch(() => {}) ?? Promise.resolve());
 }
 
 /**
@@ -56,9 +162,11 @@ self.addEventListener('push', (event) => {
   // Handle dismiss action - close matching notifications on this device
   if (payload.action === 'dismiss' && payload.tag) {
     event.waitUntil(
-      self.registration.getNotifications({ tag: payload.tag }).then((notifications) => {
+      (async () => {
+        const notifications = await self.registration.getNotifications({ tag: payload.tag });
         notifications.forEach((n) => n.close());
-      })
+        await clearBadgeIfNoNotificationsRemain();
+      })()
     );
     return;
   }
@@ -76,7 +184,12 @@ self.addEventListener('push', (event) => {
     }
   };
 
-  event.waitUntil(self.registration.showNotification(payload.title ?? 'New notification', options));
+  event.waitUntil(
+    Promise.all([
+      self.registration.showNotification(payload.title ?? 'New notification', options),
+      setFlagBadge()
+    ])
+  );
 });
 
 /**
@@ -88,17 +201,10 @@ self.addEventListener('push', (event) => {
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();
 
-  const path = event.notification.data?.url ?? '/chat';
-  // Build absolute URL for openWindow (required by some browsers).
-  // Reject any URL that resolves to a different origin — `new URL(absUrl, origin)`
-  // returns the absolute URL when its first arg is already absolute, so a push
-  // payload with `data.url = "https://attacker.example/"` would otherwise
-  // navigate the user there.
-  const candidate = new URL(path, self.location.origin);
-  if (candidate.origin !== self.location.origin) {
-    return;
-  }
-  const url = candidate.href;
+  const rawUrl =
+    typeof event.notification.data?.url === 'string' ? event.notification.data.url : undefined;
+  const url = normalizeSameOriginUrl(rawUrl, self.location.origin);
+  if (!url) return;
 
   event.waitUntil(
     (async () => {


### PR DESCRIPTION
- Adds versioned app-shell caching in the service worker while keeping Chatto API, auth, live, and uploaded asset requests network-only.
- Moves service-worker request/url policy into tested pure helpers and relies on SvelteKit for production registration.
- Documents the PWA shell behavior in FDR-027 and the frontend conventions.
- Verified with `pnpm test:unit --run --project server src/lib/pwa/serviceWorkerPolicy.spec.ts`, `pnpm check`, `pnpm build`, `pnpm lint`, and an offline preview smoke test.
