### PR TITLE
fix: remember sidebar visibility preferences

### DIFF
--- a/frontend/src/lib/state/globals.svelte.spec.ts
+++ b/frontend/src/lib/state/globals.svelte.spec.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getMainSidebarOpen, setMainSidebarOpen } from '$lib/storage/mainSidebarOpen';
+import { SidebarNavState } from './globals.svelte';
+
+describe('SidebarNavState', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('hydrates the desktop open state from storage', () => {
+    setMainSidebarOpen(false);
+
+    const sidebar = new SidebarNavState();
+
+    expect(sidebar.isOpen).toBe(false);
+  });
+
+  it('persists desktop toggles', () => {
+    const sidebar = new SidebarNavState(true);
+
+    sidebar.toggle();
+    expect(sidebar.isOpen).toBe(false);
+    expect(getMainSidebarOpen()).toBe(false);
+
+    sidebar.toggle();
+    expect(sidebar.isOpen).toBe(true);
+    expect(getMainSidebarOpen()).toBe(true);
+  });
+
+  it('does not persist mobile overlay open and close changes', () => {
+    setMainSidebarOpen(true);
+    const sidebar = new SidebarNavState();
+
+    sidebar.setMobile(true);
+    expect(sidebar.isOpen).toBe(false);
+
+    sidebar.toggle();
+    expect(sidebar.isOpen).toBe(true);
+    expect(getMainSidebarOpen()).toBe(true);
+
+    sidebar.close();
+    expect(sidebar.isOpen).toBe(false);
+    expect(getMainSidebarOpen()).toBe(true);
+
+    sidebar.setMobile(false);
+    expect(sidebar.isOpen).toBe(true);
+  });
+
+  it('restores a closed desktop preference after mobile use', () => {
+    setMainSidebarOpen(false);
+    const sidebar = new SidebarNavState();
+
+    sidebar.setMobile(true);
+    sidebar.toggle();
+    expect(sidebar.isOpen).toBe(true);
+
+    sidebar.setMobile(false);
+    expect(sidebar.isOpen).toBe(false);
+    expect(getMainSidebarOpen()).toBe(false);
+  });
+});

--- a/frontend/src/lib/state/globals.svelte.ts
+++ b/frontend/src/lib/state/globals.svelte.ts
@@ -5,6 +5,8 @@
  * are not scoped to an instance or room, and don't use Svelte context.
  */
 
+import { getMainSidebarOpen, setMainSidebarOpen } from '$lib/storage/mainSidebarOpen';
+
 // ---------------------------------------------------------------------------
 // AppState — browser focus tracking
 // ---------------------------------------------------------------------------
@@ -91,7 +93,7 @@ export const SIDEBAR_PANEL_WIDTH_PX = 68 + 256;
  * finger delta (relative to the open position). Templates should disable
  * CSS transitions while dragging and apply the transform from `progress`.
  */
