### PR TITLE
feat: add simple and rich composer modes

### DIFF
--- a/frontend/e2e/audio-player.test.ts
+++ b/frontend/e2e/audio-player.test.ts
@@ -33,7 +33,7 @@ test.describe('audio player', () => {
 
         // User 1 uploads and sends an audio file
         await roomPage.fileInput.setInputFiles('e2e/fixtures/test-audio.mp3');
-        await roomPage.messageInput.press('Control+Enter');
+        await roomPage.messageInput.press('Enter');
 
         // User 1 sees the audio player
         await expect(roomPage.audioPlayer).toBeVisible({ timeout: TIMEOUTS.COMPLEX_OPERATION });

--- a/frontend/e2e/auto-scroll.test.ts
+++ b/frontend/e2e/auto-scroll.test.ts
@@ -789,7 +789,7 @@ Line 7: Sunt in culpa qui officia deserunt mollit anim id est laborum.
 Line 8: This is the last line of this long message.`;
 
     await roomPage.messageInput.fill(longMessage);
-    await roomPage.messageInput.press('Control+Enter');
+    await roomPage.messageInput.press('Enter');
 
     // Wait for the message to appear
     await expect(page.getByText('Line 8: This is the last line of this long message.')).toBeVisible(

--- a/frontend/e2e/composer.test.ts
+++ b/frontend/e2e/composer.test.ts
@@ -160,8 +160,8 @@ test.describe('Composer focus', () => {
   });
 });
 
-test.describe('Composer keyboard submit hint', () => {
-  test('sends when Enter is pressed from a trailing blank paragraph', async ({
+test.describe('Composer simple/rich keyboard modes', () => {
+  test('sends simple text with Enter and hides the rich shortcut hint', async ({
     page,
     chatPage,
     roomPage
@@ -174,12 +174,33 @@ test.describe('Composer keyboard submit hint', () => {
     const message = `Return again send ${Date.now()}`;
     await roomPage.waitForInputEditable();
     await roomPage.messageInput.fill(message);
-    await expect(page.getByText(/(?:Cmd|Ctrl)\+Return to Send/)).toBeVisible();
+    await expect(page.getByText(/(?:Cmd|Ctrl)\+Return to Send/)).not.toBeVisible();
 
     await roomPage.messageInput.press('Enter');
+    await expect(roomPage.getMessage(message).locator).toBeVisible({ timeout: TIMEOUTS.UI_FAST });
+    await expect(roomPage.messageInput).toHaveText('');
+  });
+
+  test('activates rich mode with Control+Enter before sending', async ({
+    page,
+    chatPage,
+    roomPage
+  }) => {
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.enterRoom('general');
+    await waitForRoomReady(page, 'general');
+
+    const message = `Manual rich send ${Date.now()}`;
+    await roomPage.waitForInputEditable();
+    await roomPage.messageInput.fill(message);
+
+    await roomPage.messageInput.press('Control+Enter');
+    await expect(roomPage.getMessage(message).locator).not.toBeVisible();
+    await expect(roomPage.messageInput.locator(':scope > p')).toHaveCount(2);
     await expect(page.getByText(/(?:Return|Enter) again to Send/)).toBeVisible();
 
-    await roomPage.messageInput.press('Enter');
+    await roomPage.messageInput.press('Control+Enter');
     await expect(roomPage.getMessage(message).locator).toBeVisible({ timeout: TIMEOUTS.UI_FAST });
     await expect(roomPage.messageInput).toHaveText('');
   });

--- a/frontend/e2e/drag-drop-upload.test.ts
+++ b/frontend/e2e/drag-drop-upload.test.ts
@@ -12,7 +12,7 @@ test.describe('drag and drop image upload', () => {
 
     const testMessage = `Drag drop test ${Date.now()}`;
     await roomPage.messageInput.fill(testMessage);
-    await roomPage.messageInput.press('Control+Enter');
+    await roomPage.messageInput.press('Enter');
 
     await expect(roomPage.attachmentPreview).not.toBeVisible();
     await roomPage.expectMessageVisible(testMessage);

--- a/frontend/e2e/emoji-autocomplete.test.ts
+++ b/frontend/e2e/emoji-autocomplete.test.ts
@@ -36,7 +36,7 @@ test.describe('Emoji autocomplete (composer integration)', () => {
     await expect(popup).not.toBeVisible();
     await expect(roomPage.messageInput).toHaveText(/👋/);
 
-    await roomPage.messageInput.press('Control+Enter');
+    await roomPage.messageInput.press('Enter');
     await expect(page.locator('[role="article"]', { hasText: '👋' })).toBeVisible({
       timeout: TIMEOUTS.UI_STANDARD
     });

--- a/frontend/e2e/fixtures/realtimeSync.ts
+++ b/frontend/e2e/fixtures/realtimeSync.ts
@@ -32,7 +32,7 @@ export async function verifyRealtimeSync(
 
   // Sender sends sync message
   await senderRoom.messageInput.fill(syncId);
-  await senderRoom.messageInput.press('Control+Enter');
+  await senderRoom.messageInput.press('Enter');
 
   // Receiver waits to see it (proves subscription is connected)
   await expect(receiverRoom.page.getByText(syncId)).toBeVisible({ timeout });

--- a/frontend/e2e/gif-to-video.test.ts
+++ b/frontend/e2e/gif-to-video.test.ts
@@ -41,7 +41,7 @@ test.describe('animated GIF to video conversion @ffmpeg', () => {
       await expect(roomPage.attachmentPreview).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
 
       // Send the message
-      await roomPage.messageInput.press('Control+Enter');
+      await roomPage.messageInput.press('Enter');
 
       // Wait for preview to clear (message sent)
       await expect(roomPage.attachmentPreview).not.toBeVisible({
@@ -104,7 +104,7 @@ test.describe('animated GIF to video conversion @ffmpeg', () => {
     await expect(roomPage.attachmentPreview).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
 
     // Send the message
-    await roomPage.messageInput.press('Control+Enter');
+    await roomPage.messageInput.press('Enter');
     await expect(roomPage.attachmentPreview).not.toBeVisible({
       timeout: TIMEOUTS.COMPLEX_OPERATION
     });

--- a/frontend/e2e/link-previews.test.ts
+++ b/frontend/e2e/link-previews.test.ts
@@ -68,7 +68,7 @@ test.describe('Link previews', () => {
     await expect(composerPreview).toBeVisible({ timeout: TIMEOUTS.COMPLEX_OPERATION });
 
     // Now send — the preview data is included in the mutation
-    await roomPage.messageInput.press('Control+Enter');
+    await roomPage.messageInput.press('Enter');
     await expect(page.getByText(messageText)).toBeVisible();
 
     // The preview should be visible on the posted message (stored at post-time)
@@ -119,7 +119,7 @@ test.describe('Link previews', () => {
     });
 
     // Send the message (preview data included in mutation)
-    await roomPage.messageInput.press('Control+Enter');
+    await roomPage.messageInput.press('Enter');
     await expect(page.getByText(messageText)).toBeVisible();
 
     // Wait for the preview to appear on the posted message
@@ -165,7 +165,7 @@ test.describe('Link previews', () => {
     });
 
     // Send the message (preview data included in mutation)
-    await roomPage.messageInput.press('Control+Enter');
+    await roomPage.messageInput.press('Enter');
     await expect(page.getByText(messageText)).toBeVisible();
 
     // Wait for the first preview to appear

--- a/frontend/e2e/mention-autocomplete.test.ts
+++ b/frontend/e2e/mention-autocomplete.test.ts
@@ -28,7 +28,7 @@ test.describe('Mention autocomplete', () => {
 
     await expect(roomPage.messageInput).toHaveText(`@${user.login} `);
     await roomPage.messageInput.pressSequentially('hello');
-    await roomPage.messageInput.press('Control+Enter');
+    await roomPage.messageInput.press('Enter');
 
     await expect(page.locator('[role="article"]', { hasText: `@${user.login} hello` })).toBeVisible(
       { timeout: TIMEOUTS.UI_STANDARD }

--- a/frontend/e2e/message-duplicate.test.ts
+++ b/frontend/e2e/message-duplicate.test.ts
@@ -22,10 +22,12 @@ test.describe('Message duplication bug', () => {
 
     // Post a message
     await roomPage.messageInput.fill(testMessage);
-    await roomPage.messageInput.press('Control+Enter');
+    await roomPage.messageInput.press('Enter');
 
     // Wait for message to appear (use first() to avoid strict mode with duplicates)
-    await expect(page.getByText(testMessage).first()).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+    await expect(page.getByText(testMessage).first()).toBeVisible({
+      timeout: TIMEOUTS.UI_STANDARD
+    });
 
     // Poll for message count stability - verify exactly 1 message with this text
     // This replaces an arbitrary timeout with deterministic polling
@@ -38,9 +40,7 @@ test.describe('Message duplication bug', () => {
     const count = await messagesWithText.count();
 
     // Print relevant console logs for debugging BEFORE the assertion
-    const relevantLogs = consoleLogs.filter(
-      (log) => log.includes('SpaceEventBus')
-    );
+    const relevantLogs = consoleLogs.filter((log) => log.includes('SpaceEventBus'));
     console.log('\n=== Console logs ===');
     for (const log of relevantLogs) {
       console.log(log);

--- a/frontend/e2e/message-editing.test.ts
+++ b/frontend/e2e/message-editing.test.ts
@@ -440,14 +440,14 @@ test.describe('Message editing', () => {
     await chatPage.enterRoom('general');
 
     // Compose "line1" + blank line + "line2". Shift+Enter inserts a hard
-    // break in the composer; Ctrl+Enter submits the message.
+    // break in the composer; Enter submits the simple-mode message.
     await roomPage.waitForInputEditable();
     await roomPage.messageInput.click();
     await page.keyboard.type('line1');
     await page.keyboard.press('Shift+Enter');
     await page.keyboard.press('Shift+Enter');
     await page.keyboard.type('line2');
-    await roomPage.messageInput.press('Control+Enter');
+    await roomPage.messageInput.press('Enter');
 
     const message = roomPage.getMessage('line1');
     await expect(message.locator).toBeVisible();

--- a/frontend/e2e/message-links.test.ts
+++ b/frontend/e2e/message-links.test.ts
@@ -196,8 +196,10 @@ test.describe('Message links', () => {
       timeout: TIMEOUTS.UI_STANDARD
     });
 
-    // Click "Jump to Present" to return to the latest messages
-    await page.getByTestId('jump-to-present').click();
+    // Activate "Jump to Present" to return to the latest messages. The floating
+    // button can sit over a moving scroll layer, so avoid pointer interception
+    // from timeline content while still exercising the button's click handler.
+    await page.getByTestId('jump-to-present').evaluate((button: HTMLElement) => button.click());
 
     // The latest filler should become visible
     await expect(page.getByText(`Filler 60 - ${timestamp}`)).toBeVisible({
@@ -250,9 +252,10 @@ test.describe('Message links', () => {
       timeout: TIMEOUTS.UI_STANDARD
     });
 
-    // The target message should be visible (scope to <p> to avoid matching the preview card snippet)
-    await expect(page.locator('p', { hasText: targetBody })).toBeVisible({
-      timeout: TIMEOUTS.REALTIME_EVENT
-    });
+    // The target message should be visible. The same text can also appear in
+    // the link preview card, so avoid a strict locator over all matching <p>s.
+    await expect(
+      page.locator('[role="article"] .prose p', { hasText: targetBody }).first()
+    ).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
   });
 });

--- a/frontend/e2e/messages.test.ts
+++ b/frontend/e2e/messages.test.ts
@@ -588,7 +588,7 @@ test('image lightbox supports keyboard navigation with multiple images', async (
   await expect(roomPage.attachmentPreview).toHaveCount(2);
 
   // Send the message
-  await roomPage.messageInput.press('Control+Enter');
+  await roomPage.messageInput.press('Enter');
 
   // Wait for both attachment images to appear in the message
   await expect(roomPage.attachmentImage).toHaveCount(2, { timeout: TIMEOUTS.COMPLEX_OPERATION });

--- a/frontend/e2e/pages/RoomPage.ts
+++ b/frontend/e2e/pages/RoomPage.ts
@@ -155,7 +155,8 @@ export class RoomPage {
   async sendMessage(text: string): Promise<MessageComponent> {
     await this.waitForInputEditable();
     await this.messageInput.fill(text);
-    await this.messageInput.press('Control+Enter');
+    await this.dismissAutocompleteIfOpen(this.messageInput);
+    await this.messageInput.press('Enter');
     const message = this.getMessage(text);
     await expect(message.locator).toBeVisible({ timeout: TIMEOUTS.UI_FAST });
     return message;
@@ -192,7 +193,8 @@ export class RoomPage {
     if (text) {
       await this.messageInput.fill(text);
     }
-    await this.messageInput.press('Control+Enter');
+    await this.dismissAutocompleteIfOpen(this.messageInput);
+    await this.messageInput.press('Enter');
 
     // Wait for attachment preview to clear (message sent)
     await expect(this.attachmentPreview).not.toBeVisible();
@@ -554,7 +556,8 @@ export class RoomPage {
       timeout: TIMEOUTS.UI_STANDARD
     });
     await this.threadReplyInput.fill(text);
-    await this.threadReplyInput.press('Control+Enter');
+    await this.dismissAutocompleteIfOpen(this.threadReplyInput);
+    await this.threadReplyInput.press('Enter');
     await expect(this.threadPane.getByText(text)).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
   }
 
@@ -575,9 +578,20 @@ export class RoomPage {
 
     // Post the reply
     await this.threadReplyInput.fill(text);
-    await this.threadReplyInput.press('Control+Enter');
+    await this.dismissAutocompleteIfOpen(this.threadReplyInput);
+    await this.threadReplyInput.press('Enter');
     // Wait for message to appear in thread pane specifically
     await expect(this.threadPane.getByText(text)).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+  }
+
+  private async dismissAutocompleteIfOpen(input: Locator): Promise<void> {
+    const popup = this.page
+      .locator('[data-testid="mention-autocomplete"], [data-testid="emoji-autocomplete"]')
+      .first();
+    await popup.waitFor({ state: 'visible', timeout: 250 }).catch(() => undefined);
+    if (await popup.isVisible()) {
+      await input.press('Escape');
+    }
   }
 
   /**

--- a/frontend/e2e/room-files.test.ts
+++ b/frontend/e2e/room-files.test.ts
@@ -42,7 +42,7 @@ test('room Files sidebar jumps to root files and opens thread reply files', asyn
     timeout: TIMEOUTS.UI_STANDARD
   });
   await roomPage.threadReplyInput.fill(threadReplyText);
-  await roomPage.threadReplyInput.press('Control+Enter');
+  await roomPage.threadReplyInput.press('Enter');
   await roomPage.expectTextInThreadPane(threadReplyText);
   await roomPage.closeThread();
 

--- a/frontend/e2e/thread-reply-echo.test.ts
+++ b/frontend/e2e/thread-reply-echo.test.ts
@@ -1211,7 +1211,7 @@ test.describe('Thread Reply Echo ("Also send to channel")', () => {
       // Post the reply
       const replyBody = `Reply to target ${timestamp}`;
       await page.getByTestId('thread-reply-input').fill(replyBody);
-      await page.getByTestId('thread-reply-input').press('Control+Enter');
+      await page.getByTestId('thread-reply-input').press('Enter');
 
       // Wait for reply to appear
       await expect(page.getByTestId('thread-pane').getByText(replyBody)).toBeVisible({
@@ -1296,7 +1296,7 @@ test.describe('Thread Reply Echo ("Also send to channel")', () => {
 
       // Post the reply
       await page.getByTestId('thread-reply-input').fill(echoBody);
-      await page.getByTestId('thread-reply-input').press('Control+Enter');
+      await page.getByTestId('thread-reply-input').press('Enter');
 
       // Wait for the echo reply to appear in the thread
       await expect(page.getByTestId('thread-pane').getByText(echoBody)).toBeVisible({

--- a/frontend/e2e/video-player.test.ts
+++ b/frontend/e2e/video-player.test.ts
@@ -47,7 +47,7 @@ test.describe('video player @ffmpeg', () => {
         });
 
         // Send the message
-        await roomPage.messageInput.press('Control+Enter');
+        await roomPage.messageInput.press('Enter');
 
         // Wait for preview to clear (message sent)
         await expect(roomPage.videoAttachmentPreview).not.toBeVisible({
@@ -115,7 +115,7 @@ test.describe('video player @ffmpeg', () => {
       });
       await expect(roomPage.videoAttachmentPreview).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
 
-      await roomPage.messageInput.press('Control+Enter');
+      await roomPage.messageInput.press('Enter');
       await expect(roomPage.videoAttachmentPreview).not.toBeVisible({
         timeout: TIMEOUTS.COMPLEX_OPERATION
       });

--- a/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -198,6 +198,7 @@
       editSeededForEvent = eventId;
       draftState.clearText();
       message = originalBody;
+      manualRichMode = false;
       alsoSendToChannel = editState.channelEchoEventId !== null;
       api?.setContent(originalBody);
       tick().then(() => api?.focus('end'));
@@ -206,6 +207,7 @@
     } else if (editSeededForEvent && !eventId) {
       // Exiting edit mode - clear the input
       message = '';
+      manualRichMode = false;
       alsoSendToChannel = false;
       editSeededForEvent = '';
       api?.setContent('');
@@ -223,6 +225,7 @@
 
     const draft = draftState.switchKey(DRAFT_KEY);
     message = draft;
+    manualRichMode = false;
     editorApi?.setContent(draft);
     attachments.restore(untrack(() => draftState.takeFiles()));
 
@@ -316,9 +319,16 @@
       (hasVisibleContent(message) || hasSendableAttachments || isEditing)
   );
   let editorNextEnterWillSend = $state(false);
-  let nextEnterWillSend = $derived(canSubmit && editorNextEnterWillSend);
+  let manualRichMode = $state(false);
+  let editorHasRichStructure = $state(false);
+  let isRichComposer = $derived(isEditing || manualRichMode || editorHasRichStructure);
+  let nextEnterWillSend = $derived(canSubmit && isRichComposer && editorNextEnterWillSend);
   let submitHint = $derived(
-    shortcutHints ? (nextEnterWillSend ? shortcutHints.enterAgain : shortcutHints.submit) : null
+    shortcutHints && isRichComposer
+      ? nextEnterWillSend
+        ? shortcutHints.enterAgain
+        : shortcutHints.submit
+      : null
   );
 
   $effect(() => {
@@ -464,6 +474,7 @@
     inReplyTo: string | null;
     linkPreviewInput: ReturnType<typeof linkPreviews.buildInput>;
     alsoSendToChannel: boolean;
+    wasRichComposer: boolean;
   };
 
   type PendingMentionConfirmation = PreparedPost & MentionConfirmation;
@@ -513,6 +524,7 @@
 
   function restorePreparedPost(post: PreparedPost) {
     message = post.bodyToSend;
+    manualRichMode = post.wasRichComposer;
     editorApi?.setContent(post.bodyToSend);
     if (post.filesToSend) {
       attachments.restore(attachments.filesToPreviewItems(post.filesToSend));
@@ -551,6 +563,7 @@
 
     // Reset "also send to channel" checkbox after successful send
     alsoSendToChannel = false;
+    manualRichMode = false;
   }
 
   function cancelMentionConfirmation() {
@@ -595,12 +608,14 @@
       threadRootEventId: inThread ?? null,
       inReplyTo: inReplyTo ?? null,
       linkPreviewInput: linkPreviews.buildInput(),
-      alsoSendToChannel
+      alsoSendToChannel,
+      wasRichComposer: isRichComposer
     };
 
     // Optimistically clear the editor so the user can start typing the next
     // message immediately (matches Slack/Discord behavior).
     message = '';
+    manualRichMode = false;
     editorApi?.setContent('');
     attachments.clear();
     linkPreviews.clear();
@@ -676,17 +691,13 @@
   function cancelEdit() {
     editState.cancelEdit();
     message = '';
+    manualRichMode = false;
     editorApi?.setContent('');
   }
 
   // Handle keyboard events from TipTap editor.
   // Return true to prevent TipTap's default handling.
   function handleEditorKeyDown(event: KeyboardEvent): boolean {
-    if (event.key === 'Enter' && !event.shiftKey && (event.metaKey || event.ctrlKey)) {
-      handleSubmit(); // Fire-and-forget (async, but keydown must return sync)
-      return true;
-    }
-
     // Handle emoji autocomplete keyboard events first
     if (autocomplete.emoji && autocomplete.emojiRef) {
       if (autocomplete.emojiRef.handleKeyDown(event)) {
@@ -701,15 +712,26 @@
       }
     }
 
-    if (
-      event.key === 'Enter' &&
-      !event.shiftKey &&
-      !event.metaKey &&
-      !event.ctrlKey &&
-      nextEnterWillSend
-    ) {
-      handleSubmit(); // Fire-and-forget (async, but keydown must return sync)
-      return true;
+    if (event.key === 'Enter' && !event.shiftKey) {
+      if (event.metaKey || event.ctrlKey) {
+        if (isRichComposer) {
+          handleSubmit(); // Fire-and-forget (async, but keydown must return sync)
+        } else {
+          manualRichMode = true;
+          editorApi?.insertBlockBreak();
+        }
+        return true;
+      }
+
+      if (!isRichComposer) {
+        if (canSubmit) {
+          handleSubmit(); // Fire-and-forget (async, but keydown must return sync)
+          return true;
+        }
+      } else if (nextEnterWillSend) {
+        handleSubmit(); // Fire-and-forget (async, but keydown must return sync)
+        return true;
+      }
     }
 
     // Handle Tab for @mention autocomplete
@@ -760,6 +782,9 @@
   function handleEditorUpdate(text: string) {
     const previousMessage = message;
     message = text;
+    if (!text) {
+      manualRichMode = false;
+    }
     // Only trigger typing indicator for actual user input.
     // Programmatic setContent calls suppress TipTap update events, but this
     // guard still protects any same-value editor update from emitting typing.
@@ -767,6 +792,10 @@
       onTyping?.();
     }
     autocomplete.update();
+  }
+
+  function handleRichStructureChange(value: boolean) {
+    editorHasRichStructure = value;
   }
 
   // Called when TipTap editor is ready - sync any pending state
@@ -914,6 +943,7 @@
         onKeyDown={handleEditorKeyDown}
         onPaste={handlePaste}
         onNextEnterWillSendChange={(value) => (editorNextEnterWillSend = value)}
+        onRichStructureChange={handleRichStructureChange}
         onReady={handleEditorReady}
       />
     {/await}
@@ -937,7 +967,7 @@
         disabled={!canSubmit}
         class="flex h-8 w-8 cursor-pointer items-center justify-center rounded text-muted transition-colors duration-100 enabled:hover:text-text disabled:cursor-not-allowed disabled:opacity-50"
         aria-label="Send message"
-        title="Send message (Ctrl/Cmd+Enter)"
+        title={isRichComposer ? 'Send message (Ctrl/Cmd+Enter)' : 'Send message (Enter)'}
       >
         <span class="iconify text-xl uil--telegram-alt"></span>
       </button>

--- a/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -526,7 +526,7 @@ describe('MessageComposer', () => {
       expect(icon).not.toBeNull();
     });
 
-    it('shows a compact keyboard shortcut hint when the composer can submit', async () => {
+    it('hides the keyboard shortcut hint in simple mode', async () => {
       const { container } = renderMessageComposer(
         { roomId: 'room_456' },
         new Map([['$$_urql', mockClient]])
@@ -536,9 +536,23 @@ describe('MessageComposer', () => {
       expect(q(container, '[title$="Return to Send"]')).toBeNull();
       await typeEditorLiteralText(editor, 'hint me');
 
+      expect(q(container, '[title$="Return to Send"]')).toBeNull();
+    });
+
+    it('shows the enter-again hint after manually activating rich mode', async () => {
+      const { container } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = await findEditor(container);
+
+      await typeEditorLiteralText(editor, 'hint me');
+      await pressEditorKey(editor, 'Enter', { ctrlKey: true });
+
+      await vi.waitFor(() => expect(editor.querySelectorAll(':scope > p')).toHaveLength(2));
       await vi.waitFor(() => {
-        const hint = q(container, '[title$="Return to Send"]');
-        expect(hint?.textContent).toMatch(/^(Cmd|Ctrl)\+Return to Send$/);
+        const hint = q(container, '[title$="to Send"]');
+        expect(hint?.textContent).toMatch(/^(Return|Enter) again to Send$/);
       });
     });
 
@@ -1042,6 +1056,28 @@ describe('MessageComposer', () => {
       expect(mutationMock).not.toHaveBeenCalled();
     });
 
+    it('keeps edit mode on rich keyboard behavior', async () => {
+      roomStateMock.editState.eventId = 'evt_edit';
+      roomStateMock.editState.originalBody = 'original body';
+      const { container } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = await findEditor(container);
+
+      await vi.waitFor(() => expect(container.textContent).toMatch(/(?:Cmd|Ctrl)\+Return to Send/));
+      await pressEditorKey(editor, 'Enter');
+      expect(mutationMock).not.toHaveBeenCalled();
+
+      await pressEditorKey(editor, 'Enter', { ctrlKey: true });
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({
+        eventId: 'evt_edit',
+        body: 'original body'
+      });
+    });
+
     it('preserves literal HTML-looking text when restoring and saving an edit', async () => {
       const body = '<script>alert(1)</script> & <b>bold?</b>';
       const editedBody = `${body}!`;
@@ -1121,7 +1157,7 @@ describe('MessageComposer', () => {
   });
 
   describe('submit behavior', () => {
-    it('uses Enter to complete an active mention before Ctrl+Enter can send', async () => {
+    it('uses Enter to complete an active mention before plain Enter can send', async () => {
       roomStateMock.members = [roomMember('alice')];
       const { container, roomId } = renderMessageComposer(
         { roomId: 'room_456' },
@@ -1139,7 +1175,7 @@ describe('MessageComposer', () => {
       await vi.waitFor(() => expect(editor.textContent).toBe('@alice '));
       expect(mutationMock).not.toHaveBeenCalled();
 
-      await pressEditorKey(editor, 'Enter', { ctrlKey: true });
+      await pressEditorKey(editor, 'Enter');
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -1148,7 +1184,7 @@ describe('MessageComposer', () => {
       });
     });
 
-    it('sends plain text with Ctrl+Enter', async () => {
+    it('sends plain text with Enter in simple mode', async () => {
       const { container, roomId } = renderMessageComposer(
         { roomId: 'room_456' },
         new Map([['$$_urql', mockClient]])
@@ -1156,7 +1192,7 @@ describe('MessageComposer', () => {
       const editor = await findEditor(container);
 
       await typeEditorLiteralText(editor, 'hello from shortcut');
-      await pressEditorKey(editor, 'Enter', { ctrlKey: true });
+      await pressEditorKey(editor, 'Enter');
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
@@ -1165,27 +1201,27 @@ describe('MessageComposer', () => {
       });
     });
 
-    it('sends with plain Enter from a trailing blank paragraph', async () => {
+    it('activates rich mode with Ctrl+Enter in simple mode', async () => {
       const { container, roomId } = renderMessageComposer(
         { roomId: 'room_456' },
         new Map([['$$_urql', mockClient]])
       );
       const editor = await findEditor(container);
 
-      await typeEditorLiteralText(editor, 'hello from return');
-      await vi.waitFor(() => expect(container.textContent).toMatch(/(?:Cmd|Ctrl)\+Return to Send/));
-      await pressEditorKey(editor, 'Enter');
+      await typeEditorLiteralText(editor, 'hello from shortcut');
+      await pressEditorKey(editor, 'Enter', { ctrlKey: true });
       expect(mutationMock).not.toHaveBeenCalled();
+      await vi.waitFor(() => expect(editor.querySelectorAll(':scope > p')).toHaveLength(2));
       await vi.waitFor(() =>
         expect(container.textContent).toMatch(/(?:Return|Enter) again to Send/)
       );
 
-      await pressEditorKey(editor, 'Enter');
+      await pressEditorKey(editor, 'Enter', { ctrlKey: true });
 
       await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
         roomId,
-        body: 'hello from return'
+        body: 'hello from shortcut'
       });
     });
 
@@ -1404,7 +1440,7 @@ describe('MessageComposer', () => {
       const editor = await findEditor(container);
 
       await typeEditorLiteralText(editor, 'or this:');
-      await pressEditorKey(editor, 'Enter');
+      await pressEditorKey(editor, 'Enter', { ctrlKey: true });
       await insertEditorLiteralText(editor, '```go ');
 
       await vi.waitFor(() => expect(editor.querySelector('pre code')).toBeTruthy());
@@ -2054,15 +2090,24 @@ describe('MessageComposer', () => {
         .toHaveAttribute('title', 'Attach file');
     });
 
-    it('send button has title attribute', async () => {
+    it('send button title follows composer mode', async () => {
       const { container } = renderMessageComposer(
         { roomId: 'room_456' },
         new Map([['$$_urql', mockClient]])
       );
+      const editor = await findEditor(container);
 
       await expect
         .element(q(container, 'button[aria-label="Send message"]'))
-        .toHaveAttribute('title', 'Send message (Ctrl/Cmd+Enter)');
+        .toHaveAttribute('title', 'Send message (Enter)');
+
+      await typeEditorLiteralText(editor, '- first');
+      await vi.waitFor(() =>
+        expect(q(container, 'button[aria-label="Send message"]')).toHaveAttribute(
+          'title',
+          'Send message (Ctrl/Cmd+Enter)'
+        )
+      );
     });
   });
 });

