### PR TITLE
fix(frontend): submit simple message edits with enter

### DIFF
--- a/frontend/e2e/message-editing.test.ts
+++ b/frontend/e2e/message-editing.test.ts
@@ -30,6 +30,29 @@ test.describe('Up arrow to edit last message', () => {
     await expect(roomPage.composer).toHaveText(originalMessage);
   });
 
+  test('pressing Enter commits a simple up-arrow edit', async ({ page, chatPage, roomPage }) => {
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.enterRoom('general');
+
+    const originalMessage = `Simple up edit ${Date.now()}`;
+    await roomPage.sendMessage(originalMessage);
+
+    await roomPage.messageInput.clear();
+    await roomPage.messageInput.focus();
+    await roomPage.pressUpArrow();
+    await roomPage.expectEditModeActive();
+
+    const editedMessage = `Simple up edit saved ${Date.now()}`;
+    await roomPage.messageInput.fill(editedMessage);
+    await expect(page.getByText(/(?:Cmd|Ctrl)\+Return to Send/)).not.toBeVisible();
+
+    await roomPage.messageInput.press('Enter');
+    await roomPage.expectEditModeInactive();
+    await roomPage.expectMessageVisible(editedMessage);
+    await roomPage.expectMessageNotVisible(originalMessage);
+  });
+
   test('pressing up arrow with text in input does NOT start editing', async ({
     page,
     chatPage,
@@ -477,7 +500,7 @@ test.describe('Message editing', () => {
       await page.keyboard.press(docEnd);
       await page.keyboard.type('x');
       await page.keyboard.press('Backspace');
-      await roomPage.composer.press('Control+Enter');
+      await roomPage.composer.press('Enter');
       await roomPage.expectEditModeInactive();
       return snapshot;
     };

--- a/frontend/e2e/pages/RoomPage.ts
+++ b/frontend/e2e/pages/RoomPage.ts
@@ -439,7 +439,7 @@ export class RoomPage {
    */
   async completeEdit(newText: string): Promise<void> {
     await this.composer.fill(newText);
-    await this.composer.press('Control+Enter');
+    await this.composer.press('Enter');
     await expect(this.editingIndicator).not.toBeVisible({ timeout: TIMEOUTS.UI_FAST });
   }
 
@@ -691,7 +691,7 @@ export class RoomPage {
    */
   async completeThreadEdit(newText: string): Promise<void> {
     await this.threadReplyInput.fill(newText);
-    await this.threadReplyInput.press('Control+Enter');
+    await this.threadReplyInput.press('Enter');
     await expect(this.threadEditingIndicator).not.toBeVisible({ timeout: TIMEOUTS.UI_FAST });
   }
 

--- a/frontend/e2e/threading.test.ts
+++ b/frontend/e2e/threading.test.ts
@@ -234,7 +234,7 @@ test.describe('Message Threading', () => {
         await roomPage.expectThreadEditModeActive();
         const editedReply = `Edited reply ${Date.now()}`;
         await roomPage.threadReplyInput.fill(editedReply);
-        await roomPage.threadReplyInput.press('Control+Enter');
+        await roomPage.threadReplyInput.press('Enter');
 
         // User B should see the new content and the (edited) marker.
         await expect(roomPage2.threadPane.getByText(editedReply)).toBeVisible({

--- a/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -332,7 +332,7 @@
   let editorNextEnterWillSend = $state(false);
   let manualRichMode = $state(false);
   let editorHasRichStructure = $state(false);
-  let isRichComposer = $derived(isEditing || manualRichMode || editorHasRichStructure);
+  let isRichComposer = $derived(manualRichMode || editorHasRichStructure);
   let nextEnterWillSend = $derived(canSubmit && isRichComposer && editorNextEnterWillSend);
   let submitHint = $derived(
     shortcutHints && isRichComposer

--- a/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -1146,7 +1146,7 @@ describe('MessageComposer', () => {
       );
     });
 
-    it('keeps edit mode on rich keyboard behavior', async () => {
+    it('sends a plain text edit with Enter', async () => {
       roomStateMock.editState.eventId = 'evt_edit';
       roomStateMock.editState.originalBody = 'original body';
       const { container } = renderMessageComposer(
@@ -1155,9 +1155,33 @@ describe('MessageComposer', () => {
       );
       const editor = await findEditor(container);
 
-      await vi.waitFor(() => expect(container.textContent).toMatch(/(?:Cmd|Ctrl)\+Return to Send/));
+      await vi.waitFor(() => expect(editor.textContent).toBe('original body'));
+      expect(container.textContent).not.toMatch(/(?:Cmd|Ctrl)\+Return to Send/);
       await pressEditorKey(editor, 'Enter');
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({
+        eventId: 'evt_edit',
+        body: 'original body'
+      });
+    });
+
+    it('can force rich keyboard behavior while editing plain text', async () => {
+      roomStateMock.editState.eventId = 'evt_edit';
+      roomStateMock.editState.originalBody = 'original body';
+      const { container } = renderMessageComposer(
+        { roomId: 'room_456' },
+        new Map([['$$_urql', mockClient]])
+      );
+      const editor = await findEditor(container);
+
+      await vi.waitFor(() => expect(editor.textContent).toBe('original body'));
+      await pressEditorKey(editor, 'Enter', { ctrlKey: true });
       expect(mutationMock).not.toHaveBeenCalled();
+      await vi.waitFor(() => expect(editor.querySelectorAll(':scope > p')).toHaveLength(2));
+      await vi.waitFor(() =>
+        expect(container.textContent).toMatch(/(?:Return|Enter) again to Send/)
+      );
 
       await pressEditorKey(editor, 'Enter', { ctrlKey: true });
 


### PR DESCRIPTION
## Summary

Fixes message editing so simple edits commit with Enter instead of being forced into rich composer shortcuts.
Keeps rich-mode behavior available when the edit actually has rich structure or the user activates it with Cmd/Ctrl+Enter.
Adds E2E coverage for committing a simple up-arrow edit with Enter and updates edit helpers to match the behavior.

## Verification

- `mise x -- pnpm exec playwright test e2e/message-editing.test.ts e2e/composer.test.ts --retries=0`
- `mise x -- pnpm exec playwright test e2e/threading.test.ts -g "thread reply edit propagates|reply in thread quotes|reply in room quotes" --retries=0`
- `mise x -- pnpm exec playwright test e2e/thread-reply-echo.test.ts -g "editing echo in main room propagates|editing original in thread propagates|editing an un-echoed thread reply can add|editing an echoed thread reply can remove|editing an echo in the main room can remove" --retries=0`
- `mise x -- pnpm exec vitest run src/lib/components/composer/MessageComposer.svelte.spec.ts`
