### PR TITLE
fix(connectrpc): reject missing read anchors

### DIFF
--- a/cli/internal/connectapi/api.go
+++ b/cli/internal/connectapi/api.go
@@ -115,7 +115,7 @@ func (a *API) roomReadAnchor(ctx context.Context, room *corev1.Room, eventID str
 		return "", time.Time{}, false, connectError(err)
 	}
 	if event == nil {
-		return "", time.Time{}, false, nil
+		return "", time.Time{}, false, connect.NewError(connect.CodeNotFound, errors.New("up_to_event_id event not found"))
 	}
 	message := event.GetMessagePosted()
 	if message == nil || message.GetInThread() != "" || message.GetEchoOfEventId() != "" {

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -729,11 +729,69 @@ func TestReadStateServiceMarkRoomAsReadAnchorsAndDoesNotRegress(t *testing.T) {
 	if _, err := env.readState.MarkRoomAsRead(ctx, connect.NewRequest(&apiv1.MarkRoomAsReadRequest{
 		RoomId:      room.Id,
 		UpToEventId: "missing-event",
+	})); connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("MarkRoomAsRead missing event code = %v, want %v", connect.CodeOf(err), connect.CodeNotFound)
+	}
+	if got, err := env.core.GetLastReadEventID(env.ctx, core.KindChannel, reader.Id, room.Id); err != nil || got != e2.Id {
+		t.Fatalf("marker after missing event = %q, %v; want %s", got, err, e2.Id)
+	}
+
+	if _, err := env.readState.MarkRoomAsRead(ctx, connect.NewRequest(&apiv1.MarkRoomAsReadRequest{
+		RoomId: room.Id,
 	})); err != nil {
-		t.Fatalf("MarkRoomAsRead missing event fallback: %v", err)
+		t.Fatalf("MarkRoomAsRead omitted anchor: %v", err)
 	}
 	if got, err := env.core.GetLastReadEventID(env.ctx, core.KindChannel, reader.Id, room.Id); err != nil || got != e3.Id {
-		t.Fatalf("marker after missing event fallback = %q, %v; want %s", got, err, e3.Id)
+		t.Fatalf("marker after omitted anchor = %q, %v; want %s", got, err, e3.Id)
+	}
+}
+
+func TestReadStateServiceMarkRoomAsReadRejectsMissingAnchorWithoutLazyMarker(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	room, err := env.core.CreateRoom(env.ctx, env.viewer.Id, core.KindChannel, "", "read-state-universal", "", core.WithUniversalRoom(true))
+	if err != nil {
+		t.Fatalf("CreateRoom universal: %v", err)
+	}
+	if _, err := env.core.JoinRoom(env.ctx, env.viewer.Id, core.KindChannel, env.viewer.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom viewer: %v", err)
+	}
+	reader, err := env.core.CreateUser(env.ctx, core.SystemActorID, "read-state-lazy-reader", "Read State Lazy Reader", "password")
+	if err != nil {
+		t.Fatalf("CreateUser reader: %v", err)
+	}
+
+	e1 := env.post(room.Id, env.viewer.Id, "one", "")
+	e2 := env.post(room.Id, env.viewer.Id, "two", "")
+	if marker, exists, err := env.core.PeekLastReadEventID(env.ctx, reader.Id, room.Id); err != nil || exists || marker != "" {
+		t.Fatalf("reader marker before request = %q exists=%v err=%v, want absent", marker, exists, err)
+	}
+
+	ctx := auth.WithUser(env.ctx, reader)
+	if _, err := env.readState.MarkRoomAsRead(ctx, connect.NewRequest(&apiv1.MarkRoomAsReadRequest{
+		RoomId:      room.Id,
+		UpToEventId: "missing-event",
+	})); connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("MarkRoomAsRead missing event code = %v, want %v", connect.CodeOf(err), connect.CodeNotFound)
+	}
+	if marker, exists, err := env.core.PeekLastReadEventID(env.ctx, reader.Id, room.Id); err != nil || exists || marker != "" {
+		t.Fatalf("reader marker after rejected request = %q exists=%v err=%v, want absent", marker, exists, err)
+	}
+
+	resp, err := env.readState.MarkRoomAsRead(ctx, connect.NewRequest(&apiv1.MarkRoomAsReadRequest{
+		RoomId:      room.Id,
+		UpToEventId: e1.Id,
+	}))
+	if err != nil {
+		t.Fatalf("MarkRoomAsRead e1 after rejected request: %v", err)
+	}
+	if resp.Msg.PreviousLastReadAt != nil {
+		t.Fatalf("PreviousLastReadAt after missing marker = %v, want nil", resp.Msg.PreviousLastReadAt)
+	}
+	if got, err := env.core.GetLastReadEventID(env.ctx, core.KindChannel, reader.Id, room.Id); err != nil || got != e1.Id {
+		t.Fatalf("marker after valid e1 = %q, %v; want %s", got, err, e1.Id)
+	}
+	if e2.Id == e1.Id {
+		t.Fatal("test setup posted duplicate event IDs")
 	}
 }
 

