### PR TITLE
fix(frontend): echo local room posts after send

### DIFF
--- a/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -640,6 +640,32 @@ describe('MessagesStore — room lifecycle ownership', () => {
 		store.dispose();
 	});
 
+	it('ingests a returned root room message immediately and dedupes later subscription delivery', async () => {
+		const fake = new FakeGqlClient(
+			roomEventsResult({
+				events: [],
+				startCursor: null,
+				endCursor: null,
+				hasOlder: false,
+				hasNewer: false
+			})
+		);
+		const store = new MessagesStore(fake as unknown as GraphQLClient, () => null);
+		const returnedPost = threadMessageEvent('m-local');
+
+		store.setRoom('room-1');
+		await settle();
+		fake.queryMock.mockClear();
+
+		store.ingestEvent(returnedPost as never);
+		expect(store.rootEvents.map((event) => event.id)).toEqual(['m-local']);
+
+		store.ingestServerEvent(returnedPost as never);
+		expect(store.rootEvents.map((event) => event.id)).toEqual(['m-local']);
+		expect(fake.queryMock).not.toHaveBeenCalled();
+		store.dispose();
+	});
+
 	it('soft-refreshes the latest room window without entering initial loading', async () => {
 		const fake = new FakeGqlClient([
 			roomEventsResult({

--- a/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -21,6 +21,7 @@
     createComposerContext,
     createMentionRoles,
     getRoomMembers,
+    MessagesStore,
     RoomFilesStore,
     RoomMembersStore,
     setRoomMembersStore,
@@ -36,7 +37,7 @@
   import { clearLastRoom, setLastRoom } from '$lib/storage/lastRoom';
   import PageTitle from '$lib/ui/PageTitle.svelte';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
-  import { tick } from 'svelte';
+  import { onDestroy, tick } from 'svelte';
   import { fly } from 'svelte/transition';
   import RoomEventsPane from './RoomEventsPane.svelte';
   import RoomSidebar from './RoomSidebar.svelte';
@@ -83,6 +84,12 @@
   const replyState = composerContext.replyState;
   const jumpState = composerContext.jumpState;
   const currentUser = $derived(serverRegistry.getStore(getActiveServer()).currentUser);
+  const roomMessageStore = new MessagesStore(
+    connection(),
+    () => currentUser.user?.id ?? null
+  );
+
+  onDestroy(() => roomMessageStore.dispose());
 
   // --- Extracted hooks ---
   const room = useRoomData(() => ({ roomId }));
@@ -471,6 +478,7 @@
 
         <RoomEventsPane
           {roomId}
+          messageStore={roomMessageStore}
           unreadAfterTime={unread.unreadAfterTime}
           unreadBeforeTime={unread.unreadBeforeTime}
           onOpenThread={openThread}
@@ -489,7 +497,21 @@
           autoFocus={!threadId && !mobileRoomSidebarPanel}
           onReady={(api) => (composerApi = api)}
           onTyping={() => typingIndicator?.sendTypingIndicator()}
-          onMessageSent={() => typingIndicator?.resetDebounce()}
+          onMessageSent={(event) => {
+            typingIndicator?.resetDebounce();
+            if (event) {
+              roomMessageStore.ingestEvent(event);
+              if (
+                event.event?.__typename === 'MessagePostedEvent' &&
+                event.event.roomId === roomId &&
+                !event.event.threadRootEventId
+              ) {
+                unread.noteReadCursor(event.createdAt);
+              }
+            } else {
+              void roomMessageStore.refreshCurrentWindow(null);
+            }
+          }}
         />
       </div>
 

--- a/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { q } from '$lib/test-utils';
+
+const { mocks } = vi.hoisted(() => {
+  const queryData = {
+    server: { roles: [] },
+    room: {
+      events: {
+        events: [],
+        startCursor: null,
+        endCursor: null,
+        hasOlder: false,
+        hasNewer: false
+      },
+      members: {
+        users: [],
+        totalCount: 0,
+        hasMore: false
+      }
+    }
+  };
+
+  return {
+    mocks: {
+      goto: vi.fn(),
+      pushState: vi.fn(),
+      replaceState: vi.fn(),
+      noteReadCursor: vi.fn(),
+      markRoomAsRead: vi.fn(),
+      resetTypingDebounce: vi.fn(),
+      query: vi.fn(() => ({
+        toPromise: vi.fn().mockResolvedValue({ data: queryData, error: null })
+      })),
+      mutation: vi.fn(() => ({
+        toPromise: vi.fn().mockResolvedValue({ data: {}, error: null })
+      })),
+      subscription: vi.fn()
+    }
+  };
+});
+
+vi.mock('$app/state', () => ({
+  page: {
+    params: { serverId: '-', roomId: 'room-1' },
+    state: {},
+    url: new URL('https://chat.example.test/chat/-/room-1')
+  }
+}));
+
+vi.mock('$app/navigation', () => ({
+  goto: mocks.goto,
+  pushState: mocks.pushState,
+  replaceState: mocks.replaceState
+}));
+
+vi.mock('$app/paths', () => ({
+  resolve: (path: string, params?: Record<string, string>) =>
+    path
+      .replace('[serverId]', params?.serverId ?? '')
+      .replace('[roomId]', params?.roomId ?? '')
+      .replace('[threadId]', params?.threadId ?? '')
+}));
+
+vi.mock('$lib/navigation', () => ({
+  serverIdToSegment: () => '-',
+  segmentToServerId: () => 'server-1'
+}));
+
+vi.mock('$lib/hooks', () => ({
+  useRoomData: () => ({
+    roomData: {
+      room: { id: 'room-1', name: 'general', type: 'CHANNEL' },
+      spaceName: 'Test Space',
+      canPostMessage: true,
+      canPostInThread: true,
+      canAttach: false,
+      canReact: true,
+      canManageOthersMessage: false,
+      canEchoMessage: true,
+      canManageRoom: false,
+      canBanRoomMembers: false
+    },
+    dmData: null,
+    isDM: false,
+    isRoomLoading: false
+  }),
+  useRoomUnread: () => ({
+    unreadAfterTime: null,
+    unreadBeforeTime: null,
+    markRoomAsRead: mocks.markRoomAsRead,
+    noteReadCursor: mocks.noteReadCursor
+  }),
+  useEvent: vi.fn(),
+  usePresenceChange: vi.fn(),
+  createTypingIndicator: () => ({
+    userIds: [],
+    sendTypingIndicator: vi.fn(),
+    resetDebounce: mocks.resetTypingDebounce,
+    removeTypingUser: vi.fn()
+  })
+}));
+
+vi.mock('$lib/state/server/connection.svelte', () => ({
+  useConnection: () => () => ({
+    isConnected: true,
+    showConnectionLostBanner: false,
+    client: {
+      query: mocks.query,
+      mutation: mocks.mutation,
+      subscription: mocks.subscription
+    }
+  })
+}));
+
+vi.mock('$lib/state/server/registry.svelte', () => ({
+  serverRegistry: {
+    getStore: () => ({
+      currentUser: { user: { id: 'test-user', login: 'testuser' }, loading: false },
+      serverInfo: {
+        livekitUrl: null,
+        videoProcessingEnabled: false,
+        maxUploadSize: 25 * 1024 * 1024,
+        maxVideoUploadSize: 25 * 1024 * 1024
+      },
+      notifications: {
+        dismissDMNotifications: vi.fn().mockResolvedValue({ byRoom: {} }),
+        dismissMentionNotifications: vi.fn().mockResolvedValue({ byRoom: {} }),
+        dismissRoomReplyNotifications: vi.fn().mockResolvedValue({ byRoom: {} }),
+        dismissRoomMessageNotifications: vi.fn().mockResolvedValue({ byRoom: {} })
+      },
+      pendingHighlights: {
+        consume: vi.fn(() => null)
+      },
+      rooms: {
+        decrementUnreadNotification: vi.fn()
+      }
+    }),
+    originServer: { id: 'server-1', url: 'https://chat.example.test' },
+    getServer: () => ({ id: 'server-1', url: 'https://chat.example.test' })
+  }
+}));
+
+vi.mock('$lib/state/activeServer.svelte', () => ({
+  getActiveServer: () => 'server-1'
+}));
+
+vi.mock('$lib/storage/lastRoom', () => ({
+  clearLastRoom: vi.fn(),
+  setLastRoom: vi.fn()
+}));
+
+vi.mock('$lib/attachments/dropZone.svelte', () => ({
+  dropZone: vi.fn()
+}));
+
+vi.mock('$lib/components/composer/MessageComposer.svelte', async () => {
+  const { default: MessageComposerMock } = await import('./RoomLocalEchoMessageComposerMock.svelte');
+  return { default: MessageComposerMock };
+});
+
+vi.mock('./RoomEventsPane.svelte', async () => {
+  const { default: RoomEventsPaneMock } = await import('./RoomLocalEchoRoomEventsPaneMock.svelte');
+  return { default: RoomEventsPaneMock };
+});
+
+vi.mock('./ThreadPane.svelte', async () => {
+  const { default: EmptyMock } = await import('./RoomLocalEchoEmptyMock.svelte');
+  return { default: EmptyMock };
+});
+
+vi.mock('./RoomSidebar.svelte', async () => {
+  const { default: EmptyMock } = await import('./RoomLocalEchoEmptyMock.svelte');
+  return { default: EmptyMock };
+});
+
+vi.mock('./RoomSidebarToggle.svelte', async () => {
+  const { default: EmptyMock } = await import('./RoomLocalEchoEmptyMock.svelte');
+  return { default: EmptyMock };
+});
+
+vi.mock('$lib/attachments/DropZoneOverlay.svelte', async () => {
+  const { default: EmptyMock } = await import('./RoomLocalEchoEmptyMock.svelte');
+  return { default: EmptyMock };
+});
+
+vi.mock('$lib/components/voice/VoiceCallButton.svelte', async () => {
+  const { default: EmptyMock } = await import('./RoomLocalEchoEmptyMock.svelte');
+  return { default: EmptyMock };
+});
+
+vi.mock('$lib/components/voice/VoiceCallPanel.svelte', async () => {
+  const { default: EmptyMock } = await import('./RoomLocalEchoEmptyMock.svelte');
+  return { default: EmptyMock };
+});
+
+vi.mock('$lib/ui/PageTitle.svelte', async () => {
+  const { default: EmptyMock } = await import('./RoomLocalEchoEmptyMock.svelte');
+  return { default: EmptyMock };
+});
+
+vi.mock('$lib/ui/PaneHeader.svelte', async () => {
+  const { default: EmptyMock } = await import('./RoomLocalEchoEmptyMock.svelte');
+  return { default: EmptyMock };
+});
+
+import Room from './Room.svelte';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Room local message echo', () => {
+  it('inserts a returned main-room post into the same store rendered by the room timeline', async () => {
+    const { container } = render(Room, { props: { roomId: 'room-1' } });
+
+    await expect.element(q(container, '[data-testid="room-event-ids"]')).toHaveTextContent('');
+
+    (q(container, '[data-testid="emit-returned-post"]') as HTMLButtonElement).click();
+
+    await expect
+      .element(q(container, '[data-testid="room-event-ids"]'))
+      .toHaveTextContent('msg-local');
+    expect(mocks.resetTypingDebounce).toHaveBeenCalledOnce();
+    expect(mocks.noteReadCursor).toHaveBeenCalledWith('2026-06-17T10:47:00Z');
+  });
+
+  it('does not advance the current room read cursor for a stale returned post from another room', async () => {
+    const { container } = render(Room, { props: { roomId: 'room-2' } });
+
+    await expect.element(q(container, '[data-testid="room-event-ids"]')).toHaveTextContent('');
+
+    (q(container, '[data-testid="emit-returned-post"]') as HTMLButtonElement).click();
+
+    await expect.element(q(container, '[data-testid="room-event-ids"]')).toHaveTextContent('');
+    expect(mocks.resetTypingDebounce).toHaveBeenCalledOnce();
+    expect(mocks.noteReadCursor).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomEventsPane.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomEventsPane.svelte
@@ -1,19 +1,16 @@
 <script lang="ts">
-  import { onDestroy } from 'svelte';
   import { useEvent } from '$lib/hooks';
-  import { useConnection } from '$lib/state/server/connection.svelte';
   import {
     getComposerContext,
-    MessagesStore,
     type RefreshCurrentWindowResult,
     type RoomMember
   } from '$lib/state/room';
-  import { getActiveServer } from '$lib/state/activeServer.svelte';
-  import { serverRegistry } from '$lib/state/server/registry.svelte';
+  import type { MessagesStore } from '$lib/state/room';
   import EventList from './EventList.svelte';
 
   let {
     roomId,
+    messageStore: store,
     unreadAfterTime = null,
     unreadBeforeTime = null,
     onOpenThread,
@@ -21,6 +18,7 @@
     typingMembers = []
   }: {
     roomId: string;
+    messageStore: MessagesStore;
     unreadAfterTime?: string | null;
     unreadBeforeTime?: string | null;
     onOpenThread?: (threadRootEventId: string, highlightEventId?: string) => void;
@@ -28,17 +26,9 @@
     typingMembers?: RoomMember[];
   } = $props();
 
-  const connection = useConnection();
   const composerContext = getComposerContext();
   const editState = composerContext.editState;
   const jumpState = composerContext.jumpState;
-  const currentUser = $derived(serverRegistry.getStore(getActiveServer()).currentUser);
-
-  const store = new MessagesStore(
-    connection(),
-    () => currentUser.user?.id ?? null
-  );
-  onDestroy(() => store.dispose());
 
   let roomEvents = $derived(store.rootEvents);
   let updateCounter = $derived(roomEvents.length);

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomLocalEchoEmptyMock.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomLocalEchoEmptyMock.svelte
@@ -1,0 +1,1 @@
+<span data-testid="empty-mock"></span>

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomLocalEchoMessageComposerMock.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomLocalEchoMessageComposerMock.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import type { RoomEventViewFragment } from '$lib/gql/graphql';
+
+  let {
+    onMessageSent
+  }: {
+    onMessageSent?: (event: RoomEventViewFragment | null) => void;
+  } = $props();
+
+  const returnedPost = {
+    __typename: 'Event',
+    id: 'msg-local',
+    createdAt: '2026-06-17T10:47:00Z',
+    actorId: 'test-user',
+    actor: null,
+    event: {
+      __typename: 'MessagePostedEvent',
+      roomId: 'room-1',
+      body: 'local hello',
+      attachments: [],
+      linkPreview: null,
+      reactions: [],
+      updatedAt: null,
+      inReplyTo: null,
+      threadRootEventId: null,
+      echoOfEventId: null,
+      echoFromThreadRootEventId: null,
+      channelEchoEventId: null,
+      replyCount: 0,
+      lastReplyAt: null,
+      threadParticipants: [],
+      viewerIsFollowingThread: true
+    }
+  } as RoomEventViewFragment;
+</script>
+
+<button data-testid="emit-returned-post" onclick={() => onMessageSent?.(returnedPost)}>
+  emit returned post
+</button>

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomLocalEchoRoomEventsPaneMock.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomLocalEchoRoomEventsPaneMock.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import type { MessagesStore } from '$lib/state/room';
+
+  let {
+    roomId,
+    messageStore
+  }: {
+    roomId: string;
+    messageStore: MessagesStore;
+  } = $props();
+
+  $effect(() => {
+    messageStore.setRoom(roomId);
+  });
+
+  const eventIds = $derived(messageStore.rootEvents.map((event) => event.id).join(','));
+</script>
+
+<output data-testid="room-event-ids">{eventIds}</output>


### PR DESCRIPTION
- Shares the main room `MessagesStore` between `Room.svelte` and `RoomEventsPane` so mutation-returned posts can be inserted before websocket/subscription delivery.
- Ingests successful main-room `postMessage` responses locally, falls back to refreshing the current window when no event is returned, and only advances the unread cursor when the returned event still belongs to the active room.
- Adds regression coverage for returned room posts, subscription dedupe, and stale post responses from another room.

Tests:
- `mise x -- pnpm test:unit --run --project client 'src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts' 'src/lib/state/room/messages.svelte.spec.ts'`
- `pnpm check`
- `pnpm lint`
