### PR TITLE
fix(auth): reject empty-user runtime credentials

### DIFF
--- a/cli/internal/core/auth_codes.go
+++ b/cli/internal/core/auth_codes.go
@@ -76,6 +76,9 @@ func (c *ChattoCore) CreateAuthCode(ctx context.Context, userID, redirectURI, co
 // CreateAuthCodeForGeneration creates an OAuth authorization code for an
 // already-authenticated session that proved authGeneration.
 func (c *ChattoCore) CreateAuthCodeForGeneration(ctx context.Context, userID, redirectURI, codeChallenge, codeChallengeMethod string, authGeneration uint64) (string, error) {
+	if userID == "" {
+		return "", ErrAuthCodeNotFound
+	}
 	if codeChallengeMethod != "S256" {
 		return "", ErrAuthCodeInvalidMethod
 	}
@@ -139,6 +142,9 @@ func (c *ChattoCore) ExchangeAuthCode(ctx context.Context, code, codeVerifier, r
 	var codeData AuthCodeData
 	if err := json.Unmarshal(entry.Value(), &codeData); err != nil {
 		return "", "", fmt.Errorf("failed to unmarshal auth code: %w", err)
+	}
+	if codeData.UserID == "" {
+		return "", "", ErrAuthCodeNotFound
 	}
 
 	// Validate redirect_uri matches

--- a/cli/internal/core/auth_codes_test.go
+++ b/cli/internal/core/auth_codes_test.go
@@ -44,6 +44,16 @@ func TestChattoCore_CreateAuthCode(t *testing.T) {
 	assertRawRuntimeTokenKeyAbsent(t, core, authCodeKeyPrefix+code)
 }
 
+func TestChattoCore_CreateAuthCodeRejectsEmptyUser(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	challenge := GenerateCodeChallenge("verifier123")
+	if code, err := core.CreateAuthCodeForGeneration(ctx, "", "https://example.com/callback", challenge, "S256", 0); !errors.Is(err, ErrAuthCodeNotFound) {
+		t.Fatalf("CreateAuthCodeForGeneration err = %v, code = %q, want ErrAuthCodeNotFound", err, code)
+	}
+}
+
 func TestChattoCore_ExchangeAuthCode_HappyPath(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)

--- a/cli/internal/core/auth_tokens.go
+++ b/cli/internal/core/auth_tokens.go
@@ -218,6 +218,9 @@ func (c *ChattoCore) CreateAuthTokenWithSource(ctx context.Context, userID, sour
 // CreateAuthTokenWithSourceGeneration creates a bearer token for an
 // authentication that proved credentials against authGeneration.
 func (c *ChattoCore) CreateAuthTokenWithSourceGeneration(ctx context.Context, userID, source string, authGeneration uint64) (string, error) {
+	if userID == "" {
+		return "", ErrAuthTokenNotFound
+	}
 	if err := c.RequireAuthenticationAllowed(ctx, userID, authGeneration); err != nil {
 		if errors.Is(err, ErrAuthenticationRevoked) {
 			return "", ErrAuthTokenNotFound

--- a/cli/internal/core/auth_tokens_test.go
+++ b/cli/internal/core/auth_tokens_test.go
@@ -46,6 +46,15 @@ func TestChattoCore_CreateAuthToken(t *testing.T) {
 	assertRawRuntimeTokenKeyAbsent(t, core, authTokenKeyPrefix+token)
 }
 
+func TestChattoCore_CreateAuthTokenRejectsEmptyUser(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	if token, err := core.CreateAuthTokenWithSourceGeneration(ctx, "", "password_login", 0); !errors.Is(err, ErrAuthTokenNotFound) {
+		t.Fatalf("CreateAuthTokenWithSourceGeneration err = %v, token = %q, want ErrAuthTokenNotFound", err, token)
+	}
+}
+
 func TestChattoCore_BearerTokenFreshAuth(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
@@ -171,6 +180,34 @@ func TestChattoCore_LegacyFreshBearerTokenCanSatisfyExistingFreshWindow(t *testi
 
 	if err := core.RequireFreshAuthForBearerToken(ctx, token); err != nil {
 		t.Fatalf("RequireFreshAuthForBearerToken: %v", err)
+	}
+}
+
+func TestChattoCore_EmptyUserBearerTokenCannotSatisfyFreshAuth(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	token := NewAuthToken()
+	data, err := json.Marshal(AuthTokenData{
+		CreatedAt:       time.Now(),
+		AuthGeneration:  0,
+		FreshAuthAt:     time.Now(),
+		FreshAuthMethod: "password",
+		FreshAuthSource: "password_login",
+	})
+	if err != nil {
+		t.Fatalf("marshal token: %v", err)
+	}
+	key := core.authTokenKey(token)
+	if _, err := core.storage.runtimeStateKV.Create(ctx, key, data, jetstream.KeyTTL(core.authTokenTTL())); err != nil {
+		t.Fatalf("store token: %v", err)
+	}
+
+	if err := core.RequireFreshAuthForBearerToken(ctx, token); !errors.Is(err, ErrAuthTokenNotFound) {
+		t.Fatalf("RequireFreshAuthForBearerToken err = %v, want ErrAuthTokenNotFound", err)
+	}
+	if _, err := core.storage.runtimeStateKV.Get(ctx, key); !errors.Is(err, jetstream.ErrKeyNotFound) {
+		t.Fatalf("empty-user token should be deleted, get err = %v", err)
 	}
 }
 

--- a/cli/internal/core/cookie_sessions_test.go
+++ b/cli/internal/core/cookie_sessions_test.go
@@ -86,6 +86,15 @@ func TestChattoCore_CreateAndValidateCookieSession(t *testing.T) {
 	}
 }
 
+func TestChattoCore_CreateCookieSessionRejectsEmptyUser(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	if sessionID, _, err := core.CreateCookieSessionForGeneration(ctx, "", "password_login", 0); !errors.Is(err, ErrCookieSessionNotFound) {
+		t.Fatalf("CreateCookieSessionForGeneration err = %v, sessionID = %q, want ErrCookieSessionNotFound", err, sessionID)
+	}
+}
+
 func TestChattoCore_CookieSessionFreshAuth(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)

--- a/cli/internal/core/fresh_auth.go
+++ b/cli/internal/core/fresh_auth.go
@@ -92,6 +92,9 @@ func (d AuthTokenData) canSatisfyFreshAuth() bool {
 }
 
 func (c *ChattoCore) authTokenData(ctx context.Context, token string) (AuthTokenData, jetstream.KeyValueEntry, error) {
+	if token == "" {
+		return AuthTokenData{}, nil, ErrAuthTokenNotFound
+	}
 	key := c.authTokenKey(token)
 	entry, err := c.storage.runtimeStateKV.Get(ctx, key)
 	if err != nil {
@@ -103,9 +106,14 @@ func (c *ChattoCore) authTokenData(ctx context.Context, token string) (AuthToken
 
 	var tokenData AuthTokenData
 	if err := json.Unmarshal(entry.Value(), &tokenData); err != nil {
-		return AuthTokenData{}, nil, fmt.Errorf("failed to unmarshal auth token: %w", err)
+		_ = c.storage.runtimeStateKV.Delete(ctx, key)
+		return AuthTokenData{}, nil, ErrAuthTokenNotFound
 	}
 	if tokenData.presentationOrDefault() != AuthTokenPresentationBearer {
+		return AuthTokenData{}, nil, ErrAuthTokenNotFound
+	}
+	if tokenData.UserID == "" {
+		_ = c.storage.runtimeStateKV.Delete(ctx, key)
 		return AuthTokenData{}, nil, ErrAuthTokenNotFound
 	}
 	if _, err := c.ValidateRuntimeCredential(ctx, RuntimeCredential{

--- a/cli/internal/core/sessions.go
+++ b/cli/internal/core/sessions.go
@@ -73,6 +73,9 @@ func (c *ChattoCore) CreateCookieSessionForGenerationPreservingFreshAuth(ctx con
 }
 
 func (c *ChattoCore) createCookieSessionForGeneration(ctx context.Context, userID, source string, authGeneration uint64, freshAuthAt time.Time, freshAuthMethod, freshAuthSource string) (string, *corev1.CookieSession, error) {
+	if userID == "" {
+		return "", nil, ErrCookieSessionNotFound
+	}
 	if err := c.RequireAuthenticationAllowed(ctx, userID, authGeneration); err != nil {
 		if !errors.Is(err, ErrAuthenticationRevoked) {
 			return "", nil, err


### PR DESCRIPTION
Rejects empty-user runtime credentials at creation time for bearer tokens, cookie sessions, and OAuth authorization codes.
Hardens bearer fresh-auth record loading so empty handles, malformed JSON records, and empty-user bearer records fail closed and clean up where appropriate.
Adds focused regression coverage for empty-user credential/code issuance and malformed fresh-auth bearer records.
Verification: `mise test-cli`; targeted core, HTTP auth, and Connect fresh-auth suites.
