### PR TITLE
fix(frontend): make scrollbars follow selected theme

### DIFF
--- a/apps/frontend/e2e/user-settings.test.ts
+++ b/apps/frontend/e2e/user-settings.test.ts
@@ -28,22 +28,27 @@ test.describe('User Settings - Display', () => {
 
     await darkOption.click();
     await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+    await expect(page.locator('html')).toHaveCSS('color-scheme', 'dark');
 
     await page.reload();
     await expect(darkOption).toHaveAttribute('aria-checked', 'true');
     await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+    await expect(page.locator('html')).toHaveCSS('color-scheme', 'dark');
 
     await lightOption.click();
     await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
+    await expect(page.locator('html')).toHaveCSS('color-scheme', 'light');
 
     await systemOption.click();
     await expect(systemOption).toHaveAttribute('aria-checked', 'true');
     await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
+    await expect(page.locator('html')).toHaveCSS('color-scheme', 'light');
 
     await page.emulateMedia({ colorScheme: 'dark' });
     await page.reload();
     await expect(systemOption).toHaveAttribute('aria-checked', 'true');
     await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+    await expect(page.locator('html')).toHaveCSS('color-scheme', 'dark');
   });
 
   test('can choose a local language', async ({ page }) => {

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -28,6 +28,8 @@
  * `data-theme="dark"`.
  */
 :root {
+  color-scheme: light;
+
   --color-background: var(--color-gray-100);
   --color-text: var(--color-gray-600);
   --color-text-top: var(--color-black);

--- a/apps/frontend/src/app.html
+++ b/apps/frontend/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" dir="ltr" style="color-scheme: light dark">
+<html lang="en" dir="ltr" style="color-scheme: light">
   <head>
     <meta charset="utf-8" />
     <script>
@@ -39,6 +39,7 @@
           root.dataset.theme = effective;
           // Pre-CSS background hint, mirrors --color-background.
           root.style.backgroundColor = effective === 'dark' ? '#171717' : '#f3f4f6';
+          root.style.colorScheme = effective;
         }
 
         function applyLocale() {

--- a/apps/frontend/src/appHtml.spec.ts
+++ b/apps/frontend/src/appHtml.spec.ts
@@ -94,11 +94,13 @@ describe('app.html theme bootstrap', () => {
 
     expect(root.dataset.theme).toBe('light');
     expect(root.style.backgroundColor).toBe('#f3f4f6');
+    expect(root.style.colorScheme).toBe('light');
   });
 
   it('uses legacy localStorage.theme when no display preference exists', () => {
     const { root } = runThemeScript({ legacyTheme: 'dark', systemDark: false });
     expect(root.dataset.theme).toBe('dark');
+    expect(root.style.colorScheme).toBe('dark');
   });
 
   it('follows prefers-color-scheme when the display preference is system', () => {
@@ -108,11 +110,13 @@ describe('app.html theme bootstrap', () => {
     });
 
     expect(root.dataset.theme).toBe('dark');
+    expect(root.style.colorScheme).toBe('dark');
   });
 
   it('follows prefers-color-scheme when no display preference exists', () => {
     const { root } = runThemeScript({ systemDark: true });
     expect(root.dataset.theme).toBe('dark');
+    expect(root.style.colorScheme).toBe('dark');
   });
 
   it('only reacts to system theme changes while the display preference is system', () => {

--- a/apps/frontend/src/lib/state/userPreferences.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/userPreferences.svelte.spec.ts
@@ -27,6 +27,7 @@ describe('UserPreferencesState', () => {
     localStorage.clear();
     delete document.documentElement.dataset.theme;
     document.documentElement.style.backgroundColor = '';
+    document.documentElement.style.colorScheme = '';
   });
 
   describe('initial state', () => {
@@ -205,6 +206,7 @@ describe('UserPreferencesState', () => {
         expect(state.displayTheme).toBe(displayTheme);
         expect(document.documentElement.dataset.theme).toBe(effectiveTheme);
         expect(document.documentElement.style.backgroundColor).toBe(background);
+        expect(document.documentElement.style.colorScheme).toBe(effectiveTheme);
 
         const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}');
         expect(stored.displayTheme).toBe(displayTheme);

--- a/apps/frontend/src/lib/state/userPreferences.svelte.ts
+++ b/apps/frontend/src/lib/state/userPreferences.svelte.ts
@@ -80,6 +80,7 @@ export function applyDisplayTheme(theme: DisplayTheme): void {
   const root = document.documentElement;
   root.dataset.theme = effective;
   root.style.backgroundColor = effective === 'dark' ? '#171717' : '#f3f4f6';
+  root.style.colorScheme = effective;
 }
 
 function normalizeNotificationSoundFilters(value: unknown): NotificationSoundFilters {


### PR DESCRIPTION
## Summary
Fix native scrollbar theming by applying Chatto's effective display theme to the root `color-scheme` during bootstrap and runtime preference changes.
This keeps platform scrollbars aligned with explicit light/dark selections while preserving system-mode behavior.

## Verification
- `npx @sveltejs/mcp svelte-autofixer apps/frontend/src/lib/state/userPreferences.svelte.ts --svelte-version 5`
- `mise x -- pnpm --filter chatto-frontend exec vitest run src/appHtml.spec.ts src/lib/state/userPreferences.svelte.spec.ts`
- `mise x -- pnpm --filter chatto-frontend exec playwright test e2e/user-settings.test.ts --retries=0`
- Browser check: emulated light OS theme with Chatto forced dark computed `color-scheme: dark`.
