### PR TITLE
fix(connectapi): harden message post migration

### DIFF
--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -228,6 +228,8 @@ func TestMessageServicePostMessageValidatesInput(t *testing.T) {
 	env := newConnectAPITestEnv(t)
 	room := env.createJoinedRoom("message-post-validation")
 	ctx := auth.WithUser(env.ctx, env.viewer)
+	root := env.post(room.Id, env.viewer.Id, "root", "")
+	reply := env.post(room.Id, env.viewer.Id, "reply", root.Id)
 
 	tests := []struct {
 		name string
@@ -253,6 +255,35 @@ func TestMessageServicePostMessageValidatesInput(t *testing.T) {
 			},
 			code: connect.CodeInvalidArgument,
 		},
+		{
+			name: "missing thread root",
+			req: &apiv1.PostMessageRequest{
+				RoomId:            room.Id,
+				Body:              "reply",
+				ThreadRootEventId: "missing-thread-root",
+			},
+			code: connect.CodeNotFound,
+		},
+		{
+			name: "thread reply as thread root",
+			req: &apiv1.PostMessageRequest{
+				RoomId:            room.Id,
+				Body:              "reply",
+				ThreadRootEventId: reply.Id,
+			},
+			code: connect.CodeInvalidArgument,
+		},
+		{
+			name: "link preview URL too long",
+			req: &apiv1.PostMessageRequest{
+				RoomId: room.Id,
+				Body:   "hello",
+				LinkPreview: &apiv1.MessageLinkPreviewInput{
+					Url: strings.Repeat("x", core.MaxLinkPreviewURLLength+1),
+				},
+			},
+			code: connect.CodeInvalidArgument,
+		},
 	}
 
 	for _, tt := range tests {
@@ -261,6 +292,28 @@ func TestMessageServicePostMessageValidatesInput(t *testing.T) {
 				t.Fatalf("PostMessage code = %v, want %v", connect.CodeOf(err), tt.code)
 			}
 		})
+	}
+}
+
+func TestMessageServicePostMessageInfersVideoProcessingAssetIDs(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	room := env.createJoinedRoom("message-post-video")
+
+	original, err := env.core.UploadAttachment(env.ctx, env.viewer.Id, room.Id, "clip.mp4", "video/mp4", bytes.NewReader([]byte("original video")))
+	if err != nil {
+		t.Fatalf("UploadAttachment original: %v", err)
+	}
+
+	if _, err := env.messages.PostMessage(auth.WithUser(env.ctx, env.viewer), connect.NewRequest(&apiv1.PostMessageRequest{
+		RoomId:             room.Id,
+		AttachmentAssetIds: []string{original.Id},
+	})); err != nil {
+		t.Fatalf("PostMessage: %v", err)
+	}
+
+	manifest, ok := env.core.Assets.VideoAttachmentManifest(original.Id)
+	if !ok || manifest.Started == nil {
+		t.Fatalf("VideoAttachmentManifest = %+v, %v; want started", manifest, ok)
 	}
 }
 
@@ -882,6 +935,8 @@ func TestConnectErrorMapping(t *testing.T) {
 		{"message not found", core.ErrMessageNotFound, connect.CodeNotFound},
 		{"jetstream key not found", jetstream.ErrKeyNotFound, connect.CodeNotFound},
 		{"message too long", core.ErrMessageTooLong, connect.CodeInvalidArgument},
+		{"invalid argument", core.ErrInvalidArgument, connect.CodeInvalidArgument},
+		{"string length", &core.StringLengthError{Field: "field", Max: 10}, connect.CodeInvalidArgument},
 		{"room archived", core.ErrRoomArchived, connect.CodeFailedPrecondition},
 		{"unknown", errors.New("boom"), connect.CodeInternal},
 	}
@@ -892,6 +947,10 @@ func TestConnectErrorMapping(t *testing.T) {
 				t.Fatalf("connectError code = %v, want %v", got, tt.code)
 			}
 		})
+	}
+
+	if err := connectError(errors.New("boom")); strings.Contains(err.Error(), "boom") {
+		t.Fatalf("connectError leaked internal error: %v", err)
 	}
 }
 

