### PR TITLE
fix(frontend): tighten mobile message action sheet

### DIFF
--- a/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionSheet.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionSheet.svelte
@@ -97,13 +97,13 @@
   }
 </script>
 
-<div class="flex flex-col rounded-xl bg-background">
+<div class="flex flex-col gap-2">
   <!-- Quick reactions row -->
   {#if canReact}
-    <div class="flex justify-around py-2">
+    <div class="flex justify-between menu-section px-2 py-1.5">
       {#each quickReactions as emoji (emoji)}
         <button
-          class="flex h-11 w-11 cursor-pointer items-center justify-center rounded-full text-2xl active:bg-surface-100"
+          class="flex h-10 w-10 cursor-pointer items-center justify-center rounded-full text-xl active:bg-surface-100"
           onclick={() => handleReaction(emoji)}
           aria-label="React with {emoji}"
         >
@@ -112,7 +112,7 @@
       {/each}
       {#if onOpenEmojiPicker}
         <button
-          class="flex h-11 w-11 cursor-pointer items-center justify-center rounded-full text-2xl text-muted active:bg-surface-100"
+          class="flex h-10 w-10 cursor-pointer items-center justify-center rounded-full text-xl text-muted active:bg-surface-100"
           onclick={() => {
             onOpenEmojiPicker();
             onClose();
@@ -123,40 +123,40 @@
         </button>
       {/if}
     </div>
-
-    <hr class="my-1 border-border" />
   {/if}
 
-  <!-- Action list using sidebar-item styling with extra padding for mobile tap targets -->
-  <nav class="sidebar-nav">
+  <nav class="sidebar-nav gap-0 menu-section p-1">
     {#if onReplyInRoom}
-      <button class="sidebar-item py-3.5" onclick={handleReplyInRoom}>
+      <button class="sidebar-item min-h-11 gap-3 px-3 py-2.5 text-base" onclick={handleReplyInRoom}>
         <span class="sidebar-icon iconify uil--corner-up-left"></span>
         Reply
       </button>
     {/if}
 
     {#if onReply}
-      <button class="sidebar-item py-3.5" onclick={handleReply}>
+      <button class="sidebar-item min-h-11 gap-3 px-3 py-2.5 text-base" onclick={handleReply}>
         <span class="sidebar-icon iconify uil--comment-alt-lines"></span>
         Reply in thread
       </button>
     {/if}
 
     {#if canEdit}
-      <button class="sidebar-item py-3.5" onclick={handleEdit}>
+      <button class="sidebar-item min-h-11 gap-3 px-3 py-2.5 text-base" onclick={handleEdit}>
         <span class="sidebar-icon iconify uil--pen"></span>
         Edit
       </button>
     {/if}
 
-    <button class="sidebar-item py-3.5" onclick={handleCopyLink}>
+    <button class="sidebar-item min-h-11 gap-3 px-3 py-2.5 text-base" onclick={handleCopyLink}>
       <span class="sidebar-icon iconify uil--copy"></span>
       Copy link
     </button>
 
     {#if canDelete}
-      <button class="sidebar-item py-3.5" onclick={handleDelete}>
+      <button
+        class="sidebar-item min-h-11 gap-3 px-3 py-2.5 text-base text-danger hover:text-danger"
+        onclick={handleDelete}
+      >
         <span class="sidebar-icon iconify uil--trash-alt"></span>
         Delete
       </button>

--- a/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionSheet.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionSheet.svelte.spec.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { q } from '$lib/test-utils';
+import MessageActionSheet from './MessageActionSheet.svelte';
+
+const mocks = vi.hoisted(() => ({
+  actions: {
+    toggleReaction: vi.fn(),
+    startEdit: vi.fn(),
+    openDeleteConfirmation: vi.fn(),
+    copyMessageLink: vi.fn()
+  }
+}));
+
+vi.mock('$lib/hooks', () => ({
+  useMessageActions: () => mocks.actions
+}));
+
+vi.mock('$lib/state/recentEmojis.svelte', () => ({
+  getRecentEmojis: () => ({
+    quickReactions: ['👍', '❤️']
+  })
+}));
+
+const baseProps = {
+  serverId: 'server-1',
+  roomId: 'room-1',
+  messageEventId: 'message-event-1',
+  eventId: 'event-1',
+  messageBody: 'Hello',
+  onClose: vi.fn()
+};
+
+function renderSheet(props: Record<string, unknown> = {}) {
+  return render(MessageActionSheet, {
+    props: {
+      ...baseProps,
+      ...props
+    }
+  });
+}
+
+function actionLabels(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll<HTMLButtonElement>('nav button'))
+    .map((button) => button.textContent?.trim())
+    .filter((label): label is string => !!label);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  baseProps.onClose.mockClear();
+});
+
+describe('MessageActionSheet', () => {
+  it('renders quick reactions when reactions are allowed', async () => {
+    const { container } = renderSheet({ canReact: true });
+
+    await expect.element(q(container, '[aria-label="React with 👍"]')).toBeInTheDocument();
+    await expect.element(q(container, '[aria-label="React with ❤️"]')).toBeInTheDocument();
+  });
+
+  it('keeps the action order unchanged', () => {
+    const { container } = renderSheet({
+      canEdit: true,
+      canDelete: true,
+      onReply: vi.fn(),
+      onReplyInRoom: vi.fn()
+    });
+
+    expect(actionLabels(container)).toEqual([
+      'Reply',
+      'Reply in thread',
+      'Edit',
+      'Copy link',
+      'Delete'
+    ]);
+  });
+
+  it('closes after invoking sheet actions', async () => {
+    const onReplyInRoom = vi.fn();
+    const onReply = vi.fn();
+    const { container } = renderSheet({
+      canReact: true,
+      canEdit: true,
+      canDelete: true,
+      onReplyInRoom,
+      onReply
+    });
+
+    container.querySelector<HTMLButtonElement>('[aria-label="React with 👍"]')!.click();
+    await vi.waitFor(() => {
+      expect(mocks.actions.toggleReaction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          roomId: 'room-1',
+          messageEventId: 'message-event-1'
+        }),
+        '👍',
+        false
+      );
+    });
+    expect(baseProps.onClose).toHaveBeenCalledOnce();
+
+    baseProps.onClose.mockClear();
+    Array.from(container.querySelectorAll<HTMLButtonElement>('nav button'))
+      .find((button) => button.textContent?.trim() === 'Reply')!
+      .click();
+    expect(onReplyInRoom).toHaveBeenCalledOnce();
+    expect(baseProps.onClose).toHaveBeenCalledOnce();
+
+    baseProps.onClose.mockClear();
+    Array.from(container.querySelectorAll<HTMLButtonElement>('nav button'))
+      .find((button) => button.textContent?.trim() === 'Reply in thread')!
+      .click();
+    expect(onReply).toHaveBeenCalledOnce();
+    expect(baseProps.onClose).toHaveBeenCalledOnce();
+
+    baseProps.onClose.mockClear();
+    Array.from(container.querySelectorAll<HTMLButtonElement>('nav button'))
+      .find((button) => button.textContent?.includes('Edit'))!
+      .click();
+    expect(mocks.actions.startEdit).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: 'event-1', messageBody: 'Hello' })
+    );
+    expect(baseProps.onClose).toHaveBeenCalledOnce();
+
+    baseProps.onClose.mockClear();
+    Array.from(container.querySelectorAll<HTMLButtonElement>('nav button'))
+      .find((button) => button.textContent?.includes('Copy link'))!
+      .click();
+    expect(mocks.actions.copyMessageLink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverId: 'server-1',
+        roomId: 'room-1',
+        messageEventId: 'message-event-1'
+      })
+    );
+    await vi.waitFor(() => {
+      expect(baseProps.onClose).toHaveBeenCalledOnce();
+    });
+
+    baseProps.onClose.mockClear();
+    Array.from(container.querySelectorAll<HTMLButtonElement>('nav button'))
+      .find((button) => button.textContent?.includes('Delete'))!
+      .click();
+    expect(mocks.actions.openDeleteConfirmation).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: 'event-1' })
+    );
+    expect(baseProps.onClose).toHaveBeenCalledOnce();
+  });
+
+  it('keeps Delete styled as destructive', () => {
+    const { container } = renderSheet({ canDelete: true });
+
+    const deleteButton = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('nav button')
+    ).find((button) => button.textContent?.includes('Delete'));
+
+    expect(deleteButton).toBeDefined();
+    expect(deleteButton).toHaveClass('text-danger');
+  });
+});


### PR DESCRIPTION
## Summary

- Tightens the mobile message action sheet so it uses lightweight menu sections instead of a heavy nested panel.
- Keeps message action ordering and behavior unchanged while restoring local spacing/tap-target overrides.
- Adds browser-mode component coverage for reactions, action ordering, close behavior, and destructive styling.

## Tests

- `npx @sveltejs/mcp svelte-autofixer 'src/routes/chat/[serverId]/[roomId]/MessageActionSheet.svelte' --svelte-version 5`
- `mise x -- pnpm test:unit --run --project client 'src/routes/chat/[serverId]/[roomId]/MessageActionSheet.svelte.spec.ts'`
- `mise x -- pnpm check`
- Chrome DevTools MCP mobile viewport visual check
