### PR TITLE
feat(docs): add release notes pages

### DIFF
--- a/.agents/skills/chatto-release-notes/SKILL.md
+++ b/.agents/skills/chatto-release-notes/SKILL.md
@@ -1,34 +1,334 @@
 ---
 name: "chatto-release-notes"
-description: "Create or update Chatto release notes, including existing GitHub releases, by comparing tags, commits, and PRs"
+description: "Create or update Chatto docs website release pages by comparing release-please state, tags, commits, changelog entries, and PRs"
 ---
 
-Generate or update user-facing release notes for a Chatto release.
+Generate or update user-facing release pages for Chatto minor releases.
 
-## Workflow
+Release notes now live in the docs website, not in local `.context` Markdown
+files or GitHub release bodies. The output is one MDX page per minor release,
+for example:
 
-- Identify the release tag. If the user did not provide one, find the newest git tag and the previous tag.
-- Inspect the existing GitHub release body with `gh release view <tag> --json body,url --jq ...`.
-- Inspect the commits and PRs between the previous tag and the release tag. Use PR bodies when available; they usually explain user impact better than commit titles.
-- Write the updated release notes to `.context/release-<version>.md`, where `<version>` is the release tag.
-- Update the existing GitHub release with `gh release edit <tag> --notes-file .context/release-<version>.md`.
-- Verify the stored release body afterward with `gh release view <tag> --json body --jq .body`. If useful, diff it against the local `.context` file.
+```text
+apps/docs-website/src/content/docs/releases/0-4-0.mdx
+```
 
-## Format
+Use a URL-safe filename with hyphens (`0-4-0`) because Starlight content slugs
+do not preserve dotted version filenames as sidebar slugs. Keep the visible
+title, description, hero, and version text dotted (`0.4.0`).
 
-- Keep any generated changelog that is already present in the release body intact. Add the human-facing release description above it.
-- Start with a short one-paragraph summary of the release.
-- Keep phrasing tight. Avoid explaining why an obvious user-facing improvement is useful when the title and direct description already make it clear.
-- Group noteworthy human-written changes under concise `###` headings that make sense for the release, such as "Highlights", "Sign-in and Setup", "Permissions and Administration", "Calls and Realtime Reliability", or "Chat Polish".
-- Group API changes under a dedicated `## API Changes` section, using plain bullets without bold summaries.
-- Use `## Upgrade Notes ⚠️` when breaking changes or upgrade work affect server operators, admins, or client developers.
-- Use `- **Bold Summary**: explanatory text` only for notable new features and changes.
-- Bug fixes should always be written in the format `- Fixed an issue [description of issue]`, with no bold summary.
-- Keep wording end-user focused. Describe what people can do now, what behaves better, or what operators need to know.
-- Mention breaking changes and upgrade work in a dedicated upgrade section when they affect server operators, admins, or client developers.
-- Do not summarize internal refactoring unless it has direct user, operator, or client-developer impact.
-- Keep it concise and focused. Avoid emojis except the warning marker in `## Upgrade Notes ⚠️`.
+## Audience
 
-## Fallback
+Write only for:
 
