### PR TITLE
perf(frontend): load room members in larger batches

### DIFF
--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
@@ -153,7 +153,7 @@ for simple list browsing.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `limit` | `int32` | Maximum number of items to return. Each RPC defines its default; the common maximum for public API list pages is 500. |
+| `limit` | `int32` | Maximum number of items to request. Each RPC defines its default and effective maximum; this shared request shape accepts values up to 500. |
 | `offset` | `int32` | Zero-based number of matching items to skip. |
 
 <a id="chatto-api-v1-LinkPreview"></a>

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
@@ -153,7 +153,7 @@ for simple list browsing.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `limit` | `int32` | Maximum number of items to return. Each RPC defines its default; the common maximum for public API list pages is 100. |
+| `limit` | `int32` | Maximum number of items to return. Each RPC defines its default; the common maximum for public API list pages is 500. |
 | `offset` | `int32` | Zero-based number of matching items to skip. |
 
 <a id="chatto-api-v1-LinkPreview"></a>

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -2985,7 +2985,7 @@ for simple list browsing.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `limit` | `int32` | Maximum number of items to return. Each RPC defines its default; the common maximum for public API list pages is 500. |
+| `limit` | `int32` | Maximum number of items to request. Each RPC defines its default and effective maximum; this shared request shape accepts values up to 500. |
 | `offset` | `int32` | Zero-based number of matching items to skip. |
 
 

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -2985,7 +2985,7 @@ for simple list browsing.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `limit` | `int32` | Maximum number of items to return. Each RPC defines its default; the common maximum for public API list pages is 100. |
+| `limit` | `int32` | Maximum number of items to return. Each RPC defines its default; the common maximum for public API list pages is 500. |
 | `offset` | `int32` | Zero-based number of matching items to skip. |
 
 

--- a/apps/frontend/src/lib/components/QuickSwitcher.svelte
+++ b/apps/frontend/src/lib/components/QuickSwitcher.svelte
@@ -11,6 +11,7 @@
   import { getGradientForName } from '$lib/utils/gradients';
   import { recentQuickSwitcher } from '$lib/state/recentQuickSwitcher.svelte';
   import { quickSwitcher } from '$lib/state/globals.svelte';
+  import { ROOM_MEMBERS_PAGE_SIZE } from '$lib/state/room/members.svelte';
   import * as m from '$lib/i18n/messages';
   import { toast } from '$lib/ui/toast';
   import { createRoomCommandAPI } from '@chatto/api-client/rooms';
