### PR TITLE
fix(frontend): localize date formatting

### DIFF
--- a/apps/frontend/src/lib/utils/formatTime.spec.ts
+++ b/apps/frontend/src/lib/utils/formatTime.spec.ts
@@ -51,6 +51,10 @@ describe('formatDate', () => {
     expect(formatDate('2025-04-27T14:30:00Z', utc12)).toMatch(/Apr\s*27,?\s*2025/);
   });
 
+  it('uses an explicit locale for visible date labels', () => {
+    expect(formatDate('2025-04-27T14:30:00Z', utc12, 'de-DE')).toMatch(/27\. Apr\.? 2025/);
+  });
+
   it('crosses midnight in non-UTC zone correctly', () => {
     // 2025-04-27T01:00Z is still 2025-04-26 in Los Angeles
     const la = settings('America/Los_Angeles', false);
@@ -64,12 +68,23 @@ describe('formatDateTime', () => {
     expect(out).toMatch(/April\s*27,?\s*2025/);
     expect(out).toContain('14:30');
   });
+
+  it('uses an explicit locale for visible date-time labels', () => {
+    const out = formatDateTime('2025-04-27T14:30:00Z', utc12, 'de-DE');
+    expect(out).toMatch(/27\. April 2025/);
+    expect(out).toContain('14:30');
+  });
 });
 
 describe('formatMonthYear', () => {
   it('formats the month and year in the user timezone', () => {
     const la = settings('America/Los_Angeles', false);
     expect(formatMonthYear('2026-06-01T01:00:00Z', la)).toMatch(/May\s*2026/);
+  });
+
+  it('uses an explicit locale for visible month-year labels', () => {
+    const la = settings('America/Los_Angeles', false);
+    expect(formatMonthYear('2026-06-01T01:00:00Z', la, 'de-DE')).toBe('Mai 2026');
   });
 });
 
