### PR TITLE
fix(frontend): show active call badges for DMs

### DIFF
--- a/frontend/e2e/pages/ChatPage.ts
+++ b/frontend/e2e/pages/ChatPage.ts
@@ -187,13 +187,15 @@ export class ChatPage {
    * state.
    */
   async openCreateRoomModal(): Promise<void> {
+    const headers = await csrfHeaders(this.page);
+    // Unload the currently mounted app before logging out. If the SPA stays
+    // mounted during API logout, it can observe the session change and race the
+    // following admin navigation with its own redirect.
+    await this.page.goto('about:blank');
     const logoutResponse = await this.page.request.post('/auth/logout', {
-      headers: await csrfHeaders(this.page)
+      headers
     });
     expect(logoutResponse.ok()).toBeTruthy();
-    // Unload the currently mounted app before re-authenticating as admin; the
-    // previous session can otherwise issue a late redirect during navigation.
-    await this.page.goto('about:blank');
     await loginAsAdmin(this.page);
     await this.page.goto(routes.serverAdminRooms);
     await expect(this.page).toHaveURL(/\/server-admin\/rooms/);

--- a/frontend/e2e/room-permissions.test.ts
+++ b/frontend/e2e/room-permissions.test.ts
@@ -59,11 +59,12 @@ async function loginUser(page: Page, login: string, password: string): Promise<v
 }
 
 async function logoutUser(page: Page): Promise<void> {
-  const response = await page.request.post('/auth/logout', { headers: await csrfHeaders(page) });
-  expect(response.ok()).toBeTruthy();
+  const headers = await csrfHeaders(page);
   // Unload the SPA before switching identities. Otherwise the old authenticated
   // app can react to logout and race a later page.goto() with its own redirect.
   await page.goto('about:blank');
+  const response = await page.request.post('/auth/logout', { headers });
+  expect(response.ok()).toBeTruthy();
 }
 
 async function joinSpaceViaAPI(_page: Page, _spaceId: string): Promise<void> {

--- a/frontend/src/lib/RoomList.svelte
+++ b/frontend/src/lib/RoomList.svelte
@@ -117,6 +117,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   // hasRoomNotification deliberately excludes DMs.
   function isHighlighted(room: RoomsListItem): boolean {
     if (room.id === activeRoomId) return true;
+    if (activeCallRooms.has(room.id)) return true;
     if (room.hasUnread) return true;
     if (room.type === RoomType.Dm) {
       return notificationStore.hasDMRoomNotification(room.id);
@@ -261,13 +262,47 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   }
 </script>
 
+{#snippet callBadge(room: RoomsListItem, callParticipants: CallRoomParticipant[])}
+  <div
+    class="basis-full pl-7 cursor-pointer"
+    role="button"
+    tabindex="0"
+    aria-label="Join active call"
+    data-testid="room-call-badge"
+    onclick={(e) => handleCallBadgeClick(e, room.id)}
+    onkeydown={(e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        handleCallBadgeClick(e, room.id);
+      }
+    }}
+  >
+    <div
+      class={[
+        'meta-badge border-transparent gap-1.5 px-1.5 py-0.5',
+        room.id === activeRoomId ? 'bg-surface-200' : ''
+      ]}
+    >
+      <span class="iconify animate-pulse text-accent uil--phone text-sm"></span>
+      {#if callParticipants.length > 0}
+        <div class="inline-flex -space-x-1.5">
+          {#each callParticipants as p (p.userId)}
+            <UserAvatar user={toAvatarUser(p)} size="xs" showPresence={false} />
+          {/each}
+        </div>
+      {/if}
+    </div>
+  </div>
+{/snippet}
+
 {#snippet roomLink(room: RoomsListItem)}
-  {@const callParticipants = activeCallRooms.has(room.id) ? activeCallRooms.getParticipants(room.id) : []}
+  {@const hasActiveCall = activeCallRooms.has(room.id)}
+  {@const callParticipants = hasActiveCall ? activeCallRooms.getParticipants(room.id) : []}
   <a
     href={resolve('/chat/[serverId]/[roomId]', { serverId: serverSegment, roomId: room.id })}
     class={[
       'sidebar-item group/badges',
-      callParticipants.length > 0 ? 'flex-wrap gap-y-1' : '',
+      hasActiveCall ? 'flex-wrap gap-y-1' : '',
       room.id === activeRoomId ? 'bg-surface-100' : '',
       room.hasUnread &&
       room.id !== activeRoomId &&
@@ -299,32 +334,20 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
 
     <!-- Call participant avatars (badge row, wraps below room name).
          Clicking the badge navigates to the room AND joins the call. -->
-    {#if callParticipants.length > 0}
-      <div
-        class="basis-full pl-7 cursor-pointer"
-        role="button"
-        tabindex="0"
-        onclick={(e) => handleCallBadgeClick(e, room.id)}
-        onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleCallBadgeClick(e, room.id); } }}
-      >
-        <div class={["meta-badge border-transparent gap-1.5 px-1.5 py-0.5", room.id === activeRoomId ? 'bg-surface-200' : '']}>
-          <span class="iconify animate-pulse text-accent uil--phone text-sm"></span>
-          <div class="inline-flex -space-x-1.5">
-            {#each callParticipants as p (p.userId)}
-              <UserAvatar user={toAvatarUser(p)} size="xs" showPresence={false} />
-            {/each}
-          </div>
-        </div>
-      </div>
+    {#if hasActiveCall}
+      {@render callBadge(room, callParticipants)}
     {/if}
   </a>
 {/snippet}
 
 {#snippet dmLink(room: RoomsListItem)}
+  {@const hasActiveCall = activeCallRooms.has(room.id)}
+  {@const callParticipants = hasActiveCall ? activeCallRooms.getParticipants(room.id) : []}
   <a
     href={resolve('/chat/[serverId]/[roomId]', { serverId: serverSegment, roomId: room.id })}
     class={[
-      'sidebar-item',
+      'sidebar-item group/badges',
+      hasActiveCall ? 'flex-wrap gap-y-1' : '',
       room.id === activeRoomId ? 'bg-surface-100' : '',
       room.hasUnread && room.id !== activeRoomId ? 'font-semibold' : ''
     ]}
@@ -350,6 +373,10 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     {:else if room.hasUnread}
       <UnreadDot color="primary" testid="dm-unread-dot" />
       <span class="sr-only">unread messages</span>
+    {/if}
+
+    {#if hasActiveCall}
+      {@render callBadge(room, callParticipants)}
     {/if}
   </a>
 {/snippet}

--- a/frontend/src/lib/RoomList.svelte.spec.ts
+++ b/frontend/src/lib/RoomList.svelte.spec.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { q } from '$lib/test-utils';
+import { RoomType } from '$lib/gql/graphql';
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    activeCallRoomIds: new Set<string>(),
+    callParticipants: new Map<string, unknown[]>(),
+    store: {
+      currentUser: { user: { id: 'me' } },
+      notifications: {
+        hasDMRoomNotification: vi.fn().mockReturnValue(false),
+        hasRoomNotification: vi.fn().mockReturnValue(false),
+        getDMRoomNotification: vi.fn().mockReturnValue(null),
+        getRoomNotification: vi.fn().mockReturnValue(null),
+        dismiss: vi.fn(),
+        getCleanPath: vi.fn().mockReturnValue('/chat/-/room')
+      },
+      notificationLevels: {
+        isRoomMuted: vi.fn().mockReturnValue(false)
+      },
+      activeCallRooms: {
+        load: vi.fn().mockResolvedValue(undefined),
+        has: vi.fn((roomId: string) => mocks.activeCallRoomIds.has(roomId)),
+        getParticipants: vi.fn((roomId: string) => mocks.callParticipants.get(roomId) ?? []),
+        handleJoin: vi.fn(),
+        handleLeave: vi.fn(),
+        handleEnd: vi.fn()
+      },
+      voiceCall: {
+        join: vi.fn().mockResolvedValue(undefined),
+        handleParticipantLeftEvent: vi.fn(),
+        handleCallEndedEvent: vi.fn()
+      },
+      serverInfo: {
+        livekitUrl: null
+      },
+      rooms: {
+        rooms: [],
+        roomGroups: null,
+        isInitialLoading: false,
+        currentUserId: 'me',
+        markRead: vi.fn(),
+        bumpRoom: vi.fn(),
+        setUnread: vi.fn()
+      },
+      pendingHighlights: {
+        set: vi.fn()
+      },
+      handleVoiceCallJoinFailed: vi.fn()
+    }
+  }
+}));
+
+vi.mock('$app/state', () => ({
+  page: {
+    params: {
+      serverId: '-',
+      roomId: undefined
+    }
+  }
+}));
+
+vi.mock('$app/navigation', () => ({
+  goto: vi.fn()
+}));
+
+vi.mock('$app/paths', () => ({
+  resolve: (path: string, params?: Record<string, string>) =>
+    path
+      .replace('[serverId]', params?.serverId ?? '')
+      .replace('[roomId]', params?.roomId ?? '')
+}));
+
+vi.mock('$lib/navigation', () => ({
+  serverIdToSegment: () => '-',
+  segmentToServerId: () => 'origin'
+}));
+
+vi.mock('$lib/state/activeServer.svelte', () => ({
+  getActiveServer: () => 'origin'
+}));
+
+vi.mock('$lib/state/server/registry.svelte', () => ({
+  serverRegistry: {
+    getStore: vi.fn(() => mocks.store),
+    isOriginServer: vi.fn(() => true),
+    getServer: vi.fn(() => ({ id: 'origin', url: 'https://chat.example.test' })),
+    originServer: { id: 'origin' },
+    servers: [{ id: 'origin', url: 'https://chat.example.test' }]
+  }
+}));
+
+vi.mock('$lib/hooks', () => ({
+  useEvent: vi.fn(),
+  useRoomMarkedAsRead: vi.fn(),
+  useTabResumeCallback: vi.fn()
+}));
+
+vi.mock('$lib/state/presenceCache.svelte', () => ({
+  getPresenceCache: () => ({
+    get: (_userId: string, fallback: string) => fallback
+  })
+}));
+
+vi.mock('$lib/state/userProfiles.svelte', () => ({
+  getLiveDisplayName: (_userId: string, fallback: string) => fallback,
+  getLiveAvatarUrl: (_userId: string, fallback: string | null) => fallback
+}));
+
+import RoomList from './RoomList.svelte';
+
+function user(id: string, login: string, displayName: string) {
+  return {
+    id,
+    login,
+    displayName,
+    avatarUrl: null,
+    presenceStatus: 'ONLINE'
+  };
+}
+
+function setRooms() {
+  mocks.store.rooms.rooms = [
+    {
+      id: 'channel-1',
+      name: 'general',
+      type: RoomType.Channel,
+      hasUnread: false,
+      members: []
+    },
+    {
+      id: 'dm-with-participants',
+      name: '',
+      type: RoomType.Dm,
+      hasUnread: false,
+      members: [user('me', 'me', 'Me'), user('teal', 'teal', 'Teal')]
+    },
+    {
+      id: 'dm-phone-only',
+      name: '',
+      type: RoomType.Dm,
+      hasUnread: false,
+      members: [user('me', 'me', 'Me'), user('river', 'river', 'River')]
+    }
+  ] as never;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  mocks.activeCallRoomIds = new Set();
+  mocks.callParticipants = new Map();
+  mocks.store.rooms.roomGroups = null;
+  mocks.store.rooms.isInitialLoading = false;
+  mocks.store.rooms.currentUserId = 'me';
+  setRooms();
+  vi.clearAllMocks();
+});
+
+describe('RoomList', () => {
+  it('renders active-call badges for DM rows', async () => {
+    mocks.activeCallRoomIds.add('dm-with-participants');
+    mocks.callParticipants.set('dm-with-participants', [
+      {
+        userId: 'teal',
+        login: 'teal',
+        displayName: 'Teal',
+        avatarUrl: null
+      }
+    ]);
+
+    const { container } = render(RoomList);
+
+    await expect.element(q(container, '[href="/chat/-/dm-with-participants"]')).toBeInTheDocument();
+    const dmRow = q(container, '[href="/chat/-/dm-with-participants"]');
+    const badge = dmRow?.querySelector('[data-testid="room-call-badge"]');
+    expect(badge).not.toBeNull();
+    expect(badge?.querySelector('.uil--phone')).not.toBeNull();
+    expect(badge?.textContent).toContain('T');
+  });
+
+  it('renders a phone-only active-call badge when participants are not loaded', async () => {
+    mocks.activeCallRoomIds.add('dm-phone-only');
+
+    const { container } = render(RoomList);
+
+    await expect.element(q(container, '[href="/chat/-/dm-phone-only"]')).toBeInTheDocument();
+    const dmRow = q(container, '[href="/chat/-/dm-phone-only"]');
+    const badge = dmRow?.querySelector('[data-testid="room-call-badge"]');
+    expect(badge).not.toBeNull();
+    expect(badge?.querySelector('.uil--phone')).not.toBeNull();
+    expect(badge?.querySelector('.inline-flex')).toBeNull();
+  });
+
+  it('keeps channel active-call badges working', async () => {
+    mocks.activeCallRoomIds.add('channel-1');
+    mocks.callParticipants.set('channel-1', [
+      {
+        userId: 'teal',
+        login: 'teal',
+        displayName: 'Teal',
+        avatarUrl: null
+      }
+    ]);
+
+    const { container } = render(RoomList);
+
+    await expect.element(q(container, '[href="/chat/-/channel-1"]')).toBeInTheDocument();
+    const channelRow = q(container, '[href="/chat/-/channel-1"]');
+    expect(channelRow?.querySelector('[data-testid="room-call-badge"]')).not.toBeNull();
+    expect(channelRow?.querySelector('.uil--phone')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Shows active-call badges on DM room rows using the same shared sidebar badge markup as channel rooms.
- Keeps active-call rooms visible when sidebar groups are collapsed and supports phone-only badges while participant snapshots are empty.
- Adds browser component coverage for DM and channel active-call badge rendering.
- Avoids e2e identity-switch races by unloading the SPA before API logout in affected helpers.

## Tests
- `npx @sveltejs/mcp svelte-autofixer ./src/lib/RoomList.svelte --svelte-version 5`
- `mise x -- pnpm test:unit --run --project client src/lib/RoomList.svelte.spec.ts`
- `mise x -- pnpm exec playwright test e2e/room-creation.test.ts e2e/room-permissions.test.ts --retries=0`
- `mise x -- pnpm check`
