### PR TITLE
fix: support implicit SMTP TLS

### DIFF
--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -97,6 +97,11 @@ var initCmd = &cobra.Command{
 					StorageBackend: config.StorageBackendNATS,
 				},
 			},
+			SMTP: config.SMTPConfig{
+				Enabled: false,
+				Port:    587,
+				TLS:     config.SMTPTLSMandatory,
+			},
 			NATS: config.NATSConfig{
 				Replicas: 1,
 				Client: config.NATSClientConfig{

--- a/cli/cmd/init_test.go
+++ b/cli/cmd/init_test.go
@@ -49,6 +49,15 @@ func TestInitGeneratesCoreSecret(t *testing.T) {
 	if cfg.NATS.Client.URL != "" {
 		t.Fatalf("generated embedded NATS client URL = %q, want empty when TCP listener is disabled", cfg.NATS.Client.URL)
 	}
+	if cfg.SMTP.Enabled {
+		t.Fatal("generated SMTP config should be disabled by default")
+	}
+	if cfg.SMTP.Port != 587 {
+		t.Fatalf("generated SMTP port = %d, want 587", cfg.SMTP.Port)
+	}
+	if cfg.SMTP.TLS != config.SMTPTLSMandatory {
+		t.Fatalf("generated SMTP TLS policy = %q, want %q", cfg.SMTP.TLS, config.SMTPTLSMandatory)
+	}
 	raw, err := os.ReadFile(filepath.Join(tmpDir, "chatto.toml"))
 	if err != nil {
 		t.Fatalf("read generated raw config: %v", err)
@@ -89,6 +98,15 @@ func TestInitGeneratesCoreSecret(t *testing.T) {
 	}
 	if !strings.Contains(rawText, "storage_backend = 'nats'") {
 		t.Fatal("generated config should set core.assets.storage_backend to 'nats'")
+	}
+	if !strings.Contains(rawText, "\n[smtp]\n") {
+		t.Fatal("generated config should include SMTP defaults")
+	}
+	if !strings.Contains(rawText, "\nport = 587\n") {
+		t.Fatal("generated SMTP config should default to STARTTLS submission port 587")
+	}
+	if !strings.Contains(rawText, "\ntls = 'mandatory'\n") {
+		t.Fatal("generated SMTP config should default to mandatory STARTTLS")
 	}
 	if !strings.Contains(rawText, "\nreplicas = 1\n") {
 		t.Fatal("generated config should set nats.replicas to 1")

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -555,20 +555,29 @@ func (c *OwnersConfig) IsServerOwnerEmail(email string) bool {
 	return false
 }
 
-// SMTPTLSPolicy controls how the SMTP client negotiates STARTTLS.
+// SMTPTLSPolicy controls how the SMTP client encrypts the transport.
 type SMTPTLSPolicy string
 
 const (
 	SMTPTLSMandatory     SMTPTLSPolicy = "mandatory"
 	SMTPTLSOpportunistic SMTPTLSPolicy = "opportunistic"
+	SMTPTLSImplicit      SMTPTLSPolicy = "implicit"
 )
 
 // TLSPolicyOrDefault returns the configured SMTP TLS policy, defaulting to
 // mandatory STARTTLS so transactional email tokens are not sent in plaintext.
+// Port 465 is the standard implicit TLS/SMTPS submission port, so treat the
+// default/mandatory policy as implicit TLS there for operator compatibility.
 func (c *SMTPConfig) TLSPolicyOrDefault() SMTPTLSPolicy {
 	policy := SMTPTLSPolicy(strings.ToLower(strings.TrimSpace(string(c.TLS))))
 	if policy == "" {
+		if c.Port == 465 {
+			return SMTPTLSImplicit
+		}
 		return SMTPTLSMandatory
+	}
+	if policy == SMTPTLSMandatory && c.Port == 465 {
+		return SMTPTLSImplicit
 	}
 	return policy
 }
@@ -578,7 +587,7 @@ type SMTPConfig struct {
 	Enabled  bool          `toml:"enabled" env:"CHATTO_SMTP_ENABLED" comment:"Enable SMTP for sending transactional emails (verification, password reset, etc.)."`
 	Host     string        `toml:"host" env:"CHATTO_SMTP_HOST" comment:"SMTP server hostname. Example: smtp.example.com"`
 	Port     int           `toml:"port" env:"CHATTO_SMTP_PORT" comment:"SMTP server port. Common value: 587 (STARTTLS)."`
-	TLS      SMTPTLSPolicy `toml:"tls,commented" env:"CHATTO_SMTP_TLS" comment:"SMTP TLS policy: mandatory (default) or opportunistic. Opportunistic allows plaintext fallback and should only be used when explicitly required."`
+	TLS      SMTPTLSPolicy `toml:"tls" env:"CHATTO_SMTP_TLS" comment:"SMTP TLS policy: mandatory STARTTLS (default), implicit TLS/SMTPS, or opportunistic. Opportunistic allows plaintext fallback and should only be used when explicitly required."`
 	Username string        `toml:"username" env:"CHATTO_SMTP_USERNAME" comment:"SMTP authentication username."`
 	Password string        `toml:"password" env:"CHATTO_SMTP_PASSWORD" comment:"SMTP authentication password. NEVER SHARE THIS!"`
 	From     string        `toml:"from" env:"CHATTO_SMTP_FROM" comment:"From address for outgoing emails. Example: noreply@example.com"`
@@ -911,9 +920,9 @@ func (c *ChattoConfig) Validate() error {
 
 	// SMTP configuration
 	switch c.SMTP.TLSPolicyOrDefault() {
-	case SMTPTLSMandatory, SMTPTLSOpportunistic:
+	case SMTPTLSMandatory, SMTPTLSOpportunistic, SMTPTLSImplicit:
 	default:
-		errs = append(errs, "smtp.tls must be one of: mandatory, opportunistic")
+		errs = append(errs, "smtp.tls must be one of: mandatory, opportunistic, implicit")
 	}
 	if c.SMTP.Enabled {
 		if c.Webserver.URL == "" {

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -624,6 +624,48 @@ func TestReadConfig_SMTPPolicyFromEnv(t *testing.T) {
 	}
 }
 
+func TestSMTPConfig_TLSPolicyOrDefault(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  SMTPConfig
+		want SMTPTLSPolicy
+	}{
+		{
+			name: "empty policy defaults to mandatory STARTTLS",
+			cfg:  SMTPConfig{Port: 587},
+			want: SMTPTLSMandatory,
+		},
+		{
+			name: "empty policy on port 465 defaults to implicit TLS",
+			cfg:  SMTPConfig{Port: 465},
+			want: SMTPTLSImplicit,
+		},
+		{
+			name: "mandatory policy on port 465 uses implicit TLS",
+			cfg:  SMTPConfig{Port: 465, TLS: SMTPTLSMandatory},
+			want: SMTPTLSImplicit,
+		},
+		{
+			name: "explicit implicit TLS",
+			cfg:  SMTPConfig{Port: 465, TLS: SMTPTLSImplicit},
+			want: SMTPTLSImplicit,
+		},
+		{
+			name: "opportunistic policy",
+			cfg:  SMTPConfig{Port: 587, TLS: SMTPTLSOpportunistic},
+			want: SMTPTLSOpportunistic,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.TLSPolicyOrDefault(); got != tt.want {
+				t.Errorf("TLSPolicyOrDefault() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestTLSConfig_CacheDirOrDefault(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -1869,12 +1911,24 @@ func TestChattoConfig_Validate_SMTP(t *testing.T) {
 			wantError: false,
 		},
 		{
+			name: "valid config with explicit implicit SMTP TLS",
+			modify: func(c *ChattoConfig) {
+				c.Webserver.URL = "https://chat.example"
+				c.SMTP.Enabled = true
+				c.SMTP.Host = "smtp.example.com"
+				c.SMTP.Port = 465
+				c.SMTP.TLS = SMTPTLSImplicit
+				c.SMTP.From = "noreply@example.com"
+			},
+			wantError: false,
+		},
+		{
 			name: "invalid SMTP TLS policy fails",
 			modify: func(c *ChattoConfig) {
 				c.SMTP.TLS = "plaintext"
 			},
 			wantError: true,
-			errorMsg:  "smtp.tls must be one of: mandatory, opportunistic",
+			errorMsg:  "smtp.tls must be one of: mandatory, opportunistic, implicit",
 		},
 		{
 			name: "SMTP enabled without host fails",

--- a/cli/internal/email/email.go
+++ b/cli/internal/email/email.go
@@ -65,11 +65,7 @@ func (m *Mailer) SendContext(ctx context.Context, msg Message) error {
 	message.SetBodyString(mail.TypeTextPlain, msg.Body)
 
 	// Build client options
-	opts := []mail.Option{
-		mail.WithPort(m.config.Port),
-		mail.WithTLSPortPolicy(mailTLSPolicy(m.config)),
-		mail.WithHELO("localhost"), // Use consistent HELO domain across all environments
-	}
+	opts := mailOptions(m.config)
 
 	// Add authentication if credentials provided
 	if m.config.Username != "" && m.config.Password != "" {
@@ -98,11 +94,20 @@ func (m *Mailer) IsEnabled() bool {
 	return m.config.Enabled
 }
 
-func mailTLSPolicy(cfg config.SMTPConfig) mail.TLSPolicy {
-	switch cfg.TLSPolicyOrDefault() {
-	case config.SMTPTLSOpportunistic:
-		return mail.TLSOpportunistic
-	default:
-		return mail.TLSMandatory
+func mailOptions(cfg config.SMTPConfig) []mail.Option {
+	opts := []mail.Option{
+		mail.WithPort(cfg.Port),
+		mail.WithHELO("localhost"), // Use consistent HELO domain across all environments
 	}
+
+	switch cfg.TLSPolicyOrDefault() {
+	case config.SMTPTLSImplicit:
+		opts = append(opts, mail.WithSSL())
+	case config.SMTPTLSOpportunistic:
+		opts = append(opts, mail.WithTLSPortPolicy(mail.TLSOpportunistic))
+	default:
+		opts = append(opts, mail.WithTLSPortPolicy(mail.TLSMandatory))
+	}
+
+	return opts
 }

--- a/cli/internal/email/email_test.go
+++ b/cli/internal/email/email_test.go
@@ -2,6 +2,7 @@ package email
 
 import (
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/wneessen/go-mail"
@@ -47,39 +48,52 @@ func TestMailer_IsEnabled(t *testing.T) {
 	}
 }
 
-func TestMailTLSPolicy(t *testing.T) {
+func TestMailOptionsTLS(t *testing.T) {
 	tests := []struct {
-		name string
-		cfg  config.SMTPConfig
-		want mail.TLSPolicy
+		name    string
+		cfg     config.SMTPConfig
+		wantSSL bool
 	}{
 		{
-			name: "defaults to mandatory",
-			cfg:  config.SMTPConfig{},
-			want: mail.TLSMandatory,
+			name:    "mandatory STARTTLS does not use implicit TLS",
+			cfg:     config.SMTPConfig{Port: 587, TLS: config.SMTPTLSMandatory},
+			wantSSL: false,
 		},
 		{
-			name: "mandatory",
-			cfg:  config.SMTPConfig{TLS: config.SMTPTLSMandatory},
-			want: mail.TLSMandatory,
+			name:    "opportunistic STARTTLS does not use implicit TLS",
+			cfg:     config.SMTPConfig{Port: 587, TLS: config.SMTPTLSOpportunistic},
+			wantSSL: false,
 		},
 		{
-			name: "opportunistic",
-			cfg:  config.SMTPConfig{TLS: config.SMTPTLSOpportunistic},
-			want: mail.TLSOpportunistic,
+			name:    "explicit implicit TLS uses SSL mode",
+			cfg:     config.SMTPConfig{Port: 465, TLS: config.SMTPTLSImplicit},
+			wantSSL: true,
 		},
 		{
-			name: "unknown falls back to mandatory",
-			cfg:  config.SMTPConfig{TLS: "unexpected"},
-			want: mail.TLSMandatory,
+			name:    "port 465 with default policy uses SSL mode",
+			cfg:     config.SMTPConfig{Port: 465},
+			wantSSL: true,
+		},
+		{
+			name:    "port 465 with mandatory policy uses SSL mode",
+			cfg:     config.SMTPConfig{Port: 465, TLS: config.SMTPTLSMandatory},
+			wantSSL: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := mailTLSPolicy(tt.cfg); got != tt.want {
-				t.Errorf("mailTLSPolicy() = %v, want %v", got, tt.want)
+			client, err := mail.NewClient("smtp.example.com", mailOptions(tt.cfg)...)
+			if err != nil {
+				t.Fatalf("NewClient() failed: %v", err)
+			}
+			if got := clientUsesSSL(client); got != tt.wantSSL {
+				t.Errorf("implicit TLS = %v, want %v", got, tt.wantSSL)
 			}
 		})
 	}
+}
+
+func clientUsesSSL(client *mail.Client) bool {
+	return reflect.ValueOf(client).Elem().FieldByName("useSSL").Bool()
 }

--- a/docs-website/src/content/docs/guides/dockercompose.mdx
+++ b/docs-website/src/content/docs/guides/dockercompose.mdx
@@ -197,6 +197,9 @@ By the end of this section, your project directory will look like this:
 
    Replace all `<generate-me>` values with output from `openssl rand -hex 32`. Make sure `NATS_TOKEN` and `CHATTO_NATS_CLIENT_TOKEN` match, and the LiveKit key/secret match what's in `livekit.yaml`.
 
+   The SMTP example uses STARTTLS submission on port `587`. For providers that
+   require SMTPS on port `465`, set `CHATTO_SMTP_TLS=implicit`.
+
    Set `CHATTO_OWNERS_EMAILS` to the email address you will use for the first account. Registration sends a code by email and creates the account with that email already verified; if it matches this list, Chatto assigns the owner role automatically.
 
 6. **Start the stack**
@@ -364,7 +367,7 @@ rtc:
 
 **Chatto can't connect to NATS** — Ensure `NATS_TOKEN` and `CHATTO_NATS_CLIENT_TOKEN` match in `.env`.
 
-**Registration says email delivery is not configured** — Direct email/password registration requires SMTP. Set `CHATTO_SMTP_ENABLED=true` and configure `CHATTO_SMTP_HOST`, `CHATTO_SMTP_PORT`, `CHATTO_SMTP_TLS`, and `CHATTO_SMTP_FROM`. Add username and password when your SMTP server requires authentication.
+**Registration says email delivery is not configured** — Direct email/password registration requires SMTP. Set `CHATTO_SMTP_ENABLED=true` and configure `CHATTO_SMTP_HOST`, `CHATTO_SMTP_PORT`, `CHATTO_SMTP_TLS`, and `CHATTO_SMTP_FROM`. Use `CHATTO_SMTP_TLS=implicit` for SMTPS providers on port `465`. Add username and password when your SMTP server requires authentication.
 
 **The first account is not an owner** — Make sure `CHATTO_OWNERS_EMAILS` contains the verified email address for that account. For an already-verified account, restart Chatto after updating the variable; Chatto applies matching owner roles on boot.
 

--- a/docs-website/src/content/docs/reference/environment-variables.mdx
+++ b/docs-website/src/content/docs/reference/environment-variables.mdx
@@ -271,11 +271,11 @@ See [External Login Providers](/guides/external-login-providers/) for callback U
 </EnvVar>
 
 <EnvVar name="CHATTO_SMTP_PORT" toml="smtp.port">
-  SMTP port. Common value: `587` (STARTTLS).
+  SMTP port. Common values: `587` for STARTTLS, or `465` for implicit TLS/SMTPS.
 </EnvVar>
 
 <EnvVar name="CHATTO_SMTP_TLS" toml="smtp.tls" default="mandatory">
-  SMTP TLS policy. Use `mandatory` to require STARTTLS. Use `opportunistic` only when the SMTP server cannot support mandatory STARTTLS and plaintext fallback is explicitly acceptable.
+  SMTP TLS policy. Use `mandatory` to require STARTTLS on port `587`, or `implicit` for SMTPS on port `465`. When this value is omitted or left as `mandatory`, Chatto automatically uses implicit TLS for port `465`. Use `opportunistic` only when the SMTP server cannot support mandatory STARTTLS and plaintext fallback is explicitly acceptable.
 </EnvVar>
 
 <EnvVar name="CHATTO_SMTP_USERNAME" toml="smtp.username">

--- a/examples/dockercompose/.env.example
+++ b/examples/dockercompose/.env.example
@@ -35,6 +35,7 @@ CHATTO_LIVEKIT_API_SECRET=your-api-secret
 # email verification, and password reset)
 CHATTO_SMTP_ENABLED=true
 CHATTO_SMTP_HOST=smtp.example.com
+# Use port 587 with mandatory STARTTLS, or port 465 with implicit TLS/SMTPS.
 CHATTO_SMTP_PORT=587
 CHATTO_SMTP_TLS=mandatory
 CHATTO_SMTP_USERNAME=your-smtp-username

--- a/examples/k8s/secrets.yaml
+++ b/examples/k8s/secrets.yaml
@@ -35,6 +35,7 @@ stringData:
   # SMTP configuration (optional - uncomment to enable)
   # CHATTO_SMTP_ENABLED: "true"
   # CHATTO_SMTP_HOST: "smtp.example.com"
+  # Use port 587 with mandatory STARTTLS, or port 465 with implicit TLS/SMTPS.
   # CHATTO_SMTP_PORT: "587"
   # CHATTO_SMTP_TLS: "mandatory"
   # CHATTO_SMTP_USERNAME: "your-smtp-username"


### PR DESCRIPTION
- Add SMTP `implicit` TLS support for SMTPS providers on port 465, including automatic implicit TLS selection for port 465 with the default or mandatory policy.
- Keep `mandatory` STARTTLS behavior for port 587 and preserve `opportunistic` behavior.
- Generate safer SMTP defaults from `chatto init` and update self-hosting docs/examples for STARTTLS vs SMTPS.
- Add config, mailer, and init tests for the new behavior.

Tests:
- `cd cli && mise x -- go test ./internal/config ./internal/email ./cmd -timeout 90s`
