### PR TITLE
test(frontend): migrate deterministic e2e coverage

### DIFF
--- a/frontend/e2e/page-titles.test.ts
+++ b/frontend/e2e/page-titles.test.ts
@@ -21,23 +21,6 @@ async function createAndLoginAdminUser(page: Page): Promise<TestUser> {
 }
 
 test.describe('Page titles', () => {
-  // 'Browse Spaces page has correct title' was retired with the Browse
-  // Spaces UI in PR(a).
-
-  test('browse rooms page has correct title', async ({ page, chatPage }) => {
-    await createAndLoginTestUser(page);
-    await chatPage.goto();
-    const spaceName = await chatPage.createSpace();
-
-    // Navigate to Browse Rooms page (space context but no specific room)
-    await page.getByRole('link', { name: 'Overview' }).click();
-    await page.waitForURL(routes.patterns.browseRooms);
-
-    // Post-#330 PR(a) the instance name falls back to the bootstrap space's
-    // name when no runtime override is configured.
-    await expect(page).toHaveTitle(`Overview | ${spaceName}`);
-  });
-
   test('room page has room and space name in title', async ({ page, chatPage }) => {
     await createAndLoginTestUser(page);
     await chatPage.goto();
@@ -49,26 +32,6 @@ test.describe('Page titles', () => {
 
     // Title: "#room - <space> | <instance>". Post-PR(a) instance name falls
     // back to the space name when no runtime override is configured.
-    await expect(page).toHaveTitle(`#general - ${spaceName} | ${spaceName}`);
-  });
-
-  test('room title updates when switching pages', async ({ page, chatPage }) => {
-    await createAndLoginTestUser(page);
-    await chatPage.goto();
-    const spaceName = await chatPage.createSpace();
-
-    // Enter general room
-    await chatPage.enterRoom('general');
-    await expect(chatPage.getRoomHeader('general')).toBeVisible();
-    await expect(page).toHaveTitle(`#general - ${spaceName} | ${spaceName}`);
-
-    // Go back to space index by navigating to browse rooms and back
-    await page.getByRole('link', { name: 'Overview' }).click();
-    await expect(page).toHaveTitle(`Overview | ${spaceName}`);
-
-    // Re-enter general room and verify title is set again
-    await chatPage.enterRoom('general');
-    await expect(chatPage.getRoomHeader('general')).toBeVisible();
     await expect(page).toHaveTitle(`#general - ${spaceName} | ${spaceName}`);
   });
 
@@ -91,54 +54,6 @@ test.describe('Page titles', () => {
 
     // Title should use custom instance name
     await expect(page).toHaveTitle(`#general - ${spaceName} | Test Server`);
-  });
-
-  test('title reverts cleanly when leaving a room for another page', async ({ page, chatPage }) => {
-    await createAndLoginTestUser(page);
-    await chatPage.goto();
-    const spaceName = await chatPage.createSpace();
-
-    // Enter room — title should include room and space name
-    await chatPage.enterRoom('general');
-    await expect(chatPage.getRoomHeader('general')).toBeVisible();
-    await expect(page).toHaveTitle(`#general - ${spaceName} | ${spaceName}`);
-
-    // Navigate to Browse Rooms — title should switch to that page's title, not blank
-    await page.goto(routes.browseRooms);
-    await page.waitForURL(routes.browseRooms);
-    await expect(page).toHaveTitle(`Overview | ${spaceName}`);
-  });
-
-  test('title stays correct during rapid navigation between rooms and pages', async ({
-    page,
-    chatPage
-  }) => {
-    await createAndLoginTestUser(page);
-    await chatPage.goto();
-    const spaceName = await chatPage.createSpace();
-
-    // Enter room
-    await chatPage.enterRoom('general');
-    await expect(chatPage.getRoomHeader('general')).toBeVisible();
-    await expect(page).toHaveTitle(`#general - ${spaceName} | ${spaceName}`);
-
-    // Navigate to Browse Rooms via sidebar link (SPA navigation)
-    await page.getByRole('link', { name: 'Overview' }).click();
-    await expect(page).toHaveTitle(`Overview | ${spaceName}`);
-
-    // Back to room
-    await chatPage.enterRoom('general');
-    await expect(chatPage.getRoomHeader('general')).toBeVisible();
-    await expect(page).toHaveTitle(`#general - ${spaceName} | ${spaceName}`);
-
-    // Full navigation to Browse Rooms verifies title after page load
-    await page.goto(routes.browseRooms);
-    await expect(page).toHaveTitle(`Overview | ${spaceName}`);
-
-    // Back to room again
-    await page.goBack();
-    await expect(chatPage.getRoomHeader('general')).toBeVisible();
-    await expect(page).toHaveTitle(`#general - ${spaceName} | ${spaceName}`);
   });
 
   test('page title updates in real-time when instance name changes', async ({ page, browser }) => {
@@ -171,21 +86,5 @@ test.describe('Page titles', () => {
 
     // Clean up
     await context2.close();
-  });
-});
-
-test.describe('PWA theme-color meta tags', () => {
-  test('light mode theme-color matches outer frame background (gray-200)', async ({ page }) => {
-    await page.goto('/chat');
-
-    const lightMeta = page.locator('meta[name="theme-color"][media*="light"]');
-    await expect(lightMeta).toHaveAttribute('content', '#e5e7eb');
-  });
-
-  test('dark mode theme-color matches outer frame background (neutral-800)', async ({ page }) => {
-    await page.goto('/chat');
-
-    const darkMeta = page.locator('meta[name="theme-color"][media*="dark"]');
-    await expect(darkMeta).toHaveAttribute('content', '#262626');
   });
 });

--- a/frontend/e2e/quick-switcher.test.ts
+++ b/frontend/e2e/quick-switcher.test.ts
@@ -39,13 +39,10 @@ test.describe('Quick Switcher (Cmd-K)', () => {
   test('opens with Cmd-K and closes with Escape', async ({ page, chatPage }) => {
     await createAndLoginTestUser(page);
     await chatPage.goto();
-    await chatPage.createSpace('Switcher Test');
 
-    // Open
     const dialog = await openSwitcher(page);
     await expect(switcherInput(dialog)).toBeFocused();
 
-    // Close with Escape
     await page.keyboard.press('Escape');
     await expect(dialog).not.toBeVisible({ timeout: TIMEOUTS.UI_FAST });
   });
@@ -64,155 +61,27 @@ test.describe('Quick Switcher (Cmd-K)', () => {
   test('closes when clicking outside the dialog', async ({ page, chatPage }) => {
     await createAndLoginTestUser(page);
     await chatPage.goto();
-    await chatPage.createSpace('Switcher Test');
 
     const dialog = await openSwitcher(page);
 
-    // Click backdrop (top-left corner, outside the dialog content)
     await page.mouse.click(5, 5);
     await expect(dialog).not.toBeVisible({ timeout: TIMEOUTS.UI_FAST });
-  });
-
-  test('shows joined rooms', async ({ page, chatPage }) => {
-    await createAndLoginTestUser(page);
-    await chatPage.goto();
-    void (await chatPage.createSpace());
-    const roomName = await chatPage.createRoom();
-
-    const dialog = await openSwitcher(page);
-
-    // Wait for loading to finish
-    await expect(dialog.locator('.animate-spin')).not.toBeVisible({
-      timeout: TIMEOUTS.UI_STANDARD
-    });
-
-    // Post-#330 PR(a) the QuickSwitcher no longer surfaces a "Space" tier —
-    // every joined room shows up as a Room entry directly.
-    await expect(
-      dialog.getByRole('button', { name: new RegExp(`#${roomName}.*Room`) })
-    ).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
-  });
-
-  test('fuzzy search filters results', async ({ page, chatPage }) => {
-    await createAndLoginTestUser(page);
-    await chatPage.goto();
-    await chatPage.createSpace();
-    await chatPage.createRoom('xylophone-chat');
-
-    const dialog = await openSwitcher(page);
-    const input = switcherInput(dialog);
-    const results = switcherResults(dialog);
-
-    // Wait for data to load
-    await expect(results.first()).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
-    const totalCount = await results.count();
-
-    // Search for a specific room — should narrow results
-    await input.fill('xylophone');
-    await expect(results.filter({ hasText: 'xylophone-chat' })).toBeVisible();
-    const filteredCount = await results.count();
-    expect(filteredCount).toBeLessThan(totalCount);
-
-    // Search for something that doesn't exist
-    await input.fill('zzzznothing');
-    await expect(dialog.getByText('No results')).toBeVisible({
-      timeout: TIMEOUTS.UI_FAST
-    });
-  });
-
-  test('# prefix filters to rooms only', async ({ page, chatPage }) => {
-    await createAndLoginTestUser(page);
-    await chatPage.goto();
-    await chatPage.createSpace();
-    const roomName = await chatPage.createRoom();
-
-    const dialog = await openSwitcher(page);
-    const input = switcherInput(dialog);
-    const results = switcherResults(dialog);
-
-    // Wait for data to load (no filter — shows spaces + rooms)
-    await expect(results.first()).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
-    const countBefore = await results.count();
-    // Should have at least a space + default rooms + created room
-    expect(countBefore).toBeGreaterThan(1);
-
-    // Type "#" — should filter to rooms only (fewer results than unfiltered)
-    await input.fill('#');
-    await expect(results.filter({ hasText: `#${roomName}` })).toBeVisible();
-    const countAfter = await results.count();
-    expect(countAfter).toBeLessThan(countBefore);
-  });
-
-  test('shows "No results" for non-matching query', async ({ page, chatPage }) => {
-    await createAndLoginTestUser(page);
-    await chatPage.goto();
-    await chatPage.createSpace();
-
-    const dialog = await openSwitcher(page);
-    const input = switcherInput(dialog);
-
-    // Wait for data to load, then search for something that doesn't exist
-    await expect(switcherResults(dialog).first()).toBeVisible({
-      timeout: TIMEOUTS.UI_STANDARD
-    });
-    await input.fill('zzzznonexistent');
-
-    await expect(dialog.getByText('No results')).toBeVisible({
-      timeout: TIMEOUTS.UI_FAST
-    });
-  });
-
-  test('keyboard navigation: arrow keys and Enter', async ({ page, chatPage }) => {
-    await createAndLoginTestUser(page);
-    await chatPage.goto();
-    await chatPage.createSpace();
-    const roomName = await chatPage.createRoom();
-
-    const dialog = await openSwitcher(page);
-    const input = switcherInput(dialog);
-
-    // Wait for results
-    await expect(switcherResults(dialog).first()).toBeVisible({
-      timeout: TIMEOUTS.UI_STANDARD
-    });
-
-    // Filter to just the room
-    await input.fill(`#${roomName}`);
-    await expect(switcherResults(dialog).filter({ hasText: roomName })).toBeVisible();
-
-    // Press Enter to navigate
-    await page.keyboard.press('Enter');
-
-    // Dialog should close
-    await expect(dialog).not.toBeVisible({ timeout: TIMEOUTS.UI_FAST });
-
-    // Should have navigated to the room
-    await expect(page.getByRole('heading', { name: `# ${roomName}` })).toBeVisible({
-      timeout: TIMEOUTS.UI_STANDARD
-    });
   });
 
   test('clicking a result navigates to it', async ({ page, chatPage }) => {
     await createAndLoginTestUser(page);
     await chatPage.goto();
-    await chatPage.createSpace();
-    const roomName = await chatPage.createRoom();
 
     const dialog = await openSwitcher(page);
 
-    // Wait for results
     await expect(switcherResults(dialog).first()).toBeVisible({
       timeout: TIMEOUTS.UI_STANDARD
     });
 
-    // Click the room result
-    await switcherResults(dialog).filter({ hasText: roomName }).click();
+    await switcherResults(dialog).filter({ hasText: 'general' }).click();
 
-    // Dialog should close
     await expect(dialog).not.toBeVisible({ timeout: TIMEOUTS.UI_FAST });
-
-    // Should have navigated to the room
-    await expect(page.getByRole('heading', { name: `# ${roomName}` })).toBeVisible({
+    await expect(page.getByRole('heading', { name: '# general' })).toBeVisible({
       timeout: TIMEOUTS.UI_STANDARD
     });
   });
@@ -248,95 +117,5 @@ test.describe('Quick Switcher (Cmd-K)', () => {
     } finally {
       await context2.close();
     }
-  });
-
-  test('lists the server as a destination entry', async ({ page, chatPage }) => {
-    await createAndLoginTestUser(page);
-    await chatPage.goto();
-
-    const dialog = await openSwitcher(page);
-
-    // Wait for results to load
-    await expect(dialog.locator('.animate-spin')).not.toBeVisible({
-      timeout: TIMEOUTS.UI_STANDARD
-    });
-
-    // The bootstrap server's name (from e2e/fixtures/chatto.toml) should
-    // appear as a Server entry in the switcher.
-    await expect(dialog.getByRole('button', { name: /E2E Test Server.*Server/ })).toBeVisible({
-      timeout: TIMEOUTS.UI_STANDARD
-    });
-  });
-
-  test('fuzzy search surfaces the server overview by name', async ({ page, chatPage }) => {
-    await createAndLoginTestUser(page);
-    await chatPage.goto();
-
-    const dialog = await openSwitcher(page);
-    const input = switcherInput(dialog);
-
-    await expect(switcherResults(dialog).first()).toBeVisible({
-      timeout: TIMEOUTS.UI_STANDARD
-    });
-
-    // Typing the server name (or a fuzzy fragment of it) should keep the
-    // Server entry in the results. Excluding "·" filters out room entries,
-    // whose accessible name is "# {room} · {server}".
-    await input.fill('e2e test');
-    await expect(
-      switcherResults(dialog).filter({ hasText: 'E2E Test Server' }).filter({ hasNotText: '·' })
-    ).toBeVisible();
-  });
-
-  test('selecting the server entry navigates to its overview page', async ({ page, chatPage }) => {
-    await createAndLoginTestUser(page);
-    await chatPage.goto();
-    // Navigate into a room first so we're somewhere other than the overview.
-    await chatPage.createSpace();
-    await chatPage.createRoom();
-
-    const dialog = await openSwitcher(page);
-    const input = switcherInput(dialog);
-
-    await expect(switcherResults(dialog).first()).toBeVisible({
-      timeout: TIMEOUTS.UI_STANDARD
-    });
-
-    await input.fill('e2e test');
-    await switcherResults(dialog)
-      .filter({ hasText: 'E2E Test Server' })
-      .filter({ hasNotText: '·' })
-      .first()
-      .click();
-
-    await expect(dialog).not.toBeVisible({ timeout: TIMEOUTS.UI_FAST });
-
-    // The Overview page renders a "Overview" heading.
-    await expect(page.getByRole('heading', { name: 'Overview' })).toBeVisible({
-      timeout: TIMEOUTS.UI_STANDARD
-    });
-  });
-
-  test('navigating to a space works', async ({ page, chatPage }) => {
-    await createAndLoginTestUser(page);
-    await chatPage.goto();
-    const spaceName = await chatPage.createSpace();
-    // Create a room so we're inside the space, then open switcher
-    await chatPage.createRoom();
-
-    const dialog = await openSwitcher(page);
-    const input = switcherInput(dialog);
-
-    // Wait for results
-    await expect(switcherResults(dialog).first()).toBeVisible({
-      timeout: TIMEOUTS.UI_STANDARD
-    });
-
-    // Search for the space and click it
-    await input.fill(spaceName);
-    await switcherResults(dialog).filter({ hasText: spaceName }).first().click();
-
-    // Dialog should close
-    await expect(dialog).not.toBeVisible({ timeout: TIMEOUTS.UI_FAST });
   });
 });

--- a/frontend/src/appHtml.spec.ts
+++ b/frontend/src/appHtml.spec.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const appHtml = readFileSync(new URL('./app.html', import.meta.url), 'utf8');
+
+function metaContent(name: string, mediaFragment: string): string | null {
+  const tag = appHtml.match(
+    new RegExp(
+      `<meta\\s+[^>]*name="${name}"[^>]*media="[^"]*${mediaFragment}[^"]*"[^>]*>`,
+      'i'
+    )
+  )?.[0];
+
+  return tag?.match(/\bcontent="([^"]+)"/i)?.[1] ?? null;
+}
+
+describe('app.html metadata', () => {
+  it('defines theme colors matching the outer frame background colors', () => {
+    expect(metaContent('theme-color', 'light')).toBe('#e5e7eb');
+    expect(metaContent('theme-color', 'dark')).toBe('#262626');
+  });
+});

--- a/frontend/src/lib/components/QuickSwitcher.svelte.spec.ts
+++ b/frontend/src/lib/components/QuickSwitcher.svelte.spec.ts
@@ -1,0 +1,398 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { flushSync } from 'svelte';
+import { q } from '$lib/test-utils';
+import { RoomType } from '$lib/gql/graphql';
+import { quickSwitcher } from '$lib/state/globals.svelte';
+
+const mocks = vi.hoisted(() => ({
+  goto: vi.fn(),
+  query: vi.fn(),
+  mutation: vi.fn(),
+  toastError: vi.fn(),
+  recents: {
+    urls: [] as string[],
+    record: vi.fn((url: string) => {
+      mocks.recents.urls = [url, ...mocks.recents.urls.filter((entry) => entry !== url)];
+    })
+  },
+  servers: [
+    {
+      id: 'origin',
+      url: 'https://chat.example.test',
+      name: 'Fallback Server'
+    }
+  ],
+  store: {
+    serverInfo: {
+      name: 'Workspace Server'
+    }
+  }
+}));
+
+vi.mock('$app/navigation', () => ({
+  goto: mocks.goto
+}));
+
+vi.mock('$app/paths', () => ({
+  resolve: (path: string, params?: Record<string, string>) =>
+    path
+      .replace('[serverId]', params?.serverId ?? '')
+      .replace('[roomId]', params?.roomId ?? '')
+}));
+
+vi.mock('$lib/navigation', () => ({
+  serverIdToSegment: () => '-'
+}));
+
+vi.mock('$lib/gql', () => ({
+  graphql: (source: string) => source,
+  useFragment: (_document: unknown, value: unknown) => value
+}));
+
+vi.mock('$lib/state/server/registry.svelte', () => ({
+  serverRegistry: {
+    get servers() {
+      return mocks.servers;
+    },
+    tryGetStore: vi.fn(() => mocks.store)
+  }
+}));
+
+vi.mock('$lib/state/server/graphqlClient.svelte', () => ({
+  graphqlClientManager: {
+    getClient: () => ({
+      client: {
+        query: mocks.query,
+        mutation: mocks.mutation
+      }
+    })
+  }
+}));
+
+vi.mock('$lib/state/recentQuickSwitcher.svelte', () => ({
+  recentQuickSwitcher: mocks.recents
+}));
+
+vi.mock('$lib/state/presenceCache.svelte', () => ({
+  getPresenceCache: () => ({
+    get: (_userId: string, fallback: string) => fallback
+  })
+}));
+
+vi.mock('$lib/state/userProfiles.svelte', () => ({
+  getLiveAvatarUrl: (_userId: string, fallback: string | null) => fallback
+}));
+
+vi.mock('$lib/ui/toast', () => ({
+  toast: {
+    error: mocks.toastError
+  }
+}));
+
+import QuickSwitcher from './QuickSwitcher.svelte';
+
+type User = {
+  id: string;
+  login: string;
+  displayName: string;
+  avatarUrl: string | null;
+  presenceStatus: string;
+};
+
+function user(id: string, login: string, displayName: string): User {
+  return {
+    id,
+    login,
+    displayName,
+    avatarUrl: null,
+    presenceStatus: 'ONLINE'
+  };
+}
+
+const currentUser = user('user-current', 'alice', 'Alice Current');
+const teammate = user('user-teammate', 'river', 'River Teammate');
+let currentRender: { unmount: () => void } | undefined;
+let originalShowModal: typeof HTMLDialogElement.prototype.showModal;
+let originalClose: typeof HTMLDialogElement.prototype.close;
+
+function queryResult(data: unknown) {
+  return {
+    toPromise: vi.fn().mockResolvedValue({ data })
+  };
+}
+
+function mutationResult(data: unknown) {
+  return {
+    toPromise: vi.fn().mockResolvedValue({ data })
+  };
+}
+
+function operationName(document: unknown): string {
+  if (typeof document === 'string') {
+    return document.match(/\b(?:query|mutation)\s+(\w+)/)?.[1] ?? document;
+  }
+
+  const definitions = (document as { definitions?: Array<{ name?: { value?: string } }> })
+    .definitions;
+  return definitions?.[0]?.name?.value ?? '';
+}
+
+function installQueryMocks() {
+  mocks.query.mockImplementation((document: unknown, variables?: Record<string, unknown>) => {
+    const name = operationName(document);
+
+    if (name === 'QuickSwitcherServer') {
+      return queryResult({
+        server: {
+          profile: {
+            name: 'E2E Test Server',
+            logoUrl: null
+          }
+        }
+      });
+    }
+
+    if (name === 'QuickSwitcherRooms') {
+      return queryResult({
+        viewer: {
+          user: {
+            id: currentUser.id,
+            rooms: [
+              {
+                id: 'room-general',
+                name: 'general',
+                type: RoomType.Channel,
+                members: {
+                  users: [currentUser]
+                }
+              },
+              {
+                id: 'room-xylophone',
+                name: 'xylophone-chat',
+                type: RoomType.Channel,
+                members: {
+                  users: [currentUser]
+                }
+              },
+              {
+                id: 'dm-existing',
+                name: '',
+                type: RoomType.Dm,
+                members: {
+                  users: [currentUser, teammate]
+                }
+              }
+            ]
+          }
+        }
+      });
+    }
+
+    if (name === 'QuickSwitcherMembers') {
+      return queryResult({
+        viewer: {
+          canStartDMs: true,
+          user: {
+            id: currentUser.id
+          }
+        },
+        server: {
+          members: {
+            users:
+              variables?.search === 'river-login'
+                ? [user('user-river-login', 'river-login', 'River Login')]
+                : []
+          }
+        }
+      });
+    }
+
+    throw new Error(`Unexpected query document: ${name}`);
+  });
+
+  mocks.mutation.mockReturnValue(mutationResult({ startDM: { id: 'dm-new' } }));
+}
+
+async function renderOpenSwitcher() {
+  const rendered = render(QuickSwitcher);
+  currentRender = rendered;
+
+  quickSwitcher.open();
+  flushSync();
+
+  await vi.waitFor(() => {
+    expect(dialog(rendered.container).hasAttribute('open')).toBe(true);
+  });
+  await vi.waitFor(() => {
+    expect(rendered.container.textContent).toContain('xylophone-chat');
+  });
+
+  return rendered;
+}
+
+function input(container: HTMLElement): HTMLInputElement {
+  return q(
+    container,
+    'input[placeholder="Go to server, room, or conversation..."]'
+  ) as HTMLInputElement;
+}
+
+function dialog(container: HTMLElement): HTMLDialogElement {
+  const el = q(container, 'dialog.quick-switcher') as HTMLDialogElement | null;
+  if (!el) throw new Error('QuickSwitcher dialog not found');
+  return el;
+}
+
+function setSearch(container: HTMLElement, value: string) {
+  const search = input(container);
+  search.value = value;
+  search.dispatchEvent(new Event('input', { bubbles: true }));
+  flushSync();
+}
+
+function resultButtons(container: HTMLElement): HTMLButtonElement[] {
+  return Array.from(container.querySelectorAll<HTMLButtonElement>('button.sidebar-item'));
+}
+
+async function waitForDebouncedUserSearch() {
+  await new Promise((resolve) => setTimeout(resolve, 250));
+  await vi.waitFor(() => {
+    expect(
+      mocks.query.mock.calls.some(([document]) => operationName(document) === 'QuickSwitcherMembers')
+    ).toBe(true);
+  });
+}
+
+beforeAll(() => {
+  originalShowModal = HTMLDialogElement.prototype.showModal;
+  originalClose = HTMLDialogElement.prototype.close;
+  HTMLDialogElement.prototype.showModal = function showModal() {
+    this.setAttribute('open', '');
+  };
+  HTMLDialogElement.prototype.close = function close() {
+    this.removeAttribute('open');
+  };
+});
+
+beforeEach(() => {
+  quickSwitcher.close();
+  flushSync();
+  installQueryMocks();
+  mocks.goto.mockReset();
+  mocks.toastError.mockReset();
+  mocks.recents.urls = [];
+  mocks.recents.record.mockClear();
+  mocks.mutation.mockClear();
+  mocks.query.mockClear();
+});
+
+afterEach(() => {
+  quickSwitcher.close();
+  flushSync();
+  currentRender?.unmount();
+  currentRender = undefined;
+});
+
+afterAll(() => {
+  HTMLDialogElement.prototype.showModal = originalShowModal;
+  HTMLDialogElement.prototype.close = originalClose;
+});
+
+describe('QuickSwitcher', () => {
+  it('opens with server, destination, room, and DM results from mocked data', async () => {
+    const { container } = await renderOpenSwitcher();
+
+    expect(container.textContent).toContain('Notifications');
+    expect(container.textContent).toContain('E2E Test Server');
+    expect(container.textContent).toContain('general');
+    expect(container.textContent).toContain('River Teammate');
+    expect(input(container)).toBe(document.activeElement);
+  });
+
+  it('fuzzy-filters rooms and shows no results for misses', async () => {
+    const { container } = await renderOpenSwitcher();
+    const initialCount = resultButtons(container).length;
+
+    setSearch(container, 'xylophone');
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('xylophone-chat');
+      expect(resultButtons(container).length).toBeLessThan(initialCount);
+    });
+
+    setSearch(container, 'zzzznothing');
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('No results');
+    });
+  });
+
+  it('limits # searches to channel rooms', async () => {
+    const { container } = await renderOpenSwitcher();
+
+    setSearch(container, '#');
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('general');
+      expect(container.textContent).toContain('xylophone-chat');
+      expect(container.textContent).not.toContain('Notifications');
+      expect(container.textContent).not.toContain('River Teammate');
+    });
+  });
+
+  it('records and navigates when selecting a room with Enter', async () => {
+    const { container } = await renderOpenSwitcher();
+
+    setSearch(container, '#xylophone');
+    input(container).dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+    );
+
+    await vi.waitFor(() => {
+      expect(mocks.goto).toHaveBeenCalledWith('/chat/-/room-xylophone');
+    });
+    expect(mocks.recents.record).toHaveBeenCalledWith('/chat/-/room-xylophone');
+    expect(dialog(container).hasAttribute('open')).toBe(false);
+  });
+
+  it('navigates to the server overview from the server result', async () => {
+    const { container } = await renderOpenSwitcher();
+
+    setSearch(container, 'e2e test');
+    const serverResult = resultButtons(container).find((button) =>
+      button.textContent?.includes('E2E Test Server')
+    );
+    expect(serverResult).toBeTruthy();
+    serverResult!.click();
+
+    await vi.waitFor(() => {
+      expect(mocks.goto).toHaveBeenCalledWith('/chat/-/overview');
+    });
+    expect(mocks.recents.record).toHaveBeenCalledWith('/chat/-/overview');
+  });
+
+  it('loads searchable server members and starts a DM for user results', async () => {
+    const { container } = await renderOpenSwitcher();
+
+    setSearch(container, 'river-login');
+    await waitForDebouncedUserSearch();
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('River Login');
+    });
+
+    resultButtons(container)
+      .find((button) => button.textContent?.includes('River Login'))!
+      .click();
+
+    await vi.waitFor(() => {
+      const [document, variables] = mocks.mutation.mock.calls[0] ?? [];
+      expect(operationName(document)).toBe('QuickSwitcherStartDM');
+      expect(variables).toEqual({
+        input: {
+          participantIds: ['user-river-login']
+        }
+      });
+      expect(mocks.goto).toHaveBeenCalledWith('/chat/-/dm-new');
+    });
+    expect(mocks.recents.record).toHaveBeenCalledWith('/chat/-/dm-new');
+  });
+});

