### PR TITLE
perf(build): improve frontend and CLI cache reuse

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Build frontend assets for CLI image
         run: mise build-frontend
+        env:
+          CHATTO_FRONTEND_PRECOMPRESS: "1"
 
       - name: Prepare Docker context
         run: |
@@ -65,7 +67,7 @@ jobs:
 
           (
             cd cli
-            CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o "$context/chatto" .
+            CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o "$context/chatto" .
           )
 
       - name: Build and push Chatto image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         run: mise build-frontend
 
       - name: Run Go tests
-        run: cd cli && go test -p 1 -tags test_endpoints ./...
+        run: cd cli && go test -trimpath -p 1 -tags test_endpoints ./...
 
   test-e2e:
     runs-on: ubicloud-standard-4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,8 @@ jobs:
 
       - name: Build frontend once
         run: mise build-frontend
+        env:
+          CHATTO_FRONTEND_PRECOMPRESS: "1"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: amd64
+    flags:
+      - -trimpath
     ldflags:
       - -s -w
 

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -2,6 +2,8 @@ import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 import { execSync } from 'node:child_process';
 
+const precompress = process.env.CHATTO_FRONTEND_PRECOMPRESS === '1';
+
 function buildVersionName() {
   if (process.env.npm_package_version) return process.env.npm_package_version;
 
@@ -20,7 +22,7 @@ const config = {
   kit: {
     adapter: adapter({
       fallback: '200.html',
-      precompress: true
+      precompress
     }),
     version: {
       // Use package version when run through package scripts, or the current

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -255,6 +255,7 @@ export default defineConfig({
     devtoolsJson()
   ],
   build: {
+    reportCompressedSize: false,
     rollupOptions: {
       output: {
         manualChunks(id) {

--- a/mise.toml
+++ b/mise.toml
@@ -139,7 +139,7 @@ outputs = ["build/.mise-build-stamp", "../cli/internal/http_server/.client/.gitk
 description = "Build the development CLI application for the current architecture"
 depends = ["setup-cli", "build-frontend"]
 dir = "cli"
-run = "go build -tags bootstrap -o bin/chatto ."
+run = "go build -trimpath -tags bootstrap -o bin/chatto ."
 sources = [
     "go.mod",
     "go.sum",
@@ -161,7 +161,7 @@ dir = "cli"
 # test-only HTTP endpoints (e.g. /auth/test/create-user) used by per-test
 # fixtures. Deliberately scoped — the e2e binary should NOT pull in any
 # future broader dev-only code that might land under a separate tag.
-run = "CGO_ENABLED=0 go build -tags 'bootstrap test_endpoints' -ldflags '-s -w' -o ../frontend/e2e/fixtures/bin/chatto ."
+run = "CGO_ENABLED=0 go build -trimpath -tags 'bootstrap test_endpoints' -ldflags '-s -w' -o ../frontend/e2e/fixtures/bin/chatto ."
 sources = [
     "**/*.go",
     "cmd/embedded/LICENSE",
@@ -180,7 +180,7 @@ run = "pnpm storybook"
 description = "Build and run the local development backend"
 depends = ["setup-cli"]
 dir = "cli"
-run = "go build -tags bootstrap -o bin/chatto-dev . && exec ./bin/chatto-dev start"
+run = "go build -trimpath -tags bootstrap -o bin/chatto-dev . && exec ./bin/chatto-dev start"
 
 [tasks.dev-frontend]
 description = "Run the local development frontend"
@@ -233,14 +233,14 @@ run = "printf 'Chatto URL: %s\\n' \"$CHATTO_WEBSERVER_URL\" && exec bin/chatto"
 description = "Run CLI tests"
 depends = ["setup-cli", "build-frontend"]
 dir = "cli"
-run = "go test -p ${CHATTO_GO_TEST_P:-4} -tags test_endpoints ./..."
+run = "go test -trimpath -p ${CHATTO_GO_TEST_P:-4} -tags test_endpoints ./..."
 sources = ["**/*.go", "cmd/embedded/LICENSE", "cmd/embedded/NOTICE"]
 
 [tasks.test-cli-shutdown]
 description = "Run backend process shutdown integration tests"
 depends = ["setup-cli"]
 dir = "cli"
-run = "go test -tags integration ./cmd -run TestRunCommandShutsDownOnSignals -count=1 -timeout 2m"
+run = "go test -trimpath -tags integration ./cmd -run TestRunCommandShutsDownOnSignals -count=1 -timeout 2m"
 sources = ["**/*.go", "cmd/embedded/LICENSE", "cmd/embedded/NOTICE"]
 
 [tasks.lint-frontend]


### PR DESCRIPTION
- Make frontend adapter precompression opt-in so normal builds skip `.br`/`.gz` generation.
- Preserve precompressed release and manual image artifacts by setting `CHATTO_FRONTEND_PRECOMPRESS=1` in those workflows.
- Disable Vite compressed-size reporting and add `-trimpath` to Go CLI build/test paths for better cache reuse across worktrees.

Verified with `pnpm build`, `CHATTO_FRONTEND_PRECOMPRESS=1 pnpm build`, `go build -trimpath -tags bootstrap`, `go test -trimpath ./internal/config -run '^$' -timeout 30s`, `goreleaser check`, and `git diff --check`.
