### PR TITLE
docs(adr): address ADR review drift

### DIFF
--- a/.agents/skills/adr-review/SKILL.md
+++ b/.agents/skills/adr-review/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: adr-review
+description: "Run a full review of all Architecture Decision Records for implementation drift, contradictions, stale decisions, missing supersession notes, weak rationale, and missing cross-references. Use when the user asks for an ADR review, ADR audit, stale ADR check, architecture decision consistency check, or wants to verify ADRs against the current codebase, feature/design records, architecture docs, glossary, or public API state."
+---
+
+# ADR Review
+
+Review ADRs as architectural records that must remain useful to future maintainers. An ADR review is an audit and recommendation pass, not a rewrite pass unless the user explicitly asks for edits.
+
+## Ground Rules
+
+- Read `docs/adr/INDEX.md` first.
+- Always audit the full ADR set.
+- Read individual ADR files according to the full-audit plan; read related ADRs together when they form a decision chain.
+- Treat reviews as propose-only by default: report findings and concrete proposed edits, but do not modify ADRs, related records, or other docs unless the user asks.
+- Use current code and docs as evidence. Do not mark an ADR stale only because a newer preference exists; show the contradiction, missing supersession, or drift.
+- Do not use partial file lists to decide what to review.
+- If editing is requested, also use the `adr` skill's update/supersede workflow.
+
+## Full ADR Audit
+
+1. Read `docs/adr/INDEX.md`.
+2. Group ADRs by topic so related decisions are checked together.
+3. Prioritize recent ADRs, superseded/superseding chains, and ADRs likely to affect current architecture:
+   - storage, data models, events, jobs, queues, caches, indexes, and projections
+   - public APIs, wire protocols, compatibility, and generated clients
+   - authorization, identity, tenancy, privacy, and encryption
+   - frontend/client architecture, localization, delivery, and deployment
+4. Audit in parallel with subagents when available; otherwise use local searches and read-only shell commands.
+5. Write a consolidated report rather than scattering findings across ADRs.
+6. Search for related feature records, design records, architecture docs, and user-facing docs that cite or should cite each ADR.
+7. Check the current implementation and relevant docs for every ADR topic.
+
+## Evidence Sources
+
+Use these sources according to the ADR topic. Adapt paths to the project if its documentation layout differs:
+
+- ADR inventory: `docs/adr/INDEX.md`
+- Related decision/feature records: `docs/fdr/`, `docs/rfc/`, `docs/design/`, `docs/features/`, or equivalent project-specific directories when present
+- Current architecture inventory: `docs/ARCHITECTURE.md`, `docs/architecture/`, or equivalent
+- Canonical vocabulary: `docs/GLOSSARY.md`, terminology docs, or domain model docs when present
+- Public APIs and protocols: API schemas, IDLs, OpenAPI specs, protobuf/Thrift/GraphQL schemas, REST/RPC route definitions, WebSocket protocols, and generated clients
+- Core implementation: service wiring, domain models, persistence code, background jobs, event handlers, migrations, and integration boundaries
+- Client implementation: frontend, mobile, SDK, CLI, or other consumer code affected by the decision
+- Deployment and operations: infrastructure config, runtime configuration, observability, backup/restore, and rollout docs
+- Existing repo rules: root `AGENTS.md` and path-specific `AGENTS.md` files when present
+
+## What To Check
+
+For every ADR, check:
+
+- **Existence and index:** file exists, index row points to the right file, title and date match.
+- **Decision clarity:** the Decision section states a concrete architectural choice, not only intent or background.
+- **Context currency:** the motivating problem still makes sense or is clearly historical.
+- **Implementation drift:** current code, schemas, generated APIs, runtime resources, deployment config, or client structure contradict the ADR.
+- **Supersession:** superseded ADRs are marked clearly, replacement ADRs reference the old decisions, and the index title makes supersession discoverable when appropriate.
+- **Consequences:** consequences name real tradeoffs, migration costs, compatibility constraints, operational effects, or maintenance burdens.
+- **Public compatibility:** storage, schemas, discovery, API, protocol, and mixed-version implications are explicit when relevant.
+- **Cross-references:** related feature/design records, architecture docs, and user-facing docs cite or align with the ADR where appropriate.
+- **Vocabulary:** terms match the project's glossary, domain model, and current product or architecture naming.
+- **Documentation drift:** architecture docs, docs website pages, related decision records, and feature docs do not describe a different current architecture.
+
+## Finding Categories
+
+Classify findings with one of these labels:
+
+- **Contradiction:** the ADR conflicts with current code or another active ADR.
+- **Stale:** the ADR describes old architecture without a supersession/update note.
+- **Missing Supersession:** a newer ADR or implementation replaced the decision, but the old ADR does not say so.
+- **Weak Decision:** the ADR does not record a concrete choice.
+- **Weak Consequences:** important tradeoffs, compatibility impact, or operational costs are omitted.
+- **Missing Cross-Reference:** related records or docs should cite or align with the ADR.
+- **Index Issue:** `docs/adr/INDEX.md` is missing, mislabeling, or mislinking an ADR.
+- **No Issue:** checked and no material update is needed.
+
+## Report Format
+
+Start with findings, ordered by severity. Use file links and concrete evidence.
+
+```markdown
+## Findings
+
+- **Contradiction:** [ADR-042](docs/adr/ADR-042-example-decision.md) says ...
+  Evidence: `src/...` now ...
+  Proposed fix: ...
+
+## Clean / Low-Risk ADRs
+
+- ADR-044: checked against the relevant implementation and docs; no material drift found.
+
+## Open Questions
+
+- ...
+
+## Proposed Edits
+
+- Update ADR-...
+- Add supersession note to ADR-...
+- Update related feature/design record references.
+```
+
+Keep the report concise. For large audits, include a summary table and save detailed notes in `.context/adr-review-YYYY-MM-DD.md` when useful for collaboration with other agents.
+
+## Applying Fixes
+
+Only apply fixes when the user asks.
+
+When applying fixes:
+
+1. Use the `adr` skill workflow for updating or superseding ADRs.
+2. Preserve ADR numbering and filenames unless creating a new ADR.
+3. Update `docs/adr/INDEX.md` if a title changes or a new ADR is added.
+4. Run a cross-reference sweep: scan related feature/design record indexes and update ADR reference lines when an ADR becomes relevant.
+5. Update architecture docs, glossary/terminology docs, or docs website pages only when the review finding requires it and the user approved edits.
+6. Run targeted verification for edited docs, such as markdown link checks or focused grep checks for references.

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -98,7 +98,7 @@ Chatto's RBAC model. Read top-to-bottom — terms build on each other.
 
 **Everyone** — Implicit virtual role (position 0) held by every authenticated user. Default-permission grants attach here.
 
