### PR TITLE
feat: add notification sound shaping controls

### DIFF
--- a/docs/fdr/FDR-012-notifications.md
+++ b/docs/fdr/FDR-012-notifications.md
@@ -15,6 +15,7 @@ Chatto has a persistent notification system surfaced through a bell icon and not
 - Notifications auto-expire after 90 days.
 - Dismissing a notification removes it everywhere — across all the user's open tabs and devices.
 - A notification sound plays and the badge updates in real time as new notifications arrive.
+- Users can choose and locally shape the notification sound on each browser with volume, tone, and effect controls.
 - Sidebar orange dots for mentions, replies, DMs, and all-message subscriptions derive from pending notification records.
 
 ## Notification Levels
@@ -82,6 +83,12 @@ Per space and per room, the user picks one of four levels:
 **Decision:** @mention orange dots are derived from pending mention notifications. Chatto does not maintain a separate `room_mention_status.*` flag.
 **Why:** The separate flag duplicated notification state and had to be cleared in lockstep with notification dismissals and room reads. A single pending-notification model gives one source of truth for mention, reply, DM, and all-message attention indicators.
 **Tradeoff:** Pending mention dots now have the same retention and dismissal semantics as notifications. This is deliberate: a mention that is no longer a pending notification is no longer pending attention.
+
+### 9. Notification sound choice and shaping are local
+
+**Decision:** Notification sound selection and sound-shaping controls are stored in browser-local preferences.
+**Why:** They are playback-device preferences, not server behavior. Keeping them local matches the existing sound picker and avoids adding durable compatibility surface for an annoyance/subtlety control.
+**Tradeoff:** A user who signs in on a new browser reconfigures sound taste there. Server-synced display settings remain separate.
 
 ## Permissions
 

--- a/frontend/src/lib/audio/notificationSounds.spec.ts
+++ b/frontend/src/lib/audio/notificationSounds.spec.ts
@@ -1,0 +1,202 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+class FakeAudioParam {
+  value = 0;
+
+  setValueAtTime = vi.fn();
+  linearRampToValueAtTime = vi.fn();
+  exponentialRampToValueAtTime = vi.fn();
+  cancelScheduledValues = vi.fn();
+}
+
+class FakeAudioNode {
+  static instances: FakeAudioNode[] = [];
+
+  connections: FakeAudioNode[] = [];
+  disconnectCalls = 0;
+
+  constructor(readonly kind: string) {
+    FakeAudioNode.instances.push(this);
+  }
+
+  connect(destination: FakeAudioNode | FakeAudioParam) {
+    if (destination instanceof FakeAudioNode) {
+      this.connections.push(destination);
+    }
+    return destination;
+  }
+
+  disconnect() {
+    this.disconnectCalls += 1;
+    this.connections = [];
+  }
+}
+
+class FakeOscillatorNode extends FakeAudioNode {
+  frequency = new FakeAudioParam();
+  type: OscillatorType = 'sine';
+
+  constructor() {
+    super('oscillator');
+  }
+
+  start = vi.fn();
+  stop = vi.fn();
+}
+
+class FakeBufferSourceNode extends FakeAudioNode {
+  buffer: FakeAudioBuffer | null = null;
+
+  constructor() {
+    super('buffer-source');
+  }
+
+  start = vi.fn();
+  stop = vi.fn();
+}
+
+class FakeGainNode extends FakeAudioNode {
+  gain = new FakeAudioParam();
+
+  constructor() {
+    super('gain');
+  }
+}
+
+class FakeBiquadFilterNode extends FakeAudioNode {
+  frequency = new FakeAudioParam();
+  Q = new FakeAudioParam();
+  type: BiquadFilterType = 'lowpass';
+
+  constructor() {
+    super('biquad-filter');
+  }
+}
+
+class FakeDelayNode extends FakeAudioNode {
+  delayTime = new FakeAudioParam();
+
+  constructor() {
+    super('delay');
+  }
+}
+
+class FakeWaveShaperNode extends FakeAudioNode {
+  curve: Float32Array<ArrayBuffer> | null = null;
+  oversample: OverSampleType = 'none';
+
+  constructor() {
+    super('wave-shaper');
+  }
+}
+
+class FakeConvolverNode extends FakeAudioNode {
+  buffer: FakeAudioBuffer | null = null;
+
+  constructor() {
+    super('convolver');
+  }
+}
+
+class FakeAudioBuffer {
+  readonly numberOfChannels: number;
+  readonly channels: Float32Array<ArrayBuffer>[];
+
+  constructor(channels: number, length: number) {
+    this.numberOfChannels = channels;
+    this.channels = Array.from(
+      { length: channels },
+      () => new Float32Array(new ArrayBuffer(length * Float32Array.BYTES_PER_ELEMENT))
+    );
+  }
+
+  getChannelData(channel: number) {
+    return this.channels[channel];
+  }
+}
+
+class FakeAudioContext {
+  static instances: FakeAudioContext[] = [];
+
+  currentTime = 0;
+  sampleRate = 100;
+  state: AudioContextState = 'running';
+  destination = new FakeAudioNode('destination');
+
+  constructor() {
+    FakeAudioContext.instances.push(this);
+  }
+
+  resume = vi.fn().mockResolvedValue(undefined);
+  createOscillator = vi.fn(() => new FakeOscillatorNode());
+  createBufferSource = vi.fn(() => new FakeBufferSourceNode());
+  createGain = vi.fn(() => new FakeGainNode());
+  createBiquadFilter = vi.fn(() => new FakeBiquadFilterNode());
+  createDelay = vi.fn(() => new FakeDelayNode());
+  createWaveShaper = vi.fn(() => new FakeWaveShaperNode());
+  createConvolver = vi.fn(() => new FakeConvolverNode());
+  createBuffer = vi.fn((channels: number, length: number) => new FakeAudioBuffer(channels, length));
+}
+
+describe('notificationSounds', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    FakeAudioNode.instances = [];
+    FakeAudioContext.instances = [];
+    vi.stubGlobal('AudioContext', FakeAudioContext);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('fades the previous sound graph before disconnecting it', async () => {
+    expect.assertions(6);
+
+    const { defaultNotificationSoundFilters, playNotificationSound } =
+      await import('./notificationSounds');
+
+    const firstPlayback = playNotificationSound('ding', {
+      ...defaultNotificationSoundFilters,
+      echo: 100,
+      reverb: 100,
+      crunch: 100
+    });
+    const firstPlaybackNodes = [...FakeAudioNode.instances];
+    const destination = FakeAudioContext.instances[0].destination;
+    const firstOutput = firstPlaybackNodes.find(
+      (node): node is FakeGainNode =>
+        node instanceof FakeGainNode && node.connections.includes(destination)
+    );
+
+    expect(firstPlaybackNodes.some((node) => node.kind === 'delay')).toBe(true);
+    expect(firstPlaybackNodes.some((node) => node.kind === 'convolver')).toBe(true);
+    expect(firstOutput).toBeDefined();
+
+    const secondPlayback = playNotificationSound('pop', defaultNotificationSoundFilters);
+
+    expect(firstOutput?.gain.linearRampToValueAtTime).toHaveBeenCalledWith(0, 0.04);
+    expect(
+      firstPlaybackNodes
+        .filter((node) =>
+          ['biquad-filter', 'delay', 'convolver', 'wave-shaper'].includes(node.kind)
+        )
+        .some((node) => node.disconnectCalls > 0)
+    ).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(40);
+
+    expect(
+      firstPlaybackNodes
+        .filter((node) =>
+          ['biquad-filter', 'delay', 'convolver', 'wave-shaper'].includes(node.kind)
+        )
+        .every((node) => node.disconnectCalls > 0)
+    ).toBe(true);
+
+    await vi.runAllTimersAsync();
+    await Promise.all([firstPlayback, secondPlayback]);
+  });
+});

