### PR TITLE
fix: validate cookie encryption secret early

### DIFF
--- a/cli/chatto.toml
+++ b/cli/chatto.toml
@@ -9,6 +9,7 @@ url = 'http://localhost:5173'
 port = 4000
 allowed_origins = []
 cookie_signing_secret = '3ad5f5f911b6865b1a729335f4544d102a99a2847a3d5076431ed43877dd6bd9'
+cookie_encryption_secret = 'f61dd5e478f0c494bd7cc1d6136d8fd9b1c9cde38677f5c3a04f2ae181fd8464'
 
 [core]
 secret_key = '7f3e0d39031f4ee7e2078aafc785f1969b8f1d4a4ea178a4732cb2096fe7f3bb'

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/hex"
 	"fmt"
 	"net/url"
 	"os"
@@ -74,6 +75,26 @@ type WebserverConfig struct {
 	CookieSigningSecret    string    `toml:"cookie_signing_secret" env:"CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET" comment:"Secret for signing session cookies. NEVER SHARE THIS!\nIf it leaks, change it immediately, but please note that all existing sessions will become invalid."`
 	CookieEncryptionSecret string    `toml:"cookie_encryption_secret" env:"CHATTO_WEBSERVER_COOKIE_ENCRYPTION_SECRET" comment:"Optional hex-encoded secret used to encrypt session cookies (in addition to signing). Must decode to 16, 24, or 32 bytes (AES-128/192/256). If unset, cookies are signed but not encrypted — anything ever written to the session is readable by anyone who steals the cookie."`
 	TLS                    TLSConfig `toml:"tls" comment:"Automatic TLS configuration via Let's Encrypt."`
+}
+
+// CookieEncryptionKey decodes the optional cookie encryption secret into an
+// AES key suitable for securecookie. Empty means cookies are signed only.
+func (c *WebserverConfig) CookieEncryptionKey() ([]byte, error) {
+	if c.CookieEncryptionSecret == "" {
+		return nil, nil
+	}
+
+	key, err := hex.DecodeString(c.CookieEncryptionSecret)
+	if err != nil {
+		return nil, fmt.Errorf("webserver.cookie_encryption_secret must be hex-encoded: %w", err)
+	}
+
+	switch len(key) {
+	case 16, 24, 32:
+		return key, nil
+	default:
+		return nil, fmt.Errorf("webserver.cookie_encryption_secret must decode to 16, 24, or 32 bytes (got %d)", len(key))
+	}
 }
 
 // WebSocketCompressionEnabled returns whether WebSocket compression is enabled (default: true)
@@ -516,6 +537,9 @@ func (c *ChattoConfig) Validate() error {
 	}
 	if c.Core.SecretKey == "" {
 		errs = append(errs, "core.secret_key is required")
+	}
+	if _, err := c.Webserver.CookieEncryptionKey(); err != nil {
+		errs = append(errs, err.Error())
 	}
 
 	// Port ranges (port 0 is allowed when TLS is enabled, as it defaults to 443)

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -23,6 +23,7 @@ func TestReadConfig_WithoutConfigFile(t *testing.T) {
 	// Set required env vars
 	t.Setenv("CHATTO_WEBSERVER_PORT", "4000")
 	t.Setenv("CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET", "test-cookie-secret")
+	t.Setenv("CHATTO_WEBSERVER_COOKIE_ENCRYPTION_SECRET", "000102030405060708090a0b0c0d0e0f")
 	t.Setenv("CHATTO_CORE_SECRET_KEY", "test-core-secret")
 	t.Setenv("CHATTO_CORE_ASSETS_SIGNING_SECRET", "test-assets-secret")
 
@@ -38,6 +39,9 @@ func TestReadConfig_WithoutConfigFile(t *testing.T) {
 	}
 	if cfg.Webserver.CookieSigningSecret != "test-cookie-secret" {
 		t.Errorf("expected cookie secret to be set from env var")
+	}
+	if cfg.Webserver.CookieEncryptionSecret != "000102030405060708090a0b0c0d0e0f" {
+		t.Errorf("expected cookie encryption secret to be set from env var")
 	}
 	if cfg.Core.SecretKey != "test-core-secret" {
 		t.Errorf("expected core secret to be set from env var")
@@ -123,6 +127,29 @@ signing_secret = "file-assets-secret"
 	// Env var should override file
 	if cfg.Webserver.Port != 6000 {
 		t.Errorf("expected port 6000 from env override, got %d", cfg.Webserver.Port)
+	}
+}
+
+func TestReadConfig_InvalidCookieEncryptionSecretFromEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(originalDir) })
+
+	t.Setenv("CHATTO_WEBSERVER_PORT", "4000")
+	t.Setenv("CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET", "test-cookie-secret")
+	t.Setenv("CHATTO_WEBSERVER_COOKIE_ENCRYPTION_SECRET", "not-hex")
+	t.Setenv("CHATTO_CORE_SECRET_KEY", "test-core-secret")
+	t.Setenv("CHATTO_CORE_ASSETS_SIGNING_SECRET", "test-assets-secret")
+
+	_, err = ReadConfig("")
+	if err == nil || !strings.Contains(err.Error(), "webserver.cookie_encryption_secret must be hex-encoded") {
+		t.Fatalf("ReadConfig() error = %v, want cookie encryption validation error", err)
 	}
 }
 
