### PR TITLE
feat(core): persist link preview assets via storage backend

### DIFF
--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -573,15 +574,146 @@ func (c *ChattoCore) GetLinkPreview(ctx context.Context, url string) (*corev1.Li
 	return preview, nil
 }
 
+// HydrateLinkPreviewImageAsset ensures a posted LinkPreview carries the
+// server-issued AssetRecord for its preview image. Clients only send
+// image_asset_id for compatibility; the backend rehydrates the storage pointer
+// from the server-side preview cache or by probing known backends.
+func (c *ChattoCore) HydrateLinkPreviewImageAsset(ctx context.Context, preview *corev1.LinkPreview) error {
+	if preview == nil {
+		return nil
+	}
+
+	imageAsset := preview.GetImageAsset()
+	imageAssetID := preview.GetImageAssetId()
+	if imageAsset != nil {
+		if imageAsset.GetId() == "" {
+			return fmt.Errorf("link preview image asset record is missing id")
+		}
+		if imageAssetID != "" && imageAssetID != imageAsset.GetId() {
+			return fmt.Errorf("link preview image asset id mismatch")
+		}
+		if imageAssetID == "" {
+			id := imageAsset.GetId()
+			preview.ImageAssetId = &id
+		}
+		return nil
+	}
+	if imageAssetID == "" {
+		return nil
+	}
+
+	if cached, err := c.linkPreviewCache.Get(ctx, preview.GetUrl()); err == nil && cached != nil {
+		if cachedAsset := cached.GetImageAsset(); cachedAsset != nil && cachedAsset.GetId() == imageAssetID {
+			preview.ImageAsset = proto.Clone(cachedAsset).(*corev1.AssetRecord)
+			return nil
+		}
+	} else if err != nil && !errors.Is(err, linkpreview.ErrCachedFailure) {
+		c.logger.Debug("Failed to hydrate link preview image asset from cache", "url", preview.GetUrl(), "error", err)
+	}
+
+	asset, err := c.ServerAssetRecordFromAnyBackend(ctx, imageAssetID, "link-preview.webp")
+	if err != nil {
+		return fmt.Errorf("hydrate link preview image asset: %w", err)
+	}
+	preview.ImageAsset = asset
+	return nil
+}
+
 // S3Client returns the S3 client, or nil if S3 is not configured.
 func (c *ChattoCore) S3Client() *S3Client {
 	return c.s3Client
+}
+
+func (c *ChattoCore) storeLinkPreviewImage(ctx context.Context, assetID string, data []byte, contentType string) (*corev1.AssetRecord, error) {
+	asset := &corev1.AssetRecord{
+		Id:          assetID,
+		Filename:    "link-preview.webp",
+		ContentType: contentType,
+		Size:        int64(len(data)),
+	}
+	if c.ShouldUseS3() {
+		s3Key := S3KeyServerAsset(assetID)
+		if _, err := c.s3Client.PutObjectFromBytes(ctx, s3Key, data, contentType); err != nil {
+			return nil, fmt.Errorf("upload link preview image to S3: %w", err)
+		}
+		asset.Storage = &corev1.AssetRecord_S3{S3: &corev1.S3Asset{
+			Key:    assetID,
+			Bucket: proto.String(c.s3Client.Bucket()),
+		}}
+		c.logger.Debug("Stored link preview image in S3", "asset_id", assetID, "size", len(data))
+		return asset, nil
+	}
+
+	meta := jetstream.ObjectMeta{
+		Name: assetID,
+		Headers: map[string][]string{
+			"Content-Type": {contentType},
+		},
+	}
+	info, err := c.storage.serverAssets.Put(ctx, meta, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("upload link preview image to SERVER_ASSETS: %w", err)
+	}
+	asset.Size = int64(info.Size)
+	asset.Storage = &corev1.AssetRecord_Nats{Nats: &corev1.NATSAsset{Key: assetID}}
+	c.logger.Debug("Stored link preview image in SERVER_ASSETS", "asset_id", assetID, "size", len(data))
+	return asset, nil
 }
 
 // ServerAssetInfo contains metadata about a server asset.
 type ServerAssetInfo struct {
 	Size        int64
 	ContentType string
+}
+
+// ServerAssetRecordFromAnyBackend builds an AssetRecord by probing the
+// server-asset backends. It is primarily for legacy ID-only server-scoped
+// assets that need to be rehydrated into richer metadata.
+func (c *ChattoCore) ServerAssetRecordFromAnyBackend(ctx context.Context, assetID, filename string) (*corev1.AssetRecord, error) {
+	obj, err := c.storage.serverAssets.Get(ctx, assetID)
+	if err == nil {
+		if closer, ok := obj.(io.Closer); ok {
+			defer closer.Close()
+		}
+		info, _ := obj.Info()
+		contentType := info.Headers.Get("Content-Type")
+		if contentType == "" {
+			contentType = "application/octet-stream"
+		}
+		return &corev1.AssetRecord{
+			Id:          assetID,
+			Filename:    filename,
+			ContentType: contentType,
+			Size:        int64(info.Size),
+			Storage:     &corev1.AssetRecord_Nats{Nats: &corev1.NATSAsset{Key: assetID}},
+		}, nil
+	}
+
+	if c.s3Client != nil {
+		s3Info, s3Err := c.s3Client.StatObject(ctx, S3KeyServerAsset(assetID))
+		if s3Err == nil {
+			contentType := s3Info.ContentType
+			if contentType == "" {
+				contentType = "application/octet-stream"
+			}
+			return &corev1.AssetRecord{
+				Id:          assetID,
+				Filename:    filename,
+				ContentType: contentType,
+				Size:        s3Info.Size,
+				Storage: &corev1.AssetRecord_S3{S3: &corev1.S3Asset{
+					Key:    assetID,
+					Bucket: proto.String(c.s3Client.Bucket()),
+				}},
+			}, nil
+		}
+		c.logger.Debug("Server asset record not found in either backend",
+			"asset_id", assetID,
+			"nats_error", err,
+			"s3_error", s3Err)
+	}
+
+	return nil, err
 }
 
 // GetServerAssetFromAnyBackend retrieves a server asset by probing both NATS and S3 backends.