--- a/frontend/src/lib/audio/notificationSounds.ts
+++ b/frontend/src/lib/audio/notificationSounds.ts
@@ -52,6 +52,30 @@ export interface NotificationSound {
   category: SoundCategory;
 }
 
+export interface NotificationSoundFilters {
+  /** Master output gain. 1 is the original synthesized volume. */
+  volume: number;
+  /** High-pass cutoff in Hz. 20 is treated as effectively off. */
+  highPassHz: number;
+  /** Low-pass cutoff in Hz. 20000 is treated as effectively off. */
+  lowPassHz: number;
+  /** Delay/echo amount from 0 to 100. */
+  echo: number;
+  /** Synthetic room reverb amount from 0 to 100. */
+  reverb: number;
+  /** Wave-shaping distortion amount from 0 to 100. */
+  crunch: number;
+}
+
+export const defaultNotificationSoundFilters: NotificationSoundFilters = {
+  volume: 1,
+  highPassHz: 20,
+  lowPassHz: 20000,
+  echo: 0,
+  reverb: 0,
+  crunch: 0
+};
+
 export const notificationSounds: NotificationSound[] = [
   // Silent
   { id: 'silent', name: 'Silent', category: 'Silent' },
@@ -106,30 +130,226 @@ export const soundCategories: SoundCategory[] = [
 
 // Lazy-initialized AudioContext (created on first user interaction)
 let audioCtx: AudioContext | null = null;
+const reverbImpulseCache = new WeakMap<AudioContext, Map<number, AudioBuffer>>();
+const activeOutputCleanups = new Set<() => void>();
+const OUTPUT_CLEANUP_DELAY_MS = 5_000;
+const OUTPUT_FADE_OUT_SECONDS = 0.04;
 
 function getContext(): AudioContext {
-  if (!audioCtx) {
+  if (!audioCtx || audioCtx.state === 'closed') {
     audioCtx = new AudioContext();
   }
   // Resume if suspended (browsers suspend until user interaction)
   if (audioCtx.state === 'suspended') {
-    audioCtx.resume();
+    void audioCtx.resume();
   }
   return audioCtx;
+}
+
+function stopActiveNotificationSounds() {
+  for (const cleanup of Array.from(activeOutputCleanups)) {
+    cleanup();
+  }
+}
+
+function registerOutputCleanup(ctx: AudioContext, nodes: AudioNode[], output: GainNode) {
+  let cleaned = false;
+
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
+
+    const now = ctx.currentTime;
+    output.gain.cancelScheduledValues(now);
+    output.gain.setValueAtTime(output.gain.value, now);
+    output.gain.linearRampToValueAtTime(0, now + OUTPUT_FADE_OUT_SECONDS);
+
+    setTimeout(() => {
+      for (const node of nodes) {
+        try {
+          node.disconnect();
+        } catch {
+          // Some browsers throw if the node has already been disconnected.
+        }
+      }
+
+      activeOutputCleanups.delete(cleanup);
+    }, OUTPUT_FADE_OUT_SECONDS * 1_000);
+  };
+
+  activeOutputCleanups.add(cleanup);
+  setTimeout(cleanup, OUTPUT_CLEANUP_DELAY_MS);
+}
+
+function createNotificationOutput(
+  ctx: AudioContext,
+  filters: NotificationSoundFilters
+): BiquadFilterNode {
+  const highPass = ctx.createBiquadFilter();
+  const lowPass = ctx.createBiquadFilter();
+  const shaped = ctx.createGain();
+  const gain = ctx.createGain();
+  const output = ctx.createGain();
+  const nodes: AudioNode[] = [highPass, lowPass, shaped, gain, output];
+
+  highPass.type = 'highpass';
+  highPass.frequency.value = filters.highPassHz;
+
+  lowPass.type = 'lowpass';
+  lowPass.frequency.value = filters.lowPassHz;
+
+  applyCrunch(ctx, lowPass, shaped, filters.crunch / 100, nodes);
+
+  gain.gain.value = filters.volume;
+  output.gain.value = 1;
+
+  highPass.connect(lowPass);
+  shaped.connect(gain);
+  gain.connect(output);
+  output.connect(ctx.destination);
+  applyEcho(ctx, gain, output, filters.echo / 100, nodes);
+  applyReverb(ctx, gain, output, filters.reverb / 100, nodes);
+
+  registerOutputCleanup(ctx, nodes, output);
+
+  return highPass;
+}
+
+function applyCrunch(
+  ctx: AudioContext,
+  input: AudioNode,
+  output: AudioNode,
+  amount: number,
+  nodes: AudioNode[]
+) {
+  if (amount <= 0) {
+    input.connect(output);
+    return;
+  }
+
+  const dry = ctx.createGain();
+  const wet = ctx.createGain();
+  const shaper = ctx.createWaveShaper();
+  nodes.push(dry, wet, shaper);
+
+  dry.gain.value = 1 - amount * 0.25;
+  wet.gain.value = amount * 0.75;
+  shaper.curve = createCrunchCurve(amount);
+  shaper.oversample = '2x';
+
+  input.connect(dry);
+  dry.connect(output);
+  input.connect(shaper);
+  shaper.connect(wet);
+  wet.connect(output);
+}
+
+function applyEcho(
+  ctx: AudioContext,
+  input: AudioNode,
+  output: AudioNode,
+  amount: number,
+  nodes: AudioNode[]
+) {
+  if (amount <= 0) return;
+
+  const delay = ctx.createDelay(0.8);
+  const feedback = ctx.createGain();
+  const wet = ctx.createGain();
+  nodes.push(delay, feedback, wet);
+
+  delay.delayTime.value = 0.08 + amount * 0.22;
+  feedback.gain.value = 0.12 + amount * 0.48;
+  wet.gain.value = amount * 0.55;
+
+  input.connect(delay);
+  delay.connect(wet);
+  wet.connect(output);
+  delay.connect(feedback);
+  feedback.connect(delay);
+}
+
+function applyReverb(
+  ctx: AudioContext,
+  input: AudioNode,
+  output: AudioNode,
+  amount: number,
+  nodes: AudioNode[]
+) {
+  if (amount <= 0) return;
+
+  const convolver = ctx.createConvolver();
+  const wet = ctx.createGain();
+  nodes.push(convolver, wet);
+
+  convolver.buffer = getReverbImpulse(ctx, amount);
+  wet.gain.value = amount * 0.45;
+
+  input.connect(convolver);
+  convolver.connect(wet);
+  wet.connect(output);
+}
+
+function createCrunchCurve(amount: number): Float32Array<ArrayBuffer> {
+  const samples = 256;
+  const curve: Float32Array<ArrayBuffer> = new Float32Array(
+    new ArrayBuffer(samples * Float32Array.BYTES_PER_ELEMENT)
+  );
+  const drive = 1 + amount * 45;
+
+  for (let i = 0; i < samples; i += 1) {
+    const x = (i * 2) / samples - 1;
+    curve[i] = ((1 + drive) * x) / (1 + drive * Math.abs(x));
+  }
+
+  return curve;
+}
+
+function getReverbImpulse(ctx: AudioContext, amount: number): AudioBuffer {
+  const cacheKey = Math.round(amount * 100);
+  let cache = reverbImpulseCache.get(ctx);
+  if (!cache) {
+    cache = new Map();
+    reverbImpulseCache.set(ctx, cache);
+  }
+
+  const cached = cache.get(cacheKey);
+  if (cached) return cached;
+
+  const sampleRate = ctx.sampleRate;
+  const duration = 0.18 + amount * 1.1;
+  const length = Math.max(1, Math.floor(sampleRate * duration));
+  const impulse = ctx.createBuffer(2, length, sampleRate);
+  const decay = 1.4 + amount * 2.2;
+
+  for (let channel = 0; channel < impulse.numberOfChannels; channel += 1) {
+    const data = impulse.getChannelData(channel);
+    for (let i = 0; i < length; i += 1) {
+      const t = i / length;
+      data[i] = (Math.random() * 2 - 1) * (1 - t) ** decay;
+    }
+  }
+
+  cache.set(cacheKey, impulse);
+  return impulse;
 }
 
 /**
  * Play a notification sound by ID.
  * Returns a promise that resolves when the sound finishes.
  */
-export function playNotificationSound(soundId: NotificationSoundId): Promise<void> {
+export function playNotificationSound(
+  soundId: NotificationSoundId,
+  filters: NotificationSoundFilters = defaultNotificationSoundFilters
+): Promise<void> {
   if (soundId === 'silent') {
     return Promise.resolve();
   }
 
   const player = soundPlayers[soundId];
   if (player) {
-    return player();
+    stopActiveNotificationSounds();
+    return player(filters);
   }
 
   console.warn(`Unknown notification sound: ${soundId}`);
@@ -137,20 +357,23 @@ export function playNotificationSound(soundId: NotificationSoundId): Promise<voi
 }
 
 // Sound player functions
-const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
+const soundPlayers: Record<
+  NotificationSoundId,
+  (filters: NotificationSoundFilters) => Promise<void>
+> = {
   silent: () => Promise.resolve(),
 
   // ============================================================================
   // SIMPLE - Clean, professional notification sounds
   // ============================================================================
 
-  ding: () => {
+  ding: (filters) => {
     const ctx = getContext();
     const osc = ctx.createOscillator();
     const gain = ctx.createGain();
 
     osc.connect(gain);
-    gain.connect(ctx.destination);
+    gain.connect(createNotificationOutput(ctx, filters));
 
     osc.frequency.value = 880;
     osc.type = 'sine';
@@ -164,7 +387,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     return delay(400);
   },
 
-  'chime-up': () => {
+  'chime-up': (filters) => {
     const ctx = getContext();
 
     [659.25, 880].forEach((freq, i) => {
@@ -172,7 +395,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
       const gain = ctx.createGain();
 
       osc.connect(gain);
-      gain.connect(ctx.destination);
+      gain.connect(createNotificationOutput(ctx, filters));
 
       osc.frequency.value = freq;
       osc.type = 'sine';
@@ -188,7 +411,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     return delay(420);
   },
 
-  'chime-down': () => {
+  'chime-down': (filters) => {
     const ctx = getContext();
 
     [880, 659.25].forEach((freq, i) => {
@@ -196,7 +419,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
       const gain = ctx.createGain();
 
       osc.connect(gain);
-      gain.connect(ctx.destination);
+      gain.connect(createNotificationOutput(ctx, filters));
 
       osc.frequency.value = freq;
       osc.type = 'sine';
@@ -212,13 +435,13 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     return delay(420);
   },
 
-  pop: () => {
+  pop: (filters) => {
     const ctx = getContext();
     const osc = ctx.createOscillator();
     const gain = ctx.createGain();
 
     osc.connect(gain);
-    gain.connect(ctx.destination);
+    gain.connect(createNotificationOutput(ctx, filters));
 
     osc.frequency.setValueAtTime(600, ctx.currentTime);
     osc.frequency.exponentialRampToValueAtTime(200, ctx.currentTime + 0.1);
@@ -233,13 +456,13 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     return delay(100);
   },
 
-  bubble: () => {
+  bubble: (filters) => {
     const ctx = getContext();
     const osc = ctx.createOscillator();
     const gain = ctx.createGain();
 
     osc.connect(gain);
-    gain.connect(ctx.destination);
+    gain.connect(createNotificationOutput(ctx, filters));
 
     osc.frequency.setValueAtTime(400, ctx.currentTime);
     osc.frequency.exponentialRampToValueAtTime(800, ctx.currentTime + 0.1);
@@ -259,13 +482,13 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
   // PLAYFUL - Retro gaming sounds
   // ============================================================================
 
-  retro: () => {
+  retro: (filters) => {
     const ctx = getContext();
     const osc = ctx.createOscillator();
     const gain = ctx.createGain();
 
     osc.connect(gain);
-    gain.connect(ctx.destination);
+    gain.connect(createNotificationOutput(ctx, filters));
 
     osc.type = 'square';
     osc.frequency.setValueAtTime(440, ctx.currentTime);
@@ -281,7 +504,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     return delay(200);
   },
 
-  coin: () => {
+  coin: (filters) => {
     const ctx = getContext();
 
     // Classic coin sound: first note short, second note sustains longer
@@ -295,7 +518,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
       const gain = ctx.createGain();
 
       osc.connect(gain);
-      gain.connect(ctx.destination);
+      gain.connect(createNotificationOutput(ctx, filters));
 
       osc.frequency.value = freq;
       osc.type = 'square';
@@ -311,7 +534,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     return delay(280);
   },
 
-  powerup: () => {
+  powerup: (filters) => {
     const ctx = getContext();
 
     const notes = [262, 330, 392, 523, 659, 784];
@@ -320,7 +543,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
       const gain = ctx.createGain();
 
       osc.connect(gain);
-      gain.connect(ctx.destination);
+      gain.connect(createNotificationOutput(ctx, filters));
 
       osc.type = 'square';
       osc.frequency.value = freq;
@@ -336,7 +559,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     return delay(400);
   },
 
-  fanfare: () => {
+  fanfare: (filters) => {
     const ctx = getContext();
 
     const melody = [
@@ -351,7 +574,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
       const gain = ctx.createGain();
 
       osc.connect(gain);
-      gain.connect(ctx.destination);
+      gain.connect(createNotificationOutput(ctx, filters));
 
       osc.type = 'square';
       osc.frequency.value = freq;
@@ -368,13 +591,13 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     return delay(550);
   },
 
-  laser: () => {
+  laser: (filters) => {
     const ctx = getContext();
     const osc = ctx.createOscillator();
     const gain = ctx.createGain();
 
     osc.connect(gain);
-    gain.connect(ctx.destination);
+    gain.connect(createNotificationOutput(ctx, filters));
 
     osc.type = 'sawtooth';
     osc.frequency.setValueAtTime(1500, ctx.currentTime);
@@ -389,7 +612,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     return delay(150);
   },
 
-  'la-cucaracha': () => {
+  'la-cucaracha': (filters) => {
     const ctx = getContext();
 
     // Classic "La Cucaracha" horn melody: C-C-C-F-A
@@ -407,7 +630,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
       const gain = ctx.createGain();
 
       osc.connect(gain);
-      gain.connect(ctx.destination);
+      gain.connect(createNotificationOutput(ctx, filters));
 
       osc.type = 'square';
       osc.frequency.value = freq;
@@ -428,7 +651,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
   // ROBOTS - Bleeps, bloops, and digital voices
   // ============================================================================
 
-  robot: () => {
+  robot: (filters) => {
     const ctx = getContext();
 
     const notes = [200, 250, 200, 300];
@@ -439,7 +662,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
 
       osc.connect(gain);
       osc2.connect(gain);
-      gain.connect(ctx.destination);
+      gain.connect(createNotificationOutput(ctx, filters));
 
       osc.type = 'square';
       osc2.type = 'square';
@@ -459,7 +682,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     return delay(350);
   },
 
-  ufo: () => {
+  ufo: (filters) => {
     const ctx = getContext();
     const osc = ctx.createOscillator();
     const lfo = ctx.createOscillator();
@@ -470,7 +693,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     lfoGain.connect(osc.frequency);
 
     osc.connect(gain);
-    gain.connect(ctx.destination);
+    gain.connect(createNotificationOutput(ctx, filters));
 
     osc.type = 'sine';
     osc.frequency.value = 600;
@@ -490,7 +713,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     return delay(400);
   },
 
-  beepboop: () => {
+  beepboop: (filters) => {
     const ctx = getContext();
 
     // Classic robot "beep boop" pattern
@@ -507,7 +730,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
       const gain = ctx.createGain();
 
       osc.connect(gain);
-      gain.connect(ctx.destination);
+      gain.connect(createNotificationOutput(ctx, filters));
 
       osc.type = 'square';
       osc.frequency.value = freq;
@@ -524,7 +747,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     return delay(500);
   },
 
-  dialup: () => {
+  dialup: (filters) => {
     const ctx = getContext();
 
     // Simulated dial-up modem handshake sounds
@@ -534,7 +757,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
 
     osc.connect(gain);
     osc2.connect(gain);
-    gain.connect(ctx.destination);
+    gain.connect(createNotificationOutput(ctx, filters));
 
     osc.type = 'square';
     osc2.type = 'sawtooth';
@@ -561,7 +784,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     return delay(400);
   },
 
-  r2d2: () => {
+  r2d2: (filters) => {
     const ctx = getContext();
 
     // R2-D2 style excited beeping
@@ -579,7 +802,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
       const gain = ctx.createGain();
 
       osc.connect(gain);
-      gain.connect(ctx.destination);
+      gain.connect(createNotificationOutput(ctx, filters));
 
       osc.type = 'sine';
       // Add slight frequency wobble
@@ -602,7 +825,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
   // MUSICAL - Melodies and harmonies
   // ============================================================================
 
-  harp: () => {
+  harp: (filters) => {
     const ctx = getContext();
 
     const notes = [523, 659, 784, 1047, 1319, 1568, 1319, 1047];
@@ -613,7 +836,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
 
       osc.connect(gain);
       osc2.connect(gain);
-      gain.connect(ctx.destination);
+      gain.connect(createNotificationOutput(ctx, filters));
 
       osc.type = 'triangle';
       osc2.type = 'sine';
@@ -636,7 +859,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     return delay(620);
   },
 
-  'music-box': () => {
+  'music-box': (filters) => {
     const ctx = getContext();
 
     const melody = [
@@ -653,7 +876,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
       const gain = ctx.createGain();
 
       osc.connect(gain);
-      gain.connect(ctx.destination);
+      gain.connect(createNotificationOutput(ctx, filters));
 
       osc.type = 'sine';
       osc.frequency.value = freq;
@@ -669,7 +892,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
       const harm = ctx.createOscillator();
       const harmGain = ctx.createGain();
       harm.connect(harmGain);
-      harmGain.connect(ctx.destination);
+      harmGain.connect(createNotificationOutput(ctx, filters));
 
       harm.type = 'sine';
       harm.frequency.value = freq * 2;
@@ -685,7 +908,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     return delay(850);
   },
 
-  celesta: () => {
+  celesta: (filters) => {
     const ctx = getContext();
 
     const melody = [
@@ -702,7 +925,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
       const gain = ctx.createGain();
 
       osc.connect(gain);
-      gain.connect(ctx.destination);
+      gain.connect(createNotificationOutput(ctx, filters));
 
       osc.type = 'sine';
       osc.frequency.value = freq;
@@ -720,7 +943,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
         const harmGain = ctx.createGain();
 
         harm.connect(harmGain);
-        harmGain.connect(ctx.destination);
+        harmGain.connect(createNotificationOutput(ctx, filters));
 
         harm.type = 'sine';
         harm.frequency.value = freq * mult;
@@ -738,7 +961,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     return delay(1000);
   },
 
-  synth: () => {
+  synth: (filters) => {
     const ctx = getContext();
 
     const chord = [440, 523.25, 659.25, 783.99];
@@ -752,7 +975,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
       osc.connect(filter);
       osc2.connect(filter);
       filter.connect(gain);
-      gain.connect(ctx.destination);
+      gain.connect(createNotificationOutput(ctx, filters));
 
       osc.type = 'sawtooth';
       osc2.type = 'sawtooth';
@@ -779,7 +1002,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     return delay(400);
   },
 
-  orchestra: () => {
+  orchestra: (filters) => {
     const ctx = getContext();
 
     const notes: Array<{ freq: number; type: OscillatorType }> = [
@@ -798,7 +1021,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
 
       osc.connect(filter);
       filter.connect(gain);
-      gain.connect(ctx.destination);
+      gain.connect(createNotificationOutput(ctx, filters));
 
       osc.type = type;
       osc.frequency.value = freq;
@@ -823,7 +1046,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
   // HERE BE DRAGONS - Absolute madness
   // ============================================================================
 
-  chaos: () => {
+  chaos: (filters) => {
     const ctx = getContext();
 
     // Random frequency chaos with multiple oscillators
@@ -832,7 +1055,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
       const gain = ctx.createGain();
 
       osc.connect(gain);
-      gain.connect(ctx.destination);
+      gain.connect(createNotificationOutput(ctx, filters));
 
       osc.type = ['sine', 'square', 'sawtooth', 'triangle'][
         Math.floor(Math.random() * 4)
@@ -855,7 +1078,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     return delay(500);
   },
 
-  glitch: () => {
+  glitch: (filters) => {
     const ctx = getContext();
 
     // Digital glitch - rapid frequency jumping with bit-crushed feel
@@ -863,7 +1086,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     const gain = ctx.createGain();
 
     osc.connect(gain);
-    gain.connect(ctx.destination);
+    gain.connect(createNotificationOutput(ctx, filters));
 
     osc.type = 'square';
 
@@ -895,7 +1118,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
 
       const noiseGain = ctx.createGain();
       noise.connect(noiseGain);
-      noiseGain.connect(ctx.destination);
+      noiseGain.connect(createNotificationOutput(ctx, filters));
 
       const startTime = ctx.currentTime + i * 0.1 + 0.05;
       noiseGain.gain.setValueAtTime(0.1, startTime);
@@ -908,7 +1131,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     return delay(350);
   },
 
-  siren: () => {
+  siren: (filters) => {
     const ctx = getContext();
 
     // Crazy alert siren with multiple phases
@@ -918,7 +1141,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
 
     osc.connect(gain);
     osc2.connect(gain);
-    gain.connect(ctx.destination);
+    gain.connect(createNotificationOutput(ctx, filters));
 
     osc.type = 'sawtooth';
     osc2.type = 'square';
@@ -948,7 +1171,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     return delay(600);
   },
 
-  dubstep: () => {
+  dubstep: (filters) => {
     const ctx = getContext();
 
     // Wobble bass drop
@@ -963,7 +1186,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
 
     osc.connect(filter);
     filter.connect(gain);
-    gain.connect(ctx.destination);
+    gain.connect(createNotificationOutput(ctx, filters));
 
     osc.type = 'sawtooth';
     osc.frequency.setValueAtTime(55, ctx.currentTime); // Low bass
@@ -993,7 +1216,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     const sub = ctx.createOscillator();
     const subGain = ctx.createGain();
     sub.connect(subGain);
-    subGain.connect(ctx.destination);
+    subGain.connect(createNotificationOutput(ctx, filters));
 
     sub.type = 'sine';
     sub.frequency.setValueAtTime(60, ctx.currentTime);
@@ -1008,7 +1231,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
     return delay(700);
   },
 
-  circus: () => {
+  circus: (filters) => {
     const ctx = getContext();
 
     // Chaotic circus calliope melody
@@ -1032,7 +1255,7 @@ const soundPlayers: Record<NotificationSoundId, () => Promise<void>> = {
 
       osc.connect(gain);
       osc2.connect(gain);
-      gain.connect(ctx.destination);
+      gain.connect(createNotificationOutput(ctx, filters));
 
       // Slightly detuned for that out-of-tune calliope feel
       osc.type = 'square';

--- a/frontend/src/lib/components/NotificationSync.svelte
+++ b/frontend/src/lib/components/NotificationSync.svelte
@@ -39,7 +39,10 @@ Include this component once in the chat layout (unconditionally).
         if (event.event.__typename === 'NotificationCreatedEvent') {
           notificationStore.addNotification();
           stores.rooms.incrementUnreadNotification(event.event.roomId);
-          playNotificationSound(userPreferences.notificationSound);
+          playNotificationSound(
+            userPreferences.notificationSound,
+            userPreferences.notificationSoundFilters
+          );
         }
 
         if (event.event.__typename === 'NotificationDismissedEvent') {

--- a/frontend/src/lib/state/userPreferences.svelte.spec.ts
+++ b/frontend/src/lib/state/userPreferences.svelte.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { defaultSoundId } from '$lib/audio/notificationSounds';
+import { defaultNotificationSoundFilters, defaultSoundId } from '$lib/audio/notificationSounds';
 import { UserPreferencesState } from './userPreferences.svelte';
 
 const STORAGE_KEY = 'chatto:preferences';
@@ -13,12 +13,60 @@ describe('UserPreferencesState', () => {
     it('uses the default sound when storage is empty', () => {
       const state = new UserPreferencesState();
       expect(state.notificationSound).toBe(defaultSoundId);
+      expect(state.notificationSoundFilters).toEqual(defaultNotificationSoundFilters);
     });
 
     it('hydrates a valid persisted sound', () => {
       localStorage.setItem(STORAGE_KEY, JSON.stringify({ notificationSound: 'silent' }));
       const state = new UserPreferencesState();
       expect(state.notificationSound).toBe('silent');
+      expect(state.notificationSoundFilters).toEqual(defaultNotificationSoundFilters);
+    });
+
+    it('hydrates valid persisted notification sound filters', () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          notificationSound: 'pop',
+          notificationSoundFilters: {
+            volume: 1.5,
+            highPassHz: 500,
+            lowPassHz: 8000,
+            echo: 45,
+            reverb: 30,
+            crunch: 75
+          }
+        })
+      );
+
+      const state = new UserPreferencesState();
+      expect(state.notificationSound).toBe('pop');
+      expect(state.notificationSoundFilters).toEqual({
+        volume: 1.5,
+        highPassHz: 500,
+        lowPassHz: 8000,
+        echo: 45,
+        reverb: 30,
+        crunch: 75
+      });
+    });
+
+    it('merges partial stored notification sound filters with defaults', () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          notificationSound: 'pop',
+          notificationSoundFilters: {
+            volume: 0.35
+          }
+        })
+      );
+
+      const state = new UserPreferencesState();
+      expect(state.notificationSoundFilters).toEqual({
+        ...defaultNotificationSoundFilters,
+        volume: 0.35
+      });
     });
 
     it('falls back to default when stored sound id is invalid', () => {
@@ -31,6 +79,33 @@ describe('UserPreferencesState', () => {
       localStorage.setItem(STORAGE_KEY, 'not-json');
       const state = new UserPreferencesState();
       expect(state.notificationSound).toBe(defaultSoundId);
+    });
+
+    it('falls back to safe filter values when stored filters are invalid', () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          notificationSound: 'pop',
+          notificationSoundFilters: {
+            volume: 7,
+            highPassHz: -1,
+            lowPassHz: 'loud',
+            echo: 101,
+            reverb: Number.NaN,
+            crunch: 'yes'
+          }
+        })
+      );
+
+      const state = new UserPreferencesState();
+      expect(state.notificationSoundFilters).toEqual({
+        volume: defaultNotificationSoundFilters.volume,
+        highPassHz: 20,
+        lowPassHz: defaultNotificationSoundFilters.lowPassHz,
+        echo: defaultNotificationSoundFilters.echo,
+        reverb: defaultNotificationSoundFilters.reverb,
+        crunch: defaultNotificationSoundFilters.crunch
+      });
     });
   });
 
@@ -56,6 +131,53 @@ describe('UserPreferencesState', () => {
 
       const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}');
       expect(stored.notificationSound).toBe('pop');
+    });
+
+    it('updates and persists individual notification sound filters', () => {
+      const state = new UserPreferencesState();
+      state.setNotificationSoundFilter('volume', 1.75);
+      state.setNotificationSoundFilter('highPassHz', 900);
+      state.setNotificationSoundFilter('lowPassHz', 5000);
+      state.setNotificationSoundFilter('echo', 35);
+      state.setNotificationSoundFilter('reverb', 45);
+      state.setNotificationSoundFilter('crunch', 55);
+
+      expect(state.notificationSoundFilters).toEqual({
+        volume: 1.75,
+        highPassHz: 900,
+        lowPassHz: 5000,
+        echo: 35,
+        reverb: 45,
+        crunch: 55
+      });
+
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}');
+      expect(stored.notificationSoundFilters).toEqual({
+        volume: 1.75,
+        highPassHz: 900,
+        lowPassHz: 5000,
+        echo: 35,
+        reverb: 45,
+        crunch: 55
+      });
+    });
+
+    it('resets notification sound filters to defaults', () => {
+      const state = new UserPreferencesState();
+      state.notificationSoundFilters = {
+        volume: 0.25,
+        highPassHz: 700,
+        lowPassHz: 4000,
+        echo: 35,
+        reverb: 45,
+        crunch: 55
+      };
+
+      state.resetNotificationSoundFilters();
+
+      expect(state.notificationSoundFilters).toEqual(defaultNotificationSoundFilters);
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}');
+      expect(stored.notificationSoundFilters).toEqual(defaultNotificationSoundFilters);
     });
   });
 });

--- a/frontend/src/lib/state/userPreferences.svelte.ts
+++ b/frontend/src/lib/state/userPreferences.svelte.ts
@@ -6,7 +6,9 @@
  */
 
 import {
+  type NotificationSoundFilters,
   type NotificationSoundId,
+  defaultNotificationSoundFilters,
   defaultSoundId,
   notificationSounds
 } from '$lib/audio/notificationSounds';
@@ -14,13 +16,42 @@ import { Codecs, globalSlot } from '$lib/storage/slot';
 
 interface Preferences {
   notificationSound: NotificationSoundId;
+  notificationSoundFilters: NotificationSoundFilters;
 }
 
 const defaultPreferences: Preferences = {
-  notificationSound: defaultSoundId
+  notificationSound: defaultSoundId,
+  notificationSoundFilters: defaultNotificationSoundFilters
 };
 
 const slot = globalSlot('preferences', defaultPreferences, Codecs.json<Preferences>());
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function clampNumber(value: unknown, min: number, max: number, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  if (value < min || value > max) return fallback;
+  return value;
+}
+
+function normalizeNotificationSoundFilters(value: unknown): NotificationSoundFilters {
+  const stored = isRecord(value) ? value : {};
+  return {
+    volume: clampNumber(stored.volume, 0, 2, defaultNotificationSoundFilters.volume),
+    highPassHz: clampNumber(
+      stored.highPassHz,
+      20,
+      2000,
+      defaultNotificationSoundFilters.highPassHz
+    ),
+    lowPassHz: clampNumber(stored.lowPassHz, 800, 20000, defaultNotificationSoundFilters.lowPassHz),
+    echo: clampNumber(stored.echo, 0, 100, defaultNotificationSoundFilters.echo),
+    reverb: clampNumber(stored.reverb, 0, 100, defaultNotificationSoundFilters.reverb),
+    crunch: clampNumber(stored.crunch, 0, 100, defaultNotificationSoundFilters.crunch)
+  };
+}
 
 function loadPreferences(): Preferences {
   const stored = slot.get();
@@ -30,7 +61,8 @@ function loadPreferences(): Preferences {
   return {
     ...defaultPreferences,
     ...stored,
-    notificationSound: isValidSound ? stored.notificationSound : defaultSoundId
+    notificationSound: isValidSound ? stored.notificationSound : defaultSoundId,
+    notificationSoundFilters: normalizeNotificationSoundFilters(stored.notificationSoundFilters)
   };
 }
 
@@ -44,6 +76,26 @@ export class UserPreferencesState {
   set notificationSound(value: NotificationSoundId) {
     this.#prefs.notificationSound = value;
     slot.set(this.#prefs);
+  }
+
+  get notificationSoundFilters(): NotificationSoundFilters {
+    return this.#prefs.notificationSoundFilters;
+  }
+
+  set notificationSoundFilters(value: NotificationSoundFilters) {
+    this.#prefs.notificationSoundFilters = normalizeNotificationSoundFilters(value);
+    slot.set(this.#prefs);
+  }
+
+  setNotificationSoundFilter(key: keyof NotificationSoundFilters, value: number) {
+    this.notificationSoundFilters = {
+      ...this.#prefs.notificationSoundFilters,
+      [key]: value
+    };
+  }
+
+  resetNotificationSoundFilters() {
+    this.notificationSoundFilters = defaultNotificationSoundFilters;
   }
 
   /**

--- a/frontend/src/lib/ui/FormSection.svelte
+++ b/frontend/src/lib/ui/FormSection.svelte
@@ -5,16 +5,25 @@
     title,
     maxWidth,
     bordered = false,
+    actions,
     children
   }: {
     title: string;
     maxWidth?: 'max-w-md' | 'max-w-lg' | 'max-w-xl' | 'max-w-2xl';
     bordered?: boolean;
+    actions?: Snippet;
     children: Snippet;
   } = $props();
 </script>
 
 <section class={[maxWidth, bordered && 'border-t border-border pt-6']}>
-  <h3 class="mb-4 text-sm font-semibold text-muted uppercase">{title}</h3>
+  <div class="mb-4 flex items-center justify-between gap-3">
+    <h3 class="text-sm font-semibold text-muted uppercase">{title}</h3>
+    {#if actions}
+      <div class="flex shrink-0 items-center gap-2">
+        {@render actions()}
+      </div>
+    {/if}
+  </div>
   {@render children()}
 </section>

--- a/frontend/src/routes/chat/[serverId]/settings/notifications/+page.svelte
+++ b/frontend/src/routes/chat/[serverId]/settings/notifications/+page.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-  import { PaneHeader, Hint } from '$lib/ui';
+  import { PaneHeader, Hint, FormSection } from '$lib/ui';
   import NotificationLevelSettings from '$lib/components/settings/NotificationLevelSettings.svelte';
   import { userPreferences } from '$lib/state/userPreferences.svelte';
   import {
     notificationSounds,
     playNotificationSound,
     soundCategories,
+    type NotificationSoundFilters,
     type NotificationSoundId,
     type SoundCategory
   } from '$lib/audio/notificationSounds';
@@ -23,8 +24,54 @@
   function selectSound(soundId: NotificationSoundId) {
     userPreferences.notificationSound = soundId;
     if (soundId !== 'silent') {
-      playNotificationSound(soundId);
+      playNotificationSound(soundId, userPreferences.notificationSoundFilters);
     }
+  }
+
+  function previewSelectedSound() {
+    if (userPreferences.notificationSound === 'silent') return;
+    playNotificationSound(
+      userPreferences.notificationSound,
+      userPreferences.notificationSoundFilters
+    );
+  }
+
+  function updateSoundFilter(key: keyof NotificationSoundFilters, event: Event) {
+    const value = Number((event.currentTarget as HTMLInputElement).value);
+    userPreferences.setNotificationSoundFilter(key, value);
+  }
+
+  function updateMuffledFilter(event: Event) {
+    const amount = Number((event.currentTarget as HTMLInputElement).value);
+    userPreferences.setNotificationSoundFilter('lowPassHz', lowPassHzFromMuffledAmount(amount));
+  }
+
+  function lowPassHzFromMuffledAmount(amount: number) {
+    return 20000 - (amount / 100) * (20000 - 800);
+  }
+
+  function muffledAmountFromLowPassHz(value: number) {
+    return Math.round(((20000 - value) / (20000 - 800)) * 100);
+  }
+
+  function formatVolume(value: number) {
+    return `${Math.round(value * 100)}%`;
+  }
+
+  function formatEffect(value: number) {
+    if (value <= 0) return 'Off';
+    return `${Math.round(value)}%`;
+  }
+
+  function formatTinny(value: number) {
+    if (value <= 20) return 'Off';
+    return `${Math.round(((value - 20) / (2000 - 20)) * 100)}%`;
+  }
+
+  function formatMuffled(value: number) {
+    const amount = muffledAmountFromLowPassHz(value);
+    if (amount <= 0) return 'Off';
+    return `${amount}%`;
   }
 
   function getSoundsForCategory(category: SoundCategory) {
@@ -200,4 +247,167 @@
       {/each}
     </div>
   </div>
+
+  <FormSection title="Sound Shape" maxWidth="max-w-lg" bordered>
+    {#snippet actions()}
+      <button
+        type="button"
+        class="cursor-pointer rounded-lg border border-border bg-surface-100 px-3 py-1.5 text-sm transition-colors hover:bg-surface-200 disabled:cursor-not-allowed disabled:opacity-50"
+        onclick={previewSelectedSound}
+        disabled={userPreferences.notificationSound === 'silent'}
+      >
+        Preview
+      </button>
+      <button
+        type="button"
+        class="hover:text-foreground cursor-pointer rounded-lg border border-border px-3 py-1.5 text-sm text-muted transition-colors hover:bg-surface-100"
+        onclick={() => userPreferences.resetNotificationSoundFilters()}
+      >
+        Reset
+      </button>
+    {/snippet}
+
+    <div class="flex flex-col gap-2">
+      <label class="flex flex-col gap-2 rounded-lg border border-border px-3 py-2">
+        <span class="flex items-center justify-between gap-3 text-sm">
+          <span class="flex min-w-0 items-center gap-2 font-medium">
+            <span class="iconify shrink-0 text-base text-muted uil--volume" aria-hidden="true"
+            ></span>
+            <span>Volume</span>
+          </span>
+          <span class="text-muted tabular-nums">
+            {formatVolume(userPreferences.notificationSoundFilters.volume)}
+          </span>
+        </span>
+        <input
+          data-testid="notification-volume-filter"
+          type="range"
+          min="0"
+          max="2"
+          step="0.05"
+          value={userPreferences.notificationSoundFilters.volume}
+          oninput={(event) => updateSoundFilter('volume', event)}
+          onchange={previewSelectedSound}
+          class="w-full cursor-pointer accent-accent"
+        />
+      </label>
+
+      <label class="flex flex-col gap-2 rounded-lg border border-border px-3 py-2">
+        <span class="flex items-center justify-between gap-3 text-sm">
+          <span class="flex min-w-0 items-center gap-2 font-medium">
+            <span class="iconify shrink-0 text-base text-muted uil--bolt" aria-hidden="true"></span>
+            <span>Tinny</span>
+          </span>
+          <span class="text-muted tabular-nums">
+            {formatTinny(userPreferences.notificationSoundFilters.highPassHz)}
+          </span>
+        </span>
+        <input
+          data-testid="notification-high-pass-filter"
+          type="range"
+          min="20"
+          max="2000"
+          step="10"
+          value={userPreferences.notificationSoundFilters.highPassHz}
+          oninput={(event) => updateSoundFilter('highPassHz', event)}
+          onchange={previewSelectedSound}
+          class="w-full cursor-pointer accent-accent"
+        />
+      </label>
+
+      <label class="flex flex-col gap-2 rounded-lg border border-border px-3 py-2">
+        <span class="flex items-center justify-between gap-3 text-sm">
+          <span class="flex min-w-0 items-center gap-2 font-medium">
+            <span class="iconify shrink-0 text-base text-muted uil--volume-mute" aria-hidden="true"
+            ></span>
+            <span>Muffled</span>
+          </span>
+          <span class="text-muted tabular-nums">
+            {formatMuffled(userPreferences.notificationSoundFilters.lowPassHz)}
+          </span>
+        </span>
+        <input
+          data-testid="notification-low-pass-filter"
+          type="range"
+          min="0"
+          max="100"
+          step="1"
+          value={muffledAmountFromLowPassHz(userPreferences.notificationSoundFilters.lowPassHz)}
+          oninput={updateMuffledFilter}
+          onchange={previewSelectedSound}
+          class="w-full cursor-pointer accent-accent"
+        />
+      </label>
+
+      <label class="flex flex-col gap-2 rounded-lg border border-border px-3 py-2">
+        <span class="flex items-center justify-between gap-3 text-sm">
+          <span class="flex min-w-0 items-center gap-2 font-medium">
+            <span class="iconify shrink-0 text-base text-muted uil--redo" aria-hidden="true"></span>
+            <span>Echo</span>
+          </span>
+          <span class="text-muted tabular-nums">
+            {formatEffect(userPreferences.notificationSoundFilters.echo)}
+          </span>
+        </span>
+        <input
+          data-testid="notification-echo-filter"
+          type="range"
+          min="0"
+          max="100"
+          step="1"
+          value={userPreferences.notificationSoundFilters.echo}
+          oninput={(event) => updateSoundFilter('echo', event)}
+          onchange={previewSelectedSound}
+          class="w-full cursor-pointer accent-accent"
+        />
+      </label>
+
+      <label class="flex flex-col gap-2 rounded-lg border border-border px-3 py-2">
+        <span class="flex items-center justify-between gap-3 text-sm">
+          <span class="flex min-w-0 items-center gap-2 font-medium">
+            <span class="iconify shrink-0 text-base text-muted uil--cloud" aria-hidden="true"
+            ></span>
+            <span>Reverb</span>
+          </span>
+          <span class="text-muted tabular-nums">
+            {formatEffect(userPreferences.notificationSoundFilters.reverb)}
+          </span>
+        </span>
+        <input
+          data-testid="notification-reverb-filter"
+          type="range"
+          min="0"
+          max="100"
+          step="1"
+          value={userPreferences.notificationSoundFilters.reverb}
+          oninput={(event) => updateSoundFilter('reverb', event)}
+          onchange={previewSelectedSound}
+          class="w-full cursor-pointer accent-accent"
+        />
+      </label>
+
+      <label class="flex flex-col gap-2 rounded-lg border border-border px-3 py-2">
+        <span class="flex items-center justify-between gap-3 text-sm">
+          <span class="flex min-w-0 items-center gap-2 font-medium">
+            <span class="iconify shrink-0 text-base text-muted uil--fire" aria-hidden="true"></span>
+            <span>Crunch</span>
+          </span>
+          <span class="text-muted tabular-nums">
+            {formatEffect(userPreferences.notificationSoundFilters.crunch)}
+          </span>
+        </span>
+        <input
+          data-testid="notification-crunch-filter"
+          type="range"
+          min="0"
+          max="100"
+          step="1"
+          value={userPreferences.notificationSoundFilters.crunch}
+          oninput={(event) => updateSoundFilter('crunch', event)}
+          onchange={previewSelectedSound}
+          class="w-full cursor-pointer accent-accent"
+        />
+      </label>
+    </div>
+  </FormSection>
 </div>

--- a/frontend/src/routes/chat/[serverId]/settings/notifications/notifications.page.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/settings/notifications/notifications.page.svelte.spec.ts
@@ -5,6 +5,7 @@ import NotificationsPage from './+page.svelte';
 import { NotificationLevel } from '$lib/gql/graphql';
 import { q } from '$lib/test-utils';
 import { userPreferences } from '$lib/state/userPreferences.svelte';
+import { defaultNotificationSoundFilters } from '$lib/audio/notificationSounds';
 
 const mocks = vi.hoisted(() => ({
   query: vi.fn(),
@@ -66,6 +67,18 @@ async function settle() {
   flushSync();
 }
 
+function setRangeValue(input: HTMLInputElement, value: string) {
+  input.value = value;
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  flushSync();
+}
+
+function commitRangeValue(input: HTMLInputElement, value: string) {
+  setRangeValue(input, value);
+  input.dispatchEvent(new Event('change', { bubbles: true }));
+  flushSync();
+}
+
 function preferenceResult() {
   return {
     server: {
@@ -105,6 +118,7 @@ describe('Notification settings page', () => {
   beforeEach(() => {
     localStorage.clear();
     userPreferences.notificationSound = 'chime-up';
+    userPreferences.resetNotificationSoundFilters();
     mocks.playNotificationSound.mockClear();
     mocks.notificationLevels.setServerPreference.mockClear();
     mocks.notificationLevels.setRoomPreference.mockClear();
@@ -130,6 +144,23 @@ describe('Notification settings page', () => {
     expect(container.textContent).toContain('Silent');
     expect(container.textContent).toContain('Simple');
     expect(container.textContent).toContain('Soft Pop');
+    expect(container.textContent).toContain('Sound Shape');
+    await expect.element(q(container, '[data-testid="notification-volume-filter"]')).toBeVisible();
+    await expect
+      .element(q(container, '[data-testid="notification-high-pass-filter"]'))
+      .toBeVisible();
+    await expect
+      .element(q(container, '[data-testid="notification-low-pass-filter"]'))
+      .toBeVisible();
+    await expect.element(q(container, '[data-testid="notification-echo-filter"]')).toBeVisible();
+    await expect.element(q(container, '[data-testid="notification-reverb-filter"]')).toBeVisible();
+    await expect.element(q(container, '[data-testid="notification-crunch-filter"]')).toBeVisible();
+    expect(container.querySelector('.uil--volume')).not.toBeNull();
+    expect(container.querySelector('.uil--bolt')).not.toBeNull();
+    expect(container.querySelector('.uil--volume-mute')).not.toBeNull();
+    expect(container.querySelector('.uil--redo')).not.toBeNull();
+    expect(container.querySelector('.uil--cloud')).not.toBeNull();
+    expect(container.querySelector('.uil--fire')).not.toBeNull();
   });
 
   it('selects and persists a non-silent notification sound', async () => {
@@ -144,7 +175,10 @@ describe('Notification settings page', () => {
     expect(JSON.parse(localStorage.getItem('chatto:preferences') ?? '{}')).toMatchObject({
       notificationSound: 'pop'
     });
-    expect(mocks.playNotificationSound).toHaveBeenCalledWith('pop');
+    expect(mocks.playNotificationSound).toHaveBeenCalledWith(
+      'pop',
+      defaultNotificationSoundFilters
+    );
     await expect.element(softPopButton).toHaveClass(/border-accent/);
   });
 
@@ -159,5 +193,157 @@ describe('Notification settings page', () => {
     expect(userPreferences.notificationSound).toBe('silent');
     expect(mocks.playNotificationSound).not.toHaveBeenCalled();
     await expect.element(silentButton).toHaveClass(/border-accent/);
+  });
+
+  it('updates and persists notification sound filter sliders', async () => {
+    const { container } = render(NotificationsPage);
+    await settle();
+
+    setRangeValue(
+      q(container, '[data-testid="notification-volume-filter"]') as HTMLInputElement,
+      '1.5'
+    );
+    setRangeValue(
+      q(container, '[data-testid="notification-high-pass-filter"]') as HTMLInputElement,
+      '500'
+    );
+    setRangeValue(
+      q(container, '[data-testid="notification-low-pass-filter"]') as HTMLInputElement,
+      '63'
+    );
+    setRangeValue(
+      q(container, '[data-testid="notification-echo-filter"]') as HTMLInputElement,
+      '35'
+    );
+    setRangeValue(
+      q(container, '[data-testid="notification-reverb-filter"]') as HTMLInputElement,
+      '45'
+    );
+    setRangeValue(
+      q(container, '[data-testid="notification-crunch-filter"]') as HTMLInputElement,
+      '55'
+    );
+
+    expect(userPreferences.notificationSoundFilters).toEqual({
+      volume: 1.5,
+      highPassHz: 500,
+      lowPassHz: 7904,
+      echo: 35,
+      reverb: 45,
+      crunch: 55
+    });
+    expect(JSON.parse(localStorage.getItem('chatto:preferences') ?? '{}')).toMatchObject({
+      notificationSoundFilters: {
+        volume: 1.5,
+        highPassHz: 500,
+        lowPassHz: 7904,
+        echo: 35,
+        reverb: 45,
+        crunch: 55
+      }
+    });
+    expect(container.textContent).toContain('150%');
+    expect(container.textContent).toContain('Tinny');
+    expect(container.textContent).toContain('24%');
+    expect(container.textContent).toContain('Muffled');
+    expect(container.textContent).toContain('63%');
+    expect(container.textContent).toContain('Echo');
+    expect(container.textContent).toContain('35%');
+    expect(container.textContent).toContain('Reverb');
+    expect(container.textContent).toContain('45%');
+    expect(container.textContent).toContain('Crunch');
+    expect(container.textContent).toContain('55%');
+  });
+
+  it('previews the selected sound with the current filters', async () => {
+    const { container } = render(NotificationsPage);
+    await settle();
+
+    setRangeValue(
+      q(container, '[data-testid="notification-high-pass-filter"]') as HTMLInputElement,
+      '400'
+    );
+    mocks.playNotificationSound.mockClear();
+
+    buttonWithText(container, 'Preview').click();
+    flushSync();
+
+    expect(mocks.playNotificationSound).toHaveBeenCalledWith('chime-up', {
+      ...defaultNotificationSoundFilters,
+      highPassHz: 400
+    });
+  });
+
+  it('previews a filter change only when the slider change is committed', async () => {
+    const { container } = render(NotificationsPage);
+    await settle();
+
+    const volumeInput = q(
+      container,
+      '[data-testid="notification-volume-filter"]'
+    ) as HTMLInputElement;
+    mocks.playNotificationSound.mockClear();
+
+    setRangeValue(volumeInput, '1.25');
+    expect(mocks.playNotificationSound).not.toHaveBeenCalled();
+
+    volumeInput.dispatchEvent(new Event('change', { bubbles: true }));
+    flushSync();
+
+    expect(mocks.playNotificationSound).toHaveBeenCalledOnce();
+    expect(mocks.playNotificationSound).toHaveBeenCalledWith('chime-up', {
+      ...defaultNotificationSoundFilters,
+      volume: 1.25
+    });
+  });
+
+  it('does not preview committed filter changes while Silent is selected', async () => {
+    const { container } = render(NotificationsPage);
+    await settle();
+
+    buttonWithText(container, 'Silent').click();
+    flushSync();
+    mocks.playNotificationSound.mockClear();
+
+    commitRangeValue(
+      q(container, '[data-testid="notification-echo-filter"]') as HTMLInputElement,
+      '60'
+    );
+
+    expect(mocks.playNotificationSound).not.toHaveBeenCalled();
+  });
+
+  it('disables preview when silent is selected', async () => {
+    const { container } = render(NotificationsPage);
+    await settle();
+
+    buttonWithText(container, 'Silent').click();
+    flushSync();
+    mocks.playNotificationSound.mockClear();
+
+    const previewButton = buttonWithText(container, 'Preview');
+    expect(previewButton.disabled).toBe(true);
+    previewButton.click();
+    flushSync();
+
+    expect(mocks.playNotificationSound).not.toHaveBeenCalled();
+  });
+
+  it('resets notification sound filters to defaults', async () => {
+    const { container } = render(NotificationsPage);
+    await settle();
+
+    setRangeValue(
+      q(container, '[data-testid="notification-volume-filter"]') as HTMLInputElement,
+      '0.5'
+    );
+    buttonWithText(container, 'Reset').click();
+    flushSync();
+
+    expect(userPreferences.notificationSoundFilters).toEqual(defaultNotificationSoundFilters);
+    expect(JSON.parse(localStorage.getItem('chatto:preferences') ?? '{}')).toMatchObject({
+      notificationSoundFilters: defaultNotificationSoundFilters
+    });
+    expect(container.textContent).toContain('100%');
   });
 });


### PR DESCRIPTION
- Adds browser-local notification sound shaping preferences for volume, tone, echo, reverb, and crunch.
- Routes notification playback through a Web Audio effects chain with preview interruption, fade-out cleanup, and filter-aware notification sync.
- Updates the notification settings UI, shared `FormSection` actions, FDR docs, and focused unit coverage.

Tests: `pnpm test:unit --run --project client src/lib/state/userPreferences.svelte.spec.ts src/routes/chat/[serverId]/settings/notifications/notifications.page.svelte.spec.ts`, `pnpm test:unit --run --project server src/lib/audio/notificationSounds.spec.ts`, `pnpm check`, `pnpm lint`.
