### PR TITLE
fix: support configurable Docker runtime user

### DIFF
--- a/docker/Dockerfile.goreleaser
+++ b/docker/Dockerfile.goreleaser
@@ -2,41 +2,65 @@ FROM alpine:3.22
 
 ARG NATS_CLI_VERSION=0.4.0
 ARG TARGETARCH
-
-RUN set -eux; \
- apk add --no-cache ca-certificates tzdata ffmpeg \
- && apk add --no-cache --virtual .build-deps curl unzip \
- && case "$TARGETARCH" in \
-      amd64) arch=amd64 ;; \
-      arm64) arch=arm64 ;; \
-      *) echo "unsupported arch: $TARGETARCH" >&2; exit 1 ;; \
-    esac \
- && archive="nats-${NATS_CLI_VERSION}-linux-${arch}.zip" \
- && curl -fsSL -o "/tmp/${archive}" \
-      "https://github.com/nats-io/natscli/releases/download/v${NATS_CLI_VERSION}/${archive}" \
- && curl -fsSL -o /tmp/nats-SHA256SUMS \
-      "https://github.com/nats-io/natscli/releases/download/v${NATS_CLI_VERSION}/SHA256SUMS" \
- && cd /tmp \
- && grep "  ${archive}$" nats-SHA256SUMS | sha256sum -c - \
- && unzip -j "/tmp/${archive}" "*/nats" -d /usr/local/bin/ \
- && chmod +x /usr/local/bin/nats \
- && rm "/tmp/${archive}" /tmp/nats-SHA256SUMS \
- && apk del .build-deps \
- && addgroup -g 10001 chatto \
- && adduser -D -u 10001 -G chatto -h /home/chatto -s /sbin/nologin chatto \
- && mkdir -p /config /data \
- && chown chatto:chatto /config /data
-
-COPY chatto /chatto
-COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-RUN chmod +x /chatto /usr/local/bin/docker-entrypoint.sh
+ARG CHATTO_UID=1000
+ARG CHATTO_GID=1000
 
 # Tell the nats CLI which context to use by default. The file itself is
 # written at container start by docker-entrypoint.sh.
 ENV NATS_CONTEXT=chatto
+ENV HOME=/home/chatto
+
+# Runtime dependencies:
+# - ffmpeg is used for media processing.
+# - shadow provides usermod/groupmod for PUID/PGID remapping at startup.
+# - su-exec drops from the root entrypoint to the unprivileged chatto user.
+RUN set -eux; \
+ apk add --no-cache \
+      ca-certificates \
+      ffmpeg \
+      shadow \
+      su-exec \
+      tzdata
+
+# Bundle the nats CLI so operators can inspect the same NATS server Chatto uses
+# with `docker exec <container> nats ...`. The entrypoint writes its context.
+RUN set -eux; \
+ apk add --no-cache --virtual .build-deps curl unzip; \
+ case "$TARGETARCH" in \
+      amd64) arch=amd64 ;; \
+      arm64) arch=arm64 ;; \
+      *) echo "unsupported arch: $TARGETARCH" >&2; exit 1 ;; \
+    esac; \
+ archive="nats-${NATS_CLI_VERSION}-linux-${arch}.zip"; \
+ curl -fsSL -o "/tmp/${archive}" \
+      "https://github.com/nats-io/natscli/releases/download/v${NATS_CLI_VERSION}/${archive}"; \
+ curl -fsSL -o /tmp/nats-SHA256SUMS \
+      "https://github.com/nats-io/natscli/releases/download/v${NATS_CLI_VERSION}/SHA256SUMS"; \
+ cd /tmp; \
+ grep "  ${archive}$" nats-SHA256SUMS | sha256sum -c -; \
+ unzip -j "/tmp/${archive}" "*/nats" -d /usr/local/bin/; \
+ chmod +x /usr/local/bin/nats; \
+ rm "/tmp/${archive}" /tmp/nats-SHA256SUMS; \
+ apk del .build-deps
+
+# Create the default runtime user and writable paths. PUID/PGID can remap this
+# user at container startup; mounted directories are not recursively chowned.
+RUN set -eux; \
+ addgroup -g "$CHATTO_GID" chatto; \
+ adduser -D -u "$CHATTO_UID" -G chatto -h "$HOME" -s /sbin/nologin chatto; \
+ mkdir -p /config /data; \
+ chown chatto:chatto /config /data "$HOME"
+
+# GoReleaser places the compiled Linux binary in the Docker build context as
+# `chatto`; the release image only packages that binary and the entrypoint.
+COPY chatto /chatto
+COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /chatto /usr/local/bin/docker-entrypoint.sh
 
 WORKDIR /