--- a/frontend/src/lib/hooks/usePageTitle.svelte.spec.ts
+++ b/frontend/src/lib/hooks/usePageTitle.svelte.spec.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync } from 'svelte';
+import { titleState } from '$lib/state/globals.svelte';
+
+const mocks = vi.hoisted(() => ({
+  originServer: undefined as { id: string } | undefined,
+  servers: [] as Array<{ id: string }>,
+  stores: new Map<
+    string,
+    {
+      isAuthenticated: boolean;
+      serverInfo: { name: string };
+      notifications: { count: number };
+    }
+  >()
+}));
+
+vi.mock('$lib/state/server/registry.svelte', () => ({
+  serverRegistry: {
+    get originServer() {
+      return mocks.originServer;
+    },
+    get servers() {
+      return mocks.servers;
+    },
+    getStore: (id: string) => {
+      const store = mocks.stores.get(id);
+      if (!store) throw new Error(`No mocked store for ${id}`);
+      return store;
+    }
+  }
+}));
+
+import { usePageTitle } from './usePageTitle.svelte';
+
+function store(name: string, count = 0, isAuthenticated = true) {
+  return {
+    isAuthenticated,
+    serverInfo: { name },
+    notifications: { count }
+  };
+}
+
+function setServers(
+  entries: Array<{
+    id: string;
+    name: string;
+    count?: number;
+    isAuthenticated?: boolean;
+    origin?: boolean;
+  }>
+) {
+  mocks.servers = entries.map(({ id }) => ({ id }));
+  mocks.stores.clear();
+  mocks.originServer = undefined;
+
+  for (const entry of entries) {
+    mocks.stores.set(entry.id, store(entry.name, entry.count ?? 0, entry.isAuthenticated ?? true));
+    if (entry.origin) mocks.originServer = { id: entry.id };
+  }
+}
+
+function createTitleGetter() {
+  let getTitle: (() => string) | undefined;
+  const cleanup = $effect.root(() => {
+    getTitle = usePageTitle();
+  });
+  flushSync();
+  if (!getTitle) throw new Error('Title getter was not initialized');
+  return { getTitle, cleanup };
+}
+
+beforeEach(() => {
+  titleState.clearPageTitle();
+  setServers([{ id: 'origin', name: 'Chatto Test', origin: true }]);
+});
+
+afterEach(() => {
+  titleState.clearPageTitle();
+});
+
+describe('usePageTitle', () => {
+  it('uses the origin server name as the base title', () => {
+    const { getTitle, cleanup } = createTitleGetter();
+
+    expect(getTitle()).toBe('Chatto Test');
+
+    cleanup();
+  });
+
+  it('combines the page title with the origin server name', () => {
+    titleState.setPageTitle('Overview');
+    const { getTitle, cleanup } = createTitleGetter();
+
+    expect(getTitle()).toBe('Overview | Chatto Test');
+
+    cleanup();
+  });
+
+  it('falls back to Chatto without an origin server', () => {
+    setServers([]);
+    titleState.setPageTitle('Sign In');
+    const { getTitle, cleanup } = createTitleGetter();
+
+    expect(getTitle()).toBe('Sign In | Chatto');
+
+    cleanup();
+  });
+
+  it('prefixes authenticated notification counts across servers', () => {
+    setServers([
+      { id: 'origin', name: 'Chatto Test', count: 2, origin: true },
+      { id: 'remote', name: 'Remote', count: 3 },
+      { id: 'signed-out', name: 'Signed Out', count: 99, isAuthenticated: false }
+    ]);
+    titleState.setPageTitle('Overview');
+    const { getTitle, cleanup } = createTitleGetter();
+
+    expect(getTitle()).toBe('(5) Overview | Chatto Test');
+
+    cleanup();
+  });
+
+  it('reacts when the page title segment changes', () => {
+    const { getTitle, cleanup } = createTitleGetter();
+
+    titleState.setPageTitle('Overview');
+    flushSync();
+    expect(getTitle()).toBe('Overview | Chatto Test');
+
+    titleState.setPageTitle('#general - Test Space');
+    flushSync();
+    expect(getTitle()).toBe('#general - Test Space | Chatto Test');
+
+    cleanup();
+  });
+});

