### PR TITLE
test(frontend): refactor notification e2e setup

### DIFF
--- a/frontend/e2e/notifications.test.ts
+++ b/frontend/e2e/notifications.test.ts
@@ -1,4 +1,4 @@
-import { expect } from '@playwright/test';
+import { expect, type Browser, type Page } from '@playwright/test';
 import { test } from './setup';
 import { ChatPage, RoomPage, NotificationsPage } from './pages';
 import {
@@ -9,6 +9,99 @@ import {
 } from './fixtures/testUser';
 import * as routes from './routes';
 import { POLLING_INTERVALS, TIMEOUTS } from './constants';
+
+interface ServerUserSession {
+  page: Page;
+  chatPage: ChatPage;
+  roomPage: RoomPage;
+}
+
+async function withServerUser<T>(
+  browser: Browser,
+  serverURL: string,
+  run: (session: ServerUserSession) => Promise<T>
+): Promise<T> {
+  const context = await browser.newContext({ baseURL: serverURL });
+  const page = await context.newPage();
+
+  try {
+    await createAndLoginTestUser(page);
+    await openServer(page);
+
+    return await run({
+      page,
+      chatPage: new ChatPage(page),
+      roomPage: new RoomPage(page)
+    });
+  } finally {
+    await context.close();
+  }
+}
+
+async function postMentionFromServerUser(
+  browser: Browser,
+  serverURL: string,
+  mentionedLogin: string,
+  message: string,
+  roomName = 'general'
+): Promise<void> {
+  await withServerUser(browser, serverURL, async ({ chatPage, roomPage }) => {
+    await chatPage.enterRoom(roomName);
+    await roomPage.sendMessage(`@${mentionedLogin} ${message}`);
+  });
+}
+
+async function postThreadReplyFromServerUser(
+  browser: Browser,
+  serverURL: string,
+  rootMessage: string,
+  replyText: string
+): Promise<void> {
+  await withServerUser(browser, serverURL, async ({ chatPage, roomPage }) => {
+    await chatPage.enterRoom('general');
+    const message = roomPage.getMessage(rootMessage);
+    await message.openThread();
+    await roomPage.expectThreadPaneVisible();
+    await roomPage.postThreadReply(replyText);
+  });
+}
+
+async function postRoomReplyFromServerUser(
+  browser: Browser,
+  serverURL: string,
+  rootMessage: string,
+  replyText: string
+): Promise<void> {
+  await withServerUser(browser, serverURL, async ({ page, chatPage, roomPage }) => {
+    await chatPage.enterRoom('general');
+    const targetMsg = roomPage.getMessage(rootMessage);
+    await targetMsg.replyInRoom();
+    await expect(page.getByTestId('reply-indicator')).toBeVisible({
+      timeout: TIMEOUTS.UI_STANDARD
+    });
+    await roomPage.sendMessage(replyText);
+  });
+}
+
+function serverNotificationBadge(page: Page) {
+  return page
+    .locator('.server-gutter [data-testid="server-icon"]')
+    .first()
+    .locator('..')
+    .getByTestId('server-notification-badge');
+}
+
+async function joinRoomFromOverview(page: Page, roomName: string): Promise<void> {
+  await page.getByRole('link', { name: 'Overview' }).click();
+  const roomItem = page.locator('li', { hasText: `# ${roomName}` });
+  await roomItem.getByRole('button', { name: 'Join' }).click();
+  // The Joined button swaps visible text to "Leave" on hover, and Playwright
+  // leaves the cursor on the button it just clicked. Asserting on `title` is
+  // stable across hover state.
+  await expect(roomItem.locator('button[title^="Joined "]')).toBeVisible({
+    timeout: TIMEOUTS.UI_STANDARD
+  });
+}
 
 test.describe('Mention Notifications', () => {
   // Note: Toast notifications for mentions were removed - the bell icon with notification badge
@@ -24,8 +117,6 @@ test.describe('Mention Notifications', () => {
     const userA = await createAndLoginTestUser(page);
     await chatPage.goto();
 
-    const spaceId = await chatPage.getServerScopeId();
-
     // Navigate to "announcements" room (User A stays here to observe general)
     await chatPage.enterRoom('announcements');
 
@@ -36,40 +127,17 @@ test.describe('Mention Notifications', () => {
     const mentionBadge = generalLink.getByTestId('room-notification-badge');
     await expect(mentionBadge).not.toBeVisible();
 
-    // User B: Create account and open the server
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
+    // User B enters general room and mentions User A
+    await postMentionFromServerUser(browser!, serverURL, userA.login, 'you have a mention!');
 
-    try {
-      await createAndLoginTestUser(page2);
+    // User A: Verify mention indicator appears on general room
+    await expect(mentionBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+    await expect(mentionBadge).toHaveText('1');
 
-      // User B opens the server
-      await openServer(page2);
-      await page2.goto(routes.space());
-      await page2.waitForURL(routes.patterns.anySpace);
-
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-
-      // User B enters general room and mentions User A
-      await chatPage2.enterRoom('general');
-      await roomPage2.sendMessage(`Hey @${userA.login} you have a mention!`);
-
-      // User A: Verify mention indicator appears on general room
-      await expect(mentionBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-      await expect(mentionBadge).toHaveText('1');
-
-      // User A: Verify mention cascades to server icon
-      const serverGutter = page.locator('.server-gutter');
-      const spaceButton = serverGutter.locator('[data-testid="server-icon"]').first();
-      const spaceNotificationBadge = spaceButton
-        .locator('..')
-        .getByTestId('server-notification-badge');
-      await expect(spaceNotificationBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-      await expect(spaceNotificationBadge).toHaveText('1');
-    } finally {
-      await context2.close();
-    }
+    // User A: Verify mention cascades to server icon
+    const notificationBadge = serverNotificationBadge(page);
+    await expect(notificationBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+    await expect(notificationBadge).toHaveText('1');
   });
 
   test('notification badge appears on server icon with logo image', async ({
@@ -112,38 +180,22 @@ test.describe('Mention Notifications', () => {
     const spaceLogoImage = spaceButton.locator('img');
     await expect(spaceLogoImage).toBeVisible();
 
-    // User B: Create account and open the server
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
+    // User B enters general room and mentions User A
+    await postMentionFromServerUser(
+      browser!,
+      serverURL,
+      userA.login,
+      'notification on server with logo!'
+    );
 
-    try {
-      await createAndLoginTestUser(page2);
+    // User A: Verify notification badge appears on server icon with logo.
+    // The badge should be visible even when the server has an image logo.
+    const notificationBadge = serverNotificationBadge(page);
+    await expect(notificationBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+    await expect(notificationBadge).toHaveText('1');
 
-      // User B opens the server
-      await openServer(page2);
-      await page2.goto(routes.space());
-      await page2.waitForURL(routes.patterns.anySpace);
-
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-
-      // User B enters general room and mentions User A
-      await chatPage2.enterRoom('general');
-      await roomPage2.sendMessage(`Hey @${userA.login} notification on server with logo!`);
-
-      // User A: Verify notification badge appears on server icon with logo.
-      // The badge should be visible even when the server has an image logo.
-      const spaceNotificationBadge = spaceButton
-        .locator('..')
-        .getByTestId('server-notification-badge');
-      await expect(spaceNotificationBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-      await expect(spaceNotificationBadge).toHaveText('1');
-
-      // Also verify the logo is still visible (not replaced by anything)
-      await expect(spaceLogoImage).toBeVisible();
-    } finally {
-      await context2.close();
-    }
+    // Also verify the logo is still visible (not replaced by anything)
+    await expect(spaceLogoImage).toBeVisible();
   });
 
   test('mention indicator clears when entering the room', async ({
@@ -156,40 +208,26 @@ test.describe('Mention Notifications', () => {
     const userA = await createAndLoginTestUser(page);
     await chatPage.goto();
 
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('announcements');
 
     const generalLink = chatPage.roomList.locator('a', { hasText: '# general' });
     const mentionBadge = generalLink.getByTestId('room-notification-badge');
 
     // User B: Mention User A in general
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
+    await postMentionFromServerUser(browser!, serverURL, userA.login, 'clearing mention test');
 
-    try {
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-      await chatPage2.enterRoom('general');
-      await roomPage2.sendMessage(`@${userA.login} clearing mention test`);
+    // Wait for mention indicator to appear.
+    await expect(mentionBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+    await expect(mentionBadge).toHaveText('1');
 
-      // Wait for mention indicator to appear.
-      await expect(mentionBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-      await expect(mentionBadge).toHaveText('1');
+    // User A: Navigate to general room
+    await generalLink.click();
+    await page.waitForURL(routes.patterns.anyRoom);
 
-      // User A: Navigate to general room
-      await generalLink.click();
-      await page.waitForURL(routes.patterns.anyRoom);
-
-      // Verify mention indicator is cleared (poll to allow server read event to propagate)
-      await expect(async () => {
-        await expect(mentionBadge).not.toBeVisible();
-      }).toPass({ timeout: TIMEOUTS.UI_STANDARD, intervals: POLLING_INTERVALS });
-    } finally {
-      await context2.close();
-    }
+    // Verify mention indicator is cleared (poll to allow server read event to propagate)
+    await expect(async () => {
+      await expect(mentionBadge).not.toBeVisible();
+    }).toPass({ timeout: TIMEOUTS.UI_STANDARD, intervals: POLLING_INTERVALS });
   });
 });
 
@@ -204,7 +242,6 @@ test.describe('Thread Reply Notifications (Cascading Indicators)', () => {
     // User A: Create account and post a root message
     await createAndLoginTestUser(page);
     await chatPage.goto();
-    const spaceId = await chatPage.getServerScopeId();
 
     await chatPage.enterRoom('general');
     const rootMessage = `Thread notify test ${Date.now()}`;
@@ -214,66 +251,43 @@ test.describe('Thread Reply Notifications (Cascading Indicators)', () => {
     await chatPage.enterRoom('announcements');
 
     // User B: Create account, open the server, and reply to User A's thread
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
+    const replyMessage = `Reply from User B ${Date.now()}`;
+    await postThreadReplyFromServerUser(browser!, serverURL, rootMessage, replyMessage);
 
-    try {
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
+    // User A: Verify cascading notification indicators appear.
 
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
+    // 1. Notification badge on the "general" room in room list.
+    const generalRoomLink = chatPage.roomList.locator('a', { hasText: '# general' });
+    const roomNotificationBadge = generalRoomLink.getByTestId('room-notification-badge');
+    await expect(roomNotificationBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+    await expect(roomNotificationBadge).toHaveText('1');
 
-      await chatPage2.enterRoom('general');
-      const message2 = roomPage2.getMessage(rootMessage);
-      await message2.openThread();
-      await roomPage2.expectThreadPaneVisible();
+    // 2. Notification badge on the server icon.
+    const notificationBadge = serverNotificationBadge(page);
+    await expect(notificationBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+    await expect(notificationBadge).toHaveText('1');
 
-      const replyMessage = `Reply from User B ${Date.now()}`;
-      await roomPage2.postThreadReply(replyMessage);
+    // 3. Navigate to general room and verify thread has notification indicator
+    await chatPage.enterRoom('general');
 
-      // User A: Verify cascading notification indicators appear.
+    // The thread indicator button shows "1 reply" and should have orange dot
+    const threadButton = page.getByRole('button', { name: /1 reply/i });
+    await expect(threadButton).toBeVisible();
+    const threadNotificationDot = threadButton.locator('.bg-warning');
+    await expect(threadNotificationDot).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
 
-      // 1. Notification badge on the "general" room in room list.
-      const generalRoomLink = chatPage.roomList.locator('a', { hasText: '# general' });
-      const roomNotificationBadge = generalRoomLink.getByTestId('room-notification-badge');
-      await expect(roomNotificationBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-      await expect(roomNotificationBadge).toHaveText('1');
+    // 4. Open the thread - notification should be dismissed
+    await message.openThread();
+    await roomPage.expectThreadPaneVisible();
 
-      // 2. Notification badge on the server icon.
-      const serverGutter = page.locator('.server-gutter');
-      const spaceButton = serverGutter.locator('[data-testid="server-icon"]').first();
-      const spaceNotificationBadge = spaceButton
-        .locator('..')
-        .getByTestId('server-notification-badge');
-      await expect(spaceNotificationBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-      await expect(spaceNotificationBadge).toHaveText('1');
+    // Thread orange dot should be gone
+    await expect(threadNotificationDot).not.toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
 
-      // 3. Navigate to general room and verify thread has notification indicator
-      await chatPage.enterRoom('general');
+    // Room notification badge should also be gone (no more notifications for this room).
+    await expect(roomNotificationBadge).not.toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
 
-      // The thread indicator button shows "1 reply" and should have orange dot
-      const threadButton = page.getByRole('button', { name: /1 reply/i });
-      await expect(threadButton).toBeVisible();
-      const threadNotificationDot = threadButton.locator('.bg-warning');
-      await expect(threadNotificationDot).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-
-      // 4. Open the thread - notification should be dismissed
-      await message.openThread();
-      await roomPage.expectThreadPaneVisible();
-
-      // Thread orange dot should be gone
-      await expect(threadNotificationDot).not.toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
-
-      // Room notification badge should also be gone (no more notifications for this room).
-      await expect(roomNotificationBadge).not.toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
-
-      // Server notification badge should also be gone (no more notifications on this server).
-      await expect(spaceNotificationBadge).not.toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
-    } finally {
-      await context2.close();
-    }
+    // Server notification badge should also be gone (no more notifications on this server).
+    await expect(notificationBadge).not.toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
   });
 });
 
@@ -295,30 +309,16 @@ test.describe('Notification Bell & Page', () => {
     // User A: Create account
     const userA = await createAndLoginTestUser(page);
     await chatPage.goto();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('announcements');
 
     // Verify bell has no indicator initially
     await notificationsPage.expectBellIndicatorNotVisible();
 
     // User B: Mention User A to create a notification
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
+    await postMentionFromServerUser(browser!, serverURL, userA.login, 'bell icon test');
 
-    try {
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-      await chatPage2.enterRoom('general');
-      await roomPage2.sendMessage(`@${userA.login} bell icon test`);
-
-      // User A: Bell should now have indicator
-      await notificationsPage.expectBellIndicatorVisible();
-    } finally {
-      await context2.close();
-    }
+    // User A: Bell should now have indicator
+    await notificationsPage.expectBellIndicatorVisible();
   });
 
   test('clicking bell navigates to notifications page', async ({
@@ -359,37 +359,23 @@ test.describe('Notification Page Display', () => {
     const userA = await createAndLoginTestUser(page);
     await chatPage.goto();
     const serverName = await chatPage.getServerName();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('announcements');
 
     // User B: Mention User A
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
+    await postMentionFromServerUser(browser!, serverURL, userA.login, 'notification display test');
 
-    try {
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-      await chatPage2.enterRoom('general');
-      await roomPage2.sendMessage(`@${userA.login} notification display test`);
+    // User A: Navigate to notifications page
+    await notificationsPage.goto();
 
-      // User A: Navigate to notifications page
-      await notificationsPage.goto();
+    // Verify notification appears with correct content
+    const notification = notificationsPage.getNotificationBySummary('mentioned you');
+    await expect(notification).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
 
-      // Verify notification appears with correct content
-      const notification = notificationsPage.getNotificationBySummary('mentioned you');
-      await expect(notification).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+    // Verify location is shown (room and server name)
+    await notificationsPage.expectNotificationWithLocation(notification, 'general', serverName);
 
-      // Verify location is shown (room and server name)
-      await notificationsPage.expectNotificationWithLocation(notification, 'general', serverName);
-
-      // Verify Clear all button is visible
-      await notificationsPage.expectClearAllVisible();
-    } finally {
-      await context2.close();
-    }
+    // Verify Clear all button is visible
+    await notificationsPage.expectClearAllVisible();
   });
 
   test('reply notification shows summary, location, and time', async ({
@@ -404,7 +390,6 @@ test.describe('Notification Page Display', () => {
     await createAndLoginTestUser(page);
     await chatPage.goto();
     const serverName = await chatPage.getServerName();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('general');
     const rootMessage = `Reply notification test ${Date.now()}`;
     await roomPage.sendMessage(rootMessage);
@@ -413,33 +398,22 @@ test.describe('Notification Page Display', () => {
     await chatPage.enterRoom('announcements');
 
     // User B: Reply to User A's message
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
+    await postThreadReplyFromServerUser(
+      browser!,
+      serverURL,
+      rootMessage,
+      'Reply to trigger notification'
+    );
 
-    try {
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-      await chatPage2.enterRoom('general');
-      const message2 = roomPage2.getMessage(rootMessage);
-      await message2.openThread();
-      await roomPage2.expectThreadPaneVisible();
-      await roomPage2.postThreadReply('Reply to trigger notification');
+    // User A: Navigate to notifications page
+    await notificationsPage.goto();
 
-      // User A: Navigate to notifications page
-      await notificationsPage.goto();
+    // Verify notification appears with correct content
+    const notification = notificationsPage.getNotificationBySummary('replied to your message');
+    await expect(notification).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
 
-      // Verify notification appears with correct content
-      const notification = notificationsPage.getNotificationBySummary('replied to your message');
-      await expect(notification).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-
-      // Verify location is shown (room and server name)
-      await notificationsPage.expectNotificationWithLocation(notification, 'general', serverName);
-    } finally {
-      await context2.close();
-    }
+    // Verify location is shown (room and server name)
+    await notificationsPage.expectNotificationWithLocation(notification, 'general', serverName);
   });
 
   test('multiple notifications show in list with correct count', async ({
@@ -453,7 +427,6 @@ test.describe('Notification Page Display', () => {
     // User A: Create account, post a message in general, and create an additional room
     const userA = await createAndLoginTestUser(page);
     await chatPage.goto();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('general');
     const rootMessage = `Multiple notifications test ${Date.now()}`;
     await roomPage.sendMessage(rootMessage);
@@ -464,45 +437,26 @@ test.describe('Notification Page Display', () => {
 
     // User B: Create multiple notifications (mention in the second room + reply in general)
     // Using separate rooms so notifications aren't deduplicated
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
-
-    try {
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const roomPage2 = new RoomPage(page2);
-
+    await withServerUser(browser!, serverURL, async ({ page: page2, chatPage, roomPage }) => {
       // Join the second room via Browse Rooms (User B doesn't have room.create)
-      await page2.getByRole('link', { name: 'Overview' }).click();
-      const roomItem = page2.locator('li', { hasText: `# ${secondRoomName}` });
-      await roomItem.getByRole('button', { name: 'Join' }).click();
-      // The Joined button swaps visible text to "Leave" on hover, and
-      // Playwright leaves the cursor on the button it just clicked.
-      // Asserting on `title` is stable across hover state.
-      await expect(roomItem.locator('button[title^="Joined "]')).toBeVisible({
-        timeout: TIMEOUTS.UI_STANDARD
-      });
+      await joinRoomFromOverview(page2, secondRoomName);
 
       // Navigate to the room via sidebar (Browse Rooms no longer auto-navigates)
-      const chatPage2 = new ChatPage(page2);
-      await chatPage2.enterRoom(secondRoomName);
+      await chatPage.enterRoom(secondRoomName);
 
       // Create mention notification in the second room (User A is not in any room)
-      await roomPage2.sendMessage(`@${userA.login} first notification`);
-      await chatPage2.enterRoom('general');
-      const message2 = roomPage2.getMessage(rootMessage);
+      await roomPage.sendMessage(`@${userA.login} first notification`);
+      await chatPage.enterRoom('general');
+      const message2 = roomPage.getMessage(rootMessage);
       await message2.openThread();
-      await roomPage2.expectThreadPaneVisible();
-      await roomPage2.postThreadReply('Reply notification');
+      await roomPage.expectThreadPaneVisible();
+      await roomPage.postThreadReply('Reply notification');
+    });
 
-      // User A: Verify both notifications appear
-      // Use longer timeout to allow real-time events to propagate
-      await notificationsPage.goto();
-      await notificationsPage.expectNotificationCount(2, TIMEOUTS.COMPLEX_OPERATION);
-    } finally {
-      await context2.close();
-    }
+    // User A: Verify both notifications appear
+    // Use longer timeout to allow real-time events to propagate
+    await notificationsPage.goto();
+    await notificationsPage.expectNotificationCount(2, TIMEOUTS.COMPLEX_OPERATION);
   });
 });
 
@@ -517,35 +471,21 @@ test.describe('Notification Dismissal', () => {
     // User A: Create account
     const userA = await createAndLoginTestUser(page);
     await chatPage.goto();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('announcements');
 
     // User B: Mention User A
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
+    await postMentionFromServerUser(browser!, serverURL, userA.login, 'dismiss test');
 
-    try {
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-      await chatPage2.enterRoom('general');
-      await roomPage2.sendMessage(`@${userA.login} dismiss test`);
+    // User A: Navigate to notifications and dismiss
+    await notificationsPage.goto();
+    const notification = notificationsPage.getNotificationBySummary('mentioned you');
+    await expect(notification).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
 
-      // User A: Navigate to notifications and dismiss
-      await notificationsPage.goto();
-      const notification = notificationsPage.getNotificationBySummary('mentioned you');
-      await expect(notification).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+    await notificationsPage.dismissNotification(notification);
 
-      await notificationsPage.dismissNotification(notification);
-
-      // Verify notification is gone and empty state shows
-      await expect(notification).not.toBeVisible();
-      await notificationsPage.expectEmptyState();
-    } finally {
-      await context2.close();
-    }
+    // Verify notification is gone and empty state shows
+    await expect(notification).not.toBeVisible();
+    await notificationsPage.expectEmptyState();
   });
 
   test('dismiss all notifications via Clear all button', async ({
@@ -559,7 +499,6 @@ test.describe('Notification Dismissal', () => {
     // User A: Create account, post message in general, and create an additional room
     const userA = await createAndLoginTestUser(page);
     await chatPage.goto();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('general');
     const rootMessage = `Clear all test ${Date.now()}`;
     await roomPage.sendMessage(rootMessage);
@@ -570,50 +509,31 @@ test.describe('Notification Dismissal', () => {
 
     // User B: Create multiple notifications (mention in second room + reply in general)
     // Using separate rooms so notifications aren't deduplicated
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
-
-    try {
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const roomPage2 = new RoomPage(page2);
-
+    await withServerUser(browser!, serverURL, async ({ page: page2, chatPage, roomPage }) => {
       // Join the second room via Browse Rooms (User B doesn't have room.create)
-      await page2.getByRole('link', { name: 'Overview' }).click();
-      const roomItem = page2.locator('li', { hasText: `# ${secondRoomName}` });
-      await roomItem.getByRole('button', { name: 'Join' }).click();
-      // The Joined button swaps visible text to "Leave" on hover, and
-      // Playwright leaves the cursor on the button it just clicked.
-      // Asserting on `title` is stable across hover state.
-      await expect(roomItem.locator('button[title^="Joined "]')).toBeVisible({
-        timeout: TIMEOUTS.UI_STANDARD
-      });
+      await joinRoomFromOverview(page2, secondRoomName);
 
       // Navigate to the room via sidebar (Browse Rooms no longer auto-navigates)
-      const chatPage2 = new ChatPage(page2);
-      await chatPage2.enterRoom(secondRoomName);
+      await chatPage.enterRoom(secondRoomName);
 
       // Create mention in the second room (User A is not in any room)
-      await roomPage2.sendMessage(`@${userA.login} clear all test 1`);
-      await chatPage2.enterRoom('general');
-      const message2 = roomPage2.getMessage(rootMessage);
+      await roomPage.sendMessage(`@${userA.login} clear all test 1`);
+      await chatPage.enterRoom('general');
+      const message2 = roomPage.getMessage(rootMessage);
       await message2.openThread();
-      await roomPage2.expectThreadPaneVisible();
-      await roomPage2.postThreadReply('Clear all test 2');
+      await roomPage.expectThreadPaneVisible();
+      await roomPage.postThreadReply('Clear all test 2');
+    });
 
-      // User A: Dismiss all
-      // Use longer timeout to allow real-time events to propagate
-      await notificationsPage.goto();
-      await notificationsPage.expectNotificationCount(2, TIMEOUTS.COMPLEX_OPERATION);
-      await notificationsPage.dismissAll();
+    // User A: Dismiss all
+    // Use longer timeout to allow real-time events to propagate
+    await notificationsPage.goto();
+    await notificationsPage.expectNotificationCount(2, TIMEOUTS.COMPLEX_OPERATION);
+    await notificationsPage.dismissAll();
 
-      // Verify all gone
-      await notificationsPage.expectEmptyState();
-      await notificationsPage.expectClearAllNotVisible();
-    } finally {
-      await context2.close();
-    }
+    // Verify all gone
+    await notificationsPage.expectEmptyState();
+    await notificationsPage.expectClearAllNotVisible();
   });
 
   test('bell indicator clears after dismissing all notifications', async ({
@@ -626,35 +546,21 @@ test.describe('Notification Dismissal', () => {
     // User A: Create account
     const userA = await createAndLoginTestUser(page);
     await chatPage.goto();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('announcements');
 
     // User B: Mention User A
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
+    await postMentionFromServerUser(browser!, serverURL, userA.login, 'bell clear test');
 
-    try {
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-      await chatPage2.enterRoom('general');
-      await roomPage2.sendMessage(`@${userA.login} bell clear test`);
+    // User A: Verify bell has indicator
+    await notificationsPage.expectBellIndicatorVisible();
 
-      // User A: Verify bell has indicator
-      await notificationsPage.expectBellIndicatorVisible();
+    // Dismiss all
+    await notificationsPage.goto();
+    await notificationsPage.dismissAll();
 
-      // Dismiss all
-      await notificationsPage.goto();
-      await notificationsPage.dismissAll();
-
-      // Navigate back to chat and verify bell indicator is gone
-      await chatPage.goto();
-      await notificationsPage.expectBellIndicatorNotVisible();
-    } finally {
-      await context2.close();
-    }
+    // Navigate back to chat and verify bell indicator is gone
+    await chatPage.goto();
+    await notificationsPage.expectBellIndicatorNotVisible();
   });
 });
 
@@ -669,34 +575,20 @@ test.describe('Navigation from Notifications', () => {
     // User A: Create account
     const userA = await createAndLoginTestUser(page);
     await chatPage.goto();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('announcements');
 
     // User B: Mention User A
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
+    await postMentionFromServerUser(browser!, serverURL, userA.login, 'nav test');
 
-    try {
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-      await chatPage2.enterRoom('general');
-      await roomPage2.sendMessage(`@${userA.login} nav test`);
+    // User A: Click notification
+    await notificationsPage.goto();
+    const notification = notificationsPage.getNotificationBySummary('mentioned you');
+    await expect(notification).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+    await notificationsPage.clickNotification(notification);
 
-      // User A: Click notification
-      await notificationsPage.goto();
-      const notification = notificationsPage.getNotificationBySummary('mentioned you');
-      await expect(notification).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-      await notificationsPage.clickNotification(notification);
-
-      // Verify navigated to the room
-      await page.waitForURL(routes.patterns.anyRoomWithQuery);
-      await expect(page.getByRole('heading', { name: '# general' })).toBeVisible();
-    } finally {
-      await context2.close();
-    }
+    // Verify navigated to the room
+    await page.waitForURL(routes.patterns.anyRoomWithQuery);
+    await expect(page.getByRole('heading', { name: '# general' })).toBeVisible();
   });
 
   test('clicking reply notification navigates to the thread', async ({
@@ -710,45 +602,28 @@ test.describe('Navigation from Notifications', () => {
     // User A: Create account and post message
     await createAndLoginTestUser(page);
     await chatPage.goto();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('general');
     const rootMessage = `Thread nav test ${Date.now()}`;
     await roomPage.sendMessage(rootMessage);
     await chatPage.enterRoom('announcements');
 
     // User B: Reply to thread
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
+    const replyText = `Reply for nav test ${Date.now()}`;
+    await postThreadReplyFromServerUser(browser!, serverURL, rootMessage, replyText);
 
-    try {
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-      await chatPage2.enterRoom('general');
-      const message2 = roomPage2.getMessage(rootMessage);
-      await message2.openThread();
-      await roomPage2.expectThreadPaneVisible();
-      const replyText = `Reply for nav test ${Date.now()}`;
-      await roomPage2.postThreadReply(replyText);
+    // User A: Click notification
+    await notificationsPage.goto();
+    const notification = notificationsPage.getNotificationBySummary('replied to your message');
+    await expect(notification).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+    await notificationsPage.clickNotification(notification);
 
-      // User A: Click notification
-      await notificationsPage.goto();
-      const notification = notificationsPage.getNotificationBySummary('replied to your message');
-      await expect(notification).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-      await notificationsPage.clickNotification(notification);
-
-      // Verify navigated to the thread URL. Highlight intent is delivered via
-      // PendingHighlightStore now (not ?highlight= URL param), so the URL is clean.
-      await page.waitForURL(routes.patterns.anyThread);
-      // Thread pane should be visible and scrolled to the new reply
-      await roomPage.expectThreadPaneVisible();
-      await roomPage.expectTextInThreadPane(replyText);
-      await expect(roomPage.threadPane.getByText(replyText)).toBeInViewport();
-    } finally {
-      await context2.close();
-    }
+    // Verify navigated to the thread URL. Highlight intent is delivered via
+    // PendingHighlightStore now (not ?highlight= URL param), so the URL is clean.
+    await page.waitForURL(routes.patterns.anyThread);
+    // Thread pane should be visible and scrolled to the new reply
+    await roomPage.expectThreadPaneVisible();
+    await roomPage.expectTextInThreadPane(replyText);
+    await expect(roomPage.threadPane.getByText(replyText)).toBeInViewport();
   });
 
   test('clicking notification dismisses it', async ({
@@ -761,35 +636,21 @@ test.describe('Navigation from Notifications', () => {
     // User A: Create account
     const userA = await createAndLoginTestUser(page);
     await chatPage.goto();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('announcements');
 
     // User B: Mention User A in general room (User B can't post in announcements due to RBAC)
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
+    await postMentionFromServerUser(browser!, serverURL, userA.login, 'dismiss on click test');
 
-    try {
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-      await chatPage2.enterRoom('general');
-      await roomPage2.sendMessage(`@${userA.login} dismiss on click test`);
+    // User A: Click notification
+    await notificationsPage.goto();
+    const notification = notificationsPage.getNotificationBySummary('mentioned you');
+    await expect(notification).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+    await notificationsPage.clickNotification(notification);
+    await page.waitForURL(routes.patterns.anyRoomWithQuery);
 
-      // User A: Click notification
-      await notificationsPage.goto();
-      const notification = notificationsPage.getNotificationBySummary('mentioned you');
-      await expect(notification).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-      await notificationsPage.clickNotification(notification);
-      await page.waitForURL(routes.patterns.anyRoomWithQuery);
-
-      // Go back to notifications - should be empty
-      await notificationsPage.gotoDirectly();
-      await notificationsPage.expectEmptyState();
-    } finally {
-      await context2.close();
-    }
+    // Go back to notifications - should be empty
+    await notificationsPage.gotoDirectly();
+    await notificationsPage.expectEmptyState();
   });
 });
 
@@ -804,16 +665,11 @@ test.describe('Cross-Tab Sync', () => {
     // User A: Create account
     const userA = await createAndLoginTestUser(page);
     await chatPage.goto();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('announcements');
 
     // User A: Open second tab (same user, same session)
     const context1b = await browser!.newContext({ baseURL: serverURL });
     const page1b = await context1b.newPage();
-
-    // User B context
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
 
     try {
       // Log User A into second tab
@@ -827,13 +683,7 @@ test.describe('Cross-Tab Sync', () => {
       await notificationsPage1b.expectBellIndicatorNotVisible();
 
       // User B: Create account and mention User A in general (User B can't post in announcements due to RBAC)
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-      await chatPage2.enterRoom('general');
-      await roomPage2.sendMessage(`@${userA.login} cross tab test`);
+      await postMentionFromServerUser(browser!, serverURL, userA.login, 'cross tab test');
 
       // Both of User A's tabs should show bell indicator
       await notificationsPage.expectBellIndicatorVisible();
@@ -844,7 +694,6 @@ test.describe('Cross-Tab Sync', () => {
       await notificationsPage1b.expectNotificationWithSummary('mentioned you');
     } finally {
       await context1b.close();
-      await context2.close();
     }
   });
 
@@ -858,16 +707,11 @@ test.describe('Cross-Tab Sync', () => {
     // User A: Create account
     const userA = await createAndLoginTestUser(page);
     await chatPage.goto();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('announcements');
 
     // User A: Open second tab
     const context1b = await browser!.newContext({ baseURL: serverURL });
     const page1b = await context1b.newPage();
-
-    // User B context
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
 
     try {
       // Log User A into second tab
@@ -876,13 +720,7 @@ test.describe('Cross-Tab Sync', () => {
       const notificationsPage1b = new NotificationsPage(page1b);
 
       // User B: Mention User A in general (User B can't post in announcements due to RBAC)
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-      await chatPage2.enterRoom('general');
-      await roomPage2.sendMessage(`@${userA.login} cross tab dismiss test`);
+      await postMentionFromServerUser(browser!, serverURL, userA.login, 'cross tab dismiss test');
 
       // Both tabs should show bell indicator
       await notificationsPage.expectBellIndicatorVisible();
@@ -905,7 +743,6 @@ test.describe('Cross-Tab Sync', () => {
       await notificationsPage1b.expectEmptyState();
     } finally {
       await context1b.close();
-      await context2.close();
     }
   });
 
@@ -918,16 +755,11 @@ test.describe('Cross-Tab Sync', () => {
     // User A: Create account
     const userA = await createAndLoginTestUser(page);
     await chatPage.goto();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('announcements');
 
     // User A: Open second tab on notifications page
     const context1b = await browser!.newContext({ baseURL: serverURL });
     const page1b = await context1b.newPage();
-
-    // User B context
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
 
     try {
       // Log User A into second tab
@@ -935,13 +767,12 @@ test.describe('Cross-Tab Sync', () => {
       const notificationsPage1b = new NotificationsPage(page1b);
 
       // User B: Mention User A in general (User B can't post in announcements due to RBAC)
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-      await chatPage2.enterRoom('general');
-      await roomPage2.sendMessage(`@${userA.login} room entry dismiss sync test`);
+      await postMentionFromServerUser(
+        browser!,
+        serverURL,
+        userA.login,
+        'room entry dismiss sync test'
+      );
 
       // User A (tab 2): Go to notifications page and verify notification exists
       await notificationsPage1b.gotoDirectly();
@@ -956,11 +787,10 @@ test.describe('Cross-Tab Sync', () => {
       await notificationsPage1b.expectEmptyState();
     } finally {
       await context1b.close();
-      await context2.close();
     }
   });
 
-  test('notification dismissed by opening thread syncs to other tabs', async ({
+  test('reply notification is dismissed by opening the thread', async ({
     page,
     chatPage,
     roomPage,
@@ -971,54 +801,28 @@ test.describe('Cross-Tab Sync', () => {
     // User A: Create account and post message
     await createAndLoginTestUser(page);
     await chatPage.goto();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('general');
     const rootMessage = `Thread sync test ${Date.now()}`;
     const message = await roomPage.sendMessage(rootMessage);
 
-    // User A: Open second tab
-    const context1b = await browser!.newContext({ baseURL: serverURL });
-    const page1b = await context1b.newPage();
+    // User B: Reply to User A's message
+    await postThreadReplyFromServerUser(
+      browser!,
+      serverURL,
+      rootMessage,
+      'Reply for thread sync test'
+    );
 
-    // User B context
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
+    // User A: Verify bell indicator
+    await notificationsPage.expectBellIndicatorVisible();
 
-    try {
-      // Get user info from first page's logged in state
-      // We'll verify via notification sync instead of explicit login
+    // User A: Open the thread (auto-dismisses reply notification)
+    await chatPage.enterRoom('general');
+    await message.openThread();
+    await roomPage.expectThreadPaneVisible();
 
-      // Actually, let's use the credentials - we need to get the login from somewhere
-      // For simplicity, let's navigate tab2 to notifications and watch for changes
-      await page1b.goto(`${serverURL}${routes.space()}`);
-      // This will require auth, so let's use a different approach
-
-      // User B: Reply to User A's message
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-      await chatPage2.enterRoom('general');
-      const message2 = roomPage2.getMessage(rootMessage);
-      await message2.openThread();
-      await roomPage2.expectThreadPaneVisible();
-      await roomPage2.postThreadReply('Reply for thread sync test');
-
-      // User A (tab 1): Verify bell indicator
-      await notificationsPage.expectBellIndicatorVisible();
-
-      // User A (tab 1): Open the thread (auto-dismisses reply notification)
-      await chatPage.enterRoom('general');
-      await message.openThread();
-      await roomPage.expectThreadPaneVisible();
-
-      // User A (tab 1): Bell indicator should be gone
-      await notificationsPage.expectBellIndicatorNotVisible();
-    } finally {
-      await context1b.close();
-      await context2.close();
-    }
+    // User A: Bell indicator should be gone
+    await notificationsPage.expectBellIndicatorNotVisible();
   });
 
   test('dismissing a mention notification clears the room badge on other tabs and survives reload', async ({
@@ -1046,8 +850,6 @@ test.describe('Cross-Tab Sync', () => {
 
     const context1b = await browser!.newContext({ baseURL: serverURL });
     const page1b = await context1b.newPage();
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
 
     try {
       // User A: second tab, also navigated to announcements so #general's
@@ -1060,13 +862,12 @@ test.describe('Cross-Tab Sync', () => {
       const generalMentionBadge1b = generalLink1b.getByTestId('room-notification-badge');
 
       // User B: mention User A in #general.
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-      await chatPage2.enterRoom('general');
-      await roomPage2.sendMessage(`@${userA.login} cross-device mention sync test`);
+      await postMentionFromServerUser(
+        browser!,
+        serverURL,
+        userA.login,
+        'cross-device mention sync test'
+      );
 
       // Both tabs show the room-level mention badge and the bell.
       await expect(generalMentionBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
@@ -1102,7 +903,6 @@ test.describe('Cross-Tab Sync', () => {
       }).toPass({ timeout: TIMEOUTS.REALTIME_EVENT, intervals: [100, 250, 500, 1000] });
     } finally {
       await context1b.close();
-      await context2.close();
     }
   });
 });
@@ -1118,35 +918,21 @@ test.describe('Real-time Notification Updates', () => {
     // User A: Create account and go to notifications page
     const userA = await createAndLoginTestUser(page);
     await chatPage.goto();
-    const spaceId = await chatPage.getServerScopeId();
 
     // Navigate to notifications page (empty)
     await notificationsPage.goto();
     await notificationsPage.expectEmptyState();
 
     // User B: Mention User A while A is on notifications page
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
+    await postMentionFromServerUser(browser!, serverURL, userA.login, 'real-time test');
 
-    try {
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-      await chatPage2.enterRoom('general');
-      await roomPage2.sendMessage(`@${userA.login} real-time test`);
+    // User A: Notification should appear without refresh
+    const notification = notificationsPage.getNotificationBySummary('mentioned you');
+    await expect(notification).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
 
-      // User A: Notification should appear without refresh
-      const notification = notificationsPage.getNotificationBySummary('mentioned you');
-      await expect(notification).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-
-      // Empty state should be gone, Clear all should be visible
-      await expect(notificationsPage.emptyState).not.toBeVisible();
-      await notificationsPage.expectClearAllVisible();
-    } finally {
-      await context2.close();
-    }
+    // Empty state should be gone, Clear all should be visible
+    await expect(notificationsPage.emptyState).not.toBeVisible();
+    await notificationsPage.expectClearAllVisible();
   });
 
   test('notification count updates in real-time', async ({
@@ -1160,7 +946,6 @@ test.describe('Real-time Notification Updates', () => {
     // User A: Create account, post message, go to notifications
     const userA = await createAndLoginTestUser(page);
     await chatPage.goto();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('general');
     const rootMessage = `Count test ${Date.now()}`;
     await roomPage.sendMessage(rootMessage);
@@ -1169,34 +954,23 @@ test.describe('Real-time Notification Updates', () => {
     await notificationsPage.expectEmptyState();
 
     // User B: Create multiple notifications
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
-
-    try {
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-
+    await withServerUser(browser!, serverURL, async ({ chatPage, roomPage }) => {
       // First notification (mention) - User B posts in general since they can't post in announcements
-      await chatPage2.enterRoom('general');
-      await roomPage2.sendMessage(`@${userA.login} count test 1`);
+      await chatPage.enterRoom('general');
+      await roomPage.sendMessage(`@${userA.login} count test 1`);
 
       // User A: Should see 1 notification
       await notificationsPage.expectNotificationCount(1);
 
       // Second notification (reply) - User B is already in general
-      const message2 = roomPage2.getMessage(rootMessage);
+      const message2 = roomPage.getMessage(rootMessage);
       await message2.openThread();
-      await roomPage2.expectThreadPaneVisible();
-      await roomPage2.postThreadReply('Count test 2');
+      await roomPage.expectThreadPaneVisible();
+      await roomPage.postThreadReply('Count test 2');
+    });
 
-      // User A: Should see 2 notifications
-      await notificationsPage.expectNotificationCount(2);
-    } finally {
-      await context2.close();
-    }
+    // User A: Should see 2 notifications
+    await notificationsPage.expectNotificationCount(2);
   });
 });
 
@@ -1210,30 +984,16 @@ test.describe('Page Title Notification Count', () => {
     // User A: Create account
     const userA = await createAndLoginTestUser(page);
     await chatPage.goto();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('announcements');
 
     // Verify title does not have count prefix initially
     await expect(page).toHaveTitle(/^(?!\(\d+\)).*$/);
 
     // User B: Mention User A in general (User B can't post in announcements due to RBAC)
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
+    await postMentionFromServerUser(browser!, serverURL, userA.login, 'page title test');
 
-    try {
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-      await chatPage2.enterRoom('general');
-      await roomPage2.sendMessage(`@${userA.login} page title test`);
-
-      // User A: Page title should now show (1) prefix
-      await expect(page).toHaveTitle(/^\(1\) /, { timeout: TIMEOUTS.REALTIME_EVENT });
-    } finally {
-      await context2.close();
-    }
+    // User A: Page title should now show (1) prefix
+    await expect(page).toHaveTitle(/^\(1\) /, { timeout: TIMEOUTS.REALTIME_EVENT });
   });
 
   test('page title count updates as notifications are added', async ({
@@ -1246,7 +1006,6 @@ test.describe('Page Title Notification Count', () => {
     // User A: Create account, post message in general, and create an additional room
     const userA = await createAndLoginTestUser(page);
     await chatPage.goto();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('general');
     const rootMessage = `Title count test ${Date.now()}`;
     await roomPage.sendMessage(rootMessage);
@@ -1261,46 +1020,27 @@ test.describe('Page Title Notification Count', () => {
 
     // User B: Create multiple notifications (mention in second room + reply in general)
     // Using separate rooms so notifications aren't deduplicated
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
-
-    try {
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const roomPage2 = new RoomPage(page2);
-
+    await withServerUser(browser!, serverURL, async ({ page: page2, chatPage, roomPage }) => {
       // Join the second room via Browse Rooms (User B doesn't have room.create)
-      await page2.getByRole('link', { name: 'Overview' }).click();
-      const roomItem = page2.locator('li', { hasText: `# ${secondRoomName}` });
-      await roomItem.getByRole('button', { name: 'Join' }).click();
-      // The Joined button swaps visible text to "Leave" on hover, and
-      // Playwright leaves the cursor on the button it just clicked.
-      // Asserting on `title` is stable across hover state.
-      await expect(roomItem.locator('button[title^="Joined "]')).toBeVisible({
-        timeout: TIMEOUTS.UI_STANDARD
-      });
+      await joinRoomFromOverview(page2, secondRoomName);
 
       // Navigate to the room via sidebar (Browse Rooms no longer auto-navigates)
-      const chatPage2 = new ChatPage(page2);
-      await chatPage2.enterRoom(secondRoomName);
+      await chatPage.enterRoom(secondRoomName);
 
       // First notification (mention in the second room)
-      await roomPage2.sendMessage(`@${userA.login} title count 1`);
+      await roomPage.sendMessage(`@${userA.login} title count 1`);
 
       // User A: Title should show (1)
       await expect(page).toHaveTitle(/^\(1\) /, { timeout: TIMEOUTS.REALTIME_EVENT });
-      await chatPage2.enterRoom('general');
-      const message2 = roomPage2.getMessage(rootMessage);
+      await chatPage.enterRoom('general');
+      const message2 = roomPage.getMessage(rootMessage);
       await message2.openThread();
-      await roomPage2.expectThreadPaneVisible();
-      await roomPage2.postThreadReply('Title count 2');
+      await roomPage.expectThreadPaneVisible();
+      await roomPage.postThreadReply('Title count 2');
+    });
 
-      // User A: Title should show (2)
-      await expect(page).toHaveTitle(/^\(2\) /, { timeout: TIMEOUTS.REALTIME_EVENT });
-    } finally {
-      await context2.close();
-    }
+    // User A: Title should show (2)
+    await expect(page).toHaveTitle(/^\(2\) /, { timeout: TIMEOUTS.REALTIME_EVENT });
   });
 
   test('page title returns to normal after dismissing all notifications', async ({
@@ -1313,34 +1053,20 @@ test.describe('Page Title Notification Count', () => {
     // User A: Create account
     const userA = await createAndLoginTestUser(page);
     await chatPage.goto();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('announcements');
 
     // User B: Mention User A in general (User B can't post in announcements due to RBAC)
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
+    await postMentionFromServerUser(browser!, serverURL, userA.login, 'title dismiss test');
 
-    try {
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-      await chatPage2.enterRoom('general');
-      await roomPage2.sendMessage(`@${userA.login} title dismiss test`);
+    // User A: Verify title has count
+    await expect(page).toHaveTitle(/^\(1\) /, { timeout: TIMEOUTS.REALTIME_EVENT });
 
-      // User A: Verify title has count
-      await expect(page).toHaveTitle(/^\(1\) /, { timeout: TIMEOUTS.REALTIME_EVENT });
+    // Dismiss all notifications
+    await notificationsPage.goto();
+    await notificationsPage.dismissAll();
 
-      // Dismiss all notifications
-      await notificationsPage.goto();
-      await notificationsPage.dismissAll();
-
-      // Title should no longer have count prefix
-      await expect(page).toHaveTitle(/^(?!\(\d+\)).*$/);
-    } finally {
-      await context2.close();
-    }
+    // Title should no longer have count prefix
+    await expect(page).toHaveTitle(/^(?!\(\d+\)).*$/);
   });
 
   test('page title count decrements when notification is dismissed', async ({
@@ -1354,7 +1080,6 @@ test.describe('Page Title Notification Count', () => {
     // User A: Create account, post message in general, and create an additional room
     const userA = await createAndLoginTestUser(page);
     await chatPage.goto();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('general');
     const rootMessage = `Title decrement test ${Date.now()}`;
     await roomPage.sendMessage(rootMessage);
@@ -1366,60 +1091,40 @@ test.describe('Page Title Notification Count', () => {
 
     // User B: Create two notifications (mention in second room + reply in general)
     // Using separate rooms so notifications aren't deduplicated
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
-
-    try {
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const roomPage2 = new RoomPage(page2);
-
+    await withServerUser(browser!, serverURL, async ({ page: page2, chatPage, roomPage }) => {
       // Join the second room via Browse Rooms (User B doesn't have room.create)
-      await page2.getByRole('link', { name: 'Overview' }).click();
-      const roomItem = page2.locator('li', { hasText: `# ${secondRoomName}` });
-      await roomItem.getByRole('button', { name: 'Join' }).click();
-      // The Joined button swaps visible text to "Leave" on hover, and
-      // Playwright leaves the cursor on the button it just clicked.
-      // Asserting on `title` is stable across hover state.
-      await expect(roomItem.locator('button[title^="Joined "]')).toBeVisible({
-        timeout: TIMEOUTS.UI_STANDARD
-      });
+      await joinRoomFromOverview(page2, secondRoomName);
 
       // Navigate to the room via sidebar (Browse Rooms no longer auto-navigates)
-      const chatPage2 = new ChatPage(page2);
-      await chatPage2.enterRoom(secondRoomName);
+      await chatPage.enterRoom(secondRoomName);
 
       // First notification (mention in the second room)
-      await roomPage2.sendMessage(`@${userA.login} title decrement 1`);
-      await chatPage2.enterRoom('general');
-      const message2 = roomPage2.getMessage(rootMessage);
+      await roomPage.sendMessage(`@${userA.login} title decrement 1`);
+      await chatPage.enterRoom('general');
+      const message2 = roomPage.getMessage(rootMessage);
       await message2.openThread();
-      await roomPage2.expectThreadPaneVisible();
-      await roomPage2.postThreadReply('Title decrement 2');
+      await roomPage.expectThreadPaneVisible();
+      await roomPage.postThreadReply('Title decrement 2');
+    });
 
-      // User A: Verify title shows (2)
-      await expect(page).toHaveTitle(/^\(2\) /, { timeout: TIMEOUTS.REALTIME_EVENT });
+    // User A: Verify title shows (2)
+    await expect(page).toHaveTitle(/^\(2\) /, { timeout: TIMEOUTS.REALTIME_EVENT });
 
-      // Dismiss one notification
-      await notificationsPage.goto();
-      const mentionNotification = notificationsPage.getNotificationBySummary('mentioned you');
-      await expect(mentionNotification).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-      await notificationsPage.dismissNotification(mentionNotification);
+    // Dismiss one notification
+    await notificationsPage.goto();
+    const mentionNotification = notificationsPage.getNotificationBySummary('mentioned you');
+    await expect(mentionNotification).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+    await notificationsPage.dismissNotification(mentionNotification);
 
-      // Title should now show (1)
-      await expect(page).toHaveTitle(/^\(1\) /);
+    // Title should now show (1)
+    await expect(page).toHaveTitle(/^\(1\) /);
 
-      // Dismiss the remaining notification
-      const replyNotification =
-        notificationsPage.getNotificationBySummary('replied to your message');
-      await notificationsPage.dismissNotification(replyNotification);
+    // Dismiss the remaining notification
+    const replyNotification = notificationsPage.getNotificationBySummary('replied to your message');
+    await notificationsPage.dismissNotification(replyNotification);
 
-      // Title should have no count prefix
-      await expect(page).toHaveTitle(/^(?!\(\d+\)).*$/);
-    } finally {
-      await context2.close();
-    }
+    // Title should have no count prefix
+    await expect(page).toHaveTitle(/^(?!\(\d+\)).*$/);
   });
 });
 
@@ -1433,47 +1138,37 @@ test.describe('Clickable Notification Badges', () => {
     // User A: Create account
     const userA = await createAndLoginTestUser(page);
     await chatPage.goto();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('announcements');
 
     // User B: Mention User A in general
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
+    await postMentionFromServerUser(
+      browser!,
+      serverURL,
+      userA.login,
+      `clickable dot test ${Date.now()}`
+    );
 
-    try {
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-      await chatPage2.enterRoom('general');
-      const testMessage = `@${userA.login} clickable dot test ${Date.now()}`;
-      await roomPage2.sendMessage(testMessage);
+    // User A: Navigate to the server (not in general room)
+    await page.goto(routes.space());
+    await chatPage.enterRoom('announcements');
 
-      // User A: Navigate to the server (not in general room)
-      await page.goto(routes.space());
-      await chatPage.enterRoom('announcements');
+    // Verify notification badge appears on general room.
+    const roomNotificationBadge = page
+      .locator('.room-list a', { hasText: 'general' })
+      .getByTestId('room-notification-badge');
+    await expect(roomNotificationBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+    await expect(roomNotificationBadge).toHaveText('1');
 
-      // Verify notification badge appears on general room.
-      const roomNotificationBadge = page
-        .locator('.room-list a', { hasText: 'general' })
-        .getByTestId('room-notification-badge');
-      await expect(roomNotificationBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-      await expect(roomNotificationBadge).toHaveText('1');
+    // Click the notification badge (not the room link itself).
+    await roomNotificationBadge.click();
 
-      // Click the notification badge (not the room link itself).
-      await roomNotificationBadge.click();
+    // Verify navigated to general room. Highlight intent is delivered via
+    // PendingHighlightStore now (not ?highlight= URL param), so the URL is clean.
+    await page.waitForURL(routes.patterns.anyRoom);
+    await expect(page.getByRole('heading', { name: '# general' })).toBeVisible();
 
-      // Verify navigated to general room. Highlight intent is delivered via
-      // PendingHighlightStore now (not ?highlight= URL param), so the URL is clean.
-      await page.waitForURL(routes.patterns.anyRoom);
-      await expect(page.getByRole('heading', { name: '# general' })).toBeVisible();
-
-      // Verify notification badge is gone (notification was dismissed).
-      await expect(roomNotificationBadge).not.toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
-    } finally {
-      await context2.close();
-    }
+    // Verify notification badge is gone (notification was dismissed).
+    await expect(roomNotificationBadge).not.toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
   });
 
   test('clicking notification badge for room reply navigates to room with highlight', async ({
@@ -1486,7 +1181,6 @@ test.describe('Clickable Notification Badges', () => {
     // User A: Create account and post a message
     await createAndLoginTestUser(page);
     await chatPage.goto();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('general');
     const rootMessage = `Room reply dot test ${Date.now()}`;
     await roomPage.sendMessage(rootMessage);
@@ -1495,45 +1189,25 @@ test.describe('Clickable Notification Badges', () => {
     await chatPage.enterRoom('announcements');
 
     // User B: Reply to User A's message in room (not thread)
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
+    await postRoomReplyFromServerUser(browser!, serverURL, rootMessage, `Room reply ${Date.now()}`);
 
-    try {
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
+    // User A: Verify notification badge on general room.
+    const roomNotificationBadge = page
+      .locator('.room-list a', { hasText: 'general' })
+      .getByTestId('room-notification-badge');
+    await expect(roomNotificationBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+    await expect(roomNotificationBadge).toHaveText('1');
 
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-      await chatPage2.enterRoom('general');
+    // Click the notification badge.
+    await roomNotificationBadge.click();
 
-      const targetMsg = roomPage2.getMessage(rootMessage);
-      await targetMsg.replyInRoom();
-      await expect(page2.getByTestId('reply-indicator')).toBeVisible({
-        timeout: TIMEOUTS.UI_STANDARD
-      });
-      await roomPage2.sendMessage(`Room reply ${Date.now()}`);
+    // Verify navigated to general room (not a thread URL). Highlight intent
+    // is delivered via PendingHighlightStore now, so the URL is clean.
+    await page.waitForURL(routes.patterns.anyRoom);
+    await expect(page.getByRole('heading', { name: '# general' })).toBeVisible();
 
-      // User A: Verify notification badge on general room.
-      const roomNotificationBadge = page
-        .locator('.room-list a', { hasText: 'general' })
-        .getByTestId('room-notification-badge');
-      await expect(roomNotificationBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-      await expect(roomNotificationBadge).toHaveText('1');
-
-      // Click the notification badge.
-      await roomNotificationBadge.click();
-
-      // Verify navigated to general room (not a thread URL). Highlight intent
-      // is delivered via PendingHighlightStore now, so the URL is clean.
-      await page.waitForURL(routes.patterns.anyRoom);
-      await expect(page.getByRole('heading', { name: '# general' })).toBeVisible();
-
-      // Verify notification badge is gone.
-      await expect(roomNotificationBadge).not.toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
-    } finally {
-      await context2.close();
-    }
+    // Verify notification badge is gone.
+    await expect(roomNotificationBadge).not.toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
   });
 
   // The DM-icon click-to-navigate test was removed alongside the
@@ -1555,7 +1229,6 @@ test.describe('Room Reply Notifications', () => {
     await createAndLoginTestUser(page);
     await chatPage.goto();
     const serverName = await chatPage.getServerName();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('general');
     const rootMessage = `Room reply notify test ${Date.now()}`;
     await roomPage.sendMessage(rootMessage);
@@ -1564,51 +1237,32 @@ test.describe('Room Reply Notifications', () => {
     await chatPage.enterRoom('announcements');
 
     // User B: Reply to User A's message in room (not thread)
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
+    await postRoomReplyFromServerUser(
+      browser!,
+      serverURL,
+      rootMessage,
+      `Reply from User B ${Date.now()}`
+    );
 
-    try {
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
+    // User A: Bell indicator should appear
+    await notificationsPage.expectBellIndicatorVisible();
 
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-      await chatPage2.enterRoom('general');
+    // Verify notification badge on general room in room list.
+    const generalLink = chatPage.roomList.locator('a', { hasText: '# general' });
+    const roomNotificationBadge = generalLink.getByTestId('room-notification-badge');
+    await expect(roomNotificationBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+    await expect(roomNotificationBadge).toHaveText('1');
 
-      const targetMsg = roomPage2.getMessage(rootMessage);
-      await targetMsg.replyInRoom();
-      await expect(page2.getByTestId('reply-indicator')).toBeVisible({
-        timeout: TIMEOUTS.UI_STANDARD
-      });
-      await roomPage2.sendMessage(`Reply from User B ${Date.now()}`);
+    // Verify notification badge on server icon.
+    const notificationBadge = serverNotificationBadge(page);
+    await expect(notificationBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+    await expect(notificationBadge).toHaveText('1');
 
-      // User A: Bell indicator should appear
-      await notificationsPage.expectBellIndicatorVisible();
-
-      // Verify notification badge on general room in room list.
-      const generalLink = chatPage.roomList.locator('a', { hasText: '# general' });
-      const roomNotificationBadge = generalLink.getByTestId('room-notification-badge');
-      await expect(roomNotificationBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-      await expect(roomNotificationBadge).toHaveText('1');
-
-      // Verify notification badge on server icon.
-      const serverGutter = page.locator('.server-gutter');
-      const spaceButton = serverGutter.locator('[data-testid="server-icon"]').first();
-      const spaceNotificationBadge = spaceButton
-        .locator('..')
-        .getByTestId('server-notification-badge');
-      await expect(spaceNotificationBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-      await expect(spaceNotificationBadge).toHaveText('1');
-
-      // Verify notification page shows reply notification with correct content
-      await notificationsPage.goto();
-      const notification = notificationsPage.getNotificationBySummary('replied to your message');
-      await expect(notification).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-      await notificationsPage.expectNotificationWithLocation(notification, 'general', serverName);
-    } finally {
-      await context2.close();
-    }
+    // Verify notification page shows reply notification with correct content
+    await notificationsPage.goto();
+    const notification = notificationsPage.getNotificationBySummary('replied to your message');
+    await expect(notification).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+    await notificationsPage.expectNotificationWithLocation(notification, 'general', serverName);
   });
 
   test('clicking room reply notification navigates to room with highlight', async ({
@@ -1622,44 +1276,24 @@ test.describe('Room Reply Notifications', () => {
     // User A: Create account and post a message
     await createAndLoginTestUser(page);
     await chatPage.goto();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('general');
     const rootMessage = `Room reply nav test ${Date.now()}`;
     await roomPage.sendMessage(rootMessage);
     await chatPage.enterRoom('announcements');
 
     // User B: Reply to User A's message in room
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
+    await postRoomReplyFromServerUser(browser!, serverURL, rootMessage, `Nav reply ${Date.now()}`);
 
-    try {
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-      await chatPage2.enterRoom('general');
+    // User A: Click the reply notification
+    await notificationsPage.goto();
+    const notification = notificationsPage.getNotificationBySummary('replied to your message');
+    await expect(notification).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+    await notificationsPage.clickNotification(notification);
 
-      const targetMsg = roomPage2.getMessage(rootMessage);
-      await targetMsg.replyInRoom();
-      await expect(page2.getByTestId('reply-indicator')).toBeVisible({
-        timeout: TIMEOUTS.UI_STANDARD
-      });
-      await roomPage2.sendMessage(`Nav reply ${Date.now()}`);
-
-      // User A: Click the reply notification
-      await notificationsPage.goto();
-      const notification = notificationsPage.getNotificationBySummary('replied to your message');
-      await expect(notification).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-      await notificationsPage.clickNotification(notification);
-
-      // Verify navigated to room (NOT a thread URL with 3 path segments).
-      // Highlight intent is delivered via PendingHighlightStore now.
-      await page.waitForURL(routes.patterns.anyRoom);
-      await expect(page.getByRole('heading', { name: '# general' })).toBeVisible();
-    } finally {
-      await context2.close();
-    }
+    // Verify navigated to room (NOT a thread URL with 3 path segments).
+    // Highlight intent is delivered via PendingHighlightStore now.
+    await page.waitForURL(routes.patterns.anyRoom);
+    await expect(page.getByRole('heading', { name: '# general' })).toBeVisible();
   });
 
   test('room reply notification dismissed on room entry', async ({
@@ -1673,41 +1307,26 @@ test.describe('Room Reply Notifications', () => {
     // User A: Create account and post a message
     await createAndLoginTestUser(page);
     await chatPage.goto();
-    const spaceId = await chatPage.getServerScopeId();
     await chatPage.enterRoom('general');
     const rootMessage = `Room reply dismiss test ${Date.now()}`;
     await roomPage.sendMessage(rootMessage);
     await chatPage.enterRoom('announcements');
 
     // User B: Reply to User A's message in room
-    const context2 = await browser!.newContext({ baseURL: serverURL });
-    const page2 = await context2.newPage();
+    await postRoomReplyFromServerUser(
+      browser!,
+      serverURL,
+      rootMessage,
+      `Dismiss reply ${Date.now()}`
+    );
 
-    try {
-      await createAndLoginTestUser(page2);
-      await openServer(page2);
-      await page2.goto(routes.space());
-      const chatPage2 = new ChatPage(page2);
-      const roomPage2 = new RoomPage(page2);
-      await chatPage2.enterRoom('general');
+    // User A: Verify bell indicator appears
+    await notificationsPage.expectBellIndicatorVisible();
 
-      const targetMsg = roomPage2.getMessage(rootMessage);
-      await targetMsg.replyInRoom();
-      await expect(page2.getByTestId('reply-indicator')).toBeVisible({
-        timeout: TIMEOUTS.UI_STANDARD
-      });
-      await roomPage2.sendMessage(`Dismiss reply ${Date.now()}`);
+    // User A: Enter the general room (should auto-dismiss the reply notification)
+    await chatPage.enterRoom('general');
 
-      // User A: Verify bell indicator appears
-      await notificationsPage.expectBellIndicatorVisible();
-
-      // User A: Enter the general room (should auto-dismiss the reply notification)
-      await chatPage.enterRoom('general');
-
-      // Bell indicator should be gone
-      await notificationsPage.expectBellIndicatorNotVisible();
-    } finally {
-      await context2.close();
-    }
+    // Bell indicator should be gone
+    await notificationsPage.expectBellIndicatorNotVisible();
   });
 });


### PR DESCRIPTION
- Extracts local notification e2e helpers for secondary user setup, mentions, thread replies, room replies, server badges, and room joins.
- Removes repeated second-browser setup, redundant legacy `/chat/-` hops, and dead server scope reads from `notifications.test.ts`.
- Corrects one misleading reply-notification test title to match the behavior it actually verifies.
- Validation: `pnpm check`, `pnpm lint`, and `pnpm exec playwright test e2e/notifications.test.ts --retries=0 --workers=1`.
