### PR TITLE
fix(frontend): restore push notification routing

### DIFF
--- a/frontend/src/lib/notifications/pushNotifications.spec.ts
+++ b/frontend/src/lib/notifications/pushNotifications.spec.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { onNotificationClick } from './pushNotifications';
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+function stubServiceWorker() {
+  const listeners = new Set<(event: MessageEvent) => void>();
+
+  vi.stubGlobal('navigator', {
+    serviceWorker: {
+      addEventListener: vi.fn((type: string, listener: (event: MessageEvent) => void) => {
+        if (type === 'message') listeners.add(listener);
+      }),
+      removeEventListener: vi.fn((type: string, listener: (event: MessageEvent) => void) => {
+        if (type === 'message') listeners.delete(listener);
+      })
+    }
+  });
+
+  return {
+    dispatchMessage(event: Pick<MessageEvent, 'data' | 'ports'>) {
+      for (const listener of listeners) {
+        listener(event as MessageEvent);
+      }
+    },
+    listenerCount() {
+      return listeners.size;
+    }
+  };
+}
+
+describe('onNotificationClick', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('acknowledges after the notification callback completes', async () => {
+    const serviceWorker = stubServiceWorker();
+    const navigation = deferred();
+    const callback = vi.fn(() => navigation.promise);
+    const responsePort = { postMessage: vi.fn() };
+    const stop = onNotificationClick(callback);
+
+    serviceWorker.dispatchMessage({
+      data: {
+        type: 'notification-click',
+        url: 'https://chatto.example/chat/-/room-1'
+      },
+      ports: [responsePort as unknown as MessagePort]
+    });
+
+    await Promise.resolve();
+    expect(callback).toHaveBeenCalledWith('https://chatto.example/chat/-/room-1');
+    expect(responsePort.postMessage).not.toHaveBeenCalled();
+
+    navigation.resolve();
+    await navigation.promise;
+    await Promise.resolve();
+
+    expect(responsePort.postMessage).toHaveBeenCalledWith({ type: 'notification-click-ack' });
+
+    stop();
+    expect(serviceWorker.listenerCount()).toBe(0);
+  });
+
+  it('does not acknowledge when the callback rejects', async () => {
+    const serviceWorker = stubServiceWorker();
+    const callback = vi.fn(async () => {
+      throw new Error('navigation failed');
+    });
+    const responsePort = { postMessage: vi.fn() };
+    onNotificationClick(callback);
+
+    serviceWorker.dispatchMessage({
+      data: {
+        type: 'notification-click',
+        url: 'https://chatto.example/chat/-/room-1'
+      },
+      ports: [responsePort as unknown as MessagePort]
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(callback).toHaveBeenCalledOnce();
+    expect(responsePort.postMessage).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/notifications/pushNotifications.ts
+++ b/frontend/src/lib/notifications/pushNotifications.ts
@@ -6,6 +6,10 @@
  */
 
 import { graphql } from '$lib/gql';
+import {
+  NOTIFICATION_CLICK_ACK_MESSAGE_TYPE,
+  NOTIFICATION_CLICK_MESSAGE_TYPE
+} from '$lib/pwa/notificationClick.worker';
 import { graphqlClientManager } from '$lib/state/server/graphqlClient.svelte';
 
 // GraphQL mutations
@@ -220,14 +224,26 @@ export function onSubscriptionChange(callback: () => void): () => void {
  * The SW posts these instead of calling `WindowClient.navigate()` so the
  * SPA can route via `goto()` (client-side navigation, no full reload).
  */
-export function onNotificationClick(callback: (url: string) => void): () => void {
+export function onNotificationClick(callback: (url: string) => void | Promise<void>): () => void {
   if (!('serviceWorker' in navigator)) {
     return () => {};
   }
 
   const handler = (event: MessageEvent) => {
-    if (event.data?.type === 'notification-click' && typeof event.data.url === 'string') {
-      callback(event.data.url);
+    if (
+      event.data?.type === NOTIFICATION_CLICK_MESSAGE_TYPE &&
+      typeof event.data.url === 'string'
+    ) {
+      const responsePort = event.ports[0];
+      void (async () => {
+        try {
+          await callback(event.data.url);
+          responsePort?.postMessage({ type: NOTIFICATION_CLICK_ACK_MESSAGE_TYPE });
+        } catch {
+          // Leave the service worker unacknowledged so it can fall back to
+          // WindowClient.navigate() after its timeout.
+        }
+      })();
     }
   };
 

--- a/frontend/src/lib/pwa/notificationClick.worker.spec.ts
+++ b/frontend/src/lib/pwa/notificationClick.worker.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest';
+import { routeNotificationClick, type NotificationClickClient } from './notificationClick.worker';
+
+const ORIGIN = 'https://chatto.example';
+const TARGET_URL = `${ORIGIN}/chat/-/room-1?highlight=event-1`;
+
+function createAcknowledgingMessageChannel() {
+  const port1 = {
+    onmessage: null as ((event: MessageEvent) => void) | null,
+    close: vi.fn()
+  };
+  const port2 = {
+    postMessage: vi.fn((data: unknown) => {
+      port1.onmessage?.({ data } as MessageEvent);
+    })
+  };
+
+  return { port1, port2 };
+}
+
+function clientsWith(matches: NotificationClickClient[]) {
+  return {
+    matchAll: vi.fn(async () => matches),
+    openWindow: vi.fn(async () => null)
+  };
+}
+
+describe('routeNotificationClick', () => {
+  it('uses acknowledged SPA routing without navigating the window', async () => {
+    const channel = createAcknowledgingMessageChannel();
+    const client: NotificationClickClient = {
+      focus: vi.fn(async () => client),
+      navigate: vi.fn(async () => client),
+      postMessage: vi.fn((_message, transfer) => {
+        const ackPort = transfer?.[0] as { postMessage: (message: unknown) => void };
+        ackPort.postMessage({ type: 'notification-click-ack' });
+      })
+    };
+    const clients = clientsWith([client]);
+
+    const result = await routeNotificationClick(TARGET_URL, ORIGIN, clients, {
+      createMessageChannel: () => channel
+    });
+
+    expect(result).toBe('client');
+    expect(client.focus).toHaveBeenCalledOnce();
+    expect(client.postMessage).toHaveBeenCalledWith(
+      { type: 'notification-click', url: TARGET_URL },
+      [channel.port2]
+    );
+    expect(client.navigate).not.toHaveBeenCalled();
+    expect(clients.openWindow).not.toHaveBeenCalled();
+  });
+
+  it('falls back to WindowClient.navigate when the SPA does not acknowledge', async () => {
+    const client: NotificationClickClient = {
+      focus: vi.fn(async () => client),
+      navigate: vi.fn(async () => client),
+      postMessage: vi.fn()
+    };
+    const clients = clientsWith([client]);
+
+    const result = await routeNotificationClick(TARGET_URL, ORIGIN, clients, {
+      ackTimeoutMs: 1,
+      createMessageChannel: createAcknowledgingMessageChannel
+    });
+
+    expect(result).toBe('navigate');
+    expect(client.postMessage).toHaveBeenCalledOnce();
+    expect(client.navigate).toHaveBeenCalledWith(TARGET_URL);
+    expect(clients.openWindow).not.toHaveBeenCalled();
+  });
+
+  it('opens a new window when no window client exists', async () => {
+    const clients = clientsWith([]);
+
+    const result = await routeNotificationClick(TARGET_URL, ORIGIN, clients);
+
+    expect(result).toBe('open');
+    expect(clients.matchAll).toHaveBeenCalledWith({
+      type: 'window',
+      includeUncontrolled: true
+    });
+    expect(clients.openWindow).toHaveBeenCalledWith(TARGET_URL);
+  });
+
+  it('rejects malformed and cross-origin notification URLs', async () => {
+    const clients = clientsWith([]);
+
+    await expect(routeNotificationClick('http://[', ORIGIN, clients)).resolves.toBe('ignored');
+    await expect(
+      routeNotificationClick('https://other.example/chat', ORIGIN, clients)
+    ).resolves.toBe('ignored');
+
+    expect(clients.matchAll).not.toHaveBeenCalled();
+    expect(clients.openWindow).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/pwa/notificationClick.worker.ts
+++ b/frontend/src/lib/pwa/notificationClick.worker.ts
@@ -1,0 +1,144 @@
+import { normalizeSameOriginUrl } from './serviceWorkerPolicy';
+
+export const NOTIFICATION_CLICK_ACK_TIMEOUT_MS = 750;
+export const NOTIFICATION_CLICK_MESSAGE_TYPE = 'notification-click';
+export const NOTIFICATION_CLICK_ACK_MESSAGE_TYPE = 'notification-click-ack';
+
+interface NotificationClickPort {
+  onmessage: ((event: MessageEvent) => void) | null;
+  close?: () => void;
+}
+
+interface NotificationClickMessageChannel {
+  port1: NotificationClickPort;
+  port2: unknown;
+}
+
+export interface NotificationClickClient {
+  focus?: () => Promise<NotificationClickClient | null>;
+  navigate?: (url: string) => Promise<NotificationClickClient | null>;
+  postMessage?: (message: unknown, transfer?: unknown[]) => void;
+}
+
+export interface NotificationClickClients {
+  matchAll(options: {
+    type: 'window';
+    includeUncontrolled: true;
+  }): Promise<NotificationClickClient[]>;
+  openWindow(url: string): Promise<NotificationClickClient | null>;
+}
+
+interface NotificationClickLogger {
+  warn: (...args: unknown[]) => void;
+}
+
+export type NotificationClickRouteResult = 'ignored' | 'client' | 'navigate' | 'open';
+
+export interface NotificationClickRouteOptions {
+  ackTimeoutMs?: number;
+  createMessageChannel?: () => NotificationClickMessageChannel;
+  logger?: NotificationClickLogger;
+}
+
+function createDefaultMessageChannel(): NotificationClickMessageChannel {
+  return new MessageChannel();
+}
+
+function isNotificationClickAck(message: unknown): boolean {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'type' in message &&
+    message.type === NOTIFICATION_CLICK_ACK_MESSAGE_TYPE
+  );
+}
+
+function notifyClientAndWaitForAck(
+  client: NotificationClickClient,
+  url: string,
+  options: Required<Pick<NotificationClickRouteOptions, 'ackTimeoutMs' | 'createMessageChannel'>>
+): Promise<boolean> {
+  if (typeof client.postMessage !== 'function') return Promise.resolve(false);
+  const postMessage = client.postMessage;
+
+  return new Promise((resolve) => {
+    const channel = options.createMessageChannel();
+    let settled = false;
+    const timeout = setTimeout(() => finish(false), options.ackTimeoutMs);
+
+    function finish(acknowledged: boolean) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      channel.port1.onmessage = null;
+      channel.port1.close?.();
+      resolve(acknowledged);
+    }
+
+    channel.port1.onmessage = (event) => {
+      if (isNotificationClickAck(event.data)) finish(true);
+    };
+
+    try {
+      postMessage.call(client, { type: NOTIFICATION_CLICK_MESSAGE_TYPE, url }, [channel.port2]);
+    } catch {
+      finish(false);
+    }
+  });
+}
+
+async function navigateClient(client: NotificationClickClient, url: string): Promise<boolean> {
+  if (typeof client.navigate !== 'function') return false;
+  return Boolean(await client.navigate(url));
+}
+
+export async function routeNotificationClick(
+  rawUrl: string | undefined,
+  origin: string,
+  clients: NotificationClickClients,
+  options: NotificationClickRouteOptions = {}
+): Promise<NotificationClickRouteResult> {
+  const url = normalizeSameOriginUrl(rawUrl, origin);
+  if (!url) return 'ignored';
+
+  const ackOptions = {
+    ackTimeoutMs: options.ackTimeoutMs ?? NOTIFICATION_CLICK_ACK_TIMEOUT_MS,
+    createMessageChannel: options.createMessageChannel ?? createDefaultMessageChannel
+  };
+  const clientList = await clients.matchAll({
+    type: 'window',
+    includeUncontrolled: true
+  });
+
+  for (const client of clientList) {
+    if (typeof client.focus !== 'function') continue;
+
+    let focusedClient: NotificationClickClient | null = null;
+    try {
+      focusedClient = await client.focus();
+    } catch (err) {
+      options.logger?.warn('[SW] Failed to focus existing window:', err);
+    }
+
+    if (focusedClient) {
+      const acknowledged = await notifyClientAndWaitForAck(focusedClient, url, ackOptions);
+      if (acknowledged) return 'client';
+
+      try {
+        if (await navigateClient(focusedClient, url)) return 'navigate';
+      } catch (err) {
+        options.logger?.warn('[SW] Failed to navigate focused window:', err);
+      }
+    }
+
+    try {
+      if (await navigateClient(client, url)) return 'navigate';
+    } catch (err) {
+      options.logger?.warn('[SW] Failed to navigate existing window:', err);
+    }
+    break;
+  }
+
+  await clients.openWindow(url);
+  return 'open';
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -100,7 +100,7 @@
         const target = new URL(url);
         if (target.origin !== window.location.origin) return;
         // eslint-disable-next-line svelte/no-navigation-without-resolve -- URL comes from same-origin service worker notification data
-        void goto(target.pathname + target.search + target.hash);
+        return goto(target.pathname + target.search + target.hash);
       } catch {
         // Ignore malformed URLs from the SW.
       }

--- a/frontend/src/service-worker.ts
+++ b/frontend/src/service-worker.ts
@@ -10,11 +10,8 @@
  */
 
 import { build, files, version } from '$service-worker';
-import {
-  OFFLINE_SHELL_PATH,
-  classifyServiceWorkerRequest,
-  normalizeSameOriginUrl
-} from '$lib/pwa/serviceWorkerPolicy';
+import { OFFLINE_SHELL_PATH, classifyServiceWorkerRequest } from '$lib/pwa/serviceWorkerPolicy';
+import { routeNotificationClick } from '$lib/pwa/notificationClick.worker';
 import {
   handleAssetProxyFetch,
   handleAssetProxyMessage,
@@ -226,50 +223,12 @@ self.addEventListener('notificationclick', (event) => {
 
   const rawUrl =
     typeof event.notification.data?.url === 'string' ? event.notification.data.url : undefined;
-  const url = normalizeSameOriginUrl(rawUrl, self.location.origin);
-  if (!url) return;
-
   event.waitUntil(
-    (async () => {
-      const clientList = await self.clients.matchAll({
-        type: 'window',
-        includeUncontrolled: true
-      });
-
-      // Prefer postMessage to an existing client — the SPA listener handles
-      // navigation via goto(), avoiding a full document reload when the user
-      // is already on the target URL (or anywhere in the SPA).
-      for (const client of clientList) {
-        if ('focus' in client) {
-          try {
-            const focusedClient = await client.focus();
-            if (focusedClient) {
-              focusedClient.postMessage({ type: 'notification-click', url });
-              return;
-            }
-          } catch (err) {
-            console.warn('[SW] Failed to focus existing window:', err);
-          }
-          // Focus didn't yield a client — fall back to navigate().
-          try {
-            if ('navigate' in client) {
-              const navigatedClient = await (client as WindowClient).navigate(url);
-              if (navigatedClient) {
-                return;
-              }
-            }
-          } catch (err) {
-            console.warn('[SW] Failed to navigate existing window:', err);
-          }
-          break;
-        }
+    routeNotificationClick(rawUrl, self.location.origin, self.clients, { logger: console }).catch(
+      (err) => {
+        console.error('[SW] Error handling notification click:', err);
       }
-
-      // Fallback: open a new window
-      await self.clients.openWindow(url);
-    })().catch((err) => {
-      console.error('[SW] Error handling notification click:', err);
-    })
+    )
   );
 });
 


### PR DESCRIPTION
- Adds an acknowledged service-worker notification-click routing helper that keeps SPA navigation when the client responds and falls back to `WindowClient.navigate()` or `openWindow()` when it does not.
- Updates the push notification listener and root layout so acknowledgments wait for SvelteKit `goto(...)` to complete.
- Covers acknowledged routing, fallback navigation, invalid URLs, and client acknowledgment behavior with focused frontend unit tests.

Tests:
- `mise x -- pnpm test:unit --run --project server src/lib/pwa/notificationClick.worker.spec.ts src/lib/pwa/serviceWorkerPolicy.spec.ts src/lib/pwa/assetProxy.test.ts src/lib/notifications/pushNotifications.spec.ts`
- `mise lint-frontend`
- `mise build-frontend`
