### PR TITLE
feat: add LiveKit screen sharing

### DIFF
--- a/docs/fdr/FDR-016-voice-calls.md
+++ b/docs/fdr/FDR-016-voice-calls.md
@@ -5,21 +5,23 @@
 
 ## Overview
 
-Rooms support real-time voice conversations with optional camera video. A phone tab in the room sidebar lets members start or join the room call; the call panel shows participant cards with video-enabled participants first, and provides mute, camera, device-selection, and hang-up controls. Audio and video are routed through LiveKit (an external WebRTC service); Chatto only handles authorization, participant state, and the UI.
+Rooms support real-time voice conversations with optional camera video and video-only screen/window/tab sharing. A phone tab in the room sidebar lets members start or join the room call; the call panel shows screen-share tiles first, then video-enabled participant cards, then compact voice-only participant cards, and provides mute, camera, screen-share, device-selection, and hang-up controls. Audio and video are routed through LiveKit (an external WebRTC service); Chatto only handles authorization, participant state, and the UI.
 
 ## Behavior
 
 - Members of a room with the right permission see a phone tab alongside the room sidebar's members/files tabs when LiveKit is configured.
 - Opening the call tab shows the current room call. If no call is active, it offers a "Start call" action. If a call is active and the viewer has not joined, it shows projected participants as ungrouped participant cards and a "Join call" action.
 - When the current room has an active call, the phone tab is accent-highlighted and pulses while another sidebar tab is selected.
-- Joining the call switches the call tab into participant mode with larger video participant cards before compact voice-only participant cards, without separate Video or Voice section headings. Participant mode exposes speaking indicators, mute state, camera toggle, device selector, and hang-up controls.
-- While the viewer is in any call, the lower-left current-user card shows the active call room plus quick mute, camera, and leave controls so the call remains visible outside the room tab.
+- Joining the call switches the call tab into participant mode with pinned screen-share tiles first, larger camera video participant cards next, and compact voice-only participant cards after that, without separate Video or Voice section headings. Participant mode exposes mute state, camera toggle, screen-share toggle, device selector, and hang-up controls.
+- While the viewer is in any call, the lower-left current-user card shows the active call room plus quick mute, camera, screen-share, and leave controls so the call remains visible outside the room tab.
 - Other rooms with an active call replace the normal room/DM icon with the same accent phone icon and animated pulse twin used by the call tab so members know there's a conversation happening; clicking that icon opens the room with the call tab selected.
 - Message author names show a compact call presence icon when the author is in the current room's active call: phone for voice-only participants, video camera when the viewer has joined the LiveKit call and can see an active camera track.
 - A member's join/leave updates active call indicators and participant lists, but individual participant transitions are not shown as room timeline messages. Explicit user intent is recorded immediately, and LiveKit webhooks/reconciliation confirm or correct the active participant projection.
 - The first join starts a call session and shows a room timeline notice that the member started a call. The final leave ends it and shows a room timeline notice that the active call ended.
 - Hanging up disconnects from LiveKit and clears the participant from everyone else's view.
 - New clients always enable LiveKit E2EE before connecting. Chatto distributes a KMS-backed per-call shared key with the LiveKit join token; the raw key is never written to EVT and is shredded when the call ends.
+- Screen sharing is video-only in Chatto's UI. Browser tab audio sharing is not published by Chatto today.
+- Screen-share state is LiveKit track state only. Users who have not joined the call still see who is in the active call, but they do not see whether a participant is sharing a screen.
 - When LiveKit is not configured on the server, all voice UI is hidden — no button, no panel, no indicator.
 
 ## Design Decisions
@@ -48,11 +50,11 @@ Rooms support real-time voice conversations with optional camera video. A phone 
 **Why:** LiveKit delivers audio data over WebRTC, but the browser doesn't autoplay it without an attached element. Without explicit attach, the UI looks like everything works — participant rings even animate — but nobody hears anything. The pattern lives in `frontend/src/lib/state/voiceCall.svelte.ts`; any refactor that touches LiveKit subscription handling needs to keep the `track.attach()` / `track.detach()` calls intact.
 **Tradeoff:** A subtle requirement that's easy to miss when refactoring; the skill warns explicitly.
 
-### 5. Audio levels poll at ~60ms instead of using ActiveSpeakersChanged
+### 5. Screen sharing is joined-client LiveKit track state
 
-**Decision:** Speaking indicators (avatar rings) read audio levels via a 60ms `setInterval` poll instead of relying on LiveKit's `ActiveSpeakersChanged` event.
-**Why:** `ActiveSpeakersChanged` fires roughly every 100ms — fast enough for "who's talking" but visibly choppy for animated speaker rings. The 60ms poll feels smoother.
-**Tradeoff:** A small recurring poll cost. Worth it for the visual quality.
+**Decision:** Screen/window/tab sharing uses LiveKit's browser screen-share publishing path and is represented only by `Track.Source.ScreenShare` on joined clients. Chatto does not persist separate screen-share events, add GraphQL fields, or expose screen-share state to call observers before they join.
+**Why:** Screen sharing is media-session state, and the existing durable room facts already answer the server-owned question of who is in the call. Keeping screen-share state inside LiveKit avoids adding durable state that can become stale when browser capture ends.
+**Tradeoff:** Non-joined observers know a call is active and who is in it, but not whether someone is sharing. Browser-tab audio sharing is also out of scope for this version.
 
 ### 6. Test endpoints bypass webhook validation in build-tag mode
 

--- a/docs/fdr/FDR-016-voice-calls.md
+++ b/docs/fdr/FDR-016-voice-calls.md
@@ -12,7 +12,7 @@ Rooms support real-time voice conversations with optional camera video and video
 - Members of a room with the right permission see a phone tab alongside the room sidebar's members/files tabs when LiveKit is configured.
 - Opening the call tab shows the current room call. If no call is active, it offers a "Start call" action. If a call is active and the viewer has not joined, it shows projected participants as ungrouped participant cards and a "Join call" action.
 - When the current room has an active call, the phone tab is accent-highlighted and pulses while another sidebar tab is selected.
-- Joining the call switches the call tab into participant mode with pinned screen-share tiles first, larger camera video participant cards next, and compact voice-only participant cards after that, without separate Video or Voice section headings. Participant mode exposes mute state, camera toggle, screen-share toggle, device selector, and hang-up controls.
+- Joining the call switches the call tab into participant mode with pinned screen-share tiles first, larger camera video participant cards next, and compact voice-only participant cards after that, without separate Video or Voice section headings. Participant mode exposes neutral speaking indicators, mute state, camera toggle, screen-share toggle, device selector, and hang-up controls.
 - While the viewer is in any call, the lower-left current-user card shows the active call room plus quick mute, camera, screen-share, and leave controls so the call remains visible outside the room tab.
 - Other rooms with an active call replace the normal room/DM icon with the same accent phone icon and animated pulse twin used by the call tab so members know there's a conversation happening; clicking that icon opens the room with the call tab selected.
 - Message author names show a compact call presence icon when the author is in the current room's active call: phone for voice-only participants, video camera when the viewer has joined the LiveKit call and can see an active camera track.
