### PR TITLE
ci: share E2E server build artifact

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -33,6 +33,7 @@ runs:
     # with source changes. A go.sum-only build-cache key restores quickly, then
     # refuses to save fresher local package artifacts on every exact cache hit.
     - name: Cache Go modules
+      if: inputs.install-cli-deps == 'true'
       uses: actions/cache@v5
       with:
         path: ~/go/pkg/mod
@@ -41,6 +42,7 @@ runs:
           go-mod-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Cache Go build artifacts
+      if: inputs.install-cli-deps == 'true'
       uses: actions/cache@v5
       with:
         path: ~/.cache/go-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ concurrency:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   test-frontend-unit:
@@ -61,6 +62,26 @@ jobs:
       - name: Run Go tests
         run: cd cli && go test -tags test_endpoints ./...
 
+  test-e2e-build:
+    runs-on: ubicloud-standard-4
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup environment
+        uses: ./.github/actions/setup
+
+      - name: Build E2E server
+        run: mise build-e2e-server
+
+      - name: Upload E2E server
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-server-${{ github.sha }}
+          path: frontend/e2e/fixtures/bin/chatto
+          if-no-files-found: error
+          retention-days: 1
+
   test-e2e:
     runs-on: ubicloud-standard-4
     name: test-e2e (${{ matrix.shard }}/4)
@@ -74,6 +95,8 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/setup
+        with:
+          install-cli-deps: "false"
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5
@@ -87,11 +110,35 @@ jobs:
         run: cd frontend && pnpm exec playwright install chromium --with-deps
         timeout-minutes: 5
 
-      - name: Build E2E server
-        run: mise build-e2e-server
+      - name: Wait for E2E server
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const artifactName = `e2e-server-${context.sha}`;
+            for (let attempt = 0; attempt < 60; attempt += 1) {
+              const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.runId
+              });
+              if (data.artifacts.some((artifact) => artifact.name === artifactName)) return;
+              await new Promise((resolve) => setTimeout(resolve, 5000));
+            }
+            core.setFailed(`Timed out waiting for ${artifactName}`);
+
+      - name: Download E2E server
+        uses: actions/download-artifact@v7
+        with:
+          name: e2e-server-${{ github.sha }}
+          path: frontend/e2e/fixtures/bin
+
+      - name: Prepare E2E server
+        run: chmod +x frontend/e2e/fixtures/bin/chatto
 
       - name: Run E2E tests
         run: cd frontend && pnpm exec playwright test --grep-invert @ffmpeg --shard=${{ matrix.shard }}/4
+        env:
+          CHATTO_E2E_SKIP_GLOBAL_BUILD: "1"
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7
@@ -111,6 +158,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           install-ffmpeg: "true"
+          install-cli-deps: "false"
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5
@@ -124,11 +172,35 @@ jobs:
         run: cd frontend && pnpm exec playwright install chromium --with-deps
         timeout-minutes: 5
 
-      - name: Build E2E server
-        run: mise build-e2e-server
+      - name: Wait for E2E server
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const artifactName = `e2e-server-${context.sha}`;
+            for (let attempt = 0; attempt < 60; attempt += 1) {
+              const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.runId
+              });
+              if (data.artifacts.some((artifact) => artifact.name === artifactName)) return;
+              await new Promise((resolve) => setTimeout(resolve, 5000));
+            }
+            core.setFailed(`Timed out waiting for ${artifactName}`);
+
+      - name: Download E2E server
+        uses: actions/download-artifact@v7
+        with:
+          name: e2e-server-${{ github.sha }}
+          path: frontend/e2e/fixtures/bin
+
+      - name: Prepare E2E server
+        run: chmod +x frontend/e2e/fixtures/bin/chatto
 
       - name: Run media E2E tests
         run: cd frontend && pnpm exec playwright test --grep @ffmpeg
+        env:
+          CHATTO_E2E_SKIP_GLOBAL_BUILD: "1"
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -1,4 +1,6 @@
 import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import { join } from 'path';
 
 /**
  * Global setup runs once before all tests. Always invokes
@@ -8,5 +10,15 @@ import { execSync } from 'child_process';
  * a stale binary.
  */
 export default function globalSetup() {
+  if (process.env.CHATTO_E2E_SKIP_GLOBAL_BUILD === '1') {
+    const binaryPath = join(process.cwd(), 'e2e/fixtures/bin/chatto');
+    if (!existsSync(binaryPath)) {
+      throw new Error(
+        `CHATTO_E2E_SKIP_GLOBAL_BUILD is set, but the E2E server binary is missing at ${binaryPath}`
+      );
+    }
+    return;
+  }
+
   execSync('mise build-e2e-server', { stdio: 'inherit', cwd: process.cwd() });
 }


### PR DESCRIPTION
## Changes

- Add a `test-e2e-build` CI job that builds the E2E `chatto` binary once and uploads it as a short-lived artifact.
- Download that artifact in the normal E2E shards and media E2E job instead of rebuilding the server in every lane.
- Let E2E jobs start setup immediately and wait for the artifact only after Playwright dependencies are ready, so dependency setup overlaps with the shared build.
- Let CI set `CHATTO_E2E_SKIP_GLOBAL_BUILD=1` so Playwright global setup verifies the prebuilt binary exists and skips `mise build-e2e-server`.
- Skip Go module/build caches in setup jobs that opt out of CLI dependencies.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/actions/setup/action.yml"); puts "yaml ok"'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'label "ubicloud-standard-4" is unknown' .github/workflows/ci.yml`
- `mise build-e2e-server`
- `CHATTO_E2E_SKIP_GLOBAL_BUILD=1 pnpm exec playwright test e2e/registration-disabled.test.ts --retries=0 --workers=1` from `frontend/`
- CI run `27441328435` passed before the setup-overlap tweak, but was not fast enough because the matrix was serialized behind `test-e2e-build`.

## Notes

- This intentionally avoids the discarded E2E runner image approach. It targets only the duplicated E2E server build while keeping the existing runner setup.
- The real success metric is the next PR CI run: the first artifact run proved correctness, and this revision removes the serial `needs:` edge so shard setup can overlap with the shared build.
