### PR TITLE
perf(core): cache unwrapped DEKs per request

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,9 @@ path-specific guidance.
 ## Prime Directives
 
 - Prefer simple, clear changes over clever abstractions.
+- Add concise code documentation for public APIs and for otherwise important
+  fields, functions, types, invariants, and lifecycle behavior that future
+  maintainers should not have to infer from call sites.
 - Keep tests and documentation up to date when changing behavior.
 - Run verification that would actually catch regressions in the area touched.
 - Never claim full verification when only a partial signal was run.

--- a/cli/internal/connectapi/room_timeline_assembler.go
+++ b/cli/internal/connectapi/room_timeline_assembler.go
@@ -28,6 +28,8 @@ func newRoomTimelineAssembler(api *API) *roomTimelineAssembler {
 // Hydrating them here keeps the public API free of per-field resolver N+1s
 // and gives future clients one renderable page per request.
 func (a *roomTimelineAssembler) buildPage(ctx context.Context, viewerID string, kind core.RoomKind, events []*core.RoomEvent, hasOlder, hasNewer bool) (*apiv1.RoomTimelinePage, error) {
+	ctx = core.WithDEKRequestCache(ctx)
+
 	messageIDs := make([]string, 0, len(events))
 	for _, event := range events {
 		if event.GetMessagePosted() != nil {
@@ -86,6 +88,8 @@ func (a *roomTimelineAssembler) buildThreadPage(ctx context.Context, viewerID st
 }
 
 func (a *roomTimelineAssembler) hydrateEvent(ctx context.Context, viewerID string, kind core.RoomKind, event *corev1.Event) (*apiv1.RoomTimelineEvent, *apiv1.RoomTimelineIncludes, error) {
+	ctx = core.WithDEKRequestCache(ctx)
+
 	messageIDs := []string(nil)
 	if event.GetMessagePosted() != nil {
 		messageIDs = append(messageIDs, event.Id)

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -39,6 +39,7 @@ type ChattoCore struct {
 	storage            *storage
 	config             config.CoreConfig
 	encryption         *encryptionManager
+	dekResolver        *unwrappedDEKResolver
 	configManager      *ConfigManager
 	roomModel          *RoomModel
 	roomCommands       *RoomCommandModel
@@ -517,6 +518,7 @@ func (c *ChattoCore) DeleteUserEncryptionKeyAs(ctx context.Context, actorID, use
 	if !shredded {
 		return nil
 	}
+	forgetDEKRequestCacheUser(ctx, userID)
 
 	event := newEvent(actorID, &corev1.Event{
 		Event: &corev1.Event_UserKeyShredded{
@@ -941,7 +943,9 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	reactions := NewReactionProjection()
 	reactionsProjector := newProjector(reactions, "reactions", "Reactions", reactions.adminProjectionEstimate)
 
-	users := NewUserProjection(encMgr.keyWrapper, encMgr.contentKeys)
+	dekResolver := newUnwrappedDEKResolver(encMgr.keyWrapper, encMgr.contentKeys)
+
+	users := newUserProjectionWithDEKResolver(dekResolver)
 	usersProjector := newProjector(users, "users", "Users", users.adminProjectionEstimate)
 
 	contentKeys := NewContentKeyProjection()
@@ -950,7 +954,7 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	rbac := NewRBACProjection()
 	rbacProjector := newProjector(rbac, "rbac", "RBAC", rbac.adminProjectionEstimate)
 
-	mentionables := NewMentionablesProjection(encMgr.keyWrapper, encMgr.contentKeys)
+	mentionables := newMentionablesProjectionWithDEKResolver(dekResolver)
 	mentionablesProjector := newProjector(mentionables, "mentionables", "Mentionables", mentionables.adminProjectionEstimate)
 
 	configModel := NewConfigModel(eventPublisher, serverConfigProjector, serverConfigProjection)
@@ -978,6 +982,7 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 		storage:                  storage,
 		config:                   cfg,
 		encryption:               encMgr,
+		dekResolver:              dekResolver,
 		configManager:            configMgr,
 		roomModel:                roomMgr,
 		userModel:                userMgr,

--- a/cli/internal/core/core_test.go
+++ b/cli/internal/core/core_test.go
@@ -60,7 +60,7 @@ func setupTestCore(t *testing.T) (*ChattoCore, *nats.Conn) {
 //
 // Once `core.Run` owns the lifecycle of every background service, new
 // projectors (ADR-035) get picked up here automatically.
-func startCoreServices(t *testing.T, core *ChattoCore) {
+func startCoreServices(t testing.TB, core *ChattoCore) {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)

--- a/cli/internal/core/encryption_test.go
+++ b/cli/internal/core/encryption_test.go
@@ -3,6 +3,9 @@ package core
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,8 +21,28 @@ import (
 	"hmans.de/chatto/pkg/signedurl"
 )
 
+type countingKeyWrapper struct {
+	kms.KeyWrapper
+	unwraps atomic.Int32
+}
+
+func (w *countingKeyWrapper) UnwrapContentKey(ctx context.Context, keyRef string, wrapped kms.WrappedContentKey, aad []byte) ([]byte, error) {
+	w.unwraps.Add(1)
+	return w.KeyWrapper.UnwrapContentKey(ctx, keyRef, wrapped, aad)
+}
+
+type delayedKeyWrapper struct {
+	kms.KeyWrapper
+	delay time.Duration
+}
+
+func (w delayedKeyWrapper) UnwrapContentKey(ctx context.Context, keyRef string, wrapped kms.WrappedContentKey, aad []byte) ([]byte, error) {
+	time.Sleep(w.delay)
+	return w.KeyWrapper.UnwrapContentKey(ctx, keyRef, wrapped, aad)
+}
+
 // setupTestCoreWithEncryption creates a ChattoCore for encryption tests.
-func setupTestCoreWithEncryption(t *testing.T) *ChattoCore {
+func setupTestCoreWithEncryption(t testing.TB) *ChattoCore {
 	t.Helper()
 
 	_, nc := testutil.StartSharedNATS(t)
@@ -249,6 +272,128 @@ func TestUserPIIAADRejectsWrongContext(t *testing.T) {
 	require.ErrorIs(t, err, encryption.ErrDecryptionFailed)
 }
 
+func TestGetMessageBody_ReusesRequestCachedMessageBodyDEK(t *testing.T) {
+	core := setupTestCoreWithEncryption(t)
+	ctx := testContext(t)
+
+	user, err := core.CreateUser(ctx, "system", "cacheuser", "Cache User", "password123")
+	require.NoError(t, err)
+	room, err := core.CreateRoom(ctx, user.Id, KindChannel, "", "General", "General chat")
+	require.NoError(t, err)
+	event, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "Secret message content", nil, "", "", nil, false)
+	require.NoError(t, err)
+
+	wrapper := &countingKeyWrapper{KeyWrapper: core.encryption.keyWrapper}
+	core.dekResolver.keyWrapper = wrapper
+
+	readCtx := WithDEKRequestCache(ctx)
+	body, err := core.GetMessageBody(readCtx, KindChannel, event.Id)
+	require.NoError(t, err)
+	require.Equal(t, "Secret message content", body)
+	body, err = core.GetMessageBody(readCtx, KindChannel, event.Id)
+	require.NoError(t, err)
+	require.Equal(t, "Secret message content", body)
+	require.EqualValues(t, 1, wrapper.unwraps.Load(), "message body DEK should be unwrapped once and then served from cache")
+}
+
+func TestUnwrappedDEKResolver_RequestCacheDoesNotPersistAcrossContexts(t *testing.T) {
+	key, err := encryption.GenerateKey()
+	require.NoError(t, err)
+	wrapper := &countingKeyWrapper{KeyWrapper: staticProjectionKeyWrapper{key: key}}
+	resolver := newUnwrappedDEKResolver(wrapper, staticProjectionDEKStore{})
+	event := &corev1.UserDEKGeneratedEvent{
+		UserId:        "U-cache",
+		Epoch:         1,
+		Purpose:       corev1.UserDEKPurpose_USER_DEK_PURPOSE_MESSAGE_BODY,
+		ContentKeyRef: "dek.test",
+	}
+
+	ctx := WithDEKRequestCache(context.Background())
+	dek, err := resolver.Resolve(ctx, event, corev1.UserDEKPurpose_USER_DEK_PURPOSE_MESSAGE_BODY)
+	require.NoError(t, err)
+	require.Equal(t, key, dek.key)
+	dek, err = resolver.Resolve(ctx, event, corev1.UserDEKPurpose_USER_DEK_PURPOSE_MESSAGE_BODY)
+	require.NoError(t, err)
+	require.Equal(t, key, dek.key)
+	require.EqualValues(t, 1, wrapper.unwraps.Load())
+
+	dek, err = resolver.Resolve(WithDEKRequestCache(context.Background()), event, corev1.UserDEKPurpose_USER_DEK_PURPOSE_MESSAGE_BODY)
+	require.NoError(t, err)
+	require.Equal(t, key, dek.key)
+	require.EqualValues(t, 2, wrapper.unwraps.Load())
+}
+
+func TestUnwrappedDEKResolver_RequestCacheCollapsesConcurrentMisses(t *testing.T) {
+	key, err := encryption.GenerateKey()
+	require.NoError(t, err)
+	wrapper := &countingKeyWrapper{KeyWrapper: delayedKeyWrapper{
+		KeyWrapper: staticProjectionKeyWrapper{key: key},
+		delay:      25 * time.Millisecond,
+	}}
+	resolver := newUnwrappedDEKResolver(wrapper, staticProjectionDEKStore{})
+	event := &corev1.UserDEKGeneratedEvent{
+		UserId:        "U-concurrent-cache",
+		Epoch:         1,
+		Purpose:       corev1.UserDEKPurpose_USER_DEK_PURPOSE_MESSAGE_BODY,
+		ContentKeyRef: "dek.test",
+	}
+
+	ctx := WithDEKRequestCache(context.Background())
+	const goroutineCount = 16
+	start := make(chan struct{})
+	errs := make(chan error, goroutineCount)
+	var wg sync.WaitGroup
+	for i := 0; i < goroutineCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			dek, err := resolver.Resolve(ctx, event, corev1.UserDEKPurpose_USER_DEK_PURPOSE_MESSAGE_BODY)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if dek == nil || !bytes.Equal(key, dek.key) {
+				errs <- fmt.Errorf("resolved wrong DEK")
+				return
+			}
+			errs <- nil
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.EqualValues(t, 1, wrapper.unwraps.Load(), "concurrent misses for one request cache key should share one unwrap")
+}
+
+func TestDeleteUserEncryptionKeyAsInvalidatesRequestCachedDEK(t *testing.T) {
+	core := setupTestCoreWithEncryption(t)
+	ctx := testContext(t)
+
+	user, err := core.CreateUser(ctx, "system", "requestcachedelete", "Request Cache Delete", "password123")
+	require.NoError(t, err)
+	room, err := core.CreateRoom(ctx, user.Id, KindChannel, "", "General", "General chat")
+	require.NoError(t, err)
+	event, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "Secret message content", nil, "", "", nil, false)
+	require.NoError(t, err)
+
+	readCtx := WithDEKRequestCache(ctx)
+	body, err := core.GetMessageBody(readCtx, KindChannel, event.Id)
+	require.NoError(t, err)
+	require.Equal(t, "Secret message content", body)
+
+	require.NoError(t, core.DeleteUserEncryptionKeyAs(readCtx, user.Id, user.Id))
+
+	body, err = core.GetMessageBody(readCtx, KindChannel, event.Id)
+	require.NoError(t, err)
+	require.Empty(t, body, "same request context should not keep using a DEK after deleting it")
+}
+
 func TestGetMessageBody_CryptoShredding(t *testing.T) {
 	core := setupTestCoreWithEncryption(t)
 	ctx := testContext(t)
@@ -271,10 +416,8 @@ func TestGetMessageBody_CryptoShredding(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "Secret message content", body)
 
-	// Delete the message-body DEK record (crypto-shredding)
-	contentKeyEvent, ok := core.ContentKeys.Active(user.Id, corev1.UserDEKPurpose_USER_DEK_PURPOSE_MESSAGE_BODY)
-	require.True(t, ok)
-	require.NoError(t, core.encryption.contentKeys.Shred(ctx, contentKeyEvent.GetContentKeyRef()))
+	// Delete the user's DEK records through the core path.
+	require.NoError(t, core.DeleteUserEncryptionKeyAs(ctx, user.Id, user.Id))
 
 	// Verify message now returns empty string (crypto-shredded)
 	body, err = core.GetMessageBody(ctx, KindChannel, event.Id)

--- a/cli/internal/core/mentionables_projection.go
+++ b/cli/internal/core/mentionables_projection.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/protobuf/proto"
+
 	"hmans.de/chatto/internal/dekstore"
 	"hmans.de/chatto/internal/encryption"
 	"hmans.de/chatto/internal/events"
@@ -35,18 +37,23 @@ type MentionablesProjection struct {
 	events.MemoryProjection
 	owners      map[string]map[mentionableOwner]struct{}
 	userLogins  map[string]string
-	keyWrapper  kms.KeyWrapper
-	dekStore    dekstore.Reader
-	contentKeys map[string]map[corev1.UserDEKPurpose]map[int32][]byte
+	dekResolver *unwrappedDEKResolver
+	dekEvents   map[string]map[corev1.UserDEKPurpose]map[int32]*corev1.UserDEKGeneratedEvent
 }
 
+// NewMentionablesProjection creates the global mentionable-handle read model.
+// It keeps encrypted DEK event references for replay, while raw key bytes are
+// resolved through the shared unwrapped-DEK resolver.
 func NewMentionablesProjection(keyWrapper kms.KeyWrapper, dekStore dekstore.Reader) *MentionablesProjection {
+	return newMentionablesProjectionWithDEKResolver(newUnwrappedDEKResolver(keyWrapper, dekStore))
+}
+
+func newMentionablesProjectionWithDEKResolver(dekResolver *unwrappedDEKResolver) *MentionablesProjection {
 	p := &MentionablesProjection{
 		owners:      make(map[string]map[mentionableOwner]struct{}),
 		userLogins:  make(map[string]string),
-		keyWrapper:  keyWrapper,
-		dekStore:    dekStore,
-		contentKeys: make(map[string]map[corev1.UserDEKPurpose]map[int32][]byte),
+		dekResolver: dekResolver,
+		dekEvents:   make(map[string]map[corev1.UserDEKPurpose]map[int32]*corev1.UserDEKGeneratedEvent),
 	}
 	p.addOwner(MentionHandleAll, mentionableOwner{kind: mentionableOwnerVirtual, id: MentionHandleAll})
 	p.addOwner(MentionHandleHere, mentionableOwner{kind: mentionableOwnerVirtual, id: MentionHandleHere})
@@ -85,37 +92,20 @@ func (p *MentionablesProjection) Apply(event *corev1.Event, _ uint64) error {
 }
 
 func (p *MentionablesProjection) applyDEKGenerated(e *corev1.UserDEKGeneratedEvent) {
-	if e == nil || e.GetUserId() == "" || e.GetEpoch() <= 0 || e.GetContentKeyRef() == "" || p.keyWrapper == nil || p.dekStore == nil {
+	if e == nil || e.GetUserId() == "" || e.GetEpoch() <= 0 || e.GetContentKeyRef() == "" {
 		return
 	}
-	stored, err := p.dekStore.Get(context.Background(), e.GetContentKeyRef())
-	if err != nil {
-		return
-	}
-	keyRef := stored.WrappingKeyRef
-	if keyRef == "" {
-		keyRef = kms.LegacyUserKeyRef(e.GetUserId())
-	}
-	key, err := p.keyWrapper.UnwrapContentKey(context.Background(), keyRef, kms.WrappedContentKey{
-		EncryptedContentKey: stored.EncryptedContentKey,
-		Nonce:               stored.ContentKeyNonce,
-		Algorithm:           stored.WrappingAlgorithm,
-		Metadata:            stored.WrappingMetadata,
-	}, userDEKAAD(e.GetUserId(), e.GetPurpose(), e.GetEpoch()))
-	if err != nil {
-		return
-	}
-	byPurpose := p.contentKeys[e.GetUserId()]
+	byPurpose := p.dekEvents[e.GetUserId()]
 	if byPurpose == nil {
-		byPurpose = make(map[corev1.UserDEKPurpose]map[int32][]byte)
-		p.contentKeys[e.GetUserId()] = byPurpose
+		byPurpose = make(map[corev1.UserDEKPurpose]map[int32]*corev1.UserDEKGeneratedEvent)
+		p.dekEvents[e.GetUserId()] = byPurpose
 	}
 	epochs := byPurpose[e.GetPurpose()]
 	if epochs == nil {
-		epochs = make(map[int32][]byte)
+		epochs = make(map[int32]*corev1.UserDEKGeneratedEvent)
 		byPurpose[e.GetPurpose()] = epochs
 	}
-	epochs[e.GetEpoch()] = append([]byte(nil), key...)
+	epochs[e.GetEpoch()] = proto.Clone(e).(*corev1.UserDEKGeneratedEvent)
 }
 
 func (p *MentionablesProjection) applyUserAccountCreated(eventID string, e *corev1.UserAccountCreatedEvent) {
@@ -151,7 +141,7 @@ func (p *MentionablesProjection) applyUserKeyShredded(e *corev1.UserKeyShreddedE
 	if e == nil || e.GetUserId() == "" {
 		return
 	}
-	delete(p.contentKeys, e.GetUserId())
+	delete(p.dekEvents, e.GetUserId())
 }
 
 func (p *MentionablesProjection) setUserLogin(userID, login string) {
@@ -202,18 +192,22 @@ func (p *MentionablesProjection) userPIIString(eventID, userID, eventType, purpo
 	if encrypted == nil {
 		return "", false
 	}
-	byPurpose := p.contentKeys[userID]
+	byPurpose := p.dekEvents[userID]
 	if byPurpose == nil {
 		return "", false
 	}
-	key := byPurpose[corev1.UserDEKPurpose_USER_DEK_PURPOSE_USER_PII][encrypted.GetContentKeyEpoch()]
-	if len(key) == 0 {
-		key = byPurpose[corev1.UserDEKPurpose_USER_DEK_PURPOSE_UNSPECIFIED][encrypted.GetContentKeyEpoch()]
+	event := byPurpose[corev1.UserDEKPurpose_USER_DEK_PURPOSE_USER_PII][encrypted.GetContentKeyEpoch()]
+	if event == nil {
+		event = byPurpose[corev1.UserDEKPurpose_USER_DEK_PURPOSE_UNSPECIFIED][encrypted.GetContentKeyEpoch()]
 	}
-	if len(key) == 0 {
+	if event == nil || p.dekResolver == nil {
 		return "", false
 	}
-	plaintext, err := decryptUserPIIString(key, eventID, userID, eventType, purpose, encrypted)
+	dek, err := p.dekResolver.Resolve(context.Background(), event, corev1.UserDEKPurpose_USER_DEK_PURPOSE_USER_PII)
+	if err != nil || dek == nil || len(dek.key) == 0 {
+		return "", false
+	}
+	plaintext, err := decryptUserPIIString(dek.key, eventID, userID, eventType, purpose, encrypted)
 	if err != nil {
 		if errors.Is(err, encryption.ErrDecryptionFailed) || errors.Is(err, encryption.ErrKeyNotFound) {
 			return "", false

--- a/cli/internal/core/message_body_benchmark_test.go
+++ b/cli/internal/core/message_body_benchmark_test.go
@@ -1,0 +1,116 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var benchmarkHydratedBodyBytes int
+
+// messageBodyBenchmarkPage is the projected hot-read fixture for one room
+// timeline page. It benchmarks decryption from projection state rather than
+// message publishing, authorization, or transport mapping.
+type messageBodyBenchmarkPage struct {
+	core     *ChattoCore
+	eventIDs []string
+}
+
+// BenchmarkGetFullMessageBodyByEventID_DEKCache measures timeline body
+// hydration with a request-scoped DEK cache compared to no request cache, which
+// approximates the old per-message unwrap behavior.
+func BenchmarkGetFullMessageBodyByEventID_DEKCache(b *testing.B) {
+	runMessageBodyPageBenchmark(b, "same_author_page_50", 1, 50)
+	runMessageBodyPageBenchmark(b, "five_authors_page_50", 5, 50)
+}
+
+func runMessageBodyPageBenchmark(b *testing.B, name string, authorCount, messageCount int) {
+	b.Helper()
+	page := setupMessageBodyBenchmarkPage(b, authorCount, messageCount)
+	wrapper := &countingKeyWrapper{KeyWrapper: page.core.encryption.keyWrapper}
+	page.core.dekResolver.keyWrapper = wrapper
+
+	b.Run(name+"/request_cache_page", func(b *testing.B) {
+		wrapper.unwraps.Store(0)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		total := 0
+		for i := 0; i < b.N; i++ {
+			total += readBenchmarkPage(b, WithDEKRequestCache(context.Background()), page)
+		}
+		b.StopTimer()
+
+		benchmarkHydratedBodyBytes = total
+		b.ReportMetric(float64(wrapper.unwraps.Load())/float64(b.N), "unwraps/op")
+	})
+
+	b.Run(name+"/no_request_cache", func(b *testing.B) {
+		wrapper.unwraps.Store(0)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		total := 0
+		for i := 0; i < b.N; i++ {
+			total += readBenchmarkPage(b, context.Background(), page)
+		}
+		b.StopTimer()
+
+		benchmarkHydratedBodyBytes = total
+		b.ReportMetric(float64(wrapper.unwraps.Load())/float64(b.N), "unwraps/op")
+	})
+}
+
+func setupMessageBodyBenchmarkPage(b *testing.B, authorCount, messageCount int) messageBodyBenchmarkPage {
+	b.Helper()
+	core := setupTestCoreWithEncryption(b)
+	ctx := context.Background()
+
+	authors := make([]string, 0, authorCount)
+	for i := 0; i < authorCount; i++ {
+		user, err := core.CreateUser(ctx, "system", fmt.Sprintf("benchuser%d", i), fmt.Sprintf("Bench User %d", i), "password123")
+		require.NoError(b, err)
+		authors = append(authors, user.Id)
+	}
+
+	room, err := core.CreateRoom(ctx, authors[0], KindChannel, "", "Bench", "Benchmark room")
+	require.NoError(b, err)
+	for _, authorID := range authors {
+		_, err := core.JoinRoom(ctx, authorID, KindChannel, authorID, room.Id)
+		require.NoError(b, err)
+	}
+
+	body := strings.Repeat("message body content ", 8)
+	eventIDs := make([]string, 0, messageCount)
+	for i := 0; i < messageCount; i++ {
+		authorID := authors[i%len(authors)]
+		event, err := core.PostMessage(ctx, KindChannel, room.Id, authorID, body, nil, "", "", nil, false)
+		require.NoError(b, err)
+		eventIDs = append(eventIDs, event.Id)
+	}
+
+	return messageBodyBenchmarkPage{
+		core:     core,
+		eventIDs: eventIDs,
+	}
+}
+
+func readBenchmarkPage(b *testing.B, ctx context.Context, page messageBodyBenchmarkPage) int {
+	b.Helper()
+	total := 0
+	for _, eventID := range page.eventIDs {
+		total += readBenchmarkBody(b, ctx, page.core, eventID)
+	}
+	return total
+}
+
+func readBenchmarkBody(b *testing.B, ctx context.Context, core *ChattoCore, eventID string) int {
+	b.Helper()
+	body, err := core.GetFullMessageBodyByEventID(ctx, eventID)
+	require.NoError(b, err)
+	require.NotNil(b, body)
+	return len(body.Body)
+}

--- a/cli/internal/core/message_crypto.go
+++ b/cli/internal/core/message_crypto.go
@@ -8,7 +8,6 @@ import (
 
 	"hmans.de/chatto/internal/encryption"
 	"hmans.de/chatto/internal/events"
-	"hmans.de/chatto/internal/kms"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
@@ -86,43 +85,10 @@ func (c *ChattoCore) unwrapMessageContentKey(ctx context.Context, event *corev1.
 }
 
 func (c *ChattoCore) unwrapUserDEK(ctx context.Context, event *corev1.UserDEKGeneratedEvent, purpose corev1.UserDEKPurpose) (*userDEK, error) {
-	if event == nil {
-		return nil, fmt.Errorf("DEK event is nil")
-	}
-	userID := event.GetUserId()
-	epoch := event.GetEpoch()
-	contentKeyRef := event.GetContentKeyRef()
-	if userID == "" || epoch <= 0 || contentKeyRef == "" {
-		return nil, fmt.Errorf("invalid DEK event")
-	}
-	eventPurpose := event.GetPurpose()
-	if eventPurpose != corev1.UserDEKPurpose_USER_DEK_PURPOSE_UNSPECIFIED && purpose != corev1.UserDEKPurpose_USER_DEK_PURPOSE_UNSPECIFIED && eventPurpose != purpose {
-		return nil, fmt.Errorf("DEK purpose mismatch: event has %s, want %s", eventPurpose.String(), purpose.String())
-	}
-	if c.encryption.keyWrapper == nil {
+	if c.dekResolver == nil {
 		return nil, encryption.ErrKeyNotFound
 	}
-	if c.encryption.contentKeys == nil {
-		return nil, encryption.ErrKeyNotFound
-	}
-	stored, err := c.encryption.contentKeys.Get(ctx, contentKeyRef)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load DEK: %w", err)
-	}
-	keyRef := stored.WrappingKeyRef
-	if keyRef == "" {
-		keyRef = kms.LegacyUserKeyRef(userID)
-	}
-	key, err := c.encryption.keyWrapper.UnwrapContentKey(ctx, keyRef, kms.WrappedContentKey{
-		EncryptedContentKey: stored.EncryptedContentKey,
-		Nonce:               stored.ContentKeyNonce,
-		Algorithm:           stored.WrappingAlgorithm,
-		Metadata:            stored.WrappingMetadata,
-	}, userDEKAAD(userID, eventPurpose, epoch))
-	if err != nil {
-		return nil, fmt.Errorf("failed to unwrap DEK: %w", err)
-	}
-	return &userDEK{epoch: epoch, purpose: eventPurpose, key: key}, nil
+	return c.dekResolver.Resolve(ctx, event, purpose)
 }
 
 func (c *ChattoCore) generateInitialUserDEK(ctx context.Context, userID string, purpose corev1.UserDEKPurpose) (*userDEK, error) {

--- a/cli/internal/core/unwrapped_dek_resolver.go
+++ b/cli/internal/core/unwrapped_dek_resolver.go
@@ -1,0 +1,218 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"hmans.de/chatto/internal/dekstore"
+	"hmans.de/chatto/internal/encryption"
+	"hmans.de/chatto/internal/kms"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+type unwrappedDEKCacheKey struct {
+	userID        string
+	purpose       corev1.UserDEKPurpose
+	epoch         int32
+	contentKeyRef string
+}
+
+type unwrappedDEKRequestCacheKey struct{}
+
+type unwrappedDEKRequestCache struct {
+	mu              sync.Mutex
+	values          map[unwrappedDEKCacheKey][]byte
+	inFlight        map[unwrappedDEKCacheKey]*unwrappedDEKRequestCacheCall
+	userGenerations map[string]uint64
+}
+
+type unwrappedDEKRequestCacheCall struct {
+	done           chan struct{}
+	userGeneration uint64
+	key            []byte
+	err            error
+}
+
+// WithDEKRequestCache returns a child context that caches unwrapped DEKs for
+// one request or batch operation. The cache is intentionally not process-wide:
+// once a DEK record has been physically shredded from the shared store, later
+// requests fail closed instead of using a stale in-memory key.
+func WithDEKRequestCache(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := dekRequestCache(ctx); ok {
+		return ctx
+	}
+	return context.WithValue(ctx, unwrappedDEKRequestCacheKey{}, &unwrappedDEKRequestCache{
+		values:          make(map[unwrappedDEKCacheKey][]byte),
+		inFlight:        make(map[unwrappedDEKCacheKey]*unwrappedDEKRequestCacheCall),
+		userGenerations: make(map[string]uint64),
+	})
+}
+
+func dekRequestCache(ctx context.Context) (*unwrappedDEKRequestCache, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	cache, ok := ctx.Value(unwrappedDEKRequestCacheKey{}).(*unwrappedDEKRequestCache)
+	return cache, ok && cache != nil
+}
+
+func forgetDEKRequestCacheUser(ctx context.Context, userID string) {
+	cache, ok := dekRequestCache(ctx)
+	if !ok || userID == "" {
+		return
+	}
+	cache.forgetUser(userID)
+}
+
+// unwrappedDEKResolver unwraps user DEKs from the shared DEK store. It owns no
+// long-lived plaintext key cache; callers that hydrate multiple bodies in one
+// request can opt into WithDEKRequestCache for request-scoped reuse.
+type unwrappedDEKResolver struct {
+	keyWrapper kms.KeyWrapper
+	dekStore   dekstore.Reader
+}
+
+// newUnwrappedDEKResolver creates a resolver backed by the configured KMS
+// wrapper and Chatto-owned DEK record store.
+func newUnwrappedDEKResolver(keyWrapper kms.KeyWrapper, dekStore dekstore.Reader) *unwrappedDEKResolver {
+	return &unwrappedDEKResolver{
+		keyWrapper: keyWrapper,
+		dekStore:   dekStore,
+	}
+}
+
+// Resolve returns a cloned unwrapped DEK for the supplied persisted DEK event.
+// The requested purpose is checked against the event purpose, while legacy
+// unspecified-purpose DEKs remain accepted for historical payloads. Cache hits
+// are limited to an optional request cache carried by ctx.
+func (r *unwrappedDEKResolver) Resolve(ctx context.Context, event *corev1.UserDEKGeneratedEvent, purpose corev1.UserDEKPurpose) (*userDEK, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if event == nil {
+		return nil, fmt.Errorf("DEK event is nil")
+	}
+	userID := event.GetUserId()
+	epoch := event.GetEpoch()
+	contentKeyRef := event.GetContentKeyRef()
+	if userID == "" || epoch <= 0 || contentKeyRef == "" {
+		return nil, fmt.Errorf("invalid DEK event")
+	}
+	eventPurpose := event.GetPurpose()
+	if eventPurpose != corev1.UserDEKPurpose_USER_DEK_PURPOSE_UNSPECIFIED && purpose != corev1.UserDEKPurpose_USER_DEK_PURPOSE_UNSPECIFIED && eventPurpose != purpose {
+		return nil, fmt.Errorf("DEK purpose mismatch: event has %s, want %s", eventPurpose.String(), purpose.String())
+	}
+	if r == nil || r.keyWrapper == nil || r.dekStore == nil {
+		return nil, encryption.ErrKeyNotFound
+	}
+
+	cacheKey := unwrappedDEKCacheKey{
+		userID:        userID,
+		purpose:       eventPurpose,
+		epoch:         epoch,
+		contentKeyRef: contentKeyRef,
+	}
+	if requestCache, ok := dekRequestCache(ctx); ok {
+		return requestCache.resolve(ctx, cacheKey, func() ([]byte, error) {
+			return r.unwrap(ctx, event, eventPurpose)
+		})
+	}
+
+	key, err := r.unwrap(ctx, event, eventPurpose)
+	if err != nil {
+		return nil, err
+	}
+	return &userDEK{epoch: epoch, purpose: eventPurpose, key: append([]byte(nil), key...)}, nil
+}
+
+func (c *unwrappedDEKRequestCache) resolve(ctx context.Context, cacheKey unwrappedDEKCacheKey, unwrap func() ([]byte, error)) (*userDEK, error) {
+	c.mu.Lock()
+	value := c.values[cacheKey]
+	if len(value) != 0 {
+		c.mu.Unlock()
+		return cachedUserDEK(cacheKey, value), nil
+	}
+	if call := c.inFlight[cacheKey]; call != nil {
+		done := call.done
+		c.mu.Unlock()
+		select {
+		case <-done:
+			if call.err != nil {
+				return nil, call.err
+			}
+			return cachedUserDEK(cacheKey, call.key), nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	call := &unwrappedDEKRequestCacheCall{
+		done:           make(chan struct{}),
+		userGeneration: c.userGenerations[cacheKey.userID],
+	}
+	c.inFlight[cacheKey] = call
+	c.mu.Unlock()
+
+	key, err := unwrap()
+
+	c.mu.Lock()
+	if err == nil {
+		if c.userGenerations[cacheKey.userID] == call.userGeneration {
+			call.key = append([]byte(nil), key...)
+			c.values[cacheKey] = append([]byte(nil), key...)
+		} else {
+			err = encryption.ErrKeyNotFound
+		}
+	}
+	call.err = err
+	if c.inFlight[cacheKey] == call {
+		delete(c.inFlight, cacheKey)
+	}
+	close(call.done)
+	c.mu.Unlock()
+
+	if err != nil {
+		return nil, err
+	}
+	return cachedUserDEK(cacheKey, key), nil
+}
+
+func (c *unwrappedDEKRequestCache) forgetUser(userID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.userGenerations[userID]++
+	for key := range c.values {
+		if key.userID == userID {
+			delete(c.values, key)
+		}
+	}
+}
+
+func cachedUserDEK(cacheKey unwrappedDEKCacheKey, key []byte) *userDEK {
+	return &userDEK{epoch: cacheKey.epoch, purpose: cacheKey.purpose, key: append([]byte(nil), key...)}
+}
+
+func (r *unwrappedDEKResolver) unwrap(ctx context.Context, event *corev1.UserDEKGeneratedEvent, eventPurpose corev1.UserDEKPurpose) ([]byte, error) {
+	stored, err := r.dekStore.Get(ctx, event.GetContentKeyRef())
+	if err != nil {
+		return nil, fmt.Errorf("failed to load DEK: %w", err)
+	}
+	keyRef := stored.WrappingKeyRef
+	if keyRef == "" {
+		keyRef = kms.LegacyUserKeyRef(event.GetUserId())
+	}
+	key, err := r.keyWrapper.UnwrapContentKey(ctx, keyRef, kms.WrappedContentKey{
+		EncryptedContentKey: stored.EncryptedContentKey,
+		Nonce:               stored.ContentKeyNonce,
+		Algorithm:           stored.WrappingAlgorithm,
+		Metadata:            stored.WrappingMetadata,
+	}, userDEKAAD(event.GetUserId(), eventPurpose, event.GetEpoch()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to unwrap DEK: %w", err)
+	}
+	return key, nil
+}

--- a/cli/internal/core/user_projection.go
+++ b/cli/internal/core/user_projection.go
@@ -26,9 +26,8 @@ type UserProjection struct {
 	emailIndex    map[string]string
 	identityIndex map[string]string
 	eventIDSeen   eventIDSet
-	keyWrapper    kms.KeyWrapper
-	dekStore      dekstore.Reader
-	contentKeys   map[string]map[corev1.UserDEKPurpose]map[int32][]byte
+	dekResolver   *unwrappedDEKResolver
+	dekEvents     map[string]map[corev1.UserDEKPurpose]map[int32]*corev1.UserDEKGeneratedEvent
 }
 
 type projectedUser struct {
@@ -44,16 +43,22 @@ type projectedUser struct {
 	loginChanged   time.Time
 }
 
+// NewUserProjection creates the user/account read model. It owns user-facing
+// projected state, while unwrapped DEK bytes are delegated to a resolver so
+// user PII and message-body reads share one cache and shred path.
 func NewUserProjection(keyWrapper kms.KeyWrapper, dekStore dekstore.Reader) *UserProjection {
+	return newUserProjectionWithDEKResolver(newUnwrappedDEKResolver(keyWrapper, dekStore))
+}
+
+func newUserProjectionWithDEKResolver(dekResolver *unwrappedDEKResolver) *UserProjection {
 	return &UserProjection{
 		users:         make(map[string]*projectedUser),
 		loginIndex:    make(map[string]string),
 		emailIndex:    make(map[string]string),
 		identityIndex: make(map[string]string),
 		eventIDSeen:   newEventIDSet(),
-		keyWrapper:    keyWrapper,
-		dekStore:      dekStore,
-		contentKeys:   make(map[string]map[corev1.UserDEKPurpose]map[int32][]byte),
+		dekResolver:   dekResolver,
+		dekEvents:     make(map[string]map[corev1.UserDEKPurpose]map[int32]*corev1.UserDEKGeneratedEvent),
 	}
 }
 
@@ -132,38 +137,21 @@ func (p *UserProjection) ensureUserLocked(userID string) *projectedUser {
 }
 
 func (p *UserProjection) applyDEKGenerated(e *corev1.UserDEKGeneratedEvent) {
-	if e == nil || e.GetUserId() == "" || e.GetEpoch() <= 0 || e.GetContentKeyRef() == "" || p.keyWrapper == nil || p.dekStore == nil {
+	if e == nil || e.GetUserId() == "" || e.GetEpoch() <= 0 || e.GetContentKeyRef() == "" {
 		return
 	}
 	purpose := e.GetPurpose()
-	stored, err := p.dekStore.Get(context.Background(), e.GetContentKeyRef())
-	if err != nil {
-		return
-	}
-	keyRef := stored.WrappingKeyRef
-	if keyRef == "" {
-		keyRef = kms.LegacyUserKeyRef(e.GetUserId())
-	}
-	key, err := p.keyWrapper.UnwrapContentKey(context.Background(), keyRef, kms.WrappedContentKey{
-		EncryptedContentKey: stored.EncryptedContentKey,
-		Nonce:               stored.ContentKeyNonce,
-		Algorithm:           stored.WrappingAlgorithm,
-		Metadata:            stored.WrappingMetadata,
-	}, userDEKAAD(e.GetUserId(), purpose, e.GetEpoch()))
-	if err != nil {
-		return
-	}
-	byPurpose := p.contentKeys[e.GetUserId()]
+	byPurpose := p.dekEvents[e.GetUserId()]
 	if byPurpose == nil {
-		byPurpose = make(map[corev1.UserDEKPurpose]map[int32][]byte)
-		p.contentKeys[e.GetUserId()] = byPurpose
+		byPurpose = make(map[corev1.UserDEKPurpose]map[int32]*corev1.UserDEKGeneratedEvent)
+		p.dekEvents[e.GetUserId()] = byPurpose
 	}
 	epochs := byPurpose[purpose]
 	if epochs == nil {
-		epochs = make(map[int32][]byte)
+		epochs = make(map[int32]*corev1.UserDEKGeneratedEvent)
 		byPurpose[purpose] = epochs
 	}
-	epochs[e.GetEpoch()] = append([]byte(nil), key...)
+	epochs[e.GetEpoch()] = proto.Clone(e).(*corev1.UserDEKGeneratedEvent)
 }
 
 func (p *UserProjection) applyAccountCreated(eventID string, e *corev1.UserAccountCreatedEvent, envelopeCreatedAt *timestamppb.Timestamp) {
@@ -410,14 +398,14 @@ func (p *UserProjection) applyAccountDeleted(e *corev1.UserAccountDeletedEvent, 
 	u.verifiedEmail = make(map[string]VerifiedEmail)
 	u.oauthConsent = make(map[string]struct{})
 	u.loginChanged = time.Time{}
-	delete(p.contentKeys, e.GetUserId())
+	delete(p.dekEvents, e.GetUserId())
 }
 
 func (p *UserProjection) applyKeyShredded(e *corev1.UserKeyShreddedEvent) {
 	if e == nil || e.GetUserId() == "" {
 		return
 	}
-	delete(p.contentKeys, e.GetUserId())
+	delete(p.dekEvents, e.GetUserId())
 	u := p.ensureUserLocked(e.GetUserId())
 	if u.user != nil && u.user.GetLogin() != "" {
 		delete(p.loginIndex, strings.ToLower(u.user.GetLogin()))
@@ -463,18 +451,22 @@ func (p *UserProjection) userPIIString(eventID, userID, eventType, purpose strin
 	if encrypted == nil {
 		return "", false
 	}
-	byPurpose := p.contentKeys[userID]
+	byPurpose := p.dekEvents[userID]
 	if byPurpose == nil {
 		return "", false
 	}
-	key := byPurpose[corev1.UserDEKPurpose_USER_DEK_PURPOSE_USER_PII][encrypted.GetContentKeyEpoch()]
-	if len(key) == 0 {
-		key = byPurpose[corev1.UserDEKPurpose_USER_DEK_PURPOSE_UNSPECIFIED][encrypted.GetContentKeyEpoch()]
+	event := byPurpose[corev1.UserDEKPurpose_USER_DEK_PURPOSE_USER_PII][encrypted.GetContentKeyEpoch()]
+	if event == nil {
+		event = byPurpose[corev1.UserDEKPurpose_USER_DEK_PURPOSE_UNSPECIFIED][encrypted.GetContentKeyEpoch()]
 	}
-	if len(key) == 0 {
+	if event == nil || p.dekResolver == nil {
 		return "", false
 	}
-	plaintext, err := decryptUserPIIString(key, eventID, userID, eventType, purpose, encrypted)
+	dek, err := p.dekResolver.Resolve(context.Background(), event, corev1.UserDEKPurpose_USER_DEK_PURPOSE_USER_PII)
+	if err != nil || dek == nil || len(dek.key) == 0 {
+		return "", false
+	}
+	plaintext, err := decryptUserPIIString(dek.key, eventID, userID, eventType, purpose, encrypted)
 	if err != nil {
 		if errors.Is(err, encryption.ErrDecryptionFailed) || errors.Is(err, encryption.ErrKeyNotFound) {
 			return "", false


### PR DESCRIPTION
This PR changes DEK reuse from projection/process-lifetime plaintext storage to a request-scoped unwrapped-DEK cache for hot message reads.
Timeline hydration now opts into that request cache, while later requests still reload from the shared DEK store and fail closed after physical crypto-shredding.
User and mentionable projections keep DEK event references instead of plaintext key bytes, and the official key-delete path clears any same-request cache entries.
It also adds focused tests, a benchmark for 50-message page hydration, and an AGENTS rule requiring concise documentation for public or important code.

Validation: `git diff --check`, `mise x -- go test ./internal/core -timeout 120s`, `mise x -- go test ./internal/connectapi -run 'Test(MessageServicePostMessageReturnsRenderableTimelineEvent|RoomTimelineService)' -timeout 120s`, `mise x -- go test -race ./internal/core -run 'TestUnwrappedDEKResolver_RequestCacheCollapsesConcurrentMisses' -timeout 60s`, and `mise x -- go test ./internal/core -run '^$' -bench '^BenchmarkGetFullMessageBodyByEventID_DEKCache$' -benchtime=200ms -count=3 -timeout 180s`.
