### PR TITLE
fix(frontend): crop server sidebar banners

### DIFF
--- a/frontend/src/lib/components/chat/ServerBanner.svelte
+++ b/frontend/src/lib/components/chat/ServerBanner.svelte
@@ -6,18 +6,10 @@
 
 <div class="w-full p-2">
   <div class="relative aspect-[1200/630] max-h-32 w-full overflow-hidden rounded-lg bg-surface-100">
-    <div
-      aria-hidden="true"
-      class="pointer-events-none absolute inset-y-0 left-1/2 flex -translate-x-1/2 items-center blur-lg"
-    >
-      <img src={url} alt="" class="h-full w-auto max-w-none shrink-0 -scale-x-100" />
-      <img src={url} alt="" class="h-full w-auto max-w-none shrink-0" />
-      <img src={url} alt="" class="h-full w-auto max-w-none shrink-0 -scale-x-100" />
-    </div>
     <SkeletonImg
       src={url}
       alt="Server banner"
-      class="absolute inset-0 h-full w-full rounded-lg object-contain shadow-lg"
+      class="absolute inset-0 h-full w-full rounded-lg object-cover shadow-lg"
     />
   </div>
 </div>

--- a/frontend/src/lib/components/chat/ServerBanner.svelte.spec.ts
+++ b/frontend/src/lib/components/chat/ServerBanner.svelte.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { q } from '$lib/test-utils';
+
+import ServerBanner from './ServerBanner.svelte';
+
+describe('ServerBanner', () => {
+  it('renders a single cover-fitted banner image without decorative duplicates', async () => {
+    const url = 'https://cdn.example.com/server-banner.webp';
+    const { container } = render(ServerBanner, { props: { url } });
+
+    const images = container.querySelectorAll('img');
+    expect(images).toHaveLength(1);
+    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
+
+    const image = q(container, 'img[alt="Server banner"]');
+    await expect.element(image).toBeInTheDocument();
+    await expect.element(image).toHaveAttribute('src', url);
+    await expect.element(image).toHaveClass('object-cover');
+    await expect.element(image).not.toHaveClass('object-contain');
+  });
+});


### PR DESCRIPTION
## Changes

- Render chat sidebar server banners as a single `object-cover` image.
- Remove the blurred duplicate backdrop that made logo-like banner assets look letterboxed and distorted.
- Add a Svelte browser spec covering the single-image, cover-fit rendering contract.

## Tests

- `npx @sveltejs/mcp svelte-autofixer frontend/src/lib/components/chat/ServerBanner.svelte --svelte-version 5`
- `pnpm --dir frontend exec vitest --run src/lib/components/chat/ServerBanner.svelte.spec.ts`
- `pnpm --dir frontend test:unit -- --run frontend/src/lib/components/chat/ServerBanner.svelte.spec.ts`
- `pnpm --dir frontend check`
- `pnpm --dir frontend exec prettier --check src/lib/components/chat/ServerBanner.svelte src/lib/components/chat/ServerBanner.svelte.spec.ts`
