### PR TITLE
feat(web): enforce canonical server URLs

### DIFF
--- a/cli/internal/http_server/canonical_url.go
+++ b/cli/internal/http_server/canonical_url.go
@@ -39,10 +39,16 @@ func incomingRequestOrigin(c *gin.Context) string {
 	return scheme + "://" + strings.ToLower(c.Request.Host)
 }
 
+func isHealthProbePath(path string) bool {
+	return path == "/healthz" || path == "/readyz"
+}
+
 func (s *HTTPServer) canonicalRedirectMiddleware() gin.HandlerFunc {
 	canonicalOrigin := canonicalServerOrigin(s.config.Webserver.URL)
 	return func(c *gin.Context) {
-		if canonicalOrigin == "" || incomingRequestOrigin(c) == canonicalOrigin {
+		if canonicalOrigin == "" ||
+			isHealthProbePath(c.Request.URL.Path) ||
+			incomingRequestOrigin(c) == canonicalOrigin {
 			c.Next()
 			return
 		}

--- a/cli/internal/http_server/canonical_url.go
+++ b/cli/internal/http_server/canonical_url.go
@@ -31,7 +31,7 @@ func canonicalServerOrigin(webserverURL string) string {
 func incomingRequestOrigin(c *gin.Context) string {
 	scheme := "http"
 	if proto := c.GetHeader("X-Forwarded-Proto"); proto != "" {
-		scheme = firstForwardedHeaderValue(proto)
+		scheme = forwardedProtoToHTTPScheme(firstForwardedHeaderValue(proto))
 	} else if c.Request.TLS != nil {
 		scheme = "https"
 	}
@@ -46,6 +46,17 @@ func incomingRequestOrigin(c *gin.Context) string {
 
 func firstForwardedHeaderValue(value string) string {
 	return strings.ToLower(strings.TrimSpace(strings.Split(value, ",")[0]))
+}
+
+func forwardedProtoToHTTPScheme(proto string) string {
+	switch proto {
+	case "ws":
+		return "http"
+	case "wss":
+		return "https"
+	default:
+		return proto
+	}
 }
 
 func isHealthProbePath(path string) bool {

--- a/cli/internal/http_server/canonical_url.go
+++ b/cli/internal/http_server/canonical_url.go
@@ -31,12 +31,21 @@ func canonicalServerOrigin(webserverURL string) string {
 func incomingRequestOrigin(c *gin.Context) string {
 	scheme := "http"
 	if proto := c.GetHeader("X-Forwarded-Proto"); proto != "" {
-		scheme = strings.ToLower(strings.TrimSpace(strings.Split(proto, ",")[0]))
+		scheme = firstForwardedHeaderValue(proto)
 	} else if c.Request.TLS != nil {
 		scheme = "https"
 	}
 
-	return scheme + "://" + strings.ToLower(c.Request.Host)
+	host := c.Request.Host
+	if forwardedHost := c.GetHeader("X-Forwarded-Host"); forwardedHost != "" {
+		host = firstForwardedHeaderValue(forwardedHost)
+	}
+
+	return scheme + "://" + strings.ToLower(strings.TrimSpace(host))
+}
+
+func firstForwardedHeaderValue(value string) string {
+	return strings.ToLower(strings.TrimSpace(strings.Split(value, ",")[0]))
 }
 
 func isHealthProbePath(path string) bool {

--- a/cli/internal/http_server/canonical_url.go
+++ b/cli/internal/http_server/canonical_url.go
@@ -1,0 +1,54 @@
+package http_server
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// canonicalServerOrigin returns the configured public origin (scheme + host)
+// for a Chatto server. Empty or malformed config means canonicalization is off.
+func canonicalServerOrigin(webserverURL string) string {
+	if webserverURL == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(webserverURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return ""
+	}
+
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return ""
+	}
+
+	return scheme + "://" + strings.ToLower(parsed.Host)
+}
+
+func incomingRequestOrigin(c *gin.Context) string {
+	scheme := "http"
+	if proto := c.GetHeader("X-Forwarded-Proto"); proto != "" {
+		scheme = strings.ToLower(strings.TrimSpace(strings.Split(proto, ",")[0]))
+	} else if c.Request.TLS != nil {
+		scheme = "https"
+	}
+
+	return scheme + "://" + strings.ToLower(c.Request.Host)
+}
+
+func (s *HTTPServer) canonicalRedirectMiddleware() gin.HandlerFunc {
+	canonicalOrigin := canonicalServerOrigin(s.config.Webserver.URL)
+	return func(c *gin.Context) {
+		if canonicalOrigin == "" || incomingRequestOrigin(c) == canonicalOrigin {
+			c.Next()
+			return
+		}
+
+		target := canonicalOrigin + c.Request.URL.RequestURI()
+		c.Redirect(http.StatusPermanentRedirect, target)
+		c.Abort()
+	}
+}

--- a/cli/internal/http_server/canonical_url_test.go
+++ b/cli/internal/http_server/canonical_url_test.go
@@ -1,0 +1,69 @@
+package http_server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"hmans.de/chatto/internal/config"
+)
+
+func newCanonicalRedirectTestRouter(webserverURL string) *gin.Engine {
+	server := &HTTPServer{
+		config: config.ChattoConfig{Webserver: config.WebserverConfig{URL: webserverURL}},
+	}
+	router := gin.New()
+	router.Use(server.canonicalRedirectMiddleware())
+	router.Any("/*path", func(c *gin.Context) {
+		c.String(http.StatusOK, "content")
+	})
+	return router
+}
+
+func TestCanonicalRedirectMiddlewareRedirectsAliasRequests(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := newCanonicalRedirectTestRouter("https://chat.example.com")
+
+	req := httptest.NewRequest("POST", "/api/graphql?operation=Ping", nil)
+	req.Host = "alias.example.com"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusPermanentRedirect, w.Code)
+	assert.Equal(t, "https://chat.example.com/api/graphql?operation=Ping", w.Header().Get("Location"))
+}
+
+func TestCanonicalRedirectMiddlewareExemptsHealthProbes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := newCanonicalRedirectTestRouter("https://chat.example.com")
+
+	for _, path := range []string{"/healthz", "/readyz"} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest("GET", path, nil)
+			req.Host = "alias.example.com"
+			req.Header.Set("X-Forwarded-Proto", "https")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Empty(t, w.Header().Get("Location"))
+		})
+	}
+}
+
+func TestCanonicalRedirectMiddlewareDoesNotExemptHealthProbePrefixes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := newCanonicalRedirectTestRouter("https://chat.example.com")
+
+	req := httptest.NewRequest("GET", "/healthz/details", nil)
+	req.Host = "alias.example.com"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusPermanentRedirect, w.Code)
+	assert.Equal(t, "https://chat.example.com/healthz/details", w.Header().Get("Location"))
+}

