### PR TITLE
ci: serve e2e frontend from filesystem

### DIFF
--- a/cli/internal/http_server/frontend.go
+++ b/cli/internal/http_server/frontend.go
@@ -2,7 +2,6 @@ package http_server
 
 import (
 	"context"
-	"embed"
 	"io/fs"
 	"mime"
 	"net/http"
@@ -14,9 +13,6 @@ import (
 	"github.com/charmbracelet/log"
 	"github.com/gin-gonic/gin"
 )
-
-//go:embed all:.client
-var embeddedWebUIFS embed.FS
 
 // Cache control headers for different file types
 const (
@@ -145,8 +141,7 @@ func servePrecompressedFile(c *gin.Context, clientFS fs.FS, filePath string) boo
 }
 
 func (s *HTTPServer) setupFrontendRoutes() error {
-	// Get a sub-filesystem rooted at .client
-	clientFS, err := fs.Sub(embeddedWebUIFS, ".client")
+	clientFS, err := frontendAssetFS()
 	if err != nil {
 		return err
 	}

--- a/cli/internal/http_server/frontend_embed.go
+++ b/cli/internal/http_server/frontend_embed.go
@@ -1,0 +1,15 @@
+//go:build !e2e_file_frontend
+
+package http_server
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed all:.client
+var embeddedWebUIFS embed.FS
+
+func frontendAssetFS() (fs.FS, error) {
+	return fs.Sub(embeddedWebUIFS, ".client")
+}

--- a/cli/internal/http_server/frontend_file.go
+++ b/cli/internal/http_server/frontend_file.go
@@ -1,0 +1,25 @@
+//go:build e2e_file_frontend
+
+package http_server
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+const frontendDirEnv = "CHATTO_FRONTEND_DIR"
+
+func frontendAssetFS() (fs.FS, error) {
+	dir := os.Getenv(frontendDirEnv)
+	if dir == "" {
+		return nil, fmt.Errorf("%s must point at a built frontend directory", frontendDirEnv)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "200.html")); err != nil {
+		return nil, fmt.Errorf("%s must point at a built frontend directory containing 200.html: %w", frontendDirEnv, err)
+	}
+
+	return os.DirFS(dir), nil
+}

--- a/frontend/e2e/fixtures/server.ts
+++ b/frontend/e2e/fixtures/server.ts
@@ -99,6 +99,7 @@ export async function startServer(
         ...process.env,
         CHATTO_VIDEO_ENABLED: 'false',
         ...options.env,
+        CHATTO_FRONTEND_DIR: path.join(__dirname, '..', '..', 'build'),
         CHATTO_WEBSERVER_PORT: String(ports.webserver),
         CHATTO_WEBSERVER_URL: `http://localhost:${ports.webserver}`,
         CHATTO_NATS_EMBEDDED_PORT: '0',

--- a/mise.toml
+++ b/mise.toml
@@ -118,8 +118,8 @@ dir = "cli"
 # test-only HTTP endpoints (e.g. /auth/test/create-user) used by per-test
 # fixtures. Deliberately scoped — the e2e binary should NOT pull in any
 # future broader dev-only code that might land under a separate tag.
-run = "CGO_ENABLED=0 go build -tags 'bootstrap test_endpoints' -ldflags '-s -w' -o ../frontend/e2e/fixtures/bin/chatto ."
-sources = ["**/*.go", "internal/http_server/.client/**/*"]
+run = "CGO_ENABLED=0 go build -tags 'bootstrap test_endpoints e2e_file_frontend' -ldflags '-s -w' -o ../frontend/e2e/fixtures/bin/chatto ."
+sources = ["**/*.go"]
 outputs = ["../frontend/e2e/fixtures/bin/chatto"]
 
 [tasks.storybook]


### PR DESCRIPTION
- Adds a build-tagged frontend asset provider so normal binaries still embed `.client`, while E2E binaries can serve the already-built `frontend/build` directory from disk.
- Builds the E2E server with `e2e_file_frontend` and removes embedded frontend assets from the E2E Go build source list.
- Points Playwright-spawned Chatto servers at `CHATTO_FRONTEND_DIR` so browser tests still exercise the production frontend build.

Checks run: `go test -tags test_endpoints ./internal/http_server -count=1`, `go test ./internal/http_server -tags 'bootstrap test_endpoints e2e_file_frontend' -run TestNonexistent -count=1`, `mise build-e2e-server`.
