### PR TITLE
fix(core): prevent read marker regressions

### DIFF
--- a/cli/internal/connectapi/read_state.go
+++ b/cli/internal/connectapi/read_state.go
@@ -50,19 +50,13 @@ func (s *readStateService) MarkRoomAsRead(ctx context.Context, req *connect.Requ
 	}
 
 	if hasLast {
-		shouldWrite := true
-		if previousEventID != "" && previousEventID != lastEventID {
-			prevTime, perr := s.api.core.GetEventTimestamp(ctx, kind, room.Id, previousEventID)
-			if perr == nil && !prevTime.IsZero() && !lastTime.After(prevTime) {
-				shouldWrite = false
-				lastEventID = previousEventID
-				lastTime = prevTime
-			}
+		advance, err := s.api.core.AdvanceLastReadEventID(ctx, kind, user.Id, room.Id, lastEventID)
+		if err != nil {
+			return nil, connectError(err)
 		}
-		if shouldWrite {
-			if err := s.api.core.SetLastReadEventID(ctx, kind, user.Id, room.Id, lastEventID); err != nil {
-				return nil, connectError(err)
-			}
+		if advance.CurrentEventID != "" {
+			lastEventID = advance.CurrentEventID
+			lastTime = advance.CurrentTime
 		}
 	}
 

--- a/cli/internal/core/messages.go
+++ b/cli/internal/core/messages.go
@@ -625,7 +625,7 @@ func (c *ChattoCore) PostMessage(ctx context.Context, kind RoomKind, room_id, us
 		posterReadEventID = lastRootID
 	}
 	if posterReadEventID != "" {
-		if err := c.SetLastReadEventID(ctx, kind, user_id, room_id, posterReadEventID); err != nil {
+		if _, err := c.AdvanceLastReadEventID(ctx, kind, user_id, room_id, posterReadEventID); err != nil {
 			c.logger.Warn("Failed to set last read event for poster", "error", err)
 		}
 	}

--- a/cli/internal/core/room_unread.go
+++ b/cli/internal/core/room_unread.go
@@ -27,6 +27,18 @@ import (
 // room's current last root event on first read — the "caught up at deploy
 // time" semantic.
 
+const maxReadMarkerUpdateRetries = 5
+
+// LastReadEventIDAdvance describes the result of an advance-only room read
+// marker update.
+type LastReadEventIDAdvance struct {
+	PreviousEventID string
+	PreviousTime    time.Time
+	CurrentEventID  string
+	CurrentTime     time.Time
+	Updated         bool
+}
+
 // NotifyRoomMarkedAsRead publishes a live event to notify the user that they marked
 // a room as read. This enables real-time updates to space unread indicators.
 // This is best-effort - failures are logged but don't affect the mark-as-read operation.
@@ -129,6 +141,87 @@ func (c *ChattoCore) SetLastReadEventID(ctx context.Context, kind RoomKind, user
 	}
 	c.logger.Debug("Set last read event", "user_id", userID, "room_id", roomID, "event_id", eventID)
 	return nil
+}
+
+// AdvanceLastReadEventID stores eventID as the user's room read marker only if
+// it is newer than the marker already in RUNTIME_STATE. The compare-and-write
+// loop uses KV revisions so concurrent replicas cannot move the marker
+// backwards after seeing stale state.
+func (c *ChattoCore) AdvanceLastReadEventID(ctx context.Context, kind RoomKind, userID, roomID, eventID string) (*LastReadEventIDAdvance, error) {
+	nextTime, err := c.GetEventTimestamp(ctx, kind, roomID, eventID)
+	if err != nil {
+		return nil, err
+	}
+
+	bucket := c.storage.runtimeStateKV
+	key := roomReadEventKey(userID, roomID)
+
+	for attempt := 0; attempt < maxReadMarkerUpdateRetries; attempt++ {
+		entry, err := bucket.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				if eventID != "" && nextTime.IsZero() {
+					return &LastReadEventIDAdvance{}, nil
+				}
+				if _, err := bucket.Create(ctx, key, []byte(eventID)); err != nil {
+					if errors.Is(err, jetstream.ErrKeyExists) {
+						continue
+					}
+					return nil, fmt.Errorf("failed to create read marker: %w", err)
+				}
+				c.logger.Debug("Advanced last read event", "user_id", userID, "room_id", roomID, "event_id", eventID)
+				return &LastReadEventIDAdvance{
+					CurrentEventID: eventID,
+					CurrentTime:    nextTime,
+					Updated:        true,
+				}, nil
+			}
+			return nil, fmt.Errorf("failed to get read marker: %w", err)
+		}
+
+		previousEventID := string(entry.Value())
+		previousTime, err := c.GetEventTimestamp(ctx, kind, roomID, previousEventID)
+		if err != nil {
+			return nil, err
+		}
+		result := &LastReadEventIDAdvance{
+			PreviousEventID: previousEventID,
+			PreviousTime:    previousTime,
+			CurrentEventID:  previousEventID,
+			CurrentTime:     previousTime,
+		}
+
+		if !shouldAdvanceReadMarker(previousEventID, previousTime, eventID, nextTime) {
+			return result, nil
+		}
+
+		if _, err := bucket.Update(ctx, key, []byte(eventID), entry.Revision()); err != nil {
+			if errors.Is(err, jetstream.ErrKeyExists) {
+				continue
+			}
+			return nil, fmt.Errorf("failed to advance read marker: %w", err)
+		}
+		result.CurrentEventID = eventID
+		result.CurrentTime = nextTime
+		result.Updated = true
+		c.logger.Debug("Advanced last read event", "user_id", userID, "room_id", roomID, "previous_event_id", previousEventID, "event_id", eventID)
+		return result, nil
+	}
+
+	return nil, fmt.Errorf("read marker update failed after %d retries", maxReadMarkerUpdateRetries)
+}
+
+func shouldAdvanceReadMarker(currentEventID string, currentTime time.Time, nextEventID string, nextTime time.Time) bool {
+	if currentEventID == nextEventID {
+		return false
+	}
+	if nextEventID == "" || nextTime.IsZero() {
+		return currentEventID == ""
+	}
+	if currentEventID == "" || currentTime.IsZero() {
+		return true
+	}
+	return nextTime.After(currentTime)
 }
 
 // GetEventTimestamp returns the proto-level `created_at` timestamp for a

--- a/cli/internal/core/room_unread_test.go
+++ b/cli/internal/core/room_unread_test.go
@@ -96,6 +96,60 @@ func TestChattoCore_LastReadEventID(t *testing.T) {
 	}
 }
 
