### PR TITLE
perf: optimize projection dispatch matching

### DIFF
--- a/cli/internal/events/events_test.go
+++ b/cli/internal/events/events_test.go
@@ -454,6 +454,22 @@ func newReplayTrackingProjection(subjects []string, replay []string) *replayTrac
 
 func (p *replayTrackingProjection) ReplaySubjects() []string { return p.replay }
 
+type countingSubjectsProjection struct {
+	*trackingProjection
+	subjectCalls int
+}
+
+func newCountingSubjectsProjection(subs ...string) *countingSubjectsProjection {
+	return &countingSubjectsProjection{
+		trackingProjection: newTrackingProjection(subs...),
+	}
+}
+
+func (p *countingSubjectsProjection) Subjects() []string {
+	p.subjectCalls++
+	return p.trackingProjection.Subjects()
+}
+
 type blockingProjection struct {
 	*trackingProjection
 	entered chan struct{}
@@ -1188,6 +1204,44 @@ func TestSubjectMatchesFilter(t *testing.T) {
 				t.Fatalf("subjectMatchesFilter(%q, %q) = %v, want %v", tc.filter, tc.subject, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestCompiledSubjectFilterMatchesWithoutAllocations(t *testing.T) {
+	matcher := compileSubjectFilter(RoomEventTypeFilter(EventUserJoinedRoom))
+	allocs := testing.AllocsPerRun(1000, func() {
+		if !matcher.matches("evt.room.R1.user_joined") {
+			t.Fatal("expected compiled filter to match")
+		}
+		if matcher.matches("evt.room.R1.message_posted") {
+			t.Fatal("expected compiled filter not to match")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("compiled matcher allocations = %v, want 0", allocs)
+	}
+}
+
+func TestProjectorCachesProjectionSubjects(t *testing.T) {
+	proj := newCountingSubjectsProjection(
+		RoomSubjectFilter(),
+		UserEventTypeFilter(EventUserKeyShredded),
+	)
+	projector := NewProjector(nil, nil, proj, testLogger())
+
+	for i := 0; i < 10; i++ {
+		_ = projector.Subjects()
+		_ = projector.ReplaySubjects()
+		if !projector.consumesSubject("evt.room.R1.message_posted") {
+			t.Fatal("expected projector to consume room subject")
+		}
+		if projector.consumesSubject("evt.config.server.server_name_changed") {
+			t.Fatal("expected projector not to consume config subject")
+		}
+	}
+
+	if proj.subjectCalls != 1 {
+		t.Fatalf("Subjects calls = %d, want 1", proj.subjectCalls)
 	}
 }
 

--- a/cli/internal/events/projector.go
+++ b/cli/internal/events/projector.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -104,6 +103,10 @@ type Projector struct {
 	proj   Projection
 	logger Logger
 
+	subjects        []string
+	replaySubjects  []string
+	subjectMatchers []compiledSubjectFilter
+
 	mu        sync.Mutex
 	lastSeq   uint64
 	waiters   []seqWaiter
@@ -151,12 +154,17 @@ type seqWaiter struct {
 // NewProjector binds a projection to a stream. Does not start the consumer
 // — call Run for that.
 func NewProjector(js jetstream.JetStream, stream jetstream.Stream, proj Projection, logger Logger) *Projector {
+	subjects := append([]string(nil), proj.Subjects()...)
+	replaySubjects := append([]string(nil), projectionReplaySubjects(proj, subjects)...)
 	return &Projector{
-		js:       js,
-		stream:   stream,
-		proj:     proj,
-		logger:   logger,
-		failedCh: make(chan struct{}),
+		js:              js,
+		stream:          stream,
+		proj:            proj,
+		logger:          logger,
+		subjects:        subjects,
+		replaySubjects:  replaySubjects,
+		subjectMatchers: compileSubjectFilters(subjects),
+		failedCh:        make(chan struct{}),
 	}
 }
 
@@ -212,12 +220,12 @@ func (p *Projector) Started() bool {
 // Subjects returns the subject filters this projector consumes.
 // The returned slice is a copy so callers cannot mutate projection state.
 func (p *Projector) Subjects() []string {
-	return append([]string(nil), p.proj.Subjects()...)
+	return append([]string(nil), p.subjects...)
 }
 
 // ReplaySubjects returns the physical stream filters used for replay.
 func (p *Projector) ReplaySubjects() []string {
-	return append([]string(nil), projectionReplaySubjects(p.proj)...)
+	return append([]string(nil), p.replaySubjects...)
 }
 
 // AppendAndWait publishes an event for an aggregate and blocks until
@@ -338,14 +346,13 @@ func (p *Projector) waitForSeq(ctx context.Context, seq uint64) error {
 }
 
 func (p *Projector) validateConsumesSubject(subject string) error {
-	subjects := p.proj.Subjects()
-	for _, filter := range subjects {
-		if subjectMatchesFilter(filter, subject) {
+	for i := range p.subjectMatchers {
+		if p.subjectMatchers[i].matches(subject) {
 			return nil
 		}
 	}
 	return fmt.Errorf("%w: subject %q not matched by filters %v",
-		ErrProjectionSubjectNotConsumed, subject, subjects)
+		ErrProjectionSubjectNotConsumed, subject, p.subjects)
 }
 
 func (p *Projector) validateSeqSubject(ctx context.Context, pos StreamPosition) error {
@@ -364,24 +371,75 @@ func (p *Projector) validateSeqSubject(ctx context.Context, pos StreamPosition) 
 }
 
 func subjectMatchesFilter(filter, subject string) bool {
-	if filter == "" || subject == "" {
+	return compileSubjectFilter(filter).matches(subject)
+}
+
+type compiledSubjectFilter struct {
+	raw    string
+	tokens []string
+}
+
+func compileSubjectFilters(filters []string) []compiledSubjectFilter {
+	compiled := make([]compiledSubjectFilter, 0, len(filters))
+	for _, filter := range filters {
+		compiled = append(compiled, compileSubjectFilter(filter))
+	}
+	return compiled
+}
+
+func compileSubjectFilter(filter string) compiledSubjectFilter {
+	return compiledSubjectFilter{
+		raw:    filter,
+		tokens: splitSubjectTokens(filter),
+	}
+}
+
+func splitSubjectTokens(subject string) []string {
+	if subject == "" {
+		return nil
+	}
+	tokenCount := 1
+	for i := 0; i < len(subject); i++ {
+		if subject[i] == '.' {
+			tokenCount++
+		}
+	}
+	tokens := make([]string, 0, tokenCount)
+	start := 0
+	for i := 0; i <= len(subject); i++ {
+		if i == len(subject) || subject[i] == '.' {
+			tokens = append(tokens, subject[start:i])
+			start = i + 1
+		}
+	}
+	return tokens
+}
+
+func (f compiledSubjectFilter) matches(subject string) bool {
+	if f.raw == "" || subject == "" {
 		return false
 	}
-	filterTokens := strings.Split(filter, ".")
-	subjectTokens := strings.Split(subject, ".")
-
-	for i, token := range filterTokens {
+	pos := 0
+	for i, token := range f.tokens {
 		if token == ">" {
-			return i == len(filterTokens)-1 && len(subjectTokens) > i
+			return i == len(f.tokens)-1 && pos < len(subject)
 		}
-		if i >= len(subjectTokens) {
+		if pos > len(subject) {
 			return false
 		}
-		if token != "*" && token != subjectTokens[i] {
+		end := pos
+		for end < len(subject) && subject[end] != '.' {
+			end++
+		}
+		if end == pos {
 			return false
 		}
+		if token != "*" && token != subject[pos:end] {
+			return false
+		}
+		pos = end + 1
 	}
-	return len(subjectTokens) == len(filterTokens)
+	return pos == len(subject)+1
 }
 
 // WaitForCurrent blocks until the projection has applied the latest
@@ -413,7 +471,7 @@ type projectionTarget struct {
 
 func (p *Projector) currentTarget(ctx context.Context) (projectionTarget, error) {
 	var target projectionTarget
-	for _, subject := range p.proj.Subjects() {
+	for _, subject := range p.subjects {
 		msg, err := p.stream.GetLastMsgForSubject(ctx, subject)
 		if err != nil {
 			if errors.Is(err, jetstream.ErrMsgNotFound) {
@@ -428,16 +486,16 @@ func (p *Projector) currentTarget(ctx context.Context) (projectionTarget, error)
 	return target, nil
 }
 
-func projectionReplaySubjects(proj Projection) []string {
+func projectionReplaySubjects(proj Projection, subjects []string) []string {
 	if replay, ok := proj.(ReplaySubjectProjection); ok {
 		return replay.ReplaySubjects()
 	}
-	return proj.Subjects()
+	return subjects
 }
 
-func projectionConsumesSubject(proj Projection, subject string) bool {
-	for _, filter := range proj.Subjects() {
-		if subjectMatchesFilter(filter, subject) {
+func (p *Projector) consumesSubject(subject string) bool {
+	for i := range p.subjectMatchers {
+		if p.subjectMatchers[i].matches(subject) {
 			return true
 		}
 	}
@@ -510,7 +568,7 @@ func (p *Projector) Run(ctx context.Context) error {
 	p.mu.Unlock()
 
 	cons, err := p.stream.OrderedConsumer(ctx, jetstream.OrderedConsumerConfig{
-		FilterSubjects:    projectionReplaySubjects(p.proj),
+		FilterSubjects:    p.replaySubjects,
 		DeliverPolicy:     jetstream.DeliverAllPolicy,
 		InactiveThreshold: 30 * time.Second,
 	})
@@ -568,7 +626,7 @@ func (p *Projector) handleMessage(msg jetstream.Msg) {
 		return
 	}
 
-	if !projectionConsumesSubject(p.proj, msg.Subject()) {
+	if !p.consumesSubject(msg.Subject()) {
 		return
 	}
 
@@ -636,7 +694,7 @@ func (p *Projector) maybeCompleteStartup(now time.Time) {
 			"messages_per_second", rate,
 			"last_seq", lastSeq,
 			"target_seq", targetSeq,
-			"subjects", p.proj.Subjects(),
+			"subjects", p.subjects,
 		)
 	}
 }
@@ -795,9 +853,10 @@ func handleSharedProjectorMessage(msg jetstream.Msg, projectors []*Projector, fa
 	}
 
 	now := time.Now()
-	consumers := make([]*Projector, 0, len(projectors))
+	var consumerBuf [16]*Projector
+	consumers := consumerBuf[:0]
 	for _, projector := range projectors {
-		if projectionConsumesSubject(projector.proj, msg.Subject()) {
+		if projector.consumesSubject(msg.Subject()) {
 			consumers = append(consumers, projector)
 		}
 	}


### PR DESCRIPTION
- Cache projector subject filters and replay filters at construction time, then use compiled non-allocating matchers during replay dispatch.
- Avoid per-message allocation of the shared replay consumer list with a small stack buffer.
- Add regression tests for zero-allocation subject matching and cached `Subjects()` access.
- Local benchmark on copied `cli/data`: final projector startup average improved from `127.882ms` to `68.641ms`; RSS average dropped from `129.5 MB` to `119.4 MB`.
- Tests: `mise x -- go test ./internal/core ./internal/events -timeout 60s`; `git diff --check`.
