### PR TITLE
chore(conductor): run bundled executable locally

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -2,7 +2,16 @@
 
 [scripts]
 setup = "mise trust"
-run = "export VITE_PORT=$CONDUCTOR_PORT CHATTO_WEBSERVER_PORT=$((CONDUCTOR_PORT+1)) CHATTO_WEBSERVER_URL=http://localhost:$CONDUCTOR_PORT CHATTO_NATS_EMBEDDED_PORT=$((CONDUCTOR_PORT+2)) TILT_PORT=$((CONDUCTOR_PORT+9)); exec mise run dev"
+run = """
+set -e
+export CHATTO_WEBSERVER_PORT="$CONDUCTOR_PORT"
+export CHATTO_WEBSERVER_URL="http://localhost:$CONDUCTOR_PORT"
+export CHATTO_NATS_EMBEDDED_PORT="$((CONDUCTOR_PORT+1))"
+export CHATTO_NATS_CLIENT_URL="nats://localhost:$((CONDUCTOR_PORT+1))"
+mise run build-cli
+cd cli
+exec bin/chatto run
+"""
 run_mode = "concurrent"
 
 [git]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing
+
+Chatto is not accepting outside contributions at this time, but feedback, bug reports, and ideas are welcome by [email](mailto:hendrik@mans.de).
+
+## Local Development with Conductor
+
+[Conductor](https://conductor.build) workspaces build and run the bundled Chatto executable. The `run` script in `.conductor/settings.toml` wires Conductor's assigned `$CONDUCTOR_PORT` and the next port into the env vars read by the executable:
+
+| Port              | Process                            |
+| ----------------- | ---------------------------------- |
+| `$CONDUCTOR_PORT` | Chatto webserver (user-facing URL) |
+| `+1`              | Embedded NATS                      |
+
+The repository-level Conductor settings are shared in `.conductor/settings.toml`. The run command builds the frontend and CLI, then starts `bin/chatto run` without live reloads. Put machine-specific overrides in `.conductor/settings.local.toml`; that file is gitignored and wins over shared settings on your machine. Conductor also reads `.worktreeinclude` to copy gitignored local environment files, such as `.env` and `.env.*`, into new workspaces.
+
+## Developing Outside of Conductor
+
+Use `mise` for local tool versions and tasks:
+
+```sh
+mise trust
+mise run setup
+```
+
+To run the bundled executable without live reloads:
+
+```sh
+export CHATTO_WEBSERVER_PORT=4000
+export CHATTO_WEBSERVER_URL=http://localhost:4000
+export CHATTO_NATS_EMBEDDED_PORT=4555
+export CHATTO_NATS_CLIENT_URL=nats://localhost:4555
+mise run build-cli
+cd cli
+bin/chatto run
+```
+
+For the live-reload development stack, use Tilt:
+
+```sh
+mise run dev
+```
+
+The Tilt stack uses Vite on port `5173`, the Go backend on port `4000`, and embedded NATS on port `4555`.
+
+## Local Bootstrap Users
+
+Local development instances are bootstrapped from `cli/chatto.toml` when the server is otherwise empty.
+
+| Login   | Email               | Password    | Role  |
+| ------- | ------------------- | ----------- | ----- |
+| `alice` | `alice@example.com` | `foobar123` | owner |
+| `bob`   | `bob@example.com`   | `foobar123` | user  |
+
+Use `alice` when you need server administration access.

--- a/README.md
+++ b/README.md
@@ -20,27 +20,6 @@ A lot of projects say this and people often ignore it, so let me spell things ou
 
 It should be no surprise that we are working hard to move towards a release that can give better guarantees, but we're not there yet.
 
-## Development with Conductor
-
-[Conductor](https://conductor.build) workspaces run the dev stack natively via `tilt up` — no Docker or Kubernetes required. The `run` script in `.conductor/settings.toml` wires Conductor's assigned `$CONDUCTOR_PORT` (and `+1` / `+2`) into the env vars the `Tiltfile` reads:
-
-| Port              | Process                              |
-| ----------------- | ------------------------------------ |
-| `$CONDUCTOR_PORT` | Vite dev server (user-facing URL)    |
-| `+1`              | Go backend (`CHATTO_WEBSERVER_PORT`) |
-| `+2`              | Embedded NATS                        |
-| `+9`              | Tilt web UI                          |
-
-Outside Conductor, `mise x -- tilt up --stream` uses the defaults from the `Tiltfile` (Vite 5173, backend 4000, NATS 4555).
-
-The repository-level Conductor settings are shared in `.conductor/settings.toml`. The run command starts Tilt in streaming mode and lets Tilt supervise the backend, frontend, and GraphQL codegen processes. Put machine-specific overrides in `.conductor/settings.local.toml`; that file is gitignored and wins over shared settings on your machine. Conductor also reads `.worktreeinclude` to copy gitignored local environment files, such as `.env` and `.env.*`, into new workspaces.
-
-Each instance is bootstrapped with the same dev credentials (configured in `cli/chatto.toml` under `[[bootstrap.users]]`):
-
-- **Login:** `alice`
-- **Email:** `alice@example.com`
-- **Password:** `foobar123`
-
 ## License
 
 Chatto is licensed under the [GNU Affero General Public License v3.0 (AGPL-3.0)](LICENSE). This means:
@@ -53,4 +32,4 @@ For full details, see the [LICENSE](LICENSE) file or run `chatto license`.
 
 ## Contributing
 
-This project is **not accepting outside contributions** at this time. If you have feedback, bug reports, or ideas, please [get in touch](mailto:hendrik@mans.de) — we'd love to hear from you.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local development notes. This project is **not accepting outside contributions** at this time, but feedback, bug reports, and ideas are welcome by [email](mailto:hendrik@mans.de).


### PR DESCRIPTION
## Changes

- Update Conductor's shared run script to build the bundled CLI and run `bin/chatto run` instead of starting the Tilt live-reload stack.
- Move local development guidance out of `README.md` and into `CONTRIBUTING.md`.
- Document Conductor ports, outside-Conductor development commands, and local bootstrap users.

## Validation

- Ran `mise run --dry-run build-cli`.
- Earlier full build completed successfully while validating the new executable path.
