### PR TITLE
fix(frontend): remove server header leave icon

### DIFF
--- a/frontend/e2e/servers.test.ts
+++ b/frontend/e2e/servers.test.ts
@@ -39,13 +39,13 @@ test.describe('Leave Server', () => {
 		return server.baseURL.replace('localhost', '127.0.0.1');
 	}
 
-	test('leaving a remote server unregisters it from the sidebar', async ({ page, chatPage }) => {
+	test('Leave Server icon is hidden on remote instances', async ({ page, chatPage }) => {
 		await createAndLoginTestUser(page);
 		await chatPage.goto();
 
 		const baseURL = remoteBaseURL(remoteServer);
 		const remoteHostname = new URL(baseURL).hostname;
-		const remoteUser = await createUserOnRemote(baseURL, 'remoteuser-leave', 'password123');
+		const remoteUser = await createUserOnRemote(baseURL, 'remoteuser-hidden', 'password123');
 		await connectRemoteInstance(page, { ...remoteServer, baseURL }, remoteUser.userId);
 
 		// The remote should have been added to the sidebar.
@@ -58,55 +58,12 @@ test.describe('Leave Server', () => {
 		await remoteSidebarIcon.click();
 		await page.waitForURL(new RegExp(`/chat/${remoteHostname.replace(/\./g, '\\.')}`));
 
-		// Click the Leave Server icon in the space header.
-		await page.getByTitle('Leave server').click();
-
-		// Confirmation dialog should appear with Leave Server copy.
-		const dialog = page.getByRole('dialog');
-		await expect(dialog).toBeVisible({ timeout: TIMEOUTS.UI_FAST });
-		await expect(dialog.getByRole('heading', { name: 'Leave Server' })).toBeVisible();
-
-		// Confirm.
-		await dialog.getByRole('button', { name: 'Leave Server' }).click();
-
-		// Should land back on the origin instance.
-		await page.waitForURL(/\/chat\/-/, { timeout: TIMEOUTS.UI_STANDARD });
-
-		// Remote should no longer be in the sidebar or localStorage.
-		await expect(remoteSidebarIcon).not.toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
-
-		const stored = await page.evaluate(() =>
-			JSON.parse(localStorage.getItem('chatto:instances') ?? '[]')
-		);
-		expect(stored.find((i: { url: string }) => i.url.includes(remoteHostname))).toBeUndefined();
+		// The leave-server affordance was removed from the server header.
+		await expect(page.getByTitle('Leave server')).not.toBeVisible();
 	});
+});
 
-	test('cancelling Leave Server keeps the instance', async ({ page, chatPage }) => {
-		await createAndLoginTestUser(page);
-		await chatPage.goto();
-
-		const baseURL = remoteBaseURL(remoteServer);
-		const remoteHostname = new URL(baseURL).hostname;
-		const remoteUser = await createUserOnRemote(baseURL, 'remoteuser-cancel', 'password123');
-		await connectRemoteInstance(page, { ...remoteServer, baseURL }, remoteUser.userId);
-
-		const remoteSidebarIcon = page
-			.locator(`[data-testid="server-icon"][href*="${remoteHostname}"]`)
-			.first();
-		await expect(remoteSidebarIcon).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-		await remoteSidebarIcon.click();
-		await page.waitForURL(new RegExp(`/chat/${remoteHostname.replace(/\./g, '\\.')}`));
-
-		await page.getByTitle('Leave server').click();
-		const dialog = page.getByRole('dialog');
-		await expect(dialog).toBeVisible({ timeout: TIMEOUTS.UI_FAST });
-		await dialog.getByRole('button', { name: 'Cancel' }).click();
-		await expect(dialog).not.toBeVisible();
-
-		// Still in the remote server, still in the sidebar.
-		await expect(remoteSidebarIcon).toBeVisible();
-	});
-
+test.describe('Origin Server', () => {
 	test('Leave Server icon is hidden on the origin instance', async ({ page, chatPage }) => {
 		await createAndLoginTestUser(page);
 		await chatPage.goto();

--- a/frontend/src/lib/components/chat/ServerHeader.svelte
+++ b/frontend/src/lib/components/chat/ServerHeader.svelte
@@ -1,11 +1,6 @@
 <script lang="ts">
-  import { pushState } from '$app/navigation';
-  import { getActiveServer } from '$lib/state/activeServer.svelte';
-  import { serverRegistry } from '$lib/state/server/registry.svelte';
   import HeaderIconButton from '$lib/ui/HeaderIconButton.svelte';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
-
-  const isOrigin = $derived(serverRegistry.isOriginServer(getActiveServer()));
 
   let {
     serverName,
@@ -18,21 +13,12 @@
   } = $props();
 </script>
 
-<PaneHeader title={serverName} {loading} skeletonButtons={adminHref ? 2 : 1}>
-  {#snippet actions()}
-    {#if adminHref}
+{#if adminHref}
+  <PaneHeader title={serverName} {loading} skeletonButtons={1}>
+    {#snippet actions()}
       <HeaderIconButton icon="uil--setting" label="Server administration" href={adminHref} />
-    {/if}
-    {#if !isOrigin}
-      <button
-        class="iconify cursor-pointer text-muted uil--sign-out-alt hover:text-text"
-        onclick={() =>
-          pushState('', {
-            modal: { type: 'leaveServer', spaceName: serverName }
-          })}
-        title="Leave server"
-      >
-      </button>
-    {/if}
-  {/snippet}
-</PaneHeader>
+    {/snippet}
+  </PaneHeader>
+{:else}
+  <PaneHeader title={serverName} {loading} skeletonButtons={0} />
+{/if}


### PR DESCRIPTION
## Changes

- Removes the leave/remove-server icon from the server sidebar pane header.
- Keeps the server administration action when available and drops the unused header modal wiring.
- Adjusts the loading skeleton button count to match the remaining header actions.
- Updates the server e2e coverage to assert the removed header icon stays absent on origin and remote servers.

## Verification

- `npx @sveltejs/mcp svelte-autofixer frontend/src/lib/components/chat/ServerHeader.svelte --svelte-version 5`
- `pnpm run check`
- `mise x -- pnpm exec playwright test e2e/servers.test.ts --retries=0`
