### PR TITLE
feat: quote selected text when replying

### DIFF
--- a/docs/fdr/FDR-002-replies-and-threads.md
+++ b/docs/fdr/FDR-002-replies-and-threads.md
@@ -13,6 +13,7 @@ Chatto messages can link to one another via reply attribution, and they can live
 - A reply renders with a byline above the message body: the referenced author's small avatar, name, and a single-line excerpt of the referenced message.
 - Clicking the byline transports the user to the referenced message and briefly highlights it.
 - Clicking the avatar or name in the byline opens the user's context menu.
+- If the user selects text inside a message body before choosing Reply or Reply in thread, the target composer inserts that selected plain text as a Markdown blockquote while preserving any existing draft text.
 - A thread is a sequence of messages starting from a root message and continuing inside a dedicated thread pane. Threads can contain plain messages or reply-attributed messages; both are valid.
 - A user can post a plain message into a room, a reply into the room timeline, a plain message into a thread, or a reply inside a thread — each gated by separate permissions, so a room can be configured for many threading styles.
 

--- a/frontend/e2e/threading.test.ts
+++ b/frontend/e2e/threading.test.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from '@playwright/test';
+import { expect, type Locator, type Page } from '@playwright/test';
 import { createAndLoginTestUser } from './fixtures/testUser';
 import { withServerUser } from './fixtures/serverUser';
 import { waitForRoomReady } from './fixtures/realtimeSync';
@@ -39,6 +39,31 @@ async function postReplyViaAPI(
   });
   const json = await response.json();
   return json.data.postMessage.id;
