### PR TITLE
fix(frontend): restrict same-tab message links

### DIFF
--- a/frontend/src/lib/components/MessageContent.svelte
+++ b/frontend/src/lib/components/MessageContent.svelte
@@ -9,7 +9,7 @@
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { renderMarkdown as renderMd } from '$lib/markdown';
-  import { parseMessageLink, buildMessageLinkPath } from '$lib/messageLinks';
+  import { classifyMessageBodyChatLink, buildMessageLinkPath } from '$lib/messageLinks';
   import { wrapValidMentions, type RoomMember } from '$lib/mentions';
 
   let {
@@ -85,20 +85,23 @@
       return;
     }
 
-    // Handle link clicks — Chatto message links navigate in-app,
-    // all other links open in the system browser (PWA compatibility).
+    // Handle link clicks. Only allow-listed Chatto chat routes navigate in-app;
+    // other same-origin URLs stay out-of-band to avoid message-link abuse.
     const anchor = target.closest('a');
     if (anchor?.href) {
       event.preventDefault();
 
-      // Internal message link → navigate in-app via SvelteKit
-      const messageLink = parseMessageLink(anchor.href);
-      if (messageLink?.serverId) {
-        goto(buildMessageLinkPath(messageLink.serverId, messageLink.roomId, messageLink.messageId));
+      const chatLink = classifyMessageBodyChatLink(anchor.href);
+      if (chatLink?.kind === 'message') {
+        goto(buildMessageLinkPath(chatLink.serverId, chatLink.roomId, chatLink.messageId));
+        return;
+      }
+      if (chatLink) {
+        goto(chatLink.path);
         return;
       }
 
-      // External link → force opening in system browser.
+      // External or non-allow-listed link → force opening in system browser.
       // target="_blank" alone is ignored by PWAs for same-origin URLs.
       // window.open() with features forces a new browser window.
       window.open(anchor.href, '_blank', 'noopener,noreferrer');

--- a/frontend/src/lib/components/MessageContent.svelte.spec.ts
+++ b/frontend/src/lib/components/MessageContent.svelte.spec.ts
@@ -1,10 +1,47 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import '../../app.css';
-import MessageContent, { renderMarkdown, rendererReady } from './MessageContent.svelte';
 import { q } from '$lib/test-utils';
 import type { RoomMember } from '$lib/mentions';
 import { PresenceStatus } from '$lib/gql/graphql';
+
+const mocks = vi.hoisted(() => ({
+  goto: vi.fn(),
+  segmentToServerId: vi.fn((segment: string) => (segment === '-' ? 'origin' : null)),
+  store: {
+    currentUser: {
+      user: undefined as { login: string } | undefined
+    }
+  }
+}));
+
+vi.mock('$app/navigation', () => ({
+  goto: mocks.goto
+}));
+
+vi.mock('$lib/navigation', () => ({
+  serverIdToSegment: (serverId: string) => (serverId === 'origin' ? '-' : serverId),
+  segmentToServerId: mocks.segmentToServerId
+}));
+
+vi.mock('$lib/state/activeServer.svelte', () => ({
+  getActiveServer: () => 'origin'
+}));
+
+vi.mock('$lib/state/server/registry.svelte', () => ({
+  serverRegistry: {
+    tryGetStore: () => mocks.store,
+    getServer: (serverId: string) =>
+      serverId === 'origin' ? { id: 'origin', url: window.location.origin } : undefined
+  }
+}));
+
+import MessageContent, { renderMarkdown, rendererReady } from './MessageContent.svelte';
+
+const channelRoomId = 'R123456789abcde';
+const dmRoomId = 'abcdef12345678';
+const messageId = 'Eabc123DEF456gh';
+const threadRootEventId = 'Ethread12345678';
 
 function renderMessage(body: string, members: RoomMember[] = [], roleHandles: string[] = []) {
   return render(MessageContent, { props: { body, members, roleHandles } });
@@ -37,6 +74,19 @@ function computedBorderColorFor(property: string): string {
   element.remove();
   return color;
 }
+
+beforeEach(() => {
+  mocks.goto.mockReset();
+  mocks.segmentToServerId.mockReset();
+  mocks.segmentToServerId.mockImplementation((segment: string) =>
+    segment === '-' ? 'origin' : null
+  );
+  vi.spyOn(window, 'open').mockImplementation(() => null);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('renderMarkdown', () => {
   // Wait for the markdown renderer to initialize before running tests
@@ -147,6 +197,22 @@ describe('renderMarkdown', () => {
 
     it('applies security attributes to bare-domain auto-links', async () => {
       const html = await renderMarkdown('www.example.com');
+      expect(html).toContain('target="_blank"');
+      expect(html).toContain('rel="noopener noreferrer"');
+    });
+
+    it('does not add new-window attributes to allow-listed same-origin chat URLs', async () => {
+      const href = `${window.location.origin}/chat/-/${channelRoomId}`;
+      const html = await renderMarkdown(`[room](${href})`);
+      expect(html).toContain(`href="${href}"`);
+      expect(html).not.toContain('target="_blank"');
+      expect(html).not.toContain('rel="noopener noreferrer"');
+    });
+
+    it('keeps new-window attributes on non-allow-listed same-origin URLs', async () => {
+      const href = `${window.location.origin}/chat/-/settings`;
+      const html = await renderMarkdown(`[settings](${href})`);
+      expect(html).toContain(`href="${href}"`);
       expect(html).toContain('target="_blank"');
       expect(html).toContain('rel="noopener noreferrer"');
     });
@@ -315,6 +381,72 @@ describe('MessageContent component', () => {
     const link = q(container, 'a')!;
     expect(link.getAttribute('target')).toBe('_blank');
     expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+
+  it('navigates allow-listed room links in the current tab', async () => {
+    const href = `${window.location.origin}/chat/-/${channelRoomId}`;
+    const { container } = renderMessage(`[room](${href})`);
+
+    await expect.poll(() => q(container, 'a')).toBeTruthy();
+    q(container, 'a')!.click();
+
+    expect(mocks.goto).toHaveBeenCalledWith(`/chat/-/${channelRoomId}`);
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it('navigates allow-listed DM room links in the current tab', async () => {
+    const href = `${window.location.origin}/chat/-/${dmRoomId}`;
+    const { container } = renderMessage(`[dm](${href})`);
+
+    await expect.poll(() => q(container, 'a')).toBeTruthy();
+    q(container, 'a')!.click();
+
+    expect(mocks.goto).toHaveBeenCalledWith(`/chat/-/${dmRoomId}`);
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it('navigates allow-listed thread links in the current tab', async () => {
+    const href = `${window.location.origin}/chat/-/${channelRoomId}/${threadRootEventId}`;
+    const { container } = renderMessage(`[thread](${href})`);
+
+    await expect.poll(() => q(container, 'a')).toBeTruthy();
+    q(container, 'a')!.click();
+
+    expect(mocks.goto).toHaveBeenCalledWith(`/chat/-/${channelRoomId}/${threadRootEventId}`);
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it('navigates allow-listed message links through the message resolver route', async () => {
+    const href = `${window.location.origin}/chat/-/${channelRoomId}/m/${messageId}`;
+    const { container } = renderMessage(`[message](${href})`);
+
+    await expect.poll(() => q(container, 'a')).toBeTruthy();
+    q(container, 'a')!.click();
+
+    expect(mocks.goto).toHaveBeenCalledWith(`/chat/-/${channelRoomId}/m/${messageId}`);
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it('opens same-origin non-allow-listed links in a new window', async () => {
+    const href = `${window.location.origin}/chat/-/settings`;
+    const { container } = renderMessage(`[settings](${href})`);
+
+    await expect.poll(() => q(container, 'a')).toBeTruthy();
+    q(container, 'a')!.click();
+
+    expect(mocks.goto).not.toHaveBeenCalled();
+    expect(window.open).toHaveBeenCalledWith(href, '_blank', 'noopener,noreferrer');
+  });
+
+  it('opens external links in a new window', async () => {
+    const href = 'https://example.com/docs';
+    const { container } = renderMessage(`[external](${href})`);
+
+    await expect.poll(() => q(container, 'a')).toBeTruthy();
+    q(container, 'a')!.click();
+
+    expect(mocks.goto).not.toHaveBeenCalled();
+    expect(window.open).toHaveBeenCalledWith(href, '_blank', 'noopener,noreferrer');
   });
 
   it('renders fenced code blocks with highlighted markup and hides raw fences', async () => {

--- a/frontend/src/lib/components/QuickSwitcher.svelte.spec.ts
+++ b/frontend/src/lib/components/QuickSwitcher.svelte.spec.ts
@@ -36,13 +36,12 @@ vi.mock('$app/navigation', () => ({
 
 vi.mock('$app/paths', () => ({
   resolve: (path: string, params?: Record<string, string>) =>
-    path
-      .replace('[serverId]', params?.serverId ?? '')
-      .replace('[roomId]', params?.roomId ?? '')
+    path.replace('[serverId]', params?.serverId ?? '').replace('[roomId]', params?.roomId ?? '')
 }));
 
 vi.mock('$lib/navigation', () => ({
-  serverIdToSegment: () => '-'
+  serverIdToSegment: () => '-',
+  segmentToServerId: (segment: string) => (segment === '-' ? 'origin' : null)
 }));
 
 vi.mock('$lib/gql', () => ({
@@ -259,7 +258,9 @@ async function waitForDebouncedUserSearch() {
   await new Promise((resolve) => setTimeout(resolve, 250));
   await vi.waitFor(() => {
     expect(
-      mocks.query.mock.calls.some(([document]) => operationName(document) === 'QuickSwitcherMembers')
+      mocks.query.mock.calls.some(
+        ([document]) => operationName(document) === 'QuickSwitcherMembers'
+      )
     ).toBe(true);
   });
 }

--- a/frontend/src/lib/markdown.ts
+++ b/frontend/src/lib/markdown.ts
@@ -1,6 +1,7 @@
 import MarkdownIt from 'markdown-it';
 import type StateInline from 'markdown-it/lib/rules_inline/state_inline.mjs';
 import tlds from 'tlds';
+import { classifyMessageBodyChatLink } from '$lib/messageLinks';
 
 type CodeHighlightingModule = typeof import('$lib/codeHighlighting');
 
@@ -286,6 +287,7 @@ function initialize(): void {
   md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
     const token = tokens[idx];
     const hrefIndex = token.attrIndex('href');
+    let allowedSameTabChatLink = false;
 
     if (hrefIndex >= 0) {
       const href = token.attrs![hrefIndex][1];
@@ -294,12 +296,17 @@ function initialize(): void {
       if (!href.startsWith('http://') && !href.startsWith('https://')) {
         // Replace dangerous URLs with empty href
         token.attrs![hrefIndex][1] = '#';
+      } else {
+        allowedSameTabChatLink = classifyMessageBodyChatLink(href) !== null;
       }
     }
 
-    // Add security attributes for external links
-    token.attrSet('target', '_blank');
-    token.attrSet('rel', 'noopener noreferrer');
+    // External and non-allow-listed links open out-of-band. Known same-origin
+    // chat routes intentionally keep normal same-tab navigation semantics.
+    if (!allowedSameTabChatLink) {
+      token.attrSet('target', '_blank');
+      token.attrSet('rel', 'noopener noreferrer');
+    }
 
     return defaultLinkRender(tokens, idx, options, env, self);
   };

--- a/frontend/src/lib/messageLinks.spec.ts
+++ b/frontend/src/lib/messageLinks.spec.ts
@@ -1,6 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getToasts, toast } from '$lib/ui/toast';
-import { copyMessageLinkToClipboard } from './messageLinks';
+import { classifyMessageBodyChatLink, copyMessageLinkToClipboard } from './messageLinks';
+
+const origin = 'https://chat.example.test';
+const channelRoomId = 'R123456789abcde';
+const dmRoomId = 'abcdef12345678';
+const messageId = 'Eabc123DEF456gh';
+const threadRootEventId = 'Ethread12345678';
+
+function resolveServerSegment(segment: string): string | null {
+  if (segment === '-') return 'origin';
+  if (segment === 'remote.example.test') return 'remote';
+  return null;
+}
+
+function classify(input: string) {
+  return classifyMessageBodyChatLink(input, { origin, resolveServerSegment });
+}
 
 describe('copyMessageLinkToClipboard', () => {
   const writeText = vi.fn();
@@ -29,5 +45,86 @@ describe('copyMessageLinkToClipboard', () => {
     await copyMessageLinkToClipboard('server-1', 'room-1', 'message-1');
 
     expect(getToasts().map((t) => t.message)).toContain('Failed to copy link');
+  });
+});
+
+describe('classifyMessageBodyChatLink', () => {
+  it('accepts same-origin room URLs with channel room IDs', () => {
+    expect(classify(`${origin}/chat/-/${channelRoomId}`)).toMatchObject({
+      kind: 'room',
+      serverId: 'origin',
+      roomId: channelRoomId,
+      path: `/chat/-/${channelRoomId}`
+    });
+  });
+
+  it('accepts same-origin room URLs with DM room IDs', () => {
+    expect(classify(`${origin}/chat/-/${dmRoomId}`)).toMatchObject({
+      kind: 'room',
+      roomId: dmRoomId,
+      path: `/chat/-/${dmRoomId}`
+    });
+  });
+
+  it('accepts same-origin thread URLs', () => {
+    expect(classify(`${origin}/chat/-/${channelRoomId}/${threadRootEventId}`)).toMatchObject({
+      kind: 'thread',
+      roomId: channelRoomId,
+      threadRootEventId,
+      path: `/chat/-/${channelRoomId}/${threadRootEventId}`
+    });
+  });
+
+  it('accepts same-origin message URLs', () => {
+    expect(classify(`${origin}/chat/-/${channelRoomId}/m/${messageId}`)).toMatchObject({
+      kind: 'message',
+      roomId: channelRoomId,
+      messageId,
+      path: `/chat/-/${channelRoomId}/m/${messageId}`
+    });
+  });
+
+  it('accepts known remote server segments on the same origin', () => {
+    expect(classify(`${origin}/chat/remote.example.test/${channelRoomId}`)).toMatchObject({
+      kind: 'room',
+      serverId: 'remote',
+      serverSegment: 'remote.example.test'
+    });
+  });
+
+  it('rejects same-origin non-chat and reserved chat URLs', () => {
+    const rejected = [
+      `${origin}/chat/-/settings`,
+      `${origin}/chat/-/overview`,
+      `${origin}/chat/-/threads`,
+      `${origin}/chat/-/server-admin/general`,
+      `${origin}/chat/notifications`,
+      `${origin}/login`
+    ];
+
+    for (const url of rejected) {
+      expect(classify(url)).toBeNull();
+    }
+  });
+
+  it('rejects malformed room and event IDs', () => {
+    const rejected = [
+      `${origin}/chat/-/room-1`,
+      `${origin}/chat/-/R123/m/${messageId}`,
+      `${origin}/chat/-/${channelRoomId}/m/message-1`,
+      `${origin}/chat/-/${channelRoomId}/thread-1`
+    ];
+
+    for (const url of rejected) {
+      expect(classify(url)).toBeNull();
+    }
+  });
+
+  it('rejects unknown server segments', () => {
+    expect(classify(`${origin}/chat/unknown.example.test/${channelRoomId}`)).toBeNull();
+  });
+
+  it('rejects cross-origin URLs', () => {
+    expect(classify(`https://other.example.test/chat/-/${channelRoomId}`)).toBeNull();
   });
 });

--- a/frontend/src/lib/messageLinks.ts
+++ b/frontend/src/lib/messageLinks.ts
@@ -18,6 +18,44 @@ export interface MessageLink {
   messageId: string;
 }
 
+export type MessageBodyChatLink =
+  | {
+      kind: 'room';
+      serverSegment: string;
+      serverId: string;
+      roomId: string;
+      path: string;
+    }
+  | {
+      kind: 'thread';
+      serverSegment: string;
+      serverId: string;
+      roomId: string;
+      threadRootEventId: string;
+      path: string;
+    }
+  | {
+      kind: 'message';
+      serverSegment: string;
+      serverId: string;
+      roomId: string;
+      messageId: string;
+      path: string;
+    };
+
+export interface MessageBodyChatLinkOptions {
+  origin?: string;
+  resolveServerSegment?: (segment: string) => string | null;
+}
+
+const channelRoomIdPattern = /^R[a-zA-Z0-9]{14}$/;
+const dmRoomIdPattern = /^[a-f0-9]{14}$/;
+const eventIdPattern = /^E[a-zA-Z0-9]{14}$/;
+
+function isMessageRoomId(value: string): boolean {
+  return channelRoomIdPattern.test(value) || dmRoomIdPattern.test(value);
+}
+
 export function buildMessageLinkPath(serverId: string, roomId: string, messageId: string): string {
   return resolve('/chat/[serverId]/[roomId]/m/[messageId]', {
     serverId: serverIdToSegment(serverId),
@@ -57,6 +95,65 @@ export async function copyMessageLinkToClipboard(
   } catch {
     toast.error('Failed to copy link');
   }
+}
+
+/**
+ * Classify message-body URLs that may navigate in the current tab.
+ *
+ * This deliberately allows only same-origin Chatto room, thread, and message
+ * URLs with Chatto-looking IDs. Other same-origin URLs, such as settings or
+ * admin pages, should keep opening out-of-band like external links.
+ */
+export function classifyMessageBodyChatLink(
+  input: string,
+  options: MessageBodyChatLinkOptions = {}
+): MessageBodyChatLink | null {
+  const origin =
+    options.origin ?? (typeof window !== 'undefined' ? window.location.origin : undefined);
+  if (!origin) return null;
+
+  let url: URL;
+  try {
+    url = new URL(input, origin);
+  } catch {
+    return null;
+  }
+
+  if (url.origin !== origin) return null;
+
+  const parts = url.pathname.split('/').filter(Boolean);
+  if (parts[0] !== 'chat') return null;
+  if (parts.length !== 3 && parts.length !== 4 && parts.length !== 5) return null;
+
+  const [, serverSegment, roomId] = parts;
+  if (!serverSegment || !isMessageRoomId(roomId)) return null;
+
+  const resolveServerSegment = options.resolveServerSegment ?? segmentToServerId;
+  const serverId = resolveServerSegment(serverSegment);
+  if (!serverId) return null;
+
+  const path = `${url.pathname}${url.search}${url.hash}`;
+
+  if (parts.length === 3) {
+    return { kind: 'room', serverSegment, serverId, roomId, path };
+  }
+
+  if (parts.length === 4) {
+    const threadRootEventId = parts[3];
+    if (!eventIdPattern.test(threadRootEventId)) return null;
+    return {
+      kind: 'thread',
+      serverSegment,
+      serverId,
+      roomId,
+      threadRootEventId,
+      path
+    };
+  }
+
+  const [, , , marker, messageId] = parts;
+  if (marker !== 'm' || !eventIdPattern.test(messageId)) return null;
+  return { kind: 'message', serverSegment, serverId, roomId, messageId, path };
 }
 
 /**

--- a/frontend/src/routes/chat/ModalContainer.svelte.spec.ts
+++ b/frontend/src/routes/chat/ModalContainer.svelte.spec.ts
@@ -19,7 +19,9 @@ const { mocks } = vi.hoisted(() => ({
     activeServer: 'origin',
     serverIdParam: '-' as string | undefined,
     servers: [] as Array<{ id: string; url: string; name: string; token: string | null }>,
-    originServer: undefined as { id: string; url: string; name: string; token: string | null } | undefined,
+    originServer: undefined as
+      | { id: string; url: string; name: string; token: string | null }
+      | undefined,
     authenticated: {} as Record<string, boolean>,
     signOutServer: vi.fn(),
     signOutServers: vi.fn(),
@@ -51,13 +53,14 @@ vi.mock('$app/navigation', () => ({
 
 vi.mock('$app/paths', () => ({
   resolve: (path: string, params?: Record<string, string>) =>
-    path
-      .replace('[serverId]', params?.serverId ?? '')
-      .replace('[roomId]', params?.roomId ?? '')
+    path.replace('[serverId]', params?.serverId ?? '').replace('[roomId]', params?.roomId ?? '')
 }));
 
 vi.mock('$lib/navigation', () => ({
-  serverIdToSegment: (serverId: string) => (serverId === 'origin' ? '-' : `${serverId}.example.test`)
+  serverIdToSegment: (serverId: string) =>
+    serverId === 'origin' ? '-' : `${serverId}.example.test`,
+  segmentToServerId: (segment: string) =>
+    segment === '-' ? 'origin' : segment.endsWith('.example.test') ? segment.slice(0, -13) : null
 }));
 
 vi.mock('$lib/state/activeServer.svelte', () => ({
@@ -196,9 +199,9 @@ describe('ModalContainer join room modal', () => {
   it('joins and navigates from a joinable room modal', async () => {
     const { container } = render(ModalContainer);
 
-    await expect.element(q(container, 'dialog')).toHaveTextContent(
-      'Join #general to read and participate in this room.'
-    );
+    await expect
+      .element(q(container, 'dialog'))
+      .toHaveTextContent('Join #general to read and participate in this room.');
     (q(container, 'button[type="submit"]') as HTMLButtonElement).click();
 
     await vi.waitFor(() => {
@@ -232,12 +235,12 @@ describe('ModalContainer join room modal', () => {
 
     const { container } = render(ModalContainer);
 
-    await expect.element(q(container, 'dialog')).toHaveTextContent(
-      'You do not have permission to join this room.'
-    );
-    expect([...container.querySelectorAll('button')].map((button) => button.textContent?.trim())).toEqual([
-      'Got it'
-    ]);
+    await expect
+      .element(q(container, 'dialog'))
+      .toHaveTextContent('You do not have permission to join this room.');
+    expect(
+      [...container.querySelectorAll('button')].map((button) => button.textContent?.trim())
+    ).toEqual(['Got it']);
     (q(container, 'button') as HTMLButtonElement).click();
 
     expect(mocks.joinRoom).not.toHaveBeenCalled();
@@ -250,14 +253,12 @@ describe('ModalContainer sign out modal', () => {
 
     const { container } = render(ModalContainer);
 
-    await expect.element(q(container, 'dialog')).toHaveTextContent(
-      'Sign out of only the selected server'
-    );
-    expect([...container.querySelectorAll('button')].map((button) => button.textContent?.trim())).toEqual([
-      'Cancel',
-      'Current Server',
-      'All Servers'
-    ]);
+    await expect
+      .element(q(container, 'dialog'))
+      .toHaveTextContent('Sign out of only the selected server');
+    expect(
+      [...container.querySelectorAll('button')].map((button) => button.textContent?.trim())
+    ).toEqual(['Cancel', 'Current Server', 'All Servers']);
   });
 
   it('signs out of only the active remote server', async () => {

--- a/frontend/src/routes/chat/[serverId]/server-admin/event-log/event-log.page.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/server-admin/event-log/event-log.page.svelte.spec.ts
@@ -126,7 +126,8 @@ vi.mock('$app/paths', () => ({
 }));
 
 vi.mock('$lib/navigation', () => ({
-  serverIdToSegment: () => '-'
+  serverIdToSegment: () => '-',
+  segmentToServerId: (segment: string) => (segment === '-' ? 'origin' : null)
 }));
 
 vi.mock('$lib/state/activeServer.svelte', () => ({


### PR DESCRIPTION
- Restricts same-tab navigation from message body links to same-origin Chatto room, thread, and message routes with valid-looking Chatto IDs.
- Keeps unsafe same-origin URLs such as settings/admin/login pages and external URLs opening in a new window with `noopener,noreferrer`.
- Updates markdown rendering so only allow-listed chat links omit `_blank`, and adds unit/component coverage for accepted and rejected links.

Tests:
- `mise x -- pnpm test:unit --run --project server src/lib/messageLinks.spec.ts src/lib/markdown.test.ts`
- `mise x -- pnpm test:unit --run --project client src/lib/components/MessageContent.svelte.spec.ts`
- `mise x -- pnpm exec svelte-check --tsconfig ./tsconfig.json`