+func TestChattoCore_AdvanceLastReadEventIDDoesNotRegress(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	room, _ := core.CreateRoom(ctx, "test-user", KindChannel, "", "General", "General discussion")
+	poster, _ := core.CreateUser(ctx, "system", "poster", "poster", "password123")
+	reader, _ := core.CreateUser(ctx, "system", "reader", "reader", "password123")
+	core.JoinRoom(ctx, poster.Id, KindChannel, poster.Id, room.Id)
+
+	first, err := core.PostMessage(ctx, KindChannel, room.Id, poster.Id, "First message", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage first: %v", err)
+	}
+	second, err := core.PostMessage(ctx, KindChannel, room.Id, poster.Id, "Second message", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage second: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, reader.Id, KindChannel, reader.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom reader: %v", err)
+	}
+
+	advance, err := core.AdvanceLastReadEventID(ctx, KindChannel, reader.Id, room.Id, first.Id)
+	if err != nil {
+		t.Fatalf("AdvanceLastReadEventID stale first: %v", err)
+	}
+	if advance.Updated {
+		t.Fatal("AdvanceLastReadEventID updated stale marker, want no update")
+	}
+	if advance.CurrentEventID != second.Id {
+		t.Fatalf("CurrentEventID = %q, want %q", advance.CurrentEventID, second.Id)
+	}
+	got, err := core.GetLastReadEventID(ctx, KindChannel, reader.Id, room.Id)
+	if err != nil {
+		t.Fatalf("GetLastReadEventID after stale advance: %v", err)
+	}
+	if got != second.Id {
+		t.Fatalf("last read marker regressed to %q, want %q", got, second.Id)
+	}
+
+	if err := core.SetLastReadEventID(ctx, KindChannel, reader.Id, room.Id, "Edoesnotexist"); err != nil {
+		t.Fatalf("SetLastReadEventID stale marker: %v", err)
+	}
+	advance, err = core.AdvanceLastReadEventID(ctx, KindChannel, reader.Id, room.Id, first.Id)
+	if err != nil {
+		t.Fatalf("AdvanceLastReadEventID stale recovery: %v", err)
+	}
+	if !advance.Updated {
+		t.Fatal("AdvanceLastReadEventID did not repair stale marker")
+	}
+	if advance.CurrentEventID != first.Id {
+		t.Fatalf("CurrentEventID after stale recovery = %q, want %q", advance.CurrentEventID, first.Id)
+	}
+}
+
 // TestChattoCore_LastReadEventID_LazyInitCaughtUp verifies that a user with
 // no read marker yet (e.g. a pre-existing user encountering this code path
 // for the first time post-deploy) is lazy-initialized as caught up to the

