### PR TITLE
fix: ignore markdown code mentions and previews

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/vikstrous/dataloadgen v0.0.10
 	github.com/wneessen/go-mail v0.7.3
 	github.com/xhit/go-str2duration/v2 v2.1.0
+	github.com/yuin/goldmark v1.8.2
 	golang.org/x/crypto v0.52.0
 	golang.org/x/image v0.41.0
 	golang.org/x/oauth2 v0.36.0

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -446,6 +446,8 @@ github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtX
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
+github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=

--- a/cli/internal/core/linkpreview/extract.go
+++ b/cli/internal/core/linkpreview/extract.go
@@ -4,11 +4,44 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	textm "github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
 )
 
 // urlRegex matches HTTP/HTTPS URLs in text.
 // This is a simplified regex that captures most common URL patterns.
 var urlRegex = regexp.MustCompile(`https?://[^\s<>"'` + "`" + `\[\]{}|\\^]+`)
+
+var urlMarkdown = goldmark.New(
+	goldmark.WithParser(parser.NewParser(
+		parser.WithBlockParsers(
+			util.Prioritized(parser.NewSetextHeadingParser(), 100),
+			util.Prioritized(parser.NewThematicBreakParser(), 200),
+			util.Prioritized(parser.NewListParser(), 300),
+			util.Prioritized(parser.NewListItemParser(), 400),
+			util.Prioritized(parser.NewCodeBlockParser(), 500),
+			util.Prioritized(parser.NewATXHeadingParser(), 600),
+			util.Prioritized(parser.NewFencedCodeBlockParser(), 700),
+			util.Prioritized(parser.NewBlockquoteParser(), 800),
+			util.Prioritized(parser.NewParagraphParser(), 1000),
+		),
+		parser.WithInlineParsers(
+			util.Prioritized(parser.NewCodeSpanParser(), 100),
+			util.Prioritized(parser.NewLinkParser(), 200),
+			util.Prioritized(parser.NewAutoLinkParser(), 300),
+		),
+		parser.WithParagraphTransformers(parser.DefaultParagraphTransformers()...),
+	)),
+)
+
+func urlMarkdownSource(text string) string {
+	// Match the Chatto renderer's disabled backslash escapes for code spans.
+	return strings.ReplaceAll(text, "\\`", "`")
+}
 
 // ExtractURLs extracts unique HTTP/HTTPS URLs from text.
 // Returns at most maxURLs URLs, in the order they appear.