-**Scope** — Tier at which a permission is configured: `server`, `group`, or `room`. Resolution: room > group > server (first explicit decision wins). See [`cli/AGENTS.md`](../cli/AGENTS.md).
+**Scope** — Tier at which a permission is configured: `server`, `group`, or `room`. For non-owners, all applicable user and role decisions across valid scopes contribute; any deny wins, otherwise any allow grants, otherwise the API treats the result as denied. See [`cli/AGENTS.md`](../cli/AGENTS.md).
 
 **User-level override** — Permission grant or deny attached directly to a user, not via a role. Outranks every role grant. Used for suspensions and ad-hoc grants.
 

--- a/docs/adr/ADR-001-nats-jetstream-as-primary-data-store.md
+++ b/docs/adr/ADR-001-nats-jetstream-as-primary-data-store.md
@@ -2,6 +2,12 @@
 
 **Date:** 2026-03-01
 
+**Update:** ADR-033, ADR-034, and ADR-036 changed the storage pattern inside
+NATS/JetStream. The foundational decision here still stands: Chatto uses
+NATS/JetStream, NATS object stores, and NATS Core rather than adding a separate
+database or broker. The current domain source of truth is now the `EVT` stream
+with in-memory projections; latest-value runtime state lives in `RUNTIME_STATE`.
+
 ## Context
 
 Chatto needs persistent storage for messages, user profiles, space/room configuration, memberships, permissions, and more. The conventional choice would be a relational database (PostgreSQL, SQLite) or a document store (MongoDB), paired with a separate pub/sub system for real-time event delivery.
@@ -12,10 +18,11 @@ However, Chatto's core goal is a single self-hosted executable with minimal oper
 
 Use NATS JetStream as the sole persistent data store. Specifically:
 