@@ -50,19 +50,25 @@ Rooms support real-time voice conversations with optional camera video and video
 **Why:** LiveKit delivers audio data over WebRTC, but the browser doesn't autoplay it without an attached element. Without explicit attach, the UI looks like everything works — participant rings even animate — but nobody hears anything. The pattern lives in `frontend/src/lib/state/voiceCall.svelte.ts`; any refactor that touches LiveKit subscription handling needs to keep the `track.attach()` / `track.detach()` calls intact.
 **Tradeoff:** A subtle requirement that's easy to miss when refactoring; the skill warns explicitly.
 
-### 5. Screen sharing is joined-client LiveKit track state
+### 5. Speaking indicators use neutral inline glyphs
+
+**Decision:** Participant cards read audio levels through the existing 60ms cache and show a neutral inline volume glyph for active speakers instead of an accent outline around the card.
+**Why:** The fast audio-level cache gives responsive speaking feedback, while keeping the visual treatment quiet and avoiding the blue outline around participant and screen-share tiles.
+**Tradeoff:** The indicator is intentionally more subtle than the previous animated card outline.
+
+### 6. Screen sharing is joined-client LiveKit track state
 
 **Decision:** Screen/window/tab sharing uses LiveKit's browser screen-share publishing path and is represented only by `Track.Source.ScreenShare` on joined clients. Chatto does not persist separate screen-share events, add GraphQL fields, or expose screen-share state to call observers before they join.
 **Why:** Screen sharing is media-session state, and the existing durable room facts already answer the server-owned question of who is in the call. Keeping screen-share state inside LiveKit avoids adding durable state that can become stale when browser capture ends.
 **Tradeoff:** Non-joined observers know a call is active and who is in it, but not whether someone is sharing. Browser-tab audio sharing is also out of scope for this version.
 
-### 6. Test endpoints bypass webhook validation in build-tag mode
+### 7. Test endpoints bypass webhook validation in build-tag mode
 
 **Decision:** E2E tests use special `/webhooks/test/call-join` and `/webhooks/test/call-leave` endpoints that skip HMAC validation and call the core methods directly. Available only with `-tags test_endpoints`.
 **Why:** Real LiveKit isn't realistic to run in CI, but webhook flow is exactly the thing E2E tests need to exercise. Build-tag gating keeps the endpoints out of production. See ADR-020.
 **Tradeoff:** Two webhook entry points (real + test); test ones are well-isolated and trivially removable from prod builds.
 
-### 7. E2EE keys are KMS-backed per-call secrets
+### 8. E2EE keys are KMS-backed per-call secrets
 
 **Decision:** `voiceCallToken` returns both `token` and `e2eeKey`. The first join for a room creates a new call ID and per-call E2EE key through Chatto's KMS boundary, stores the raw key in `ENCRYPTION_KEYS` under `call.e2ee.{callId}`, and records only the key ref in `CallStartedEvent`. The final leave records `CallEndedEvent` and shreds the key ref. The frontend creates an `ExternalE2EEKeyProvider`, configures the LiveKit E2EE worker, sets the key, enables E2EE, then connects.
 **Why:** LiveKit E2EE key generation/distribution is application responsibility. Chatto already authorizes token access by room membership, so the token resolver is the narrow place to distribute the shared call key. Keeping the raw key out of EVT and normal backups avoids turning event-log copies into permanent decrypt material for captured media.

--- a/frontend/src/lib/components/CurrentUserBar.svelte
+++ b/frontend/src/lib/components/CurrentUserBar.svelte
@@ -134,6 +134,16 @@ to the user settings page for the active server.
         </button>
         <button
           type="button"
+          class={voiceCallState.isScreenShareEnabled ? compactCallButtonClass : compactCallDangerButtonClass}
+          title={voiceCallState.isScreenShareEnabled ? 'Stop sharing screen' : 'Share screen'}
+          aria-label={voiceCallState.isScreenShareEnabled ? 'Stop sharing screen' : 'Share screen'}
+          data-testid="current-user-call-screen-share"
+          onclick={() => voiceCallState.toggleScreenShare()}
+        >
+          <span class="iconify uil--desktop" aria-hidden="true"></span>
+        </button>
+        <button
+          type="button"
           class={compactCallDangerButtonClass}
           title="Leave call"
           aria-label="Leave call"

