### PR TITLE
docs(agents): note ConnectRPC timeline mapping

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -108,8 +108,9 @@ Room events (`live.sync.room.{kind}.{roomId}.…` plus deliverable EVT room fact
 2. Add to GraphQL schema in `events.graphqls` (type + `ServerEventType` union)
 3. Add `IsServerEventType()` method in `pb/chatto/core/v1/graphql.go`
 4. Add case in `unwrapEvent()` in `event_helpers.go`
-5. Publish via `EventPublisher` for durable EVT facts or `publishLiveEvent` for transient LiveEvent signals — choose ONE conceptual delivery path
-6. Subscribe in frontend via `eventBus.svelte.ts` (or a handler registered through `useEvent`)
+5. If the event is visible in room timelines, update the ConnectRPC room timeline proto/hydrator mapping in `cli/internal/connectapi/room_timeline.go`, and add tests so visible events cannot be silently dropped from the public timeline API.
+6. Publish via `EventPublisher` for durable EVT facts or `publishLiveEvent` for transient LiveEvent signals — choose ONE conceptual delivery path
+7. Subscribe in frontend via `eventBus.svelte.ts` (or a handler registered through `useEvent`)
 
 **When to create a live event:** Any time a user action changes state that other tabs/devices or other UI components need to reflect in real-time. Common triggers:
 - User changes a preference or setting (notification level, follow state)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ Please update this section as the project evolves, and refer to it when making d
 - Where feasible, write code comments that explain intent.
 - Make sure the code is well-tested, and that tests are easy to understand and maintain.
 - We're very likely migrating our API surface away from GraphQL to a combination of ConnectRPC and a custom wire protocol that pushes protobufs to the client. When writing new API surface, please add to the new setup, not GraphQL.
+- When adding or changing room timeline event visibility, make sure the ConnectRPC room timeline response mapping is updated too, or explicitly document why the event is hidden from the public timeline API. Add tests so visible events cannot be silently dropped by the ConnectRPC hydrator.
 - **Important:** before working on protobufs, ConnectRPC schemas, or generated API reference comments, read `proto/AGENTS.md`. Nested `AGENTS.md` files may not be loaded automatically, so this root file is the reminder.
 
 ### Specific Rules for Frontend Code


### PR DESCRIPTION
## Changes
- Adds a root agent instruction to keep ConnectRPC room timeline response mapping in sync with visible room timeline event changes.
- Extends the backend new-event checklist with the same ConnectRPC timeline hydrator/test reminder.

## Verification
- Docs-only change; no tests run.
