### PR TITLE
fix(e2e): wait for posted message articles

### DIFF
--- a/frontend/e2e/pages/RoomPage.ts
+++ b/frontend/e2e/pages/RoomPage.ts
@@ -156,8 +156,18 @@ export class RoomPage {
     await this.waitForInputEditable();
     await this.messageInput.fill(text);
     await this.messageInput.press('Enter');
-    await expect(this.page.getByText(text)).toBeVisible();
-    return this.getMessage(text);
+    const message = this.getMessage(text);
+    try {
+      await expect(message.locator).toBeVisible({ timeout: TIMEOUTS.UI_FAST });
+    } catch {
+      // Enter may first confirm an active autocomplete item when the message
+      // ends at a mention/emoji trigger. In that case, send with a second Enter.
+      if ((await this.messageInput.textContent())?.trim()) {
+        await this.messageInput.press('Enter');
+      }
+      await expect(message.locator).toBeVisible();
+    }
+    return message;
   }
 
   /**
@@ -168,8 +178,9 @@ export class RoomPage {
     await this.waitForInputEditable();
     await this.messageInput.fill(text);
     await this.sendButton.click();
-    await expect(this.page.getByText(text)).toBeVisible();
-    return this.getMessage(text);
+    const message = this.getMessage(text);
+    await expect(message.locator).toBeVisible();
+    return message;
   }
 
   /**


### PR DESCRIPTION
- Fix the room E2E page object so `sendMessage()` waits for a posted message article instead of matching text still present in the composer.
- Retry Enter once when autocomplete consumes the first Enter for messages ending in an active mention or emoji trigger.
- Tighten `sendMessageWithButton()` to assert against the posted message article too.

Verified with `pnpm lint`, `pnpm check`, targeted mention E2E, and shard 1/4 E2E locally.
