### PR TITLE
fix: reconcile in-app notification badges

### DIFF
--- a/cli/internal/core/notifications.go
+++ b/cli/internal/core/notifications.go
@@ -290,6 +290,9 @@ func (c *ChattoCore) publishNotificationCreatedEvent(ctx context.Context, notif 
 		roomID = n.Reply.RoomId
 		eventID = n.Reply.EventId
 		inReplyToID = n.Reply.InReplyToId
+	case *corev1.Notification_RoomMessage:
+		roomID = n.RoomMessage.RoomId
+		eventID = n.RoomMessage.EventId
 	}
 
 	event := newLiveEvent(notif.ActorId, &corev1.LiveEvent{
@@ -343,6 +346,8 @@ func notificationTypeName(notif *corev1.Notification) string {
 		return "mention"
 	case *corev1.Notification_Reply:
 		return "reply"
+	case *corev1.Notification_RoomMessage:
+		return "room_message"
 	default:
 		return "unknown"
 	}

--- a/cli/internal/core/notifications_test.go
+++ b/cli/internal/core/notifications_test.go
@@ -5,11 +5,14 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/protobuf/proto"
+
+	"hmans.de/chatto/internal/core/subjects"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
 func TestCreateNotification(t *testing.T) {
-	core, _ := setupTestCore(t)
+	core, nc := setupTestCore(t)
 	ctx := context.Background()
 
 	recipientID := "recipient-user"
@@ -106,6 +109,53 @@ func TestCreateNotification(t *testing.T) {
 		}
 		if replyNotif.InReplyToId != "root-event" {
 			t.Errorf("Expected in reply to ID root-event, got %s", replyNotif.InReplyToId)
+		}
+	})
+
+	t.Run("publishes room message notification routing context", func(t *testing.T) {
+		subject := subjects.LiveSyncUserEvent(recipientID, "notification_created")
+		sub, err := nc.SubscribeSync(subject)
+		if err != nil {
+			t.Fatalf("SubscribeSync(%s): %v", subject, err)
+		}
+		defer sub.Unsubscribe()
+		if err := nc.Flush(); err != nil {
+			t.Fatalf("Flush subscription: %v", err)
+		}
+
+		created, err := core.CreateNotification(ctx, recipientID, actorID, &corev1.Notification{
+			Notification: &corev1.Notification_RoomMessage{
+				RoomMessage: &corev1.RoomMessageNotification{
+					RoomId:  "all-messages-room",
+					EventId: "all-messages-event",
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("CreateNotification error: %v", err)
+		}
+
+		msg, err := sub.NextMsg(2 * time.Second)
+		if err != nil {
+			t.Fatalf("waiting for notification_created live event: %v", err)
+		}
+
+		var live corev1.LiveEvent
+		if err := proto.Unmarshal(msg.Data, &live); err != nil {
+			t.Fatalf("unmarshal live event: %v", err)
+		}
+		event := live.GetNotificationCreated()
+		if event == nil {
+			t.Fatalf("expected NotificationCreatedEvent, got %T", live.Event)
+		}
+		if event.NotificationId != created.Id {
+			t.Errorf("NotificationId = %q, want %q", event.NotificationId, created.Id)
+		}
+		if event.RoomId != "all-messages-room" {
+			t.Errorf("RoomId = %q, want all-messages-room", event.RoomId)
+		}
+		if event.EventId != "all-messages-event" {
+			t.Errorf("EventId = %q, want all-messages-event", event.EventId)
 		}
 	})
 }
@@ -452,6 +502,15 @@ func TestNotificationTypeName(t *testing.T) {
 				},
 			},
 			expected: "reply",
+		},
+		{
+			name: "room_message",
+			notif: &corev1.Notification{
+				Notification: &corev1.Notification_RoomMessage{
+					RoomMessage: &corev1.RoomMessageNotification{},
+				},
+			},
+			expected: "room_message",
 		},
 		{
 			name:     "unknown",

--- a/cli/internal/graph/subscription_test.go
+++ b/cli/internal/graph/subscription_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"hmans.de/chatto/internal/core"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 	"hmans.de/chatto/internal/testutil"
 )
 
@@ -336,6 +337,65 @@ func TestSubscriptionResolver_MyEvents_DeploymentEvents(t *testing.T) {
 				t.Errorf("Expected room ID %s, got %s", env.testRoom.Id, notifCreated.RoomId)
 			}
 			t.Logf("Successfully received notification created event for mention in room %s", notifCreated.RoomId)
+		}
+	})
+
+	t.Run("receive all-message notification with room routing context", func(t *testing.T) {
+		userB, err := env.core.CreateUser(env.ctx, "system", "all-message-poster", "All Message Poster", "password123")
+		if err != nil {
+			t.Fatalf("Failed to create user B: %v", err)
+		}
+		_, err = env.core.JoinRoom(env.ctx, userB.Id, core.KindChannel, userB.Id, env.testRoom.Id)
+		if err != nil {
+			t.Fatalf("Failed to join room: %v", err)
+		}
+		if err := env.core.SetRoomNotificationLevel(
+			env.ctx,
+			env.testUser.Id,
+			env.testRoom.Id,
+			corev1.NotificationLevel_NOTIFICATION_LEVEL_ALL_MESSAGES,
+		); err != nil {
+			t.Fatalf("SetRoomNotificationLevel: %v", err)
+		}
+
+		subCtx, cancel := context.WithTimeout(env.authContext(), 10*time.Second)
+		defer cancel()
+
+		eventChan, err := env.resolver.Subscription().MyEvents(subCtx)
+		if err != nil {
+			t.Fatalf("Unexpected error subscribing: %v", err)
+		}
+
+		time.Sleep(200 * time.Millisecond)
+
+		posted, err := env.core.PostMessage(
+			env.ctx,
+			core.KindChannel,
+			env.testRoom.Id,
+			userB.Id,
+			"Plain all-message notification trigger",
+			nil,
+			"",
+			"",
+			nil,
+			false,
+		)
+		if err != nil {
+			t.Fatalf("PostMessage: %v", err)
+		}
+
+		event := testutil.WaitForValue(t, eventChan, 2*time.Second, "all-message notification created event", func(event core.EventEnvelope) bool {
+			return event != nil && core.EventNotificationCreated(event) != nil
+		})
+		notifCreated := core.EventNotificationCreated(event)
+		if notifCreated.NotificationId == "" {
+			t.Error("Expected notification ID to be set")
+		}
+		if notifCreated.RoomId != env.testRoom.Id {
+			t.Errorf("Expected room ID %s, got %s", env.testRoom.Id, notifCreated.RoomId)
+		}
+		if notifCreated.EventId != posted.Id {
+			t.Errorf("Expected event ID %s, got %s", posted.Id, notifCreated.EventId)
 		}
 	})
 }

