### PR TITLE
fix(ci): checkout docs image PR refs

### DIFF
--- a/.github/workflows/build-docs-image.yml
+++ b/.github/workflows/build-docs-image.yml
@@ -5,10 +5,6 @@ on:
     branches: [main]
     paths:
       - "docs-website/**"
-  pull_request:
-    branches: [main]
-    paths:
-      - "docs-website/**"
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/build-docs-image.yml
+++ b/.github/workflows/build-docs-image.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref || github.ref_name }}
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Resolve image metadata
         id: image


### PR DESCRIPTION
- Fix the docs image workflow checkout fallback for pull request events.
- Use the full GitHub event ref so `actions/checkout` can resolve refs such as `refs/pull/901/merge`.
- Preserve the manual `workflow_dispatch` ref override when one is provided.
- Stop running the docs image Docker build workflow on pull requests; it now runs only for `main` docs changes and manual dispatch.