--- a/cli/internal/core/threads.go
+++ b/cli/internal/core/threads.go
@@ -435,36 +435,51 @@ func (c *ChattoCore) SetThreadLastReadEventID(ctx context.Context, kind RoomKind
 	bucket := c.storage.runtimeStateKV
 	key := threadLastOpenedKey(userID, roomID, threadRootEventID)
 
-	var previousTime time.Time
-	entry, err := bucket.Get(ctx, key)
-	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
-		return time.Time{}, fmt.Errorf("failed to get previous thread last opened: %w", err)
-	}
-	if err == nil {
-		previousTime, err = c.threadReadMarkerTime(ctx, kind, roomID, entry.Value())
-		if err != nil {
-			return time.Time{}, err
-		}
-	}
-
 	nextTime, err := c.GetEventTimestamp(ctx, kind, roomID, eventID)
 	if err != nil {
 		return time.Time{}, err
 	}
-	if nextTime.IsZero() {
+
+	for attempt := 0; attempt < maxReadMarkerUpdateRetries; attempt++ {
+		var previousTime time.Time
+		entry, err := bucket.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				if nextTime.IsZero() {
+					return time.Time{}, nil
+				}
+				if _, err := bucket.Create(ctx, key, []byte(eventID)); err != nil {
+					if errors.Is(err, jetstream.ErrKeyExists) {
+						continue
+					}
+					return time.Time{}, fmt.Errorf("failed to create thread last opened: %w", err)
+				}
+				c.logger.Debug("Set thread last read event", "user_id", userID, "room_id", roomID, "thread_root_event_id", threadRootEventID, "previous", previousTime, "event_id", eventID)
+				return previousTime, nil
+			}
+			return time.Time{}, fmt.Errorf("failed to get previous thread last opened: %w", err)
+		}
+
+		previousTime, err = c.threadReadMarkerTime(ctx, kind, roomID, entry.Value())
+		if err != nil {
+			return time.Time{}, err
+		}
+		if nextTime.IsZero() || !nextTime.After(previousTime) {
+			return previousTime, nil
+		}
+
+		if _, err := bucket.Update(ctx, key, []byte(eventID), entry.Revision()); err != nil {
+			if errors.Is(err, jetstream.ErrKeyExists) {
+				continue
+			}
+			return time.Time{}, fmt.Errorf("failed to set thread last opened: %w", err)
+		}
+
+		c.logger.Debug("Set thread last read event", "user_id", userID, "room_id", roomID, "thread_root_event_id", threadRootEventID, "previous", previousTime, "event_id", eventID)
 		return previousTime, nil
 	}
 
-	if !nextTime.After(previousTime) {
-		return previousTime, nil
-	}
-
-	if _, err = bucket.Put(ctx, key, []byte(eventID)); err != nil {
-		return time.Time{}, fmt.Errorf("failed to set thread last opened: %w", err)
-	}
-
-	c.logger.Debug("Set thread last read event", "user_id", userID, "room_id", roomID, "thread_root_event_id", threadRootEventID, "previous", previousTime, "event_id", eventID)
-	return previousTime, nil
+	return time.Time{}, fmt.Errorf("thread read marker update failed after %d retries", maxReadMarkerUpdateRetries)
 }
 
 // SetThreadLastOpenedAt is retained for timestamp-based callers/tests. It
