### PR TITLE
test(e2e): harden room readiness waits

### DIFF
--- a/frontend/e2e/cross-server-dots.test.ts
+++ b/frontend/e2e/cross-server-dots.test.ts
@@ -22,6 +22,7 @@ import {
 import type { ServerInfo } from './fixtures/server';
 import { TIMEOUTS } from './constants';
 import * as routes from './routes';
+import { waitForRoomReady } from './fixtures/realtimeSync';
 
 /**
  * Returns the remote server's base URL using 127.0.0.1 instead of localhost so
@@ -163,7 +164,8 @@ test.describe('Cross-instance dots', () => {
 
     await connectRemoteInstance(page, { ...remoteServer, baseURL }, viewer.userId);
     await page.goto(routes.room(homeGeneralRoomId));
-    await expect(page.getByText(homeBody)).toBeVisible();
+    await waitForRoomReady(page, 'general');
+    await expect(page.getByText(homeBody)).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
 
     const remoteHostSegment = new URL(baseURL).hostname;
     const remoteSpaceWrapper = page.locator('.server-gutter .server-icon-wrapper').filter({
@@ -232,7 +234,8 @@ test.describe('Cross-instance dots', () => {
 
     await connectRemoteInstance(page, { ...remoteServer, baseURL }, viewer.userId);
     await page.goto(routes.room(homeGeneralRoomId));
-    await expect(page.getByText(homeBody)).toBeVisible();
+    await waitForRoomReady(page, 'general');
+    await expect(page.getByText(homeBody)).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
 
     const remoteHostSegment = new URL(baseURL).hostname;
     const dialog = await openSwitcher(page);

--- a/frontend/e2e/fixtures/realtimeSync.ts
+++ b/frontend/e2e/fixtures/realtimeSync.ts
@@ -57,24 +57,30 @@ export async function verifyRealtimeSync(
  * // Now User 2's subscription should be connected
  * ```
  */
-export async function waitForRoomReady(page: Page, roomName?: string): Promise<void> {
+export async function waitForRoomReady(
+  page: Page,
+  roomName?: string,
+  options: { timeout?: number } = {}
+): Promise<void> {
+  const { timeout = TIMEOUTS.REALTIME_EVENT } = options;
+
   // Wait for room header (proves navigation completed)
   if (roomName) {
     await expect(page.getByRole('heading', { name: `# ${roomName}` })).toBeVisible({
-      timeout: 5000
+      timeout
     });
   }
 
   // Wait for message input to be ready (proves room component loaded).
   // Note: don't check contenteditable="true" here - the editor may be read-only
   // if the user doesn't have posting permission (e.g., announcements room).
-  await expect(page.getByTestId('message-input')).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+  await expect(page.getByTestId('message-input')).toBeVisible({ timeout });
 
   // Wait for ServerEventProvider to have mounted and initiated the subscription.
   // The hidden marker element proves the component rendered, and since
   // the `myEvents` subscription is started in the first $effect cycle after
   // render, the subscription request has been sent by the time this resolves.
   await expect(page.getByTestId('server-subscription-active')).toBeAttached({
-    timeout: TIMEOUTS.UI_STANDARD
+    timeout
   });
 }


### PR DESCRIPTION
## Changes

- Use the realtime readiness timeout consistently in `waitForRoomReady`.
- Wait for the home room to remount before asserting timeline contents in cross-server dot e2e coverage.

## Verification

- `mise x -- pnpm --dir frontend exec playwright test e2e/multi-server-identity.test.ts --retries=0`
- `mise x -- pnpm --dir frontend exec playwright test e2e/cross-server-dots.test.ts --retries=0`
- `cd frontend && pnpm lint`