-- **KV buckets** (backed by JetStream streams) for current-state data: user profiles, space/room configuration, memberships, permissions, roles.
-- **Event streams** for ordered, append-only event logs: room messages, space events, instance events.
-- **Object store buckets** for binary assets: avatars, file attachments.
-- **Core NATS pub/sub** for ephemeral real-time signals: presence, typing indicators, live events.
+- **`EVT` JetStream stream** for durable domain facts: server configuration, users, rooms, memberships, RBAC, messages, threads, reactions, voice calls, assets, and safe auth/workflow audit facts.
+- **In-memory projections** rebuilt from `EVT` for current domain reads.
+- **KV buckets** for latest-value runtime, volatile, and key-management state: especially `RUNTIME_STATE`, `MEMORY_CACHE`, and `ENCRYPTION_KEYS`.
+- **Object store buckets** for binary assets, with S3 as the optional external backend.
+- **Core NATS pub/sub** for ephemeral real-time sync signals, currently under `live.sync.>`.
 
 No relational database, no ORM, no SQL migrations.
 
@@ -23,8 +30,8 @@ No relational database, no ORM, no SQL migrations.
 
 - **Simpler deployment**: No database to provision, configure, or back up separately. NATS data lives on disk alongside the binary.
 - **Unified data and messaging**: The same system that stores messages also delivers them in real-time. No CDC, no polling, no sync layer.
-- **No ad-hoc queries**: KV is key-based lookup only. There's no `SELECT * FROM messages WHERE body LIKE '%search%'`. Full-text search requires a separate pluggable system.
-- **No joins**: Related data must be fetched with multiple KV gets or denormalized. API handlers and read models compose these lookups explicitly; complex cross-entity ad-hoc queries aren't practical.
-- **Backup is NATS-native**: `chatto backup` exports streams and KV buckets. Restoring means replaying into a fresh NATS instance.
+- **No ad-hoc queries**: NATS resources are not a relational query engine. Full-text search and analytics require dedicated projections or pluggable systems.
+- **No SQL joins**: Related data is assembled through projections and API response assemblers rather than database joins.
+- **Backup is NATS-native**: `chatto backup` exports streams, KV buckets, and object stores. Restoring means restoring NATS resources and replaying projections from `EVT`.
 - **Operational knowledge shifts**: Operators need to understand NATS streams, consumers, and KV semantics rather than SQL and database tuning.
 - **Scaling story is NATS-native**: Horizontal scaling means NATS clustering (JetStream Raft consensus), not database replicas.

--- a/docs/adr/ADR-002-single-binary-with-embedded-nats.md
+++ b/docs/adr/ADR-002-single-binary-with-embedded-nats.md
@@ -16,7 +16,7 @@ For advanced deployments, an external NATS cluster can be used instead — the a
 
 ## Consequences
 
-- **Single-command deployment**: `chatto serve` starts everything. No Docker Compose, no service orchestration required for basic use.
+- **Single-command deployment**: `chatto run` starts everything. No Docker Compose, no service orchestration required for basic use.
 - **Reduced failure modes**: No network calls between the app and its data store in single-node mode. Eliminates connection pool management, reconnection logic, and network partitions for the common case.
 - **Horizontal scaling is still possible**: Multiple Chatto instances can connect to an external NATS cluster. The embedded server is a convenience, not a constraint.
 - **Memory footprint includes NATS**: The process uses more memory than a thin web server, since it also runs the JetStream storage engine.

--- a/docs/adr/ADR-012-two-tier-realtime-events.md
+++ b/docs/adr/ADR-012-two-tier-realtime-events.md
@@ -2,11 +2,17 @@
 
 **Date:** 2026-03-01
 
-**Naming note:** This ADR refers to `space.{id}.>` and `live.space.{id}.>` subject patterns and the `StreamMySpaceEvents` fan-in function. After ADR-029 (Instance → Server rename), ADR-030 (Space tier retired), ADR-034 (EVT), and ADR-042 (protobuf-first public API), the live equivalents are `live.evt.>` for republished durable EVT facts, `live.sync.>` for transient `LiveEvent` signals, and realtime websocket delivery for the public app-session stream. `SERVER_EVENTS` no longer republishes to a live subject. The two-tier split itself (durable JetStream vs. transient NATS Core) and the per-event-type channel decision are unchanged.
+**Naming note:** This ADR refers to `space.{id}.>` and `live.space.{id}.>` subject patterns and the `StreamMySpaceEvents` fan-in function. After ADR-029 (Instance -> Server rename), ADR-030 (Space tier retired), ADR-034 (EVT), and ADR-042 (protobuf-first public API), the live equivalents are `live.evt.>` for republished durable EVT facts, `live.sync.>` for transient `LiveEvent` signals, and realtime websocket delivery for the public app-session stream. `SERVER_EVENTS` no longer republishes to a live subject. The two-tier split itself (durable JetStream vs. transient NATS Core) and the per-event-type channel decision are unchanged.
+
+**Update:** Reactions moved from the original live-only examples into durable
+room facts during the event-sourcing rollout. `ReactionAddedEvent` and
+`ReactionRemovedEvent` now live in `EVT` and reach clients through
+`live.evt.>` after projection readiness and authorization checks. See FDR-005,
+ADR-033, and ADR-034.
 
 ## Context
 
