### PR TITLE
fix(frontend): align chat control border radii

### DIFF
--- a/frontend/src/lib/components/CurrentUserBar.svelte
+++ b/frontend/src/lib/components/CurrentUserBar.svelte
@@ -38,7 +38,7 @@ to the user settings page for the active server.
 
 {#if activeServerUser}
   <div class="shrink-0 p-2">
-    <div class="flex items-center gap-3 rounded-lg bg-surface py-1 pr-3 pl-1">
+    <div class="flex items-center gap-3 rounded-xl bg-surface py-1 pr-3 pl-1">
       <UserAvatar user={activeServerUser} size="md" />
       <div class="flex min-w-0 flex-1 flex-col leading-tight">
         <span class="truncate text-sm font-semibold">{displayName}</span>

--- a/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -844,7 +844,7 @@
   <!-- Unified input container -->
   <div
     class={[
-      'relative flex items-start gap-4 rounded-lg bg-surface py-2 pr-3',
+      'relative flex items-start gap-4 rounded-xl bg-surface py-2 pr-3',
       isEditing ? 'pl-3' : 'pl-2'
     ]}
     class:opacity-50={inputDisabled}


### PR DESCRIPTION
## Changes

- Align the current-user bar and message composer shell with the server gutter item radius by using `rounded-xl`.
- Keeps the add button, account tile, and composer visually consistent.

## Verification

- `pnpm check`
- `pnpm lint`
- Browser review of the local Vite app
