### PR TITLE
feat(frontend): show call participants in room sidebar

### DIFF
--- a/frontend/src/lib/RoomList.svelte
+++ b/frontend/src/lib/RoomList.svelte
@@ -21,7 +21,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   } from '$lib/storage/roomSidebarPanel';
   import { serverStorageKey } from '$lib/storage/serverStorage';
   import { useFragment } from './gql';
-  import { RoomType } from '$lib/gql/graphql';
+  import { PresenceStatus, RoomType, type UserAvatarUserFragment } from '$lib/gql/graphql';
   import UserAvatar, { UserAvatarFragment } from '$lib/components/UserAvatar.svelte';
   import NotificationBadge from '$lib/ui/NotificationBadge.svelte';
   import UnreadDot from '$lib/ui/UnreadDot.svelte';
@@ -33,6 +33,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     type RoomsListGroup,
     type RoomsListGroupItem
   } from '$lib/state/server/rooms.svelte';
+  import type { CallRoomParticipant } from '$lib/state/server/activeCallRooms.svelte';
 
   // No props — RoomList reads everything from the active server's stores.
   // All store references go through `stores` ($derived), so when the active
@@ -123,6 +124,18 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
       return room.members.slice(0, 1);
     }
     return others.slice(0, 3);
+  }
+
+  function callParticipantAvatarUser(participant: CallRoomParticipant): UserAvatarUserFragment {
+    return {
+      __typename: 'User',
+      id: participant.userId,
+      login: participant.login,
+      displayName: participant.displayName,
+      deleted: false,
+      avatarUrl: participant.avatarUrl,
+      presenceStatus: PresenceStatus.Offline
+    };
   }
 
   // Whether a room should remain visible while its sidebar group is