--- a/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
+++ b/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
@@ -42,8 +42,10 @@ const { currentUserState, voiceCallState, roomsState } = vi.hoisted(() => ({
     roomId: null as string | null,
     isMuted: false,
     isCameraEnabled: false,
+    isScreenShareEnabled: false,
     toggleMute: vi.fn(),
     toggleCamera: vi.fn(),
+    toggleScreenShare: vi.fn(),
     leave: vi.fn()
   },
   roomsState: {
@@ -103,8 +105,10 @@ describe('CurrentUserBar', () => {
     voiceCallState.roomId = null;
     voiceCallState.isMuted = false;
     voiceCallState.isCameraEnabled = false;
+    voiceCallState.isScreenShareEnabled = false;
     voiceCallState.toggleMute.mockClear();
     voiceCallState.toggleCamera.mockClear();
+    voiceCallState.toggleScreenShare.mockClear();
     voiceCallState.leave.mockClear();
     navigation.goto.mockClear();
     roomsState.currentUserId = 'user-1';
@@ -151,6 +155,7 @@ describe('CurrentUserBar', () => {
 
     (q(container, '[data-testid="current-user-call-mute"]') as HTMLButtonElement).click();
     (q(container, '[data-testid="current-user-call-camera"]') as HTMLButtonElement).click();
+    (q(container, '[data-testid="current-user-call-screen-share"]') as HTMLButtonElement).click();
     (q(container, '[data-testid="current-user-call-leave"]') as HTMLButtonElement).click();
 
     expect(navigation.goto).toHaveBeenCalledWith('/chat/-/room-1');
@@ -163,6 +168,7 @@ describe('CurrentUserBar', () => {
     expect(storageEvents[0].newValue).toBe('call');
     expect(voiceCallState.toggleMute).toHaveBeenCalledOnce();
     expect(voiceCallState.toggleCamera).toHaveBeenCalledOnce();
+    expect(voiceCallState.toggleScreenShare).toHaveBeenCalledOnce();
     expect(voiceCallState.leave).toHaveBeenCalledOnce();
     window.removeEventListener('storage', listener);
   });

--- a/frontend/src/lib/components/voice/VideoThumbnail.svelte
+++ b/frontend/src/lib/components/voice/VideoThumbnail.svelte
@@ -17,6 +17,7 @@ resolution to request for sidebar-width tiles.
 - `name` - Participant display name (shown as tooltip)
 - `user` - User object for the avatar overlay (same shape as UserAvatar's `user` prop)
 - `showIdentityOverlay` - Whether to show the avatar overlay
+- `fit` - How the video track should fit the tile. Camera thumbnails default to `cover`; screen shares should use `contain` to avoid cropping shared content.
 -->
 <script lang="ts">
 	import { onDestroy } from 'svelte';
@@ -28,7 +29,8 @@ resolution to request for sidebar-width tiles.
 		track,
 		name,
 		user,
-		showIdentityOverlay = true
+		showIdentityOverlay = true,
+		fit = 'cover'
 	}: {
 		track: Track;
 		name: string;
@@ -40,6 +42,7 @@ resolution to request for sidebar-width tiles.
 			presenceStatus: PresenceStatus;
 		};
 		showIdentityOverlay?: boolean;
+		fit?: 'cover' | 'contain';
 	} = $props();
 
 	let videoEl = $state<HTMLVideoElement | null>(null);
@@ -82,7 +85,7 @@ resolution to request for sidebar-width tiles.
 		bind:this={videoEl}
 		width="640"
 		height="360"
-		class="h-full w-full object-cover"
+		class={['h-full w-full', fit === 'contain' ? 'object-contain' : 'object-cover']}
 		title={name}
 		autoplay
 		playsinline

--- a/frontend/src/lib/components/voice/VoiceCallPanel.svelte
+++ b/frontend/src/lib/components/voice/VoiceCallPanel.svelte
@@ -7,7 +7,7 @@ Room sidebar panel for voice/video calls.
 - **Observer mode**: Call is active but user hasn't joined. Shows participants
   from server state and a Join button.
 - **Participant mode**: User is connected to LiveKit. Shows live audio levels,
-  mute toggle, audio device selector, and hang-up button.
+  mute toggle, camera/screen-share controls, audio device selector, and hang-up button.
 
 **Props:**
 - `roomId` - The room ID
@@ -31,6 +31,7 @@ Room sidebar panel for voice/video calls.
   import AudioDeviceMenu from './AudioDeviceMenu.svelte';
   import UserContextMenu from '$lib/components/menus/UserContextMenu.svelte';
   import type { Track } from 'livekit-client';
+  import type { Attachment } from 'svelte/attachments';
   import { startDMWith } from '$lib/dm/startDM';
   import { toast } from '$lib/ui/toast';
 
@@ -186,6 +187,51 @@ Room sidebar panel for voice/video calls.
     return participant.displayName;
   }
 
+  const speakingCards: Array<{ identity: string; node: HTMLElement }> = [];
+  let speakingIndicatorInterval: ReturnType<typeof setInterval> | null = null;
+
+  function updateSpeakingIndicators() {
+    for (const { identity, node } of speakingCards) {
+      const indicator = node.querySelector<HTMLElement>('[data-speaking-indicator]');
+      if (!indicator) continue;
+
+      const { isSpeaking, audioLevel } = voiceCallState.getAudioLevel(identity);
+      const opacity = audioLevel > 0.01 ? 0.35 + Math.pow(audioLevel, 0.35) * 0.65 : 0;
+      const visible = isSpeaking || opacity > 0;
+
+      indicator.style.opacity = visible ? String(opacity || 0.85) : '0';
+      indicator.setAttribute('aria-hidden', visible ? 'false' : 'true');
+    }
+  }
+
+  function startSpeakingIndicatorLoop() {
+    if (speakingIndicatorInterval) return;
+
+    speakingIndicatorInterval = setInterval(updateSpeakingIndicators, 60);
+  }
+
+  function stopSpeakingIndicatorLoopIfIdle() {
+    if (speakingCards.length > 0 || !speakingIndicatorInterval) return;
+
+    clearInterval(speakingIndicatorInterval);
+    speakingIndicatorInterval = null;
+  }
+
+  function speakingCard(identity: string): Attachment<HTMLElement> {
+    return (node) => {
+      const entry = { identity, node };
+      speakingCards.push(entry);
+      updateSpeakingIndicators();
+      startSpeakingIndicatorLoop();
+
+      return () => {
+        const index = speakingCards.indexOf(entry);
+        if (index !== -1) speakingCards.splice(index, 1);
+        stopSpeakingIndicatorLoopIfIdle();
+      };
+    };
+  }
+
   // DM start capability
   const serverPerms = getServerPermissions();
   const canStartDMs = $derived(serverPerms.current.canStartDMs);
@@ -233,6 +279,7 @@ Room sidebar panel for voice/video calls.
         'participant-card flex w-full cursor-pointer flex-col overflow-hidden rounded-md border border-border bg-surface-100 text-left text-text transition-colors hover:bg-surface-200',
         mode === 'video' ? 'participant-card-video' : 'participant-card-compact'
       ]}
+      {@attach speakingCard(participant.key)}
       title={participantTitle(participant)}
       data-testid="call-participant-card"
       onclick={(e) => showUserMenu(participant, e)}
@@ -244,6 +291,13 @@ Room sidebar panel for voice/video calls.
           {#if participant.isMuted}
             <span class="iconify uil--microphone-slash text-danger" aria-label="Muted"></span>
           {/if}
+          <span
+            class="iconify uil--volume-up text-muted opacity-0 transition-opacity"
+            aria-label="Speaking"
+            aria-hidden="true"
+            data-speaking-indicator
+            data-testid="call-speaking-indicator"
+          ></span>
           {#if hasConnectionWarning(participant)}
             <span
               class="iconify uil--exclamation-triangle"

--- a/frontend/src/lib/components/voice/VoiceCallPanel.svelte
+++ b/frontend/src/lib/components/voice/VoiceCallPanel.svelte
@@ -369,6 +369,7 @@ Room sidebar panel for voice/video calls.
         name={`${participant.displayName}'s screen`}
         user={participant.avatarUser}
         showIdentityOverlay={false}
+        fit="contain"
       />
     </div>
   </button>

--- a/frontend/src/lib/components/voice/VoiceCallPanel.svelte
+++ b/frontend/src/lib/components/voice/VoiceCallPanel.svelte
@@ -102,6 +102,8 @@ Room sidebar panel for voice/video calls.
     connectionQuality: string;
     isCameraEnabled: boolean;
     videoTrack: Track | null;
+    isScreenShareEnabled: boolean;
+    screenShareTrack: Track | null;
   };
 
   let participants: DisplayParticipant[] = $derived.by(() => {
@@ -119,7 +121,9 @@ Room sidebar panel for voice/video calls.
         isMuted: p.isMuted,
         connectionQuality: p.connectionQuality,
         isCameraEnabled: p.isCameraEnabled,
-        videoTrack: p.videoTrack
+        videoTrack: p.videoTrack,
+        isScreenShareEnabled: p.isScreenShareEnabled,
+        screenShareTrack: p.screenShareTrack
       }));
     }
 
@@ -136,7 +140,9 @@ Room sidebar panel for voice/video calls.
       isMuted: false,
       connectionQuality: 'unknown',
       isCameraEnabled: false,
-      videoTrack: null
+      videoTrack: null,
+      isScreenShareEnabled: false,
+      screenShareTrack: null
     }));
   });
 
@@ -147,7 +153,11 @@ Room sidebar panel for voice/video calls.
       return 0;
     })
   );
