### PR TITLE
perf: optimize projection startup paths

### DIFF
--- a/cli/internal/core/reaction_projection.go
+++ b/cli/internal/core/reaction_projection.go
@@ -122,10 +122,6 @@ func (p *ReactionProjection) noteRoomOwnershipLocked(event *corev1.Event, roomID
 		if event.GetId() != "" {
 			p.messageRoom[event.GetId()] = roomID
 		}
-	case *corev1.Event_MessageBody:
-		if e.MessageBody.GetEventId() != "" {
-			p.messageRoom[e.MessageBody.GetEventId()] = roomID
-		}
 	case *corev1.Event_AssetCreated:
 		if assetID := e.AssetCreated.GetAsset().GetId(); assetID != "" {
 			p.assetRoom[assetID] = roomID

--- a/cli/internal/core/room_timeline_projection.go
+++ b/cli/internal/core/room_timeline_projection.go
@@ -134,11 +134,9 @@ func (p *RoomTimelineProjection) Apply(event *corev1.Event, seq uint64) error {
 
 	if ev := event.GetMessageBody(); ev != nil {
 		targetID := ev.GetEventId()
-		body := cloneMessageBody(ev.GetBody())
+		body := ev.GetBody()
 		if targetID != "" && body != nil {
-			if body.GetBodyEventId() == "" {
-				body.BodyEventId = event.GetId()
-			} else if body.GetBodyEventId() != event.GetId() {
+			if body.GetBodyEventId() != "" && body.GetBodyEventId() != event.GetId() {
 				return nil
 			}
 			if authorID := body.GetAuthorId(); authorID != "" {
@@ -147,6 +145,10 @@ func (p *RoomTimelineProjection) Apply(event *corev1.Event, seq uint64) error {
 					p.retractedFlags[targetID] = struct{}{}
 					p.removeAttachmentMessageLocked(targetID)
 				} else {
+					body = cloneMessageBody(body)
+					if body.GetBodyEventId() == "" {
+						body.BodyEventId = event.GetId()
+					}
 					p.latestBody[targetID] = body
 					p.bodyEventSeqs[targetID] = append(p.bodyEventSeqs[targetID], seq)
 					p.currentBodySeq[targetID] = seq
@@ -419,11 +421,20 @@ func (p *RoomTimelineProjection) addAttachmentMessageLocked(roomID, eventID stri
 
 	ids := p.attachmentMessageIDsByRoom[roomID]
 	insertAt := len(ids)
-	for i, existingID := range ids {
-		existing := p.byEventID[existingID]
-		if existing == nil || existing.StreamSeq > streamSeq {
-			insertAt = i
-			break
+	if len(ids) > 0 {
+		last := p.byEventID[ids[len(ids)-1]]
+		if last != nil && last.StreamSeq <= streamSeq {
+			ids = append(ids, eventID)
+			p.attachmentMessageIDsByRoom[roomID] = ids
+			p.attachmentMessageRoom[eventID] = roomID
+			return
+		}
+		for i, existingID := range ids {
+			existing := p.byEventID[existingID]
+			if existing == nil || existing.StreamSeq > streamSeq {
+				insertAt = i
+				break
+			}
 		}
 	}
 	ids = append(ids, "")

--- a/cli/internal/core/thread_projection.go
+++ b/cli/internal/core/thread_projection.go
@@ -14,10 +14,11 @@ type threadReplySummary struct {
 }
 
 type threadSummary struct {
-	replyIDs       []string
-	replyCount     int
-	lastReplyAt    *time.Time
-	participantIDs []string
+	replyIDs          []string
+	replyCount        int
+	lastReplyAt       *time.Time
+	participantIDs    []string
+	participantCounts map[string]int
 }
 
 // ThreadProjection holds an append-only event log per thread,
@@ -117,7 +118,7 @@ func (p *ThreadProjection) Apply(event *corev1.Event, seq uint64) error {
 			p.byThread[threadRoot] = nil
 		}
 		if _, exists := p.summaryByThread[threadRoot]; !exists {
-			p.summaryByThread[threadRoot] = &threadSummary{}
+			p.summaryByThread[threadRoot] = newThreadSummary()
 		}
 		markApplied()
 
@@ -139,11 +140,11 @@ func (p *ThreadProjection) Apply(event *corev1.Event, seq uint64) error {
 		}
 		summary := p.summaryByThread[threadRoot]
 		if summary == nil {
-			summary = &threadSummary{}
+			summary = newThreadSummary()
 			p.summaryByThread[threadRoot] = summary
 		}
 		summary.replyIDs = append(summary.replyIDs, replyID)
-		p.recomputeSummaryLocked(threadRoot)
+		p.applyReplyToSummaryLocked(summary, replyID)
 		markApplied()
 
 	case *corev1.Event_MessageEdited:
@@ -162,11 +163,20 @@ func (p *ThreadProjection) Apply(event *corev1.Event, seq uint64) error {
 		p.byThread[threadRoot] = append(p.byThread[threadRoot], &TimelineEntry{StreamSeq: seq, Event: event})
 		if reply := p.replySummaries[e.MessageRetracted.GetEventId()]; reply != nil {
 			reply.retracted = true
+			// Retractions are rare and can invalidate last-reply or participant
+			// ordering, so recomputing the affected thread keeps the hot reply
+			// path O(1) without making removal bookkeeping subtle.
 			p.recomputeSummaryLocked(threadRoot)
 		}
 		markApplied()
 	}
 	return nil
+}
+
+func newThreadSummary() *threadSummary {
+	return &threadSummary{
+		participantCounts: make(map[string]int),
+	}
 }
 
 func eventCreatedAt(event *corev1.Event) time.Time {
@@ -179,34 +189,47 @@ func eventCreatedAt(event *corev1.Event) time.Time {
 func (p *ThreadProjection) recomputeSummaryLocked(threadRoot string) {
 	summary := p.summaryByThread[threadRoot]
 	if summary == nil {
-		summary = &threadSummary{}
+		summary = newThreadSummary()
 		p.summaryByThread[threadRoot] = summary
+	} else if summary.participantCounts == nil {
+		summary.participantCounts = make(map[string]int)
 	}
 
 	summary.replyCount = 0
 	summary.lastReplyAt = nil
 	summary.participantIDs = nil
-	participants := make(map[string]struct{})
+	clear(summary.participantCounts)
 
 	for _, replyID := range summary.replyIDs {
-		reply := p.replySummaries[replyID]
-		if reply == nil || reply.retracted {
-			continue
-		}
-		if _, shredded := p.shreddedUsers[reply.actorID]; shredded {
-			continue
-		}
+		p.applyReplyToSummaryLocked(summary, replyID)
+	}
+}
 
-		summary.replyCount++
-		if !reply.createdAt.IsZero() && (summary.lastReplyAt == nil || reply.createdAt.After(*summary.lastReplyAt)) {
-			at := reply.createdAt
-			summary.lastReplyAt = &at
-		}
-		if reply.actorID != "" {
-			if _, seen := participants[reply.actorID]; !seen && len(summary.participantIDs) < maxThreadParticipants {
-				participants[reply.actorID] = struct{}{}
-				summary.participantIDs = append(summary.participantIDs, reply.actorID)
-			}
+func (p *ThreadProjection) applyReplyToSummaryLocked(summary *threadSummary, replyID string) {
+	if summary == nil || replyID == "" {
+		return
+	}
+	if summary.participantCounts == nil {
+		summary.participantCounts = make(map[string]int)
+	}
+
+	reply := p.replySummaries[replyID]
+	if reply == nil || reply.retracted {
+		return
+	}
+	if _, shredded := p.shreddedUsers[reply.actorID]; shredded {
+		return
+	}
+
+	summary.replyCount++
+	if !reply.createdAt.IsZero() && (summary.lastReplyAt == nil || reply.createdAt.After(*summary.lastReplyAt)) {
+		at := reply.createdAt
+		summary.lastReplyAt = &at
+	}
+	if reply.actorID != "" {
+		summary.participantCounts[reply.actorID]++
+		if summary.participantCounts[reply.actorID] == 1 && len(summary.participantIDs) < maxThreadParticipants {
+			summary.participantIDs = append(summary.participantIDs, reply.actorID)
 		}
 	}
 }

--- a/cli/internal/events/projector.go
+++ b/cli/internal/events/projector.go
@@ -113,6 +113,8 @@ type Projector struct {
 	startupTargetSeq uint64
 	startupEndedAt   time.Time
 	startupCompleted bool
+	startupMessages  uint64
+	startupLogged    bool
 }
 
 // ProjectorStatus is a concurrency-safe snapshot of a projector's
@@ -125,6 +127,7 @@ type ProjectorStatus struct {
 	StartupTargetSeq uint64
 	StartupComplete  bool
 	StartupDuration  time.Duration
+	StartupMessages  uint64
 
 	Failed    bool
 	FailedSeq uint64
@@ -160,6 +163,7 @@ func (p *Projector) Status() ProjectorStatus {
 		LastSeq:          p.lastSeq,
 		StartupTargetSeq: p.startupTargetSeq,
 		StartupComplete:  p.startupCompleted,
+		StartupMessages:  p.startupMessages,
 	}
 	if !p.startupStartedAt.IsZero() {
 		startupEndsAt := p.startupEndedAt
@@ -556,16 +560,51 @@ func (p *Projector) handleMessage(msg jetstream.Msg) {
 		return
 	}
 
+	p.countStartupMessage()
 	p.advance(meta.Sequence.Stream)
 	p.maybeCompleteStartup(time.Now())
 }
 
-func (p *Projector) maybeCompleteStartup(now time.Time) {
+func (p *Projector) countStartupMessage() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	if p.started && p.startupEndedAt.IsZero() {
+		p.startupMessages++
+	}
+}
+
+func (p *Projector) maybeCompleteStartup(now time.Time) {
+	p.mu.Lock()
+	shouldLog := false
+	var duration time.Duration
+	var targetSeq, lastSeq, messages uint64
 	if p.started && p.startupEndedAt.IsZero() && p.lastSeq >= p.startupTargetSeq {
 		p.startupEndedAt = now
 		p.startupCompleted = true
+	}
+	if p.started && p.startupCompleted && !p.startupLogged {
+		p.startupLogged = true
+		shouldLog = true
+		duration = p.startupEndedAt.Sub(p.startupStartedAt)
+		targetSeq = p.startupTargetSeq
+		lastSeq = p.lastSeq
+		messages = p.startupMessages
+	}
+	p.mu.Unlock()
+
+	if shouldLog {
+		var rate float64
+		if seconds := duration.Seconds(); seconds > 0 {
+			rate = float64(messages) / seconds
+		}
+		p.logger.Info("Projection startup complete",
+			"duration", duration,
+			"messages", messages,
+			"messages_per_second", rate,
+			"last_seq", lastSeq,
+			"target_seq", targetSeq,
+			"subjects", p.proj.Subjects(),
+		)
 	}
 }
 


### PR DESCRIPTION
- Add one concise projection startup log line with replay duration, replayed message count, throughput, sequences, and subjects.
- Make thread reply summary updates incremental on the hot reply path while preserving recompute behavior for rarer invalidation cases.
- Trim avoidable room timeline and reaction projection replay work.

Tests:
- `mise x -- go test ./internal/events -count=1`
- `mise x -- go test ./internal/core -count=1`
