### PR TITLE
fix(connectrpc): cap request message size

### DIFF
--- a/cli/internal/connectapi/api.go
+++ b/cli/internal/connectapi/api.go
@@ -17,6 +17,10 @@ import (
 // Prefix is the HTTP mount point for Chatto's ConnectRPC public API.
 const Prefix = "/api/connect"
 
+// MaxRequestMessageBytes caps individual inbound protobuf messages. ConnectRPC
+// defaults to unlimited reads, so keep this explicit for every public handler.
+const MaxRequestMessageBytes = 1 << 20 // 1 MiB
+
 // Handler is one generated Connect service handler and its generated service
 // path. The HTTP server owns the actual route mounting and auth injection.
 type Handler struct {
@@ -37,13 +41,16 @@ func New(core *core.ChattoCore, config config.ChattoConfig, version string) *API
 }
 
 func (a *API) Handlers() []Handler {
-	serverPath, serverHandler := apiv1connect.NewServerServiceHandler(&serverService{api: a})
-	messagePath, messageHandler := apiv1connect.NewMessageServiceHandler(&messageService{api: a})
-	prefsPath, prefsHandler := apiv1connect.NewNotificationPreferencesServiceHandler(&notificationPreferencesService{api: a})
-	readStatePath, readStateHandler := apiv1connect.NewReadStateServiceHandler(&readStateService{api: a})
-	timelinePath, timelineHandler := apiv1connect.NewRoomTimelineServiceHandler(&roomTimelineService{api: a})
-	userStatusPath, userStatusHandler := apiv1connect.NewUserStatusServiceHandler(&userStatusService{api: a})
-	threadPath, threadHandler := apiv1connect.NewThreadServiceHandler(&threadService{api: a})
+	options := []connect.HandlerOption{
+		connect.WithReadMaxBytes(MaxRequestMessageBytes),
+	}
+	serverPath, serverHandler := apiv1connect.NewServerServiceHandler(&serverService{api: a}, options...)
+	messagePath, messageHandler := apiv1connect.NewMessageServiceHandler(&messageService{api: a}, options...)
+	prefsPath, prefsHandler := apiv1connect.NewNotificationPreferencesServiceHandler(&notificationPreferencesService{api: a}, options...)
+	readStatePath, readStateHandler := apiv1connect.NewReadStateServiceHandler(&readStateService{api: a}, options...)
+	timelinePath, timelineHandler := apiv1connect.NewRoomTimelineServiceHandler(&roomTimelineService{api: a}, options...)
+	userStatusPath, userStatusHandler := apiv1connect.NewUserStatusServiceHandler(&userStatusService{api: a}, options...)
+	threadPath, threadHandler := apiv1connect.NewThreadServiceHandler(&threadService{api: a}, options...)
 	return []Handler{
 		{ServicePath: messagePath, Handler: messageHandler},
 		{ServicePath: serverPath, Handler: serverHandler},

--- a/cli/internal/http_server/connect_test.go
+++ b/cli/internal/http_server/connect_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"google.golang.org/protobuf/proto"
 	"hmans.de/chatto/internal/config"
+	"hmans.de/chatto/internal/connectapi"
 	"hmans.de/chatto/internal/core"
 	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
 	"hmans.de/chatto/internal/pb/chatto/api/v1/apiv1connect"
@@ -104,6 +105,19 @@ func TestConnectServerServiceGetServer(t *testing.T) {
 			t.Fatalf("Name = %q, want Chatto", msg.Name)
 		}
 	})
+}
+
+func TestConnectAPIRejectsOversizedRequestMessages(t *testing.T) {
+	_, ts := setupConnectTestServer(t, config.AuthConfig{})
+
+	client := apiv1connect.NewMessageServiceClient(ts.Client(), ts.URL+connectAPIPrefix)
+	_, err := client.PostMessage(context.Background(), connect.NewRequest(&apiv1.PostMessageRequest{
+		RoomId: "oversized-room",
+		Body:   strings.Repeat("a", connectapi.MaxRequestMessageBytes),
+	}))
+	if connect.CodeOf(err) != connect.CodeResourceExhausted {
+		t.Fatalf("PostMessage oversized err = %v, want resource exhausted", err)
+	}
 }
 
 func TestConnectNotificationPreferencesService(t *testing.T) {


### PR DESCRIPTION
## Changes
- Caps inbound ConnectRPC protobuf messages at 1 MiB for every public handler.
- Adds an HTTP-level regression test that oversized Connect requests fail with `ResourceExhausted` before service logic runs.

## Verification
- `cd cli && mise x -- go test ./internal/http_server -run 'TestConnect(ServerServiceGetServer|APIRejectsOversizedRequestMessages|NotificationPreferencesService)' -timeout 30s`
- `cd cli && mise x -- go test ./internal/connectapi ./internal/http_server -timeout 30s`
