### PR TITLE
fix: correct push notification deep links

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -570,6 +570,9 @@ func fetchPayloadContext(ctx context.Context, chattoCore *core.ChattoCore, notif
 	case *corev1.Notification_Reply:
 		roomID = n.Reply.RoomId
 		eventID = n.Reply.EventId
+	case *corev1.Notification_RoomMessage:
+		roomID = n.RoomMessage.RoomId
+		eventID = n.RoomMessage.EventId
 	default:
 		return nil
 	}
@@ -616,9 +619,9 @@ func fetchPayloadContext(ctx context.Context, chattoCore *core.ChattoCore, notif
 		}
 	}
 
-	// For mentions and replies, also fetch the room name
+	// For notifications shown as channel activity, also fetch the room name.
 	switch notification.Notification.(type) {
-	case *corev1.Notification_Mention, *corev1.Notification_Reply:
+	case *corev1.Notification_Mention, *corev1.Notification_Reply, *corev1.Notification_RoomMessage:
 		room, err := chattoCore.GetRoom(ctx, kind, roomID)
 		if err != nil {
 			logger.Debug("Failed to fetch room for push notification",

--- a/cli/internal/push/push.go
+++ b/cli/internal/push/push.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 
 	webpush "github.com/SherClockHolmes/webpush-go"
@@ -192,14 +193,43 @@ func (s *Sender) SendToMany(ctx context.Context, subscriptions []*corev1.PushSub
 	return results
 }
 
+func buildAppURL(baseURL string, segments []string, queryKey, queryValue string) string {
+	raw, err := url.JoinPath(baseURL, segments...)
+	if err != nil {
+		return ""
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	if queryKey != "" && queryValue != "" {
+		query := u.Query()
+		query.Set(queryKey, queryValue)
+		u.RawQuery = query.Encode()
+	}
+	return u.String()
+}
+
+func buildNotificationURL(baseURL, roomID, threadRootID, highlightEventID string) string {
+	segments := []string{"chat", "-"}
+	if roomID != "" {
+		segments = append(segments, roomID)
+	}
+	if threadRootID != "" {
+		segments = append(segments, threadRootID)
+	}
+	return buildAppURL(baseURL, segments, "highlight", highlightEventID)
+}
+
 // BuildPayloadFromNotification creates a push payload from a notification.
 // The baseURL is used to build navigation URLs (e.g., "https://chatto.example.com").
 // The optional payloadCtx provides message preview and room name for richer notifications.
 func BuildPayloadFromNotification(notif *corev1.Notification, actorDisplayName, baseURL string, payloadCtx *PayloadContext) *Payload {
 	payload := &Payload{
 		NotificationID: notif.Id,
-		Icon:           baseURL + "/icons/icon-192.png",
-		Badge:          baseURL + "/icons/icon-192.png", // Badge should be monochrome, but use same for now
+		Icon:           buildAppURL(baseURL, []string{"icons", "icon-192.png"}, "", ""),
+		Badge:          buildAppURL(baseURL, []string{"icons", "icon-192.png"}, "", ""), // Badge should be monochrome, but use same for now
 	}
 
 	// Get preview from context, truncate if needed
@@ -210,18 +240,12 @@ func BuildPayloadFromNotification(notif *corev1.Notification, actorDisplayName, 
 		roomName = payloadCtx.RoomName
 	}
 
-	// URL prefix for the home instance. Push notifications are always generated
-	// by the server the user is connected to, so the instance segment is always "-".
-	// Chat URLs go straight from instance segment to room ID — no spaceId, no /dm/
-	// prefix (DMs are surfaced as rooms under the primary space).
-	chatPrefix := baseURL + "/chat/-"
-
 	switch n := notif.Notification.(type) {
 	case *corev1.Notification_DmMessage:
 		payload.Title = fmt.Sprintf("@%s sent you a new DM", actorDisplayName)
 		payload.Body = preview
 		payload.Tag = "dm-" + n.DmMessage.EventId
-		payload.URL = chatPrefix + "/" + n.DmMessage.RoomId
+		payload.URL = buildNotificationURL(baseURL, n.DmMessage.RoomId, "", "")
 
 	case *corev1.Notification_Mention:
 		if roomName != "" {
@@ -231,10 +255,7 @@ func BuildPayloadFromNotification(notif *corev1.Notification, actorDisplayName, 
 		}
 		payload.Body = preview
 		payload.Tag = "mention-" + n.Mention.EventId
-		payload.URL = chatPrefix + "/" + n.Mention.RoomId
-		if n.Mention.EventId != "" {
-			payload.URL += "?highlight=" + n.Mention.EventId
-		}
+		payload.URL = buildNotificationURL(baseURL, n.Mention.RoomId, n.Mention.InThread, n.Mention.EventId)
 
 	case *corev1.Notification_Reply:
 		if roomName != "" {
@@ -244,13 +265,17 @@ func BuildPayloadFromNotification(notif *corev1.Notification, actorDisplayName, 
 		}
 		payload.Body = preview
 		payload.Tag = "reply-" + n.Reply.EventId
-		if n.Reply.InThread != "" {
-			// Thread reply: navigate to the thread (using thread root) and highlight the replied-to message
-			payload.URL = chatPrefix + "/" + n.Reply.RoomId + "/" + n.Reply.InThread + "?highlight=" + n.Reply.InReplyToId
+		payload.URL = buildNotificationURL(baseURL, n.Reply.RoomId, n.Reply.InThread, n.Reply.EventId)
+
+	case *corev1.Notification_RoomMessage:
+		if roomName != "" {
+			payload.Title = fmt.Sprintf("@%s posted in #%s", actorDisplayName, roomName)
 		} else {
-			// Room-level reply: navigate to room and highlight the reply message
-			payload.URL = chatPrefix + "/" + n.Reply.RoomId + "?highlight=" + n.Reply.EventId
+			payload.Title = fmt.Sprintf("@%s posted a message", actorDisplayName)
 		}
+		payload.Body = preview
+		payload.Tag = "room-message-" + n.RoomMessage.EventId
+		payload.URL = buildNotificationURL(baseURL, n.RoomMessage.RoomId, "", n.RoomMessage.EventId)
 
 	default:
 		payload.Title = "New notification"
@@ -271,6 +296,8 @@ func NotificationTag(notif *corev1.Notification) string {
 		return "mention-" + n.Mention.EventId
 	case *corev1.Notification_Reply:
 		return "reply-" + n.Reply.EventId
+	case *corev1.Notification_RoomMessage:
+		return "room-message-" + n.RoomMessage.EventId
 	default:
 		return ""
 	}

--- a/cli/internal/push/push_test.go
+++ b/cli/internal/push/push_test.go
@@ -269,6 +269,26 @@ func TestBuildPayloadFromNotification(t *testing.T) {
 		}
 	})
 
+	t.Run("builds thread mention payload", func(t *testing.T) {
+		notif := &corev1.Notification{
+			Id: "notif-thread-mention",
+			Notification: &corev1.Notification_Mention{
+				Mention: &corev1.MentionNotification{
+					RoomId:   "room-2",
+					EventId:  "mention-event",
+					InThread: "thread-root",
+				},
+			},
+		}
+
+		payload := BuildPayloadFromNotification(notif, "Bob", baseURL, nil)
+
+		expectedURL := "https://chatto.example.com/chat/-/room-2/thread-root?highlight=mention-event"
+		if payload.URL != expectedURL {
+			t.Errorf("Expected URL %s, got %s", expectedURL, payload.URL)
+		}
+	})
+
 	t.Run("builds room-level reply payload without context", func(t *testing.T) {
 		notif := &corev1.Notification{
 			Id: "notif-abc",
@@ -317,8 +337,8 @@ func TestBuildPayloadFromNotification(t *testing.T) {
 		if payload.Title != "@Diana replied to you" {
 			t.Errorf("Expected '@Diana replied to you', got %s", payload.Title)
 		}
-		// Thread reply: navigate to thread root and highlight the replied-to message
-		expectedURL := "https://chatto.example.com/chat/-/room-y/thread-root?highlight=mid-thread-msg"
+		// Thread reply: navigate to thread root and highlight the reply event itself.
+		expectedURL := "https://chatto.example.com/chat/-/room-y/thread-root?highlight=reply-event"
 		if payload.URL != expectedURL {
 			t.Errorf("Expected URL %s, got %s", expectedURL, payload.URL)
 		}
@@ -367,6 +387,54 @@ func TestBuildPayloadFromNotification(t *testing.T) {
 		}
 		if payload.Body != "Thanks for the update!" {
 			t.Errorf("Expected 'Thanks for the update!', got %s", payload.Body)
+		}
+	})
+
+	t.Run("builds room message payload with room name and preview", func(t *testing.T) {
+		notif := &corev1.Notification{
+			Id: "notif-room-message",
+			Notification: &corev1.Notification_RoomMessage{
+				RoomMessage: &corev1.RoomMessageNotification{
+					RoomId:  "room-news",
+					EventId: "room-event",
+				},
+			},
+		}
+		ctx := &PayloadContext{MessagePreview: "A watched room has a new message", RoomName: "news"}
+
+		payload := BuildPayloadFromNotification(notif, "Eve", baseURL, ctx)
+
+		if payload.Title != "@Eve posted in #news" {
+			t.Errorf("Expected '@Eve posted in #news', got %s", payload.Title)
+		}
+		if payload.Body != "A watched room has a new message" {
+			t.Errorf("Expected room message preview, got %s", payload.Body)
+		}
+		if payload.Tag != "room-message-room-event" {
+			t.Errorf("Expected tag 'room-message-room-event', got %s", payload.Tag)
+		}
+		expectedURL := "https://chatto.example.com/chat/-/room-news?highlight=room-event"
+		if payload.URL != expectedURL {
+			t.Errorf("Expected URL %s, got %s", expectedURL, payload.URL)
+		}
+	})
+
+	t.Run("escapes notification URL path segments and highlight query", func(t *testing.T) {
+		notif := &corev1.Notification{
+			Id: "notif-escaped",
+			Notification: &corev1.Notification_Mention{
+				Mention: &corev1.MentionNotification{
+					RoomId:  "room with spaces",
+					EventId: "event+plus",
+				},
+			},
+		}
+
+		payload := BuildPayloadFromNotification(notif, "Bob", baseURL, nil)
+
+		expectedURL := "https://chatto.example.com/chat/-/room%20with%20spaces?highlight=event%2Bplus"
+		if payload.URL != expectedURL {
+			t.Errorf("Expected URL %s, got %s", expectedURL, payload.URL)
 		}
 	})
 
@@ -462,6 +530,18 @@ func TestNotificationTag(t *testing.T) {
 		tag := NotificationTag(notif)
 		if tag != "reply-event-ghi" {
 			t.Errorf("Expected 'reply-event-ghi', got %s", tag)
+		}
+	})
+
+	t.Run("returns room message tag with event ID", func(t *testing.T) {
+		notif := &corev1.Notification{
+			Notification: &corev1.Notification_RoomMessage{
+				RoomMessage: &corev1.RoomMessageNotification{RoomId: "room-101", EventId: "event-room"},
+			},
+		}
+		tag := NotificationTag(notif)
+		if tag != "room-message-event-room" {
+			t.Errorf("Expected 'room-message-event-room', got %s", tag)
 		}
 	})
 

--- a/frontend/src/lib/state/server/notifications.spec.ts
+++ b/frontend/src/lib/state/server/notifications.spec.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Client } from '@urql/svelte';
-import { NotificationStore, type NotificationItem } from './notifications.svelte';
+import {
+  NotificationStore,
+  notificationTarget,
+  type NotificationItem
+} from './notifications.svelte';
 
 /**
  * Build a minimal mock urql Client whose `query` resolves with a controllable
@@ -120,6 +124,85 @@ describe('NotificationStore', () => {
       notification: cached
     });
     expect(client.query).not.toHaveBeenCalled();
+  });
+
+  it('routes notification targets to the same room/thread/event used by push payloads', () => {
+    const store = new NotificationStore(makeClient({}));
+    const threadMention = {
+      __typename: 'MentionNotificationItem',
+      id: 'thread-mention',
+      createdAt: new Date().toISOString(),
+      actor: {
+        id: 'a',
+        login: 't',
+        displayName: 't',
+        avatarUrl: null,
+        presenceStatus: 'OFFLINE'
+      },
+      summary: 'mentioned you',
+      mentionRoom: { id: 'room-2', name: 'general' },
+      mentionEventId: 'mention-event',
+      mentionInThread: 'thread-root'
+    } as unknown as NotificationItem;
+    const threadReply = {
+      __typename: 'ReplyNotificationItem',
+      id: 'thread-reply',
+      createdAt: new Date().toISOString(),
+      actor: {
+        id: 'a',
+        login: 't',
+        displayName: 't',
+        avatarUrl: null,
+        presenceStatus: 'OFFLINE'
+      },
+      summary: 'replied to you',
+      replyRoom: { id: 'room-2', name: 'general' },
+      replyEventId: 'reply-event',
+      inReplyToId: 'mid-thread-msg',
+      replyInThread: 'thread-root'
+    } as unknown as NotificationItem;
+    const roomMessage = {
+      __typename: 'RoomMessageNotificationItem',
+      id: 'room-message',
+      createdAt: new Date().toISOString(),
+      actor: {
+        id: 'a',
+        login: 't',
+        displayName: 't',
+        avatarUrl: null,
+        presenceStatus: 'OFFLINE'
+      },
+      summary: 'posted a message',
+      roomMsgRoom: { id: 'room-news', name: 'news' },
+      roomMsgEventId: 'room-event'
+    } as unknown as NotificationItem;
+
+    expect(notificationTarget(threadMention)).toMatchObject({
+      roomId: 'room-2',
+      eventId: 'mention-event',
+      threadRootId: 'thread-root'
+    });
+    expect(store.getNavigationPath('origin', threadMention)).toBe(
+      '/chat/-/room-2/thread-root?highlight=mention-event'
+    );
+
+    expect(notificationTarget(threadReply)).toMatchObject({
+      roomId: 'room-2',
+      eventId: 'reply-event',
+      threadRootId: 'thread-root'
+    });
+    expect(store.getNavigationPath('origin', threadReply)).toBe(
+      '/chat/-/room-2/thread-root?highlight=reply-event'
+    );
+
+    expect(notificationTarget(roomMessage)).toMatchObject({
+      roomId: 'room-news',
+      eventId: 'room-event',
+      threadRootId: null
+    });
+    expect(store.getNavigationPath('origin', roomMessage)).toBe(
+      '/chat/-/room-news?highlight=room-event'
+    );
   });
 
   // The motivating bug: a remote instance running an older backend rejects


### PR DESCRIPTION
## Changes
- Fix Web Push payload URLs for thread mentions, thread replies, and all-message room notifications.
- Build push navigation URLs with proper path/query escaping and add room-message push tags for cross-device dismiss.
- Add Go and frontend unit coverage to keep backend push URLs aligned with in-app notification targets.

## Tests
- `cd cli && mise x -- go test ./internal/push ./cmd`
- `cd frontend && mise x -- pnpm test:unit --run --project server src/lib/pwa/notificationClick.worker.spec.ts src/lib/pwa/serviceWorkerPolicy.spec.ts src/lib/notifications/pushNotifications.spec.ts src/lib/state/server/notifications.spec.ts`
