### PR TITLE
feat(api)!: use optional timeline presence fields

### DIFF
--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -336,8 +336,8 @@ func TestMessageServicePostMessageReturnsRenderableTimelineEvent(t *testing.T) {
 	if message == nil {
 		t.Fatalf("PostMessage payload = %T, want message_posted", event.GetEvent())
 	}
-	if message.Body != "hello over connect" || !message.BodyPresent {
-		t.Fatalf("message body = %q present=%v, want posted body", message.Body, message.BodyPresent)
+	if message.Body == nil || message.GetBody() != "hello over connect" {
+		t.Fatalf("message body = %q present=%v, want posted body", message.GetBody(), message.Body != nil)
 	}
 	if got := resp.Msg.GetIncludes().GetUsers()[env.viewer.Id]; got == nil || got.DisplayName != env.viewer.DisplayName {
 		t.Fatalf("included viewer = %+v, want %q", got, env.viewer.DisplayName)
@@ -426,8 +426,8 @@ func TestRoomTimelineServiceHydratesMessagesWithoutClientNPlusOne(t *testing.T) 
 	if payload == nil {
 		t.Fatalf("root payload = nil, want message_posted")
 	}
-	if !payload.BodyPresent || payload.Body != "root" {
-		t.Fatalf("message body present/body = %v/%q, want true/root", payload.BodyPresent, payload.Body)
+	if payload.Body == nil || payload.GetBody() != "root" {
+		t.Fatalf("message body present/body = %v/%q, want true/root", payload.Body != nil, payload.GetBody())
 	}
 	if payload.ReplyCount != 1 {
 		t.Fatalf("reply count = %d, want 1", payload.ReplyCount)

--- a/cli/internal/connectapi/room_timeline.go
+++ b/cli/internal/connectapi/room_timeline.go
@@ -333,14 +333,12 @@ func (h *timelineHydrator) event(event *core.RoomEvent) (*apiv1.RoomTimelineEven
 
 func (h *timelineHydrator) messagePosted(event *core.RoomEvent, payload *corev1.MessagePostedEvent) (*apiv1.RoomTimelineMessagePosted, error) {
 	message := &apiv1.RoomTimelineMessagePosted{
-		RoomId:                         payload.GetRoomId(),
-		InReplyTo:                      payload.GetInReplyTo(),
-		ThreadRootEventId:              payload.GetInThread(),
-		EchoOfEventId:                  payload.GetEchoOfEventId(),
-		EchoFromThreadRootEventId:      payload.GetEchoFromThreadRootEventId(),
-		ViewerIsFollowingThread:        false,
-		ViewerIsFollowingThreadPresent: false,
-		Reactions:                      h.reactions(event.Id),
+		RoomId:                    payload.GetRoomId(),
+		InReplyTo:                 payload.GetInReplyTo(),
+		ThreadRootEventId:         payload.GetInThread(),
+		EchoOfEventId:             payload.GetEchoOfEventId(),
+		EchoFromThreadRootEventId: payload.GetEchoFromThreadRootEventId(),
+		Reactions:                 h.reactions(event.Id),
 	}
 
 	if echoID, ok := h.api.core.RoomTimeline.ChannelEchoEventID(event.Id); ok {
@@ -352,8 +350,7 @@ func (h *timelineHydrator) messagePosted(event *core.RoomEvent, payload *corev1.
 		return nil, err
 	}
 	if body != nil {
-		message.Body = body.Body
-		message.BodyPresent = true
+		message.Body = &body.Body
 		message.Attachments = h.attachments(payload.GetRoomId(), event.Id, body.Attachments)
 		message.LinkPreview = h.linkPreview(body.LinkPreview)
 		if body.UpdatedAt != nil {
@@ -378,8 +375,7 @@ func (h *timelineHydrator) messagePosted(event *core.RoomEvent, payload *corev1.
 		if err != nil {
 			return nil, err
 		}
-		message.ViewerIsFollowingThread = following
-		message.ViewerIsFollowingThreadPresent = true
+		message.ViewerIsFollowingThread = &following
 	}
 
 	return message, nil

--- a/cli/internal/pb/chatto/api/v1/room_timeline.pb.go
+++ b/cli/internal/pb/chatto/api/v1/room_timeline.pb.go
@@ -765,11 +765,9 @@ type RoomTimelineMessagePosted struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Room containing the message.
 	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
-	// Message body text.
-	Body string `protobuf:"bytes,2,opt,name=body,proto3" json:"body,omitempty"`
-	// True when the original event explicitly carried a body. This lets clients
-	// distinguish an empty body from a missing body.
-	BodyPresent bool `protobuf:"varint,3,opt,name=body_present,json=bodyPresent,proto3" json:"body_present,omitempty"`
+	// Message body text, when available. A present empty string is distinct from
+	// an absent body.
+	Body *string `protobuf:"bytes,2,opt,name=body,proto3,oneof" json:"body,omitempty"`
 	// Attachments sent with the message.
 	Attachments []*RoomTimelineAttachment `protobuf:"bytes,4,rep,name=attachments,proto3" json:"attachments,omitempty"`
 	// Link preview extracted for the message, when available.
@@ -793,11 +791,8 @@ type RoomTimelineMessagePosted struct {
 	LastReplyAt *timestamppb.Timestamp `protobuf:"bytes,13,opt,name=last_reply_at,json=lastReplyAt,proto3" json:"last_reply_at,omitempty"`
 	// User IDs that have participated in this message's thread.
 	ThreadParticipantUserIds []string `protobuf:"bytes,14,rep,name=thread_participant_user_ids,json=threadParticipantUserIds,proto3" json:"thread_participant_user_ids,omitempty"`
-	// True when the current user follows this message's thread.
-	ViewerIsFollowingThread bool `protobuf:"varint,15,opt,name=viewer_is_following_thread,json=viewerIsFollowingThread,proto3" json:"viewer_is_following_thread,omitempty"`
-	// True when viewer_is_following_thread was explicitly hydrated. If false, the
-	// follow value should be treated as unknown rather than false.
-	ViewerIsFollowingThreadPresent bool `protobuf:"varint,16,opt,name=viewer_is_following_thread_present,json=viewerIsFollowingThreadPresent,proto3" json:"viewer_is_following_thread_present,omitempty"`
+	// Whether the current user follows this message's thread, when known.
+	ViewerIsFollowingThread *bool `protobuf:"varint,15,opt,name=viewer_is_following_thread,json=viewerIsFollowingThread,proto3,oneof" json:"viewer_is_following_thread,omitempty"`
 	// Reaction summaries for this message.
 	Reactions     []*RoomTimelineReactionSummary `protobuf:"bytes,17,rep,name=reactions,proto3" json:"reactions,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -842,17 +837,10 @@ func (x *RoomTimelineMessagePosted) GetRoomId() string {
 }
 
 func (x *RoomTimelineMessagePosted) GetBody() string {
-	if x != nil {
-		return x.Body
+	if x != nil && x.Body != nil {
+		return *x.Body
 	}
 	return ""
-}
-
-func (x *RoomTimelineMessagePosted) GetBodyPresent() bool {
-	if x != nil {
-		return x.BodyPresent
-	}
-	return false
 }
 
 func (x *RoomTimelineMessagePosted) GetAttachments() []*RoomTimelineAttachment {
@@ -933,15 +921,8 @@ func (x *RoomTimelineMessagePosted) GetThreadParticipantUserIds() []string {
 }
 
 func (x *RoomTimelineMessagePosted) GetViewerIsFollowingThread() bool {
-	if x != nil {
-		return x.ViewerIsFollowingThread
-	}
-	return false
-}
-
-func (x *RoomTimelineMessagePosted) GetViewerIsFollowingThreadPresent() bool {
-	if x != nil {
-		return x.ViewerIsFollowingThreadPresent
+	if x != nil && x.ViewerIsFollowingThread != nil {
+		return *x.ViewerIsFollowingThread
 	}
 	return false
 }
@@ -1946,11 +1927,10 @@ const file_chatto_api_v1_room_timeline_proto_rawDesc = "" +
 	"\x05count\x18\x02 \x01(\x05R\x05count\x12\x1f\n" +
 	"\vhas_reacted\x18\x03 \x01(\bR\n" +
 	"hasReacted\x12\x19\n" +
-	"\buser_ids\x18\x04 \x03(\tR\auserIds\"\x9d\a\n" +
+	"\buser_ids\x18\x04 \x03(\tR\auserIds\"\x9e\a\n" +
 	"\x19RoomTimelineMessagePosted\x12\x17\n" +
-	"\aroom_id\x18\x01 \x01(\tR\x06roomId\x12\x12\n" +
-	"\x04body\x18\x02 \x01(\tR\x04body\x12!\n" +
-	"\fbody_present\x18\x03 \x01(\bR\vbodyPresent\x12G\n" +
+	"\aroom_id\x18\x01 \x01(\tR\x06roomId\x12\x17\n" +
+	"\x04body\x18\x02 \x01(\tH\x00R\x04body\x88\x01\x01\x12G\n" +
 	"\vattachments\x18\x04 \x03(\v2%.chatto.api.v1.RoomTimelineAttachmentR\vattachments\x12I\n" +
 	"\flink_preview\x18\x05 \x01(\v2&.chatto.api.v1.RoomTimelineLinkPreviewR\vlinkPreview\x129\n" +
 	"\n" +
@@ -1964,10 +1944,11 @@ const file_chatto_api_v1_room_timeline_proto_rawDesc = "" +
 	"\vreply_count\x18\f \x01(\x05R\n" +
 	"replyCount\x12>\n" +
 	"\rlast_reply_at\x18\r \x01(\v2\x1a.google.protobuf.TimestampR\vlastReplyAt\x12=\n" +
-	"\x1bthread_participant_user_ids\x18\x0e \x03(\tR\x18threadParticipantUserIds\x12;\n" +
-	"\x1aviewer_is_following_thread\x18\x0f \x01(\bR\x17viewerIsFollowingThread\x12J\n" +
-	"\"viewer_is_following_thread_present\x18\x10 \x01(\bR\x1eviewerIsFollowingThreadPresent\x12H\n" +
-	"\treactions\x18\x11 \x03(\v2*.chatto.api.v1.RoomTimelineReactionSummaryR\treactions\"0\n" +
+	"\x1bthread_participant_user_ids\x18\x0e \x03(\tR\x18threadParticipantUserIds\x12@\n" +
+	"\x1aviewer_is_following_thread\x18\x0f \x01(\bH\x01R\x17viewerIsFollowingThread\x88\x01\x01\x12H\n" +
+	"\treactions\x18\x11 \x03(\v2*.chatto.api.v1.RoomTimelineReactionSummaryR\treactionsB\a\n" +
+	"\x05_bodyB\x1d\n" +
+	"\x1b_viewer_is_following_threadJ\x04\b\x03\x10\x04J\x04\b\x10\x10\x11R\fbody_presentR\"viewer_is_following_thread_present\"0\n" +
 	"\x15RoomTimelineRoomEvent\x12\x17\n" +
 	"\aroom_id\x18\x01 \x01(\tR\x06roomId\"\xf4\x05\n" +
 	"\x11RoomTimelineEvent\x12\x0e\n" +
@@ -2127,6 +2108,7 @@ func file_chatto_api_v1_room_timeline_proto_init() {
 	if File_chatto_api_v1_room_timeline_proto != nil {
 		return
 	}
+	file_chatto_api_v1_room_timeline_proto_msgTypes[8].OneofWrappers = []any{}
 	file_chatto_api_v1_room_timeline_proto_msgTypes[10].OneofWrappers = []any{
 		(*RoomTimelineEvent_MessagePosted)(nil),
 		(*RoomTimelineEvent_RoomCreated)(nil),

--- a/docs-website/src/content/docs/reference/connectrpc-api/index.mdx
+++ b/docs-website/src/content/docs/reference/connectrpc-api/index.mdx
@@ -698,8 +698,7 @@ participants, and follow state without additional per-message requests.
 | Field | Type | Description |
 | --- | --- | --- |
 | `room_id` | `string` | Room containing the message. |
-| `body` | `string` | Message body text. |
-| `body_present` | `bool` | True when the original event explicitly carried a body. This lets clients distinguish an empty body from a missing body. |
+| `body` | `optional string` | Message body text, when available. A present empty string is distinct from an absent body. |
 | `attachments` | repeated [`RoomTimelineAttachment`](#chatto-api-v1-RoomTimelineAttachment) | Attachments sent with the message. |
 | `link_preview` | [`RoomTimelineLinkPreview`](#chatto-api-v1-RoomTimelineLinkPreview) | Link preview extracted for the message, when available. |
 | `updated_at` | `google.protobuf.Timestamp` | Time when the message was last edited. |
@@ -711,8 +710,7 @@ participants, and follow state without additional per-message requests.
 | `reply_count` | `int32` | Number of replies in this message's thread. |
 | `last_reply_at` | `google.protobuf.Timestamp` | Creation time of the most recent reply in this message's thread. |
 | `thread_participant_user_ids` | `repeated string` | User IDs that have participated in this message's thread. |
-| `viewer_is_following_thread` | `bool` | True when the current user follows this message's thread. |
-| `viewer_is_following_thread_present` | `bool` | True when viewer_is_following_thread was explicitly hydrated. If false, the follow value should be treated as unknown rather than false. |
+| `viewer_is_following_thread` | `optional bool` | Whether the current user follows this message's thread, when known. |
 | `reactions` | repeated [`RoomTimelineReactionSummary`](#chatto-api-v1-RoomTimelineReactionSummary) | Reaction summaries for this message. |
 
 

--- a/frontend/src/lib/api/messages.spec.ts
+++ b/frontend/src/lib/api/messages.spec.ts
@@ -61,9 +61,7 @@ describe('createMessageAPI', () => {
 							value: new RoomTimelineMessagePosted({
 								roomId: 'room-1',
 								body: 'hello',
-								bodyPresent: true,
-								viewerIsFollowingThread: true,
-								viewerIsFollowingThreadPresent: true
+								viewerIsFollowingThread: true
 							})
 						}
 					})

--- a/frontend/src/lib/api/roomTimeline.spec.ts
+++ b/frontend/src/lib/api/roomTimeline.spec.ts
@@ -165,7 +165,6 @@ describe('roomTimelinePageToEventConnectionPage', () => {
             value: new RoomTimelineMessagePosted({
               roomId: 'room-1',
               body: 'hello',
-              bodyPresent: true,
               attachments: [
                 new RoomTimelineAttachment({
                   id: 'a-video',
@@ -209,7 +208,6 @@ describe('roomTimelinePageToEventConnectionPage', () => {
               replyCount: 1,
               threadParticipantUserIds: ['u2'],
               viewerIsFollowingThread: true,
-              viewerIsFollowingThreadPresent: true,
               reactions: [
                 {
                   emoji: 'thumbsup',

--- a/frontend/src/lib/api/roomTimeline.ts
+++ b/frontend/src/lib/api/roomTimeline.ts
@@ -205,7 +205,7 @@ function messagePostedPayload(
   return {
     __typename: 'MessagePostedEvent',
     roomId: message.roomId,
-    body: message.bodyPresent ? message.body : null,
+    body: message.body !== undefined ? message.body : null,
     attachments: message.attachments.map(attachmentView),
     linkPreview: linkPreviewView(message.linkPreview),
     updatedAt: timestampToISOOrNull(message.updatedAt),
@@ -219,9 +219,8 @@ function messagePostedPayload(
     threadParticipants: message.threadParticipantUserIds
       .map((id) => userView(id, users))
       .filter((user): user is NonNullable<ReturnType<typeof userView>> => user !== null),
-    viewerIsFollowingThread: message.viewerIsFollowingThreadPresent
-      ? message.viewerIsFollowingThread
-      : null,
+    viewerIsFollowingThread:
+      message.viewerIsFollowingThread !== undefined ? message.viewerIsFollowingThread : null,
     reactions: message.reactions.map((reaction) => ({
       __typename: 'ReactionSummary',
       emoji: reaction.emoji,

--- a/frontend/src/lib/pb/chatto/api/v1/room_timeline_pb.ts
+++ b/frontend/src/lib/pb/chatto/api/v1/room_timeline_pb.ts
@@ -671,19 +671,12 @@ export class RoomTimelineMessagePosted extends Message<RoomTimelineMessagePosted
   roomId = "";
 
   /**
-   * Message body text.
+   * Message body text, when available. A present empty string is distinct from
+   * an absent body.
    *
-   * @generated from field: string body = 2;
+   * @generated from field: optional string body = 2;
    */
-  body = "";
-
-  /**
-   * True when the original event explicitly carried a body. This lets clients
-   * distinguish an empty body from a missing body.
-   *
-   * @generated from field: bool body_present = 3;
-   */
-  bodyPresent = false;
+  body?: string;
 
   /**
    * Attachments sent with the message.
@@ -764,19 +757,11 @@ export class RoomTimelineMessagePosted extends Message<RoomTimelineMessagePosted
   threadParticipantUserIds: string[] = [];
 
   /**
-   * True when the current user follows this message's thread.
+   * Whether the current user follows this message's thread, when known.
    *
-   * @generated from field: bool viewer_is_following_thread = 15;
+   * @generated from field: optional bool viewer_is_following_thread = 15;
    */
-  viewerIsFollowingThread = false;
-
-  /**
-   * True when viewer_is_following_thread was explicitly hydrated. If false, the
-   * follow value should be treated as unknown rather than false.
-   *
-   * @generated from field: bool viewer_is_following_thread_present = 16;
-   */
-  viewerIsFollowingThreadPresent = false;
+  viewerIsFollowingThread?: boolean;
 
   /**
    * Reaction summaries for this message.
@@ -794,8 +779,7 @@ export class RoomTimelineMessagePosted extends Message<RoomTimelineMessagePosted
   static readonly typeName = "chatto.api.v1.RoomTimelineMessagePosted";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "room_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "body", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 3, name: "body_present", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 2, name: "body", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
     { no: 4, name: "attachments", kind: "message", T: RoomTimelineAttachment, repeated: true },
     { no: 5, name: "link_preview", kind: "message", T: RoomTimelineLinkPreview },
     { no: 6, name: "updated_at", kind: "message", T: Timestamp },
@@ -807,8 +791,7 @@ export class RoomTimelineMessagePosted extends Message<RoomTimelineMessagePosted
     { no: 12, name: "reply_count", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
     { no: 13, name: "last_reply_at", kind: "message", T: Timestamp },
     { no: 14, name: "thread_participant_user_ids", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
-    { no: 15, name: "viewer_is_following_thread", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
-    { no: 16, name: "viewer_is_following_thread_present", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 15, name: "viewer_is_following_thread", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
     { no: 17, name: "reactions", kind: "message", T: RoomTimelineReactionSummary, repeated: true },
   ]);
 

--- a/proto/AGENTS.md
+++ b/proto/AGENTS.md
@@ -23,3 +23,7 @@ After changing public API comments, regenerate outputs with `mise codegen-proto`
 ## Compatibility
 
 Do not renumber existing fields or change field types in messages that may already be persisted or consumed by clients. Prefer additive schema changes.
+
+## Scalar Presence
+
+For public API messages under `chatto/api/v1`, use proto3 `optional` scalar fields when clients must distinguish an absent, unhydrated, or unknown value from the scalar's default value. Avoid parallel `*_present` boolean fields for simple scalar presence; use an enum or oneof only when the API needs to model multiple availability states.

--- a/proto/chatto/api/v1/room_timeline.proto
+++ b/proto/chatto/api/v1/room_timeline.proto
@@ -155,13 +155,16 @@ message RoomTimelineReactionSummary {
 // echo entries. Thread-related fields let clients render reply counts, thread
 // participants, and follow state without additional per-message requests.
 message RoomTimelineMessagePosted {
+  reserved 3;
+  reserved 16;
+  reserved "body_present";
+  reserved "viewer_is_following_thread_present";
+
   // Room containing the message.
   string room_id = 1;
-  // Message body text.
-  string body = 2;
-  // True when the original event explicitly carried a body. This lets clients
-  // distinguish an empty body from a missing body.
-  bool body_present = 3;
+  // Message body text, when available. A present empty string is distinct from
+  // an absent body.
+  optional string body = 2;
   // Attachments sent with the message.
   repeated RoomTimelineAttachment attachments = 4;
   // Link preview extracted for the message, when available.
@@ -185,11 +188,8 @@ message RoomTimelineMessagePosted {
   google.protobuf.Timestamp last_reply_at = 13;
   // User IDs that have participated in this message's thread.
   repeated string thread_participant_user_ids = 14;
-  // True when the current user follows this message's thread.
-  bool viewer_is_following_thread = 15;
-  // True when viewer_is_following_thread was explicitly hydrated. If false, the
-  // follow value should be treated as unknown rather than false.
-  bool viewer_is_following_thread_present = 16;
+  // Whether the current user follows this message's thread, when known.
+  optional bool viewer_is_following_thread = 15;
   // Reaction summaries for this message.
   repeated RoomTimelineReactionSummary reactions = 17;
 }

--- a/proto/templates/connectrpc-starlight.md.tmpl
+++ b/proto/templates/connectrpc-starlight.md.tmpl
@@ -5,7 +5,7 @@
 | Field | Type | Description |
 | --- | --- | --- |
 {{range .Message.Fields -}}
-| `{{if .IsOneof}}{{.OneofDecl}}.{{end}}{{.Name}}` | {{template "fieldType" (dict "Field" . "Files" $.Files)}} | {{if (index .Options "deprecated"|default false)}}**Deprecated.** {{end}}{{if .Description}}{{nobr .Description}}{{else}}No field description provided.{{end}}{{if .DefaultValue}} Default: `{{.DefaultValue}}`{{end}} |
+| `{{if and .IsOneof (not (regexMatch "^_" .OneofDecl))}}{{.OneofDecl}}.{{end}}{{.Name}}` | {{template "fieldType" (dict "Field" . "Files" $.Files)}} | {{if (index .Options "deprecated"|default false)}}**Deprecated.** {{end}}{{if .Description}}{{nobr .Description}}{{else}}No field description provided.{{end}}{{if .DefaultValue}} Default: `{{.DefaultValue}}`{{end}} |
 {{end}}
 {{end}}
 {{- end -}}


### PR DESCRIPTION
## Summary

- Replace `RoomTimelineMessagePosted` companion presence booleans with proto3 `optional` fields for `body` and `viewer_is_following_thread`.
- Update ConnectRPC hydration, frontend adapters, generated protobuf bindings, and generated API reference docs.
- Add protobuf agent guidance to prefer optional scalar fields over simple `*_present` booleans for public API presence.

BREAKING CHANGE: ConnectRPC clients must read optional field presence instead of `body_present` and `viewer_is_following_thread_present`.

## Tests

- `mise codegen-proto`
- `go test ./internal/connectapi`
- `mise exec -- pnpm test:unit -- --run src/lib/api/messages.spec.ts src/lib/api/roomTimeline.spec.ts`
- `mise exec -- pnpm check`
- `git diff --check`
