### PR TITLE
fix(assets): sandbox active attachment responses

### DIFF
--- a/cli/internal/http_server/assets.go
+++ b/cli/internal/http_server/assets.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -121,12 +122,15 @@ func (s *HTTPServer) serveAttachment(c *gin.Context) {
 
 	s.logger.Debug("Serving attachment", "attachment_id", loc.AttachmentID)
 
-	// Try S3 presigned redirect first (zero-copy, full Range support).
-	if presignedURL, err := s.core.TryPresignedAttachmentURL(ctx, attachment); err == nil {
-		// Cache the redirect itself — the attachment URL is immutable
-		c.Header("Cache-Control", "public, max-age=3600")
-		c.Redirect(http.StatusFound, presignedURL)
-		return
+	// Try S3 presigned redirect first (zero-copy, full Range support) for
+	// attachment types that do not need Chatto-served security headers.
+	if attachmentCanUsePresignedRedirect(attachment.GetContentType()) {
+		if presignedURL, err := s.core.TryPresignedAttachmentURL(ctx, attachment); err == nil {
+			// Cache the redirect itself — the attachment URL is immutable
+			c.Header("Cache-Control", "public, max-age=3600")
+			c.Redirect(http.StatusFound, presignedURL)
+			return
+		}
 	}
 
 	// Otherwise stream from the recorded backend.
@@ -144,9 +148,9 @@ func (s *HTTPServer) serveAttachment(c *gin.Context) {
 	if contentType == "" {
 		contentType = "application/octet-stream"
 	}
+	setOriginalAttachmentSecurityHeaders(c, contentType)
 
-	// Immutable asset - cache forever
-	c.Header("Cache-Control", "public, max-age=31536000, immutable")
+	c.Header("Cache-Control", legacyAttachmentCacheControl(contentType))
 	c.Header("ETag", fmt.Sprintf("\"%s\"", loc.AttachmentID))
 	c.Header("Vary", "Accept-Encoding")
 
@@ -176,10 +180,14 @@ func (s *HTTPServer) serveStableAttachment(c *gin.Context) {
 	if c.GetHeader("X-Chatto-Asset-Proxy") != "1" {
 		// Try S3 presigned redirect first (zero-copy, full Range support) after
 		// validating the asset ticket/request credentials and room membership.
-		if presignedURL, err := s.core.TryPresignedAttachmentURL(ctx, attachment); err == nil {
-			c.Header("Cache-Control", "private, max-age=3600")
-			c.Redirect(http.StatusFound, presignedURL)
-			return
+		// Active document formats must stream through Chatto so the sandbox CSP
+		// below cannot be bypassed by S3's response headers.
+		if attachmentCanUsePresignedRedirect(attachment.GetContentType()) {
+			if presignedURL, err := s.core.TryPresignedAttachmentURL(ctx, attachment); err == nil {
+				c.Header("Cache-Control", "private, max-age=3600")
+				c.Redirect(http.StatusFound, presignedURL)
+				return
+			}
 		}
 	}
 
@@ -197,11 +205,47 @@ func (s *HTTPServer) serveStableAttachment(c *gin.Context) {
 	if contentType == "" {
 		contentType = "application/octet-stream"
 	}
+	setOriginalAttachmentSecurityHeaders(c, contentType)
 
 	c.Header("Cache-Control", "private, max-age=3600")
 	c.Header("ETag", fmt.Sprintf("\"%s\"", assetID))
 	c.Header("Vary", "Accept-Encoding, Authorization, Cookie, X-Chatto-Asset-Proxy")
 	c.DataFromReader(http.StatusOK, info.Size, contentType, reader, nil)
+}
+
+const originalAttachmentSandboxCSP = "sandbox"
+
+func setOriginalAttachmentSecurityHeaders(c *gin.Context, contentType string) {
+	c.Header("X-Content-Type-Options", "nosniff")
+	if originalAttachmentNeedsSandbox(contentType) {
+		c.Header("Content-Security-Policy", originalAttachmentSandboxCSP)
+	}
+}
+
+func attachmentCanUsePresignedRedirect(contentType string) bool {
+	return !originalAttachmentNeedsSandbox(contentType)
+}
+
+func originalAttachmentNeedsSandbox(contentType string) bool {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		mediaType = strings.TrimSpace(strings.Split(contentType, ";")[0])
+	}
+	mediaType = strings.ToLower(mediaType)
+
+	switch mediaType {
+	case "text/html", "application/xhtml+xml", "image/svg+xml", "application/xml", "text/xml":
+		return true
+	default:
+		return strings.HasSuffix(mediaType, "+xml")
+	}
+}
+
+func legacyAttachmentCacheControl(contentType string) string {
+	if originalAttachmentNeedsSandbox(contentType) {
+		return fmt.Sprintf("private, max-age=%d", int(core.AttachmentURLTTL.Seconds()))
+	}
+	return "public, max-age=31536000, immutable"
 }
 
 // serveStableTransformedAttachment serves an authenticated image derivative:

--- a/cli/internal/http_server/assets_test.go
+++ b/cli/internal/http_server/assets_test.go
@@ -192,6 +192,11 @@ func createAssetTestPNG(t *testing.T, width, height int) []byte {
 // doAssetMultipartUpload performs a GraphQL multipart upload request for attachments
 func (env *assetTestEnv) doAssetMultipartUpload(t *testing.T, operations string, fileData []byte, fileName string) *graphqlResponse {
 	t.Helper()
+	return env.doAssetMultipartUploadWithContentType(t, operations, fileData, fileName, "image/png")
+}
+
+func (env *assetTestEnv) doAssetMultipartUploadWithContentType(t *testing.T, operations string, fileData []byte, fileName, contentType string) *graphqlResponse {
+	t.Helper()
 
 	// Create multipart form
 	var body bytes.Buffer
@@ -210,7 +215,7 @@ func (env *assetTestEnv) doAssetMultipartUpload(t *testing.T, operations string,
 	// Add file with correct content type header
 	h := make(textproto.MIMEHeader)
 	h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="0"; filename="%s"`, fileName))
-	h.Set("Content-Type", "image/png") // Set content type explicitly for PNG images
+	h.Set("Content-Type", contentType)
 	part, err := writer.CreatePart(h)
 	if err != nil {
 		t.Fatalf("Failed to create form file: %v", err)
@@ -562,6 +567,206 @@ func TestAsset_OriginalAttachment_ServesCorrectly(t *testing.T) {
 	}
 	if len(body) == 0 {
 		t.Error("Expected non-empty response body")
+	}
+}
+
+func TestAsset_ActiveAttachment_UsesSandboxHeaders(t *testing.T) {
+	env := setupAssetTestServer(t)
+
+	user, err := env.core.CreateUser(env.ctx, "system", "sandboxuser", "Sandbox User", "password123")
+	if err != nil {
+		t.Fatalf("Failed to create user: %v", err)
+	}
+	room, err := env.core.CreateRoom(env.ctx, user.Id, "channel", "", "sandboxroom", "Sandbox Room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	if _, err := env.core.JoinRoom(env.ctx, user.Id, "channel", user.Id, room.Id); err != nil {
+		t.Fatalf("Failed to join room: %v", err)
+	}
+	env.login(t, "sandboxuser", "password123")
+
+	operations := fmt.Sprintf(`{
+		"query": "mutation($roomId: ID!, $body: String!, $file: Upload!) { postMessage(input: { roomId: $roomId, body: $body, attachments: [$file] }) { event { ... on MessagePostedEvent { attachments { id url contentType } } } } }",
+		"variables": { "roomId": "%s", "body": "html attachment", "file": null }
+	}`, room.Id)
+	resp := env.doAssetMultipartUploadWithContentType(
+		t,
+		operations,
+		[]byte("<!doctype html><script>window.__ran = true</script>"),
+		"demo.html",
+		"text/html; charset=utf-8",
+	)
+	if len(resp.Errors) > 0 {
+		t.Fatalf("Failed to post message with HTML attachment: %v", resp.Errors)
+	}
+
+	var data struct {
+		PostMessage struct {
+			Event struct {
+				Attachments []struct {
+					ID          string `json:"id"`
+					URL         string `json:"url"`
+					ContentType string `json:"contentType"`
+				} `json:"attachments"`
+			} `json:"event"`
+		} `json:"postMessage"`
+	}
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+	if len(data.PostMessage.Event.Attachments) != 1 {
+		t.Fatalf("Expected one attachment, got %d", len(data.PostMessage.Event.Attachments))
+	}
+	attachment := data.PostMessage.Event.Attachments[0]
+
+	stableResp, err := env.client.Get(env.server.URL + attachment.URL)
+	if err != nil {
+		t.Fatalf("Failed to fetch stable attachment URL: %v", err)
+	}
+	stableResp.Body.Close()
+	if stableResp.StatusCode != http.StatusOK {
+		t.Fatalf("Expected stable attachment status 200, got %d", stableResp.StatusCode)
+	}
+	assertSandboxedOriginalAttachment(t, stableResp)
+
+	loc := signedurl.AttachmentLocator{RoomID: room.Id, AttachmentID: attachment.ID}
+	signedURL := env.core.GetAttachmentURL(loc, user.Id)
+	legacyResp, err := (&http.Client{}).Get(env.server.URL + signedURL)
+	if err != nil {
+		t.Fatalf("Failed to fetch legacy signed attachment URL: %v", err)
+	}
+	legacyResp.Body.Close()
+	if legacyResp.StatusCode != http.StatusOK {
+		t.Fatalf("Expected legacy signed attachment status 200, got %d", legacyResp.StatusCode)
+	}
+	assertSandboxedOriginalAttachment(t, legacyResp)
+	assertLegacySandboxedAttachmentCache(t, legacyResp)
+}
+
+func TestAsset_ActiveAttachmentOnS3_StreamsWithSandboxInsteadOfRedirect(t *testing.T) {
+	env := setupAssetTestServerWithS3(t)
+
+	user, err := env.core.CreateUser(env.ctx, "system", "s3sandboxuser", "S3 Sandbox User", "password123")
+	if err != nil {
+		t.Fatalf("Failed to create user: %v", err)
+	}
+	room, err := env.core.CreateRoom(env.ctx, user.Id, "channel", "", "s3sandboxroom", "S3 Sandbox Room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	if _, err := env.core.JoinRoom(env.ctx, user.Id, "channel", user.Id, room.Id); err != nil {
+		t.Fatalf("Failed to join room: %v", err)
+	}
+	env.login(t, "s3sandboxuser", "password123")
+
+	operations := fmt.Sprintf(`{
+		"query": "mutation($roomId: ID!, $body: String!, $file: Upload!) { postMessage(input: { roomId: $roomId, body: $body, attachments: [$file] }) { event { ... on MessagePostedEvent { attachments { id url } } } } }",
+		"variables": { "roomId": "%s", "body": "s3 html attachment", "file": null }
+	}`, room.Id)
+	resp := env.doAssetMultipartUploadWithContentType(
+		t,
+		operations,
+		[]byte("<!doctype html><script>window.__ran = true</script>"),
+		"s3-demo.html",
+		"text/html",
+	)
+	if len(resp.Errors) > 0 {
+		t.Fatalf("Failed to post message with S3 HTML attachment: %v", resp.Errors)
+	}
+
+	var data struct {
+		PostMessage struct {
+			Event struct {
+				Attachments []struct {
+					ID  string `json:"id"`
+					URL string `json:"url"`
+				} `json:"attachments"`
+			} `json:"event"`
+		} `json:"postMessage"`
+	}
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+	if len(data.PostMessage.Event.Attachments) != 1 {
+		t.Fatalf("Expected one attachment, got %d", len(data.PostMessage.Event.Attachments))
+	}
+	attachment := data.PostMessage.Event.Attachments[0]
+
+	noRedirectClient := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	stableResp, err := noRedirectClient.Get(env.server.URL + attachment.URL)
+	if err != nil {
+		t.Fatalf("Failed to fetch S3 stable attachment URL: %v", err)
+	}
+	stableResp.Body.Close()
+	if stableResp.StatusCode != http.StatusOK {
+		t.Fatalf("Expected S3 stable attachment to stream with 200, got %d", stableResp.StatusCode)
+	}
+	assertSandboxedOriginalAttachment(t, stableResp)
+
+	loc := signedurl.AttachmentLocator{RoomID: room.Id, AttachmentID: attachment.ID}
+	signedURL := env.core.GetAttachmentURL(loc, user.Id)
+	legacyResp, err := noRedirectClient.Get(env.server.URL + signedURL)
+	if err != nil {
+		t.Fatalf("Failed to fetch S3 legacy signed attachment URL: %v", err)
+	}
+	legacyResp.Body.Close()
+	if legacyResp.StatusCode != http.StatusOK {
+		t.Fatalf("Expected S3 legacy attachment to stream with 200, got %d", legacyResp.StatusCode)
+	}
+	assertSandboxedOriginalAttachment(t, legacyResp)
+	assertLegacySandboxedAttachmentCache(t, legacyResp)
+}
+
+func TestOriginalAttachmentNeedsSandbox(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		want        bool
+	}{
+		{name: "HTML", contentType: "text/html", want: true},
+		{name: "HTML with parameters", contentType: "text/html; charset=utf-8", want: true},
+		{name: "XHTML", contentType: "application/xhtml+xml", want: true},
+		{name: "SVG", contentType: "image/svg+xml", want: true},
+		{name: "XML", contentType: "application/xml", want: true},
+		{name: "XML suffix", contentType: "application/atom+xml", want: true},
+		{name: "PNG", contentType: "image/png", want: false},
+		{name: "PDF", contentType: "application/pdf", want: false},
+		{name: "unknown", contentType: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := originalAttachmentNeedsSandbox(tt.contentType); got != tt.want {
+				t.Fatalf("originalAttachmentNeedsSandbox(%q) = %v, want %v", tt.contentType, got, tt.want)
+			}
+		})
+	}
+}
+
+func assertSandboxedOriginalAttachment(t *testing.T, resp *http.Response) {
+	t.Helper()
+	if got := resp.Header.Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("X-Content-Type-Options = %q, want nosniff", got)
+	}
+	if got := resp.Header.Get("Content-Security-Policy"); got != originalAttachmentSandboxCSP {
+		t.Fatalf("Content-Security-Policy = %q, want %q", got, originalAttachmentSandboxCSP)
+	}
+	if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/html") {
+		t.Fatalf("Content-Type = %q, want text/html", got)
+	}
+}
+
+func assertLegacySandboxedAttachmentCache(t *testing.T, resp *http.Response) {
+	t.Helper()
+	want := fmt.Sprintf("private, max-age=%d", int(core.AttachmentURLTTL.Seconds()))
+	if got := resp.Header.Get("Cache-Control"); got != want {
+		t.Fatalf("Cache-Control = %q, want %q", got, want)
 	}
 }
 

--- a/docs-website/src/content/docs/guides/security.mdx
+++ b/docs-website/src/content/docs/guides/security.mdx
@@ -184,6 +184,8 @@ Every frontend response sets:
 | `X-Frame-Options`         | `DENY`                             |
 | `Referrer-Policy`         | `strict-origin-when-cross-origin`  |
 
+Original attachment responses also set `X-Content-Type-Options: nosniff`. Uploaded active document formats such as HTML, XHTML, SVG, and XML are served with `Content-Security-Policy: sandbox`; S3-backed files of those types stream through Chatto instead of redirecting directly to object storage so that policy is preserved.
+
 For HSTS, CSP, and other policy headers, add them at your reverse proxy.
 
 ## Secret and key storage

--- a/docs/fdr/FDR-008-file-attachments-and-video.md
+++ b/docs/fdr/FDR-008-file-attachments-and-video.md
@@ -1,7 +1,7 @@
 # FDR-008: File Attachments & Video Processing
 
 **Status:** Active
-**Last reviewed:** 2026-06-05
+**Last reviewed:** 2026-06-10
 
 ## Overview
 
@@ -19,6 +19,7 @@ Users can attach files to messages — images, videos, documents — via drag-an
 - A thumbnail is generated from an early video frame.
 - Resized images can be cached as WebP with an auto-expiring cache.
 - In Service Worker-controlled browser sessions, stable asset URLs are rendered as same-origin virtual URLs and proxied to the owning server with the user's registered server credentials. Successful full responses are cached privately in the browser; media `Range` requests bypass that cache.
+- Active document attachment types such as HTML, XHTML, SVG, and XML can still be uploaded and viewed inline, but original-file responses are delivered in a browser sandbox so uploaded scripts do not run as trusted Chatto application code.
 
 ## Design Decisions
 
@@ -57,6 +58,12 @@ Users can attach files to messages — images, videos, documents — via drag-an
 **Decision:** GraphQL exposes attachment media as stable asset paths plus per-user access tickets: `/assets/files/{assetId}?access={ticket}` for originals and `/assets/files/{assetId}/image/{width}x{height}/{fit}?access={ticket}` for image derivatives. `Attachment.assetUrl` / `thumbnailAssetUrl`, video thumbnail URLs, and variant URLs also expose the ticket expiry so the client can refresh before or after a lazy-load miss. Every fetch verifies the signed user is still a member of the asset's room.
 **Why:** Cross-origin `<img>` tags (used when the SPA loads attachments from a *remote* registered server) can't carry session cookies (SameSite) or Authorization headers. A signed per-user access ticket lets browsers load remote attachments directly, while the room-membership check still auto-revokes access on kick/leave.
 **Tradeoff:** The access ticket is still a bearer capability — anyone holding it can fetch until the expiry passes or the signed user loses room membership. `core.AssetAccessTicketTTL` is currently **1 hour** so normal rendering, lazy loading, media startup, and lightbox use are reliable; clients refresh URL fields via GraphQL when tickets approach expiry or a media load fails. In Service Worker-controlled sessions, the DOM uses non-portable same-origin virtual URLs under `/__chatto/assets/{serverId}/...`; the worker keeps the ticketed target URL out of markup, fetches through the registered server credentials when possible, and caches full successful responses in a private per-browser cache. This removes the "lazy copy URL grants access" problem for the main web app, while keeping ticketed URLs as fallback for non-Service-Worker clients and for media `Range` redirects. Legacy `/assets/attachments/{signedLocator}` URLs remain supported for compatibility/internal fallback and use the shorter 5-minute locator TTL. Rotating `[core.assets].signing_secret` invalidates all outstanding tickets and legacy locators at once.
+
+### 7. Active document attachments render in a browser sandbox
+
+**Decision:** Original attachment responses for active document formats (HTML, XHTML, SVG, XML, and XML-derived media types) include a CSP sandbox and `nosniff`. S3-backed attachments of those types stream through Chatto instead of redirecting directly to a presigned object URL, so the same response policy applies.
+**Why:** Some teams need to share these file types inline, but uploaded active content must not become trusted Chatto application code. A sandbox without same-origin privileges preserves the viewing use case while preventing the easiest same-origin stored-XSS path.
+**Tradeoff:** Scripts, forms, top-level navigation, and same-origin APIs are restricted inside uploaded active documents. S3 deployments also lose the zero-copy redirect fast path for those active document types, while ordinary media files keep it.
 
 ## Permissions
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -17,7 +17,7 @@ See [`.claude/skills/fdr/SKILL.md`](../../.claude/skills/fdr/SKILL.md) for the F
 | [FDR-005](FDR-005-reactions.md) | Reactions | Active | 2026-05-19 |
 | [FDR-006](FDR-006-mentions.md) | @Mentions | Active | 2026-06-05 |
 | [FDR-007](FDR-007-direct-messages.md) | Direct Messages | Active | 2026-05-31 |
-| [FDR-008](FDR-008-file-attachments-and-video.md) | File Attachments & Video Processing | Active | 2026-05-19 |
+| [FDR-008](FDR-008-file-attachments-and-video.md) | File Attachments & Video Processing | Active | 2026-06-10 |
 | [FDR-009](FDR-009-link-previews.md) | Link Previews | Active | 2026-06-06 |
 | [FDR-010](FDR-010-typing-indicators.md) | Typing Indicators | Active | 2026-05-19 |
 | [FDR-011](FDR-011-user-presence.md) | User Presence | Active | 2026-05-19 |


### PR DESCRIPTION
- Adds sandbox CSP and `nosniff` headers for active document attachment originals such as HTML, XHTML, SVG, XML, and XML-derived media types.
- Streams sandboxed S3-backed originals through Chatto instead of redirecting directly to presigned object URLs, and bounds legacy signed active-document cache lifetimes to the locator TTL.
- Adds regression coverage for stable URLs, legacy signed URLs, S3 redirect bypass prevention, MIME classification, and legacy cache policy.
- Updates FDR-008 and the self-hosting security guide to document active attachment sandboxing.

Tests:
- `mise x -- go test -tags test_endpoints ./internal/http_server -timeout 60s`
- `mise test-cli`