@@ -484,6 +511,65 @@ func TestChattoConfig_Validate_RequiredSecrets(t *testing.T) {
 			err := cfg.Validate()
 			if err == nil || !strings.Contains(err.Error(), tt.errorMsg) {
 				t.Fatalf("Validate() error = %v, want to contain %q", err, tt.errorMsg)
+			}
+		})
+	}
+}
+
+func TestChattoConfig_Validate_CookieEncryptionSecret(t *testing.T) {
+	base := ChattoConfig{
+		Webserver: WebserverConfig{Port: 4000, CookieSigningSecret: "web-secret"},
+		Core: CoreConfig{
+			SecretKey: "core-secret",
+			Assets:    AssetsConfig{SigningSecret: "asset-secret"},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		secret    string
+		wantError string
+	}{
+		{
+			name: "empty is allowed",
+		},
+		{
+			name:   "16 byte key",
+			secret: "000102030405060708090a0b0c0d0e0f",
+		},
+		{
+			name:   "24 byte key",
+			secret: "000102030405060708090a0b0c0d0e0f1011121314151617",
+		},
+		{
+			name:   "32 byte key",
+			secret: "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+		},
+		{
+			name:      "not hex",
+			secret:    "not-hex",
+			wantError: "webserver.cookie_encryption_secret must be hex-encoded",
+		},
+		{
+			name:      "wrong decoded length",
+			secret:    "000102030405060708090a0b0c0d0e",
+			wantError: "webserver.cookie_encryption_secret must decode to 16, 24, or 32 bytes (got 15)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := base
+			cfg.Webserver.CookieEncryptionSecret = tt.secret
+			err := cfg.Validate()
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatalf("Validate() unexpected error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("Validate() error = %v, want to contain %q", err, tt.wantError)
 			}
 		})
 	}

--- a/cli/internal/http_server/server.go
+++ b/cli/internal/http_server/server.go
@@ -3,7 +3,6 @@ package http_server
 import (
 	"context"
 	"crypto/tls"
-	"encoding/hex"
 	"fmt"
 	"net/http"
 	"os"
@@ -144,16 +143,11 @@ func (s *HTTPServer) setupRoutes() error {
 	// Configure session middleware
 	authKey := []byte(s.config.Webserver.CookieSigningSecret)
 	var sessionStore cookie.Store
-	if encHex := s.config.Webserver.CookieEncryptionSecret; encHex != "" {
-		encKey, err := hex.DecodeString(encHex)
-		if err != nil {
-			return fmt.Errorf("webserver.cookie_encryption_secret: must be hex-encoded: %w", err)
-		}
-		switch len(encKey) {
-		case 16, 24, 32:
-		default:
-			return fmt.Errorf("webserver.cookie_encryption_secret must decode to 16, 24, or 32 bytes (got %d)", len(encKey))
-		}
+	encKey, err := s.config.Webserver.CookieEncryptionKey()
+	if err != nil {
+		return err
+	}
+	if len(encKey) > 0 {
 		sessionStore = cookie.NewStore(authKey, encKey)
 	} else {
 		s.logger.Warn("webserver.cookie_encryption_secret is not set; session cookies are signed but NOT encrypted. Run `chatto init` on a fresh server to generate one, or add a hex-encoded 32-byte value to chatto.toml.")

--- a/docs-website/src/content/docs/getting-started/quick-start.mdx
+++ b/docs-website/src/content/docs/getting-started/quick-start.mdx
@@ -72,7 +72,7 @@ To keep your configuration and data across container restarts, use a bind mount:
    chatto init
    ```
 
-   This creates a `chatto.toml` with random secrets for cookie signing, runtime-token verifiers, asset signing, and NATS authentication.
+   This creates a `chatto.toml` with random secrets for cookie signing, cookie encryption, runtime-token verifiers, asset signing, and NATS authentication.
 
 3. **Start the server:**
 
@@ -95,6 +95,7 @@ log_level = "debug"
 port = 4000
 url = "http://localhost:4000"
 cookie_signing_secret = "<generated>"
+cookie_encryption_secret = "<generated>"
 
 [core]
 secret_key = "<generated>"

--- a/docs-website/src/content/docs/guides/binary.mdx
+++ b/docs-website/src/content/docs/guides/binary.mdx
@@ -43,6 +43,7 @@ By the end of this section, your deployment directory will look like this:
    [webserver]
    url = "https://chat.example.com"
    cookie_signing_secret = "<generate-me>"
+   cookie_encryption_secret = "<generate-me>"
 
    [webserver.tls]
    enabled = true

--- a/docs-website/src/content/docs/guides/dockercompose.mdx
+++ b/docs-website/src/content/docs/guides/dockercompose.mdx
@@ -169,6 +169,7 @@ By the end of this section, your project directory will look like this:
    CHATTO_WEBSERVER_URL=https://chat.example.com
    CHATTO_WEBSERVER_PORT=4000
    CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET=<generate-me>
+   CHATTO_WEBSERVER_COOKIE_ENCRYPTION_SECRET=<generate-me>
    CHATTO_CORE_SECRET_KEY=<generate-me>
    CHATTO_CORE_ASSETS_SIGNING_SECRET=<generate-me>
    CHATTO_LOG_LEVEL=info

--- a/docs-website/src/content/docs/guides/horizontal-scaling.mdx
+++ b/docs-website/src/content/docs/guides/horizontal-scaling.mdx
@@ -26,7 +26,7 @@ Because there's no local state, any server process can handle any request. No se
 
 - An **external NATS cluster** (embedded NATS only supports a single server process)
 - A **load balancer** in front of the Chatto replicas (Caddy, nginx, Traefik, etc.)
-- The **same secrets** across all server processes (cookie signing, core token verifier key, asset signing)
+- The **same secrets** across all server processes (cookie signing, cookie encryption if configured, core token verifier key, asset signing)
 
 ## Configuring Chatto for Multiple Replicas
 
@@ -45,6 +45,7 @@ CHATTO_NATS_CLIENT_TOKEN=your-shared-token
 
 # These MUST be identical across all server processes
 CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET=your-cookie-secret
+CHATTO_WEBSERVER_COOKIE_ENCRYPTION_SECRET=your-cookie-encryption-secret
 CHATTO_CORE_SECRET_KEY=your-core-secret
 CHATTO_CORE_ASSETS_SIGNING_SECRET=your-assets-secret
 ```
@@ -63,7 +64,7 @@ token = "your-shared-token"
 </Tabs>
 
 <Aside type="caution">
-  All server processes **must** share the same `cookie_signing_secret`, `core.secret_key`, and `core.assets.signing_secret`. If they differ, cookies, bearer tokens, account-flow links, or asset URLs created by one server process won't validate on another.
+  All server processes **must** share the same `cookie_signing_secret`, `cookie_encryption_secret` when configured, `core.secret_key`, and `core.assets.signing_secret`. If they differ, cookies, bearer tokens, account-flow links, or asset URLs created by one server process won't validate on another.
 </Aside>
 
 ## Health Checks
@@ -144,6 +145,7 @@ The [Docker Compose deployment guide](/guides/dockercompose/) includes a Caddy c
 |---------|-------------------------------------|-------|
 | NATS client URL & credentials | Yes | All connect to the same cluster |
 | `cookie_signing_secret` | Yes | Cookie validation |
+| `cookie_encryption_secret` | Yes, when configured | Cookie confidentiality |
 | `core.secret_key` | Yes | Bearer-token and account-flow verifier keys |
 | `core.assets.signing_secret` | Yes | Asset URL signing |
 | `webserver.url` | Yes | Public URL for absolute links |

--- a/docs-website/src/content/docs/reference/environment-variables.mdx
+++ b/docs-website/src/content/docs/reference/environment-variables.mdx
@@ -31,6 +31,10 @@ Every `chatto.toml` setting can be overridden with an environment variable. The 
   256-bit hex secret for signing session cookies. Generate with `openssl rand -hex 32`.
 </EnvVar>
 
+<EnvVar name="CHATTO_WEBSERVER_COOKIE_ENCRYPTION_SECRET" toml="webserver.cookie_encryption_secret">
+  Optional hex secret for encrypting session cookies after signing. Must decode to 16, 24, or 32 bytes. Generate an AES-256 key with `openssl rand -hex 32`.
+</EnvVar>
+
 <EnvVar name="CHATTO_WEBSERVER_WEBSOCKET_COMPRESSION" toml="webserver.websocket_compression" default="true">
   Enable WebSocket compression.
 </EnvVar>

--- a/examples/dockercompose/.env.example
+++ b/examples/dockercompose/.env.example
@@ -15,12 +15,13 @@ CHATTO_NATS_CLIENT_TOKEN=your-secure-token-here
 CHATTO_WEBSERVER_URL=https://chat.example.com
 CHATTO_WEBSERVER_PORT=4000
 CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET=your-cookie-secret-here
+CHATTO_WEBSERVER_COOKIE_ENCRYPTION_SECRET=your-cookie-encryption-secret-here
 CHATTO_CORE_SECRET_KEY=your-core-secret-here
 CHATTO_CORE_ASSETS_SIGNING_SECRET=your-assets-secret-here
 CHATTO_LOG_LEVEL=info
 CHATTO_LOG_FORMAT=json
 
-# LiveKit (voice calls)
+# LiveKit (voice and video calls)
 CHATTO_LIVEKIT_ENABLED=true
 CHATTO_LIVEKIT_URL=wss://livekit.chat.example.com
 CHATTO_LIVEKIT_API_KEY=your-api-key

--- a/examples/dockercompose/README.md
+++ b/examples/dockercompose/README.md
@@ -32,6 +32,7 @@ This example deploys a clustered Chatto setup with:
    - `PUBLIC_URL` - Your domain (e.g., `chat.example.com`)
    - `NATS_TOKEN` and `CHATTO_NATS_CLIENT_TOKEN` - Must match (shared auth token)
    - `CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET` - Session cookie signing
+   - `CHATTO_WEBSERVER_COOKIE_ENCRYPTION_SECRET` - Session cookie encryption
    - `CHATTO_CORE_SECRET_KEY` - Bearer-token and account-flow verifier key
    - `CHATTO_CORE_ASSETS_SIGNING_SECRET` - Asset URL signing
    - `CHATTO_LIVEKIT_API_KEY` / `CHATTO_LIVEKIT_API_SECRET` - Must match the keys in `livekit.yaml`

--- a/examples/k8s/README.md
+++ b/examples/k8s/README.md
@@ -109,6 +109,7 @@ Update these values (generate secrets with `openssl rand -hex 32`):
 - `NATS_TOKEN` and `CHATTO_NATS_CLIENT_TOKEN` - Must match
 - `CHATTO_WEBSERVER_URL` - Your domain (e.g., `https://chat.example.com`)
 - `CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET` - Session signing secret
+- `CHATTO_WEBSERVER_COOKIE_ENCRYPTION_SECRET` - Session encryption secret
 - `CHATTO_CORE_SECRET_KEY` - Bearer-token and account-flow verifier key
 - `CHATTO_CORE_ASSETS_SIGNING_SECRET` - Asset URL signing secret
 

--- a/examples/k8s/secrets.yaml
+++ b/examples/k8s/secrets.yaml
@@ -26,6 +26,7 @@ stringData:
   CHATTO_WEBSERVER_URL: "https://chat.example.com"
   CHATTO_WEBSERVER_PORT: "4000"
   CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET: "your-cookie-secret-here"
+  CHATTO_WEBSERVER_COOKIE_ENCRYPTION_SECRET: "your-cookie-encryption-secret-here"
   CHATTO_CORE_SECRET_KEY: "your-core-secret-here"
   CHATTO_CORE_ASSETS_SIGNING_SECRET: "your-assets-secret-here"
   CHATTO_LOG_LEVEL: "info"


### PR DESCRIPTION
- Validate `webserver.cookie_encryption_secret` during config loading so malformed values fail before NATS/core/projection startup.
- Share cookie encryption key decoding between config validation and HTTP session setup.
- Add a local dev cookie encryption secret and update self-hosting docs/examples to list it alongside the signing secret.

Tests:
- `mise x -- go test ./internal/config -timeout 30s`
- `mise x -- go test -tags test_endpoints ./internal/http_server -run TestNewHTTPServerAppliesTimeouts -timeout 30s`
