### PR TITLE
fix: attribute RBAC audit events to actors

### DIFF
--- a/cli/cmd/bootstrap_apply.go
+++ b/cli/cmd/bootstrap_apply.go
@@ -268,7 +268,7 @@ func applyBootstrapServer(ctx context.Context, logger *log.Logger, c *core.Chatt
 	// rooms via the API without per-test permission setup. This file is
 	// behind a `bootstrap` build tag, so production binaries never run this
 	// code and `everyone` does not get room.create on real deployments.
-	if err := c.GrantServerPermission(ctx, core.RoleEveryone, core.PermRoomCreate); err != nil {
+	if err := c.GrantServerPermission(ctx, core.SystemActorID, core.RoleEveryone, core.PermRoomCreate); err != nil {
 		logger.Warn("Failed to grant room.create to everyone on bootstrap server", "error", err)
 	}
 	return true

--- a/cli/internal/core/can_test.go
+++ b/cli/internal/core/can_test.go
@@ -170,10 +170,10 @@ func TestCanDeleteUser(t *testing.T) {
 
 	t.Run("self-deletion denied when user.delete.self permission is revoked", func(t *testing.T) {
 		// Create a custom role that denies self-deletion
-		if _, err := core.CreateServerRole(ctx, "selfdelete-denied", "No Self Delete", ""); err != nil {
+		if _, err := core.CreateServerRole(ctx, SystemActorID, "selfdelete-denied", "No Self Delete", ""); err != nil {
 			t.Fatalf("failed to create role: %v", err)
 		}
-		if err := core.DenyServerPermission(ctx, "selfdelete-denied", PermUserDeleteSelf); err != nil {
+		if err := core.DenyServerPermission(ctx, SystemActorID, "selfdelete-denied", PermUserDeleteSelf); err != nil {
 			t.Fatalf("failed to deny permission: %v", err)
 		}
 
@@ -214,13 +214,13 @@ func TestPermissionsWithCustomRoles(t *testing.T) {
 	ctx := testContext(t)
 
 	// Create a custom role with limited admin permissions
-	customRole, err := core.CreateServerRole(ctx, "viewer", "Viewer Admin", "Can only view admin pages")
+	customRole, err := core.CreateServerRole(ctx, SystemActorID, "viewer", "Viewer Admin", "Can only view admin pages")
 	if err != nil {
 		t.Fatalf("failed to create custom role: %v", err)
 	}
 
 	// Grant only a concrete admin view permission.
-	err = core.GrantServerPermission(ctx, customRole.Name, PermAdminUsersView)
+	err = core.GrantServerPermission(ctx, SystemActorID, customRole.Name, PermAdminUsersView)
 	if err != nil {
 		t.Fatalf("failed to grant users view permission: %v", err)
 	}
@@ -391,7 +391,7 @@ func TestCanHelpers_RevokedMemberPermission(t *testing.T) {
 	// Grant and then revoke rooms.create from the everyone role
 	t.Run("grant then revoke rooms.create from everyone role", func(t *testing.T) {
 		// First grant room.create to everyone role (since it's not granted by default)
-		err := core.GrantServerPermission(ctx, RoleEveryone, PermRoomCreate)
+		err := core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, PermRoomCreate)
 		if err != nil {
 			t.Fatalf("failed to grant permission: %v", err)
 		}
@@ -406,7 +406,7 @@ func TestCanHelpers_RevokedMemberPermission(t *testing.T) {
 		}
 
 		// Now revoke it
-		err = core.RevokeServerPermission(ctx, RoleEveryone, PermRoomCreate)
+		err = core.RevokeServerPermission(ctx, SystemActorID, RoleEveryone, PermRoomCreate)
 		if err != nil {
 			t.Fatalf("failed to revoke permission: %v", err)
 		}
@@ -432,7 +432,7 @@ func TestCanHelpers_RevokedMemberPermission(t *testing.T) {
 
 	// Revoke rooms.join from the everyone role
 	t.Run("revoke rooms.join from everyone role", func(t *testing.T) {
-		err := core.RevokeServerPermission(ctx, RoleEveryone, PermRoomJoin)
+		err := core.RevokeServerPermission(ctx, SystemActorID, RoleEveryone, PermRoomJoin)
 		if err != nil {
 			t.Fatalf("failed to revoke permission: %v", err)
 		}
@@ -478,10 +478,10 @@ func TestCanHelpers_RoomOverrides(t *testing.T) {
 	}
 	t.Run("CanPostMessage respects room-level denial", func(t *testing.T) {
 		// Ensure space grants message.post
-		core.GrantServerPermission(ctx, RoleEveryone, PermMessagePost)
+		core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost)
 
 		// Deny at room level
-		core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
+		core.DenyRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermMessagePost)
 
 		can, err := core.CanPostMessage(ctx, member.Id, KindChannel, room.Id)
 		if err != nil {
@@ -492,15 +492,15 @@ func TestCanHelpers_RoomOverrides(t *testing.T) {
 		}
 
 		// Cleanup
-		core.ClearRoomPermissionState(ctx, room.Id, RoleEveryone, PermMessagePost)
+		core.ClearRoomPermissionState(ctx, SystemActorID, room.Id, RoleEveryone, PermMessagePost)
 	})
 
 	t.Run("CanPostInThread respects room-level denial", func(t *testing.T) {
 		// Ensure space grants message.post-in-thread
-		core.GrantServerPermission(ctx, RoleEveryone, PermMessagePostInThread)
+		core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePostInThread)
 
 		// Deny at room level
-		core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePostInThread)
+		core.DenyRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermMessagePostInThread)
 
 		can, err := core.CanPostInThread(ctx, member.Id, KindChannel, room.Id)
 		if err != nil {
@@ -511,15 +511,15 @@ func TestCanHelpers_RoomOverrides(t *testing.T) {
 		}
 
 		// Cleanup
-		core.ClearRoomPermissionState(ctx, room.Id, RoleEveryone, PermMessagePostInThread)
+		core.ClearRoomPermissionState(ctx, SystemActorID, room.Id, RoleEveryone, PermMessagePostInThread)
 	})
 
 	t.Run("CanReactToMessage respects room-level grant", func(t *testing.T) {
 		// Clear message.react from everyone at space level
-		core.ClearServerPermissionState(ctx, RoleEveryone, PermMessageReact)
+		core.ClearServerPermissionState(ctx, SystemActorID, RoleEveryone, PermMessageReact)
 
 		// Grant at room level
-		core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessageReact)
+		core.GrantRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermMessageReact)
 
 		can, err := core.CanReactToMessage(ctx, member.Id, KindChannel, room.Id)
 		if err != nil {
@@ -530,12 +530,12 @@ func TestCanHelpers_RoomOverrides(t *testing.T) {
 		}
 
 		// Cleanup
-		core.ClearRoomPermissionState(ctx, room.Id, RoleEveryone, PermMessageReact)
+		core.ClearRoomPermissionState(ctx, SystemActorID, room.Id, RoleEveryone, PermMessageReact)
 	})
 
 	t.Run("CanManageOthersMessage respects room-level grant", func(t *testing.T) {
 		// Grant message.manage at room level.
-		core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessageManage)
+		core.GrantRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermMessageManage)
 
 		can, err := core.CanManageOthersMessage(ctx, member.Id, KindChannel, room.Id)
 		if err != nil {
@@ -546,7 +546,7 @@ func TestCanHelpers_RoomOverrides(t *testing.T) {
 		}
 
 		// Cleanup
-		core.ClearRoomPermissionState(ctx, room.Id, RoleEveryone, PermMessageManage)
+		core.ClearRoomPermissionState(ctx, SystemActorID, room.Id, RoleEveryone, PermMessageManage)
 	})
 }
 

--- a/cli/internal/core/event_publishing_test.go
+++ b/cli/internal/core/event_publishing_test.go
@@ -323,7 +323,7 @@ func TestStreamMyEvents_DeliversDMEventsWhenMessagePostDenied(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateUser target: %v", err)
 	}
-	if err := core.DenyServerPermission(ctx, RoleEveryone, PermMessagePost); err != nil {
+	if err := core.DenyServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost); err != nil {
 		t.Fatalf("DenyServerPermission message.post: %v", err)
 	}
 	canPostMessage, err := core.HasServerPermission(ctx, target.Id, PermMessagePost)

--- a/cli/internal/core/mentions_test.go
+++ b/cli/internal/core/mentions_test.go
@@ -293,10 +293,10 @@ func TestChattoCore_ResolveRoomMentions(t *testing.T) {
 	if err := core.AssignServerRole(ctx, SystemActorID, moderatorUser.Id, RoleModerator); err != nil {
 		t.Fatalf("AssignServerRole moderatorUser: %v", err)
 	}
-	if _, err := core.CreateServerRole(ctx, "support", "Support", "Support team", true); err != nil {
+	if _, err := core.CreateServerRole(ctx, SystemActorID, "support", "Support", "Support team", true); err != nil {
 		t.Fatalf("CreateServerRole: %v", err)
 	}
-	if _, err := core.CreateServerRole(ctx, "quiet", "Quiet", "Quiet team"); err != nil {
+	if _, err := core.CreateServerRole(ctx, SystemActorID, "quiet", "Quiet", "Quiet team"); err != nil {
 		t.Fatalf("CreateServerRole quiet: %v", err)
 	}
 	if err := core.AssignServerRole(ctx, SystemActorID, roleUser.Id, "support"); err != nil {

--- a/cli/internal/core/permission_cascade_test.go
+++ b/cli/internal/core/permission_cascade_test.go
@@ -13,7 +13,7 @@ func TestCanCreateRoom_GroupTier(t *testing.T) {
 
 	// Clear the seeded everyone defaults so the test starts from a known
 	// state: no role has room.create at any scope.
-	if err := core.ClearServerPermissionState(ctx, RoleEveryone, PermRoomCreate); err != nil {
+	if err := core.ClearServerPermissionState(ctx, SystemActorID, RoleEveryone, PermRoomCreate); err != nil {
 		t.Fatalf("ClearServerPermissionState: %v", err)
 	}
 
@@ -46,11 +46,11 @@ func TestCanCreateRoom_GroupTier(t *testing.T) {
 	}
 
 	t.Run("server-scope grant allows creating in any group", func(t *testing.T) {
-		if err := core.GrantServerPermission(ctx, RoleEveryone, PermRoomCreate); err != nil {
+		if err := core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, PermRoomCreate); err != nil {
 			t.Fatalf("GrantServerPermission: %v", err)
 		}
 		t.Cleanup(func() {
-			_ = core.ClearServerPermissionState(ctx, RoleEveryone, PermRoomCreate)
+			_ = core.ClearServerPermissionState(ctx, SystemActorID, RoleEveryone, PermRoomCreate)
 		})
 
 		for _, gid := range []string{primaryGroupID, otherGroup.Id} {
@@ -73,11 +73,11 @@ func TestCanCreateRoom_GroupTier(t *testing.T) {
 	})
 
 	t.Run("group-only grant scopes creation to that group", func(t *testing.T) {
-		if err := core.GrantGroupPermission(ctx, primaryGroupID, RoleEveryone, PermRoomCreate); err != nil {
+		if err := core.GrantGroupPermission(ctx, SystemActorID, primaryGroupID, RoleEveryone, PermRoomCreate); err != nil {
 			t.Fatalf("GrantGroupPermission: %v", err)
 		}
 		t.Cleanup(func() {
-			_ = core.ClearGroupPermissionState(ctx, primaryGroupID, RoleEveryone, PermRoomCreate)
+			_ = core.ClearGroupPermissionState(ctx, SystemActorID, primaryGroupID, RoleEveryone, PermRoomCreate)
 		})
 
 		can, err := core.CanCreateRoom(ctx, member.Id, KindChannel, primaryGroupID)
@@ -98,17 +98,17 @@ func TestCanCreateRoom_GroupTier(t *testing.T) {
 	})
 
 	t.Run("group-scope deny overrides server-scope allow", func(t *testing.T) {
-		if err := core.GrantServerPermission(ctx, RoleEveryone, PermRoomCreate); err != nil {
+		if err := core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, PermRoomCreate); err != nil {
 			t.Fatalf("GrantServerPermission: %v", err)
 		}
 		t.Cleanup(func() {
-			_ = core.ClearServerPermissionState(ctx, RoleEveryone, PermRoomCreate)
+			_ = core.ClearServerPermissionState(ctx, SystemActorID, RoleEveryone, PermRoomCreate)
 		})
-		if err := core.DenyGroupPermission(ctx, primaryGroupID, RoleEveryone, PermRoomCreate); err != nil {
+		if err := core.DenyGroupPermission(ctx, SystemActorID, primaryGroupID, RoleEveryone, PermRoomCreate); err != nil {
 			t.Fatalf("DenyGroupPermission: %v", err)
 		}
 		t.Cleanup(func() {
-			_ = core.ClearGroupPermissionState(ctx, primaryGroupID, RoleEveryone, PermRoomCreate)
+			_ = core.ClearGroupPermissionState(ctx, SystemActorID, primaryGroupID, RoleEveryone, PermRoomCreate)
 		})
 
 		can, err := core.CanCreateRoom(ctx, member.Id, KindChannel, primaryGroupID)
@@ -132,11 +132,11 @@ func TestCanCreateRoom_GroupTier(t *testing.T) {
 
 	t.Run("empty groupID falls back to pure server-scope check", func(t *testing.T) {
 		// Grant only at primary group; no server-scope grant.
-		if err := core.GrantGroupPermission(ctx, primaryGroupID, RoleEveryone, PermRoomCreate); err != nil {
+		if err := core.GrantGroupPermission(ctx, SystemActorID, primaryGroupID, RoleEveryone, PermRoomCreate); err != nil {
 			t.Fatalf("GrantGroupPermission: %v", err)
 		}
 		t.Cleanup(func() {
-			_ = core.ClearGroupPermissionState(ctx, primaryGroupID, RoleEveryone, PermRoomCreate)
+			_ = core.ClearGroupPermissionState(ctx, SystemActorID, primaryGroupID, RoleEveryone, PermRoomCreate)
 		})
 
 		can, err := core.CanCreateRoom(ctx, member.Id, KindChannel, "")
@@ -170,10 +170,10 @@ func TestServerTierCascadeIntoChannelRooms(t *testing.T) {
 	// Pick a permission and start from a clean slate at every tier so the
 	// cascade chain is the only mechanism that could allow.
 	const perm = PermMessageReact
-	if err := core.ClearGroupPermissionState(ctx, groupID, RoleEveryone, perm); err != nil {
+	if err := core.ClearGroupPermissionState(ctx, SystemActorID, groupID, RoleEveryone, perm); err != nil {
 		t.Fatalf("ClearGroupPermissionState: %v", err)
 	}
-	if err := core.ClearServerPermissionState(ctx, RoleEveryone, perm); err != nil {
+	if err := core.ClearServerPermissionState(ctx, SystemActorID, RoleEveryone, perm); err != nil {
 		t.Fatalf("ClearServerPermissionState: %v", err)
 	}
 
@@ -187,11 +187,11 @@ func TestServerTierCascadeIntoChannelRooms(t *testing.T) {
 	}
 
 	t.Run("server-scope grant cascades into the channel room", func(t *testing.T) {
-		if err := core.GrantServerPermission(ctx, RoleEveryone, perm); err != nil {
+		if err := core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, perm); err != nil {
 			t.Fatalf("GrantServerPermission: %v", err)
 		}
 		t.Cleanup(func() {
-			_ = core.ClearServerPermissionState(ctx, RoleEveryone, perm)
+			_ = core.ClearServerPermissionState(ctx, SystemActorID, RoleEveryone, perm)
 		})
 
 		has, err := core.permissionResolver.HasRoomPermission(ctx, member.Id, KindChannel, room.Id, perm)
@@ -204,17 +204,17 @@ func TestServerTierCascadeIntoChannelRooms(t *testing.T) {
 	})
 
 	t.Run("group-scope deny wins over server-scope allow (same role)", func(t *testing.T) {
-		if err := core.GrantServerPermission(ctx, RoleEveryone, perm); err != nil {
+		if err := core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, perm); err != nil {
 			t.Fatalf("GrantServerPermission: %v", err)
 		}
 		t.Cleanup(func() {
-			_ = core.ClearServerPermissionState(ctx, RoleEveryone, perm)
+			_ = core.ClearServerPermissionState(ctx, SystemActorID, RoleEveryone, perm)
 		})
-		if err := core.DenyGroupPermission(ctx, groupID, RoleEveryone, perm); err != nil {
+		if err := core.DenyGroupPermission(ctx, SystemActorID, groupID, RoleEveryone, perm); err != nil {
 			t.Fatalf("DenyGroupPermission: %v", err)
 		}
 		t.Cleanup(func() {
-			_ = core.ClearGroupPermissionState(ctx, groupID, RoleEveryone, perm)
+			_ = core.ClearGroupPermissionState(ctx, SystemActorID, groupID, RoleEveryone, perm)
 		})
 
 		has, err := core.permissionResolver.HasRoomPermission(ctx, member.Id, KindChannel, room.Id, perm)

--- a/cli/internal/core/permission_explainer_test.go
+++ b/cli/internal/core/permission_explainer_test.go
@@ -27,10 +27,10 @@ func TestPermissionExplainer_AgreesWithHas(t *testing.T) {
 		t.Fatalf("assign admin role: %v", err)
 	}
 	denyUser, _ := core.CreateUser(ctx, SystemActorID, "denyuser", "Deny User", "password123")
-	if _, err := core.CreateServerRole(ctx, "denytest", "Deny message.post", "Test deny role"); err != nil {
+	if _, err := core.CreateServerRole(ctx, SystemActorID, "denytest", "Deny message.post", "Test deny role"); err != nil {
 		t.Fatalf("create deny role: %v", err)
 	}
-	if err := core.DenyServerPermission(ctx, "denytest", PermMessagePost); err != nil {
+	if err := core.DenyServerPermission(ctx, SystemActorID, "denytest", PermMessagePost); err != nil {
 		t.Fatalf("deny perm: %v", err)
 	}
 	if err := core.AssignServerRole(ctx, SystemActorID, denyUser.Id, "denytest"); err != nil {
@@ -50,7 +50,7 @@ func TestPermissionExplainer_AgreesWithHas(t *testing.T) {
 
 	// Room-level override: deny message.post for the everyone space role in this
 	// room. Higher-rank roles (owner) should still post via the hierarchy walk.
-	if err := core.DenyRoomPermission(ctx, room.Id, "everyone", PermMessagePost); err != nil {
+	if err := core.DenyRoomPermission(ctx, SystemActorID, room.Id, "everyone", PermMessagePost); err != nil {
 		t.Fatalf("deny room perm: %v", err)
 	}
 
@@ -200,7 +200,7 @@ func TestPermissionExplainer_UserLevelTrace(t *testing.T) {
 	user, _ := core.CreateUser(ctx, SystemActorID, "explainer-user-level", "User", "password123")
 
 	t.Run("server-level user grant appears in trace", func(t *testing.T) {
-		if err := core.GrantUserPermission(ctx, user.Id, PermAdminUsersView); err != nil {
+		if err := core.GrantUserPermission(ctx, SystemActorID, user.Id, PermAdminUsersView); err != nil {
 			t.Fatalf("GrantUserPermission: %v", err)
 		}
 		exp, err := core.permissionResolver.ExplainServerPermission(ctx, user.Id, PermAdminUsersView)
@@ -224,7 +224,7 @@ func TestPermissionExplainer_UserLevelTrace(t *testing.T) {
 
 	t.Run("server-level user deny appears in trace", func(t *testing.T) {
 		other, _ := core.CreateUser(ctx, SystemActorID, "explainer-user-deny", "Other", "password123")
-		if err := core.DenyUserPermission(ctx, other.Id, PermMessagePost); err != nil {
+		if err := core.DenyUserPermission(ctx, SystemActorID, other.Id, PermMessagePost); err != nil {
 			t.Fatalf("DenyUserPermission: %v", err)
 		}
 		exp, err := core.permissionResolver.ExplainServerPermission(ctx, other.Id, PermMessagePost)
@@ -242,7 +242,7 @@ func TestPermissionExplainer_UserLevelTrace(t *testing.T) {
 	t.Run("room-scoped user grant appears in trace at LevelRoom", func(t *testing.T) {
 		roomUser, _ := core.CreateUser(ctx, SystemActorID, "explainer-room-user", "Room User", "password123")
 		room, _ := core.CreateRoom(ctx, SystemActorID, KindChannel, "", "explainer-room", "Room")
-		if err := core.GrantUserRoomPermission(ctx, room.Id, roomUser.Id, PermMessageManage); err != nil {
+		if err := core.GrantUserRoomPermission(ctx, SystemActorID, room.Id, roomUser.Id, PermMessageManage); err != nil {
 			t.Fatalf("GrantUserRoomPermission: %v", err)
 		}
 		exp, err := core.permissionResolver.ExplainRoomPermission(ctx, roomUser.Id, KindChannel, room.Id, PermMessageManage)

--- a/cli/internal/core/permission_ops.go
+++ b/cli/internal/core/permission_ops.go
@@ -26,11 +26,11 @@ import (
 // ----------------------------------------------------------------------------
 
 // GrantServerPermission grants a permission to a role's server-level default.
-func (c *ChattoCore) GrantServerPermission(ctx context.Context, roleName string, perm Permission) error {
+func (c *ChattoCore) GrantServerPermission(ctx context.Context, actorID, roleName string, perm Permission) error {
 	if err := ValidatePermission(perm); err != nil {
 		return err
 	}
-	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionGranted{
+	event := newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacPermissionGranted{
 		RbacPermissionGranted: rbacRolePermissionGrantedEvent(ScopeServer, "", roleName, perm),
 	}})
 	_, err := c.appendRBACEvent(ctx, event, func() error {
@@ -46,11 +46,11 @@ func (c *ChattoCore) GrantServerPermission(ctx context.Context, roleName string,
 }
 
 // DenyServerPermission denies a permission at a role's server-level default.
-func (c *ChattoCore) DenyServerPermission(ctx context.Context, roleName string, perm Permission) error {
+func (c *ChattoCore) DenyServerPermission(ctx context.Context, actorID, roleName string, perm Permission) error {
 	if err := ValidatePermission(perm); err != nil {
 		return err
 	}
-	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionDenied{
+	event := newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacPermissionDenied{
 		RbacPermissionDenied: rbacRolePermissionDeniedEvent(ScopeServer, "", roleName, perm),
 	}})
 	_, err := c.appendRBACEvent(ctx, event, nil)
@@ -58,8 +58,8 @@ func (c *ChattoCore) DenyServerPermission(ctx context.Context, roleName string, 
 }
 
 // ClearServerPermissionState clears both grant and denial for a permission.
-func (c *ChattoCore) ClearServerPermissionState(ctx context.Context, roleName string, perm Permission) error {
-	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionCleared{
+func (c *ChattoCore) ClearServerPermissionState(ctx context.Context, actorID, roleName string, perm Permission) error {
+	event := newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacPermissionCleared{
 		RbacPermissionCleared: rbacRolePermissionClearedEvent(ScopeServer, "", roleName, perm),
 	}})
 	_, err := c.appendRBACEvent(ctx, event, nil)
@@ -76,11 +76,11 @@ func (c *ChattoCore) ClearServerPermissionState(ctx context.Context, roleName st
 // user-grant allows it even when no role grants it.
 
 // GrantUserPermission grants a permission directly to a user at server scope.
-func (c *ChattoCore) GrantUserPermission(ctx context.Context, userID string, perm Permission) error {
+func (c *ChattoCore) GrantUserPermission(ctx context.Context, actorID, userID string, perm Permission) error {
 	if err := ValidatePermission(perm); err != nil {
 		return err
 	}
-	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionGranted{
+	event := newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacPermissionGranted{
 		RbacPermissionGranted: rbacUserPermissionGrantedEvent(ScopeServer, "", userID, perm),
 	}})
 	_, err := c.appendRBACEvent(ctx, event, nil)
@@ -88,11 +88,11 @@ func (c *ChattoCore) GrantUserPermission(ctx context.Context, userID string, per
 }
 
 // DenyUserPermission denies a permission directly to a user at server scope.
-func (c *ChattoCore) DenyUserPermission(ctx context.Context, userID string, perm Permission) error {
+func (c *ChattoCore) DenyUserPermission(ctx context.Context, actorID, userID string, perm Permission) error {
 	if err := ValidatePermission(perm); err != nil {
 		return err
 	}
-	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionDenied{
+	event := newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacPermissionDenied{
 		RbacPermissionDenied: rbacUserPermissionDeniedEvent(ScopeServer, "", userID, perm),
 	}})
 	_, err := c.appendRBACEvent(ctx, event, nil)
@@ -101,8 +101,8 @@ func (c *ChattoCore) DenyUserPermission(ctx context.Context, userID string, perm
 
 // ClearUserPermissionState clears both the grant and denial for a user-level
 // permission at server scope.
-func (c *ChattoCore) ClearUserPermissionState(ctx context.Context, userID string, perm Permission) error {
-	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionCleared{
+func (c *ChattoCore) ClearUserPermissionState(ctx context.Context, actorID, userID string, perm Permission) error {
+	event := newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacPermissionCleared{
 		RbacPermissionCleared: rbacUserPermissionClearedEvent(ScopeServer, "", userID, perm),
 	}})
 	_, err := c.appendRBACEvent(ctx, event, nil)
@@ -110,11 +110,11 @@ func (c *ChattoCore) ClearUserPermissionState(ctx context.Context, userID string
 }
 
 // GrantUserRoomPermission grants a permission directly to a user for a specific room.
-func (c *ChattoCore) GrantUserRoomPermission(ctx context.Context, roomID, userID string, perm Permission) error {
+func (c *ChattoCore) GrantUserRoomPermission(ctx context.Context, actorID, roomID, userID string, perm Permission) error {
 	if !PermissionAppliesAtScope(perm, ScopeRoom) {
 		return fmt.Errorf("permission %s does not apply at room scope", perm)
 	}
-	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionGranted{
+	event := newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacPermissionGranted{
 		RbacPermissionGranted: rbacUserPermissionGrantedEvent(ScopeRoom, roomID, userID, perm),
 	}})
 	_, err := c.appendRBACEvent(ctx, event, nil)
@@ -122,11 +122,11 @@ func (c *ChattoCore) GrantUserRoomPermission(ctx context.Context, roomID, userID
 }
 
 // DenyUserRoomPermission denies a permission directly to a user for a specific room.
-func (c *ChattoCore) DenyUserRoomPermission(ctx context.Context, roomID, userID string, perm Permission) error {
+func (c *ChattoCore) DenyUserRoomPermission(ctx context.Context, actorID, roomID, userID string, perm Permission) error {
 	if !PermissionAppliesAtScope(perm, ScopeRoom) {
 		return fmt.Errorf("permission %s does not apply at room scope", perm)
 	}
-	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionDenied{
+	event := newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacPermissionDenied{
 		RbacPermissionDenied: rbacUserPermissionDeniedEvent(ScopeRoom, roomID, userID, perm),
 	}})
 	_, err := c.appendRBACEvent(ctx, event, nil)
@@ -135,8 +135,8 @@ func (c *ChattoCore) DenyUserRoomPermission(ctx context.Context, roomID, userID 
 
 // ClearUserRoomPermissionState clears both the grant and denial for a
 // user-level permission for a specific room.
-func (c *ChattoCore) ClearUserRoomPermissionState(ctx context.Context, roomID, userID string, perm Permission) error {
-	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionCleared{
+func (c *ChattoCore) ClearUserRoomPermissionState(ctx context.Context, actorID, roomID, userID string, perm Permission) error {
+	event := newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacPermissionCleared{
 		RbacPermissionCleared: rbacUserPermissionClearedEvent(ScopeRoom, roomID, userID, perm),
 	}})
 	_, err := c.appendRBACEvent(ctx, event, nil)
@@ -145,11 +145,11 @@ func (c *ChattoCore) ClearUserRoomPermissionState(ctx context.Context, roomID, u
 
 // GrantUserGroupPermission grants a permission directly to a user at a room
 // group's scope.
-func (c *ChattoCore) GrantUserGroupPermission(ctx context.Context, groupID, userID string, perm Permission) error {
+func (c *ChattoCore) GrantUserGroupPermission(ctx context.Context, actorID, groupID, userID string, perm Permission) error {
 	if !PermissionAppliesAtScope(perm, ScopeGroup) && !PermissionAppliesAtScope(perm, ScopeRoom) {
 		return fmt.Errorf("permission %s does not apply at group scope", perm)
 	}
-	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionGranted{
+	event := newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacPermissionGranted{
 		RbacPermissionGranted: rbacUserPermissionGrantedEvent(ScopeGroup, groupID, userID, perm),
 	}})
 	_, err := c.appendRBACEvent(ctx, event, nil)
@@ -158,11 +158,11 @@ func (c *ChattoCore) GrantUserGroupPermission(ctx context.Context, groupID, user
 
 // DenyUserGroupPermission denies a permission directly to a user at a room
 // group's scope.
-func (c *ChattoCore) DenyUserGroupPermission(ctx context.Context, groupID, userID string, perm Permission) error {
+func (c *ChattoCore) DenyUserGroupPermission(ctx context.Context, actorID, groupID, userID string, perm Permission) error {
 	if !PermissionAppliesAtScope(perm, ScopeGroup) && !PermissionAppliesAtScope(perm, ScopeRoom) {
 		return fmt.Errorf("permission %s does not apply at group scope", perm)
 	}
-	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionDenied{
+	event := newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacPermissionDenied{
 		RbacPermissionDenied: rbacUserPermissionDeniedEvent(ScopeGroup, groupID, userID, perm),
 	}})
 	_, err := c.appendRBACEvent(ctx, event, nil)
@@ -171,8 +171,8 @@ func (c *ChattoCore) DenyUserGroupPermission(ctx context.Context, groupID, userI
 
 // ClearUserGroupPermissionState clears both the grant and denial for a
 // user-level permission at a specific room group's scope.
-func (c *ChattoCore) ClearUserGroupPermissionState(ctx context.Context, groupID, userID string, perm Permission) error {
-	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionCleared{
+func (c *ChattoCore) ClearUserGroupPermissionState(ctx context.Context, actorID, groupID, userID string, perm Permission) error {
+	event := newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacPermissionCleared{
 		RbacPermissionCleared: rbacUserPermissionClearedEvent(ScopeGroup, groupID, userID, perm),
 	}})
 	_, err := c.appendRBACEvent(ctx, event, nil)
@@ -184,11 +184,11 @@ func (c *ChattoCore) ClearUserGroupPermissionState(ctx context.Context, groupID,
 // ----------------------------------------------------------------------------
 
 // GrantRoomPermission grants a permission to a role for a specific room.
-func (c *ChattoCore) GrantRoomPermission(ctx context.Context, roomID, roleName string, perm Permission) error {
+func (c *ChattoCore) GrantRoomPermission(ctx context.Context, actorID, roomID, roleName string, perm Permission) error {
 	if !PermissionAppliesAtScope(perm, ScopeRoom) {
 		return fmt.Errorf("permission %s does not apply at room scope", perm)
 	}
-	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionGranted{
+	event := newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacPermissionGranted{
 		RbacPermissionGranted: rbacRolePermissionGrantedEvent(ScopeRoom, roomID, roleName, perm),
 	}})
 	_, err := c.appendRBACEvent(ctx, event, nil)
@@ -196,11 +196,11 @@ func (c *ChattoCore) GrantRoomPermission(ctx context.Context, roomID, roleName s
 }
 
 // DenyRoomPermission denies a permission for a role at a specific room.
-func (c *ChattoCore) DenyRoomPermission(ctx context.Context, roomID, roleName string, perm Permission) error {
+func (c *ChattoCore) DenyRoomPermission(ctx context.Context, actorID, roomID, roleName string, perm Permission) error {
 	if !PermissionAppliesAtScope(perm, ScopeRoom) {
 		return fmt.Errorf("permission %s does not apply at room scope", perm)
 	}
-	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionDenied{
+	event := newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacPermissionDenied{
 		RbacPermissionDenied: rbacRolePermissionDeniedEvent(ScopeRoom, roomID, roleName, perm),
 	}})
 	_, err := c.appendRBACEvent(ctx, event, nil)
@@ -209,8 +209,8 @@ func (c *ChattoCore) DenyRoomPermission(ctx context.Context, roomID, roleName st
 
 // ClearRoomPermissionState removes both grant and denial for a permission at
 // room level.
-func (c *ChattoCore) ClearRoomPermissionState(ctx context.Context, roomID, roleName string, perm Permission) error {
-	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionCleared{
+func (c *ChattoCore) ClearRoomPermissionState(ctx context.Context, actorID, roomID, roleName string, perm Permission) error {
+	event := newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacPermissionCleared{
 		RbacPermissionCleared: rbacRolePermissionClearedEvent(ScopeRoom, roomID, roleName, perm),
 	}})
 	_, err := c.appendRBACEvent(ctx, event, nil)
@@ -258,7 +258,7 @@ const AnnouncementsRoomName = "announcements"
 // before the walker descends to `everyone` — no explicit per-role
 // grants needed.
 func (c *ChattoCore) SetupAnnouncementsRoomPermissions(ctx context.Context, roomID string) error {
-	if err := c.DenyRoomPermission(ctx, roomID, RoleEveryone, PermMessagePost); err != nil {
+	if err := c.DenyRoomPermission(ctx, SystemActorID, roomID, RoleEveryone, PermMessagePost); err != nil {
 		return fmt.Errorf("failed to deny %s for everyone: %w", PermMessagePost, err)
 	}
 	c.logger.Debug("Set up announcements room permissions", "room", roomID)
@@ -297,7 +297,7 @@ func (c *ChattoCore) InitDefaultPermissions(ctx context.Context) error {
 			if !PermissionAppliesAtScope(perm, ScopeServer) {
 				continue
 			}
-			if err := c.GrantServerPermission(ctx, spec.role, perm); err != nil {
+			if err := c.GrantServerPermission(ctx, SystemActorID, spec.role, perm); err != nil {
 				return fmt.Errorf("failed to grant %s permission %s: %w", spec.role, perm, err)
 			}
 		}
@@ -386,7 +386,7 @@ func (c *ChattoCore) grantSetPermissionIfMissing(ctx context.Context, groupID, r
 	if c.RBAC.GetDecision(ScopeGroup, groupID, roleName, perm) != DecisionNone {
 		return nil
 	}
-	return c.GrantGroupPermission(ctx, groupID, roleName, perm)
+	return c.GrantGroupPermission(ctx, SystemActorID, groupID, roleName, perm)
 }
 
 func (c *ChattoCore) grantServerPermissionIfMissing(ctx context.Context, roleName string, perm Permission) error {

--- a/cli/internal/core/permission_ops_test.go
+++ b/cli/internal/core/permission_ops_test.go
@@ -38,7 +38,7 @@ func TestGrantServerPermission(t *testing.T) {
 	ctx := testContext(t)
 
 	t.Run("creates allow decision for valid permission", func(t *testing.T) {
-		err := core.GrantServerPermission(ctx, RoleModerator, PermMessagePost)
+		err := core.GrantServerPermission(ctx, SystemActorID, RoleModerator, PermMessagePost)
 		if err != nil {
 			t.Fatalf("GrantServerPermission() error = %v", err)
 		}
@@ -50,13 +50,13 @@ func TestGrantServerPermission(t *testing.T) {
 
 	t.Run("removes existing denial when granting", func(t *testing.T) {
 		// First deny the permission
-		err := core.DenyServerPermission(ctx, RoleModerator, PermMessagePost)
+		err := core.DenyServerPermission(ctx, SystemActorID, RoleModerator, PermMessagePost)
 		if err != nil {
 			t.Fatalf("DenyServerPermission() error = %v", err)
 		}
 
 		// Now grant it - should remove the denial
-		err = core.GrantServerPermission(ctx, RoleModerator, PermMessagePost)
+		err = core.GrantServerPermission(ctx, SystemActorID, RoleModerator, PermMessagePost)
 		if err != nil {
 			t.Fatalf("GrantServerPermission() error = %v", err)
 		}
@@ -67,7 +67,7 @@ func TestGrantServerPermission(t *testing.T) {
 	})
 
 	t.Run("rejects unrecognised permission", func(t *testing.T) {
-		err := core.GrantServerPermission(ctx, RoleModerator, Permission("not.a.real.permission"))
+		err := core.GrantServerPermission(ctx, SystemActorID, RoleModerator, Permission("not.a.real.permission"))
 		if err == nil {
 			t.Error("Expected error for invalid permission")
 		}
@@ -79,7 +79,7 @@ func TestDenyServerPermission(t *testing.T) {
 	ctx := testContext(t)
 
 	t.Run("creates deny decision", func(t *testing.T) {
-		err := core.DenyServerPermission(ctx, RoleEveryone, PermMessagePost)
+		err := core.DenyServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost)
 		if err != nil {
 			t.Fatalf("DenyServerPermission() error = %v", err)
 		}
@@ -91,13 +91,13 @@ func TestDenyServerPermission(t *testing.T) {
 
 	t.Run("removes existing grant when denying", func(t *testing.T) {
 		// First grant the permission
-		err := core.GrantServerPermission(ctx, RoleEveryone, PermMessagePost)
+		err := core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost)
 		if err != nil {
 			t.Fatalf("GrantServerPermission() error = %v", err)
 		}
 
 		// Now deny it - should remove the grant
-		err = core.DenyServerPermission(ctx, RoleEveryone, PermMessagePost)
+		err = core.DenyServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost)
 		if err != nil {
 			t.Fatalf("DenyServerPermission() error = %v", err)
 		}
@@ -108,7 +108,7 @@ func TestDenyServerPermission(t *testing.T) {
 	})
 
 	t.Run("rejects unrecognised permission", func(t *testing.T) {
-		err := core.DenyServerPermission(ctx, RoleModerator, Permission("not.real.permission"))
+		err := core.DenyServerPermission(ctx, SystemActorID, RoleModerator, Permission("not.real.permission"))
 		if err == nil {
 			t.Error("Expected error for invalid permission")
 		}
@@ -121,13 +121,13 @@ func TestClearServerPermissionState(t *testing.T) {
 
 	t.Run("clears both grant and denial", func(t *testing.T) {
 		// Grant a permission
-		err := core.GrantServerPermission(ctx, RoleModerator, PermMessagePost)
+		err := core.GrantServerPermission(ctx, SystemActorID, RoleModerator, PermMessagePost)
 		if err != nil {
 			t.Fatalf("Failed to grant: %v", err)
 		}
 
 		// Clear it
-		err = core.ClearServerPermissionState(ctx, RoleModerator, PermMessagePost)
+		err = core.ClearServerPermissionState(ctx, SystemActorID, RoleModerator, PermMessagePost)
 		if err != nil {
 			t.Fatalf("ClearServerPermissionState() error = %v", err)
 		}
@@ -138,7 +138,7 @@ func TestClearServerPermissionState(t *testing.T) {
 	})
 
 	t.Run("succeeds when clearing non-existent key", func(t *testing.T) {
-		err := core.ClearServerPermissionState(ctx, RoleEveryone, PermMessagePost)
+		err := core.ClearServerPermissionState(ctx, SystemActorID, RoleEveryone, PermMessagePost)
 		if err != nil {
 			t.Errorf("Expected no error when clearing non-existent key, got: %v", err)
 		}
@@ -156,7 +156,7 @@ func TestGrantSpaceRolePermission(t *testing.T) {
 	_, _ = core.CreateUser(ctx, "system", "testuser", "Test User", "password123")
 
 	t.Run("creates allow decision for server role", func(t *testing.T) {
-		err := core.GrantServerPermission(ctx, RoleEveryone, PermRoomCreate)
+		err := core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, PermRoomCreate)
 		if err != nil {
 			t.Fatalf("GrantSpaceRolePermission() error = %v", err)
 		}
@@ -168,7 +168,7 @@ func TestGrantSpaceRolePermission(t *testing.T) {
 
 	t.Run("works for role override at space level", func(t *testing.T) {
 		// Instance role override at space level
-		err := core.GrantServerPermission(ctx, RoleModerator, PermRoomJoin)
+		err := core.GrantServerPermission(ctx, SystemActorID, RoleModerator, PermRoomJoin)
 		if err != nil {
 			t.Fatalf("GrantSpaceRolePermission() for role error = %v", err)
 		}
@@ -190,7 +190,7 @@ func TestDenySpaceRolePermission(t *testing.T) {
 	_, _ = core.CreateUser(ctx, "system", "testuser", "Test User", "password123")
 
 	t.Run("creates deny decision in server RBAC", func(t *testing.T) {
-		err := core.DenyServerPermission(ctx, RoleEveryone, PermMessagePost)
+		err := core.DenyServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost)
 		if err != nil {
 			t.Fatalf("DenySpaceRolePermission() error = %v", err)
 		}
@@ -209,9 +209,9 @@ func TestClearSpaceRolePermission(t *testing.T) {
 
 	t.Run("clears both grant and denial at space level", func(t *testing.T) {
 		// Grant then clear
-		_ = core.GrantServerPermission(ctx, RoleEveryone, PermRoomJoin)
+		_ = core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, PermRoomJoin)
 
-		err := core.ClearServerPermissionState(ctx, RoleEveryone, PermRoomJoin)
+		err := core.ClearServerPermissionState(ctx, SystemActorID, RoleEveryone, PermRoomJoin)
 		if err != nil {
 			t.Fatalf("ClearSpaceRolePermission() error = %v", err)
 		}
@@ -234,7 +234,7 @@ func TestGrantRoomRolePermission(t *testing.T) {
 	room, _ := core.CreateRoom(ctx, user.Id, KindChannel, "", "General", "General chat")
 
 	t.Run("creates allow decision for room-level permission", func(t *testing.T) {
-		err := core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
+		err := core.GrantRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermMessagePost)
 		if err != nil {
 			t.Fatalf("GrantRoomRolePermission() error = %v", err)
 		}
@@ -245,7 +245,7 @@ func TestGrantRoomRolePermission(t *testing.T) {
 	})
 
 	t.Run("rejects permission that does not apply at room scope", func(t *testing.T) {
-		err := core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermAdminUsersView)
+		err := core.GrantRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermAdminUsersView)
 		if err == nil {
 			t.Error("Expected error for permission that doesn't apply at room scope")
 		}
@@ -260,7 +260,7 @@ func TestDenyRoomRolePermission(t *testing.T) {
 	room, _ := core.CreateRoom(ctx, user.Id, KindChannel, "", "General", "General chat")
 
 	t.Run("creates deny decision at room level", func(t *testing.T) {
-		err := core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
+		err := core.DenyRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermMessagePost)
 		if err != nil {
 			t.Fatalf("DenyRoomRolePermission() error = %v", err)
 		}
@@ -271,7 +271,7 @@ func TestDenyRoomRolePermission(t *testing.T) {
 	})
 
 	t.Run("rejects permission that does not apply at room scope", func(t *testing.T) {
-		err := core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermAdminUsersView)
+		err := core.DenyRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermAdminUsersView)
 		if err == nil {
 			t.Error("Expected error for permission that doesn't apply at room scope")
 		}
@@ -287,9 +287,9 @@ func TestClearRoomRolePermission(t *testing.T) {
 
 	t.Run("clears both grant and denial at room level", func(t *testing.T) {
 		// Grant then clear
-		_ = core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermRoomJoin)
+		_ = core.GrantRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermRoomJoin)
 
-		err := core.ClearRoomPermissionState(ctx, room.Id, RoleEveryone, PermRoomJoin)
+		err := core.ClearRoomPermissionState(ctx, SystemActorID, room.Id, RoleEveryone, PermRoomJoin)
 		if err != nil {
 			t.Fatalf("ClearRoomRolePermission() error = %v", err)
 		}
@@ -309,24 +309,24 @@ func TestPermissionOpsIdempotency(t *testing.T) {
 	ctx := testContext(t)
 
 	t.Run("granting same permission twice succeeds", func(t *testing.T) {
-		err := core.GrantServerPermission(ctx, RoleModerator, PermMessagePost)
+		err := core.GrantServerPermission(ctx, SystemActorID, RoleModerator, PermMessagePost)
 		if err != nil {
 			t.Fatalf("First grant failed: %v", err)
 		}
 
-		err = core.GrantServerPermission(ctx, RoleModerator, PermMessagePost)
+		err = core.GrantServerPermission(ctx, SystemActorID, RoleModerator, PermMessagePost)
 		if err != nil {
 			t.Errorf("Second grant should succeed (idempotent), got: %v", err)
 		}
 	})
 
 	t.Run("denying same permission twice succeeds", func(t *testing.T) {
-		err := core.DenyServerPermission(ctx, RoleEveryone, PermMessagePost)
+		err := core.DenyServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost)
 		if err != nil {
 			t.Fatalf("First deny failed: %v", err)
 		}
 
-		err = core.DenyServerPermission(ctx, RoleEveryone, PermMessagePost)
+		err = core.DenyServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost)
 		if err != nil {
 			t.Errorf("Second deny should succeed (idempotent), got: %v", err)
 		}
@@ -336,13 +336,13 @@ func TestPermissionOpsIdempotency(t *testing.T) {
 		perm := PermMessagePost
 
 		// Grant
-		err := core.GrantServerPermission(ctx, RoleEveryone, perm)
+		err := core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, perm)
 		if err != nil {
 			t.Fatalf("Grant failed: %v", err)
 		}
 
 		// Now deny
-		err = core.DenyServerPermission(ctx, RoleEveryone, perm)
+		err = core.DenyServerPermission(ctx, SystemActorID, RoleEveryone, perm)
 		if err != nil {
 			t.Fatalf("Deny failed: %v", err)
 		}
@@ -452,7 +452,7 @@ func TestInitDefaultPermissions(t *testing.T) {
 	})
 
 	t.Run("ensure default permissions backfills missing grants without overriding denies", func(t *testing.T) {
-		if err := core.ClearServerPermissionState(ctx, RoleModerator, PermRoomMemberBan); err != nil {
+		if err := core.ClearServerPermissionState(ctx, SystemActorID, RoleModerator, PermRoomMemberBan); err != nil {
 			t.Fatalf("ClearServerPermissionState: %v", err)
 		}
 		if got := core.RBAC.GetDecision(ScopeServer, "", RoleModerator, PermRoomMemberBan); got != DecisionNone {
@@ -465,7 +465,7 @@ func TestInitDefaultPermissions(t *testing.T) {
 			t.Fatalf("decision after ensure = %s, want %s", got, DecisionAllow)
 		}
 
-		if err := core.DenyServerPermission(ctx, RoleModerator, PermRoomMemberBan); err != nil {
+		if err := core.DenyServerPermission(ctx, SystemActorID, RoleModerator, PermRoomMemberBan); err != nil {
 			t.Fatalf("DenyServerPermission: %v", err)
 		}
 		if err := core.EnsureDefaultRolePermissions(ctx); err != nil {
@@ -488,7 +488,7 @@ func TestPermissionOpsWithCancelledContext(t *testing.T) {
 	cancel() // Cancel immediately
 
 	t.Run("grant fails with cancelled context", func(t *testing.T) {
-		err := core.GrantServerPermission(ctx, RoleModerator, PermMessagePost)
+		err := core.GrantServerPermission(ctx, SystemActorID, RoleModerator, PermMessagePost)
 		if err == nil {
 			t.Error("Expected error with cancelled context")
 		}

--- a/cli/internal/core/permission_resolver_test.go
+++ b/cli/internal/core/permission_resolver_test.go
@@ -56,13 +56,13 @@ func TestPermissionResolver_HasServerPermission_DenyWins(t *testing.T) {
 
 	t.Run("same-role denial replaces grant", func(t *testing.T) {
 		// Grant permission via instance-everyone role
-		err := core.GrantServerPermission(ctx, RoleEveryone, PermMessagePost)
+		err := core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost)
 		if err != nil {
 			t.Fatalf("Failed to grant permission: %v", err)
 		}
 
 		// Deny same permission for the same role (replaces the grant)
-		err = core.DenyServerPermission(ctx, RoleEveryone, PermMessagePost)
+		err = core.DenyServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost)
 		if err != nil {
 			t.Fatalf("Failed to deny permission: %v", err)
 		}
@@ -77,7 +77,7 @@ func TestPermissionResolver_HasServerPermission_DenyWins(t *testing.T) {
 		}
 
 		// Restore for other tests
-		core.GrantServerPermission(ctx, RoleEveryone, PermMessagePost)
+		core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost)
 	})
 }
 
@@ -98,14 +98,14 @@ func TestPermissionResolver_HasServerPermission_CustomDenyRole(t *testing.T) {
 	}
 
 	// Create a custom deny role (replicates the e2e test scenario)
-	denyRole, err := core.CreateServerRole(ctx, "denytest", "Deny message.post", "Test deny role")
+	denyRole, err := core.CreateServerRole(ctx, SystemActorID, "denytest", "Deny message.post", "Test deny role")
 	if err != nil {
 		t.Fatalf("Failed to create deny role: %v", err)
 	}
 	t.Logf("Created deny role with position: %d", denyRole.Position)
 
 	// Deny message.post on the deny role
-	err = core.DenyServerPermission(ctx, "denytest", PermMessagePost)
+	err = core.DenyServerPermission(ctx, SystemActorID, "denytest", PermMessagePost)
 	if err != nil {
 		t.Fatalf("Failed to deny permission: %v", err)
 	}
@@ -149,13 +149,13 @@ func TestPermissionResolver_HasServerPermission_Hierarchy(t *testing.T) {
 
 	t.Run("higher-ranked role grant beats lower-ranked role denial", func(t *testing.T) {
 		// Deny message.post for everyone (low rank, position 0)
-		err := core.DenyServerPermission(ctx, RoleEveryone, PermMessagePost)
+		err := core.DenyServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost)
 		if err != nil {
 			t.Fatalf("Failed to deny permission: %v", err)
 		}
 
 		// Grant message.post for admin (high rank, position 900)
-		err = core.GrantServerPermission(ctx, RoleAdmin, PermMessagePost)
+		err = core.GrantServerPermission(ctx, SystemActorID, RoleAdmin, PermMessagePost)
 		if err != nil {
 			t.Fatalf("Failed to grant permission: %v", err)
 		}
@@ -171,19 +171,19 @@ func TestPermissionResolver_HasServerPermission_Hierarchy(t *testing.T) {
 		}
 
 		// Cleanup
-		core.ClearServerPermissionState(ctx, RoleEveryone, PermMessagePost)
-		core.ClearServerPermissionState(ctx, RoleAdmin, PermMessagePost)
+		core.ClearServerPermissionState(ctx, SystemActorID, RoleEveryone, PermMessagePost)
+		core.ClearServerPermissionState(ctx, SystemActorID, RoleAdmin, PermMessagePost)
 	})
 
 	t.Run("higher-ranked role denial beats lower-ranked role grant", func(t *testing.T) {
 		// Grant message.post for everyone (low rank)
-		err := core.GrantServerPermission(ctx, RoleEveryone, PermMessagePost)
+		err := core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost)
 		if err != nil {
 			t.Fatalf("Failed to grant permission: %v", err)
 		}
 
 		// Deny message.post for admin (high rank)
-		err = core.DenyServerPermission(ctx, RoleAdmin, PermMessagePost)
+		err = core.DenyServerPermission(ctx, SystemActorID, RoleAdmin, PermMessagePost)
 		if err != nil {
 			t.Fatalf("Failed to deny permission: %v", err)
 		}
@@ -198,8 +198,8 @@ func TestPermissionResolver_HasServerPermission_Hierarchy(t *testing.T) {
 		}
 
 		// Cleanup
-		core.ClearServerPermissionState(ctx, RoleEveryone, PermMessagePost)
-		core.ClearServerPermissionState(ctx, RoleAdmin, PermMessagePost)
+		core.ClearServerPermissionState(ctx, SystemActorID, RoleEveryone, PermMessagePost)
+		core.ClearServerPermissionState(ctx, SystemActorID, RoleAdmin, PermMessagePost)
 	})
 
 }
@@ -314,10 +314,10 @@ func TestPermissionResolver_ExplicitDenyOnHighestRole(t *testing.T) {
 	t.Run("explicit deny on highest-rank role wins over lower-rank grant", func(t *testing.T) {
 		// `everyone` grants the perm; `admin` (the user's highest role) denies it.
 		// Walker visits admin first → deny → stop. Result: denied.
-		if err := core.GrantServerPermission(ctx, RoleEveryone, PermMessagePost); err != nil {
+		if err := core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost); err != nil {
 			t.Fatalf("Failed to grant permission: %v", err)
 		}
-		if err := core.DenyServerPermission(ctx, RoleAdmin, PermMessagePost); err != nil {
+		if err := core.DenyServerPermission(ctx, SystemActorID, RoleAdmin, PermMessagePost); err != nil {
 			t.Fatalf("Failed to deny permission: %v", err)
 		}
 
@@ -340,7 +340,7 @@ func TestPermissionResolver_HasSpacePermission_ServerRoleOverride(t *testing.T) 
 
 	t.Run("space can override role permissions", func(t *testing.T) {
 		// Grant permission to instance-everyone at space level (override)
-		err := core.GrantServerPermission(ctx, RoleEveryone, PermRoomManage)
+		err := core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, PermRoomManage)
 		if err != nil {
 			t.Fatalf("Failed to grant permission: %v", err)
 		}
@@ -411,7 +411,7 @@ func TestPermissionResolver_HasRoomPermission(t *testing.T) {
 
 	t.Run("returns true when user has permission at room level", func(t *testing.T) {
 		// Grant permission at room level
-		err := core.GrantRoomPermission(ctx, room.Id, RoleOwner, PermMessagePost)
+		err := core.GrantRoomPermission(ctx, SystemActorID, room.Id, RoleOwner, PermMessagePost)
 		if err != nil {
 			t.Fatalf("Failed to grant room permission: %v", err)
 		}
@@ -428,7 +428,7 @@ func TestPermissionResolver_HasRoomPermission(t *testing.T) {
 	t.Run("falls back to space level", func(t *testing.T) {
 		// User is space admin, should have space.manage which doesn't apply at room level
 		// but room.manage does apply at space and room levels
-		err := core.GrantServerPermission(ctx, RoleOwner, PermRoomManage)
+		err := core.GrantServerPermission(ctx, SystemActorID, RoleOwner, PermRoomManage)
 		if err != nil {
 			t.Fatalf("Failed to grant space permission: %v", err)
 		}
@@ -457,7 +457,7 @@ func TestPermissionResolver_HasRoomPermission_AdminRoleDenials(t *testing.T) {
 	room, _ := core.CreateRoom(ctx, user.Id, KindChannel, "", "General", "General chat")
 
 	t.Run("admin role is subject to room-level denials like any other role", func(t *testing.T) {
-		if err := core.DenyRoomPermission(ctx, room.Id, RoleAdmin, PermMessagePost); err != nil {
+		if err := core.DenyRoomPermission(ctx, SystemActorID, room.Id, RoleAdmin, PermMessagePost); err != nil {
 			t.Fatalf("Failed to deny room permission: %v", err)
 		}
 
@@ -487,17 +487,17 @@ func TestPermissionResolver_HasRoomPermission_DenyWins(t *testing.T) {
 	member, _ := core.CreateUser(ctx, "system", "memberdenywins", "Member User", "password123")
 	t.Run("higher-ranked role denial wins at room level", func(t *testing.T) {
 		// Grant permission to everyone at room level
-		err := core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
+		err := core.GrantRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermMessagePost)
 		if err != nil {
 			t.Fatalf("Failed to grant room permission: %v", err)
 		}
 
 		// Create a "muted" role, which ranks above the implicit everyone role.
-		_, err = core.CreateServerRole(ctx, "muted", "Muted", "Cannot post")
+		_, err = core.CreateServerRole(ctx, SystemActorID, "muted", "Muted", "Cannot post")
 		if err != nil {
 			t.Fatalf("Failed to create muted role: %v", err)
 		}
-		err = core.DenyRoomPermission(ctx, room.Id, "muted", PermMessagePost)
+		err = core.DenyRoomPermission(ctx, SystemActorID, room.Id, "muted", PermMessagePost)
 		if err != nil {
 			t.Fatalf("Failed to deny room permission: %v", err)
 		}
@@ -534,10 +534,10 @@ func TestPermissionResolver_HasRoomPermission_RoomGrantOverridesAbsentSetGrant(t
 	// override grants it.
 	groups, _ := core.ListRoomGroupsOrdered(ctx, KindChannel)
 	groupID := groups[0].Id
-	if err := core.ClearGroupPermissionState(ctx, groupID, RoleEveryone, PermMessageReact); err != nil {
+	if err := core.ClearGroupPermissionState(ctx, SystemActorID, groupID, RoleEveryone, PermMessageReact); err != nil {
 		t.Fatalf("ClearGroupPermissionState: %v", err)
 	}
-	if err := core.ClearServerPermissionState(ctx, RoleEveryone, PermMessageReact); err != nil {
+	if err := core.ClearServerPermissionState(ctx, SystemActorID, RoleEveryone, PermMessageReact); err != nil {
 		t.Fatalf("ClearServerPermissionState: %v", err)
 	}
 
@@ -551,7 +551,7 @@ func TestPermissionResolver_HasRoomPermission_RoomGrantOverridesAbsentSetGrant(t
 	}
 
 	// Grant at room level
-	err = core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessageReact)
+	err = core.GrantRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermMessageReact)
 	if err != nil {
 		t.Fatalf("Failed to grant room permission: %v", err)
 	}
@@ -574,10 +574,10 @@ func TestPermissionResolver_HasRoomPermission_RoomDenialOverridesSpaceGrant(t *t
 
 	member, _ := core.CreateUser(ctx, "system", "roomdeny1member", "Member", "password123")
 	// Ensure message.post is granted at space level
-	core.GrantServerPermission(ctx, RoleEveryone, PermMessagePost)
+	core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost)
 
 	// Deny at room level
-	core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
+	core.DenyRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermMessagePost)
 
 	has, err := core.permissionResolver.HasRoomPermission(ctx, member.Id, KindChannel, room.Id, PermMessagePost)
 	if err != nil {
@@ -596,8 +596,8 @@ func TestPermissionResolver_HasRoomPermission_RoomGrantOverridesServerDenialForS
 	room, _ := core.CreateRoom(ctx, admin.Id, KindChannel, "", "general", "General")
 
 	member, _ := core.CreateUser(ctx, "system", "roomoverridemember", "Member", "password123")
-	core.DenyServerPermission(ctx, RoleEveryone, PermMessagePost)
-	core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
+	core.DenyServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost)
+	core.GrantRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermMessagePost)
 
 	// Under the unified hierarchy-wins algorithm, the room-level decision
 	// for a role takes precedence over that same role's server-level decision.
@@ -622,13 +622,13 @@ func TestPermissionResolver_HasRoomPermission_ConflictingRoles(t *testing.T) {
 
 	member, _ := core.CreateUser(ctx, "system", "conflictrolemember", "Member", "password123")
 	// Create a custom role (gets a positive custom position, higher rank than everyone).
-	core.CreateServerRole(ctx, "poster", "Poster", "Can post")
+	core.CreateServerRole(ctx, SystemActorID, "poster", "Poster", "Can post")
 
 	// Grant message.post to poster role at room level
-	core.GrantRoomPermission(ctx, room.Id, "poster", PermMessagePost)
+	core.GrantRoomPermission(ctx, SystemActorID, room.Id, "poster", PermMessagePost)
 
 	// Deny message.post for everyone role at room level
-	core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
+	core.DenyRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermMessagePost)
 
 	// Assign poster role to member (member now has: everyone + poster)
 	core.AssignServerRole(ctx, admin.Id, member.Id, "poster")
@@ -655,10 +655,10 @@ func TestPermissionResolver_HasRoomPermission_IsolationBetweenRooms(t *testing.T
 
 	member, _ := core.CreateUser(ctx, "system", "roomisomember", "Member", "password123")
 	// Ensure message.post is granted at space level for everyone
-	core.GrantServerPermission(ctx, RoleEveryone, PermMessagePost)
+	core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost)
 
 	// Deny message.post only in room A
-	core.DenyRoomPermission(ctx, roomA.Id, RoleEveryone, PermMessagePost)
+	core.DenyRoomPermission(ctx, SystemActorID, roomA.Id, RoleEveryone, PermMessagePost)
 
 	// Room A: denied
 	hasA, err := core.permissionResolver.HasRoomPermission(ctx, member.Id, KindChannel, roomA.Id, PermMessagePost)
@@ -688,10 +688,10 @@ func TestPermissionResolver_HasRoomPermission_ServerRoleRoomDenial(t *testing.T)
 
 	member, _ := core.CreateUser(ctx, "system", "instroomdeny1member", "Member", "password123")
 	// Ensure message.post is granted at space level
-	core.GrantServerPermission(ctx, RoleEveryone, PermMessagePost)
+	core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost)
 
 	// Deny message.post for instance-everyone at room level
-	core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
+	core.DenyRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermMessagePost)
 
 	has, err := core.permissionResolver.HasRoomPermission(ctx, member.Id, KindChannel, room.Id, PermMessagePost)
 	if err != nil {
@@ -711,10 +711,10 @@ func TestPermissionResolver_HasRoomPermission_ServerRoleRoomGrant(t *testing.T) 
 
 	member, _ := core.CreateUser(ctx, "system", "instroomgrant1member", "Member", "password123")
 	// Clear message.react from everyone at space level (no grant)
-	core.ClearServerPermissionState(ctx, RoleEveryone, PermMessageReact)
+	core.ClearServerPermissionState(ctx, SystemActorID, RoleEveryone, PermMessageReact)
 
 	// Grant message.react to instance-everyone at room level
-	core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessageReact)
+	core.GrantRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermMessageReact)
 
 	has, err := core.permissionResolver.HasRoomPermission(ctx, member.Id, KindChannel, room.Id, PermMessageReact)
 	if err != nil {
@@ -734,10 +734,10 @@ func TestPermissionResolver_HasRoomPermission_ClearFallsBackToSpace(t *testing.T
 
 	member, _ := core.CreateUser(ctx, "system", "clearfallbackmember", "Member", "password123")
 	// Grant at space level
-	core.GrantServerPermission(ctx, RoleEveryone, PermMessagePost)
+	core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost)
 
 	// Deny at room level
-	core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
+	core.DenyRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermMessagePost)
 
 	// Verify denied
 	has, _ := core.permissionResolver.HasRoomPermission(ctx, member.Id, KindChannel, room.Id, PermMessagePost)
@@ -746,7 +746,7 @@ func TestPermissionResolver_HasRoomPermission_ClearFallsBackToSpace(t *testing.T
 	}
 
 	// Clear room override
-	core.ClearRoomPermissionState(ctx, room.Id, RoleEveryone, PermMessagePost)
+	core.ClearRoomPermissionState(ctx, SystemActorID, room.Id, RoleEveryone, PermMessagePost)
 
 	// Should fall back to space grant
 	has, err := core.permissionResolver.HasRoomPermission(ctx, member.Id, KindChannel, room.Id, PermMessagePost)
@@ -767,8 +767,8 @@ func TestPermissionResolver_HasRoomPermission_MultiplePermissionsPerRoom(t *test
 
 	member, _ := core.CreateUser(ctx, "system", "multipermmember", "Member", "password123")
 	// Grant message.post at room level, deny message.react at room level
-	core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
-	core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessageReact)
+	core.GrantRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermMessagePost)
+	core.DenyRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermMessageReact)
 
 	hasPost, err := core.permissionResolver.HasRoomPermission(ctx, member.Id, KindChannel, room.Id, PermMessagePost)
 	if err != nil {
@@ -808,7 +808,7 @@ func TestPermissionResolver_UserLevelOverrides(t *testing.T) {
 			t.Fatal("baseline: moderator should have message.post")
 		}
 		// Suspend posting by user-deny.
-		if err := core.DenyUserPermission(ctx, mod.Id, PermMessagePost); err != nil {
+		if err := core.DenyUserPermission(ctx, SystemActorID, mod.Id, PermMessagePost); err != nil {
 			t.Fatalf("DenyUserPermission: %v", err)
 		}
 		has, _ = core.HasServerPermission(ctx, mod.Id, PermMessagePost)
@@ -825,7 +825,7 @@ func TestPermissionResolver_UserLevelOverrides(t *testing.T) {
 		if err := core.AssignOwnerRole(ctx, owner.Id); err != nil {
 			t.Fatalf("AssignOwnerRole: %v", err)
 		}
-		if err := core.DenyUserPermission(ctx, owner.Id, PermMessagePost); err != nil {
+		if err := core.DenyUserPermission(ctx, SystemActorID, owner.Id, PermMessagePost); err != nil {
 			t.Fatalf("DenyUserPermission: %v", err)
 		}
 		has, _ := core.HasServerPermission(ctx, owner.Id, PermMessagePost)
@@ -847,7 +847,7 @@ func TestPermissionResolver_UserLevelOverrides(t *testing.T) {
 		}
 
 		// Grant directly on the user, at room scope.
-		if err := core.GrantUserRoomPermission(ctx, room.Id, user.Id, PermMessageManage); err != nil {
+		if err := core.GrantUserRoomPermission(ctx, SystemActorID, room.Id, user.Id, PermMessageManage); err != nil {
 			t.Fatalf("GrantUserRoomPermission: %v", err)
 		}
 		has, _ = core.permissionResolver.HasRoomPermission(ctx, user.Id, KindChannel, room.Id, PermMessageManage)
@@ -869,7 +869,7 @@ func TestPermissionResolver_UserLevelOverrides(t *testing.T) {
 		user, _ := core.CreateUser(ctx, SystemActorID, "user-room-grant", "User", "password123")
 		room, _ := core.CreateRoom(ctx, SystemActorID, KindChannel, "", "private", "Private")
 		groupID := room.GroupId
-		if err := core.DenyGroupPermission(ctx, groupID, RoleEveryone, PermMessagePost); err != nil {
+		if err := core.DenyGroupPermission(ctx, SystemActorID, groupID, RoleEveryone, PermMessagePost); err != nil {
 			t.Fatalf("DenyGroupPermission: %v", err)
 		}
 		// Without the user-grant, user can't post.
@@ -878,7 +878,7 @@ func TestPermissionResolver_UserLevelOverrides(t *testing.T) {
 			t.Fatal("baseline: user should be denied by everyone-role set deny")
 		}
 		// User-level room grant.
-		if err := core.GrantUserRoomPermission(ctx, room.Id, user.Id, PermMessagePost); err != nil {
+		if err := core.GrantUserRoomPermission(ctx, SystemActorID, room.Id, user.Id, PermMessagePost); err != nil {
 			t.Fatalf("GrantUserRoomPermission: %v", err)
 		}
 		has, _ = core.permissionResolver.HasRoomPermission(ctx, user.Id, KindChannel, room.Id, PermMessagePost)
@@ -896,7 +896,7 @@ func TestPermissionResolver_UserLevelOverrides(t *testing.T) {
 		ctx2 := testContext(t)
 		user, _ := c.CreateUser(ctx2, SystemActorID, "dm-boundary-user", "User", "password123")
 		dmRoomID := "R_dm_boundary_user_test"
-		if err := c.GrantUserRoomPermission(ctx2, dmRoomID, user.Id, PermMessageManage); err != nil {
+		if err := c.GrantUserRoomPermission(ctx2, SystemActorID, dmRoomID, user.Id, PermMessageManage); err != nil {
 			t.Fatalf("GrantUserRoomPermission: %v", err)
 		}
 		has, _ := c.permissionResolver.HasRoomPermission(ctx2, user.Id, KindDM, dmRoomID, PermMessageManage)
@@ -940,12 +940,12 @@ func TestPermissionResolver_UserLevelOverrides(t *testing.T) {
 		if !has {
 			t.Fatal("baseline: user should have message.post via everyone")
 		}
-		_ = c.DenyUserPermission(c2ctx, user.Id, PermMessagePost)
+		_ = c.DenyUserPermission(c2ctx, SystemActorID, user.Id, PermMessagePost)
 		has, _ = c.HasServerPermission(c2ctx, user.Id, PermMessagePost)
 		if has {
 			t.Fatal("expected user-deny to take effect")
 		}
-		if err := c.ClearUserPermissionState(c2ctx, user.Id, PermMessagePost); err != nil {
+		if err := c.ClearUserPermissionState(c2ctx, SystemActorID, user.Id, PermMessagePost); err != nil {
 			t.Fatalf("ClearUserPermissionState: %v", err)
 		}
 		has, _ = c.HasServerPermission(c2ctx, user.Id, PermMessagePost)
@@ -1040,10 +1040,10 @@ func TestPermissionResolver_RoomOverridesServerForSameRole(t *testing.T) {
 	t.Run("room grant overrides server deny on the same role", func(t *testing.T) {
 		// Server-wide deny on everyone, room-level grant on everyone.
 		// Under hierarchy-wins, the room-level decision wins for the same role.
-		if err := core.DenyServerPermission(ctx, RoleEveryone, PermMessageReact); err != nil {
+		if err := core.DenyServerPermission(ctx, SystemActorID, RoleEveryone, PermMessageReact); err != nil {
 			t.Fatalf("DenyServerPermission: %v", err)
 		}
-		if err := core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessageReact); err != nil {
+		if err := core.GrantRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermMessageReact); err != nil {
 			t.Fatalf("GrantRoomPermission: %v", err)
 		}
 
@@ -1057,10 +1057,10 @@ func TestPermissionResolver_RoomOverridesServerForSameRole(t *testing.T) {
 	})
 
 	t.Run("room deny overrides server grant on the same role", func(t *testing.T) {
-		if err := core.GrantServerPermission(ctx, RoleEveryone, PermMessagePost); err != nil {
+		if err := core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost); err != nil {
 			t.Fatalf("GrantServerPermission: %v", err)
 		}
-		if err := core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost); err != nil {
+		if err := core.DenyRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermMessagePost); err != nil {
 			t.Fatalf("DenyRoomPermission: %v", err)
 		}
 
@@ -1079,10 +1079,10 @@ func TestPermissionResolver_RoomOverridesServerForSameRole(t *testing.T) {
 		// clears any matching deny and vice versa), but cover the rare race.
 		newUser, _ := core.CreateUser(ctx, "system", "graceuser", "Grace", "password123")
 
-		if err := core.GrantServerPermission(ctx, RoleEveryone, PermMessagePost); err != nil {
+		if err := core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost); err != nil {
 			t.Fatalf("GrantServerPermission: %v", err)
 		}
-		if err := core.DenyServerPermission(ctx, RoleEveryone, PermMessagePost); err != nil {
+		if err := core.DenyServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost); err != nil {
 			t.Fatalf("DenyServerPermission: %v", err)
 		}
 
@@ -1110,7 +1110,7 @@ func TestPermissionResolver_ServerAuthority(t *testing.T) {
 	member, _ := core.CreateUser(ctx, "system", "authmember", "Member User", "password123")
 	t.Run("instance grant applies for space member", func(t *testing.T) {
 		// Grant at instance level for instance-everyone
-		err := core.GrantServerPermission(ctx, RoleEveryone, PermMessagePost)
+		err := core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost)
 		if err != nil {
 			t.Fatalf("Failed to grant server permission: %v", err)
 		}

--- a/cli/internal/core/rbac.go
+++ b/cli/internal/core/rbac.go
@@ -327,11 +327,11 @@ func (c *ChattoCore) GetUserRoles(ctx context.Context, userID string) ([]string,
 // (GrantServerPermission, DenyServerPermission, and
 // ClearServerPermissionState live in permission_ops.go, alongside the
 // space-tier and room-tier counterparts.)
-func (c *ChattoCore) RevokeServerPermission(ctx context.Context, roleName string, perm Permission) error {
+func (c *ChattoCore) RevokeServerPermission(ctx context.Context, actorID, roleName string, perm Permission) error {
 	if err := ValidatePermission(perm); err != nil {
 		return err
 	}
-	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionCleared{
+	event := newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacPermissionCleared{
 		RbacPermissionCleared: rbacRolePermissionClearedEvent(ScopeServer, "", roleName, perm),
 	}})
 	if _, err := c.appendRBACEvent(ctx, event, func() error {
@@ -348,7 +348,7 @@ func (c *ChattoCore) RevokeServerPermission(ctx context.Context, roleName string
 		}
 		return err
 	}
-	c.logger.Info("Revoked server permission", "role", roleName, "permission", perm)
+	c.logger.Info("Revoked server permission", "role", roleName, "permission", perm, "actor_id", actorID)
 	return nil
 }
 
@@ -430,7 +430,7 @@ func (c *ChattoCore) ListServerRoles(ctx context.Context) ([]RoleWithPermissions
 // CreateServerRole creates a new custom server role.
 // Role names must be lowercase letters only (e.g., "editor", "moderator").
 // System role names (owner, admin, moderator, everyone) are reserved.
-func (c *ChattoCore) CreateServerRole(ctx context.Context, name, displayName, description string, pingableValue ...bool) (*RoleWithPermissions, error) {
+func (c *ChattoCore) CreateServerRole(ctx context.Context, actorID, name, displayName, description string, pingableValue ...bool) (*RoleWithPermissions, error) {
 	pingable := false
 	if len(pingableValue) > 0 {
 		pingable = pingableValue[0]
@@ -449,7 +449,7 @@ func (c *ChattoCore) CreateServerRole(ctx context.Context, name, displayName, de
 	}
 
 	var role *corev1.Role
-	event := newEvent(SystemActorID, &corev1.Event{})
+	event := newEvent(actorID, &corev1.Event{})
 	if _, err := c.appendRBACEventWithMentionableCheck(ctx, event, func() error {
 		if c.RBAC.RoleExists(name) {
 			return ErrRoleAlreadyExists
@@ -478,7 +478,7 @@ func (c *ChattoCore) CreateServerRole(ctx context.Context, name, displayName, de
 		return nil, err
 	}
 
-	c.logger.Info("Created role", "name", name, "display_name", displayName, "position", role.GetPosition())
+	c.logger.Info("Created role", "name", name, "display_name", displayName, "position", role.GetPosition(), "actor_id", actorID)
 
 	return &RoleWithPermissions{
 		Name:              role.GetName(),
@@ -494,13 +494,13 @@ func (c *ChattoCore) CreateServerRole(ctx context.Context, name, displayName, de
 
 // UpdateServerRole updates an existing role's metadata.
 // The role name cannot be changed.
-func (c *ChattoCore) UpdateServerRole(ctx context.Context, name, displayName, description string, pingableValue ...bool) (*RoleWithPermissions, error) {
+func (c *ChattoCore) UpdateServerRole(ctx context.Context, actorID, name, displayName, description string, pingableValue ...bool) (*RoleWithPermissions, error) {
 	if err := validateRoleMetadata(displayName, description); err != nil {
 		return nil, err
 	}
 
 	var updated *corev1.Role
-	if _, err := c.appendRBACEvent(ctx, newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacRoleDisplayNameChanged{
+	if _, err := c.appendRBACEvent(ctx, newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacRoleDisplayNameChanged{
 		RbacRoleDisplayNameChanged: &corev1.RbacRoleDisplayNameChangedEvent{RoleName: name, DisplayName: displayName},
 	}}), func() error {
 		existing, ok := c.RBAC.GetRole(name)
@@ -525,7 +525,7 @@ func (c *ChattoCore) UpdateServerRole(ctx context.Context, name, displayName, de
 		}
 	}
 
-	if _, err := c.appendRBACEvent(ctx, newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacRoleDescriptionChanged{
+	if _, err := c.appendRBACEvent(ctx, newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacRoleDescriptionChanged{
 		RbacRoleDescriptionChanged: &corev1.RbacRoleDescriptionChangedEvent{RoleName: name, Description: description},
 	}}), func() error {
 		existing, ok := c.RBAC.GetRole(name)
@@ -552,7 +552,7 @@ func (c *ChattoCore) UpdateServerRole(ctx context.Context, name, displayName, de
 
 	if len(pingableValue) > 0 {
 		pingable := pingableValue[0]
-		if _, err := c.appendRBACEvent(ctx, newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacRolePingableChanged{
+		if _, err := c.appendRBACEvent(ctx, newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacRolePingableChanged{
 			RbacRolePingableChanged: &corev1.RbacRolePingableChangedEvent{RoleName: name, Pingable: pingable},
 		}}), func() error {
 			existing, ok := c.RBAC.GetRole(name)
@@ -586,7 +586,7 @@ func (c *ChattoCore) UpdateServerRole(ctx context.Context, name, displayName, de
 		updated = existing
 	}
 
-	c.logger.Info("Updated role", "name", name, "display_name", displayName)
+	c.logger.Info("Updated role", "name", name, "display_name", displayName, "actor_id", actorID)
 
 	perms, _ := c.GetServerRolePermissions(ctx, name)
 	denials, _ := c.GetServerRolePermissionDenials(ctx, name)
@@ -628,12 +628,12 @@ func (c *ChattoCore) GetServerRole(ctx context.Context, name string) (*RoleWithP
 // DeleteServerRole deletes a custom role and all its associated data.
 // This includes: the role definition, all permission grants, and all user assignments.
 // System roles (owner, admin, moderator, everyone) cannot be deleted.
-func (c *ChattoCore) DeleteServerRole(ctx context.Context, name string) error {
+func (c *ChattoCore) DeleteServerRole(ctx context.Context, actorID, name string) error {
 	if IsSystemRole(name) {
 		return ErrCannotDeleteSystemRole
 	}
 
-	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacRoleDeleted{
+	event := newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacRoleDeleted{
 		RbacRoleDeleted: &corev1.RbacRoleDeletedEvent{RoleName: name},
 	}})
 	if _, err := c.appendRBACEvent(ctx, event, func() error {
@@ -645,7 +645,7 @@ func (c *ChattoCore) DeleteServerRole(ctx context.Context, name string) error {
 		return err
 	}
 
-	c.logger.Info("Deleted role", "role", name)
+	c.logger.Info("Deleted role", "role", name, "actor_id", actorID)
 	return nil
 }
 
@@ -654,14 +654,14 @@ func (c *ChattoCore) DeleteServerRole(ctx context.Context, name string) error {
 // Positions are assigned from PositionCustomFirst upward while skipping system-role positions.
 // Note: everyone=0, moderator=100, admin=900, owner=1000.
 // Returns all roles sorted by position.
-func (c *ChattoCore) ReorderServerRoles(ctx context.Context, roleNames []string) ([]RoleWithPermissions, error) {
+func (c *ChattoCore) ReorderServerRoles(ctx context.Context, actorID string, roleNames []string) ([]RoleWithPermissions, error) {
 	for _, name := range roleNames {
 		if IsSystemRole(name) {
 			return nil, fmt.Errorf("cannot reorder system role: %s", name)
 		}
 	}
 
-	event := newEvent(SystemActorID, &corev1.Event{})
+	event := newEvent(actorID, &corev1.Event{})
 	if _, err := c.appendRBACEvent(ctx, event, func() error {
 		customRoles := make(map[string]struct{})
 		for _, role := range c.RBAC.ListRoles() {
@@ -710,7 +710,7 @@ func (c *ChattoCore) ReorderServerRoles(ctx context.Context, roleNames []string)
 		})
 	}
 
-	c.logger.Info("Reordered roles", "order", roleNames)
+	c.logger.Info("Reordered roles", "order", roleNames, "actor_id", actorID)
 	return result, nil
 }
 
@@ -730,11 +730,11 @@ func (c *ChattoCore) GetGroupRolePermissions(ctx context.Context, groupID, roleN
 }
 
 // GrantGroupPermission writes a group-scope grant for a role on a specific room group.
-func (c *ChattoCore) GrantGroupPermission(ctx context.Context, groupID, roleName string, perm Permission) error {
+func (c *ChattoCore) GrantGroupPermission(ctx context.Context, actorID, groupID, roleName string, perm Permission) error {
 	if !PermissionAppliesAtScope(perm, ScopeGroup) && !PermissionAppliesAtScope(perm, ScopeRoom) {
 		return fmt.Errorf("permission %s does not apply at group scope", perm)
 	}
-	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionGranted{
+	event := newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacPermissionGranted{
 		RbacPermissionGranted: rbacRolePermissionGrantedEvent(ScopeGroup, groupID, roleName, perm),
 	}})
 	_, err := c.appendRBACEvent(ctx, event, nil)
@@ -742,11 +742,11 @@ func (c *ChattoCore) GrantGroupPermission(ctx context.Context, groupID, roleName
 }
 
 // DenyGroupPermission writes a group-scope deny for a role on a specific room group.
-func (c *ChattoCore) DenyGroupPermission(ctx context.Context, groupID, roleName string, perm Permission) error {
+func (c *ChattoCore) DenyGroupPermission(ctx context.Context, actorID, groupID, roleName string, perm Permission) error {
 	if !PermissionAppliesAtScope(perm, ScopeGroup) && !PermissionAppliesAtScope(perm, ScopeRoom) {
 		return fmt.Errorf("permission %s does not apply at group scope", perm)
 	}
-	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionDenied{
+	event := newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacPermissionDenied{
 		RbacPermissionDenied: rbacRolePermissionDeniedEvent(ScopeGroup, groupID, roleName, perm),
 	}})
 	_, err := c.appendRBACEvent(ctx, event, nil)
@@ -754,8 +754,8 @@ func (c *ChattoCore) DenyGroupPermission(ctx context.Context, groupID, roleName 
 }
 
 // ClearGroupPermissionState removes both allow and deny for a role on a set.
-func (c *ChattoCore) ClearGroupPermissionState(ctx context.Context, groupID, roleName string, perm Permission) error {
-	event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacPermissionCleared{
+func (c *ChattoCore) ClearGroupPermissionState(ctx context.Context, actorID, groupID, roleName string, perm Permission) error {
+	event := newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacPermissionCleared{
 		RbacPermissionCleared: rbacRolePermissionClearedEvent(ScopeGroup, groupID, roleName, perm),
 	}})
 	_, err := c.appendRBACEvent(ctx, event, nil)
@@ -806,11 +806,11 @@ func (c *ChattoCore) GetUserEffectiveSpacePermissions(ctx context.Context, kind 
 // roles are server-wide, so this clears the user from every role they hold.
 // Used during LeaveSpace cleanup and account deletion.
 // Authorization: Internal use only (no permission check needed).
-func (c *ChattoCore) RevokeAllUserRoles(ctx context.Context, userID string) error {
+func (c *ChattoCore) RevokeAllUserRoles(ctx context.Context, actorID, userID string) error {
 	roles := c.RBAC.GetUserRoles(userID)
 	entries := make([]events.BatchEntry, 0, len(roles))
 	for _, roleName := range roles {
-		event := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_RbacRoleRevoked{
+		event := newEvent(actorID, &corev1.Event{Event: &corev1.Event_RbacRoleRevoked{
 			RbacRoleRevoked: &corev1.RbacRoleRevokedEvent{UserId: userID, RoleName: roleName},
 		}})
 		entries = append(entries, events.BatchEntry{Subject: rbacSubjectForEvent(event), Event: event})
@@ -819,6 +819,6 @@ func (c *ChattoCore) RevokeAllUserRoles(ctx context.Context, userID string) erro
 		return fmt.Errorf("failed to revoke user roles: %w", err)
 	}
 
-	c.logger.Debug("Revoked all roles for user", "user_id", userID)
+	c.logger.Debug("Revoked all roles for user", "user_id", userID, "actor_id", actorID)
 	return nil
 }

--- a/cli/internal/core/rbac_test.go
+++ b/cli/internal/core/rbac_test.go
@@ -170,7 +170,7 @@ func TestChattoCore_initServerRBAC_PreservesPermissionChanges(t *testing.T) {
 	}
 
 	// Step 2: Admin revokes the permission from the everyone role
-	err = core1.DenyServerPermission(ctx, RoleEveryone, PermMessagePost)
+	err = core1.DenyServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost)
 	if err != nil {
 		t.Fatalf("Failed to deny permission: %v", err)
 	}
@@ -513,7 +513,7 @@ func TestChattoCore_HierarchyWins_HighRankGrantBeatsLowRankDeny(t *testing.T) {
 	}
 
 	// Deny space.create on the everyone role (low rank)
-	if err := core.DenyServerPermission(ctx, RoleEveryone, PermMessagePost); err != nil {
+	if err := core.DenyServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost); err != nil {
 		t.Fatalf("Failed to deny permission: %v", err)
 	}
 	// Admin role still has space.create granted (from InitServerDefaults)
@@ -577,7 +577,7 @@ func TestChattoCore_HierarchyWins_LowRankDenyBlocksWhenNoHigherGrant(t *testing.
 	userID := "hierarchy-regular"
 
 	// Deny space.create on the everyone role
-	if err := core.DenyServerPermission(ctx, RoleEveryone, PermMessagePost); err != nil {
+	if err := core.DenyServerPermission(ctx, SystemActorID, RoleEveryone, PermMessagePost); err != nil {
 		t.Fatalf("Failed to deny permission: %v", err)
 	}
 
@@ -628,10 +628,10 @@ func TestChattoCore_HierarchyWins_OwnerBeatsEverythingElse(t *testing.T) {
 	}
 
 	// Deny admin.view-users on both admin and everyone roles
-	if err := core.DenyServerPermission(ctx, RoleEveryone, PermAdminUsersView); err != nil {
+	if err := core.DenyServerPermission(ctx, SystemActorID, RoleEveryone, PermAdminUsersView); err != nil {
 		t.Fatalf("Failed to deny everyone: %v", err)
 	}
-	if err := core.DenyServerPermission(ctx, RoleAdmin, PermAdminUsersView); err != nil {
+	if err := core.DenyServerPermission(ctx, SystemActorID, RoleAdmin, PermAdminUsersView); err != nil {
 		t.Fatalf("Failed to deny admin: %v", err)
 	}
 	// Owner role still has admin.view-users granted
@@ -666,7 +666,7 @@ func TestChattoCore_CreateServerRole(t *testing.T) {
 	ctx := testContext(t)
 
 	t.Run("creates role successfully", func(t *testing.T) {
-		role, err := core.CreateServerRole(ctx, "customrole", "Custom Role", "A custom role")
+		role, err := core.CreateServerRole(ctx, SystemActorID, "customrole", "Custom Role", "A custom role")
 		if err != nil {
 			t.Fatalf("Failed to create role: %v", err)
 		}
@@ -676,7 +676,7 @@ func TestChattoCore_CreateServerRole(t *testing.T) {
 	})
 
 	t.Run("accepts role name with dashes", func(t *testing.T) {
-		role, err := core.CreateServerRole(ctx, "custom-role", "Custom", "Dashes allowed")
+		role, err := core.CreateServerRole(ctx, SystemActorID, "custom-role", "Custom", "Dashes allowed")
 		if err != nil {
 			t.Fatalf("CreateServerRole(custom-role): %v", err)
 		}
@@ -686,7 +686,7 @@ func TestChattoCore_CreateServerRole(t *testing.T) {
 	})
 
 	t.Run("accepts role name with numbers", func(t *testing.T) {
-		role, err := core.CreateServerRole(ctx, "tier2", "Tier 2", "Numbers allowed")
+		role, err := core.CreateServerRole(ctx, SystemActorID, "tier2", "Tier 2", "Numbers allowed")
 		if err != nil {
 			t.Fatalf("CreateServerRole(tier2): %v", err)
 		}
@@ -696,14 +696,14 @@ func TestChattoCore_CreateServerRole(t *testing.T) {
 	})
 
 	t.Run("rejects role name with leading dash", func(t *testing.T) {
-		_, err := core.CreateServerRole(ctx, "-custom", "Custom", "Should fail")
+		_, err := core.CreateServerRole(ctx, SystemActorID, "-custom", "Custom", "Should fail")
 		if !errors.Is(err, ErrInvalidRoleName) {
 			t.Errorf("Expected ErrInvalidRoleName, got %v", err)
 		}
 	})
 
 	t.Run("rejects system role names", func(t *testing.T) {
-		_, err := core.CreateServerRole(ctx, RoleAdmin, "Admin", "Should fail")
+		_, err := core.CreateServerRole(ctx, SystemActorID, RoleAdmin, "Admin", "Should fail")
 		if err == nil {
 			t.Error("Expected error for system role name")
 		}
@@ -711,7 +711,7 @@ func TestChattoCore_CreateServerRole(t *testing.T) {
 
 	t.Run("rejects virtual mention handles", func(t *testing.T) {
 		for _, name := range []string{"all", "here"} {
-			_, err := core.CreateServerRole(ctx, name, name, "Should fail")
+			_, err := core.CreateServerRole(ctx, SystemActorID, name, name, "Should fail")
 			if !errors.Is(err, ErrRoleAlreadyExists) {
 				t.Errorf("CreateServerRole(%q) error = %v, want ErrRoleAlreadyExists", name, err)
 			}
@@ -722,7 +722,7 @@ func TestChattoCore_CreateServerRole(t *testing.T) {
 		if _, err := core.CreateUser(ctx, SystemActorID, "role-collision-user", "Role Collision", "password123"); err != nil {
 			t.Fatalf("CreateUser role-collision-user: %v", err)
 		}
-		_, err := core.CreateServerRole(ctx, "role-collision-user", "Role Collision", "Should fail")
+		_, err := core.CreateServerRole(ctx, SystemActorID, "role-collision-user", "Role Collision", "Should fail")
 		if !errors.Is(err, ErrRoleAlreadyExists) {
 			t.Errorf("CreateServerRole existing login error = %v, want ErrRoleAlreadyExists", err)
 		}
@@ -745,7 +745,7 @@ func TestChattoCore_MentionablesServiceSerializesUserAndRoleCreation(t *testing.
 	}()
 	go func() {
 		defer wg.Done()
-		_, roleErr = core.CreateServerRole(ctx, handle, "Race Claim", "")
+		_, roleErr = core.CreateServerRole(ctx, SystemActorID, handle, "Race Claim", "")
 	}()
 	wg.Wait()
 
@@ -757,7 +757,7 @@ func TestChattoCore_MentionablesServiceSerializesUserAndRoleCreation(t *testing.
 		if !errors.Is(roleErr, ErrRoleAlreadyExists) {
 			t.Fatalf("role err = %v, want ErrRoleAlreadyExists", roleErr)
 		}
-		if _, err := core.CreateServerRole(ctx, handle, "Race Claim", ""); !errors.Is(err, ErrRoleAlreadyExists) {
+		if _, err := core.CreateServerRole(ctx, SystemActorID, handle, "Race Claim", ""); !errors.Is(err, ErrRoleAlreadyExists) {
 			t.Fatalf("CreateServerRole after user claim err = %v, want ErrRoleAlreadyExists", err)
 		}
 		return
@@ -775,10 +775,10 @@ func TestChattoCore_DeleteServerRoleReleasesMentionHandle(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	if _, err := core.CreateServerRole(ctx, "released-role", "Released", ""); err != nil {
+	if _, err := core.CreateServerRole(ctx, SystemActorID, "released-role", "Released", ""); err != nil {
 		t.Fatalf("CreateServerRole: %v", err)
 	}
-	if err := core.DeleteServerRole(ctx, "released-role"); err != nil {
+	if err := core.DeleteServerRole(ctx, SystemActorID, "released-role"); err != nil {
 		t.Fatalf("DeleteServerRole: %v", err)
 	}
 	if _, err := core.CreateUser(ctx, SystemActorID, "released-role", "Released", "password123"); err != nil {
@@ -830,7 +830,7 @@ func TestChattoCore_AssignServerRole(t *testing.T) {
 		userID := "assign-custom-test"
 
 		// Create a custom role first (must have instance- prefix)
-		_, err := core.CreateServerRole(ctx, "tester", "Tester", "QA tester")
+		_, err := core.CreateServerRole(ctx, SystemActorID, "tester", "Tester", "QA tester")
 		if err != nil {
 			t.Fatalf("Failed to create role: %v", err)
 		}
@@ -996,7 +996,7 @@ func TestChattoCore_GetUserServerRoles(t *testing.T) {
 		}
 
 		// Create custom role (must have instance- prefix)
-		core.CreateServerRole(ctx, "editor", "Editor", "Content editor")
+		core.CreateServerRole(ctx, SystemActorID, "editor", "Editor", "Content editor")
 
 		// Assign multiple roles
 		core.AssignServerRole(ctx, SystemActorID, user.Id, RoleAdmin)
@@ -1213,11 +1213,11 @@ func TestChattoCore_ReorderServerRoles(t *testing.T) {
 
 	t.Run("reorders custom roles", func(t *testing.T) {
 		// Create custom roles
-		_, err := core.CreateServerRole(ctx, "alpha", "Alpha", "First custom role")
+		_, err := core.CreateServerRole(ctx, SystemActorID, "alpha", "Alpha", "First custom role")
 		if err != nil {
 			t.Fatalf("Failed to create alpha role: %v", err)
 		}
-		_, err = core.CreateServerRole(ctx, "beta", "Beta", "Second custom role")
+		_, err = core.CreateServerRole(ctx, SystemActorID, "beta", "Beta", "Second custom role")
 		if err != nil {
 			t.Fatalf("Failed to create beta role: %v", err)
 		}
@@ -1236,7 +1236,7 @@ func TestChattoCore_ReorderServerRoles(t *testing.T) {
 		t.Logf("Initial positions: alpha=%d, beta=%d", alphaInitialPos, betaInitialPos)
 
 		// Reorder: put beta before alpha
-		reordered, err := core.ReorderServerRoles(ctx, []string{"beta", "alpha"})
+		reordered, err := core.ReorderServerRoles(ctx, SystemActorID, []string{"beta", "alpha"})
 		if err != nil {
 			t.Fatalf("Failed to reorder: %v", err)
 		}
@@ -1262,28 +1262,28 @@ func TestChattoCore_ReorderServerRoles(t *testing.T) {
 	})
 
 	t.Run("rejects system role reordering", func(t *testing.T) {
-		_, err := core.ReorderServerRoles(ctx, []string{RoleAdmin, RoleModerator})
+		_, err := core.ReorderServerRoles(ctx, SystemActorID, []string{RoleAdmin, RoleModerator})
 		if err == nil {
 			t.Error("Expected error when trying to reorder system roles")
 		}
 	})
 
 	t.Run("rejects incomplete custom role list", func(t *testing.T) {
-		_, err := core.ReorderServerRoles(ctx, []string{"alpha"})
+		_, err := core.ReorderServerRoles(ctx, SystemActorID, []string{"alpha"})
 		if err == nil {
 			t.Error("Expected error when reorder omits a custom role")
 		}
 	})
 
 	t.Run("rejects duplicate custom roles", func(t *testing.T) {
-		_, err := core.ReorderServerRoles(ctx, []string{"alpha", "alpha"})
+		_, err := core.ReorderServerRoles(ctx, SystemActorID, []string{"alpha", "alpha"})
 		if err == nil {
 			t.Error("Expected error when reorder includes a duplicate role")
 		}
 	})
 
 	t.Run("rejects unknown custom role", func(t *testing.T) {
-		_, err := core.ReorderServerRoles(ctx, []string{"alpha", "gamma"})
+		_, err := core.ReorderServerRoles(ctx, SystemActorID, []string{"alpha", "gamma"})
 		if !errors.Is(err, ErrRoleNotFound) {
 			t.Fatalf("Expected ErrRoleNotFound, got %v", err)
 		}
@@ -1322,7 +1322,7 @@ func TestChattoCore_CreateServerRole_PositionAssignment(t *testing.T) {
 	ctx := testContext(t)
 
 	t.Run("custom role gets position between everyone and moderator", func(t *testing.T) {
-		role, err := core.CreateServerRole(ctx, "reviewer", "Reviewer", "Code reviewer")
+		role, err := core.CreateServerRole(ctx, SystemActorID, "reviewer", "Reviewer", "Code reviewer")
 		if err != nil {
 			t.Fatalf("Failed to create role: %v", err)
 		}
@@ -1341,14 +1341,14 @@ func TestChattoCore_CreateServerRole_PositionAssignment(t *testing.T) {
 
 	t.Run("position preserved after update", func(t *testing.T) {
 		// Create a role
-		role, err := core.CreateServerRole(ctx, "editor", "Editor", "Content editor")
+		role, err := core.CreateServerRole(ctx, SystemActorID, "editor", "Editor", "Content editor")
 		if err != nil {
 			t.Fatalf("Failed to create role: %v", err)
 		}
 		originalPos := role.Position
 
 		// Update the display name
-		updated, err := core.UpdateServerRole(ctx, "editor", "Super Editor", "Super content editor")
+		updated, err := core.UpdateServerRole(ctx, SystemActorID, "editor", "Super Editor", "Super content editor")
 		if err != nil {
 			t.Fatalf("Failed to update role: %v", err)
 		}
@@ -1361,7 +1361,7 @@ func TestChattoCore_CreateServerRole_PositionAssignment(t *testing.T) {
 	t.Run("multiple custom roles can be created", func(t *testing.T) {
 		roles := []string{"helper", "triage", "support"}
 		for _, name := range roles {
-			_, err := core.CreateServerRole(ctx, name, name, "Test role")
+			_, err := core.CreateServerRole(ctx, SystemActorID, name, name, "Test role")
 			if err != nil {
 				t.Fatalf("Failed to create role %s: %v", name, err)
 			}
@@ -1393,7 +1393,7 @@ func TestChattoCore_CreateRole(t *testing.T) {
 	// Create a space first (roles are per-space)
 
 	// Create a role
-	role, err := core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate content")
+	role, err := core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod", "Can moderate content")
 	if err != nil {
 		t.Fatalf("Failed to create role: %v", err)
 	}
@@ -1420,7 +1420,7 @@ func TestChattoCore_CreateRole_InvalidName(t *testing.T) {
 	ctx := testContext(t)
 
 	// Try to create role with invalid name
-	_, err := core.CreateServerRole(ctx, "Invalid-Name", "Invalid", "Should fail")
+	_, err := core.CreateServerRole(ctx, SystemActorID, "Invalid-Name", "Invalid", "Should fail")
 	if err == nil {
 		t.Error("Expected error for invalid role name")
 	}
@@ -1436,7 +1436,7 @@ func TestChattoCore_RoleMetadataLengthLimits(t *testing.T) {
 	t.Run("create accepts values at max length", func(t *testing.T) {
 		role, err := core.CreateServerRole(
 			ctx,
-			"maxrole",
+			SystemActorID, "maxrole",
 			strings.Repeat("d", MaxRoleDisplayNameLength),
 			strings.Repeat("x", MaxRoleDescriptionLength),
 		)
@@ -1449,20 +1449,20 @@ func TestChattoCore_RoleMetadataLengthLimits(t *testing.T) {
 	})
 
 	t.Run("create rejects over-limit display name", func(t *testing.T) {
-		_, err := core.CreateServerRole(ctx, "longdisplay", strings.Repeat("d", MaxRoleDisplayNameLength+1), "")
+		_, err := core.CreateServerRole(ctx, SystemActorID, "longdisplay", strings.Repeat("d", MaxRoleDisplayNameLength+1), "")
 		assertStringLengthError(t, err, "role display name", MaxRoleDisplayNameLength)
 	})
 
 	t.Run("create rejects over-limit description", func(t *testing.T) {
-		_, err := core.CreateServerRole(ctx, "longdescription", "Role", strings.Repeat("d", MaxRoleDescriptionLength+1))
+		_, err := core.CreateServerRole(ctx, SystemActorID, "longdescription", "Role", strings.Repeat("d", MaxRoleDescriptionLength+1))
 		assertStringLengthError(t, err, "role description", MaxRoleDescriptionLength)
 	})
 
 	t.Run("update rejects over-limit metadata", func(t *testing.T) {
-		if _, err := core.CreateServerRole(ctx, "editable", "Editable", ""); err != nil {
+		if _, err := core.CreateServerRole(ctx, SystemActorID, "editable", "Editable", ""); err != nil {
 			t.Fatalf("CreateServerRole: %v", err)
 		}
-		_, err := core.UpdateServerRole(ctx, "editable", strings.Repeat("d", MaxRoleDisplayNameLength+1), "")
+		_, err := core.UpdateServerRole(ctx, SystemActorID, "editable", strings.Repeat("d", MaxRoleDisplayNameLength+1), "")
 		assertStringLengthError(t, err, "role display name", MaxRoleDisplayNameLength)
 	})
 }
@@ -1472,13 +1472,13 @@ func TestChattoCore_CreateRole_Duplicate(t *testing.T) {
 	ctx := testContext(t)
 
 	// Create a role
-	_, err := core.CreateServerRole(ctx, "testmod", "Test Mod", "First")
+	_, err := core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod", "First")
 	if err != nil {
 		t.Fatalf("Failed to create first role: %v", err)
 	}
 
 	// Try to create same role again
-	_, err = core.CreateServerRole(ctx, "testmod", "Test Mod 2", "Second")
+	_, err = core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod 2", "Second")
 	if err == nil {
 		t.Error("Expected error for duplicate role")
 	}
@@ -1492,7 +1492,7 @@ func TestChattoCore_GetRole(t *testing.T) {
 	ctx := testContext(t)
 
 	// Create a role
-	_, err := core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate content")
+	_, err := core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod", "Can moderate content")
 	if err != nil {
 		t.Fatalf("Failed to create role: %v", err)
 	}
@@ -1541,8 +1541,8 @@ func TestChattoCore_ListRoles(t *testing.T) {
 	}
 
 	// Create some additional roles
-	core.CreateServerRole(ctx, "testmod", "Test Mod", "Test mod role")
-	core.CreateServerRole(ctx, "vip", "VIP", "VIP role")
+	core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod", "Test mod role")
+	core.CreateServerRole(ctx, SystemActorID, "vip", "VIP", "VIP role")
 
 	// List again - should have 6 total (4 default + 2 custom)
 	roles, err = core.ListServerRoles(ctx)
@@ -1559,13 +1559,13 @@ func TestChattoCore_UpdateRole(t *testing.T) {
 	ctx := testContext(t)
 
 	// Create a role
-	_, err := core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate content")
+	_, err := core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod", "Can moderate content")
 	if err != nil {
 		t.Fatalf("Failed to create role: %v", err)
 	}
 
 	// Update it
-	updated, err := core.UpdateServerRole(ctx, "testmod", "Super Moderator", "Enhanced moderation")
+	updated, err := core.UpdateServerRole(ctx, SystemActorID, "testmod", "Super Moderator", "Enhanced moderation")
 	if err != nil {
 		t.Fatalf("Failed to update role: %v", err)
 	}
@@ -1594,13 +1594,13 @@ func TestChattoCore_DeleteRole(t *testing.T) {
 	ctx := testContext(t)
 
 	// Create a role
-	_, err := core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate content")
+	_, err := core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod", "Can moderate content")
 	if err != nil {
 		t.Fatalf("Failed to create role: %v", err)
 	}
 
 	// Delete it
-	err = core.DeleteServerRole(ctx, "testmod")
+	err = core.DeleteServerRole(ctx, SystemActorID, "testmod")
 	if err != nil {
 		t.Fatalf("Failed to delete role: %v", err)
 	}
@@ -1624,7 +1624,7 @@ func TestChattoCore_DeleteRole_SystemRole(t *testing.T) {
 	}
 
 	// Try to delete - should fail
-	err = core.DeleteServerRole(ctx, RoleOwner)
+	err = core.DeleteServerRole(ctx, SystemActorID, RoleOwner)
 	if err == nil {
 		t.Error("Expected error when deleting system role")
 	}
@@ -1634,7 +1634,7 @@ func TestChattoCore_DeleteRole_SystemRole(t *testing.T) {
 	}
 
 	// Also test everyone role
-	err = core.DeleteServerRole(ctx, RoleEveryone)
+	err = core.DeleteServerRole(ctx, SystemActorID, RoleEveryone)
 	if !errors.Is(err, ErrCannotDeleteSystemRole) {
 		t.Errorf("Expected ErrCannotDeleteSystemRole for everyone role, got %v", err)
 	}
@@ -1645,14 +1645,14 @@ func TestChattoCore_DeleteRole_CleansUpPermissionsAndAssignments(t *testing.T) {
 	ctx := testContext(t)
 
 	// Create a role, grant permissions, and assign to a user
-	_, err := core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
+	_, err := core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod", "Can moderate")
 	if err != nil {
 		t.Fatalf("Failed to create role: %v", err)
 	}
 
 	// Grant permissions
-	core.GrantServerPermission(ctx, "testmod", PermRoleAssign)
-	core.GrantServerPermission(ctx, "testmod", PermRoomManage)
+	core.GrantServerPermission(ctx, SystemActorID, "testmod", PermRoleAssign)
+	core.GrantServerPermission(ctx, SystemActorID, "testmod", PermRoomManage)
 
 	// Assign role to a user
 	core.AssignServerRole(ctx, SystemActorID, "test-user", "testmod")
@@ -1676,7 +1676,7 @@ func TestChattoCore_DeleteRole_CleansUpPermissionsAndAssignments(t *testing.T) {
 	}
 
 	// Delete the role
-	err = core.DeleteServerRole(ctx, "testmod")
+	err = core.DeleteServerRole(ctx, SystemActorID, "testmod")
 	if err != nil {
 		t.Fatalf("Failed to delete role: %v", err)
 	}
@@ -1704,10 +1704,10 @@ func TestChattoCore_GrantRolePermission(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod", "Can moderate")
 
 	// Grant a permission
-	err := core.GrantServerPermission(ctx, "testmod", PermRoleAssign)
+	err := core.GrantServerPermission(ctx, SystemActorID, "testmod", PermRoleAssign)
 	if err != nil {
 		t.Fatalf("Failed to grant permission: %v", err)
 	}
@@ -1731,11 +1731,11 @@ func TestChattoCore_GrantRolePermission_Idempotent(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod", "Can moderate")
 
 	// Grant same permission twice
-	core.GrantServerPermission(ctx, "testmod", PermRoleAssign)
-	err := core.GrantServerPermission(ctx, "testmod", PermRoleAssign)
+	core.GrantServerPermission(ctx, SystemActorID, "testmod", PermRoleAssign)
+	err := core.GrantServerPermission(ctx, SystemActorID, "testmod", PermRoleAssign)
 	if err != nil {
 		t.Fatalf("Second grant should not fail: %v", err)
 	}
@@ -1755,10 +1755,10 @@ func TestChattoCore_GrantRolePermission_InvalidPermission(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod", "Can moderate")
 
 	// Try to grant an invalid permission
-	err := core.GrantServerPermission(ctx, "testmod", Permission("invalid_perm"))
+	err := core.GrantServerPermission(ctx, SystemActorID, "testmod", Permission("invalid_perm"))
 	if err == nil {
 		t.Error("Expected error when granting invalid permission")
 	}
@@ -1773,11 +1773,11 @@ func TestChattoCore_RevokeRolePermission(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod", "Can moderate")
 
 	// Grant then revoke
-	core.GrantServerPermission(ctx, "testmod", PermRoleAssign)
-	err := core.RevokeServerPermission(ctx, "testmod", PermRoleAssign)
+	core.GrantServerPermission(ctx, SystemActorID, "testmod", PermRoleAssign)
+	err := core.RevokeServerPermission(ctx, SystemActorID, "testmod", PermRoleAssign)
 	if err != nil {
 		t.Fatalf("Failed to revoke permission: %v", err)
 	}
@@ -1793,10 +1793,10 @@ func TestChattoCore_RevokeRolePermission_Idempotent(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod", "Can moderate")
 
 	// Revoke permission that was never granted
-	err := core.RevokeServerPermission(ctx, "testmod", PermRoleAssign)
+	err := core.RevokeServerPermission(ctx, SystemActorID, "testmod", PermRoleAssign)
 	if err != nil {
 		t.Fatalf("Revoking non-existent permission should not fail: %v", err)
 	}
@@ -1806,12 +1806,12 @@ func TestChattoCore_GetRolePermissions_Multiple(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod", "Can moderate")
 
 	// Grant multiple permissions
-	core.GrantServerPermission(ctx, "testmod", PermRoomJoin)
-	core.GrantServerPermission(ctx, "testmod", PermRoleAssign)
-	core.GrantServerPermission(ctx, "testmod", PermRoomManage)
+	core.GrantServerPermission(ctx, SystemActorID, "testmod", PermRoomJoin)
+	core.GrantServerPermission(ctx, SystemActorID, "testmod", PermRoleAssign)
+	core.GrantServerPermission(ctx, SystemActorID, "testmod", PermRoomManage)
 
 	perms, err := core.GetServerRolePermissions(ctx, "testmod")
 	if err != nil {
@@ -1843,7 +1843,7 @@ func TestChattoCore_GetRolePermissions_Empty(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod", "Can moderate")
 
 	// No permissions granted yet
 	perms, err := core.GetServerRolePermissions(ctx, "testmod")
@@ -1864,7 +1864,7 @@ func TestChattoCore_AssignRole(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod", "Can moderate")
 
 	// Assign role to user
 	err := core.AssignServerRole(ctx, SystemActorID, "user123", "testmod")
@@ -1891,7 +1891,7 @@ func TestChattoCore_AssignRole_Idempotent(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod", "Can moderate")
 
 	// Assign same role twice
 	core.AssignServerRole(ctx, SystemActorID, "user123", "testmod")
@@ -1922,7 +1922,7 @@ func TestChattoCore_RevokeRole(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod", "Can moderate")
 
 	// Assign then revoke
 	core.AssignServerRole(ctx, SystemActorID, "user123", "testmod")
@@ -1942,7 +1942,7 @@ func TestChattoCore_RevokeRole_Idempotent(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod", "Can moderate")
 
 	// Revoke role that was never assigned
 	err := core.RevokeServerRole(ctx, SystemActorID, "user123", "testmod")
@@ -2015,8 +2015,8 @@ func TestChattoCore_GetUserRoles_Multiple(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
-	core.CreateServerRole(ctx, "vip", "VIP", "VIP user")
+	core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, SystemActorID, "vip", "VIP", "VIP user")
 
 	// Assign multiple roles
 	core.AssignServerRole(ctx, SystemActorID, "user123", "testmod")
@@ -2049,7 +2049,7 @@ func TestChattoCore_GetRoleUsers(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod", "Can moderate")
 
 	// Assign role to multiple users
 	core.AssignServerRole(ctx, SystemActorID, "user1", "testmod")
@@ -2080,7 +2080,7 @@ func TestChattoCore_GetRoleUsers_Empty(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
+	core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod", "Can moderate")
 
 	// No users assigned yet
 	users, err := core.GetRoleUsers(ctx, "testmod")
@@ -2101,8 +2101,8 @@ func TestChattoCore_hasSpacePermission(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
-	core.GrantServerPermission(ctx, "testmod", PermRoleAssign)
+	core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod", "Can moderate")
+	core.GrantServerPermission(ctx, SystemActorID, "testmod", PermRoleAssign)
 	core.AssignServerRole(ctx, SystemActorID, "user123", "testmod")
 
 	// User should have the permission
@@ -2129,11 +2129,11 @@ func TestChattoCore_hasSpacePermission_MultipleRoles(t *testing.T) {
 	ctx := testContext(t)
 
 	// Create two roles with different permissions
-	core.CreateServerRole(ctx, "testmod", "Test Mod", "Can moderate")
-	core.GrantServerPermission(ctx, "testmod", PermRoleAssign)
+	core.CreateServerRole(ctx, SystemActorID, "testmod", "Test Mod", "Can moderate")
+	core.GrantServerPermission(ctx, SystemActorID, "testmod", PermRoleAssign)
 
-	core.CreateServerRole(ctx, "admin", "Admin", "Full access")
-	core.GrantServerPermission(ctx, "admin", PermServerManage)
+	core.CreateServerRole(ctx, SystemActorID, "admin", "Admin", "Full access")
+	core.GrantServerPermission(ctx, SystemActorID, "admin", PermServerManage)
 
 	// Assign both roles to user
 	core.AssignServerRole(ctx, SystemActorID, "user123", "testmod")
@@ -2223,7 +2223,7 @@ func TestChattoCore_GrantRoomRolePermission(t *testing.T) {
 	room, _ := core.CreateRoom(ctx, "test-user", KindChannel, "", "test-room", "Test channel")
 
 	// Grant message.post at room level for member role
-	err := core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
+	err := core.GrantRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermMessagePost)
 	if err != nil {
 		t.Fatalf("Failed to grant room permission: %v", err)
 	}
@@ -2248,7 +2248,7 @@ func TestChattoCore_DenyRoomRolePermission(t *testing.T) {
 	room, _ := core.CreateRoom(ctx, "test-user", KindChannel, "", "test-room", "Test channel")
 
 	// Deny message.post at room level
-	err := core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
+	err := core.DenyRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermMessagePost)
 	if err != nil {
 		t.Fatalf("Failed to deny room permission: %v", err)
 	}
@@ -2272,8 +2272,8 @@ func TestChattoCore_ClearRoomRolePermission(t *testing.T) {
 	room, _ := core.CreateRoom(ctx, "test-user", KindChannel, "", "test-room", "Test channel")
 
 	// Grant, then clear
-	core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
-	err := core.ClearRoomPermissionState(ctx, room.Id, RoleEveryone, PermMessagePost)
+	core.GrantRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermMessagePost)
+	err := core.ClearRoomPermissionState(ctx, SystemActorID, room.Id, RoleEveryone, PermMessagePost)
 	if err != nil {
 		t.Fatalf("Failed to clear room permission: %v", err)
 	}
@@ -2297,7 +2297,7 @@ func TestChattoCore_GrantRoomRolePermission_InvalidScope(t *testing.T) {
 	room, _ := core.CreateRoom(ctx, "test-user", KindChannel, "", "general", "General")
 
 	// space.manage is not room-scoped — should fail
-	err := core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermServerManage)
+	err := core.GrantRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermServerManage)
 	if err == nil {
 		t.Error("Expected error for non-room-scoped permission, got nil")
 	}
@@ -2311,7 +2311,7 @@ func TestChattoCore_RoomPermissions_PerRoomIsolation(t *testing.T) {
 	room2, _ := core.CreateRoom(ctx, "test-user", KindChannel, "", "room-beta", "Room Beta")
 
 	// Deny message.post only in room1
-	core.DenyRoomPermission(ctx, room1.Id, RoleEveryone, PermMessagePost)
+	core.DenyRoomPermission(ctx, SystemActorID, room1.Id, RoleEveryone, PermMessagePost)
 
 	// Room1 should have the denial
 	grants1, denials1, _ := core.GetRoomRolePermissions(ctx, room1.Id, RoleEveryone)
@@ -2341,8 +2341,8 @@ func TestChattoCore_GrantRoomRolePermission_GrantClearsDenial(t *testing.T) {
 	room, _ := core.CreateRoom(ctx, "test-user", KindChannel, "", "general", "General")
 
 	// Deny, then grant — should clear the denial
-	core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
-	core.GrantRoomPermission(ctx, room.Id, RoleEveryone, PermMessagePost)
+	core.DenyRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermMessagePost)
+	core.GrantRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermMessagePost)
 
 	grants, denials, _ := core.GetRoomRolePermissions(ctx, room.Id, RoleEveryone)
 	if len(grants) != 1 || grants[0] != PermMessagePost {
@@ -2421,7 +2421,7 @@ func TestChattoCore_GetUserEffectiveSpacePermissions_ServerRoleGrants(t *testing
 	}
 
 	// Grant role.manage to moderator role
-	err := core.GrantServerPermission(ctx, RoleModerator, PermRoleManage)
+	err := core.GrantServerPermission(ctx, SystemActorID, RoleModerator, PermRoleManage)
 	if err != nil {
 		t.Fatalf("Failed to grant role permission: %v", err)
 	}
@@ -2450,7 +2450,7 @@ func TestChattoCore_GetUserEffectiveSpacePermissions_DenyAlwaysWins(t *testing.T
 
 	// User joins space
 	// First grant room.create to everyone role (not granted by default)
-	err := core.GrantServerPermission(ctx, RoleEveryone, PermRoomCreate)
+	err := core.GrantServerPermission(ctx, SystemActorID, RoleEveryone, PermRoomCreate)
 	if err != nil {
 		t.Fatalf("Failed to grant permission: %v", err)
 	}
@@ -2466,7 +2466,7 @@ func TestChattoCore_GetUserEffectiveSpacePermissions_DenyAlwaysWins(t *testing.T
 	}
 
 	// Deny room.create to everyone role
-	err = core.DenyServerPermission(ctx, RoleEveryone, PermRoomCreate)
+	err = core.DenyServerPermission(ctx, SystemActorID, RoleEveryone, PermRoomCreate)
 	if err != nil {
 		t.Fatalf("Failed to deny permission: %v", err)
 	}
@@ -2507,7 +2507,7 @@ func TestChattoCore_GetUserEffectiveSpacePermissions_ServerRoleDenialInSpace(t *
 	}
 
 	// Deny room.join to moderator role
-	err := core.DenyServerPermission(ctx, RoleModerator, PermRoomJoin)
+	err := core.DenyServerPermission(ctx, SystemActorID, RoleModerator, PermRoomJoin)
 	if err != nil {
 		t.Fatalf("Failed to deny role permission: %v", err)
 	}
@@ -2545,7 +2545,7 @@ func TestChattoCore_AssignRole_HierarchyEnforcement(t *testing.T) {
 	core.AssignServerRole(ctx, SystemActorID, mod, RoleModerator)
 
 	// Grant role assignment permission to moderator so we can test hierarchy
-	core.GrantServerPermission(ctx, RoleModerator, PermRoleAssign)
+	core.GrantServerPermission(ctx, SystemActorID, RoleModerator, PermRoleAssign)
 
 	t.Run("owner can assign moderator role", func(t *testing.T) {
 		// Owner (position 1000) can assign moderator
@@ -2567,7 +2567,7 @@ func TestChattoCore_AssignRole_HierarchyEnforcement(t *testing.T) {
 
 	t.Run("regular member without explicit roles is blocked by role hierarchy", func(t *testing.T) {
 		// Create a custom role
-		core.CreateServerRole(ctx, "helper", "Helper", "Can help")
+		core.CreateServerRole(ctx, SystemActorID, "helper", "Helper", "Can help")
 
 		// Regular member only has the implicit "everyone" role (position 0),
 		// which cannot manage any concrete role.
@@ -2579,7 +2579,7 @@ func TestChattoCore_AssignRole_HierarchyEnforcement(t *testing.T) {
 
 	t.Run("moderator can assign lower-ranked custom role", func(t *testing.T) {
 		// Create a custom role (will be lower rank than moderator)
-		role, _ := core.CreateServerRole(ctx, "editor", "Editor", "Can edit")
+		role, _ := core.CreateServerRole(ctx, SystemActorID, "editor", "Editor", "Can edit")
 		// Verify the custom role has a position lower than moderator
 		// (position is lower number = lower rank)
 		if role.Position >= PositionModerator {
@@ -2633,7 +2633,7 @@ func TestChattoCore_RevokeRole_PeerProtection(t *testing.T) {
 	core.AssignServerRole(ctx, SystemActorID, modB, RoleModerator)
 
 	// Grant role assignment permission to moderators so we can test hierarchy
-	core.GrantServerPermission(ctx, RoleModerator, PermRoleAssign)
+	core.GrantServerPermission(ctx, SystemActorID, RoleModerator, PermRoleAssign)
 
 	t.Run("moderator A cannot revoke moderator B's moderator role", func(t *testing.T) {
 		// Both are equal rank (moderator), so neither can demote the other
@@ -2686,7 +2686,7 @@ func TestChattoCore_CreateRole_PositionAssignment(t *testing.T) {
 
 	t.Run("first custom role gets position after system roles", func(t *testing.T) {
 		// System roles: everyone (0), moderator (100), admin (900), owner (1000)
-		role, err := core.CreateServerRole(ctx, "editor", "Editor", "Can edit")
+		role, err := core.CreateServerRole(ctx, SystemActorID, "editor", "Editor", "Can edit")
 		if err != nil {
 			t.Fatalf("CreateRole failed: %v", err)
 		}
@@ -2698,14 +2698,14 @@ func TestChattoCore_CreateRole_PositionAssignment(t *testing.T) {
 	})
 
 	t.Run("position preserved after display name update", func(t *testing.T) {
-		role, err := core.CreateServerRole(ctx, "contributor", "Contributor", "Can contribute")
+		role, err := core.CreateServerRole(ctx, SystemActorID, "contributor", "Contributor", "Can contribute")
 		if err != nil {
 			t.Fatalf("CreateRole failed: %v", err)
 		}
 		originalPos := role.Position
 
 		// Update display name
-		updated, err := core.UpdateServerRole(ctx, "contributor", "Super Contributor", "Can contribute a lot")
+		updated, err := core.UpdateServerRole(ctx, SystemActorID, "contributor", "Super Contributor", "Can contribute a lot")
 		if err != nil {
 			t.Fatalf("UpdateRole failed: %v", err)
 		}
@@ -2717,13 +2717,13 @@ func TestChattoCore_CreateRole_PositionAssignment(t *testing.T) {
 
 	t.Run("roles can be reordered via ReorderServerRoles", func(t *testing.T) {
 		// Create multiple custom roles
-		core.CreateServerRole(ctx, "alpha", "Alpha", "Alpha role")
-		core.CreateServerRole(ctx, "beta", "Beta", "Beta role")
+		core.CreateServerRole(ctx, SystemActorID, "alpha", "Alpha", "Alpha role")
+		core.CreateServerRole(ctx, SystemActorID, "beta", "Beta", "Beta role")
 
 		// Reorder all custom roles. ReorderServerRoles requires a complete
 		// custom-role list so clients cannot accidentally drop roles from the
 		// authoritative ordering event.
-		roles, err := core.ReorderServerRoles(ctx, []string{"editor", "contributor", "beta", "alpha"})
+		roles, err := core.ReorderServerRoles(ctx, SystemActorID, []string{"editor", "contributor", "beta", "alpha"})
 		if err != nil {
 			t.Fatalf("ReorderServerRoles failed: %v", err)
 		}

--- a/cli/internal/core/room_visibility_test.go
+++ b/cli/internal/core/room_visibility_test.go
@@ -32,11 +32,11 @@ func TestCanSeeRoom_VisibilityFollowsListPermission(t *testing.T) {
 	})
 
 	t.Run("room-scope deny of room.list on everyone: non-member loses visibility", func(t *testing.T) {
-		if err := core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermRoomList); err != nil {
+		if err := core.DenyRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermRoomList); err != nil {
 			t.Fatalf("DenyRoomPermission: %v", err)
 		}
 		t.Cleanup(func() {
-			_ = core.ClearRoomPermissionState(ctx, room.Id, RoleEveryone, PermRoomList)
+			_ = core.ClearRoomPermissionState(ctx, SystemActorID, room.Id, RoleEveryone, PermRoomList)
 		})
 
 		stranger, _ := core.CreateUser(ctx, SystemActorID, "vis-stranger-denied", "Stranger", "password123")
@@ -50,11 +50,11 @@ func TestCanSeeRoom_VisibilityFollowsListPermission(t *testing.T) {
 	})
 
 	t.Run("denying room.join does NOT affect visibility — separate gate", func(t *testing.T) {
-		if err := core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermRoomJoin); err != nil {
+		if err := core.DenyRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermRoomJoin); err != nil {
 			t.Fatalf("DenyRoomPermission: %v", err)
 		}
 		t.Cleanup(func() {
-			_ = core.ClearRoomPermissionState(ctx, room.Id, RoleEveryone, PermRoomJoin)
+			_ = core.ClearRoomPermissionState(ctx, SystemActorID, room.Id, RoleEveryone, PermRoomJoin)
 		})
 
 		stranger, _ := core.CreateUser(ctx, SystemActorID, "vis-stranger-no-join", "Stranger", "password123")
@@ -72,11 +72,11 @@ func TestCanSeeRoom_VisibilityFollowsListPermission(t *testing.T) {
 		if _, err := core.JoinRoom(ctx, member.Id, KindChannel, member.Id, room.Id); err != nil {
 			t.Fatalf("JoinRoom: %v", err)
 		}
-		if err := core.DenyRoomPermission(ctx, room.Id, RoleEveryone, PermRoomList); err != nil {
+		if err := core.DenyRoomPermission(ctx, SystemActorID, room.Id, RoleEveryone, PermRoomList); err != nil {
 			t.Fatalf("DenyRoomPermission: %v", err)
 		}
 		t.Cleanup(func() {
-			_ = core.ClearRoomPermissionState(ctx, room.Id, RoleEveryone, PermRoomList)
+			_ = core.ClearRoomPermissionState(ctx, SystemActorID, room.Id, RoleEveryone, PermRoomList)
 		})
 
 		got, err := core.CanSeeRoom(ctx, member.Id, KindChannel, room.Id)

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -1012,7 +1012,7 @@ func (c *ChattoCore) DeleteUser(ctx context.Context, actorID, userID string) err
 	}
 
 	// Revoke all role assignments (server-wide, no per-space loop needed).
-	if err := c.RevokeAllUserRoles(ctx, userID); err != nil {
+	if err := c.RevokeAllUserRoles(ctx, actorID, userID); err != nil {
 		c.logger.Warn("Failed to revoke user roles during deletion", "user_id", userID, "error", err)
 	}
 

--- a/cli/internal/core/users_test.go
+++ b/cli/internal/core/users_test.go
@@ -837,7 +837,7 @@ func TestChattoCore_CreateUser_MentionNamespaceReserved(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	if _, err := core.CreateServerRole(ctx, "helpdesk", "Helpdesk", ""); err != nil {
+	if _, err := core.CreateServerRole(ctx, SystemActorID, "helpdesk", "Helpdesk", ""); err != nil {
 		t.Fatalf("CreateServerRole helpdesk: %v", err)
 	}
 
@@ -862,7 +862,7 @@ func TestChattoCore_UpdateUserLoginReleasesOldMentionHandle(t *testing.T) {
 	if _, err := core.UpdateUserLogin(ctx, user.Id, "newhandle"); err != nil {
 		t.Fatalf("UpdateUserLogin: %v", err)
 	}
-	if _, err := core.CreateServerRole(ctx, "oldhandle", "Old Handle", ""); err != nil {
+	if _, err := core.CreateServerRole(ctx, SystemActorID, "oldhandle", "Old Handle", ""); err != nil {
 		t.Fatalf("CreateServerRole with released login: %v", err)
 	}
 }

--- a/cli/internal/graph/admin_event_log_test.go
+++ b/cli/internal/graph/admin_event_log_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"math"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/nats-io/nats.go/jetstream"
@@ -12,6 +13,7 @@ import (
 
 	"hmans.de/chatto/internal/core"
 	"hmans.de/chatto/internal/events"
+	"hmans.de/chatto/internal/graph/model"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
@@ -127,6 +129,58 @@ func TestEventLog_AuthorizationDenied(t *testing.T) {
 
 	_, err = adminQ.EventLogEntry(ctx, nil, "1")
 	require.True(t, errors.Is(err, core.ErrPermissionDenied), "EventLogEntry should deny non-auditor, got: %v", err)
+}
+
+func TestRBACMutationsUseAuthenticatedActorInEventLog(t *testing.T) {
+	env := setupTestResolver(t)
+	ctx := env.authContext()
+	mutation := env.resolver.Mutation()
+
+	roleName := "auditactor"
+	_, err := mutation.CreateRole(ctx, model.CreateRoleInput{
+		Name:        roleName,
+		DisplayName: "Audit Actor",
+		Description: "Role used to verify RBAC audit attribution",
+	})
+	require.NoError(t, err)
+
+	pingable := true
+	_, err = mutation.UpdateRole(ctx, model.UpdateRoleInput{
+		Name:        roleName,
+		DisplayName: "Audit Actor",
+		Description: "Role used to verify RBAC audit attribution",
+		Pingable:    &pingable,
+	})
+	require.NoError(t, err)
+
+	_, err = mutation.GrantPermission(ctx, model.GrantPermissionInput{
+		RoleName:   roleName,
+		Permission: string(core.PermRoomJoin),
+	})
+	require.NoError(t, err)
+
+	_, err = mutation.DeleteRole(ctx, model.DeleteRoleInput{Name: roleName})
+	require.NoError(t, err)
+
+	limit := int32(50)
+	conn, err := env.resolver.AdminQueries().EventLog(ctx, nil, &limit, nil)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	requireEventLogActor(t, conn.Entries, "RbacRoleCreatedEvent", env.testUser.Id, roleName)
+	requireEventLogActor(t, conn.Entries, "RbacRolePingableChangedEvent", env.testUser.Id, roleName)
+	requireEventLogActor(t, conn.Entries, "RbacPermissionGrantedEvent", env.testUser.Id, roleName)
+	requireEventLogActor(t, conn.Entries, "RbacRoleDeletedEvent", env.testUser.Id, roleName)
+}
+
+func requireEventLogActor(t *testing.T, entries []*model.EventLogEntry, eventType, actorID, payloadSubstring string) {
+	t.Helper()
+	for _, entry := range entries {
+		if entry.EventType == eventType && entry.ActorID == actorID && strings.Contains(entry.PayloadJSON, payloadSubstring) {
+			return
+		}
+	}
+	t.Fatalf("missing %s entry for actor %s containing %q", eventType, actorID, payloadSubstring)
 }
 
 func TestEventLogTotalCountUsesWideInteger(t *testing.T) {

--- a/cli/internal/graph/authz_test.go
+++ b/cli/internal/graph/authz_test.go
@@ -226,7 +226,7 @@ func TestRequireServerPermission(t *testing.T) {
 		}
 
 		// Deny message.post for everyone role
-		if err := env.core.DenyServerPermission(env.ctx, core.RoleEveryone, core.PermMessagePost); err != nil {
+		if err := env.core.DenyServerPermission(env.ctx, core.SystemActorID, core.RoleEveryone, core.PermMessagePost); err != nil {
 			t.Fatalf("Failed to deny permission: %v", err)
 		}
 

--- a/cli/internal/graph/dm_test.go
+++ b/cli/internal/graph/dm_test.go
@@ -82,10 +82,10 @@ func TestMutationResolver_StartDM(t *testing.T) {
 		}
 
 		// Create a restriction role, deny message.post on it, and assign to user
-		if _, err := env.core.CreateServerRole(env.ctx, "dmblocked", "DM Blocked", ""); err != nil {
+		if _, err := env.core.CreateServerRole(env.ctx, core.SystemActorID, "dmblocked", "DM Blocked", ""); err != nil {
 			t.Fatalf("failed to create role: %v", err)
 		}
-		if err := env.core.DenyServerPermission(env.ctx, "dmblocked", core.PermMessagePost); err != nil {
+		if err := env.core.DenyServerPermission(env.ctx, core.SystemActorID, "dmblocked", core.PermMessagePost); err != nil {
 			t.Fatalf("failed to deny permission: %v", err)
 		}
 		if err := env.core.AssignServerRole(env.ctx, core.SystemActorID, blockedUser.Id, "dmblocked"); err != nil {

--- a/cli/internal/graph/join_group_test.go
+++ b/cli/internal/graph/join_group_test.go
@@ -85,7 +85,7 @@ func TestJoinGroup_SkipsAlreadyJoinedAndNonJoinable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateRoom restricted: %v", err)
 	}
-	if err := env.core.DenyUserRoomPermission(env.ctx, restricted.Id, member.Id, core.PermRoomJoin); err != nil {
+	if err := env.core.DenyUserRoomPermission(env.ctx, core.SystemActorID, restricted.Id, member.Id, core.PermRoomJoin); err != nil {
 		t.Fatalf("DenyUserRoomPermission: %v", err)
 	}
 

--- a/cli/internal/graph/message_authorship_test.go
+++ b/cli/internal/graph/message_authorship_test.go
@@ -21,11 +21,11 @@ func TestAuthorAlwaysCanEditOrDeleteOwnMessage(t *testing.T) {
 
 	// Deny message.manage on everyone at every tier so no role grant could
 	// possibly allow author moderation. Authors must still pass.
-	if err := env.core.DenyServerPermission(env.ctx, core.RoleEveryone, core.PermMessageManage); err != nil {
+	if err := env.core.DenyServerPermission(env.ctx, core.SystemActorID, core.RoleEveryone, core.PermMessageManage); err != nil {
 		t.Fatalf("DenyServerPermission: %v", err)
 	}
 	groupID := env.testRoom.GroupId
-	if err := env.core.DenyGroupPermission(env.ctx, groupID, core.RoleEveryone, core.PermMessageManage); err != nil {
+	if err := env.core.DenyGroupPermission(env.ctx, core.SystemActorID, groupID, core.RoleEveryone, core.PermMessageManage); err != nil {
 		t.Fatalf("DenyGroupPermission: %v", err)
 	}
 
@@ -136,11 +136,11 @@ func TestRoomManageOpensPerRoomPermissionEditor(t *testing.T) {
 
 	t.Run("member with room.manage on target room can edit that room's permissions", func(t *testing.T) {
 		// Grant room.manage to this user directly on the target room.
-		if err := env.core.GrantUserRoomPermission(env.ctx, targetRoom.Id, member.Id, core.PermRoomManage); err != nil {
+		if err := env.core.GrantUserRoomPermission(env.ctx, core.SystemActorID, targetRoom.Id, member.Id, core.PermRoomManage); err != nil {
 			t.Fatalf("GrantUserRoomPermission: %v", err)
 		}
 		t.Cleanup(func() {
-			_ = env.core.ClearUserRoomPermissionState(env.ctx, targetRoom.Id, member.Id, core.PermRoomManage)
+			_ = env.core.ClearUserRoomPermissionState(env.ctx, core.SystemActorID, targetRoom.Id, member.Id, core.PermRoomManage)
 		})
 
 		_, err := mutation.GrantRoomPermission(env.authContextForUser(member), input(targetRoom.Id))
@@ -152,11 +152,11 @@ func TestRoomManageOpensPerRoomPermissionEditor(t *testing.T) {
 	t.Run("same member denied on a different room", func(t *testing.T) {
 		// Re-grant room.manage on targetRoom so the user has it somewhere
 		// (and shouldn't be confused with "no room.manage anywhere").
-		if err := env.core.GrantUserRoomPermission(env.ctx, targetRoom.Id, member.Id, core.PermRoomManage); err != nil {
+		if err := env.core.GrantUserRoomPermission(env.ctx, core.SystemActorID, targetRoom.Id, member.Id, core.PermRoomManage); err != nil {
 			t.Fatalf("GrantUserRoomPermission: %v", err)
 		}
 		t.Cleanup(func() {
-			_ = env.core.ClearUserRoomPermissionState(env.ctx, targetRoom.Id, member.Id, core.PermRoomManage)
+			_ = env.core.ClearUserRoomPermissionState(env.ctx, core.SystemActorID, targetRoom.Id, member.Id, core.PermRoomManage)
 		})
 
 		_, err := mutation.GrantRoomPermission(env.authContextForUser(member), input(otherRoom.Id))

--- a/cli/internal/graph/mutation_test.go
+++ b/cli/internal/graph/mutation_test.go
@@ -92,7 +92,7 @@ func TestCreateRoom_Authorization(t *testing.T) {
 		}
 
 		// Grant room.create to the everyone role
-		err = env.core.GrantServerPermission(env.ctx, core.RoleEveryone, core.PermRoomCreate)
+		err = env.core.GrantServerPermission(env.ctx, core.SystemActorID, core.RoleEveryone, core.PermRoomCreate)
 		if err != nil {
 			t.Fatalf("failed to grant permission: %v", err)
 		}
@@ -538,10 +538,10 @@ func TestPostMessage_ThreadPermissions(t *testing.T) {
 
 	t.Run("member with post-in-thread denied cannot post any thread reply", func(t *testing.T) {
 		groupID := env.testRoom.GroupId
-		if err := env.core.DenyGroupPermission(env.ctx, groupID, core.RoleEveryone, core.PermMessagePostInThread); err != nil {
+		if err := env.core.DenyGroupPermission(env.ctx, core.SystemActorID, groupID, core.RoleEveryone, core.PermMessagePostInThread); err != nil {
 			t.Fatalf("failed to deny permission: %v", err)
 		}
-		defer env.core.GrantGroupPermission(env.ctx, groupID, core.RoleEveryone, core.PermMessagePostInThread)
+		defer env.core.GrantGroupPermission(env.ctx, core.SystemActorID, groupID, core.RoleEveryone, core.PermMessagePostInThread)
 
 		root, err := env.core.PostMessage(env.ctx, core.KindChannel, env.testRoom.Id, env.testUser.Id, "Root for deny test", nil, "", "", nil, false)
 		if err != nil {
@@ -575,10 +575,10 @@ func TestPostMessage_ThreadPermissions(t *testing.T) {
 	})
 
 	t.Run("denying message.post does not affect thread replies", func(t *testing.T) {
-		if err := env.core.DenyServerPermission(env.ctx, core.RoleEveryone, core.PermMessagePost); err != nil {
+		if err := env.core.DenyServerPermission(env.ctx, core.SystemActorID, core.RoleEveryone, core.PermMessagePost); err != nil {
 			t.Fatalf("failed to deny permission: %v", err)
 		}
-		defer env.core.GrantServerPermission(env.ctx, core.RoleEveryone, core.PermMessagePost)
+		defer env.core.GrantServerPermission(env.ctx, core.SystemActorID, core.RoleEveryone, core.PermMessagePost)
 
 		root, err := env.core.PostMessage(env.ctx, core.KindChannel, env.testRoom.Id, env.testUser.Id, "Root for independence test", nil, "", "", nil, false)
 		if err != nil {
@@ -970,10 +970,10 @@ func TestBanRoomMember_Authorization(t *testing.T) {
 		if _, err := env.core.JoinRoom(env.ctx, target.Id, core.KindChannel, target.Id, env.testRoom.Id); err != nil {
 			t.Fatalf("JoinRoom target: %v", err)
 		}
-		if err := env.core.DenyRoomPermission(env.ctx, env.testRoom.Id, core.RoleAdmin, core.PermRoomMemberBan); err != nil {
+		if err := env.core.DenyRoomPermission(env.ctx, core.SystemActorID, env.testRoom.Id, core.RoleAdmin, core.PermRoomMemberBan); err != nil {
 			t.Fatalf("DenyRoomPermission room.ban-member: %v", err)
 		}
-		if err := env.core.GrantRoomPermission(env.ctx, env.testRoom.Id, core.RoleAdmin, core.PermRoomManage); err != nil {
+		if err := env.core.GrantRoomPermission(env.ctx, core.SystemActorID, env.testRoom.Id, core.RoleAdmin, core.PermRoomManage); err != nil {
 			t.Fatalf("GrantRoomPermission room.manage: %v", err)
 		}
 
@@ -1004,7 +1004,7 @@ func TestBanRoomMember_Authorization(t *testing.T) {
 				t.Fatalf("JoinRoom moderator: %v", err)
 			}
 		}
-		if err := env.core.GrantRoomPermission(env.ctx, env.testRoom.Id, core.RoleModerator, core.PermRoomMemberBan); err != nil {
+		if err := env.core.GrantRoomPermission(env.ctx, core.SystemActorID, env.testRoom.Id, core.RoleModerator, core.PermRoomMemberBan); err != nil {
 			t.Fatalf("GrantRoomPermission room.ban-member: %v", err)
 		}
 
@@ -1845,7 +1845,7 @@ func TestPostMessage_EchoPermission(t *testing.T) {
 		}
 
 		// Deny echo at room level for everyone role (testUser is space owner, has roles.manage)
-		err = env.core.DenyRoomPermission(env.ctx, env.testRoom.Id, core.RoleEveryone, core.PermMessageEcho)
+		err = env.core.DenyRoomPermission(env.ctx, core.SystemActorID, env.testRoom.Id, core.RoleEveryone, core.PermMessageEcho)
 		if err != nil {
 			t.Fatalf("failed to deny permission: %v", err)
 		}
@@ -1876,7 +1876,7 @@ func TestPostMessage_EchoPermission(t *testing.T) {
 		}
 
 		// Deny message.post at room level for everyone role
-		err = env.core.DenyRoomPermission(env.ctx, env.testRoom.Id, core.RoleEveryone, core.PermMessagePost)
+		err = env.core.DenyRoomPermission(env.ctx, core.SystemActorID, env.testRoom.Id, core.RoleEveryone, core.PermMessagePost)
 		if err != nil {
 			t.Fatalf("failed to deny permission: %v", err)
 		}

--- a/cli/internal/graph/permission_inspector_test.go
+++ b/cli/internal/graph/permission_inspector_test.go
@@ -84,7 +84,7 @@ func TestPermissionExplanation_RoleManagerInspectsAnotherUser(t *testing.T) {
 	if err := env.core.AssignServerRole(env.ctx, core.SystemActorID, manager.Id, core.RoleModerator); err != nil {
 		t.Fatalf("AssignServerRole: %v", err)
 	}
-	if err := env.core.GrantServerPermission(env.ctx, core.RoleModerator, core.PermRoleManage); err != nil {
+	if err := env.core.GrantServerPermission(env.ctx, core.SystemActorID, core.RoleModerator, core.PermRoleManage); err != nil {
 		t.Fatalf("GrantServerPermission role.manage: %v", err)
 	}
 

--- a/cli/internal/graph/role_permission_matrix_test.go
+++ b/cli/internal/graph/role_permission_matrix_test.go
@@ -62,7 +62,7 @@ func TestRolePermissionMatrix_ReflectsExplicitGrant(t *testing.T) {
 	env := setupTestResolver(t)
 	rbac := env.resolver.RbacQueries()
 
-	if err := env.core.GrantServerPermission(env.ctx, "moderator", core.PermMessageManage); err != nil {
+	if err := env.core.GrantServerPermission(env.ctx, core.SystemActorID, "moderator", core.PermMessageManage); err != nil {
 		t.Fatalf("GrantServerPermission: %v", err)
 	}
 

--- a/cli/internal/graph/room_groups.resolvers.go
+++ b/cli/internal/graph/room_groups.resolvers.go
@@ -189,7 +189,7 @@ func (r *mutationResolver) GrantGroupPermission(ctx context.Context, input model
 		return false, err
 	}
 	perm := core.Permission(input.Permission)
-	if err := r.core.GrantGroupPermission(ctx, input.GroupID, input.Subject, perm); err != nil {
+	if err := r.core.GrantGroupPermission(ctx, user.Id, input.GroupID, input.Subject, perm); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -205,7 +205,7 @@ func (r *mutationResolver) DenyGroupPermission(ctx context.Context, input model.
 		return false, err
 	}
 	perm := core.Permission(input.Permission)
-	if err := r.core.DenyGroupPermission(ctx, input.GroupID, input.Subject, perm); err != nil {
+	if err := r.core.DenyGroupPermission(ctx, user.Id, input.GroupID, input.Subject, perm); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -221,7 +221,7 @@ func (r *mutationResolver) ClearGroupPermissionState(ctx context.Context, input 
 		return false, err
 	}
 	perm := core.Permission(input.Permission)
-	if err := r.core.ClearGroupPermissionState(ctx, input.GroupID, input.Subject, perm); err != nil {
+	if err := r.core.ClearGroupPermissionState(ctx, user.Id, input.GroupID, input.Subject, perm); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/cli/internal/graph/room_visibility_test.go
+++ b/cli/internal/graph/room_visibility_test.go
@@ -21,8 +21,8 @@ func TestRoomResolver_ListableButNotJoinable(t *testing.T) {
 	// the listable-but-not-joinable state.
 	viewer := env.createVerifiedUser(t, "list-only-viewer", "Viewer", "password123")
 
-	if err := env.core.DenyRoomPermission(env.ctx, env.testRoom.Id, core.RoleEveryone, core.PermRoomJoin); err != nil {
-		t.Fatalf("DenyRoomPermission(room.join, everyone): %v", err)
+	if err := env.core.DenyRoomPermission(env.ctx, core.SystemActorID, env.testRoom.Id, core.RoleEveryone, core.PermRoomJoin); err != nil {
+		t.Fatalf("DenyRoomPermission(room.join, core.SystemActorID, everyone): %v", err)
 	}
 
 	ctx := env.authContextForUser(viewer)
@@ -54,8 +54,8 @@ func TestRoomResolver_HiddenWhenListDenied(t *testing.T) {
 
 	viewer := env.createVerifiedUser(t, "hidden-viewer", "Viewer", "password123")
 
-	if err := env.core.DenyRoomPermission(env.ctx, env.testRoom.Id, core.RoleEveryone, core.PermRoomList); err != nil {
-		t.Fatalf("DenyRoomPermission(room.list, everyone): %v", err)
+	if err := env.core.DenyRoomPermission(env.ctx, core.SystemActorID, env.testRoom.Id, core.RoleEveryone, core.PermRoomList); err != nil {
+		t.Fatalf("DenyRoomPermission(room.list, core.SystemActorID, everyone): %v", err)
 	}
 
 	ctx := env.authContextForUser(viewer)
@@ -82,8 +82,8 @@ func TestRoomResolver_ListableForMemberEvenWhenListDenied(t *testing.T) {
 		t.Fatalf("JoinRoom: %v", err)
 	}
 
-	if err := env.core.DenyRoomPermission(env.ctx, env.testRoom.Id, core.RoleEveryone, core.PermRoomList); err != nil {
-		t.Fatalf("DenyRoomPermission(room.list, everyone): %v", err)
+	if err := env.core.DenyRoomPermission(env.ctx, core.SystemActorID, env.testRoom.Id, core.RoleEveryone, core.PermRoomList); err != nil {
+		t.Fatalf("DenyRoomPermission(room.list, core.SystemActorID, everyone): %v", err)
 	}
 
 	ctx := env.authContextForUser(viewer)

--- a/cli/internal/graph/server_rbac.resolvers.go
+++ b/cli/internal/graph/server_rbac.resolvers.go
@@ -28,7 +28,7 @@ func (r *mutationResolver) GrantPermission(ctx context.Context, input model.Gran
 	if !can {
 		return false, core.ErrPermissionDenied
 	}
-	if err := r.core.GrantServerPermission(ctx, input.RoleName, core.Permission(input.Permission)); err != nil {
+	if err := r.core.GrantServerPermission(ctx, user.Id, input.RoleName, core.Permission(input.Permission)); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -47,7 +47,7 @@ func (r *mutationResolver) RevokePermission(ctx context.Context, input model.Rev
 	if !can {
 		return false, core.ErrPermissionDenied
 	}
-	if err := r.core.RevokeServerPermission(ctx, input.RoleName, core.Permission(input.Permission)); err != nil {
+	if err := r.core.RevokeServerPermission(ctx, user.Id, input.RoleName, core.Permission(input.Permission)); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -66,7 +66,7 @@ func (r *mutationResolver) DenyPermission(ctx context.Context, input model.DenyP
 	if !can {
 		return false, core.ErrPermissionDenied
 	}
-	if err := r.core.DenyServerPermission(ctx, input.RoleName, core.Permission(input.Permission)); err != nil {
+	if err := r.core.DenyServerPermission(ctx, user.Id, input.RoleName, core.Permission(input.Permission)); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -85,7 +85,7 @@ func (r *mutationResolver) ClearPermissionState(ctx context.Context, input model
 	if !can {
 		return false, core.ErrPermissionDenied
 	}
-	if err := r.core.ClearServerPermissionState(ctx, input.RoleName, core.Permission(input.Permission)); err != nil {
+	if err := r.core.ClearServerPermissionState(ctx, user.Id, input.RoleName, core.Permission(input.Permission)); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -111,7 +111,7 @@ func (r *mutationResolver) CreateRole(ctx context.Context, input model.CreateRol
 	if input.Pingable != nil {
 		pingable = *input.Pingable
 	}
-	role, err := r.core.CreateServerRole(ctx, input.Name, input.DisplayName, input.Description, pingable)
+	role, err := r.core.CreateServerRole(ctx, user.Id, input.Name, input.DisplayName, input.Description, pingable)
 	if err != nil {
 		return nil, err
 	}
@@ -136,9 +136,9 @@ func (r *mutationResolver) UpdateRole(ctx context.Context, input model.UpdateRol
 
 	var role *core.RoleWithPermissions
 	if input.Pingable != nil {
-		role, err = r.core.UpdateServerRole(ctx, input.Name, input.DisplayName, input.Description, *input.Pingable)
+		role, err = r.core.UpdateServerRole(ctx, user.Id, input.Name, input.DisplayName, input.Description, *input.Pingable)
 	} else {
-		role, err = r.core.UpdateServerRole(ctx, input.Name, input.DisplayName, input.Description)
+		role, err = r.core.UpdateServerRole(ctx, user.Id, input.Name, input.DisplayName, input.Description)
 	}
 	if err != nil {
 		return nil, err
@@ -162,7 +162,7 @@ func (r *mutationResolver) DeleteRole(ctx context.Context, input model.DeleteRol
 		return false, core.ErrPermissionDenied
 	}
 
-	if err := r.core.DeleteServerRole(ctx, input.Name); err != nil {
+	if err := r.core.DeleteServerRole(ctx, user.Id, input.Name); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -241,7 +241,7 @@ func (r *mutationResolver) ReorderRoles(ctx context.Context, input model.Reorder
 		return nil, core.ErrPermissionDenied
 	}
 
-	roles, err := r.core.ReorderServerRoles(ctx, input.RoleNames)
+	roles, err := r.core.ReorderServerRoles(ctx, caller.Id, input.RoleNames)
 	if err != nil {
 		return nil, err
 	}
@@ -268,15 +268,15 @@ func (r *mutationResolver) GrantUserPermission(ctx context.Context, input model.
 	perm := core.Permission(input.Permission)
 	switch {
 	case input.RoomID != nil:
-		if err := r.core.GrantUserRoomPermission(ctx, *input.RoomID, input.UserID, perm); err != nil {
+		if err := r.core.GrantUserRoomPermission(ctx, caller.Id, *input.RoomID, input.UserID, perm); err != nil {
 			return false, err
 		}
 	case input.GroupID != nil:
-		if err := r.core.GrantUserGroupPermission(ctx, *input.GroupID, input.UserID, perm); err != nil {
+		if err := r.core.GrantUserGroupPermission(ctx, caller.Id, *input.GroupID, input.UserID, perm); err != nil {
 			return false, err
 		}
 	default:
-		if err := r.core.GrantUserPermission(ctx, input.UserID, perm); err != nil {
+		if err := r.core.GrantUserPermission(ctx, caller.Id, input.UserID, perm); err != nil {
 			return false, err
 		}
 	}
@@ -298,15 +298,15 @@ func (r *mutationResolver) DenyUserPermission(ctx context.Context, input model.D
 	perm := core.Permission(input.Permission)
 	switch {
 	case input.RoomID != nil:
-		if err := r.core.DenyUserRoomPermission(ctx, *input.RoomID, input.UserID, perm); err != nil {
+		if err := r.core.DenyUserRoomPermission(ctx, caller.Id, *input.RoomID, input.UserID, perm); err != nil {
 			return false, err
 		}
 	case input.GroupID != nil:
-		if err := r.core.DenyUserGroupPermission(ctx, *input.GroupID, input.UserID, perm); err != nil {
+		if err := r.core.DenyUserGroupPermission(ctx, caller.Id, *input.GroupID, input.UserID, perm); err != nil {
 			return false, err
 		}
 	default:
-		if err := r.core.DenyUserPermission(ctx, input.UserID, perm); err != nil {
+		if err := r.core.DenyUserPermission(ctx, caller.Id, input.UserID, perm); err != nil {
 			return false, err
 		}
 	}
@@ -328,15 +328,15 @@ func (r *mutationResolver) ClearUserPermissionState(ctx context.Context, input m
 	perm := core.Permission(input.Permission)
 	switch {
 	case input.RoomID != nil:
-		if err := r.core.ClearUserRoomPermissionState(ctx, *input.RoomID, input.UserID, perm); err != nil {
+		if err := r.core.ClearUserRoomPermissionState(ctx, caller.Id, *input.RoomID, input.UserID, perm); err != nil {
 			return false, err
 		}
 	case input.GroupID != nil:
-		if err := r.core.ClearUserGroupPermissionState(ctx, *input.GroupID, input.UserID, perm); err != nil {
+		if err := r.core.ClearUserGroupPermissionState(ctx, caller.Id, *input.GroupID, input.UserID, perm); err != nil {
 			return false, err
 		}
 	default:
-		if err := r.core.ClearUserPermissionState(ctx, input.UserID, perm); err != nil {
+		if err := r.core.ClearUserPermissionState(ctx, caller.Id, input.UserID, perm); err != nil {
 			return false, err
 		}
 	}

--- a/cli/internal/graph/server_rbac_extra.resolvers.go
+++ b/cli/internal/graph/server_rbac_extra.resolvers.go
@@ -25,7 +25,7 @@ func (r *mutationResolver) GrantRoomPermission(ctx context.Context, input model.
 		return false, err
 	}
 
-	if err := r.core.GrantRoomPermission(ctx, input.RoomID, input.RoleName, core.Permission(input.Permission)); err != nil {
+	if err := r.core.GrantRoomPermission(ctx, user.Id, input.RoomID, input.RoleName, core.Permission(input.Permission)); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -41,7 +41,7 @@ func (r *mutationResolver) DenyRoomPermission(ctx context.Context, input model.D
 		return false, err
 	}
 
-	if err := r.core.DenyRoomPermission(ctx, input.RoomID, input.RoleName, core.Permission(input.Permission)); err != nil {
+	if err := r.core.DenyRoomPermission(ctx, user.Id, input.RoomID, input.RoleName, core.Permission(input.Permission)); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -57,7 +57,7 @@ func (r *mutationResolver) ClearRoomPermission(ctx context.Context, input model.
 		return false, err
 	}
 
-	if err := r.core.ClearRoomPermissionState(ctx, input.RoomID, input.RoleName, core.Permission(input.Permission)); err != nil {
+	if err := r.core.ClearRoomPermissionState(ctx, user.Id, input.RoomID, input.RoleName, core.Permission(input.Permission)); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/cli/internal/graph/server_test.go
+++ b/cli/internal/graph/server_test.go
@@ -167,7 +167,7 @@ func TestServerResolver_Rooms_RoomScopeVisibility(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateRoom: %v", err)
 	}
-	if err := env.core.DenyRoomPermission(env.ctx, privateRoom.Id, core.RoleEveryone, core.PermRoomList); err != nil {
+	if err := env.core.DenyRoomPermission(env.ctx, core.SystemActorID, privateRoom.Id, core.RoleEveryone, core.PermRoomList); err != nil {
 		t.Fatalf("DenyRoomPermission: %v", err)
 	}
 
@@ -205,11 +205,11 @@ func TestServerResolver_Rooms_RoomScopeVisibility(t *testing.T) {
 	t.Run("explicit role grant restores visibility", func(t *testing.T) {
 		// Create an "engineering" role, grant it room.list on the private
 		// room. A user with this role should see it in the directory.
-		_, err := env.core.CreateServerRole(env.ctx, "engineering", "Engineering", "Eng team")
+		_, err := env.core.CreateServerRole(env.ctx, core.SystemActorID, "engineering", "Engineering", "Eng team")
 		if err != nil {
 			t.Fatalf("CreateServerRole: %v", err)
 		}
-		if err := env.core.GrantRoomPermission(env.ctx, privateRoom.Id, "engineering", core.PermRoomList); err != nil {
+		if err := env.core.GrantRoomPermission(env.ctx, core.SystemActorID, privateRoom.Id, "engineering", core.PermRoomList); err != nil {
 			t.Fatalf("GrantRoomPermission: %v", err)
 		}
 		if err := env.core.AssignServerRole(env.ctx, core.SystemActorID, regular.Id, "engineering"); err != nil {

--- a/cli/internal/graph/tier_roles_test.go
+++ b/cli/internal/graph/tier_roles_test.go
@@ -51,7 +51,7 @@ func TestTierRoles_RoomScopeShowsServerInheritance(t *testing.T) {
 	env := setupTestResolver(t)
 	rbac := env.resolver.RbacQueries()
 
-	if err := env.core.GrantServerPermission(env.ctx, core.RoleAdmin, core.PermMessagePost); err != nil {
+	if err := env.core.GrantServerPermission(env.ctx, core.SystemActorID, core.RoleAdmin, core.PermMessagePost); err != nil {
 		t.Fatalf("seed server grant: %v", err)
 	}
 
@@ -110,7 +110,7 @@ func TestTierRoles_ServerScopeAuthorization(t *testing.T) {
 		if err := env.core.AssignServerRole(env.ctx, core.SystemActorID, manager.Id, core.RoleModerator); err != nil {
 			t.Fatalf("AssignServerRole: %v", err)
 		}
-		if err := env.core.GrantServerPermission(env.ctx, core.RoleModerator, core.PermRoleManage); err != nil {
+		if err := env.core.GrantServerPermission(env.ctx, core.SystemActorID, core.RoleModerator, core.PermRoleManage); err != nil {
 			t.Fatalf("GrantServerPermission role.manage: %v", err)
 		}
 		got, err := rbac.RolePermissionTierMatrix(env.authContextForUser(manager), nil, nil, nil)
@@ -131,7 +131,7 @@ func TestTierRoles_RoomManagerCanInspectTheirRoom(t *testing.T) {
 	if err := env.core.AssignServerRole(env.ctx, core.SystemActorID, manager.Id, core.RoleModerator); err != nil {
 		t.Fatalf("AssignServerRole: %v", err)
 	}
-	if err := env.core.GrantRoomPermission(env.ctx, env.testRoom.Id, core.RoleModerator, core.PermRoomManage); err != nil {
+	if err := env.core.GrantRoomPermission(env.ctx, core.SystemActorID, env.testRoom.Id, core.RoleModerator, core.PermRoomManage); err != nil {
 		t.Fatalf("GrantRoomPermission room.manage: %v", err)
 	}
 
@@ -150,10 +150,10 @@ func TestTierRoles_RoomOverridesMatchCoreState(t *testing.T) {
 	env := setupTestResolver(t)
 	rbac := env.resolver.RbacQueries()
 
-	if err := env.core.GrantRoomPermission(env.ctx, env.testRoom.Id, core.RoleAdmin, core.PermRoomManage); err != nil {
+	if err := env.core.GrantRoomPermission(env.ctx, core.SystemActorID, env.testRoom.Id, core.RoleAdmin, core.PermRoomManage); err != nil {
 		t.Fatalf("seed room grant: %v", err)
 	}
-	if err := env.core.DenyRoomPermission(env.ctx, env.testRoom.Id, core.RoleAdmin, core.PermMessagePost); err != nil {
+	if err := env.core.DenyRoomPermission(env.ctx, core.SystemActorID, env.testRoom.Id, core.RoleAdmin, core.PermMessagePost); err != nil {
 		t.Fatalf("seed room deny: %v", err)
 	}
 
@@ -197,7 +197,7 @@ func TestTierRoles_RoomScopeGroupDenyShadowsServerAllow(t *testing.T) {
 	// explicit deny at the room's group on everyone — the matrix's room-scope
 	// inheritance baseline should now report DENY, with no parallel ALLOW.
 	groupID := env.testRoom.GroupId
-	if err := env.core.DenyGroupPermission(env.ctx, groupID, core.RoleEveryone, core.PermMessagePost); err != nil {
+	if err := env.core.DenyGroupPermission(env.ctx, core.SystemActorID, groupID, core.RoleEveryone, core.PermMessagePost); err != nil {
 		t.Fatalf("DenyGroupPermission: %v", err)
 	}
 
@@ -240,7 +240,7 @@ func TestTierRoles_GroupScopeShowsServerInheritance(t *testing.T) {
 	// Seed a deny on admin at server scope for room.create — pinning the
 	// inheritedDenials path. Also rely on the default everyone allow for
 	// message.post (seeded at server scope) for the inheritedAllows path.
-	if err := env.core.DenyServerPermission(env.ctx, core.RoleAdmin, core.PermRoomCreate); err != nil {
+	if err := env.core.DenyServerPermission(env.ctx, core.SystemActorID, core.RoleAdmin, core.PermRoomCreate); err != nil {
 		t.Fatalf("DenyServerPermission: %v", err)
 	}
 

--- a/cli/internal/graph/user_permissions_test.go
+++ b/cli/internal/graph/user_permissions_test.go
@@ -70,7 +70,7 @@ func TestUserPermissionMatrix_ReflectsExplicitOverride(t *testing.T) {
 
 	// Deny message.post on the user at server scope. Should show up as a
 	// solid DENY override on the server column.
-	if err := env.core.DenyUserPermission(env.ctx, target.Id, core.PermMessagePost); err != nil {
+	if err := env.core.DenyUserPermission(env.ctx, core.SystemActorID, target.Id, core.PermMessagePost); err != nil {
 		t.Fatalf("DenyUserPermission: %v", err)
 	}
 

--- a/docs/fdr/FDR-001-roles-and-permissions.md
+++ b/docs/fdr/FDR-001-roles-and-permissions.md
@@ -1,7 +1,7 @@
 # FDR-001: Roles & Permissions (RBAC)
 
 **Status:** Active
-**Last reviewed:** 2026-06-12
+**Last reviewed:** 2026-06-13
 
 ## Overview
 
@@ -20,6 +20,7 @@ Chatto controls who can do what through role-based access control. Every authent
 - Operators can designate owners via `owners.emails` in `chatto.toml`. Matching users are auto-assigned the `owner` role when their email is verified, and already-verified matching users are assigned the role on server boot.
 - GraphQL RBAC editor and inspection queries live under `Query.admin.rbac`. `Query.admin` is an authenticated namespace; the RBAC fields keep their narrower gates such as `role.manage` or `room.manage`.
 - Roles have a `pingable` setting that controls whether `@role` pings notify assigned room members. Fresh servers seed `moderator` as pingable and leave `owner`, `admin`, and `everyone` unpingable.
+- User-initiated RBAC writes carry the authenticated user's ID as the event actor. Synthetic `system` actors are reserved for bootstrap, seeding, resets, migrations, and other non-user maintenance.
 
 ## Design Decisions
 
@@ -64,6 +65,8 @@ Chatto controls who can do what through role-based access control. Every authent
 **Decision:** Role definitions, role order, assignments, and explicit permission decisions are durable events, with reads served from an in-memory RBAC projection.
 **Why:** This aligns RBAC with Chatto's current event-sourced architecture and makes authorization reads rebuildable from the deployment event log. See ADR-033 and ADR-035.
 **Tradeoff:** Writes must append events and wait for local projection catch-up before returning, so mutation paths need optimistic concurrency handling instead of direct state writes.
+
+User-triggered RBAC events are audit facts as well as state facts, so their event envelope actor is the user who performed the operation. Core APIs still accept `SystemActorID` for trusted non-user paths such as bootstrapping default roles and permissions.
 
 ### 8. Permission-decision events carry typed scope and subject
 


### PR DESCRIPTION
- Require RBAC write APIs to receive an explicit actor ID and stamp user-triggered role/permission events with that actor instead of `system`.
- Pass authenticated GraphQL users through role, permission, room permission, group permission, and direct user override mutations while keeping bootstrap/maintenance paths on `SystemActorID`.
- Add an admin event-log regression for RBAC actor attribution and update FDR-001.

Tests:
- `mise x -- go test ./internal/graph -run TestRBACMutationsUseAuthenticatedActorInEventLog -timeout 60s`
- `mise x -- go test ./internal/core ./internal/graph -timeout 90s`
- `mise x -- go test -tags test_endpoints ./... -run TestDoesNotExist -timeout 90s`
- `mise test-cli`
