### PR TITLE
refactor(api): parallelize ConnectRPC read hydration

### DIFF
--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -29,6 +29,13 @@ authorization, live events, backup/restore, and backend tests.
   protocol.
 - Keep ConnectRPC transport thin: authenticate, decode, map errors/responses,
   and delegate policy/domain work to shared services.
+- Keep projected read hydration out of ConnectRPC handlers. Put per-response
+  batching, bounded concurrency, include-map construction, and protobuf response
+  assembly in small `*_assembler.go` helpers near the service that owns the
+  response shape.
+- Do not create a generic ConnectRPC loader package until multiple assemblers
+  share the same non-trivial loading semantics. Prefer concrete assemblers plus
+  small generic mechanics such as `internal/parallel`.
 - Put operation-specific authorization in the core operation model for that
   behavior. Low-level `ChattoCore` helpers are not public transport entry
   points and may assume their caller already performed the appropriate gate.

--- a/cli/internal/connectapi/api.go
+++ b/cli/internal/connectapi/api.go
@@ -18,6 +18,8 @@ const Prefix = "/api/connect"
 // defaults to unlimited reads, so keep this explicit for every public handler.
 const MaxRequestMessageBytes = 1 << 20 // 1 MiB
 
+const maxConnectAPIHydrationConcurrency = 16
+
 // AuthPolicy describes whether the HTTP edge should require authentication
 // before forwarding a request to a generated Connect handler.
 type AuthPolicy string

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -4239,7 +4239,7 @@ func TestRoomTimelineHydratorRejectsUnsupportedEvents(t *testing.T) {
 		userIDs:  make(map[string]struct{}),
 	}
 