--- a/cli/internal/connectapi/read_state.go
+++ b/cli/internal/connectapi/read_state.go
@@ -21,11 +21,6 @@ func (s *readStateService) MarkRoomAsRead(ctx context.Context, req *connect.Requ
 	}
 	kind := core.KindOfRoom(room)
 
-	previousEventID, err := s.api.core.GetLastReadEventID(ctx, kind, user.Id, room.Id)
-	if err != nil {
-		return nil, connectError(err)
-	}
-
 	var (
 		lastEventID string
 		lastTime    time.Time
@@ -47,6 +42,11 @@ func (s *readStateService) MarkRoomAsRead(ctx context.Context, req *connect.Requ
 		if err != nil {
 			return nil, connectError(err)
 		}
+	}
+
+	previousEventID, _, err := s.api.core.PeekLastReadEventID(ctx, user.Id, room.Id)
+	if err != nil {
+		return nil, connectError(err)
 	}
 
 	if hasLast {

--- a/cli/internal/core/room_unread.go
+++ b/cli/internal/core/room_unread.go
@@ -129,6 +129,19 @@ func (c *ChattoCore) GetLastReadEventID(ctx context.Context, kind RoomKind, user
 	return lastID, nil
 }
 
+// PeekLastReadEventID returns the stored read marker for a room without lazy
+// initialization. exists is false when no marker has been written yet.
+func (c *ChattoCore) PeekLastReadEventID(ctx context.Context, userID, roomID string) (eventID string, exists bool, err error) {
+	entry, err := c.storage.runtimeStateKV.Get(ctx, roomReadEventKey(userID, roomID))
+	if err == nil {
+		return string(entry.Value()), true, nil
+	}
+	if errors.Is(err, jetstream.ErrKeyNotFound) {
+		return "", false, nil
+	}
+	return "", false, fmt.Errorf("failed to get read marker: %w", err)
+}
+
 // SetLastReadEventID stores the user's last-read root-message event ID.
 //
 // Callers MUST pass either a root message event ID or the empty string. Thread

--- a/cli/internal/pb/chatto/api/v1/apiv1connect/read_state.connect.go
+++ b/cli/internal/pb/chatto/api/v1/apiv1connect/read_state.connect.go
@@ -43,8 +43,10 @@ const (
 
 // ReadStateServiceClient is a client for the chatto.api.v1.ReadStateService service.
 type ReadStateServiceClient interface {
-	// Marks a room timeline as read through the supplied event. Clients usually
-	// call this after the user has viewed the latest visible event in the room.
+	// Marks a room timeline as read through the supplied event. If no event is
+	// supplied, the server marks through the room's latest root event. Clients
+	// usually call this after the user has viewed the latest visible event in the
+	// room.
 	MarkRoomAsRead(context.Context, *connect.Request[v1.MarkRoomAsReadRequest]) (*connect.Response[v1.MarkRoomAsReadResponse], error)
 	// Marks a thread timeline as read through the supplied event without changing
 	// the room-level read marker.
@@ -95,8 +97,10 @@ func (c *readStateServiceClient) MarkThreadAsRead(ctx context.Context, req *conn
 
 // ReadStateServiceHandler is an implementation of the chatto.api.v1.ReadStateService service.
 type ReadStateServiceHandler interface {
-	// Marks a room timeline as read through the supplied event. Clients usually
-	// call this after the user has viewed the latest visible event in the room.
+	// Marks a room timeline as read through the supplied event. If no event is
+	// supplied, the server marks through the room's latest root event. Clients
+	// usually call this after the user has viewed the latest visible event in the
+	// room.
 	MarkRoomAsRead(context.Context, *connect.Request[v1.MarkRoomAsReadRequest]) (*connect.Response[v1.MarkRoomAsReadResponse], error)
 	// Marks a thread timeline as read through the supplied event without changing
 	// the room-level read marker.

--- a/cli/internal/pb/chatto/api/v1/read_state.pb.go
+++ b/cli/internal/pb/chatto/api/v1/read_state.pb.go
@@ -27,8 +27,9 @@ type MarkRoomAsReadRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Room whose timeline should be marked read.
 	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
-	// Highest room event ID the current user has read. The event should belong to
-	// the room timeline the client is marking.
+	// Highest room event ID the current user has read. When set, the event must
+	// exist as a root event in the room timeline. Leave empty to mark through the
+	// room's current latest root event.
 	UpToEventId   string `protobuf:"bytes,2,opt,name=up_to_event_id,json=upToEventId,proto3" json:"up_to_event_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/docs-website/src/content/docs/reference/connectrpc-api/index.mdx
+++ b/docs-website/src/content/docs/reference/connectrpc-api/index.mdx
@@ -326,8 +326,10 @@ Updates room and thread read state for the current user.
 
 ### MarkRoomAsRead
 
-Marks a room timeline as read through the supplied event. Clients usually
-call this after the user has viewed the latest visible event in the room.
+Marks a room timeline as read through the supplied event. If no event is
+supplied, the server marks through the room's latest root event. Clients
+usually call this after the user has viewed the latest visible event in the
+room.
 
 ```http
 POST /api/connect/chatto.api.v1.ReadStateService/MarkRoomAsRead
@@ -342,7 +344,7 @@ Request to mark a room timeline as read.
 | Field | Type | Description |
 | --- | --- | --- |
 | `room_id` | `string` | Room whose timeline should be marked read. |
-| `up_to_event_id` | `string` | Highest room event ID the current user has read. The event should belong to the room timeline the client is marking. |
+| `up_to_event_id` | `string` | Highest room event ID the current user has read. When set, the event must exist as a root event in the room timeline. Leave empty to mark through the room's current latest root event. |
 
 
 <a id="chatto-api-v1-MarkRoomAsReadResponse"></a>

--- a/frontend/src/lib/pb/chatto/api/v1/read_state_connect.ts
+++ b/frontend/src/lib/pb/chatto/api/v1/read_state_connect.ts
@@ -15,8 +15,10 @@ export const ReadStateService = {
   typeName: "chatto.api.v1.ReadStateService",
   methods: {
     /**
-     * Marks a room timeline as read through the supplied event. Clients usually
-     * call this after the user has viewed the latest visible event in the room.
+     * Marks a room timeline as read through the supplied event. If no event is
+     * supplied, the server marks through the room's latest root event. Clients
+     * usually call this after the user has viewed the latest visible event in the
+     * room.
      *
      * @generated from rpc chatto.api.v1.ReadStateService.MarkRoomAsRead
      */

--- a/frontend/src/lib/pb/chatto/api/v1/read_state_pb.ts
+++ b/frontend/src/lib/pb/chatto/api/v1/read_state_pb.ts
@@ -20,8 +20,9 @@ export class MarkRoomAsReadRequest extends Message<MarkRoomAsReadRequest> {
   roomId = "";
 
   /**
-   * Highest room event ID the current user has read. The event should belong to
-   * the room timeline the client is marking.
+   * Highest room event ID the current user has read. When set, the event must
+   * exist as a root event in the room timeline. Leave empty to mark through the
+   * room's current latest root event.
    *
    * @generated from field: string up_to_event_id = 2;
    */

--- a/proto/chatto/api/v1/read_state.proto
+++ b/proto/chatto/api/v1/read_state.proto
@@ -8,8 +8,9 @@ import "google/protobuf/timestamp.proto";
 message MarkRoomAsReadRequest {
   // Room whose timeline should be marked read.
   string room_id = 1;
-  // Highest room event ID the current user has read. The event should belong to
-  // the room timeline the client is marking.
+  // Highest room event ID the current user has read. When set, the event must
+  // exist as a root event in the room timeline. Leave empty to mark through the
+  // room's current latest root event.
   string up_to_event_id = 2;
 }
 
@@ -43,8 +44,10 @@ message MarkThreadAsReadResponse {
 
 // Updates room and thread read state for the current user.
 service ReadStateService {
-  // Marks a room timeline as read through the supplied event. Clients usually
-  // call this after the user has viewed the latest visible event in the room.
+  // Marks a room timeline as read through the supplied event. If no event is
+  // supplied, the server marks through the room's latest root event. Clients
+  // usually call this after the user has viewed the latest visible event in the
+  // room.
   rpc MarkRoomAsRead(MarkRoomAsReadRequest) returns (MarkRoomAsReadResponse);
   // Marks a thread timeline as read through the supplied event without changing
   // the room-level read marker.


### PR DESCRIPTION
## Changes
- Rejects explicit `MarkRoomAsRead.up_to_event_id` values that do not resolve to a room root event.
- Validates explicit room anchors before reading previous marker state, so rejected requests cannot lazy-initialize missing read markers.
- Preserves omitted-anchor behavior: leaving `up_to_event_id` empty still marks through the room's latest root event.
- Updates public proto comments and regenerates Go/TypeScript bindings plus ConnectRPC reference docs.

## Verification
- `mise codegen-proto`
- `cd cli && mise x -- go test ./internal/connectapi -run 'TestReadStateServiceMarkRoomAsReadAnchorsAndDoesNotRegress|TestReadStateServiceMarkRoomAsReadRejectsMissingAnchorWithoutLazyMarker|TestReadStateServiceMarkThreadAsReadAnchorsAndDoesNotRegress' -timeout 60s`
- `cd cli && mise x -- go test ./internal/connectapi -run 'TestReadStateService' -timeout 60s`
- `cd cli && mise x -- go test ./internal/connectapi -timeout 60s`
- `cd cli && mise x -- go test ./internal/core ./internal/connectapi -timeout 60s`
