### PR TITLE
fix: improve push notification routing

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -486,15 +486,15 @@ func setupPushNotifications(chattoCore *core.ChattoCore, cfg config.ChattoConfig
 				// Subscription is no longer valid, delete it
 				if err := chattoCore.DeletePushSubscription(ctx, notification.RecipientId, result.Endpoint); err != nil {
 					logger.Warn("Failed to delete expired push subscription",
-						"endpoint", result.Endpoint[:min(50, len(result.Endpoint))],
+						"endpoint_id", push.EndpointLogID(result.Endpoint),
 						"error", err)
 				} else {
 					logger.Debug("Deleted expired push subscription",
-						"endpoint", result.Endpoint[:min(50, len(result.Endpoint))])
+						"endpoint_id", push.EndpointLogID(result.Endpoint))
 				}
 			} else if result.Error != nil {
 				logger.Warn("Failed to send push notification",
-					"endpoint", result.Endpoint[:min(50, len(result.Endpoint))],
+					"endpoint_id", push.EndpointLogID(result.Endpoint),
 					"error", result.Error)
 			} else if result.Success {
 				logger.Debug("Push notification sent",
@@ -537,12 +537,12 @@ func setupPushNotifications(chattoCore *core.ChattoCore, cfg config.ChattoConfig
 			if result.Gone {
 				if err := chattoCore.DeletePushSubscription(ctx, userID, result.Endpoint); err != nil {
 					logger.Warn("Failed to delete expired push subscription",
-						"endpoint", result.Endpoint[:min(50, len(result.Endpoint))],
+						"endpoint_id", push.EndpointLogID(result.Endpoint),
 						"error", err)
 				}
 			} else if result.Error != nil {
 				logger.Debug("Failed to send dismiss push",
-					"endpoint", result.Endpoint[:min(50, len(result.Endpoint))],
+					"endpoint_id", push.EndpointLogID(result.Endpoint),
 					"error", result.Error)
 			} else if result.Success {
 				logger.Debug("Dismiss push sent",

--- a/cli/internal/push/push.go
+++ b/cli/internal/push/push.go
@@ -4,6 +4,8 @@ package push
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -181,6 +183,12 @@ func pushServiceStatusError(prefix string, statusCode int, body string, readErr 
 		return fmt.Errorf("%s %d", prefix, statusCode)
 	}
 	return fmt.Errorf("%s %d: %s", prefix, statusCode, body)
+}
+
+// EndpointLogID returns a stable, opaque identifier for a push endpoint.
+func EndpointLogID(endpoint string) string {
+	hash := sha256.Sum256([]byte(endpoint))
+	return hex.EncodeToString(hash[:8])
 }
 
 // SendToMany sends a push notification to multiple subscriptions.

--- a/cli/internal/push/push_test.go
+++ b/cli/internal/push/push_test.go
@@ -57,6 +57,24 @@ func TestNewSender(t *testing.T) {
 	})
 }
 
+func TestEndpointLogID(t *testing.T) {
+	endpoint := "https://push.example.com/send/private-device-token"
+
+	got := EndpointLogID(endpoint)
+	if got == "" {
+		t.Fatal("EndpointLogID returned empty string")
+	}
+	if len(got) != 16 {
+		t.Fatalf("EndpointLogID length = %d, want 16", len(got))
+	}
+	if got != EndpointLogID(endpoint) {
+		t.Fatal("EndpointLogID should be stable for the same endpoint")
+	}
+	if got == endpoint || strings.Contains(got, "private-device-token") {
+		t.Fatalf("EndpointLogID leaked endpoint material: %q", got)
+	}
+}
+
 func TestPayloadMarshal(t *testing.T) {
 	t.Run("marshals all fields", func(t *testing.T) {
 		payload := &Payload{

--- a/frontend/src/lib/components/PushNotificationSetup.svelte
+++ b/frontend/src/lib/components/PushNotificationSetup.svelte
@@ -14,10 +14,23 @@ Include this component once in the authenticated layout.
   const originId = serverRegistry.originServer?.id ?? '';
   const originServerInfo = originId ? serverRegistry.getStore(originId).serverInfo : undefined;
 
-  $effect(() => {
+  function refreshPushSubscription() {
     if (!originServerInfo?.pushNotificationsEnabled) return;
     if (!originServerInfo.vapidPublicKey) return;
 
     void ensureRegistered(originServerInfo.vapidPublicKey, { prompt: false });
+  }
+
+  $effect(() => {
+    if (!originServerInfo?.pushNotificationsEnabled) return;
+    if (!originServerInfo.vapidPublicKey) return;
+
+    refreshPushSubscription();
+    if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return;
+
+    navigator.serviceWorker.addEventListener('controllerchange', refreshPushSubscription);
+    return () => {
+      navigator.serviceWorker.removeEventListener('controllerchange', refreshPushSubscription);
+    };
   });
 </script>

--- a/frontend/src/lib/components/PushNotificationSetup.svelte.spec.ts
+++ b/frontend/src/lib/components/PushNotificationSetup.svelte.spec.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { flushSync } from 'svelte';
+import PushNotificationSetup from './PushNotificationSetup.svelte';
+
+const mocks = vi.hoisted(() => ({
+  ensureRegistered: vi.fn(),
+  serverInfo: {
+    pushNotificationsEnabled: true,
+    vapidPublicKey: 'vapid-key' as string | null
+  }
+}));
+
+vi.mock('$lib/notifications/pushNotifications', () => ({
+  ensureRegistered: mocks.ensureRegistered
+}));
+
+vi.mock('$lib/state/server/registry.svelte', () => ({
+  serverRegistry: {
+    originServer: { id: 'origin' },
+    getStore: () => ({
+      serverInfo: mocks.serverInfo
+    })
+  }
+}));
+
+type ServiceWorkerListener = (event: Event) => void;
+
+function installServiceWorkerStub() {
+  const listeners = new Set<ServiceWorkerListener>();
+  const serviceWorker = {
+    addEventListener: vi.fn((type: string, listener: ServiceWorkerListener) => {
+      if (type === 'controllerchange') listeners.add(listener);
+    }),
+    removeEventListener: vi.fn((type: string, listener: ServiceWorkerListener) => {
+      if (type === 'controllerchange') listeners.delete(listener);
+    }),
+    dispatchControllerChange() {
+      for (const listener of listeners) {
+        listener(new Event('controllerchange'));
+      }
+    },
+    listenerCount() {
+      return listeners.size;
+    }
+  };
+
+  Object.defineProperty(navigator, 'serviceWorker', {
+    configurable: true,
+    value: serviceWorker
+  });
+
+  return serviceWorker;
+}
+
+async function settle() {
+  await Promise.resolve();
+  await Promise.resolve();
+  flushSync();
+}
+
+describe('PushNotificationSetup', () => {
+  beforeEach(() => {
+    mocks.ensureRegistered.mockReset();
+    mocks.serverInfo.pushNotificationsEnabled = true;
+    mocks.serverInfo.vapidPublicKey = 'vapid-key';
+  });
+
+  it('refreshes granted-permission subscriptions on startup and service worker controller changes', async () => {
+    const serviceWorker = installServiceWorkerStub();
+
+    render(PushNotificationSetup);
+    await settle();
+
+    expect(mocks.ensureRegistered).toHaveBeenCalledWith('vapid-key', { prompt: false });
+    expect(serviceWorker.addEventListener).toHaveBeenCalledWith(
+      'controllerchange',
+      expect.any(Function)
+    );
+
+    serviceWorker.dispatchControllerChange();
+    await settle();
+
+    expect(mocks.ensureRegistered).toHaveBeenCalledTimes(2);
+    expect(mocks.ensureRegistered).toHaveBeenLastCalledWith('vapid-key', { prompt: false });
+  });
+
+  it('does not reconcile when push is not configured', async () => {
+    const serviceWorker = installServiceWorkerStub();
+    mocks.serverInfo.pushNotificationsEnabled = false;
+
+    render(PushNotificationSetup);
+    await settle();
+
+    expect(mocks.ensureRegistered).not.toHaveBeenCalled();
+    expect(serviceWorker.listenerCount()).toBe(0);
+  });
+});

--- a/frontend/src/lib/pwa/notificationClick.worker.spec.ts
+++ b/frontend/src/lib/pwa/notificationClick.worker.spec.ts
@@ -28,14 +28,13 @@ function clientsWith(matches: NotificationClickClient[]) {
 describe('routeNotificationClick', () => {
   it('uses acknowledged SPA routing, then focuses the window without navigating', async () => {
     const channel = createAcknowledgingMessageChannel();
-    let client!: NotificationClickClient;
     const focus = vi.fn(async () => client);
     const navigate = vi.fn(async () => client);
     const postMessage = vi.fn((_message, transfer) => {
       const ackPort = transfer?.[0] as { postMessage: (message: unknown) => void };
       ackPort.postMessage({ type: 'notification-click-ack' });
     });
-    client = {
+    const client: NotificationClickClient = {
       focus,
       navigate,
       postMessage
@@ -57,11 +56,10 @@ describe('routeNotificationClick', () => {
   });
 
   it('falls back to WindowClient.navigate before focusing when the SPA does not acknowledge', async () => {
-    let client!: NotificationClickClient;
     const focus = vi.fn(async () => client);
     const navigate = vi.fn(async () => client);
     const postMessage = vi.fn();
-    client = {
+    const client: NotificationClickClient = {
       focus,
       navigate,
       postMessage

--- a/frontend/src/lib/pwa/notificationClick.worker.spec.ts
+++ b/frontend/src/lib/pwa/notificationClick.worker.spec.ts
@@ -26,15 +26,19 @@ function clientsWith(matches: NotificationClickClient[]) {
 }
 
 describe('routeNotificationClick', () => {
-  it('uses acknowledged SPA routing without navigating the window', async () => {
+  it('uses acknowledged SPA routing, then focuses the window without navigating', async () => {
     const channel = createAcknowledgingMessageChannel();
-    const client: NotificationClickClient = {
-      focus: vi.fn(async () => client),
-      navigate: vi.fn(async () => client),
-      postMessage: vi.fn((_message, transfer) => {
-        const ackPort = transfer?.[0] as { postMessage: (message: unknown) => void };
-        ackPort.postMessage({ type: 'notification-click-ack' });
-      })
+    let client!: NotificationClickClient;
+    const focus = vi.fn(async () => client);
+    const navigate = vi.fn(async () => client);
+    const postMessage = vi.fn((_message, transfer) => {
+      const ackPort = transfer?.[0] as { postMessage: (message: unknown) => void };
+      ackPort.postMessage({ type: 'notification-click-ack' });
+    });
+    client = {
+      focus,
+      navigate,
+      postMessage
     };
     const clients = clientsWith([client]);
 
@@ -43,20 +47,24 @@ describe('routeNotificationClick', () => {
     });
 
     expect(result).toBe('client');
-    expect(client.focus).toHaveBeenCalledOnce();
-    expect(client.postMessage).toHaveBeenCalledWith(
-      { type: 'notification-click', url: TARGET_URL },
-      [channel.port2]
-    );
-    expect(client.navigate).not.toHaveBeenCalled();
+    expect(focus).toHaveBeenCalledOnce();
+    expect(postMessage).toHaveBeenCalledWith({ type: 'notification-click', url: TARGET_URL }, [
+      channel.port2
+    ]);
+    expect(postMessage.mock.invocationCallOrder[0]).toBeLessThan(focus.mock.invocationCallOrder[0]);
+    expect(navigate).not.toHaveBeenCalled();
     expect(clients.openWindow).not.toHaveBeenCalled();
   });
 
-  it('falls back to WindowClient.navigate when the SPA does not acknowledge', async () => {
-    const client: NotificationClickClient = {
-      focus: vi.fn(async () => client),
-      navigate: vi.fn(async () => client),
-      postMessage: vi.fn()
+  it('falls back to WindowClient.navigate before focusing when the SPA does not acknowledge', async () => {
+    let client!: NotificationClickClient;
+    const focus = vi.fn(async () => client);
+    const navigate = vi.fn(async () => client);
+    const postMessage = vi.fn();
+    client = {
+      focus,
+      navigate,
+      postMessage
     };
     const clients = clientsWith([client]);
 
@@ -66,8 +74,40 @@ describe('routeNotificationClick', () => {
     });
 
     expect(result).toBe('navigate');
-    expect(client.postMessage).toHaveBeenCalledOnce();
-    expect(client.navigate).toHaveBeenCalledWith(TARGET_URL);
+    expect(postMessage).toHaveBeenCalledOnce();
+    expect(navigate).toHaveBeenCalledWith(TARGET_URL);
+    expect(focus).toHaveBeenCalledOnce();
+    expect(navigate.mock.invocationCallOrder[0]).toBeLessThan(focus.mock.invocationCallOrder[0]);
+    expect(clients.openWindow).not.toHaveBeenCalled();
+  });
+
+  it('tries later window clients when an earlier client cannot route or navigate', async () => {
+    const staleClient: NotificationClickClient = {
+      focus: vi.fn(async () => staleClient),
+      navigate: vi.fn(async () => null),
+      postMessage: vi.fn()
+    };
+    const activeClient: NotificationClickClient = {
+      focus: vi.fn(async () => activeClient),
+      navigate: vi.fn(async () => activeClient),
+      postMessage: vi.fn((_message, transfer) => {
+        const ackPort = transfer?.[0] as { postMessage: (message: unknown) => void };
+        ackPort.postMessage({ type: 'notification-click-ack' });
+      })
+    };
+    const clients = clientsWith([staleClient, activeClient]);
+
+    const result = await routeNotificationClick(TARGET_URL, ORIGIN, clients, {
+      ackTimeoutMs: 1,
+      createMessageChannel: createAcknowledgingMessageChannel
+    });
+
+    expect(result).toBe('client');
+    expect(staleClient.postMessage).toHaveBeenCalledOnce();
+    expect(staleClient.navigate).toHaveBeenCalledWith(TARGET_URL);
+    expect(staleClient.focus).not.toHaveBeenCalled();
+    expect(activeClient.postMessage).toHaveBeenCalledOnce();
+    expect(activeClient.focus).toHaveBeenCalledOnce();
     expect(clients.openWindow).not.toHaveBeenCalled();
   });
 
@@ -82,6 +122,21 @@ describe('routeNotificationClick', () => {
       includeUncontrolled: true
     });
     expect(clients.openWindow).toHaveBeenCalledWith(TARGET_URL);
+  });
+
+  it('accepts room, thread, and DM notification route URLs', async () => {
+    const routes = [
+      `${ORIGIN}/chat/-/dm-room`,
+      `${ORIGIN}/chat/-/room-1?highlight=event-1`,
+      `${ORIGIN}/chat/-/room-1/thread-root?highlight=reply-event`
+    ];
+
+    for (const url of routes) {
+      const clients = clientsWith([]);
+
+      await expect(routeNotificationClick(url, ORIGIN, clients)).resolves.toBe('open');
+      expect(clients.openWindow).toHaveBeenCalledWith(url);
+    }
   });
 
   it('rejects malformed and cross-origin notification URLs', async () => {

--- a/frontend/src/lib/pwa/notificationClick.worker.ts
+++ b/frontend/src/lib/pwa/notificationClick.worker.ts
@@ -87,9 +87,16 @@ function notifyClientAndWaitForAck(
   });
 }
 
-async function navigateClient(client: NotificationClickClient, url: string): Promise<boolean> {
-  if (typeof client.navigate !== 'function') return false;
-  return Boolean(await client.navigate(url));
+async function focusClient(
+  client: NotificationClickClient,
+  logger?: NotificationClickLogger
+): Promise<void> {
+  if (typeof client.focus !== 'function') return;
+  try {
+    await client.focus();
+  } catch (err) {
+    logger?.warn('[SW] Failed to focus existing window:', err);
+  }
 }
 
 export async function routeNotificationClick(
@@ -111,32 +118,21 @@ export async function routeNotificationClick(
   });
 
   for (const client of clientList) {
-    if (typeof client.focus !== 'function') continue;
-
-    let focusedClient: NotificationClickClient | null = null;
-    try {
-      focusedClient = await client.focus();
-    } catch (err) {
-      options.logger?.warn('[SW] Failed to focus existing window:', err);
+    const acknowledged = await notifyClientAndWaitForAck(client, url, ackOptions);
+    if (acknowledged) {
+      await focusClient(client, options.logger);
+      return 'client';
     }
 
-    if (focusedClient) {
-      const acknowledged = await notifyClientAndWaitForAck(focusedClient, url, ackOptions);
-      if (acknowledged) return 'client';
-
-      try {
-        if (await navigateClient(focusedClient, url)) return 'navigate';
-      } catch (err) {
-        options.logger?.warn('[SW] Failed to navigate focused window:', err);
+    try {
+      const navigatedClient = await client.navigate?.(url);
+      if (navigatedClient) {
+        await focusClient(navigatedClient, options.logger);
+        return 'navigate';
       }
-    }
-
-    try {
-      if (await navigateClient(client, url)) return 'navigate';
     } catch (err) {
       options.logger?.warn('[SW] Failed to navigate existing window:', err);
     }
-    break;
   }
 
   await clients.openWindow(url);


### PR DESCRIPTION
- Harden service-worker notification clicks so Chatto routes before focusing, falls back to navigation without showing the last-opened room, and keeps trying usable clients before opening a new window.
- Refresh granted push subscriptions on authenticated startup and service-worker controller changes without prompting again.
- Replace push endpoint log prefixes with stable opaque endpoint IDs.
- Add focused tests for click routing, route URL shapes, subscription reconciliation, and endpoint log IDs.
