### PR TITLE
ci: make e2e server builds cheaper

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -29,15 +29,24 @@ runs:
       with:
         version: 10
 
+    # Keep module downloads stable, but let the compiled package cache roll forward
+    # with source changes. A go.sum-only build-cache key restores quickly, then
+    # refuses to save fresher local package artifacts on every exact cache hit.
     - name: Cache Go modules
       uses: actions/cache@v5
       with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: go-${{ runner.os }}-${{ hashFiles('cli/go.sum') }}
+        path: ~/go/pkg/mod
+        key: go-mod-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('cli/go.sum') }}
         restore-keys: |
-          go-${{ runner.os }}-
+          go-mod-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Cache Go build artifacts
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/go-build
+        key: go-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('cli/go.sum', 'cli/**/*.go', 'proto/**/*.go', 'proto/**/*.proto', 'frontend/package.json', 'frontend/pnpm-lock.yaml', 'frontend/src/**', 'frontend/static/**', 'frontend/svelte.config.js', 'frontend/tsconfig.json', 'frontend/vite.config.ts', 'mise.toml') }}
+        restore-keys: |
+          go-build-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Install ffmpeg (required for video processing e2e tests)
       if: inputs.install-ffmpeg == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,11 @@ jobs:
 
   test-e2e:
     runs-on: ubicloud-standard-4
-    name: test-e2e (${{ matrix.shard }}/4)
+    name: test-e2e (${{ matrix.shard }}/3)
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -91,7 +91,7 @@ jobs:
         run: mise build-e2e-server
 
       - name: Run E2E tests
-        run: cd frontend && pnpm exec playwright test --grep-invert @ffmpeg --shard=${{ matrix.shard }}/4
+        run: cd frontend && pnpm exec playwright test --grep-invert @ffmpeg --shard=${{ matrix.shard }}/3
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,11 @@ jobs:
 
   test-e2e:
     runs-on: ubicloud-standard-4
-    name: test-e2e (${{ matrix.shard }}/3)
+    name: test-e2e (${{ matrix.shard }}/4)
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -91,7 +91,7 @@ jobs:
         run: mise build-e2e-server
 
       - name: Run E2E tests
-        run: cd frontend && pnpm exec playwright test --grep-invert @ffmpeg --shard=${{ matrix.shard }}/3
+        run: cd frontend && pnpm exec playwright test --grep-invert @ffmpeg --shard=${{ matrix.shard }}/4
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7

--- a/mise.toml
+++ b/mise.toml
@@ -118,7 +118,7 @@ dir = "cli"
 # test-only HTTP endpoints (e.g. /auth/test/create-user) used by per-test
 # fixtures. Deliberately scoped — the e2e binary should NOT pull in any
 # future broader dev-only code that might land under a separate tag.
-run = "go build -tags 'bootstrap test_endpoints' -o ../frontend/e2e/fixtures/bin/chatto ."
+run = "CGO_ENABLED=0 go build -tags 'bootstrap test_endpoints' -ldflags '-s -w' -o ../frontend/e2e/fixtures/bin/chatto ."
 sources = ["**/*.go", "internal/http_server/.client/**/*"]
 outputs = ["../frontend/e2e/fixtures/bin/chatto"]
 


### PR DESCRIPTION
- Split Go module caching from Go build artifact caching so compiled package caches can roll forward with source changes.
- Build the disposable E2E server binary with `CGO_ENABLED=0` and stripped debug tables to reduce link work and binary size.
- Verified locally with YAML parsing, actionlint, `mise build-e2e-server`, `chatto --help`, and a focused Playwright smoke test.
