### PR TITLE
fix(frontend): reconcile PWA notification badges

### DIFF
--- a/apps/frontend/src/lib/components/NotificationSync.svelte
+++ b/apps/frontend/src/lib/components/NotificationSync.svelte
@@ -7,7 +7,7 @@ and PWA badge updates.
 **Responsibilities:**
 - Listens for new notifications on all instance event buses and plays the user's selected sound
 - Syncs notification dismissals from other devices
-- Updates PWA dock badge based on aggregated notification count and unread state
+- Updates PWA dock badge based on aggregated pending-notification count
 
 Include this component once in the chat layout (unconditionally).
 -->
@@ -18,9 +18,8 @@ Include this component once in the chat layout (unconditionally).
   import { playNotificationSound } from '$lib/audio/notificationSounds';
   import {
     updateBadge,
-    setFlagBadge,
     clearBadge,
-    syncServiceWorkerUnreadBadgeState
+    syncServiceWorkerNotificationBadgeState
   } from '$lib/notifications/appBadge';
   import type { EventEnvelope, EventHandler } from '$lib/eventBus.svelte';
   import { RoomEventKind, roomEventKind } from '$lib/render/eventKinds';
@@ -98,33 +97,29 @@ Include this component once in the chat layout (unconditionally).
     };
   });
 
