### PR TITLE
fix(pwa): reduce service worker reload churn

### DIFF
--- a/apps/frontend/e2e/service-worker.test.ts
+++ b/apps/frontend/e2e/service-worker.test.ts
@@ -5,8 +5,7 @@ type CacheSnapshot = {
   cacheNames: string[];
   rootShellCached: boolean;
   fallbackShellCached: boolean;
-  manifestCached: boolean;
-  iconCached: boolean;
+  lazyStaticAssetCached: boolean;
   apiDiscoveryCached: boolean;
   apiConnectCached: boolean;
   uploadedAssetCached: boolean;
@@ -93,11 +92,14 @@ test('service worker caches only the app shell and serves it offline', async ({
   );
   expect(onlineCacheSnapshot.rootShellCached).toBe(true);
   expect(onlineCacheSnapshot.fallbackShellCached).toBe(true);
-  expect(onlineCacheSnapshot.manifestCached).toBe(true);
-  expect(onlineCacheSnapshot.iconCached).toBe(true);
+  expect(onlineCacheSnapshot.lazyStaticAssetCached).toBe(false);
   expect(onlineCacheSnapshot.apiDiscoveryCached).toBe(false);
   expect(onlineCacheSnapshot.apiConnectCached).toBe(false);
   expect(onlineCacheSnapshot.uploadedAssetCached).toBe(false);
+
+  await requestLazyStaticAsset(page);
+  const lazyCacheSnapshot = await cacheSnapshot(page);
+  expect(lazyCacheSnapshot.lazyStaticAssetCached).toBe(true);
 
   await context.setOffline(true);
   try {
@@ -136,13 +138,21 @@ async function cacheSnapshot(page: Page) {
       cacheNames: await caches.keys(),
       rootShellCached: Boolean(await caches.match('/')),
       fallbackShellCached: Boolean(await caches.match('/200.html')),
-      manifestCached: Boolean(await caches.match('/manifest.webmanifest')),
-      iconCached: Boolean(await caches.match('/icons/icon-192.png')),
+      lazyStaticAssetCached: Boolean(await caches.match('/robots.txt')),
       apiDiscoveryCached: Boolean(
         await caches.match('/api/connect/chatto.api.v1.ServerDiscoveryService/GetServer')
       ),
       apiConnectCached: Boolean(await caches.match('/api/connect')),
       uploadedAssetCached: Boolean(await caches.match('/assets/example.png'))
     };
+  });
+}
+
+async function requestLazyStaticAsset(page: Page) {
+  await page.evaluate(async () => {
+    const response = await fetch('/robots.txt');
+    if (!response.ok) {
+      throw new Error(`robots.txt request failed with ${response.status}`);
+    }
   });
 }

--- a/apps/frontend/e2e/service-worker.test.ts
+++ b/apps/frontend/e2e/service-worker.test.ts
@@ -79,7 +79,6 @@ test('service worker caches only the app shell and serves it offline', async ({
   expect(registration.scope).toBe(`${new URL(page.url()).origin}/`);
   expect(registration.scriptURL).toBe(`${new URL(page.url()).origin}/service-worker.js`);
 
-  await page.reload({ waitUntil: 'domcontentloaded' });
   await expect
     .poll(() => page.evaluate(() => Boolean(navigator.serviceWorker.controller)))
     .toBe(true);

--- a/apps/frontend/nginx.conf
+++ b/apps/frontend/nginx.conf
@@ -27,6 +27,16 @@ server {
         try_files $uri =404;
     }
 
+    # Service worker — validate cheaply, but don't force a full refetch churn
+    location = /service-worker.js {
+        add_header Cache-Control "no-cache, must-revalidate" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy-Report-Only $chatto_csp_report_only always;
+        try_files $uri =404;
+    }
+
     # All other static files — no cache
     location / {
         add_header Cache-Control "no-store, no-cache, must-revalidate" always;

--- a/apps/frontend/src/service-worker.ts
+++ b/apps/frontend/src/service-worker.ts
@@ -28,7 +28,7 @@ const CACHE_NAME = `${CACHE_PREFIX}-${version}`;
 const BADGE_STATE_CACHE_NAME = 'chatto-badge-state-v1';
 const BADGE_STATE_URL = `${self.location.origin}/__chatto_badge_state__`;
 const SHELL_ASSETS = new Set([...build, ...files, OFFLINE_SHELL_PATH]);
-const PRECACHE_ASSETS = Array.from(new Set([...build, ...files, OFFLINE_SHELL_PATH, '/']));
+const PRECACHE_ASSETS = [OFFLINE_SHELL_PATH, '/'];
 
 type AppBadgeNavigator = Navigator & {
   setAppBadge?: (contents?: number) => Promise<void>;

--- a/apps/frontend/src/service-worker.ts
+++ b/apps/frontend/src/service-worker.ts
@@ -28,7 +28,7 @@ const CACHE_NAME = `${CACHE_PREFIX}-${version}`;
 const BADGE_STATE_CACHE_NAME = 'chatto-badge-state-v1';
 const BADGE_STATE_URL = `${self.location.origin}/__chatto_badge_state__`;
 const SHELL_ASSETS = new Set([...build, ...files, OFFLINE_SHELL_PATH]);
-const PRECACHE_ASSETS = [OFFLINE_SHELL_PATH, '/'];
+const PRECACHE_ASSETS = Array.from(new Set([...build, OFFLINE_SHELL_PATH, '/']));
 
 type AppBadgeNavigator = Navigator & {
   setAppBadge?: (contents?: number) => Promise<void>;

--- a/cli/internal/http_server/frontend.go
+++ b/cli/internal/http_server/frontend.go
@@ -2,7 +2,9 @@ package http_server
 
 import (
 	"context"
+	"crypto/sha256"
 	"embed"
+	"fmt"
 	"io/fs"
 	"mime"
 	"net/http"
@@ -22,6 +24,8 @@ var embeddedWebUIFS embed.FS
 const (
 	// HTML files must never be cached to ensure users get the latest version
 	cacheControlNoCache = "no-store, no-cache, must-revalidate"
+	// Service worker bytes should be revalidated without forcing a full refetch
+	cacheControlRevalidate = "no-cache, must-revalidate"
 	// Hashed assets (in _app/) are immutable - cache for 1 year
 	cacheControlImmutable = "public, max-age=31536000, immutable"
 	// Report-only CSP preserves Chatto's multi-server client model while surfacing
@@ -57,6 +61,58 @@ func extractImmutableETag(urlPath string) string {
 	}
 	// Pattern 2: the entire name is the hash
 	return name
+}
+
+func serviceWorkerETag(content []byte) string {
+	sum := sha256.Sum256(content)
+	return fmt.Sprintf(`W/"%x"`, sum)
+}
+
+func etagMatches(ifNoneMatch string, etag string) bool {
+	for _, part := range strings.Split(ifNoneMatch, ",") {
+		if strings.TrimSpace(part) == etag {
+			return true
+		}
+	}
+	return false
+}
+
+func setServiceWorkerETag(c *gin.Context, content []byte) bool {
+	etag := serviceWorkerETag(content)
+	c.Header("ETag", etag)
+	if etagMatches(c.GetHeader("If-None-Match"), etag) {
+		c.Status(http.StatusNotModified)
+		return true
+	}
+	return false
+}
+
+func setFrontendCacheHeaders(c *gin.Context) {
+	urlPath := c.Request.URL.Path
+	if strings.HasPrefix(urlPath, "/_app/immutable/") {
+		c.Header("Cache-Control", cacheControlImmutable)
+
+		// Extract ETag from the content-hashed filename
+		if etag := extractImmutableETag(urlPath); etag != "" {
+			quotedETag := `"` + etag + `"`
+			c.Header("ETag", quotedETag)
+
+			// Check If-None-Match for conditional requests
+			if match := c.GetHeader("If-None-Match"); match != "" {
+				// Handle both quoted and unquoted ETags, and weak ETags (W/"...")
+				if match == quotedETag || match == etag || match == `W/`+quotedETag {
+					c.AbortWithStatus(http.StatusNotModified)
+					return
+				}
+			}
+		}
+	} else if urlPath == "/service-worker.js" {
+		c.Header("Cache-Control", cacheControlRevalidate)
+	} else {
+		// For HTML and other non-hashed files, prevent caching
+		c.Header("Cache-Control", cacheControlNoCache)
+	}
+	c.Next()
 }
 
 // clientAcceptsEncoding checks if the client accepts a specific encoding.
@@ -171,31 +227,7 @@ func (s *HTTPServer) setupFrontendRoutes() error {
 	// SvelteKit puts all hashed/immutable assets under /_app/immutable/
 	// Other files under /_app/ (like version.json, env.js) are NOT content-hashed
 	// and must not be cached immutably.
-	s.router.Use(func(c *gin.Context) {
-		urlPath := c.Request.URL.Path
-		if strings.HasPrefix(urlPath, "/_app/immutable/") {
-			c.Header("Cache-Control", cacheControlImmutable)
-
-			// Extract ETag from the content-hashed filename
-			if etag := extractImmutableETag(urlPath); etag != "" {
-				quotedETag := `"` + etag + `"`
-				c.Header("ETag", quotedETag)
-
-				// Check If-None-Match for conditional requests
-				if match := c.GetHeader("If-None-Match"); match != "" {
-					// Handle both quoted and unquoted ETags, and weak ETags (W/"...")
-					if match == quotedETag || match == etag || match == `W/`+quotedETag {
-						c.AbortWithStatus(http.StatusNotModified)
-						return
-					}
-				}
-			}
-		} else {
-			// For HTML and other non-hashed files, prevent caching
-			c.Header("Cache-Control", cacheControlNoCache)
-		}
-		c.Next()
-	})
+	s.router.Use(setFrontendCacheHeaders)
 
 	// refreshSessionIfAuthenticated validates and rotates authenticated
 	// cookie-session records for active SPA browsing. KV TTL is set only when
@@ -231,6 +263,17 @@ func (s *HTTPServer) setupFrontendRoutes() error {
 		if filePath == "200.html" {
 			s.serveSPAFallback(c, clientFS)
 			return
+		}
+
+		if filePath == "service-worker.js" {
+			content, err := fs.ReadFile(clientFS, filePath)
+			if err != nil {
+				c.Status(http.StatusInternalServerError)
+				return
+			}
+			if setServiceWorkerETag(c, content) {
+				return
+			}
 		}
 
 		// Try to serve precompressed version first

--- a/cli/internal/http_server/frontend_test.go
+++ b/cli/internal/http_server/frontend_test.go
@@ -66,28 +66,7 @@ func TestImmutableAssetCaching(t *testing.T) {
 	// Create a minimal test router that simulates our caching middleware
 	router := gin.New()
 
-	// Add the caching middleware (same logic as in setupFrontendRoutes)
-	router.Use(func(c *gin.Context) {
-		urlPath := c.Request.URL.Path
-		if len(urlPath) > len("/_app/immutable/") && urlPath[:len("/_app/immutable/")] == "/_app/immutable/" {
-			c.Header("Cache-Control", cacheControlImmutable)
-
-			if etag := extractImmutableETag(urlPath); etag != "" {
-				quotedETag := `"` + etag + `"`
-				c.Header("ETag", quotedETag)
-
-				if match := c.GetHeader("If-None-Match"); match != "" {
-					if match == quotedETag || match == etag || match == `W/`+quotedETag {
-						c.AbortWithStatus(http.StatusNotModified)
-						return
-					}
-				}
-			}
-		} else {
-			c.Header("Cache-Control", cacheControlNoCache)
-		}
-		c.Next()
-	})
+	router.Use(setFrontendCacheHeaders)
 
 	// Add a simple handler that returns content
 	router.GET("/*path", func(c *gin.Context) {
@@ -151,6 +130,55 @@ func TestImmutableAssetCaching(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Equal(t, cacheControlNoCache, w.Header().Get("Cache-Control"))
 		assert.Empty(t, w.Header().Get("ETag"))
+	})
+
+	t.Run("service worker returns revalidate cache policy", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/service-worker.js", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, cacheControlRevalidate, w.Header().Get("Cache-Control"))
+		assert.Empty(t, w.Header().Get("ETag"))
+	})
+}
+
+func TestServiceWorkerETag(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	content := []byte("self.addEventListener('fetch', () => {});")
+	etag := serviceWorkerETag(content)
+
+	router := gin.New()
+	router.Use(setFrontendCacheHeaders)
+	router.GET("/service-worker.js", func(c *gin.Context) {
+		if setServiceWorkerETag(c, content) {
+			return
+		}
+		c.Data(http.StatusOK, "application/javascript", content)
+	})
+
+	t.Run("returns etag", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/service-worker.js", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, cacheControlRevalidate, w.Header().Get("Cache-Control"))
+		assert.Equal(t, etag, w.Header().Get("ETag"))
+		assert.Equal(t, string(content), w.Body.String())
+	})
+
+	t.Run("matching if none match returns 304", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/service-worker.js", nil)
+		req.Header.Set("If-None-Match", etag)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotModified, w.Code)
+		assert.Equal(t, cacheControlRevalidate, w.Header().Get("Cache-Control"))
+		assert.Equal(t, etag, w.Header().Get("ETag"))
+		assert.Empty(t, w.Body.String())
 	})
 }
 

--- a/docs/fdr/FDR-027-pwa-shell-and-service-worker.md
+++ b/docs/fdr/FDR-027-pwa-shell-and-service-worker.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-Chatto ships a service worker so the installed web app can launch reliably, handle push notifications, and proxy private asset loads through non-portable same-origin URLs. The worker caches the versioned frontend shell and static PWA assets. It deliberately does not cache chat data, API responses, or live-event traffic. It may cache uploaded asset bytes privately after the user has already loaded them, because those bytes are immutable content the browser has already received.
+Chatto ships a service worker so the installed web app can launch reliably, handle push notifications, and proxy private asset loads through non-portable same-origin URLs. The worker caches the SPA fallback shell during install and caches versioned frontend shell/static assets when the browser actually requests them. It deliberately does not cache chat data, API responses, or live-event traffic. It may cache uploaded asset bytes privately after the user has already loaded them, because those bytes are immutable content the browser has already received.
 
 Offline support means the app can open and show its normal disconnected state instead of the browser's generic offline page. It does not mean offline message history, offline search, or an outbox for composing messages while disconnected.
 
@@ -14,9 +14,9 @@ Reconnect catch-up is owned by the foreground web app, not the service worker. W
 ## Behavior
 
 - The service worker is registered by SvelteKit in production builds.
-- On install, the worker caches SvelteKit build assets, static PWA assets, and the SPA fallback shell.
+- On install, the worker caches only the minimal SPA fallback shell.
 - On activate, old Chatto shell caches are deleted and the new worker claims open clients.
-- Known shell assets are served cache-first from the versioned cache.
+- Known shell assets are served cache-first from the versioned cache and cached lazily on first request.
 - Same-origin navigations are network-first, falling back to the cached SPA shell only when the network fails.
 - API, auth, webhook, non-GET, and cross-origin requests are network-only.
 - Same-origin virtual asset requests under `/__chatto/assets/{serverId}/...` are resolved by the worker to the registered server's hidden ticketed asset URL. The worker does not receive registered-server API bearer tokens, asks Chatto to stream originals instead of redirecting to S3 for cacheable full responses, and keeps media `Range` requests network-only.
@@ -29,14 +29,14 @@ Reconnect catch-up is owned by the foreground web app, not the service worker. W
 
 ### 1. Shell-only caching
 
-**Decision:** Cache only the app shell and static PWA assets.
+**Decision:** Cache only the app shell and static PWA assets, and cache build/static assets lazily after install.
 **Why:** Chatto is a real-time chat app. Serving stale messages, permissions, assets, or notification state as if they were live would be worse than showing the disconnected state.
-**Tradeoff:** Offline launches do not show recent rooms or messages unless the live app already has that state in memory. This keeps the data model honest.
+**Tradeoff:** Offline launches do not show recent rooms or messages unless the live app already has that state in memory, and full shell asset coverage accumulates as the app requests assets. This keeps the data model honest and keeps service-worker updates cheap.
 
 ### 2. Versioned cache names
 
 **Decision:** Shell caches include the SvelteKit app version in their name.
-**Why:** A deploy can replace hashed JavaScript and CSS chunks. Versioned cache names let the new worker populate the new shell and delete older shell caches during activation.
+**Why:** A deploy can replace hashed JavaScript and CSS chunks. Versioned cache names let the new worker populate a fresh shell cache and delete older shell caches during activation.
 **Tradeoff:** A user briefly stores two shell versions during update. The cached asset set is small, so this is acceptable.
 
 ### 3. SvelteKit owns registration

--- a/docs/fdr/FDR-027-pwa-shell-and-service-worker.md
+++ b/docs/fdr/FDR-027-pwa-shell-and-service-worker.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-Chatto ships a service worker so the installed web app can launch reliably, handle push notifications, and proxy private asset loads through non-portable same-origin URLs. The worker caches the SPA fallback shell during install and caches versioned frontend shell/static assets when the browser actually requests them. It deliberately does not cache chat data, API responses, or live-event traffic. It may cache uploaded asset bytes privately after the user has already loaded them, because those bytes are immutable content the browser has already received.
+Chatto ships a service worker so the installed web app can launch reliably, handle push notifications, and proxy private asset loads through non-portable same-origin URLs. The worker caches the SPA fallback shell and SvelteKit build assets during install, then caches static PWA assets when the browser actually requests them. It deliberately does not cache chat data, API responses, or live-event traffic. It may cache uploaded asset bytes privately after the user has already loaded them, because those bytes are immutable content the browser has already received.
 
 Offline support means the app can open and show its normal disconnected state instead of the browser's generic offline page. It does not mean offline message history, offline search, or an outbox for composing messages while disconnected.
 
@@ -14,9 +14,9 @@ Reconnect catch-up is owned by the foreground web app, not the service worker. W
 ## Behavior
 
 - The service worker is registered by SvelteKit in production builds.
-- On install, the worker caches only the minimal SPA fallback shell.
+- On install, the worker caches the SPA fallback shell and SvelteKit build assets required to boot it.
 - On activate, old Chatto shell caches are deleted and the new worker claims open clients.
-- Known shell assets are served cache-first from the versioned cache and cached lazily on first request.
+- Known shell assets are served cache-first from the versioned cache; static PWA assets are cached lazily on first request.
 - Same-origin navigations are network-first, falling back to the cached SPA shell only when the network fails.
 - API, auth, webhook, non-GET, and cross-origin requests are network-only.
 - Same-origin virtual asset requests under `/__chatto/assets/{serverId}/...` are resolved by the worker to the registered server's hidden ticketed asset URL. The worker does not receive registered-server API bearer tokens, asks Chatto to stream originals instead of redirecting to S3 for cacheable full responses, and keeps media `Range` requests network-only.
@@ -29,9 +29,9 @@ Reconnect catch-up is owned by the foreground web app, not the service worker. W
 
 ### 1. Shell-only caching
 
-**Decision:** Cache only the app shell and static PWA assets, and cache build/static assets lazily after install.
+**Decision:** Cache only the app shell and static PWA assets. Build assets required to boot the shell are cached during install, while static PWA assets are cached lazily after install.
 **Why:** Chatto is a real-time chat app. Serving stale messages, permissions, assets, or notification state as if they were live would be worse than showing the disconnected state.
-**Tradeoff:** Offline launches do not show recent rooms or messages unless the live app already has that state in memory, and full shell asset coverage accumulates as the app requests assets. This keeps the data model honest and keeps service-worker updates cheap.
+**Tradeoff:** Offline launches do not show recent rooms or messages unless the live app already has that state in memory, and full static asset coverage accumulates as the app requests assets. This keeps the data model honest while avoiding install-time requests for icons, manifests, and unrelated static files.
 
 ### 2. Versioned cache names
 


### PR DESCRIPTION
## Summary
- switch the PWA service worker install step to cache only the minimal SPA fallback shell instead of every build/static asset
- add cheap `/service-worker.js` revalidation headers for both nginx and embedded Go serving
- update service-worker e2e coverage, Go header/ETag tests, and FDR-027 for lazy shell asset caching

## Validation
- `mise x -- pnpm exec playwright test e2e/service-worker.test.ts --retries=0`
- `mise x -- go test ./internal/http_server -run 'Test(ImmutableAssetCaching|ServiceWorkerETag)$' -count=1 -v`
- `mise x -- go test ./internal/http_server -count=1`
- `git diff --check origin/main...`
