### PR TITLE
chore(conductor): add Chatto preview URL

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,5 +1,9 @@
 "$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
 
+[[preview_urls]]
+name = "Chatto"
+url = "http://localhost:$CONDUCTOR_PORT"
+
 [scripts]
 setup = "mise trust"
 run = "mise run chatto run"


### PR DESCRIPTION
- Adds a Conductor preview URL named `Chatto` that opens `http://localhost:$CONDUCTOR_PORT`.
- Matches the existing workspace-safe `mise run chatto run` port configuration.

Verification:
- `mise x taplo -- taplo lint .conductor/settings.toml`
