### PR TITLE
fix: refine conversation start marker UX

### DIFF
--- a/frontend/e2e/pagination.test.ts
+++ b/frontend/e2e/pagination.test.ts
@@ -240,9 +240,7 @@ test.describe('message pagination', () => {
     if (!box) throw new Error('Container not visible');
     await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
 
-    const startMarker = page.getByText(
-      "You've reached the very beginning of this conversation."
-    );
+    const startMarker = page.getByText('This is the beginning of this conversation.');
 
     let markerVisible = false;
     for (let i = 0; i < 60; i++) {

--- a/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -31,6 +31,7 @@
     enablePagination = false,
     isLoadingMore = false,
     hasReachedStart = false,
+    showStartMarker = true,
     onLoadMore,
     // Event updates
     updateCounter = 0,
@@ -68,6 +69,7 @@
     enablePagination?: boolean;
     isLoadingMore?: boolean;
     hasReachedStart?: boolean;
+    showStartMarker?: boolean;
     onLoadMore?: () => Promise<void>;
     // Event updates
     updateCounter?: number;
@@ -140,7 +142,12 @@
 
   // Build flat array for the virtualizer (events + interleaved separators)
   let virtualItems = $derived(
-    buildVirtualItems(eventsWithMeta, unreadAfterEventId ?? null, hasReachedStart)
+    buildVirtualItems(
+      eventsWithMeta,
+      unreadAfterEventId ?? null,
+      hasReachedStart,
+      showStartMarker
+    )
   );
 
   // Register finder for up-arrow-to-edit (computed on-demand, not reactively)
@@ -617,7 +624,7 @@
               <!-- Stale virtualizer index during data transition, skip -->
             {:else if item.type === 'start-marker'}
               <div class="pt-10 pb-2 text-center text-sm text-muted/40">
-                You've reached the very beginning of this conversation.
+                This is the beginning of this conversation.
               </div>
             {:else if item.type === 'day-separator'}
               <DaySeparator label={item.label} />

--- a/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -300,6 +300,7 @@
     enablePagination={true}
     isLoadingMore={store.isLoadingMore}
     hasReachedStart={store.hasReachedStart}
+    showStartMarker={false}
     onLoadMore={() => store.loadMore()}
     filterThreadReplies={false}
     {updateCounter}

--- a/frontend/src/routes/chat/[serverId]/[roomId]/virtualItems.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/virtualItems.spec.ts
@@ -100,6 +100,12 @@ describe('buildVirtualItems', () => {
     expect(items[0]).toMatchObject({ type: 'start-marker' });
   });
 
+  it('omits start-marker when showStartMarker is false', () => {
+    const events = [makeMessageEvent({ id: 'e1' })];
+    const items = buildVirtualItems(meta(events), null, true, false);
+    expect(items.find((i) => i.type === 'start-marker')).toBeUndefined();
+  });
+
   it('does not emit start-marker for an empty event list even if hasReachedStart', () => {
     expect(buildVirtualItems([], null, true)).toEqual([]);
   });

--- a/frontend/src/routes/chat/[serverId]/[roomId]/virtualItems.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/virtualItems.ts
@@ -45,7 +45,8 @@ function getSystemGroupKind(event: RoomEventViewFragment): SystemGroupKind | nul
 export function buildVirtualItems(
   eventsWithMeta: EventWithMeta[],
   firstUnreadEventId: string | null,
-  hasReachedStart: boolean
+  hasReachedStart: boolean,
+  showStartMarker = true
 ): VirtualItem[] {
   const items: VirtualItem[] = [];
 
@@ -70,7 +71,7 @@ export function buildVirtualItems(
     openGroup = null;
   };
 
-  if (hasReachedStart && eventsWithMeta.length > 0) {
+  if (showStartMarker && hasReachedStart && eventsWithMeta.length > 0) {
     items.push({ type: 'start-marker', key: 'start-marker' });
   }
 


### PR DESCRIPTION
## Changes

- Updates the room timeline start marker copy to read neutrally in short conversations.
- Adds a `showStartMarker` opt-out and hides the marker entirely in thread panes.
- Adds virtual item unit coverage for the hidden-marker case and updates the pagination e2e assertion.

## Tests

- `mise lint-frontend`
- `mise x -- pnpm --dir frontend test:unit --run --project server 'src/routes/chat/[serverId]/[roomId]/virtualItems.spec.ts'`
- `mise x -- pnpm --dir frontend check`
- `mise x -- pnpm --dir frontend exec playwright test e2e/pagination.test.ts -g "backward pagination reaches the very beginning of conversation" --retries=0`
