### PR TITLE
fix(frontend): clarify remote push notification support

### DIFF
--- a/docs/fdr/FDR-013-web-push-notifications.md
+++ b/docs/fdr/FDR-013-web-push-notifications.md
@@ -1,7 +1,7 @@
 # FDR-013: Web Push Notifications
 
 **Status:** Active
-**Last reviewed:** 2026-06-17
+**Last reviewed:** 2026-06-25
 
 ## Overview
 
@@ -13,6 +13,7 @@ Users can opt in to receive notifications through the browser's W3C Web Push sys
 - If push is configured and supported, signed-in users who have not made a browser permission choice see a small top-overlay prompt offering to enable push or opt out of future prompts on that device.
 - On granting permission, the browser creates a subscription using the server's VAPID public key. The subscription details (endpoint URL, keys) are sent to the server and stored.
 - When a signed-in user opens Chatto and browser notification permission is already granted, Chatto refreshes the server's copy of the current browser subscription without prompting again.
+- In multi-server mode, native Web Push controls are shown only for the server that served the installed app. Remote servers can still update in-app notification badges and sounds while Chatto is open, but they do not offer direct browser push registration from another server's app origin.
 - Stored subscription fields are bounded: endpoint 4,096 bytes, public key 256 bytes, auth secret 128 bytes, and user agent 512 bytes.
 - A user can have multiple devices subscribed simultaneously — every device receives every push.
 - Push payloads include a title, a truncated message preview (max 100 chars, broken at word boundaries), and a navigation URL.
@@ -65,6 +66,12 @@ Users can opt in to receive notifications through the browser's W3C Web Push sys
 **Decision:** The enable-push prompt is device-local and can be dismissed without changing server-side notification settings.
 **Why:** Whether push is useful depends on the device. Dismissing the prompt on a desktop browser should not suppress the prompt on an iOS PWA where push may be more valuable.
 **Tradeoff:** The same user may see the prompt again on another browser or device. That is intentional; each device has its own push subscription and OS permission.
+
+### 8. Origin-bound native push registration
+
+**Decision:** Direct browser push registration is offered only for the Chatto server that served the installed web app.
+**Why:** A browser push subscription belongs to a service worker origin and is created with a single application server key. Registering arbitrary remote servers from another server's app origin would imply cross-origin routing and VAPID-key behavior that Chatto has not designed yet.
+**Tradeoff:** Users connected to remote servers do not get native OS notifications for those servers through this app origin. They still get realtime in-app badges and notification sounds while Chatto is open, and remote-native push can be revisited with an explicit relay or shared-key design.
 
 ## Permissions
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -22,7 +22,7 @@ See [`.claude/skills/fdr/SKILL.md`](../../.claude/skills/fdr/SKILL.md) for the F
 | [FDR-010](FDR-010-typing-indicators.md) | Typing Indicators | Active | 2026-05-19 |
 | [FDR-011](FDR-011-user-presence.md) | User Presence | Active | 2026-06-23 |
 | [FDR-012](FDR-012-notifications.md) | Notifications | Active | 2026-06-12 |
-| [FDR-013](FDR-013-web-push-notifications.md) | Web Push Notifications | Active | 2026-06-17 |
+| [FDR-013](FDR-013-web-push-notifications.md) | Web Push Notifications | Active | 2026-06-25 |
 | [FDR-014](FDR-014-jump-to-present.md) | Jump to Present | Active | 2026-05-19 |
 | [FDR-015](FDR-015-quick-switcher.md) | Quick Switcher (Cmd-K) | Active | 2026-05-31 |
 | [FDR-016](FDR-016-voice-calls.md) | Voice Calls | Active | 2026-06-15 |

--- a/frontend/messages/de/settings.json
+++ b/frontend/messages/de/settings.json
@@ -150,7 +150,9 @@
         "enabling": "Wird aktiviert...",
         "blocked_error": "Push-Benachrichtigungen sind in deinen Browser- oder Betriebssystemeinstellungen blockiert.",
         "enable_failed": "Push-Benachrichtigungen konnten nicht aktiviert werden. Bitte versuche es erneut.",
