### PR TITLE
fix(auth): restrict OAuth redirect origins

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -66,7 +66,7 @@ func (c *TLSConfig) HTTPPortOrDefault() int {
 type WebserverConfig struct {
 	URL                    string    `toml:"url" env:"CHATTO_WEBSERVER_URL" comment:"Public URL where the webserver is accessible. Used for generating absolute URLs."`
 	Port                   int       `toml:"port" env:"CHATTO_WEBSERVER_PORT" comment:"Port for the webserver to listen on."`
-	AllowedOrigins         []string  `toml:"allowed_origins" env:"CHATTO_WEBSERVER_ALLOWED_ORIGINS" comment:"Additional origins allowed for CORS and WebSocket connections. Defaults to wildcard (*) for multi-server support. Set explicitly to restrict cross-origin access."`
+	AllowedOrigins         []string  `toml:"allowed_origins" env:"CHATTO_WEBSERVER_ALLOWED_ORIGINS" comment:"Additional origins allowed for CORS, WebSocket connections, and OAuth redirect callbacks. Defaults to wildcard (*) for CORS multi-server support, but OAuth ignores wildcard and requires explicit trusted origins."`
 	WebSocketCompression   *bool     `toml:"websocket_compression" env:"CHATTO_WEBSERVER_WEBSOCKET_COMPRESSION" comment:"Enable WebSocket compression for GraphQL connections. Reduces bandwidth but uses more CPU. Default: true."`
 	RequestLogging         *bool     `toml:"request_logging" env:"CHATTO_WEBSERVER_REQUEST_LOGGING" comment:"Log HTTP requests. Useful for debugging but can be noisy in production. Default: false."`
 	CookieSigningSecret    string    `toml:"cookie_signing_secret" env:"CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET" comment:"Secret for signing session cookies. NEVER SHARE THIS!\nIf it leaks, change it immediately, but please note that all existing sessions will become invalid."`

--- a/cli/internal/http_server/oauth.go
+++ b/cli/internal/http_server/oauth.go
@@ -84,10 +84,10 @@ func (s *HTTPServer) setupOAuthRoutes() {
 			return
 		}
 
-		if !isValidRedirectURI(redirectURI) {
+		if !s.isAllowedOAuthRedirectURI(redirectURI) {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error":             "invalid_request",
-				"error_description": "Invalid redirect_uri: must be HTTPS or localhost",
+				"error_description": "Invalid redirect_uri: must use an allowed HTTPS origin or localhost",
 			})
 			return
 		}
@@ -279,32 +279,79 @@ func hasPendingOAuthAuthorize(session sessions.Session) bool {
 	return redirectURI != ""
 }
 
-// isValidRedirectURI validates a redirect URI for the OAuth authorize flow.
-// Accepts:
-//   - HTTPS URLs (any origin)
-//   - http://localhost:* and http://127.0.0.1:* (for desktop apps and development)
-func isValidRedirectURI(uri string) bool {
+// isAllowedOAuthRedirectURI validates a redirect URI for the OAuth authorize
+// flow. In addition to requiring HTTPS (except loopback development URLs), it
+// only accepts origins this server explicitly trusts: its own public
+// webserver.url origin, webserver.allowed_origins entries, and localhost.
+func (s *HTTPServer) isAllowedOAuthRedirectURI(uri string) bool {
 	u, err := url.Parse(uri)
 	if err != nil {
 		return false
 	}
 
 	// Must have a scheme and host
-	if u.Scheme == "" || u.Host == "" {
+	if u.Scheme == "" || u.Host == "" || u.User != nil || u.Fragment != "" {
 		return false
 	}
 
-	// HTTPS is always allowed
-	if u.Scheme == "https" {
+	if isLoopbackOAuthRedirectHost(u.Hostname()) {
+		return u.Scheme == "http" || u.Scheme == "https"
+	}
+
+	if u.Scheme != "https" {
+		return false
+	}
+
+	redirectOrigin := canonicalOrigin(u)
+	for _, allowed := range s.allowedOAuthRedirectOrigins() {
+		if redirectOrigin == allowed {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (s *HTTPServer) allowedOAuthRedirectOrigins() []string {
+	origins := make([]string, 0, len(s.config.Webserver.AllowedOrigins)+1)
+	if origin, ok := parseConfiguredOAuthOrigin(s.config.Webserver.URL); ok {
+		origins = append(origins, origin)
+	}
+	for _, raw := range s.config.Webserver.AllowedOrigins {
+		if raw == "*" {
+			continue
+		}
+		if origin, ok := parseConfiguredOAuthOrigin(raw); ok {
+			origins = append(origins, origin)
+		}
+	}
+	return origins
+}
+
+func parseConfiguredOAuthOrigin(raw string) (string, bool) {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" || u.User != nil {
+		return "", false
+	}
+	if isLoopbackOAuthRedirectHost(u.Hostname()) {
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return "", false
+		}
+	} else if u.Scheme != "https" {
+		return "", false
+	}
+	return canonicalOrigin(u), true
+}
+
+func canonicalOrigin(u *url.URL) string {
+	return strings.ToLower(u.Scheme) + "://" + strings.ToLower(u.Host)
+}
+
+func isLoopbackOAuthRedirectHost(host string) bool {
+	switch strings.ToLower(host) {
+	case "localhost", "127.0.0.1", "::1":
 		return true
 	}
-
-	// HTTP is only allowed for localhost (desktop apps, development)
-	if u.Scheme == "http" {
-		host := strings.Split(u.Host, ":")[0] // strip port
-		return host == "localhost" || host == "127.0.0.1"
-	}
-
 	return false
 }
 

--- a/cli/internal/http_server/oauth_test.go
+++ b/cli/internal/http_server/oauth_test.go
@@ -48,7 +48,11 @@ func setupOAuthServer(t *testing.T) *HTTPServer {
 	router.Use(sessions.Sessions("chatto_session", sessionStore))
 
 	s := &HTTPServer{
-		config:  config.ChattoConfig{},
+		config: config.ChattoConfig{
+			Webserver: config.WebserverConfig{
+				URL: "https://chatto.example",
+			},
+		},
 		nc:      nc,
 		router:  router,
 		core:    chattoCore,
@@ -67,7 +71,7 @@ func TestOAuthAuthorize_ValidParams(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/oauth/authorize?"+url.Values{
 		"response_type":         {"code"},
-		"redirect_uri":          {"https://example.com/callback"},
+		"redirect_uri":          {"https://chatto.example/servers/callback"},
 		"code_challenge":        {challenge},
 		"code_challenge_method": {"S256"},
 		"state":                 {"random123"},
@@ -97,7 +101,7 @@ func TestOAuthAuthorize_MissingParams(t *testing.T) {
 		{
 			"missing response_type",
 			url.Values{
-				"redirect_uri":          {"https://example.com/callback"},
+				"redirect_uri":          {"https://chatto.example/servers/callback"},
 				"code_challenge":        {"challenge"},
 				"code_challenge_method": {"S256"},
 			},
@@ -116,7 +120,7 @@ func TestOAuthAuthorize_MissingParams(t *testing.T) {
 			"missing code_challenge",
 			url.Values{
 				"response_type":         {"code"},
-				"redirect_uri":          {"https://example.com/callback"},
+				"redirect_uri":          {"https://chatto.example/servers/callback"},
 				"code_challenge_method": {"S256"},
 			},
 			"invalid_request",
@@ -125,7 +129,7 @@ func TestOAuthAuthorize_MissingParams(t *testing.T) {
 			"wrong code_challenge_method",
 			url.Values{
 				"response_type":         {"code"},
-				"redirect_uri":          {"https://example.com/callback"},
+				"redirect_uri":          {"https://chatto.example/servers/callback"},
 				"code_challenge":        {"challenge"},
 				"code_challenge_method": {"plain"},
 			},
@@ -160,8 +164,10 @@ func TestOAuthAuthorize_InvalidRedirectURI(t *testing.T) {
 		redirectURI string
 	}{
 		{"plain HTTP", "http://example.com/callback"},
+		{"unconfigured HTTPS origin", "https://evil.example/callback"},
 		{"no scheme", "example.com/callback"},
 		{"ftp scheme", "ftp://example.com/callback"},
+		{"fragment", "https://chatto.example/callback#frag"},
 	}
 
 	for _, tt := range tests {
@@ -179,6 +185,73 @@ func TestOAuthAuthorize_InvalidRedirectURI(t *testing.T) {
 				t.Errorf("expected 400 for redirect_uri %q, got %d", tt.redirectURI, w.Code)
 			}
 		})
+	}
+}
+
+func TestOAuthAuthorize_AllowsConfiguredRedirectOrigin(t *testing.T) {
+	s := setupOAuthServer(t)
+	s.config.Webserver.AllowedOrigins = []string{"https://client.example"}
+
+	req := httptest.NewRequest("GET", "/oauth/authorize?"+url.Values{
+		"response_type":         {"code"},
+		"redirect_uri":          {"https://client.example/servers/callback"},
+		"code_challenge":        {"challenge"},
+		"code_challenge_method": {"S256"},
+	}.Encode(), nil)
+	w := httptest.NewRecorder()
+	s.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("expected 307 for configured redirect origin, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestOAuthAuthorize_RejectsUnconfiguredRedirectForAuthenticatedUser(t *testing.T) {
+	s := setupOAuthServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	user, err := s.core.CreateUser(ctx, "", "oauth-victim", "OAuth Victim", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	s.router.GET("/test/login-victim", func(c *gin.Context) {
+		if err := s.createCookieSession(c, user.Id, "test"); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.Status(http.StatusNoContent)
+	})
+
+	loginReq := httptest.NewRequest("GET", "/test/login-victim", nil)
+	loginW := httptest.NewRecorder()
+	s.router.ServeHTTP(loginW, loginReq)
+	if loginW.Code != http.StatusNoContent {
+		t.Fatalf("login fixture status = %d, want 204: %s", loginW.Code, loginW.Body.String())
+	}
+
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	challenge := core.GenerateCodeChallenge(verifier)
+	req := httptest.NewRequest("GET", "/oauth/authorize?"+url.Values{
+		"response_type":         {"code"},
+		"redirect_uri":          {"https://evil.example/callback"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {"attacker-state"},
+	}.Encode(), nil)
+	for _, cookie := range loginW.Result().Cookies() {
+		req.AddCookie(cookie)
+	}
+
+	w := httptest.NewRecorder()
+	s.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unconfigured redirect, got %d: location=%q body=%s", w.Code, w.Header().Get("Location"), w.Body.String())
+	}
+	if location := w.Header().Get("Location"); strings.Contains(location, "code=") {
+		t.Fatalf("unconfigured redirect minted code in Location %q", location)
 	}
 }
 
@@ -458,28 +531,34 @@ func TestOAuthToken_FullExchange(t *testing.T) {
 }
 
 func TestIsValidRedirectURI(t *testing.T) {
+	s := setupOAuthServer(t)
+	s.config.Webserver.AllowedOrigins = []string{"https://client.example"}
+
 	tests := []struct {
 		uri  string
 		want bool
 	}{
-		{"https://example.com/callback", true},
-		{"https://example.com:8443/callback", true},
+		{"https://chatto.example/callback", true},
+		{"https://client.example/callback", true},
 		{"http://localhost:3000/callback", true},
 		{"http://localhost/callback", true},
 		{"http://127.0.0.1:5173/callback", true},
 		{"http://127.0.0.1/callback", true},
+		{"http://[::1]:5173/callback", true},
+		{"https://evil.example/callback", false},
 		{"http://example.com/callback", false},
 		{"ftp://example.com/callback", false},
 		{"example.com/callback", false},
 		{"/callback", false},
+		{"https://chatto.example/callback#fragment", false},
 		{"", false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.uri, func(t *testing.T) {
-			got := isValidRedirectURI(tt.uri)
+			got := s.isAllowedOAuthRedirectURI(tt.uri)
 			if got != tt.want {
-				t.Errorf("isValidRedirectURI(%q) = %v, want %v", tt.uri, got, tt.want)
+				t.Errorf("isAllowedOAuthRedirectURI(%q) = %v, want %v", tt.uri, got, tt.want)
 			}
 		})
 	}

--- a/cli/internal/http_server/test_endpoints.go
+++ b/cli/internal/http_server/test_endpoints.go
@@ -262,8 +262,8 @@ func registerTestEndpoints(auth *gin.RouterGroup, s *HTTPServer) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "code_challenge_method must be S256"})
 			return
 		}
-		if !isValidRedirectURI(req.RedirectURI) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid redirect_uri: must be HTTPS or localhost"})
+		if !s.isAllowedOAuthRedirectURI(req.RedirectURI) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid redirect_uri: must use an allowed HTTPS origin or localhost"})
 			return
 		}
 

--- a/docs/adr/ADR-024-opaque-bearer-tokens-for-cross-origin-auth.md
+++ b/docs/adr/ADR-024-opaque-bearer-tokens-for-cross-origin-auth.md
@@ -31,7 +31,7 @@ To enable a multi-instance client — where a single frontend connects to multip
 
 ## Decision
 
-Use opaque bearer tokens stored in NATS KV. Tokens are issued alongside existing cookie sessions (not replacing them) on all authentication endpoints. Clients authenticate via the `Authorization: Bearer <token>` HTTP header for GraphQL queries/mutations, and via `connectionParams.token` in the graphql-ws `connection_init` payload for WebSocket subscriptions.
+Use opaque bearer tokens stored in NATS KV. Tokens are issued alongside existing cookie sessions (not replacing them) on password, registration, and trusted OAuth code-exchange authentication flows. Clients authenticate via the `Authorization: Bearer <token>` HTTP header for GraphQL queries/mutations, and via `connectionParams.token` in the graphql-ws `connection_init` payload for WebSocket subscriptions.
 
 **2026-05 update:** bearer token records now live in `RUNTIME_STATE` under HMAC-derived `session.{hmac}` keys with per-key TTL. The HMAC input is `session\0{token}` keyed by `[core].secret_key`, so backups can preserve sessions without containing raw bearer-token values.
 
@@ -52,12 +52,18 @@ Issuance and explicit revocation append safe audit facts to `EVT` with source/re
 1. Check `Authorization: Bearer <token>` header → validate token → load user
 2. Fall back to session cookie (existing behavior, unchanged)
 
+**OAuth authorization for cross-origin Chatto clients:**
+- Clients start at `/oauth/authorize` with `response_type=code`, PKCE `code_challenge`, and a callback `redirect_uri`.
+- The server only accepts redirect URI origins it trusts: the configured `webserver.url` origin, explicit `webserver.allowed_origins` entries, and loopback development origins. The wildcard CORS default (`*`) does not authorize OAuth redirects.
+- The callback receives a short-lived authorization code, not a bearer token. The client exchanges the code and PKCE verifier at `/oauth/token`.
+- Auth codes are stored as HMAC-derived `grant.{hmac}` runtime-state keys and are deleted on exchange attempt.
+
 ## Consequences
 
-- **Cross-origin clients become possible**: Any client that can send an HTTP header can authenticate, regardless of origin. This unblocks the multi-instance client epic.
+- **Cross-origin clients become possible**: Clients that can obtain a bearer token through a trusted OAuth redirect or another authentication flow can authenticate with an HTTP header. This unblocks the multi-instance client epic without trusting arbitrary web origins.
 - **Cookie auth is unchanged**: The embedded SPA continues to work exactly as before. No migration needed for existing deployments.
 - **No token refresh complexity**: Long-lived tokens with server-side TTL are simple. If a token expires, the client re-authenticates. No refresh token dance.
 - **Instant revocation**: Deleting a KV key immediately invalidates the token. No blocklist management or "wait for JWT expiry" window.
 - **One KV lookup per request**: Token validation requires a `Get` on `RUNTIME_STATE`, but this is negligible given we already do a user load per authenticated request.
 - **No reverse index**: user-wide cleanup does a `session.*` prefix scan and matches the stored user ID. The revocation guarantee comes from the token's stored auth generation being compared to the current user auth generation, so concurrent issuance cannot survive by missing the scan. A secondary index can be added later if token counts make scans too expensive.
-- **OAuth token delivery**: OAuth callbacks append `?token=...` to the redirect URL. This is simple but means the token briefly appears in browser history and server logs. For v1 this is acceptable; a more secure code-exchange flow can be added later if needed.
+- **OAuth redirect setup**: A separately hosted Chatto frontend must be configured in `webserver.allowed_origins` on each server it connects to. This adds an operator step, but prevents malicious sites from using `/oauth/authorize` as a logged-in user's bearer-token minting oracle.

--- a/docs/adr/ADR-025-multi-instance-client-architecture.md
+++ b/docs/adr/ADR-025-multi-instance-client-architecture.md
@@ -53,7 +53,8 @@ Bearer tokens use NATS KV TTL (default 90 days). Each successful `ValidateAuthTo
 ### Negative
 
 - Remote instance bearer tokens in `localStorage` are vulnerable to XSS (cookie auth is not)
-- `/api/server` is the only cross-origin endpoint (wildcard CORS) — rich data needed pre-registration must go there, not in GraphQL
+- `/api/server` is the only cross-origin endpoint with wildcard CORS — rich data needed pre-registration must go there, not in GraphQL
+- Separately hosted multi-instance frontends must be listed explicitly in each remote server's `webserver.allowed_origins` before OAuth authorization codes can redirect back to them; wildcard CORS does not imply OAuth redirect trust
 - The probe is async for unauthenticated users, so the origin may not be registered by the time the first render completes
 
 ### Trade-offs

--- a/docs/fdr/FDR-023-authentication-and-sessions.md
+++ b/docs/fdr/FDR-023-authentication-and-sessions.md
@@ -11,6 +11,7 @@ Chatto authenticates users via two parallel mechanisms: HTTP-only cookie session
 
 - **Login** — users sign in with login + password on a `/login` page. The page is also used for redirect-after-signup.
 - **OAuth login** — operators can configure OAuth providers (e.g., Google). The login page shows provider buttons; clicking takes the user through the standard authorization-code flow.
+- **Chatto OAuth authorization** — cross-origin Chatto clients use `/oauth/authorize` with PKCE to obtain a short-lived authorization code, then exchange it at `/oauth/token` for an opaque bearer token. Redirect URIs must use this server's configured `webserver.url` origin, an explicit `webserver.allowed_origins` entry, or a loopback development origin; wildcard CORS does not authorize OAuth redirects.
 - **Cookie session** — on successful auth from the embedded SPA, the server issues an HTTP-only, SameSite=Lax cookie with a 90-day expiry. The cookie carries an opaque session ID plus the user ID needed to derive the lookup key; the authoritative `CookieSession` protobuf record lives in `RUNTIME_STATE` under `cookie_session.{userId}.{hmac}` with a per-key TTL. The server validates the KV record and resolves the current user from projections per request.
 - **Bearer token** — every authentication endpoint also issues an opaque token (format: `cht_AT` + 14-char NanoID). Cross-origin clients store it (usually in `localStorage`) and send it as `Authorization: Bearer …` on HTTP requests and `connectionParams.token` on graphql-ws upgrades. The token record lives in `RUNTIME_STATE` as an HMAC-derived `session.{hmac}` key with a per-key TTL.
 - **WebSocket auth** — for the embedded SPA, the cookie is automatically attached to the WebSocket upgrade and the user is authenticated before the WS handshake completes. For cross-origin clients, the token in `connectionParams` is checked at upgrade time.
@@ -65,11 +66,11 @@ Chatto authenticates users via two parallel mechanisms: HTTP-only cookie session
 **Why:** Without it, users get subtle errors when a deployed schema change lands but their old client is still connected. A "the server has been upgraded, please refresh" toast handles it explicitly.
 **Tradeoff:** The frontend has to handle the toast and the user has to act on it. Considered acceptable for the rare deployment-during-session case.
 
-### 8. OAuth tokens delivered via query parameter
+### 8. OAuth code exchange and redirect-origin allow-list
 
-**Decision:** OAuth callbacks redirect to the frontend with `?token=…` in the URL.
-**Why:** The simplest delivery mechanism. The browser hands the token to the frontend; the frontend stores it (or sets up its cookie session) and replaces the URL to drop the parameter from history.
-**Tradeoff:** The token briefly appears in browser history and server access logs. Acceptable for v1; a code-exchange flow can be added later if needed. See ADR-024.
+**Decision:** Chatto's OAuth authorization endpoint returns a short-lived authorization code to the client's callback; the client exchanges that code plus its PKCE verifier at `/oauth/token` for a bearer token. Redirect URIs are accepted only for trusted origins: the server's own configured `webserver.url` origin, explicit `webserver.allowed_origins` entries, and loopback development origins.
+**Why:** PKCE keeps bearer tokens out of callback URLs, and the redirect allow-list prevents a logged-in user from being tricked into sending an authorization code to an attacker-controlled HTTPS origin. The `allowed_origins = ["*"]` CORS default is intentionally not treated as OAuth trust.
+**Tradeoff:** A separately hosted multi-server frontend must be listed explicitly in each server's `webserver.allowed_origins` before users can connect that server through OAuth. This is more operational setup than accepting arbitrary HTTPS callbacks, but avoids drive-by bearer-token issuance to malicious clients. See ADR-024 and ADR-025.
 
 ### 9. EVT audit facts without raw secrets
 
@@ -97,4 +98,4 @@ Authentication itself doesn't have a permission gate (you're either authenticate
 ## Open Questions
 
 - A "revoke all tokens for this user" admin affordance. Core supports revoke-all for password/account lifecycle flows, but there is no dedicated admin UI action yet.
-- A code-exchange OAuth callback flow to keep the token out of the URL/history. Not currently planned.
+- A consent screen for third-party OAuth clients. Today Chatto relies on trusted redirect origins plus PKCE rather than prompting on each authorization request.


### PR DESCRIPTION
- Restricts Chatto OAuth authorization redirects to the configured server origin, explicit `webserver.allowed_origins`, or loopback development origins.
- Updates the test-only OAuth helper and regression tests so authenticated users cannot mint codes for untrusted HTTPS callbacks.
- Documents that wildcard CORS does not grant OAuth redirect trust in the auth FDR, bearer-token ADR, multi-instance ADR, and config comments.

Tests:
- `mise x -- go test -tags test_endpoints ./internal/http_server -timeout 60s`
