### PR TITLE
fix(docs): keep release note cards in grid lanes

### DIFF
--- a/apps/docs-website/src/components/release-notes/ReleaseFeatureCard.astro
+++ b/apps/docs-website/src/components/release-notes/ReleaseFeatureCard.astro
@@ -42,6 +42,7 @@ const {
     --release-lane-span: 2;
     grid-column: span 2;
     display: flex;
+    margin: 0;
     min-height: 13rem;
     flex-direction: column;
     padding: 1.15rem;
@@ -57,10 +58,10 @@ const {
   }
 
   .release-feature-card.size-large {
-    --release-lane-span: 4;
-    grid-column: span 4;
-    min-height: 15rem;
-    padding: 1.35rem;
+    --release-lane-span: 2;
+    grid-column: span 2;
+    min-height: 13rem;
+    border-color: color-mix(in srgb, var(--sl-color-accent), var(--sl-color-gray-5) 68%);
     background:
       linear-gradient(135deg, color-mix(in srgb, var(--sl-color-accent-low), transparent 58%), transparent 68%),
       var(--sl-color-gray-7);
@@ -74,7 +75,7 @@ const {
   }
 
   .release-feature-card.size-large h2 {
-    font-size: clamp(1.75rem, 5vw, 2.45rem);
+    font-size: clamp(1.45rem, 3vw, 1.7rem);
   }
 
   .release-feature-body {

--- a/apps/docs-website/src/components/release-notes/ReleaseFeatureGrid.astro
+++ b/apps/docs-website/src/components/release-notes/ReleaseFeatureGrid.astro
@@ -41,6 +41,8 @@
       const width = columnWidth * span + gap * (span - 1);
       item.style.width = `${width}px`;
       item.style.position = "absolute";
+      item.style.insetBlockStart = "0";
+      item.style.insetInlineStart = "0";
 
       const maxStart = columnCount - span;
       let bestStart = 0;
@@ -72,6 +74,8 @@
     for (const item of Array.from(grid.children)) {
       if (!(item instanceof HTMLElement)) continue;
       item.style.position = "";
+      item.style.insetBlockStart = "";
+      item.style.insetInlineStart = "";
       item.style.transform = "";
       item.style.width = "";
     }


### PR DESCRIPTION
## Summary
Keep large release note cards in the same grid lane footprint as the smaller cards while preserving visual emphasis with the gradient and accent border.

Fix the masonry fallback positioning by anchoring absolute-positioned cards to the grid origin and resetting card margins so Starlight prose spacing does not offset later cards.

## Verification
Ran `mise x -- pnpm --dir apps/docs-website build` and a local Playwright coordinate check for `/releases/0-4-0/`.