-  // Aggregate notification count and unread state across all authenticated instances.
-  let totalNotificationCount = $derived(
-    serverRegistry.servers.reduce((sum, instance) => {
-      const stores = serverRegistry.getStore(instance.id);
-      if (!stores.isAuthenticated) return sum;
-      return (
-        sum + Math.max(stores.notifications.unreadNotificationCount, stores.notifications.count)
-      );
-    }, 0)
-  );
+  let badgeState = $derived.by(() => {
+    let count = 0;
+    let allStoresLoaded = true;
 
-  let hasAnyUnread = $derived(
-    serverRegistry.servers.some((instance) => {
+    for (const instance of serverRegistry.servers) {
       const stores = serverRegistry.getStore(instance.id);
-      if (!stores.isAuthenticated) return false;
-      return stores.roomUnread.hasAnyUnread;
-    })
-  );
+      if (!stores.isAuthenticated) continue;
+      if (!stores.notifications.hasLoaded) allStoresLoaded = false;
+      count += Math.max(stores.notifications.unreadNotificationCount, stores.notifications.count);
+    }
 
-  // Update PWA dock badge based on aggregated state
+    return { count, allStoresLoaded };
+  });
+
+  // Update PWA dock badge based on pending notifications only. Plain unread
+  // rooms stay in-app so users can choose notification levels for important rooms.
   $effect(() => {
-    syncServiceWorkerUnreadBadgeState(hasAnyUnread);
+    if (badgeState.count === 0 && !badgeState.allStoresLoaded) return;
 
-    if (totalNotificationCount > 0) {
-      updateBadge(totalNotificationCount);
-    } else if (hasAnyUnread) {
-      setFlagBadge();
+    syncServiceWorkerNotificationBadgeState(badgeState.count);
+
+    if (badgeState.count > 0) {
+      updateBadge(badgeState.count);
     } else {
       clearBadge();
     }

--- a/apps/frontend/src/lib/components/NotificationSync.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/NotificationSync.svelte.spec.ts
@@ -14,6 +14,7 @@ const { mocks } = vi.hoisted(() => {
     notifications: {
       count: 0,
       unreadNotificationCount: 0,
+      hasLoaded: true,
       addNotification: vi.fn(() => Promise.resolve()),
       removeNotification: vi.fn(),
       consumeLocalDismissal: vi.fn(),
@@ -36,9 +37,8 @@ const { mocks } = vi.hoisted(() => {
       store,
       playNotificationSound: vi.fn(),
       updateBadge: vi.fn(() => Promise.resolve()),
-      setFlagBadge: vi.fn(() => Promise.resolve()),
       clearBadge: vi.fn(() => Promise.resolve()),
-      syncServiceWorkerUnreadBadgeState: vi.fn()
+      syncServiceWorkerNotificationBadgeState: vi.fn()
     }
   };
 });
@@ -76,9 +76,8 @@ vi.mock('$lib/audio/notificationSounds', () => ({
 
 vi.mock('$lib/notifications/appBadge', () => ({
   updateBadge: mocks.updateBadge,
-  setFlagBadge: mocks.setFlagBadge,
   clearBadge: mocks.clearBadge,
-  syncServiceWorkerUnreadBadgeState: mocks.syncServiceWorkerUnreadBadgeState
+  syncServiceWorkerNotificationBadgeState: mocks.syncServiceWorkerNotificationBadgeState
 }));
 
 function dispatch(event: Record<string, unknown>) {
@@ -109,6 +108,7 @@ describe('NotificationSync', () => {
     mocks.store.isAuthenticated = true;
     mocks.store.notifications.count = 0;
     mocks.store.notifications.unreadNotificationCount = 0;
+    mocks.store.notifications.hasLoaded = true;
     mocks.store.roomUnread.hasAnyUnread = false;
     mocks.store.notifications.addNotification.mockResolvedValue(undefined);
     mocks.store.notifications.removeNotification.mockReturnValue(null);
@@ -192,8 +192,7 @@ describe('NotificationSync', () => {
     await renderAndWaitForSubscription();
 
     await vi.waitFor(() => expect(mocks.updateBadge).toHaveBeenCalledWith(3));
-    expect(mocks.syncServiceWorkerUnreadBadgeState).toHaveBeenCalledWith(false);
-    expect(mocks.setFlagBadge).not.toHaveBeenCalled();
+    expect(mocks.syncServiceWorkerNotificationBadgeState).toHaveBeenCalledWith(3);
     expect(mocks.clearBadge).not.toHaveBeenCalled();
   });
 
@@ -201,19 +200,38 @@ describe('NotificationSync', () => {
     await renderAndWaitForSubscription();
 
     await vi.waitFor(() => expect(mocks.clearBadge).toHaveBeenCalledOnce());
-    expect(mocks.syncServiceWorkerUnreadBadgeState).toHaveBeenCalledWith(false);
+    expect(mocks.syncServiceWorkerNotificationBadgeState).toHaveBeenCalledWith(0);
     expect(mocks.updateBadge).not.toHaveBeenCalled();
-    expect(mocks.setFlagBadge).not.toHaveBeenCalled();
   });
 
-  it('shares unread-only badge state with the service worker', async () => {
+  it('does not treat startup zero as authoritative before notifications load', async () => {
+    mocks.store.notifications.hasLoaded = false;
+
+    await renderAndWaitForSubscription();
+
+    expect(mocks.syncServiceWorkerNotificationBadgeState).not.toHaveBeenCalled();
+    expect(mocks.updateBadge).not.toHaveBeenCalled();
+    expect(mocks.clearBadge).not.toHaveBeenCalled();
+  });
+
+  it('still publishes a positive count before all stores are loaded', async () => {
+    mocks.store.notifications.hasLoaded = false;
+    mocks.store.notifications.unreadNotificationCount = 2;
+
+    await renderAndWaitForSubscription();
+
+    await vi.waitFor(() => expect(mocks.updateBadge).toHaveBeenCalledWith(2));
+    expect(mocks.syncServiceWorkerNotificationBadgeState).toHaveBeenCalledWith(2);
+    expect(mocks.clearBadge).not.toHaveBeenCalled();
+  });
+
+  it('does not set a dock badge for unread-only rooms', async () => {
     mocks.store.roomUnread.hasAnyUnread = true;
 
     await renderAndWaitForSubscription();
 
-    await vi.waitFor(() => expect(mocks.setFlagBadge).toHaveBeenCalledOnce());
-    expect(mocks.syncServiceWorkerUnreadBadgeState).toHaveBeenCalledWith(true);
+    await vi.waitFor(() => expect(mocks.clearBadge).toHaveBeenCalledOnce());
+    expect(mocks.syncServiceWorkerNotificationBadgeState).toHaveBeenCalledWith(0);
     expect(mocks.updateBadge).not.toHaveBeenCalled();
-    expect(mocks.clearBadge).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/lib/notifications/appBadge.spec.ts
+++ b/apps/frontend/src/lib/notifications/appBadge.spec.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { syncServiceWorkerNotificationBadgeState } from './appBadge';
+
+function stubBadgeEnvironment(options: { installed: boolean }) {
+  const postMessage = vi.fn();
+  vi.stubGlobal('navigator', {
+    setAppBadge: vi.fn(),
+    clearAppBadge: vi.fn(),
+    serviceWorker: {
+      controller: { postMessage }
+    }
+  });
+  vi.stubGlobal('window', {
+    matchMedia: vi.fn((query: string) => ({
+      matches: options.installed && query === '(display-mode: standalone)'
+    }))
+  });
+
+  return { postMessage };
+}
+
+describe('syncServiceWorkerNotificationBadgeState', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('tells the service worker to skip worker-side badging in a browser tab', () => {
+    const { postMessage } = stubBadgeEnvironment({ installed: false });
+
+    syncServiceWorkerNotificationBadgeState(3);
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'chatto-badge-state',
+      notificationCount: 3,
+      serviceWorkerAppBadgeEnabled: false
+    });
+  });
+
+  it('allows worker-side badging in an installed app display mode', () => {
+    const { postMessage } = stubBadgeEnvironment({ installed: true });
+
+    syncServiceWorkerNotificationBadgeState(3);
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'chatto-badge-state',
+      notificationCount: 3,
+      serviceWorkerAppBadgeEnabled: true
+    });
+  });
+});

--- a/apps/frontend/src/lib/notifications/appBadge.ts
+++ b/apps/frontend/src/lib/notifications/appBadge.ts
@@ -14,16 +14,34 @@ export function isSupported(): boolean {
   return typeof navigator !== 'undefined' && 'setAppBadge' in navigator;
 }
 
+function isInstalledAppContext(): boolean {
+  if (typeof window === 'undefined') return false;
+
+  const standaloneDisplayModes = ['standalone', 'fullscreen', 'minimal-ui', 'window-controls-overlay'];
+  if (standaloneDisplayModes.some((mode) => window.matchMedia?.(`(display-mode: ${mode})`).matches)) {
+    return true;
+  }
+
+  return (navigator as Navigator & { standalone?: boolean }).standalone === true;
+}
+
+function normalizeBadgeCount(notificationCount: number): number {
+  if (!Number.isFinite(notificationCount)) return 0;
+  return Math.max(0, Math.floor(notificationCount));
+}
+
 /**
- * Share foreground unread badge state with the service worker so its native
- * notification cleanup does not erase an unread-only dock flag.
+ * Share the foreground notification count with the service worker so stale
+ * push/native notification badge state can be reconciled against the app's
+ * authoritative pending-notification state.
  */
-export function syncServiceWorkerUnreadBadgeState(hasAnyUnread: boolean): void {
+export function syncServiceWorkerNotificationBadgeState(notificationCount: number): void {
   if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return;
 
   navigator.serviceWorker.controller?.postMessage({
     type: 'chatto-badge-state',
-    hasAnyUnread
+    notificationCount: normalizeBadgeCount(notificationCount),
+    serviceWorkerAppBadgeEnabled: isSupported() && isInstalledAppContext()
   });
 }
 
@@ -62,19 +80,5 @@ export async function clearBadge(): Promise<void> {
     await navigator.clearAppBadge();
   } catch {
     // Silently fail
-  }
-}
-
-/**
- * Set a flag badge (dot without number).
- * Indicates activity without a specific count.
- */
-export async function setFlagBadge(): Promise<void> {
-  if (!isSupported()) return;
-
-  try {
-    await navigator.setAppBadge(); // No argument = flag mode
-  } catch (e) {
-    console.debug('Badge update failed:', e);
   }
 }

--- a/apps/frontend/src/lib/pwa/notificationBadge.worker.spec.ts
+++ b/apps/frontend/src/lib/pwa/notificationBadge.worker.spec.ts
@@ -1,0 +1,397 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  applyAuthoritativeBadgeState,
+  BadgeStateVersionGate,
+  type ForegroundNotificationCountStorage,
+  ServiceWorkerBadgeCoordinator,
+  syncBadgeFromNativeNotifications
+} from './notificationBadge.worker';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function createMemoryForegroundCountStorage(): ForegroundNotificationCountStorage {
+  let notificationCount: number | null = null;
+  let serviceWorkerAppBadgeEnabled = false;
+  return {
+    async readForegroundNotificationCount() {
+      return notificationCount;
+    },
+    async readServiceWorkerAppBadgeEnabled() {
+      return serviceWorkerAppBadgeEnabled;
+    },
+    async writeForegroundNotificationState(count, enabled) {
+      notificationCount = count;
+      serviceWorkerAppBadgeEnabled = enabled;
+    },
+    async clearForegroundNotificationCount() {
+      notificationCount = null;
+    }
+  };
+}
+
+describe('syncBadgeFromNativeNotifications', () => {
+  it('sets the app badge to the remaining native notification count', async () => {
+    const registration = {
+      getNotifications: vi.fn(async () => [{}, {}])
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+
+    await syncBadgeFromNativeNotifications(registration, badgeNavigator);
+
+    expect(registration.getNotifications).toHaveBeenCalledOnce();
+    expect(badgeNavigator.setAppBadge).toHaveBeenCalledWith(2);
+    expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
+  });
+
+  it('uses the foreground notification count as a lower bound when requested', async () => {
+    const registration = {
+      getNotifications: vi.fn(async () => [])
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+
+    await syncBadgeFromNativeNotifications(registration, badgeNavigator, {
+      minimumNotificationCount: 3
+    });
+
+    expect(registration.getNotifications).toHaveBeenCalledOnce();
+    expect(badgeNavigator.setAppBadge).toHaveBeenCalledWith(3);
+    expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
+  });
+
+  it('clears the app badge when no native notifications remain', async () => {
+    const registration = {
+      getNotifications: vi.fn(async () => [])
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+
+    await syncBadgeFromNativeNotifications(registration, badgeNavigator);
+
+    expect(registration.getNotifications).toHaveBeenCalledOnce();
+    expect(badgeNavigator.clearAppBadge).toHaveBeenCalledOnce();
+    expect(badgeNavigator.setAppBadge).not.toHaveBeenCalled();
+  });
+
+  it('does not update the app badge when native notification listing fails', async () => {
+    const registration = {
+      getNotifications: vi.fn(async () => {
+        throw new Error('notification store unavailable');
+      })
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+
+    await syncBadgeFromNativeNotifications(registration, badgeNavigator);
+
+    expect(registration.getNotifications).toHaveBeenCalledOnce();
+    expect(badgeNavigator.setAppBadge).not.toHaveBeenCalled();
+    expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
+  });
+
+  it('preserves the foreground lower bound when native notification listing fails', async () => {
+    const registration = {
+      getNotifications: vi.fn(async () => {
+        throw new Error('notification store unavailable');
+      })
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+
+    await syncBadgeFromNativeNotifications(registration, badgeNavigator, {
+      minimumNotificationCount: 3
+    });
+
+    expect(registration.getNotifications).toHaveBeenCalledOnce();
+    expect(badgeNavigator.setAppBadge).toHaveBeenCalledWith(3);
+    expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
+  });
+});
+
+describe('applyAuthoritativeBadgeState', () => {
+  it('sets a numeric app badge when the authoritative notification count is positive', async () => {
+    const registration = {
+      getNotifications: vi.fn(async () => [{ close: vi.fn() }])
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+
+    await applyAuthoritativeBadgeState(registration, badgeNavigator, 3);
+
+    expect(badgeNavigator.setAppBadge).toHaveBeenCalledWith(3);
+    expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
+    expect(registration.getNotifications).not.toHaveBeenCalled();
+  });
+
+  it('skips a stale positive badge update when a newer state arrived', async () => {
+    const registration = {
+      getNotifications: vi.fn(async () => [])
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+
+    await applyAuthoritativeBadgeState(registration, badgeNavigator, 3, {
+      isCurrent: () => false
+    });
+
+    expect(badgeNavigator.setAppBadge).not.toHaveBeenCalled();
+    expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
+    expect(registration.getNotifications).not.toHaveBeenCalled();
+  });
+
+  it('closes stale native notifications and clears the app badge when count is zero', async () => {
+    const nativeNotifications = [{ close: vi.fn() }, { close: vi.fn() }];
+    const registration = {
+      getNotifications: vi.fn(async () => nativeNotifications)
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+
+    await applyAuthoritativeBadgeState(registration, badgeNavigator, 0);
+
+    expect(registration.getNotifications).toHaveBeenCalledOnce();
+    expect(nativeNotifications[0].close).toHaveBeenCalledOnce();
+    expect(nativeNotifications[1].close).toHaveBeenCalledOnce();
+    expect(badgeNavigator.clearAppBadge).toHaveBeenCalledOnce();
+    expect(badgeNavigator.setAppBadge).not.toHaveBeenCalled();
+  });
+
+  it('does not close notifications or clear the badge when a zero update becomes stale', async () => {
+    const nativeNotifications = [{ close: vi.fn() }, { close: vi.fn() }];
+    const registration = {
+      getNotifications: vi.fn(async () => nativeNotifications)
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+
+    await applyAuthoritativeBadgeState(registration, badgeNavigator, 0, {
+      isCurrent: () => false
+    });
+
+    expect(registration.getNotifications).toHaveBeenCalledOnce();
+    expect(nativeNotifications[0].close).not.toHaveBeenCalled();
+    expect(nativeNotifications[1].close).not.toHaveBeenCalled();
+    expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
+    expect(badgeNavigator.setAppBadge).not.toHaveBeenCalled();
+  });
+
+  it('does not close a pushed notification when a pending zero update is invalidated', async () => {
+    const nativeNotifications = [{ close: vi.fn() }];
+    const listing = deferred<typeof nativeNotifications>();
+    const registration = {
+      getNotifications: vi.fn(() => listing.promise)
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+    const gate = new BadgeStateVersionGate();
+
+    const pending = applyAuthoritativeBadgeState(registration, badgeNavigator, 0, {
+      isCurrent: gate.next()
+    });
+    gate.invalidate();
+    listing.resolve(nativeNotifications);
+    await pending;
+
+    expect(registration.getNotifications).toHaveBeenCalledOnce();
+    expect(nativeNotifications[0].close).not.toHaveBeenCalled();
+    expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
+    expect(badgeNavigator.setAppBadge).not.toHaveBeenCalled();
+  });
+
+  it('still clears the app badge when native notification listing fails for zero count', async () => {
+    const registration = {
+      getNotifications: vi.fn(async () => {
+        throw new Error('notification store unavailable');
+      })
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+
+    await applyAuthoritativeBadgeState(registration, badgeNavigator, 0);
+
+    expect(registration.getNotifications).toHaveBeenCalledOnce();
+    expect(badgeNavigator.clearAppBadge).toHaveBeenCalledOnce();
+    expect(badgeNavigator.setAppBadge).not.toHaveBeenCalled();
+  });
+});
+
+describe('ServiceWorkerBadgeCoordinator', () => {
+  it('preserves the authoritative foreground count after clicking the only native notification', async () => {
+    const registration = {
+      getNotifications: vi.fn(async () => [])
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+    const coordinator = new ServiceWorkerBadgeCoordinator(registration, badgeNavigator);
+
+    await coordinator.applyForegroundNotificationCount(3);
+    await coordinator.reconcileAfterNotificationClick();
+
+    expect(badgeNavigator.setAppBadge).toHaveBeenLastCalledWith(3);
+    expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
+  });
+
+  it('preserves the authoritative foreground count after a service worker restart', async () => {
+    const registration = {
+      getNotifications: vi.fn(async () => [])
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+    const foregroundCountStorage = createMemoryForegroundCountStorage();
+
+    await new ServiceWorkerBadgeCoordinator(
+      registration,
+      badgeNavigator,
+      foregroundCountStorage
+    ).applyForegroundNotificationCount(3, { serviceWorkerAppBadgeEnabled: true });
+
+    await new ServiceWorkerBadgeCoordinator(
+      registration,
+      badgeNavigator,
+      foregroundCountStorage
+    ).reconcileAfterNotificationClick();
+
+    expect(badgeNavigator.setAppBadge).toHaveBeenLastCalledWith(3);
+    expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
+  });
+
+  it('does not call the worker Badging API when foreground reports a browser tab context', async () => {
+    const registration = {
+      getNotifications: vi.fn(async () => [])
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+    const foregroundCountStorage = createMemoryForegroundCountStorage();
+
+    const coordinator = new ServiceWorkerBadgeCoordinator(
+      registration,
+      badgeNavigator,
+      foregroundCountStorage
+    );
+
+    await coordinator.applyForegroundNotificationCount(3, { serviceWorkerAppBadgeEnabled: false });
+    await coordinator.reconcileAfterNotificationClick();
+    await coordinator.setProvisionalPushFlagBadge();
+
+    expect(badgeNavigator.setAppBadge).not.toHaveBeenCalled();
+    expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
+  });
+
+  it('does not preserve a cached foreground count after a dismiss push', async () => {
+    const registration = {
+      getNotifications: vi.fn(async () => [])
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+    const coordinator = new ServiceWorkerBadgeCoordinator(registration, badgeNavigator);
+
+    await coordinator.applyForegroundNotificationCount(1);
+    await coordinator.reconcileAfterDismissPush();
+
+    expect(badgeNavigator.clearAppBadge).toHaveBeenCalledOnce();
+    expect(badgeNavigator.setAppBadge).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the persisted foreground count after a dismiss push', async () => {
+    const registration = {
+      getNotifications: vi.fn(async () => [])
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+    const foregroundCountStorage = createMemoryForegroundCountStorage();
+
+    const coordinator = new ServiceWorkerBadgeCoordinator(
+      registration,
+      badgeNavigator,
+      foregroundCountStorage
+    );
+    await coordinator.applyForegroundNotificationCount(3, { serviceWorkerAppBadgeEnabled: true });
+    await coordinator.reconcileAfterDismissPush();
+
+    await new ServiceWorkerBadgeCoordinator(
+      registration,
+      badgeNavigator,
+      foregroundCountStorage
+    ).reconcileAfterNotificationClick();
+
+    expect(badgeNavigator.clearAppBadge).toHaveBeenLastCalledWith();
+    expect(badgeNavigator.setAppBadge).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates a pending zero-count foreground reconciliation when a regular push arrives', async () => {
+    const nativeNotifications = [{ close: vi.fn() }];
+    const listing = deferred<typeof nativeNotifications>();
+    const registration = {
+      getNotifications: vi.fn(() => listing.promise)
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+    const coordinator = new ServiceWorkerBadgeCoordinator(registration, badgeNavigator);
+
+    const pending = coordinator.applyForegroundNotificationCount(0);
+    coordinator.recordRegularPush();
+    listing.resolve(nativeNotifications);
+    await pending;
+
+    expect(nativeNotifications[0].close).not.toHaveBeenCalled();
+    expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
+  });
+
+  it('does not treat regular pushes as exact increments of the foreground count', async () => {
+    const registration = {
+      getNotifications: vi.fn(async () => [])
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+    const coordinator = new ServiceWorkerBadgeCoordinator(registration, badgeNavigator);
+
+    await coordinator.applyForegroundNotificationCount(3);
+    coordinator.recordRegularPush();
+    await coordinator.reconcileAfterNotificationClick();
+
+    expect(badgeNavigator.setAppBadge).toHaveBeenLastCalledWith(3);
+  });
+});

--- a/apps/frontend/src/lib/pwa/notificationBadge.worker.ts
+++ b/apps/frontend/src/lib/pwa/notificationBadge.worker.ts
@@ -1,0 +1,239 @@
+export interface BadgeCapableNavigator {
+  setAppBadge?: (contents?: number) => Promise<void>;
+  clearAppBadge?: () => Promise<void>;
+}
+
+export interface NativeNotificationLike {
+  close?: () => void;
+}
+
+export interface NotificationListingRegistration {
+  getNotifications(options?: { tag?: string }): Promise<readonly NativeNotificationLike[]>;
+}
+
+export interface ForegroundNotificationCountStorage {
+  readForegroundNotificationCount(): Promise<number | null>;
+  readServiceWorkerAppBadgeEnabled(): Promise<boolean>;
+  writeForegroundNotificationState(
+    notificationCount: number,
+    serviceWorkerAppBadgeEnabled: boolean
+  ): Promise<void>;
+  clearForegroundNotificationCount(): Promise<void>;
+}
+
+const FOREGROUND_NOTIFICATION_COUNT_REQUEST = '/__chatto/foreground-notification-count';
+
+function normalizeBadgeCount(notificationCount: number): number {
+  if (!Number.isFinite(notificationCount)) return 0;
+  return Math.max(0, Math.floor(notificationCount));
+}
+
+interface StoredForegroundBadgeState {
+  notificationCount: number | null;
+  serviceWorkerAppBadgeEnabled: boolean;
+}
+
+function normalizeStoredForegroundBadgeState(value: unknown): StoredForegroundBadgeState {
+  if (!value || typeof value !== 'object') {
+    return { notificationCount: null, serviceWorkerAppBadgeEnabled: false };
+  }
+
+  const state = value as {
+    notificationCount?: unknown;
+    serviceWorkerAppBadgeEnabled?: unknown;
+  };
+  return {
+    notificationCount:
+      typeof state.notificationCount === 'number'
+        ? normalizeBadgeCount(state.notificationCount)
+        : null,
+    serviceWorkerAppBadgeEnabled: state.serviceWorkerAppBadgeEnabled === true
+  };
+}
+
+export function createCacheForegroundNotificationCountStorage(
+  caches: CacheStorage,
+  cacheName: string
+): ForegroundNotificationCountStorage {
+  async function readState(): Promise<StoredForegroundBadgeState> {
+    try {
+      const cache = await caches.open(cacheName);
+      const response = await cache.match(FOREGROUND_NOTIFICATION_COUNT_REQUEST);
+      if (!response) return { notificationCount: null, serviceWorkerAppBadgeEnabled: false };
+
+      return normalizeStoredForegroundBadgeState(await response.json());
+    } catch {
+      return { notificationCount: null, serviceWorkerAppBadgeEnabled: false };
+    }
+  }
+
+  async function writeState(state: StoredForegroundBadgeState): Promise<void> {
+    try {
+      const cache = await caches.open(cacheName);
+      await cache.put(
+        FOREGROUND_NOTIFICATION_COUNT_REQUEST,
+        new Response(JSON.stringify(state), {
+          headers: { 'content-type': 'application/json' }
+        })
+      );
+    } catch {
+      // Badge state persistence is best-effort; foreground messages still update
+      // the current worker instance and the visible app badge.
+    }
+  }
+
+  return {
+    async readForegroundNotificationCount() {
+      return (await readState()).notificationCount;
+    },
+    async readServiceWorkerAppBadgeEnabled() {
+      return (await readState()).serviceWorkerAppBadgeEnabled;
+    },
+    async writeForegroundNotificationState(notificationCount, serviceWorkerAppBadgeEnabled) {
+      await writeState({
+        notificationCount: normalizeBadgeCount(notificationCount),
+        serviceWorkerAppBadgeEnabled
+      });
+    },
+    async clearForegroundNotificationCount() {
+      const state = await readState();
+      await writeState({ ...state, notificationCount: null });
+    }
+  };
+}
+
+export class BadgeStateVersionGate {
+  #version = 0;
+
+  next(): () => boolean {
+    const version = ++this.#version;
+    return () => version === this.#version;
+  }
+
+  invalidate(): void {
+    this.#version++;
+  }
+}
+
+export async function syncBadgeFromNativeNotifications(
+  registration: NotificationListingRegistration,
+  badgeNavigator: BadgeCapableNavigator,
+  options: { minimumNotificationCount?: number } = {}
+): Promise<void> {
+  const minimumNotificationCount = normalizeBadgeCount(options.minimumNotificationCount ?? 0);
+  let notifications: readonly NativeNotificationLike[];
+  try {
+    notifications = await registration.getNotifications();
+  } catch {
+    if (minimumNotificationCount > 0) {
+      await (badgeNavigator.setAppBadge?.(minimumNotificationCount).catch(() => {}) ??
+        Promise.resolve());
+    }
+    return;
+  }
+
+  const count = Math.max(notifications.length, minimumNotificationCount);
+  if (count > 0) {
+    await (badgeNavigator.setAppBadge?.(count).catch(() => {}) ?? Promise.resolve());
+  } else {
+    await (badgeNavigator.clearAppBadge?.().catch(() => {}) ?? Promise.resolve());
+  }
+}
+
+export async function applyAuthoritativeBadgeState(
+  registration: NotificationListingRegistration,
+  badgeNavigator: BadgeCapableNavigator,
+  notificationCount: number,
+  options: { isCurrent?: () => boolean } = {}
+): Promise<void> {
+  const count = normalizeBadgeCount(notificationCount);
+  if (count > 0) {
+    if (options.isCurrent && !options.isCurrent()) return;
+    await (badgeNavigator.setAppBadge?.(count).catch(() => {}) ?? Promise.resolve());
+    return;
+  }
+
+  let notifications: readonly NativeNotificationLike[] = [];
+  try {
+    notifications = await registration.getNotifications();
+  } catch {
+    // Still clear the badge below; the foreground app's zero count is the
+    // authoritative notification state even if native listing is unavailable.
+  }
+
+  if (options.isCurrent && !options.isCurrent()) return;
+  for (const notification of notifications) {
+    notification.close?.();
+  }
+  await (badgeNavigator.clearAppBadge?.().catch(() => {}) ?? Promise.resolve());
+}
+
+export class ServiceWorkerBadgeCoordinator {
+  #foregroundNotificationCount: number | null = null;
+  #serviceWorkerAppBadgeEnabled: boolean | null = null;
+  #gate = new BadgeStateVersionGate();
+
+  constructor(
+    private readonly registration: NotificationListingRegistration,
+    private readonly badgeNavigator: BadgeCapableNavigator,
+    private readonly foregroundCountStorage?: ForegroundNotificationCountStorage
+  ) {}
+
+  async applyForegroundNotificationCount(
+    notificationCount: number,
+    options: { serviceWorkerAppBadgeEnabled?: boolean } = {}
+  ): Promise<void> {
+    const count = normalizeBadgeCount(notificationCount);
+    this.#foregroundNotificationCount = count;
+    if (options.serviceWorkerAppBadgeEnabled !== undefined) {
+      this.#serviceWorkerAppBadgeEnabled = options.serviceWorkerAppBadgeEnabled;
+    }
+    const isCurrent = this.#gate.next();
+    await this.foregroundCountStorage?.writeForegroundNotificationState(
+      count,
+      await this.isServiceWorkerAppBadgeEnabled()
+    );
+    await applyAuthoritativeBadgeState(this.registration, await this.badgeNavigatorIfEnabled(), count, {
+      isCurrent
+    });
+  }
+
+  recordRegularPush(): void {
+    this.#gate.invalidate();
+    this.#foregroundNotificationCount = Math.max(this.#foregroundNotificationCount ?? 0, 1);
+  }
+
+  async reconcileAfterDismissPush(): Promise<void> {
+    this.#gate.invalidate();
+    this.#foregroundNotificationCount = null;
+    await this.foregroundCountStorage?.clearForegroundNotificationCount();
+    await syncBadgeFromNativeNotifications(this.registration, await this.badgeNavigatorIfEnabled());
+  }
+
+  async reconcileAfterNotificationClick(): Promise<void> {
+    this.#gate.invalidate();
+    const persistedForegroundCount =
+      (await this.foregroundCountStorage?.readForegroundNotificationCount()) ?? 0;
+    await syncBadgeFromNativeNotifications(this.registration, await this.badgeNavigatorIfEnabled(), {
+      minimumNotificationCount: Math.max(this.#foregroundNotificationCount ?? 0, persistedForegroundCount)
+    });
+  }
+
+  async setProvisionalPushFlagBadge(): Promise<void> {
+    const badgeNavigator = await this.badgeNavigatorIfEnabled();
+    await (badgeNavigator.setAppBadge?.().catch(() => {}) ?? Promise.resolve());
+  }
+
+  private async isServiceWorkerAppBadgeEnabled(): Promise<boolean> {
+    if (this.#serviceWorkerAppBadgeEnabled !== null) return this.#serviceWorkerAppBadgeEnabled;
+    if (!this.foregroundCountStorage) return true;
+
+    this.#serviceWorkerAppBadgeEnabled =
+      await this.foregroundCountStorage.readServiceWorkerAppBadgeEnabled();
+    return this.#serviceWorkerAppBadgeEnabled;
+  }
+
+  private async badgeNavigatorIfEnabled(): Promise<BadgeCapableNavigator> {
+    return (await this.isServiceWorkerAppBadgeEnabled()) ? this.badgeNavigator : {};
+  }
+}

--- a/apps/frontend/src/lib/pwa/notificationClick.worker.spec.ts
+++ b/apps/frontend/src/lib/pwa/notificationClick.worker.spec.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import {
-  clearBadgeIfNoNotificationsRemain,
-  routeNotificationClick,
-  type NotificationClickClient
-} from './notificationClick.worker';
+import { routeNotificationClick, type NotificationClickClient } from './notificationClick.worker';
 
 const ORIGIN = 'https://chatto.example';
 const TARGET_URL = `${ORIGIN}/chat/-/room-1?highlight=event-1`;
@@ -151,71 +147,5 @@ describe('routeNotificationClick', () => {
 
     expect(clients.matchAll).not.toHaveBeenCalled();
     expect(clients.openWindow).not.toHaveBeenCalled();
-  });
-});
-
-describe('clearBadgeIfNoNotificationsRemain', () => {
-  it('clears the app badge when no native notifications remain', async () => {
-    const registration = {
-      getNotifications: vi.fn(async () => [])
-    };
-    const badgeNavigator = {
-      clearAppBadge: vi.fn(async () => {})
-    };
-
-    await clearBadgeIfNoNotificationsRemain(registration, badgeNavigator);
-
-    expect(registration.getNotifications).toHaveBeenCalledOnce();
-    expect(badgeNavigator.clearAppBadge).toHaveBeenCalledOnce();
-  });
-
-  it('keeps the app badge when native notifications remain', async () => {
-    const registration = {
-      getNotifications: vi.fn(async () => [{}])
-    };
-    const badgeNavigator = {
-      clearAppBadge: vi.fn(async () => {})
-    };
-
-    await clearBadgeIfNoNotificationsRemain(registration, badgeNavigator);
-
-    expect(registration.getNotifications).toHaveBeenCalledOnce();
-    expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
-  });
-
-  it('preserves a flag badge when foreground unread state still exists', async () => {
-    const registration = {
-      getNotifications: vi.fn(async () => [])
-    };
-    const badgeNavigator = {
-      setAppBadge: vi.fn(async () => {}),
-      clearAppBadge: vi.fn(async () => {})
-    };
-
-    await clearBadgeIfNoNotificationsRemain(registration, badgeNavigator, { preserveFlag: true });
-
-    expect(registration.getNotifications).toHaveBeenCalledOnce();
-    expect(badgeNavigator.setAppBadge).toHaveBeenCalledOnce();
-    expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
-  });
-
-  it('does not throw or clear when native notification listing fails', async () => {
-    const registration = {
-      getNotifications: vi.fn(async () => {
-        throw new Error('notification store unavailable');
-      })
-    };
-    const badgeNavigator = {
-      setAppBadge: vi.fn(async () => {}),
-      clearAppBadge: vi.fn(async () => {})
-    };
-
-    await expect(
-      clearBadgeIfNoNotificationsRemain(registration, badgeNavigator)
-    ).resolves.toBeUndefined();
-
-    expect(registration.getNotifications).toHaveBeenCalledOnce();
-    expect(badgeNavigator.setAppBadge).not.toHaveBeenCalled();
-    expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/lib/pwa/notificationClick.worker.ts
+++ b/apps/frontend/src/lib/pwa/notificationClick.worker.ts
@@ -24,21 +24,12 @@ export interface NotificationClickClients {
   matchAll(options: {
     type: 'window';
     includeUncontrolled: true;
-  }): Promise<NotificationClickClient[]>;
+  }): Promise<readonly NotificationClickClient[]>;
   openWindow(url: string): Promise<NotificationClickClient | null>;
 }
 
 interface NotificationClickLogger {
   warn: (...args: unknown[]) => void;
-}
-
-export interface BadgeCapableNavigator {
-  setAppBadge?: (contents?: number) => Promise<void>;
-  clearAppBadge?: () => Promise<void>;
-}
-
-export interface NotificationListingRegistration {
-  getNotifications(): Promise<readonly unknown[]>;
 }
 
 export type NotificationClickRouteResult = 'ignored' | 'client' | 'navigate' | 'open';
@@ -51,25 +42,6 @@ export interface NotificationClickRouteOptions {
 
 function createDefaultMessageChannel(): NotificationClickMessageChannel {
   return new MessageChannel();
-}
-
-export async function clearBadgeIfNoNotificationsRemain(
-  registration: NotificationListingRegistration,
-  badgeNavigator: BadgeCapableNavigator,
-  options: { preserveFlag?: boolean } = {}
-): Promise<void> {
-  let notifications: readonly unknown[];
-  try {
-    notifications = await registration.getNotifications();
-  } catch {
-    return;
-  }
-  if (notifications.length > 0) return;
-  if (options.preserveFlag) {
-    await (badgeNavigator.setAppBadge?.().catch(() => {}) ?? Promise.resolve());
-  } else {
-    await (badgeNavigator.clearAppBadge?.().catch(() => {}) ?? Promise.resolve());
-  }
 }
 
 function isNotificationClickAck(message: unknown): boolean {

--- a/apps/frontend/src/lib/state/server/notifications.spec.ts
+++ b/apps/frontend/src/lib/state/server/notifications.spec.ts
@@ -94,6 +94,7 @@ describe('NotificationStore', () => {
     await store.fetch();
     expect(store.notifications).toHaveLength(2);
     expect(store.error).toBeNull();
+    expect(store.hasLoaded).toBe(true);
   });
 
   it('fetchRoomNotification returns the newest room-scoped notification and caches it', async () => {
@@ -279,6 +280,7 @@ describe('NotificationStore', () => {
     expect(store.notifications).toHaveLength(1);
     expect(store.notifications[0].id).toBe('original');
     expect(store.error).toContain('Cannot query field');
+    expect(store.hasLoaded).toBe(false);
     expect(consoleError).toHaveBeenCalled();
   });
 

--- a/apps/frontend/src/lib/state/server/notifications.svelte.ts
+++ b/apps/frontend/src/lib/state/server/notifications.svelte.ts
@@ -144,6 +144,7 @@ export class NotificationStore {
   serverName = $state<string | null>(null);
   unreadNotificationCount = $state(0);
   loading = $state(false);
+  hasLoaded = $state(false);
   error = $state<string | null>(null);
 
   constructor(api: NotificationAPI) {
@@ -348,6 +349,7 @@ export class NotificationStore {
       this.notifications = page.items;
       this.unreadNotificationCount = page.totalCount;
       this.serverName = page.serverName;
+      this.hasLoaded = true;
     } catch (e) {
       this.error = e instanceof Error ? e.message : 'Failed to fetch notifications';
       console.error('Failed to fetch notifications:', e);

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -236,11 +236,17 @@
     return title;
   });
 
-  // Dismiss notifications when entering the room
+  // Dismiss notifications when entering the room, and when new notifications
+  // arrive for a room the viewer is already present in.
   $effect(() => {
     if (!appState.isFocused) return;
 
     const currentRoomId = roomId;
+    const currentRoomData = room.roomData;
+    if (!currentRoomData || currentRoomData.room.id !== currentRoomId) return;
+    const notificationRevision = notificationStore.notifications.map((n) => n.id).join('\0');
+    void notificationRevision;
+
     void (async () => {
       const results = room.isDM
         ? [await notificationStore.dismissDMNotifications(currentRoomId)]

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -50,7 +50,9 @@ const { mocks } = vi.hoisted(() => {
         getThreadEventsAround: vi.fn()
       },
       livekitUrl: null as string | null,
+      roomKind: 1,
       notifications: {
+        notifications: [] as Array<{ id: string }>,
         dismissDMNotifications: vi.fn().mockResolvedValue({ byRoom: {} }),
         dismissMentionNotifications: vi.fn().mockResolvedValue({ byRoom: {} }),
         dismissRoomReplyNotifications: vi.fn().mockResolvedValue({ byRoom: {} }),
@@ -98,7 +100,7 @@ vi.mock('$lib/hooks', () => ({
         id: 'room-1',
         name: 'general',
         description: 'Room description',
-        type: RoomKind.CHANNEL,
+        type: mocks.roomKind,
         isUniversal: false
       },
       spaceName: 'Test Space',
@@ -112,7 +114,7 @@ vi.mock('$lib/hooks', () => ({
       canBanRoomMembers: false
     },
     dmData: null,
-    isDM: false,
+    isDM: mocks.roomKind === RoomKind.DM,
     isRoomLoading: false
   }),
   useRoomUnread: () => ({
@@ -271,6 +273,8 @@ beforeEach(() => {
   mocks.timeline.getThreadEvents.mockResolvedValue(emptyTimelinePage());
   mocks.timeline.getThreadEventsAround.mockResolvedValue(emptyTimelinePage());
   mocks.livekitUrl = null;
+  mocks.roomKind = RoomKind.CHANNEL;
+  mocks.notifications.notifications = [];
   mocks.notifications.dismissDMNotifications.mockResolvedValue({ byRoom: {} });
   mocks.notifications.dismissMentionNotifications.mockResolvedValue({ byRoom: {} });
   mocks.notifications.dismissRoomReplyNotifications.mockResolvedValue({ byRoom: {} });
@@ -313,7 +317,9 @@ describe('Room local message echo', () => {
     const rendered = render(Room, { props: { roomId: 'room-1' } });
     const { container } = rendered;
 
-    await expect.element(q(container, '[data-testid="composer-in-reply-to"]')).toHaveTextContent('');
+    await expect
+      .element(q(container, '[data-testid="composer-in-reply-to"]'))
+      .toHaveTextContent('');
 
     (q(container, '[data-testid="start-composer-reply"]') as HTMLButtonElement).click();
     await expect
@@ -322,7 +328,9 @@ describe('Room local message echo', () => {
 
     await rendered.rerender({ roomId: 'room-2' });
 
-    await expect.element(q(container, '[data-testid="composer-in-reply-to"]')).toHaveTextContent('');
+    await expect
+      .element(q(container, '[data-testid="composer-in-reply-to"]'))
+      .toHaveTextContent('');
   });
 
   it('opens a pending call panel request as a mobile sidebar after navigation', async () => {
@@ -348,6 +356,20 @@ describe('Room local message echo', () => {
 
     await vi.waitFor(() => {
       expect(mocks.rooms.decrementUnreadNotification).toHaveBeenCalledWith('room-1', 1);
+      expect(mocks.rooms.refreshNotificationCounts).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('dismisses active DM notifications and refreshes room notification counts', async () => {
+    mocks.roomKind = RoomKind.DM;
+    mocks.notifications.dismissDMNotifications.mockResolvedValue({ byRoom: { 'room-1': 2 } });
+
+    render(Room, { props: { roomId: 'room-1' } });
+
+    await vi.waitFor(() => {
+      expect(mocks.notifications.dismissDMNotifications).toHaveBeenCalledWith('room-1');
+      expect(mocks.notifications.dismissMentionNotifications).not.toHaveBeenCalled();
+      expect(mocks.rooms.decrementUnreadNotification).toHaveBeenCalledWith('room-1', 2);
       expect(mocks.rooms.refreshNotificationCounts).toHaveBeenCalledOnce();
     });
   });

--- a/apps/frontend/src/service-worker.spec.ts
+++ b/apps/frontend/src/service-worker.spec.ts
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$service-worker', () => ({
+  build: ['/app.js'],
+  files: ['/manifest.webmanifest'],
+  version: 'test-version'
+}));
+
+type ServiceWorkerHandler = (event: {
+  data?: { json: () => unknown };
+  notification?: { close: () => void; data?: { url?: string } };
+  waitUntil: (promise: Promise<unknown>) => void;
+}) => void;
+
+type TestNativeNotification = {
+  close?: () => void;
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function createWaitUntilEvent(extra: Record<string, unknown> = {}) {
+  const pending: Promise<unknown>[] = [];
+  return {
+    event: {
+      ...extra,
+      waitUntil: (promise: Promise<unknown>) => pending.push(promise)
+    },
+    pending
+  };
+}
+
+function createMemoryCacheStorage() {
+  const cachesByName = new Map<string, Map<string, Response>>();
+  return {
+    open: vi.fn(async (name: string) => {
+      let cache = cachesByName.get(name);
+      if (!cache) {
+        cache = new Map();
+        cachesByName.set(name, cache);
+      }
+
+      return {
+        match: vi.fn(async (request: RequestInfo | URL) =>
+          cache.get(request.toString())?.clone()
+        ),
+        put: vi.fn(async (request: RequestInfo | URL, response: Response) => {
+          cache.set(request.toString(), response.clone());
+        }),
+        delete: vi.fn(async (request: RequestInfo | URL) => cache.delete(request.toString()))
+      };
+    }),
+    keys: vi.fn(async () => Array.from(cachesByName.keys())),
+    delete: vi.fn(async (name: string) => cachesByName.delete(name))
+  };
+}
+
+async function importServiceWorker(cacheStorage = createMemoryCacheStorage()) {
+  const handlers = new Map<string, ServiceWorkerHandler[]>();
+  const registration = {
+    getNotifications: vi.fn(
+      async (_options?: { tag?: string }): Promise<TestNativeNotification[]> => []
+    ),
+    showNotification: vi.fn(async () => {})
+  };
+  const clients = {
+    claim: vi.fn(async () => {}),
+    matchAll: vi.fn(async () => []),
+    openWindow: vi.fn(async () => null)
+  };
+  const setAppBadge = vi.fn(async () => {});
+  const clearAppBadge = vi.fn(async () => {});
+
+  vi.stubGlobal('self', {
+    location: { origin: 'https://chatto.example' },
+    registration,
+    clients,
+    skipWaiting: vi.fn(),
+    addEventListener: vi.fn((type: string, handler: ServiceWorkerHandler) => {
+      const list = handlers.get(type) ?? [];
+      list.push(handler);
+      handlers.set(type, list);
+    })
+  });
+  vi.stubGlobal('navigator', { setAppBadge, clearAppBadge });
+  vi.stubGlobal('caches', cacheStorage);
+
+  await import('./service-worker');
+
+  const dispatch = async (type: string, extra: Record<string, unknown> = {}) => {
+    const { event, pending } = createWaitUntilEvent(extra);
+    for (const handler of handlers.get(type) ?? []) {
+      handler(event);
+    }
+    await Promise.all(pending);
+  };
+
+  return {
+    clients,
+    dispatch,
+    getPendingDispatch(type: string, extra: Record<string, unknown> = {}) {
+      return createWaitUntilEvent(extra);
+    },
+    handlers,
+    registration,
+    setAppBadge,
+    clearAppBadge,
+    cacheStorage
+  };
+}
+
+describe('service worker badge orchestration', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('does not let a stale foreground zero clear a regular pushed notification', async () => {
+    const worker = await importServiceWorker();
+    const nativeNotification = { close: vi.fn() };
+    const listing = deferred<Array<typeof nativeNotification>>();
+    worker.registration.getNotifications.mockReturnValueOnce(listing.promise);
+
+    const messageDispatch = worker.getPendingDispatch('message', {
+      data: {
+        type: 'chatto-badge-state',
+        notificationCount: 0,
+        serviceWorkerAppBadgeEnabled: true
+      }
+    });
+    for (const handler of worker.handlers.get('message') ?? []) {
+      handler(messageDispatch.event);
+    }
+
+    await worker.dispatch('push', {
+      data: {
+        json: () => ({
+          title: 'New notification',
+          body: 'Hello',
+          tag: 'notification-1',
+          url: 'https://chatto.example/chat/-/room-1'
+        })
+      }
+    });
+
+    listing.resolve([nativeNotification]);
+    await Promise.all(messageDispatch.pending);
+
+    expect(worker.registration.showNotification).toHaveBeenCalledOnce();
+    expect(nativeNotification.close).not.toHaveBeenCalled();
+    expect(worker.clearAppBadge).not.toHaveBeenCalled();
+  });
+
+  it('preserves a foreground authoritative count after clicking the only native notification', async () => {
+    const worker = await importServiceWorker();
+
+    await worker.dispatch('message', {
+      data: {
+        type: 'chatto-badge-state',
+        notificationCount: 3,
+        serviceWorkerAppBadgeEnabled: true
+      }
+    });
+    worker.registration.getNotifications.mockResolvedValueOnce([]);
+
+    await worker.dispatch('notificationclick', {
+      notification: {
+        close: vi.fn(),
+        data: { url: 'https://chatto.example/chat/-/room-1' }
+      }
+    });
+
+    expect(worker.clearAppBadge).not.toHaveBeenCalled();
+    expect(worker.setAppBadge).toHaveBeenLastCalledWith(3);
+  });
+
+  it('preserves a foreground authoritative count after a service worker restart', async () => {
+    const cacheStorage = createMemoryCacheStorage();
+    const firstWorker = await importServiceWorker(cacheStorage);
+
+    await firstWorker.dispatch('message', {
+      data: {
+        type: 'chatto-badge-state',
+        notificationCount: 3,
+        serviceWorkerAppBadgeEnabled: true
+      }
+    });
+
+    vi.resetModules();
+    const restartedWorker = await importServiceWorker(cacheStorage);
+    restartedWorker.registration.getNotifications.mockResolvedValueOnce([]);
+
+    await restartedWorker.dispatch('notificationclick', {
+      notification: {
+        close: vi.fn(),
+        data: { url: 'https://chatto.example/chat/-/room-1' }
+      }
+    });
+
+    expect(restartedWorker.clearAppBadge).not.toHaveBeenCalled();
+    expect(restartedWorker.setAppBadge).toHaveBeenLastCalledWith(3);
+  });
+
+  it('does not call the worker Badging API for a foreground browser tab', async () => {
+    const worker = await importServiceWorker();
+
+    await worker.dispatch('message', {
+      data: {
+        type: 'chatto-badge-state',
+        notificationCount: 3,
+        serviceWorkerAppBadgeEnabled: false
+      }
+    });
+    worker.registration.getNotifications.mockResolvedValueOnce([]);
+
+    await worker.dispatch('notificationclick', {
+      notification: {
+        close: vi.fn(),
+        data: { url: 'https://chatto.example/chat/-/room-1' }
+      }
+    });
+
+    expect(worker.clearAppBadge).not.toHaveBeenCalled();
+    expect(worker.setAppBadge).not.toHaveBeenCalled();
+  });
+
+  it('does not preserve a foreground count after a dismiss push without a fresh count', async () => {
+    const worker = await importServiceWorker();
+    const staleNotification = { close: vi.fn() };
+
+    await worker.dispatch('message', {
+      data: {
+        type: 'chatto-badge-state',
+        notificationCount: 1,
+        serviceWorkerAppBadgeEnabled: true
+      }
+    });
+    worker.registration.getNotifications
+      .mockResolvedValueOnce([staleNotification])
+      .mockResolvedValueOnce([]);
+
+    await worker.dispatch('push', {
+      data: {
+        json: () => ({
+          action: 'dismiss',
+          tag: 'notification-1'
+        })
+      }
+    });
+
+    expect(staleNotification.close).toHaveBeenCalledOnce();
+    expect(worker.clearAppBadge).toHaveBeenCalledOnce();
+    expect(worker.setAppBadge).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/frontend/src/service-worker.ts
+++ b/apps/frontend/src/service-worker.ts
@@ -12,32 +12,37 @@
 import { build, files, version } from '$service-worker';
 import { OFFLINE_SHELL_PATH, classifyServiceWorkerRequest } from '$lib/pwa/serviceWorkerPolicy';
 import {
-  clearBadgeIfNoNotificationsRemain,
-  routeNotificationClick
+  routeNotificationClick,
+  type NotificationClickClients
 } from '$lib/pwa/notificationClick.worker';
 import {
   handleAssetProxyFetch,
   handleAssetProxyMessage,
   parseAssetProxyRequest
 } from '$lib/pwa/assetProxy.worker';
+import {
+  ServiceWorkerBadgeCoordinator,
+  createCacheForegroundNotificationCountStorage
+} from '$lib/pwa/notificationBadge.worker';
 
 declare const self: ServiceWorkerGlobalScope;
 
 const CACHE_PREFIX = 'chatto-shell';
 const CACHE_NAME = `${CACHE_PREFIX}-${version}`;
 const BADGE_STATE_CACHE_NAME = 'chatto-badge-state-v1';
-const BADGE_STATE_URL = `${self.location.origin}/__chatto_badge_state__`;
 const SHELL_ASSETS = new Set([...build, ...files, OFFLINE_SHELL_PATH]);
 const PRECACHE_ASSETS = Array.from(new Set([...build, OFFLINE_SHELL_PATH, '/']));
 
-type AppBadgeNavigator = Navigator & {
+type ServiceWorkerAppBadgeNavigator = WorkerNavigator & {
   setAppBadge?: (contents?: number) => Promise<void>;
   clearAppBadge?: () => Promise<void>;
 };
 
-type BadgeState = {
-  hasAnyUnread: boolean;
-};
+const badgeCoordinator = new ServiceWorkerBadgeCoordinator(
+  self.registration,
+  navigator as ServiceWorkerAppBadgeNavigator,
+  createCacheForegroundNotificationCountStorage(caches, BADGE_STATE_CACHE_NAME)
+);
 
 /**
  * Immediately activate new service worker versions.
@@ -158,46 +163,17 @@ interface PushPayload {
   action?: 'dismiss';
 }
 
-function setFlagBadge(): Promise<void> {
-  const badgeNavigator = navigator as AppBadgeNavigator;
-  return badgeNavigator.setAppBadge?.().catch(() => {}) ?? Promise.resolve();
-}
-
 function handleBadgeStateMessage(event: ExtendableMessageEvent): boolean {
   const message = event.data as Record<string, unknown> | undefined;
   if (!message || message.type !== 'chatto-badge-state') return false;
-  if (typeof message.hasAnyUnread !== 'boolean') return false;
+  if (typeof message.notificationCount !== 'number') return false;
 
-  event.waitUntil(saveBadgeState({ hasAnyUnread: message.hasAnyUnread }));
-  return true;
-}
-
-async function saveBadgeState(state: BadgeState): Promise<void> {
-  const cache = await caches.open(BADGE_STATE_CACHE_NAME);
-  await cache.put(
-    BADGE_STATE_URL,
-    new Response(JSON.stringify(state), {
-      headers: { 'content-type': 'application/json' }
+  event.waitUntil(
+    badgeCoordinator.applyForegroundNotificationCount(message.notificationCount, {
+      serviceWorkerAppBadgeEnabled: message.serviceWorkerAppBadgeEnabled === true
     })
   );
-}
-
-async function loadBadgeState(): Promise<BadgeState> {
-  try {
-    const cache = await caches.open(BADGE_STATE_CACHE_NAME);
-    const response = await cache.match(BADGE_STATE_URL);
-    const data = (await response?.json()) as Partial<BadgeState> | undefined;
-    return { hasAnyUnread: data?.hasAnyUnread === true };
-  } catch {
-    return { hasAnyUnread: false };
-  }
-}
-
-async function reconcileNativeNotificationBadge(): Promise<void> {
-  const badgeState = await loadBadgeState();
-  await clearBadgeIfNoNotificationsRemain(self.registration, navigator as AppBadgeNavigator, {
-    preserveFlag: badgeState.hasAnyUnread
-  });
+  return true;
 }
 
 /**
@@ -224,11 +200,13 @@ self.addEventListener('push', (event) => {
       (async () => {
         const notifications = await self.registration.getNotifications({ tag: payload.tag });
         notifications.forEach((n) => n.close());
-        await reconcileNativeNotificationBadge();
+        await badgeCoordinator.reconcileAfterDismissPush();
       })()
     );
     return;
   }
+
+  badgeCoordinator.recordRegularPush();
 
   // Regular notification display
   const options: NotificationOptions = {
@@ -246,7 +224,7 @@ self.addEventListener('push', (event) => {
   event.waitUntil(
     Promise.all([
       self.registration.showNotification(payload.title ?? 'New notification', options),
-      setFlagBadge()
+      badgeCoordinator.setProvisionalPushFlagBadge()
     ])
   );
 });
@@ -264,8 +242,13 @@ self.addEventListener('notificationclick', (event) => {
     typeof event.notification.data?.url === 'string' ? event.notification.data.url : undefined;
   event.waitUntil(
     (async () => {
-      await reconcileNativeNotificationBadge().catch(() => {});
-      await routeNotificationClick(rawUrl, self.location.origin, self.clients, { logger: console });
+      await badgeCoordinator.reconcileAfterNotificationClick().catch(() => {});
+      await routeNotificationClick(
+        rawUrl,
+        self.location.origin,
+        self.clients as unknown as NotificationClickClients,
+        { logger: console }
+      );
     })().catch((err) => {
       console.error('[SW] Error handling notification click:', err);
     })

--- a/docs/fdr/FDR-012-notifications.md
+++ b/docs/fdr/FDR-012-notifications.md
@@ -1,7 +1,7 @@
 # FDR-012: Notifications
 
 **Status:** Active
-**Last reviewed:** 2026-06-25
+**Last reviewed:** 2026-07-01
 
 ## Overview
 
@@ -14,7 +14,8 @@ Chatto has a persistent notification system surfaced through a bell icon and not
 - Mention notifications may come from direct `@username`, role `@role`, `@all`, or `@here` mentions. Sends that would notify more than 10 users require confirmation before notifications are created.
 - Notifications auto-expire after 90 days.
 - Dismissing a notification removes it everywhere — across all the user's open tabs and devices.
-- A notification sound plays and the badge updates in real time as new notifications arrive.
+- A notification sound plays and the in-app and installed PWA notification badges update in real time as new notifications arrive.
+- The installed PWA dock badge reflects pending notifications only; ordinary unread rooms stay in the in-app sidebar unless the user has configured them to create notifications.
 - Users can choose and locally shape the notification sound on each browser with volume, tone, and effect controls.
 - Sidebar orange dots for mentions, replies, DMs, and all-message subscriptions derive from pending notification records.
 - A recipient's Do Not Disturb presence still stores new notifications and updates counts, but those creation events are silent: no notification sound and no web push while DND is active.

--- a/docs/fdr/FDR-013-web-push-notifications.md
+++ b/docs/fdr/FDR-013-web-push-notifications.md
@@ -1,7 +1,7 @@
 # FDR-013: Web Push Notifications
 
 **Status:** Active
-**Last reviewed:** 2026-06-25
+**Last reviewed:** 2026-07-01
 
 ## Overview
 
@@ -14,7 +14,7 @@ Users can opt in to receive notifications through the browser's W3C Web Push sys
 - On granting permission, the browser creates a subscription using the server's VAPID public key. The subscription details (endpoint URL, keys) are sent to the server and stored.
 - When a signed-in user opens Chatto and browser notification permission is already granted, Chatto refreshes the server's copy of the current browser subscription without prompting again.
 - In multi-server mode, native Web Push controls are shown only for the server that served the installed app. Remote servers can still update in-app notification badges and sounds while Chatto is open, but they do not offer direct browser push registration from another server's app origin.
-- On iOS/iPadOS, Web Push is available only for Home Screen web apps on supported versions. Chatto treats Web Push as a notification trigger rather than authoritative app state and reconciles state on foreground reconnect.
+- On iOS/iPadOS, Web Push is available only for Home Screen web apps on supported versions. Chatto treats Web Push as a notification trigger rather than authoritative app state and reconciles pending-notification count, native notifications, and dock badge state when the app is open.
 - Stored subscription fields are bounded: endpoint 4,096 bytes, public key 256 bytes, auth secret 128 bytes, and user agent 512 bytes.
 - A user can have multiple devices subscribed simultaneously — every device receives every push.
 - Push payloads include a title, a truncated message preview (max 100 chars, broken at word boundaries), and a navigation URL.

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -21,8 +21,8 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-009](FDR-009-link-previews.md) | Link Previews | Active | 2026-06-06 |
 | [FDR-010](FDR-010-typing-indicators.md) | Typing Indicators | Active | 2026-05-19 |
 | [FDR-011](FDR-011-user-presence.md) | User Presence | Active | 2026-06-23 |
-| [FDR-012](FDR-012-notifications.md) | Notifications | Active | 2026-06-12 |
-| [FDR-013](FDR-013-web-push-notifications.md) | Web Push Notifications | Active | 2026-06-25 |
+| [FDR-012](FDR-012-notifications.md) | Notifications | Active | 2026-07-01 |
+| [FDR-013](FDR-013-web-push-notifications.md) | Web Push Notifications | Active | 2026-07-01 |
 | [FDR-014](FDR-014-jump-to-present.md) | Jump to Present | Active | 2026-05-19 |
 | [FDR-015](FDR-015-quick-switcher.md) | Quick Switcher (Cmd-K) | Active | 2026-05-31 |
 | [FDR-016](FDR-016-voice-calls.md) | Voice Calls | Active | 2026-06-15 |


### PR DESCRIPTION
Fixes PWA dock badge semantics so installed app badges represent pending notifications only, with foreground notification counts coordinated through the service worker.
This removes unread-room fallback badges, adds a dedicated service-worker badge coordinator, and covers push/dismiss/click races with worker-level tests.
It also fixes active-room DM notification auto-dismissal so notifications that arrive while the viewer is already present in the DM are cleared.
Validated with Svelte autofixer, focused notification/PWA tests, `svelte-check --tsconfig ./tsconfig.json`, and `mise test-frontend`.