--- a/frontend/src/lib/components/composer/TipTapEditor.svelte
+++ b/frontend/src/lib/components/composer/TipTapEditor.svelte
@@ -13,6 +13,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
 - `onKeyDown` - Keyboard event handler; return true to prevent TipTap default
 - `onPaste` - Paste event handler; return true to prevent TipTap default
 - `onNextEnterWillSendChange` - Called when selection enters/leaves a trailing empty paragraph
+- `onRichStructureChange` - Called when the document gains/loses structural Markdown blocks
 - `onReady` - Called with editor API when editor is initialized
 -->
 <script lang="ts">
@@ -634,6 +635,20 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     return previousNode.type.name !== 'paragraph' || previousNode.content.size > 0;
   }
 
+  function hasRichStructure(e: Editor): boolean {
+    let found = false;
+    e.state.doc.descendants((node) => {
+      if (
+        ['heading', 'bulletList', 'orderedList', 'blockquote', 'codeBlock'].includes(node.type.name)
+      ) {
+        found = true;
+        return false;
+      }
+      return true;
+    });
+    return found;
+  }
+
   export type TipTapEditorApi = {
     /** Get the editor's plain text content */
     getText: () => string;
@@ -651,6 +666,8 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
      * length relative to the cursor.
      */
     replaceTextBeforeCursor: (charCount: number, replacement: string) => void;
+    /** Insert the same block break the editor would create for a plain Enter key. */
+    insertBlockBreak: () => void;
   };
 
   let {
@@ -662,6 +679,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     onKeyDown,
     onPaste,
     onNextEnterWillSendChange,
+    onRichStructureChange,
     onReady
   }: {
     placeholder?: string;
@@ -672,6 +690,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     onKeyDown?: (event: KeyboardEvent) => boolean;
     onPaste?: (event: ClipboardEvent) => boolean;
     onNextEnterWillSendChange?: (value: boolean) => void;
+    onRichStructureChange?: (value: boolean) => void;
     onReady?: (api: TipTapEditorApi) => void;
   } = $props();
 
