### PR TITLE
chore: tighten mise task inputs

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -8,7 +8,7 @@ export CHATTO_WEBSERVER_PORT="$CONDUCTOR_PORT"
 export CHATTO_WEBSERVER_URL="http://localhost:$CONDUCTOR_PORT"
 export CHATTO_NATS_EMBEDDED_PORT="$((CONDUCTOR_PORT+1))"
 export CHATTO_NATS_CLIENT_URL="nats://localhost:$((CONDUCTOR_PORT+1))"
-GOFLAGS="-tags=bootstrap" mise run build-cli
+mise run build-dev-cli
 cd cli
 exec bin/chatto run
 """

--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -8,7 +8,7 @@ export CHATTO_WEBSERVER_PORT="$CONDUCTOR_PORT"
 export CHATTO_WEBSERVER_URL="http://localhost:$CONDUCTOR_PORT"
 export CHATTO_NATS_EMBEDDED_PORT="$((CONDUCTOR_PORT+1))"
 export CHATTO_NATS_CLIENT_URL="nats://localhost:$((CONDUCTOR_PORT+1))"
-GOFLAGS="-tags=bootstrap" mise run --force build-cli
+GOFLAGS="-tags=bootstrap" mise run build-cli
 cd cli
 exec bin/chatto run
 """

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Chatto is not accepting outside contributions at this time, but feedback, bug re
 | `$CONDUCTOR_PORT` | Chatto webserver (user-facing URL) |
 | `+1`              | Embedded NATS                      |
 
-The repository-level Conductor settings are shared in `.conductor/settings.toml`. The run command builds the frontend and CLI, then starts `bin/chatto run` without live reloads. Put machine-specific overrides in `.conductor/settings.local.toml`; that file is gitignored and wins over shared settings on your machine. Conductor also reads `.worktreeinclude` to copy gitignored local environment files, such as `.env` and `.env.*`, into new workspaces.
+The repository-level Conductor settings are shared in `.conductor/settings.toml`. The run command builds the frontend and development CLI, then starts `bin/chatto run` without live reloads. Put machine-specific overrides in `.conductor/settings.local.toml`; that file is gitignored and wins over shared settings on your machine. Conductor also reads `.worktreeinclude` to copy gitignored local environment files, such as `.env` and `.env.*`, into new workspaces.
 
 ## Developing Outside of Conductor
 
@@ -29,7 +29,7 @@ export CHATTO_WEBSERVER_PORT=4000
 export CHATTO_WEBSERVER_URL=http://localhost:4000
 export CHATTO_NATS_EMBEDDED_PORT=4555
 export CHATTO_NATS_CLIENT_URL=nats://localhost:4555
-mise run build-cli
+mise run build-dev-cli
 cd cli
 bin/chatto run
 ```

--- a/mise.toml
+++ b/mise.toml
@@ -111,11 +111,11 @@ sources = [
 ]
 outputs = ["build/.mise-build-stamp", "../cli/internal/http_server/.client/.gitkeep"]
 
-[tasks.build-cli]
-description = "Build the CLI application for the current architecture"
+[tasks.build-dev-cli]
+description = "Build the development CLI application for the current architecture"
 depends = ["deps-cli", "build-frontend"]
 dir = "cli"
-run = "go build -o bin/chatto ."
+run = "go build -tags bootstrap -o bin/chatto ."
 sources = [
     "go.mod",
     "go.sum",
@@ -237,8 +237,8 @@ run = "bin/chatto run"
 description = "Clean all build artifacts"
 run = [
     "rm -rf cli/bin/*",
-    "rm -rf cli/internal/http_server/.client/*",
-    "rm -rf frontend/build/*",
+    "rm -rf cli/internal/http_server/.client",
+    "rm -rf frontend/build",
 ]
 
 [tasks.reset-config]

--- a/mise.toml
+++ b/mise.toml
@@ -30,7 +30,9 @@ sources = ["go.mod", "go.sum"]
 description = "Install frontend dependencies"
 dir = "frontend"
 run = "pnpm install"
-sources = ["package.json", "pnpm-lock.yaml"]
+# package.json also contains app metadata and scripts; the lockfile is the
+# dependency-resolution input that should trigger installs.
+sources = ["pnpm-lock.yaml", "pnpm-workspace.yaml", ".npmrc"]
 
 [tasks.deps]
 description = "Install all dependencies"
@@ -87,26 +89,43 @@ dir = "frontend"
 run = [
     "pnpm svelte-kit sync",
     "pnpm build",
+    "touch build/.mise-build-stamp",
     "rm -rf ../cli/internal/http_server/.client",
     "cp -r build ../cli/internal/http_server/.client",
     "touch ../cli/internal/http_server/.client/.gitkeep",
 ]
 sources = [
+    ".npmrc",
     "package.json",
     "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
     "src/**/*",
+    "!src/**/*.spec.*",
+    "!src/**/*.test.*",
+    "!src/**/*.stories.*",
+    "!src/**/*TestHarness.svelte",
     "static/**/*",
     "svelte.config.js",
     "tsconfig.json",
     "vite.config.ts",
 ]
+outputs = ["build/.mise-build-stamp", "../cli/internal/http_server/.client/.gitkeep"]
 
 [tasks.build-cli]
 description = "Build the CLI application for the current architecture"
 depends = ["deps-cli", "build-frontend"]
 dir = "cli"
 run = "go build -o bin/chatto ."
-sources = ["**/*.go", "internal/http_server/.client/**/*"]
+sources = [
+    "go.mod",
+    "go.sum",
+    "**/*.go",
+    "!**/*_test.go",
+    "cmd/LICENSE",
+    "cmd/NOTICE",
+    "internal/graph/*.graphqls",
+    "internal/http_server/.client/**/*",
+]
 outputs = ["bin/chatto"]
 
 [tasks.build-e2e-server]


### PR DESCRIPTION
## Changes

- Tighten mise dependency/build task inputs so frontend installs and production builds skip unrelated changes.
- Add explicit frontend build output markers and exclude frontend test/story harness files from production build inputs.
- Rename the local bootstrap binary task to `build-dev-cli` and bake in the `bootstrap` tag for Conductor/local runs.
- Make `mise clean` remove frontend build directories so dotfile output markers cannot leave stale builds marked fresh.

## Verification

- `mise run clean`
- `mise run build-dev-cli`
- `mise run --dry-run build-dev-cli`
- `git diff --check`
