### PR TITLE
test(cli): speed up Go test suite

### DIFF
--- a/.claude/rules/testing-backend.md
+++ b/.claude/rules/testing-backend.md
@@ -12,7 +12,7 @@ Always run Go tests through `mise` so the repo toolchain is active. For full-sui
 
 ## Iterate with targeted runs; reserve `mise test-cli` for checkpoints
 
-The full suite takes 90–180s (tracked in #625). While iterating on a change, **don't run the whole suite as your feedback loop** — it wastes wall-clock time and buries real signal in noise. Instead:
+The full suite is still broad enough to be a checkpoint, not an edit-refresh loop. While iterating on a change, **don't run the whole suite as your feedback loop** — it wastes wall-clock time and buries real signal in noise. Instead:
 
 - Drill into the specific package and test you care about:
   ```

--- a/cli/internal/core/attachments_test.go
+++ b/cli/internal/core/attachments_test.go
@@ -988,7 +988,7 @@ func setupTestCoreWithS3PathPrefix(t *testing.T, pathPrefix string) (*ChattoCore
 
 	endpointHost := s3Server.URL[7:] // Remove "http://"
 
-	_, nc := testutil.StartNATS(t)
+	_, nc := testutil.StartSharedNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)
@@ -1039,7 +1039,7 @@ func setupTestCoreWithS3PathPrefix(t *testing.T, pathPrefix string) (*ChattoCore
 func setupTestCoreWithCache(t *testing.T) (*ChattoCore, *nats.Conn) {
 	t.Helper()
 
-	_, nc := testutil.StartNATS(t)
+	_, nc := testutil.StartSharedNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)

--- a/cli/internal/core/core_test.go
+++ b/cli/internal/core/core_test.go
@@ -32,7 +32,7 @@ func testContext(t *testing.T) context.Context {
 func setupTestCore(t *testing.T) (*ChattoCore, *nats.Conn) {
 	t.Helper()
 
-	_, nc := testutil.StartNATS(t)
+	_, nc := testutil.StartSharedNATS(t)
 
 	ctx := testContext(t)
 

--- a/cli/internal/core/encryption_test.go
+++ b/cli/internal/core/encryption_test.go
@@ -22,7 +22,7 @@ import (
 func setupTestCoreWithEncryption(t *testing.T) *ChattoCore {
 	t.Helper()
 
-	_, nc := testutil.StartNATS(t)
+	_, nc := testutil.StartSharedNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)

--- a/cli/internal/core/room_events_stream_test.go
+++ b/cli/internal/core/room_events_stream_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+	"hmans.de/chatto/internal/testutil"
 )
 
 func TestChattoCore_StreamRoomEventsLive(t *testing.T) {
@@ -38,22 +41,16 @@ func TestChattoCore_StreamRoomEventsLive(t *testing.T) {
 		t.Fatalf("Failed to post message: %v", err)
 	}
 
-	// Use select with timeout to prevent indefinite blocking
-	select {
-	case event := <-eventChan:
-		if event.GetMessagePosted() == nil {
-			t.Error("Expected MessagePosted event")
-		}
+	event := testutil.WaitForValue(t, eventChan, 2*time.Second, "live room MessagePosted event", func(event *corev1.Event) bool {
+		return event.GetMessagePosted() != nil
+	})
 
-		// Body lookup is keyed by the durable event envelope id.
-		fetchedBody, err := core.GetMessageBody(ctx, KindChannel, event.Id)
-		if err != nil {
-			t.Fatalf("Failed to fetch message body: %v", err)
-		}
-		if fetchedBody != "Live message" {
-			t.Errorf("Expected message 'Live message', got '%s'", fetchedBody)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("Timeout waiting for live event")
+	// Body lookup is keyed by the durable event envelope id.
+	fetchedBody, err := core.GetMessageBody(ctx, KindChannel, event.Id)
+	if err != nil {
+		t.Fatalf("Failed to fetch message body: %v", err)
+	}
+	if fetchedBody != "Live message" {
+		t.Errorf("Expected message 'Live message', got '%s'", fetchedBody)
 	}
 }

--- a/cli/internal/core/shared_nats_test.go
+++ b/cli/internal/core/shared_nats_test.go
@@ -1,0 +1,14 @@
+package core
+
+import (
+	"os"
+	"testing"
+
+	"hmans.de/chatto/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	testutil.ShutdownSharedNATS()
+	os.Exit(code)
+}

--- a/cli/internal/graph/dataloader/shared_nats_test.go
+++ b/cli/internal/graph/dataloader/shared_nats_test.go
@@ -1,0 +1,14 @@
+package dataloader_test
+
+import (
+	"os"
+	"testing"
+
+	"hmans.de/chatto/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	testutil.ShutdownSharedNATS()
+	os.Exit(code)
+}

--- a/cli/internal/graph/dataloader/user_loader_test.go
+++ b/cli/internal/graph/dataloader/user_loader_test.go
@@ -16,7 +16,7 @@ import (
 func setupTestCore(t *testing.T) *core.ChattoCore {
 	t.Helper()
 
-	_, nc := testutil.StartNATS(t)
+	_, nc := testutil.StartSharedNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)

--- a/cli/internal/graph/shared_nats_test.go
+++ b/cli/internal/graph/shared_nats_test.go
@@ -1,0 +1,14 @@
+package graph
+
+import (
+	"os"
+	"testing"
+
+	"hmans.de/chatto/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	testutil.ShutdownSharedNATS()
+	os.Exit(code)
+}

--- a/cli/internal/graph/subscription_test.go
+++ b/cli/internal/graph/subscription_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"hmans.de/chatto/internal/core"
+	"hmans.de/chatto/internal/testutil"
 )
 
 // ============================================================================
@@ -42,24 +43,9 @@ func TestSubscriptionResolver_MyEvents(t *testing.T) {
 			}
 		}()
 
-		// Wait for MessagePosted event (skip non-message events like presence)
-		deadline := time.After(3 * time.Second)
-		found := false
-		for !found {
-			select {
-			case event := <-eventChan:
-				if event == nil {
-					t.Error("Received nil event")
-					return
-				}
-				if core.EventMessagePosted(event) != nil {
-					found = true
-				}
-			case <-deadline:
-				t.Error("Timeout waiting for MessagePosted event")
-				return
-			}
-		}
+		testutil.WaitForValue(t, eventChan, 2*time.Second, "MessagePosted event", func(event core.EventEnvelope) bool {
+			return event != nil && core.EventMessagePosted(event) != nil
+		})
 	})
 
 	t.Run("subscribe without authentication", func(t *testing.T) {
@@ -200,21 +186,11 @@ func TestSubscriptionResolver_MyEvents(t *testing.T) {
 		// Drain the channel, ignoring any non-MessagePosted events that the
 		// merged subscription now interleaves (presence, etc.).
 		receivedIDs := make([]string, 0, len(messages))
-		deadline := time.After(5 * time.Second)
 		for len(receivedIDs) < len(messages) {
-			select {
-			case event := <-eventChan:
-				if event == nil {
-					t.Error("Received nil event")
-					continue
-				}
-				if core.EventMessagePosted(event) == nil {
-					continue // not a message event — skip
-				}
-				receivedIDs = append(receivedIDs, event.ID())
-			case <-deadline:
-				t.Fatalf("Timeout waiting for message events: got %d of %d (ids so far: %v)", len(receivedIDs), len(messages), receivedIDs)
-			}
+			event := testutil.WaitForValue(t, eventChan, 2*time.Second, "ordered MessagePosted event", func(event core.EventEnvelope) bool {
+				return event != nil && core.EventMessagePosted(event) != nil
+			})
+			receivedIDs = append(receivedIDs, event.ID())
 		}
 
 		for i, want := range expectedIDs {
@@ -267,26 +243,18 @@ func TestSubscriptionResolver_MyEvents(t *testing.T) {
 			}
 		}()
 
-		// User A should receive the thread reply as a MessagePosted event with inThread set
-		// Loop to skip other events (joins, etc.) until we find the thread reply
-		timeout := time.After(10 * time.Second)
-		for {
-			select {
-			case event := <-eventChan:
-				if event == nil {
-					continue
-				}
-				if msg := core.EventMessagePosted(event); msg != nil && msg.InThread != "" {
-					if msg.InThread != rootEventID {
-						t.Errorf("Expected InThread=%q, got %q", rootEventID, msg.InThread)
-					}
-					t.Logf("Received MessagePosted for thread reply in thread=%s", msg.InThread)
-					return // Success - thread reply received
-				}
-			case <-timeout:
-				t.Fatal("Timeout waiting for thread reply event")
+		event := testutil.WaitForValue(t, eventChan, 2*time.Second, "thread reply MessagePosted event", func(event core.EventEnvelope) bool {
+			if event == nil {
+				return false
 			}
+			msg := core.EventMessagePosted(event)
+			return msg != nil && msg.InThread != ""
+		})
+		msg := core.EventMessagePosted(event)
+		if msg.InThread != rootEventID {
+			t.Errorf("Expected InThread=%q, got %q", rootEventID, msg.InThread)
 		}
+		t.Logf("Received MessagePosted for thread reply in thread=%s", msg.InThread)
 	})
 }
 
@@ -350,38 +318,24 @@ func TestSubscriptionResolver_MyEvents_DeploymentEvents(t *testing.T) {
 			}
 		}()
 
-		// Wait for mention notification event (for room indicator) or notification created event (for bell icon)
-		// Accept whichever of MentionNotificationEvent or
-		// NotificationCreatedEvent arrives first. Skip presence and other
-		// chatter the merged subscription now delivers.
-		deadline := time.After(5 * time.Second)
-		for {
-			select {
-			case event := <-eventChan:
-				if event == nil {
-					t.Fatal("Received nil event")
-				}
-				if mentioned := core.EventMentionNotification(event); mentioned != nil {
-					if mentioned.RoomId != env.testRoom.Id {
-						t.Errorf("Expected room ID %s, got %s", env.testRoom.Id, mentioned.RoomId)
-					}
-					if mentioned.MentionedByUserId != userB.Id {
-						t.Errorf("Expected mentioner ID %s, got %s", userB.Id, mentioned.MentionedByUserId)
-					}
-					t.Logf("Successfully received mention notification in room %s", mentioned.RoomId)
-					return
-				}
-				if notifCreated := core.EventNotificationCreated(event); notifCreated != nil {
-					if notifCreated.RoomId != env.testRoom.Id {
-						t.Errorf("Expected room ID %s, got %s", env.testRoom.Id, notifCreated.RoomId)
-					}
-					t.Logf("Successfully received notification created event for mention in room %s", notifCreated.RoomId)
-					return
-				}
-				t.Logf("Ignoring non-mention event: %T", event.Payload())
-			case <-deadline:
-				t.Fatal("Timeout waiting for mention event")
+		event := testutil.WaitForValue(t, eventChan, 2*time.Second, "mention notification event", func(event core.EventEnvelope) bool {
+			return event != nil && (core.EventMentionNotification(event) != nil || core.EventNotificationCreated(event) != nil)
+		})
+		if mentioned := core.EventMentionNotification(event); mentioned != nil {
+			if mentioned.RoomId != env.testRoom.Id {
+				t.Errorf("Expected room ID %s, got %s", env.testRoom.Id, mentioned.RoomId)
 			}
+			if mentioned.MentionedByUserId != userB.Id {
+				t.Errorf("Expected mentioner ID %s, got %s", userB.Id, mentioned.MentionedByUserId)
+			}
+			t.Logf("Successfully received mention notification in room %s", mentioned.RoomId)
+			return
+		}
+		if notifCreated := core.EventNotificationCreated(event); notifCreated != nil {
+			if notifCreated.RoomId != env.testRoom.Id {
+				t.Errorf("Expected room ID %s, got %s", env.testRoom.Id, notifCreated.RoomId)
+			}
+			t.Logf("Successfully received notification created event for mention in room %s", notifCreated.RoomId)
 		}
 	})
 }
@@ -425,33 +379,14 @@ func TestSubscriptionResolver_Presence(t *testing.T) {
 			t.Fatalf("Unexpected error subscribing User B to server events: %v", err)
 		}
 
-		// User A should receive a PresenceChangedEvent for User B via space events
-		deadline := time.After(5 * time.Second)
-		found := false
-		for !found {
-			select {
-			case event := <-eventChanA:
-				if event == nil {
-					t.Fatal("Received nil event")
-				}
-				presenceEvent := core.EventPresenceChanged(event)
-				if presenceEvent == nil {
-					t.Logf("Received non-presence event: %T, skipping", event.Payload())
-					continue
-				}
-				if event.ActorID() != userB.Id {
-					t.Logf("Received presence event for %s (not User B), skipping", event.ActorID())
-					continue
-				}
-				if presenceEvent.Status != "ONLINE" {
-					t.Errorf("Expected status ONLINE, got %s", presenceEvent.Status)
-				}
-				t.Logf("Successfully received presence event: user %s is now %s", event.ActorID(), presenceEvent.Status)
-				found = true
-			case <-deadline:
-				t.Fatal("Timeout waiting for User B's presence event")
-			}
+		event := testutil.WaitForValue(t, eventChanA, 2*time.Second, "User B presence event", func(event core.EventEnvelope) bool {
+			return event != nil && event.ActorID() == userB.Id && core.EventPresenceChanged(event) != nil
+		})
+		presenceEvent := core.EventPresenceChanged(event)
+		if presenceEvent.Status != "ONLINE" {
+			t.Errorf("Expected status ONLINE, got %s", presenceEvent.Status)
 		}
+		t.Logf("Successfully received presence event: user %s is now %s", event.ActorID(), presenceEvent.Status)
 	})
 
 	t.Run("presence set by server-events subscription, remains after subscription ends (TTL-based expiry)", func(t *testing.T) {

--- a/cli/internal/graph/test_helpers.go
+++ b/cli/internal/graph/test_helpers.go
@@ -28,7 +28,7 @@ type testEnv struct {
 func setupTestResolver(t *testing.T) *testEnv {
 	t.Helper()
 
-	_, nc := testutil.StartNATS(t)
+	_, nc := testutil.StartSharedNATS(t)
 
 	// Use a context with timeout for setup
 	setupCtx, setupCancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -158,7 +158,7 @@ func (e *testEnv) createVerifiedUser(t *testing.T, login, displayName, password 
 func setupTestResolverWithAdmin(t *testing.T, ownerEmails []string) *testEnv {
 	t.Helper()
 
-	_, nc := testutil.StartNATS(t)
+	_, nc := testutil.StartSharedNATS(t)
 
 	// Use a context with timeout for setup
 	setupCtx, setupCancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/cli/internal/http_server/assets_test.go
+++ b/cli/internal/http_server/assets_test.go
@@ -61,7 +61,7 @@ func setupAssetTestServerWithConfig(t *testing.T, useS3 bool) *assetTestEnv {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	_, nc := testutil.StartNATS(t)
+	_, nc := testutil.StartSharedNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)

--- a/cli/internal/http_server/csrf_test.go
+++ b/cli/internal/http_server/csrf_test.go
@@ -33,7 +33,7 @@ func setupCSRFTestServer(t *testing.T) (*httptest.Server, *http.Client) {
 	})
 	router.Use(sessions.Sessions("chatto_session", sessionStore))
 
-	_, nc := testutil.StartNATS(t)
+	_, nc := testutil.StartSharedNATS(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)
 	chattoCore, err := core.NewChattoCore(ctx, nc, config.CoreConfig{})

--- a/cli/internal/http_server/graphql_test.go
+++ b/cli/internal/http_server/graphql_test.go
@@ -66,7 +66,7 @@ func setupGraphQLTestServerFull(t *testing.T, ownersConfig config.OwnersConfig, 
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	_, nc := testutil.StartNATS(t)
+	_, nc := testutil.StartSharedNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)

--- a/cli/internal/http_server/oauth_test.go
+++ b/cli/internal/http_server/oauth_test.go
@@ -25,7 +25,7 @@ func setupOAuthServer(t *testing.T) *HTTPServer {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	_, nc := testutil.StartNATS(t)
+	_, nc := testutil.StartSharedNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)

--- a/cli/internal/http_server/server_info_test.go
+++ b/cli/internal/http_server/server_info_test.go
@@ -42,7 +42,7 @@ func setupServerInfoServer(t *testing.T, authConfig config.AuthConfig) *HTTPServ
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	_, nc := testutil.StartNATS(t)
+	_, nc := testutil.StartSharedNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)

--- a/cli/internal/http_server/server_test.go
+++ b/cli/internal/http_server/server_test.go
@@ -188,7 +188,7 @@ func setupTestHTTPServerWithHook(t *testing.T, configure func(*HTTPServer)) (*ht
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	_, nc := testutil.StartNATS(t)
+	_, nc := testutil.StartSharedNATS(t)
 
 	ctx := testContext(t)
 
@@ -260,7 +260,7 @@ func setupTestHTTPServerWithMailerConfig(t *testing.T, emailOTP config.EmailOTPC
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	_, nc := testutil.StartNATS(t)
+	_, nc := testutil.StartSharedNATS(t)
 
 	ctx := testContext(t)
 
@@ -1169,7 +1169,7 @@ func setupTestHTTPServerWithRegistrationDisabled(t *testing.T) (*httptest.Server
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	_, nc := testutil.StartNATS(t)
+	_, nc := testutil.StartSharedNATS(t)
 
 	ctx := testContext(t)
 

--- a/cli/internal/http_server/shared_nats_test.go
+++ b/cli/internal/http_server/shared_nats_test.go
@@ -1,0 +1,14 @@
+package http_server
+
+import (
+	"os"
+	"testing"
+
+	"hmans.de/chatto/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	testutil.ShutdownSharedNATS()
+	os.Exit(code)
+}

--- a/cli/internal/http_server/upload_test.go
+++ b/cli/internal/http_server/upload_test.go
@@ -43,7 +43,7 @@ func setupUploadTestServer(t *testing.T) *uploadTestEnv {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	_, nc := testutil.StartNATS(t)
+	_, nc := testutil.StartSharedNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)

--- a/cli/internal/http_server/websocket_test.go
+++ b/cli/internal/http_server/websocket_test.go
@@ -40,7 +40,7 @@ func setupWebSocketTestServer(t *testing.T) *wsTestEnv {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	_, nc := testutil.StartNATS(t)
+	_, nc := testutil.StartSharedNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	t.Cleanup(cancel)

--- a/cli/internal/testutil/nats.go
+++ b/cli/internal/testutil/nats.go
@@ -1,11 +1,23 @@
 package testutil
 
 import (
+	"context"
+	"errors"
+	"os"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+var (
+	sharedNATSMu     sync.Mutex
+	sharedNATSOnce   sync.Once
+	sharedNATSServer *server.Server
+	sharedNATSErr    error
 )
 
 // StartNATS starts an embedded JetStream-enabled NATS server for tests and
@@ -40,4 +52,131 @@ func StartNATS(t testing.TB) (*server.Server, *nats.Conn) {
 	})
 
 	return ns, nc
+}
+
+// StartSharedNATS returns a fresh in-process connection to a package-shared
+// embedded NATS server. It removes Chatto's known JetStream resources before
+// returning so callers can create a fresh ChattoCore without paying per-test
+// server startup cost.
+//
+// This helper assumes package tests are not marked t.Parallel. It is intended
+// for integration-style test helpers that already serialize access through Go's
+// default test runner.
+func StartSharedNATS(t testing.TB) (*server.Server, *nats.Conn) {
+	t.Helper()
+
+	ns := sharedNATS(t)
+	nc, err := nats.Connect(nats.DefaultURL, nats.InProcessServer(ns))
+	if err != nil {
+		t.Fatalf("Failed to connect to shared NATS: %v", err)
+	}
+	t.Cleanup(nc.Close)
+
+	ResetChattoJetStream(t, nc)
+
+	return ns, nc
+}
+
+// ResetChattoJetStream deletes the durable resources Chatto test cores create.
+// It deliberately targets current Chatto resource names rather than deleting
+// every stream in the account, so ad-hoc test streams remain opt-in.
+func ResetChattoJetStream(t testing.TB, nc *nats.Conn) {
+	t.Helper()
+
+	sharedNATSMu.Lock()
+	defer sharedNATSMu.Unlock()
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatalf("create JetStream context: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	for _, bucket := range []string{
+		"ENCRYPTION_KEYS",
+		"RUNTIME_STATE",
+		"MEMORY_CACHE",
+	} {
+		if err := js.DeleteKeyValue(ctx, bucket); err != nil && !errors.Is(err, jetstream.ErrBucketNotFound) {
+			t.Fatalf("delete KV bucket %s: %v", bucket, err)
+		}
+	}
+
+	for _, bucket := range []string{
+		"ASSET_CACHE",
+		"SERVER_ASSETS",
+	} {
+		if err := js.DeleteObjectStore(ctx, bucket); err != nil && !errors.Is(err, jetstream.ErrBucketNotFound) {
+			t.Fatalf("delete object store %s: %v", bucket, err)
+		}
+	}
+
+	for _, stream := range []string{"EVT"} {
+		if err := js.DeleteStream(ctx, stream); err != nil && !errors.Is(err, jetstream.ErrStreamNotFound) {
+			t.Fatalf("delete stream %s: %v", stream, err)
+		}
+	}
+
+	if err := nc.FlushTimeout(2 * time.Second); err != nil {
+		t.Fatalf("flush after JetStream reset: %v", err)
+	}
+}
+
+// WaitForValue reads from ch until match accepts a value or timeout expires.
+func WaitForValue[T any](t testing.TB, ch <-chan T, timeout time.Duration, description string, match func(T) bool) T {
+	t.Helper()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	var zero T
+	for {
+		select {
+		case value, ok := <-ch:
+			if !ok {
+				t.Fatalf("channel closed while waiting for %s", description)
+			}
+			if match(value) {
+				return value
+			}
+		case <-timer.C:
+			t.Fatalf("timeout waiting for %s", description)
+			return zero
+		}
+	}
+}
+
+func sharedNATS(t testing.TB) *server.Server {
+	t.Helper()
+
+	sharedNATSOnce.Do(func() {
+		storeDir, err := os.MkdirTemp("", "chatto-shared-nats-*")
+		if err != nil {
+			sharedNATSErr = err
+			return
+		}
+
+		sharedNATSServer, sharedNATSErr = server.NewServer(&server.Options{
+			JetStream:  true,
+			DontListen: true,
+			StoreDir:   storeDir,
+			NoSigs:     true,
+		})
+		if sharedNATSErr != nil {
+			return
+		}
+
+		sharedNATSServer.Start()
+		if !sharedNATSServer.ReadyForConnections(5 * time.Second) {
+			sharedNATSErr = errors.New("shared NATS server not ready")
+		}
+	})
+
+	if sharedNATSErr != nil {
+		t.Fatalf("Failed to create shared NATS server: %v", sharedNATSErr)
+	}
+
+	return sharedNATSServer
 }

--- a/cli/internal/testutil/nats.go
+++ b/cli/internal/testutil/nats.go
@@ -17,6 +17,7 @@ var (
 	sharedNATSMu     sync.Mutex
 	sharedNATSOnce   sync.Once
 	sharedNATSServer *server.Server
+	sharedNATSStore  string
 	sharedNATSErr    error
 )
 
@@ -75,6 +76,27 @@ func StartSharedNATS(t testing.TB) (*server.Server, *nats.Conn) {
 	ResetChattoJetStream(t, nc)
 
 	return ns, nc
+}
+
+// ShutdownSharedNATS stops the package-shared embedded server and removes its
+// JetStream store directory. Packages that use StartSharedNATS should call this
+// from TestMain after m.Run so the store survives for the whole package test
+// process but does not leak under the system temp directory.
+func ShutdownSharedNATS() {
+	sharedNATSMu.Lock()
+	defer sharedNATSMu.Unlock()
+
+	if sharedNATSServer != nil {
+		sharedNATSServer.Shutdown()
+		sharedNATSServer.WaitForShutdown()
+		sharedNATSServer = nil
+	}
+	if sharedNATSStore != "" {
+		_ = os.RemoveAll(sharedNATSStore)
+		sharedNATSStore = ""
+	}
+	sharedNATSErr = nil
+	sharedNATSOnce = sync.Once{}
 }
 
 // ResetChattoJetStream deletes the durable resources Chatto test cores create.
@@ -157,6 +179,7 @@ func sharedNATS(t testing.TB) *server.Server {
 			sharedNATSErr = err
 			return
 		}
+		sharedNATSStore = storeDir
 
 		sharedNATSServer, sharedNATSErr = server.NewServer(&server.Options{
 			JetStream:  true,

--- a/mise.toml
+++ b/mise.toml
@@ -199,7 +199,7 @@ run = "exec bin/chatto"
 description = "Run CLI tests"
 depends = ["deps-cli", "build-frontend"]
 dir = "cli"
-run = "go test -tags test_endpoints ./..."
+run = "go test -p ${CHATTO_GO_TEST_P:-4} -tags test_endpoints ./..."
 sources = ["**/*.go"]
 
 [tasks.test-cli-shutdown]


### PR DESCRIPTION
Fixes #625.

- Adds shared embedded NATS test fixtures with JetStream resource reset for high-volume Go integration tests.
- Migrates core, graph, dataloader, and HTTP server test setup helpers to the shared fixture and shortens selected live-event waits.
- Caps `mise test-cli` package concurrency with `CHATTO_GO_TEST_P` and refreshes backend test guidance.

Tests:
- `mise test-cli`
- `go test -tags test_endpoints -count=5 ./internal/core -run 'StreamMyEvents|StreamRoomEventsLive|RoomEventsLive' -timeout 60s`
- `go test -tags test_endpoints -count=5 ./internal/graph -run 'SubscriptionResolver' -timeout 60s`
- `go test -tags test_endpoints -count=3 ./internal/http_server -timeout 60s`
