### PR TITLE
fix(frontend): prevent expired edit via ArrowUp

### DIFF
--- a/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -509,6 +509,20 @@ describe('MessageComposer', () => {
   });
 
   describe('edit mode transitions', () => {
+    it('does not start editing on ArrowUp when no editable message is available', async () => {
+      const { container } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = q(container, '[data-testid="message-input"]')!;
+
+      await pressEditorKey(editor, 'ArrowUp');
+
+      expect(roomStateMock.lastEditableMessage.getLastEditableMessage).toHaveBeenCalledOnce();
+      expect(roomStateMock.editState.startEdit).not.toHaveBeenCalled();
+      await expect.element(editor).toHaveTextContent('');
+    });
+
     it('prefills edit text, hides attachment controls, and cancels on Escape', async () => {
       roomStateMock.editState.eventId = 'evt_edit';
       roomStateMock.editState.originalBody = 'original body';

--- a/frontend/src/lib/components/composer/TipTapEditor.svelte
+++ b/frontend/src/lib/components/composer/TipTapEditor.svelte
@@ -84,10 +84,12 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
       getText: () => e.getText({ blockSeparator: '\n' }),
 
       setContent: (text: string) => {
+        if (e.isDestroyed) return;
         e.commands.setContent(plainTextToHtml(text));
       },
 
       focus: (position: 'start' | 'end' = 'end') => {
+        if (e.isDestroyed) return;
         e.commands.focus(position);
       },
 

--- a/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -13,6 +13,7 @@
   import TypingIndicator from './TypingIndicator.svelte';
   import { computeEventMetadata } from './messageGrouping';
   import { buildVirtualItems, type VirtualItem } from './virtualItems';
+  import { findLastEditableMessage } from './lastEditableMessage';
   import ScrollFader from '$lib/ui/ScrollFader.svelte';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
@@ -142,50 +143,27 @@
 
   // Build flat array for the virtualizer (events + interleaved separators)
   let virtualItems = $derived(
-    buildVirtualItems(
-      eventsWithMeta,
-      unreadAfterEventId ?? null,
-      hasReachedStart,
-      showStartMarker
-    )
+    buildVirtualItems(eventsWithMeta, unreadAfterEventId ?? null, hasReachedStart, showStartMarker)
   );
 
   // Register finder for up-arrow-to-edit (computed on-demand, not reactively)
   const lastEditableMessageCtx = composerContext.lastEditableMessage;
-  const currentUser = $derived(serverRegistry.getStore(getActiveServer()).currentUser);
+  const stores = serverRegistry.getStore(getActiveServer());
+  const currentUser = $derived(stores.currentUser);
+  const serverInfo = stores.serverInfo;
   const roomPermissions = $derived(getRoomPermissions());
 
   $effect(() => {
     if (!enableLastEditableFinder) return;
 
     lastEditableMessageCtx?.setFinder(() => {
-      const userId = currentUser.user?.id;
-      if (!userId) return null;
-
-      for (let i = filteredEvents.length - 1; i >= 0; i--) {
-        const e = filteredEvents[i];
-        if (e.actorId !== userId) continue;
-        if (e.event?.__typename !== 'MessagePostedEvent') continue;
-        if (e.event?.body == null) continue;
-        const isEcho = !!e.event.echoOfEventId;
-        const eventId = isEcho ? e.event.echoOfEventId! : e.id;
-        const threadRootEventId = isEcho
-          ? (e.event.echoFromThreadRootEventId ?? null)
-          : (e.event.threadRootEventId ?? null);
-        const channelEchoEventId = isEcho ? e.id : (e.event.channelEchoEventId ?? null);
-        const canAddChannelEcho =
-          !!threadRootEventId &&
-          (!!channelEchoEventId ||
-            (roomPermissions.canEchoMessage && roomPermissions.canPostMessage));
-        return {
-          eventId,
-          body: e.event.body,
-          threadRootEventId,
-          channelEchoEventId,
-          canAddChannelEcho
-        };
-      }
-      return null;
+      return findLastEditableMessage({
+        events: filteredEvents,
+        currentUserId: currentUser.user?.id,
+        roomPermissions,
+        messageEditWindowSeconds: serverInfo.messageEditWindowSeconds,
+        nowMs: Date.now()
+      });
     });
   });
 

--- a/frontend/src/routes/chat/[serverId]/[roomId]/lastEditableMessage.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/lastEditableMessage.spec.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import type { RoomEventViewFragment } from '$lib/gql/graphql';
+import type { RoomPermissions } from '$lib/state/room';
+import { findLastEditableMessage } from './lastEditableMessage';
+
+const nowMs = Date.parse('2026-06-15T12:00:00Z');
+const editWindowSeconds = 3 * 60 * 60;
+
+const canEchoRoomPermissions: RoomPermissions = {
+  canPostMessage: true,
+  canPostInThread: true,
+  canReact: true,
+  canManageOthersMessage: false,
+  canEchoMessage: true,
+  canManageRoom: false,
+  canBanRoomMembers: false
+};
+
+function makeMessageEvent(
+  overrides: Partial<{
+    id: string;
+    actorId: string;
+    createdAt: string;
+    body: string | null;
+    threadRootEventId: string | null;
+    echoOfEventId: string | null;
+    echoFromThreadRootEventId: string | null;
+    channelEchoEventId: string | null;
+  }> = {}
+): RoomEventViewFragment {
+  const actorId = overrides.actorId ?? 'user_self';
+  return {
+    id: overrides.id ?? 'evt_' + Math.random().toString(36).slice(2),
+    createdAt: overrides.createdAt ?? '2026-06-15T11:00:00Z',
+    actorId,
+    actor: { id: actorId, login: 'tester', avatarUrl: null },
+    event: {
+      __typename: 'MessagePostedEvent',
+      roomId: 'room_test',
+      body: 'body' in overrides ? overrides.body : 'hello',
+      attachments: [],
+      linkPreview: null,
+      reactions: [],
+      updatedAt: null,
+      inReplyTo: null,
+      threadRootEventId: overrides.threadRootEventId ?? null,
+      echoOfEventId: overrides.echoOfEventId ?? null,
+      echoFromThreadRootEventId: overrides.echoFromThreadRootEventId ?? null,
+      channelEchoEventId: overrides.channelEchoEventId ?? null,
+      replyCount: 0,
+      lastReplyAt: null,
+      threadParticipants: [],
+      viewerIsFollowingThread: null
+    }
+  } as unknown as RoomEventViewFragment;
+}
+
+function find(events: RoomEventViewFragment[]) {
+  return findLastEditableMessage({
+    events,
+    currentUserId: 'user_self',
+    roomPermissions: canEchoRoomPermissions,
+    messageEditWindowSeconds: editWindowSeconds,
+    nowMs
+  });
+}
+
+describe('findLastEditableMessage', () => {
+  it('returns the latest own message within the edit window', () => {
+    const result = find([
+      makeMessageEvent({ id: 'evt_old', body: 'old body', createdAt: '2026-06-15T10:00:00Z' }),
+      makeMessageEvent({ id: 'evt_new', body: 'new body', createdAt: '2026-06-15T11:30:00Z' })
+    ]);
+
+    expect(result).toMatchObject({
+      eventId: 'evt_new',
+      body: 'new body',
+      threadRootEventId: null,
+      channelEchoEventId: null,
+      canAddChannelEcho: false
+    });
+  });
+
+  it('returns null when the latest own message is exactly at the edit-window boundary', () => {
+    const result = find([
+      makeMessageEvent({
+        id: 'evt_boundary',
+        body: 'too late',
+        createdAt: '2026-06-15T09:00:00Z'
+      })
+    ]);
+
+    expect(result).toBeNull();
+  });
+
+  it('skips other users messages', () => {
+    const result = find([
+      makeMessageEvent({
+        id: 'evt_other',
+        actorId: 'user_other',
+        body: 'not mine',
+        createdAt: '2026-06-15T11:55:00Z'
+      }),
+      makeMessageEvent({
+        id: 'evt_self',
+        body: 'mine',
+        createdAt: '2026-06-15T11:00:00Z'
+      })
+    ]);
+
+    expect(result?.eventId).toBe('evt_self');
+    expect(result?.body).toBe('mine');
+  });
+
+  it('skips deleted messages and falls back to an earlier editable message', () => {
+    const result = find([
+      makeMessageEvent({
+        id: 'evt_editable',
+        body: 'still editable',
+        createdAt: '2026-06-15T11:00:00Z'
+      }),
+      makeMessageEvent({
+        id: 'evt_deleted',
+        body: null,
+        createdAt: '2026-06-15T11:55:00Z'
+      })
+    ]);
+
+    expect(result?.eventId).toBe('evt_editable');
+    expect(result?.body).toBe('still editable');
+  });
+
+  it('preserves echo metadata for echoed thread replies', () => {
+    const result = find([
+      makeMessageEvent({
+        id: 'evt_echo',
+        body: 'echoed reply',
+        createdAt: '2026-06-15T11:30:00Z',
+        echoOfEventId: 'evt_original_reply',
+        echoFromThreadRootEventId: 'evt_thread_root'
+      })
+    ]);
+
+    expect(result).toMatchObject({
+      eventId: 'evt_original_reply',
+      body: 'echoed reply',
+      threadRootEventId: 'evt_thread_root',
+      channelEchoEventId: 'evt_echo',
+      canAddChannelEcho: true
+    });
+  });
+});

--- a/frontend/src/routes/chat/[serverId]/[roomId]/lastEditableMessage.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/lastEditableMessage.ts
@@ -1,0 +1,51 @@
+import type { RoomEventViewFragment } from '$lib/gql/graphql';
+import type { EditableMessage, RoomPermissions } from '$lib/state/room';
+
+type FindLastEditableMessageOptions = {
+  events: RoomEventViewFragment[];
+  currentUserId: string | null | undefined;
+  roomPermissions: RoomPermissions;
+  messageEditWindowSeconds: number;
+  nowMs: number;
+};
+
+export function findLastEditableMessage({
+  events,
+  currentUserId,
+  roomPermissions,
+  messageEditWindowSeconds,
+  nowMs
+}: FindLastEditableMessageOptions): EditableMessage | null {
+  if (!currentUserId) return null;
+
+  const editWindowMs = messageEditWindowSeconds * 1000;
+
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i];
+    const message = event.event;
+    if (event.actorId !== currentUserId) continue;
+    if (message?.__typename !== 'MessagePostedEvent') continue;
+    if (message.body == null) continue;
+    if (nowMs - new Date(event.createdAt).getTime() >= editWindowMs) continue;
+
+    const isEcho = !!message.echoOfEventId;
+    const eventId = isEcho ? message.echoOfEventId! : event.id;
+    const threadRootEventId = isEcho
+      ? (message.echoFromThreadRootEventId ?? null)
+      : (message.threadRootEventId ?? null);
+    const channelEchoEventId = isEcho ? event.id : (message.channelEchoEventId ?? null);
+    const canAddChannelEcho =
+      !!threadRootEventId &&
+      (!!channelEchoEventId || (roomPermissions.canEchoMessage && roomPermissions.canPostMessage));
+
+    return {
+      eventId,
+      body: message.body,
+      threadRootEventId,
+      channelEchoEventId,
+      canAddChannelEcho
+    };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Changes

- Prevent ArrowUp-to-edit from selecting own messages after the server edit window has expired.
- Extract last-editable-message lookup into a pure helper with coverage for expiry, author filtering, deleted messages, and echoed thread replies.
- Guard TipTap composer API calls after editor destruction to avoid async focus errors.

## Tests

- `mise x -- pnpm test:unit --run --project server 'src/routes/chat/[serverId]/[roomId]/lastEditableMessage.spec.ts'`
- `mise x -- pnpm test:unit --run --project client src/lib/components/composer/MessageComposer.svelte.spec.ts`
- `mise x -- pnpm check`
- `mise x -- pnpm exec eslint 'src/routes/chat/[serverId]/[roomId]/lastEditableMessage.ts' 'src/routes/chat/[serverId]/[roomId]/lastEditableMessage.spec.ts' 'src/routes/chat/[serverId]/[roomId]/EventList.svelte' src/lib/components/composer/MessageComposer.svelte.spec.ts src/lib/components/composer/TipTapEditor.svelte`