@@ -686,6 +705,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
   let linkDraftInitializedFor = $state<string | null>(null);
   let codeLanguageLoadToken = 0;
   let lastNextEnterWillSend = false;
+  let lastRichStructure = false;
 
   let hasLinkControls = $derived(activeLinkHref !== null);
   let activeCodeBlockLanguageLabel = $derived(
@@ -766,6 +786,13 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     if (value === lastNextEnterWillSend) return;
     lastNextEnterWillSend = value;
     onNextEnterWillSendChange?.(value);
+  }
+
+  function updateRichStructure(e: Editor) {
+    const value = !e.isDestroyed && hasRichStructure(e);
+    if (value === lastRichStructure) return;
+    lastRichStructure = value;
+    onRichStructureChange?.(value);
   }
 
   function updateActiveControls(e: Editor) {
@@ -912,6 +939,8 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     const syncControls = () => {
       if (e.isDestroyed) return;
       updateActiveControls(e);
+      updateNextEnterWillSend(e);
+      updateRichStructure(e);
     };
 
     return {
@@ -923,6 +952,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
           contentType: 'markdown',
           emitUpdate: false
         });
+        updateRichStructure(e);
         ensureEditorCodeLanguages(e);
         tick().then(syncControls);
       },
@@ -949,6 +979,12 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
           .deleteRange({ from: from - charCount, to: from })
           .insertContent(replacement)
           .run();
