### PR TITLE
fix(api): close ConnectRPC RBAC gaps

### DIFF
--- a/cli/internal/connectapi/admin_user_management.go
+++ b/cli/internal/connectapi/admin_user_management.go
@@ -171,6 +171,18 @@ func (s *adminUserManagementService) SetUserPassword(ctx context.Context, req *c
 	if req.Msg.GetPassword() == "" {
 		return nil, invalidArgument("password is required")
 	}
+	if caller.UserID != req.Msg.GetUserId() {
+		canManage, err := s.api.core.CanManageUserAccounts(ctx, caller.UserID)
+		if err != nil {
+			return nil, connectError(err)
+		}
+		if !canManage {
+			return nil, connectError(core.ErrPermissionDenied)
+		}
+	}
+	if err := s.api.requireFreshCredential(ctx, caller, ""); err != nil {
+		return nil, connectError(err)
+	}
 	if err := s.api.core.AdminSetUserPasswordAuthorized(ctx, caller.UserID, req.Msg.GetUserId(), req.Msg.GetPassword()); err != nil {
 		return nil, connectError(err)
 	}

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -1725,6 +1725,26 @@ func TestAdminMemberServiceUpdatesUsersAndClearsCooldown(t *testing.T) {
 	})); connect.CodeOf(err) != connect.CodePermissionDenied {
 		t.Fatalf("regular SetUserPassword code = %v, want permission_denied", connect.CodeOf(err))
 	}