-class SidebarNavState {
+export class SidebarNavState {
   isOpen = $state(true);
   /**
    * Live drag offset in px relative to the *open* position. Negative values
@@ -102,6 +104,11 @@ class SidebarNavState {
   private desktopOpen = $state(true);
   private _isMobile = $state(false);
   private dragBaselineOpen = false;
+
+  constructor(initialDesktopOpen = getMainSidebarOpen()) {
+    this.isOpen = initialDesktopOpen;
+    this.desktopOpen = initialDesktopOpen;
+  }
 
   setMobile(isMobile: boolean) {
     if (this._isMobile === isMobile) return;
@@ -117,10 +124,12 @@ class SidebarNavState {
   }
 
   toggle() {
-    this.isOpen = !this.isOpen;
-    if (!this._isMobile) {
-      this.desktopOpen = this.isOpen;
+    if (this._isMobile) {
+      this.isOpen = !this.isOpen;
+      return;
     }
+
+    this.setDesktopOpen(!this.isOpen);
   }
 
   get isMobile(): boolean {
@@ -143,6 +152,9 @@ class SidebarNavState {
 
   close() {
     this.isOpen = false;
+    if (!this._isMobile) {
+      this.setDesktopOpen(false);
+    }
   }
 
   startDrag() {
@@ -182,6 +194,12 @@ class SidebarNavState {
     const handler = (e: MediaQueryListEvent) => this.setMobile(e.matches);
     mq.addEventListener('change', handler);
     return () => mq.removeEventListener('change', handler);
+  }
+
+  private setDesktopOpen(open: boolean) {
+    this.desktopOpen = open;
+    this.isOpen = open;
+    setMainSidebarOpen(open);
   }
 }
 

--- a/frontend/src/lib/storage/mainSidebarOpen.spec.ts
+++ b/frontend/src/lib/storage/mainSidebarOpen.spec.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { globalSlot } from './slot';
+import {
+  getMainSidebarOpen,
+  MAIN_SIDEBAR_DEFAULT_OPEN,
+  setMainSidebarOpen
+} from './mainSidebarOpen';
+
+const storage = new Map<string, string>();
+const localStorageMock: Storage = {
+  getItem: (key) => storage.get(key) ?? null,
+  setItem: (key, value) => storage.set(key, value),
+  removeItem: (key) => storage.delete(key),
+  clear: () => storage.clear(),
+  get length() {
+    return storage.size;
+  },
+  key: (index) => [...storage.keys()][index] ?? null
+};
+vi.stubGlobal('localStorage', localStorageMock);
+
+beforeEach(() => {
+  storage.clear();
+});
+
+describe('main sidebar open storage', () => {
+  it('defaults to open', () => {
+    expect(getMainSidebarOpen()).toBe(MAIN_SIDEBAR_DEFAULT_OPEN);
+  });
+
+  it('persists both states globally', () => {
+    setMainSidebarOpen(false);
+    expect(getMainSidebarOpen()).toBe(false);
+
+    setMainSidebarOpen(true);
+    expect(getMainSidebarOpen()).toBe(true);
+  });
+
+  it('falls back to open for unknown stored values', () => {
+    const key = globalSlot('mainSidebarOpen', true, {
+      serialize: String,
+      parse: (raw) => raw
+    }).key;
+
+    localStorage.setItem(key, 'sometimes');
+
+    expect(getMainSidebarOpen()).toBe(true);
+  });
+});

--- a/frontend/src/lib/storage/mainSidebarOpen.ts
+++ b/frontend/src/lib/storage/mainSidebarOpen.ts
@@ -1,0 +1,13 @@
+import { Codecs, globalSlot } from './slot';
+
+export const MAIN_SIDEBAR_DEFAULT_OPEN = true;
+
+const slot = globalSlot('mainSidebarOpen', MAIN_SIDEBAR_DEFAULT_OPEN, Codecs.boolean);
+
+export function getMainSidebarOpen(): boolean {
+  return slot.get();
+}
+
+export function setMainSidebarOpen(open: boolean): void {
+  slot.set(open);
+}

--- a/frontend/src/lib/storage/roomSidebarPanel.spec.ts
+++ b/frontend/src/lib/storage/roomSidebarPanel.spec.ts
@@ -2,8 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { serverStorageKey } from './serverStorage';
 import {
   getRoomSidebarPanel,
+  getRoomSidebarPanelState,
+  ROOM_SIDEBAR_DEFAULT_PANEL,
   roomSidebarPanelStorageSuffix,
-  setRoomSidebarPanel
+  setRoomSidebarPanel,
+  setRoomSidebarPanelState
 } from './roomSidebarPanel';
 
 const storage = new Map<string, string>();
@@ -26,6 +29,7 @@ beforeEach(() => {
 describe('room sidebar panel storage', () => {
   it('defaults to members', () => {
     expect(getRoomSidebarPanel('server-a', 'room-1')).toBe('members');
+    expect(getRoomSidebarPanelState('server-a', 'room-1')).toBe(ROOM_SIDEBAR_DEFAULT_PANEL);
   });
 
   it('persists the selected panel per server and room', () => {
@@ -36,6 +40,25 @@ describe('room sidebar panel storage', () => {
     expect(getRoomSidebarPanel('server-a', 'room-1')).toBe('files');
     expect(getRoomSidebarPanel('server-a', 'room-2')).toBe('members');
     expect(getRoomSidebarPanel('server-b', 'room-1')).toBe('members');
+  });
+
+  it('persists closed state per server and room', () => {
+    setRoomSidebarPanelState('server-a', 'room-1', null);
+    setRoomSidebarPanelState('server-a', 'room-2', 'files');
+    setRoomSidebarPanelState('server-b', 'room-1', 'members');
+
+    const key = serverStorageKey('server-a', roomSidebarPanelStorageSuffix('room-1'));
+
+    expect(localStorage.getItem(key)).toBe('closed');
+    expect(getRoomSidebarPanelState('server-a', 'room-1')).toBeNull();
+    expect(getRoomSidebarPanelState('server-a', 'room-2')).toBe('files');
+    expect(getRoomSidebarPanelState('server-b', 'room-1')).toBe('members');
+  });
+
+  it('keeps panel-only reads compatible when the sidebar is closed', () => {
+    setRoomSidebarPanelState('server-a', 'room-1', null);
+
+    expect(getRoomSidebarPanel('server-a', 'room-1')).toBe('members');
   });
 
   it('falls back to members for unknown stored values', () => {

--- a/frontend/src/lib/storage/roomSidebarPanel.ts
+++ b/frontend/src/lib/storage/roomSidebarPanel.ts
@@ -3,23 +3,29 @@ import { serverSlot, type Codec } from './slot';
 export const ROOM_SIDEBAR_PANELS = ['members', 'files'] as const;
 
 export type RoomSidebarPanel = (typeof ROOM_SIDEBAR_PANELS)[number];
+export type RoomSidebarPanelState = RoomSidebarPanel | null;
 
 export const ROOM_SIDEBAR_DEFAULT_PANEL: RoomSidebarPanel = 'members';
+const ROOM_SIDEBAR_CLOSED_VALUE = 'closed';
 
 function isRoomSidebarPanel(value: unknown): value is RoomSidebarPanel {
   return typeof value === 'string' && ROOM_SIDEBAR_PANELS.includes(value as RoomSidebarPanel);
 }
 
-const codec: Codec<RoomSidebarPanel> = {
-  serialize: (value) => value,
-  parse: (raw) => (isRoomSidebarPanel(raw) ? raw : undefined)
+const codec: Codec<RoomSidebarPanelState> = {
+  serialize: (value) => value ?? ROOM_SIDEBAR_CLOSED_VALUE,
+  parse: (raw) => {
+    if (raw === ROOM_SIDEBAR_CLOSED_VALUE) return null;
+    if (isRoomSidebarPanel(raw)) return raw;
+    return undefined;
+  }
 };
 
 export function roomSidebarPanelStorageSuffix(roomId: string): string {
   return `room:${roomId}:sidebarPanel`;
 }
 
-export function getRoomSidebarPanel(serverId: string, roomId: string): RoomSidebarPanel {
+export function getRoomSidebarPanelState(serverId: string, roomId: string): RoomSidebarPanelState {
   return serverSlot(
     serverId,
     roomSidebarPanelStorageSuffix(roomId),
@@ -28,10 +34,10 @@ export function getRoomSidebarPanel(serverId: string, roomId: string): RoomSideb
   ).get();
 }
 
-export function setRoomSidebarPanel(
+export function setRoomSidebarPanelState(
   serverId: string,
   roomId: string,
-  panel: RoomSidebarPanel
+  panel: RoomSidebarPanelState
 ): void {
   serverSlot(
     serverId,
@@ -39,4 +45,16 @@ export function setRoomSidebarPanel(
     ROOM_SIDEBAR_DEFAULT_PANEL,
     codec
   ).set(panel);
+}
+
+export function getRoomSidebarPanel(serverId: string, roomId: string): RoomSidebarPanel {
+  return getRoomSidebarPanelState(serverId, roomId) ?? ROOM_SIDEBAR_DEFAULT_PANEL;
+}
+
+export function setRoomSidebarPanel(
+  serverId: string,
+  roomId: string,
+  panel: RoomSidebarPanel
+): void {
+  setRoomSidebarPanelState(serverId, roomId, panel);
 }

--- a/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -30,15 +30,15 @@
   import { resolve } from '$app/paths';
   import { serverIdToSegment } from '$lib/navigation';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
-  import { getRoomSidebarPanel, setRoomSidebarPanel } from '$lib/storage/roomSidebarPanel';
   import { clearLastRoom, setLastRoom } from '$lib/storage/lastRoom';
   import PageTitle from '$lib/ui/PageTitle.svelte';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
   import { tick } from 'svelte';
   import { fly } from 'svelte/transition';
   import RoomEventsPane from './RoomEventsPane.svelte';
-  import RoomSidebar, { type RoomSidebarPanel } from './RoomSidebar.svelte';
+  import RoomSidebar from './RoomSidebar.svelte';
   import RoomSidebarToggle from './RoomSidebarToggle.svelte';
+  import { RoomSidebarPanelsState } from './roomSidebarPanels.svelte';
   import ThreadPane from './ThreadPane.svelte';
 
   let { roomId, threadId }: { roomId: string; threadId?: string } = $props();
@@ -279,52 +279,12 @@
   let showVoiceCall = $derived(!!room.roomData && !!serverInfo.livekitUrl);
   // Channel rooms can always be left. DMs are permanent (no leave action).
   let showLeaveRoom = $derived(!!room.roomData && !room.isDM);
-  let selectedRoomSidebarPanel = $state<RoomSidebarPanel>('members');
-  let selectedRoomSidebarScope = $state<string | null>(null);
-  let roomSidebarHidden = $state(false);
-  let mobileRoomSidebarOpen = $state(false);
-
-  const currentRoomSidebarScope = $derived(`${getActiveServer()}:${roomId}`);
-  const selectedRoomSidebarPanelForRoom = $derived.by(() => {
-    if (selectedRoomSidebarScope === currentRoomSidebarScope) {
-      return selectedRoomSidebarPanel;
-    }
-
-    return getRoomSidebarPanel(getActiveServer(), roomId);
-  });
-  const activeRoomSidebarPanel = $derived(
-    roomSidebarHidden ? null : selectedRoomSidebarPanelForRoom
+  const roomSidebarPanels = new RoomSidebarPanelsState(
+    () => getActiveServer(),
+    () => roomId
   );
-  const mobileRoomSidebarPanel = $derived(
-    mobileRoomSidebarOpen ? selectedRoomSidebarPanelForRoom : null
-  );
-
-  function selectRoomSidebarPanel(panel: RoomSidebarPanel) {
-    const serverId = getActiveServer();
-    setRoomSidebarPanel(serverId, roomId, panel);
-    selectedRoomSidebarScope = `${serverId}:${roomId}`;
-    selectedRoomSidebarPanel = panel;
-  }
-
-  function toggleRoomSidebarPanel(panel: RoomSidebarPanel) {
-    if (activeRoomSidebarPanel === panel) {
-      roomSidebarHidden = true;
-      return;
-    }
-
-    selectRoomSidebarPanel(panel);
-    roomSidebarHidden = false;
-  }
-
-  function toggleMobileRoomSidebarPanel(panel: RoomSidebarPanel) {
-    if (mobileRoomSidebarPanel === panel) {
-      mobileRoomSidebarOpen = false;
-      return;
-    }
-
-    selectRoomSidebarPanel(panel);
-    mobileRoomSidebarOpen = true;
-  }
+  const activeRoomSidebarPanel = $derived(roomSidebarPanels.activeDesktopPanel);
+  const mobileRoomSidebarPanel = $derived(roomSidebarPanels.mobilePanel);
 
   let leavingRoom = $state(false);
 
@@ -355,7 +315,7 @@
   onkeydown={(e) => {
     if (e.key === 'Escape' && mobileRoomSidebarPanel && !e.defaultPrevented) {
       e.preventDefault();
-      mobileRoomSidebarOpen = false;
+      roomSidebarPanels.closeMobile();
       return;
     }
 
@@ -374,7 +334,7 @@
       ) {
         return;
       }
-      mobileRoomSidebarOpen = false;
+      roomSidebarPanels.closeMobile();
       return;
     }
 
@@ -425,12 +385,12 @@
               <RoomSidebarToggle
                 mode="mobile"
                 activePanel={mobileRoomSidebarPanel}
-                onToggle={toggleMobileRoomSidebarPanel}
+                onToggle={(panel) => roomSidebarPanels.toggleMobilePanel(panel)}
               />
               <RoomSidebarToggle
                 mode="desktop"
                 activePanel={activeRoomSidebarPanel}
-                onToggle={toggleRoomSidebarPanel}
+                onToggle={(panel) => roomSidebarPanels.toggleDesktopPanel(panel)}
               />
             {/if}
             {#if showVoiceCall}
@@ -503,7 +463,7 @@
           type="button"
           class="absolute inset-0 z-10 bg-transparent lg:hidden"
           aria-label="Close room extras"
-          onclick={() => (mobileRoomSidebarOpen = false)}
+          onclick={() => roomSidebarPanels.closeMobile()}
         ></button>
         <div
           class="absolute inset-y-0 right-0 z-20 flex min-h-0 w-full min-w-0 flex-col overflow-hidden border-l border-border bg-background shadow-[-4px_0_12px_rgba(0,0,0,0.15)] sm:w-[90%] lg:hidden"
@@ -518,7 +478,7 @@
             canBanRoomMembers={room.roomData?.canBanRoomMembers ?? false}
             currentUserId={currentUser.user?.id ?? null}
             onLoadMoreMembers={roomMembers.loadMoreMembers}
-            onClose={() => (mobileRoomSidebarOpen = false)}
+            onClose={() => roomSidebarPanels.closeMobile()}
           />
         </div>
       {/if}
@@ -533,7 +493,7 @@
           canBanRoomMembers={room.roomData?.canBanRoomMembers ?? false}
           currentUserId={currentUser.user?.id ?? null}
           onLoadMoreMembers={roomMembers.loadMoreMembers}
-          onClose={() => (roomSidebarHidden = true)}
+          onClose={() => roomSidebarPanels.closeDesktop()}
         />
       </div>
     {/if}

--- a/frontend/src/routes/chat/[serverId]/[roomId]/roomSidebarPanels.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/roomSidebarPanels.svelte.spec.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  getRoomSidebarPanelState,
+  setRoomSidebarPanelState
+} from '$lib/storage/roomSidebarPanel';
+import { RoomSidebarPanelsState } from './roomSidebarPanels.svelte';
+
+describe('RoomSidebarPanelsState', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('persists desktop panel changes and closes per room', () => {
+    const sidebar = new RoomSidebarPanelsState(() => 'server-a', () => 'room-1');
+
+    sidebar.toggleDesktopPanel('files');
+
+    expect(sidebar.activeDesktopPanel).toBe('files');
+    expect(getRoomSidebarPanelState('server-a', 'room-1')).toBe('files');
+
+    sidebar.toggleDesktopPanel('files');
+
+    expect(sidebar.activeDesktopPanel).toBeNull();
+    expect(getRoomSidebarPanelState('server-a', 'room-1')).toBeNull();
+  });
+
+  it('does not let mobile overlay selection overwrite a persisted desktop close', () => {
+    setRoomSidebarPanelState('server-a', 'room-1', null);
+    const sidebar = new RoomSidebarPanelsState(() => 'server-a', () => 'room-1');
+
+    expect(sidebar.activeDesktopPanel).toBeNull();
+
+    sidebar.toggleMobilePanel('files');
+
+    expect(sidebar.mobilePanel).toBe('files');
+    expect(sidebar.activeDesktopPanel).toBeNull();
+    expect(getRoomSidebarPanelState('server-a', 'room-1')).toBeNull();
+  });
+
+  it('does not let mobile overlay selection overwrite a persisted desktop panel', () => {
+    setRoomSidebarPanelState('server-a', 'room-1', 'files');
+    const sidebar = new RoomSidebarPanelsState(() => 'server-a', () => 'room-1');
+
+    sidebar.toggleMobilePanel('members');
+
+    expect(sidebar.mobilePanel).toBe('members');
+    expect(sidebar.activeDesktopPanel).toBe('files');
+    expect(getRoomSidebarPanelState('server-a', 'room-1')).toBe('files');
+  });
+
+  it('treats mobile overlay state as closed after the room changes', () => {
+    let roomId = 'room-1';
+    const sidebar = new RoomSidebarPanelsState(() => 'server-a', () => roomId);
+
+    sidebar.toggleMobilePanel('files');
+    expect(sidebar.mobilePanel).toBe('files');
+
+    roomId = 'room-2';
+    expect(sidebar.mobilePanel).toBeNull();
+  });
+});

--- a/frontend/src/routes/chat/[serverId]/[roomId]/roomSidebarPanels.svelte.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/roomSidebarPanels.svelte.ts
@@ -1,0 +1,81 @@
+import {
+  getRoomSidebarPanelState,
+  ROOM_SIDEBAR_DEFAULT_PANEL,
+  setRoomSidebarPanelState,
+  type RoomSidebarPanel,
+  type RoomSidebarPanelState
+} from '$lib/storage/roomSidebarPanel';
+
+export class RoomSidebarPanelsState {
+  #getServerId: () => string;
+  #getRoomId: () => string;
+  #desktopState = $state<RoomSidebarPanelState>(ROOM_SIDEBAR_DEFAULT_PANEL);
+  #desktopScope = $state<string | null>(null);
+  #mobilePanel = $state<RoomSidebarPanelState>(null);
+  #mobileScope = $state<string | null>(null);
+
+  constructor(getServerId: () => string, getRoomId: () => string) {
+    this.#getServerId = getServerId;
+    this.#getRoomId = getRoomId;
+  }
+
+  get selectedPanelForRoom(): RoomSidebarPanel {
+    return this.#desktopStateForRoom ?? ROOM_SIDEBAR_DEFAULT_PANEL;
+  }
+
+  get activeDesktopPanel(): RoomSidebarPanelState {
+    return this.#desktopStateForRoom;
+  }
+
+  get mobilePanel(): RoomSidebarPanelState {
+    if (this.#mobileScope !== this.#currentScope) return null;
+    return this.#mobilePanel;
+  }
+
+  toggleDesktopPanel(panel: RoomSidebarPanel): void {
+    if (this.activeDesktopPanel === panel) {
+      this.closeDesktop();
+      return;
+    }
+
+    this.#setDesktopState(panel);
+  }
+
+  closeDesktop(): void {
+    this.#setDesktopState(null);
+  }
+
+  toggleMobilePanel(panel: RoomSidebarPanel): void {
+    if (this.mobilePanel === panel) {
+      this.closeMobile();
+      return;
+    }
+
+    this.#mobileScope = this.#currentScope;
+    this.#mobilePanel = panel;
+  }
+
+  closeMobile(): void {
+    this.#mobilePanel = null;
+  }
+
+  get #currentScope(): string {
+    return `${this.#getServerId()}:${this.#getRoomId()}`;
+  }
+
+  get #desktopStateForRoom(): RoomSidebarPanelState {
+    if (this.#desktopScope === this.#currentScope) {
+      return this.#desktopState;
+    }
+
+    return getRoomSidebarPanelState(this.#getServerId(), this.#getRoomId());
+  }
+
+  #setDesktopState(state: RoomSidebarPanelState): void {
+    const serverId = this.#getServerId();
+    const roomId = this.#getRoomId();
+    setRoomSidebarPanelState(serverId, roomId, state);
+    this.#desktopScope = `${serverId}:${roomId}`;
+    this.#desktopState = state;
+  }
+}


### PR DESCRIPTION
## Summary

- Persist the desktop room extras sidebar as `members`, `files`, or closed per room while keeping mobile room extras overlay state transient.
- Persist the main desktop left sidebar open/closed preference without allowing mobile overlay open/close behavior to overwrite it.
- Add focused storage and Svelte state tests for both sidebar persistence paths.

## Verification

- `mise x -- pnpm test:unit --run --project server src/lib/storage/roomSidebarPanel.spec.ts src/lib/storage/mainSidebarOpen.spec.ts`
- `mise x -- pnpm test:unit --run --project client src/lib/state/globals.svelte.spec.ts 'src/routes/chat/[serverId]/[roomId]/RoomSidebarToggle.svelte.spec.ts' 'src/routes/chat/[serverId]/[roomId]/roomSidebarPanels.svelte.spec.ts'`
- `mise x -- pnpm check`
- `mise x -- pnpm lint`
