### PR TITLE
fix(frontend): use commit hash for dev app version

### DIFF
--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -1,5 +1,16 @@
 import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import { execSync } from 'node:child_process';
+
+function buildVersionName() {
+  if (process.env.npm_package_version) return process.env.npm_package_version;
+
+  try {
+    return execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
+  } catch {
+    return 'dev';
+  }
+}
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -12,8 +23,9 @@ const config = {
       precompress: true
     }),
     version: {
-      // Use package version or build timestamp for version tracking
-      name: process.env.npm_package_version || Date.now().toString(),
+      // Use package version when run through package scripts, or the current
+      // commit hash when launched directly by local dev tooling.
+      name: buildVersionName(),
       // Check for new version every 60 seconds
       pollInterval: 60000
     }


### PR DESCRIPTION
- Uses the current short git commit hash for the SvelteKit app version when launched outside package scripts.
- Keeps the package version when `npm_package_version` is available and falls back to `dev` if git metadata is unavailable.

Validation:
- `node --check frontend/svelte.config.js`
- `git diff --check`
