### PR TITLE
fix(frontend): sync room thread follow bell state

### DIFF
--- a/frontend/e2e/thread-following.test.ts
+++ b/frontend/e2e/thread-following.test.ts
@@ -214,6 +214,46 @@ test.describe('Thread Following', () => {
     );
   });
 
+  test('room-view bell updates after unfollowing an auto-followed thread', async ({
+    page,
+    chatPage,
+    roomPage,
+    browser,
+    serverURL
+  }) => {
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.enterRoom('general');
+
+    const rootText = `Root ${Date.now()}`;
+    await roomPage.sendMessage(rootText);
+
+    await withServerUser(
+      browser!,
+      serverURL,
+      async ({ page: page2, chatPage: chatPage2, roomPage: roomPage2 }) => {
+        await chatPage2.enterRoom('general');
+        await waitForRoomReady(page2, 'general');
+
+        const rootMsg2 = roomPage2.getMessage(rootText);
+        await rootMsg2.openThread();
+        await roomPage2.expectThreadPaneVisible();
+        await roomPage2.postThreadReply(`Reply from Bob ${Date.now()}`);
+
+        await rootMsg2.expectFollowingThread();
+
+        await rootMsg2.locator
+          .getByTitle('Unfollow thread')
+          .evaluate((button: HTMLElement) => button.click());
+        await rootMsg2.expectNotFollowingThread();
+
+        await page2.reload();
+        await page2.waitForLoadState('networkidle');
+        await roomPage2.getMessage(rootText).expectNotFollowingThread();
+      }
+    );
+  });
+
   test('unfollow persists when another user replies', async ({
     page,
     chatPage,

--- a/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -119,6 +119,24 @@ export class MessagesStore {
     );
   }
 
+  /** Update the viewer's thread follow state on a known thread root event. */
+  setThreadRootFollowState(threadRootEventId: string, isFollowing: boolean): void {
+    const idx = this.events.findIndex((e) => e.id === threadRootEventId);
+    if (idx === -1) return;
+
+    const rootEvent = this.events[idx];
+    if (rootEvent.event?.__typename !== 'MessagePostedEvent') return;
+    if (rootEvent.event.viewerIsFollowingThread === isFollowing) return;
+
+    this.events[idx] = {
+      ...rootEvent,
+      event: {
+        ...rootEvent.event,
+        viewerIsFollowingThread: isFollowing
+      }
+    };
+  }
+
   /** Fetch an off-window event for previews. Transient errors are not cached. */
   ensureEvent(eventId: string): Promise<void> | undefined {
     if (!this.roomId) return undefined;

--- a/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -298,28 +298,29 @@
   const isRootMessage = $derived(!isEcho && messageEvent?.threadRootEventId == null);
   const hasReplies = $derived(isRootMessage && (messageEvent?.replyCount ?? 0) > 0);
 
-  // Thread follow state — managed as plain $state.
-  // Seed once per message identity, then update only via mutations / live events.
-  let isFollowingThread = $state(false);
-  let _followSeededForEvent = '';
+  // Overridable derived state: backing event data is the default, while
+  // mutations/live events can update the row immediately.
+  let isFollowingThread = $derived(messageEvent?.viewerIsFollowingThread ?? false);
 
-  $effect(() => {
+  function setThreadFollowState(value: boolean) {
     if (!event) return;
-    const id = event.id;
-    const value = messageEvent?.viewerIsFollowingThread ?? false;
-    if (_followSeededForEvent !== id) {
-      _followSeededForEvent = id;
-      isFollowingThread = value;
-    } else if (value && !isFollowingThread) {
-      // Sync auto-follow (false→true only, preserves optimistic unfollows)
-      isFollowingThread = true;
-    }
-  });
+    isFollowingThread = value;
+    messageStore?.setThreadRootFollowState(event.id, value);
+  }
+
+  function syncThreadFollowEvents() {
+    return onThreadFollowChanged((update) => {
+      if (update.roomId === roomId && update.threadRootEventId === event.id) {
+        setThreadFollowState(update.isFollowing);
+      }
+    });
+  }
 
   async function toggleThreadFollow(e: MouseEvent) {
     e.stopPropagation();
     const wasFollowing = isFollowingThread;
-    isFollowingThread = !wasFollowing;
+    const nextFollowing = !wasFollowing;
+    setThreadFollowState(nextFollowing);
 
     try {
       const conn = connection();
@@ -333,19 +334,11 @@
       } else {
         await api.followThread({ roomId, threadRootEventId: event.id });
       }
+      setThreadFollowState(nextFollowing);
     } catch {
-      isFollowingThread = wasFollowing;
+      setThreadFollowState(wasFollowing);
     }
   }
-
-  // Sync thread follow state from live events (auto-follow on reply, cross-tab sync).
-  $effect(() =>
-    onThreadFollowChanged((update) => {
-      if (update.threadRootEventId === event.id) {
-        isFollowingThread = update.isFollowing;
-      }
-    })
-  );
 
   // Check if message has attachments
   const hasAttachments = $derived((msg?.attachments?.length ?? 0) > 0);
@@ -602,6 +595,7 @@
     ]}
     role="article"
     data-event-id={event.id}
+    {@attach syncThreadFollowEvents}
   >
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div


### PR DESCRIPTION
## Summary

Fixes the room-view thread follow bell so manual unfollow updates immediately after the viewer auto-follows by replying in another user's thread.
The message row now writes follow-state changes back into the room message store, and live follow updates are scoped by room before syncing local state.
Adds an e2e regression that covers the auto-followed reply author unfollowing from the room-view bell and verifying the state after reload.

## Verification

- `mise run test-e2e -- --grep "room-view bell updates after unfollowing an auto-followed thread" --retries=0`
- `mise run test-e2e -- e2e/thread-following.test.ts --retries=0`
- `mise run lint-frontend`
