### PR TITLE
fix(auth): include server name in auth emails

### DIFF
--- a/cli/internal/http_server/auth.go
+++ b/cli/internal/http_server/auth.go
@@ -1,6 +1,7 @@
 package http_server
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -24,6 +25,15 @@ var (
 
 func isStaleLoginCredentialError(err error) bool {
 	return errors.Is(err, core.ErrCookieSessionNotFound) || errors.Is(err, core.ErrAuthTokenNotFound)
+}
+
+func (s *HTTPServer) authEmailServerName(ctx context.Context) string {
+	if s.core != nil && s.core.ConfigManager() != nil {
+		if name, err := s.core.ConfigManager().GetEffectiveServerName(ctx); err == nil && strings.TrimSpace(name) != "" {
+			return name
+		}
+	}
+	return "Chatto"
 }
 
 func (s *HTTPServer) setupAuthRoutes() {
@@ -269,10 +279,11 @@ func (s *HTTPServer) setupAuthRoutes() {
 		}
 
 		// Send registration email
+		serverName := s.authEmailServerName(ctx)
 		err = s.mailer.Send(email.Message{
 			To:      req.Email,
-			Subject: "Complete your Chatto registration",
-			Body:    fmt.Sprintf("Welcome to Chatto!\n\nYour verification code is:\n\n%s\n\nThis code will expire in 15 minutes.\n\nIf you didn't request this, you can ignore this email.", code),
+			Subject: fmt.Sprintf("Complete your registration for %s", serverName),
+			Body:    fmt.Sprintf("Welcome to %s!\n\nUse this verification code to finish creating your account on %s:\n\n%s\n\nThis code will expire in 15 minutes.\n\nIf you didn't request this, you can ignore this email.", serverName, serverName, code),
 		})
 		if err != nil {
 			log.Error("Failed to send registration email", "email", req.Email, "error", err)
@@ -486,10 +497,11 @@ func (s *HTTPServer) setupAuthRoutes() {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to send verification code"})
 			return
 		}
+		serverName := s.authEmailServerName(req.Context())
 		if err := s.mailer.Send(email.Message{
 			To:      body.Email,
-			Subject: "Verify your Chatto email",
-			Body:    fmt.Sprintf("Your Chatto email verification code is:\n\n%s\n\nThis code will expire in 15 minutes.\n\nIf you didn't request this, you can ignore this email.", code),
+			Subject: fmt.Sprintf("Verify your email for %s", serverName),
+			Body:    fmt.Sprintf("Use this verification code to add this email address to your %s account:\n\n%s\n\nThis code will expire in 15 minutes.\n\nIf you didn't request this, you can ignore this email.", serverName, code),
 		}); err != nil {
 			log.Error("Failed to send email verification code", "userId", user.Id, "email", body.Email, "error", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to send verification code"})
@@ -563,11 +575,12 @@ func (s *HTTPServer) setupAuthRoutes() {
 
 		// Only send email if token was created (email exists and is verified)
 		if token != "" && s.mailer != nil {
+			serverName := s.authEmailServerName(ctx)
 			resetURL := fmt.Sprintf("%s/reset-password?token=%s", s.config.Webserver.URL, token)
 			err = s.mailer.Send(email.Message{
 				To:      normalizedEmail,
-				Subject: "Reset your Chatto password",
-				Body:    fmt.Sprintf("Hi,\n\nWe received a request to reset your password for your Chatto account.\n\nClick the link below to set a new password:\n\n%s\n\nThis link will expire in 1 hour.\n\nIf you didn't request this, you can safely ignore this email.\n\n- The Chatto Team", resetURL),
+				Subject: fmt.Sprintf("Reset your %s password", serverName),
+				Body:    fmt.Sprintf("Hi,\n\nWe received a request to reset the password for your %s account.\n\nClick the link below to set a new password:\n\n%s\n\nThis link will expire in 1 hour.\n\nIf you didn't request this, you can safely ignore this email.", serverName, resetURL),
 			})
 			if err != nil {
 				log.Error("Failed to send password reset email", "email", normalizedEmail, "error", err)

--- a/cli/internal/http_server/server_test.go
+++ b/cli/internal/http_server/server_test.go
@@ -21,6 +21,7 @@ import (
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/core"
 	"hmans.de/chatto/internal/email"
+	configv1 "hmans.de/chatto/internal/pb/chatto/config/v1"
 	"hmans.de/chatto/internal/testutil"
 )
 
@@ -260,6 +261,13 @@ func setupTestHTTPServerWithMailer(t *testing.T) (*httptest.Server, *http.Client
 	}
 
 	return ts, client, chattoCore, mockMailer
+}
+
+func setTestServerName(t *testing.T, ctx context.Context, chattoCore *core.ChattoCore, name string) {
+	t.Helper()
+	if err := chattoCore.ConfigManager().SetServerConfig(ctx, "test", &configv1.ServerConfig{ServerName: name}); err != nil {
+		t.Fatalf("Failed to set test server name: %v", err)
+	}
 }
 
 // ============================================================================
@@ -530,7 +538,9 @@ func TestAuthRoutes_Logout(t *testing.T) {
 }
 
 func TestAuthRoutes_Register_SendsRegistrationEmail(t *testing.T) {
-	ts, client, _, mockMailer := setupTestHTTPServerWithMailer(t)
+	ts, client, chattoCore, mockMailer := setupTestHTTPServerWithMailer(t)
+	ctx := testContext(t)
+	setTestServerName(t, ctx, chattoCore, "Engineering")
 
 	// Step 1: POST /auth/register with email only
 	reqBody := map[string]string{"email": "newuser@example.com"}
@@ -566,8 +576,14 @@ func TestAuthRoutes_Register_SendsRegistrationEmail(t *testing.T) {
 	if email.To != "newuser@example.com" {
 		t.Errorf("Expected email to newuser@example.com, got %s", email.To)
 	}
-	if email.Subject != "Complete your Chatto registration" {
-		t.Errorf("Expected subject 'Complete your Chatto registration', got %s", email.Subject)
+	if email.Subject != "Complete your registration for Engineering" {
+		t.Errorf("Expected subject 'Complete your registration for Engineering', got %s", email.Subject)
+	}
+	if !strings.Contains(email.Body, "Welcome to Engineering!") {
+		t.Errorf("Expected email body to include server name welcome, got: %s", email.Body)
+	}
+	if !strings.Contains(email.Body, "finish creating your account on Engineering") {
+		t.Errorf("Expected email body to describe account creation on server, got: %s", email.Body)
 	}
 	if regexp.MustCompile(`\b\d{6}\b`).FindString(email.Body) == "" {
 		t.Errorf("Expected email body to contain six-digit registration code, got: %s", email.Body)
@@ -1140,8 +1156,9 @@ func TestAuthRoutes_RegisterComplete_DisabledReturns403(t *testing.T) {
 }
 
 func TestAuthRoutes_EmailVerification_Success(t *testing.T) {
-	ts, client, chattoCore := setupTestHTTPServer(t)
+	ts, client, chattoCore, mockMailer := setupTestHTTPServerWithMailer(t)
 	ctx := testContext(t)
+	setTestServerName(t, ctx, chattoCore, "Engineering")
 
 	// Create a user directly
 	user, err := chattoCore.CreateUser(ctx, "system", "verifyuser", "Verify User", "password123")
@@ -1168,9 +1185,32 @@ func TestAuthRoutes_EmailVerification_Success(t *testing.T) {
 		t.Fatalf("Login failed with status %d", loginResp.StatusCode)
 	}
 
-	code, err := chattoCore.CreateEmailVerificationCode(ctx, user.Id, "verify@example.com")
+	requestBody, _ := json.Marshal(map[string]string{"email": "verify@example.com"})
+	requestResp, err := client.Post(ts.URL+"/auth/verify-email/request-code", "application/json", bytes.NewReader(requestBody))
 	if err != nil {
-		t.Fatalf("Failed to create verification code: %v", err)
+		t.Fatalf("Failed to request verification code: %v", err)
+	}
+	requestResp.Body.Close()
+	if requestResp.StatusCode != http.StatusOK {
+		t.Fatalf("Verification code request failed with status %d", requestResp.StatusCode)
+	}
+
+	msg := mockMailer.LastMessage()
+	if msg == nil {
+		t.Fatal("Expected verification email to be sent")
+	}
+	if msg.Subject != "Verify your email for Engineering" {
+		t.Errorf("Expected subject 'Verify your email for Engineering', got %s", msg.Subject)
+	}
+	if !strings.Contains(msg.Body, "add this email address to your Engineering account") {
+		t.Errorf("Expected email body to mention Engineering account, got: %s", msg.Body)
+	}
+	if !strings.Contains(msg.Body, "15 minutes") {
+		t.Errorf("Expected email body to mention 15-minute expiration, got: %s", msg.Body)
+	}
+	code := regexp.MustCompile(`\b\d{6}\b`).FindString(msg.Body)
+	if code == "" {
+		t.Fatalf("Could not extract verification code from email body: %s", msg.Body)
 	}
 
 	verifyBody, _ := json.Marshal(map[string]string{"email": "verify@example.com", "code": code})
@@ -1671,8 +1711,8 @@ func TestAuthRoutes_TestEmailEndpoint(t *testing.T) {
 	if emailResult["to"] != "testendpoint@example.com" {
 		t.Errorf("Expected to: testendpoint@example.com, got %v", emailResult["to"])
 	}
-	if emailResult["subject"] != "Complete your Chatto registration" {
-		t.Errorf("Expected subject: 'Complete your Chatto registration', got %v", emailResult["subject"])
+	if emailResult["subject"] != "Complete your registration for Chatto" {
+		t.Errorf("Expected subject: 'Complete your registration for Chatto', got %v", emailResult["subject"])
 	}
 
 	// Test DELETE /auth/test/emails
@@ -1699,6 +1739,7 @@ func TestAuthRoutes_TestEmailEndpoint(t *testing.T) {
 func TestAuthRoutes_ForgotPassword_SendsEmail(t *testing.T) {
 	ts, client, chattoCore, mockMailer := setupTestHTTPServerWithMailer(t)
 	ctx := testContext(t)
+	setTestServerName(t, ctx, chattoCore, "Engineering")
 
 	// Create a user with verified email
 	user, err := chattoCore.CreateUser(ctx, "system", "forgotuser", "Forgot User", "oldpassword")
@@ -1745,14 +1786,20 @@ func TestAuthRoutes_ForgotPassword_SendsEmail(t *testing.T) {
 	if email.To != "forgot@example.com" {
 		t.Errorf("Expected email to forgot@example.com, got %s", email.To)
 	}
-	if email.Subject != "Reset your Chatto password" {
-		t.Errorf("Expected subject 'Reset your Chatto password', got %s", email.Subject)
+	if email.Subject != "Reset your Engineering password" {
+		t.Errorf("Expected subject 'Reset your Engineering password', got %s", email.Subject)
+	}
+	if !strings.Contains(email.Body, "reset the password for your Engineering account") {
+		t.Errorf("Expected email body to mention Engineering account, got: %s", email.Body)
 	}
 	if !strings.Contains(email.Body, "/reset-password?token=PR") {
 		t.Errorf("Expected email body to contain reset link with PR token, got: %s", email.Body)
 	}
 	if !strings.Contains(email.Body, "1 hour") {
 		t.Errorf("Expected email body to mention 1-hour expiration")
+	}
+	if strings.Contains(email.Body, "The Chatto Team") {
+		t.Errorf("Expected password reset email not to use generic Chatto signoff, got: %s", email.Body)
 	}
 }
 


### PR DESCRIPTION
## Changes
- Resolve the effective Chatto server name when sending auth emails.
- Include that server name in registration, email-verification, and password-reset email subjects and body copy.
- Remove the generic Chatto Team signoff from password reset emails.
- Extend HTTP auth route tests to cover configured server names and existing code/link expiry behavior.

## Tests
- `mise x -- go test -tags test_endpoints ./internal/http_server -run 'TestAuthRoutes_.*Email|TestAuthRoutes_ForgotPassword|TestAuthRoutes_ResetPassword|TestAuthRoutes_CompletePasswordResetFlow' -timeout 60s`
- `git diff --check`
