### PR TITLE
refactor(connectrpc): move read state authz into core services

### DIFF
--- a/.claude/rules/authorization.md
+++ b/.claude/rules/authorization.md
@@ -1,6 +1,6 @@
 # Authorization Model
 
-This document describes the authorization requirements and policies for Chatto's GraphQL API.
+This document describes the authorization requirements and policies for Chatto's public APIs and core operation services.
 
 ## Core Principles
 
@@ -13,18 +13,23 @@ This document describes the authorization requirements and policies for Chatto's
 
 ## Authorization Architecture
 
-Authorization is enforced at the **API boundary**, not in core:
+Legacy GraphQL resolvers enforce authorization at the API boundary, but new
+public transports should authenticate at the edge and pass the actor ID into a
+core operation service. That operation service owns authorization and domain
+validation before it calls lower-level core helpers.
 
 | Layer | Responsibility |
 |-------|----------------|
-| **GraphQL** | User-facing API. Checks authorization via `Can*` functions before calling core. |
-| **Core** | Pure business logic. Assumes caller is authorized. Documents requirements in comments. |
+| **GraphQL** | Legacy user-facing API. Checks authorization via `Can*` functions before calling lower-level core helpers unless it has been moved onto a shared operation service. |
+| **ConnectRPC / protobuf APIs** | User-facing API. Authenticates the request and passes the actor ID to a core operation service. |
+| **Core operation services** | User-facing operation policy. Checks authorization, validates operation-specific anchors/targets, and then calls lower-level core helpers. |
+| **Lower-level core helpers** | Durable state mechanics. Trusted/internal callers may use them directly and must satisfy the documented authorization preconditions. |
 | **NATS** | Extension/internal API. Trusted context, calls core directly. |
 
 **Why this design:**
-- Core functions are reusable from trusted contexts (NATS handlers, background jobs)
-- No redundant permission checks when core calls other core functions
-- Clear separation: GraphQL handles user authorization, core handles business logic
+- Public transports share one authorization path as GraphQL migrates to ConnectRPC
+- Trusted lower-level helpers remain reusable from NATS handlers and background jobs
+- API edges stay focused on authentication, request decoding, and response/error mapping
 - Audit logging can be added orthogonally without coupling to authorization
 
 ## Permission System

