### PR TITLE
refactor(connectrpc): move timeline read authz into core

### DIFF
--- a/cli/internal/connectapi/room_timeline.go
+++ b/cli/internal/connectapi/room_timeline.go
@@ -21,34 +21,38 @@ type roomTimelineService struct {
 }
 
 func (s *roomTimelineService) GetRoomEvents(ctx context.Context, req *connect.Request[apiv1.GetRoomEventsRequest]) (*connect.Response[apiv1.GetRoomEventsResponse], error) {
-	user, room, err := s.requireRoomMember(ctx, req.Msg.RoomId)
+	user, err := requireAuth(ctx)
 	if err != nil {
 		return nil, err
 	}
-	kind := core.KindOfRoom(room)
 
-	var page *core.RoomEventsResult
+	input := core.RoomTimelineEventsInput{
+		ActorID: user.Id,
+		RoomID:  req.Msg.RoomId,
+		Limit:   int(req.Msg.Limit),
+	}
 	switch cursor := req.Msg.Cursor.(type) {
 	case *apiv1.GetRoomEventsRequest_After:
 		seq, err := parseRoomTimelineCursor(cursor.After)
 		if err != nil {
 			return nil, err
 		}
-		page, err = s.api.core.GetRoomEventsAfter(ctx, kind, room.Id, seq, int(req.Msg.Limit))
+		input.AfterSeq = &seq
 	case *apiv1.GetRoomEventsRequest_Before:
 		seq, err := parseRoomTimelineCursor(cursor.Before)
 		if err != nil {
 			return nil, err
 		}
-		page, err = s.api.core.GetRoomEvents(ctx, kind, room.Id, int(req.Msg.Limit), &seq)
-	default:
-		page, err = s.api.core.GetRoomEvents(ctx, kind, room.Id, int(req.Msg.Limit), nil)
+		input.BeforeSeq = &seq
 	}
+
+	result, err := s.api.core.RoomTimelineReads().GetRoomEvents(ctx, input)
 	if err != nil {
 		return nil, connectError(err)
 	}
 
-	resp, err := s.buildPage(ctx, user.Id, kind, page.Events, page.HasOlder, page.HasNewer)
+	page := result.Page
+	resp, err := s.buildPage(ctx, user.Id, result.Kind, page.Events, page.HasOlder, page.HasNewer)
 	if err != nil {
 		return nil, connectError(err)
 	}
@@ -58,70 +62,63 @@ func (s *roomTimelineService) GetRoomEvents(ctx context.Context, req *connect.Re
 }
 
 func (s *roomTimelineService) GetRoomEventsAround(ctx context.Context, req *connect.Request[apiv1.GetRoomEventsAroundRequest]) (*connect.Response[apiv1.GetRoomEventsAroundResponse], error) {
-	user, room, err := s.requireRoomMember(ctx, req.Msg.RoomId)
+	user, err := requireAuth(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if strings.TrimSpace(req.Msg.EventId) == "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("event_id is required"))
-	}
-	kind := core.KindOfRoom(room)
-
-	result, err := s.api.core.GetRoomEventsAround(ctx, kind, room.Id, req.Msg.EventId, int(req.Msg.Limit))
+	result, err := s.api.core.RoomTimelineReads().GetRoomEventsAround(ctx, user.Id, req.Msg.RoomId, req.Msg.EventId, int(req.Msg.Limit))
 	if err != nil {
 		return nil, connectError(err)
 	}
-	page, err := s.buildPage(ctx, user.Id, kind, result.Events, result.HasOlder, result.HasNewer)
+	around := result.Result
+	page, err := s.buildPage(ctx, user.Id, result.Kind, around.Events, around.HasOlder, around.HasNewer)
 	if err != nil {
 		return nil, connectError(err)
 	}
-	if len(result.Events) > 0 {
-		page.StartCursor = formatRoomTimelineCursor(result.Events[0].Sequence)
-		page.EndCursor = formatRoomTimelineCursor(result.Events[len(result.Events)-1].Sequence)
+	if len(around.Events) > 0 {
+		page.StartCursor = formatRoomTimelineCursor(around.Events[0].Sequence)
+		page.EndCursor = formatRoomTimelineCursor(around.Events[len(around.Events)-1].Sequence)
 	}
 
 	return connect.NewResponse(&apiv1.GetRoomEventsAroundResponse{
 		Page:        page,
-		TargetIndex: int32(result.TargetIndex),
+		TargetIndex: int32(around.TargetIndex),
 	}), nil
 }
 
 func (s *roomTimelineService) GetThreadEvents(ctx context.Context, req *connect.Request[apiv1.GetThreadEventsRequest]) (*connect.Response[apiv1.GetThreadEventsResponse], error) {
-	user, room, err := s.requireRoomMember(ctx, req.Msg.RoomId)
+	user, err := requireAuth(ctx)
 	if err != nil {
 		return nil, err
 	}
-	root, err := s.threadRootEvent(ctx, room, req.Msg.ThreadRootEventId)
-	if err != nil {
-		return nil, err
-	}
-	kind := core.KindOfRoom(room)
 
-	var replies *core.RoomEventsResult
-	includeRoot := true
+	input := core.ThreadTimelineEventsInput{
+		ActorID:           user.Id,
+		RoomID:            req.Msg.RoomId,
+		ThreadRootEventID: req.Msg.ThreadRootEventId,
+		Limit:             int(req.Msg.Limit),
+	}
 	switch cursor := req.Msg.Cursor.(type) {
 	case *apiv1.GetThreadEventsRequest_After:
-		includeRoot = false
 		seq, err := parseRoomTimelineCursor(cursor.After)
 		if err != nil {
 			return nil, err
 		}
-		replies, err = s.api.core.GetThreadReplyEvents(ctx, kind, room.Id, root.Event.Id, int(req.Msg.Limit), nil, &seq)
+		input.AfterSeq = &seq
 	case *apiv1.GetThreadEventsRequest_Before:
-		includeRoot = false
 		seq, err := parseRoomTimelineCursor(cursor.Before)
 		if err != nil {
 			return nil, err
 		}
-		replies, err = s.api.core.GetThreadReplyEvents(ctx, kind, room.Id, root.Event.Id, int(req.Msg.Limit), &seq, nil)
-	default:
-		replies, err = s.api.core.GetThreadReplyEvents(ctx, kind, room.Id, root.Event.Id, int(req.Msg.Limit), nil, nil)
+		input.BeforeSeq = &seq
 	}
+
+	result, err := s.api.core.RoomTimelineReads().GetThreadEvents(ctx, input)
 	if err != nil {
 		return nil, connectError(err)
 	}
 
-	page, err := s.buildThreadPage(ctx, user.Id, kind, root, replies, includeRoot)
+	page, err := s.buildThreadPage(ctx, user.Id, result.Kind, result.Root, result.Replies, result.IncludeRoot)
 	if err != nil {
 		return nil, connectError(err)
 	}
@@ -129,79 +126,23 @@ func (s *roomTimelineService) GetThreadEvents(ctx context.Context, req *connect.
 }
 
 func (s *roomTimelineService) GetThreadEventsAround(ctx context.Context, req *connect.Request[apiv1.GetThreadEventsAroundRequest]) (*connect.Response[apiv1.GetThreadEventsAroundResponse], error) {
-	user, room, err := s.requireRoomMember(ctx, req.Msg.RoomId)
+	user, err := requireAuth(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if strings.TrimSpace(req.Msg.EventId) == "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("event_id is required"))
-	}
-	root, err := s.threadRootEvent(ctx, room, req.Msg.ThreadRootEventId)
-	if err != nil {
-		return nil, err
-	}
-	kind := core.KindOfRoom(room)
-
-	replies, err := s.api.core.GetThreadReplyEventsAround(ctx, kind, room.Id, root.Event.Id, req.Msg.EventId, int(req.Msg.Limit))
+	result, err := s.api.core.RoomTimelineReads().GetThreadEventsAround(ctx, user.Id, req.Msg.RoomId, req.Msg.ThreadRootEventId, req.Msg.EventId, int(req.Msg.Limit))
 	if err != nil {
 		return nil, connectError(err)
 	}
-	page, err := s.buildThreadPage(ctx, user.Id, kind, root, replies, true)
+	page, err := s.buildThreadPage(ctx, user.Id, result.Kind, result.Root, result.Replies, true)
 	if err != nil {
 		return nil, connectError(err)
 	}
 
 	return connect.NewResponse(&apiv1.GetThreadEventsAroundResponse{
 		Page:        page,
-		TargetIndex: threadPageTargetIndex(root.Event.Id, req.Msg.EventId, replies.Events),
+		TargetIndex: int32(result.TargetIndex),
 	}), nil
-}
-
-func (s *roomTimelineService) requireRoomMember(ctx context.Context, roomID string) (*corev1.User, *corev1.Room, error) {
-	user, err := requireAuth(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	if strings.TrimSpace(roomID) == "" {
-		return nil, nil, connect.NewError(connect.CodeInvalidArgument, errors.New("room_id is required"))
-	}
-
-	room, err := s.api.core.FindRoomByID(ctx, roomID)
-	if err != nil {
-		return nil, nil, connectError(err)
-	}
-	kind := core.KindOfRoom(room)
-	ok, err := s.api.core.RoomMembershipExists(ctx, kind, user.Id, room.Id)
-	if err != nil {
-		return nil, nil, connectError(err)
-	}
-	if !ok {
-		return nil, nil, connectError(core.ErrNotRoomMember)
-	}
-	return user, room, nil
-}
-
-func (s *roomTimelineService) threadRootEvent(ctx context.Context, room *corev1.Room, threadRootEventID string) (*core.RoomEvent, error) {
-	if strings.TrimSpace(threadRootEventID) == "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("thread_root_event_id is required"))
-	}
-	kind := core.KindOfRoom(room)
-	event, err := s.api.core.GetRoomEventByEventID(ctx, kind, room.Id, threadRootEventID)
-	if err != nil {
-		return nil, connectError(err)
-	}
-	if event == nil {
-		return nil, connect.NewError(connect.CodeNotFound, errors.New("thread root event not found"))
-	}
-	message := event.GetMessagePosted()
-	if message == nil || message.GetInThread() != "" || message.GetEchoOfEventId() != "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("thread_root_event_id must identify a root message"))
-	}
-	seq, err := s.api.core.GetEventSequence(ctx, kind, room.Id, threadRootEventID)
-	if err != nil {
-		return nil, connectError(err)
-	}
-	return &core.RoomEvent{Event: event, Sequence: seq}, nil
 }
 
 // buildPage turns projected room timeline entries into the public Connect view.
@@ -268,18 +209,6 @@ func (s *roomTimelineService) buildThreadPage(ctx context.Context, viewerID stri
 	page.StartCursor = formatRoomTimelineCursor(replies.StartCursorSeq)
 	page.EndCursor = formatRoomTimelineCursor(replies.EndCursorSeq)
 	return page, nil
-}
-
-func threadPageTargetIndex(rootEventID, targetEventID string, replies []*core.RoomEvent) int32 {
-	if targetEventID == rootEventID {
-		return 0
-	}
-	for i, event := range replies {
-		if event != nil && event.Event != nil && event.Event.Id == targetEventID {
-			return int32(i + 1)
-		}
-	}
-	return 0
 }
 
 type timelineHydrator struct {

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -43,6 +43,7 @@ type ChattoCore struct {
 	roomService        *RoomService
 	messageService     *MessageService
 	notificationPrefs  *NotificationPreferencesService
+	roomTimelineReads  *RoomTimelineReadService
 	readStateService   *ReadStateService
 	threadFollows      *ThreadFollowService
 	userService        *UserService
@@ -1031,6 +1032,7 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	core.assetService = NewAssetService(core)
 	core.messageService = &MessageService{core: core}
 	core.notificationPrefs = &NotificationPreferencesService{core: core}
+	core.roomTimelineReads = &RoomTimelineReadService{core: core}
 	core.readStateService = &ReadStateService{core: core}
 	core.threadFollows = &ThreadFollowService{core: core}
 

--- a/cli/internal/core/core_test.go
+++ b/cli/internal/core/core_test.go
@@ -92,6 +92,9 @@ func TestNewChattoCoreInitializesOperationServices(t *testing.T) {
 	if core.NotificationPreferences() == nil {
 		t.Fatal("NotificationPreferences() = nil")
 	}
+	if core.RoomTimelineReads() == nil {
+		t.Fatal("RoomTimelineReads() = nil")
+	}
 	if core.ReadState() == nil {
 		t.Fatal("ReadState() = nil")
 	}

--- a/cli/internal/core/room_timeline_read_service.go
+++ b/cli/internal/core/room_timeline_read_service.go
@@ -1,0 +1,183 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// RoomTimelineReads returns the operation-level service for user-facing room
+// and thread timeline reads.
+func (c *ChattoCore) RoomTimelineReads() *RoomTimelineReadService {
+	return c.roomTimelineReads
+}
+
+// RoomTimelineReadService owns public timeline read authorization and target
+// validation. It returns core event pages; transports remain responsible for
+// cursor encoding and public DTO hydration.
+type RoomTimelineReadService struct {
+	core *ChattoCore
+}
+
+type RoomTimelineEventsInput struct {
+	ActorID   string
+	RoomID    string
+	Limit     int
+	BeforeSeq *uint64
+	AfterSeq  *uint64
+}
+
+type RoomTimelineEventsResult struct {
+	Kind RoomKind
+	Page *RoomEventsResult
+}
+
+type RoomTimelineAroundResult struct {
+	Kind   RoomKind
+	Result *RoomEventsAroundResult
+}
+
+type ThreadTimelineEventsInput struct {
+	ActorID           string
+	RoomID            string
+	ThreadRootEventID string
+	Limit             int
+	BeforeSeq         *uint64
+	AfterSeq          *uint64
+}
+
+type ThreadTimelineEventsResult struct {
+	Kind        RoomKind
+	Root        *RoomEvent
+	Replies     *RoomEventsResult
+	IncludeRoot bool
+}
+
+type ThreadTimelineAroundResult struct {
+	Kind        RoomKind
+	Root        *RoomEvent
+	Replies     *RoomEventsResult
+	TargetIndex int
+}
+
+func (s *RoomTimelineReadService) GetRoomEvents(ctx context.Context, input RoomTimelineEventsInput) (*RoomTimelineEventsResult, error) {
+	room, kind, err := s.core.requireRoomMember(ctx, input.ActorID, input.RoomID)
+	if err != nil {
+		return nil, err
+	}
+
+	var page *RoomEventsResult
+	switch {
+	case input.AfterSeq != nil:
+		page, err = s.core.GetRoomEventsAfter(ctx, kind, room.Id, *input.AfterSeq, input.Limit)
+	case input.BeforeSeq != nil:
+		page, err = s.core.GetRoomEvents(ctx, kind, room.Id, input.Limit, input.BeforeSeq)
+	default:
+		page, err = s.core.GetRoomEvents(ctx, kind, room.Id, input.Limit, nil)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &RoomTimelineEventsResult{Kind: kind, Page: page}, nil
+}
+
+func (s *RoomTimelineReadService) GetRoomEventsAround(ctx context.Context, actorID, roomID, eventID string, limit int) (*RoomTimelineAroundResult, error) {
+	room, kind, err := s.core.requireRoomMember(ctx, actorID, roomID)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(eventID) == "" {
+		return nil, invalidArgument("event_id is required")
+	}
+
+	result, err := s.core.GetRoomEventsAround(ctx, kind, room.Id, eventID, limit)
+	if err != nil {
+		return nil, err
+	}
+	return &RoomTimelineAroundResult{Kind: kind, Result: result}, nil
+}
+
+func (s *RoomTimelineReadService) GetThreadEvents(ctx context.Context, input ThreadTimelineEventsInput) (*ThreadTimelineEventsResult, error) {
+	room, kind, err := s.core.requireRoomMember(ctx, input.ActorID, input.RoomID)
+	if err != nil {
+		return nil, err
+	}
+	root, err := s.threadRootEvent(ctx, kind, room.Id, input.ThreadRootEventID)
+	if err != nil {
+		return nil, err
+	}
+
+	includeRoot := true
+	var replies *RoomEventsResult
+	switch {
+	case input.AfterSeq != nil:
+		includeRoot = false
+		replies, err = s.core.GetThreadReplyEvents(ctx, kind, room.Id, root.Event.Id, input.Limit, nil, input.AfterSeq)
+	case input.BeforeSeq != nil:
+		includeRoot = false
+		replies, err = s.core.GetThreadReplyEvents(ctx, kind, room.Id, root.Event.Id, input.Limit, input.BeforeSeq, nil)
+	default:
+		replies, err = s.core.GetThreadReplyEvents(ctx, kind, room.Id, root.Event.Id, input.Limit, nil, nil)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &ThreadTimelineEventsResult{
+		Kind:        kind,
+		Root:        root,
+		Replies:     replies,
+		IncludeRoot: includeRoot,
+	}, nil
+}
+
+func (s *RoomTimelineReadService) GetThreadEventsAround(ctx context.Context, actorID, roomID, threadRootEventID, eventID string, limit int) (*ThreadTimelineAroundResult, error) {
+	room, kind, err := s.core.requireRoomMember(ctx, actorID, roomID)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(eventID) == "" {
+		return nil, invalidArgument("event_id is required")
+	}
+	root, err := s.threadRootEvent(ctx, kind, room.Id, threadRootEventID)
+	if err != nil {
+		return nil, err
+	}
+
+	replies, err := s.core.GetThreadReplyEventsAround(ctx, kind, room.Id, root.Event.Id, eventID, limit)
+	if err != nil {
+		return nil, err
+	}
+	return &ThreadTimelineAroundResult{
+		Kind:        kind,
+		Root:        root,
+		Replies:     replies,
+		TargetIndex: threadTimelineTargetIndex(root.Event.Id, eventID, replies.Events),
+	}, nil
+}
+
+func (s *RoomTimelineReadService) threadRootEvent(ctx context.Context, kind RoomKind, roomID, threadRootEventID string) (*RoomEvent, error) {
+	event, err := s.core.requireThreadRoot(ctx, kind, roomID, threadRootEventID)
+	if err != nil {
+		return nil, err
+	}
+	seq, err := s.core.GetEventSequence(ctx, kind, roomID, threadRootEventID)
+	if err != nil {
+		return nil, err
+	}
+	if seq == 0 {
+		return nil, fmt.Errorf("thread root event not found: %w", ErrNotFound)
+	}
+	return &RoomEvent{Event: event, Sequence: seq}, nil
+}
+
+func threadTimelineTargetIndex(rootEventID, targetEventID string, replies []*RoomEvent) int {
+	if targetEventID == rootEventID {
+		return 0
+	}
+	for i, event := range replies {
+		if event != nil && event.Event != nil && event.Event.Id == targetEventID {
+			return i + 1
+		}
+	}
+	return 0
+}

--- a/cli/internal/core/room_timeline_read_service_test.go
+++ b/cli/internal/core/room_timeline_read_service_test.go
@@ -1,0 +1,148 @@
+package core
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestRoomTimelineReadServiceRequiresMembership(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	room, err := core.CreateRoom(ctx, SystemActorID, KindChannel, "", "timeline-read-authz", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	member, err := core.CreateUser(ctx, SystemActorID, "timeline-reader", "Timeline Reader", "password")
+	if err != nil {
+		t.Fatalf("CreateUser member: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, member.Id, KindChannel, member.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom member: %v", err)
+	}
+	outsider, err := core.CreateUser(ctx, SystemActorID, "timeline-outsider", "Timeline Outsider", "password")
+	if err != nil {
+		t.Fatalf("CreateUser outsider: %v", err)
+	}
+
+	if _, err := core.RoomTimelineReads().GetRoomEvents(ctx, RoomTimelineEventsInput{
+		ActorID: outsider.Id,
+		RoomID:  room.Id,
+	}); !errors.Is(err, ErrNotRoomMember) {
+		t.Fatalf("GetRoomEvents outsider error = %v, want ErrNotRoomMember", err)
+	}
+
+	if _, err := core.RoomTimelineReads().GetRoomEvents(ctx, RoomTimelineEventsInput{
+		ActorID: member.Id,
+		RoomID:  room.Id,
+	}); err != nil {
+		t.Fatalf("GetRoomEvents member: %v", err)
+	}
+
+	message, err := core.PostMessage(ctx, KindChannel, room.Id, member.Id, "visible", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage: %v", err)
+	}
+	if _, err := core.RoomTimelineReads().GetRoomEventsAround(ctx, outsider.Id, room.Id, message.Id, 3); !errors.Is(err, ErrNotRoomMember) {
+		t.Fatalf("GetRoomEventsAround outsider error = %v, want ErrNotRoomMember", err)
+	}
+}
+
+func TestRoomTimelineReadServiceValidatesThreadRoot(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	room, err := core.CreateRoom(ctx, SystemActorID, KindChannel, "", "timeline-thread-authz", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	user, err := core.CreateUser(ctx, SystemActorID, "timeline-thread-reader", "Timeline Thread Reader", "password")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom: %v", err)
+	}
+
+	root, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "root", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("Post root: %v", err)
+	}
+	reply, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "reply", nil, root.Id, "", nil, false)
+	if err != nil {
+		t.Fatalf("Post reply: %v", err)
+	}
+
+	if _, err := core.RoomTimelineReads().GetThreadEvents(ctx, ThreadTimelineEventsInput{
+		ActorID:           user.Id,
+		RoomID:            room.Id,
+		ThreadRootEventID: "missing-root",
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("missing root error = %v, want ErrNotFound", err)
+	}
+
+	if _, err := core.RoomTimelineReads().GetThreadEvents(ctx, ThreadTimelineEventsInput{
+		ActorID:           user.Id,
+		RoomID:            room.Id,
+		ThreadRootEventID: reply.Id,
+	}); !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("reply root error = %v, want ErrInvalidArgument", err)
+	}
+
+	outsider, err := core.CreateUser(ctx, SystemActorID, "timeline-thread-outsider", "Timeline Thread Outsider", "password")
+	if err != nil {
+		t.Fatalf("CreateUser outsider: %v", err)
+	}
+	if _, err := core.RoomTimelineReads().GetThreadEventsAround(ctx, outsider.Id, room.Id, root.Id, reply.Id, 3); !errors.Is(err, ErrNotRoomMember) {
+		t.Fatalf("GetThreadEventsAround outsider error = %v, want ErrNotRoomMember", err)
+	}
+}
+
+func TestRoomTimelineReadServiceThreadAroundComputesTargetIndex(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	room, err := core.CreateRoom(ctx, SystemActorID, KindChannel, "", "timeline-thread-around", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	user, err := core.CreateUser(ctx, SystemActorID, "timeline-around-reader", "Timeline Around Reader", "password")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom: %v", err)
+	}
+
+	root, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "root", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("Post root: %v", err)
+	}
+	if _, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "reply one", nil, root.Id, "", nil, false); err != nil {
+		t.Fatalf("Post reply one: %v", err)
+	}
+	reply2, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "reply two", nil, root.Id, "", nil, false)
+	if err != nil {
+		t.Fatalf("Post reply two: %v", err)
+	}
+	if _, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "reply three", nil, root.Id, "", nil, false); err != nil {
+		t.Fatalf("Post reply three: %v", err)
+	}
+
+	result, err := core.RoomTimelineReads().GetThreadEventsAround(ctx, user.Id, room.Id, root.Id, reply2.Id, 3)
+	if err != nil {
+		t.Fatalf("GetThreadEventsAround: %v", err)
+	}
+	if result.TargetIndex != 2 {
+		t.Fatalf("TargetIndex = %d, want 2", result.TargetIndex)
+	}
+	if result.Kind != KindChannel {
+		t.Fatalf("Kind = %v, want KindChannel", result.Kind)
+	}
+	if result.Root == nil || result.Root.Event.Id != root.Id {
+		t.Fatalf("Root = %+v, want %s", result.Root, root.Id)
+	}
+	if len(result.Replies.Events) != 3 {
+		t.Fatalf("reply count = %d, want 3", len(result.Replies.Events))
+	}
+}


### PR DESCRIPTION
## Summary
- move ConnectRPC room/thread timeline read authorization and target validation into a core `RoomTimelineReadService`
- keep ConnectRPC timeline handlers focused on authN, cursor/protobuf mapping, hydration, and Connect error translation
- add direct core operation tests for membership, thread-root validation, and thread-around target indexing

Fixes #1113

## Tests
- `mise x -- go test ./internal/core -run 'TestRoomTimelineReadService|TestNewChattoCoreInitializesOperationServices' -count=1`
- `mise x -- go test ./internal/connectapi -run 'TestRoomTimelineService' -count=1`
- `mise x -- go test ./internal/core ./internal/connectapi -count=1`
- `git diff --check`

## Review
- Addressed reviewer finding: added direct non-member regression tests for `GetRoomEventsAround` and `GetThreadEventsAround`.
- Re-review result: no findings.
