### PR TITLE
feat: group room files by date

### DIFF
--- a/docs/fdr/FDR-008-file-attachments-and-video.md
+++ b/docs/fdr/FDR-008-file-attachments-and-video.md
@@ -1,7 +1,7 @@
 # FDR-008: File Attachments & Video Processing
 
 **Status:** Active
-**Last reviewed:** 2026-06-11
+**Last reviewed:** 2026-06-17
 
 ## Overview
 
@@ -20,7 +20,7 @@ Users can attach files to messages — images, videos, documents — via drag-an
 - Resized images can be cached as WebP with an auto-expiring cache.
 - In Service Worker-controlled browser sessions, stable asset URLs are rendered as same-origin virtual URLs and proxied to the owning server with the user's registered server credentials. Successful full responses are cached privately in the browser; media `Range` requests bypass that cache.
 - Active document attachment types such as HTML, XHTML, SVG, and XML can still be uploaded and viewed inline, but original-file responses are delivered in a browser sandbox so uploaded scripts do not run as trusted Chatto application code.
-- The room sidebar Files panel lists current accessible attachments from both root messages and thread replies. Rows show a thumbnail or file-type icon, filename, and upload time; selecting a root-message attachment jumps the room timeline to that message, while selecting a thread-reply attachment opens the thread pane and highlights the reply.
+- The room sidebar Files panel lists current accessible attachments from both root messages and thread replies, grouped by date as Today, Yesterday, This week, This month, then older calendar months. Rows show a thumbnail or file-type icon, filename, and upload time; selecting a root-message attachment jumps the room timeline to that message, while selecting a thread-reply attachment opens the thread pane and highlights the reply.
 
 ## Design Decisions
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -17,7 +17,7 @@ See [`.claude/skills/fdr/SKILL.md`](../../.claude/skills/fdr/SKILL.md) for the F
 | [FDR-005](FDR-005-reactions.md) | Reactions | Active | 2026-05-19 |
 | [FDR-006](FDR-006-mentions.md) | @Mentions | Active | 2026-06-15 |
 | [FDR-007](FDR-007-direct-messages.md) | Direct Messages | Active | 2026-05-31 |
-| [FDR-008](FDR-008-file-attachments-and-video.md) | File Attachments & Video Processing | Active | 2026-06-10 |
+| [FDR-008](FDR-008-file-attachments-and-video.md) | File Attachments & Video Processing | Active | 2026-06-17 |
 | [FDR-009](FDR-009-link-previews.md) | Link Previews | Active | 2026-06-06 |
 | [FDR-010](FDR-010-typing-indicators.md) | Typing Indicators | Active | 2026-05-19 |
 | [FDR-011](FDR-011-user-presence.md) | User Presence | Active | 2026-05-19 |

--- a/frontend/src/lib/utils/formatTime.spec.ts
+++ b/frontend/src/lib/utils/formatTime.spec.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
+  fileDateGroup,
+  firstDayOfWeekForLocale,
   formatMessageTime,
   formatDate,
   formatDateTime,
+  formatMonthYear,
   formatDayLabel,
   isSameDay
 } from './formatTime';
@@ -61,6 +64,13 @@ describe('formatDateTime', () => {
   });
 });
 