-USER chatto:chatto
 EXPOSE 4000
+
+# The entrypoint handles optional PUID/PGID remapping, writes the nats CLI
+# context, then execs `/chatto start -c /config/chatto.toml` by default.
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["start", "-c", "/config/chatto.toml"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,10 +8,12 @@ automation.
 - `Dockerfile.goreleaser` builds the backend release image that GoReleaser
   publishes as `ghcr.io/chattocorp/chatto`. The release image uses
   `/config/chatto.toml` as its default config path and `/data` as the embedded
-  NATS data directory.
+  NATS data directory. It defaults the runtime user to `1000:1000` and supports
+  `PUID`/`PGID` environment variables for matching host volume ownership.
 - `docker-entrypoint.sh` is copied into the backend release image. It writes a
-  NATS CLI context from Chatto's runtime NATS environment before starting the
-  `chatto` binary.
+  NATS CLI context from Chatto's runtime NATS environment, applies the runtime
+  user/group, and drops privileges before starting the `chatto` binary. It does
+  not recursively change ownership of mounted operator directories.
 - `Dockerfile.frontend.prebuilt` packages the already-built frontend static
   files into the release-only `ghcr.io/chattocorp/chatto-client` image.
 - `Dockerfile.dev` is the backend development image used by Tilt-oriented local

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -4,6 +4,32 @@
 # itself is using. Runs once per container start.
 set -eu
 
+if [ "$(id -u)" = "0" ]; then
+    # LinuxServer-style PUID/PGID support: start as root only long enough to
+    # map the internal app user to the operator's chosen host IDs, then drop
+    # privileges below. Mounted directories are not recursively chowned here;
+    # operators should make writable mounts owned by these IDs.
+    PUID="${PUID:-1000}"
+    PGID="${PGID:-1000}"
+
+    case "$PUID" in
+        ''|*[!0-9]*) echo "PUID must be a numeric user ID, got: $PUID" >&2; exit 1 ;;
+    esac
+    case "$PGID" in
+        ''|*[!0-9]*) echo "PGID must be a numeric group ID, got: $PGID" >&2; exit 1 ;;
+    esac
+
+    current_uid="$(id -u chatto)"
+    current_gid="$(id -g chatto)"
+    if [ "$current_gid" != "$PGID" ]; then
+        groupmod -o -g "$PGID" chatto
+    fi
+    if [ "$current_uid" != "$PUID" ] || [ "$current_gid" != "$PGID" ]; then
+        usermod -o -u "$PUID" -g "$PGID" chatto
+    fi
+    export HOME=/home/chatto
+fi
+
 if [ -n "${CHATTO_NATS_CLIENT_URL:-}" ]; then
     nats_dir="${HOME:-/home/chatto}/.config/nats"
     mkdir -p "$nats_dir/context"
@@ -25,6 +51,15 @@ if [ -n "${CHATTO_NATS_CLIENT_URL:-}" ]; then
     # also needing $NATS_CONTEXT (e.g. `nats context info`, which is a
     # context-management command and ignores the env var).
     printf 'chatto\n' > "$nats_dir/context.txt"
+fi
+
+if [ "$(id -u)" = "0" ]; then
+    if [ -d "${HOME:-/home/chatto}/.config" ]; then
+        # The entrypoint writes this internal CLI context before su-exec.
+        # Keep that generated container state readable by the runtime user.
+        chown -R chatto:chatto "${HOME:-/home/chatto}/.config"
+    fi
+    exec su-exec chatto:chatto /chatto "$@"
 fi
 
 exec /chatto "$@"

--- a/docs-website/src/content/docs/getting-started/quick-start.mdx
+++ b/docs-website/src/content/docs/getting-started/quick-start.mdx
@@ -33,7 +33,8 @@ Create a local directory for the first run so the generated config and data are 
 
    ```bash
    docker run --rm \
-     --user "$(id -u):$(id -g)" \
+     -e PUID="$(id -u)" \
+     -e PGID="$(id -g)" \
      -v ./config:/config \
      -v ./data:/data \
      ghcr.io/chattocorp/chatto:latest \
@@ -42,7 +43,7 @@ Create a local directory for the first run so the generated config and data are 
 
    The Docker image's entrypoint runs the bundled `chatto` binary, so `init -c /config/chatto.toml` is the container equivalent of running `chatto init -c /config/chatto.toml`. This writes `chatto.toml` with generated secrets into `config/`. In the Docker image, the generated embedded NATS data directory resolves to the `/data` mount.
 
-   The `--user` flag keeps generated files owned by your host user when bind-mounting local directories.
+   `PUID` and `PGID` keep generated files owned by your host user when bind-mounting local directories. If you omit them, the image defaults to `1000:1000`.
 
    The config file is optional. Every `chatto.toml` setting can also be provided through environment variables, which is how the Docker Compose guide configures Chatto.
 
@@ -54,7 +55,8 @@ Create a local directory for the first run so the generated config and data are 
 
    ```bash
    docker run --name chatto --rm -p 4000:4000 \