-        "enable_error": "Beim Aktivieren der Push-Benachrichtigungen ist ein Fehler aufgetreten"
+        "enable_error": "Beim Aktivieren der Push-Benachrichtigungen ist ein Fehler aufgetreten",
+        "remote_title": "Native Push-Benachrichtigungen sind für entfernte Server nicht verfügbar",
+        "remote_description": "Diese installierte App kann Browser-Push-Benachrichtigungen nur bei dem Server registrieren, der sie ausgeliefert hat. In-App-Badges und Benachrichtigungstöne funktionieren für diesen Server weiterhin, solange Chatto geöffnet ist."
       },
       "push_prompt": {
         "title": "Push-Benachrichtigungen aktivieren",

--- a/frontend/messages/en/settings.json
+++ b/frontend/messages/en/settings.json
@@ -150,7 +150,9 @@
         "enabling": "Enabling...",
         "blocked_error": "Push notifications are blocked in your browser or OS settings.",
         "enable_failed": "Failed to enable push notifications. Please try again.",
-        "enable_error": "An error occurred while enabling push notifications"
+        "enable_error": "An error occurred while enabling push notifications",
+        "remote_title": "Native push is unavailable for remote servers",
+        "remote_description": "This installed app can only register browser push notifications with the server that served it. In-app notification badges and sounds still work for this server while Chatto is open."
       },
       "push_prompt": {
         "title": "Enable push notifications",

--- a/frontend/src/lib/i18n/messages.ts
+++ b/frontend/src/lib/i18n/messages.ts
@@ -208,6 +208,8 @@ const msg_settings_notifications_push_enabling = (): LocalizedString => messages
 const msg_settings_notifications_push_blocked_error = (): LocalizedString => messages().settings_notifications_push_blocked_error(empty());
 const msg_settings_notifications_push_enable_failed = (): LocalizedString => messages().settings_notifications_push_enable_failed(empty());
 const msg_settings_notifications_push_enable_error = (): LocalizedString => messages().settings_notifications_push_enable_error(empty());
+const msg_settings_notifications_push_remote_title = (): LocalizedString => messages().settings_notifications_push_remote_title(empty());
+const msg_settings_notifications_push_remote_description = (): LocalizedString => messages().settings_notifications_push_remote_description(empty());
 const msg_settings_notifications_push_prompt_title = (): LocalizedString => messages().settings_notifications_push_prompt_title(empty());
 const msg_settings_notifications_push_prompt_message = (): LocalizedString => messages().settings_notifications_push_prompt_message(empty());
 const msg_settings_notifications_push_prompt_enabled = (): LocalizedString => messages().settings_notifications_push_prompt_enabled(empty());
@@ -1286,6 +1288,8 @@ export { msg_settings_notifications_push_enabling as 'settings.notifications.pus
 export { msg_settings_notifications_push_blocked_error as 'settings.notifications.push.blocked_error' };
 export { msg_settings_notifications_push_enable_failed as 'settings.notifications.push.enable_failed' };
 export { msg_settings_notifications_push_enable_error as 'settings.notifications.push.enable_error' };
+export { msg_settings_notifications_push_remote_title as 'settings.notifications.push.remote_title' };
+export { msg_settings_notifications_push_remote_description as 'settings.notifications.push.remote_description' };
 export { msg_settings_notifications_push_prompt_title as 'settings.notifications.push_prompt.title' };
 export { msg_settings_notifications_push_prompt_message as 'settings.notifications.push_prompt.message' };
 export { msg_settings_notifications_push_prompt_enabled as 'settings.notifications.push_prompt.enabled' };

--- a/frontend/src/routes/chat/[serverId]/settings/notifications/+page.svelte
+++ b/frontend/src/routes/chat/[serverId]/settings/notifications/+page.svelte
@@ -21,7 +21,9 @@
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import * as m from '$lib/i18n/messages';
 
-  const serverInfo = serverRegistry.getStore(getActiveServer()).serverInfo;
+  const activeServerId = $derived(getActiveServer());
+  const serverInfo = $derived(serverRegistry.getStore(activeServerId).serverInfo);
+  const isOriginServer = $derived(serverRegistry.isOriginServer(activeServerId));
 
   function selectSound(soundId: NotificationSoundId) {
     userPreferences.notificationSound = soundId;
@@ -158,6 +160,8 @@
 
   // Push notifications state
   let pushEnabled = $derived(serverInfo.pushNotificationsEnabled);
+  let showOriginPushControls = $derived(pushEnabled && isOriginServer);
+  let showRemotePushNotice = $derived(pushEnabled && !isOriginServer);
   let pushSupported = isPushSupported();
   let pushPermission = $state<NotificationPermission | null>(getPermission());
   let pushSubscribed = $state(false);
@@ -166,7 +170,7 @@
 
   // Check push subscription status on mount
   $effect(() => {
-    if (pushEnabled && pushSupported) {
+    if (showOriginPushControls && pushSupported) {
       pushPermission = getPermission();
       checkPushSubscription().then((subscribed) => {
         pushSubscribed = subscribed;
@@ -213,7 +217,21 @@
   <NotificationLevelSettings />
 
   <!-- Push Notifications Section (only show if enabled on server) -->
-  {#if pushEnabled}
+  {#if showRemotePushNotice}
+    <div class="max-w-lg">
+      <h3 class="mb-4 text-sm font-semibold text-muted">
+        {m['settings.notifications.push.title']()}
+      </h3>
+      <Hint tone="info">
+        <div>
+          <p class="font-medium">{m['settings.notifications.push.remote_title']()}</p>
+          <p class="mt-1 text-sm text-muted">
+            {m['settings.notifications.push.remote_description']()}
+          </p>
+        </div>
+      </Hint>
+    </div>
+  {:else if showOriginPushControls}
     <div class="max-w-lg">
       <h3 class="mb-4 text-sm font-semibold text-muted">
         {m['settings.notifications.push.title']()}

--- a/frontend/src/routes/chat/[serverId]/settings/notifications/notifications.page.svelte.spec.ts
+++ b/frontend/src/routes/chat/[serverId]/settings/notifications/notifications.page.svelte.spec.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   mutation: vi.fn(),
   setRoomNotificationLevel: vi.fn(),
   playNotificationSound: vi.fn(),
+  activeServerId: 'origin',
   notificationLevels: {
     setServerPreference: vi.fn(),
     setRoomPreference: vi.fn()
@@ -49,7 +50,7 @@ vi.mock('$lib/api/notificationPreferences', () => ({
 }));
 
 vi.mock('$lib/state/activeServer.svelte', () => ({
-  getActiveServer: () => 'origin'
+  getActiveServer: () => mocks.activeServerId
 }));
 
 vi.mock('$lib/state/server/registry.svelte', () => ({
@@ -57,7 +58,8 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
     getStore: () => ({
       serverInfo: mocks.serverInfo,
       notificationLevels: mocks.notificationLevels
-    })
+    }),
+    isOriginServer: (serverId: string) => serverId === 'origin'
   }
 }));
 
@@ -134,6 +136,7 @@ describe('Notification settings page', () => {
     localStorage.clear();
     userPreferences.notificationSound = 'chime-up';
     userPreferences.resetNotificationSoundFilters();
+    mocks.activeServerId = 'origin';
     mocks.playNotificationSound.mockClear();
     mocks.notificationLevels.setServerPreference.mockClear();
     mocks.notificationLevels.setRoomPreference.mockClear();
@@ -265,6 +268,30 @@ describe('Notification settings page', () => {
     expect(container.textContent).toContain('Push Notifications');
     await expect.element(buttonWithText(container, 'Enable')).toBeVisible();
     expect(container.textContent).not.toContain('Disable');
+  });
+
+  it('does not offer native push registration for remote servers', async () => {
+    mocks.activeServerId = 'remote';
+    mocks.serverInfo.pushNotificationsEnabled = true;
+    mocks.serverInfo.vapidPublicKey = 'vapid-key';
+    mocks.pushNotifications.isSubscribed.mockResolvedValue(false);
+
+    const { container } = render(NotificationsPage);
+    await settle();
+
+    expect(container.textContent).toContain('Push Notifications');
+    expect(container.textContent).toContain('Native push is unavailable for remote servers');
+    expect(container.textContent).toContain('In-app notification badges and sounds still work');
+    expect(container.textContent).not.toContain(
+      'Get notified about new messages even when the browser is closed.'
+    );
+    expect(
+      Array.from(container.querySelectorAll('button')).some((button) =>
+        button.textContent?.includes('Enable')
+      )
+    ).toBe(false);
+    expect(mocks.pushNotifications.isSubscribed).not.toHaveBeenCalled();
+    expect(mocks.pushNotifications.ensureRegistered).not.toHaveBeenCalled();
   });
 
   it('enables push notifications through the registration helper', async () => {


### PR DESCRIPTION
- Hide native Web Push registration controls on remote server notification settings pages.
- Show localized explanatory copy that native push only works with the app origin while in-app badges and sounds still work for remote servers.
- Add a browser-mode component test covering the remote-server branch and ensuring push registration helpers are not called.
- Update FDR-013 to record the current origin-bound native push behavior.

Tests:
- `mise exec -- pnpm exec vitest run 'src/routes/chat/[serverId]/settings/notifications/notifications.page.svelte.spec.ts'`
- `mise exec -- pnpm run check`
- `mise exec -- pnpm exec eslint 'src/routes/chat/[serverId]/settings/notifications/+page.svelte' 'src/routes/chat/[serverId]/settings/notifications/notifications.page.svelte.spec.ts'`
