### PR TITLE
fix(frontend): make thread badges native links

### DIFF
--- a/docs/fdr/FDR-002-replies-and-threads.md
+++ b/docs/fdr/FDR-002-replies-and-threads.md
@@ -15,6 +15,7 @@ Chatto messages can link to one another via reply attribution, and they can live
 - Clicking the avatar or name in the byline opens the user's context menu.
 - If the user selects text inside a message body before choosing Reply or Reply in thread, the target composer inserts that selected plain text as a Markdown blockquote while preserving any existing draft text.
 - A thread is a sequence of messages starting from a root message and continuing inside a dedicated thread pane. Threads can contain plain messages or reply-attributed messages; both are valid.
+- Thread badges in the room timeline are normal links to the thread URL, so users can copy or open the thread link through browser-native link actions.
 - A user can post a plain message into a room, a reply into the room timeline, a plain message into a thread, or a reply inside a thread — each gated by separate permissions, so a room can be configured for many threading styles.
 
 ## Design Decisions

--- a/frontend/e2e/notifications.test.ts
+++ b/frontend/e2e/notifications.test.ts
@@ -227,10 +227,11 @@ test.describe('Thread Reply Notifications (Cascading Indicators)', () => {
     // 3. Navigate to general room and verify thread has notification indicator
     await chatPage.enterRoom('general');
 
-    // The thread indicator button shows "1 reply" and should have orange dot
-    const threadButton = page.getByRole('button', { name: /1 reply/i });
-    await expect(threadButton).toBeVisible();
-    const threadNotificationDot = threadButton.locator('.bg-warning');
+    // The thread indicator is a native link and should have an orange dot.
+    const threadLink = page.getByRole('link', { name: /1 reply/i });
+    await expect(threadLink).toBeVisible();
+    await expect(threadLink).toHaveAttribute('href', /\/chat\/-\/[^/]+\/[^/]+$/);
+    const threadNotificationDot = threadLink.locator('.bg-warning');
     await expect(threadNotificationDot).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
 
     // 4. Open the thread - notification should be dismissed

--- a/frontend/e2e/threading.test.ts
+++ b/frontend/e2e/threading.test.ts
@@ -277,10 +277,11 @@ test.describe('Message Threading', () => {
     // The message in the main view should show a thread indicator with "1 reply"
     await expect(page.getByText('1 reply')).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
 
-    // The thread indicator button should contain at least one avatar
-    const threadButton = page.getByRole('button', { name: /1 reply/i });
-    await expect(threadButton).toBeVisible();
-    const avatarContainer = threadButton.locator('div.-space-x-1\\.5');
+    // The thread indicator link should contain at least one avatar.
+    const threadLink = page.getByRole('link', { name: /1 reply/i });
+    await expect(threadLink).toBeVisible();
+    await expect(threadLink).toHaveAttribute('href', /\/chat\/-\/[^/]+\/[^/]+$/);
+    const avatarContainer = threadLink.locator('div.-space-x-1\\.5');
     await expect(avatarContainer).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
     const avatarElement = avatarContainer.locator('[aria-label]').first();
     await expect(avatarElement).toBeVisible();

--- a/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -258,6 +258,9 @@
   const editChannelEchoEventId = $derived(
     isEcho ? event.id : (messageEvent?.channelEchoEventId ?? null)
   );
+  const threadRootEventId = $derived(
+    isEcho ? (messageEvent?.echoFromThreadRootEventId ?? null) : event.id
+  );
   const canReconcileChannelEcho = $derived(
     isAuthor &&
       !!editThreadRootEventId &&
@@ -794,6 +797,8 @@
           <MessageMetaBar
             {roomId}
             messageEventId={event.id}
+            serverSegment={serverIdToSegment(getActiveServer())}
+            {threadRootEventId}
             reactions={msg?.reactions ?? []}
             replyCount={messageEvent?.replyCount}
             threadParticipants={messageEvent?.threadParticipants}

--- a/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte
@@ -8,6 +8,8 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
 - `spaceId` - Space ID
 - `roomId` - Room ID
 - `messageEventId` - Event ID of the message
+- `serverSegment` - URL segment for the active server
+- `threadRootEventId` - Root event ID for the linked thread
 - `reactions` - Array of reaction summaries
 - `replyCount` - Number of thread replies
 - `threadParticipants` - Thread participant user fragments (for avatars)
@@ -19,6 +21,7 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
 - `onOpenEmojiPicker` - Callback to open the emoji picker
 -->
 <script lang="ts">
+  import { resolve } from '$app/paths';
   import type { RoomEventViewFragment } from '$lib/gql/graphql';
   import UserAvatar, { UserAvatarFragment } from '$lib/components/UserAvatar.svelte';
   import UnreadDot from '$lib/ui/UnreadDot.svelte';
@@ -43,6 +46,8 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
   let {
     roomId,
     messageEventId,
+    serverSegment,
+    threadRootEventId,
     reactions,
     replyCount = 0,
     threadParticipants,
@@ -56,6 +61,8 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
   }: {
     roomId: string;
     messageEventId: string;
+    serverSegment: string;
+    threadRootEventId?: string | null;
     reactions: ReactionSummary[];
     replyCount?: number;
     threadParticipants?: MessagePostedEvent['threadParticipants'];
@@ -103,20 +110,45 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
       toast.error('Failed to update reaction');
     }
   }
+
+  function openThreadFromLink(e: MouseEvent) {
+    if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+      return;
+    }
+
+    e.preventDefault();
+    onOpenThread?.();
+  }
 </script>
 
 <div class="mt-1 flex flex-wrap items-center gap-1">
   <!-- Echo "Thread" indicator -->
-  {#if isEchoEvent && onOpenThread}
-    <button class="{baseButtonClass} gap-2 border-transparent px-2 text-xs" onclick={onOpenThread}>
+  {#if isEchoEvent && onOpenThread && threadRootEventId}
+    <a
+      href={resolve('/chat/[serverId]/[roomId]/[threadId]', {
+        serverId: serverSegment,
+        roomId,
+        threadId: threadRootEventId
+      })}
+      class="{baseButtonClass} gap-2 border-transparent px-2 text-xs"
+      onclick={openThreadFromLink}
+    >
       <span class="iconify uil--corner-up-right"></span>
       <span>Thread</span>
-    </button>
+    </a>
   {/if}
 
   <!-- Thread reply button -->
-  {#if replyCount > 0 && onOpenThread}
-    <button class="{baseButtonClass} gap-2 border-transparent px-2 text-xs" onclick={onOpenThread}>
+  {#if replyCount > 0 && onOpenThread && threadRootEventId}
+    <a
+      href={resolve('/chat/[serverId]/[roomId]/[threadId]', {
+        serverId: serverSegment,
+        roomId,
+        threadId: threadRootEventId
+      })}
+      class="{baseButtonClass} gap-2 border-transparent px-2 text-xs"
+      onclick={openThreadFromLink}
+    >
       <span class="iconify uil--comment-alt-lines"></span>
       {#if threadParticipants && threadParticipants.length > 0}
         <div class="flex -space-x-1.5">
@@ -135,7 +167,7 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
       {#if hasThreadNotification}
         <UnreadDot />
       {/if}
-    </button>
+    </a>
     {#if onToggleThreadFollow}
       <button
         class={[

--- a/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte
@@ -22,6 +22,7 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
 -->
 <script lang="ts">
   import { resolve } from '$app/paths';
+  import { on } from 'svelte/events';
   import type { RoomEventViewFragment } from '$lib/gql/graphql';
   import UserAvatar, { UserAvatarFragment } from '$lib/components/UserAvatar.svelte';
   import UnreadDot from '$lib/ui/UnreadDot.svelte';
@@ -119,6 +120,24 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
     e.preventDefault();
     onOpenThread?.();
   }
+
+  function stopMessageGesturePropagation(e: Event) {
+    e.stopPropagation();
+  }
+
+  function threadLinkGestureBoundary(el: HTMLAnchorElement) {
+    const removeTouchStart = on(el, 'touchstart', stopMessageGesturePropagation, {
+      capture: true
+    });
+    const removeMouseDown = on(el, 'mousedown', stopMessageGesturePropagation, {
+      capture: true
+    });
+
+    return () => {
+      removeTouchStart();
+      removeMouseDown();
+    };
+  }
 </script>
 
 <div class="mt-1 flex flex-wrap items-center gap-1">
@@ -132,6 +151,7 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
       })}
       class="{baseButtonClass} gap-2 border-transparent px-2 text-xs"
       onclick={openThreadFromLink}
+      {@attach threadLinkGestureBoundary}
     >
       <span class="iconify uil--corner-up-right"></span>
       <span>Thread</span>
@@ -148,6 +168,7 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
       })}
       class="{baseButtonClass} gap-2 border-transparent px-2 text-xs"
       onclick={openThreadFromLink}
+      {@attach threadLinkGestureBoundary}
     >
       <span class="iconify uil--comment-alt-lines"></span>
       {#if threadParticipants && threadParticipants.length > 0}

--- a/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts
@@ -110,6 +110,31 @@ describe('MessageMetaBar', () => {
     expect(onOpenThread).not.toHaveBeenCalled();
   });
 
+  it('does not bubble press-start gestures to the message row', () => {
+    const { container } = render(MessageMetaBar, {
+      props: {
+        ...baseProps,
+        replyCount: 1
+      }
+    });
+    const touchStart = vi.fn();
+    const mouseDown = vi.fn();
+    container.addEventListener('touchstart', touchStart);
+    container.addEventListener('mousedown', mouseDown);
+
+    const link = q(container, 'a[href="/chat/-/room-1/thread-1"]') as HTMLAnchorElement;
+    const touchEvent = new Event('touchstart', { bubbles: true, cancelable: true });
+    const mouseEvent = new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0 });
+
+    expect(link.dispatchEvent(touchEvent)).toBe(true);
+    expect(touchEvent.defaultPrevented).toBe(false);
+    expect(touchStart).not.toHaveBeenCalled();
+
+    expect(link.dispatchEvent(mouseEvent)).toBe(true);
+    expect(mouseEvent.defaultPrevented).toBe(false);
+    expect(mouseDown).not.toHaveBeenCalled();
+  });
+
   it('keeps follow toggles as buttons', () => {
     const { container } = render(MessageMetaBar, {
       props: {

--- a/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { q } from '$lib/test-utils';
+import MessageMetaBar from './MessageMetaBar.svelte';
+
+vi.mock('$app/paths', () => ({
+  resolve: (path: string, params?: Record<string, string>) =>
+    path
+      .replace('[serverId]', params?.serverId ?? '')
+      .replace('[roomId]', params?.roomId ?? '')
+      .replace('[threadId]', params?.threadId ?? '')
+}));
+
+vi.mock('$lib/gql', () => ({
+  graphql: (source: string) => source
+}));
+
+vi.mock('$lib/gql/fragment-masking', () => ({
+  useFragment: (_document: unknown, value: unknown) => value
+}));
+
+vi.mock('$lib/state/server/connection.svelte', () => ({
+  useConnection: () => () => ({
+    client: {
+      mutation: vi.fn().mockResolvedValue({ error: null })
+    }
+  })
+}));
+
+const baseProps = {
+  roomId: 'room-1',
+  messageEventId: 'thread-1',
+  serverSegment: '-',
+  threadRootEventId: 'thread-1',
+  reactions: [],
+  onOpenThread: vi.fn()
+};
+
+describe('MessageMetaBar', () => {
+  it('renders the reply count badge as a native thread link', async () => {
+    const { container } = render(MessageMetaBar, {
+      props: {
+        ...baseProps,
+        replyCount: 2
+      }
+    });
+
+    const link = q(container, 'a[href="/chat/-/room-1/thread-1"]') as HTMLAnchorElement;
+
+    await expect.element(link).toBeInTheDocument();
+    expect(link.textContent?.replace(/\s+/g, ' ').trim()).toContain('2 replies');
+  });
+
+  it('renders the echo thread badge as a native thread link', async () => {
+    const { container } = render(MessageMetaBar, {
+      props: {
+        ...baseProps,
+        isEchoEvent: true
+      }
+    });
+
+    const link = q(container, 'a[href="/chat/-/room-1/thread-1"]') as HTMLAnchorElement;
+
+    await expect.element(link).toBeInTheDocument();
+    expect(link.textContent).toContain('Thread');
+  });
+
+  it('opens the thread through the existing callback for plain primary clicks', () => {
+    const onOpenThread = vi.fn();
+    const { container } = render(MessageMetaBar, {
+      props: {
+        ...baseProps,
+        onOpenThread,
+        replyCount: 1
+      }
+    });
+
+    const link = q(container, 'a[href="/chat/-/room-1/thread-1"]') as HTMLAnchorElement;
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 });
+
+    const allowed = link.dispatchEvent(event);
+
+    expect(allowed).toBe(false);
+    expect(event.defaultPrevented).toBe(true);
+    expect(onOpenThread).toHaveBeenCalledOnce();
+  });
+
+  it('leaves modified clicks to native link behavior', () => {
+    const onOpenThread = vi.fn();
+    const { container } = render(MessageMetaBar, {
+      props: {
+        ...baseProps,
+        onOpenThread,
+        replyCount: 1
+      }
+    });
+
+    const link = q(container, 'a[href="/chat/-/room-1/thread-1"]') as HTMLAnchorElement;
+    const event = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+      metaKey: true
+    });
+
+    const allowed = link.dispatchEvent(event);
+
+    expect(allowed).toBe(true);
+    expect(event.defaultPrevented).toBe(false);
+    expect(onOpenThread).not.toHaveBeenCalled();
+  });
+
+  it('keeps follow toggles as buttons', () => {
+    const { container } = render(MessageMetaBar, {
+      props: {
+        ...baseProps,
+        replyCount: 1,
+        isFollowingThread: true,
+        onToggleThreadFollow: vi.fn()
+      }
+    });
+
+    const followButton = q(container, 'button[title="Unfollow thread"]');
+
+    expect(followButton).not.toBeNull();
+    expect(followButton?.closest('a')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Make thread reply and echo badges native links to the thread route so users can right-click, copy, and open them with browser link actions.
- Preserve existing primary-click behavior by routing ordinary clicks through the current open-thread callback while leaving modified clicks native.
- Stop thread badge touch/mouse press-start events from bubbling into the message row long-press action-sheet handler.
- Add component coverage for link rendering, click handling, and the follow toggle remaining a button.
- Update FDR-002 to document thread badge link behavior.

## Verification

- `npx @sveltejs/mcp svelte-autofixer 'src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte'`
- `pnpm vitest 'src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts' --run`
- `pnpm exec svelte-check --tsconfig ./tsconfig.json --fail-on-warnings`
- `pnpm exec eslint 'src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte' 'src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts'`
- `pnpm exec playwright test e2e/threading.test.ts -g "thread indicator shows reply count and participant avatars"`
- `pnpm exec playwright test e2e/notifications.test.ts -g "thread reply shows indicators on thread, room, and server"`
- `pnpm check`
- `pnpm lint`
- Browser DOM/click check with Chrome DevTools MCP against a temporary local harness.
