### PR TITLE
feat(admin): auto-paginate event log

### DIFF
--- a/.claude/rules/testing-frontend.md
+++ b/.claude/rules/testing-frontend.md
@@ -39,6 +39,10 @@ Co-locate next to the source. The Vitest project split is purely by filename suf
 
 `.test.ts` and `.spec.ts` are both accepted; existing files use both. Match the surrounding directory.
 
+In SvelteKit route directories, don't name specs with a leading `+` (for example, avoid
+`+page.svelte.spec.ts`). SvelteKit reserves `+*` filenames for route modules and `svelte-kit sync`
+will reject them. Use a nearby descriptive name such as `members.page.svelte.spec.ts` instead.
+
 ## Use the shared helpers
 
 `frontend/src/lib/test-utils/` exists to keep boilerplate out of specs. Don't re-roll any of these per file:

--- a/frontend/src/lib/components/admin/DataTable.svelte
+++ b/frontend/src/lib/components/admin/DataTable.svelte
@@ -1,5 +1,6 @@
 <script lang="ts" generics="T">
   import type { Snippet } from 'svelte';
+  import type { Attachment } from 'svelte/attachments';
 
   let {
     items,
@@ -9,7 +10,13 @@
     emptyMessage = 'No data',
     onRowClick,
     getKey,
-    hoverable = true
+    hoverable = true,
+    hasMore = false,
+    loadingMore = false,
+    onLoadMore,
+    loadMoreRoot,
+    loadMoreRootMargin = '0px 0px 160px 0px',
+    loadingMoreMessage = 'Loading more...'
   }: {
     items: T[];
     columns: number;
@@ -25,7 +32,21 @@
      * would be visual noise.
      */
     hoverable?: boolean;
+    /** Whether another page can be loaded when the table end is reached. */
+    hasMore?: boolean;
+    /** Whether the next page is currently loading. */
+    loadingMore?: boolean;
+    /** Called when the trailing sentinel reaches the configured scroll root. */
+    onLoadMore?: () => void | Promise<void>;
+    /** Scroll container used as the IntersectionObserver root. */
+    loadMoreRoot?: HTMLElement;
+    /** IntersectionObserver root margin for the trailing sentinel. */
+    loadMoreRootMargin?: string;
+    /** Compact status text shown in the trailing loading row. */
+    loadingMoreMessage?: string;
   } = $props();
+
+  let loadMoreInFlight = false;
 
   // Default key function: use id if present, otherwise use index
   function defaultGetKey(item: T, index: number): string | number {
@@ -36,6 +57,41 @@
   }
 
   const keyFn = $derived(getKey ?? defaultGetKey);
+
+  function triggerLoadMore(callback = onLoadMore) {
+    if (!hasMore || loadingMore || loadMoreInFlight || !callback) return;
+
+    loadMoreInFlight = true;
+    try {
+      void Promise.resolve(callback()).finally(() => {
+        loadMoreInFlight = false;
+      });
+    } catch (e) {
+      loadMoreInFlight = false;
+      throw e;
+    }
+  }
+
+  const loadMoreSentinel: Attachment<HTMLTableRowElement> = (element) => {
+    const root = loadMoreRoot;
+    if (!root || !onLoadMore || !hasMore || loadingMore) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          triggerLoadMore(onLoadMore);
+        }
+      },
+      {
+        root,
+        rootMargin: loadMoreRootMargin
+      }
+    );
+
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  };
 </script>
 
 <table class="w-full [&_thead_th]:whitespace-nowrap">
@@ -61,5 +117,25 @@
         <td colspan={columns} class="px-4 py-8 text-center text-muted">{emptyMessage}</td>
       </tr>
     {/each}