--- a/cli/internal/connectapi/errors.go
+++ b/cli/internal/connectapi/errors.go
@@ -36,7 +36,8 @@ func connectError(err error) error {
 		errors.Is(err, core.ErrCustomStatusTextRequired) ||
 		errors.Is(err, core.ErrCustomStatusEmojiTooLong) ||
 		errors.Is(err, core.ErrCustomStatusTextTooLong) ||
-		errors.Is(err, core.ErrCustomStatusExpiryInPast) {
+		errors.Is(err, core.ErrCustomStatusExpiryInPast) ||
+		errors.Is(err, core.ErrInvalidArgument) {
 		return connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	if errors.Is(err, core.ErrNotFound) ||
@@ -50,5 +51,5 @@ func connectError(err error) error {
 	if errors.Is(err, core.ErrRoomArchived) {
 		return connect.NewError(connect.CodeFailedPrecondition, err)
 	}
-	return connect.NewError(connect.CodeInternal, err)
+	return connect.NewError(connect.CodeInternal, errors.New("internal server error"))
 }

--- a/cli/internal/core/errors.go
+++ b/cli/internal/core/errors.go
@@ -19,6 +19,11 @@ var (
 	// to perform an operation.
 	ErrPermissionDenied = errors.New("permission denied")
 
+	// ErrInvalidArgument is returned when a caller provides invalid request
+	// input. Wrap this with an InvalidArgumentError when the caller should see a
+	// specific validation message.
+	ErrInvalidArgument = errors.New("invalid argument")
+
 	// ErrNotSpaceMember is returned when a user attempts to access a space
 	// they are not a member of.
 	ErrNotSpaceMember = errors.New("not a member of this space")
@@ -137,6 +142,24 @@ var (
 	// the entire user-provided password contributes to the hash and to bound work.
 	ErrPasswordTooLong = fmt.Errorf("password cannot exceed %d bytes", MaxPasswordLength)
 )
+
+// InvalidArgumentError carries a caller-safe validation message while still
+// matching ErrInvalidArgument through errors.Is.
+type InvalidArgumentError struct {
+	Message string
+}
+
+func (e *InvalidArgumentError) Error() string {
+	return e.Message
+}
+
+func (e *InvalidArgumentError) Is(target error) bool {
+	return target == ErrInvalidArgument
+}
+
+func invalidArgument(message string) error {
+	return &InvalidArgumentError{Message: message}
+}
 
 // Input validation limits.
 // Note: These limits are enforced using len() which counts bytes, not Unicode characters.

--- a/cli/internal/core/message_service.go
+++ b/cli/internal/core/message_service.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
@@ -58,7 +57,7 @@ func (s *MessageService) PostMessage(ctx context.Context, input MessagePostInput
 		return nil, ErrNotAuthenticated
 	}
 	if strings.TrimSpace(input.RoomID) == "" {
-		return nil, fmt.Errorf("room_id is required")
+		return nil, invalidArgument("room_id is required")
 	}
 
 	room, err := s.core.FindRoomByID(ctx, input.RoomID)
@@ -105,7 +104,7 @@ func (s *MessageService) PostMessage(ctx context.Context, input MessagePostInput
 
 	if input.AlsoSendToChannel {
 		if input.ThreadRootEventID == "" {
-			return nil, fmt.Errorf("alsoSendToChannel can only be used with thread replies (threadRootEventId must be set)")
+			return nil, invalidArgument("alsoSendToChannel can only be used with thread replies (threadRootEventId must be set)")
 		}
 		can, err := s.core.CanEchoMessage(ctx, input.ActorID, kind, room.Id)
 		if err != nil {
@@ -152,9 +151,10 @@ func (s *MessageService) PostMessage(ctx context.Context, input MessagePostInput
 		}
 	}
 
+	videoProcessingAssetIDs := s.videoProcessingAssetIDsForPost(input)
 	options := make([]PostMessageOption, 0, 2)
-	if len(input.VideoProcessingAssetIDs) > 0 {
-		options = append(options, WithVideoProcessingAssets(input.VideoProcessingAssetIDs...))
+	if len(videoProcessingAssetIDs) > 0 {
+		options = append(options, WithVideoProcessingAssets(videoProcessingAssetIDs...))
 	}
 	if mentionConfirmed {
 		options = append(options, WithLargeMentionConfirmed())
@@ -177,4 +177,39 @@ func (s *MessageService) PostMessage(ctx context.Context, input MessagePostInput
 
 	s.core.NotifyRoomMarkedAsRead(ctx, input.ActorID, kind, room.Id)
 	return &MessagePostResult{Event: event}, nil
+}
+
+func (s *MessageService) videoProcessingAssetIDsForPost(input MessagePostInput) []string {
+	assetIDs := make([]string, 0, len(input.VideoProcessingAssetIDs)+len(input.AttachmentAssetIDs))
+	seen := make(map[string]struct{}, len(input.VideoProcessingAssetIDs)+len(input.AttachmentAssetIDs))
+	add := func(assetID string) {
+		if assetID == "" {
+			return
+		}
+		if _, ok := seen[assetID]; ok {
+			return
+		}
+		seen[assetID] = struct{}{}
+		assetIDs = append(assetIDs, assetID)
+	}
+
+	// Explicit IDs are still needed for upload-byte-derived decisions such as
+	// animated GIF conversion. Transports that only submit attachment asset IDs
+	// can infer ordinary video/* assets from durable asset metadata.
+	for _, assetID := range input.VideoProcessingAssetIDs {
+		add(assetID)
+	}
+	for _, assetID := range input.AttachmentAssetIDs {
+		if _, ok := seen[assetID]; ok || assetID == "" {
+			continue
+		}
+		declared, ok := s.core.assetLifecycle().AssetCreation(assetID)
+		if !ok || declared == nil {
+			continue
+		}
+		if AttachmentNeedsVideoProcessing(attachmentFromAsset(declared.GetAsset()), false) {
+			add(assetID)
+		}
+	}
+	return assetIDs
 }

--- a/cli/internal/core/messages.go
+++ b/cli/internal/core/messages.go
@@ -417,7 +417,7 @@ func (c *ChattoCore) PostMessage(ctx context.Context, kind RoomKind, room_id, us
 	hasBody := HasVisibleContent(body)
 	hasAttachments := len(assetIDs) > 0
 	if !hasBody && !hasAttachments {
-		return nil, fmt.Errorf("message must have either body or attachments")
+		return nil, invalidArgument("message must have either body or attachments")
 	}
 
 	// Resolve referenced assets from the projection. Each must already exist
@@ -452,7 +452,7 @@ func (c *ChattoCore) PostMessage(ctx context.Context, kind RoomKind, room_id, us
 		resolvedAssetIDs = append(resolvedAssetIDs, id)
 	}
 	if !hasBody && len(resolvedAssetIDs) == 0 {
-		return nil, fmt.Errorf("message must have either body or attachments")
+		return nil, invalidArgument("message must have either body or attachments")
 	}
 
 	// Verify room exists and isn't archived
@@ -484,15 +484,15 @@ func (c *ChattoCore) PostMessage(ctx context.Context, kind RoomKind, room_id, us
 			return nil, fmt.Errorf("failed to get thread root message: %w", err)
 		}
 		if rootEvent == nil {
-			return nil, fmt.Errorf("thread root message not found: event ID %s", inThread)
+			return nil, fmt.Errorf("thread root message not found: %w", ErrMessageNotFound)
 		}
 		rootMsg := rootEvent.GetMessagePosted()
 		if rootMsg == nil {
-			return nil, fmt.Errorf("thread root is not a message event: event ID %s", inThread)
+			return nil, invalidArgument("thread root is not a message event")
 		}
 		// Verify it's actually a root message (not itself a thread reply)
 		if rootMsg.InThread != "" {
-			return nil, fmt.Errorf("thread root must be a root message, not a thread reply: event ID %s", inThread)
+			return nil, invalidArgument("thread root must be a root message, not a thread reply")
 		}
 	}
 
@@ -1178,10 +1178,10 @@ func validateLinkPreview(linkPreview *corev1.LinkPreview) error {
 			return err
 		}
 		if linkPreview.GetImageAssetId() != "" && imageAsset.GetId() != "" && linkPreview.GetImageAssetId() != imageAsset.GetId() {
-			return fmt.Errorf("link preview image asset ID does not match image asset record")
+			return invalidArgument("link preview image asset ID does not match image asset record")
 		}
 		if imageAsset.GetStorage() == nil {
-			return fmt.Errorf("link preview image asset record is missing storage")
+			return invalidArgument("link preview image asset record is missing storage")
 		}
 	}
 	if err := validateStringMaxLength("link preview site name", linkPreview.GetSiteName(), MaxLinkPreviewSiteNameLength); err != nil {

--- a/cli/internal/core/validation.go
+++ b/cli/internal/core/validation.go
@@ -17,6 +17,10 @@ func (e *StringLengthError) Error() string {
 	return fmt.Sprintf("%s cannot exceed %d bytes", e.Field, e.Max)
 }
 
+func (e *StringLengthError) Is(target error) bool {
+	return target == ErrInvalidArgument
+}
+
 func validateStringMaxLength(field, value string, max int) error {
 	if len(value) > max {
 		return &StringLengthError{Field: field, Max: max}


### PR DESCRIPTION
## Summary

- Classify shared message-post validation errors as Connect `InvalidArgument`/`NotFound` instead of `Internal`.
- Sanitize fallback Connect internal errors so raw backend error text is not exposed to clients.
- Infer `video/*` attachment processing for Connect message posts and add regression coverage for the migrated paths.

## Tests

- `mise x -- go test ./internal/connectapi -run 'TestMessageServicePostMessage|TestConnectErrorMapping' -count=1`
- `mise x -- go test ./internal/core -run 'TestChattoCore_PostMessage|TestScheduleVideoProcessing|TestMessageService' -count=1`
- `mise x -- go test ./internal/connectapi ./internal/core -count=1`
