### PR TITLE
fix: tighten sidebar item spacing

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -333,7 +333,7 @@
 }
 
 @utility sidebar-item {
-  @apply relative flex w-full shrink-0 cursor-pointer items-center gap-2 overflow-hidden rounded-md px-3 py-1.5 text-text;
+  @apply relative flex w-full shrink-0 cursor-pointer items-center gap-2 overflow-hidden rounded-md px-1 py-1 text-text;
   @apply hover:bg-surface-100 hover:text-text;
 }
 

--- a/frontend/src/lib/ui/CollapsibleGroup.svelte
+++ b/frontend/src/lib/ui/CollapsibleGroup.svelte
@@ -70,7 +70,7 @@ offline member groups).
   <button
     type="button"
     onclick={toggle}
-    class="flex w-full cursor-pointer items-center gap-2 px-3 py-1 text-xs font-semibold tracking-wider text-muted uppercase transition-colors hover:text-text"
+    class="flex w-full cursor-pointer items-center gap-2 px-1 py-1 text-xs font-semibold tracking-wider text-muted uppercase transition-colors hover:text-text"
   >
     <span class="sidebar-icon">
       <span


### PR DESCRIPTION
Changes:
- Tightens shared sidebar item padding from `px-3 py-1.5` to `px-1 py-1`.
- Aligns collapsible group headers with the new sidebar row inset.

Checks:
- `pnpm -C frontend check`
