### PR TITLE
fix(frontend): remember last visited DM rooms

### DIFF
--- a/docs/fdr/FDR-026-last-room-memory.md
+++ b/docs/fdr/FDR-026-last-room-memory.md
@@ -1,19 +1,18 @@
 # FDR-026: Last-Room Memory
 
 **Status:** Active
-**Last reviewed:** 2026-05-19
+**Last reviewed:** 2026-06-16
 
 ## Overview
 
-The frontend remembers, per connected server, the last channel room the user was in. When the user re-enters a server — by clicking its icon in the sidebar, by landing on the app after sign-in, or by hitting any link that points at the server root — they're taken back to that room instead of an intermediate landing page. The mechanic is local to the device and lightweight; if no last room is known, the user falls through to the server's Overview page.
+The frontend remembers, per connected server, the last room the user was in. When the user re-enters a server — by clicking its icon in the sidebar, by landing on the app after sign-in, or by hitting any link that points at the server root — they're taken back to that room instead of an intermediate landing page. The mechanic is local to the device and lightweight; if no last room is known, the user falls through to the server's Overview page.
 
 ## Behavior
 
-- Visiting a channel room records it as the server's last room. The record is per-server, not global.
+- Visiting a channel or DM room records it as the server's last room. The record is per-server, not global.
 - Visiting `/chat/{server}` (the server root) redirects to the recorded last room. If none is stored, it falls through to the server's Overview page at `/chat/{server}/overview`.
 - Visiting `/` (the app root) after sign-in redirects to the home server's last room when one exists. Otherwise it lands on the home server's root, which itself falls through to Overview.
 - The Overview page is reachable directly at `/chat/{server}/overview` — typing that URL, or clicking the sidebar "Overview" entry, never bounces to the last room.
