### PR TITLE
fix: log graphql errors

### DIFF
--- a/cli/internal/http_server/graphql.go
+++ b/cli/internal/http_server/graphql.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 	"hmans.de/chatto/internal/assets"
 	"hmans.de/chatto/internal/graph"
 	"hmans.de/chatto/internal/graph/auth"
@@ -47,6 +48,13 @@ func (s *HTTPServer) setupGraphQLAPI(allowedOrigins []string) {
 	h := handler.New(graph.NewExecutableSchema(config))
 	h.AroundFields(graph.DefaultAuthFieldMiddleware)
 
+	graphqlLogger := s.logger.WithPrefix("graphql")
+	h.SetErrorPresenter(func(ctx context.Context, err error) *gqlerror.Error {
+		gqlErr := graphql.DefaultErrorPresenter(ctx, err)
+		logGraphQLError(ctx, graphqlLogger, gqlErr, err)
+		return gqlErr
+	})
+
 	// Add request timing middleware
 	h.AroundOperations(func(ctx context.Context, next graphql.OperationHandler) graphql.ResponseHandler {
 		oc := graphql.GetOperationContext(ctx)
@@ -57,11 +65,9 @@ func (s *HTTPServer) setupGraphQLAPI(allowedOrigins []string) {
 			userID = user.Id
 		}
 
-		logger := log.WithPrefix("graphql")
-
 		// For subscriptions, just log the start
 		if oc.Operation.Operation == ast.Subscription {
-			logger.Debug("GraphQL subscription started",
+			graphqlLogger.Debug("GraphQL subscription started",
 				"operation", oc.OperationName,
 				"type", "subscription",
 				"userId", userID)
@@ -74,7 +80,7 @@ func (s *HTTPServer) setupGraphQLAPI(allowedOrigins []string) {
 		resp := next(ctx)
 		duration := time.Since(start)
 
-		logger.Debug("GraphQL operation completed",
+		graphqlLogger.Debug("GraphQL operation completed",
 			"duration", duration.String(),
 			"operation", oc.OperationName,
 			"type", string(oc.Operation.Operation),
@@ -236,6 +242,63 @@ func (s *HTTPServer) setupGraphQLAPI(allowedOrigins []string) {
 	s.router.GET("/api/playground", func(c *gin.Context) {
 		p.ServeHTTP(c.Writer, c.Request)
 	})
+}
+
+func logGraphQLError(ctx context.Context, logger *log.Logger, gqlErr *gqlerror.Error, err error) {
+	if gqlErr == nil {
+		return
+	}
+	if err == nil {
+		err = gqlErr
+	}
+
+	operationName, operationType := graphQLOperationDetails(ctx)
+
+	userID := ""
+	if user := auth.ForContext(ctx); user != nil {
+		userID = user.Id
+	}
+
+	keyvals := []any{
+		"error", err,
+		"message", gqlErr.Message,
+		"path", gqlErr.Path.String(),
+		"operation", operationName,
+		"type", operationType,
+		"userId", userID,
+	}
+	if len(gqlErr.Locations) > 0 {
+		keyvals = append(keyvals, "locations", gqlErr.Locations)
+	}
+	if gqlErr.Rule != "" {
+		keyvals = append(keyvals, "rule", gqlErr.Rule)
+	}
+
+	logger.Error("GraphQL operation failed", keyvals...)
+}
+
+func graphQLOperationDetails(ctx context.Context) (operationName, operationType string) {
+	defer func() {
+		if recover() != nil {
+			operationName = ""
+			operationType = ""
+		}
+	}()
+
+	oc := graphql.GetOperationContext(ctx)
+	if oc == nil {
+		return "", ""
+	}
+
+	operationName = oc.OperationName
+	if oc.Operation != nil {
+		operationType = string(oc.Operation.Operation)
+		if operationName == "" {
+			operationName = oc.Operation.Name
+		}
+	}
+
+	return operationName, operationType
 }
 
 func limitGraphQLJSONRequestBody(c *gin.Context) bool {

--- a/cli/internal/http_server/graphql_test.go
+++ b/cli/internal/http_server/graphql_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/log"
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-gonic/gin"
@@ -793,6 +794,16 @@ func TestGraphQL_Query_Viewer(t *testing.T) {
 // ============================================================================
 
 func TestGraphQL_ErrorFormat(t *testing.T) {
+	var logOutput bytes.Buffer
+	oldLogger := log.Default()
+	log.SetDefault(log.NewWithOptions(&logOutput, log.Options{
+		Level:     log.DebugLevel,
+		Formatter: log.JSONFormatter,
+	}))
+	t.Cleanup(func() {
+		log.SetDefault(oldLogger)
+	})
+
 	env := setupGraphQLTestServer(t)
 
 	// Invalid query syntax
@@ -806,6 +817,20 @@ func TestGraphQL_ErrorFormat(t *testing.T) {
 	err := resp.Errors[0]
 	if err.Message == "" {
 		t.Error("Expected error message")
+	}
+
+	logs := logOutput.String()
+	if !strings.Contains(logs, `"level":"error"`) {
+		t.Fatalf("Expected GraphQL error to be logged at error level, got logs: %s", logs)
+	}
+	if !strings.Contains(logs, `"prefix":"graphql"`) {
+		t.Fatalf("Expected GraphQL error log to use graphql prefix, got logs: %s", logs)
+	}
+	if !strings.Contains(logs, `"msg":"GraphQL operation failed"`) {
+		t.Fatalf("Expected GraphQL error log message, got logs: %s", logs)
+	}
+	if !strings.Contains(logs, "thisFieldDoesNotExist") {
+		t.Fatalf("Expected GraphQL error log to include validation error, got logs: %s", logs)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Log GraphQL errors centrally through gqlgen's error presenter.
- Include operation, type, path, user id, locations, and validation rule metadata when available.
- Keep existing GraphQL error responses unchanged.
- Add regression coverage that invalid GraphQL requests emit error-level logs with the graphql prefix.

## Tests
- env GOCACHE=/Users/hmans/src/chatto-umbrella/.cache/go-build go test ./internal/http_server -run TestGraphQL_ErrorFormat -count=1
- env GOCACHE=/Users/hmans/src/chatto-umbrella/.cache/go-build go test ./internal/http_server -run TestGraphQL -count=1

Note: full env GOCACHE=/Users/hmans/src/chatto-umbrella/.cache/go-build go test ./internal/http_server -count=1 currently fails at TestAuthRoutes_TestEmailEndpoint with 404 instead of 200, unrelated to this GraphQL logging change.