@@ -474,29 +489,49 @@ func (c *ChattoCore) SetThreadLastOpenedAt(ctx context.Context, kind RoomKind, u
 	bucket := c.storage.runtimeStateKV
 	key := threadLastOpenedKey(userID, roomID, threadRootEventID)
 
-	var previousTime time.Time
-	entry, err := bucket.Get(ctx, key)
-	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
-		return time.Time{}, fmt.Errorf("failed to get previous thread last opened: %w", err)
-	}
-	if err == nil {
+	for attempt := 0; attempt < maxReadMarkerUpdateRetries; attempt++ {
+		var previousTime time.Time
+		entry, err := bucket.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				if ts.IsZero() {
+					return time.Time{}, nil
+				}
+				buf := make([]byte, 8)
+				binary.BigEndian.PutUint64(buf, uint64(ts.UnixNano()))
+				if _, err := bucket.Create(ctx, key, buf); err != nil {
+					if errors.Is(err, jetstream.ErrKeyExists) {
+						continue
+					}
+					return time.Time{}, fmt.Errorf("failed to create thread last opened: %w", err)
+				}
+				c.logger.Debug("Set legacy thread last opened timestamp", "user_id", userID, "room_id", roomID, "thread_root_event_id", threadRootEventID, "previous", previousTime, "at", ts)
+				return previousTime, nil
+			}
+			return time.Time{}, fmt.Errorf("failed to get previous thread last opened: %w", err)
+		}
+
 		previousTime, err = c.threadReadMarkerTime(ctx, kind, roomID, entry.Value())
 		if err != nil {
 			return time.Time{}, err
 		}
-	}
+		if !ts.After(previousTime) {
+			return previousTime, nil
+		}
 
-	if !ts.After(previousTime) {
+		buf := make([]byte, 8)
+		binary.BigEndian.PutUint64(buf, uint64(ts.UnixNano()))
+		if _, err := bucket.Update(ctx, key, buf, entry.Revision()); err != nil {
+			if errors.Is(err, jetstream.ErrKeyExists) {
+				continue
+			}
+			return time.Time{}, fmt.Errorf("failed to set thread last opened: %w", err)
+		}
+		c.logger.Debug("Set legacy thread last opened timestamp", "user_id", userID, "room_id", roomID, "thread_root_event_id", threadRootEventID, "previous", previousTime, "at", ts)
 		return previousTime, nil
 	}
 
-	buf := make([]byte, 8)
-	binary.BigEndian.PutUint64(buf, uint64(ts.UnixNano()))
-	if _, err = bucket.Put(ctx, key, buf); err != nil {
-		return time.Time{}, fmt.Errorf("failed to set thread last opened: %w", err)
-	}
-	c.logger.Debug("Set legacy thread last opened timestamp", "user_id", userID, "room_id", roomID, "thread_root_event_id", threadRootEventID, "previous", previousTime, "at", ts)
-	return previousTime, nil
+	return time.Time{}, fmt.Errorf("thread read marker update failed after %d retries", maxReadMarkerUpdateRetries)
 }
 
 // SetThreadLastOpened records the latest current reply in the thread as read.

--- a/cli/internal/core/threads_test.go
+++ b/cli/internal/core/threads_test.go
@@ -1638,6 +1638,70 @@ func TestChattoCore_PostMessage_InReplyToNotification(t *testing.T) {
 	})
 }
 
