### PR TITLE
fix(frontend): ignore stale DM member loads when switching rooms

### DIFF
--- a/frontend/src/lib/hooks/useRoomData.svelte.spec.ts
+++ b/frontend/src/lib/hooks/useRoomData.svelte.spec.ts
@@ -1,0 +1,173 @@
+import { flushSync } from 'svelte';
+import type { Client } from '@urql/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PresenceStatus, RoomType } from '$lib/gql/graphql';
+import { useRoomData } from './useRoomData.svelte';
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    client: undefined as Client | undefined,
+    reconnect: { count: 0 }
+  }
+}));
+
+vi.mock('$lib/state/server/connection.svelte', () => ({
+  useConnection: () => () => ({ client: mocks.client })
+}));
+
+vi.mock('$lib/hooks/useEvent.svelte', () => ({
+  useActiveRoomLayoutUpdated: () => undefined
+}));
+
+vi.mock('$lib/hooks/useReconnectCallback.svelte', () => ({
+  useReconnectTrigger: () => mocks.reconnect
+}));
+
+type QueryResult = {
+  data?: unknown;
+  error?: unknown;
+};
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function operationName(document: unknown): string {
+  const definition = (document as { definitions?: Array<{ name?: { value?: string } }> }).definitions?.find(
+    (candidate) => candidate.name?.value
+  );
+  return definition?.name?.value ?? 'unknown';
+}
+
+function roomQueryResult(roomId: string): QueryResult {
+  return {
+    data: {
+      room: {
+        id: roomId,
+        name: roomId,
+        description: null,
+        type: RoomType.Dm,
+        isUniversal: false,
+        viewerCanPostMessage: true,
+        viewerCanPostInThread: true,
+        viewerCanAttach: true,
+        viewerCanReact: true,
+        viewerCanManageOthersMessage: false,
+        viewerCanEchoMessage: false,
+        viewerCanManageRoom: false,
+        viewerCanBanRoomMembers: false
+      },
+      server: {
+        profile: { name: 'Test Server' },
+        viewerCanManageRooms: false
+      }
+    }
+  };
+}
+
+function dmMembersResult(roomId: string, userId: string, displayName: string): QueryResult {
+  return {
+    data: {
+      room: {
+        id: roomId,
+        members: {
+          users: [
+            {
+              id: userId,
+              login: userId,
+              displayName,
+              avatarUrl: null,
+              presenceStatus: PresenceStatus.Online
+            }
+          ],
+          totalCount: 1,
+          hasMore: false
+        }
+      },
+      viewer: {
+        user: { id: 'viewer' }
+      }
+    }
+  };
+}
+
+describe('useRoomData', () => {
+  let pendingDmQueries: Map<string, Deferred<QueryResult>>;
+
+  beforeEach(() => {
+    mocks.reconnect = { count: 0 };
+    pendingDmQueries = new Map();
+    mocks.client = {
+      query: vi.fn().mockImplementation((document: unknown, variables: { roomId: string }) => {
+        const name = operationName(document);
+
+        if (name === 'GetRoom') {
+          return { toPromise: () => Promise.resolve(roomQueryResult(variables.roomId)) };
+        }
+
+        if (name === 'GetDMRoomMembers') {
+          const pending = deferred<QueryResult>();
+          pendingDmQueries.set(variables.roomId, pending);
+          return { toPromise: () => pending.promise };
+        }
+
+        throw new Error(`Unexpected query: ${name}`);
+      }),
+      mutation: vi.fn(),
+      subscription: vi.fn()
+    } as unknown as Client;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('ignores stale DM member responses after switching rooms', async () => {
+    let harness!: {
+      room: ReturnType<typeof useRoomData>;
+      switchRoom: (nextRoomId: string) => void;
+    };
+    const destroy = $effect.root(() => {
+      let roomId = $state('dm-a');
+      const room = useRoomData(() => ({ roomId }));
+
+      flushSync();
+
+      harness = {
+        room,
+        switchRoom(nextRoomId: string) {
+          roomId = nextRoomId;
+          flushSync();
+        }
+      };
+    });
+
+    try {
+      await vi.waitFor(() => expect(pendingDmQueries.has('dm-a')).toBe(true));
+      harness.switchRoom('dm-b');
+      await vi.waitFor(() => expect(pendingDmQueries.has('dm-b')).toBe(true));
+
+      pendingDmQueries.get('dm-b')?.resolve(dmMembersResult('dm-b', 'user-b', 'User B'));
+      await vi.waitFor(() => expect(harness.room.dmData?.participants[0]?.id).toBe('user-b'));
+
+      pendingDmQueries.get('dm-a')?.resolve(dmMembersResult('dm-a', 'user-a', 'User A'));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(harness.room.dmData?.participants[0]?.id).toBe('user-b');
+    } finally {
+      destroy();
+    }
+  });
+});

--- a/frontend/src/lib/hooks/useRoomData.svelte.ts
+++ b/frontend/src/lib/hooks/useRoomData.svelte.ts
@@ -122,6 +122,7 @@ export function useRoomData(getProps: () => { roomId: string }) {
   let roomData = $state<RoomData | null | undefined>(undefined);
   let dmData = $state<DMData | null>(null);
   const roomLoadId = { current: 0 };
+  const dmLoadId = { current: 0 };
 
   // Post-PR(b) we tell channel vs DM via `Room.type` (the resolver returns
   // `RoomType.DM` for DM rooms and `CHANNEL` for everything else).
@@ -210,11 +211,14 @@ export function useRoomData(getProps: () => { roomId: string }) {
   // Load DM participants
   $effect(() => {
     if (!isDM) {
+      dmLoadId.current++;
       dmData = null;
       return;
     }
 
     void reconnect.count;
+    const currentRoomId = getProps().roomId;
+    const thisLoadId = ++dmLoadId.current;
 
     connection()
       .client.query(
@@ -237,10 +241,13 @@ export function useRoomData(getProps: () => { roomId: string }) {
             }
           }
         `),
-        { roomId: getProps().roomId }
+        { roomId: currentRoomId }
       )
       .toPromise()
       .then((resp) => {
+        if (dmLoadId.current !== thisLoadId) return;
+        if (resp.data?.room?.id && resp.data.room.id !== currentRoomId) return;
+
         if (!resp.data?.room) {
           dmData = { participants: [], currentUserId: null };
           return;
@@ -251,6 +258,13 @@ export function useRoomData(getProps: () => { roomId: string }) {
           ),
           currentUserId: resp.data.viewer?.user.id ?? null
         };
+      })
+      .catch((err) => {
+        if (dmLoadId.current !== thisLoadId) return;
+        console.warn('[useRoomData] failed to load DM members', {
+          roomId: currentRoomId,
+          error: err
+        });
       });
   });
 


### PR DESCRIPTION
## Summary
- Guard DM participant loading with a per-request load id so late responses from a previously selected room are ignored.
- Capture the active room id before issuing the DM members query and verify the response still matches that room before updating state.
- Add a regression test covering the room-switch race.

## Why
When users switch between DM rooms quickly, an older `GetDMRoomMembers` request could resolve after the new room was already active and overwrite the current room's participants. This change prevents that stale response from clobbering `dmData` and keeps the UI aligned with the selected room.

## Testing
- Added a focused Vitest spec for the stale-response race in `useRoomData`.