### PR TITLE
fix(frontend): defer unread separator until return to the room

### DIFF
--- a/frontend/e2e/unread-indicators.test.ts
+++ b/frontend/e2e/unread-indicators.test.ts
@@ -399,7 +399,7 @@ test.describe('Room unread separator', () => {
     );
   });
 
-  test('unread separator appears in real time while the tab is hidden', async ({
+  test('unread separator is deferred until the hidden tab returns', async ({
     page,
     chatPage,
     roomPage,
@@ -432,8 +432,8 @@ test.describe('Room unread separator', () => {
         // No separator yet — User B has read everything.
         await roomPage2.expectNoUnreadSeparator();
 
-        // User B's tab goes to the background. They stay in the room; presence
-        // just drops, which anchors the unread separator at the read cursor.
+        // User B's tab goes to the background. They stay in the room, but the
+        // rendered separator should not change until they return.
         await page2.evaluate(() => {
           Object.defineProperty(document, 'visibilityState', {
             value: 'hidden',
@@ -447,15 +447,16 @@ test.describe('Room unread separator', () => {
         const awayMessage = `Posted while hidden ${Date.now()}`;
         await roomPage.sendMessage(awayMessage);
 
-        // The message streams in over the live subscription, and because the
-        // separator was anchored the moment presence dropped, it shows up
-        // immediately — without User B having to navigate away and back.
+        // The message streams in over the live subscription, but the in-room
+        // separator is deferred so Chatto does not visibly repaint the marker
+        // while the user is away.
         await roomPage2.expectMessageVisible(awayMessage);
-        await roomPage2.expectUnreadSeparator();
+        await expect(async () => {
+          await roomPage2.expectNoUnreadSeparator();
+        }).toPass({ timeout: TIMEOUTS.UI_STANDARD, intervals: POLLING_INTERVALS });
 
-        // Re-focusing the tab refines the separator (clamps its upper bound)
-        // but must not blink it out — the anchor already matches the server's
-        // previousLastReadAt, so the marker stays put across the transition.
+        // Re-focusing the tab reveals the deferred separator and keeps it
+        // stable across the mark-read round-trip.
         await page2.evaluate(() => {
           Object.defineProperty(document, 'visibilityState', {
             value: 'visible',
@@ -463,6 +464,58 @@ test.describe('Room unread separator', () => {
             configurable: true
           });
           document.dispatchEvent(new Event('visibilitychange'));
+        });
+
+        await expect(async () => {
+          await roomPage2.expectUnreadSeparator();
+        }).toPass({ timeout: TIMEOUTS.UI_STANDARD, intervals: POLLING_INTERVALS });
+      }
+    );
+  });
+
+  test('unread separator is deferred until the blurred window is focused again', async ({
+    page,
+    chatPage,
+    roomPage,
+    browser,
+    serverURL
+  }) => {
+    test.setTimeout(60000); // Multi-user test with real-time events needs more time
+
+    // User A: Create account, post an initial message in general.
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+
+    await chatPage.enterRoom('general');
+    await waitForRoomReady(page, 'general');
+    await roomPage.sendMessage('Initial blur message');
+
+    const generalRoomId = await getRoomIdByName(page, 'general');
+
+    // User B: Stay in general, then switch focus away without hiding the tab.
+    await withServerUser(
+      browser!,
+      serverURL,
+      async ({ page: page2, chatPage: chatPage2, roomPage: roomPage2 }) => {
+        await chatPage2.enterRoom('general');
+        await waitForRoomReady(page2, 'general');
+        await roomPage2.expectMessageVisible('Initial blur message');
+        await waitForRoomRead(page2, generalRoomId);
+        await roomPage2.expectNoUnreadSeparator();
+
+        await page2.evaluate(() => {
+          window.dispatchEvent(new Event('blur'));
+        });
+
+        const awayMessage = `Posted while blurred ${Date.now()}`;
+        await roomPage.sendMessage(awayMessage);
+        await roomPage2.expectMessageVisible(awayMessage);
+        await expect(async () => {
+          await roomPage2.expectNoUnreadSeparator();
+        }).toPass({ timeout: TIMEOUTS.UI_STANDARD, intervals: POLLING_INTERVALS });
+
+        await page2.evaluate(() => {
+          window.dispatchEvent(new Event('focus'));
         });
 
         await expect(async () => {
@@ -486,11 +539,8 @@ test.describe('Room unread separator', () => {
     // tab was hidden was a non-message room event (join, leave). The server-
     // side read cursor only tracks root messages, so a refocus mutation
     // round-trip returned previousLastReadAt === lastReadAt and the bounded
-    // window collapsed to empty — making the marker disappear on focus and
-    // reappear on every blur.
-    //
-    // The fix in useRoomUnread no longer overwrites bounds on a same-room
-    // refocus; this test exercises the exact path that used to break.
+    // window collapsed to empty. The marker is now deferred until refocus,
+    // and the same-room refocus must not overwrite that deferred anchor.
 
     // User A: Create account, enter general, post the initial message
     // so User B has a real read cursor anchored on a root message.
@@ -515,8 +565,8 @@ test.describe('Room unread separator', () => {
         await waitForRoomRead(page2, generalRoomId);
         await roomPage2.expectNoUnreadSeparator();
 
-        // User B's tab goes hidden — presence drops, anchoring the unread
-        // separator at the server read cursor with an open upper bound.
+        // User B's tab goes hidden. The unread anchor is captured, but the
+        // rendered separator is deferred until User B returns.
         await page2.evaluate(() => {
           Object.defineProperty(document, 'visibilityState', {
             value: 'hidden',
@@ -533,17 +583,19 @@ test.describe('Room unread separator', () => {
         await page.getByRole('dialog').getByRole('button', { name: 'Leave Room' }).click();
 
         // User B (still hidden) receives the leave event over the live
-        // subscription. The separator anchors above it.
+        // subscription, but the separator should not render while hidden.
         await expect(page2.getByText(`${userA.displayName} left the room`)).toBeVisible({
           timeout: TIMEOUTS.REALTIME_EVENT
         });
-        await roomPage2.expectUnreadSeparator();
+        await expect(async () => {
+          await roomPage2.expectNoUnreadSeparator();
+        }).toPass({ timeout: TIMEOUTS.UI_STANDARD, intervals: POLLING_INTERVALS });
 
         // User B's tab returns to the foreground. With the bug, this refocus
         // would fire markRoomAsRead which returns previousLastReadAt ===
         // lastReadAt (server cursor never moved), the .then() would overwrite
-        // the bounds with that empty window, and the separator would blink out.
-        // The fix preserves the unfocus-edge anchor on a same-room refocus.
+        // the deferred open-bound anchor with an empty window, and the
+        // separator would blink out.
         await page2.evaluate(() => {
           Object.defineProperty(document, 'visibilityState', {
             value: 'visible',

--- a/frontend/src/lib/hooks/useRoomUnread.svelte.ts
+++ b/frontend/src/lib/hooks/useRoomUnread.svelte.ts
@@ -20,9 +20,15 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
   let unreadBeforeTime = $state<string | null>(null);
 
   // The server's most recent read cursor (`lastReadAt`) for this room.
-  // Updated from every markRoomAsRead result; used to anchor the unread
-  // separator the instant the user leaves (see the presence-false edge).
+  // Updated from every markRoomAsRead result; used to capture where the
+  // unread separator should be anchored when the user leaves.
   let lastCursor: string | null = null;
+  // Captured while the app is hidden/unfocused, but intentionally not exposed
+  // to the timeline until the user returns. This lets unread dots update in
+  // the background without repainting the open room's separator while the user
+  // is looking at another app.
+  let pendingAwayAfterTime: string | null = null;
+  let pendingAwayHasEvents = false;
 
   async function markRoomAsRead(targetRoomId: string, upToEventId?: string) {
     roomUnreadStore.setRoomUnread(targetRoomId, false);
@@ -59,9 +65,9 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
    * this hook — notably when the user posts their own message, since
    * PostMessage auto-marks the room read on the server.
    *
-   * Also advances the open-upper-bound separator anchor (set on
-   * presence-false) past the new cursor whenever it lands beyond the
-   * anchor, regardless of presence. Two scenarios both need this:
+   * Also advances open-upper-bound separator anchors past the new cursor
+   * whenever it lands beyond the anchor, regardless of presence. Two scenarios
+   * both need this:
    *
    * 1. Own message lands while away (e.g. posted from another device): the
    *    presence-false anchor was set from a stale cursor; without this the
@@ -73,15 +79,19 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
    *    separator stays stuck at the prior cursor and renders BETWEEN the
    *    user's two own posts (one before bg, one after refocus).
    *
-   * Gating on `unreadBeforeTime === null` keeps the closed (after, before]
-   * window from a fresh room entry intact — that window represents "this
-   * is what you missed last time", and the user posting doesn't change
-   * what they previously hadn't seen.
+   * Gating the visible anchor on `unreadBeforeTime === null` keeps the closed
+   * (after, before] window from a fresh room entry intact — that window
+   * represents "this is what you missed last time", and the user posting
+   * doesn't change what they previously hadn't seen.
    */
   function noteReadCursor(timestamp: string) {
     const ts = Date.parse(timestamp);
     if (lastCursor && ts <= Date.parse(lastCursor)) return;
     lastCursor = timestamp;
+
+    if (pendingAwayAfterTime !== null && ts > Date.parse(pendingAwayAfterTime)) {
+      pendingAwayAfterTime = timestamp;
+    }
 
     if (
       unreadAfterTime !== null &&
@@ -92,10 +102,17 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
     }
   }
 
+  function noteAwayEvent() {
+    if (pendingAwayAfterTime !== null) {
+      pendingAwayHasEvents = true;
+    }
+  }
+
   // Fire markRoomAsRead on every presence-true edge (fresh entry OR
   // refocus/tab-reveal) and on room changes while present. The mutation
-  // result drives the unread separator so a refocus shows what arrived
-  // while the user was away.
+  // result drives the unread separator on room entry; same-room refocus uses
+  // the deferred away anchor so the separator does not appear in the
+  // background before the user returns.
   let lastFiredRoomId = '';
   let wasPresent = false;
 
@@ -104,15 +121,13 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
     const present = appState.isPresent;
 
     if (!present) {
-      // Presence-false edge: anchor the unread separator at the current
-      // read cursor with no upper bound, so messages arriving while the
-      // user is away pile up below the marker in real time — it's already
-      // there the moment the tab comes back on-screen (or right away if
-      // the window is visible but unfocused). The presence-true edge below
-      // refines it on return.
+      // Presence-false edge: capture the current read cursor, but do not
+      // expose it to the rendered timeline yet. Messages can keep streaming
+      // in and sidebar unread dots can light up while the user is away; the
+      // in-room separator appears only on the presence-true edge below.
       if (wasPresent && lastCursor) {
-        unreadAfterTime = lastCursor;
-        unreadBeforeTime = null;
+        pendingAwayAfterTime = lastCursor;
+        pendingAwayHasEvents = false;
       }
       wasPresent = false;
       return;
@@ -126,12 +141,21 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
 
     // On a room change, clear the previous room's separator so it can't
     // flash in the new room while the mutation below is in flight. On a
-    // refocus of the *same* room, leave the existing separator in place —
-    // it was anchored on the presence-false edge and the mutation result
-    // is deliberately ignored below so the marker stays stable.
+    // refocus of the *same* room, reveal any deferred away anchor and leave
+    // the mutation result ignored below so the marker stays stable.
     if (isRoomChange) {
+      pendingAwayAfterTime = null;
+      pendingAwayHasEvents = false;
       unreadAfterTime = null;
       unreadBeforeTime = null;
+    } else if (pendingAwayAfterTime && pendingAwayHasEvents) {
+      unreadAfterTime = pendingAwayAfterTime;
+      unreadBeforeTime = null;
+      pendingAwayAfterTime = null;
+      pendingAwayHasEvents = false;
+    } else {
+      pendingAwayAfterTime = null;
+      pendingAwayHasEvents = false;
     }
 
     markRoomAsRead(roomId).then((result) => {
@@ -139,11 +163,11 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
       if (current.roomId === roomId && result) {
         // Only adopt the server's (previousLastReadAt, lastReadAt] window on
         // a fresh room entry. On a same-room refocus the separator was just
-        // anchored on the presence-false edge against `lastCursor` with an
-        // open upper bound — overwriting it here collapses the window to
-        // empty whenever the server cursor hasn't moved (e.g. only non-
-        // message events like joins/leaves arrived while away), making the
-        // separator vanish on focus and reappear on every blur.
+        // revealed from the deferred away anchor with an open upper bound —
+        // overwriting it here collapses the window to empty whenever the
+        // server cursor hasn't moved (e.g. only non-message events like
+        // joins/leaves arrived while away), making the separator vanish on
+        // focus and reappear on every blur.
         if (isRoomChange && result.previousLastReadAt && result.lastReadAt) {
           unreadAfterTime = result.previousLastReadAt;
           unreadBeforeTime = result.lastReadAt;
@@ -160,6 +184,7 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
       return unreadBeforeTime;
     },
     markRoomAsRead,
-    noteReadCursor
+    noteReadCursor,
+    noteAwayEvent
   };
 }

--- a/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -6,6 +6,7 @@
   import MessageComposer, {
     type MessageComposerApi
   } from '$lib/components/composer/MessageComposer.svelte';
+  import type { EventEnvelope } from '$lib/eventBus.svelte';
   import { graphql } from '$lib/gql';
   import {
     useRoomData,
@@ -292,6 +293,28 @@
     }
   }
 
+  function shouldRevealAwaySeparator(event: EventEnvelope): boolean {
+    const eventData = event.event;
+    if (!eventData) return false;
+    if (event.actorId === currentUser.user?.id) return false;
+
+    switch (eventData.__typename) {
+      case 'MessagePostedEvent':
+        return (
+          eventData.roomId === roomId && (!!eventData.echoOfEventId || !eventData.threadRootEventId)
+        );
+      case 'UserJoinedRoomEvent':
+      case 'UserLeftRoomEvent':
+      case 'RoomUpdatedEvent':
+      case 'RoomDeletedEvent':
+      case 'RoomArchivedEvent':
+      case 'RoomUnarchivedEvent':
+        return eventData.roomId === roomId;
+      default:
+        return false;
+    }
+  }
+
   // Keep the read cursor in sync with incoming root messages:
   // - Other users' messages mark the room read (with explicit event ID, so
   //   the server cursor matches what the client rendered) while the user is
@@ -304,6 +327,10 @@
     roomFilesStore.ingestServerEvent(event);
     roomMembersStore.ingestServerEvent(event);
     if (!event.event) return;
+
+    if (!appState.isPresent && shouldRevealAwaySeparator(event)) {
+      unread.noteAwayEvent();
+    }
 
     if (event.event.__typename === 'MessagePostedEvent' && event.event.roomId === roomId) {
       const actorId = event.actorId;

--- a/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -31,6 +31,7 @@ const { mocks } = vi.hoisted(() => {
       pushState: vi.fn(),
       replaceState: vi.fn(),
       noteReadCursor: vi.fn(),
+      noteAwayEvent: vi.fn(),
       markRoomAsRead: vi.fn(),
       resetTypingDebounce: vi.fn(),
       query: vi.fn(() => ({
@@ -110,7 +111,8 @@ vi.mock('$lib/hooks', () => ({
     unreadAfterTime: null,
     unreadBeforeTime: null,
     markRoomAsRead: mocks.markRoomAsRead,
-    noteReadCursor: mocks.noteReadCursor
+    noteReadCursor: mocks.noteReadCursor,
+    noteAwayEvent: mocks.noteAwayEvent
   }),
   useEvent: vi.fn(),
   usePresenceChange: vi.fn(),


### PR DESCRIPTION
## Summary
- Defer rendering the room unread separator while the user is hidden or blurred, so the marker does not repaint in the background.
- Track away-time events in `useRoomUnread` and reveal the separator only when the user returns to the room.
- Update room event handling and tests to cover hidden-tab and blurred-window focus flows.

## Why
Previously, the unread separator could appear immediately while the user was away and then disappear or re-anchor on refocus, which caused visible churn. This change keeps the separator hidden until the user comes back, while still preserving the correct unread anchor and allowing unread state to continue updating in the background.

## Tests
- Extended E2E coverage for hidden-tab and blurred-window refocus behavior.
- Updated `Room.svelte.spec.ts` mocks to cover the new away-event hook path.