### PR TITLE
chore(dev): support Paseo workspace ports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,17 +18,18 @@ machine-specific settings, and private prompts out of tracked files; use local
 settings such as `.conductor/settings.local.toml` or your tool's user-level
 configuration for those.
 
-## Local Development with Conductor
+## Local Development with Conductor or Paseo
 
-[Conductor](https://conductor.build) workspaces build and run the bundled Chatto executable. The `run` script in `.conductor/settings.toml` wires Conductor's assigned `$CONDUCTOR_PORT` and the next port into the env vars read by the executable:
+[Conductor](https://conductor.build) and Paseo workspaces build and run the bundled Chatto executable. The Conductor `run` script in `.conductor/settings.toml` and the Paseo service script in `paseo.json` both delegate to `mise run chatto run`. The mise task uses Conductor's assigned `$CONDUCTOR_PORT`, Paseo's assigned `$PASEO_PORT`, or `4000` outside either tool, then reserves the next ports for bundled services:
 
-| Port              | Process                            |
-| ----------------- | ---------------------------------- |
-| `$CONDUCTOR_PORT` | Chatto webserver (user-facing URL) |
-| `+1`              | Embedded NATS                      |
-| `+2`              | Prometheus metrics                 |
+| Port                             | Process                            |
+| -------------------------------- | ---------------------------------- |
+| `$CONDUCTOR_PORT` / `$PASEO_PORT` | Chatto webserver (user-facing URL) |
+| `+1`                             | Embedded NATS                      |
+| `+2`                             | Prometheus metrics                 |
+| `+3`                             | Deployment-wide exporter metrics   |
 
-The repository-level Conductor settings are shared in `.conductor/settings.toml`. The run command delegates to `mise run chatto run`, which builds the frontend and development CLI, wires the per-workspace ports, and starts `bin/chatto run` without live reloads. Put machine-specific overrides in `.conductor/settings.local.toml`; that file is gitignored and wins over shared settings on your machine. Conductor also reads `.worktreeinclude` to copy gitignored local environment files, such as `.env` and `.env.*`, into new workspaces.
+The repository-level Conductor settings are shared in `.conductor/settings.toml`, and the repository-level Paseo settings are shared in `paseo.json`. Both build the frontend and development CLI, wire per-workspace ports, and start `bin/chatto run` without live reloads. Put machine-specific Conductor overrides in `.conductor/settings.local.toml`; that file is gitignored and wins over shared settings on your machine. Conductor also reads `.worktreeinclude` to copy gitignored local environment files, such as `.env` and `.env.*`, into new workspaces.
 
 ## Developing Outside of Conductor
 
@@ -45,7 +46,7 @@ To run the bundled executable without live reloads using the same port wiring as
 mise run chatto run
 ```
 
-When `CONDUCTOR_PORT` is unset, `mise run chatto run` uses `4000` for Chatto, `4001` for embedded NATS, and `4002` for Prometheus metrics. Pass explicit CLI arguments after the task name, for example `mise chatto version`.
+When both `CONDUCTOR_PORT` and `PASEO_PORT` are unset, `mise run chatto run` uses `4000` for Chatto, `4001` for embedded NATS, `4002` for Prometheus metrics, and `4003` for exporter metrics. Pass explicit CLI arguments after the task name, for example `mise chatto version`.
 
 For the live-reload development stack, use Tilt:
 

--- a/cli/chatto.toml
+++ b/cli/chatto.toml
@@ -18,7 +18,7 @@ port = 9090
 path = '/metrics'
 
 # Deployment-wide Prometheus exporter. `mise chatto` overrides this port with
-# CONDUCTOR_PORT+3 so multiple Conductor workspaces can run side by side.
+# the workspace base port + 3 so multiple workspaces can run side by side.
 [exporter]
 enabled = true
 bind_address = '127.0.0.1'

--- a/mise.toml
+++ b/mise.toml
@@ -206,20 +206,20 @@ description = "Build and run the bundled Chatto CLI command with workspace-safe 
 depends = ["build-dev-cli"]
 dir = "cli"
 env = {
-  CHATTO_WEBSERVER_PORT = "{{env.CONDUCTOR_PORT | default(value='4000')}}",
-  CHATTO_WEBSERVER_URL = "http://localhost:{{env.CONDUCTOR_PORT | default(value='4000')}}",
-  CHATTO_NATS_EMBEDDED_PORT = "{{env.CONDUCTOR_PORT | default(value='4000') | int + 1}}",
-  CHATTO_NATS_CLIENT_URL = "nats://localhost:{{env.CONDUCTOR_PORT | default(value='4000') | int + 1}}",
+  CHATTO_WEBSERVER_PORT = "{{env.CONDUCTOR_PORT | default(value=env.PASEO_PORT | default(value='4000'))}}",
+  CHATTO_WEBSERVER_URL = "http://localhost:{{env.CONDUCTOR_PORT | default(value=env.PASEO_PORT | default(value='4000'))}}",
+  CHATTO_NATS_EMBEDDED_PORT = "{{env.CONDUCTOR_PORT | default(value=env.PASEO_PORT | default(value='4000')) | int + 1}}",
+  CHATTO_NATS_CLIENT_URL = "nats://localhost:{{env.CONDUCTOR_PORT | default(value=env.PASEO_PORT | default(value='4000')) | int + 1}}",
   CHATTO_METRICS_ENABLED = "true",
   CHATTO_METRICS_BIND_ADDRESS = "127.0.0.1",
-  CHATTO_METRICS_PORT = "{{env.CONDUCTOR_PORT | default(value='4000') | int + 2}}",
+  CHATTO_METRICS_PORT = "{{env.CONDUCTOR_PORT | default(value=env.PASEO_PORT | default(value='4000')) | int + 2}}",
   CHATTO_METRICS_PATH = "/metrics",
   CHATTO_EXPORTER_ENABLED = "true",
   CHATTO_EXPORTER_BIND_ADDRESS = "127.0.0.1",
-  CHATTO_EXPORTER_PORT = "{{env.CONDUCTOR_PORT | default(value='4000') | int + 3}}",
+  CHATTO_EXPORTER_PORT = "{{env.CONDUCTOR_PORT | default(value=env.PASEO_PORT | default(value='4000')) | int + 3}}",
   CHATTO_EXPORTER_PATH = "/metrics",
 }
-run = "exec bin/chatto"
+run = "printf 'Chatto URL: %s\\n' \"$CHATTO_WEBSERVER_URL\" && exec bin/chatto"
 
 # =============================================================================
 # Testing

--- a/paseo.json
+++ b/paseo.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": {
       "type": "service",
-      "command": "mise dev"
+      "command": "mise run chatto run"
     }
   }
 }


### PR DESCRIPTION
- Add Paseo service wiring for the bundled Chatto run task so it follows the same port layout as Conductor.
- Teach the shared `mise run chatto run` task to prefer `PASEO_PORT` when `CONDUCTOR_PORT` is absent and print the resolved Chatto URL before starting the CLI.
- Document the shared Conductor/Paseo workspace port layout.

Verification:
- `ruby -rjson -e 'JSON.parse(File.read("paseo.json")); puts "valid json"'`
- `mise run --skip-deps --dry-run chatto run`
- `PASEO_PORT=62000 mise run --skip-deps --dry-run chatto run`
- `CONDUCTOR_PORT=61000 PASEO_PORT=62000 mise run --skip-deps --dry-run chatto run`
- `PASEO_PORT=62000 mise run --skip-deps chatto version`
- `CONDUCTOR_PORT=61000 PASEO_PORT=62000 mise run --skip-deps chatto version`
