### PR TITLE
fix: refresh room layout state after room creation

### DIFF
--- a/frontend/src/lib/state/server/roomDirectory.svelte.spec.ts
+++ b/frontend/src/lib/state/server/roomDirectory.svelte.spec.ts
@@ -263,7 +263,7 @@ describe('RoomDirectoryStore — ingestServerEvent', () => {
     expect(queryMock).toHaveBeenCalledTimes(2);
   });
 
-  it('refreshes on RoomArchivedEvent and RoomUnarchivedEvent', async () => {
+  it('refreshes on room catalog and layout changes', async () => {
     const { client, queryMock } = makeClient({
       query: { server: { id: SPACE_ID, rooms: [] } }
     });
@@ -271,12 +271,20 @@ describe('RoomDirectoryStore — ingestServerEvent', () => {
     void store.refresh();
     await settle();
 
+    store.ingestServerEvent(makeEvent('RoomCreatedEvent'));
+    await settle();
+    store.ingestServerEvent(makeEvent('RoomUpdatedEvent'));
+    await settle();
     store.ingestServerEvent(makeEvent('RoomArchivedEvent'));
     await settle();
     store.ingestServerEvent(makeEvent('RoomUnarchivedEvent'));
     await settle();
+    store.ingestServerEvent(makeEvent('RoomDeletedEvent'));
+    await settle();
+    store.ingestServerEvent(makeEvent('RoomGroupsUpdatedEvent'));
+    await settle();
 
-    expect(queryMock).toHaveBeenCalledTimes(3);
+    expect(queryMock).toHaveBeenCalledTimes(7);
   });
 
   it('does NOT refresh on irrelevant event types', async () => {

--- a/frontend/src/lib/state/server/roomDirectory.svelte.ts
+++ b/frontend/src/lib/state/server/roomDirectory.svelte.ts
@@ -1,6 +1,7 @@
 import { SvelteSet } from 'svelte/reactivity';
 import type { Client } from '@urql/svelte';
 import { graphql } from '$lib/gql';
+import { isRoomStateRefreshEvent } from './rooms.svelte';
 
 export type DirectoryRoom = {
   id: string;
@@ -195,8 +196,9 @@ export class RoomDirectoryStore {
   // ---------------------------------------------------------------------------
 
   /**
-   * Refresh on membership / archive changes. Other event types are no-ops.
-   * Mirrors the trigger set used by {@link RoomsStore.ingestServerEvent}.
+   * Refresh on membership, room catalog, and group layout changes. Other
+   * event types are no-ops. Mirrors the trigger set used by
+   * {@link RoomsStore.ingestServerEvent}.
    *
    * Accepts a discriminated-union envelope so the test harness can pass a
    * minimal stub without needing to materialise a full RoomEventViewFragment
@@ -205,12 +207,7 @@ export class RoomDirectoryStore {
   ingestServerEvent(serverEvent: { event?: { __typename?: string } | null }): void {
     const event = serverEvent.event;
     if (!event) return;
-    if (
-      event.__typename === 'UserJoinedRoomEvent' ||
-      event.__typename === 'UserLeftRoomEvent' ||
-      event.__typename === 'RoomArchivedEvent' ||
-      event.__typename === 'RoomUnarchivedEvent'
-    ) {
+    if (isRoomStateRefreshEvent(event.__typename)) {
       void this.refresh();
     }
   }

--- a/frontend/src/lib/state/server/rooms.svelte.spec.ts
+++ b/frontend/src/lib/state/server/rooms.svelte.spec.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi } from 'vitest';
+import { flushSync } from 'svelte';
+import type { Client } from '@urql/svelte';
+import { NotificationLevel, RoomType } from '$lib/gql/graphql';
+import { NotificationLevelStore } from './notificationLevel.svelte';
+import { RoomUnreadStore } from './roomUnread.svelte';
+import { isRoomStateRefreshEvent, RoomsStore } from './rooms.svelte';
+
+type QueryRoom = {
+  id: string;
+  name: string;
+  type: RoomType;
+  hasUnread: boolean;
+  archived: boolean;
+  viewerNotificationPreference: {
+    level: NotificationLevel;
+    effectiveLevel: NotificationLevel;
+  } | null;
+  members: {
+    users: Array<{
+      id: string;
+      login: string;
+      displayName: string;
+      avatarUrl: string | null;
+      presenceStatus: string;
+    }>;
+  };
+};
+
+type QueryResponse = {
+  viewer: {
+    user: {
+      id: string;
+      rooms: QueryRoom[];
+    };
+  };
+  server: {
+    roomGroups: Array<{
+      id: string;
+      name: string;
+      rooms: Array<{ id: string }>;
+    }>;
+  };
+};
+
+function makeRoom(id: string, overrides: Partial<QueryRoom> = {}): QueryRoom {
+  return {
+    id,
+    name: overrides.name ?? id,
+    type: overrides.type ?? RoomType.Channel,
+    hasUnread: overrides.hasUnread ?? false,
+    archived: overrides.archived ?? false,
+    viewerNotificationPreference:
+      overrides.viewerNotificationPreference === undefined
+        ? {
+            level: NotificationLevel.Default,
+            effectiveLevel: NotificationLevel.Normal
+          }
+        : overrides.viewerNotificationPreference,
+    members: overrides.members ?? {
+      users: [
+        {
+          id: 'U1',
+          login: 'alice',
+          displayName: 'Alice',
+          avatarUrl: null,
+          presenceStatus: 'ONLINE'
+        }
+      ]
+    }
+  };
+}
+
+function makeResponse(
+  rooms: QueryRoom[],
+  groups: QueryResponse['server']['roomGroups'] = []
+): QueryResponse {
+  return {
+    viewer: {
+      user: {
+        id: 'U1',
+        rooms
+      }
+    },
+    server: {
+      roomGroups: groups
+    }
+  };
+}
+
+function makeStore(client: Client) {
+  return new RoomsStore(client, new NotificationLevelStore(), new RoomUnreadStore());
+}
+
+function makeClient(responses: Array<QueryResponse | null>) {
+  const queue = [...responses];
+  const queryMock = vi.fn(() => ({
+    toPromise: () => Promise.resolve({ data: queue.shift() ?? null, error: null })
+  }));
+  const client = { query: queryMock } as unknown as Client;
+  return { client, queryMock };
+}
+
+async function settle() {
+  await Promise.resolve();
+  await Promise.resolve();
+  flushSync();
+}
+
+describe('RoomsStore - refresh', () => {
+  it('discards out-of-order responses', async () => {
+    let resolveFirst!: (value: { data: QueryResponse; error: null }) => void;
+    let resolveSecond!: (value: { data: QueryResponse; error: null }) => void;
+    const queryMock = vi
+      .fn()
+      .mockImplementationOnce(() => ({
+        toPromise: () => new Promise((resolve) => (resolveFirst = resolve))
+      }))
+      .mockImplementationOnce(() => ({
+        toPromise: () => new Promise((resolve) => (resolveSecond = resolve))
+      }));
+    const store = makeStore({ query: queryMock } as unknown as Client);
+
+    void store.refresh();
+    void store.refresh();
+
+    resolveSecond({
+      data: makeResponse(
+        [makeRoom('newer')],
+        [{ id: 'g1', name: 'Lobby', rooms: [{ id: 'newer' }] }]
+      ),
+      error: null
+    });
+    await settle();
+
+    expect(store.rooms.map((room) => room.id)).toEqual(['newer']);
+    expect(store.roomGroups).toEqual([{ id: 'g1', name: 'Lobby', roomIds: ['newer'] }]);
+
+    resolveFirst({
+      data: makeResponse(
+        [makeRoom('older')],
+        [{ id: 'g1', name: 'Lobby', rooms: [{ id: 'older' }] }]
+      ),
+      error: null
+    });
+    await settle();
+
+    expect(store.rooms.map((room) => room.id)).toEqual(['newer']);
+    expect(store.roomGroups).toEqual([{ id: 'g1', name: 'Lobby', roomIds: ['newer'] }]);
+  });
+});
+
+describe('RoomsStore - ingestServerEvent', () => {
+  function makeEvent(typename: string) {
+    return { event: { __typename: typename } };
+  }
+
+  it('uses one shared predicate for room state refresh events', () => {
+    expect(isRoomStateRefreshEvent('RoomCreatedEvent')).toBe(true);
+    expect(isRoomStateRefreshEvent('RoomGroupsUpdatedEvent')).toBe(true);
+    expect(isRoomStateRefreshEvent('ReactionAddedEvent')).toBe(false);
+  });
+
+  it('refreshes on RoomCreatedEvent', () => {
+    const { client } = makeClient([]);
+    const store = makeStore(client);
+    store.refresh = vi.fn().mockResolvedValue(undefined);
+
+    store.ingestServerEvent(makeEvent('RoomCreatedEvent'));
+
+    expect(store.refresh).toHaveBeenCalledOnce();
+  });
+
+  it('refreshes on RoomGroupsUpdatedEvent', () => {
+    const { client } = makeClient([]);
+    const store = makeStore(client);
+    store.refresh = vi.fn().mockResolvedValue(undefined);
+
+    store.ingestServerEvent(makeEvent('RoomGroupsUpdatedEvent'));
+
+    expect(store.refresh).toHaveBeenCalledOnce();
+  });
+
+  it('refreshes on UserJoinedRoomEvent', () => {
+    const { client } = makeClient([]);
+    const store = makeStore(client);
+    store.refresh = vi.fn().mockResolvedValue(undefined);
+
+    store.ingestServerEvent(makeEvent('UserJoinedRoomEvent'));
+
+    expect(store.refresh).toHaveBeenCalledOnce();
+  });
+
+  it('does not refresh on irrelevant event types', () => {
+    const { client } = makeClient([]);
+    const store = makeStore(client);
+    store.refresh = vi.fn().mockResolvedValue(undefined);
+
+    store.ingestServerEvent(makeEvent('ReactionAddedEvent'));
+    store.ingestServerEvent(makeEvent('HeartbeatEvent'));
+
+    expect(store.refresh).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/state/server/rooms.svelte.ts
+++ b/frontend/src/lib/state/server/rooms.svelte.ts
@@ -1,11 +1,7 @@
 import { untrack } from 'svelte';
 import type { Client } from '@urql/svelte';
 import { graphql, useFragment } from '$lib/gql';
-import {
-  RoomType,
-  UserAvatarUserFragmentDoc,
-  type UserAvatarUserFragment
-} from '$lib/gql/graphql';
+import { RoomType, UserAvatarUserFragmentDoc, type UserAvatarUserFragment } from '$lib/gql/graphql';
 import type { NotificationLevelStore } from '$lib/state/server/notificationLevel.svelte';
 import type { RoomUnreadStore } from '$lib/state/server/roomUnread.svelte';
 
@@ -68,6 +64,21 @@ function uniqueById<T extends { id: string }>(items: T[]): T[] {
   });
 }
 
+const roomStateRefreshEvents = new Set([
+  'RoomCreatedEvent',
+  'RoomDeletedEvent',
+  'RoomGroupsUpdatedEvent',
+  'RoomUpdatedEvent',
+  'RoomArchivedEvent',
+  'RoomUnarchivedEvent',
+  'UserJoinedRoomEvent',
+  'UserLeftRoomEvent'
+]);
+
+export function isRoomStateRefreshEvent(typename: string | undefined): boolean {
+  return !!typename && roomStateRefreshEvents.has(typename);
+}
+
 /**
  * Reactive store for a server's joined-room list, layout, and per-room
  * unread/mention state. One store per registered server, owned by
@@ -124,12 +135,14 @@ export class RoomsStore {
       }
 
       const visible = allRooms.filter((r: { archived: boolean }) => !r.archived);
-      this.rooms = visible.map((r: typeof allRooms[number]) => ({
+      this.rooms = visible.map((r: (typeof allRooms)[number]) => ({
         id: r.id,
         name: r.name,
         type: r.type,
         hasUnread: r.hasUnread,
-        members: r.members.users.map((m: typeof r.members.users[number]) => useFragment(UserAvatarUserFragmentDoc, m))
+        members: r.members.users.map((m: (typeof r.members.users)[number]) =>
+          useFragment(UserAvatarUserFragmentDoc, m)
+        )
       }));
       this.roomUnread.initRooms(visible);
     }
@@ -192,23 +205,19 @@ export class RoomsStore {
   // -------------------------------------------------------------------------
 
   /**
-   * Refresh the room list when membership or room metadata changes. Other
-   * event types (messages, reactions, presence) are no-ops at this level
-   * unless the message arrives for a room we don't yet know about — that's
-   * how a freshly-created empty DM (filtered from the active member-room DM
-   * list until its first message lands) shows up in the sidebar without a
-   * manual reload.
+   * Refresh the room list when membership, room metadata, or group layout
+   * changes. Other event types (messages, reactions, presence) are no-ops at
+   * this level unless the message arrives for a room we don't yet know about —
+   * that's how a freshly-created empty DM (filtered from the active
+   * member-room DM list until its first message lands) shows up in the
+   * sidebar without a manual reload.
    */
-  ingestServerEvent(serverEvent: { event?: { __typename?: string; roomId?: string } | null }): void {
+  ingestServerEvent(serverEvent: {
+    event?: { __typename?: string; roomId?: string } | null;
+  }): void {
     const event = serverEvent.event;
     if (!event) return;
-    if (
-      event.__typename === 'UserJoinedRoomEvent' ||
-      event.__typename === 'UserLeftRoomEvent' ||
-      event.__typename === 'RoomUpdatedEvent' ||
-      event.__typename === 'RoomArchivedEvent' ||
-      event.__typename === 'RoomUnarchivedEvent'
-    ) {
+    if (isRoomStateRefreshEvent(event.__typename)) {
       void this.refresh();
       return;
     }

--- a/frontend/src/lib/state/server/store.svelte.spec.ts
+++ b/frontend/src/lib/state/server/store.svelte.spec.ts
@@ -29,7 +29,6 @@ class FakeGqlClient {
       subscription: vi.fn(() => this.subject.source as unknown as Source<unknown>)
     } as unknown as Client;
   }
-
 }
 
 const registered: RegisteredServer = {
@@ -167,7 +166,7 @@ describe('ServerStateStore live server updates', () => {
     expect(store.serverInfo.livekitUrl).toBe('wss://livekit');
   });
 
-  it('forwards RoomGroupsUpdatedEvent to the admin room layout store', async () => {
+  it('forwards RoomGroupsUpdatedEvent once to every room-state store', async () => {
     const fake = new FakeGqlClient([
       {
         server: {
@@ -197,7 +196,9 @@ describe('ServerStateStore live server updates', () => {
     store.currentUser.user = { id: 'U1', login: 'alice', displayName: 'Alice' } as never;
     await Promise.resolve();
     await Promise.resolve();
-    fake.query.mockClear();
+    store.rooms.refresh = vi.fn().mockResolvedValue(undefined);
+    store.roomDirectory.refresh = vi.fn().mockResolvedValue(undefined);
+    store.adminRoomLayout.refresh = vi.fn().mockResolvedValue(undefined);
 
     eventBusManager.startBus(registered.id, fake as unknown as GraphQLClient);
     flushSync();
@@ -216,14 +217,9 @@ describe('ServerStateStore live server updates', () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(fake.query).toHaveBeenCalledTimes(3);
-    expect(store.adminRoomLayout.groups).toEqual([
-      {
-        id: 'g1',
-        name: 'Lobby',
-        rooms: [{ id: 'r1', name: 'general', description: null, archived: false }]
-      }
-    ]);
+    expect(store.rooms.refresh).toHaveBeenCalledOnce();
+    expect(store.roomDirectory.refresh).toHaveBeenCalledOnce();
+    expect(store.adminRoomLayout.refresh).toHaveBeenCalledOnce();
   });
 
   it('refreshes projected server state for bearer-auth sessions', async () => {

--- a/frontend/src/lib/state/server/store.svelte.ts
+++ b/frontend/src/lib/state/server/store.svelte.ts
@@ -142,10 +142,6 @@ export class ServerStateStore {
               });
             }
           }
-          if (event.event?.__typename === 'RoomGroupsUpdatedEvent') {
-            void this.rooms.refresh();
-            this.roomDirectory.ingestRoomLayoutUpdated();
-          }
         };
         const catchUpHandler = (reason: EventBusCatchUpReason) => {
           void this.refreshProjectedStateAfterMissedEvents(reason);
@@ -168,9 +164,12 @@ export class ServerStateStore {
 
     if (this.#catchUpRefreshInFlight) {
       this.#queuedCatchUpRefreshReason = reason;
-      console.debug(`[server:${this.#registered.url}] queued catch-up refresh while one is running`, {
-        reason
-      });
+      console.debug(
+        `[server:${this.#registered.url}] queued catch-up refresh while one is running`,
+        {
+          reason
+        }
+      );
       return;
     }
 
@@ -186,9 +185,12 @@ export class ServerStateStore {
     let failed = false;
 
     try {
-      console.debug(`[server:${this.#registered.url}] refreshing projected state after event bus gap`, {
-        reason
-      });
+      console.debug(
+        `[server:${this.#registered.url}] refreshing projected state after event bus gap`,
+        {
+          reason
+        }
+      );
 
       const run = async (label: string, task: () => Promise<unknown>) => {
         try {
@@ -214,9 +216,12 @@ export class ServerStateStore {
 
       if (!failed) {
         this.#lastSuccessfulCatchUpRefreshAt = Date.now();
-        console.debug(`[server:${this.#registered.url}] projected state catch-up refresh completed`, {
-          reason
-        });
+        console.debug(
+          `[server:${this.#registered.url}] projected state catch-up refresh completed`,
+          {
+            reason
+          }
+        );
       }
     } finally {
       this.#catchUpRefreshInFlight = false;

--- a/frontend/src/routes/chat/[serverId]/server-admin/rooms/+page.svelte
+++ b/frontend/src/routes/chat/[serverId]/server-admin/rooms/+page.svelte
@@ -7,9 +7,15 @@
 
   const activeServerId = $derived(getActiveServer());
   const serverSegment = $derived(serverIdToSegment(activeServerId));
-  const layout = $derived(serverRegistry.getStore(activeServerId).adminRoomLayout);
+  const stores = $derived(serverRegistry.getStore(activeServerId));
+  const layout = $derived(stores.adminRoomLayout);
+
+  function refreshServerRoomState() {
+    void stores.rooms.refresh();
+    void stores.roomDirectory.refresh();
+  }
 </script>
 
 <PageTitle title="Rooms | Space Admin" />
 
-<AdminRoomLayoutEditor {layout} {serverSegment} />
+<AdminRoomLayoutEditor {layout} {serverSegment} onroomcreated={refreshServerRoomState} />

--- a/frontend/src/routes/chat/[serverId]/server-admin/rooms/AdminRoomLayoutEditor.svelte
+++ b/frontend/src/routes/chat/[serverId]/server-admin/rooms/AdminRoomLayoutEditor.svelte
@@ -21,10 +21,12 @@
 
   let {
     layout,
-    serverSegment
+    serverSegment,
+    onroomcreated
   }: {
     layout: AdminRoomLayoutStore;
     serverSegment: string;
+    onroomcreated?: () => void;
   } = $props();
 
   type DndRoomItem = RoomInfo & { id: string };
@@ -287,6 +289,7 @@
     createRoomGroupId = null;
     toast.success('Room created');
     layout.handleRoomCreated();
+    onroomcreated?.();
   }
 </script>
 


### PR DESCRIPTION
- Refresh server room and room-directory stores from shared room catalog/layout event triggers, including room creation and group layout updates.
- Remove duplicate RoomGroupsUpdatedEvent forwarding from ServerStateStore and explicitly refresh same-tab room state after admin room creation.
- Add focused store coverage for refresh triggers, stale load guards, and single dispatch behavior.

Tests: `mise x -- pnpm test:unit --run --project client src/lib/state/server/rooms.svelte.spec.ts src/lib/state/server/roomDirectory.svelte.spec.ts src/lib/state/server/store.svelte.spec.ts 'src/routes/chat/[serverId]/server-admin/rooms/AdminRoomLayoutEditor.svelte.spec.ts'`; `mise x -- pnpm check`; `mise x -- pnpm exec playwright test e2e/room-layout.test.ts --retries=0 --workers=1`.
