### PR TITLE
fix(timeline): order migrated membership events chronologically

### DIFF
--- a/cli/internal/core/room_events.go
+++ b/cli/internal/core/room_events.go
@@ -6,6 +6,15 @@ import (
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
+// RoomTimelineCursor is an opaque room-timeline position. StreamSeq keeps
+// old sequence-only cursors working; CreatedAtUnixNano is set for the
+// room-visible index, whose display order is created_at + stream seq.
+type RoomTimelineCursor struct {
+	StreamSeq         uint64
+	CreatedAtUnixNano int64
+	HasCreatedAt      bool
+}
+
 // RoomEvent pairs a *corev1.Event with its stream sequence so the
 // pagination layer can build opaque cursors without re-deriving the
 // sequence per event. Event is embedded so callers can access event
@@ -26,6 +35,8 @@ type RoomEventsResult struct {
 	HasNewer       bool
 	StartCursorSeq uint64
 	EndCursorSeq   uint64
+	StartCursor    RoomTimelineCursor
+	EndCursor      RoomTimelineCursor
 }
 
 // RoomEventsAroundResult contains the result of fetching events around
@@ -54,15 +65,21 @@ type RoomEventsAroundResult struct {
 // evt.room.{R}.{eventType} — kind is a property of the room, not the
 // event).
 func (c *ChattoCore) GetRoomEvents(ctx context.Context, kind RoomKind, room_id string, limit int, beforeSeq *uint64) (*RoomEventsResult, error) {
-	limit = clampHistoricalMessageLimit(limit)
-	var before uint64
+	var before *RoomTimelineCursor
 	if beforeSeq != nil {
-		before = *beforeSeq
+		before = &RoomTimelineCursor{StreamSeq: *beforeSeq}
 	}
+	return c.GetRoomEventsByCursor(ctx, kind, room_id, limit, before)
+}
+
+// GetRoomEventsByCursor is the cursor-rich form used by GraphQL room
+// pagination. It returns room-visible entries in chronological display order.
+func (c *ChattoCore) GetRoomEventsByCursor(ctx context.Context, kind RoomKind, room_id string, limit int, before *RoomTimelineCursor) (*RoomEventsResult, error) {
+	limit = clampHistoricalMessageLimit(limit)
 
 	// Bounded newest-first walk via the derived visible-room timeline. Fetch
 	// limit+1 to detect HasOlder without a second call.
-	raw := c.RoomTimeline.VisibleRoomTimeline(room_id, limit+1, before, nil)
+	raw := c.RoomTimeline.VisibleRoomTimelineByCursor(room_id, limit+1, before, nil)
 	hasOlder := len(raw) > limit
 	if hasOlder {
 		raw = raw[:limit]
@@ -81,12 +98,9 @@ func (c *ChattoCore) GetRoomEvents(ctx context.Context, kind RoomKind, room_id s
 	r := &RoomEventsResult{
 		Events:   visible,
 		HasOlder: hasOlder,
-		HasNewer: beforeSeq != nil,
+		HasNewer: before != nil,
 	}
-	if len(visible) > 0 {
-		r.StartCursorSeq = visible[0].Sequence
-		r.EndCursorSeq = visible[len(visible)-1].Sequence
-	}
+	setRoomEventsResultPositionCursors(r)
 	return r, nil
 }
 
@@ -160,12 +174,18 @@ func (c *ChattoCore) GetRoomEventsAround(ctx context.Context, kind RoomKind, roo
 //
 // Authorization: caller must verify room membership before calling.
 func (c *ChattoCore) GetRoomEventsAfter(ctx context.Context, kind RoomKind, roomID string, afterSeq uint64, limit int) (*RoomEventsResult, error) {
+	return c.GetRoomEventsAfterCursor(ctx, kind, roomID, RoomTimelineCursor{StreamSeq: afterSeq}, limit)
+}
+
+// GetRoomEventsAfterCursor returns events after a room-visible cursor in
+// chronological display order.
+func (c *ChattoCore) GetRoomEventsAfterCursor(ctx context.Context, kind RoomKind, roomID string, after RoomTimelineCursor, limit int) (*RoomEventsResult, error) {
 	limit = clampHistoricalMessageLimit(limit)
 
 	// Walk visible entries oldest-first from the cursor so forward
 	// pagination returns the nearest newer events first. Fetch limit+1
 	// to detect whether another forward page exists.
-	raw := c.RoomTimeline.VisibleRoomTimelineAfter(roomID, limit+1, afterSeq, nil)
+	raw := c.RoomTimeline.VisibleRoomTimelineAfterCursor(roomID, limit+1, after, nil)
 	hasNewer := len(raw) > limit
 	if hasNewer {
 		raw = raw[:limit]
@@ -180,11 +200,39 @@ func (c *ChattoCore) GetRoomEventsAfter(ctx context.Context, kind RoomKind, room
 		HasOlder: true, // forward pagination always has older content (everything <= afterSeq).
 		HasNewer: hasNewer,
 	}
-	if len(newer) > 0 {
-		r.StartCursorSeq = newer[0].Sequence
-		r.EndCursorSeq = newer[len(newer)-1].Sequence
-	}
+	setRoomEventsResultPositionCursors(r)
 	return r, nil
+}
+
+func setRoomEventsResultPositionCursors(result *RoomEventsResult) {
+	if result == nil || len(result.Events) == 0 {
+		return
+	}
+	start := result.Events[0]
+	end := result.Events[len(result.Events)-1]
+	result.StartCursorSeq = start.Sequence
+	result.EndCursorSeq = end.Sequence
+	result.StartCursor = roomEventCursor(start.Event, start.Sequence)
+	result.EndCursor = roomEventCursor(end.Event, end.Sequence)
+}
+
+func roomEventCursor(event *corev1.Event, seq uint64) RoomTimelineCursor {
+	cursor := RoomTimelineCursor{StreamSeq: seq}
+	if event != nil && event.GetCreatedAt() != nil {
+		cursor.CreatedAtUnixNano = event.GetCreatedAt().AsTime().UnixNano()
+		cursor.HasCreatedAt = true
+	}
+	return cursor
+}
+
+func roomTimelineUnixNano(event *corev1.Event, seq uint64) int64 {
+	if event != nil && event.GetCreatedAt() != nil {
+		return event.GetCreatedAt().AsTime().UnixNano()
+	}
+	if seq <= uint64(^uint64(0)>>1) {
+		return int64(seq)
+	}
+	return int64(^uint64(0) >> 1)
 }
 
 func clampHistoricalMessageLimit(limit int) int {

--- a/cli/internal/core/room_timeline_projection.go
+++ b/cli/internal/core/room_timeline_projection.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"sort"
 	"strings"
 
 	"google.golang.org/protobuf/proto"
@@ -205,7 +206,7 @@ func (p *RoomTimelineProjection) Apply(event *corev1.Event, seq uint64) error {
 	entry := &TimelineEntry{StreamSeq: seq, Event: event}
 	p.byRoom[roomID] = append(p.byRoom[roomID], entry)
 	if isVisibleRoomTimelineEntry(event) {
-		p.visibleByRoom[roomID] = append(p.visibleByRoom[roomID], entry)
+		p.insertVisibleRoomEntryLocked(roomID, entry)
 	}
 	if eid := event.GetId(); eid != "" {
 		p.byEventID[eid] = entry
@@ -295,6 +296,17 @@ func (p *RoomTimelineProjection) Apply(event *corev1.Event, seq uint64) error {
 		}
 	}
 	return nil
+}
+
+func (p *RoomTimelineProjection) insertVisibleRoomEntryLocked(roomID string, entry *TimelineEntry) {
+	entries := p.visibleByRoom[roomID]
+	idx := sort.Search(len(entries), func(i int) bool {
+		return compareTimelineEntries(entries[i], entry) >= 0
+	})
+	entries = append(entries, nil)
+	copy(entries[idx+1:], entries[idx:])
+	entries[idx] = entry
+	p.visibleByRoom[roomID] = entries
 }
 
 func (p *RoomTimelineProjection) applyUserKeyShreddedLocked(userID string) {
@@ -869,6 +881,23 @@ func (p *RoomTimelineProjection) VisibleRoomTimeline(
 	beforeStreamSeq uint64,
 	visible func(*corev1.Event) bool,
 ) []*TimelineEntry {
+	var before *RoomTimelineCursor
+	if beforeStreamSeq > 0 {
+		before = &RoomTimelineCursor{StreamSeq: beforeStreamSeq}
+	}
+	return p.VisibleRoomTimelineByCursor(roomID, limit, before, visible)
+}
+
+// VisibleRoomTimelineByCursor walks the room's timeline newest-first in
+// display order, applying `visible` as a per-entry filter. A position cursor
+// excludes entries at or newer than that display position; a sequence-only
+// cursor keeps the legacy stream-sequence behavior.
+func (p *RoomTimelineProjection) VisibleRoomTimelineByCursor(
+	roomID string,
+	limit int,
+	before *RoomTimelineCursor,
+	visible func(*corev1.Event) bool,
+) []*TimelineEntry {
 	if limit <= 0 {
 		return nil
 	}
@@ -881,7 +910,7 @@ func (p *RoomTimelineProjection) VisibleRoomTimeline(
 	out := make([]*TimelineEntry, 0, limit)
 	for i := len(entries) - 1; i >= 0 && len(out) < limit; i-- {
 		e := entries[i]
-		if beforeStreamSeq > 0 && e.StreamSeq >= beforeStreamSeq {
+		if before != nil && !entryBeforeCursor(e, *before) {
 			continue
 		}
 		if p.isHiddenEchoEntryLocked(e) {
@@ -905,6 +934,17 @@ func (p *RoomTimelineProjection) VisibleRoomTimelineAfter(
 	afterStreamSeq uint64,
 	visible func(*corev1.Event) bool,
 ) []*TimelineEntry {
+	return p.VisibleRoomTimelineAfterCursor(roomID, limit, RoomTimelineCursor{StreamSeq: afterStreamSeq}, visible)
+}
+
+// VisibleRoomTimelineAfterCursor walks the room's timeline oldest-first in
+// display order, returning entries strictly after the cursor position.
+func (p *RoomTimelineProjection) VisibleRoomTimelineAfterCursor(
+	roomID string,
+	limit int,
+	after RoomTimelineCursor,
+	visible func(*corev1.Event) bool,
+) []*TimelineEntry {
 	if limit <= 0 {
 		return nil
 	}
@@ -916,7 +956,7 @@ func (p *RoomTimelineProjection) VisibleRoomTimelineAfter(
 	}
 	out := make([]*TimelineEntry, 0, limit)
 	for _, e := range entries {
-		if e.StreamSeq <= afterStreamSeq {
+		if !entryAfterCursor(e, after) {
 			continue
 		}
 		if p.isHiddenEchoEntryLocked(e) {
@@ -989,6 +1029,62 @@ func (p *RoomTimelineProjection) VisibleRoomTimelineAround(
 		}
 	}
 	return out, targetVisibleIndex - start, start > 0, end < visibleCount, true
+}
+
+func compareTimelineEntries(a, b *TimelineEntry) int {
+	aTime := timelineEntryUnixNano(a)
+	bTime := timelineEntryUnixNano(b)
+	if aTime < bTime {
+		return -1
+	}
+	if aTime > bTime {
+		return 1
+	}
+	aSeq := timelineEntrySeq(a)
+	bSeq := timelineEntrySeq(b)
+	if aSeq < bSeq {
+		return -1
+	}
+	if aSeq > bSeq {
+		return 1
+	}
+	return 0
+}
+
+func entryBeforeCursor(entry *TimelineEntry, cursor RoomTimelineCursor) bool {
+	if cursor.HasCreatedAt {
+		entryTime := timelineEntryUnixNano(entry)
+		if entryTime != cursor.CreatedAtUnixNano {
+			return entryTime < cursor.CreatedAtUnixNano
+		}
+		return timelineEntrySeq(entry) < cursor.StreamSeq
+	}
+	return cursor.StreamSeq == 0 || timelineEntrySeq(entry) < cursor.StreamSeq
+}
+
+func entryAfterCursor(entry *TimelineEntry, cursor RoomTimelineCursor) bool {
+	if cursor.HasCreatedAt {
+		entryTime := timelineEntryUnixNano(entry)
+		if entryTime != cursor.CreatedAtUnixNano {
+			return entryTime > cursor.CreatedAtUnixNano
+		}
+		return timelineEntrySeq(entry) > cursor.StreamSeq
+	}
+	return timelineEntrySeq(entry) > cursor.StreamSeq
+}
+
+func timelineEntryUnixNano(entry *TimelineEntry) int64 {
+	if entry == nil {
+		return 0
+	}
+	return roomTimelineUnixNano(entry.Event, entry.StreamSeq)
+}
+
+func timelineEntrySeq(entry *TimelineEntry) uint64 {
+	if entry == nil {
+		return 0
+	}
+	return entry.StreamSeq
 }
 
 func (p *RoomTimelineProjection) isHiddenEchoEntryLocked(entry *TimelineEntry) bool {

--- a/cli/internal/core/room_timeline_projection_test.go
+++ b/cli/internal/core/room_timeline_projection_test.go
@@ -425,6 +425,38 @@ func TestRoomTimeline_DerivedVisibleTimelineSkipsFoldedEntries(t *testing.T) {
 	}
 }
 
+func TestRoomTimeline_VisibleTimelineUsesCreatedAtThenStreamSeq(t *testing.T) {
+	p := NewRoomTimelineProjection()
+
+	// Simulates ES migration append order: room aggregate membership facts can
+	// land before imported messages even when their preserved created_at places
+	// them later in the human timeline.
+	applyAll(t, p, []*corev1.Event{
+		roomCreatedTimelineEvent("ENV-CREATE", "R1", "general", 1),
+		joinedEvent("ENV-JOIN-LATE", "R1", "U2", 5),
+		postedEvent(postedOpts{envelopeID: "ENV-MESSAGE", eventID: "M1", roomID: "R1", actorID: "U1", body: "hello", at: 3}),
+	})
+
+	visible := p.VisibleRoomTimeline("R1", 10, 0, nil)
+	if got := eventIDs(visible); !slices.Equal(got, []string{"ENV-JOIN-LATE", "ENV-MESSAGE", "ENV-CREATE"}) {
+		t.Fatalf("visible newest-first = %v, want join/message/create by created_at", got)
+	}
+
+	cursor := RoomTimelineCursor{
+		StreamSeq:         3,
+		CreatedAtUnixNano: fixedTime(3).UnixNano(),
+		HasCreatedAt:      true,
+	}
+	older := p.VisibleRoomTimelineByCursor("R1", 10, &cursor, nil)
+	if got := eventIDs(older); !slices.Equal(got, []string{"ENV-CREATE"}) {
+		t.Fatalf("older than message cursor = %v, want create only", got)
+	}
+	newer := p.VisibleRoomTimelineAfterCursor("R1", 10, cursor, nil)
+	if got := eventIDs(newer); !slices.Equal(got, []string{"ENV-JOIN-LATE"}) {
+		t.Fatalf("newer than message cursor = %v, want late join only", got)
+	}
+}
+
 func TestRoomTimeline_RetractingOriginalTombstonesEchoBody(t *testing.T) {
 	p := NewRoomTimelineProjection()
 	applyAll(t, p, []*corev1.Event{
@@ -695,9 +727,9 @@ func TestRoomTimeline_NonRoomEventsSkipped(t *testing.T) {
 	stray := &corev1.Event{
 		Id:        "ENV-STRAY",
 		CreatedAt: timestamppb.New(fixedTime(1)),
-			Event: &corev1.Event_ServerMemberDeleted{
-				ServerMemberDeleted: &corev1.ServerMemberDeletedEvent{UserId: "U1"},
-			},
+		Event: &corev1.Event_ServerMemberDeleted{
+			ServerMemberDeleted: &corev1.ServerMemberDeletedEvent{UserId: "U1"},
+		},
 	}
 	if err := p.Apply(stray, 1); err != nil {
 		t.Fatalf("Apply: %v", err)

--- a/cli/internal/core/threads.go
+++ b/cli/internal/core/threads.go
@@ -168,6 +168,8 @@ func setRoomEventsResultCursors(result *RoomEventsResult) {
 	}
 	result.StartCursorSeq = result.Events[0].Sequence
 	result.EndCursorSeq = result.Events[len(result.Events)-1].Sequence
+	result.StartCursor = RoomTimelineCursor{StreamSeq: result.StartCursorSeq}
+	result.EndCursor = RoomTimelineCursor{StreamSeq: result.EndCursorSeq}
 }
 
 // notifyThreadFollowers creates persistent notifications for all thread followers when someone replies.

--- a/cli/internal/graph/events.resolvers.go
+++ b/cli/internal/graph/events.resolvers.go
@@ -601,10 +601,11 @@ func (r *messagePostedEventResolver) ThreadReplies(ctx context.Context, obj *mod
 
 	fetchLimit := roomEventsLimit(limit)
 	if after != nil && *after != "" {
-		afterSeq, err := parseRoomEventCursor(*after)
+		afterCursor, err := parseRoomEventCursor(*after)
 		if err != nil {
 			return nil, fmt.Errorf("invalid after cursor: %w", err)
 		}
+		afterSeq := afterCursor.StreamSeq
 		result, err := r.core.GetThreadReplyEvents(ctx, kind, payload.RoomId, eventID, fetchLimit, nil, &afterSeq)
 		if err != nil {
 			return nil, err
@@ -614,10 +615,11 @@ func (r *messagePostedEventResolver) ThreadReplies(ctx context.Context, obj *mod
 
 	var beforeSeq *uint64
 	if before != nil && *before != "" {
-		seq, err := parseRoomEventCursor(*before)
+		beforeCursor, err := parseRoomEventCursor(*before)
 		if err != nil {
 			return nil, fmt.Errorf("invalid before cursor: %w", err)
 		}
+		seq := beforeCursor.StreamSeq
 		beforeSeq = &seq
 	}
 	result, err := r.core.GetThreadReplyEvents(ctx, kind, payload.RoomId, eventID, fetchLimit, beforeSeq, nil)

--- a/cli/internal/graph/room.resolvers.go
+++ b/cli/internal/graph/room.resolvers.go
@@ -219,24 +219,24 @@ func (r *roomResolver) Events(ctx context.Context, obj *corev1.Room, limit *int3
 
 	var result *core.RoomEventsResult
 	if after != nil && *after != "" {
-		afterSeq, err := parseRoomEventCursor(*after)
+		afterCursor, err := parseRoomEventCursor(*after)
 		if err != nil {
 			return nil, fmt.Errorf("invalid after cursor: %w", err)
 		}
-		result, err = r.core.GetRoomEventsAfter(ctx, core.KindOfRoom(obj), obj.Id, afterSeq, fetchLimit)
+		result, err = r.core.GetRoomEventsAfterCursor(ctx, core.KindOfRoom(obj), obj.Id, afterCursor, fetchLimit)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		var beforeSeq *uint64
+		var beforeCursor *core.RoomTimelineCursor
 		if before != nil && *before != "" {
-			seq, err := parseRoomEventCursor(*before)
+			cursor, err := parseRoomEventCursor(*before)
 			if err != nil {
 				return nil, fmt.Errorf("invalid before cursor: %w", err)
 			}
-			beforeSeq = &seq
+			beforeCursor = &cursor
 		}
-		result, err = r.core.GetRoomEvents(ctx, core.KindOfRoom(obj), obj.Id, fetchLimit, beforeSeq)
+		result, err = r.core.GetRoomEventsByCursor(ctx, core.KindOfRoom(obj), obj.Id, fetchLimit, beforeCursor)
 		if err != nil {
 			return nil, err
 		}
@@ -302,10 +302,10 @@ func (r *roomResolver) EventsAround(ctx context.Context, obj *corev1.Room, event
 		HasNewer:    result.HasNewer,
 	}
 	if len(result.Events) > 0 {
-		if start := formatRoomEventCursor(result.Events[0].Sequence); start != "" {
+		if start := formatRoomEventCursor(roomEventPositionCursor(result.Events[0])); start != "" {
 			out.StartCursor = &start
 		}
-		if end := formatRoomEventCursor(result.Events[len(result.Events)-1].Sequence); end != "" {
+		if end := formatRoomEventCursor(roomEventPositionCursor(result.Events[len(result.Events)-1])); end != "" {
 			out.EndCursor = &end
 		}
 	}

--- a/cli/internal/graph/room_events_cursor.go
+++ b/cli/internal/graph/room_events_cursor.go
@@ -10,8 +10,8 @@ import (
 )
 
 // buildRoomEventsConnection unwraps core.RoomEvent (which carries the
-// JetStream sequence) into delivered Event envelopes for the GraphQL
-// model and renders the cursor sequences as opaque strings.
+// timeline position) into delivered Event envelopes for the GraphQL
+// model and renders opaque cursors.
 func buildRoomEventsConnection(r *core.RoomEventsResult) *model.RoomEventsConnection {
 	events := make([]core.EventEnvelope, len(r.Events))
 	for i, e := range r.Events {
@@ -22,10 +22,10 @@ func buildRoomEventsConnection(r *core.RoomEventsResult) *model.RoomEventsConnec
 		HasOlder: r.HasOlder,
 		HasNewer: r.HasNewer,
 	}
-	if start := formatRoomEventCursor(r.StartCursorSeq); start != "" {
+	if start := formatRoomEventCursor(r.StartCursor); start != "" {
 		conn.StartCursor = &start
 	}
-	if end := formatRoomEventCursor(r.EndCursorSeq); end != "" {
+	if end := formatRoomEventCursor(r.EndCursor); end != "" {
 		conn.EndCursor = &end
 	}
 	return conn
@@ -33,44 +33,79 @@ func buildRoomEventsConnection(r *core.RoomEventsResult) *model.RoomEventsConnec
 
 // Room-event pagination cursors.
 //
-// Internally a cursor is a JetStream stream sequence (`uint64`). At the
-// GraphQL boundary it's an opaque string of the form `seq:<n>`. The
-// `seq:` prefix exists so a future migration to a richer cursor (e.g.,
-// time-based, or carrying a stream identifier) can be detected without
-// silently mis-parsing old cursors as the new format.
+// Internally, room-visible pagination uses (created_at, stream sequence) so
+// migrated historical events can be displayed chronologically even when their
+// EVT append order was grouped by migration step. At the GraphQL boundary the
+// rich cursor is `pos:<unix-nano>:<seq>`. Legacy `seq:<n>` cursors remain
+// accepted for old in-flight clients and thread pagination.
 //
 // Cursors are exposed via `RoomEventsConnection.startCursor` and
 // `endCursor` and consumed via the `before`/`after` query args. Clients
 // must treat them as opaque.
 
 const cursorSeqPrefix = "seq:"
+const cursorPosPrefix = "pos:"
 
-// formatRoomEventCursor renders a JetStream sequence as the opaque cursor
-// string clients see. Returns "" for sequence 0 so the GraphQL field can
-// be a nullable String — empty pages have no cursor.
-func formatRoomEventCursor(seq uint64) string {
-	if seq == 0 {
+// formatRoomEventCursor renders a room timeline position as the opaque cursor
+// string clients see. Returns "" for zero-value cursors so the GraphQL field
+// can be nullable — empty pages have no cursor.
+func formatRoomEventCursor(cursor core.RoomTimelineCursor) string {
+	if cursor.StreamSeq == 0 {
 		return ""
 	}
-	return cursorSeqPrefix + strconv.FormatUint(seq, 10)
+	if cursor.HasCreatedAt {
+		return cursorPosPrefix + strconv.FormatInt(cursor.CreatedAtUnixNano, 10) + ":" + strconv.FormatUint(cursor.StreamSeq, 10)
+	}
+	return cursorSeqPrefix + strconv.FormatUint(cursor.StreamSeq, 10)
 }
 
-// parseRoomEventCursor decodes an opaque cursor back to a sequence.
+// parseRoomEventCursor decodes an opaque cursor back to a timeline position.
 // Returns 0 with no error if the cursor is the empty string (treated as
 // "no cursor"). Any other malformed input is an error so a stale or
 // hand-edited cursor surfaces clearly rather than silently paging from
 // the start of the stream.
-func parseRoomEventCursor(cursor string) (uint64, error) {
+func parseRoomEventCursor(cursor string) (core.RoomTimelineCursor, error) {
 	if cursor == "" {
-		return 0, nil
+		return core.RoomTimelineCursor{}, nil
 	}
-	rest, ok := strings.CutPrefix(cursor, cursorSeqPrefix)
+	if rest, ok := strings.CutPrefix(cursor, cursorSeqPrefix); ok {
+		seq, err := strconv.ParseUint(rest, 10, 64)
+		if err != nil {
+			return core.RoomTimelineCursor{}, fmt.Errorf("invalid cursor sequence: %w", err)
+		}
+		return core.RoomTimelineCursor{StreamSeq: seq}, nil
+	}
+	rest, ok := strings.CutPrefix(cursor, cursorPosPrefix)
 	if !ok {
-		return 0, fmt.Errorf("invalid cursor format")
+		return core.RoomTimelineCursor{}, fmt.Errorf("invalid cursor format")
 	}
-	seq, err := strconv.ParseUint(rest, 10, 64)
+	timePart, seqPart, ok := strings.Cut(rest, ":")
+	if !ok {
+		return core.RoomTimelineCursor{}, fmt.Errorf("invalid cursor position")
+	}
+	nanos, err := strconv.ParseInt(timePart, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("invalid cursor sequence: %w", err)
+		return core.RoomTimelineCursor{}, fmt.Errorf("invalid cursor timestamp: %w", err)
 	}
-	return seq, nil
+	seq, err := strconv.ParseUint(seqPart, 10, 64)
+	if err != nil {
+		return core.RoomTimelineCursor{}, fmt.Errorf("invalid cursor sequence: %w", err)
+	}
+	return core.RoomTimelineCursor{
+		StreamSeq:         seq,
+		CreatedAtUnixNano: nanos,
+		HasCreatedAt:      true,
+	}, nil
+}
+
+func roomEventPositionCursor(event *core.RoomEvent) core.RoomTimelineCursor {
+	if event == nil {
+		return core.RoomTimelineCursor{}
+	}
+	cursor := core.RoomTimelineCursor{StreamSeq: event.Sequence}
+	if event.Event != nil && event.Event.GetCreatedAt() != nil {
+		cursor.CreatedAtUnixNano = event.Event.GetCreatedAt().AsTime().UnixNano()
+		cursor.HasCreatedAt = true
+	}
+	return cursor
 }

--- a/cli/internal/migrations/room_aggregate_es.go
+++ b/cli/internal/migrations/room_aggregate_es.go
@@ -18,7 +18,22 @@ import (
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
-type legacyRoomMembershipEvents map[string]map[string]*corev1.Event
+type legacyRoomMembershipEvents map[string][]legacyRoomMembershipEvent
+
+type legacyRoomMembershipEvent struct {
+	userID    string
+	createdAt time.Time
+	order     int
+	isJoin    bool
+	event     *corev1.Event
+}
+
+type roomMembershipMigrationEvent struct {
+	userID    string
+	createdAt time.Time
+	order     int
+	event     *corev1.Event
+}
 
 // MigrateRoomAggregateToES seeds the EVT stream from the existing
 // `room.{kind}.{roomID}` keys and both known room membership key shapes
@@ -64,11 +79,11 @@ func MigrateRoomAggregateToES(
 		return fmt.Errorf("load memberships: %w", err)
 	}
 
-	legacyJoins, err := loadLegacyRoomMembershipEvents(ctx, firstLegacyStream(legacyServerEvents), logger)
+	legacyMembershipEvents, err := loadLegacyRoomMembershipEvents(ctx, firstLegacyStream(legacyServerEvents), logger)
 	if err != nil {
 		return fmt.Errorf("load legacy room membership events: %w", err)
 	}
-	applyLegacyMembershipEvents(memberships, legacyJoins)
+	membershipEvents := buildRoomMembershipMigrationEvents(memberships, legacyMembershipEvents)
 
 	var migrated, skipped, archivedEvents, memberEvents, memberBackfillEvents int
 	for _, key := range roomKeys {
@@ -126,11 +141,11 @@ func MigrateRoomAggregateToES(
 			})
 		}
 
-		for _, m := range memberships[room.GetId()] {
-			joinedEvent := m.joinEvent(room.GetId())
+		for _, m := range membershipEvents[room.GetId()] {
+			event := proto.Clone(m.event).(*corev1.Event)
 			batch = append(batch, events.BatchEntry{
-				Subject: agg.SubjectFor(joinedEvent),
-				Event:   joinedEvent,
+				Subject: agg.SubjectFor(event),
+				Event:   event,
 			})
 		}
 
@@ -151,7 +166,7 @@ func MigrateRoomAggregateToES(
 		if room.GetArchived() {
 			archivedEvents++
 		}
-		memberEvents += len(memberships[room.GetId()])
+		memberEvents += len(membershipEvents[room.GetId()])
 	}
 
 	if migrated > 0 || skipped > 0 {
@@ -226,6 +241,16 @@ func (m membershipEntry) joinEvent(roomID string) *corev1.Event {
 	return stamp(&corev1.Event{Event: &corev1.Event_UserJoinedRoom{
 		UserJoinedRoom: &corev1.UserJoinedRoomEvent{RoomId: roomID},
 	}}, m.userID, timestamppb.New(m.createdAt))
+}
+
+func (m membershipEntry) migrationEvent(roomID string, order int) roomMembershipMigrationEvent {
+	event := m.joinEvent(roomID)
+	return roomMembershipMigrationEvent{
+		userID:    m.userID,
+		createdAt: event.GetCreatedAt().AsTime(),
+		order:     order,
+		event:     event,
+	}
 }
 
 // loadMembershipsByRoom reads every `room_membership.>` key and groups
@@ -351,21 +376,29 @@ func loadLegacyRoomMembershipEvents(
 	}
 
 	byRoom := make(legacyRoomMembershipEvents)
+	order := 0
 	for msg := range msgs.Messages() {
+		order++
 		var legacyEvent corev1.Event
 		if err := proto.Unmarshal(msg.Data(), &legacyEvent); err != nil {
 			logger.Warn("room_aggregate ES migration: skipping unmarshalable legacy room meta event", "subject", msg.Subject(), "error", err)
 			continue
 		}
 
-		join := legacyEvent.GetUserJoinedRoom()
-		if join == nil {
+		var roomID string
+		var isJoin bool
+		switch event := legacyEvent.GetEvent().(type) {
+		case *corev1.Event_UserJoinedRoom:
+			roomID = event.UserJoinedRoom.GetRoomId()
+			isJoin = true
+		case *corev1.Event_UserLeftRoom:
+			roomID = event.UserLeftRoom.GetRoomId()
+		default:
 			continue
 		}
-		roomID := join.GetRoomId()
 		userID := legacyEvent.GetActorId()
 		if roomID == "" || userID == "" {
-			logger.Warn("room_aggregate ES migration: skipping legacy room join with missing room or actor", "subject", msg.Subject(), "room_id", roomID, "actor_id", userID)
+			logger.Warn("room_aggregate ES migration: skipping legacy room membership event with missing room or actor", "subject", msg.Subject(), "room_id", roomID, "actor_id", userID)
 			continue
 		}
 
@@ -374,45 +407,101 @@ func loadLegacyRoomMembershipEvents(
 			legacyEvent.Id = newMigrationEventID()
 		}
 
-		roomJoins := byRoom[roomID]
-		if roomJoins == nil {
-			roomJoins = make(map[string]*corev1.Event)
-			byRoom[roomID] = roomJoins
-		}
-		if existing := roomJoins[userID]; existing != nil && legacyEvent.GetCreatedAt().AsTime().Before(existing.GetCreatedAt().AsTime()) {
-			continue
-		}
-		roomJoins[userID] = proto.Clone(&legacyEvent).(*corev1.Event)
+		byRoom[roomID] = append(byRoom[roomID], legacyRoomMembershipEvent{
+			userID:    userID,
+			createdAt: legacyEvent.GetCreatedAt().AsTime(),
+			order:     order,
+			isJoin:    isJoin,
+			event:     proto.Clone(&legacyEvent).(*corev1.Event),
+		})
 	}
 	return byRoom, nil
 }
 
-func applyLegacyMembershipEvents(
+func buildRoomMembershipMigrationEvents(
 	memberships map[string][]membershipEntry,
-	legacyJoins legacyRoomMembershipEvents,
-) {
-	for roomID, joins := range legacyJoins {
-		members := memberships[roomID]
-		seen := make(map[string]int, len(members))
-		for i, member := range members {
-			seen[member.userID] = i
-		}
-
-		for userID, event := range joins {
-			if idx, ok := seen[userID]; ok {
-				members[idx].createdAt = event.GetCreatedAt().AsTime()
-				members[idx].legacyEvent = event
-			}
-		}
-
-		sort.Slice(members, func(i, j int) bool {
-			if !members[i].createdAt.Equal(members[j].createdAt) {
-				return members[i].createdAt.Before(members[j].createdAt)
-			}
-			return members[i].userID < members[j].userID
-		})
-		memberships[roomID] = members
+	legacyEvents legacyRoomMembershipEvents,
+) map[string][]roomMembershipMigrationEvent {
+	byRoom := make(map[string][]roomMembershipMigrationEvent)
+	roomIDs := make(map[string]struct{}, len(memberships)+len(legacyEvents))
+	for roomID := range memberships {
+		roomIDs[roomID] = struct{}{}
 	}
+	for roomID := range legacyEvents {
+		roomIDs[roomID] = struct{}{}
+	}
+
+	for roomID := range roomIDs {
+		syntheticOrder := len(legacyEvents[roomID]) + 1
+		current := make(map[string]membershipEntry)
+		for _, member := range memberships[roomID] {
+			current[member.userID] = member
+		}
+
+		legacyByUser := make(map[string][]legacyRoomMembershipEvent)
+		for _, event := range legacyEvents[roomID] {
+			legacyByUser[event.userID] = append(legacyByUser[event.userID], event)
+		}
+
+		var roomEvents []roomMembershipMigrationEvent
+		for userID, userEvents := range legacyByUser {
+			userEvents = compactLegacyMembershipEvents(userEvents)
+			member, isCurrentMember := current[userID]
+			if len(userEvents) > 0 && userEvents[len(userEvents)-1].isJoin && !isCurrentMember {
+				userEvents = userEvents[:len(userEvents)-1]
+			}
+			for _, event := range userEvents {
+				roomEvents = append(roomEvents, roomMembershipMigrationEvent{
+					userID:    event.userID,
+					createdAt: event.createdAt,
+					order:     event.order,
+					event:     event.event,
+				})
+			}
+			if isCurrentMember && (len(userEvents) == 0 || !userEvents[len(userEvents)-1].isJoin) {
+				roomEvents = append(roomEvents, member.migrationEvent(roomID, syntheticOrder))
+			}
+			delete(current, userID)
+		}
+
+		for _, member := range memberships[roomID] {
+			if _, stillPending := current[member.userID]; !stillPending {
+				continue
+			}
+			roomEvents = append(roomEvents, member.migrationEvent(roomID, syntheticOrder))
+		}
+
+		sort.Slice(roomEvents, func(i, j int) bool {
+			if !roomEvents[i].createdAt.Equal(roomEvents[j].createdAt) {
+				return roomEvents[i].createdAt.Before(roomEvents[j].createdAt)
+			}
+			if roomEvents[i].order != roomEvents[j].order {
+				return roomEvents[i].order < roomEvents[j].order
+			}
+			return roomEvents[i].userID < roomEvents[j].userID
+		})
+		byRoom[roomID] = roomEvents
+	}
+	return byRoom
+}
+
+func compactLegacyMembershipEvents(events []legacyRoomMembershipEvent) []legacyRoomMembershipEvent {
+	sort.Slice(events, func(i, j int) bool {
+		if !events[i].createdAt.Equal(events[j].createdAt) {
+			return events[i].createdAt.Before(events[j].createdAt)
+		}
+		return events[i].order < events[j].order
+	})
+	compacted := make([]legacyRoomMembershipEvent, 0, len(events))
+	for _, event := range events {
+		last := len(compacted) - 1
+		if last >= 0 && compacted[last].isJoin == event.isJoin {
+			compacted[last] = event
+			continue
+		}
+		compacted = append(compacted, event)
+	}
+	return compacted
 }
 
 // listSortedKeys returns the union of keys matching the given filters,

--- a/cli/internal/migrations/room_aggregate_es_test.go
+++ b/cli/internal/migrations/room_aggregate_es_test.go
@@ -329,6 +329,65 @@ func TestMigrateRoomAggregateToES_PreservesLatestLegacyJoinForCurrentMembership(
 	require.Equal(t, "R1", ev.GetUserJoinedRoom().GetRoomId())
 }
 
+func TestMigrateRoomAggregateToES_PreservesLegacyJoinLeaveTimeline(t *testing.T) {
+	ctx, kv, stream, publisher, js := setupTestESWithJS(t)
+	legacyStream, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+		Name:     "SERVER_EVENTS_TEST",
+		Subjects: []string{"server.>"},
+		Storage:  jetstream.MemoryStorage,
+	})
+	require.NoError(t, err)
+
+	seedRoom(t, kv, "channel", &corev1.Room{
+		Id:   "R1",
+		Name: "general",
+		Kind: corev1.RoomKind_ROOM_KIND_CHANNEL,
+	})
+
+	joinedAt := time.Date(2026, 3, 17, 13, 38, 0, 0, time.UTC)
+	leftAt := time.Date(2026, 3, 18, 9, 0, 0, 0, time.UTC)
+	legacyEvents := []*corev1.Event{
+		{
+			Id:        "EjoinedThenLeft",
+			ActorId:   "U1",
+			CreatedAt: timestamppb.New(joinedAt),
+			Event: &corev1.Event_UserJoinedRoom{
+				UserJoinedRoom: &corev1.UserJoinedRoomEvent{RoomId: "R1"},
+			},
+		},
+		{
+			Id:        "EleftAfterJoin",
+			ActorId:   "U1",
+			CreatedAt: timestamppb.New(leftAt),
+			Event: &corev1.Event_UserLeftRoom{
+				UserLeftRoom: &corev1.UserLeftRoomEvent{RoomId: "R1"},
+			},
+		},
+	}
+	for _, legacyEvent := range legacyEvents {
+		data, err := proto.Marshal(legacyEvent)
+		require.NoError(t, err)
+		_, err = js.Publish(ctx, "server.room.channel.R1.meta", data)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, MigrateRoomAggregateToES(ctx, kv, publisher, testLogger(), legacyStream))
+
+	info, err := stream.Info(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, 3, info.State.Msgs)
+
+	for i, want := range legacyEvents {
+		msg, err := stream.GetMsg(ctx, uint64(i+2))
+		require.NoError(t, err)
+		var ev corev1.Event
+		require.NoError(t, proto.Unmarshal(msg.Data, &ev))
+		require.Equal(t, want.GetId(), ev.GetId())
+		require.Equal(t, want.GetActorId(), ev.GetActorId())
+		require.True(t, ev.GetCreatedAt().AsTime().Equal(want.GetCreatedAt().AsTime()))
+	}
+}
+
 func TestMigrateRoomAggregateToES_DoesNotResurrectLegacyJoinWithoutMembership(t *testing.T) {
 	ctx, kv, stream, publisher, js := setupTestESWithJS(t)
 	legacyStream, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -293,7 +293,7 @@ messages/threads, reactions, RBAC, and auth workflow audit facts.
 - `EVT` is the source of truth.
 - Boot importers seed `EVT` from pre-ES KV/`SERVER_EVENTS` data when those resources exist.
 - Reads come from in-memory projections rebuilt from `EVT`.
-- Room timeline reads use `RoomTimelineProjection`'s derived visible-room index for initial loads, forward/backward pagination, and around-message windows. The raw room log still preserves folded facts such as edits, retractions, reactions, assets, and thread replies; visible readers skip or fold those facts before serving the room timeline.
+- Room timeline reads use `RoomTimelineProjection`'s derived visible-room index for initial loads, forward/backward pagination, and around-message windows. The visible index is ordered by event `created_at` with EVT stream sequence as the stable tie-breaker, so migration-appended historical membership events interleave with imported messages by their original timeline time. The raw room log still preserves folded facts such as edits, retractions, reactions, assets, and thread replies; visible readers skip or fold those facts before serving the room timeline.
 - Writes append to `EVT` only; legacy KV/stream data is not maintained as a mirror.
 - Read-your-writes is provided by waiting for the local projector to reach the append sequence.
 
@@ -808,7 +808,7 @@ Messages are persisted as durable `EVT` facts. Public timeline facts (`MessagePo
 **Read Path:**
 
 - Room-level message history is served from `RoomTimelineProjection`, which keeps the raw room event log plus derived indexes for latest body state, hidden echoes, assets, and room-visible timeline entries.
-- Initial loads and cursor pagination walk the derived visible-room index so thread replies, edits, retractions, reactions, asset-processing facts, and directly hidden echoes do not count as separate room timeline rows.
+- Initial loads and cursor pagination walk the derived visible-room index so thread replies, edits, retractions, reactions, asset-processing facts, and directly hidden echoes do not count as separate room timeline rows. Room timeline cursors encode the visible position (`created_at` + EVT stream sequence); legacy sequence-only cursors are still accepted. Thread reply cursors remain sequence-based.
 - `eventsAround` uses the same visible-room index to center jump-to-message windows on the target's visible position.
 - Thread panes read the root message from `RoomTimelineProjection` and cursor-paginated replies from `ThreadProjection`.
 


### PR DESCRIPTION
- Orders room-visible timeline entries by event `created_at` plus EVT stream sequence so migrated join/leave history interleaves correctly with imported messages.
- Preserves legacy room membership join/leave history during ES import without resurrecting users who are no longer room members.
- Adds regression coverage for migrated membership ordering and updates the architecture inventory with the new room timeline cursor behavior.

Tests:
- `mise x -- go test ./internal/core ./internal/migrations ./internal/graph -timeout 90s`
