### PR TITLE
fix(messages): validate reply targets before posting

### DIFF
--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -52,6 +52,7 @@
   import { extractURLs } from '$lib/linkPreview';
   import MessagePreviewCard from '$lib/components/MessagePreviewCard.svelte';
   import { shouldHighlightCurrentUserMention } from './messageMentionHighlight';
+  import { roomReplyTargetEventId } from './messageReplyTarget';
   import { selectedQuoteTextForMessageBody } from './selectedReplyQuote';
   import { createThreadAPI } from '$lib/api/threads';
   import { createRoomCommandAPI } from '$lib/api/rooms';
@@ -551,7 +552,7 @@
   function handleReplyInRoom() {
     const quote = takeSelectedReplyQuote();
     const excerpt = (msg?.body ?? '').slice(0, 80);
-    replyState.startReply(event.id, displayName, excerpt);
+    replyState.startReply(roomReplyTargetEventId(event), displayName, excerpt);
     if (quote) {
       composerContext.quoteInsertionState.requestInsertQuote(quote);
     }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -98,6 +98,7 @@
   const composerContext = createComposerContext({ scroll: true });
   const mentionRoles = createMentionRoles();
   const replyState = composerContext.replyState;
+  let replyStateRoomId: string | null = null;
   const jumpState = composerContext.jumpState;
   const currentUser = $derived(serverRegistry.getStore(getActiveServer()).currentUser);
   const roomMessageStore = new MessagesStore(connection(), () => currentUser.user?.id ?? null);
@@ -119,6 +120,17 @@
 
   // --- Extracted hooks ---
   const room = useRoomData(() => ({ roomId }));
+
+  $effect(() => {
+    const currentRoomId = roomId;
+    if (replyStateRoomId === null) {
+      replyStateRoomId = currentRoomId;
+      return;
+    }
+    if (replyStateRoomId === currentRoomId) return;
+    replyStateRoomId = currentRoomId;
+    replyState.cancelReply();
+  });
 
   $effect(() => {
     const conn = connection();

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -309,6 +309,22 @@ describe('Room local message echo', () => {
     expect(mocks.noteReadCursor).not.toHaveBeenCalled();
   });
 
+  it('clears pending in-room reply state when the room changes', async () => {
+    const rendered = render(Room, { props: { roomId: 'room-1' } });
+    const { container } = rendered;
+
+    await expect.element(q(container, '[data-testid="composer-in-reply-to"]')).toHaveTextContent('');
+
+    (q(container, '[data-testid="start-composer-reply"]') as HTMLButtonElement).click();
+    await expect
+      .element(q(container, '[data-testid="composer-in-reply-to"]'))
+      .toHaveTextContent('reply-target');
+
+    await rendered.rerender({ roomId: 'room-2' });
+
+    await expect.element(q(container, '[data-testid="composer-in-reply-to"]')).toHaveTextContent('');
+  });
+
   it('opens a pending call panel request as a mobile sidebar after navigation', async () => {
     mocks.livekitUrl = 'wss://livekit.example.test';
     vi.stubGlobal(

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomLocalEchoMessageComposerMock.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomLocalEchoMessageComposerMock.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
   import { RoomEventKind } from '$lib/render/eventKinds';
   import type { RoomEventView } from '$lib/render/types';
+  import { getComposerContext } from '$lib/state/room';
 
   let {
+    inReplyTo,
     onMessageSent
   }: {
+    inReplyTo?: string;
     onMessageSent?: (event: RoomEventView | null) => void;
   } = $props();
+
+  const composerContext = getComposerContext();
 
   const returnedPost = {
     id: 'msg-local',
@@ -66,3 +71,12 @@
 <button data-testid="emit-returned-echo" onclick={() => onMessageSent?.(returnedEcho)}>
   emit returned echo
 </button>
+
+<button
+  data-testid="start-composer-reply"
+  onclick={() => composerContext.replyState.startReply('reply-target', 'Reply Target', 'excerpt')}
+>
+  start composer reply
+</button>
+
+<output data-testid="composer-in-reply-to">{inReplyTo ?? ''}</output>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageReplyTarget.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageReplyTarget.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { RoomEventKind } from '$lib/render/eventKinds';
+import type { RoomEventView } from '$lib/render/types';
+import { roomReplyTargetEventId } from './messageReplyTarget';
+
+function messageEvent(id: string, echoOfEventId: string | null = null): RoomEventView {
+  return {
+    id,
+    createdAt: '2026-06-28T12:00:00Z',
+    actorId: 'user-1',
+    actor: null,
+    event: {
+      kind: RoomEventKind.MessagePosted,
+      roomId: 'room-1',
+      body: 'hello',
+      attachments: [],
+      linkPreview: null,
+      reactions: [],
+      updatedAt: null,
+      inReplyTo: null,
+      threadRootEventId: null,
+      echoOfEventId,
+      echoFromThreadRootEventId: echoOfEventId ? 'thread-root' : null,
+      channelEchoEventId: null,
+      replyCount: 0,
+      lastReplyAt: null,
+      threadParticipants: [],
+      viewerIsFollowingThread: false
+    }
+  };
+}
+
+describe('roomReplyTargetEventId', () => {
+  it('uses the visible event id for regular messages', () => {
+    expect(roomReplyTargetEventId(messageEvent('message-1'))).toBe('message-1');
+  });
+
+  it('uses the original reply id for channel echoes', () => {
+    expect(roomReplyTargetEventId(messageEvent('echo-1', 'original-reply-1'))).toBe(
+      'original-reply-1'
+    );
+  });
+});

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageReplyTarget.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageReplyTarget.ts
@@ -1,0 +1,7 @@
+import type { RoomEventView } from '$lib/render/types';
+import { isMessagePostedEvent } from '$lib/render/eventKinds';
+
+export function roomReplyTargetEventId(event: RoomEventView): string {
+  const message = isMessagePostedEvent(event.event) ? event.event : null;
+  return message?.echoOfEventId ?? event.id;
+}

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -3011,6 +3011,8 @@ func TestMessageServicePostMessageValidatesInput(t *testing.T) {
 	ctx := withCaller(env.ctx, env.viewer)
 	root := env.post(room.Id, env.viewer.Id, "root", "")
 	reply := env.post(room.Id, env.viewer.Id, "reply", root.Id)
+	otherRoom := env.createJoinedRoom("message-post-validation-other")
+	otherRoomMessage := env.post(otherRoom.Id, env.viewer.Id, "other room", "")
 
 	tests := []struct {
 		name string
@@ -3051,6 +3053,24 @@ func TestMessageServicePostMessageValidatesInput(t *testing.T) {
 				RoomId:            room.Id,
 				Body:              "reply",
 				ThreadRootEventId: reply.Id,
+			},
+			code: connect.CodeInvalidArgument,
+		},
+		{
+			name: "missing in-reply-to target",
+			req: &apiv1.PostMessageRequest{
+				RoomId:    room.Id,
+				Body:      "reply",
+				InReplyTo: "missing-reply-target",
+			},
+			code: connect.CodeInvalidArgument,
+		},
+		{
+			name: "other room in-reply-to target",
+			req: &apiv1.PostMessageRequest{
+				RoomId:    room.Id,
+				Body:      "reply",
+				InReplyTo: otherRoomMessage.Id,
 			},
 			code: connect.CodeInvalidArgument,
 		},
@@ -3245,6 +3265,8 @@ func TestMessageServicePostMessageValidationPreflightDoesNotCreateAssets(t *test
 
 	root := env.post(room.Id, env.viewer.Id, "root", "")
 	reply := env.post(room.Id, env.viewer.Id, "reply", root.Id)
+	otherRoom := env.createJoinedRoom("upload-validation-other")
+	otherRoomMessage := env.post(otherRoom.Id, env.viewer.Id, "other room", "")
 
 	tests := []struct {
 		name string
@@ -3275,6 +3297,34 @@ func TestMessageServicePostMessageValidationPreflightDoesNotCreateAssets(t *test
 					Filename:    "note.txt",
 					ContentType: "text/plain",
 					Content:     []byte("bad root upload"),
+				}},
+			},
+			code: connect.CodeInvalidArgument,
+		},
+		{
+			name: "missing in-reply-to target",
+			req: &apiv1.PostMessageRequest{
+				RoomId:    room.Id,
+				Body:      "reply with file",
+				InReplyTo: "missing-reply-target",
+				Attachments: []*apiv1.MessageAttachmentUpload{{
+					Filename:    "note.txt",
+					ContentType: "text/plain",
+					Content:     []byte("missing reply upload"),
+				}},
+			},
+			code: connect.CodeInvalidArgument,
+		},
+		{
+			name: "other room in-reply-to target",
+			req: &apiv1.PostMessageRequest{
+				RoomId:    room.Id,
+				Body:      "reply with file",
+				InReplyTo: otherRoomMessage.Id,
+				Attachments: []*apiv1.MessageAttachmentUpload{{
+					Filename:    "note.txt",
+					ContentType: "text/plain",
+					Content:     []byte("other room reply upload"),
 				}},
 			},
 			code: connect.CodeInvalidArgument,

--- a/cli/internal/connectapi/messages.go
+++ b/cli/internal/connectapi/messages.go
@@ -99,6 +99,7 @@ func (s *messageService) uploadPostAttachments(ctx context.Context, actorID stri
 		AttachmentAssetIDs:       attachmentAssetIDs,
 		HasPendingAttachments:    true,
 		ThreadRootEventID:        req.GetThreadRootEventId(),
+		InReplyTo:                req.GetInReplyTo(),
 		AlsoSendToChannel:        req.GetAlsoSendToChannel(),
 		MentionConfirmationToken: req.GetMentionConfirmationToken(),
 		LinkPreview:              apiMessageLinkPreviewToCore(req.GetLinkPreview()),

--- a/cli/internal/core/message_model.go
+++ b/cli/internal/core/message_model.go
@@ -225,6 +225,19 @@ func (s *MessageModel) validatePostBeforeUpload(ctx context.Context, input Messa
 		return err
 	}
 
+	if inReplyTo := strings.TrimSpace(input.InReplyTo); inReplyTo != "" {
+		targetEvent, err := s.core.GetRoomEventByEventID(ctx, authorization.Kind, authorization.Room.Id, inReplyTo)
+		if err != nil {
+			return fmt.Errorf("failed to get in-reply-to message: %w", err)
+		}
+		if targetEvent == nil {
+			return invalidArgument("in_reply_to message not found in room")
+		}
+		if targetEvent.GetMessagePosted() == nil {
+			return invalidArgument("in_reply_to target is not a message event")
+		}
+	}
+
 	if input.ThreadRootEventID == "" {
 		return nil
 	}

--- a/cli/internal/core/messages_test.go
+++ b/cli/internal/core/messages_test.go
@@ -1376,3 +1376,115 @@ func TestChattoCore_ArchiveRoom_BlocksWrites(t *testing.T) {
 		}
 	})
 }
+
+func TestMessageModel_PostMessageValidatesInReplyTo(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	user, err := core.CreateUser(ctx, SystemActorID, "reply-target-user", "Reply Target User", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	room, err := core.CreateRoom(ctx, user.Id, KindChannel, "", "reply-target-room", "")
+	if err != nil {
+		t.Fatalf("CreateRoom room: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom room: %v", err)
+	}
+	otherRoom, err := core.CreateRoom(ctx, user.Id, KindChannel, "", "reply-target-other-room", "")
+	if err != nil {
+		t.Fatalf("CreateRoom otherRoom: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, user.Id, KindChannel, user.Id, otherRoom.Id); err != nil {
+		t.Fatalf("JoinRoom otherRoom: %v", err)
+	}
+
+	root, err := core.Messages().PostMessage(ctx, MessagePostInput{
+		ActorID: user.Id,
+		RoomID:  room.Id,
+		Body:    "root",
+	})
+	if err != nil {
+		t.Fatalf("PostMessage root: %v", err)
+	}
+	threadReply, err := core.Messages().PostMessage(ctx, MessagePostInput{
+		ActorID:           user.Id,
+		RoomID:            room.Id,
+		Body:              "thread reply",
+		ThreadRootEventID: root.Event.Id,
+	})
+	if err != nil {
+		t.Fatalf("PostMessage thread reply: %v", err)
+	}
+	otherRoomMessage, err := core.Messages().PostMessage(ctx, MessagePostInput{
+		ActorID: user.Id,
+		RoomID:  otherRoom.Id,
+		Body:    "other room",
+	})
+	if err != nil {
+		t.Fatalf("PostMessage other room: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		inReplyTo string
+		wantErr   bool
+	}{
+		{
+			name:      "valid room reply",
+			inReplyTo: root.Event.Id,
+		},
+		{
+			name:      "valid thread reply target",
+			inReplyTo: threadReply.Event.Id,
+		},
+		{
+			name:      "missing target",
+			inReplyTo: "missing-reply-target",
+			wantErr:   true,
+		},
+		{
+			name:      "other room target",
+			inReplyTo: otherRoomMessage.Event.Id,
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			beforeID, _, beforeExists, err := core.GetRoomLastEvent(ctx, KindChannel, room.Id)
+			if err != nil {
+				t.Fatalf("GetRoomLastEvent before post: %v", err)
+			}
+			result, err := core.Messages().PostMessage(ctx, MessagePostInput{
+				ActorID:   user.Id,
+				RoomID:    room.Id,
+				Body:      "reply",
+				InReplyTo: tt.inReplyTo,
+			})
+			if tt.wantErr {
+				if !errors.Is(err, ErrInvalidArgument) {
+					t.Fatalf("PostMessage error = %v, want ErrInvalidArgument", err)
+				}
+				afterID, _, afterExists, err := core.GetRoomLastEvent(ctx, KindChannel, room.Id)
+				if err != nil {
+					t.Fatalf("GetRoomLastEvent after rejected post: %v", err)
+				}
+				if afterExists != beforeExists || afterID != beforeID {
+					t.Fatalf("last room event after rejected post = %q/%v, want unchanged %q/%v", afterID, afterExists, beforeID, beforeExists)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("PostMessage: %v", err)
+			}
+			if result == nil || result.Event == nil {
+				t.Fatalf("PostMessage result = %+v, want event", result)
+			}
+			if got := result.Event.GetMessagePosted().GetInReplyTo(); got != tt.inReplyTo {
+				t.Fatalf("InReplyTo = %q, want %q", got, tt.inReplyTo)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Validate `inReplyTo` before public message posts are committed so missing, hidden, or cross-room reply targets cannot create dangling timeline references.

## Details

The root cause was that the bundled client could preserve stale reply state while the backend treated unresolved `inReplyTo` as non-fatal and still persisted it. This adds backend validation before attachment upload, clears room-scoped reply state on room changes, and makes replies to channel echoes target the original reply event. Validation covered targeted Go tests, focused frontend Vitest specs, `svelte-check`, and `git diff --check`.
