### PR TITLE
refactor: split message composer state

### DIFF
--- a/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -1,39 +1,25 @@
-<script module lang="ts">
-  // Module-level Map to stash file attachments across room switches.
-  // Files can't go in sessionStorage (not serializable), but this Map
-  // survives component re-mounts within the same SPA session.
-  type FileWithUrl = { file: File; url: string };
-  // eslint-disable-next-line svelte/prefer-svelte-reactivity -- module-level stash, never read reactively
-  const draftFilesMap = new Map<string, FileWithUrl[]>();
-</script>
-
 <script lang="ts">
   import { tick, untrack } from 'svelte';
-  import { SvelteMap, SvelteSet } from 'svelte/reactivity';
   import { graphql } from '$lib/gql';
-  import type { LinkPreviewForComposerQuery } from '$lib/gql/graphql';
-
-  type ComposerLinkPreview = NonNullable<LinkPreviewForComposerQuery['linkPreview']>;
   import { useConnection } from '$lib/state/server/connection.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
-  import { extractURLs } from '$lib/linkPreview';
   import { parseMessageLink } from '$lib/messageLinks';
-  import LinkPreviewCard, { LinkPreviewFragment } from '$lib/components/LinkPreviewCard.svelte';
+  import LinkPreviewCard from '$lib/components/LinkPreviewCard.svelte';
   import LinkPreviewSkeleton from '$lib/components/LinkPreviewSkeleton.svelte';
-  import { useFragment } from '$lib/gql/fragment-masking';
   import MessagePreviewCard from '$lib/components/MessagePreviewCard.svelte';
   import { toast } from '$lib/ui/toast';
   import { getRoomMembers, getComposerContext } from '$lib/state/room';
   import { shouldAutoFocus } from '$lib/utils/shouldAutoFocus';
   import { isTouchDevice } from '$lib/utils/isTouchDevice';
   import { hasVisibleContent } from '$lib/validation';
-  import { fuzzyMatch } from '$lib/fuzzyMatch';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
-  import { searchEmojis } from '$lib/emoji';
   import EmojiAutocomplete from '$lib/components/composer/EmojiAutocomplete.svelte';
   import MentionAutocomplete from '$lib/components/composer/MentionAutocomplete.svelte';
   import TipTapEditor, { type TipTapEditorApi } from './TipTapEditor.svelte';
-  import { prepareFiles } from '$lib/attachments/prepareFiles';
+  import { DraftState, draftKey } from './draft.svelte';
+  import { AttachmentsState } from './attachments.svelte';
+  import { LinkPreviewState } from './linkPreviews.svelte';
+  import { AutocompleteState } from './autocomplete.svelte';
 
   const stores = serverRegistry.getStore(getActiveServer());
   const serverInfo = stores.serverInfo;
@@ -105,13 +91,18 @@
     return () => observer.disconnect();
   });
 
-  const DRAFT_KEY = $derived(
-    inThread ? `chatto:draft:${roomId}:thread:${inThread}` : `chatto:draft:${roomId}`
-  );
+  const DRAFT_KEY = $derived(draftKey(roomId, inThread));
   let message = $state('');
 
   // TipTap editor API (received via onReady callback)
   let editorApi = $state<TipTapEditorApi | null>(null);
+  const draftState = new DraftState();
+  const attachments = new AttachmentsState(() => serverInfo);
+  const linkPreviews = new LinkPreviewState(() => connection().client);
+  const autocomplete = new AutocompleteState(
+    () => editorApi,
+    () => members
+  );
 
   // Dynamic placeholder changes between normal and edit mode
   let currentPlaceholder = $derived(
@@ -121,50 +112,57 @@
   // Testid for E2E tests - distinguishes main input from thread reply input
   let testid = $derived(inThread ? 'thread-reply-input' : 'message-input');
 
-  // Track previous editing state to detect transitions
-  let wasEditing = $state(false);
+  // Track editing transitions by event identity so editor setContent() doesn't
+  // run repeatedly while TipTap echoes updates back through onUpdate.
+  let editSeededForEvent = '';
 
   // When entering edit mode, pre-fill with original message body and clear any pending attachments.
   // When exiting edit mode (cancelled or message deleted), clear the input.
   $effect(() => {
-    if (editState.eventId && editState.originalBody) {
-      message = editState.originalBody;
-      wasEditing = true;
-      editorApi?.setContent(editState.originalBody);
-      tick().then(() => editorApi?.focus('end'));
+    const eventId = editState.eventId;
+    const originalBody = editState.originalBody;
+    const api = editorApi;
 
-      // Clear pending file attachments — editMessage only supports text.
-      // Use untrack() to avoid making filesWithUrls a dependency of this effect,
-      // which would cause re-runs that overwrite the message with originalBody.
-      untrack(() => {
-        for (const { url } of filesWithUrls) {
-          URL.revokeObjectURL(url);
-        }
-        filesWithUrls = [];
-      });
-    } else if (wasEditing && !editState.eventId) {
+    if (eventId && originalBody && editSeededForEvent !== eventId) {
+      editSeededForEvent = eventId;
+      draftState.clearText();
+      message = originalBody;
+      api?.setContent(originalBody);
+      tick().then(() => api?.focus('end'));
+      attachments.clear();
+      linkPreviews.clear();
+    } else if (editSeededForEvent && !eventId) {
       // Exiting edit mode - clear the input
       message = '';
-      wasEditing = false;
-      editorApi?.setContent('');
+      editSeededForEvent = '';
+      api?.setContent('');
     }
   });
 
   // Load draft from sessionStorage when room changes
   // Using sessionStorage (not localStorage) so drafts are tab-specific
   $effect(() => {
-    const draft = sessionStorage.getItem(DRAFT_KEY) ?? '';
+    if (isEditing) {
+      draftState.switchKey(DRAFT_KEY);
+      attachments.restore([]);
+      return;
+    }
+
+    const draft = draftState.switchKey(DRAFT_KEY);
     message = draft;
     editorApi?.setContent(draft);
+    attachments.restore(untrack(() => draftState.takeFiles()));
+
+    return () => {
+      draftState.stashFiles(untrack(() => attachments.filesWithUrls));
+    };
   });
 
   // Persist draft to sessionStorage
   $effect(() => {
-    if (message) {
-      sessionStorage.setItem(DRAFT_KEY, message);
-    } else {
-      sessionStorage.removeItem(DRAFT_KEY);
-    }
+    void DRAFT_KEY;
+    if (isEditing) return;
+    draftState.persistText(message);
   });
 
   const PostMessageMutation = graphql(`
@@ -181,116 +179,12 @@
     }
   `);
 
-  const LinkPreviewQuery = graphql(`
-    query LinkPreviewForComposer($url: String!) {
-      linkPreview(url: $url) {
-        ...LinkPreviewView
-        imageAssetId
-      }
-    }
-  `);
-
-  // Link preview state
-  let detectedURLs = $state<string[]>([]);
-  const previews = new SvelteMap<string, ComposerLinkPreview | null>();
-  const dismissedURLs = new SvelteSet<string>();
-  const fetchingURLs = new SvelteSet<string>();
-
-  // Debounced URL detection (500ms)
-  let urlDetectionTimeout: ReturnType<typeof setTimeout>;
-
   $effect(() => {
-    // Track message for reactivity
-    const currentMessage = message;
-
-    // Clear previous timeout
-    clearTimeout(urlDetectionTimeout);
-
-    // Don't detect URLs in edit mode
-    if (isEditing) {
-      detectedURLs = [];
-      return;
-    }
-
-    urlDetectionTimeout = setTimeout(() => {
-      const urls = extractURLs(currentMessage).filter((u) => !dismissedURLs.has(u));
-      detectedURLs = urls;
-
-      // Fetch OG previews for new URLs (skip message links — those are rendered from a separate GraphQL query)
-      for (const url of urls) {
-        if (parseMessageLink(url)) continue;
-        if (!previews.has(url) && !fetchingURLs.has(url)) {
-          fetchPreview(url);
-        }
-      }
-    }, 500);
-
-    return () => clearTimeout(urlDetectionTimeout);
+    return linkPreviews.scheduleDetection(message, isEditing);
   });
-
-  async function fetchPreview(url: string) {
-    fetchingURLs.add(url);
-
-    const result = await connection().client.query(LinkPreviewQuery, { url });
-
-    fetchingURLs.delete(url);
-
-    if (result.data?.linkPreview) {
-      previews.set(url, result.data.linkPreview);
-    } else {
-      // Mark as fetched but no preview available
-      previews.set(url, null);
-    }
-  }
-
-  function dismissPreview(url: string) {
-    dismissedURLs.add(url);
-    detectedURLs = detectedURLs.filter((u) => u !== url);
-  }
-
-  // Clear link preview state when message is sent
-  function clearLinkPreviews() {
-    detectedURLs = [];
-    previews.clear();
-    dismissedURLs.clear();
-    fetchingURLs.clear();
-  }
 
   let loading = $state(false);
   let fileInputElement = $state<HTMLInputElement>();
-
-  let filesWithUrls = $state<FileWithUrl[]>([]);
-  let pendingAttachmentCount = $state(0);
-
-  // Derive just the files for posting
-  let selectedFiles = $derived(filesWithUrls.map((f) => f.file));
-
-  const attachmentAccept = $derived(
-    serverInfo.videoProcessingEnabled ? 'image/*,video/*,audio/*' : 'image/*,audio/*'
-  );
-
-  // Save/restore draft file attachments across room switches.
-  // When leaving a room (DRAFT_KEY changes or unmount), stash files in the
-  // module-level Map. When entering a room, restore any stashed files.
-  $effect(() => {
-    const key = DRAFT_KEY;
-
-    const saved = draftFilesMap.get(key);
-    if (saved) {
-      filesWithUrls = saved;
-      draftFilesMap.delete(key);
-    } else {
-      filesWithUrls = [];
-    }
-
-    return () => {
-      if (filesWithUrls.length > 0) {
-        draftFilesMap.set(key, filesWithUrls);
-      } else {
-        draftFilesMap.delete(key);
-      }
-    };
-  });
 
   // Input is disabled when user can't post or websocket is disconnected.
   // Note: loading is intentionally excluded — the editor stays editable during sends
@@ -302,8 +196,8 @@
   let canSubmit = $derived(
     !loading &&
       !inputDisabled &&
-      pendingAttachmentCount === 0 &&
-      (hasVisibleContent(message) || selectedFiles.length > 0 || isEditing)
+      attachments.pendingCount === 0 &&
+      (hasVisibleContent(message) || attachments.selectedFiles.length > 0 || isEditing)
   );
 
   // Auto-focus the input when the component mounts, room changes, a reply
@@ -323,295 +217,41 @@
     }
   });
 
