### PR TITLE
feat(frontend): add display theme preference

### DIFF
--- a/docs/fdr/FDR-022-user-profile.md
+++ b/docs/fdr/FDR-022-user-profile.md
@@ -1,11 +1,11 @@
 # FDR-022: User Profile
 
 **Status:** Active
-**Last reviewed:** 2026-06-15
+**Last reviewed:** 2026-06-19
 
 ## Overview
 
-A user's profile carries the public identity they present to the rest of the server (login, display name, avatar) plus personal settings (timezone, time format). Most of the profile is self-editable; one field — the login — is throttled to discourage identity-confusion abuse, with an admin escape hatch for legitimate needs.
+A user's profile carries the public identity they present to the rest of the server (login, display name, avatar) plus server-synced personal settings (timezone, time format). Most of the profile is self-editable; one field — the login — is throttled to discourage identity-confusion abuse, with an admin escape hatch for legitimate needs. Browser-local display preferences, such as theme, live outside the profile.
 
 ## Behavior
 
@@ -14,6 +14,7 @@ A user's profile carries the public identity they present to the rest of the ser
 - **Case-only changes** (e.g., `alice` → `Alice`) bypass the cooldown.
 - **Avatar** — users upload an image; the server resizes to 256×256 max and stores it as lossless WebP. The old avatar is deleted after the new one is committed. Users can also delete their avatar (falling back to an initial-letter placeholder).
 - **Settings** — currently timezone (IANA name, e.g., `Europe/Berlin`) and time format (browser default / 12-hour / 24-hour). Stored server-side so they sync across devices. If not set, the frontend uses the browser timezone and locale time-format default.
+- **Display theme** — users can choose System, Light, or Dark. System follows the browser or OS color-scheme preference. The choice is browser-local and applies immediately on that device.
 - **Admin overrides** — operators with the right permissions can update other users' profiles, bypass the login cooldown, clear the cooldown so the user can change again before the 30 days expire, and force-delete an avatar.
 
 ## Design Decisions
@@ -44,9 +45,9 @@ A user's profile carries the public identity they present to the rest of the ser
 
 ### 5. Server-side settings, not browser-local
 
-**Decision:** Timezone and time format live in the user's profile (in `User.settings`), synced server-side.
+**Decision:** Timezone and time format live in the user's profile (in `User.settings`), synced server-side. Display theme is browser-local.
 **Why:** A user signing in from a new browser shouldn't have to re-pick their preferences. Local storage works fine for one device; for multi-device users it's actively worse than server-side.
-**Tradeoff:** Every settings change requires a mutation, but settings change rarely so the cost is negligible.
+**Tradeoff:** Every timezone or time-format change requires a mutation, but settings change rarely so the cost is negligible. Theme can differ per browser, which is appropriate for device-specific light/dark preferences but means it does not sync across devices.
 
 ### 6. Browser timezone fallback when unset
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -31,7 +31,7 @@ See [`.claude/skills/fdr/SKILL.md`](../../.claude/skills/fdr/SKILL.md) for the F
 | [FDR-019](FDR-019-room-lifecycle.md) | Room Lifecycle | Active | 2026-06-15 |
 | [FDR-020](FDR-020-server-branding-and-configuration.md) | Server Branding & Configuration | Active | 2026-06-06 |
 | [FDR-021](FDR-021-admin-dashboard.md) | Admin Dashboard & System Monitoring | Active | 2026-06-15 |
-| [FDR-022](FDR-022-user-profile.md) | User Profile | Active | 2026-06-15 |
+| [FDR-022](FDR-022-user-profile.md) | User Profile | Active | 2026-06-19 |
 | [FDR-023](FDR-023-authentication-and-sessions.md) | Authentication & Sessions | Active | 2026-06-19 |
 | [FDR-024](FDR-024-permission-inspection-tool.md) | Permission Inspection Tool | Active | 2026-06-15 |
 | [FDR-025](FDR-025-user-search-and-member-directory.md) | User Search & Member Directory | Active | 2026-05-19 |

