### PR TITLE
ci: reduce test endpoint password hash cost

### DIFF
--- a/cli/internal/core/password_cost.go
+++ b/cli/internal/core/password_cost.go
@@ -1,0 +1,7 @@
+//go:build !test_endpoints
+
+package core
+
+import "golang.org/x/crypto/bcrypt"
+
+const passwordHashCost = bcrypt.DefaultCost

--- a/cli/internal/core/password_cost_test_endpoints.go
+++ b/cli/internal/core/password_cost_test_endpoints.go
@@ -1,0 +1,9 @@
+//go:build test_endpoints
+
+package core
+
+import "golang.org/x/crypto/bcrypt"
+
+// Test-endpoint builds create many short-lived users during E2E runs. Keep the
+// auth flow real while avoiding production-grade bcrypt cost for throwaway data.
+const passwordHashCost = bcrypt.MinCost

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -153,7 +153,7 @@ func (c *ChattoCore) CreateUser(ctx context.Context, actorID string, login, disp
 		Event:   accountCreated,
 	}}
 	if password != "" {
-		hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+		hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), passwordHashCost)
 		if err != nil {
 			return nil, fmt.Errorf("failed to hash password: %w", err)
 		}
@@ -306,7 +306,7 @@ func (c *ChattoCore) SetPasswordHash(ctx context.Context, userID string, passwor
 	}
 
 	// Hash the password
-	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), passwordHashCost)
 	if err != nil {
 		return fmt.Errorf("failed to hash password: %w", err)
 	}


### PR DESCRIPTION
## Changes

- Route password hashing through a package-level `passwordHashCost`.
- Keep production and ordinary builds on `bcrypt.DefaultCost`.
- Use `bcrypt.MinCost` only for `test_endpoints` builds, where E2E helpers create many short-lived throwaway users.

## Measurements

- `/auth/test/create-user-session` local p50 dropped from ~52ms to ~3.4ms.
- Fresh E2E bootstrap startup local p50 dropped from ~103ms to ~51ms.

## Verification

- `go test ./internal/core`
- `go test -tags test_endpoints ./internal/core`
- `go test -tags test_endpoints ./internal/http_server`
- `pnpm exec playwright test e2e/auth.test.ts --grep "can login via the login form|complete user journey" --retries=0 --workers=1` from `frontend/`

## Notes

- This does not change production password hashing cost.
- Plain `go test ./internal/http_server` currently fails on `TestAuthRoutes_TestEmailEndpoint`, which expects test endpoints in a non-`test_endpoints` build; the tagged HTTP-server test run passes.
