### PR TITLE
fix(frontend): align call control button colors

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -205,6 +205,12 @@
   @apply hover:from-accent/75 hover:to-accent;
 }
 
+@utility btn-success {
+  @apply btn text-white;
+  @apply bg-gradient-to-br from-success/65 to-success/95 ring-1 ring-success/30;
+  @apply hover:from-success/75 hover:to-success;
+}
+
 @utility btn-secondary {
   /* Quiet surface gradient + neutral ring — distinct from surfaces
      (dialogs, panels) without competing with the saturated variants. */

--- a/frontend/src/lib/components/CurrentUserBar.svelte
+++ b/frontend/src/lib/components/CurrentUserBar.svelte
@@ -63,6 +63,7 @@ to the user settings page for the active server.
     return `# ${room.name}`;
   });
   const compactCallButtonClass = 'btn-secondary h-7 w-7 shrink-0 !px-0 !py-0 text-xs';
+  const compactCallActiveButtonClass = 'btn-success h-7 w-7 shrink-0 !px-0 !py-0 text-xs';
   const compactCallDangerButtonClass = 'btn-danger h-7 w-7 shrink-0 !px-0 !py-0 text-xs';
 
   function openActiveCallRoom(): void {
@@ -105,7 +106,7 @@ to the user settings page for the active server.
         </button>
         <button
           type="button"
-          class={voiceCallState.isMuted ? compactCallDangerButtonClass : compactCallButtonClass}
+          class={voiceCallState.isMuted ? compactCallButtonClass : compactCallActiveButtonClass}
           title={voiceCallState.isMuted ? m['voice.unmute']() : m['voice.mute']()}
           aria-label={voiceCallState.isMuted ? m['voice.unmute']() : m['voice.mute']()}
           data-testid="current-user-call-mute"
@@ -122,8 +123,8 @@ to the user settings page for the active server.
         <button
           type="button"
           class={voiceCallState.isCameraEnabled
-            ? compactCallButtonClass
-            : compactCallDangerButtonClass}
+            ? compactCallActiveButtonClass
+            : compactCallButtonClass}
           title={voiceCallState.isCameraEnabled
             ? m['voice.turn_off_camera']()
             : m['voice.turn_on_camera']()}
@@ -141,8 +142,8 @@ to the user settings page for the active server.
         <button
           type="button"
           class={voiceCallState.isScreenShareEnabled
-            ? compactCallButtonClass
-            : compactCallDangerButtonClass}
+            ? compactCallActiveButtonClass
+            : compactCallButtonClass}
           title={voiceCallState.isScreenShareEnabled
             ? m['voice.stop_share_screen']()
             : m['voice.share_screen']()}

