### PR TITLE
fix(frontend): clear stale mention autocomplete state

### DIFF
--- a/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -199,6 +199,7 @@
 
     if (eventId && originalBody && editSeededForEvent !== eventId) {
       editSeededForEvent = eventId;
+      autocomplete.reset();
       draftState.clearText();
       message = originalBody;
       manualRichMode = false;
@@ -209,6 +210,7 @@
       linkPreviews.clear();
     } else if (editSeededForEvent && !eventId) {
       // Exiting edit mode - clear the input
+      autocomplete.reset();
       message = '';
       manualRichMode = false;
       alsoSendToChannel = false;
@@ -540,6 +542,7 @@
   }
 
   function restorePreparedPost(post: PreparedPost) {
+    autocomplete.reset();
     message = post.bodyToSend;
     manualRichMode = post.wasRichComposer;
     editorApi?.setContent(post.bodyToSend);
@@ -631,6 +634,7 @@
 
     // Optimistically clear the editor so the user can start typing the next
     // message immediately (matches Slack/Discord behavior).
+    autocomplete.reset();
     message = '';
     manualRichMode = false;
     editorApi?.setContent('');
@@ -686,6 +690,7 @@
     if (response.error) {
       toast.error(response.error.message || 'Failed to edit message');
     } else {
+      autocomplete.reset();
       message = '';
       editorApi?.setContent('');
       editState.cancelEdit();
@@ -706,6 +711,7 @@
   }
 
   function cancelEdit() {
+    autocomplete.reset();
     editState.cancelEdit();
     message = '';
     manualRichMode = false;

--- a/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -1061,6 +1061,59 @@ describe('MessageComposer', () => {
       expect(mutationMock).not.toHaveBeenCalled();
     });
 
+    it('closes mention autocomplete when cancelling an edit', async () => {
+      roomStateMock.members = [roomMember('golden_fox07')];
+      roomStateMock.editState.eventId = 'evt_edit';
+      roomStateMock.editState.originalBody = 'original body';
+      const { container } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = await findEditor(container);
+
+      await typeEditorLiteralText(editor, '@gold');
+      await vi.waitFor(() =>
+        expect(container.querySelector('[data-testid="mention-autocomplete"]')).toBeTruthy()
+      );
+
+      const cancelButton = Array.from(container.querySelectorAll('button')).find(
+        (button) => button.textContent?.trim() === 'Cancel'
+      ) as HTMLButtonElement | undefined;
+      expect(cancelButton).toBeTruthy();
+      cancelButton!.click();
+
+      expect(roomStateMock.editState.cancelEdit).toHaveBeenCalledOnce();
+      await vi.waitFor(() =>
+        expect(container.querySelector('[data-testid="mention-autocomplete"]')).toBeNull()
+      );
+    });
+
+    it('closes mention autocomplete after saving an edit', async () => {
+      roomStateMock.members = [roomMember('golden_fox07')];
+      roomStateMock.editState.eventId = 'evt_edit';
+      roomStateMock.editState.originalBody = 'original body';
+      const { container } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = await findEditor(container);
+
+      await typeEditorLiteralText(editor, '@gold');
+      await vi.waitFor(() =>
+        expect(container.querySelector('[data-testid="mention-autocomplete"]')).toBeTruthy()
+      );
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({
+        eventId: 'evt_edit',
+        body: '@gold'
+      });
+      await vi.waitFor(() =>
+        expect(container.querySelector('[data-testid="mention-autocomplete"]')).toBeNull()
+      );
+    });
+
     it('keeps edit mode on rich keyboard behavior', async () => {
       roomStateMock.editState.eventId = 'evt_edit';
       roomStateMock.editState.originalBody = 'original body';

--- a/frontend/src/lib/components/composer/autocomplete.svelte.ts
+++ b/frontend/src/lib/components/composer/autocomplete.svelte.ts
@@ -40,10 +40,14 @@ export class AutocompleteState {
     private readonly getRoles: () => MentionRole[] = () => []
   ) {}
 
-  resetForRoom(): void {
+  reset(): void {
     this.emoji = null;
     this.mention = null;
     this.tabCompletion = null;
+  }
+
+  resetForRoom(): void {
+    this.reset();
   }
 
   update(): void {


### PR DESCRIPTION
- Clear composer autocomplete state whenever TipTap content is programmatically cleared or replaced.
- Keep `resetForRoom()` behavior while adding a reusable `AutocompleteState.reset()` helper.
- Add regression coverage for mention autocomplete closing on edit cancel and edit save.
- Tested with focused Vitest specs, `svelte-check`, ESLint, and a frontend smoke check.
