### PR TITLE
feat(dev): add Mailpit to mise dev

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -4,6 +4,10 @@
 name = "Chatto"
 url = "http://localhost:$CONDUCTOR_PORT"
 
+[[preview_urls]]
+name = "Mailpit"
+url = "http://localhost:$CONDUCTOR_PORT+9"
+
 [scripts]
 setup = "mise trust && mise setup"
 run_mode = "concurrent"

--- a/mise.toml
+++ b/mise.toml
@@ -199,9 +199,18 @@ env = {
   CHATTO_DEV_LIVEKIT_KEYS = "devkey: devsecret",
   CHATTO_DEV_LIVEKIT_PORT = "{{env.CHATTO_DEV_PORT_BASE | int + 5}}",
   CHATTO_DEV_LIVEKIT_RTC_TCP_PORT = "{{env.CHATTO_DEV_PORT_BASE | int + 6}}",
-  CHATTO_DEV_LIVEKIT_UDP_PORTS = "{{env.CHATTO_DEV_PORT_BASE | int + 7}}-{{env.CHATTO_DEV_PORT_BASE | int + 9}}",
+  CHATTO_DEV_LIVEKIT_UDP_PORTS = "{{env.CHATTO_DEV_PORT_BASE | int + 7}}",
 }
 run = "exec livekit-server --dev --bind 127.0.0.1 --node-ip 127.0.0.1 --keys \"$CHATTO_DEV_LIVEKIT_KEYS\" --port \"$CHATTO_DEV_LIVEKIT_PORT\" --rtc.tcp_port \"$CHATTO_DEV_LIVEKIT_RTC_TCP_PORT\" --udp-port \"$CHATTO_DEV_LIVEKIT_UDP_PORTS\""
+
+[tasks.dev-mailpit]
+description = "Run a local Mailpit SMTP server with workspace-safe ports"
+env = {
+  CHATTO_DEV_PORT_BASE = "{{env.CONDUCTOR_PORT | default(value=env.PASEO_PORT | default(value='4000'))}}",
+  CHATTO_DEV_MAILPIT_SMTP_PORT = "{{env.CHATTO_DEV_PORT_BASE | int + 8}}",
+  CHATTO_DEV_MAILPIT_UI_PORT = "{{env.CHATTO_DEV_PORT_BASE | int + 9}}",
+}
+run = "exec mailpit --smtp \"127.0.0.1:$CHATTO_DEV_MAILPIT_SMTP_PORT\" --listen \"127.0.0.1:$CHATTO_DEV_MAILPIT_UI_PORT\""
 
 [tasks.dev]
 description = "Run the local backend and frontend development servers"
@@ -227,12 +236,19 @@ export CHATTO_LIVEKIT_URL="${CHATTO_LIVEKIT_URL:-ws://localhost:$((workspace_por
 export CHATTO_LIVEKIT_API_KEY="${CHATTO_LIVEKIT_API_KEY:-devkey}"
 export CHATTO_LIVEKIT_API_SECRET="${CHATTO_LIVEKIT_API_SECRET:-devsecret}"
 export CHATTO_LIVEKIT_WEBHOOK_URL="${CHATTO_LIVEKIT_WEBHOOK_URL:-http://localhost:$CHATTO_WEBSERVER_PORT/webhooks/livekit}"
+export CHATTO_SMTP_ENABLED="${CHATTO_SMTP_ENABLED:-true}"
+export CHATTO_SMTP_HOST="${CHATTO_SMTP_HOST:-127.0.0.1}"
+export CHATTO_SMTP_PORT="${CHATTO_SMTP_PORT:-$((workspace_port_base + 8))}"
+export CHATTO_SMTP_TLS="${CHATTO_SMTP_TLS:-opportunistic}"
+export CHATTO_SMTP_FROM="${CHATTO_SMTP_FROM:-chatto-dev@chatto.localhost}"
 
 printf 'Chatto frontend URL: %s\\n' "$CHATTO_WEBSERVER_URL"
 printf 'Chatto backend URL: http://localhost:%s\\n' "$CHATTO_WEBSERVER_PORT"
 printf 'LiveKit URL: %s\\n' "$CHATTO_LIVEKIT_URL"
+printf 'Mailpit SMTP: %s:%s\\n' "$CHATTO_SMTP_HOST" "$CHATTO_SMTP_PORT"
+printf 'Mailpit UI: http://localhost:%s\\n' "$((workspace_port_base + 9))"
 
-exec mise run --jobs 3 dev-backend ::: dev-frontend ::: dev-livekit
+exec mise run --jobs 4 dev-backend ::: dev-frontend ::: dev-livekit ::: dev-mailpit
 """
 
 [tasks.dev-docs-website]
@@ -271,6 +287,11 @@ env = {
   CHATTO_LIVEKIT_API_KEY = "devkey",
   CHATTO_LIVEKIT_API_SECRET = "devsecret",
   CHATTO_LIVEKIT_WEBHOOK_URL = "http://localhost:{{env.CONDUCTOR_PORT | default(value=env.PASEO_PORT | default(value='4000')) | int}}/webhooks/livekit",
+  CHATTO_SMTP_ENABLED = "true",
+  CHATTO_SMTP_HOST = "127.0.0.1",
+  CHATTO_SMTP_PORT = "{{env.CONDUCTOR_PORT | default(value=env.PASEO_PORT | default(value='4000')) | int + 8}}",
+  CHATTO_SMTP_TLS = "opportunistic",
+  CHATTO_SMTP_FROM = "chatto-dev@chatto.localhost",
 }
 run = "printf 'Chatto URL: %s\\n' \"$CHATTO_WEBSERVER_URL\" && exec bin/chatto"
 


### PR DESCRIPTION
Adds Mailpit to the local `mise dev` stack so Chatto development emails are captured automatically.

This wires Chatto SMTP defaults to Mailpit, keeps all dev services within Conductor's allocated port range, and adds a Mailpit preview URL to Conductor settings.

Validated with `git diff --check`, `mise tasks --json`, the `dev` shell syntax check, Conductor settings TOML parsing, and a local LiveKit/Mailpit smoke test.
