### PR TITLE
fix(frontend): refresh messages after local deletions

### DIFF
--- a/apps/frontend/src/lib/state/room/messageMutationEvents.ts
+++ b/apps/frontend/src/lib/state/room/messageMutationEvents.ts
@@ -1,0 +1,32 @@
+export type RoomMessageMutationReason =
+  | 'message-deleted'
+  | 'attachment-deleted'
+  | 'link-preview-deleted';
+
+export type RoomMessageMutatedDetail = {
+  roomId: string;
+  eventId: string;
+  reason: RoomMessageMutationReason;
+};
+
+export const ROOM_MESSAGE_MUTATED_EVENT = 'chatto:room-message-mutated';
+
+export function notifyRoomMessageMutated(detail: RoomMessageMutatedDetail): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(ROOM_MESSAGE_MUTATED_EVENT, { detail }));
+}
+
+export function onRoomMessageMutated(
+  handler: (detail: RoomMessageMutatedDetail) => void
+): () => void {
+  if (typeof window === 'undefined') return () => {};
+
+  const listener = (event: Event) => {
+    const detail = (event as CustomEvent<RoomMessageMutatedDetail>).detail;
+    if (!detail?.roomId || !detail.eventId) return;
+    handler(detail);
+  };
+
+  window.addEventListener(ROOM_MESSAGE_MUTATED_EVENT, listener);
+  return () => window.removeEventListener(ROOM_MESSAGE_MUTATED_EVENT, listener);
+}

--- a/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -1147,6 +1147,7 @@ describe('MessagesStore — thread lifecycle ownership', () => {
 			__typename: 'MessagePostedEvent',
 			channelEchoEventId: 'echo1'
 		});
+		expect(store.refreshAnchorForMessageMutation('echo1')).toBe('reply1');
 
 		store.ingestServerEvent({
 			id: 'retract-echo1',

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -119,6 +119,31 @@ export class MessagesStore {
     );
   }
 
+  /** Find the visible event to anchor a refresh for a message mutation.
+   * Mutations from channel echoes use the original message ID, while the
+   * rendered room timeline contains the echo wrapper event.
+   */
+  refreshAnchorForMessageMutation(messageEventId: string): string | null {
+    for (const event of this.events) {
+      if (event.id === messageEventId) return event.id;
+      const payload = event.event;
+      if (payload?.__typename === 'MessagePostedEvent' && payload.echoOfEventId === messageEventId) {
+        return event.id;
+      }
+    }
+
+    for (const event of this.previewEvents.values()) {
+      if (!event) continue;
+      if (event.id === messageEventId) return event.id;
+      const payload = event.event;
+      if (payload?.__typename === 'MessagePostedEvent' && payload.echoOfEventId === messageEventId) {
+        return event.id;
+      }
+    }
+
+    return null;
+  }
+
   /** Update the viewer's thread follow state on a known thread root event. */
   setThreadRootFollowState(threadRootEventId: string, isFollowing: boolean): void {
     const idx = this.events.findIndex((e) => e.id === threadRootEventId);

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -130,6 +130,12 @@ export class MessagesStore {
       if (payload?.__typename === 'MessagePostedEvent' && payload.echoOfEventId === messageEventId) {
         return event.id;
       }
+      if (
+        payload?.__typename === 'MessagePostedEvent' &&
+        payload.channelEchoEventId === messageEventId
+      ) {
+        return event.id;
+      }
     }
 
     for (const event of this.previewEvents.values()) {
@@ -139,9 +145,20 @@ export class MessagesStore {
       if (payload?.__typename === 'MessagePostedEvent' && payload.echoOfEventId === messageEventId) {
         return event.id;
       }
+      if (
+        payload?.__typename === 'MessagePostedEvent' &&
+        payload.channelEchoEventId === messageEventId
+      ) {
+        return event.id;
+      }
     }
 
     return null;
+  }
+
+  /** Apply a successful local message delete without querying around a now-hidden echo. */
+  applyLocalMessageDeletion(messageEventId: string): void {
+    this.applyDeletion(messageEventId);
   }
 
   /** Update the viewer's thread follow state on a known thread root event. */
@@ -640,6 +657,7 @@ export class MessagesStore {
       targetPayload.echoOfEventId
     ) {
       this.events.splice(targetIndex, 1);
+      this.seenIds.delete(messageEventId);
       return;
     }
 
@@ -651,7 +669,7 @@ export class MessagesStore {
 
       this.events[i] = {
         ...e,
-        event: { ...evt, body: null, attachments: [] }
+        event: { ...evt, body: null, attachments: [], linkPreview: null }
       };
     }
 
@@ -660,7 +678,7 @@ export class MessagesStore {
     if (preview?.event?.__typename === 'MessagePostedEvent') {
       this.previewEvents.set(previewKey, {
         ...preview,
-        event: { ...preview.event, body: null, attachments: [] }
+        event: { ...preview.event, body: null, attachments: [], linkPreview: null }
       });
     }
   }

--- a/apps/frontend/src/routes/chat/ModalContainer.svelte
+++ b/apps/frontend/src/routes/chat/ModalContainer.svelte
@@ -22,6 +22,7 @@
   import { refreshAttachmentUrlsForMessage } from '$lib/attachments/attachmentUrls';
   import { toast } from '$lib/ui/toast';
   import { clearLastRoom } from '$lib/storage/lastRoom';
+  import { notifyRoomMessageMutated } from '$lib/state/room/messageMutationEvents';
 
   /** Get the GraphQL client for the currently active instance (derived from URL). */
   function getActiveClient() {
@@ -131,6 +132,7 @@
       toast.error(m['room.message.delete_failed']());
       console.error('Error deleting message:', result.error);
     } else {
+      notifyRoomMessageMutated({ roomId, eventId, reason: 'message-deleted' });
       toast.success(m['room.message.deleted']());
     }
     closeModal();
@@ -153,6 +155,8 @@
     if (result.error) {
       toast.error(m['room.link_preview.delete_failed']());
       console.error('Error deleting link preview:', result.error);
+    } else {
+      notifyRoomMessageMutated({ roomId, eventId, reason: 'link-preview-deleted' });
     }
     closeModal();
   }
@@ -174,6 +178,8 @@
     if (result.error) {
       toast.error(m['room.attachment.delete_failed']());
       console.error('Error deleting attachment:', result.error);
+    } else {
+      notifyRoomMessageMutated({ roomId, eventId, reason: 'attachment-deleted' });
     }
     closeModal();
   }

