### PR TITLE
test: simplify e2e setup helpers

### DIFF
--- a/frontend/e2e/admin.test.ts
+++ b/frontend/e2e/admin.test.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from '@playwright/test';
+import { expect, type Browser, type Page } from '@playwright/test';
 import { test } from './setup';
 import { AdminPage, ChatPage } from './pages';
 import * as routes from './routes';
@@ -12,7 +12,27 @@ import {
   revokePermission,
   type TestUser
 } from './fixtures/testUser';
-import { withServerUser } from './fixtures/serverUser';
+import {
+  withServerUser,
+  type ServerUserOptions,
+  type ServerUserSession
+} from './fixtures/serverUser';
+
+type RegularAdminSession = ServerUserSession & { adminPage: AdminPage };
+
+async function withRegularAdminPage<T>(
+  browser: Browser,
+  serverURL: string,
+  run: (session: RegularAdminSession) => Promise<T>,
+  options?: ServerUserOptions
+): Promise<T> {
+  return withServerUser(
+    browser,
+    serverURL,
+    async (session) => run({ ...session, adminPage: new AdminPage(session.page) }),
+    options
+  );
+}
 
 async function createRoleViaAPI(page: Page, name: string, displayName: string): Promise<void> {
   const resp = await page.request.post('/api/graphql', {
@@ -244,154 +264,132 @@ test.describe('Admin Granular Permissions', () => {
 
   test('user with a concrete admin capability can access their admin section', async ({
     page,
-    browser
+    browser,
+    serverURL
   }) => {
     // First, as admin, grant an admin-view capability to everyone role.
     await createAndLoginAdminUser(page);
     await grantPermission(page, 'everyone', 'admin.view-users');
 
-    // Now create a regular user and try to access admin
-    const regularContext = await browser.newContext();
-    const regularPage = await regularContext.newPage();
-    const regularAdminPage = new AdminPage(regularPage);
-    await createAndLoginTestUser(regularPage);
+    await withRegularAdminPage(browser, serverURL, async ({ adminPage: regularAdminPage }) => {
+      await regularAdminPage.gotoUsers();
 
-    await regularAdminPage.gotoUsers();
-
-    // Should see the permitted section (not access denied) and the dedicated
-    // admin sidebar should only expose their allowed links.
-    await regularAdminPage.expectUsersPageVisible();
-    await regularAdminPage.expectSidebarLinkVisible('Users');
-    await regularAdminPage.expectSidebarLinkActive('Users');
+      // Should see the permitted section (not access denied) and the dedicated
+      // admin sidebar should only expose their allowed links.
+      await regularAdminPage.expectUsersPageVisible();
+      await regularAdminPage.expectSidebarLinkVisible('Users');
+      await regularAdminPage.expectSidebarLinkActive('Users');
+    });
 
     // Clean up: revoke the permission
     await revokePermission(page, 'everyone', 'admin.view-users');
-    await regularContext.close();
   });
 
   test('user with room.manage but without admin.view-users sees limited nav items', async ({
     page,
-    browser
+    browser,
+    serverURL
   }) => {
     // Grant only a non-user admin capability to everyone role.
     await createAndLoginAdminUser(page);
     await grantPermission(page, 'everyone', 'room.manage');
 
-    // Create regular user and access admin
-    const regularContext = await browser.newContext();
-    const regularPage = await regularContext.newPage();
-    const regularAdminPage = new AdminPage(regularPage);
-    await createAndLoginTestUser(regularPage);
+    await withRegularAdminPage(browser, serverURL, async ({ page: regularPage, adminPage }) => {
+      await regularPage.goto(routes.serverAdminRooms);
 
-    await regularPage.goto(routes.serverAdminRooms);
+      // Should see their concrete admin section in nav
+      await adminPage.expectSidebarLinkVisible('Rooms');
 
-    // Should see their concrete admin section in nav
-    await regularAdminPage.expectSidebarLinkVisible('Rooms');
-
-    // Should NOT see Users, System (no permissions for those)
-    await regularAdminPage.expectSidebarLinkNotVisible('Users');
-    await regularAdminPage.expectSidebarLinkNotVisible('System');
+      // Should NOT see Users, System (no permissions for those)
+      await adminPage.expectSidebarLinkNotVisible('Users');
+      await adminPage.expectSidebarLinkNotVisible('System');
+    });
 
     // Clean up
     await revokePermission(page, 'everyone', 'room.manage');
-    await regularContext.close();
   });
 
-  test('user with admin.view-users permission can see users list', async ({ page, browser }) => {
+  test('user with admin.view-users permission can see users list', async ({
+    page,
+    browser,
+    serverURL
+  }) => {
     await createAndLoginAdminUser(page);
     await grantPermission(page, 'everyone', 'admin.view-users');
 
-    // Create regular user
-    const regularContext = await browser.newContext();
-    const regularPage = await regularContext.newPage();
-    const regularAdminPage = new AdminPage(regularPage);
-    await createAndLoginTestUser(regularPage);
+    await withRegularAdminPage(browser, serverURL, async ({ adminPage: regularAdminPage }) => {
+      await regularAdminPage.gotoUsers();
 
-    await regularAdminPage.gotoUsers();
-
-    // Should see the users page with data
-    await regularAdminPage.expectUsersPageVisible();
-    await regularAdminPage.expectUsersTableHeadersVisible();
-    // Should see at least one user in the list (the user count)
-    await regularAdminPage.expectUserCountVisible();
+      // Should see the users page with data
+      await regularAdminPage.expectUsersPageVisible();
+      await regularAdminPage.expectUsersTableHeadersVisible();
+      // Should see at least one user in the list (the user count)
+      await regularAdminPage.expectUserCountVisible();
+    });
 
     // Clean up
     await revokePermission(page, 'everyone', 'admin.view-users');
-    await regularContext.close();
   });
 
   test('user without admin.view-users sees access denied on /chat/-/admin/users', async ({
     page,
-    browser
+    browser,
+    serverURL
   }) => {
     await createAndLoginAdminUser(page);
 
-    // Create regular user
-    const regularContext = await browser.newContext();
-    const regularPage = await regularContext.newPage();
-    const regularAdminPage = new AdminPage(regularPage);
-    await createAndLoginTestUser(regularPage);
+    await withRegularAdminPage(browser, serverURL, async ({ adminPage: regularAdminPage }) => {
+      await regularAdminPage.gotoUsers();
 
-    await regularAdminPage.gotoUsers();
-
-    // Should see access denied with the specific permission mentioned
-    await regularAdminPage.expectAccessDeniedForPermission('admin.view-users');
-
-    await regularContext.close();
+      // Should see access denied with the specific permission mentioned
+      await regularAdminPage.expectAccessDeniedForPermission('admin.view-users');
+    });
   });
 
-  test('non-owner sees access denied on /chat/-/admin/system', async ({ page, browser }) => {
+  test('non-owner sees access denied on /chat/-/admin/system', async ({
+    page,
+    browser,
+    serverURL
+  }) => {
     await createAndLoginAdminUser(page);
 
-    const regularContext = await browser.newContext();
-    const regularPage = await regularContext.newPage();
-    const regularAdminPage = new AdminPage(regularPage);
-    await createAndLoginTestUser(regularPage);
+    await withRegularAdminPage(browser, serverURL, async ({ adminPage: regularAdminPage }) => {
+      await regularAdminPage.gotoSystem();
 
-    await regularAdminPage.gotoSystem();
-
-    await regularAdminPage.expectAccessDeniedForPermission('admin.view-system');
-
-    await regularContext.close();
+      await regularAdminPage.expectAccessDeniedForPermission('admin.view-system');
+    });
   });
 
   test('user without admin.view-roles sees access denied on permissions', async ({
     page,
-    browser
+    browser,
+    serverURL
   }) => {
     await createAndLoginAdminUser(page);
 
-    const regularContext = await browser.newContext();
-    const regularPage = await regularContext.newPage();
-    const regularAdminPage = new AdminPage(regularPage);
-    await createAndLoginTestUser(regularPage);
+    await withRegularAdminPage(browser, serverURL, async ({ adminPage: regularAdminPage }) => {
+      await regularAdminPage.gotoRoles();
 
-    await regularAdminPage.gotoRoles();
-
-    await regularAdminPage.expectAccessDeniedForPermission('admin.view-roles');
-
-    await regularContext.close();
+      await regularAdminPage.expectAccessDeniedForPermission('admin.view-roles');
+    });
   });
 
   test('user with admin.view-system permission still cannot see owner-only system page', async ({
     page,
-    browser
+    browser,
+    serverURL
   }) => {
     await createAndLoginAdminUser(page);
     await grantPermission(page, 'everyone', 'admin.view-system');
 
-    const regularContext = await browser.newContext();
-    const regularPage = await regularContext.newPage();
-    const regularAdminPage = new AdminPage(regularPage);
-    await createAndLoginTestUser(regularPage);
+    await withRegularAdminPage(browser, serverURL, async ({ adminPage: regularAdminPage }) => {
+      await regularAdminPage.gotoSystem();
 
-    await regularAdminPage.gotoSystem();
-
-    await regularAdminPage.expectAccessDeniedForPermission('owner');
+      await regularAdminPage.expectAccessDeniedForPermission('owner');
+    });
 
     // Clean up
     await revokePermission(page, 'everyone', 'admin.view-system');
-    await regularContext.close();
   });
 
   // Note: a read-only view of the roles page (admin.view-roles without
@@ -401,40 +399,40 @@ test.describe('Admin Granular Permissions', () => {
   // sufficient to render the page. Re-add the test once the matrix grows
   // a read-only mode.
 
-  test('nav items dynamically update based on granted permissions', async ({ page, browser }) => {
+  test('nav items dynamically update based on granted permissions', async ({
+    page,
+    browser,
+    serverURL
+  }) => {
     // Start with one concrete admin capability.
     await createAndLoginAdminUser(page);
     await grantPermission(page, 'everyone', 'room.manage');
 
-    const regularContext = await browser.newContext();
-    const regularPage = await regularContext.newPage();
-    const regularAdminPage = new AdminPage(regularPage);
-    await createAndLoginTestUser(regularPage);
+    await withRegularAdminPage(browser, serverURL, async ({ page: regularPage, adminPage }) => {
+      await regularPage.goto(routes.serverAdminRooms);
 
-    await regularPage.goto(routes.serverAdminRooms);
+      // Initially should only see the room management section
+      await adminPage.expectSidebarLinkVisible('Rooms');
+      await adminPage.expectSidebarLinkNotVisible('Users');
 
-    // Initially should only see the room management section
-    await regularAdminPage.expectSidebarLinkVisible('Rooms');
-    await regularAdminPage.expectSidebarLinkNotVisible('Users');
+      // Now grant admin.view-users permission as admin
+      await grantPermission(page, 'everyone', 'admin.view-users');
 
-    // Now grant admin.view-users permission as admin
-    await grantPermission(page, 'everyone', 'admin.view-users');
+      // Reload and check nav updated
+      await regularPage.reload();
+      await adminPage.expectSidebarLinkVisible('Users');
 
-    // Reload and check nav updated
-    await regularPage.reload();
-    await regularAdminPage.expectSidebarLinkVisible('Users');
-
-    // Grant admin.view-system. System diagnostics remain owner-only for now,
-    // so this permission alone must not reveal the route.
-    await grantPermission(page, 'everyone', 'admin.view-system');
-    await regularPage.reload();
-    await regularAdminPage.expectSidebarLinkNotVisible('System');
+      // Grant admin.view-system. System diagnostics remain owner-only for now,
+      // so this permission alone must not reveal the route.
+      await grantPermission(page, 'everyone', 'admin.view-system');
+      await regularPage.reload();
+      await adminPage.expectSidebarLinkNotVisible('System');
+    });
 
     // Clean up
     await revokePermission(page, 'everyone', 'room.manage');
     await revokePermission(page, 'everyone', 'admin.view-users');
     await revokePermission(page, 'everyone', 'admin.view-system');
-    await regularContext.close();
   });
 });
 
@@ -458,33 +456,33 @@ test.describe('User Permission Management', () => {
 
   test('granting a role with admin.view-users gives user admin access', async ({
     page,
-    browser
+    browser,
+    serverURL
   }) => {
     await createAndLoginAdminUser(page);
 
-    // Create a regular user
-    const regularContext = await browser.newContext();
-    const regularPage = await regularContext.newPage();
-    const regularAdminPage = new AdminPage(regularPage);
-    const regularUser = await createAndLoginTestUser(regularPage);
+    await withRegularAdminPage(
+      browser,
+      serverURL,
+      async ({ page: regularPage, user: regularUser, adminPage: regularAdminPage }) => {
+        // Regular user should NOT have admin access initially
+        await regularAdminPage.gotoUsers();
+        await expect(regularPage.getByText('Access Denied', { exact: true })).toBeVisible();
 
-    // Regular user should NOT have admin access initially
-    await regularAdminPage.gotoUsers();
-    await expect(regularPage.getByText('Access Denied', { exact: true })).toBeVisible();
+        // Create a role with an admin-view capability and assign it to the user.
+        const roleName = generateRoleName('grant');
+        await createRoleViaAPI(page, roleName, 'Grant Admin');
+        await grantPermission(page, roleName, 'admin.view-users');
+        await assignRoleViaAPI(page, regularUser.id!, roleName);
 
-    // Create a role with an admin-view capability and assign it to the user.
-    const roleName = generateRoleName('grant');
-    await createRoleViaAPI(page, roleName, 'Grant Admin');
-    await grantPermission(page, roleName, 'admin.view-users');
-    await assignRoleViaAPI(page, regularUser.id!, roleName);
+        // Regular user should now have admin access
+        await regularPage.reload();
+        await regularAdminPage.expectUsersPageVisible();
 
-    // Regular user should now have admin access
-    await regularPage.reload();
-    await regularAdminPage.expectUsersPageVisible();
-
-    // Clean up
-    await revokeRoleViaAPI(page, regularUser.id!, roleName);
-    await regularContext.close();
+        // Clean up
+        await revokeRoleViaAPI(page, regularUser.id!, roleName);
+      }
+    );
   });
 
   // The "deny `space.list` blocks the Browse Spaces page" pair was retired
@@ -840,95 +838,101 @@ test.describe('Instance Role Permission Denials', () => {
 });
 
 test.describe('Identity Editing', () => {
-  test('admin can rename a user and reset their cooldown', async ({ page, adminPage, browser }) => {
+  test('admin can rename a user and reset their cooldown', async ({
+    page,
+    adminPage,
+    browser,
+    serverURL
+  }) => {
     await createAndLoginAdminUser(page);
 
-    const regularContext = await browser.newContext();
-    const regularPage = await regularContext.newPage();
-    const regularUser = await createAndLoginTestUser(regularPage, { loginPrefix: 'edituser' });
+    await withServerUser(
+      browser,
+      serverURL,
+      async ({ page: regularPage, user: regularUser }) => {
+        // The regular user changes their own login first to set a cooldown
+        // timestamp. We need this to verify Reset cooldown actually clears it.
+        const userChosenLogin = `userpicked${Date.now()}`;
+        const userRenameResp = await regularPage.request.post('/api/graphql', {
+          headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
+          data: {
+            query: `mutation($input: UpdateProfileInput!) { updateProfile(input: $input) { id login } }`,
+            variables: { input: { userId: regularUser.id, login: userChosenLogin } }
+          }
+        });
+        expect(userRenameResp.ok()).toBeTruthy();
 
-    // The regular user changes their own login first to set a cooldown
-    // timestamp. We need this to verify Reset cooldown actually clears it.
-    const userChosenLogin = `userpicked${Date.now()}`;
-    const userRenameResp = await regularPage.request.post('/api/graphql', {
-      headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
-      data: {
-        query: `mutation($input: UpdateProfileInput!) { updateProfile(input: $input) { id login } }`,
-        variables: { input: { userId: regularUser.id, login: userChosenLogin } }
-      }
-    });
-    expect(userRenameResp.ok()).toBeTruthy();
+        // Admin navigates to the user management page
+        await adminPage.gotoUserManagement(regularUser.id!);
+        await adminPage.expectUserManagementVisible();
 
-    // Admin navigates to the user management page
-    await adminPage.gotoUserManagement(regularUser.id!);
-    await adminPage.expectUserManagementVisible();
+        // Identity panel should be visible
+        await expect(page.getByRole('heading', { name: 'Identity' })).toBeVisible();
 
-    // Identity panel should be visible
-    await expect(page.getByRole('heading', { name: 'Identity' })).toBeVisible();
+        // The username field should reflect the user's last self-chosen login
+        const usernameInput = page.getByTestId('admin-identity-login');
+        const displayNameInput = page.getByTestId('admin-identity-display-name');
+        await expect(usernameInput).toHaveValue(userChosenLogin);
 
-    // The username field should reflect the user's last self-chosen login
-    const usernameInput = page.getByTestId('admin-identity-login');
-    const displayNameInput = page.getByTestId('admin-identity-display-name');
-    await expect(usernameInput).toHaveValue(userChosenLogin);
+        // Save is disabled while pristine
+        const saveButton = page.getByRole('button', { name: 'Save' });
+        await expect(saveButton).toBeDisabled();
 
-    // Save is disabled while pristine
-    const saveButton = page.getByRole('button', { name: 'Save' });
-    await expect(saveButton).toBeDisabled();
+        // Admin renames the user via the panel
+        const adminChosenLogin = `adminpicked${Date.now()}`;
+        const adminChosenDisplay = 'Renamed By Admin';
+        await usernameInput.fill(adminChosenLogin);
+        await displayNameInput.fill(adminChosenDisplay);
 
-    // Admin renames the user via the panel
-    const adminChosenLogin = `adminpicked${Date.now()}`;
-    const adminChosenDisplay = 'Renamed By Admin';
-    await usernameInput.fill(adminChosenLogin);
-    await displayNameInput.fill(adminChosenDisplay);
+        // Submitting via Enter inside the form should work (the panel uses a real <form>)
+        await usernameInput.press('Enter');
 
-    // Submitting via Enter inside the form should work (the panel uses a real <form>)
-    await usernameInput.press('Enter');
+        // Toast confirmation
+        await expect(page.getByText('User updated')).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
 
-    // Toast confirmation
-    await expect(page.getByText('User updated')).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+        // The User Details panel reflects the new identity (without a page reload —
+        // the mutation refetches the query).
+        const userDetailsPanel = page
+          .locator('section, div')
+          .filter({ hasText: 'User Details' })
+          .first();
+        await expect(userDetailsPanel.getByText(adminChosenLogin).first()).toBeVisible();
+        await expect(userDetailsPanel.getByText(adminChosenDisplay).first()).toBeVisible();
 
-    // The User Details panel reflects the new identity (without a page reload —
-    // the mutation refetches the query).
-    const userDetailsPanel = page
-      .locator('section, div')
-      .filter({ hasText: 'User Details' })
-      .first();
-    await expect(userDetailsPanel.getByText(adminChosenLogin).first()).toBeVisible();
-    await expect(userDetailsPanel.getByText(adminChosenDisplay).first()).toBeVisible();
+        // The cooldown is unchanged because admin edits don't advance the user's
+        // clock. The "Reset cooldown" button should still be enabled.
+        const resetCooldownButton = page.getByRole('button', { name: 'Reset cooldown' });
+        await expect(resetCooldownButton).toBeEnabled();
+        await resetCooldownButton.click();
 
-    // The cooldown is unchanged because admin edits don't advance the user's
-    // clock. The "Reset cooldown" button should still be enabled.
-    const resetCooldownButton = page.getByRole('button', { name: 'Reset cooldown' });
-    await expect(resetCooldownButton).toBeEnabled();
-    await resetCooldownButton.click();
+        await expect(page.getByText('Username change cooldown cleared')).toBeVisible({
+          timeout: TIMEOUTS.UI_STANDARD
+        });
 
-    await expect(page.getByText('Username change cooldown cleared')).toBeVisible({
-      timeout: TIMEOUTS.UI_STANDARD
-    });
+        // After clearing, the panel should show the "never changed" state and the
+        // button should be disabled (no cooldown to reset).
+        await expect(page.getByText('User has never changed their username.')).toBeVisible();
+        await expect(resetCooldownButton).toBeDisabled();
 
-    // After clearing, the panel should show the "never changed" state and the
-    // button should be disabled (no cooldown to reset).
-    await expect(page.getByText('User has never changed their username.')).toBeVisible();
-    await expect(resetCooldownButton).toBeDisabled();
-
-    // Sanity check: the user can now successfully rename themselves immediately,
-    // proving the cooldown was actually cleared on the backend.
-    const userSecondRename = `userrenamed${Date.now()}`;
-    const secondRenameResp = await regularPage.request.post('/api/graphql', {
-      headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
-      data: {
-        query: `mutation($input: UpdateProfileInput!) { updateProfile(input: $input) { id login } }`,
-        variables: { input: { userId: regularUser.id, login: userSecondRename } }
-      }
-    });
-    expect(secondRenameResp.ok()).toBeTruthy();
-    const secondRenameData = (await secondRenameResp.json()) as {
-      data?: { updateProfile?: { login?: string } };
-      errors?: unknown;
-    };
-    expect(secondRenameData.errors).toBeUndefined();
-    expect(secondRenameData.data?.updateProfile?.login).toBe(userSecondRename);
-
-    await regularContext.close();
+        // Sanity check: the user can now successfully rename themselves immediately,
+        // proving the cooldown was actually cleared on the backend.
+        const userSecondRename = `userrenamed${Date.now()}`;
+        const secondRenameResp = await regularPage.request.post('/api/graphql', {
+          headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
+          data: {
+            query: `mutation($input: UpdateProfileInput!) { updateProfile(input: $input) { id login } }`,
+            variables: { input: { userId: regularUser.id, login: userSecondRename } }
+          }
+        });
+        expect(secondRenameResp.ok()).toBeTruthy();
+        const secondRenameData = (await secondRenameResp.json()) as {
+          data?: { updateProfile?: { login?: string } };
+          errors?: unknown;
+        };
+        expect(secondRenameData.errors).toBeUndefined();
+        expect(secondRenameData.data?.updateProfile?.login).toBe(userSecondRename);
+      },
+      { userOptions: { loginPrefix: 'edituser' } }
+    );
   });
 });

--- a/frontend/e2e/fixtures/adminRequest.ts
+++ b/frontend/e2e/fixtures/adminRequest.ts
@@ -1,0 +1,44 @@
+import { expect, request, type APIRequestContext } from '@playwright/test';
+
+interface GraphQLResponse<T> {
+  data?: T;
+  errors?: unknown[];
+}
+
+export async function createBootstrapAdminRequest(baseURL: string): Promise<APIRequestContext> {
+  const adminRequest = await request.newContext({ baseURL });
+  const loginResponse = await adminRequest.post('/auth/login', {
+    data: { login: 'e2eadmin', password: 'adminpassword123' }
+  });
+  expect(loginResponse.ok()).toBeTruthy();
+  return adminRequest;
+}
+
+export async function adminGraphql<T>(
+  adminRequest: APIRequestContext,
+  query: string,
+  variables?: Record<string, unknown>
+): Promise<T> {
+  const response = await adminRequest.post('/api/graphql', {
+    headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
+    data: { query, variables }
+  });
+  expect(response.ok()).toBeTruthy();
+  const json = (await response.json()) as GraphQLResponse<T>;
+  if (json.errors) throw new Error(JSON.stringify(json.errors));
+  if (!json.data) throw new Error('GraphQL response contained no data');
+  return json.data;
+}
+
+export async function withBootstrapAdminRequest<T>(
+  baseURL: string,
+  run: (adminRequest: APIRequestContext) => Promise<T>
+): Promise<T> {
+  const adminRequest = await createBootstrapAdminRequest(baseURL);
+
+  try {
+    return await run(adminRequest);
+  } finally {
+    await adminRequest.dispose();
+  }
+}

--- a/frontend/e2e/fixtures/serverUser.ts
+++ b/frontend/e2e/fixtures/serverUser.ts
@@ -1,7 +1,14 @@
 import { expect, type Browser, type BrowserContextOptions, type Page } from '@playwright/test';
 import { ChatPage, RoomPage } from '../pages';
 import { TIMEOUTS } from '../constants';
-import { createAndLoginTestUser, loginTestUser, openServer, type TestUser } from './testUser';
+import { withBootstrapAdminRequest } from './adminRequest';
+import {
+  createAndLoginTestUser,
+  loginTestUser,
+  openServer,
+  type CreateTestUserOptions,
+  type TestUser
+} from './testUser';
 
 export interface ServerUserSession {
   page: Page;
@@ -10,17 +17,37 @@ export interface ServerUserSession {
   roomPage: RoomPage;
 }
 
+export interface ServerUserOptions extends BrowserContextOptions {
+  userOptions?: CreateTestUserOptions;
+}
+
+export async function loginAndEnterRoom(
+  page: Page,
+  roomName = 'general',
+  userOptions?: CreateTestUserOptions
+): Promise<ServerUserSession> {
+  const user = await createAndLoginTestUser(page, userOptions);
+  const chatPage = new ChatPage(page);
+  const roomPage = new RoomPage(page);
+
+  await chatPage.goto();
+  await chatPage.enterRoom(roomName);
+
+  return { page, user, chatPage, roomPage };
+}
+
 export async function withServerUser<T>(
   browser: Browser,
   serverURL: string,
   run: (session: ServerUserSession) => Promise<T>,
-  contextOptions: BrowserContextOptions = {}
+  options: ServerUserOptions = {}
 ): Promise<T> {
+  const { userOptions, ...contextOptions } = options;
   const context = await browser.newContext({ ...contextOptions, baseURL: serverURL });
   const page = await context.newPage();
 
   try {
-    const user = await createAndLoginTestUser(page);
+    const user = await createAndLoginTestUser(page, userOptions);
     await openServer(page);
 
     return await run({
@@ -58,6 +85,8 @@ export async function withLoggedInServerWindow<T>(
     await context.close();
   }
 }
+
+export { withBootstrapAdminRequest } from './adminRequest';
 
 export async function postMentionFromServerUser(
   browser: Browser,

--- a/frontend/e2e/pages/ChatPage.ts
+++ b/frontend/e2e/pages/ChatPage.ts
@@ -1,16 +1,9 @@
-import { expect, request, type APIRequestContext, type Locator, type Page } from '@playwright/test';
+import { expect, type Locator, type Page } from '@playwright/test';
 import * as routes from '../routes';
+import { adminGraphql, createBootstrapAdminRequest } from '../fixtures/adminRequest';
 import { graphqlQuery } from '../fixtures/graphqlHelpers';
 import { loginAsAdmin, logoutCurrentUser } from '../fixtures/testUser';
 import { RoomPage } from './RoomPage';
-
-const E2E_ADMIN_LOGIN = 'e2eadmin';
-const E2E_ADMIN_PASSWORD = 'adminpassword123';
-
-interface GraphQLResponse<T> {
-  data?: T;
-  errors?: unknown[];
-}
 
 /**
  * Page object for the main chat interface.
@@ -18,35 +11,6 @@ interface GraphQLResponse<T> {
  */
 export class ChatPage {
   constructor(readonly page: Page) {}
-
-  private async createAdminRequestContext(): Promise<APIRequestContext> {
-    const baseURL = new URL(this.page.url()).origin;
-    const adminContext = await request.newContext({ baseURL });
-    const loginResponse = await adminContext.post('/auth/login', {
-      data: {
-        login: E2E_ADMIN_LOGIN,
-        password: E2E_ADMIN_PASSWORD
-      }
-    });
-    expect(loginResponse.ok()).toBeTruthy();
-    return adminContext;
-  }
-
-  private async adminGraphql<T>(
-    adminContext: APIRequestContext,
-    query: string,
-    variables?: Record<string, unknown>
-  ): Promise<T> {
-    const response = await adminContext.post('/api/graphql', {
-      headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
-      data: { query, variables }
-    });
-    expect(response.ok()).toBeTruthy();
-    const json = (await response.json()) as GraphQLResponse<T>;
-    if (json.errors) throw new Error(JSON.stringify(json.errors));
-    if (!json.data) throw new Error('GraphQL response contained no data');
-    return json.data;
-  }
 
   /** The room list container in the sidebar */
   get roomList(): Locator {
@@ -188,10 +152,10 @@ export class ChatPage {
    */
   async createRoom(name?: string, description?: string): Promise<string> {
     const roomName = name ?? `test-room-${Date.now()}`;
-    const adminContext = await this.createAdminRequestContext();
+    const adminContext = await createBootstrapAdminRequest(new URL(this.page.url()).origin);
     let roomId: string;
     try {
-      const groupData = await this.adminGraphql<{ server: { roomGroups: { id: string }[] } }>(
+      const groupData = await adminGraphql<{ server: { roomGroups: { id: string }[] } }>(
         adminContext,
         `query { server { roomGroups { id } } }`
       );
@@ -200,7 +164,7 @@ export class ChatPage {
         throw new Error('No room group available for e2e room creation');
       }
 
-      const createData = await this.adminGraphql<{ createRoom: { id: string; name: string } }>(
+      const createData = await adminGraphql<{ createRoom: { id: string; name: string } }>(
         adminContext,
         `mutation($input: CreateRoomInput!) { createRoom(input: $input) { id name } }`,
         { input: { name: roomName, description: description || undefined, groupId } }

--- a/frontend/e2e/room-files.test.ts
+++ b/frontend/e2e/room-files.test.ts
@@ -1,7 +1,8 @@
 import { expect, type Page } from '@playwright/test';
 import { TIMEOUTS } from './constants';
 import { test } from './setup';
-import { createAndLoginTestUser } from './fixtures/testUser';
+import { postMessageViaAPI } from './fixtures/graphqlHelpers';
+import { loginAndEnterRoom } from './fixtures/serverUser';
 
 function roomIdFromUrl(page: Page): string {
   const match = page.url().match(/\/chat\/-\/([^/]+)/);
@@ -11,26 +12,13 @@ function roomIdFromUrl(page: Page): string {
 
 async function postFillerMessages(page: Page, roomId: string, prefix: string, count: number) {
   for (let index = 0; index < count; index++) {
-    const response = await page.request.post('/api/graphql', {
-      headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
-      data: {
-        query: `mutation($input: PostMessageInput!) { postMessage(input: $input) { id } }`,
-        variables: { input: { roomId, body: `${prefix} ${index}` } }
-      }
-    });
-    expect(response.ok()).toBe(true);
+    await postMessageViaAPI(page, roomId, `${prefix} ${index}`);
   }
 }
 
-test('room Files sidebar jumps to root files and opens thread reply files', async ({
-  page,
-  chatPage,
-  roomPage
-}) => {
+test('room Files sidebar jumps to root files and opens thread reply files', async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 820 });
-  await createAndLoginTestUser(page);
-  await chatPage.goto();
-  await chatPage.enterRoom('general');
+  const { roomPage } = await loginAndEnterRoom(page);
 
   const roomId = roomIdFromUrl(page);
   const stamp = Date.now();

--- a/frontend/e2e/room-layout.test.ts
+++ b/frontend/e2e/room-layout.test.ts
@@ -1,10 +1,6 @@
 import { expect, type Page } from '@playwright/test';
 import { test } from './setup';
-import {
-  createAndLoginTestUser,
-  openServer,
-  loginAsAdminAndUsePrimaryServer
-} from './fixtures/testUser';
+import { createAndLoginTestUser, loginAsAdminAndUsePrimaryServer } from './fixtures/testUser';
 import { withServerUser } from './fixtures/serverUser';
 import { ServerAdminPage } from './pages';
 import { TIMEOUTS } from './constants';
@@ -974,55 +970,52 @@ test.describe('Room Layout', () => {
 
       // User B shows up empty-handed — no auto-join, no rooms in their
       // sidebar yet.
-      const context2 = await browser!.newContext({ baseURL: serverURL });
-      const page2 = await context2.newPage();
-
-      try {
-        await createAndLoginTestUser(page2, { skipDefaultRooms: true });
-        await openServer(page2);
-
-        // Go to the server Overview (which hosts the room directory).
-        await page2.goto(routes.browseRooms);
-        await expect(page2.getByRole('heading', { name: 'Overview' })).toBeVisible({
-          timeout: TIMEOUTS.UI_STANDARD
-        });
-
-        // Click the group's "Join all" button.
-        const joinAll = page2.getByRole('button', { name: 'Join all' }).first();
-        await expect(joinAll).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
-        await joinAll.click();
-        // Move the cursor off the group card so no row stays in :hover
-        // (which would swap a freshly-joined row's button label from
-        // "Joined" to "Leave" and break the regex below).
-        await page2.mouse.move(0, 0);
-
-        // After the bulk join finishes, the rows for all three rooms
-        // should render the "Joined" pill in the directory. The
-        // button's accessible name resolves to its visible text
-        // ("Joined" when off-hover, "Leave" on hover); we matched the
-        // hover away above so the off-hover label is stable.
-        for (const name of ['alpha', 'bravo', 'charlie']) {
-          const row = page2.locator('li', { hasText: `# ${name}` });
-          await expect(row.getByRole('button', { name: 'Joined' })).toBeVisible({
-            timeout: TIMEOUTS.REALTIME_EVENT
+      await withServerUser(
+        browser!,
+        serverURL,
+        async ({ page: page2 }) => {
+          // Go to the server Overview (which hosts the room directory).
+          await page2.goto(routes.browseRooms);
+          await expect(page2.getByRole('heading', { name: 'Overview' })).toBeVisible({
+            timeout: TIMEOUTS.UI_STANDARD
           });
-        }
 
-        // And the rooms now appear in the sidebar (alongside the
-        // bootstrap rooms, which "Join all" also joined since they
-        // share the group). The seed "Lobby" group has 5 rooms total:
-        // announcements, general, alpha, bravo, charlie.
-        await navigateToSpace(page2);
-        await expect(async () => {
-          const roomNames = await waitForSidebarRooms(page2, 5);
-          expect(roomNames).toEqual(expect.arrayContaining(['alpha', 'bravo', 'charlie']));
-        }).toPass({
-          timeout: TIMEOUTS.REALTIME_EVENT,
-          intervals: [500, 1000, 2000]
-        });
-      } finally {
-        await context2.close();
-      }
+          // Click the group's "Join all" button.
+          const joinAll = page2.getByRole('button', { name: 'Join all' }).first();
+          await expect(joinAll).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+          await joinAll.click();
+          // Move the cursor off the group card so no row stays in :hover
+          // (which would swap a freshly-joined row's button label from
+          // "Joined" to "Leave" and break the regex below).
+          await page2.mouse.move(0, 0);
+
+          // After the bulk join finishes, the rows for all three rooms
+          // should render the "Joined" pill in the directory. The
+          // button's accessible name resolves to its visible text
+          // ("Joined" when off-hover, "Leave" on hover); we matched the
+          // hover away above so the off-hover label is stable.
+          for (const name of ['alpha', 'bravo', 'charlie']) {
+            const row = page2.locator('li', { hasText: `# ${name}` });
+            await expect(row.getByRole('button', { name: 'Joined' })).toBeVisible({
+              timeout: TIMEOUTS.REALTIME_EVENT
+            });
+          }
+
+          // And the rooms now appear in the sidebar (alongside the
+          // bootstrap rooms, which "Join all" also joined since they
+          // share the group). The seed "Lobby" group has 5 rooms total:
+          // announcements, general, alpha, bravo, charlie.
+          await navigateToSpace(page2);
+          await expect(async () => {
+            const roomNames = await waitForSidebarRooms(page2, 5);
+            expect(roomNames).toEqual(expect.arrayContaining(['alpha', 'bravo', 'charlie']));
+          }).toPass({
+            timeout: TIMEOUTS.REALTIME_EVENT,
+            intervals: [500, 1000, 2000]
+          });
+        },
+        { userOptions: { skipDefaultRooms: true } }
+      );
     });
   });
 });

--- a/frontend/e2e/server-flows.test.ts
+++ b/frontend/e2e/server-flows.test.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test';
+import type { Browser, BrowserContext, BrowserContextOptions, Page } from '@playwright/test';
 import { test, expect } from './setup';
 import { createAndLoginTestUser } from './fixtures/testUser';
 import { withServerUser } from './fixtures/serverUser';
@@ -8,30 +8,43 @@ import { DMPage } from './pages/DMPage';
 import * as routes from './routes';
 import { TIMEOUTS } from './constants';
 
+interface FreshPageSession {
+  context: BrowserContext;
+  page: Page;
+}
+
+async function withFreshPage<T>(
+  browser: Browser,
+  run: (session: FreshPageSession) => Promise<T>,
+  contextOptions: BrowserContextOptions = {}
+): Promise<T> {
+  const context = await browser.newContext(contextOptions);
+  const page = await context.newPage();
+
+  try {
+    return await run({ context, page });
+  } finally {
+    await context.close();
+  }
+}
+
 test.describe('Landing Page', () => {
   test('unauthenticated user is redirected to /login', async ({ browser }) => {
-    // Fresh context — no localStorage, no cookies
-    const context = await browser.newContext();
-    const page = await context.newPage();
-
-    await page.goto('/');
-    await page.waitForURL(routes.login);
-
-    await context.close();
+    await withFreshPage(browser, async ({ page }) => {
+      await page.goto('/');
+      await page.waitForURL(routes.login);
+    });
   });
 
   test('unauthenticated user does not see sidebar nav icons', async ({ browser }) => {
-    const context = await browser.newContext();
-    const page = await context.newPage();
+    await withFreshPage(browser, async ({ page }) => {
+      await page.goto(routes.login);
 
-    await page.goto(routes.login);
-
-    // Sidebar nav icons for DMs, Browse Spaces, and Create Space should not be present
-    await expect(page.getByTestId('dm-icon')).not.toBeVisible();
-    await expect(page.getByRole('link', { name: 'Explore Spaces' })).not.toBeVisible();
-    await expect(page.getByRole('link', { name: 'Create Space' })).not.toBeVisible();
-
-    await context.close();
+      // Sidebar nav icons for DMs, Browse Spaces, and Create Space should not be present
+      await expect(page.getByTestId('dm-icon')).not.toBeVisible();
+      await expect(page.getByRole('link', { name: 'Explore Spaces' })).not.toBeVisible();
+      await expect(page.getByRole('link', { name: 'Create Space' })).not.toBeVisible();
+    });
   });
 
   test('fresh browser context accepts a valid session cookie without a CSRF cookie', async ({
@@ -45,35 +58,35 @@ test.describe('Landing Page', () => {
     );
     expect(sessionCookie).toBeDefined();
 
-    const context = await browser.newContext({ baseURL: serverURL });
-    await context.addCookies([sessionCookie!]);
-    const freshPage = await context.newPage();
+    await withFreshPage(
+      browser,
+      async ({ context, page: freshPage }) => {
+        await context.addCookies([sessionCookie!]);
 
-    try {
-      const rejectedResponse = await freshPage.request.post('/api/graphql', {
-        headers: { 'Content-Type': 'application/json' },
-        data: {
-          query: `query { viewer { user { id } } }`
-        }
-      });
-      expect(rejectedResponse.status()).toBe(403);
+        const rejectedResponse = await freshPage.request.post('/api/graphql', {
+          headers: { 'Content-Type': 'application/json' },
+          data: {
+            query: `query { viewer { user { id } } }`
+          }
+        });
+        expect(rejectedResponse.status()).toBe(403);
 
-      const acceptedResponse = await freshPage.request.post('/api/graphql', {
-        headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
-        data: {
-          query: `query { viewer { user { id } } }`
-        }
-      });
-      expect(acceptedResponse.ok()).toBe(true);
-      const acceptedBody = await acceptedResponse.json();
-      expect(acceptedBody.data.viewer.user.id).toBeTruthy();
+        const acceptedResponse = await freshPage.request.post('/api/graphql', {
+          headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
+          data: {
+            query: `query { viewer { user { id } } }`
+          }
+        });
+        expect(acceptedResponse.ok()).toBe(true);
+        const acceptedBody = await acceptedResponse.json();
+        expect(acceptedBody.data.viewer.user.id).toBeTruthy();
 
-      await freshPage.goto(routes.settings);
-      await expect(freshPage.getByRole('heading', { name: 'Profile' })).toBeVisible();
-      await expect(freshPage).not.toHaveURL(routes.login);
-    } finally {
-      await context.close();
-    }
+        await freshPage.goto(routes.settings);
+        await expect(freshPage.getByRole('heading', { name: 'Profile' })).toBeVisible();
+        await expect(freshPage).not.toHaveURL(routes.login);
+      },
+      { baseURL: serverURL }
+    );
   });
 
   test('authenticated user with instances is redirected into the server', async ({ page }) => {
@@ -383,13 +396,10 @@ test.describe('Sign Out', () => {
 
 test.describe('/chat backward compatibility', () => {
   test('/chat redirects to / for unauthenticated users', async ({ browser }) => {
-    const context = await browser.newContext();
-    const page = await context.newPage();
-
-    await page.goto('/chat');
-    await page.waitForURL('/');
-
-    await context.close();
+    await withFreshPage(browser, async ({ page }) => {
+      await page.goto('/chat');
+      await page.waitForURL('/');
+    });
   });
 
   test('/chat redirects authenticated users to /', async ({ page }) => {

--- a/frontend/e2e/thread-reply-echo.test.ts
+++ b/frontend/e2e/thread-reply-echo.test.ts
@@ -1,6 +1,6 @@
 import { expect, type Page } from '@playwright/test';
 import { createAndLoginTestUser } from './fixtures/testUser';
-import { withServerUser } from './fixtures/serverUser';
+import { withBootstrapAdminRequest, withServerUser } from './fixtures/serverUser';
 import { waitForRoomReady } from './fixtures/realtimeSync';
 import { waitForSpaceUnread, getRoomIdByName, waitForRoomRead } from './fixtures/graphqlHelpers';
 import { test } from './setup';
@@ -885,15 +885,9 @@ test.describe('Thread Reply Echo ("Also send to channel")', () => {
       // ADR-031: message.echo is a channel-room permission, so the deny must
       // be scoped to the room's set (server-scope grants don't cascade into
       // channel rooms anymore). "general" lives in the seed "Lobby" group.
-      const adminContext = await page.context().browser()!.newContext();
-      const adminPage = await adminContext.newPage();
-      try {
-        await adminPage.request.post('/auth/login', {
-          data: { login: 'e2eadmin', password: 'adminpassword123' }
-        });
-
+      await withBootstrapAdminRequest(serverURL, async (adminRequest) => {
         // Find the seed set's ID.
-        const layoutResp = await adminPage.request.post('/api/graphql', {
+        const layoutResp = await adminRequest.post('/api/graphql', {
           headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
           data: { query: `query { server { roomGroups { id } } }` }
         });
@@ -901,7 +895,7 @@ test.describe('Thread Reply Echo ("Also send to channel")', () => {
         const layoutJson = await layoutResp.json();
         const seedSetId = layoutJson.data.server.roomGroups[0].id as string;
 
-        const resp = await adminPage.request.post('/api/graphql', {
+        const resp = await adminRequest.post('/api/graphql', {
           headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
           data: {
             query: `mutation($input: GroupPermissionInput!) { denyGroupPermission(input: $input) }`,
@@ -913,9 +907,7 @@ test.describe('Thread Reply Echo ("Also send to channel")', () => {
         expect(resp.ok()).toBeTruthy();
         const respJson = await resp.json();
         expect(respJson.errors).toBeFalsy();
-      } finally {
-        await adminContext.close();
-      }
+      });
     });
 
     await withServerUser(

--- a/frontend/e2e/unread-indicators.test.ts
+++ b/frontend/e2e/unread-indicators.test.ts
@@ -5,7 +5,11 @@ import { waitForRoomReady } from './fixtures/realtimeSync';
 import { test } from './setup';
 import { TIMEOUTS, POLLING_INTERVALS } from './constants';
 import * as routes from './routes';
-import { withLoggedInServerWindow, withServerUser } from './fixtures/serverUser';
+import {
+  withBootstrapAdminRequest,
+  withLoggedInServerWindow,
+  withServerUser
+} from './fixtures/serverUser';
 
 test.describe('Multi-Tab Unread Sync', () => {
   test('entering room clears unread in other tabs via RoomMarkedAsReadEvent', async ({
@@ -824,24 +828,17 @@ test.describe('Unread dot stability after loadRooms refresh', () => {
 
         // Rename the general room → triggers RoomUpdatedEvent → loadRooms() in
         // User B. Issue #330: regular members can't manage rooms on the
-        // bootstrap server, so do the rename as e2eadmin in a side context (so
-        // user A's page session stays intact).
-        const adminCtx = await browser!.newContext({ baseURL: serverURL });
-        try {
-          const adminPage = await adminCtx.newPage();
-          await adminPage.request.post('/auth/login', {
-            data: { login: 'e2eadmin', password: 'adminpassword123' }
-          });
-          await adminPage.request.post('/api/graphql', {
+        // bootstrap server, so do the rename as e2eadmin through a side request
+        // context that leaves user A's page session intact.
+        await withBootstrapAdminRequest(serverURL, async (adminRequest) => {
+          await adminRequest.post('/api/graphql', {
             headers: { 'Content-Type': 'application/json', 'X-REQUEST-TYPE': 'GraphQL' },
             data: {
               query: `mutation($input: UpdateRoomInput!) { updateRoom(input: $input) { id name } }`,
               variables: { input: { roomId: generalRoomId, name: 'general-renamed' } }
             }
           });
-        } finally {
-          await adminCtx.close();
-        }
+        });
 
         // Wait for the rename to be visible in User B's room list
         const renamedLink = chatPage2.roomList.locator('a', { hasText: '# general-renamed' });


### PR DESCRIPTION
- Add shared bootstrap-admin request helpers and route ChatPage/server-user setup through them.
- Extend server-user helpers for primary-page room setup and user creation options.
- Replace remaining hand-rolled e2e browser contexts in admin, room layout, room files, unread, thread echo, and server flow tests.

Validation:
- `mise x -- pnpm check`
- `mise x -- pnpm lint`
- Focused Playwright runs for admin, server flows/messages, room layout/files, unread, and thread echo suites.