--- a/cli/internal/http_server/canonical_url_test.go
+++ b/cli/internal/http_server/canonical_url_test.go
@@ -51,6 +51,23 @@ func TestCanonicalRedirectMiddlewareHonorsForwardedHost(t *testing.T) {
 	assert.Empty(t, w.Header().Get("Location"))
 }
 
+func TestCanonicalRedirectMiddlewareHonorsForwardedWebSocketHost(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := newCanonicalRedirectTestRouter("http://localhost:55080")
+
+	req := httptest.NewRequest("GET", "/api/graphql", nil)
+	req.Host = "localhost:55081"
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("X-Forwarded-Proto", "ws")
+	req.Header.Set("X-Forwarded-Host", "localhost:55080")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get("Location"))
+}
+
 func TestCanonicalRedirectMiddlewareExemptsHealthProbes(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := newCanonicalRedirectTestRouter("https://chat.example.com")

--- a/cli/internal/http_server/canonical_url_test.go
+++ b/cli/internal/http_server/canonical_url_test.go
@@ -36,6 +36,21 @@ func TestCanonicalRedirectMiddlewareRedirectsAliasRequests(t *testing.T) {
 	assert.Equal(t, "https://chat.example.com/api/graphql?operation=Ping", w.Header().Get("Location"))
 }
 
+func TestCanonicalRedirectMiddlewareHonorsForwardedHost(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := newCanonicalRedirectTestRouter("http://localhost:55080")
+
+	req := httptest.NewRequest("POST", "/api/graphql", nil)
+	req.Host = "localhost:55081"
+	req.Header.Set("X-Forwarded-Proto", "http")
+	req.Header.Set("X-Forwarded-Host", "localhost:55080")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get("Location"))
+}
+
 func TestCanonicalRedirectMiddlewareExemptsHealthProbes(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := newCanonicalRedirectTestRouter("https://chat.example.com")

--- a/cli/internal/http_server/frontend_test.go
+++ b/cli/internal/http_server/frontend_test.go
@@ -287,6 +287,92 @@ func TestServeSPAFallback(t *testing.T) {
 	})
 }
 
