### PR TITLE
fix(frontend): align muted call participant icon

### DIFF
--- a/frontend/src/lib/components/voice/VoiceCallPanel.svelte
+++ b/frontend/src/lib/components/voice/VoiceCallPanel.svelte
@@ -288,10 +288,7 @@ Room sidebar panel for voice/video calls.
       <div class="flex min-w-0 items-center gap-2 p-2">
         <UserAvatar user={participant.avatarUser} size="sm" showPresence={false} />
         <span class="min-w-0 flex-1 truncate text-sm font-medium">{participant.displayName}</span>
-        <span class="inline-flex min-w-4 shrink-0 items-center justify-end gap-1.5 text-sm">
-          {#if participant.isMuted}
-            <span class="iconify uil--microphone-slash text-danger" aria-label="Muted"></span>
-          {/if}
+        <span class="inline-flex h-5 min-w-5 shrink-0 items-center justify-end gap-1.5 text-sm">
           <span
             class="iconify uil--volume-up text-muted opacity-0 transition-opacity"
             aria-label="Speaking"
@@ -299,6 +296,13 @@ Room sidebar panel for voice/video calls.
             data-speaking-indicator
             data-testid="call-speaking-indicator"
           ></span>
+          {#if participant.isMuted}
+            <span
+              class="iconify uil--microphone-slash text-danger"
+              aria-label="Muted"
+              data-testid="call-muted-indicator"
+            ></span>
+          {/if}
           {#if hasConnectionWarning(participant)}
             <span
               class="iconify uil--exclamation-triangle"

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -540,6 +540,13 @@ describe('RoomSidebar', () => {
     expect(participantCards).toHaveLength(2);
     expect(participantCards[0].className).toContain('participant-card-video');
     expect(participantCards[1].className).toContain('participant-card-compact');
+    const mutedIndicator = q(participantCards[1], '[data-testid="call-muted-indicator"]');
+    const speakingIndicator = q(participantCards[1], '[data-testid="call-speaking-indicator"]');
+    expect(mutedIndicator).toBeTruthy();
+    expect(speakingIndicator).toBeTruthy();
+    expect(
+      speakingIndicator!.compareDocumentPosition(mutedIndicator!) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
 
     (q(container, '[data-testid="call-mute-toggle"]') as HTMLButtonElement).click();
     (q(container, '[data-testid="call-camera-toggle"]') as HTMLButtonElement).click();


### PR DESCRIPTION
## Changes

- Align the muted indicator in call participant cards by keeping the hidden speaking indicator before the muted icon and giving the status cluster stable dimensions.
- Add a regression assertion that muted participant cards keep the muted indicator after the speaking indicator in DOM order.

## Tests

- `pnpm exec vitest run 'src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts'`
