### PR TITLE
fix(logging): stop logging user PII

### DIFF
--- a/.claude/rules/general.md
+++ b/.claude/rules/general.md
@@ -24,6 +24,7 @@ plan; do not assume data can be discarded.
 ## Code Style & Approach
 
 - **Prefer the simplest possible approach first.** Do not over-engineer solutions. If a fix can be done in 2-3 lines, do not create abstractions, wrappers, or complex architectures. Wait for user feedback before adding complexity.
+- **Never log PII.** Runtime logs, request logs, debug logs, and test-only helper logs must not include raw login names, display names, email addresses, submitted auth identifiers, OAuth/OIDC provider subject identifiers, tokens, passwords, auth codes, reset links, raw IP addresses, or full query strings. Prefer opaque Chatto IDs, counts, booleans, event names, and already-safe hashes from audit-specific code.
 - **When fixing bugs involving caches or state, prefer minimal, targeted invalidation** over clearing entire caches. Avoid full-page reload flashes or broad cache wipes. Only invalidate the specific stale data.
 - **Functions that depend on "which server" should require an explicit server ID parameter.** Don't default to a global "current server" — it creates coupling and timing bugs. Navigation helpers, storage functions, and state lookups all take `serverId` as the first parameter.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,3 +51,4 @@ Please update this section as the project evolves, and refer to it when making d
 - Prefer simplicity and clarity over cleverness.
 - Where feasible, write code comments that explain intent.
 - Make sure the code is well-tested, and that tests are easy to understand and maintain.
+- Never log PII. Logs must not include raw login names, display names, email addresses, submitted auth identifiers, OAuth/OIDC provider subject identifiers, tokens, passwords, auth codes, reset links, raw IP addresses, or full query strings. Prefer opaque Chatto IDs, counts, booleans, event names, and already-safe hashes from audit-specific code.

--- a/cli/cmd/bootstrap_apply.go
+++ b/cli/cmd/bootstrap_apply.go
@@ -61,7 +61,7 @@ func applyBootstrap(ctx context.Context, c *core.ChattoCore, cfg config.Bootstra
 		}
 		if created {
 			usersCreated++
-			logger.Info("Created user from [bootstrap]", "login", u.Login, "user_id", userID)
+			logger.Info("Created user from [bootstrap]", "user_id", userID)
 		} else {
 			usersExisting++
 		}
@@ -144,10 +144,10 @@ func applyBootstrapUser(ctx context.Context, logger *log.Logger, c *core.ChattoC
 	}
 
 	if existing, err := c.GetUserByLogin(ctx, u.Login); err == nil && existing != nil {
-		logger.Debug("[bootstrap] user already exists; skipping create", "login", u.Login)
+		logger.Debug("[bootstrap] user already exists; skipping create", "user_id", existing.Id)
 		// Still try to apply role + email below (idempotent).
-		assignBootstrapRole(ctx, logger, c, existing.Id, u.ServerRole, u.Login)
-		ensureBootstrapEmail(ctx, logger, c, existing.Id, u.Email, u.Login)
+		assignBootstrapRole(ctx, logger, c, existing.Id, u.ServerRole)
+		ensureBootstrapEmail(ctx, logger, c, existing.Id, u.Email)
 		return existing.Id, false
 	}
 
@@ -158,29 +158,29 @@ func applyBootstrapUser(ctx context.Context, logger *log.Logger, c *core.ChattoC
 
 	user, err := c.CreateUser(ctx, "system", u.Login, displayName, u.Password)
 	if err != nil {
-		logger.Error("Failed to create [bootstrap] user", "login", u.Login, "error", err)
+		logger.Error("Failed to create [bootstrap] user", "error", err)
 		return "", false
 	}
 
-	ensureBootstrapEmail(ctx, logger, c, user.Id, u.Email, u.Login)
-	assignBootstrapRole(ctx, logger, c, user.Id, u.ServerRole, u.Login)
+	ensureBootstrapEmail(ctx, logger, c, user.Id, u.Email)
+	assignBootstrapRole(ctx, logger, c, user.Id, u.ServerRole)
 
 	return user.Id, true
 }
 
