### PR TITLE
fix(frontend): remove redundant universal room badge

### DIFF
--- a/frontend/src/lib/RoomDirectory.svelte
+++ b/frontend/src/lib/RoomDirectory.svelte
@@ -19,7 +19,6 @@ registry.
   import { toast } from '$lib/ui/toast';
   import { Button } from '$lib/ui/form';
   import Dialog from '$lib/ui/Dialog.svelte';
-  import Pill from '$lib/ui/Pill.svelte';
   import type { RoomsStore } from '$lib/state/server/rooms.svelte';
   import type {
     RoomDirectoryStore,
@@ -215,16 +214,6 @@ registry.
         <div class="min-w-0 flex-1">
           <div class="flex min-w-0 items-center gap-2">
             <span class="min-w-0 truncate">{room.name}</span>
-            {#if room.isUniversal}
-              <Pill
-                tone="accent"
-                title="Universal rooms are joined automatically"
-                class="inline-flex shrink-0 items-center gap-1 rounded-md px-1.5"
-              >
-                <span class="iconify uil--globe text-xs" aria-hidden="true"></span>
-                Universal
-              </Pill>
-            {/if}
           </div>
           {#if room.description}
             <div class="truncate text-xs font-normal text-muted/80">{room.description}</div>

--- a/frontend/src/lib/RoomDirectory.svelte.spec.ts
+++ b/frontend/src/lib/RoomDirectory.svelte.spec.ts
@@ -92,6 +92,8 @@ describe('RoomDirectory', () => {
     flushSync();
 
     expect(container.textContent).toContain('Universal');
+    expect(container.textContent?.match(/Universal/g)?.length).toBe(1);
+    expect(container.textContent).not.toContain('Joined');
     expect(container.textContent).not.toContain('Leave');
     expect(findButton(container, 'Universal')).toBeUndefined();
   });


### PR DESCRIPTION
## Summary
- Removes the duplicate Universal badge next to room names in the room directory.
- Keeps Universal rooms represented by the right-side Universal status instead of join/leave.
- Adds component coverage that Universal appears only once and does not show Joined or Leave.

## Tests
- `npx @sveltejs/mcp svelte-autofixer frontend/src/lib/RoomDirectory.svelte`
- `mise x -- pnpm test:unit --run --project client src/lib/RoomDirectory.svelte.spec.ts`
- `mise x -- pnpm exec eslint src/lib/RoomDirectory.svelte src/lib/RoomDirectory.svelte.spec.ts`
- Chrome DevTools preview