+
+    {#if hasMore || loadingMore}
+      <tr
+        class="border-b border-border last:border-0"
+        aria-hidden={!loadingMore}
+        {@attach hasMore ? loadMoreSentinel : undefined}
+      >
+        <td
+          colspan={columns}
+          class={loadingMore ? 'px-4 py-3 text-center text-sm text-muted' : 'h-px p-0'}
+        >
+          {#if loadingMore}
+            <span class="inline-flex items-center gap-2" aria-live="polite">
+              <span class="iconify animate-spin text-base uil--spinner" aria-hidden="true"></span>
+              {loadingMoreMessage}
+            </span>
+          {/if}
+        </td>
+      </tr>
+    {/if}
   </tbody>
 </table>

--- a/frontend/src/lib/components/admin/DataTable.svelte.spec.ts
+++ b/frontend/src/lib/components/admin/DataTable.svelte.spec.ts
@@ -1,9 +1,68 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { testSnippet } from '$lib/test-utils';
 import DataTable from './DataTable.svelte';
 
-function renderTable(props: { hoverable?: boolean } = {}) {
+let originalIntersectionObserver: typeof IntersectionObserver;
+let observers: MockIntersectionObserver[] = [];
+
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root: Element | Document | null;
+  readonly rootMargin: string;
+  readonly thresholds: ReadonlyArray<number> = [];
+  private elements: Element[] = [];
+
+  constructor(
+    private readonly callback: IntersectionObserverCallback,
+    options?: IntersectionObserverInit
+  ) {
+    this.root = options?.root ?? null;
+    this.rootMargin = options?.rootMargin ?? '0px';
+    observers.push(this);
+  }
+
+  observe = (target: Element) => {
+    this.elements.push(target);
+  };
+
+  unobserve = (target: Element) => {
+    this.elements = this.elements.filter((element) => element !== target);
+  };
+
+  disconnect = () => {
+    this.elements = [];
+  };
+
+  takeRecords = () => [];
+
+  trigger(isIntersecting: boolean) {
+    const target = this.elements[0] ?? document.createElement('tr');
+    this.callback(
+      [
+        {
+          boundingClientRect: target.getBoundingClientRect(),
+          intersectionRatio: isIntersecting ? 1 : 0,
+          intersectionRect: target.getBoundingClientRect(),
+          isIntersecting,
+          rootBounds: null,
+          target,
+          time: performance.now()
+        }
+      ],
+      this
+    );
+  }
+}
+
+function renderTable(
+  props: {
+    hoverable?: boolean;
+    hasMore?: boolean;
+    loadingMore?: boolean;
+    onLoadMore?: () => void | Promise<void>;
+    loadMoreRoot?: HTMLElement;
+  } = {}
+) {
   return render(DataTable, {
     props: {
       items: [{ id: '1', name: 'Alice' }],
@@ -19,6 +78,17 @@ function renderTable(props: { hoverable?: boolean } = {}) {
 }
 
 describe('DataTable.hoverable', () => {
+  beforeEach(() => {
+    originalIntersectionObserver = globalThis.IntersectionObserver;
+    observers = [];
+    globalThis.IntersectionObserver =
+      MockIntersectionObserver as unknown as typeof IntersectionObserver;
+  });
+
+  afterEach(() => {
+    globalThis.IntersectionObserver = originalIntersectionObserver;
+  });
+
   it('applies hover bg by default', async () => {
     const { container } = renderTable();
     const tr = container.querySelector('tbody tr') as HTMLElement;
@@ -45,5 +115,43 @@ describe('DataTable.hoverable', () => {
     });
     const tr = container.querySelector('tbody tr') as HTMLElement;
     expect(tr.className).toContain('cursor-pointer');
+  });
+
+  it('does not render an auto-load sentinel by default', async () => {
+    const { container } = renderTable();
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(1);
+    expect(observers).toHaveLength(0);
+  });
+
+  it('calls onLoadMore when the trailing sentinel intersects the scroll root', async () => {
+    const root = document.createElement('div');
+    const onLoadMore = vi.fn();
+    renderTable({ hasMore: true, loadMoreRoot: root, onLoadMore });
+
+    expect(observers).toHaveLength(1);
+    expect(observers[0].root).toBe(root);
+    expect(observers[0].rootMargin).toBe('0px 0px 160px 0px');
+
+    observers[0].trigger(true);
+
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onLoadMore when already loading more', async () => {
+    const root = document.createElement('div');
+    const onLoadMore = vi.fn();
+    renderTable({ hasMore: true, loadingMore: true, loadMoreRoot: root, onLoadMore });
+
+    expect(observers).toHaveLength(0);
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it('does not call onLoadMore when no more rows are available', async () => {
+    const root = document.createElement('div');
+    const onLoadMore = vi.fn();
+    renderTable({ hasMore: false, loadMoreRoot: root, onLoadMore });
+
+    expect(observers).toHaveLength(0);
+    expect(onLoadMore).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/routes/chat/[serverId]/server-admin/event-log/+page.svelte
+++ b/frontend/src/routes/chat/[serverId]/server-admin/event-log/+page.svelte
@@ -1,18 +1,21 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { serverIdToSegment } from '$lib/navigation';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { graphql } from '$lib/gql';
-  import { useQuery } from '$lib/hooks';
+  import type { AdminEventLogQuery } from '$lib/gql/graphql';
   import { Panel, DataTable } from '$lib/components/admin';
   import { Hint, Pill } from '$lib/ui';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
   import PageTitle from '$lib/ui/PageTitle.svelte';
   import { getUserSettings } from '$lib/state/userSettings.svelte';
+  import { useConnection } from '$lib/state/server/connection.svelte';
   import { formatDateTime as formatDateTimeUtil } from '$lib/utils/formatTime';
 
   const userSettings = getUserSettings();
+  const connection = useConnection();
 
   const EventLogQuery = graphql(`
     query AdminEventLog($limit: Int, $before: String) {
@@ -36,70 +39,123 @@
     }
   `);
 
-  // The page accumulates entries across pagination clicks; the query
-  // itself only ever fetches one page at a time.
   const pageSize = 50;
-  let beforeCursor = $state<string | null>(null);
-  let accumulated = $state<Entry[]>([]);
-  let totalCount = $state(0);
+  type EventLogConnection = NonNullable<AdminEventLogQuery['admin']>['eventLog'];
+  type Entry = EventLogConnection['entries'][number];
+
+  let entries = $state<Entry[]>([]);
+  let totalCount = $state('0');
   let hasOlder = $state(false);
-  let lastLoadedCursor = $state<string | null>(null);
+  let endCursor = $state<string | null>(null);
+  let loading = $state(true);
+  let loadingMore = $state(false);
+  let error = $state<string | null>(null);
+  let requestId = 0;
+  let scrollContainer = $state<HTMLDivElement>();
+  let formattedTotalCount = $derived(formatTotalCount(totalCount));
 
-  type Entry = {
-    sequence: string;
-    subject: string;
-    aggregateType: string;
-    aggregateId: string;
-    eventType: string;
-    eventId: string;
-    actorId: string;
-    createdAt: string;
-  };
-
-  const eventsQuery = useQuery(EventLogQuery, () => ({
-    limit: pageSize,
-    before: beforeCursor
-  }));
-
-  // When a fresh page lands, append it to the accumulator. Guard against
-  // double-append by tracking the endCursor we last consumed.
-  $effect(() => {
-    const conn = eventsQuery.data?.admin?.eventLog;
-    if (!conn) return;
-    const cursorKey = conn.endCursor ?? '__head__';
-    if (cursorKey === lastLoadedCursor) return;
-    lastLoadedCursor = cursorKey;
-    if (beforeCursor === null) {
-      accumulated = [...conn.entries];
-    } else {
-      accumulated = [...accumulated, ...conn.entries];
-    }
-    totalCount = conn.totalCount;
-    hasOlder = conn.hasOlder;
+  onMount(() => {
+    void loadFirstPage();
   });
 
-  let loading = $derived(eventsQuery.loading);
-  let error = $derived(
-    eventsQuery.error ??
-      (!eventsQuery.loading && !eventsQuery.data?.admin
-        ? 'Event log unavailable (audit permission required)'
-        : null)
-  );
+  function formatTotalCount(count: string): string {
+    const numeric = Number(count);
+    return Number.isSafeInteger(numeric) ? numeric.toLocaleString() : count;
+  }
 
   function formatTimestamp(iso: string): string {
     return formatDateTimeUtil(iso, userSettings);
   }
 
+  async function queryEventLog(before: string | null) {
+    return connection()
+      .client.query(EventLogQuery, {
+        limit: pageSize,
+        before
+      })
+      .toPromise();
+  }
+
+  async function loadFirstPage() {
+    const currentRequest = ++requestId;
+    loading = true;
+    error = null;
+    entries = [];
+    totalCount = '0';
+    hasOlder = false;
+    endCursor = null;
+
+    try {
+      const result = await queryEventLog(null);
+      if (currentRequest !== requestId) return;
+
+      if (result.error) {
+        error = result.error.message;
+        return;
+      }
+
+      const conn = result.data?.admin?.eventLog;
+      if (!conn) {
+        error = 'Event log unavailable (audit permission required)';
+        return;
+      }
+
+      entries = conn.entries;
+      totalCount = String(conn.totalCount);
+      hasOlder = conn.hasOlder;
+      endCursor = conn.endCursor ?? null;
+    } catch (e) {
+      if (currentRequest !== requestId) return;
+      error = e instanceof Error ? e.message : 'Failed to load event log';
+    } finally {
+      if (currentRequest === requestId) {
+        loading = false;
+      }
+    }
+  }
+
   async function loadMore() {
-    if (loading || !hasOlder) return;
-    const last = accumulated[accumulated.length - 1];
-    if (!last) return;
-    beforeCursor = last.sequence;
-    // Belt-and-suspenders refetch — the variables-function reactive tracking
-    // inside useQuery is supposed to trigger this automatically when
-    // beforeCursor changes, but force it here so the user click never
-    // gets stuck on a subtle reactivity miss.
-    await eventsQuery.refetch();
+    if (loading || loadingMore || !hasOlder) return;
+
+    const before = endCursor ?? entries[entries.length - 1]?.sequence;
+    if (!before) return;
+
+    const currentRequest = ++requestId;
+    loadingMore = true;
+    error = null;
+
+    try {
+      const result = await queryEventLog(before);
+      if (currentRequest !== requestId) return;
+
+      if (result.error) {
+        error = result.error.message;
+        return;
+      }
+
+      const conn = result.data?.admin?.eventLog;
+      if (!conn) {
+        error = 'Event log unavailable (audit permission required)';
+        return;
+      }
+
+      entries = mergeEntries(entries, conn.entries);
+      totalCount = String(conn.totalCount);
+      hasOlder = conn.hasOlder;
+      endCursor = conn.endCursor ?? null;
+    } catch (e) {
+      if (currentRequest !== requestId) return;
+      error = e instanceof Error ? e.message : 'Failed to load older events';
+    } finally {
+      if (currentRequest === requestId) {
+        loadingMore = false;
+      }
+    }
+  }
+
+  function mergeEntries(existing: Entry[], next: Entry[]): Entry[] {
+    const seen = new Set(existing.map((entry) => entry.sequence));
+    return [...existing, ...next.filter((entry) => !seen.has(entry.sequence))];
   }
 
   function openEntry(entry: Entry) {
@@ -121,60 +177,52 @@
     showMobileNav
   />
 
-  <div class="min-h-0 flex-1 overflow-y-auto">
+  <div class="min-h-0 flex-1 overflow-y-auto" bind:this={scrollContainer}>
     <div class="flex flex-col gap-4 p-6">
-    {#if error}
-      <Hint tone="danger">{error}</Hint>
-    {/if}
+      {#if error}
+        <Hint tone="danger">{error}</Hint>
+      {/if}
 
-    <div class="text-sm text-muted">
-      {totalCount.toLocaleString()} total event{totalCount === 1 ? '' : 's'} in stream
-    </div>
-
-    <Panel noPadding>
-      <DataTable
-        items={accumulated}
-        columns={5}
-        emptyMessage={loading ? 'Loading…' : 'No events recorded yet.'}
-        onRowClick={openEntry}
-      >
-        {#snippet header()}
-          <th class="px-4 py-3 font-medium">Seq</th>
-          <th class="px-4 py-3 font-medium">Time</th>
-          <th class="px-4 py-3 font-medium">Event</th>
-          <th class="px-4 py-3 font-medium">Aggregate</th>
-          <th class="px-4 py-3 font-medium">Actor</th>
-        {/snippet}
-        {#snippet row(entry)}
-          <td class="px-4 py-3 font-mono text-sm text-muted">{entry.sequence}</td>
-          <td class="px-4 py-3 text-sm">{formatTimestamp(entry.createdAt)}</td>
-          <td class="px-4 py-3">
-            <Pill tone="accent">{entry.eventType || '—'}</Pill>
-          </td>
-          <td class="px-4 py-3 font-mono text-xs">
-            {#if entry.aggregateType}
-              <span class="text-muted">{entry.aggregateType}.</span>{entry.aggregateId}
-            {:else}
-              <span class="text-muted">{entry.subject}</span>
-            {/if}
-          </td>
-          <td class="px-4 py-3 font-mono text-xs">{entry.actorId || '—'}</td>
-        {/snippet}
-      </DataTable>
-    </Panel>
-
-    {#if hasOlder}
-      <div class="flex justify-center">
-        <button
-          type="button"
-          class="cursor-pointer rounded-lg border border-text/10 bg-surface-100 px-4 py-2 text-sm hover:bg-surface-200"
-          onclick={loadMore}
-          disabled={loading}
-        >
-          {loading ? 'Loading…' : 'Load older events'}
-        </button>
+      <div class="text-sm text-muted">
+        {formattedTotalCount} total event{totalCount === '1' ? '' : 's'} in stream
       </div>
-    {/if}
+
+      <Panel noPadding>
+        <DataTable
+          items={entries}
+          columns={5}
+          emptyMessage={loading ? 'Loading…' : 'No events recorded yet.'}
+          hasMore={hasOlder && !error}
+          {loadingMore}
+          onLoadMore={loadMore}
+          loadMoreRoot={scrollContainer}
+          loadingMoreMessage="Loading older events..."
+          onRowClick={openEntry}
+        >
+          {#snippet header()}
+            <th class="px-4 py-3 font-medium">Seq</th>
+            <th class="px-4 py-3 font-medium">Time</th>
+            <th class="px-4 py-3 font-medium">Event</th>
+            <th class="px-4 py-3 font-medium">Aggregate</th>
+            <th class="px-4 py-3 font-medium">Actor</th>
+          {/snippet}
+          {#snippet row(entry)}
+            <td class="px-4 py-3 font-mono text-sm text-muted">{entry.sequence}</td>
+            <td class="px-4 py-3 text-sm">{formatTimestamp(entry.createdAt)}</td>
+            <td class="px-4 py-3">
+              <Pill tone="accent">{entry.eventType || '—'}</Pill>
+            </td>
+            <td class="px-4 py-3 font-mono text-xs">
+              {#if entry.aggregateType}
+                <span class="text-muted">{entry.aggregateType}.</span>{entry.aggregateId}
+              {:else}
+                <span class="text-muted">{entry.subject}</span>
+              {/if}
+            </td>
+            <td class="px-4 py-3 font-mono text-xs">{entry.actorId || '—'}</td>
+          {/snippet}
+        </DataTable>
+      </Panel>
     </div>
   </div>
 </div>

--- a/frontend/src/routes/chat/[serverId]/server-admin/event-log/event-log.page.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/server-admin/event-log/event-log.page.svelte.spec.ts
@@ -1,14 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { flushSync } from 'svelte';
-import MembersPage from './+page.svelte';
+import EventLogPage from './+page.svelte';
 
-type Member = {
-  id: string;
-  login: string;
-  displayName: string;
-  avatarUrl: string | null;
-  roles: string[];
+type Entry = {
+  sequence: string;
+  subject: string;
+  aggregateType: string;
+  aggregateId: string;
+  eventType: string;
+  eventId: string;
+  actorId: string;
   createdAt: string;
 };
 
@@ -100,31 +102,38 @@ vi.mock('$lib/state/server/connection.svelte', () => ({
   })
 }));
 
-function member(index: number, prefix = 'member'): Member {
+function entry(sequence: string, eventType: string): Entry {
   return {
-    id: `${prefix}-${index}`,
-    login: `${prefix}${index}`,
-    displayName: `${prefix} ${index}`,
-    avatarUrl: null,
-    roles: ['everyone'],
+    sequence,
+    subject: `evt.test.${sequence}`,
+    aggregateType: 'test',
+    aggregateId: sequence,
+    eventType,
+    eventId: `event-${sequence}`,
+    actorId: `actor-${sequence}`,
     createdAt: '2026-01-01T12:00:00Z'
   };
 }
 
-function result(users: Member[], totalCount = users.length, hasMore = false) {
+function result(
+  entries: Entry[],
+  totalCount = entries.length,
+  hasOlder = false,
+  endCursor?: string
+) {
   return {
-    server: {
-      roles: [{ name: 'admin', displayName: 'Admin' }],
-      members: {
-        users,
+    admin: {
+      eventLog: {
+        entries,
         totalCount,
-        hasMore
+        hasOlder,
+        endCursor: endCursor ?? entries.at(-1)?.sequence ?? null
       }
     }
   };
 }
 
-function queueResults(...results: ReturnType<typeof result>[]) {
+function queueResults(...results: Array<ReturnType<typeof result> | { admin: null }>) {
   mocks.query.mockImplementation(() => {
     const data = results.shift();
     return {
@@ -143,9 +152,8 @@ async function settle() {
   flushSync();
 }
 
-describe('server admin members pagination', () => {
+describe('server admin event log pagination', () => {
   beforeEach(() => {
-    vi.useFakeTimers();
     originalIntersectionObserver = globalThis.IntersectionObserver;
     observers = [];
     globalThis.IntersectionObserver =
@@ -156,72 +164,44 @@ describe('server admin members pagination', () => {
 
   afterEach(() => {
     globalThis.IntersectionObserver = originalIntersectionObserver;
-    vi.useRealTimers();
   });
 
-  it('loads the first offset page on mount and the next page when the table end intersects', async () => {
+  it('loads the first cursor page and auto-loads older entries from the table sentinel', async () => {
     queueResults(
-      result(
-        Array.from({ length: 20 }, (_, i) => member(i)),
-        21,
-        true
-      ),
-      result([member(20)], 21, false)
+      result([entry('102', 'user.created'), entry('101', 'room.created')], 3, true, '101'),
+      result([entry('101', 'room.created'), entry('100', 'auth.login')], 3, false, '100')
     );
 
-    const { container } = render(MembersPage);
+    const { container } = render(EventLogPage);
     await settle();
 
     expect(mocks.query).toHaveBeenNthCalledWith(1, expect.anything(), {
-      search: null,
-      limit: 20,
-      offset: 0
+      limit: 50,
+      before: null
     });
-    expect(container.textContent).toContain('Showing 20 of 21 member(s)');
+    expect(container.textContent).toContain('3 total events in stream');
+    expect(container.textContent).toContain('user.created');
+    expect(container.textContent).toContain('room.created');
 
     expect(observers).toHaveLength(1);
     observers[0].trigger(true);
     await settle();
 
     expect(mocks.query).toHaveBeenNthCalledWith(2, expect.anything(), {
-      search: null,
-      limit: 20,
-      offset: 20
+      limit: 50,
+      before: '101'
     });
-    expect(container.textContent).toContain('@member20');
-    expect(container.textContent).toContain('Showing 21 of 21 member(s)');
+    expect(container.textContent).toContain('auth.login');
+    expect(container.textContent?.match(/room.created/g)).toHaveLength(1);
   });
 
-  it('searches from offset zero and hides load-more when the filtered page is complete', async () => {
-    queueResults(
-      result([member(0, 'unrelated')], 42, true),
-      result([member(0, 'target')], 1, false)
-    );
+  it('renders the audit permission error when admin data is unavailable', async () => {
+    queueResults({ admin: null });
 
-    const { container } = render(MembersPage);
+    const { container } = render(EventLogPage);
     await settle();
 
-    const input = container.querySelector('input') as HTMLInputElement;
-    input.value = ' target ';
-    input.dispatchEvent(new Event('input', { bubbles: true }));
-    await vi.advanceTimersByTimeAsync(300);
-    await settle();
-
-    expect(mocks.query).toHaveBeenNthCalledWith(2, expect.anything(), {
-      search: 'target',
-      limit: 20,
-      offset: 0
-    });
-    expect(container.textContent).toContain('@target0');
-    expect(container.textContent).not.toContain('@unrelated0');
-  });
-
-  it('renders the members body as a scroll region', async () => {
-    queueResults(result([], 0, false));
-
-    const { container } = render(MembersPage);
-    await settle();
-
-    expect(container.querySelector('.min-h-0.flex-1.overflow-y-auto')).toBeTruthy();
+    expect(container.textContent).toContain('Event log unavailable (audit permission required)');
+    expect(observers).toHaveLength(0);
   });
 });

--- a/frontend/src/routes/chat/[serverId]/server-admin/members/+page.svelte
+++ b/frontend/src/routes/chat/[serverId]/server-admin/members/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, tick } from 'svelte';
+  import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { serverIdToSegment } from '$lib/navigation';
@@ -18,7 +18,6 @@
   const userSettings = getUserSettings();
   const connection = useConnection();
   const PAGE_SIZE = 20;
-  const AUTO_LOAD_THRESHOLD_PX = 160;
 
   const ServerAdminMembersDocument = graphql(`
     query ServerAdminMembers($search: String, $limit: Int!, $offset: Int!) {
@@ -57,7 +56,7 @@
   let error = $state<string | null>(null);
   let requestId = 0;
   let searchTimer: ReturnType<typeof setTimeout> | null = null;
-  let scrollContainer: HTMLDivElement | undefined;
+  let scrollContainer = $state<HTMLDivElement>();
 
   onMount(() => {
     void loadFirstPage('');
@@ -126,8 +125,6 @@
     } finally {
       if (currentRequest === requestId) {
         loading = false;
-        await tick();
-        maybeLoadMore();
       }
     }
   }
@@ -140,7 +137,6 @@
     const offset = users.length;
     loadingMore = true;
     error = null;
-    let loadedPage = false;
 
     try {
       const result = await queryMembers(search, offset);
@@ -162,31 +158,13 @@
       users = [...users, ...members.users.filter((user) => !seen.has(user.id))];
       totalCount = members.totalCount;
       hasMore = members.hasMore;
-      loadedPage = true;
     } catch (e) {
       if (currentRequest !== requestId) return;
       error = e instanceof Error ? e.message : 'Failed to load more members';
     } finally {
       if (currentRequest === requestId) {
         loadingMore = false;
-        if (loadedPage) {
-          await tick();
-          maybeLoadMore();
-        }
       }
-    }
-  }
-
-  function isNearScrollEnd(): boolean {
-    if (!scrollContainer) return false;
-    const scrollableDistance = scrollContainer.scrollHeight - scrollContainer.clientHeight;
-    if (scrollableDistance <= 0) return false;
-    return scrollableDistance - scrollContainer.scrollTop <= AUTO_LOAD_THRESHOLD_PX;
-  }
-
-  function maybeLoadMore() {
-    if (isNearScrollEnd()) {
-      void loadMore();
     }
   }
 
@@ -211,13 +189,13 @@
 <PageTitle title="Members | Admin" />
 
 <div class="flex min-h-0 min-w-0 flex-1 flex-col">
-  <PaneHeader title="Members" subtitle="View and manage server members and their roles" showMobileNav />
+  <PaneHeader
+    title="Members"
+    subtitle="View and manage server members and their roles"
+    showMobileNav
+  />
 
-  <div
-    class="min-h-0 flex-1 overflow-y-auto"
-    bind:this={scrollContainer}
-    onscroll={maybeLoadMore}
-  >
+  <div class="min-h-0 flex-1 overflow-y-auto" bind:this={scrollContainer}>
     <div class="flex flex-col gap-6 p-6">
       <!-- Search input -->
       <div class="max-w-md">
@@ -241,6 +219,11 @@
             items={users}
             columns={4}
             emptyMessage="No members found"
+            hasMore={hasMore && !error}
+            {loadingMore}
+            onLoadMore={loadMore}
+            loadMoreRoot={scrollContainer}
+            loadingMoreMessage="Loading more members..."
             onRowClick={(user) =>
               goto(
                 resolve('/chat/[serverId]/server-admin/members/[userId]', {
@@ -287,13 +270,6 @@
           <div class="text-sm text-muted">
             Showing {users.length} of {totalCount} member(s)
           </div>
-
-          {#if loadingMore}
-            <div class="flex items-center gap-2 text-sm text-muted" aria-live="polite">
-              <span class="iconify text-base uil--spinner animate-spin" aria-hidden="true"></span>
-              Loading more members...
-            </div>
-          {/if}
         </div>
       {/if}
     </div>


### PR DESCRIPTION
- Adds shared auto-load support to the admin `DataTable` using an intersection sentinel.
- Migrates Server Admin Members and Event Log to use the shared auto-pagination behavior.
- Reworks Event Log pagination into an explicit cursor-based state machine and adds browser coverage for loading older entries.
- Updates frontend testing guidance to avoid SvelteKit-reserved `+*` spec filenames.

Tests:
- `npm run test:unit -- --run src/lib/components/admin/DataTable.svelte.spec.ts 'src/routes/chat/[serverId]/server-admin/members/members.page.svelte.spec.ts' 'src/routes/chat/[serverId]/server-admin/event-log/event-log.page.svelte.spec.ts'`
- `npm run check`
