### PR TITLE
fix(connectapi): harden timeline and thread read handling

### DIFF
--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -653,6 +653,28 @@ func TestRoomTimelineServiceHydratesProcessedVideoAttachments(t *testing.T) {
 	}
 }
 
+func TestRoomTimelineHydratorRejectsUnsupportedEvents(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	h := &timelineHydrator{
+		api:      env.api,
+		ctx:      env.ctx,
+		viewerID: env.viewer.Id,
+		kind:     core.KindChannel,
+		userIDs:  make(map[string]struct{}),
+	}
+
+	_, err := h.event(&core.RoomEvent{Event: &corev1.Event{
+		Id:      "Eunsupported",
+		ActorId: env.viewer.Id,
+		Event: &corev1.Event_RoomUniversalChanged{
+			RoomUniversalChanged: &corev1.RoomUniversalChangedEvent{RoomId: "Runsupported"},
+		},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "unsupported room timeline event") {
+		t.Fatalf("unsupported event error = %v, want unsupported room timeline event", err)
+	}
+}
+
 func TestReadStateServiceRequiresAuthAndMembership(t *testing.T) {
 	env := newConnectAPITestEnv(t)
 	room := env.createJoinedRoom("read-state-authz")
@@ -862,6 +884,21 @@ func TestReadStateServiceMarkThreadAsReadAnchorsAndDoesNotRegress(t *testing.T) 
 	}
 	if !markerAfterInvalid.Equal(marker2) {
 		t.Fatalf("thread marker changed after invalid anchor from %v to %v", marker2, markerAfterInvalid)
+	}
+
+	if _, err := env.readState.MarkThreadAsRead(ctx, connect.NewRequest(&apiv1.MarkThreadAsReadRequest{
+		RoomId:            room.Id,
+		ThreadRootEventId: root.Id,
+		UpToEventId:       "missing-event",
+	})); connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("MarkThreadAsRead missing anchor code = %v, want %v", connect.CodeOf(err), connect.CodeNotFound)
+	}
+	markerAfterMissing, err := env.core.GetThreadLastOpened(env.ctx, core.KindChannel, reader.Id, room.Id, root.Id)
+	if err != nil {
+		t.Fatalf("GetThreadLastOpened after missing anchor: %v", err)
+	}
+	if !markerAfterMissing.Equal(marker2) {
+		t.Fatalf("thread marker changed after missing anchor from %v to %v", marker2, markerAfterMissing)
 	}
 }
 

--- a/cli/internal/connectapi/room_timeline.go
+++ b/cli/internal/connectapi/room_timeline.go
@@ -254,7 +254,7 @@ func (h *timelineHydrator) event(event *core.RoomEvent) (*apiv1.RoomTimelineEven
 	case *corev1.Event_UserLeftRoom:
 		apiEvent.Event = &apiv1.RoomTimelineEvent_UserLeftRoom{UserLeftRoom: roomEvent(payload.UserLeftRoom.GetRoomId())}
 	default:
-		return nil, nil
+		return nil, fmt.Errorf("unsupported room timeline event %T", payload)
 	}
 
 	return apiEvent, nil

--- a/cli/internal/core/event_facts.go
+++ b/cli/internal/core/event_facts.go
@@ -135,6 +135,14 @@ func isVisibleRoomTimelineEntry(event *corev1.Event) bool {
 	switch e := event.GetEvent().(type) {
 	case *corev1.Event_MessagePosted:
 		return e.MessagePosted.GetInThread() == ""
+	case *corev1.Event_RoomCreated,
+		*corev1.Event_RoomUpdated,
+		*corev1.Event_RoomDeleted,
+		*corev1.Event_RoomArchived,
+		*corev1.Event_RoomUnarchived,
+		*corev1.Event_UserJoinedRoom,
+		*corev1.Event_UserLeftRoom:
+		return true
 	case *corev1.Event_MessageEdited, *corev1.Event_MessageRetracted,
 		*corev1.Event_ThreadCreated,
 		*corev1.Event_RoomUniversalChanged,
@@ -147,7 +155,7 @@ func isVisibleRoomTimelineEntry(event *corev1.Event) bool {
 		*corev1.Event_VoiceCallParticipantLeft, *corev1.Event_VoiceCallEnded:
 		return false
 	}
-	return true
+	return false
 }
 
 func isDeliverableLiveEVTRoomEvent(event *corev1.Event) bool {

--- a/cli/internal/core/event_facts_test.go
+++ b/cli/internal/core/event_facts_test.go
@@ -77,6 +77,14 @@ func TestEventFactsRoomIDAndVisibility(t *testing.T) {
 			roomID:  "R1",
 			visible: false,
 		},
+		{
+			name: "unlisted event variant is hidden by default",
+			event: &corev1.Event{Event: &corev1.Event_RoomGroupCreated{
+				RoomGroupCreated: &corev1.RoomGroupCreatedEvent{GroupId: "G1"},
+			}},
+			roomID:  "",
+			visible: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cli/internal/core/read_state_service.go
+++ b/cli/internal/core/read_state_service.go
@@ -159,7 +159,7 @@ func (s *ReadStateService) threadReadAnchor(ctx context.Context, kind RoomKind, 
 		return "", err
 	}
 	if event == nil {
-		return "", nil
+		return "", fmt.Errorf("up_to_event_id event not found: %w", ErrNotFound)
 	}
 	message := event.GetMessagePosted()
 	if message == nil {


### PR DESCRIPTION
## Summary

- Return `NotFound` when an explicit thread read anchor does not exist instead of advancing to the latest thread event.
- Make room timeline visibility allowlisted and reject unsupported hydrated timeline payloads.
- Add regression coverage for missing thread anchors, unsupported timeline hydrator payloads, and unlisted event variants defaulting hidden.

## Tests

- `cd cli && mise x -- go test ./internal/core ./internal/connectapi -count=1 -timeout 120s`