-	_, err := h.event(&core.RoomEvent{Event: &corev1.Event{
+	_, err := h.event(env.ctx, &core.RoomEvent{Event: &corev1.Event{
 		Id:      "Eunsupported",
 		ActorId: env.viewer.Id,
 		Event: &corev1.Event_RoomUniversalChanged{
@@ -4349,7 +4349,7 @@ func TestRoomTimelineHydratorSupportsVisibleCoreEvents(t *testing.T) {
 			if !core.IsVisibleRoomTimelineEntry(tt.event) {
 				t.Fatalf("test event is not visible according to core")
 			}
-			if _, err := h.event(&core.RoomEvent{Event: tt.event}); err != nil {
+			if _, err := h.event(env.ctx, &core.RoomEvent{Event: tt.event}); err != nil {
 				t.Fatalf("hydrate visible event: %v", err)
 			}
 		})

--- a/cli/internal/connectapi/messages.go
+++ b/cli/internal/connectapi/messages.go
@@ -246,7 +246,7 @@ func (s *messageService) hydratePostedEvent(ctx context.Context, viewerID string
 		reactionsByMessageID: reactionsByMessageID,
 		userIDs:              make(map[string]struct{}),
 	}
-	apiEvent, err := h.event(&core.RoomEvent{Event: event})
+	apiEvent, err := h.event(ctx, &core.RoomEvent{Event: event})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cli/internal/connectapi/notification_assembler.go
+++ b/cli/internal/connectapi/notification_assembler.go
@@ -1,0 +1,172 @@
+package connectapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"hmans.de/chatto/internal/core"
+	"hmans.de/chatto/internal/parallel"
+	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+type notificationAssembler struct {
+	api *API
+}
+
+func newNotificationAssembler(api *API) *notificationAssembler {
+	return &notificationAssembler{api: api}
+}
+
+func (a *notificationAssembler) pageFromList(ctx context.Context, notifications []*corev1.Notification, pageRequest *apiv1.PageRequest) (*apiv1.ListNotificationsResponse, error) {
+	limitVal, offsetVal := apiPagination(pageRequest, defaultNotificationLimit, maxNotificationLimit)
+	page, totalCount, hasMore := paginateNotifications(notifications, limitVal, offsetVal)
+	mapped, err := parallel.Map(ctx, maxConnectAPIHydrationConcurrency, page, func(ctx context.Context, _ int, notification *corev1.Notification) (*apiv1.NotificationItem, error) {
+		return a.item(ctx, notification)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]*apiv1.NotificationItem, 0, len(mapped))
+	for _, item := range mapped {
+		if item != nil {
+			items = append(items, item)
+		}
+	}
+
+	response := a.emptyPage(ctx)
+	response.Items = items
+	response.Page = apiPageInfo(totalCount, hasMore)
+	return response, nil
+}
+
+func (a *notificationAssembler) emptyPage(ctx context.Context) *apiv1.ListNotificationsResponse {
+	name := "Chatto"
+	if cm := a.api.core.ConfigManager(); cm != nil {
+		if configuredName, err := cm.GetEffectiveServerName(ctx); err == nil && configuredName != "" {
+			name = configuredName
+		}
+	}
+	return &apiv1.ListNotificationsResponse{
+		Items:      []*apiv1.NotificationItem{},
+		ServerName: name,
+	}
+}
+
+func (a *notificationAssembler) item(ctx context.Context, notification *corev1.Notification) (*apiv1.NotificationItem, error) {
+	if notification == nil {
+		return nil, nil
+	}
+
+	actor, err := a.actor(ctx, notification.GetActorId())
+	if err != nil {
+		return nil, err
+	}
+	item := &apiv1.NotificationItem{
+		Id:        notification.GetId(),
+		CreatedAt: notification.GetCreatedAt(),
+		Actor:     actor,
+		Summary:   notificationSummary(actor, notification),
+	}
+
+	switch payload := notification.GetNotification().(type) {
+	case *corev1.Notification_DmMessage:
+		item.Kind = &apiv1.NotificationItem_DirectMessage{
+			DirectMessage: &apiv1.DirectMessageNotification{
+				RoomId:  payload.DmMessage.GetRoomId(),
+				EventId: payload.DmMessage.GetEventId(),
+			},
+		}
+	case *corev1.Notification_Mention:
+		room, err := a.room(ctx, payload.Mention.GetRoomId())
+		if err != nil {
+			return nil, err
+		}
+		mention := &apiv1.MentionNotification{
+			Room:    room,
+			EventId: payload.Mention.GetEventId(),
+		}
+		if threadID := payload.Mention.GetInThread(); threadID != "" {
+			mention.ThreadRootEventId = &threadID
+		}
+		item.Kind = &apiv1.NotificationItem_Mention{Mention: mention}
+	case *corev1.Notification_Reply:
+		room, err := a.room(ctx, payload.Reply.GetRoomId())
+		if err != nil {
+			return nil, err
+		}
+		reply := &apiv1.ReplyNotification{
+			Room:        room,
+			EventId:     payload.Reply.GetEventId(),
+			InReplyToId: payload.Reply.GetInReplyToId(),
+		}
+		if threadID := payload.Reply.GetInThread(); threadID != "" {
+			reply.ThreadRootEventId = &threadID
+		}
+		item.Kind = &apiv1.NotificationItem_Reply{Reply: reply}
+	case *corev1.Notification_RoomMessage:
+		room, err := a.room(ctx, payload.RoomMessage.GetRoomId())
+		if err != nil {
+			return nil, err
+		}
+		item.Kind = &apiv1.NotificationItem_RoomMessage{
+			RoomMessage: &apiv1.RoomMessageNotification{
+				Room:    room,
+				EventId: payload.RoomMessage.GetEventId(),
+			},
+		}
+	default:
+		return nil, fmt.Errorf("unknown notification type %T", notification.GetNotification())
+	}
+
+	return item, nil
+}
+
+func (a *notificationAssembler) actor(ctx context.Context, userID string) (*apiv1.UserProfile, error) {
+	if userID == "" {
+		return nil, nil
+	}
+	user, err := a.api.core.GetUser(ctx, userID)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	presence, err := a.api.core.GetUserPresence(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	actor := &apiv1.UserProfile{
+		User: &apiv1.User{
+			Id:          user.GetId(),
+			Login:       user.GetLogin(),
+			DisplayName: user.GetDisplayName(),
+			Deleted:     user.GetDeleted(),
+		},
+		PresenceStatus: corePresenceStatusToAPI(presence),
+		CustomStatus:   coreCustomStatusToAPI(user.GetCustomStatus()),
+	}
+	if avatarURL, err := a.api.core.GetUserAvatarURL(ctx, userID, nil, nil, ""); err != nil {
+		return nil, err
+	} else if avatarURL != "" {
+		actor.User.AvatarUrl = stringPtr(a.api.absolutizeAssetURL(ctx, avatarURL))
+	}
+	return actor, nil
+}
+
+func (a *notificationAssembler) room(ctx context.Context, roomID string) (*apiv1.NotificationRoom, error) {
+	if roomID == "" {
+		return nil, nil
+	}
+	room, err := a.api.core.FindRoomByID(ctx, roomID)
+	if err != nil {
+		return nil, err
+	}
+	return &apiv1.NotificationRoom{
+		Id:   room.GetId(),
+		Name: room.GetName(),
+	}, nil
+}

--- a/cli/internal/connectapi/notification_assembler.go
+++ b/cli/internal/connectapi/notification_assembler.go
@@ -22,18 +22,11 @@ func newNotificationAssembler(api *API) *notificationAssembler {
 func (a *notificationAssembler) pageFromList(ctx context.Context, notifications []*corev1.Notification, pageRequest *apiv1.PageRequest) (*apiv1.ListNotificationsResponse, error) {
 	limitVal, offsetVal := apiPagination(pageRequest, defaultNotificationLimit, maxNotificationLimit)
 	page, totalCount, hasMore := paginateNotifications(notifications, limitVal, offsetVal)
-	mapped, err := parallel.Map(ctx, maxConnectAPIHydrationConcurrency, page, func(ctx context.Context, _ int, notification *corev1.Notification) (*apiv1.NotificationItem, error) {
+	items, err := parallel.MapNonNil(ctx, maxConnectAPIHydrationConcurrency, page, func(ctx context.Context, _ int, notification *corev1.Notification) (*apiv1.NotificationItem, error) {
 		return a.item(ctx, notification)
 	})
 	if err != nil {
 		return nil, err
-	}
-
-	items := make([]*apiv1.NotificationItem, 0, len(mapped))
-	for _, item := range mapped {
-		if item != nil {
-			items = append(items, item)
-		}
 	}
 
 	response := a.emptyPage(ctx)

--- a/cli/internal/connectapi/notifications.go
+++ b/cli/internal/connectapi/notifications.go
@@ -2,11 +2,9 @@ package connectapi
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"connectrpc.com/connect"
-	"hmans.de/chatto/internal/core"
 	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
@@ -37,14 +35,14 @@ func (s *notificationService) ListRoomNotifications(ctx context.Context, req *co
 	if err != nil {
 		return nil, connectError(err)
 	}
-	page, err := s.notificationPageFromList(ctx, notifications, req.Msg.GetPage())
+	page, err := newNotificationAssembler(s.api).pageFromList(ctx, notifications, req.Msg.GetPage())
 	if err != nil {
-		return nil, err
+		return nil, connectError(err)
 	}
 	return connect.NewResponse(&apiv1.ListRoomNotificationsResponse{
-		Items:      page.Msg.GetItems(),
-		ServerName: page.Msg.GetServerName(),
-		Page:       page.Msg.GetPage(),
+		Items:      page.GetItems(),
+		ServerName: page.GetServerName(),
+		Page:       page.GetPage(),
 	}), nil
 }
 
@@ -130,156 +128,11 @@ func (s *notificationService) notificationPage(ctx context.Context, userID strin
 		}
 	}
 
-	return s.notificationPageFromList(ctx, filtered, pageRequest)
-}
-
-func (s *notificationService) notificationPageFromList(ctx context.Context, notifications []*corev1.Notification, pageRequest *apiv1.PageRequest) (*connect.Response[apiv1.ListNotificationsResponse], error) {
-	limitVal, offsetVal := apiPagination(pageRequest, defaultNotificationLimit, maxNotificationLimit)
-	page, totalCount, hasMore := paginateNotifications(notifications, limitVal, offsetVal)
-	items := make([]*apiv1.NotificationItem, 0, len(page))
-	for _, notification := range page {
-		item, err := s.apiNotificationItem(ctx, notification)
-		if err != nil {
-			return nil, err
-		}
-		if item != nil {
-			items = append(items, item)
-		}
-	}
-
-	response := s.emptyPage(ctx)
-	response.Items = items
-	response.Page = apiPageInfo(totalCount, hasMore)
-	return connect.NewResponse(response), nil
-}
-
-func (s *notificationService) emptyPage(ctx context.Context) *apiv1.ListNotificationsResponse {
-	name := "Chatto"
-	if cm := s.api.core.ConfigManager(); cm != nil {
-		if configuredName, err := cm.GetEffectiveServerName(ctx); err == nil && configuredName != "" {
-			name = configuredName
-		}
-	}
-	return &apiv1.ListNotificationsResponse{
-		Items:      []*apiv1.NotificationItem{},
-		ServerName: name,
-	}
-}
-
-func (s *notificationService) apiNotificationItem(ctx context.Context, notification *corev1.Notification) (*apiv1.NotificationItem, error) {
-	if notification == nil {
-		return nil, nil
-	}
-
-	actor, err := s.notificationActor(ctx, notification.GetActorId())
-	if err != nil {
-		return nil, err
-	}
-	item := &apiv1.NotificationItem{
-		Id:        notification.GetId(),
-		CreatedAt: notification.GetCreatedAt(),
-		Actor:     actor,
-		Summary:   notificationSummary(actor, notification),
-	}
-
-	switch payload := notification.GetNotification().(type) {
-	case *corev1.Notification_DmMessage:
-		item.Kind = &apiv1.NotificationItem_DirectMessage{
-			DirectMessage: &apiv1.DirectMessageNotification{
-				RoomId:  payload.DmMessage.GetRoomId(),
-				EventId: payload.DmMessage.GetEventId(),
-			},
-		}
-	case *corev1.Notification_Mention:
-		room, err := s.notificationRoom(ctx, payload.Mention.GetRoomId())
-		if err != nil {
-			return nil, err
-		}
-		mention := &apiv1.MentionNotification{
-			Room:    room,
-			EventId: payload.Mention.GetEventId(),
-		}
-		if threadID := payload.Mention.GetInThread(); threadID != "" {
-			mention.ThreadRootEventId = &threadID
-		}
-		item.Kind = &apiv1.NotificationItem_Mention{Mention: mention}
-	case *corev1.Notification_Reply:
-		room, err := s.notificationRoom(ctx, payload.Reply.GetRoomId())
-		if err != nil {
-			return nil, err
-		}
-		reply := &apiv1.ReplyNotification{
-			Room:        room,
-			EventId:     payload.Reply.GetEventId(),
-			InReplyToId: payload.Reply.GetInReplyToId(),
-		}
-		if threadID := payload.Reply.GetInThread(); threadID != "" {
-			reply.ThreadRootEventId = &threadID
-		}
-		item.Kind = &apiv1.NotificationItem_Reply{Reply: reply}
-	case *corev1.Notification_RoomMessage:
-		room, err := s.notificationRoom(ctx, payload.RoomMessage.GetRoomId())
-		if err != nil {
-			return nil, err
-		}
-		item.Kind = &apiv1.NotificationItem_RoomMessage{
-			RoomMessage: &apiv1.RoomMessageNotification{
-				Room:    room,
-				EventId: payload.RoomMessage.GetEventId(),
-			},
-		}
-	default:
-		return nil, connectError(fmt.Errorf("unknown notification type %T", notification.GetNotification()))
-	}
-
-	return item, nil
-}
-
-func (s *notificationService) notificationActor(ctx context.Context, userID string) (*apiv1.UserProfile, error) {
-	if userID == "" {
-		return nil, nil
-	}
-	user, err := s.api.core.GetUser(ctx, userID)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			return nil, nil
-		}
-		return nil, connectError(err)
-	}
-	presence, err := s.api.core.GetUserPresence(ctx, userID)
+	page, err := newNotificationAssembler(s.api).pageFromList(ctx, filtered, pageRequest)
 	if err != nil {
 		return nil, connectError(err)
 	}
-	actor := &apiv1.UserProfile{
-		User: &apiv1.User{
-			Id:          user.GetId(),
-			Login:       user.GetLogin(),
-			DisplayName: user.GetDisplayName(),
-			Deleted:     user.GetDeleted(),
-		},
-		PresenceStatus: corePresenceStatusToAPI(presence),
-		CustomStatus:   coreCustomStatusToAPI(user.GetCustomStatus()),
-	}
-	if avatarURL, err := s.api.core.GetUserAvatarURL(ctx, userID, nil, nil, ""); err != nil {
-		return nil, connectError(err)
-	} else if avatarURL != "" {
-		actor.User.AvatarUrl = stringPtr(s.api.absolutizeAssetURL(ctx, avatarURL))
-	}
-	return actor, nil
-}
-
-func (s *notificationService) notificationRoom(ctx context.Context, roomID string) (*apiv1.NotificationRoom, error) {
-	if roomID == "" {
-		return nil, nil
-	}
-	room, err := s.api.core.FindRoomByID(ctx, roomID)
-	if err != nil {
-		return nil, connectError(err)
-	}
-	return &apiv1.NotificationRoom{
-		Id:   room.GetId(),
-		Name: room.GetName(),
-	}, nil
+	return connect.NewResponse(page), nil
 }
 
 func notificationSummary(actor *apiv1.UserProfile, notification *corev1.Notification) string {

--- a/cli/internal/connectapi/room_timeline_assembler.go
+++ b/cli/internal/connectapi/room_timeline_assembler.go
@@ -49,19 +49,13 @@ func (a *roomTimelineAssembler) buildPage(ctx context.Context, viewerID string, 
 		userIDs:              make(map[string]struct{}),
 	}
 
-	hydratedEvents, err := parallel.Map(ctx, maxConnectAPIHydrationConcurrency, events, func(ctx context.Context, _ int, event *core.RoomEvent) (*apiv1.RoomTimelineEvent, error) {
+	apiEvents, err := parallel.MapNonNil(ctx, maxConnectAPIHydrationConcurrency, events, func(ctx context.Context, _ int, event *core.RoomEvent) (*apiv1.RoomTimelineEvent, error) {
 		return h.event(ctx, event)
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	apiEvents := make([]*apiv1.RoomTimelineEvent, 0, len(hydratedEvents))
-	for _, apiEvent := range hydratedEvents {
-		if apiEvent != nil {
-			apiEvents = append(apiEvents, apiEvent)
-		}
-	}
 	users, err := h.users()
 	if err != nil {
 		return nil, err

--- a/cli/internal/connectapi/room_timeline_assembler.go
+++ b/cli/internal/connectapi/room_timeline_assembler.go
@@ -9,6 +9,7 @@ import (
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"hmans.de/chatto/internal/core"
+	"hmans.de/chatto/internal/parallel"
 	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
@@ -41,9 +42,6 @@ func (a *roomTimelineAssembler) buildPage(ctx context.Context, viewerID string, 
 		return nil, err
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	h := &timelineHydrator{
 		api:                  a.api,
 		ctx:                  ctx,
@@ -53,38 +51,11 @@ func (a *roomTimelineAssembler) buildPage(ctx context.Context, viewerID string, 
 		userIDs:              make(map[string]struct{}),
 	}
 
-	hydratedEvents := make([]*apiv1.RoomTimelineEvent, len(events))
-	if len(events) > 0 {
-		sem := make(chan struct{}, maxRoomTimelineHydrationConcurrency)
-		var wg sync.WaitGroup
-		var errMu sync.Mutex
-		var firstErr error
-
-		for i, event := range events {
-			sem <- struct{}{}
-			wg.Add(1)
-			go func(i int, event *core.RoomEvent) {
-				defer wg.Done()
-				defer func() { <-sem }()
-
-				apiEvent, err := h.event(event)
-				if err != nil {
-					errMu.Lock()
-					if firstErr == nil {
-						firstErr = err
-						cancel()
-					}
-					errMu.Unlock()
-					return
-				}
-				hydratedEvents[i] = apiEvent
-			}(i, event)
-		}
-
-		wg.Wait()
-		if firstErr != nil {
-			return nil, firstErr
-		}
+	hydratedEvents, err := parallel.Map(ctx, maxRoomTimelineHydrationConcurrency, events, func(ctx context.Context, _ int, event *core.RoomEvent) (*apiv1.RoomTimelineEvent, error) {
+		return h.event(ctx, event)
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	apiEvents := make([]*apiv1.RoomTimelineEvent, 0, len(hydratedEvents))
@@ -141,7 +112,7 @@ func (a *roomTimelineAssembler) hydrateEvent(ctx context.Context, viewerID strin
 		reactionsByMessageID: reactionsByMessageID,
 		userIDs:              make(map[string]struct{}),
 	}
-	apiEvent, err := h.event(&core.RoomEvent{Event: event})
+	apiEvent, err := h.event(ctx, &core.RoomEvent{Event: event})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -162,7 +133,7 @@ type timelineHydrator struct {
 	userIDs              map[string]struct{}
 }
 
-func (h *timelineHydrator) event(event *core.RoomEvent) (*apiv1.RoomTimelineEvent, error) {
+func (h *timelineHydrator) event(ctx context.Context, event *core.RoomEvent) (*apiv1.RoomTimelineEvent, error) {
 	if event == nil || event.Event == nil {
 		return nil, nil
 	}
@@ -176,7 +147,7 @@ func (h *timelineHydrator) event(event *core.RoomEvent) (*apiv1.RoomTimelineEven
 
 	switch payload := event.Event.GetEvent().(type) {
 	case *corev1.Event_MessagePosted:
-		message, err := h.messagePosted(event, payload.MessagePosted)
+		message, err := h.messagePosted(ctx, event, payload.MessagePosted)
 		if err != nil {
 			return nil, err
 		}
@@ -202,7 +173,7 @@ func (h *timelineHydrator) event(event *core.RoomEvent) (*apiv1.RoomTimelineEven
 	return apiEvent, nil
 }
 
-func (h *timelineHydrator) messagePosted(event *core.RoomEvent, payload *corev1.MessagePostedEvent) (*apiv1.RoomTimelineMessagePosted, error) {
+func (h *timelineHydrator) messagePosted(ctx context.Context, event *core.RoomEvent, payload *corev1.MessagePostedEvent) (*apiv1.RoomTimelineMessagePosted, error) {
 	message := &apiv1.RoomTimelineMessagePosted{
 		RoomId:                    payload.GetRoomId(),
 		InReplyTo:                 payload.GetInReplyTo(),
@@ -216,7 +187,7 @@ func (h *timelineHydrator) messagePosted(event *core.RoomEvent, payload *corev1.
 		message.ChannelEchoEventId = echoID
 	}
 
-	body, err := h.api.core.GetFullMessageBodyByEventID(h.ctx, event.Id)
+	body, err := h.api.core.GetFullMessageBodyByEventID(ctx, event.Id)
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +201,7 @@ func (h *timelineHydrator) messagePosted(event *core.RoomEvent, payload *corev1.
 	}
 
 	if payload.GetInThread() == "" {
-		metadata, err := h.api.core.GetThreadMetadata(h.ctx, h.kind, payload.GetRoomId(), event.Id)
+		metadata, err := h.api.core.GetThreadMetadata(ctx, h.kind, payload.GetRoomId(), event.Id)
 		if err != nil && !errors.Is(err, core.ErrNotFound) {
 			return nil, err
 		}
@@ -242,7 +213,7 @@ func (h *timelineHydrator) messagePosted(event *core.RoomEvent, payload *corev1.
 			message.ThreadParticipantUserIds = firstN(metadata.ParticipantIDs, 5)
 			h.addUserIDs(message.ThreadParticipantUserIds)
 		}
-		following, err := h.api.core.IsFollowingThread(h.ctx, h.kind, h.viewerID, payload.GetRoomId(), event.Id)
+		following, err := h.api.core.IsFollowingThread(ctx, h.kind, h.viewerID, payload.GetRoomId(), event.Id)
 		if err != nil {
 			return nil, err
 		}

--- a/cli/internal/connectapi/room_timeline_assembler.go
+++ b/cli/internal/connectapi/room_timeline_assembler.go
@@ -14,8 +14,6 @@ import (
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
-const maxRoomTimelineHydrationConcurrency = 16
-
 type roomTimelineAssembler struct {
 	api *API
 }
@@ -51,7 +49,7 @@ func (a *roomTimelineAssembler) buildPage(ctx context.Context, viewerID string, 
 		userIDs:              make(map[string]struct{}),
 	}
 
-	hydratedEvents, err := parallel.Map(ctx, maxRoomTimelineHydrationConcurrency, events, func(ctx context.Context, _ int, event *core.RoomEvent) (*apiv1.RoomTimelineEvent, error) {
+	hydratedEvents, err := parallel.Map(ctx, maxConnectAPIHydrationConcurrency, events, func(ctx context.Context, _ int, event *core.RoomEvent) (*apiv1.RoomTimelineEvent, error) {
 		return h.event(ctx, event)
 	})
 	if err != nil {

--- a/cli/internal/connectapi/thread_assembler.go
+++ b/cli/internal/connectapi/thread_assembler.go
@@ -1,0 +1,106 @@
+package connectapi
+
+import (
+	"context"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"hmans.de/chatto/internal/core"
+	"hmans.de/chatto/internal/parallel"
+	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
+)
+
+type threadAssembler struct {
+	api *API
+}
+
+func newThreadAssembler(api *API) *threadAssembler {
+	return &threadAssembler{api: api}
+}
+
+func (a *threadAssembler) followedThreadsResponse(ctx context.Context, viewerID string, page *core.FollowedThreadsPage) (*apiv1.ListFollowedThreadsResponse, error) {
+	if page == nil {
+		return &apiv1.ListFollowedThreadsResponse{
+			Includes: &apiv1.RoomTimelineIncludes{Users: map[string]*apiv1.User{}},
+			Page:     apiPageInfo(0, false),
+		}, nil
+	}
+
+	messageIDs := make([]string, 0, len(page.Threads))
+	for _, thread := range page.Threads {
+		if thread != nil && thread.ThreadRootEventID != "" {
+			messageIDs = append(messageIDs, thread.ThreadRootEventID)
+		}
+	}
+	reactionsByMessageID, err := a.api.core.GetReactionsBatch(ctx, messageIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	h := &timelineHydrator{
+		api:                  a.api,
+		ctx:                  ctx,
+		viewerID:             viewerID,
+		kind:                 core.KindChannel,
+		reactionsByMessageID: reactionsByMessageID,
+		userIDs:              make(map[string]struct{}),
+	}
+
+	mapped, err := parallel.Map(ctx, maxConnectAPIHydrationConcurrency, page.Threads, func(ctx context.Context, _ int, thread *core.FollowedThread) (*apiv1.FollowedThread, error) {
+		if thread == nil {
+			return nil, nil
+		}
+
+		kind := core.RoomKindFromLegacySpaceID(thread.SpaceID)
+		room, err := a.api.core.GetRoom(ctx, kind, thread.RoomID)
+		if err != nil {
+			return nil, err
+		}
+
+		event, err := a.api.core.GetRoomEventByEventID(ctx, kind, thread.RoomID, thread.ThreadRootEventID)
+		if err != nil {
+			return nil, err
+		}
+		var rootMessage *apiv1.RoomTimelineEvent
+		if event != nil {
+			rootMessage, err = h.event(ctx, &core.RoomEvent{Event: event})
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		var lastReplyAt *timestamppb.Timestamp
+		if thread.LastReplyAt != nil {
+			lastReplyAt = timestamppb.New(*thread.LastReplyAt)
+		}
+		return &apiv1.FollowedThread{
+			RoomId:            thread.RoomID,
+			RoomName:          room.GetName(),
+			ThreadRootEventId: thread.ThreadRootEventID,
+			RootMessage:       rootMessage,
+			ReplyCount:        int32(thread.ReplyCount),
+			LastReplyAt:       lastReplyAt,
+			HasUnread:         thread.HasUnread,
+		}, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	threads := make([]*apiv1.FollowedThread, 0, len(mapped))
+	for _, thread := range mapped {
+		if thread != nil {
+			threads = append(threads, thread)
+		}
+	}
+
+	users, err := h.users()
+	if err != nil {
+		return nil, err
+	}
+
+	return &apiv1.ListFollowedThreadsResponse{
+		Threads:  threads,
+		Includes: &apiv1.RoomTimelineIncludes{Users: users},
+		Page:     apiPageInfo(page.TotalCount, page.HasMore),
+	}, nil
+}

--- a/cli/internal/connectapi/thread_assembler.go
+++ b/cli/internal/connectapi/thread_assembler.go
@@ -45,7 +45,7 @@ func (a *threadAssembler) followedThreadsResponse(ctx context.Context, viewerID 
 		userIDs:              make(map[string]struct{}),
 	}
 
-	mapped, err := parallel.Map(ctx, maxConnectAPIHydrationConcurrency, page.Threads, func(ctx context.Context, _ int, thread *core.FollowedThread) (*apiv1.FollowedThread, error) {
+	threads, err := parallel.MapNonNil(ctx, maxConnectAPIHydrationConcurrency, page.Threads, func(ctx context.Context, _ int, thread *core.FollowedThread) (*apiv1.FollowedThread, error) {
 		if thread == nil {
 			return nil, nil
 		}
@@ -84,13 +84,6 @@ func (a *threadAssembler) followedThreadsResponse(ctx context.Context, viewerID 
 	})
 	if err != nil {
 		return nil, err
-	}
-
-	threads := make([]*apiv1.FollowedThread, 0, len(mapped))
-	for _, thread := range mapped {
-		if thread != nil {
-			threads = append(threads, thread)
-		}
 	}
 
 	users, err := h.users()

--- a/cli/internal/connectapi/threads.go
+++ b/cli/internal/connectapi/threads.go
@@ -4,8 +4,6 @@ import (
 	"context"
 
 	"connectrpc.com/connect"
-	"google.golang.org/protobuf/types/known/timestamppb"
-	"hmans.de/chatto/internal/core"
 	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
 )
 
@@ -30,7 +28,7 @@ func (s *threadService) ListFollowedThreads(ctx context.Context, req *connect.Re
 		return nil, connectError(err)
 	}
 
-	resp, err := s.followedThreadsResponse(ctx, caller.UserID, page)
+	resp, err := newThreadAssembler(s.api).followedThreadsResponse(ctx, caller.UserID, page)
 	if err != nil {
 		return nil, connectError(err)
 	}
@@ -57,83 +55,4 @@ func (s *threadService) UnfollowThread(ctx context.Context, req *connect.Request
 		return nil, connectError(err)
 	}
 	return connect.NewResponse(&apiv1.UnfollowThreadResponse{Following: false}), nil
-}
-
-func (s *threadService) followedThreadsResponse(ctx context.Context, viewerID string, page *core.FollowedThreadsPage) (*apiv1.ListFollowedThreadsResponse, error) {
-	if page == nil {
-		return &apiv1.ListFollowedThreadsResponse{
-			Includes: &apiv1.RoomTimelineIncludes{Users: map[string]*apiv1.User{}},
-			Page:     apiPageInfo(0, false),
-		}, nil
-	}
-
-	messageIDs := make([]string, 0, len(page.Threads))
-	for _, thread := range page.Threads {
-		if thread != nil && thread.ThreadRootEventID != "" {
-			messageIDs = append(messageIDs, thread.ThreadRootEventID)
-		}
-	}
-	reactionsByMessageID, err := s.api.core.GetReactionsBatch(ctx, messageIDs)
-	if err != nil {
-		return nil, err
-	}
-
-	h := &timelineHydrator{
-		api:                  s.api,
-		ctx:                  ctx,
-		viewerID:             viewerID,
-		kind:                 core.KindChannel,
-		reactionsByMessageID: reactionsByMessageID,
-		userIDs:              make(map[string]struct{}),
-	}
-
-	threads := make([]*apiv1.FollowedThread, 0, len(page.Threads))
-	for _, thread := range page.Threads {
-		if thread == nil {
-			continue
-		}
-
-		kind := core.RoomKindFromLegacySpaceID(thread.SpaceID)
-		room, err := s.api.core.GetRoom(ctx, kind, thread.RoomID)
-		if err != nil {
-			return nil, err
-		}
-
-		event, err := s.api.core.GetRoomEventByEventID(ctx, kind, thread.RoomID, thread.ThreadRootEventID)
-		if err != nil {
-			return nil, err
-		}
-		var rootMessage *apiv1.RoomTimelineEvent
-		if event != nil {
-			rootMessage, err = h.event(ctx, &core.RoomEvent{Event: event})
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		var lastReplyAt *timestamppb.Timestamp
-		if thread.LastReplyAt != nil {
-			lastReplyAt = timestamppb.New(*thread.LastReplyAt)
-		}
-		threads = append(threads, &apiv1.FollowedThread{
-			RoomId:            thread.RoomID,
-			RoomName:          room.GetName(),
-			ThreadRootEventId: thread.ThreadRootEventID,
-			RootMessage:       rootMessage,
-			ReplyCount:        int32(thread.ReplyCount),
-			LastReplyAt:       lastReplyAt,
-			HasUnread:         thread.HasUnread,
-		})
-	}
-
-	users, err := h.users()
-	if err != nil {
-		return nil, err
-	}
-
-	return &apiv1.ListFollowedThreadsResponse{
-		Threads:  threads,
-		Includes: &apiv1.RoomTimelineIncludes{Users: users},
-		Page:     apiPageInfo(page.TotalCount, page.HasMore),
-	}, nil
 }

--- a/cli/internal/connectapi/threads.go
+++ b/cli/internal/connectapi/threads.go
@@ -105,7 +105,7 @@ func (s *threadService) followedThreadsResponse(ctx context.Context, viewerID st
 		}
 		var rootMessage *apiv1.RoomTimelineEvent
 		if event != nil {
-			rootMessage, err = h.event(&core.RoomEvent{Event: event})
+			rootMessage, err = h.event(ctx, &core.RoomEvent{Event: event})
 			if err != nil {
 				return nil, err
 			}

--- a/cli/internal/parallel/map.go
+++ b/cli/internal/parallel/map.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Map runs fn for each item with bounded concurrency and returns results in
-// input order. The first error cancels the remaining work.
+// input order. The first error cancels the worker context.
 func Map[T any, R any](ctx context.Context, limit int, items []T, fn func(context.Context, int, T) (R, error)) ([]R, error) {
 	out := make([]R, len(items))
 	if len(items) == 0 {
@@ -33,4 +33,20 @@ func Map[T any, R any](ctx context.Context, limit int, items []T, fn func(contex
 	}
 
 	return out, g.Wait()
+}
+
+// MapNonNil runs fn for each item with bounded concurrency, drops nil results,
+// and returns the remaining results in input order.
+func MapNonNil[T any, R any](ctx context.Context, limit int, items []T, fn func(context.Context, int, T) (*R, error)) ([]*R, error) {
+	mapped, err := Map(ctx, limit, items, fn)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*R, 0, len(mapped))
+	for _, item := range mapped {
+		if item != nil {
+			out = append(out, item)
+		}
+	}
+	return out, nil
 }

--- a/cli/internal/parallel/map.go
+++ b/cli/internal/parallel/map.go
@@ -1,0 +1,36 @@
+package parallel
+
+import (
+	"context"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// Map runs fn for each item with bounded concurrency and returns results in
+// input order. The first error cancels the remaining work.
+func Map[T any, R any](ctx context.Context, limit int, items []T, fn func(context.Context, int, T) (R, error)) ([]R, error) {
+	out := make([]R, len(items))
+	if len(items) == 0 {
+		return out, nil
+	}
+	if limit <= 0 || limit > len(items) {
+		limit = len(items)
+	}
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(limit)
+
+	for i, item := range items {
+		i, item := i, item
+		g.Go(func() error {
+			result, err := fn(ctx, i, item)
+			if err != nil {
+				return err
+			}
+			out[i] = result
+			return nil
+		})
+	}
+
+	return out, g.Wait()
+}

--- a/cli/internal/parallel/map_test.go
+++ b/cli/internal/parallel/map_test.go
@@ -1,0 +1,52 @@
+package parallel
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestMapPreservesOrderAndLimit(t *testing.T) {
+	var inFlight int32
+	var maxInFlight int32
+
+	got, err := Map(context.Background(), 2, []int{1, 2, 3, 4}, func(ctx context.Context, _ int, n int) (int, error) {
+		current := atomic.AddInt32(&inFlight, 1)
+		for {
+			previous := atomic.LoadInt32(&maxInFlight)
+			if current <= previous || atomic.CompareAndSwapInt32(&maxInFlight, previous, current) {
+				break
+			}
+		}
+		time.Sleep(time.Millisecond)
+		atomic.AddInt32(&inFlight, -1)
+		return n * 10, nil
+	})
+	if err != nil {
+		t.Fatalf("Map returned error: %v", err)
+	}
+	if maxInFlight > 2 {
+		t.Fatalf("max in-flight = %d, want <= 2", maxInFlight)
+	}
+	for i, want := range []int{10, 20, 30, 40} {
+		if got[i] != want {
+			t.Fatalf("got[%d] = %d, want %d", i, got[i], want)
+		}
+	}
+}
+
+func TestMapReturnsFirstError(t *testing.T) {
+	wantErr := errors.New("boom")
+
+	_, err := Map(context.Background(), 2, []int{1, 2, 3}, func(ctx context.Context, _ int, n int) (int, error) {
+		if n == 2 {
+			return 0, wantErr
+		}
+		return n, nil
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Map error = %v, want %v", err, wantErr)
+	}
+}

--- a/cli/internal/parallel/map_test.go
+++ b/cli/internal/parallel/map_test.go
@@ -50,3 +50,24 @@ func TestMapReturnsFirstError(t *testing.T) {
 		t.Fatalf("Map error = %v, want %v", err, wantErr)
 	}
 }
+
+func TestMapNonNilDropsNilResultsAndPreservesOrder(t *testing.T) {
+	got, err := MapNonNil(context.Background(), 2, []int{1, 2, 3, 4}, func(ctx context.Context, _ int, n int) (*int, error) {
+		if n%2 == 0 {
+			return nil, nil
+		}
+		result := n * 10
+		return &result, nil
+	})
+	if err != nil {
+		t.Fatalf("MapNonNil returned error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2", len(got))
+	}
+	for i, want := range []int{10, 30} {
+		if *got[i] != want {
+			t.Fatalf("got[%d] = %d, want %d", i, *got[i], want)
+		}
+	}
+}

--- a/docs/adr/ADR-044-connectrpc-service-conventions.md
+++ b/docs/adr/ADR-044-connectrpc-service-conventions.md
@@ -56,6 +56,10 @@ Core operation models are responsible for:
 - read-your-writes waits;
 - response semantics shared across transports.
 
+Read responses that hydrate projected data from multiple sources should keep that fanout out of service handlers. Handlers stay responsible for caller/auth, request translation, pagination parameters, and response wrapping. Per-response loading, batching, bounded concurrency, and include-map construction should live in small response assemblers or focused helper functions near the service that owns the response shape.
+
+These assemblers should stay concrete until repetition proves otherwise. Do not introduce a generic ConnectRPC loader package just because several endpoints hydrate data: most hydration code also owns response-shape details such as protobuf messages, include maps, viewer visibility, nullable fields, and endpoint-specific absence behavior. Shared helpers are appropriate for truly generic mechanics such as bounded parallel mapping, or after multiple assemblers share the same non-trivial loading behavior with the same semantics.
+
 ConnectRPC errors are mapped through the shared `connectError` helper so core authentication, authorization, validation, not-found, conflict, and room-state errors produce consistent Connect status codes. Handlers should return `connect.NewResponse` for success and avoid service-local status-code mapping unless the public method has a deliberate protocol-specific error.
 
 Adding a new public ConnectRPC service requires the same change set:
@@ -74,7 +78,7 @@ Adding a new public ConnectRPC service requires the same change set:
 
 ConnectRPC services become predictable to review: public surface, auth policy, validation, and handler options are visible in one place.
 
-Some small mapping code remains in each handler. That is intentional. The handler layer should be thin and explicit rather than hiding service behavior behind broad reflection or generic transport abstractions.
+Some small request and response wrapping code remains in each handler. That is intentional. The handler layer should be thin and explicit rather than hiding service behavior behind broad reflection or generic transport abstractions. Heavier read-response assembly belongs in named assemblers/helpers so batching and concurrency are reusable without spreading loader control flow through handlers. A separate loader layer should be extracted only when the shared semantics are already visible in concrete assemblers.
 
 Operation-specific authorization lives in shared core operation models for public API actions. This reduces transport drift, but it means older trusted core helpers can coexist with newer operation models. Trusted/internal callers may still use lower-level helpers; public transports should use operation models.
 


### PR DESCRIPTION
## Why

The new ConnectRPC read endpoints were doing gqlgen-style response hydration serially in a few hot paths. `GetRoomEvents` already showed this pain: every timeline item could trigger independent projection lookups for message bodies, thread metadata, reactions, users, and related response data.

This PR keeps the ConnectRPC/protobuf API shape explicit, but steals the useful part of the old GraphQL execution model: independent read hydration work can run concurrently behind a bounded helper.

## What Changed

- Added `internal/parallel.Map`, a tiny bounded concurrent map helper with tests.
- Updated room timeline hydration to map timeline events concurrently while preserving response order and existing include behavior.
- Moved followed-thread response hydration out of the service handler into `threadAssembler` and hydrated followed thread rows concurrently.
- Moved notification page/item hydration out of the service handler into `notificationAssembler` and hydrated notification rows concurrently.
- Added a shared ConnectAPI hydration concurrency cap so read assemblers do not spawn unbounded goroutines.
- Updated ADR-044 and `cli/AGENTS.md` to document the rule: handlers stay thin, projected read hydration lives in concrete response assemblers, and we do not introduce a generic loader package until repeated semantics justify it.

## Notes

This does not change protobuf contracts or endpoint behavior. It is intended as a small implementation-level performance and structure cleanup: batch APIs still come first where available, and bounded parallelism is used only for per-row read hydration that is already independent.

## Validation

- `mise x -- go test ./internal/parallel ./internal/connectapi`
- `mise x -- go test -race -count=1 ./internal/connectapi`
- GitHub Actions: all PR checks passing, including `test-cli`, frontend unit tests, E2E shards, media E2E, and `codegen-proto-drift`.
