### PR TITLE
chore: pass commands through mise chatto task

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -2,7 +2,7 @@
 
 [scripts]
 setup = "mise trust"
-run = "mise run chatto"
+run = "mise run chatto run"
 run_mode = "concurrent"
 
 [git]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ configuration for those.
 | `+1`              | Embedded NATS                      |
 | `+2`              | Prometheus metrics                 |
 
-The repository-level Conductor settings are shared in `.conductor/settings.toml`. The run command delegates to `mise run chatto`, which builds the frontend and development CLI, wires the per-workspace ports, and starts `bin/chatto run` without live reloads. Put machine-specific overrides in `.conductor/settings.local.toml`; that file is gitignored and wins over shared settings on your machine. Conductor also reads `.worktreeinclude` to copy gitignored local environment files, such as `.env` and `.env.*`, into new workspaces.
+The repository-level Conductor settings are shared in `.conductor/settings.toml`. The run command delegates to `mise run chatto run`, which builds the frontend and development CLI, wires the per-workspace ports, and starts `bin/chatto run` without live reloads. Put machine-specific overrides in `.conductor/settings.local.toml`; that file is gitignored and wins over shared settings on your machine. Conductor also reads `.worktreeinclude` to copy gitignored local environment files, such as `.env` and `.env.*`, into new workspaces.
 
 ## Developing Outside of Conductor
 
@@ -42,10 +42,10 @@ mise run setup
 To run the bundled executable without live reloads using the same port wiring as Conductor:
 
 ```sh
-mise run chatto
+mise run chatto run
 ```
 
-When `CONDUCTOR_PORT` is unset, `mise run chatto` uses `4000` for Chatto, `4001` for embedded NATS, and `4002` for Prometheus metrics. Pass explicit CLI arguments after the task name, for example `mise chatto version`.
+When `CONDUCTOR_PORT` is unset, `mise run chatto run` uses `4000` for Chatto, `4001` for embedded NATS, and `4002` for Prometheus metrics. Pass explicit CLI arguments after the task name, for example `mise chatto version`.
 
 For the live-reload development stack, use Tilt:
 

--- a/mise.toml
+++ b/mise.toml
@@ -176,12 +176,9 @@ exec tilt up --stream
 """
 
 [tasks.chatto]
-description = "Build and run the bundled Chatto CLI"
+description = "Build and run the bundled Chatto CLI command"
 depends = ["build-dev-cli"]
 dir = "cli"
-usage = '''
-arg "[args]" var=#true
-'''
 env = {
   CHATTO_WEBSERVER_PORT = "{{env.CONDUCTOR_PORT | default(value='4000')}}",
   CHATTO_WEBSERVER_URL = "http://localhost:{{env.CONDUCTOR_PORT | default(value='4000')}}",
@@ -192,17 +189,7 @@ env = {
   CHATTO_METRICS_PORT = "{{env.CONDUCTOR_PORT | default(value='4000') | int + 2}}",
   CHATTO_METRICS_PATH = "/metrics",
 }
-run = """
-#!/usr/bin/env bash
-set -euo pipefail
-
-if [ -z "${usage_args:-}" ]; then
-  exec bin/chatto run
-fi
-
-eval "chatto_args=($usage_args)"
-exec bin/chatto "${chatto_args[@]}"
-"""
+run = "exec bin/chatto"
 
 # =============================================================================
 # Testing


### PR DESCRIPTION
## Changes

- Make the `chatto` mise task a direct pass-through to `bin/chatto`, relying on mise's native task argument forwarding.
- Update Conductor's run script to invoke the server explicitly with `mise run chatto run`.
- Update contributor docs to describe the explicit `mise run chatto run` workflow.

## Verification

- `git diff --check`
- `mise run --dry-run chatto run`
- `mise run --skip-deps --raw chatto version`
