### PR TITLE
ci: tune go dependency caching

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -16,6 +16,25 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Cache Go modules
+      if: inputs.install-cli-deps == 'true'
+      uses: actions/cache@v5
+      with:
+        path: ~/go/pkg/mod
+        key: go-mod-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('cli/go.sum') }}
+        restore-keys: |
+          go-mod-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Cache Go build artifacts
+      if: inputs.install-cli-deps == 'true'
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/go-build
+        key: go-build-${{ github.job }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('cli/go.sum', 'cli/**/*.go', 'proto/**/*.go', 'proto/**/*.proto', 'frontend/package.json', 'frontend/pnpm-lock.yaml', 'frontend/src/**', 'frontend/static/**', 'frontend/svelte.config.js', 'frontend/tsconfig.json', 'frontend/vite.config.ts', 'mise.toml') }}
+        restore-keys: |
+          go-build-${{ github.job }}-${{ runner.os }}-${{ runner.arch }}-
+          go-build-${{ runner.os }}-${{ runner.arch }}-
+
     # mise-action installs mise and the tools defined in mise.toml (Go, Node)
     # with automatic caching of the tool installations
     - name: Setup mise
@@ -28,25 +47,6 @@ runs:
       uses: pnpm/action-setup@v5
       with:
         version: 10
-
-    # Keep module downloads stable, but let the compiled package cache roll forward
-    # with source changes. A go.sum-only build-cache key restores quickly, then
-    # refuses to save fresher local package artifacts on every exact cache hit.
-    - name: Cache Go modules
-      uses: actions/cache@v5
-      with:
-        path: ~/go/pkg/mod
-        key: go-mod-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('cli/go.sum') }}
-        restore-keys: |
-          go-mod-${{ runner.os }}-${{ runner.arch }}-
-
-    - name: Cache Go build artifacts
-      uses: actions/cache@v5
-      with:
-        path: ~/.cache/go-build
-        key: go-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('cli/go.sum', 'cli/**/*.go', 'proto/**/*.go', 'proto/**/*.proto', 'frontend/package.json', 'frontend/pnpm-lock.yaml', 'frontend/src/**', 'frontend/static/**', 'frontend/svelte.config.js', 'frontend/tsconfig.json', 'frontend/vite.config.ts', 'mise.toml') }}
-        restore-keys: |
-          go-build-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Install ffmpeg (required for video processing e2e tests)
       if: inputs.install-ffmpeg == 'true'

--- a/mise.toml
+++ b/mise.toml
@@ -23,7 +23,7 @@ run = { task = "deps" }
 [tasks.deps-cli]
 description = "Install Go dependencies"
 dir = "cli"
-run = "go get ./..."
+run = "go mod download"
 sources = ["go.mod", "go.sum"]
 
 [tasks.deps-frontend]


### PR DESCRIPTION
- Restores Go module/build caches before `mise` installs Go tools, avoiding module-cache restore conflicts after `protoc-gen-go` setup.
- Skips Go caches for frontend-only setup runs and scopes Go build caches by GitHub job so frontend/test-cli/E2E jobs do not share one exact cache entry.
- Replaces `mise deps-cli`'s `go get ./...` with `go mod download`.

Checks run: `mise deps-cli`, `go test -tags test_endpoints ./internal/http_server -count=1`, `mise build-e2e-server`, `go test -tags test_endpoints ./...`.
