### PR TITLE
feat(config): configure SMTP TLS verification

### DIFF
--- a/apps/docs-website/src/content/docs/reference/environment-variables.mdx
+++ b/apps/docs-website/src/content/docs/reference/environment-variables.mdx
@@ -332,6 +332,14 @@ See [External Login Providers](/guides/external-login-providers/) for callback U
   SMTP TLS policy. Use `mandatory` to require STARTTLS on port `587`, or `implicit` for SMTPS on port `465`. When this value is omitted or left as `mandatory`, Chatto automatically uses implicit TLS for port `465`. Use `opportunistic` only when the SMTP server cannot support mandatory STARTTLS and plaintext fallback is explicitly acceptable.
 </EnvVar>
 
+<EnvVar name="CHATTO_SMTP_TLS_SERVER_NAME" toml="smtp.tls_server_name">
+  SMTP TLS server name for certificate verification and SNI. Use when `smtp.host` is an IP address or internal alias but the certificate is issued for a DNS name.
+</EnvVar>
+
+<EnvVar name="CHATTO_SMTP_TLS_SKIP_VERIFY" toml="smtp.tls_skip_verify" default="false">
+  Disable SMTP TLS certificate verification. Insecure; use only for trusted internal SMTP servers with self-signed or mismatched certificates.
+</EnvVar>
+
 <EnvVar name="CHATTO_SMTP_USERNAME" toml="smtp.username">
   SMTP username.
 </EnvVar>

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -714,13 +714,15 @@ func (c *SMTPConfig) TLSPolicyOrDefault() SMTPTLSPolicy {
 
 // SMTPConfig contains settings for sending transactional emails.
 type SMTPConfig struct {
-	Enabled  bool          `toml:"enabled" env:"CHATTO_SMTP_ENABLED" comment:"Enable SMTP for sending transactional emails (verification, password reset, etc.)."`
-	Host     string        `toml:"host" env:"CHATTO_SMTP_HOST" comment:"SMTP server hostname. Example: smtp.example.com"`
-	Port     int           `toml:"port" env:"CHATTO_SMTP_PORT" comment:"SMTP server port. Common value: 587 (STARTTLS)."`
-	TLS      SMTPTLSPolicy `toml:"tls" env:"CHATTO_SMTP_TLS" comment:"SMTP TLS policy: mandatory STARTTLS (default), implicit TLS/SMTPS, or opportunistic. Opportunistic allows plaintext fallback and should only be used when explicitly required."`
-	Username string        `toml:"username" env:"CHATTO_SMTP_USERNAME" comment:"SMTP authentication username."`
-	Password string        `toml:"password" env:"CHATTO_SMTP_PASSWORD" comment:"SMTP authentication password. NEVER SHARE THIS!"`
-	From     string        `toml:"from" env:"CHATTO_SMTP_FROM" comment:"From address for outgoing emails. Example: noreply@example.com"`
+	Enabled       bool          `toml:"enabled" env:"CHATTO_SMTP_ENABLED" comment:"Enable SMTP for sending transactional emails (verification, password reset, etc.)."`
+	Host          string        `toml:"host" env:"CHATTO_SMTP_HOST" comment:"SMTP server hostname. Example: smtp.example.com"`
+	Port          int           `toml:"port" env:"CHATTO_SMTP_PORT" comment:"SMTP server port. Common value: 587 (STARTTLS)."`
+	TLS           SMTPTLSPolicy `toml:"tls" env:"CHATTO_SMTP_TLS" comment:"SMTP TLS policy: mandatory STARTTLS (default), implicit TLS/SMTPS, or opportunistic. Opportunistic allows plaintext fallback and should only be used when explicitly required."`
+	TLSServerName string        `toml:"tls_server_name,commented" env:"CHATTO_SMTP_TLS_SERVER_NAME" comment:"SMTP TLS server name for certificate verification and SNI. Use when smtp.host is an IP address or internal alias but the certificate is issued for a DNS name."`
+	TLSSkipVerify bool          `toml:"tls_skip_verify,commented" env:"CHATTO_SMTP_TLS_SKIP_VERIFY" comment:"Disable SMTP TLS certificate verification. Insecure; use only for trusted internal SMTP servers with self-signed or mismatched certificates."`
+	Username      string        `toml:"username" env:"CHATTO_SMTP_USERNAME" comment:"SMTP authentication username."`
+	Password      string        `toml:"password" env:"CHATTO_SMTP_PASSWORD" comment:"SMTP authentication password. NEVER SHARE THIS!"`
+	From          string        `toml:"from" env:"CHATTO_SMTP_FROM" comment:"From address for outgoing emails. Example: noreply@example.com"`
 }
 
 // PushConfig contains settings for Web Push notifications.

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -613,6 +613,8 @@ func TestReadConfig_SMTPPolicyFromEnv(t *testing.T) {
 	t.Setenv("CHATTO_CORE_SECRET_KEY", "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789")
 	t.Setenv("CHATTO_CORE_ASSETS_SIGNING_SECRET", "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff")
 	t.Setenv("CHATTO_SMTP_TLS", "opportunistic")
+	t.Setenv("CHATTO_SMTP_TLS_SERVER_NAME", "mail.example.com")
+	t.Setenv("CHATTO_SMTP_TLS_SKIP_VERIFY", "true")
 
 	cfg, err := ReadConfig("")
 	if err != nil {
@@ -621,6 +623,12 @@ func TestReadConfig_SMTPPolicyFromEnv(t *testing.T) {
 
 	if got := cfg.SMTP.TLSPolicyOrDefault(); got != SMTPTLSOpportunistic {
 		t.Errorf("expected SMTP TLS policy %q from env, got %q", SMTPTLSOpportunistic, got)
+	}
+	if got := cfg.SMTP.TLSServerName; got != "mail.example.com" {
+		t.Errorf("expected SMTP TLS server name from env, got %q", got)
+	}
+	if !cfg.SMTP.TLSSkipVerify {
+		t.Error("expected SMTP TLS skip verify from env")
 	}
 }
 

--- a/cli/internal/email/email.go
+++ b/cli/internal/email/email.go
@@ -3,6 +3,7 @@ package email
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 
@@ -107,6 +108,18 @@ func mailOptions(cfg config.SMTPConfig) []mail.Option {
 		opts = append(opts, mail.WithTLSPortPolicy(mail.TLSOpportunistic))
 	default:
 		opts = append(opts, mail.WithTLSPortPolicy(mail.TLSMandatory))
+	}
+
+	if cfg.TLSSkipVerify || cfg.TLSServerName != "" {
+		serverName := cfg.Host
+		if cfg.TLSServerName != "" {
+			serverName = cfg.TLSServerName
+		}
+		opts = append(opts, mail.WithTLSConfig(&tls.Config{
+			ServerName:         serverName,
+			InsecureSkipVerify: cfg.TLSSkipVerify,
+			MinVersion:         tls.VersionTLS12,
+		}))
 	}
 
 	return opts

--- a/cli/internal/email/email_test.go
+++ b/cli/internal/email/email_test.go
@@ -1,6 +1,7 @@
 package email
 
 import (
+	"crypto/tls"
 	"errors"
 	"reflect"
 	"testing"
@@ -50,34 +51,54 @@ func TestMailer_IsEnabled(t *testing.T) {
 
 func TestMailOptionsTLS(t *testing.T) {
 	tests := []struct {
-		name    string
-		cfg     config.SMTPConfig
-		wantSSL bool
+		name           string
+		cfg            config.SMTPConfig
+		wantSSL        bool
+		wantSkipVerify bool
+		wantServerName string
 	}{
 		{
-			name:    "mandatory STARTTLS does not use implicit TLS",
-			cfg:     config.SMTPConfig{Port: 587, TLS: config.SMTPTLSMandatory},
-			wantSSL: false,
+			name:           "mandatory STARTTLS does not use implicit TLS",
+			cfg:            config.SMTPConfig{Port: 587, TLS: config.SMTPTLSMandatory},
+			wantSSL:        false,
+			wantServerName: "smtp.example.com",
 		},
 		{
-			name:    "opportunistic STARTTLS does not use implicit TLS",
-			cfg:     config.SMTPConfig{Port: 587, TLS: config.SMTPTLSOpportunistic},
-			wantSSL: false,
+			name:           "opportunistic STARTTLS does not use implicit TLS",
+			cfg:            config.SMTPConfig{Port: 587, TLS: config.SMTPTLSOpportunistic},
+			wantSSL:        false,
+			wantServerName: "smtp.example.com",
 		},
 		{
-			name:    "explicit implicit TLS uses SSL mode",
-			cfg:     config.SMTPConfig{Port: 465, TLS: config.SMTPTLSImplicit},
-			wantSSL: true,
+			name:           "explicit implicit TLS uses SSL mode",
+			cfg:            config.SMTPConfig{Port: 465, TLS: config.SMTPTLSImplicit},
+			wantSSL:        true,
+			wantServerName: "smtp.example.com",
 		},
 		{
-			name:    "port 465 with default policy uses SSL mode",
-			cfg:     config.SMTPConfig{Port: 465},
-			wantSSL: true,
+			name:           "port 465 with default policy uses SSL mode",
+			cfg:            config.SMTPConfig{Port: 465},
+			wantSSL:        true,
+			wantServerName: "smtp.example.com",
 		},
 		{
-			name:    "port 465 with mandatory policy uses SSL mode",
-			cfg:     config.SMTPConfig{Port: 465, TLS: config.SMTPTLSMandatory},
-			wantSSL: true,
+			name:           "port 465 with mandatory policy uses SSL mode",
+			cfg:            config.SMTPConfig{Port: 465, TLS: config.SMTPTLSMandatory},
+			wantSSL:        true,
+			wantServerName: "smtp.example.com",
+		},
+		{
+			name:           "skip verify configures insecure TLS verification",
+			cfg:            config.SMTPConfig{Host: "smtp.example.com", Port: 587, TLS: config.SMTPTLSMandatory, TLSSkipVerify: true},
+			wantSSL:        false,
+			wantSkipVerify: true,
+			wantServerName: "smtp.example.com",
+		},
+		{
+			name:           "server name override configures SNI without skip verify",
+			cfg:            config.SMTPConfig{Host: "192.0.2.10", Port: 587, TLS: config.SMTPTLSMandatory, TLSServerName: "mail.example.com"},
+			wantSSL:        false,
+			wantServerName: "mail.example.com",
 		},
 	}
 
@@ -90,10 +111,31 @@ func TestMailOptionsTLS(t *testing.T) {
 			if got := clientUsesSSL(client); got != tt.wantSSL {
 				t.Errorf("implicit TLS = %v, want %v", got, tt.wantSSL)
 			}
+			if got := clientTLSSkipVerify(client); got != tt.wantSkipVerify {
+				t.Errorf("TLS skip verify = %v, want %v", got, tt.wantSkipVerify)
+			}
+			if got := clientTLSServerName(client); got != tt.wantServerName {
+				t.Errorf("TLS server name = %q, want %q", got, tt.wantServerName)
+			}
+			if got := clientTLSMinVersion(client); got != tls.VersionTLS12 {
+				t.Errorf("TLS min version = %d, want %d", got, tls.VersionTLS12)
+			}
 		})
 	}
 }
 
 func clientUsesSSL(client *mail.Client) bool {
 	return reflect.ValueOf(client).Elem().FieldByName("useSSL").Bool()
+}
+
+func clientTLSSkipVerify(client *mail.Client) bool {
+	return reflect.ValueOf(client).Elem().FieldByName("tlsconfig").Elem().FieldByName("InsecureSkipVerify").Bool()
+}
+
+func clientTLSServerName(client *mail.Client) string {
+	return reflect.ValueOf(client).Elem().FieldByName("tlsconfig").Elem().FieldByName("ServerName").String()
+}
+
+func clientTLSMinVersion(client *mail.Client) uint64 {
+	return reflect.ValueOf(client).Elem().FieldByName("tlsconfig").Elem().FieldByName("MinVersion").Uint()
 }

--- a/examples/dockercompose/.env.example
+++ b/examples/dockercompose/.env.example
@@ -48,6 +48,10 @@ CHATTO_SMTP_HOST=smtp.example.com
 # Use port 587 with mandatory STARTTLS, or port 465 with implicit TLS/SMTPS.
 CHATTO_SMTP_PORT=587
 CHATTO_SMTP_TLS=mandatory
+# Use when CHATTO_SMTP_HOST is an IP address or internal alias but the certificate is issued for a DNS name.
+# CHATTO_SMTP_TLS_SERVER_NAME=mail.example.com
+# Insecure; use only for trusted internal SMTP servers with self-signed or mismatched certificates.
+# CHATTO_SMTP_TLS_SKIP_VERIFY=false
 CHATTO_SMTP_USERNAME=your-smtp-username
 CHATTO_SMTP_PASSWORD=your-smtp-password
 CHATTO_SMTP_FROM=noreply@example.com

--- a/examples/dockercompose/init-env.sh
+++ b/examples/dockercompose/init-env.sh
@@ -107,6 +107,10 @@ CHATTO_SMTP_ENABLED=true
 CHATTO_SMTP_HOST=smtp.example.com
 CHATTO_SMTP_PORT=587
 CHATTO_SMTP_TLS=mandatory
+# Use when CHATTO_SMTP_HOST is an IP address or internal alias but the certificate is issued for a DNS name.
+# CHATTO_SMTP_TLS_SERVER_NAME=mail.example.com
+# Insecure; use only for trusted internal SMTP servers with self-signed or mismatched certificates.
+# CHATTO_SMTP_TLS_SKIP_VERIFY=false
 CHATTO_SMTP_USERNAME=your-smtp-username
 CHATTO_SMTP_PASSWORD=your-smtp-password
 CHATTO_SMTP_FROM=${smtp_from}

--- a/examples/k8s/secrets.yaml
+++ b/examples/k8s/secrets.yaml
@@ -38,6 +38,10 @@ stringData:
   # Use port 587 with mandatory STARTTLS, or port 465 with implicit TLS/SMTPS.
   # CHATTO_SMTP_PORT: "587"
   # CHATTO_SMTP_TLS: "mandatory"
+  # Use when CHATTO_SMTP_HOST is an IP address or internal alias but the certificate is issued for a DNS name.
+  # CHATTO_SMTP_TLS_SERVER_NAME: "mail.example.com"
+  # Insecure; use only for trusted internal SMTP servers with self-signed or mismatched certificates.
+  # CHATTO_SMTP_TLS_SKIP_VERIFY: "false"
   # CHATTO_SMTP_USERNAME: "your-smtp-username"
   # CHATTO_SMTP_PASSWORD: "your-smtp-password"
   # CHATTO_SMTP_FROM: "noreply@example.com"


### PR DESCRIPTION
## Summary
- Add `smtp.tls_server_name` / `CHATTO_SMTP_TLS_SERVER_NAME` for SMTP certificate verification and SNI overrides.
- Add `smtp.tls_skip_verify` / `CHATTO_SMTP_TLS_SKIP_VERIFY` for trusted internal SMTP servers with self-signed or mismatched certificates.
- Wire both options into SMTP TLS config without changing existing `mandatory`, `opportunistic`, or `implicit` policy behavior.
- Document the insecure escape hatch in the env var reference and deployment examples.

## Tests
- `mise x -- go test ./internal/config -run 'TestReadConfig_SMTP|TestChattoConfig_Validate_SMTP' -timeout 30s`
- `mise x -- go test ./internal/email -run 'TestMailOptionsTLS' -timeout 30s`
- `mise x -- go test ./internal/config -timeout 30s`
- `mise x -- go test ./internal/email -timeout 30s`