-  // Tab-completion state for @mentions
-  type TabCompletionState = {
-    candidates: string[]; // Matching usernames
-    index: number; // Current position in cycle
-    triggerStart: number; // Position of @ in text (relative to full text before cursor)
-    originalPartial: string; // Original typed partial
-  };
-  let tabCompletionState = $state<TabCompletionState | null>(null);
-
-  // Emoji autocomplete state
-  type EmojiAutocompleteState = {
-    query: string; // Search query (without leading colon)
-    triggerStart: number; // Position of : in text (relative to full text before cursor)
-  };
-  let emojiAutocomplete = $state<EmojiAutocompleteState | null>(null);
-  let emojiAutocompleteRef = $state<{ handleKeyDown: (e: KeyboardEvent) => boolean } | null>(null);
-
-  // Mention autocomplete state
-  type MentionAutocompleteState = {
-    query: string; // Search query (without leading @)
-    triggerStart: number; // Position of @ in text
-  };
-  let mentionAutocomplete = $state<MentionAutocompleteState | null>(null);
-  let mentionAutocompleteRef = $state<{ handleKeyDown: (e: KeyboardEvent) => boolean } | null>(
-    null
-  );
-
   // Close autocomplete popups when switching rooms
   $effect(() => {
     void roomId;
-    emojiAutocomplete = null;
-    mentionAutocomplete = null;
+    autocomplete.resetForRoom();
   });
