### PR TITLE
ci: use GitHub-hosted runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,3 @@
-self-hosted-runner:
-  labels:
-    - ubicloud-standard-4
+# self-hosted-runner:
+#   labels:
+#     - ubicloud-standard-4

--- a/.github/workflows/build-docs-image.yml
+++ b/.github/workflows/build-docs-image.yml
@@ -22,7 +22,8 @@ permissions:
 
 jobs:
   build-docs-image:
-    runs-on: ubicloud-standard-4
+    # runs-on: ubicloud-standard-4
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -14,7 +14,8 @@ permissions:
 
 jobs:
   build-image:
-    runs-on: ubicloud-standard-4
+    # runs-on: ubicloud-standard-4
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ permissions:
 
 jobs:
   codegen-proto-drift:
-    runs-on: ubicloud-standard-4
+    # runs-on: ubicloud-standard-4
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -38,7 +39,8 @@ jobs:
           fi
 
   test-frontend-unit:
-    runs-on: ubicloud-standard-4
+    # runs-on: ubicloud-standard-4
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -70,7 +72,8 @@ jobs:
         run: cd apps/frontend && pnpm vitest --run
 
   test-cli:
-    runs-on: ubicloud-standard-4
+    # runs-on: ubicloud-standard-4
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -85,7 +88,8 @@ jobs:
         run: cd cli && go test -trimpath -p 1 -tags test_endpoints ./...
 
   test-e2e:
-    runs-on: ubicloud-standard-4
+    # runs-on: ubicloud-standard-4
+    runs-on: ubuntu-latest
     name: test-e2e (${{ matrix.shard }}/4)
     strategy:
       fail-fast: false
@@ -125,7 +129,8 @@ jobs:
           retention-days: 14
 
   test-e2e-media:
-    runs-on: ubicloud-standard-4
+    # runs-on: ubicloud-standard-4
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,8 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubicloud-standard-4
+    # runs-on: ubicloud-standard-4
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Switch CI, image build, docs image build, and release jobs from Ubicloud self-hosted runners to GitHub-hosted `ubuntu-latest` runners.
- Leave the previous Ubicloud runner labels commented out so the comparison can be reverted quickly if needed.
- Comment out the actionlint self-hosted runner label allowlist while the workflows use hosted runners.

## Validation

- `mise x -- actionlint`
