### PR TITLE
fix(frontend): style room member search clear button

### DIFF
--- a/apps/frontend/messages/de/room.json
+++ b/apps/frontend/messages/de/room.json
@@ -112,6 +112,7 @@
       "members": "Mitglieder",
       "search_members": "Raummitglieder suchen",
       "search_members_placeholder": "Mitglieder suchen",
+      "clear_member_search": "Mitgliedersuche leeren",
       "no_members": "Keine Mitglieder gefunden.",
       "online": "Online ({count})",
       "offline": "Offline ({count})",

--- a/apps/frontend/messages/en/room.json
+++ b/apps/frontend/messages/en/room.json
@@ -112,6 +112,7 @@
       "members": "Members",
       "search_members": "Search room members",
       "search_members_placeholder": "Search members",
+      "clear_member_search": "Clear member search",
       "no_members": "No members found.",
       "online": "Online ({count})",
       "offline": "Offline ({count})",

--- a/apps/frontend/src/lib/i18n/messages.ts
+++ b/apps/frontend/src/lib/i18n/messages.ts
@@ -649,6 +649,7 @@ const msg_room_sidebar_hide = (): LocalizedString => messages().room_sidebar_hid
 const msg_room_sidebar_members = (): LocalizedString => messages().room_sidebar_members(empty());
 const msg_room_sidebar_search_members = (): LocalizedString => messages().room_sidebar_search_members(empty());
 const msg_room_sidebar_search_members_placeholder = (): LocalizedString => messages().room_sidebar_search_members_placeholder(empty());
+const msg_room_sidebar_clear_member_search = (): LocalizedString => messages().room_sidebar_clear_member_search(empty());
 const msg_room_sidebar_no_members = (): LocalizedString => messages().room_sidebar_no_members(empty());
 const msg_room_sidebar_online = (
   inputs: Parameters<LocaleMessages['room_sidebar_online']>[0]
@@ -1835,6 +1836,7 @@ export { msg_room_sidebar_hide as 'room.sidebar.hide' };
 export { msg_room_sidebar_members as 'room.sidebar.members' };
 export { msg_room_sidebar_search_members as 'room.sidebar.search_members' };
 export { msg_room_sidebar_search_members_placeholder as 'room.sidebar.search_members_placeholder' };
+export { msg_room_sidebar_clear_member_search as 'room.sidebar.clear_member_search' };
 export { msg_room_sidebar_no_members as 'room.sidebar.no_members' };
 export { msg_room_sidebar_online as 'room.sidebar.online' };
 export { msg_room_sidebar_offline as 'room.sidebar.offline' };

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
@@ -92,6 +92,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
   let banDialogMember = $state<RoomMember | null>(null);
   let banError = $state<string | null>(null);
   let memberSearchTimer: ReturnType<typeof setTimeout> | null = null;
+  let memberSearchInput = $state<HTMLInputElement | null>(null);
 
   onDestroy(() => {
     if (memberSearchTimer) clearTimeout(memberSearchTimer);
@@ -197,8 +198,18 @@ calls, and similar room-specific panels can plug into the same shell. See the
     membersStore.searchInput = value;
     if (memberSearchTimer) clearTimeout(memberSearchTimer);
     memberSearchTimer = setTimeout(() => {
+      memberSearchTimer = null;
       void membersStore.setSearch(value);
     }, 250);
+  }
+
+  function clearMemberSearch() {
+    if (memberSearchTimer) {
+      clearTimeout(memberSearchTimer);
+      memberSearchTimer = null;
+    }
+    void membersStore.setSearch('');
+    memberSearchInput?.focus();
   }
 </script>
 
@@ -241,13 +252,28 @@ calls, and similar room-specific panels can plug into the same shell. See the
             aria-hidden="true"
           ></span>
           <input
+            bind:this={memberSearchInput}
             id="room-member-search"
             type="search"
             value={membersStore.searchInput}
             oninput={scheduleMemberSearch}
             placeholder={m['room.sidebar.search_members_placeholder']()}
-            class="h-8 w-full rounded-md bg-surface py-1 pr-2 pl-8 text-sm transition-colors outline-none placeholder:text-muted"
+            class={[
+              'room-member-search-input h-8 w-full rounded-md bg-surface py-1 pl-8 text-sm transition-colors outline-none placeholder:text-muted',
+              membersStore.searchInput ? 'pr-8' : 'pr-2'
+            ]}
           />
+          {#if membersStore.searchInput}
+            <button
+              type="button"
+              class="pane-header-icon-button absolute top-1/2 right-1 h-6 w-6 -translate-y-1/2"
+              aria-label={m['room.sidebar.clear_member_search']()}
+              title={m['room.sidebar.clear_member_search']()}
+              onclick={clearMemberSearch}
+            >
+              <span class="pane-header-icon-glyph iconify uil--times" aria-hidden="true"></span>
+            </button>
+          {/if}
         </div>
       </div>
 
@@ -335,6 +361,14 @@ calls, and similar room-specific panels can plug into the same shell. See the
     />
   {/if}
 </aside>
+
+<style>
+  .room-member-search-input::-webkit-search-cancel-button {
+    -webkit-appearance: none;
+    appearance: none;
+    display: none;
+  }
+</style>
 
 {#snippet memberRow(member: RoomMember)}
   {@const isOnline = isOnlineStatus(getPresence(member))}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -887,6 +887,49 @@ describe('RoomSidebar', () => {
     expect(memberDirectoryMocks.listRoomMembers).toHaveBeenCalledTimes(1);
   });
 
+  it('clears the member search with the Chatto-styled clear button without refetching', async () => {
+    memberDirectoryMocks.listRoomMembers.mockResolvedValueOnce(
+      memberPage([member(1), { ...member(2), displayName: 'Boris Member' }])
+    );
+
+    const { container } = render(RoomSidebarTestHarness, {
+      props: {
+        roomData: roomData([], 0, false)
+      }
+    });
+
+    await vi.waitFor(() => {
+      expect(renderedMemberTitles(container)).toHaveLength(2);
+    });
+
+    const input = container.querySelector('#room-member-search') as HTMLInputElement;
+    input.value = 'bor';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    await waitForMemberSearchDebounce();
+
+    await vi.waitFor(() => {
+      expect(renderedMemberTitles(container)).toEqual(['View profile of Boris Member']);
+    });
+
+    const clearButton = q(
+      container,
+      'button[aria-label="Clear member search"]'
+    ) as HTMLButtonElement;
+    expect(clearButton.className).toContain('pane-header-icon-button');
+    clearButton.click();
+    await tick();
+
+    await vi.waitFor(() => {
+      expect(input.value).toBe('');
+      expect(renderedMemberTitles(container)).toHaveLength(2);
+      expect(q(container, 'h1')?.textContent).toContain('Members (2)');
+      expect(document.activeElement).toBe(input);
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 350));
+    expect(memberDirectoryMocks.listRoomMembers).toHaveBeenCalledTimes(1);
+  });
+
   it('shows an empty local search result without changing the canonical total count', async () => {
     memberDirectoryMocks.listRoomMembers.mockResolvedValueOnce(memberPage([member(1), member(2)]));
 


### PR DESCRIPTION
Replaces the browser-native room member search clear affordance with a Chatto-styled icon button and suppresses the WebKit/Blink native cancel control. Clearing now cancels pending debounce, resets the local member filter immediately, and refocuses the search input. Adds English and German labels plus component coverage for clearing without refetching.

Validation: Svelte autofixer, `git diff --check`, targeted `RoomSidebar.svelte.spec.ts`, and `mise test-frontend`.
