### PR TITLE
fix: emit structured logs for Loki

### DIFF
--- a/cli/chatto.toml
+++ b/cli/chatto.toml
@@ -2,6 +2,7 @@
 
 [general]
 log_level = 'debug'
+log_format = 'text'
 
 [webserver]
 url = 'http://localhost:5173'

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -72,7 +72,8 @@ var initCmd = &cobra.Command{
 		unlimited := -1
 		cfg := config.ChattoConfig{
 			General: config.GeneralConfig{
-				LogLevel: "debug",
+				LogLevel:  "debug",
+				LogFormat: "auto",
 			},
 			Auth: config.AuthConfig{
 				DirectRegistration: &directRegistration,

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nats-io/nats.go"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/term"
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/core"
 	"hmans.de/chatto/internal/embedded_nats"
@@ -70,8 +71,10 @@ func runServer(configPath string) {
 		log.Fatal("Failed to read configuration", "error", err)
 	}
 
-	setLogLevel(cfg.General.LogLevel)
-	printBanner()
+	configureLogging(cfg.General)
+	if shouldPrintBanner(cfg.General.LogFormat, isLogOutputTerminal()) {
+		printBanner()
+	}
 
 	exitCode := 0
 	defer func() {
@@ -355,6 +358,44 @@ func printBanner() {
 	for line := range strings.SplitSeq(banner, "\n") {
 		log.Info(line)
 	}
+}
+
+func configureLogging(cfg config.GeneralConfig) {
+	setLogFormat(cfg.LogFormat, isLogOutputTerminal())
+	setLogLevel(cfg.LogLevel)
+}
+
+func setLogFormat(format string, outputIsTerminal bool) {
+	switch effectiveLogFormat(format, outputIsTerminal) {
+	case "json":
+		log.SetFormatter(log.JSONFormatter)
+	case "logfmt":
+		log.SetFormatter(log.LogfmtFormatter)
+	default:
+		log.SetFormatter(log.TextFormatter)
+	}
+}
+
+func effectiveLogFormat(format string, outputIsTerminal bool) string {
+	switch strings.ToLower(format) {
+	case "", "auto":
+		if outputIsTerminal {
+			return "text"
+		}
+		return "json"
+	case "json", "logfmt", "text":
+		return strings.ToLower(format)
+	default:
+		return "text"
+	}
+}
+
+func shouldPrintBanner(format string, outputIsTerminal bool) bool {
+	return effectiveLogFormat(format, outputIsTerminal) == "text"
+}
+
+func isLogOutputTerminal() bool {
+	return term.IsTerminal(int(os.Stderr.Fd()))
 }
 
 func setLogLevel(level string) {

--- a/cli/cmd/run_test.go
+++ b/cli/cmd/run_test.go
@@ -8,6 +8,44 @@ import (
 	"hmans.de/chatto/internal/testutil"
 )
 
+func TestEffectiveLogFormat(t *testing.T) {
+	tests := []struct {
+		name             string
+		configuredFormat string
+		outputIsTerminal bool
+		want             string
+	}{
+		{name: "auto uses text on terminal", configuredFormat: "auto", outputIsTerminal: true, want: "text"},
+		{name: "auto uses json off terminal", configuredFormat: "auto", outputIsTerminal: false, want: "json"},
+		{name: "empty defaults to auto text on terminal", configuredFormat: "", outputIsTerminal: true, want: "text"},
+		{name: "empty defaults to auto json off terminal", configuredFormat: "", outputIsTerminal: false, want: "json"},
+		{name: "explicit text", configuredFormat: "text", outputIsTerminal: false, want: "text"},
+		{name: "explicit json", configuredFormat: "json", outputIsTerminal: true, want: "json"},
+		{name: "explicit logfmt", configuredFormat: "logfmt", outputIsTerminal: true, want: "logfmt"},
+		{name: "case insensitive", configuredFormat: "JSON", outputIsTerminal: false, want: "json"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := effectiveLogFormat(tt.configuredFormat, tt.outputIsTerminal); got != tt.want {
+				t.Fatalf("effectiveLogFormat() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldPrintBannerOnlyForTextLogs(t *testing.T) {
+	if !shouldPrintBanner("text", false) {
+		t.Fatal("expected text logs to print banner")
+	}
+	if shouldPrintBanner("json", true) {
+		t.Fatal("expected json logs to suppress banner")
+	}
+	if shouldPrintBanner("auto", false) {
+		t.Fatal("expected auto logs off terminal to suppress banner")
+	}
+}
+
 func TestCloseNATSConnectionWaitsForDrainToComplete(t *testing.T) {
 	ns, _ := testutil.StartNATS(t)
 

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -34,7 +34,8 @@ func (d Duration) Duration() time.Duration {
 }
 
 type GeneralConfig struct {
-	LogLevel string `toml:"log_level" env:"CHATTO_LOG_LEVEL" comment:"Log level. Possible values: debug, info, warn, error."`
+	LogLevel  string `toml:"log_level" env:"CHATTO_LOG_LEVEL" comment:"Log level. Possible values: debug, info, warn, error."`
+	LogFormat string `toml:"log_format,commented" env:"CHATTO_LOG_FORMAT" comment:"Log output format. Possible values: auto, text, json, logfmt. Default: auto (text on terminals, JSON otherwise)."`
 }
 
 // TLSConfig contains settings for automatic TLS via Let's Encrypt.
@@ -559,6 +560,12 @@ func (c *ChattoConfig) Validate() error {
 		validLevels := map[string]bool{"debug": true, "info": true, "warn": true, "error": true}
 		if !validLevels[strings.ToLower(c.General.LogLevel)] {
 			errs = append(errs, "general.log_level must be one of: debug, info, warn, error")
+		}
+	}
+	if c.General.LogFormat != "" {
+		validFormats := map[string]bool{"auto": true, "text": true, "json": true, "logfmt": true}
+		if !validFormats[strings.ToLower(c.General.LogFormat)] {
+			errs = append(errs, "general.log_format must be one of: auto, text, json, logfmt")
 		}
 	}
 

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -126,6 +126,53 @@ signing_secret = "file-assets-secret"
 	}
 }
 
+func TestReadConfig_GeneralLogFormatFromTOMLAndEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(originalDir) })
+
+	configContent := `
+[general]
+log_format = "text"
+
+[webserver]
+port = 5000
+cookie_signing_secret = "file-cookie-secret"
+
+[core]
+secret_key = "file-core-secret"
+
+[core.assets]
+signing_secret = "file-assets-secret"
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "chatto.toml"), []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	cfg, err := ReadConfig("")
+	if err != nil {
+		t.Fatalf("ReadConfig() failed: %v", err)
+	}
+	if cfg.General.LogFormat != "text" {
+		t.Fatalf("expected TOML log_format %q, got %q", "text", cfg.General.LogFormat)
+	}
+
+	t.Setenv("CHATTO_LOG_FORMAT", "json")
+	cfg, err = ReadConfig("")
+	if err != nil {
+		t.Fatalf("ReadConfig() with env override failed: %v", err)
+	}
+	if cfg.General.LogFormat != "json" {
+		t.Fatalf("expected env log_format %q, got %q", "json", cfg.General.LogFormat)
+	}
+}
+
 func TestReadConfig_OAuthRedirectOriginsFromTOMLAndEnv(t *testing.T) {
 	tmpDir := t.TempDir()
 	originalDir, err := os.Getwd()
@@ -439,6 +486,33 @@ func TestChattoConfig_Validate_RequiredSecrets(t *testing.T) {
 				t.Fatalf("Validate() error = %v, want to contain %q", err, tt.errorMsg)
 			}
 		})
+	}
+}
+
+func TestChattoConfig_Validate_LogFormat(t *testing.T) {
+	base := ChattoConfig{
+		Webserver: WebserverConfig{Port: 4000, CookieSigningSecret: "web-secret"},
+		Core: CoreConfig{
+			SecretKey: "core-secret",
+			Assets:    AssetsConfig{SigningSecret: "asset-secret"},
+		},
+	}
+
+	for _, format := range []string{"", "auto", "text", "json", "logfmt", "JSON"} {
+		t.Run("valid_"+format, func(t *testing.T) {
+			cfg := base
+			cfg.General.LogFormat = format
+			if err := cfg.Validate(); err != nil {
+				t.Fatalf("Validate() unexpected error = %v", err)
+			}
+		})
+	}
+
+	cfg := base
+	cfg.General.LogFormat = "pretty"
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "general.log_format must be one of: auto, text, json, logfmt") {
+		t.Fatalf("Validate() error = %v, want invalid log_format error", err)
 	}
 }
 

--- a/cli/internal/http_server/request_logger_test.go
+++ b/cli/internal/http_server/request_logger_test.go
@@ -1,0 +1,65 @@
+package http_server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/charmbracelet/log"
+	"github.com/gin-gonic/gin"
+)
+
+func TestRequestLoggerUsesConfiguredFormatter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var buf bytes.Buffer
+	logger := log.New(&buf)
+	logger.SetFormatter(log.JSONFormatter)
+	logger.SetPrefix("server.HTTP")
+
+	router := gin.New()
+	router.Use(requestLogger(logger))
+	router.GET("/missing", func(c *gin.Context) {
+		c.String(http.StatusNotFound, "missing")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/missing?asset=avatar", nil)
+	req.Header.Set("User-Agent", "chatto-test")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+
+	var line map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &line); err != nil {
+		t.Fatalf("request log should be JSON, got %q: %v", buf.String(), err)
+	}
+
+	assertLogField(t, line, "level", "warn")
+	assertLogField(t, line, "prefix", "server.HTTP")
+	assertLogField(t, line, "msg", "HTTP request")
+	assertLogField(t, line, "method", http.MethodGet)
+	assertLogField(t, line, "path", "/missing")
+	assertLogField(t, line, "query", "asset=avatar")
+	assertLogField(t, line, "user_agent", "chatto-test")
+
+	if got := line["status"]; got != float64(http.StatusNotFound) {
+		t.Fatalf("status field = %v, want %d", got, http.StatusNotFound)
+	}
+	if _, ok := line["latency"].(string); !ok {
+		t.Fatalf("latency field = %T, want string", line["latency"])
+	}
+}
+
+func assertLogField(t *testing.T, line map[string]any, key string, want string) {
+	t.Helper()
+
+	if got := line[key]; got != want {
+		t.Fatalf("%s field = %v, want %q", key, got, want)
+	}
+}

--- a/cli/internal/http_server/server.go
+++ b/cli/internal/http_server/server.go
@@ -70,7 +70,7 @@ func NewHTTPServer(cfg HTTPServerConfig) (*HTTPServer, error) {
 	router := gin.New()
 	router.Use(gin.Recovery())
 	if cfg.Config.Webserver.RequestLoggingEnabled() {
-		router.Use(gin.Logger())
+		router.Use(requestLogger(logger))
 	}
 
 	s := &HTTPServer{
@@ -99,6 +99,42 @@ func newHTTPServer(addr string, handler http.Handler) *http.Server {
 		Handler:           handler,
 		ReadHeaderTimeout: httpServerReadHeaderTimeout,
 		IdleTimeout:       httpServerIdleTimeout,
+	}
+}
+
+func requestLogger(logger *log.Logger) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+		path := c.Request.URL.Path
+		query := c.Request.URL.RawQuery
+
+		c.Next()
+
+		status := c.Writer.Status()
+		fields := []any{
+			"status", status,
+			"method", c.Request.Method,
+			"path", path,
+			"latency", time.Since(start).String(),
+			"client_ip", c.ClientIP(),
+			"user_agent", c.Request.UserAgent(),
+			"bytes", c.Writer.Size(),
+		}
+		if query != "" {
+			fields = append(fields, "query", query)
+		}
+		if len(c.Errors) > 0 {
+			fields = append(fields, "errors", c.Errors.ByType(gin.ErrorTypePrivate).String())
+		}
+
+		switch {
+		case status >= http.StatusInternalServerError:
+			logger.Error("HTTP request", fields...)
+		case status >= http.StatusBadRequest:
+			logger.Warn("HTTP request", fields...)
+		default:
+			logger.Info("HTTP request", fields...)
+		}
 	}
 }
 

--- a/docs-website/src/content/docs/guides/dockercompose.mdx
+++ b/docs-website/src/content/docs/guides/dockercompose.mdx
@@ -172,6 +172,7 @@ By the end of this section, your project directory will look like this:
    CHATTO_CORE_SECRET_KEY=<generate-me>
    CHATTO_CORE_ASSETS_SIGNING_SECRET=<generate-me>
    CHATTO_LOG_LEVEL=info
+   CHATTO_LOG_FORMAT=json
 
    # LiveKit
    CHATTO_LIVEKIT_ENABLED=true

--- a/docs-website/src/content/docs/reference/environment-variables.mdx
+++ b/docs-website/src/content/docs/reference/environment-variables.mdx
@@ -13,6 +13,10 @@ Every `chatto.toml` setting can be overridden with an environment variable. The 
   Log level. Values: `debug`, `info`, `warn`, `error`.
 </EnvVar>
 
+<EnvVar name="CHATTO_LOG_FORMAT" toml="general.log_format" default="auto">
+  Log output format. Values: `auto`, `text`, `json`, `logfmt`. `auto` uses text when Chatto is attached to a terminal and JSON otherwise. Use `json` for Loki/Grafana ingestion so each log line includes a structured `level` field.
+</EnvVar>
+
 ## Web Server
 
 <EnvVar name="CHATTO_WEBSERVER_URL" toml="webserver.url" required>

--- a/examples/dockercompose/.env.example
+++ b/examples/dockercompose/.env.example
@@ -18,6 +18,7 @@ CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET=your-cookie-secret-here
 CHATTO_CORE_SECRET_KEY=your-core-secret-here
 CHATTO_CORE_ASSETS_SIGNING_SECRET=your-assets-secret-here
 CHATTO_LOG_LEVEL=info
+CHATTO_LOG_FORMAT=json
 
 # LiveKit (voice calls)
 CHATTO_LIVEKIT_ENABLED=true

--- a/examples/k8s/secrets.yaml
+++ b/examples/k8s/secrets.yaml
@@ -29,6 +29,7 @@ stringData:
   CHATTO_CORE_SECRET_KEY: "your-core-secret-here"
   CHATTO_CORE_ASSETS_SIGNING_SECRET: "your-assets-secret-here"
   CHATTO_LOG_LEVEL: "info"
+  CHATTO_LOG_FORMAT: "json"
 
   # SMTP configuration (optional - uncomment to enable)
   # CHATTO_SMTP_ENABLED: "true"


### PR DESCRIPTION
## Changes
- Add `CHATTO_LOG_FORMAT` / `general.log_format` with `auto`, `text`, `json`, and `logfmt` options.
- Default `auto` logging to JSON for non-TTY output so Loki/Grafana can read a structured `level` field.
- Route optional HTTP request logging through the configured logger instead of Gin's plaintext logger.
- Document JSON logging for Docker Compose and Kubernetes deployments.

## Tests
- `go test ./cmd ./internal/config -count=1`
- `go test ./internal/http_server -run TestRequestLoggerUsesConfiguredFormatter -count=1`
