### PR TITLE
feat(composer): submit with Ctrl/Cmd+Enter

### DIFF
--- a/frontend/e2e/audio-player.test.ts
+++ b/frontend/e2e/audio-player.test.ts
@@ -33,7 +33,7 @@ test.describe('audio player', () => {
 
         // User 1 uploads and sends an audio file
         await roomPage.fileInput.setInputFiles('e2e/fixtures/test-audio.mp3');
-        await roomPage.messageInput.press('Enter');
+        await roomPage.messageInput.press('Control+Enter');
 
         // User 1 sees the audio player
         await expect(roomPage.audioPlayer).toBeVisible({ timeout: TIMEOUTS.COMPLEX_OPERATION });

--- a/frontend/e2e/auto-scroll.test.ts
+++ b/frontend/e2e/auto-scroll.test.ts
@@ -789,7 +789,7 @@ Line 7: Sunt in culpa qui officia deserunt mollit anim id est laborum.
 Line 8: This is the last line of this long message.`;
 
     await roomPage.messageInput.fill(longMessage);
-    await roomPage.messageInput.press('Enter');
+    await roomPage.messageInput.press('Control+Enter');
 
     // Wait for the message to appear
     await expect(page.getByText('Line 8: This is the last line of this long message.')).toBeVisible(

--- a/frontend/e2e/composer.test.ts
+++ b/frontend/e2e/composer.test.ts
@@ -184,7 +184,7 @@ test.describe('Composer keyboard submit hint', () => {
     await expect(roomPage.messageInput).toHaveText('');
   });
 
-  test('allows a blank paragraph after exiting a list before Enter sends', async ({
+  test('sends from the visible trailing paragraph after exiting a list', async ({
     page,
     chatPage,
     roomPage
@@ -205,11 +205,7 @@ test.describe('Composer keyboard submit hint', () => {
     await roomPage.messageInput.press('Enter');
     await expect(roomPage.messageInput.locator('ul li')).toHaveCount(1);
     await expect(roomPage.messageInput.locator(':scope > p')).toHaveCount(1);
-    await expect(page.getByText(/(?:Cmd|Ctrl)\+Return to Send/)).toBeVisible();
-
-    await roomPage.messageInput.press('Enter');
     await expect(page.getByText(/(?:Return|Enter) again to Send/)).toBeVisible();
-    await expect(roomPage.messageInput.locator(':scope > p')).toHaveCount(2);
 
     await roomPage.messageInput.press('Enter');
     await expect(roomPage.getMessage('first').locator).toBeVisible({ timeout: TIMEOUTS.UI_FAST });

--- a/frontend/e2e/composer.test.ts
+++ b/frontend/e2e/composer.test.ts
@@ -183,6 +183,38 @@ test.describe('Composer keyboard submit hint', () => {
     await expect(roomPage.getMessage(message).locator).toBeVisible({ timeout: TIMEOUTS.UI_FAST });
     await expect(roomPage.messageInput).toHaveText('');
   });
+
+  test('allows a blank paragraph after exiting a list before Enter sends', async ({
+    page,
+    chatPage,
+    roomPage
+  }) => {
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.enterRoom('general');
+    await waitForRoomReady(page, 'general');
+
+    await roomPage.waitForInputEditable();
+    await roomPage.messageInput.fill('- first');
+    await expect(page.getByText(/(?:Cmd|Ctrl)\+Return to Send/)).toBeVisible();
+
+    await roomPage.messageInput.press('Enter');
+    await expect(roomPage.messageInput.locator('ul li')).toHaveCount(2);
+    await expect(page.getByText(/(?:Cmd|Ctrl)\+Return to Send/)).toBeVisible();
+
+    await roomPage.messageInput.press('Enter');
+    await expect(roomPage.messageInput.locator('ul li')).toHaveCount(1);
+    await expect(roomPage.messageInput.locator(':scope > p')).toHaveCount(1);
+    await expect(page.getByText(/(?:Cmd|Ctrl)\+Return to Send/)).toBeVisible();
+
+    await roomPage.messageInput.press('Enter');
+    await expect(page.getByText(/(?:Return|Enter) again to Send/)).toBeVisible();
+    await expect(roomPage.messageInput.locator(':scope > p')).toHaveCount(2);
+
+    await roomPage.messageInput.press('Enter');
+    await expect(roomPage.getMessage('first').locator).toBeVisible({ timeout: TIMEOUTS.UI_FAST });
+    await expect(roomPage.messageInput).toHaveText('');
+  });
 });
 
 // Use #general (postable) as the starting room and a freshly-created custom

--- a/frontend/e2e/composer.test.ts
+++ b/frontend/e2e/composer.test.ts
@@ -160,6 +160,31 @@ test.describe('Composer focus', () => {
   });
 });
 
+test.describe('Composer keyboard submit hint', () => {
+  test('sends when Enter is pressed from a trailing blank paragraph', async ({
+    page,
+    chatPage,
+    roomPage
+  }) => {
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.enterRoom('general');
+    await waitForRoomReady(page, 'general');
+
+    const message = `Return again send ${Date.now()}`;
+    await roomPage.waitForInputEditable();
+    await roomPage.messageInput.fill(message);
+    await expect(page.getByText(/(?:Cmd|Ctrl)\+Return to Send/)).toBeVisible();
+
+    await roomPage.messageInput.press('Enter');
+    await expect(page.getByText(/(?:Return|Enter) again to Send/)).toBeVisible();
+
+    await roomPage.messageInput.press('Enter');
+    await expect(roomPage.getMessage(message).locator).toBeVisible({ timeout: TIMEOUTS.UI_FAST });
+    await expect(roomPage.messageInput).toHaveText('');
+  });
+});
+
 // Use #general (postable) as the starting room and a freshly-created custom
 // room (also postable) as the navigation target. We can't use #announcements
 // — its special permissions deny message.post for regular members, which

--- a/frontend/e2e/drag-drop-upload.test.ts
+++ b/frontend/e2e/drag-drop-upload.test.ts
@@ -12,7 +12,7 @@ test.describe('drag and drop image upload', () => {
 
     const testMessage = `Drag drop test ${Date.now()}`;
     await roomPage.messageInput.fill(testMessage);
-    await roomPage.messageInput.press('Enter');
+    await roomPage.messageInput.press('Control+Enter');
 
     await expect(roomPage.attachmentPreview).not.toBeVisible();
     await roomPage.expectMessageVisible(testMessage);

--- a/frontend/e2e/emoji-autocomplete.test.ts
+++ b/frontend/e2e/emoji-autocomplete.test.ts
@@ -36,7 +36,7 @@ test.describe('Emoji autocomplete (composer integration)', () => {
     await expect(popup).not.toBeVisible();
     await expect(roomPage.messageInput).toHaveText(/👋/);
 
-    await roomPage.messageInput.press('Enter');
+    await roomPage.messageInput.press('Control+Enter');
     await expect(page.locator('[role="article"]', { hasText: '👋' })).toBeVisible({
       timeout: TIMEOUTS.UI_STANDARD
     });

--- a/frontend/e2e/fixtures/realtimeSync.ts
+++ b/frontend/e2e/fixtures/realtimeSync.ts
@@ -32,7 +32,7 @@ export async function verifyRealtimeSync(
 
   // Sender sends sync message
   await senderRoom.messageInput.fill(syncId);
-  await senderRoom.messageInput.press('Enter');
+  await senderRoom.messageInput.press('Control+Enter');
 
   // Receiver waits to see it (proves subscription is connected)
   await expect(receiverRoom.page.getByText(syncId)).toBeVisible({ timeout });

--- a/frontend/e2e/gif-to-video.test.ts
+++ b/frontend/e2e/gif-to-video.test.ts
@@ -41,7 +41,7 @@ test.describe('animated GIF to video conversion @ffmpeg', () => {
       await expect(roomPage.attachmentPreview).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
 
       // Send the message
-      await roomPage.messageInput.press('Enter');
+      await roomPage.messageInput.press('Control+Enter');
 
       // Wait for preview to clear (message sent)
       await expect(roomPage.attachmentPreview).not.toBeVisible({
@@ -104,7 +104,7 @@ test.describe('animated GIF to video conversion @ffmpeg', () => {
     await expect(roomPage.attachmentPreview).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
 
     // Send the message
-    await roomPage.messageInput.press('Enter');
+    await roomPage.messageInput.press('Control+Enter');
     await expect(roomPage.attachmentPreview).not.toBeVisible({
       timeout: TIMEOUTS.COMPLEX_OPERATION
     });

--- a/frontend/e2e/link-previews.test.ts
+++ b/frontend/e2e/link-previews.test.ts
@@ -68,7 +68,7 @@ test.describe('Link previews', () => {
     await expect(composerPreview).toBeVisible({ timeout: TIMEOUTS.COMPLEX_OPERATION });
 
     // Now send — the preview data is included in the mutation
-    await roomPage.messageInput.press('Enter');
+    await roomPage.messageInput.press('Control+Enter');
     await expect(page.getByText(messageText)).toBeVisible();
 
     // The preview should be visible on the posted message (stored at post-time)
@@ -119,7 +119,7 @@ test.describe('Link previews', () => {
     });
 
     // Send the message (preview data included in mutation)
-    await roomPage.messageInput.press('Enter');
+    await roomPage.messageInput.press('Control+Enter');
     await expect(page.getByText(messageText)).toBeVisible();
 
     // Wait for the preview to appear on the posted message
@@ -165,7 +165,7 @@ test.describe('Link previews', () => {
     });
 
     // Send the message (preview data included in mutation)
-    await roomPage.messageInput.press('Enter');
+    await roomPage.messageInput.press('Control+Enter');
     await expect(page.getByText(messageText)).toBeVisible();
 
     // Wait for the first preview to appear

--- a/frontend/e2e/mention-autocomplete.test.ts
+++ b/frontend/e2e/mention-autocomplete.test.ts
@@ -28,7 +28,7 @@ test.describe('Mention autocomplete', () => {
 
     await expect(roomPage.messageInput).toHaveText(`@${user.login} `);
     await roomPage.messageInput.pressSequentially('hello');
-    await roomPage.messageInput.press('Enter');
+    await roomPage.messageInput.press('Control+Enter');
 
     await expect(page.locator('[role="article"]', { hasText: `@${user.login} hello` })).toBeVisible(
       { timeout: TIMEOUTS.UI_STANDARD }

--- a/frontend/e2e/message-duplicate.test.ts
+++ b/frontend/e2e/message-duplicate.test.ts
@@ -22,7 +22,7 @@ test.describe('Message duplication bug', () => {
 
     // Post a message
     await roomPage.messageInput.fill(testMessage);
-    await roomPage.messageInput.press('Enter');
+    await roomPage.messageInput.press('Control+Enter');
 
     // Wait for message to appear (use first() to avoid strict mode with duplicates)
     await expect(page.getByText(testMessage).first()).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });

--- a/frontend/e2e/message-editing.test.ts
+++ b/frontend/e2e/message-editing.test.ts
@@ -440,14 +440,14 @@ test.describe('Message editing', () => {
     await chatPage.enterRoom('general');
 
     // Compose "line1" + blank line + "line2". Shift+Enter inserts a hard
-    // break in the composer (Enter alone submits the message).
+    // break in the composer; Ctrl+Enter submits the message.
     await roomPage.waitForInputEditable();
     await roomPage.messageInput.click();
     await page.keyboard.type('line1');
     await page.keyboard.press('Shift+Enter');
     await page.keyboard.press('Shift+Enter');
     await page.keyboard.type('line2');
-    await roomPage.messageInput.press('Enter');
+    await roomPage.messageInput.press('Control+Enter');
 
     const message = roomPage.getMessage('line1');
     await expect(message.locator).toBeVisible();
@@ -477,7 +477,7 @@ test.describe('Message editing', () => {
       await page.keyboard.press(docEnd);
       await page.keyboard.type('x');
       await page.keyboard.press('Backspace');
-      await roomPage.composer.press('Enter');
+      await roomPage.composer.press('Control+Enter');
       await roomPage.expectEditModeInactive();
       return snapshot;
     };

--- a/frontend/e2e/messages.test.ts
+++ b/frontend/e2e/messages.test.ts
@@ -588,7 +588,7 @@ test('image lightbox supports keyboard navigation with multiple images', async (
   await expect(roomPage.attachmentPreview).toHaveCount(2);
 
   // Send the message
-  await roomPage.messageInput.press('Enter');
+  await roomPage.messageInput.press('Control+Enter');
 
   // Wait for both attachment images to appear in the message
   await expect(roomPage.attachmentImage).toHaveCount(2, { timeout: TIMEOUTS.COMPLEX_OPERATION });

--- a/frontend/e2e/pages/RoomPage.ts
+++ b/frontend/e2e/pages/RoomPage.ts
@@ -41,7 +41,7 @@ export class RoomPage {
 
   /** The send button */
   get sendButton(): Locator {
-    return this.page.getByTitle('Send message');
+    return this.page.getByRole('button', { name: 'Send message' });
   }
 
   /** Video attachment preview in the composer (shown when a video file is staged) */
@@ -155,23 +155,14 @@ export class RoomPage {
   async sendMessage(text: string): Promise<MessageComponent> {
     await this.waitForInputEditable();
     await this.messageInput.fill(text);
-    await this.messageInput.press('Enter');
+    await this.messageInput.press('Control+Enter');
     const message = this.getMessage(text);
-    try {
-      await expect(message.locator).toBeVisible({ timeout: TIMEOUTS.UI_FAST });
-    } catch {
-      // Enter may first confirm an active autocomplete item when the message
-      // ends at a mention/emoji trigger. In that case, send with a second Enter.
-      if ((await this.messageInput.textContent())?.trim()) {
-        await this.messageInput.press('Enter');
-      }
-      await expect(message.locator).toBeVisible();
-    }
+    await expect(message.locator).toBeVisible({ timeout: TIMEOUTS.UI_FAST });
     return message;
   }
 
   /**
-   * Send a text message using the send button (instead of Enter key).
+   * Send a text message using the send button (instead of the keyboard shortcut).
    * Returns a MessageComponent for the new message.
    */
   async sendMessageWithButton(text: string): Promise<MessageComponent> {
@@ -201,7 +192,7 @@ export class RoomPage {
     if (text) {
       await this.messageInput.fill(text);
     }
-    await this.messageInput.press('Enter');
+    await this.messageInput.press('Control+Enter');
 
     // Wait for attachment preview to clear (message sent)
     await expect(this.attachmentPreview).not.toBeVisible();
@@ -221,10 +212,10 @@ export class RoomPage {
   }
 
   /**
-   * Press Enter with empty input (for testing empty message prevention).
+   * Press the keyboard submit shortcut with empty input.
    */
   async submitEmpty(): Promise<void> {
-    await this.messageInput.press('Enter');
+    await this.messageInput.press('Control+Enter');
   }
 
   /**
@@ -441,12 +432,12 @@ export class RoomPage {
   // --- Message Editing ---
 
   /**
-   * Complete editing a message (fill new text and press Enter).
+   * Complete editing a message (fill new text and press the keyboard submit shortcut).
    * Assumes edit mode is already active.
    */
   async completeEdit(newText: string): Promise<void> {
     await this.composer.fill(newText);
-    await this.composer.press('Enter');
+    await this.composer.press('Control+Enter');
     await expect(this.editingIndicator).not.toBeVisible({ timeout: TIMEOUTS.UI_FAST });
   }
 
@@ -563,7 +554,7 @@ export class RoomPage {
       timeout: TIMEOUTS.UI_STANDARD
     });
     await this.threadReplyInput.fill(text);
-    await this.threadReplyInput.press('Enter');
+    await this.threadReplyInput.press('Control+Enter');
     await expect(this.threadPane.getByText(text)).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
   }
 
@@ -584,7 +575,7 @@ export class RoomPage {
 
     // Post the reply
     await this.threadReplyInput.fill(text);
-    await this.threadReplyInput.press('Enter');
+    await this.threadReplyInput.press('Control+Enter');
     // Wait for message to appear in thread pane specifically
     await expect(this.threadPane.getByText(text)).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
   }
@@ -681,12 +672,12 @@ export class RoomPage {
   }
 
   /**
-   * Complete editing a message in the thread pane (fill new text and press Enter).
+   * Complete editing a message in the thread pane (fill new text and press the keyboard submit shortcut).
    * Assumes edit mode is already active in the thread pane.
    */
   async completeThreadEdit(newText: string): Promise<void> {
     await this.threadReplyInput.fill(newText);
-    await this.threadReplyInput.press('Enter');
+    await this.threadReplyInput.press('Control+Enter');
     await expect(this.threadEditingIndicator).not.toBeVisible({ timeout: TIMEOUTS.UI_FAST });
   }
 

--- a/frontend/e2e/room-files.test.ts
+++ b/frontend/e2e/room-files.test.ts
@@ -42,7 +42,7 @@ test('room Files sidebar jumps to root files and opens thread reply files', asyn
     timeout: TIMEOUTS.UI_STANDARD
   });
   await roomPage.threadReplyInput.fill(threadReplyText);
-  await roomPage.threadReplyInput.press('Enter');
+  await roomPage.threadReplyInput.press('Control+Enter');
   await roomPage.expectTextInThreadPane(threadReplyText);
   await roomPage.closeThread();
 

--- a/frontend/e2e/server-roles.test.ts
+++ b/frontend/e2e/server-roles.test.ts
@@ -1012,7 +1012,7 @@ test.describe('Server Permission Enforcement', () => {
       await expect(page.getByTestId('message-input')).toHaveAttribute('contenteditable', 'false');
 
       // Send button should also be disabled
-      await expect(page.getByTitle('Send message')).toBeDisabled();
+      await expect(page.getByRole('button', { name: 'Send message' })).toBeDisabled();
     });
 
     test('reaction buttons hidden when user lacks message.react permission', async ({

--- a/frontend/e2e/thread-reply-echo.test.ts
+++ b/frontend/e2e/thread-reply-echo.test.ts
@@ -1211,7 +1211,7 @@ test.describe('Thread Reply Echo ("Also send to channel")', () => {
       // Post the reply
       const replyBody = `Reply to target ${timestamp}`;
       await page.getByTestId('thread-reply-input').fill(replyBody);
-      await page.getByTestId('thread-reply-input').press('Enter');
+      await page.getByTestId('thread-reply-input').press('Control+Enter');
 
       // Wait for reply to appear
       await expect(page.getByTestId('thread-pane').getByText(replyBody)).toBeVisible({
@@ -1296,7 +1296,7 @@ test.describe('Thread Reply Echo ("Also send to channel")', () => {
 
       // Post the reply
       await page.getByTestId('thread-reply-input').fill(echoBody);
-      await page.getByTestId('thread-reply-input').press('Enter');
+      await page.getByTestId('thread-reply-input').press('Control+Enter');
 
       // Wait for the echo reply to appear in the thread
       await expect(page.getByTestId('thread-pane').getByText(echoBody)).toBeVisible({

--- a/frontend/e2e/threading.test.ts
+++ b/frontend/e2e/threading.test.ts
@@ -209,7 +209,7 @@ test.describe('Message Threading', () => {
         await roomPage.expectThreadEditModeActive();
         const editedReply = `Edited reply ${Date.now()}`;
         await roomPage.threadReplyInput.fill(editedReply);
-        await roomPage.threadReplyInput.press('Enter');
+        await roomPage.threadReplyInput.press('Control+Enter');
 
         // User B should see the new content and the (edited) marker.
         await expect(roomPage2.threadPane.getByText(editedReply)).toBeVisible({

--- a/frontend/e2e/video-player.test.ts
+++ b/frontend/e2e/video-player.test.ts
@@ -47,7 +47,7 @@ test.describe('video player @ffmpeg', () => {
         });
 
         // Send the message
-        await roomPage.messageInput.press('Enter');
+        await roomPage.messageInput.press('Control+Enter');
 
         // Wait for preview to clear (message sent)
         await expect(roomPage.videoAttachmentPreview).not.toBeVisible({
@@ -115,7 +115,7 @@ test.describe('video player @ffmpeg', () => {
       });
       await expect(roomPage.videoAttachmentPreview).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
 
-      await roomPage.messageInput.press('Enter');
+      await roomPage.messageInput.press('Control+Enter');
       await expect(roomPage.videoAttachmentPreview).not.toBeVisible({
         timeout: TIMEOUTS.COMPLEX_OPERATION
       });

--- a/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -25,6 +25,17 @@
 
   const tipTapEditorModule = import('./TipTapEditor.svelte');
 
+  function getSubmitShortcutHint(): string | null {
+    if (typeof navigator === 'undefined' || isTouchDevice()) return null;
+
+    const userAgentDataPlatform =
+      'userAgentData' in navigator
+        ? (navigator.userAgentData as { platform?: string } | undefined)?.platform
+        : undefined;
+    const platform = userAgentDataPlatform ?? navigator.platform ?? '';
+    return /Mac|iPhone|iPad|iPod/i.test(platform) ? 'Cmd+Return to Send' : 'Ctrl+Return to Send';
+  }
+
   const stores = serverRegistry.getStore(getActiveServer());
   const serverInfo = stores.serverInfo;
   const roomUnreadStore = stores.roomUnread;
@@ -122,6 +133,7 @@
 
   // Testid for E2E tests - distinguishes main input from thread reply input
   let testid = $derived(inThread ? 'thread-reply-input' : 'message-input');
+  const submitShortcutHint = getSubmitShortcutHint();
 
   // Track editing transitions by event identity so editor setContent() doesn't
   // run repeatedly while TipTap echoes updates back through onUpdate.
@@ -360,6 +372,16 @@
     return text.replace(/\n{3,}/g, '\n\n');
   }
 
+  function hasStructuralMarkdownBody(text: string): boolean {
+    return text.split('\n').some((line) => /^ {0,3}(?:#{1,6}|[-+*]|\d{1,9}[.)]|>)[ \t]$/.test(line));
+  }
+
+  function bodyForSend(text: string): string {
+    const normalized = normalizeMessageBody(text);
+    if (hasStructuralMarkdownBody(normalized)) return normalized;
+    return normalizeMessageBody(text.trim());
+  }
+
   type MentionConfirmation = {
     recipientCount: number;
     token: string;
@@ -492,7 +514,7 @@
   async function postMessage() {
     // Require either non-empty message body or attachments.
     // hasVisibleContent rejects messages with only invisible Unicode characters.
-    const bodyToSend = normalizeMessageBody(message.trim());
+    const bodyToSend = bodyForSend(message);
     const hasBody = hasVisibleContent(bodyToSend);
     const filesToSend =
       attachments.selectedFiles.length > 0 ? [...attachments.selectedFiles] : null;
@@ -536,7 +558,7 @@
   }
 
   async function editMessage() {
-    const trimmedBody = normalizeMessageBody(message.trim());
+    const trimmedBody = bodyForSend(message);
     if (!trimmedBody) {
       toast.error('Message cannot be empty');
       return;
@@ -592,6 +614,11 @@
   // Handle keyboard events from TipTap editor.
   // Return true to prevent TipTap's default handling.
   function handleEditorKeyDown(event: KeyboardEvent): boolean {
+    if (event.key === 'Enter' && !event.shiftKey && (event.metaKey || event.ctrlKey)) {
+      handleSubmit(); // Fire-and-forget (async, but keydown must return sync)
+      return true;
+    }
+
     // Handle emoji autocomplete keyboard events first
     if (autocomplete.emoji && autocomplete.emojiRef) {
       if (autocomplete.emojiRef.handleKeyDown(event)) {
@@ -645,21 +672,6 @@
         });
         return true;
       }
-    }
-
-    if (event.key === 'Enter' && !event.shiftKey && (event.metaKey || event.ctrlKey)) {
-      handleSubmit(); // Fire-and-forget (async, but keydown must return sync)
-      return true;
-    }
-
-    if (
-      event.key === 'Enter' &&
-      !event.shiftKey &&
-      !isTouchDevice() &&
-      editorApi?.isInPlainParagraph()
-    ) {
-      handleSubmit(); // Fire-and-forget (async, but keydown must return sync)
-      return true;
     }
 
     return false; // Let TipTap handle it (e.g., Shift+Enter for hard break)
@@ -824,17 +836,30 @@
       />
     {/await}
 
-    <!-- Send button -->
-    <button
-      type="button"
-      onpointerdown={(e) => e.preventDefault()}
-      onclick={handleSubmit}
-      disabled={!canSubmit}
-      class="flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded text-muted transition-colors duration-100 enabled:hover:text-text disabled:cursor-not-allowed disabled:opacity-50"
-      title="Send message"
-    >
-      <span class="iconify text-xl uil--telegram-alt"></span>
-    </button>
+    <div class="flex h-8 shrink-0 items-center gap-2">
+      {#if submitShortcutHint && canSubmit}
+        <span
+          aria-hidden="true"
+          title={submitShortcutHint}
+          class="whitespace-nowrap px-0.5 text-xs font-medium leading-none text-muted/75"
+        >
+          {submitShortcutHint}
+        </span>
+      {/if}
+
+      <!-- Send button -->
+      <button
+        type="button"
+        onpointerdown={(e) => e.preventDefault()}
+        onclick={handleSubmit}
+        disabled={!canSubmit}
+        class="flex h-8 w-8 cursor-pointer items-center justify-center rounded text-muted transition-colors duration-100 enabled:hover:text-text disabled:cursor-not-allowed disabled:opacity-50"
+        aria-label="Send message"
+        title="Send message (Ctrl/Cmd+Enter)"
+      >
+        <span class="iconify text-xl uil--telegram-alt"></span>
+      </button>
+    </div>
   </div>
 
   <!-- Also send to channel checkbox (thread replies only, when permitted) -->

--- a/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -25,7 +25,12 @@
 
   const tipTapEditorModule = import('./TipTapEditor.svelte');
 
-  function getSubmitShortcutHint(): string | null {
+  type ShortcutHints = {
+    submit: string;
+    enterAgain: string;
+  };
+
+  function getShortcutHints(): ShortcutHints | null {
     if (typeof navigator === 'undefined' || isTouchDevice()) return null;
 
     const userAgentDataPlatform =
@@ -33,7 +38,10 @@
         ? (navigator.userAgentData as { platform?: string } | undefined)?.platform
         : undefined;
     const platform = userAgentDataPlatform ?? navigator.platform ?? '';
-    return /Mac|iPhone|iPad|iPod/i.test(platform) ? 'Cmd+Return to Send' : 'Ctrl+Return to Send';
+    const usesReturn = /Mac|iPhone|iPad|iPod/i.test(platform);
+    return usesReturn
+      ? { submit: 'Cmd+Return to Send', enterAgain: 'Return again to Send' }
+      : { submit: 'Ctrl+Return to Send', enterAgain: 'Enter again to Send' };
   }
 
   const stores = serverRegistry.getStore(getActiveServer());
@@ -133,7 +141,7 @@
 
   // Testid for E2E tests - distinguishes main input from thread reply input
   let testid = $derived(inThread ? 'thread-reply-input' : 'message-input');
-  const submitShortcutHint = getSubmitShortcutHint();
+  const shortcutHints = getShortcutHints();
 
   // Track editing transitions by event identity so editor setContent() doesn't
   // run repeatedly while TipTap echoes updates back through onUpdate.
@@ -265,6 +273,11 @@
       attachments.pendingCount === 0 &&
       (hasVisibleContent(message) || attachments.selectedFiles.length > 0 || isEditing)
   );
+  let editorNextEnterWillSend = $state(false);
+  let nextEnterWillSend = $derived(canSubmit && editorNextEnterWillSend);
+  let submitHint = $derived(
+    shortcutHints ? (nextEnterWillSend ? shortcutHints.enterAgain : shortcutHints.submit) : null
+  );
 
   // Auto-focus the input when the component mounts, room changes, a reply
   // starts, or the editor becomes editable (canPost loads async after a
@@ -373,7 +386,9 @@
   }
 
   function hasStructuralMarkdownBody(text: string): boolean {
-    return text.split('\n').some((line) => /^ {0,3}(?:#{1,6}|[-+*]|\d{1,9}[.)]|>)[ \t]$/.test(line));
+    return text
+      .split('\n')
+      .some((line) => /^ {0,3}(?:#{1,6}|[-+*]|\d{1,9}[.)]|>)[ \t]$/.test(line));
   }
 
   function bodyForSend(text: string): string {
@@ -633,6 +648,17 @@
       }
     }
 
+    if (
+      event.key === 'Enter' &&
+      !event.shiftKey &&
+      !event.metaKey &&
+      !event.ctrlKey &&
+      nextEnterWillSend
+    ) {
+      handleSubmit(); // Fire-and-forget (async, but keydown must return sync)
+      return true;
+    }
+
     // Handle Tab for @mention autocomplete
     if (event.key === 'Tab') {
       if (autocomplete.handleTabCompletion(event)) {
@@ -832,18 +858,19 @@
         onUpdate={handleEditorUpdate}
         onKeyDown={handleEditorKeyDown}
         onPaste={handlePaste}
+        onNextEnterWillSendChange={(value) => (editorNextEnterWillSend = value)}
         onReady={handleEditorReady}
       />
     {/await}
 
     <div class="flex h-8 shrink-0 items-center gap-2">
-      {#if submitShortcutHint && canSubmit}
+      {#if submitHint && canSubmit}
         <span
           aria-hidden="true"
-          title={submitShortcutHint}
-          class="whitespace-nowrap px-0.5 text-xs font-medium leading-none text-muted/75"
+          title={submitHint}
+          class="px-0.5 text-xs leading-none font-medium whitespace-nowrap text-muted/75"
         >
-          {submitShortcutHint}
+          {submitHint}
         </span>
       {/if}
 

--- a/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -1105,6 +1105,30 @@ describe('MessageComposer', () => {
       });
     });
 
+    it('sends with plain Enter from a trailing blank paragraph', async () => {
+      const { container, roomId } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = await findEditor(container);
+
+      await typeEditorLiteralText(editor, 'hello from return');
+      await vi.waitFor(() => expect(container.textContent).toMatch(/(?:Cmd|Ctrl)\+Return to Send/));
+      await pressEditorKey(editor, 'Enter');
+      expect(mutationMock).not.toHaveBeenCalled();
+      await vi.waitFor(() =>
+        expect(container.textContent).toMatch(/(?:Return|Enter) again to Send/)
+      );
+
+      await pressEditorKey(editor, 'Enter');
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({
+        roomId,
+        body: 'hello from return'
+      });
+    });
+
     it('posts markdown after TipTap formatting shortcuts are applied', async () => {
       const { container, roomId } = renderMessageComposer(
         { roomId: 'room_456' },
@@ -1447,7 +1471,7 @@ describe('MessageComposer', () => {
       });
     });
 
-    it('does not send with Enter after the cursor has left a bullet list', async () => {
+    it('sends with Enter from a trailing blank paragraph after leaving a bullet list', async () => {
       const { container, roomId } = renderMessageComposer(
         { roomId: 'room_456' },
         new Map([['$$_urql', mockClient]])
@@ -1461,13 +1485,11 @@ describe('MessageComposer', () => {
       await pressEditorKey(editor, 'Enter');
       expect(mutationMock).not.toHaveBeenCalled();
       await vi.waitFor(() => expect(editor.querySelectorAll('ul li')).toHaveLength(1));
+      await vi.waitFor(() =>
+        expect(container.textContent).toMatch(/(?:Return|Enter) again to Send/)
+      );
 
       await pressEditorKey(editor, 'Enter');
-
-      await vi.waitFor(() => expect(editor.querySelectorAll('p').length).toBeGreaterThan(1));
-      expect(mutationMock).not.toHaveBeenCalled();
-
-      await pressEditorKey(editor, 'Enter', { ctrlKey: true });
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -1562,8 +1584,11 @@ describe('MessageComposer', () => {
       expect(getComputedStyle(editor.querySelector('p')!).marginTop).toBe('0px');
       await pressEditorKey(editor, 'Enter');
       expect(mutationMock).not.toHaveBeenCalled();
+      await vi.waitFor(() =>
+        expect(container.textContent).toMatch(/(?:Return|Enter) again to Send/)
+      );
 
-      await pressEditorKey(editor, 'Enter', { ctrlKey: true });
+      await pressEditorKey(editor, 'Enter');
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({

--- a/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -1471,7 +1471,7 @@ describe('MessageComposer', () => {
       });
     });
 
-    it('sends with Enter from a trailing blank paragraph after leaving a bullet list', async () => {
+    it('allows a blank paragraph after leaving a bullet list before Enter sends', async () => {
       const { container, roomId } = renderMessageComposer(
         { roomId: 'room_456' },
         new Map([['$$_urql', mockClient]])
@@ -1485,6 +1485,10 @@ describe('MessageComposer', () => {
       await pressEditorKey(editor, 'Enter');
       expect(mutationMock).not.toHaveBeenCalled();
       await vi.waitFor(() => expect(editor.querySelectorAll('ul li')).toHaveLength(1));
+      await vi.waitFor(() => expect(container.textContent).toMatch(/(?:Cmd|Ctrl)\+Return to Send/));
+
+      await pressEditorKey(editor, 'Enter');
+      expect(mutationMock).not.toHaveBeenCalled();
       await vi.waitFor(() =>
         expect(container.textContent).toMatch(/(?:Return|Enter) again to Send/)
       );
@@ -1581,7 +1585,7 @@ describe('MessageComposer', () => {
 
       document.execCommand('insertText', false, 'body');
       await vi.waitFor(() => expect(editor.querySelector('p')?.textContent).toBe('body'));
-      expect(getComputedStyle(editor.querySelector('p')!).marginTop).toBe('0px');
+      expect(getComputedStyle(editor.querySelector('p')!).marginTop).not.toBe('0px');
       await pressEditorKey(editor, 'Enter');
       expect(mutationMock).not.toHaveBeenCalled();
       await vi.waitFor(() =>

--- a/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -1471,7 +1471,7 @@ describe('MessageComposer', () => {
       });
     });
 
-    it('allows a blank paragraph after leaving a bullet list before Enter sends', async () => {
+    it('sends with Enter from the visible trailing paragraph after leaving a bullet list', async () => {
       const { container, roomId } = renderMessageComposer(
         { roomId: 'room_456' },
         new Map([['$$_urql', mockClient]])
@@ -1485,10 +1485,6 @@ describe('MessageComposer', () => {
       await pressEditorKey(editor, 'Enter');
       expect(mutationMock).not.toHaveBeenCalled();
       await vi.waitFor(() => expect(editor.querySelectorAll('ul li')).toHaveLength(1));
-      await vi.waitFor(() => expect(container.textContent).toMatch(/(?:Cmd|Ctrl)\+Return to Send/));
-
-      await pressEditorKey(editor, 'Enter');
-      expect(mutationMock).not.toHaveBeenCalled();
       await vi.waitFor(() =>
         expect(container.textContent).toMatch(/(?:Return|Enter) again to Send/)
       );

--- a/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -477,7 +477,7 @@ describe('MessageComposer', () => {
         new Map([['$$_urql', mockClient]])
       );
 
-      await expect.element(q(container, 'button[title="Send message"]')).toBeInTheDocument();
+      await expect.element(q(container, 'button[aria-label="Send message"]')).toBeInTheDocument();
     });
 
     it('send button is disabled when input is empty', async () => {
@@ -486,7 +486,7 @@ describe('MessageComposer', () => {
         new Map([['$$_urql', mockClient]])
       );
 
-      await expect.element(q(container, 'button[title="Send message"]')).toBeDisabled();
+      await expect.element(q(container, 'button[aria-label="Send message"]')).toBeDisabled();
     });
 
     it('send button has paper plane icon', async () => {
@@ -495,9 +495,51 @@ describe('MessageComposer', () => {
         new Map([['$$_urql', mockClient]])
       );
 
-      const sendButton = q(container, 'button[title="Send message"]');
+      const sendButton = q(container, 'button[aria-label="Send message"]');
       const icon = sendButton?.querySelector('.uil--telegram-alt');
       expect(icon).not.toBeNull();
+    });
+
+    it('shows a compact keyboard shortcut hint when the composer can submit', async () => {
+      const { container } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = await findEditor(container);
+
+      expect(q(container, '[title$="Return to Send"]')).toBeNull();
+      await typeEditorLiteralText(editor, 'hint me');
+
+      await vi.waitFor(() => {
+        const hint = q(container, '[title$="Return to Send"]');
+        expect(hint?.textContent).toMatch(/^(Cmd|Ctrl)\+Return to Send$/);
+      });
+    });
+
+    it('treats an empty block element as sendable composer content', async () => {
+      const { container, roomId } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = await findEditor(container);
+
+      await typeEditorLiteralText(editor, '- ');
+      await vi.waitFor(() => expect(editor.querySelector('ul li')).toBeTruthy());
+
+      await expect.element(q(container, 'button[aria-label="Send message"]')).not.toBeDisabled();
+
+      await vi.waitFor(() => {
+        const hint = q(container, '[title$="Return to Send"]');
+        expect(hint?.textContent).toMatch(/^(Cmd|Ctrl)\+Return to Send$/);
+      });
+
+      await pressEditorKey(editor, 'Enter', { ctrlKey: true });
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({
+        roomId,
+        body: '- '
+      });
     });
   });
 
@@ -514,7 +556,7 @@ describe('MessageComposer', () => {
 
       pasteFile(editor, file);
       await typeInEditor(editor, 'message with image');
-      const sendButton = q(container, 'button[title="Send message"]')! as HTMLButtonElement;
+      const sendButton = q(container, 'button[aria-label="Send message"]')! as HTMLButtonElement;
       await expect.element(sendButton).toBeDisabled();
 
       editor.dispatchEvent(
@@ -544,7 +586,7 @@ describe('MessageComposer', () => {
         new Map([['$$_urql', mockClient]])
       );
       const editor = await findEditor(container);
-      const sendButton = q(container, 'button[title="Send message"]')! as HTMLButtonElement;
+      const sendButton = q(container, 'button[aria-label="Send message"]')! as HTMLButtonElement;
 
       pasteFile(editor, file);
       await expect.element(sendButton).toBeDisabled();
@@ -573,7 +615,7 @@ describe('MessageComposer', () => {
         new Map([['$$_urql', mockClient]])
       );
       const editor = await findEditor(container);
-      const sendButton = q(container, 'button[title="Send message"]')! as HTMLButtonElement;
+      const sendButton = q(container, 'button[aria-label="Send message"]')! as HTMLButtonElement;
 
       pasteFile(editor, imageFile());
       await expect.element(sendButton).toBeDisabled();
@@ -900,7 +942,7 @@ describe('MessageComposer', () => {
         expect(sessionStorage.getItem(`chatto:draft:${roomId}`)).toBe('send and clear draft')
       );
 
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       await vi.waitFor(() => expect(sessionStorage.getItem(`chatto:draft:${roomId}`)).toBeNull());
@@ -956,7 +998,7 @@ describe('MessageComposer', () => {
       document.execCommand('insertText', false, '!');
       await vi.waitFor(() => expect(editor.textContent).toBe(editedBody));
 
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -999,8 +1041,7 @@ describe('MessageComposer', () => {
 
       await vi.waitFor(() => expect(editor.querySelectorAll('pre code')).toHaveLength(1));
       await placeCaretAtEditorEnd(editor);
-      await insertEditorLiteralText(editor, '```js');
-      await pressEditorKey(editor, 'Enter', { shiftKey: true });
+      await insertEditorLiteralText(editor, '```js ');
 
       await vi.waitFor(() => expect(editor.querySelectorAll('pre code')).toHaveLength(2));
       document.execCommand('insertText', false, 'console.log("second");');
@@ -1009,7 +1050,7 @@ describe('MessageComposer', () => {
           'console.log("second");'
         )
       );
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -1020,7 +1061,7 @@ describe('MessageComposer', () => {
   });
 
   describe('submit behavior', () => {
-    it('uses Enter to complete an active mention before Enter can send', async () => {
+    it('uses Enter to complete an active mention before Ctrl+Enter can send', async () => {
       roomStateMock.members = [roomMember('alice')];
       const { container, roomId } = renderMessageComposer(
         { roomId: 'room_456' },
@@ -1038,12 +1079,29 @@ describe('MessageComposer', () => {
       await vi.waitFor(() => expect(editor.textContent).toBe('@alice '));
       expect(mutationMock).not.toHaveBeenCalled();
 
-      await pressEditorKey(editor, 'Enter');
+      await pressEditorKey(editor, 'Enter', { ctrlKey: true });
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
         roomId,
         body: '@alice'
+      });
+    });
+
+    it('sends plain text with Ctrl+Enter', async () => {
+      const { container, roomId } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = await findEditor(container);
+
+      await typeEditorLiteralText(editor, 'hello from shortcut');
+      await pressEditorKey(editor, 'Enter', { ctrlKey: true });
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({
+        roomId,
+        body: 'hello from shortcut'
       });
     });
 
@@ -1056,7 +1114,7 @@ describe('MessageComposer', () => {
 
       await typeEditorKeys(editor, '**bold**');
       await vi.waitFor(() => expect(editor.querySelector('strong')?.textContent).toBe('bold'));
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -1078,7 +1136,7 @@ describe('MessageComposer', () => {
         expect(link?.textContent).toBe('example');
         expect(link?.getAttribute('href')).toBe('https://example.com');
       });
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -1096,7 +1154,7 @@ describe('MessageComposer', () => {
       const editor = await findEditor(container);
 
       await typeInEditor(editor, body);
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -1114,7 +1172,7 @@ describe('MessageComposer', () => {
       const editor = await findEditor(container);
 
       await typeInEditor(editor, body);
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -1132,7 +1190,7 @@ describe('MessageComposer', () => {
       const editor = await findEditor(container);
 
       await typeInEditor(editor, body);
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -1149,7 +1207,7 @@ describe('MessageComposer', () => {
       const editor = await findEditor(container);
 
       await typeInEditor(editor, '> not a quote');
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -1175,7 +1233,7 @@ describe('MessageComposer', () => {
       await vi.waitFor(() =>
         expect(editor.querySelector('a')?.getAttribute('href')).toBe('https://chatto.test/docs')
       );
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -1196,7 +1254,7 @@ describe('MessageComposer', () => {
 
       (q(container, 'button[title="Remove link"]') as HTMLButtonElement).click();
       await vi.waitFor(() => expect(editor.querySelector('a')).toBeNull());
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -1212,15 +1270,14 @@ describe('MessageComposer', () => {
       );
       const editor = await findEditor(container);
 
-      await typeEditorLiteralText(editor, '```ts');
-      await pressEditorKey(editor, 'Enter', { shiftKey: true });
+      await typeEditorLiteralText(editor, '```ts ');
       await vi.waitFor(() => expect(editor.querySelector('pre code')).toBeTruthy());
 
       document.execCommand('insertText', false, 'const answer = 42;');
       await vi.waitFor(() =>
         expect(editor.querySelector('pre code')?.textContent).toContain('const answer = 42;')
       );
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -1237,9 +1294,8 @@ describe('MessageComposer', () => {
       const editor = await findEditor(container);
 
       await typeEditorLiteralText(editor, 'or this:');
-      await pressEditorKey(editor, 'Enter', { shiftKey: true });
-      await insertEditorLiteralText(editor, '```go');
-      await pressEditorKey(editor, 'Enter', { shiftKey: true });
+      await pressEditorKey(editor, 'Enter');
+      await insertEditorLiteralText(editor, '```go ');
 
       await vi.waitFor(() => expect(editor.querySelector('pre code')).toBeTruthy());
       document.execCommand('insertText', false, 'IO.puts("moo")');
@@ -1247,7 +1303,7 @@ describe('MessageComposer', () => {
         expect(editor.querySelector('pre code')?.textContent).toContain('IO.puts("moo")')
       );
 
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -1268,16 +1324,15 @@ describe('MessageComposer', () => {
       await vi.waitFor(() => expect(editor.querySelectorAll('pre code')).toHaveLength(1));
       await placeCaretAtEditorEnd(editor);
       await insertEditorLiteralText(editor, 'or this:');
-      await pressEditorKey(editor, 'Enter', { shiftKey: true });
-      await insertEditorLiteralText(editor, '```go');
-      await pressEditorKey(editor, 'Enter', { shiftKey: true });
+      await pressEditorKey(editor, 'Enter');
+      await insertEditorLiteralText(editor, '```go ');
       await vi.waitFor(() => expect(editor.querySelectorAll('pre code')).toHaveLength(2));
 
       document.execCommand('insertText', false, 'IO.puts("moo")');
       await vi.waitFor(() =>
         expect(editor.querySelectorAll('pre code')[1]?.textContent).toContain('IO.puts("moo")')
       );
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -1293,8 +1348,7 @@ describe('MessageComposer', () => {
       );
       const editor = await findEditor(container);
 
-      await typeEditorLiteralText(editor, '```ts');
-      await pressEditorKey(editor, 'Enter', { shiftKey: true });
+      await typeEditorLiteralText(editor, '```ts ');
       await vi.waitFor(() => expect(editor.querySelector('pre code')).toBeTruthy());
 
       document.execCommand('insertText', false, 'const first = 1;');
@@ -1311,7 +1365,7 @@ describe('MessageComposer', () => {
       );
       expect(editor.querySelectorAll('pre code')).toHaveLength(1);
 
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -1320,42 +1374,26 @@ describe('MessageComposer', () => {
       });
     });
 
-    it('uses Shift+Enter to escape an active code block without submitting', async () => {
+    it('lets Shift+Enter insert a hard break without submitting', async () => {
       const { container, roomId } = renderMessageComposer(
         { roomId: 'room_456' },
         new Map([['$$_urql', mockClient]])
       );
       const editor = await findEditor(container);
 
-      await typeEditorLiteralText(editor, '```ts');
-      await pressEditorKey(editor, 'Enter', { shiftKey: true });
-      await vi.waitFor(() => expect(editor.querySelector('pre code')).toBeTruthy());
-
-      document.execCommand('insertText', false, 'const first = 1;');
-      await vi.waitFor(() =>
-        expect(editor.querySelector('pre code')?.textContent).toContain('const first = 1;')
-      );
+      await typeEditorLiteralText(editor, 'first');
       await pressEditorKey(editor, 'Enter', { shiftKey: true });
       expect(mutationMock).not.toHaveBeenCalled();
+      document.execCommand('insertText', false, 'second');
+      await vi.waitFor(() => expect(editor.textContent).toContain('firstsecond'));
+      expect(editor.querySelector('br')).toBeTruthy();
 
-      document.execCommand('insertText', false, 'between blocks');
-      await vi.waitFor(() => expect(editor.textContent).toContain('between blocks'));
-      await pressEditorKey(editor, 'Enter', { shiftKey: true });
-      await insertEditorLiteralText(editor, '```ts');
-      await pressEditorKey(editor, 'Enter', { shiftKey: true });
-      document.execCommand('insertText', false, 'const second = 2;');
-
-      await vi.waitFor(() => expect(editor.querySelectorAll('pre code')).toHaveLength(2));
-      await vi.waitFor(() =>
-        expect(editor.querySelectorAll('pre code')[1]?.textContent).toContain('const second = 2;')
-      );
-
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
         roomId,
-        body: '```ts\nconst first = 1;\n```\n\nbetween blocks\n\n```ts\nconst second = 2;\n```'
+        body: 'first  \nsecond'
       });
     });
 
@@ -1366,8 +1404,7 @@ describe('MessageComposer', () => {
       );
       const editor = await findEditor(container);
 
-      await typeEditorLiteralText(editor, '```ts');
-      await pressEditorKey(editor, 'Enter', { shiftKey: true });
+      await typeEditorLiteralText(editor, '```ts ');
       await vi.waitFor(() => expect(editor.querySelector('pre code')).toBeTruthy());
       document.execCommand('insertText', false, 'const answer = 42;');
       await vi.waitFor(() =>
@@ -1401,7 +1438,7 @@ describe('MessageComposer', () => {
         expect(editor.querySelectorAll('ul li')[1]?.textContent).toBe('second')
       );
 
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -1410,7 +1447,7 @@ describe('MessageComposer', () => {
       });
     });
 
-    it('sends with Enter only after the cursor has left a bullet list', async () => {
+    it('does not send with Enter after the cursor has left a bullet list', async () => {
       const { container, roomId } = renderMessageComposer(
         { roomId: 'room_456' },
         new Map([['$$_urql', mockClient]])
@@ -1426,6 +1463,11 @@ describe('MessageComposer', () => {
       await vi.waitFor(() => expect(editor.querySelectorAll('ul li')).toHaveLength(1));
 
       await pressEditorKey(editor, 'Enter');
+
+      await vi.waitFor(() => expect(editor.querySelectorAll('p').length).toBeGreaterThan(1));
+      expect(mutationMock).not.toHaveBeenCalled();
+
+      await pressEditorKey(editor, 'Enter', { ctrlKey: true });
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -1469,7 +1511,7 @@ describe('MessageComposer', () => {
       document.execCommand('insertText', false, 'lists');
       await vi.waitFor(() => expect(editor.querySelector('ul li')?.textContent).toBe('lists'));
 
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -1493,7 +1535,7 @@ describe('MessageComposer', () => {
       document.execCommand('insertText', false, 'lists');
       await vi.waitFor(() => expect(editor.querySelector('ol li')?.textContent).toBe('lists'));
 
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -1502,7 +1544,7 @@ describe('MessageComposer', () => {
       });
     });
 
-    it('lets Enter leave a heading before the next Enter can submit', async () => {
+    it('lets Enter leave a heading without submitting', async () => {
       const { container, roomId } = renderMessageComposer(
         { roomId: 'room_456' },
         new Map([['$$_urql', mockClient]])
@@ -1511,12 +1553,17 @@ describe('MessageComposer', () => {
 
       await typeEditorLiteralText(editor, '# Heading');
       await vi.waitFor(() => expect(editor.querySelector('h1')?.textContent).toBe('Heading'));
+      expect(Array.from(editor.children).map((child) => child.tagName)).toEqual(['H1']);
       await pressEditorKey(editor, 'Enter');
       expect(mutationMock).not.toHaveBeenCalled();
 
       document.execCommand('insertText', false, 'body');
       await vi.waitFor(() => expect(editor.querySelector('p')?.textContent).toBe('body'));
+      expect(getComputedStyle(editor.querySelector('p')!).marginTop).toBe('0px');
       await pressEditorKey(editor, 'Enter');
+      expect(mutationMock).not.toHaveBeenCalled();
+
+      await pressEditorKey(editor, 'Enter', { ctrlKey: true });
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -1532,8 +1579,7 @@ describe('MessageComposer', () => {
       );
       const editor = await findEditor(container);
 
-      await typeEditorLiteralText(editor, '```ts');
-      await pressEditorKey(editor, 'Enter', { shiftKey: true });
+      await typeEditorLiteralText(editor, '```ts ');
       await vi.waitFor(() => expect(editor.querySelector('pre code')).toBeTruthy());
       await vi.waitFor(() =>
         expect(editor.querySelector('pre')).toHaveAttribute('data-language', 'ts')
@@ -1554,7 +1600,7 @@ describe('MessageComposer', () => {
         expect(editor.querySelector('pre')).toHaveAttribute('data-language', 'js')
       );
       expect(editor.querySelector('pre code span')).toBeTruthy();
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -1581,7 +1627,7 @@ describe('MessageComposer', () => {
 
       await typeInEditor(editor, 'hello world');
       (q(container, 'input[type="checkbox"]') as HTMLInputElement).click();
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -1628,7 +1674,7 @@ describe('MessageComposer', () => {
       const editor = await findEditor(container);
 
       await typeInEditor(editor, '@all hello');
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await expect.element(getByRole('dialog', { name: 'Notify 12 people?' })).toBeInTheDocument();
       await expect
@@ -1670,7 +1716,7 @@ describe('MessageComposer', () => {
 
       await expect.poll(() => q(container, 'img')).toBeTruthy();
       await typeInEditor(editor, '@all with attachment');
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await expect.element(getByRole('dialog', { name: 'Notify 12 people?' })).toBeInTheDocument();
       expect(mutationMock).toHaveBeenCalledOnce();
@@ -1710,7 +1756,7 @@ describe('MessageComposer', () => {
 
       await expect.poll(() => q(container, 'img')).toBeTruthy();
       await typeInEditor(editor, '@all will retry');
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await expect.element(getByRole('dialog', { name: 'Notify 12 people?' })).toBeInTheDocument();
       await userEvent.click(getByRole('button', { name: 'Send Anyway' }));
@@ -1736,7 +1782,7 @@ describe('MessageComposer', () => {
 
       await expect.poll(() => q(container, 'img')).toBeTruthy();
       await typeInEditor(editor, 'will retry');
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       await expect.element(editor).toHaveTextContent('will retry');
@@ -1781,7 +1827,7 @@ describe('MessageComposer', () => {
       await vi.waitFor(() => expect(queryMock).toHaveBeenCalledTimes(2), { timeout: 1000 });
       await expect.element(q(container, '[data-testid="link-preview-card"]')).toBeInTheDocument();
 
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input.linkPreview).toMatchObject({
@@ -1806,7 +1852,7 @@ describe('MessageComposer', () => {
       await vi.waitFor(() => expect(queryMock).toHaveBeenCalledTimes(2), { timeout: 1000 });
       (q(container, 'button[aria-label="Dismiss preview"]') as HTMLButtonElement).click();
 
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input.linkPreview).toBeNull();
@@ -1837,7 +1883,7 @@ describe('MessageComposer', () => {
       selectFirstAttachment(q(container, 'input[type="file"]') as HTMLInputElement);
       await typeInEditor(editor, 'with file');
 
-      (q(container, 'button[title="Send message"]') as HTMLButtonElement).click();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:test');
@@ -1864,8 +1910,8 @@ describe('MessageComposer', () => {
       );
 
       await expect
-        .element(q(container, 'button[title="Send message"]'))
-        .toHaveAttribute('title', 'Send message');
+        .element(q(container, 'button[aria-label="Send message"]'))
+        .toHaveAttribute('title', 'Send message (Ctrl/Cmd+Enter)');
     });
   });
 });

--- a/frontend/src/lib/components/composer/TipTapEditor.svelte
+++ b/frontend/src/lib/components/composer/TipTapEditor.svelte
@@ -605,12 +605,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     if (selectionFrom.after(1) !== doc.content.size) return false;
 
     const previousNode = doc.child(doc.childCount - 2);
-    if (previousNode.type.name === 'paragraph' && previousNode.content.size > 0) return true;
-    if (previousNode.type.name !== 'paragraph') return false;
-    if (doc.childCount <= 2) return false;
-
-    const nodeBeforePrevious = doc.child(doc.childCount - 3);
-    return nodeBeforePrevious.type.name !== 'paragraph' || nodeBeforePrevious.content.size > 0;
+    return previousNode.type.name !== 'paragraph' || previousNode.content.size > 0;
   }
 
   export type TipTapEditorApi = {

--- a/frontend/src/lib/components/composer/TipTapEditor.svelte
+++ b/frontend/src/lib/components/composer/TipTapEditor.svelte
@@ -12,6 +12,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
 - `onUpdate` - Called with markdown content on each change
 - `onKeyDown` - Keyboard event handler; return true to prevent TipTap default
 - `onPaste` - Paste event handler; return true to prevent TipTap default
+- `onNextEnterWillSendChange` - Called when selection enters/leaves a trailing empty paragraph
 - `onReady` - Called with editor API when editor is initialized
 -->
 <script lang="ts">
@@ -594,6 +595,19 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     return firstChild?.type.name === 'paragraph' && firstChild.content.size === 0;
   }
 
+  function isSelectionInTrailingEmptyParagraph(e: Editor): boolean {
+    const { doc, selection } = e.state;
+    if (!selection.empty || doc.childCount <= 1) return false;
+
+    const selectionFrom = selection.$from;
+    if (selectionFrom.depth !== 1 || selectionFrom.parent.type.name !== 'paragraph') return false;
+    if (selectionFrom.parent.content.size !== 0 || selectionFrom.parentOffset !== 0) return false;
+    if (selectionFrom.after(1) !== doc.content.size) return false;
+
+    const previousNode = doc.child(doc.childCount - 2);
+    return previousNode.type.name !== 'paragraph' || previousNode.content.size > 0;
+  }
+
   export type TipTapEditorApi = {
     /** Get the editor's plain text content */
     getText: () => string;
@@ -621,6 +635,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     onUpdate,
     onKeyDown,
     onPaste,
+    onNextEnterWillSendChange,
     onReady
   }: {
     placeholder?: string;
@@ -630,6 +645,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     onUpdate?: (text: string) => void;
     onKeyDown?: (event: KeyboardEvent) => boolean;
     onPaste?: (event: ClipboardEvent) => boolean;
+    onNextEnterWillSendChange?: (value: boolean) => void;
     onReady?: (api: TipTapEditorApi) => void;
   } = $props();
 
@@ -643,6 +659,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
   let linkHrefDraft = $state('');
   let linkDraftInitializedFor = $state<string | null>(null);
   let codeLanguageLoadToken = 0;
+  let lastNextEnterWillSend = false;
 
   let hasLinkControls = $derived(activeLinkHref !== null);
   let activeCodeBlockLanguageLabel = $derived(
@@ -716,6 +733,13 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
       right: frameRect.right - preRect.right,
       bottom: frameRect.bottom - preRect.bottom
     };
+  }
+
+  function updateNextEnterWillSend(e: Editor) {
+    const value = !e.isDestroyed && isSelectionInTrailingEmptyParagraph(e);
+    if (value === lastNextEnterWillSend) return;
+    lastNextEnterWillSend = value;
+    onNextEnterWillSendChange?.(value);
   }
 
   function updateActiveControls(e: Editor) {
@@ -955,11 +979,13 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
           },
           onUpdate: ({ editor: ed }) => {
             updateActiveControls(ed);
+            updateNextEnterWillSend(ed);
             ensureEditorCodeLanguages(ed);
             onUpdate?.(hasDefaultEmptyDocument(ed) ? '' : getSerializedMarkdown(ed));
           },
           onSelectionUpdate: ({ editor: ed }) => {
             updateActiveControls(ed);
+            updateNextEnterWillSend(ed);
           }
         })
     );
@@ -969,10 +995,13 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     // Notify parent that editor is ready with API
     tick().then(() => {
       if (e.isDestroyed || editor !== e) return;
+      updateNextEnterWillSend(e);
       onReady?.(buildApi(e));
     });
 
     return () => {
+      lastNextEnterWillSend = false;
+      onNextEnterWillSendChange?.(false);
       editor?.destroy();
       editor = null;
     };

--- a/frontend/src/lib/components/composer/TipTapEditor.svelte
+++ b/frontend/src/lib/components/composer/TipTapEditor.svelte
@@ -605,7 +605,12 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     if (selectionFrom.after(1) !== doc.content.size) return false;
 
     const previousNode = doc.child(doc.childCount - 2);
-    return previousNode.type.name !== 'paragraph' || previousNode.content.size > 0;
+    if (previousNode.type.name === 'paragraph' && previousNode.content.size > 0) return true;
+    if (previousNode.type.name !== 'paragraph') return false;
+    if (doc.childCount <= 2) return false;
+
+    const nodeBeforePrevious = doc.child(doc.childCount - 3);
+    return nodeBeforePrevious.type.name !== 'paragraph' || nodeBeforePrevious.content.size > 0;
   }
 
   export type TipTapEditorApi = {
@@ -1125,6 +1130,31 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
   :global(.tiptap-editor .ProseMirror h4),
   :global(.tiptap-editor .ProseMirror h5),
   :global(.tiptap-editor .ProseMirror h6) {
+    margin: 0;
+  }
+
+  :global(.tiptap-editor .ProseMirror > p),
+  :global(.tiptap-editor .ProseMirror > blockquote),
+  :global(.tiptap-editor .ProseMirror > ul),
+  :global(.tiptap-editor .ProseMirror > ol),
+  :global(.tiptap-editor .ProseMirror > h1),
+  :global(.tiptap-editor .ProseMirror > h2),
+  :global(.tiptap-editor .ProseMirror > h3),
+  :global(.tiptap-editor .ProseMirror > h4),
+  :global(.tiptap-editor .ProseMirror > h5),
+  :global(.tiptap-editor .ProseMirror > h6) {
+    margin-block: 0.5em;
+  }
+
+  :global(.tiptap-editor .ProseMirror > :first-child) {
+    margin-top: 0;
+  }
+
+  :global(.tiptap-editor .ProseMirror > :last-child) {
+    margin-bottom: 0;
+  }
+
+  :global(.tiptap-editor .ProseMirror li > p) {
     margin: 0;
   }
 

--- a/frontend/src/lib/components/composer/TipTapEditor.svelte
+++ b/frontend/src/lib/components/composer/TipTapEditor.svelte
@@ -190,70 +190,6 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     }
   });
 
-  const MarkdownCodeFenceShortcut = Extension.create({
-    name: 'markdownCodeFenceShortcut',
-    priority: 1000,
-
-    addKeyboardShortcuts() {
-      return {
-        'Shift-Enter': () => {
-          const { editor } = this;
-          if (editor.isActive('codeBlock')) {
-            return editor.commands.exitCode();
-          }
-
-          const { selection } = editor.state;
-          const { empty } = selection;
-          const fromPos = selection.$from;
-          if (!empty || fromPos.parent.type.name !== 'paragraph') return false;
-          if (fromPos.depth !== 1) return false;
-
-          const textBeforeCursor = fromPos.parent.textBetween(0, fromPos.parentOffset, '\n', '\n');
-          const textAfterCursor = fromPos.parent.textBetween(
-            fromPos.parentOffset,
-            fromPos.parent.content.size,
-            '\n',
-            '\n'
-          );
-          const currentLine = textBeforeCursor.split('\n').at(-1) ?? '';
-          if (textAfterCursor && !textAfterCursor.startsWith('\n')) return false;
-
-          const match = currentLine.match(codeFenceLineRegex);
-          if (!match) return false;
-
-          const paragraphPos = fromPos.before(1);
-          const currentLineIndex = textBeforeCursor.split('\n').length - 1;
-          const appendTrailingParagraph =
-            paragraphPos + fromPos.parent.nodeSize === editor.state.doc.content.size;
-          const replacement = buildCodeFenceReplacement({
-            schema: editor.state.schema,
-            paragraph: fromPos.parent,
-            openLineIndex: currentLineIndex,
-            closeLineIndex: null,
-            appendTrailingParagraph
-          });
-          if (!replacement) return false;
-
-          const codePosition = paragraphPos + replacement.beforeNodeSize;
-          const tr = editor.state.tr.replaceWith(
-            paragraphPos,
-            paragraphPos + fromPos.parent.nodeSize,
-            replacement.nodes
-          );
-          tr.setSelection(TextSelection.create(tr.doc, codePosition + 1));
-          editor.view.dispatch(tr.scrollIntoView());
-          return true;
-        },
-
-        Enter: () => {
-          const { editor } = this;
-          if (!editor.isActive('codeBlock')) return false;
-          return editor.commands.newlineInCode();
-        }
-      };
-    }
-  });
-
   const CompletedMarkdownCodeFence = Extension.create({
     name: 'completedMarkdownCodeFence',
 
@@ -652,6 +588,12 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     );
   }
 
+  function hasDefaultEmptyDocument(e: Editor): boolean {
+    if (e.state.doc.childCount !== 1) return false;
+    const firstChild = e.state.doc.firstChild;
+    return firstChild?.type.name === 'paragraph' && firstChild.content.size === 0;
+  }
+
   export type TipTapEditorApi = {
     /** Get the editor's plain text content */
     getText: () => string;
@@ -663,8 +605,6 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     getTextBeforeCursor: () => string;
     /** Whether the current selection is inside a code block */
     isInCodeBlock: () => boolean;
-    /** Whether the current selection is inside a top-level plain paragraph */
-    isInPlainParagraph: () => boolean;
     /**
      * Replace N characters before the cursor with new text.
      * Used for mention/emoji completion where we know the pattern
@@ -950,11 +890,6 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
       },
 
       isInCodeBlock: () => !e.isDestroyed && e.isActive('codeBlock'),
-      isInPlainParagraph: () => {
-        if (e.isDestroyed) return false;
-        const selectionFrom = e.state.selection.$from;
-        return selectionFrom.depth === 1 && selectionFrom.parent.type.name === 'paragraph';
-      },
 
       replaceTextBeforeCursor: (charCount: number, replacement: string) => {
         if (e.isDestroyed) return;
@@ -987,6 +922,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
               strike: false,
               underline: false,
               horizontalRule: false,
+              trailingNode: false,
               link: {
                 openOnClick: false,
                 enableClickSelection: true
@@ -999,7 +935,6 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
             }),
             ComposerCodeBlockLowlight.configure({ lowlight }),
             MarkdownLinkInputRule,
-            MarkdownCodeFenceShortcut,
             CompletedMarkdownCodeFence,
             MarkdownListMarkerAfterHardBreak,
             TrailingParagraphAfterCodeBlock,
@@ -1021,7 +956,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
           onUpdate: ({ editor: ed }) => {
             updateActiveControls(ed);
             ensureEditorCodeLanguages(ed);
-            onUpdate?.(ed.isEmpty ? '' : getSerializedMarkdown(ed));
+            onUpdate?.(hasDefaultEmptyDocument(ed) ? '' : getSerializedMarkdown(ed));
           },
           onSelectionUpdate: ({ editor: ed }) => {
             updateActiveControls(ed);
@@ -1162,10 +1097,6 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
   :global(.tiptap-editor .ProseMirror h5),
   :global(.tiptap-editor .ProseMirror h6) {
     margin: 0;
-  }
-
-  :global(.tiptap-editor .ProseMirror > * + *) {
-    margin-top: 0.5em;
   }
 
   :global(.tiptap-editor .ProseMirror strong) {

--- a/frontend/src/lib/components/composer/autocomplete.svelte.spec.ts
+++ b/frontend/src/lib/components/composer/autocomplete.svelte.spec.ts
@@ -36,7 +36,6 @@ function editor(
       focus: () => {},
       getTextBeforeCursor: () => text.slice(0, cursor),
       isInCodeBlock: () => false,
-      isInPlainParagraph: () => true,
       replaceTextBeforeCursor: (charCount, replacement) => {
         text = text.slice(0, cursor - charCount) + replacement + text.slice(cursor);
         cursor = cursor - charCount + replacement.length;


### PR DESCRIPTION
## Summary

- Switch composer submission to Ctrl/Cmd+Enter, the send button, or a contextual second Enter from a trailing blank paragraph.
- Remove the custom code-fence shortcut, keep TipTap editing defaults for active blocks, and add OS-aware send hints including `Return again to Send`.
- Restore modest top-level block spacing in the composer so paragraphs after lists/headings render as visible editing lines.
- Update composer unit coverage, e2e helpers, direct send usages, and focused composer e2e coverage for the new shortcut contract.

## Verification

- `pnpm --dir frontend check`
- `pnpm --dir frontend lint`
- `pnpm --dir frontend test:unit -- --run src/lib/components/composer/MessageComposer.svelte.spec.ts src/lib/components/composer/autocomplete.svelte.spec.ts src/lib/components/composer/AutocompletePopup.svelte.spec.ts`
- `pnpm --dir frontend test:e2e -- composer.test.ts --grep "sends when Enter is pressed from a trailing blank paragraph"`
- `pnpm --dir frontend test:e2e -- composer.test.ts --grep "sends when Enter is pressed from a trailing blank paragraph|sends from the visible trailing paragraph after exiting a list"`
- Targeted Playwright e2e suites for composer, messages, editing, threading, attachments, and link previews
- Chrome DevTools browser verification for Enter, Shift+Enter, Ctrl/Cmd+Enter, send button, heading spacing, shortcut hints, empty structural blocks, code blocks, and lists