-If the user asks for a standalone announcement instead of updating a GitHub release, write the Markdown announcement to `.context/release-<version>.md` and tell the user where it is.
+- Chatto users.
+- Self-hosters, server operators, and admins.
+
+Do not list changes that do not affect either group. Skip routine refactors,
+test work, CI work, codegen churn, internal API rearrangement, and dependency
+maintenance unless they change user-visible behavior or operator action.
+
+API changes belong on these pages only when they affect self-hosters or people
+running integrations against their own Chatto servers. Phrase them as operator
+or integration impact, not as maintainer implementation detail.
+
+Major public API replacements, removed protocols, or required integration
+migrations are headline release-page items. Do not hide them behind generic
+phrases such as "API foundation" or place them after smaller operational
+improvements. Use an explicit title like `ConnectRPC replaces GraphQL`, mark the
+card `size="large"`, and repeat the required operator action in plain
+`## Upgrade Notes` text.
+
+## Target Release
+
+- Use release-please state as the source of truth:
+  - `.release-please-config.json`
+  - `.release-please-manifest.json`
+  - the release-please PR, if present
+- Create or update the page for the immediate next stable minor release being
+  prepared.
+- If release-please is currently configured for prereleases, do not create a
+  prerelease page. Strip the prerelease suffix and target the stable base
+  version instead. Example: `0.4.0-beta.4` targets `0.4.0`.
+- Release pages are per minor release only. Normalize the page version to
+  `x.y.0`.
+- If the stable target release has not shipped yet, clearly mark the page as
+  unreleased. Use `(unreleased)` in the frontmatter title, an unreleased
+  description, and `status="Unreleased"` on `ReleaseHero`. Remove those markers
+  only when the stable release exists.
+- If the computed target is not clear, stop and explain the ambiguity before
+  writing files.
+
+Useful local check:
+
+```sh
+jq -r '.["."]' .release-please-manifest.json
+```
+
+## Existing Page Safety
+
+Before writing, check whether the target page already exists:
+
+```text
+apps/docs-website/src/content/docs/releases/<version-with-hyphens>.mdx
+```
+
+If it exists, assume a human maintainer has edited it manually.
+
+- Do not overwrite or restructure the existing page unless the user explicitly
+  asked for that.
+- Read the existing page and preserve its voice, order, and manual wording.
+- If the user did not explicitly ask you to edit an existing page, write proposed
+  additions or replacements to `.context/release-page-<version>-proposal.md`
+  and tell the user where they are.
+- If the user explicitly asked for an update, make the smallest targeted edits
+  needed and preserve unrelated text.
+
+## Required Components
+
+Release pages should use the dedicated release-note components in:
+
+```text
+apps/docs-website/src/components/release-notes/
+```
+
+Expected components:
+
+- `ReleaseHero.astro` for the page opening.
+- `ReleaseFeatureGrid.astro` to group feature cards.
+- `ReleaseFeatureCard.astro` for one user/operator-facing feature per card.
+  Use `size="large"` for headline features, `size="small"` for compact items,
+  and omit `size` for normal cards. Maintainer-provided images can be attached
+  with `imageSrc`, `imageAlt`, `imageCaption`, and `imagePosition`.
+  Do not add audience labels or subheadings inside cards; cards should show only
+  the feature title and body text unless they include a maintainer-provided
+  image.
+- `ReleaseImage.astro` for standalone maintainer-provided images.
+
+If these components are missing, add them before creating a release page.
+
+`ReleaseFeatureGrid` uses CSS Grid Lanes for the box layout, with a local
+polyfill fallback for browsers that do not support `display: grid-lanes` yet.
+Keep release feature cards as direct children of `ReleaseFeatureGrid` so native
+lanes and the polyfill can place them correctly.
+
+## Research Workflow
+
+### Comparison Scope
+
+Release pages compare the upcoming stable minor release against the highest
+stable patch release of the previous minor line.
+
+- For a `0.4.0` page, compare against the highest stable `0.3.x` tag, such as
+  `v0.3.8`.
+- Do not use the latest prerelease tag, such as `v0.4.0-beta.4`, as the baseline
+  for a stable minor release page.
+- Include all user/operator/integration-facing changes that will land in
+  `0.4.0`, including changes first released in `0.4.0-beta.*`.
+- Ignore prerelease tags when choosing the baseline. Prerelease tags are useful
+  evidence for grouping changelog sections, not the comparison start point.
+- Treat prerelease-only refinements to a new system as part of that system, not
+  as separate release-page features. For example, if a new ConnectRPC API lands
+  during the `0.4.0` prerelease cycle and later prereleases clean up method
+  names, message shapes, or generated docs before the stable release, describe
+  the stable ConnectRPC API once. Mention beta-to-stable migration work only in
+  upgrade notes for people who tested prereleases.
+
+Identify the baseline by listing stable tags for the previous minor:
+
+```sh
+git tag --list 'v0.3.*' --sort=-version:refname | grep -v '-' | head -1
+```
+
+Then inspect changes from that baseline to the current release-preparation
+state:
+
+```sh
+git log --oneline <previous-minor-highest-stable-tag>..HEAD
+git diff --name-only <previous-minor-highest-stable-tag>..HEAD
+```
+
+- Inspect `CHANGELOG.md` for all stable and prerelease sections that roll into
+  the target stable release.
+- Inspect commits and PRs in the comparison range. Use PR bodies when available;
+  they usually explain impact better than commit titles.
+- Build a complete bug-fix inventory from every `Bug Fixes` section in the
+  comparison range, plus any post-prerelease `fix:` commits not yet in
+  `CHANGELOG.md`.
+- Cross-check docs/FDRs/ADRs only when they clarify user behavior or operator
+  implications.
+- Filter aggressively for the release-page audience. Keep a scratch list of
+  skipped internal changes if needed, but do not put it in the visible page.
+- A prerelease-only bug in a feature that was introduced and fixed before the
+  stable release should not be listed as a separate stable-release fix unless it
+  changes the final user/operator behavior. Fold it into the feature wording or
+  omit it.
+
+Useful commands:
+
+```sh
+git tag --list --sort=-version:refname
+gh pr view <number> --json title,body,url
+```
+
+## Page Structure
+
+- Use concise frontmatter:
+
+```mdx
+---
+title: Chatto <version> (unreleased)
+description: Unreleased release notes for Chatto <version>.
+---
+```
+
+For already shipped stable releases, remove `(unreleased)` from the title and
+use `Release notes for Chatto <version>.` as the description.
+
+- Import the release-note components from
+  `../../../components/release-notes/...`.
+- Start with `ReleaseHero`. For unreleased pages, pass `status="Unreleased"`.
+- Decide the page grouping based on the release contents. Do not force a fixed
+  set of sections when the release does not need them.
+- Always list the biggest tentpole changes first, directly after the hero. This
+  first section does not need a heading when the cards themselves make the
+  release shape clear.
+- Add a self-hosters/integrators section only when there are changes that affect
+  server operators, admins, or integration authors. Use `## Running and
+  Integrating Chatto` by default unless a more specific title fits the release
+  better.
+- Use one `ReleaseFeatureCard` per notable feature.
+- Do not put bug fixes in `ReleaseFeatureCard`, even if several fixes share a
+  theme or feel user-visible. Bug fixes belong only in the grouped "Smaller
+  fixes you'll appreciate" section.
+- Do not create a second feature card for refinements, cleanup, renames, or
+  shape changes made to a feature before its first stable release. Fold those
+  details into the main feature card only when they affect the stable behavior,
+  or into `## Upgrade Notes` when they affect prerelease testers.
+- Do not generate screenshots or demo images. If the maintainer already provided
+  an image or explicitly asks you to add one, place it near the card or section
+  it supports with `ReleaseImage` or the image props on `ReleaseFeatureCard`.
+- Add a plain `## Upgrade Notes` section only when server operators, admins, or
+  integration authors need to act or review compatibility. Do not put upgrade
+  notes in a box or card.
+- Add an exhaustive "Smaller fixes you'll appreciate" section for
+  user/operator/integration-impacting bug fixes. Group the fixes by
+  functionality with concise `###` subheadings such as "Messages and Threads",
+  "Notifications and Unread State", "Calls and Media", or "API and Operations".
+  Do not use one ungrouped catch-all list.
+- The fixes section must cover every relevant bug fix in the comparison range.
+  Skip only internal/CI/test fixes and prerelease-only repairs to unreleased
+  behavior; if a fix is skipped for that reason, be ready to explain that in the
+  final response.
+- Keep bug-fix bullets concrete, but vary the phrasing in longer lists so the
+  section reads naturally. Use `Fixed ...`, `Prevented ...`, `Kept ...`, or
+  another direct verb when it is clearer than repeating `Fixed an issue where`.
+- End the page with a `## GitHub release` section that links to the canonical
+  GitHub release URL for the stable version. The URL is always
+  `https://github.com/chattocorp/chatto/releases/tag/v<version>`, for example
+  `https://github.com/chattocorp/chatto/releases/tag/v0.4.0`.
+- Do not duplicate the full release-please changelog on the docs page. The
+  GitHub release is the exhaustive source for PR and commit links.
+- Avoid raw changelog dumps and PR-number lists in the human-written narrative
+  sections.
+- Avoid emojis in visible release pages.
+
+## GitHub Release Link
+
+Every release page must end with `## GitHub release`.
+
+Use this format:
+
+```mdx
+## GitHub release
+
+The generated GitHub release lists every PR and commit:
+[github.com/chattocorp/chatto/releases/tag/v<version>](https://github.com/chattocorp/chatto/releases/tag/v<version>)
+```
+
+For unreleased pages, keep the same link target even if the GitHub release does
+not exist yet. The page is already marked as unreleased, and the URL will become
+valid when the stable release is published.
+
+## Manual Images
+
+Do not create or generate release-page images by default. Use images only when
+the maintainer provides an asset, points you at an existing asset, or explicitly
+asks you to add one.
+
+Store release-specific images under:
+
+```text
+apps/docs-website/public/releases/<version-with-hyphens>/<descriptive-name>.png
+```
+
+For a standalone image, import `ReleaseImage` and reference it as:
+
+```mdx
+<ReleaseImage
+  src="/releases/<version-with-hyphens>/<descriptive-name>.png"
+  alt="..."
+  caption="..."
+/>
+```
+
+For an image attached to a feature card, use:
+
+```mdx
+<ReleaseFeatureCard
+  title="..."
+  imageSrc="/releases/<version-with-hyphens>/<descriptive-name>.png"
+  imageAlt="..."
+  imageCaption="..."
+>
+  ...
+</ReleaseFeatureCard>
+```
+
+- Always provide useful alt text.
+- Keep captions factual and short.
+- Place the image near the feature it supports.
+- The feature must be visible without explanation.
+- Verify the image file renders in the docs page after the docs build.
+
+## Sidebar
+
+New pages usually need a sidebar entry in:
+
+```text
+apps/docs-website/astro.config.mjs
+```
+
+Add a `Releases` sidebar group if none exists. If a group exists, add only the
+new page. Preserve existing order and labels.
+
+## Wording Rules
+
+- Lead with what changes for the user or operator.
+- In visible section headings, speak to the reader directly. Avoid labels such
+  as "users" when the page is addressing them; prefer headings like "Smaller
+  fixes you'll appreciate".
+- Avoid self-referential filler such as "Chatto adds", "Chatto moves", or
+  "Chatto now". The page is already about Chatto. Prefer direct subject-first
+  copy such as "Presence now shows up..." or "The public API has moved...".
+- Use "server" or "Chatto server" for deployments.
+- Use "self-hosters" sparingly; prefer "operators" when the sentence is about
+  operating a running deployment.
+- Mention breaking changes and upgrade work only when they affect server
+  operators, admins, users, or self-hosted integrations.
+- For fixes, use direct, concrete wording. Avoid vague bullets, but do not force
+  every item into the same sentence template.
+- Keep cards independent so maintainers can move, delete, or rewrite one card at
+  a time.
+
+## Verification
+
+- Run the docs build after edits:
+
+```sh
+mise x -- pnpm --filter docs-website build
+```
+
+- If the page or component styling changed materially, open the docs site in the
+  browser and check the release page on desktop and mobile widths.
+- Do not claim full verification if only the build ran.

