### PR TITLE
feat: add s3 asset path prefix

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -117,6 +117,7 @@ const (
 type S3Config struct {
 	Endpoint        string `toml:"endpoint" env:"CHATTO_CORE_ASSETS_S3_ENDPOINT" comment:"S3 endpoint URL. Use 's3.amazonaws.com' for AWS, or custom endpoint for MinIO, Wasabi, etc."`
 	Bucket          string `toml:"bucket" env:"CHATTO_CORE_ASSETS_S3_BUCKET" comment:"S3 bucket name for storing assets."`
+	PathPrefix      string `toml:"path_prefix" env:"CHATTO_CORE_ASSETS_S3_PATH_PREFIX" comment:"Optional object key prefix for all S3 assets. Stored asset references remain prefix-free so this can be changed after moving objects in S3."`
 	Region          string `toml:"region" env:"CHATTO_CORE_ASSETS_S3_REGION" comment:"AWS region. Optional for non-AWS S3-compatible services."`
 	AccessKeyID     string `toml:"access_key_id" env:"CHATTO_CORE_ASSETS_S3_ACCESS_KEY_ID" comment:"S3 access key ID."`
 	SecretAccessKey string `toml:"secret_access_key" env:"CHATTO_CORE_ASSETS_S3_SECRET_ACCESS_KEY" comment:"S3 secret access key. NEVER SHARE THIS!"`
@@ -138,6 +139,26 @@ func (c *S3Config) PathStyleOrDefault() bool {
 		return false
 	}
 	return *c.PathStyle
+}
+
+// NormalizePathPrefix trims harmless leading/trailing slashes from the S3
+// object prefix. Empty and "/" both preserve the historical bucket-root layout.
+func (c *S3Config) NormalizePathPrefix() {
+	c.PathPrefix = strings.Trim(c.PathPrefix, "/")
+}
+
+// ValidatePathPrefix rejects ambiguous prefixes before they become physical
+// object keys. Call NormalizePathPrefix first so "/" is accepted as empty.
+func (c *S3Config) ValidatePathPrefix() error {
+	if strings.Contains(c.PathPrefix, "//") {
+		return fmt.Errorf("core.assets.s3.path_prefix must not contain empty path segments")
+	}
+	for _, r := range c.PathPrefix {
+		if r < 0x20 || r == 0x7f {
+			return fmt.Errorf("core.assets.s3.path_prefix must not contain control characters")
+		}
+	}
+	return nil
 }
 
 // TTLOrDefault returns the configured TTL, or 7 days if not set.
@@ -619,6 +640,7 @@ func (c *ChattoConfig) Validate() error {
 
 	// S3 configuration (required when storage_backend = "s3")
 	if c.Core.Assets.StorageBackend == StorageBackendS3 {
+		c.Core.Assets.S3.NormalizePathPrefix()
 		if c.Core.Assets.S3.Endpoint == "" {
 			errs = append(errs, "core.assets.s3.endpoint is required when storage_backend = 's3'")
 		}
@@ -630,6 +652,9 @@ func (c *ChattoConfig) Validate() error {
 		}
 		if c.Core.Assets.S3.SecretAccessKey == "" {
 			errs = append(errs, "core.assets.s3.secret_access_key is required when storage_backend = 's3'")
+		}
+		if err := c.Core.Assets.S3.ValidatePathPrefix(); err != nil {
+			errs = append(errs, err.Error())
 		}
 	}
 

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -126,6 +126,58 @@ signing_secret = "file-assets-secret"
 	}
 }
 
