### PR TITLE
fix(api): preserve offline presence in snapshots

### DIFF
--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/index.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/index.mdx
@@ -185,7 +185,7 @@ Request to report the current user's live presence status.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `status` | [`PresenceStatus`](#chatto-api-v1-PresenceStatus) | Live status to report for the authenticated user. |
+| `status` | [`PresenceStatus`](#chatto-api-v1-PresenceStatus) | Live status to report for the authenticated user. Offline is rejected. |
 | `user_selected` | `bool` | True when this report comes from a deliberate user selection rather than automatic idle/refresh reporting. Automatic reports do not overwrite an active manually selected Away or Do Not Disturb status from another client. |
 
 
@@ -197,7 +197,7 @@ Result of reporting live presence.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `status` | [`PresenceStatus`](#chatto-api-v1-PresenceStatus) | Status accepted and stored by the server. |
+| `status` | [`PresenceStatus`](#chatto-api-v1-PresenceStatus) | Reportable status accepted and stored by the server. |
 
 
 <a id="chatto-api-v1-UserStatusService"></a>
@@ -5853,11 +5853,11 @@ Notification delivery level for a room.
 
 ### PresenceStatus
 
-Live presence status a client can report for the current user.
+Live presence status returned by public read APIs.
 
-Offline is not a reportable status. Clients that want the user to appear
-offline should stop reporting presence and let the server's live presence
-record expire.
+Offline is a read-side state only. Clients cannot report Offline through
+PresenceService.ReportPresence; they should stop reporting presence and let
+the server's live presence record expire.
 
 | Name | Number | Description |
 | --- | --- | --- |
@@ -5865,6 +5865,7 @@ record expire.
 | `PRESENCE_STATUS_ONLINE` | `1` | The user is actively available. |
 | `PRESENCE_STATUS_AWAY` | `2` | The user is connected but away or idle. |
 | `PRESENCE_STATUS_DO_NOT_DISTURB` | `3` | The user does not want notifications while this live status is active. |
+| `PRESENCE_STATUS_OFFLINE` | `4` | The user has no active live presence record. |
 
 
 <a id="chatto-api-v1-TimeFormat"></a>

--- a/apps/frontend/e2e/presence-indicators.test.ts
+++ b/apps/frontend/e2e/presence-indicators.test.ts
@@ -207,10 +207,9 @@ test.describe('Member list grouping', () => {
     // Wait for member list to be populated first
     await roomPage.expectMemberVisible(user.login);
 
-    // Bootstrap server members include e2eadmin (the owner) plus the test
-    // user. Connect-based presence reports the bootstrap admin as online, so
-    // Online is exactly 2.
-    await expect(roomPage.onlineSectionHeader).toHaveText('Online (2)', {
+    // The test user has an active presence report; the bootstrap admin has no
+    // live presence record and remains offline.
+    await expect(roomPage.onlineSectionHeader).toHaveText('Online (1)', {
       timeout: TIMEOUTS.REALTIME_EVENT
     });
   });
@@ -227,8 +226,9 @@ test.describe('Member list grouping', () => {
 
     const roomPage = await chatPage.enterRoom('general');
 
-    // Initially the bootstrap admin and User A are online.
-    await expect(roomPage.onlineSectionHeader).toHaveText('Online (2)', {
+    // Initially only User A is online; the bootstrap admin has no live
+    // presence record.
+    await expect(roomPage.onlineSectionHeader).toHaveText('Online (1)', {
       timeout: TIMEOUTS.REALTIME_EVENT
     });
 
@@ -245,8 +245,8 @@ test.describe('Member list grouping', () => {
         await chatPage2.enterRoom('general');
         await waitForRoomReady(page2, 'general');
 
-        // User A should see the bootstrap admin, User A, and User B online.
-        await expect(roomPage.onlineSectionHeader).toHaveText('Online (3)', {
+        // User A should see User A and User B online.
+        await expect(roomPage.onlineSectionHeader).toHaveText('Online (2)', {
           timeout: TIMEOUTS.REALTIME_EVENT
         });
 
@@ -262,7 +262,7 @@ test.describe('Member list grouping', () => {
     // scenarios. The offline transition is tested in unit tests.
 
     // User B should still be in the Online section (TTL hasn't expired)
-    await expect(roomPage.onlineSectionHeader).toHaveText('Online (3)', {
+    await expect(roomPage.onlineSectionHeader).toHaveText('Online (2)', {
       timeout: TIMEOUTS.UI_STANDARD
     });
 
@@ -291,8 +291,9 @@ test.describe('Member list grouping', () => {
     // Wait for member list to load
     await roomPage.expectMemberVisible(userA.login);
 
-    // Initially the bootstrap admin and User A are online.
-    await expect(roomPage.onlineSectionHeader).toHaveText('Online (2)', {
+    // Initially only User A is online; the bootstrap admin has no live
+    // presence record.
+    await expect(roomPage.onlineSectionHeader).toHaveText('Online (1)', {
       timeout: TIMEOUTS.REALTIME_EVENT
     });
 
@@ -301,8 +302,8 @@ test.describe('Member list grouping', () => {
       await chatPage2.enterRoom('general');
       await waitForRoomReady(page2, 'general');
 
-      // Bootstrap admin, User A, and User B should all be online.
-      await expect(roomPage.onlineSectionHeader).toHaveText('Online (3)', {
+      // User A and User B should both be online.
+      await expect(roomPage.onlineSectionHeader).toHaveText('Online (2)', {
         timeout: TIMEOUTS.REALTIME_EVENT
       });
     });
@@ -310,7 +311,7 @@ test.describe('Member list grouping', () => {
     // User B remains online until TTL expires (60s). We use TTL-based expiry
     // to support multi-device scenarios. The offline transition is tested in
     // unit tests which can control timing.
-    await expect(roomPage.onlineSectionHeader).toHaveText('Online (3)', {
+    await expect(roomPage.onlineSectionHeader).toHaveText('Online (2)', {
       timeout: TIMEOUTS.UI_STANDARD
     });
   });

--- a/apps/frontend/src/lib/api/memberDirectory.spec.ts
+++ b/apps/frontend/src/lib/api/memberDirectory.spec.ts
@@ -133,4 +133,38 @@ describe('createMemberDirectoryAPI', () => {
       { headers: undefined }
     );
   });
+
+  it('maps offline and unspecified read statuses to offline', async () => {
+    mocks.listServerMembers.mockResolvedValue({
+      members: [
+        {
+          id: 'U3',
+          login: 'carol',
+          displayName: 'Carol',
+          deleted: false,
+          presenceStatus: APIPresenceStatus.OFFLINE,
+          roles: []
+        },
+        {
+          id: 'U4',
+          login: 'dave',
+          displayName: 'Dave',
+          deleted: false,
+          presenceStatus: APIPresenceStatus.UNSPECIFIED,
+          roles: []
+        }
+      ],
+      totalCount: 2,
+      hasMore: false
+    });
+
+    const api = createMemberDirectoryAPI({ baseUrl: '/api/connect', bearerToken: null });
+
+    await expect(api.listServerMembers()).resolves.toMatchObject({
+      members: [
+        { id: 'U3', presenceStatus: PresenceStatus.Offline },
+        { id: 'U4', presenceStatus: PresenceStatus.Offline }
+      ]
+    });
+  });
 });

--- a/apps/frontend/src/lib/api/memberDirectory.ts
+++ b/apps/frontend/src/lib/api/memberDirectory.ts
@@ -102,8 +102,10 @@ function apiPresenceStatus(status: APIPresenceStatus): PresenceStatus {
     case APIPresenceStatus.DO_NOT_DISTURB:
       return PresenceStatus.DoNotDisturb;
     case APIPresenceStatus.ONLINE:
+      return PresenceStatus.Online;
+    case APIPresenceStatus.OFFLINE:
     case APIPresenceStatus.UNSPECIFIED:
     default:
-      return PresenceStatus.Online;
+      return PresenceStatus.Offline;
   }
 }

--- a/apps/frontend/src/lib/api/notifications.spec.ts
+++ b/apps/frontend/src/lib/api/notifications.spec.ts
@@ -63,7 +63,7 @@ describe('createNotificationAPI', () => {
             displayName: 'Alice',
             deleted: false,
             avatarUrl: 'https://cdn/avatar.webp',
-            presenceStatus: APIPresenceStatus.AWAY
+            presenceStatus: APIPresenceStatus.OFFLINE
           },
           summary: 'Alice mentioned you',
           kind: {
@@ -107,7 +107,7 @@ describe('createNotificationAPI', () => {
             displayName: 'Alice',
             deleted: false,
             avatarUrl: 'https://cdn/avatar.webp',
-            presenceStatus: PresenceStatus.Away,
+            presenceStatus: PresenceStatus.Offline,
             customStatus: null
           },
           summary: 'Alice mentioned you',

--- a/apps/frontend/src/lib/api/notifications.ts
+++ b/apps/frontend/src/lib/api/notifications.ts
@@ -226,8 +226,10 @@ function apiPresenceStatus(status: APIPresenceStatus): PresenceStatus {
     case APIPresenceStatus.DO_NOT_DISTURB:
       return PresenceStatus.DoNotDisturb;
     case APIPresenceStatus.ONLINE:
+      return PresenceStatus.Online;
+    case APIPresenceStatus.OFFLINE:
     case APIPresenceStatus.UNSPECIFIED:
     default:
-      return PresenceStatus.Online;
+      return PresenceStatus.Offline;
   }
 }

--- a/apps/frontend/src/lib/api/rooms.spec.ts
+++ b/apps/frontend/src/lib/api/rooms.spec.ts
@@ -202,7 +202,7 @@ describe('createRoomCommandAPI', () => {
             login: 'mod',
             displayName: 'Moderator',
             deleted: false,
-            presenceStatus: APIPresenceStatus.ONLINE,
+            presenceStatus: APIPresenceStatus.OFFLINE,
             roles: []
           },
           reason: 'policy',
@@ -248,7 +248,7 @@ describe('createRoomCommandAPI', () => {
           displayName: 'Moderator',
           deleted: false,
           avatarUrl: null,
-          presenceStatus: PresenceStatus.Online,
+          presenceStatus: PresenceStatus.Offline,
           customStatus: null,
           roles: [],
           createdAt: null

--- a/apps/frontend/src/lib/api/viewer.spec.ts
+++ b/apps/frontend/src/lib/api/viewer.spec.ts
@@ -91,7 +91,7 @@ describe('getCurrentUserViaConnect', () => {
     });
   });
 
-  it('omits auth headers and defaults unspecified enum values', async () => {
+  it('omits auth headers and maps unspecified presence as offline', async () => {
     mocks.getViewer.mockResolvedValue({
       user: {
         id: 'U2',
@@ -110,7 +110,7 @@ describe('getCurrentUserViaConnect', () => {
     });
 
     expect(mocks.getViewer).toHaveBeenCalledWith({}, { headers: undefined });
-    expect(user.presenceStatus).toBe(PresenceStatus.Online);
+    expect(user.presenceStatus).toBe(PresenceStatus.Offline);
     expect(user.settings?.timeFormat).toBe(TimeFormat.Auto);
     expect(user.customStatus).toBeNull();
     expect(user.viewerCanDeleteAccount).toBe(false);

--- a/apps/frontend/src/lib/api/viewer.ts
+++ b/apps/frontend/src/lib/api/viewer.ts
@@ -145,9 +145,11 @@ function apiPresenceStatus(status: APIPresenceStatus): PresenceStatus {
     case APIPresenceStatus.DO_NOT_DISTURB:
       return PresenceStatus.DoNotDisturb;
     case APIPresenceStatus.ONLINE:
+      return PresenceStatus.Online;
+    case APIPresenceStatus.OFFLINE:
     case APIPresenceStatus.UNSPECIFIED:
     default:
-      return PresenceStatus.Online;
+      return PresenceStatus.Offline;
   }
 }
 

--- a/apps/frontend/src/lib/pb/chatto/api/v1/presence_pb.ts
+++ b/apps/frontend/src/lib/pb/chatto/api/v1/presence_pb.ts
@@ -7,11 +7,11 @@ import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialM
 import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
- * Live presence status a client can report for the current user.
+ * Live presence status returned by public read APIs.
  *
- * Offline is not a reportable status. Clients that want the user to appear
- * offline should stop reporting presence and let the server's live presence
- * record expire.
+ * Offline is a read-side state only. Clients cannot report Offline through
+ * PresenceService.ReportPresence; they should stop reporting presence and let
+ * the server's live presence record expire.
  *
  * @generated from enum chatto.api.v1.PresenceStatus
  */
@@ -43,6 +43,13 @@ export enum PresenceStatus {
    * @generated from enum value: PRESENCE_STATUS_DO_NOT_DISTURB = 3;
    */
   DO_NOT_DISTURB = 3,
+
+  /**
+   * The user has no active live presence record.
+   *
+   * @generated from enum value: PRESENCE_STATUS_OFFLINE = 4;
+   */
+  OFFLINE = 4,
 }
 // Retrieve enum metadata with: proto3.getEnumType(PresenceStatus)
 proto3.util.setEnumType(PresenceStatus, "chatto.api.v1.PresenceStatus", [
@@ -50,6 +57,7 @@ proto3.util.setEnumType(PresenceStatus, "chatto.api.v1.PresenceStatus", [
   { no: 1, name: "PRESENCE_STATUS_ONLINE" },
   { no: 2, name: "PRESENCE_STATUS_AWAY" },
   { no: 3, name: "PRESENCE_STATUS_DO_NOT_DISTURB" },
+  { no: 4, name: "PRESENCE_STATUS_OFFLINE" },
 ]);
 
 /**
@@ -59,7 +67,7 @@ proto3.util.setEnumType(PresenceStatus, "chatto.api.v1.PresenceStatus", [
  */
 export class ReportPresenceRequest extends Message<ReportPresenceRequest> {
   /**
-   * Live status to report for the authenticated user.
+   * Live status to report for the authenticated user. Offline is rejected.
    *
    * @generated from field: chatto.api.v1.PresenceStatus status = 1;
    */
@@ -110,7 +118,7 @@ export class ReportPresenceRequest extends Message<ReportPresenceRequest> {
  */
 export class ReportPresenceResponse extends Message<ReportPresenceResponse> {
   /**
-   * Status accepted and stored by the server.
+   * Reportable status accepted and stored by the server.
    *
    * @generated from field: chatto.api.v1.PresenceStatus status = 1;
    */

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -224,6 +224,18 @@ func TestUserServiceReadsPublicProfiles(t *testing.T) {
 	}
 
 	ctx := withCaller(env.ctx, env.viewer)
+	offlineUser, err := env.core.CreateUser(env.ctx, core.SystemActorID, "offline-profile", "Offline Profile", "password")
+	if err != nil {
+		t.Fatalf("CreateUser offline profile: %v", err)
+	}
+	offlineResp, err := env.users.GetUser(ctx, connect.NewRequest(&apiv1.GetUserRequest{UserId: offlineUser.Id}))
+	if err != nil {
+		t.Fatalf("GetUser offline profile: %v", err)
+	}
+	if offlineResp.Msg.GetUser().GetPresenceStatus() != apiv1.PresenceStatus_PRESENCE_STATUS_OFFLINE {
+		t.Fatalf("offline profile presence = %v, want OFFLINE", offlineResp.Msg.GetUser().GetPresenceStatus())
+	}
+
 	if _, err := env.core.SetUserCustomStatus(env.ctx, env.viewer.Id, "wave", "around", nil); err != nil {
 		t.Fatalf("SetUserCustomStatus: %v", err)
 	}
@@ -793,6 +805,14 @@ func TestViewerServiceGetViewerReturnsSelfScopedState(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("UpdateUserSettings: %v", err)
 	}
+	offlineResp, err := env.viewerService.GetViewer(ctx, connect.NewRequest(&apiv1.GetViewerRequest{}))
+	if err != nil {
+		t.Fatalf("GetViewer offline presence: %v", err)
+	}
+	if offlineResp.Msg.GetUser().GetPresenceStatus() != apiv1.PresenceStatus_PRESENCE_STATUS_OFFLINE {
+		t.Fatalf("initial viewer presence = %v, want OFFLINE", offlineResp.Msg.GetUser().GetPresenceStatus())
+	}
+
 	if err := env.core.SetPresence(env.ctx, env.viewer.Id, core.PresenceStatusAway); err != nil {
 		t.Fatalf("SetPresence: %v", err)
 	}
@@ -2252,6 +2272,9 @@ func TestMemberDirectoryServiceListServerMembers(t *testing.T) {
 	if gotByID[alice.Id].GetPresenceStatus() != apiv1.PresenceStatus_PRESENCE_STATUS_AWAY {
 		t.Fatalf("alice presence = %v, want AWAY", gotByID[alice.Id].GetPresenceStatus())
 	}
+	if gotByID[bob.Id].GetPresenceStatus() != apiv1.PresenceStatus_PRESENCE_STATUS_OFFLINE {
+		t.Fatalf("bob presence = %v, want OFFLINE", gotByID[bob.Id].GetPresenceStatus())
+	}
 	if roles := strings.Join(gotByID[bob.Id].GetRoles(), ","); roles != "everyone,admin" {
 		t.Fatalf("bob roles = %q, want everyone,admin", roles)
 	}
@@ -2675,6 +2698,11 @@ func TestPresenceServiceReportPresence(t *testing.T) {
 		Status: apiv1.PresenceStatus_PRESENCE_STATUS_UNSPECIFIED,
 	})); connect.CodeOf(err) != connect.CodeInvalidArgument {
 		t.Fatalf("unspecified ReportPresence code = %v, want %v", connect.CodeOf(err), connect.CodeInvalidArgument)
+	}
+	if _, err := env.presence.ReportPresence(ctx, connect.NewRequest(&apiv1.ReportPresenceRequest{
+		Status: apiv1.PresenceStatus_PRESENCE_STATUS_OFFLINE,
+	})); connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("offline ReportPresence code = %v, want %v", connect.CodeOf(err), connect.CodeInvalidArgument)
 	}
 
 	resp, err := env.presence.ReportPresence(ctx, connect.NewRequest(&apiv1.ReportPresenceRequest{

--- a/cli/internal/connectapi/presence.go
+++ b/cli/internal/connectapi/presence.go
@@ -44,6 +44,8 @@ func apiPresenceStatusToCore(status apiv1.PresenceStatus) (string, error) {
 		return core.PresenceStatusAway, nil
 	case apiv1.PresenceStatus_PRESENCE_STATUS_DO_NOT_DISTURB:
 		return core.PresenceStatusDoNotDisturb, nil
+	case apiv1.PresenceStatus_PRESENCE_STATUS_OFFLINE:
+		return "", connect.NewError(connect.CodeInvalidArgument, errors.New("status must be ONLINE, AWAY, or DO_NOT_DISTURB"))
 	default:
 		return "", connect.NewError(connect.CodeInvalidArgument, errors.New("status must be ONLINE, AWAY, or DO_NOT_DISTURB"))
 	}
@@ -51,6 +53,8 @@ func apiPresenceStatusToCore(status apiv1.PresenceStatus) (string, error) {
 
 func corePresenceStatusToAPI(status string) apiv1.PresenceStatus {
 	switch status {
+	case core.PresenceStatusOffline:
+		return apiv1.PresenceStatus_PRESENCE_STATUS_OFFLINE
 	case core.PresenceStatusAway:
 		return apiv1.PresenceStatus_PRESENCE_STATUS_AWAY
 	case core.PresenceStatusDoNotDisturb:

--- a/cli/internal/pb/chatto/api/v1/presence.pb.go
+++ b/cli/internal/pb/chatto/api/v1/presence.pb.go
@@ -21,11 +21,11 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// Live presence status a client can report for the current user.
+// Live presence status returned by public read APIs.
 //
-// Offline is not a reportable status. Clients that want the user to appear
-// offline should stop reporting presence and let the server's live presence
-// record expire.
+// Offline is a read-side state only. Clients cannot report Offline through
+// PresenceService.ReportPresence; they should stop reporting presence and let
+// the server's live presence record expire.
 type PresenceStatus int32
 
 const (
@@ -37,6 +37,8 @@ const (
 	PresenceStatus_PRESENCE_STATUS_AWAY PresenceStatus = 2
 	// The user does not want notifications while this live status is active.
 	PresenceStatus_PRESENCE_STATUS_DO_NOT_DISTURB PresenceStatus = 3
+	// The user has no active live presence record.
+	PresenceStatus_PRESENCE_STATUS_OFFLINE PresenceStatus = 4
 )
 
 // Enum value maps for PresenceStatus.
@@ -46,12 +48,14 @@ var (
 		1: "PRESENCE_STATUS_ONLINE",
 		2: "PRESENCE_STATUS_AWAY",
 		3: "PRESENCE_STATUS_DO_NOT_DISTURB",
+		4: "PRESENCE_STATUS_OFFLINE",
 	}
 	PresenceStatus_value = map[string]int32{
 		"PRESENCE_STATUS_UNSPECIFIED":    0,
 		"PRESENCE_STATUS_ONLINE":         1,
 		"PRESENCE_STATUS_AWAY":           2,
 		"PRESENCE_STATUS_DO_NOT_DISTURB": 3,
+		"PRESENCE_STATUS_OFFLINE":        4,
 	}
 )
 
@@ -85,7 +89,7 @@ func (PresenceStatus) EnumDescriptor() ([]byte, []int) {
 // Request to report the current user's live presence status.
 type ReportPresenceRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Live status to report for the authenticated user.
+	// Live status to report for the authenticated user. Offline is rejected.
 	Status PresenceStatus `protobuf:"varint,1,opt,name=status,proto3,enum=chatto.api.v1.PresenceStatus" json:"status,omitempty"`
 	// True when this report comes from a deliberate user selection rather than
 	// automatic idle/refresh reporting. Automatic reports do not overwrite an
@@ -142,7 +146,7 @@ func (x *ReportPresenceRequest) GetUserSelected() bool {
 // Result of reporting live presence.
 type ReportPresenceResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Status accepted and stored by the server.
+	// Reportable status accepted and stored by the server.
 	Status        PresenceStatus `protobuf:"varint,1,opt,name=status,proto3,enum=chatto.api.v1.PresenceStatus" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -194,12 +198,13 @@ const file_chatto_api_v1_presence_proto_rawDesc = "" +
 	"\x06status\x18\x01 \x01(\x0e2\x1d.chatto.api.v1.PresenceStatusR\x06status\x12#\n" +
 	"\ruser_selected\x18\x02 \x01(\bR\fuserSelected\"O\n" +
 	"\x16ReportPresenceResponse\x125\n" +
-	"\x06status\x18\x01 \x01(\x0e2\x1d.chatto.api.v1.PresenceStatusR\x06status*\x8b\x01\n" +
+	"\x06status\x18\x01 \x01(\x0e2\x1d.chatto.api.v1.PresenceStatusR\x06status*\xa8\x01\n" +
 	"\x0ePresenceStatus\x12\x1f\n" +
 	"\x1bPRESENCE_STATUS_UNSPECIFIED\x10\x00\x12\x1a\n" +
 	"\x16PRESENCE_STATUS_ONLINE\x10\x01\x12\x18\n" +
 	"\x14PRESENCE_STATUS_AWAY\x10\x02\x12\"\n" +
-	"\x1ePRESENCE_STATUS_DO_NOT_DISTURB\x10\x032p\n" +
+	"\x1ePRESENCE_STATUS_DO_NOT_DISTURB\x10\x03\x12\x1b\n" +
+	"\x17PRESENCE_STATUS_OFFLINE\x10\x042p\n" +
 	"\x0fPresenceService\x12]\n" +
 	"\x0eReportPresence\x12$.chatto.api.v1.ReportPresenceRequest\x1a%.chatto.api.v1.ReportPresenceResponseB\xa9\x01\n" +
 	"\x11com.chatto.api.v1B\rPresenceProtoP\x01Z/hmans.de/chatto/internal/pb/chatto/api/v1;apiv1\xa2\x02\x03CAX\xaa\x02\rChatto.Api.V1\xca\x02\rChatto\\Api\\V1\xe2\x02\x19Chatto\\Api\\V1\\GPBMetadata\xea\x02\x0fChatto::Api::V1b\x06proto3"

--- a/proto/chatto/api/v1/presence.proto
+++ b/proto/chatto/api/v1/presence.proto
@@ -2,11 +2,11 @@ syntax = "proto3";
 
 package chatto.api.v1;
 
-// Live presence status a client can report for the current user.
+// Live presence status returned by public read APIs.
 //
-// Offline is not a reportable status. Clients that want the user to appear
-// offline should stop reporting presence and let the server's live presence
-// record expire.
+// Offline is a read-side state only. Clients cannot report Offline through
+// PresenceService.ReportPresence; they should stop reporting presence and let
+// the server's live presence record expire.
 enum PresenceStatus {
   // No presence status was specified.
   PRESENCE_STATUS_UNSPECIFIED = 0;
@@ -16,11 +16,13 @@ enum PresenceStatus {
   PRESENCE_STATUS_AWAY = 2;
   // The user does not want notifications while this live status is active.
   PRESENCE_STATUS_DO_NOT_DISTURB = 3;
+  // The user has no active live presence record.
+  PRESENCE_STATUS_OFFLINE = 4;
 }
 
 // Request to report the current user's live presence status.
 message ReportPresenceRequest {
-  // Live status to report for the authenticated user.
+  // Live status to report for the authenticated user. Offline is rejected.
   PresenceStatus status = 1;
   // True when this report comes from a deliberate user selection rather than
   // automatic idle/refresh reporting. Automatic reports do not overwrite an
@@ -30,7 +32,7 @@ message ReportPresenceRequest {
 
 // Result of reporting live presence.
 message ReportPresenceResponse {
-  // Status accepted and stored by the server.
+  // Reportable status accepted and stored by the server.
   PresenceStatus status = 1;
 }
 


### PR DESCRIPTION
## Summary

Fixes presence snapshots so public read APIs can return `OFFLINE` instead of collapsing expired presence to `ONLINE`.
Adds `PRESENCE_STATUS_OFFLINE` as a read-side API enum value while keeping `ReportPresence` limited to online, away, and do-not-disturb.
Updates backend/frontend mappings, generated API bindings/docs, and regression coverage for offline reads and rejected offline reports.

## Tests

- `mise x -- go test ./internal/connectapi -run 'Test(UserServiceReadsPublicProfiles|ViewerServiceGetViewer|MemberDirectoryServiceListServerMembers|PresenceServiceReportPresence|NotificationServiceListsAndDismissesNotifications)' -timeout 90s`
- `mise x -- pnpm exec vitest run src/lib/api/memberDirectory.spec.ts src/lib/api/viewer.spec.ts src/lib/api/notifications.spec.ts src/lib/api/rooms.spec.ts src/lib/presenceTracking.spec.ts`
- `mise x -- pnpm exec playwright test e2e/presence-indicators.test.ts --retries=0`
- `git diff --check`