--- a/apps/frontend/src/routes/chat/ModalContainer.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/ModalContainer.svelte.spec.ts
@@ -16,6 +16,9 @@ const { mocks } = vi.hoisted(() => ({
     toastError: vi.fn(),
     joinRoom: vi.fn(),
     refreshRooms: vi.fn(),
+    mutation: vi.fn(() => ({
+      toPromise: () => Promise.resolve({ data: {}, error: null })
+    })),
     activeServer: 'origin',
     serverIdParam: '-' as string | undefined,
     servers: [] as Array<{ id: string; url: string; name: string; token: string | null }>,
@@ -96,9 +99,7 @@ vi.mock('$lib/state/server/graphqlClient.svelte', () => ({
   graphqlClientManager: {
     getClient: vi.fn(() => ({
       client: {
-        mutation: vi.fn(() => ({
-          toPromise: () => Promise.resolve({ data: {}, error: null })
-        }))
+        mutation: mocks.mutation
       }
     }))
   }
@@ -179,6 +180,9 @@ beforeEach(() => {
     viewerCanJoinRoom: true
   };
   mocks.joinRoom.mockResolvedValue({ ok: true, room: { id: 'room-1', name: 'general' } });
+  mocks.mutation.mockReturnValue({
+    toPromise: () => Promise.resolve({ data: {}, error: null })
+  });
   mocks.refreshRooms.mockResolvedValue(undefined);
   mocks.signOutServer.mockResolvedValue(new Response('{}', { status: 200 }));
   mocks.signOutServers.mockResolvedValue(undefined);
@@ -400,5 +404,35 @@ describe('ModalContainer sign out modal', () => {
     expect(findButton(second.container, 'All Servers')).not.toBeDisabled();
 
     finishSignOut?.(new Response('{}', { status: 200 }));
+  });
+});
+
+describe('ModalContainer message mutation modals', () => {
+  it('notifies the visible room after link preview deletion succeeds', async () => {
+    mocks.modal = {
+      type: 'deleteLinkPreview',
+      roomId: 'room-1',
+      eventId: 'event-1',
+      previewUrl: 'https://example.test/article'
+    };
+    const listener = vi.fn();
+    window.addEventListener('chatto:room-message-mutated', listener);
+
+    try {
+      const { container } = render(ModalContainer);
+      clickButton(container, 'Delete');
+
+      await vi.waitFor(() => {
+        expect(mocks.mutation).toHaveBeenCalledOnce();
+        expect(listener).toHaveBeenCalledOnce();
+      });
+      expect((listener.mock.calls[0][0] as CustomEvent).detail).toEqual({
+        roomId: 'room-1',
+        eventId: 'event-1',
+        reason: 'link-preview-deleted'
+      });
+    } finally {
+      window.removeEventListener('chatto:room-message-mutated', listener);
+    }
   });
 });

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -106,8 +106,9 @@
   $effect(() =>
     onRoomMessageMutated((detail) => {
       if (detail.roomId !== roomId) return;
-      if (!roomMessageStore.getEventById(detail.eventId)) return;
-      void roomMessageStore.refreshCurrentWindow(detail.eventId);
+      const anchorEventId = roomMessageStore.refreshAnchorForMessageMutation(detail.eventId);
+      if (!anchorEventId) return;
+      void roomMessageStore.refreshCurrentWindow(anchorEventId);
     })
   );
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -29,6 +29,7 @@
     DEFAULT_ROOM_PERMISSIONS,
     type QuoteInsertionContent
   } from '$lib/state/room';
+  import { onRoomMessageMutated } from '$lib/state/room/messageMutationEvents';
   import { useConnection } from '$lib/state/server/connection.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { getLiveDisplayName } from '$lib/state/userProfiles.svelte';
@@ -101,6 +102,14 @@
   const roomMessageStore = new MessagesStore(connection(), () => currentUser.user?.id ?? null);
 
   onDestroy(() => roomMessageStore.dispose());
+
+  $effect(() =>
+    onRoomMessageMutated((detail) => {
+      if (detail.roomId !== roomId) return;
+      if (!roomMessageStore.getEventById(detail.eventId)) return;
+      void roomMessageStore.refreshCurrentWindow(detail.eventId);
+    })
+  );
 
   // --- Extracted hooks ---
   const room = useRoomData(() => ({ roomId }));

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -106,6 +106,10 @@
   $effect(() =>
     onRoomMessageMutated((detail) => {
       if (detail.roomId !== roomId) return;
+      if (detail.reason === 'message-deleted') {
+        roomMessageStore.applyLocalMessageDeletion(detail.eventId);
+        return;
+      }
       const anchorEventId = roomMessageStore.refreshAnchorForMessageMutation(detail.eventId);
       if (!anchorEventId) return;
       void roomMessageStore.refreshCurrentWindow(anchorEventId);

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -293,4 +293,34 @@ describe('Room local message echo', () => {
       expect(mocks.rooms.refreshNotificationCounts).toHaveBeenCalledOnce();
     });
   });
+
+  it('refreshes the visible room window after a local link-preview deletion succeeds', async () => {
+    const { container } = render(Room, { props: { roomId: 'room-1' } });
+
+    await expect.element(q(container, '[data-testid="room-event-ids"]')).toHaveTextContent('');
+    (q(container, '[data-testid="emit-returned-post"]') as HTMLButtonElement).click();
+    await expect
+      .element(q(container, '[data-testid="room-event-ids"]'))
+      .toHaveTextContent('msg-local');
+    await vi.waitFor(() => expect(mocks.query).toHaveBeenCalled());
+    mocks.query.mockClear();
+
+    window.dispatchEvent(
+      new CustomEvent('chatto:room-message-mutated', {
+        detail: {
+          roomId: 'room-1',
+          eventId: 'msg-local',
+          reason: 'link-preview-deleted'
+        }
+      })
+    );
+
+    await vi.waitFor(() => {
+      expect(mocks.query).toHaveBeenCalledWith(
+        expect.anything(),
+        { roomId: 'room-1', eventId: 'msg-local', limit: 50 },
+        { requestPolicy: 'network-only' }
+      );
+    });
+  });
 });

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -353,4 +353,29 @@ describe('Room local message echo', () => {
       );
     });
   });
