### PR TITLE
feat(frontend): show reaction names in popups

### DIFF
--- a/frontend/e2e/pages/MessageComponent.ts
+++ b/frontend/e2e/pages/MessageComponent.ts
@@ -347,41 +347,28 @@ export class MessageComponent {
     await expect(reactionButton).not.toBeVisible({ timeout: TIMEOUTS.UI_FAST });
   }
 
-  /**
-   * Get the reaction group container for a specific emoji.
-   * The container holds both the button and its tooltip.
-   */
-  private getReactionGroup(emoji: string): Locator {
-    // Find the button, then go up to its parent group container
-    return this.locator
-      .getByRole('button', { name: new RegExp(`${emoji} reaction`) })
-      .locator('..');
+  private getReactionButton(emoji: string): Locator {
+    return this.locator.getByRole('button', { name: new RegExp(`${emoji} reaction`) });
   }
 
   /**
    * Hover over a reaction button and verify the tooltip shows the expected text.
    */
   async expectReactionTooltip(emoji: string, expectedText: string | RegExp): Promise<void> {
-    const group = this.getReactionGroup(emoji);
-    const button = group.getByRole('button');
-    await button.hover();
+    await this.getReactionButton(emoji).hover();
 
-    // Find the tooltip within the same group container (sibling of button)
-    const tooltip = group.getByRole('tooltip');
+    const tooltip = this.page.getByRole('tooltip');
     await expect(tooltip).toBeVisible();
-    await expect(tooltip).toHaveText(expectedText);
+    await expect(tooltip).toContainText(expectedText);
   }
 
   /**
    * Hover over a reaction and verify tooltip contains specific user name(s).
    */
   async expectReactionTooltipContains(emoji: string, userName: string): Promise<void> {
-    const group = this.getReactionGroup(emoji);
-    const button = group.getByRole('button');
-    await button.hover();
+    await this.getReactionButton(emoji).hover();
 
-    // Find the tooltip within the same group container (sibling of button)
-    const tooltip = group.getByRole('tooltip');
+    const tooltip = this.page.getByRole('tooltip');
     await expect(tooltip).toBeVisible();
     await expect(tooltip).toContainText(userName);
   }

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -435,6 +435,11 @@
   @apply bg-surface-100;
 }
 