--- a/frontend/e2e/user-settings.test.ts
+++ b/frontend/e2e/user-settings.test.ts
@@ -12,6 +12,40 @@ test.describe('User Settings - Display', () => {
     });
   });
 
+  test('can choose a local display theme', async ({ page }) => {
+    await page.emulateMedia({ colorScheme: 'light' });
+    await createAndLoginTestUser(page);
+    await page.goto(routes.settingsPreferences);
+    await expect(page.getByRole('heading', { name: 'Display' })).toBeVisible({
+      timeout: TIMEOUTS.UI_STANDARD
+    });
+
+    const systemOption = page.getByRole('radio', { name: /System/ });
+    const lightOption = page.getByRole('radio', { name: /Light/ });
+    const darkOption = page.getByRole('radio', { name: /Dark/ });
+
+    await expect(systemOption).toHaveAttribute('aria-checked', 'true');
+
+    await darkOption.click();
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+
+    await page.reload();
+    await expect(darkOption).toHaveAttribute('aria-checked', 'true');
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+
+    await lightOption.click();
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
+
+    await systemOption.click();
+    await expect(systemOption).toHaveAttribute('aria-checked', 'true');
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
+
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await page.reload();
+    await expect(systemOption).toHaveAttribute('aria-checked', 'true');
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+  });
+
   test('can set timezone and save', async ({ page }) => {
     await createAndLoginTestUser(page);
     await page.goto(routes.settingsPreferences);

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -18,8 +18,10 @@
  * Theme tokens.
  *
  * The active theme is selected by `data-theme` on `<html>`, which is set by
- * the inline script in `app.html`. That script reads `localStorage.theme` for
- * an explicit override, otherwise mirrors `prefers-color-scheme`.
+ * the inline script in `app.html`. That script reads
+ * `chatto:preferences.displayTheme` for the client-side Display setting,
+ * falls back to legacy `localStorage.theme`, then mirrors
+ * `prefers-color-scheme`.
  *
  * Light is the default (`:root`). Dark applies via the attribute selector,
  * so it wins whenever the script (or Storybook's theme toolbar) has set

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -6,31 +6,48 @@
       // Resolve and apply the active theme as early as possible — before CSS
       // loads — so:
       //   1. The active token set is in place by first paint (no FOUC).
-      //   2. A future "Choose theme" UI can write `localStorage.theme` and
-      //      have it picked up here without waiting for SvelteKit to hydrate.
+      //   2. The client-side Display setting works before SvelteKit hydrates.
       //
-      // Resolution: localStorage.theme ('light' | 'dark') if set, otherwise
-      // the OS-level prefers-color-scheme. Anything else (including 'auto'
-      // or missing) follows the system.
+      // Resolution: chatto:preferences.displayTheme ('system' | 'light' |
+      // 'dark') if set, then legacy localStorage.theme ('light' | 'dark'),
+      // otherwise the OS-level prefers-color-scheme.
       (() => {
         const root = document.documentElement;
         const mq = window.matchMedia('(prefers-color-scheme: dark)');
+
+        function storedPreferenceTheme() {
+          try {
+            const raw = localStorage.getItem('chatto:preferences');
+            if (!raw) return null;
+            const parsed = JSON.parse(raw);
+            const theme = parsed && typeof parsed === 'object' ? parsed.displayTheme : null;
+            return theme === 'system' || theme === 'light' || theme === 'dark' ? theme : null;
+          } catch {
+            return null;
+          }
+        }
+
+        function legacyTheme() {
+          try {
+            const theme = localStorage.getItem('theme');
+            return theme === 'light' || theme === 'dark' ? theme : null;
+          } catch {
+            return null;
+          }
+        }
+
         function apply() {
-          const stored = localStorage.getItem('theme');
+          const stored = storedPreferenceTheme() ?? legacyTheme() ?? 'system';
           const effective =
-            stored === 'light' || stored === 'dark'
-              ? stored
-              : mq.matches
-                ? 'dark'
-                : 'light';
+            stored === 'light' || stored === 'dark' ? stored : mq.matches ? 'dark' : 'light';
           root.dataset.theme = effective;
           // Pre-CSS background hint, mirrors --color-background.
           root.style.backgroundColor = effective === 'dark' ? '#171717' : '#f3f4f6';
         }
         apply();
-        // Live updates when the OS theme changes (only relevant when no
-        // explicit override is stored — apply() recomputes either way).
-        mq.addEventListener('change', apply);
+        mq.addEventListener('change', () => {
+          if ((storedPreferenceTheme() ?? legacyTheme() ?? 'system') === 'system') apply();
+        });
       })();
     </script>
     <!-- OG_META_PLACEHOLDER -->

--- a/frontend/src/appHtml.spec.ts
+++ b/frontend/src/appHtml.spec.ts
@@ -1,22 +1,118 @@
 import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
 import { describe, expect, it } from 'vitest';
 
 const appHtml = readFileSync(new URL('./app.html', import.meta.url), 'utf8');
+const themeScript = appHtml.match(/<script>\s*([\s\S]*?)\s*<\/script>/i)?.[1];
 
 function metaContent(name: string, mediaFragment: string): string | null {
   const tag = appHtml.match(
-    new RegExp(
-      `<meta\\s+[^>]*name="${name}"[^>]*media="[^"]*${mediaFragment}[^"]*"[^>]*>`,
-      'i'
-    )
+    new RegExp(`<meta\\s+[^>]*name="${name}"[^>]*media="[^"]*${mediaFragment}[^"]*"[^>]*>`, 'i')
   )?.[0];
 
   return tag?.match(/\bcontent="([^"]+)"/i)?.[1] ?? null;
+}
+
+function runThemeScript({
+  preferences,
+  legacyTheme,
+  systemDark
+}: {
+  preferences?: unknown;
+  legacyTheme?: string;
+  systemDark: boolean;
+}) {
+  if (!themeScript) throw new Error('theme script not found');
+
+  const storage = new Map<string, string>();
+  if (preferences !== undefined) {
+    storage.set('chatto:preferences', JSON.stringify(preferences));
+  }
+  if (legacyTheme !== undefined) {
+    storage.set('theme', legacyTheme);
+  }
+
+  let dark = systemDark;
+  let changeHandler: (() => void) | undefined;
+  const root = { dataset: {} as Record<string, string>, style: {} as Record<string, string> };
+
+  runInNewContext(themeScript, {
+    document: { documentElement: root },
+    localStorage: {
+      getItem: (key: string) => storage.get(key) ?? null
+    },
+    window: {
+      matchMedia: () => ({
+        get matches() {
+          return dark;
+        },
+        addEventListener: (_type: string, handler: () => void) => {
+          changeHandler = handler;
+        }
+      })
+    }
+  });
+
+  return {
+    root,
+    changeSystemTheme(systemTheme: 'light' | 'dark') {
+      dark = systemTheme === 'dark';
+      changeHandler?.();
+    }
+  };
 }
 
 describe('app.html metadata', () => {
   it('defines theme colors matching the outer frame background colors', () => {
     expect(metaContent('theme-color', 'light')).toBe('#e5e7eb');
     expect(metaContent('theme-color', 'dark')).toBe('#262626');
+  });
+});
+
+describe('app.html theme bootstrap', () => {
+  it('reads chatto:preferences.displayTheme before legacy localStorage.theme', () => {
+    const { root } = runThemeScript({
+      preferences: { displayTheme: 'light' },
+      legacyTheme: 'dark',
+      systemDark: true
+    });
+
+    expect(root.dataset.theme).toBe('light');
+    expect(root.style.backgroundColor).toBe('#f3f4f6');
+  });
+
+  it('uses legacy localStorage.theme when no display preference exists', () => {
+    const { root } = runThemeScript({ legacyTheme: 'dark', systemDark: false });
+    expect(root.dataset.theme).toBe('dark');
+  });
+
+  it('follows prefers-color-scheme when the display preference is system', () => {
+    const { root } = runThemeScript({
+      preferences: { displayTheme: 'system' },
+      systemDark: true
+    });
+
+    expect(root.dataset.theme).toBe('dark');
+  });
+
+  it('follows prefers-color-scheme when no display preference exists', () => {
+    const { root } = runThemeScript({ systemDark: true });
+    expect(root.dataset.theme).toBe('dark');
+  });
+
+  it('only reacts to system theme changes while the display preference is system', () => {
+    const system = runThemeScript({
+      preferences: { displayTheme: 'system' },
+      systemDark: false
+    });
+    system.changeSystemTheme('dark');
+    expect(system.root.dataset.theme).toBe('dark');
+
+    const explicit = runThemeScript({
+      preferences: { displayTheme: 'light' },
+      systemDark: false
+    });
+    explicit.changeSystemTheme('dark');
+    expect(explicit.root.dataset.theme).toBe('light');
   });
 });

--- a/frontend/src/lib/state/userPreferences.svelte.spec.ts
+++ b/frontend/src/lib/state/userPreferences.svelte.spec.ts
@@ -1,15 +1,69 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { defaultNotificationSoundFilters, defaultSoundId } from '$lib/audio/notificationSounds';
-import { UserPreferencesState } from './userPreferences.svelte';
+import { UserPreferencesState, resolveDisplayTheme } from './userPreferences.svelte';
 
 const STORAGE_KEY = 'chatto:preferences';
 
+function mockSystemTheme(theme: 'light' | 'dark') {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((query: string) => ({
+      matches: query === '(prefers-color-scheme: dark)' && theme === 'dark',
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn()
+    }))
+  );
+}
+
 describe('UserPreferencesState', () => {
   beforeEach(() => {
+    vi.unstubAllGlobals();
+    mockSystemTheme('light');
     localStorage.clear();
+    delete document.documentElement.dataset.theme;
+    document.documentElement.style.backgroundColor = '';
   });
 
   describe('initial state', () => {
+    it('uses the system display theme when storage is empty', () => {
+      const state = new UserPreferencesState();
+      expect(state.displayTheme).toBe('system');
+      expect(state.effectiveDisplayTheme).toBe('light');
+    });
+
+    it('resolves the system display theme from prefers-color-scheme', () => {
+      mockSystemTheme('dark');
+      const state = new UserPreferencesState();
+      expect(resolveDisplayTheme(state.displayTheme)).toBe('dark');
+      expect(state.effectiveDisplayTheme).toBe('dark');
+    });
+
+    it.each(['system', 'light', 'dark'] as const)(
+      'hydrates a persisted %s display theme',
+      (displayTheme) => {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify({ displayTheme }));
+        const state = new UserPreferencesState();
+        expect(state.displayTheme).toBe(displayTheme);
+      }
+    );
+
+    it('falls back to system when the stored display theme is invalid', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ displayTheme: 'sepia' }));
+      const state = new UserPreferencesState();
+      expect(state.displayTheme).toBe('system');
+    });
+
+    it('hydrates the legacy localStorage.theme value when no preference exists', () => {
+      localStorage.setItem('theme', 'dark');
+      const state = new UserPreferencesState();
+      expect(state.displayTheme).toBe('dark');
+    });
+
     it('uses the default sound when storage is empty', () => {
       const state = new UserPreferencesState();
       expect(state.notificationSound).toBe(defaultSoundId);
@@ -124,6 +178,39 @@ describe('UserPreferencesState', () => {
   });
 
   describe('mutation', () => {
+    it.each([
+      {
+        displayTheme: 'light' as const,
+        effectiveTheme: 'light' as const,
+        background: 'rgb(243, 244, 246)'
+      },
+      {
+        displayTheme: 'dark' as const,
+        effectiveTheme: 'dark' as const,
+        background: 'rgb(23, 23, 23)'
+      },
+      {
+        displayTheme: 'system' as const,
+        effectiveTheme: 'dark' as const,
+        background: 'rgb(23, 23, 23)'
+      }
+    ])(
+      'updates, persists, and applies the $displayTheme display theme',
+      ({ displayTheme, effectiveTheme, background }) => {
+        mockSystemTheme('dark');
+        const state = new UserPreferencesState();
+
+        state.displayTheme = displayTheme;
+
+        expect(state.displayTheme).toBe(displayTheme);
+        expect(document.documentElement.dataset.theme).toBe(effectiveTheme);
+        expect(document.documentElement.style.backgroundColor).toBe(background);
+
+        const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}');
+        expect(stored.displayTheme).toBe(displayTheme);
+      }
+    );
+
     it('updates and persists the notification sound', () => {
       const state = new UserPreferencesState();
       state.notificationSound = 'pop';

--- a/frontend/src/lib/state/userPreferences.svelte.ts
+++ b/frontend/src/lib/state/userPreferences.svelte.ts
@@ -14,12 +14,17 @@ import {
 } from '$lib/audio/notificationSounds';
 import { Codecs, globalSlot } from '$lib/storage/slot';
 
+export type DisplayTheme = 'system' | 'light' | 'dark';
+type EffectiveTheme = 'light' | 'dark';
+
 interface Preferences {
+  displayTheme: DisplayTheme;
   notificationSound: NotificationSoundId;
   notificationSoundFilters: NotificationSoundFilters;
 }
 
 const defaultPreferences: Preferences = {
+  displayTheme: 'system',
   notificationSound: defaultSoundId,
   notificationSoundFilters: defaultNotificationSoundFilters
 };
@@ -34,6 +39,47 @@ function clampNumber(value: unknown, min: number, max: number, fallback: number)
   if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
   if (value < min || value > max) return fallback;
   return value;
+}
+
+function isDisplayTheme(value: unknown): value is DisplayTheme {
+  return value === 'system' || value === 'light' || value === 'dark';
+}
+
+function getLegacyDisplayTheme(): DisplayTheme | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const legacy = localStorage.getItem('theme');
+    return isDisplayTheme(legacy) && legacy !== 'system' ? legacy : null;
+  } catch {
+    return null;
+  }
+}
+
+function getStoredDisplayTheme(): DisplayTheme | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(slot.key);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) return null;
+    return isDisplayTheme(parsed.displayTheme) ? parsed.displayTheme : null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveDisplayTheme(theme: DisplayTheme): EffectiveTheme {
+  if (theme === 'light' || theme === 'dark') return theme;
+  if (typeof window === 'undefined') return 'light';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+export function applyDisplayTheme(theme: DisplayTheme): void {
+  if (typeof document === 'undefined') return;
+  const effective = resolveDisplayTheme(theme);
+  const root = document.documentElement;
+  root.dataset.theme = effective;
+  root.style.backgroundColor = effective === 'dark' ? '#171717' : '#f3f4f6';
 }
 
 function normalizeNotificationSoundFilters(value: unknown): NotificationSoundFilters {
@@ -58,9 +104,12 @@ function loadPreferences(): Preferences {
   // Validate that the stored sound ID is still valid — silently fall back
   // to the default if the user migrated away from a sound we no longer ship.
   const isValidSound = notificationSounds.some((s) => s.id === stored.notificationSound);
+  const displayTheme =
+    getStoredDisplayTheme() ?? getLegacyDisplayTheme() ?? defaultPreferences.displayTheme;
   return {
     ...defaultPreferences,
     ...stored,
+    displayTheme,
     notificationSound: isValidSound ? stored.notificationSound : defaultSoundId,
     notificationSoundFilters: normalizeNotificationSoundFilters(stored.notificationSoundFilters)
   };
@@ -68,6 +117,21 @@ function loadPreferences(): Preferences {
 
 export class UserPreferencesState {
   #prefs = $state<Preferences>(loadPreferences());
+
+  get displayTheme(): DisplayTheme {
+    return this.#prefs.displayTheme;
+  }
+
+  set displayTheme(value: DisplayTheme) {
+    const displayTheme = isDisplayTheme(value) ? value : defaultPreferences.displayTheme;
+    this.#prefs.displayTheme = displayTheme;
+    slot.set(this.#prefs);
+    applyDisplayTheme(displayTheme);
+  }
+
+  get effectiveDisplayTheme(): EffectiveTheme {
+    return resolveDisplayTheme(this.#prefs.displayTheme);
+  }
 
   get notificationSound(): NotificationSoundId {
     return this.#prefs.notificationSound;

--- a/frontend/src/routes/chat/[serverId]/settings/preferences/+page.svelte
+++ b/frontend/src/routes/chat/[serverId]/settings/preferences/+page.svelte
@@ -3,6 +3,7 @@
   import { graphql } from '$lib/gql';
   import { TimeFormat } from '$lib/gql/graphql';
   import { getUserSettings } from '$lib/state/userSettings.svelte';
+  import { userPreferences, type DisplayTheme } from '$lib/state/userPreferences.svelte';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { PaneHeader, FormSection } from '$lib/ui';
@@ -169,6 +170,28 @@
     }
   }
 
+  const themeOptions: Array<{
+    value: DisplayTheme;
+    label: string;
+    description: string;
+  }> = [
+    {
+      value: 'system',
+      label: 'System',
+      description: 'Follow your browser or OS appearance'
+    },
+    {
+      value: 'light',
+      label: 'Light',
+      description: 'Use the light interface on this browser'
+    },
+    {
+      value: 'dark',
+      label: 'Dark',
+      description: 'Use the dark interface on this browser'
+    }
+  ];
+
   const timeFormatOptions = [
     {
       value: TimeFormat.Auto,
@@ -188,11 +211,47 @@
   ];
 </script>
 
-<PaneHeader title="Display" subtitle="Choose how dates and times appear" showMobileNav />
+<PaneHeader title="Display" subtitle="Choose how Chatto appears" showMobileNav />
 
 <div class="flex flex-col gap-6 overflow-y-auto p-6">
+  <!-- Theme -->
+  <FormSection title="Theme" maxWidth="max-w-md">
+    <div class="flex flex-col gap-2" role="radiogroup" aria-label="Theme">
+      {#each themeOptions as option (option.value)}
+        {@const isSelected = userPreferences.displayTheme === option.value}
+        <button
+          type="button"
+          role="radio"
+          aria-checked={isSelected}
+          class={[
+            'flex cursor-pointer items-center gap-3 rounded-lg border px-3 py-2 text-left transition-colors',
+            isSelected
+              ? 'border-accent bg-accent/10'
+              : 'hover:border-border-highlighted border-border hover:bg-surface-100'
+          ]}
+          onclick={() => (userPreferences.displayTheme = option.value)}
+        >
+          <span
+            class={[
+              'flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-colors',
+              isSelected ? 'border-accent bg-accent' : 'border-muted'
+            ]}
+          >
+            {#if isSelected}
+              <span class="h-2 w-2 rounded-full bg-white"></span>
+            {/if}
+          </span>
+          <div>
+            <div class={isSelected ? 'font-medium' : ''}>{option.label}</div>
+            <div class="text-sm text-muted">{option.description}</div>
+          </div>
+        </button>
+      {/each}
+    </div>
+  </FormSection>
+
   <!-- Timezone -->
-  <FormSection title="Timezone" maxWidth="max-w-md">
+  <FormSection title="Timezone" maxWidth="max-w-md" bordered>
     <p class="mb-3 text-sm text-muted">
       Set your timezone to display timestamps in your local time. Leave empty to use your browser's
       default.


### PR DESCRIPTION
Adds a client-side Display theme preference with System, Light, and Dark options.

- Persists the choice in `chatto:preferences.displayTheme` while keeping legacy `localStorage.theme` as a read-only fallback.
- Applies the selected theme before hydration and from the Display settings page without touching server-side settings.
- Covers bootstrap, preference-store, and user-settings E2E behavior; updates FDR-022 to document browser-local theme behavior.

Validation: targeted theme unit specs, `svelte-check`, targeted user-settings E2E, Svelte autofixer, Chrome DevTools desktop/mobile review.