--- a/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
+++ b/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
@@ -153,10 +153,26 @@ describe('CurrentUserBar', () => {
     expect(link.textContent).toContain('# general');
     link.click();
 
-    (q(container, '[data-testid="current-user-call-mute"]') as HTMLButtonElement).click();
-    (q(container, '[data-testid="current-user-call-camera"]') as HTMLButtonElement).click();
-    (q(container, '[data-testid="current-user-call-screen-share"]') as HTMLButtonElement).click();
-    (q(container, '[data-testid="current-user-call-leave"]') as HTMLButtonElement).click();
+    const muteButton = q(container, '[data-testid="current-user-call-mute"]') as HTMLButtonElement;
+    const cameraButton = q(
+      container,
+      '[data-testid="current-user-call-camera"]'
+    ) as HTMLButtonElement;
+    const screenShareButton = q(
+      container,
+      '[data-testid="current-user-call-screen-share"]'
+    ) as HTMLButtonElement;
+    const leaveButton = q(container, '[data-testid="current-user-call-leave"]') as HTMLButtonElement;
+
+    expect(muteButton.className).toContain('btn-success');
+    expect(cameraButton.className).toContain('btn-secondary');
+    expect(screenShareButton.className).toContain('btn-secondary');
+    expect(leaveButton.className).toContain('btn-danger');
+
+    muteButton.click();
+    cameraButton.click();
+    screenShareButton.click();
+    leaveButton.click();
 
     expect(navigation.goto).toHaveBeenCalledWith('/chat/-/room-1');
     expect(getRoomSidebarPanelState('origin', 'room-1')).toBe('call');
@@ -171,6 +187,29 @@ describe('CurrentUserBar', () => {
     expect(voiceCallState.toggleScreenShare).toHaveBeenCalledOnce();
     expect(voiceCallState.leave).toHaveBeenCalledOnce();
     window.removeEventListener('storage', listener);
+  });
+
+  it('uses green only for active compact call media controls', () => {
+    voiceCallState.connected = true;
+    voiceCallState.roomId = 'room-1';
+    voiceCallState.isMuted = true;
+    voiceCallState.isCameraEnabled = true;
+    voiceCallState.isScreenShareEnabled = true;
+
+    const { container } = render(CurrentUserBarTestHarness);
+
+    expect(q(container, '[data-testid="current-user-call-mute"]')!.className).toContain(
+      'btn-secondary'
+    );
+    expect(q(container, '[data-testid="current-user-call-camera"]')!.className).toContain(
+      'btn-success'
+    );
+    expect(q(container, '[data-testid="current-user-call-screen-share"]')!.className).toContain(
+      'btn-success'
+    );
+    expect(q(container, '[data-testid="current-user-call-leave"]')!.className).toContain(
+      'btn-danger'
+    );
   });
 
   it('uses the DM participant label for active direct-message calls', () => {

--- a/frontend/src/lib/components/voice/VoiceCallPanel.svelte
+++ b/frontend/src/lib/components/voice/VoiceCallPanel.svelte
@@ -169,6 +169,7 @@ Room sidebar panel for voice/video calls.
     return hasActiveCall ? m['voice.join_call']() : m['voice.start_call']();
   });
   const controlButtonClass = 'btn-secondary btn-sm h-9 w-full !px-0';
+  const activeControlButtonClass = 'btn-success btn-sm h-9 w-full !px-0';
   const dangerControlButtonClass = 'btn-danger btn-sm h-9 w-full !px-0';
 
   function hasVideo(participant: DisplayParticipant) {
@@ -406,7 +407,7 @@ Room sidebar panel for voice/video calls.
 
         <button
           type="button"
-          class={voiceCallState.isCameraEnabled ? controlButtonClass : dangerControlButtonClass}
+          class={voiceCallState.isCameraEnabled ? activeControlButtonClass : controlButtonClass}
           title={voiceCallState.isCameraEnabled
             ? m['voice.turn_off_camera']()
             : m['voice.turn_on_camera']()}
@@ -427,7 +428,7 @@ Room sidebar panel for voice/video calls.
 
         <button
           type="button"
-          class={voiceCallState.isMuted ? dangerControlButtonClass : controlButtonClass}
+          class={voiceCallState.isMuted ? controlButtonClass : activeControlButtonClass}
           title={voiceCallState.isMuted ? m['voice.unmute']() : m['voice.mute']()}
           aria-label={voiceCallState.isMuted ? m['voice.unmute']() : m['voice.mute']()}
           data-testid="call-mute-toggle"
@@ -445,8 +446,8 @@ Room sidebar panel for voice/video calls.
         <button
           type="button"
           class={voiceCallState.isScreenShareEnabled
-            ? controlButtonClass
-            : dangerControlButtonClass}
+            ? activeControlButtonClass
+            : controlButtonClass}
           title={voiceCallState.isScreenShareEnabled
             ? m['voice.stop_share_screen']()
             : m['voice.share_screen']()}

--- a/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -548,16 +548,62 @@ describe('RoomSidebar', () => {
       speakingIndicator!.compareDocumentPosition(mutedIndicator!) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
 
-    (q(container, '[data-testid="call-mute-toggle"]') as HTMLButtonElement).click();
-    (q(container, '[data-testid="call-camera-toggle"]') as HTMLButtonElement).click();
-    (q(container, '[data-testid="call-screen-share-toggle"]') as HTMLButtonElement).click();
-    (q(container, '[data-testid="call-leave-button"]') as HTMLButtonElement).click();
+    const deviceButton = q(
+      container,
+      '[data-testid="call-device-menu-button"]'
+    ) as HTMLButtonElement;
+    const muteButton = q(container, '[data-testid="call-mute-toggle"]') as HTMLButtonElement;
+    const cameraButton = q(container, '[data-testid="call-camera-toggle"]') as HTMLButtonElement;
+    const screenShareButton = q(
+      container,
+      '[data-testid="call-screen-share-toggle"]'
+    ) as HTMLButtonElement;
+    const leaveButton = q(container, '[data-testid="call-leave-button"]') as HTMLButtonElement;
+
+    expect(deviceButton.className).toContain('btn-secondary');
+    expect(muteButton.className).toContain('btn-success');
+    expect(cameraButton.className).toContain('btn-secondary');
+    expect(screenShareButton.className).toContain('btn-secondary');
+    expect(leaveButton.className).toContain('btn-danger');
+
+    muteButton.click();
+    cameraButton.click();
+    screenShareButton.click();
+    leaveButton.click();
     await tick();
 
     expect(callStore.voiceCall.toggleMute).toHaveBeenCalledOnce();
     expect(callStore.voiceCall.toggleCamera).toHaveBeenCalledOnce();
     expect(callStore.voiceCall.toggleScreenShare).toHaveBeenCalledOnce();
     expect(callStore.voiceCall.leave).toHaveBeenCalledOnce();
+  });
+
+  it('uses green only for active call media controls', async () => {
+    callStore.voiceCall.connected = true;
+    callStore.voiceCall.isInAnyCall = true;
+    callStore.voiceCall.roomId = 'room-1';
+    callStore.voiceCall.isMuted = true;
+    callStore.voiceCall.isCameraEnabled = true;
+    callStore.voiceCall.isScreenShareEnabled = true;
+
+    const { container } = render(RoomSidebarTestHarness, {
+      props: {
+        roomData: roomData([], 0, false),
+        activePanel: 'call',
+        livekitUrl: 'wss://livekit.example.test'
+      }
+    });
+
+    expect(q(container, '[data-testid="call-mute-toggle"]')!.className).toContain(
+      'btn-secondary'
+    );
+    expect(q(container, '[data-testid="call-camera-toggle"]')!.className).toContain(
+      'btn-success'
+    );
+    expect(q(container, '[data-testid="call-screen-share-toggle"]')!.className).toContain(
+      'btn-success'
+    );
+    expect(q(container, '[data-testid="call-leave-button"]')!.className).toContain('btn-danger');
   });
 
   it('shows a neutral speaking indicator for active speakers', async () => {


### PR DESCRIPTION
## Summary

- Adds a shared success button utility for green active call controls.
- Updates full and compact call controls so voice, camera, and screen sharing are green only when active and grey when muted or off.
- Keeps hang up red and settings grey, with regression coverage for both call control surfaces.

## Verification

- `pnpm vitest run src/lib/components/CurrentUserBar.svelte.spec.ts 'src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts'`
- `pnpm lint`
