### PR TITLE
chore: add Docker verification tooling

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - ubicloud-standard-4

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,24 @@
+# Docker Assets
+
+This directory contains Docker build assets used by development, CI, and release
+automation.
+
+## Files
+
+- `Dockerfile.goreleaser` builds the backend release image that GoReleaser
+  publishes as `ghcr.io/chattocorp/chatto`.
+- `docker-entrypoint.sh` is copied into the backend release image. It writes a
+  NATS CLI context from Chatto's runtime NATS environment before starting the
+  `chatto` binary.
+- `Dockerfile.frontend.prebuilt` packages the already-built frontend static
+  files into the release-only `ghcr.io/chattocorp/chatto-client` image.
+- `Dockerfile.dev` is the backend development image used by Tilt-oriented local
+  or cluster development.
+- `Dockerfile.frontend.dev` is the frontend development image used by
+  Tilt-oriented local or cluster development.
+- `*.dockerignore` files are scoped to individual root-context Dockerfiles.
+  Keep them next to the Dockerfile they apply to instead of recreating a broad
+  root `.dockerignore`.
+
+Copyable deployment examples still live under `examples/`, for example
+`examples/dockercompose/`.

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,9 @@
 [tools]
+actionlint = "latest"
 buf = "latest"
 go = "1.26.2"
 "go:google.golang.org/protobuf/cmd/protoc-gen-go" = "v1.36.11"
+goreleaser = "latest"
 node = "22"
 tilt = "latest"
 
@@ -276,6 +278,30 @@ run = """
 echo "Starting pkgsite documentation server..."
 echo "Browse to: http://localhost:6060/hmans.de/chatto"
 pkgsite -http=localhost:6060 .
+"""
+
+[tasks.verify-docker]
+description = "Validate Docker, GoReleaser, and image workflow wiring"
+run = """
+set -euo pipefail
+
+goreleaser check
+
+actionlint .github/workflows/*.yml
+
+docker buildx build --check --build-arg TARGETARCH=amd64 -f docker/Dockerfile.dev .
+docker buildx build --check -f docker/Dockerfile.frontend.dev frontend
+docker buildx build --check -f docker/Dockerfile.frontend.prebuilt .
+
+tmp="$(mktemp -d /tmp/chatto-docker-verify.XXXXXX)"
+trap 'rm -rf "$tmp"' EXIT
+context="$tmp/linux-amd64"
+mkdir -p "$context/docker"
+cp docker/Dockerfile.goreleaser "$context/Dockerfile"
+cp docker/docker-entrypoint.sh "$context/docker/docker-entrypoint.sh"
+printf '#!/bin/sh\necho chatto dummy\n' > "$context/chatto"
+chmod +x "$context/chatto"
+docker buildx build --build-arg TARGETARCH=amd64 -f "$context/Dockerfile" "$context"
 """
 
 # =============================================================================


### PR DESCRIPTION
- Documents the ownership and intended use of Docker build assets under `docker/`.
- Adds actionlint configuration for the `ubicloud-standard-4` runner label.
- Adds mise-managed `actionlint` and `goreleaser` tools plus a `mise verify-docker` task for GoReleaser, workflow, Dockerfile, and manual image-context checks.

Validation: `mise verify-docker`.
