### PR TITLE
fix(frontend): add embed frame vertical spacing

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -266,7 +266,7 @@
 
 /* Embed frame utility (attachments, link previews, embedded messages, video embeds) */
 @utility embed-frame {
-  @apply overflow-hidden rounded-md border border-border bg-surface-100 shadow-sm outline-[3px] outline-offset-0 outline-surface-300 transition-shadow hover:shadow-md focus-visible:shadow-md;
+  @apply my-1.5 overflow-hidden rounded-md border border-border bg-surface-100 shadow-sm outline-[3px] outline-offset-0 outline-surface-300 transition-shadow hover:shadow-md focus-visible:shadow-md;
 }
 
 @utility embed-control-button {


### PR DESCRIPTION
- Add `my-1.5` vertical spacing to the shared `embed-frame` utility.
- Applies consistently to bordered embeds such as attachments, link previews, embedded messages, and video embeds.
- Verified with `pnpm -C frontend check` and a browser-computed style check.