-Chatto's real-time events span a wide spectrum of persistence and frequency requirements. Messages, joins, and room lifecycle events must be durably stored and replayable. Typing indicators, reactions, presence changes, and message update notifications are ephemeral — they matter for the current moment but have no audit or replay value.
+Chatto's real-time events span a wide spectrum of persistence and frequency requirements. Messages, joins, room lifecycle events, reactions, and other durable room facts must be durably stored and replayable. Typing indicators, presence changes, and notification sync signals are ephemeral - they matter for the current moment but have no audit or replay value.
 
 Publishing all events to JetStream would waste storage on high-frequency transient signals. Using only bare NATS pub/sub would lose ordering guarantees and replay for messages.
 
@@ -14,8 +20,8 @@ Publishing all events to JetStream would waste storage on high-frequency transie
 
 Split events into two channels based on persistence:
 
-1. **JetStream events** (messages, joins, leaves, room lifecycle): Published to `space.{id}.>` subjects on a persisted per-space stream. Consumed via ordered JetStream consumers with replay support.
-2. **Live-only events** (reactions, typing indicators, presence, message updates/deletes): Published to `live.space.{id}.>` subjects via bare NATS Core pub/sub. Not stored. Consumed via plain NATS subscriptions.
+1. **JetStream events** (messages, joins, leaves, room lifecycle, reactions): Originally published to `space.{id}.>` subjects on a persisted per-space stream; currently published as durable `EVT` facts and exposed internally through `live.evt.>`.
+2. **Live-only events** (typing indicators, presence, notification sync, session/user/config invalidations): Originally published to `live.space.{id}.>` subjects via bare NATS Core pub/sub; currently published as `corev1.LiveEvent` messages under `live.sync.>`. Not stored. Consumed via plain NATS subscriptions.
 
 The realtime delivery layer merges durable and transient live channels, then maps authorized events into public protobuf live events for connected clients.
 
@@ -23,6 +29,6 @@ The realtime delivery layer merges durable and transient live channels, then map
 
 - **Efficient storage**: High-frequency transient events don't accumulate in JetStream streams. A busy space with constant typing indicators doesn't bloat its event stream.
 - **Appropriate delivery guarantees**: Messages get ordered, durable delivery. Typing indicators get fire-and-forget delivery, which is correct — a missed typing indicator is harmless.
-- **Fan-in complexity**: `StreamMySpaceEvents` must merge three async sources (JetStream consumer, two NATS Core subscriptions) into one output channel. This is the most complex goroutine in the codebase.
-- **Silent drops on missing registration**: Every new event type must be added to the type switch in `StreamMySpaceEvents` that extracts the room ID. If it's missing, the event is silently dropped with no error log. This is a known footgun documented in the live-events rules.
+- **Fan-in complexity**: The realtime delivery layer merges durable committed facts and transient sync signals into one authorized stream. The current `StreamMyEvents` path consumes `live.evt.>` and `live.sync.>` and maps both to public realtime protobuf frames.
+- **Delivery mapping must stay explicit**: Every new live event type must be registered in the current `StreamMyEvents` / realtime mapping path so delivery can extract its authorization scope and public protobuf shape. Missing mappings can still hide otherwise-valid events from clients, so live-event changes need tests at the delivery boundary.
 - **New event types require a channel decision**: When adding a new event type, developers must decide whether it belongs in JetStream (persistent, ordered) or NATS Core (ephemeral, best-effort). This is an explicit architectural choice, not a default.

--- a/docs/adr/ADR-023-hmac-signed-image-transform-urls.md
+++ b/docs/adr/ADR-023-hmac-signed-image-transform-urls.md
@@ -2,6 +2,13 @@
 
 **Date:** 2026-03-01
 