@@ -304,29 +317,63 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
 
 {#snippet activeCallIcon()}
   <span
-    class="sidebar-icon relative text-accent"
+    class="relative sidebar-icon text-accent"
     aria-label="Active call"
     data-testid="room-call-icon"
   >
     <span class="relative inline-flex">
       <span
-        class="pane-header-icon-glyph absolute inset-0 animate-ping opacity-45 uil--phone"
+        class="absolute inset-0 pane-header-icon-glyph animate-ping opacity-45 uil--phone"
         aria-hidden="true"
         data-testid="active-call-pulse-icon"
       ></span>
-      <span
-        class="pane-header-icon-glyph relative text-accent uil--phone"
-        aria-hidden="true"
+      <span class="relative pane-header-icon-glyph text-accent uil--phone" aria-hidden="true"
       ></span>
     </span>
   </span>
+{/snippet}
+
+{#snippet activeCallParticipants(roomId: string)}
+  {@const participants = activeCallRooms.getParticipants(roomId)}
+  {#if participants.length > 0}
+    <div
+      class="hidden shrink-0 items-center -space-x-1 @min-[220px]:flex"
+      aria-label={`${participants.length} participants in call`}
+      data-testid="room-call-participants"
+    >
+      {#each participants.slice(0, 4) as participant, i (participant.userId)}
+        <span
+          class={[
+            'inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full ring-1 ring-background',
+            i === 2 ? 'hidden @min-[280px]:inline-flex' : '',
+            i === 3 ? 'hidden @min-[340px]:inline-flex' : ''
+          ]}
+          data-testid="room-call-participant-avatar"
+        >
+          <UserAvatar
+            user={callParticipantAvatarUser(participant)}
+            size="xs"
+            showPresence={false}
+          />
+        </span>
+      {/each}
+      {#if participants.length > 4}
+        <span
+          class="hidden h-5 min-w-5 shrink-0 items-center justify-center rounded-full bg-surface-200 px-1 text-[10px] leading-none font-medium text-muted ring-1 ring-background @min-[380px]:inline-flex"
+          data-testid="room-call-overflow"
+        >
+          +{participants.length - 4}
+        </span>
+      {/if}
+    </div>
+  {/if}
 {/snippet}
 
 {#snippet roomLink(room: RoomsListItem)}
   {@const hasActiveCall = activeCallRooms.has(room.id)}
   {@const isJoined = room.viewerIsMember}
   {@const rowClass = [
-    'sidebar-item group/badges',
+    '@container sidebar-item group/badges',
     room.id === activeRoomId ? 'bg-surface-100' : '',
     room.hasUnread && room.id !== activeRoomId && !notificationLevelStore.isRoomMuted(room.id)
       ? 'font-semibold'
@@ -340,9 +387,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     onclick={(e) => handleRoomLinkClick(e, room)}
     onkeydown={(e) => handleRoomLinkKeydown(e, room)}
   >
-    {#if isJoined && hasActiveCall}
-      {@render activeCallIcon()}
-    {:else if isJoined}
+    {#if isJoined}
       <span class="sidebar-icon text-muted">#</span>
     {:else if room.viewerCanJoinRoom}
       <span class="sidebar-icon text-muted">+</span>
@@ -350,6 +395,10 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
       <span class="sidebar-icon iconify text-muted uil--lock"></span>
     {/if}
     <span class="flex-1 truncate">{room.name}</span>
+    {#if isJoined && hasActiveCall}
+      {@render activeCallParticipants(room.id)}
+      {@render activeCallIcon()}
+    {/if}
 
     <!-- Notification Indicator (warning color for mentions and thread replies) -->
     {#if isJoined && room.viewerNotificationCount > 0}
@@ -367,7 +416,6 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
       <UnreadDot color="primary" testid="room-unread-dot" />
       <span class="sr-only">unread messages</span>
     {/if}
-
   </a>
 {/snippet}
 
@@ -376,7 +424,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   <a
     href={resolve('/chat/[serverId]/[roomId]', { serverId: serverSegment, roomId: room.id })}
     class={[
-      'group/badges sidebar-item',
+      'group/badges @container sidebar-item',
       room.id === activeRoomId ? 'bg-surface-100' : '',
       room.hasUnread && room.id !== activeRoomId ? 'font-semibold' : ''
     ]}
@@ -384,16 +432,16 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     onclick={(e) => handleRoomLinkClick(e, room)}
     onkeydown={(e) => handleRoomLinkKeydown(e, room)}
   >
-    {#if hasActiveCall}
-      {@render activeCallIcon()}
-    {:else}
-      <div class="flex shrink-0 -space-x-1">
-        {#each dmAvatarParticipants(room) as participant (participant.id)}
-          <UserAvatar user={participant} size="xs" />
-        {/each}
-      </div>
-    {/if}
+    <div class="flex shrink-0 -space-x-1">
+      {#each dmAvatarParticipants(room) as participant (participant.id)}
+        <UserAvatar user={participant} size="xs" />
+      {/each}
+    </div>
     <span class="flex-1 truncate">{dmDisplayName(room)}</span>
+    {#if hasActiveCall}
+      {@render activeCallParticipants(room.id)}
+      {@render activeCallIcon()}
+    {/if}
 
     {#if room.viewerNotificationCount > 0}
       <button
@@ -409,7 +457,6 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
       <UnreadDot color="primary" testid="dm-unread-dot" />
       <span class="sr-only">unread messages</span>
     {/if}
-
   </a>
 {/snippet}
 

--- a/frontend/src/lib/RoomList.svelte.spec.ts
+++ b/frontend/src/lib/RoomList.svelte.spec.ts
@@ -253,7 +253,7 @@ beforeEach(() => {
 });
 
 describe('RoomList', () => {
-  it('replaces DM avatars with the active-call pulse icon twin', async () => {
+  it('renders active-call DM rows with the pulse icon and participant avatars', async () => {
     mocks.activeCallRoomIds.add('dm-with-participants');
     mocks.callParticipants.set('dm-with-participants', [
       {
@@ -270,12 +270,18 @@ describe('RoomList', () => {
     const dmRow = q(container, '[href="/chat/-/dm-with-participants"]');
     const icon = dmRow?.querySelector('[data-testid="room-call-icon"]');
     const pulseIcon = icon?.querySelector('[data-testid="active-call-pulse-icon"]');
+    const children = Array.from(dmRow?.children ?? []);
     expect(icon).not.toBeNull();
     expect(icon?.classList.contains('text-accent')).toBe(true);
     expect(icon?.querySelector('.uil--phone')).not.toBeNull();
     expect(pulseIcon).not.toBeNull();
     expect(pulseIcon?.classList.contains('animate-ping')).toBe(true);
-    expect(dmRow?.querySelector('[data-testid="room-call-badge"]')).toBeNull();
+    expect(dmRow?.querySelector('[data-testid="room-call-participants"]')).not.toBeNull();
+    expect(dmRow?.querySelectorAll('[data-testid="room-call-participant-avatar"]')).toHaveLength(1);
+    expect(children.indexOf(dmRow!.querySelector('[data-testid="room-call-participants"]')!)).toBe(
+      children.indexOf(icon!) - 1
+    );
+    expect(children[0]?.querySelector('[data-testid="room-call-icon"]')).toBeNull();
   });
 
   it('renders the active-call phone icon when participants are not loaded', async () => {
@@ -289,10 +295,10 @@ describe('RoomList', () => {
     expect(icon).not.toBeNull();
     expect(icon?.querySelector('.uil--phone')).not.toBeNull();
     expect(icon?.querySelector('[data-testid="active-call-pulse-icon"]')).not.toBeNull();
-    expect(dmRow?.querySelector('[data-testid="room-call-badge"]')).toBeNull();
+    expect(dmRow?.querySelector('[data-testid="room-call-participants"]')).toBeNull();
   });
 
-  it('replaces channel room icons with the active-call pulse icon twin', async () => {
+  it('renders active-call channel rows with the pulse icon and participant avatars', async () => {
     mocks.activeCallRoomIds.add('channel-1');
     mocks.callParticipants.set('channel-1', [
       {
@@ -309,11 +315,44 @@ describe('RoomList', () => {
     const channelRow = q(container, '[href="/chat/-/channel-1"]');
     const icon = channelRow?.querySelector('[data-testid="room-call-icon"]');
     const pulseIcon = icon?.querySelector('[data-testid="active-call-pulse-icon"]');
+    const leadingIcon = channelRow?.querySelector('.sidebar-icon');
+    const children = Array.from(channelRow?.children ?? []);
     expect(icon).not.toBeNull();
     expect(icon?.querySelector('.uil--phone')).not.toBeNull();
     expect(pulseIcon).not.toBeNull();
     expect(pulseIcon?.classList.contains('animate-ping')).toBe(true);
-    expect(channelRow?.querySelector('[data-testid="room-call-badge"]')).toBeNull();
+    expect(leadingIcon?.textContent).toBe('#');
+    expect(leadingIcon).not.toBe(icon);
+    expect(channelRow?.querySelector('[data-testid="room-call-participants"]')).not.toBeNull();
+    expect(
+      channelRow?.querySelectorAll('[data-testid="room-call-participant-avatar"]')
+    ).toHaveLength(1);
+    expect(
+      children.indexOf(channelRow!.querySelector('[data-testid="room-call-participants"]')!)
+    ).toBe(children.indexOf(icon!) - 1);
+  });
+
+  it('renders a compact overflow count for larger active calls', async () => {
+    mocks.activeCallRoomIds.add('channel-1');
+    mocks.callParticipants.set('channel-1', [
+      { userId: 'teal', login: 'teal', displayName: 'Teal', avatarUrl: null },
+      { userId: 'river', login: 'river', displayName: 'River', avatarUrl: null },
+      { userId: 'sage', login: 'sage', displayName: 'Sage', avatarUrl: null },
+      { userId: 'ash', login: 'ash', displayName: 'Ash', avatarUrl: null },
+      { userId: 'sol', login: 'sol', displayName: 'Sol', avatarUrl: null },
+      { userId: 'moon', login: 'moon', displayName: 'Moon', avatarUrl: null }
+    ]);
+
+    const { container } = render(RoomList);
+
+    await expect.element(q(container, '[href="/chat/-/channel-1"]')).toBeInTheDocument();
+    const channelRow = q(container, '[href="/chat/-/channel-1"]');
+    expect(
+      channelRow?.querySelectorAll('[data-testid="room-call-participant-avatar"]')
+    ).toHaveLength(4);
+    await expect
+      .element(q(channelRow!, '[data-testid="room-call-overflow"]'))
+      .toHaveTextContent('+2');
   });
 
   it('opens the call panel when an active-call room icon is clicked', async () => {
@@ -363,26 +402,29 @@ describe('RoomList', () => {
   it.each([
     ['Enter', 'Enter'],
     ['Space', ' ']
-  ])('opens the call panel on %s when an active-call row has keyboard focus', async (_label, key) => {
-    mocks.activeCallRoomIds.add('channel-1');
+  ])(
+    'opens the call panel on %s when an active-call row has keyboard focus',
+    async (_label, key) => {
+      mocks.activeCallRoomIds.add('channel-1');
 
-    const { container } = render(RoomList);
+      const { container } = render(RoomList);
 
-    await expect.element(q(container, '[href="/chat/-/channel-1"]')).toBeInTheDocument();
-    const channelRow = q(container, '[href="/chat/-/channel-1"]') as HTMLAnchorElement;
+      await expect.element(q(container, '[href="/chat/-/channel-1"]')).toBeInTheDocument();
+      const channelRow = q(container, '[href="/chat/-/channel-1"]') as HTMLAnchorElement;
 
-    const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
-    const wasNotCanceled = channelRow.dispatchEvent(event);
+      const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+      const wasNotCanceled = channelRow.dispatchEvent(event);
 
-    expect(wasNotCanceled).toBe(false);
-    await vi.waitFor(() => {
-      expect(mocks.goto).toHaveBeenCalledWith('/chat/-/channel-1');
-    });
-    expect(
-      localStorage.getItem(serverStorageKey('origin', roomSidebarPanelStorageSuffix('channel-1')))
-    ).toBe('call');
-    expect(consumePendingRoomSidebarPanel('origin', 'channel-1')).toBe('call');
-  });
+      expect(wasNotCanceled).toBe(false);
+      await vi.waitFor(() => {
+        expect(mocks.goto).toHaveBeenCalledWith('/chat/-/channel-1');
+      });
+      expect(
+        localStorage.getItem(serverStorageKey('origin', roomSidebarPanelStorageSuffix('channel-1')))
+      ).toBe('call');
+      expect(consumePendingRoomSidebarPanel('origin', 'channel-1')).toBe('call');
+    }
+  );
 
   it('opens a join modal for a faded joinable non-member channel row', async () => {
     const { container } = render(RoomList);


### PR DESCRIPTION
- Show active call participants as responsive mini avatars in room sidebar rows.
- Keep the normal channel/DM leading icon and move call status to trailing avatars plus the pulsing phone icon.
- Add RoomList coverage for avatar rendering, overflow counts, fallback phone-only state, and call-panel navigation.

Tests:
- `pnpm exec vitest --run src/lib/RoomList.svelte.spec.ts`
- `pnpm check`
- `pnpm exec eslint src/lib/RoomList.svelte src/lib/RoomList.svelte.spec.ts`
- `pnpm exec prettier --check src/lib/RoomList.svelte src/lib/RoomList.svelte.spec.ts`
