### PR TITLE
fix: preserve session auth for GraphQL CSRF

### DIFF
--- a/frontend/e2e/server-flows.test.ts
+++ b/frontend/e2e/server-flows.test.ts
@@ -38,6 +38,48 @@ test.describe('Landing Page', () => {
 		await context.close();
 	});
 
+	test('fresh browser context accepts a valid session cookie without a CSRF cookie', async ({
+		browser,
+		page,
+		serverURL
+	}) => {
+		await createAndLoginTestUser(page);
+		const sessionCookie = (await page.context().cookies()).find(
+			(cookie) => cookie.name === 'chatto_session'
+		);
+		expect(sessionCookie).toBeDefined();
+
+		const context = await browser.newContext({ baseURL: serverURL });
+		await context.addCookies([sessionCookie!]);
+		const freshPage = await context.newPage();
+
+		try {
+			const rejectedResponse = await freshPage.request.post('/api/graphql', {
+				headers: { 'Content-Type': 'application/json' },
+				data: {
+					query: `query { viewer { user { id } } }`
+				}
+			});
+			expect(rejectedResponse.status()).toBe(403);
+
+			const acceptedResponse = await freshPage.request.post('/api/graphql', {
+				headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
+				data: {
+					query: `query { viewer { user { id } } }`
+				}
+			});
+			expect(acceptedResponse.ok()).toBe(true);
+			const acceptedBody = await acceptedResponse.json();
+			expect(acceptedBody.data.viewer.user.id).toBeTruthy();
+
+			await freshPage.goto(routes.settings);
+			await expect(freshPage.getByRole('heading', { name: 'Profile' })).toBeVisible();
+			await expect(freshPage).not.toHaveURL(routes.login);
+		} finally {
+			await context.close();
+		}
+	});
+
 	test('authenticated user with instances is redirected into the server', async ({
 		page
 	}) => {

--- a/frontend/src/lib/state/server/graphqlClient.svelte.spec.ts
+++ b/frontend/src/lib/state/server/graphqlClient.svelte.spec.ts
@@ -136,19 +136,34 @@ describe('GraphQLClient', () => {
 		new GraphQLClient(makeConfig({ token: null }));
 		expect(lastClientConfig()?.fetchOptions).toBeDefined();
 		const opts = (lastClientConfig()!.fetchOptions as () => Record<string, unknown>)();
-		expect(opts).toEqual({ headers: { 'X-CSRF-Token': 'csrf-token' } });
+		expect(opts).toEqual({
+			headers: { 'X-REQUEST-TYPE': 'GraphQL', 'X-CSRF-Token': 'csrf-token' }
+		});
+	});
+
+	it('sets GraphQL request type header for cookie auth when the CSRF cookie is missing', () => {
+		new GraphQLClient(makeConfig({ token: null }));
+		expect(lastClientConfig()?.fetchOptions).toBeDefined();
+		const opts = (lastClientConfig()!.fetchOptions as () => Record<string, unknown>)();
+		expect(opts).toEqual({ headers: { 'X-REQUEST-TYPE': 'GraphQL' } });
 	});
 
 	it('sets fetchOptions with Authorization header when token is provided', () => {
 		document.cookie = 'chatto_csrf=csrf-token; path=/';
-		new GraphQLClient(makeConfig({ url: 'https://remote.example.com/api/graphql', token: 'my-token' }));
+		new GraphQLClient(
+			makeConfig({ url: 'https://remote.example.com/api/graphql', token: 'my-token' })
+		);
 		expect(lastClientConfig()?.fetchOptions).toBeDefined();
 		const opts = (lastClientConfig()!.fetchOptions as () => Record<string, unknown>)();
-		expect(opts).toEqual({ headers: { Authorization: 'Bearer my-token' } });
+		expect(opts).toEqual({
+			headers: { 'X-REQUEST-TYPE': 'GraphQL', Authorization: 'Bearer my-token' }
+		});
 	});
 
 	it('sets connectionParams when token is provided', () => {
-		new GraphQLClient(makeConfig({ url: 'https://remote.example.com/api/graphql', token: 'my-token' }));
+		new GraphQLClient(
+			makeConfig({ url: 'https://remote.example.com/api/graphql', token: 'my-token' })
+		);
 		expect(createWSClient).toHaveBeenCalledWith(
 			expect.objectContaining({
 				connectionParams: expect.any(Function)

--- a/frontend/src/lib/state/server/graphqlClient.svelte.ts
+++ b/frontend/src/lib/state/server/graphqlClient.svelte.ts
@@ -4,6 +4,7 @@ import { serverRegistry } from './registry.svelte';
 import { csrfHeaders } from '$lib/auth/csrf';
 
 const SESSION_VALIDATION_COOLDOWN_MS = 5000;
+const GRAPHQL_REQUEST_HEADERS = { 'X-REQUEST-TYPE': 'GraphQL' };
 
 /**
  * Delay between WS reconnection attempts. The first attempt after a
@@ -271,7 +272,13 @@ export class GraphQLClient {
 			url,
 			preferGetMethod: false,
 			fetchOptions: () => ({
-				headers: token ? { Authorization: `Bearer ${token}` } : csrfHeaders()
+				// The backend's CSRF middleware treats explicitly-marked GraphQL
+				// requests as safe to authenticate with the session cookie alone.
+				// Keep the marker on every GraphQL POST; add the CSRF token when
+				// this browser has one, or bearer auth for remote servers.
+				headers: token
+					? { ...GRAPHQL_REQUEST_HEADERS, Authorization: `Bearer ${token}` }
+					: { ...GRAPHQL_REQUEST_HEADERS, ...csrfHeaders() }
 			}),
 			exchanges: [
 				mapExchange({


### PR DESCRIPTION
## Summary

- Mark every frontend GraphQL HTTP request with `X-REQUEST-TYPE: GraphQL` so the backend CSRF middleware accepts valid session cookies even when a fresh browser context lacks `chatto_csrf`.
- Preserve existing CSRF-token and bearer-token headers, and document why the GraphQL request marker is required.
- Add unit and e2e coverage for a fresh browser context carrying only `chatto_session`, including direct backend acceptance/rejection checks.

## Tests

- `pnpm exec vitest --run src/lib/state/server/graphqlClient.svelte.spec.ts`
- `pnpm exec playwright test e2e/server-flows.test.ts -g "fresh browser context" --retries=0`
- `pnpm check`
- `pnpm lint`
- `go test ./internal/http_server -run CSRF`