+**Update:** This ADR now describes the low-level HMAC transform-signing
+primitive, not the whole current browser-facing asset URL model. Attachment
+URLs later moved to stable `/assets/files/{assetId}` paths with signed per-user
+access tickets (ADR-032, ADR-039, FDR-008). Legacy
+`/assets/attachments/.../t/...` locator URLs still use this primitive for
+compatibility and internal fallback.
+
 ## Context
 
 Chatto serves user-uploaded images (avatars, attachments) and supports on-demand resizing and cropping. The transform parameters (width, height, crop mode) are specified in the URL. Without protection, any client could request arbitrarily large or unusual transformations, consuming server CPU and memory.
@@ -16,7 +23,9 @@ The options are:
 
 Use HMAC-SHA256-signed URL path components for image transform requests. The signed path encodes:
 
-1. The resource identifiers (space ID, asset ID)
+1. The resource identifiers that bind the signature to the transformed object
+   (for example, a stable asset ID plus the legacy locator or server-asset
+   resource namespace)
 2. The transform parameters as base64-encoded JSON
 3. An HMAC-SHA256 signature (truncated to 32 hex characters) computed over the combined path
 
@@ -28,5 +37,5 @@ The signature is appended after a dot separator in the URL path. The server veri
 - **Resource-specific signatures**: The HMAC covers the resource identity, so a signature for asset A cannot be reused for asset B. Changing any parameter invalidates the signature.
 - **No token storage**: Unlike API keys or session-based authorization, HMAC signatures are stateless. The server only needs the signing secret to verify any URL.
 - **Separate signing secret**: The image transform signing key is independent of the session cookie signing key. Compromising one doesn't compromise the other.
-- **Cache-friendly**: Signed URLs are deterministic — the same parameters always produce the same URL and signature. This makes CDN and browser caching effective.
+- **Cache-friendly**: Signed transform components are deterministic - the same resource binding and parameters produce the same signature. Browser-facing attachment URLs may still carry expiring access tickets, so those full URLs are not stable CDN keys.
 - **URL opacity**: The base64-encoded parameters make URLs opaque to humans. Debugging requires decoding the parameter blob, but this is a minor inconvenience.

--- a/docs/adr/ADR-031-room-group-centric-acl.md
+++ b/docs/adr/ADR-031-room-group-centric-acl.md
@@ -50,16 +50,22 @@ For **DM rooms**: room groups do not apply. Reading is membership-based, startin
 
 For **channel-room-scope** permissions in room R (belonging to group G):
 
-1. **User-level overrides**, in order: room R → group G → server (server only for permissions that carry both `ScopeServer` and `ScopeGroup` / `ScopeRoom`). First explicit decision wins.
-2. **Role walk**, highest rank first. For each role:
-   1. Room R's grant/deny for that role
-   2. Group G's grant/deny for that role
-   3. Server-scope grant/deny for that role (fallback, only for dual-scope perms)
-3. **Default deny** if no decision was reached.
+1. The resolver collects every applicable explicit decision for the user, their
+   assigned roles, and the implicit `everyone` role.
+2. Applicable scope inputs are server, group G, and room R when the permission is
+   valid at those scopes. Server-scope message and room permissions act as broad
+   defaults and broad restrictions; group and room decisions are local inputs to
+   the same check.
+3. ADR-040 defines the combination rule for non-owners: any applicable deny
+   blocks the permission; otherwise any applicable allow grants it; otherwise
+   the result is denied at the API boundary. Role position is display/order
+   metadata, not an authorization rank.
 
