### PR TITLE
ci: speed up validation and releases

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@
 !frontend/.npmrc
 !frontend/src/
 !frontend/static/
+!frontend/build/
 !frontend/svelte.config.js
 !frontend/tsconfig.json
 !frontend/vite.config.ts

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,6 +5,14 @@ inputs:
     description: "Install ffmpeg (only needed for E2E tests with video processing)"
     required: false
     default: "false"
+  install-cli-deps:
+    description: "Install Go/CLI dependencies"
+    required: false
+    default: "true"
+  install-frontend-deps:
+    description: "Install frontend dependencies"
+    required: false
+    default: "true"
 runs:
   using: "composite"
   steps:
@@ -39,9 +47,11 @@ runs:
         sudo apt-get install -y -qq ffmpeg
 
     - name: Install CLI dependencies
+      if: inputs.install-cli-deps == 'true'
       shell: bash
       run: mise deps-cli
 
     - name: Install Frontend dependencies
+      if: inputs.install-frontend-deps == 'true'
       shell: bash
       run: mise deps-frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,13 @@ jobs:
       - name: Run Go tests
         run: cd cli && go test -tags test_endpoints ./...
 
-  test-e2e-build:
+  test-e2e:
     runs-on: ubicloud-standard-4
+    name: test-e2e (${{ matrix.shard }}/4)
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -70,25 +75,34 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('frontend/pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Install Playwright dependencies
+        run: cd frontend && pnpm exec playwright install chromium --with-deps
+        timeout-minutes: 5
+
       - name: Build E2E server
         run: mise build-e2e-server
 
-      - name: Upload E2E server
-        uses: actions/upload-artifact@v7
-        with:
-          name: chatto-e2e-server
-          path: frontend/e2e/fixtures/bin/chatto
-          if-no-files-found: error
-          retention-days: 1
+      - name: Run E2E tests
+        run: cd frontend && pnpm exec playwright test --grep-invert @ffmpeg --shard=${{ matrix.shard }}/4
 
-  test-e2e:
-    needs: test-e2e-build
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v7
+        if: ${{ failure() }}
+        with:
+          name: playwright-report-${{ matrix.shard }}-of-4
+          path: frontend/playwright-report/
+          retention-days: 14
+
+  test-e2e-media:
     runs-on: ubicloud-standard-4
-    name: test-e2e (${{ matrix.shard }}/4)
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2, 3, 4]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -110,24 +124,16 @@ jobs:
         run: cd frontend && pnpm exec playwright install chromium --with-deps
         timeout-minutes: 5
 
-      - name: Download E2E server
-        uses: actions/download-artifact@v7
-        with:
-          name: chatto-e2e-server
-          path: frontend/e2e/fixtures/bin
+      - name: Build E2E server
+        run: mise build-e2e-server
 
-      - name: Prepare E2E server
-        run: chmod +x frontend/e2e/fixtures/bin/chatto
-
-      - name: Run E2E tests
-        run: cd frontend && pnpm exec playwright test --shard=${{ matrix.shard }}/4
-        env:
-          CHATTO_E2E_SKIP_SERVER_BUILD: "1"
+      - name: Run media E2E tests
+        run: cd frontend && pnpm exec playwright test --grep @ffmpeg
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7
         if: ${{ failure() }}
         with:
-          name: playwright-report-${{ matrix.shard }}-of-4
+          name: playwright-report-media
           path: frontend/playwright-report/
           retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,15 @@ name: ci
 on:
   push:
     branches: [main]
-    tags: ["*"]
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
-  contents: write
-  packages: write
-  id-token: write
+  contents: read
 
 jobs:
   test-frontend-unit:
@@ -21,6 +22,8 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/setup
+        with:
+          install-cli-deps: "false"
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5
@@ -60,6 +63,11 @@ jobs:
 
   test-e2e:
     runs-on: ubicloud-standard-4
