### PR TITLE
fix(frontend): improve blockquote styling

### DIFF
--- a/frontend/src/lib/components/MessageContent.svelte.spec.ts
+++ b/frontend/src/lib/components/MessageContent.svelte.spec.ts
@@ -20,6 +20,24 @@ function member(login: string): RoomMember {
   };
 }
 
+function computedColorFor(property: string): string {
+  const element = document.createElement('div');
+  element.style.color = `var(${property})`;
+  document.body.appendChild(element);
+  const color = window.getComputedStyle(element).color;
+  element.remove();
+  return color;
+}
+
+function computedBorderColorFor(property: string): string {
+  const element = document.createElement('div');
+  element.style.borderLeft = `1px solid var(${property})`;
+  document.body.appendChild(element);
+  const color = window.getComputedStyle(element).borderLeftColor;
+  element.remove();
+  return color;
+}
+
 describe('renderMarkdown', () => {
   // Wait for the markdown renderer to initialize before running tests
   beforeAll(async () => {
@@ -275,6 +293,18 @@ describe('MessageContent component', () => {
 
     const wrapper = q(container, '.prose');
     await expect.element(wrapper).toBeInTheDocument();
+  });
+
+  it('styles blockquotes as distinct quote blocks', async () => {
+    const { container } = renderMessage('> quoted text\n>\n> second line');
+
+    await expect.poll(() => q(container, 'blockquote')).toBeTruthy();
+
+    const blockquote = q(container, 'blockquote')!;
+    const styles = window.getComputedStyle(blockquote);
+    expect(styles.borderLeftColor).not.toBe(computedBorderColorFor('--color-border'));
+    expect(styles.backgroundImage).toBe('none');
+    expect(styles.color).not.toBe(computedColorFor('--color-muted'));
   });
 
   it('renders links with security attributes', async () => {

--- a/frontend/src/lib/components/composer/TipTapEditor.svelte
+++ b/frontend/src/lib/components/composer/TipTapEditor.svelte
@@ -1207,10 +1207,21 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
   }
 
   :global(.tiptap-editor .ProseMirror blockquote) {
-    border-left: 3px solid var(--color-border);
-    padding-left: 1em;
-    color: var(--color-muted);
+    --composer-quote-border: color-mix(in srgb, var(--color-muted), var(--color-accent) 42%);
+    --composer-quote-text: color-mix(in srgb, var(--color-text), var(--color-muted) 48%);
+
+    border-left: 3px solid var(--composer-quote-border);
+    padding: 0.35em 0 0.35em 0.9em;
+    color: var(--composer-quote-text);
     font-style: italic;
+  }
+
+  :global(.tiptap-editor .ProseMirror blockquote > *) {
+    margin-block: 0;
+  }
+
+  :global(.tiptap-editor .ProseMirror blockquote > * + *) {
+    margin-top: 0.45em;
   }
 
   :global(.tiptap-editor .ProseMirror code:not(pre code)) {

--- a/frontend/src/prose.css
+++ b/frontend/src/prose.css
@@ -10,6 +10,8 @@
   --composer-code-title: #8250df;
   --composer-code-literal: #0550ae;
   --composer-code-attribute: #953800;
+  --prose-quote-border: color-mix(in srgb, var(--color-muted), var(--color-accent) 42%);
+  --prose-quote-text: color-mix(in srgb, var(--color-text), var(--color-muted) 48%);
 
   font-size: inherit;
   line-height: 1.5;
@@ -82,10 +84,18 @@
 
   /* Blockquotes */
   & blockquote {
-    border-left: 3px solid var(--color-border);
-    padding-left: 1em;
-    color: var(--color-muted);
+    border-left: 3px solid var(--prose-quote-border);
+    padding: 0.35em 0 0.35em 0.9em;
+    color: var(--prose-quote-text);
     font-style: italic;
+  }
+
+  & blockquote > * {
+    margin-block: 0;
+  }
+
+  & blockquote > * + * {
+    margin-top: 0.45em;
   }
 
   /* Inline code */


### PR DESCRIPTION
## Changes

- Improves rendered Markdown blockquote styling with a more visible themed quote rail, softer quote text, and tighter multi-paragraph spacing.
- Mirrors the same blockquote treatment in the TipTap composer so editing and rendered messages stay aligned.
- Adds a browser-mode component regression test for the blockquote rail, absence of background treatment, and text contrast.

## Tests

- `mise x -- pnpm test:unit --run --project client src/lib/components/MessageContent.svelte.spec.ts`
- `mise x -- pnpm check`