--- a/apps/docs-website/astro.config.mjs
+++ b/apps/docs-website/astro.config.mjs
@@ -42,6 +42,10 @@ export default defineConfig({
           ],
         },
         {
+          label: "Releases",
+          items: ["releases/0-4-0", "releases/0-3-0", "releases/0-2-0"],
+        },
+        {
           label: "Reference",
           items: [
             {

--- a/apps/docs-website/package.json
+++ b/apps/docs-website/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.40.0",
+    "@fontsource-variable/fraunces": "^5.2.9",
     "@fontsource-variable/ibm-plex-sans": "^5.2.8",
     "astro": "^6.4.7",
     "sharp": "^0.34.5"

--- a/apps/docs-website/src/components/release-notes/ReleaseFeatureCard.astro
+++ b/apps/docs-website/src/components/release-notes/ReleaseFeatureCard.astro
@@ -1,0 +1,145 @@
+---
+interface Props {
+  title: string;
+  size?: "small" | "medium" | "large";
+  imageSrc?: string;
+  imageAlt?: string;
+  imageCaption?: string;
+  imagePosition?: "top" | "bottom";
+}
+
+const {
+  title,
+  size = "medium",
+  imageSrc,
+  imageAlt = "",
+  imageCaption,
+  imagePosition = "top"
+} = Astro.props;
+---
+
+<article class:list={["release-feature-card", `size-${size}`]}>
+  {imageSrc && imagePosition === "top" && (
+    <figure class="release-feature-image">
+      <img src={imageSrc} alt={imageAlt} loading="lazy" decoding="async" />
+      {imageCaption && <figcaption>{imageCaption}</figcaption>}
+    </figure>
+  )}
+  <h2>{title}</h2>
+  <div class="release-feature-body">
+    <slot />
+  </div>
+  {imageSrc && imagePosition === "bottom" && (
+    <figure class="release-feature-image bottom">
+      <img src={imageSrc} alt={imageAlt} loading="lazy" decoding="async" />
+      {imageCaption && <figcaption>{imageCaption}</figcaption>}
+    </figure>
+  )}
+</article>
+
+<style>
+  .release-feature-card {
+    --release-lane-span: 2;
+    grid-column: span 2;
+    display: flex;
+    min-height: 13rem;
+    flex-direction: column;
+    padding: 1.15rem;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.5rem;
+    background: var(--sl-color-gray-7);
+  }
+
+  .release-feature-card.size-small {
+    --release-lane-span: 2;
+    grid-column: span 2;
+    min-height: 9.5rem;
+  }
+
+  .release-feature-card.size-large {
+    --release-lane-span: 4;
+    grid-column: span 4;
+    min-height: 15rem;
+    padding: 1.35rem;
+    background:
+      linear-gradient(135deg, color-mix(in srgb, var(--sl-color-accent-low), transparent 58%), transparent 68%),
+      var(--sl-color-gray-7);
+  }
+
+  .release-feature-card h2 {
+    margin: 0;
+    color: var(--sl-color-white);
+    font-size: 1.35rem;
+    line-height: 1.15;
+  }
+
+  .release-feature-card.size-large h2 {
+    font-size: clamp(1.75rem, 5vw, 2.45rem);
+  }
+
+  .release-feature-body {
+    margin-top: 0.85rem;
+    color: var(--sl-color-gray-2);
+    line-height: 1.55;
+  }
+
+  .release-feature-body :global(:first-child) {
+    margin-top: 0;
+  }
+
+  .release-feature-body :global(:last-child) {
+    margin-bottom: 0;
+  }
+
+  .release-feature-body :global(ul) {
+    padding-inline-start: 1.2rem;
+  }
+
+  .release-feature-body :global(li + li) {
+    margin-top: 0.35rem;
+  }
+
+  .release-feature-image {
+    margin: -0.35rem -0.35rem 1rem;
+  }
+
+  .release-feature-image.bottom {
+    margin: 1rem -0.35rem -0.35rem;
+  }
+
+  .release-feature-image img {
+    display: block;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    object-fit: cover;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.4rem;
+    background: var(--sl-color-gray-6);
+  }
+
+  .release-feature-image figcaption {
+    margin-top: 0.5rem;
+    color: var(--sl-color-gray-3);
+    font-size: 0.85rem;
+    line-height: 1.45;
+  }
+
+  @media (max-width: 42rem) {
+    .release-feature-card,
+    .release-feature-card.size-small,
+    .release-feature-card.size-large {
+      --release-lane-span: 2;
+      grid-column: span 2;
+    }
+  }
+
+  @media (max-width: 36rem) {
+    .release-feature-card,
+    .release-feature-card.size-small,
+    .release-feature-card.size-large {
+      --release-lane-span: 1;
+      grid-column: span 1;
+      min-height: 0;
+    }
+  }
+</style>

--- a/apps/docs-website/src/components/release-notes/ReleaseFeatureGrid.astro
+++ b/apps/docs-website/src/components/release-notes/ReleaseFeatureGrid.astro
@@ -1,0 +1,138 @@
+<section class="release-feature-grid" data-release-feature-grid>
+  <slot />
+</section>
+
+<script>
+  const grids = document.querySelectorAll<HTMLElement>("[data-release-feature-grid]");
+
+  const parseGap = (value: string): number => {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  };
+
+  const itemSpan = (item: HTMLElement, columnCount: number): number => {
+    const raw = Number.parseInt(getComputedStyle(item).getPropertyValue("--release-lane-span"), 10);
+    if (!Number.isFinite(raw) || raw < 1) return 1;
+    return Math.min(raw, columnCount);
+  };
+
+  const layoutGrid = (grid: HTMLElement): void => {
+    const items = Array.from(grid.children).filter(
+      (child): child is HTMLElement => child instanceof HTMLElement
+    );
+    if (items.length === 0) return;
+
+    const styles = getComputedStyle(grid);
+    const gap = parseGap(styles.columnGap || styles.gap);
+    const gridWidth = grid.clientWidth;
+    const columnCount = Number.parseInt(
+      styles.getPropertyValue("--release-lane-count").trim(),
+      10
+    );
+    if (!Number.isFinite(columnCount) || columnCount < 1 || gridWidth <= 0) return;
+
+    grid.classList.add("release-feature-grid-polyfilled");
+
+    const columnWidth = (gridWidth - gap * (columnCount - 1)) / columnCount;
+    const laneHeights = Array.from({ length: columnCount }, () => 0);
+
+    for (const item of items) {
+      const span = itemSpan(item, columnCount);
+      const width = columnWidth * span + gap * (span - 1);
+      item.style.width = `${width}px`;
+      item.style.position = "absolute";
+
+      const maxStart = columnCount - span;
+      let bestStart = 0;
+      let bestTop = Number.POSITIVE_INFINITY;
+
+      for (let start = 0; start <= maxStart; start += 1) {
+        const top = Math.max(...laneHeights.slice(start, start + span));
+        if (top < bestTop) {
+          bestTop = top;
+          bestStart = start;
+        }
+      }
+
+      const left = bestStart * (columnWidth + gap);
+      item.style.transform = `translate(${left}px, ${bestTop}px)`;
+
+      const bottom = bestTop + item.offsetHeight + gap;
+      for (let lane = bestStart; lane < bestStart + span; lane += 1) {
+        laneHeights[lane] = bottom;
+      }
+    }
+
+    grid.style.height = `${Math.max(...laneHeights)}px`;
+  };
+
+  const resetGrid = (grid: HTMLElement): void => {
+    grid.classList.remove("release-feature-grid-polyfilled");
+    grid.style.height = "";
+    for (const item of Array.from(grid.children)) {
+      if (!(item instanceof HTMLElement)) continue;
+      item.style.position = "";
+      item.style.transform = "";
+      item.style.width = "";
+    }
+  };
+
+  const initializeGrid = (grid: HTMLElement): void => {
+    if (CSS.supports("display", "grid-lanes")) {
+      resetGrid(grid);
+      return;
+    }
+
+    let frame = 0;
+    const schedule = () => {
+      window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(() => layoutGrid(grid));
+    };
+
+    schedule();
+
+    const observer = new ResizeObserver(schedule);
+    observer.observe(grid);
+    for (const item of Array.from(grid.children)) {
+      if (item instanceof HTMLElement) observer.observe(item);
+    }
+
+    if (document.fonts) {
+      document.fonts.ready.then(schedule).catch(() => undefined);
+    }
+  };
+
+  for (const grid of grids) {
+    initializeGrid(grid);
+  }
+</script>
+
+<style>
+  .release-feature-grid {
+    --release-lane-count: 4;
+    display: grid;
+    display: grid-lanes;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1rem;
+    margin-block: 1.5rem 2.5rem;
+  }
+
+  .release-feature-grid-polyfilled {
+    display: block;
+    position: relative;
+  }
+
+  @media (max-width: 42rem) {
+    .release-feature-grid {
+      --release-lane-count: 2;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 36rem) {
+    .release-feature-grid {
+      --release-lane-count: 1;
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/apps/docs-website/src/components/release-notes/ReleaseHero.astro
+++ b/apps/docs-website/src/components/release-notes/ReleaseHero.astro
@@ -1,0 +1,129 @@
+---
+interface Props {
+  version: string;
+  status?: string;
+  kicker?: string;
+  title?: string;
+  summary: string;
+}
+
+const { version, status, kicker = "Release notes", title, summary } = Astro.props;
+---
+
+<header class="release-hero">
+  <div>
+    <p class="release-kicker">{kicker}</p>
+    {title && <h2>{title}</h2>}
+    <p class="release-summary">{summary}</p>
+  </div>
+  <div class="release-badges" aria-label="Release status">
+    <span class="release-version">{version}</span>
+    {status && <span class="release-status">{status}</span>}
+  </div>
+</header>
+
+<style>
+  .release-hero {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 1.5rem;
+    align-items: start;
+    padding: 2rem;
+    margin-block: 1rem 2rem;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.5rem;
+    background:
+      linear-gradient(135deg, color-mix(in srgb, var(--sl-color-accent-low), transparent 35%), transparent 65%),
+      var(--sl-color-bg);
+  }
+
+  .release-kicker {
+    margin: 0 0 0.35rem;
+    color: var(--sl-color-accent-high);
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .release-hero h2 {
+    margin: 0;
+    color: var(--sl-color-white);
+    font-size: clamp(1.75rem, 5vw, 2.45rem);
+    line-height: 1.05;
+  }
+
+  .release-summary {
+    max-width: 44rem;
+    margin: 1rem 0 0;
+    color: var(--sl-color-gray-2);
+    font-size: 1.2rem;
+    line-height: 1.55;
+  }
+
+  .release-version {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 5.5rem;
+    padding: 0.45rem 0.75rem;
+    border: 1px solid var(--sl-color-accent);
+    border-radius: 999px;
+    color: var(--sl-color-accent-high);
+    background: var(--sl-color-accent-low);
+    font-size: 0.95rem;
+    font-weight: 700;
+    white-space: nowrap;
+  }
+
+  .release-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    justify-content: flex-end;
+  }
+
+  .release-status {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.45rem 0.75rem;
+    border: 1px solid var(--sl-color-orange);
+    border-radius: 999px;
+    color: var(--sl-color-orange-high);
+    background: var(--sl-color-orange-low);
+    font-size: 0.95rem;
+    font-weight: 700;
+    white-space: nowrap;
+  }
+
+  :root[data-theme="dark"] .release-hero h2 {
+    color: var(--sl-color-gray-1);
+  }
+
+  :root[data-theme="dark"] .release-kicker,
+  :root[data-theme="dark"] .release-version,
+  :root[data-theme="dark"] .release-status {
+    color: var(--sl-color-accent-high);
+  }
+
+  :root[data-theme="dark"] .release-status {
+    color: var(--sl-color-orange-high);
+  }
+
+  @media (max-width: 42rem) {
+    .release-hero {
+      grid-template-columns: 1fr;
+      padding: 1.25rem;
+    }
+
+    .release-badges {
+      justify-content: flex-start;
+    }
+
+    .release-version,
+    .release-status {
+      width: fit-content;
+    }
+  }
+</style>

--- a/apps/docs-website/src/components/release-notes/ReleaseImage.astro
+++ b/apps/docs-website/src/components/release-notes/ReleaseImage.astro
@@ -1,0 +1,41 @@
+---
+interface Props {
+  src: string;
+  alt: string;
+  caption?: string;
+  bleed?: boolean;
+}
+
+const { src, alt, caption, bleed = false } = Astro.props;
+---
+
+<figure class:list={["release-image", { bleed }]}>
+  <img src={src} alt={alt} loading="lazy" decoding="async" />
+  {caption && <figcaption>{caption}</figcaption>}
+</figure>
+
+<style>
+  .release-image {
+    margin-block: 1.5rem 2.25rem;
+  }
+
+  .release-image.bleed {
+    margin-inline: calc(var(--sl-content-pad-x, 1rem) * -1);
+  }
+
+  .release-image img {
+    display: block;
+    width: 100%;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.5rem;
+    background: var(--sl-color-gray-7);
+    box-shadow: var(--sl-shadow-md);
+  }
+
+  .release-image figcaption {
+    margin-top: 0.65rem;
+    color: var(--sl-color-gray-3);
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+</style>

--- a/apps/docs-website/src/content/docs/releases/0-2-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-2-0.mdx
@@ -1,0 +1,75 @@
+---
+title: Chatto 0.2.0
+description: Release notes for Chatto 0.2.0.
+---
+
+import ReleaseFeatureCard from "../../../components/release-notes/ReleaseFeatureCard.astro";
+import ReleaseFeatureGrid from "../../../components/release-notes/ReleaseFeatureGrid.astro";
+import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
+
+<ReleaseHero
+  version="0.2.0"
+  summary="This release covers the full 0.2.0 line since 0.1.0: Markdown previews while composing, notification badge counts, direct-message room sidebars, email-code throttling, and a clearer Docker runtime layout."
+/>
+
+<ReleaseFeatureGrid>
+  <ReleaseFeatureCard title="Markdown previews in the composer" size="large">
+    The composer can preview Markdown while you write, including formatting shortcuts,
+    links, code fences, syntax highlighting, and language selection for code blocks.
+  </ReleaseFeatureCard>
+
+  <ReleaseFeatureCard title="Notification badge counts" size="large">
+    Room rows and the server gutter show notification counts, while unread-message dots
+    remain separate. Badge counts can be loaded without waiting for a websocket event.
+  </ReleaseFeatureCard>
+
+  <ReleaseFeatureCard title="Room sidebar controls in direct messages">
+    Direct-message rooms now expose the room sidebar where it makes sense, including the
+    files panel, while keeping DM moderation actions hidden.
+  </ReleaseFeatureCard>
+</ReleaseFeatureGrid>
+
+## Running and Integrating Chatto
+
+<ReleaseFeatureGrid>
+  <ReleaseFeatureCard title="Email-code throttling is configurable" size="large">
+    Registration and email-verification codes have configurable guardrails for expiration,
+    resend throttling, wrong-code attempts, and disabling throttling for controlled
+    environments. Failed sends roll back their OTP records, so delivery problems do not
+    consume throttle capacity.
+  </ReleaseFeatureCard>
+</ReleaseFeatureGrid>
+
+## Upgrade Notes
+
+- Docker self-hosters should move mounts from the old `/home/chatto` layout to
+  `/config/chatto.toml` and `/data`.
+- Review registration and email-verification OTP throttling settings if your deployment
+  relies on custom signup or verification flows.
+- SMTP providers that require SMTPS on port 465 can use implicit TLS instead of trying to
+  force STARTTLS semantics.
+
+## Smaller fixes you'll appreciate
+
+### Auth, email, and server runtime
+
+- CSRF tokens are stateless and bound to the authenticated cookie-session generation.
+- Server lifecycle logs are less noisy and include clearer shutdown and metrics startup
+  details.
+
+### Rooms, notifications, and calls
+
+- Navigating from a notification into a different server remounts the room route so
+  server-scoped room state is rebuilt correctly.
+- Room and directory state refresh after room creation and room layout changes.
+- Direct-message rows show active call badges consistently.
+
+### Docker and operations
+
+- Docker containers use the documented config and data root paths.
+- Implicit SMTP TLS works for SMTPS providers.
+
+## GitHub release
+
+The GitHub release lists every PR and commit:
+[github.com/chattocorp/chatto/releases/tag/v0.2.0](https://github.com/chattocorp/chatto/releases/tag/v0.2.0)

--- a/apps/docs-website/src/content/docs/releases/0-3-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-3-0.mdx
@@ -1,0 +1,96 @@
+---
+title: Chatto 0.3.0
+description: Release notes for Chatto 0.3.0.
+---
+
+import ReleaseFeatureCard from "../../../components/release-notes/ReleaseFeatureCard.astro";
+import ReleaseFeatureGrid from "../../../components/release-notes/ReleaseFeatureGrid.astro";
+import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
+
+<ReleaseHero
+  version="0.3.0"
+  summary="This release covers the full 0.3.0 line since 0.2.3: room discovery in the sidebar, simpler message composition, attachment permissions, richer message previews, and clearer notification opt-in."
+/>
+
+<ReleaseFeatureGrid>
+  <ReleaseFeatureCard title="Rooms are easier to discover" size="large">
+    The sidebar can show channel rooms you are allowed to see, even before you join them.
+    Non-member rooms are shown as available spaces instead of disappearing, with join and
+    access flows that explain what happens next.
+  </ReleaseFeatureCard>
+
+  <ReleaseFeatureCard title="Simple and rich composer modes" size="large">
+    Enter now sends ordinary plain messages quickly, while rich drafts keep multiline and
+    structured Markdown behavior. The composer switches modes when the draft needs richer
+    formatting, so fast chat and careful editing both feel natural.
+  </ReleaseFeatureCard>
+
+  <ReleaseFeatureCard title="Better member browsing">
+    Room members load lazily, support search, and paginate automatically. Large rooms and
+    mention lookups no longer need to eagerly load every member before the room is usable.
+  </ReleaseFeatureCard>
+
+  <ReleaseFeatureCard title="Richer linked message previews">
+    Links to Chatto messages render as scrollable previews with shared embed styling,
+    image refresh handling, and video thumbnail fallbacks.
+  </ReleaseFeatureCard>
+
+  <ReleaseFeatureCard title="Message links are easier to share" size="small">
+    Message action menus include a copy-link action, so you can point someone directly at
+    the relevant message.
+  </ReleaseFeatureCard>
+
+  <ReleaseFeatureCard title="Clearer Web Push opt-in" size="small">
+    Web Push setup follows the browser and operating-system permission model more closely,
+    with a dismissible prompt and improved settings copy.
+  </ReleaseFeatureCard>
+</ReleaseFeatureGrid>
+
+## Running and Integrating Chatto
+
+<ReleaseFeatureGrid>
+  <ReleaseFeatureCard title="Attachment uploads have their own permission" size="large">
+    File uploads are now gated by the room-scoped `message.attach` permission. The composer
+    hides upload controls when the current member cannot attach files, and servers can grant
+    attachment rights separately from message posting.
+  </ReleaseFeatureCard>
+
+  <ReleaseFeatureCard title="Room visibility is part of the sidebar contract">
+    The frontend sidebar now depends on room-list visibility and membership state instead
+    of only showing joined rooms. Custom GraphQL clients that mirror the bundled sidebar
+    need the new room visibility fields.
+  </ReleaseFeatureCard>
+</ReleaseFeatureGrid>
+
+## Upgrade Notes
+
+- The bundled frontend expects GraphQL room data that includes `Room.viewerIsMember`.
+  Upgrade custom clients or mixed frontend/server deployments that depend on the old
+  sidebar room query shape.
+- Existing deployments may need to grant `message.attach` where uploads should remain
+  available. Fresh/default RBAC state grants it to `everyone`, but existing permission
+  state is not backfilled automatically.
+
+## Smaller fixes you'll appreciate
+
+### Composer and message rendering
+
+- Composer headings preserve literal trailing `#` characters when messages are stored and
+  rendered.
+- Blockquotes have clearer quote rails, softer text, and tighter multi-paragraph spacing.
+
+### Notifications and sidebar
+
+- Room badges route from scoped notifications, so stale room and DM badges clear more
+  reliably.
+- Sidebar item spacing is tighter and better aligned with collapsible group headers.
+
+### Interface polish
+
+- Chat controls use consistent border radii across the current-user bar, add button, and
+  composer shell.
+
+## GitHub release
+
+The GitHub release lists every PR and commit:
+[github.com/chattocorp/chatto/releases/tag/v0.3.0](https://github.com/chattocorp/chatto/releases/tag/v0.3.0)

--- a/apps/docs-website/src/content/docs/releases/0-4-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-4-0.mdx
@@ -1,0 +1,147 @@
+---
+title: Chatto 0.4.0 (unreleased)
+description: Unreleased release notes for Chatto 0.4.0.
+---
+
+import ReleaseFeatureCard from "../../../components/release-notes/ReleaseFeatureCard.astro";
+import ReleaseFeatureGrid from "../../../components/release-notes/ReleaseFeatureGrid.astro";
+import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
+
+<ReleaseHero
+  version="0.4.0"
+  status="Unreleased"
+  summary="This unreleased page covers the full 0.4.0 line since 0.3.8: a GraphQL-to-ConnectRPC API replacement, universal rooms, richer presence controls, custom statuses, and broader interface localization."
+/>
+
+<ReleaseFeatureGrid>
+  <ReleaseFeatureCard title="ConnectRPC replaces GraphQL" size="large">
+    The public API has moved from GraphQL to ConnectRPC. The bundled web app uses the new
+    API for room, message, reaction, direct-message, typing, and realtime flows, and custom
+    clients, bots, and integrations need to move to the generated protobuf/ConnectRPC
+    clients before upgrading production deployments.
+  </ReleaseFeatureCard>
+
+  <ReleaseFeatureCard title="Universal rooms" size="large">
+    Important channels can now be made available to the whole server without asking every
+    member to join manually. The seeded announcements room, hidden leave actions, directory
+    behavior, and sidebar updates make shared rooms feel like part of the server rather
+    than another room membership chore.
+  </ReleaseFeatureCard>
+
+  <ReleaseFeatureCard title="Presence modes and custom statuses">
+    Choose automatic presence, Away, Do Not Disturb, or Look offline, and add a custom
+    status with built-in templates for lunch, vacation, sick leave, or your own text and
+    emoji. Do Not Disturb suppresses notification sounds and push alerts, while Look
+    offline stops presence reports for better privacy.
+  </ReleaseFeatureCard>
+
+  <ReleaseFeatureCard title="A localized interface foundation">
+    The app shell, sidebar, settings, auth, chat, room, composer, calls, admin, media, and
+    shared UI strings now flow through English and German message catalogs. Display
+    settings include a browser-local language preference that updates without a full
+    reload.
+  </ReleaseFeatureCard>
+
+  <ReleaseFeatureCard title="Clearer room and call context" size="small">
+    Room headers show channel descriptions on desktop, room rows show active call
+    participants, and reaction popups show readable reaction names.
+  </ReleaseFeatureCard>
+
+</ReleaseFeatureGrid>
+
+## Running and Integrating Chatto
+
+<ReleaseFeatureGrid>
+  <ReleaseFeatureCard title="A broader public API surface" size="large">
+    ConnectRPC now covers room lifecycle, room directory reads, message management,
+    reactions, direct-message starts, presence reporting, custom statuses, and protobuf
+    realtime delivery. The generated API reference is split into domain pages, and new API
+    stability tiers explain what integration authors can rely on.
+  </ReleaseFeatureCard>
+
+  <ReleaseFeatureCard title="Admin screens for daily operations">
+    The system dashboard has clearer broker, JetStream, stream activity, consumer, and
+    projection sections. Member detail pages expose account status, join date, verified
+    email visibility, copyable user IDs, role count, deletion capability, and username
+    cooldown state. Event log filters make investigations less noisy.
+  </ReleaseFeatureCard>
+
+  <ReleaseFeatureCard title="Deployment-wide Prometheus metrics" size="small">
+    The new `chatto exporter` command and `[exporter]` config expose deployment-wide
+    Prometheus metrics, either standalone or embedded in `chatto run`.
+  </ReleaseFeatureCard>
+
+  <ReleaseFeatureCard title="Storage-backed link previews" size="small">
+    Link preview assets now use the configured storage backend, which makes preview media
+    behave like other persisted uploaded assets when S3-compatible storage is configured.
+  </ReleaseFeatureCard>
+
+  <ReleaseFeatureCard title="SMTP TLS controls" size="small">
+    New SMTP TLS server-name and skip-verify settings handle internal mail servers with
+    self-signed or mismatched certificates without changing existing TLS policy behavior.
+  </ReleaseFeatureCard>
+
+  <ReleaseFeatureCard title="Faster loading paths">
+    The frontend splits chat code from the application shell, and server-side projection
+    startup/replay paths have been tightened. Large or long-running deployments should
+    spend less time on avoidable loading work.
+  </ReleaseFeatureCard>
+</ReleaseFeatureGrid>
+
+## Upgrade Notes
+
+- GraphQL has been replaced by ConnectRPC. Update custom clients, bots, and integrations
+  before upgrading production deployments that depend on the old GraphQL API.
+- The ConnectRPC API shape changed during the 0.4.0 prerelease cycle. If you already
+  tested against a 0.4.0 beta, regenerate clients and review the generated API reference.
+- If you override SMTP security behavior, review the TLS verification configuration for
+  your mail provider.
+- Link preview media is now stored through the configured storage backend. Confirm your
+  backup and object storage policies cover these assets.
+
+## Smaller fixes you'll appreciate
+
+### Messages and threads
+
+- Replies to deleted, hidden, or cross-room targets no longer submit or leave dangling
+  timeline references.
+- Local message deletions now refresh the visible message list reliably.
+- Simple message edits can be submitted with Enter again.
+- Reply attribution previews are easier to read.
+- Stale direct-message member loads no longer appear after switching rooms.
+- Same-tab message links stay in the right context.
+- Thread follow controls no longer show stale bell state.
+- Unread separators wait until you return to a room instead of appearing too early.
+
+### Notifications and unread state
+
+- Dismissing notifications keeps unread badges in sync.
+- Unread channel rows have stronger contrast.
+- Push notification controls stay hidden for remote servers, where native Web Push cannot
+  work from the app origin.
+- Read markers no longer move backwards during concurrent room or thread updates.
+
+### Calls, media, and interface polish
+
+- LiveKit call observation stays scoped to the active call.
+- Muted call participant icons and call control buttons are visually consistent.
+- Scrollbars follow the selected display theme.
+- Asset proxy token handling is more defensive.
+
+### API and operations
+
+- ConnectRPC room commands and directory reads share the same core authorization checks as
+  room behavior.
+- ConnectRPC message posting returns clearer errors, avoids exposing raw backend text, and
+  keeps video attachment processing intact.
+- ConnectRPC caller authentication checks fail closed.
+- ConnectRPC timeline and thread reads reject missing or unsupported anchors with the right
+  error.
+- ConnectRPC requests now have a message-size cap.
+- Generated API docs include the custom user status service.
+- Service inventory metrics cover the full service set.
+
+## GitHub release
+
+The generated GitHub release will list every PR and commit once 0.4.0 is published:
+[github.com/chattocorp/chatto/releases/tag/v0.4.0](https://github.com/chattocorp/chatto/releases/tag/v0.4.0)

--- a/apps/docs-website/src/custom.css
+++ b/apps/docs-website/src/custom.css
@@ -1,8 +1,10 @@
 @import "@fontsource-variable/ibm-plex-sans";
 @import "@fontsource-variable/ibm-plex-sans/wght-italic.css";
+@import "@fontsource-variable/fraunces/index.css";
 
 :root {
   --sl-font: "IBM Plex Sans Variable", sans-serif;
+  --chatto-heading-font: "Fraunces Variable", serif;
   --sl-text-body: 1.1rem;
 
   /* Sky blue accent — matches Chatto frontend (sky-600 light / sky-400 dark) */
@@ -13,6 +15,12 @@
 
 body {
   font-size: var(--sl-text-body);
+}
+
+h1,
+h2 {
+  font-family: var(--chatto-heading-font);
+  font-variation-settings: "SOFT" 50, "WONK" 0, "opsz" 72;
 }
 
 :root[data-theme="dark"] {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@astrojs/starlight':
         specifier: ^0.40.0
         version: 0.40.0(astro@6.4.7(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.0)(yaml@2.9.0))(typescript@5.9.3)
+      '@fontsource-variable/fraunces':
+        specifier: ^5.2.9
+        version: 5.2.9
       '@fontsource-variable/ibm-plex-sans':
         specifier: ^5.2.8
         version: 5.2.8
@@ -628,6 +631,9 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource-variable/fraunces@5.2.9':
+    resolution: {integrity: sha512-Y6IjunlN9Ni723np+GIgAaKzCDBrPRrqNi01TZxHs5wtHYROWFM9W6yiT+/gGwSjWIRD18oX17kD/BRWekc/Lw==}
 
   '@fontsource-variable/ibm-plex-sans@5.2.8':
     resolution: {integrity: sha512-n5PF2iFa0CZT0QYTPzxvZ39opC9LnU0zdoRccoADbs+Dtsd+lbXOZF7RNuIPHcQX1dKjF63sxnRImQIB5eD0Ag==}
@@ -4916,6 +4922,8 @@ snapshots:
       '@floating-ui/utils': 0.2.11
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource-variable/fraunces@5.2.9': {}
 
   '@fontsource-variable/ibm-plex-sans@5.2.8': {}
 


### PR DESCRIPTION
## Summary

Adds docs website release pages for 0.4.0, 0.3.0, and 0.2.0 using new release-note components and a Releases sidebar group. Updates the Chatto release-notes skill so future pages target docs pages, compare the right stable baselines, separate features from fixes, keep upgrade notes plain, and support maintainer-provided images. Refreshes docs typography with Fraunces headings and keeps the release feature card layout on CSS Grid Lanes with a local fallback.

## Validation

- `mise x -- pnpm --filter docs-website build`
- Browser-render checked the release pages locally with Playwright screenshots