-
-  // Detect :emoji pattern at cursor (requires at least 2 chars after :)
-  function getEmojiPartialAtCursor(): { query: string; start: number } | null {
-    if (!editorApi) return null;
-
-    const textBefore = editorApi.getTextBeforeCursor();
-
-    // Match :word at end of text (requires at least 2 chars after :)
-    // Must be preceded by whitespace, start of string, or another emoji
-    const match = textBefore.match(/(?:^|[\s]):([\w]{2,})$/);
-    if (!match) return null;
-
-    return {
-      query: match[1],
-      start: textBefore.length - match[1].length - 1 // Position of :
-    };
-  }
-
-  // Update emoji autocomplete state when input changes
-  function updateEmojiAutocomplete() {
-    const partial = getEmojiPartialAtCursor();
-    if (partial && searchEmojis(partial.query, 1).length > 0) {
-      emojiAutocomplete = {
-        query: partial.query,
-        triggerStart: partial.start
-      };
-      // Only one popup at a time
-      mentionAutocomplete = null;
-    } else {
-      emojiAutocomplete = null;
-    }
-  }
 
   // Handle emoji selection from autocomplete
   function handleEmojiSelect(emoji: string, _name: string) {
-    if (!emojiAutocomplete || !editorApi) return;
-
-    const textBefore = editorApi.getTextBeforeCursor();
-    const charsToReplace = textBefore.length - emojiAutocomplete.triggerStart;
-    editorApi.replaceTextBeforeCursor(charsToReplace, emoji + ' ');
-    emojiAutocomplete = null;
+    autocomplete.selectEmoji(emoji);
   }
 
   function closeEmojiAutocomplete() {
-    emojiAutocomplete = null;
-  }
-
-  // Update mention autocomplete state when input changes
-  function updateMentionAutocomplete() {
-    // Don't show mention popup if emoji popup is active
-    if (emojiAutocomplete) {
-      mentionAutocomplete = null;
-      return;
-    }
-
-    const partial = getMentionPartialAtCursor();
-    if (partial && findMatchingMembers(partial.partial).length > 0) {
-      mentionAutocomplete = {
-        query: partial.partial,
-        triggerStart: partial.start
-      };
-    } else {
-      mentionAutocomplete = null;
-    }
+    autocomplete.closeEmoji();
   }
 
   // Handle mention selection from autocomplete
   function handleMentionSelect(login: string, viaTab: boolean) {
-    if (!mentionAutocomplete) return;
-
-    const triggerStart = mentionAutocomplete.triggerStart;
-    const originalPartial = mentionAutocomplete.query;
-
-    applyCompletion(login, triggerStart);
-    mentionAutocomplete = null;
-
-    // When selected via Tab, set up tab completion state so subsequent
-    // Tab presses cycle through the other candidates (matching existing behavior).
-    if (viaTab) {
-      const candidates = findMatchingMembers(originalPartial);
-      if (candidates.length > 1) {
-        const selectedIdx = candidates.indexOf(login);
-        tabCompletionState = {
-          candidates,
-          index: selectedIdx >= 0 ? selectedIdx : 0,
-          triggerStart,
-          originalPartial
-        };
-      }
-    }
+    autocomplete.selectMention(login, viaTab);
   }
 
   function closeMentionAutocomplete() {
-    mentionAutocomplete = null;
-  }
-
-  // Find usernames that match a partial string using fuzzy matching
-  function findMatchingMembers(partial: string): string[] {
-    const scored: { login: string; score: number }[] = [];
-
-    for (const m of members) {
-      const loginScore = fuzzyMatch(partial, m.login);
-      const displayScore = fuzzyMatch(partial, m.displayName);
-      const bestScore = Math.max(loginScore ?? -1, displayScore ?? -1);
-
-      if (bestScore > 0) {
-        scored.push({ login: m.login, score: bestScore });
-      }
-    }
-
-    // Sort by score (descending) so better matches come first
-    scored.sort((a, b) => b.score - a.score);
-
-    return scored.map((s) => s.login);
-  }
-
-  // Detect if cursor is at end of @partial pattern (at least 1 char after @)
-  function getMentionPartialAtCursor(): { partial: string; start: number } | null {
-    if (!editorApi) return null;
-
-    const textBefore = editorApi.getTextBeforeCursor();
-
-    // Match @word at end of text (requires at least 1 char after @)
-    // Must be preceded by whitespace or start of string
-    // Includes dots for usernames like "hendrik.mans"
-    const match = textBefore.match(/(?:^|[\s])@([a-zA-Z0-9_.-]+)$/);
-    if (!match) return null;
-
-    return {
-      partial: match[1],
-      start: textBefore.length - match[1].length - 1 // Position of @
-    };
-  }
-
-  // Apply a completion - replace @partial with @username + space
-  function applyCompletion(username: string, atPosition: number) {
-    if (!editorApi) return;
-
-    const textBefore = editorApi.getTextBeforeCursor();
-    const charsToReplace = textBefore.length - atPosition;
-    editorApi.replaceTextBeforeCursor(charsToReplace, '@' + username + ' ');
-  }
-
-  // Handle Tab key for @mention autocomplete
-  function handleTabCompletion(event: KeyboardEvent): boolean {
-    // First, check if we're continuing an active completion cycle
-    // (cursor is right after a completed username + space)
-    if (tabCompletionState && tabCompletionState.candidates.length > 1) {
-      const currentUsername = tabCompletionState.candidates[tabCompletionState.index];
-      const expectedCursorPos = tabCompletionState.triggerStart + 1 + currentUsername.length + 1; // @ + username + space
-      const currentPos = editorApi?.getTextBeforeCursor().length ?? 0;
-
-      if (currentPos === expectedCursorPos) {
-        // Continue cycling through candidates
-        event.preventDefault();
-        const nextIndex = (tabCompletionState.index + 1) % tabCompletionState.candidates.length;
-        tabCompletionState = { ...tabCompletionState, index: nextIndex };
-        applyCompletion(tabCompletionState.candidates[nextIndex], tabCompletionState.triggerStart);
-        return true;
-      }
-    }
-
-    // Check for new @mention partial
-    const mentionInfo = getMentionPartialAtCursor();
-    if (!mentionInfo || mentionInfo.partial.length === 0) {
-      return false; // Let default Tab behavior happen
-    }
-
-    event.preventDefault();
-
-    // Start new completion
-    const candidates = findMatchingMembers(mentionInfo.partial);
-    if (candidates.length > 0) {
-      tabCompletionState = {
-        candidates,
-        index: 0,
-        triggerStart: mentionInfo.start,
-        originalPartial: mentionInfo.partial
-      };
-      applyCompletion(candidates[0], mentionInfo.start);
-    }
-
-    return true;
-  }
-
-  function formatFileSize(bytes: number): string {
-    if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(0)} MB`;
-    if (bytes >= 1024) return `${(bytes / 1024).toFixed(0)} KB`;
-    return `${bytes} bytes`;
-  }
-
-  /**
-   * Validate files against instance capabilities and upload limits.
-   * Returns only the files that pass validation, toasting errors for rejected ones.
-   */
-  function validateFiles(files: File[]): File[] {
-    const accepted: File[] = [];
-    for (const file of files) {
-      const isVideo = file.type.startsWith('video/');
-      if (isVideo && !serverInfo.videoProcessingEnabled) {
-        toast.error('Video uploads are disabled on this server.');
-        continue;
-      }
-
-      const limit = isVideo ? serverInfo.maxVideoUploadSize : serverInfo.maxUploadSize;
-      if (file.size > limit) {
-        toast.error(
-          `${file.name} is too large (${formatFileSize(file.size)}). Maximum is ${formatFileSize(limit)}.`
-        );
-      } else {
-        accepted.push(file);
-      }
-    }
-    return accepted;
-  }
-
-  function filesToPreviewItems(files: File[]): FileWithUrl[] {
-    return files.map((file) => ({
-      file,
-      url: URL.createObjectURL(file)
-    }));
-  }
-
-  async function stageFiles(files: File[]) {
-    const validFiles = validateFiles(files);
-    if (validFiles.length === 0) return;
-
-    pendingAttachmentCount += validFiles.length;
-    try {
-      const prepared = await prepareFiles(validFiles);
-      if (prepared.length > 0) {
-        filesWithUrls = [...filesWithUrls, ...filesToPreviewItems(prepared)];
-      }
-    } catch (err) {
-      console.error('Error preparing attachment files:', err);
-      toast.error('Failed to prepare attachment');
-    } finally {
-      pendingAttachmentCount -= validFiles.length;
-    }
+    autocomplete.closeMention();
   }
 
   function handleFileSelect(event: Event) {
     const target = event.target as HTMLInputElement;
     if (target.files) {
-      void stageFiles(Array.from(target.files));
+      void attachments.stageFiles(Array.from(target.files));
     }
     // Reset input so same file can be selected again
     target.value = '';
   }
 
   function removeFile(index: number) {
-    const removed = filesWithUrls[index];
-    if (removed) {
-      URL.revokeObjectURL(removed.url);
-    }
-    filesWithUrls = filesWithUrls.filter((_, i) => i !== index);
+    attachments.removeFile(index);
   }
 
   /**
@@ -619,7 +259,7 @@
    * Creates object URLs for preview and adds to the attachment list.
    */
   async function addFiles(files: File[]) {
-    await stageFiles(files);
+    await attachments.stageFiles(files);
   }
 
   // Focus the input programmatically (e.g., when opening thread from mobile action sheet)
@@ -653,7 +293,7 @@
     }
 
     if (pastedFiles.length > 0) {
-      void stageFiles(pastedFiles);
+      void attachments.stageFiles(pastedFiles);
       return true; // Prevent TipTap from processing the paste
     }
     return false; // Let TipTap handle text pastes
@@ -671,35 +311,18 @@
     // hasVisibleContent rejects messages with only invisible Unicode characters.
     const bodyToSend = normalizeMessageBody(message.trim());
     const hasBody = hasVisibleContent(bodyToSend);
-    const filesToSend = selectedFiles.length > 0 ? [...selectedFiles] : null;
+    const filesToSend =
+      attachments.selectedFiles.length > 0 ? [...attachments.selectedFiles] : null;
     if (!hasBody && !filesToSend) return;
 
-    // Capture active link preview before clearing state
-    const previewURL = detectedURLs[0];
-    const activePreview = previewURL ? previews.get(previewURL) : null;
-    const previewFields = activePreview ? useFragment(LinkPreviewFragment, activePreview) : null;
-    const linkPreviewInput =
-      activePreview && previewFields && !dismissedURLs.has(previewURL)
-        ? {
-            url: previewFields.url,
-            title: previewFields.title,
-            description: previewFields.description,
-            siteName: previewFields.siteName,
-            imageAssetId: activePreview.imageAssetId,
-            embedType: previewFields.embedType,
-            embedId: previewFields.embedId
-          }
-        : null;
+    const linkPreviewInput = linkPreviews.buildInput();
 
     // Optimistically clear the editor so the user can start typing the next
     // message immediately (matches Slack/Discord behavior).
     message = '';
     editorApi?.setContent('');
-    for (const { url } of filesWithUrls) {
-      URL.revokeObjectURL(url);
-    }
-    filesWithUrls = [];
-    clearLinkPreviews();
+    attachments.clear();
+    linkPreviews.clear();
 
     loading = true;
 
@@ -723,7 +346,7 @@
         message = bodyToSend;
         editorApi?.setContent(bodyToSend);
         if (filesToSend) {
-          filesWithUrls = filesToPreviewItems(filesToSend);
+          attachments.restore(attachments.filesToPreviewItems(filesToSend));
         }
       } else {
         // Scroll the enclosing pane to the user's new message. The composer
@@ -779,7 +402,7 @@
   async function handleSubmit() {
     // Guard against double-sends while editor stays editable, and against
     // submitting before pasted/dropped/selected files have finished staging.
-    if (loading || inputDisabled || pendingAttachmentCount > 0) return;
+    if (loading || inputDisabled || attachments.pendingCount > 0) return;
     if (isEditing) {
       await editMessage();
     } else {
@@ -797,22 +420,22 @@
   // Return true to prevent TipTap's default handling.
   function handleEditorKeyDown(event: KeyboardEvent): boolean {
     // Handle emoji autocomplete keyboard events first
-    if (emojiAutocomplete && emojiAutocompleteRef) {
-      if (emojiAutocompleteRef.handleKeyDown(event)) {
+    if (autocomplete.emoji && autocomplete.emojiRef) {
+      if (autocomplete.emojiRef.handleKeyDown(event)) {
         return true;
       }
     }
 
     // Handle mention autocomplete keyboard events
-    if (mentionAutocomplete && mentionAutocompleteRef) {
-      if (mentionAutocompleteRef.handleKeyDown(event)) {
+    if (autocomplete.mention && autocomplete.mentionRef) {
+      if (autocomplete.mentionRef.handleKeyDown(event)) {
         return true;
       }
     }
 
     // Handle Tab for @mention autocomplete
     if (event.key === 'Tab') {
-      if (handleTabCompletion(event)) {
+      if (autocomplete.handleTabCompletion(event)) {
         return true;
       }
       // If no completion happened, let default Tab behavior occur
@@ -820,7 +443,7 @@
 
     // Reset tab-completion state on any other key
     if (event.key !== 'Tab') {
-      tabCompletionState = null;
+      autocomplete.resetTabCompletion();
     }
 
     if (event.key === 'Escape') {
@@ -866,8 +489,7 @@
     if (text !== previousMessage) {
       onTyping?.();
     }
-    updateEmojiAutocomplete();
-    updateMentionAutocomplete();
+    autocomplete.update();
   }
 
   // Called when TipTap editor is ready - sync any pending state
@@ -892,22 +514,25 @@
   }}
 >
   <!-- Link / message preview -->
-  {#if detectedURLs[0]}
-    {@const url = detectedURLs[0]}
+  {#if linkPreviews.activeURL}
+    {@const url = linkPreviews.activeURL}
     {@const messageLink = parseMessageLink(url)}
     {#if messageLink}
-      <MessagePreviewCard link={messageLink} onDismiss={() => dismissPreview(url)} />
-    {:else if fetchingURLs.has(url)}
+      <MessagePreviewCard link={messageLink} onDismiss={() => linkPreviews.dismissPreview(url)} />
+    {:else if linkPreviews.fetchingURLs.has(url)}
       <LinkPreviewSkeleton />
-    {:else if previews.get(url)}
-      <LinkPreviewCard preview={previews.get(url)!} onDismiss={() => dismissPreview(url)} />
+    {:else if linkPreviews.previews.get(url)}
+      <LinkPreviewCard
+        preview={linkPreviews.previews.get(url)!}
+        onDismiss={() => linkPreviews.dismissPreview(url)}
+      />
     {/if}
   {/if}
 
   <!-- Selected files preview -->
-  {#if filesWithUrls.length > 0}
+  {#if attachments.filesWithUrls.length > 0}
     <div class="flex flex-wrap gap-2 rounded-lg bg-surface-300 p-2">
-      {#each filesWithUrls as { file, url }, index (index)}
+      {#each attachments.filesWithUrls as { file, url }, index (url)}
         <div class="relative">
           {#if file.type.startsWith('image/')}
             <img src={url} alt={file.name} class="h-16 w-16 rounded-md object-cover" />
@@ -948,7 +573,7 @@
   <input
     bind:this={fileInputElement}
     type="file"
-    accept={attachmentAccept}
+    accept={attachments.accept}
     multiple
     onchange={handleFileSelect}
     class="hidden"
@@ -964,20 +589,20 @@
     class:sending={loading}
   >
     <!-- Emoji autocomplete popup -->
-    {#if emojiAutocomplete}
+    {#if autocomplete.emoji}
       <EmojiAutocomplete
-        bind:this={emojiAutocompleteRef}
-        query={emojiAutocomplete.query}
+        bind:this={autocomplete.emojiRef}
+        query={autocomplete.emoji.query}
         onSelect={handleEmojiSelect}
         onClose={closeEmojiAutocomplete}
       />
     {/if}
 
     <!-- Mention autocomplete popup -->
-    {#if mentionAutocomplete}
+    {#if autocomplete.mention}
       <MentionAutocomplete
-        bind:this={mentionAutocompleteRef}
-        query={mentionAutocomplete.query}
+        bind:this={autocomplete.mentionRef}
+        query={autocomplete.mention.query}
         {members}
         onSelect={handleMentionSelect}
         onClose={closeMentionAutocomplete}

--- a/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -1,13 +1,36 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from 'vitest-browser-svelte';
+import { tick, type ComponentProps } from 'svelte';
 import MessageComposer from './MessageComposer.svelte';
 import { createMockGraphqlClient, q } from '$lib/test-utils';
 import { getToasts, toast } from '$lib/ui/toast';
+import type { RoomMember } from '$lib/state/room';
 
 const mutationData = { postMessage: { id: 'msg_123' } };
+const updateMutationData = { updateMessage: true };
 const prepareFilesMock = vi.hoisted(() => vi.fn());
 const mutationMock = vi.hoisted(() => vi.fn());
 const queryMock = vi.hoisted(() => vi.fn());
+const roomStateMock = vi.hoisted(() => ({
+  members: [] as RoomMember[],
+  editState: {
+    eventId: null as string | null,
+    originalBody: '',
+    startEdit: vi.fn(),
+    cancelEdit: vi.fn()
+  },
+  lastEditableMessage: {
+    getLastEditableMessage: vi.fn(() => null as { eventId: string; body: string } | null),
+    setFinder: vi.fn()
+  },
+  scrollState: {
+    scrollRequestCounter: 0,
+    requestScrollToBottom: vi.fn(),
+    setContainer: vi.fn(),
+    setShouldScroll: vi.fn(),
+    scrollToBottomIfSticky: vi.fn()
+  }
+}));
 
 // Mock instance state
 const mockInstanceStores = {
@@ -39,7 +62,13 @@ vi.mock('$lib/attachments/prepareFiles', () => ({
 }));
 
 vi.mock('$lib/state/server/registry.svelte', () => ({
-  serverRegistry: { getStore: () => mockInstanceStores }
+  serverRegistry: {
+    getStore: () => mockInstanceStores,
+    getServer: () => ({ id: 'test-instance', url: 'http://localhost' }),
+    isOriginServer: () => true,
+    originServer: { id: 'test-instance', url: 'http://localhost' },
+    servers: [{ id: 'test-instance', url: 'http://localhost' }]
+  }
 }));
 
 vi.mock('$lib/state/activeServer.svelte', () => ({
@@ -47,33 +76,22 @@ vi.mock('$lib/state/activeServer.svelte', () => ({
 }));
 
 vi.mock('$lib/state/room', () => ({
-  getRoomMembers: () => [],
+  getRoomMembers: () => roomStateMock.members,
   getComposerContext: () => ({
-    editState: {
-      eventId: null,
-      originalBody: '',
-      startEdit: vi.fn(),
-      cancelEdit: vi.fn()
-    },
-    lastEditableMessage: {
-      getLastEditableMessage: () => null,
-      setFinder: vi.fn()
-    },
-    scrollState: {
-      scrollRequestCounter: 0,
-      requestScrollToBottom: vi.fn(),
-      setContainer: vi.fn(),
-      setShouldScroll: vi.fn(),
-      scrollToBottomIfSticky: vi.fn()
-    }
+    editState: roomStateMock.editState,
+    lastEditableMessage: roomStateMock.lastEditableMessage,
+    scrollState: roomStateMock.scrollState
   })
 }));
 
+type MessageComposerProps = ComponentProps<typeof MessageComposer>;
+
 function renderMessageComposer(
-  props: { roomId: string },
-  context: Map<string, unknown>
+  props: Partial<MessageComposerProps> & { roomId: string },
+  context: Map<string, unknown>,
+  options: { exactRoomId?: boolean } = {}
 ) {
-  const roomId = `${props.roomId}-${renderId++}`;
+  const roomId = options.exactRoomId ? props.roomId : `${props.roomId}-${renderId++}`;
   return {
     ...render(MessageComposer, {
       props: { ...props, roomId },
@@ -123,8 +141,19 @@ function pasteFile(target: HTMLElement, file: File) {
 
 async function typeInEditor(editor: HTMLElement, text: string) {
   editor.focus();
+  document.execCommand('selectAll');
   document.execCommand('insertText', false, text);
   await vi.waitFor(() => expect(editor.textContent).toBe(text));
+}
+
+async function pressEditorKey(editor: HTMLElement, key: string) {
+  editor.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+  await tick();
+}
+
+function selectFirstAttachment(input: HTMLInputElement, file = imageFile()) {
+  selectFiles(input, [file]);
+  return file;
 }
 
 describe('MessageComposer', () => {
@@ -133,6 +162,17 @@ describe('MessageComposer', () => {
   beforeEach(() => {
     mockClient = createMockGraphqlClient({ mutationData });
     mockInstanceStores.serverInfo.videoProcessingEnabled = false;
+    mockInstanceStores.roomUnread.setRoomUnread.mockClear();
+    roomStateMock.members = [];
+    roomStateMock.editState.eventId = null;
+    roomStateMock.editState.originalBody = '';
+    roomStateMock.editState.startEdit.mockClear();
+    roomStateMock.editState.cancelEdit.mockClear();
+    roomStateMock.lastEditableMessage.getLastEditableMessage.mockReset();
+    roomStateMock.lastEditableMessage.getLastEditableMessage.mockReturnValue(null);
+    roomStateMock.lastEditableMessage.setFinder.mockClear();
+    roomStateMock.scrollState.requestScrollToBottom.mockClear();
+    roomStateMock.scrollState.scrollToBottomIfSticky.mockClear();
     toast.clear();
     Object.defineProperty(URL, 'createObjectURL', {
       value: vi.fn(() => 'blob:test'),
@@ -145,7 +185,10 @@ describe('MessageComposer', () => {
     prepareFilesMock.mockReset();
     prepareFilesMock.mockImplementation(async (files: File[]) => files);
     mutationMock.mockReset();
-    mutationMock.mockResolvedValue({ data: mutationData, error: null });
+    mutationMock.mockImplementation((_mutation, variables) => {
+      if (variables?.input?.eventId) return Promise.resolve({ data: updateMutationData, error: null });
+      return Promise.resolve({ data: mutationData, error: null });
+    });
     queryMock.mockReset();
     queryMock.mockResolvedValue({ data: null, error: null });
     sessionStorage.clear();
@@ -406,6 +449,262 @@ describe('MessageComposer', () => {
       await vi.waitFor(() => expect(mutationMock).not.toHaveBeenCalled());
       await expect.element(sendButton).toBeDisabled();
       expect(container.querySelector('.sending')).toBeNull();
+    });
+  });
+
+  describe('draft lifecycle', () => {
+    it('loads and persists a room text draft in sessionStorage', async () => {
+      sessionStorage.setItem('chatto:draft:room_draft', 'saved draft');
+
+      const { container } = renderMessageComposer(
+        { roomId: 'room_draft' },
+        new Map([['$$_urql', mockClient]]),
+        { exactRoomId: true }
+      );
+      const editor = q(container, '[data-testid="message-input"]')!;
+
+      await expect.element(editor).toHaveTextContent('saved draft');
+
+      await typeInEditor(editor, 'saved draft + more');
+
+      await vi.waitFor(() =>
+        expect(sessionStorage.getItem('chatto:draft:room_draft')).toBe('saved draft + more')
+      );
+    });
+
+    it('uses a separate thread draft key', async () => {
+      sessionStorage.setItem('chatto:draft:room_draft', 'room draft');
+      sessionStorage.setItem('chatto:draft:room_draft:thread:msg_root', 'thread draft');
+
+      const { container } = renderMessageComposer(
+        { roomId: 'room_draft', inThread: 'msg_root' },
+        new Map([['$$_urql', mockClient]]),
+        { exactRoomId: true }
+      );
+
+      await expect
+        .element(q(container, '[data-testid="thread-reply-input"]'))
+        .toHaveTextContent('thread draft');
+      expect(sessionStorage.getItem('chatto:draft:room_draft')).toBe('room draft');
+    });
+
+    it('clears the active text draft after a successful send', async () => {
+      const { container, roomId } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = q(container, '[data-testid="message-input"]')!;
+
+      await typeInEditor(editor, 'send and clear draft');
+      await vi.waitFor(() =>
+        expect(sessionStorage.getItem(`chatto:draft:${roomId}`)).toBe('send and clear draft')
+      );
+
+      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      await vi.waitFor(() => expect(sessionStorage.getItem(`chatto:draft:${roomId}`)).toBeNull());
+    });
+  });
+
+  describe('edit mode transitions', () => {
+    it('prefills edit text, hides attachment controls, and cancels on Escape', async () => {
+      roomStateMock.editState.eventId = 'evt_edit';
+      roomStateMock.editState.originalBody = 'original body';
+      const { container } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = q(container, '[data-testid="message-input"]')!;
+
+      await expect.element(editor).toHaveTextContent('original body');
+      expect(q(container, 'button[title="Attach file"]')).toBeNull();
+
+      await pressEditorKey(editor, 'Escape');
+
+      expect(roomStateMock.editState.cancelEdit).toHaveBeenCalledOnce();
+      expect(mutationMock).not.toHaveBeenCalled();
+    });
+
+    it('clears staged attachments when edit mode is active at mount', async () => {
+      const roomId = 'room_edit_attachments';
+      const firstRender = renderMessageComposer(
+        { roomId },
+        new Map([['$$_urql', mockClient]]),
+        { exactRoomId: true }
+      );
+      const file = selectFirstAttachment(
+        q(firstRender.container, 'input[type="file"]') as HTMLInputElement
+      );
+      await expect.poll(() => q(firstRender.container, 'img')).toBeTruthy();
+      firstRender.unmount();
+
+      // Stash an attachment draft for the same room, then mount directly into edit mode.
+      // The composer should discard attachments because editMessage only supports text.
+      roomStateMock.editState.eventId = 'evt_edit';
+      roomStateMock.editState.originalBody = 'editable';
+      const { container } = renderMessageComposer(
+        { roomId },
+        new Map([['$$_urql', mockClient]]),
+        { exactRoomId: true }
+      );
+      expect(q(container, 'button[title="Attach file"]')).toBeNull();
+      expect(file.name).toBe('paste.png');
+      expect(q(container, 'img')).toBeNull();
+    });
+  });
+
+  describe('submit behavior', () => {
+    it('posts normalized body and all thread/reply options', async () => {
+      const onCancelReply = vi.fn();
+      const onMessageSent = vi.fn();
+      const { container, roomId } = renderMessageComposer(
+        {
+          roomId: 'room_456',
+          inThread: 'evt_thread_root',
+          inReplyTo: 'evt_reply_to',
+          showAlsoSendToChannel: true,
+          onCancelReply,
+          onMessageSent
+        },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = q(container, '[data-testid="thread-reply-input"]')!;
+
+      await typeInEditor(editor, 'hello world');
+      (q(container, 'input[type="checkbox"]') as HTMLInputElement).click();
+      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({
+        roomId,
+        body: 'hello world',
+        attachments: null,
+        threadRootEventId: 'evt_thread_root',
+        inReplyTo: 'evt_reply_to',
+        alsoSendToChannel: true
+      });
+      expect(onCancelReply).toHaveBeenCalledOnce();
+      expect(onMessageSent).toHaveBeenCalledOnce();
+      expect(mockInstanceStores.roomUnread.setRoomUnread).toHaveBeenCalledWith(roomId, false);
+      expect(roomStateMock.scrollState.requestScrollToBottom).toHaveBeenCalledOnce();
+    });
+
+    it('restores text and attachments after a failed post', async () => {
+      mutationMock.mockResolvedValueOnce({ data: null, error: new Error('nope') });
+      const { container } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = q(container, '[data-testid="message-input"]')!;
+      const file = selectFirstAttachment(q(container, 'input[type="file"]') as HTMLInputElement);
+
+      await expect.poll(() => q(container, 'img')).toBeTruthy();
+      await typeInEditor(editor, 'will retry');
+      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      await expect.element(editor).toHaveTextContent('will retry');
+      await expect.poll(() => q(container, 'img')).toBeTruthy();
+      expect(mutationMock.mock.calls[0][1].input.attachments).toEqual([file]);
+      expect(getToasts().map((t) => t.message)).toContain('Failed to send message');
+    });
+  });
+
+  describe('link preview composer behavior', () => {
+    function mockLinkPreview(url: string) {
+      queryMock.mockResolvedValueOnce({
+        data: {
+          linkPreview: {
+            url,
+            title: 'Preview title',
+            description: 'Preview description',
+            imageUrl: null,
+            siteName: 'Preview site',
+            embedType: null,
+            embedId: null,
+            imageAssetId: 'asset_preview'
+          }
+        },
+        error: null
+      });
+    }
+
+    it('fetches a non-message-link preview and sends it with the post mutation', async () => {
+      const url = 'https://example.com/story';
+      mockLinkPreview(url);
+      const { container } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = q(container, '[data-testid="message-input"]')!;
+
+      await typeInEditor(editor, `Look ${url}`);
+
+      await vi.waitFor(() => expect(queryMock).toHaveBeenCalledOnce(), { timeout: 1000 });
+      await expect.element(q(container, '[data-testid="link-preview-card"]')).toBeInTheDocument();
+
+      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input.linkPreview).toMatchObject({
+        url,
+        title: 'Preview title',
+        description: 'Preview description',
+        siteName: 'Preview site',
+        imageAssetId: 'asset_preview'
+      });
+    });
+
+    it('dismisses a fetched preview so it is not attached to the outgoing message', async () => {
+      const url = 'https://example.com/dismiss';
+      mockLinkPreview(url);
+      const { container } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = q(container, '[data-testid="message-input"]')!;
+
+      await typeInEditor(editor, `Dismiss ${url}`);
+      await vi.waitFor(() => expect(queryMock).toHaveBeenCalledOnce(), { timeout: 1000 });
+      (q(container, 'button[aria-label="Dismiss preview"]') as HTMLButtonElement).click();
+
+      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input.linkPreview).toBeNull();
+    });
+  });
+
+  describe('attachment object URL lifecycle', () => {
+    it('revokes object URLs when removing staged files', async () => {
+      const { container } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      selectFirstAttachment(q(container, 'input[type="file"]') as HTMLInputElement);
+      await expect.poll(() => q(container, 'img')).toBeTruthy();
+
+      (q(container, 'button.absolute') as HTMLButtonElement).click();
+
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:test');
+      await vi.waitFor(() => expect(q(container, 'img')).toBeNull());
+    });
+
+    it('revokes object URLs after a successful send', async () => {
+      const { container } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = q(container, '[data-testid="message-input"]')!;
+      selectFirstAttachment(q(container, 'input[type="file"]') as HTMLInputElement);
+      await typeInEditor(editor, 'with file');
+
+      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:test');
+      expect(q(container, 'img')).toBeNull();
     });
   });
 

--- a/frontend/src/lib/components/composer/TipTapEditor.svelte
+++ b/frontend/src/lib/components/composer/TipTapEditor.svelte
@@ -157,6 +157,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
 
     // Notify parent that editor is ready with API
     tick().then(() => {
+      if (e.isDestroyed || editor !== e) return;
       onReady?.(buildApi(e));
     });
 

--- a/frontend/src/lib/components/composer/attachments.svelte.ts
+++ b/frontend/src/lib/components/composer/attachments.svelte.ts
@@ -1,0 +1,95 @@
+import { toast } from '$lib/ui/toast';
+import { prepareFiles } from '$lib/attachments/prepareFiles';
+
+export type FileWithUrl = { file: File; url: string };
+
+export type AttachmentLimits = {
+  videoProcessingEnabled: boolean;
+  maxUploadSize: number;
+  maxVideoUploadSize: number;
+};
+
+function formatFileSize(bytes: number): string {
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(0)} MB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${bytes} bytes`;
+}
+
+export class AttachmentsState {
+  filesWithUrls = $state<FileWithUrl[]>([]);
+  pendingCount = $state(0);
+
+  constructor(private readonly getLimits: () => AttachmentLimits) {}
+
+  get selectedFiles(): File[] {
+    return this.filesWithUrls.map((f) => f.file);
+  }
+
+  get accept(): string {
+    return this.getLimits().videoProcessingEnabled ? 'image/*,video/*,audio/*' : 'image/*,audio/*';
+  }
+
+  restore(files: FileWithUrl[]): void {
+    this.filesWithUrls = files;
+  }
+
+  validateFiles(files: File[]): File[] {
+    const limits = this.getLimits();
+    const accepted: File[] = [];
+    for (const file of files) {
+      const isVideo = file.type.startsWith('video/');
+      if (isVideo && !limits.videoProcessingEnabled) {
+        toast.error('Video uploads are disabled on this server.');
+        continue;
+      }
+
+      const limit = isVideo ? limits.maxVideoUploadSize : limits.maxUploadSize;
+      if (file.size > limit) {
+        toast.error(
+          `${file.name} is too large (${formatFileSize(file.size)}). Maximum is ${formatFileSize(limit)}.`
+        );
+      } else {
+        accepted.push(file);
+      }
+    }
+    return accepted;
+  }
+
+  filesToPreviewItems(files: File[]): FileWithUrl[] {
+    return files.map((file) => ({
+      file,
+      url: URL.createObjectURL(file)
+    }));
+  }
+
+  async stageFiles(files: File[]): Promise<void> {
+    const validFiles = this.validateFiles(files);
+    if (validFiles.length === 0) return;
+
+    this.pendingCount += validFiles.length;
+    try {
+      const prepared = await prepareFiles(validFiles);
+      if (prepared.length > 0) {
+        this.filesWithUrls = [...this.filesWithUrls, ...this.filesToPreviewItems(prepared)];
+      }
+    } catch (err) {
+      console.error('Error preparing attachment files:', err);
+      toast.error('Failed to prepare attachment');
+    } finally {
+      this.pendingCount -= validFiles.length;
+    }
+  }
+
+  removeFile(index: number): void {
+    const removed = this.filesWithUrls[index];
+    if (removed) URL.revokeObjectURL(removed.url);
+    this.filesWithUrls = this.filesWithUrls.filter((_, i) => i !== index);
+  }
+
+  clear(): void {
+    for (const { url } of this.filesWithUrls) {
+      URL.revokeObjectURL(url);
+    }
+    this.filesWithUrls = [];
+  }
+}

