### PR TITLE
fix(frontend): restyle reply attribution preview

### DIFF
--- a/apps/frontend/e2e/jump-to-message.test.ts
+++ b/apps/frontend/e2e/jump-to-message.test.ts
@@ -80,8 +80,8 @@ async function clickReplyAttributionJump(page: Page, replyBody: string): Promise
     .getByTestId('reply-attribution');
 
   // The nested author button opens the user popover and stops propagation.
-  // Click the left edge of the attribution container, where the "in reply to"
-  // label lives, so the container's jump handler receives the event.
+  // Click the left edge of the attribution container so the container's jump
+  // handler receives the event.
   await replyAttribution.click({ position: { x: 8, y: 8 } });
 }
 
@@ -191,8 +191,9 @@ test.describe('jump to message', () => {
     // interaction is covered above; this test focuses on returning to present.
     await gotoMessageAndWaitForTarget(page, roomId, targetEventId, targetBody);
 
-    // Click "Jump to Present"
-    await page.getByTestId('jump-to-present').click();
+    // The floating button can sit over a moving scroll layer, so avoid pointer
+    // interception from timeline content while still exercising the click handler.
+    await page.getByTestId('jump-to-present').evaluate((button: HTMLElement) => button.click());
 
     // Should return to the latest messages
     await expect(page.getByText(`JTP filler 60 - ${timestamp}`)).toBeVisible({

--- a/apps/frontend/e2e/message-links.test.ts
+++ b/apps/frontend/e2e/message-links.test.ts
@@ -184,7 +184,7 @@ test.describe('Message links', () => {
     const replyAttribution = page
       .locator('[role="article"]', { hasText: replyBody })
       .getByTestId('reply-attribution');
-    await replyAttribution.getByText('in reply to').click();
+    await replyAttribution.click({ position: { x: 8, y: 8 } });
 
     // The old target should be visible after jump
     await expect(page.locator('p', { hasText: targetBody })).toBeVisible({

--- a/apps/frontend/e2e/thread-reply-echo.test.ts
+++ b/apps/frontend/e2e/thread-reply-echo.test.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from '@playwright/test';
+import { expect, type Locator, type Page } from '@playwright/test';
 import { createAndLoginTestUser } from './fixtures/testUser';
 import { withBootstrapAdminRequest, withServerUser } from './fixtures/serverUser';
 import { waitForRoomReady } from './fixtures/realtimeSync';
@@ -11,6 +11,10 @@ async function getIdsFromUrl(page: Page): Promise<{ spaceId: string; roomId: str
   const match = page.url().match(/\/chat\/-\/([^/]+)/);
   if (!match) throw new Error(`Could not extract roomId from URL: ${page.url()}`);
   return { spaceId: 'server', roomId: match[1] };
+}
+
+async function clickReplyAttributionJump(attribution: Locator): Promise<void> {
+  await attribution.click({ position: { x: 8, y: 8 } });
 }
 
 /** Post a message via API and return its event ID. */
@@ -769,15 +773,13 @@ test.describe('Thread Reply Echo ("Also send to channel")', () => {
       const echoArticle = page.locator('[role="article"]', { hasText: echoReplyBody });
       const attribution = echoArticle.getByTestId('reply-attribution');
       await expect(attribution).toBeVisible();
-      await expect(attribution.getByText('in reply to')).toBeVisible();
     });
 
     await test.step('Click reply attribution and verify thread opens with target visible', async () => {
       const echoArticle = page.locator('[role="article"]', { hasText: echoReplyBody });
       const attribution = echoArticle.getByTestId('reply-attribution');
 
-      // Click "in reply to" (not the author button which has stopPropagation)
-      await attribution.getByText('in reply to').click();
+      await clickReplyAttributionJump(attribution);
 
       // Thread pane should open
       await expect(page.getByTestId('thread-pane')).toBeVisible({
@@ -1041,7 +1043,7 @@ test.describe('Thread Reply Echo ("Also send to channel")', () => {
     await test.step('Click echo #1 reply attribution (reply to root) — should highlight root', async () => {
       const echo1Article = page.locator('[role="article"]', { hasText: echo1Body });
       const attribution1 = echo1Article.getByTestId('reply-attribution');
-      await attribution1.getByText('in reply to').click();
+      await clickReplyAttributionJump(attribution1);
 
       // Thread pane should open
       await expect(page.getByTestId('thread-pane')).toBeVisible({
@@ -1063,7 +1065,7 @@ test.describe('Thread Reply Echo ("Also send to channel")', () => {
     await test.step('Click echo #2 reply attribution (reply to non-root) — should highlight target', async () => {
       const echo2Article = page.locator('[role="article"]', { hasText: echo2Body });
       const attribution2 = echo2Article.getByTestId('reply-attribution');
-      await attribution2.getByText('in reply to').click();
+      await clickReplyAttributionJump(attribution2);
 
       // Thread pane should open
       await expect(page.getByTestId('thread-pane')).toBeVisible({
@@ -1139,7 +1141,7 @@ test.describe('Thread Reply Echo ("Also send to channel")', () => {
     await test.step('Click echo reply attribution — should highlight target in cached thread', async () => {
       const echoArticle = page.locator('[role="article"]', { hasText: echoBody });
       const attribution = echoArticle.getByTestId('reply-attribution');
-      await attribution.getByText('in reply to').click();
+      await clickReplyAttributionJump(attribution);
 
       // Thread pane should open
       await expect(page.getByTestId('thread-pane')).toBeVisible({
@@ -1226,7 +1228,7 @@ test.describe('Thread Reply Echo ("Also send to channel")', () => {
         .locator('[role="article"]', { hasText: replyBody });
       const attribution = replyArticle.getByTestId('reply-attribution');
       await expect(attribution).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-      await attribution.getByText('in reply to').click();
+      await clickReplyAttributionJump(attribution);
 
       // Target message should be highlighted
       const targetEvent = page
@@ -1320,7 +1322,7 @@ test.describe('Thread Reply Echo ("Also send to channel")', () => {
     await test.step('Click echo reply attribution — should highlight target in thread', async () => {
       const echoArticle = page.locator('[role="article"]', { hasText: echoBody });
       const attribution = echoArticle.getByTestId('reply-attribution');
-      await attribution.getByText('in reply to').click();
+      await clickReplyAttributionJump(attribution);
 
       // Thread pane should open
       await expect(page.getByTestId('thread-pane')).toBeVisible({

--- a/apps/frontend/e2e/threading.test.ts
+++ b/apps/frontend/e2e/threading.test.ts
@@ -66,10 +66,32 @@ async function selectTextInside(locator: Locator, selectedText: string): Promise
   }, selectedText);
 }
 
+async function insertTextAtComposerEnd(page: Page, composer: Locator, text: string): Promise<void> {
+  await composer.evaluate((root) => {
+    const trailingParagraph =
+      Array.from(root.children)
+        .reverse()
+        .find((child): child is HTMLParagraphElement => child instanceof HTMLParagraphElement) ??
+      root;
+    const range = document.createRange();
+    range.selectNodeContents(trailingParagraph);
+    range.collapse(false);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    (root as HTMLElement).focus();
+  });
+  await page.keyboard.insertText(text);
+}
+
 async function getIdsFromUrl(page: Page): Promise<{ spaceId: string; roomId: string }> {
   const match = page.url().match(/\/chat\/-\/([^/]+)/);
   if (!match) throw new Error(`Could not extract roomId from URL: ${page.url()}`);
   return { spaceId: 'server', roomId: match[1] };
+}
+
+async function clickReplyAttributionJump(attribution: Locator): Promise<void> {
+  await attribution.click({ position: { x: 8, y: 8 } });
 }
 
 /**
@@ -360,7 +382,7 @@ test.describe('Message Threading', () => {
     });
 
     const replyBody = `Room quote reply ${timestamp}`;
-    await page.keyboard.type(replyBody);
+    await insertTextAtComposerEnd(page, roomPage.messageInput, replyBody);
     await roomPage.messageInput.press('Control+Enter');
 
     const reply = roomPage.getMessage(replyBody);
@@ -394,7 +416,7 @@ test.describe('Message Threading', () => {
     });
 
     const replyBody = `Thread quote reply ${timestamp}`;
-    await page.keyboard.type(replyBody);
+    await insertTextAtComposerEnd(page, roomPage.threadReplyInput, replyBody);
     await roomPage.threadReplyInput.press('Control+Enter');
 
     const reply = roomPage.getThreadMessage(replyBody);
@@ -1399,12 +1421,12 @@ test.describe('Message Threading', () => {
     // Target should NOT be visible (outside the loaded message window)
     await expect(page.locator('p', { hasText: targetBody })).not.toBeVisible();
 
-    // Click the "in reply to" text specifically to avoid the nested author button,
-    // which has stopPropagation and opens a user popover instead of jumping.
+    // Click the attribution connector to avoid the nested author button, which has
+    // stopPropagation and opens a user popover instead of jumping.
     const attribution = page
       .locator('[role="article"]', { hasText: replyBody })
       .getByTestId('reply-attribution');
-    await attribution.getByText('in reply to').click();
+    await clickReplyAttributionJump(attribution);
 
     // Target message should now be visible (fetched via roomEventsAround and scrolled into view)
     await expect(page.locator('p', { hasText: targetBody })).toBeVisible({

--- a/apps/frontend/messages/de/room.json
+++ b/apps/frontend/messages/de/room.json
@@ -88,6 +88,7 @@
         "remove_reaction_label": "{emoji}-Reaktion entfernen ({count})",
         "copy_link_title": "Klicken, um den Link zu dieser Nachricht zu kopieren",
         "in_reply_to": "als Antwort auf",
+        "reply_preview_fallback": "Nachricht",
         "deleted": "Diese Nachricht wurde gelöscht."
       }
     },

--- a/apps/frontend/messages/en/room.json
+++ b/apps/frontend/messages/en/room.json
@@ -88,6 +88,7 @@
         "remove_reaction_label": "Remove {emoji} reaction ({count})",
         "copy_link_title": "Click to copy link to this message",
         "in_reply_to": "in reply to",
+        "reply_preview_fallback": "Message",
         "deleted": "This message has been deleted."
       }
     },

--- a/apps/frontend/src/lib/i18n/messages.ts
+++ b/apps/frontend/src/lib/i18n/messages.ts
@@ -550,6 +550,7 @@ const msg_room_message_meta_remove_reaction_label = (
 ): LocalizedString => messages().room_message_meta_remove_reaction_label(inputs);
 const msg_room_message_meta_copy_link_title = (): LocalizedString => messages().room_message_meta_copy_link_title(empty());
 const msg_room_message_meta_in_reply_to = (): LocalizedString => messages().room_message_meta_in_reply_to(empty());
+const msg_room_message_meta_reply_preview_fallback = (): LocalizedString => messages().room_message_meta_reply_preview_fallback(empty());
 const msg_room_message_meta_deleted = (): LocalizedString => messages().room_message_meta_deleted(empty());
 const msg_room_attachment_delete_title = (): LocalizedString => messages().room_attachment_delete_title(empty());
 const msg_room_attachment_delete_prompt = (): LocalizedString => messages().room_attachment_delete_prompt(empty());
@@ -1600,6 +1601,7 @@ export { msg_room_message_meta_add_reaction_label as 'room.message.meta.add_reac
 export { msg_room_message_meta_remove_reaction_label as 'room.message.meta.remove_reaction_label' };
 export { msg_room_message_meta_copy_link_title as 'room.message.meta.copy_link_title' };
 export { msg_room_message_meta_in_reply_to as 'room.message.meta.in_reply_to' };
+export { msg_room_message_meta_reply_preview_fallback as 'room.message.meta.reply_preview_fallback' };
 export { msg_room_message_meta_deleted as 'room.message.meta.deleted' };
 export { msg_room_attachment_delete_title as 'room.attachment.delete_title' };
 export { msg_room_attachment_delete_prompt as 'room.attachment.delete_prompt' };

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -686,12 +686,12 @@
             {#if compact}
               <span
                 aria-hidden="true"
-                class="group-hover/reply:border-surface-400 h-3 w-5 shrink-0 rounded-tl-md border-t-2 border-l-2 border-surface-300/70 transition-colors"
+                class="h-3 w-5 shrink-0 rounded-tl-md border-t-2 border-l-2 border-surface-300/30 transition-colors group-hover/reply:border-surface-300/55"
               ></span>
             {:else}
               <span
                 aria-hidden="true"
-                class="group-hover/reply:border-surface-400 absolute top-[11px] -left-[39px] h-7 w-[39px] rounded-tl-md border-t-2 border-l-2 border-surface-300/70 transition-colors"
+                class="absolute top-[11px] -left-[39px] h-7 w-[39px] rounded-tl-md border-t-2 border-l-2 border-surface-300/30 transition-colors group-hover/reply:border-surface-300/55"
               ></span>
             {/if}
             {#if replyPreview.actor}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -663,7 +663,60 @@
 
       <!-- Message content column -->
       <div class="min-w-0 flex-1 space-y-1">
-        <!-- Author, timestamp, and reply attribution -->
+        {#if replyPreview}
+          {@const replyJumpText =
+            replyPreview.body ??
+            (replyPreview.actor
+              ? m['room.message.meta.reply_preview_fallback']()
+              : replyPreview.name)}
+          {@const replyJumpLabel = `${m['room.message.meta.in_reply_to']()} ${replyJumpText}`}
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <!-- svelte-ignore a11y_click_events_have_key_events -->
+          <div
+            data-testid="reply-attribution"
+            aria-label={m['room.message.meta.in_reply_to']()}
+            title={m['room.message.meta.in_reply_to']()}
+            class="group/reply flex min-w-0 cursor-pointer items-center gap-1.5 py-0.5 text-xs leading-none text-muted"
+            onclick={scrollToReplyTarget}
+            onmousedown={(e) => e.stopPropagation()}
+          >
+            <span
+              aria-hidden="true"
+              class="group-hover/reply:border-surface-400 h-3 w-5 shrink-0 rounded-tl-md border-t-2 border-l-2 border-surface-300/70 transition-colors"
+            ></span>
+            {#if replyPreview.actor}
+              {@const replyCallPresence = activeCallRooms.getParticipantCallPresence(
+                roomId,
+                replyPreview.actor.id
+              )}
+              <button
+                type="button"
+                data-testid="reply-attribution-author"
+                class="inline-flex max-w-[45%] min-w-0 shrink-0 cursor-pointer items-center gap-1 hover:underline"
+                onclick={(e) => {
+                  e.stopPropagation();
+                  showPopoverForReplyAuthor(e);
+                }}
+              >
+                <UserAvatar user={replyPreview.actor} size="xs" />
+                <strong class="truncate font-medium">{replyPreview.name}</strong>
+                {@render callPresenceIcon(replyCallPresence)}
+              </button>
+            {:else if replyPreview.body}
+              <strong class="max-w-[45%] shrink-0 truncate font-medium">{replyPreview.name}</strong>
+            {/if}
+            <button
+              type="button"
+              class="min-w-0 flex-1 cursor-pointer truncate text-left opacity-75 hover:text-text"
+              aria-label={replyJumpLabel}
+              title={replyJumpLabel}
+            >
+              {replyJumpText}
+            </button>
+          </div>
+        {/if}
+
+        <!-- Author and timestamp -->
         {#if !compact}
           <div class="flex min-w-0 items-center gap-2">
             {#if actor}
@@ -697,43 +750,6 @@
             >
               {timestamp}
             </a>
-          </div>
-        {/if}
-
-        {#if replyPreview}
-          <!-- svelte-ignore a11y_no_static_element_interactions -->
-          <!-- svelte-ignore a11y_click_events_have_key_events -->
-          <div
-            data-testid="reply-attribution"
-            class="flex min-w-0 cursor-pointer items-center gap-1 text-xs leading-none text-muted hover:text-text"
-            onclick={scrollToReplyTarget}
-            onmousedown={(e) => e.stopPropagation()}
-          >
-            <span class="shrink-0">{m['room.message.meta.in_reply_to']()}</span>
-            {#if replyPreview.actor}
-              {@const replyCallPresence = activeCallRooms.getParticipantCallPresence(
-                roomId,
-                replyPreview.actor.id
-              )}
-              <button
-                type="button"
-                data-testid="reply-attribution-author"
-                class="flex shrink-0 cursor-pointer items-center gap-1 hover:underline"
-                onclick={(e) => {
-                  e.stopPropagation();
-                  showPopoverForReplyAuthor(e);
-                }}
-              >
-                <UserAvatar user={replyPreview.actor} size="xs" />
-                <strong class="font-medium">{replyPreview.name}</strong>
-                {@render callPresenceIcon(replyCallPresence)}
-              </button>
-            {:else}
-              <strong class="shrink-0 font-medium">{replyPreview.name}</strong>
-            {/if}
-            {#if replyPreview.body}
-              <span class="min-w-0 truncate opacity-70">{replyPreview.body}</span>
-            {/if}
           </div>
         {/if}
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -679,7 +679,10 @@
             data-testid="reply-attribution"
             aria-label={m['room.message.meta.in_reply_to']()}
             title={m['room.message.meta.in_reply_to']()}
-            class="group/reply relative flex min-w-0 cursor-pointer items-center gap-1.5 py-0.5 text-xs leading-none text-muted"
+            class={[
+              'group/reply relative flex min-w-0 cursor-pointer items-center gap-1.5 py-0.5 text-xs leading-none text-muted',
+              compact ? '' : '-ml-[39px] pl-[39px]'
+            ]}
             onclick={scrollToReplyTarget}
             onmousedown={(e) => e.stopPropagation()}
           >
@@ -691,7 +694,7 @@
             {:else}
               <span
                 aria-hidden="true"
-                class="absolute top-[11px] -left-[39px] h-7 w-[39px] rounded-tl-md border-t-2 border-l-2 border-surface-300/30 transition-colors group-hover/reply:border-surface-300/55"
+                class="absolute top-[11px] left-0 h-7 w-[39px] rounded-tl-md border-t-2 border-l-2 border-surface-300/30 transition-colors group-hover/reply:border-surface-300/55"
               ></span>
             {/if}
             {#if replyPreview.actor}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -636,7 +636,7 @@
         {#if actor}
           <button
             type="button"
-            class="absolute top-1 left-2 cursor-pointer"
+            class={['absolute left-2 z-10 cursor-pointer', replyPreview ? 'top-8' : 'top-1']}
             onclick={showPopoverForActor}
             ontouchstart={(e) => e.stopPropagation()}
             oncontextmenu={(e) => {
@@ -654,7 +654,10 @@
         {:else}
           <!-- Deleted user placeholder avatar -->
           <div
-            class="absolute top-1 left-2 flex h-11 w-11 items-center justify-center rounded-full bg-surface-200 text-muted shadow-md ring-1 ring-surface-200/30"
+            class={[
+              'absolute left-2 z-10 flex h-11 w-11 items-center justify-center rounded-full bg-surface-200 text-muted shadow-md ring-1 ring-surface-200/30',
+              replyPreview ? 'top-8' : 'top-1'
+            ]}
           >
             <span class="iconify text-xl uil--user-times"></span>
           </div>
@@ -676,14 +679,21 @@
             data-testid="reply-attribution"
             aria-label={m['room.message.meta.in_reply_to']()}
             title={m['room.message.meta.in_reply_to']()}
-            class="group/reply flex min-w-0 cursor-pointer items-center gap-1.5 py-0.5 text-xs leading-none text-muted"
+            class="group/reply relative flex min-w-0 cursor-pointer items-center gap-1.5 py-0.5 text-xs leading-none text-muted"
             onclick={scrollToReplyTarget}
             onmousedown={(e) => e.stopPropagation()}
           >
-            <span
-              aria-hidden="true"
-              class="group-hover/reply:border-surface-400 h-3 w-5 shrink-0 rounded-tl-md border-t-2 border-l-2 border-surface-300/70 transition-colors"
-            ></span>
+            {#if compact}
+              <span
+                aria-hidden="true"
+                class="group-hover/reply:border-surface-400 h-3 w-5 shrink-0 rounded-tl-md border-t-2 border-l-2 border-surface-300/70 transition-colors"
+              ></span>
+            {:else}
+              <span
+                aria-hidden="true"
+                class="group-hover/reply:border-surface-400 absolute top-[11px] -left-[39px] h-7 w-[39px] rounded-tl-md border-t-2 border-l-2 border-surface-300/70 transition-colors"
+              ></span>
+            {/if}
             {#if replyPreview.actor}
               {@const replyCallPresence = activeCallRooms.getParticipantCallPresence(
                 roomId,


### PR DESCRIPTION
## Summary

- Restyles reply attribution as a compact preview row above the replied message content.
- Keeps the author popover as its own control while making the preview/fallback text the accessible jump target.
- Updates reply-attribution e2e selectors after removing the visible `in reply to` label.

Closes #1139.

## Verification

- `mise x -- npx @sveltejs/mcp svelte-autofixer apps/frontend/src/routes/chat/'[serverId]'/'[roomId]'/MessageEvent.svelte --svelte-version 5`
- `mise x -- pnpm --dir apps/frontend exec svelte-check --tsconfig ./tsconfig.json`
- `mise x -- pnpm --dir apps/frontend exec playwright test e2e/threading.test.ts e2e/jump-to-message.test.ts e2e/message-links.test.ts e2e/thread-reply-echo.test.ts --retries=0`
- Browser verification at desktop and mobile widths
