### PR TITLE
feat(pwa): enrich web app manifest

### DIFF
--- a/frontend/static/manifest.webmanifest
+++ b/frontend/static/manifest.webmanifest
@@ -1,11 +1,18 @@
 {
+  "id": "/",
   "name": "Chatto",
   "short_name": "Chatto",
-  "description": "Real-time chat application",
+  "description": "A real-time chat app for teams and communities.",
+  "lang": "en",
+  "dir": "ltr",
   "start_url": "/",
+  "scope": "/",
   "display": "standalone",
+  "display_override": ["standalone", "browser"],
   "background_color": "#f3f4f6",
   "theme_color": "#e5e7eb",
+  "categories": ["communication", "social", "productivity"],
+  "prefer_related_applications": false,
   "icons": [
     {
       "src": "/icons/icon-192.png",
@@ -28,6 +35,34 @@
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "Open Chatto",
+      "short_name": "Chatto",
+      "description": "Open Chatto.",
+      "url": "/",
+      "icons": [
+        {
+          "src": "/icons/icon-192.png",
+          "sizes": "192x192",
+          "type": "image/png"
+        }
+      ]
+    },
+    {
+      "name": "Notifications",
+      "short_name": "Notifications",
+      "description": "Open your Chatto notifications.",
+      "url": "/chat/notifications",
+      "icons": [
+        {
+          "src": "/icons/icon-192.png",
+          "sizes": "192x192",
+          "type": "image/png"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Changes

- Enriches the web app manifest with stable install metadata: `id`, `scope`, language, direction, categories, display override, and related-app preference.
- Adds manifest shortcuts for opening Chatto and the notifications view.

## Validation

- `mise x -- node -e "JSON.parse(require('fs').readFileSync('frontend/static/manifest.webmanifest','utf8')); console.log('manifest ok')"`
- `git diff --check`