+        tick().then(syncControls);
+      },
+
+      insertBlockBreak: () => {
+        if (e.isDestroyed) return;
+        e.chain().focus().splitBlock().run();
         tick().then(syncControls);
       }
     };
@@ -1009,12 +1045,14 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
           onUpdate: ({ editor: ed }) => {
             updateActiveControls(ed);
             updateNextEnterWillSend(ed);
+            updateRichStructure(ed);
             ensureEditorCodeLanguages(ed);
             onUpdate?.(hasDefaultEmptyDocument(ed) ? '' : getSerializedMarkdown(ed));
           },
           onSelectionUpdate: ({ editor: ed }) => {
             updateActiveControls(ed);
             updateNextEnterWillSend(ed);
+            updateRichStructure(ed);
           }
         })
     );
@@ -1025,12 +1063,15 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     tick().then(() => {
       if (e.isDestroyed || editor !== e) return;
       updateNextEnterWillSend(e);
+      updateRichStructure(e);
       onReady?.(buildApi(e));
     });
 
     return () => {
       lastNextEnterWillSend = false;
       onNextEnterWillSendChange?.(false);
+      lastRichStructure = false;
+      onRichStructureChange?.(false);
       editor?.destroy();
       editor = null;
     };

--- a/frontend/src/lib/components/composer/autocomplete.svelte.spec.ts
+++ b/frontend/src/lib/components/composer/autocomplete.svelte.spec.ts
@@ -39,7 +39,8 @@ function editor(
       replaceTextBeforeCursor: (charCount, replacement) => {
         text = text.slice(0, cursor - charCount) + replacement + text.slice(cursor);
         cursor = cursor - charCount + replacement.length;
-      }
+      },
+      insertBlockBreak: () => {}
     },
     getText: () => text,
     setText: (next) => {


### PR DESCRIPTION
## Summary

- Add simple composer mode where Enter sends plain messages, while Cmd/Ctrl+Enter explicitly switches to rich mode and inserts a new block.
- Keep editing and structural Markdown drafts in rich mode, preserving multiline TipTap behavior and rich-mode shortcut hints.
- Update composer unit tests and E2E coverage, including normal posting helpers, for the new keyboard behavior.

## Verification

- `pnpm check`
- `pnpm lint`
- `pnpm vitest --run src/lib/components/composer/MessageComposer.svelte.spec.ts src/lib/components/composer/autocomplete.svelte.spec.ts`
- `pnpm exec playwright test e2e/mention-rendering.test.ts e2e/composer.test.ts`
- `pnpm exec playwright test e2e/notifications.test.ts e2e/threading.test.ts e2e/message-links.test.ts e2e/multi-server-identity.test.ts`
