### PR TITLE
fix(attachments): crop extreme image thumbnails

### DIFF
--- a/apps/frontend/src/lib/api/attachments.spec.ts
+++ b/apps/frontend/src/lib/api/attachments.spec.ts
@@ -162,7 +162,7 @@ describe('createAttachmentAPI', () => {
           new RefreshedAttachmentUrls({
             attachmentId: 'att_1',
             assetUrl: assetUrl('/assets/files/att_1?fresh=1'),
-            thumbnailAssetUrl: assetUrl('/assets/files/att_1/image/960x800/contain?fresh=1'),
+            thumbnailAssetUrl: assetUrl('/assets/files/att_1/image/960x800/cover?fresh=1'),
             videoThumbnailAssetUrl: assetUrl('/assets/files/thumb?fresh=1'),
             variants: [
               new RoomTimelineVideoVariant({
@@ -186,14 +186,14 @@ describe('createAttachmentAPI', () => {
     const urls = await api.refreshMessageAttachmentUrls('room_1', 'event_1', {
       width: 960,
       height: 800,
-      fit: FitMode.Contain
+      fit: FitMode.Cover
     });
 
     expect(mocks.refreshMessageAttachmentUrls).toHaveBeenCalledWith(
       {
         roomId: 'room_1',
         eventId: 'event_1',
-        thumbnail: { width: 960, height: 800, fit: AttachmentFitMode.CONTAIN }
+        thumbnail: { width: 960, height: 800, fit: AttachmentFitMode.COVER }
       },
       { headers: undefined }
     );

--- a/apps/frontend/src/lib/api/roomTimeline.spec.ts
+++ b/apps/frontend/src/lib/api/roomTimeline.spec.ts
@@ -241,7 +241,7 @@ describe('roomTimelinePageToEventConnectionPage', () => {
                     expiresAt: Timestamp.fromDate(new Date('2026-06-01T13:00:00Z'))
                   }),
                   thumbnailAssetUrl: new RoomTimelineAssetUrl({
-                    url: '/assets/files/a-video/image/960x800/contain',
+                    url: '/assets/files/a-video/image/960x800/cover',
                     expiresAt: Timestamp.fromDate(new Date('2026-06-01T13:00:00Z'))
                   }),
                   videoProcessing: new RoomTimelineVideoProcessing({

--- a/apps/frontend/src/lib/attachments/attachmentUrls.test.ts
+++ b/apps/frontend/src/lib/attachments/attachmentUrls.test.ts
@@ -69,7 +69,7 @@ describe('refreshAttachmentUrlsForMessage', () => {
     expect(refreshMessageAttachmentUrls).toHaveBeenCalledWith('room_1', 'event_1', {
       width: 960,
       height: 800,
-      fit: FitMode.Contain
+      fit: FitMode.Cover
     });
     expect(urls.get('att_1')?.assetUrl.url).toBe('https://cdn.example.com/fresh-1.jpg');
     expect(urls.get('att_1')?.videoThumbnailAssetUrl?.url).toBe(

--- a/apps/frontend/src/lib/attachments/attachmentUrls.ts
+++ b/apps/frontend/src/lib/attachments/attachmentUrls.ts
@@ -22,7 +22,7 @@ export type AttachmentThumbnailRefreshOptions = {
 export const DEFAULT_ATTACHMENT_THUMBNAIL_REFRESH: AttachmentThumbnailRefreshOptions = {
   width: 960,
   height: 800,
-  fit: FitMode.Contain
+  fit: FitMode.Cover
 };
 
 export const ASSET_URL_REFRESH_LEAD_MS = 2 * 60_000;

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
@@ -124,11 +124,25 @@
   );
 
   const MIN_THUMB_SIZE = 24;
+  const EXTREME_ASPECT_RATIO = 3;
+  const LANDSCAPE_THUMB_MAX_WIDTH = 480;
+  const LANDSCAPE_THUMB_MAX_HEIGHT = 320;
+  const PORTRAIT_THUMB_MAX_WIDTH = 320;
+  const PORTRAIT_THUMB_MAX_HEIGHT = 400;
 
   function thumbSize(w: number, h: number) {
     const isLandscape = w > h;
-    const maxW = isLandscape ? 480 : 320;
-    const maxH = isLandscape ? 320 : 400;
+    const aspectRatio = w / h;
+    const maxW = isLandscape ? LANDSCAPE_THUMB_MAX_WIDTH : PORTRAIT_THUMB_MAX_WIDTH;
+    const maxH = isLandscape ? LANDSCAPE_THUMB_MAX_HEIGHT : PORTRAIT_THUMB_MAX_HEIGHT;
+
+    if (aspectRatio >= EXTREME_ASPECT_RATIO || aspectRatio <= 1 / EXTREME_ASPECT_RATIO) {
+      return {
+        width: maxW,
+        height: maxH
+      };
+    }
+
     const scale = Math.min(maxW / w, maxH / h, 1);
     return {
       width: Math.max(Math.round(w * scale), MIN_THUMB_SIZE),

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import MessageAttachments from './MessageAttachments.svelte';
+import type { MessageAttachmentView } from '$lib/render/types';
+
+vi.mock('$app/navigation', () => ({
+  goto: vi.fn(),
+  pushState: vi.fn(),
+  replaceState: vi.fn()
+}));
+
+vi.mock('$lib/api/attachments', () => ({
+  createAttachmentAPI: vi.fn(() => ({
+    refreshMessageAttachmentUrls: vi.fn().mockResolvedValue(new Map())
+  }))
+}));
+
+vi.mock('$lib/state/server/connection.svelte', () => ({
+  useConnection: () => () => ({
+    serverId: 'server_1',
+    connectBaseUrl: 'https://chat.example.test/api/connect',
+    bearerToken: null
+  })
+}));
+
+const transparentGif = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+
+function imageAttachment(overrides: Partial<MessageAttachmentView>): MessageAttachmentView {
+  return {
+    id: 'att_1',
+    filename: 'image.jpg',
+    contentType: 'image/jpeg',
+    width: 800,
+    height: 600,
+    assetUrl: {
+      url: transparentGif,
+      expiresAt: '2027-05-29T15:00:00Z'
+    },
+    thumbnailAssetUrl: {
+      url: `${transparentGif}#thumb`,
+      expiresAt: '2027-05-29T15:00:00Z'
+    },
+    videoProcessing: null,
+    ...overrides
+  };
+}
+
+function renderAttachment(attachment: MessageAttachmentView) {
+  return render(MessageAttachments, {
+    props: {
+      attachments: [attachment],
+      serverId: 'server_1',
+      roomId: 'room_1',
+      eventId: 'event_1'
+    }
+  });
+}
+
+function imageFrame(container: HTMLElement, filename: string) {
+  const image = container.querySelector<HTMLImageElement>(`img[alt="${filename}"]`);
+  expect(image).not.toBeNull();
+  const button = image?.closest('button');
+  expect(button).not.toBeNull();
+  return { image: image!, button: button! };
+}
+
+describe('MessageAttachments', () => {
+  it('renders extreme portrait images in a cropped portrait thumbnail frame', () => {
+    const { container } = renderAttachment(
+      imageAttachment({
+        filename: 'portrait.jpg',
+        width: 320,
+        height: 1200
+      })
+    );
+
+    const { image, button } = imageFrame(container, 'portrait.jpg');
+
+    expect(button.getAttribute('style')).toContain('width: 320px');
+    expect(button.getAttribute('style')).toContain('aspect-ratio: 320 / 400');
+    expect(image.className).toContain('object-cover');
+    expect(image.className).toContain('h-full');
+    expect(image.className).toContain('w-full');
+  });
+
+  it('renders extreme landscape images in a cropped landscape thumbnail frame', () => {
+    const { container } = renderAttachment(
+      imageAttachment({
+        filename: 'landscape.jpg',
+        width: 1200,
+        height: 320
+      })
+    );
+
+    const { image, button } = imageFrame(container, 'landscape.jpg');
+
+    expect(button.getAttribute('style')).toContain('width: 480px');
+    expect(button.getAttribute('style')).toContain('aspect-ratio: 480 / 320');
+    expect(image.className).toContain('object-cover');
+    expect(image.className).toContain('h-full');
+    expect(image.className).toContain('w-full');
+  });
+
+  it('keeps ordinary images proportionally sized', () => {
+    const { container } = renderAttachment(
+      imageAttachment({
+        filename: 'ordinary.jpg',
+        width: 1600,
+        height: 900
+      })
+    );
+
+    const { image, button } = imageFrame(container, 'ordinary.jpg');
+
+    expect(button.getAttribute('style')).toContain('width: 480px');
+    expect(button.getAttribute('style')).toContain('aspect-ratio: 480 / 270');
+    expect(image.className).toContain('object-cover');
+    expect(image.className).toContain('h-full');
+    expect(image.className).toContain('w-full');
+  });
+});

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -4160,6 +4160,9 @@ func TestRoomTimelineServiceHydratesProcessedVideoAttachments(t *testing.T) {
 	if len(attachments) != 1 {
 		t.Fatalf("attachments = %d, want 1", len(attachments))
 	}
+	if got := attachments[0].GetThumbnailAssetUrl().GetUrl(); !strings.Contains(got, "/960x800/cover") {
+		t.Fatalf("attachment thumbnail URL = %q, want 960x800 cover transform", got)
+	}
 	processing := attachments[0].GetVideoProcessing()
 	if processing == nil {
 		t.Fatal("videoProcessing = nil, want completed manifest")

--- a/cli/internal/connectapi/room_timeline_assembler.go
+++ b/cli/internal/connectapi/room_timeline_assembler.go
@@ -228,7 +228,7 @@ func (h *timelineHydrator) attachments(roomID, messageEventID string, attachment
 			attachment.MessageBodyId = messageEventID
 		}
 		assetURL := h.api.core.GetStableAttachmentAssetURL(attachment.Id, h.viewerID)
-		thumbnailURL := h.api.core.GetStableTransformedAttachmentAssetURL(attachment.Id, h.viewerID, 960, 800, "contain")
+		thumbnailURL := h.api.core.GetStableTransformedAttachmentAssetURL(attachment.Id, h.viewerID, 960, 800, "cover")
 		result = append(result, &apiv1.RoomTimelineAttachment{
 			Id:                attachment.Id,
 			Filename:          attachment.Filename,


### PR DESCRIPTION
Extreme-ratio image attachments now render in fixed crop frames instead of skinny or strip-like previews. Timeline hydration and attachment URL refreshes request `cover` thumbnails so the server thumbnailer generates sharp cropped previews rather than CSS upscaling a contained thumbnail. The full image still opens through the existing image viewer. Validation: Svelte autofixer, focused frontend specs, `mise test-frontend`, and `go test -trimpath -tags test_endpoints ./internal/connectapi -count=1`.