-- DM rooms are deliberately not recorded. Only channel rooms qualify as a "last room".
 - The record is cleared when:
   - The room becomes inaccessible (deleted, the user lost access, or the server says it can't be loaded). The user is redirected back to the server root, which then falls through to Overview.
   - The server is removed from the client (disconnect or sign out).
@@ -35,11 +34,11 @@ The frontend remembers, per connected server, the last channel room the user was
 **Why:** Re-entering a server you've been using should land you in the room you were last in — that's the dominant case. But the Overview must still be reachable on demand (sidebar nav, Cmd-K, the empty-state link in the room list). Splitting the routes makes the URL itself the source of truth: one URL means "take me back where I was", the other means "show me the Overview".
 **Tradeoff:** Two URLs for what was previously one. Worth it; the alternative (querystring flags or shallow state) would couple the page to its callers.
 
-### 3. Channels only — never DMs
+### 3. Channels and DMs share one slot
 
-**Decision:** Only channel rooms are recorded. Entering a DM does not update the last-room slot.
-**Why:** DMs are conversation-driven, not place-driven. Auto-landing in a DM the user opened a week ago is surprising and easily wrong (the conversation may be stale, the user may not want it surfaced first). Channels are the implicit "where I work" destination.
-**Tradeoff:** A user whose primary use of a server is DMs gets the Overview as a landing page until they visit a channel. Acceptable; the Overview is a usable starting point.
+**Decision:** Channel rooms and DM rooms both update the same last-room slot.
+**Why:** DMs use the same room URL shape and sidebar as channels, so returning to the last room should behave consistently regardless of room type.
+**Tradeoff:** A user can be returned to a DM when they re-enter a server. This matches the literal "last room" behavior, but it means a stale DM can temporarily displace a channel until the user visits another room.
 
 ### 4. Stored on-device in `localStorage`
 

--- a/frontend/e2e/dm.test.ts
+++ b/frontend/e2e/dm.test.ts
@@ -131,7 +131,7 @@ test.describe('Direct Messages (room-shaped)', () => {
       const userC = await createAndLoginTestUser(pageC);
 
       // Seed two existing DMs from User A's side, B last so it sorts above C
-      // by last-activity (newest first). User A then leaves the chat root open
+      // by last-activity (newest first). User A then leaves the Overview open
       // — *not* in either DM — so subsequent activity must bump via subscription.
       const dmA = new DMPage(page);
       const aToC = await dmA.startConversation(userC.login);
@@ -139,8 +139,8 @@ test.describe('Direct Messages (room-shaped)', () => {
       const aToB = await dmA.startConversation(userB.login);
       await aToB.sendMessage('seed B');
 
-      await page.goto(routes.chat);
-      await page.waitForURL(routes.chat);
+      await page.goto(routes.browseRooms);
+      await page.waitForURL(routes.browseRooms);
       await expect(
         page.getByRole('button', { name: /direct messages/i })
       ).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
@@ -211,8 +211,8 @@ test.describe('Direct Messages (room-shaped)', () => {
       await aToC.sendMessage('seed C');
       // C is now most-recent.
 
-      await page.goto(routes.chat);
-      await page.waitForURL(routes.chat);
+      await page.goto(routes.browseRooms);
+      await page.waitForURL(routes.browseRooms);
       const dmRows = () =>
         page.locator('nav a.sidebar-item').filter({
           has: page.getByText(new RegExp(`^(${userB.displayName}|${userC.displayName})$`))
@@ -254,9 +254,9 @@ test.describe('Direct Messages (room-shaped)', () => {
     try {
       await createAndLoginTestUser(pageB);
 
-      // User A on chat root with no DMs yet — server icon has no indicator.
-      await page.goto(routes.chat);
-      await page.waitForURL(routes.chat);
+      // User A on Overview with no DMs yet — server icon has no indicator.
+      await page.goto(routes.browseRooms);
+      await page.waitForURL(routes.browseRooms);
       // Scope to the Server Gutter so we don't collide with notification
       // buttons rendered inside the Server Sidebar.
       const serverIconWrapper = page
@@ -310,8 +310,8 @@ test.describe('Direct Messages (room-shaped)', () => {
       const aToC = await dmA.startConversation(userC.login);
       await aToC.sendMessage('seed C');
 
-      await page.goto(routes.chat);
-      await page.waitForURL(routes.chat);
+      await page.goto(routes.browseRooms);
+      await page.waitForURL(routes.browseRooms);
 
       const groupHeader = page.getByRole('button', { name: /direct messages/i });
       const dmRow = (displayName: string) =>

--- a/frontend/e2e/server-flows.test.ts
+++ b/frontend/e2e/server-flows.test.ts
@@ -7,6 +7,7 @@ import {
 	createUserOnRemote
 } from './fixtures/multiServer';
 import type { ServerInfo } from './fixtures/server';
+import { DMPage } from './pages/DMPage';
 import * as routes from './routes';
 import { TIMEOUTS } from './constants';
 
@@ -113,6 +114,54 @@ test.describe('Last-Room Memory', () => {
 		await expect(chatPage.getRoomHeader(roomName)).toBeVisible();
 	});
 
+	test('navigating to /chat/- redirects to the last visited DM', async ({
+		page,
+		browser,
+		serverURL
+	}) => {
+		const userA = await createAndLoginTestUser(page);
+
+		const context2 = await browser.newContext({ baseURL: serverURL });
+		const page2 = await context2.newPage();
+		try {
+			await createAndLoginTestUser(page2);
+
+			const room = await new DMPage(page2).startConversation(userA.login);
+			await room.sendMessage('seed for remembered DM');
+			const dmUrl = page2.url();
+
+			await page2.goto(routes.chat);
+			await expect(page2).toHaveURL(dmUrl);
+			await expect(page2.getByTestId('message-input')).toBeVisible();
+		} finally {
+			await context2.close();
+		}
+	});
+
+	test('navigating to / redirects to the home server last visited DM', async ({
+		page,
+		browser,
+		serverURL
+	}) => {
+		const userA = await createAndLoginTestUser(page);
+
+		const context2 = await browser.newContext({ baseURL: serverURL });
+		const page2 = await context2.newPage();
+		try {
+			await createAndLoginTestUser(page2);
+
+			const room = await new DMPage(page2).startConversation(userA.login);
+			await room.sendMessage('seed for root remembered DM');
+			const dmUrl = page2.url();
+
+			await page2.goto(routes.root);
+			await expect(page2).toHaveURL(dmUrl);
+			await expect(page2.getByTestId('message-input')).toBeVisible();
+		} finally {
+			await context2.close();
+		}
+	});
+
 	test('/chat/- falls through to Overview when no last room is stored', async ({
 		page,
 		chatPage
@@ -126,21 +175,29 @@ test.describe('Last-Room Memory', () => {
 		await expect(page.getByRole('heading', { name: 'Overview' })).toBeVisible();
 	});
 
-	test('Overview page is reachable directly even when a last room is stored', async ({
+	test('Overview page is reachable directly even when a last DM is stored', async ({
 		page,
-		chatPage
+		browser,
+		serverURL
 	}) => {
-		await createAndLoginTestUser(page);
-		await chatPage.goto();
+		const userA = await createAndLoginTestUser(page);
 
-		// Visit a room so a last-room is stored.
-		await chatPage.createRoom();
+		const context2 = await browser.newContext({ baseURL: serverURL });
+		const page2 = await context2.newPage();
+		try {
+			await createAndLoginTestUser(page2);
 
-		// Navigating directly to the Overview URL should stay on Overview,
-		// not bounce to the last room.
-		await page.goto('/chat/-/overview');
-		await expect(page).toHaveURL(/\/chat\/-\/overview$/);
-		await expect(page.getByRole('heading', { name: 'Overview' })).toBeVisible();
+			const room = await new DMPage(page2).startConversation(userA.login);
+			await room.sendMessage('seed for overview reachability');
+
+			// Navigating directly to the Overview URL should stay on Overview,
+			// not bounce to the last room.
+			await page2.goto(routes.browseRooms);
+			await expect(page2).toHaveURL(/\/chat\/-\/overview$/);
+			await expect(page2.getByRole('heading', { name: 'Overview' })).toBeVisible();
+		} finally {
+			await context2.close();
+		}
 	});
 });
 

--- a/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -189,12 +189,10 @@
   });
 
   // Remember this room as the last visited (for the chat-root → last-room
-  // auto-redirect). DM rooms are deliberately excluded: their lifecycle is
-  // user-driven (start a conversation, post a message), not "the room I was
-  // last in," and auto-landing on a DM after returning to the instance is
-  // surprising — channels are the implicit destination.
+  // auto-redirect). Room.svelte is reused across roomId changes, so wait for
+  // the loaded room data to catch up to the current route before writing.
   $effect(() => {
-    if (room.roomData && !room.isDM) {
+    if (room.roomData?.room.id === roomId) {
       setLastRoom(getActiveServer(), roomId);
     }
   });


### PR DESCRIPTION
## Summary
- Remember DM rooms in the same per-server last-room slot as channel rooms.
- Update FDR-026 to document channels and DMs sharing last-room memory.
- Add e2e coverage for DM re-entry from `/chat/-` and `/`, while preserving direct Overview access.

## Verification
- `pnpm check`
- `pnpm lint`
- `pnpm test:e2e e2e/server-flows.test.ts e2e/dm.test.ts`
- Browser smoke test confirmed `/chat/-` redirects back to a remembered DM.
