### PR TITLE
fix(composer): keep autolink boundaries editable

### DIFF
--- a/frontend/e2e/composer.test.ts
+++ b/frontend/e2e/composer.test.ts
@@ -213,6 +213,43 @@ test.describe('Composer keyboard submit hint', () => {
   });
 });
 
+test.describe('Composer links', () => {
+  test('typing space after a pasted autolink leaves the link', async ({
+    page,
+    chatPage,
+    roomPage
+  }) => {
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.enterRoom('general');
+    await waitForRoomReady(page, 'general');
+
+    const url = 'https://www.spiegel.de/';
+    await roomPage.waitForInputEditable();
+    await roomPage.messageInput.click();
+    await roomPage.messageInput.evaluate((element, pastedUrl) => {
+      const dataTransfer = new DataTransfer();
+      dataTransfer.setData('text/plain', pastedUrl);
+      element.dispatchEvent(
+        new ClipboardEvent('paste', {
+          bubbles: true,
+          cancelable: true,
+          clipboardData: dataTransfer
+        })
+      );
+    }, url);
+
+    const link = roomPage.messageInput.locator('a');
+    await expect(link).toHaveText(url);
+    await expect(link).toHaveAttribute('href', url);
+
+    await roomPage.messageInput.pressSequentially(' after');
+
+    await expect(link).toHaveText(url);
+    await expect(roomPage.messageInput).toHaveText(`${url} after`);
+  });
+});
+
 // Use #general (postable) as the starting room and a freshly-created custom
 // room (also postable) as the navigation target. We can't use #announcements
 // — its special permissions deny message.post for regular members, which

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,7 @@
     "@tailwindcss/vite": "^4.3.0",
     "@tiptap/core": "^3.23.2",
     "@tiptap/extension-code-block-lowlight": "3.23.2",
+    "@tiptap/extension-link": "3.23.2",
     "@tiptap/extension-placeholder": "^3.23.2",
     "@tiptap/markdown": "3.23.2",
     "@tiptap/pm": "^3.23.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       '@tiptap/extension-code-block-lowlight':
         specifier: 3.23.2
         version: 3.23.2(@tiptap/core@3.23.2(@tiptap/pm@3.23.2))(@tiptap/extension-code-block@3.23.2(@tiptap/core@3.23.2(@tiptap/pm@3.23.2))(@tiptap/pm@3.23.2))(@tiptap/pm@3.23.2)(highlight.js@11.11.1)(lowlight@3.3.0)
+      '@tiptap/extension-link':
+        specifier: 3.23.2
+        version: 3.23.2(@tiptap/core@3.23.2(@tiptap/pm@3.23.2))(@tiptap/pm@3.23.2)
       '@tiptap/extension-placeholder':
         specifier: ^3.23.2
         version: 3.23.2(@tiptap/extensions@3.23.2(@tiptap/core@3.23.2(@tiptap/pm@3.23.2))(@tiptap/pm@3.23.2))

--- a/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -183,6 +183,18 @@ function pasteFile(target: HTMLElement, file: File) {
   );
 }
 
+function pasteText(target: HTMLElement, text: string) {
+  const dataTransfer = new DataTransfer();
+  dataTransfer.setData('text/plain', text);
+  target.dispatchEvent(
+    new ClipboardEvent('paste', {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: dataTransfer
+    })
+  );
+}
+
 async function findEditor(container: Element, testid = 'message-input'): Promise<HTMLElement> {
   await vi.waitFor(() => expect(q(container, `[data-testid="${testid}"]`)).toBeTruthy(), {
     timeout: 5000
@@ -1166,6 +1178,32 @@ describe('MessageComposer', () => {
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
         roomId,
         body: '[example](https://example.com)'
+      });
+    });
+
+    it('keeps typed space after a pasted autolink outside the link', async () => {
+      const url = 'https://www.spiegel.de/';
+      const { container } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = await findEditor(container);
+
+      editor.focus();
+      pasteText(editor, url);
+      await vi.waitFor(() => {
+        const link = editor.querySelector('a');
+        expect(link?.textContent).toBe(url);
+        expect(link?.getAttribute('href')).toBe(url);
+      });
+
+      await insertEditorLiteralText(editor, ' after');
+
+      await vi.waitFor(() => {
+        const links = editor.querySelectorAll('a');
+        expect(links).toHaveLength(1);
+        expect(links[0]?.textContent).toBe(url);
+        expect(editor.textContent).toBe(`${url} after`);
       });
     });
 

--- a/frontend/src/lib/components/composer/TipTapEditor.svelte
+++ b/frontend/src/lib/components/composer/TipTapEditor.svelte
@@ -21,6 +21,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
   import type { Node as ProseMirrorNode, Schema } from '@tiptap/pm/model';
   import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state';
   import StarterKit from '@tiptap/starter-kit';
+  import Link from '@tiptap/extension-link';
   import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
   import { Markdown } from '@tiptap/markdown';
   import Placeholder from '@tiptap/extension-placeholder';
@@ -54,6 +55,8 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
       ];
     }
   });
+
+  const ComposerLink = Link.extend({ inclusive: false });
 
   function paragraphTextWithLineBreaks(node: ProseMirrorNode) {
     return node.textBetween(0, node.content.size, '\n', '\n');
@@ -947,10 +950,13 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
               underline: false,
               horizontalRule: false,
               trailingNode: false,
-              link: {
-                openOnClick: false,
-                enableClickSelection: true
-              }
+              link: false
+            }),
+            ComposerLink.configure({
+              autolink: true,
+              linkOnPaste: true,
+              openOnClick: false,
+              enableClickSelection: true
             }),
             Markdown.configure({
               markedOptions: {


### PR DESCRIPTION
- Keep typed text after pasted/autolinked URLs outside the link by using an explicit TipTap Link extension with `inclusive: false`.
- Preserve composer autolink, link-on-paste, and link control behavior while declaring `@tiptap/extension-link` as a direct frontend dependency.
- Add unit and e2e coverage for pasting a URL, typing a space plus text, and keeping only the URL linked.

Tests: `pnpm --dir frontend check`; `pnpm --dir frontend lint`; `pnpm --dir frontend test:unit -- --run src/lib/components/composer/MessageComposer.svelte.spec.ts`; `pnpm --dir frontend test:e2e -- composer.test.ts`.