+
+  it('removes a deleted visible channel echo without refreshing around the hidden echo', async () => {
+    const { container } = render(Room, { props: { roomId: 'room-1' } });
+
+    await expect.element(q(container, '[data-testid="room-event-ids"]')).toHaveTextContent('');
+    (q(container, '[data-testid="emit-returned-echo"]') as HTMLButtonElement).click();
+    await expect
+      .element(q(container, '[data-testid="room-event-ids"]'))
+      .toHaveTextContent('echo-local');
+    await vi.waitFor(() => expect(mocks.query).toHaveBeenCalled());
+    mocks.query.mockClear();
+
+    window.dispatchEvent(
+      new CustomEvent('chatto:room-message-mutated', {
+        detail: {
+          roomId: 'room-1',
+          eventId: 'echo-local',
+          reason: 'message-deleted'
+        }
+      })
+    );
+
+    await expect.element(q(container, '[data-testid="room-event-ids"]')).toHaveTextContent('');
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
 });

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -323,4 +323,34 @@ describe('Room local message echo', () => {
       );
     });
   });
+
+  it('refreshes a visible channel echo when a local mutation references the original message', async () => {
+    const { container } = render(Room, { props: { roomId: 'room-1' } });
+
+    await expect.element(q(container, '[data-testid="room-event-ids"]')).toHaveTextContent('');
+    (q(container, '[data-testid="emit-returned-echo"]') as HTMLButtonElement).click();
+    await expect
+      .element(q(container, '[data-testid="room-event-ids"]'))
+      .toHaveTextContent('echo-local');
+    await vi.waitFor(() => expect(mocks.query).toHaveBeenCalled());
+    mocks.query.mockClear();
+
+    window.dispatchEvent(
+      new CustomEvent('chatto:room-message-mutated', {
+        detail: {
+          roomId: 'room-1',
+          eventId: 'original-reply',
+          reason: 'attachment-deleted'
+        }
+      })
+    );
+
+    await vi.waitFor(() => {
+      expect(mocks.query).toHaveBeenCalledWith(
+        expect.anything(),
+        { roomId: 'room-1', eventId: 'echo-local', limit: 50 },
+        { requestPolicy: 'network-only' }
+      );
+    });
+  });
 });

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomLocalEchoMessageComposerMock.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomLocalEchoMessageComposerMock.svelte
@@ -32,8 +32,38 @@
       viewerIsFollowingThread: true
     }
   } as RoomEventViewFragment;
