### PR TITLE
test(http_server): tag test-only email endpoint coverage

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -169,7 +169,7 @@ case "user":
 
 ## Known Test Issues
 
-- `cli/internal/http_server` tests that hit `/auth/test/*` or `/webhooks/test/*` endpoints require the `test_endpoints` build tag. Plain `go test ./...` will fail `TestAuthRoutes_TestEmailEndpoint` with a 404 because those routes are compiled out. For targeted runs, use `mise x -- go test -tags test_endpoints ./internal/http_server -run TestX -timeout 30s`; for full backend checkpoints, use `mise test-cli`, which sets the tag for the suite.
+- `cli/internal/http_server` tests that hit `/auth/test/*` or `/webhooks/test/*` endpoints require the `test_endpoints` build tag and should live in `//go:build test_endpoints` files. For targeted endpoint runs, use `mise x -- go test -tags test_endpoints ./internal/http_server -run TestX -timeout 30s`; for full backend checkpoints, use `mise test-cli`, which sets the tag for the suite.
 
 ## Cost Reference
 

--- a/.claude/rules/testing-backend.md
+++ b/.claude/rules/testing-backend.md
@@ -8,7 +8,7 @@ Patterns and gotchas for Go tests in `cli/`. See `testing-frontend.md` for Vites
 
 ## Run Go Tests via `mise test-cli`
 
-Always run Go tests through `mise` so the repo toolchain is active. For full-suite checkpoints, use `mise test-cli`, **not** plain `go test ./...`. The `http_server` package requires `-tags test_endpoints` to enable mock email/webhook endpoints used by tests. Running without this tag causes test failures with 404 errors on test endpoints like `/auth/test/last-email`.
+Always run Go tests through `mise` so the repo toolchain is active. For full-suite checkpoints, use `mise test-cli`, **not** plain `go test ./...`. The `http_server` package has endpoint-specific tests that require `-tags test_endpoints` to enable mock email/webhook routes such as `/auth/test/last-email`; tests for those routes are build-tagged and only run when the tag is present.
 
 ## Iterate with targeted runs; reserve `mise test-cli` for checkpoints
 