--- a/frontend/src/lib/components/composer/autocomplete.svelte.spec.ts
+++ b/frontend/src/lib/components/composer/autocomplete.svelte.spec.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { PresenceStatus } from '$lib/gql/graphql';
+import type { RoomMember } from '$lib/state/room';
+import type { TipTapEditorApi } from './TipTapEditor.svelte';
+import { AutocompleteState } from './autocomplete.svelte';
+
+function member(login: string, displayName = login): RoomMember {
+  return {
+    id: `user_${login}`,
+    login,
+    displayName,
+    avatarUrl: null,
+    presenceStatus: PresenceStatus.Offline
+  };
+}
+
+function editor(initialText: string): { api: TipTapEditorApi; getText: () => string; setText: (text: string) => void } {
+  let text = initialText;
+  let cursor = text.length;
+  return {
+    api: {
+      getText: () => text,
+      setContent: (next) => {
+        text = next;
+        cursor = text.length;
+      },
+      focus: () => {},
+      getTextBeforeCursor: () => text.slice(0, cursor),
+      replaceTextBeforeCursor: (charCount, replacement) => {
+        text = text.slice(0, cursor - charCount) + replacement + text.slice(cursor);
+        cursor = cursor - charCount + replacement.length;
+      }
+    },
+    getText: () => text,
+    setText: (next) => {
+      text = next;
+      cursor = text.length;
+    }
+  };
+}
+
+function tabEvent(): KeyboardEvent {
+  return new KeyboardEvent('keydown', { key: 'Tab', cancelable: true });
+}
+
+describe('AutocompleteState', () => {
+  it('gives emoji autocomplete priority over mention autocomplete', () => {
+    const fakeEditor = editor('@al');
+    const state = new AutocompleteState(() => fakeEditor.api, () => [member('alice')]);
+
+    state.update();
+    expect(state.mention?.query).toBe('al');
+    expect(state.emoji).toBeNull();
+
+    fakeEditor.setText('@al :fi');
+    state.update();
+
+    expect(state.emoji?.query).toBe('fi');
+    expect(state.mention).toBeNull();
+  });
+
+  it('cycles mention Tab completion and resets the cycle on another key', () => {
+    const fakeEditor = editor('@ali');
+    const state = new AutocompleteState(
+      () => fakeEditor.api,
+      () => [member('alice'), member('alicia')]
+    );
+
+    const firstTab = tabEvent();
+    expect(state.handleTabCompletion(firstTab)).toBe(true);
+    expect(firstTab.defaultPrevented).toBe(true);
+    expect(fakeEditor.getText()).toBe('@alice ');
+
+    expect(state.handleTabCompletion(tabEvent())).toBe(true);
+    expect(fakeEditor.getText()).toBe('@alicia ');
+
+    state.resetTabCompletion();
+    expect(state.handleTabCompletion(tabEvent())).toBe(false);
+    expect(fakeEditor.getText()).toBe('@alicia ');
+  });
+
+  it('selects a mention from the popup and seeds Tab cycling only for Tab selection', () => {
+    const fakeEditor = editor('@ali');
+    const state = new AutocompleteState(
+      () => fakeEditor.api,
+      () => [member('alice'), member('alicia')]
+    );
+
+    state.update();
+    state.selectMention('alice', false);
+
+    expect(fakeEditor.getText()).toBe('@alice ');
+    expect(state.tabCompletion).toBeNull();
+
+    fakeEditor.setText('@ali');
+    state.update();
+    state.selectMention('alice', true);
+
+    expect(state.tabCompletion?.candidates).toEqual(['alice', 'alicia']);
+  });
+
+  it('selects an emoji by replacing the shortcode before the cursor', () => {
+    const fakeEditor = editor('hello :fi');
+    const state = new AutocompleteState(() => fakeEditor.api, () => []);
+
+    state.update();
+    state.selectEmoji('🔥');
+
+    expect(fakeEditor.getText()).toBe('hello 🔥 ');
+    expect(state.emoji).toBeNull();
+  });
+});

