### PR TITLE
fix(ci): gate release-please on green ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,13 @@ name: ci
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'release-[0-9]*'
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'release-[0-9]*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,7 +1,9 @@
 name: release-please
 
 on:
-  push:
+  workflow_run:
+    workflows: [ci]
+    types: [completed]
     branches:
       - main
       - 'release-[0-9]*'
@@ -12,9 +14,10 @@ permissions:
 
 jobs:
   release-please:
+    if: ${{ github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     env:
-      TARGET_BRANCH: ${{ github.ref_name }}
+      TARGET_BRANCH: ${{ github.event.workflow_run.head_branch }}
       CONFIG_FILE: .release-please-config.json
       MANIFEST_FILE: .release-please-manifest.json
     steps:


### PR DESCRIPTION
## Summary

- Run `release-please` only after the `ci` workflow completes successfully for push events.
- Extend CI branch coverage to `release-[0-9]*` so release branches have the same gate as `main`.

## Verification

- `mise x -- actionlint .github/workflows/ci.yml .github/workflows/release-please.yml`
- `git diff --check`