+describe('formatMonthYear', () => {
+  it('formats the month and year in the user timezone', () => {
+    const la = settings('America/Los_Angeles', false);
+    expect(formatMonthYear('2026-06-01T01:00:00Z', la)).toMatch(/May\s*2026/);
+  });
+});
+
 describe('isSameDay', () => {
   it('returns true for same UTC day', () => {
     expect(
@@ -114,6 +124,108 @@ describe('formatDayLabel', () => {
     const out = formatDayLabel('2024-03-10T12:00:00Z', utc12);
     expect(out).toMatch(/March/);
     expect(out).toMatch(/2024/);
+  });
+});
+
+describe('firstDayOfWeekForLocale', () => {
+  it('uses locale week information when available', () => {
+    expect(firstDayOfWeekForLocale('en-US')).toBe(0);
+    expect(firstDayOfWeekForLocale('de-DE')).toBe(1);
+  });
+
+  it('falls back to Monday for invalid locale input', () => {
+    expect(firstDayOfWeekForLocale('invalid_locale')).toBe(1);
+  });
+
+  it('uses the browser locale when no explicit locale is passed', () => {
+    vi.stubGlobal('navigator', { languages: ['en-US'], language: 'en-US' });
+
+    try {
+      expect(firstDayOfWeekForLocale()).toBe(0);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
+describe('fileDateGroup', () => {
+  const now = new Date('2026-06-17T12:00:00Z');
+
+  it('groups files from today', () => {
+    expect(fileDateGroup('2026-06-17T08:00:00Z', utc12, now, 'de-DE')).toEqual({
+      key: 'today',
+      label: 'Today'
+    });
+  });
+
+  it('groups files from yesterday', () => {
+    expect(fileDateGroup('2026-06-16T08:00:00Z', utc12, now, 'de-DE')).toEqual({
+      key: 'yesterday',
+      label: 'Yesterday'
+    });
+  });
+
+  it('groups earlier files in the current locale week', () => {
+    expect(fileDateGroup('2026-06-15T08:00:00Z', utc12, now, 'de-DE')).toEqual({
+      key: 'this-week',
+      label: 'This week'
+    });
+  });
+
+  it('uses the locale week start for this-week grouping', () => {
+    expect(fileDateGroup('2026-06-14T08:00:00Z', utc12, now, 'en-US')).toEqual({
+      key: 'this-week',
+      label: 'This week'
+    });
+
+    expect(fileDateGroup('2026-06-14T08:00:00Z', utc12, now, 'de-DE')).toEqual({
+      key: 'this-month',
+      label: 'This month'
+    });
+  });
+
+  it('groups files from earlier in the current month', () => {
+    expect(fileDateGroup('2026-06-10T08:00:00Z', utc12, now, 'de-DE')).toEqual({
+      key: 'this-month',
+      label: 'This month'
+    });
+  });
+
+  it('lets this week take precedence across a month boundary', () => {
+    expect(
+      fileDateGroup(
+        '2026-05-31T08:00:00Z',
+        utc12,
+        new Date('2026-06-03T12:00:00Z'),
+        'en-US'
+      )
+    ).toEqual({
+      key: 'this-week',
+      label: 'This week'
+    });
+  });
+
+  it('groups older files by calendar month and year', () => {
+    expect(fileDateGroup('2026-05-21T08:00:00Z', utc12, now, 'de-DE')).toEqual({
+      key: 'month:2026-05',
+      label: 'May 2026'
+    });
+  });
+
+  it('uses the user timezone for calendar-day boundaries', () => {
+    const berlin = settings('Europe/Berlin', false);
+
+    expect(
+      fileDateGroup(
+        '2026-06-16T23:30:00Z',
+        berlin,
+        new Date('2026-06-17T00:30:00Z'),
+        'de-DE'
+      )
+    ).toEqual({
+      key: 'today',
+      label: 'Today'
+    });
   });
 });
 

--- a/frontend/src/lib/utils/formatTime.ts
+++ b/frontend/src/lib/utils/formatTime.ts
@@ -11,6 +11,8 @@
 
 import type { UserSettingsState } from '$lib/state/userSettings.svelte';
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
 function toDate(date: Date | string): Date {
   return typeof date === 'string' ? new Date(date) : date;
 }
@@ -29,6 +31,79 @@ function getFormatter(
     formatterCache.set(key, fmt);
   }
   return fmt;
+}
+
+type DateParts = {
+  year: number;
+  month: number;
+  day: number;
+};
+
+type WeekInfo = {
+  firstDay?: number;
+};
+
+type LocaleWithWeekInfo = {
+  weekInfo?: WeekInfo;
+  getWeekInfo?: () => WeekInfo;
+};
+
+export type FileDateGroup = {
+  key: string;
+  label: string;
+};
+
+function dateParts(date: Date, settings: UserSettingsState): DateParts {
+  const fmt = getFormatter('en-US', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    timeZone: settings.effectiveTimezone
+  });
+  const parts = fmt.formatToParts(date);
+  const value = (type: string) => Number(parts.find((part) => part.type === type)?.value ?? 0);
+  return {
+    year: value('year'),
+    month: value('month'),
+    day: value('day')
+  };
+}
+
+function daySerial(parts: DateParts): number {
+  return Math.floor(Date.UTC(parts.year, parts.month - 1, parts.day) / DAY_MS);
+}
+
+function weekday(parts: DateParts): number {
+  return new Date(Date.UTC(parts.year, parts.month - 1, parts.day)).getUTCDay();
+}
+
+function normalizeFirstDay(firstDay: number | undefined): number | null {
+  if (typeof firstDay !== 'number' || !Number.isInteger(firstDay)) return null;
+  if (firstDay === 7) return 0;
+  if (firstDay >= 1 && firstDay <= 6) return firstDay;
+  if (firstDay === 0) return 0;
+  return null;
+}
+
+export function firstDayOfWeekForLocale(locale?: string): number {
+  const fallback = 1;
+  const localeName =
+    locale ?? globalThis.navigator?.languages?.[0] ?? globalThis.navigator?.language;
+  if (!localeName || typeof Intl.Locale !== 'function') return fallback;
+
+  try {
+    const intlLocale = new Intl.Locale(localeName) as LocaleWithWeekInfo;
+    const info = intlLocale.weekInfo ?? intlLocale.getWeekInfo?.();
+    return normalizeFirstDay(info?.firstDay) ?? fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function startOfWeekSerial(parts: DateParts, firstDay: number): number {
+  const currentWeekday = weekday(parts);
+  const offset = (currentWeekday - firstDay + 7) % 7;
+  return daySerial(parts) - offset;
 }
 
 /**
@@ -115,4 +190,42 @@ export function formatDayLabel(date: Date | string, settings: UserSettingsState)
     timeZone: tz
   });
   return labelFmt.format(d);
+}
+
+export function formatMonthYear(date: Date | string, settings: UserSettingsState): string {
+  const fmt = getFormatter(undefined, {
+    month: 'long',
+    year: 'numeric',
+    timeZone: settings.effectiveTimezone
+  });
+  return fmt.format(toDate(date));
+}
+
+export function fileDateGroup(
+  date: Date | string,
+  settings: UserSettingsState,
+  now: Date = new Date(),
+  locale?: string
+): FileDateGroup {
+  const d = toDate(date);
+  const itemParts = dateParts(d, settings);
+  const nowParts = dateParts(now, settings);
+  const daysAgo = daySerial(nowParts) - daySerial(itemParts);
+
+  if (daysAgo === 0) return { key: 'today', label: 'Today' };
+  if (daysAgo === 1) return { key: 'yesterday', label: 'Yesterday' };
+
+  const firstDay = firstDayOfWeekForLocale(locale);
+  if (startOfWeekSerial(itemParts, firstDay) === startOfWeekSerial(nowParts, firstDay)) {
+    return { key: 'this-week', label: 'This week' };
+  }
+
+  if (itemParts.year === nowParts.year && itemParts.month === nowParts.month) {
+    return { key: 'this-month', label: 'This month' };
+  }
+
+  return {
+    key: `month:${itemParts.year}-${String(itemParts.month).padStart(2, '0')}`,
+    label: formatMonthYear(d, settings)
+  };
 }

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomFilesPanel.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomFilesPanel.svelte
@@ -19,10 +19,12 @@ Room-scoped file list for the room sidebar.
   let {
     store,
     serverId,
+    fileGroupingNow,
     onOpenFile
   }: {
     store: RoomFilesStore;
     serverId: string;
+    fileGroupingNow?: Date;
     onOpenFile?: (messageEventId: string, threadRootEventId: string | null) => void;
   } = $props();
 
@@ -37,7 +39,9 @@ Room-scoped file list for the room sidebar.
     const groups: RoomFileGroup[] = [];
 
     for (const item of items) {
-      const group = fileDateGroup(item.createdAt, userSettings);
+      const group = fileGroupingNow
+        ? fileDateGroup(item.createdAt, userSettings, fileGroupingNow)
+        : fileDateGroup(item.createdAt, userSettings);
       let existing = groups.find((candidate) => candidate.key === group.key);
       if (!existing) {
         existing = { ...group, items: [] };

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomFilesPanel.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomFilesPanel.svelte
@@ -8,7 +8,13 @@ Room-scoped file list for the room sidebar.
   import type { RoomFileItem, RoomFilesStore } from '$lib/state/room';
   import { assetUrlForServer } from '$lib/assets/assetUrls';
   import { getUserSettings } from '$lib/state/userSettings.svelte';
-  import { formatDateTime } from '$lib/utils/formatTime';
+  import { fileDateGroup, formatDateTime } from '$lib/utils/formatTime';
+
+  type RoomFileGroup = {
+    key: string;
+    label: string;
+    items: RoomFileItem[];
+  };
 
   let {
     store,
@@ -23,8 +29,25 @@ Room-scoped file list for the room sidebar.
   const userSettings = getUserSettings();
 
   const files = $derived(store.items);
+  const fileGroups = $derived.by(() => groupFiles(files));
   const loading = $derived(store.isInitialLoading);
   let failedThumbnailUrls = $state.raw(new Set<string>());
+
+  function groupFiles(items: RoomFileItem[]): RoomFileGroup[] {
+    const groups: RoomFileGroup[] = [];
+
+    for (const item of items) {
+      const group = fileDateGroup(item.createdAt, userSettings);
+      let existing = groups.find((candidate) => candidate.key === group.key);
+      if (!existing) {
+        existing = { ...group, items: [] };
+        groups.push(existing);
+      }
+      existing.items.push(item);
+    }
+
+    return groups;
+  }
 
   function normalizeUrl(url: string | null | undefined): string | null {
     if (!url) return null;
@@ -130,45 +153,61 @@ Room-scoped file list for the room sidebar.
       No files in this room yet.
     </div>
   {:else}
-    <ul role="list" class="space-y-1">
-      {#each files as item (item.messageEventId + ':' + item.attachment.id)}
-        {@const thumb = usableThumbnailUrl(thumbnailUrl(item))}
-        <li>
-          <button
-            type="button"
-            class="sidebar-item min-h-14 w-full cursor-pointer gap-3 text-left"
-            onclick={() => openFile(item)}
-            title={`Jump to ${item.attachment.filename}`}
-            data-testid="room-file-row"
+    <div class="space-y-4">
+      {#each fileGroups as group (group.key)}
+        <section aria-labelledby={`room-file-group-${group.key}`}>
+          <h2
+            id={`room-file-group-${group.key}`}
+            class="px-2 pb-1 text-xs font-medium tracking-wide text-muted uppercase"
+            data-testid="room-file-group-heading"
           >
-            <span
-              class="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-md border border-border bg-surface-100 text-muted"
-            >
-              {#if thumb}
-                <img
-                  class="h-full w-full object-cover"
-                  src={thumb}
-                  alt=""
-                  loading="lazy"
-                  onerror={() => handleThumbnailError(item, thumb)}
-                />
-              {:else}
-                <span
-                  class={['sidebar-icon iconify text-xl', fileIcon(item.attachment.contentType)]}
-                  aria-hidden="true"
-                ></span>
-              {/if}
-            </span>
-            <span class="min-w-0 flex-1">
-              <span class="block truncate text-sm">{item.attachment.filename}</span>
-              <span class="block truncate text-xs text-muted"
-                >{formatTimestamp(item.createdAt)}</span
-              >
-            </span>
-          </button>
-        </li>
+            {group.label}
+          </h2>
+          <ul role="list" class="space-y-1">
+            {#each group.items as item (item.messageEventId + ':' + item.attachment.id)}
+              {@const thumb = usableThumbnailUrl(thumbnailUrl(item))}
+              <li>
+                <button
+                  type="button"
+                  class="sidebar-item min-h-14 w-full cursor-pointer gap-3 text-left"
+                  onclick={() => openFile(item)}
+                  title={`Jump to ${item.attachment.filename}`}
+                  data-testid="room-file-row"
+                >
+                  <span
+                    class="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-md border border-border bg-surface-100 text-muted"
+                  >
+                    {#if thumb}
+                      <img
+                        class="h-full w-full object-cover"
+                        src={thumb}
+                        alt=""
+                        loading="lazy"
+                        onerror={() => handleThumbnailError(item, thumb)}
+                      />
+                    {:else}
+                      <span
+                        class={[
+                          'sidebar-icon iconify text-xl',
+                          fileIcon(item.attachment.contentType)
+                        ]}
+                        aria-hidden="true"
+                      ></span>
+                    {/if}
+                  </span>
+                  <span class="min-w-0 flex-1">
+                    <span class="block truncate text-sm">{item.attachment.filename}</span>
+                    <span class="block truncate text-xs text-muted"
+                      >{formatTimestamp(item.createdAt)}</span
+                    >
+                  </span>
+                </button>
+              </li>
+            {/each}
+          </ul>
+        </section>
       {/each}
-    </ul>
+    </div>
 
     {#if store.hasMore}
       <div

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
@@ -47,6 +47,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
     canBanRoomMembers = false,
     currentUserId = null,
     filesStore,
+    fileGroupingNow,
     onLoadMoreMembers,
     onOpenFile,
     onClose
@@ -58,6 +59,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
     canBanRoomMembers?: boolean;
     currentUserId?: string | null;
     filesStore?: RoomFilesStore;
+    fileGroupingNow?: Date;
     onLoadMoreMembers?: () => void | Promise<void>;
     onOpenFile?: (messageEventId: string, threadRootEventId: string | null) => void;
     onClose?: () => void;
@@ -273,7 +275,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
     </nav>
   {:else if activePanel === 'files'}
     {#if filesStore}
-      <RoomFilesPanel store={filesStore} serverId={getActiveServer()} {onOpenFile} />
+      <RoomFilesPanel store={filesStore} serverId={getActiveServer()} {fileGroupingNow} {onOpenFile} />
     {:else}
       <div class="flex min-h-0 flex-1 items-center justify-center p-4 text-sm text-muted">
         No files in this room yet.

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -108,6 +108,40 @@ function presenceBadge(container: Element, label: string): Element | null {
   return container.querySelector(`[aria-label="${label}"]`);
 }
 
+function roomFileGroupHeadings(container: Element): string[] {
+  return Array.from(container.querySelectorAll('[data-testid="room-file-group-heading"]')).map(
+    (element) => element.textContent?.trim() ?? ''
+  );
+}
+
+function roomFileRowLabels(container: Element): string[] {
+  return Array.from(container.querySelectorAll('[data-testid="room-file-row"]')).map(
+    (element) => element.textContent?.trim() ?? ''
+  );
+}
+
+async function flushRoomFilesPanel(): Promise<void> {
+  await tick();
+  await Promise.resolve();
+  await tick();
+  await Promise.resolve();
+  await tick();
+}
+
+function localNoonIso(daysFromToday: number): string {
+  const date = new Date();
+  date.setHours(12, 0, 0, 0);
+  date.setDate(date.getDate() + daysFromToday);
+  return date.toISOString();
+}
+
+function previousMonthLocalNoonIso(dayOfMonth: number): string {
+  const date = new Date();
+  date.setHours(12, 0, 0, 0);
+  date.setMonth(date.getMonth() - 1, dayOfMonth);
+  return date.toISOString();
+}
+
 function roomData(members: RoomMember[], totalCount: number, hasMore: boolean): RoomData {
   return {
     room: { id: 'room-1', name: 'general', type: 'CHANNEL' },
@@ -125,11 +159,16 @@ function roomData(members: RoomMember[], totalCount: number, hasMore: boolean): 
   };
 }
 
-function roomFile(messageEventId: string, threadRootEventId: string | null, filename: string) {
+function roomFile(
+  messageEventId: string,
+  threadRootEventId: string | null,
+  filename: string,
+  createdAt = '2026-06-15T12:00:00Z'
+) {
   return {
     messageEventId,
     threadRootEventId,
-    createdAt: '2026-06-15T12:00:00Z',
+    createdAt,
     attachment: {
       id: `att-${filename}`,
       filename,
@@ -514,6 +553,77 @@ describe('RoomSidebar', () => {
     buttonByText(container, 'thread.txt')!.click();
     await tick();
     expect(onOpenFile).toHaveBeenCalledWith('thread-message', 'thread-root');
+  });
+
+  it('groups room files by date and appends loaded pages into the matching groups', async () => {
+    const olderMonthDate = previousMonthLocalNoonIso(21);
+    const olderMonthLabel = new Intl.DateTimeFormat(undefined, {
+      month: 'long',
+      year: 'numeric'
+    }).format(new Date(olderMonthDate));
+
+    queryMock
+      .mockResolvedValueOnce({
+        data: {
+          room: {
+            attachments: {
+              items: [
+                roomFile('today-message', null, 'today.txt', localNoonIso(0)),
+                roomFile('yesterday-message', null, 'yesterday.txt', localNoonIso(-1))
+              ],
+              totalCount: 5,
+              hasMore: true
+            }
+          }
+        },
+        error: null
+      })
+      .mockResolvedValueOnce({
+        data: {
+          room: {
+            attachments: {
+              items: [
+                roomFile('week-message', null, 'week.txt', localNoonIso(-2)),
+                roomFile('month-message', null, 'month.txt', localNoonIso(-7)),
+                roomFile('older-month-message', null, 'older-month.txt', olderMonthDate)
+              ],
+              totalCount: 5,
+              hasMore: false
+            }
+          }
+        },
+        error: null
+      });
+
+    const { container } = render(RoomSidebarTestHarness, {
+      props: {
+        activePanel: 'files',
+        roomData: roomData([member(1)], 1, false)
+      }
+    });
+
+    await flushRoomFilesPanel();
+    expect(roomFileGroupHeadings(container)).toEqual(['Today', 'Yesterday']);
+    expect(roomFileRowLabels(container)).toHaveLength(2);
+    expect(roomFileRowLabels(container)[0]).toContain('today.txt');
+    expect(roomFileRowLabels(container)[1]).toContain('yesterday.txt');
+
+    MockIntersectionObserver.instances[0].trigger();
+    await flushRoomFilesPanel();
+
+    expect(roomFileGroupHeadings(container)).toEqual([
+      'Today',
+      'Yesterday',
+      'This week',
+      'This month',
+      olderMonthLabel
+    ]);
+    const labels = roomFileRowLabels(container);
+    expect(labels).toHaveLength(5);
+    expect(labels.filter((label) => label.includes('today.txt'))).toHaveLength(1);
+    expect(labels[2]).toContain('week.txt');
+    expect(labels[3]).toContain('month.txt');
+    expect(labels[4]).toContain('older-month.txt');
   });
 
   it('falls back to a file icon when a video thumbnail fails to load', async () => {

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -128,20 +128,6 @@ async function flushRoomFilesPanel(): Promise<void> {
   await tick();
 }
 
-function localNoonIso(daysFromToday: number): string {
-  const date = new Date();
-  date.setHours(12, 0, 0, 0);
-  date.setDate(date.getDate() + daysFromToday);
-  return date.toISOString();
-}
-
-function previousMonthLocalNoonIso(dayOfMonth: number): string {
-  const date = new Date();
-  date.setHours(12, 0, 0, 0);
-  date.setMonth(date.getMonth() - 1, dayOfMonth);
-  return date.toISOString();
-}
-
 function roomData(members: RoomMember[], totalCount: number, hasMore: boolean): RoomData {
   return {
     room: { id: 'room-1', name: 'general', type: 'CHANNEL' },
@@ -556,11 +542,7 @@ describe('RoomSidebar', () => {
   });
 
   it('groups room files by date and appends loaded pages into the matching groups', async () => {
-    const olderMonthDate = previousMonthLocalNoonIso(21);
-    const olderMonthLabel = new Intl.DateTimeFormat(undefined, {
-      month: 'long',
-      year: 'numeric'
-    }).format(new Date(olderMonthDate));
+    const fileGroupingNow = new Date('2026-06-17T12:00:00Z');
 
     queryMock
       .mockResolvedValueOnce({
@@ -568,8 +550,8 @@ describe('RoomSidebar', () => {
           room: {
             attachments: {
               items: [
-                roomFile('today-message', null, 'today.txt', localNoonIso(0)),
-                roomFile('yesterday-message', null, 'yesterday.txt', localNoonIso(-1))
+                roomFile('today-message', null, 'today.txt', '2026-06-17T08:00:00Z'),
+                roomFile('yesterday-message', null, 'yesterday.txt', '2026-06-16T08:00:00Z')
               ],
               totalCount: 5,
               hasMore: true
@@ -583,9 +565,9 @@ describe('RoomSidebar', () => {
           room: {
             attachments: {
               items: [
-                roomFile('week-message', null, 'week.txt', localNoonIso(-2)),
-                roomFile('month-message', null, 'month.txt', localNoonIso(-7)),
-                roomFile('older-month-message', null, 'older-month.txt', olderMonthDate)
+                roomFile('week-message', null, 'week.txt', '2026-06-15T08:00:00Z'),
+                roomFile('month-message', null, 'month.txt', '2026-06-10T08:00:00Z'),
+                roomFile('older-month-message', null, 'older-month.txt', '2026-05-21T08:00:00Z')
               ],
               totalCount: 5,
               hasMore: false
@@ -598,7 +580,8 @@ describe('RoomSidebar', () => {
     const { container } = render(RoomSidebarTestHarness, {
       props: {
         activePanel: 'files',
-        roomData: roomData([member(1)], 1, false)
+        roomData: roomData([member(1)], 1, false),
+        fileGroupingNow
       }
     });
 
@@ -616,7 +599,7 @@ describe('RoomSidebar', () => {
       'Yesterday',
       'This week',
       'This month',
-      olderMonthLabel
+      'May 2026'
     ]);
     const labels = roomFileRowLabels(container);
     expect(labels).toHaveLength(5);

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarTestHarness.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarTestHarness.svelte
@@ -21,6 +21,7 @@ mounting the full chat room shell.
     presentation = 'desktop',
     currentUserId = 'viewer',
     canBanRoomMembers = false,
+    fileGroupingNow,
     onPresenceCacheReady,
     onOpenFile,
     onClose
@@ -31,6 +32,7 @@ mounting the full chat room shell.
     presentation?: 'desktop' | 'overlay';
     currentUserId?: string | null;
     canBanRoomMembers?: boolean;
+    fileGroupingNow?: Date;
     onPresenceCacheReady?: (cache: PresenceCache) => void;
     onOpenFile?: (messageEventId: string, threadRootEventId: string | null) => void;
     onClose?: () => void;
@@ -65,6 +67,7 @@ mounting the full chat room shell.
   {canBanRoomMembers}
   {currentUserId}
   filesStore={roomFilesStore}
+  {fileGroupingNow}
   onLoadMoreMembers={roomMembers.loadMoreMembers}
   {onOpenFile}
   {onClose}


### PR DESCRIPTION
- Group the room sidebar Files panel into Today, Yesterday, This week, This month, and older calendar-month sections.
- Add timezone-aware date bucket helpers that respect browser locale week starts with a Monday fallback.
- Cover the grouping behavior with date utility tests and the existing room sidebar browser component spec.
- Update FDR-008 to document the grouped Files panel behavior.

Tests:
- `mise x -- pnpm test:unit --run --project server src/lib/utils/formatTime.spec.ts`
- `mise x -- pnpm test:unit --run --project client 'src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts'`
- `mise lint-frontend`