+func TestReadConfig_S3PathPrefixFromTOMLAndEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(originalDir) })
+
+	configContent := `
+[webserver]
+port = 5000
+cookie_signing_secret = "file-cookie-secret"
+
+[core]
+secret_key = "file-core-secret"
+
+[core.assets]
+signing_secret = "file-assets-secret"
+storage_backend = "s3"
+
+[core.assets.s3]
+endpoint = "s3.amazonaws.com"
+bucket = "test-bucket"
+path_prefix = "/tenant-a/chatto/"
+access_key_id = "test-key"
+secret_access_key = "test-secret"
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "chatto.toml"), []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	cfg, err := ReadConfig("")
+	if err != nil {
+		t.Fatalf("ReadConfig() failed: %v", err)
+	}
+	if cfg.Core.Assets.S3.PathPrefix != "tenant-a/chatto" {
+		t.Fatalf("expected normalized TOML prefix, got %q", cfg.Core.Assets.S3.PathPrefix)
+	}
+
+	t.Setenv("CHATTO_CORE_ASSETS_S3_PATH_PREFIX", "/tenant-b/chatto/")
+	cfg, err = ReadConfig("")
+	if err != nil {
+		t.Fatalf("ReadConfig() with env override failed: %v", err)
+	}
+	if cfg.Core.Assets.S3.PathPrefix != "tenant-b/chatto" {
+		t.Fatalf("expected normalized env prefix, got %q", cfg.Core.Assets.S3.PathPrefix)
+	}
+}
+
 func TestReadConfig_SMTPPolicyFromEnv(t *testing.T) {
 	tmpDir := t.TempDir()
 	originalDir, err := os.Getwd()
@@ -870,6 +922,64 @@ func TestChattoConfig_Validate_S3(t *testing.T) {
 				}
 			},
 			wantError: false,
+		},
+		{
+			name: "valid S3 backend with empty path prefix",
+			modify: func(c *ChattoConfig) {
+				c.Core.Assets.StorageBackend = StorageBackendS3
+				c.Core.Assets.S3 = S3Config{
+					Endpoint:        "s3.amazonaws.com",
+					Bucket:          "test-bucket",
+					PathPrefix:      "/",
+					AccessKeyID:     "test-key",
+					SecretAccessKey: "test-secret",
+				}
+			},
+			wantError: false,
+		},
+		{
+			name: "valid S3 backend normalizes path prefix",
+			modify: func(c *ChattoConfig) {
+				c.Core.Assets.StorageBackend = StorageBackendS3
+				c.Core.Assets.S3 = S3Config{
+					Endpoint:        "s3.amazonaws.com",
+					Bucket:          "test-bucket",
+					PathPrefix:      "/tenant-a/chatto/",
+					AccessKeyID:     "test-key",
+					SecretAccessKey: "test-secret",
+				}
+			},
+			wantError: false,
+		},
+		{
+			name: "S3 backend with empty path segment fails",
+			modify: func(c *ChattoConfig) {
+				c.Core.Assets.StorageBackend = StorageBackendS3
+				c.Core.Assets.S3 = S3Config{
+					Endpoint:        "s3.amazonaws.com",
+					Bucket:          "test-bucket",
+					PathPrefix:      "tenant//chatto",
+					AccessKeyID:     "test-key",
+					SecretAccessKey: "test-secret",
+				}
+			},
+			wantError: true,
+			errorMsg:  "core.assets.s3.path_prefix must not contain empty path segments",
+		},
+		{
+			name: "S3 backend with control character path prefix fails",
+			modify: func(c *ChattoConfig) {
+				c.Core.Assets.StorageBackend = StorageBackendS3
+				c.Core.Assets.S3 = S3Config{
+					Endpoint:        "s3.amazonaws.com",
+					Bucket:          "test-bucket",
+					PathPrefix:      "tenant\nchatto",
+					AccessKeyID:     "test-key",
+					SecretAccessKey: "test-secret",
+				}
+			},
+			wantError: true,
+			errorMsg:  "core.assets.s3.path_prefix must not contain control characters",
 		},
 		{
 			name: "S3 backend without endpoint fails",

--- a/cli/internal/core/attachments_test.go
+++ b/cli/internal/core/attachments_test.go
@@ -297,6 +297,45 @@ func TestChattoCore_UploadAttachment_S3(t *testing.T) {
 	}
 }
 
+func TestChattoCore_UploadAttachment_S3PathPrefixKeepsStoredKeyLogical(t *testing.T) {
+	core, _, s3Client, rawS3Client, _ := setupTestCoreWithS3PathPrefix(t, "tenant-a/chatto")
+	ctx := testContext(t)
+
+	room, err := core.CreateRoom(ctx, "test-user", KindChannel, "", "test-room", "Test room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+
+	attachment, err := core.UploadAttachment(ctx, SystemActorID, room.Id, "test.txt", "text/plain", bytes.NewReader([]byte("hello prefixed S3")))
+	if err != nil {
+		t.Fatalf("Failed to upload attachment: %v", err)
+	}
+
+	s3Storage := attachment.Storage.GetS3()
+	if s3Storage == nil {
+		t.Fatal("Attachment storage should be S3")
+	}
+	wantLogicalKey := S3KeyAttachment(attachment.Id)
+	if s3Storage.Key != wantLogicalKey {
+		t.Fatalf("persisted S3 key = %q, want logical key %q", s3Storage.Key, wantLogicalKey)
+	}
+
+	info, err := s3Client.StatObject(ctx, s3Storage.Key)
+	if err != nil {
+		t.Fatalf("logical S3 stat should find object through configured prefix: %v", err)
+	}
+	if info.Key != wantLogicalKey {
+		t.Fatalf("logical stat key = %q, want %q", info.Key, wantLogicalKey)
+	}
+
+	if _, err := rawS3Client.StatObject(ctx, s3Storage.Key); err == nil {
+		t.Fatal("raw bucket-root stat should not find object at the logical key")
+	}
+	if _, err := rawS3Client.StatObject(ctx, "tenant-a/chatto/"+s3Storage.Key); err != nil {
+		t.Fatalf("raw stat should find physical prefixed object: %v", err)
+	}
+}
+
 func TestChattoCore_DeleteAttachmentFromStorage_S3(t *testing.T) {
 	core, _, s3Client := setupTestCoreWithS3(t)
 	ctx := testContext(t)
@@ -330,6 +369,130 @@ func TestChattoCore_DeleteAttachmentFromStorage_S3(t *testing.T) {
 	if err == nil {
 		t.Error("Object should be deleted from S3")
 	}
+}
+
+func TestChattoCore_S3PathPrefixCanMoveBasePathWithoutChangingStoredKey(t *testing.T) {
+	core, _, oldPrefixClient, rawS3Client, s3Cfg := setupTestCoreWithS3PathPrefix(t, "tenant-a/chatto")
+	ctx := testContext(t)
+
+	room, err := core.CreateRoom(ctx, "test-user", KindChannel, "", "test-room", "Test room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+
+	content := []byte("move me between prefixes")
+	attachment, err := core.UploadAttachment(ctx, SystemActorID, room.Id, "move.txt", "text/plain", bytes.NewReader(content))
+	if err != nil {
+		t.Fatalf("Failed to upload attachment: %v", err)
+	}
+	storedKey := attachment.Storage.GetS3().Key
+
+	if _, err := oldPrefixClient.StatObject(ctx, storedKey); err != nil {
+		t.Fatalf("old prefix client should find uploaded object: %v", err)
+	}
+
+	// Simulate an operator moving objects in S3 before changing config.
+	if _, err := rawS3Client.PutObjectFromBytes(ctx, "tenant-b/chatto/"+storedKey, content, "text/plain"); err != nil {
+		t.Fatalf("failed to copy object to new prefix: %v", err)
+	}
+	if err := rawS3Client.DeleteObject(ctx, "tenant-a/chatto/"+storedKey); err != nil {
+		t.Fatalf("failed to remove object from old prefix: %v", err)
+	}
+
+	s3Cfg.PathPrefix = "tenant-b/chatto"
+	newPrefixClient, err := NewS3Client(s3Cfg)
+	if err != nil {
+		t.Fatalf("failed to create new-prefix S3 client: %v", err)
+	}
+	core.s3Client = newPrefixClient
+
+	reader, info, err := core.GetAttachmentReader(ctx, attachment)
+	if err != nil {
+		t.Fatalf("GetAttachmentReader after prefix change: %v", err)
+	}
+	defer reader.(io.Closer).Close()
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("failed to read moved object: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("moved object content = %q, want %q", got, content)
+	}
+	if info.ContentType != "text/plain" {
+		t.Fatalf("content type = %q, want text/plain", info.ContentType)
+	}
+
+	presignedURL, err := core.TryPresignedAttachmentURL(ctx, attachment)
+	if err != nil {
+		t.Fatalf("TryPresignedAttachmentURL after prefix change: %v", err)
+	}
+	if !bytes.Contains([]byte(presignedURL), []byte("tenant-b/chatto/"+storedKey)) {
+		t.Fatalf("presigned URL %q does not contain new physical prefix", presignedURL)
+	}
+}
+
+func TestChattoCore_S3PathPrefixAppliesToAllAssetUploadsWithoutPersistingPrefix(t *testing.T) {
+	core, _, s3Client, rawS3Client, _ := setupTestCoreWithS3PathPrefix(t, "tenant-a/chatto")
+	ctx := testContext(t)
+
+	user, err := core.CreateUser(ctx, SystemActorID, "prefixed-user", "Prefixed User", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser failed: %v", err)
+	}
+	room, err := core.CreateRoom(ctx, user.Id, KindChannel, "", "prefixed-room", "Prefixed Room")
+	if err != nil {
+		t.Fatalf("CreateRoom failed: %v", err)
+	}
+
+	avatar, err := core.UploadUserAvatar(ctx, user.Id, bytes.NewReader(createTestPNG(64, 64)))
+	if err != nil {
+		t.Fatalf("UploadUserAvatar failed: %v", err)
+	}
+	logo, err := core.UploadServerLogo(ctx, bytes.NewReader(createTestPNG(100, 100)))
+	if err != nil {
+		t.Fatalf("UploadServerLogo failed: %v", err)
+	}
+	original, err := core.UploadAttachment(ctx, user.Id, room.Id, "original.png", "image/png", bytes.NewReader(createTestPNG(80, 80)))
+	if err != nil {
+		t.Fatalf("UploadAttachment failed: %v", err)
+	}
+	derivative, err := core.UploadDerivativeAttachment(ctx, original.Id, corev1.AssetDerivativeRole_ASSET_DERIVATIVE_ROLE_THUMBNAIL, room.Id, "thumb.png", "image/png", bytes.NewReader(createTestPNG(32, 32)))
+	if err != nil {
+		t.Fatalf("UploadDerivativeAttachment failed: %v", err)
+	}
+
+	checkServerAsset := func(name string, asset *corev1.DeprecatedAsset) {
+		t.Helper()
+		key := asset.GetS3().GetKey()
+		if bytes.Contains([]byte(key), []byte("tenant-a/chatto")) {
+			t.Fatalf("%s persisted key contains prefix: %q", name, key)
+		}
+		logicalS3Key := S3KeyServerAsset(key)
+		if _, err := s3Client.StatObject(ctx, logicalS3Key); err != nil {
+			t.Fatalf("%s logical S3 stat failed: %v", name, err)
+		}
+		if _, err := rawS3Client.StatObject(ctx, "tenant-a/chatto/"+logicalS3Key); err != nil {
+			t.Fatalf("%s raw physical S3 stat failed: %v", name, err)
+		}
+	}
+	checkAttachment := func(name string, attachment *corev1.Attachment) {
+		t.Helper()
+		key := attachment.GetStorage().GetS3().GetKey()
+		if key != S3KeyAttachment(attachment.Id) {
+			t.Fatalf("%s persisted key = %q, want logical attachment key", name, key)
+		}
+		if _, err := s3Client.StatObject(ctx, key); err != nil {
+			t.Fatalf("%s logical S3 stat failed: %v", name, err)
+		}
+		if _, err := rawS3Client.StatObject(ctx, "tenant-a/chatto/"+key); err != nil {
+			t.Fatalf("%s raw physical S3 stat failed: %v", name, err)
+		}
+	}
+
+	checkServerAsset("avatar", assetStorageFromAsset(avatar))
+	checkServerAsset("server logo", logo)
+	checkAttachment("original attachment", original)
+	checkAttachment("derivative attachment", derivative)
 }
 
 // ============================================================================
@@ -404,6 +567,34 @@ func TestGetAttachmentReader_ProbesWhenStorageMissing(t *testing.T) {
 		data, _ := io.ReadAll(reader)
 		if string(data) != "s3-binary" {
 			t.Errorf("expected 's3-binary', got %q", data)
+		}
+	})
+
+	t.Run("falls back to prefixed S3 legacy layouts", func(t *testing.T) {
+		core, _, _, rawS3Client, _ := setupTestCoreWithS3PathPrefix(t, "tenant-a/chatto")
+		ctx := testContext(t)
+
+		attachmentID := "att_legacy_prefixed"
+		legacyLogicalKey := "spaces/server/attachments/" + attachmentID
+		legacyPhysicalKey := "tenant-a/chatto/" + legacyLogicalKey
+		if _, err := rawS3Client.PutObjectFromBytes(ctx, legacyPhysicalKey, []byte("prefixed-legacy-s3"), "text/plain"); err != nil {
+			t.Fatalf("failed to seed legacy S3 object: %v", err)
+		}
+
+		minimal := &corev1.Attachment{Id: attachmentID, RoomId: "room-legacy"}
+		reader, info, err := core.GetAttachmentReader(ctx, minimal)
+		if err != nil {
+			t.Fatalf("GetAttachmentReader with prefixed legacy S3 attachment: %v", err)
+		}
+		if closer, ok := reader.(io.Closer); ok {
+			defer closer.Close()
+		}
+		data, _ := io.ReadAll(reader)
+		if string(data) != "prefixed-legacy-s3" {
+			t.Errorf("expected 'prefixed-legacy-s3', got %q", data)
+		}
+		if info.ContentType != "text/plain" {
+			t.Errorf("expected content type 'text/plain', got %q", info.ContentType)
 		}
 	})
 
@@ -782,6 +973,14 @@ func TestImageCacheKey(t *testing.T) {
 // setupTestCoreWithS3 creates a ChattoCore backed by a fake in-memory S3 server.
 // Returns the core, NATS connection, and S3 client for verification.
 func setupTestCoreWithS3(t *testing.T) (*ChattoCore, *nats.Conn, *S3Client) {
+	core, nc, s3Client, _, _ := setupTestCoreWithS3PathPrefix(t, "")
+	return core, nc, s3Client
+}
+
+// setupTestCoreWithS3PathPrefix creates a ChattoCore backed by a fake
+// in-memory S3 server. It returns both a prefix-aware verification client and a
+// raw bucket-root client for assertions about physical object keys.
+func setupTestCoreWithS3PathPrefix(t *testing.T, pathPrefix string) (*ChattoCore, *nats.Conn, *S3Client, *S3Client, config.S3Config) {
 	t.Helper()
 
 	// Start fake S3 server
@@ -808,6 +1007,7 @@ func setupTestCoreWithS3(t *testing.T) (*ChattoCore, *nats.Conn, *S3Client) {
 			S3: config.S3Config{
 				Endpoint:        endpointHost,
 				Bucket:          "test-bucket",
+				PathPrefix:      pathPrefix,
 				AccessKeyID:     "test-key",
 				SecretAccessKey: "test-secret",
 				UseSSL:          &useSSL,
@@ -828,7 +1028,14 @@ func setupTestCoreWithS3(t *testing.T) (*ChattoCore, *nats.Conn, *S3Client) {
 		t.Fatalf("Failed to create verification S3 client: %v", err)
 	}
 
-	return core, nc, verifyClient
+	rawCfg := cfg.Assets.S3
+	rawCfg.PathPrefix = ""
+	rawVerifyClient, err := NewS3Client(rawCfg)
+	if err != nil {
+		t.Fatalf("Failed to create raw verification S3 client: %v", err)
+	}
+
+	return core, nc, verifyClient, rawVerifyClient, cfg.Assets.S3
 }
 
 // setupTestCoreWithCache creates a ChattoCore with asset caching enabled

--- a/cli/internal/core/s3.go
+++ b/cli/internal/core/s3.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/minio/minio-go/v7"
@@ -15,8 +16,9 @@ import (
 
 // S3Client wraps minio-go client for S3-compatible storage operations.
 type S3Client struct {
-	client *minio.Client
-	bucket string
+	client     *minio.Client
+	bucket     string
+	pathPrefix string
 }
 
 // NewS3Client creates a new S3 client from configuration.
@@ -24,6 +26,10 @@ type S3Client struct {
 func NewS3Client(cfg config.S3Config) (*S3Client, error) {
 	if cfg.Endpoint == "" || cfg.Bucket == "" {
 		return nil, nil
+	}
+	cfg.NormalizePathPrefix()
+	if err := cfg.ValidatePathPrefix(); err != nil {
+		return nil, err
 	}
 
 	// Set up bucket lookup type based on path-style config
@@ -45,14 +51,37 @@ func NewS3Client(cfg config.S3Config) (*S3Client, error) {
 	}
 
 	return &S3Client{
-		client: client,
-		bucket: cfg.Bucket,
+		client:     client,
+		bucket:     cfg.Bucket,
+		pathPrefix: cfg.PathPrefix,
 	}, nil
 }
 
 // Bucket returns the configured bucket name.
 func (s *S3Client) Bucket() string {
 	return s.bucket
+}
+
+// PathPrefix returns the configured S3 object-key prefix after normalization.
+func (s *S3Client) PathPrefix() string {
+	return s.pathPrefix
+}
+
+func (s *S3Client) physicalKey(logicalKey string) string {
+	if s.pathPrefix == "" {
+		return logicalKey
+	}
+	if logicalKey == "" {
+		return s.pathPrefix
+	}
+	return s.pathPrefix + "/" + logicalKey
+}
+
+func (s *S3Client) logicalKey(physicalKey string) string {
+	if s.pathPrefix == "" {
+		return physicalKey
+	}
+	return strings.TrimPrefix(physicalKey, s.pathPrefix+"/")
 }
 
 // EnsureBucket creates the bucket if it doesn't exist.
@@ -83,13 +112,13 @@ func (s *S3Client) PutObject(ctx context.Context, key string, reader io.Reader, 
 		ContentType: contentType,
 	}
 
-	info, err := s.client.PutObject(ctx, s.bucket, key, reader, size, opts)
+	info, err := s.client.PutObject(ctx, s.bucket, s.physicalKey(key), reader, size, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to upload object: %w", err)
 	}
 
 	return &S3ObjectInfo{
-		Key:         info.Key,
+		Key:         s.logicalKey(info.Key),
 		Size:        info.Size,
 		ContentType: contentType,
 	}, nil
@@ -103,7 +132,7 @@ func (s *S3Client) PutObjectFromBytes(ctx context.Context, key string, data []by
 // GetObject retrieves an object from S3.
 // The returned reader must be closed by the caller.
 func (s *S3Client) GetObject(ctx context.Context, key string) (io.ReadCloser, *S3ObjectInfo, error) {
-	obj, err := s.client.GetObject(ctx, s.bucket, key, minio.GetObjectOptions{})
+	obj, err := s.client.GetObject(ctx, s.bucket, s.physicalKey(key), minio.GetObjectOptions{})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get object: %w", err)
 	}
@@ -115,7 +144,7 @@ func (s *S3Client) GetObject(ctx context.Context, key string) (io.ReadCloser, *S
 	}
 
 	return obj, &S3ObjectInfo{
-		Key:         stat.Key,
+		Key:         s.logicalKey(stat.Key),
 		Size:        stat.Size,
 		ContentType: stat.ContentType,
 	}, nil
@@ -127,7 +156,7 @@ func (s *S3Client) GetObjectFromBucket(ctx context.Context, bucket, key string) 
 		bucket = s.bucket
 	}
 
-	obj, err := s.client.GetObject(ctx, bucket, key, minio.GetObjectOptions{})
+	obj, err := s.client.GetObject(ctx, bucket, s.physicalKey(key), minio.GetObjectOptions{})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get object: %w", err)
 	}
@@ -139,7 +168,7 @@ func (s *S3Client) GetObjectFromBucket(ctx context.Context, bucket, key string) 
 	}
 
 	return obj, &S3ObjectInfo{
-		Key:         stat.Key,
+		Key:         s.logicalKey(stat.Key),
 		Size:        stat.Size,
 		ContentType: stat.ContentType,
 	}, nil
@@ -147,7 +176,7 @@ func (s *S3Client) GetObjectFromBucket(ctx context.Context, bucket, key string) 
 
 // DeleteObject deletes an object from S3.
 func (s *S3Client) DeleteObject(ctx context.Context, key string) error {
-	err := s.client.RemoveObject(ctx, s.bucket, key, minio.RemoveObjectOptions{})
+	err := s.client.RemoveObject(ctx, s.bucket, s.physicalKey(key), minio.RemoveObjectOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to delete object: %w", err)
 	}
@@ -160,7 +189,7 @@ func (s *S3Client) DeleteObjectFromBucket(ctx context.Context, bucket, key strin
 		bucket = s.bucket
 	}
 
-	err := s.client.RemoveObject(ctx, bucket, key, minio.RemoveObjectOptions{})
+	err := s.client.RemoveObject(ctx, bucket, s.physicalKey(key), minio.RemoveObjectOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to delete object: %w", err)
 	}
@@ -169,13 +198,13 @@ func (s *S3Client) DeleteObjectFromBucket(ctx context.Context, bucket, key strin
 
 // StatObject returns metadata about an object without downloading it.
 func (s *S3Client) StatObject(ctx context.Context, key string) (*S3ObjectInfo, error) {
-	stat, err := s.client.StatObject(ctx, s.bucket, key, minio.StatObjectOptions{})
+	stat, err := s.client.StatObject(ctx, s.bucket, s.physicalKey(key), minio.StatObjectOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to stat object: %w", err)
 	}
 
 	return &S3ObjectInfo{
-		Key:         stat.Key,
+		Key:         s.logicalKey(stat.Key),
 		Size:        stat.Size,
 		ContentType: stat.ContentType,
 	}, nil
@@ -196,7 +225,7 @@ func IsNoSuchKeyError(err error) bool {
 // PresignedGetURL generates a presigned GET URL for an S3 object.
 // The URL is valid for the specified duration (max 7 days).
 func (s *S3Client) PresignedGetURL(ctx context.Context, key string, expiry time.Duration) (*url.URL, error) {
-	return s.client.PresignedGetObject(ctx, s.bucket, key, expiry, nil)
+	return s.client.PresignedGetObject(ctx, s.bucket, s.physicalKey(key), expiry, nil)
 }
 
 // S3 key helpers for organizing assets in S3.

--- a/cli/internal/core/s3_test.go
+++ b/cli/internal/core/s3_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/johannesboyne/gofakes3"
 	"github.com/johannesboyne/gofakes3/backend/s3mem"
@@ -166,6 +168,67 @@ func TestS3Client_StatObject(t *testing.T) {
 	require.Equal(t, int64(1024), info.Size)
 }
 
+func TestS3Client_PathPrefixUsesPhysicalKeyAndReturnsLogicalKey(t *testing.T) {
+	server, endpoint := setupFakeS3Server(t)
+	defer server.Close()
+
+	endpointHost := endpoint[7:]
+	useSSL := false
+	pathStyle := true
+
+	prefixedCfg := config.S3Config{
+		Endpoint:        endpointHost,
+		Bucket:          "test-bucket",
+		PathPrefix:      "/tenant-a/chatto/",
+		AccessKeyID:     "test-key",
+		SecretAccessKey: "test-secret",
+		UseSSL:          &useSSL,
+		PathStyle:       &pathStyle,
+	}
+	prefixedClient, err := core.NewS3Client(prefixedCfg)
+	require.NoError(t, err)
+	require.Equal(t, "tenant-a/chatto", prefixedClient.PathPrefix())
+
+	verifierCfg := prefixedCfg
+	verifierCfg.PathPrefix = ""
+	verifierClient, err := core.NewS3Client(verifierCfg)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, prefixedClient.EnsureBucket(ctx))
+
+	logicalKey := "test/object.txt"
+	physicalKey := "tenant-a/chatto/test/object.txt"
+	testData := []byte("under a prefix")
+
+	putInfo, err := prefixedClient.PutObjectFromBytes(ctx, logicalKey, testData, "text/plain")
+	require.NoError(t, err)
+	require.Equal(t, logicalKey, putInfo.Key)
+
+	_, err = verifierClient.StatObject(ctx, logicalKey)
+	require.Error(t, err)
+
+	physicalInfo, err := verifierClient.StatObject(ctx, physicalKey)
+	require.NoError(t, err)
+	require.Equal(t, physicalKey, physicalInfo.Key)
+
+	reader, getInfo, err := prefixedClient.GetObject(ctx, logicalKey)
+	require.NoError(t, err)
+	defer reader.Close()
+	require.Equal(t, logicalKey, getInfo.Key)
+	content, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.Equal(t, testData, content)
+
+	presignedURL, err := prefixedClient.PresignedGetURL(ctx, logicalKey, 15*time.Minute)
+	require.NoError(t, err)
+	require.Contains(t, presignedURL.Path, physicalKey)
+
+	require.NoError(t, prefixedClient.DeleteObject(ctx, logicalKey))
+	_, err = verifierClient.StatObject(ctx, physicalKey)
+	require.Error(t, err)
+}
+
 // TestS3KeyHelpers tests the S3 key generation helpers.
 func TestS3KeyHelpers(t *testing.T) {
 	tests := []struct {
@@ -203,6 +266,20 @@ func TestS3Client_NilWhenNotConfigured(t *testing.T) {
 	client, err := core.NewS3Client(cfg)
 	require.NoError(t, err)
 	require.Nil(t, client)
+}
+
+func TestS3Client_InvalidPathPrefix(t *testing.T) {
+	cfg := config.S3Config{
+		Endpoint:        "s3.amazonaws.com",
+		Bucket:          "test-bucket",
+		PathPrefix:      "tenant//chatto",
+		AccessKeyID:     "test-key",
+		SecretAccessKey: "test-secret",
+	}
+	client, err := core.NewS3Client(cfg)
+	require.Nil(t, client)
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "path_prefix"))
 }
 
 // TestStorageBackendEncapsulation_URLGeneration tests that URL generation always uses

--- a/docs-website/src/content/docs/guides/s3-storage.mdx
+++ b/docs-website/src/content/docs/guides/s3-storage.mdx
@@ -12,8 +12,9 @@ Switching to an S3-compatible backend offloads file storage to a dedicated objec
 ## How It Works
 
 - **New uploads** go to S3 when configured
-- **Existing attachments** stored in NATS continue to work — Chatto checks both backends when serving files
+- **Existing attachments** stored in NATS continue to work — each asset remembers which backend stores its bytes
 - **URLs don't change** — the storage backend is an internal detail; asset URLs always use the same format
+- **S3 prefixes are movable** — Chatto stores prefix-free asset keys, so you can move objects to a different S3 prefix and update config without rewriting Chatto metadata
 
 This means you can enable S3 at any time without migrating existing data. Old NATS-stored files remain accessible alongside new S3-stored ones.
 
@@ -27,6 +28,7 @@ Set the storage backend to `s3` and provide your bucket credentials:
 CHATTO_CORE_ASSETS_STORAGE_BACKEND=s3
 CHATTO_CORE_ASSETS_S3_ENDPOINT=s3.amazonaws.com
 CHATTO_CORE_ASSETS_S3_BUCKET=chatto-assets
+CHATTO_CORE_ASSETS_S3_PATH_PREFIX=production/chatto
 CHATTO_CORE_ASSETS_S3_REGION=eu-central-1
 CHATTO_CORE_ASSETS_S3_ACCESS_KEY_ID=your-access-key
 CHATTO_CORE_ASSETS_S3_SECRET_ACCESS_KEY=your-secret-key
@@ -40,6 +42,7 @@ storage_backend = "s3"
 [core.assets.s3]
 endpoint = "s3.amazonaws.com"
 bucket = "chatto-assets"
+path_prefix = "production/chatto"
 region = "eu-central-1"
 access_key_id = "your-access-key"
 secret_access_key = "your-secret-key"
@@ -55,6 +58,7 @@ Chatto creates the bucket automatically on startup if it doesn't exist.
 |---------|---------|-------------|
 | `endpoint` | — | S3 endpoint URL |
 | `bucket` | — | Bucket name |
+| `path_prefix` | — | Optional object key prefix for all S3 assets. Leading/trailing slashes are ignored. |
 | `region` | — | AWS region (optional for non-AWS services) |
 | `access_key_id` | — | Access key |
 | `secret_access_key` | — | Secret key |
@@ -102,7 +106,8 @@ CHATTO_CORE_ASSETS_S3_PATH_STYLE=true
 
 ## Switching Storage Backends
 
-You can switch **from S3 back to NATS** at any time — just change `storage_backend` back to `nats`. Existing S3 files remain accessible because Chatto checks both backends when serving attachments. New uploads will go to NATS.
+You can switch **from S3 back to NATS** at any time — just change `storage_backend` back to `nats`. Existing S3 files remain accessible because each asset records its storage backend. New uploads will go to NATS.
+You can also change `path_prefix` after moving or copying the S3 objects to the new prefix. Chatto stores logical, prefix-free asset keys in NATS, so no Chatto metadata rewrite is needed.
 
 <Aside type="caution">
   You **cannot** change from one S3 provider or bucket to another. Chatto only has a single S3 configuration — if you switch endpoints or buckets, files stored in the previous location become inaccessible. If you need to migrate between S3 providers, copy the data at the storage level first.

--- a/docs-website/src/content/docs/reference/environment-variables.mdx
+++ b/docs-website/src/content/docs/reference/environment-variables.mdx
@@ -95,6 +95,10 @@ Only used when `storage_backend` is set to `s3`. See the [S3 Storage guide](/gui
   S3 bucket name. Created automatically on startup if it doesn't exist.
 </EnvVar>
 
+<EnvVar name="CHATTO_CORE_ASSETS_S3_PATH_PREFIX" toml="core.assets.s3.path_prefix">
+  Optional object key prefix for all S3 assets. Leave empty to store objects at the bucket root.
+</EnvVar>
+
 <EnvVar name="CHATTO_CORE_ASSETS_S3_REGION" toml="core.assets.s3.region">
   AWS region. Optional for non-AWS S3-compatible services.
 </EnvVar>

--- a/docs/fdr/FDR-008-file-attachments-and-video.md
+++ b/docs/fdr/FDR-008-file-attachments-and-video.md
@@ -24,9 +24,9 @@ Users can attach files to messages — images, videos, documents — via drag-an
 
 ### 1. Dual storage backends (NATS ObjectStore + S3)
 
-**Decision:** Attachments can be stored in NATS ObjectStore (default, good for development and small deployments) or in an S3-compatible bucket (production-grade). The retrieval layer tries both, with the configured primary first.
+**Decision:** Attachments can be stored in NATS ObjectStore (default, good for development and small deployments) or in an S3-compatible bucket (production-grade). Each asset records its storage backend and logical key at upload time; S3 deployments may add a configurable object-key prefix that is applied only at the S3 client boundary.
 **Why:** Self-hosters running a single binary shouldn't have to spin up S3 just to send a screenshot. Larger operators need durable, replicated object storage. Supporting both lets us serve both ends of the spectrum. See ADR-021.
-**Tradeoff:** Migration between backends is operator-managed. The "try both" retrieval logic adds a tiny overhead but greatly improves the migration experience.
+**Tradeoff:** Migration between backends or S3 prefixes is operator-managed. Stored asset keys remain prefix-free so moving objects between S3 base paths does not require rewriting Chatto metadata.
 
 ### 2. Video processing is in-process and best-effort
 


### PR DESCRIPTION
## Summary

- Add optional S3 asset `path_prefix` config with normalization and validation.
- Apply the prefix inside the S3 client while keeping persisted asset keys logical and prefix-free.
- Cover prefixed uploads, base-prefix moves, legacy fallback layouts, docs, and FDR behavior.

## Tests

- `mise x -- go test ./internal/config -run "TestReadConfig|TestChattoConfig_Validate_S3" -timeout 30s`
- `mise x -- go test ./internal/core -run "TestS3|TestChattoCore_.*S3|TestChattoCore_DeleteMessage_DeletesS3Attachments|TestChattoCore_DeleteAttachmentFromMessage_S3" -timeout 60s`
- `mise x -- go test ./internal/core -run TestGetAttachmentReader_ProbesWhenStorageMissing -timeout 60s`
- `mise x -- go test -tags test_endpoints ./internal/http_server -run "TestAsset_.*S3|TestAsset_SignedURLOnS3IsCapability" -timeout 60s`
