### PR TITLE
feat(frontend): refresh call sidebar UI

### DIFF
--- a/cli/chatto.toml
+++ b/cli/chatto.toml
@@ -54,12 +54,13 @@ vapid_subject = 'mailto:dev@chatto.run'
 [video]
 enabled = true
 
-# LiveKit voice calls. Provided by the always-on chatto-tools stack on OrbStack.
+# LiveKit voice calls. For local development, run:
+# LIVEKIT_KEYS='devkey: devsecret' livekit-server --dev --bind 0.0.0.0
 [livekit]
 enabled = true
-url = 'ws://livekit.chatto-tools.orb.local:7880'
+url = 'ws://localhost:7880'
 api_key = 'devkey'
-api_secret = 'secret'
+api_secret = 'devsecret'
 
 [nats.embedded]
 enabled = true

--- a/docs/fdr/FDR-016-voice-calls.md
+++ b/docs/fdr/FDR-016-voice-calls.md
@@ -5,14 +5,14 @@
 
 ## Overview
 
-Rooms support real-time voice conversations with optional camera video. A phone tab in the room sidebar lets members start or join the room call; the call panel shows participant cards, separates video participants from voice-only participants after joining, and provides mute, camera, device-selection, and hang-up controls. Audio and video are routed through LiveKit (an external WebRTC service); Chatto only handles authorization, participant state, and the UI.
+Rooms support real-time voice conversations with optional camera video. A phone tab in the room sidebar lets members start or join the room call; the call panel shows participant cards with video-enabled participants first, and provides mute, camera, device-selection, and hang-up controls. Audio and video are routed through LiveKit (an external WebRTC service); Chatto only handles authorization, participant state, and the UI.
 
 ## Behavior
 
 - Members of a room with the right permission see a phone tab alongside the room sidebar's members/files tabs when LiveKit is configured.
 - Opening the call tab shows the current room call. If no call is active, it offers a "Start call" action. If a call is active and the viewer has not joined, it shows projected participants as ungrouped participant cards and a "Join call" action.
 - When the current room has an active call, the phone tab is accent-highlighted and pulses while another sidebar tab is selected.
-- Joining the call switches the call tab into participant mode with compact voice-only participant cards and larger video participant cards. Participant mode groups cards under Video and Voice headings when those groups are non-empty, and exposes speaking indicators, mute state, camera toggle, device selector, and hang-up controls.
+- Joining the call switches the call tab into participant mode with larger video participant cards before compact voice-only participant cards, without separate Video or Voice section headings. Participant mode exposes speaking indicators, mute state, camera toggle, device selector, and hang-up controls.
 - While the viewer is in any call, the lower-left current-user card shows the active call room plus quick mute, camera, and leave controls so the call remains visible outside the room tab.
 - Other rooms with an active call replace the normal room/DM icon with the same accent phone icon and animated pulse twin used by the call tab so members know there's a conversation happening; clicking that icon opens the room with the call tab selected.
 - Message author names show a compact call presence icon when the author is in the current room's active call: phone for voice-only participants, video camera when the viewer has joined the LiveKit call and can see an active camera track.

--- a/docs/fdr/FDR-016-voice-calls.md
+++ b/docs/fdr/FDR-016-voice-calls.md
@@ -1,18 +1,18 @@
 # FDR-016: Voice Calls
 
 **Status:** Active
-**Last reviewed:** 2026-06-18
+**Last reviewed:** 2026-06-19
 
 ## Overview
 
-Rooms support real-time voice conversations with optional camera video. A phone tab in the room sidebar lets members start or join the room call; the call panel shows video participants separately from voice-only participants and provides mute, camera, device-selection, and hang-up controls. Audio and video are routed through LiveKit (an external WebRTC service); Chatto only handles authorization, participant state, and the UI.
+Rooms support real-time voice conversations with optional camera video. A phone tab in the room sidebar lets members start or join the room call; the call panel shows participant cards, separates video participants from voice-only participants after joining, and provides mute, camera, device-selection, and hang-up controls. Audio and video are routed through LiveKit (an external WebRTC service); Chatto only handles authorization, participant state, and the UI.
 
 ## Behavior
 
 - Members of a room with the right permission see a phone tab alongside the room sidebar's members/files tabs when LiveKit is configured.
-- Opening the call tab shows the current room call. If no call is active, it offers a "Start call" action. If a call is active and the viewer has not joined, it shows projected participants and a "Join call" action.
+- Opening the call tab shows the current room call. If no call is active, it offers a "Start call" action. If a call is active and the viewer has not joined, it shows projected participants as ungrouped participant cards and a "Join call" action.
 - When the current room has an active call, the phone tab is accent-highlighted and pulses while another sidebar tab is selected.
-- Joining the call switches the call tab into participant mode with each participant's avatar or camera preview (with a speaking-indicator ring), mute toggle, camera toggle, device selector, and hang-up button.
+- Joining the call switches the call tab into participant mode with compact voice-only participant cards and larger video participant cards. Participant mode groups cards under Video and Voice headings when those groups are non-empty, and exposes speaking indicators, mute state, camera toggle, device selector, and hang-up controls.
 - While the viewer is in any call, the lower-left current-user card shows the active call room plus quick mute, camera, and leave controls so the call remains visible outside the room tab.
 - Other rooms with an active call replace the normal room/DM icon with the same accent phone icon and animated pulse twin used by the call tab so members know there's a conversation happening; clicking that icon opens the room with the call tab selected.
 - Message author names show a compact call presence icon when the author is in the current room's active call: phone for voice-only participants, video camera when the viewer has joined the LiveKit call and can see an active camera track.

--- a/docs/fdr/FDR-016-voice-calls.md
+++ b/docs/fdr/FDR-016-voice-calls.md
@@ -1,17 +1,21 @@
 # FDR-016: Voice Calls
 
 **Status:** Active
-**Last reviewed:** 2026-06-15
+**Last reviewed:** 2026-06-18
 
 ## Overview
 
-Rooms support real-time voice conversations. A small phone icon in the room header lets members join the call; a panel shows participants with mute, device selection, and hang-up controls. Audio is routed through LiveKit (an external WebRTC service); Chatto only handles authorization, participant state, and the UI.
+Rooms support real-time voice conversations with optional camera video. A phone tab in the room sidebar lets members start or join the room call; the call panel shows video participants separately from voice-only participants and provides mute, camera, device-selection, and hang-up controls. Audio and video are routed through LiveKit (an external WebRTC service); Chatto only handles authorization, participant state, and the UI.
 
 ## Behavior
 
-- Members of a room with the right permission see a "Join call" button in the room header.
-- Joining the call opens a panel showing each participant's avatar (with a speaking-indicator ring), a mute toggle, an audio device selector, and a hang-up button.
-- Other rooms with an active call show a small headphone icon in the sidebar so members know there's a conversation happening.
+- Members of a room with the right permission see a phone tab alongside the room sidebar's members/files tabs when LiveKit is configured.
+- Opening the call tab shows the current room call. If no call is active, it offers a "Start call" action. If a call is active and the viewer has not joined, it shows projected participants and a "Join call" action.
+- When the current room has an active call, the phone tab is accent-highlighted and pulses while another sidebar tab is selected.
+- Joining the call switches the call tab into participant mode with each participant's avatar or camera preview (with a speaking-indicator ring), mute toggle, camera toggle, device selector, and hang-up button.
+- While the viewer is in any call, the lower-left current-user card shows the active call room plus quick mute, camera, and leave controls so the call remains visible outside the room tab.
+- Other rooms with an active call replace the normal room/DM icon with the same accent phone icon and animated pulse twin used by the call tab so members know there's a conversation happening; clicking that icon opens the room with the call tab selected.
+- Message author names show a compact call presence icon when the author is in the current room's active call: phone for voice-only participants, video camera when the viewer has joined the LiveKit call and can see an active camera track.
 - A member's join/leave updates active call indicators and participant lists, but individual participant transitions are not shown as room timeline messages. Explicit user intent is recorded immediately, and LiveKit webhooks/reconciliation confirm or correct the active participant projection.
 - The first join starts a call session and shows a room timeline notice that the member started a call. The final leave ends it and shows a room timeline notice that the active call ended.
 - Hanging up disconnects from LiveKit and clears the participant from everyone else's view.

--- a/frontend/e2e/voice-call.spec.ts
+++ b/frontend/e2e/voice-call.spec.ts
@@ -60,17 +60,26 @@ async function joinRoomViaAPI(page: Page, roomId: string) {
   });
 }
 
