### PR TITLE
fix(timeline): preserve migrated room join order

### DIFF
--- a/cli/internal/migrations/migrations.go
+++ b/cli/internal/migrations/migrations.go
@@ -122,7 +122,7 @@ func RunAll(
 	// seed together: a RoomCreatedEvent first, then the chronologically
 	// ordered UserJoinedRoomEvents. Atomic AppendBatch keeps that invariant.
 	if err := run("room_aggregate_es", serverConfigKV != nil, func() error {
-		return MigrateRoomAggregateToES(ctx, serverConfigKV, publisher, logger)
+		return MigrateRoomAggregateToES(ctx, serverConfigKV, publisher, logger, serverEventsStream)
 	}); err != nil {
 		return err
 	}

--- a/cli/internal/migrations/room_aggregate_es.go
+++ b/cli/internal/migrations/room_aggregate_es.go
@@ -18,6 +18,8 @@ import (
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
+type legacyRoomMembershipEvents map[string]map[string]*corev1.Event
+
 // MigrateRoomAggregateToES seeds the EVT stream from the existing
 // `room.{kind}.{roomID}` keys and both known room membership key shapes
 // in SERVER_CONFIG (ADR-035 phase 3 for the room aggregate):
@@ -50,6 +52,7 @@ func MigrateRoomAggregateToES(
 	serverConfigKV jetstream.KeyValue,
 	publisher *events.Publisher,
 	logger *log.Logger,
+	legacyServerEvents ...jetstream.Stream,
 ) error {
 	roomKeys, err := listSortedKeys(ctx, serverConfigKV, "room.channel.*", "room.dm.*")
 	if err != nil {
@@ -60,6 +63,12 @@ func MigrateRoomAggregateToES(
 	if err != nil {
 		return fmt.Errorf("load memberships: %w", err)
 	}
+
+	legacyJoins, err := loadLegacyRoomMembershipEvents(ctx, firstLegacyStream(legacyServerEvents), logger)
+	if err != nil {
+		return fmt.Errorf("load legacy room membership events: %w", err)
+	}
+	applyLegacyMembershipEvents(memberships, legacyJoins)
 
 	var migrated, skipped, archivedEvents, memberEvents, memberBackfillEvents int
 	for _, key := range roomKeys {
@@ -118,9 +127,7 @@ func MigrateRoomAggregateToES(
 		}
 
 		for _, m := range memberships[room.GetId()] {
-			joinedEvent := stamp(&corev1.Event{Event: &corev1.Event_UserJoinedRoom{
-				UserJoinedRoom: &corev1.UserJoinedRoomEvent{RoomId: room.GetId()},
-			}}, m.userID, timestamppb.New(m.createdAt))
+			joinedEvent := m.joinEvent(room.GetId())
 			batch = append(batch, events.BatchEntry{
 				Subject: agg.SubjectFor(joinedEvent),
 				Event:   joinedEvent,
@@ -191,9 +198,7 @@ func backfillMissingRoomMemberships(
 			continue
 		}
 
-		event := stamp(&corev1.Event{Event: &corev1.Event_UserJoinedRoom{
-			UserJoinedRoom: &corev1.UserJoinedRoomEvent{RoomId: roomID},
-		}}, membership.userID, timestamppb.New(membership.createdAt))
+		event := membership.joinEvent(roomID)
 
 		seq, err := publisher.AppendAt(ctx, subject, event, expectedSeq)
 		if err != nil {
@@ -209,8 +214,18 @@ func backfillMissingRoomMemberships(
 // its room_membership entry. Used to order UserJoinedRoom events
 // chronologically within each room's seed batch.
 type membershipEntry struct {
-	userID    string
-	createdAt time.Time
+	userID      string
+	createdAt   time.Time
+	legacyEvent *corev1.Event
+}
+
+func (m membershipEntry) joinEvent(roomID string) *corev1.Event {
+	if m.legacyEvent != nil {
+		return proto.Clone(m.legacyEvent).(*corev1.Event)
+	}
+	return stamp(&corev1.Event{Event: &corev1.Event_UserJoinedRoom{
+		UserJoinedRoom: &corev1.UserJoinedRoomEvent{RoomId: roomID},
+	}}, m.userID, timestamppb.New(m.createdAt))
 }
 
 // loadMembershipsByRoom reads every `room_membership.>` key and groups
@@ -288,6 +303,115 @@ func parseRoomMembershipKey(key string) (roomID string, userID string, ok bool) 
 		return parts[2], parts[1], true
 	default:
 		return "", "", false
+	}
+}
+
+func firstLegacyStream(streams []jetstream.Stream) jetstream.Stream {
+	if len(streams) == 0 {
+		return nil
+	}
+	return streams[0]
+}
+
+func loadLegacyRoomMembershipEvents(
+	ctx context.Context,
+	stream jetstream.Stream,
+	logger *log.Logger,
+) (legacyRoomMembershipEvents, error) {
+	if stream == nil {
+		return nil, nil
+	}
+
+	consumer, err := stream.CreateConsumer(ctx, jetstream.ConsumerConfig{
+		FilterSubjects:    []string{"server.room.*.*.meta"},
+		DeliverPolicy:     jetstream.DeliverAllPolicy,
+		AckPolicy:         jetstream.AckNonePolicy,
+		MemoryStorage:     true,
+		InactiveThreshold: 30 * time.Second,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create legacy room membership consumer on SERVER_EVENTS: %w", err)
+	}
+	defer stream.DeleteConsumer(context.Background(), consumer.CachedInfo().Name)
+
+	info, err := consumer.Info(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy room membership consumer info: %w", err)
+	}
+	if info.NumPending == 0 {
+		return nil, nil
+	}
+
+	msgs, err := consumer.Fetch(int(info.NumPending), jetstream.FetchMaxWait(60*time.Second))
+	if err != nil && !errors.Is(err, jetstream.ErrNoMessages) {
+		return nil, fmt.Errorf("fetch legacy room membership events: %w", err)
+	}
+	if msgs == nil {
+		return nil, nil
+	}
+
+	byRoom := make(legacyRoomMembershipEvents)
+	for msg := range msgs.Messages() {
+		var legacyEvent corev1.Event
+		if err := proto.Unmarshal(msg.Data(), &legacyEvent); err != nil {
+			logger.Warn("room_aggregate ES migration: skipping unmarshalable legacy room meta event", "subject", msg.Subject(), "error", err)
+			continue
+		}
+
+		join := legacyEvent.GetUserJoinedRoom()
+		if join == nil {
+			continue
+		}
+		roomID := join.GetRoomId()
+		userID := legacyEvent.GetActorId()
+		if roomID == "" || userID == "" {
+			logger.Warn("room_aggregate ES migration: skipping legacy room join with missing room or actor", "subject", msg.Subject(), "room_id", roomID, "actor_id", userID)
+			continue
+		}
+
+		legacyEvent.CreatedAt = preserveTimestamp(legacyEvent.GetCreatedAt())
+		if legacyEvent.GetId() == "" {
+			legacyEvent.Id = newMigrationEventID()
+		}
+
+		roomJoins := byRoom[roomID]
+		if roomJoins == nil {
+			roomJoins = make(map[string]*corev1.Event)
+			byRoom[roomID] = roomJoins
+		}
+		if existing := roomJoins[userID]; existing != nil && !legacyEvent.GetCreatedAt().AsTime().Before(existing.GetCreatedAt().AsTime()) {
+			continue
+		}
+		roomJoins[userID] = proto.Clone(&legacyEvent).(*corev1.Event)
+	}
+	return byRoom, nil
+}
+
+func applyLegacyMembershipEvents(
+	memberships map[string][]membershipEntry,
+	legacyJoins legacyRoomMembershipEvents,
+) {
+	for roomID, joins := range legacyJoins {
+		members := memberships[roomID]
+		seen := make(map[string]int, len(members))
+		for i, member := range members {
+			seen[member.userID] = i
+		}
+
+		for userID, event := range joins {
+			if idx, ok := seen[userID]; ok {
+				members[idx].createdAt = event.GetCreatedAt().AsTime()
+				members[idx].legacyEvent = event
+			}
+		}
+
+		sort.Slice(members, func(i, j int) bool {
+			if !members[i].createdAt.Equal(members[j].createdAt) {
+				return members[i].createdAt.Before(members[j].createdAt)
+			}
+			return members[i].userID < members[j].userID
+		})
+		memberships[roomID] = members
 	}
 }
 

--- a/cli/internal/migrations/room_aggregate_es.go
+++ b/cli/internal/migrations/room_aggregate_es.go
@@ -379,7 +379,7 @@ func loadLegacyRoomMembershipEvents(
 			roomJoins = make(map[string]*corev1.Event)
 			byRoom[roomID] = roomJoins
 		}
-		if existing := roomJoins[userID]; existing != nil && !legacyEvent.GetCreatedAt().AsTime().Before(existing.GetCreatedAt().AsTime()) {
+		if existing := roomJoins[userID]; existing != nil && legacyEvent.GetCreatedAt().AsTime().Before(existing.GetCreatedAt().AsTime()) {
 			continue
 		}
 		roomJoins[userID] = proto.Clone(&legacyEvent).(*corev1.Event)

--- a/cli/internal/migrations/room_aggregate_es_test.go
+++ b/cli/internal/migrations/room_aggregate_es_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"hmans.de/chatto/internal/events"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
@@ -230,6 +231,88 @@ func TestMigrateRoomAggregateToES_ChronologicalMembershipOrder(t *testing.T) {
 		require.NoError(t, proto.Unmarshal(msg.Data, &ev))
 		require.Equal(t, wantActor, ev.GetActorId(), "join #%d actor", i)
 	}
+}
+
+func TestMigrateRoomAggregateToES_PreservesLegacyJoinEnvelope(t *testing.T) {
+	ctx, kv, stream, publisher, js := setupTestESWithJS(t)
+	legacyStream, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+		Name:     "SERVER_EVENTS_TEST",
+		Subjects: []string{"server.>"},
+		Storage:  jetstream.MemoryStorage,
+	})
+	require.NoError(t, err)
+
+	seedRoom(t, kv, "dm", &corev1.Room{
+		Id:   "DM1",
+		Kind: corev1.RoomKind_ROOM_KIND_DM,
+	})
+	seedMembership(t, kv, "dm", "DM1", "U1")
+
+	legacyCreatedAt := time.Date(2026, 3, 17, 13, 38, 0, 0, time.UTC)
+	legacyJoin := &corev1.Event{
+		Id:        "ElegacyJoinU1",
+		ActorId:   "U1",
+		CreatedAt: timestamppb.New(legacyCreatedAt),
+		Event: &corev1.Event_UserJoinedRoom{
+			UserJoinedRoom: &corev1.UserJoinedRoomEvent{RoomId: "DM1"},
+		},
+	}
+	data, err := proto.Marshal(legacyJoin)
+	require.NoError(t, err)
+	_, err = js.Publish(ctx, "server.room.dm.DM1.meta", data)
+	require.NoError(t, err)
+
+	require.NoError(t, MigrateRoomAggregateToES(ctx, kv, publisher, testLogger(), legacyStream))
+
+	msg, err := stream.GetMsg(ctx, 2)
+	require.NoError(t, err)
+	var ev corev1.Event
+	require.NoError(t, proto.Unmarshal(msg.Data, &ev))
+	require.Equal(t, "ElegacyJoinU1", ev.GetId())
+	require.Equal(t, "U1", ev.GetActorId())
+	require.True(t, ev.GetCreatedAt().AsTime().Equal(legacyCreatedAt))
+	require.Equal(t, "DM1", ev.GetUserJoinedRoom().GetRoomId())
+}
+
+func TestMigrateRoomAggregateToES_DoesNotResurrectLegacyJoinWithoutMembership(t *testing.T) {
+	ctx, kv, stream, publisher, js := setupTestESWithJS(t)
+	legacyStream, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+		Name:     "SERVER_EVENTS_TEST",
+		Subjects: []string{"server.>"},
+		Storage:  jetstream.MemoryStorage,
+	})
+	require.NoError(t, err)
+
+	seedRoom(t, kv, "channel", &corev1.Room{
+		Id:   "R1",
+		Name: "general",
+		Kind: corev1.RoomKind_ROOM_KIND_CHANNEL,
+	})
+
+	legacyJoin := &corev1.Event{
+		Id:        "EdepartedJoin",
+		ActorId:   "Udeparted",
+		CreatedAt: timestamppb.New(time.Date(2026, 3, 17, 13, 38, 0, 0, time.UTC)),
+		Event: &corev1.Event_UserJoinedRoom{
+			UserJoinedRoom: &corev1.UserJoinedRoomEvent{RoomId: "R1"},
+		},
+	}
+	data, err := proto.Marshal(legacyJoin)
+	require.NoError(t, err)
+	_, err = js.Publish(ctx, "server.room.channel.R1.meta", data)
+	require.NoError(t, err)
+
+	require.NoError(t, MigrateRoomAggregateToES(ctx, kv, publisher, testLogger(), legacyStream))
+
+	info, err := stream.Info(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, info.State.Msgs)
+
+	msg, err := stream.GetMsg(ctx, 1)
+	require.NoError(t, err)
+	var ev corev1.Event
+	require.NoError(t, proto.Unmarshal(msg.Data, &ev))
+	require.NotNil(t, ev.GetRoomCreated())
 }
 
 // firstAggregateSeq returns the lowest stream sequence carrying a

--- a/cli/internal/migrations/room_aggregate_es_test.go
+++ b/cli/internal/migrations/room_aggregate_es_test.go
@@ -274,6 +274,61 @@ func TestMigrateRoomAggregateToES_PreservesLegacyJoinEnvelope(t *testing.T) {
 	require.Equal(t, "DM1", ev.GetUserJoinedRoom().GetRoomId())
 }
 
+func TestMigrateRoomAggregateToES_PreservesLatestLegacyJoinForCurrentMembership(t *testing.T) {
+	ctx, kv, stream, publisher, js := setupTestESWithJS(t)
+	legacyStream, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+		Name:     "SERVER_EVENTS_TEST",
+		Subjects: []string{"server.>"},
+		Storage:  jetstream.MemoryStorage,
+	})
+	require.NoError(t, err)
+
+	seedRoom(t, kv, "channel", &corev1.Room{
+		Id:   "R1",
+		Name: "general",
+		Kind: corev1.RoomKind_ROOM_KIND_CHANNEL,
+	})
+	seedMembership(t, kv, "channel", "R1", "U1")
+
+	firstJoinedAt := time.Date(2026, 3, 17, 13, 38, 0, 0, time.UTC)
+	rejoinedAt := time.Date(2026, 5, 8, 9, 0, 0, 0, time.UTC)
+	legacyJoins := []*corev1.Event{
+		{
+			Id:        "EfirstJoin",
+			ActorId:   "U1",
+			CreatedAt: timestamppb.New(firstJoinedAt),
+			Event: &corev1.Event_UserJoinedRoom{
+				UserJoinedRoom: &corev1.UserJoinedRoomEvent{RoomId: "R1"},
+			},
+		},
+		{
+			Id:        "Erejoin",
+			ActorId:   "U1",
+			CreatedAt: timestamppb.New(rejoinedAt),
+			Event: &corev1.Event_UserJoinedRoom{
+				UserJoinedRoom: &corev1.UserJoinedRoomEvent{RoomId: "R1"},
+			},
+		},
+	}
+	for _, legacyJoin := range legacyJoins {
+		data, err := proto.Marshal(legacyJoin)
+		require.NoError(t, err)
+		_, err = js.Publish(ctx, "server.room.channel.R1.meta", data)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, MigrateRoomAggregateToES(ctx, kv, publisher, testLogger(), legacyStream))
+
+	msg, err := stream.GetMsg(ctx, 2)
+	require.NoError(t, err)
+	var ev corev1.Event
+	require.NoError(t, proto.Unmarshal(msg.Data, &ev))
+	require.Equal(t, "Erejoin", ev.GetId())
+	require.Equal(t, "U1", ev.GetActorId())
+	require.True(t, ev.GetCreatedAt().AsTime().Equal(rejoinedAt))
+	require.Equal(t, "R1", ev.GetUserJoinedRoom().GetRoomId())
+}
+
 func TestMigrateRoomAggregateToES_DoesNotResurrectLegacyJoinWithoutMembership(t *testing.T) {
 	ctx, kv, stream, publisher, js := setupTestESWithJS(t)
 	legacyStream, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{

--- a/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -24,7 +24,7 @@ class FakeGqlClient {
 						: queryDataQueue.length > 1
 							? queryDataQueue.shift()
 							: queryDataQueue[0];
-				return Promise.resolve({ data, error: null });
+				return Promise.resolve(data).then((resolvedData) => ({ data: resolvedData, error: null }));
 			}
 		}));
 		this.client = {
@@ -44,6 +44,14 @@ async function settle() {
 	await Promise.resolve();
 	await Promise.resolve();
 	flushSync();
+}
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((r) => {
+		resolve = r;
+	});
+	return { promise, resolve };
 }
 
 function threadMessageEvent(id: string, threadRootEventId: string | null = null) {
@@ -99,6 +107,32 @@ function threadQueryResult({
 						hasNewer
 					}
 				}
+			}
+		}
+	};
+}
+
+function roomEventsResult({
+	events,
+	startCursor,
+	endCursor,
+	hasOlder,
+	hasNewer
+}: {
+	events: unknown[];
+	startCursor: string | null;
+	endCursor: string | null;
+	hasOlder: boolean;
+	hasNewer: boolean;
+}) {
+	return {
+		room: {
+			events: {
+				events,
+				startCursor,
+				endCursor,
+				hasOlder,
+				hasNewer
 			}
 		}
 	};
@@ -393,6 +427,69 @@ describe('MessagesStore — room lifecycle ownership', () => {
 		await settle();
 		expect(fake.queryMock).toHaveBeenCalledTimes(2);
 
+		store.dispose();
+	});
+
+	it('keeps already-loaded room events before reconnect catch-up pages', async () => {
+		const fake = new FakeGqlClient([
+			roomEventsResult({
+				events: [threadMessageEvent('m1'), threadMessageEvent('m2')],
+				startCursor: 'seq:1',
+				endCursor: 'seq:2',
+				hasOlder: false,
+				hasNewer: false
+			}),
+			roomEventsResult({
+				events: [threadMessageEvent('m3'), threadMessageEvent('m4')],
+				startCursor: 'seq:3',
+				endCursor: 'seq:4',
+				hasOlder: false,
+				hasNewer: true
+			})
+		]);
+		const store = new MessagesStore(fake as unknown as GraphQLClient, () => null);
+
+		store.setRoom('room-1');
+		await settle();
+
+		fake.bumpReconnect();
+		await settle();
+
+		expect(store.rootEvents.map((event) => event.id)).toEqual(['m1', 'm2', 'm3', 'm4']);
+		store.dispose();
+	});
+
+	it('keeps live room events after in-flight reconnect catch-up pages', async () => {
+		const catchUp = deferred<unknown>();
+		const fake = new FakeGqlClient([
+			roomEventsResult({
+				events: [threadMessageEvent('m1'), threadMessageEvent('m2')],
+				startCursor: 'seq:1',
+				endCursor: 'seq:2',
+				hasOlder: false,
+				hasNewer: false
+			}),
+			catchUp.promise
+		]);
+		const store = new MessagesStore(fake as unknown as GraphQLClient, () => null);
+
+		store.setRoom('room-1');
+		await settle();
+
+		fake.bumpReconnect();
+		store.ingestServerEvent(threadMessageEvent('m5') as never);
+		catchUp.resolve(
+			roomEventsResult({
+				events: [threadMessageEvent('m3'), threadMessageEvent('m4')],
+				startCursor: 'seq:3',
+				endCursor: 'seq:4',
+				hasOlder: false,
+				hasNewer: false
+			})
+		);
+		await settle();
+
+		expect(store.rootEvents.map((event) => event.id)).toEqual(['m1', 'm2', 'm3', 'm4', 'm5']);
 		store.dispose();
 	});
 

--- a/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -690,7 +690,7 @@ export class MessagesStore {
   }
 
   private catchUpRoomForward(thisLoad: number, after: string): void {
-    const seenBeforeFetch = new Set<string>(this.seenIds);
+    const seenBeforeFetch = new SvelteSet<string>(this.seenIds);
 
     this.client
       .query(RoomAfterQuery, {

--- a/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -530,6 +530,33 @@ export class MessagesStore {
     return newOnes.length;
   }
 
+  private mergeForwardPage(
+    rawEvents: readonly RawEvent[],
+    seenBeforeFetch: ReadonlySet<string>
+  ): RoomEventViewFragment[] {
+    const fetched = unmask(rawEvents);
+    const newSeen = new SvelteSet<string>();
+    const merged: RoomEventViewFragment[] = [];
+
+    const add = (event: RoomEventViewFragment) => {
+      if (newSeen.has(event.id)) return;
+      newSeen.add(event.id);
+      merged.push(event);
+    };
+
+    for (const event of this.events) {
+      if (seenBeforeFetch.has(event.id)) add(event);
+    }
+    for (const event of fetched) add(event);
+    for (const event of this.events) {
+      if (!seenBeforeFetch.has(event.id)) add(event);
+    }
+
+    this.events = merged;
+    this.seenIds = newSeen;
+    return fetched;
+  }
+
   /**
    * Replace the buffer with fetched events but preserve any subscription
    * events that arrived during the in-flight query. Always the right
@@ -663,6 +690,8 @@ export class MessagesStore {
   }
 
   private catchUpRoomForward(thisLoad: number, after: string): void {
+    const seenBeforeFetch = new Set<string>(this.seenIds);
+
     this.client
       .query(RoomAfterQuery, {
         roomId: this.roomId,
@@ -679,23 +708,17 @@ export class MessagesStore {
         const page = result.data?.room?.events;
         if (!page) return;
 
-        const fetched = unmask(page.events);
-        const strategy = page.hasNewer ? 'replace' : 'append';
+        const fetched = this.mergeForwardPage(page.events, seenBeforeFetch);
         console.debug(
           '[MessagesStore] catchUpForward: roomId=%s after=%s fetched=%d hasNewer=%s strategy=%s',
           this.roomId,
           after,
           fetched.length,
           page.hasNewer,
-          strategy
+          'merge-forward'
         );
-        if (page.hasNewer) {
-          this.replaceWithFetchedAndUpdateCursors(page);
-        } else {
-          if (page.endCursor) {
-            this.newestCursor = page.endCursor;
-          }
-          this.appendMany(fetched);
+        if (page.endCursor) {
+          this.newestCursor = page.endCursor;
         }
       })
       .catch((error: unknown) => {

--- a/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -113,21 +113,9 @@
   const scrollState = composerContext.scrollState;
   const userSettings = getUserSettings();
 
-  // Sort events chronologically. Uses createdAt with event ID tiebreaker for
-  // the rare case of sub-millisecond concurrent posts. Events from JetStream
-  // are already ordered; this is a safety net for merged live + historical data.
-  let sortedEvents = $derived(
-    [...events].sort((a, b) => {
-      const timeA = new Date(a.createdAt).getTime();
-      const timeB = new Date(b.createdAt).getTime();
-      if (timeA !== timeB) return timeA - timeB;
-      return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
-    })
-  );
-
   // Filter events based on configuration
   let filteredEvents = $derived(
-    sortedEvents.filter((e) => {
+    events.filter((e) => {
       if (e.event?.__typename !== 'MessagePostedEvent') return true;
 
       const msg = e.event;

--- a/frontend/src/routes/chat/[serverId]/[roomId]/virtualItems.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/virtualItems.spec.ts
@@ -182,6 +182,22 @@ describe('buildVirtualItems', () => {
     expect(e2).toMatchObject({ type: 'event', isFirstInGroup: false });
   });
 
+  it('preserves input event order even when createdAt moves backwards', () => {
+    const events = [
+      makeSystemEvent('UserJoinedRoomEvent', { id: 'join', createdAt: '2025-05-08T12:00:00Z' }),
+      makeMessageEvent({ id: 'first-message', createdAt: '2025-03-17T12:00:00Z' }),
+      makeMessageEvent({ id: 'second-message', createdAt: '2025-03-18T12:00:00Z' })
+    ];
+
+    const items = buildVirtualItems(meta(events), null, false);
+    const eventKeys = items.flatMap((i) => {
+      if (i.type === 'event') return i.key;
+      if (i.type === 'system-group') return i.events.map((event) => event.id);
+      return [];
+    });
+    expect(eventKeys).toEqual(['join', 'first-message', 'second-message']);
+  });
+
   it('produces stable, unique keys per item', () => {
     const events = [
       makeMessageEvent({ id: 'e1', createdAt: '2025-04-26T23:00:00Z' }),


### PR DESCRIPTION
## Summary

- Preserve legacy `UserJoinedRoomEvent` envelope metadata during the room aggregate ES migration when it matches a current room membership.
- Preserve the latest matching legacy join for members who left and later rejoined before migration.
- Keep room event rendering in server/projection order instead of re-sorting by `createdAt`.
- Keep reconnect catch-up pages ordered after already-loaded events and before live events that arrive while catch-up is in flight.
- Add backend and frontend regressions for migrated join metadata and non-monotonic timestamps.

## Verification

- `go test ./internal/migrations -run 'TestMigrateRoomAggregateToES'`
- `go test ./internal/migrations`
- `go test ./internal/migrations -run 'TestMigrateRoomAggregateToES|TestMigrateMessagesToES|TestMigrateReactionsToES' -count=1`
- `pnpm exec vitest run src/lib/state/room/messages.svelte.spec.ts`
- `pnpm exec vitest run 'src/routes/chat/[serverId]/[roomId]/virtualItems.spec.ts'`
- `pnpm exec svelte-check --tsconfig ./tsconfig.json`
