### PR TITLE
fix(composer): preserve trailing hashes in headings

### DIFF
--- a/frontend/src/lib/components/MessageContent.svelte.spec.ts
+++ b/frontend/src/lib/components/MessageContent.svelte.spec.ts
@@ -165,6 +165,11 @@ describe('renderMarkdown', () => {
       }
     });
 
+    it('renders encoded trailing hashes as literal heading text', async () => {
+      const html = await renderMarkdown('# test &#35;');
+      expect(html).toContain('<h1>test #</h1>');
+    });
+
     it('does not render setext (underline-style) headings', async () => {
       const html = await renderMarkdown('Heading\n===');
       expect(html).not.toContain('<h1');

--- a/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -1009,7 +1009,7 @@ describe('MessageComposer', () => {
       const editor = await findEditor(container);
 
       await expect.element(editor).toHaveTextContent(body);
-      editor.focus();
+      await placeCaretAtEditorEnd(editor);
       document.execCommand('insertText', false, '!');
       await vi.waitFor(() => expect(editor.textContent).toBe(editedBody));
 
@@ -1635,6 +1635,46 @@ describe('MessageComposer', () => {
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
         roomId,
         body: '# Heading\n\nbody'
+      });
+    });
+
+    it('preserves literal trailing hashes in heading text when sending', async () => {
+      const { container, roomId } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = await findEditor(container);
+
+      await typeEditorLiteralText(editor, '# test #');
+      await vi.waitFor(() => expect(editor.querySelector('h1')?.textContent).toBe('test #'));
+      expect(Array.from(editor.children).map((child) => child.tagName)).toEqual(['H1']);
+
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({
+        roomId,
+        body: '# test &#35;'
+      });
+    });
+
+    it('preserves multiple literal trailing hashes in heading text when sending', async () => {
+      const { container, roomId } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = await findEditor(container);
+
+      await typeEditorLiteralText(editor, '# test ##');
+      await vi.waitFor(() => expect(editor.querySelector('h1')?.textContent).toBe('test ##'));
+      expect(Array.from(editor.children).map((child) => child.tagName)).toEqual(['H1']);
+
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({
+        roomId,
+        body: '# test &#35;&#35;'
       });
     });
 

--- a/frontend/src/lib/components/composer/TipTapEditor.svelte
+++ b/frontend/src/lib/components/composer/TipTapEditor.svelte
@@ -437,10 +437,15 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     return result;
   }
 
+  type MarkdownTransformOptions = {
+    skipLinkDestinations?: boolean;
+    preserveInlineCode?: boolean;
+  };
+
   function transformMarkdownTextSegment(
     text: string,
     transformText: (text: string) => string,
-    { skipLinkDestinations = false }: { skipLinkDestinations?: boolean } = {}
+    { skipLinkDestinations = false }: MarkdownTransformOptions = {}
   ): string {
     return skipLinkDestinations
       ? transformOutsideMarkdownLinkDestinations(text, transformText)
@@ -450,7 +455,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
   function transformOutsideInlineCode(
     line: string,
     transformText: (text: string) => string,
-    options: { skipLinkDestinations?: boolean } = {}
+    options: MarkdownTransformOptions = {}
   ): string {
     let result = '';
     let index = 0;
@@ -484,7 +489,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
   function transformMarkdownOutsideCode(
     markdown: string,
     transformText: (text: string) => string,
-    options: { skipLinkDestinations?: boolean } = {}
+    options: MarkdownTransformOptions = {}
   ): string {
     const lines = markdown.match(/[^\n]*(?:\n|$)/g) ?? [];
     if (lines[lines.length - 1] === '') {
@@ -500,7 +505,10 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
 
     const flushPendingText = () => {
       if (!pendingText) return;
-      result += transformOutsideInlineCode(pendingText, transformText, options);
+      result +=
+        options.preserveInlineCode === false
+          ? transformMarkdownTextSegment(pendingText, transformText, options)
+          : transformOutsideInlineCode(pendingText, transformText, options);
       pendingText = '';
     };
 
@@ -586,9 +594,24 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     return markdown.replace(/ {2,}(\n\s*\n\s*(?:[-+*]|\d{1,9}[.)])\s)/g, '$1');
   }
 
+  function encodeSerializedHeadingClosingHashes(markdown: string): string {
+    return transformMarkdownOutsideCode(
+      markdown,
+      (text) =>
+        text.replace(
+          /(^|\n)((?:[ \t]{0,3}>[ \t]?)*[ \t]{0,3}#{1,6}[ \t]+[^\n]*?)([ \t]+)(#{1,})([ \t]*)(?=\n|$)/g,
+          (_match, lineStart, headingStart, separator, hashes, trailingWhitespace) =>
+            `${lineStart}${headingStart}${separator}${hashes.replace(/#/g, '&#35;')}${trailingWhitespace}`
+        ),
+      { preserveInlineCode: false }
+    );
+  }
+
   function getSerializedMarkdown(e: Editor): string {
     return normalizeSerializedHardBreaksBeforeLists(
-      trimSerializedTrailingEmptyParagraph(decodeSerializedMarkdownText(e.getMarkdown()), e)
+      encodeSerializedHeadingClosingHashes(
+        trimSerializedTrailingEmptyParagraph(decodeSerializedMarkdownText(e.getMarkdown()), e)
+      )
     );
   }
 


### PR DESCRIPTION
## Changes

- Preserve literal trailing `#` characters when the rich composer serializes ATX headings.
- Store ambiguous heading text like `# test #` as `# test &#35;` so the renderer keeps the final hash visible.
- Add composer and Markdown renderer regression coverage for the serialized entity form.

## Verification

- `mise run test-frontend -- src/lib/components/composer/MessageComposer.svelte.spec.ts`
- `mise run test-frontend -- src/lib/components/MessageContent.svelte.spec.ts`
- Browser smoke test: posted `# test #` and confirmed the rendered message is an H1 with `test #`.
