### PR TITLE
fix(frontend): reconcile notification badge dismissals

### DIFF
--- a/frontend/src/lib/RoomList.svelte
+++ b/frontend/src/lib/RoomList.svelte
@@ -312,7 +312,11 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     }
     roomsStore.decrementUnreadNotification(roomId);
     void notificationStore.dismiss(notification.id).then((dismissed) => {
-      if (!dismissed) roomsStore.incrementUnreadNotification(roomId);
+      if (!dismissed) {
+        roomsStore.incrementUnreadNotification(roomId);
+        return;
+      }
+      void roomsStore.refreshNotificationCounts();
     });
 
     const path = notificationStore.getCleanPath(getActiveServer(), notification);

--- a/frontend/src/lib/RoomList.svelte.spec.ts
+++ b/frontend/src/lib/RoomList.svelte.spec.ts
@@ -64,7 +64,8 @@ const { mocks } = vi.hoisted(() => ({
         setUnread: vi.fn(),
         clearUnreadNotifications: vi.fn(),
         decrementUnreadNotification: vi.fn(),
-        incrementUnreadNotification: vi.fn()
+        incrementUnreadNotification: vi.fn(),
+        refreshNotificationCounts: vi.fn().mockResolvedValue(undefined)
       },
       pendingHighlights: {
         set: vi.fn()
@@ -256,6 +257,7 @@ beforeEach(() => {
     notification: null
   });
   mocks.store.notifications.getCleanPath.mockReturnValue('/chat/-/room');
+  mocks.store.rooms.refreshNotificationCounts.mockResolvedValue(undefined);
 });
 
 describe('RoomList', () => {
@@ -582,6 +584,7 @@ describe('RoomList', () => {
       );
       expect(mocks.store.rooms.decrementUnreadNotification).toHaveBeenCalledWith('channel-1');
       expect(mocks.store.notifications.dismiss).toHaveBeenCalledWith('mention-1');
+      expect(mocks.store.rooms.refreshNotificationCounts).toHaveBeenCalledOnce();
       expect(mocks.goto).toHaveBeenCalledWith('/chat/-/channel-1/thread-1');
     });
   });
@@ -612,6 +615,7 @@ describe('RoomList', () => {
         'dm-with-participants'
       );
       expect(mocks.store.notifications.dismiss).toHaveBeenCalledWith('dm-1');
+      expect(mocks.store.rooms.refreshNotificationCounts).toHaveBeenCalledOnce();
       expect(mocks.goto).toHaveBeenCalledWith('/chat/-/dm-with-participants');
     });
   });

--- a/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -232,6 +232,7 @@
       );
       if (dismissedForRoom > 0) {
         stores.rooms.decrementUnreadNotification(currentRoomId, dismissedForRoom);
+        void stores.rooms.refreshNotificationCounts();
       }
     })();
   });

--- a/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -40,7 +40,17 @@ const { mocks } = vi.hoisted(() => {
         toPromise: vi.fn().mockResolvedValue({ data: {}, error: null })
       })),
       subscription: vi.fn(),
-      livekitUrl: null as string | null
+      livekitUrl: null as string | null,
+      notifications: {
+        dismissDMNotifications: vi.fn().mockResolvedValue({ byRoom: {} }),
+        dismissMentionNotifications: vi.fn().mockResolvedValue({ byRoom: {} }),
+        dismissRoomReplyNotifications: vi.fn().mockResolvedValue({ byRoom: {} }),
+        dismissRoomMessageNotifications: vi.fn().mockResolvedValue({ byRoom: {} })
+      },
+      rooms: {
+        decrementUnreadNotification: vi.fn(),
+        refreshNotificationCounts: vi.fn().mockResolvedValue(undefined)
+      }
     }
   };
 });
@@ -134,21 +144,14 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
         maxUploadSize: 25 * 1024 * 1024,
         maxVideoUploadSize: 25 * 1024 * 1024
       },
-      notifications: {
-        dismissDMNotifications: vi.fn().mockResolvedValue({ byRoom: {} }),
-        dismissMentionNotifications: vi.fn().mockResolvedValue({ byRoom: {} }),
-        dismissRoomReplyNotifications: vi.fn().mockResolvedValue({ byRoom: {} }),
-        dismissRoomMessageNotifications: vi.fn().mockResolvedValue({ byRoom: {} })
-      },
+      notifications: mocks.notifications,
       pendingHighlights: {
         consume: vi.fn(() => null)
       },
       activeCallRooms: {
         has: vi.fn(() => false)
       },
