### PR TITLE
docs: add event sourcing skill

### DIFF
--- a/.agents/skills/chatto-event-sourcing/SKILL.md
+++ b/.agents/skills/chatto-event-sourcing/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: "chatto-event-sourcing"
+description: "Use when designing, implementing, reviewing, debugging, or documenting Chatto event-sourced domain behavior, including EVT subjects, aggregate boundaries, Services, projections, optimistic concurrency control, read-your-writes, live/reconnect delivery, replay compatibility, migration safety, and rollback/deployment implications."
+---
+
+# Chatto Event Sourcing
+
+Use this skill whenever touching durable domain state in Chatto. It is a guardrail checklist for the event-sourced architecture, not a replacement for the architecture docs.
+
+## Start Here
+
+Read only what is relevant to the task:
+
+- `docs/ARCHITECTURE.md` for the current runtime inventory, registered projections, EVT subject patterns, and live delivery shape.
+- `docs/adr/INDEX.md` to find relevant architecture decisions; read only the ADRs that apply to the current event-sourcing, stream, projection, or runtime-state question.
+- Relevant FDRs in `docs/fdr/` before changing user-visible behavior.
+- `.claude/rules/backend.md` and `.claude/rules/authorization.md` when changing backend writes, auth, or room visibility.
+
+Authoritative code anchors:
+
+- `cli/internal/events/publisher.go` - OCC-only event publishing.
+- `cli/internal/events/subjects.go` - aggregate types, event tokens, subject helpers, and wildcard filters.
+- `proto/chatto/core/v1/event.proto` and sibling `*_events.proto` files - durable event payloads.
+- `cli/internal/core/core.go` - service/projection wiring and live/reconnect delivery.
+- `cli/internal/core/*_service.go` - domain services and write orchestration.
+- `cli/internal/core/*_projection.go` - in-memory read models.
+- `cli/internal/core/projection_subjects_test.go` - subject-policy regression tests.
+
+## Core Rules
+
+- Durable domain facts go into `EVT`. Do not add durable mirrors in KV or object metadata unless the architecture explicitly calls the state runtime, ephemeral, secret, binary, or cache data.
+- Domain state interactions should go through a Service for that domain. Avoid direct JetStream, KV, object-store, or projection manipulation from unrelated code.
+- `ChattoCore` is a facade and wiring point. Prefer moving domain-specific write/readiness logic into a focused Service.
+- Projections are process-local read models rebuilt from `EVT`. They are not locks, coordination points, or sources of durable truth.
+- Multi-replica safety comes from JetStream OCC plus projection catch-up, not from in-process mutexes or "only one server will do this" assumptions.
+- Every successful write that needs read-your-writes must wait for the local projector(s) that serve the next read path.
+- Event subjects are part of the persisted data model. Changing an aggregate lane is a compatibility decision, not a refactor.
+
+## Before Adding Or Changing A Write
+
+Answer these questions before editing:
+
+1. Is this a durable domain fact, runtime state, transient live sync, binary/object data, a secret, or a cache?
+2. Which Service owns the domain? If none exists, should this change introduce one?
+3. Which aggregate owns the event subject?
+4. What invariant does the OCC filter protect?
+5. Which projections must consume the event?
+6. Which projections must be current before the mutation returns?
+7. Does the write need to publish transient `LiveEvent`s, or will `EVT` republish through `live.evt.>` be enough?
+8. What happens with multiple replicas racing the same write?
+9. What happens on forward deploy, mixed-version rolling deploy, and rollback?
+10. Which focused tests lock down the subject, replay, OCC, projection, and delivery behavior?
+
+## Choosing An Aggregate Subject
+
+Use `events.{Domain}Aggregate(...).SubjectFor(event)` helpers instead of hand-built subjects.
+
+Subject guidance:
+
+- Put the aggregate ID in the subject when it is the concurrency and ordering boundary.
+- Keep actor IDs, room visibility, ownership details, and extra context in the protobuf payload unless they are truly the aggregate ID.
+- Use event-type wildcard filters such as `evt.room.*.reaction_added` only for projections that need a narrow cross-aggregate event family.
+- Use aggregate-wide filters such as `evt.room.>` when a projection genuinely needs the full aggregate namespace.
+- If an invariant spans multiple aggregate instances or event types, use `AppendAtFilter` with an OCC filter that covers the invariant, not just the target subject.
+
+When moving an event family to a new aggregate lane, decide explicitly:
+
+- current write subject,
+- legacy replay subject(s),
+- whether old events and new events can coexist for one logical entity,
+- whether old code can survive new subjects during rollback,
+- how live delivery and reconnect replay find the authorization context.
+
+The asset migration is the current example: new writes use `evt.asset.{assetId}.*`, while `AssetProjection` still consumes beta-era `evt.room.*.asset_*` lanes for replay compatibility. This supports forward deploy, but rollback to code that only understands room-scoped asset facts is not symmetric.
+
+## OCC Checklist
+
+Use `events.Publisher`; do not add non-OCC publish paths.
+
+Common patterns:
+
+- Per-aggregate append: use the typed aggregate helper and the publisher's append path.
+- Cross-event-type invariant on one aggregate family: read the wildcard tail with `LastSubjectPosition(filter)`, wait for any needed projections to catch up, re-check the projected invariant, then `AppendAtFilter`.
+- Multi-event atomic write: use atomic publish entries with explicit OCC on every entry that needs protection. Do not publish a batch with no OCC guard.
+- Retry only after re-reading the OCC tail and re-checking the invariant from projections.
+
+Pitfalls:
+
+- Checking only the target subject when the invariant is broader.
+- Using projection state from before the OCC tail caught up.
+- Adding a best-effort publish because "it is only metadata".
+- Depending on a process-local mutex for correctness across replicas.
+- Having old and new versions write equivalent facts under different OCC filters during a rolling deploy.
+
+## Projection Rules
+
+Projection implementations should be boring and replay-safe:
+
+- `Subjects()` must be intentional and tested in `projection_subjects_test.go`.
+- `Apply` should tolerate duplicate delivery, replay order within the stream, nil/partial payloads where possible, and historical compatible shapes.
+- Store cloned protobuf messages when retaining them in memory.
+- Keep derived indexes consistent when events remove, replace, tombstone, or supersede prior state.
+- Return cloned/protective values from projection read methods.
+- Use stable stream sequence numbers for reconnect replay and delivery cursors.
+- Add admin projection estimates when adding meaningful in-memory indexes.
+
+When a projection consumes legacy lanes, name them as legacy compatibility in comments/docs/tests. New writes should still have one canonical subject family.
+
+## Read-Your-Writes
+
+After appending to `EVT`, wait for every local projector needed by the response or by immediately following reads.
+
+Check:
+
+- The returned stream position uses the same subject or filter the projector consumes.
+- Composite write paths wait for all affected projections, not just the one that owns the Service.
+- Live `live.evt.>` delivery waits for projection readiness before authorizing or shaping GraphQL events.
+- Reconnect replay waits for projections through the global cutoff before planning replay.
+
+## Live Delivery And Reconnect Replay
+
+Durable EVT facts are not delivered directly to clients. `live.evt.>` is an internal raw committed-event feed.
+
+When adding or moving deliverable events:
+
+- Update the deliverable event switch in core live filtering.
+- Ensure authorization can be resolved from projections.
+- If the subject is not room-scoped, add a path to resolve room/user visibility from payload/projections.
+- Include the event family in reconnect replay if clients need to recover it after disconnect.
+- Keep replay ordered by global stream sequence and deduplicate by event ID where room and non-room projections can both see legacy facts.
+- Transient `LiveEvent`s on `live.sync.>` are not replayed and are not projection input.
+
+## Compatibility And Deployment
+
+For existing persisted `EVT` histories, forward replay compatibility matters more than ideal cleanliness.
+
+Before merging a subject or payload compatibility change, document:
+
+- Which historical event shapes still replay.
+- Whether the current writer ever emits the historical shape.
+- Whether mixed historical and current facts for one entity are valid.
+- Whether rollback after new writes is safe.
+- Whether a rolling deploy can cause duplicate or conflicting facts because old and new code use different OCC filters.
+- Whether a one-time stream migration is required. Avoid this unless the compatibility reader is impossible or unsafe.
+
+Prefer additive protobuf changes. Avoid breaking persisted event payload fields. If a breaking protobuf change is unavoidable, call it out clearly and design a migration/replay story first.
+
+## Test Expectations
+
+For event-sourced changes, look for focused tests in addition to end-to-end behavior:
+
+- Subject helper tests in `cli/internal/events`.
+- Projection `Subjects()` policy in `cli/internal/core/projection_subjects_test.go`.
+- Projection replay tests for canonical and legacy event shapes.
+- OCC conflict/race tests for the invariant being protected.
+- Read-your-writes tests that assert projections are current after writes.
+- Live delivery authorization tests, especially when the subject is not room-scoped.
+- Reconnect replay tests for cursor ordering, deduplication, limits, and authorization.
+- Deployment compatibility tests when old and new subject families can coexist.
+
+## Documentation Touchpoints
+
+Update docs in the same change when architecture behavior shifts:
+
+- `docs/ARCHITECTURE.md` for current services, projections, resources, subject patterns, and event inventories.
+- `docs/adr/` for new or changed cross-cutting architectural decisions.
+- `docs/fdr/` for user-facing behavior and rationale.
+- `docs/GLOSSARY.md` when canonical terms change.
+
+Keep docs crisp: current architecture in `ARCHITECTURE.md`, decisions in ADRs/FDRs, and pitfalls/checklists here.


### PR DESCRIPTION
## Summary

- Add a `chatto-event-sourcing` agent skill for EVT/projection work.
- Capture guardrails for Services, aggregate subjects, OCC filters, projection readiness, live/reconnect delivery, and deployment compatibility.
- Point future agents at the authoritative architecture docs, ADRs/FDRs, and source files instead of duplicating the full architecture.

## Tests

- `git diff --cached --check`
