### PR TITLE
test: speed up isolated e2e setup

### DIFF
--- a/cli/internal/http_server/test_endpoints.go
+++ b/cli/internal/http_server/test_endpoints.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/log"
 	"github.com/gin-gonic/gin"
 	"hmans.de/chatto/internal/config"
+	"hmans.de/chatto/internal/core"
 	"hmans.de/chatto/internal/email"
 )
 
@@ -29,6 +30,7 @@ func createMailer(_ config.SMTPConfig) (*email.MockSender, email.Sender) {
 //   - DELETE /auth/test/emails - Clear all captured emails
 //   - POST /auth/test/verify-email - Directly verify a user's email
 //   - POST /auth/test/create-user - Directly create a user without registration flow
+//   - POST /auth/test/create-user-session - Create, verify, join defaults, and log in a test user
 //   - POST /auth/test/create-registration-code - Create a registration code without email delivery
 //   - POST /auth/test/oauth-callback - Simulate OAuth callback
 //   - POST /auth/test/oauth-authorize - Mint an OAuth authorization code without UI interaction
@@ -123,6 +125,82 @@ func registerTestEndpoints(auth *gin.RouterGroup, s *HTTPServer) {
 			"id":          user.Id,
 			"login":       user.Login,
 			"displayName": user.DisplayName,
+		})
+	})
+
+	// Test-only endpoint to create a ready-to-use E2E user in one round trip.
+	// This keeps ordinary browser tests isolated while avoiding the repeated
+	// create -> verify -> login -> list rooms -> join rooms setup sequence.
+	auth.POST("test/create-user-session", func(c *gin.Context) {
+		var req struct {
+			Login            string `json:"login" binding:"required"`
+			DisplayName      string `json:"displayName"`
+			Password         string `json:"password" binding:"required"`
+			Email            string `json:"email" binding:"required,email"`
+			JoinDefaultRooms *bool  `json:"joinDefaultRooms"`
+		}
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		if !isValidLogin(req.Login) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Login must be 2-32 characters, using only letters, numbers, dots, dashes, or underscores (no consecutive periods)"})
+			return
+		}
+
+		displayName := req.DisplayName
+		if displayName == "" {
+			displayName = req.Login
+		}
+
+		ctx := c.Request.Context()
+		user, err := s.core.CreateVerifiedUser(ctx, core.SystemActorID, req.Login, displayName, req.Password, req.Email)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		joinDefaultRooms := true
+		if req.JoinDefaultRooms != nil {
+			joinDefaultRooms = *req.JoinDefaultRooms
+		}
+		if joinDefaultRooms {
+			rooms, err := s.core.ListRooms(ctx, core.KindChannel)
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				return
+			}
+			defaults := map[string]struct{}{
+				"announcements": {},
+				"general":       {},
+			}
+			for _, room := range rooms {
+				if _, ok := defaults[room.Name]; !ok {
+					continue
+				}
+				if _, err := s.core.JoinRoom(ctx, user.Id, core.KindChannel, user.Id, room.Id); err != nil {
+					c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+					return
+				}
+			}
+		}
+
+		if err := s.createCookieSession(c, user.Id, "test_create_user_session"); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		if err := s.core.RecordLoginSucceeded(ctx, user.Id, req.Login); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"success": true,
+			"user": gin.H{
+				"id":          user.Id,
+				"login":       user.Login,
+				"displayName": user.DisplayName,
+			},
 		})
 	})
 

--- a/frontend/e2e/fixtures/server.ts
+++ b/frontend/e2e/fixtures/server.ts
@@ -61,7 +61,7 @@ async function waitForServer(port: number, timeoutMs = 45000): Promise<void> {
     } catch {
       // Server not ready yet
     }
-    await new Promise((r) => setTimeout(r, 100));
+    await new Promise((r) => setTimeout(r, 25));
   }
   throw new Error(`Server on port ${port} did not become ready within ${timeoutMs}ms`);
 }