-A small revision from the original ADR text: server scope acts as the **global default** for channel-room perms. The walker checks group state first, room state on top of that, and falls back to server only when neither tier emits a decision. This gives operators a single "global default" they can adjust once and have apply everywhere, while still letting per-group and per-room edits override locally. DMs (which aren't in any group) resolve at server scope only.
-
-The earlier ADR text said "there is no cascade from server scope into channel-room scope." That was the initial intent; in practice it made DMs and operator-friendly defaults awkward, so we restored the cascade. ADR-040 later simplified the combination rule further: for non-owners, all applicable server/group/room decisions contribute, any deny wins, and any allow grants only when no deny applies.
+The earlier ADR text said "there is no cascade from server scope into
+channel-room scope" and later described a first-explicit-decision walker. Both
+were superseded by ADR-040's permission-only deny-wins model. The room-group
+container decision remains active: room groups are still the operator-facing
+place to configure permissions shared by a set of channel rooms.
 
 **The announcements pattern uses a room-scoped deny** against `everyone.message.post`. With deny-wins this blocks root posts for all non-owner users in that room, because every authenticated user carries `everyone`. The benefit over a server-level restriction is locality: the deny is scoped, audit-visible inside its room, and doesn't affect other rooms.
 

--- a/docs/adr/ADR-045-public-api-stability-tiers.md
+++ b/docs/adr/ADR-045-public-api-stability-tiers.md
@@ -24,7 +24,7 @@ question: which parts of the protobuf API carry which stability promise?
 
 ## Decision
 
-Chatto defines three public API stability tiers:
+Chatto defines four public API stability tiers:
 
 1. **Integration API**: `chatto.api.v1` ConnectRPC services and shared messages
    that represent coherent external-client behavior. This is the default home

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -16,7 +16,7 @@ For more about ADRs, see [Michael Nygard's article](https://cognitect.com/blog/2
 | [ADR-006](ADR-006-kv-source-of-truth-streams-audit-log.md) | KV as Source of Truth, Streams as Audit Logs | 2026-03-01 |
 | [ADR-007](ADR-007-per-user-encryption-with-crypto-shredding.md) | Per-User Encryption Keys with Crypto-Shredding for GDPR | 2026-03-01 |
 | [ADR-008](ADR-008-protobuf-for-event-serialization.md) | Protobuf for Event Serialization | 2026-03-01 |
-| [ADR-009](ADR-009-webhook-driven-voice-call-state.md) | Webhook-Driven Voice Call State | 2026-03-01 |
+| [ADR-009](ADR-009-webhook-driven-voice-call-state.md) | Durable LiveKit Call State | 2026-03-01 |
 | [ADR-010](ADR-010-svelte5-reactive-cache-whitelisting.md) | Svelte 5 Reactive Cache Whitelisting | 2026-03-01 |
 | [ADR-011](ADR-011-message-body-event-split.md) | Message Body / Event Split | 2026-03-01 |
 | [ADR-012](ADR-012-two-tier-realtime-events.md) | Two-Tier Real-Time Event System | 2026-03-01 |
@@ -36,11 +36,11 @@ For more about ADRs, see [Michael Nygard's article](https://cognitect.com/blog/2
 | [ADR-026](ADR-026-event-identity-via-nanoid.md) | Event Identity via NanoID, Not JetStream Sequence Numbers | 2026-03-26 |
 | [ADR-027](ADR-027-instance-space-server-consolidation.md) | Consolidate Instance + Space into a Single "Server" Concept | 2026-05-04 |
 | [ADR-028](ADR-028-event-id-keyed-read-state.md) | Event-ID-Keyed Read State | 2026-05-06 |
-| [ADR-029](ADR-029-instance-to-server-rename.md) | Rename `Instance` → `Server` Across the Codebase | 2026-05-11 |
+| [ADR-029](ADR-029-instance-to-server-rename.md) | Rename `Instance` → `Server` across the codebase | 2026-05-11 |
 | [ADR-030](ADR-030-space-tier-retirement.md) | Retire the Space tier | 2026-05-11 |
 | [ADR-031](ADR-031-room-group-centric-acl.md) | Room-Group-Centric ACL for Room-Scope Permissions | 2026-05-13 |
 | [ADR-032](ADR-032-signed-attachment-locator-urls.md) | Self-Describing Signed Attachment URLs | 2026-05-23 |
-| [ADR-033](ADR-033-event-sourced-state-with-projections.md) | Event-Sourced State with Derived Projections (supersedes ADR-006) | 2026-05-24 |
+| [ADR-033](ADR-033-event-sourced-state-with-projections.md) | Event-Sourced State with Derived Projections | 2026-05-24 |
 | [ADR-034](ADR-034-single-event-stream.md) | Single Event Stream with Event-Type Subject Lanes | 2026-05-24 |
 | [ADR-035](ADR-035-per-aggregate-phased-migration.md) | Per-Aggregate Phased Migration to Event Sourcing | 2026-05-24 |
 | [ADR-036](ADR-036-runtime-state-kv-boundary.md) | Persist Runtime State in RUNTIME_STATE | 2026-05-27 |


### PR DESCRIPTION
Adds an `adr-review` workflow skill for full ADR audits and updates stale ADR documentation found by that workflow.
The ADR changes align storage, realtime reactions, RBAC scope resolution, asset transform URLs, API tier counts, command naming, and index titles with the current implementation and architecture docs.
The glossary now matches ADR-040 deny-wins permission resolution.
Validation: `git diff --check`, ADR index/header consistency script, and targeted stale-phrase scans.
