### PR TITLE
fix(frontend): remount room on notification switch

### DIFF
--- a/frontend/e2e/cross-server-dots.test.ts
+++ b/frontend/e2e/cross-server-dots.test.ts
@@ -9,6 +9,7 @@ import {
 	joinSpaceOnRemote,
 	getRoomOnRemote,
 	postMessageOnRemote,
+	postThreadReplyOnRemote,
 	connectRemoteInstance
 } from './fixtures/multiServer';
 import {
@@ -97,6 +98,75 @@ test.describe('Cross-instance dots', () => {
 	// "DM on a remote instance lights up the DM icon" was removed with the
 	// cross-instance DM icon (#330 phase 3). Cross-server DM aggregation will
 	// be re-tested when that view is reintroduced.
+
+	test('clicking a remote thread notification dot remounts the containing room timeline', async ({
+		page,
+		chatPage,
+		roomPage
+	}) => {
+		// Home: mount a normal room first. This is the stale-state setup: the
+		// currently rendered Room subtree belongs to the home server before the
+		// remote notification dot routes to another server.
+		await createAndLoginTestUser(page);
+		await chatPage.goto();
+		await chatPage.createSpace();
+		await chatPage.enterRoom('general');
+		const homeGeneralRoomId = await getRoomIdByName(page, 'general');
+		const homeBody = `Home room before remote dot ${Date.now()}`;
+		await roomPage.sendMessage(homeBody);
+
+		// Remote: viewer will receive a mention on a thread reply.
+		const baseURL = remoteBaseURL(remoteServer);
+		const suffix = Date.now().toString(36);
+		const viewerLogin = `tv${suffix}`;
+		const owner = await createUserOnRemote(baseURL, `to${suffix}`, 'password123');
+		const viewer = await createUserOnRemote(baseURL, viewerLogin, 'password123');
+		const mentioner = await createUserOnRemote(baseURL, `tm${suffix}`, 'password123');
+		const remoteGeneralRoomId = await getRoomOnRemote(baseURL, owner.token, 'general');
+		const remoteRootBody = `Remote thread root ${suffix}`;
+		const remoteRootEventId = await postMessageOnRemote(
+			baseURL,
+			owner.token,
+			remoteGeneralRoomId,
+			remoteRootBody
+		);
+
+		await connectRemoteInstance(page, { ...remoteServer, baseURL }, viewer.userId);
+		await page.goto(routes.room(homeGeneralRoomId));
+		await expect(page.getByText(homeBody)).toBeVisible();
+
+		const remoteHostSegment = new URL(baseURL).hostname;
+		const remoteSpaceWrapper = page
+			.locator('.server-gutter .server-icon-wrapper')
+			.filter({ has: page.locator(`a[data-testid="server-icon"][href*="/chat/${remoteHostSegment}"]`) });
+		const remoteSpaceDot = remoteSpaceWrapper.locator('.bg-warning');
+		await expect(remoteSpaceDot).not.toBeVisible();
+
+		const remoteReplyBody = `@${viewerLogin} remote thread reply ${suffix}`;
+		await postThreadReplyOnRemote(
+			baseURL,
+			mentioner.token,
+			remoteGeneralRoomId,
+			remoteReplyBody,
+			remoteRootEventId
+		);
+
+		await expect(remoteSpaceDot).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+		await remoteSpaceDot.click();
+
+		await page.waitForURL(
+			(url) =>
+				url.pathname ===
+				`/chat/${remoteHostSegment}/${remoteGeneralRoomId}/${remoteRootEventId}`
+		);
+		await expect(page.getByRole('heading', { name: '# general' })).toBeVisible();
+		await roomPage.expectThreadPaneVisible();
+		await roomPage.expectTextInThreadPane(remoteReplyBody);
+
+		const mainRoomTimeline = page.locator('[data-testid="messages-container"]').first();
+		await expect(mainRoomTimeline.locator('[role="article"]')).not.toHaveCount(0);
+		await expect(mainRoomTimeline.getByText(remoteRootBody)).toBeVisible();
+	});
 
 	test('mention on a thread message: clicking the space dot opens the thread', async ({
 		page,

--- a/frontend/e2e/cross-server-dots.test.ts
+++ b/frontend/e2e/cross-server-dots.test.ts
@@ -1,4 +1,4 @@
-import { expect } from '@playwright/test';
+import { expect, type Locator, type Page } from '@playwright/test';
 import { test } from './setup';
 import { createAndLoginTestUser, joinSpace } from './fixtures/testUser';
 import {
@@ -10,6 +10,7 @@ import {
 	getRoomOnRemote,
 	postMessageOnRemote,
 	postThreadReplyOnRemote,
+	startDMOnRemote,
 	connectRemoteInstance
 } from './fixtures/multiServer';
 import {
@@ -27,6 +28,27 @@ import * as routes from './routes';
  */
 function remoteBaseURL(server: ServerInfo): string {
 	return server.baseURL.replace('localhost', '127.0.0.1');
+}
+
+async function openSwitcher(page: Page): Promise<Locator> {
+	const isMac = process.platform === 'darwin';
+	const key = isMac ? 'Meta+k' : 'Control+k';
+	const dialog = page.locator('dialog.quick-switcher');
+
+	await expect(async () => {
+		await page.keyboard.press(key);
+		await expect(dialog).toBeVisible({ timeout: 500 });
+	}).toPass({ timeout: TIMEOUTS.UI_STANDARD, intervals: [200, 500, 1000] });
+
+	return dialog;
+}
+
+function switcherInput(dialog: Locator): Locator {
+	return dialog.getByPlaceholder('Go to server, room, or conversation...');
+}
+
+function switcherResults(dialog: Locator): Locator {
+	return dialog.locator('button.sidebar-item');
 }
 
 /**
@@ -166,6 +188,69 @@ test.describe('Cross-instance dots', () => {
 		const mainRoomTimeline = page.locator('[data-testid="messages-container"]').first();
 		await expect(mainRoomTimeline.locator('[role="article"]')).not.toHaveCount(0);
 		await expect(mainRoomTimeline.getByText(remoteRootBody)).toBeVisible();
+	});
+
+	test('quick switching to a remote DM keeps that server room timelines populated', async ({
+		page,
+		chatPage,
+		roomPage
+	}) => {
+		// Home: mount a room first so the quick switcher has to replace an
+		// already-rendered room subtree when it jumps to the remote instance.
+		await createAndLoginTestUser(page);
+		await chatPage.goto();
+		await chatPage.createSpace();
+		await chatPage.enterRoom('general');
+		const homeGeneralRoomId = await getRoomIdByName(page, 'general');
+		const homeBody = `Home room before remote DM switch ${Date.now()}`;
+		await roomPage.sendMessage(homeBody);
+
+		// Remote: create a DM for the connected viewer, plus a normal room event
+		// that must still be visible after navigating from the remote DM to #general.
+		const baseURL = remoteBaseURL(remoteServer);
+		const suffix = Date.now().toString(36);
+		const viewer = await createUserOnRemote(baseURL, `qv${suffix}`, 'password123');
+		const senderLogin = `qs${suffix}`;
+		const sender = await createUserOnRemote(baseURL, senderLogin, 'password123');
+		const remoteDmBody = `Remote DM before room navigation ${suffix}`;
+		const remoteDmRoomId = await startDMOnRemote(
+			baseURL,
+			sender.token,
+			viewer.userId,
+			remoteDmBody
+		);
+		const remoteGeneralRoomId = await getRoomOnRemote(baseURL, viewer.token, 'general');
+		const remoteRoomBody = `Remote general after DM switch ${suffix}`;
+		await postMessageOnRemote(baseURL, sender.token, remoteGeneralRoomId, remoteRoomBody);
+
+		await connectRemoteInstance(page, { ...remoteServer, baseURL }, viewer.userId);
+		await page.goto(routes.room(homeGeneralRoomId));
+		await expect(page.getByText(homeBody)).toBeVisible();
+
+		const remoteHostSegment = new URL(baseURL).hostname;
+		const dialog = await openSwitcher(page);
+		const input = switcherInput(dialog);
+		await expect(switcherResults(dialog).first()).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+		await input.fill(senderLogin);
+
+		const dmResult = switcherResults(dialog).filter({ hasText: senderLogin }).first();
+		await expect(dmResult).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+		await dmResult.click();
+
+		await page.waitForURL((url) => url.pathname === `/chat/${remoteHostSegment}/${remoteDmRoomId}`);
+		await expect(page.getByText(remoteDmBody)).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+
+		const remoteGeneralLink = chatPage.roomList.getByRole('link', { name: '# general' });
+		await expect(remoteGeneralLink).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+		await remoteGeneralLink.click();
+		await page.waitForURL(
+			(url) => url.pathname === `/chat/${remoteHostSegment}/${remoteGeneralRoomId}`
+		);
+		await expect(page.getByRole('heading', { name: '# general' })).toBeVisible();
+
+		const mainRoomTimeline = page.locator('[data-testid="messages-container"]').first();
+		await expect(mainRoomTimeline.locator('[role="article"]')).not.toHaveCount(0);
+		await expect(mainRoomTimeline.getByText(remoteRoomBody)).toBeVisible();
 	});
 
 	test('mention on a thread message: clicking the space dot opens the thread', async ({

--- a/frontend/e2e/fixtures/multiServer.ts
+++ b/frontend/e2e/fixtures/multiServer.ts
@@ -258,7 +258,7 @@ export async function startDMOnRemote(
 	const roomId = startData.data?.startDM?.id;
 	if (!roomId) throw new Error(`Failed to start DM on remote: ${JSON.stringify(startData)}`);
 
-	await postMessageOnRemote(remoteBaseURL, senderToken, 'DM', roomId, message);
+	await postMessageOnRemote(remoteBaseURL, senderToken, roomId, message);
 	return roomId;
 }
 

--- a/frontend/e2e/fixtures/multiServer.ts
+++ b/frontend/e2e/fixtures/multiServer.ts
@@ -198,6 +198,41 @@ export async function postMessageOnRemote(
 }
 
 /**
+ * Posts a thread reply in a room on a remote server. Returns the new event ID.
+ */
+export async function postThreadReplyOnRemote(
+	remoteBaseURL: string,
+	token: string,
+	roomId: string,
+	body: string,
+	threadRootEventId: string
+): Promise<string> {
+	const response = await fetch(`${remoteBaseURL}/api/graphql`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			'X-REQUEST-TYPE': 'GraphQL',
+			Authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify({
+			query: `mutation($input: PostMessageInput!) { postMessage(input: $input) { id } }`,
+			variables: { input: { roomId, body, threadRootEventId } }
+		})
+	});
+
+	if (!response.ok) {
+		throw new Error(`Failed to post thread reply on remote: ${await response.text()}`);
+	}
+
+	const data = await response.json();
+	const id = data.data?.postMessage?.id;
+	if (!id) {
+		throw new Error(`No event ID returned from remote thread reply: ${JSON.stringify(data)}`);
+	}
+	return id;
+}
+
+/**
  * Starts a DM conversation on a remote server and posts an initial message.
  * Returns the conversation (room) ID.
  */

--- a/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -191,6 +191,32 @@ function roomEventsResult({
 }
 
 describe('MessagesStore — room lifecycle ownership', () => {
+	it('does not refetch or clear events when setRoom is called for the current room', async () => {
+		const loaded = threadMessageEvent('m1');
+		const fake = new FakeGqlClient(
+			roomEventsResult({
+				events: [loaded],
+				startCursor: null,
+				endCursor: null,
+				hasOlder: false,
+				hasNewer: false
+			})
+		);
+		const store = new MessagesStore(fake as unknown as GraphQLClient, () => null);
+
+		store.setRoom('room-1');
+		await settle();
+		fake.queryMock.mockClear();
+
+		store.setRoom('room-1');
+		await settle();
+
+		expect(fake.queryMock).not.toHaveBeenCalled();
+		expect(store.rootEvents.map((event) => event.id)).toEqual(['m1']);
+		expect(store.isInitialLoading).toBe(false);
+		store.dispose();
+	});
+
 	it('serves already-loaded events by id without querying GraphQL', async () => {
 		const loaded = threadMessageEvent('m1');
 		const fake = new FakeGqlClient(
@@ -872,6 +898,31 @@ describe('MessagesStore — room lifecycle ownership', () => {
 });
 
 describe('MessagesStore — thread lifecycle ownership', () => {
+	it('does not refetch or clear events when setThread is called for the current thread', async () => {
+		const fake = new FakeGqlClient(
+			threadQueryResult({
+				replies: [threadMessageEvent('r1', 't1')],
+				startCursor: null,
+				endCursor: null,
+				hasOlder: false,
+				hasNewer: false
+			})
+		);
+		const store = new MessagesStore(fake as unknown as GraphQLClient, () => null);
+
+		store.setThread('room-1', 't1');
+		await settle();
+		fake.queryMock.mockClear();
+
+		store.setThread('room-1', 't1');
+		await settle();
+
+		expect(fake.queryMock).not.toHaveBeenCalled();
+		expect(store.threadEvents.map((event) => event.id)).toEqual(['t1', 'r1']);
+		expect(store.isInitialLoading).toBe(false);
+		store.dispose();
+	});
+
 	it('links and unlinks visible echoes for thread replies from live events', async () => {
 		const fake = new FakeGqlClient(
 			threadQueryResult({

--- a/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -151,6 +151,8 @@ export class MessagesStore {
   }
 
   setRoom(roomId: string): void {
+    if (this.scope === 'room' && this.roomId === roomId) return;
+
     this.scope = 'room';
     this.roomId = roomId;
     this.threadRootEventId = '';
@@ -158,6 +160,14 @@ export class MessagesStore {
   }
 
   setThread(roomId: string, threadRootEventId: string): void {
+    if (
+      this.scope === 'thread' &&
+      this.roomId === roomId &&
+      this.threadRootEventId === threadRootEventId
+    ) {
+      return;
+    }
+
     this.scope = 'thread';
     this.roomId = roomId;
     this.threadRootEventId = threadRootEventId;

--- a/frontend/src/routes/chat/[serverId]/[roomId]/+layout.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/+layout.svelte
@@ -8,11 +8,13 @@
 
   let { roomId } = $derived(data);
 
+  const activeServerId = $derived(getActiveServer());
+
   // Wait for the active server's merged rooms store (channels + DMs) to
   // settle before letting children mount. Without this, a freshly-loaded
   // room page can fire queries against the URL roomId before the store has
   // decided whether the room exists, briefly showing the not-found redirect.
-  const roomsStore = $derived(serverRegistry.getStore(getActiveServer()).rooms);
+  const roomsStore = $derived(serverRegistry.getStore(activeServerId).rooms);
   const ready = $derived(!roomsStore.isInitialLoading);
 
   let threadId = $derived(page.params.threadId);
@@ -29,6 +31,8 @@
 			Room is rendered in the layout so it stays mounted when navigating
 			between room and thread URLs. This prevents unnecessary reloads.
 		-->
-    <Room {roomId} {threadId} />
+    {#key activeServerId}
+      <Room {roomId} {threadId} />
+    {/key}
   {/if}
 {/if}


### PR DESCRIPTION
- Key the room route subtree by active server so notification-dot navigation to another server rebuilds server-scoped room state while preserving same-server thread navigation.
- Make `MessagesStore.setRoom` and `setThread` no-op when already scoped to the requested destination, preventing redundant timeline clears/refetches.
- Add cross-server e2e coverage for remote thread notification dots, quick-switcher remote DM navigation into remote rooms, and unit coverage for the idempotent message-store lifecycle guards.

Tests:
- `pnpm check`
- `pnpm test:unit -- --run src/lib/state/room/messages.svelte.spec.ts`
- `pnpm test:e2e -- cross-server-dots.test.ts`