@@ -904,7 +1036,7 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	// Initialize link preview cache and fetcher
 	core.linkPreviewCache = linkpreview.NewCache(storage.runtimeStateKV)
 	assetsConfig := core.AssetsConfig()
-	core.linkPreviewFetcher = linkpreview.NewFetcher(storage.serverAssets, &assetsConfig, NewAssetID)
+	core.linkPreviewFetcher = linkpreview.NewFetcher(&assetsConfig, NewAssetID, core.storeLinkPreviewImage)
 
 	// ensureChannelRoomsAreInAGroup is deferred to core.Run() — it
 	// needs the projectors to be live so its CreateRoomGroup /

--- a/cli/internal/core/linkpreview/fetcher.go
+++ b/cli/internal/core/linkpreview/fetcher.go
@@ -14,9 +14,8 @@ import (
 	_ "image/png"
 
 	"github.com/charmbracelet/log"
-	"github.com/nats-io/nats.go"
-	"github.com/nats-io/nats.go/jetstream"
 	"github.com/otiai10/opengraph/v2"
+	"google.golang.org/protobuf/proto"
 
 	"hmans.de/chatto/internal/assets"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
@@ -37,37 +36,40 @@ const (
 	PageFetchTimeout = 10 * time.Second
 )
 
+// StoreImageFunc persists a processed preview image under the supplied asset ID.
+type StoreImageFunc func(ctx context.Context, assetID string, data []byte, contentType string) (*corev1.AssetRecord, error)
+
 // Fetcher fetches link preview metadata using OpenGraph.
 type Fetcher struct {
 	httpClient   *http.Client
 	imageClient  *http.Client
-	assetStore   jetstream.ObjectStore
 	assetsConfig *assets.Config
 	newAssetID   func() string // Generates new asset IDs
+	storeImage   StoreImageFunc
 	logger       *log.Logger
 }
 
 // NewFetcher creates a new link preview fetcher.
 // The newAssetID function is used to generate asset IDs for stored images.
-func NewFetcher(assetStore jetstream.ObjectStore, assetsConfig *assets.Config, newAssetID func() string) *Fetcher {
+func NewFetcher(assetsConfig *assets.Config, newAssetID func() string, storeImage StoreImageFunc) *Fetcher {
 	return &Fetcher{
 		httpClient:   NewSSRFSafeClient(PageFetchTimeout),
 		imageClient:  NewSSRFSafeClient(ImageFetchTimeout),
-		assetStore:   assetStore,
 		assetsConfig: assetsConfig,
 		newAssetID:   newAssetID,
+		storeImage:   storeImage,
 		logger:       log.WithPrefix("linkpreview"),
 	}
 }
 
 // FetchResult contains the fetched link preview metadata.
 type FetchResult struct {
-	Title        string
-	Description  string
-	SiteName     string
-	ImageAssetID string // Asset ID if image was downloaded, empty otherwise
-	EmbedType    string // "generic", "youtube"
-	EmbedID      string // For YouTube: video ID
+	Title       string
+	Description string
+	SiteName    string
+	ImageAsset  *corev1.AssetRecord // Image asset if image was downloaded, nil otherwise
+	EmbedType   string              // "generic", "youtube"
+	EmbedID     string              // For YouTube: video ID
 }
 
 // Fetch fetches link preview metadata for a URL.
@@ -151,13 +153,13 @@ func (f *Fetcher) Fetch(ctx context.Context, rawURL string) (*FetchResult, error
 	if len(og.Image) > 0 && og.Image[0].URL != "" {
 		imageURL := og.Image[0].URL
 		f.logger.Debug("Attempting to download preview image", "image_url", imageURL)
-		assetID, err := f.downloadAndStoreImage(ctx, imageURL)
+		asset, err := f.downloadAndStoreImage(ctx, imageURL)
 		if err != nil {
 			f.logger.Warn("Failed to download preview image", "url", imageURL, "error", err)
 			// Continue without image - don't fail the whole preview
 		} else {
-			f.logger.Debug("Successfully stored preview image", "asset_id", assetID)
-			result.ImageAssetID = assetID
+			f.logger.Debug("Successfully stored preview image", "asset_id", asset.GetId())
+			result.ImageAsset = asset
 		}
 	} else {
 		f.logger.Debug("No preview image found", "url", rawURL)
@@ -175,18 +177,18 @@ func truncate(s string, maxLen int) string {
 }
 
 // downloadAndStoreImage downloads an image and stores it as an server asset.
-func (f *Fetcher) downloadAndStoreImage(ctx context.Context, imageURL string) (string, error) {
+func (f *Fetcher) downloadAndStoreImage(ctx context.Context, imageURL string) (*corev1.AssetRecord, error) {
 	// Create request with context
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil)
 	if err != nil {
-		return "", fmt.Errorf("create request: %w", err)
+		return nil, fmt.Errorf("create request: %w", err)
 	}
 	req.Header.Set("User-Agent", "ChattoBot/1.0 (Link Preview)")
 
 	// Fetch the image
 	resp, err := f.imageClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("fetch image: %w", err)
+		return nil, fmt.Errorf("fetch image: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -198,23 +200,23 @@ func (f *Fetcher) downloadAndStoreImage(ctx context.Context, imageURL string) (s
 	)
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("image returned status %d", resp.StatusCode)
+		return nil, fmt.Errorf("image returned status %d", resp.StatusCode)
 	}
 
 	// Check content type - be lenient since some servers don't set it properly
 	contentType := resp.Header.Get("Content-Type")
 	if contentType != "" && !strings.HasPrefix(contentType, "image/") && contentType != "application/octet-stream" {
-		return "", fmt.Errorf("not an image: %s", contentType)
+		return nil, fmt.Errorf("not an image: %s", contentType)
 	}
 
 	// Read with size limit
 	limitedReader := io.LimitReader(resp.Body, MaxImageSize+1)
 	imageData, err := io.ReadAll(limitedReader)
 	if err != nil {
-		return "", fmt.Errorf("read image: %w", err)
+		return nil, fmt.Errorf("read image: %w", err)
 	}
 	if len(imageData) > MaxImageSize {
-		return "", fmt.Errorf("image too large (>%d bytes)", MaxImageSize)
+		return nil, fmt.Errorf("image too large (>%d bytes)", MaxImageSize)
 	}
 
 	f.logger.Debug("Downloaded image data", "size", len(imageData))
@@ -222,12 +224,12 @@ func (f *Fetcher) downloadAndStoreImage(ctx context.Context, imageURL string) (s
 	// Process the image (resize to fit OG dimensions, convert to WebP)
 	processedReader, err := assets.ProcessLinkPreviewImageWithConfig(bytes.NewReader(imageData), *f.assetsConfig)
 	if err != nil {
-		return "", fmt.Errorf("process image: %w", err)
+		return nil, fmt.Errorf("process image: %w", err)
 	}
 
 	processedData, err := io.ReadAll(processedReader)
 	if err != nil {
-		return "", fmt.Errorf("read processed image: %w", err)
+		return nil, fmt.Errorf("read processed image: %w", err)
 	}
 
 	f.logger.Debug("Processed image", "original_size", len(imageData), "processed_size", len(processedData))
@@ -235,22 +237,17 @@ func (f *Fetcher) downloadAndStoreImage(ctx context.Context, imageURL string) (s
 	// Generate asset ID and store
 	assetID := f.newAssetID()
 
-	headers := nats.Header{}
-	headers.Set("Content-Type", "image/webp")
-
-	meta := jetstream.ObjectMeta{
-		Name:    assetID,
-		Headers: headers,
+	if f.storeImage == nil {
+		return nil, fmt.Errorf("store image: no image store configured")
 	}
-
-	_, err = f.assetStore.Put(ctx, meta, bytes.NewReader(processedData))
+	asset, err := f.storeImage(ctx, assetID, processedData, "image/webp")
 	if err != nil {
-		return "", fmt.Errorf("store image: %w", err)
+		return nil, fmt.Errorf("store image: %w", err)
 	}
 
 	f.logger.Debug("Stored image asset", "asset_id", assetID)
 
-	return assetID, nil
+	return asset, nil
 }
 
 // ToProto converts a FetchResult to a protobuf LinkPreview.
@@ -262,8 +259,10 @@ func (r *FetchResult) ToProto(url string) *corev1.LinkPreview {
 		SiteName:    r.SiteName,
 		EmbedType:   r.EmbedType,
 	}
-	if r.ImageAssetID != "" {
-		lp.ImageAssetId = &r.ImageAssetID
+	if r.ImageAsset != nil && r.ImageAsset.GetId() != "" {
+		imageAssetID := r.ImageAsset.GetId()
+		lp.ImageAssetId = &imageAssetID
+		lp.ImageAsset = proto.Clone(r.ImageAsset).(*corev1.AssetRecord)
 	}
 	if r.EmbedID != "" {
 		lp.EmbedId = &r.EmbedID

--- a/cli/internal/core/linkpreview_test.go
+++ b/cli/internal/core/linkpreview_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"hmans.de/chatto/internal/core/linkpreview"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
 func TestLinkPreviewImageStorageAndRetrieval(t *testing.T) {
@@ -53,6 +54,37 @@ func TestLinkPreviewImageStorageAndRetrieval(t *testing.T) {
 
 	require.Equal(t, "Local Link Preview", preview.Title)
 	require.NotEmpty(t, preview.GetImageAssetId(), "ImageAssetId should not be empty")
+	require.NotNil(t, preview.GetImageAsset(), "ImageAsset should be populated")
+	require.Equal(t, preview.GetImageAssetId(), preview.GetImageAsset().GetId())
+	require.Equal(t, "image/webp", preview.GetImageAsset().GetContentType())
+	require.NotNil(t, preview.GetImageAsset().GetNats(), "NATS-backed preview should carry NATS storage pointer")
+
+	idOnlyPreview := &corev1.LinkPreview{Url: url, ImageAssetId: preview.ImageAssetId}
+	require.NoError(t, core.HydrateLinkPreviewImageAsset(ctx, idOnlyPreview))
+	require.NotNil(t, idOnlyPreview.GetImageAsset(), "ID-only preview should be hydrated with ImageAsset")
+	require.Equal(t, preview.GetImageAsset().GetId(), idOnlyPreview.GetImageAsset().GetId())
+	require.NotNil(t, idOnlyPreview.GetImageAsset().GetNats(), "hydrated preview should carry NATS storage pointer")
+
+	room, err := core.CreateRoom(ctx, "test-user", KindChannel, "", "Previews", "Preview discussion")
+	require.NoError(t, err)
+	user, err := core.CreateUser(ctx, "system", "previewposter", "previewposter", "password123")
+	require.NoError(t, err)
+	_, err = core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id)
+	require.NoError(t, err)
+
+	postPreview := &corev1.LinkPreview{
+		Url:          url,
+		Title:        preview.GetTitle(),
+		ImageAssetId: preview.ImageAssetId,
+	}
+	event, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "preview", nil, "", "", postPreview, false)
+	require.NoError(t, err)
+	body, err := core.GetFullMessageBodyByEventID(ctx, event.GetId())
+	require.NoError(t, err)
+	require.NotNil(t, body)
+	require.NotNil(t, body.LinkPreview.GetImageAsset(), "posted ID-only preview should be stored with ImageAsset")
+	require.Equal(t, preview.GetImageAssetId(), body.LinkPreview.GetImageAsset().GetId())
+	require.NotNil(t, body.LinkPreview.GetImageAsset().GetNats())
 
 	// Now try to retrieve the stored image
 	reader, info, err := core.GetServerAssetFromAnyBackend(ctx, preview.GetImageAssetId())
@@ -76,4 +108,63 @@ func TestLinkPreviewImageStorageAndRetrieval(t *testing.T) {
 	require.True(t, len(data) >= 12, "Data should be at least 12 bytes")
 	require.Equal(t, "RIFF", string(data[0:4]), "Should start with RIFF")
 	require.Equal(t, "WEBP", string(data[8:12]), "Should have WEBP magic number")
+}
+
+func TestLinkPreviewImageUsesS3WhenConfigured(t *testing.T) {
+	ctx := context.Background()
+	core, _, s3Client, rawS3Client, _ := setupTestCoreWithS3PathPrefix(t, "tenant-a/chatto")
+
+	restoreLocalhost := linkpreview.AllowLocalhostForTesting()
+	defer restoreLocalhost()
+
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/article":
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = w.Write([]byte(`<!doctype html>
+<html>
+<head>
+<meta property="og:title" content="S3 Link Preview">
+<meta property="og:description" content="A hermetic S3 preview fixture">
+<meta property="og:image" content="` + serverURL + `/preview.png">
+</head>
+<body>hello</body>
+</html>`))
+		case "/preview.png":
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(createTestPNG(64, 64))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	preview, err := core.GetLinkPreview(ctx, server.URL+"/article")
+	require.NoError(t, err)
+	require.NotNil(t, preview)
+	require.Equal(t, "S3 Link Preview", preview.Title)
+	require.NotEmpty(t, preview.GetImageAssetId())
+	require.NotNil(t, preview.GetImageAsset(), "ImageAsset should be populated")
+	require.Equal(t, preview.GetImageAssetId(), preview.GetImageAsset().GetId())
+	require.Equal(t, "image/webp", preview.GetImageAsset().GetContentType())
+	require.NotNil(t, preview.GetImageAsset().GetS3(), "S3-backed preview should carry S3 storage pointer")
+	require.Equal(t, preview.GetImageAssetId(), preview.GetImageAsset().GetS3().GetKey())
+
+	_, err = core.storage.serverAssets.Get(ctx, preview.GetImageAssetId())
+	require.Error(t, err, "link preview image should not be stored in SERVER_ASSETS when S3 is configured")
+
+	logicalS3Key := S3KeyServerAsset(preview.GetImageAssetId())
+	if _, err := s3Client.StatObject(ctx, logicalS3Key); err != nil {
+		t.Fatalf("logical S3 stat failed: %v", err)
+	}
+	if _, err := rawS3Client.StatObject(ctx, "tenant-a/chatto/"+logicalS3Key); err != nil {
+		t.Fatalf("raw physical S3 stat failed: %v", err)
+	}
+
+	reader, info, err := core.GetServerAssetFromAnyBackend(ctx, preview.GetImageAssetId())
+	require.NoError(t, err)
+	require.NotNil(t, reader)
+	require.Equal(t, "image/webp", info.ContentType)
 }

--- a/cli/internal/core/messages.go
+++ b/cli/internal/core/messages.go
@@ -405,6 +405,12 @@ func (c *ChattoCore) PostMessage(ctx context.Context, kind RoomKind, room_id, us
 	if err := validateLinkPreview(linkPreview); err != nil {
 		return nil, err
 	}
+	if err := c.HydrateLinkPreviewImageAsset(ctx, linkPreview); err != nil {
+		return nil, err
+	}
+	if err := validateLinkPreview(linkPreview); err != nil {
+		return nil, err
+	}
 
 	// Validate that message has either body or attachments.
 	// HasVisibleContent rejects messages with only invisible Unicode characters.
@@ -1166,6 +1172,17 @@ func validateLinkPreview(linkPreview *corev1.LinkPreview) error {
 	}
 	if err := validateStringMaxLength("link preview image asset ID", linkPreview.GetImageAssetId(), MaxLinkPreviewImageAssetIDLength); err != nil {
 		return err
+	}
+	if imageAsset := linkPreview.GetImageAsset(); imageAsset != nil {
+		if err := validateStringMaxLength("link preview image asset ID", imageAsset.GetId(), MaxLinkPreviewImageAssetIDLength); err != nil {
+			return err
+		}
+		if linkPreview.GetImageAssetId() != "" && imageAsset.GetId() != "" && linkPreview.GetImageAssetId() != imageAsset.GetId() {
+			return fmt.Errorf("link preview image asset ID does not match image asset record")
+		}
+		if imageAsset.GetStorage() == nil {
+			return fmt.Errorf("link preview image asset record is missing storage")
+		}
 	}
 	if err := validateStringMaxLength("link preview site name", linkPreview.GetSiteName(), MaxLinkPreviewSiteNameLength); err != nil {
 		return err

--- a/cli/internal/core/messages_test.go
+++ b/cli/internal/core/messages_test.go
@@ -561,9 +561,13 @@ func TestChattoCore_PostMessage_LinkPreviewLengthLimits(t *testing.T) {
 			Title:        strings.Repeat("t", MaxLinkPreviewTitleLength),
 			Description:  strings.Repeat("d", MaxLinkPreviewDescriptionLength),
 			ImageAssetId: &imageAssetID,
-			SiteName:     strings.Repeat("s", MaxLinkPreviewSiteNameLength),
-			EmbedType:    strings.Repeat("e", MaxLinkPreviewEmbedTypeLength),
-			EmbedId:      &embedID,
+			ImageAsset: &corev1.AssetRecord{
+				Id:      imageAssetID,
+				Storage: &corev1.AssetRecord_Nats{Nats: &corev1.NATSAsset{Key: imageAssetID}},
+			},
+			SiteName:  strings.Repeat("s", MaxLinkPreviewSiteNameLength),
+			EmbedType: strings.Repeat("e", MaxLinkPreviewEmbedTypeLength),
+			EmbedId:   &embedID,
 		}
 		if _, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "preview", nil, "", "", preview, false); err != nil {
 			t.Fatalf("PostMessage with max-length link preview: %v", err)

--- a/cli/internal/core/s3.go
+++ b/cli/internal/core/s3.go
@@ -239,7 +239,7 @@ func S3KeyAttachment(attachmentID string) string {
 	return fmt.Sprintf("attachments/%s", attachmentID)
 }
 
-// S3KeyServerAsset returns the S3 key for an server asset (avatar, logo, banner).
+// S3KeyServerAsset returns the S3 key for a server asset (avatar, logo, banner, link preview image).
 // Format: instance/{assetId}
 // This matches the NATS key format so HTTP handlers can probe both backends with the same key.
 func S3KeyServerAsset(assetID string) string {

--- a/cli/internal/graph/linkpreview.resolvers.go
+++ b/cli/internal/graph/linkpreview.resolvers.go
@@ -17,6 +17,9 @@ import (
 // ImageURL is the resolver for the imageUrl field on LinkPreview.
 func (r *linkPreviewResolver) ImageURL(ctx context.Context, obj *corev1.LinkPreview, width *int32, height *int32, fit *model.FitMode) (*string, error) {
 	imageAssetId := obj.GetImageAssetId()
+	if obj.GetImageAsset() != nil && obj.GetImageAsset().GetId() != "" {
+		imageAssetId = obj.GetImageAsset().GetId()
+	}
 	if imageAssetId == "" {
 		return nil, nil
 	}

--- a/cli/internal/pb/chatto/core/v1/models.pb.go
+++ b/cli/internal/pb/chatto/core/v1/models.pb.go
@@ -1549,12 +1549,15 @@ type LinkPreview struct {
 	Title       string `protobuf:"bytes,2,opt,name=title,proto3" json:"title,omitempty"`
 	Description string `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
 	SiteName    string `protobuf:"bytes,4,opt,name=site_name,json=siteName,proto3" json:"site_name,omitempty"`
-	// Asset ID for the preview image (stored in instance ObjectStore)
+	// Asset ID for the preview image. Kept for GraphQL/client compatibility;
+	// new previews also carry image_asset with storage metadata.
 	ImageAssetId *string `protobuf:"bytes,5,opt,name=image_asset_id,json=imageAssetId,proto3,oneof" json:"image_asset_id,omitempty"`
 	// Embed type: "generic", "youtube", "vimeo", etc.
 	EmbedType string `protobuf:"bytes,6,opt,name=embed_type,json=embedType,proto3" json:"embed_type,omitempty"`
 	// Embed ID for rich embeds (e.g., YouTube video ID)
-	EmbedId       *string `protobuf:"bytes,7,opt,name=embed_id,json=embedId,proto3,oneof" json:"embed_id,omitempty"`
+	EmbedId *string `protobuf:"bytes,7,opt,name=embed_id,json=embedId,proto3,oneof" json:"embed_id,omitempty"`
+	// Preview image content metadata and storage pointer.
+	ImageAsset    *AssetRecord `protobuf:"bytes,8,opt,name=image_asset,json=imageAsset,proto3" json:"image_asset,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1636,6 +1639,13 @@ func (x *LinkPreview) GetEmbedId() string {
 		return *x.EmbedId
 	}
 	return ""
+}
+
+func (x *LinkPreview) GetImageAsset() *AssetRecord {
+	if x != nil {
+		return x.ImageAsset
+	}
+	return nil
 }
 
 // CachedLinkPreview wraps LinkPreview with cache metadata.
@@ -2330,7 +2340,7 @@ const file_chatto_core_v1_models_proto_rawDesc = "" +
 	"\x10encryption_nonce\x18\x15 \x01(\fR\x0fencryptionNonce\x12<\n" +
 	"\vattachments\x18\x1e \x03(\v2\x1a.chatto.core.v1.AttachmentR\vattachments\x12\x1b\n" +
 	"\tasset_ids\x18\x1f \x03(\tR\bassetIds\x12>\n" +
-	"\flink_preview\x18( \x01(\v2\x1b.chatto.core.v1.LinkPreviewR\vlinkPreview\"\xfe\x01\n" +
+	"\flink_preview\x18( \x01(\v2\x1b.chatto.core.v1.LinkPreviewR\vlinkPreview\"\xbc\x02\n" +
 	"\vLinkPreview\x12\x10\n" +
 	"\x03url\x18\x01 \x01(\tR\x03url\x12\x14\n" +
 	"\x05title\x18\x02 \x01(\tR\x05title\x12 \n" +
@@ -2339,7 +2349,9 @@ const file_chatto_core_v1_models_proto_rawDesc = "" +
 	"\x0eimage_asset_id\x18\x05 \x01(\tH\x00R\fimageAssetId\x88\x01\x01\x12\x1d\n" +
 	"\n" +
 	"embed_type\x18\x06 \x01(\tR\tembedType\x12\x1e\n" +
-	"\bembed_id\x18\a \x01(\tH\x01R\aembedId\x88\x01\x01B\x11\n" +
+	"\bembed_id\x18\a \x01(\tH\x01R\aembedId\x88\x01\x01\x12<\n" +
+	"\vimage_asset\x18\b \x01(\v2\x1b.chatto.core.v1.AssetRecordR\n" +
+	"imageAssetB\x11\n" +
 	"\x0f_image_asset_idB\v\n" +
 	"\t_embed_id\"\xca\x01\n" +
 	"\x11CachedLinkPreview\x12\x10\n" +
@@ -2469,20 +2481,21 @@ var file_chatto_core_v1_models_proto_depIdxs = []int32{
 	28, // 14: chatto.core.v1.MessageBody.updated_at:type_name -> google.protobuf.Timestamp
 	18, // 15: chatto.core.v1.MessageBody.attachments:type_name -> chatto.core.v1.Attachment
 	20, // 16: chatto.core.v1.MessageBody.link_preview:type_name -> chatto.core.v1.LinkPreview
-	20, // 17: chatto.core.v1.CachedLinkPreview.preview:type_name -> chatto.core.v1.LinkPreview
-	25, // 18: chatto.core.v1.RoomLayout.legacy_sections:type_name -> chatto.core.v1.RoomGroup
-	3,  // 19: chatto.core.v1.SidebarGroupEntry.kind:type_name -> chatto.core.v1.SidebarGroupEntry.Kind
-	24, // 20: chatto.core.v1.RoomGroup.entries:type_name -> chatto.core.v1.SidebarGroupEntry
-	23, // 21: chatto.core.v1.RoomGroup.sidebar_links:type_name -> chatto.core.v1.SidebarLink
-	2,  // 22: chatto.core.v1.VideoProcessingState.status:type_name -> chatto.core.v1.VideoStatus
-	27, // 23: chatto.core.v1.VideoProcessingState.variants:type_name -> chatto.core.v1.VideoVariant
-	18, // 24: chatto.core.v1.VideoProcessingState.thumbnail_attachment:type_name -> chatto.core.v1.Attachment
-	18, // 25: chatto.core.v1.VideoVariant.attachment:type_name -> chatto.core.v1.Attachment
-	26, // [26:26] is the sub-list for method output_type
-	26, // [26:26] is the sub-list for method input_type
-	26, // [26:26] is the sub-list for extension type_name
-	26, // [26:26] is the sub-list for extension extendee
-	0,  // [0:26] is the sub-list for field type_name
+	12, // 17: chatto.core.v1.LinkPreview.image_asset:type_name -> chatto.core.v1.AssetRecord
+	20, // 18: chatto.core.v1.CachedLinkPreview.preview:type_name -> chatto.core.v1.LinkPreview
+	25, // 19: chatto.core.v1.RoomLayout.legacy_sections:type_name -> chatto.core.v1.RoomGroup
+	3,  // 20: chatto.core.v1.SidebarGroupEntry.kind:type_name -> chatto.core.v1.SidebarGroupEntry.Kind
+	24, // 21: chatto.core.v1.RoomGroup.entries:type_name -> chatto.core.v1.SidebarGroupEntry
+	23, // 22: chatto.core.v1.RoomGroup.sidebar_links:type_name -> chatto.core.v1.SidebarLink
+	2,  // 23: chatto.core.v1.VideoProcessingState.status:type_name -> chatto.core.v1.VideoStatus
+	27, // 24: chatto.core.v1.VideoProcessingState.variants:type_name -> chatto.core.v1.VideoVariant
+	18, // 25: chatto.core.v1.VideoProcessingState.thumbnail_attachment:type_name -> chatto.core.v1.Attachment
+	18, // 26: chatto.core.v1.VideoVariant.attachment:type_name -> chatto.core.v1.Attachment
+	27, // [27:27] is the sub-list for method output_type
+	27, // [27:27] is the sub-list for method input_type
+	27, // [27:27] is the sub-list for extension type_name
+	27, // [27:27] is the sub-list for extension extendee
+	0,  // [0:27] is the sub-list for field type_name
 }
 
 func init() { file_chatto_core_v1_models_proto_init() }

--- a/cli/internal/pb/chatto/core/v1/room_group_events.pb.go
+++ b/cli/internal/pb/chatto/core/v1/room_group_events.pb.go
@@ -361,7 +361,7 @@ type SidebarLinkAddedToGroupEvent struct {
 	GroupId       string                 `protobuf:"bytes,1,opt,name=group_id,json=groupId,proto3" json:"group_id,omitempty"`
 	LinkId        string                 `protobuf:"bytes,2,opt,name=link_id,json=linkId,proto3" json:"link_id,omitempty"`
 	Label         string                 `protobuf:"bytes,3,opt,name=label,proto3" json:"label,omitempty"`
-	Url           string                 `protobuf:"bytes,4,opt,name=url,proto3" json:"url,omitempty"`
+	Url           string                 `protobuf:"bytes,4,opt,name=url,proto3" json:"url,omitempty"` // Absolute http(s) URL or server-local path starting with /
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -429,7 +429,7 @@ type SidebarLinkUpdatedEvent struct {
 	GroupId       string                 `protobuf:"bytes,1,opt,name=group_id,json=groupId,proto3" json:"group_id,omitempty"`
 	LinkId        string                 `protobuf:"bytes,2,opt,name=link_id,json=linkId,proto3" json:"link_id,omitempty"`
 	Label         string                 `protobuf:"bytes,3,opt,name=label,proto3" json:"label,omitempty"`
-	Url           string                 `protobuf:"bytes,4,opt,name=url,proto3" json:"url,omitempty"`
+	Url           string                 `protobuf:"bytes,4,opt,name=url,proto3" json:"url,omitempty"` // Absolute http(s) URL or server-local path starting with /
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/docs-website/src/content/docs/guides/s3-storage.mdx
+++ b/docs-website/src/content/docs/guides/s3-storage.mdx
@@ -1,18 +1,18 @@
 ---
 title: S3 Storage
-description: How to configure S3-compatible object storage for file attachments and media.
+description: How to configure S3-compatible object storage for persisted assets.
 ---
 
 import { Aside, Tabs, TabItem, LinkCard } from "@astrojs/starlight/components";
 
-By default, Chatto stores file attachments (images, videos, documents) inside NATS JetStream object stores. This works well for small to medium deployments, but can put pressure on your NATS storage as usage grows.
+By default, Chatto stores persisted assets (attachments, avatars, server branding images, and link-preview images) inside NATS JetStream object stores. This works well for small to medium deployments, but can put pressure on your NATS storage as usage grows.
 
-Switching to an S3-compatible backend offloads file storage to a dedicated object store while keeping all other data (messages, users, rooms) in NATS.
+Switching to an S3-compatible backend offloads persisted asset storage to a dedicated object store while keeping all other data (messages, users, rooms) in NATS.
 
 ## How It Works
 
-- **New uploads** go to S3 when configured
-- **Existing attachments** stored in NATS continue to work — each asset remembers which backend stores its bytes
+- **New persisted assets** go to S3 when configured
+- **Existing assets** stored in NATS continue to work — each asset remembers which backend stores its bytes
 - **URLs don't change** — the storage backend is an internal detail; asset URLs always use the same format
 - **S3 prefixes are movable** — Chatto stores prefix-free asset keys, so you can move objects to a different S3 prefix and update config without rewriting Chatto metadata
 

--- a/docs-website/src/content/docs/reference/environment-variables.mdx
+++ b/docs-website/src/content/docs/reference/environment-variables.mdx
@@ -120,7 +120,7 @@ Built-in automatic TLS via Let's Encrypt. When enabled, Chatto handles certifica
 </EnvVar>
 
 <EnvVar name="CHATTO_CORE_ASSETS_STORAGE_BACKEND" toml="core.assets.storage_backend" default="nats">
-  Storage backend for file attachments. Values: `nats`, `s3`.
+  Storage backend for persisted assets. Values: `nats`, `s3`.
 </EnvVar>
 
 ### S3 Storage
@@ -162,7 +162,7 @@ Only used when `storage_backend` is set to `s3`. See the [S3 Storage guide](/gui
 ### Image Cache
 
 <EnvVar name="CHATTO_CORE_ASSETS_CACHE_ENABLED" toml="core.assets.cache.enabled" default="false">
-  Enable caching for resized images. Reduces CPU usage for repeated thumbnail generation.
+  Enable caching for resized image transforms. Reduces CPU usage for repeated thumbnail generation.
 </EnvVar>
 
 <EnvVar name="CHATTO_CORE_ASSETS_CACHE_TTL" toml="core.assets.cache.ttl" default="7d">

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -332,8 +332,8 @@ Diagnostic fields (`admin.systemInfo`, `admin.eventLog`, `admin.eventLogEntry`, 
 | KV      | `RUNTIME_STATE`               | Persisted latest-value runtime/user state, including pending notifications, push subscriptions, auth/workflow tokens, and wrapped app DEK records |
 | KV      | `MEMORY_CACHE`                | Volatile memory-backed cache state for presence and short-lived leader leases; excluded from backups |
 | KV      | `ENCRYPTION_KEYS`             | KMS key-encryption keys and per-call LiveKit E2EE keys; excluded from backups |
-| Objects | `SERVER_ASSETS`               | Asset binaries (avatars, server branding, link previews, message attachments) |
-| Objects | `ASSET_CACHE`                 | Optional cached image transforms with TTL    |
+| Objects | `SERVER_ASSETS` or S3 bucket  | Persisted asset binaries                    |
+| Objects | `ASSET_CACHE`                 | Optional cached image transforms with TTL   |
 
 See [NATS Resource Inventory](#nats-resource-inventory) for detailed key patterns and subjects.
 
@@ -389,7 +389,7 @@ Key files: [`cli/internal/core/core.go`](../cli/internal/core/core.go), [`cli/in
 | KV bucket    | `RUNTIME_STATE`     | File    | Yes    | Persisted latest-value runtime state, auth/session tokens, notifications, wrapped app DEKs |
 | KV bucket    | `MEMORY_CACHE`      | Memory  | No     | Volatile presence and short-lived leader leases                             |
 | KV bucket    | `ENCRYPTION_KEYS`   | File    | No     | KMS key-encryption keys and per-call LiveKit E2EE keys; excluded from backups |
-| Object store | `SERVER_ASSETS`     | File    | Yes    | Asset binaries for avatars, branding, link previews, attachments, derivatives |
+| Object store | `SERVER_ASSETS`     | File    | Yes    | Default/legacy NATS-backed persisted asset binaries                         |
 | Object store | `ASSET_CACHE`       | File    | No     | Optional TTL cache for transformed image bytes                               |
 | NATS Core    | `live.sync.>`       | None    | No     | Transient `corev1.LiveEvent` pubsub signals                                  |
 | Republish    | `live.evt.>`        | None    | No     | Raw committed `EVT` facts republished by JetStream for server-side live delivery |
@@ -670,7 +670,7 @@ Notes: Memory-based storage (not persisted, not backed up). Presence uses per-ke
 | Bucket                      | Description                                       |
 | --------------------------- | ------------------------------------------------- |
 | `ASSET_CACHE`               | Cached resized images (optional)                  |
-| `SERVER_ASSETS`             | Asset binaries (avatars, server icon/banner, link previews, message attachments) |
+| `SERVER_ASSETS`             | NATS-backed persisted asset binaries              |
 
 **ASSET_CACHE keys:**
 
@@ -683,11 +683,18 @@ Notes: Only created when `[core.assets.cache]` is enabled in config. Uses TTL fo
 
 **SERVER\_ASSETS keys:**
 
-| Key                   | Description                                     |
-| --------------------- | ----------------------------------------------- |
-| `{assetId}`           | User avatars, server branding images, link-preview images, original attachment files, and derivative binaries |
+| Key         | Description                                    |
+| ----------- | ---------------------------------------------- |
+| `{assetId}` | Persisted asset binary by ID when stored in NATS |
 
-Notes: Asset IDs are globally unique (NanoID), so no kind segment is needed. Channel and DM assets share the same flat keyspace. Content-Type and original filename stored in object headers where available. S2 compression enabled. `MediaService` owns binary storage and serving helpers; `AssetService` owns durable lifecycle facts. Asset **metadata** (filename, dimensions, duration, storage pointer, …) is created in `AssetCreatedEvent` on `evt.asset.{assetId}.asset_created`; room scope and ownership context lives on the event (`message`, `derivative`, `user_avatar`, or `server_branding`) rather than inside `Asset`. New message bodies reference message-owned assets by ID. Processing events refer to created asset IDs and are appended under the same `evt.asset.{assetId}.*` aggregate. The asset projection also reads beta-era `evt.room.{roomId}.asset_*` facts so existing 0.1.0 histories continue to replay without a stream rewrite. Message posting asks the process-local video service to spawn video/animated-GIF processing after appending asset creation and processing-started events; there is no transient NATS Core worker subject or `video_processed` live signal. Boot recovery derives missed work from the EVT projections and calls the same local path. Video processing success records thumbnail/variant asset IDs, while each derivative binary is separately declared with `AssetCreatedEvent` and an owner pointing at the original asset. `AssetProcessingFailedEvent.failure_code` records failed/unavailable outcomes. Account deletion follows the projected message asset graph and appends `AssetDeletedEvent` for source assets and derivative children before deleting backing bytes. The asset HTTP handler doesn't look up a separate index bucket; stable asset URLs resolve metadata and room scope from `AssetProjection`, while legacy locator URLs carry the body-or-video-manifest locator in the URL itself (see "Dynamic Image Transformation" below).
+**S3 asset keys:**
+
+| Key                     | Description                                                  |
+| ----------------------- | ------------------------------------------------------------ |
+| `attachments/{assetId}` | Message attachment originals and derivative binaries         |
+| `instance/{assetId}`    | Server-scoped assets: user avatars, server branding images, and link-preview images |
+
+Notes: Asset IDs are globally unique (NanoID), so NATS-backed assets do not need a kind segment. S3 stores logical, prefix-free keys; any configured `path_prefix` is applied only when talking to the S3 backend. Content-Type and original filename stored in object headers where available. S2 compression enabled for `SERVER_ASSETS`. `MediaService` owns binary storage and serving helpers; `AssetService` owns durable lifecycle facts. Asset **metadata** (filename, dimensions, duration, storage pointer, …) is created in `AssetCreatedEvent` on `evt.asset.{assetId}.asset_created`; room scope and ownership context lives on the event (`message`, `derivative`, `user_avatar`, or `server_branding`) rather than inside `Asset`. New message bodies reference message-owned assets by ID. Link preview images are server-scoped persisted assets and are embedded in message bodies as `LinkPreview.image_asset` (`AssetRecord`) so the body records whether the image lives in S3 or `SERVER_ASSETS`; `image_asset_id` remains for compatibility with clients and older stored previews. Processing events refer to created asset IDs and are appended under the same `evt.asset.{assetId}.*` aggregate. The asset projection also reads beta-era `evt.room.{roomId}.asset_*` facts so existing 0.1.0 histories continue to replay without a stream rewrite. Message posting asks the process-local video service to spawn video/animated-GIF processing after appending asset creation and processing-started events; there is no transient NATS Core worker subject or `video_processed` live signal. Boot recovery derives missed work from the EVT projections and calls the same local path. Video processing success records thumbnail/variant asset IDs, while each derivative binary is separately declared with `AssetCreatedEvent` and an owner pointing at the original asset. `AssetProcessingFailedEvent.failure_code` records failed/unavailable outcomes. Account deletion follows the projected message asset graph and appends `AssetDeletedEvent` for source assets and derivative children before deleting backing bytes. The asset HTTP handler doesn't look up a separate index bucket; stable asset URLs resolve metadata and room scope from `AssetProjection`, while legacy locator URLs carry the body-or-video-manifest locator in the URL itself (see "Dynamic Image Transformation" below).
 
 ### Dynamic Image Transformation
 

--- a/docs/fdr/FDR-009-link-previews.md
+++ b/docs/fdr/FDR-009-link-previews.md
@@ -44,11 +44,11 @@ When a message contains a URL, Chatto can attach a preview card with the page's 
 **Why:** Without these protections, a maliciously crafted URL could make the server fetch internal services. A pre-fetch DNS lookup is bypassable via rebinding; connection-time enforcement is not.
 **Tradeoff:** Some legitimate internal-network use cases (preview an intranet wiki page) don't work. Operators who need that can disable previews entirely.
 
-### 5. Preview images are downloaded, resized, and stored as server assets
+### 5. Preview images are downloaded, resized, and stored as persisted assets
 
-**Decision:** Preview images are fetched once, resized to 1200×630 max, converted to WebP, and stored as assets on the Chatto server.
+**Decision:** Preview images are fetched once, resized to 1200×630 max, converted to WebP, and stored through the configured persisted asset backend (S3 when configured, otherwise NATS `SERVER_ASSETS`). Sent message bodies carry the preview image as `LinkPreview.image_asset` (`AssetRecord`); `image_asset_id` remains as a compatibility field for GraphQL clients and older stored previews.
 **Why:** Hot-linking preview images from third-party sites means broken previews when those sites change URLs, plus a privacy leak (the third party sees every Chatto user's fetch). Storing locally fixes both.
-**Tradeoff:** Per-server storage cost. Acceptable given asset deduplication and the small fixed size cap.
+**Tradeoff:** Per-server storage cost. Acceptable given the small fixed size cap and the fact that posted message previews should not lose images just because a cache expired.
 
 ### 6. Stored preview metadata is bounded
 

--- a/proto/chatto/core/v1/models.proto
+++ b/proto/chatto/core/v1/models.proto
@@ -305,7 +305,8 @@ message LinkPreview {
   string description = 3;
   string site_name = 4;
 
-  // Asset ID for the preview image (stored in instance ObjectStore)
+  // Asset ID for the preview image. Kept for GraphQL/client compatibility;
+  // new previews also carry image_asset with storage metadata.
   optional string image_asset_id = 5;
 
   // Embed type: "generic", "youtube", "vimeo", etc.
@@ -313,6 +314,9 @@ message LinkPreview {
 
   // Embed ID for rich embeds (e.g., YouTube video ID)
   optional string embed_id = 7;
+
+  // Preview image content metadata and storage pointer.
+  AssetRecord image_asset = 8;
 }
 
 // CachedLinkPreview wraps LinkPreview with cache metadata.


### PR DESCRIPTION
## Summary

- Store link preview images through the configured persisted asset backend, using S3 when configured and `SERVER_ASSETS` otherwise.
- Add `LinkPreview.image_asset` so new persisted previews carry an `AssetRecord` storage pointer while keeping `image_asset_id` for compatibility.
- Update link preview tests plus architecture, FDR, and self-hosting docs for the broader persisted-asset behavior.

## Tests

- `mise x -- go test ./internal/core -run 'TestLinkPreviewImageStorageAndRetrieval|TestLinkPreviewImageUsesS3WhenConfigured|TestChattoCore_PostMessage_LinkPreviewLengthLimits' -timeout 90s`
- `mise x -- go test ./internal/core/... ./internal/graph ./internal/http_server -timeout 120s`

Note: this is an additive protobuf change to `LinkPreview`.
