### PR TITLE
chore: remove legacy server bodies cleanup

### DIFF
--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -898,7 +898,6 @@ func (c *ChattoCore) Subscribe(ctx context.Context, subject string, handler nats
 type storage struct {
 	encryptionKV   jetstream.KeyValue // ENCRYPTION_KEYS - KMS KEKs (excluded from backups)
 	runtimeStateKV jetstream.KeyValue // RUNTIME_STATE  - persisted latest-value runtime/user state + wrapped app DEKs
-	serverBodiesKV jetstream.KeyValue // SERVER_BODIES    - legacy message bodies retained for cleanup
 
 	serverAssets    jetstream.ObjectStore // SERVER_ASSETS - all NATS-backed asset binaries
 	serverEvtStream jetstream.Stream      // EVT       - event-sourcing log (ADR-033/034).
@@ -965,11 +964,6 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		}
 	}
 
-	serverBodiesKV, err := openLegacyKeyValue(ctx, js, "SERVER_BODIES")
-	if err != nil {
-		return nil, fmt.Errorf("failed to open legacy SERVER_BODIES KV bucket: %w", err)
-	}
-
 	serverAssets, err := js.CreateOrUpdateObjectStore(ctx, jetstream.ObjectStoreConfig{
 		Bucket:      "SERVER_ASSETS",
 		Description: "Server asset binaries (avatars, branding, link previews, attachments)",
@@ -1010,23 +1004,11 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 	return &storage{
 		encryptionKV:    encryptionKV,
 		runtimeStateKV:  runtimeStateKV,
-		serverBodiesKV:  serverBodiesKV,
 		serverAssets:    serverAssets,
 		serverEvtStream: serverEvtStream,
 		memoryCacheKV:   memoryCacheKV,
 		imageCacheStore: imageCacheStore,
 	}, nil
-}
-
-func openLegacyKeyValue(ctx context.Context, js jetstream.JetStream, bucket string) (jetstream.KeyValue, error) {
-	kv, err := js.KeyValue(ctx, bucket)
-	if err == nil {
-		return kv, nil
-	}
-	if errors.Is(err, jetstream.ErrBucketNotFound) {
-		return nil, nil
-	}
-	return nil, err
 }
 
 // ============================================================================
@@ -1080,13 +1062,6 @@ func roomKeyPrefix(kind RoomKind) string {
 // trying again).
 func roomNameIndexKey(name string) string {
 	return fmt.Sprintf("room_name_index.%s", strings.ToLower(strings.TrimSpace(name)))
-}
-
-// messageBodyKey returns the KV key for a message body in a bodies bucket.
-// The key format is {userID}.{bodyID} to enable efficient prefix-based filtering
-// when deleting all message bodies for a specific user.
-func messageBodyKey(userID, messageBodyID string) string {
-	return userID + "." + messageBodyID
 }
 
 // eventIDFromBodyKey extracts the event ID portion from a message body key.

--- a/cli/internal/core/message_body.go
+++ b/cli/internal/core/message_body.go
@@ -6,9 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/nats-io/nats.go/jetstream"
-	"google.golang.org/protobuf/proto"
-
 	"hmans.de/chatto/internal/encryption"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
@@ -172,65 +169,3 @@ func (c *ChattoCore) decryptMessageBody(ctx context.Context, eventID, roomID str
 // publish path. Body keys have the legacy format {userId}.{eventId};
 // the projection-backed body readers in this file consult it to
 // extract the event-id portion.)
-
-// deleteUserMessageBodiesInSpace deletes all message bodies authored
-// by a user in a specific space's legacy SERVER_BODIES bucket.
-//
-// This is retained for GDPR / account-deletion cleanup of the legacy
-// bucket during the migration window. Once ADR-035 phase 7
-// decommissions SERVER_BODIES, this becomes a no-op and can be
-// removed alongside the bucket. New posts (post-cutover) don't write
-// to SERVER_BODIES at all, so this function only touches data
-// imported from before the cutover.
-//
-// Returns the number of legacy body entries deleted.
-func (c *ChattoCore) deleteUserMessageBodiesInSpace(ctx context.Context, userID string, kind RoomKind) (int, error) {
-	bucket := c.storage.serverBodiesKV
-	if bucket == nil {
-		return 0, nil
-	}
-
-	lister, err := bucket.ListKeysFiltered(ctx, userID+".>")
-	if err != nil {
-		if errors.Is(err, jetstream.ErrNoKeysFound) {
-			return 0, nil
-		}
-		return 0, fmt.Errorf("failed to list message body keys: %w", err)
-	}
-
-	var keys []string
-	for key := range lister.Keys() {
-		keys = append(keys, key)
-	}
-
-	deleted := 0
-	for _, key := range keys {
-		entry, err := bucket.Get(ctx, key)
-		if err != nil {
-			c.logger.Debug("Failed to get message body during deletion", "key", key, "error", err)
-			continue
-		}
-
-		var messageBody corev1.MessageBody
-		if err := proto.Unmarshal(entry.Value(), &messageBody); err != nil {
-			c.logger.Debug("Failed to unmarshal message body during deletion", "key", key, "error", err)
-			continue
-		}
-
-		for _, attachment := range c.MessageBodyAttachments(&messageBody) {
-			if err := c.DeleteAttachmentFromStorage(ctx, attachment); err != nil {
-				c.logger.Warn("Failed to delete attachment during user deletion",
-					"attachment_id", attachment.Id,
-					"message_body_key", key,
-					"error", err)
-			}
-		}
-
-		if err := bucket.Delete(ctx, key); err != nil {
-			c.logger.Warn("Failed to delete message body during user deletion", "key", key, "error", err)
-			continue
-		}
-		deleted++
-	}
-	return deleted, nil
-}

--- a/cli/internal/core/messages.go
+++ b/cli/internal/core/messages.go
@@ -381,7 +381,7 @@ func (c *ChattoCore) appendMessageWithOptionalThreadCreated(ctx context.Context,
 
 // PostMessage posts a message to a room. Publishes a
 // MessagePostedEvent on evt.room.{R}.message_posted with the
-// encrypted body embedded — no separate SERVER_BODIES write.
+// encrypted body in a companion MessageBodyEvent.
 //
 // Threading: inThread is the event ID of the thread root for replies,
 // empty for root posts. If inThread is empty but inReplyTo points at

--- a/cli/internal/core/room_timeline_projection.go
+++ b/cli/internal/core/room_timeline_projection.go
@@ -40,10 +40,8 @@ type RoomTimelineProjection struct {
 	// echoLinks maps an original message's event_id to the event_ids
 	// of any echoes pointing at it. Maintained as MessagePostedEvents
 	// with EchoOfEventId arrive. Used by EditMessage / DeleteMessage
-	// to fan mutations across linked messages — pre-cutover the
-	// echo + original shared a messageBodyId, so an edit on either
-	// updated both via the shared SERVER_BODIES entry; post-cutover
-	// each has its own projected body payload and we need explicit
+	// to fan mutations across linked messages. Each echo has its own
+	// projected body payload, so edits and retractions need explicit
 	// propagation.
 	echoLinks map[string][]string
 	// hiddenEchoes tracks echo MessagePostedEvents that were directly

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -952,16 +952,6 @@ func (c *ChattoCore) DeleteUser(ctx context.Context, actorID, userID string) err
 	// cleanup iterates each kind.
 	allKinds := []RoomKind{KindChannel, KindDM}
 
-	// Delete all message bodies authored by this user
-	for _, kind := range allKinds {
-		deleted, err := c.deleteUserMessageBodiesInSpace(ctx, userID, kind)
-		if err != nil {
-			c.logger.Warn("Failed to delete message bodies", "user_id", userID, "kind", kind, "error", err)
-		} else if deleted > 0 {
-			c.logger.Info("Deleted message bodies during user deletion", "user_id", userID, "kind", kind, "count", deleted)
-		}
-	}
-
 	// Delete encryption key (crypto-shreds any remaining encrypted data) and
 	// record the durable shred signal projections use to tombstone messages
 	// before decrypting.


### PR DESCRIPTION
Follow-up to #596.

- Removes the optional `SERVER_BODIES` KV handle and legacy body-cleanup helper from core storage.
- Drops the account-deletion scan of legacy message body records now that message bodies live in EVT-backed projections.
- Updates stale comments around message body projection and echo propagation.

Tests:
- `mise x -- go test ./internal/core ./internal/events -count=1 -timeout 90s`
