### PR TITLE
fix(dockercompose): enable LiveKit TURN relay

### DIFF
--- a/apps/docs-website/src/components/diagrams/DockerComposeDiagram.astro
+++ b/apps/docs-website/src/components/diagrams/DockerComposeDiagram.astro
@@ -24,7 +24,7 @@ import Dot from './Dot.astro';
   <path id="p-caddy-chatto" class="conn" d="M385,170 L463,170"/>
   <path id="p-caddy-livekit" class="conn" d="M385,185 L463,265"/>
   <path id="p-browser-livekit" class="conn-dash" d="M86,200 L86,270 L463,270"/>
-  <text class="proto" x="270" y="285" text-anchor="middle">UDP :50000–50200</text>
+  <text class="proto" x="270" y="285" text-anchor="middle">UDP :3478, :50000–50200</text>
 
   <path id="p-chatto-nats" class="conn" d="M541,140 L541,110"/>
   <path id="p-nats-chatto" class="conn" d="M549,110 L549,140"/>

--- a/apps/docs-website/src/content/docs/guides/dockercompose.mdx
+++ b/apps/docs-website/src/content/docs/guides/dockercompose.mdx
@@ -32,7 +32,7 @@ Consider all of these optional; if you don't want to use Caddy, feel free to rep
 - Docker and Docker Compose v2
 - A domain pointing to your server (e.g., `chat.example.com`)
 - A `livekit.*` subdomain pointing to the same server (e.g., `livekit.chat.example.com`)
-- Firewall allowing inbound TCP 80, 443 and UDP 50000-50200
+- Firewall allowing inbound TCP 80/443 and UDP 3478, 50000-50200
 - SMTP credentials for email/password registration, email verification, and password reset
 
 ## Setup
@@ -162,27 +162,29 @@ If you don't need voice and video calls, simplify the stack by:
 3. Removing the `livekit.*` block from the `Caddyfile`
 4. Removing the `CHATTO_LIVEKIT_*` variables from `.env`
 
-You won't need the `livekit.*` subdomain or the UDP port range.
+You won't need the `livekit.*` subdomain or the LiveKit UDP ports.
 
 ## TURN Server for Restrictive Networks
 
-The default setup exposes LiveKit's UDP port range directly. This works for most networks, but users behind strict corporate firewalls or symmetric NATs that block all UDP traffic won't be able to join calls.
-
-For Docker Compose deployments, the shortest path is LiveKit's built-in TURN server on a dedicated TCP port:
-
-```yaml
-turn:
-  enabled: true
-  tls_port: 5349
-```
-
-Expose that port on the `livekit` service:
+The default setup exposes LiveKit's direct UDP media range and its embedded TURN/UDP relay:
 
 ```yaml
 ports:
   - "50000-50200:50000-50200/udp"
-  - "5349:5349/tcp" # TURN/TLS relay
+  - "3478:3478/udp"
 ```
+
+The generated and checked-in LiveKit configs enable the matching relay:
+
+```yaml
+turn:
+  enabled: true
+  udp_port: 3478
+```
+
+This helps with symmetric NATs and many mobile, Firefox, and restrictive-network failures while keeping the Compose example certificate-free.
+
+Networks that block UDP entirely still need TURN/TLS. Add that only when you also provide a TURN domain plus certificate/key, or run LiveKit behind L4 TLS forwarding that terminates TLS before LiveKit.
 
 <Aside>
   Some networks only allow outbound traffic on TCP 443. If you need TURN on