-func ensureBootstrapEmail(ctx context.Context, logger *log.Logger, c *core.ChattoCore, userID, email, login string) {
+func ensureBootstrapEmail(ctx context.Context, logger *log.Logger, c *core.ChattoCore, userID, email string) {
 	if email == "" {
 		return
 	}
 	if err := c.AddVerifiedEmailDirect(ctx, userID, email); err != nil {
 		// ErrEmailAlreadyVerified is fine — the email is already attached.
 		if !errors.Is(err, core.ErrEmailAlreadyVerified) {
-			logger.Warn("Failed to add verified email for [bootstrap] user", "login", login, "email", email, "error", err)
+			logger.Warn("Failed to add verified email for [bootstrap] user", "user_id", userID, "error", err)
 		}
 	}
 }
 
-func assignBootstrapRole(ctx context.Context, logger *log.Logger, c *core.ChattoCore, userID, role, login string) {
+func assignBootstrapRole(ctx context.Context, logger *log.Logger, c *core.ChattoCore, userID, role string) {
 	if role == "" {
 		return
 	}
@@ -193,12 +193,12 @@ func assignBootstrapRole(ctx context.Context, logger *log.Logger, c *core.Chatto
 	case "moderator":
 		roleName = core.RoleModerator
 	default:
-		logger.Warn("Unknown instance_role in [bootstrap]; ignoring", "login", login, "role", role)
+		logger.Warn("Unknown instance_role in [bootstrap]; ignoring", "user_id", userID, "role", role)
 		return
 	}
 	// SystemActorID bypasses hierarchy checks — bootstrap operates as the system.
 	if err := c.AssignServerRole(ctx, core.SystemActorID, userID, roleName); err != nil {
-		logger.Warn("Failed to assign role for [bootstrap] user", "login", login, "role", role, "error", err)
+		logger.Warn("Failed to assign role for [bootstrap] user", "user_id", userID, "role", role, "error", err)
 	}
 }
 

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -201,7 +201,7 @@ func (c *ChattoCore) CreateUser(ctx context.Context, actorID string, login, disp
 		c.logger.Error("failed to publish user created event", "error", err, "user_id", userID)
 	}
 
-	c.logger.Info("Created user", "id", userID, "login", login)
+	c.logger.Info("Created user", "id", userID)
 
 	return user, nil
 }
@@ -237,7 +237,7 @@ func (c *ChattoCore) CreateVerifiedUser(ctx context.Context, actorID, login, dis
 // rollbackUserCreation undoes the persisted writes performed by CreateUser. Best-effort —
 // failures are logged but not returned, since the caller is already in an error path.
 func (c *ChattoCore) rollbackUserCreation(ctx context.Context, user *corev1.User) {
-	c.logger.Warn("rolling back user creation", "user_id", user.Id, "login", user.Login)
+	c.logger.Warn("rolling back user creation", "user_id", user.Id)
 	_ = c.DeleteUser(ctx, "system:rollback", user.Id)
 }
 
@@ -685,7 +685,7 @@ func (c *ChattoCore) UpdateUserDisplayName(ctx context.Context, userID, displayN
 	}
 	user.DisplayName = displayName
 
-	c.logger.Info("Updated user display name", "id", userID, "displayName", displayName)
+	c.logger.Info("Updated user display name", "id", userID)
 
 	// Publish profile update event
 	c.publishUserProfileUpdate(ctx, userID)
@@ -702,7 +702,7 @@ func (c *ChattoCore) AdminUpdateUserDisplayName(ctx context.Context, userID, dis
 	if err != nil {
 		return nil, err
 	}
-	c.logger.Info("Admin updated user display name", "id", userID, "display_name", displayName)
+	c.logger.Info("Admin updated user display name", "id", userID)
 	return user, nil
 }
 
@@ -730,7 +730,7 @@ func (c *ChattoCore) AdminUpdateUserLogin(ctx context.Context, userID, newLogin 
 	if err != nil {
 		return nil, err
 	}
-	c.logger.Info("Admin updated user login", "id", userID, "new_login", newLogin)
+	c.logger.Info("Admin updated user login", "id", userID)
 	return user, nil
 }
 
@@ -815,7 +815,7 @@ func (c *ChattoCore) applyLoginChange(ctx context.Context, userID, newLogin stri
 	}
 	user.Login = newLogin
 
-	c.logger.Info("Updated user login", "id", userID, "new_login", newLogin)
+	c.logger.Info("Updated user login", "id", userID)
 
 	// Publish profile update event
 	c.publishUserProfileUpdate(ctx, userID)
@@ -938,9 +938,7 @@ func (c *ChattoCore) ValidateAccountDeletionToken(ctx context.Context, token, us
 // This performs GDPR-compliant deletion including removal of message bodies.
 // Authorization: Caller must verify CanDeleteUser(actorID, userID) before calling.
 func (c *ChattoCore) DeleteUser(ctx context.Context, actorID, userID string) error {
-	// Get the user first to get their login for index cleanup
-	user, err := c.GetUser(ctx, userID)
-	if err != nil {
+	if _, err := c.GetUser(ctx, userID); err != nil {
 		return fmt.Errorf("user not found: %w", err)
 	}
 
@@ -1028,7 +1026,7 @@ func (c *ChattoCore) DeleteUser(ctx context.Context, actorID, userID string) err
 		c.logger.Warn("Failed to publish SessionTerminatedEvent", "user_id", userID, "error", err)
 	}
 
-	c.logger.Info("Deleted user account", "id", userID, "login", user.Login)
+	c.logger.Info("Deleted user account", "id", userID)
 
 	return nil
 }

--- a/cli/internal/core/verified_emails.go
+++ b/cli/internal/core/verified_emails.go
@@ -242,10 +242,10 @@ func (c *ChattoCore) addVerifiedEmail(ctx context.Context, userID, email string)
 	if c.config.Owners.IsServerOwnerEmail(email) {
 		if err := c.AssignServerRole(ctx, SystemActorID, userID, RoleOwner); err != nil {
 			c.logger.Warn("Failed to auto-assign owner role on email verification",
-				"user_id", userID, "email", email, "error", err)
+				"user_id", userID, "error", err)
 		} else {
 			c.logger.Info("Auto-promoted user to owner via owners.emails match",
-				"user_id", userID, "email", email)
+				"user_id", userID)
 		}
 	}
 
@@ -319,7 +319,7 @@ func (c *ChattoCore) applyConfigOwners(ctx context.Context) error {
 				return fmt.Errorf("assign owner role to %s: %w", userID, err)
 			}
 			promoted++
-			c.logger.Info("Applied owners.emails owner role", "user_id", userID, "email", ve.Email)
+			c.logger.Info("Applied owners.emails owner role", "user_id", userID)
 			break
 		}
 	}

