### PR TITLE
fix(frontend): remove server name from room header

### DIFF
--- a/frontend/e2e/mobile-nav.test.ts
+++ b/frontend/e2e/mobile-nav.test.ts
@@ -163,6 +163,24 @@ test.describe('Mobile Navigation', () => {
     await expect(page.getByRole('heading', { name: 'Notifications' })).toBeVisible();
   });
 
+  test('room header omits redundant server name on mobile', async ({ page, chatPage }) => {
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.enterRoom('general');
+
+    const serverName = await chatPage.getServerName();
+
+    await page.setViewportSize({ width: 375, height: 667 });
+
+    const roomHeading = chatPage.getRoomHeader('general');
+    await expect(roomHeading).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+
+    const roomHeader = roomHeading.locator(
+      'xpath=ancestor::div[contains(concat(" ", normalize-space(@class), " "), " border-b ")][1]'
+    );
+    await expect(roomHeader).not.toContainText(serverName);
+  });
+
   test('hamburger menu works on admin pages', async ({ page }) => {
     // Login as admin (the bootstrap admin user)
     const adminUser = await loginAsAdmin(page);

--- a/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -16,7 +16,7 @@
     usePresenceChange,
     createTypingIndicator
   } from '$lib/hooks';
-  import { appState, sidebarNav } from '$lib/state/globals.svelte';
+  import { appState } from '$lib/state/globals.svelte';
   import {
     createComposerContext,
     createMentionRoles,
@@ -424,11 +424,6 @@
         <DropZoneOverlay visible={isDraggingFiles} />
 
         <PaneHeader {title} loading={!room.roomData}>
-          {#snippet afterTitle()}
-            {#if !sidebarNav.isOpen && !room.isDM && room.roomData?.spaceName}
-              <span class="text-sm text-muted">{room.roomData.spaceName}</span>
-            {/if}
-          {/snippet}
           {#snippet actions()}
             <RoomSidebarToggle
               mode="mobile"


### PR DESCRIPTION
- Remove the redundant server/space label from the room pane header so the header focuses on the room name and actions.
- Keep the global server chrome/sidebar server name unchanged.
- Add a mobile navigation regression test that verifies the room header does not include the server name.

Verified with `pnpm -C frontend check`, `pnpm -C frontend lint`, the Svelte autofixer, and the focused Playwright mobile header test.
