### PR TITLE
refactor(connectapi): reduce handler plumbing duplication

### DIFF
--- a/cli/internal/connectapi/api.go
+++ b/cli/internal/connectapi/api.go
@@ -39,13 +39,16 @@ func (a *API) Handlers() []Handler {
 	options := []connect.HandlerOption{
 		connect.WithReadMaxBytes(MaxRequestMessageBytes),
 	}
+	privateOptions := append([]connect.HandlerOption{}, options...)
+	privateOptions = append(privateOptions, connect.WithInterceptors(requireAuthedUnaryInterceptor()))
+
 	serverPath, serverHandler := apiv1connect.NewServerServiceHandler(&serverService{api: a}, options...)
-	messagePath, messageHandler := apiv1connect.NewMessageServiceHandler(&messageService{api: a}, options...)
-	prefsPath, prefsHandler := apiv1connect.NewNotificationPreferencesServiceHandler(&notificationPreferencesService{api: a}, options...)
-	readStatePath, readStateHandler := apiv1connect.NewReadStateServiceHandler(&readStateService{api: a}, options...)
-	timelinePath, timelineHandler := apiv1connect.NewRoomTimelineServiceHandler(&roomTimelineService{api: a}, options...)
-	userStatusPath, userStatusHandler := apiv1connect.NewUserStatusServiceHandler(&userStatusService{api: a}, options...)
-	threadPath, threadHandler := apiv1connect.NewThreadServiceHandler(&threadService{api: a}, options...)
+	messagePath, messageHandler := apiv1connect.NewMessageServiceHandler(&messageService{api: a}, privateOptions...)
+	prefsPath, prefsHandler := apiv1connect.NewNotificationPreferencesServiceHandler(&notificationPreferencesService{api: a}, privateOptions...)
+	readStatePath, readStateHandler := apiv1connect.NewReadStateServiceHandler(&readStateService{api: a}, privateOptions...)
+	timelinePath, timelineHandler := apiv1connect.NewRoomTimelineServiceHandler(&roomTimelineService{api: a}, privateOptions...)
+	userStatusPath, userStatusHandler := apiv1connect.NewUserStatusServiceHandler(&userStatusService{api: a}, privateOptions...)
+	threadPath, threadHandler := apiv1connect.NewThreadServiceHandler(&threadService{api: a}, privateOptions...)
 	return []Handler{
 		{ServicePath: messagePath, Handler: messageHandler},
 		{ServicePath: serverPath, Handler: serverHandler},

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -52,6 +52,20 @@ func TestAPIHandlers(t *testing.T) {
 	}
 }
 
+func TestPrivateHandlersRequireAuth(t *testing.T) {
+	api := New(nil, config.ChattoConfig{}, "test")
+	mux := http.NewServeMux()
+	for _, handler := range api.Handlers() {
+		mux.Handle(handler.ServicePath, handler.Handler)
+	}
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	client := apiv1connect.NewMessageServiceClient(ts.Client(), ts.URL)
+	_, err := client.PostMessage(context.Background(), connect.NewRequest(&apiv1.PostMessageRequest{}))
+	requireConnectCode(t, err, connect.CodeUnauthenticated)
+}
+
 func TestServerServiceGetServerPublicMetadata(t *testing.T) {
 	api := New(nil, config.ChattoConfig{
 		Auth: config.AuthConfig{
@@ -675,6 +689,111 @@ func TestRoomTimelineHydratorRejectsUnsupportedEvents(t *testing.T) {
 	}
 }
 
+func TestRoomTimelineHydratorSupportsVisibleCoreEvents(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	room := env.createJoinedRoom("timeline-visible-events")
+	posted := env.post(room.Id, env.viewer.Id, "visible root", "")
+
+	h := &timelineHydrator{
+		api:      env.api,
+		ctx:      env.ctx,
+		viewerID: env.viewer.Id,
+		kind:     core.KindChannel,
+		userIDs:  make(map[string]struct{}),
+	}
+
+	tests := []struct {
+		name  string
+		event *corev1.Event
+	}{
+		{
+			name:  "message posted",
+			event: posted,
+		},
+		{
+			name: "room created",
+			event: &corev1.Event{
+				Id:      "Eroom-created",
+				ActorId: env.viewer.Id,
+				Event: &corev1.Event_RoomCreated{
+					RoomCreated: &corev1.RoomCreatedEvent{RoomId: room.Id},
+				},
+			},
+		},
+		{
+			name: "room updated",
+			event: &corev1.Event{
+				Id:      "Eroom-updated",
+				ActorId: env.viewer.Id,
+				Event: &corev1.Event_RoomUpdated{
+					RoomUpdated: &corev1.RoomUpdatedEvent{RoomId: room.Id},
+				},
+			},
+		},
+		{
+			name: "room deleted",
+			event: &corev1.Event{
+				Id:      "Eroom-deleted",
+				ActorId: env.viewer.Id,
+				Event: &corev1.Event_RoomDeleted{
+					RoomDeleted: &corev1.RoomDeletedEvent{RoomId: room.Id},
+				},
+			},
+		},
+		{
+			name: "room archived",
+			event: &corev1.Event{
+				Id:      "Eroom-archived",
+				ActorId: env.viewer.Id,
+				Event: &corev1.Event_RoomArchived{
+					RoomArchived: &corev1.RoomArchivedEvent{RoomId: room.Id},
+				},
+			},
+		},
+		{
+			name: "room unarchived",
+			event: &corev1.Event{
+				Id:      "Eroom-unarchived",
+				ActorId: env.viewer.Id,
+				Event: &corev1.Event_RoomUnarchived{
+					RoomUnarchived: &corev1.RoomUnarchivedEvent{RoomId: room.Id},
+				},
+			},
+		},
+		{
+			name: "user joined room",
+			event: &corev1.Event{
+				Id:      "Euser-joined",
+				ActorId: env.viewer.Id,
+				Event: &corev1.Event_UserJoinedRoom{
+					UserJoinedRoom: &corev1.UserJoinedRoomEvent{RoomId: room.Id},
+				},
+			},
+		},
+		{
+			name: "user left room",
+			event: &corev1.Event{
+				Id:      "Euser-left",
+				ActorId: env.viewer.Id,
+				Event: &corev1.Event_UserLeftRoom{
+					UserLeftRoom: &corev1.UserLeftRoomEvent{RoomId: room.Id},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !core.IsVisibleRoomTimelineEntry(tt.event) {
+				t.Fatalf("test event is not visible according to core")
+			}
+			if _, err := h.event(&core.RoomEvent{Event: tt.event}); err != nil {
+				t.Fatalf("hydrate visible event: %v", err)
+			}
+		})
+	}
+}
+
 func TestReadStateServiceRequiresAuthAndMembership(t *testing.T) {
 	env := newConnectAPITestEnv(t)
 	room := env.createJoinedRoom("read-state-authz")
@@ -1046,6 +1165,13 @@ func TestConnectErrorMapping(t *testing.T) {
 
 	if err := connectError(errors.New("boom")); strings.Contains(err.Error(), "boom") {
 		t.Fatalf("connectError leaked internal error: %v", err)
+	}
+}
+
+func requireConnectCode(t testing.TB, err error, want connect.Code) {
+	t.Helper()
+	if got := connect.CodeOf(err); got != want {
+		t.Fatalf("connect code = %v, want %v (err = %v)", got, want, err)
 	}
 }
 

--- a/cli/internal/connectapi/handler_helpers.go
+++ b/cli/internal/connectapi/handler_helpers.go
@@ -1,0 +1,44 @@
+package connectapi
+
+import (
+	"context"
+	"errors"
+
+	"connectrpc.com/connect"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+type authenticatedUser = *corev1.User
+
+type authedUnaryHandler[Res any] func(context.Context, authenticatedUser) (*Res, error)
+
+func handleAuthedUnary[Res any](ctx context.Context, handler authedUnaryHandler[Res]) (*connect.Response[Res], error) {
+	user, err := requireAuth(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := handler(ctx, user)
+	if err != nil {
+		return nil, connectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func requireAuthedUnaryInterceptor() connect.UnaryInterceptorFunc {
+	return connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			if _, err := requireAuth(ctx); err != nil {
+				return nil, err
+			}
+			resp, err := next(ctx, req)
+			if err != nil {
+				return nil, connectError(err)
+			}
+			return resp, nil
+		}
+	})
+}
+
+func invalidArgument(message string) error {
+	return connect.NewError(connect.CodeInvalidArgument, errors.New(message))
+}

--- a/cli/internal/connectapi/messages.go
+++ b/cli/internal/connectapi/messages.go
@@ -15,55 +15,52 @@ type messageService struct {
 }
 
 func (s *messageService) PostMessage(ctx context.Context, req *connect.Request[apiv1.PostMessageRequest]) (*connect.Response[apiv1.PostMessageResponse], error) {
-	user, err := requireAuth(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	result, err := s.api.core.Messages().PostMessage(ctx, core.MessagePostInput{
-		ActorID:                  user.Id,
-		RoomID:                   req.Msg.RoomId,
-		Body:                     req.Msg.Body,
-		AttachmentAssetIDs:       append([]string(nil), req.Msg.AttachmentAssetIds...),
-		ThreadRootEventID:        req.Msg.ThreadRootEventId,
-		InReplyTo:                req.Msg.InReplyTo,
-		AlsoSendToChannel:        req.Msg.AlsoSendToChannel,
-		MentionConfirmationToken: req.Msg.MentionConfirmationToken,
-		LinkPreview:              apiMessageLinkPreviewToCore(req.Msg.LinkPreview),
-	})
-	if err != nil {
-		return nil, connectError(err)
-	}
-	if result == nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.New("message post returned no result"))
-	}
-	if challenge := result.MentionConfirmation; challenge != nil {
-		return connect.NewResponse(&apiv1.PostMessageResponse{
-			Result: &apiv1.PostMessageResponse_MentionConfirmation{
-				MentionConfirmation: &apiv1.MentionConfirmationChallenge{
-					RecipientCount: int32(challenge.RecipientCount),
-					Token:          challenge.Token,
+	return handleAuthedUnary(ctx, func(ctx context.Context, user authenticatedUser) (*apiv1.PostMessageResponse, error) {
+		result, err := s.api.core.Messages().PostMessage(ctx, core.MessagePostInput{
+			ActorID:                  user.Id,
+			RoomID:                   req.Msg.RoomId,
+			Body:                     req.Msg.Body,
+			AttachmentAssetIDs:       append([]string(nil), req.Msg.AttachmentAssetIds...),
+			ThreadRootEventID:        req.Msg.ThreadRootEventId,
+			InReplyTo:                req.Msg.InReplyTo,
+			AlsoSendToChannel:        req.Msg.AlsoSendToChannel,
+			MentionConfirmationToken: req.Msg.MentionConfirmationToken,
+			LinkPreview:              apiMessageLinkPreviewToCore(req.Msg.LinkPreview),
+		})
+		if err != nil {
+			return nil, err
+		}
+		if result == nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.New("message post returned no result"))
+		}
+		if challenge := result.MentionConfirmation; challenge != nil {
+			return &apiv1.PostMessageResponse{
+				Result: &apiv1.PostMessageResponse_MentionConfirmation{
+					MentionConfirmation: &apiv1.MentionConfirmationChallenge{
+						RecipientCount: int32(challenge.RecipientCount),
+						Token:          challenge.Token,
+					},
 				},
-			},
-		}), nil
-	}
-	if result.Event == nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.New("message post returned no event"))
-	}
+			}, nil
+		}
+		if result.Event == nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.New("message post returned no event"))
+		}
 
-	roomID := result.Event.GetMessagePosted().GetRoomId()
-	kind := core.KindChannel
-	if room, err := s.api.core.FindRoomByID(ctx, roomID); err == nil && room != nil {
-		kind = core.KindOfRoom(room)
-	}
-	apiEvent, includes, err := s.hydratePostedEvent(ctx, user.Id, kind, result.Event)
-	if err != nil {
-		return nil, connectError(err)
-	}
-	return connect.NewResponse(&apiv1.PostMessageResponse{
-		Result:   &apiv1.PostMessageResponse_Event{Event: apiEvent},
-		Includes: includes,
-	}), nil
+		roomID := result.Event.GetMessagePosted().GetRoomId()
+		kind := core.KindChannel
+		if room, err := s.api.core.FindRoomByID(ctx, roomID); err == nil && room != nil {
+			kind = core.KindOfRoom(room)
+		}
+		apiEvent, includes, err := s.hydratePostedEvent(ctx, user.Id, kind, result.Event)
+		if err != nil {
+			return nil, err
+		}
+		return &apiv1.PostMessageResponse{
+			Result:   &apiv1.PostMessageResponse_Event{Event: apiEvent},
+			Includes: includes,
+		}, nil
+	})
 }
 
 func (s *messageService) hydratePostedEvent(ctx context.Context, viewerID string, kind core.RoomKind, event *corev1.Event) (*apiv1.RoomTimelineEvent, *apiv1.RoomTimelineIncludes, error) {

--- a/cli/internal/connectapi/notification_preferences.go
+++ b/cli/internal/connectapi/notification_preferences.go
@@ -2,7 +2,6 @@ package connectapi
 
 import (
 	"context"
-	"errors"
 	"strings"
 
 	"connectrpc.com/connect"
@@ -15,47 +14,43 @@ type notificationPreferencesService struct {
 }
 
 func (s *notificationPreferencesService) GetRoomNotificationPreference(ctx context.Context, req *connect.Request[apiv1.GetRoomNotificationPreferenceRequest]) (*connect.Response[apiv1.GetRoomNotificationPreferenceResponse], error) {
-	user, err := requireAuth(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if strings.TrimSpace(req.Msg.RoomId) == "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("room_id is required"))
-	}
-	// Keep ConnectRPC transport code thin: authenticate the request, translate
-	// protobufs/errors, and delegate operation authZ to the core service.
-	pref, err := s.api.core.NotificationPreferences().GetRoomNotificationPreference(ctx, user.Id, req.Msg.RoomId)
-	if err != nil {
-		return nil, connectError(err)
-	}
-	return connect.NewResponse(&apiv1.GetRoomNotificationPreferenceResponse{
-		Level:          coreNotificationLevelToAPI(pref.Level),
-		EffectiveLevel: coreNotificationLevelToAPI(pref.EffectiveLevel),
-	}), nil
+	return handleAuthedUnary(ctx, func(ctx context.Context, user authenticatedUser) (*apiv1.GetRoomNotificationPreferenceResponse, error) {
+		if strings.TrimSpace(req.Msg.RoomId) == "" {
+			return nil, invalidArgument("room_id is required")
+		}
+		// Keep ConnectRPC transport code thin: authenticate the request, translate
+		// protobufs/errors, and delegate operation authZ to the core service.
+		pref, err := s.api.core.NotificationPreferences().GetRoomNotificationPreference(ctx, user.Id, req.Msg.RoomId)
+		if err != nil {
+			return nil, err
+		}
+		return &apiv1.GetRoomNotificationPreferenceResponse{
+			Level:          coreNotificationLevelToAPI(pref.Level),
+			EffectiveLevel: coreNotificationLevelToAPI(pref.EffectiveLevel),
+		}, nil
+	})
 }
 
 func (s *notificationPreferencesService) SetRoomNotificationLevel(ctx context.Context, req *connect.Request[apiv1.SetRoomNotificationLevelRequest]) (*connect.Response[apiv1.SetRoomNotificationLevelResponse], error) {
-	user, err := requireAuth(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if strings.TrimSpace(req.Msg.RoomId) == "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("room_id is required"))
-	}
-	level, err := apiNotificationLevelToCore(req.Msg.Level)
-	if err != nil {
-		return nil, err
-	}
-	// Keep membership checks and response semantics in the shared service so
-	// GraphQL and ConnectRPC cannot drift.
-	pref, err := s.api.core.NotificationPreferences().SetRoomNotificationLevel(ctx, user.Id, req.Msg.RoomId, level)
-	if err != nil {
-		return nil, connectError(err)
-	}
-	return connect.NewResponse(&apiv1.SetRoomNotificationLevelResponse{
-		Level:          coreNotificationLevelToAPI(pref.Level),
-		EffectiveLevel: coreNotificationLevelToAPI(pref.EffectiveLevel),
-	}), nil
+	return handleAuthedUnary(ctx, func(ctx context.Context, user authenticatedUser) (*apiv1.SetRoomNotificationLevelResponse, error) {
+		if strings.TrimSpace(req.Msg.RoomId) == "" {
+			return nil, invalidArgument("room_id is required")
+		}
+		level, err := apiNotificationLevelToCore(req.Msg.Level)
+		if err != nil {
+			return nil, err
+		}
+		// Keep membership checks and response semantics in the shared service so
+		// GraphQL and ConnectRPC cannot drift.
+		pref, err := s.api.core.NotificationPreferences().SetRoomNotificationLevel(ctx, user.Id, req.Msg.RoomId, level)
+		if err != nil {
+			return nil, err
+		}
+		return &apiv1.SetRoomNotificationLevelResponse{
+			Level:          coreNotificationLevelToAPI(pref.Level),
+			EffectiveLevel: coreNotificationLevelToAPI(pref.EffectiveLevel),
+		}, nil
+	})
 }
 
 func apiNotificationLevelToCore(level apiv1.NotificationLevel) (corev1.NotificationLevel, error) {
@@ -69,7 +64,7 @@ func apiNotificationLevelToCore(level apiv1.NotificationLevel) (corev1.Notificat
 	case apiv1.NotificationLevel_NOTIFICATION_LEVEL_ALL_MESSAGES:
 		return corev1.NotificationLevel_NOTIFICATION_LEVEL_ALL_MESSAGES, nil
 	default:
-		return corev1.NotificationLevel_NOTIFICATION_LEVEL_UNSPECIFIED, connect.NewError(connect.CodeInvalidArgument, errors.New("notification level must be DEFAULT, MUTED, NORMAL, or ALL_MESSAGES"))
+		return corev1.NotificationLevel_NOTIFICATION_LEVEL_UNSPECIFIED, invalidArgument("notification level must be DEFAULT, MUTED, NORMAL, or ALL_MESSAGES")
 	}
 }
 

--- a/cli/internal/connectapi/read_state.go
+++ b/cli/internal/connectapi/read_state.go
@@ -13,38 +13,34 @@ type readStateService struct {
 }
 
 func (s *readStateService) MarkRoomAsRead(ctx context.Context, req *connect.Request[apiv1.MarkRoomAsReadRequest]) (*connect.Response[apiv1.MarkRoomAsReadResponse], error) {
-	user, err := requireAuth(ctx)
-	if err != nil {
-		return nil, err
-	}
-	result, err := s.api.core.ReadState().MarkRoomAsRead(ctx, user.Id, req.Msg.RoomId, req.Msg.UpToEventId)
-	if err != nil {
-		return nil, connectError(err)
-	}
+	return handleAuthedUnary(ctx, func(ctx context.Context, user authenticatedUser) (*apiv1.MarkRoomAsReadResponse, error) {
+		result, err := s.api.core.ReadState().MarkRoomAsRead(ctx, user.Id, req.Msg.RoomId, req.Msg.UpToEventId)
+		if err != nil {
+			return nil, err
+		}
 
-	resp := &apiv1.MarkRoomAsReadResponse{}
-	if !result.LastReadAt.IsZero() {
-		resp.LastReadAt = timestamppb.New(result.LastReadAt)
-	}
-	if !result.PreviousLastReadAt.IsZero() {
-		resp.PreviousLastReadAt = timestamppb.New(result.PreviousLastReadAt)
-	}
-	return connect.NewResponse(resp), nil
+		resp := &apiv1.MarkRoomAsReadResponse{}
+		if !result.LastReadAt.IsZero() {
+			resp.LastReadAt = timestamppb.New(result.LastReadAt)
+		}
+		if !result.PreviousLastReadAt.IsZero() {
+			resp.PreviousLastReadAt = timestamppb.New(result.PreviousLastReadAt)
+		}
+		return resp, nil
+	})
 }
 
 func (s *readStateService) MarkThreadAsRead(ctx context.Context, req *connect.Request[apiv1.MarkThreadAsReadRequest]) (*connect.Response[apiv1.MarkThreadAsReadResponse], error) {
-	user, err := requireAuth(ctx)
-	if err != nil {
-		return nil, err
-	}
-	result, err := s.api.core.ReadState().MarkThreadAsRead(ctx, user.Id, req.Msg.RoomId, req.Msg.ThreadRootEventId, req.Msg.UpToEventId)
-	if err != nil {
-		return nil, connectError(err)
-	}
+	return handleAuthedUnary(ctx, func(ctx context.Context, user authenticatedUser) (*apiv1.MarkThreadAsReadResponse, error) {
+		result, err := s.api.core.ReadState().MarkThreadAsRead(ctx, user.Id, req.Msg.RoomId, req.Msg.ThreadRootEventId, req.Msg.UpToEventId)
+		if err != nil {
+			return nil, err
+		}
 
-	resp := &apiv1.MarkThreadAsReadResponse{}
-	if !result.PreviousReadAt.IsZero() {
-		resp.PreviousReadAt = timestamppb.New(result.PreviousReadAt)
-	}
-	return connect.NewResponse(resp), nil
+		resp := &apiv1.MarkThreadAsReadResponse{}
+		if !result.PreviousReadAt.IsZero() {
+			resp.PreviousReadAt = timestamppb.New(result.PreviousReadAt)
+		}
+		return resp, nil
+	})
 }

--- a/cli/internal/connectapi/room_timeline.go
+++ b/cli/internal/connectapi/room_timeline.go
@@ -21,128 +21,104 @@ type roomTimelineService struct {
 }
 
 func (s *roomTimelineService) GetRoomEvents(ctx context.Context, req *connect.Request[apiv1.GetRoomEventsRequest]) (*connect.Response[apiv1.GetRoomEventsResponse], error) {
-	user, err := requireAuth(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	input := core.RoomTimelineEventsInput{
-		ActorID: user.Id,
-		RoomID:  req.Msg.RoomId,
-		Limit:   int(req.Msg.Limit),
-	}
-	switch cursor := req.Msg.Cursor.(type) {
-	case *apiv1.GetRoomEventsRequest_After:
-		seq, err := parseRoomTimelineCursor(cursor.After)
+	return handleAuthedUnary(ctx, func(ctx context.Context, user authenticatedUser) (*apiv1.GetRoomEventsResponse, error) {
+		afterSeq, beforeSeq, err := roomTimelineCursorBounds(req.Msg.Cursor)
 		if err != nil {
 			return nil, err
 		}
-		input.AfterSeq = &seq
-	case *apiv1.GetRoomEventsRequest_Before:
-		seq, err := parseRoomTimelineCursor(cursor.Before)
+
+		input := core.RoomTimelineEventsInput{
+			ActorID:   user.Id,
+			RoomID:    req.Msg.RoomId,
+			Limit:     int(req.Msg.Limit),
+			AfterSeq:  afterSeq,
+			BeforeSeq: beforeSeq,
+		}
+
+		result, err := s.api.core.RoomTimelineReads().GetRoomEvents(ctx, input)
 		if err != nil {
 			return nil, err
 		}
-		input.BeforeSeq = &seq
-	}
 
-	result, err := s.api.core.RoomTimelineReads().GetRoomEvents(ctx, input)
-	if err != nil {
-		return nil, connectError(err)
-	}
-
-	page := result.Page
-	resp, err := s.buildPage(ctx, user.Id, result.Kind, page.Events, page.HasOlder, page.HasNewer)
-	if err != nil {
-		return nil, connectError(err)
-	}
-	resp.StartCursor = formatRoomTimelineCursor(page.StartCursorSeq)
-	resp.EndCursor = formatRoomTimelineCursor(page.EndCursorSeq)
-	return connect.NewResponse(&apiv1.GetRoomEventsResponse{Page: resp}), nil
+		page := result.Page
+		resp, err := s.buildPage(ctx, user.Id, result.Kind, page.Events, page.HasOlder, page.HasNewer)
+		if err != nil {
+			return nil, err
+		}
+		resp.StartCursor = formatRoomTimelineCursor(page.StartCursorSeq)
+		resp.EndCursor = formatRoomTimelineCursor(page.EndCursorSeq)
+		return &apiv1.GetRoomEventsResponse{Page: resp}, nil
+	})
 }
 
 func (s *roomTimelineService) GetRoomEventsAround(ctx context.Context, req *connect.Request[apiv1.GetRoomEventsAroundRequest]) (*connect.Response[apiv1.GetRoomEventsAroundResponse], error) {
-	user, err := requireAuth(ctx)
-	if err != nil {
-		return nil, err
-	}
-	result, err := s.api.core.RoomTimelineReads().GetRoomEventsAround(ctx, user.Id, req.Msg.RoomId, req.Msg.EventId, int(req.Msg.Limit))
-	if err != nil {
-		return nil, connectError(err)
-	}
-	around := result.Result
-	page, err := s.buildPage(ctx, user.Id, result.Kind, around.Events, around.HasOlder, around.HasNewer)
-	if err != nil {
-		return nil, connectError(err)
-	}
-	if len(around.Events) > 0 {
-		page.StartCursor = formatRoomTimelineCursor(around.Events[0].Sequence)
-		page.EndCursor = formatRoomTimelineCursor(around.Events[len(around.Events)-1].Sequence)
-	}
+	return handleAuthedUnary(ctx, func(ctx context.Context, user authenticatedUser) (*apiv1.GetRoomEventsAroundResponse, error) {
+		result, err := s.api.core.RoomTimelineReads().GetRoomEventsAround(ctx, user.Id, req.Msg.RoomId, req.Msg.EventId, int(req.Msg.Limit))
+		if err != nil {
+			return nil, err
+		}
+		around := result.Result
+		page, err := s.buildPage(ctx, user.Id, result.Kind, around.Events, around.HasOlder, around.HasNewer)
+		if err != nil {
+			return nil, err
+		}
+		if len(around.Events) > 0 {
+			page.StartCursor = formatRoomTimelineCursor(around.Events[0].Sequence)
+			page.EndCursor = formatRoomTimelineCursor(around.Events[len(around.Events)-1].Sequence)
+		}
 
-	return connect.NewResponse(&apiv1.GetRoomEventsAroundResponse{
-		Page:        page,
-		TargetIndex: int32(around.TargetIndex),
-	}), nil
+		return &apiv1.GetRoomEventsAroundResponse{
+			Page:        page,
+			TargetIndex: int32(around.TargetIndex),
+		}, nil
+	})
 }
 
 func (s *roomTimelineService) GetThreadEvents(ctx context.Context, req *connect.Request[apiv1.GetThreadEventsRequest]) (*connect.Response[apiv1.GetThreadEventsResponse], error) {
-	user, err := requireAuth(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	input := core.ThreadTimelineEventsInput{
-		ActorID:           user.Id,
-		RoomID:            req.Msg.RoomId,
-		ThreadRootEventID: req.Msg.ThreadRootEventId,
-		Limit:             int(req.Msg.Limit),
-	}
-	switch cursor := req.Msg.Cursor.(type) {
-	case *apiv1.GetThreadEventsRequest_After:
-		seq, err := parseRoomTimelineCursor(cursor.After)
+	return handleAuthedUnary(ctx, func(ctx context.Context, user authenticatedUser) (*apiv1.GetThreadEventsResponse, error) {
+		afterSeq, beforeSeq, err := roomTimelineCursorBounds(req.Msg.Cursor)
 		if err != nil {
 			return nil, err
 		}
-		input.AfterSeq = &seq
-	case *apiv1.GetThreadEventsRequest_Before:
-		seq, err := parseRoomTimelineCursor(cursor.Before)
+
+		input := core.ThreadTimelineEventsInput{
+			ActorID:           user.Id,
+			RoomID:            req.Msg.RoomId,
+			ThreadRootEventID: req.Msg.ThreadRootEventId,
+			Limit:             int(req.Msg.Limit),
+			AfterSeq:          afterSeq,
+			BeforeSeq:         beforeSeq,
+		}
+
+		result, err := s.api.core.RoomTimelineReads().GetThreadEvents(ctx, input)
 		if err != nil {
 			return nil, err
 		}
-		input.BeforeSeq = &seq
-	}
 
-	result, err := s.api.core.RoomTimelineReads().GetThreadEvents(ctx, input)
-	if err != nil {
-		return nil, connectError(err)
-	}
-
-	page, err := s.buildThreadPage(ctx, user.Id, result.Kind, result.Root, result.Replies, result.IncludeRoot)
-	if err != nil {
-		return nil, connectError(err)
-	}
-	return connect.NewResponse(&apiv1.GetThreadEventsResponse{Page: page}), nil
+		page, err := s.buildThreadPage(ctx, user.Id, result.Kind, result.Root, result.Replies, result.IncludeRoot)
+		if err != nil {
+			return nil, err
+		}
+		return &apiv1.GetThreadEventsResponse{Page: page}, nil
+	})
 }
 
 func (s *roomTimelineService) GetThreadEventsAround(ctx context.Context, req *connect.Request[apiv1.GetThreadEventsAroundRequest]) (*connect.Response[apiv1.GetThreadEventsAroundResponse], error) {
-	user, err := requireAuth(ctx)
-	if err != nil {
-		return nil, err
-	}
-	result, err := s.api.core.RoomTimelineReads().GetThreadEventsAround(ctx, user.Id, req.Msg.RoomId, req.Msg.ThreadRootEventId, req.Msg.EventId, int(req.Msg.Limit))
-	if err != nil {
-		return nil, connectError(err)
-	}
-	page, err := s.buildThreadPage(ctx, user.Id, result.Kind, result.Root, result.Replies, true)
-	if err != nil {
-		return nil, connectError(err)
-	}
+	return handleAuthedUnary(ctx, func(ctx context.Context, user authenticatedUser) (*apiv1.GetThreadEventsAroundResponse, error) {
+		result, err := s.api.core.RoomTimelineReads().GetThreadEventsAround(ctx, user.Id, req.Msg.RoomId, req.Msg.ThreadRootEventId, req.Msg.EventId, int(req.Msg.Limit))
+		if err != nil {
+			return nil, err
+		}
+		page, err := s.buildThreadPage(ctx, user.Id, result.Kind, result.Root, result.Replies, true)
+		if err != nil {
+			return nil, err
+		}
 
-	return connect.NewResponse(&apiv1.GetThreadEventsAroundResponse{
-		Page:        page,
-		TargetIndex: int32(result.TargetIndex),
-	}), nil
+		return &apiv1.GetThreadEventsAroundResponse{
+			Page:        page,
+			TargetIndex: int32(result.TargetIndex),
+		}, nil
+	})
 }
 
 // buildPage turns projected room timeline entries into the public Connect view.
@@ -537,6 +513,39 @@ func parseRoomTimelineCursor(cursor string) (uint64, error) {
 		return 0, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid cursor sequence: %w", err))
 	}
 	return seq, nil
+}
+
+func roomTimelineCursorBounds(cursor any) (afterSeq, beforeSeq *uint64, err error) {
+	switch cursor := cursor.(type) {
+	case nil:
+		return nil, nil, nil
+	case *apiv1.GetRoomEventsRequest_After:
+		seq, err := parseRoomTimelineCursor(cursor.After)
+		if err != nil {
+			return nil, nil, err
+		}
+		return &seq, nil, nil
+	case *apiv1.GetRoomEventsRequest_Before:
+		seq, err := parseRoomTimelineCursor(cursor.Before)
+		if err != nil {
+			return nil, nil, err
+		}
+		return nil, &seq, nil
+	case *apiv1.GetThreadEventsRequest_After:
+		seq, err := parseRoomTimelineCursor(cursor.After)
+		if err != nil {
+			return nil, nil, err
+		}
+		return &seq, nil, nil
+	case *apiv1.GetThreadEventsRequest_Before:
+		seq, err := parseRoomTimelineCursor(cursor.Before)
+		if err != nil {
+			return nil, nil, err
+		}
+		return nil, &seq, nil
+	default:
+		return nil, nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("unsupported cursor type %T", cursor))
+	}
 }
 
 func firstN(values []string, n int) []string {

--- a/cli/internal/connectapi/threads.go
+++ b/cli/internal/connectapi/threads.go
@@ -12,25 +12,19 @@ type threadService struct {
 }
 
 func (s *threadService) FollowThread(ctx context.Context, req *connect.Request[apiv1.FollowThreadRequest]) (*connect.Response[apiv1.FollowThreadResponse], error) {
-	user, err := requireAuth(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := s.api.core.ThreadFollows().FollowThread(ctx, user.Id, req.Msg.RoomId, req.Msg.ThreadRootEventId); err != nil {
-		return nil, connectError(err)
-	}
-	return connect.NewResponse(&apiv1.FollowThreadResponse{Following: true}), nil
+	return handleAuthedUnary(ctx, func(ctx context.Context, user authenticatedUser) (*apiv1.FollowThreadResponse, error) {
+		if err := s.api.core.ThreadFollows().FollowThread(ctx, user.Id, req.Msg.RoomId, req.Msg.ThreadRootEventId); err != nil {
+			return nil, err
+		}
+		return &apiv1.FollowThreadResponse{Following: true}, nil
+	})
 }
 
 func (s *threadService) UnfollowThread(ctx context.Context, req *connect.Request[apiv1.UnfollowThreadRequest]) (*connect.Response[apiv1.UnfollowThreadResponse], error) {
-	user, err := requireAuth(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := s.api.core.ThreadFollows().UnfollowThread(ctx, user.Id, req.Msg.RoomId, req.Msg.ThreadRootEventId); err != nil {
-		return nil, connectError(err)
-	}
-	return connect.NewResponse(&apiv1.UnfollowThreadResponse{Following: false}), nil
+	return handleAuthedUnary(ctx, func(ctx context.Context, user authenticatedUser) (*apiv1.UnfollowThreadResponse, error) {
+		if err := s.api.core.ThreadFollows().UnfollowThread(ctx, user.Id, req.Msg.RoomId, req.Msg.ThreadRootEventId); err != nil {
+			return nil, err
+		}
+		return &apiv1.UnfollowThreadResponse{Following: false}, nil
+	})
 }

--- a/cli/internal/connectapi/user_status.go
+++ b/cli/internal/connectapi/user_status.go
@@ -2,7 +2,6 @@ package connectapi
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"connectrpc.com/connect"
@@ -16,40 +15,34 @@ type userStatusService struct {
 }
 
 func (s *userStatusService) SetCustomStatus(ctx context.Context, req *connect.Request[apiv1.SetCustomStatusRequest]) (*connect.Response[apiv1.SetCustomStatusResponse], error) {
-	user, err := requireAuth(ctx)
-	if err != nil {
-		return nil, err
-	}
+	return handleAuthedUnary(ctx, func(ctx context.Context, user authenticatedUser) (*apiv1.SetCustomStatusResponse, error) {
+		expiresAt, err := apiTimestampToTime(req.Msg.ExpiresAt)
+		if err != nil {
+			return nil, err
+		}
 
-	expiresAt, err := apiTimestampToTime(req.Msg.ExpiresAt)
-	if err != nil {
-		return nil, err
-	}
+		updated, err := s.api.core.SetUserCustomStatus(ctx, user.Id, req.Msg.Emoji, req.Msg.Text, expiresAt)
+		if err != nil {
+			return nil, err
+		}
 
-	updated, err := s.api.core.SetUserCustomStatus(ctx, user.Id, req.Msg.Emoji, req.Msg.Text, expiresAt)
-	if err != nil {
-		return nil, connectError(err)
-	}
-
-	return connect.NewResponse(&apiv1.SetCustomStatusResponse{
-		Status: coreCustomStatusToAPI(updated.GetCustomStatus()),
-	}), nil
+		return &apiv1.SetCustomStatusResponse{
+			Status: coreCustomStatusToAPI(updated.GetCustomStatus()),
+		}, nil
+	})
 }
 
 func (s *userStatusService) ClearCustomStatus(ctx context.Context, _ *connect.Request[apiv1.ClearCustomStatusRequest]) (*connect.Response[apiv1.ClearCustomStatusResponse], error) {
-	user, err := requireAuth(ctx)
-	if err != nil {
-		return nil, err
-	}
+	return handleAuthedUnary(ctx, func(ctx context.Context, user authenticatedUser) (*apiv1.ClearCustomStatusResponse, error) {
+		updated, err := s.api.core.ClearUserCustomStatus(ctx, user.Id)
+		if err != nil {
+			return nil, err
+		}
 
-	updated, err := s.api.core.ClearUserCustomStatus(ctx, user.Id)
-	if err != nil {
-		return nil, connectError(err)
-	}
-
-	return connect.NewResponse(&apiv1.ClearCustomStatusResponse{
-		Status: coreCustomStatusToAPI(updated.GetCustomStatus()),
-	}), nil
+		return &apiv1.ClearCustomStatusResponse{
+			Status: coreCustomStatusToAPI(updated.GetCustomStatus()),
+		}, nil
+	})
 }
 
 func apiTimestampToTime(ts *timestamppb.Timestamp) (*time.Time, error) {
@@ -57,7 +50,7 @@ func apiTimestampToTime(ts *timestamppb.Timestamp) (*time.Time, error) {
 		return nil, nil
 	}
 	if err := ts.CheckValid(); err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("expires_at is invalid"))
+		return nil, invalidArgument("expires_at is invalid")
 	}
 	expiresAt := ts.AsTime()
 	return &expiresAt, nil

--- a/cli/internal/core/event_facts.go
+++ b/cli/internal/core/event_facts.go
@@ -158,6 +158,12 @@ func isVisibleRoomTimelineEntry(event *corev1.Event) bool {
 	return false
 }
 
+// IsVisibleRoomTimelineEntry reports whether an event should surface in the
+// public room timeline.
+func IsVisibleRoomTimelineEntry(event *corev1.Event) bool {
+	return isVisibleRoomTimelineEntry(event)
+}
+
 func isDeliverableLiveEVTRoomEvent(event *corev1.Event) bool {
 	switch event.GetEvent().(type) {
 	case *corev1.Event_RoomCreated,


### PR DESCRIPTION
## Summary

- Add shared ConnectAPI handler plumbing for authenticated unary calls, private-service auth interception, and common invalid-argument errors.
- Refactor Connect handlers to use the shared path while keeping service-specific core calls explicit, and extract shared room timeline cursor bounds parsing.
- Add tests for private handler auth and visible core timeline event hydration support.

Fixes #1119

## Tests

- `cd cli && mise x -- go test ./internal/connectapi ./internal/core -count=1 -timeout 120s`
- `cd cli && mise x -- go test ./internal/http_server -run 'TestConnect' -count=1 -timeout 120s`