@@ -97,6 +97,7 @@ export async function startServer(
       cwd: __dirname,
       env: {
         ...process.env,
+        CHATTO_VIDEO_ENABLED: 'false',
         ...options.env,
         CHATTO_WEBSERVER_PORT: String(ports.webserver),
         CHATTO_WEBSERVER_URL: `http://localhost:${ports.webserver}`,

--- a/frontend/e2e/fixtures/testUser.ts
+++ b/frontend/e2e/fixtures/testUser.ts
@@ -349,72 +349,26 @@ export async function createAndLoginTestUser(
     password: 'testpassword123'
   };
 
-  // Create user via the test-only endpoint. Bypasses the full registration
-  // flow (email delivery, token verification, session creation) — these are
-  // covered by dedicated registration-flow tests, not every test that needs
-  // *some* user. The endpoint is gated behind the `test_endpoints` build
-  // tag and is never compiled into production binaries.
-  const createUserResponse = await page.request.post('/auth/test/create-user', {
+  // Create, verify, log in, and optionally join the default rooms via one
+  // test-only endpoint. The production registration/login flow is covered by
+  // dedicated tests; most E2E tests just need a ready authenticated user.
+  const createUserResponse = await page.request.post('/auth/test/create-user-session', {
     headers: { 'Content-Type': 'application/json' },
     data: {
       login: testUser.login,
       displayName: testUser.displayName,
-      password: testUser.password
+      password: testUser.password,
+      email: `${testUser.login}@example.com`,
+      joinDefaultRooms: !options?.skipDefaultRooms
     }
   });
   expect(createUserResponse.ok()).toBeTruthy();
-  const createUserData = (await createUserResponse.json()) as { id: string };
-  testUser.id = createUserData.id;
-
-  // Verify user's email so admin checks, password reset, etc. behave as if
-  // the user completed real registration.
-  const verifyResponse = await page.request.post('/auth/test/verify-email', {
-    headers: { 'Content-Type': 'application/json' },
-    data: { userId: testUser.id, email: `${testUser.login}@example.com` }
-  });
-  expect(verifyResponse.ok()).toBeTruthy();
-
-  // Login via HTTP endpoint to get the session cookie on the page.
-  const loginResponse = await page.request.post('/auth/login', {
-    data: { login: testUser.login, password: testUser.password }
-  });
-  expect(loginResponse.ok()).toBeTruthy();
-  const loginData = await loginResponse.json();
-  expect(loginData.success).toBe(true);
-
-  // Auto-join the bootstrap default rooms (announcements + general). Server
-  // membership is implicit but room membership is now strictly explicit
-  // after the auto-join feature was retired, so a freshly-minted user lands
-  // in an empty sidebar. Most tests assume `# general` is reachable from
-  // the sidebar; do that join here so every test doesn't have to repeat
-  // the dance. Idempotent — joining an already-joined room is a no-op.
-  if (!options?.skipDefaultRooms) {
-    await autoJoinDefaultRooms(page);
-  }
+  const createUserData = (await createUserResponse.json()) as {
+    user: { id: string };
+  };
+  testUser.id = createUserData.user.id;
 
   return testUser;
-}
-
-async function autoJoinDefaultRooms(page: Page): Promise<void> {
-  const roomsResp = await page.request.post('/api/graphql', {
-    headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
-    data: { query: `query { server { rooms(type: CHANNEL) { id name } } }` }
-  });
-  if (!roomsResp.ok()) return;
-  const roomsData = (await roomsResp.json()) as {
-    data?: { server?: { rooms?: Array<{ id: string; name: string }> } };
-  };
-  const defaults = new Set(['general', 'announcements']);
-  const targets = (roomsData.data?.server?.rooms ?? []).filter((r) => defaults.has(r.name));
-  for (const room of targets) {
-    await page.request.post('/api/graphql', {
-      headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
-      data: {
-        query: `mutation($input: JoinRoomInput!) { joinRoom(input: $input) { id } }`,
-        variables: { input: { roomId: room.id } }
-      }
-    });
-  }
 }
 
 /**

--- a/frontend/e2e/gif-to-video.test.ts
+++ b/frontend/e2e/gif-to-video.test.ts
@@ -8,6 +8,8 @@ import * as routes from './routes';
 // Video processing (ffmpeg transcode) can take up to 60s for small test files on CI.
 const VIDEO_PROCESSING_TIMEOUT = 60_000;
 
+test.use({ serverOptions: { env: { CHATTO_VIDEO_ENABLED: 'true' } } });
+
 test.describe('animated GIF to video conversion @ffmpeg', () => {
 	test.setTimeout(120_000);
 

--- a/frontend/e2e/video-player.test.ts
+++ b/frontend/e2e/video-player.test.ts
@@ -8,6 +8,8 @@ import { TIMEOUTS } from './constants';
 // Video processing (ffmpeg transcode) can take up to 45s for small test videos.
 const VIDEO_PROCESSING_TIMEOUT = 45_000;
 
+test.use({ serverOptions: { env: { CHATTO_VIDEO_ENABLED: 'true' } } });
+
 test.describe('video player @ffmpeg', () => {
 	test.setTimeout(90_000);
 


### PR DESCRIPTION
- Add a test-only endpoint that creates, verifies, logs in, and default-room-joins an E2E user in one request.
- Use that endpoint from `createAndLoginTestUser` to keep isolated tests cheaper without sharing server state.
- Disable video processing for ordinary E2E servers, while opting the `@ffmpeg` suites back in explicitly.
- Poll `/readyz` more frequently to avoid adding up to 100ms of avoidable wait per test server.

Checks run: `pnpm --dir frontend check`, `pnpm --dir frontend lint`, `go test -tags 'bootstrap test_endpoints' ./cmd ./internal/http_server`, and focused Playwright smoke tests.
