### PR TITLE
fix: downgrade invalid session cookie logs

### DIFF
--- a/cli/internal/http_server/server.go
+++ b/cli/internal/http_server/server.go
@@ -145,7 +145,7 @@ func (s *HTTPServer) setupRoutes() error {
 
 	// Configure session middleware
 	authKey := []byte(s.config.Webserver.CookieSigningSecret)
-	var sessionStore cookie.Store
+	var sessionStore sessions.Store
 	encKey, err := s.config.Webserver.CookieEncryptionKey()
 	if err != nil {
 		return err
@@ -157,6 +157,7 @@ func (s *HTTPServer) setupRoutes() error {
 		sessionStore = cookie.NewStore(authKey)
 	}
 	sessionStore.Options(cookieSessionOptions(s.config.Auth.TokenTTLOrDefault(), strings.HasPrefix(s.config.Webserver.URL, "https")))
+	sessionStore = newDebugSessionStore(sessionStore, s.logger)
 	s.router.Use(sessions.Sessions("chatto_session", sessionStore))
 
 	// Build allowed origins list once and share between CORS middleware and WebSocket CheckOrigin

--- a/cli/internal/http_server/session_store.go
+++ b/cli/internal/http_server/session_store.go
@@ -1,0 +1,54 @@
+package http_server
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/charmbracelet/log"
+	ginsessions "github.com/gin-contrib/sessions"
+	"github.com/gorilla/securecookie"
+	gsessions "github.com/gorilla/sessions"
+)
+
+type debugSessionStore struct {
+	ginsessions.Store
+	logger *log.Logger
+}
+
+func newDebugSessionStore(store ginsessions.Store, logger *log.Logger) ginsessions.Store {
+	return &debugSessionStore{
+		Store:  store,
+		logger: logger,
+	}
+}
+
+func (s *debugSessionStore) Get(r *http.Request, name string) (*gsessions.Session, error) {
+	session, err := s.Store.Get(r, name)
+	if err == nil {
+		return session, nil
+	}
+
+	if isExpectedSessionCookieDecodeError(err) && session != nil {
+		s.logger.Debug("Ignoring invalid session cookie",
+			"cookieName", name,
+			"hasCookie", hasCookieNamed(r, name),
+			"reason", err.Error(),
+		)
+		return session, nil
+	}
+
+	return session, err
+}
+
+func isExpectedSessionCookieDecodeError(err error) bool {
+	var secureCookieErr securecookie.Error
+	return errors.As(err, &secureCookieErr) &&
+		secureCookieErr.IsDecode() &&
+		!secureCookieErr.IsUsage() &&
+		!secureCookieErr.IsInternal()
+}
+
+func hasCookieNamed(r *http.Request, name string) bool {
+	_, err := r.Cookie(name)
+	return err == nil
+}

--- a/cli/internal/http_server/session_store_test.go
+++ b/cli/internal/http_server/session_store_test.go
@@ -1,0 +1,148 @@
+package http_server
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/log"
+	ginsessions "github.com/gin-contrib/sessions"
+	"github.com/gin-contrib/sessions/cookie"
+	"github.com/gorilla/securecookie"
+	gsessions "github.com/gorilla/sessions"
+)
+
+func TestDebugSessionStoreSuppressesSecureCookieDecodeErrors(t *testing.T) {
+	const cookieName = "chatto_session"
+	authKey := []byte("test-secret-key-32-bytes-long!!")
+	baseStore := cookie.NewStore(authKey)
+
+	var logOutput bytes.Buffer
+	store := newDebugSessionStore(baseStore, log.NewWithOptions(&logOutput, log.Options{
+		Level:     log.DebugLevel,
+		Formatter: log.JSONFormatter,
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{
+		Name: cookieName,
+		Value: expiredSecureCookieValue(t, authKey, cookieName, map[interface{}]interface{}{
+			sessionKeyUserID: "user_123",
+		}),
+	})
+
+	session, err := store.Get(req, cookieName)
+	if err != nil {
+		t.Fatalf("Get returned error for expired securecookie: %v", err)
+	}
+	if session == nil {
+		t.Fatal("Get returned nil session")
+	}
+	if !session.IsNew {
+		t.Fatal("expired securecookie session was not treated as a new session")
+	}
+	if len(session.Values) != 0 {
+		t.Fatalf("expired securecookie session kept values: %#v", session.Values)
+	}
+
+	logged := logOutput.String()
+	if !strings.Contains(logged, "Ignoring invalid session cookie") {
+		t.Fatalf("debug log did not include expected message: %s", logged)
+	}
+	if !strings.Contains(logged, `"level":"debug"`) {
+		t.Fatalf("log was not emitted at debug level: %s", logged)
+	}
+	if !strings.Contains(logged, "securecookie: expired timestamp") {
+		t.Fatalf("debug log did not include securecookie reason: %s", logged)
+	}
+	if strings.Contains(logged, `"level":"error"`) || strings.Contains(logged, "[sessions] ERROR!") {
+		t.Fatalf("expired securecookie was logged as an error: %s", logged)
+	}
+}
+
+func TestDebugSessionStoreReturnsNonDecodeErrors(t *testing.T) {
+	expectedErr := errors.New("store failed")
+	baseStore := &failingSessionStore{err: expectedErr}
+
+	var logOutput bytes.Buffer
+	store := newDebugSessionStore(baseStore, log.NewWithOptions(&logOutput, log.Options{
+		Level:     log.DebugLevel,
+		Formatter: log.JSONFormatter,
+	}))
+
+	_, err := store.Get(httptest.NewRequest(http.MethodGet, "/", nil), "chatto_session")
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("Get error = %v, want %v", err, expectedErr)
+	}
+	if logOutput.Len() != 0 {
+		t.Fatalf("unexpected log output for non-decode error: %s", logOutput.String())
+	}
+}
+
+func TestDebugSessionStoreReturnsSecureCookieUsageErrors(t *testing.T) {
+	var values map[interface{}]interface{}
+	expectedErr := securecookie.New(nil, nil).Decode("chatto_session", "invalid", &values)
+	if expectedErr == nil {
+		t.Fatal("expected securecookie usage error")
+	}
+
+	baseStore := &failingSessionStore{err: expectedErr}
+	var logOutput bytes.Buffer
+	store := newDebugSessionStore(baseStore, log.NewWithOptions(&logOutput, log.Options{
+		Level:     log.DebugLevel,
+		Formatter: log.JSONFormatter,
+	}))
+
+	_, err := store.Get(httptest.NewRequest(http.MethodGet, "/", nil), "chatto_session")
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("Get error = %v, want %v", err, expectedErr)
+	}
+	if logOutput.Len() != 0 {
+		t.Fatalf("unexpected log output for securecookie usage error: %s", logOutput.String())
+	}
+}
+
+type failingSessionStore struct {
+	ginsessions.Store
+	err error
+}
+
+func (s *failingSessionStore) Get(_ *http.Request, name string) (*gsessions.Session, error) {
+	return gsessions.NewSession(s, name), s.err
+}
+
+func expiredSecureCookieValue(t *testing.T, authKey []byte, name string, values map[interface{}]interface{}) string {
+	t.Helper()
+
+	encoded, err := securecookie.New(authKey, nil).Encode(name, values)
+	if err != nil {
+		t.Fatalf("encode securecookie: %v", err)
+	}
+
+	decoded, err := base64.URLEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode securecookie envelope: %v", err)
+	}
+
+	parts := bytes.SplitN(decoded, []byte("|"), 3)
+	if len(parts) != 3 {
+		t.Fatalf("unexpected securecookie envelope: %q", decoded)
+	}
+
+	expiredAt := time.Now().Add(-31 * 24 * time.Hour).UTC().Unix()
+	payload := parts[1]
+	macInput := []byte(fmt.Sprintf("%s|%d|%s", name, expiredAt, payload))
+	mac := hmac.New(sha256.New, authKey)
+	_, _ = mac.Write(macInput)
+
+	envelope := append([]byte(fmt.Sprintf("%d|%s|", expiredAt, payload)), mac.Sum(nil)...)
+	return base64.URLEncoding.EncodeToString(envelope)
+}


### PR DESCRIPTION
## Changes

- Wrap the Gin session store so expected securecookie decode failures are logged by Chatto at debug level instead of surfacing as `[sessions] ERROR!`.
- Preserve propagation for non-decode and securecookie usage/internal errors.
- Add focused tests for expired session cookies and error passthrough behavior.

## Tests

- `cd cli && mise x -- go test -tags test_endpoints ./internal/http_server -run "Test.*Session.*Cookie|Test.*SessionStore" -timeout 30s`
