### PR TITLE
fix: tidy server lifecycle logs

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -86,7 +86,23 @@ func runServer(configPath string) {
 	// Conductor stops foreground run scripts with SIGHUP before escalating.
 	// Chatto has no reload-on-HUP behavior, so treat it as graceful shutdown
 	// alongside the usual terminal and supervisor stop signals.
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
+	shutdownSignals := []os.Signal{syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM}
+	signalLog := make(chan os.Signal, 1)
+	stopSignalLog := make(chan struct{})
+	signal.Notify(signalLog, shutdownSignals...)
+	defer func() {
+		signal.Stop(signalLog)
+		close(stopSignalLog)
+	}()
+	go func() {
+		select {
+		case sig := <-signalLog:
+			log.Info("Received shutdown signal", "signal", sig.String())
+		case <-stopSignalLog:
+		}
+	}()
+
+	ctx, stop := signal.NotifyContext(context.Background(), shutdownSignals...)
 	defer stop()
 
 	// Use errgroup to coordinate services
@@ -306,15 +322,10 @@ func connectToNATS(ctx context.Context, cfg config.ChattoConfig, embeddedNATS *s
 		nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
 			if err != nil {
 				logger.Warn("NATS disconnected", "error", err)
-			} else {
-				logger.Info("NATS disconnected (graceful)")
 			}
 		}),
 		nats.ReconnectHandler(func(nc *nats.Conn) {
 			logger.Info("NATS reconnected", "url", nc.ConnectedUrl())
-		}),
-		nats.ClosedHandler(func(_ *nats.Conn) {
-			logger.Info("NATS connection closed")
 		}),
 	)
 

--- a/cli/internal/embedded_nats/nats_server.go
+++ b/cli/internal/embedded_nats/nats_server.go
@@ -48,10 +48,9 @@ func ShutdownServer(ns *server.Server) {
 		return
 	}
 	logger := log.WithPrefix("server.NATS")
-	logger.Info("Shutting down embedded NATS server")
 	ns.Shutdown()
 	ns.WaitForShutdown()
-	logger.Info("Embedded NATS server shutdown complete")
+	logger.Info("Embedded NATS server shut down")
 }
 
 // createServer creates an embedded NATS server configured from chatto.toml.

--- a/cli/internal/http_server/server.go
+++ b/cli/internal/http_server/server.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync/atomic"
@@ -235,7 +236,7 @@ func (s *HTTPServer) Run(ctx context.Context) error {
 	// Start HTTP servers
 	for _, srv := range servers {
 		if srv == metricsServer {
-			s.logger.Info("Starting metrics server", "addr", srv.Addr, "path", s.config.Metrics.PathOrDefault())
+			s.logger.Info("Starting metrics server", "url", metricsServerURL(srv.Addr, s.config.Metrics.PathOrDefault()))
 		} else {
 			s.logger.Info("Starting HTTP server", "addr", srv.Addr, "url", s.config.Webserver.URL)
 		}
@@ -276,13 +277,15 @@ func (s *HTTPServer) Run(ctx context.Context) error {
 	}
 }
 
+func metricsServerURL(addr, path string) string {
+	return (&url.URL{Scheme: "http", Host: addr, Path: path}).String()
+}
+
 func (s *HTTPServer) shutdownServer(server *http.Server) error {
 	return s.shutdownServerWithTimeout(server, httpServerShutdownTimeout)
 }
 
 func (s *HTTPServer) shutdownServerWithTimeout(server *http.Server, timeout time.Duration) error {
-	s.logger.Info("Shutting down server", "addr", server.Addr)
-
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -294,7 +297,6 @@ func (s *HTTPServer) shutdownServerWithTimeout(server *http.Server, timeout time
 		return err
 	}
 
-	s.logger.Info("Server shutdown complete", "addr", server.Addr)
 	return nil
 }
 


### PR DESCRIPTION
## Changes

- Log the shutdown signal that caused Chatto to quit.
- Remove redundant normal shutdown log lines from HTTP, NATS connection, and embedded NATS shutdown.
- Align the metrics server startup log with the main HTTP startup log by reporting a full `url`.

## Tests

- `cd cli && mise x -- go test ./internal/http_server -run TestMetrics -timeout 30s`
- `cd cli && mise x -- go test ./cmd -timeout 30s`
