### PR TITLE
feat: show room sidebar in DMs

### DIFF
--- a/cli/internal/core/dm_test.go
+++ b/cli/internal/core/dm_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -672,6 +673,43 @@ func TestDMUnreadStatus(t *testing.T) {
 			t.Error("Expected user2 to NOT have unread after marking as read")
 		}
 	})
+}
+
+func TestDMRoomMembersCannotBeBannedAtCoreLayer(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	user1, err := core.CreateUser(ctx, "system", "dm-ban-core-1", "DM Ban Core 1", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser user1: %v", err)
+	}
+	user2, err := core.CreateUser(ctx, "system", "dm-ban-core-2", "DM Ban Core 2", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser user2: %v", err)
+	}
+
+	room, _, err := core.FindOrCreateDM(ctx, user1.Id, []string{user2.Id})
+	if err != nil {
+		t.Fatalf("FindOrCreateDM: %v", err)
+	}
+
+	if _, err := core.BanRoomMember(ctx, user1.Id, KindDM, room.Id, user2.Id, "not allowed", nil); !errors.Is(err, ErrCannotBanDMRoomMember) {
+		t.Fatalf("expected ErrCannotBanDMRoomMember from BanRoomMember, got %v", err)
+	}
+	if err := core.UnbanRoomMember(ctx, user1.Id, KindDM, room.Id, user2.Id, "not allowed"); !errors.Is(err, ErrCannotBanDMRoomMember) {
+		t.Fatalf("expected ErrCannotBanDMRoomMember from UnbanRoomMember, got %v", err)
+	}
+
+	isMember, err := core.RoomMembershipExists(ctx, KindDM, user2.Id, room.Id)
+	if err != nil {
+		t.Fatalf("RoomMembershipExists: %v", err)
+	}
+	if !isMember {
+		t.Fatal("expected DM membership to remain after rejected ban")
+	}
+	if _, ok := core.RoomBans.ActiveBan(room.Id, user2.Id, time.Now()); ok {
+		t.Fatal("expected rejected DM ban not to create an active ban")
+	}
 }
 
 func TestDMReactions(t *testing.T) {

--- a/docs/fdr/FDR-007-direct-messages.md
+++ b/docs/fdr/FDR-007-direct-messages.md
@@ -12,6 +12,7 @@ Users can start a direct conversation (1-to-1 or small group, up to 10 participa
 - A DM is started from user context menus inside the chat UI (member list clicks, @mention clicks, message author clicks).
 - Starting a DM with a user (or set of users) navigates to the resulting DM room. If a DM with the same participant set already exists, the user lands in that room rather than creating a duplicate.
 - DM rooms appear in the per-server room sidebar with their participants' names and avatars rather than a room name.
+- Inside a DM room, the room extras sidebar is available but starts closed and does not show the Members panel. The current Files panel and future non-member panels are shared, while channel-style moderation actions such as banning/removing room members remain unavailable.
 - Maximum 10 participants per DM.
 - A user can read a DM if and only if they are a participant in that DM room. There is no separate "can view DMs" permission.
 - Operators can prevent a user from starting new DMs or sending root messages in existing DMs by revoking `message.post`; thread replies follow `message.post-in-thread`.

--- a/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -38,6 +38,11 @@
   import RoomEventsPane from './RoomEventsPane.svelte';
   import RoomSidebar from './RoomSidebar.svelte';
   import RoomSidebarToggle from './RoomSidebarToggle.svelte';
+  import {
+    canBanMembersFromRoomSidebar,
+    DM_ROOM_SIDEBAR_PANELS,
+    roomSidebarPanelForRoom
+  } from './roomSidebarBehavior';
   import { RoomSidebarPanelsState } from './roomSidebarPanels.svelte';
   import ThreadPane from './ThreadPane.svelte';
 
@@ -281,8 +286,13 @@
     () => getActiveServer(),
     () => roomId
   );
-  const activeRoomSidebarPanel = $derived(roomSidebarPanels.activeDesktopPanel);
-  const mobileRoomSidebarPanel = $derived(roomSidebarPanels.mobilePanel);
+  const activeRoomSidebarPanel = $derived(
+    roomSidebarPanelForRoom(room.isDM, roomSidebarPanels.activeDesktopPanel)
+  );
+  const mobileRoomSidebarPanel = $derived(
+    roomSidebarPanelForRoom(room.isDM, roomSidebarPanels.mobilePanel)
+  );
+  const roomSidebarTogglePanels = $derived(room.isDM ? DM_ROOM_SIDEBAR_PANELS : undefined);
 
   let leavingRoom = $state(false);
 
@@ -377,18 +387,18 @@
             {/if}
           {/snippet}
           {#snippet actions()}
-            {#if !room.isDM}
-              <RoomSidebarToggle
-                mode="mobile"
-                activePanel={mobileRoomSidebarPanel}
-                onToggle={(panel) => roomSidebarPanels.toggleMobilePanel(panel)}
-              />
-              <RoomSidebarToggle
-                mode="desktop"
-                activePanel={activeRoomSidebarPanel}
-                onToggle={(panel) => roomSidebarPanels.toggleDesktopPanel(panel)}
-              />
-            {/if}
+            <RoomSidebarToggle
+              mode="mobile"
+              activePanel={mobileRoomSidebarPanel}
+              panels={roomSidebarTogglePanels}
+              onToggle={(panel) => roomSidebarPanels.toggleMobilePanel(panel)}
+            />
+            <RoomSidebarToggle
+              mode="desktop"
+              activePanel={activeRoomSidebarPanel}
+              panels={roomSidebarTogglePanels}
+              onToggle={(panel) => roomSidebarPanels.toggleDesktopPanel(panel)}
+            />
             {#if showVoiceCall}
               <VoiceCallButton {roomId} livekitUrl={serverInfo.livekitUrl!} />
             {/if}
@@ -454,7 +464,7 @@
         />
       {/if}
 
-      {#if !room.isDM && mobileRoomSidebarPanel}
+      {#if mobileRoomSidebarPanel}
         <button
           type="button"
           class="absolute inset-0 z-10 bg-transparent lg:hidden"
@@ -471,7 +481,10 @@
             activePanel={mobileRoomSidebarPanel}
             presentation="overlay"
             loading={room.isRoomLoading}
-            canBanRoomMembers={room.roomData?.canBanRoomMembers ?? false}
+            canBanRoomMembers={canBanMembersFromRoomSidebar(
+              room.isDM,
+              room.roomData?.canBanRoomMembers
+            )}
             currentUserId={currentUser.user?.id ?? null}
             onLoadMoreMembers={roomMembers.loadMoreMembers}
             onClose={() => roomSidebarPanels.closeMobile()}
@@ -480,13 +493,16 @@
       {/if}
     </div>
 
-    {#if !room.isDM && activeRoomSidebarPanel}
+    {#if activeRoomSidebarPanel}
       <div class="hidden lg:flex">
         <RoomSidebar
           {roomId}
           activePanel={activeRoomSidebarPanel}
           loading={room.isRoomLoading}
-          canBanRoomMembers={room.roomData?.canBanRoomMembers ?? false}
+          canBanRoomMembers={canBanMembersFromRoomSidebar(
+            room.isDM,
+            room.roomData?.canBanRoomMembers
+          )}
           currentUserId={currentUser.user?.id ?? null}
           onLoadMoreMembers={roomMembers.loadMoreMembers}
           onClose={() => roomSidebarPanels.closeDesktop()}

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -340,4 +340,48 @@ describe('RoomSidebar', () => {
     expect(container.textContent).toContain('Files coming soon.');
     expect(container.querySelector('[aria-label="Members"]')).toBeFalsy();
   });
+
+  it('shows the room-ban action for other members when allowed', async () => {
+    const { container } = render(RoomSidebarTestHarness, {
+      props: {
+        currentUserId: 'viewer',
+        canBanRoomMembers: true,
+        roomData: roomData(
+          [
+            { ...member(0), id: 'viewer', displayName: 'Viewer' },
+            { ...member(1), id: 'other', displayName: 'Other Member' }
+          ],
+          2,
+          false
+        )
+      }
+    });
+
+    buttonByText(container, 'Other Member')!.click();
+    await tick();
+
+    expect(container.textContent).toContain('Ban from room');
+  });
+
+  it('hides the room-ban action when member moderation is disabled', async () => {
+    const { container } = render(RoomSidebarTestHarness, {
+      props: {
+        currentUserId: 'viewer',
+        canBanRoomMembers: false,
+        roomData: roomData(
+          [
+            { ...member(0), id: 'viewer', displayName: 'Viewer' },
+            { ...member(1), id: 'other', displayName: 'Other Member' }
+          ],
+          2,
+          false
+        )
+      }
+    });
+
+    buttonByText(container, 'Other Member')!.click();
+    await tick();
+
+    expect(container.textContent).not.toContain('Ban from room');
+  });
 });

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarTestHarness.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarTestHarness.svelte
@@ -17,6 +17,7 @@ mounting the full chat room shell.
     activePanel = 'members',
     presentation = 'desktop',
     currentUserId = 'viewer',
+    canBanRoomMembers = false,
     onPresenceCacheReady,
     onClose
   }: {
@@ -25,6 +26,7 @@ mounting the full chat room shell.
     activePanel?: RoomSidebarPanel;
     presentation?: 'desktop' | 'overlay';
     currentUserId?: string | null;
+    canBanRoomMembers?: boolean;
     onPresenceCacheReady?: (cache: PresenceCache) => void;
     onClose?: () => void;
   } = $props();
@@ -47,7 +49,7 @@ mounting the full chat room shell.
   {activePanel}
   {presentation}
   loading={false}
-  canBanRoomMembers={false}
+  {canBanRoomMembers}
   {currentUserId}
   onLoadMoreMembers={roomMembers.loadMoreMembers}
   {onClose}

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarToggle.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarToggle.svelte
@@ -5,6 +5,7 @@ Room header affordance for opening or hiding room extras panels.
 
 **Props:**
 - `activePanel` - Currently visible room sidebar panel, or `null` when hidden.
+- `panels` - Panel buttons to show. Defaults to every room sidebar panel.
 - `onToggle` - Called with the panel requested by the user.
 - `mode` - Responsive visibility for the toggle group.
 -->
@@ -13,15 +14,17 @@ Room header affordance for opening or hiding room extras panels.
 
   let {
     activePanel,
+    panels,
     onToggle,
     mode = 'desktop'
   }: {
     activePanel: RoomSidebarPanel | null;
+    panels?: RoomSidebarPanel[];
     onToggle: (panel: RoomSidebarPanel) => void;
     mode?: 'desktop' | 'mobile' | 'always';
   } = $props();
 
-  const panels: {
+  const panelDefinitions: {
     id: RoomSidebarPanel;
     icon: string;
     showLabel: string;
@@ -41,6 +44,10 @@ Room header affordance for opening or hiding room extras panels.
     }
   ];
 
+  const visiblePanels = $derived(
+    panels ? panelDefinitions.filter((panel) => panels.includes(panel.id)) : panelDefinitions
+  );
+
   const visibilityClass = $derived.by(() => {
     switch (mode) {
       case 'mobile':
@@ -57,7 +64,7 @@ Room header affordance for opening or hiding room extras panels.
   class={['group/badges items-center gap-1', visibilityClass]}
   data-testid="room-sidebar-toggle"
 >
-  {#each panels as panel (panel.id)}
+  {#each visiblePanels as panel (panel.id)}
     {@const isActive = activePanel === panel.id}
     <button
       type="button"

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarToggle.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarToggle.svelte.spec.ts
@@ -53,6 +53,19 @@ describe('RoomSidebarToggle', () => {
     expect(onToggle).toHaveBeenCalledWith('files');
   });
 
+  it('can render only the files panel', async () => {
+    const { container } = render(RoomSidebarToggle, {
+      props: {
+        activePanel: null,
+        panels: ['files'],
+        onToggle: vi.fn()
+      }
+    });
+
+    expect(container.querySelector('[aria-label="Show members"]')).toBeFalsy();
+    expect(container.querySelector('[aria-label="Show files"]')).toBeTruthy();
+  });
+
   it('uses a background-only pressed state for the active panel', async () => {
     const { container } = render(RoomSidebarToggle, {
       props: {

--- a/frontend/src/routes/chat/[serverId]/[roomId]/roomSidebarBehavior.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/roomSidebarBehavior.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canBanMembersFromRoomSidebar,
+  DM_ROOM_SIDEBAR_PANELS,
+  roomSidebarPanelForRoom
+} from './roomSidebarBehavior';
+
+describe('room sidebar behavior', () => {
+  it('allows channel member bans when the room capability is present', () => {
+    expect(canBanMembersFromRoomSidebar(false, true)).toBe(true);
+  });
+
+  it('suppresses member bans for DM rooms even if stale capability data says otherwise', () => {
+    expect(canBanMembersFromRoomSidebar(true, true)).toBe(false);
+  });
+
+  it('suppresses member bans when the room capability is absent', () => {
+    expect(canBanMembersFromRoomSidebar(false, false)).toBe(false);
+    expect(canBanMembersFromRoomSidebar(false, null)).toBe(false);
+    expect(canBanMembersFromRoomSidebar(false, undefined)).toBe(false);
+  });
+
+  it('only exposes files as a DM room sidebar panel', () => {
+    expect(DM_ROOM_SIDEBAR_PANELS).toEqual(['files']);
+  });
+
+  it('keeps channel room sidebar panels unchanged', () => {
+    expect(roomSidebarPanelForRoom(false, 'members')).toBe('members');
+    expect(roomSidebarPanelForRoom(false, 'files')).toBe('files');
+    expect(roomSidebarPanelForRoom(false, null)).toBeNull();
+  });
+
+  it('treats the members default as closed for DM rooms', () => {
+    expect(roomSidebarPanelForRoom(true, 'members')).toBeNull();
+    expect(roomSidebarPanelForRoom(true, null)).toBeNull();
+  });
+
+  it('allows the files panel to open for DM rooms', () => {
+    expect(roomSidebarPanelForRoom(true, 'files')).toBe('files');
+  });
+});

--- a/frontend/src/routes/chat/[serverId]/[roomId]/roomSidebarBehavior.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/roomSidebarBehavior.ts
@@ -1,0 +1,18 @@
+import type { RoomSidebarPanel, RoomSidebarPanelState } from '$lib/storage/roomSidebarPanel';
+
+export const DM_ROOM_SIDEBAR_PANELS: RoomSidebarPanel[] = ['files'];
+
+export function canBanMembersFromRoomSidebar(
+  isDM: boolean,
+  roomCanBanMembers: boolean | null | undefined
+): boolean {
+  return !isDM && !!roomCanBanMembers;
+}
+
+export function roomSidebarPanelForRoom(
+  isDM: boolean,
+  panel: RoomSidebarPanelState
+): RoomSidebarPanelState {
+  if (!isDM) return panel;
+  return DM_ROOM_SIDEBAR_PANELS.includes(panel as RoomSidebarPanel) ? panel : null;
+}


### PR DESCRIPTION
- Enable the room extras sidebar controls for DM rooms, but expose only the Files panel there and keep the DM sidebar closed by default.
- Keep DM moderation private by suppressing room-ban actions even if stale room capability data says they are allowed.
- Add focused frontend/sidebar behavior tests, a core server-side DM-ban regression test, and document the DM room extras behavior in FDR-007.

Tests: `pnpm exec vitest --run 'src/routes/chat/[serverId]/[roomId]'`; `pnpm check`; `pnpm lint`; `go test -tags test_endpoints ./internal/core -run TestDMRoomMembersCannotBeBannedAtCoreLayer -count=1`; `go test -tags test_endpoints ./internal/graph -run 'TestBanRoomMember_Authorization/DM_room_members_cannot_be_banned' -count=1`.
