### PR TITLE
fix: remove graphql error logging

### DIFF
--- a/cli/internal/http_server/graphql.go
+++ b/cli/internal/http_server/graphql.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	"github.com/vektah/gqlparser/v2/ast"
-	"github.com/vektah/gqlparser/v2/gqlerror"
 	"hmans.de/chatto/internal/assets"
 	"hmans.de/chatto/internal/graph"
 	"hmans.de/chatto/internal/graph/auth"
@@ -49,11 +48,6 @@ func (s *HTTPServer) setupGraphQLAPI(allowedOrigins []string) {
 	h.AroundFields(graph.DefaultAuthFieldMiddleware)
 
 	graphqlLogger := s.logger.WithPrefix("graphql")
-	h.SetErrorPresenter(func(ctx context.Context, err error) *gqlerror.Error {
-		gqlErr := graphql.DefaultErrorPresenter(ctx, err)
-		logGraphQLError(ctx, graphqlLogger, gqlErr, err)
-		return gqlErr
-	})
 
 	// Add request timing middleware
 	h.AroundOperations(func(ctx context.Context, next graphql.OperationHandler) graphql.ResponseHandler {
@@ -242,63 +236,6 @@ func (s *HTTPServer) setupGraphQLAPI(allowedOrigins []string) {
 	s.router.GET("/api/playground", func(c *gin.Context) {
 		p.ServeHTTP(c.Writer, c.Request)
 	})
-}
-
-func logGraphQLError(ctx context.Context, logger *log.Logger, gqlErr *gqlerror.Error, err error) {
-	if gqlErr == nil {
-		return
-	}
-	if err == nil {
-		err = gqlErr
-	}
-
-	operationName, operationType := graphQLOperationDetails(ctx)
-
-	userID := ""
-	if user := auth.ForContext(ctx); user != nil {
-		userID = user.Id
-	}
-
-	keyvals := []any{
-		"error", err,
-		"message", gqlErr.Message,
-		"path", gqlErr.Path.String(),
-		"operation", operationName,
-		"type", operationType,
-		"userId", userID,
-	}
-	if len(gqlErr.Locations) > 0 {
-		keyvals = append(keyvals, "locations", gqlErr.Locations)
-	}
-	if gqlErr.Rule != "" {
-		keyvals = append(keyvals, "rule", gqlErr.Rule)
-	}
-
-	logger.Error("GraphQL operation failed", keyvals...)
-}
-
-func graphQLOperationDetails(ctx context.Context) (operationName, operationType string) {
-	defer func() {
-		if recover() != nil {
-			operationName = ""
-			operationType = ""
-		}
-	}()
-
-	oc := graphql.GetOperationContext(ctx)
-	if oc == nil {
-		return "", ""
-	}
-
-	operationName = oc.OperationName
-	if oc.Operation != nil {
-		operationType = string(oc.Operation.Operation)
-		if operationName == "" {
-			operationName = oc.Operation.Name
-		}
-	}
-
-	return operationName, operationType
 }
 
 func limitGraphQLJSONRequestBody(c *gin.Context) bool {

--- a/cli/internal/http_server/graphql_test.go
+++ b/cli/internal/http_server/graphql_test.go
@@ -820,17 +820,8 @@ func TestGraphQL_ErrorFormat(t *testing.T) {
 	}
 
 	logs := logOutput.String()
-	if !strings.Contains(logs, `"level":"error"`) {
-		t.Fatalf("Expected GraphQL error to be logged at error level, got logs: %s", logs)
-	}
-	if !strings.Contains(logs, `"prefix":"graphql"`) {
-		t.Fatalf("Expected GraphQL error log to use graphql prefix, got logs: %s", logs)
-	}
-	if !strings.Contains(logs, `"msg":"GraphQL operation failed"`) {
-		t.Fatalf("Expected GraphQL error log message, got logs: %s", logs)
-	}
-	if !strings.Contains(logs, "thisFieldDoesNotExist") {
-		t.Fatalf("Expected GraphQL error log to include validation error, got logs: %s", logs)
+	if strings.Contains(logs, `"msg":"GraphQL operation failed"`) {
+		t.Fatalf("Expected invalid GraphQL request not to emit removed error log, got logs: %s", logs)
 	}
 }
 


### PR DESCRIPTION
- Removed the custom GraphQL error presenter that logged every GraphQL response error as `GraphQL operation failed`.
- Kept gqlgen's default error response behavior unchanged.
- Updated the HTTP server GraphQL error-format test to guard against reintroducing the removed log message.

Tests:
- `mise x -- go test -tags test_endpoints ./internal/http_server -run TestGraphQL_ErrorFormat -timeout 60s`
- `mise x -- go test -tags test_endpoints ./internal/http_server -timeout 120s`