--- a/frontend/src/lib/components/composer/autocomplete.svelte.ts
+++ b/frontend/src/lib/components/composer/autocomplete.svelte.ts
@@ -1,0 +1,212 @@
+import type { RoomMember } from '$lib/state/room';
+import { fuzzyMatch } from '$lib/fuzzyMatch';
+import { searchEmojis } from '$lib/emoji';
+import type { TipTapEditorApi } from './TipTapEditor.svelte';
+
+type TabCompletionState = {
+  candidates: string[];
+  index: number;
+  triggerStart: number;
+  originalPartial: string;
+};
+
+export type EmojiAutocompleteState = {
+  query: string;
+  triggerStart: number;
+};
+
+export type MentionAutocompleteState = {
+  query: string;
+  triggerStart: number;
+};
+
+export class AutocompleteState {
+  tabCompletion = $state<TabCompletionState | null>(null);
+  emoji = $state<EmojiAutocompleteState | null>(null);
+  emojiRef = $state<{ handleKeyDown: (e: KeyboardEvent) => boolean } | null>(null);
+  mention = $state<MentionAutocompleteState | null>(null);
+  mentionRef = $state<{ handleKeyDown: (e: KeyboardEvent) => boolean } | null>(null);
+
+  constructor(
+    private readonly getEditorApi: () => TipTapEditorApi | null,
+    private readonly getMembers: () => RoomMember[]
+  ) {}
+
+  resetForRoom(): void {
+    this.emoji = null;
+    this.mention = null;
+    this.tabCompletion = null;
+  }
+
+  update(): void {
+    this.updateEmoji();
+    this.updateMention();
+  }
+
+  closeEmoji(): void {
+    this.emoji = null;
+  }
+
+  closeMention(): void {
+    this.mention = null;
+  }
+
+  selectEmoji(emoji: string): void {
+    if (!this.emoji) return;
+    const editorApi = this.getEditorApi();
+    if (!editorApi) return;
+
+    const textBefore = editorApi.getTextBeforeCursor();
+    const charsToReplace = textBefore.length - this.emoji.triggerStart;
+    editorApi.replaceTextBeforeCursor(charsToReplace, emoji + ' ');
+    this.emoji = null;
+  }
+
+  selectMention(login: string, viaTab: boolean): void {
+    if (!this.mention) return;
+
+    const triggerStart = this.mention.triggerStart;
+    const originalPartial = this.mention.query;
+
+    this.applyCompletion(login, triggerStart);
+    this.mention = null;
+
+    if (!viaTab) return;
+
+    const candidates = this.findMatchingMembers(originalPartial);
+    if (candidates.length > 1) {
+      const selectedIdx = candidates.indexOf(login);
+      this.tabCompletion = {
+        candidates,
+        index: selectedIdx >= 0 ? selectedIdx : 0,
+        triggerStart,
+        originalPartial
+      };
+    }
+  }
+
+  handleTabCompletion(event: KeyboardEvent): boolean {
+    const editorApi = this.getEditorApi();
+    if (!editorApi) return false;
+
+    if (this.tabCompletion && this.tabCompletion.candidates.length > 1) {
+      const currentUsername = this.tabCompletion.candidates[this.tabCompletion.index];
+      const expectedCursorPos = this.tabCompletion.triggerStart + 1 + currentUsername.length + 1;
+      const currentPos = editorApi.getTextBeforeCursor().length;
+
+      if (currentPos === expectedCursorPos) {
+        event.preventDefault();
+        const nextIndex = (this.tabCompletion.index + 1) % this.tabCompletion.candidates.length;
+        this.tabCompletion = { ...this.tabCompletion, index: nextIndex };
+        this.applyCompletion(this.tabCompletion.candidates[nextIndex], this.tabCompletion.triggerStart);
+        return true;
+      }
+    }
+
+    const mentionInfo = this.getMentionPartialAtCursor();
+    if (!mentionInfo || mentionInfo.partial.length === 0) return false;
+
+    event.preventDefault();
+
+    const candidates = this.findMatchingMembers(mentionInfo.partial);
+    if (candidates.length > 0) {
+      this.tabCompletion = {
+        candidates,
+        index: 0,
+        triggerStart: mentionInfo.start,
+        originalPartial: mentionInfo.partial
+      };
+      this.applyCompletion(candidates[0], mentionInfo.start);
+    }
+
+    return true;
+  }
+
+  resetTabCompletion(): void {
+    this.tabCompletion = null;
+  }
+
+  private updateEmoji(): void {
+    const partial = this.getEmojiPartialAtCursor();
+    if (partial && searchEmojis(partial.query, 1).length > 0) {
+      this.emoji = {
+        query: partial.query,
+        triggerStart: partial.start
+      };
+      this.mention = null;
+    } else {
+      this.emoji = null;
+    }
+  }
+
+  private updateMention(): void {
+    if (this.emoji) {
+      this.mention = null;
+      return;
+    }
+
+    const partial = this.getMentionPartialAtCursor();
+    if (partial && this.findMatchingMembers(partial.partial).length > 0) {
+      this.mention = {
+        query: partial.partial,
+        triggerStart: partial.start
+      };
+    } else {
+      this.mention = null;
+    }
+  }
+
+  private findMatchingMembers(partial: string): string[] {
+    const scored: { login: string; score: number }[] = [];
+
+    for (const m of this.getMembers()) {
+      const loginScore = fuzzyMatch(partial, m.login);
+      const displayScore = fuzzyMatch(partial, m.displayName);
+      const bestScore = Math.max(loginScore ?? -1, displayScore ?? -1);
+
+      if (bestScore > 0) {
+        scored.push({ login: m.login, score: bestScore });
+      }
+    }
+
+    scored.sort((a, b) => b.score - a.score);
+    return scored.map((s) => s.login);
+  }
+
+  private getEmojiPartialAtCursor(): { query: string; start: number } | null {
+    const editorApi = this.getEditorApi();
+    if (!editorApi) return null;
+
+    const textBefore = editorApi.getTextBeforeCursor();
+    const match = textBefore.match(/(?:^|[\s]):([\w]{2,})$/);
+    if (!match) return null;
+
+    return {
+      query: match[1],
+      start: textBefore.length - match[1].length - 1
+    };
+  }
+
+  private getMentionPartialAtCursor(): { partial: string; start: number } | null {
+    const editorApi = this.getEditorApi();
+    if (!editorApi) return null;
+
+    const textBefore = editorApi.getTextBeforeCursor();
+    const match = textBefore.match(/(?:^|[\s])@([a-zA-Z0-9_.-]+)$/);
+    if (!match) return null;
+
+    return {
+      partial: match[1],
+      start: textBefore.length - match[1].length - 1
+    };
+  }
+
+  private applyCompletion(username: string, atPosition: number): void {
+    const editorApi = this.getEditorApi();
+    if (!editorApi) return;
+
+    const textBefore = editorApi.getTextBeforeCursor();
+    const charsToReplace = textBefore.length - atPosition;
+    editorApi.replaceTextBeforeCursor(charsToReplace, '@' + username + ' ');
+  }
+}