+	if _, err := env.core.UpdateUserLogin(env.ctx, regular.Id, "admin-user-regular-renamed"); err != nil {
+		t.Fatalf("UpdateUserLogin regular: %v", err)
+	}
+	if _, err := env.adminUsers.UpdateUser(withCaller(env.ctx, regular), connect.NewRequest(&adminv1.UpdateUserRequest{
+		UserId: regular.Id,
+		Login:  stringPtr("admin-user-regular-bypass"),
+	})); connect.CodeOf(err) != connect.CodePermissionDenied {
+		t.Fatalf("regular self UpdateUser code = %v, want permission_denied", connect.CodeOf(err))
+	}
+	if _, err := env.core.UpdateUserLogin(env.ctx, regular.Id, "admin-user-regular-cooldown"); !errors.Is(err, core.ErrLoginChangeCooldown) {
+		t.Fatalf("regular cooldown after denied self UpdateUser err = %v, want cooldown", err)
+	}
+	if _, err := env.adminUsers.ClearUsernameCooldown(withCaller(env.ctx, regular), connect.NewRequest(&adminv1.ClearUsernameCooldownRequest{
+		UserId: regular.Id,
+	})); connect.CodeOf(err) != connect.CodePermissionDenied {
+		t.Fatalf("regular self ClearUsernameCooldown code = %v, want permission_denied", connect.CodeOf(err))
+	}
+	if _, err := env.core.UpdateUserLogin(env.ctx, regular.Id, "regular-still-cooldown"); !errors.Is(err, core.ErrLoginChangeCooldown) {
+		t.Fatalf("regular cooldown after denied self clear err = %v, want cooldown", err)
+	}
 
 	roleAssigner, err := env.core.CreateUser(env.ctx, core.SystemActorID, "admin-user-role-assigner", "Admin User Role Assigner", "password")
 	if err != nil {
@@ -1747,7 +1767,17 @@ func TestAdminMemberServiceUpdatesUsersAndClearsCooldown(t *testing.T) {
 	if err := env.core.GrantUserPermission(env.ctx, core.SystemActorID, accountManager.Id, core.PermUserManageAccounts); err != nil {
 		t.Fatalf("GrantUserPermission user.manage-accounts: %v", err)
 	}
-	accountManagerResp, err := env.adminUsers.SetUserPassword(withCaller(env.ctx, accountManager), connect.NewRequest(&adminv1.SetUserPasswordRequest{
+	if _, err := env.adminUsers.SetUserPassword(withCaller(env.ctx, accountManager), connect.NewRequest(&adminv1.SetUserPasswordRequest{
+		UserId:   target.Id,
+		Password: "accountmanagerpass456",
+	})); connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Fatalf("account manager stale SetUserPassword code = %v, want failed_precondition", connect.CodeOf(err))
+	}
+	accountManagerToken, err := env.core.CreateAuthTokenWithSource(env.ctx, accountManager.Id, "password_login")
+	if err != nil {
+		t.Fatalf("CreateAuthTokenWithSource account manager: %v", err)
+	}
+	accountManagerResp, err := env.adminUsers.SetUserPassword(withBearerCredential(env.ctx, accountManager, accountManagerToken), connect.NewRequest(&adminv1.SetUserPasswordRequest{
 		UserId:   target.Id,
 		Password: "accountmanagerpass456",
 	}))
@@ -1768,7 +1798,11 @@ func TestAdminMemberServiceUpdatesUsersAndClearsCooldown(t *testing.T) {
 	if err := env.core.AssignAdminRole(env.ctx, admin.Id); err != nil {
 		t.Fatalf("AssignAdminRole: %v", err)
 	}
-	adminCtx := withCaller(env.ctx, admin)
+	adminToken, err := env.core.CreateAuthTokenWithSource(env.ctx, admin.Id, "password_login")
+	if err != nil {
+		t.Fatalf("CreateAuthTokenWithSource admin: %v", err)
+	}
+	adminCtx := withBearerCredential(env.ctx, admin, adminToken)
 
 	if _, err := env.adminUsers.UpdateUser(adminCtx, connect.NewRequest(&adminv1.UpdateUserRequest{
 		UserId: target.Id,
@@ -5462,6 +5496,44 @@ func TestThreadServiceListFollowedThreadsReturnsHydratedPage(t *testing.T) {
 	}
 }
 
+func TestThreadServiceListFollowedThreadsFiltersMembershipLoss(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	room := env.createJoinedRoom("followed-loss")
+	participant, err := env.core.CreateUser(env.ctx, core.SystemActorID, "thread-loss-participant", "Thread Loss Participant", "password")
+	if err != nil {
+		t.Fatalf("CreateUser participant: %v", err)
+	}
+	if _, err := env.core.JoinRoom(env.ctx, participant.Id, core.KindChannel, participant.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom participant: %v", err)
+	}
+	root := env.post(room.Id, env.viewer.Id, "root body", "")
+	env.post(room.Id, participant.Id, "reply body", root.Id)
+
+	ctx := withCaller(env.ctx, env.viewer)
+	if _, err := env.threads.FollowThread(ctx, connect.NewRequest(&apiv1.FollowThreadRequest{
+		RoomId:            room.Id,
+		ThreadRootEventId: root.Id,
+	})); err != nil {
+		t.Fatalf("FollowThread: %v", err)
+	}
+	if err := env.core.LeaveRoom(env.ctx, env.viewer.Id, core.KindChannel, env.viewer.Id, room.Id); err != nil {
+		t.Fatalf("LeaveRoom viewer: %v", err)
+	}
+
+	resp, err := env.threads.ListFollowedThreads(ctx, connect.NewRequest(&apiv1.ListFollowedThreadsRequest{
+		Page: &apiv1.PageRequest{Limit: 20},
+	}))
+	if err != nil {
+		t.Fatalf("ListFollowedThreads: %v", err)
+	}
+	if got := len(resp.Msg.GetThreads()); got != 0 {
+		t.Fatalf("ListFollowedThreads returned %d threads after membership loss, want 0", got)
+	}
+	if resp.Msg.GetPage().GetTotalCount() != 0 || resp.Msg.GetPage().GetHasMore() {
+		t.Fatalf("ListFollowedThreads page metadata = total %d hasMore %v, want total 0 hasMore false", resp.Msg.GetPage().GetTotalCount(), resp.Msg.GetPage().GetHasMore())
+	}
+}
+
 func TestNotificationLevelMapping(t *testing.T) {
 	valid := []struct {
 		name string
@@ -5548,6 +5620,41 @@ func requireConnectCode(t testing.TB, err error, want connect.Code) {
 	t.Helper()
 	if got := connect.CodeOf(err); got != want {
 		t.Fatalf("connect code = %v, want %v (err = %v)", got, want, err)
+	}
+}
+
+func TestAPIPermissionExplanationMarksWinningTraceFirst(t *testing.T) {
+	got := apiPermissionExplanation(core.PermissionExplanation{
+		Permission:    core.PermAdminUsersView,
+		State:         core.DecisionDeny,
+		DecidedAt:     core.LevelRoom,
+		DecidedByRole: core.RoleEveryone,
+		Trace: []core.TraceEntry{
+			{
+				Level:    core.LevelServer,
+				RoleName: "custom",
+				Decision: core.DecisionAllow,
+			},
+			{
+				Level:    core.LevelRoom,
+				RoleName: core.RoleEveryone,
+				Decision: core.DecisionDeny,
+			},
+		},
+	})
+
+	if got.GetState() != adminv1.PermissionDecision_PERMISSION_DECISION_DENY {
+		t.Fatalf("state = %v, want deny", got.GetState())
+	}
+	trace := got.GetTrace()
+	if len(trace) != 2 {
+		t.Fatalf("trace length = %d, want 2", len(trace))
+	}
+	if trace[0].GetRoleName() != core.RoleEveryone || trace[0].GetDecision() != adminv1.PermissionDecision_PERMISSION_DECISION_DENY || !trace[0].GetApplied() {
+		t.Fatalf("first trace entry = %+v, want winning deny applied", trace[0])
+	}
+	if trace[1].GetApplied() {
+		t.Fatalf("second trace entry applied = true, want false")
 	}
 }
 

--- a/cli/internal/connectapi/permissions.go
+++ b/cli/internal/connectapi/permissions.go
@@ -118,15 +118,39 @@ func apiPermissionExplanation(explanation core.PermissionExplanation) *adminv1.P
 		DecidedByRole: explanation.DecidedByRole,
 		Trace:         make([]*adminv1.PermissionTraceEntry, 0, len(explanation.Trace)),
 	}
-	for i, entry := range explanation.Trace {
+	for i, entry := range winningTraceFirst(explanation) {
 		out.Trace = append(out.Trace, &adminv1.PermissionTraceEntry{
 			Level:    apiPermissionDecisionLevel(entry.Level),
 			RoleName: entry.RoleName,
 			Decision: apiPermissionExplanationDecision(entry.Decision),
-			Applied:  i == 0,
+			Applied:  i == 0 && traceEntryWins(explanation, entry),
 		})
 	}
 	return out
+}
+
+func winningTraceFirst(explanation core.PermissionExplanation) []core.TraceEntry {
+	trace := append([]core.TraceEntry(nil), explanation.Trace...)
+	winningIndex := -1
+	for i, entry := range trace {
+		if traceEntryWins(explanation, entry) {
+			winningIndex = i
+			break
+		}
+	}
+	if winningIndex <= 0 {
+		return trace
+	}
+	winning := trace[winningIndex]
+	copy(trace[1:winningIndex+1], trace[:winningIndex])
+	trace[0] = winning
+	return trace
+}
+
+func traceEntryWins(explanation core.PermissionExplanation, entry core.TraceEntry) bool {
+	return entry.Level == explanation.DecidedAt &&
+		entry.RoleName == explanation.DecidedByRole &&
+		entry.Decision == explanation.State
 }
 
 func apiPermissionExplanationDecision(decision core.DecisionKind) adminv1.PermissionDecision {

--- a/cli/internal/core/permission.go
+++ b/cli/internal/core/permission.go
@@ -280,7 +280,6 @@ func DefaultSeedEveryonePermissions() []Permission {
 // list contains only moderator-specific server-scope capabilities.
 func DefaultModeratorPermissions() []Permission {
 	return []Permission{
-		PermAdminUsersView,
 		PermMessageManage,
 		PermRoomMemberBan,
 	}

--- a/cli/internal/core/permission_ops_test.go
+++ b/cli/internal/core/permission_ops_test.go
@@ -450,36 +450,39 @@ func TestInitDefaultPermissions(t *testing.T) {
 		}
 	})
 
-	t.Run("moderator has server-scope admin user visibility and moderation permissions", func(t *testing.T) {
-		moderatorPerms := []Permission{PermAdminUsersView, PermMessageManage, PermRoomMemberBan}
+	t.Run("moderator has server-scope moderation permissions", func(t *testing.T) {
+		moderatorPerms := []Permission{PermMessageManage, PermRoomMemberBan}
 		for _, perm := range moderatorPerms {
 			if got := core.RBAC.GetDecision(ScopeServer, "", RoleModerator, perm); got != DecisionAllow {
 				t.Errorf("moderator decision for %s = %s, want %s", perm, got, DecisionAllow)
 			}
 		}
+		if got := core.RBAC.GetDecision(ScopeServer, "", RoleModerator, PermAdminUsersView); got != DecisionNone {
+			t.Errorf("moderator admin.view-users decision = %s, want %s", got, DecisionNone)
+		}
 	})
 
 	t.Run("ensure default permissions backfills missing grants without overriding denies", func(t *testing.T) {
-		if err := core.ClearServerPermissionState(ctx, SystemActorID, RoleModerator, PermAdminUsersView); err != nil {
+		if err := core.ClearServerPermissionState(ctx, SystemActorID, RoleModerator, PermMessageManage); err != nil {
 			t.Fatalf("ClearServerPermissionState: %v", err)
 		}
-		if got := core.RBAC.GetDecision(ScopeServer, "", RoleModerator, PermAdminUsersView); got != DecisionNone {
+		if got := core.RBAC.GetDecision(ScopeServer, "", RoleModerator, PermMessageManage); got != DecisionNone {
 			t.Fatalf("decision after clear = %s, want %s", got, DecisionNone)
 		}
 		if err := core.EnsureDefaultRolePermissions(ctx); err != nil {
 			t.Fatalf("EnsureDefaultRolePermissions backfill: %v", err)
 		}
-		if got := core.RBAC.GetDecision(ScopeServer, "", RoleModerator, PermAdminUsersView); got != DecisionAllow {
+		if got := core.RBAC.GetDecision(ScopeServer, "", RoleModerator, PermMessageManage); got != DecisionAllow {
 			t.Fatalf("decision after ensure = %s, want %s", got, DecisionAllow)
 		}
 
-		if err := core.DenyServerPermission(ctx, SystemActorID, RoleModerator, PermAdminUsersView); err != nil {
+		if err := core.DenyServerPermission(ctx, SystemActorID, RoleModerator, PermMessageManage); err != nil {
 			t.Fatalf("DenyServerPermission: %v", err)
 		}
 		if err := core.EnsureDefaultRolePermissions(ctx); err != nil {
 			t.Fatalf("EnsureDefaultRolePermissions preserve deny: %v", err)
 		}
-		if got := core.RBAC.GetDecision(ScopeServer, "", RoleModerator, PermAdminUsersView); got != DecisionDeny {
+		if got := core.RBAC.GetDecision(ScopeServer, "", RoleModerator, PermMessageManage); got != DecisionDeny {
 			t.Fatalf("decision after denied ensure = %s, want %s", got, DecisionDeny)
 		}
 	})

--- a/cli/internal/core/permission_test.go
+++ b/cli/internal/core/permission_test.go
@@ -290,7 +290,6 @@ func TestDefaultModeratorPermissions(t *testing.T) {
 	perms := DefaultModeratorPermissions()
 
 	mustInclude := []Permission{
-		PermAdminUsersView,
 		PermMessageManage,
 		PermRoomMemberBan,
 	}
@@ -300,8 +299,9 @@ func TestDefaultModeratorPermissions(t *testing.T) {
 		}
 	}
 
-	// Moderators are not server admins.
-	for _, mustNotInclude := range []Permission{PermRoomCreate, PermRoomManage, PermServerManage, PermRoleManage} {
+	// Moderators can moderate content and bans, but do not get admin visibility
+	// or general server administration by default.
+	for _, mustNotInclude := range []Permission{PermAdminUsersView, PermRoomCreate, PermRoomManage, PermServerManage, PermRoleManage} {
 		if slices.Contains(perms, mustNotInclude) {
 			t.Errorf("moderator defaults must not include %v", mustNotInclude)
 		}

--- a/cli/internal/core/rbac_test.go
+++ b/cli/internal/core/rbac_test.go
@@ -2486,14 +2486,18 @@ func TestChattoCore_GetUserEffectiveSpacePermissions_ServerRoleDenialInSpace(t *
 	// Create a space
 	_, _ = core.CreateUser(ctx, SystemActorID, "creator4", "Creator", "password123")
 
-	// Verify moderator has admin.view-users by default.
+	// Moderators do not get admin.view-users by default.
 	perms1, _ := core.GetUserEffectiveSpacePermissions(ctx, KindChannel, user.Id)
 	permSet1 := make(map[string]bool)
 	for _, p := range perms1 {
 		permSet1[string(p)] = true
 	}
-	if !permSet1["admin.view-users"] {
-		t.Error("User should have admin.view-users by default")
+	if permSet1["admin.view-users"] {
+		t.Error("User should not have admin.view-users by default")
+	}
+
+	if err := core.GrantServerPermission(ctx, SystemActorID, RoleModerator, PermAdminUsersView); err != nil {
+		t.Fatalf("Failed to grant role permission: %v", err)
 	}
 
 	// Deny admin.view-users to moderator role.

--- a/cli/internal/core/threads.go
+++ b/cli/internal/core/threads.go
@@ -759,6 +759,15 @@ func (c *ChattoCore) listFollowedThreadsInSpace(ctx context.Context, userID stri
 		roomID := parts[2]
 		threadRootEventID := parts[3]
 
+		isMember, err := c.RoomMembershipExists(ctx, kind, userID, roomID)
+		if err != nil {
+			c.logger.Warn("Failed to check room membership for followed thread", "error", err, "room_id", roomID, "thread_root_event_id", threadRootEventID)
+			continue
+		}
+		if !isMember {
+			continue
+		}
+
 		// Get thread metadata (reply count, last reply, participants)
 		metadata, err := c.GetThreadMetadata(ctx, kind, roomID, threadRootEventID)
 		if err != nil {

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -978,7 +978,7 @@ type AdminUpdateUserInput struct {
 }
 
 func (c *ChattoCore) AdminUpdateUser(ctx context.Context, actorID, targetUserID string, input AdminUpdateUserInput) (*corev1.User, error) {
-	if err := c.requireCanAdminManageUser(ctx, actorID, targetUserID); err != nil {
+	if err := c.requireCanAdminManageOtherUser(ctx, actorID, targetUserID); err != nil {
 		return nil, err
 	}
 	if input.Login == nil && input.DisplayName == nil {
@@ -988,13 +988,13 @@ func (c *ChattoCore) AdminUpdateUser(ctx context.Context, actorID, targetUserID 
 }
 
 func (c *ChattoCore) AdminClearLoginChangeCooldown(ctx context.Context, actorID, targetUserID string) error {
-	if err := c.requireCanAdminManageUser(ctx, actorID, targetUserID); err != nil {
+	if err := c.requireCanAdminManageOtherUser(ctx, actorID, targetUserID); err != nil {
 		return err
 	}
 	return c.ClearLoginChangeCooldownAs(ctx, actorID, targetUserID)
 }
 
-func (c *ChattoCore) requireCanAdminManageUser(ctx context.Context, actorID, targetUserID string) error {
+func (c *ChattoCore) requireCanAdminManageOtherUser(ctx context.Context, actorID, targetUserID string) error {
 	if actorID == "" {
 		return ErrNotAuthenticated
 	}
@@ -1002,7 +1002,7 @@ func (c *ChattoCore) requireCanAdminManageUser(ctx context.Context, actorID, tar
 		return fmt.Errorf("%w: target user ID is required", ErrInvalidArgument)
 	}
 	if actorID == targetUserID {
-		return nil
+		return ErrPermissionDenied
 	}
 	canManage, err := c.CanManageUserAccounts(ctx, actorID)
 	if err != nil {

--- a/cli/internal/core/users_test.go
+++ b/cli/internal/core/users_test.go
@@ -1755,7 +1755,7 @@ func TestChattoCore_AdminUpdateUserAuthorization(t *testing.T) {
 		}
 	})
 
-	t.Run("self update preserves legacy admin mutation behavior", func(t *testing.T) {
+	t.Run("self update uses account path not admin mutation path", func(t *testing.T) {
 		c, _ := setupTestCore(t)
 		ctx := testContext(t)
 		user, err := c.CreateUser(ctx, SystemActorID, "adminauth-self", "Self", "password123")
@@ -1763,9 +1763,15 @@ func TestChattoCore_AdminUpdateUserAuthorization(t *testing.T) {
 			t.Fatalf("CreateUser self: %v", err)
 		}
 		login := "adminauth-self-updated"
-		updated, err := c.AdminUpdateUser(ctx, user.Id, user.Id, AdminUpdateUserInput{Login: &login})
+		if _, err := c.AdminUpdateUser(ctx, user.Id, user.Id, AdminUpdateUserInput{Login: &login}); !errors.Is(err, ErrPermissionDenied) {
+			t.Fatalf("AdminUpdateUser self err = %v, want ErrPermissionDenied", err)
+		}
+		if err := c.AdminClearLoginChangeCooldown(ctx, user.Id, user.Id); !errors.Is(err, ErrPermissionDenied) {
+			t.Fatalf("AdminClearLoginChangeCooldown self err = %v, want ErrPermissionDenied", err)
+		}
+		updated, err := c.UpdateUserLogin(ctx, user.Id, login)
 		if err != nil {
-			t.Fatalf("AdminUpdateUser self: %v", err)
+			t.Fatalf("UpdateUserLogin self: %v", err)
 		}
 		if updated.GetLogin() != login {
 			t.Fatalf("updated login = %q, want %q", updated.GetLogin(), login)


### PR DESCRIPTION
## Summary

Close several ConnectRPC RBAC gaps by separating admin user mutation from self-service updates, requiring fresh auth for admin password resets, filtering followed threads by current room membership, and fixing permission explanation trace ordering.

The root cause was that a few migrated ConnectRPC paths reused legacy/core helpers that were too broad for the new API boundary, while moderator defaults still granted `admin.view-users`.

This keeps self-updates on the account path with cooldowns intact and removes unintended visibility or mutation paths for non-admin callers.

## Validation

- `mise x -- go test ./internal/connectapi -count=1`
- `mise x -- go test ./internal/core -count=1`
- `git diff --check`