@@ -204,9 +206,9 @@ See [Voice & Video Calls](/guides/voice-calls/#turn-for-restrictive-networks) fo
 
 **Container startup order** — `depends_on` with `condition: service_healthy` ensures NATS and LiveKit are ready before Chatto starts. If health checks fail, check the individual service logs.
 
-**Calls don't connect** — Verify the LiveKit API key/secret in `.env` matches the selected LiveKit config (`livekit.generated.yaml` or `livekit.yaml`). Ensure `CHATTO_LIVEKIT_URL` uses the public `wss://livekit.*` subdomain (browsers connect to it directly). Check that UDP 50000-50200 is open in your firewall.
+**Calls don't connect** — Verify the LiveKit API key/secret in `.env` matches the selected LiveKit config (`livekit.generated.yaml` or `livekit.yaml`). Ensure `CHATTO_LIVEKIT_URL` uses the public `wss://livekit.*` subdomain (browsers connect to it directly). Check that UDP 3478 and 50000-50200 are open in your firewall.
 
-**Calls fail for some users** — Users behind firewalls that block UDP need a TURN relay. See [TURN server for restrictive networks](#turn-server-for-restrictive-networks).
+**Calls fail for some users** — Confirm the built-in TURN/UDP relay is reachable on UDP 3478. Users behind firewalls that block UDP entirely need TURN/TLS. See [TURN server for restrictive networks](#turn-server-for-restrictive-networks).
 
 <CardGrid>
   <LinkCard

--- a/apps/docs-website/src/content/docs/guides/voice-calls.mdx
+++ b/apps/docs-website/src/content/docs/guides/voice-calls.mdx
@@ -107,24 +107,24 @@ Use `wss://` (WebSocket Secure) URLs in production. Plain `ws://` should only be
 :::
 
 - **Network**: Users connect directly to the LiveKit server from their browsers. Make sure your LiveKit server is reachable from the public internet (or your private network, for internal deployments).
-- **TURN/STUN**: LiveKit includes a built-in TURN server for NAT traversal. For restrictive networks, you may need to configure it to listen on port 443.
+- **TURN/STUN**: LiveKit includes a built-in TURN server for NAT traversal. TURN/UDP on port 3478 helps many NAT traversal failures; networks that block UDP entirely need TURN/TLS, often on port 443.
 - **Scaling**: A single LiveKit server handles hundreds of concurrent participants for typical small deployments. For larger deployments, LiveKit supports multi-node clustering with Redis.
 - **End-to-end encryption**: Chatto enables LiveKit E2EE automatically for clients. No additional LiveKit server configuration is required.
 - **API Secret**: Keep your API secret confidential. It's used to sign JWT tokens and should never be exposed to clients.
 
 ## TURN for Restrictive Networks
 
-LiveKit can usually connect browsers directly over UDP. Users behind strict corporate firewalls or symmetric NATs may need a TURN relay so media can fall back to TCP or TLS.
+LiveKit can usually connect browsers directly over UDP. Users behind symmetric NATs, mobile networks, or browser/network combinations that fail direct ICE checks need a TURN relay.
 
-For most self-hosted deployments, enable LiveKit's built-in TURN server first:
+For most self-hosted deployments, enable LiveKit's built-in TURN/UDP server first:
 
 ```yaml
 turn:
   enabled: true
-  tls_port: 5349
+  udp_port: 3478
 ```
 
-Expose the TURN/TLS port on the LiveKit host and keep the UDP media range open. If your users can only reach outbound TCP 443, LiveKit or TURN needs a dedicated IP address or host so it can listen on 443 without conflicting with your HTTPS reverse proxy.
+Expose UDP 3478 on the LiveKit host and keep the UDP media range open. Networks that block UDP entirely need TURN/TLS instead. If your users can only reach outbound TCP 443, LiveKit or TURN needs a dedicated IP address or host so it can listen on 443 without conflicting with your HTTPS reverse proxy, and the TURN TLS certificate must match the advertised TURN domain.
 
 Use a dedicated TURN server such as [coturn](https://github.com/coturn/coturn) when you need tighter network separation, a shared TURN service for multiple LiveKit deployments, or TURN/TLS on port 443 without moving LiveKit itself. Configure static credentials on the TURN server and list it under LiveKit's `rtc.turn_servers` configuration.
 

--- a/examples/dockercompose/README.md
+++ b/examples/dockercompose/README.md
@@ -12,6 +12,7 @@ This example deploys a clustered Chatto setup with:
 - Docker and Docker Compose (v2) installed
 - A domain pointing to your server (for automatic HTTPS)
 - A `livekit.` subdomain pointing to the same server (e.g., `livekit.chat.example.com`)
+- Firewall allowing inbound TCP 80/443 and UDP 3478, 50000-50200
 
 ## Configuration
 
@@ -134,4 +135,6 @@ If you don't need voice calls, remove the `livekit` service from `compose.yml`, 
 
 **Voice calls not working**: Ensure the LiveKit API key/secret in `.env` matches the `keys:` section in the selected LiveKit config (`livekit.generated.yaml` or `livekit.yaml`). Also verify the webhook URL points to your Chatto instance. Make sure `CHATTO_LIVEKIT_URL` uses the public `wss://livekit.` subdomain (not the internal Docker hostname), since browsers connect to it directly.
 
-**LiveKit UDP ports**: WebRTC requires UDP ports 50000-50200. Ensure your firewall allows inbound UDP on this range.
+**LiveKit UDP ports**: The example exposes UDP 50000-50200 for direct WebRTC media and UDP 3478 for LiveKit's embedded TURN/STUN relay. Ensure your firewall allows inbound UDP on both.
+
+**Calls fail for some users**: The built-in TURN/UDP relay helps with symmetric NATs and some mobile, Firefox, and restrictive-network cases. Networks that block UDP entirely still need an advanced TURN/TLS setup, such as a dedicated TURN host or L4 TLS forwarding with matching certificates.

--- a/examples/dockercompose/compose.yml
+++ b/examples/dockercompose/compose.yml
@@ -17,6 +17,7 @@ services:
       - /etc/livekit.yaml
     ports:
       - "50000-50200:50000-50200/udp"  # WebRTC media (UDP, must be direct)
+      - "3478:3478/udp"  # TURN/STUN relay for NAT traversal
     expose:
       - "7880"  # WebSocket signaling (proxied through Caddy)
     volumes:

--- a/examples/dockercompose/init-env.sh
+++ b/examples/dockercompose/init-env.sh
@@ -129,6 +129,10 @@ rtc:
   port_range_end: 50200
   use_external_ip: true
 
+turn:
+  enabled: true
+  udp_port: 3478
+
 keys:
   ${livekit_api_key}: ${livekit_api_secret}
 

--- a/examples/dockercompose/livekit.yaml
+++ b/examples/dockercompose/livekit.yaml
@@ -4,6 +4,10 @@ rtc:
   port_range_end: 50200
   use_external_ip: true
 
+turn:
+  enabled: true
+  udp_port: 3478
+
 keys:
   # Must match CHATTO_LIVEKIT_API_KEY / CHATTO_LIVEKIT_API_SECRET in .env
   your-api-key: replace-with-at-least-32-character-livekit-secret


### PR DESCRIPTION
Enable LiveKit's embedded TURN/UDP relay in the Docker Compose example and publish UDP 3478 alongside the direct media range. Update the generated LiveKit config path so `init-env.sh` produces matching TURN settings. Refresh the example README, docs guide, voice-call guidance, and diagram so operators know which firewall ports are required and when TURN/TLS is still needed. Validated with generated Compose config checks and the docs website build.