+func TestCanonicalRedirect(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	newRouter := func(webserverURL string) *gin.Engine {
+		server := &HTTPServer{
+			config: config.ChattoConfig{Webserver: config.WebserverConfig{URL: webserverURL}},
+		}
+		router := gin.New()
+		router.Use(server.canonicalRedirectMiddleware())
+		router.Any("/*path", func(c *gin.Context) {
+			c.String(http.StatusOK, "content")
+		})
+		return router
+	}
+
+	t.Run("redirects alias-host requests to configured origin", func(t *testing.T) {
+		router := newRouter("https://chat.example.com")
+
+		req := httptest.NewRequest("GET", "/chat/-/room-1?thread=abc", nil)
+		req.Host = "alias.example.com"
+		req.Header.Set("X-Forwarded-Proto", "https")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusPermanentRedirect, w.Code)
+		assert.Equal(t, "https://chat.example.com/chat/-/room-1?thread=abc", w.Header().Get("Location"))
+	})
+
+	t.Run("redirects alias-host requests for any method and path", func(t *testing.T) {
+		router := newRouter("https://chat.example.com")
+
+		tests := []struct {
+			method string
+			path   string
+		}{
+			{method: "HEAD", path: "/chat/-"},
+			{method: "POST", path: "/api/graphql"},
+			{method: "OPTIONS", path: "/api/server"},
+			{method: "GET", path: "/_app/immutable/app.hash.js"},
+			{method: "GET", path: "/assets/attachments/test"},
+			{method: "GET", path: "/healthz"},
+			{method: "GET", path: "/webhooks/livekit"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.method+" "+tt.path, func(t *testing.T) {
+				req := httptest.NewRequest(tt.method, tt.path, nil)
+				req.Host = "alias.example.com"
+				req.Header.Set("X-Forwarded-Proto", "https")
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
+
+				assert.Equal(t, http.StatusPermanentRedirect, w.Code)
+				assert.Equal(t, "https://chat.example.com"+tt.path, w.Header().Get("Location"))
+			})
+		}
+	})
+
+	t.Run("does not redirect canonical-host requests", func(t *testing.T) {
+		router := newRouter("https://chat.example.com")
+
+		req := httptest.NewRequest("GET", "/chat/-", nil)
+		req.Host = "chat.example.com"
+		req.Header.Set("X-Forwarded-Proto", "https")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "content", w.Body.String())
+		assert.Empty(t, w.Header().Get("Location"))
+	})
+
+	t.Run("does not redirect when webserver url is unset", func(t *testing.T) {
+		router := newRouter("")
+
+		req := httptest.NewRequest("GET", "/chat/-", nil)
+		req.Host = "alias.example.com"
+		req.Header.Set("X-Forwarded-Proto", "https")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Empty(t, w.Header().Get("Location"))
+	})
+}
+
 func TestSecurityHeaders(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/cli/internal/http_server/frontend_test.go
+++ b/cli/internal/http_server/frontend_test.go
@@ -327,7 +327,6 @@ func TestCanonicalRedirect(t *testing.T) {
 			{method: "OPTIONS", path: "/api/server"},
 			{method: "GET", path: "/_app/immutable/app.hash.js"},
 			{method: "GET", path: "/assets/attachments/test"},
-			{method: "GET", path: "/healthz"},
 			{method: "GET", path: "/webhooks/livekit"},
 		}
 
@@ -370,6 +369,24 @@ func TestCanonicalRedirect(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Empty(t, w.Header().Get("Location"))
+	})
+
+	t.Run("does not redirect health probes", func(t *testing.T) {
+		router := newRouter("https://chat.example.com")
+
+		for _, path := range []string{"/healthz", "/readyz"} {
+			t.Run(path, func(t *testing.T) {
+				req := httptest.NewRequest("GET", path, nil)
+				req.Host = "alias.example.com"
+				req.Header.Set("X-Forwarded-Proto", "https")
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
+
+				assert.Equal(t, http.StatusOK, w.Code)
+				assert.Equal(t, "content", w.Body.String())
+				assert.Empty(t, w.Header().Get("Location"))
+			})
+		}
 	})
 }
 

