### PR TITLE
docs: update Docker Compose example guidance

### DIFF
--- a/examples/dockercompose/.env.example
+++ b/examples/dockercompose/.env.example
@@ -1,5 +1,7 @@
 # Copy this to .env and fill in your values
-# Generate secrets with: openssl rand -hex 32
+# Generate Chatto secrets with: openssl rand -hex 32
+# Generate the LiveKit API secret with at least 32 characters, for example:
+# openssl rand -hex 32
 
 # Public URL (used by Caddy for domain, Chatto for absolute URLs)
 PUBLIC_URL=chat.example.com
@@ -33,7 +35,7 @@ CHATTO_LOG_FORMAT=json
 CHATTO_LIVEKIT_ENABLED=true
 CHATTO_LIVEKIT_URL=wss://livekit.chat.example.com
 CHATTO_LIVEKIT_API_KEY=your-api-key
-CHATTO_LIVEKIT_API_SECRET=your-api-secret
+CHATTO_LIVEKIT_API_SECRET=replace-with-at-least-32-character-livekit-secret
 
 # SMTP configuration (required for direct email/password registration,
 # email verification, and password reset)

--- a/examples/dockercompose/README.md
+++ b/examples/dockercompose/README.md
@@ -24,7 +24,7 @@ This example deploys a clustered Chatto setup with:
 2. Edit `.env` and fill in your values:
 
    ```bash
-   # Generate secrets with:
+   # Generate Chatto and LiveKit secrets with:
    openssl rand -hex 32
    ```
 
@@ -38,7 +38,7 @@ This example deploys a clustered Chatto setup with:
    - `CHATTO_CORE_SECRET_KEY` - Bearer-token and account-flow verifier key
    - `CHATTO_CORE_ASSETS_SIGNING_SECRET` - Asset URL signing
    - `CHATTO_SMTP_*` - Required for direct email/password registration, email verification, and password reset
-   - `CHATTO_LIVEKIT_API_KEY` / `CHATTO_LIVEKIT_API_SECRET` - Must match the keys in `livekit.yaml`
+   - `CHATTO_LIVEKIT_API_KEY` / `CHATTO_LIVEKIT_API_SECRET` - Must match the keys in `livekit.yaml`. LiveKit requires the API secret to be at least 32 characters.
 
 3. Edit `livekit.yaml` and update:
    - The API key/secret pair under `keys:` (must match the `.env` values)
@@ -73,6 +73,16 @@ docker compose down -v
 ```bash
 # Scale to 5 replicas
 docker compose up -d --scale chatto=5
+```
+
+## Inspecting NATS
+
+The Chatto image includes the `nats` CLI and writes a context for the runtime
+NATS connection. Run it as the `chatto` user so the CLI reads the context from
+`/home/chatto`:
+
+```bash
+docker compose exec -u chatto chatto nats stream ls
 ```
 
 ## Updating

--- a/examples/dockercompose/livekit.yaml
+++ b/examples/dockercompose/livekit.yaml
@@ -6,7 +6,7 @@ rtc:
 
 keys:
   # Must match CHATTO_LIVEKIT_API_KEY / CHATTO_LIVEKIT_API_SECRET in .env
-  your-api-key: your-api-secret
+  your-api-key: replace-with-at-least-32-character-livekit-secret
 
 webhook:
   urls:


### PR DESCRIPTION
- Clarify Docker Compose secret generation for Chatto and LiveKit.
- Update the LiveKit example secret placeholder so current LiveKit images do not warn that it is too short.
- Document how to inspect the compose NATS server with the bundled `nats` CLI as the `chatto` user.