--- a/frontend/e2e/notifications.test.ts
+++ b/frontend/e2e/notifications.test.ts
@@ -142,6 +142,52 @@ test.describe('Mention Notifications', () => {
   });
 });
 
+test.describe('All Messages Notifications', () => {
+  test('plain room messages show room and server notification badges for ALL_MESSAGES subscribers', async ({
+    page,
+    chatPage,
+    notificationsPage,
+    browser,
+    serverURL
+  }) => {
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+
+    await page.goto(routes.settingsNotifications);
+    await expect(page.getByRole('heading', { name: 'Notifications' })).toBeVisible();
+
+    const generalNotificationRow = page.getByTestId('room-notification-general');
+    await expect(generalNotificationRow).toBeVisible();
+    await generalNotificationRow.locator('select').selectOption('ALL_MESSAGES');
+    await expect(page.getByText('Room notification level updated')).toBeVisible({
+      timeout: TIMEOUTS.UI_STANDARD
+    });
+
+    await chatPage.goto();
+    await chatPage.enterRoom('announcements');
+
+    const generalLink = chatPage.roomList.locator('a', { hasText: '# general' });
+    const roomNotificationBadge = generalLink.getByTestId('room-notification-badge');
+    await expect(roomNotificationBadge).not.toBeVisible();
+
+    await withServerUser(browser!, serverURL, async ({ chatPage, roomPage }) => {
+      await chatPage.enterRoom('general');
+      await roomPage.sendMessage(`plain all-messages notification ${Date.now()}`);
+    });
+
+    await expect(roomNotificationBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+    await expect(roomNotificationBadge).toHaveText('1');
+
+    const notificationBadge = serverNotificationBadge(page);
+    await expect(notificationBadge).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+    await expect(notificationBadge).toHaveText('1');
+
+    await notificationsPage.goto();
+    const notification = notificationsPage.getNotificationBySummary('posted a message');
+    await expect(notification).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+  });
+});
+
 test.describe('Thread Reply Notifications (Cascading Indicators)', () => {
   test('thread reply shows indicators on thread, room, and server', async ({
     page,

--- a/frontend/src/lib/components/NotificationSync.svelte
+++ b/frontend/src/lib/components/NotificationSync.svelte
@@ -37,8 +37,10 @@ Include this component once in the chat layout (unconditionally).
         if (!event.event) return;
 
         if (event.event.__typename === 'NotificationCreatedEvent') {
-          notificationStore.addNotification();
-          stores.rooms.incrementUnreadNotification(event.event.roomId);
+          void Promise.allSettled([
+            notificationStore.addNotification(),
+            stores.rooms.refreshNotificationCounts()
+          ]);
           playNotificationSound(
             userPreferences.notificationSound,
             userPreferences.notificationSoundFilters
@@ -48,9 +50,12 @@ Include this component once in the chat layout (unconditionally).
         if (event.event.__typename === 'NotificationDismissedEvent') {
           const roomId = notificationStore.removeNotification(event.event.notificationId);
           if (roomId) {
-            stores.rooms.decrementUnreadNotification(roomId);
+            void stores.rooms.refreshNotificationCounts();
           } else if (!notificationStore.consumeLocalDismissal(event.event.notificationId)) {
-            void Promise.allSettled([notificationStore.fetch(), stores.rooms.refresh()]);
+            void Promise.allSettled([
+              notificationStore.fetch(),
+              stores.rooms.refreshNotificationCounts()
+            ]);
           }
         }
       };

--- a/frontend/src/lib/components/NotificationSync.svelte.spec.ts
+++ b/frontend/src/lib/components/NotificationSync.svelte.spec.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import NotificationSync from './NotificationSync.svelte';
+import type { EventEnvelope, EventHandler } from '$lib/eventBus.svelte';
+
+const { mocks } = vi.hoisted(() => {
+  const bus = {
+    handlers: new Set<EventHandler>(),
+    catchUpHandlers: new Set()
+  };
+  const store = {
+    isAuthenticated: true,
+    notifications: {
+      count: 0,
+      addNotification: vi.fn(() => Promise.resolve()),
+      removeNotification: vi.fn(),
+      consumeLocalDismissal: vi.fn(),
+      fetch: vi.fn(() => Promise.resolve())
+    },
+    rooms: {
+      refreshNotificationCounts: vi.fn(() => Promise.resolve()),
+      incrementUnreadNotification: vi.fn(),
+      decrementUnreadNotification: vi.fn(),
+      refresh: vi.fn()
+    },
+    roomUnread: {
+      hasAnyUnread: false
+    }
+  };
+
+  return {
+    mocks: {
+      bus,
+      store,
+      playNotificationSound: vi.fn(),
+      updateBadge: vi.fn(() => Promise.resolve()),
+      setFlagBadge: vi.fn(() => Promise.resolve()),
+      clearBadge: vi.fn(() => Promise.resolve())
+    }
+  };
+});
+
+vi.mock('$lib/state/server/registry.svelte', () => ({
+  serverRegistry: {
+    servers: [{ id: 'origin' }],
+    getStore: vi.fn(() => mocks.store)
+  }
+}));
+
+vi.mock('$lib/state/server/eventBus.svelte', () => ({
+  eventBusManager: {
+    getBus: vi.fn(() => mocks.bus)
+  }
+}));
+
+vi.mock('$lib/state/userPreferences.svelte', () => ({
+  userPreferences: {
+    notificationSound: 'soft',
+    notificationSoundFilters: {
+      volume: 1,
+      highPassHz: 20,
+      lowPassHz: 20000,
+      echo: 0,
+      reverb: 0,
+      crunch: 0
+    }
+  }
+}));
+
+vi.mock('$lib/audio/notificationSounds', () => ({
+  playNotificationSound: mocks.playNotificationSound
+}));
+
+vi.mock('$lib/notifications/appBadge', () => ({
+  updateBadge: mocks.updateBadge,
+  setFlagBadge: mocks.setFlagBadge,
+  clearBadge: mocks.clearBadge
+}));
+
+function dispatch(event: NonNullable<EventEnvelope['event']>) {
+  const envelope = {
+    id: 'event-id',
+    createdAt: new Date().toISOString(),
+    actorId: 'actor-id',
+    actor: null,
+    event
+  } as EventEnvelope;
+
+  for (const handler of mocks.bus.handlers) {
+    handler(envelope);
+  }
+}
+
+async function renderAndWaitForSubscription() {
+  render(NotificationSync);
+  await vi.waitFor(() => expect(mocks.bus.handlers.size).toBe(1));
+}
+
+describe('NotificationSync', () => {
+  beforeEach(() => {
+    mocks.bus.handlers.clear();
+    mocks.bus.catchUpHandlers.clear();
+    vi.clearAllMocks();
+
+    mocks.store.isAuthenticated = true;
+    mocks.store.notifications.count = 0;
+    mocks.store.roomUnread.hasAnyUnread = false;
+    mocks.store.notifications.addNotification.mockResolvedValue(undefined);
+    mocks.store.notifications.removeNotification.mockReturnValue(null);
+    mocks.store.notifications.consumeLocalDismissal.mockReturnValue(false);
+    mocks.store.notifications.fetch.mockResolvedValue(undefined);
+    mocks.store.rooms.refreshNotificationCounts.mockResolvedValue(undefined);
+  });
+
+  it('reconciles authoritative counts on notification creation instead of incrementing locally', async () => {
+    await renderAndWaitForSubscription();
+
+    dispatch({
+      __typename: 'NotificationCreatedEvent',
+      notificationId: 'n1',
+      roomId: 'room-1',
+      eventId: 'event-1',
+      inReplyToId: null
+    });
+
+    expect(mocks.store.notifications.addNotification).toHaveBeenCalledOnce();
+    expect(mocks.store.rooms.refreshNotificationCounts).toHaveBeenCalledOnce();
+    expect(mocks.store.rooms.incrementUnreadNotification).not.toHaveBeenCalled();
+    expect(mocks.playNotificationSound).toHaveBeenCalledOnce();
+  });
+
+  it('reconciles counts when a cached notification is dismissed elsewhere', async () => {
+    mocks.store.notifications.removeNotification.mockReturnValue('room-1');
+    await renderAndWaitForSubscription();
+
+    dispatch({
+      __typename: 'NotificationDismissedEvent',
+      notificationId: 'n1'
+    });
+
+    expect(mocks.store.notifications.removeNotification).toHaveBeenCalledWith('n1');
+    expect(mocks.store.rooms.refreshNotificationCounts).toHaveBeenCalledOnce();
+    expect(mocks.store.rooms.decrementUnreadNotification).not.toHaveBeenCalled();
+    expect(mocks.store.notifications.fetch).not.toHaveBeenCalled();
+  });
+
+  it('refetches notification state and counts when an uncached remote dismissal arrives', async () => {
+    mocks.store.notifications.removeNotification.mockReturnValue(null);
+    mocks.store.notifications.consumeLocalDismissal.mockReturnValue(false);
+    await renderAndWaitForSubscription();
+
+    dispatch({
+      __typename: 'NotificationDismissedEvent',
+      notificationId: 'unknown-notification'
+    });
+
+    expect(mocks.store.notifications.consumeLocalDismissal).toHaveBeenCalledWith(
+      'unknown-notification'
+    );
+    expect(mocks.store.notifications.fetch).toHaveBeenCalledOnce();
+    expect(mocks.store.rooms.refreshNotificationCounts).toHaveBeenCalledOnce();
+    expect(mocks.store.rooms.refresh).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/state/server/rooms.svelte.spec.ts
+++ b/frontend/src/lib/state/server/rooms.svelte.spec.ts
@@ -275,6 +275,81 @@ describe('RoomsStore - refresh', () => {
     });
   });
 
+  it('refreshes notification counts for an already-loaded room list', async () => {
+    let countQueries = 0;
+    const queryMock = vi.fn((document: unknown) => {
+      if (operationName(document) === 'GetMyServerRoomNotificationCounts') {
+        countQueries++;
+        return {
+          toPromise: () =>
+            Promise.resolve({
+              data: makeCountsResponse({ general: countQueries === 1 ? 1 : 0 }),
+              error: null
+            })
+        };
+      }
+      return {
+        toPromise: () => Promise.resolve({ data: makeResponse([makeRoom('general')]), error: null })
+      };
+    });
+    const store = makeStore({ query: queryMock } as unknown as Client);
+
+    await store.refresh();
+    await vi.waitFor(() => {
+      expect(store.rooms).toMatchObject([{ id: 'general', viewerNotificationCount: 1 }]);
+    });
+
+    await store.refreshNotificationCounts();
+
+    expect(store.rooms).toMatchObject([{ id: 'general', viewerNotificationCount: 0 }]);
+  });
+
+  it('discards out-of-order notification count refresh responses', async () => {
+    let countQueries = 0;
+    let resolveOlder!: (value: { data: NotificationCountsResponse; error: null }) => void;
+    let resolveNewer!: (value: { data: NotificationCountsResponse; error: null }) => void;
+    const queryMock = vi.fn((document: unknown) => {
+      if (operationName(document) === 'GetMyServerRoomNotificationCounts') {
+        countQueries++;
+        if (countQueries === 1) {
+          return {
+            toPromise: () => Promise.resolve({ data: makeCountsResponse({ general: 0 }), error: null })
+          };
+        }
+        if (countQueries === 2) {
+          return {
+            toPromise: () => new Promise((resolve) => (resolveOlder = resolve))
+          };
+        }
+        return {
+          toPromise: () => new Promise((resolve) => (resolveNewer = resolve))
+        };
+      }
+      return {
+        toPromise: () => Promise.resolve({ data: makeResponse([makeRoom('general')]), error: null })
+      };
+    });
+    const store = makeStore({ query: queryMock } as unknown as Client);
+
+    await store.refresh();
+    await vi.waitFor(() => {
+      expect(store.rooms).toMatchObject([{ id: 'general', viewerNotificationCount: 0 }]);
+    });
+
+    const olderRefresh = store.refreshNotificationCounts();
+    const newerRefresh = store.refreshNotificationCounts();
+
+    resolveNewer({ data: makeCountsResponse({ general: 2 }), error: null });
+    await newerRefresh;
+
+    expect(store.rooms).toMatchObject([{ id: 'general', viewerNotificationCount: 2 }]);
+
+    resolveOlder({ data: makeCountsResponse({ general: 1 }), error: null });
+    await olderRefresh;
+
+    expect(store.rooms).toMatchObject([{ id: 'general', viewerNotificationCount: 2 }]);
+  });
+
   it('keeps rooms visible when the optional notification count field is unsupported', async () => {
     const queryMock = vi.fn((document: unknown) => {
       if (operationName(document) === 'GetMyServerRoomNotificationCounts') {

--- a/frontend/src/lib/state/server/rooms.svelte.ts
+++ b/frontend/src/lib/state/server/rooms.svelte.ts
@@ -214,6 +214,7 @@ export class RoomsStore {
   currentUserId = $state<string | null>(null);
 
   private loadId = 0;
+  private notificationCountsLoadId = 0;
 
   constructor(
     private readonly client: Client,
@@ -272,7 +273,7 @@ export class RoomsStore {
         }))
       ];
       this.roomUnread.initRooms([...visibleChannels, ...visibleDms]);
-      void this.refreshNotificationCounts(thisLoad);
+      void this.refreshNotificationCounts();
 
       if (result.data.server.roomGroups) {
         type SetT = (typeof result.data.server.roomGroups)[number];
@@ -290,10 +291,15 @@ export class RoomsStore {
     this.isInitialLoading = false;
   }
 
-  private async refreshNotificationCounts(loadId: number): Promise<void> {
+  async refreshNotificationCounts(): Promise<void> {
+    const loadId = this.loadId;
+    const notificationCountsLoadId = ++this.notificationCountsLoadId;
+
     try {
       const result = await this.client.query(MyRoomNotificationCountsQuery, {}).toPromise();
-      if (this.loadId !== loadId) return;
+      if (this.loadId !== loadId || this.notificationCountsLoadId !== notificationCountsLoadId) {
+        return;
+      }
 
       if (result.error) {
         if (!isUnsupportedGraphQLFieldError(result.error, 'viewerNotifications')) {
@@ -315,7 +321,9 @@ export class RoomsStore {
         }));
       });
     } catch (err) {
-      console.warn('failed to load room notification counts', err);
+      if (this.loadId === loadId && this.notificationCountsLoadId === notificationCountsLoadId) {
+        console.warn('failed to load room notification counts', err);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Include room routing context on live ALL_MESSAGES notification events.
- Reconcile room notification badges from authoritative counts instead of local increment/decrement drift.
- Add backend, component, store, and e2e coverage for ALL_MESSAGES badge behavior.

## Tests

- `go test ./internal/core ./internal/graph`
- `pnpm --dir frontend exec vitest run src/lib/components/NotificationSync.svelte.spec.ts src/lib/state/server/rooms.svelte.spec.ts`
- `pnpm --dir frontend exec playwright test e2e/notifications.test.ts -g "plain room messages show room and server notification badges"`
- `pnpm --dir frontend run check`
- `pnpm --dir frontend run lint`
