### PR TITLE
fix(config): tighten chatto config validation

### DIFF
--- a/cli/chatto.toml
+++ b/cli/chatto.toml
@@ -47,11 +47,6 @@ url = 'ws://livekit.chatto-tools.orb.local:7880'
 api_key = 'devkey'
 api_secret = 'secret'
 
-[nats.client]
-url = 'nats://localhost:4555'
-auth_method = 'token'
-token = 'd5ed70d13c4682609dfd0a4f65bf7e59ef22f3be8502762b501d3b7cf0b73b43'
-
 [nats.embedded]
 enabled = true
 port = 4555
@@ -67,7 +62,7 @@ login = 'alice'
 display_name = 'Alice'
 email = 'alice@example.com'
 password = 'foobar123'
-instance_role = 'owner'
+server_role = 'owner'
 
 [[bootstrap.users]]
 login = 'bob'
@@ -75,5 +70,5 @@ display_name = 'Bob'
 email = 'bob@example.com'
 password = 'foobar123'
 
-[bootstrap.instance]
+[bootstrap.server]
 name = 'Local Development'

--- a/cli/cmd/bootstrap_apply.go
+++ b/cli/cmd/bootstrap_apply.go
@@ -24,7 +24,8 @@ import (
 func applyBootstrap(ctx context.Context, c *core.ChattoCore, cfg config.BootstrapConfig) {
 	logger := log.WithPrefix("bootstrap")
 
-	hasServer := cfg.Server != nil
+	serverConfig := cfg.ServerOrDefault()
+	hasServer := serverConfig != nil
 	if len(cfg.Users) == 0 && !hasServer {
 		// Always log something so operators can confirm the bootstrap path ran.
 		// At debug level so a config without a [bootstrap] section doesn't add
@@ -56,7 +57,7 @@ func applyBootstrap(ctx context.Context, c *core.ChattoCore, cfg config.Bootstra
 		if firstUserID == "" {
 			firstUserID = userID
 		}
-		if ownerID == "" && u.ServerRole == "owner" {
+		if ownerID == "" && u.RoleOrDefault() == "owner" {
 			ownerID = userID
 		}
 		if created {
@@ -74,16 +75,16 @@ func applyBootstrap(ctx context.Context, c *core.ChattoCore, cfg config.Bootstra
 	serverCreated := false
 	if hasServer {
 		if ownerID == "" {
-			logger.Error("[bootstrap] instance requires at least one user; skipping server setup")
+			logger.Error("[bootstrap] server requires at least one user; skipping server setup")
 		} else {
-			serverCreated = applyBootstrapServer(ctx, logger, c, *cfg.Server, ownerID, bootstrapUserIDs)
+			serverCreated = applyBootstrapServer(ctx, logger, c, *serverConfig, ownerID, bootstrapUserIDs)
 		}
 	}
 
 	logger.Info("[bootstrap] apply complete",
 		"users_created", usersCreated,
 		"users_existing", usersExisting,
-		"instance_created", serverCreated,
+		"server_created", serverCreated,
 	)
 }
 
@@ -146,7 +147,7 @@ func applyBootstrapUser(ctx context.Context, logger *log.Logger, c *core.ChattoC
 	if existing, err := c.GetUserByLogin(ctx, u.Login); err == nil && existing != nil {
 		logger.Debug("[bootstrap] user already exists; skipping create", "user_id", existing.Id)
 		// Still try to apply role + email below (idempotent).
-		assignBootstrapRole(ctx, logger, c, existing.Id, u.ServerRole)
+		assignBootstrapRole(ctx, logger, c, existing.Id, u.RoleOrDefault())
 		ensureBootstrapEmail(ctx, logger, c, existing.Id, u.Email)
 		return existing.Id, false
 	}
@@ -163,7 +164,7 @@ func applyBootstrapUser(ctx context.Context, logger *log.Logger, c *core.ChattoC
 	}
 
 	ensureBootstrapEmail(ctx, logger, c, user.Id, u.Email)
-	assignBootstrapRole(ctx, logger, c, user.Id, u.ServerRole)
+	assignBootstrapRole(ctx, logger, c, user.Id, u.RoleOrDefault())
 
 	return user.Id, true
 }
@@ -193,7 +194,7 @@ func assignBootstrapRole(ctx context.Context, logger *log.Logger, c *core.Chatto
 	case "moderator":
 		roleName = core.RoleModerator
 	default:
-		logger.Warn("Unknown instance_role in [bootstrap]; ignoring", "user_id", userID, "role", role)
+		logger.Warn("Unknown server_role in [bootstrap]; ignoring", "user_id", userID, "role", role)
 		return
 	}
 	// SystemActorID bypasses hierarchy checks — bootstrap operates as the system.
@@ -211,7 +212,7 @@ func assignBootstrapRole(ctx context.Context, logger *log.Logger, c *core.Chatto
 // skipped).
 func applyBootstrapServer(ctx context.Context, logger *log.Logger, c *core.ChattoCore, inst config.BootstrapServer, ownerID string, bootstrapUserIDs []string) bool {
 	if inst.Name == "" {
-		logger.Error("Skipping [bootstrap.instance] with empty name")
+		logger.Error("Skipping [bootstrap.server] with empty name")
 		return false
 	}
 
@@ -221,7 +222,7 @@ func applyBootstrapServer(ctx context.Context, logger *log.Logger, c *core.Chatt
 	if cm := c.ConfigManager(); cm != nil {
 		current, err := cm.GetServerConfig(ctx)
 		if err != nil {
-			logger.Warn("Failed to read server config before [bootstrap.instance] seed", "error", err)
+			logger.Warn("Failed to read server config before [bootstrap.server] seed", "error", err)
 		} else if current == nil || current.ServerName == "" {
 			if _, err := cm.UpdateServerConfigFunc(ctx, "system:bootstrap", func(current *configv1.ServerConfig) (*configv1.ServerConfig, error) {
 				if current == nil {
@@ -232,7 +233,7 @@ func applyBootstrapServer(ctx context.Context, logger *log.Logger, c *core.Chatt
 				}
 				return current, nil
 			}); err != nil {
-				logger.Warn("Failed to seed server config from [bootstrap.instance]", "error", err)
+				logger.Warn("Failed to seed server config from [bootstrap.server]", "error", err)
 			}
 		}
 	}

--- a/cli/cmd/bootstrap_test.go
+++ b/cli/cmd/bootstrap_test.go
@@ -23,8 +23,8 @@ func setupCore(t *testing.T) *core.ChattoCore {
 	t.Cleanup(cancel)
 
 	cfg := config.CoreConfig{
-		SecretKey: "test-core-secret",
-		Assets:    config.AssetsConfig{SigningSecret: "test-secret"},
+		SecretKey: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+		Assets:    config.AssetsConfig{SigningSecret: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"},
 	}
 	c, err := core.NewChattoCore(ctx, nc, cfg)
 	if err != nil {

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -95,12 +95,6 @@ var initCmd = &cobra.Command{
 				},
 			},
 			NATS: config.NATSConfig{
-				// Client config for CLI commands to connect to the embedded server
-				Client: config.NATSClientConfig{
-					URL:        "nats://localhost:4222",
-					AuthMethod: config.NATSAuthToken,
-					Token:      authTokenString,
-				},
 				Embedded: config.EmbeddedNATSConfig{
 					Enabled:     true,
 					Port:        4222,

--- a/cli/cmd/init_test.go
+++ b/cli/cmd/init_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"hmans.de/chatto/internal/config"
@@ -35,5 +36,18 @@ func TestInitGeneratesCoreSecret(t *testing.T) {
 	}
 	if _, err := hex.DecodeString(cfg.Core.SecretKey); err != nil {
 		t.Fatalf("generated core secret should be hex: %v", err)
+	}
+	if cfg.NATS.Client.URL != "nats://127.0.0.1:4222" {
+		t.Fatalf("derived embedded NATS client URL = %q", cfg.NATS.Client.URL)
+	}
+	if cfg.NATS.Client.Token != cfg.NATS.Embedded.AuthToken {
+		t.Fatalf("derived embedded NATS client token should match embedded auth token")
+	}
+	raw, err := os.ReadFile(filepath.Join(tmpDir, "chatto.toml"))
+	if err != nil {
+		t.Fatalf("read generated raw config: %v", err)
+	}
+	if strings.Contains(string(raw), "[nats.client]") {
+		t.Fatal("generated embedded config should not include a duplicate [nats.client] table")
 	}
 }

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/hex"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"strings"
@@ -75,6 +76,73 @@ type WebserverConfig struct {
 	CookieSigningSecret    string    `toml:"cookie_signing_secret" env:"CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET" comment:"Secret for signing session cookies. NEVER SHARE THIS!\nIf it leaks, change it immediately, but please note that all existing sessions will become invalid."`
 	CookieEncryptionSecret string    `toml:"cookie_encryption_secret" env:"CHATTO_WEBSERVER_COOKIE_ENCRYPTION_SECRET" comment:"Optional hex-encoded secret used to encrypt session cookies (in addition to signing). Must decode to 16, 24, or 32 bytes (AES-128/192/256). If unset, cookies are signed but not encrypted — anything ever written to the session is readable by anyone who steals the cookie."`
 	TLS                    TLSConfig `toml:"tls" comment:"Automatic TLS configuration via Let's Encrypt."`
+}
+
+func validateHexSecret(name, value string, required bool) error {
+	if value == "" {
+		if required {
+			return fmt.Errorf("%s is required", name)
+		}
+		return nil
+	}
+	decoded, err := hex.DecodeString(value)
+	if err != nil {
+		return fmt.Errorf("%s must be hex-encoded: %w", name, err)
+	}
+	if len(decoded) != 32 {
+		return fmt.Errorf("%s must decode to 32 bytes (got %d)", name, len(decoded))
+	}
+	return nil
+}
+
+func validateAbsoluteHTTPURL(name, raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("%s is invalid: %w", name, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("%s must use http or https", name)
+	}
+	if u.Host == "" || u.User != nil {
+		return fmt.Errorf("%s must include a host and must not include user info", name)
+	}
+	return nil
+}
+
+func validateOrigin(name, raw string, allowWildcard bool, requireHTTPSExceptLoopback bool) error {
+	raw = strings.TrimSpace(raw)
+	if allowWildcard && raw == "*" {
+		return nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("%s contains invalid origin %q: %w", name, raw, err)
+	}
+	if u.Scheme == "" || u.Host == "" || u.User != nil {
+		return fmt.Errorf("%s contains invalid origin %q: must include scheme and host only", name, raw)
+	}
+	if u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
+		return fmt.Errorf("%s contains invalid origin %q: origins must not include path, query, or fragment", name, raw)
+	}
+	if requireHTTPSExceptLoopback && !isLoopbackHost(u.Hostname()) {
+		if u.Scheme != "https" {
+			return fmt.Errorf("%s contains invalid origin %q: non-loopback OAuth redirect origins must use https", name, raw)
+		}
+		return nil
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("%s contains invalid origin %q: origin must use http or https", name, raw)
+	}
+	return nil
+}
+
+func isLoopbackHost(host string) bool {
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 // CookieEncryptionKey decodes the optional cookie encryption secret into an
@@ -164,19 +232,29 @@ func (c *S3Config) PathStyleOrDefault() bool {
 	return *c.PathStyle
 }
 
+// NormalizedPathPrefix returns PathPrefix with harmless leading/trailing slashes
+// removed. Empty and "/" both preserve the historical bucket-root layout.
+func (c *S3Config) NormalizedPathPrefix() string {
+	return strings.Trim(c.PathPrefix, "/")
+}
+
 // NormalizePathPrefix trims harmless leading/trailing slashes from the S3
 // object prefix. Empty and "/" both preserve the historical bucket-root layout.
 func (c *S3Config) NormalizePathPrefix() {
-	c.PathPrefix = strings.Trim(c.PathPrefix, "/")
+	c.PathPrefix = c.NormalizedPathPrefix()
 }
 
 // ValidatePathPrefix rejects ambiguous prefixes before they become physical
 // object keys. Call NormalizePathPrefix first so "/" is accepted as empty.
 func (c *S3Config) ValidatePathPrefix() error {
-	if strings.Contains(c.PathPrefix, "//") {
+	return validateS3PathPrefix(c.PathPrefix)
+}
+
+func validateS3PathPrefix(prefix string) error {
+	if strings.Contains(prefix, "//") {
 		return fmt.Errorf("core.assets.s3.path_prefix must not contain empty path segments")
 	}
-	for _, r := range c.PathPrefix {
+	for _, r := range prefix {
 		if r < 0x20 || r == 0x7f {
 			return fmt.Errorf("core.assets.s3.path_prefix must not contain control characters")
 		}
@@ -230,7 +308,7 @@ func (c *OIDCConfig) LabelOrDefault() string {
 
 // IsConfigured returns true if OIDC is enabled and all required fields are set.
 func (c *OIDCConfig) IsConfigured() bool {
-	return c.Enabled && c.IssuerURL != "" && c.ClientID != ""
+	return c.Enabled && c.IssuerURL != "" && c.ClientID != "" && c.ClientSecret != ""
 }
 
 type AuthConfig struct {
@@ -320,7 +398,7 @@ func (c *NATSClientConfig) NATSAuthConfig() natsauth.Config {
 
 type NATSConfig struct {
 	Replicas int                `toml:"replicas,commented" env:"CHATTO_NATS_REPLICAS" comment:"Number of replicas for JetStream streams, KV buckets, and object stores. Must be 1, 3, or 5 (odd numbers for quorum). Default: 1. Set to 3 or 5 when running a NATS cluster for fault tolerance."`
-	Client   NATSClientConfig   `toml:"client" comment:"Client settings for CLI commands to connect to NATS."`
+	Client   NATSClientConfig   `toml:"client,omitempty" comment:"Client settings for CLI commands to connect to NATS."`
 	Embedded EmbeddedNATSConfig `toml:"embedded"`
 }
 
@@ -459,8 +537,9 @@ type LiveKitConfig struct {
 	APIKey           string `toml:"api_key" env:"CHATTO_LIVEKIT_API_KEY" comment:"LiveKit API key."`
 	APISecret        string `toml:"api_secret" env:"CHATTO_LIVEKIT_API_SECRET" comment:"LiveKit API secret. NEVER SHARE THIS!"`
 	WebhookURL       string `toml:"webhook_url" env:"CHATTO_LIVEKIT_WEBHOOK_URL" comment:"URL where LiveKit sends webhook events. Defaults to {webserver.url}/webhooks/livekit."`
-	ServerID         string `toml:"instance_id,commented" env:"CHATTO_LIVEKIT_INSTANCE_ID" comment:"Unique identifier for this instance, prefixed to LiveKit room names. Required when multiple Chatto instances share the same LiveKit cluster."`
-	WebhookAPIKey    string `toml:"webhook_api_key,commented" env:"CHATTO_LIVEKIT_WEBHOOK_API_KEY" comment:"API key LiveKit uses to sign webhooks. Falls back to api_key if not set. Required when the webhook signing key differs from the per-instance API key."`
+	ServerID         string `toml:"server_id,commented" env:"CHATTO_LIVEKIT_SERVER_ID" comment:"Unique identifier for this server, prefixed to LiveKit room names. Required when multiple Chatto servers share the same LiveKit cluster."`
+	InstanceID       string `toml:"instance_id,commented" env:"CHATTO_LIVEKIT_INSTANCE_ID" comment:"Deprecated alias for server_id. Prefer server_id / CHATTO_LIVEKIT_SERVER_ID."`
+	WebhookAPIKey    string `toml:"webhook_api_key,commented" env:"CHATTO_LIVEKIT_WEBHOOK_API_KEY" comment:"API key LiveKit uses to sign webhooks. Falls back to api_key if not set. Required when the webhook signing key differs from the per-server API key."`
 	WebhookAPISecret string `toml:"webhook_api_secret,commented" env:"CHATTO_LIVEKIT_WEBHOOK_API_SECRET" comment:"API secret for webhook signature validation. Falls back to api_secret if not set."`
 }
 
@@ -486,22 +565,42 @@ func (c *LiveKitConfig) IsConfigured() bool {
 // binaries parse the section but ignore its contents. Plaintext passwords
 // are fine here for the same reason.
 type BootstrapConfig struct {
-	Users  []BootstrapUser  `toml:"users"`
-	Server *BootstrapServer `toml:"instance,commented" comment:"Seeds the server config (name) and the deployment's primary room group on first boot."`
+	Users          []BootstrapUser  `toml:"users"`
+	Server         *BootstrapServer `toml:"server,commented" comment:"Seeds the server config (name) and the deployment's primary room group on first boot."`
+	LegacyInstance *BootstrapServer `toml:"instance,commented" comment:"Deprecated alias for [bootstrap.server]. Prefer [bootstrap.server]."`
 }
 
 // BootstrapUser describes a user to create on startup in bootstrap-tag builds.
 type BootstrapUser struct {
-	Login       string `toml:"login" comment:"Required. The user's login (username)."`
-	DisplayName string `toml:"display_name,commented" comment:"Defaults to Login if empty."`
-	Email       string `toml:"email,commented" comment:"Optional. If set, added as a verified email."`
-	Password    string `toml:"password,commented" comment:"Optional. Required to log in via password; safe in plaintext because bootstrap-tag builds only."`
-	ServerRole  string `toml:"instance_role,commented" comment:"Optional: owner | admin | moderator."`
+	Login        string `toml:"login" comment:"Required. The user's login (username)."`
+	DisplayName  string `toml:"display_name,commented" comment:"Defaults to Login if empty."`
+	Email        string `toml:"email,commented" comment:"Optional. If set, added as a verified email."`
+	Password     string `toml:"password,commented" comment:"Optional. Required to log in via password; safe in plaintext because bootstrap-tag builds only."`
+	ServerRole   string `toml:"server_role,commented" comment:"Optional: owner | admin | moderator."`
+	InstanceRole string `toml:"instance_role,commented" comment:"Deprecated alias for server_role. Prefer server_role."`
 }
 
-// BootstrapServer describes the instance to seed on startup in bootstrap-tag
+// RoleOrDefault returns the normalized bootstrap role, honoring the deprecated
+// instance_role alias only when server_role is unset.
+func (u BootstrapUser) RoleOrDefault() string {
+	if u.ServerRole != "" {
+		return u.ServerRole
+	}
+	return u.InstanceRole
+}
+
+// ServerOrDefault returns the normalized bootstrap server, honoring the
+// deprecated [bootstrap.instance] alias only when [bootstrap.server] is unset.
+func (c BootstrapConfig) ServerOrDefault() *BootstrapServer {
+	if c.Server != nil {
+		return c.Server
+	}
+	return c.LegacyInstance
+}
+
+// BootstrapServer describes the server to seed on startup in bootstrap-tag
 // builds. Per ADR-027 there is no separate "space" concept any more — the
-// instance is the server. The bootstrap creates whatever underlying storage
+// server is the product surface. The bootstrap creates whatever underlying storage
 // records (notably a primary space) the data layer still needs, but those
 // are internal: operators only configure the server's name.
 type BootstrapServer struct {
@@ -524,19 +623,70 @@ type ChattoConfig struct {
 	Bootstrap BootstrapConfig `toml:"bootstrap,commented" comment:"Dev/E2E-only: users and spaces auto-created on startup. ONLY honored by builds compiled with the 'bootstrap' build tag; release binaries ignore this section entirely."`
 }
 
+// ApplyDefaults fills derived config values that are safe to compute from other
+// fields. Keep validation separate so Validate can remain a pure check.
+func (c *ChattoConfig) ApplyDefaults() {
+	if c.NATS.Embedded.Enabled && c.NATS.Embedded.Port > 0 {
+		if c.NATS.Client.URL == "" {
+			c.NATS.Client.URL = embeddedNATSClientURL(c.NATS.Embedded)
+		}
+		if c.NATS.Client.AuthMethod == "" {
+			if c.NATS.Embedded.AuthToken != "" {
+				c.NATS.Client.AuthMethod = NATSAuthToken
+			} else {
+				c.NATS.Client.AuthMethod = NATSAuthNone
+			}
+		}
+		if c.NATS.Client.AuthMethod == NATSAuthToken && c.NATS.Client.Token == "" {
+			c.NATS.Client.Token = c.NATS.Embedded.AuthToken
+		}
+	}
+
+	if c.LiveKit.ServerID == "" {
+		c.LiveKit.ServerID = c.LiveKit.InstanceID
+	}
+	if c.LiveKit.Enabled && c.LiveKit.WebhookURL == "" && c.Webserver.URL != "" {
+		c.LiveKit.WebhookURL = strings.TrimRight(c.Webserver.URL, "/") + "/webhooks/livekit"
+	}
+
+	for i := range c.Bootstrap.Users {
+		if c.Bootstrap.Users[i].ServerRole == "" {
+			c.Bootstrap.Users[i].ServerRole = c.Bootstrap.Users[i].InstanceRole
+		}
+	}
+	if c.Bootstrap.Server == nil {
+		c.Bootstrap.Server = c.Bootstrap.LegacyInstance
+	}
+}
+
+// Normalize canonicalizes harmless config spelling differences without applying
+// semantic defaults.
+func (c *ChattoConfig) Normalize() {
+	c.Core.Assets.S3.NormalizePathPrefix()
+}
+
+func embeddedNATSClientURL(cfg EmbeddedNATSConfig) string {
+	host := cfg.BindAddressOrDefault()
+	switch host {
+	case "", "0.0.0.0", "::":
+		host = "127.0.0.1"
+	}
+	return fmt.Sprintf("nats://%s", net.JoinHostPort(host, fmt.Sprint(cfg.Port)))
+}
+
 // Validate checks the configuration for errors and returns a descriptive error if any are found.
 func (c *ChattoConfig) Validate() error {
 	var errs []string
 
 	// Required fields
-	if c.Webserver.CookieSigningSecret == "" {
-		errs = append(errs, "webserver.cookie_signing_secret is required")
+	if err := validateHexSecret("webserver.cookie_signing_secret", c.Webserver.CookieSigningSecret, true); err != nil {
+		errs = append(errs, err.Error())
 	}
-	if c.Core.Assets.SigningSecret == "" {
-		errs = append(errs, "core.assets.signing_secret is required")
+	if err := validateHexSecret("core.assets.signing_secret", c.Core.Assets.SigningSecret, true); err != nil {
+		errs = append(errs, err.Error())
 	}
-	if c.Core.SecretKey == "" {
-		errs = append(errs, "core.secret_key is required")
+	if err := validateHexSecret("core.secret_key", c.Core.SecretKey, true); err != nil {
+		errs = append(errs, err.Error())
 	}
 	if _, err := c.Webserver.CookieEncryptionKey(); err != nil {
 		errs = append(errs, err.Error())
@@ -569,13 +719,23 @@ func (c *ChattoConfig) Validate() error {
 
 	// URL format
 	if c.Webserver.URL != "" {
-		if _, err := url.Parse(c.Webserver.URL); err != nil {
-			errs = append(errs, fmt.Sprintf("webserver.url is invalid: %v", err))
+		if err := validateAbsoluteHTTPURL("webserver.url", c.Webserver.URL); err != nil {
+			errs = append(errs, err.Error())
 		}
 	}
 	if c.NATS.Client.URL != "" {
 		if _, err := url.Parse(c.NATS.Client.URL); err != nil {
 			errs = append(errs, fmt.Sprintf("nats.client.url is invalid: %v", err))
+		}
+	}
+	for _, origin := range c.Webserver.AllowedOrigins {
+		if err := validateOrigin("webserver.allowed_origins", origin, true, false); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+	for _, origin := range c.Webserver.OAuthRedirectOrigins {
+		if err := validateOrigin("webserver.oauth_redirect_origins", origin, true, true); err != nil {
+			errs = append(errs, err.Error())
 		}
 	}
 
@@ -610,6 +770,9 @@ func (c *ChattoConfig) Validate() error {
 		errs = append(errs, "smtp.tls must be one of: mandatory, opportunistic")
 	}
 	if c.SMTP.Enabled {
+		if c.Webserver.URL == "" {
+			errs = append(errs, "webserver.url is required when SMTP is enabled")
+		}
 		if c.SMTP.Host == "" {
 			errs = append(errs, "smtp.host is required when SMTP is enabled")
 		}
@@ -621,8 +784,27 @@ func (c *ChattoConfig) Validate() error {
 		}
 	}
 
+	// OIDC configuration
+	if c.Auth.OIDC.Enabled {
+		if c.Webserver.URL == "" {
+			errs = append(errs, "webserver.url is required when OIDC is enabled")
+		}
+		if c.Auth.OIDC.IssuerURL == "" {
+			errs = append(errs, "auth.oidc.issuer_url is required when OIDC is enabled")
+		}
+		if c.Auth.OIDC.ClientID == "" {
+			errs = append(errs, "auth.oidc.client_id is required when OIDC is enabled")
+		}
+		if c.Auth.OIDC.ClientSecret == "" {
+			errs = append(errs, "auth.oidc.client_secret is required when OIDC is enabled")
+		}
+	}
+
 	// Push notification configuration
 	if c.Push.Enabled {
+		if c.Webserver.URL == "" {
+			errs = append(errs, "webserver.url is required when push is enabled")
+		}
 		if c.Push.VAPIDPublicKey == "" {
 			errs = append(errs, "push.vapid_public_key is required when push is enabled")
 		}
@@ -636,6 +818,9 @@ func (c *ChattoConfig) Validate() error {
 
 	// LiveKit configuration
 	if c.LiveKit.Enabled {
+		if c.Webserver.URL == "" {
+			errs = append(errs, "webserver.url is required when LiveKit is enabled")
+		}
 		if c.LiveKit.URL == "" {
 			errs = append(errs, "livekit.url is required when LiveKit is enabled")
 		}
@@ -644,10 +829,6 @@ func (c *ChattoConfig) Validate() error {
 		}
 		if c.LiveKit.APISecret == "" {
 			errs = append(errs, "livekit.api_secret is required when LiveKit is enabled")
-		}
-		// Default webhook URL to {webserver.url}/webhooks/livekit
-		if c.LiveKit.WebhookURL == "" && c.Webserver.URL != "" {
-			c.LiveKit.WebhookURL = strings.TrimRight(c.Webserver.URL, "/") + "/webhooks/livekit"
 		}
 	}
 
@@ -670,7 +851,6 @@ func (c *ChattoConfig) Validate() error {
 
 	// S3 configuration (required when storage_backend = "s3")
 	if c.Core.Assets.StorageBackend == StorageBackendS3 {
-		c.Core.Assets.S3.NormalizePathPrefix()
 		if c.Core.Assets.S3.Endpoint == "" {
 			errs = append(errs, "core.assets.s3.endpoint is required when storage_backend = 's3'")
 		}
@@ -683,9 +863,18 @@ func (c *ChattoConfig) Validate() error {
 		if c.Core.Assets.S3.SecretAccessKey == "" {
 			errs = append(errs, "core.assets.s3.secret_access_key is required when storage_backend = 's3'")
 		}
-		if err := c.Core.Assets.S3.ValidatePathPrefix(); err != nil {
+		if err := validateS3PathPrefix(c.Core.Assets.S3.NormalizedPathPrefix()); err != nil {
 			errs = append(errs, err.Error())
 		}
+	}
+
+	if c.NATS.Embedded.Enabled &&
+		c.NATS.Embedded.Port > 0 &&
+		c.NATS.Embedded.AuthToken != "" &&
+		c.NATS.Client.AuthMethod == NATSAuthToken &&
+		c.NATS.Client.Token != "" &&
+		c.NATS.Client.Token != c.NATS.Embedded.AuthToken {
+		errs = append(errs, "nats.client.token must match nats.embedded.auth_token when embedded NATS uses token auth")
 	}
 
 	if len(errs) > 0 {
@@ -720,7 +909,11 @@ func ReadConfig(configPath string) (ChattoConfig, error) {
 		return cfg, fmt.Errorf("failed to parse environment variables: %w", err)
 	}
 
-	// 3. Validate
+	// 3. Apply derived defaults and normalize harmless spelling differences
+	cfg.ApplyDefaults()
+	cfg.Normalize()
+
+	// 4. Validate
 	if err := cfg.Validate(); err != nil {
 		return cfg, err
 	}

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -22,10 +22,10 @@ func TestReadConfig_WithoutConfigFile(t *testing.T) {
 
 	// Set required env vars
 	t.Setenv("CHATTO_WEBSERVER_PORT", "4000")
-	t.Setenv("CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET", "test-cookie-secret")
+	t.Setenv("CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
 	t.Setenv("CHATTO_WEBSERVER_COOKIE_ENCRYPTION_SECRET", "000102030405060708090a0b0c0d0e0f")
-	t.Setenv("CHATTO_CORE_SECRET_KEY", "test-core-secret")
-	t.Setenv("CHATTO_CORE_ASSETS_SIGNING_SECRET", "test-assets-secret")
+	t.Setenv("CHATTO_CORE_SECRET_KEY", "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789")
+	t.Setenv("CHATTO_CORE_ASSETS_SIGNING_SECRET", "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff")
 
 	// ReadConfig should succeed even without chatto.toml
 	cfg, err := ReadConfig("")
@@ -37,13 +37,13 @@ func TestReadConfig_WithoutConfigFile(t *testing.T) {
 	if cfg.Webserver.Port != 4000 {
 		t.Errorf("expected port 4000, got %d", cfg.Webserver.Port)
 	}
-	if cfg.Webserver.CookieSigningSecret != "test-cookie-secret" {
+	if cfg.Webserver.CookieSigningSecret != "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" {
 		t.Errorf("expected cookie secret to be set from env var")
 	}
 	if cfg.Webserver.CookieEncryptionSecret != "000102030405060708090a0b0c0d0e0f" {
 		t.Errorf("expected cookie encryption secret to be set from env var")
 	}
-	if cfg.Core.SecretKey != "test-core-secret" {
+	if cfg.Core.SecretKey != "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789" {
 		t.Errorf("expected core secret to be set from env var")
 	}
 }
@@ -64,13 +64,13 @@ func TestReadConfig_WithConfigFile(t *testing.T) {
 	configContent := `
 [webserver]
 port = 5000
-cookie_signing_secret = "file-cookie-secret"
+cookie_signing_secret = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
 [core]
-secret_key = "file-core-secret"
+secret_key = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
 
 [core.assets]
-signing_secret = "file-assets-secret"
+signing_secret = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
 `
 	if err := os.WriteFile(filepath.Join(tmpDir, "chatto.toml"), []byte(configContent), 0644); err != nil {
 		t.Fatalf("failed to write config file: %v", err)
@@ -104,13 +104,13 @@ func TestReadConfig_EnvOverridesFile(t *testing.T) {
 	configContent := `
 [webserver]
 port = 5000
-cookie_signing_secret = "file-cookie-secret"
+cookie_signing_secret = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
 [core]
-secret_key = "file-core-secret"
+secret_key = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
 
 [core.assets]
-signing_secret = "file-assets-secret"
+signing_secret = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
 `
 	if err := os.WriteFile(filepath.Join(tmpDir, "chatto.toml"), []byte(configContent), 0644); err != nil {
 		t.Fatalf("failed to write config file: %v", err)
@@ -142,14 +142,114 @@ func TestReadConfig_InvalidCookieEncryptionSecretFromEnv(t *testing.T) {
 	t.Cleanup(func() { os.Chdir(originalDir) })
 
 	t.Setenv("CHATTO_WEBSERVER_PORT", "4000")
-	t.Setenv("CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET", "test-cookie-secret")
+	t.Setenv("CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
 	t.Setenv("CHATTO_WEBSERVER_COOKIE_ENCRYPTION_SECRET", "not-hex")
-	t.Setenv("CHATTO_CORE_SECRET_KEY", "test-core-secret")
-	t.Setenv("CHATTO_CORE_ASSETS_SIGNING_SECRET", "test-assets-secret")
+	t.Setenv("CHATTO_CORE_SECRET_KEY", "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789")
+	t.Setenv("CHATTO_CORE_ASSETS_SIGNING_SECRET", "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff")
 
 	_, err = ReadConfig("")
 	if err == nil || !strings.Contains(err.Error(), "webserver.cookie_encryption_secret must be hex-encoded") {
 		t.Fatalf("ReadConfig() error = %v, want cookie encryption validation error", err)
+	}
+}
+
+func TestReadConfig_ValidatesEnvOverrides(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    string
+		env       map[string]string
+		wantError string
+	}{
+		{
+			name: "required secret overridden by env must be valid hex",
+			config: `
+[webserver]
+port = 5000
+cookie_signing_secret = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+[core]
+secret_key = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+
+[core.assets]
+signing_secret = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
+`,
+			env: map[string]string{
+				"CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET": "not-hex",
+			},
+			wantError: "webserver.cookie_signing_secret must be hex-encoded",
+		},
+		{
+			name: "allowed origins overridden by env must be real origins",
+			config: `
+[webserver]
+port = 5000
+cookie_signing_secret = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+allowed_origins = ["https://client.example"]
+
+[core]
+secret_key = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+
+[core.assets]
+signing_secret = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
+`,
+			env: map[string]string{
+				"CHATTO_WEBSERVER_ALLOWED_ORIGINS": "https://client.example/path",
+			},
+			wantError: "webserver.allowed_origins contains invalid origin",
+		},
+		{
+			name: "OIDC enabled through env must include client secret",
+			env: map[string]string{
+				"CHATTO_WEBSERVER_PORT":                  "4000",
+				"CHATTO_WEBSERVER_URL":                   "https://chat.example",
+				"CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+				"CHATTO_CORE_SECRET_KEY":                 "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+				"CHATTO_CORE_ASSETS_SIGNING_SECRET":      "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
+				"CHATTO_AUTH_OIDC_ENABLED":               "true",
+				"CHATTO_AUTH_OIDC_ISSUER_URL":            "https://id.example",
+				"CHATTO_AUTH_OIDC_CLIENT_ID":             "chatto",
+			},
+			wantError: "auth.oidc.client_secret is required when OIDC is enabled",
+		},
+		{
+			name: "webserver URL from env must include scheme and host",
+			env: map[string]string{
+				"CHATTO_WEBSERVER_PORT":                  "4000",
+				"CHATTO_WEBSERVER_URL":                   "chat.example",
+				"CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+				"CHATTO_CORE_SECRET_KEY":                 "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+				"CHATTO_CORE_ASSETS_SIGNING_SECRET":      "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
+			},
+			wantError: "webserver.url must use http or https",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			originalDir, err := os.Getwd()
+			if err != nil {
+				t.Fatalf("failed to get working directory: %v", err)
+			}
+			if err := os.Chdir(tmpDir); err != nil {
+				t.Fatalf("failed to change to temp directory: %v", err)
+			}
+			t.Cleanup(func() { os.Chdir(originalDir) })
+
+			if tt.config != "" {
+				if err := os.WriteFile(filepath.Join(tmpDir, "chatto.toml"), []byte(tt.config), 0644); err != nil {
+					t.Fatalf("failed to write config file: %v", err)
+				}
+			}
+			for key, value := range tt.env {
+				t.Setenv(key, value)
+			}
+
+			_, err = ReadConfig("")
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("ReadConfig() error = %v, want to contain %q", err, tt.wantError)
+			}
+		})
 	}
 }
 
@@ -170,13 +270,13 @@ log_format = "text"
 
 [webserver]
 port = 5000
-cookie_signing_secret = "file-cookie-secret"
+cookie_signing_secret = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
 [core]
-secret_key = "file-core-secret"
+secret_key = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
 
 [core.assets]
-signing_secret = "file-assets-secret"
+signing_secret = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
 `
 	if err := os.WriteFile(filepath.Join(tmpDir, "chatto.toml"), []byte(configContent), 0644); err != nil {
 		t.Fatalf("failed to write config file: %v", err)
@@ -214,14 +314,14 @@ func TestReadConfig_OAuthRedirectOriginsFromTOMLAndEnv(t *testing.T) {
 	configContent := `
 [webserver]
 port = 5000
-cookie_signing_secret = "file-cookie-secret"
+cookie_signing_secret = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 oauth_redirect_origins = ["https://client.example"]
 
 [core]
-secret_key = "file-core-secret"
+secret_key = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
 
 [core.assets]
-signing_secret = "file-assets-secret"
+signing_secret = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
 `
 	if err := os.WriteFile(filepath.Join(tmpDir, "chatto.toml"), []byte(configContent), 0644); err != nil {
 		t.Fatalf("failed to write config file: %v", err)
@@ -259,13 +359,13 @@ func TestReadConfig_S3PathPrefixFromTOMLAndEnv(t *testing.T) {
 	configContent := `
 [webserver]
 port = 5000
-cookie_signing_secret = "file-cookie-secret"
+cookie_signing_secret = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
 [core]
-secret_key = "file-core-secret"
+secret_key = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
 
 [core.assets]
-signing_secret = "file-assets-secret"
+signing_secret = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
 storage_backend = "s3"
 
 [core.assets.s3]
@@ -273,7 +373,7 @@ endpoint = "s3.amazonaws.com"
 bucket = "test-bucket"
 path_prefix = "/tenant-a/chatto/"
 access_key_id = "test-key"
-secret_access_key = "test-secret"
+secret_access_key = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 `
 	if err := os.WriteFile(filepath.Join(tmpDir, "chatto.toml"), []byte(configContent), 0644); err != nil {
 		t.Fatalf("failed to write config file: %v", err)
@@ -309,9 +409,9 @@ func TestReadConfig_SMTPPolicyFromEnv(t *testing.T) {
 	t.Cleanup(func() { os.Chdir(originalDir) })
 
 	t.Setenv("CHATTO_WEBSERVER_PORT", "4000")
-	t.Setenv("CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET", "test-cookie-secret")
-	t.Setenv("CHATTO_CORE_SECRET_KEY", "test-core-secret")
-	t.Setenv("CHATTO_CORE_ASSETS_SIGNING_SECRET", "test-assets-secret")
+	t.Setenv("CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	t.Setenv("CHATTO_CORE_SECRET_KEY", "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789")
+	t.Setenv("CHATTO_CORE_ASSETS_SIGNING_SECRET", "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff")
 	t.Setenv("CHATTO_SMTP_TLS", "opportunistic")
 
 	cfg, err := ReadConfig("")
@@ -467,14 +567,23 @@ func intPtr(i int) *int {
 	return &i
 }
 
-func TestChattoConfig_Validate_RequiredSecrets(t *testing.T) {
-	base := ChattoConfig{
-		Webserver: WebserverConfig{Port: 4000, CookieSigningSecret: "web-secret"},
+func validTestConfig() ChattoConfig {
+	return ChattoConfig{
+		Webserver: WebserverConfig{
+			Port:                4000,
+			CookieSigningSecret: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		},
 		Core: CoreConfig{
-			SecretKey: "core-secret",
-			Assets:    AssetsConfig{SigningSecret: "asset-secret"},
+			SecretKey: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+			Assets: AssetsConfig{
+				SigningSecret: "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
+			},
 		},
 	}
+}
+
+func TestChattoConfig_Validate_RequiredSecrets(t *testing.T) {
+	base := validTestConfig()
 
 	tests := []struct {
 		name     string
@@ -502,6 +611,27 @@ func TestChattoConfig_Validate_RequiredSecrets(t *testing.T) {
 			},
 			errorMsg: "core.assets.signing_secret is required",
 		},
+		{
+			name: "core secret must be hex",
+			modify: func(c *ChattoConfig) {
+				c.Core.SecretKey = "not-hex"
+			},
+			errorMsg: "core.secret_key must be hex-encoded",
+		},
+		{
+			name: "webserver cookie secret must be 32 bytes",
+			modify: func(c *ChattoConfig) {
+				c.Webserver.CookieSigningSecret = "000102"
+			},
+			errorMsg: "webserver.cookie_signing_secret must decode to 32 bytes",
+		},
+		{
+			name: "asset signing secret must be 32 bytes",
+			modify: func(c *ChattoConfig) {
+				c.Core.Assets.SigningSecret = "000102"
+			},
+			errorMsg: "core.assets.signing_secret must decode to 32 bytes",
+		},
 	}
 
 	for _, tt := range tests {
@@ -517,13 +647,7 @@ func TestChattoConfig_Validate_RequiredSecrets(t *testing.T) {
 }
 
 func TestChattoConfig_Validate_CookieEncryptionSecret(t *testing.T) {
-	base := ChattoConfig{
-		Webserver: WebserverConfig{Port: 4000, CookieSigningSecret: "web-secret"},
-		Core: CoreConfig{
-			SecretKey: "core-secret",
-			Assets:    AssetsConfig{SigningSecret: "asset-secret"},
-		},
-	}
+	base := validTestConfig()
 
 	tests := []struct {
 		name      string
@@ -576,13 +700,7 @@ func TestChattoConfig_Validate_CookieEncryptionSecret(t *testing.T) {
 }
 
 func TestChattoConfig_Validate_LogFormat(t *testing.T) {
-	base := ChattoConfig{
-		Webserver: WebserverConfig{Port: 4000, CookieSigningSecret: "web-secret"},
-		Core: CoreConfig{
-			SecretKey: "core-secret",
-			Assets:    AssetsConfig{SigningSecret: "asset-secret"},
-		},
-	}
+	base := validTestConfig()
 
 	for _, format := range []string{"", "auto", "text", "json", "logfmt", "JSON"} {
 		t.Run("valid_"+format, func(t *testing.T) {
@@ -599,6 +717,302 @@ func TestChattoConfig_Validate_LogFormat(t *testing.T) {
 	err := cfg.Validate()
 	if err == nil || !strings.Contains(err.Error(), "general.log_format must be one of: auto, text, json, logfmt") {
 		t.Fatalf("Validate() error = %v, want invalid log_format error", err)
+	}
+}
+
+func TestChattoConfig_Validate_URLsAndOrigins(t *testing.T) {
+	tests := []struct {
+		name      string
+		modify    func(*ChattoConfig)
+		wantError string
+	}{
+		{
+			name: "valid webserver URL and origins",
+			modify: func(c *ChattoConfig) {
+				c.Webserver.URL = "https://chat.example"
+				c.Webserver.AllowedOrigins = []string{"https://client.example", "http://localhost:5173", "*"}
+				c.Webserver.OAuthRedirectOrigins = []string{"https://client.example", "http://localhost:5173", "*"}
+			},
+		},
+		{
+			name: "webserver URL requires http or https",
+			modify: func(c *ChattoConfig) {
+				c.Webserver.URL = "chat.example"
+			},
+			wantError: "webserver.url must use http or https",
+		},
+		{
+			name: "allowed origin rejects paths",
+			modify: func(c *ChattoConfig) {
+				c.Webserver.AllowedOrigins = []string{"https://client.example/path"}
+			},
+			wantError: "webserver.allowed_origins contains invalid origin",
+		},
+		{
+			name: "OAuth origin requires https outside loopback",
+			modify: func(c *ChattoConfig) {
+				c.Webserver.OAuthRedirectOrigins = []string{"http://client.example"}
+			},
+			wantError: "non-loopback OAuth redirect origins must use https",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validTestConfig()
+			tt.modify(&cfg)
+			err := cfg.Validate()
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatalf("Validate() unexpected error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("Validate() error = %v, want to contain %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestChattoConfig_Validate_OIDC(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.Webserver.URL = "https://chat.example"
+	cfg.Auth.OIDC = OIDCConfig{
+		Enabled:      true,
+		IssuerURL:    "https://id.example",
+		ClientID:     "chatto",
+		ClientSecret: "secret",
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() with complete OIDC config failed: %v", err)
+	}
+	if !cfg.Auth.OIDC.IsConfigured() {
+		t.Fatal("complete OIDC config should be configured")
+	}
+
+	cfg.Auth.OIDC.ClientSecret = ""
+	if cfg.Auth.OIDC.IsConfigured() {
+		t.Fatal("OIDC without client_secret should not be configured")
+	}
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "auth.oidc.client_secret is required when OIDC is enabled") {
+		t.Fatalf("Validate() error = %v, want missing OIDC client secret", err)
+	}
+}
+
+func TestChattoConfig_Validate_EnabledIntegrationsRequireWebserverURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		modify    func(*ChattoConfig)
+		wantError string
+	}{
+		{
+			name: "SMTP",
+			modify: func(c *ChattoConfig) {
+				c.SMTP.Enabled = true
+				c.SMTP.Host = "smtp.example.com"
+				c.SMTP.Port = 587
+				c.SMTP.From = "noreply@example.com"
+			},
+			wantError: "webserver.url is required when SMTP is enabled",
+		},
+		{
+			name: "OIDC",
+			modify: func(c *ChattoConfig) {
+				c.Auth.OIDC = OIDCConfig{
+					Enabled:      true,
+					IssuerURL:    "https://id.example",
+					ClientID:     "chatto",
+					ClientSecret: "secret",
+				}
+			},
+			wantError: "webserver.url is required when OIDC is enabled",
+		},
+		{
+			name: "push",
+			modify: func(c *ChattoConfig) {
+				c.Push.Enabled = true
+				c.Push.VAPIDPublicKey = "public-key"
+				c.Push.VAPIDPrivateKey = "private-key"
+				c.Push.VAPIDSubject = "mailto:admin@example.com"
+			},
+			wantError: "webserver.url is required when push is enabled",
+		},
+		{
+			name: "LiveKit",
+			modify: func(c *ChattoConfig) {
+				c.LiveKit.Enabled = true
+				c.LiveKit.URL = "wss://livekit.example"
+				c.LiveKit.APIKey = "key"
+				c.LiveKit.APISecret = "secret"
+			},
+			wantError: "webserver.url is required when LiveKit is enabled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validTestConfig()
+			tt.modify(&cfg)
+			err := cfg.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("Validate() error = %v, want to contain %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestChattoConfig_ApplyDefaultsAndNormalize(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.Webserver.URL = "https://chat.example"
+	cfg.NATS.Embedded = EmbeddedNATSConfig{
+		Enabled:   true,
+		Port:      4222,
+		AuthToken: "nats-token",
+	}
+	cfg.LiveKit = LiveKitConfig{
+		Enabled:    true,
+		URL:        "wss://livekit.example",
+		APIKey:     "key",
+		APISecret:  "secret",
+		InstanceID: "legacy-server-id",
+	}
+	cfg.Core.Assets.StorageBackend = StorageBackendS3
+	cfg.Core.Assets.S3 = S3Config{
+		Endpoint:        "s3.amazonaws.com",
+		Bucket:          "assets",
+		PathPrefix:      "/tenant/chatto/",
+		AccessKeyID:     "key",
+		SecretAccessKey: "secret",
+	}
+	cfg.Bootstrap.LegacyInstance = &BootstrapServer{Name: "Legacy"}
+	cfg.Bootstrap.Users = []BootstrapUser{{Login: "alice", InstanceRole: "owner"}}
+
+	cfg.ApplyDefaults()
+	cfg.Normalize()
+
+	if cfg.NATS.Client.URL != "nats://127.0.0.1:4222" {
+		t.Fatalf("derived NATS client URL = %q", cfg.NATS.Client.URL)
+	}
+	if cfg.NATS.Client.AuthMethod != NATSAuthToken || cfg.NATS.Client.Token != "nats-token" {
+		t.Fatalf("derived NATS client auth = %q/%q", cfg.NATS.Client.AuthMethod, cfg.NATS.Client.Token)
+	}
+	if cfg.LiveKit.ServerID != "legacy-server-id" {
+		t.Fatalf("LiveKit server ID = %q", cfg.LiveKit.ServerID)
+	}
+	if cfg.LiveKit.WebhookURL != "https://chat.example/webhooks/livekit" {
+		t.Fatalf("LiveKit webhook URL = %q", cfg.LiveKit.WebhookURL)
+	}
+	if cfg.Core.Assets.S3.PathPrefix != "tenant/chatto" {
+		t.Fatalf("normalized S3 prefix = %q", cfg.Core.Assets.S3.PathPrefix)
+	}
+	if cfg.Bootstrap.Server == nil || cfg.Bootstrap.Server.Name != "Legacy" {
+		t.Fatalf("bootstrap server alias was not applied: %+v", cfg.Bootstrap.Server)
+	}
+	if cfg.Bootstrap.Users[0].ServerRole != "owner" {
+		t.Fatalf("bootstrap server_role alias = %q", cfg.Bootstrap.Users[0].ServerRole)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() after defaults failed: %v", err)
+	}
+}
+
+func TestChattoConfig_ValidateDoesNotMutate(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.Webserver.URL = "https://chat.example"
+	cfg.LiveKit = LiveKitConfig{
+		Enabled:   true,
+		URL:       "wss://livekit.example",
+		APIKey:    "key",
+		APISecret: "secret",
+	}
+	cfg.Core.Assets.StorageBackend = StorageBackendS3
+	cfg.Core.Assets.S3 = S3Config{
+		Endpoint:        "s3.amazonaws.com",
+		Bucket:          "assets",
+		PathPrefix:      "/tenant/chatto/",
+		AccessKeyID:     "key",
+		SecretAccessKey: "secret",
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() unexpected error = %v", err)
+	}
+	if cfg.LiveKit.WebhookURL != "" {
+		t.Fatalf("Validate() mutated LiveKit webhook URL to %q", cfg.LiveKit.WebhookURL)
+	}
+	if cfg.Core.Assets.S3.PathPrefix != "/tenant/chatto/" {
+		t.Fatalf("Validate() mutated S3 path prefix to %q", cfg.Core.Assets.S3.PathPrefix)
+	}
+}
+
+func TestChattoConfig_Validate_NATSClientTokenMatchesEmbedded(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.NATS.Embedded = EmbeddedNATSConfig{
+		Enabled:   true,
+		Port:      4222,
+		AuthToken: "embedded-token",
+	}
+	cfg.NATS.Client = NATSClientConfig{
+		AuthMethod: NATSAuthToken,
+		Token:      "other-token",
+	}
+
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "nats.client.token must match nats.embedded.auth_token") {
+		t.Fatalf("Validate() error = %v, want NATS token mismatch", err)
+	}
+}
+
+func TestReadConfig_DeprecatedServerAliases(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(originalDir) })
+
+	configContent := `
+[webserver]
+port = 4000
+cookie_signing_secret = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+[core]
+secret_key = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+
+[core.assets]
+signing_secret = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
+
+[livekit]
+instance_id = "legacy-server-id"
+
+[[bootstrap.users]]
+login = "alice"
+instance_role = "owner"
+
+[bootstrap.instance]
+name = "Legacy Bootstrap"
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "chatto.toml"), []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	cfg, err := ReadConfig("")
+	if err != nil {
+		t.Fatalf("ReadConfig() failed: %v", err)
+	}
+	if cfg.LiveKit.ServerID != "legacy-server-id" {
+		t.Fatalf("LiveKit legacy instance_id alias = %q", cfg.LiveKit.ServerID)
+	}
+	if cfg.Bootstrap.Server == nil || cfg.Bootstrap.Server.Name != "Legacy Bootstrap" {
+		t.Fatalf("bootstrap legacy instance alias = %+v", cfg.Bootstrap.Server)
+	}
+	if got := cfg.Bootstrap.Users[0].ServerRole; got != "owner" {
+		t.Fatalf("bootstrap legacy instance_role alias = %q", got)
 	}
 }
 
@@ -631,13 +1045,13 @@ func TestReadConfig_LimitsFromTOML(t *testing.T) {
 	configContent := `
 [webserver]
 port = 4000
-cookie_signing_secret = "x"
+cookie_signing_secret = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
 [core]
-secret_key = "z"
+secret_key = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
 
 [core.assets]
-signing_secret = "y"
+signing_secret = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
 
 [limits]
 max_users = -1
@@ -664,9 +1078,9 @@ func TestReadConfig_LimitsFromEnv(t *testing.T) {
 	t.Cleanup(func() { os.Chdir(originalDir) })
 
 	t.Setenv("CHATTO_WEBSERVER_PORT", "4000")
-	t.Setenv("CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET", "x")
-	t.Setenv("CHATTO_CORE_SECRET_KEY", "z")
-	t.Setenv("CHATTO_CORE_ASSETS_SIGNING_SECRET", "y")
+	t.Setenv("CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	t.Setenv("CHATTO_CORE_SECRET_KEY", "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789")
+	t.Setenv("CHATTO_CORE_ASSETS_SIGNING_SECRET", "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff")
 	t.Setenv("CHATTO_LIMITS_MAX_USERS", "0")
 
 	cfg, err := ReadConfig("")
@@ -681,8 +1095,8 @@ func TestReadConfig_LimitsFromEnv(t *testing.T) {
 func TestChattoConfig_Validate_Limits(t *testing.T) {
 	base := func() ChattoConfig {
 		return ChattoConfig{
-			Webserver: WebserverConfig{Port: 4000, CookieSigningSecret: "x"},
-			Core:      CoreConfig{SecretKey: "z", Assets: AssetsConfig{SigningSecret: "y"}},
+			Webserver: WebserverConfig{Port: 4000, CookieSigningSecret: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"},
+			Core:      CoreConfig{SecretKey: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789", Assets: AssetsConfig{SigningSecret: "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"}},
 		}
 	}
 
@@ -710,12 +1124,12 @@ func TestChattoConfig_Validate_TLS(t *testing.T) {
 		return ChattoConfig{
 			Webserver: WebserverConfig{
 				Port:                4000,
-				CookieSigningSecret: "test-secret",
+				CookieSigningSecret: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 			},
 			Core: CoreConfig{
-				SecretKey: "test-core-secret",
+				SecretKey: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
 				Assets: AssetsConfig{
-					SigningSecret: "test-asset-secret",
+					SigningSecret: "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
 				},
 			},
 		}
@@ -833,12 +1247,12 @@ func TestChattoConfig_Validate_EmbeddedNATS(t *testing.T) {
 		return ChattoConfig{
 			Webserver: WebserverConfig{
 				Port:                4000,
-				CookieSigningSecret: "test-secret",
+				CookieSigningSecret: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 			},
 			Core: CoreConfig{
-				SecretKey: "test-core-secret",
+				SecretKey: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
 				Assets: AssetsConfig{
-					SigningSecret: "test-asset-secret",
+					SigningSecret: "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
 				},
 			},
 			NATS: NATSConfig{
@@ -961,12 +1375,12 @@ func TestChattoConfig_Validate_SMTP(t *testing.T) {
 		return ChattoConfig{
 			Webserver: WebserverConfig{
 				Port:                4000,
-				CookieSigningSecret: "test-secret",
+				CookieSigningSecret: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 			},
 			Core: CoreConfig{
-				SecretKey: "test-core-secret",
+				SecretKey: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
 				Assets: AssetsConfig{
-					SigningSecret: "test-asset-secret",
+					SigningSecret: "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
 				},
 			},
 		}
@@ -986,6 +1400,7 @@ func TestChattoConfig_Validate_SMTP(t *testing.T) {
 		{
 			name: "valid config with SMTP",
 			modify: func(c *ChattoConfig) {
+				c.Webserver.URL = "https://chat.example"
 				c.SMTP.Enabled = true
 				c.SMTP.Host = "smtp.example.com"
 				c.SMTP.Port = 587
@@ -996,6 +1411,7 @@ func TestChattoConfig_Validate_SMTP(t *testing.T) {
 		{
 			name: "valid config with explicit mandatory SMTP TLS",
 			modify: func(c *ChattoConfig) {
+				c.Webserver.URL = "https://chat.example"
 				c.SMTP.Enabled = true
 				c.SMTP.Host = "smtp.example.com"
 				c.SMTP.Port = 587
@@ -1007,6 +1423,7 @@ func TestChattoConfig_Validate_SMTP(t *testing.T) {
 		{
 			name: "valid config with explicit opportunistic SMTP TLS",
 			modify: func(c *ChattoConfig) {
+				c.Webserver.URL = "https://chat.example"
 				c.SMTP.Enabled = true
 				c.SMTP.Host = "smtp.example.com"
 				c.SMTP.Port = 587
@@ -1092,12 +1509,12 @@ func TestChattoConfig_Validate_S3(t *testing.T) {
 		return ChattoConfig{
 			Webserver: WebserverConfig{
 				Port:                4000,
-				CookieSigningSecret: "test-secret",
+				CookieSigningSecret: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 			},
 			Core: CoreConfig{
-				SecretKey: "test-core-secret",
+				SecretKey: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
 				Assets: AssetsConfig{
-					SigningSecret: "test-asset-secret",
+					SigningSecret: "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
 				},
 			},
 		}
@@ -1123,7 +1540,7 @@ func TestChattoConfig_Validate_S3(t *testing.T) {
 					Bucket:          "test-bucket",
 					Region:          "us-east-1",
 					AccessKeyID:     "test-key",
-					SecretAccessKey: "test-secret",
+					SecretAccessKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 				}
 			},
 			wantError: false,
@@ -1137,7 +1554,7 @@ func TestChattoConfig_Validate_S3(t *testing.T) {
 					Bucket:          "test-bucket",
 					PathPrefix:      "/",
 					AccessKeyID:     "test-key",
-					SecretAccessKey: "test-secret",
+					SecretAccessKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 				}
 			},
 			wantError: false,
@@ -1151,7 +1568,7 @@ func TestChattoConfig_Validate_S3(t *testing.T) {
 					Bucket:          "test-bucket",
 					PathPrefix:      "/tenant-a/chatto/",
 					AccessKeyID:     "test-key",
-					SecretAccessKey: "test-secret",
+					SecretAccessKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 				}
 			},
 			wantError: false,
@@ -1165,7 +1582,7 @@ func TestChattoConfig_Validate_S3(t *testing.T) {
 					Bucket:          "test-bucket",
 					PathPrefix:      "tenant//chatto",
 					AccessKeyID:     "test-key",
-					SecretAccessKey: "test-secret",
+					SecretAccessKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 				}
 			},
 			wantError: true,
@@ -1180,7 +1597,7 @@ func TestChattoConfig_Validate_S3(t *testing.T) {
 					Bucket:          "test-bucket",
 					PathPrefix:      "tenant\nchatto",
 					AccessKeyID:     "test-key",
-					SecretAccessKey: "test-secret",
+					SecretAccessKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 				}
 			},
 			wantError: true,
@@ -1193,7 +1610,7 @@ func TestChattoConfig_Validate_S3(t *testing.T) {
 				c.Core.Assets.S3 = S3Config{
 					Bucket:          "test-bucket",
 					AccessKeyID:     "test-key",
-					SecretAccessKey: "test-secret",
+					SecretAccessKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 				}
 			},
 			wantError: true,
@@ -1206,7 +1623,7 @@ func TestChattoConfig_Validate_S3(t *testing.T) {
 				c.Core.Assets.S3 = S3Config{
 					Endpoint:        "s3.amazonaws.com",
 					AccessKeyID:     "test-key",
-					SecretAccessKey: "test-secret",
+					SecretAccessKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 				}
 			},
 			wantError: true,
@@ -1219,7 +1636,7 @@ func TestChattoConfig_Validate_S3(t *testing.T) {
 				c.Core.Assets.S3 = S3Config{
 					Endpoint:        "s3.amazonaws.com",
 					Bucket:          "test-bucket",
-					SecretAccessKey: "test-secret",
+					SecretAccessKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 				}
 			},
 			wantError: true,
@@ -1391,12 +1808,12 @@ func TestChattoConfig_Validate_Push(t *testing.T) {
 		return ChattoConfig{
 			Webserver: WebserverConfig{
 				Port:                4000,
-				CookieSigningSecret: "test-secret",
+				CookieSigningSecret: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 			},
 			Core: CoreConfig{
-				SecretKey: "test-core-secret",
+				SecretKey: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
 				Assets: AssetsConfig{
-					SigningSecret: "test-asset-secret",
+					SigningSecret: "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
 				},
 			},
 		}
@@ -1416,6 +1833,7 @@ func TestChattoConfig_Validate_Push(t *testing.T) {
 		{
 			name: "valid config with push",
 			modify: func(c *ChattoConfig) {
+				c.Webserver.URL = "https://chat.example"
 				c.Push.Enabled = true
 				c.Push.VAPIDPublicKey = "public-key"
 				c.Push.VAPIDPrivateKey = "private-key"

--- a/docs-website/src/content/docs/getting-started/quick-start.mdx
+++ b/docs-website/src/content/docs/getting-started/quick-start.mdx
@@ -111,9 +111,4 @@ bind_address = "127.0.0.1"
 http_port = 8222
 data_dir = "./data"
 auth_token = "<generated>"
-
-[nats.client]
-url = "nats://localhost:4222"
-auth_method = "token"
-token = "<generated>"
 ```

--- a/docs-website/src/content/docs/guides/horizontal-scaling.mdx
+++ b/docs-website/src/content/docs/guides/horizontal-scaling.mdx
@@ -121,13 +121,13 @@ startupProbe:
 
 ## Voice and Video Calls with Multiple Server Processes
 
-If you're using LiveKit for calls, set a unique `instance_id` on each Chatto server process so LiveKit webhooks are routed correctly:
+If you're using LiveKit for calls, set the same `server_id` on every replica of one Chatto server. Use a different value only for different Chatto servers that share the same LiveKit cluster:
 
 ```bash
-CHATTO_LIVEKIT_INSTANCE_ID=server-1
+CHATTO_LIVEKIT_SERVER_ID=server-1
 ```
 
-The `instance_id` is prefixed to LiveKit room names, allowing the webhook handler to identify which Chatto server process should process each event. Without it, webhooks may be misrouted when multiple server processes share a LiveKit cluster.
+The `server_id` is prefixed to deterministic LiveKit room names, allowing the webhook handler to identify which Chatto server owns each event. If replicas of the same Chatto server use different values, users routed to different replicas can receive tokens for different LiveKit rooms for the same Chatto room.
 
 ## Load Balancing
 
@@ -149,7 +149,7 @@ The [Docker Compose deployment guide](/guides/dockercompose/) includes a Caddy c
 | `core.secret_key` | Yes | Bearer-token and account-flow verifier keys |
 | `core.assets.signing_secret` | Yes | Asset URL signing |
 | `webserver.url` | Yes | Public URL for absolute links |
-| `livekit.instance_id` | **No** — must be unique | Webhook routing |
+| `livekit.server_id` | Yes, within one Chatto server | Use a different value only across Chatto servers sharing one LiveKit cluster |
 
 <CardGrid>
   <LinkCard title="High Availability" href="/guides/high-availability/" description="NATS clustering and JetStream replication for fault tolerance." />

--- a/docs-website/src/content/docs/reference/environment-variables.mdx
+++ b/docs-website/src/content/docs/reference/environment-variables.mdx
@@ -170,7 +170,7 @@ Only used when `storage_backend` is set to `s3`. See the [S3 Storage guide](/gui
 </EnvVar>
 
 <EnvVar name="CHATTO_NATS_EMBEDDED_AUTH_TOKEN" toml="nats.embedded.auth_token">
-  Auth token for the embedded NATS server. Must match `CHATTO_NATS_CLIENT_TOKEN` when using token auth.
+  Auth token for the embedded NATS server. For embedded mode, Chatto derives matching `nats.client` defaults for CLI/admin commands unless you override them explicitly.
 </EnvVar>
 
 ### Client
@@ -184,7 +184,7 @@ Only used when `storage_backend` is set to `s3`. See the [S3 Storage guide](/gui
 </EnvVar>
 
 <EnvVar name="CHATTO_NATS_CLIENT_TOKEN" toml="nats.client.token">
-  NATS auth token (when using `token` auth method). Must match `CHATTO_NATS_EMBEDDED_AUTH_TOKEN` when using the embedded server.
+  NATS auth token (when using `token` auth method). When explicitly set alongside embedded NATS, it must match `CHATTO_NATS_EMBEDDED_AUTH_TOKEN`.
 </EnvVar>
 
 <EnvVar name="CHATTO_NATS_CLIENT_USERNAME" toml="nats.client.username">
@@ -331,12 +331,12 @@ Only used when `storage_backend` is set to `s3`. See the [S3 Storage guide](/gui
   URL where LiveKit sends webhook events. Defaults to `{webserver.url}/webhooks/livekit`.
 </EnvVar>
 
-<EnvVar name="CHATTO_LIVEKIT_INSTANCE_ID" toml="livekit.instance_id">
-  Unique identifier for this Chatto server process, prefixed to LiveKit room names. Required when multiple Chatto replicas share the same LiveKit cluster, so that webhook events can be routed correctly. When empty, room names use the unprefixed format.
+<EnvVar name="CHATTO_LIVEKIT_SERVER_ID" toml="livekit.server_id">
+  Unique identifier for this Chatto server, prefixed to deterministic LiveKit room names. This value must match across replicas of one Chatto server, and should differ only across different Chatto servers sharing the same LiveKit cluster. When empty, room names use the unprefixed format. The old `CHATTO_LIVEKIT_INSTANCE_ID` / `livekit.instance_id` name is still accepted as a deprecated alias.
 </EnvVar>
 
 <EnvVar name="CHATTO_LIVEKIT_WEBHOOK_API_KEY" toml="livekit.webhook_api_key">
-  API key that LiveKit uses to sign webhook requests. When multiple Chatto replicas share a LiveKit cluster, the webhook signing key may differ from the per-replica API key. Falls back to `CHATTO_LIVEKIT_API_KEY` when not set.
+  API key that LiveKit uses to sign webhook requests. When multiple Chatto servers share a LiveKit cluster, the webhook signing key may differ from the per-server API key. Falls back to `CHATTO_LIVEKIT_API_KEY` when not set.
 </EnvVar>
 
 <EnvVar name="CHATTO_LIVEKIT_WEBHOOK_API_SECRET" toml="livekit.webhook_api_secret">

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,29 +46,28 @@ This document uses the canonical terms from the [glossary](GLOSSARY.md), especia
 
 ## NATS Authentication
 
-Chatto supports multiple methods for authenticating with NATS, configured via `[nats.client]` in `chatto.toml`:
+Chatto supports embedded NATS for single-process/self-hosted installs and external NATS for clustered deployments. Embedded NATS is configured under `[nats.embedded]`; when the embedded TCP listener is enabled, `ReadConfig` derives matching `[nats.client]` defaults for CLI/admin commands. External NATS connections are configured explicitly via `[nats.client]`.
 
-| Method        | Config             | Description                                                      |
-| ------------- | ------------------ | ---------------------------------------------------------------- |
-| `nkey`        | `nkey_seed`        | Default for embedded NATS. Uses Ed25519 keypairs.                |
-| `userpass`    | `username`, `password` | Simple username/password authentication.                      |
-| `credentials` | `credentials_file` | JWT authentication via standard `.creds` file (for external NATS). |
-| `none`        | -                  | No authentication (for trusted networks only).                   |
+| Method        | Config                                  | Description                                                       |
+| ------------- | --------------------------------------- | ----------------------------------------------------------------- |
+| `token`       | `token` / `nats.embedded.auth_token`    | Default for embedded NATS and simple external deployments.        |
+| `userpass`    | `username`, `password`                  | Simple username/password authentication.                          |
+| `credentials` | `credentials_file`                      | JWT authentication via standard `.creds` file for external NATS.  |
+| `nkey`        | `nkey_seed`                             | NKey seed auth for external NATS deployments that use NKeys.      |
+| `none`        | -                                       | No authentication; only acceptable on trusted private networks.   |
 
 **Embedded NATS Setup:**
 
 When using embedded NATS (default), `chatto init` generates:
-- `chatto.toml` with NKey seed in `[nats.client]`
-- `nats-server.conf` with the corresponding public key in `authorization.users`
-
-The `nats-server.conf` file is auto-generated on first startup if missing. Users can edit it to add clustering, TLS, or additional authorization rules.
+- `chatto.toml` with `[nats.embedded]`, a local TCP listener, JetStream data directory, and generated `auth_token`
+- Derived `[nats.client]` connection defaults at config-load time so CLI commands can connect to the embedded server without duplicating the token in the file
 
 **External NATS Setup:**
 
-For connecting to an external NATS cluster with JWT authentication:
+For connecting to an external NATS cluster:
 1. Set `nats.embedded.enabled = false`
-2. Set `nats.client.auth_method = "credentials"`
-3. Set `nats.client.credentials_file = "path/to/your.creds"`
+2. Set `nats.client.url` to the external NATS URL(s)
+3. Set `nats.client.auth_method` plus the matching credential field (`token`, `username`/`password`, `credentials_file`, or `nkey_seed`)
 
 ## Architecture & APIs
 

--- a/docs/adr/ADR-030-space-tier-retirement.md
+++ b/docs/adr/ADR-030-space-tier-retirement.md
@@ -62,7 +62,7 @@ Out of scope (deferred):
 - **`space.{spaceId}` KV record**: stays as orphan. One small entry per deployment, no readers post-Phase-1.
 - **`ServerMemberDeletedEvent` proto message** (`corev1.Event` field 320): renamed during the 0.1 protobuf cleanup while preserving the field number. No 0.1 servers had been deployed yet, and 0.0 import remains field-number based, so the source name could still be corrected before beta.
 - **`space_id` fields on other persisted event payloads** (e.g. message events): stay for the same reason — wire format must decode existing stored events.
-- **`KV_INSTANCE*` bucket names, `instance.logo`/`instance.banner` KV keys, `/api/instance` REST endpoint, `livekit.instance_id` config**: stay. Already covered by ADR-029.
+- **`KV_INSTANCE*` bucket names, `instance.logo`/`instance.banner` KV keys, `/api/instance` REST endpoint**: stay. Already covered by ADR-029. The public LiveKit config key was later renamed from `livekit.instance_id` to `livekit.server_id`, with the old name retained as a deprecated alias for existing configs.
 
 ### Phases (PR boundaries)
 

--- a/frontend/e2e/fixtures/chatto.toml
+++ b/frontend/e2e/fixtures/chatto.toml
@@ -19,10 +19,10 @@ cookie_signing_secret = '327201ce7e1a01980daac57c941f754a0fde9f08180d5e72599054d
 
 # Core service configuration.
 [core]
-secret_key = 'e2e-test-core-secret-do-not-use-in-production'
+secret_key = 'e2e0000000000000000000000000000000000000000000000000000000000001'
 
 [core.assets]
-signing_secret = 'e2e-test-signing-secret-do-not-use-in-production'
+signing_secret = 'e2e0000000000000000000000000000000000000000000000000000000000002'
 max_upload_size = '25 MB'
 
 # Authentication configuration.
@@ -54,12 +54,12 @@ login = 'e2eadmin'
 display_name = 'Admin User'
 email = 'e2eadmin@test.local'
 password = 'adminpassword123'
-instance_role = 'owner'
+server_role = 'owner'
 
-# Bootstrap the deployment's instance config (per ADR-027 the instance IS the
+# Bootstrap the deployment's server config (per ADR-027 the server is the
 # server — there is no separately-named "space" concept any more). New users
-# created during tests auto-join the instance, so most tests can drop their
+# created during tests auto-join the server, so most tests can drop their
 # per-test createSpace setup.
-[bootstrap.instance]
+[bootstrap.server]
 name = 'E2E Test Server'
-description = 'Bootstrap instance used by every e2e test.'
+description = 'Bootstrap server used by every e2e test.'


### PR DESCRIPTION
- Tightens resolved config validation for required 32-byte hex secrets, webserver URLs/origins, enabled OIDC, and integrations that need `webserver.url`.
- Splits derived defaults/normalization from pure validation, derives embedded NATS client defaults, and removes duplicate generated `[nats.client]` config.
- Renames public LiveKit/bootstrap config toward Server terminology while retaining compatibility aliases for existing `instance_*` keys.
- Updates tests, E2E fixtures, and docs for the stricter 0.1.0 config surface.

Compatibility note: intended/operator-generated configs remain compatible, but malformed existing TOML, env overrides, or manually edited preserved Secrets can now fail startup instead of being accepted.

Tests:
- `mise x -- go test ./internal/config ./cmd`
- `mise x -- go test ./cmd -tags bootstrap`
- `mise x -- go test ./internal/config ./cmd -run 'Test(ReadConfig|ChattoConfig|InitGeneratesCoreSecret|Bootstrap)' -timeout 60s`
- `mise x -- pnpm exec playwright test e2e/auth.test.ts --retries=0 --workers=1`
- `mise test-e2e` (634 passed, 1 flaky passed on retry)
- `git diff --check`
