### PR TITLE
fix(frontend): constrain current user card height

### DIFF
--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte
@@ -284,7 +284,7 @@ to the user settings page for the active server.
     {/if}
 
     <div
-      class="flex items-center gap-3 rounded-xl bg-surface py-1 pr-3 pl-1"
+      class="flex h-12 max-h-12 min-h-12 items-center gap-3 overflow-hidden rounded-xl bg-surface pr-3 pl-1"
       data-testid="current-user-identity-card"
     >
       <button
@@ -303,8 +303,8 @@ to the user settings page for the active server.
           <span class={['h-2.5 w-2.5 rounded-full', presenceDotClass]}></span>
         </span>
       </button>
-      <div class="flex min-w-0 flex-1 flex-col leading-tight">
-        <span class="flex min-w-0 items-center gap-1.5 text-sm font-semibold">
+      <div class="flex min-w-0 flex-1 flex-col overflow-hidden leading-tight">
+        <span class="flex min-w-0 items-center gap-1.5 overflow-hidden text-sm font-semibold">
           <span class="min-w-0 truncate">{displayName}</span>
           <UserCustomStatusBadge status={activeServerUser.customStatus} class="text-xs" />
         </span>
@@ -315,8 +315,11 @@ to the user settings page for the active server.
       <a
         href={resolve('/chat/[serverId]/settings', { serverId: serverSegment })}
         title={m['voice.user_settings']()}
-        class="iconify shrink-0 cursor-pointer text-muted uil--setting hover:text-text"
-      ></a>
+        aria-label={m['voice.user_settings']()}
+        class="flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center text-muted hover:text-text"
+      >
+        <span class="iconify text-lg uil--setting" aria-hidden="true"></span>
+      </a>
     </div>
   </div>
 {/if}

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
+import '../../app.css';
 import { q } from '$lib/test-utils';
 import { PresenceStatus } from '$lib/render/types';
 import { presencePreference } from '$lib/state/presencePreference.svelte';
@@ -231,6 +232,45 @@ describe('CurrentUserBar', () => {
     expect(q(container, '[data-testid="current-user-identity-card"]')!.textContent).not.toContain(
       'Out for lunch'
     );
+  });
+
+  it('keeps the identity card at the same control height with long profile content', () => {
+    currentUserState.user = {
+      ...currentUserState.user!,
+      login: 'alice-with-a-very-long-login-name-that-must-truncate',
+      displayName: 'Alice With A Very Long Display Name That Must Stay Inside The User Card',
+      customStatus: {
+        emoji: '🍜',
+        text: 'chatto:status:out_for_lunch',
+        expiresAt: null
+      }
+    };
+
+    const { container } = render(CurrentUserBarTestHarness);
+    const bar = container.firstElementChild as HTMLElement;
+    bar.style.width = '224px';
+
+    const card = q(container, '[data-testid="current-user-identity-card"]')!;
+    const cardRect = card.getBoundingClientRect();
+    const controlReference = document.createElement('div');
+    controlReference.className = 'h-12';
+    document.body.append(controlReference);
+    const expectedHeight = controlReference.getBoundingClientRect().height;
+    controlReference.remove();
+
+    expect(expectedHeight).toBeGreaterThan(0);
+    expect(cardRect.height).toBe(expectedHeight);
+    expect(card.scrollHeight).toBeLessThanOrEqual(card.clientHeight);
+
+    for (const child of Array.from(card.children)) {
+      const rect = child.getBoundingClientRect();
+      expect(rect.top).toBeGreaterThanOrEqual(cardRect.top);
+      expect(rect.bottom).toBeLessThanOrEqual(cardRect.bottom);
+    }
+
+    const settingsIcon = q(card, 'a[href$="/settings"] .iconify')!;
+    const settingsIconRect = settingsIcon.getBoundingClientRect();
+    expect(settingsIconRect.height).toBeLessThan(cardRect.height / 2);
   });
 
   it('hides call controls when the user is not in a call', () => {


### PR DESCRIPTION
## Summary
Fixes the current user card growing taller than nearby bottom controls by pinning it to the shared control height and clipping long identity content.
The settings gear keeps a normal-sized glyph inside a stable hit target, so it no longer expands with the link box.
Adds a browser component regression test for long profile content, vertical containment, and gear glyph sizing.

## Checks
- `mise x -- npx @sveltejs/mcp svelte-autofixer apps/frontend/src/lib/components/CurrentUserBar.svelte --svelte-version 5`
- `mise x -- pnpm --dir apps/frontend exec vitest run src/lib/components/CurrentUserBar.svelte.spec.ts`
- `mise test-frontend`