+    name: test-e2e (${{ matrix.shard }}/4)
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -85,80 +93,12 @@ jobs:
         run: mise build-e2e-server
 
       - name: Run E2E tests
-        run: cd frontend && pnpm exec playwright test
+        run: cd frontend && pnpm exec playwright test --shard=${{ matrix.shard }}/4
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7
         if: ${{ failure() }}
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.shard }}-of-4
           path: frontend/playwright-report/
           retention-days: 14
-
-  release:
-    needs: [test-cli, test-e2e, test-frontend-unit]
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubicloud-standard-4
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          # needed by GoReleaser to create changelog
-          fetch-depth: 0
-
-      - name: Setup environment
-        uses: ./.github/actions/setup
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          distribution: goreleaser
-          version: "~> v2"
-          args: release --clean
-        env:
-          # Use a PAT so the release is authored by a user account rather
-          # than github-actions[bot]. Bot-authored releases don't get
-          # GitHub's autolink rendering for commit SHAs and #NNN PR refs.
-          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
-
-      - name: Extract version from tag
-        id: version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
-
-      - name: Build frontend Docker tags
-        id: frontend_tags
-        run: |
-          {
-            echo "tags<<EOF"
-            echo "ghcr.io/chattocorp/chatto-client:${{ steps.version.outputs.version }}"
-            if [[ "${{ steps.version.outputs.version }}" == *-* ]]; then
-              echo "ghcr.io/chattocorp/chatto-client:next"
-            else
-              echo "ghcr.io/chattocorp/chatto-client:latest"
-            fi
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Build and push frontend Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile.frontend
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.frontend_tags.outputs.tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,28 @@ jobs:
       - name: Run Go tests
         run: cd cli && go test -tags test_endpoints ./...
 
+  test-e2e-build:
+    runs-on: ubicloud-standard-4
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup environment
+        uses: ./.github/actions/setup
+
+      - name: Build E2E server
+        run: mise build-e2e-server
+
+      - name: Upload E2E server
+        uses: actions/upload-artifact@v7
+        with:
+          name: chatto-e2e-server
+          path: frontend/e2e/fixtures/bin/chatto
+          if-no-files-found: error
+          retention-days: 1
+
   test-e2e:
+    needs: test-e2e-build
     runs-on: ubicloud-standard-4
     name: test-e2e (${{ matrix.shard }}/4)
     strategy:
@@ -89,11 +110,19 @@ jobs:
         run: cd frontend && pnpm exec playwright install chromium --with-deps
         timeout-minutes: 5
 
-      - name: Build E2E server
-        run: mise build-e2e-server
+      - name: Download E2E server
+        uses: actions/download-artifact@v7
+        with:
+          name: chatto-e2e-server
+          path: frontend/e2e/fixtures/bin
+
+      - name: Prepare E2E server
+        run: chmod +x frontend/e2e/fixtures/bin/chatto
 
       - name: Run E2E tests
         run: cd frontend && pnpm exec playwright test --shard=${{ matrix.shard }}/4
+        env:
+          CHATTO_E2E_SKIP_SERVER_BUILD: "1"
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,126 @@
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubicloud-standard-4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fetch main
+        run: git fetch origin +refs/heads/main:refs/remotes/origin/main
+
+      - name: Verify release-please tag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tag_commit="$(git rev-parse "${GITHUB_REF_NAME}^{commit}")"
+
+          if ! git merge-base --is-ancestor "$tag_commit" origin/main; then
+            echo "::error::Refusing to release ${GITHUB_REF_NAME}: tagged commit is not reachable from origin/main."
+            exit 1
+          fi
+
+          parent_count="$(git rev-list --parents -n 1 "$tag_commit" | awk '{ print NF - 1 }')"
+          if [[ "$parent_count" -lt 1 ]]; then
+            echo "::error::Refusing to release ${GITHUB_REF_NAME}: tagged commit has no parent to compare against."
+            exit 1
+          fi
+
+          disallowed=()
+          while IFS= read -r path; do
+            case "$path" in
+              .release-please-config.json|\
+              .release-please-config-prerelease.json|\
+              .release-please-manifest.json|\
+              .release-please-manifest-prerelease.json|\
+              CHANGELOG.md|\
+              cli/version.go|\
+              frontend/package.json)
+                ;;
+              *)
+                disallowed+=("$path")
+                ;;
+            esac
+          done < <(git diff --name-only "${tag_commit}^" "$tag_commit")
+
+          if (( ${#disallowed[@]} > 0 )); then
+            echo "::error::Refusing to release ${GITHUB_REF_NAME}: tagged commit contains non-release-please files."
+            printf 'Disallowed file: %s\n' "${disallowed[@]}"
+            exit 1
+          fi
+
+      - name: Setup environment
+        uses: ./.github/actions/setup
+
+      - name: Build frontend once
+        run: mise build-frontend
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          # Use a PAT so the release is authored by a user account rather
+          # than github-actions[bot]. Bot-authored releases don't get
+          # GitHub's autolink rendering for commit SHAs and #NNN PR refs.
+          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build frontend Docker tags
+        id: frontend_tags
+        shell: bash
+        run: |
+          {
+            echo "tags<<EOF"
+            echo "ghcr.io/chattocorp/chatto-client:${{ steps.version.outputs.version }}"
+            if [[ "${{ steps.version.outputs.version }}" == *-* ]]; then
+              echo "ghcr.io/chattocorp/chatto-client:next"
+            else
+              echo "ghcr.io/chattocorp/chatto-client:latest"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push frontend Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.frontend.prebuilt
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.frontend_tags.outputs.tags }}
+          cache-from: type=gha,scope=chatto-client
+          cache-to: type=gha,scope=chatto-client,mode=max

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,10 +1,6 @@
 version: 2
 project_name: chatto
 
-before:
-  hooks:
-    - mise build-frontend
-
 builds:
   - env:
       - CGO_ENABLED=0
@@ -46,6 +42,8 @@ dockers:
     build_flag_templates:
       - "--pull"
       - "--platform=linux/amd64"
+      - "--cache-from=type=gha,scope=chatto-backend-amd64"
+      - "--cache-to=type=gha,scope=chatto-backend-amd64,mode=max"
       - "--label=org.opencontainers.image.source=https://github.com/chattocorp/chatto"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.created={{ .Date }}"
@@ -60,6 +58,8 @@ dockers:
     build_flag_templates:
       - "--pull"
       - "--platform=linux/arm64"
+      - "--cache-from=type=gha,scope=chatto-backend-arm64"
+      - "--cache-to=type=gha,scope=chatto-backend-arm64,mode=max"
       - "--label=org.opencontainers.image.source=https://github.com/chattocorp/chatto"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.created={{ .Date }}"

--- a/Dockerfile.frontend.prebuilt
+++ b/Dockerfile.frontend.prebuilt
@@ -1,0 +1,8 @@
+# Release-only frontend image. The workflow builds frontend/build once before
+# invoking Docker, then this image only packages those static files.
+FROM fholzer/nginx-brotli:v1.28.0
+
+COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
+COPY frontend/build /usr/share/nginx/html
+
+EXPOSE 80

--- a/frontend/e2e/gif-to-video.test.ts
+++ b/frontend/e2e/gif-to-video.test.ts
@@ -8,7 +8,7 @@ import * as routes from './routes';
 // Video processing (ffmpeg transcode) can take up to 60s for small test files on CI.
 const VIDEO_PROCESSING_TIMEOUT = 60_000;
 
-test.describe('animated GIF to video conversion', () => {
+test.describe('animated GIF to video conversion @ffmpeg', () => {
 	test.setTimeout(120_000);
 
 	test('animated GIF is converted to looping video player', async ({

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -1,23 +1,12 @@
 import { execSync } from 'child_process';
-import { existsSync } from 'fs';
 
 /**
- * Global setup runs once before all tests. Local runs invoke
- * `mise build-e2e-server` so iterating on backend + e2e together doesn't
- * silently use a stale binary. CI shards can opt out after downloading the
- * binary built by the dedicated E2E build job.
+ * Global setup runs once before all tests. Always invokes
+ * `mise build-e2e-server` — mise's source/output tracking turns this
+ * into a no-op when nothing has changed and a real rebuild when backend
+ * code has, so iterating on backend + e2e together doesn't silently use
+ * a stale binary.
  */
 export default function globalSetup() {
-  if (process.env.CHATTO_E2E_SKIP_SERVER_BUILD === '1') {
-    const binaryPath = 'e2e/fixtures/bin/chatto';
-    if (!existsSync(binaryPath)) {
-      throw new Error(
-        `CHATTO_E2E_SKIP_SERVER_BUILD=1 but ${binaryPath} is missing. ` +
-          'Download the E2E server artifact before running Playwright.'
-      );
-    }
-    return;
-  }
-
   execSync('mise build-e2e-server', { stdio: 'inherit', cwd: process.cwd() });
 }

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -1,12 +1,23 @@
 import { execSync } from 'child_process';
+import { existsSync } from 'fs';
 
 /**
- * Global setup runs once before all tests. Always invokes
- * `mise build-e2e-server` — mise's source/output tracking turns this
- * into a no-op when nothing has changed and a real rebuild when backend
- * code has, so iterating on backend + e2e together doesn't silently use
- * a stale binary.
+ * Global setup runs once before all tests. Local runs invoke
+ * `mise build-e2e-server` so iterating on backend + e2e together doesn't
+ * silently use a stale binary. CI shards can opt out after downloading the
+ * binary built by the dedicated E2E build job.
  */
 export default function globalSetup() {
+  if (process.env.CHATTO_E2E_SKIP_SERVER_BUILD === '1') {
+    const binaryPath = 'e2e/fixtures/bin/chatto';
+    if (!existsSync(binaryPath)) {
+      throw new Error(
+        `CHATTO_E2E_SKIP_SERVER_BUILD=1 but ${binaryPath} is missing. ` +
+          'Download the E2E server artifact before running Playwright.'
+      );
+    }
+    return;
+  }
+
   execSync('mise build-e2e-server', { stdio: 'inherit', cwd: process.cwd() });
 }

--- a/frontend/e2e/video-player.test.ts
+++ b/frontend/e2e/video-player.test.ts
@@ -8,7 +8,7 @@ import { TIMEOUTS } from './constants';
 // Video processing (ffmpeg transcode) can take up to 45s for small test videos.
 const VIDEO_PROCESSING_TIMEOUT = 45_000;
 
-test.describe('video player', () => {
+test.describe('video player @ffmpeg', () => {
 	test.setTimeout(90_000);
 
 	test('uploaded video renders Vidstack player without settings menu', async ({


### PR DESCRIPTION
## Summary

- Shard Playwright E2E validation across four CI jobs and cancel superseded PR runs.
- Keep ffmpeg-dependent media E2E coverage in a dedicated job so normal shards avoid apt install overhead.
- Move tag publishing out of `ci.yml` into a tag-only release workflow guarded to release-please metadata commits.
- Build the frontend once for releases, package the client image from prebuilt static files, and add BuildKit GHA caches for release images.
- Add setup-action toggles so jobs can skip unnecessary dependency installs.

## Verification

- Loaded workflow/action/GoReleaser YAML, checked the Playwright `@ffmpeg` split with `--list`, and ran `goreleaser check`, `mise build-frontend`, `pnpm check`, a prebuilt frontend Docker build, a non-publishing GoReleaser snapshot, and the release guard against `v0.1.0-beta.4`.