+func TestChattoCore_SetThreadLastReadEventIDDoesNotRegress(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	room, _ := core.CreateRoom(ctx, "test-user", KindChannel, "", "General", "General discussion")
+	user, _ := core.CreateUser(ctx, "system", "threadreader", "threadreader", "password123")
+	core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id)
+
+	root, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "Root message", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage root: %v", err)
+	}
+	reply1, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "First reply", nil, root.Id, "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage reply1: %v", err)
+	}
+	reply2, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "Second reply", nil, root.Id, "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage reply2: %v", err)
+	}
+	if reply2.GetCreatedAt().AsTime().IsZero() {
+		t.Fatal("reply2 created_at is zero")
+	}
+
+	marker2, err := core.GetThreadLastOpened(ctx, KindChannel, user.Id, room.Id, root.Id)
+	if err != nil {
+		t.Fatalf("GetThreadLastOpened after reply2: %v", err)
+	}
+	if marker2.IsZero() {
+		t.Fatal("thread marker after reply2 is zero")
+	}
+
+	previous, err := core.SetThreadLastReadEventID(ctx, KindChannel, user.Id, room.Id, root.Id, reply1.Id)
+	if err != nil {
+		t.Fatalf("SetThreadLastReadEventID stale reply1: %v", err)
+	}
+	if !previous.Equal(marker2) {
+		t.Fatalf("previous marker = %v, want %v", previous, marker2)
+	}
+	markerAfter, err := core.GetThreadLastOpened(ctx, KindChannel, user.Id, room.Id, root.Id)
+	if err != nil {
+		t.Fatalf("GetThreadLastOpened after stale reply1: %v", err)
+	}
+	if !markerAfter.Equal(marker2) {
+		t.Fatalf("thread marker regressed from %v to %v", marker2, markerAfter)
+	}
+
+	reply1Time := reply1.GetCreatedAt().AsTime()
+	previous, err = core.SetThreadLastOpenedAt(ctx, KindChannel, user.Id, room.Id, root.Id, reply1Time)
+	if err != nil {
+		t.Fatalf("SetThreadLastOpenedAt stale reply1 time: %v", err)
+	}
+	if !previous.Equal(marker2) {
+		t.Fatalf("previous legacy marker = %v, want %v", previous, marker2)
+	}
+	markerAfterLegacy, err := core.GetThreadLastOpened(ctx, KindChannel, user.Id, room.Id, root.Id)
+	if err != nil {
+		t.Fatalf("GetThreadLastOpened after stale legacy timestamp: %v", err)
+	}
+	if !markerAfterLegacy.Equal(marker2) {
+		t.Fatalf("thread marker regressed through legacy setter from %v to %v", marker2, markerAfterLegacy)
+	}
+}
+
 func eventIDsForTest(events []*RoomEvent) []string {
 	ids := make([]string, 0, len(events))
 	for _, event := range events {

--- a/cli/internal/graph/mutation.resolvers.go
+++ b/cli/internal/graph/mutation.resolvers.go
@@ -633,21 +633,13 @@ func (r *mutationResolver) MarkRoomAsRead(ctx context.Context, input model.MarkR
 	}
 
 	if hasLast {
-		// Advance-only: don't regress the marker if the client passed a
-		// stale upToEventId (e.g. another tab/device is further ahead).
-		shouldWrite := true
-		if previousEventID != "" && previousEventID != lastEventID {
-			prevTime, perr := r.core.GetEventTimestamp(ctx, kind, input.RoomID, previousEventID)
-			if perr == nil && !prevTime.IsZero() && !lastTime.After(prevTime) {
-				shouldWrite = false
-				lastEventID = previousEventID
-				lastTime = prevTime
-			}
+		advance, err := r.core.AdvanceLastReadEventID(ctx, kind, user.Id, input.RoomID, lastEventID)
+		if err != nil {
+			return nil, err
 		}
-		if shouldWrite {
-			if err := r.core.SetLastReadEventID(ctx, kind, user.Id, input.RoomID, lastEventID); err != nil {
-				return nil, err
-			}
+		if advance.CurrentEventID != "" {
+			lastEventID = advance.CurrentEventID
+			lastTime = advance.CurrentTime
 		}
 	}
 


### PR DESCRIPTION
## Changes
- Moves room read marker advancement into core with revision-based KV `Create`/`Update` retries.
- Uses the atomic room advance path from ConnectRPC, GraphQL, and poster auto-marking.
- Makes thread read marker writes, including legacy timestamp writes, advance-only under KV revision checks.
- Adds focused regression tests for room and thread marker stale-write attempts.

## Verification
- `cd cli && mise x -- go test ./internal/core -run 'TestChattoCore_(AdvanceLastReadEventIDDoesNotRegress|SetThreadLastReadEventIDDoesNotRegress|LastReadEventID|HasUnread|PostMessage_Threading)' -timeout 60s`
- `cd cli && mise x -- go test ./internal/connectapi -run 'TestReadStateService' -timeout 60s`
- `cd cli && mise x -- go test ./internal/graph -run 'TestMark(Room|Thread)AsRead' -timeout 60s`
- `cd cli && mise x -- go test ./internal/core ./internal/connectapi ./internal/graph -timeout 60s`