@@ -95,9 +96,9 @@
         await Promise.all(
           rooms.map(async (room) => {
             if (room.kind === RoomKind.DM) {
-              const participants = (await members.listRoomMembers(room.id, '', 100, 0)).members.map(
-                avatarUser
-              );
+              const participants = (
+                await members.listRoomMembers(room.id, '', ROOM_MEMBERS_PAGE_SIZE, 0)
+              ).members.map(avatarUser);
               items.push({
                 kind: 'dm',
                 id: room.id,
@@ -394,7 +395,6 @@
     const url = itemUrl(item);
     if (url) {
       recentQuickSwitcher.record(url);
-      // eslint-disable-next-line svelte/no-navigation-without-resolve -- itemUrl() returns resolved app routes
       goto(url);
     }
   }

--- a/apps/frontend/src/lib/components/QuickSwitcher.svelte
+++ b/apps/frontend/src/lib/components/QuickSwitcher.svelte
@@ -395,6 +395,7 @@
     const url = itemUrl(item);
     if (url) {
       recentQuickSwitcher.record(url);
+      // eslint-disable-next-line svelte/no-navigation-without-resolve -- itemUrl() returns resolved app routes
       goto(url);
     }
   }

--- a/apps/frontend/src/lib/hooks/useRoomData.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useRoomData.svelte.ts
@@ -3,6 +3,7 @@ import { createMemberDirectoryAPI, type DirectoryMember } from '@chatto/api-clie
 import { createRoomDirectoryAPI, RoomKind } from '@chatto/api-client/roomDirectory';
 import { useActiveRoomLayoutUpdated } from '$lib/hooks/useEvent.svelte';
 import { useReconnectTrigger } from '$lib/hooks/useReconnectCallback.svelte';
+import { ROOM_MEMBERS_PAGE_SIZE } from '$lib/state/room/members.svelte';
 import { useConnection } from '$lib/state/server/connection.svelte';
 import { serverRegistry } from '$lib/state/server/registry.svelte';
 import { untrack } from 'svelte';
@@ -160,7 +161,7 @@ export function useRoomData(getProps: () => { roomId: string }) {
       bearerToken: currentConnection.bearerToken
     });
     api
-      .listRoomMembers(currentRoomId, '', 100, 0)
+      .listRoomMembers(currentRoomId, '', ROOM_MEMBERS_PAGE_SIZE, 0)
       .then((resp) => {
         if (dmLoadId.current !== thisLoadId) return;
         dmData = {

--- a/apps/frontend/src/lib/state/room/members.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/members.svelte.spec.ts
@@ -3,7 +3,7 @@ import type { EventEnvelope } from '$lib/eventBus.svelte';
 import { RoomEventKind } from '$lib/render/eventKinds';
 import { PresenceStatus } from '$lib/render/types';
 import type { MemberDirectoryAPI, MemberDirectoryPage } from '@chatto/api-client/memberDirectory';
-import { RoomMembersStore } from './members.svelte';
+import { ROOM_MEMBERS_PAGE_SIZE, RoomMembersStore } from './members.svelte';
 
 class FakeMemberDirectoryAPI {
   listRoomMembers: MemberDirectoryAPI['listRoomMembers'];
@@ -60,14 +60,29 @@ function createStore(results: Array<MemberDirectoryPage | Promise<MemberDirector
 
 describe('RoomMembersStore', () => {
   it('eagerly loads every room member page into the canonical member list', async () => {
-    const store = createStore([
+    const fakeAPI = new FakeMemberDirectoryAPI([
       pageResult([user('u1', 'alice')], true, 3),
       pageResult([user('u2', 'boris'), user('u3', 'cora')], false, 3)
     ]);
+    const store = new RoomMembersStore(fakeAPI);
 
     store.setRoom('room-1');
     await store.loadInitial();
 
+    expect(fakeAPI.listRoomMembers).toHaveBeenNthCalledWith(
+      1,
+      'room-1',
+      '',
+      ROOM_MEMBERS_PAGE_SIZE,
+      0
+    );
+    expect(fakeAPI.listRoomMembers).toHaveBeenNthCalledWith(
+      2,
+      'room-1',
+      '',
+      ROOM_MEMBERS_PAGE_SIZE,
+      1
+    );
     expect(store.members.map((member) => member.login)).toEqual(['alice', 'boris', 'cora']);
     expect(store.filteredMembers.map((member) => member.login)).toEqual(['alice', 'boris', 'cora']);
     expect(store.totalCount).toBe(3);

--- a/apps/frontend/src/lib/state/room/members.svelte.ts
+++ b/apps/frontend/src/lib/state/room/members.svelte.ts
@@ -12,7 +12,7 @@ import { RoomEventKind, roomEventKind } from '$lib/render/eventKinds';
 import type { ServerConnection } from '$lib/state/server/serverConnection.svelte';
 import type { CustomUserStatus } from '$lib/state/userProfiles.svelte';
 
-export const ROOM_MEMBERS_PAGE_SIZE = 100;
+export const ROOM_MEMBERS_PAGE_SIZE = 500;
 const MENTION_MEMBER_SEARCH_LIMIT = 10;
 const roomMemberInvalidatingEventKinds = new Set<RoomEventKind>([
   RoomEventKind.UserJoinedRoom,

--- a/apps/frontend/src/lib/state/server/rooms.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/rooms.svelte.spec.ts
@@ -7,6 +7,7 @@ import {
   type UserAvatarUserView
 } from '$lib/render/types';
 import { RoomEventKind } from '$lib/render/eventKinds';
+import { ROOM_MEMBERS_PAGE_SIZE } from '$lib/state/room/members.svelte';
 import {
   RoomDirectoryScope,
   RoomKind,
@@ -172,7 +173,12 @@ describe('RoomsStore - refresh', () => {
     await store.refresh();
 
     expect(roomDirectoryAPI.listRooms).toHaveBeenCalledWith(RoomDirectoryScope.ALL);
-    expect(memberDirectoryAPI.listRoomMembers).toHaveBeenCalledWith('dm-1', '', 100, 0);
+    expect(memberDirectoryAPI.listRoomMembers).toHaveBeenCalledWith(
+      'dm-1',
+      '',
+      ROOM_MEMBERS_PAGE_SIZE,
+      0
+    );
     expect(store.rooms).toMatchObject([
       {
         id: 'public',

--- a/apps/frontend/src/lib/state/server/rooms.svelte.ts
+++ b/apps/frontend/src/lib/state/server/rooms.svelte.ts
@@ -14,6 +14,7 @@ import type { ViewerState } from '@chatto/api-client/viewer';
 import type { NotificationLevelStore } from '$lib/state/server/notificationLevel.svelte';
 import type { RoomUnreadStore } from '$lib/state/server/roomUnread.svelte';
 import type { NotificationAPI } from '@chatto/api-client/notifications';
+import { ROOM_MEMBERS_PAGE_SIZE } from '$lib/state/room/members.svelte';
 
 export type RoomsListItem = {
   id: string;
@@ -172,9 +173,14 @@ export class RoomsStore {
           async (room) =>
             [
               room.id,
-              (await this.memberDirectoryAPI.listRoomMembers(room.id, '', 100, 0)).members.map(
-                avatarUserFromDirectoryMember
-              )
+              (
+                await this.memberDirectoryAPI.listRoomMembers(
+                  room.id,
+                  '',
+                  ROOM_MEMBERS_PAGE_SIZE,
+                  0
+                )
+              ).members.map(avatarUserFromDirectoryMember)
             ] as const
         )
       )

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { tick } from 'svelte';
 import { q } from '$lib/test-utils';
-import type { RoomMember } from '$lib/state/room';
+import { ROOM_MEMBERS_PAGE_SIZE, type RoomMember } from '$lib/state/room/members.svelte';
 import type { PresenceCache } from '$lib/state/presenceCache.svelte';
 import type { RoomData } from '$lib/hooks/useRoomData.svelte';
 import { PresenceStatus } from '$lib/render/types';
@@ -408,8 +408,18 @@ describe('RoomSidebar', () => {
 
     await expect.element(q(container, 'h1')).toHaveTextContent('Members (142)');
     await vi.waitFor(() => {
-      expect(memberDirectoryMocks.listRoomMembers).toHaveBeenCalledWith('room-1', '', 100, 0);
-      expect(memberDirectoryMocks.listRoomMembers).toHaveBeenCalledWith('room-1', '', 100, 100);
+      expect(memberDirectoryMocks.listRoomMembers).toHaveBeenCalledWith(
+        'room-1',
+        '',
+        ROOM_MEMBERS_PAGE_SIZE,
+        0
+      );
+      expect(memberDirectoryMocks.listRoomMembers).toHaveBeenCalledWith(
+        'room-1',
+        '',
+        ROOM_MEMBERS_PAGE_SIZE,
+        100
+      );
     });
 
     await vi.waitFor(() => {

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -3146,6 +3146,22 @@ func TestMemberDirectoryServiceListRoomMembersRequiresMembership(t *testing.T) {
 	}
 }
 
+func TestMemberDirectoryOversizedPagesClampTo500(t *testing.T) {
+	limit, offset := apiPagination(&apiv1.PageRequest{Limit: 9999}, defaultMemberDirectoryLimit, maxMemberDirectoryLimit)
+	if limit != 500 || offset != 0 {
+		t.Fatalf("apiPagination limit, offset = %d, %d; want 500, 0", limit, offset)
+	}
+
+	users := make([]*corev1.User, 501)
+	for i := range users {
+		users[i] = &corev1.User{Id: fmt.Sprintf("user-%03d", i)}
+	}
+	page, totalCount, hasMore := paginateDirectoryUsers(users, limit, offset)
+	if len(page) != 500 || totalCount != 501 || !hasMore {
+		t.Fatalf("paginated users len, total, hasMore = %d, %d, %v; want 500, 501, true", len(page), totalCount, hasMore)
+	}
+}
+
 func TestAccountServiceSetAndClearCustomStatus(t *testing.T) {
 	env := newConnectAPITestEnv(t)
 	ctx := withCaller(env.ctx, env.viewer)

--- a/cli/internal/connectapi/member_directory.go
+++ b/cli/internal/connectapi/member_directory.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	defaultMemberDirectoryLimit = 20
-	maxMemberDirectoryLimit     = 100
+	maxMemberDirectoryLimit     = 500
 )
 
 type memberDirectoryService struct {

--- a/cli/internal/pb/chatto/api/v1/pagination.pb.go
+++ b/cli/internal/pb/chatto/api/v1/pagination.pb.go
@@ -26,8 +26,8 @@ const (
 // for simple list browsing.
 type PageRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Maximum number of items to return. Each RPC defines its default; the common
-	// maximum for public API list pages is 500.
+	// Maximum number of items to request. Each RPC defines its default and
+	// effective maximum; this shared request shape accepts values up to 500.
 	Limit int32 `protobuf:"varint,1,opt,name=limit,proto3" json:"limit,omitempty"`
 	// Zero-based number of matching items to skip.
 	Offset        int32 `protobuf:"varint,2,opt,name=offset,proto3" json:"offset,omitempty"`

--- a/cli/internal/pb/chatto/api/v1/pagination.pb.go
+++ b/cli/internal/pb/chatto/api/v1/pagination.pb.go
@@ -27,7 +27,7 @@ const (
 type PageRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Maximum number of items to return. Each RPC defines its default; the common
-	// maximum for public API list pages is 100.
+	// maximum for public API list pages is 500.
 	Limit int32 `protobuf:"varint,1,opt,name=limit,proto3" json:"limit,omitempty"`
 	// Zero-based number of matching items to skip.
 	Offset        int32 `protobuf:"varint,2,opt,name=offset,proto3" json:"offset,omitempty"`
@@ -138,9 +138,10 @@ var File_chatto_api_v1_pagination_proto protoreflect.FileDescriptor
 
 const file_chatto_api_v1_pagination_proto_rawDesc = "" +
 	"\n" +
-	"\x1echatto/api/v1/pagination.proto\x12\rchatto.api.v1\x1a\x1bbuf/validate/validate.proto\"O\n" +
-	"\vPageRequest\x12\x1f\n" +
-	"\x05limit\x18\x01 \x01(\x05B\t\xbaH\x06\x1a\x04\x18d(\x00R\x05limit\x12\x1f\n" +
+	"\x1echatto/api/v1/pagination.proto\x12\rchatto.api.v1\x1a\x1bbuf/validate/validate.proto\"P\n" +
+	"\vPageRequest\x12 \n" +
+	"\x05limit\x18\x01 \x01(\x05B\n" +
+	"\xbaH\a\x1a\x05\x18\xf4\x03(\x00R\x05limit\x12\x1f\n" +
 	"\x06offset\x18\x02 \x01(\x05B\a\xbaH\x04\x1a\x02(\x00R\x06offset\"F\n" +
 	"\bPageInfo\x12\x1f\n" +
 	"\vtotal_count\x18\x01 \x01(\x03R\n" +

--- a/packages/api-types/src/chatto/api/v1/pagination_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/pagination_pb.ts
@@ -14,8 +14,8 @@ import { Message, proto3, protoInt64 } from "@bufbuild/protobuf";
  */
 export class PageRequest extends Message<PageRequest> {
   /**
-   * Maximum number of items to return. Each RPC defines its default; the common
-   * maximum for public API list pages is 500.
+   * Maximum number of items to request. Each RPC defines its default and
+   * effective maximum; this shared request shape accepts values up to 500.
    *
    * @generated from field: int32 limit = 1;
    */

--- a/packages/api-types/src/chatto/api/v1/pagination_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/pagination_pb.ts
@@ -15,7 +15,7 @@ import { Message, proto3, protoInt64 } from "@bufbuild/protobuf";
 export class PageRequest extends Message<PageRequest> {
   /**
    * Maximum number of items to return. Each RPC defines its default; the common
-   * maximum for public API list pages is 100.
+   * maximum for public API list pages is 500.
    *
    * @generated from field: int32 limit = 1;
    */

--- a/proto/chatto/api/v1/pagination.proto
+++ b/proto/chatto/api/v1/pagination.proto
@@ -8,10 +8,10 @@ import "buf/validate/validate.proto";
 // for simple list browsing.
 message PageRequest {
   // Maximum number of items to return. Each RPC defines its default; the common
-  // maximum for public API list pages is 100.
+  // maximum for public API list pages is 500.
   int32 limit = 1 [(buf.validate.field).int32 = {
     gte: 0,
-    lte: 100
+    lte: 500
   }];
   // Zero-based number of matching items to skip.
   int32 offset = 2 [(buf.validate.field).int32.gte = 0];

--- a/proto/chatto/api/v1/pagination.proto
+++ b/proto/chatto/api/v1/pagination.proto
@@ -7,8 +7,8 @@ import "buf/validate/validate.proto";
 // Offset-based page request for list RPCs whose result order is stable enough
 // for simple list browsing.
 message PageRequest {
-  // Maximum number of items to return. Each RPC defines its default; the common
-  // maximum for public API list pages is 500.
+  // Maximum number of items to request. Each RPC defines its default and
+  // effective maximum; this shared request shape accepts values up to 500.
   int32 limit = 1 [(buf.validate.field).int32 = {
     gte: 0,
     lte: 500


### PR DESCRIPTION
## Summary

Raise member directory pages from 100 to 500 so large room member eager-loads make fewer ConnectRPC calls.
Thread the shared room member page-size constant through DM sidebar, room data, and quick switcher member fetches.
Add targeted backend and frontend coverage for the new clamp and request size behavior.

## Validation

- `mise x -- go test ./internal/connectapi -run 'TestMemberDirectoryService|TestMemberDirectoryOversizedPagesClampTo500'` from `cli/`
- `mise x -- pnpm run build:api-client`
- `mise x -- pnpm run lint:frontend`
- `mise x -- pnpm --filter chatto-frontend exec vitest --run src/lib/state/room/members.svelte.spec.ts src/lib/state/server/rooms.svelte.spec.ts 'src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts'`
- `mise x -- pnpm --filter chatto-frontend exec playwright test e2e/presence-indicators.test.ts --retries=0`
