### PR TITLE
refactor(frontend): extract admin sidebar group

### DIFF
--- a/frontend/src/lib/components/chat/AdminSidebarGroup.svelte
+++ b/frontend/src/lib/components/chat/AdminSidebarGroup.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  /* eslint-disable svelte/no-navigation-without-resolve -- admin hrefs are resolved before they are passed in */
+  import type { AdminNavItem } from './adminNav';
+
+  let { currentPath, expandedByDefault, items }: {
+    currentPath: string;
+    expandedByDefault: boolean;
+    items: AdminNavItem[];
+  } = $props();
+
+  let expansionOverride = $state<boolean | null>(null);
+  const expanded = $derived(expansionOverride ?? expandedByDefault);
+
+  function isActive(href: string): boolean {
+    return currentPath.startsWith(href);
+  }
+</script>
+
+{#if items.length > 0}
+  <button
+    type="button"
+    class="sidebar-item text-left"
+    aria-expanded={expanded}
+    aria-controls="server-admin-sidebar-links"
+    onclick={() => {
+      expansionOverride = !expanded;
+    }}
+  >
+    <span class="sidebar-icon iconify uil--setting"></span>
+    <span class="min-w-0 flex-1 truncate">Administration</span>
+    <span
+      class={[
+        'iconify uil--angle-right-b shrink-0 text-base text-muted transition-transform',
+        expanded ? 'rotate-90' : ''
+      ]}
+    ></span>
+  </button>
+  {#if expanded}
+    <div id="server-admin-sidebar-links" class="sidebar-nav">
+      {#each items as item (item.href)}
+        <a
+          href={item.href}
+          class={['sidebar-item pl-8', isActive(item.href) ? 'bg-surface-100' : '']}
+        >
+          <span class="sidebar-icon {item.icon}"></span>
+          {item.label}
+        </a>
+      {/each}
+    </div>
+  {/if}
+{/if}

--- a/frontend/src/lib/components/chat/Chrome.svelte
+++ b/frontend/src/lib/components/chat/Chrome.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  /* eslint-disable svelte/no-navigation-without-resolve -- admin child hrefs are resolved when adminNavItems is built */
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
@@ -20,6 +19,8 @@
   import ServerEventProvider from './ServerEventProvider.svelte';
   import SidebarNav from '$lib/components/SidebarNav.svelte';
   import MyThreadsNavItem from './MyThreadsNavItem.svelte';
+  import AdminSidebarGroup from './AdminSidebarGroup.svelte';
+  import { getAdminNavItems } from './adminNav';
 
   let { children } = $props();
 
@@ -32,8 +33,6 @@
     resolve('/chat/[serverId]/server-admin', { serverId: serverSegment })
   );
   const isAdminMode = $derived(page.url.pathname.startsWith(adminPrefix));
-  let adminGroupExpanded = $state(false);
-  let wasAdminMode = $state(false);
 
   // Detect if we're in user settings mode
   const settingsPrefix = $derived(
@@ -242,95 +241,14 @@
   // Read server-wide permissions for admin-flavoured nav items (system, audit).
   const serverPerms = getServerPermissions();
 
-  $effect(() => {
-    if (isAdminMode && !wasAdminMode) {
-      adminGroupExpanded = true;
-    }
-    wasAdminMode = isAdminMode;
-  });
-
   // Admin navigation items - filtered based on permissions
-  const adminNavItems = $derived.by(() => {
-    if (!spaceData) return [];
-    if (!spaceData.hasAnyAdminPermission && !serverPerms.current.canViewAdmin) return [];
-
-    const items: { href: string; label: string; icon: string }[] = [];
-
-    if (spaceData.canManage) {
-      items.push({
-        href: resolve('/chat/[serverId]/server-admin/general', { serverId: serverSegment }),
-        label: 'General',
-        icon: 'iconify uil--setting'
-      });
-    }
-
-    if (spaceData.canAssignRoles || serverPerms.current.canAdminViewUsers) {
-      items.push({
-        href: resolve('/chat/[serverId]/server-admin/members', { serverId: serverSegment }),
-        label: 'Members',
-        icon: 'iconify uil--users-alt'
-      });
-    }
-
-    if (spaceData.canManageRooms) {
-      items.push({
-        href: resolve('/chat/[serverId]/server-admin/rooms', { serverId: serverSegment }),
-        label: 'Rooms',
-        icon: 'iconify uil--apps'
-      });
-    }
-
-    if (spaceData.hasAnyAdminPermission) {
-      items.push({
-        href: resolve('/chat/[serverId]/server-admin/moderation', { serverId: serverSegment }),
-        label: 'Moderation',
-        icon: 'iconify uil--ban'
-      });
-    }
-
-    if (spaceData.canManageRoles || serverPerms.current.canAdminViewRoles) {
-      items.push({
-        href: resolve('/chat/[serverId]/server-admin/permissions', { serverId: serverSegment }),
-        label: 'Permissions',
-        icon: 'iconify uil--shield-check'
-      });
-    }
-
-    if (spaceData.canManage) {
-      items.push({
-        href: resolve('/chat/[serverId]/server-admin/security', { serverId: serverSegment }),
-        label: 'Security',
-        icon: 'iconify uil--shield-exclamation'
-      });
-    }
-
-    if (serverPerms.current.canAdminViewAudit) {
-      items.push({
-        href: resolve('/chat/[serverId]/server-admin/event-log', { serverId: serverSegment }),
-        label: 'Event Log',
-        icon: 'iconify uil--history'
-      });
-    }
-
-    if (serverPerms.current.canAdminViewSystem) {
-      items.push({
-        href: resolve('/chat/[serverId]/server-admin/system', { serverId: serverSegment }),
-        label: 'System',
-        icon: 'iconify uil--server'
-      });
-    }
-
-    return items;
-  });
-
-  // Check if an admin nav item is active (custom logic for nested URLs)
-  function isAdminNavActive(href: string, _items: unknown): boolean {
-    const adminBase = resolve('/chat/[serverId]/server-admin', { serverId: serverSegment });
-    if (href === adminBase) {
-      return page.url.pathname === adminBase;
-    }
-    return page.url.pathname.startsWith(href);
-  }
+  const adminNavItems = $derived(
+    getAdminNavItems({
+      serverSegment,
+      space: spaceData,
+      server: serverPerms.current
+    })
+  );
 </script>
 
 <ServerEventProvider>
@@ -392,42 +310,13 @@
                   <span class="sidebar-icon iconify uil--bell"></span>
                   Preferences
                 </a>
-                {#if adminNavItems.length > 0}
-                  <button
-                    type="button"
-                    class="sidebar-item text-left"
-                    aria-expanded={adminGroupExpanded}
-                    aria-controls="server-admin-sidebar-links"
-                    onclick={() => {
-                      adminGroupExpanded = !adminGroupExpanded;
-                    }}
-                  >
-                    <span class="sidebar-icon iconify uil--setting"></span>
-                    <span class="min-w-0 flex-1 truncate">Administration</span>
-                    <span
-                      class={[
-                        'iconify uil--angle-right-b shrink-0 text-base text-muted transition-transform',
-                        adminGroupExpanded ? 'rotate-90' : ''
-                      ]}
-                    ></span>
-                  </button>
-                  {#if adminGroupExpanded}
-                    <div id="server-admin-sidebar-links" class="sidebar-nav">
-                      {#each adminNavItems as item (item.href)}
-                        <a
-                          href={item.href}
-                          class={[
-                            'sidebar-item pl-8',
-                            isAdminNavActive(item.href, adminNavItems) ? 'bg-surface-100' : ''
-                          ]}
-                        >
-                          <span class="sidebar-icon {item.icon}"></span>
-                          {item.label}
-                        </a>
-                      {/each}
-                    </div>
-                  {/if}
-                {/if}
+                {#key isAdminMode}
+                  <AdminSidebarGroup
+                    currentPath={page.url.pathname}
+                    expandedByDefault={isAdminMode}
+                    items={adminNavItems}
+                  />
+                {/key}
               </nav>
 
               <hr class="border-border" />

--- a/frontend/src/lib/components/chat/adminNav.ts
+++ b/frontend/src/lib/components/chat/adminNav.ts
@@ -1,0 +1,104 @@
+import { resolve } from '$app/paths';
+
+export type AdminNavSpacePermissions = {
+  hasAnyAdminPermission: boolean;
+  canManage: boolean;
+  canManageRooms: boolean;
+  canManageRoles: boolean;
+  canAssignRoles: boolean;
+};
+
+export type AdminNavServerPermissions = {
+  canViewAdmin: boolean;
+  canAdminViewUsers: boolean;
+  canAdminViewRoles: boolean;
+  canAdminViewAudit: boolean;
+  canAdminViewSystem: boolean;
+};
+
+export type AdminNavItem = {
+  href: string;
+  label: string;
+  icon: string;
+};
+
+export function getAdminNavItems({
+  serverSegment,
+  space,
+  server
+}: {
+  serverSegment: string;
+  space: AdminNavSpacePermissions | null;
+  server: AdminNavServerPermissions;
+}): AdminNavItem[] {
+  if (!space) return [];
+  if (!space.hasAnyAdminPermission && !server.canViewAdmin) return [];
+
+  const items: AdminNavItem[] = [];
+
+  if (space.canManage) {
+    items.push({
+      href: resolve('/chat/[serverId]/server-admin/general', { serverId: serverSegment }),
+      label: 'General',
+      icon: 'iconify uil--setting'
+    });
+  }
+
+  if (space.canAssignRoles || server.canAdminViewUsers) {
+    items.push({
+      href: resolve('/chat/[serverId]/server-admin/members', { serverId: serverSegment }),
+      label: 'Members',
+      icon: 'iconify uil--users-alt'
+    });
+  }
+
+  if (space.canManageRooms) {
+    items.push({
+      href: resolve('/chat/[serverId]/server-admin/rooms', { serverId: serverSegment }),
+      label: 'Rooms',
+      icon: 'iconify uil--apps'
+    });
+  }
+
+  if (space.hasAnyAdminPermission) {
+    items.push({
+      href: resolve('/chat/[serverId]/server-admin/moderation', { serverId: serverSegment }),
+      label: 'Moderation',
+      icon: 'iconify uil--ban'
+    });
+  }
+
+  if (space.canManageRoles || server.canAdminViewRoles) {
+    items.push({
+      href: resolve('/chat/[serverId]/server-admin/permissions', { serverId: serverSegment }),
+      label: 'Permissions',
+      icon: 'iconify uil--shield-check'
+    });
+  }
+
+  if (space.canManage) {
+    items.push({
+      href: resolve('/chat/[serverId]/server-admin/security', { serverId: serverSegment }),
+      label: 'Security',
+      icon: 'iconify uil--shield-exclamation'
+    });
+  }
+
+  if (server.canAdminViewAudit) {
+    items.push({
+      href: resolve('/chat/[serverId]/server-admin/event-log', { serverId: serverSegment }),
+      label: 'Event Log',
+      icon: 'iconify uil--history'
+    });
+  }
+
+  if (server.canAdminViewSystem) {
+    items.push({
+      href: resolve('/chat/[serverId]/server-admin/system', { serverId: serverSegment }),
+      label: 'System',
+      icon: 'iconify uil--server'
+    });
+  }
+
+  return items;
+}


### PR DESCRIPTION
## Summary

- Extracts inline Administration sidebar rendering into `AdminSidebarGroup.svelte`.
- Moves admin nav permission/link mapping into `adminNav.ts`.
- Keeps `Chrome.svelte` focused on composing sidebar state while preserving admin route expansion and active child highlighting.

## Tests

- `mise lint-frontend`
- `cd frontend && mise x -- pnpm exec playwright test e2e/admin.test.ts --retries=0`
- `cd frontend && mise x -- pnpm exec playwright test e2e/mobile-nav.test.ts --retries=0`
