### PR TITLE
fix(sidebar): server-local sidebar links now open in the same window

### DIFF
--- a/cli/internal/core/room_groups.go
+++ b/cli/internal/core/room_groups.go
@@ -156,7 +156,7 @@ func validateSidebarLink(label, rawURL string) (string, string, error) {
 
 func isValidSidebarLinkURL(rawURL string) bool {
 	if strings.HasPrefix(rawURL, "/") {
-		if strings.HasPrefix(rawURL, "//") {
+		if strings.HasPrefix(rawURL, "//") || strings.Contains(rawURL, "\\") {
 			return false
 		}
 		parsed, err := url.ParseRequestURI(rawURL)

--- a/cli/internal/core/room_groups.go
+++ b/cli/internal/core/room_groups.go
@@ -47,7 +47,7 @@ var (
 	ErrSidebarLinkNotFound      = errors.New("sidebar link not found")
 	ErrSidebarLinkSourceChanged = errors.New("sidebar link source group changed")
 	ErrSidebarLinkLabelEmpty    = errors.New("sidebar link label must not be empty")
-	ErrSidebarLinkURLInvalid    = errors.New("sidebar link URL must be an absolute http(s) URL")
+	ErrSidebarLinkURLInvalid    = errors.New("sidebar link URL must be an absolute http(s) URL or server-local path")
 )
 
 // CreateRoomGroup publishes a RoomGroupCreatedEvent and appends the
@@ -148,11 +148,27 @@ func validateSidebarLink(label, rawURL string) (string, string, error) {
 	if err := validateStringMaxLength("sidebar link URL", rawURL, MaxSidebarLinkURLLength); err != nil {
 		return "", "", err
 	}
-	parsed, err := url.Parse(rawURL)
-	if err != nil || !parsed.IsAbs() || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+	if !isValidSidebarLinkURL(rawURL) {
 		return "", "", ErrSidebarLinkURLInvalid
 	}
 	return label, rawURL, nil
+}
+
+func isValidSidebarLinkURL(rawURL string) bool {
+	if strings.HasPrefix(rawURL, "/") {
+		if strings.HasPrefix(rawURL, "//") {
+			return false
+		}
+		parsed, err := url.ParseRequestURI(rawURL)
+		return err == nil && parsed != nil && parsed.Scheme == "" && parsed.Host == ""
+	}
+
+	parsed, err := url.Parse(rawURL)
+	return err == nil &&
+		parsed != nil &&
+		parsed.IsAbs() &&
+		parsed.Host != "" &&
+		(parsed.Scheme == "http" || parsed.Scheme == "https")
 }
 
 // GetRoomGroup reads a single group from the RoomGroups projection.

--- a/cli/internal/core/room_groups_test.go
+++ b/cli/internal/core/room_groups_test.go
@@ -622,6 +622,95 @@ func TestSidebarLinkLifecycleAndOrdering(t *testing.T) {
 	}
 }
 
+func TestSidebarLinkURLsAcceptAbsoluteHTTPAndServerLocalPaths(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		createURL  string
+		updateURL  string
+		wantStored string
+	}{
+		{
+			name:       "absolute https",
+			createURL:  "https://example.com/docs",
+			updateURL:  "https://example.com/reference",
+			wantStored: "https://example.com/reference",
+		},
+		{
+			name:       "server local docs path",
+			createURL:  "/docs",
+			updateURL:  "/docs/reference",
+			wantStored: "/docs/reference",
+		},
+		{
+			name:       "server local chat path",
+			createURL:  "/chat/-/room",
+			updateURL:  "/chat/-/room?tab=files",
+			wantStored: "/chat/-/room?tab=files",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			core, _ := setupTestCore(t)
+			ctx := testContext(t)
+			group, err := core.CreateRoomGroup(ctx, "actor", "Links", "")
+			if err != nil {
+				t.Fatalf("CreateRoomGroup: %v", err)
+			}
+
+			link, err := core.CreateSidebarLink(ctx, "actor", group.Id, "Docs", tc.createURL)
+			if err != nil {
+				t.Fatalf("CreateSidebarLink(%q): %v", tc.createURL, err)
+			}
+
+			updated, err := core.UpdateSidebarLink(ctx, "actor", link.Id, "Docs Updated", tc.updateURL)
+			if err != nil {
+				t.Fatalf("UpdateSidebarLink(%q): %v", tc.updateURL, err)
+			}
+			if updated.Url != tc.wantStored {
+				t.Fatalf("updated URL = %q, want %q", updated.Url, tc.wantStored)
+			}
+		})
+	}
+}
+
+func TestSidebarLinkURLsRejectUnsafeOrMalformedTargets(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+	group, err := core.CreateRoomGroup(ctx, "actor", "Links", "")
+	if err != nil {
+		t.Fatalf("CreateRoomGroup: %v", err)
+	}
+
+	tooLongPath := "/" + strings.Repeat("a", MaxSidebarLinkURLLength)
+	for _, tc := range []struct {
+		name    string
+		rawURL  string
+		tooLong bool
+	}{
+		{name: "relative without leading slash", rawURL: "docs"},
+		{name: "protocol relative URL", rawURL: "//evil.example"},
+		{name: "javascript scheme", rawURL: "javascript:alert(1)"},
+		{name: "mailto scheme", rawURL: "mailto:hello@example.com"},
+		{name: "malformed absolute URL", rawURL: "https://%"},
+		{name: "over length path", rawURL: tooLongPath, tooLong: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := core.CreateSidebarLink(ctx, "actor", group.Id, "Docs", tc.rawURL)
+			if err == nil {
+				t.Fatalf("CreateSidebarLink(%q) succeeded, want error", tc.rawURL)
+			}
+			if tc.tooLong {
+				if !strings.Contains(err.Error(), "cannot exceed") {
+					t.Fatalf("CreateSidebarLink(%q) err = %v, want max length error", tc.rawURL, err)
+				}
+				return
+			}
+			if !errors.Is(err, ErrSidebarLinkURLInvalid) {
+				t.Fatalf("CreateSidebarLink(%q) err = %v, want ErrSidebarLinkURLInvalid", tc.rawURL, err)
+			}
+		})
+	}
+}
+
 func TestMoveSidebarLinkToGroup(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)

