### PR TITLE
fix(frontend): use app modal for mention confirmation

### DIFF
--- a/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -8,6 +8,7 @@
   import LinkPreviewCard from '$lib/components/LinkPreviewCard.svelte';
   import LinkPreviewSkeleton from '$lib/components/LinkPreviewSkeleton.svelte';
   import MessagePreviewCard from '$lib/components/MessagePreviewCard.svelte';
+  import ConfirmDialog from '$lib/ui/ConfirmDialog.svelte';
   import { toast } from '$lib/ui/toast';
   import { getRoomMembers, getComposerContext } from '$lib/state/room';
   import { shouldAutoFocus } from '$lib/utils/shouldAutoFocus';
@@ -364,6 +365,21 @@
     token: string;
   };
 
+  type PreparedPost = {
+    roomId: string;
+    bodyToSend: string;
+    filesToSend: File[] | null;
+    threadRootEventId: string | null;
+    inReplyTo: string | null;
+    linkPreviewInput: ReturnType<typeof linkPreviews.buildInput>;
+    alsoSendToChannel: boolean;
+  };
+
+  type PendingMentionConfirmation = PreparedPost & MentionConfirmation;
+
+  let pendingMentionConfirmation = $state<PendingMentionConfirmation | null>(null);
+  let mentionConfirmationLoading = $state(false);
+
   function mentionConfirmation(error: unknown): MentionConfirmation | null {
     const graphQLErrors =
       error && typeof error === 'object' && 'graphQLErrors' in error
@@ -382,6 +398,97 @@
     return null;
   }
 