+
+  const returnedEcho = {
+    __typename: 'Event',
+    id: 'echo-local',
+    createdAt: '2026-06-17T10:48:00Z',
+    actorId: 'test-user',
+    actor: null,
+    event: {
+      __typename: 'MessagePostedEvent',
+      roomId: 'room-1',
+      body: 'echoed reply',
+      attachments: [],
+      linkPreview: null,
+      reactions: [],
+      updatedAt: null,
+      inReplyTo: null,
+      threadRootEventId: null,
+      echoOfEventId: 'original-reply',
+      echoFromThreadRootEventId: 'thread-root',
+      channelEchoEventId: null,
+      replyCount: 0,
+      lastReplyAt: null,
+      threadParticipants: [],
+      viewerIsFollowingThread: true
+    }
+  } as RoomEventViewFragment;
 </script>
 
 <button data-testid="emit-returned-post" onclick={() => onMessageSent?.(returnedPost)}>
   emit returned post
+</button>
+
+<button data-testid="emit-returned-echo" onclick={() => onMessageSent?.(returnedEcho)}>
+  emit returned echo
 </button>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -63,8 +63,9 @@
   $effect(() =>
     onRoomMessageMutated((detail) => {
       if (detail.roomId !== roomId) return;
-      if (!store.getEventById(detail.eventId)) return;
-      void store.refreshCurrentWindow(detail.eventId);
+      const anchorEventId = store.refreshAnchorForMessageMutation(detail.eventId);
+      if (!anchorEventId) return;
+      void store.refreshCurrentWindow(anchorEventId);
     })
   );
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -63,6 +63,10 @@
   $effect(() =>
     onRoomMessageMutated((detail) => {
       if (detail.roomId !== roomId) return;
+      if (detail.reason === 'message-deleted') {
+        store.applyLocalMessageDeletion(detail.eventId);
+        return;
+      }
       const anchorEventId = store.refreshAnchorForMessageMutation(detail.eventId);
       if (!anchorEventId) return;
       void store.refreshCurrentWindow(anchorEventId);

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -18,6 +18,7 @@
     MessagesStore,
     type QuoteInsertionRequest
   } from '$lib/state/room';
+  import { onRoomMessageMutated } from '$lib/state/room/messageMutationEvents';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
   import HeaderIconButton from '$lib/ui/HeaderIconButton.svelte';
   import MessageComposer, {
@@ -58,6 +59,14 @@
 
   const store = new MessagesStore(connection(), () => currentUser.user?.id ?? null);
   onDestroy(() => store.dispose());
+
+  $effect(() =>
+    onRoomMessageMutated((detail) => {
+      if (detail.roomId !== roomId) return;
+      if (!store.getEventById(detail.eventId)) return;
+      void store.refreshCurrentWindow(detail.eventId);
+    })
+  );
 
   let threadEvents = $derived(store.threadEvents);
   let updateCounter = $derived(threadEvents.length);


### PR DESCRIPTION
## Summary

Refresh the visible room or thread message window after local delete-message, delete-attachment, and delete-link-preview mutations succeed, so the acting tab does not depend on realtime delivery to see its own change.

The local refresh path now handles linked channel echoes in both directions, and local echo deletion removes the visible echo without querying around a backend-hidden event and jumping the room window to latest.

## Verification

- `mise x -- pnpm -C apps/frontend run test:unit -- --run 'src/routes/chat/ModalContainer.svelte.spec.ts' 'src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts'`
- `mise x -- pnpm -C apps/frontend run test:unit -- --run 'src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts' 'src/lib/state/room/messages.svelte.spec.ts'`
- `mise lint-frontend`
