### PR TITLE
ci: add e2e runner base image

### DIFF
--- a/.github/actions/setup-e2e/action.yml
+++ b/.github/actions/setup-e2e/action.yml
@@ -1,0 +1,36 @@
+name: "Setup E2E Environment"
+description: "Restores caches and installs repo dependencies inside the Chatto E2E runner image"
+runs:
+  using: "composite"
+  steps:
+    - name: Cache pnpm store
+      uses: actions/cache@v5
+      with:
+        path: ~/.local/share/pnpm/store
+        key: pnpm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('frontend/pnpm-lock.yaml') }}
+        restore-keys: |
+          pnpm-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Cache Go modules
+      uses: actions/cache@v5
+      with:
+        path: ~/go/pkg/mod
+        key: go-mod-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('cli/go.sum') }}
+        restore-keys: |
+          go-mod-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Cache Go build artifacts
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/go-build
+        key: go-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('cli/go.mod', 'cli/go.sum', 'cli/**/*.go', 'proto/**/*.go', 'proto/**/*.proto', 'frontend/package.json', 'frontend/pnpm-lock.yaml', 'frontend/src/**', 'frontend/static/**', 'frontend/svelte.config.js', 'frontend/tsconfig.json', 'frontend/vite.config.ts', 'tools/build-e2e-server.sh', 'mise.toml') }}
+        restore-keys: |
+          go-build-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Install CLI dependencies
+      shell: bash
+      run: cd cli && go mod download
+
+    - name: Install frontend dependencies
+      shell: bash
+      run: cd frontend && pnpm install --frozen-lockfile

--- a/.github/workflows/build-e2e-runner.yml
+++ b/.github/workflows/build-e2e-runner.yml
@@ -1,0 +1,45 @@
+name: build e2e runner
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - Dockerfile.e2e-runner
+      - .github/workflows/build-e2e-runner.yml
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/chattocorp/chatto-e2e-runner
+  IMAGE_TAG: playwright-1.60.0-go-1.26.2-node-24
+
+jobs:
+  build-e2e-runner:
+    runs-on: ubicloud-standard-4
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push E2E runner image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.e2e-runner
+          push: true
+          platforms: linux/amd64
+          tags: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          cache-from: type=gha,scope=chatto-e2e-runner
+          cache-to: type=gha,scope=chatto-e2e-runner,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,74 @@ concurrency:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
+  prepare-e2e-runner:
+    runs-on: ubicloud-standard-4
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE_NAME: ghcr.io/chattocorp/chatto-e2e-runner
+      IMAGE_TAG: playwright-1.60.0-go-1.26.2-node-24
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check whether E2E runner image changed
+        id: runner-image
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          else
+            base="${{ github.event.before }}"
+            head="${{ github.sha }}"
+
+            if [[ "$base" == "0000000000000000000000000000000000000000" ]]; then
+              base="HEAD^"
+            fi
+          fi
+
+          changed_files="$(git diff --name-only "$base" "$head")"
+          printf '%s\n' "$changed_files"
+
+          if grep -Eq '^(Dockerfile\.e2e-runner|\.github/workflows/(ci|build-e2e-runner)\.yml)$' <<<"$changed_files"; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.runner-image.outputs.changed == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        if: steps.runner-image.outputs.changed == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push E2E runner image
+        if: steps.runner-image.outputs.changed == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.e2e-runner
+          push: true
+          platforms: linux/amd64
+          tags: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          cache-from: type=gha,scope=chatto-e2e-runner
+          cache-to: type=gha,scope=chatto-e2e-runner,mode=max
+
   test-frontend-unit:
     runs-on: ubicloud-standard-4
     steps:
@@ -64,31 +130,27 @@ jobs:
   test-e2e:
     runs-on: ubicloud-standard-4
     name: test-e2e (${{ matrix.shard }}/4)
+    needs: prepare-e2e-runner
+    container:
+      image: ghcr.io/chattocorp/chatto-e2e-runner:playwright-1.60.0-go-1.26.2-node-24
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
         shard: [1, 2, 3, 4]
+    env:
+      CHATTO_E2E_SKIP_GLOBAL_BUILD: "1"
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup environment
-        uses: ./.github/actions/setup
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('frontend/pnpm-lock.yaml') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Install Playwright dependencies
-        run: cd frontend && pnpm exec playwright install chromium --with-deps
-        timeout-minutes: 5
+      - name: Setup E2E environment
+        uses: ./.github/actions/setup-e2e
 
       - name: Build E2E server
-        run: mise build-e2e-server
+        run: tools/build-e2e-server.sh
 
       - name: Run E2E tests
         run: cd frontend && pnpm exec playwright test --grep-invert @ffmpeg --shard=${{ matrix.shard }}/4
@@ -103,29 +165,23 @@ jobs:
 
   test-e2e-media:
     runs-on: ubicloud-standard-4
+    needs: prepare-e2e-runner
+    container:
+      image: ghcr.io/chattocorp/chatto-e2e-runner:playwright-1.60.0-go-1.26.2-node-24
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      CHATTO_E2E_SKIP_GLOBAL_BUILD: "1"
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup environment
-        uses: ./.github/actions/setup
-        with:
-          install-ffmpeg: "true"
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('frontend/pnpm-lock.yaml') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Install Playwright dependencies
-        run: cd frontend && pnpm exec playwright install chromium --with-deps
-        timeout-minutes: 5
+      - name: Setup E2E environment
+        uses: ./.github/actions/setup-e2e
 
       - name: Build E2E server