--- a/frontend/src/lib/components/composer/draft.svelte.ts
+++ b/frontend/src/lib/components/composer/draft.svelte.ts
@@ -1,0 +1,52 @@
+import { SvelteMap } from 'svelte/reactivity';
+import type { FileWithUrl } from './attachments.svelte';
+
+const draftFilesMap = new SvelteMap<string, FileWithUrl[]>();
+
+export function draftKey(roomId: string, threadRootEventId?: string): string {
+  return threadRootEventId
+    ? `chatto:draft:${roomId}:thread:${threadRootEventId}`
+    : `chatto:draft:${roomId}`;
+}
+
+export class DraftState {
+  key = '';
+
+  switchKey(key: string): string {
+    this.key = key;
+    return sessionStorage.getItem(key) ?? '';
+  }
+
+  persistText(message: string): void {
+    if (!this.key) return;
+    if (message) {
+      sessionStorage.setItem(this.key, message);
+    } else {
+      sessionStorage.removeItem(this.key);
+    }
+  }
+
+  clearText(): void {
+    if (this.key) sessionStorage.removeItem(this.key);
+  }
+
+  takeFiles(): FileWithUrl[] {
+    if (!this.key) return [];
+    const saved = draftFilesMap.get(this.key) ?? [];
+    draftFilesMap.delete(this.key);
+    return saved;
+  }
+
+  stashFiles(files: FileWithUrl[]): void {
+    if (!this.key) return;
+    if (files.length > 0) {
+      draftFilesMap.set(this.key, files);
+    } else {
+      draftFilesMap.delete(this.key);
+    }
+  }
+
+  discardFiles(): void {
+    if (this.key) draftFilesMap.delete(this.key);
+  }
+}

