### PR TITLE
fix(notifications): preserve unread badge state across dismissals

### DIFF
--- a/cli/internal/core/notifications.go
+++ b/cli/internal/core/notifications.go
@@ -210,6 +210,21 @@ func (c *ChattoCore) DismissAllNotifications(ctx context.Context, userID string)
 
 	deleted := 0
 	for _, key := range keys {
+		var notif *corev1.Notification
+		entry, err := c.storage.runtimeStateKV.Get(ctx, key)
+		if err != nil {
+			if !errors.Is(err, jetstream.ErrKeyNotFound) {
+				c.logger.Warn("Failed to get notification before dismissing", "key", key, "error", err)
+			}
+		} else {
+			var decoded corev1.Notification
+			if err := proto.Unmarshal(entry.Value(), &decoded); err != nil {
+				c.logger.Warn("Failed to unmarshal notification before dismissing", "key", key, "error", err)
+			} else {
+				notif = &decoded
+			}
+		}
+
 		if err := c.storage.runtimeStateKV.Delete(ctx, key); err != nil {
 			if !errors.Is(err, jetstream.ErrKeyNotFound) {
 				c.logger.Warn("Failed to delete notification", "key", key, "error", err)
@@ -223,6 +238,10 @@ func (c *ChattoCore) DismissAllNotifications(ctx context.Context, userID string)
 		keyPrefix := notificationKeyPrefix + userID + "."
 		if notificationID := strings.TrimPrefix(key, keyPrefix); notificationID != key {
 			c.publishNotificationDismissedEvent(ctx, userID, notificationID)
+		}
+
+		if notif != nil && c.OnNotificationDismissed != nil {
+			go c.OnNotificationDismissed(context.WithoutCancel(ctx), userID, notif)
 		}
 	}
 

--- a/cli/internal/core/notifications_test.go
+++ b/cli/internal/core/notifications_test.go
@@ -312,6 +312,11 @@ func TestDismissAllNotifications(t *testing.T) {
 	userID := "dismiss-all-user"
 
 	t.Run("returns 0 when no notifications", func(t *testing.T) {
+		callbacks := make(chan *corev1.Notification, 1)
+		core.OnNotificationDismissed = func(ctx context.Context, userID string, notification *corev1.Notification) {
+			callbacks <- notification
+		}
+
 		count, err := core.DismissAllNotifications(ctx, userID)
 		if err != nil {
 			t.Fatalf("DismissAllNotifications error: %v", err)
@@ -319,16 +324,33 @@ func TestDismissAllNotifications(t *testing.T) {
 		if count != 0 {
 			t.Errorf("Expected 0, got %d", count)
 		}
+
+		select {
+		case notification := <-callbacks:
+			t.Fatalf("Expected no dismiss callback, got notification %s", notification.Id)
+		default:
+		}
 	})
 
-	t.Run("dismisses all notifications for user", func(t *testing.T) {
+	t.Run("dismisses all notifications for user and sends dismiss callbacks", func(t *testing.T) {
+		callbacks := make(chan *corev1.Notification, 3)
+		core.OnNotificationDismissed = func(ctx context.Context, userID string, notification *corev1.Notification) {
+			callbacks <- notification
+		}
+
 		// Create 3 notifications
+		expectedRoomsByID := map[string]string{}
+		roomIDs := []string{"room-a", "room-b", "room-c"}
 		for i := 0; i < 3; i++ {
-			core.CreateNotification(ctx, userID, "actor", &corev1.Notification{
+			created, err := core.CreateNotification(ctx, userID, "actor", &corev1.Notification{
 				Notification: &corev1.Notification_DmMessage{
-					DmMessage: &corev1.DMMessageNotification{RoomId: "room"},
+					DmMessage: &corev1.DMMessageNotification{RoomId: roomIDs[i]},
 				},
 			})
+			if err != nil {
+				t.Fatalf("CreateNotification error: %v", err)
+			}
+			expectedRoomsByID[created.Id] = created.GetDmMessage().RoomId
 		}
 
 		count, err := core.DismissAllNotifications(ctx, userID)
@@ -343,6 +365,33 @@ func TestDismissAllNotifications(t *testing.T) {
 		remaining, _ := core.GetNotifications(ctx, userID)
 		if len(remaining) != 0 {
 			t.Errorf("Expected 0 remaining, got %d", len(remaining))
+		}
+
+		received := map[string]string{}
+		for i := 0; i < 3; i++ {
+			select {
+			case notification := <-callbacks:
+				dm := notification.GetDmMessage()
+				if dm == nil {
+					t.Fatalf("Expected DM notification callback, got %T", notification.Notification)
+				}
+				received[notification.Id] = dm.RoomId
+			case <-time.After(time.Second):
+				t.Fatalf("Timed out waiting for dismiss callback %d", i+1)
+			}
+		}
+		if len(received) != len(expectedRoomsByID) {
+			t.Fatalf("Expected %d callbacks, got %d", len(expectedRoomsByID), len(received))
+		}
+		for id, expectedRoom := range expectedRoomsByID {
+			if received[id] != expectedRoom {
+				t.Errorf("Expected callback for %s with room %s, got %s", id, expectedRoom, received[id])
+			}
+		}
+		select {
+		case notification := <-callbacks:
+			t.Fatalf("Expected no extra dismiss callback, got notification %s", notification.Id)
+		default:
 		}
 	})
 }

--- a/frontend/src/lib/components/NotificationSync.svelte
+++ b/frontend/src/lib/components/NotificationSync.svelte
@@ -16,7 +16,12 @@ Include this component once in the chat layout (unconditionally).
   import { eventBusManager } from '$lib/state/server/eventBus.svelte';
   import { userPreferences } from '$lib/state/userPreferences.svelte';
   import { playNotificationSound } from '$lib/audio/notificationSounds';
-  import { updateBadge, setFlagBadge, clearBadge } from '$lib/notifications/appBadge';
+  import {
+    updateBadge,
+    setFlagBadge,
+    clearBadge,
+    syncServiceWorkerUnreadBadgeState
+  } from '$lib/notifications/appBadge';
   import type { EventHandler } from '$lib/eventBus.svelte';
 
   // Subscribe to notification events on all authenticated instance buses.
@@ -74,7 +79,9 @@ Include this component once in the chat layout (unconditionally).
     serverRegistry.servers.reduce((sum, instance) => {
       const stores = serverRegistry.getStore(instance.id);
       if (!stores.isAuthenticated) return sum;
-      return sum + stores.notifications.count;
+      return (
+        sum + Math.max(stores.notifications.unreadNotificationCount, stores.notifications.count)
+      );
     }, 0)
   );
 
@@ -88,6 +95,8 @@ Include this component once in the chat layout (unconditionally).
 
   // Update PWA dock badge based on aggregated state
   $effect(() => {
+    syncServiceWorkerUnreadBadgeState(hasAnyUnread);
+
     if (totalNotificationCount > 0) {
       updateBadge(totalNotificationCount);
     } else if (hasAnyUnread) {

--- a/frontend/src/lib/components/NotificationSync.svelte.spec.ts
+++ b/frontend/src/lib/components/NotificationSync.svelte.spec.ts
@@ -12,6 +12,7 @@ const { mocks } = vi.hoisted(() => {
     isAuthenticated: true,
     notifications: {
       count: 0,
+      unreadNotificationCount: 0,
       addNotification: vi.fn(() => Promise.resolve()),
       removeNotification: vi.fn(),
       consumeLocalDismissal: vi.fn(),
@@ -35,7 +36,8 @@ const { mocks } = vi.hoisted(() => {
       playNotificationSound: vi.fn(),
       updateBadge: vi.fn(() => Promise.resolve()),
       setFlagBadge: vi.fn(() => Promise.resolve()),
-      clearBadge: vi.fn(() => Promise.resolve())
+      clearBadge: vi.fn(() => Promise.resolve()),
+      syncServiceWorkerUnreadBadgeState: vi.fn()
     }
   };
 });
@@ -74,7 +76,8 @@ vi.mock('$lib/audio/notificationSounds', () => ({
 vi.mock('$lib/notifications/appBadge', () => ({
   updateBadge: mocks.updateBadge,
   setFlagBadge: mocks.setFlagBadge,
-  clearBadge: mocks.clearBadge
+  clearBadge: mocks.clearBadge,
+  syncServiceWorkerUnreadBadgeState: mocks.syncServiceWorkerUnreadBadgeState
 }));
 
 function dispatch(event: NonNullable<EventEnvelope['event']>) {
@@ -104,6 +107,7 @@ describe('NotificationSync', () => {
 
     mocks.store.isAuthenticated = true;
     mocks.store.notifications.count = 0;
+    mocks.store.notifications.unreadNotificationCount = 0;
     mocks.store.roomUnread.hasAnyUnread = false;
     mocks.store.notifications.addNotification.mockResolvedValue(undefined);
     mocks.store.notifications.removeNotification.mockReturnValue(null);
@@ -160,5 +164,37 @@ describe('NotificationSync', () => {
     expect(mocks.store.notifications.fetch).toHaveBeenCalledOnce();
     expect(mocks.store.rooms.refreshNotificationCounts).toHaveBeenCalledOnce();
     expect(mocks.store.rooms.refresh).not.toHaveBeenCalled();
+  });
+
+  it('uses the authoritative notification count when the cached list is lower', async () => {
+    mocks.store.notifications.count = 1;
+    mocks.store.notifications.unreadNotificationCount = 3;
+
+    await renderAndWaitForSubscription();
+
+    await vi.waitFor(() => expect(mocks.updateBadge).toHaveBeenCalledWith(3));
+    expect(mocks.syncServiceWorkerUnreadBadgeState).toHaveBeenCalledWith(false);
+    expect(mocks.setFlagBadge).not.toHaveBeenCalled();
+    expect(mocks.clearBadge).not.toHaveBeenCalled();
+  });
+
+  it('clears the app badge when there are no notifications or unread rooms', async () => {
+    await renderAndWaitForSubscription();
+
+    await vi.waitFor(() => expect(mocks.clearBadge).toHaveBeenCalledOnce());
+    expect(mocks.syncServiceWorkerUnreadBadgeState).toHaveBeenCalledWith(false);
+    expect(mocks.updateBadge).not.toHaveBeenCalled();
+    expect(mocks.setFlagBadge).not.toHaveBeenCalled();
+  });
+
+  it('shares unread-only badge state with the service worker', async () => {
+    mocks.store.roomUnread.hasAnyUnread = true;
+
+    await renderAndWaitForSubscription();
+
+    await vi.waitFor(() => expect(mocks.setFlagBadge).toHaveBeenCalledOnce());
+    expect(mocks.syncServiceWorkerUnreadBadgeState).toHaveBeenCalledWith(true);
+    expect(mocks.updateBadge).not.toHaveBeenCalled();
+    expect(mocks.clearBadge).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/lib/notifications/appBadge.ts
+++ b/frontend/src/lib/notifications/appBadge.ts
@@ -15,6 +15,19 @@ export function isSupported(): boolean {
 }
 
 /**
+ * Share foreground unread badge state with the service worker so its native
+ * notification cleanup does not erase an unread-only dock flag.
+ */
+export function syncServiceWorkerUnreadBadgeState(hasAnyUnread: boolean): void {
+  if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return;
+
+  navigator.serviceWorker.controller?.postMessage({
+    type: 'chatto-badge-state',
+    hasAnyUnread
+  });
+}
+
+/**
  * Update the app badge with the given count.
  * Sets a numeric badge if count > 0, clears it otherwise.
  *

--- a/frontend/src/lib/pwa/notificationClick.worker.spec.ts
+++ b/frontend/src/lib/pwa/notificationClick.worker.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
-import { routeNotificationClick, type NotificationClickClient } from './notificationClick.worker';
+import {
+  clearBadgeIfNoNotificationsRemain,
+  routeNotificationClick,
+  type NotificationClickClient
+} from './notificationClick.worker';
 
 const ORIGIN = 'https://chatto.example';
 const TARGET_URL = `${ORIGIN}/chat/-/room-1?highlight=event-1`;
@@ -147,5 +151,71 @@ describe('routeNotificationClick', () => {
 
     expect(clients.matchAll).not.toHaveBeenCalled();
     expect(clients.openWindow).not.toHaveBeenCalled();
+  });
+});
+
+describe('clearBadgeIfNoNotificationsRemain', () => {
+  it('clears the app badge when no native notifications remain', async () => {
+    const registration = {
+      getNotifications: vi.fn(async () => [])
+    };
+    const badgeNavigator = {
+      clearAppBadge: vi.fn(async () => {})
+    };
+
+    await clearBadgeIfNoNotificationsRemain(registration, badgeNavigator);
+
+    expect(registration.getNotifications).toHaveBeenCalledOnce();
+    expect(badgeNavigator.clearAppBadge).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the app badge when native notifications remain', async () => {
+    const registration = {
+      getNotifications: vi.fn(async () => [{}])
+    };
+    const badgeNavigator = {
+      clearAppBadge: vi.fn(async () => {})
+    };
+
+    await clearBadgeIfNoNotificationsRemain(registration, badgeNavigator);
+
+    expect(registration.getNotifications).toHaveBeenCalledOnce();
+    expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
+  });
+
+  it('preserves a flag badge when foreground unread state still exists', async () => {
+    const registration = {
+      getNotifications: vi.fn(async () => [])
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+
+    await clearBadgeIfNoNotificationsRemain(registration, badgeNavigator, { preserveFlag: true });
+
+    expect(registration.getNotifications).toHaveBeenCalledOnce();
+    expect(badgeNavigator.setAppBadge).toHaveBeenCalledOnce();
+    expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
+  });
+
+  it('does not throw or clear when native notification listing fails', async () => {
+    const registration = {
+      getNotifications: vi.fn(async () => {
+        throw new Error('notification store unavailable');
+      })
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+
+    await expect(
+      clearBadgeIfNoNotificationsRemain(registration, badgeNavigator)
+    ).resolves.toBeUndefined();
+
+    expect(registration.getNotifications).toHaveBeenCalledOnce();
+    expect(badgeNavigator.setAppBadge).not.toHaveBeenCalled();
+    expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/lib/pwa/notificationClick.worker.ts
+++ b/frontend/src/lib/pwa/notificationClick.worker.ts
@@ -32,6 +32,15 @@ interface NotificationClickLogger {
   warn: (...args: unknown[]) => void;
 }
 
+export interface BadgeCapableNavigator {
+  setAppBadge?: (contents?: number) => Promise<void>;
+  clearAppBadge?: () => Promise<void>;
+}
+
+export interface NotificationListingRegistration {
+  getNotifications(): Promise<readonly unknown[]>;
+}
+
 export type NotificationClickRouteResult = 'ignored' | 'client' | 'navigate' | 'open';
 
 export interface NotificationClickRouteOptions {
@@ -42,6 +51,25 @@ export interface NotificationClickRouteOptions {
 
 function createDefaultMessageChannel(): NotificationClickMessageChannel {
   return new MessageChannel();
+}
+
+export async function clearBadgeIfNoNotificationsRemain(
+  registration: NotificationListingRegistration,
+  badgeNavigator: BadgeCapableNavigator,
+  options: { preserveFlag?: boolean } = {}
+): Promise<void> {
+  let notifications: readonly unknown[];
+  try {
+    notifications = await registration.getNotifications();
+  } catch {
+    return;
+  }
+  if (notifications.length > 0) return;
+  if (options.preserveFlag) {
+    await (badgeNavigator.setAppBadge?.().catch(() => {}) ?? Promise.resolve());
+  } else {
+    await (badgeNavigator.clearAppBadge?.().catch(() => {}) ?? Promise.resolve());
+  }
 }
 
 function isNotificationClickAck(message: unknown): boolean {

--- a/frontend/src/service-worker.ts
+++ b/frontend/src/service-worker.ts
@@ -11,7 +11,10 @@
 
 import { build, files, version } from '$service-worker';
 import { OFFLINE_SHELL_PATH, classifyServiceWorkerRequest } from '$lib/pwa/serviceWorkerPolicy';
-import { routeNotificationClick } from '$lib/pwa/notificationClick.worker';
+import {
+  clearBadgeIfNoNotificationsRemain,
+  routeNotificationClick
+} from '$lib/pwa/notificationClick.worker';
 import {
   handleAssetProxyFetch,
   handleAssetProxyMessage,
@@ -22,12 +25,18 @@ declare const self: ServiceWorkerGlobalScope;
 
 const CACHE_PREFIX = 'chatto-shell';
 const CACHE_NAME = `${CACHE_PREFIX}-${version}`;
+const BADGE_STATE_CACHE_NAME = 'chatto-badge-state-v1';
+const BADGE_STATE_URL = `${self.location.origin}/__chatto_badge_state__`;
 const SHELL_ASSETS = new Set([...build, ...files, OFFLINE_SHELL_PATH]);
 const PRECACHE_ASSETS = Array.from(new Set([...build, ...files, OFFLINE_SHELL_PATH, '/']));
 
-type BadgeCapableNavigator = Navigator & {
+type AppBadgeNavigator = Navigator & {
   setAppBadge?: (contents?: number) => Promise<void>;
   clearAppBadge?: () => Promise<void>;
+};
+
+type BadgeState = {
+  hasAnyUnread: boolean;
 };
 
 /**
@@ -60,7 +69,8 @@ self.addEventListener('activate', (event) => {
 });
 
 self.addEventListener('message', (event) => {
-  handleAssetProxyMessage(event);
+  if (handleAssetProxyMessage(event)) return;
+  handleBadgeStateMessage(event);
 });
 
 /**
@@ -149,16 +159,45 @@ interface PushPayload {
 }
 
 function setFlagBadge(): Promise<void> {
-  const badgeNavigator = navigator as BadgeCapableNavigator;
+  const badgeNavigator = navigator as AppBadgeNavigator;
   return badgeNavigator.setAppBadge?.().catch(() => {}) ?? Promise.resolve();
 }
 
-async function clearBadgeIfNoNotificationsRemain(): Promise<void> {
-  const notifications = await self.registration.getNotifications();
-  if (notifications.length > 0) return;
+function handleBadgeStateMessage(event: ExtendableMessageEvent): boolean {
+  const message = event.data as Record<string, unknown> | undefined;
+  if (!message || message.type !== 'chatto-badge-state') return false;
+  if (typeof message.hasAnyUnread !== 'boolean') return false;
 
-  const badgeNavigator = navigator as BadgeCapableNavigator;
-  await (badgeNavigator.clearAppBadge?.().catch(() => {}) ?? Promise.resolve());
+  event.waitUntil(saveBadgeState({ hasAnyUnread: message.hasAnyUnread }));
+  return true;
+}
+
+async function saveBadgeState(state: BadgeState): Promise<void> {
+  const cache = await caches.open(BADGE_STATE_CACHE_NAME);
+  await cache.put(
+    BADGE_STATE_URL,
+    new Response(JSON.stringify(state), {
+      headers: { 'content-type': 'application/json' }
+    })
+  );
+}
+
+async function loadBadgeState(): Promise<BadgeState> {
+  try {
+    const cache = await caches.open(BADGE_STATE_CACHE_NAME);
+    const response = await cache.match(BADGE_STATE_URL);
+    const data = (await response?.json()) as Partial<BadgeState> | undefined;
+    return { hasAnyUnread: data?.hasAnyUnread === true };
+  } catch {
+    return { hasAnyUnread: false };
+  }
+}
+
+async function reconcileNativeNotificationBadge(): Promise<void> {
+  const badgeState = await loadBadgeState();
+  await clearBadgeIfNoNotificationsRemain(self.registration, navigator as AppBadgeNavigator, {
+    preserveFlag: badgeState.hasAnyUnread
+  });
 }
 
 /**
@@ -185,7 +224,7 @@ self.addEventListener('push', (event) => {
       (async () => {
         const notifications = await self.registration.getNotifications({ tag: payload.tag });
         notifications.forEach((n) => n.close());
-        await clearBadgeIfNoNotificationsRemain();
+        await reconcileNativeNotificationBadge();
       })()
     );
     return;
@@ -224,11 +263,12 @@ self.addEventListener('notificationclick', (event) => {
   const rawUrl =
     typeof event.notification.data?.url === 'string' ? event.notification.data.url : undefined;
   event.waitUntil(
-    routeNotificationClick(rawUrl, self.location.origin, self.clients, { logger: console }).catch(
-      (err) => {
-        console.error('[SW] Error handling notification click:', err);
-      }
-    )
+    (async () => {
+      await reconcileNativeNotificationBadge().catch(() => {});
+      await routeNotificationClick(rawUrl, self.location.origin, self.clients, { logger: console });
+    })().catch((err) => {
+      console.error('[SW] Error handling notification click:', err);
+    })
   );
 });
 


### PR DESCRIPTION
## What changed
- Capture the full notification payload before bulk dismissing notifications in the CLI core, and invoke `OnNotificationDismissed` for each dismissed notification when available.
- Update `NotificationSync` to treat the authoritative unread notification count as the badge source of truth, and synchronize unread-only badge state to the service worker.
- Add a small app-badge bridge so the foreground app can tell the service worker whether unread state still exists.
- Teach the service worker to persist unread badge state in cache storage and only clear the native badge when no notifications remain and no unread state needs to be preserved.
- Factor notification-click badge cleanup into a reusable helper and add coverage for the new badge reconciliation behavior.

## Why
- Bulk notification dismissal previously lost the original notification payload, which prevented downstream dismissal callbacks from seeing the dismissed notification data.
- Native notification cleanup in the service worker could clear the app badge too aggressively, which broke unread-only dock badge state.
- This change keeps foreground badge state, service worker cleanup, and native notifications aligned so badge behavior stays correct across dismissals and notification clicks.

## Tests
- Expanded CLI notification dismissal tests to verify callbacks are emitted with the original notification data.
- Added frontend tests for badge count precedence, badge clearing, unread-state syncing, and service worker notification-click cleanup.