-      rooms: {
-        decrementUnreadNotification: vi.fn()
-      }
+      rooms: mocks.rooms
     }),
     originServer: { id: 'server-1', url: 'https://chat.example.test' },
     getServer: () => ({ id: 'server-1', url: 'https://chat.example.test' })
@@ -157,6 +160,13 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
 
 vi.mock('$lib/state/activeServer.svelte', () => ({
   getActiveServer: () => 'server-1'
+}));
+
+vi.mock('$lib/state/globals.svelte', () => ({
+  appState: {
+    isFocused: true,
+    isPresent: true
+  }
 }));
 
 vi.mock('$lib/storage/lastRoom', () => ({
@@ -225,6 +235,11 @@ beforeEach(() => {
   localStorage.clear();
   sessionStorage.clear();
   mocks.livekitUrl = null;
+  mocks.notifications.dismissDMNotifications.mockResolvedValue({ byRoom: {} });
+  mocks.notifications.dismissMentionNotifications.mockResolvedValue({ byRoom: {} });
+  mocks.notifications.dismissRoomReplyNotifications.mockResolvedValue({ byRoom: {} });
+  mocks.notifications.dismissRoomMessageNotifications.mockResolvedValue({ byRoom: {} });
+  mocks.rooms.refreshNotificationCounts.mockResolvedValue(undefined);
   vi.stubGlobal('matchMedia', vi.fn(() => ({ matches: true })));
 });
 
@@ -264,5 +279,16 @@ describe('Room local message echo', () => {
 
     await expect.element(q(container, '[data-testid="room-sidebar-mobile-pane"]')).toBeInTheDocument();
     expect(consumePendingRoomSidebarPanel('server-1', 'room-1')).toBeNull();
+  });
+
+  it('refreshes room notification counts after active-room notifications auto-dismiss', async () => {
+    mocks.notifications.dismissMentionNotifications.mockResolvedValue({ byRoom: { 'room-1': 1 } });
+
+    render(Room, { props: { roomId: 'room-1' } });
+
+    await vi.waitFor(() => {
+      expect(mocks.rooms.decrementUnreadNotification).toHaveBeenCalledWith('room-1', 1);
+      expect(mocks.rooms.refreshNotificationCounts).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -235,6 +235,7 @@
       const dismissedForRoom = counts.byRoom[currentRoomId] ?? 0;
       if (dismissedForRoom > 0) {
         stores.rooms.decrementUnreadNotification(currentRoomId, dismissedForRoom);
+        void stores.rooms.refreshNotificationCounts();
       }
     });
   });

--- a/frontend/src/routes/chat/notifications/+page.svelte
+++ b/frontend/src/routes/chat/notifications/+page.svelte
@@ -103,6 +103,7 @@
     void store.dismiss(item.notification.id).then((dismissed) => {
       if (dismissed && target.roomId) {
         stores.rooms.decrementUnreadNotification(target.roomId);
+        void stores.rooms.refreshNotificationCounts();
       }
     });
 
@@ -118,6 +119,7 @@
     const dismissed = await stores.notifications.dismiss(item.notification.id);
     if (dismissed && target.roomId) {
       stores.rooms.decrementUnreadNotification(target.roomId);
+      void stores.rooms.refreshNotificationCounts();
     }
   }
 
@@ -131,6 +133,7 @@
         stores.notifications.dismissAll().then((dismissed) => {
           if (hadNotifications || dismissed > 0) {
             stores.rooms.clearAllUnreadNotifications();
+            void stores.rooms.refreshNotificationCounts();
           }
         })
       );


### PR DESCRIPTION
## Summary
- Refresh authoritative room notification counts after successful notification dismissals from active rooms, threads, room badges, and the notifications page.
- Keep optimistic badge updates for responsiveness while preventing stale count refresh races from restoring dismissed badges.
- Add focused browser specs for active-room auto-dismiss reconciliation and manual room/DM badge dismissals.

## Tests
- `mise x -- pnpm test:unit --run --project client 'src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts'`
- `mise x -- pnpm test:unit --run --project client src/lib/RoomList.svelte.spec.ts`
- `mise x -- pnpm exec playwright test e2e/notifications.test.ts -g "mention indicator clears|room entry dismiss|reply notification is dismissed" --retries=0`
- `mise lint-frontend`