@@ -16,44 +49,105 @@ func ExtractURLs(text string, maxURLs int) []string {
 	if maxURLs <= 0 {
 		return nil
 	}
-
-	matches := urlRegex.FindAllString(text, -1)
-	if len(matches) == 0 {
+	if !strings.Contains(text, "http://") && !strings.Contains(text, "https://") {
 		return nil
 	}
 
 	seen := make(map[string]bool)
 	var result []string
 
-	for _, match := range matches {
-		// Clean up trailing punctuation that might have been captured
-		match = strings.TrimRight(match, ".,;:!?)")
-
+	add := func(raw string) {
+		if len(result) >= maxURLs {
+			return
+		}
+		match := cleanURLMatch(raw)
+		if match == "" {
+			return
+		}
 		// Validate the URL
 		u, err := url.Parse(match)
 		if err != nil {
-			continue
+			return
 		}
 
 		// Only allow http/https schemes
 		if u.Scheme != "http" && u.Scheme != "https" {
-			continue
+			return
 		}
 
 		// Skip if we've already seen this URL
 		normalized := normalizeURL(u)
 		if seen[normalized] {
-			continue
+			return
 		}
 		seen[normalized] = true
 
 		result = append(result, match)
-		if len(result) >= maxURLs {
-			break
+	}
+
+	source := []byte(urlMarkdownSource(text))
+	root := urlMarkdown.Parser().Parse(textm.NewReader(source))
+	_ = ast.Walk(root, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering || len(result) >= maxURLs {
+			return ast.WalkContinue, nil
 		}
+
+		switch node.Kind() {
+		case ast.KindCodeSpan, ast.KindCodeBlock, ast.KindFencedCodeBlock, ast.KindBlockquote:
+			return ast.WalkSkipChildren, nil
+		case ast.KindLink:
+			add(string(node.(*ast.Link).Destination))
+			return ast.WalkSkipChildren, nil
+		case ast.KindAutoLink:
+			autoLink := node.(*ast.AutoLink)
+			if autoLink.AutoLinkType == ast.AutoLinkURL {
+				add(string(autoLink.URL(source)))
+			}
+			return ast.WalkSkipChildren, nil
+		case ast.KindText:
+			textNode := node.(*ast.Text)
+			for _, match := range urlRegex.FindAllString(string(textNode.Segment.Value(source)), -1) {
+				add(match)
+			}
+		case ast.KindString:
+			for _, match := range urlRegex.FindAllString(string(node.(*ast.String).Value), -1) {
+				add(match)
+			}
+		}
+
+		return ast.WalkContinue, nil
+	})
+
+	if len(result) == 0 {
+		return nil
 	}
 
 	return result
+}
+
+func cleanURLMatch(match string) string {
+	for {
+		cleaned := strings.TrimRight(match, ".,;:!?")
+		if cleaned != match {
+			match = cleaned
+			continue
+		}
+		if strings.HasSuffix(match, ")") && countByte(match, ')') > countByte(match, '(') {
+			match = strings.TrimSuffix(match, ")")
+			continue
+		}
+		return match
+	}
+}
+
+func countByte(value string, target byte) int {
+	count := 0
+	for i := range len(value) {
+		if value[i] == target {
+			count++
+		}
+	}
+	return count
 }
 
 // normalizeURL normalizes a URL for deduplication and caching.
@@ -97,6 +191,9 @@ var youtubePathRegex = regexp.MustCompile(
 func ParseYouTubeVideoID(rawURL string) string {
 	u, err := url.Parse(rawURL)
 	if err != nil {
+		return ""
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
 		return ""
 	}
 

--- a/cli/internal/core/linkpreview/extract_test.go
+++ b/cli/internal/core/linkpreview/extract_test.go
@@ -19,8 +19,26 @@ func TestExtractURLs(t *testing.T) {
 		{"respects maxURLs", "see https://a.com and https://b.com", 1, []string{"https://a.com"}},
 		{"deduplicates", "see https://example.com and https://example.com again", 5, []string{"https://example.com"}},
 		{"strips trailing punctuation", "visit https://example.com.", 5, []string{"https://example.com"}},
+		{"strips multiple trailing punctuation marks", "visit https://example.com/path!!", 5, []string{"https://example.com/path"}},
+		{"strips wrapper closing parenthesis", "visit (https://example.com/path)", 5, []string{"https://example.com/path"}},
+		{"keeps balanced path parentheses", "visit https://example.com/path_(v1)", 5, []string{"https://example.com/path_(v1)"}},
+		{"keeps query string", "visit https://example.com/path?q=1&sort=desc", 5, []string{"https://example.com/path?q=1&sort=desc"}},
+		{"deduplicates ignoring fragment", "see https://example.com/a#one and https://example.com/a#two", 5, []string{"https://example.com/a#one"}},
+		{"deduplicates lowercased host", "see https://Example.com/a and https://example.com/a", 5, []string{"https://Example.com/a"}},
 		{"http scheme", "visit http://example.com", 5, []string{"http://example.com"}},
 		{"zero maxURLs", "https://example.com", 0, nil},
+		{"negative maxURLs", "https://example.com", -1, nil},
+		{"ignores ftp scheme", "visit ftp://example.com", 5, nil},
+		{"ignores email addresses", "mail user@example.com", 5, nil},
+		{"ignores inline code URLs", "run `curl https://example.com` first", 5, nil},
+		{"ignores escaped-backtick inline code URLs", "run \\`curl https://example.com\\` first", 5, nil},
+		{"detects URL immediately after inline code", "`curl`https://example.com", 5, []string{"https://example.com"}},
+		{"ignores fenced code URLs", "```\nhttps://example.com\n```\nhttps://outside.example", 5, []string{"https://outside.example"}},
+		{"ignores indented code URLs", "    https://example.com\nhttps://outside.example", 5, []string{"https://outside.example"}},
+		{"ignores blockquote URLs", "> https://quoted.example\n\nhttps://outside.example", 5, []string{"https://outside.example"}},
+		{"detects explicit markdown link destination", "read [the docs](https://example.com/docs)", 5, []string{"https://example.com/docs"}},
+		{"detects angle autolink", "read <https://example.com/docs>", 5, []string{"https://example.com/docs"}},
+		{"preserves order around excluded markdown regions", "https://a.example `https://skip.example` https://b.example\n> https://quote.example\n\nhttps://c.example", 5, []string{"https://a.example", "https://b.example", "https://c.example"}},
 	}
 
 	for _, tt := range tests {
@@ -46,6 +64,8 @@ func TestParseYouTubeVideoID(t *testing.T) {
 		{"v/ URL", "https://www.youtube.com/v/dQw4w9WgXcQ", "dQw4w9WgXcQ"},
 		{"mobile URL", "https://m.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"},
 		{"no www", "https://youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		{"watch URL with trailing params", "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=42", "dQw4w9WgXcQ"},
+		{"short URL with query", "https://youtu.be/dQw4w9WgXcQ?t=42", "dQw4w9WgXcQ"},
 
 		// Non-YouTube URLs that should NOT match (hostname-anchored)
 		{"not youtube domain", "https://notyoutube.com/watch?v=dQw4w9WgXcQ", ""},
@@ -57,7 +77,9 @@ func TestParseYouTubeVideoID(t *testing.T) {
 		{"empty string", "", ""},
 		{"not a URL", "not-a-url", ""},
 		{"wrong ID length", "https://youtu.be/short", ""},
+		{"short URL with extra path segment", "https://youtu.be/dQw4w9WgXcQ/extra", ""},
 		{"no video ID", "https://www.youtube.com/watch", ""},
+		{"non-http youtube URL", "ftp://www.youtube.com/watch?v=dQw4w9WgXcQ", ""},
 	}
 
 	for _, tt := range tests {

--- a/cli/internal/core/mentions.go
+++ b/cli/internal/core/mentions.go
@@ -3,9 +3,13 @@ package core
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
 	"hmans.de/chatto/internal/core/subjects"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
@@ -69,33 +73,145 @@ func (c *ChattoCore) requireRoleMentionHandleAvailable(roleName string) error {
 	return ErrRoleAlreadyExists
 }
 
-// mentionRegex matches @username patterns in message text.
-// Usernames can contain alphanumeric characters, underscores, hyphens, and dots.
-// Dots are only allowed as internal separators (not trailing) to avoid capturing
-// sentence punctuation like "Thanks @user." → captures "user" not "user."
-// The @ must be preceded by whitespace or start of string to avoid matching emails.
-// The pattern is case-insensitive for extraction, but lookup is also case-insensitive.
-var mentionRegex = regexp.MustCompile(`(?:^|[^a-zA-Z0-9])@([a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)*)`)
+var mentionNodeKind = ast.NewNodeKind("Mention")
+
+type mentionNode struct {
+	ast.BaseInline
+	Username string
+}
+
+func (n *mentionNode) Kind() ast.NodeKind {
+	return mentionNodeKind
+}
+
+func (n *mentionNode) Dump(source []byte, level int) {
+	ast.DumpHelper(n, source, level, map[string]string{
+		"Username": n.Username,
+	}, nil)
+}
+
+type mentionInlineParser struct{}
+
+func (p mentionInlineParser) Trigger() []byte {
+	return []byte{'@'}
+}
+
+func (p mentionInlineParser) Parse(parent ast.Node, block text.Reader, pc parser.Context) ast.Node {
+	line, segment := block.PeekLine()
+	if len(line) < 2 || line[0] != '@' {
+		return nil
+	}
+
+	source := block.Source()
+	if segment.Start > 0 && isMentionAlphanumeric(source[segment.Start-1]) {
+		return nil
+	}
+
+	stop := 1
+	for stop < len(line) && isMentionHandleChar(line[stop]) {
+		stop++
+	}
+	if stop == 1 {
+		return nil
+	}
+	for stop < len(line) && line[stop] == '.' {
+		next := stop + 1
+		if next >= len(line) || !isMentionHandleChar(line[next]) {
+			break
+		}
+		stop = next + 1
+		for stop < len(line) && isMentionHandleChar(line[stop]) {
+			stop++
+		}
+	}
+
+	username := string(line[1:stop])
+	block.Advance(stop)
+	return &mentionNode{Username: username}
+}
+
+func isMentionAlphanumeric(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}
+
+func isMentionHandleChar(c byte) bool {
+	return isMentionAlphanumeric(c) || c == '_' || c == '-'
+}
+
+var mentionMarkdown = goldmark.New(
+	goldmark.WithParser(parser.NewParser(
+		parser.WithBlockParsers(
+			util.Prioritized(parser.NewSetextHeadingParser(), 100),
+			util.Prioritized(parser.NewThematicBreakParser(), 200),
+			util.Prioritized(parser.NewListParser(), 300),
+			util.Prioritized(parser.NewListItemParser(), 400),
+			util.Prioritized(parser.NewCodeBlockParser(), 500),
+			util.Prioritized(parser.NewATXHeadingParser(), 600),
+			util.Prioritized(parser.NewFencedCodeBlockParser(), 700),
+			util.Prioritized(parser.NewBlockquoteParser(), 800),
+			util.Prioritized(parser.NewParagraphParser(), 1000),
+		),
+		parser.WithInlineParsers(
+			util.Prioritized(parser.NewCodeSpanParser(), 100),
+			util.Prioritized(parser.NewLinkParser(), 200),
+			util.Prioritized(parser.NewAutoLinkParser(), 300),
+			util.Prioritized(mentionInlineParser{}, 400),
+			util.Prioritized(parser.NewEmphasisParser(), 500),
+		),
+		parser.WithParagraphTransformers(parser.DefaultParagraphTransformers()...),
+	)),
+)
+
+func mentionMarkdownSource(body string) string {
+	// Chatto's message renderer disables Markdown backslash escapes, so
+	// \` still participates in code-span parsing and \@alice still contains
+	// a visible mention boundary. Goldmark's inline loop hardcodes backslash
+	// escaping, so normalize just those cases for mention extraction.
+	body = strings.ReplaceAll(body, "\\`", "`")
+	return strings.ReplaceAll(body, "\\@", "\\\\@")
+}
 
 // ExtractMentionUsernames extracts all unique @username mentions from a message body.
 // Returns a slice of usernames (without the @ prefix) in the order they appear.
-// Duplicate mentions are deduplicated.
+// Duplicate mentions are deduplicated. Mentions inside Markdown code spans,
+// code blocks, and blockquotes are ignored.
 func ExtractMentionUsernames(body string) []string {
-	matches := mentionRegex.FindAllStringSubmatch(body, -1)
-	if len(matches) == 0 {
+	if !strings.Contains(body, "@") {
 		return nil
 	}
 
 	// Deduplicate while preserving order
 	seen := make(map[string]bool)
 	var usernames []string
-	for _, match := range matches {
-		username := match[1]
-		if !seen[username] {
-			seen[username] = true
-			usernames = append(usernames, username)
+
+	add := func(username string) {
+		if username == "" {
+			return
 		}
+		if seen[username] {
+			return
+		}
+		seen[username] = true
+		usernames = append(usernames, username)
 	}
+
+	source := []byte(mentionMarkdownSource(body))
+	root := mentionMarkdown.Parser().Parse(text.NewReader(source))
+	_ = ast.Walk(root, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+
+		switch node.Kind() {
+		case ast.KindCodeBlock, ast.KindFencedCodeBlock, ast.KindBlockquote:
+			return ast.WalkSkipChildren, nil
+		case mentionNodeKind:
+			add(node.(*mentionNode).Username)
+		}
+
+		return ast.WalkContinue, nil
+	})
+
 	return usernames
 }
 

--- a/cli/internal/core/mentions_test.go
+++ b/cli/internal/core/mentions_test.go
@@ -137,6 +137,86 @@ func TestExtractMentionUsernames(t *testing.T) {
 			body:     "Line one\n@alice line two",
 			expected: []string{"alice"},
 		},
+		{
+			name:     "mention does not cross emphasis boundary",
+			body:     "@al*ice*",
+			expected: []string{"al"},
+		},
+		{
+			name:     "mention does not start across emphasis boundary",
+			body:     "@*alice*",
+			expected: nil,
+		},
+		{
+			name:     "underscore in mention handle survives adjacent text nodes",
+			body:     "@user_name",
+			expected: []string{"user_name"},
+		},
+		{
+			name:     "inline code mention ignored",
+			body:     "`@alice` @bob",
+			expected: []string{"bob"},
+		},
+		{
+			name:     "escaped backticks still form inline code",
+			body:     "\\`@alice\\` @bob",
+			expected: []string{"bob"},
+		},
+		{
+			name:     "mention immediately after inline code at start",
+			body:     "`cmd`@alice",
+			expected: []string{"alice"},
+		},
+		{
+			name:     "mention immediately after escaped-backtick inline code",
+			body:     "\\`cmd\\`@alice",
+			expected: []string{"alice"},
+		},
+		{
+			name:     "mention immediately after inline code after prior text",
+			body:     "see`cmd`@alice",
+			expected: []string{"alice"},
+		},
+		{
+			name:     "mention immediately after inline code after prior whitespace",
+			body:     "see `cmd`@alice",
+			expected: []string{"alice"},
+		},
+		{
+			name:     "fenced code mention ignored",
+			body:     "```\n@all\n```\n@bob",
+			expected: []string{"bob"},
+		},
+		{
+			name:     "indented code mention ignored",
+			body:     "    @alice\n@bob",
+			expected: []string{"bob"},
+		},
+		{
+			name:     "blockquote mention ignored",
+			body:     "> @alice said hi\n\n@bob replied",
+			expected: []string{"bob"},
+		},
+		{
+			name:     "outside mentions around excluded regions preserve order",
+			body:     "@alice `@bob` @charlie\n> @dora\n```\n@erin\n```\n@frank",
+			expected: []string{"alice", "charlie", "frank"},
+		},
+		{
+			name:     "unmatched backtick does not suppress mention",
+			body:     "` @alice",
+			expected: []string{"alice"},
+		},
+		{
+			name:     "literal html code tag is plain markdown text",
+			body:     "<code>@alice</code>",
+			expected: []string{"alice"},
+		},
+		{
+			name:     "backslash before mention remains mention boundary",
+			body:     "\\@alice",
+			expected: []string{"alice"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -429,6 +509,10 @@ func TestChattoCore_LargeMentionConfirmation(t *testing.T) {
 		}
 	}
 
+	if _, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "```\n@all\n```", nil, "", "", nil, false); err != nil {
+		t.Fatalf("PostMessage with @all inside fenced code block: %v", err)
+	}
+
 	if _, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "@all confirmed", nil, "", "", nil, false, WithLargeMentionConfirmed()); err != nil {
 		t.Fatalf("PostMessage with confirmation: %v", err)
 	}
@@ -467,5 +551,133 @@ func TestChattoCore_MentionCreatesNotificationWithoutMentionStatus(t *testing.T)
 	}
 	if len(notifications) != 1 || notifications[0].GetMention() == nil {
 		t.Fatalf("expected one mention notification, got %#v", notifications)
+	}
+}
+
+func TestChattoCore_MentionInsideMarkdownCodeDoesNotNotify(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	mentioned, err := core.CreateUser(ctx, "system", "code-mentioned", "Code Mentioned", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser mentioned: %v", err)
+	}
+	mentioner, err := core.CreateUser(ctx, "system", "code-mentionauthor", "Code Mention Author", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser mentioner: %v", err)
+	}
+	room, err := core.CreateRoom(ctx, mentioned.Id, KindChannel, "", "code-mentions", "Code Mentions")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, mentioner.Id, KindChannel, mentioner.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom mentioner: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, mentioned.Id, KindChannel, mentioned.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom mentioned: %v", err)
+	}
+
+	for _, body := range []string{"`@code-mentioned`", "\\`@code-mentioned\\`"} {
+		t.Run(body, func(t *testing.T) {
+			event, err := core.PostMessage(ctx, KindChannel, room.Id, mentioner.Id, body, nil, "", "", nil, false)
+			if err != nil {
+				t.Fatalf("PostMessage: %v", err)
+			}
+			if got := event.GetMessagePosted().GetMentionedUserIds(); len(got) != 0 {
+				t.Fatalf("mentioned_user_ids = %v, want none", got)
+			}
+
+			notifications, err := core.GetNotifications(ctx, mentioned.Id)
+			if err != nil {
+				t.Fatalf("GetNotifications: %v", err)
+			}
+			if len(notifications) != 0 {
+				t.Fatalf("expected no mention notification, got %#v", notifications)
+			}
+		})
+	}
+}
+
+func TestChattoCore_MentionImmediatelyAfterMarkdownCodeNotifies(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	mentioned, err := core.CreateUser(ctx, "system", "post-code-mentioned", "Post Code Mentioned", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser mentioned: %v", err)
+	}
+	mentioner, err := core.CreateUser(ctx, "system", "post-code-author", "Post Code Author", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser mentioner: %v", err)
+	}
+	room, err := core.CreateRoom(ctx, mentioned.Id, KindChannel, "", "post-code-mentions", "Post Code Mentions")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, mentioner.Id, KindChannel, mentioner.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom mentioner: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, mentioned.Id, KindChannel, mentioned.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom mentioned: %v", err)
+	}
+
+	event, err := core.PostMessage(ctx, KindChannel, room.Id, mentioner.Id, "`cmd`@post-code-mentioned", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage: %v", err)
+	}
+	requireUserIDs(t, event.GetMessagePosted().GetMentionedUserIds(), mentioned.Id)
+
+	notifications, err := core.GetNotifications(ctx, mentioned.Id)
+	if err != nil {
+		t.Fatalf("GetNotifications: %v", err)
+	}
+	if len(notifications) != 1 || notifications[0].GetMention() == nil {
+		t.Fatalf("expected one mention notification, got %#v", notifications)
+	}
+}
+
+func TestChattoCore_MentionSplitByMarkdownFormattingDoesNotNotify(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	alice, err := core.CreateUser(ctx, "system", "format-alice", "Format Alice", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser alice: %v", err)
+	}
+	author, err := core.CreateUser(ctx, "system", "format-author", "Format Author", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser author: %v", err)
+	}
+	room, err := core.CreateRoom(ctx, alice.Id, KindChannel, "", "format-mentions", "Format Mentions")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, author.Id, KindChannel, author.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom author: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, alice.Id, KindChannel, alice.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom alice: %v", err)
+	}
+
+	for _, body := range []string{"@format-al*ice*", "@*format-alice*"} {
+		t.Run(body, func(t *testing.T) {
+			event, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, body, nil, "", "", nil, false)
+			if err != nil {
+				t.Fatalf("PostMessage: %v", err)
+			}
+			for _, mentionedUserID := range event.GetMessagePosted().GetMentionedUserIds() {
+				if mentionedUserID == alice.Id {
+					t.Fatalf("mentioned_user_ids includes formatted handle target %s", alice.Id)
+				}
+			}
+
+			notifications, err := core.GetNotifications(ctx, alice.Id)
+			if err != nil {
+				t.Fatalf("GetNotifications: %v", err)
+			}
+			if len(notifications) != 0 {
+				t.Fatalf("expected no mention notification, got %#v", notifications)
+			}
+		})
 	}
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -812,8 +812,8 @@ Messages are persisted as durable `EVT` facts. Public timeline facts (`MessagePo
 
 **@Mentions:**
 
-- `@username` patterns in message body are extracted via regex (ASCII alphanumeric, underscore, hyphen)
-- Usernames are resolved to user IDs; only server members are included (non-members silently ignored)
+- `@username` patterns in message body are parsed as Markdown inline mention tokens (ASCII alphanumeric, underscore, hyphen, dot), excluding code spans, code blocks, and blockquotes.
+- Mention handles are resolved in the posting room; direct user handles only notify current room members, and invalid/non-member handles are silently ignored.
 - `MessagePostedEvent.mentioned_user_ids` contains resolved user IDs
 - Mention resolution is post-time only; later `MessageEditedEvent` facts update body content but do not add, remove, dismiss, or re-send mention notifications
 - Pending mention state is a notification record in `RUNTIME_STATE` (`notification.{userId}.{notificationId}`); sidebar orange dots derive from pending notifications, not a separate mention flag.

--- a/docs/fdr/FDR-006-mentions.md
+++ b/docs/fdr/FDR-006-mentions.md
@@ -1,7 +1,7 @@
 # FDR-006: @Mentions
 
 **Status:** Active
-**Last reviewed:** 2026-06-13
+**Last reviewed:** 2026-06-15
 
 ## Overview
 
@@ -20,7 +20,7 @@ Users can mention users, roles, and room-scoped virtual groups with `@handle` sy
 - `@here` mentions current room members whose presence is not offline.
 - `@everyone` is not a message mention handle. Use `@all` for room-wide delivery; `everyone` remains the implicit RBAC role.
 - Valid user, role, and virtual mentions render with highlight styling in the posted message. Self-mentions get additional styling.
-- Mentions inside code blocks, pre-formatted text, and blockquotes are not styled — they render as plain text.
+- Mentions inside code spans, code blocks, pre-formatted text, and blockquotes do not resolve, notify, or receive mention styling.
 - Mentioning yourself does not produce a notification.
 - Mentioning a user who isn't a room member leaves the `@name` as plain text — the mention is not delivered.
 - If a message would notify more than 10 users, the composer asks for confirmation before sending. The backend enforces the same guard for API callers.

--- a/docs/fdr/FDR-009-link-previews.md
+++ b/docs/fdr/FDR-009-link-previews.md
@@ -1,7 +1,7 @@
 # FDR-009: Link Previews
 
 **Status:** Active
-**Last reviewed:** 2026-06-06
+**Last reviewed:** 2026-06-15
 
 ## Overview
 
@@ -11,6 +11,7 @@ When a message contains a URL, Chatto can attach a preview card with the page's 
 
 - The composer fetches a link preview as soon as the user has typed a complete URL.
 - Only the first URL in a message gets a preview. There is no multi-preview layout.
+- URLs inside code spans, code blocks, pre-formatted text, and blockquotes do not trigger link previews.
 - YouTube URLs get a specialized embed-ready card without scraping the page.
 - A preview shows up in the composer with a dismiss button. Dismissing the preview prevents it from being attached to the sent message, and the dismissal is remembered for that URL during the composition session.
 - When the message is sent, the preview data ships with it and is stored as part of the message body.

--- a/frontend/src/lib/components/MessageContent.svelte.spec.ts
+++ b/frontend/src/lib/components/MessageContent.svelte.spec.ts
@@ -301,6 +301,25 @@ describe('MessageContent component', () => {
       expect(q(container, 'span.mention')).toBeNull();
     });
 
+    it('does not wrap an @mention inside escaped-backtick inline code', async () => {
+      const { container } = renderMessage('\\`@alice\\`', [member('alice')]);
+      await expect.poll(() => q(container, 'code')).toBeTruthy();
+      expect(q(container, 'span.mention')).toBeNull();
+    });
+
+    it('does not wrap an @mention split by markdown formatting', async () => {
+      const { container } = renderMessage('@*alice*', [member('alice')]);
+      await expect.poll(() => q(container, 'em')).toBeTruthy();
+      expect(q(container, 'span.mention')).toBeNull();
+    });
+
+    it('wraps an @mention immediately after escaped-backtick inline code', async () => {
+      const { container } = renderMessage('\\`cmd\\`@alice', [member('alice')]);
+      await expect.poll(() => q(container, 'span.mention')).toBeTruthy();
+      expect(q(container, 'code')?.textContent).toContain('cmd');
+      expect(q(container, 'span.mention')?.textContent).toBe('@alice');
+    });
+
     it('wraps a known role mention when role handles include the name', async () => {
       const { container } = renderMessage('Hello @admin!', [], ['admin']);
       await expect.poll(() => q(container, 'span.mention-role')).toBeTruthy();

--- a/frontend/src/lib/components/composer/linkPreviews.svelte.spec.ts
+++ b/frontend/src/lib/components/composer/linkPreviews.svelte.spec.ts
@@ -24,6 +24,29 @@ describe('LinkPreviewState', () => {
     expect(query).not.toHaveBeenCalled();
   });
 
+  it('does not fetch previews for ignored markdown URL regions or non-http URLs', async () => {
+    vi.useFakeTimers();
+    const query = vi.fn();
+    const state = new LinkPreviewState(() => clientWithQuery(query));
+
+    for (const message of [
+      '`https://example.com`',
+      '\\`https://example.com\\`',
+      '```\nhttps://example.com\n```',
+      '> https://example.com',
+      'mail user@example.com',
+      'ftp://example.com/file'
+    ]) {
+      const cleanup = state.scheduleDetection(message, false);
+      await vi.advanceTimersByTimeAsync(500);
+      cleanup();
+
+      expect(state.detectedURLs).toEqual([]);
+    }
+
+    expect(query).not.toHaveBeenCalled();
+  });
+
   it('fetches non-message links and converts the active preview into mutation input', async () => {
     vi.useFakeTimers();
     const url = 'https://example.com/story';

--- a/frontend/src/lib/linkPreview.spec.ts
+++ b/frontend/src/lib/linkPreview.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extractURLs } from './linkPreview';
+import { extractURLs, isYouTubeURL, parseYouTubeVideoID } from './linkPreview';
 
 describe('extractURLs', () => {
   describe('protocol URLs', () => {
@@ -14,6 +14,21 @@ describe('extractURLs', () => {
     it('extracts URLs with paths and query strings', () => {
       expect(extractURLs('See https://example.com/path?q=1')).toEqual([
         'https://example.com/path?q=1'
+      ]);
+    });
+
+    it('strips trailing punctuation from protocol URLs', () => {
+      expect(extractURLs('See https://example.com/path!!')).toEqual([
+        'https://example.com/path'
+      ]);
+    });
+
+    it('strips wrapper closing parentheses but keeps balanced URL parentheses', () => {
+      expect(extractURLs('See (https://example.com/path)')).toEqual([
+        'https://example.com/path'
+      ]);
+      expect(extractURLs('See https://example.com/path_(v1)')).toEqual([
+        'https://example.com/path_(v1)'
       ]);
     });
   });
@@ -70,6 +85,17 @@ describe('extractURLs', () => {
       const urls = extractURLs('www.example.com and https://www.example.com', 5);
       expect(urls).toHaveLength(1);
     });
+
+    it('deduplicates case-insensitive hosts and ignores fragments', () => {
+      expect(extractURLs('https://Example.com/a#one https://example.com/a#two', 5)).toEqual([
+        'https://Example.com/a#one'
+      ]);
+    });
+
+    it('returns no URLs when maxURLs is zero or negative', () => {
+      expect(extractURLs('https://example.com', 0)).toEqual([]);
+      expect(extractURLs('https://example.com', -1)).toEqual([]);
+    });
   });
 
   describe('edge cases', () => {
@@ -88,5 +114,87 @@ describe('extractURLs', () => {
     it('handles URL at end of text', () => {
       expect(extractURLs('check out https://example.com')).toEqual(['https://example.com']);
     });
+
+    it('ignores email addresses and non-http URLs', () => {
+      expect(extractURLs('mail user@example.com')).toEqual([]);
+      expect(extractURLs('fetch ftp://example.com/file')).toEqual([]);
+    });
+  });
+
+  describe('markdown boundaries', () => {
+    it('ignores URLs inside inline code', () => {
+      expect(extractURLs('Run `curl https://example.com` first')).toEqual([]);
+    });
+
+    it('ignores URLs inside escaped-backtick inline code', () => {
+      expect(extractURLs('Run \\`curl https://example.com\\` first')).toEqual([]);
+    });
+
+    it('detects URLs immediately after inline code', () => {
+      expect(extractURLs('`curl`https://example.com')).toEqual(['https://example.com']);
+    });
+
+    it('ignores URLs inside fenced and indented code blocks', () => {
+      expect(extractURLs('```\nhttps://example.com\n```\nhttps://outside.example')).toEqual([
+        'https://outside.example'
+      ]);
+      expect(extractURLs('    https://example.com\nhttps://outside.example')).toEqual([
+        'https://outside.example'
+      ]);
+    });
+
+    it('ignores URLs inside blockquotes', () => {
+      expect(extractURLs('> https://quoted.example\n\nhttps://outside.example')).toEqual([
+        'https://outside.example'
+      ]);
+    });
+
+    it('detects explicit markdown link destinations', () => {
+      expect(extractURLs('Read [the docs](https://example.com/docs)')).toEqual([
+        'https://example.com/docs'
+      ]);
+    });
+
+    it('preserves order around excluded markdown regions', () => {
+      expect(
+        extractURLs(
+          'https://a.example `https://skip.example` https://b.example\n> https://quote.example\n\nhttps://c.example',
+          5
+        )
+      ).toEqual(['https://a.example', 'https://b.example', 'https://c.example']);
+    });
+  });
+});
+
+describe('parseYouTubeVideoID', () => {
+  it('extracts valid YouTube video IDs from supported URL forms', () => {
+    expect(parseYouTubeVideoID('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe(
+      'dQw4w9WgXcQ'
+    );
+    expect(parseYouTubeVideoID('https://www.youtube.com/watch?feature=share&v=dQw4w9WgXcQ')).toBe(
+      'dQw4w9WgXcQ'
+    );
+    expect(parseYouTubeVideoID('https://www.youtube.com/embed/dQw4w9WgXcQ')).toBe(
+      'dQw4w9WgXcQ'
+    );
+    expect(parseYouTubeVideoID('https://youtu.be/dQw4w9WgXcQ?t=42')).toBe('dQw4w9WgXcQ');
+    expect(parseYouTubeVideoID('https://m.youtube.com/shorts/dQw4w9WgXcQ')).toBe(
+      'dQw4w9WgXcQ'
+    );
+  });
+
+  it('rejects non-YouTube hosts and invalid video URL forms', () => {
+    expect(parseYouTubeVideoID('https://notyoutube.com/watch?v=dQw4w9WgXcQ')).toBeNull();
+    expect(
+      parseYouTubeVideoID('https://evil.com/redirect?to=youtube.com/watch?v=dQw4w9WgXcQ')
+    ).toBeNull();
+    expect(parseYouTubeVideoID('https://youtu.be/short')).toBeNull();
+    expect(parseYouTubeVideoID('https://youtu.be/dQw4w9WgXcQ/extra')).toBeNull();
+    expect(parseYouTubeVideoID('ftp://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBeNull();
+  });
+
+  it('backs isYouTubeURL with the same parser', () => {
+    expect(isYouTubeURL('https://youtu.be/dQw4w9WgXcQ')).toBe(true);
+    expect(isYouTubeURL('https://example.com/watch?v=dQw4w9WgXcQ')).toBe(false);
   });
 });

--- a/frontend/src/lib/linkPreview.ts
+++ b/frontend/src/lib/linkPreview.ts
@@ -6,11 +6,20 @@
  */
 
 import LinkifyIt from 'linkify-it';
+import MarkdownIt from 'markdown-it';
 import tlds from 'tlds';
 
 /** Shared linkify-it instance configured with the full IANA TLD list. */
 export const linkify = new LinkifyIt();
 linkify.tlds(tlds);
+
+const markdown = new MarkdownIt({
+  html: false,
+  linkify: true,
+  breaks: true
+});
+markdown.linkify.tlds(tlds);
+markdown.disable(['escape']);
 
 /**
  * Extracts unique URLs from text, including bare-domain URLs (e.g. www.hmans.dev).
@@ -18,25 +27,58 @@ linkify.tlds(tlds);
  * Bare-domain URLs are normalized to https://.
  */
 export function extractURLs(text: string, maxURLs = 1): string[] {
-  const matches = linkify.match(text);
-  if (!matches) return [];
+  if (maxURLs <= 0 || !text) return [];
 
   const seen = new Set<string>();
   const result: string[] = [];
 
-  for (const match of matches) {
-    // linkify-it adds http:// to bare domains (schema === '');
-    // upgrade those to https:// since it's the safer default.
-    // Explicit http:// URLs (schema === 'http://') are kept as-is.
-    const url = match.schema === '' ? match.url.replace(/^http:\/\//, 'https://') : match.url;
+  const addURL = (rawUrl: string, rawText = '') => {
+    if (result.length >= maxURLs) return;
+
+    let url = rawUrl;
+    if (
+      rawText &&
+      !/^[a-z][a-z0-9+.-]*:/i.test(rawText) &&
+      /^http:\/\//i.test(url)
+    ) {
+      // linkify-it adds http:// to bare domains; upgrade those to https://.
+      url = url.replace(/^http:\/\//i, 'https://');
+    }
+
+    if (!/^https?:\/\//i.test(url)) return;
+
     const normalized = normalizeURL(url);
 
     if (!seen.has(normalized)) {
       seen.add(normalized);
       result.push(url);
-      if (result.length >= maxURLs) {
-        break;
-      }
+    }
+  };
+
+  let blockquoteDepth = 0;
+  for (const token of markdown.parse(text, {})) {
+    if (token.type === 'blockquote_open') {
+      blockquoteDepth++;
+      continue;
+    }
+    if (token.type === 'blockquote_close') {
+      blockquoteDepth = Math.max(0, blockquoteDepth - 1);
+      continue;
+    }
+    if (blockquoteDepth > 0) continue;
+    if (token.type === 'fence' || token.type === 'code_block') continue;
+    if (token.type !== 'inline') continue;
+
+    const children = token.children ?? [];
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i];
+      if (child.type !== 'link_open') continue;
+
+      const href = child.attrGet('href');
+      if (!href) continue;
+
+      const rawText = child.markup === 'linkify' ? (children[i + 1]?.content ?? '') : '';
+      addURL(href, rawText);
     }
   }
 
@@ -78,6 +120,9 @@ export function parseYouTubeVideoID(rawUrl: string): string | null {
   try {
     parsed = new URL(rawUrl);
   } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
     return null;
   }
 

--- a/frontend/src/lib/mentions.svelte.test.ts
+++ b/frontend/src/lib/mentions.svelte.test.ts
@@ -69,6 +69,12 @@ describe('wrapValidMentions', () => {
       // bob inside code should not be styled
       expect(result).not.toContain('data-user-id="bob"');
     });
+
+    it('styles mentions immediately after inline code', () => {
+      const result = wrapValidMentions('<p><code>cmd</code>@alice</p>', members);
+      expect(result).toContain('<code>cmd</code>');
+      expect(result).toContain('<span class="mention" data-user-id="alice">@alice</span>');
+    });
   });
 
   describe('blockquote exclusion', () => {

--- a/frontend/src/lib/mentions.test.ts
+++ b/frontend/src/lib/mentions.test.ts
@@ -66,6 +66,61 @@ describe('extractMentions', () => {
     // The regex doesn't allow trailing dots
     expect(extractMentions('@alice.')).toEqual(['alice']);
   });
+
+  it('does not extract mentions across emphasis boundaries', () => {
+    expect(extractMentions('@al*ice*')).toEqual(['al']);
+    expect(extractMentions('@*alice*')).toEqual([]);
+  });
+
+  it('ignores mentions inside inline code', () => {
+    expect(extractMentions('`@alice` @bob')).toEqual(['bob']);
+  });
+
+  it('ignores mentions inside escaped-backtick inline code', () => {
+    expect(extractMentions('\\`@alice\\` @bob')).toEqual(['bob']);
+  });
+
+  it('extracts mentions immediately after inline code', () => {
+    expect(extractMentions('`cmd`@alice')).toEqual(['alice']);
+    expect(extractMentions('see`cmd`@alice')).toEqual(['alice']);
+    expect(extractMentions('see `cmd`@alice')).toEqual(['alice']);
+  });
+
+  it('extracts mentions immediately after escaped-backtick inline code', () => {
+    expect(extractMentions('\\`cmd\\`@alice')).toEqual(['alice']);
+  });
+
+  it('ignores mentions inside fenced code blocks', () => {
+    expect(extractMentions('```\n@all\n```\n@bob')).toEqual(['bob']);
+  });
+
+  it('ignores mentions inside indented code blocks', () => {
+    expect(extractMentions('    @alice\n@bob')).toEqual(['bob']);
+  });
+
+  it('ignores mentions inside blockquotes', () => {
+    expect(extractMentions('> @alice said hi\n\n@bob replied')).toEqual(['bob']);
+  });
+
+  it('preserves mention order around excluded markdown regions', () => {
+    expect(extractMentions('@alice `@bob` @charlie\n> @dora\n```\n@erin\n```\n@frank')).toEqual([
+      'alice',
+      'charlie',
+      'frank'
+    ]);
+  });
+
+  it('does not treat unmatched backticks as code spans', () => {
+    expect(extractMentions('` @alice')).toEqual(['alice']);
+  });
+
+  it('treats literal html code tags as plain markdown text', () => {
+    expect(extractMentions('<code>@alice</code>')).toEqual(['alice']);
+  });
+
+  it('keeps a backslash before a mention as a mention boundary', () => {
+    expect(extractMentions('\\@alice')).toEqual(['alice']);
+  });
 });
 
 describe('findMemberByMention', () => {
@@ -122,5 +177,26 @@ describe('isUserMentioned', () => {
 
   it('returns false for empty text', () => {
     expect(isUserMentioned('', 'alice', members)).toBe(false);
+  });
+
+  it('returns false when the mention handle is split by emphasis', () => {
+    expect(isUserMentioned('@al*ice*', 'alice', members)).toBe(false);
+    expect(isUserMentioned('@*alice*', 'alice', members)).toBe(false);
+  });
+
+  it('returns false for a mention inside inline code', () => {
+    expect(isUserMentioned('Hello `@alice`!', 'alice', members)).toBe(false);
+  });
+
+  it('returns false for a mention inside escaped-backtick inline code', () => {
+    expect(isUserMentioned('Hello \\`@alice\\`!', 'alice', members)).toBe(false);
+  });
+
+  it('returns true for a mention immediately after inline code', () => {
+    expect(isUserMentioned('Hello `cmd`@alice!', 'alice', members)).toBe(true);
+  });
+
+  it('returns false for a mention inside a blockquote', () => {
+    expect(isUserMentioned('> Hello @alice!', 'alice', members)).toBe(false);
   });
 });

--- a/frontend/src/lib/mentions.ts
+++ b/frontend/src/lib/mentions.ts
@@ -1,4 +1,6 @@
+import MarkdownIt from 'markdown-it';
 import type { RoomMember } from '$lib/state/room';
+import type StateInline from 'markdown-it/lib/rules_inline/state_inline.mjs';
 
 // Re-export for convenience
 export type { RoomMember };
@@ -9,23 +11,88 @@ export type { RoomMember };
  *
  * Pattern matches @username where username contains alphanumeric, underscores, hyphens, and dots.
  * Dots are only allowed as internal separators (not trailing).
- * Same pattern as backend (mentions.go:21).
+ * Used for wrapping mentions in already-rendered DOM text nodes.
  */
 function createMentionRegex(): RegExp {
   return /(^|[^a-zA-Z0-9])@([a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)*)/g;
 }
 
+function isMentionAlphanumeric(value: string): boolean {
+  return /^[a-zA-Z0-9]$/.test(value);
+}
+
+function isMentionHandleChar(value: string): boolean {
+  return /^[a-zA-Z0-9_-]$/.test(value);
+}
+
+function mentionRule(state: StateInline, silent: boolean): boolean {
+  const start = state.pos;
+  if (state.src[start] !== '@') return false;
+  if (start > 0 && isMentionAlphanumeric(state.src[start - 1])) return false;
+
+  let stop = start + 1;
+  while (stop < state.posMax && isMentionHandleChar(state.src[stop])) {
+    stop++;
+  }
+  if (stop === start + 1) return false;
+
+  while (stop < state.posMax && state.src[stop] === '.') {
+    const next = stop + 1;
+    if (next >= state.posMax || !isMentionHandleChar(state.src[next])) break;
+    stop = next + 1;
+    while (stop < state.posMax && isMentionHandleChar(state.src[stop])) {
+      stop++;
+    }
+  }
+
+  if (!silent) {
+    const token = state.push('mention', '', 0);
+    token.content = state.src.slice(start + 1, stop);
+    token.markup = '@';
+  }
+  state.pos = stop;
+  return true;
+}
+
+const mentionMarkdown = new MarkdownIt({
+  html: false,
+  linkify: false,
+  breaks: true
+});
+mentionMarkdown.disable(['escape']);
+mentionMarkdown.inline.ruler.before('emphasis', 'mention', mentionRule);
+
 /**
  * Extract @usernames from text (without validation).
  * Returns deduplicated list of usernames in order of appearance.
+ * Ignores mentions inside Markdown code spans, code blocks, and blockquotes.
  */
 export function extractMentions(text: string): string[] {
+  if (!text.includes('@')) return [];
+
   const mentions: string[] = [];
-  const regex = createMentionRegex();
-  let match;
-  while ((match = regex.exec(text)) !== null) {
-    mentions.push(match[2]); // Capture group 2 is the username
+
+  let blockquoteDepth = 0;
+  for (const token of mentionMarkdown.parse(text, {})) {
+    if (token.type === 'blockquote_open') {
+      blockquoteDepth++;
+      continue;
+    }
+    if (token.type === 'blockquote_close') {
+      blockquoteDepth = Math.max(0, blockquoteDepth - 1);
+      continue;
+    }
+    if (blockquoteDepth > 0) continue;
+    if (token.type === 'fence' || token.type === 'code_block') continue;
+    if (token.type === 'inline') {
+      for (const child of token.children ?? []) {
+        if (child.type === 'mention') {
+          mentions.push(child.content);
+        }
+      }
+    }
   }
+
   return [...new Set(mentions)]; // Deduplicate
 }
 


### PR DESCRIPTION
- Parse backend mention handles with Goldmark inline mention tokens so code spans, code blocks, and blockquotes do not notify.
- Mirror raw-body frontend mention extraction with markdown-it mention tokens while leaving rendered DOM wrapping behavior intact.
- Make link-preview URL detection Markdown-aware so code spans, code blocks, and blockquotes do not trigger previews, while explicit Markdown link destinations still do.
- Expand backend and frontend coverage for mention boundaries, URL punctuation, dedupe, Markdown exclusions, non-HTTP URLs, composer preview fetches, and YouTube URL forms.
- Update the mentions and link-preview FDRs plus architecture inventory to describe the parser-backed exclusions.