+  let screenShareParticipants = $derived(
+    sortedParticipants.filter((p) => p.isScreenShareEnabled && p.screenShareTrack)
+  );
   let videoParticipants = $derived(sortedParticipants.filter((p) => p.isCameraEnabled && p.videoTrack));
+  let mediaTileCount = $derived(screenShareParticipants.length + videoParticipants.length);
   let isIdle = $derived(!hasActiveCall && !isInThisCall);
   let joinLabel = $derived.by(() => {
     if (isConnecting) return hasActiveCall ? 'Joining...' : 'Starting...';
@@ -158,6 +168,10 @@ Room sidebar panel for voice/video calls.
 
   function hasVideo(participant: DisplayParticipant) {
     return participant.isCameraEnabled && participant.videoTrack;
+  }
+
+  function hasScreenShare(participant: DisplayParticipant) {
+    return participant.isScreenShareEnabled && participant.screenShareTrack;
   }
 
   function hasConnectionWarning(participant: DisplayParticipant) {
@@ -171,46 +185,6 @@ Room sidebar panel for voice/video calls.
 
     return participant.displayName;
   }
-
-  // --- Imperative audio level ring animation ---
-  // Reads from voiceCallState.getAudioLevel() (non-reactive) and directly
-  // mutates DOM elements at ~60ms. Completely bypasses Svelte's reactive graph.
-  // eslint-disable-next-line svelte/prefer-svelte-reactivity -- imperative DOM ref map, not read reactively
-  const buttonRefs = new Map<string, HTMLElement>();
-
-  function trackButton(node: HTMLElement, identity: string) {
-    buttonRefs.set(identity, node);
-    return {
-      update(newIdentity: string) {
-        buttonRefs.delete(identity);
-        identity = newIdentity;
-        buttonRefs.set(identity, node);
-      },
-      destroy() {
-        buttonRefs.delete(identity);
-      }
-    };
-  }
-
-  $effect(() => {
-    if (!isInThisCall) return;
-
-    const interval = setInterval(() => {
-      for (const [identity, button] of buttonRefs) {
-        const { isSpeaking, audioLevel } = voiceCallState.getAudioLevel(identity);
-        const ringOpacity = audioLevel > 0.01 ? 0.3 + Math.pow(audioLevel, 0.3) * 0.7 : 0;
-        button.style.setProperty('--ring-opacity', String(ringOpacity));
-        button.classList.toggle('voice-ring-speaking', ringOpacity > 0);
-
-        // Also update muted ring (muted + speaking should show speaking ring)
-        if (button.classList.contains('voice-ring-muted') && isSpeaking) {
-          button.classList.remove('voice-ring-muted');
-        }
-      }
-    }, 60);
-
-    return () => clearInterval(interval);
-  });
 
   // DM start capability
   const serverPerms = getServerPermissions();
@@ -256,11 +230,9 @@ Room sidebar panel for voice/video calls.
     <button
       type="button"
       class={[
-        'participant-card voice-ring voice-ring-card flex w-full cursor-pointer flex-col overflow-hidden rounded-md border border-border bg-surface-100 text-left text-text transition-colors hover:bg-surface-200',
-        mode === 'video' ? 'participant-card-video' : 'participant-card-compact',
-        participant.isMuted && 'voice-ring-muted'
+        'participant-card flex w-full cursor-pointer flex-col overflow-hidden rounded-md border border-border bg-surface-100 text-left text-text transition-colors hover:bg-surface-200',
+        mode === 'video' ? 'participant-card-video' : 'participant-card-compact'
       ]}
-      use:trackButton={participant.key}
       title={participantTitle(participant)}
       data-testid="call-participant-card"
       onclick={(e) => showUserMenu(participant, e)}
@@ -324,13 +296,37 @@ Room sidebar panel for voice/video calls.
   {/if}
 {/snippet}
 
+{#snippet screenShareCard(participant: DisplayParticipant)}
+  <button
+    type="button"
+    class="participant-card participant-card-video @min-[368px]:col-span-2 flex w-full cursor-pointer flex-col overflow-hidden rounded-md border border-border bg-surface-100 text-left text-text transition-colors hover:bg-surface-200"
+    title={`${participant.displayName}'s screen`}
+    data-testid="call-screen-share-card"
+    onclick={(e) => showUserMenu(participant, e)}
+  >
+    <div class="flex min-w-0 items-center gap-2 p-2">
+      <UserAvatar user={participant.avatarUser} size="sm" showPresence={false} />
+      <span class="min-w-0 flex-1 truncate text-sm font-medium">{participant.displayName}'s screen</span>
+      <span class="iconify uil--desktop shrink-0 text-muted" aria-label="Screen share"></span>
+    </div>
+    <div class="p-2 pt-0">
+      <VideoThumbnail
+        track={participant.screenShareTrack!}
+        name={`${participant.displayName}'s screen`}
+        user={participant.avatarUser}
+        showIdentityOverlay={false}
+      />
+    </div>
+  </button>
+{/snippet}
+
 <div
   class="flex min-h-0 flex-1 flex-col"
   data-testid={isInThisCall ? 'call-participant-panel' : 'call-observer-panel'}
 >
   <div class="border-b border-border bg-background p-3">
     {#if isInThisCall}
-      <div class="grid grid-cols-4 gap-2">
+      <div class="grid grid-cols-5 gap-2">
         <button
           type="button"
           class={controlButtonClass}
@@ -378,6 +374,17 @@ Room sidebar panel for voice/video calls.
 
         <button
           type="button"
+          class={voiceCallState.isScreenShareEnabled ? controlButtonClass : dangerControlButtonClass}
+          title={voiceCallState.isScreenShareEnabled ? 'Stop sharing screen' : 'Share screen'}
+          aria-label={voiceCallState.isScreenShareEnabled ? 'Stop sharing screen' : 'Share screen'}
+          data-testid="call-screen-share-toggle"
+          onclick={() => voiceCallState.toggleScreenShare()}
+        >
+          <span class="iconify uil--desktop text-lg" aria-hidden="true"></span>
+        </button>
+
+        <button
+          type="button"
           class={dangerControlButtonClass}
           onclick={() => voiceCallState.leave()}
           title="Leave call"
@@ -407,10 +414,15 @@ Room sidebar panel for voice/video calls.
         <div
           class={[
             'grid grid-cols-1 gap-3',
-            isInThisCall && videoParticipants.length > 1 && '@min-[368px]:grid-cols-2'
+            isInThisCall && mediaTileCount > 1 && '@min-[368px]:grid-cols-2'
           ]}
           data-testid="call-participants-list"
         >
+          {#each screenShareParticipants as participant (`${participant.key}:screen`)}
+            {#if hasScreenShare(participant)}
+              {@render screenShareCard(participant)}
+            {/if}
+          {/each}
           {#each sortedParticipants as participant (participant.key)}
             {@render participantCard(participant, isInThisCall && hasVideo(participant) ? 'video' : 'compact')}
           {/each}
@@ -433,34 +445,3 @@ Room sidebar panel for voice/video calls.
     onClose={closeUserMenu}
   />
 {/if}
-
-<style>
-  .voice-ring {
-    position: relative;
-    outline: 0 solid transparent;
-    outline-offset: 0;
-    transition:
-      outline-color 150ms ease-out,
-      outline-width 150ms ease-out,
-      outline-offset 150ms ease-out;
-  }
-
-  .voice-ring-muted {
-    outline-color: var(--color-danger);
-  }
-
-  .voice-ring-card {
-    border-radius: 0.5rem;
-  }
-
-  /* Applied imperatively via classList.toggle() in the 60ms audio level loop */
-  .voice-ring:global(.voice-ring-speaking) {
-    outline-color: color-mix(
-      in srgb,
-      var(--color-accent) calc(var(--ring-opacity, 0) * 100%),
-      var(--color-border)
-    );
-    outline-width: calc(2px + var(--ring-opacity, 0) * 2.5px);
-    outline-offset: calc(1px + var(--ring-opacity, 0) * 2px);
-  }
-</style>

--- a/frontend/src/lib/state/server/voiceCall.svelte.spec.ts
+++ b/frontend/src/lib/state/server/voiceCall.svelte.spec.ts
@@ -4,8 +4,20 @@ import { VoiceCallState } from './voiceCall.svelte';
 const calls: string[] = [];
 let lastRoomOptions: Record<string, unknown> | null = null;
 let lastKeyProvider: { setKey: ReturnType<typeof vi.fn> } | null = null;
-let lastRoom: { disconnect: ReturnType<typeof vi.fn> } | null = null;
+let lastRoom: {
+  disconnect: ReturnType<typeof vi.fn>;
+  localParticipant: {
+    setScreenShareEnabled: ReturnType<typeof vi.fn>;
+    setCameraEnabled: ReturnType<typeof vi.fn>;
+  };
+} | null = null;
 let connectFailure: Error | null = null;
+let screenShareFailure: Error | null = null;
+let roomEventHandlers = new Map<string, () => void>();
+let localTrackPublications: Array<{
+  isMuted: boolean;
+  track: { source: string; mediaStreamTrack?: MediaStreamTrack };
+}> = [];
 
 vi.mock('livekit-client', () => {
   class MockExternalE2EEKeyProvider {
@@ -27,6 +39,31 @@ vi.mock('livekit-client', () => {
       setMicrophoneEnabled: vi.fn(async () => {
         calls.push('setMicrophoneEnabled');
       }),
+      setCameraEnabled: vi.fn(async (enabled: boolean) => {
+        calls.push(`setCameraEnabled:${enabled}`);
+        localTrackPublications = localTrackPublications.filter((pub) => pub.track.source !== 'camera');
+        if (enabled) {
+          localTrackPublications.push({
+            isMuted: false,
+            track: { source: 'camera' }
+          });
+        }
+      }),
+      setScreenShareEnabled: vi.fn(async (enabled: boolean) => {
+        calls.push(`setScreenShareEnabled:${enabled}`);
+        if (screenShareFailure) {
+          throw screenShareFailure;
+        }
+        localTrackPublications = localTrackPublications.filter(
+          (pub) => pub.track.source !== 'screen_share'
+        );
+        if (enabled) {
+          localTrackPublications.push({
+            isMuted: false,
+            track: { source: 'screen_share' }
+          });
+        }
+      }),
       getTrackPublication: vi.fn(),
       identity: 'local-user',
       name: 'Local User',
@@ -34,16 +71,19 @@ vi.mock('livekit-client', () => {
       connectionQuality: 'excellent',
       isSpeaking: false,
       audioLevel: 0,
-      getTrackPublications: vi.fn(() => [])
+      getTrackPublications: vi.fn(() => localTrackPublications)
     };
     remoteParticipants = new Map();
 
     constructor(options: Record<string, unknown>) {
       lastRoomOptions = options;
-      lastRoom = { disconnect: this.disconnect };
+      lastRoom = { disconnect: this.disconnect, localParticipant: this.localParticipant };
     }
 
-    on = vi.fn();
+    on = vi.fn((event: string, handler: () => void) => {
+      roomEventHandlers.set(event, handler);
+      return this;
+    });
     connect = vi.fn(async () => {
       calls.push('connect');
       if (connectFailure) {
@@ -71,11 +111,13 @@ vi.mock('livekit-client', () => {
       TrackSubscribed: 'TrackSubscribed',
       TrackUnsubscribed: 'TrackUnsubscribed',
       TrackPublished: 'TrackPublished',
-      TrackUnpublished: 'TrackUnpublished'
+      TrackUnpublished: 'TrackUnpublished',
+      LocalTrackPublished: 'LocalTrackPublished',
+      LocalTrackUnpublished: 'LocalTrackUnpublished'
     },
     Track: {
       Kind: { Audio: 'audio' },
-      Source: { Microphone: 'microphone', Camera: 'camera' }
+      Source: { Microphone: 'microphone', Camera: 'camera', ScreenShare: 'screen_share' }
     },
     AudioPresets: { speech: {} },
     VideoPresets: { h720: { resolution: {} } }
@@ -88,6 +130,27 @@ vi.mock('livekit-client/e2ee-worker?worker', () => ({
   }
 }));
 
+function createVoiceCallClient() {
+  return {
+    mutation: vi.fn(() => ({
+      toPromise: vi.fn(async () => ({ data: { joinVoiceCall: true } }))
+    })),
+    query: vi.fn(() => ({
+      toPromise: vi.fn(async () => ({
+        data: {
+          room: {
+            voiceCallToken: {
+              token: 'livekit-token',
+              e2eeKey: 'shared-e2ee-key',
+              callId: 'call-1'
+            }
+          }
+        }
+      }))
+    }))
+  };
+}
+
 describe('VoiceCallState', () => {
   beforeEach(() => {
     calls.length = 0;
@@ -95,6 +158,9 @@ describe('VoiceCallState', () => {
     lastKeyProvider = null;
     lastRoom = null;
     connectFailure = null;
+    screenShareFailure = null;
+    roomEventHandlers = new Map();
+    localTrackPublications = [];
   });
 
   afterEach(() => {
@@ -297,5 +363,90 @@ describe('VoiceCallState', () => {
     expect(lastRoom?.disconnect).toHaveBeenCalledOnce();
     expect(client.mutation).toHaveBeenCalledTimes(1);
     expect(state.isInAnyCall).toBe(false);
+  });
+
+  it('toggles video-only screen sharing through LiveKit', async () => {
+    const client = createVoiceCallClient();
+    const state = new VoiceCallState(client as never);
+    await state.join('wss://livekit.example.test', 'R1');
+
+    await state.toggleScreenShare();
+
+    expect(lastRoom?.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(true);
+    expect(state.isScreenShareEnabled).toBe(true);
+    expect(state.participants[0]).toMatchObject({
+      identity: 'local-user',
+      isCameraEnabled: false,
+      isScreenShareEnabled: true
+    });
+    expect(state.participants[0].videoTrack).toBeNull();
+    expect(state.participants[0].screenShareTrack).toMatchObject(localTrackPublications[0].track);
+
+    await state.toggleScreenShare();
+
+    expect(lastRoom?.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(false);
+    expect(state.isScreenShareEnabled).toBe(false);
+    expect(state.participants[0].screenShareTrack).toBeNull();
+  });
+
+  it('keeps the call connected when screen capture fails', async () => {
+    const client = createVoiceCallClient();
+    const state = new VoiceCallState(client as never);
+    await state.join('wss://livekit.example.test', 'R1');
+    screenShareFailure = new Error('permission denied');
+
+    await state.toggleScreenShare();
+
+    expect(lastRoom?.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(true);
+    expect(state.isScreenShareEnabled).toBe(false);
+    expect(state.isInAnyCall).toBe(true);
+    expect(state.roomId).toBe('R1');
+  });
+
+  it('keeps camera and screen-share tracks separate', async () => {
+    const client = createVoiceCallClient();
+    const state = new VoiceCallState(client as never);
+    await state.join('wss://livekit.example.test', 'R1');
+
+    await state.toggleCamera();
+    const cameraTrack = localTrackPublications.find((pub) => pub.track.source === 'camera')!.track;
+    await state.toggleScreenShare();
+    const screenShareTrack = localTrackPublications.find(
+      (pub) => pub.track.source === 'screen_share'
+    )!.track;
+
+    expect(state.participants[0]).toMatchObject({
+      isCameraEnabled: true,
+      isScreenShareEnabled: true
+    });
+    expect(state.participants[0].videoTrack).toMatchObject(cameraTrack);
+    expect(state.participants[0].screenShareTrack).toMatchObject(screenShareTrack);
+    expect(cameraTrack).not.toBe(screenShareTrack);
+  });
+
+  it('clears screen-share state on leave', async () => {
+    const client = createVoiceCallClient();
+    const state = new VoiceCallState(client as never);
+    await state.join('wss://livekit.example.test', 'R1');
+    await state.toggleScreenShare();
+
+    await state.leave();
+
+    expect(state.isScreenShareEnabled).toBe(false);
+    expect(state.participants).toEqual([]);
+  });
+
+  it('updates screen-share state when LiveKit reports local unpublish', async () => {
+    const client = createVoiceCallClient();
+    const state = new VoiceCallState(client as never);
+    await state.join('wss://livekit.example.test', 'R1');
+    await state.toggleScreenShare();
+    expect(state.isScreenShareEnabled).toBe(true);
+
+    localTrackPublications = [];
+    roomEventHandlers.get('LocalTrackUnpublished')?.();
+
+    expect(state.isScreenShareEnabled).toBe(false);
+    expect(state.participants[0].screenShareTrack).toBeNull();
   });
 });

--- a/frontend/src/lib/state/server/voiceCall.svelte.ts
+++ b/frontend/src/lib/state/server/voiceCall.svelte.ts
@@ -3,7 +3,7 @@
  *
  * Per-instance class that wraps livekit-client's Room instance.
  * Handles joining/leaving calls, mute toggle, camera toggle,
- * and audio/video device selection.
+ * screen share toggle, and audio/video device selection.
  */
 
 import {
@@ -31,6 +31,8 @@ export type CallParticipantInfo = {
   connectionQuality: 'excellent' | 'good' | 'poor' | 'lost' | 'unknown';
   isCameraEnabled: boolean;
   videoTrack: Track | null;
+  isScreenShareEnabled: boolean;
+  screenShareTrack: Track | null;
 };
 
 /** Non-reactive audio level snapshot, read imperatively by the UI at ~60ms. */
@@ -84,6 +86,7 @@ export class VoiceCallState {
 
   // Video state — camera is always disabled by default
   isCameraEnabled = $state(false);
+  isScreenShareEnabled = $state(false);
 
   // Participants (including local)
   participants = $state<CallParticipantInfo[]>([]);
@@ -110,8 +113,7 @@ export class VoiceCallState {
   private audioLevelInterval: ReturnType<typeof setInterval> | null = null;
   private suppressDisconnectToast = false;
 
-  // Non-reactive audio level cache — updated at 60ms by the polling interval,
-  // read imperatively by VoiceCallPanel to drive the speaking ring animation.
+  // Non-reactive audio level cache — updated at 60ms by the polling interval.
   // Deliberately NOT $state to avoid triggering Svelte reactivity at 60Hz.
   // eslint-disable-next-line svelte/prefer-svelte-reactivity -- deliberately non-reactive, polled imperatively at 60Hz
   private audioLevelCache = new Map<string, AudioLevelInfo>();
@@ -378,6 +380,22 @@ export class VoiceCallState {
   }
 
   /**
+   * Toggle video-only screen/window/tab sharing.
+   */
+  async toggleScreenShare(): Promise<void> {
+    if (!this.room) return;
+
+    const newEnabled = !this.isScreenShareEnabled;
+    try {
+      await this.room.localParticipant.setScreenShareEnabled(newEnabled);
+      this.isScreenShareEnabled = newEnabled;
+    } catch {
+      this.isScreenShareEnabled = newEnabled ? false : this.isScreenShareEnabled;
+    }
+    this.updateParticipants();
+  }
+
+  /**
    * Refresh available audio and video devices.
    */
   async refreshDevices(): Promise<void> {
@@ -515,9 +533,16 @@ export class VoiceCallState {
       this.updateParticipants();
     });
 
-    // Poll audio levels at ~60ms for smooth visual feedback.
-    // ActiveSpeakersChanged fires at ~100ms which is slightly too coarse
-    // for buttery equalizer animation.
+    this.room.on(RoomEvent.LocalTrackPublished, () => {
+      this.updateParticipants();
+    });
+
+    this.room.on(RoomEvent.LocalTrackUnpublished, () => {
+      this.updateParticipants();
+    });
+
+    // Keep audio level snapshots fresh for call UI consumers without pushing
+    // 60Hz updates through Svelte's reactive graph.
     this.audioLevelInterval = setInterval(() => {
       this.updateAudioLevels();
     }, 60);
@@ -533,6 +558,8 @@ export class VoiceCallState {
       this.room.localParticipant,
       ...Array.from(this.room.remoteParticipants.values())
     ];
+    this.isCameraEnabled = isParticipantCameraEnabled(this.room.localParticipant);
+    this.isScreenShareEnabled = isParticipantScreenShareEnabled(this.room.localParticipant);
 
     this.participants = allParticipants.map((p) => {
       const md = parseParticipantMetadata(p.metadata);
@@ -545,7 +572,9 @@ export class VoiceCallState {
         isLocal: p === this.room!.localParticipant,
         connectionQuality: p.connectionQuality as CallParticipantInfo['connectionQuality'],
         isCameraEnabled: isParticipantCameraEnabled(p),
-        videoTrack: getParticipantVideoTrack(p)
+        videoTrack: getParticipantCameraTrack(p),
+        isScreenShareEnabled: isParticipantScreenShareEnabled(p),
+        screenShareTrack: getParticipantScreenShareTrack(p)
       };
     });
   }
@@ -553,7 +582,7 @@ export class VoiceCallState {
   /**
    * Update the non-reactive audio level cache. Called at ~60ms.
    * Writes to a plain Map (not $state) so Svelte's reactive graph is
-   * completely untouched — the UI reads this imperatively via getAudioLevel().
+   * completely untouched.
    */
   private updateAudioLevels(): void {
     if (!this.room) return;
@@ -660,6 +689,7 @@ export class VoiceCallState {
     this.roomId = null;
     this.isMuted = false;
     this.isCameraEnabled = false;
+    this.isScreenShareEnabled = false;
     this.participants = [];
     this.audioDevices = [];
     this.selectedDeviceId = null;
@@ -700,9 +730,27 @@ function isParticipantCameraEnabled(participant: Participant): boolean {
   return false;
 }
 
-function getParticipantVideoTrack(participant: Participant): Track | null {
+function getParticipantCameraTrack(participant: Participant): Track | null {
   for (const pub of participant.getTrackPublications()) {
     if (pub.track?.source === Track.Source.Camera && !pub.isMuted) {
+      return pub.track;
+    }
+  }
+  return null;
+}
+
+function isParticipantScreenShareEnabled(participant: Participant): boolean {
+  for (const pub of participant.getTrackPublications()) {
+    if (pub.track?.source === Track.Source.ScreenShare) {
+      return !pub.isMuted;
+    }
+  }
+  return false;
+}
+
+function getParticipantScreenShareTrack(participant: Participant): Track | null {
+  for (const pub of participant.getTrackPublications()) {
+    if (pub.track?.source === Track.Source.ScreenShare && !pub.isMuted) {
       return pub.track;
     }
   }

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -46,7 +46,7 @@ const callStore = vi.hoisted(() => ({
     toggleCamera: vi.fn().mockResolvedValue(undefined),
     toggleScreenShare: vi.fn().mockResolvedValue(undefined),
     refreshDevices: vi.fn().mockResolvedValue(undefined),
-    getAudioLevel: vi.fn(() => ({ isSpeaking: false, audioLevel: 0 })),
+    getAudioLevel: vi.fn((_identity?: string) => ({ isSpeaking: false, audioLevel: 0 })),
     handleParticipantLeftEvent: vi.fn(),
     handleCallEndedEvent: vi.fn()
   },
@@ -339,6 +339,7 @@ describe('RoomSidebar', () => {
     callStore.voiceCall.toggleScreenShare.mockClear();
     callStore.voiceCall.refreshDevices.mockClear();
     callStore.voiceCall.getAudioLevel.mockClear();
+    callStore.voiceCall.getAudioLevel.mockImplementation(() => ({ isSpeaking: false, audioLevel: 0 }));
     callStore.activeCallRooms.active = false;
     callStore.activeCallRooms.load.mockClear();
     callStore.activeCallRooms.has.mockClear();
@@ -550,6 +551,50 @@ describe('RoomSidebar', () => {
     expect(callStore.voiceCall.toggleCamera).toHaveBeenCalledOnce();
     expect(callStore.voiceCall.toggleScreenShare).toHaveBeenCalledOnce();
     expect(callStore.voiceCall.leave).toHaveBeenCalledOnce();
+  });
+
+  it('shows a neutral speaking indicator for active speakers', async () => {
+    callStore.voiceCall.connected = true;
+    callStore.voiceCall.isInAnyCall = true;
+    callStore.voiceCall.roomId = 'room-1';
+    callStore.voiceCall.getAudioLevel.mockImplementation((identity?: string) => ({
+      isSpeaking: identity === 'viewer',
+      audioLevel: identity === 'viewer' ? 0.5 : 0
+    }));
+    callStore.voiceCall.participants = [
+      {
+        identity: 'viewer',
+        login: 'alice',
+        name: 'Alice',
+        avatarUrl: null,
+        isMuted: false,
+        isLocal: true,
+        connectionQuality: 'excellent',
+        isCameraEnabled: false,
+        videoTrack: null,
+        isScreenShareEnabled: false,
+        screenShareTrack: null
+      }
+    ];
+
+    const { container } = render(RoomSidebarTestHarness, {
+      props: {
+        roomData: roomData([], 0, false),
+        activePanel: 'call',
+        livekitUrl: 'wss://livekit.example.test'
+      }
+    });
+
+    const card = q(container, '[data-testid="call-participant-card"]') as HTMLElement;
+    const indicator = q(container, '[data-testid="call-speaking-indicator"]') as HTMLElement;
+
+    await vi.waitFor(() => {
+      expect(callStore.voiceCall.getAudioLevel).toHaveBeenCalledWith('viewer');
+      expect(indicator.getAttribute('aria-hidden')).toBe('false');
+      expect(Number(indicator.style.opacity)).toBeGreaterThan(0);
+    });
+    expect(indicator.className).toContain('text-muted');
+    expect(card.className).not.toContain('voice-ring');
   });
 
   it('renders one participant list without empty section labels', async () => {

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -17,6 +17,7 @@ const callStore = vi.hoisted(() => ({
     isInAnyCall: false,
     isMuted: false,
     isCameraEnabled: false,
+    isScreenShareEnabled: false,
     participants: [] as Array<{
       identity: string;
       name: string;
@@ -27,6 +28,8 @@ const callStore = vi.hoisted(() => ({
       connectionQuality: 'excellent' | 'good' | 'poor' | 'lost' | 'unknown';
       isCameraEnabled: boolean;
       videoTrack: unknown;
+      isScreenShareEnabled: boolean;
+      screenShareTrack: unknown;
     }>,
     audioDevices: [],
     audioOutputDevices: [],
@@ -41,6 +44,7 @@ const callStore = vi.hoisted(() => ({
     leave: vi.fn().mockResolvedValue(undefined),
     toggleMute: vi.fn().mockResolvedValue(undefined),
     toggleCamera: vi.fn().mockResolvedValue(undefined),
+    toggleScreenShare: vi.fn().mockResolvedValue(undefined),
     refreshDevices: vi.fn().mockResolvedValue(undefined),
     getAudioLevel: vi.fn(() => ({ isSpeaking: false, audioLevel: 0 })),
     handleParticipantLeftEvent: vi.fn(),
@@ -325,12 +329,14 @@ describe('RoomSidebar', () => {
     callStore.voiceCall.isInAnyCall = false;
     callStore.voiceCall.isMuted = false;
     callStore.voiceCall.isCameraEnabled = false;
+    callStore.voiceCall.isScreenShareEnabled = false;
     callStore.voiceCall.participants = [];
     callStore.voiceCall.isInCall.mockClear();
     callStore.voiceCall.join.mockClear();
     callStore.voiceCall.leave.mockClear();
     callStore.voiceCall.toggleMute.mockClear();
     callStore.voiceCall.toggleCamera.mockClear();
+    callStore.voiceCall.toggleScreenShare.mockClear();
     callStore.voiceCall.refreshDevices.mockClear();
     callStore.voiceCall.getAudioLevel.mockClear();
     callStore.activeCallRooms.active = false;
@@ -493,7 +499,9 @@ describe('RoomSidebar', () => {
         isLocal: true,
         connectionQuality: 'excellent',
         isCameraEnabled: true,
-        videoTrack
+        videoTrack,
+        isScreenShareEnabled: false,
+        screenShareTrack: null
       },
       {
         identity: 'user-2',
@@ -504,7 +512,9 @@ describe('RoomSidebar', () => {
         isLocal: false,
         connectionQuality: 'good',
         isCameraEnabled: false,
-        videoTrack: null
+        videoTrack: null,
+        isScreenShareEnabled: false,
+        screenShareTrack: null
       }
     ];
 
@@ -532,11 +542,13 @@ describe('RoomSidebar', () => {
 
     (q(container, '[data-testid="call-mute-toggle"]') as HTMLButtonElement).click();
     (q(container, '[data-testid="call-camera-toggle"]') as HTMLButtonElement).click();
+    (q(container, '[data-testid="call-screen-share-toggle"]') as HTMLButtonElement).click();
     (q(container, '[data-testid="call-leave-button"]') as HTMLButtonElement).click();
     await tick();
 
     expect(callStore.voiceCall.toggleMute).toHaveBeenCalledOnce();
     expect(callStore.voiceCall.toggleCamera).toHaveBeenCalledOnce();
+    expect(callStore.voiceCall.toggleScreenShare).toHaveBeenCalledOnce();
     expect(callStore.voiceCall.leave).toHaveBeenCalledOnce();
   });
 
@@ -558,7 +570,9 @@ describe('RoomSidebar', () => {
         isLocal: true,
         connectionQuality: 'excellent',
         isCameraEnabled: true,
-        videoTrack
+        videoTrack,
+        isScreenShareEnabled: false,
+        screenShareTrack: null
       }
     ];
 
@@ -576,6 +590,82 @@ describe('RoomSidebar', () => {
     const participantList = q(container, '[data-testid="call-participants-list"]');
     expect(participantList).toBeTruthy();
     expect(participantList!.className).not.toContain('@min-[368px]:grid-cols-2');
+  });
+
+  it('pins screen-share tiles before camera and voice participant cards', async () => {
+    const screenShareTrack = {
+      attach: vi.fn(),
+      detach: vi.fn()
+    };
+    const cameraTrack = {
+      attach: vi.fn(),
+      detach: vi.fn()
+    };
+    callStore.voiceCall.connected = true;
+    callStore.voiceCall.isInAnyCall = true;
+    callStore.voiceCall.roomId = 'room-1';
+    callStore.voiceCall.participants = [
+      {
+        identity: 'viewer',
+        login: 'alice',
+        name: 'Alice',
+        avatarUrl: null,
+        isMuted: false,
+        isLocal: true,
+        connectionQuality: 'excellent',
+        isCameraEnabled: false,
+        videoTrack: null,
+        isScreenShareEnabled: true,
+        screenShareTrack
+      },
+      {
+        identity: 'user-2',
+        login: 'bob',
+        name: 'Bob',
+        avatarUrl: null,
+        isMuted: false,
+        isLocal: false,
+        connectionQuality: 'good',
+        isCameraEnabled: true,
+        videoTrack: cameraTrack,
+        isScreenShareEnabled: false,
+        screenShareTrack: null
+      },
+      {
+        identity: 'user-3',
+        login: 'carol',
+        name: 'Carol',
+        avatarUrl: null,
+        isMuted: false,
+        isLocal: false,
+        connectionQuality: 'good',
+        isCameraEnabled: false,
+        videoTrack: null,
+        isScreenShareEnabled: false,
+        screenShareTrack: null
+      }
+    ];
+
+    const { container } = render(RoomSidebarTestHarness, {
+      props: {
+        roomData: roomData([], 0, false),
+        activePanel: 'call',
+        livekitUrl: 'wss://livekit.example.test'
+      }
+    });
+
+    const participantList = q(container, '[data-testid="call-participants-list"]');
+    expect(participantList).toBeTruthy();
+    const cards = Array.from(participantList!.children);
+    expect(cards[0].getAttribute('data-testid')).toBe('call-screen-share-card');
+    expect(cards[0].textContent).toContain("Alice's screen");
+    expect(cards[1].getAttribute('data-testid')).toBe('call-participant-card');
+    expect(cards[1].textContent).toContain('Bob');
+    expect(cards[2].getAttribute('data-testid')).toBe('call-participant-card');
+    expect(cards[2].textContent).toContain('Alice');
+    expect(cards[3].getAttribute('data-testid')).toBe('call-participant-card');
+    expect(cards[3].textContent).toContain('Carol');
+    expect(participantList!.className).toContain('@min-[368px]:grid-cols-2');
   });
 
   it('uses a two-column video grid when multiple videos have room', async () => {
@@ -600,7 +690,9 @@ describe('RoomSidebar', () => {
         isLocal: true,
         connectionQuality: 'excellent',
         isCameraEnabled: true,
-        videoTrack: videoTrackA
+        videoTrack: videoTrackA,
+        isScreenShareEnabled: false,
+        screenShareTrack: null
       },
       {
         identity: 'user-2',
@@ -611,7 +703,9 @@ describe('RoomSidebar', () => {
         isLocal: false,
         connectionQuality: 'good',
         isCameraEnabled: true,
-        videoTrack: videoTrackB
+        videoTrack: videoTrackB,
+        isScreenShareEnabled: false,
+        screenShareTrack: null
       }
     ];
 

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -704,8 +704,10 @@ describe('RoomSidebar', () => {
     const cards = Array.from(participantList!.children);
     expect(cards[0].getAttribute('data-testid')).toBe('call-screen-share-card');
     expect(cards[0].textContent).toContain("Alice's screen");
+    expect(cards[0].querySelector('video')?.className).toContain('object-contain');
     expect(cards[1].getAttribute('data-testid')).toBe('call-participant-card');
     expect(cards[1].textContent).toContain('Bob');
+    expect(cards[1].querySelector('video')?.className).toContain('object-cover');
     expect(cards[2].getAttribute('data-testid')).toBe('call-participant-card');
     expect(cards[2].textContent).toContain('Alice');
     expect(cards[3].getAttribute('data-testid')).toBe('call-participant-card');


### PR DESCRIPTION
## Changes

- Add frontend LiveKit screen-share state, toggling, participant mapping, and cleanup for video-only screen/window/tab sharing.
- Add call-panel and current-user-bar screen-share controls, with pinned screen-share tiles before camera and voice participants.
- Update voice-call tests and FDR-016 to document screen sharing as joined-client LiveKit track state only.

## Validation

- `mise x -- pnpm test:unit --run --project client src/lib/state/server/voiceCall.svelte.spec.ts 'src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts' src/lib/components/CurrentUserBar.svelte.spec.ts`
- `mise x -- pnpm check`
- `mise x -- pnpm lint`
- `mise x -- pnpm exec playwright test e2e/voice-call.spec.ts --retries=0`
