### PR TITLE
chore(conductor): run setup task during workspace setup

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -5,7 +5,7 @@ name = "Chatto"
 url = "http://localhost:$CONDUCTOR_PORT"
 
 [scripts]
-setup = "mise trust"
+setup = "mise trust && mise setup"
 run = "mise run chatto run"
 run_mode = "concurrent"
 


### PR DESCRIPTION
Updates the Conductor workspace setup script so it runs both `mise trust` and `mise setup`.
This ensures workspace setup performs the project setup task after trusting the local mise configuration.

Verification: `git diff --check`.
