### PR TITLE
fix(frontend): improve extreme image thumbnails

### DIFF
--- a/apps/frontend/e2e/messages.test.ts
+++ b/apps/frontend/e2e/messages.test.ts
@@ -1,8 +1,83 @@
 import { expect } from '@playwright/test';
+import sharp from 'sharp';
 import { TIMEOUTS } from './constants';
 import { test } from './setup';
 import { createAndLoginTestUser } from './fixtures/testUser';
 import { withServerUser } from './fixtures/serverUser';
+import type { MessageComponent, RoomPage } from './pages';
+
+type GeneratedImageAttachment = {
+  width: number;
+  height: number;
+  filename: string;
+  textPrefix: string;
+};
+
+async function sendGeneratedImageAttachment(
+  roomPage: RoomPage,
+  { width, height, filename, textPrefix }: GeneratedImageAttachment
+): Promise<MessageComponent> {
+  const image = await sharp({
+    create: {
+      width,
+      height,
+      channels: 3,
+      background: { r: 220, g: 224, b: 232 }
+    }
+  })
+    .png()
+    .toBuffer();
+  const text = `${textPrefix} ${Date.now()}`;
+
+  await roomPage.fileInput.setInputFiles({
+    name: filename,
+    mimeType: 'image/png',
+    buffer: image
+  });
+  await expect(roomPage.attachmentPreview).toBeVisible();
+  await roomPage.waitForInputEditable();
+  await roomPage.messageInput.fill(text);
+  await roomPage.messageInput.press('Enter');
+  await expect(roomPage.attachmentPreview).not.toBeVisible();
+
+  const message = roomPage.getMessage(text);
+  await expect(message.locator).toBeVisible({ timeout: TIMEOUTS.UI_FAST });
+  return message;
+}
+
+async function expectContainedAttachmentThumbnail(
+  message: MessageComponent,
+  {
+    maxHeight,
+    minWidthToHeightRatio,
+    minHeightToWidthRatio
+  }: {
+    maxHeight: number;
+    minWidthToHeightRatio?: number;
+    minHeightToWidthRatio?: number;
+  }
+) {
+  const thumbnailButton = message.locator.locator('button[aria-label^="View"]').first();
+  const thumbnailImage = thumbnailButton.locator('img').first();
+  await expect(thumbnailImage).toBeVisible({ timeout: TIMEOUTS.COMPLEX_OPERATION });
+
+  await expect.poll(() => thumbnailImage.evaluate((img) => getComputedStyle(img).objectFit)).toBe(
+    'contain'
+  );
+
+  const buttonBox = await thumbnailButton.boundingBox();
+  const messageBox = await message.locator.boundingBox();
+  expect(buttonBox).not.toBeNull();
+  expect(messageBox).not.toBeNull();
+  expect(buttonBox!.width).toBeLessThanOrEqual(messageBox!.width);
+  expect(buttonBox!.height).toBeLessThanOrEqual(maxHeight);
+  if (minWidthToHeightRatio !== undefined) {
+    expect(buttonBox!.width / buttonBox!.height).toBeGreaterThan(minWidthToHeightRatio);
+  }
+  if (minHeightToWidthRatio !== undefined) {
+    expect(buttonBox!.height / buttonBox!.width).toBeGreaterThan(minHeightToWidthRatio);
+  }
+}
 
 test('consecutive messages from same user are grouped', async ({ page, chatPage, roomPage }) => {
   const testUser = await createAndLoginTestUser(page);
@@ -182,6 +257,48 @@ test('image attachment respects container width on narrow viewport', async ({
   expect(imageBox).not.toBeNull();
   expect(containerBox).not.toBeNull();
   expect(imageBox!.width).toBeLessThanOrEqual(containerBox!.width);
+});
+
+test('ultra-wide image attachment renders as a shallow contained thumbnail', async ({
+  page,
+  chatPage,
+  roomPage
+}) => {
+  await createAndLoginTestUser(page);
+  await chatPage.goto();
+  await chatPage.enterRoom('general');
+
+  const message = await sendGeneratedImageAttachment(roomPage, {
+    width: 2000,
+    height: 100,
+    filename: 'ultra-wide.png',
+    textPrefix: 'Ultra-wide image'
+  });
+  await expectContainedAttachmentThumbnail(message, {
+    maxHeight: 50,
+    minWidthToHeightRatio: 8
+  });
+});
+
+test('very tall image attachment renders as a narrow contained thumbnail', async ({
+  page,
+  chatPage,
+  roomPage
+}) => {
+  await createAndLoginTestUser(page);
+  await chatPage.goto();
+  await chatPage.enterRoom('general');
+
+  const message = await sendGeneratedImageAttachment(roomPage, {
+    width: 100,
+    height: 2000,
+    filename: 'very-tall.png',
+    textPrefix: 'Tall image'
+  });
+  await expectContainedAttachmentThumbnail(message, {
+    maxHeight: 205,
+    minHeightToWidthRatio: 8
+  });
 });
 
 test('room scrolls to bottom on load even with slow-loading images', async ({

--- a/apps/frontend/src/lib/api-client-tests/attachments.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/attachments.spec.ts
@@ -159,7 +159,7 @@ describe('createAttachmentAPI', () => {
           new RefreshedAttachmentUrls({
             attachmentId: 'att_1',
             assetUrl: assetUrl('/assets/files/att_1?fresh=1'),
-            thumbnailAssetUrl: assetUrl('/assets/files/att_1/image/960x800/cover?fresh=1'),
+            thumbnailAssetUrl: assetUrl('/assets/files/att_1/image/960x800/contain?fresh=1'),
             videoThumbnailAssetUrl: assetUrl('/assets/files/thumb?fresh=1'),
             variants: [
               new RoomTimelineVideoVariant({
@@ -183,14 +183,14 @@ describe('createAttachmentAPI', () => {
     const urls = await api.refreshMessageAttachmentUrls('room_1', 'event_1', {
       width: 960,
       height: 800,
-      fit: FitMode.Cover
+      fit: FitMode.Contain
     });
 
     expect(mocks.refreshMessageAttachmentUrls).toHaveBeenCalledWith(
       {
         roomId: 'room_1',
         eventId: 'event_1',
-        thumbnail: { width: 960, height: 800, fit: AttachmentFitMode.COVER }
+        thumbnail: { width: 960, height: 800, fit: AttachmentFitMode.CONTAIN }
       },
       { headers: undefined }
     );

--- a/apps/frontend/src/lib/api-client-tests/roomTimeline.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/roomTimeline.spec.ts
@@ -249,7 +249,7 @@ describe('roomTimelinePageToEventConnectionPage', () => {
                     expiresAt: Timestamp.fromDate(new Date('2026-06-01T13:00:00Z'))
                   }),
                   thumbnailAssetUrl: new RoomTimelineAssetUrl({
-                    url: '/assets/files/a-video/image/960x800/cover',
+                    url: '/assets/files/a-video/image/960x800/contain',
                     expiresAt: Timestamp.fromDate(new Date('2026-06-01T13:00:00Z'))
                   }),
                   videoProcessing: new RoomTimelineVideoProcessing({

--- a/apps/frontend/src/lib/attachments/attachmentUrls.test.ts
+++ b/apps/frontend/src/lib/attachments/attachmentUrls.test.ts
@@ -69,7 +69,7 @@ describe('refreshAttachmentUrlsForMessage', () => {
     expect(refreshMessageAttachmentUrls).toHaveBeenCalledWith('room_1', 'event_1', {
       width: 960,
       height: 800,
-      fit: FitMode.Cover
+      fit: FitMode.Contain
     });
     expect(urls.get('att_1')?.assetUrl.url).toBe('https://cdn.example.com/fresh-1.jpg');
     expect(urls.get('att_1')?.videoThumbnailAssetUrl?.url).toBe(

--- a/apps/frontend/src/lib/attachments/attachmentUrls.ts
+++ b/apps/frontend/src/lib/attachments/attachmentUrls.ts
@@ -22,7 +22,7 @@ export type AttachmentThumbnailRefreshOptions = {
 export const DEFAULT_ATTACHMENT_THUMBNAIL_REFRESH: AttachmentThumbnailRefreshOptions = {
   width: 960,
   height: 800,
-  fit: FitMode.Cover
+  fit: FitMode.Contain
 };
 
 export const ASSET_URL_REFRESH_LEAD_MS = 2 * 60_000;

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
@@ -128,26 +128,34 @@
   const LANDSCAPE_THUMB_MAX_WIDTH = 480;
   const LANDSCAPE_THUMB_MAX_HEIGHT = 320;
   const PORTRAIT_THUMB_MAX_WIDTH = 320;
-  const PORTRAIT_THUMB_MAX_HEIGHT = 400;
+  const PORTRAIT_THUMB_MAX_HEIGHT = 200;
 
-  function thumbSize(w: number, h: number) {
+  function fitThumbWithinBounds(
+    w: number,
+    h: number,
+    maxW: number,
+    maxH: number,
+    fit: 'cover' | 'contain'
+  ) {
+    const scale = Math.min(maxW / w, maxH / h, 1);
+    return {
+      width: Math.max(Math.round(w * scale), MIN_THUMB_SIZE),
+      height: Math.max(Math.round(h * scale), MIN_THUMB_SIZE),
+      fit
+    };
+  }
+
+  function thumbDisplay(w: number, h: number) {
     const isLandscape = w > h;
     const aspectRatio = w / h;
     const maxW = isLandscape ? LANDSCAPE_THUMB_MAX_WIDTH : PORTRAIT_THUMB_MAX_WIDTH;
     const maxH = isLandscape ? LANDSCAPE_THUMB_MAX_HEIGHT : PORTRAIT_THUMB_MAX_HEIGHT;
 
-    if (aspectRatio >= EXTREME_ASPECT_RATIO || aspectRatio <= 1 / EXTREME_ASPECT_RATIO) {
-      return {
-        width: maxW,
-        height: maxH
-      };
-    }
-
-    const scale = Math.min(maxW / w, maxH / h, 1);
-    return {
-      width: Math.max(Math.round(w * scale), MIN_THUMB_SIZE),
-      height: Math.max(Math.round(h * scale), MIN_THUMB_SIZE)
-    };
+    const fit =
+      aspectRatio >= EXTREME_ASPECT_RATIO || aspectRatio <= 1 / EXTREME_ASPECT_RATIO
+        ? 'contain'
+        : 'cover';
+    return fitThumbWithinBounds(w, h, maxW, maxH, fit);
   }
 
   const imageAttachments = $derived(attachments.filter((a) => a.contentType.startsWith('image/')));
@@ -344,9 +352,9 @@
           {/if}
         </div>
       {:else if attachment.contentType.startsWith('image/')}
-        {@const size =
+        {@const display =
           attachment.width && attachment.height
-            ? thumbSize(attachment.width, attachment.height)
+            ? thumbDisplay(attachment.width, attachment.height)
             : null}
         <button
           type="button"
@@ -354,17 +362,20 @@
           aria-label={m['room.attachment.view_label']({ filename: attachment.filename })}
           class={[
             'group/attachment relative embed-frame block min-w-0 cursor-pointer',
-            !size && 'max-h-64'
+            !display && 'max-h-32'
           ]}
-          style={size
-            ? `width: ${size.width}px; max-width: 100%; aspect-ratio: ${size.width} / ${size.height}`
+          style={display
+            ? `width: ${display.width}px; max-width: 100%; aspect-ratio: ${display.width} / ${display.height}`
             : undefined}
         >
           <SkeletonImg
             loading="lazy"
             src={attachment.thumbnailUrl ?? attachment.url}
             alt={attachment.filename}
-            class={['object-cover', size ? 'h-full w-full' : 'max-h-64 w-auto']}
+            class={[
+              display?.fit === 'contain' ? 'object-contain' : 'object-cover',
+              display ? 'h-full w-full' : 'max-h-32 w-auto'
+            ]}
             onerror={() =>
               refreshAfterAssetError(attachment, attachment.thumbnailUrl ? 'thumbnail' : 'asset')}
           />

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
@@ -65,38 +65,40 @@ function imageFrame(container: HTMLElement, filename: string) {
 }
 
 describe('MessageAttachments', () => {
-  it('renders extreme portrait images in a cropped portrait thumbnail frame', () => {
+  it('renders very tall portrait images as contained narrow strips', () => {
     const { container } = renderAttachment(
       imageAttachment({
-        filename: 'portrait.jpg',
+        filename: 'tall.jpg',
         width: 320,
-        height: 1200
+        height: 1600
       })
     );
 
-    const { image, button } = imageFrame(container, 'portrait.jpg');
+    const { image, button } = imageFrame(container, 'tall.jpg');
 
-    expect(button.getAttribute('style')).toContain('width: 320px');
-    expect(button.getAttribute('style')).toContain('aspect-ratio: 320 / 400');
-    expect(image.className).toContain('object-cover');
+    expect(button.getAttribute('style')).toContain('width: 40px');
+    expect(button.getAttribute('style')).toContain('aspect-ratio: 40 / 200');
+    expect(image.className).toContain('object-contain');
+    expect(image.className).not.toContain('object-cover');
     expect(image.className).toContain('h-full');
     expect(image.className).toContain('w-full');
   });
 
-  it('renders extreme landscape images in a cropped landscape thumbnail frame', () => {
+  it('renders ultra-wide landscape images as contained shallow strips', () => {
     const { container } = renderAttachment(
       imageAttachment({
-        filename: 'landscape.jpg',
-        width: 1200,
-        height: 320
+        filename: 'ultra-wide.jpg',
+        width: 2000,
+        height: 100
       })
     );
 
-    const { image, button } = imageFrame(container, 'landscape.jpg');
+    const { image, button } = imageFrame(container, 'ultra-wide.jpg');
 
     expect(button.getAttribute('style')).toContain('width: 480px');
-    expect(button.getAttribute('style')).toContain('aspect-ratio: 480 / 320');
-    expect(image.className).toContain('object-cover');
+    expect(button.getAttribute('style')).toContain('aspect-ratio: 480 / 24');
+    expect(image.className).toContain('object-contain');
+    expect(image.className).not.toContain('object-cover');
     expect(image.className).toContain('h-full');
     expect(image.className).toContain('w-full');
   });

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -5004,8 +5004,8 @@ func TestRoomTimelineServiceHydratesProcessedVideoAttachments(t *testing.T) {
 	if len(attachments) != 1 {
 		t.Fatalf("attachments = %d, want 1", len(attachments))
 	}
-	if got := attachments[0].GetThumbnailAssetUrl().GetUrl(); !strings.Contains(got, "/960x800/cover") {
-		t.Fatalf("attachment thumbnail URL = %q, want 960x800 cover transform", got)
+	if got := attachments[0].GetThumbnailAssetUrl().GetUrl(); !strings.Contains(got, "/960x800/contain") {
+		t.Fatalf("attachment thumbnail URL = %q, want 960x800 contain transform", got)
 	}
 	processing := attachments[0].GetVideoProcessing()
 	if processing == nil {

--- a/cli/internal/connectapi/room_timeline_assembler.go
+++ b/cli/internal/connectapi/room_timeline_assembler.go
@@ -232,7 +232,7 @@ func (h *timelineHydrator) attachments(roomID, messageEventID string, attachment
 			attachment.MessageBodyId = messageEventID
 		}
 		assetURL := h.api.core.GetStableAttachmentAssetURL(attachment.Id, h.viewerID)
-		thumbnailURL := h.api.core.GetStableTransformedAttachmentAssetURL(attachment.Id, h.viewerID, 960, 800, "cover")
+		thumbnailURL := h.api.core.GetStableTransformedAttachmentAssetURL(attachment.Id, h.viewerID, 960, 800, "contain")
 		result = append(result, &apiv1.RoomTimelineAttachment{
 			Id:                attachment.Id,
 			Filename:          attachment.Filename,


### PR DESCRIPTION
Fixes message image thumbnails so ultra-wide and very tall attachments render with contained aspect-ratio frames instead of cropped oversized cards, while keeping ordinary image sizing behavior.
Timeline attachment thumbnail refreshes now request contained 960x800 derivatives so generated thumbnails preserve the full image.
Validated with the Svelte autofixer, targeted Vitest suites, Connect API attachment tests, `go test ./internal/connectapi -run 'Test.*Attachment' -count=1`, and Playwright coverage for generated ultra-wide and very tall image uploads.
