### PR TITLE
fix(frontend): prevent room badge clipping

### DIFF
--- a/frontend/src/lib/RoomList.svelte
+++ b/frontend/src/lib/RoomList.svelte
@@ -356,7 +356,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
       <button
         type="button"
         onclick={(e) => handleNotificationBadgeClick(e, room.id, false)}
-        class="-mr-2 flex h-6 min-w-6 cursor-pointer items-center justify-center notification-dot"
+        class="flex h-6 min-w-6 cursor-pointer items-center justify-center notification-dot"
         aria-label={`Go to ${room.viewerNotificationCount} notifications`}
       >
         <NotificationBadge count={room.viewerNotificationCount} testid="room-notification-badge" />
@@ -399,7 +399,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
       <button
         type="button"
         onclick={(e) => handleNotificationBadgeClick(e, room.id, true)}
-        class="-mr-2 flex h-6 min-w-6 cursor-pointer items-center justify-center notification-dot"
+        class="flex h-6 min-w-6 cursor-pointer items-center justify-center notification-dot"
         aria-label={`Go to ${room.viewerNotificationCount} direct message notifications`}
       >
         <NotificationBadge count={room.viewerNotificationCount} testid="dm-notification-badge" />


### PR DESCRIPTION
- Removes the negative right margin from channel and DM room notification badge buttons.
- Keeps badge hit targets inside the clipped sidebar row after the recent menu-entry padding changes.

Checks:
- `npx @sveltejs/mcp svelte-autofixer ./src/lib/RoomList.svelte --svelte-version 5`
- `pnpm exec vitest run src/lib/RoomList.svelte.spec.ts`
- `pnpm run check`