--- a/cli/internal/http_server/auth.go
+++ b/cli/internal/http_server/auth.go
@@ -144,7 +144,7 @@ func (s *HTTPServer) setupAuthRoutes() {
 			if auditErr := s.core.RecordLoginFailed(ctx, login); auditErr != nil {
 				log.Warn("Failed to append failed-login audit event", "error", auditErr)
 			}
-			log.Error("Login failed", "login", login, "error", err)
+			log.Error("Login failed", "error", err)
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid credentials"})
 			return
 		}
@@ -155,7 +155,7 @@ func (s *HTTPServer) setupAuthRoutes() {
 				if auditErr := s.core.RecordLoginFailed(ctx, login); auditErr != nil {
 					log.Warn("Failed to append stale-login audit event", "error", auditErr)
 				}
-				log.Warn("Login became stale before session creation", "login", login, "userId", user.Id)
+				log.Warn("Login became stale before session creation", "userId", user.Id)
 				c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid credentials"})
 				return
 			}
@@ -183,7 +183,7 @@ func (s *HTTPServer) setupAuthRoutes() {
 				if auditErr := s.core.RecordLoginFailed(ctx, login); auditErr != nil {
 					log.Warn("Failed to append stale-login audit event", "error", auditErr)
 				}
-				log.Warn("Login became stale before bearer token creation", "login", login, "userId", user.Id)
+				log.Warn("Login became stale before bearer token creation", "userId", user.Id)
 				c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid credentials"})
 				return
 			}
@@ -204,7 +204,7 @@ func (s *HTTPServer) setupAuthRoutes() {
 			return
 		}
 
