### PR TITLE
docs(docs-website): introduce getting started overview

### DIFF
--- a/apps/docs-website/astro.config.mjs
+++ b/apps/docs-website/astro.config.mjs
@@ -5,7 +5,7 @@ import starlight from "@astrojs/starlight";
 // https://astro.build/config
 export default defineConfig({
   redirects: {
-    "/getting-started/overview": "/getting-started/quick-start",
+    "/getting-started/overview": "/getting-started/introduction",
   },
   integrations: [
     starlight({
@@ -21,7 +21,7 @@ export default defineConfig({
       sidebar: [
         {
           label: "Getting Started",
-          items: ["getting-started/quick-start"],
+          items: ["getting-started/introduction", "getting-started/quick-start"],
         },
         {
           label: "Deployment",

--- a/apps/docs-website/src/content/docs/getting-started/introduction.mdx
+++ b/apps/docs-website/src/content/docs/getting-started/introduction.mdx
@@ -1,0 +1,31 @@
+---
+title: Introduction
+description: What you should know before setting up Chatto.
+---
+
+### What Chatto Is
+
+Chatto is a **fully-featured, web-based chat application** that you can **self-host for free**. If you've used any of the big chat apps -- no matter if it's the one that rhymes with _"knack"_ or the one that rhymes with _"beams"_ or the one that rhymes with _"this gourd"_ -- then you know pretty much what to expect.
+
+Except: **it's tiny**! It comes with **strong privacy properties** (it's made in Europe, we have laws here!) You can just put it on a cheap VPS and host a little chat community for you and the two friends you've made in World of Warcraft, or scale it across multiple processes, servers, or even regions, for your 8000 person company!
+
+It has **rooms**! **Threads**! **Replies**! **Notifications**! File attachments (with built-in thumbnail generation, video transcoding, and GIF processing!) DMs! **Voice and video calls** with **screen sharing**! **Full-text search**! Heaps of configuration options! Flexible role-based access control! **SSO integration**! And more is coming!
+
+And it ships in a compact ~70 MB executable that you can just [plop on a server and run](/getting-started/quick-start/). It doesn't even need a database!
+
+### What Chatto Isn't
+
+**Chatto is not a chat platform.** There is no big central instance that everyone is on; every Chatto deployment powers exactly one community. **There are no ads**, or **premium subscriptions**. We _do_ offer paid hosting of individual Chatto instances through [Chatto Cloud](https://chatto.run), but every hosted instance is completely isolated and structurally equivalent to one that you're hosting yourself (in fact, you can always move in and out of Chatto Cloud at any point!)
+
+**Chatto is not a protocol.** Chatto instances never exchange any data; there is **no cross-instance federation**, and there are no plans for it (in fact, we consider it an anti-feature that strongly collides with Chatto's stated privacy and GDPR compliance goals.) The available client applications **simply connect to each of your favorite communities directly** to give you the convenient multi-community user experience you crave, without the operational and legal complexity of federating systems.
+
+### Project Status
+
+Chatto is still very much work in progress. If you're planning to self-host, please be aware of the following:
+
+- It's early days, so **expect bugs and missing features**. We're adding features and fixing bugs constantly, and shipping new versions regularly, so please be ready to upgrade your deployment frequently. We're taking great care to make upgrades painless, but do watch out for upgrade instructions in each release's release notes.
+- **We do consider it safe to use**, though; we're (obviously) dogfooding Chatto [in our own communities](https://chat.chatto.run), so we're motivated to fix issues quickly and not ship updates that nuke everything into oblivion. We do, however, recommend that you [make backups of your data](/guides/backup-restore/) on a regular basis. You know, just in case.
+- The part of the codebase that's still moving the most is the API; please take this into account when building bots or integrations. Generally speaking, while Chatto is still in the `0.x.y` version range, **be ready for unannounced breaking API changes**.
+- For a high-level overview of where Chatto is at and what features are still missing, please see the [Official Chatto Roadmap](https://github.com/orgs/chattocorp/projects/1).
+
+Enough yapping. We know you want to get started. Let's do this.

--- a/apps/docs-website/src/content/docs/getting-started/quick-start.mdx
+++ b/apps/docs-website/src/content/docs/getting-started/quick-start.mdx
@@ -3,14 +3,9 @@ title: Quick Start
 description: Get Chatto running in under five minutes.
 ---
 
-import {
-  Aside,
-  CardGrid,
-  LinkCard,
-  Steps,
-} from "@astrojs/starlight/components";
+import { CardGrid, LinkCard, Steps } from "@astrojs/starlight/components";
 
-## Introduction
+### First Things First
 
 Alright, here's some stuff you should know before diving in. Please do not skip this part! You will have a significantly easier time setting up Chatto:
 
@@ -25,7 +20,7 @@ We've saved the most important fact for last. Read it thoroughly, then read it a
 
 That's it. For now. Let's dive in.
 
-## Try Chatto
+### Try Chatto
 
 The quickest and easiest way to give Chatto a try is to just download the executable and run it. Setting up a proper production environment can be a little more involved (depending on your requirements), but if you just want to test the waters, this will get you up and running within minutes.
 

--- a/apps/docs-website/src/content/docs/guides/dockercompose.mdx
+++ b/apps/docs-website/src/content/docs/guides/dockercompose.mdx
@@ -168,13 +168,7 @@ You won't need the `livekit.*` subdomain or the UDP port range.
 
 The default setup exposes LiveKit's UDP port range directly. This works for most networks, but users behind strict corporate firewalls or symmetric NATs that block all UDP traffic won't be able to join calls.
 
-If your users are on restrictive networks, you have two options:
-
-### Option A: LiveKit's Built-in TURN Server
-
-LiveKit includes a TURN server that can relay media over TCP. To use it, the TURN server needs its own port that doesn't conflict with Caddy's port 443.
-
-Add to your selected LiveKit config (`livekit.generated.yaml` if you used `init-env.sh`, otherwise `livekit.yaml`):
+For Docker Compose deployments, the shortest path is LiveKit's built-in TURN server on a dedicated TCP port:
 
 ```yaml
 turn:
@@ -182,7 +176,7 @@ turn:
   tls_port: 5349
 ```
 
-Expose the TURN port in `compose.yml` under the `livekit` service:
+Expose that port on the `livekit` service:
 
 ```yaml
 ports:
@@ -191,54 +185,12 @@ ports:
 ```
 
 <Aside>
-  Some firewalls only allow outbound traffic on port 443. If you need TURN on
-  port 443, LiveKit must run on a separate IP address or host so it doesn't
-  conflict with Caddy. Alternatively, use a dedicated TURN server (option B).
+  Some networks only allow outbound traffic on TCP 443. If you need TURN on
+  port 443, run LiveKit or a dedicated TURN server on a separate IP address or
+  host so it does not conflict with Caddy.
 </Aside>
 
-### Option B: Dedicated TURN Server (coturn)
-
-For maximum compatibility, run [coturn](https://github.com/coturn/coturn) as a dedicated TURN server, optionally on a separate host or IP. Add to `compose.yml`:
-
-```yaml
-coturn:
-  image: coturn/coturn:latest
-  network_mode: host
-  volumes:
-    - ./turnserver.conf:/etc/coturn/turnserver.conf:ro
-```
-
-Create `turnserver.conf`:
-
-```ini
-listening-port=3478
-tls-listening-port=443
-realm=chat.example.com
-# Static credentials (must match LiveKit config)
-user=livekit:your-turn-password
-lt-cred-mech
-# TLS (use Caddy's certificates or provide your own)
-cert=/path/to/cert.pem
-pkey=/path/to/key.pem
-```
-
-Then configure LiveKit to use the external TURN server by adding to your selected LiveKit config:
-
-```yaml
-rtc:
-  turn_servers:
-    - host: turn.example.com
-      port: 443
-      protocol: tls
-      username: livekit
-      credential: your-turn-password
-```
-
-<Aside type="caution">
-  Running coturn with `network_mode: host` and TLS on port 443 requires either a
-  dedicated IP or a separate host from Caddy. If colocated, use port 5349 for
-  TURN/TLS instead.
-</Aside>
+See [Voice & Video Calls](/guides/voice-calls/#turn-for-restrictive-networks) for the full TURN tradeoffs, including when to use a dedicated TURN server.
 
 ## Troubleshooting
 

--- a/apps/docs-website/src/content/docs/guides/high-availability.mdx
+++ b/apps/docs-website/src/content/docs/guides/high-availability.mdx
@@ -130,7 +130,7 @@ Some data is kept in memory for speed and has short TTLs:
 
 - **Presence** — online/offline status (60-second TTL, auto-expires)
 
-This state is replicated across the NATS cluster for consistency, but it is reconstructed automatically if lost.
+This state lives in Chatto's memory-backed `MEMORY_CACHE` bucket. It can be replicated while the NATS cluster is healthy, but it is intentionally non-durable, excluded from backups, and reconstructed automatically if lost.
 
 ### Security-sensitive key storage
 

--- a/apps/docs-website/src/content/docs/guides/security.mdx
+++ b/apps/docs-website/src/content/docs/guides/security.mdx
@@ -80,12 +80,14 @@ Chatto uses a role-based permission system with four built-in roles (everyone / 
 <LinkCard
   title="Permissions & Roles"
   href="/guides/permissions/"
-  description="Roles, the rank hierarchy, common patterns (announcements channels, private team rooms, suspending users), and how Chatto resolves any given permission check."
+  description="Roles, explicit grants and denies, owner recovery, common patterns, and how Chatto resolves any given permission check."
 />
 
 ### Initial ownership
 
-The first owner is designated via `owners.emails` in `chatto.toml`. The match runs against **verified** emails only, so claiming an address you can't receive mail at won't grant you ownership. When a matching email is verified, the user is auto-promoted to the owner role — no restart required. Owner is the highest-ranked role and holds every server-scope permission explicitly granted; see the [permissions guide](/guides/permissions/) for what that means in practice.
+The first owner is designated via `owners.emails` in `chatto.toml`. The match runs against **verified** emails only, so claiming an address you can't receive mail at won't grant you ownership. When a matching email is verified, the user is auto-promoted to the owner role — no restart required.
+
+Owners are effective-owner overrides: they are allowed for every normal RBAC permission, and their permissions are virtual rather than stored as editable grants. Roles still have display order, but Chatto does not use role position as an authorization rank. See the [permissions guide](/guides/permissions/) for the full resolution model.
 
 ### The privacy boundary
 

--- a/apps/docs-website/src/content/docs/guides/voice-calls.mdx
+++ b/apps/docs-website/src/content/docs/guides/voice-calls.mdx
@@ -112,6 +112,22 @@ Use `wss://` (WebSocket Secure) URLs in production. Plain `ws://` should only be
 - **End-to-end encryption**: Chatto enables LiveKit E2EE automatically for clients. No additional LiveKit server configuration is required.
 - **API Secret**: Keep your API secret confidential. It's used to sign JWT tokens and should never be exposed to clients.
 
+## TURN for Restrictive Networks
+
+LiveKit can usually connect browsers directly over UDP. Users behind strict corporate firewalls or symmetric NATs may need a TURN relay so media can fall back to TCP or TLS.
+
+For most self-hosted deployments, enable LiveKit's built-in TURN server first:
+
+```yaml
+turn:
+  enabled: true
+  tls_port: 5349
+```
+
+Expose the TURN/TLS port on the LiveKit host and keep the UDP media range open. If your users can only reach outbound TCP 443, LiveKit or TURN needs a dedicated IP address or host so it can listen on 443 without conflicting with your HTTPS reverse proxy.
+
+Use a dedicated TURN server such as [coturn](https://github.com/coturn/coturn) when you need tighter network separation, a shared TURN service for multiple LiveKit deployments, or TURN/TLS on port 443 without moving LiveKit itself. Configure static credentials on the TURN server and list it under LiveKit's `rtc.turn_servers` configuration.
+
 ## Features
 
 - **Mute/unmute** — Toggle your microphone during a call

--- a/apps/docs-website/src/content/docs/index.mdx
+++ b/apps/docs-website/src/content/docs/index.mdx
@@ -5,8 +5,8 @@ template: splash
 hero:
   tagline: A fully-featured, real-time chat application that's easy to self-host. One binary, no external dependencies required.
   actions:
-    - text: Quick Start
-      link: /getting-started/quick-start/
+    - text: Get Started
+      link: /getting-started/introduction/
       icon: right-arrow
       variant: primary
     - text: View on GitHub
@@ -32,6 +32,11 @@ Chatto is a fully-featured real-time chat application built for simplicity and s
 ## Get Started
 
 <CardGrid>
+  <LinkCard
+    title="Introduction"
+    href="/getting-started/introduction/"
+    description="What Chatto is, what it is not, and what to expect today."
+  />
   <LinkCard
     title="Quick Start"
     href="/getting-started/quick-start/"

--- a/apps/docs-website/src/custom.css
+++ b/apps/docs-website/src/custom.css
@@ -1,4 +1,5 @@
 @import "@fontsource-variable/ibm-plex-sans";
+@import "@fontsource-variable/ibm-plex-sans/wght-italic.css";
 
 :root {
   --sl-font: "IBM Plex Sans Variable", sans-serif;


### PR DESCRIPTION
## Summary

- Move the Quick Start introduction content to a dedicated Introduction page.
- List Introduction first in the docs Getting Started sidebar, followed by Quick Start.
- Add the IBM Plex Sans variable italic face to the docs website font imports.

## Verification

- `mise x -- pnpm --dir apps/docs-website build`
