### PR TITLE
feat(frontend): add multi-image attachment gallery

### DIFF
--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -77,6 +77,9 @@ generated protobuf clients, Vitest browser tests, Playwright e2e, and Storybook.
 - Use `<SkeletonImg>` instead of `<img class="skeleton">`.
 - Use `link` for inline links, not `text-primary`.
 - Flex children with truncation or fixed-width media usually need `min-w-0`.
+- Prefer native browser scrolling for scrollable regions and galleries; do not
+  intercept wheel, touch, or pointer scrolling unless the interaction is
+  explicitly custom and approved.
 - Do not double-nest `Panel`.
 - `PaneHeader` actions are icon affordances. Put primary actions such as Save,
   Cancel, and Create in the page body or form area.

--- a/apps/frontend/e2e/messages.test.ts
+++ b/apps/frontend/e2e/messages.test.ts
@@ -1,4 +1,5 @@
 import { expect } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
 import sharp from 'sharp';
 import { TIMEOUTS } from './constants';
 import { test } from './setup';
@@ -61,9 +62,9 @@ async function expectContainedAttachmentThumbnail(
   const thumbnailImage = thumbnailButton.locator('img').first();
   await expect(thumbnailImage).toBeVisible({ timeout: TIMEOUTS.COMPLEX_OPERATION });
 
-  await expect.poll(() => thumbnailImage.evaluate((img) => getComputedStyle(img).objectFit)).toBe(
-    'contain'
-  );
+  await expect
+    .poll(() => thumbnailImage.evaluate((img) => getComputedStyle(img).objectFit))
+    .toBe('contain');
 
   const buttonBox = await thumbnailButton.boundingBox();
   const messageBox = await message.locator.boundingBox();
@@ -696,46 +697,142 @@ test('image lightbox supports keyboard navigation with multiple images', async (
   await chatPage.goto();
   await chatPage.enterRoom('general');
 
-  // Upload two images in a single message
-  await roomPage.fileInput.setInputFiles([
-    'e2e/fixtures/brighton.jpg',
-    'e2e/fixtures/brighton2.jpg'
+  const thirdImage = await sharp({
+    create: {
+      width: 1600,
+      height: 900,
+      channels: 3,
+      background: { r: 190, g: 210, b: 235 }
+    }
+  })
+    .png()
+    .toBuffer();
+  const [brightonImage, brighton2Image] = await Promise.all([
+    readFile('e2e/fixtures/brighton.jpg'),
+    readFile('e2e/fixtures/brighton2.jpg')
   ]);
 
-  // Wait for both attachment previews to appear
-  await expect(roomPage.attachmentPreview).toHaveCount(2);
+  // Upload three images in a single message so the desktop gallery overflows its viewport.
+  await roomPage.fileInput.setInputFiles([
+    {
+      name: 'brighton.jpg',
+      mimeType: 'image/jpeg',
+      buffer: brightonImage
+    },
+    {
+      name: 'brighton2.jpg',
+      mimeType: 'image/jpeg',
+      buffer: brighton2Image
+    },
+    {
+      name: 'generated-gallery-third.png',
+      mimeType: 'image/png',
+      buffer: thirdImage
+    }
+  ]);
+
+  // Wait for all attachment previews to appear
+  await expect(roomPage.attachmentPreview).toHaveCount(3);
 
   // Send the message
   await roomPage.messageInput.press('Enter');
 
-  // Wait for both attachment images to appear in the message
-  await expect(roomPage.attachmentImage).toHaveCount(2, { timeout: TIMEOUTS.COMPLEX_OPERATION });
+  // Wait for all attachment images to appear in the message
+  await expect(roomPage.attachmentImage).toHaveCount(3, { timeout: TIMEOUTS.COMPLEX_OPERATION });
+
+  const gallery = page.getByTestId('message-image-gallery');
+  await expect(gallery).toBeVisible();
+  await expect.poll(() => gallery.evaluate((el) => getComputedStyle(el).columnGap)).toBe('12px');
+  const galleryImages = gallery.locator('button[aria-label^="View"]');
+  await expect(galleryImages).toHaveCount(3);
+  await expect.poll(() => gallery.evaluate((el) => el.scrollWidth > el.clientWidth)).toBe(true);
+  await gallery.evaluate((el) => {
+    el.scrollLeft = 0;
+  });
+  await gallery.hover();
+  await page.mouse.wheel(80, 0);
+  await expect.poll(() => gallery.evaluate((el) => el.scrollLeft)).toBeGreaterThan(0);
+  const scrollLeftAfterFirstWheel = await gallery.evaluate((el) => el.scrollLeft);
+  await page.mouse.wheel(80, 0);
+  await expect
+    .poll(() => gallery.evaluate((el) => el.scrollLeft))
+    .toBeGreaterThan(scrollLeftAfterFirstWheel);
+  const galleryBoxes = await galleryImages.evaluateAll((buttons) =>
+    buttons.map((button) => {
+      const rect = button.getBoundingClientRect();
+      return { width: rect.width, height: rect.height };
+    })
+  );
+  expect(galleryBoxes).toHaveLength(3);
+  expect(Math.abs(galleryBoxes[0].height - galleryBoxes[1].height)).toBeLessThanOrEqual(1);
+  expect(galleryBoxes[0].height).toBeGreaterThan(0);
+  expect(Math.max(...galleryBoxes.map((box) => box.width))).toBeLessThanOrEqual(321);
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(gallery).toBeVisible();
+  await gallery.evaluate((el) => {
+    el.scrollLeft = 0;
+    el.dispatchEvent(new Event('scroll'));
+  });
+  const leftFade = page.getByTestId('message-image-gallery-left-fade');
+  const rightFade = page.getByTestId('message-image-gallery-right-fade');
+  await expect.poll(() => leftFade.evaluate((el) => el.classList.contains('opacity-0'))).toBe(true);
+  await expect
+    .poll(() => rightFade.evaluate((el) => el.classList.contains('opacity-0')))
+    .toBe(false);
+  const narrowGalleryBoxes = await galleryImages.evaluateAll((buttons) =>
+    buttons.map((button) => {
+      const rect = button.getBoundingClientRect();
+      return { width: rect.width, height: rect.height };
+    })
+  );
+  expect(narrowGalleryBoxes).toHaveLength(3);
+  expect(Math.abs(narrowGalleryBoxes[0].height - narrowGalleryBoxes[1].height)).toBeLessThanOrEqual(
+    1
+  );
+  expect(Math.max(...narrowGalleryBoxes.map((box) => box.width))).toBeLessThanOrEqual(321);
+
+  await gallery.evaluate((el) => {
+    el.scrollLeft = el.scrollWidth;
+    el.dispatchEvent(new Event('scroll'));
+  });
+  await expect
+    .poll(() => leftFade.evaluate((el) => el.classList.contains('opacity-0')))
+    .toBe(false);
+  await expect
+    .poll(() => rightFade.evaluate((el) => el.classList.contains('opacity-0')))
+    .toBe(true);
 
   // Click the first image to open the lightbox
   await roomPage.attachmentImage.first().click();
 
-  // Verify lightbox is open with counter showing "1 / 2"
+  // Verify lightbox is open with counter showing "1 / 3"
   const dialog = page.locator('dialog[open]');
   await expect(dialog).toBeVisible();
-  await expect(dialog.getByText('1 / 2')).toBeVisible();
+  await expect(dialog.getByText('1 / 3')).toBeVisible();
 
   // Verify the "brighton.jpg" filename is shown
   await expect(dialog.getByText('brighton.jpg')).toBeVisible();
 
   // Press ArrowRight to go to the next image
   await page.keyboard.press('ArrowRight');
-  await expect(dialog.getByText('2 / 2')).toBeVisible();
+  await expect(dialog.getByText('2 / 3')).toBeVisible();
   await expect(dialog.getByText('brighton2.jpg')).toBeVisible();
+
+  // Press ArrowRight again to go to the third image
+  await page.keyboard.press('ArrowRight');
+  await expect(dialog.getByText('3 / 3')).toBeVisible();
+  await expect(dialog.getByText('generated-gallery-third.png')).toBeVisible();
 
   // Press ArrowRight again to wrap around to the first image
   await page.keyboard.press('ArrowRight');
-  await expect(dialog.getByText('1 / 2')).toBeVisible();
+  await expect(dialog.getByText('1 / 3')).toBeVisible();
   await expect(dialog.getByText('brighton.jpg')).toBeVisible();
 
   // Press ArrowLeft to wrap backwards to the last image
   await page.keyboard.press('ArrowLeft');
-  await expect(dialog.getByText('2 / 2')).toBeVisible();
-  await expect(dialog.getByText('brighton2.jpg')).toBeVisible();
+  await expect(dialog.getByText('3 / 3')).toBeVisible();
+  await expect(dialog.getByText('generated-gallery-third.png')).toBeVisible();
 
   // Verify navigation buttons are present
   await expect(dialog.getByRole('button', { name: 'Previous image' })).toBeVisible();
@@ -743,7 +840,7 @@ test('image lightbox supports keyboard navigation with multiple images', async (
 
   // Click the "Next image" button
   await dialog.getByRole('button', { name: 'Next image' }).click();
-  await expect(dialog.getByText('1 / 2')).toBeVisible();
+  await expect(dialog.getByText('1 / 3')).toBeVisible();
 
   // Close with Escape
   await page.keyboard.press('Escape');

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
@@ -48,6 +48,8 @@
   const assetRetrySalts = new SvelteMap<string, number>();
   let refreshPromise: Promise<Map<string, RefreshedAttachmentUrls>> | null = null;
   const failedAssetRefreshKeys = new SvelteSet<string>();
+  let galleryScrolledFromLeft = $state(false);
+  let galleryScrolledFromRight = $state(false);
 
   function normalizeAssetUrl(value: ExpiringAssetUrl | null | undefined): ExpiringAssetUrl | null {
     if (!value) return null;
@@ -126,9 +128,18 @@
   const MIN_THUMB_SIZE = 24;
   const EXTREME_ASPECT_RATIO = 3;
   const LANDSCAPE_THUMB_MAX_WIDTH = 480;
-  const LANDSCAPE_THUMB_MAX_HEIGHT = 320;
   const PORTRAIT_THUMB_MAX_WIDTH = 320;
-  const PORTRAIT_THUMB_MAX_HEIGHT = 200;
+  const SINGLE_THUMB_MAX_HEIGHT = 200;
+  const GALLERY_THUMB_HEIGHT = 180;
+  const GALLERY_THUMB_MIN_WIDTH = 72;
+  const GALLERY_THUMB_MAX_WIDTH = 320;
+  const GALLERY_VIEWPORT_MAX_WIDTH = 680;
+
+  type ThumbDisplay = {
+    width: number;
+    height: number;
+    fit: 'cover' | 'contain';
+  };
 
   function fitThumbWithinBounds(
     w: number,
@@ -149,16 +160,95 @@
     const isLandscape = w > h;
     const aspectRatio = w / h;
     const maxW = isLandscape ? LANDSCAPE_THUMB_MAX_WIDTH : PORTRAIT_THUMB_MAX_WIDTH;
-    const maxH = isLandscape ? LANDSCAPE_THUMB_MAX_HEIGHT : PORTRAIT_THUMB_MAX_HEIGHT;
 
     const fit =
       aspectRatio >= EXTREME_ASPECT_RATIO || aspectRatio <= 1 / EXTREME_ASPECT_RATIO
         ? 'contain'
         : 'cover';
-    return fitThumbWithinBounds(w, h, maxW, maxH, fit);
+    return fitThumbWithinBounds(w, h, maxW, SINGLE_THUMB_MAX_HEIGHT, fit);
   }
 
-  const imageAttachments = $derived(attachments.filter((a) => a.contentType.startsWith('image/')));
+  function galleryThumbDisplay(w: number, h: number): ThumbDisplay {
+    const aspectRatio = w / h;
+    return {
+      width: Math.min(
+        Math.max(Math.round(GALLERY_THUMB_HEIGHT * aspectRatio), GALLERY_THUMB_MIN_WIDTH),
+        GALLERY_THUMB_MAX_WIDTH
+      ),
+      height: GALLERY_THUMB_HEIGHT,
+      fit: 'contain'
+    };
+  }
+
+  function fallbackGalleryThumbDisplay(): ThumbDisplay {
+    return {
+      width: GALLERY_THUMB_HEIGHT,
+      height: GALLERY_THUMB_HEIGHT,
+      fit: 'contain'
+    };
+  }
+
+  function isGalleryImageAttachment(attachment: Attachment): boolean {
+    return (
+      attachment.contentType.startsWith('image/') &&
+      !(attachment.contentType === 'image/gif' && attachment.videoProcessing)
+    );
+  }
+
+  function imageButtonStyle(display: ThumbDisplay, variant: 'single' | 'gallery'): string {
+    if (variant === 'gallery') {
+      return `width: ${display.width}px; height: ${display.height}px`;
+    }
+    return `width: ${display.width}px; max-width: 100%; aspect-ratio: ${display.width} / ${display.height}`;
+  }
+
+  function galleryViewportStyle(): string {
+    return `width: min(100%, ${GALLERY_VIEWPORT_MAX_WIDTH}px)`;
+  }
+
+  function updateGalleryScrollEdges(el: HTMLElement) {
+    const maxScrollLeft = Math.max(0, el.scrollWidth - el.clientWidth);
+    const scrollLeft = Math.min(Math.max(el.scrollLeft, 0), maxScrollLeft);
+    const canScroll = maxScrollLeft > 1;
+
+    galleryScrolledFromLeft = canScroll && scrollLeft > 1;
+    galleryScrolledFromRight = canScroll && maxScrollLeft - scrollLeft > 1;
+  }
+
+  function trackGalleryScrollEdges(el: HTMLElement) {
+    const update = () => updateGalleryScrollEdges(el);
+
+    update();
+    el.addEventListener('scroll', update, { passive: true });
+
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    for (const child of el.children) {
+      if (child instanceof HTMLElement) ro.observe(child);
+    }
+
+    const mo = new MutationObserver(() => {
+      ro.disconnect();
+      ro.observe(el);
+      for (const child of el.children) {
+        if (child instanceof HTMLElement) ro.observe(child);
+      }
+      update();
+    });
+    mo.observe(el, { childList: true });
+
+    return () => {
+      el.removeEventListener('scroll', update);
+      mo.disconnect();
+      ro.disconnect();
+    };
+  }
+
+  const imageAttachments = $derived(attachments.filter(isGalleryImageAttachment));
+  const hasImageGallery = $derived(imageAttachments.length > 1);
+  const remainingAttachments = $derived(
+    hasImageGallery ? attachments.filter((a) => !isGalleryImageAttachment(a)) : attachments
+  );
 
   const connection = useConnection();
 
@@ -324,185 +414,237 @@
 </script>
 
 {#if attachments.length > 0}
-  <div class="mt-2 flex flex-wrap gap-x-2 gap-y-3 first:mt-0">
-    {#each attachments as attachment (attachment.id)}
-      {#if attachment.contentType === 'image/gif' && attachment.videoProcessing}
-        <div class="group/attachment relative min-w-0">
-          <VideoPlayer
-            status={attachment.videoProcessing.status}
-            variants={attachment.videoProcessing.variants}
-            thumbnailUrl={attachment.videoProcessing.thumbnailUrl}
-            width={attachment.videoProcessing.width}
-            height={attachment.videoProcessing.height}
-            reasonCode={attachment.videoProcessing.reasonCode}
-            filename={attachment.filename}
-            autoLoop
-            onMediaError={() => refreshAfterAssetError(attachment, 'video')}
-          />
-          {#if canDeleteAttachment}
-            <button
-              type="button"
-              onclick={(e) => openDeleteConfirmation(attachment, e)}
-              class="embed-control-button md:group-hover/attachment:opacity-100"
-              aria-label={m['room.attachment.delete_label']()}
-              title={m['room.attachment.delete_label']()}
-            >
-              <span class="iconify text-sm uil--times"></span>
-            </button>
-          {/if}
-        </div>
-      {:else if attachment.contentType.startsWith('image/')}
-        {@const display =
-          attachment.width && attachment.height
-            ? thumbDisplay(attachment.width, attachment.height)
-            : null}
-        <button
-          type="button"
-          onclick={() => openImageModal(attachment)}
-          aria-label={m['room.attachment.view_label']({ filename: attachment.filename })}
-          class={[
-            'group/attachment relative embed-frame block min-w-0 cursor-pointer',
-            !display && 'max-h-32'
-          ]}
-          style={display
-            ? `width: ${display.width}px; max-width: 100%; aspect-ratio: ${display.width} / ${display.height}`
-            : undefined}
+  {#snippet imageAttachmentButton(attachment: Attachment, variant: 'single' | 'gallery')}
+    {@const display =
+      attachment.width && attachment.height
+        ? variant === 'gallery'
+          ? galleryThumbDisplay(attachment.width, attachment.height)
+          : thumbDisplay(attachment.width, attachment.height)
+        : variant === 'gallery'
+          ? fallbackGalleryThumbDisplay()
+          : null}
+    <button
+      type="button"
+      onclick={() => openImageModal(attachment)}
+      aria-label={m['room.attachment.view_label']({ filename: attachment.filename })}
+      data-testid={variant === 'gallery' ? 'message-gallery-image' : undefined}
+      class={[
+        'group/attachment relative embed-frame block min-w-0 cursor-pointer',
+        variant === 'gallery' && 'shrink-0',
+        !display && 'max-h-32'
+      ]}
+      style={display ? imageButtonStyle(display, variant) : undefined}
+    >
+      <SkeletonImg
+        loading="lazy"
+        src={attachment.thumbnailUrl ?? attachment.url}
+        alt={attachment.filename}
+        class={[
+          display?.fit === 'contain' ? 'object-contain' : 'object-cover',
+          display ? 'h-full w-full' : 'max-h-32 w-auto'
+        ]}
+        onerror={() =>
+          refreshAfterAssetError(attachment, attachment.thumbnailUrl ? 'thumbnail' : 'asset')}
+      />
+      {#if canDeleteAttachment}
+        <span
+          role="button"
+          tabindex="-1"
+          onclick={(e) => openDeleteConfirmation(attachment, e)}
+          onkeydown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') openDeleteConfirmation(attachment, e);
+          }}
+          class="embed-control-button md:group-hover/attachment:opacity-100"
+          aria-label={m['room.attachment.delete_label']()}
+          title={m['room.attachment.delete_label']()}
         >
-          <SkeletonImg
-            loading="lazy"
-            src={attachment.thumbnailUrl ?? attachment.url}
-            alt={attachment.filename}
-            class={[
-              display?.fit === 'contain' ? 'object-contain' : 'object-cover',
-              display ? 'h-full w-full' : 'max-h-32 w-auto'
-            ]}
-            onerror={() =>
-              refreshAfterAssetError(attachment, attachment.thumbnailUrl ? 'thumbnail' : 'asset')}
-          />
-          {#if canDeleteAttachment}
-            <span
-              role="button"
-              tabindex="-1"
-              onclick={(e) => openDeleteConfirmation(attachment, e)}
-              onkeydown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') openDeleteConfirmation(attachment, e);
-              }}
-              class="embed-control-button md:group-hover/attachment:opacity-100"
-              aria-label={m['room.attachment.delete_label']()}
-              title={m['room.attachment.delete_label']()}
-            >
-              <span class="iconify text-sm uil--times"></span>
-            </span>
-          {/if}
-        </button>
-      {:else if attachment.contentType.startsWith('video/') && attachment.videoProcessing}
-        <div class="group/attachment relative min-w-0">
-          <VideoPlayer
-            status={attachment.videoProcessing.status}
-            variants={attachment.videoProcessing.variants}
-            thumbnailUrl={attachment.videoProcessing.thumbnailUrl}
-            width={attachment.videoProcessing.width}
-            height={attachment.videoProcessing.height}
-            reasonCode={attachment.videoProcessing.reasonCode}
-            filename={attachment.filename}
-            onMediaError={() => refreshAfterAssetError(attachment, 'video')}
-          />
-          {#if canDeleteAttachment}
-            <button
-              type="button"
-              onclick={(e) => openDeleteConfirmation(attachment, e)}
-              class="embed-control-button z-10 md:group-hover/attachment:opacity-100"
-              aria-label={m['room.attachment.delete_label']()}
-              title={m['room.attachment.delete_label']()}
-            >
-              <span class="iconify text-sm uil--times"></span>
-            </button>
-          {/if}
-        </div>
-      {:else if attachment.contentType.startsWith('video/')}
-        <!--
+          <span class="iconify text-sm uil--times"></span>
+        </span>
+      {/if}
+    </button>
+  {/snippet}
+
+  {#snippet attachmentItem(attachment: Attachment)}
+    {#if attachment.contentType === 'image/gif' && attachment.videoProcessing}
+      <div class="group/attachment relative min-w-0">
+        <VideoPlayer
+          status={attachment.videoProcessing.status}
+          variants={attachment.videoProcessing.variants}
+          thumbnailUrl={attachment.videoProcessing.thumbnailUrl}
+          width={attachment.videoProcessing.width}
+          height={attachment.videoProcessing.height}
+          reasonCode={attachment.videoProcessing.reasonCode}
+          filename={attachment.filename}
+          autoLoop
+          onMediaError={() => refreshAfterAssetError(attachment, 'video')}
+        />
+        {#if canDeleteAttachment}
+          <button
+            type="button"
+            onclick={(e) => openDeleteConfirmation(attachment, e)}
+            class="embed-control-button md:group-hover/attachment:opacity-100"
+            aria-label={m['room.attachment.delete_label']()}
+            title={m['room.attachment.delete_label']()}
+          >
+            <span class="iconify text-sm uil--times"></span>
+          </button>
+        {/if}
+      </div>
+    {:else if attachment.contentType.startsWith('image/')}
+      {@render imageAttachmentButton(attachment, 'single')}
+    {:else if attachment.contentType.startsWith('video/') && attachment.videoProcessing}
+      <div class="group/attachment relative min-w-0">
+        <VideoPlayer
+          status={attachment.videoProcessing.status}
+          variants={attachment.videoProcessing.variants}
+          thumbnailUrl={attachment.videoProcessing.thumbnailUrl}
+          width={attachment.videoProcessing.width}
+          height={attachment.videoProcessing.height}
+          reasonCode={attachment.videoProcessing.reasonCode}
+          filename={attachment.filename}
+          onMediaError={() => refreshAfterAssetError(attachment, 'video')}
+        />
+        {#if canDeleteAttachment}
+          <button
+            type="button"
+            onclick={(e) => openDeleteConfirmation(attachment, e)}
+            class="embed-control-button z-10 md:group-hover/attachment:opacity-100"
+            aria-label={m['room.attachment.delete_label']()}
+            title={m['room.attachment.delete_label']()}
+          >
+            <span class="iconify text-sm uil--times"></span>
+          </button>
+        {/if}
+      </div>
+    {:else if attachment.contentType.startsWith('video/')}
+      <!--
           A video attachment that hasn't been projected as a processing manifest
           yet — e.g. the message arrived before AssetProcessingStartedEvent did,
           or processing has never been requested for this asset. Render the raw
           original so the user can at least play it.
         -->
-        <div class="embed-frame">
-          <video
+      <div class="embed-frame">
+        <video
+          controls
+          preload="metadata"
+          src={attachment.url}
+          class="max-h-64 max-w-full"
+          onerror={() => refreshAfterAssetError(attachment, 'asset')}
+        >
+          <track kind="captions" />
+        </video>
+      </div>
+    {:else if attachment.contentType.startsWith('audio/')}
+      <div class="group/attachment relative min-w-0">
+        <div class="embed-frame flex items-center gap-3 px-3 py-2">
+          <audio
             controls
             preload="metadata"
             src={attachment.url}
-            class="max-h-64 max-w-full"
+            class="h-8 max-w-xs"
+            data-testid="audio-player"
             onerror={() => refreshAfterAssetError(attachment, 'asset')}
           >
-            <track kind="captions" />
-          </video>
+            {attachment.filename}
+          </audio>
+          <span class="text-sm text-muted">{attachment.filename}</span>
         </div>
-      {:else if attachment.contentType.startsWith('audio/')}
-        <div class="group/attachment relative min-w-0">
-          <div class="embed-frame flex items-center gap-3 px-3 py-2">
-            <audio
-              controls
-              preload="metadata"
-              src={attachment.url}
-              class="h-8 max-w-xs"
-              data-testid="audio-player"
-              onerror={() => refreshAfterAssetError(attachment, 'asset')}
-            >
-              {attachment.filename}
-            </audio>
-            <span class="text-sm text-muted">{attachment.filename}</span>
-          </div>
-          {#if canDeleteAttachment}
-            <button
-              type="button"
-              onclick={(e) => openDeleteConfirmation(attachment, e)}
-              class="embed-control-button md:group-hover/attachment:opacity-100"
-              aria-label={m['room.attachment.delete_label']()}
-              title={m['room.attachment.delete_label']()}
-            >
-              <span class="iconify text-sm uil--times"></span>
-            </button>
-          {/if}
-        </div>
-      {:else}
-        <div class="group/attachment relative embed-frame block">
+        {#if canDeleteAttachment}
           <button
             type="button"
-            onclick={() => openDownload(attachment)}
-            aria-label={m['room.attachment.download_label']({ filename: attachment.filename })}
-            class="block w-full cursor-pointer text-left"
+            onclick={(e) => openDeleteConfirmation(attachment, e)}
+            class="embed-control-button md:group-hover/attachment:opacity-100"
+            aria-label={m['room.attachment.delete_label']()}
+            title={m['room.attachment.delete_label']()}
           >
-            <div class="flex h-16 items-center gap-2 px-3">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="h-6 w-6 text-muted"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"
-                />
-              </svg>
-              <span class="text-sm">{attachment.filename}</span>
-            </div>
+            <span class="iconify text-sm uil--times"></span>
           </button>
-          {#if canDeleteAttachment}
-            <button
-              type="button"
-              onclick={(e) => openDeleteConfirmation(attachment, e)}
-              class="embed-control-button md:group-hover/attachment:opacity-100"
-              aria-label={m['room.attachment.delete_label']()}
-              title={m['room.attachment.delete_label']()}
+        {/if}
+      </div>
+    {:else}
+      <div class="group/attachment relative embed-frame block">
+        <button
+          type="button"
+          onclick={() => openDownload(attachment)}
+          aria-label={m['room.attachment.download_label']({ filename: attachment.filename })}
+          class="block w-full cursor-pointer text-left"
+        >
+          <div class="flex h-16 items-center gap-2 px-3">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-6 w-6 text-muted"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
             >
-              <span class="iconify text-sm uil--times"></span>
-            </button>
-          {/if}
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"
+              />
+            </svg>
+            <span class="text-sm">{attachment.filename}</span>
+          </div>
+        </button>
+        {#if canDeleteAttachment}
+          <button
+            type="button"
+            onclick={(e) => openDeleteConfirmation(attachment, e)}
+            class="embed-control-button md:group-hover/attachment:opacity-100"
+            aria-label={m['room.attachment.delete_label']()}
+            title={m['room.attachment.delete_label']()}
+          >
+            <span class="iconify text-sm uil--times"></span>
+          </button>
+        {/if}
+      </div>
+    {/if}
+  {/snippet}
+
+  {#if hasImageGallery}
+    <div class="mt-2 flex min-w-0 flex-col gap-2 first:mt-0">
+      <div class="relative max-w-full min-w-0" style={galleryViewportStyle()}>
+        <div
+          {@attach trackGalleryScrollEdges}
+          class="flex w-full gap-3 overflow-x-auto overscroll-x-contain pb-1"
+          data-testid="message-image-gallery"
+        >
+          {#each imageAttachments as attachment (attachment.id)}
+            {@render imageAttachmentButton(attachment, 'gallery')}
+          {/each}
+        </div>
+        <div
+          aria-hidden="true"
+          data-testid="message-image-gallery-left-fade"
+          class={[
+            'pointer-events-none absolute inset-y-0 left-0 z-10 w-8 bg-gradient-to-r from-background to-transparent transition-opacity',
+            !galleryScrolledFromLeft && 'opacity-0'
+          ]}
+        ></div>
+        <div
+          aria-hidden="true"
+          data-testid="message-image-gallery-right-fade"
+          class={[
+            'pointer-events-none absolute inset-y-0 right-0 z-10 w-8 bg-gradient-to-l from-background to-transparent transition-opacity',
+            !galleryScrolledFromRight && 'opacity-0'
+          ]}
+        ></div>
+      </div>
+
+      {#if remainingAttachments.length > 0}
+        <div class="flex flex-wrap gap-x-2 gap-y-3">
+          {#each remainingAttachments as attachment (attachment.id)}
+            {@render attachmentItem(attachment)}
+          {/each}
         </div>
       {/if}
-    {/each}
-  </div>
+    </div>
+  {:else}
+    <div class="mt-2 flex flex-wrap gap-x-2 gap-y-3 first:mt-0">
+      {#each remainingAttachments as attachment (attachment.id)}
+        {@render attachmentItem(attachment)}
+      {/each}
+    </div>
+  {/if}
 {/if}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
@@ -45,15 +45,36 @@ function imageAttachment(overrides: Partial<MessageAttachmentView>): MessageAtta
   };
 }
 
-function renderAttachment(attachment: MessageAttachmentView) {
+function fileAttachment(overrides: Partial<MessageAttachmentView>): MessageAttachmentView {
+  return {
+    id: 'file_1',
+    filename: 'document.pdf',
+    contentType: 'application/pdf',
+    width: 0,
+    height: 0,
+    assetUrl: {
+      url: 'https://chat.example.test/document.pdf',
+      expiresAt: '2027-05-29T15:00:00Z'
+    },
+    thumbnailAssetUrl: null,
+    videoProcessing: null,
+    ...overrides
+  };
+}
+
+function renderAttachments(attachments: MessageAttachmentView[]) {
   return render(MessageAttachments, {
     props: {
-      attachments: [attachment],
+      attachments,
       serverId: 'server_1',
       roomId: 'room_1',
       eventId: 'event_1'
     }
   });
+}
+
+function renderAttachment(attachment: MessageAttachmentView) {
+  return renderAttachments([attachment]);
 }
 
 function imageFrame(container: HTMLElement, filename: string) {
@@ -114,10 +135,98 @@ describe('MessageAttachments', () => {
 
     const { image, button } = imageFrame(container, 'ordinary.jpg');
 
-    expect(button.getAttribute('style')).toContain('width: 480px');
-    expect(button.getAttribute('style')).toContain('aspect-ratio: 480 / 270');
+    expect(button.getAttribute('style')).toContain('width: 356px');
+    expect(button.getAttribute('style')).toContain('aspect-ratio: 356 / 200');
     expect(image.className).toContain('object-cover');
     expect(image.className).toContain('h-full');
     expect(image.className).toContain('w-full');
+  });
+
+  it('renders multiple images inside a horizontal gallery with equal-height frames', () => {
+    const { container } = renderAttachments([
+      imageAttachment({
+        id: 'wide',
+        filename: 'wide.jpg',
+        width: 1600,
+        height: 900
+      }),
+      imageAttachment({
+        id: 'tall',
+        filename: 'tall.jpg',
+        width: 320,
+        height: 1600
+      })
+    ]);
+
+    const gallery = container.querySelector<HTMLElement>('[data-testid="message-image-gallery"]');
+    expect(gallery).not.toBeNull();
+    expect(gallery!.className).toContain('overflow-x-auto');
+    expect(gallery!.className).toContain('overscroll-x-contain');
+    expect(gallery!.className).toContain('gap-3');
+    expect(
+      container.querySelector('[data-testid="message-image-gallery-left-fade"]')
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="message-image-gallery-right-fade"]')
+    ).not.toBeNull();
+
+    const buttons = Array.from(gallery!.querySelectorAll<HTMLButtonElement>('button'));
+    expect(buttons).toHaveLength(2);
+    expect(buttons.map((button) => button.style.height)).toEqual(['180px', '180px']);
+    expect(buttons.every((button) => Number.parseFloat(button.style.width) <= 320)).toBe(true);
+  });
+
+  it('contains ultra-wide gallery images instead of creating shallow thumbnails', () => {
+    const { container } = renderAttachments([
+      imageAttachment({
+        id: 'ultra-wide',
+        filename: 'ultra-wide.jpg',
+        width: 2000,
+        height: 100
+      }),
+      imageAttachment({
+        id: 'ordinary',
+        filename: 'ordinary.jpg',
+        width: 1600,
+        height: 900
+      })
+    ]);
+
+    const { image, button } = imageFrame(container, 'ultra-wide.jpg');
+
+    expect(button.closest('[data-testid="message-image-gallery"]')).not.toBeNull();
+    expect(button.getAttribute('style')).toContain('width: 320px');
+    expect(button.getAttribute('style')).toContain('height: 180px');
+    expect(image.className).toContain('object-contain');
+    expect(image.className).not.toContain('object-cover');
+  });
+
+  it('renders image galleries before non-image attachments in mixed messages', () => {
+    const { container } = renderAttachments([
+      imageAttachment({
+        id: 'first-image',
+        filename: 'first.jpg'
+      }),
+      fileAttachment({
+        id: 'document',
+        filename: 'document.pdf'
+      }),
+      imageAttachment({
+        id: 'second-image',
+        filename: 'second.jpg'
+      })
+    ]);
+
+    const gallery = container.querySelector<HTMLElement>('[data-testid="message-image-gallery"]');
+    const downloadButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label^="Download"]'
+    );
+
+    expect(gallery).not.toBeNull();
+    expect(gallery!.querySelectorAll('button[aria-label^="View"]')).toHaveLength(2);
+    expect(downloadButton).not.toBeNull();
+    expect(
+      gallery!.compareDocumentPosition(downloadButton!) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

Adds a horizontal multi-image attachment gallery with equal-height thumbnail frames, capped widths, native overflow scrolling, and fade hints at scroll edges. Keeps single-image messages on the proportional thumbnail path while aligning their maximum height so ordinary landscape images no longer render taller than other thumbnails. Preserves processed GIF/video handling and image lightbox ordering, and adds frontend guidance to prefer native browser scrolling for scrollable regions unless custom input handling is explicitly approved.

## Validation

Ran Svelte autofixer, the targeted `MessageAttachments.svelte.spec.ts` Vitest suite, the targeted Playwright multiple-image attachment test, and `git diff --check`.