-        run: mise build-e2e-server
+        run: tools/build-e2e-server.sh
 
       - name: Run media E2E tests
         run: cd frontend && pnpm exec playwright test --grep @ffmpeg

--- a/Dockerfile.e2e-runner
+++ b/Dockerfile.e2e-runner
@@ -1,0 +1,38 @@
+FROM node:24-bookworm-slim
+
+ARG GO_VERSION=1.26.2
+ARG PLAYWRIGHT_VERSION=1.60.0
+ARG PNPM_VERSION=10.19.0
+ARG TARGETARCH
+
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl ffmpeg git xz-utils; \
+    rm -rf /var/lib/apt/lists/*; \
+    npm install -g "pnpm@${PNPM_VERSION}" "playwright@${PLAYWRIGHT_VERSION}"; \
+    playwright install chromium --with-deps; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) go_arch=amd64 ;; \
+      arm64) go_arch=arm64 ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${go_arch}.tar.gz" -o /tmp/go.tgz; \
+    tar -C /usr/local -xzf /tmp/go.tgz; \
+    rm /tmp/go.tgz; \
+    ln -s /usr/local/go/bin/go /usr/local/bin/go; \
+    ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+WORKDIR /workspace
+
+RUN set -eux; \
+    node --version; \
+    pnpm --version; \
+    go version; \
+    playwright --version

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -1,12 +1,17 @@
 import { execSync } from 'child_process';
 
 /**
- * Global setup runs once before all tests. Always invokes
+ * Global setup runs once before all tests. Usually invokes
  * `mise build-e2e-server` — mise's source/output tracking turns this
  * into a no-op when nothing has changed and a real rebuild when backend
  * code has, so iterating on backend + e2e together doesn't silently use
- * a stale binary.
+ * a stale binary. CI can opt out after building the binary explicitly inside
+ * the E2E runner container.
  */
 export default function globalSetup() {
+  if (process.env.CHATTO_E2E_SKIP_GLOBAL_BUILD === '1') {
+    return;
+  }
+
   execSync('mise build-e2e-server', { stdio: 'inherit', cwd: process.cwd() });
 }

--- a/mise.toml
+++ b/mise.toml
@@ -111,16 +111,27 @@ outputs = ["bin/chatto"]
 
 [tasks.build-e2e-server]
 description = "Build the E2E test server binary with dev bootstrap and test endpoints enabled"
-depends = ["deps-cli", "build-frontend"]
-dir = "cli"
+depends = ["deps-cli", "deps-frontend"]
 # `bootstrap` enables the [bootstrap] section in chatto.toml, which seeds
 # the e2eadmin user the harness logs in as. `test_endpoints` exposes the
 # test-only HTTP endpoints (e.g. /auth/test/create-user) used by per-test
 # fixtures. Deliberately scoped — the e2e binary should NOT pull in any
 # future broader dev-only code that might land under a separate tag.
-run = "CGO_ENABLED=0 go build -tags 'bootstrap test_endpoints' -ldflags '-s -w' -o ../frontend/e2e/fixtures/bin/chatto ."
-sources = ["**/*.go", "internal/http_server/.client/**/*"]
-outputs = ["../frontend/e2e/fixtures/bin/chatto"]
+run = "tools/build-e2e-server.sh"
+sources = [
+    "tools/build-e2e-server.sh",
+    "cli/go.mod",
+    "cli/go.sum",
+    "cli/**/*.go",
+    "frontend/package.json",
+    "frontend/pnpm-lock.yaml",
+    "frontend/src/**/*",
+    "frontend/static/**/*",
+    "frontend/svelte.config.js",
+    "frontend/tsconfig.json",
+    "frontend/vite.config.ts",
+]
+outputs = ["frontend/e2e/fixtures/bin/chatto"]
 
 [tasks.storybook]
 description = "Run the Storybook design-system catalog"

--- a/tools/build-e2e-server.sh
+++ b/tools/build-e2e-server.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$repo_root/frontend"
+pnpm svelte-kit sync
+pnpm build
+
+rm -rf "$repo_root/cli/internal/http_server/.client"
+cp -r "$repo_root/frontend/build" "$repo_root/cli/internal/http_server/.client"
+touch "$repo_root/cli/internal/http_server/.client/.gitkeep"
+
+cd "$repo_root/cli"
+CGO_ENABLED="${CGO_ENABLED:-0}" go build \
+  -buildvcs=false \
+  -tags 'bootstrap test_endpoints' \
+  -ldflags '-s -w' \
+  -o "$repo_root/frontend/e2e/fixtures/bin/chatto" \
+  .


### PR DESCRIPTION
## Changes
- Add a Node 24, Go, pnpm, Playwright, Chromium, and ffmpeg E2E runner image plus a GHCR publishing workflow.
- Run E2E shards inside the runner image with a dedicated setup action that only restores repo dependency caches and installs project deps.
- Move the E2E server build into a shared script and let CI skip Playwright's global rebuild after the explicit build step.

## Validation
- YAML parse, actionlint, local amd64 Docker build, runner tool probe, `mise build-e2e-server`, and focused Playwright smoke.