+async function openCallTab(page: Page) {
+  await page
+    .locator('[data-testid="room-sidebar-toggle"]:visible')
+    .getByLabel('Show call')
+    .click();
+}
+
 test.describe('Voice calls', () => {
-  test('call button appears in room header', async ({ page, chatPage }) => {
+  test('call tab appears in room sidebar toggle', async ({ page, chatPage }) => {
     await createAndLoginTestUser(page);
     await chatPage.goto();
     await chatPage.enterRoom('general');
 
-    const callButton = page.getByTitle('Join voice call');
-    await expect(callButton).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+    const callTab = page
+      .locator('[data-testid="room-sidebar-toggle"]:visible')
+      .getByLabel('Show call');
+    await expect(callTab).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
   });
 
-  test('call button appears in DM rooms', async ({ page, browser, serverURL }) => {
+  test('call tab appears in DM rooms', async ({ page, browser, serverURL }) => {
     // Create two users
     await createAndLoginTestUser(page);
 
@@ -79,9 +88,11 @@ test.describe('Voice calls', () => {
       const dmPage = new DMPage(page);
       await dmPage.startConversation(userB.login);
 
-      // Call button should be visible in the DM room header
-      const callButton = page.getByTitle('Join voice call');
-      await expect(callButton).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+      // Call tab should be visible in the DM room sidebar toggle
+      const callTab = page
+        .locator('[data-testid="room-sidebar-toggle"]:visible')
+        .getByLabel('Show call');
+      await expect(callTab).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
     });
   });
 
@@ -200,7 +211,7 @@ test.describe('Voice calls', () => {
     const roomId = await getRoomIdByName(page, 'general');
 
     // The call icon should NOT be visible initially
-    const callIcon = chatPage.roomList.locator('.uil--phone');
+    const callIcon = chatPage.roomList.getByTestId('room-call-icon');
     await expect(callIcon).not.toBeVisible();
 
     // User B joins the same server and room
@@ -219,7 +230,7 @@ test.describe('Voice calls', () => {
         }
       });
 
-      // User A should see the call icon appear
+      // User A should see the active-call icon appear
       await expect(callIcon).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
 
       // Simulate User B leaving the voice call
@@ -231,7 +242,7 @@ test.describe('Voice calls', () => {
         }
       });
 
-      // User A should see the call icon disappear
+      // User A should see the active-call icon disappear
       // (handleLeave re-queries activeCallRoomIds, which returns [] since KV is now empty)
       await expect(callIcon).not.toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
     });
@@ -323,7 +334,9 @@ test.describe('Voice calls', () => {
         }
       });
 
-      // User A should see the observer panel with "Call active" and a Join button
+      await openCallTab(page);
+
+      // User A should see the call sidebar observer state with a Join button
       const observerPanel = page.getByTestId('call-observer-panel');
       await expect(observerPanel).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
       await expect(page.getByTestId('call-join-button')).toBeVisible();
@@ -331,13 +344,15 @@ test.describe('Voice calls', () => {
       // User A should see User B's display name in the participant list
       await expect(observerPanel.getByTitle(userB.displayName)).toBeVisible();
 
-      // Simulate User B leaving — observer panel should disappear
+      // Simulate User B leaving — the open call tab falls back to its idle start-call state
       await page.request.post('/webhooks/test/call-leave', {
         data: { spaceId, roomId, userId: userB.id }
       });
 
-      await expect(observerPanel).not.toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-      await expect(page.getByTestId('call-join-button')).not.toBeVisible();
+      await expect(observerPanel.getByTitle(userB.displayName)).not.toBeVisible({
+        timeout: TIMEOUTS.REALTIME_EVENT
+      });
+      await expect(page.getByTestId('call-join-button')).toHaveText('Start call');
     });
   });
 
@@ -360,8 +375,6 @@ test.describe('Voice calls', () => {
       await withServerUser(browser!, serverURL, async ({ page: page3, user: userC }) => {
         await joinRoomViaAPI(page3, roomId);
 
-        const observerPanel = page.getByTestId('call-observer-panel');
-
         // User B joins the call
         await page.request.post('/webhooks/test/call-join', {
           data: {
@@ -372,6 +385,9 @@ test.describe('Voice calls', () => {
             login: userB.login
           }
         });
+
+        await openCallTab(page);
+        const observerPanel = page.getByTestId('call-observer-panel');
 
         await expect(observerPanel).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
         await expect(observerPanel.getByTitle(userB.displayName)).toBeVisible();
@@ -404,17 +420,20 @@ test.describe('Voice calls', () => {
         await expect(observerPanel.getByTitle(userC.displayName)).toBeVisible();
         await expect(observerPanel).toBeVisible();
 
-        // User C leaves — panel should disappear
+        // User C leaves — the open call tab falls back to its idle start-call state
         await page.request.post('/webhooks/test/call-leave', {
           data: { spaceId, roomId, userId: userC.id }
         });
 
-        await expect(observerPanel).not.toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+        await expect(observerPanel.getByTitle(userC.displayName)).not.toBeVisible({
+          timeout: TIMEOUTS.REALTIME_EVENT
+        });
+        await expect(page.getByTestId('call-join-button')).toHaveText('Start call');
       });
     });
   });
 
-  test('participant avatars appear in room list sidebar during active call', async ({
+  test('active-call icon appears in room list sidebar during active call', async ({
     page,
     chatPage,
     browser,
@@ -427,9 +446,10 @@ test.describe('Voice calls', () => {
     await chatPage.enterRoom('general');
     const roomId = await getRoomIdByName(page, 'general');
 
-    // No call badge in sidebar initially
+    // No active-call icon in sidebar initially
     const roomList = chatPage.roomList;
-    await expect(roomList.locator('.meta-badge')).not.toBeVisible();
+    const callIcon = roomList.getByTestId('room-call-icon');
+    await expect(callIcon).not.toBeVisible();
 
     await withServerUser(browser!, serverURL, async ({ page: page2, user: userB }) => {
       await joinRoomViaAPI(page2, roomId);
@@ -445,17 +465,17 @@ test.describe('Voice calls', () => {
         }
       });
 
-      // Call badge with phone icon should appear in sidebar
-      const callBadge = roomList.locator('.meta-badge');
-      await expect(callBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-      await expect(callBadge.locator('.uil--phone')).toBeVisible();
+      // Active-call icon with phone pulse twin should appear in sidebar
+      await expect(callIcon).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+      await expect(callIcon.locator('.uil--phone').first()).toBeVisible();
+      await expect(callIcon.getByTestId('active-call-pulse-icon')).toBeVisible();
 
-      // Simulate User B leaving — badge should disappear
+      // Simulate User B leaving — active-call icon should disappear
       await page.request.post('/webhooks/test/call-leave', {
         data: { spaceId, roomId, userId: userB.id }
       });
 
-      await expect(callBadge).not.toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+      await expect(callIcon).not.toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
     });
   });
 

--- a/frontend/src/lib/RoomList.svelte
+++ b/frontend/src/lib/RoomList.svelte
@@ -13,11 +13,15 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import CollapsibleGroup from '$lib/ui/CollapsibleGroup.svelte';
   import EmptyState from '$lib/ui/EmptyState.svelte';
-  import type { CallRoomParticipant } from '$lib/state/server/activeCallRooms.svelte';
   import { useEvent, useTabResumeCallback, useRoomMarkedAsRead } from '$lib/hooks';
+  import {
+    roomSidebarPanelStorageSuffix,
+    setPendingRoomSidebarPanel,
+    setRoomSidebarPanel
+  } from '$lib/storage/roomSidebarPanel';
   import { serverStorageKey } from '$lib/storage/serverStorage';
   import { useFragment } from './gql';
-  import { RoomType, type PresenceStatus } from '$lib/gql/graphql';
+  import { RoomType } from '$lib/gql/graphql';
   import UserAvatar, { UserAvatarFragment } from '$lib/components/UserAvatar.svelte';
   import NotificationBadge from '$lib/ui/NotificationBadge.svelte';
   import UnreadDot from '$lib/ui/UnreadDot.svelte';
@@ -35,8 +39,9 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   // server changes (URL [serverId] param changes), every derived read in the
   // template re-evaluates against the new server's state automatically.
 
-  const serverSegment = $derived(serverIdToSegment(getActiveServer()));
-  const stores = $derived(serverRegistry.getStore(getActiveServer()));
+  const activeServerId = $derived(getActiveServer());
+  const serverSegment = $derived(serverIdToSegment(activeServerId));
+  const stores = $derived(serverRegistry.getStore(activeServerId));
   const currentUserState = $derived(stores.currentUser);
   const notificationStore = $derived(stores.notifications);
   const notificationLevelStore = $derived(stores.notificationLevels);
@@ -215,32 +220,6 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     roomsStore.setUnread(event.roomId);
   });
 
-  function toAvatarUser(p: CallRoomParticipant) {
-    return {
-      id: p.userId,
-      login: p.login,
-      displayName: p.displayName,
-      avatarUrl: p.avatarUrl,
-      presenceStatus: 'ONLINE' as PresenceStatus
-    };
-  }
-
-  // Handle click on call participant badge — navigate to room and join the call
-  function handleCallBadgeClick(e: Event, roomId: string) {
-    e.preventDefault();
-    e.stopPropagation();
-
-    const livekitUrl = serverInfo.livekitUrl;
-    if (livekitUrl) {
-      voiceCallState.join(livekitUrl, roomId).catch(() => {
-        stores.handleVoiceCallJoinFailed(roomId);
-        // Silently catch — VoiceCallPanel provides fallback Join button
-      });
-    }
-
-    goto(resolve('/chat/[serverId]/[roomId]', { serverId: serverSegment, roomId }));
-  }
-
   function openJoinRoomModal(room: RoomsListItem) {
     pushState('', {
       modal: {
@@ -250,6 +229,46 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
         viewerCanJoinRoom: room.viewerCanJoinRoom
       }
     });
+  }
+
+  function wasCallIconClick(event: MouseEvent): boolean {
+    const target = event.target;
+    return target instanceof Element && target.closest('[data-testid="room-call-icon"]') !== null;
+  }
+
+  async function openRoomCallPanel(roomId: string): Promise<void> {
+    setRoomSidebarPanel(activeServerId, roomId, 'call');
+    setPendingRoomSidebarPanel(activeServerId, roomId, 'call');
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: serverStorageKey(activeServerId, roomSidebarPanelStorageSuffix(roomId)),
+        newValue: 'call'
+      })
+    );
+    await goto(resolve('/chat/[serverId]/[roomId]', { serverId: serverSegment, roomId }));
+  }
+
+  function handleRoomLinkClick(event: MouseEvent, room: RoomsListItem): void {
+    if (!room.viewerIsMember) {
+      event.preventDefault();
+      openJoinRoomModal(room);
+      return;
+    }
+
+    if (activeCallRooms.has(room.id) && wasCallIconClick(event)) {
+      event.preventDefault();
+      void openRoomCallPanel(room.id);
+    }
+  }
+
+  function handleRoomLinkKeydown(event: KeyboardEvent, room: RoomsListItem): void {
+    if (event.target !== event.currentTarget) return;
+    if (!room.viewerIsMember) return;
+    if (!activeCallRooms.has(room.id)) return;
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+
+    event.preventDefault();
+    void openRoomCallPanel(room.id);
   }
 
   async function handleNotificationBadgeClick(event: MouseEvent, roomId: string, isDM: boolean) {
@@ -283,46 +302,31 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   }
 </script>
 
-{#snippet callBadge(room: RoomsListItem, callParticipants: CallRoomParticipant[])}
-  <div
-    class="basis-full cursor-pointer pl-7"
-    role="button"
-    tabindex="0"
-    aria-label="Join active call"
-    data-testid="room-call-badge"
-    onclick={(e) => handleCallBadgeClick(e, room.id)}
-    onkeydown={(e) => {
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        handleCallBadgeClick(e, room.id);
-      }
-    }}
+{#snippet activeCallIcon()}
+  <span
+    class="sidebar-icon relative text-accent"
+    aria-label="Active call"
+    data-testid="room-call-icon"
   >
-    <div
-      class={[
-        'meta-badge gap-1.5 border-transparent px-1.5 py-0.5',
-        room.id === activeRoomId ? 'bg-surface-200' : ''
-      ]}
-    >
-      <span class="iconify animate-pulse text-sm text-accent uil--phone"></span>
-      {#if callParticipants.length > 0}
-        <div class="inline-flex -space-x-1.5">
-          {#each callParticipants as p (p.userId)}
-            <UserAvatar user={toAvatarUser(p)} size="xs" showPresence={false} />
-          {/each}
-        </div>
-      {/if}
-    </div>
-  </div>
+    <span class="relative inline-flex">
+      <span
+        class="pane-header-icon-glyph absolute inset-0 animate-ping opacity-45 uil--phone"
+        aria-hidden="true"
+        data-testid="active-call-pulse-icon"
+      ></span>
+      <span
+        class="pane-header-icon-glyph relative text-accent uil--phone"
+        aria-hidden="true"
+      ></span>
+    </span>
+  </span>
 {/snippet}
 
 {#snippet roomLink(room: RoomsListItem)}
   {@const hasActiveCall = activeCallRooms.has(room.id)}
-  {@const callParticipants = hasActiveCall ? activeCallRooms.getParticipants(room.id) : []}
   {@const isJoined = room.viewerIsMember}
   {@const rowClass = [
     'sidebar-item group/badges',
-    hasActiveCall ? 'flex-wrap gap-y-1' : '',
     room.id === activeRoomId ? 'bg-surface-100' : '',
     room.hasUnread && room.id !== activeRoomId && !notificationLevelStore.isRoomMuted(room.id)
       ? 'font-semibold'
@@ -333,14 +337,12 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     href={resolve('/chat/[serverId]/[roomId]', { serverId: serverSegment, roomId: room.id })}
     class={rowClass}
     aria-current={room.id === activeRoomId ? 'page' : undefined}
-    onclick={(e) => {
-      if (!isJoined) {
-        e.preventDefault();
-        openJoinRoomModal(room);
-      }
-    }}
+    onclick={(e) => handleRoomLinkClick(e, room)}
+    onkeydown={(e) => handleRoomLinkKeydown(e, room)}
   >
-    {#if isJoined}
+    {#if isJoined && hasActiveCall}
+      {@render activeCallIcon()}
+    {:else if isJoined}
       <span class="sidebar-icon text-muted">#</span>
     {:else if room.viewerCanJoinRoom}
       <span class="sidebar-icon text-muted">+</span>
@@ -366,32 +368,31 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
       <span class="sr-only">unread messages</span>
     {/if}
 
-    <!-- Call participant avatars (badge row, wraps below room name).
-         Clicking the badge navigates to the room AND joins the call. -->
-    {#if isJoined && hasActiveCall}
-      {@render callBadge(room, callParticipants)}
-    {/if}
   </a>
 {/snippet}
 
 {#snippet dmLink(room: RoomsListItem)}
   {@const hasActiveCall = activeCallRooms.has(room.id)}
-  {@const callParticipants = hasActiveCall ? activeCallRooms.getParticipants(room.id) : []}
   <a
     href={resolve('/chat/[serverId]/[roomId]', { serverId: serverSegment, roomId: room.id })}
     class={[
       'group/badges sidebar-item',
-      hasActiveCall ? 'flex-wrap gap-y-1' : '',
       room.id === activeRoomId ? 'bg-surface-100' : '',
       room.hasUnread && room.id !== activeRoomId ? 'font-semibold' : ''
     ]}
     aria-current={room.id === activeRoomId ? 'page' : undefined}
+    onclick={(e) => handleRoomLinkClick(e, room)}
+    onkeydown={(e) => handleRoomLinkKeydown(e, room)}
   >
-    <div class="flex shrink-0 -space-x-1">
-      {#each dmAvatarParticipants(room) as participant (participant.id)}
-        <UserAvatar user={participant} size="xs" />
-      {/each}
-    </div>
+    {#if hasActiveCall}
+      {@render activeCallIcon()}
+    {:else}
+      <div class="flex shrink-0 -space-x-1">
+        {#each dmAvatarParticipants(room) as participant (participant.id)}
+          <UserAvatar user={participant} size="xs" />
+        {/each}
+      </div>
+    {/if}
     <span class="flex-1 truncate">{dmDisplayName(room)}</span>
 
     {#if room.viewerNotificationCount > 0}
@@ -409,9 +410,6 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
       <span class="sr-only">unread messages</span>
     {/if}
 
-    {#if hasActiveCall}
-      {@render callBadge(room, callParticipants)}
-    {/if}
   </a>
 {/snippet}
 

--- a/frontend/src/lib/RoomList.svelte.spec.ts
+++ b/frontend/src/lib/RoomList.svelte.spec.ts
@@ -2,6 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { q } from '$lib/test-utils';
 import { RoomType } from '$lib/gql/graphql';
+import { serverStorageKey } from '$lib/storage/serverStorage';
+import {
+  consumePendingRoomSidebarPanel,
+  roomSidebarPanelStorageSuffix
+} from '$lib/storage/roomSidebarPanel';
 
 const { mocks } = vi.hoisted(() => ({
   mocks: {
@@ -226,6 +231,7 @@ function setRoomNotificationCount(roomId: string, count: number) {
 
 beforeEach(() => {
   localStorage.clear();
+  sessionStorage.clear();
   mocks.activeCallRoomIds = new Set();
   mocks.callParticipants = new Map();
   mocks.store.rooms.roomGroups = null;
@@ -247,7 +253,7 @@ beforeEach(() => {
 });
 
 describe('RoomList', () => {
-  it('renders active-call badges for DM rows', async () => {
+  it('replaces DM avatars with the active-call pulse icon twin', async () => {
     mocks.activeCallRoomIds.add('dm-with-participants');
     mocks.callParticipants.set('dm-with-participants', [
       {
@@ -262,26 +268,31 @@ describe('RoomList', () => {
 
     await expect.element(q(container, '[href="/chat/-/dm-with-participants"]')).toBeInTheDocument();
     const dmRow = q(container, '[href="/chat/-/dm-with-participants"]');
-    const badge = dmRow?.querySelector('[data-testid="room-call-badge"]');
-    expect(badge).not.toBeNull();
-    expect(badge?.querySelector('.uil--phone')).not.toBeNull();
-    expect(badge?.textContent).toContain('T');
+    const icon = dmRow?.querySelector('[data-testid="room-call-icon"]');
+    const pulseIcon = icon?.querySelector('[data-testid="active-call-pulse-icon"]');
+    expect(icon).not.toBeNull();
+    expect(icon?.classList.contains('text-accent')).toBe(true);
+    expect(icon?.querySelector('.uil--phone')).not.toBeNull();
+    expect(pulseIcon).not.toBeNull();
+    expect(pulseIcon?.classList.contains('animate-ping')).toBe(true);
+    expect(dmRow?.querySelector('[data-testid="room-call-badge"]')).toBeNull();
   });
 
-  it('renders a phone-only active-call badge when participants are not loaded', async () => {
+  it('renders the active-call phone icon when participants are not loaded', async () => {
     mocks.activeCallRoomIds.add('dm-phone-only');
 
     const { container } = render(RoomList);
 
     await expect.element(q(container, '[href="/chat/-/dm-phone-only"]')).toBeInTheDocument();
     const dmRow = q(container, '[href="/chat/-/dm-phone-only"]');
-    const badge = dmRow?.querySelector('[data-testid="room-call-badge"]');
-    expect(badge).not.toBeNull();
-    expect(badge?.querySelector('.uil--phone')).not.toBeNull();
-    expect(badge?.querySelector('.inline-flex')).toBeNull();
+    const icon = dmRow?.querySelector('[data-testid="room-call-icon"]');
+    expect(icon).not.toBeNull();
+    expect(icon?.querySelector('.uil--phone')).not.toBeNull();
+    expect(icon?.querySelector('[data-testid="active-call-pulse-icon"]')).not.toBeNull();
+    expect(dmRow?.querySelector('[data-testid="room-call-badge"]')).toBeNull();
   });
 
-  it('keeps channel active-call badges working', async () => {
+  it('replaces channel room icons with the active-call pulse icon twin', async () => {
     mocks.activeCallRoomIds.add('channel-1');
     mocks.callParticipants.set('channel-1', [
       {
@@ -296,8 +307,81 @@ describe('RoomList', () => {
 
     await expect.element(q(container, '[href="/chat/-/channel-1"]')).toBeInTheDocument();
     const channelRow = q(container, '[href="/chat/-/channel-1"]');
-    expect(channelRow?.querySelector('[data-testid="room-call-badge"]')).not.toBeNull();
-    expect(channelRow?.querySelector('.uil--phone')).not.toBeNull();
+    const icon = channelRow?.querySelector('[data-testid="room-call-icon"]');
+    const pulseIcon = icon?.querySelector('[data-testid="active-call-pulse-icon"]');
+    expect(icon).not.toBeNull();
+    expect(icon?.querySelector('.uil--phone')).not.toBeNull();
+    expect(pulseIcon).not.toBeNull();
+    expect(pulseIcon?.classList.contains('animate-ping')).toBe(true);
+    expect(channelRow?.querySelector('[data-testid="room-call-badge"]')).toBeNull();
+  });
+
+  it('opens the call panel when an active-call room icon is clicked', async () => {
+    mocks.activeCallRoomIds.add('channel-1');
+
+    const { container } = render(RoomList);
+
+    await expect.element(q(container, '[href="/chat/-/channel-1"]')).toBeInTheDocument();
+    const channelRow = q(container, '[href="/chat/-/channel-1"]');
+    const icon = channelRow?.querySelector('[data-testid="room-call-icon"]') as HTMLElement | null;
+    expect(icon).not.toBeNull();
+
+    icon!.click();
+
+    await vi.waitFor(() => {
+      expect(mocks.goto).toHaveBeenCalledWith('/chat/-/channel-1');
+    });
+    expect(
+      localStorage.getItem(serverStorageKey('origin', roomSidebarPanelStorageSuffix('channel-1')))
+    ).toBe('call');
+    expect(consumePendingRoomSidebarPanel('origin', 'channel-1')).toBe('call');
+  });
+
+  it('opens the call panel when an active-call DM icon is clicked', async () => {
+    mocks.activeCallRoomIds.add('dm-with-participants');
+
+    const { container } = render(RoomList);
+
+    await expect.element(q(container, '[href="/chat/-/dm-with-participants"]')).toBeInTheDocument();
+    const dmRow = q(container, '[href="/chat/-/dm-with-participants"]');
+    const icon = dmRow?.querySelector('[data-testid="room-call-icon"]') as HTMLElement | null;
+    expect(icon).not.toBeNull();
+
+    icon!.click();
+
+    await vi.waitFor(() => {
+      expect(mocks.goto).toHaveBeenCalledWith('/chat/-/dm-with-participants');
+    });
+    expect(
+      localStorage.getItem(
+        serverStorageKey('origin', roomSidebarPanelStorageSuffix('dm-with-participants'))
+      )
+    ).toBe('call');
+    expect(consumePendingRoomSidebarPanel('origin', 'dm-with-participants')).toBe('call');
+  });
+
+  it.each([
+    ['Enter', 'Enter'],
+    ['Space', ' ']
+  ])('opens the call panel on %s when an active-call row has keyboard focus', async (_label, key) => {
+    mocks.activeCallRoomIds.add('channel-1');
+
+    const { container } = render(RoomList);
+
+    await expect.element(q(container, '[href="/chat/-/channel-1"]')).toBeInTheDocument();
+    const channelRow = q(container, '[href="/chat/-/channel-1"]') as HTMLAnchorElement;
+
+    const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+    const wasNotCanceled = channelRow.dispatchEvent(event);
+
+    expect(wasNotCanceled).toBe(false);
+    await vi.waitFor(() => {
+      expect(mocks.goto).toHaveBeenCalledWith('/chat/-/channel-1');
+    });
+    expect(
+      localStorage.getItem(serverStorageKey('origin', roomSidebarPanelStorageSuffix('channel-1')))
+    ).toBe('call');
+    expect(consumePendingRoomSidebarPanel('origin', 'channel-1')).toBe('call');
   });
 
   it('opens a join modal for a faded joinable non-member channel row', async () => {

--- a/frontend/src/lib/components/CurrentUserBar.svelte
+++ b/frontend/src/lib/components/CurrentUserBar.svelte
@@ -7,17 +7,26 @@ to the user settings page for the active server.
 -->
 <script lang="ts">
   import { resolve } from '$app/paths';
+  import { goto } from '$app/navigation';
   import { serverIdToSegment } from '$lib/navigation';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { getLiveDisplayName } from '$lib/state/userProfiles.svelte';
+  import { RoomType } from '$lib/gql/graphql';
+  import {
+    roomSidebarPanelStorageSuffix,
+    setPendingRoomSidebarPanel,
+    setRoomSidebarPanel
+  } from '$lib/storage/roomSidebarPanel';
+  import { serverStorageKey } from '$lib/storage/serverStorage';
   import UserAvatar from './UserAvatar.svelte';
 
   const activeServerId = $derived(getActiveServer());
   const serverSegment = $derived(serverIdToSegment(activeServerId));
-  const activeServerUser = $derived(
-    serverRegistry.tryGetStore(activeServerId)?.currentUser.user
-  );
+  const activeStore = $derived(serverRegistry.tryGetStore(activeServerId));
+  const activeServerUser = $derived(activeStore?.currentUser.user);
+  const voiceCallState = $derived(activeStore?.voiceCall);
+  const roomsStore = $derived(activeStore?.rooms);
 
   const displayName = $derived(
     activeServerUser
@@ -31,14 +40,115 @@ to the user settings page for the active server.
   const login = $derived(activeServerUser?.login ?? '');
   const showLogin = $derived(!!login && login !== displayName);
 
-  const settingsHref = $derived(
-    resolve('/chat/[serverId]/settings', { serverId: serverSegment })
+  const activeCallRoomId = $derived(
+    voiceCallState?.connected && voiceCallState.roomId ? voiceCallState.roomId : null
   );
+  const activeCallRoom = $derived(
+    activeCallRoomId ? (roomsStore?.rooms.find((room) => room.id === activeCallRoomId) ?? null) : null
+  );
+  const activeCallRoomName = $derived.by(() => {
+    const room = activeCallRoom;
+    if (!room) return 'Current call';
+    if (room.type === RoomType.Dm) {
+      const meId = roomsStore?.currentUserId;
+      const others = room.members.filter((member) => member.id !== meId);
+      if (others.length === 0) return 'You';
+      return others
+        .map((member) => getLiveDisplayName(member.id, member.displayName || member.login))
+        .join(', ');
+    }
+    return `# ${room.name}`;
+  });
+  const compactCallButtonClass = 'btn-secondary h-7 w-7 shrink-0 !px-0 !py-0 text-xs';
+  const compactCallDangerButtonClass = 'btn-danger h-7 w-7 shrink-0 !px-0 !py-0 text-xs';
+
+  function openActiveCallRoom(): void {
+    const roomId = activeCallRoomId;
+    if (!roomId) return;
+
+    setRoomSidebarPanel(activeServerId, roomId, 'call');
+    setPendingRoomSidebarPanel(activeServerId, roomId, 'call');
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: serverStorageKey(activeServerId, roomSidebarPanelStorageSuffix(roomId)),
+        newValue: 'call'
+      })
+    );
+    goto(
+      resolve('/chat/[serverId]/[roomId]', {
+        serverId: serverSegment,
+        roomId
+      })
+    );
+  }
 </script>
 
 {#if activeServerUser}
-  <div class="shrink-0 p-2">
-    <div class="flex items-center gap-3 rounded-xl bg-surface py-1 pr-3 pl-1">
+  <div class="flex shrink-0 flex-col gap-1 p-2">
+    {#if activeCallRoomId && voiceCallState}
+      <div
+        class="flex min-w-0 items-center gap-1.5 rounded-xl bg-surface p-1"
+        data-testid="current-user-call-card"
+      >
+        <button
+          type="button"
+          class="btn-secondary h-7 min-w-0 flex-1 cursor-pointer !justify-start !px-2 !py-0 text-xs"
+          title={`Open ${activeCallRoomName}`}
+          data-testid="current-user-call-link"
+          onclick={openActiveCallRoom}
+        >
+          <span class="iconify uil--phone shrink-0 animate-pulse text-accent"></span>
+          <span class="truncate">{activeCallRoomName}</span>
+        </button>
+        <button
+          type="button"
+          class={voiceCallState.isMuted ? compactCallDangerButtonClass : compactCallButtonClass}
+          title={voiceCallState.isMuted ? 'Unmute' : 'Mute'}
+          aria-label={voiceCallState.isMuted ? 'Unmute' : 'Mute'}
+          data-testid="current-user-call-mute"
+          onclick={() => voiceCallState.toggleMute()}
+        >
+          <span
+            class={[
+              'iconify',
+              voiceCallState.isMuted ? 'uil--microphone-slash' : 'uil--microphone'
+            ]}
+            aria-hidden="true"
+          ></span>
+        </button>
+        <button
+          type="button"
+          class={voiceCallState.isCameraEnabled ? compactCallButtonClass : compactCallDangerButtonClass}
+          title={voiceCallState.isCameraEnabled ? 'Turn off camera' : 'Turn on camera'}
+          aria-label={voiceCallState.isCameraEnabled ? 'Turn off camera' : 'Turn on camera'}
+          data-testid="current-user-call-camera"
+          onclick={() => voiceCallState.toggleCamera()}
+        >
+          <span
+            class={[
+              'iconify',
+              voiceCallState.isCameraEnabled ? 'uil--video' : 'uil--video-slash'
+            ]}
+            aria-hidden="true"
+          ></span>
+        </button>
+        <button
+          type="button"
+          class={compactCallDangerButtonClass}
+          title="Leave call"
+          aria-label="Leave call"
+          data-testid="current-user-call-leave"
+          onclick={() => voiceCallState.leave()}
+        >
+          <span class="iconify uil--phone-slash" aria-hidden="true"></span>
+        </button>
+      </div>
+    {/if}
+
+    <div
+      class="flex items-center gap-3 rounded-xl bg-surface py-1 pr-3 pl-1"
+      data-testid="current-user-identity-card"
+    >
       <UserAvatar user={activeServerUser} size="md" />
       <div class="flex min-w-0 flex-1 flex-col leading-tight">
         <span class="truncate text-sm font-semibold">{displayName}</span>
@@ -47,7 +157,7 @@ to the user settings page for the active server.
         {/if}
       </div>
       <a
-        href={settingsHref}
+        href={resolve('/chat/[serverId]/settings', { serverId: serverSegment })}
         title="User Settings"
         class="iconify shrink-0 cursor-pointer text-muted uil--setting hover:text-text"
       ></a>

--- a/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
+++ b/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
@@ -2,29 +2,81 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { q } from '$lib/test-utils';
 import { PresenceStatus } from '$lib/gql/graphql';
+import {
+  consumePendingRoomSidebarPanel,
+  getRoomSidebarPanelState,
+  roomSidebarPanelStorageSuffix
+} from '$lib/storage/roomSidebarPanel';
+import { serverStorageKey } from '$lib/storage/serverStorage';
 import CurrentUserBarTestHarness from './CurrentUserBarTestHarness.svelte';
 
-const currentUserState = vi.hoisted(() => ({
-  user: null as {
-    id: string;
-    login: string;
-    displayName: string;
-    avatarUrl: string | null;
-    presenceStatus: PresenceStatus;
-    hasVerifiedEmail: boolean;
-    settings: null;
-  } | null
+type MockRoomMember = {
+  id: string;
+  login: string;
+  displayName: string;
+  avatarUrl: string | null;
+  presenceStatus: PresenceStatus;
+};
+
+type MockRoom = {
+  id: string;
+  name: string;
+  type: 'CHANNEL' | 'DM';
+  members: MockRoomMember[];
+};
+
+const { currentUserState, voiceCallState, roomsState } = vi.hoisted(() => ({
+  currentUserState: {
+    user: null as {
+      id: string;
+      login: string;
+      displayName: string;
+      avatarUrl: string | null;
+      presenceStatus: PresenceStatus;
+      hasVerifiedEmail: boolean;
+      settings: null;
+    } | null
+  },
+  voiceCallState: {
+    connected: false,
+    roomId: null as string | null,
+    isMuted: false,
+    isCameraEnabled: false,
+    toggleMute: vi.fn(),
+    toggleCamera: vi.fn(),
+    leave: vi.fn()
+  },
+  roomsState: {
+    currentUserId: 'user-1',
+    rooms: [
+      {
+        id: 'room-1',
+        name: 'general',
+        type: 'CHANNEL',
+        members: []
+      }
+    ] as MockRoom[]
+  }
+}));
+const navigation = vi.hoisted(() => ({
+  goto: vi.fn()
 }));
 
 vi.mock('$lib/state/activeServer.svelte', () => ({
   getActiveServer: () => 'origin'
 }));
 
+vi.mock('$app/navigation', () => ({
+  goto: navigation.goto
+}));
+
 vi.mock('$lib/state/server/registry.svelte', () => ({
   serverRegistry: {
     isOriginServer: () => true,
     tryGetStore: () => ({
-      currentUser: currentUserState
+      currentUser: currentUserState,
+      voiceCall: voiceCallState,
+      rooms: roomsState
     })
   }
 }));
@@ -36,6 +88,8 @@ vi.mock('$lib/state/userProfiles.svelte', () => ({
 
 describe('CurrentUserBar', () => {
   beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
     currentUserState.user = {
       id: 'user-1',
       login: 'alice',
@@ -45,6 +99,23 @@ describe('CurrentUserBar', () => {
       hasVerifiedEmail: true,
       settings: null
     };
+    voiceCallState.connected = false;
+    voiceCallState.roomId = null;
+    voiceCallState.isMuted = false;
+    voiceCallState.isCameraEnabled = false;
+    voiceCallState.toggleMute.mockClear();
+    voiceCallState.toggleCamera.mockClear();
+    voiceCallState.leave.mockClear();
+    navigation.goto.mockClear();
+    roomsState.currentUserId = 'user-1';
+    roomsState.rooms = [
+      {
+        id: 'room-1',
+        name: 'general',
+        type: 'CHANNEL',
+        members: []
+      }
+    ];
   });
 
   it('uses the seeded presence cache instead of the first-login offline fallback', () => {
@@ -54,5 +125,79 @@ describe('CurrentUserBar', () => {
     expect(q(container, '[aria-label="Offline"]')).toBeFalsy();
     expect(container.textContent).toContain('Alice');
     expect(container.textContent).toContain('@alice');
+  });
+
+  it('hides call controls when the user is not in a call', () => {
+    const { container } = render(CurrentUserBarTestHarness);
+
+    expect(container.querySelector('[data-testid="current-user-call-link"]')).toBeFalsy();
+    expect(container.querySelector('[data-testid="current-user-call-mute"]')).toBeFalsy();
+  });
+
+  it('shows active call controls and links to the call room', async () => {
+    voiceCallState.connected = true;
+    voiceCallState.roomId = 'room-1';
+    const storageEvents: StorageEvent[] = [];
+    const listener = (event: StorageEvent) => storageEvents.push(event);
+    window.addEventListener('storage', listener);
+
+    const { container } = render(CurrentUserBarTestHarness);
+
+    expect(q(container, '[data-testid="current-user-call-card"]')).toBeTruthy();
+    expect(q(container, '[data-testid="current-user-identity-card"]')).toBeTruthy();
+    const link = q(container, '[data-testid="current-user-call-link"]') as HTMLButtonElement;
+    expect(link.textContent).toContain('# general');
+    link.click();
+
+    (q(container, '[data-testid="current-user-call-mute"]') as HTMLButtonElement).click();
+    (q(container, '[data-testid="current-user-call-camera"]') as HTMLButtonElement).click();
+    (q(container, '[data-testid="current-user-call-leave"]') as HTMLButtonElement).click();
+
+    expect(navigation.goto).toHaveBeenCalledWith('/chat/-/room-1');
+    expect(getRoomSidebarPanelState('origin', 'room-1')).toBe('call');
+    expect(consumePendingRoomSidebarPanel('origin', 'room-1')).toBe('call');
+    expect(storageEvents).toHaveLength(1);
+    expect(storageEvents[0].key).toBe(
+      serverStorageKey('origin', roomSidebarPanelStorageSuffix('room-1'))
+    );
+    expect(storageEvents[0].newValue).toBe('call');
+    expect(voiceCallState.toggleMute).toHaveBeenCalledOnce();
+    expect(voiceCallState.toggleCamera).toHaveBeenCalledOnce();
+    expect(voiceCallState.leave).toHaveBeenCalledOnce();
+    window.removeEventListener('storage', listener);
+  });
+
+  it('uses the DM participant label for active direct-message calls', () => {
+    voiceCallState.connected = true;
+    voiceCallState.roomId = 'dm-1';
+    roomsState.rooms = [
+      {
+        id: 'dm-1',
+        name: 'dm-1',
+        type: 'DM',
+        members: [
+          {
+            id: 'user-1',
+            login: 'alice',
+            displayName: 'Alice',
+            avatarUrl: null,
+            presenceStatus: PresenceStatus.Online
+          },
+          {
+            id: 'user-2',
+            login: 'bob',
+            displayName: 'Bob',
+            avatarUrl: null,
+            presenceStatus: PresenceStatus.Online
+          }
+        ]
+      }
+    ];
+
+    const { container } = render(CurrentUserBarTestHarness);
+
+    const callLink = q(container, '[data-testid="current-user-call-link"]');
+    expect(callLink).toBeTruthy();
+    expect(callLink!.textContent ?? '').toContain('Bob');
   });
 });

--- a/frontend/src/lib/components/voice/VideoThumbnail.svelte
+++ b/frontend/src/lib/components/voice/VideoThumbnail.svelte
@@ -9,7 +9,7 @@ when the track reference actually changes, not on every parent re-render.
 This prevents flicker from the 60ms audio level polling in VoiceCallPanel.
 
 The explicit width/height attributes tell LiveKit's `adaptiveStream` what
-resolution to request (h180 simulcast layer for 120px thumbnails).
+resolution to request for sidebar-width tiles.
 
 **Props:**
 - `track` - The LiveKit video Track to display
@@ -73,35 +73,20 @@ resolution to request (h180 simulcast layer for 120px thumbnails).
 	});
 </script>
 
-<div class="video-thumbnail">
+<div class="relative block aspect-video w-full overflow-hidden rounded-md bg-surface-200">
 	<video
 		bind:this={videoEl}
-		width="120"
-		height="68"
-		class="rounded object-cover"
+		width="640"
+		height="360"
+		class="h-full w-full object-cover"
 		title={name}
 		autoplay
 		playsinline
 		muted
 	></video>
-	<div class="avatar-badge">
+	<div
+		class="absolute top-2 left-2 h-6 w-6 rounded-full shadow-[0_0_0_1.5px_var(--color-surface-100)]"
+	>
 		<UserAvatar {user} size="xs" showPresence={false} />
 	</div>
 </div>
-
-<style>
-	.video-thumbnail {
-		position: relative;
-		display: inline-flex;
-	}
-
-	.avatar-badge {
-		position: absolute;
-		top: 2px;
-		left: 2px;
-		width: 1.25rem;
-		height: 1.25rem;
-		border-radius: 9999px;
-		box-shadow: 0 0 0 1.5px var(--color-surface-100);
-	}
-</style>

--- a/frontend/src/lib/components/voice/VideoThumbnail.svelte
+++ b/frontend/src/lib/components/voice/VideoThumbnail.svelte
@@ -1,8 +1,9 @@
 <!--
 @component
 
-Renders a LiveKit video track in a thumbnail-sized `<video>` element with
-a small avatar overlay in the top-left corner for identification.
+Renders a LiveKit video track in a thumbnail-sized `<video>` element.
+It can optionally include a small avatar overlay in the top-left corner for
+identification.
 
 Manages the attach/detach lifecycle imperatively — only detaches/reattaches
 when the track reference actually changes, not on every parent re-render.
@@ -15,6 +16,7 @@ resolution to request for sidebar-width tiles.
 - `track` - The LiveKit video Track to display
 - `name` - Participant display name (shown as tooltip)
 - `user` - User object for the avatar overlay (same shape as UserAvatar's `user` prop)
+- `showIdentityOverlay` - Whether to show the avatar overlay
 -->
 <script lang="ts">
 	import { onDestroy } from 'svelte';
@@ -25,7 +27,8 @@ resolution to request for sidebar-width tiles.
 	let {
 		track,
 		name,
-		user
+		user,
+		showIdentityOverlay = true
 	}: {
 		track: Track;
 		name: string;
@@ -36,6 +39,7 @@ resolution to request for sidebar-width tiles.
 			avatarUrl: string | null;
 			presenceStatus: PresenceStatus;
 		};
+		showIdentityOverlay?: boolean;
 	} = $props();
 
 	let videoEl = $state<HTMLVideoElement | null>(null);
@@ -84,9 +88,11 @@ resolution to request for sidebar-width tiles.
 		playsinline
 		muted
 	></video>
-	<div
-		class="absolute top-2 left-2 h-6 w-6 rounded-full shadow-[0_0_0_1.5px_var(--color-surface-100)]"
-	>
-		<UserAvatar {user} size="xs" showPresence={false} />
-	</div>
+	{#if showIdentityOverlay}
+		<div
+			class="absolute top-2 left-2 h-6 w-6 rounded-full shadow-[0_0_0_1.5px_var(--color-surface-100)]"
+		>
+			<UserAvatar {user} size="xs" showPresence={false} />
+		</div>
+	{/if}
 </div>

--- a/frontend/src/lib/components/voice/VoiceCallPanel.svelte
+++ b/frontend/src/lib/components/voice/VoiceCallPanel.svelte
@@ -1,16 +1,13 @@
 <!--
 @component
 
-Compact bar shown below the room header when there is an active voice call.
+Room sidebar panel for voice/video calls.
 
 **Two modes:**
 - **Observer mode**: Call is active but user hasn't joined. Shows participants
   from server state and a Join button.
 - **Participant mode**: User is connected to LiveKit. Shows live audio levels,
   mute toggle, audio device selector, and hang-up button.
-
-Both modes share the same layout — only the participant data source and action
-buttons differ. This prevents layout shift when joining/leaving a call.
 
 **Props:**
 - `roomId` - The room ID
@@ -49,8 +46,14 @@ buttons differ. This prevents layout shift when joining/leaving a call.
   let isInAnotherCall = $derived(voiceCallState.isInAnyCall && !isInThisCall);
   let isConnecting = $derived(voiceCallState.connecting && voiceCallState.roomId === roomId);
   let hasActiveCall = $derived(activeCallRooms.has(roomId));
-  let visible = $derived(isInThisCall || hasActiveCall);
   let deviceMenuAnchor = $state<{ top: number; bottom: number; left: number } | null>(null);
+
+  // The call tab can be opened directly from a room even if the sidebar room
+  // list has not refreshed its active-call snapshot yet. Refresh here so
+  // observers see the active participants before deciding whether to join.
+  $effect(() => {
+    if (!isInThisCall) void activeCallRooms.load();
+  });
 
   // Load server-side participants when there's an active call and we're not in it
   $effect(() => {
@@ -101,8 +104,6 @@ buttons differ. This prevents layout shift when joining/leaving a call.
     videoTrack: Track | null;
   };
 
-  const MAX_VISIBLE_PARTICIPANTS = 6;
-
   let participants: DisplayParticipant[] = $derived.by(() => {
     if (isInThisCall) {
       return voiceCallState.participants.map((p) => ({
@@ -146,18 +147,23 @@ buttons differ. This prevents layout shift when joining/leaving a call.
       return 0;
     })
   );
-  let visibleParticipants = $derived(sortedParticipants.slice(0, MAX_VISIBLE_PARTICIPANTS));
-  let overflowCount = $derived(sortedParticipants.length - MAX_VISIBLE_PARTICIPANTS);
-  let videoParticipants = $derived(visibleParticipants.filter((p) => p.isCameraEnabled && p.videoTrack));
-  let voiceParticipants = $derived(visibleParticipants.filter((p) => !(p.isCameraEnabled && p.videoTrack)));
+  let videoParticipants = $derived(sortedParticipants.filter((p) => p.isCameraEnabled && p.videoTrack));
+  let voiceParticipants = $derived(sortedParticipants.filter((p) => !(p.isCameraEnabled && p.videoTrack)));
+  let isIdle = $derived(!hasActiveCall && !isInThisCall);
+  let joinLabel = $derived.by(() => {
+    if (isConnecting) return hasActiveCall ? 'Joining...' : 'Starting...';
+    return hasActiveCall ? 'Join call' : 'Start call';
+  });
+  const controlButtonClass = 'btn-secondary btn-sm h-9 w-full !px-0';
+  const dangerControlButtonClass = 'btn-danger btn-sm h-9 w-full !px-0';
 
   // --- Imperative audio level ring animation ---
   // Reads from voiceCallState.getAudioLevel() (non-reactive) and directly
   // mutates DOM elements at ~60ms. Completely bypasses Svelte's reactive graph.
   // eslint-disable-next-line svelte/prefer-svelte-reactivity -- imperative DOM ref map, not read reactively
-  const buttonRefs = new Map<string, HTMLButtonElement>();
+  const buttonRefs = new Map<string, HTMLElement>();
 
-  function trackButton(node: HTMLButtonElement, identity: string) {
+  function trackButton(node: HTMLElement, identity: string) {
     buttonRefs.set(identity, node);
     return {
       update(newIdentity: string) {
@@ -229,150 +235,180 @@ buttons differ. This prevents layout shift when joining/leaving a call.
   }
 </script>
 
-{#if visible}
-  <div
-    class="flex min-h-10 flex-row items-center gap-3 bg-surface-100 px-3 py-1.5"
-    data-testid={isInThisCall ? undefined : 'call-observer-panel'}
-  >
-    <!-- Call indicator -->
-    <div class="flex flex-row items-center gap-1.5 text-accent">
-      <span class="iconify animate-pulse uil--phone"></span>
-    </div>
-
-    <!-- Participants -->
-    <div class="flex flex-row items-center gap-2">
-      {#each videoParticipants as participant (participant.key)}
+<div
+  class="flex min-h-0 flex-1 flex-col"
+  data-testid={isInThisCall ? 'call-participant-panel' : 'call-observer-panel'}
+>
+  <div class="border-b border-border bg-background p-3">
+    {#if isInThisCall}
+      <div class="grid grid-cols-4 gap-2">
         <button
           type="button"
-          class="voice-ring voice-ring-video cursor-pointer"
-          class:voice-ring-muted={participant.isMuted}
-          use:trackButton={participant.key}
-          title={participant.connectionQuality === 'poor' || participant.connectionQuality === 'lost'
-            ? `${participant.displayName} — poor connection`
-            : participant.displayName}
-          onclick={(e) => showUserMenu(participant, e)}
-        >
-          <VideoThumbnail track={participant.videoTrack!} name={participant.displayName} user={participant.avatarUser} />
-          {#if participant.connectionQuality === 'poor' || participant.connectionQuality === 'lost'}
-            <span
-              class="connection-warning iconify uil--exclamation-triangle"
-              class:text-danger={participant.connectionQuality === 'lost'}
-              class:text-warning={participant.connectionQuality === 'poor'}
-            ></span>
-          {/if}
-        </button>
-      {/each}
-
-      {#if voiceParticipants.length > 0}
-        <div class="voice-only-grid">
-          {#each voiceParticipants as participant (participant.key)}
-            <button
-              type="button"
-              class="voice-ring cursor-pointer"
-              class:voice-ring-muted={participant.isMuted}
-              use:trackButton={participant.key}
-              title={participant.connectionQuality === 'poor' || participant.connectionQuality === 'lost'
-                ? `${participant.displayName} — poor connection`
-                : participant.displayName}
-              onclick={(e) => showUserMenu(participant, e)}
-            >
-              <UserAvatar user={participant.avatarUser} size="xs" showPresence={false} />
-              {#if participant.connectionQuality === 'poor' || participant.connectionQuality === 'lost'}
-                <span
-                  class="connection-warning iconify uil--exclamation-triangle"
-                  class:text-danger={participant.connectionQuality === 'lost'}
-                  class:text-warning={participant.connectionQuality === 'poor'}
-                ></span>
-              {/if}
-            </button>
-          {/each}
-        </div>
-      {/if}
-
-      {#if overflowCount > 0}
-        <span class="text-xs text-muted">+{overflowCount}</span>
-      {/if}
-    </div>
-
-    <!-- Actions -->
-    <div class="ml-auto flex flex-row items-center gap-2">
-      {#if isInThisCall}
-        <!-- Device selector -->
-        <button
-          type="button"
-          class="iconify cursor-pointer text-muted uil--setting hover:text-text"
+          class={controlButtonClass}
           title="Devices"
+          aria-label="Devices"
           data-testid="call-device-menu-button"
           onclick={openDeviceMenu}
-        ></button>
+        >
+          <span class="iconify uil--setting text-lg" aria-hidden="true"></span>
+        </button>
 
-        {#if deviceMenuAnchor}
-          <AudioDeviceMenu anchor={deviceMenuAnchor} onclose={() => (deviceMenuAnchor = null)} />
-        {/if}
-
-        <!-- Camera toggle -->
         <button
           type="button"
-          class={[
-            'iconify cursor-pointer hover:text-text',
-            voiceCallState.isCameraEnabled
-              ? 'text-muted uil--video'
-              : 'text-danger uil--video-slash'
-          ]}
+          class={voiceCallState.isCameraEnabled ? controlButtonClass : dangerControlButtonClass}
           title={voiceCallState.isCameraEnabled ? 'Turn off camera' : 'Turn on camera'}
+          aria-label={voiceCallState.isCameraEnabled ? 'Turn off camera' : 'Turn on camera'}
           data-testid="call-camera-toggle"
           onclick={() => voiceCallState.toggleCamera()}
-        ></button>
+        >
+          <span
+            class={[
+              'iconify text-lg',
+              voiceCallState.isCameraEnabled ? 'uil--video' : 'uil--video-slash'
+            ]}
+            aria-hidden="true"
+          ></span>
+        </button>
 
-        <!-- Mute toggle -->
         <button
           type="button"
-          class={[
-            'iconify cursor-pointer hover:text-text',
-            voiceCallState.isMuted
-              ? 'text-danger uil--microphone-slash'
-              : 'text-muted uil--microphone'
-          ]}
+          class={voiceCallState.isMuted ? dangerControlButtonClass : controlButtonClass}
           title={voiceCallState.isMuted ? 'Unmute' : 'Mute'}
+          aria-label={voiceCallState.isMuted ? 'Unmute' : 'Mute'}
+          data-testid="call-mute-toggle"
           onclick={() => voiceCallState.toggleMute()}
-        ></button>
+        >
+          <span
+            class={[
+              'iconify text-lg',
+              voiceCallState.isMuted ? 'uil--microphone-slash' : 'uil--microphone'
+            ]}
+            aria-hidden="true"
+          ></span>
+        </button>
 
-        <!-- Hang up -->
         <button
           type="button"
-          class="iconify cursor-pointer text-danger uil--phone-slash hover:brightness-125"
+          class={dangerControlButtonClass}
           onclick={() => voiceCallState.leave()}
           title="Leave call"
-        ></button>
-      {:else}
-        <!-- Join button -->
-        <button
-          type="button"
-          class="cursor-pointer rounded bg-accent px-3 py-1 text-xs font-medium text-white hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
-          data-testid="call-join-button"
-          onclick={handleJoin}
-          disabled={isInAnotherCall || isConnecting}
-          title={isInAnotherCall ? 'Already in another call' : 'Join voice call'}
+          aria-label="Leave call"
+          data-testid="call-leave-button"
         >
-          {#if isConnecting}
-            Joining...
-          {:else}
-            Join
-          {/if}
+          <span class="iconify uil--phone-slash text-lg" aria-hidden="true"></span>
         </button>
-      {/if}
-    </div>
+      </div>
+    {:else}
+      <button
+        type="button"
+        class="btn-accent btn-sm w-full"
+        data-testid="call-join-button"
+        onclick={handleJoin}
+        disabled={isInAnotherCall || isConnecting}
+        title={isInAnotherCall ? 'Already in another call' : joinLabel}
+      >
+        {joinLabel}
+      </button>
+    {/if}
   </div>
 
-  {#if popoverParticipant && popoverAnchorRect}
-    <UserContextMenu
-      user={popoverParticipant.avatarUser}
-      anchorRect={popoverAnchorRect}
-      canSendMessage={canStartDMs}
-      onSendMessage={() => startDMWith(getActiveServer(), popoverParticipant!.avatarUser.id)}
-      onClose={closeUserMenu}
-    />
-  {/if}
+  <div class="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto p-3">
+    {#if !isIdle}
+      {#if videoParticipants.length > 0}
+        <section class="@container flex flex-col gap-2" aria-label="Video participants">
+          <h2 class="px-1 text-xs font-semibold tracking-wider text-muted uppercase">
+            Video ({videoParticipants.length})
+          </h2>
+          <div
+            class={[
+              'grid grid-cols-1 gap-3',
+              videoParticipants.length > 1 && '@min-[368px]:grid-cols-2'
+            ]}
+            data-testid="call-video-grid"
+          >
+            {#each videoParticipants as participant (participant.key)}
+              <button
+                type="button"
+                class="voice-ring voice-ring-video aspect-video w-full cursor-pointer overflow-hidden bg-surface-100 text-left"
+                class:voice-ring-muted={participant.isMuted}
+                use:trackButton={participant.key}
+                title={participant.connectionQuality === 'poor' || participant.connectionQuality === 'lost'
+                  ? `${participant.displayName} — poor connection`
+                  : participant.displayName}
+                onclick={(e) => showUserMenu(participant, e)}
+              >
+                <VideoThumbnail
+                  track={participant.videoTrack!}
+                  name={participant.displayName}
+                  user={participant.avatarUser}
+                />
+                {#if participant.connectionQuality === 'poor' || participant.connectionQuality === 'lost'}
+                  <span
+                    class="connection-warning iconify uil--exclamation-triangle"
+                    class:text-danger={participant.connectionQuality === 'lost'}
+                    class:text-warning={participant.connectionQuality === 'poor'}
+                  ></span>
+                {/if}
+              </button>
+            {/each}
+          </div>
+        </section>
+      {/if}
+
+      {#if voiceParticipants.length > 0}
+        <section class="flex flex-col gap-2" aria-label="Voice participants">
+          <h2 class="px-1 text-xs font-semibold tracking-wider text-muted uppercase">
+            Voice ({voiceParticipants.length})
+          </h2>
+          <div class="sidebar-nav">
+            {#each voiceParticipants as participant (participant.key)}
+              <button
+                type="button"
+                class="sidebar-item text-left"
+                title={participant.connectionQuality === 'poor' || participant.connectionQuality === 'lost'
+                  ? `${participant.displayName} — poor connection`
+                  : participant.displayName}
+                onclick={(e) => showUserMenu(participant, e)}
+              >
+                <span
+                  class="voice-ring shrink-0"
+                  class:voice-ring-muted={participant.isMuted}
+                  use:trackButton={participant.key}
+                >
+                  <UserAvatar user={participant.avatarUser} size="sm" showPresence={false} />
+                  {#if participant.connectionQuality === 'poor' || participant.connectionQuality === 'lost'}
+                    <span
+                      class="connection-warning iconify uil--exclamation-triangle"
+                      class:text-danger={participant.connectionQuality === 'lost'}
+                      class:text-warning={participant.connectionQuality === 'poor'}
+                    ></span>
+                  {/if}
+                </span>
+                <span class="min-w-0 flex-1 truncate">{participant.displayName}</span>
+                {#if participant.isMuted}
+                  <span class="iconify uil--microphone-slash text-danger" aria-label="Muted"></span>
+                {/if}
+              </button>
+            {/each}
+          </div>
+        </section>
+      {/if}
+    {/if}
+  </div>
+</div>
+
+{#if deviceMenuAnchor}
+  <AudioDeviceMenu anchor={deviceMenuAnchor} onclose={() => (deviceMenuAnchor = null)} />
+{/if}
+
+{#if popoverParticipant && popoverAnchorRect}
+  <UserContextMenu
+    user={popoverParticipant.avatarUser}
+    anchorRect={popoverAnchorRect}
+    canSendMessage={canStartDMs}
+    onSendMessage={() => startDMWith(getActiveServer(), popoverParticipant!.avatarUser.id)}
+    onClose={closeUserMenu}
+  />
 {/if}
 
 <style>
@@ -393,15 +429,8 @@ buttons differ. This prevents layout shift when joining/leaving a call.
   }
 
   .voice-ring-video {
+    display: block;
     border-radius: 0.25rem;
-  }
-
-  .voice-only-grid {
-    display: flex;
-    flex-wrap: wrap;
-    align-content: center;
-    gap: 0.375rem;
-    max-height: 68px;
   }
 
   .connection-warning {

--- a/frontend/src/lib/components/voice/VoiceCallPanel.svelte
+++ b/frontend/src/lib/components/voice/VoiceCallPanel.svelte
@@ -157,6 +157,22 @@ Room sidebar panel for voice/video calls.
   const controlButtonClass = 'btn-secondary btn-sm h-9 w-full !px-0';
   const dangerControlButtonClass = 'btn-danger btn-sm h-9 w-full !px-0';
 
+  function hasVideo(participant: DisplayParticipant) {
+    return participant.isCameraEnabled && participant.videoTrack;
+  }
+
+  function hasConnectionWarning(participant: DisplayParticipant) {
+    return participant.connectionQuality === 'poor' || participant.connectionQuality === 'lost';
+  }
+
+  function participantTitle(participant: DisplayParticipant) {
+    if (isInThisCall && hasConnectionWarning(participant)) {
+      return `${participant.displayName} — poor connection`;
+    }
+
+    return participant.displayName;
+  }
+
   // --- Imperative audio level ring animation ---
   // Reads from voiceCallState.getAudioLevel() (non-reactive) and directly
   // mutates DOM elements at ~60ms. Completely bypasses Svelte's reactive graph.
@@ -234,6 +250,80 @@ Room sidebar panel for voice/video calls.
     }
   }
 </script>
+
+{#snippet participantCard(participant: DisplayParticipant, mode: 'compact' | 'video')}
+  {@const showVideo = mode === 'video' && hasVideo(participant)}
+  {#if isInThisCall}
+    <button
+      type="button"
+      class={[
+        'participant-card voice-ring voice-ring-card flex w-full cursor-pointer flex-col overflow-hidden rounded-md border border-border bg-surface-100 text-left text-text transition-colors hover:border-text/20 hover:bg-surface-200',
+        mode === 'video' ? 'participant-card-video' : 'participant-card-compact',
+        participant.isMuted && 'voice-ring-muted'
+      ]}
+      use:trackButton={participant.key}
+      title={participantTitle(participant)}
+      data-testid="call-participant-card"
+      onclick={(e) => showUserMenu(participant, e)}
+    >
+      <div class="flex min-w-0 items-center gap-2 p-2">
+        <UserAvatar user={participant.avatarUser} size="sm" showPresence={false} />
+        <span class="min-w-0 flex-1 truncate text-sm font-medium">{participant.displayName}</span>
+        <span class="inline-flex min-w-4 shrink-0 items-center justify-end gap-1.5 text-sm">
+          {#if participant.isMuted}
+            <span class="iconify uil--microphone-slash text-danger" aria-label="Muted"></span>
+          {/if}
+          {#if hasConnectionWarning(participant)}
+            <span
+              class="iconify uil--exclamation-triangle"
+              class:text-danger={participant.connectionQuality === 'lost'}
+              class:text-warning={participant.connectionQuality === 'poor'}
+              aria-label="Poor connection"
+            ></span>
+          {/if}
+        </span>
+      </div>
+
+      {#if showVideo}
+        <div class="border-t border-border">
+          <VideoThumbnail
+            track={participant.videoTrack!}
+            name={participant.displayName}
+            user={participant.avatarUser}
+            showIdentityOverlay={false}
+          />
+        </div>
+      {/if}
+    </button>
+  {:else}
+    <button
+      type="button"
+      class={[
+        'participant-card flex w-full cursor-pointer flex-col overflow-hidden rounded-md border border-border bg-surface-100 text-left text-text transition-colors hover:border-text/20 hover:bg-surface-200',
+        mode === 'video' ? 'participant-card-video' : 'participant-card-compact'
+      ]}
+      title={participantTitle(participant)}
+      data-testid="call-participant-card"
+      onclick={(e) => showUserMenu(participant, e)}
+    >
+      <div class="flex min-w-0 items-center gap-2 p-2">
+        <UserAvatar user={participant.avatarUser} size="sm" showPresence={false} />
+        <span class="min-w-0 flex-1 truncate text-sm font-medium">{participant.displayName}</span>
+      </div>
+
+      {#if showVideo}
+        <div class="border-t border-border">
+          <VideoThumbnail
+            track={participant.videoTrack!}
+            name={participant.displayName}
+            user={participant.avatarUser}
+            showIdentityOverlay={false}
+          />
+        </div>
+      {/if}
+    </button>
+  {/if}
+{/snippet}
 
 <div
   class="flex min-h-0 flex-1 flex-col"
@@ -314,81 +404,43 @@ Room sidebar panel for voice/video calls.
 
   <div class="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto p-3">
     {#if !isIdle}
-      {#if videoParticipants.length > 0}
-        <section class="@container flex flex-col gap-2" aria-label="Video participants">
-          <h2 class="px-1 text-xs font-semibold tracking-wider text-muted uppercase">
-            Video ({videoParticipants.length})
-          </h2>
-          <div
-            class={[
-              'grid grid-cols-1 gap-3',
-              videoParticipants.length > 1 && '@min-[368px]:grid-cols-2'
-            ]}
-            data-testid="call-video-grid"
-          >
-            {#each videoParticipants as participant (participant.key)}
-              <button
-                type="button"
-                class="voice-ring voice-ring-video aspect-video w-full cursor-pointer overflow-hidden bg-surface-100 text-left"
-                class:voice-ring-muted={participant.isMuted}
-                use:trackButton={participant.key}
-                title={participant.connectionQuality === 'poor' || participant.connectionQuality === 'lost'
-                  ? `${participant.displayName} — poor connection`
-                  : participant.displayName}
-                onclick={(e) => showUserMenu(participant, e)}
-              >
-                <VideoThumbnail
-                  track={participant.videoTrack!}
-                  name={participant.displayName}
-                  user={participant.avatarUser}
-                />
-                {#if participant.connectionQuality === 'poor' || participant.connectionQuality === 'lost'}
-                  <span
-                    class="connection-warning iconify uil--exclamation-triangle"
-                    class:text-danger={participant.connectionQuality === 'lost'}
-                    class:text-warning={participant.connectionQuality === 'poor'}
-                  ></span>
-                {/if}
-              </button>
-            {/each}
-          </div>
-        </section>
-      {/if}
+      {#if isInThisCall}
+        {#if videoParticipants.length > 0}
+          <section class="@container flex flex-col gap-2" aria-label="Video participants">
+            <h2 class="px-1 text-xs font-semibold tracking-wider text-muted uppercase">
+              Video ({videoParticipants.length})
+            </h2>
+            <div
+              class={[
+                'grid grid-cols-1 gap-3',
+                videoParticipants.length > 1 && '@min-[368px]:grid-cols-2'
+              ]}
+              data-testid="call-video-grid"
+            >
+              {#each videoParticipants as participant (participant.key)}
+                {@render participantCard(participant, 'video')}
+              {/each}
+            </div>
+          </section>
+        {/if}
 
-      {#if voiceParticipants.length > 0}
-        <section class="flex flex-col gap-2" aria-label="Voice participants">
-          <h2 class="px-1 text-xs font-semibold tracking-wider text-muted uppercase">
-            Voice ({voiceParticipants.length})
-          </h2>
-          <div class="sidebar-nav">
-            {#each voiceParticipants as participant (participant.key)}
-              <button
-                type="button"
-                class="sidebar-item text-left"
-                title={participant.connectionQuality === 'poor' || participant.connectionQuality === 'lost'
-                  ? `${participant.displayName} — poor connection`
-                  : participant.displayName}
-                onclick={(e) => showUserMenu(participant, e)}
-              >
-                <span
-                  class="voice-ring shrink-0"
-                  class:voice-ring-muted={participant.isMuted}
-                  use:trackButton={participant.key}
-                >
-                  <UserAvatar user={participant.avatarUser} size="sm" showPresence={false} />
-                  {#if participant.connectionQuality === 'poor' || participant.connectionQuality === 'lost'}
-                    <span
-                      class="connection-warning iconify uil--exclamation-triangle"
-                      class:text-danger={participant.connectionQuality === 'lost'}
-                      class:text-warning={participant.connectionQuality === 'poor'}
-                    ></span>
-                  {/if}
-                </span>
-                <span class="min-w-0 flex-1 truncate">{participant.displayName}</span>
-                {#if participant.isMuted}
-                  <span class="iconify uil--microphone-slash text-danger" aria-label="Muted"></span>
-                {/if}
-              </button>
+        {#if voiceParticipants.length > 0}
+          <section class="flex flex-col gap-2" aria-label="Voice participants">
+            <h2 class="px-1 text-xs font-semibold tracking-wider text-muted uppercase">
+              Voice ({voiceParticipants.length})
+            </h2>
+            <div class="flex flex-col gap-2">
+              {#each voiceParticipants as participant (participant.key)}
+                {@render participantCard(participant, 'compact')}
+              {/each}
+            </div>
+          </section>
+        {/if}
+      {:else}
+        <section class="flex flex-col gap-2" aria-label="Call participants">
+          <div class="flex flex-col gap-2" data-testid="call-participants-list">
+            {#each sortedParticipants as participant (participant.key)}
+              {@render participantCard(participant, 'compact')}
             {/each}
           </div>
         </section>
@@ -414,10 +466,8 @@ Room sidebar panel for voice/video calls.
 <style>
   .voice-ring {
     position: relative;
-    display: inline-flex;
     outline: 2px solid var(--color-border);
     outline-offset: 1px;
-    border-radius: 9999px;
     transition:
       outline-color 150ms ease-out,
       outline-width 150ms ease-out,
@@ -428,16 +478,8 @@ Room sidebar panel for voice/video calls.
     outline-color: var(--color-danger);
   }
 
-  .voice-ring-video {
-    display: block;
-    border-radius: 0.25rem;
-  }
-
-  .connection-warning {
-    position: absolute;
-    bottom: -2px;
-    right: -2px;
-    font-size: 0.625rem;
+  .voice-ring-card {
+    border-radius: 0.5rem;
   }
 
   /* Applied imperatively via classList.toggle() in the 60ms audio level loop */

--- a/frontend/src/lib/components/voice/VoiceCallPanel.svelte
+++ b/frontend/src/lib/components/voice/VoiceCallPanel.svelte
@@ -284,7 +284,7 @@ Room sidebar panel for voice/video calls.
       </div>
 
       {#if showVideo}
-        <div class="border-t border-border p-2">
+        <div class="p-2 pt-0">
           <VideoThumbnail
             track={participant.videoTrack!}
             name={participant.displayName}
@@ -311,7 +311,7 @@ Room sidebar panel for voice/video calls.
       </div>
 
       {#if showVideo}
-        <div class="border-t border-border p-2">
+        <div class="p-2 pt-0">
           <VideoThumbnail
             track={participant.videoTrack!}
             name={participant.displayName}

--- a/frontend/src/lib/components/voice/VoiceCallPanel.svelte
+++ b/frontend/src/lib/components/voice/VoiceCallPanel.svelte
@@ -256,7 +256,7 @@ Room sidebar panel for voice/video calls.
     <button
       type="button"
       class={[
-        'participant-card voice-ring voice-ring-card flex w-full cursor-pointer flex-col overflow-hidden rounded-md border border-border bg-surface-100 text-left text-text transition-colors hover:border-text/20 hover:bg-surface-200',
+        'participant-card voice-ring voice-ring-card flex w-full cursor-pointer flex-col overflow-hidden rounded-md border border-border bg-surface-100 text-left text-text transition-colors hover:bg-surface-200',
         mode === 'video' ? 'participant-card-video' : 'participant-card-compact',
         participant.isMuted && 'voice-ring-muted'
       ]}
@@ -298,7 +298,7 @@ Room sidebar panel for voice/video calls.
     <button
       type="button"
       class={[
-        'participant-card flex w-full cursor-pointer flex-col overflow-hidden rounded-md border border-border bg-surface-100 text-left text-text transition-colors hover:border-text/20 hover:bg-surface-200',
+        'participant-card flex w-full cursor-pointer flex-col overflow-hidden rounded-md border border-border bg-surface-100 text-left text-text transition-colors hover:bg-surface-200',
         mode === 'video' ? 'participant-card-video' : 'participant-card-compact'
       ]}
       title={participantTitle(participant)}
@@ -437,8 +437,8 @@ Room sidebar panel for voice/video calls.
 <style>
   .voice-ring {
     position: relative;
-    outline: 2px solid var(--color-border);
-    outline-offset: 1px;
+    outline: 0 solid transparent;
+    outline-offset: 0;
     transition:
       outline-color 150ms ease-out,
       outline-width 150ms ease-out,

--- a/frontend/src/lib/components/voice/VoiceCallPanel.svelte
+++ b/frontend/src/lib/components/voice/VoiceCallPanel.svelte
@@ -148,7 +148,6 @@ Room sidebar panel for voice/video calls.
     })
   );
   let videoParticipants = $derived(sortedParticipants.filter((p) => p.isCameraEnabled && p.videoTrack));
-  let voiceParticipants = $derived(sortedParticipants.filter((p) => !(p.isCameraEnabled && p.videoTrack)));
   let isIdle = $derived(!hasActiveCall && !isInThisCall);
   let joinLabel = $derived.by(() => {
     if (isConnecting) return hasActiveCall ? 'Joining...' : 'Starting...';
@@ -285,7 +284,7 @@ Room sidebar panel for voice/video calls.
       </div>
 
       {#if showVideo}
-        <div class="border-t border-border">
+        <div class="border-t border-border p-2">
           <VideoThumbnail
             track={participant.videoTrack!}
             name={participant.displayName}
@@ -312,7 +311,7 @@ Room sidebar panel for voice/video calls.
       </div>
 
       {#if showVideo}
-        <div class="border-t border-border">
+        <div class="border-t border-border p-2">
           <VideoThumbnail
             track={participant.videoTrack!}
             name={participant.displayName}
@@ -404,47 +403,19 @@ Room sidebar panel for voice/video calls.
 
   <div class="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto p-3">
     {#if !isIdle}
-      {#if isInThisCall}
-        {#if videoParticipants.length > 0}
-          <section class="@container flex flex-col gap-2" aria-label="Video participants">
-            <h2 class="px-1 text-xs font-semibold tracking-wider text-muted uppercase">
-              Video ({videoParticipants.length})
-            </h2>
-            <div
-              class={[
-                'grid grid-cols-1 gap-3',
-                videoParticipants.length > 1 && '@min-[368px]:grid-cols-2'
-              ]}
-              data-testid="call-video-grid"
-            >
-              {#each videoParticipants as participant (participant.key)}
-                {@render participantCard(participant, 'video')}
-              {/each}
-            </div>
-          </section>
-        {/if}
-
-        {#if voiceParticipants.length > 0}
-          <section class="flex flex-col gap-2" aria-label="Voice participants">
-            <h2 class="px-1 text-xs font-semibold tracking-wider text-muted uppercase">
-              Voice ({voiceParticipants.length})
-            </h2>
-            <div class="flex flex-col gap-2">
-              {#each voiceParticipants as participant (participant.key)}
-                {@render participantCard(participant, 'compact')}
-              {/each}
-            </div>
-          </section>
-        {/if}
-      {:else}
-        <section class="flex flex-col gap-2" aria-label="Call participants">
-          <div class="flex flex-col gap-2" data-testid="call-participants-list">
-            {#each sortedParticipants as participant (participant.key)}
-              {@render participantCard(participant, 'compact')}
-            {/each}
-          </div>
-        </section>
-      {/if}
+      <section class="@container flex flex-col gap-2" aria-label="Call participants">
+        <div
+          class={[
+            'grid grid-cols-1 gap-3',
+            isInThisCall && videoParticipants.length > 1 && '@min-[368px]:grid-cols-2'
+          ]}
+          data-testid="call-participants-list"
+        >
+          {#each sortedParticipants as participant (participant.key)}
+            {@render participantCard(participant, isInThisCall && hasVideo(participant) ? 'video' : 'compact')}
+          {/each}
+        </div>
+      </section>
     {/if}
   </div>
 </div>

--- a/frontend/src/lib/state/server/activeCallRooms.svelte.spec.ts
+++ b/frontend/src/lib/state/server/activeCallRooms.svelte.spec.ts
@@ -34,6 +34,49 @@ describe('ActiveCallRoomsState', () => {
 		]);
 	});
 
+	it('reports backend-observed participants as voice call participants', () => {
+		const state = new ActiveCallRoomsState(
+			{ query: vi.fn() } as never,
+			{ connected: false, roomId: null, participants: [] } as never
+		);
+
+		state.handleJoin('R1', 'call-1', {
+			id: 'U1',
+			displayName: 'Alice',
+			login: 'alice',
+			avatarUrl: null
+		} as never);
+
+		expect(state.getParticipantCallPresence('R1', 'U1')).toBe('voice');
+		expect(state.getParticipantCallPresence('R1', 'U2')).toBeNull();
+	});
+
+	it('reports active LiveKit camera participants as video participants', () => {
+		const state = new ActiveCallRoomsState(
+			{ query: vi.fn() } as never,
+			{
+				connected: true,
+				roomId: 'R1',
+				participants: [
+					{
+						identity: 'U1',
+						isCameraEnabled: true,
+						videoTrack: {}
+					},
+					{
+						identity: 'U2',
+						isCameraEnabled: false,
+						videoTrack: null
+					}
+				]
+			} as never
+		);
+
+		expect(state.getParticipantCallPresence('R1', 'U1')).toBe('video');
+		expect(state.getParticipantCallPresence('R1', 'U2')).toBe('voice');
+		expect(state.getParticipantCallPresence('R2', 'U1')).toBeNull();
+	});
+
 	it('clears a room when its call ends', () => {
 		const state = new ActiveCallRoomsState(
 			{ query: vi.fn() } as never,
@@ -49,6 +92,33 @@ describe('ActiveCallRoomsState', () => {
 
 		expect(state.has('R1')).toBe(true);
 		expect(state.getParticipants('R1')).toHaveLength(1);
+
+		state.handleEnd('R1', 'call-1');
+
+		expect(state.has('R1')).toBe(false);
+		expect(state.getParticipants('R1')).toEqual([]);
+	});
+
+	it('clears a room with an unknown call id when a call end event arrives', async () => {
+		const state = new ActiveCallRoomsState(
+			{
+				query: vi
+					.fn()
+					.mockReturnValueOnce({
+						toPromise: vi.fn(async () => ({ data: { activeCallRoomIds: ['R1'] } }))
+					})
+					.mockReturnValueOnce({
+						toPromise: vi.fn(async () => ({
+							data: { room: { callParticipants: [] } }
+						}))
+					})
+			} as never,
+			{ connected: false, roomId: null } as never
+		);
+
+		await state.load();
+
+		expect(state.has('R1')).toBe(true);
 
 		state.handleEnd('R1', 'call-1');
 

--- a/frontend/src/lib/state/server/activeCallRooms.svelte.ts
+++ b/frontend/src/lib/state/server/activeCallRooms.svelte.ts
@@ -44,6 +44,8 @@ export type CallRoomParticipant = {
 	avatarUrl: string | null;
 };
 
+export type CallPresenceKind = 'voice' | 'video';
+
 type ActiveCallRoomSnapshot = {
 	callId: string | null;
 	participants: CallRoomParticipant[];
@@ -77,6 +79,27 @@ export class ActiveCallRoomsState {
 	 */
 	getParticipants(roomId: string): CallRoomParticipant[] {
 		return this.serverRooms.get(roomId)?.participants ?? [];
+	}
+
+	/**
+	 * Return a user's call presence for a room.
+	 *
+	 * Backend-observed participants only tell us that someone is in the call,
+	 * so those render as voice. Once the local user has joined LiveKit, track
+	 * state lets us upgrade participants with an active camera track to video.
+	 */
+	getParticipantCallPresence(roomId: string, userId: string): CallPresenceKind | null {
+		if (this.#voiceCall.connected && this.#voiceCall.roomId === roomId) {
+			const liveParticipant = this.#voiceCall.participants.find((p) => p.identity === userId);
+			if (liveParticipant) {
+				return liveParticipant.isCameraEnabled && liveParticipant.videoTrack ? 'video' : 'voice';
+			}
+		}
+
+		const serverParticipant = this.serverRooms
+			.get(roomId)
+			?.participants.some((p) => p.userId === userId);
+		return serverParticipant ? 'voice' : null;
 	}
 
 	/**
@@ -180,7 +203,9 @@ export class ActiveCallRoomsState {
 	 * Handle a CallEndedEvent — clear the room's server-side call snapshot.
 	 */
 	handleEnd(roomId: string, callId: string): void {
-		if (this.serverRooms.get(roomId)?.callId !== callId) return;
+		const snapshot = this.serverRooms.get(roomId);
+		if (!snapshot) return;
+		if (snapshot.callId !== null && snapshot.callId !== callId) return;
 		this.serverRooms.delete(roomId);
 	}
 

--- a/frontend/src/lib/state/server/callParticipants.svelte.spec.ts
+++ b/frontend/src/lib/state/server/callParticipants.svelte.spec.ts
@@ -57,6 +57,25 @@ describe('CallParticipantsState', () => {
 		expect(state.participants).toEqual([]);
 	});
 
+	it('clears observer state for an end event when the loaded snapshot had no call id', async () => {
+		const state = new CallParticipantsState({
+			query: vi.fn(() => ({
+				toPromise: vi.fn(async () => ({ data: { room: { callParticipants: [] } } }))
+			}))
+		} as never);
+
+		await state.load('R1');
+		state.handleEnd('R1', 'call-1');
+		state.handleJoin('R1', 'call-1', {
+			id: 'U1',
+			displayName: 'Alice',
+			login: 'alice',
+			avatarUrl: null
+		} as never);
+
+		expect(state.participants).toEqual([]);
+	});
+
 	it('ignores stale leave and end events from an older call', async () => {
 		const state = new CallParticipantsState({
 			query: vi.fn(() => ({

--- a/frontend/src/lib/state/server/callParticipants.svelte.ts
+++ b/frontend/src/lib/state/server/callParticipants.svelte.ts
@@ -112,7 +112,7 @@ export class CallParticipantsState {
 	/** Clear observer participants when the room's call ends. */
 	handleEnd(roomId: string, callId: string): void {
 		if (roomId !== this.currentRoomId) return;
-		if (this.currentCallId !== callId) return;
+		if (this.currentCallId !== null && this.currentCallId !== callId) return;
 		this.clear();
 	}
 

--- a/frontend/src/lib/state/server/voiceCall.svelte.spec.ts
+++ b/frontend/src/lib/state/server/voiceCall.svelte.spec.ts
@@ -135,6 +135,67 @@ describe('VoiceCallState', () => {
     expect(calls.indexOf('setE2EEEnabled:true')).toBeLessThan(calls.indexOf('connect'));
   });
 
+  it('coalesces duplicate joins for the same room while connecting', async () => {
+    const client = {
+      mutation: vi.fn(() => ({
+        toPromise: vi.fn(async () => ({ data: { joinVoiceCall: true } }))
+      })),
+      query: vi.fn(() => ({
+        toPromise: vi.fn(async () => ({
+          data: {
+            room: {
+              voiceCallToken: {
+                token: 'livekit-token',
+                e2eeKey: 'shared-e2ee-key',
+                callId: 'call-1'
+              }
+            }
+          }
+        }))
+      }))
+    };
+
+    const state = new VoiceCallState(client as never);
+    await Promise.all([
+      state.join('wss://livekit.example.test', 'R1'),
+      state.join('wss://livekit.example.test', 'R1')
+    ]);
+
+    expect(client.mutation).toHaveBeenCalledTimes(1);
+    expect(client.query).toHaveBeenCalledTimes(1);
+    expect(calls.filter((call) => call === 'connect')).toHaveLength(1);
+  });
+
+  it('coalesces duplicate leave actions while the leave intent is in flight', async () => {
+    const client = {
+      mutation: vi.fn(() => ({
+        toPromise: vi.fn(async () => ({ data: { joinVoiceCall: true } }))
+      })),
+      query: vi.fn(() => ({
+        toPromise: vi.fn(async () => ({
+          data: {
+            room: {
+              voiceCallToken: {
+                token: 'livekit-token',
+                e2eeKey: 'shared-e2ee-key',
+                callId: 'call-1'
+              }
+            }
+          }
+        }))
+      }))
+    };
+
+    const state = new VoiceCallState(client as never);
+    await state.join('wss://livekit.example.test', 'R1');
+
+    await Promise.all([state.leave(), state.leave()]);
+
+    expect(client.mutation).toHaveBeenCalledTimes(2);
+    expect(lastRoom?.disconnect).toHaveBeenCalledOnce();
+    expect(state.isInAnyCall).toBe(false);
+  });
+
   it('records a compensating leave when LiveKit connect fails after join intent', async () => {
     connectFailure = new Error('connect failed');
     const client = {

--- a/frontend/src/lib/state/server/voiceCall.svelte.ts
+++ b/frontend/src/lib/state/server/voiceCall.svelte.ts
@@ -103,6 +103,9 @@ export class VoiceCallState {
   // Internal LiveKit room instance
   private room: Room | null = null;
   private activeCallId: string | null = null;
+  private joinInFlight: Promise<void> | null = null;
+  private joinInFlightRoomId: string | null = null;
+  private leaveInFlight: Promise<void> | null = null;
   private e2eeWorker: Worker | null = null;
   private audioLevelInterval: ReturnType<typeof setInterval> | null = null;
   private suppressDisconnectToast = false;
@@ -155,6 +158,28 @@ export class VoiceCallState {
     // Already in this call
     if (this.isInCall(roomId)) return;
 
+    if (this.joinInFlight) {
+      if (this.joinInFlightRoomId === roomId) {
+        return this.joinInFlight;
+      }
+      await this.joinInFlight;
+      if (this.isInCall(roomId)) return;
+    }
+
+    const joinPromise = this.performJoin(livekitUrl, roomId);
+    this.joinInFlight = joinPromise;
+    this.joinInFlightRoomId = roomId;
+    try {
+      await joinPromise;
+    } finally {
+      if (this.joinInFlight === joinPromise) {
+        this.joinInFlight = null;
+        this.joinInFlightRoomId = null;
+      }
+    }
+  }
+
+  private async performJoin(livekitUrl: string, roomId: string): Promise<void> {
     // Leave existing call first
     if (this.connected) {
       await this.leave();
@@ -250,14 +275,27 @@ export class VoiceCallState {
    * Leave the current voice call.
    */
   async leave(): Promise<void> {
+    if (this.leaveInFlight) return this.leaveInFlight;
     if (!this.room) return;
 
+    const leavePromise = this.performLeave();
+    this.leaveInFlight = leavePromise;
+    try {
+      await leavePromise;
+    } finally {
+      if (this.leaveInFlight === leavePromise) {
+        this.leaveInFlight = null;
+      }
+    }
+  }
+
+  private async performLeave(): Promise<void> {
     const roomId = this.roomId;
     if (roomId) {
       await this.recordLeaveIntent(roomId);
     }
 
-    this.room.disconnect();
+    this.room?.disconnect();
     this.cleanup();
   }
 
@@ -614,6 +652,8 @@ export class VoiceCallState {
     this.e2eeWorker?.terminate();
     this.e2eeWorker = null;
     this.activeCallId = null;
+    this.joinInFlight = null;
+    this.joinInFlightRoomId = null;
     this.suppressDisconnectToast = false;
     this.connected = false;
     this.connecting = false;

--- a/frontend/src/lib/storage/roomSidebarPanel.spec.ts
+++ b/frontend/src/lib/storage/roomSidebarPanel.spec.ts
@@ -1,15 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { serverStorageKey } from './serverStorage';
 import {
+  consumePendingRoomSidebarPanel,
   getRoomSidebarPanel,
   getRoomSidebarPanelState,
   ROOM_SIDEBAR_DEFAULT_PANEL,
   roomSidebarPanelStorageSuffix,
+  setPendingRoomSidebarPanel,
   setRoomSidebarPanel,
   setRoomSidebarPanelState
 } from './roomSidebarPanel';
 
 const storage = new Map<string, string>();
+const sessionStorageMap = new Map<string, string>();
 const localStorageMock: Storage = {
   getItem: (key) => storage.get(key) ?? null,
   setItem: (key, value) => storage.set(key, value),
@@ -20,10 +23,22 @@ const localStorageMock: Storage = {
   },
   key: (index) => [...storage.keys()][index] ?? null
 };
+const sessionStorageMock: Storage = {
+  getItem: (key) => sessionStorageMap.get(key) ?? null,
+  setItem: (key, value) => sessionStorageMap.set(key, value),
+  removeItem: (key) => sessionStorageMap.delete(key),
+  clear: () => sessionStorageMap.clear(),
+  get length() {
+    return sessionStorageMap.size;
+  },
+  key: (index) => [...sessionStorageMap.keys()][index] ?? null
+};
 vi.stubGlobal('localStorage', localStorageMock);
+vi.stubGlobal('sessionStorage', sessionStorageMock);
 
 beforeEach(() => {
   storage.clear();
+  sessionStorageMap.clear();
 });
 
 describe('room sidebar panel storage', () => {
@@ -35,11 +50,11 @@ describe('room sidebar panel storage', () => {
   it('persists the selected panel per server and room', () => {
     setRoomSidebarPanel('server-a', 'room-1', 'files');
     setRoomSidebarPanel('server-a', 'room-2', 'members');
-    setRoomSidebarPanel('server-b', 'room-1', 'members');
+    setRoomSidebarPanel('server-b', 'room-1', 'call');
 
     expect(getRoomSidebarPanel('server-a', 'room-1')).toBe('files');
     expect(getRoomSidebarPanel('server-a', 'room-2')).toBe('members');
-    expect(getRoomSidebarPanel('server-b', 'room-1')).toBe('members');
+    expect(getRoomSidebarPanel('server-b', 'room-1')).toBe('call');
   });
 
   it('does not persist closed state across sessions', () => {
@@ -65,5 +80,13 @@ describe('room sidebar panel storage', () => {
 
     localStorage.setItem(key, 'calendar');
     expect(getRoomSidebarPanel('server-a', 'room-1')).toBe('members');
+  });
+
+  it('stores and consumes a pending panel open request for a specific room', () => {
+    setPendingRoomSidebarPanel('server-a', 'room-1', 'call');
+
+    expect(consumePendingRoomSidebarPanel('server-a', 'room-2')).toBeNull();
+    expect(consumePendingRoomSidebarPanel('server-a', 'room-1')).toBe('call');
+    expect(consumePendingRoomSidebarPanel('server-a', 'room-1')).toBeNull();
   });
 });

--- a/frontend/src/lib/storage/roomSidebarPanel.ts
+++ b/frontend/src/lib/storage/roomSidebarPanel.ts
@@ -1,11 +1,18 @@
 import { serverSlot, type Codec } from './slot';
+import { serverStorageKey } from './serverStorage';
 
-export const ROOM_SIDEBAR_PANELS = ['members', 'files'] as const;
+export const ROOM_SIDEBAR_PANELS = ['members', 'files', 'call'] as const;
 
 export type RoomSidebarPanel = (typeof ROOM_SIDEBAR_PANELS)[number];
 export type RoomSidebarPanelState = RoomSidebarPanel | null;
 
 export const ROOM_SIDEBAR_DEFAULT_PANEL: RoomSidebarPanel = 'members';
+const PENDING_ROOM_SIDEBAR_PANEL_SUFFIX = 'roomSidebarPanel:pendingOpen';
+
+type PendingRoomSidebarPanel = {
+  roomId: string;
+  panel: RoomSidebarPanel;
+};
 
 function isRoomSidebarPanel(value: unknown): value is RoomSidebarPanel {
   return typeof value === 'string' && ROOM_SIDEBAR_PANELS.includes(value as RoomSidebarPanel);
@@ -57,4 +64,57 @@ export function setRoomSidebarPanel(
   panel: RoomSidebarPanel
 ): void {
   setRoomSidebarPanelState(serverId, roomId, panel);
+}
+
+export function setPendingRoomSidebarPanel(
+  serverId: string,
+  roomId: string,
+  panel: RoomSidebarPanel
+): void {
+  const storage = getSessionStorage();
+  if (!storage) return;
+
+  storage.setItem(
+    serverSlotKey(serverId),
+    JSON.stringify({
+      roomId,
+      panel
+    } satisfies PendingRoomSidebarPanel)
+  );
+}
+
+export function consumePendingRoomSidebarPanel(
+  serverId: string,
+  roomId: string
+): RoomSidebarPanelState {
+  const storage = getSessionStorage();
+  if (!storage) return null;
+
+  const key = serverSlotKey(serverId);
+  const raw = storage.getItem(key);
+  if (!raw) return null;
+
+  let pending: Partial<PendingRoomSidebarPanel>;
+  try {
+    pending = JSON.parse(raw) as Partial<PendingRoomSidebarPanel>;
+  } catch {
+    storage.removeItem(key);
+    return null;
+  }
+
+  if (pending.roomId !== roomId) return null;
+  storage.removeItem(key);
+  return isRoomSidebarPanel(pending.panel) ? pending.panel : null;
+}
+
+function serverSlotKey(serverId: string): string {
+  return serverStorageKey(serverId, PENDING_ROOM_SIDEBAR_PANEL_SUFFIX);
+}
+
+function getSessionStorage(): Storage | null {
+  try {
+    return globalThis.sessionStorage ?? null;
+  } catch {
+    return null;
+  }
 }

--- a/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -28,6 +28,7 @@
   const stores = serverRegistry.getStore(getActiveServer());
   const notificationStore = stores.notifications;
   const serverInfo = stores.serverInfo;
+  const activeCallRooms = stores.activeCallRooms;
   import { getLiveDisplayName } from '$lib/state/userProfiles.svelte';
   import MessageActionSheet from './MessageActionSheet.svelte';
   import MessageContextMenu from '$lib/components/menus/MessageContextMenu.svelte';
@@ -97,6 +98,9 @@
   // Display name with live updates from profile cache
   const displayName = $derived(
     actor ? getLiveDisplayName(actor.id, actor.displayName || actor.login) : 'Deleted User'
+  );
+  const actorCallPresence = $derived(
+    actor ? activeCallRooms.getParticipantCallPresence(roomId, actor.id) : null
   );
 
   // Permission checks for message actions. Authors can always edit (within
@@ -574,6 +578,20 @@
   }
 </script>
 
+{#snippet callPresenceIcon(kind: 'voice' | 'video' | null)}
+  {#if kind}
+    <span
+      class={[
+        'iconify shrink-0 text-xs leading-none text-accent',
+        kind === 'video' ? 'uil--video' : 'uil--phone'
+      ]}
+      title={kind === 'video' ? 'In a video call' : 'In a voice call'}
+      aria-label={kind === 'video' ? 'In a video call' : 'In a voice call'}
+      data-testid={`user-call-presence-${kind}`}
+    ></span>
+  {/if}
+{/snippet}
+
 {#if msg}
   <div
     class={[
@@ -657,7 +675,7 @@
             {#if actor}
               <button
                 type="button"
-                class="shrink-0 cursor-pointer leading-none font-semibold hover:underline"
+                class="inline-flex shrink-0 cursor-pointer items-center gap-1.5 leading-none font-semibold hover:underline"
                 onclick={showPopoverForActor}
                 ontouchstart={(e) => e.stopPropagation()}
                 oncontextmenu={(e) => {
@@ -666,7 +684,8 @@
                   showPopoverForActor(e);
                 }}
               >
-                {displayName}
+                <span>{displayName}</span>
+                {@render callPresenceIcon(actorCallPresence)}
               </button>
             {:else}
               <strong class="shrink-0 leading-none font-semibold text-muted">{displayName}</strong>
@@ -698,6 +717,10 @@
           >
             <span class="shrink-0">in reply to</span>
             {#if replyPreview.actor}
+              {@const replyCallPresence = activeCallRooms.getParticipantCallPresence(
+                roomId,
+                replyPreview.actor.id
+              )}
               <button
                 type="button"
                 data-testid="reply-attribution-author"
@@ -709,6 +732,7 @@
               >
                 <UserAvatar user={replyPreview.actor} size="xs" showPresence={false} />
                 <strong class="font-medium">{replyPreview.name}</strong>
+                {@render callPresenceIcon(replyCallPresence)}
               </button>
             {:else}
               <strong class="shrink-0 font-medium">{replyPreview.name}</strong>

--- a/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -7,8 +7,6 @@
     type MessageComposerApi
   } from '$lib/components/composer/MessageComposer.svelte';
   import { graphql } from '$lib/gql';
-  import VoiceCallButton from '$lib/components/voice/VoiceCallButton.svelte';
-  import VoiceCallPanel from '$lib/components/voice/VoiceCallPanel.svelte';
   import {
     useRoomData,
     useRoomUnread,
@@ -35,6 +33,12 @@
   import { serverIdToSegment } from '$lib/navigation';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { clearLastRoom, setLastRoom } from '$lib/storage/lastRoom';
+  import {
+    consumePendingRoomSidebarPanel,
+    roomSidebarPanelStorageSuffix,
+    type RoomSidebarPanel
+  } from '$lib/storage/roomSidebarPanel';
+  import { serverStorageKey } from '$lib/storage/serverStorage';
   import PageTitle from '$lib/ui/PageTitle.svelte';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
   import { onDestroy, tick } from 'svelte';
@@ -44,8 +48,8 @@
   import RoomSidebarToggle from './RoomSidebarToggle.svelte';
   import {
     canBanMembersFromRoomSidebar,
-    DM_ROOM_SIDEBAR_PANELS,
-    roomSidebarPanelForRoom
+    roomSidebarPanelForRoom,
+    roomSidebarPanelsForRoom
   } from './roomSidebarBehavior';
   import { RoomSidebarPanelsState } from './roomSidebarPanels.svelte';
   import ThreadPane from './ThreadPane.svelte';
@@ -325,14 +329,37 @@
     () => roomId
   );
   const activeRoomSidebarPanel = $derived(
-    roomSidebarPanelForRoom(room.isDM, roomSidebarPanels.activeDesktopPanel)
+    roomSidebarPanelForRoom(room.isDM, roomSidebarPanels.activeDesktopPanel, showVoiceCall)
   );
   const mobileRoomSidebarPanel = $derived(
-    roomSidebarPanelForRoom(room.isDM, roomSidebarPanels.mobilePanel)
+    roomSidebarPanelForRoom(room.isDM, roomSidebarPanels.mobilePanel, showVoiceCall)
   );
-  const roomSidebarTogglePanels = $derived(room.isDM ? DM_ROOM_SIDEBAR_PANELS : undefined);
+  const roomSidebarTogglePanels = $derived(roomSidebarPanelsForRoom(room.isDM, showVoiceCall));
+  const hasActiveRoomCall = $derived(stores.activeCallRooms.has(roomId));
 
   let leavingRoom = $state(false);
+
+  function openRoomSidebarPanel(panel: RoomSidebarPanel): void {
+    if (window.matchMedia('(min-width: 1024px)').matches) {
+      roomSidebarPanels.openDesktopPanel(panel);
+    } else {
+      roomSidebarPanels.openMobilePanel(panel);
+    }
+  }
+
+  function handleRoomSidebarPanelStorage(event: StorageEvent): void {
+    const key = serverStorageKey(getActiveServer(), roomSidebarPanelStorageSuffix(roomId));
+    if (event.key !== key) return;
+    if (event.newValue !== 'call') return;
+
+    consumePendingRoomSidebarPanel(getActiveServer(), roomId);
+    openRoomSidebarPanel('call');
+  }
+
+  $effect(() => {
+    const pendingPanel = consumePendingRoomSidebarPanel(getActiveServer(), roomId);
+    if (pendingPanel) openRoomSidebarPanel(pendingPanel);
+  });
 
   function openFileMessage(
     messageEventId: string,
@@ -373,6 +400,7 @@
 </script>
 
 <svelte:window
+  onstorage={handleRoomSidebarPanelStorage}
   onkeydown={(e) => {
     if (e.key === 'Escape' && mobileRoomSidebarPanel && !e.defaultPrevented) {
       e.preventDefault();
@@ -439,17 +467,16 @@
               mode="mobile"
               activePanel={mobileRoomSidebarPanel}
               panels={roomSidebarTogglePanels}
+              hasActiveCall={hasActiveRoomCall}
               onToggle={(panel) => roomSidebarPanels.toggleMobilePanel(panel)}
             />
             <RoomSidebarToggle
               mode="desktop"
               activePanel={activeRoomSidebarPanel}
               panels={roomSidebarTogglePanels}
+              hasActiveCall={hasActiveRoomCall}
               onToggle={(panel) => roomSidebarPanels.toggleDesktopPanel(panel)}
             />
-            {#if showVoiceCall}
-              <VoiceCallButton {roomId} livekitUrl={serverInfo.livekitUrl!} />
-            {/if}
             {#if showLeaveRoom}
               <button
                 class="group/pane-header-icon-button pane-header-icon-button"
@@ -469,10 +496,6 @@
             {/if}
           {/snippet}
         </PaneHeader>
-
-        {#if room.roomData && serverInfo.livekitUrl}
-          <VoiceCallPanel {roomId} livekitUrl={serverInfo.livekitUrl} />
-        {/if}
 
         <RoomEventsPane
           {roomId}
@@ -551,6 +574,7 @@
             presentation="overlay"
             loading={room.isRoomLoading}
             filesStore={roomFilesStore}
+            livekitUrl={serverInfo.livekitUrl ?? undefined}
             canBanRoomMembers={canBanMembersFromRoomSidebar(
               room.isDM,
               room.roomData?.canBanRoomMembers
@@ -572,6 +596,7 @@
           activePanel={activeRoomSidebarPanel}
           loading={room.isRoomLoading}
           filesStore={roomFilesStore}
+          livekitUrl={serverInfo.livekitUrl ?? undefined}
           canBanRoomMembers={canBanMembersFromRoomSidebar(
             room.isDM,
             room.roomData?.canBanRoomMembers

--- a/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { q } from '$lib/test-utils';
+import {
+  consumePendingRoomSidebarPanel,
+  setPendingRoomSidebarPanel
+} from '$lib/storage/roomSidebarPanel';
 
 const { mocks } = vi.hoisted(() => {
   const queryData = {
@@ -35,7 +39,8 @@ const { mocks } = vi.hoisted(() => {
       mutation: vi.fn(() => ({
         toPromise: vi.fn().mockResolvedValue({ data: {}, error: null })
       })),
-      subscription: vi.fn()
+      subscription: vi.fn(),
+      livekitUrl: null as string | null
     }
   };
 });
@@ -118,7 +123,7 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
     getStore: () => ({
       currentUser: { user: { id: 'test-user', login: 'testuser' }, loading: false },
       serverInfo: {
-        livekitUrl: null,
+        livekitUrl: mocks.livekitUrl,
         videoProcessingEnabled: false,
         maxUploadSize: 25 * 1024 * 1024,
         maxVideoUploadSize: 25 * 1024 * 1024
@@ -131,6 +136,9 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
       },
       pendingHighlights: {
         consume: vi.fn(() => null)
+      },
+      activeCallRooms: {
+        has: vi.fn(() => false)
       },
       rooms: {
         decrementUnreadNotification: vi.fn()
@@ -208,6 +216,10 @@ import Room from './Room.svelte';
 
 beforeEach(() => {
   vi.clearAllMocks();
+  localStorage.clear();
+  sessionStorage.clear();
+  mocks.livekitUrl = null;
+  vi.stubGlobal('matchMedia', vi.fn(() => ({ matches: true })));
 });
 
 describe('Room local message echo', () => {
@@ -235,5 +247,16 @@ describe('Room local message echo', () => {
     await expect.element(q(container, '[data-testid="room-event-ids"]')).toHaveTextContent('');
     expect(mocks.resetTypingDebounce).toHaveBeenCalledOnce();
     expect(mocks.noteReadCursor).not.toHaveBeenCalled();
+  });
+
+  it('opens a pending call panel request as a mobile sidebar after navigation', async () => {
+    mocks.livekitUrl = 'wss://livekit.example.test';
+    vi.stubGlobal('matchMedia', vi.fn(() => ({ matches: false })));
+    setPendingRoomSidebarPanel('server-1', 'room-1', 'call');
+
+    const { container } = render(Room, { props: { roomId: 'room-1' } });
+
+    await expect.element(q(container, '[data-testid="room-sidebar-mobile-pane"]')).toBeInTheDocument();
+    expect(consumePendingRoomSidebarPanel('server-1', 'room-1')).toBeNull();
   });
 });

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
@@ -7,7 +7,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
 "UI" section of `docs/GLOSSARY.md`.
 -->
 <script module lang="ts">
-  export type RoomSidebarPanel = 'members' | 'files';
+  export type RoomSidebarPanel = 'members' | 'files' | 'call';
 </script>
 
 <script lang="ts">
@@ -32,6 +32,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
   import { toast } from '$lib/ui/toast';
   import HeaderIconButton from '$lib/ui/HeaderIconButton.svelte';
   import BanRoomMemberModal from '$lib/components/moderation/BanRoomMemberModal.svelte';
+  import VoiceCallPanel from '$lib/components/voice/VoiceCallPanel.svelte';
   import RoomFilesPanel from './RoomFilesPanel.svelte';
 
   const BanRoomMemberMutation = graphql(`
@@ -49,6 +50,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
     currentUserId = null,
     membersStore,
     filesStore,
+    livekitUrl,
     fileGroupingNow,
     onOpenFile,
     onClose
@@ -61,6 +63,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
     currentUserId?: string | null;
     membersStore: RoomMembersStore;
     filesStore?: RoomFilesStore;
+    livekitUrl?: string;
     fileGroupingNow?: Date;
     onOpenFile?: (messageEventId: string, threadRootEventId: string | null) => void;
     onClose?: () => void;
@@ -71,7 +74,11 @@ calls, and similar room-specific panels can plug into the same shell. See the
 
   const members = $derived(membersStore.members);
   const memberCount = $derived(membersStore.totalCount);
-  const title = $derived(activePanel === 'members' ? `Members (${memberCount})` : 'Files');
+  const title = $derived.by(() => {
+    if (activePanel === 'members') return `Members (${memberCount})`;
+    if (activePanel === 'files') return 'Files';
+    return 'Call';
+  });
 
   // Check if user can start DMs (from centralized server permissions)
   const serverPerms = getServerPermissions();
@@ -312,6 +319,14 @@ calls, and similar room-specific panels can plug into the same shell. See the
     {:else}
       <div class="flex min-h-0 flex-1 items-center justify-center p-4 text-sm text-muted">
         No files in this room yet.
+      </div>
+    {/if}
+  {:else if activePanel === 'call'}
+    {#if livekitUrl}
+      <VoiceCallPanel {roomId} {livekitUrl} />
+    {:else}
+      <div class="flex min-h-0 flex-1 items-center justify-center p-4 text-sm text-muted">
+        Calls are not available on this server.
       </div>
     {/if}
   {/if}

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -465,8 +465,11 @@ describe('RoomSidebar', () => {
 
     await expect.element(q(container, '[data-testid="call-observer-panel"]')).toBeInTheDocument();
     expect(container.textContent).not.toContain('1 in call');
-    expect(container.textContent).toContain('Voice (1)');
+    expect(container.textContent).not.toContain('Voice (1)');
+    expect(container.textContent).not.toContain('Video (1)');
     expect(container.textContent).toContain('Bob');
+    await expect.element(q(container, '[data-testid="call-participant-card"]')).toBeInTheDocument();
+    await expect.element(q(container, '[data-testid="call-participants-list"]')).toBeInTheDocument();
     await vi.waitFor(() => {
       expect(callStore.callParticipants.load).toHaveBeenCalledWith('room-1');
     });
@@ -532,7 +535,8 @@ describe('RoomSidebar', () => {
     expect(container.textContent).toContain('Voice (1)');
     expect(container.textContent).toContain('Bob');
     expect(q(container, '[data-testid="call-device-menu-button"]')).toBeTruthy();
-    expect(q(container, '.voice-ring-video')!.classList.contains('aspect-video')).toBe(true);
+    expect(q(container, '.participant-card-video')).toBeTruthy();
+    expect(q(container, '.participant-card-compact')).toBeTruthy();
 
     (q(container, '[data-testid="call-mute-toggle"]') as HTMLButtonElement).click();
     (q(container, '[data-testid="call-camera-toggle"]') as HTMLButtonElement).click();

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -9,6 +9,65 @@ import { PresenceStatus } from '$lib/gql/graphql';
 import RoomSidebarTestHarness from './RoomSidebarTestHarness.svelte';
 
 const queryMock = vi.hoisted(() => vi.fn());
+const callStore = vi.hoisted(() => ({
+  voiceCall: {
+    roomId: null as string | null,
+    connecting: false,
+    connected: false,
+    isInAnyCall: false,
+    isMuted: false,
+    isCameraEnabled: false,
+    participants: [] as Array<{
+      identity: string;
+      name: string;
+      login: string;
+      avatarUrl: string | null;
+      isMuted: boolean;
+      isLocal: boolean;
+      connectionQuality: 'excellent' | 'good' | 'poor' | 'lost' | 'unknown';
+      isCameraEnabled: boolean;
+      videoTrack: unknown;
+    }>,
+    audioDevices: [],
+    audioOutputDevices: [],
+    videoDevices: [],
+    selectedDeviceId: null,
+    selectedOutputDeviceId: null,
+    selectedVideoDeviceId: null,
+    isInCall: vi.fn((roomId: string) => callStore.voiceCall.connected && callStore.voiceCall.roomId === roomId),
+    join: vi.fn().mockResolvedValue(undefined),
+    leave: vi.fn().mockResolvedValue(undefined),
+    toggleMute: vi.fn().mockResolvedValue(undefined),
+    toggleCamera: vi.fn().mockResolvedValue(undefined),
+    refreshDevices: vi.fn().mockResolvedValue(undefined),
+    getAudioLevel: vi.fn(() => ({ isSpeaking: false, audioLevel: 0 })),
+    handleParticipantLeftEvent: vi.fn(),
+    handleCallEndedEvent: vi.fn()
+  },
+  activeCallRooms: {
+    active: false,
+    load: vi.fn().mockResolvedValue(undefined),
+    has: vi.fn(() => callStore.activeCallRooms.active),
+    handleEnd: vi.fn()
+  },
+  callParticipants: {
+    participants: [] as Array<{
+      userId: string;
+      displayName: string;
+      login: string;
+      avatarUrl: string | null;
+    }>,
+    load: vi.fn().mockResolvedValue(undefined),
+    clear: vi.fn(),
+    handleJoin: vi.fn(),
+    handleLeave: vi.fn(),
+    handleEnd: vi.fn()
+  },
+  rooms: {
+    currentUserId: 'viewer'
+  },
+  handleVoiceCallJoinFailed: vi.fn()
+}));
 
 class MockIntersectionObserver {
   static instances: MockIntersectionObserver[] = [];
@@ -47,6 +106,10 @@ vi.mock('$lib/hooks/useEvent.svelte', () => ({
   usePresenceChange: vi.fn()
 }));
 
+vi.mock('$lib/hooks', () => ({
+  useEvent: vi.fn()
+}));
+
 vi.mock('$lib/state/server/connection.svelte', () => ({
   useConnection: () => () => ({
     isConnected: true,
@@ -66,6 +129,13 @@ vi.mock('$lib/state/server/connection.svelte', () => ({
 
 vi.mock('$lib/state/activeServer.svelte', () => ({
   getActiveServer: () => 'test-server'
+}));
+
+vi.mock('$lib/state/server/registry.svelte', () => ({
+  serverRegistry: {
+    getStore: () => callStore,
+    getServer: () => ({ id: 'test-server', url: 'https://chat.example.test' })
+  }
 }));
 
 vi.mock('$lib/state/server/permissions.svelte', () => ({
@@ -247,6 +317,30 @@ describe('RoomSidebar', () => {
     localStorage.clear();
     MockIntersectionObserver.instances = [];
     vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+    callStore.voiceCall.roomId = null;
+    callStore.voiceCall.connecting = false;
+    callStore.voiceCall.connected = false;
+    callStore.voiceCall.isInAnyCall = false;
+    callStore.voiceCall.isMuted = false;
+    callStore.voiceCall.isCameraEnabled = false;
+    callStore.voiceCall.participants = [];
+    callStore.voiceCall.isInCall.mockClear();
+    callStore.voiceCall.join.mockClear();
+    callStore.voiceCall.leave.mockClear();
+    callStore.voiceCall.toggleMute.mockClear();
+    callStore.voiceCall.toggleCamera.mockClear();
+    callStore.voiceCall.refreshDevices.mockClear();
+    callStore.voiceCall.getAudioLevel.mockClear();
+    callStore.activeCallRooms.active = false;
+    callStore.activeCallRooms.load.mockClear();
+    callStore.activeCallRooms.has.mockClear();
+    callStore.callParticipants.participants = [];
+    callStore.callParticipants.load.mockClear();
+    callStore.callParticipants.clear.mockClear();
+    callStore.callParticipants.handleJoin.mockClear();
+    callStore.callParticipants.handleLeave.mockClear();
+    callStore.callParticipants.handleEnd.mockClear();
+    callStore.handleVoiceCallJoinFailed.mockClear();
   });
 
   it('shows the exact total count and automatically loads additional member pages', async () => {
@@ -326,6 +420,236 @@ describe('RoomSidebar', () => {
     for (let index = 1; index <= 142; index++) {
       expect(renderedTitles).toContain(`View profile of User ${index}`);
     }
+  });
+
+  it('renders the call tab empty state and starts a call', async () => {
+    const { container } = render(RoomSidebarTestHarness, {
+      props: {
+        roomData: roomData([], 0, false),
+        activePanel: 'call',
+        livekitUrl: 'wss://livekit.example.test'
+      }
+    });
+
+    await expect.element(q(container, 'h1')).toHaveTextContent('Call');
+    await expect.element(q(container, '[data-testid="call-join-button"]')).toHaveTextContent(
+      'Start call'
+    );
+    expect(container.textContent).not.toContain('No active call');
+    expect(container.textContent).not.toContain("Start one when you're ready.");
+
+    (q(container, '[data-testid="call-join-button"]') as HTMLButtonElement).click();
+    await tick();
+
+    expect(callStore.voiceCall.join).toHaveBeenCalledWith('wss://livekit.example.test', 'room-1');
+  });
+
+  it('renders projected call participants before joining', async () => {
+    callStore.activeCallRooms.active = true;
+    callStore.callParticipants.participants = [
+      {
+        userId: 'user-2',
+        login: 'bob',
+        displayName: 'Bob',
+        avatarUrl: null
+      }
+    ];
+
+    const { container } = render(RoomSidebarTestHarness, {
+      props: {
+        roomData: roomData([], 0, false),
+        activePanel: 'call',
+        livekitUrl: 'wss://livekit.example.test'
+      }
+    });
+
+    await expect.element(q(container, '[data-testid="call-observer-panel"]')).toBeInTheDocument();
+    expect(container.textContent).not.toContain('1 in call');
+    expect(container.textContent).toContain('Voice (1)');
+    expect(container.textContent).toContain('Bob');
+    await vi.waitFor(() => {
+      expect(callStore.callParticipants.load).toHaveBeenCalledWith('room-1');
+    });
+  });
+
+  it('refreshes active-call room state when the call tab opens for an observer', async () => {
+    render(RoomSidebarTestHarness, {
+      props: {
+        roomData: roomData([], 0, false),
+        activePanel: 'call',
+        livekitUrl: 'wss://livekit.example.test'
+      }
+    });
+
+    await vi.waitFor(() => {
+      expect(callStore.activeCallRooms.load).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('splits connected video and voice participants and exposes call controls', async () => {
+    const videoTrack = {
+      attach: vi.fn(),
+      detach: vi.fn()
+    };
+    callStore.voiceCall.connected = true;
+    callStore.voiceCall.isInAnyCall = true;
+    callStore.voiceCall.roomId = 'room-1';
+    callStore.voiceCall.participants = [
+      {
+        identity: 'viewer',
+        login: 'alice',
+        name: 'Alice',
+        avatarUrl: null,
+        isMuted: false,
+        isLocal: true,
+        connectionQuality: 'excellent',
+        isCameraEnabled: true,
+        videoTrack
+      },
+      {
+        identity: 'user-2',
+        login: 'bob',
+        name: 'Bob',
+        avatarUrl: null,
+        isMuted: true,
+        isLocal: false,
+        connectionQuality: 'good',
+        isCameraEnabled: false,
+        videoTrack: null
+      }
+    ];
+
+    const { container } = render(RoomSidebarTestHarness, {
+      props: {
+        roomData: roomData([], 0, false),
+        activePanel: 'call',
+        livekitUrl: 'wss://livekit.example.test'
+      }
+    });
+
+    await expect.element(q(container, '[data-testid="call-participant-panel"]')).toBeInTheDocument();
+    expect(container.textContent).toContain('Video (1)');
+    expect(container.textContent).toContain('Voice (1)');
+    expect(container.textContent).toContain('Bob');
+    expect(q(container, '[data-testid="call-device-menu-button"]')).toBeTruthy();
+    expect(q(container, '.voice-ring-video')!.classList.contains('aspect-video')).toBe(true);
+
+    (q(container, '[data-testid="call-mute-toggle"]') as HTMLButtonElement).click();
+    (q(container, '[data-testid="call-camera-toggle"]') as HTMLButtonElement).click();
+    (q(container, '[data-testid="call-leave-button"]') as HTMLButtonElement).click();
+    await tick();
+
+    expect(callStore.voiceCall.toggleMute).toHaveBeenCalledOnce();
+    expect(callStore.voiceCall.toggleCamera).toHaveBeenCalledOnce();
+    expect(callStore.voiceCall.leave).toHaveBeenCalledOnce();
+  });
+
+  it('hides empty call participant sections', async () => {
+    const videoTrack = {
+      attach: vi.fn(),
+      detach: vi.fn()
+    };
+    callStore.voiceCall.connected = true;
+    callStore.voiceCall.isInAnyCall = true;
+    callStore.voiceCall.roomId = 'room-1';
+    callStore.voiceCall.participants = [
+      {
+        identity: 'viewer',
+        login: 'alice',
+        name: 'Alice',
+        avatarUrl: null,
+        isMuted: false,
+        isLocal: true,
+        connectionQuality: 'excellent',
+        isCameraEnabled: true,
+        videoTrack
+      }
+    ];
+
+    const { container } = render(RoomSidebarTestHarness, {
+      props: {
+        roomData: roomData([], 0, false),
+        activePanel: 'call',
+        livekitUrl: 'wss://livekit.example.test'
+      }
+    });
+
+    expect(container.textContent).toContain('Video (1)');
+    expect(container.textContent).not.toContain('Voice (0)');
+    expect(container.textContent).not.toContain('No voice-only participants.');
+    const videoGrid = q(container, '[data-testid="call-video-grid"]');
+    expect(videoGrid).toBeTruthy();
+    expect(videoGrid!.className).not.toContain('@min-[368px]:grid-cols-2');
+  });
+
+  it('uses a two-column video grid when multiple videos have room', async () => {
+    const videoTrackA = {
+      attach: vi.fn(),
+      detach: vi.fn()
+    };
+    const videoTrackB = {
+      attach: vi.fn(),
+      detach: vi.fn()
+    };
+    callStore.voiceCall.connected = true;
+    callStore.voiceCall.isInAnyCall = true;
+    callStore.voiceCall.roomId = 'room-1';
+    callStore.voiceCall.participants = [
+      {
+        identity: 'viewer',
+        login: 'alice',
+        name: 'Alice',
+        avatarUrl: null,
+        isMuted: false,
+        isLocal: true,
+        connectionQuality: 'excellent',
+        isCameraEnabled: true,
+        videoTrack: videoTrackA
+      },
+      {
+        identity: 'user-2',
+        login: 'bob',
+        name: 'Bob',
+        avatarUrl: null,
+        isMuted: false,
+        isLocal: false,
+        connectionQuality: 'good',
+        isCameraEnabled: true,
+        videoTrack: videoTrackB
+      }
+    ];
+
+    const { container } = render(RoomSidebarTestHarness, {
+      props: {
+        roomData: roomData([], 0, false),
+        activePanel: 'call',
+        livekitUrl: 'wss://livekit.example.test'
+      }
+    });
+
+    expect(container.textContent).toContain('Video (2)');
+    const videoGrid = q(container, '[data-testid="call-video-grid"]');
+    expect(videoGrid).toBeTruthy();
+    expect(videoGrid!.className).toContain('@min-[368px]:grid-cols-2');
+  });
+
+  it('disables joining this room while connected to another call', async () => {
+    callStore.activeCallRooms.active = true;
+    callStore.voiceCall.connected = true;
+    callStore.voiceCall.isInAnyCall = true;
+    callStore.voiceCall.roomId = 'other-room';
+
+    const { container } = render(RoomSidebarTestHarness, {
+      props: {
+        roomData: roomData([], 0, false),
+        activePanel: 'call',
+        livekitUrl: 'wss://livekit.example.test'
+      }
+    });
+
+    const joinButton = q(container, '[data-testid="call-join-button"]') as HTMLButtonElement;
+    expect(joinButton.disabled).toBe(true);
+    expect(joinButton.title).toBe('Already in another call');
   });
 
   it('keeps existing pagination state when automatic pagination fails and allows retry', async () => {

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -489,7 +489,7 @@ describe('RoomSidebar', () => {
     });
   });
 
-  it('splits connected video and voice participants and exposes call controls', async () => {
+  it('renders connected participant cards video-first and exposes call controls', async () => {
     const videoTrack = {
       attach: vi.fn(),
       detach: vi.fn()
@@ -531,12 +531,16 @@ describe('RoomSidebar', () => {
     });
 
     await expect.element(q(container, '[data-testid="call-participant-panel"]')).toBeInTheDocument();
-    expect(container.textContent).toContain('Video (1)');
-    expect(container.textContent).toContain('Voice (1)');
+    expect(container.textContent).not.toContain('Video (1)');
+    expect(container.textContent).not.toContain('Voice (1)');
     expect(container.textContent).toContain('Bob');
     expect(q(container, '[data-testid="call-device-menu-button"]')).toBeTruthy();
-    expect(q(container, '.participant-card-video')).toBeTruthy();
-    expect(q(container, '.participant-card-compact')).toBeTruthy();
+    const participantCards = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-testid="call-participant-card"]')
+    );
+    expect(participantCards).toHaveLength(2);
+    expect(participantCards[0].className).toContain('participant-card-video');
+    expect(participantCards[1].className).toContain('participant-card-compact');
 
     (q(container, '[data-testid="call-mute-toggle"]') as HTMLButtonElement).click();
     (q(container, '[data-testid="call-camera-toggle"]') as HTMLButtonElement).click();
@@ -548,7 +552,7 @@ describe('RoomSidebar', () => {
     expect(callStore.voiceCall.leave).toHaveBeenCalledOnce();
   });
 
-  it('hides empty call participant sections', async () => {
+  it('renders one participant list without empty section labels', async () => {
     const videoTrack = {
       attach: vi.fn(),
       detach: vi.fn()
@@ -578,12 +582,12 @@ describe('RoomSidebar', () => {
       }
     });
 
-    expect(container.textContent).toContain('Video (1)');
+    expect(container.textContent).not.toContain('Video (1)');
     expect(container.textContent).not.toContain('Voice (0)');
     expect(container.textContent).not.toContain('No voice-only participants.');
-    const videoGrid = q(container, '[data-testid="call-video-grid"]');
-    expect(videoGrid).toBeTruthy();
-    expect(videoGrid!.className).not.toContain('@min-[368px]:grid-cols-2');
+    const participantList = q(container, '[data-testid="call-participants-list"]');
+    expect(participantList).toBeTruthy();
+    expect(participantList!.className).not.toContain('@min-[368px]:grid-cols-2');
   });
 
   it('uses a two-column video grid when multiple videos have room', async () => {
@@ -631,10 +635,10 @@ describe('RoomSidebar', () => {
       }
     });
 
-    expect(container.textContent).toContain('Video (2)');
-    const videoGrid = q(container, '[data-testid="call-video-grid"]');
-    expect(videoGrid).toBeTruthy();
-    expect(videoGrid!.className).toContain('@min-[368px]:grid-cols-2');
+    expect(container.textContent).not.toContain('Video (2)');
+    const participantList = q(container, '[data-testid="call-participants-list"]');
+    expect(participantList).toBeTruthy();
+    expect(participantList!.className).toContain('@min-[368px]:grid-cols-2');
   });
 
   it('disables joining this room while connected to another call', async () => {

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarTestHarness.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarTestHarness.svelte
@@ -20,6 +20,7 @@ mounting the full chat room shell.
     presentation = 'desktop',
     currentUserId = 'viewer',
     canBanRoomMembers = false,
+    livekitUrl,
     fileGroupingNow,
     onPresenceCacheReady,
     onOpenFile,
@@ -31,6 +32,7 @@ mounting the full chat room shell.
     presentation?: 'desktop' | 'overlay';
     currentUserId?: string | null;
     canBanRoomMembers?: boolean;
+    livekitUrl?: string;
     fileGroupingNow?: Date;
     onPresenceCacheReady?: (cache: PresenceCache) => void;
     onOpenFile?: (messageEventId: string, threadRootEventId: string | null) => void;
@@ -68,6 +70,7 @@ mounting the full chat room shell.
   {currentUserId}
   membersStore={roomMembersStore}
   filesStore={roomFilesStore}
+  {livekitUrl}
   {fileGroupingNow}
   {onOpenFile}
   {onClose}

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarToggle.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarToggle.svelte
@@ -16,12 +16,14 @@ Room header affordance for opening or hiding room extras panels.
     activePanel,
     panels,
     onToggle,
-    mode = 'desktop'
+    mode = 'desktop',
+    hasActiveCall = false
   }: {
     activePanel: RoomSidebarPanel | null;
     panels?: RoomSidebarPanel[];
     onToggle: (panel: RoomSidebarPanel) => void;
     mode?: 'desktop' | 'mobile' | 'always';
+    hasActiveCall?: boolean;
   } = $props();
 
   const panelDefinitions: {
@@ -41,6 +43,12 @@ Room header affordance for opening or hiding room extras panels.
       icon: 'uil--paperclip',
       showLabel: 'Show files',
       hideLabel: 'Hide files'
+    },
+    {
+      id: 'call',
+      icon: 'uil--phone',
+      showLabel: 'Show call',
+      hideLabel: 'Hide call'
     }
   ];
 
@@ -66,18 +74,37 @@ Room header affordance for opening or hiding room extras panels.
 >
   {#each visiblePanels as panel (panel.id)}
     {@const isActive = activePanel === panel.id}
+    {@const isActiveCallPanel = panel.id === 'call' && hasActiveCall}
+    {@const shouldPulseCallIcon = isActiveCallPanel && !isActive}
     <button
       type="button"
       class={[
         'group/pane-header-icon-button pane-header-icon-button',
-        isActive && 'pane-header-icon-button-active'
+        isActive && 'pane-header-icon-button-active',
+        isActiveCallPanel && 'text-accent'
       ]}
       onclick={() => onToggle(panel.id)}
       title={isActive ? panel.hideLabel : panel.showLabel}
       aria-label={isActive ? panel.hideLabel : panel.showLabel}
       aria-pressed={isActive}
     >
-      <span class={['pane-header-icon-glyph', panel.icon]} aria-hidden="true"></span>
+      <span class="relative inline-flex">
+        {#if shouldPulseCallIcon}
+          <span
+            class={['pane-header-icon-glyph absolute inset-0 animate-ping opacity-45', panel.icon]}
+            aria-hidden="true"
+            data-testid="active-call-pulse-icon"
+          ></span>
+        {/if}
+        <span
+          class={[
+            'pane-header-icon-glyph relative',
+            panel.icon,
+            isActiveCallPanel && 'text-accent'
+          ]}
+          aria-hidden="true"
+        ></span>
+      </span>
     </button>
   {/each}
 </span>

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarToggle.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarToggle.svelte.spec.ts
@@ -53,6 +53,24 @@ describe('RoomSidebarToggle', () => {
     expect(onToggle).toHaveBeenCalledWith('files');
   });
 
+  it('switches to the call panel', async () => {
+    const onToggle = vi.fn();
+    const { container } = render(RoomSidebarToggle, {
+      props: {
+        activePanel: 'members',
+        onToggle
+      }
+    });
+
+    const button = container.querySelector('[aria-label="Show call"]') as HTMLButtonElement | null;
+    expect(button).toBeTruthy();
+
+    button!.click();
+    await tick();
+
+    expect(onToggle).toHaveBeenCalledWith('call');
+  });
+
   it('can render only the files panel', async () => {
     const { container } = render(RoomSidebarToggle, {
       props: {
@@ -64,6 +82,20 @@ describe('RoomSidebarToggle', () => {
 
     expect(container.querySelector('[aria-label="Show members"]')).toBeFalsy();
     expect(container.querySelector('[aria-label="Show files"]')).toBeTruthy();
+  });
+
+  it('can render only files and call panels', async () => {
+    const { container } = render(RoomSidebarToggle, {
+      props: {
+        activePanel: null,
+        panels: ['files', 'call'],
+        onToggle: vi.fn()
+      }
+    });
+
+    expect(container.querySelector('[aria-label="Show members"]')).toBeFalsy();
+    expect(container.querySelector('[aria-label="Show files"]')).toBeTruthy();
+    expect(container.querySelector('[aria-label="Show call"]')).toBeTruthy();
   });
 
   it('uses a background-only pressed state for the active panel', async () => {
@@ -87,6 +119,43 @@ describe('RoomSidebarToggle', () => {
     expect(filesButton!.classList.contains('pane-header-icon-button-active')).toBe(true);
     expect(membersButton!.classList.contains('pane-header-icon-button')).toBe(true);
     expect(membersButton!.classList.contains('pane-header-icon-button-active')).toBe(false);
+  });
+
+  it('highlights and pulses the call tab when a call is active in the room', async () => {
+    const { container } = render(RoomSidebarToggle, {
+      props: {
+        activePanel: 'members',
+        hasActiveCall: true,
+        onToggle: vi.fn()
+      }
+    });
+
+    const callButton = container.querySelector(
+      '[aria-label="Show call"]'
+    ) as HTMLButtonElement | null;
+
+    expect(callButton).toBeTruthy();
+    expect(callButton!.classList.contains('text-accent')).toBe(true);
+    expect(callButton!.querySelector('[data-testid="active-call-pulse-icon"]')).toBeTruthy();
+  });
+
+  it('keeps the active call tab highlighted without the pulse twin when selected', async () => {
+    const { container } = render(RoomSidebarToggle, {
+      props: {
+        activePanel: 'call',
+        hasActiveCall: true,
+        onToggle: vi.fn()
+      }
+    });
+
+    const callButton = container.querySelector(
+      '[aria-label="Hide call"]'
+    ) as HTMLButtonElement | null;
+
+    expect(callButton).toBeTruthy();
+    expect(callButton!.classList.contains('text-accent')).toBe(true);
+    expect(callButton!.classList.contains('pane-header-icon-button-active')).toBe(true);
+    expect(callButton!.querySelector('[data-testid="active-call-pulse-icon"]')).toBeFalsy();
   });
 
   it('renders desktop-only by default', async () => {

--- a/frontend/src/routes/chat/[serverId]/[roomId]/roomSidebarBehavior.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/roomSidebarBehavior.spec.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
   canBanMembersFromRoomSidebar,
+  CHANNEL_ROOM_SIDEBAR_PANELS,
   DM_ROOM_SIDEBAR_PANELS,
-  roomSidebarPanelForRoom
+  roomSidebarPanelForRoom,
+  roomSidebarPanelsForRoom
 } from './roomSidebarBehavior';
 
 describe('room sidebar behavior', () => {
@@ -20,13 +22,14 @@ describe('room sidebar behavior', () => {
     expect(canBanMembersFromRoomSidebar(false, undefined)).toBe(false);
   });
 
-  it('only exposes files as a DM room sidebar panel', () => {
-    expect(DM_ROOM_SIDEBAR_PANELS).toEqual(['files']);
+  it('exposes files and calls as DM room sidebar panels', () => {
+    expect(DM_ROOM_SIDEBAR_PANELS).toEqual(['files', 'call']);
   });
 
   it('keeps channel room sidebar panels unchanged', () => {
     expect(roomSidebarPanelForRoom(false, 'members')).toBe('members');
     expect(roomSidebarPanelForRoom(false, 'files')).toBe('files');
+    expect(roomSidebarPanelForRoom(false, 'call')).toBe('call');
     expect(roomSidebarPanelForRoom(false, null)).toBeNull();
   });
 
@@ -37,5 +40,21 @@ describe('room sidebar behavior', () => {
 
   it('allows the files panel to open for DM rooms', () => {
     expect(roomSidebarPanelForRoom(true, 'files')).toBe('files');
+  });
+
+  it('allows the call panel to open for DM rooms when LiveKit is configured', () => {
+    expect(roomSidebarPanelForRoom(true, 'call', true)).toBe('call');
+  });
+
+  it('hides the call panel when LiveKit is not configured', () => {
+    expect(roomSidebarPanelForRoom(false, 'call', false)).toBeNull();
+    expect(roomSidebarPanelForRoom(true, 'call', false)).toBeNull();
+    expect(roomSidebarPanelsForRoom(false, false)).toEqual(['members', 'files']);
+    expect(roomSidebarPanelsForRoom(true, false)).toEqual(['files']);
+  });
+
+  it('returns all channel panels when LiveKit is configured', () => {
+    expect(CHANNEL_ROOM_SIDEBAR_PANELS).toEqual(['members', 'files', 'call']);
+    expect(roomSidebarPanelsForRoom(false, true)).toEqual(['members', 'files', 'call']);
   });
 });

--- a/frontend/src/routes/chat/[serverId]/[roomId]/roomSidebarBehavior.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/roomSidebarBehavior.ts
@@ -1,6 +1,7 @@
 import type { RoomSidebarPanel, RoomSidebarPanelState } from '$lib/storage/roomSidebarPanel';
 
-export const DM_ROOM_SIDEBAR_PANELS: RoomSidebarPanel[] = ['files'];
+export const CHANNEL_ROOM_SIDEBAR_PANELS: RoomSidebarPanel[] = ['members', 'files', 'call'];
+export const DM_ROOM_SIDEBAR_PANELS: RoomSidebarPanel[] = ['files', 'call'];
 
 export function canBanMembersFromRoomSidebar(
   isDM: boolean,
@@ -11,8 +12,17 @@ export function canBanMembersFromRoomSidebar(
 
 export function roomSidebarPanelForRoom(
   isDM: boolean,
-  panel: RoomSidebarPanelState
+  panel: RoomSidebarPanelState,
+  livekitEnabled = true
 ): RoomSidebarPanelState {
-  if (!isDM) return panel;
-  return DM_ROOM_SIDEBAR_PANELS.includes(panel as RoomSidebarPanel) ? panel : null;
+  if (panel === null) return null;
+  const panels = isDM ? DM_ROOM_SIDEBAR_PANELS : CHANNEL_ROOM_SIDEBAR_PANELS;
+  if (!panels.includes(panel)) return null;
+  if (panel === 'call' && !livekitEnabled) return null;
+  return panel;
+}
+
+export function roomSidebarPanelsForRoom(isDM: boolean, livekitEnabled: boolean): RoomSidebarPanel[] {
+  const panels = isDM ? DM_ROOM_SIDEBAR_PANELS : CHANNEL_ROOM_SIDEBAR_PANELS;
+  return livekitEnabled ? panels : panels.filter((panel) => panel !== 'call');
 }

--- a/frontend/src/routes/chat/[serverId]/[roomId]/roomSidebarPanels.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/roomSidebarPanels.svelte.spec.ts
@@ -70,6 +70,43 @@ describe('RoomSidebarPanelsState', () => {
     expect(getRoomSidebarPanelState('server-a', 'room-1')).toBe('files');
   });
 
+  it('persists the call panel for desktop rooms', () => {
+    const sidebar = new RoomSidebarPanelsState(
+      () => 'server-a',
+      () => 'room-1'
+    );
+
+    sidebar.toggleDesktopPanel('call');
+
+    expect(sidebar.activeDesktopPanel).toBe('call');
+    expect(getRoomSidebarPanelState('server-a', 'room-1')).toBe('call');
+  });
+
+  it('opens the requested desktop panel even after the panel was session-closed', () => {
+    const sidebar = new RoomSidebarPanelsState(
+      () => 'server-a',
+      () => 'room-1'
+    );
+
+    sidebar.closeDesktop();
+    sidebar.openDesktopPanel('call');
+
+    expect(sidebar.activeDesktopPanel).toBe('call');
+    expect(getRoomSidebarPanelState('server-a', 'room-1')).toBe('call');
+  });
+
+  it('opens the requested mobile panel without toggling it closed', () => {
+    const sidebar = new RoomSidebarPanelsState(
+      () => 'server-a',
+      () => 'room-1'
+    );
+
+    sidebar.openMobilePanel('call');
+    sidebar.openMobilePanel('call');
+
+    expect(sidebar.mobilePanel).toBe('call');
+  });
+
   it('treats mobile overlay state as closed after the room changes', () => {
     let roomId = 'room-1';
     const sidebar = new RoomSidebarPanelsState(

--- a/frontend/src/routes/chat/[serverId]/[roomId]/roomSidebarPanels.svelte.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/roomSidebarPanels.svelte.ts
@@ -40,6 +40,10 @@ export class RoomSidebarPanelsState {
     this.#setDesktopState(panel);
   }
 
+  openDesktopPanel(panel: RoomSidebarPanel): void {
+    this.#setDesktopState(panel);
+  }
+
   closeDesktop(): void {
     this.#setDesktopState(null);
   }
@@ -50,6 +54,11 @@ export class RoomSidebarPanelsState {
       return;
     }
 
+    this.#mobileScope = this.#currentScope;
+    this.#mobilePanel = panel;
+  }
+
+  openMobilePanel(panel: RoomSidebarPanel): void {
     this.#mobileScope = this.#currentScope;
     this.#mobilePanel = panel;
   }


### PR DESCRIPTION
Fixes #986.

## Summary
- Moves the call experience into the room sidebar call tab, with LiveKit-aware panel filtering for channels and DMs.
- Adds call controls, video/voice participant sections, active-call current-user controls, timeline call-presence icons, and active call tab highlighting.
- Hardens duplicate join/leave handling and updates local LiveKit dev config plus FDR-016.

## Tests
- `mise lint-frontend`
- `mise test-frontend`