-		log.Info("User logged in successfully", "userId", user.Id, "login", user.Login)
+		log.Info("User logged in successfully", "userId", user.Id)
 
 		response := gin.H{
 			"success": true,
@@ -251,11 +251,11 @@ func (s *HTTPServer) setupAuthRoutes() {
 		// Check if email is already claimed — but always return 200 to prevent enumeration
 		emailClaimed, err := s.core.IsEmailClaimed(ctx, req.Email)
 		if err != nil {
-			log.Error("Failed to check email availability", "email", req.Email, "error", err)
+			log.Error("Failed to check email availability", "error", err)
 		}
 		if emailClaimed {
 			// Don't reveal that the email is taken — just return success
-			log.Info("Registration attempt for already-claimed email", "email", req.Email)
+			log.Info("Registration attempt for already-claimed email")
 			c.JSON(http.StatusOK, gin.H{
 				"message": "If this email is available, you will receive a registration code.",
 			})
@@ -267,13 +267,13 @@ func (s *HTTPServer) setupAuthRoutes() {
 		if err != nil {
 			if errors.Is(err, core.ErrRegistrationCodeLimitExceeded) ||
 				errors.Is(err, core.ErrRegistrationCodeExhausted) {
-				log.Info("Registration code request throttled", "email", req.Email)
+				log.Info("Registration code request throttled")
 				c.JSON(http.StatusOK, gin.H{
 					"message": "If this email is available, you will receive a registration code.",
 				})
 				return
 			}
-			log.Error("Failed to create registration code", "email", req.Email, "error", err)
+			log.Error("Failed to create registration code", "error", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Registration failed"})
 			return
 		}
@@ -286,12 +286,12 @@ func (s *HTTPServer) setupAuthRoutes() {
 			Body:    fmt.Sprintf("Welcome to %s!\n\nUse this verification code to finish creating your account on %s:\n\n%s\n\nThis code will expire in 15 minutes.\n\nIf you didn't request this, you can ignore this email.", serverName, serverName, code),
 		})
 		if err != nil {
-			log.Error("Failed to send registration email", "email", req.Email, "error", err)
+			log.Error("Failed to send registration email", "error", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to send email"})
 			return
 		}
 
-		log.Info("Sent registration email", "email", req.Email)
+		log.Info("Sent registration email")
 		c.JSON(http.StatusOK, gin.H{
 			"message": "If this email is available, you will receive a registration code.",
 		})
@@ -325,7 +325,7 @@ func (s *HTTPServer) setupAuthRoutes() {
 				c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid or expired registration code"})
 				return
 			}
-			log.Error("Failed to verify registration code", "email", req.Email, "error", err)
+			log.Error("Failed to verify registration code", "error", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Registration failed"})
 			return
 		}
@@ -384,7 +384,7 @@ func (s *HTTPServer) setupAuthRoutes() {
 		// Check if login is blocked
 		isBlocked, err := s.core.ConfigManager().IsUsernameBlocked(ctx, req.Login)
 		if err != nil {
-			log.Error("Failed to check blocked usernames", "login", req.Login, "error", err)
+			log.Error("Failed to check blocked usernames", "error", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Registration failed"})
 			return
 		}
@@ -396,7 +396,7 @@ func (s *HTTPServer) setupAuthRoutes() {
 		// Check if email was claimed while token was outstanding
 		emailClaimed, err := s.core.IsEmailClaimed(ctx, tokenData.Email)
 		if err != nil {
-			log.Error("Failed to check email availability", "email", tokenData.Email, "error", err)
+			log.Error("Failed to check email availability", "error", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Registration failed"})
 			return
 		}
@@ -428,7 +428,7 @@ func (s *HTTPServer) setupAuthRoutes() {
 				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 				return
 			}
-			log.Error("Registration failed", "login", req.Login, "error", err)
+			log.Error("Registration failed", "error", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Registration failed"})
 			return
 		}
@@ -448,7 +448,7 @@ func (s *HTTPServer) setupAuthRoutes() {
 			return
 		}
 
-		log.Info("User registered and logged in", "userId", user.Id, "login", user.Login)
+		log.Info("User registered and logged in", "userId", user.Id)
 
 		response := gin.H{
 			"success": true,
@@ -493,7 +493,7 @@ func (s *HTTPServer) setupAuthRoutes() {
 				c.JSON(http.StatusTooManyRequests, gin.H{"error": "Too many verification code requests. Please try again later."})
 				return
 			}
-			log.Error("Failed to create email verification code", "userId", user.Id, "email", body.Email, "error", err)
+			log.Error("Failed to create email verification code", "userId", user.Id, "error", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to send verification code"})
 			return
 		}
@@ -503,7 +503,7 @@ func (s *HTTPServer) setupAuthRoutes() {
 			Subject: fmt.Sprintf("Verify your email for %s", serverName),
 			Body:    fmt.Sprintf("Use this verification code to add this email address to your %s account:\n\n%s\n\nThis code will expire in 15 minutes.\n\nIf you didn't request this, you can ignore this email.", serverName, code),
 		}); err != nil {
-			log.Error("Failed to send email verification code", "userId", user.Id, "email", body.Email, "error", err)
+			log.Error("Failed to send email verification code", "userId", user.Id, "error", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to send verification code"})
 			return
 		}
@@ -542,7 +542,7 @@ func (s *HTTPServer) setupAuthRoutes() {
 				c.JSON(http.StatusConflict, gin.H{"error": "This email address is already in use"})
 				return
 			}
-			log.Error("Email verification failed", "userId", user.Id, "email", body.Email, "error", err)
+			log.Error("Email verification failed", "userId", user.Id, "error", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Email verification failed"})
 			return
 		}
@@ -583,9 +583,9 @@ func (s *HTTPServer) setupAuthRoutes() {
 				Body:    fmt.Sprintf("Hi,\n\nWe received a request to reset the password for your %s account.\n\nClick the link below to set a new password:\n\n%s\n\nThis link will expire in 1 hour.\n\nIf you didn't request this, you can safely ignore this email.", serverName, resetURL),
 			})
 			if err != nil {
-				log.Error("Failed to send password reset email", "email", normalizedEmail, "error", err)
+				log.Error("Failed to send password reset email", "error", err)
 			} else {
-				log.Info("Sent password reset email", "email", normalizedEmail)
+				log.Info("Sent password reset email")
 			}
 		}
 

--- a/cli/internal/http_server/graphql.go
+++ b/cli/internal/http_server/graphql.go
@@ -137,7 +137,7 @@ func (s *HTTPServer) setupGraphQLAPI(allowedOrigins []string) {
 			}
 
 			if user != nil {
-				s.logger.Debug("WebSocket connection authenticated", "userId", user.Id, "login", user.Login)
+				s.logger.Debug("WebSocket connection authenticated", "userId", user.Id)
 			}
 
 			// Create a fresh context for the WebSocket connection WITHOUT dataloaders.

--- a/cli/internal/http_server/oidc.go
+++ b/cli/internal/http_server/oidc.go
@@ -171,7 +171,7 @@ func (s *HTTPServer) setupOIDCRoutes() {
 
 		// Check for error from provider
 		if errCode := c.Query("error"); errCode != "" {
-			log.Warn("OIDC provider returned error", "error", errCode, "description", c.Query("error_description"))
+			log.Warn("OIDC provider returned error", "error", errCode)
 			c.Redirect(http.StatusTemporaryRedirect, "/login?error=oidc_denied")
 			return
 		}
@@ -217,12 +217,12 @@ func (s *HTTPServer) setupOIDCRoutes() {
 			return
 		}
 
-		log.Info("OIDC token verified", "sub", idToken.Subject, "issuer", idToken.Issuer)
+		log.Info("OIDC token verified", "issuer", idToken.Issuer)
 
 		// Some providers (e.g. Zitadel) don't include email in the ID token.
 		// Fall back to the userinfo endpoint.
 		if claims.Email == "" {
-			log.Info("OIDC ID token missing email, falling back to userinfo", "sub", idToken.Subject)
+			log.Info("OIDC ID token missing email, falling back to userinfo")
 			userInfo, err := op.provider.UserInfo(ctx, oauth2.StaticTokenSource(token))
 			if err != nil {
 				log.Error("Failed to fetch OIDC userinfo", "error", err)
@@ -256,15 +256,15 @@ func (s *HTTPServer) setupOIDCRoutes() {
 		}
 
 		if user != nil {
-			log.Info("OIDC login matched by subject", "sub", subject, "userId", user.Id)
+			log.Info("OIDC login matched by subject", "userId", user.Id)
 		} else {
 			// 2. No subject link — try to find existing user by verified email
 			user, _ = s.core.GetUserByVerifiedEmail(ctx, claims.Email)
 
 			if user != nil {
-				log.Info("OIDC login matched by email, linking subject", "sub", subject, "userId", user.Id)
+				log.Info("OIDC login matched by email, linking subject", "userId", user.Id)
 			} else {
-				log.Info("OIDC login creating new user", "sub", subject)
+				log.Info("OIDC login creating new user")
 				// 3. No existing user — create a new one
 				login := deriveLoginFromEmail(claims.Email)
 				displayName := claims.Name
@@ -288,9 +288,9 @@ func (s *HTTPServer) setupOIDCRoutes() {
 
 			// Link the OIDC subject to this user for future logins
 			if err := s.core.LinkOIDCSubject(ctx, issuer, subject, user.Id); err != nil {
-				log.Error("Failed to link OIDC subject", "error", err, "userId", user.Id, "subject", subject)
+				log.Error("Failed to link OIDC subject", "error", err, "userId", user.Id)
 			} else {
-				log.Info("Linked OIDC subject to user", "userId", user.Id, "subject", subject)
+				log.Info("Linked OIDC subject to user", "userId", user.Id)
 			}
 		}
 

--- a/cli/internal/http_server/request_logger_test.go
+++ b/cli/internal/http_server/request_logger_test.go
@@ -45,7 +45,18 @@ func TestRequestLoggerUsesConfiguredFormatter(t *testing.T) {
 	assertLogField(t, line, "msg", "HTTP request")
 	assertLogField(t, line, "method", http.MethodGet)
 	assertLogField(t, line, "path", "/missing")
-	assertLogField(t, line, "query", "asset=avatar")
+	if got := line["query_present"]; got != true {
+		t.Fatalf("query_present field = %v, want true", got)
+	}
+	if _, ok := line["query"]; ok {
+		t.Fatalf("request log should not include raw query string: %v", line["query"])
+	}
+	if got := line["client_ip_present"]; got != true {
+		t.Fatalf("client_ip_present field = %v, want true", got)
+	}
+	if _, ok := line["client_ip"]; ok {
+		t.Fatalf("request log should not include raw client IP: %v", line["client_ip"])
+	}
 	assertLogField(t, line, "user_agent", "chatto-test")
 
 	if got := line["status"]; got != float64(http.StatusNotFound) {

--- a/cli/internal/http_server/server.go
+++ b/cli/internal/http_server/server.go
@@ -106,7 +106,7 @@ func requestLogger(logger *log.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		start := time.Now()
 		path := c.Request.URL.Path
-		query := c.Request.URL.RawQuery
+		hasQuery := c.Request.URL.RawQuery != ""
 
 		c.Next()
 
@@ -116,15 +116,15 @@ func requestLogger(logger *log.Logger) gin.HandlerFunc {
 			"method", c.Request.Method,
 			"path", path,
 			"latency", time.Since(start).String(),
-			"client_ip", c.ClientIP(),
+			"client_ip_present", c.ClientIP() != "",
 			"user_agent", c.Request.UserAgent(),
 			"bytes", c.Writer.Size(),
 		}
-		if query != "" {
-			fields = append(fields, "query", query)
+		if hasQuery {
+			fields = append(fields, "query_present", true)
 		}
 		if len(c.Errors) > 0 {
-			fields = append(fields, "errors", c.Errors.ByType(gin.ErrorTypePrivate).String())
+			fields = append(fields, "error_count", len(c.Errors.ByType(gin.ErrorTypePrivate)))
 		}
 
 		switch {

--- a/cli/internal/http_server/test_endpoints.go
+++ b/cli/internal/http_server/test_endpoints.go
@@ -282,7 +282,7 @@ func registerTestEndpoints(auth *gin.RouterGroup, s *HTTPServer) {
 					log.Warn("Failed to auto-verify OAuth email", "error", err, "userId", newUser.Id)
 					// Don't fail - continue with login
 				} else {
-					log.Info("Auto-verified OAuth email", "userId", newUser.Id, "email", req.Email)
+					log.Info("Auto-verified OAuth email", "userId", newUser.Id)
 				}
 			}
 


### PR DESCRIPTION
## Changes

- Removes raw login, email, display-name, OIDC subject, query string, client IP, and raw Gin error details from backend, access, bootstrap, and test-helper logs.
- Keeps safe operational context through opaque Chatto user IDs, counts, booleans, and event messages.
- Documents the no-PII logging rule in `AGENTS.md` and `.claude/rules/general.md`.

## Tests

- `mise x -- go test -tags test_endpoints ./internal/http_server -run 'TestRequestLoggerUsesConfiguredFormatter|TestLogin|TestPassword|TestRegistration|TestEmail|TestOIDC|TestAuth' -count=1`
- `mise x -- go test ./internal/core -run 'TestChattoCore_LoginAndLogoutAuditEvents|TestUserPII|Test.*User|Test.*Email|Test.*Owner|Test.*Delete' -count=1`
- `mise x -- go test -tags bootstrap ./cmd -run TestBootstrap -count=1`