--- a/cli/internal/http_server/server.go
+++ b/cli/internal/http_server/server.go
@@ -100,6 +100,8 @@ func newHTTPServer(addr string, handler http.Handler) *http.Server {
 }
 
 func (s *HTTPServer) setupRoutes() error {
+	s.router.Use(s.canonicalRedirectMiddleware())
+
 	// SESSION MANAGEMENT
 
 	// Configure session middleware

--- a/cli/internal/http_server/server_info.go
+++ b/cli/internal/http_server/server_info.go
@@ -9,6 +9,7 @@ import (
 
 // serverInfoResponse is the JSON response for GET /api/server.
 type serverInfoResponse struct {
+	URL              string   `json:"url,omitempty"`
 	Name             string   `json:"name"`
 	Version          string   `json:"version"`
 	AuthMethods      []string `json:"authMethods"`
@@ -95,6 +96,7 @@ func (s *HTTPServer) handleServerInfo(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, serverInfoResponse{
+		URL:              canonicalServerOrigin(s.config.Webserver.URL),
 		Name:             name,
 		Version:          s.version,
 		AuthMethods:      authMethods,

--- a/cli/internal/http_server/server_info_test.go
+++ b/cli/internal/http_server/server_info_test.go
@@ -38,7 +38,7 @@ func bannerImageBytes(t *testing.T) io.Reader {
 }
 
 // setupServerInfoServer creates a minimal HTTPServer for instance info endpoint tests.
-func setupServerInfoServer(t *testing.T, authConfig config.AuthConfig) *HTTPServer {
+func setupServerInfoServer(t *testing.T, authConfig config.AuthConfig, webserverURL ...string) *HTTPServer {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
@@ -53,10 +53,16 @@ func setupServerInfoServer(t *testing.T, authConfig config.AuthConfig) *HTTPServ
 	}
 	startCoreServices(t, chattoCore)
 
+	url := ""
+	if len(webserverURL) > 0 {
+		url = webserverURL[0]
+	}
+
 	router := gin.New()
 	s := &HTTPServer{
 		config: config.ChattoConfig{
-			Auth: authConfig,
+			Auth:      authConfig,
+			Webserver: config.WebserverConfig{URL: url},
 		},
 		nc:      nc,
 		router:  router,
@@ -171,6 +177,55 @@ func TestServerInfo(t *testing.T) {
 
 		if resp.AuthorizeURL != "/oauth/authorize" {
 			t.Errorf("expected authorizeUrl '/oauth/authorize', got %q", resp.AuthorizeURL)
+		}
+	})
+
+	t.Run("includes canonical url when webserver url is configured", func(t *testing.T) {
+		s := setupServerInfoServer(t, config.AuthConfig{}, "https://chat.example.com/some/path")
+
+		req := httptest.NewRequest("GET", "/api/server", nil)
+		w := httptest.NewRecorder()
+		s.router.ServeHTTP(w, req)
+
+		var resp serverInfoResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to parse response: %v", err)
+		}
+
+		if resp.URL != "https://chat.example.com" {
+			t.Errorf("expected canonical url https://chat.example.com, got %q", resp.URL)
+		}
+	})
+
+	t.Run("omits canonical url when webserver url is unset", func(t *testing.T) {
+		s := setupServerInfoServer(t, config.AuthConfig{})
+
+		req := httptest.NewRequest("GET", "/api/server", nil)
+		w := httptest.NewRecorder()
+		s.router.ServeHTTP(w, req)
+
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+			t.Fatalf("failed to parse response: %v", err)
+		}
+		if _, present := raw["url"]; present {
+			t.Errorf("expected url absent when webserver.url is unset, got %s", string(raw["url"]))
+		}
+	})
+
+	t.Run("omits canonical url when webserver url is invalid", func(t *testing.T) {
+		s := setupServerInfoServer(t, config.AuthConfig{}, "chat.example.com")
+
+		req := httptest.NewRequest("GET", "/api/server", nil)
+		w := httptest.NewRecorder()
+		s.router.ServeHTTP(w, req)
+
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+			t.Fatalf("failed to parse response: %v", err)
+		}
+		if _, present := raw["url"]; present {
+			t.Errorf("expected url absent when webserver.url is invalid, got %s", string(raw["url"]))
 		}
 	})
 

--- a/docs-website/src/content/docs/reference/environment-variables.mdx
+++ b/docs-website/src/content/docs/reference/environment-variables.mdx
@@ -16,7 +16,7 @@ Every `chatto.toml` setting can be overridden with an environment variable. The 
 ## Web Server
 
 <EnvVar name="CHATTO_WEBSERVER_URL" toml="webserver.url" required>
-  Public URL of the server, used for absolute links and OAuth redirects.
+  Public URL of the server, used for absolute links, OAuth redirects, canonical-host redirects, and multi-server discovery.
 </EnvVar>
 
 <EnvVar name="CHATTO_WEBSERVER_PORT" toml="webserver.port" default="4000">

--- a/docs/adr/ADR-025-multi-instance-client-architecture.md
+++ b/docs/adr/ADR-025-multi-instance-client-architecture.md
@@ -16,7 +16,7 @@ Users wanted to connect to multiple Chatto instances from a single client (simil
 
 The frontend is instance-agnostic by default. It doesn't assume it's served by a Chatto instance. Instead:
 
-1. **Probe-based origin detection**: On init, fetch `/api/server` on the current origin. If it responds, auto-register the origin as an instance. If it fails (static hosting), skip.
+1. **Probe-based origin detection**: On init, fetch `/api/server` on the current origin. If it responds, auto-register the origin as an instance. If it fails (static hosting), skip. Servers with `webserver.url` configured redirect alias-host requests to that canonical origin and expose the same origin as `/api/server.url`.
 2. **No `isHome` flag**: The origin instance is identified by comparing `instance.url` to `window.location.origin` at runtime — no stored flag.
 3. **Dual auth**: Origin uses cookie auth (HttpOnly, SameSite). Remote instances use opaque bearer tokens stored in `localStorage`.
 
@@ -53,7 +53,7 @@ Bearer tokens use NATS KV TTL (default 90 days). Each successful `ValidateAuthTo
 ### Negative
 
 - Remote instance bearer tokens in `localStorage` are vulnerable to XSS (cookie auth is not)
-- `/api/server` is the only cross-origin endpoint (wildcard CORS) — rich data needed pre-registration must go there, not in GraphQL
+- `/api/server` is the only cross-origin endpoint (wildcard CORS) — rich data needed pre-registration must go there, not in GraphQL. Remote add-server flows use its `url` field, when present, as the canonical server origin for OAuth and registry storage.
 - The probe is async for unauthenticated users, so the origin may not be registered by the time the first render completes
 
 ### Trade-offs

--- a/frontend/e2e/fixtures/multiServer.ts
+++ b/frontend/e2e/fixtures/multiServer.ts
@@ -14,7 +14,7 @@ export async function startSecondServer(testInfo: TestInfo): Promise<ServerInfo>
 		parallelIndex: testInfo.parallelIndex + 5
 	} as TestInfo;
 
-	return startServer(modifiedTestInfo);
+	return startServer(modifiedTestInfo, { publicHost: '127.0.0.1' });
 }
 
 /**

--- a/frontend/e2e/fixtures/server.ts
+++ b/frontend/e2e/fixtures/server.ts
@@ -67,6 +67,8 @@ async function waitForServer(port: number, timeoutMs = 45000): Promise<void> {
 }
 
 export interface StartServerOptions {
+  /** Hostname advertised as this server's canonical public URL */
+  publicHost?: string;
   /** Additional environment variables for the server process */
   env?: Record<string, string>;
 }
@@ -80,6 +82,8 @@ export async function startServer(
   options: StartServerOptions = {}
 ): Promise<ServerInfo> {
   const ports = getPortsForTest(testInfo.workerIndex, testInfo.parallelIndex);
+  const publicHost = options.publicHost ?? 'localhost';
+  const baseURL = `http://${publicHost}:${ports.webserver}`;
   // Use testId for unique data directory per test
   const dataDir = path.join(__dirname, `data-${testInfo.testId.replace(/[^a-zA-Z0-9]/g, '-')}`);
 
@@ -97,13 +101,13 @@ export async function startServer(
       cwd: __dirname,
       env: {
         ...process.env,
-        ...options.env,
         CHATTO_WEBSERVER_PORT: String(ports.webserver),
-        CHATTO_WEBSERVER_URL: `http://localhost:${ports.webserver}`,
+        CHATTO_WEBSERVER_URL: baseURL,
         CHATTO_NATS_EMBEDDED_PORT: '0',
         CHATTO_NATS_EMBEDDED_HTTP_PORT: '0',
         CHATTO_NATS_EMBEDDED_DATA_DIR: dataDir,
-        CHATTO_TEST_EMAIL_ENDPOINT: 'true' // Enable test email endpoint for E2E tests
+        CHATTO_TEST_EMAIL_ENDPOINT: 'true', // Enable test email endpoint for E2E tests
+        ...options.env
       },
       stdio: ['ignore', 'pipe', 'pipe']
     }
@@ -128,7 +132,7 @@ export async function startServer(
   await waitForServer(ports.webserver);
 
   return {
-    baseURL: `http://localhost:${ports.webserver}`,
+    baseURL,
     port: ports.webserver,
     process: serverProcess
   };

--- a/frontend/src/lib/components/AddServerDialog.svelte
+++ b/frontend/src/lib/components/AddServerDialog.svelte
@@ -144,8 +144,7 @@ ADR-027 — only user-facing copy says "server".
     if (url.origin !== serverUrl) {
       throw new Error('This server returned an invalid sign-in URL.');
     }
-    url.search = params.toString();
-    return url.toString();
+    return `${url.origin}${url.pathname}?${params}`;
   }
 
   async function handleProbe() {

--- a/frontend/src/lib/components/AddServerDialog.svelte
+++ b/frontend/src/lib/components/AddServerDialog.svelte
@@ -32,6 +32,7 @@ ADR-027 — only user-facing copy says "server".
   } = $props();
 
   type InstanceInfo = {
+    url?: string;
     name: string;
     version?: string;
     authMethods: string[];
@@ -116,6 +117,37 @@ ADR-027 — only user-facing copy says "server".
     }
   }
 
+  function findConnectedServer(url: string) {
+    const normalizedUrl = normalizeUrl(url).toLowerCase();
+    return serverRegistry.servers.find(
+      (server) => normalizeUrl(server.url).toLowerCase() === normalizedUrl
+        && (server.token || server.userId)
+    );
+  }
+
+  function canonicalUrlFromInfo(info: InstanceInfo, fallbackUrl: string): string {
+    if (!info.url) return fallbackUrl;
+
+    try {
+      const parsed = new URL(info.url.trim());
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        throw new Error('unsupported scheme');
+      }
+      return parsed.origin;
+    } catch {
+      throw new Error('This server returned an invalid canonical URL.');
+    }
+  }
+
+  function authorizeUrlForServer(serverUrl: string, authorizeUrl: string, params: URLSearchParams): string {
+    const url = new URL(authorizeUrl, serverUrl);
+    if (url.origin !== serverUrl) {
+      throw new Error('This server returned an invalid sign-in URL.');
+    }
+    url.search = params.toString();
+    return url.toString();
+  }
+
   async function handleProbe() {
     formError = '';
 
@@ -128,10 +160,7 @@ ADR-027 — only user-facing copy says "server".
       return;
     }
 
-    const existing = serverRegistry.servers.find(
-      (i) => i.url.toLowerCase() === url.toLowerCase()
-    );
-    if (existing && (existing.token || existing.userId)) {
+    if (findConnectedServer(url)) {
       formError = 'This server is already connected.';
       return;
     }
@@ -158,7 +187,13 @@ ADR-027 — only user-facing copy says "server".
         return;
       }
 
-      probedUrl = probedFromUrl;
+      const canonicalUrl = canonicalUrlFromInfo(info, probedFromUrl);
+      if (findConnectedServer(canonicalUrl)) {
+        formError = 'This server is already connected.';
+        return;
+      }
+
+      probedUrl = canonicalUrl;
       probedInfo = info;
       stage = 'preview';
     } catch (err) {
@@ -202,7 +237,7 @@ ADR-027 — only user-facing copy says "server".
         state
       });
 
