### PR TITLE
refactor(frontend): reduce local svelte effects

### DIFF
--- a/frontend/src/lib/components/AddServerDialog.svelte
+++ b/frontend/src/lib/components/AddServerDialog.svelte
@@ -53,21 +53,20 @@ ADR-027 — only user-facing copy says "server".
   let probing = $state(false);
   let connecting = $state(false);
 
-  // Reset everything whenever the dialog is closed so reopening starts
-  // fresh — the component is mounted persistently by its callers (sidebar,
-  // instances page, login), so without this the previous URL and any prior
-  // error/preview would still be present on the next open.
-  $effect(() => {
-    if (!visible) {
-      stage = 'url';
-      serverUrl = '';
-      probedUrl = '';
-      probedInfo = null;
-      formError = '';
-      probing = false;
-      connecting = false;
-    }
-  });
+  function reset() {
+    stage = 'url';
+    serverUrl = '';
+    probedUrl = '';
+    probedInfo = null;
+    formError = '';
+    probing = false;
+    connecting = false;
+  }
+
+  function handleClose() {
+    reset();
+    onclose();
+  }
 
   function normalizeUrl(url: string): string {
     let u = url.trim().replace(/\/+$/, '');
@@ -234,7 +233,7 @@ ADR-027 — only user-facing copy says "server".
   {disabled}
   error={formError}
   onsubmit={stage === 'url' ? handleProbe : handleConnect}
-  {onclose}
+  onclose={handleClose}
 >
   {#snippet description()}
     {#if stage === 'url'}

--- a/frontend/src/lib/components/EmojiPicker.svelte
+++ b/frontend/src/lib/components/EmojiPicker.svelte
@@ -11,7 +11,6 @@ Uses the same section styling as MessageContextMenu (rounded-md bg-background se
 - `onClose` - Callback to dismiss the picker (Escape key)
 -->
 <script lang="ts">
-  import { tick } from 'svelte';
   import * as m from '$lib/i18n/messages';
   import { searchEmojis, EMOJI_BY_CATEGORY } from '$lib/emoji';
   import { isTouchDevice } from '$lib/utils/isTouchDevice';
@@ -28,7 +27,6 @@ Uses the same section styling as MessageContextMenu (rounded-md bg-background se
   } = $props();
 
   let query = $state('');
-  let searchInput: HTMLInputElement | undefined = $state();
   const isTouch = isTouchDevice();
 
   const recentStore = $derived(getRecentEmojis(serverId));
@@ -37,11 +35,9 @@ Uses the same section styling as MessageContextMenu (rounded-md bg-background se
   const searchResults = $derived(query.trim() ? searchEmojis(query.trim(), 50) : []);
   const isSearching = $derived(query.trim().length > 0);
 
-  $effect(() => {
-    if (!isTouch && searchInput) {
-      tick().then(() => searchInput?.focus());
-    }
-  });
+  function focusSearchInput(node: HTMLInputElement) {
+    if (!isTouch) queueMicrotask(() => node.focus());
+  }
 
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === 'Escape') {
@@ -65,7 +61,7 @@ Uses the same section styling as MessageContextMenu (rounded-md bg-background se
   <!-- Search section -->
   <div class="menu-section p-2 md:p-1">
     <input
-      bind:this={searchInput}
+      {@attach focusSearchInput}
       bind:value={query}
       type="text"
       placeholder={m['emoji.search_placeholder']()}

--- a/frontend/src/lib/components/QuickSwitcher.svelte
+++ b/frontend/src/lib/components/QuickSwitcher.svelte
@@ -44,8 +44,8 @@
   let userSearchLoading = $state(false);
   let allItems = $state.raw<ResultItem[]>([]);
   let userItems = $state.raw<ResultItem[]>([]);
-  let dialogEl: HTMLDialogElement | undefined = $state();
-  let inputEl: HTMLInputElement | undefined = $state();
+  let dialogEl: HTMLDialogElement | undefined;
+  let inputEl: HTMLInputElement | undefined;
   let userSearchTimer: ReturnType<typeof setTimeout> | undefined;
   let userSearchRequestId = 0;
 
@@ -365,7 +365,8 @@
 
   // --- Visibility ---
 
-  $effect(() => {
+  function syncQuickSwitcherDialog(node: HTMLDialogElement) {
+    dialogEl = node;
     const visible = quickSwitcher.visible;
 
     untrack(() => {
@@ -375,7 +376,7 @@
         allItems = [];
         userItems = [];
         scheduleUserSearch('');
-        dialogEl?.showModal();
+        if (!node.open) node.showModal();
         requestAnimationFrame(() => inputEl?.focus());
         loadAll();
       } else {
@@ -383,10 +384,14 @@
         userItems = [];
         userSearchLoading = false;
         userSearchRequestId++;
-        dialogEl?.close();
+        if (node.open) node.close();
       }
     });
-  });
+  }
+
+  function registerInput(node: HTMLInputElement) {
+    inputEl = node;
+  }
 
   // --- Navigation ---
 
@@ -545,7 +550,7 @@
 
 <!-- Outer wrapper replicates ContextMenu.svelte's container exactly -->
 <dialog
-  bind:this={dialogEl}
+  {@attach syncQuickSwitcherDialog}
   onclose={() => quickSwitcher.close()}
   onkeydown={(e) => {
     if (e.key === 'Escape') e.stopPropagation();
@@ -568,7 +573,7 @@
         <div class="flex items-center gap-2 px-3 py-1.5">
           <span class="sidebar-icon iconify text-muted uil--search"></span>
           <input
-            bind:this={inputEl}
+            {@attach registerInput}
             bind:value={query}
             oninput={handleQueryInput}
             onkeydown={handleKeydown}

--- a/frontend/src/lib/components/WelcomeBanner.svelte
+++ b/frontend/src/lib/components/WelcomeBanner.svelte
@@ -12,27 +12,25 @@ Only renders when the `welcome=true` query parameter is present.
   import * as m from '$lib/i18n/messages';
   import { Hint } from '$lib/ui';
 
-  let showWelcome = $state(page.url.searchParams.get('welcome') === 'true' || page.state.welcome === true);
+  let showWelcome = $state(
+    page.url.searchParams.get('welcome') === 'true' || page.state.welcome === true
+  );
 
-  // Clear the welcome param from URL after showing
-  $effect(() => {
-    if (showWelcome) {
-      // Remove the query param from URL without navigation
-      const url = new URL(window.location.href);
-      url.searchParams.delete('welcome');
-      window.history.replaceState({}, '', url.toString());
+  function mountWelcomeBanner() {
+    // Remove the query param from URL without navigation.
+    const url = new URL(window.location.href);
+    url.searchParams.delete('welcome');
+    window.history.replaceState({}, '', url.toString());
 
-      // Auto-dismiss after 5 seconds
-      const timer = setTimeout(() => {
-        showWelcome = false;
-      }, 5000);
-      return () => clearTimeout(timer);
-    }
-  });
+    const timer = setTimeout(() => {
+      showWelcome = false;
+    }, 5000);
+    return () => clearTimeout(timer);
+  }
 </script>
 
 {#if showWelcome}
-  <div class="mb-2">
+  <div class="mb-2" {@attach mountWelcomeBanner}>
     <Hint tone="success">
       <div class="flex items-start justify-between gap-3">
         <span>{m['welcome.verified']()}</span>

--- a/frontend/src/lib/components/chat/FullscreenVideoOverlay.svelte
+++ b/frontend/src/lib/components/chat/FullscreenVideoOverlay.svelte
@@ -26,15 +26,11 @@
     elementsReady = true;
   });
 
-  let playerEl = $state<HTMLElement | null>(null);
-
   // Seek to captured playback position once the player can play
-  $effect(() => {
-    if (!playerEl || !fullscreenVideo.isOpen) return;
-
+  function attachPlayer(node: HTMLElement) {
     function handleCanPlay() {
       if (fullscreenVideo.startTime > 0) {
-        const video = playerEl?.querySelector('video');
+        const video = node.querySelector('video');
         if (video) video.currentTime = fullscreenVideo.startTime;
       }
     }
@@ -43,14 +39,14 @@
       e.preventDefault();
     }
 
-    playerEl.addEventListener('can-play', handleCanPlay, { once: true });
+    node.addEventListener('can-play', handleCanPlay, { once: true });
     // Use capture phase so we intercept before Vidstack's internal handler.
-    playerEl.addEventListener('media-enter-fullscreen-request', blockFullscreen, true);
+    node.addEventListener('media-enter-fullscreen-request', blockFullscreen, true);
     return () => {
-      playerEl?.removeEventListener('can-play', handleCanPlay);
-      playerEl?.removeEventListener('media-enter-fullscreen-request', blockFullscreen, true);
+      node.removeEventListener('can-play', handleCanPlay);
+      node.removeEventListener('media-enter-fullscreen-request', blockFullscreen, true);
     };
-  });
+  }
 
   function close() {
     if (document.fullscreenElement) {
@@ -85,7 +81,7 @@
     </button>
 
     <media-player
-      bind:this={playerEl}
+      {@attach attachPlayer}
       src={{ src: fullscreenVideo.src, type: 'video/mp4' }}
       autoplay
       playsinline

--- a/frontend/src/lib/components/chat/VideoPlayer.svelte
+++ b/frontend/src/lib/components/chat/VideoPlayer.svelte
@@ -89,19 +89,15 @@
 		}
 	});
 
-	let playerEl = $state<HTMLElement | null>(null);
-
 	// Intercept Vidstack's fullscreen request — the <media-player> lives inside
 	// virtua's virtualized list, so native fullscreen would cause virtua to
 	// unmount the DOM node. Instead, open our CSS overlay outside the list.
-	$effect(() => {
-		if (!playerEl) return;
-
+	function interceptFullscreenRequest(node: HTMLElement) {
 		function handleFullscreenRequest(e: Event) {
 			e.preventDefault();
 			if (!selectedVariant) return;
 
-			const video = playerEl?.querySelector('video');
+			const video = node.querySelector('video');
 			if (video) video.pause();
 
 			fullscreenVideo.open(
@@ -121,12 +117,11 @@
 		}
 
 		// Use capture phase so we intercept before Vidstack's internal handler.
-		playerEl.addEventListener('media-enter-fullscreen-request', handleFullscreenRequest, true);
+		node.addEventListener('media-enter-fullscreen-request', handleFullscreenRequest, true);
 		return () => {
-			playerEl?.removeEventListener('media-enter-fullscreen-request', handleFullscreenRequest, true);
+			node.removeEventListener('media-enter-fullscreen-request', handleFullscreenRequest, true);
 		};
-	});
-
+	}
 </script>
 
 {#if status === 'COMPLETED' && selectedVariant && autoLoop}
@@ -153,7 +148,7 @@
 		style="width: {displaySize.width}px; max-width: 100%;"
 	>
 		<media-player
-			bind:this={playerEl}
+			{@attach interceptFullscreenRequest}
 			src={videoSrc}
 			playsinline
 			onerror={onMediaError}

--- a/frontend/src/lib/components/composer/AutocompletePopup.svelte
+++ b/frontend/src/lib/components/composer/AutocompletePopup.svelte
@@ -40,12 +40,9 @@ configurable selection keys, and customizable item rendering via snippets.
     item
   }: Props = $props();
 
-  let selectedIndex = $state(0);
-
-  // Reset selection when items change
-  $effect(() => {
+  let selectedIndex = $derived.by(() => {
     void items;
-    selectedIndex = 0;
+    return 0;
   });
 
   export function handleKeyDown(event: KeyboardEvent): boolean {

--- a/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -126,21 +126,17 @@
       (editState.channelEchoEventId !== null || editState.canAddChannelEcho)
   );
 
-  // Element ref for ResizeObserver
-  let composerEl = $state<HTMLDivElement>();
-
   // When the composer resizes (editor grows/shrinks, attachments added/removed),
   // scroll to bottom if sticky. This replaces the synchronous scrollToBottomIfSticky()
   // that was lost when the old textarea's autoResize() was removed during TipTap migration.
-  $effect(() => {
-    if (!composerEl || !scrollState) return;
-
+  function observeComposerResize(node: HTMLDivElement) {
+    if (!scrollState) return;
     const observer = new ResizeObserver(() => {
       scrollState.scrollToBottomIfSticky();
     });
-    observer.observe(composerEl);
+    observer.observe(node);
     return () => observer.disconnect();
-  });
+  }
 
   const DRAFT_KEY = $derived(draftKey(roomId, inThread));
   let message = $state('');
@@ -882,7 +878,7 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
-  bind:this={composerEl}
+  {@attach observeComposerResize}
   class="flex flex-col gap-2 p-2"
   onclick={(e) => {
     if (!(e.target as HTMLElement).closest('button, a, input, label, select, .tiptap')) {

--- a/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -221,7 +221,13 @@
 
   // Load draft from sessionStorage when room changes
   // Using sessionStorage (not localStorage) so drafts are tab-specific
+  let autocompleteResetRoomId = '';
   $effect(() => {
+    if (autocompleteResetRoomId !== roomId) {
+      autocompleteResetRoomId = roomId;
+      autocomplete.resetForRoom();
+    }
+
     if (isEditing) {
       draftState.switchKey(DRAFT_KEY);
       attachments.restore([]);
@@ -357,12 +363,6 @@
     if (editorApi && !inputDisabled) {
       tick().then(() => editorApi?.focus());
     }
-  });
-
-  // Close autocomplete popups when switching rooms
-  $effect(() => {
-    void roomId;
-    autocomplete.resetForRoom();
   });
 
   // Handle emoji selection from autocomplete

--- a/frontend/src/lib/ui/BottomSheet.svelte
+++ b/frontend/src/lib/ui/BottomSheet.svelte
@@ -13,8 +13,8 @@
     onclose?: () => void;
   } = $props();
 
-  let dialogEl: HTMLDialogElement | undefined = $state();
-  let contentEl: HTMLElement | undefined = $state();
+  let dialogEl: HTMLDialogElement | undefined;
+  let contentEl: HTMLElement | undefined;
   let closing = $state(false);
   let dragging = $state(false);
   let dragOffsetY = $state(0);
@@ -31,14 +31,19 @@
   // Downward fling velocity (px/ms) that always closes regardless of distance.
   const FLING_CLOSE_VELOCITY = 0.5;
 
-  $effect(() => {
+  function syncSheetVisibility(node: HTMLDialogElement) {
+    dialogEl = node;
     if (visible) {
       closing = false;
-      dialogEl?.showModal();
-    } else if (dialogEl?.open && !closing) {
-      dialogEl?.close();
+      if (!node.open) node.showModal();
+    } else if (node.open && !closing) {
+      node.close();
     }
-  });
+  }
+
+  function registerContent(node: HTMLElement) {
+    contentEl = node;
+  }
 
   function handleNativeClose() {
     visible = false;
@@ -59,7 +64,7 @@
 </script>
 
 <dialog
-  bind:this={dialogEl}
+  {@attach syncSheetVisibility}
   onclose={handleNativeClose}
   oncancel={(e) => {
     e.preventDefault();
@@ -100,7 +105,7 @@
   class:closing
 >
   <div
-    bind:this={contentEl}
+    {@attach registerContent}
     class="pb-safe rounded-t-xl border-t border-border bg-surface"
     class:dragging
     style:transform={dragOffsetY > 0 ? `translateY(${dragOffsetY}px)` : undefined}

--- a/frontend/src/lib/ui/Dialog.svelte
+++ b/frontend/src/lib/ui/Dialog.svelte
@@ -22,7 +22,7 @@
     onclose?: () => void;
   } = $props();
 
-  let dialogEl: HTMLDialogElement | undefined = $state();
+  let dialogEl: HTMLDialogElement | undefined;
   let closing = $state(false);
   // True when the current press started inside the content. Prevents a drag
   // that began inside (e.g. text selection) from closing on release outside.
@@ -44,11 +44,12 @@
     lg: 'w-200 max-w-[90vw]'
   };
 
-  $effect(() => {
+  function syncDialogVisibility(node: HTMLDialogElement) {
+    dialogEl = node;
     if (visible) {
       closing = false;
       pressStartedInside = true;
-      dialogEl?.showModal();
+      if (!node.open) node.showModal();
       // showModal() naturally focuses the first focusable element, which
       // for our layout is the Close (X) button in the header — not what
       // users expect. Move focus to the first form field, falling back
@@ -58,26 +59,25 @@
       // focus via the native `autofocus` attribute is left alone.
       if (shouldAutoFocus()) {
         queueMicrotask(() => {
-          if (!dialogEl) return;
           const fieldSelector =
             'input:not([type="hidden"]):not([disabled]),textarea:not([disabled]),select:not([disabled])';
           const active = document.activeElement;
           const alreadyOnField =
             active instanceof HTMLElement &&
-            dialogEl.contains(active) &&
+            node.contains(active) &&
             active.matches(fieldSelector);
           if (alreadyOnField) return;
           const target =
-            dialogEl.querySelector<HTMLElement>(fieldSelector) ??
-            dialogEl.querySelector<HTMLElement>('button[type="submit"]:not([disabled])');
+            node.querySelector<HTMLElement>(fieldSelector) ??
+            node.querySelector<HTMLElement>('button[type="submit"]:not([disabled])');
           target?.focus();
         });
       }
-    } else if (dialogEl?.open && !closing) {
+    } else if (node.open && !closing) {
       // Already closed via close() function
-      dialogEl?.close();
+      node.close();
     }
-  });
+  }
 
   function handleNativeClose() {
     visible = false;
@@ -96,7 +96,7 @@
 </script>
 
 <dialog
-  bind:this={dialogEl}
+  {@attach syncDialogVisibility}
   onclose={handleNativeClose}
   oncancel={(e) => {
     // Always run our animated close path; never let the browser close the

--- a/frontend/src/lib/ui/FloatingPopover.svelte
+++ b/frontend/src/lib/ui/FloatingPopover.svelte
@@ -70,11 +70,11 @@ pointer-only).
     children: Snippet;
   } = $props();
 
-  let node = $state<HTMLDivElement>();
+  let node: HTMLDivElement | undefined;
 
-  function applyPosition() {
-    if (!node) return;
-    const { height, width } = node.getBoundingClientRect();
+  function applyPosition(popover = node) {
+    if (!popover) return;
+    const { height, width } = popover.getBoundingClientRect();
     let top: number;
     let left: number;
 
@@ -123,29 +123,28 @@ pointer-only).
       return;
     }
 
-    node.style.top = `${top}px`;
-    node.style.left = `${left}px`;
+    popover.style.top = `${top}px`;
+    popover.style.left = `${left}px`;
   }
 
-  function showAndPosition() {
-    if (!node) return;
-    const wasOpen = node.matches(':popover-open');
+  function showAndPosition(popover: HTMLDivElement) {
+    const wasOpen = popover.matches(':popover-open');
 
     if (!wasOpen) {
-      node.style.visibility = 'hidden';
-      node.showPopover();
+      popover.style.visibility = 'hidden';
+      popover.showPopover();
     }
 
-    applyPosition();
+    applyPosition(popover);
 
     if (!wasOpen) {
-      node.style.visibility = '';
+      popover.style.visibility = '';
     }
   }
 
   // Show on mount + reposition reactively whenever anchor/position changes.
-  $effect(() => {
-    if (!node) return;
+  function syncPopover(popover: HTMLDivElement) {
+    node = popover;
     // Re-read reactive inputs so the effect retriggers when they change.
     void open;
     void anchor;
@@ -153,31 +152,31 @@ pointer-only).
     void position;
 
     if (!open) {
-      if (node.matches(':popover-open')) node.hidePopover();
+      if (popover.matches(':popover-open')) popover.hidePopover();
       return;
     }
 
-    showAndPosition();
-  });
+    showAndPosition(popover);
+  }
 
   // Reposition when child content changes size after the popover has opened.
-  $effect(() => {
-    if (!node || !open) return;
-    const observer = new ResizeObserver(() => applyPosition());
-    observer.observe(node);
+  function observePopoverSize(popover: HTMLDivElement) {
+    if (!open) return;
+    const observer = new ResizeObserver(() => applyPosition(popover));
+    observer.observe(popover);
     return () => observer.disconnect();
-  });
+  }
 
   // Pointer-based dismissal (deferred one frame so the opening click doesn't
   // immediately close the popover).
-  $effect(() => {
-    if (!node || !open || !onclose) return;
+  function closeOnOutsideInteraction(popover: HTMLDivElement) {
+    if (!open || !onclose) return;
     const handlePointerDown = (e: PointerEvent) => {
-      if (!node || node.contains(e.target as Node)) return;
+      if (popover.contains(e.target as Node)) return;
       onclose();
     };
     const handleScroll = (e: Event) => {
-      if (!node || node.contains(e.target as Node)) return;
+      if (popover.contains(e.target as Node)) return;
       onclose();
     };
     const frame = requestAnimationFrame(() => {
@@ -189,11 +188,13 @@ pointer-only).
       document.removeEventListener('pointerdown', handlePointerDown);
       window.removeEventListener('scroll', handleScroll, { capture: true });
     };
-  });
+  }
 </script>
 
 <div
-  bind:this={node}
+  {@attach syncPopover}
+  {@attach observePopoverSize}
+  {@attach closeOnOutsideInteraction}
   {id}
   popover="manual"
   class={['fixed inset-auto z-50 m-0', !open && 'hidden', className]}

--- a/frontend/src/lib/ui/HelpTooltip.svelte
+++ b/frontend/src/lib/ui/HelpTooltip.svelte
@@ -45,18 +45,27 @@ handles viewport-clamped positioning.
   let anchorRect = $state<{ top: number; bottom: number; left: number } | null>(null);
   const tooltipId = `help-tooltip-${crypto.randomUUID().slice(0, 8)}`;
 
+  function setOpen(value: boolean) {
+    open = value;
+    if (value) {
+      updateAnchor();
+    } else {
+      anchorRect = null;
+    }
+  }
+
   function showHover() {
-    if (!pinned) open = true;
+    if (!pinned) setOpen(true);
   }
   function hideHover() {
-    if (!pinned) open = false;
+    if (!pinned) setOpen(false);
   }
   function toggle(e: MouseEvent) {
     // Stop propagation so the document click listener doesn't immediately
     // unpin a freshly-pinned popover.
     e.stopPropagation();
     pinned = !pinned;
-    open = pinned;
+    setOpen(pinned);
   }
 
   function updateAnchor() {
@@ -65,45 +74,39 @@ handles viewport-clamped positioning.
     anchorRect = { top: r.top, bottom: r.bottom, left: r.left };
   }
 
-  // Keep the anchor following the trigger while open. FloatingPopover
-  // re-positions reactively when `anchorRect` updates.
-  $effect(() => {
-    if (!open) {
-      anchorRect = null;
-      return;
-    }
-    updateAnchor();
-    const onScrollOrResize = () => updateAnchor();
-    window.addEventListener('scroll', onScrollOrResize, true);
-    window.addEventListener('resize', onScrollOrResize);
+  function attachTrigger(node: HTMLButtonElement) {
+    trigger = node;
     return () => {
-      window.removeEventListener('scroll', onScrollOrResize, true);
-      window.removeEventListener('resize', onScrollOrResize);
+      if (trigger === node) trigger = undefined;
     };
-  });
+  }
 
-  // Escape closes a pinned popover. Pointer-outside dismissal is handled
-  // by FloatingPopover via the `onclose` callback below.
-  $effect(() => {
+  function handleViewportChange() {
+    if (open) updateAnchor();
+  }
+
+  function handleDocumentKeydown(e: KeyboardEvent) {
     if (!pinned) return;
-    function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') {
-        pinned = false;
-        open = false;
-      }
+    if (e.key === 'Escape') {
+      pinned = false;
+      setOpen(false);
     }
-    document.addEventListener('keydown', onKey);
-    return () => document.removeEventListener('keydown', onKey);
-  });
+  }
 
   function handleOutsideDismiss() {
     pinned = false;
-    open = false;
+    setOpen(false);
   }
 </script>
 
+<!-- Keep the anchor following the trigger while open. FloatingPopover re-positions reactively when `anchorRect` updates. -->
+<svelte:window onscrollcapture={handleViewportChange} onresize={handleViewportChange} />
+
+<!-- Escape closes a pinned popover. Pointer-outside dismissal is handled by FloatingPopover via the `onclose` callback below. -->
+<svelte:document onkeydown={handleDocumentKeydown} />
+
 <button
-  bind:this={trigger}
+  {@attach attachTrigger}
   type="button"
   aria-label={label}
   aria-describedby={open ? tooltipId : undefined}
@@ -122,10 +125,10 @@ handles viewport-clamped positioning.
     anchor={anchorRect}
     role="tooltip"
     id={tooltipId}
-    class="menu max-w-xs"
+    class="max-w-xs menu"
     onclose={pinned ? handleOutsideDismiss : undefined}
   >
-    <div class="menu-section whitespace-normal px-3 py-2 text-xs">
+    <div class="menu-section px-3 py-2 text-xs whitespace-normal">
       {@render children()}
     </div>
   </FloatingPopover>

--- a/frontend/src/lib/ui/ImageModal.svelte
+++ b/frontend/src/lib/ui/ImageModal.svelte
@@ -22,11 +22,9 @@
   let current = $derived(items[index]);
   let hasMultiple = $derived(items.length > 1);
 
-  let dialogEl: HTMLDialogElement | undefined = $state();
-
-  $effect(() => {
-    dialogEl?.showModal();
-  });
+  function showDialog(node: HTMLDialogElement) {
+    node.showModal();
+  }
 
   function close() {
     onclose();
@@ -51,11 +49,11 @@
 </script>
 
 <dialog
-  bind:this={dialogEl}
+  {@attach showDialog}
   onclose={close}
   onkeydown={handleKeydown}
   onclick={(e) => {
-    if (e.target === dialogEl) close();
+    if (e.target === e.currentTarget) close();
   }}
   class="fixed inset-0 m-0 flex h-dvh max-h-dvh w-dvw max-w-dvw items-center justify-center border-none bg-black/80 p-0 backdrop:bg-transparent"
 >

--- a/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -130,6 +130,13 @@
   let lastSeenNewestId = $state<string | null>(null);
   let firstVisibleDate = $state<string | null>(null);
 
+  function setShouldScrollToBottom(value: boolean) {
+    shouldScrollToBottom = value;
+    if (value) {
+      hasNewMessages = false;
+    }
+  }
+
   // Track previous scroll offset for direction detection
   let previousOffset = $state<number | null>(null);
 
@@ -192,8 +199,7 @@
     void roomId;
 
     initialScrollDone = false;
-    shouldScrollToBottom = true;
-    hasNewMessages = false;
+    setShouldScrollToBottom(true);
     lastSeenNewestId = null;
     previousOffset = null;
   });
@@ -203,7 +209,7 @@
   let prevJumpedMode: boolean | undefined;
   $effect(() => {
     if (prevJumpedMode && !isJumpedMode) {
-      shouldScrollToBottom = true;
+      setShouldScrollToBottom(true);
     }
     prevJumpedMode = isJumpedMode;
   });
@@ -224,13 +230,6 @@
     lastSeenNewestId = newestId;
   });
 
-  // Clear new messages indicator when scrolling back to bottom
-  $effect(() => {
-    if (shouldScrollToBottom) {
-      hasNewMessages = false;
-    }
-  });
-
   // Watch for scroll-to-bottom requests from MessageComposer (after posting a message).
   // Clears scrollUpLock since posting a message is explicit user intent to see the bottom.
   // Uses scrollContainer.scrollTop instead of scrollToIndex because the user may have
@@ -240,7 +239,7 @@
     if (!scrollState || alwaysScrollToBottom) return;
     const counter = scrollState.scrollRequestCounter;
     if (counter > 0) {
-      shouldScrollToBottom = true;
+      setShouldScrollToBottom(true);
       scrollUpLock = false;
       if (scrollUpLockTimer) {
         clearTimeout(scrollUpLockTimer);
@@ -268,7 +267,7 @@
     if (targetIdx === -1) return;
 
     // Disable auto-scroll so it doesn't race with the jump scroll.
-    shouldScrollToBottom = false;
+    setShouldScrollToBottom(false);
     // Mark initial scroll as done so pending initial loading state cannot obscure the jump.
     initialScrollDone = true;
 
@@ -291,7 +290,7 @@
           virtualizerHandle.getScrollOffset() -
           virtualizerHandle.getViewportSize();
         if (dist < 50) {
-          shouldScrollToBottom = true;
+          setShouldScrollToBottom(true);
         }
       }, 200);
 
@@ -393,8 +392,7 @@
 
   // Scroll to bottom when clicking the new messages indicator
   function scrollToBottom() {
-    shouldScrollToBottom = true;
-    hasNewMessages = false;
+    setShouldScrollToBottom(true);
     if (virtualizerHandle) {
       safeScrollToIndex(virtualItems.length - 1, { align: 'end' });
       scrollFader?.refresh();
@@ -516,7 +514,7 @@
       await new Promise((resolve) => requestAnimationFrame(resolve));
 
       if (wasAtBottom) {
-        shouldScrollToBottom = true;
+        setShouldScrollToBottom(true);
         initialScrollDone = true;
         startScrollCorrection();
         scrollContainer?.scrollTo({ top: scrollContainer.scrollHeight });
@@ -573,7 +571,7 @@
       virtualizerHandle.getScrollSize() -
       virtualizerHandle.getScrollOffset() -
       virtualizerHandle.getViewportSize();
-    if (dist > 50) shouldScrollToBottom = false;
+    if (dist > 50) setShouldScrollToBottom(false);
   });
 
   let forwardLoadInFlight = false;
@@ -581,8 +579,7 @@
   function exitJumpedModeAtPresent(bottomDistance: number): boolean {
     if (!isJumpedMode || !hasReachedEnd || bottomDistance >= 50 || !onReachedPresent) return false;
 
-    shouldScrollToBottom = true;
-    hasNewMessages = false;
+    setShouldScrollToBottom(true);
     console.debug('[room-refresh] reached present after forward pagination', {
       roomId,
       bottomDistance,
@@ -624,7 +621,7 @@
     if (!alwaysScrollToBottom) {
       // Re-enable auto-scroll if we're at the bottom (and not locked)
       if (distanceFromBottom < 10 && !scrollUpLock) {
-        shouldScrollToBottom = true;
+        setShouldScrollToBottom(true);
       }
       // Disable auto-scroll if user scrolled up (and clearly not near the bottom).
       // Gated on a recent wheel/touchmove signal so virtua's internal scroll
@@ -639,7 +636,7 @@
         offset < previousOffset - 10 &&
         distanceFromBottom > 20
       ) {
-        shouldScrollToBottom = false;
+        setShouldScrollToBottom(false);
         pendingScrollCorrection = false;
         if (scrollCorrectionTimer) {
           clearTimeout(scrollCorrectionTimer);

--- a/frontend/src/routes/chat/[serverId]/settings/+page.svelte
+++ b/frontend/src/routes/chat/[serverId]/settings/+page.svelte
@@ -95,13 +95,10 @@
       });
   });
 
-  // Clear messages when the user modifies inputs
-  $effect(() => {
-    if (displayNameModified || loginModified) {
-      error = '';
-      successMessage = '';
-    }
-  });
+  function clearProfileMessages() {
+    error = '';
+    successMessage = '';
+  }
 
   function customStatusAPIConfig() {
     const conn = connection();
@@ -340,7 +337,6 @@
       isSaving = false;
     }
   }
-
 </script>
 
 <PaneHeader
@@ -428,6 +424,7 @@
       bind:value={displayName}
       placeholder={m['settings.profile.display_name.placeholder']()}
       disabled={isSaving}
+      oninput={clearProfileMessages}
     />
 
     <TextInput
@@ -436,6 +433,7 @@
       placeholder={m['settings.profile.username.placeholder']()}
       disabled={isSaving || !canChangeLogin}
       testid="settings-username"
+      oninput={clearProfileMessages}
     />
 
     {#if cooldownLoaded && !canChangeLogin}


### PR DESCRIPTION
## Summary

- Replace simple local `$effect` state resets with event handlers or writable `$derived`
- Move DOM lifecycle work for composer resize, emoji autofocus, help tooltip positioning/dismissal, welcome banner cleanup, image modal opening, video fullscreen interception, and shared dialog/popover lifecycles into Svelte attachments/event elements
- Keep real external side-effect boundaries such as subscriptions, async loaders, timers, update reloads, service worker listeners, and event bus work on `$effect`
- Reduce frontend `$effect` call sites from 137 to 118

Closes #1124.

## Verification

- `git diff --check`
- Svelte autofixer on edited components
- focused Vitest coverage for Dialog, FloatingPopover consumers, QuickSwitcher, ImageModal, and MessageComposer
- `mise lint-frontend`
- `mise test-frontend`