+/* Simple non-interactive tooltip surface for FloatingTooltip. */
+@utility floating-tooltip {
+  @apply max-w-xs rounded-md border border-text/10 bg-surface-200 px-2.5 py-1.5 text-xs leading-snug text-text shadow-lg;
+}
+
 @layer base {
   html {
     height: 100%;

--- a/frontend/src/lib/emoji.spec.ts
+++ b/frontend/src/lib/emoji.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { getEmojiDisplayName } from './emoji';
+
+describe('getEmojiDisplayName', () => {
+  it('formats known reaction shortcodes as readable names', () => {
+    expect(getEmojiDisplayName('thumbsup')).toBe('Thumbs up');
+    expect(getEmojiDisplayName('woman_health_worker')).toBe('Woman Health Worker');
+  });
+
+  it('formats unicode emoji as readable names', () => {
+    expect(getEmojiDisplayName('🚀')).toBe('Rocket');
+    expect(getEmojiDisplayName('❤️')).toBe('Heart');
+  });
+
+  it('falls back to a readable version of unknown names', () => {
+    expect(getEmojiDisplayName('custom-party')).toBe('Custom Party');
+  });
+});

--- a/frontend/src/lib/emoji.ts
+++ b/frontend/src/lib/emoji.ts
@@ -133,6 +133,35 @@ export function emojiToName(emoji: string): string | undefined {
   return emojiToNameMap[emoji];
 }
 
+const EMOJI_DISPLAY_NAME_OVERRIDES: Record<string, string> = {
+  thumbsup: 'Thumbs up',
+  thumbsdown: 'Thumbs down'
+};
+
+/**
+ * Human-readable label for a reaction emoji or shortcode.
+ * @example getEmojiDisplayName('thumbsup') // 'Thumbs up'
+ * @example getEmojiDisplayName('🚀') // 'Rocket'
+ */
+export function getEmojiDisplayName(emojiOrName: string): string {
+  const emoji = getEmojiByName(emojiOrName) ?? emojiOrName;
+  const name = emojiToName(emoji) ?? emojiOrName;
+  const override = EMOJI_DISPLAY_NAME_OVERRIDES[name];
+  if (override) return override;
+
+  const readable = name
+    .replace(/^:+|:+$/g, '')
+    .replace(/[+_-]+/g, ' ')
+    .trim();
+
+  if (!readable) return emojiOrName;
+
+  return readable
+    .split(/\s+/)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
 /**
  * Emoji categories with representative icons for tab rendering.
  * Order matches the standard Unicode emoji category order.

--- a/frontend/src/lib/ui/FloatingPopover.svelte
+++ b/frontend/src/lib/ui/FloatingPopover.svelte
@@ -14,8 +14,9 @@ this with their own semantics and styling; reach for them first.
 Positioning modes (exactly one is required):
 
 - **`anchor`** — anchor rect with `{ top, bottom, left }`. The popover
-  is placed below the anchor by default, flipped above if there's no
-  room, and horizontally clamped to the viewport.
+  is placed below the anchor by default, or above when `anchorPlacement`
+  is `"top"`, with fallback to the opposite side if there is no room. It
+  is horizontally clamped to the viewport.
 - **`position`** — viewport point `{ x, y }`, with optional
   `alignRight` / `centerX` flags. Used for cursor-driven menus.
 
@@ -39,6 +40,8 @@ pointer-only).
   let {
     position,
     anchor,
+    anchorPlacement = 'bottom',
+    open = true,
     role,
     ariaLabel,
     id,
@@ -50,6 +53,8 @@ pointer-only).
   }: {
     position?: { x: number; y: number; alignRight?: boolean; centerX?: boolean };
     anchor?: { top: number; bottom: number; left: number } | null;
+    anchorPlacement?: 'top' | 'bottom';
+    open?: boolean;
     role?: string;
     ariaLabel?: string;
     id?: string;
@@ -74,11 +79,20 @@ pointer-only).
     let left: number;
 
     if (anchor) {
-      // Anchor mode: prefer below, fall back above, then pin to bottom.
-      if (anchor.bottom + GAP + height <= window.innerHeight - PADDING) {
-        top = anchor.bottom + GAP;
-      } else if (anchor.top - GAP - height >= PADDING) {
+      const fitsBelow = anchor.bottom + GAP + height <= window.innerHeight - PADDING;
+      const fitsAbove = anchor.top - GAP - height >= PADDING;
+      const preferAbove = anchorPlacement === 'top';
+
+      // Anchor mode: honor preferred side, fall back to the opposite side,
+      // then pin inside the viewport.
+      if (preferAbove && fitsAbove) {
         top = anchor.top - GAP - height;
+      } else if (!preferAbove && fitsBelow) {
+        top = anchor.bottom + GAP;
+      } else if (fitsAbove) {
+        top = anchor.top - GAP - height;
+      } else if (fitsBelow) {
+        top = anchor.bottom + GAP;
       } else {
         top = Math.max(PADDING, window.innerHeight - PADDING - height);
       }
@@ -113,20 +127,43 @@ pointer-only).
     node.style.left = `${left}px`;
   }
 
+  function showAndPosition() {
+    if (!node) return;
+    const wasOpen = node.matches(':popover-open');
+
+    if (!wasOpen) {
+      node.style.visibility = 'hidden';
+      node.showPopover();
+    }
+
+    applyPosition();
+
+    if (!wasOpen) {
+      node.style.visibility = '';
+    }
+  }
+
   // Show on mount + reposition reactively whenever anchor/position changes.
   $effect(() => {
     if (!node) return;
     // Re-read reactive inputs so the effect retriggers when they change.
+    void open;
     void anchor;
+    void anchorPlacement;
     void position;
-    node.showPopover();
-    applyPosition();
+
+    if (!open) {
+      if (node.matches(':popover-open')) node.hidePopover();
+      return;
+    }
+
+    showAndPosition();
   });
 
   // Pointer-based dismissal (deferred one frame so the opening click doesn't
   // immediately close the popover).
   $effect(() => {
-    if (!node || !onclose) return;
+    if (!node || !open || !onclose) return;
     const handlePointerDown = (e: PointerEvent) => {
       if (!node || node.contains(e.target as Node)) return;
       onclose();
@@ -151,7 +188,7 @@ pointer-only).
   bind:this={node}
   {id}
   popover="manual"
-  class={['fixed z-50 m-0', className]}
+  class={['fixed inset-auto z-50 m-0', !open && 'hidden', className]}
   {role}
   aria-label={ariaLabel}
   {onmouseenter}

--- a/frontend/src/lib/ui/FloatingTooltip.stories.svelte
+++ b/frontend/src/lib/ui/FloatingTooltip.stories.svelte
@@ -1,0 +1,84 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import FloatingTooltip from './FloatingTooltip.svelte';
+
+  const componentDescription = `
+FloatingTooltip is a lightweight, non-interactive tooltip surface for short contextual labels.
+It renders through \`FloatingPopover\`, so it appears in the browser top layer and avoids clipping
+inside virtualized lists, sticky panes, or transformed parents.
+
+### Composition
+
+The trigger owns open/closed state. Read the trigger's \`getBoundingClientRect()\` when opening,
+pass that rect as \`anchor\`, and wire the tooltip id to the trigger with \`aria-describedby\`.
+When the trigger lives inside a measured or virtualized list, keep the tooltip mounted and toggle
+the \`open\` prop instead of conditionally rendering it; that avoids child-list mutations inside
+the measured row.
+
+\`\`\`svelte
+<FloatingTooltip open={!!tooltipAnchor} anchor={tooltipAnchor} id="reaction-tooltip">
+  <span><strong class="font-semibold">Thumbs up</strong> · Alice, Bob</span>
+</FloatingTooltip>
+\`\`\`
+
+Use \`HelpTooltip\` when the trigger is an info icon with pin/dismiss behavior. Use \`ContextMenu\`
+for interactive floating content.
+`.trim();
+
+  const { Story } = defineMeta({
+    title: 'UI/FloatingTooltip',
+    component: FloatingTooltip,
+    tags: ['autodocs'],
+    parameters: { docs: { description: { component: componentDescription } } }
+  });
+</script>
+
+<script lang="ts">
+  let reactionAnchor = $state<{ top: number; bottom: number; left: number } | null>(null);
+  const reactionTooltipId = 'storybook-reaction-tooltip';
+
+  function showReactionTooltip(e: MouseEvent | FocusEvent) {
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    reactionAnchor = { top: rect.top, bottom: rect.bottom, left: rect.left };
+  }
+
+  function hideReactionTooltip() {
+    reactionAnchor = null;
+  }
+</script>
+
+<Story
+  name="Reaction detail"
+  asChild
+  parameters={{
+    docs: {
+      description: {
+        story:
+          'A compact, one-line tooltip for reaction metadata. The tooltip stays mounted and toggles `open`, matching virtualized-list usage.'
+      }
+    }
+  }}
+>
+  <div class="flex min-h-32 items-center gap-3 rounded border border-input-border bg-surface p-6 text-text">
+    <button
+      type="button"
+      class="meta-badge h-[25px] cursor-pointer gap-1 border-accent/50 px-2 text-sm text-muted"
+      aria-describedby={reactionAnchor ? reactionTooltipId : undefined}
+      onmouseenter={showReactionTooltip}
+      onmouseleave={hideReactionTooltip}
+      onfocus={showReactionTooltip}
+      onblur={hideReactionTooltip}
+    >
+      <span aria-hidden="true">👍</span>
+      <span class="text-xs" aria-hidden="true">2</span>
+    </button>
+    <span class="text-sm text-muted">Hover or focus the reaction badge.</span>
+
+    <FloatingTooltip open={!!reactionAnchor} anchor={reactionAnchor} id={reactionTooltipId}>
+      <span class="whitespace-nowrap">
+        <strong class="font-semibold">Thumbs up</strong>
+        <span> · Alice, Bob</span>
+      </span>
+    </FloatingTooltip>
+  </div>
+</Story>

--- a/frontend/src/lib/ui/FloatingTooltip.svelte
+++ b/frontend/src/lib/ui/FloatingTooltip.svelte
@@ -1,0 +1,56 @@
+<!--
+@component
+
+Small non-interactive tooltip surface rendered through `FloatingPopover`.
+
+Use this when a trigger already owns its hover/focus/open state and only needs
+to display short contextual text in the top layer. For pinned or interactive
+help content, use `HelpTooltip` instead.
+
+**Props:**
+- `anchor` - Element rect `{ top, bottom, left }` for anchor-based positioning
+- `open` - Whether the tooltip is visible. Keep mounted and toggle this when the trigger is in a measured list.
+- `placement` - Preferred side for anchored tooltips, defaults to `bottom`
+- `position` - Viewport point for cursor/coordinate positioning
+- `id` - Optional tooltip id for `aria-describedby`
+- `ariaLabel` - Optional accessible label for the tooltip surface
+- `class` - Optional extra classes for the floating surface
+-->
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import type { ClassValue } from 'svelte/elements';
+  import FloatingPopover from './FloatingPopover.svelte';
+
+  let {
+    anchor,
+    open = true,
+    placement = 'bottom',
+    position,
+    id,
+    ariaLabel,
+    class: className,
+    children
+  }: {
+    anchor?: { top: number; bottom: number; left: number } | null;
+    open?: boolean;
+    placement?: 'top' | 'bottom';
+    position?: { x: number; y: number; alignRight?: boolean; centerX?: boolean };
+    id?: string;
+    ariaLabel?: string;
+    class?: ClassValue;
+    children: Snippet;
+  } = $props();
+</script>
+
+<FloatingPopover
+  {anchor}
+  {open}
+  anchorPlacement={placement}
+  {position}
+  role="tooltip"
+  {id}
+  {ariaLabel}
+  class={['floating-tooltip pointer-events-none', className]}
+>
+  {@render children()}
+</FloatingPopover>

--- a/frontend/src/lib/ui/FloatingTooltip.svelte.spec.ts
+++ b/frontend/src/lib/ui/FloatingTooltip.svelte.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { testSnippet } from '$lib/test-utils';
+import FloatingTooltip from './FloatingTooltip.svelte';
+
+describe('FloatingTooltip', () => {
+  it('stays mounted when closed so measured parents do not get child-list mutations', () => {
+    const { container } = render(FloatingTooltip, {
+      props: {
+        open: false,
+        position: { x: 24, y: 32 },
+        id: 'tooltip-closed',
+        children: testSnippet('<span>Tooltip body</span>')
+      }
+    });
+
+    const tooltip = container.querySelector('[role="tooltip"]') as HTMLElement;
+
+    expect(tooltip).not.toBeNull();
+    expect(tooltip.matches(':popover-open')).toBe(false);
+    expect(getComputedStyle(tooltip).display).toBe('none');
+  });
+
+  it('renders short non-interactive tooltip content through the shared surface', async () => {
+    const { container } = render(FloatingTooltip, {
+      props: {
+        position: { x: 24, y: 32 },
+        id: 'tooltip-1',
+        children: testSnippet('<span>Tooltip body</span>')
+      }
+    });
+
+    const tooltip = container.querySelector('[role="tooltip"]') as HTMLElement;
+
+    await expect.element(tooltip).toBeInTheDocument();
+    expect(tooltip.id).toBe('tooltip-1');
+    expect(tooltip.classList.contains('floating-tooltip')).toBe(true);
+    expect(tooltip.textContent?.trim()).toBe('Tooltip body');
+  });
+});

--- a/frontend/src/lib/ui/index.ts
+++ b/frontend/src/lib/ui/index.ts
@@ -8,6 +8,7 @@ export { default as EmptyState } from './EmptyState.svelte';
 export { default as FormDialog } from './FormDialog.svelte';
 export { default as FormSection } from './FormSection.svelte';
 export { default as FloatingPopover } from './FloatingPopover.svelte';
+export { default as FloatingTooltip } from './FloatingTooltip.svelte';
 export { default as Frame } from './Frame.svelte';
 export { default as HeaderIconButton } from './HeaderIconButton.svelte';
 export { default as HelpTooltip } from './HelpTooltip.svelte';

--- a/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte
@@ -30,7 +30,8 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
   import { useConnection } from '$lib/state/server/connection.svelte';
   import { graphql } from '$lib/gql';
   import { toast } from '$lib/ui/toast';
-  import { getEmojiByName } from '$lib/emoji';
+  import FloatingTooltip from '$lib/ui/FloatingTooltip.svelte';
+  import { getEmojiByName, getEmojiDisplayName } from '$lib/emoji';
 
   // Extract the MessagePostedEvent type from the union
   type MessagePostedEvent = Extract<
@@ -77,6 +78,12 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
   } = $props();
 
   const connection = useConnection();
+  const reactionTooltipId = `reaction-tooltip-${crypto.randomUUID().slice(0, 8)}`;
+  let tooltipReactionEmoji = $state<string | null>(null);
+  let tooltipAnchor = $state<{ top: number; bottom: number; left: number } | null>(null);
+  const tooltipReaction = $derived(
+    tooltipReactionEmoji ? (reactions.find((r) => r.emoji === tooltipReactionEmoji) ?? null) : null
+  );
 
   const addReactionMutation = graphql(`
     mutation AddReaction($input: AddReactionInput!) {
@@ -99,6 +106,20 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
       return names.join(', ') + ` + ${remaining}`;
     }
     return names.join(', ');
+  }
+
+  function showReactionTooltip(e: MouseEvent | FocusEvent, reaction: ReactionSummary) {
+    if (reaction.users.length === 0) return;
+
+    const button = e.currentTarget as HTMLElement;
+    const rect = button.getBoundingClientRect();
+    tooltipReactionEmoji = reaction.emoji;
+    tooltipAnchor = { top: rect.top, bottom: rect.bottom, left: rect.left };
+  }
+
+  function hideReactionTooltip() {
+    tooltipReactionEmoji = null;
+    tooltipAnchor = null;
   }
 
   async function toggleReaction(reaction: ReactionSummary) {
@@ -207,16 +228,11 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
 
   <!-- Reaction pills -->
   {#each reactions as reaction (reaction.emoji)}
-    <span class="group/reaction relative">
-      {#if reaction.users.length > 0}
-        <span
-          class="pointer-events-none absolute bottom-full left-1/2 z-10 mb-1 -translate-x-1/2 rounded-md bg-surface-100 px-3 py-2 text-sm whitespace-nowrap text-text opacity-0 shadow-xl transition-opacity group-hover/reaction:opacity-100"
-          role="tooltip"
-        >
-          {formatReactionUsers(reaction.users, reaction.count)}
-        </span>
-      {/if}
-
+    <span
+      role="group"
+      onmouseenter={(e) => showReactionTooltip(e, reaction)}
+      onmouseleave={hideReactionTooltip}
+    >
       <button
         class={[
           baseButtonClass,
@@ -225,7 +241,10 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
           reaction.hasReacted ? 'border-accent/50' : 'border-transparent'
         ]}
         onclick={() => canReact && toggleReaction(reaction)}
+        onfocus={(e) => showReactionTooltip(e, reaction)}
+        onblur={hideReactionTooltip}
         disabled={!canReact}
+        aria-describedby={tooltipReactionEmoji === reaction.emoji ? reactionTooltipId : undefined}
         aria-label="{reaction.hasReacted
           ? 'Remove'
           : 'Add'} {getEmojiByName(reaction.emoji) ?? reaction.emoji} reaction ({reaction.count})"
@@ -248,3 +267,16 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
     </button>
   {/if}
 </div>
+
+<FloatingTooltip
+  open={!!tooltipReaction && !!tooltipAnchor}
+  anchor={tooltipAnchor}
+  id={reactionTooltipId}
+>
+  {#if tooltipReaction}
+    <span class="whitespace-nowrap">
+      <strong class="font-semibold">{getEmojiDisplayName(tooltipReaction.emoji)}</strong>
+      <span> · {formatReactionUsers(tooltipReaction.users, tooltipReaction.count)}</span>
+    </span>
+  {/if}
+</FloatingTooltip>

--- a/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { flushSync } from 'svelte';
 import { render } from 'vitest-browser-svelte';
 import { q } from '$lib/test-utils';
 import MessageMetaBar from './MessageMetaBar.svelte';
@@ -35,6 +36,26 @@ const baseProps = {
   reactions: [],
   onOpenThread: vi.fn()
 };
+
+function reaction(
+  overrides: Partial<{
+    emoji: string;
+    count: number;
+    hasReacted: boolean;
+    users: { id: string; displayName: string }[];
+  }> = {}
+) {
+  return {
+    emoji: 'thumbsup',
+    count: 2,
+    hasReacted: false,
+    users: [
+      { id: 'user-1', displayName: 'Alice' },
+      { id: 'user-2', displayName: 'Bob' }
+    ],
+    ...overrides
+  };
+}
 
 describe('MessageMetaBar', () => {
   it('renders the reply count badge as a native thread link', async () => {
@@ -149,5 +170,48 @@ describe('MessageMetaBar', () => {
 
     expect(followButton).not.toBeNull();
     expect(followButton?.closest('a')).toBeNull();
+  });
+
+  it('shows reaction tooltips with the readable reaction name and reacting users', () => {
+    const { container } = render(MessageMetaBar, {
+      props: {
+        ...baseProps,
+        reactions: [reaction()]
+      }
+    });
+
+    const wrapper = q(container, 'button[aria-label="Add 👍 reaction (2)"]')!
+      .parentElement as HTMLElement;
+
+    wrapper.dispatchEvent(new MouseEvent('mouseenter'));
+    flushSync();
+
+    const tooltip = q(container, '[role="tooltip"]')!;
+    const reactionName = q(tooltip, 'strong')!;
+
+    expect(tooltip.textContent?.trim()).toBe('Thumbs up · Alice, Bob');
+    expect(reactionName.textContent?.trim()).toBe('Thumbs up');
+    expect(reactionName.classList.contains('font-semibold')).toBe(true);
+  });
+
+  it('keeps the reaction tooltip available when the reaction button is disabled', () => {
+    const { container } = render(MessageMetaBar, {
+      props: {
+        ...baseProps,
+        reactions: [reaction({ emoji: 'heart', count: 1, users: [{ id: 'user-1', displayName: 'Alice' }] })],
+        canReact: false
+      }
+    });
+
+    const button = q(container, 'button[aria-label="Add ❤️ reaction (1)"]')! as HTMLButtonElement;
+    const wrapper = button.parentElement as HTMLElement;
+
+    expect(button.disabled).toBe(true);
+
+    wrapper.dispatchEvent(new MouseEvent('mouseenter'));
+    flushSync();
+
+    const tooltip = q(container, '[role="tooltip"]')!;
+    expect(tooltip.textContent?.trim()).toBe('Heart · Alice');
   });
 });


### PR DESCRIPTION
## Changes

- Show a readable reaction name above the user list in reaction popups.
- Render the reaction name in bold while keeping the user list at normal weight.
- Add a reusable `FloatingTooltip` component with a lighter tooltip surface, documentation, and a Storybook story.
- Keep reaction tooltip content on one line and keep the tooltip mounted while toggling `open`, avoiding child-list mutations inside virtualized message rows.
- Force closed persistent popovers to `display: none` so they cannot add message-row height.
- Hide newly opened popovers until their first measured position is applied.
- Add emoji display-name formatting, tooltip surface, and reaction popup coverage.

## Verification

- `mise x -- pnpm check`
- `mise x -- pnpm lint`
- `mise x -- pnpm test:unit --run --project server src/lib/emoji.spec.ts`
- `mise x -- pnpm test:unit --run --project client src/lib/ui/FloatingTooltip.svelte.spec.ts 'src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts'`
- `mise x -- pnpm test:unit --run --project client src/lib/ui/HelpTooltip.svelte.spec.ts`
- Storybook browser check for `UI/FloatingTooltip`, including closed `display: none`, bold reaction name (`font-weight: 600`), below-reaction placement, and measured 0px movement for the badge, shell height, body height, and child count before/after hover