--- a/cli/internal/connectapi/api.go
+++ b/cli/internal/connectapi/api.go
@@ -1,17 +1,12 @@
 package connectapi
 
 import (
-	"context"
-	"errors"
 	"net/http"
-	"strings"
-	"time"
 
 	"connectrpc.com/connect"
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/core"
 	"hmans.de/chatto/internal/pb/chatto/api/v1/apiv1connect"
-	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
 // Prefix is the HTTP mount point for Chatto's ConnectRPC public API.
@@ -60,97 +55,4 @@ func (a *API) Handlers() []Handler {
 		{ServicePath: userStatusPath, Handler: userStatusHandler},
 		{ServicePath: threadPath, Handler: threadHandler},
 	}
-}
-
-func (a *API) requireRoomMember(ctx context.Context, roomID string) (*corev1.User, *corev1.Room, error) {
-	user, err := requireAuth(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	if strings.TrimSpace(roomID) == "" {
-		return nil, nil, connect.NewError(connect.CodeInvalidArgument, errors.New("room_id is required"))
-	}
-
-	room, err := a.core.FindRoomByID(ctx, roomID)
-	if err != nil {
-		return nil, nil, connectError(err)
-	}
-	kind := core.KindOfRoom(room)
-	ok, err := a.core.RoomMembershipExists(ctx, kind, user.Id, room.Id)
-	if err != nil {
-		return nil, nil, connectError(err)
-	}
-	if !ok {
-		return nil, nil, connectError(core.ErrNotRoomMember)
-	}
-	return user, room, nil
-}
-
-func (a *API) requireThreadRoot(ctx context.Context, room *corev1.Room, threadRootEventID string) (*corev1.Event, error) {
-	if strings.TrimSpace(threadRootEventID) == "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("thread_root_event_id is required"))
-	}
-	kind := core.KindOfRoom(room)
-	event, err := a.core.GetRoomEventByEventID(ctx, kind, room.Id, threadRootEventID)
-	if err != nil {
-		return nil, connectError(err)
-	}
-	if event == nil {
-		return nil, connect.NewError(connect.CodeNotFound, errors.New("thread root event not found"))
-	}
-	message := event.GetMessagePosted()
-	if message == nil || message.GetInThread() != "" || message.GetEchoOfEventId() != "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("thread_root_event_id must identify a root message"))
-	}
-	return event, nil
-}
-
-func (a *API) roomReadAnchor(ctx context.Context, room *corev1.Room, eventID string) (eventIDOut string, ts time.Time, found bool, err error) {
-	if strings.TrimSpace(eventID) == "" {
-		return "", time.Time{}, false, nil
-	}
-	kind := core.KindOfRoom(room)
-	event, err := a.core.GetRoomEventByEventID(ctx, kind, room.Id, eventID)
-	if err != nil {
-		return "", time.Time{}, false, connectError(err)
-	}
-	if event == nil {
-		return "", time.Time{}, false, connect.NewError(connect.CodeNotFound, errors.New("up_to_event_id event not found"))
-	}
-	message := event.GetMessagePosted()
-	if message == nil || message.GetInThread() != "" || message.GetEchoOfEventId() != "" {
-		return "", time.Time{}, false, connect.NewError(connect.CodeInvalidArgument, errors.New("up_to_event_id must identify a root message in the room timeline"))
-	}
-	if createdAt := event.GetCreatedAt(); createdAt != nil {
-		return event.Id, createdAt.AsTime(), true, nil
-	}
-	return event.Id, time.Time{}, true, nil
-}
-
-func (a *API) threadReadAnchor(ctx context.Context, room *corev1.Room, threadRootEventID string, eventID string) (string, error) {
-	if strings.TrimSpace(eventID) == "" {
-		return "", nil
-	}
-	kind := core.KindOfRoom(room)
-	event, err := a.core.GetRoomEventByEventID(ctx, kind, room.Id, eventID)
-	if err != nil {
-		return "", connectError(err)
-	}
-	if event == nil {
-		return "", nil
-	}
-	message := event.GetMessagePosted()
-	if message == nil {
-		return "", connect.NewError(connect.CodeInvalidArgument, errors.New("up_to_event_id must identify a message in the thread"))
-	}
-	if event.Id == threadRootEventID {
-		if message.GetInThread() == "" && message.GetEchoOfEventId() == "" {
-			return event.Id, nil
-		}
-		return "", connect.NewError(connect.CodeInvalidArgument, errors.New("up_to_event_id must identify a message in the thread"))
-	}
-	if message.GetInThread() != threadRootEventID {
-		return "", connect.NewError(connect.CodeInvalidArgument, errors.New("up_to_event_id must identify a message in the thread"))
-	}
-	return event.Id, nil
 }