--- a/frontend/src/lib/ui/PageTitle.svelte.spec.ts
+++ b/frontend/src/lib/ui/PageTitle.svelte.spec.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { flushSync } from 'svelte';
+import { titleState } from '$lib/state/globals.svelte';
+import PageTitle from './PageTitle.svelte';
+
+beforeEach(() => {
+  titleState.clearPageTitle();
+});
+
+afterEach(() => {
+  titleState.clearPageTitle();
+});
+
+describe('PageTitle', () => {
+  it('sets the global page title while mounted', () => {
+    const rendered = render(PageTitle, { props: { title: 'Overview' } });
+    flushSync();
+
+    expect(titleState.pageTitle).toBe('Overview');
+
+    rendered.unmount();
+  });
+
+  it('updates the global page title when the prop changes', async () => {
+    const rendered = render(PageTitle, { props: { title: 'Overview' } });
+    flushSync();
+
+    await rendered.rerender({ title: '#general - Test Space' });
+    flushSync();
+
+    expect(titleState.pageTitle).toBe('#general - Test Space');
+
+    rendered.unmount();
+  });
+
+  it('clears the global page title on unmount', () => {
+    const rendered = render(PageTitle, { props: { title: 'Overview' } });
+    flushSync();
+
+    rendered.unmount();
+    flushSync();
+
+    expect(titleState.pageTitle).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Move deterministic Quick Switcher coverage into a Vitest browser spec with mocked GraphQL, navigation, recents, and user search behavior.
- Keep Playwright focused on real shortcut/header/backdrop wiring, one bootstrap-room navigation smoke, and the real server-member search integration path.
- Move deterministic page-title composition, `PageTitle` lifecycle behavior, and static theme-color metadata checks into unit/browser specs.
- Keep page-title e2e coverage focused on route title wiring, custom instance names, and live instance-name updates.

## Tests
- `mise x -- pnpm test:unit --run --project client src/lib/components/QuickSwitcher.svelte.spec.ts`
- `mise x -- pnpm exec playwright test e2e/quick-switcher.test.ts --retries=0 --workers=1`
- `mise x -- pnpm test:unit --run --project client src/lib/hooks/usePageTitle.svelte.spec.ts src/lib/ui/PageTitle.svelte.spec.ts`
- `mise x -- pnpm test:unit --run --project server src/appHtml.spec.ts`
- `mise x -- pnpm exec playwright test e2e/page-titles.test.ts --retries=0 --workers=1`
- `pnpm check`
- `mise x -- pnpm test:unit --run`
- `git diff --check`