--- a/cli/internal/core/room_groups_test.go
+++ b/cli/internal/core/room_groups_test.go
@@ -688,6 +688,7 @@ func TestSidebarLinkURLsRejectUnsafeOrMalformedTargets(t *testing.T) {
 	}{
 		{name: "relative without leading slash", rawURL: "docs"},
 		{name: "protocol relative URL", rawURL: "//evil.example"},
+		{name: "backslash host path", rawURL: `/\evil.example/path`},
 		{name: "javascript scheme", rawURL: "javascript:alert(1)"},
 		{name: "mailto scheme", rawURL: "mailto:hello@example.com"},
 		{name: "malformed absolute URL", rawURL: "https://%"},

--- a/cli/internal/graph/model/models_gen.go
+++ b/cli/internal/graph/model/models_gen.go
@@ -259,7 +259,7 @@ type CreateSidebarLinkInput struct {
 	GroupID string `json:"groupId"`
 	// Display label for the link.
 	Label string `json:"label"`
-	// Absolute http(s) URL.
+	// Absolute http(s) URL or server-local path starting with /.
 	URL string `json:"url"`
 }
 
@@ -1400,7 +1400,7 @@ type UpdateSidebarLinkInput struct {
 	LinkID string `json:"linkId"`
 	// Display label for the link.
 	Label string `json:"label"`
-	// Absolute http(s) URL.
+	// Absolute http(s) URL or server-local path starting with /.
 	URL string `json:"url"`
 }
 

--- a/cli/internal/graph/room_groups.graphqls
+++ b/cli/internal/graph/room_groups.graphqls
@@ -113,7 +113,7 @@ input CreateSidebarLinkInput {
   groupId: ID!
   "Display label for the link."
   label: String! @length(max: 80)
-  "Absolute http(s) URL."
+  "Absolute http(s) URL or server-local path starting with /."
   url: String! @length(max: 2048)
 }
 
@@ -122,7 +122,7 @@ input UpdateSidebarLinkInput {
   linkId: ID!
   "Display label for the link."
   label: String! @length(max: 80)
-  "Absolute http(s) URL."
+  "Absolute http(s) URL or server-local path starting with /."
   url: String! @length(max: 2048)
 }
 
@@ -199,16 +199,16 @@ extend type Mutation {
   """
   reorderRoomsInGroup(input: ReorderRoomsInGroupInput!): RoomGroup!
 
-  "Create an external sidebar link inside a room group. Requires `room.manage` in that group."
+  "Create a sidebar link inside a room group. Requires `room.manage` in that group."
   createSidebarLink(input: CreateSidebarLinkInput!): SidebarLink!
 
-  "Update an external sidebar link. Requires `room.manage` in the link's group."
+  "Update a sidebar link. Requires `room.manage` in the link's group."
   updateSidebarLink(input: UpdateSidebarLinkInput!): SidebarLink!
 
-  "Delete an external sidebar link. Requires `room.manage` in the link's group."
+  "Delete a sidebar link. Requires `room.manage` in the link's group."
   deleteSidebarLink(input: DeleteSidebarLinkInput!): Boolean!
 
-  "Move an external sidebar link into another room group. Requires `room.manage` in both source and target groups."
+  "Move a sidebar link into another room group. Requires `room.manage` in both source and target groups."
   moveSidebarLinkToGroup(input: MoveSidebarLinkToGroupInput!): SidebarLink!
 
   """

--- a/cli/internal/graph/room_layout.graphqls
+++ b/cli/internal/graph/room_layout.graphqls
@@ -12,7 +12,7 @@ type RoomGroup {
   description: String!
   "Ordered list of channel rooms in this room group."
   rooms: [Room!]! @goField(forceResolver: true)
-  "Ordered mixed list of rooms and external links in this room group."
+  "Ordered mixed list of rooms and sidebar links in this room group."
   items: [RoomGroupItem!]! @goField(forceResolver: true)
 }
 
@@ -26,7 +26,7 @@ type SidebarLink {
   id: ID!
   "Display label shown in the server sidebar."
   label: String!
-  "Absolute http(s) URL opened outside Chatto."
+  "Absolute http(s) URL or server-local path starting with /."
   url: String!
 }
 

--- a/cli/internal/graph/sidebar_links_test.go
+++ b/cli/internal/graph/sidebar_links_test.go
@@ -35,17 +35,24 @@ func TestSidebarLinkMutationsUseGroupRoomManage(t *testing.T) {
 	link, err := mutation.CreateSidebarLink(managerCtx, model.CreateSidebarLinkInput{
 		GroupID: sourceGroupID,
 		Label:   "Docs",
-		URL:     "https://docs.example.com",
+		URL:     "/docs",
 	})
 	if err != nil {
 		t.Fatalf("CreateSidebarLink in managed group: %v", err)
 	}
-	if _, err := mutation.UpdateSidebarLink(managerCtx, model.UpdateSidebarLinkInput{
+	if link.Url != "/docs" {
+		t.Fatalf("created link URL = %q, want /docs", link.Url)
+	}
+	updated, err := mutation.UpdateSidebarLink(managerCtx, model.UpdateSidebarLinkInput{
 		LinkID: link.Id,
 		Label:  "Docs Updated",
-		URL:    "https://docs.example.com/updated",
-	}); err != nil {
+		URL:    "/docs/updated",
+	})
+	if err != nil {
 		t.Fatalf("UpdateSidebarLink in managed group: %v", err)
+	}
+	if updated.Url != "/docs/updated" {
+		t.Fatalf("updated link URL = %q, want /docs/updated", updated.Url)
 	}
 
 	_, err = mutation.MoveSidebarLinkToGroup(managerCtx, model.MoveSidebarLinkToGroupInput{

--- a/cli/internal/pb/chatto/core/v1/models.pb.go
+++ b/cli/internal/pb/chatto/core/v1/models.pb.go
@@ -1811,7 +1811,7 @@ type SidebarLink struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`       // NanoID for stable identity across renames/moves
 	Label         string                 `protobuf:"bytes,2,opt,name=label,proto3" json:"label,omitempty"` // Display label shown in the server sidebar
-	Url           string                 `protobuf:"bytes,3,opt,name=url,proto3" json:"url,omitempty"`     // Absolute http(s) URL opened outside Chatto
+	Url           string                 `protobuf:"bytes,3,opt,name=url,proto3" json:"url,omitempty"`     // Absolute http(s) URL or server-local path starting with /
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -266,7 +266,7 @@ Admin queries are nested under a single `admin: AdminQueries` field that returns
 | `reorderRoomGroups`               | Reorder all room groups (full list, exactly once each).                                      |
 | `reorderRoomsInGroup`             | Reorder rooms within a single group.                                                         |
 | `moveRoomToGroup`                 | Move a room into a different group (`room.manage` in both source and target — see ADR-031). |
-| `createSidebarLink`               | Add an external link to a room group (`room.manage`).                                        |
+| `createSidebarLink`               | Add an external or server-local link to a room group (`room.manage`).                        |
 | `updateSidebarLink`               | Rename or retarget a sidebar link (`room.manage`).                                           |
 | `deleteSidebarLink`               | Remove a sidebar link from its group (`room.manage`).                                        |
 | `moveSidebarLinkToGroup`          | Move a sidebar link into a different group (`room.manage` in both source and target).        |

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -46,7 +46,7 @@ User-facing concepts. If a user might say the word, it goes here.
 
 **Room Group** — Named collection of rooms within a server, with its own per-group permission overrides. See [ADR-031](adr/ADR-031-room-group-centric-acl.md) and [FDR-017](fdr/FDR-017-room-groups-and-sidebar-layout.md).
 
-**Sidebar Link** — Operator-managed external link shown in the Server Sidebar inside a Room Group, ordered alongside rooms and stored as a durable group aggregate fact. See [FDR-017](fdr/FDR-017-room-groups-and-sidebar-layout.md).
+**Sidebar Link** — Operator-managed link shown in the Server Sidebar inside a Room Group, ordered alongside rooms and stored as a durable group aggregate fact. See [FDR-017](fdr/FDR-017-room-groups-and-sidebar-layout.md).
 
 **DM (Direct Message)** — Private conversation between users, modelled as a room with `kind: dm`. See [FDR-007](fdr/FDR-007-direct-messages.md).
 

--- a/docs/fdr/FDR-017-room-groups-and-sidebar-layout.md
+++ b/docs/fdr/FDR-017-room-groups-and-sidebar-layout.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-Channel rooms are organized into **room groups** — named, ordered containers that act as both a UI grouping concept (collapsible sections in the sidebar) and the primary permission scope for room-level permissions. Every channel room belongs to exactly one group; DMs sit outside the group system entirely. Groups can also contain sidebar links: operator-managed external links rendered in the same ordered sidebar section as rooms.
+Channel rooms are organized into **room groups** — named, ordered containers that act as both a UI grouping concept (collapsible sections in the sidebar) and the primary permission scope for room-level permissions. Every channel room belongs to exactly one group; DMs sit outside the group system entirely. Groups can also contain sidebar links: operator-managed links rendered in the same ordered sidebar section as rooms.
 
 ## Behavior
 
@@ -14,7 +14,7 @@ Channel rooms are organized into **room groups** — named, ordered containers t
 - Server admins can create, rename, reorder, and delete groups via the admin UI.
 - Group names are limited to 80 bytes; group descriptions are limited to 500 bytes.
 - Every channel room belongs to exactly one group. There's no "uncategorized" branch — room creation requires a group.
-- Sidebar links belong to exactly one group, carry a label and absolute `http`/`https` URL, and are visible to authenticated users who can see the server sidebar.
+- Sidebar links belong to exactly one group, carry a label and either an absolute `http`/`https` URL or a server-local path starting with `/`, and are visible to authenticated users who can see the server sidebar.
 - A freshly bootstrapped server has one group named "Lobby" containing the auto-created `announcements` and `general` rooms. Operators can rename it, reorder it, or replace it like any other group.
 - Deleting a group is rejected while rooms or sidebar links still live in it. Operators move or delete its contents first.
 - Moving a room between groups requires `room.manage` in both the source and the target group (the room's effective ACL changes overnight).

--- a/frontend/src/lib/RoomList.svelte
+++ b/frontend/src/lib/RoomList.svelte
@@ -9,6 +9,10 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
   import { serverIdToSegment } from '$lib/navigation';
+  import {
+    sidebarLinkAnchorAttributes,
+    sidebarLinkTarget
+  } from '$lib/navigation/sidebarLinkTarget';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import CollapsibleGroup from '$lib/ui/CollapsibleGroup.svelte';
@@ -41,6 +45,8 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
 
   const activeServerId = $derived(getActiveServer());
   const serverSegment = $derived(serverIdToSegment(activeServerId));
+  const activeServer = $derived(serverRegistry.getServer(activeServerId));
+  const activeServerBaseURL = $derived(activeServer?.url ?? null);
   const stores = $derived(serverRegistry.getStore(activeServerId));
   const currentUserState = $derived(stores.currentUser);
   const notificationStore = $derived(stores.notifications);
@@ -304,19 +310,17 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
 
 {#snippet activeCallIcon()}
   <span
-    class="sidebar-icon relative text-accent"
+    class="relative sidebar-icon text-accent"
     aria-label="Active call"
     data-testid="room-call-icon"
   >
     <span class="relative inline-flex">
       <span
-        class="pane-header-icon-glyph absolute inset-0 animate-ping opacity-45 uil--phone"
+        class="absolute inset-0 pane-header-icon-glyph animate-ping opacity-45 uil--phone"
         aria-hidden="true"
         data-testid="active-call-pulse-icon"
       ></span>
-      <span
-        class="pane-header-icon-glyph relative text-accent uil--phone"
-        aria-hidden="true"
+      <span class="relative pane-header-icon-glyph text-accent uil--phone" aria-hidden="true"
       ></span>
     </span>
   </span>
@@ -367,7 +371,6 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
       <UnreadDot color="primary" testid="room-unread-dot" />
       <span class="sr-only">unread messages</span>
     {/if}
-
   </a>
 {/snippet}
 
@@ -409,7 +412,6 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
       <UnreadDot color="primary" testid="dm-unread-dot" />
       <span class="sr-only">unread messages</span>
     {/if}
-
   </a>
 {/snippet}
 
@@ -420,14 +422,18 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
       {@render roomLink(room)}
     {/if}
   {:else}
-    <button
-      type="button"
-      class="sidebar-item w-full text-left"
-      onclick={() => window.open(item.link.url, '_blank', 'noopener,noreferrer')}
+    {@const target = sidebarLinkTarget(item.link.url, activeServerBaseURL)}
+    <a
+      {...sidebarLinkAnchorAttributes(target)}
+      aria-disabled={!target.valid}
+      class={['sidebar-item w-full text-left', !target.valid && 'cursor-not-allowed opacity-60']}
+      onclick={(event) => {
+        if (!target.valid) event.preventDefault();
+      }}
     >
       <span class="sidebar-icon iconify text-muted uil--external-link-alt"></span>
       <span class="flex-1 truncate">{item.link.label}</span>
-    </button>
+    </a>
   {/if}
 {/snippet}
 

--- a/frontend/src/lib/RoomList.svelte.spec.ts
+++ b/frontend/src/lib/RoomList.svelte.spec.ts
@@ -363,26 +363,29 @@ describe('RoomList', () => {
   it.each([
     ['Enter', 'Enter'],
     ['Space', ' ']
-  ])('opens the call panel on %s when an active-call row has keyboard focus', async (_label, key) => {
-    mocks.activeCallRoomIds.add('channel-1');
+  ])(
+    'opens the call panel on %s when an active-call row has keyboard focus',
+    async (_label, key) => {
+      mocks.activeCallRoomIds.add('channel-1');
 
-    const { container } = render(RoomList);
+      const { container } = render(RoomList);
 
-    await expect.element(q(container, '[href="/chat/-/channel-1"]')).toBeInTheDocument();
-    const channelRow = q(container, '[href="/chat/-/channel-1"]') as HTMLAnchorElement;
+      await expect.element(q(container, '[href="/chat/-/channel-1"]')).toBeInTheDocument();
+      const channelRow = q(container, '[href="/chat/-/channel-1"]') as HTMLAnchorElement;
 
-    const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
-    const wasNotCanceled = channelRow.dispatchEvent(event);
+      const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+      const wasNotCanceled = channelRow.dispatchEvent(event);
 
-    expect(wasNotCanceled).toBe(false);
-    await vi.waitFor(() => {
-      expect(mocks.goto).toHaveBeenCalledWith('/chat/-/channel-1');
-    });
-    expect(
-      localStorage.getItem(serverStorageKey('origin', roomSidebarPanelStorageSuffix('channel-1')))
-    ).toBe('call');
-    expect(consumePendingRoomSidebarPanel('origin', 'channel-1')).toBe('call');
-  });
+      expect(wasNotCanceled).toBe(false);
+      await vi.waitFor(() => {
+        expect(mocks.goto).toHaveBeenCalledWith('/chat/-/channel-1');
+      });
+      expect(
+        localStorage.getItem(serverStorageKey('origin', roomSidebarPanelStorageSuffix('channel-1')))
+      ).toBe('call');
+      expect(consumePendingRoomSidebarPanel('origin', 'channel-1')).toBe('call');
+    }
+  );
 
   it('opens a join modal for a faded joinable non-member channel row', async () => {
     const { container } = render(RoomList);
@@ -423,6 +426,87 @@ describe('RoomList', () => {
         viewerCanJoinRoom: false
       }
     });
+  });
+
+  it('renders server-local sidebar links as same-tab anchors resolved against the active server', async () => {
+    mocks.store.rooms.roomGroups = [
+      {
+        id: 'g1',
+        name: 'Links',
+        roomIds: [],
+        items: [
+          {
+            id: 'link:docs',
+            type: 'link',
+            link: { id: 'docs', label: 'Docs', url: '/docs' }
+          }
+        ]
+      }
+    ];
+
+    const { container } = render(RoomList);
+
+    const link = q(container, '[href="https://chat.example.test/docs"]') as HTMLAnchorElement;
+    await expect.element(link).toBeInTheDocument();
+    expect(link.textContent).toContain('Docs');
+    expect(link.getAttribute('target')).toBeNull();
+    expect(link.getAttribute('rel')).toBeNull();
+  });
+
+  it('renders active-server host sidebar links as same-tab anchors', async () => {
+    mocks.store.rooms.roomGroups = [
+      {
+        id: 'g1',
+        name: 'Links',
+        roomIds: [],
+        items: [
+          {
+            id: 'link:admin',
+            type: 'link',
+            link: {
+              id: 'admin',
+              label: 'Admin',
+              url: 'https://chat.example.test/admin'
+            }
+          }
+        ]
+      }
+    ];
+
+    const { container } = render(RoomList);
+
+    const link = q(container, '[href="https://chat.example.test/admin"]') as HTMLAnchorElement;
+    await expect.element(link).toBeInTheDocument();
+    expect(link.getAttribute('target')).toBeNull();
+    expect(link.getAttribute('rel')).toBeNull();
+  });
+
+  it('renders external sidebar links as new-tab anchors', async () => {
+    mocks.store.rooms.roomGroups = [
+      {
+        id: 'g1',
+        name: 'Links',
+        roomIds: [],
+        items: [
+          {
+            id: 'link:external',
+            type: 'link',
+            link: {
+              id: 'external',
+              label: 'External Docs',
+              url: 'https://docs.example.test'
+            }
+          }
+        ]
+      }
+    ];
+
+    const { container } = render(RoomList);
+
+    const link = q(container, '[href="https://docs.example.test/"]') as HTMLAnchorElement;
+    await expect.element(link).toBeInTheDocument();
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer');
   });
 
   it('resolves a stale channel badge through the room-scoped notification query', async () => {

--- a/frontend/src/lib/RoomList.svelte.spec.ts
+++ b/frontend/src/lib/RoomList.svelte.spec.ts
@@ -7,6 +7,7 @@ import {
   consumePendingRoomSidebarPanel,
   roomSidebarPanelStorageSuffix
 } from '$lib/storage/roomSidebarPanel';
+import type { RoomsListGroup } from '$lib/state/server/rooms.svelte';
 
 const { mocks } = vi.hoisted(() => ({
   mocks: {
@@ -55,7 +56,7 @@ const { mocks } = vi.hoisted(() => ({
       },
       rooms: {
         rooms: [],
-        roomGroups: null,
+        roomGroups: null as RoomsListGroup[] | null,
         isInitialLoading: false,
         currentUserId: 'me',
         markRead: vi.fn(),

--- a/frontend/src/lib/navigation/sidebarLinkTarget.spec.ts
+++ b/frontend/src/lib/navigation/sidebarLinkTarget.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { sidebarLinkTarget } from './sidebarLinkTarget';
+
+describe('sidebarLinkTarget', () => {
+  it('resolves server-local paths against the active server base URL', () => {
+    expect(sidebarLinkTarget('/docs', 'https://remote.example.test')).toEqual({
+      valid: true,
+      href: 'https://remote.example.test/docs'
+    });
+  });
+
+  it('opens absolute URLs on the active server host in the same tab', () => {
+    expect(
+      sidebarLinkTarget('https://remote.example.test/docs', 'https://remote.example.test')
+    ).toEqual({
+      valid: true,
+      href: 'https://remote.example.test/docs'
+    });
+  });
+
+  it('compares hosts with ports intact', () => {
+    expect(sidebarLinkTarget('http://localhost:4000/docs', 'http://localhost:4000')).toEqual({
+      valid: true,
+      href: 'http://localhost:4000/docs'
+    });
+    expect(sidebarLinkTarget('http://localhost:4001/docs', 'http://localhost:4000')).toEqual({
+      valid: true,
+      href: 'http://localhost:4001/docs',
+      target: '_blank',
+      rel: 'noopener noreferrer'
+    });
+  });
+
+  it('opens external absolute URLs in a new tab', () => {
+    expect(sidebarLinkTarget('https://docs.example.test', 'https://remote.example.test')).toEqual({
+      valid: true,
+      href: 'https://docs.example.test/',
+      target: '_blank',
+      rel: 'noopener noreferrer'
+    });
+  });
+
+  it.each(['docs', '//evil.example', 'javascript:alert(1)', 'mailto:hello@example.test'])(
+    'treats %s as invalid',
+    (rawURL) => {
+      expect(sidebarLinkTarget(rawURL, 'https://remote.example.test')).toEqual({
+        valid: false,
+        href: '#'
+      });
+    }
+  );
+});

--- a/frontend/src/lib/navigation/sidebarLinkTarget.spec.ts
+++ b/frontend/src/lib/navigation/sidebarLinkTarget.spec.ts
@@ -40,7 +40,13 @@ describe('sidebarLinkTarget', () => {
     });
   });
 
-  it.each(['docs', '//evil.example', 'javascript:alert(1)', 'mailto:hello@example.test'])(
+  it.each([
+    'docs',
+    '//evil.example',
+    '/\\evil.example/path',
+    'javascript:alert(1)',
+    'mailto:hello@example.test'
+  ])(
     'treats %s as invalid',
     (rawURL) => {
       expect(sidebarLinkTarget(rawURL, 'https://remote.example.test')).toEqual({

--- a/frontend/src/lib/navigation/sidebarLinkTarget.ts
+++ b/frontend/src/lib/navigation/sidebarLinkTarget.ts
@@ -1,0 +1,78 @@
+export type SidebarLinkTarget =
+  | {
+      valid: true;
+      href: string;
+      target?: '_blank';
+      rel?: 'noopener noreferrer';
+    }
+  | {
+      valid: false;
+      href: '#';
+    };
+
+export type SidebarLinkAnchorAttributes = {
+  href: string;
+  target?: '_blank';
+  rel?: 'noopener noreferrer';
+};
+
+function invalidSidebarLinkTarget(): SidebarLinkTarget {
+  return { valid: false, href: '#' };
+}
+
+function parseServerBaseURL(serverBaseURL: string | null | undefined): URL | null {
+  if (!serverBaseURL) return null;
+  try {
+    return new URL(serverBaseURL);
+  } catch {
+    return null;
+  }
+}
+
+export function sidebarLinkTarget(
+  rawURL: string,
+  serverBaseURL: string | null | undefined
+): SidebarLinkTarget {
+  const value = rawURL.trim();
+  if (!value) return invalidSidebarLinkTarget();
+
+  const serverURL = parseServerBaseURL(serverBaseURL);
+
+  if (value.startsWith('/')) {
+    if (!serverURL || value.startsWith('//')) return invalidSidebarLinkTarget();
+    try {
+      return { valid: true, href: new URL(value, serverURL).toString() };
+    } catch {
+      return invalidSidebarLinkTarget();
+    }
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return invalidSidebarLinkTarget();
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return invalidSidebarLinkTarget();
+  }
+
+  if (serverURL && parsed.host === serverURL.host) {
+    return { valid: true, href: parsed.toString() };
+  }
+
+  return {
+    valid: true,
+    href: parsed.toString(),
+    target: '_blank',
+    rel: 'noopener noreferrer'
+  };
+}
+
+export function sidebarLinkAnchorAttributes(
+  target: SidebarLinkTarget
+): SidebarLinkAnchorAttributes {
+  if (!target.valid) return { href: target.href };
+  return { href: target.href, target: target.target, rel: target.rel };
+}

--- a/frontend/src/lib/navigation/sidebarLinkTarget.ts
+++ b/frontend/src/lib/navigation/sidebarLinkTarget.ts
@@ -39,7 +39,9 @@ export function sidebarLinkTarget(
   const serverURL = parseServerBaseURL(serverBaseURL);
 
   if (value.startsWith('/')) {
-    if (!serverURL || value.startsWith('//')) return invalidSidebarLinkTarget();
+    if (!serverURL || value.startsWith('//') || value.includes('\\')) {
+      return invalidSidebarLinkTarget();
+    }
     try {
       return { valid: true, href: new URL(value, serverURL).toString() };
     } catch {

--- a/frontend/src/routes/chat/[serverId]/server-admin/rooms/AdminRoomLayoutEditor.svelte
+++ b/frontend/src/routes/chat/[serverId]/server-admin/rooms/AdminRoomLayoutEditor.svelte
@@ -656,7 +656,12 @@
   onclose={() => (linkDialogVisible = false)}
 >
   <TextInput id="sidebar-link-label" label="Label" bind:value={linkLabel} />
-  <TextInput id="sidebar-link-url" label="URL" bind:value={linkUrl} />
+  <TextInput
+    id="sidebar-link-url"
+    label="URL"
+    bind:value={linkUrl}
+    placeholder="https://docs.example.com or /docs"
+  />
 </FormDialog>
 
 {#if deleteGroupConfirmDialogVisible && deleteGroupConfirm}

--- a/proto/chatto/core/v1/models.proto
+++ b/proto/chatto/core/v1/models.proto
@@ -372,7 +372,7 @@ message RoomLayout {
 message SidebarLink {
   string id = 1;     // NanoID for stable identity across renames/moves
   string label = 2;  // Display label shown in the server sidebar
-  string url = 3;    // Absolute http(s) URL opened outside Chatto
+  string url = 3;    // Absolute http(s) URL or server-local path starting with /
 }
 
 message SidebarGroupEntry {

--- a/proto/chatto/core/v1/room_group_events.proto
+++ b/proto/chatto/core/v1/room_group_events.proto
@@ -71,14 +71,14 @@ message SidebarLinkAddedToGroupEvent {
   string group_id = 1;
   string link_id = 2;
   string label = 3;
-  string url = 4;
+  string url = 4; // Absolute http(s) URL or server-local path starting with /
 }
 
 message SidebarLinkUpdatedEvent {
   string group_id = 1;
   string link_id = 2;
   string label = 3;
-  string url = 4;
+  string url = 4; // Absolute http(s) URL or server-local path starting with /
 }
 
 message SidebarLinkRemovedFromGroupEvent {


### PR DESCRIPTION
## Summary
- Support server-local room-group sidebar links that resolve against the active server and open in the same tab.
- Keep off-server absolute links opening in a new tab, with focused backend/frontend tests for accepted and rejected targets.
- Update FDR, glossary, architecture, GraphQL descriptions, and protobuf comments for the expanded sidebar-link URL contract.

## Tests
- `mise x -- go test ./internal/core ./internal/graph -run "SidebarLink" -timeout 60s`
- `pnpm test:unit --run --project client src/lib/RoomList.svelte.spec.ts src/lib/navigation/sidebarLinkTarget.spec.ts`
- `pnpm test:unit --run --project server src/lib/navigation/sidebarLinkTarget.spec.ts`

Protocol buffer and GraphQL schema files changed only in comments/descriptions; no wire or API shape changes.
