### PR TITLE
fix(graphql): enforce room move group permissions

### DIFF
--- a/cli/internal/core/room_groups.go
+++ b/cli/internal/core/room_groups.go
@@ -43,6 +43,7 @@ var (
 	ErrRoomGroupHasRooms        = errors.New("room group has rooms; move them out before deleting")
 	ErrRoomGroupNameEmpty       = errors.New("room group name must not be empty")
 	ErrRoomGroupOrderMismatch   = errors.New("room group order must be a permutation of existing groups")
+	ErrRoomMoveSourceChanged    = errors.New("room move source group changed")
 	ErrSidebarLinkNotFound      = errors.New("sidebar link not found")
 	ErrSidebarLinkSourceChanged = errors.New("sidebar link source group changed")
 	ErrSidebarLinkLabelEmpty    = errors.New("sidebar link label must not be empty")
@@ -293,6 +294,18 @@ func (c *ChattoCore) DeleteRoomGroup(ctx context.Context, actorID, groupID strin
 // Authorization for the source and target groups must be checked by
 // the caller — see ADR-031's two-group rule.
 func (c *ChattoCore) MoveRoomToGroup(ctx context.Context, actorID, roomID, targetGroupID string) error {
+	return c.moveRoomToGroup(ctx, actorID, roomID, "", targetGroupID, false)
+}
+
+// MoveRoomToGroupFromSource moves a room only if the room's current source
+// group still matches sourceGroupID. API callers that authorize the source
+// group before calling core should use this variant so a concurrent move
+// cannot swap the source group between authorization and append.
+func (c *ChattoCore) MoveRoomToGroupFromSource(ctx context.Context, actorID, roomID, sourceGroupID, targetGroupID string) error {
+	return c.moveRoomToGroup(ctx, actorID, roomID, sourceGroupID, targetGroupID, true)
+}
+
+func (c *ChattoCore) moveRoomToGroup(ctx context.Context, actorID, roomID, authorizedSourceGroupID, targetGroupID string, bindSource bool) error {
 	occFilter := events.GroupSubjectFilter()
 	for attempt := 0; attempt < maxMoveRoomToGroupRetries; attempt++ {
 		snapshot := c.RoomGroups.MoveSnapshot(roomID, targetGroupID)
@@ -307,6 +320,9 @@ func (c *ChattoCore) MoveRoomToGroup(ctx context.Context, actorID, roomID, targe
 		}
 
 		sourceGroupID := snapshot.SourceGroupID
+		if bindSource && sourceGroupID != authorizedSourceGroupID {
+			return ErrRoomMoveSourceChanged
+		}
 		if sourceGroupID == targetGroupID {
 			if err := c.rooms().waitForGroupLayoutCurrent(ctx, c.EventPublisher); err != nil {
 				return fmt.Errorf("wait for room group layout projection before no-op decision: %w", err)
@@ -315,6 +331,9 @@ func (c *ChattoCore) MoveRoomToGroup(ctx context.Context, actorID, roomID, targe
 			sourceGroupID = snapshot.SourceGroupID
 			if !snapshot.TargetExists {
 				return ErrRoomGroupNotFound
+			}
+			if bindSource && sourceGroupID != authorizedSourceGroupID {
+				return ErrRoomMoveSourceChanged
 			}
 			if sourceGroupID != targetGroupID {
 				continue

--- a/cli/internal/core/room_groups_test.go
+++ b/cli/internal/core/room_groups_test.go
@@ -265,6 +265,105 @@ func TestMoveRoomToSet_TargetNotFound(t *testing.T) {
 	}
 }
 
+func TestMoveRoomToSet_FromSourceRejectsChangedSource(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	setA, _ := core.CreateRoomGroup(ctx, "actor", "A", "")
+	setB, _ := core.CreateRoomGroup(ctx, "actor", "B", "")
+	setC, _ := core.CreateRoomGroup(ctx, "actor", "C", "")
+	room, _ := core.CreateRoom(ctx, "actor", KindChannel, "", "general", "")
+
+	if err := core.MoveRoomToGroup(ctx, "actor", room.Id, setA.Id); err != nil {
+		t.Fatalf("MoveRoomToGroup A failed: %v", err)
+	}
+	if err := core.MoveRoomToGroup(ctx, "other-actor", room.Id, setB.Id); err != nil {
+		t.Fatalf("MoveRoomToGroup B failed: %v", err)
+	}
+
+	err := core.MoveRoomToGroupFromSource(ctx, "actor", room.Id, setA.Id, setC.Id)
+	if !errors.Is(err, ErrRoomMoveSourceChanged) {
+		t.Fatalf("MoveRoomToGroupFromSource err = %v, want ErrRoomMoveSourceChanged", err)
+	}
+
+	gotB, _ := core.GetRoomGroup(ctx, setB.Id)
+	if len(gotB.RoomIds) != 1 || gotB.RoomIds[0] != room.Id {
+		t.Fatalf("Set B should still contain the room after rejected move: %+v", gotB.RoomIds)
+	}
+	gotC, _ := core.GetRoomGroup(ctx, setC.Id)
+	if len(gotC.RoomIds) != 0 {
+		t.Fatalf("Set C should remain empty after rejected move: %+v", gotC.RoomIds)
+	}
+}
+
+func TestMoveRoomToSet_FromSourceRejectsChangedSourceAfterOCCRetry(t *testing.T) {
+	harness := newTestEventHarness(t)
+	ctx := testContext(t)
+
+	groupLayout := NewRoomGroupLayoutProjection()
+	groupLayoutProjector := harness.projector(groupLayout)
+	core := &ChattoCore{
+		nc:                       harness.nc,
+		logger:                   testServiceLogger(),
+		EventPublisher:           harness.publisher,
+		RoomGroupLayout:          groupLayout,
+		RoomGroupLayoutProjector: groupLayoutProjector,
+		RoomGroups:               groupLayout.Groups,
+		RoomLayout:               groupLayout.Layout,
+	}
+	core.roomService = newRoomService(nil, nil, groupLayout, groupLayoutProjector, nil, nil, nil, nil, nil, nil)
+
+	eventsToAppend := []*corev1.Event{
+		newEvent("actor", groupCreatedEvent("G-source", "Source", "")),
+		newEvent("actor", groupCreatedEvent("G-other", "Other", "")),
+		newEvent("actor", groupCreatedEvent("G-target", "Target", "")),
+		newEvent("actor", roomAddedToGroupEvent("G-source", "R1")),
+		newEvent("other-actor", roomRemovedFromGroupEvent("G-source", "R1")),
+		newEvent("other-actor", roomAddedToGroupEvent("G-other", "R1")),
+	}
+	for i, event := range eventsToAppend {
+		subject := events.GroupAggregate(groupIDOfTestGroupEvent(t, event)).SubjectFor(event)
+		seq, err := harness.publisher.AppendEventually(ctx, subject, event)
+		if err != nil {
+			t.Fatalf("append setup event %d: %v", i, err)
+		}
+		if i < 4 {
+			if err := groupLayout.Apply(event, seq); err != nil {
+				t.Fatalf("seed stale group projection event %d: %v", i, err)
+			}
+		}
+	}
+	if got := core.RoomGroups.GroupForRoom("R1"); got != "G-source" {
+		t.Fatalf("test setup source group = %q, want stale G-source", got)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- core.MoveRoomToGroupFromSource(ctx, "actor", "R1", "G-source", "G-target")
+	}()
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("MoveRoomToGroupFromSource returned before OCC retry catch-up: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	startTestProjector(t, groupLayoutProjector)
+	if err := <-errCh; !errors.Is(err, ErrRoomMoveSourceChanged) {
+		t.Fatalf("MoveRoomToGroupFromSource after OCC retry err = %v, want ErrRoomMoveSourceChanged", err)
+	}
+	if got := core.RoomGroups.GroupForRoom("R1"); got != "G-other" {
+		t.Fatalf("room source after rejected move = %q, want G-other", got)
+	}
+	target, ok := core.RoomGroups.Get("G-target")
+	if !ok {
+		t.Fatal("target group missing after catch-up")
+	}
+	if len(target.RoomIds) != 0 {
+		t.Fatalf("target room IDs = %v, want empty", target.RoomIds)
+	}
+}
+
 func TestMoveRoomToSet_TargetCreatedBeforeProjectionCatchup(t *testing.T) {
 	harness := newTestEventHarness(t)
 	ctx := testContext(t)

--- a/cli/internal/graph/room_groups.resolvers.go
+++ b/cli/internal/graph/room_groups.resolvers.go
@@ -7,6 +7,7 @@ package graph
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"hmans.de/chatto/internal/core"
@@ -147,17 +148,33 @@ func (r *mutationResolver) MoveRoomToGroup(ctx context.Context, input model.Move
 	if err != nil {
 		return nil, err
 	}
-	if err := r.requireGroupManageAuth(ctx, user.Id); err != nil {
-		return nil, err
+
+	for attempt := 0; attempt < 5; attempt++ {
+		room, err := r.core.GetRoom(ctx, core.KindChannel, input.RoomID)
+		if err != nil {
+			return nil, err
+		}
+		sourceGroupID := room.GroupId
+		if err := r.requireRoomGroupRoomManageAuth(ctx, user.Id, sourceGroupID); err != nil {
+			return nil, err
+		}
+		if err := r.requireRoomGroupRoomManageAuth(ctx, user.Id, input.GroupID); err != nil {
+			return nil, err
+		}
+		if err := r.core.MoveRoomToGroupFromSource(ctx, user.Id, input.RoomID, sourceGroupID, input.GroupID); err != nil {
+			if errors.Is(err, core.ErrRoomMoveSourceChanged) {
+				continue
+			}
+			return nil, err
+		}
+		room, err = r.core.GetRoom(ctx, core.KindChannel, input.RoomID)
+		if err != nil {
+			return nil, err
+		}
+		return room, nil
 	}
-	if err := r.core.MoveRoomToGroup(ctx, user.Id, input.RoomID, input.GroupID); err != nil {
-		return nil, err
-	}
-	room, err := r.core.GetRoom(ctx, core.KindChannel, input.RoomID)
-	if err != nil {
-		return nil, err
-	}
-	return room, nil
+
+	return nil, fmt.Errorf("move room source authorization retry exhausted: %w", core.ErrRoomMoveSourceChanged)
 }
 
 // ReorderRoomsInGroup is the resolver for the reorderRoomsInGroup field.

--- a/cli/internal/graph/room_groups_auth_test.go
+++ b/cli/internal/graph/room_groups_auth_test.go
@@ -1,0 +1,97 @@
+package graph
+
+import (
+	"errors"
+	"testing"
+
+	"hmans.de/chatto/internal/core"
+	"hmans.de/chatto/internal/graph/model"
+)
+
+func TestMoveRoomToGroupRequiresRoomManageInSourceAndTarget(t *testing.T) {
+	tests := []struct {
+		name            string
+		grantSource     bool
+		grantTarget     bool
+		grantRoleManage bool
+		wantErr         bool
+	}{
+		{
+			name:        "source allowed target denied rejects",
+			grantSource: true,
+			wantErr:     true,
+		},
+		{
+			name:        "source denied target allowed rejects",
+			grantTarget: true,
+			wantErr:     true,
+		},
+		{
+			name:        "both allowed succeeds",
+			grantSource: true,
+			grantTarget: true,
+		},
+		{
+			name:            "role manage alone rejects",
+			grantRoleManage: true,
+			wantErr:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := setupTestResolver(t)
+			mutation := env.resolver.Mutation()
+			manager := env.createVerifiedUser(t, "room-move-manager", "Room Move Manager", "password123")
+			sourceGroupID := env.testRoom.GroupId
+			if sourceGroupID == "" {
+				t.Fatal("expected test room to have a source group")
+			}
+
+			targetGroup, err := env.core.CreateRoomGroup(env.ctx, core.SystemActorID, "Move Target", "")
+			if err != nil {
+				t.Fatalf("CreateRoomGroup: %v", err)
+			}
+			if tt.grantSource {
+				if err := env.core.GrantUserGroupPermission(env.ctx, core.SystemActorID, sourceGroupID, manager.Id, core.PermRoomManage); err != nil {
+					t.Fatalf("GrantUserGroupPermission(source): %v", err)
+				}
+			}
+			if tt.grantTarget {
+				if err := env.core.GrantUserGroupPermission(env.ctx, core.SystemActorID, targetGroup.Id, manager.Id, core.PermRoomManage); err != nil {
+					t.Fatalf("GrantUserGroupPermission(target): %v", err)
+				}
+			}
+			if tt.grantRoleManage {
+				if err := env.core.GrantUserPermission(env.ctx, core.SystemActorID, manager.Id, core.PermRoleManage); err != nil {
+					t.Fatalf("GrantUserPermission(role.manage): %v", err)
+				}
+			}
+
+			room, err := mutation.MoveRoomToGroup(env.authContextForUser(manager), model.MoveRoomToGroupInput{
+				RoomID:  env.testRoom.Id,
+				GroupID: targetGroup.Id,
+			})
+			if tt.wantErr {
+				if !errors.Is(err, core.ErrPermissionDenied) {
+					t.Fatalf("MoveRoomToGroup err = %v, want ErrPermissionDenied", err)
+				}
+				current, getErr := env.core.GetRoom(env.ctx, core.KindChannel, env.testRoom.Id)
+				if getErr != nil {
+					t.Fatalf("GetRoom after rejected move: %v", getErr)
+				}
+				if current.GroupId != sourceGroupID {
+					t.Fatalf("rejected move changed group to %q, want %q", current.GroupId, sourceGroupID)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("MoveRoomToGroup: %v", err)
+			}
+			if room.GroupId != targetGroup.Id {
+				t.Fatalf("moved room group = %q, want %q", room.GroupId, targetGroup.Id)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Changes

- Enforces `room.manage` in both the source and target room groups before `moveRoomToGroup` delegates to core.
- Adds a source-bound core move path so the authorized source group must match the fresh move snapshot, including after OCC retries.
- Adds resolver regression coverage for source-only, target-only, both-groups, and `role.manage`-only authorization cases.
- Fixes #983.

## Tests

- `mise x -- go test ./internal/graph -run TestMoveRoomToGroupRequiresRoomManageInSourceAndTarget -timeout 60s`
- `mise x -- go test ./internal/core -run 'TestMoveRoomToSet_(FromSourceRejectsChangedSource|FromSourceRejectsChangedSourceAfterOCCRetry|TargetNotFound|ConcurrentMovesLeaveSingleAssignment)' -timeout 60s`
- `mise x -- go test ./internal/graph -timeout 120s`
- `mise x -- go test ./internal/core ./internal/graph -timeout 180s`