@@ -134,7 +149,7 @@ describe('formatDayLabel', () => {
 
     try {
       expect(formatDayLabel('2025-04-27T08:00:00Z', utc12)).toBe('Heute');
-      expect(formatDayLabel('2025-03-10T12:00:00Z', utc12)).toMatch(/Montag/);
+      expect(formatDayLabel('2025-03-10T12:00:00Z', utc12, 'de-DE')).toMatch(/Montag/);
     } finally {
       await loadLocaleMessages('en');
       setReactiveLocale('en');
@@ -218,7 +233,7 @@ describe('fileDateGroup', () => {
   it('groups older files by calendar month and year', () => {
     expect(fileDateGroup('2026-05-21T08:00:00Z', utc12, now, 'de-DE')).toEqual({
       key: 'month:2026-05',
-      label: 'May 2026'
+      label: 'Mai 2026'
     });
   });
 

--- a/apps/frontend/src/lib/utils/formatTime.ts
+++ b/apps/frontend/src/lib/utils/formatTime.ts
@@ -115,8 +115,12 @@ function startOfWeekSerial(parts: DateParts, firstDay: number): number {
 /**
  * Format a message timestamp (e.g., "2:30 PM" or "14:30").
  */
-export function formatMessageTime(date: Date | string, settings: UserSettingsState): string {
-  const fmt = getFormatter(activeLocale(), {
+export function formatMessageTime(
+  date: Date | string,
+  settings: UserSettingsState,
+  locale: string = activeLocale()
+): string {
+  const fmt = getFormatter(locale, {
     hour: '2-digit',
     minute: '2-digit',
     hour12: settings.effectiveHour12,
@@ -128,8 +132,12 @@ export function formatMessageTime(date: Date | string, settings: UserSettingsSta
 /**
  * Format a date for display (e.g., "Jan 15, 2025").
  */
-export function formatDate(date: Date | string, settings: UserSettingsState): string {
-  const fmt = getFormatter(activeLocale(), {
+export function formatDate(
+  date: Date | string,
+  settings: UserSettingsState,
+  locale: string = activeLocale()
+): string {
+  const fmt = getFormatter(locale, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
@@ -141,8 +149,12 @@ export function formatDate(date: Date | string, settings: UserSettingsState): st
 /**
  * Format a date with time for display (e.g., "November 15, 2025, 02:30 PM").
  */
-export function formatDateTime(date: Date | string, settings: UserSettingsState): string {
-  const fmt = getFormatter(activeLocale(), {
+export function formatDateTime(
+  date: Date | string,
+  settings: UserSettingsState,
+  locale: string = activeLocale()
+): string {
+  const fmt = getFormatter(locale, {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
@@ -170,7 +182,11 @@ export function isSameDay(date1: Date, date2: Date, settings: UserSettingsState)
 /**
  * Format a day separator label ("Today", "Yesterday", or a full date).
  */
-export function formatDayLabel(date: Date | string, settings: UserSettingsState): string {
+export function formatDayLabel(
+  date: Date | string,
+  settings: UserSettingsState,
+  locale: string = activeLocale()
+): string {
   const d = toDate(date);
   const now = new Date();
 
@@ -188,7 +204,7 @@ export function formatDayLabel(date: Date | string, settings: UserSettingsState)
   const yearFmt = getFormatter('en-US', { year: 'numeric', timeZone: tz });
   const sameYear = yearFmt.format(d) === yearFmt.format(now);
 
-  const labelFmt = getFormatter(activeLocale(), {
+  const labelFmt = getFormatter(locale, {
     weekday: 'long',
     month: 'long',
     day: 'numeric',
@@ -198,8 +214,12 @@ export function formatDayLabel(date: Date | string, settings: UserSettingsState)
   return labelFmt.format(d);
 }
 
-export function formatMonthYear(date: Date | string, settings: UserSettingsState): string {
-  const fmt = getFormatter(activeLocale(), {
+export function formatMonthYear(
+  date: Date | string,
+  settings: UserSettingsState,
+  locale: string = activeLocale()
+): string {
+  const fmt = getFormatter(locale, {
     month: 'long',
     year: 'numeric',
     timeZone: settings.effectiveTimezone
@@ -232,6 +252,6 @@ export function fileDateGroup(
 
   return {
     key: `month:${itemParts.year}-${String(itemParts.month).padStart(2, '0')}`,
-    label: formatMonthYear(d, settings)
+    label: formatMonthYear(d, settings, locale)
   };
 }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -3,6 +3,7 @@
   import { fade } from 'svelte/transition';
   import { Virtualizer, type VirtualizerHandle } from 'virtua/svelte';
   import * as m from '$lib/i18n/messages';
+  import { getLocale } from '$lib/i18n/runtime';
   import type { RoomEventView } from '$lib/render/types';
   import { isMessagePostedEvent } from '$lib/render/eventKinds';
   import type {
@@ -129,12 +130,13 @@
   let shouldScrollToBottom = $state(true);
   let hasNewMessages = $state(false);
   let lastSeenNewestId = $state<string | null>(null);
-  let firstVisibleDate = $state<string | null>(null);
+  let firstVisibleAt = $state<string | null>(null);
 
   function setShouldScrollToBottom(value: boolean) {
     shouldScrollToBottom = value;
     if (value) {
       hasNewMessages = false;
+      firstVisibleAt = null;
     }
   }
 
@@ -145,6 +147,10 @@
   const composerContext = getComposerContext();
   const scrollState = composerContext.scrollState;
   const userSettings = getUserSettings();
+  const activeLocale = $derived(getLocale());
+  const firstVisibleDate = $derived(
+    firstVisibleAt ? formatDayLabel(firstVisibleAt, userSettings, activeLocale) : null
+  );
 
   // Filter events based on configuration
   let filteredEvents = $derived(
@@ -163,7 +169,7 @@
   );
 
   // Apply message grouping and day separators
-  let eventsWithMeta = $derived(computeEventMetadata(filteredEvents, userSettings));
+  let eventsWithMeta = $derived(computeEventMetadata(filteredEvents, userSettings, activeLocale));
 
   // The unread separator event ID is computed by the parent component
   // (RoomEventsPane for sequence-based, ThreadPane for time-based)
@@ -202,6 +208,7 @@
     initialScrollDone = false;
     setShouldScrollToBottom(true);
     lastSeenNewestId = null;
+    firstVisibleAt = null;
     previousOffset = null;
   });
 
@@ -677,7 +684,7 @@
       for (let i = idx; i < virtualItems.length; i++) {
         const item = virtualItems[i];
         if (item.type === 'event') {
-          firstVisibleDate = formatDayLabel(item.event.createdAt, userSettings);
+          firstVisibleAt = item.event.createdAt;
           break;
         }
       }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/LocaleDateMetadataHarness.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/LocaleDateMetadataHarness.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import { getLocale } from '$lib/i18n/runtime';
+  import type { RoomEventView } from '$lib/render/types';
+  import { RoomEventKind } from '$lib/render/eventKinds';
+  import type { UserSettingsState } from '$lib/state/userSettings.svelte';
+  import { computeEventMetadata } from './messageGrouping';
+
+  const settings = {
+    get effectiveTimezone(): string | undefined {
+      return 'UTC';
+    },
+    get effectiveHour12(): boolean | undefined {
+      return undefined;
+    }
+  } as unknown as UserSettingsState;
+
+  const events = [
+    {
+      id: 'evt-1',
+      createdAt: '2025-11-20T10:00:00Z',
+      actorId: 'u_alice',
+      actor: {
+        id: 'u_alice',
+        login: 'alice',
+        displayName: 'Alice',
+        deleted: false,
+        presenceStatus: 'ONLINE',
+        avatarUrl: null
+      },
+      event: {
+        kind: RoomEventKind.MessagePosted,
+        roomId: 'r_test',
+        body: 'Hello',
+        attachments: [],
+        linkPreview: null,
+        reactions: [],
+        updatedAt: null,
+        inReplyTo: null,
+        threadRootEventId: null,
+        replyCount: 0,
+        lastReplyAt: null,
+        threadParticipants: [],
+        viewerIsFollowingThread: null
+      }
+    }
+  ] as unknown as RoomEventView[];
+
+  const activeLocale = $derived(getLocale());
+  const metadata = $derived(computeEventMetadata(events, settings, activeLocale));
+</script>
+
+<div data-testid="day-label">{metadata[0]?.dayLabel}</div>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/LocaleDateMetadataHarness.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/LocaleDateMetadataHarness.svelte.spec.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync } from 'svelte';
+import { render } from 'vitest-browser-svelte';
+import { q } from '$lib/test-utils';
+import { loadLocaleMessages } from '$lib/i18n/messages';
+import { setReactiveLocale } from '$lib/i18n/state.svelte';
+import LocaleDateMetadataHarness from './LocaleDateMetadataHarness.svelte';
+
+describe('localized date metadata', () => {
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-11-28T12:00:00Z'));
+    await loadLocaleMessages('en');
+    setReactiveLocale('en');
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await loadLocaleMessages('en');
+    setReactiveLocale('en');
+  });
+
+  it('updates precomputed day labels when the active locale changes', async () => {
+    const { container } = render(LocaleDateMetadataHarness);
+    flushSync();
+
+    const label = q(container, '[data-testid="day-label"]');
+    await expect.element(label).toHaveTextContent('Thursday, November 20');
+
+    await loadLocaleMessages('de');
+    setReactiveLocale('de');
+    flushSync();
+
+    await expect.element(label).toHaveTextContent(/Donnerstag/);
+    await expect.element(label).toHaveTextContent(/November/);
+  });
+});

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -39,6 +39,7 @@
   import { isTouchDevice } from '$lib/utils/isTouchDevice';
   import { getUserSettings } from '$lib/state/userSettings.svelte';
   import { formatMessageTime } from '$lib/utils/formatTime';
+  import { getLocale } from '$lib/i18n/runtime';
   import { onThreadFollowChanged } from '$lib/eventBus.svelte';
   import { useMessageActions } from '$lib/hooks';
   import { emojiToName } from '$lib/emoji';
@@ -88,6 +89,7 @@
   const replyState = composerContext.replyState;
   const jumpState = composerContext.jumpState;
   const userSettings = getUserSettings();
+  const activeLocale = $derived(getLocale());
   const isTouch = isTouchDevice();
   // Wrap in $derived to ensure reactivity when the member list changes
   const members = $derived(getRoomMembers());
@@ -273,7 +275,9 @@
   // Common message data for rendering (body, attachments, reactions, updatedAt)
   const msg = $derived(messageEvent);
 
-  const timestamp = $derived(event ? formatMessageTime(event.createdAt, userSettings) : '');
+  const timestamp = $derived(
+    event ? formatMessageTime(event.createdAt, userSettings, activeLocale) : ''
+  );
 
   // Message links referenced in this message's body — rendered inline as previews.
   const embeddedMessageLinks = $derived.by<MessageLink[]>(() => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomFilesPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomFilesPanel.svelte
@@ -9,6 +9,7 @@ Room-scoped file list for the room sidebar.
   import { assetUrlForServer } from '$lib/assets/assetUrls';
   import { getUserSettings } from '$lib/state/userSettings.svelte';
   import { fileDateGroup, formatDateTime } from '$lib/utils/formatTime';
+  import { getLocale } from '$lib/i18n/runtime';
   import * as m from '$lib/i18n/messages';
 
   type RoomFileGroup = {
@@ -30,6 +31,7 @@ Room-scoped file list for the room sidebar.
   } = $props();
 
   const userSettings = getUserSettings();
+  const activeLocale = $derived(getLocale());
 
   const files = $derived(store.items);
   const fileGroups = $derived.by(() => groupFiles(files));
@@ -41,8 +43,8 @@ Room-scoped file list for the room sidebar.
 
     for (const item of items) {
       const group = fileGroupingNow
-        ? fileDateGroup(item.createdAt, userSettings, fileGroupingNow)
-        : fileDateGroup(item.createdAt, userSettings);
+        ? fileDateGroup(item.createdAt, userSettings, fileGroupingNow, activeLocale)
+        : fileDateGroup(item.createdAt, userSettings, undefined, activeLocale);
       let existing = groups.find((candidate) => candidate.key === group.key);
       if (!existing) {
         existing = { ...group, items: [] };
@@ -105,7 +107,7 @@ Room-scoped file list for the room sidebar.
   }
 
   function formatTimestamp(value: string): string {
-    return formatDateTime(value, userSettings);
+    return formatDateTime(value, userSettings, activeLocale);
   }
 
   $effect(() => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { tick } from 'svelte';
 import { q } from '$lib/test-utils';
+import { loadLocaleMessages } from '$lib/i18n/messages';
+import { setReactiveLocale } from '$lib/i18n/state.svelte';
 import { ROOM_MEMBERS_PAGE_SIZE, type RoomMember } from '$lib/state/room/members.svelte';
 import type { PresenceCache } from '$lib/state/presenceCache.svelte';
 import type { RoomData } from '$lib/hooks/useRoomData.svelte';
@@ -338,7 +340,9 @@ function roomAudioFile(filename: string) {
 }
 
 describe('RoomSidebar', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await loadLocaleMessages('en');
+    setReactiveLocale('en');
     queryMock.mockReset();
     memberDirectoryMocks.listRoomMembers.mockReset();
     attachmentMocks.listRoomAttachments.mockReset();
@@ -1605,6 +1609,42 @@ describe('RoomSidebar', () => {
     expect(labels[2]).toContain('week.txt');
     expect(labels[3]).toContain('month.txt');
     expect(labels[4]).toContain('older-month.txt');
+  });
+
+  it('localizes room file date groups with the active locale', async () => {
+    await loadLocaleMessages('de');
+    setReactiveLocale('de');
+    const fileGroupingNow = new Date('2026-06-17T12:00:00Z');
+
+    attachmentMocks.listRoomAttachments.mockResolvedValueOnce({
+      items: [
+        roomFile('today-message', null, 'today.txt', '2026-06-17T08:00:00Z'),
+        roomFile('yesterday-message', null, 'yesterday.txt', '2026-06-16T08:00:00Z'),
+        roomFile('week-message', null, 'week.txt', '2026-06-15T08:00:00Z'),
+        roomFile('month-message', null, 'month.txt', '2026-06-10T08:00:00Z'),
+        roomFile('older-month-message', null, 'older-month.txt', '2026-05-21T08:00:00Z')
+      ],
+      totalCount: 5,
+      hasMore: false
+    });
+
+    const { container } = render(RoomSidebarTestHarness, {
+      props: {
+        activePanel: 'files',
+        roomData: roomData([member(1)], 1, false),
+        fileGroupingNow
+      }
+    });
+
+    await flushRoomFilesPanel();
+
+    expect(roomFileGroupHeadings(container)).toEqual([
+      'Heute',
+      'Gestern',
+      'Diese Woche',
+      'Dieser Monat',
+      'Mai 2026'
+    ]);
   });
 
   it('falls back to a file icon when a video thumbnail fails to load', async () => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageGrouping.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageGrouping.spec.ts
@@ -3,6 +3,8 @@ import { computeEventMetadata } from './messageGrouping';
 import type { RoomEventView } from '$lib/render/types';
 import { RoomEventKind } from '$lib/render/eventKinds';
 import type { UserSettingsState } from '$lib/state/userSettings.svelte';
+import { loadLocaleMessages } from '$lib/i18n/messages';
+import { setReactiveLocale } from '$lib/i18n/state.svelte';
 
 // Mock settings with explicit UTC timezone so tests are deterministic regardless of host TZ
 const defaultSettings = {
@@ -356,6 +358,23 @@ describe('computeEventMetadata', () => {
       const result = computeEventMetadata([event], defaultSettings);
 
       expect(result[0].dayLabel).toMatch(/Thursday, November 20/);
+    });
+
+    it('uses an explicit locale for visible day labels', async () => {
+      await loadLocaleMessages('de');
+      setReactiveLocale('de');
+
+      try {
+        const event = createMockEvent({ createdAt: '2025-11-20T10:00:00Z' });
+        const result = computeEventMetadata([event], defaultSettings, 'de-DE');
+
+        expect(result[0].dayLabel).toMatch(/Donnerstag/);
+        expect(result[0].dayLabel).toMatch(/November/);
+        expect(result[0].dayLabel).toMatch(/20/);
+      } finally {
+        await loadLocaleMessages('en');
+        setReactiveLocale('en');
+      }
     });
 
     it('includes year for dates from different year', () => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageGrouping.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageGrouping.ts
@@ -14,7 +14,8 @@ export type EventWithMeta = {
 
 export function computeEventMetadata(
   events: RoomEventView[],
-  settings: UserSettingsState
+  settings: UserSettingsState,
+  locale?: string
 ): EventWithMeta[] {
   const result: EventWithMeta[] = [];
 
@@ -27,7 +28,7 @@ export function computeEventMetadata(
 
     // Check if we need a day separator (timezone-aware)
     const showDaySeparator = !prevEventDate || !isSameDay(eventDate, prevEventDate, settings);
-    const dayLabel = showDaySeparator ? formatDayLabel(eventDate, settings) : '';
+    const dayLabel = showDaySeparator ? formatDayLabel(eventDate, settings, locale) : '';
 
     // Determine if this is the first message in a group
     let isFirstInGroup = true;

--- a/apps/frontend/src/routes/chat/[serverId]/server-admin/event-log/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/server-admin/event-log/+page.svelte
@@ -18,9 +18,11 @@
   import { Button, Combobox } from '$lib/ui/form';
   import { getUserSettings } from '$lib/state/userSettings.svelte';
   import { formatDateTime as formatDateTimeUtil, formatDayLabel } from '$lib/utils/formatTime';
+  import { getLocale } from '$lib/i18n/runtime';
   import * as m from '$lib/i18n/messages';
 
   const userSettings = getUserSettings();
+  const activeLocale = $derived(getLocale());
 
   const activeServerId = $derived(getActiveServer());
   const stores = $derived(serverRegistry.getStore(activeServerId));
@@ -86,11 +88,11 @@
   }
 
   function formatTimestamp(iso: string): string {
-    return formatDateTimeUtil(iso, userSettings);
+    return formatDateTimeUtil(iso, userSettings, activeLocale);
   }
 
   function formatDateGroup(iso: string): string {
-    return formatDayLabel(iso, userSettings);
+    return formatDayLabel(iso, userSettings, activeLocale);
   }
 
   function dateGroupKey(iso: string): string {

--- a/apps/frontend/src/routes/chat/[serverId]/server-admin/members/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/server-admin/members/+page.svelte
@@ -17,10 +17,12 @@
   import { getUserSettings } from '$lib/state/userSettings.svelte';
   import { useConnection } from '$lib/state/server/connection.svelte';
   import { formatDate as formatDateUtil } from '$lib/utils/formatTime';
+  import { getLocale } from '$lib/i18n/runtime';
   import * as m from '$lib/i18n/messages';
 
   const userSettings = getUserSettings();
   const connection = useConnection();
+  const activeLocale = $derived(getLocale());
   const PAGE_SIZE = 20;
 
   let searchInput = $state('');
@@ -133,7 +135,7 @@
 
   function formatDate(dateStr: string | null | undefined): string {
     if (!dateStr) return '—';
-    return formatDateUtil(dateStr, userSettings);
+    return formatDateUtil(dateStr, userSettings, activeLocale);
   }
 
   // Roles to display in the members list. `everyone` is implicit on every

--- a/apps/frontend/src/routes/chat/[serverId]/server-admin/members/[userId]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/server-admin/members/[userId]/+page.svelte
@@ -20,6 +20,7 @@
   import { toast } from '$lib/ui/toast';
   import { getAvatarInitials } from '$lib/utils/initials';
   import { formatDate, formatDateTime } from '$lib/utils/formatTime';
+  import { getLocale } from '$lib/i18n/runtime';
   import { getLiveLogin } from '$lib/state/userProfiles.svelte';
   import { getUserSettings } from '$lib/state/userSettings.svelte';
   import * as m from '$lib/i18n/messages';
@@ -36,6 +37,7 @@
   const currentUser = $derived(serverRegistry.getStore(getActiveServer()).currentUser);
   const connection = useConnection();
   const userSettings = getUserSettings();
+  const activeLocale = $derived(getLocale());
   const userId = $derived(page.params.userId!);
 
   const serverPerms = getServerPermissions();
@@ -260,14 +262,14 @@
     }
     if (lastLoginChange) {
       return m['admin.member_detail.last_self_rename']({
-        time: formatDateTime(lastLoginChange, userSettings)
+        time: formatDateTime(lastLoginChange, userSettings, activeLocale)
       });
     }
     return m['admin.member_detail.no_self_rename']();
   });
 
   function formatOptionalDate(date: string | null | undefined): string {
-    return date ? formatDate(date, userSettings) : m['admin.common.unknown']();
+    return date ? formatDate(date, userSettings, activeLocale) : m['admin.common.unknown']();
   }
 
   function emailSummary(user: AdminMember): string {
@@ -476,7 +478,7 @@
                   })}
                 {:else if lastLoginChange}
                   {m['admin.members.last_self_rename']({
-                    time: lastLoginChange.toLocaleString()
+                    time: formatDateTime(lastLoginChange, userSettings, activeLocale)
                   })}
                 {:else}
                   {m['admin.members.never_renamed']()}

--- a/apps/frontend/src/routes/chat/[serverId]/server-admin/moderation/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/server-admin/moderation/+page.svelte
@@ -10,12 +10,14 @@
   import UnbanRoomMemberModal from '$lib/components/moderation/UnbanRoomMemberModal.svelte';
   import { getUserSettings } from '$lib/state/userSettings.svelte';
   import { formatDate as formatDateUtil } from '$lib/utils/formatTime';
+  import { getLocale } from '$lib/i18n/runtime';
   import { toast } from '$lib/ui/toast';
   import { useConnection } from '$lib/state/server/connection.svelte';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import * as m from '$lib/i18n/messages';
 
   const userSettings = getUserSettings();
+  const activeLocale = $derived(getLocale());
   const connection = useConnection();
 
   let bans = $state.raw<RoomBanSummary[]>([]);
@@ -70,7 +72,7 @@
 
   function formatDate(value: string | null | undefined): string {
     if (!value) return m['admin.moderation.no_expiry']();
-    return formatDateUtil(value, userSettings);
+    return formatDateUtil(value, userSettings, activeLocale);
   }
 
   function roomLabel(ban: RoomBanSummary): string {

--- a/apps/frontend/src/routes/chat/[serverId]/threads/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/threads/+page.svelte
@@ -16,6 +16,7 @@
   import RoomEvent from '../[roomId]/RoomEvent.svelte';
   import { getUserSettings } from '$lib/state/userSettings.svelte';
   import { formatDate } from '$lib/utils/formatTime';
+  import { getLocale } from '$lib/i18n/runtime';
   import { onThreadFollowChanged } from '$lib/eventBus.svelte';
   import { useEvent } from '$lib/hooks';
   import { isMessagePostedEvent } from '$lib/render/eventKinds';
@@ -37,6 +38,7 @@
 
   const connection = useConnection();
   const userSettings = getUserSettings();
+  const activeLocale = $derived(getLocale());
   const PAGE_SIZE = 20;
 
   type FollowedThreadItem = {
@@ -169,7 +171,7 @@
     if (diffHours < 24) return m['chat.notifications.time_hours']({ count: diffHours });
     if (diffDays < 7) return m['chat.notifications.time_days']({ count: diffDays });
 
-    return formatDate(date, userSettings);
+    return formatDate(date, userSettings, activeLocale);
   }
 </script>
 

--- a/apps/frontend/src/routes/chat/notifications/+page.svelte
+++ b/apps/frontend/src/routes/chat/notifications/+page.svelte
@@ -10,8 +10,10 @@
   import UserAvatar from '$lib/components/UserAvatar.svelte';
   import { getUserSettings } from '$lib/state/userSettings.svelte';
   import { formatDate } from '$lib/utils/formatTime';
+  import { getLocale } from '$lib/i18n/runtime';
 
   const userSettings = getUserSettings();
+  const activeLocale = $derived(getLocale());
 
   // Collect notification stores from all authenticated instances
   type ServerNotification = {
@@ -88,7 +90,7 @@
     if (diffHours < 24) return m['chat.notifications.time_hours']({ count: diffHours });
     if (diffDays < 7) return m['chat.notifications.time_days']({ count: diffDays });
 
-    return formatDate(date, userSettings);
+    return formatDate(date, userSettings, activeLocale);
   }
 
   async function handleClick(item: ServerNotification) {


### PR DESCRIPTION
Localizes frontend date and time labels by threading the active Paraglide locale through shared format helpers and affected chat/admin surfaces.
This fixes German UI dates in room timeline separators, jump-to-present labels, room file groups, message timestamps, notifications, thread lists, and admin/member fields while preserving user timezone and time-format settings.
Added formatter, grouping, and browser coverage for German labels and reactive locale changes.

Validation:
- `mise x -- pnpm --dir apps/frontend run check`
- `mise x -- pnpm --dir apps/frontend exec vitest run --project server src/lib/utils/formatTime.spec.ts 'src/routes/chat/[serverId]/[roomId]/messageGrouping.spec.ts'`
- `mise x -- pnpm --dir apps/frontend exec vitest run --project client 'src/routes/chat/[serverId]/[roomId]/LocaleDateMetadataHarness.svelte.spec.ts' 'src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts'`
- `mise x -- pnpm --dir apps/frontend exec vitest run --project client 'src/routes/chat/[serverId]/server-admin/event-log/event-log.page.svelte.spec.ts'`
- `mise x -- pnpm --dir apps/frontend exec vitest run --project client 'src/routes/chat/[serverId]/server-admin/members/members.page.svelte.spec.ts'`

Note: `mise test-frontend` was attempted, but Vitest browser suites failed to import after Vite dependency-optimization reloads; targeted suites covering this change passed.
