### PR TITLE
fix(frontend): defer camera permission until enabled

### DIFF
--- a/apps/frontend/src/lib/state/server/voiceCall.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/voiceCall.svelte.spec.ts
@@ -16,6 +16,7 @@ import {
   VoiceCallJoinError,
   VoiceCallState
 } from './voiceCall.svelte';
+import { Room } from 'livekit-client';
 
 const calls: string[] = [];
 let lastRoomOptions: Record<string, unknown> | null = null;
@@ -31,6 +32,7 @@ let lastRoom: {
 let connectFailure: Error | null = null;
 let connectGate: { promise: Promise<void>; resolve: () => void } | null = null;
 let microphoneGate: { promise: Promise<void>; resolve: () => void } | null = null;
+let microphoneFailure: Error | null = null;
 let cameraGate: { promise: Promise<void>; resolve: () => void } | null = null;
 let screenShareGate: { promise: Promise<void>; resolve: () => void } | null = null;
 let screenShareFailure: Error | null = null;
@@ -55,12 +57,26 @@ vi.mock('livekit-client', () => {
   }
 
   class MockRoom {
-    static getLocalDevices = vi.fn(async () => []);
+    static getLocalDevices = vi.fn(async (kind?: MediaDeviceKind) => {
+      if (kind === 'audioinput') {
+        return [{ deviceId: 'audio-input-1', kind, label: 'Microphone' }];
+      }
+      if (kind === 'audiooutput') {
+        return [{ deviceId: 'audio-output-1', kind, label: 'Speaker' }];
+      }
+      if (kind === 'videoinput') {
+        return [{ deviceId: 'video-input-1', kind, label: 'Camera' }];
+      }
+      return [];
+    });
 
     localParticipant = {
-      setMicrophoneEnabled: vi.fn(async () => {
+      setMicrophoneEnabled: vi.fn(async (enabled: boolean) => {
         calls.push('setMicrophoneEnabled');
         await microphoneGate?.promise;
+        if (enabled && microphoneFailure) {
+          throw microphoneFailure;
+        }
       }),
       setCameraEnabled: vi.fn(async (enabled: boolean) => {
         calls.push(`setCameraEnabled:${enabled}`);
@@ -199,6 +215,7 @@ describe('VoiceCallState', () => {
     connectFailure = null;
     connectGate = null;
     microphoneGate = null;
+    microphoneFailure = null;
     cameraGate = null;
     screenShareGate = null;
     screenShareFailure = null;
@@ -212,6 +229,7 @@ describe('VoiceCallState', () => {
     vi.stubGlobal('RTCRtpScriptTransform', class MockRTCRtpScriptTransform {});
     vi.stubGlobal('crypto', { subtle: {} });
     soundMocks.playCallSound.mockClear();
+    vi.mocked(Room.getLocalDevices).mockClear();
   });
 
   afterEach(() => {
@@ -242,6 +260,35 @@ describe('VoiceCallState', () => {
     await state.join('wss://livekit.example.test', 'R1');
 
     expect(soundMocks.playCallSound).not.toHaveBeenCalled();
+  });
+
+  it('joins with microphone enabled but does not request camera permission while refreshing devices', async () => {
+    const client = createVoiceCallClient();
+    const state = new VoiceCallState(client);
+
+    await state.join('wss://livekit.example.test', 'R1');
+
+    expect(lastRoom?.localParticipant.setMicrophoneEnabled).toHaveBeenCalledWith(true);
+    expect(lastRoom?.localParticipant.setCameraEnabled).not.toHaveBeenCalled();
+    expect(Room.getLocalDevices).toHaveBeenCalledWith('audioinput');
+    expect(Room.getLocalDevices).toHaveBeenCalledWith('audiooutput');
+    expect(Room.getLocalDevices).toHaveBeenCalledWith('videoinput', false);
+    expect(Room.getLocalDevices).not.toHaveBeenCalledWith('videoinput');
+    expect(Room.getLocalDevices).not.toHaveBeenCalledWith('videoinput', true);
+  });
+
+  it('joins muted when microphone enable fails without enabling the camera', async () => {
+    microphoneFailure = new Error('microphone unavailable');
+    const client = createVoiceCallClient();
+    const state = new VoiceCallState(client);
+
+    await state.join('wss://livekit.example.test', 'R1');
+
+    expect(lastRoom?.localParticipant.setMicrophoneEnabled).toHaveBeenCalledWith(true);
+    expect(lastRoom?.localParticipant.setCameraEnabled).not.toHaveBeenCalled();
+    expect(state.isMuted).toBe(true);
+    expect(state.isInAnyCall).toBe(true);
+    expect(Room.getLocalDevices).toHaveBeenCalledWith('videoinput', false);
   });
 
   it('plays a deferred current-user join event after connecting successfully', async () => {
@@ -452,6 +499,26 @@ describe('VoiceCallState', () => {
 
     expect(state.isCameraPending).toBe(false);
     expect(state.isCameraEnabled).toBe(true);
+  });
+
+  it('refreshes devices without camera permission until camera is explicitly enabled', async () => {
+    const client = createVoiceCallClient();
+    const state = new VoiceCallState(client);
+    await state.join('wss://livekit.example.test', 'R1');
+    vi.mocked(Room.getLocalDevices).mockClear();
+
+    await state.refreshDevices();
+    roomEventHandlers.get('MediaDevicesChanged')?.();
+    await flushPromises();
+
+    expect(Room.getLocalDevices).toHaveBeenCalledWith('videoinput', false);
+    expect(Room.getLocalDevices).not.toHaveBeenCalledWith('videoinput', true);
+
+    vi.mocked(Room.getLocalDevices).mockClear();
+    await state.toggleCamera();
+
+    expect(lastRoom?.localParticipant.setCameraEnabled).toHaveBeenCalledWith(true);
+    expect(Room.getLocalDevices).toHaveBeenCalledWith('videoinput', true);
   });
 
   it('keeps screen share pending until LiveKit applies the toggle', async () => {

--- a/apps/frontend/src/lib/state/server/voiceCall.svelte.ts
+++ b/apps/frontend/src/lib/state/server/voiceCall.svelte.ts
@@ -494,6 +494,9 @@ export class VoiceCallState {
       if (this.room !== room) return;
 
       this.isCameraEnabled = newEnabled;
+      if (newEnabled) {
+        await this.refreshDevices({ requestVideoPermissions: true });
+      }
     } catch {
       // Permission denied or no camera available — keep current state
       if (this.room !== room) return;
@@ -541,12 +544,13 @@ export class VoiceCallState {
   /**
    * Refresh available audio and video devices.
    */
-  async refreshDevices(): Promise<void> {
+  async refreshDevices(options: { requestVideoPermissions?: boolean } = {}): Promise<void> {
     try {
+      const requestVideoPermissions = options.requestVideoPermissions ?? this.isCameraEnabled;
       const [inputDevices, outputDevices, videoInputDevices] = await Promise.all([
         Room.getLocalDevices('audioinput'),
         Room.getLocalDevices('audiooutput'),
-        Room.getLocalDevices('videoinput')
+        Room.getLocalDevices('videoinput', requestVideoPermissions)
       ]);
 
       this.audioDevices = inputDevices;


### PR DESCRIPTION
## Summary

Fixes call join so it only requests microphone access and defers camera permission until the user explicitly enables their camera.

The root cause was LiveKit device refresh using the default permission-requesting video enumeration path immediately after joining.

This keeps camera device labels generic until camera permission is granted, while preserving microphone join behavior and muted fallback.

Validation: `mise x -- pnpm exec vitest run src/lib/state/server/voiceCall.svelte.spec.ts`; `git diff --check`; Svelte autofixer on `voiceCall.svelte.ts`.
