### PR TITLE
chore(conductor): build run binary with bootstrap tag

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -8,7 +8,7 @@ export CHATTO_WEBSERVER_PORT="$CONDUCTOR_PORT"
 export CHATTO_WEBSERVER_URL="http://localhost:$CONDUCTOR_PORT"
 export CHATTO_NATS_EMBEDDED_PORT="$((CONDUCTOR_PORT+1))"
 export CHATTO_NATS_CLIENT_URL="nats://localhost:$((CONDUCTOR_PORT+1))"
-mise run build-cli
+GOFLAGS="-tags=bootstrap" mise run --force build-cli
 cd cli
 exec bin/chatto run
 """


### PR DESCRIPTION
- Build the Conductor run binary with the Go `bootstrap` tag so local dev bootstrap users are compiled in.
- Force the mise build task during Conductor run startup so an existing non-bootstrap binary is not reused.

Tested with `cd cli && GOFLAGS="-tags=bootstrap" go test ./cmd -run TestApplyBootstrap_EmptySectionIsNoOp -count=1`.
