### PR TITLE
docs(adr): document protobuf-first API strategy

### DIFF
--- a/docs/adr/ADR-003-graphql-as-primary-api.md
+++ b/docs/adr/ADR-003-graphql-as-primary-api.md
@@ -2,6 +2,8 @@
 
 **Date:** 2026-03-01
 
+**Status:** Superseded for future public API direction by [ADR-042](ADR-042-protobuf-first-public-api.md). GraphQL remains the current implemented API until the protobuf-first API is built and migrated.
+
 ## Context
 
 Chatto's frontend needs to query structured data (users, spaces, rooms, messages), perform mutations (post message, join room, update settings), and receive real-time updates (new messages, presence changes, typing indicators). The API must support all three patterns efficiently.

--- a/docs/adr/ADR-042-protobuf-first-public-api.md
+++ b/docs/adr/ADR-042-protobuf-first-public-api.md
@@ -1,0 +1,77 @@
+# ADR-042: Protobuf-First Public API with ConnectRPC and Realtime WebSocket
+
+**Date:** 2026-06-22
+
+**Supersedes:** [ADR-003](ADR-003-graphql-as-primary-api.md) for future public API direction. GraphQL remains the current implemented API until the protobuf-first API is built and migrated.
+
+## Context
+
+GraphQL gave Chatto a fast early path for typed queries, mutations, and subscriptions from the embedded web client. It is now a poor fit for the direction of the product:
+
+- Chatto needs a stable public integration surface for bots, SDKs, tooling, and alternate clients.
+- Mixed-version clients are becoming normal because users can self-host and separately hosted clients may connect to older servers.
+- GraphQL query validation makes additive schema changes riskier for multi-server clients than they should be.
+- GraphQL subscriptions are not an ideal long-running realtime transport for Chatto's single app-session live-event stream.
+- Chatto's backend is already event-sourced and protobuf-based internally, but GraphQL forces an additional schema and generated model layer at the public boundary.
+- JSON field names, nullability, enum strings, and error shapes become a long-lived public contract as soon as they are exposed.
+
+Chatto needs a public API contract that is typed, efficient, SDK-friendly, and compatible with its command/projection/live-event architecture. The contract should not expose storage internals such as raw EVT messages, NATS subjects, or JetStream sequence numbers.
+
+## Decision
+
+Chatto will move toward a protobuf-first public API.
+
+Public API `.proto` files will be the authoritative contract for the next API generation. They should live separately from persisted event protos, for example under `proto/chatto/api/v1/`. Public API messages may reuse concepts from core models, but they are compatibility contracts for callers and must not simply expose durable EVT payloads.
+
+The API has two primary transports:
+
+1. **ConnectRPC over HTTP** for request/response service calls.
+2. **A Chatto-defined protobuf WebSocket protocol** for long-lived realtime delivery.
+
+ConnectRPC over HTTP is the canonical transport for requestful interactions:
+
+- projection reads,
+- commands and mutations,
+- admin and tooling operations,
+- bounded streaming operations such as imports, exports, uploads, downloads, or progress reporting.
+
+Chatto will not use ConnectRPC streaming as the primary app-session realtime subscription mechanism. Connect streaming remains available for bounded flows, but long-lived live-event delivery needs app-level control over resume, heartbeat, cancellation, reconnect, backpressure, and multiplexing semantics.
+
+The realtime WebSocket protocol will use binary protobuf frames. Its initial required scope is:
+
+- connection hello and server capability/version announcement,
+- authentication using the same effective identity model as the HTTP API,
+- subscription to the caller's authorized live event stream,
+- opaque resume cursors,
+- heartbeat/ping behavior,
+- protocol errors,
+- close semantics and reconnect guidance.
+
+WebSocket live events are public API events, not raw EVT facts. They may be derived from durable EVT events and transient live sync signals, but they must preserve authorization checks, projection readiness, and replay compatibility at the API boundary.
+
+The WebSocket protocol should reserve frame shapes for future multiplexed RPC-over-WebSocket. That fast path is a future optimization, not part of the initial required implementation. If implemented, it must:
+
+- use the same protobuf service contracts as ConnectRPC,
+- call the same backend handlers or shared service boundary,
+- preserve the same authorization, validation, OCC, read-your-writes, idempotency, and error semantics,
+- avoid WebSocket-only product APIs except connection-control operations.
+
+JSON is deferred. Chatto may later expose JSON encodings or generated JSON/HTTP convenience endpoints for selected public API protos, but JSON is not the source of truth for the new API contract.
+
+Existing HTTP endpoints that are not GraphQL should be reviewed separately during migration. In particular, `/api/server` remains a high-stability discovery surface, and auth, OAuth, uploads, asset delivery, webhooks, and health/metrics endpoints may remain explicit HTTP APIs where that shape is still appropriate.
+
+## Consequences
+
+The public API contract moves from GraphQL schema files to protobuf service and message definitions. Field numbers, service names, method names, enum values, oneof shapes, streaming semantics, and error details become long-lived compatibility commitments.
+
+Generated clients become a first-class part of the API strategy. Bots and integrations should normally use generated SDKs rather than hand-written HTTP calls. This makes strongly typed Go, TypeScript, Python, Rust, mobile, and other clients more realistic.
+
+The first-party web client gets a cleaner split between request/response operations and app-session realtime delivery. The live connection can be designed around Chatto's actual needs instead of fitting them through GraphQL subscriptions or generic HTTP streaming.
+
+Deferring JSON keeps the initial compatibility surface smaller. The cost is that casual `curl`-style integrations are less ergonomic until JSON support, SDKs, CLI tooling, or debug helpers exist.
+
+Separating public API protos from persisted EVT protos prevents storage compatibility requirements from leaking into caller-facing contracts. It also means some mapping code is unavoidable.
+
+ConnectRPC over HTTP remains the baseline for debuggability, infrastructure compatibility, and non-browser clients. RPC-over-WebSocket is only a latency and connection-count optimization for already-connected clients, so the project can defer its complexity until there is a concrete need.
+
+GraphQL should be retained as a compatibility layer during migration. Removing or deprecating GraphQL requires a separate migration plan, frontend migration, compatibility communication, and release decision.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -49,3 +49,4 @@ For more about ADRs, see [Michael Nygard's article](https://cognitect.com/blog/2
 | [ADR-039](ADR-039-service-worker-virtual-asset-urls.md) | Service Worker Virtual Asset URLs with Ticketed Fallback | 2026-06-08 |
 | [ADR-040](ADR-040-permission-only-rbac-with-owner-override.md) | Permission-Only RBAC with Owner Override | 2026-06-15 |
 | [ADR-041](ADR-041-runtime-units.md) | Runtime Units for Optional Chatto Processes | 2026-06-21 |
+| [ADR-042](ADR-042-protobuf-first-public-api.md) | Protobuf-First Public API with ConnectRPC and Realtime WebSocket | 2026-06-22 |


### PR DESCRIPTION
## Summary

- Adds ADR-042 documenting a protobuf-first public API strategy with ConnectRPC over HTTP and a Chatto protobuf realtime WebSocket.
- Marks ADR-003 as superseded for future public API direction while keeping GraphQL as the current implemented API during migration.
- Updates the ADR index.

## Testing

- `git diff --check`
