### PR TITLE
fix(frontend): improve unread channel contrast

### DIFF
--- a/frontend/src/lib/RoomList.svelte
+++ b/frontend/src/lib/RoomList.svelte
@@ -383,12 +383,15 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
 {#snippet roomLink(room: RoomsListItem)}
   {@const hasActiveCall = activeCallRooms.has(room.id)}
   {@const isJoined = room.viewerIsMember}
+  {@const hasUnreadAttention =
+    isJoined &&
+    room.hasUnread &&
+    room.id !== activeRoomId &&
+    !notificationLevelStore.isRoomMuted(room.id)}
   {@const rowClass = [
     '@container sidebar-item group/badges',
     room.id === activeRoomId ? 'bg-surface-100' : '',
-    room.hasUnread && room.id !== activeRoomId && !notificationLevelStore.isRoomMuted(room.id)
-      ? 'font-semibold'
-      : '',
+    hasUnreadAttention ? 'font-semibold text-text-top' : '',
     !isJoined ? 'opacity-60 hover:opacity-85' : ''
   ]}
   <a
@@ -399,7 +402,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     onkeydown={(e) => handleRoomLinkKeydown(e, room)}
   >
     {#if isJoined}
-      <span class="sidebar-icon text-muted">#</span>
+      <span class={['sidebar-icon', hasUnreadAttention ? 'text-text-top' : 'text-muted']}>#</span>
     {:else if room.viewerCanJoinRoom}
       <span class="sidebar-icon text-muted">+</span>
     {:else}
@@ -436,12 +439,13 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
 
 {#snippet dmLink(room: RoomsListItem)}
   {@const hasActiveCall = activeCallRooms.has(room.id)}
+  {@const hasUnreadAttention = room.hasUnread && room.id !== activeRoomId}
   <a
     href={resolve('/chat/[serverId]/[roomId]', { serverId: serverSegment, roomId: room.id })}
     class={[
       'group/badges @container sidebar-item',
       room.id === activeRoomId ? 'bg-surface-100' : '',
-      room.hasUnread && room.id !== activeRoomId ? 'font-semibold' : ''
+      hasUnreadAttention ? 'font-semibold text-text-top' : ''
     ]}
     aria-current={room.id === activeRoomId ? 'page' : undefined}
     onclick={(e) => handleRoomLinkClick(e, room)}

--- a/frontend/src/lib/RoomList.svelte
+++ b/frontend/src/lib/RoomList.svelte
@@ -391,7 +391,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   {@const rowClass = [
     '@container sidebar-item group/badges',
     room.id === activeRoomId ? 'bg-surface-100' : '',
-    hasUnreadAttention ? 'font-semibold text-text-top' : '',
+    hasUnreadAttention ? 'font-semibold text-text-top hover:!text-text-top' : '',
     !isJoined ? 'opacity-60 hover:opacity-85' : ''
   ]}
   <a
@@ -445,7 +445,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     class={[
       'group/badges @container sidebar-item',
       room.id === activeRoomId ? 'bg-surface-100' : '',
-      hasUnreadAttention ? 'font-semibold text-text-top' : ''
+      hasUnreadAttention ? 'font-semibold text-text-top hover:!text-text-top' : ''
     ]}
     aria-current={room.id === activeRoomId ? 'page' : undefined}
     onclick={(e) => handleRoomLinkClick(e, room)}

--- a/frontend/src/lib/RoomList.svelte.spec.ts
+++ b/frontend/src/lib/RoomList.svelte.spec.ts
@@ -236,6 +236,16 @@ function setRoomNotificationCount(roomId: string, count: number) {
   room.viewerNotificationCount = count;
 }
 
+function setRoomUnread(roomId: string, hasUnread: boolean) {
+  const rooms = mocks.store.rooms.rooms as Array<{
+    id: string;
+    hasUnread: boolean;
+  }>;
+  const room = rooms.find((item) => item.id === roomId);
+  if (!room) throw new Error(`Missing mocked room ${roomId}`);
+  room.hasUnread = hasUnread;
+}
+
 beforeEach(() => {
   localStorage.clear();
   sessionStorage.clear();
@@ -473,6 +483,20 @@ describe('RoomList', () => {
         viewerCanJoinRoom: false
       }
     });
+  });
+
+  it('renders unread channel rows and icons in full-contrast text', async () => {
+    setRoomUnread('channel-1', true);
+
+    const { container } = render(RoomList);
+
+    const row = q(container, '[href="/chat/-/channel-1"]') as HTMLAnchorElement;
+    await expect.element(row).toBeInTheDocument();
+    const icon = row.querySelector('.sidebar-icon');
+    expect(row.classList.contains('font-semibold')).toBe(true);
+    expect(row.classList.contains('text-text-top')).toBe(true);
+    expect(icon?.classList.contains('text-text-top')).toBe(true);
+    expect(icon?.classList.contains('text-muted')).toBe(false);
   });
 
   it('renders server-local sidebar links as same-tab anchors resolved against the active server', async () => {

--- a/frontend/src/lib/RoomList.svelte.spec.ts
+++ b/frontend/src/lib/RoomList.svelte.spec.ts
@@ -495,6 +495,7 @@ describe('RoomList', () => {
     const icon = row.querySelector('.sidebar-icon');
     expect(row.classList.contains('font-semibold')).toBe(true);
     expect(row.classList.contains('text-text-top')).toBe(true);
+    expect(row.classList.contains('hover:!text-text-top')).toBe(true);
     expect(icon?.classList.contains('text-text-top')).toBe(true);
     expect(icon?.classList.contains('text-muted')).toBe(false);
   });


### PR DESCRIPTION
## Changes

- Render unread, non-muted room rows with full-contrast `text-text-top` styling.
- Keep unread channel `#` icons full contrast instead of muted, and apply the same unread text contrast to DM rows.
- Add RoomList regression coverage for unread channel row and icon classes.

## Verification

- `./node_modules/.bin/vitest --run src/lib/RoomList.svelte.spec.ts`
- `./node_modules/.bin/prettier --check src/lib/RoomList.svelte src/lib/RoomList.svelte.spec.ts`
- Chrome DevTools computed-color check: unread rows/icons are white in dark mode and black in light mode.
