### PR TITLE
feat(messages): add copy link menu action

### DIFF
--- a/frontend/src/lib/components/menus/MessageContextMenu.svelte
+++ b/frontend/src/lib/components/menus/MessageContextMenu.svelte
@@ -66,6 +66,7 @@ Rendered inside a ContextMenu when right-clicking a message.
   const actions = useMessageActions();
 
   const params: MessageActionParams = $derived({
+    serverId,
     roomId,
     messageEventId,
     eventId,
@@ -105,6 +106,11 @@ Rendered inside a ContextMenu when right-clicking a message.
     onClose();
   }
 
+  async function handleCopyLink() {
+    await actions.copyMessageLink(params);
+    onClose();
+  }
+
   function handleDelete() {
     actions.openDeleteConfirmation(params);
     onClose();
@@ -141,40 +147,43 @@ Rendered inside a ContextMenu when right-clicking a message.
   </div>
 {/if}
 
-{#if onReplyInRoom || onReply || canEdit || canDelete}
-  <div class="menu-section">
-    <nav class="sidebar-nav">
-      {#if onReplyInRoom}
-        <button class="sidebar-item" onclick={handleReplyInRoom} role="menuitem">
-          <span class="sidebar-icon iconify uil--corner-up-left"></span>
-          Reply
-        </button>
-      {/if}
+<div class="menu-section">
+  <nav class="sidebar-nav">
+    {#if onReplyInRoom}
+      <button class="sidebar-item" onclick={handleReplyInRoom} role="menuitem">
+        <span class="sidebar-icon iconify uil--corner-up-left"></span>
+        Reply
+      </button>
+    {/if}
 
-      {#if onReply}
-        <button class="sidebar-item" onclick={handleReply} role="menuitem">
-          <span class="sidebar-icon iconify uil--comment-alt-lines"></span>
-          Reply in thread
-        </button>
-      {/if}
+    {#if onReply}
+      <button class="sidebar-item" onclick={handleReply} role="menuitem">
+        <span class="sidebar-icon iconify uil--comment-alt-lines"></span>
+        Reply in thread
+      </button>
+    {/if}
 
-      {#if canEdit}
-        <button class="sidebar-item" onclick={handleEdit} role="menuitem">
-          <span class="sidebar-icon iconify uil--pen"></span>
-          Edit
-        </button>
-      {/if}
+    {#if canEdit}
+      <button class="sidebar-item" onclick={handleEdit} role="menuitem">
+        <span class="sidebar-icon iconify uil--pen"></span>
+        Edit
+      </button>
+    {/if}
 
-      {#if canDelete}
-        <button
-          class="sidebar-item text-danger hover:text-danger"
-          onclick={handleDelete}
-          role="menuitem"
-        >
-          <span class="sidebar-icon iconify uil--trash-alt"></span>
-          Delete
-        </button>
-      {/if}
-    </nav>
-  </div>
-{/if}
+    <button class="sidebar-item" onclick={handleCopyLink} role="menuitem">
+      <span class="sidebar-icon iconify uil--copy"></span>
+      Copy link
+    </button>
+
+    {#if canDelete}
+      <button
+        class="sidebar-item text-danger hover:text-danger"
+        onclick={handleDelete}
+        role="menuitem"
+      >
+        <span class="sidebar-icon iconify uil--trash-alt"></span>
+        Delete
+      </button>
+    {/if}
+  </nav>
+</div>

--- a/frontend/src/lib/components/menus/MessageContextMenu.svelte.spec.ts
+++ b/frontend/src/lib/components/menus/MessageContextMenu.svelte.spec.ts
@@ -7,7 +7,8 @@ const mocks = vi.hoisted(() => ({
   actions: {
     toggleReaction: vi.fn(),
     startEdit: vi.fn(),
-    openDeleteConfirmation: vi.fn()
+    openDeleteConfirmation: vi.fn(),
+    copyMessageLink: vi.fn()
   }
 }));
 
@@ -64,7 +65,23 @@ describe('MessageContextMenu', () => {
     expect(container.textContent).toContain('Reply');
     expect(container.textContent).toContain('Reply in thread');
     expect(container.textContent).toContain('Edit');
+    expect(container.textContent).toContain('Copy link');
     expect(container.textContent).toContain('Delete');
+  });
+
+  it('orders copy link between edit and delete', () => {
+    const { container } = renderMenu({
+      canEdit: true,
+      canDelete: true
+    });
+
+    const actionLabels = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')
+    )
+      .map((button) => button.textContent?.trim())
+      .filter(Boolean);
+
+    expect(actionLabels).toEqual(['Edit', 'Copy link', 'Delete']);
   });
 
   it('renders no empty actions section for a non-author thread reply', () => {
@@ -78,6 +95,18 @@ describe('MessageContextMenu', () => {
     expect(container.textContent).not.toContain('Edit');
     expect(container.textContent).not.toContain('Delete');
     expect(container.querySelectorAll('.menu-section')).toHaveLength(2);
+  });
+
+  it('renders copy link as the only action when no permissions are granted', () => {
+    const { container } = renderMenu();
+
+    const actionLabels = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')
+    )
+      .map((button) => button.textContent?.trim())
+      .filter(Boolean);
+
+    expect(actionLabels).toEqual(['Copy link']);
   });
 
   it('closes after invoking menu actions', async () => {
@@ -103,25 +132,40 @@ describe('MessageContextMenu', () => {
     expect(baseProps.onClose).toHaveBeenCalledOnce();
 
     baseProps.onClose.mockClear();
-    (Array.from(container.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')).find(
-      (button) => button.textContent?.trim() === 'Reply in thread'
-    )!).click();
+    Array.from(container.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'))
+      .find((button) => button.textContent?.trim() === 'Reply in thread')!
+      .click();
     expect(onReply).toHaveBeenCalledOnce();
     expect(baseProps.onClose).toHaveBeenCalledOnce();
 
     baseProps.onClose.mockClear();
-    (Array.from(container.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')).find(
-      (button) => button.textContent?.includes('Edit')
-    )!).click();
+    Array.from(container.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'))
+      .find((button) => button.textContent?.includes('Edit'))!
+      .click();
     expect(mocks.actions.startEdit).toHaveBeenCalledWith(
       expect.objectContaining({ eventId: 'event-1', messageBody: 'Hello' })
     );
     expect(baseProps.onClose).toHaveBeenCalledOnce();
 
     baseProps.onClose.mockClear();
-    (Array.from(container.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')).find(
-      (button) => button.textContent?.includes('Delete')
-    )!).click();
+    Array.from(container.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'))
+      .find((button) => button.textContent?.includes('Copy link'))!
+      .click();
+    expect(mocks.actions.copyMessageLink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverId: 'server-1',
+        roomId: 'room-1',
+        messageEventId: 'message-event-1'
+      })
+    );
+    await vi.waitFor(() => {
+      expect(baseProps.onClose).toHaveBeenCalledOnce();
+    });
+
+    baseProps.onClose.mockClear();
+    Array.from(container.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'))
+      .find((button) => button.textContent?.includes('Delete'))!
+      .click();
     expect(mocks.actions.openDeleteConfirmation).toHaveBeenCalledWith(
       expect.objectContaining({ eventId: 'event-1' })
     );

--- a/frontend/src/lib/hooks/useMessageActions.svelte.ts
+++ b/frontend/src/lib/hooks/useMessageActions.svelte.ts
@@ -1,98 +1,102 @@
 import { useConnection } from '$lib/state/server/connection.svelte';
-import { graphql } from '$lib/gql';
 import { toast } from '$lib/ui/toast';
 import { pushState } from '$app/navigation';
 import { getComposerContext } from '$lib/state/room';
 import { emojiToName } from '$lib/emoji';
+import { copyMessageLinkToClipboard } from '$lib/messageLinks';
+import {
+  AddReactionFromActionsDocument,
+  RemoveReactionFromActionsDocument
+} from '$lib/gql/graphql';
 
 export type MessageActionParams = {
-	roomId: string;
-	messageEventId: string;
-	eventId: string;
-	deleteEventId?: string;
-	messageBody: string;
-	threadRootEventId?: string | null;
-	channelEchoEventId?: string | null;
-	canAddChannelEcho?: boolean;
+  serverId: string;
+  roomId: string;
+  messageEventId: string;
+  eventId: string;
+  deleteEventId?: string;
+  messageBody: string;
+  threadRootEventId?: string | null;
+  channelEchoEventId?: string | null;
+  canAddChannelEcho?: boolean;
 };
-
-const addReactionMutation = graphql(`
-	mutation AddReactionFromActions($input: AddReactionInput!) {
-		addReaction(input: $input)
-	}
-`);
-
-const removeReactionMutation = graphql(`
-	mutation RemoveReactionFromActions($input: RemoveReactionInput!) {
-		removeReaction(input: $input)
-	}
-`);
 
 /**
  * Shared message action handlers for context menu and action sheet.
  * Must be called during component initialization (uses getEditState context).
  */
 export function useMessageActions() {
-	const editState = getComposerContext().editState;
-	const connection = useConnection();
+  const editState = getComposerContext().editState;
+  const connection = useConnection();
 
-	async function addReaction(params: MessageActionParams, emoji: string) {
-		const name = emojiToName(emoji);
-		if (!name) return;
+  async function addReaction(params: MessageActionParams, emoji: string) {
+    const name = emojiToName(emoji);
+    if (!name) return;
 
-		const result = await connection().client.mutation(addReactionMutation, {
-			input: {
-				roomId: params.roomId,
-				messageEventId: params.messageEventId,
-				emoji: name
-			}
-		});
-		if (result.error) {
-			toast.error('Failed to add reaction');
-		}
-	}
+    const result = await connection().client.mutation(AddReactionFromActionsDocument, {
+      input: {
+        roomId: params.roomId,
+        messageEventId: params.messageEventId,
+        emoji: name
+      }
+    });
+    if (result.error) {
+      toast.error('Failed to add reaction');
+    }
+  }
 
-	async function removeReaction(params: MessageActionParams, emoji: string) {
-		const name = emojiToName(emoji);
-		if (!name) return;
+  async function removeReaction(params: MessageActionParams, emoji: string) {
+    const name = emojiToName(emoji);
+    if (!name) return;
 
-		const result = await connection().client.mutation(removeReactionMutation, {
-			input: {
-				roomId: params.roomId,
-				messageEventId: params.messageEventId,
-				emoji: name
-			}
-		});
-		if (result.error) {
-			toast.error('Failed to remove reaction');
-		}
-	}
+    const result = await connection().client.mutation(RemoveReactionFromActionsDocument, {
+      input: {
+        roomId: params.roomId,
+        messageEventId: params.messageEventId,
+        emoji: name
+      }
+    });
+    if (result.error) {
+      toast.error('Failed to remove reaction');
+    }
+  }
 
-	async function toggleReaction(params: MessageActionParams, emoji: string, hasReacted: boolean) {
-		if (hasReacted) {
-			await removeReaction(params, emoji);
-		} else {
-			await addReaction(params, emoji);
-		}
-	}
+  async function toggleReaction(params: MessageActionParams, emoji: string, hasReacted: boolean) {
+    if (hasReacted) {
+      await removeReaction(params, emoji);
+    } else {
+      await addReaction(params, emoji);
+    }
+  }
 
-	function startEdit(params: MessageActionParams) {
-		editState.startEdit(params.eventId, params.messageBody, {
-			threadRootEventId: params.threadRootEventId,
-			channelEchoEventId: params.channelEchoEventId,
-			canAddChannelEcho: params.canAddChannelEcho
-		});
-	}
+  function startEdit(params: MessageActionParams) {
+    editState.startEdit(params.eventId, params.messageBody, {
+      threadRootEventId: params.threadRootEventId,
+      channelEchoEventId: params.channelEchoEventId,
+      canAddChannelEcho: params.canAddChannelEcho
+    });
+  }
 
-	function openDeleteConfirmation(params: MessageActionParams) {
-		pushState('', {
-			modal: {
-				type: 'deleteMessage',
-				roomId: params.roomId,
-				eventId: params.deleteEventId ?? params.eventId
-			}
-		});
-	}
+  function openDeleteConfirmation(params: MessageActionParams) {
+    pushState('', {
+      modal: {
+        type: 'deleteMessage',
+        roomId: params.roomId,
+        eventId: params.deleteEventId ?? params.eventId
+      }
+    });
+  }
 
-	return { addReaction, removeReaction, toggleReaction, startEdit, openDeleteConfirmation };
+  async function copyMessageLink(params: MessageActionParams) {
+    await copyMessageLinkToClipboard(params.serverId, params.roomId, params.messageEventId);
+  }
+
+  return {
+    addReaction,
+    removeReaction,
+    toggleReaction,
+    startEdit,
+    openDeleteConfirmation,
+    copyMessageLink
+  };
 }

--- a/frontend/src/lib/messageLinks.spec.ts
+++ b/frontend/src/lib/messageLinks.spec.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getToasts, toast } from '$lib/ui/toast';
+import { copyMessageLinkToClipboard } from './messageLinks';
+
+describe('copyMessageLinkToClipboard', () => {
+  const writeText = vi.fn();
+
+  beforeEach(() => {
+    toast.clear();
+    writeText.mockReset();
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true
+    });
+  });
+
+  it('copies the message link and shows a success toast', async () => {
+    writeText.mockResolvedValue(undefined);
+
+    await copyMessageLinkToClipboard('server-1', 'room-1', 'message-1');
+
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('/chat/-/room-1/m/message-1'));
+    expect(getToasts().map((t) => t.message)).toContain('Message link copied');
+  });
+
+  it('shows an error toast when clipboard copy fails', async () => {
+    writeText.mockRejectedValue(new Error('denied'));
+
+    await copyMessageLinkToClipboard('server-1', 'room-1', 'message-1');
+
+    expect(getToasts().map((t) => t.message)).toContain('Failed to copy link');
+  });
+});

--- a/frontend/src/lib/messageLinks.ts
+++ b/frontend/src/lib/messageLinks.ts
@@ -7,6 +7,7 @@
 import { resolve } from '$app/paths';
 import { serverRegistry } from '$lib/state/server/registry.svelte';
 import { serverIdToSegment, segmentToServerId } from '$lib/navigation';
+import { toast } from '$lib/ui/toast';
 
 export interface MessageLink {
   /** URL segment for the server (`-` for origin, hostname for remote). */
@@ -17,11 +18,7 @@ export interface MessageLink {
   messageId: string;
 }
 
-export function buildMessageLinkPath(
-  serverId: string,
-  roomId: string,
-  messageId: string
-): string {
+export function buildMessageLinkPath(serverId: string, roomId: string, messageId: string): string {
   return resolve('/chat/[serverId]/[roomId]/m/[messageId]', {
     serverId: serverIdToSegment(serverId),
     roomId,
@@ -30,11 +27,7 @@ export function buildMessageLinkPath(
 }
 
 /** Absolute URL for clipboard copy. */
-export function buildMessageLinkURL(
-  serverId: string,
-  roomId: string,
-  messageId: string
-): string {
+export function buildMessageLinkURL(serverId: string, roomId: string, messageId: string): string {
   const path = buildMessageLinkPath(serverId, roomId, messageId);
 
   const server = serverRegistry.getServer(serverId);
@@ -53,6 +46,19 @@ export function buildMessageLinkURL(
   return path;
 }
 
+export async function copyMessageLinkToClipboard(
+  serverId: string,
+  roomId: string,
+  messageId: string
+): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(buildMessageLinkURL(serverId, roomId, messageId));
+    toast.success('Message link copied');
+  } catch {
+    toast.error('Failed to copy link');
+  }
+}
+
 /**
  * Parse a URL (absolute or relative) and return message link details if it
  * matches the Chatto message link pattern. Returns null for any non-match.
@@ -65,7 +71,10 @@ export function parseMessageLink(input: string): MessageLink | null {
   let hostnameSegment: string | null = null;
 
   try {
-    const url = new URL(input, typeof window !== 'undefined' ? window.location.origin : 'https://_');
+    const url = new URL(
+      input,
+      typeof window !== 'undefined' ? window.location.origin : 'https://_'
+    );
     pathname = url.pathname;
     if (typeof window !== 'undefined' && url.host !== window.location.host) {
       hostnameSegment = url.hostname;

--- a/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionSheet.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionSheet.svelte
@@ -46,6 +46,7 @@
   const actions = useMessageActions();
 
   const params: MessageActionParams = $derived({
+    serverId,
     roomId,
     messageEventId,
     eventId,
@@ -82,6 +83,11 @@
 
   function handleEdit() {
     actions.startEdit(params);
+    onClose();
+  }
+
+  async function handleCopyLink() {
+    await actions.copyMessageLink(params);
     onClose();
   }
 
@@ -122,35 +128,38 @@
   {/if}
 
   <!-- Action list using sidebar-item styling with extra padding for mobile tap targets -->
-  {#if onReplyInRoom || onReply || canEdit || canDelete}
-    <nav class="sidebar-nav">
-      {#if onReplyInRoom}
-        <button class="sidebar-item py-3.5" onclick={handleReplyInRoom}>
-          <span class="sidebar-icon iconify uil--corner-up-left"></span>
-          Reply
-        </button>
-      {/if}
+  <nav class="sidebar-nav">
+    {#if onReplyInRoom}
+      <button class="sidebar-item py-3.5" onclick={handleReplyInRoom}>
+        <span class="sidebar-icon iconify uil--corner-up-left"></span>
+        Reply
+      </button>
+    {/if}
 
-      {#if onReply}
-        <button class="sidebar-item py-3.5" onclick={handleReply}>
-          <span class="sidebar-icon iconify uil--comment-alt-lines"></span>
-          Reply in thread
-        </button>
-      {/if}
+    {#if onReply}
+      <button class="sidebar-item py-3.5" onclick={handleReply}>
+        <span class="sidebar-icon iconify uil--comment-alt-lines"></span>
+        Reply in thread
+      </button>
+    {/if}
 
-      {#if canEdit}
-        <button class="sidebar-item py-3.5" onclick={handleEdit}>
-          <span class="sidebar-icon iconify uil--pen"></span>
-          Edit
-        </button>
-      {/if}
+    {#if canEdit}
+      <button class="sidebar-item py-3.5" onclick={handleEdit}>
+        <span class="sidebar-icon iconify uil--pen"></span>
+        Edit
+      </button>
+    {/if}
 
-      {#if canDelete}
-        <button class="sidebar-item py-3.5" onclick={handleDelete}>
-          <span class="sidebar-icon iconify uil--trash-alt"></span>
-          Delete
-        </button>
-      {/if}
-    </nav>
-  {/if}
+    <button class="sidebar-item py-3.5" onclick={handleCopyLink}>
+      <span class="sidebar-icon iconify uil--copy"></span>
+      Copy link
+    </button>
+
+    {#if canDelete}
+      <button class="sidebar-item py-3.5" onclick={handleDelete}>
+        <span class="sidebar-icon iconify uil--trash-alt"></span>
+        Delete
+      </button>
+    {/if}
+  </nav>
 </div>

--- a/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -42,7 +42,11 @@
   import { useMessageActions } from '$lib/hooks';
   import { emojiToName } from '$lib/emoji';
   import { toast } from '$lib/ui/toast';
-  import { buildMessageLinkURL, parseMessageLink, type MessageLink } from '$lib/messageLinks';
+  import {
+    copyMessageLinkToClipboard,
+    parseMessageLink,
+    type MessageLink
+  } from '$lib/messageLinks';
   import { serverIdToSegment } from '$lib/navigation';
   import { extractURLs } from '$lib/linkPreview';
   import MessagePreviewCard from '$lib/components/MessagePreviewCard.svelte';
@@ -143,6 +147,7 @@
     if (!msg) return;
 
     const params = {
+      serverId: getActiveServer(),
       roomId,
       messageEventId: event.id,
       eventId: isEcho ? messageEvent!.echoOfEventId! : event.id,
@@ -233,7 +238,9 @@
 
   const editEventId = $derived(isEcho ? messageEvent!.echoOfEventId! : event.id);
   const editThreadRootEventId = $derived(
-    isEcho ? (messageEvent?.echoFromThreadRootEventId ?? null) : (messageEvent?.threadRootEventId ?? null)
+    isEcho
+      ? (messageEvent?.echoFromThreadRootEventId ?? null)
+      : (messageEvent?.threadRootEventId ?? null)
   );
   const editChannelEchoEventId = $derived(
     isEcho ? event.id : (messageEvent?.channelEchoEventId ?? null)
@@ -262,12 +269,7 @@
     if (!event) return;
     e.preventDefault();
     e.stopPropagation();
-    try {
-      await navigator.clipboard.writeText(buildMessageLinkURL(getActiveServer(), roomId, event.id));
-      toast.success('Message link copied');
-    } catch {
-      toast.error('Failed to copy link');
-    }
+    await copyMessageLinkToClipboard(getActiveServer(), roomId, event.id);
   }
 
   // Check if message has been edited (updatedAt is non-null)

--- a/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.svelte
@@ -69,6 +69,7 @@ Desktop only (pointer-fine); mobile uses the long-press action sheet instead.
   const actions = useMessageActions();
 
   const params: MessageActionParams = $derived({
+    serverId,
     roomId,
     messageEventId,
     eventId,


### PR DESCRIPTION
## Summary

- Add a Copy link action to message context menus and mobile action sheets.
- Reuse the existing message permalink clipboard helper for timestamp clicks and menu actions.
- Cover the new menu ordering and clipboard helper behavior with focused frontend tests.

## Testing

- `pnpm --dir frontend exec vitest run src/lib/components/menus/MessageContextMenu.svelte.spec.ts src/lib/messageLinks.spec.ts`
- `pnpm --dir frontend check`
- Browser verification on a disposable local E2E server