--- a/cli/internal/connectapi/messages.go
+++ b/cli/internal/connectapi/messages.go
@@ -3,7 +3,6 @@ package connectapi
 import (
 	"context"
 	"errors"
-	"strings"
 
 	"connectrpc.com/connect"
 	"hmans.de/chatto/internal/core"
@@ -19,15 +18,6 @@ func (s *messageService) PostMessage(ctx context.Context, req *connect.Request[a
 	user, err := requireAuth(ctx)
 	if err != nil {
 		return nil, err
-	}
-	if strings.TrimSpace(req.Msg.RoomId) == "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("room_id is required"))
-	}
-	if !core.HasVisibleContent(req.Msg.Body) && len(req.Msg.AttachmentAssetIds) == 0 {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("message must have either body or attachments"))
-	}
-	if req.Msg.AlsoSendToChannel && strings.TrimSpace(req.Msg.ThreadRootEventId) == "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("also_send_to_channel requires thread_root_event_id"))
 	}
 
 	result, err := s.api.core.Messages().PostMessage(ctx, core.MessagePostInput{

--- a/cli/internal/connectapi/read_state.go
+++ b/cli/internal/connectapi/read_state.go
@@ -2,11 +2,9 @@ package connectapi
 
 import (
 	"context"
-	"time"
 
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/types/known/timestamppb"
-	"hmans.de/chatto/internal/core"
 	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
 )
 
@@ -15,103 +13,38 @@ type readStateService struct {
 }
 
 func (s *readStateService) MarkRoomAsRead(ctx context.Context, req *connect.Request[apiv1.MarkRoomAsReadRequest]) (*connect.Response[apiv1.MarkRoomAsReadResponse], error) {
-	user, room, err := s.api.requireRoomMember(ctx, req.Msg.RoomId)
+	user, err := requireAuth(ctx)
 	if err != nil {
 		return nil, err
 	}
-	kind := core.KindOfRoom(room)
-
-	var (
-		lastEventID string
-		lastTime    time.Time
-		hasLast     bool
-	)
-	if req.Msg.UpToEventId != "" {
-		targetEventID, targetTime, found, terr := s.api.roomReadAnchor(ctx, room, req.Msg.UpToEventId)
-		if terr != nil {
-			return nil, terr
-		}
-		if found && !targetTime.IsZero() {
-			lastEventID = targetEventID
-			lastTime = targetTime
-			hasLast = true
-		}
-	}
-	if !hasLast {
-		lastEventID, lastTime, hasLast, err = s.api.core.GetRoomLastEvent(ctx, kind, room.Id)
-		if err != nil {
-			return nil, connectError(err)
-		}
-	}
-
-	previousEventID, _, err := s.api.core.PeekLastReadEventID(ctx, user.Id, room.Id)
+	result, err := s.api.core.ReadState().MarkRoomAsRead(ctx, user.Id, req.Msg.RoomId, req.Msg.UpToEventId)
 	if err != nil {
 		return nil, connectError(err)
 	}
 
-	if hasLast {
-		advance, err := s.api.core.AdvanceLastReadEventID(ctx, kind, user.Id, room.Id, lastEventID)
-		if err != nil {
-			return nil, connectError(err)
-		}
-		if advance.CurrentEventID != "" {
-			lastEventID = advance.CurrentEventID
-			lastTime = advance.CurrentTime
-		}
-	}
-
-	s.api.core.NotifyRoomMarkedAsRead(ctx, user.Id, kind, room.Id)
-
 	resp := &apiv1.MarkRoomAsReadResponse{}
-	if hasLast && !lastTime.IsZero() {
-		resp.LastReadAt = timestamppb.New(lastTime)
+	if !result.LastReadAt.IsZero() {
+		resp.LastReadAt = timestamppb.New(result.LastReadAt)
 	}
-	if previousEventID != "" {
-		if t, err := s.api.core.GetEventTimestamp(ctx, kind, room.Id, previousEventID); err == nil && !t.IsZero() {
-			resp.PreviousLastReadAt = timestamppb.New(t)
-		}
+	if !result.PreviousLastReadAt.IsZero() {
+		resp.PreviousLastReadAt = timestamppb.New(result.PreviousLastReadAt)
 	}
 	return connect.NewResponse(resp), nil
 }
 
 func (s *readStateService) MarkThreadAsRead(ctx context.Context, req *connect.Request[apiv1.MarkThreadAsReadRequest]) (*connect.Response[apiv1.MarkThreadAsReadResponse], error) {
-	user, room, err := s.api.requireRoomMember(ctx, req.Msg.RoomId)
+	user, err := requireAuth(ctx)
 	if err != nil {
 		return nil, err
 	}
-	kind := core.KindOfRoom(room)
-	if _, err := s.api.requireThreadRoot(ctx, room, req.Msg.ThreadRootEventId); err != nil {
-		return nil, err
-	}
-
-	markerEventID := ""
-	if req.Msg.UpToEventId != "" {
-		eventID, eerr := s.api.threadReadAnchor(ctx, room, req.Msg.ThreadRootEventId, req.Msg.UpToEventId)
-		if eerr != nil {
-			return nil, eerr
-		}
-		markerEventID = eventID
-	} else {
-		events, eerr := s.api.core.GetThreadEvents(ctx, kind, room.Id, req.Msg.ThreadRootEventId)
-		if eerr != nil {
-			return nil, connectError(eerr)
-		}
-		for i := len(events) - 1; i >= 0; i-- {
-			if events[i] != nil && events[i].GetMessagePosted() != nil {
-				markerEventID = events[i].Id
-				break
-			}
-		}
-	}
-
-	previousReadAt, err := s.api.core.SetThreadLastReadEventID(ctx, kind, user.Id, room.Id, req.Msg.ThreadRootEventId, markerEventID)
+	result, err := s.api.core.ReadState().MarkThreadAsRead(ctx, user.Id, req.Msg.RoomId, req.Msg.ThreadRootEventId, req.Msg.UpToEventId)
 	if err != nil {
 		return nil, connectError(err)
 	}
 
 	resp := &apiv1.MarkThreadAsReadResponse{}
-	if !previousReadAt.IsZero() {
-		resp.PreviousReadAt = timestamppb.New(previousReadAt)
+	if !result.PreviousReadAt.IsZero() {
+		resp.PreviousReadAt = timestamppb.New(result.PreviousReadAt)
 	}
 	return connect.NewResponse(resp), nil
 }

--- a/cli/internal/connectapi/threads.go
+++ b/cli/internal/connectapi/threads.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"connectrpc.com/connect"
-	"hmans.de/chatto/internal/core"
 	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
 )
 
@@ -13,32 +12,24 @@ type threadService struct {
 }
 
 func (s *threadService) FollowThread(ctx context.Context, req *connect.Request[apiv1.FollowThreadRequest]) (*connect.Response[apiv1.FollowThreadResponse], error) {
-	user, room, err := s.api.requireRoomMember(ctx, req.Msg.RoomId)
+	user, err := requireAuth(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if _, err := s.api.requireThreadRoot(ctx, room, req.Msg.ThreadRootEventId); err != nil {
-		return nil, err
-	}
-	kind := core.KindOfRoom(room)
 
-	if err := s.api.core.FollowThread(ctx, kind, user.Id, room.Id, req.Msg.ThreadRootEventId); err != nil {
+	if err := s.api.core.ThreadFollows().FollowThread(ctx, user.Id, req.Msg.RoomId, req.Msg.ThreadRootEventId); err != nil {
 		return nil, connectError(err)
 	}
 	return connect.NewResponse(&apiv1.FollowThreadResponse{Following: true}), nil
 }
 
 func (s *threadService) UnfollowThread(ctx context.Context, req *connect.Request[apiv1.UnfollowThreadRequest]) (*connect.Response[apiv1.UnfollowThreadResponse], error) {
-	user, room, err := s.api.requireRoomMember(ctx, req.Msg.RoomId)
+	user, err := requireAuth(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if _, err := s.api.requireThreadRoot(ctx, room, req.Msg.ThreadRootEventId); err != nil {
-		return nil, err
-	}
-	kind := core.KindOfRoom(room)
 
-	if err := s.api.core.UnfollowThread(ctx, kind, user.Id, room.Id, req.Msg.ThreadRootEventId); err != nil {
+	if err := s.api.core.ThreadFollows().UnfollowThread(ctx, user.Id, req.Msg.RoomId, req.Msg.ThreadRootEventId); err != nil {
 		return nil, connectError(err)
 	}
 	return connect.NewResponse(&apiv1.UnfollowThreadResponse{Following: false}), nil

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -43,6 +43,8 @@ type ChattoCore struct {
 	roomService        *RoomService
 	messageService     *MessageService
 	notificationPrefs  *NotificationPreferencesService
+	readStateService   *ReadStateService
+	threadFollows      *ThreadFollowService
 	userService        *UserService
 	rbacService        *RBACService
 	mentionables       *MentionablesService
@@ -1029,6 +1031,8 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	core.assetService = NewAssetService(core)
 	core.messageService = &MessageService{core: core}
 	core.notificationPrefs = &NotificationPreferencesService{core: core}
+	core.readStateService = &ReadStateService{core: core}
+	core.threadFollows = &ThreadFollowService{core: core}
 
 	if err := core.seedDefaultRBAC(ctx); err != nil {
 		return nil, fmt.Errorf("failed to seed default RBAC: %w", err)

--- a/cli/internal/core/core_test.go
+++ b/cli/internal/core/core_test.go
@@ -86,11 +86,17 @@ func startCoreServices(t *testing.T, core *ChattoCore) {
 	}
 }
 
-func TestNewChattoCoreInitializesNotificationPreferencesService(t *testing.T) {
+func TestNewChattoCoreInitializesOperationServices(t *testing.T) {
 	core, _ := setupTestCore(t)
 
 	if core.NotificationPreferences() == nil {
 		t.Fatal("NotificationPreferences() = nil")
+	}
+	if core.ReadState() == nil {
+		t.Fatal("ReadState() = nil")
+	}
+	if core.ThreadFollows() == nil {
+		t.Fatal("ThreadFollows() = nil")
 	}
 }
 

--- a/cli/internal/core/message_service.go
+++ b/cli/internal/core/message_service.go
@@ -59,6 +59,12 @@ func (s *MessageService) PostMessage(ctx context.Context, input MessagePostInput
 	if strings.TrimSpace(input.RoomID) == "" {
 		return nil, invalidArgument("room_id is required")
 	}
+	if !HasVisibleContent(input.Body) && len(input.AttachmentAssetIDs) == 0 {
+		return nil, invalidArgument("message must have either body or attachments")
+	}
+	if input.AlsoSendToChannel && strings.TrimSpace(input.ThreadRootEventID) == "" {
+		return nil, invalidArgument("also_send_to_channel requires thread_root_event_id")
+	}
 
 	room, err := s.core.FindRoomByID(ctx, input.RoomID)
 	if err != nil {

--- a/cli/internal/core/operation_auth.go
+++ b/cli/internal/core/operation_auth.go
@@ -1,0 +1,57 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+func requireAuthenticatedActor(actorID string) error {
+	if strings.TrimSpace(actorID) == "" {
+		return ErrNotAuthenticated
+	}
+	return nil
+}
+
+func (c *ChattoCore) requireRoomMember(ctx context.Context, actorID, roomID string) (*corev1.Room, RoomKind, error) {
+	if err := requireAuthenticatedActor(actorID); err != nil {
+		return nil, KindChannel, err
+	}
+	if strings.TrimSpace(roomID) == "" {
+		return nil, KindChannel, invalidArgument("room_id is required")
+	}
+
+	room, err := c.FindRoomByID(ctx, roomID)
+	if err != nil {
+		return nil, KindChannel, err
+	}
+	kind := KindOfRoom(room)
+	isMember, err := c.RoomMembershipExists(ctx, kind, actorID, room.Id)
+	if err != nil {
+		return nil, KindChannel, err
+	}
+	if !isMember {
+		return nil, KindChannel, ErrNotRoomMember
+	}
+	return room, kind, nil
+}
+
+func (c *ChattoCore) requireThreadRoot(ctx context.Context, kind RoomKind, roomID, threadRootEventID string) (*corev1.Event, error) {
+	if strings.TrimSpace(threadRootEventID) == "" {
+		return nil, invalidArgument("thread_root_event_id is required")
+	}
+	event, err := c.GetRoomEventByEventID(ctx, kind, roomID, threadRootEventID)
+	if err != nil {
+		return nil, err
+	}
+	if event == nil {
+		return nil, fmt.Errorf("thread root event not found: %w", ErrNotFound)
+	}
+	message := event.GetMessagePosted()
+	if message == nil || message.GetInThread() != "" || message.GetEchoOfEventId() != "" {
+		return nil, invalidArgument("thread_root_event_id must identify a root message")
+	}
+	return event, nil
+}

--- a/cli/internal/core/read_state_service.go
+++ b/cli/internal/core/read_state_service.go
@@ -1,0 +1,178 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// MarkRoomAsReadResult describes the timestamp response for a room-level read
+// marker update.
+type MarkRoomAsReadResult struct {
+	LastReadAt         time.Time
+	PreviousLastReadAt time.Time
+}
+
+// MarkThreadAsReadResult describes the timestamp response for a thread-level
+// read marker update.
+type MarkThreadAsReadResult struct {
+	PreviousReadAt time.Time
+}
+
+// ReadState returns the operation-level service for user-facing read marker
+// updates. Public transports should authenticate at the edge, pass the actor
+// ID here, and let this service own membership checks and anchor validation.
+func (c *ChattoCore) ReadState() *ReadStateService {
+	return c.readStateService
+}
+
+// ReadStateService owns user-facing read marker mutations. Lower-level marker
+// helpers stay available for trusted/internal callers, while this service keeps
+// public API authorization and anchor semantics in one place.
+type ReadStateService struct {
+	core *ChattoCore
+}
+
+func (s *ReadStateService) MarkRoomAsRead(ctx context.Context, actorID, roomID, upToEventID string) (*MarkRoomAsReadResult, error) {
+	room, kind, err := s.core.requireRoomMember(ctx, actorID, roomID)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		lastEventID string
+		lastTime    time.Time
+		hasLast     bool
+	)
+	if strings.TrimSpace(upToEventID) != "" {
+		targetEventID, targetTime, found, err := s.roomReadAnchor(ctx, kind, room.Id, upToEventID)
+		if err != nil {
+			return nil, err
+		}
+		if found && !targetTime.IsZero() {
+			lastEventID = targetEventID
+			lastTime = targetTime
+			hasLast = true
+		}
+	}
+	if !hasLast {
+		lastEventID, lastTime, hasLast, err = s.core.GetRoomLastEvent(ctx, kind, room.Id)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	previousEventID, _, err := s.core.PeekLastReadEventID(ctx, actorID, room.Id)
+	if err != nil {
+		return nil, err
+	}
+
+	if hasLast {
+		advance, err := s.core.AdvanceLastReadEventID(ctx, kind, actorID, room.Id, lastEventID)
+		if err != nil {
+			return nil, err
+		}
+		if advance.CurrentEventID != "" {
+			lastEventID = advance.CurrentEventID
+			lastTime = advance.CurrentTime
+		}
+	}
+
+	s.core.NotifyRoomMarkedAsRead(ctx, actorID, kind, room.Id)
+
+	result := &MarkRoomAsReadResult{}
+	if hasLast && !lastTime.IsZero() {
+		result.LastReadAt = lastTime
+	}
+	if previousEventID != "" {
+		if previousTime, err := s.core.GetEventTimestamp(ctx, kind, room.Id, previousEventID); err == nil && !previousTime.IsZero() {
+			result.PreviousLastReadAt = previousTime
+		}
+	}
+	return result, nil
+}
+
+func (s *ReadStateService) MarkThreadAsRead(ctx context.Context, actorID, roomID, threadRootEventID, upToEventID string) (*MarkThreadAsReadResult, error) {
+	room, kind, err := s.core.requireRoomMember(ctx, actorID, roomID)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := s.core.requireThreadRoot(ctx, kind, room.Id, threadRootEventID); err != nil {
+		return nil, err
+	}
+
+	markerEventID := ""
+	if strings.TrimSpace(upToEventID) != "" {
+		eventID, err := s.threadReadAnchor(ctx, kind, room.Id, threadRootEventID, upToEventID)
+		if err != nil {
+			return nil, err
+		}
+		markerEventID = eventID
+	} else {
+		events, err := s.core.GetThreadEvents(ctx, kind, room.Id, threadRootEventID)
+		if err != nil {
+			return nil, err
+		}
+		for i := len(events) - 1; i >= 0; i-- {
+			if events[i] != nil && events[i].GetMessagePosted() != nil {
+				markerEventID = events[i].Id
+				break
+			}
+		}
+	}
+
+	previousReadAt, err := s.core.SetThreadLastReadEventID(ctx, kind, actorID, room.Id, threadRootEventID, markerEventID)
+	if err != nil {
+		return nil, err
+	}
+	return &MarkThreadAsReadResult{PreviousReadAt: previousReadAt}, nil
+}
+
+func (s *ReadStateService) roomReadAnchor(ctx context.Context, kind RoomKind, roomID, eventID string) (eventIDOut string, ts time.Time, found bool, err error) {
+	if strings.TrimSpace(eventID) == "" {
+		return "", time.Time{}, false, nil
+	}
+	event, err := s.core.GetRoomEventByEventID(ctx, kind, roomID, eventID)
+	if err != nil {
+		return "", time.Time{}, false, err
+	}
+	if event == nil {
+		return "", time.Time{}, false, fmt.Errorf("up_to_event_id event not found: %w", ErrNotFound)
+	}
+	message := event.GetMessagePosted()
+	if message == nil || message.GetInThread() != "" || message.GetEchoOfEventId() != "" {
+		return "", time.Time{}, false, invalidArgument("up_to_event_id must identify a root message in the room timeline")
+	}
+	if createdAt := event.GetCreatedAt(); createdAt != nil {
+		return event.Id, createdAt.AsTime(), true, nil
+	}
+	return event.Id, time.Time{}, true, nil
+}
+
+func (s *ReadStateService) threadReadAnchor(ctx context.Context, kind RoomKind, roomID, threadRootEventID, eventID string) (string, error) {
+	if strings.TrimSpace(eventID) == "" {
+		return "", nil
+	}
+	event, err := s.core.GetRoomEventByEventID(ctx, kind, roomID, eventID)
+	if err != nil {
+		return "", err
+	}
+	if event == nil {
+		return "", nil
+	}
+	message := event.GetMessagePosted()
+	if message == nil {
+		return "", invalidArgument("up_to_event_id must identify a message in the thread")
+	}
+	if event.Id == threadRootEventID {
+		if message.GetInThread() == "" && message.GetEchoOfEventId() == "" {
+			return event.Id, nil
+		}
+		return "", invalidArgument("up_to_event_id must identify a message in the thread")
+	}
+	if message.GetInThread() != threadRootEventID {
+		return "", invalidArgument("up_to_event_id must identify a message in the thread")
+	}
+	return event.Id, nil
+}

--- a/cli/internal/core/thread_follow_service.go
+++ b/cli/internal/core/thread_follow_service.go
@@ -1,0 +1,38 @@
+package core
+
+import "context"
+
+// ThreadFollows returns the operation-level service for user-facing thread
+// follow state changes.
+func (c *ChattoCore) ThreadFollows() *ThreadFollowService {
+	return c.threadFollows
+}
+
+// ThreadFollowService owns public thread follow/unfollow mutations. It keeps
+// membership and thread-root validation alongside the operation, while the
+// lower-level KV helpers remain available for trusted/internal call sites.
+type ThreadFollowService struct {
+	core *ChattoCore
+}
+
+func (s *ThreadFollowService) FollowThread(ctx context.Context, actorID, roomID, threadRootEventID string) error {
+	room, kind, err := s.core.requireRoomMember(ctx, actorID, roomID)
+	if err != nil {
+		return err
+	}
+	if _, err := s.core.requireThreadRoot(ctx, kind, room.Id, threadRootEventID); err != nil {
+		return err
+	}
+	return s.core.FollowThread(ctx, kind, actorID, room.Id, threadRootEventID)
+}
+
+func (s *ThreadFollowService) UnfollowThread(ctx context.Context, actorID, roomID, threadRootEventID string) error {
+	room, kind, err := s.core.requireRoomMember(ctx, actorID, roomID)
+	if err != nil {
+		return err
+	}
+	if _, err := s.core.requireThreadRoot(ctx, kind, room.Id, threadRootEventID); err != nil {
+		return err
+	}
+	return s.core.UnfollowThread(ctx, kind, actorID, room.Id, threadRootEventID)
+}


### PR DESCRIPTION
## Summary
- move ConnectRPC read-state and thread-follow authorization/domain validation into core operation services that accept an actor ID
- keep ConnectRPC handlers focused on authentication, request mapping, response shaping, and Connect error translation
- move remaining ConnectRPC message-post validation into `MessageService`
- update the authorization agent rule to distinguish legacy GraphQL boundary authZ from the new ConnectRPC/core-operation pattern

## Tests
- `mise x -- go test ./internal/connectapi -run 'Test(ReadStateService|ThreadService|MessageService|PostMessage)' -count=1`
- `mise x -- go test ./internal/core -run 'TestNewChattoCoreInitializesOperationServices|TestChattoCore_ThreadFollow|Test.*Read|Test.*Message' -count=1`
- `mise x -- go test ./internal/core ./internal/connectapi -count=1`
- `git diff --check`