+  function buildPostVariables(post: PreparedPost, mentionConfirmationToken: string | null) {
+    return {
+      input: {
+        roomId: post.roomId,
+        body: post.bodyToSend || null,
+        attachments: post.filesToSend,
+        threadRootEventId: post.threadRootEventId,
+        inReplyTo: post.inReplyTo,
+        linkPreview: post.linkPreviewInput,
+        alsoSendToChannel: post.alsoSendToChannel || null,
+        mentionConfirmationToken
+      }
+    };
+  }
+
+  function sendPreparedPost(post: PreparedPost, mentionConfirmationToken: string | null) {
+    return connection().client.mutation(
+      PostMessageMutation,
+      buildPostVariables(post, mentionConfirmationToken)
+    );
+  }
+
+  function restorePreparedPost(post: PreparedPost) {
+    message = post.bodyToSend;
+    editorApi?.setContent(post.bodyToSend);
+    if (post.filesToSend) {
+      attachments.restore(attachments.filesToPreviewItems(post.filesToSend));
+    }
+  }
+
+  function handlePostFailure(error: unknown, post: PreparedPost) {
+    toast.error('Failed to send message');
+    console.error('Error posting message:', error);
+    restorePreparedPost(post);
+  }
+
+  function handlePostSuccess(
+    response: Awaited<ReturnType<typeof sendPreparedPost>>,
+    post: PreparedPost
+  ) {
+    const postedEvent = response.data?.postMessage
+      ? useFragment(RoomEventViewFragmentDoc, response.data.postMessage)
+      : null;
+
+    // Notify parent before scrolling so it can synchronously ingest the
+    // returned event and make the target row available.
+    onMessageSent?.(postedEvent);
+
+    // Scroll the enclosing pane to the user's new message. The composer
+    // reads `scrollState` from its surrounding ComposerContext, so this
+    // targets the main room's EventList in a room composer and the
+    // thread's EventList in a thread composer.
+    scrollState?.requestScrollToBottom();
+
+    // Clear reply-in-room state after sending
+    onCancelReply?.();
+
+    // Mark this room as read (we just posted, so we've seen all messages)
+    roomUnreadStore.setRoomUnread(post.roomId, false);
+
+    // Reset "also send to channel" checkbox after successful send
+    alsoSendToChannel = false;
+  }
+
+  function cancelMentionConfirmation() {
+    const pendingPost = pendingMentionConfirmation;
+    pendingMentionConfirmation = null;
+    if (pendingPost) {
+      restorePreparedPost(pendingPost);
+    }
+  }
+
+  async function confirmMentionSend() {
+    const pendingPost = pendingMentionConfirmation;
+    if (!pendingPost || mentionConfirmationLoading) return;
+
+    mentionConfirmationLoading = true;
+    try {
+      const response = await sendPreparedPost(pendingPost, pendingPost.token);
+      pendingMentionConfirmation = null;
+
+      if (response.error) {
+        handlePostFailure(response.error, pendingPost);
+      } else {
+        handlePostSuccess(response, pendingPost);
+      }
+    } finally {
+      mentionConfirmationLoading = false;
+    }
+  }
+
   async function postMessage() {
     // Require either non-empty message body or attachments.
     // hasVisibleContent rejects messages with only invisible Unicode characters.
@@ -391,7 +498,15 @@
       attachments.selectedFiles.length > 0 ? [...attachments.selectedFiles] : null;
     if (!hasBody && !filesToSend) return;
 
-    const linkPreviewInput = linkPreviews.buildInput();
+    const preparedPost: PreparedPost = {
+      roomId,
+      bodyToSend,
+      filesToSend,
+      threadRootEventId: inThread ?? null,
+      inReplyTo: inReplyTo ?? null,
+      linkPreviewInput: linkPreviews.buildInput(),
+      alsoSendToChannel
+    };
 
     // Optimistically clear the editor so the user can start typing the next
     // message immediately (matches Slack/Discord behavior).
@@ -403,75 +518,17 @@
     loading = true;
 
     try {
-      const buildInput = (mentionConfirmationToken: string | null) => ({
-        input: {
-          roomId,
-          body: bodyToSend || null,
-          attachments: filesToSend,
-          threadRootEventId: inThread ?? null,
-          inReplyTo: inReplyTo ?? null,
-          linkPreview: linkPreviewInput,
-          alsoSendToChannel: alsoSendToChannel || null,
-          mentionConfirmationToken
-        }
-      });
-
-      let response = await connection().client.mutation(PostMessageMutation, buildInput(null));
+      const response = await sendPreparedPost(preparedPost, null);
 
       if (response.error) {
         const confirmation = mentionConfirmation(response.error);
         if (confirmation !== null) {
-          const confirmed = window.confirm(
-            `This message will notify ${confirmation.recipientCount} people. Send it anyway?`
-          );
-          if (confirmed) {
-            response = await connection().client.mutation(
-              PostMessageMutation,
-              buildInput(confirmation.token)
-            );
-          } else {
-            message = bodyToSend;
-            editorApi?.setContent(bodyToSend);
-            if (filesToSend) {
-              attachments.restore(attachments.filesToPreviewItems(filesToSend));
-            }
-            return;
-          }
+          pendingMentionConfirmation = { ...preparedPost, ...confirmation };
+          return;
         }
-      }
-
-      if (response.error) {
-        toast.error('Failed to send message');
-        console.error('Error posting message:', response.error);
-        // Restore message so user can retry without retyping
-        message = bodyToSend;
-        editorApi?.setContent(bodyToSend);
-        if (filesToSend) {
-          attachments.restore(attachments.filesToPreviewItems(filesToSend));
-        }
+        handlePostFailure(response.error, preparedPost);
       } else {
-        const postedEvent = response.data?.postMessage
-          ? useFragment(RoomEventViewFragmentDoc, response.data.postMessage)
-          : null;
-
-        // Notify parent before scrolling so it can synchronously ingest the
-        // returned event and make the target row available.
-        onMessageSent?.(postedEvent);
-
-        // Scroll the enclosing pane to the user's new message. The composer
-        // reads `scrollState` from its surrounding ComposerContext, so this
-        // targets the main room's EventList in a room composer and the
-        // thread's EventList in a thread composer.
-        scrollState?.requestScrollToBottom();
-
-        // Clear reply-in-room state after sending
-        onCancelReply?.();
-
-        // Mark this room as read (we just posted, so we've seen all messages)
-        roomUnreadStore.setRoomUnread(roomId, false);
-
-        // Reset "also send to channel" checkbox after successful send
-        alsoSendToChannel = false;
+        handlePostSuccess(response, preparedPost);
       }
     } finally {
       loading = false;
@@ -847,6 +904,20 @@
     </div>
   {/if}
 </div>
+
+{#if pendingMentionConfirmation}
+  <ConfirmDialog
+    title={`Notify ${pendingMentionConfirmation.recipientCount} people?`}
+    tone="warning"
+    actionLabel="Send Anyway"
+    actionIcon="iconify uil--telegram-alt"
+    loading={mentionConfirmationLoading}
+    onconfirm={confirmMentionSend}
+    onclose={cancelMentionConfirmation}
+  >
+    This message will notify {pendingMentionConfirmation.recipientCount} people. Send it anyway?
+  </ConfirmDialog>
+{/if}
 
 <style>
   .sending {

--- a/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -1602,7 +1602,6 @@ describe('MessageComposer', () => {
     });
 
     it('retries large mention sends with the confirmation token', async () => {
-      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
       mutationMock
         .mockResolvedValueOnce({
           data: null,
@@ -1620,7 +1619,7 @@ describe('MessageComposer', () => {
         })
         .mockResolvedValueOnce({ data: mutationData, error: null });
 
-      const { container } = renderMessageComposer(
+      const { container, getByRole, getByText } = renderMessageComposer(
         { roomId: 'room_456' },
         new Map([['$$_urql', mockClient]])
       );
@@ -1629,14 +1628,99 @@ describe('MessageComposer', () => {
       await typeInEditor(editor, '@all hello');
       (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
 
+      await expect.element(getByRole('dialog', { name: 'Notify 12 people?' })).toBeInTheDocument();
+      await expect
+        .element(getByText('This message will notify 12 people. Send it anyway?'))
+        .toBeInTheDocument();
+      expect(mutationMock).toHaveBeenCalledOnce();
+
+      await userEvent.click(getByRole('button', { name: 'Send Anyway' }));
+
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledTimes(2));
-      expect(confirmSpy).toHaveBeenCalledWith(
-        'This message will notify 12 people. Send it anyway?'
-      );
       expect(mutationMock.mock.calls[0][1].input.mentionConfirmationToken).toBeNull();
       expect(mutationMock.mock.calls[1][1].input.mentionConfirmationToken).toBe(
         'jwt.confirmation.token'
       );
+    });
+
+    it('restores text and attachments when cancelling a large mention send', async () => {
+      mutationMock.mockResolvedValueOnce({
+        data: null,
+        error: {
+          graphQLErrors: [
+            {
+              extensions: {
+                code: 'MENTION_CONFIRMATION_REQUIRED',
+                recipientCount: 12,
+                mentionConfirmationToken: 'jwt.confirmation.token'
+              }
+            }
+          ]
+        }
+      });
+
+      const { container, getByRole } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = await findEditor(container);
+      const file = selectFirstAttachment(q(container, 'input[type="file"]') as HTMLInputElement);
+
+      await expect.poll(() => q(container, 'img')).toBeTruthy();
+      await typeInEditor(editor, '@all with attachment');
+      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+
+      await expect.element(getByRole('dialog', { name: 'Notify 12 people?' })).toBeInTheDocument();
+      expect(mutationMock).toHaveBeenCalledOnce();
+
+      await userEvent.click(getByRole('button', { name: 'Cancel' }));
+
+      await expect.element(editor).toHaveTextContent('@all with attachment');
+      await expect.poll(() => q(container, 'img')).toBeTruthy();
+      expect(mutationMock).toHaveBeenCalledOnce();
+      expect(mutationMock.mock.calls[0][1].input.attachments).toEqual([file]);
+    });
+
+    it('restores text and attachments after a failed large mention confirmation retry', async () => {
+      mutationMock
+        .mockResolvedValueOnce({
+          data: null,
+          error: {
+            graphQLErrors: [
+              {
+                extensions: {
+                  code: 'MENTION_CONFIRMATION_REQUIRED',
+                  recipientCount: 12,
+                  mentionConfirmationToken: 'jwt.confirmation.token'
+                }
+              }
+            ]
+          }
+        })
+        .mockResolvedValueOnce({ data: null, error: new Error('still nope') });
+
+      const { container, getByRole } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = await findEditor(container);
+      const file = selectFirstAttachment(q(container, 'input[type="file"]') as HTMLInputElement);
+
+      await expect.poll(() => q(container, 'img')).toBeTruthy();
+      await typeInEditor(editor, '@all will retry');
+      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+
+      await expect.element(getByRole('dialog', { name: 'Notify 12 people?' })).toBeInTheDocument();
+      await userEvent.click(getByRole('button', { name: 'Send Anyway' }));
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledTimes(2));
+      await expect.element(editor).toHaveTextContent('@all will retry');
+      await expect.poll(() => q(container, 'img')).toBeTruthy();
+      expect(mutationMock.mock.calls[1][1].input.mentionConfirmationToken).toBe(
+        'jwt.confirmation.token'
+      );
+      expect(mutationMock.mock.calls[1][1].input.attachments).toEqual([file]);
+      expect(getToasts().map((t) => t.message)).toContain('Failed to send message');
     });
 
     it('restores text and attachments after a failed post', async () => {


### PR DESCRIPTION
## Changes

- Replaces the large-mention browser confirmation with Chatto's in-app `ConfirmDialog`.
- Preserves the confirmation-token retry flow and restores message text plus attachments on cancel or retry failure.
- Adds component coverage for confirm, cancel, and failed retry behavior.

## Tests

- `npx @sveltejs/mcp svelte-autofixer src/lib/components/composer/MessageComposer.svelte --svelte-version 5`
- `pnpm test:unit --run --project client src/lib/components/composer/MessageComposer.svelte.spec.ts`
- `pnpm check`