-      window.location.href = `${probedUrl}${probedInfo.authorizeUrl}?${params}`;
+      window.location.href = authorizeUrlForServer(probedUrl, probedInfo.authorizeUrl, params);
     } catch (err) {
       connecting = false;
       formError = err instanceof Error ? err.message : 'Failed to start sign-in.';

--- a/frontend/src/lib/components/AddServerDialog.svelte.spec.ts
+++ b/frontend/src/lib/components/AddServerDialog.svelte.spec.ts
@@ -130,6 +130,43 @@ describe('AddServerDialog', () => {
     expect(visible).toBe(true);
   });
 
+  it('uses the advertised canonical URL when probing an alias', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      makeProbeResponse({
+        url: 'https://chat.example.com',
+        name: 'Canonical Chatto',
+        version: '0.1.0',
+        authMethods: ['password'],
+        registrationOpen: true,
+        authorizeUrl: '/oauth/authorize'
+      })
+    ) as unknown as typeof fetch;
+
+    const { container } = render(AddServerDialog, {
+      props: { visible: true, onclose: () => {} }
+    });
+
+    const input = container.querySelector<HTMLInputElement>('#add-server-url')!;
+    input.value = 'https://alias.example.com';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+
+    container.querySelector('form')!.requestSubmit();
+
+    await vi.waitFor(() => {
+      const submit = container.querySelector<HTMLButtonElement>('button[type="submit"]');
+      expect(submit?.textContent ?? '').toMatch(/^\s*Sign in\s*$/);
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://alias.example.com/api/server',
+      expect.any(Object)
+    );
+    expect(container.textContent).toContain('Canonical Chatto');
+    expect(container.textContent).toContain('chat.example.com');
+    expect(container.textContent).not.toContain('alias.example.com');
+  });
+
   it('shows an error when the probe response is not a Chatto server', async () => {
     globalThis.fetch = vi.fn(async () =>
       makeProbeResponse({ unrelated: true })
@@ -186,5 +223,53 @@ describe('AddServerDialog', () => {
     });
 
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('blocks adding an alias for an already connected canonical server', async () => {
+    serverRegistry.servers = [
+      {
+        id: 'remote',
+        url: 'https://chat.example.com',
+        name: 'Remote',
+        iconUrl: null,
+        token: 'abc',
+        userId: 'user-1',
+        userLogin: 'someone',
+        userDisplayName: null,
+        userAvatarUrl: null,
+        addedAt: 0
+      }
+    ];
+
+    globalThis.fetch = vi.fn(async () =>
+      makeProbeResponse({
+        url: 'https://chat.example.com',
+        name: 'Remote',
+        version: '0.1.0',
+        authMethods: ['password'],
+        registrationOpen: true,
+        authorizeUrl: '/oauth/authorize'
+      })
+    ) as unknown as typeof fetch;
+
+    const { container } = render(AddServerDialog, {
+      props: { visible: true, onclose: () => {} }
+    });
+
+    const input = container.querySelector<HTMLInputElement>('#add-server-url')!;
+    input.value = 'https://alias.example.com';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+
+    container.querySelector('form')!.requestSubmit();
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('already connected');
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://alias.example.com/api/server',
+      expect.any(Object)
+    );
   });
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -46,12 +46,14 @@ export default defineConfig({
     proxy: {
       '/playground': {
         target: backendTarget,
-        changeOrigin: true
+        changeOrigin: true,
+        xfwd: true
       },
       '/api': {
         target: backendTarget,
         ws: true,
         changeOrigin: true,
+        xfwd: true,
         secure: false,
         cookieDomainRewrite: { '*': '' },
         // Rewrite the Origin header on WebSocket upgrades so the
@@ -61,15 +63,18 @@ export default defineConfig({
       '/auth': {
         target: backendTarget,
         changeOrigin: true,
+        xfwd: true,
         cookieDomainRewrite: { '*': '' }
       },
       '/assets': {
         target: backendTarget,
-        changeOrigin: true
+        changeOrigin: true,
+        xfwd: true
       },
       '/webhooks': {
         target: backendTarget,
-        changeOrigin: true
+        changeOrigin: true,
+        xfwd: true
       }
     }
   },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -54,11 +54,16 @@ export default defineConfig({
         ws: true,
         changeOrigin: true,
         xfwd: true,
+        configure: (proxy) => {
+          proxy.on('proxyReqWs', (proxyReq, req) => {
+            const forwardedHost = req.headers.host;
+            if (forwardedHost) {
+              proxyReq.setHeader('X-Forwarded-Host', forwardedHost);
+            }
+          });
+        },
         secure: false,
-        cookieDomainRewrite: { '*': '' },
-        // Rewrite the Origin header on WebSocket upgrades so the
-        // backend's CheckOrigin accepts the connection.
-        rewriteWsOrigin: true
+        cookieDomainRewrite: { '*': '' }
       },
       '/auth': {
         target: backendTarget,


### PR DESCRIPTION
## Changes
- Redirect alias-host requests to the configured `webserver.url` with a backend `308`, preserving path and query.
- Expose the canonical server origin from `/api/server` and make the add-server flow use it for OAuth and registry storage.
- Update ADR-025 and the self-hosting environment-variable docs.

## Tests
- `cd cli && mise x -- go test ./internal/http_server -run 'Test(ServerInfo|CanonicalRedirect)' -timeout 30s`
- `cd frontend && mise x -- pnpm vitest run src/lib/components/AddServerDialog.svelte.spec.ts`
- `cd frontend && mise x -- pnpm check`