+}
+
+async function selectTextInside(locator: Locator, selectedText: string): Promise<void> {
+  await locator.evaluate((root, text) => {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    let node: Node | null = walker.nextNode();
+
+    while (node) {
+      const value = node.textContent ?? '';
+      const index = value.indexOf(text);
+      if (index !== -1) {
+        const range = document.createRange();
+        range.setStart(node, index);
+        range.setEnd(node, index + text.length);
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+        return;
+      }
+
+      node = walker.nextNode();
+    }
+
+    throw new Error(`Could not find text to select: ${text}`);
+  }, selectedText);
 }
 
 async function getIdsFromUrl(page: Page): Promise<{ spaceId: string; roomId: string }> {
@@ -309,6 +334,71 @@ test.describe('Message Threading', () => {
     await waitForRoomReady(page);
     await expect(page.getByText(roomReplyText)).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
     await expect(page.getByText('1 reply')).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+  });
+
+  test('reply quotes selected message text in the room composer', async ({
+    page,
+    chatPage,
+    roomPage
+  }) => {
+    const user = await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.enterRoom('general');
+
+    const timestamp = Date.now();
+    const selectedText = `selected room quote ${timestamp}`;
+    const rootBody = `Before ${selectedText} after`;
+    const rootMsg = await roomPage.sendMessage(rootBody);
+
+    await selectTextInside(rootMsg.locator, selectedText);
+    await rootMsg.replyInRoom();
+
+    await expect(page.getByText('Replying to')).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+    await expect(roomPage.messageInput.locator('blockquote')).toContainText(selectedText, {
+      timeout: TIMEOUTS.UI_STANDARD
+    });
+
+    const replyBody = `Room quote reply ${timestamp}`;
+    await page.keyboard.type(replyBody);
+    await roomPage.messageInput.press('Control+Enter');
+
+    const reply = roomPage.getMessage(replyBody);
+    await expect(reply.locator).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+    await expect(reply.locator.locator('blockquote')).toContainText(selectedText);
+    await expect(reply.locator.getByTestId('reply-attribution-author')).toContainText(
+      user.displayName
+    );
+  });
+
+  test('reply in thread quotes selected message text in the thread composer', async ({
+    page,
+    chatPage,
+    roomPage
+  }) => {
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.enterRoom('general');
+
+    const timestamp = Date.now();
+    const selectedText = `selected thread quote ${timestamp}`;
+    const rootBody = `Before ${selectedText} after`;
+    const rootMsg = await roomPage.sendMessage(rootBody);
+
+    await selectTextInside(rootMsg.locator, selectedText);
+    await rootMsg.openThread();
+    await roomPage.expectThreadPaneVisible();
+
+    await expect(roomPage.threadReplyInput.locator('blockquote')).toContainText(selectedText, {
+      timeout: TIMEOUTS.UI_STANDARD
+    });
+
+    const replyBody = `Thread quote reply ${timestamp}`;
+    await page.keyboard.type(replyBody);
+    await roomPage.threadReplyInput.press('Control+Enter');
+
+    const reply = roomPage.getThreadMessage(replyBody);
+    await expect(reply.locator).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+    await expect(reply.locator.locator('blockquote')).toContainText(selectedText);
   });
 
   test('switching threads clears previous thread messages', async ({

--- a/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -56,6 +56,7 @@
   export type MessageComposerApi = {
     addFiles: (files: File[]) => void;
     focus: () => void;
+    insertQuote: (text: string) => void;
   };
 
   let {
@@ -112,6 +113,7 @@
 
   const composerContext = getComposerContext();
   const editState = composerContext.editState;
+  const quoteInsertionState = composerContext.quoteInsertionState;
   const lastEditableMessageCtx = composerContext.lastEditableMessage;
   const scrollState = composerContext.scrollState;
   const isEditing = $derived(editState.eventId !== null);
@@ -409,9 +411,23 @@
     tick().then(() => editorApi?.focus());
   }
 
+  function insertQuote(text: string) {
+    tick().then(() => editorApi?.insertQuote(text));
+  }
+
+  let insertedQuoteRequestId = 0;
+  $effect(() => {
+    const request = quoteInsertionState.request;
+    const api = editorApi;
+    if (!request || !api || request.id === insertedQuoteRequestId) return;
+
+    insertedQuoteRequestId = request.id;
+    api.insertQuote(request.text);
+  });
+
   // Expose API to parent via onReady callback
   $effect(() => {
-    onReady?.({ addFiles, focus });
+    onReady?.({ addFiles, focus, insertQuote });
   });
 
   // Handle paste events - intercept images before TipTap processes them

--- a/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -53,6 +53,9 @@ const roomStateMock = vi.hoisted(() => ({
     startEdit: vi.fn(),
     cancelEdit: vi.fn()
   },
+  quoteInsertionState: {
+    request: null as { id: number; text: string } | null
+  },
   lastEditableMessage: {
     getLastEditableMessage: vi.fn(() => null as { eventId: string; body: string } | null),
     setFinder: vi.fn()
@@ -116,6 +119,7 @@ vi.mock('$lib/state/room', () => ({
   }),
   getComposerContext: () => ({
     editState: roomStateMock.editState,
+    quoteInsertionState: roomStateMock.quoteInsertionState,
     lastEditableMessage: roomStateMock.lastEditableMessage,
     scrollState: roomStateMock.scrollState
   })
@@ -293,6 +297,7 @@ describe('MessageComposer', () => {
     roomStateMock.editState.originalBody = '';
     roomStateMock.editState.startEdit.mockClear();
     roomStateMock.editState.cancelEdit.mockClear();
+    roomStateMock.quoteInsertionState.request = null;
     roomStateMock.lastEditableMessage.getLastEditableMessage.mockReset();
     roomStateMock.lastEditableMessage.getLastEditableMessage.mockReturnValue(null);
     roomStateMock.lastEditableMessage.setFinder.mockClear();
@@ -1199,6 +1204,76 @@ describe('MessageComposer', () => {
         roomId,
         body: 'hello from shortcut'
       });
+    });
+
+    it('inserts selected reply quotes without replacing draft text', async () => {
+      let composerApi: MessageComposerApi | null = null;
+      const { container } = renderMessageComposer(
+        {
+          roomId: 'room_456',
+          onReady: (api) => {
+            composerApi = api;
+          }
+        },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = await findEditor(container);
+
+      await typeInEditor(editor, 'draft');
+      await vi.waitFor(() => expect(composerApi).not.toBeNull());
+      composerApi!.insertQuote('quoted text');
+
+      await vi.waitFor(() => expect(editor.querySelector('blockquote')).toBeTruthy());
+      expect(editor.textContent).toContain('draft');
+      expect(editor.querySelector('blockquote')?.textContent).toBe('quoted text');
+    });
+
+    it('submits inserted selected reply quotes as blockquote markdown', async () => {
+      let composerApi: MessageComposerApi | null = null;
+      const { container, roomId } = renderMessageComposer(
+        {
+          roomId: 'room_456',
+          onReady: (api) => {
+            composerApi = api;
+          }
+        },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = await findEditor(container);
+
+      await typeInEditor(editor, 'draft');
+      await vi.waitFor(() => expect(composerApi).not.toBeNull());
+      composerApi!.insertQuote('quoted text');
+      await vi.waitFor(() => expect(editor.querySelector('blockquote')).toBeTruthy());
+
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({
+        roomId,
+        body: 'draft\n\n> quoted text'
+      });
+    });
+
+    it('preserves line breaks inside inserted reply quotes', async () => {
+      let composerApi: MessageComposerApi | null = null;
+      const { container } = renderMessageComposer(
+        {
+          roomId: 'room_456',
+          onReady: (api) => {
+            composerApi = api;
+          }
+        },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = await findEditor(container);
+
+      await vi.waitFor(() => expect(composerApi).not.toBeNull());
+      composerApi!.insertQuote('first line\nsecond line');
+
+      await vi.waitFor(() => expect(editor.querySelector('blockquote')).toBeTruthy());
+      expect(editor.querySelectorAll('blockquote p')).toHaveLength(2);
+      expect(editor.querySelector('blockquote')?.textContent).toBe('first linesecond line');
     });
 
     it('activates rich mode with Ctrl+Enter in simple mode', async () => {

--- a/frontend/src/lib/components/composer/TipTapEditor.svelte
+++ b/frontend/src/lib/components/composer/TipTapEditor.svelte
@@ -18,7 +18,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
 -->
 <script lang="ts">
   import { tick, untrack } from 'svelte';
-  import { Editor, Extension, InputRule, mergeAttributes } from '@tiptap/core';
+  import { Editor, Extension, InputRule, mergeAttributes, type JSONContent } from '@tiptap/core';
   import type { Node as ProseMirrorNode, Schema } from '@tiptap/pm/model';
   import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state';
   import StarterKit from '@tiptap/starter-kit';
@@ -666,6 +666,8 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
      * length relative to the cursor.
      */
     replaceTextBeforeCursor: (charCount: number, replacement: string) => void;
+    /** Insert selected reply text as a blockquote at the current cursor. */
+    insertQuote: (text: string) => void;
     /** Insert the same block break the editor would create for a plain Enter key. */
     insertBlockBreak: () => void;
   };
@@ -978,6 +980,29 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
           .focus()
           .deleteRange({ from: from - charCount, to: from })
           .insertContent(replacement)
+          .run();
+        tick().then(syncControls);
+      },
+
+      insertQuote: (text: string) => {
+        if (e.isDestroyed) return;
+        const normalized = text.replace(/\r\n?/g, '\n').trim();
+        if (!normalized) return;
+
+        const quoteParagraphs: JSONContent[] = normalized.split('\n').map((line) => ({
+          type: 'paragraph',
+          content: line ? [{ type: 'text', text: line }] : undefined
+        }));
+
+        e.chain()
+          .focus()
+          .insertContent([
+            {
+              type: 'blockquote',
+              content: quoteParagraphs
+            },
+            { type: 'paragraph' }
+          ])
           .run();
         tick().then(syncControls);
       },

--- a/frontend/src/lib/components/composer/autocomplete.svelte.spec.ts
+++ b/frontend/src/lib/components/composer/autocomplete.svelte.spec.ts
@@ -40,7 +40,8 @@ function editor(
         text = text.slice(0, cursor - charCount) + replacement + text.slice(cursor);
         cursor = cursor - charCount + replacement.length;
       },
-      insertBlockBreak: () => {}
+      insertBlockBreak: () => {},
+      insertQuote: () => {}
     },
     getText: () => text,
     setText: (next) => {

--- a/frontend/src/lib/state/room/composerContext.svelte.ts
+++ b/frontend/src/lib/state/room/composerContext.svelte.ts
@@ -51,6 +51,30 @@ export class ReplyState {
 }
 
 // ---------------------------------------------------------------------------
+// QuoteInsertionState — one-shot requests to insert selected reply quotes
+// ---------------------------------------------------------------------------
+
+export type QuoteInsertionRequest = {
+  id: number;
+  text: string;
+};
+
+export class QuoteInsertionState {
+  request = $state<QuoteInsertionRequest | null>(null);
+  private nextRequestId = 1;
+
+  requestInsertQuote(text: string) {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+
+    this.request = {
+      id: this.nextRequestId++,
+      text: trimmed
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
 // LastEditableMessageContext — finder for up-arrow-to-edit
 // ---------------------------------------------------------------------------
 
@@ -157,6 +181,7 @@ export interface ComposerContextOptions {
 export class ComposerContext {
   readonly editState = new EditState();
   readonly replyState = new ReplyState();
+  readonly quoteInsertionState = new QuoteInsertionState();
   readonly lastEditableMessage = new LastEditableMessageContext();
   readonly jumpState = new JumpToMessageState();
   readonly scrollState: ScrollState | null;

--- a/frontend/src/lib/state/room/index.ts
+++ b/frontend/src/lib/state/room/index.ts
@@ -12,7 +12,8 @@ export {
 export type {
   ComposerContextOptions,
   EditableMessage,
-  FindLastEditableMessage
+  FindLastEditableMessage,
+  QuoteInsertionRequest
 } from './composerContext.svelte';
 export {
   createRoomMembers,

--- a/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -80,7 +80,11 @@
     // Event updates
     updateCounter?: number;
     // Threading
-    onOpenThread?: (threadRootEventId: string, highlightEventId?: string) => void;
+    onOpenThread?: (
+      threadRootEventId: string,
+      highlightEventId?: string,
+      quoteText?: string
+    ) => void;
     // Filtering
     filterThreadReplies?: boolean;
     // Up-arrow-to-edit
@@ -713,13 +717,14 @@
     if (eventData.__typename === 'MessagePostedEvent') {
       // Echoes open the original thread
       if (eventData.echoOfEventId != null) {
-        return (_threadRootEventId: string, highlightEventId?: string) =>
-          onOpenThread(eventData.echoFromThreadRootEventId!, highlightEventId);
+        return (_threadRootEventId: string, highlightEventId?: string, quoteText?: string) =>
+          onOpenThread(eventData.echoFromThreadRootEventId!, highlightEventId, quoteText);
       }
       // Thread replies don't open threads from the main channel
       if (eventData.threadRootEventId !== null) return undefined;
       // Root messages open their own thread
-      return () => onOpenThread(event.id);
+      return (_threadRootEventId?: string, _highlightEventId?: string, quoteText?: string) =>
+        onOpenThread(event.id, undefined, quoteText);
     }
 
     return undefined;

--- a/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -51,6 +51,7 @@
   import { extractURLs } from '$lib/linkPreview';
   import MessagePreviewCard from '$lib/components/MessagePreviewCard.svelte';
   import { shouldHighlightCurrentUserMention } from './messageMentionHighlight';
+  import { selectedQuoteTextForMessageBody } from './selectedReplyQuote';
 
   // Long-press thresholds in milliseconds
   const HIGHLIGHT_DELAY_MS = 150; // Delay before showing visual feedback (avoids flicker on scroll)
@@ -67,7 +68,11 @@
     compact?: boolean;
     roomId: string;
     messageStore?: MessagesStore | null;
-    onOpenThread?: (threadRootEventId: string, highlightEventId?: string) => void;
+    onOpenThread?: (
+      threadRootEventId: string,
+      highlightEventId?: string,
+      quoteText?: string
+    ) => void;
   } = $props();
 
   const connection = useConnection();
@@ -120,6 +125,8 @@
     alignRight?: boolean;
     centerX?: boolean;
   } | null>(null);
+  let messageBodySelectionRoot = $state<HTMLElement>();
+  let selectedReplyQuoteSnapshot = $state<string | null>(null);
 
   // Emoji picker state (position doubles as visibility flag; on mobile ContextMenu ignores it)
   let emojiPickerPos = $state<{ x: number; y: number } | null>(null);
@@ -221,6 +228,7 @@
   // Open context menu from the toolbar's "more actions" button,
   // positioned to cover the toolbar exactly.
   function openMenuFromToolbar(e: MouseEvent) {
+    selectedReplyQuoteSnapshot = getSelectedReplyQuote();
     const button = e.currentTarget as HTMLElement;
     const toolbar = button.closest('[role="toolbar"]') as HTMLElement;
     const rect = toolbar?.getBoundingClientRect() ?? button.getBoundingClientRect();
@@ -532,16 +540,34 @@
     }
   }
 
+  function getSelectedReplyQuote(): string | null {
+    return selectedQuoteTextForMessageBody(
+      typeof window === 'undefined' ? null : window.getSelection(),
+      messageBodySelectionRoot
+    );
+  }
+
+  function takeSelectedReplyQuote(): string | null {
+    const quote = selectedReplyQuoteSnapshot ?? getSelectedReplyQuote();
+    selectedReplyQuoteSnapshot = null;
+    return quote;
+  }
+
   function handleReplyInRoom() {
+    const quote = takeSelectedReplyQuote();
     const excerpt = (msg?.body ?? '').slice(0, 80);
     replyState.startReply(event.id, displayName, excerpt);
+    if (quote) {
+      composerContext.quoteInsertionState.requestInsertQuote(quote);
+    }
   }
 
   function handleOpenThread() {
     if (onOpenThread) {
+      const quote = takeSelectedReplyQuote();
       // For echoes, use the original thread root event ID (not the echo's wrapper event ID)
       const threadRoot = (isEcho ? messageEvent?.echoFromThreadRootEventId : null) ?? event.id;
-      onOpenThread(threadRoot);
+      onOpenThread(threadRoot, undefined, quote ?? undefined);
       // Note: Thread notifications are dismissed by ThreadPane's $effect when it mounts,
       // which also handles direct URL navigation to threads.
     }
@@ -698,7 +724,7 @@
           <!-- Message deleted or encryption key removed -->
           <span class="text-muted/50 italic">This message has been deleted.</span>
         {:else if msg.body}
-          <div class="pointer-fine:select-text">
+          <div bind:this={messageBodySelectionRoot} class="pointer-fine:select-text">
             <MessageContent
               body={msg.body}
               {members}

--- a/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.svelte
@@ -117,7 +117,10 @@ Desktop only (pointer-fine); mobile uses the long-press action sheet instead.
   role="toolbar"
   tabindex="-1"
   aria-label="Message actions"
-  onmousedown={(e) => e.stopPropagation()}
+  onmousedown={(e) => {
+    e.preventDefault();
+    e.stopPropagation();
+  }}
 >
   {#if canReact}
     <div class="flex items-center menu-section-sm">

--- a/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -61,9 +61,12 @@
 
   // Thread navigation functions (URL-driven state)
   let pendingThreadHighlight = $state<string | null>(null);
+  let pendingThreadQuote = $state<{ id: number; text: string } | null>(null);
+  let pendingThreadQuoteId = 0;
 
-  function openThread(threadRootEventId: string, highlightEventId?: string) {
+  function openThread(threadRootEventId: string, highlightEventId?: string, quoteText?: string) {
     pendingThreadHighlight = highlightEventId ?? null;
+    pendingThreadQuote = quoteText ? { id: ++pendingThreadQuoteId, text: quoteText } : null;
     goto(
       resolve('/chat/[serverId]/[roomId]/[threadId]', {
         serverId: serverSegment,
@@ -503,8 +506,12 @@
           canAttach={room.roomData.canAttach}
           canEchoMessage={room.roomData.canEchoMessage && room.roomData.canPostMessage}
           highlightEventId={pendingThreadHighlight}
+          pendingQuote={pendingThreadQuote}
           onHighlightComplete={() => {
             pendingThreadHighlight = null;
+          }}
+          onQuoteConsumed={() => {
+            pendingThreadQuote = null;
           }}
         />
       {/if}

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomEvent.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomEvent.svelte
@@ -155,7 +155,11 @@
     compact?: boolean;
     roomId: string;
     messageStore?: MessagesStore | null;
-    onOpenThread?: (threadRootEventId: string, highlightEventId?: string) => void;
+    onOpenThread?: (
+      threadRootEventId: string,
+      highlightEventId?: string,
+      quoteText?: string
+    ) => void;
   } = $props();
 
   // Join/leave events are confusing in DM 1:1 conversations. Post-PR(b) we

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomEventsPane.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomEventsPane.svelte
@@ -23,7 +23,11 @@
     roomId: string;
     unreadAfterTime?: string | null;
     unreadBeforeTime?: string | null;
-    onOpenThread?: (threadRootEventId: string, highlightEventId?: string) => void;
+    onOpenThread?: (
+      threadRootEventId: string,
+      highlightEventId?: string,
+      quoteText?: string
+    ) => void;
     typingUserIds?: string[];
     typingMembers?: RoomMember[];
   } = $props();

--- a/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -10,7 +10,12 @@
   const stores = serverRegistry.getStore(getActiveServer());
   const notificationStore = stores.notifications;
   import { appState } from '$lib/state/globals.svelte';
-  import { getRoomMembers, createComposerContext, MessagesStore } from '$lib/state/room';
+  import {
+    getRoomMembers,
+    createComposerContext,
+    MessagesStore,
+    type QuoteInsertionRequest
+  } from '$lib/state/room';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
   import HeaderIconButton from '$lib/ui/HeaderIconButton.svelte';
   import MessageComposer, {
@@ -28,7 +33,9 @@
     canAttach = true,
     canEchoMessage = false,
     highlightEventId = null,
-    onHighlightComplete
+    pendingQuote = null,
+    onHighlightComplete,
+    onQuoteConsumed
   }: {
     roomId: string;
     roomName: string;
@@ -38,7 +45,9 @@
     canAttach?: boolean;
     canEchoMessage?: boolean;
     highlightEventId?: string | null;
+    pendingQuote?: QuoteInsertionRequest | null;
     onHighlightComplete?: () => void;
+    onQuoteConsumed?: () => void;
   } = $props();
 
   const connection = useConnection();
@@ -86,6 +95,8 @@
   // not the main room's.
   const composerContext = createComposerContext({ scroll: true });
   const replyState = composerContext.replyState;
+  let consumedQuoteId = 0;
+  let composerApi = $state<MessageComposerApi | null>(null);
 
   // Thread-scoped jump state so "in reply to" clicks scroll within the thread.
   const jumpState = composerContext.jumpState;
@@ -105,6 +116,16 @@
   $effect(() => {
     if (!highlightEventId || store.isInitialLoading) return;
     jumpState.jumpToMessage(highlightEventId);
+  });
+
+  $effect(() => {
+    const quote = pendingQuote;
+    const api = composerApi;
+    if (!quote || !api || quote.id === consumedQuoteId) return;
+
+    consumedQuoteId = quote.id;
+    composerContext.quoteInsertionState.requestInsertQuote(quote.text);
+    onQuoteConsumed?.();
   });
 
   // Subscribe to server events: clear typing indicator on a thread reply,
@@ -338,7 +359,10 @@
     {canAttach}
     showAlsoSendToChannel={canEchoMessage}
     onEscape={onClose}
-    onReady={(api: MessageComposerApi) => api.focus()}
+    onReady={(api: MessageComposerApi) => {
+      composerApi = api;
+      api.focus();
+    }}
     onTyping={() => typingIndicator?.sendTypingIndicator()}
     onMessageSent={(event) => {
       typingIndicator?.resetDebounce();

--- a/frontend/src/routes/chat/[serverId]/[roomId]/selectedReplyQuote.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/selectedReplyQuote.svelte.spec.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { normalizeSelectedQuoteText, selectedQuoteTextForMessageBody } from './selectedReplyQuote';
+
+function selectText(startNode: Node, startOffset: number, endNode: Node, endOffset: number) {
+  const range = document.createRange();
+  range.setStart(startNode, startOffset);
+  range.setEnd(endNode, endOffset);
+
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+  return selection;
+}
+
+describe('selected reply quotes', () => {
+  afterEach(() => {
+    window.getSelection()?.removeAllRanges();
+    document.body.replaceChildren();
+  });
+
+  it('normalizes selected quote text', () => {
+    expect(normalizeSelectedQuoteText(' \r\n first\rsecond\n ')).toBe('first\nsecond');
+    expect(normalizeSelectedQuoteText('   \n\t  ')).toBeNull();
+  });
+
+  it('returns selected text when both endpoints are inside the message body', () => {
+    const body = document.createElement('div');
+    body.append('quoted text');
+    document.body.append(body);
+    const textNode = body.firstChild!;
+
+    const selection = selectText(textNode, 0, textNode, 'quoted'.length);
+
+    expect(selectedQuoteTextForMessageBody(selection, body)).toBe('quoted');
+  });
+
+  it('ignores selections that leave the message body', () => {
+    const body = document.createElement('div');
+    body.append('message text');
+    const outside = document.createElement('div');
+    outside.append('outside text');
+    document.body.append(body, outside);
+
+    const selection = selectText(body.firstChild!, 0, outside.firstChild!, 'outside'.length);
+
+    expect(selectedQuoteTextForMessageBody(selection, body)).toBeNull();
+  });
+});

--- a/frontend/src/routes/chat/[serverId]/[roomId]/selectedReplyQuote.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/selectedReplyQuote.ts
@@ -1,0 +1,27 @@
+export function normalizeSelectedQuoteText(text: string): string | null {
+  const normalized = text.replace(/\r\n?/g, '\n').trim();
+  return normalized ? normalized : null;
+}
+
+function nodeIsInside(root: HTMLElement, node: Node | null): boolean {
+  if (!node) return false;
+  return root === node || root.contains(node);
+}
+
+export function selectedQuoteTextForMessageBody(
+  selection: Selection | null,
+  messageBodyRoot: HTMLElement | null | undefined
+): string | null {
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0 || !messageBodyRoot) {
+    return null;
+  }
+
+  if (
+    !nodeIsInside(messageBodyRoot, selection.anchorNode) ||
+    !nodeIsInside(messageBodyRoot, selection.focusNode)
+  ) {
+    return null;
+  }
+
+  return normalizeSelectedQuoteText(selection.toString());
+}


### PR DESCRIPTION
## Summary

- Add selected-text quoting for room replies and thread replies, inserting real TipTap blockquotes while preserving draft text.
- Limit quote capture to selections fully inside the message body and preserve selection through reply toolbar/menu entry points.
- Cover quote insertion, selection validation, and room/thread reply flows with focused unit and Playwright tests.
- Update [FDR-002 replies and threads](docs/fdr/FDR-002-replies-and-threads.md).

## Testing

- `npx @sveltejs/mcp svelte-autofixer`
- `mise x -- pnpm test:unit --run --project client src/lib/components/composer/MessageComposer.svelte.spec.ts src/lib/components/composer/autocomplete.svelte.spec.ts 'src/routes/chat/[serverId]/[roomId]/selectedReplyQuote.svelte.spec.ts'`
- `mise x -- pnpm exec playwright test e2e/threading.test.ts -g "quotes selected" --retries=0`
- `mise x -- pnpm check`