--- a/frontend/src/lib/components/composer/linkPreviews.svelte.spec.ts
+++ b/frontend/src/lib/components/composer/linkPreviews.svelte.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { Client } from '@urql/svelte';
+import { LinkPreviewState } from './linkPreviews.svelte';
+
+function clientWithQuery(query: ReturnType<typeof vi.fn>): Client {
+  return { query } as unknown as Client;
+}
+
+describe('LinkPreviewState', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not fetch OpenGraph data for Chatto message links', async () => {
+    vi.useFakeTimers();
+    const query = vi.fn();
+    const state = new LinkPreviewState(() => clientWithQuery(query));
+
+    const cleanup = state.scheduleDetection('See http://localhost/chat/-/room_456/m/evt_123', false);
+    await vi.advanceTimersByTimeAsync(500);
+    cleanup();
+
+    expect(state.detectedURLs).toEqual(['http://localhost/chat/-/room_456/m/evt_123']);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('fetches non-message links and converts the active preview into mutation input', async () => {
+    vi.useFakeTimers();
+    const url = 'https://example.com/story';
+    const query = vi.fn().mockResolvedValue({
+      data: {
+        linkPreview: {
+          url,
+          title: 'Preview title',
+          description: 'Preview description',
+          imageUrl: null,
+          siteName: 'Preview site',
+          embedType: null,
+          embedId: null,
+          imageAssetId: 'asset_preview'
+        }
+      },
+      error: null
+    });
+    const state = new LinkPreviewState(() => clientWithQuery(query));
+
+    const cleanup = state.scheduleDetection(`Look ${url}`, false);
+    await vi.advanceTimersByTimeAsync(500);
+    await vi.waitFor(() => expect(query).toHaveBeenCalledOnce());
+    cleanup();
+
+    expect(state.buildInput()).toMatchObject({
+      url,
+      title: 'Preview title',
+      description: 'Preview description',
+      siteName: 'Preview site',
+      imageAssetId: 'asset_preview'
+    });
+  });
+
+  it('dismisses active URLs and clears preview state', async () => {
+    const state = new LinkPreviewState(() => clientWithQuery(vi.fn()));
+    state.detectedURLs = ['https://example.com'];
+    state.previews.set('https://example.com', null);
+    state.fetchingURLs.add('https://example.com');
+
+    state.dismissPreview('https://example.com');
+    expect(state.detectedURLs).toEqual([]);
+    expect(state.dismissedURLs.has('https://example.com')).toBe(true);
+
+    state.clear();
+    expect(state.previews.size).toBe(0);
+    expect(state.fetchingURLs.size).toBe(0);
+    expect(state.dismissedURLs.size).toBe(0);
+  });
+});