-     --user "$(id -u):$(id -g)" \
+     -e PUID="$(id -u)" \
+     -e PGID="$(id -g)" \
      -v ./config:/config \
      -v ./data:/data \
      ghcr.io/chattocorp/chatto:latest

--- a/docs-website/src/content/docs/guides/dockercompose.mdx
+++ b/docs-website/src/content/docs/guides/dockercompose.mdx
@@ -81,6 +81,9 @@ By the end of this section, your project directory will look like this:
      chatto:
        image: ghcr.io/chattocorp/chatto:latest
        env_file: .env
+       environment:
+         PUID: "${PUID:-1000}"
+         PGID: "${PGID:-1000}"
        depends_on:
          nats:
            condition: service_healthy
@@ -166,6 +169,8 @@ By the end of this section, your project directory will look like this:
 
    PUBLIC_URL=chat.example.com
    CHATTO_OWNERS_EMAILS=admin@example.com
+   PUID=1000
+   PGID=1000
 
    # NATS
    NATS_TOKEN=<generate-me>
@@ -220,6 +225,8 @@ By the end of this section, your project directory will look like this:
 </Steps>
 
 The Chatto container is configured entirely through `.env` in this guide. The image's default config path is `/config/chatto.toml`, but the server can start without that file when the required settings are provided through environment variables.
+
+The image runs Chatto as a non-root user. By default that user is `1000:1000`; set `PUID` and `PGID` in your shell or Compose environment if the files mounted into `/config` or `/data` are owned by a different host user or group. The entrypoint does not recursively change ownership of mounted directories, so make sure writable mounts are owned by the configured IDs.
 
 ## Operations
 

--- a/examples/dockercompose/.env.example
+++ b/examples/dockercompose/.env.example
@@ -8,6 +8,10 @@ PUBLIC_URL=chat.example.com
 # Use the email address you will use for the first account.
 CHATTO_OWNERS_EMAILS=admin@example.com
 
+# Container user/group for files Chatto writes to mounted volumes.
+PUID=1000
+PGID=1000
+
 # NATS authentication token (shared between NATS server and Chatto clients)
 NATS_TOKEN=your-secure-token-here
 

--- a/examples/dockercompose/README.md
+++ b/examples/dockercompose/README.md
@@ -31,6 +31,7 @@ This example deploys a clustered Chatto setup with:
    Key settings:
    - `PUBLIC_URL` - Your domain (e.g., `chat.example.com`)
    - `CHATTO_OWNERS_EMAILS` - Comma-separated verified email addresses that should become Chatto owners. Include the email address you will use for the first account.
+   - `PUID` and `PGID` - Host user and group IDs Chatto should use for files it writes to mounted volumes. Defaults to `1000:1000`.
    - `NATS_TOKEN` and `CHATTO_NATS_CLIENT_TOKEN` - Must match (shared auth token)
    - `CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET` - Session cookie signing
    - `CHATTO_WEBSERVER_COOKIE_ENCRYPTION_SECRET` - Session cookie encryption

--- a/examples/dockercompose/compose.yml
+++ b/examples/dockercompose/compose.yml
@@ -30,6 +30,9 @@ services:
   chatto:
     image: ghcr.io/chattocorp/chatto:latest
     env_file: .env
+    environment:
+      PUID: "${PUID:-1000}"
+      PGID: "${PGID:-1000}"
     depends_on:
       nats:
         condition: service_healthy

--- a/examples/k8s/chatto.yaml
+++ b/examples/k8s/chatto.yaml
@@ -27,9 +27,9 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 10001
-        runAsGroup: 10001
-        fsGroup: 10001
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
         seccompProfile:
           type: RuntimeDefault
       containers:


### PR DESCRIPTION
- Default the Chatto release image runtime user to `1000:1000` and support `PUID`/`PGID` overrides.
- Restructure the GoReleaser Dockerfile and make the entrypoint switch the runtime user before dropping privileges with `su-exec`.
- Update Docker quick start, Compose docs/examples, and the Kubernetes sample for the new runtime UID/GID behavior.

Tests: Docker release-image smoke tests for read-only `/config`, custom `PUID`/`PGID`, NATS context setup, and `chatto --help`; `git diff --check`.
