### PR TITLE
perf: fast-path projection stream sequence parsing

### DIFF
--- a/cli/internal/events/events_test.go
+++ b/cli/internal/events/events_test.go
@@ -1222,6 +1222,90 @@ func TestCompiledSubjectFilterMatchesWithoutAllocations(t *testing.T) {
 	}
 }
 
+func TestStreamSequenceFromReply(t *testing.T) {
+	cases := []struct {
+		name    string
+		reply   string
+		want    uint64
+		wantErr bool
+	}{
+		{
+			name:  "v2 with domain and token",
+			reply: "$JS.ACK.domain.hash-123.stream.cons.100.200.150.123456789.100.token",
+			want:  200,
+		},
+		{
+			name:  "v2 without trailing token",
+			reply: "$JS.ACK.domain.hash-123.stream.cons.100.201.150.123456789.100",
+			want:  201,
+		},
+		{
+			name:  "v2 underscore domain",
+			reply: "$JS.ACK._.hash-123.stream.cons.100.202.150.123456789.100.token",
+			want:  202,
+		},
+		{
+			name:  "v1",
+			reply: "$JS.ACK.stream.cons.100.203.150.123456789.100",
+			want:  203,
+		},
+		{
+			name:    "invalid prefix",
+			reply:   "$ABC.123.stream.cons.100.200.150.123456789.100",
+			wantErr: true,
+		},
+		{
+			name:    "invalid token count",
+			reply:   "$JS.ACK.stream.cons.100.200.150.123456789.100.extra",
+			wantErr: true,
+		},
+		{
+			name:    "non numeric sequence",
+			reply:   "$JS.ACK.stream.cons.100.not-a-seq.150.123456789.100",
+			wantErr: true,
+		},
+		{
+			name:    "empty",
+			reply:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := streamSequenceFromReply(tc.reply)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("streamSequenceFromReply(%q) error = nil, want error", tc.reply)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("streamSequenceFromReply(%q) error = %v", tc.reply, err)
+			}
+			if got != tc.want {
+				t.Fatalf("streamSequenceFromReply(%q) = %d, want %d", tc.reply, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStreamSequenceFromReplyDoesNotAllocate(t *testing.T) {
+	reply := "$JS.ACK.domain.hash-123.stream.cons.100.200.150.123456789.100.token"
+	allocs := testing.AllocsPerRun(1000, func() {
+		got, err := streamSequenceFromReply(reply)
+		if err != nil {
+			t.Fatalf("streamSequenceFromReply error = %v", err)
+		}
+		if got != 200 {
+			t.Fatalf("streamSequenceFromReply = %d, want 200", got)
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("streamSequenceFromReply allocations = %v, want 0", allocs)
+	}
+}
+
 func TestProjectorCachesProjectionSubjects(t *testing.T) {
 	proj := newCountingSubjectsProjection(
 		RoomSubjectFilter(),

--- a/cli/internal/events/projector.go
+++ b/cli/internal/events/projector.go
@@ -619,7 +619,7 @@ func (p *Projector) handleMessage(msg jetstream.Msg) {
 		return
 	}
 
-	meta, err := msg.Metadata()
+	seq, err := streamSequenceFromMsg(msg)
 	if err != nil {
 		p.logger.Error("Projection message metadata failed", "subject", msg.Subject(), "error", err)
 		p.fail(0, fmt.Errorf("message metadata for subject %q: %w", msg.Subject(), err))
@@ -635,24 +635,24 @@ func (p *Projector) handleMessage(msg jetstream.Msg) {
 		err = fmt.Errorf("unmarshal event on subject %q: %w", msg.Subject(), err)
 		p.logger.Error("Projection decode failed",
 			"subject", msg.Subject(),
-			"seq", meta.Sequence.Stream,
+			"seq", seq,
 			"error", err)
-		p.fail(meta.Sequence.Stream, err)
+		p.fail(seq, err)
 		return
 	}
 
-	if err := p.proj.Apply(&event, meta.Sequence.Stream); err != nil {
+	if err := p.proj.Apply(&event, seq); err != nil {
 		p.logger.Error("Projection Apply failed",
 			"subject", msg.Subject(),
-			"seq", meta.Sequence.Stream,
+			"seq", seq,
 			"event_id", event.GetId(),
 			"error", err)
-		p.fail(meta.Sequence.Stream, err)
+		p.fail(seq, err)
 		return
 	}
 
 	p.countStartupMessage()
-	p.advance(meta.Sequence.Stream)
+	p.advance(seq)
 	p.maybeCompleteStartup(time.Now())
 }
 
@@ -841,7 +841,7 @@ func sameSubjects(a, b []string) bool {
 }
 
 func handleSharedProjectorMessage(msg jetstream.Msg, projectors []*Projector, failedCh chan<- struct{}) {
-	meta, err := msg.Metadata()
+	seq, err := streamSequenceFromMsg(msg)
 	if err != nil {
 		err := fmt.Errorf("message metadata for subject %q: %w", msg.Subject(), err)
 		for _, projector := range projectors {
@@ -870,9 +870,9 @@ func handleSharedProjectorMessage(msg jetstream.Msg, projectors []*Projector, fa
 		for _, projector := range consumers {
 			projector.logger.Error("Projection decode failed",
 				"subject", msg.Subject(),
-				"seq", meta.Sequence.Stream,
+				"seq", seq,
 				"error", err)
-			projector.fail(meta.Sequence.Stream, err)
+			projector.fail(seq, err)
 		}
 		notifySharedProjectorFailure(failedCh)
 		return
@@ -880,25 +880,82 @@ func handleSharedProjectorMessage(msg jetstream.Msg, projectors []*Projector, fa
 
 	var applyErr error
 	for _, projector := range consumers {
-		if err := projector.proj.Apply(&event, meta.Sequence.Stream); err != nil {
+		if err := projector.proj.Apply(&event, seq); err != nil {
 			projector.logger.Error("Projection Apply failed",
 				"subject", msg.Subject(),
-				"seq", meta.Sequence.Stream,
+				"seq", seq,
 				"event_id", event.GetId(),
 				"error", err)
-			projector.fail(meta.Sequence.Stream, err)
+			projector.fail(seq, err)
 			if applyErr == nil {
 				applyErr = err
 			}
 			continue
 		}
 		projector.countStartupMessage()
-		projector.advance(meta.Sequence.Stream)
+		projector.advance(seq)
 		projector.maybeCompleteStartup(now)
 	}
 	if applyErr != nil {
 		notifySharedProjectorFailure(failedCh)
 	}
+}
+
+func streamSequenceFromMsg(msg jetstream.Msg) (uint64, error) {
+	return streamSequenceFromReply(msg.Reply())
+}
+
+func streamSequenceFromReply(reply string) (uint64, error) {
+	const jsAckPrefix = "$JS.ACK."
+	if len(reply) < len(jsAckPrefix) || reply[:len(jsAckPrefix)] != jsAckPrefix {
+		return 0, fmt.Errorf("invalid JetStream ACK reply subject")
+	}
+
+	var v1Start, v1End int
+	var v2Start, v2End int
+	tokenStart := 0
+	tokenIndex := 0
+	for i := 0; i <= len(reply); i++ {
+		if i != len(reply) && reply[i] != '.' {
+			continue
+		}
+		switch tokenIndex {
+		case 5:
+			v1Start, v1End = tokenStart, i
+		case 7:
+			v2Start, v2End = tokenStart, i
+		}
+		tokenIndex++
+		tokenStart = i + 1
+	}
+
+	switch {
+	case tokenIndex == 9:
+		return parseAckSequenceToken(reply[v1Start:v1End])
+	case tokenIndex >= 11:
+		return parseAckSequenceToken(reply[v2Start:v2End])
+	default:
+		return 0, fmt.Errorf("invalid JetStream ACK reply subject")
+	}
+}
+
+func parseAckSequenceToken(token string) (uint64, error) {
+	if token == "" {
+		return 0, fmt.Errorf("invalid JetStream ACK stream sequence")
+	}
+	var n uint64
+	for i := 0; i < len(token); i++ {
+		c := token[i]
+		if c < '0' || c > '9' {
+			return 0, fmt.Errorf("invalid JetStream ACK stream sequence")
+		}
+		digit := uint64(c - '0')
+		if n > (^uint64(0)-digit)/10 {
+			return 0, fmt.Errorf("invalid JetStream ACK stream sequence")
+		}
+		n = n*10 + digit
+	}
+	return n, nil
 }
 
 func notifySharedProjectorFailure(ch chan<- struct{}) {


### PR DESCRIPTION
- Fast-path projection stream sequence extraction by parsing only the JetStream ACK reply token instead of allocating full message metadata in projector handlers.
- Preserve projection failure, waiter, and read-your-writes sequencing behavior by continuing to use the stream sequence.
- Add coverage for v1/v2 ACK reply formats, invalid replies, non-numeric sequences, and zero-allocation parsing.

Tests:
- `mise x -- go test ./internal/events -timeout 60s`
- `mise x -- go test ./internal/core ./internal/events -timeout 60s`

Benchmark:
- Local imported-data startup benchmark: projector replay average `78.4ms` on `origin/main` to `68.9ms` on this branch across four runs.