--- a/frontend/src/lib/components/composer/linkPreviews.svelte.ts
+++ b/frontend/src/lib/components/composer/linkPreviews.svelte.ts
@@ -1,0 +1,96 @@
+import type { Client } from '@urql/svelte';
+import { SvelteMap, SvelteSet } from 'svelte/reactivity';
+import {
+  LinkPreviewForComposerDocument,
+  type LinkPreviewForComposerQuery,
+  type LinkPreviewInput
+} from '$lib/gql/graphql';
+import { useFragment } from '$lib/gql/fragment-masking';
+import { extractURLs } from '$lib/linkPreview';
+import { parseMessageLink } from '$lib/messageLinks';
+import { LinkPreviewFragment } from '$lib/components/LinkPreviewCard.svelte';
+
+type PreviewData = NonNullable<LinkPreviewForComposerQuery['linkPreview']>;
+
+export class LinkPreviewState {
+  detectedURLs = $state<string[]>([]);
+  previews = new SvelteMap<string, PreviewData | null>();
+  dismissedURLs = new SvelteSet<string>();
+  fetchingURLs = new SvelteSet<string>();
+  #urlDetectionTimeout: ReturnType<typeof setTimeout> | undefined;
+
+  constructor(private readonly getClient: () => Client) {}
+
+  get activeURL(): string | undefined {
+    return this.detectedURLs[0];
+  }
+
+  scheduleDetection(message: string, isEditing: boolean): () => void {
+    clearTimeout(this.#urlDetectionTimeout);
+
+    if (isEditing) {
+      this.detectedURLs = [];
+      return () => clearTimeout(this.#urlDetectionTimeout);
+    }
+
+    this.#urlDetectionTimeout = setTimeout(() => {
+      const urls = extractURLs(message).filter((u) => !this.dismissedURLs.has(u));
+      this.detectedURLs = urls;
+
+      for (const url of urls) {
+        if (parseMessageLink(url)) continue;
+        if (!this.previews.has(url) && !this.fetchingURLs.has(url)) {
+          void this.fetchPreview(url);
+        }
+      }
+    }, 500);
+
+    return () => clearTimeout(this.#urlDetectionTimeout);
+  }
+
+  async fetchPreview(url: string): Promise<void> {
+    this.fetchingURLs.add(url);
+
+    const result = await this.getClient().query(LinkPreviewForComposerDocument, { url });
+
+    this.fetchingURLs.delete(url);
+
+    if (result.data?.linkPreview) {
+      this.previews.set(url, result.data.linkPreview);
+    } else {
+      this.previews.set(url, null);
+    }
+  }
+
+  dismissPreview(url: string): void {
+    this.dismissedURLs.add(url);
+    this.detectedURLs = this.detectedURLs.filter((u) => u !== url);
+  }
+
+  clear(): void {
+    this.detectedURLs = [];
+    this.previews.clear();
+    this.dismissedURLs.clear();
+    this.fetchingURLs.clear();
+  }
+
+  buildInput(): LinkPreviewInput | null {
+    const previewURL = this.activeURL;
+    const activePreview = previewURL ? this.previews.get(previewURL) : null;
+    const previewFields = activePreview ? useFragment(LinkPreviewFragment, activePreview) : null;
+
+    if (!previewURL || !activePreview || !previewFields || this.dismissedURLs.has(previewURL)) {
+      return null;
+    }
+
+    return {
+      url: previewFields.url,
+      title: previewFields.title,
+      description: previewFields.description,
+      siteName: previewFields.siteName,
+      imageAssetId: activePreview.imageAssetId,
+      embedType: previewFields.embedType,
+      embedId: previewFields.embedId
+    };
+  }
+}


### PR DESCRIPTION
## Changes

- Adds focused composer unit coverage for draft lifecycle, edit transitions, submit payloads, link previews, autocomplete, and object URL cleanup.
- Extracts draft, attachment, link preview, and autocomplete state from `MessageComposer.svelte` into Svelte 5 modules under the composer directory.
- Keeps `MessageComposer.svelte` focused on wiring/rendering and guards `TipTapEditor` ready callbacks after teardown.

## Verification

- `mise x -- pnpm check`
- `mise x -- pnpm lint`
- `mise x -- pnpm test:unit --run --project client src/lib/components/composer/MessageComposer.svelte.spec.ts src/lib/components/composer/autocomplete.svelte.spec.ts src/lib/components/composer/linkPreviews.svelte.spec.ts`
- `mise x -- pnpm test:unit --run --project client`
- `mise x -- pnpm exec playwright test e2e/composer.test.ts e2e/link-previews.test.ts e2e/message-editing.test.ts e2e/drag-drop-upload.test.ts e2e/mention-autocomplete.test.ts e2e/emoji-autocomplete.test.ts --retries=0`