@@ -19,17 +19,17 @@ The full suite is still broad enough to be a checkpoint, not an edit-refresh loo
   mise x -- go test ./internal/<pkg> -run TestX -timeout 30s
   ```
   Multiple tests via regex: `-run "TestX|TestY"`.
-- **If the package is `internal/http_server`, add `-tags test_endpoints`:**
+- **If the package is `internal/http_server` and you need test-only endpoint coverage, add `-tags test_endpoints`:**
   ```
   mise x -- go test -tags test_endpoints ./internal/http_server -run TestX -timeout 30s
   ```
-  The same applies to any cross-package targeted run that includes `./internal/http_server`. Without the tag, tests that touch `/auth/test/*` or `/webhooks/test/*` compile those routes out and fail with misleading 404s.
+  The same applies to any cross-package targeted run that must exercise `/auth/test/*` or `/webhooks/test/*`. Without the tag, those routes are intentionally compiled out; tagged tests for them will not run.
 - **Always set `-timeout`.** A hung test will otherwise peg the session for the Go default of 10 minutes. 30s for unit-ish tests, 60s for ones that exercise live-event delivery.
 - On a suspected flake, retry with `-count=3 -timeout 60s` to confirm flake-vs-bug before reading the failure as definitive.
 - Reserve `mise test-cli` for "I think I'm done with this chunk" checkpoints, not feedback-loop iteration.
 - Inside `cli/`, you can call `mise x -- go test …` directly; outside, prefix with `cd cli && …` or use absolute paths.
 
-The same goes for cross-package work: prefer `mise x -- go test ./internal/core/ ./internal/graph/ -run TestX -timeout 60s` over the whole suite when you're chasing a specific change's blast radius. If that targeted set includes `./internal/http_server`, use `mise x -- go test -tags test_endpoints ...`.
+The same goes for cross-package work: prefer `mise x -- go test ./internal/core/ ./internal/graph/ -run TestX -timeout 60s` over the whole suite when you're chasing a specific change's blast radius. If that targeted set needs test-only `http_server` endpoints, use `mise x -- go test -tags test_endpoints ...`.
 
 ## Use Table-Driven Tests Where Possible
 

--- a/cli/internal/http_server/server_test.go
+++ b/cli/internal/http_server/server_test.go
@@ -1892,64 +1892,6 @@ func TestAuthRoutes_Register_EmailContainsValidCode(t *testing.T) {
 	}
 }
 
-func TestAuthRoutes_TestEmailEndpoint(t *testing.T) {
-	ts, client, _, mockMailer := setupTestHTTPServerWithMailer(t)
-
-	// Trigger a registration email
-	reqBody := map[string]string{"email": "testendpoint@example.com"}
-	body, _ := json.Marshal(reqBody)
-
-	resp, err := client.Post(ts.URL+"/auth/register", "application/json", bytes.NewReader(body))
-	if err != nil {
-		t.Fatalf("Failed to send register request: %v", err)
-	}
-	resp.Body.Close()
-
-	// Verify email was captured
-	if mockMailer.LastMessage() == nil {
-		t.Fatal("Expected email to be captured")
-	}
-
-	// Test the /auth/test/last-email endpoint
-	emailResp, err := client.Get(ts.URL + "/auth/test/last-email")
-	if err != nil {
-		t.Fatalf("Failed to get last email: %v", err)
-	}
-	defer emailResp.Body.Close()
-
-	if emailResp.StatusCode != http.StatusOK {
-		t.Errorf("Expected status 200, got %d", emailResp.StatusCode)
-	}
-
-	var emailResult map[string]interface{}
-	if err := json.NewDecoder(emailResp.Body).Decode(&emailResult); err != nil {
-		t.Fatalf("Failed to decode email response: %v", err)
-	}
-
-	if emailResult["to"] != "testendpoint@example.com" {
-		t.Errorf("Expected to: testendpoint@example.com, got %v", emailResult["to"])
-	}
-	if emailResult["subject"] != "Complete your registration for Chatto" {
-		t.Errorf("Expected subject: 'Complete your registration for Chatto', got %v", emailResult["subject"])
-	}
-
-	// Test DELETE /auth/test/emails
-	req, _ := http.NewRequest("DELETE", ts.URL+"/auth/test/emails", nil)
-	deleteResp, err := client.Do(req)
-	if err != nil {
-		t.Fatalf("Failed to delete emails: %v", err)
-	}
-	deleteResp.Body.Close()
-
-	if deleteResp.StatusCode != http.StatusOK {
-		t.Errorf("Expected status 200, got %d", deleteResp.StatusCode)
-	}
-
-	if mockMailer.LastMessage() != nil {
-		t.Error("Expected emails to be cleared")
-	}
-}
-
 // ============================================================================
 // Password Reset Tests
 // ============================================================================

--- a/cli/internal/http_server/test_endpoints_absent_test.go
+++ b/cli/internal/http_server/test_endpoints_absent_test.go
@@ -1,0 +1,26 @@
+//go:build !test_endpoints
+
+package http_server
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestAuthTestEndpointsUnavailableWithoutTag(t *testing.T) {
+	ts, client, _, mockMailer := setupTestHTTPServerWithMailer(t)
+
+	if mockMailer.LastMessage() != nil {
+		t.Fatal("expected test mailer to start empty")
+	}
+
+	resp, err := client.Get(ts.URL + "/auth/test/last-email")
+	if err != nil {
+		t.Fatalf("Failed to get last email: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("Expected status 404, got %d", resp.StatusCode)
+	}
+}

--- a/cli/internal/http_server/test_endpoints_email_test.go
+++ b/cli/internal/http_server/test_endpoints_email_test.go
@@ -1,0 +1,68 @@
+//go:build test_endpoints
+
+package http_server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestAuthRoutes_TestEmailEndpoint(t *testing.T) {
+	ts, client, _, mockMailer := setupTestHTTPServerWithMailer(t)
+
+	// Trigger a registration email
+	reqBody := map[string]string{"email": "testendpoint@example.com"}
+	body, _ := json.Marshal(reqBody)
+
+	resp, err := client.Post(ts.URL+"/auth/register", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("Failed to send register request: %v", err)
+	}
+	resp.Body.Close()
+
+	// Verify email was captured
+	if mockMailer.LastMessage() == nil {
+		t.Fatal("Expected email to be captured")
+	}
+
+	// Test the /auth/test/last-email endpoint
+	emailResp, err := client.Get(ts.URL + "/auth/test/last-email")
+	if err != nil {
+		t.Fatalf("Failed to get last email: %v", err)
+	}
+	defer emailResp.Body.Close()
+
+	if emailResp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", emailResp.StatusCode)
+	}
+
+	var emailResult map[string]interface{}
+	if err := json.NewDecoder(emailResp.Body).Decode(&emailResult); err != nil {
+		t.Fatalf("Failed to decode email response: %v", err)
+	}
+
+	if emailResult["to"] != "testendpoint@example.com" {
+		t.Errorf("Expected to: testendpoint@example.com, got %v", emailResult["to"])
+	}
+	if emailResult["subject"] != "Complete your registration for Chatto" {
+		t.Errorf("Expected subject: 'Complete your registration for Chatto', got %v", emailResult["subject"])
+	}
+
+	// Test DELETE /auth/test/emails
+	req, _ := http.NewRequest("DELETE", ts.URL+"/auth/test/emails", nil)
+	deleteResp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Failed to delete emails: %v", err)
+	}
+	deleteResp.Body.Close()
+
+	if deleteResp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", deleteResp.StatusCode)
+	}
+
+	if mockMailer.LastMessage() != nil {
+		t.Error("Expected emails to be cleared")
+	}
+}


### PR DESCRIPTION
- Moves the `/auth/test/last-email` endpoint behavior test into a `test_endpoints`-tagged file.
- Adds untagged coverage that asserts test-only auth endpoints stay unavailable in production builds.
- Updates backend agent testing guidance so plain untagged Go test runs are no longer documented as failing on this endpoint.

Tests:
- `mise x -- go test ./internal/http_server -run 'TestAuthRoutes_TestEmailEndpoint|TestAuthTestEndpointsUnavailableWithoutTag' -count=1 -timeout 30s`
- `mise x -- go test -tags test_endpoints ./internal/http_server -run TestAuthRoutes_TestEmailEndpoint -count=1 -timeout 30s`
- `mise x -- go test ./internal/http_server -count=1 -timeout 60s`
- `mise test-cli`
- `mise x -- go test ./... -count=1 -timeout 90s`
