### PR TITLE
fix(frontend): preserve nested reply quotes

### DIFF
--- a/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -14,6 +14,7 @@
     getRoomMembers,
     getRoomMembersStore,
     getComposerContext,
+    type QuoteInsertionContent,
     type RoomMember
   } from '$lib/state/room';
   import { shouldAutoFocus } from '$lib/utils/shouldAutoFocus';
@@ -56,7 +57,7 @@
   export type MessageComposerApi = {
     addFiles: (files: File[]) => void;
     focus: () => void;
-    insertQuote: (text: string) => void;
+    insertQuote: (text: QuoteInsertionContent) => void;
   };
 
   let {
@@ -411,7 +412,7 @@
     tick().then(() => editorApi?.focus());
   }
 
-  function insertQuote(text: string) {
+  function insertQuote(text: QuoteInsertionContent) {
     tick().then(() => editorApi?.insertQuote(text));
   }
 

--- a/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -5,7 +5,7 @@ import { tick, type ComponentProps } from 'svelte';
 import MessageComposer, { type MessageComposerApi } from './MessageComposer.svelte';
 import { createMockGraphqlClient, q } from '$lib/test-utils';
 import { getToasts, toast } from '$lib/ui/toast';
-import type { RoomMember } from '$lib/state/room';
+import type { QuoteInsertionContent, RoomMember } from '$lib/state/room';
 import { PresenceStatus } from '$lib/gql/graphql';
 
 function postedMessageEvent(
@@ -54,7 +54,7 @@ const roomStateMock = vi.hoisted(() => ({
     cancelEdit: vi.fn()
   },
   quoteInsertionState: {
-    request: null as { id: number; text: string } | null
+    request: null as { id: number; text: QuoteInsertionContent } | null
   },
   lastEditableMessage: {
     getLastEditableMessage: vi.fn(() => null as { eventId: string; body: string } | null),
@@ -1274,6 +1274,62 @@ describe('MessageComposer', () => {
       await vi.waitFor(() => expect(editor.querySelector('blockquote')).toBeTruthy());
       expect(editor.querySelectorAll('blockquote p')).toHaveLength(2);
       expect(editor.querySelector('blockquote')?.textContent).toBe('first linesecond line');
+    });
+
+    it('renders structured selected reply quotes as nested blockquotes', async () => {
+      let composerApi: MessageComposerApi | null = null;
+      const { container } = renderMessageComposer(
+        {
+          roomId: 'room_456',
+          onReady: (api) => {
+            composerApi = api;
+          }
+        },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = await findEditor(container);
+
+      await vi.waitFor(() => expect(composerApi).not.toBeNull());
+      composerApi!.insertQuote([
+        { quoteDepth: 0, text: 'a' },
+        { quoteDepth: 1, text: 'nice, love it' },
+        { quoteDepth: 0, text: ':D' }
+      ]);
+
+      await vi.waitFor(() => expect(editor.querySelector('blockquote blockquote')).toBeTruthy());
+      const outerQuote = editor.querySelector('blockquote')!;
+      const outerParagraphs = Array.from(outerQuote.children).filter(
+        (child): child is HTMLParagraphElement => child instanceof HTMLParagraphElement
+      );
+      expect(outerParagraphs.map((paragraph) => paragraph.textContent)).toEqual(['a', ':D']);
+      expect(editor.querySelector('blockquote blockquote p')?.textContent).toBe('nice, love it');
+    });
+
+    it('submits structured selected reply quotes as nested blockquote markdown', async () => {
+      let composerApi: MessageComposerApi | null = null;
+      const { container, roomId } = renderMessageComposer(
+        {
+          roomId: 'room_456',
+          onReady: (api) => {
+            composerApi = api;
+          }
+        },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = await findEditor(container);
+
+      await typeInEditor(editor, 'draft');
+      await vi.waitFor(() => expect(composerApi).not.toBeNull());
+      composerApi!.insertQuote([{ quoteDepth: 1, text: 'quoted text' }]);
+      await vi.waitFor(() => expect(editor.querySelector('blockquote blockquote')).toBeTruthy());
+
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({
+        roomId,
+        body: 'draft\n\n> > quoted text'
+      });
     });
 
     it('activates rich mode with Ctrl+Enter in simple mode', async () => {

--- a/frontend/src/lib/components/composer/TipTapEditor.svelte
+++ b/frontend/src/lib/components/composer/TipTapEditor.svelte
@@ -31,6 +31,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     ensureCodeLanguagesLoaded,
     lowlight
   } from '$lib/codeHighlighting';
+  import type { QuoteInsertionContent, SelectedQuoteBlock } from '$lib/state/room';
 
   const markdownLinkInputRegex = /(^|\s)\[([^\]\n]+)\]\((https?:\/\/[^\s)]+)\)$/;
   const codeFenceLineRegex = /^```([\w-]+)?$/;
@@ -649,6 +650,53 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     return found;
   }
 
+  function quoteParagraphsForText(text: string): JSONContent[] {
+    return text
+      .replace(/\r\n?/g, '\n')
+      .split('\n')
+      .map((line) => ({
+        type: 'paragraph',
+        content: line ? [{ type: 'text', text: line }] : undefined
+      }));
+  }
+
+  function normalizeQuoteInsertionContent(text: QuoteInsertionContent): SelectedQuoteBlock[] {
+    if (typeof text !== 'string') {
+      return text
+        .map((block) => ({
+          quoteDepth: Math.max(0, Math.floor(block.quoteDepth)),
+          text: block.text.replace(/\r\n?/g, '\n').trim()
+        }))
+        .filter((block) => block.text.length > 0);
+    }
+
+    const normalized = text.replace(/\r\n?/g, '\n').trim();
+    if (!normalized) return [];
+    return normalized.split('\n').map((line) => ({ quoteDepth: 0, text: line }));
+  }
+
+  function buildQuoteContent(blocks: SelectedQuoteBlock[]): JSONContent[] {
+    const content: JSONContent[] = [];
+
+    for (const block of blocks) {
+      let target = content;
+
+      for (let depth = 0; depth < block.quoteDepth; depth++) {
+        let current = target.at(-1);
+        if (current?.type !== 'blockquote') {
+          current = { type: 'blockquote', content: [] };
+          target.push(current);
+        }
+        current.content ??= [];
+        target = current.content;
+      }
+
+      target.push(...quoteParagraphsForText(block.text));
+    }
+
+    return content;
+  }
+
   export type TipTapEditorApi = {
     /** Get the editor's plain text content */
     getText: () => string;
@@ -667,7 +715,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
      */
     replaceTextBeforeCursor: (charCount: number, replacement: string) => void;
     /** Insert selected reply text as a blockquote at the current cursor. */
-    insertQuote: (text: string) => void;
+    insertQuote: (text: QuoteInsertionContent) => void;
     /** Insert the same block break the editor would create for a plain Enter key. */
     insertBlockBreak: () => void;
   };
@@ -984,22 +1032,18 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
         tick().then(syncControls);
       },
 
-      insertQuote: (text: string) => {
+      insertQuote: (text: QuoteInsertionContent) => {
         if (e.isDestroyed) return;
-        const normalized = text.replace(/\r\n?/g, '\n').trim();
-        if (!normalized) return;
-
-        const quoteParagraphs: JSONContent[] = normalized.split('\n').map((line) => ({
-          type: 'paragraph',
-          content: line ? [{ type: 'text', text: line }] : undefined
-        }));
+        const quoteBlocks = normalizeQuoteInsertionContent(text);
+        if (quoteBlocks.length === 0) return;
+        const quoteContent = buildQuoteContent(quoteBlocks);
 
         e.chain()
           .focus()
           .insertContent([
             {
               type: 'blockquote',
-              content: quoteParagraphs
+              content: quoteContent
             },
             { type: 'paragraph' }
           ])

--- a/frontend/src/lib/state/room/composerContext.svelte.ts
+++ b/frontend/src/lib/state/room/composerContext.svelte.ts
@@ -56,20 +56,32 @@ export class ReplyState {
 
 export type QuoteInsertionRequest = {
   id: number;
+  text: QuoteInsertionContent;
+};
+
+export type SelectedQuoteBlock = {
+  quoteDepth: number;
   text: string;
 };
+
+export type QuoteInsertionContent = string | SelectedQuoteBlock[];
 
 export class QuoteInsertionState {
   request = $state<QuoteInsertionRequest | null>(null);
   private nextRequestId = 1;
 
-  requestInsertQuote(text: string) {
-    const trimmed = text.trim();
-    if (!trimmed) return;
+  requestInsertQuote(text: QuoteInsertionContent) {
+    const quoteText =
+      typeof text === 'string'
+        ? text.trim()
+        : text
+            .map((block) => ({ ...block, text: block.text.trim() }))
+            .filter((block) => block.text.length > 0);
+    if (typeof quoteText === 'string' ? !quoteText : quoteText.length === 0) return;
 
     this.request = {
       id: this.nextRequestId++,
-      text: trimmed
+      text: quoteText
     };
   }
 }

--- a/frontend/src/lib/state/room/index.ts
+++ b/frontend/src/lib/state/room/index.ts
@@ -13,6 +13,8 @@ export type {
   ComposerContextOptions,
   EditableMessage,
   FindLastEditableMessage,
+  QuoteInsertionContent,
+  SelectedQuoteBlock,
   QuoteInsertionRequest
 } from './composerContext.svelte';
 export {

--- a/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -3,7 +3,12 @@
   import { fade } from 'svelte/transition';
   import { Virtualizer, type VirtualizerHandle } from 'virtua/svelte';
   import type { RoomEventViewFragment } from '$lib/gql/graphql';
-  import type { MessagesStore, RefreshCurrentWindowResult, RoomMember } from '$lib/state/room';
+  import type {
+    MessagesStore,
+    QuoteInsertionContent,
+    RefreshCurrentWindowResult,
+    RoomMember
+  } from '$lib/state/room';
   import { getComposerContext, getRoomPermissions } from '$lib/state/room';
   import RoomEvent from './RoomEvent.svelte';
   import SystemEventGroup from './SystemEventGroup.svelte';
@@ -83,7 +88,7 @@
     onOpenThread?: (
       threadRootEventId: string,
       highlightEventId?: string,
-      quoteText?: string
+      quoteText?: QuoteInsertionContent
     ) => void;
     // Filtering
     filterThreadReplies?: boolean;
@@ -454,7 +459,10 @@
   function captureRefreshAnchor(): RefreshAnchor | null {
     if (!scrollContainer || !virtualizerHandle || virtualItems.length === 0) return null;
 
-    const startIdx = Math.max(0, virtualizerHandle.findItemIndex(virtualizerHandle.getScrollOffset()));
+    const startIdx = Math.max(
+      0,
+      virtualizerHandle.findItemIndex(virtualizerHandle.getScrollOffset())
+    );
     for (let i = startIdx; i < virtualItems.length; i++) {
       const eventId = eventIdForVirtualItem(virtualItems[i]);
       if (!eventId) continue;
@@ -479,7 +487,8 @@
 
     const bottomDistance = distanceFromBottom();
     const wasAtBottom =
-      alwaysScrollToBottom || (bottomDistance === null ? shouldScrollToBottom : bottomDistance < 50);
+      alwaysScrollToBottom ||
+      (bottomDistance === null ? shouldScrollToBottom : bottomDistance < 50);
     const anchor = wasAtBottom ? null : captureRefreshAnchor();
 
     softRefreshInFlight = true;
@@ -717,14 +726,20 @@
     if (eventData.__typename === 'MessagePostedEvent') {
       // Echoes open the original thread
       if (eventData.echoOfEventId != null) {
-        return (_threadRootEventId: string, highlightEventId?: string, quoteText?: string) =>
-          onOpenThread(eventData.echoFromThreadRootEventId!, highlightEventId, quoteText);
+        return (
+          _threadRootEventId: string,
+          highlightEventId?: string,
+          quoteText?: QuoteInsertionContent
+        ) => onOpenThread(eventData.echoFromThreadRootEventId!, highlightEventId, quoteText);
       }
       // Thread replies don't open threads from the main channel
       if (eventData.threadRootEventId !== null) return undefined;
       // Root messages open their own thread
-      return (_threadRootEventId?: string, _highlightEventId?: string, quoteText?: string) =>
-        onOpenThread(event.id, undefined, quoteText);
+      return (
+        _threadRootEventId?: string,
+        _highlightEventId?: string,
+        quoteText?: QuoteInsertionContent
+      ) => onOpenThread(event.id, undefined, quoteText);
     }
 
     return undefined;

--- a/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -18,6 +18,7 @@
     getMentionRoles,
     getComposerContext,
     type MessagesStore,
+    type QuoteInsertionContent,
     type RoomMember
   } from '$lib/state/room';
   import { useConnection } from '$lib/state/server/connection.svelte';
@@ -71,7 +72,7 @@
     onOpenThread?: (
       threadRootEventId: string,
       highlightEventId?: string,
-      quoteText?: string
+      quoteText?: QuoteInsertionContent
     ) => void;
   } = $props();
 
@@ -126,7 +127,7 @@
     centerX?: boolean;
   } | null>(null);
   let messageBodySelectionRoot = $state<HTMLElement>();
-  let selectedReplyQuoteSnapshot = $state<string | null>(null);
+  let selectedReplyQuoteSnapshot = $state<QuoteInsertionContent | null>(null);
 
   // Emoji picker state (position doubles as visibility flag; on mobile ContextMenu ignores it)
   let emojiPickerPos = $state<{ x: number; y: number } | null>(null);
@@ -540,14 +541,14 @@
     }
   }
 
-  function getSelectedReplyQuote(): string | null {
+  function getSelectedReplyQuote(): QuoteInsertionContent | null {
     return selectedQuoteTextForMessageBody(
       typeof window === 'undefined' ? null : window.getSelection(),
       messageBodySelectionRoot
     );
   }
 
-  function takeSelectedReplyQuote(): string | null {
+  function takeSelectedReplyQuote(): QuoteInsertionContent | null {
     const quote = selectedReplyQuoteSnapshot ?? getSelectedReplyQuote();
     selectedReplyQuoteSnapshot = null;
     return quote;

--- a/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -26,7 +26,8 @@
     RoomMembersStore,
     setRoomMembersStore,
     createRoomPermissions,
-    DEFAULT_ROOM_PERMISSIONS
+    DEFAULT_ROOM_PERMISSIONS,
+    type QuoteInsertionContent
   } from '$lib/state/room';
   import { useConnection } from '$lib/state/server/connection.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
@@ -62,10 +63,14 @@
 
   // Thread navigation functions (URL-driven state)
   let pendingThreadHighlight = $state<string | null>(null);
-  let pendingThreadQuote = $state<{ id: number; text: string } | null>(null);
+  let pendingThreadQuote = $state<{ id: number; text: QuoteInsertionContent } | null>(null);
   let pendingThreadQuoteId = 0;
 
-  function openThread(threadRootEventId: string, highlightEventId?: string, quoteText?: string) {
+  function openThread(
+    threadRootEventId: string,
+    highlightEventId?: string,
+    quoteText?: QuoteInsertionContent
+  ) {
     pendingThreadHighlight = highlightEventId ?? null;
     pendingThreadQuote = quoteText ? { id: ++pendingThreadQuoteId, text: quoteText } : null;
     goto(
@@ -87,10 +92,7 @@
   const replyState = composerContext.replyState;
   const jumpState = composerContext.jumpState;
   const currentUser = $derived(serverRegistry.getStore(getActiveServer()).currentUser);
-  const roomMessageStore = new MessagesStore(
-    connection(),
-    () => currentUser.user?.id ?? null
-  );
+  const roomMessageStore = new MessagesStore(connection(), () => currentUser.user?.id ?? null);
 
   onDestroy(() => roomMessageStore.dispose());
 
@@ -154,9 +156,7 @@
 
   // Room permissions — derived reactively, no $effect needed
   let permissions = $derived(room.roomData ?? DEFAULT_ROOM_PERMISSIONS);
-  let composerCanAttach = $derived(
-    room.roomData === undefined ? true : permissions.canAttach
-  );
+  let composerCanAttach = $derived(room.roomData === undefined ? true : permissions.canAttach);
 
   createRoomPermissions(() => permissions);
 

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomEvent.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomEvent.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { graphql } from '$lib/gql';
   import type { RoomEventViewFragment } from '$lib/gql/graphql';
-  import type { MessagesStore } from '$lib/state/room';
+  import type { MessagesStore, QuoteInsertionContent } from '$lib/state/room';
   import MessageEvent from './MessageEvent.svelte';
   import SystemEvent from './SystemEvent.svelte';
 
@@ -158,7 +158,7 @@
     onOpenThread?: (
       threadRootEventId: string,
       highlightEventId?: string,
-      quoteText?: string
+      quoteText?: QuoteInsertionContent
     ) => void;
   } = $props();
 

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomEventsPane.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomEventsPane.svelte
@@ -2,6 +2,7 @@
   import { useEvent } from '$lib/hooks';
   import {
     getComposerContext,
+    type QuoteInsertionContent,
     type RefreshCurrentWindowResult,
     type RoomMember
   } from '$lib/state/room';
@@ -24,7 +25,7 @@
     onOpenThread?: (
       threadRootEventId: string,
       highlightEventId?: string,
-      quoteText?: string
+      quoteText?: QuoteInsertionContent
     ) => void;
     typingUserIds?: string[];
     typingMembers?: RoomMember[];

--- a/frontend/src/routes/chat/[serverId]/[roomId]/selectedReplyQuote.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/selectedReplyQuote.svelte.spec.ts
@@ -25,13 +25,44 @@ describe('selected reply quotes', () => {
 
   it('returns selected text when both endpoints are inside the message body', () => {
     const body = document.createElement('div');
-    body.append('quoted text');
+    body.innerHTML = '<p>quoted text</p>';
     document.body.append(body);
-    const textNode = body.firstChild!;
+    const textNode = body.querySelector('p')!.firstChild!;
 
     const selection = selectText(textNode, 0, textNode, 'quoted'.length);
 
-    expect(selectedQuoteTextForMessageBody(selection, body)).toBe('quoted');
+    expect(selectedQuoteTextForMessageBody(selection, body)).toEqual([
+      { quoteDepth: 0, text: 'quoted' }
+    ]);
+  });
+
+  it('returns quote depth for selected text inside a blockquote', () => {
+    const body = document.createElement('div');
+    body.innerHTML = '<blockquote><p>quoted text</p></blockquote>';
+    document.body.append(body);
+    const textNode = body.querySelector('p')!.firstChild!;
+
+    const selection = selectText(textNode, 0, textNode, 'quoted'.length);
+
+    expect(selectedQuoteTextForMessageBody(selection, body)).toEqual([
+      { quoteDepth: 1, text: 'quoted' }
+    ]);
+  });
+
+  it('preserves mixed normal and quoted selected text as separate quote blocks', () => {
+    const body = document.createElement('div');
+    body.innerHTML = '<p>a</p><blockquote><p>nice, love it</p></blockquote><p>:D</p>';
+    document.body.append(body);
+    const firstTextNode = body.querySelector('p')!.firstChild!;
+    const lastTextNode = body.children[2].firstChild!;
+
+    const selection = selectText(firstTextNode, 0, lastTextNode, ':D'.length);
+
+    expect(selectedQuoteTextForMessageBody(selection, body)).toEqual([
+      { quoteDepth: 0, text: 'a' },
+      { quoteDepth: 1, text: 'nice, love it' },
+      { quoteDepth: 0, text: ':D' }
+    ]);
   });
 
   it('ignores selections that leave the message body', () => {

--- a/frontend/src/routes/chat/[serverId]/[roomId]/selectedReplyQuote.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/selectedReplyQuote.ts
@@ -1,3 +1,5 @@
+import type { QuoteInsertionContent, SelectedQuoteBlock } from '$lib/state/room';
+
 export function normalizeSelectedQuoteText(text: string): string | null {
   const normalized = text.replace(/\r\n?/g, '\n').trim();
   return normalized ? normalized : null;
@@ -8,10 +10,78 @@ function nodeIsInside(root: HTMLElement, node: Node | null): boolean {
   return root === node || root.contains(node);
 }
 
+function countBlockquoteAncestors(root: HTMLElement, node: Node): number {
+  let depth = 0;
+  let current: Node | null = node.parentNode;
+
+  while (current && current !== root) {
+    if (current instanceof HTMLElement && current.tagName === 'BLOCKQUOTE') {
+      depth++;
+    }
+    current = current.parentNode;
+  }
+
+  return depth;
+}
+
+function selectedTextForBlock(range: Range, block: HTMLElement): string | null {
+  let text = '';
+  const walker = document.createTreeWalker(block, NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT, {
+    acceptNode(node) {
+      if (node instanceof HTMLElement && node.tagName !== 'BR') {
+        return NodeFilter.FILTER_SKIP;
+      }
+      return range.intersectsNode(node) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
+    }
+  });
+
+  while (walker.nextNode()) {
+    const node = walker.currentNode;
+    if (node instanceof Text) {
+      const start = range.startContainer === node ? range.startOffset : 0;
+      const end = range.endContainer === node ? range.endOffset : node.data.length;
+      if (start < end) text += node.data.slice(start, end);
+    } else if (node instanceof HTMLElement && node.tagName === 'BR') {
+      text += '\n';
+    }
+  }
+
+  return normalizeSelectedQuoteText(text);
+}
+
+function selectedQuoteBlocksForRange(
+  range: Range,
+  messageBodyRoot: HTMLElement
+): SelectedQuoteBlock[] {
+  const blocks: SelectedQuoteBlock[] = [];
+  const blockSelector = 'p, li, pre, h1, h2, h3, h4, h5, h6';
+  const walker = document.createTreeWalker(messageBodyRoot, NodeFilter.SHOW_ELEMENT, {
+    acceptNode(node) {
+      if (!(node instanceof HTMLElement) || !node.matches(blockSelector)) {
+        return NodeFilter.FILTER_SKIP;
+      }
+      return range.intersectsNode(node) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
+    }
+  });
+
+  while (walker.nextNode()) {
+    const block = walker.currentNode as HTMLElement;
+    const text = selectedTextForBlock(range, block);
+    if (text) {
+      blocks.push({
+        quoteDepth: countBlockquoteAncestors(messageBodyRoot, block),
+        text
+      });
+    }
+  }
+
+  return blocks;
+}
+
 export function selectedQuoteTextForMessageBody(
   selection: Selection | null,
   messageBodyRoot: HTMLElement | null | undefined
-): string | null {
+): QuoteInsertionContent | null {
   if (!selection || selection.isCollapsed || selection.rangeCount === 0 || !messageBodyRoot) {
     return null;
   }
@@ -23,5 +93,7 @@ export function selectedQuoteTextForMessageBody(
     return null;
   }
 
-  return normalizeSelectedQuoteText(selection.toString());
+  const range = selection.getRangeAt(0);
+  const blocks = selectedQuoteBlocksForRange(range, messageBodyRoot);
+  return blocks.length > 0 ? blocks : normalizeSelectedQuoteText(selection.toString());
 }


### PR DESCRIPTION
- Preserve nested blockquote depth when selected quoted message text is inserted into a reply composer.
- Carry structured selected-quote data through room and thread reply paths while keeping plain-string quote insertion compatible.
- Add focused coverage for DOM quote extraction and nested blockquote composer submission.

Tests: `pnpm exec vitest run src/routes/chat/'[serverId]'/'[roomId]'/selectedReplyQuote.svelte.spec.ts src/lib/components/composer/MessageComposer.svelte.spec.ts`, `pnpm run check`, `pnpm run lint`.
