### PR TITLE
fix(api): align ConnectRPC permission exposure

### DIFF
--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
@@ -717,6 +717,7 @@ Ordered group of channel rooms and sidebar links.
 | `name` | `string` | Display name. |
 | `description` | `string` | Public group description, when set. |
 | `items` | repeated [`RoomGroupItem`](#chatto-api-v1-RoomGroupItem) | Mixed room/sidebar-link entries in sidebar order. |
+| `viewer_state` | [`RoomGroupViewerState`](#chatto-api-v1-RoomGroupViewerState) | State and permissions resolved for the current user. |
 
 <a id="chatto-api-v1-RoomGroupItem"></a>
 
@@ -728,6 +729,16 @@ One ordered item in a room group.
 | --- | --- | --- |
 | `item.room` | [`DirectoryRoom`](#chatto-api-v1-DirectoryRoom) | Visible room entry. |
 | `item.sidebar_link` | [`SidebarLink`](#chatto-api-v1-SidebarLink) | Sidebar link entry. |
+
+<a id="chatto-api-v1-RoomGroupViewerState"></a>
+
+### RoomGroupViewerState
+
+Viewer-specific state for one room group.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `can_create_room` | `bool` | True when the current user can create rooms in this group. |
 
 <a id="chatto-api-v1-RoomViewerState"></a>
 

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -3939,6 +3939,7 @@ Ordered group of channel rooms and sidebar links.
 | `name` | `string` | Display name. |
 | `description` | `string` | Public group description, when set. |
 | `items` | repeated [`RoomGroupItem`](#chatto-api-v1-RoomGroupItem) | Mixed room/sidebar-link entries in sidebar order. |
+| `viewer_state` | [`RoomGroupViewerState`](#chatto-api-v1-RoomGroupViewerState) | State and permissions resolved for the current user. |
 
 
 
@@ -3952,6 +3953,18 @@ One ordered item in a room group.
 | --- | --- | --- |
 | `item.room` | [`DirectoryRoom`](#chatto-api-v1-DirectoryRoom) | Visible room entry. |
 | `item.sidebar_link` | [`SidebarLink`](#chatto-api-v1-SidebarLink) | Sidebar link entry. |
+
+
+
+<a id="chatto-api-v1-RoomGroupViewerState"></a>
+
+### RoomGroupViewerState
+
+Viewer-specific state for one room group.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `can_create_room` | `bool` | True when the current user can create rooms in this group. |
 
 
 

--- a/apps/frontend/e2e/admin.test.ts
+++ b/apps/frontend/e2e/admin.test.ts
@@ -322,7 +322,7 @@ test.describe('Admin Granular Permissions', () => {
   test.afterEach(async ({ page }) => {
     // Reset all potentially modified everyone role permissions.
     // Uses page.request which maintains the admin session cookies.
-    const permissions = ['admin.view-users', 'admin.view-system', 'role.manage', 'room.manage'];
+    const permissions = ['admin.view-users', 'role.manage', 'room.manage'];
 
     for (const permission of permissions) {
       try {
@@ -445,26 +445,6 @@ test.describe('Admin Granular Permissions', () => {
     });
   });
 
-  test('user with admin.view-system permission still cannot see owner-only system page', async ({
-    page,
-    browser,
-    serverURL
-  }) => {
-    await createAndLoginAdminUser(page);
-    await grantPermission(page, 'everyone', 'admin.view-system');
-
-    await withRegularAdminPage(browser, serverURL, async ({ adminPage: regularAdminPage }) => {
-      await regularAdminPage.gotoSystem();
-
-      await regularAdminPage.expectAccessDeniedForPermission('admin.view-system');
-      await regularAdminPage.expectSidebarLinkNotVisible('System');
-      await expect(regularAdminPage.page.getByText('Connected to Server')).toHaveCount(0);
-    });
-
-    // Clean up
-    await revokePermission(page, 'everyone', 'admin.view-system');
-  });
-
   // Note: a read-only view of the roles page (admin.view-roles without
   // admin.manage-roles) was removed when the UI moved from a per-role
   // editor to the unified matrix. The matrix's rolePermissionTierMatrix query gates on
@@ -495,9 +475,6 @@ test.describe('Admin Granular Permissions', () => {
       await regularPage.reload();
       await adminPage.expectSidebarLinkVisible('Users');
 
-      // Grant admin.view-system. System diagnostics remain owner-only for now,
-      // so this permission alone must not reveal the route.
-      await grantPermission(page, 'everyone', 'admin.view-system');
       await regularPage.reload();
       await adminPage.expectSidebarLinkNotVisible('System');
     });
@@ -505,7 +482,6 @@ test.describe('Admin Granular Permissions', () => {
     // Clean up
     await revokePermission(page, 'everyone', 'room.manage');
     await revokePermission(page, 'everyone', 'admin.view-users');
-    await revokePermission(page, 'everyone', 'admin.view-system');
   });
 });
 

--- a/apps/frontend/src/lib/api-client-tests/adminRoomLayout.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/adminRoomLayout.spec.ts
@@ -72,7 +72,13 @@ describe('createAdminRoomLayoutAPI', () => {
       bearerToken: 'token'
     });
 
-    await api.createRoomGroup({ name: 'Projects' });
+    await expect(api.createRoomGroup({ name: 'Projects' })).resolves.toEqual({
+      id: 'g2',
+      name: 'Projects',
+      canCreateRoom: false,
+      rooms: [],
+      items: []
+    });
     await api.updateRoomGroup({ groupId: 'g2', name: 'Renamed' });
     await api.deleteRoomGroup('g2');
     await api.reorderRoomGroups(['g2', 'g1']);

--- a/apps/frontend/src/lib/api-client-tests/roomDirectory.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/roomDirectory.spec.ts
@@ -260,6 +260,7 @@ describe('createRoomDirectoryAPI', () => {
         {
           id: 'g1',
           name: 'Lobby',
+          viewerState: { canCreateRoom: true },
           items: [
             {
               item: {
@@ -299,6 +300,7 @@ describe('createRoomDirectoryAPI', () => {
       {
         id: 'g1',
         name: 'Lobby',
+        canCreateRoom: true,
         roomIds: ['general', 'random'],
         items: [
           {
@@ -329,6 +331,7 @@ describe('createRoomDirectoryAPI', () => {
         {
           id: 'g1',
           name: 'Lobby',
+          viewerState: { canCreateRoom: false },
           items: []
         }
       ]
@@ -342,6 +345,7 @@ describe('createRoomDirectoryAPI', () => {
     await expect(api.listRoomGroups()).resolves.toMatchObject([
       {
         id: 'g1',
+        canCreateRoom: false,
         roomIds: [],
         items: []
       }
@@ -356,6 +360,7 @@ describe('createRoomDirectoryAPI', () => {
     const group = {
       id: 'g1',
       name: 'Lobby',
+      viewerState: { canCreateRoom: true },
       items: [
         {
           item: {
@@ -375,11 +380,13 @@ describe('createRoomDirectoryAPI', () => {
 
     await expect(api.getRoomGroup('g1')).resolves.toMatchObject({
       id: 'g1',
+      canCreateRoom: true,
       roomIds: ['general']
     });
     await expect(api.batchGetRoomGroups(['g1', 'missing'])).resolves.toMatchObject([
       {
         id: 'g1',
+        canCreateRoom: true,
         roomIds: ['general']
       }
     ]);

--- a/apps/frontend/src/lib/api-client-tests/serverState.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/serverState.spec.ts
@@ -109,13 +109,15 @@ describe('getAuthenticatedServerState', () => {
           { permission: 'role.manage', granted: true },
           { permission: 'role.assign', granted: true },
           { permission: 'admin.view-users', granted: true },
-          { permission: 'admin.view-system', granted: false },
           { permission: 'admin.view-audit', granted: true },
           { permission: 'user.delete-any', granted: false },
           { permission: 'user.delete-self', granted: true },
           { permission: 'user.manage-permissions', granted: true },
           { permission: 'bot.example.do-thing', granted: true }
         ]
+      },
+      capabilities: {
+        grants: [{ capability: 'admin.view-system', granted: true }]
       },
       viewerState: {
         hasUnreadRooms: true
@@ -156,7 +158,6 @@ describe('getAuthenticatedServerState', () => {
       messageEditWindowSeconds: 7200,
       viewerPermissions: {
         'admin.view-audit': true,
-        'admin.view-system': false,
         'admin.view-users': true,
         'bot.example.do-thing': true,
         'message.attach': true,
@@ -192,7 +193,7 @@ describe('getAuthenticatedServerState', () => {
       viewerCanManageRoles: true,
       viewerCanAssignRoles: true,
       viewerCanViewAdminUsers: true,
-      viewerCanViewAdminSystem: false,
+      viewerCanViewAdminSystem: true,
       viewerCanViewAdminAudit: true,
       viewerCanDeleteAnyUser: false,
       viewerCanDeleteSelf: true,
@@ -248,7 +249,7 @@ describe('getAuthenticatedServerState', () => {
           logoUrl: 'https://cdn/logo.webp',
           bannerUrl: 'https://cdn/banner.webp'
         },
-        motd: 'Connect MOTD',
+        motd: 'Connect MOTD'
       }
     });
 

--- a/apps/frontend/src/lib/api-client/adminRoomLayout.ts
+++ b/apps/frontend/src/lib/api-client/adminRoomLayout.ts
@@ -206,7 +206,9 @@ function mapAdminRoomLayoutGroup(group: APIAdminRoomLayoutGroup): AdminRoomGroup
   return {
     id: group.id,
     name: group.name,
-    canCreateRoom: true,
+    // Admin layout mutations are authorized by role.manage and do not return
+    // viewer room-creation state. Directory reads rehydrate the real value.
+    canCreateRoom: false,
     rooms: roomsFromSidebarItems(items),
     items
   };

--- a/apps/frontend/src/lib/api-client/adminRoomLayout.ts
+++ b/apps/frontend/src/lib/api-client/adminRoomLayout.ts
@@ -1,16 +1,16 @@
-import { authHeaders, createChattoClient, handleAuthError } from "./connect.js";
-import { AdminRoomLayoutService } from "@chatto/api-types/admin/v1/room_layout_connect";
+import { authHeaders, createChattoClient, handleAuthError } from './connect.js';
+import { AdminRoomLayoutService } from '@chatto/api-types/admin/v1/room_layout_connect';
 import {
   AdminRoomLayoutItemKind,
   type AdminRoomLayoutGroup as APIAdminRoomLayoutGroup,
-  type AdminRoomLayoutItem as APIAdminRoomLayoutItem,
-} from "@chatto/api-types/admin/v1/room_layout_pb";
+  type AdminRoomLayoutItem as APIAdminRoomLayoutItem
+} from '@chatto/api-types/admin/v1/room_layout_pb';
 import type {
   DirectoryRoomGroup,
   DirectoryRoomGroupItem,
-  DirectorySidebarLink,
-} from "./roomDirectory.js";
-import type { Room } from "@chatto/api-types/api/v1/rooms_pb";
+  DirectorySidebarLink
+} from './roomDirectory.js';
+import type { Room } from '@chatto/api-types/api/v1/rooms_pb';
 
 export type AdminRoomLayoutAPIConfig = {
   serverId?: string;
@@ -36,24 +36,25 @@ export type AdminSidebarLinkInfo = {
 export type AdminSidebarItem =
   | {
       id: string;
-      kind: "room";
+      kind: 'room';
       room: AdminRoomInfo;
     }
   | {
       id: string;
-      kind: "link";
+      kind: 'link';
       link: AdminSidebarLinkInfo;
     };
 
 export type AdminRoomGroup = {
   id: string;
   name: string;
+  canCreateRoom: boolean;
   rooms: AdminRoomInfo[];
   items: AdminSidebarItem[];
 };
 
 export type AdminRoomLayoutItemMutationInput = {
-  kind: AdminSidebarItem["kind"];
+  kind: AdminSidebarItem['kind'];
   id: string;
 };
 
@@ -67,8 +68,8 @@ export function createAdminRoomLayoutAPI(config: AdminRoomLayoutAPIConfig) {
     }): Promise<AdminRoomGroup | null> {
       try {
         const response = await layout.createRoomGroup(
-          { name: input.name, description: input.description ?? "" },
-          { headers: headers() },
+          { name: input.name, description: input.description ?? '' },
+          { headers: headers() }
         );
         return response.group ? mapAdminRoomLayoutGroup(response.group) : null;
       } catch (err) {
@@ -86,9 +87,9 @@ export function createAdminRoomLayoutAPI(config: AdminRoomLayoutAPIConfig) {
           {
             groupId: input.groupId,
             name: input.name,
-            description: input.description ?? "",
+            description: input.description ?? ''
           },
-          { headers: headers() },
+          { headers: headers() }
         );
         return response.group ? mapAdminRoomLayoutGroup(response.group) : null;
       } catch (err) {
@@ -98,23 +99,18 @@ export function createAdminRoomLayoutAPI(config: AdminRoomLayoutAPIConfig) {
 
     async deleteRoomGroup(groupId: string): Promise<boolean> {
       try {
-        const response = await layout.deleteRoomGroup(
-          { groupId },
-          { headers: headers() },
-        );
+        const response = await layout.deleteRoomGroup({ groupId }, { headers: headers() });
         return response.deleted;
       } catch (err) {
         return handleAuthError(config, err);
       }
     },
 
-    async reorderRoomGroups(
-      orderedGroupIds: string[],
-    ): Promise<AdminRoomGroup[]> {
+    async reorderRoomGroups(orderedGroupIds: string[]): Promise<AdminRoomGroup[]> {
       try {
         const response = await layout.reorderRoomGroups(
           { orderedGroupIds },
-          { headers: headers() },
+          { headers: headers() }
         );
         return response.groups.map(mapAdminRoomLayoutGroup);
       } catch (err) {
@@ -122,10 +118,7 @@ export function createAdminRoomLayoutAPI(config: AdminRoomLayoutAPIConfig) {
       }
     },
 
-    async moveRoomToGroup(input: {
-      roomId: string;
-      groupId: string;
-    }): Promise<void> {
+    async moveRoomToGroup(input: { roomId: string; groupId: string }): Promise<void> {
       try {
         await layout.moveRoomToGroup(input, { headers: headers() });
       } catch (err) {
@@ -144,12 +137,12 @@ export function createAdminRoomLayoutAPI(config: AdminRoomLayoutAPIConfig) {
             items: input.items.map((item) => ({
               id: item.id,
               kind:
-                item.kind === "room"
+                item.kind === 'room'
                   ? AdminRoomLayoutItemKind.ROOM
-                  : AdminRoomLayoutItemKind.SIDEBAR_LINK,
-            })),
+                  : AdminRoomLayoutItemKind.SIDEBAR_LINK
+            }))
           },
-          { headers: headers() },
+          { headers: headers() }
         );
         return response.group ? mapAdminRoomLayoutGroup(response.group) : null;
       } catch (err) {
@@ -164,11 +157,9 @@ export function createAdminRoomLayoutAPI(config: AdminRoomLayoutAPIConfig) {
     }): Promise<AdminSidebarLinkInfo | null> {
       try {
         const response = await layout.createSidebarLink(input, {
-          headers: headers(),
+          headers: headers()
         });
-        return response.sidebarLink
-          ? mapSidebarLink(response.sidebarLink)
-          : null;
+        return response.sidebarLink ? mapSidebarLink(response.sidebarLink) : null;
       } catch (err) {
         return handleAuthError(config, err);
       }
@@ -181,11 +172,9 @@ export function createAdminRoomLayoutAPI(config: AdminRoomLayoutAPIConfig) {
     }): Promise<AdminSidebarLinkInfo | null> {
       try {
         const response = await layout.updateSidebarLink(input, {
-          headers: headers(),
+          headers: headers()
         });
-        return response.sidebarLink
-          ? mapSidebarLink(response.sidebarLink)
-          : null;
+        return response.sidebarLink ? mapSidebarLink(response.sidebarLink) : null;
       } catch (err) {
         return handleAuthError(config, err);
       }
@@ -193,75 +182,59 @@ export function createAdminRoomLayoutAPI(config: AdminRoomLayoutAPIConfig) {
 
     async deleteSidebarLink(linkId: string): Promise<boolean> {
       try {
-        const response = await layout.deleteSidebarLink(
-          { linkId },
-          { headers: headers() },
-        );
+        const response = await layout.deleteSidebarLink({ linkId }, { headers: headers() });
         return response.deleted;
       } catch (err) {
         return handleAuthError(config, err);
       }
     },
 
-    async moveSidebarLinkToGroup(input: {
-      linkId: string;
-      groupId: string;
-    }): Promise<void> {
+    async moveSidebarLinkToGroup(input: { linkId: string; groupId: string }): Promise<void> {
       try {
         await layout.moveSidebarLinkToGroup(input, { headers: headers() });
       } catch (err) {
         return handleAuthError(config, err);
       }
-    },
+    }
   };
 }
 
 export type AdminRoomLayoutAPI = ReturnType<typeof createAdminRoomLayoutAPI>;
 
-function mapAdminRoomLayoutGroup(
-  group: APIAdminRoomLayoutGroup,
-): AdminRoomGroup {
-  const items = (group.items ?? []).flatMap(
-    (item) => mapAdminRoomLayoutItem(item) ?? [],
-  );
+function mapAdminRoomLayoutGroup(group: APIAdminRoomLayoutGroup): AdminRoomGroup {
+  const items = (group.items ?? []).flatMap((item) => mapAdminRoomLayoutItem(item) ?? []);
   return {
     id: group.id,
     name: group.name,
+    canCreateRoom: true,
     rooms: roomsFromSidebarItems(items),
-    items,
+    items
   };
 }
 
-export function adminRoomGroupFromDirectoryGroup(
-  group: DirectoryRoomGroup,
-): AdminRoomGroup {
-  const items = group.items.flatMap(
-    (item) => directoryItemToAdminSidebarItem(item) ?? [],
-  );
+export function adminRoomGroupFromDirectoryGroup(group: DirectoryRoomGroup): AdminRoomGroup {
+  const items = group.items.flatMap((item) => directoryItemToAdminSidebarItem(item) ?? []);
   return {
     id: group.id,
     name: group.name,
+    canCreateRoom: group.canCreateRoom,
     rooms: roomsFromSidebarItems(items),
-    items,
+    items
   };
 }
 
-export function adminRoomGroupsFromDirectoryGroups(
-  groups: DirectoryRoomGroup[],
-): AdminRoomGroup[] {
+export function adminRoomGroupsFromDirectoryGroups(groups: DirectoryRoomGroup[]): AdminRoomGroup[] {
   return groups.map(adminRoomGroupFromDirectoryGroup);
 }
 
-function mapAdminRoomLayoutItem(
-  item: APIAdminRoomLayoutItem,
-): AdminSidebarItem | null {
-  if (item.item.case === "room") {
+function mapAdminRoomLayoutItem(item: APIAdminRoomLayoutItem): AdminSidebarItem | null {
+  if (item.item.case === 'room') {
     const room = mapAdminRoom(item.item.value);
-    return { id: `room:${room.id}`, kind: "room", room };
+    return { id: `room:${room.id}`, kind: 'room', room };
   }
-  if (item.item.case === "sidebarLink") {
+  if (item.item.case === 'sidebarLink') {
     const link = mapSidebarLink(item.item.value);
-    return { id: `link:${link.id}`, kind: "link", link };
+    return { id: `link:${link.id}`, kind: 'link', link };
   }
   return null;
 }
@@ -272,35 +245,33 @@ function mapAdminRoom(room: Room): AdminRoomInfo {
     name: room.name,
     description: room.description || null,
     archived: room.archived ?? false,
-    isUniversal: room.universal ?? false,
+    isUniversal: room.universal ?? false
   };
 }
 
-function directoryItemToAdminSidebarItem(
-  item: DirectoryRoomGroupItem,
-): AdminSidebarItem | null {
-  if (item.type === "room") {
+function directoryItemToAdminSidebarItem(item: DirectoryRoomGroupItem): AdminSidebarItem | null {
+  if (item.type === 'room') {
     const room: AdminRoomInfo = {
       id: item.room.id,
       name: item.room.name,
       description: item.room.description,
       archived: item.room.archived,
-      isUniversal: item.room.isUniversal,
+      isUniversal: item.room.isUniversal
     };
-    return { id: `room:${room.id}`, kind: "room", room };
+    return { id: `room:${room.id}`, kind: 'room', room };
   }
   const link = mapSidebarLink(item.link);
-  return { id: `link:${link.id}`, kind: "link", link };
+  return { id: `link:${link.id}`, kind: 'link', link };
 }
 
 function roomsFromSidebarItems(items: AdminSidebarItem[]): AdminRoomInfo[] {
-  return items.flatMap((item) => (item.kind === "room" ? [item.room] : []));
+  return items.flatMap((item) => (item.kind === 'room' ? [item.room] : []));
 }
 
 function mapSidebarLink(link: DirectorySidebarLink): AdminSidebarLinkInfo {
   return {
     id: link.id,
     label: link.label,
-    url: link.url,
+    url: link.url
   };
 }

--- a/apps/frontend/src/lib/api-client/roomDirectory.ts
+++ b/apps/frontend/src/lib/api-client/roomDirectory.ts
@@ -4,16 +4,16 @@ import {
   ConnectError,
   createChattoClient,
   handleAuthError,
-  type ConnectAPIConfig,
-} from "./connect.js";
-import { RoomDirectoryService } from "@chatto/api-types/api/v1/room_directory_connect";
+  type ConnectAPIConfig
+} from './connect.js';
+import { RoomDirectoryService } from '@chatto/api-types/api/v1/room_directory_connect';
 import type {
   DirectoryRoom,
   RoomGroup,
-  RoomGroupItem,
-} from "@chatto/api-types/api/v1/room_directory_pb";
-import { RoomDirectoryScope } from "@chatto/api-types/api/v1/room_directory_pb";
-import { RoomKind } from "@chatto/api-types/api/v1/rooms_pb";
+  RoomGroupItem
+} from '@chatto/api-types/api/v1/room_directory_pb';
+import { RoomDirectoryScope } from '@chatto/api-types/api/v1/room_directory_pb';
+import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
 
 export type RoomDirectoryAPIConfig = ConnectAPIConfig;
 
@@ -49,19 +49,20 @@ export type DirectorySidebarLink = {
 export type DirectoryRoomGroupItem =
   | {
       id: string;
-      type: "room";
+      type: 'room';
       roomId: string;
       room: DirectoryRoomSummary;
     }
   | {
       id: string;
-      type: "link";
+      type: 'link';
       link: DirectorySidebarLink;
     };
 
 export type DirectoryRoomGroup = {
   id: string;
   name: string;
+  canCreateRoom: boolean;
   roomIds: string[];
   items: DirectoryRoomGroupItem[];
 };
@@ -78,14 +79,9 @@ export function createRoomDirectoryAPI(config: RoomDirectoryAPIConfig) {
   const headers = () => authHeaders(config);
 
   return {
-    async listRooms(
-      scope: RoomDirectoryScope,
-    ): Promise<DirectoryRoomSummary[]> {
+    async listRooms(scope: RoomDirectoryScope): Promise<DirectoryRoomSummary[]> {
       try {
-        const response = await directory.listRooms(
-          { scope },
-          { headers: headers() },
-        );
+        const response = await directory.listRooms({ scope }, { headers: headers() });
         return response.rooms.flatMap((entry) => mapDirectoryRoom(entry) ?? []);
       } catch (err) {
         return handleAuthError(config, err);
@@ -94,10 +90,7 @@ export function createRoomDirectoryAPI(config: RoomDirectoryAPIConfig) {
 
     async getRoom(roomId: string): Promise<DirectoryRoomDetails | null> {
       try {
-        const response = await directory.getRoom(
-          { roomId },
-          { headers: headers() },
-        );
+        const response = await directory.getRoom({ roomId }, { headers: headers() });
         return mapDirectoryRoomDetails(response.room);
       } catch (err) {
         if (err instanceof ConnectError && err.code === Code.NotFound) {
@@ -109,10 +102,7 @@ export function createRoomDirectoryAPI(config: RoomDirectoryAPIConfig) {
 
     async batchGetRooms(roomIds: string[]): Promise<DirectoryRoomDetails[]> {
       try {
-        const response = await directory.batchGetRooms(
-          { roomIds },
-          { headers: headers() },
-        );
+        const response = await directory.batchGetRooms({ roomIds }, { headers: headers() });
         return response.rooms.flatMap((entry) => {
           const mapped = mapDirectoryRoomDetails(entry);
           return mapped ? [mapped] : [];
@@ -122,13 +112,11 @@ export function createRoomDirectoryAPI(config: RoomDirectoryAPIConfig) {
       }
     },
 
-    async listRoomGroups(
-      options: RoomGroupReadOptions = {},
-    ): Promise<DirectoryRoomGroup[]> {
+    async listRoomGroups(options: RoomGroupReadOptions = {}): Promise<DirectoryRoomGroup[]> {
       try {
         const response = await directory.listRoomGroups(
           { includeArchivedRooms: options.includeArchivedRooms ?? false },
-          { headers: headers() },
+          { headers: headers() }
         );
         return response.groups.map(mapRoomGroup);
       } catch (err) {
@@ -138,15 +126,15 @@ export function createRoomDirectoryAPI(config: RoomDirectoryAPIConfig) {
 
     async getRoomGroup(
       groupId: string,
-      options: RoomGroupReadOptions = {},
+      options: RoomGroupReadOptions = {}
     ): Promise<DirectoryRoomGroup | null> {
       try {
         const response = await directory.getRoomGroup(
           {
             groupId,
-            includeArchivedRooms: options.includeArchivedRooms ?? false,
+            includeArchivedRooms: options.includeArchivedRooms ?? false
           },
-          { headers: headers() },
+          { headers: headers() }
         );
         return response.group ? mapRoomGroup(response.group) : null;
       } catch (err) {
@@ -159,29 +147,27 @@ export function createRoomDirectoryAPI(config: RoomDirectoryAPIConfig) {
 
     async batchGetRoomGroups(
       groupIds: string[],
-      options: RoomGroupReadOptions = {},
+      options: RoomGroupReadOptions = {}
     ): Promise<DirectoryRoomGroup[]> {
       try {
         const response = await directory.batchGetRoomGroups(
           {
             groupIds,
-            includeArchivedRooms: options.includeArchivedRooms ?? false,
+            includeArchivedRooms: options.includeArchivedRooms ?? false
           },
-          { headers: headers() },
+          { headers: headers() }
         );
         return response.groups.map(mapRoomGroup);
       } catch (err) {
         return handleAuthError(config, err);
       }
-    },
+    }
   };
 }
 
 export type RoomDirectoryAPI = ReturnType<typeof createRoomDirectoryAPI>;
 
-function mapDirectoryRoomDetails(
-  entry: DirectoryRoom | undefined,
-): DirectoryRoomDetails | null {
+function mapDirectoryRoomDetails(entry: DirectoryRoom | undefined): DirectoryRoomDetails | null {
   const summary = entry ? mapDirectoryRoom(entry) : null;
   if (!summary) return null;
 
@@ -194,7 +180,7 @@ function mapDirectoryRoomDetails(
     canEchoMessage: entry?.viewerState?.canEchoMessage ?? false,
     canManageOthersMessage: entry?.viewerState?.canManageOthersMessage ?? false,
     canManageRoom: entry?.viewerState?.canManageRoom ?? false,
-    canBanRoomMembers: entry?.viewerState?.canBanRoomMembers ?? false,
+    canBanRoomMembers: entry?.viewerState?.canBanRoomMembers ?? false
   };
 }
 
@@ -209,7 +195,7 @@ function mapDirectoryRoom(entry: DirectoryRoom): DirectoryRoomSummary | null {
     isUniversal: entry.room.universal,
     isMember: entry.viewerState?.isMember ?? false,
     hasUnread: entry.viewerState?.hasUnread ?? false,
-    canJoinRoom: entry.viewerState?.canJoinRoom ?? false,
+    canJoinRoom: entry.viewerState?.canJoinRoom ?? false
   };
 }
 
@@ -217,15 +203,16 @@ function mapRoomGroup(group: RoomGroup): DirectoryRoomGroup {
   return {
     id: group.id,
     name: group.name,
+    canCreateRoom: group.viewerState?.canCreateRoom ?? false,
     roomIds: uniqueRoomIds(group.items),
-    items: sidebarItemsFromAPI(group),
+    items: sidebarItemsFromAPI(group)
   };
 }
 
 function uniqueRoomIds(items: readonly RoomGroupItem[]): string[] {
   const seen: Record<string, true> = Object.create(null);
   return items.flatMap((item) => {
-    if (item.item.case !== "room") return [];
+    if (item.item.case !== 'room') return [];
     const id = item.item.value.room?.id;
     if (!id || seen[id]) return [];
     seen[id] = true;
@@ -238,22 +225,20 @@ function sidebarItemsFromAPI(group: RoomGroup): DirectoryRoomGroupItem[] {
 }
 
 function mapRoomGroupItem(item: RoomGroupItem): DirectoryRoomGroupItem | null {
-  if (item.item.case === "room") {
+  if (item.item.case === 'room') {
     const roomId = item.item.value.room?.id;
     const room = mapDirectoryRoom(item.item.value);
-    return roomId && room
-      ? { id: `room:${roomId}`, type: "room", roomId, room }
-      : null;
+    return roomId && room ? { id: `room:${roomId}`, type: 'room', roomId, room } : null;
   }
-  if (item.item.case === "sidebarLink") {
+  if (item.item.case === 'sidebarLink') {
     return {
       id: `link:${item.item.value.id}`,
-      type: "link",
+      type: 'link',
       link: {
         id: item.item.value.id,
         label: item.item.value.label,
-        url: item.item.value.url,
-      },
+        url: item.item.value.url
+      }
     };
   }
   return null;

--- a/apps/frontend/src/lib/api-client/serverState.ts
+++ b/apps/frontend/src/lib/api-client/serverState.ts
@@ -1,8 +1,8 @@
-import { authHeaders, createChattoClient } from "./connect.js";
-import { AdminServerService } from "@chatto/api-types/admin/v1/server_connect";
-import { ServerService } from "@chatto/api-types/api/v1/server_state_connect";
-import { ViewerService } from "@chatto/api-types/api/v1/viewer_connect";
-import { mapServerProfile, type ServerProfile } from "./serverProfile.js";
+import { authHeaders, createChattoClient } from './connect.js';
+import { AdminServerService } from '@chatto/api-types/admin/v1/server_connect';
+import { ServerService } from '@chatto/api-types/api/v1/server_state_connect';
+import { ViewerService } from '@chatto/api-types/api/v1/viewer_connect';
+import { mapServerProfile, type ServerProfile } from './serverProfile.js';
 
 export type ServerStateAPIConfig = {
   baseUrl: string;
@@ -63,13 +63,18 @@ export type ServerSecurityConfig = {
 };
 
 function mapViewerPermissions(
-  permissions: Array<{ permission: string; granted: boolean }> | undefined,
+  permissions: Array<{ permission: string; granted: boolean }> | undefined
 ): Record<string, boolean> {
   return Object.fromEntries(
-    (permissions ?? []).map((permission) => [
-      permission.permission,
-      permission.granted,
-    ]),
+    (permissions ?? []).map((permission) => [permission.permission, permission.granted])
+  );
+}
+
+function mapViewerCapabilities(
+  capabilities: Array<{ capability: string; granted: boolean }> | undefined
+): Record<string, boolean> {
+  return Object.fromEntries(
+    (capabilities ?? []).map((capability) => [capability.capability, capability.granted])
   );
 }
 
@@ -90,42 +95,42 @@ function mapEditableServerConfig(
         welcomeMessage?: string;
       }
     | null
-    | undefined,
+    | undefined
 ): EditableServerConfig {
   return {
-    name: config?.serverName ?? "",
-    description: config?.description ?? "",
-    motd: config?.motd ?? "",
-    welcomeMessage: config?.welcomeMessage ?? "",
+    name: config?.serverName ?? '',
+    description: config?.description ?? '',
+    motd: config?.motd ?? '',
+    welcomeMessage: config?.welcomeMessage ?? ''
   };
 }
 
 function blockedUsernamesText(entries: readonly string[] | undefined): string {
-  return (entries ?? []).join("\n");
+  return (entries ?? []).join('\n');
 }
 
 function blockedUsernameEntries(text: string): string[] {
   return text
-    .split("\n")
+    .split('\n')
     .map((entry) => entry.trim())
     .filter(Boolean);
 }
 
 export async function getAuthenticatedServerState(
-  config: ServerStateAPIConfig,
+  config: ServerStateAPIConfig
 ): Promise<AuthenticatedServerState> {
   const { server, viewer, headers } = serverClients(config);
   const [response, viewerResponse] = await Promise.all([
     server.getServerState({}, { headers }),
-    viewer.getViewer({}, { headers }),
+    viewer.getViewer({}, { headers })
   ]);
   const profile = mapServerProfile(response.profile);
   const runtime = response.runtime;
-  const viewerPermissions = mapViewerPermissions(
-    viewerResponse.viewerPermissions?.permissions,
-  );
+  const viewerPermissions = mapViewerPermissions(viewerResponse.viewerPermissions?.permissions);
+  const viewerCapabilities = mapViewerCapabilities(viewerResponse.capabilities?.grants);
   const viewerState = viewerResponse.viewerState;
   const can = (permission: string) => viewerPermissions[permission] ?? false;
+  const capability = (key: string) => viewerCapabilities[key] ?? false;
 
   return {
     name: profile.name,
@@ -143,33 +148,31 @@ export async function getAuthenticatedServerState(
     maxVideoUploadSize: Number(runtime?.maxVideoUploadSize ?? 0),
     messageEditWindowSeconds: runtime?.messageEditWindowSeconds ?? 0,
     viewerPermissions,
-    viewerCanManageServer: can("server.manage"),
-    viewerCanCreateRooms: can("room.create"),
-    viewerCanJoinRooms: can("room.join"),
-    viewerCanListRooms: can("room.list"),
-    viewerCanManageRooms: can("room.manage"),
-    viewerCanBanRoomMembers: can("room.ban-member"),
-    viewerCanPostMessages: can("message.post"),
-    viewerCanPostInThreads: can("message.post-in-thread"),
-    viewerCanAttachFiles: can("message.attach"),
-    viewerCanManageMessages: can("message.manage"),
-    viewerCanReactToMessages: can("message.react"),
-    viewerCanEchoMessages: can("message.echo"),
-    viewerCanManageRoles: can("role.manage"),
-    viewerCanAssignRoles: can("role.assign"),
-    viewerCanViewAdminUsers: can("admin.view-users"),
-    viewerCanViewAdminSystem: can("admin.view-system"),
-    viewerCanViewAdminAudit: can("admin.view-audit"),
-    viewerCanDeleteAnyUser: can("user.delete-any"),
-    viewerCanDeleteSelf: can("user.delete-self"),
-    viewerCanManageUserPermissions: can("user.manage-permissions"),
-    viewerHasUnreadRooms: viewerState?.hasUnreadRooms ?? false,
+    viewerCanManageServer: can('server.manage'),
+    viewerCanCreateRooms: can('room.create'),
+    viewerCanJoinRooms: can('room.join'),
+    viewerCanListRooms: can('room.list'),
+    viewerCanManageRooms: can('room.manage'),
+    viewerCanBanRoomMembers: can('room.ban-member'),
+    viewerCanPostMessages: can('message.post'),
+    viewerCanPostInThreads: can('message.post-in-thread'),
+    viewerCanAttachFiles: can('message.attach'),
+    viewerCanManageMessages: can('message.manage'),
+    viewerCanReactToMessages: can('message.react'),
+    viewerCanEchoMessages: can('message.echo'),
+    viewerCanManageRoles: can('role.manage'),
+    viewerCanAssignRoles: can('role.assign'),
+    viewerCanViewAdminUsers: can('admin.view-users'),
+    viewerCanViewAdminSystem: capability('admin.view-system'),
+    viewerCanViewAdminAudit: can('admin.view-audit'),
+    viewerCanDeleteAnyUser: can('user.delete-any'),
+    viewerCanDeleteSelf: can('user.delete-self'),
+    viewerCanManageUserPermissions: can('user.manage-permissions'),
+    viewerHasUnreadRooms: viewerState?.hasUnreadRooms ?? false
   };
 }
 
-export async function getServerConfig(
-  config: ServerStateAPIConfig,
-): Promise<EditableServerConfig> {
+export async function getServerConfig(config: ServerStateAPIConfig): Promise<EditableServerConfig> {
   const { adminServer, headers } = serverClients(config);
   const response = await adminServer.getServerConfig({}, { headers });
   return mapEditableServerConfig(response.config);
@@ -177,7 +180,7 @@ export async function getServerConfig(
 
 export async function updateServerConfig(
   config: ServerStateAPIConfig,
-  input: EditableServerConfig,
+  input: EditableServerConfig
 ): Promise<EditableServerProfile> {
   const { adminServer, headers } = serverClients(config);
   const response = await adminServer.updateServerConfig(
@@ -185,9 +188,9 @@ export async function updateServerConfig(
       serverName: input.name,
       description: input.description,
       motd: input.motd,
-      welcomeMessage: input.welcomeMessage,
+      welcomeMessage: input.welcomeMessage
     },
-    { headers },
+    { headers }
   );
 
   return mapServerProfile(response.profile);
@@ -195,22 +198,22 @@ export async function updateServerConfig(
 
 export async function uploadServerLogo(
   config: ServerStateAPIConfig,
-  file: File,
+  file: File
 ): Promise<EditableServerProfile> {
   const { adminServer, headers } = serverClients(config);
   const response = await adminServer.uploadServerLogo(
     {
       image: new Uint8Array(await file.arrayBuffer()),
       filename: file.name,
-      contentType: file.type,
+      contentType: file.type
     },
-    { headers },
+    { headers }
   );
   return mapServerProfile(response.profile);
 }
 
 export async function deleteServerLogo(
-  config: ServerStateAPIConfig,
+  config: ServerStateAPIConfig
 ): Promise<EditableServerProfile> {
   const { adminServer, headers } = serverClients(config);
   const response = await adminServer.deleteServerLogo({}, { headers });
@@ -219,22 +222,22 @@ export async function deleteServerLogo(
 
 export async function uploadServerBanner(
   config: ServerStateAPIConfig,
-  file: File,
+  file: File
 ): Promise<EditableServerProfile> {
   const { adminServer, headers } = serverClients(config);
   const response = await adminServer.uploadServerBanner(
     {
       image: new Uint8Array(await file.arrayBuffer()),
       filename: file.name,
-      contentType: file.type,
+      contentType: file.type
     },
-    { headers },
+    { headers }
   );
   return mapServerProfile(response.profile);
 }
 
 export async function deleteServerBanner(
-  config: ServerStateAPIConfig,
+  config: ServerStateAPIConfig
 ): Promise<EditableServerProfile> {
   const { adminServer, headers } = serverClients(config);
   const response = await adminServer.deleteServerBanner({}, { headers });
@@ -242,25 +245,25 @@ export async function deleteServerBanner(
 }
 
 export async function getServerSecurityConfig(
-  config: ServerStateAPIConfig,
+  config: ServerStateAPIConfig
 ): Promise<ServerSecurityConfig> {
   const { adminServer, headers } = serverClients(config);
   const response = await adminServer.getServerSecurityConfig({}, { headers });
   return {
-    blockedUsernames: blockedUsernamesText(response.blockedUsernames),
+    blockedUsernames: blockedUsernamesText(response.blockedUsernames)
   };
 }
 
 export async function updateBlockedUsernames(
   config: ServerStateAPIConfig,
-  blockedUsernames: string,
+  blockedUsernames: string
 ): Promise<ServerSecurityConfig> {
   const { adminServer, headers } = serverClients(config);
   const response = await adminServer.updateBlockedUsernames(
     { blockedUsernames: blockedUsernameEntries(blockedUsernames) },
-    { headers },
+    { headers }
   );
   return {
-    blockedUsernames: blockedUsernamesText(response.blockedUsernames),
+    blockedUsernames: blockedUsernamesText(response.blockedUsernames)
   };
 }

--- a/apps/frontend/src/lib/permissions.spec.ts
+++ b/apps/frontend/src/lib/permissions.spec.ts
@@ -5,7 +5,6 @@ describe('PERMISSION_METADATA', () => {
   it('covers every current backend permission', () => {
     expect(Object.keys(PERMISSION_METADATA).sort()).toEqual([
       'admin.view-audit',
-      'admin.view-system',
       'admin.view-users',
       'message.attach',
       'message.echo',

--- a/apps/frontend/src/lib/permissions.ts
+++ b/apps/frontend/src/lib/permissions.ts
@@ -71,9 +71,6 @@ export const PERMISSION_METADATA: Record<string, PermissionMetadata> = {
   'admin.view-users': {
     description: m['rbac.permission_descriptions.admin_view_users']
   },
-  'admin.view-system': {
-    description: m['rbac.permission_descriptions.admin_view_system']
-  },
   'admin.view-audit': {
     description: m['rbac.permission_descriptions.admin_view_audit']
   },

--- a/apps/frontend/src/lib/state/server/adminRoomLayout.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/adminRoomLayout.svelte.spec.ts
@@ -291,8 +291,9 @@ describe('AdminRoomLayoutStore — loading', () => {
 });
 
 describe('AdminRoomLayoutStore — mutations', () => {
-  it('creates, renames, and deletes groups optimistically on success', async () => {
-    const { client, directory, mutation } = makeClient({
+  it('creates groups, rehydrates create permission, and mutates them on success', async () => {
+    const { client, directory, query, mutation } = makeClient({
+      queries: [{ data: queryData([group('g2', [], 'Projects')]) }],
       mutations: [
         { data: { id: 'g2', name: 'Projects', canCreateRoom: false, rooms: [], items: [] } },
         { data: { id: 'g2', name: 'Renamed', rooms: [], items: [] } },
@@ -304,9 +305,10 @@ describe('AdminRoomLayoutStore — mutations', () => {
     const createResult = await store.createGroup('Projects');
     expect(createResult).toEqual({
       ok: true,
-      group: { id: 'g2', name: 'Projects', canCreateRoom: false, rooms: [], items: [] }
+      group: { id: 'g2', name: 'Projects', canCreateRoom: true, rooms: [], items: [] }
     });
-    expect(store.groups[0]?.canCreateRoom).toBe(false);
+    expect(query).toHaveBeenCalledWith({ includeArchivedRooms: true });
+    expect(store.groups[0]?.canCreateRoom).toBe(true);
     expect(store.groups.map((g) => g.name)).toEqual(['Projects']);
 
     await expect(store.renameGroup('g2', 'Renamed')).resolves.toEqual({ ok: true });
@@ -474,19 +476,19 @@ describe('AdminRoomLayoutStore — live events', () => {
     let now = 1000;
     const { client, directory, query } = makeClient({
       mutations: [{ data: group('g1', [], 'Lobby') }],
-      queries: [{ data: queryData([group('g1', [])]) }]
+      queries: [{ data: queryData([group('g1', [])]) }, { data: queryData([group('g1', [])]) }]
     });
     const store = new AdminRoomLayoutStore(client, directory, roomAPI(), () => now);
 
     await store.createGroup('Lobby');
     now = 1500;
     expect(store.ingestRoomLayoutUpdated()).toBe(false);
-    expect(query).not.toHaveBeenCalled();
+    expect(query).toHaveBeenCalledTimes(1);
 
     now = 3100;
     expect(store.ingestRoomLayoutUpdated()).toBe(true);
     await settle();
-    expect(query).toHaveBeenCalledTimes(1);
+    expect(query).toHaveBeenCalledTimes(2);
   });
 
   it('refreshes on external room metadata/archive events', async () => {

--- a/apps/frontend/src/lib/state/server/adminRoomLayout.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/adminRoomLayout.svelte.spec.ts
@@ -323,6 +323,27 @@ describe('AdminRoomLayoutStore — mutations', () => {
     ]);
   });
 
+  it('keeps created groups hidden from room creation when directory denies it', async () => {
+    const { client, directory, query } = makeClient({
+      queries: [
+        { data: [{ id: 'g2', name: 'Projects', canCreateRoom: false, roomIds: [], items: [] }] }
+      ],
+      mutations: [
+        { data: { id: 'g2', name: 'Projects', canCreateRoom: false, rooms: [], items: [] } }
+      ]
+    });
+    const store = new AdminRoomLayoutStore(client, directory, roomAPI());
+
+    const createResult = await store.createGroup('Projects');
+
+    expect(createResult).toEqual({
+      ok: true,
+      group: { id: 'g2', name: 'Projects', canCreateRoom: false, rooms: [], items: [] }
+    });
+    expect(query).toHaveBeenCalledWith({ includeArchivedRooms: true });
+    expect(store.groups[0]?.canCreateRoom).toBe(false);
+  });
+
   it('does not optimistically update a group when rename fails', async () => {
     const { client, directory } = makeClient({ mutations: [{ error: { message: 'nope' } }] });
     const store = new AdminRoomLayoutStore(client, directory, roomAPI());

--- a/apps/frontend/src/lib/state/server/adminRoomLayout.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/adminRoomLayout.svelte.spec.ts
@@ -27,6 +27,7 @@ function group(id: string, rooms: AdminRoomInfo[], name = id): AdminRoomGroup {
   return {
     id,
     name,
+    canCreateRoom: true,
     rooms,
     items: rooms.map((room) => ({ id: `room:${room.id}`, kind: 'room', room }))
   };
@@ -36,6 +37,7 @@ function queryData(groups: AdminRoomGroup[]): DirectoryRoomGroup[] {
   return groups.map((group) => ({
     id: group.id,
     name: group.name,
+    canCreateRoom: group.canCreateRoom,
     roomIds: group.rooms.map((room) => room.id),
     items: group.items.map((item) =>
       item.kind === 'room'
@@ -210,6 +212,7 @@ describe('AdminRoomLayoutStore — loading', () => {
       {
         id: 'g1',
         name: 'Lobby',
+        canCreateRoom: true,
         rooms: [room('r1'), archived],
         items: [
           { id: 'room:r1', kind: 'room', room: room('r1') },
@@ -223,7 +226,9 @@ describe('AdminRoomLayoutStore — loading', () => {
 
   it('keeps groups empty when the API does not provide sidebar items', async () => {
     const { client, directory } = makeClient({
-      queries: [{ data: [{ id: 'g1', name: 'Lobby', roomIds: [], items: [] }] }]
+      queries: [
+        { data: [{ id: 'g1', name: 'Lobby', canCreateRoom: false, roomIds: [], items: [] }] }
+      ]
     });
     const store = new AdminRoomLayoutStore(client, directory, roomAPI());
 
@@ -234,6 +239,7 @@ describe('AdminRoomLayoutStore — loading', () => {
       {
         id: 'g1',
         name: 'Lobby',
+        canCreateRoom: false,
         rooms: [],
         items: []
       }

--- a/apps/frontend/src/lib/state/server/adminRoomLayout.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/adminRoomLayout.svelte.spec.ts
@@ -294,7 +294,7 @@ describe('AdminRoomLayoutStore — mutations', () => {
   it('creates, renames, and deletes groups optimistically on success', async () => {
     const { client, directory, mutation } = makeClient({
       mutations: [
-        { data: { id: 'g2', name: 'Projects', rooms: [], items: [] } },
+        { data: { id: 'g2', name: 'Projects', canCreateRoom: false, rooms: [], items: [] } },
         { data: { id: 'g2', name: 'Renamed', rooms: [], items: [] } },
         { data: true }
       ]
@@ -304,8 +304,9 @@ describe('AdminRoomLayoutStore — mutations', () => {
     const createResult = await store.createGroup('Projects');
     expect(createResult).toEqual({
       ok: true,
-      group: { id: 'g2', name: 'Projects', rooms: [], items: [] }
+      group: { id: 'g2', name: 'Projects', canCreateRoom: false, rooms: [], items: [] }
     });
+    expect(store.groups[0]?.canCreateRoom).toBe(false);
     expect(store.groups.map((g) => g.name)).toEqual(['Projects']);
 
     await expect(store.renameGroup('g2', 'Renamed')).resolves.toEqual({ ok: true });

--- a/apps/frontend/src/lib/state/server/adminRoomLayout.svelte.ts
+++ b/apps/frontend/src/lib/state/server/adminRoomLayout.svelte.ts
@@ -287,7 +287,8 @@ export class AdminRoomLayoutStore {
     if (!group) return { ok: false, error: 'Room group not found' };
     this.groups = [...this.groups, group];
     this.markMutation();
-    return { ok: true, group };
+    await this.refresh();
+    return { ok: true, group: this.groups.find((candidate) => candidate.id === group.id) ?? group };
   }
 
   async renameGroup(groupId: string, newName: string): Promise<StoreResult> {

--- a/apps/frontend/src/lib/state/server/permissions.svelte.ts
+++ b/apps/frontend/src/lib/state/server/permissions.svelte.ts
@@ -73,7 +73,6 @@ const PERMISSION_TO_FIELD: Record<string, keyof ViewerData> = {
   'role.assign': 'canAssignRoles',
   'user.manage-accounts': 'canAdminManageAccounts',
   'role.manage': 'canAdminManageRoles',
-  'admin.view-system': 'canAdminViewSystem',
   'admin.view-audit': 'canAdminViewAudit'
 };
 

--- a/apps/frontend/src/lib/state/server/rooms.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/rooms.svelte.spec.ts
@@ -176,6 +176,7 @@ describe('RoomsStore - refresh', () => {
         {
           id: 'g1',
           name: 'Lobby',
+          canCreateRoom: false,
           roomIds: ['public'],
           items: [makeGroupRoomItem('public')]
         }
@@ -442,6 +443,7 @@ describe('RoomsStore - refresh', () => {
           {
             id: 'g1',
             name: 'Lobby',
+            canCreateRoom: false,
             roomIds: ['general'],
             items: [
               {

--- a/apps/frontend/src/lib/types/core.ts
+++ b/apps/frontend/src/lib/types/core.ts
@@ -105,10 +105,6 @@ export const PermRoleAssign: Permission = "role.assign";
  */
 export const PermAdminUsersView: Permission = "admin.view-users";
 /**
- * PermAdminSystemView allows viewing projection diagnostics in admin.
- */
-export const PermAdminSystemView: Permission = "admin.view-system";
-/**
  * PermAdminAuditView allows viewing the audit log in admin.
  */
 export const PermAdminAuditView: Permission = "admin.view-audit";

--- a/apps/frontend/src/routes/chat/[serverId]/server-admin/rooms/AdminRoomLayoutEditor.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/server-admin/rooms/AdminRoomLayoutEditor.svelte
@@ -516,10 +516,12 @@
               </div>
 
               <div class="flex items-center gap-2">
-                <Button variant="secondary" size="sm" onclick={() => openCreateRoom(group)}>
-                  <span class="iconify uil--plus"></span>
-                  {m['admin.rooms_admin.new_room']()}
-                </Button>
+                {#if group.canCreateRoom}
+                  <Button variant="secondary" size="sm" onclick={() => openCreateRoom(group)}>
+                    <span class="iconify uil--plus"></span>
+                    {m['admin.rooms_admin.new_room']()}
+                  </Button>
+                {/if}
                 <Button variant="secondary" size="sm" onclick={() => openCreateLink(group)}>
                   <span class="iconify uil--external-link-alt"></span>
                   {m['admin.rooms_admin.new_link']()}

--- a/apps/frontend/src/routes/chat/[serverId]/server-admin/rooms/AdminRoomLayoutEditor.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/server-admin/rooms/AdminRoomLayoutEditor.svelte.spec.ts
@@ -57,6 +57,7 @@ function group(id: string, rooms: AdminRoomInfo[], name = id): AdminRoomGroup {
   return {
     id,
     name,
+    canCreateRoom: true,
     rooms,
     items: rooms.map((room) => ({ id: `room:${room.id}`, kind: 'room', room }))
   };
@@ -191,7 +192,9 @@ describe('AdminRoomLayoutEditor', () => {
     layout.initialized = true;
     layout.groups = [group('g1', [room('r1', { name: 'general' })], 'Lobby')];
     const updateRoom = vi.spyOn(layout, 'updateRoom').mockResolvedValue({ ok: true });
-    const updateRoomUniversal = vi.spyOn(layout, 'updateRoomUniversal').mockResolvedValue({ ok: true });
+    const updateRoomUniversal = vi
+      .spyOn(layout, 'updateRoomUniversal')
+      .mockResolvedValue({ ok: true });
     const { container } = renderEditor(layout);
 
     expect(container.querySelector('[title="Make universal room"]')).toBeNull();

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -1806,14 +1806,38 @@ func TestViewerServiceGetViewerReturnsSelfScopedState(t *testing.T) {
 	if caps := resp.Msg.GetCapabilities(); !apiCapabilityGranted(caps.GetGrants(), viewerCapabilityAssignRoles) || apiCapabilityGranted(caps.GetGrants(), viewerCapabilityAdminManageUsers) {
 		t.Fatalf("viewer capabilities = %+v, want role.assign true and account management false", caps.GetGrants())
 	}
+	if apiCapabilityGranted(resp.Msg.GetCapabilities().GetGrants(), viewerCapabilityAdminViewSystem) {
+		t.Fatalf("viewer system capability = true for regular viewer, want false")
+	}
 	if resp.Msg.GetViewerPermissions() == nil {
 		t.Fatal("ViewerPermissions = nil")
 	}
 	if got, want := len(resp.Msg.GetViewerPermissions().GetPermissions()), len(core.AllPermissions()); got != want {
 		t.Fatalf("viewer permissions len = %d, want %d", got, want)
 	}
+	if apiPermissionGrantPresent(resp.Msg.GetViewerPermissions().GetPermissions(), viewerCapabilityAdminViewSystem) {
+		t.Fatalf("%s should be exposed only as an owner-only capability, not as a permission grant", viewerCapabilityAdminViewSystem)
+	}
 	if resp.Msg.GetViewerState() == nil {
 		t.Fatal("ViewerState = nil")
+	}
+
+	owner, err := env.core.CreateUser(env.ctx, core.SystemActorID, "viewer-owner", "Viewer Owner", "password")
+	if err != nil {
+		t.Fatalf("CreateUser owner: %v", err)
+	}
+	if err := env.core.AssignOwnerRole(env.ctx, owner.Id); err != nil {
+		t.Fatalf("AssignOwnerRole: %v", err)
+	}
+	ownerResp, err := env.viewerService.GetViewer(withCaller(env.ctx, owner), connect.NewRequest(&apiv1.GetViewerRequest{}))
+	if err != nil {
+		t.Fatalf("GetViewer owner: %v", err)
+	}
+	if !apiCapabilityGranted(ownerResp.Msg.GetCapabilities().GetGrants(), viewerCapabilityAdminViewSystem) {
+		t.Fatalf("owner system capability = false, want true")
+	}
+	if apiPermissionGrantPresent(ownerResp.Msg.GetViewerPermissions().GetPermissions(), viewerCapabilityAdminViewSystem) {
+		t.Fatalf("%s should not be exposed as a permission grant for owners", viewerCapabilityAdminViewSystem)
 	}
 }
 
@@ -3513,6 +3537,9 @@ func TestRoomDirectoryServiceListRoomGroupsFiltersHiddenRoomsAndKeepsLinks(t *te
 	if group == nil {
 		t.Fatalf("group %s missing from response", groupID)
 	}
+	if group.GetViewerState().GetCanCreateRoom() {
+		t.Fatalf("group CanCreateRoom = true before group grant, want false")
+	}
 	if !roomGroupItemsContainRoom(group.GetItems(), visible.Id) {
 		t.Fatalf("visible room %s missing from group items", visible.Id)
 	}
@@ -3538,6 +3565,9 @@ func TestRoomDirectoryServiceListRoomGroupsFiltersHiddenRoomsAndKeepsLinks(t *te
 	if !roomGroupItemsContainRoom(withArchivedGroup.GetItems(), archived.Id) {
 		t.Fatalf("archived room %s missing from include archived group items", archived.Id)
 	}
+	if err := env.core.GrantUserGroupPermission(env.ctx, core.SystemActorID, groupID, caller.Id, core.PermRoomCreate); err != nil {
+		t.Fatalf("GrantUserGroupPermission room.create: %v", err)
+	}
 
 	getResp, err := env.directory.GetRoomGroup(withCaller(env.ctx, caller), connect.NewRequest(&apiv1.GetRoomGroupRequest{
 		GroupId: groupID,
@@ -3548,6 +3578,9 @@ func TestRoomDirectoryServiceListRoomGroupsFiltersHiddenRoomsAndKeepsLinks(t *te
 	getGroup := getResp.Msg.GetGroup()
 	if getGroup.GetId() != groupID {
 		t.Fatalf("GetRoomGroup id = %q, want %q", getGroup.GetId(), groupID)
+	}
+	if !getGroup.GetViewerState().GetCanCreateRoom() {
+		t.Fatalf("group CanCreateRoom = false after group grant, want true")
 	}
 	if !roomGroupItemsContainRoom(getGroup.GetItems(), visible.Id) ||
 		roomGroupItemsContainRoom(getGroup.GetItems(), hidden.Id) ||
@@ -6628,6 +6661,15 @@ func apiCapabilityGranted(grants []*apiv1.CapabilityGrant, capability string) bo
 	for _, grant := range grants {
 		if grant.GetCapability() == capability {
 			return grant.GetGranted()
+		}
+	}
+	return false
+}
+
+func apiPermissionGrantPresent(grants []*apiv1.PermissionGrant, permission string) bool {
+	for _, grant := range grants {
+		if grant.GetPermission() == permission {
+			return true
 		}
 	}
 	return false

--- a/cli/internal/connectapi/room_directory.go
+++ b/cli/internal/connectapi/room_directory.go
@@ -156,6 +156,9 @@ func apiRoomGroup(group *core.DirectoryRoomGroup) *apiv1.RoomGroup {
 		Id:          group.Group.GetId(),
 		Name:        group.Group.GetName(),
 		Description: group.Group.GetDescription(),
+		ViewerState: &apiv1.RoomGroupViewerState{
+			CanCreateRoom: group.ViewerState.CanCreateRoom,
+		},
 	}
 	for _, item := range group.Items {
 		switch {

--- a/cli/internal/connectapi/viewer.go
+++ b/cli/internal/connectapi/viewer.go
@@ -22,7 +22,7 @@ const (
 	viewerCapabilityAssignRoles      = string(core.PermRoleAssign)
 	viewerCapabilityAdminViewRoles   = "role.view"
 	viewerCapabilityAdminManageRoles = string(core.PermRoleManage)
-	viewerCapabilityAdminViewSystem  = string(core.PermAdminSystemView)
+	viewerCapabilityAdminViewSystem  = "admin.view-system"
 	viewerCapabilityAdminViewAudit   = string(core.PermAdminAuditView)
 	viewerCapabilityManageUserPerms  = string(core.PermUserManagePermissions)
 )

--- a/cli/internal/core/can.go
+++ b/cli/internal/core/can.go
@@ -43,8 +43,8 @@ func (c *ChattoCore) CanManageRoles(ctx context.Context, userID string) (bool, e
 
 // CanAdminSystemView checks if a user can view system projection diagnostics
 // in admin. The diagnostics endpoint exposes low-level system state and is
-// owner-only, so this mirrors GetAdminDiagnostics instead of the historical
-// admin.view-system permission flag.
+// owner-only, so this mirrors GetAdminDiagnostics instead of any grantable
+// RBAC permission.
 func (c *ChattoCore) CanAdminSystemView(ctx context.Context, userID string) (bool, error) {
 	return c.IsServerOwner(ctx, userID)
 }
@@ -109,7 +109,6 @@ var adminPermissions = []Permission{
 	PermUserManageAccounts,
 	PermUserManagePermissions,
 	PermAdminUsersView,
-	PermAdminSystemView,
 	PermAdminAuditView,
 }
 

--- a/cli/internal/core/permission.go
+++ b/cli/internal/core/permission.go
@@ -106,9 +106,6 @@ const (
 	// PermAdminUsersView allows viewing the users page in admin.
 	PermAdminUsersView Permission = "admin.view-users"
 
-	// PermAdminSystemView allows viewing projection diagnostics in admin.
-	PermAdminSystemView Permission = "admin.view-system"
-
 	// PermAdminAuditView allows viewing the audit log in admin.
 	PermAdminAuditView Permission = "admin.view-audit"
 
@@ -171,7 +168,6 @@ var allPermissions = []PermissionMetadata{
 
 	// Admin
 	{PermAdminUsersView, "View Users", "View the users page in admin", CategoryAdmin, []PermissionScope{ScopeServer}},
-	{PermAdminSystemView, "View System", "View projection diagnostics in admin", CategoryAdmin, []PermissionScope{ScopeServer}},
 	{PermAdminAuditView, "View Audit Log", "View the audit log in admin", CategoryAdmin, []PermissionScope{ScopeServer}},
 
 	// User management

--- a/cli/internal/core/permission_test.go
+++ b/cli/internal/core/permission_test.go
@@ -328,6 +328,9 @@ func TestAllPermissions(t *testing.T) {
 	}
 
 	for _, p := range perms {
+		if p.Permission == "admin.view-system" {
+			t.Error("admin.view-system should not be a grantable RBAC permission")
+		}
 		if p.Permission == "" {
 			t.Error("Found permission with empty Permission field")
 		}

--- a/cli/internal/core/room_directory_read_model.go
+++ b/cli/internal/core/room_directory_read_model.go
@@ -48,9 +48,14 @@ type DirectoryRoomViewerState struct {
 }
 
 type DirectoryRoomGroup struct {
-	Group *corev1.RoomGroup
-	Rooms []*DirectoryRoom
-	Items []DirectoryRoomGroupItem
+	Group       *corev1.RoomGroup
+	ViewerState DirectoryRoomGroupViewerState
+	Rooms       []*DirectoryRoom
+	Items       []DirectoryRoomGroupItem
+}
+
+type DirectoryRoomGroupViewerState struct {
+	CanCreateRoom bool
 }
 
 type DirectoryRoomGroupItem struct {
@@ -309,7 +314,11 @@ func (s *RoomDirectoryReadModel) visibleChannelRoomMap(ctx context.Context, acto
 }
 
 func (s *RoomDirectoryReadModel) directoryGroup(ctx context.Context, actorID string, group *corev1.RoomGroup, visibleRooms map[string]*corev1.Room) (*DirectoryRoomGroup, error) {
-	dirGroup := &DirectoryRoomGroup{Group: group}
+	state, err := s.roomGroupViewerState(ctx, actorID, group.GetId())
+	if err != nil {
+		return nil, err
+	}
+	dirGroup := &DirectoryRoomGroup{Group: group, ViewerState: state}
 	for _, roomID := range group.GetRoomIds() {
 		room := visibleRooms[roomID]
 		if room == nil {
@@ -347,6 +356,14 @@ func (s *RoomDirectoryReadModel) directoryGroup(ctx context.Context, actorID str
 		}
 	}
 	return dirGroup, nil
+}
+
+func (s *RoomDirectoryReadModel) roomGroupViewerState(ctx context.Context, actorID, groupID string) (DirectoryRoomGroupViewerState, error) {
+	canCreateRoom, err := s.core.CanCreateRoom(ctx, actorID, KindChannel, groupID)
+	if err != nil {
+		return DirectoryRoomGroupViewerState{}, err
+	}
+	return DirectoryRoomGroupViewerState{CanCreateRoom: canCreateRoom}, nil
 }
 
 func (s *RoomDirectoryReadModel) directoryRoom(ctx context.Context, actorID string, room *corev1.Room) (*DirectoryRoom, error) {

--- a/cli/internal/pb/chatto/api/v1/room_directory.pb.go
+++ b/cli/internal/pb/chatto/api/v1/room_directory.pb.go
@@ -431,6 +431,52 @@ func (*RoomGroupItem_Room) isRoomGroupItem_Item() {}
 
 func (*RoomGroupItem_SidebarLink) isRoomGroupItem_Item() {}
 
+// Viewer-specific state for one room group.
+type RoomGroupViewerState struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// True when the current user can create rooms in this group.
+	CanCreateRoom bool `protobuf:"varint,1,opt,name=can_create_room,json=canCreateRoom,proto3" json:"can_create_room,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RoomGroupViewerState) Reset() {
+	*x = RoomGroupViewerState{}
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RoomGroupViewerState) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RoomGroupViewerState) ProtoMessage() {}
+
+func (x *RoomGroupViewerState) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RoomGroupViewerState.ProtoReflect.Descriptor instead.
+func (*RoomGroupViewerState) Descriptor() ([]byte, []int) {
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *RoomGroupViewerState) GetCanCreateRoom() bool {
+	if x != nil {
+		return x.CanCreateRoom
+	}
+	return false
+}
+
 // Ordered group of channel rooms and sidebar links.
 type RoomGroup struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -441,14 +487,16 @@ type RoomGroup struct {
 	// Public group description, when set.
 	Description string `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
 	// Mixed room/sidebar-link entries in sidebar order.
-	Items         []*RoomGroupItem `protobuf:"bytes,5,rep,name=items,proto3" json:"items,omitempty"`
+	Items []*RoomGroupItem `protobuf:"bytes,5,rep,name=items,proto3" json:"items,omitempty"`
+	// State and permissions resolved for the current user.
+	ViewerState   *RoomGroupViewerState `protobuf:"bytes,6,opt,name=viewer_state,json=viewerState,proto3" json:"viewer_state,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *RoomGroup) Reset() {
 	*x = RoomGroup{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[4]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -460,7 +508,7 @@ func (x *RoomGroup) String() string {
 func (*RoomGroup) ProtoMessage() {}
 
 func (x *RoomGroup) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[4]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -473,7 +521,7 @@ func (x *RoomGroup) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomGroup.ProtoReflect.Descriptor instead.
 func (*RoomGroup) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{4}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *RoomGroup) GetId() string {
@@ -504,6 +552,13 @@ func (x *RoomGroup) GetItems() []*RoomGroupItem {
 	return nil
 }
 
+func (x *RoomGroup) GetViewerState() *RoomGroupViewerState {
+	if x != nil {
+		return x.ViewerState
+	}
+	return nil
+}
+
 // Request for rooms visible to the current user.
 type ListRoomsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -515,7 +570,7 @@ type ListRoomsRequest struct {
 
 func (x *ListRoomsRequest) Reset() {
 	*x = ListRoomsRequest{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[5]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -527,7 +582,7 @@ func (x *ListRoomsRequest) String() string {
 func (*ListRoomsRequest) ProtoMessage() {}
 
 func (x *ListRoomsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[5]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -540,7 +595,7 @@ func (x *ListRoomsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoomsRequest.ProtoReflect.Descriptor instead.
 func (*ListRoomsRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{5}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ListRoomsRequest) GetScope() RoomDirectoryScope {
@@ -561,7 +616,7 @@ type ListRoomsResponse struct {
 
 func (x *ListRoomsResponse) Reset() {
 	*x = ListRoomsResponse{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[6]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -573,7 +628,7 @@ func (x *ListRoomsResponse) String() string {
 func (*ListRoomsResponse) ProtoMessage() {}
 
 func (x *ListRoomsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[6]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -586,7 +641,7 @@ func (x *ListRoomsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoomsResponse.ProtoReflect.Descriptor instead.
 func (*ListRoomsResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{6}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ListRoomsResponse) GetRooms() []*DirectoryRoom {
@@ -609,7 +664,7 @@ type ListRoomGroupsRequest struct {
 
 func (x *ListRoomGroupsRequest) Reset() {
 	*x = ListRoomGroupsRequest{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[7]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -621,7 +676,7 @@ func (x *ListRoomGroupsRequest) String() string {
 func (*ListRoomGroupsRequest) ProtoMessage() {}
 
 func (x *ListRoomGroupsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[7]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -634,7 +689,7 @@ func (x *ListRoomGroupsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoomGroupsRequest.ProtoReflect.Descriptor instead.
 func (*ListRoomGroupsRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{7}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ListRoomGroupsRequest) GetIncludeArchivedRooms() bool {
@@ -655,7 +710,7 @@ type ListRoomGroupsResponse struct {
 
 func (x *ListRoomGroupsResponse) Reset() {
 	*x = ListRoomGroupsResponse{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[8]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -667,7 +722,7 @@ func (x *ListRoomGroupsResponse) String() string {
 func (*ListRoomGroupsResponse) ProtoMessage() {}
 
 func (x *ListRoomGroupsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[8]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -680,7 +735,7 @@ func (x *ListRoomGroupsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoomGroupsResponse.ProtoReflect.Descriptor instead.
 func (*ListRoomGroupsResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{8}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ListRoomGroupsResponse) GetGroups() []*RoomGroup {
@@ -705,7 +760,7 @@ type GetRoomGroupRequest struct {
 
 func (x *GetRoomGroupRequest) Reset() {
 	*x = GetRoomGroupRequest{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[9]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -717,7 +772,7 @@ func (x *GetRoomGroupRequest) String() string {
 func (*GetRoomGroupRequest) ProtoMessage() {}
 
 func (x *GetRoomGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[9]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -730,7 +785,7 @@ func (x *GetRoomGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoomGroupRequest.ProtoReflect.Descriptor instead.
 func (*GetRoomGroupRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{9}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *GetRoomGroupRequest) GetGroupId() string {
@@ -758,7 +813,7 @@ type GetRoomGroupResponse struct {
 
 func (x *GetRoomGroupResponse) Reset() {
 	*x = GetRoomGroupResponse{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[10]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -770,7 +825,7 @@ func (x *GetRoomGroupResponse) String() string {
 func (*GetRoomGroupResponse) ProtoMessage() {}
 
 func (x *GetRoomGroupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[10]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -783,7 +838,7 @@ func (x *GetRoomGroupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoomGroupResponse.ProtoReflect.Descriptor instead.
 func (*GetRoomGroupResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{10}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *GetRoomGroupResponse) GetGroup() *RoomGroup {
@@ -808,7 +863,7 @@ type BatchGetRoomGroupsRequest struct {
 
 func (x *BatchGetRoomGroupsRequest) Reset() {
 	*x = BatchGetRoomGroupsRequest{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[11]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -820,7 +875,7 @@ func (x *BatchGetRoomGroupsRequest) String() string {
 func (*BatchGetRoomGroupsRequest) ProtoMessage() {}
 
 func (x *BatchGetRoomGroupsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[11]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -833,7 +888,7 @@ func (x *BatchGetRoomGroupsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BatchGetRoomGroupsRequest.ProtoReflect.Descriptor instead.
 func (*BatchGetRoomGroupsRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{11}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *BatchGetRoomGroupsRequest) GetGroupIds() []string {
@@ -861,7 +916,7 @@ type BatchGetRoomGroupsResponse struct {
 
 func (x *BatchGetRoomGroupsResponse) Reset() {
 	*x = BatchGetRoomGroupsResponse{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[12]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -873,7 +928,7 @@ func (x *BatchGetRoomGroupsResponse) String() string {
 func (*BatchGetRoomGroupsResponse) ProtoMessage() {}
 
 func (x *BatchGetRoomGroupsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[12]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -886,7 +941,7 @@ func (x *BatchGetRoomGroupsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BatchGetRoomGroupsResponse.ProtoReflect.Descriptor instead.
 func (*BatchGetRoomGroupsResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{12}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *BatchGetRoomGroupsResponse) GetGroups() []*RoomGroup {
@@ -907,7 +962,7 @@ type GetRoomRequest struct {
 
 func (x *GetRoomRequest) Reset() {
 	*x = GetRoomRequest{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[13]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -919,7 +974,7 @@ func (x *GetRoomRequest) String() string {
 func (*GetRoomRequest) ProtoMessage() {}
 
 func (x *GetRoomRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[13]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -932,7 +987,7 @@ func (x *GetRoomRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoomRequest.ProtoReflect.Descriptor instead.
 func (*GetRoomRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{13}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *GetRoomRequest) GetRoomId() string {
@@ -953,7 +1008,7 @@ type GetRoomResponse struct {
 
 func (x *GetRoomResponse) Reset() {
 	*x = GetRoomResponse{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[14]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -965,7 +1020,7 @@ func (x *GetRoomResponse) String() string {
 func (*GetRoomResponse) ProtoMessage() {}
 
 func (x *GetRoomResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[14]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -978,7 +1033,7 @@ func (x *GetRoomResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoomResponse.ProtoReflect.Descriptor instead.
 func (*GetRoomResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{14}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *GetRoomResponse) GetRoom() *DirectoryRoom {
@@ -1001,7 +1056,7 @@ type BatchGetRoomsRequest struct {
 
 func (x *BatchGetRoomsRequest) Reset() {
 	*x = BatchGetRoomsRequest{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[15]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1013,7 +1068,7 @@ func (x *BatchGetRoomsRequest) String() string {
 func (*BatchGetRoomsRequest) ProtoMessage() {}
 
 func (x *BatchGetRoomsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[15]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1026,7 +1081,7 @@ func (x *BatchGetRoomsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BatchGetRoomsRequest.ProtoReflect.Descriptor instead.
 func (*BatchGetRoomsRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{15}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *BatchGetRoomsRequest) GetRoomIds() []string {
@@ -1047,7 +1102,7 @@ type BatchGetRoomsResponse struct {
 
 func (x *BatchGetRoomsResponse) Reset() {
 	*x = BatchGetRoomsResponse{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[16]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1059,7 +1114,7 @@ func (x *BatchGetRoomsResponse) String() string {
 func (*BatchGetRoomsResponse) ProtoMessage() {}
 
 func (x *BatchGetRoomsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[16]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1072,7 +1127,7 @@ func (x *BatchGetRoomsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BatchGetRoomsResponse.ProtoReflect.Descriptor instead.
 func (*BatchGetRoomsResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{16}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *BatchGetRoomsResponse) GetRooms() []*DirectoryRoom {
@@ -1113,12 +1168,15 @@ const file_chatto_api_v1_room_directory_proto_rawDesc = "" +
 	"\rRoomGroupItem\x122\n" +
 	"\x04room\x18\x01 \x01(\v2\x1c.chatto.api.v1.DirectoryRoomH\x00R\x04room\x12?\n" +
 	"\fsidebar_link\x18\x02 \x01(\v2\x1a.chatto.api.v1.SidebarLinkH\x00R\vsidebarLinkB\x06\n" +
-	"\x04item\"\x92\x01\n" +
+	"\x04item\">\n" +
+	"\x14RoomGroupViewerState\x12&\n" +
+	"\x0fcan_create_room\x18\x01 \x01(\bR\rcanCreateRoom\"\xda\x01\n" +
 	"\tRoomGroup\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
 	"\vdescription\x18\x03 \x01(\tR\vdescription\x122\n" +
-	"\x05items\x18\x05 \x03(\v2\x1c.chatto.api.v1.RoomGroupItemR\x05itemsJ\x04\b\x04\x10\x05R\x05rooms\"U\n" +
+	"\x05items\x18\x05 \x03(\v2\x1c.chatto.api.v1.RoomGroupItemR\x05items\x12F\n" +
+	"\fviewer_state\x18\x06 \x01(\v2#.chatto.api.v1.RoomGroupViewerStateR\vviewerStateJ\x04\b\x04\x10\x05R\x05rooms\"U\n" +
 	"\x10ListRoomsRequest\x12A\n" +
 	"\x05scope\x18\x01 \x01(\x0e2!.chatto.api.v1.RoomDirectoryScopeB\b\xbaH\x05\x82\x01\x02\x10\x01R\x05scope\"G\n" +
 	"\x11ListRoomsResponse\x122\n" +
@@ -1174,58 +1232,60 @@ func file_chatto_api_v1_room_directory_proto_rawDescGZIP() []byte {
 }
 
 var file_chatto_api_v1_room_directory_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_chatto_api_v1_room_directory_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_chatto_api_v1_room_directory_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_chatto_api_v1_room_directory_proto_goTypes = []any{
 	(RoomDirectoryScope)(0),            // 0: chatto.api.v1.RoomDirectoryScope
 	(*RoomViewerState)(nil),            // 1: chatto.api.v1.RoomViewerState
 	(*DirectoryRoom)(nil),              // 2: chatto.api.v1.DirectoryRoom
 	(*SidebarLink)(nil),                // 3: chatto.api.v1.SidebarLink
 	(*RoomGroupItem)(nil),              // 4: chatto.api.v1.RoomGroupItem
-	(*RoomGroup)(nil),                  // 5: chatto.api.v1.RoomGroup
-	(*ListRoomsRequest)(nil),           // 6: chatto.api.v1.ListRoomsRequest
-	(*ListRoomsResponse)(nil),          // 7: chatto.api.v1.ListRoomsResponse
-	(*ListRoomGroupsRequest)(nil),      // 8: chatto.api.v1.ListRoomGroupsRequest
-	(*ListRoomGroupsResponse)(nil),     // 9: chatto.api.v1.ListRoomGroupsResponse
-	(*GetRoomGroupRequest)(nil),        // 10: chatto.api.v1.GetRoomGroupRequest
-	(*GetRoomGroupResponse)(nil),       // 11: chatto.api.v1.GetRoomGroupResponse
-	(*BatchGetRoomGroupsRequest)(nil),  // 12: chatto.api.v1.BatchGetRoomGroupsRequest
-	(*BatchGetRoomGroupsResponse)(nil), // 13: chatto.api.v1.BatchGetRoomGroupsResponse
-	(*GetRoomRequest)(nil),             // 14: chatto.api.v1.GetRoomRequest
-	(*GetRoomResponse)(nil),            // 15: chatto.api.v1.GetRoomResponse
-	(*BatchGetRoomsRequest)(nil),       // 16: chatto.api.v1.BatchGetRoomsRequest
-	(*BatchGetRoomsResponse)(nil),      // 17: chatto.api.v1.BatchGetRoomsResponse
-	(*Room)(nil),                       // 18: chatto.api.v1.Room
+	(*RoomGroupViewerState)(nil),       // 5: chatto.api.v1.RoomGroupViewerState
+	(*RoomGroup)(nil),                  // 6: chatto.api.v1.RoomGroup
+	(*ListRoomsRequest)(nil),           // 7: chatto.api.v1.ListRoomsRequest
+	(*ListRoomsResponse)(nil),          // 8: chatto.api.v1.ListRoomsResponse
+	(*ListRoomGroupsRequest)(nil),      // 9: chatto.api.v1.ListRoomGroupsRequest
+	(*ListRoomGroupsResponse)(nil),     // 10: chatto.api.v1.ListRoomGroupsResponse
+	(*GetRoomGroupRequest)(nil),        // 11: chatto.api.v1.GetRoomGroupRequest
+	(*GetRoomGroupResponse)(nil),       // 12: chatto.api.v1.GetRoomGroupResponse
+	(*BatchGetRoomGroupsRequest)(nil),  // 13: chatto.api.v1.BatchGetRoomGroupsRequest
+	(*BatchGetRoomGroupsResponse)(nil), // 14: chatto.api.v1.BatchGetRoomGroupsResponse
+	(*GetRoomRequest)(nil),             // 15: chatto.api.v1.GetRoomRequest
+	(*GetRoomResponse)(nil),            // 16: chatto.api.v1.GetRoomResponse
+	(*BatchGetRoomsRequest)(nil),       // 17: chatto.api.v1.BatchGetRoomsRequest
+	(*BatchGetRoomsResponse)(nil),      // 18: chatto.api.v1.BatchGetRoomsResponse
+	(*Room)(nil),                       // 19: chatto.api.v1.Room
 }
 var file_chatto_api_v1_room_directory_proto_depIdxs = []int32{
-	18, // 0: chatto.api.v1.DirectoryRoom.room:type_name -> chatto.api.v1.Room
+	19, // 0: chatto.api.v1.DirectoryRoom.room:type_name -> chatto.api.v1.Room
 	1,  // 1: chatto.api.v1.DirectoryRoom.viewer_state:type_name -> chatto.api.v1.RoomViewerState
 	2,  // 2: chatto.api.v1.RoomGroupItem.room:type_name -> chatto.api.v1.DirectoryRoom
 	3,  // 3: chatto.api.v1.RoomGroupItem.sidebar_link:type_name -> chatto.api.v1.SidebarLink
 	4,  // 4: chatto.api.v1.RoomGroup.items:type_name -> chatto.api.v1.RoomGroupItem
-	0,  // 5: chatto.api.v1.ListRoomsRequest.scope:type_name -> chatto.api.v1.RoomDirectoryScope
-	2,  // 6: chatto.api.v1.ListRoomsResponse.rooms:type_name -> chatto.api.v1.DirectoryRoom
-	5,  // 7: chatto.api.v1.ListRoomGroupsResponse.groups:type_name -> chatto.api.v1.RoomGroup
-	5,  // 8: chatto.api.v1.GetRoomGroupResponse.group:type_name -> chatto.api.v1.RoomGroup
-	5,  // 9: chatto.api.v1.BatchGetRoomGroupsResponse.groups:type_name -> chatto.api.v1.RoomGroup
-	2,  // 10: chatto.api.v1.GetRoomResponse.room:type_name -> chatto.api.v1.DirectoryRoom
-	2,  // 11: chatto.api.v1.BatchGetRoomsResponse.rooms:type_name -> chatto.api.v1.DirectoryRoom
-	6,  // 12: chatto.api.v1.RoomDirectoryService.ListRooms:input_type -> chatto.api.v1.ListRoomsRequest
-	8,  // 13: chatto.api.v1.RoomDirectoryService.ListRoomGroups:input_type -> chatto.api.v1.ListRoomGroupsRequest
-	10, // 14: chatto.api.v1.RoomDirectoryService.GetRoomGroup:input_type -> chatto.api.v1.GetRoomGroupRequest
-	12, // 15: chatto.api.v1.RoomDirectoryService.BatchGetRoomGroups:input_type -> chatto.api.v1.BatchGetRoomGroupsRequest
-	14, // 16: chatto.api.v1.RoomDirectoryService.GetRoom:input_type -> chatto.api.v1.GetRoomRequest
-	16, // 17: chatto.api.v1.RoomDirectoryService.BatchGetRooms:input_type -> chatto.api.v1.BatchGetRoomsRequest
-	7,  // 18: chatto.api.v1.RoomDirectoryService.ListRooms:output_type -> chatto.api.v1.ListRoomsResponse
-	9,  // 19: chatto.api.v1.RoomDirectoryService.ListRoomGroups:output_type -> chatto.api.v1.ListRoomGroupsResponse
-	11, // 20: chatto.api.v1.RoomDirectoryService.GetRoomGroup:output_type -> chatto.api.v1.GetRoomGroupResponse
-	13, // 21: chatto.api.v1.RoomDirectoryService.BatchGetRoomGroups:output_type -> chatto.api.v1.BatchGetRoomGroupsResponse
-	15, // 22: chatto.api.v1.RoomDirectoryService.GetRoom:output_type -> chatto.api.v1.GetRoomResponse
-	17, // 23: chatto.api.v1.RoomDirectoryService.BatchGetRooms:output_type -> chatto.api.v1.BatchGetRoomsResponse
-	18, // [18:24] is the sub-list for method output_type
-	12, // [12:18] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	5,  // 5: chatto.api.v1.RoomGroup.viewer_state:type_name -> chatto.api.v1.RoomGroupViewerState
+	0,  // 6: chatto.api.v1.ListRoomsRequest.scope:type_name -> chatto.api.v1.RoomDirectoryScope
+	2,  // 7: chatto.api.v1.ListRoomsResponse.rooms:type_name -> chatto.api.v1.DirectoryRoom
+	6,  // 8: chatto.api.v1.ListRoomGroupsResponse.groups:type_name -> chatto.api.v1.RoomGroup
+	6,  // 9: chatto.api.v1.GetRoomGroupResponse.group:type_name -> chatto.api.v1.RoomGroup
+	6,  // 10: chatto.api.v1.BatchGetRoomGroupsResponse.groups:type_name -> chatto.api.v1.RoomGroup
+	2,  // 11: chatto.api.v1.GetRoomResponse.room:type_name -> chatto.api.v1.DirectoryRoom
+	2,  // 12: chatto.api.v1.BatchGetRoomsResponse.rooms:type_name -> chatto.api.v1.DirectoryRoom
+	7,  // 13: chatto.api.v1.RoomDirectoryService.ListRooms:input_type -> chatto.api.v1.ListRoomsRequest
+	9,  // 14: chatto.api.v1.RoomDirectoryService.ListRoomGroups:input_type -> chatto.api.v1.ListRoomGroupsRequest
+	11, // 15: chatto.api.v1.RoomDirectoryService.GetRoomGroup:input_type -> chatto.api.v1.GetRoomGroupRequest
+	13, // 16: chatto.api.v1.RoomDirectoryService.BatchGetRoomGroups:input_type -> chatto.api.v1.BatchGetRoomGroupsRequest
+	15, // 17: chatto.api.v1.RoomDirectoryService.GetRoom:input_type -> chatto.api.v1.GetRoomRequest
+	17, // 18: chatto.api.v1.RoomDirectoryService.BatchGetRooms:input_type -> chatto.api.v1.BatchGetRoomsRequest
+	8,  // 19: chatto.api.v1.RoomDirectoryService.ListRooms:output_type -> chatto.api.v1.ListRoomsResponse
+	10, // 20: chatto.api.v1.RoomDirectoryService.ListRoomGroups:output_type -> chatto.api.v1.ListRoomGroupsResponse
+	12, // 21: chatto.api.v1.RoomDirectoryService.GetRoomGroup:output_type -> chatto.api.v1.GetRoomGroupResponse
+	14, // 22: chatto.api.v1.RoomDirectoryService.BatchGetRoomGroups:output_type -> chatto.api.v1.BatchGetRoomGroupsResponse
+	16, // 23: chatto.api.v1.RoomDirectoryService.GetRoom:output_type -> chatto.api.v1.GetRoomResponse
+	18, // 24: chatto.api.v1.RoomDirectoryService.BatchGetRooms:output_type -> chatto.api.v1.BatchGetRoomsResponse
+	19, // [19:25] is the sub-list for method output_type
+	13, // [13:19] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_chatto_api_v1_room_directory_proto_init() }
@@ -1244,7 +1304,7 @@ func file_chatto_api_v1_room_directory_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_api_v1_room_directory_proto_rawDesc), len(file_chatto_api_v1_room_directory_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   17,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/docs/fdr/FDR-001-roles-and-permissions.md
+++ b/docs/fdr/FDR-001-roles-and-permissions.md
@@ -82,7 +82,7 @@ The full permission catalog is in `cli/internal/core/permission.go`. Key permiss
 - `role.assign` — assign roles to users.
 - `user.manage-accounts` — create users, edit account identity, reset passwords, attach verified emails, and clear login cooldowns.
 - `user.manage-permissions` — edit direct per-user permission overrides.
-- `admin.view-users`, `admin.view-system`, `admin.view-audit` — gate specific admin UI sub-views; admin UI entry is derived from concrete capabilities rather than a standalone `admin.access` permission.
+- `admin.view-users`, `admin.view-audit` — gate specific admin UI sub-views; admin UI entry is derived from concrete capabilities rather than a standalone `admin.access` permission. System diagnostics are owner-only and exposed through a viewer capability, not through grantable RBAC.
 - `message.post` — post root messages in rooms and start DMs. Fresh servers grant this to `everyone` at server scope; announcement rooms add a room-level `everyone` deny.
 - `message.attach` — attach files to new messages. Fresh servers grant this to `everyone` at server scope; existing servers are not automatically backfilled after upgrade, so operators may need to grant it manually if uploads should remain enabled.
 - `room.manage` — edit/configure/delete channel rooms.

--- a/docs/fdr/FDR-021-admin-dashboard.md
+++ b/docs/fdr/FDR-021-admin-dashboard.md
@@ -58,14 +58,14 @@ The admin section gives owners and admins visibility into the server's operation
 
 ### 7. Admin APIs use service-level grouping with field-specific capability gates
 
-**Decision:** Admin operations are grouped under dedicated ConnectRPC services, while sensitive methods check their own capabilities (`server.manage`, `admin.view-users`, `admin.view-system`, `admin.view-audit`, `role.manage`, owner-only diagnostics) before returning data.
+**Decision:** Admin operations are grouped under dedicated ConnectRPC services, while sensitive methods check their own capabilities (`server.manage`, `admin.view-users`, `admin.view-audit`, `role.manage`, owner-only diagnostics) before returning data.
 **Why:** Dedicated service grouping gives the API obvious admin-tooling namespaces, and method-level checks let operators delegate user, system, audit, and RBAC-editor visibility independently.
 **Tradeoff:** A user may be able to enter the admin area but see permission denials or empty panels for specific sections. The UI has to reflect that capability split clearly.
 
 ## Permissions
 
 - `admin.view-users` — gates user-management views, admin-only affordances, and user-sensitive fields such as other users' verified email addresses and login cooldowns. The underlying `server.members` directory query remains authenticated-user visible; see FDR-025.
-- `admin.view-system` — gates admin projection diagnostics; system info is owner-only for now.
+- System diagnostics are owner-only; `admin.view-system` is exposed only as a viewer capability key, not as a grantable RBAC permission.
 - `admin.view-audit` — gates admin event log, event type, and event detail reads.
 - `role.assign` — gates user role assignment and revocation.
 - `user.manage-accounts` — gates user creation, cross-user identity edits, password resets, verified-email attachment, and login-cooldown resets.

--- a/packages/api-types/src/chatto/api/v1/room_directory_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/room_directory_pb.ts
@@ -344,6 +344,47 @@ export class RoomGroupItem extends Message<RoomGroupItem> {
 }
 
 /**
+ * Viewer-specific state for one room group.
+ *
+ * @generated from message chatto.api.v1.RoomGroupViewerState
+ */
+export class RoomGroupViewerState extends Message<RoomGroupViewerState> {
+  /**
+   * True when the current user can create rooms in this group.
+   *
+   * @generated from field: bool can_create_room = 1;
+   */
+  canCreateRoom = false;
+
+  constructor(data?: PartialMessage<RoomGroupViewerState>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.api.v1.RoomGroupViewerState";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "can_create_room", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RoomGroupViewerState {
+    return new RoomGroupViewerState().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): RoomGroupViewerState {
+    return new RoomGroupViewerState().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): RoomGroupViewerState {
+    return new RoomGroupViewerState().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: RoomGroupViewerState | PlainMessage<RoomGroupViewerState> | undefined, b: RoomGroupViewerState | PlainMessage<RoomGroupViewerState> | undefined): boolean {
+    return proto3.util.equals(RoomGroupViewerState, a, b);
+  }
+}
+
+/**
  * Ordered group of channel rooms and sidebar links.
  *
  * @generated from message chatto.api.v1.RoomGroup
@@ -377,6 +418,13 @@ export class RoomGroup extends Message<RoomGroup> {
    */
   items: RoomGroupItem[] = [];
 
+  /**
+   * State and permissions resolved for the current user.
+   *
+   * @generated from field: chatto.api.v1.RoomGroupViewerState viewer_state = 6;
+   */
+  viewerState?: RoomGroupViewerState;
+
   constructor(data?: PartialMessage<RoomGroup>) {
     super();
     proto3.util.initPartial(data, this);
@@ -389,6 +437,7 @@ export class RoomGroup extends Message<RoomGroup> {
     { no: 2, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "description", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 5, name: "items", kind: "message", T: RoomGroupItem, repeated: true },
+    { no: 6, name: "viewer_state", kind: "message", T: RoomGroupViewerState },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RoomGroup {

--- a/proto/chatto/api/v1/room_directory.proto
+++ b/proto/chatto/api/v1/room_directory.proto
@@ -76,6 +76,12 @@ message RoomGroupItem {
   }
 }
 
+// Viewer-specific state for one room group.
+message RoomGroupViewerState {
+  // True when the current user can create rooms in this group.
+  bool can_create_room = 1;
+}
+
 // Ordered group of channel rooms and sidebar links.
 message RoomGroup {
   reserved 4;
@@ -89,6 +95,8 @@ message RoomGroup {
   string description = 3;
   // Mixed room/sidebar-link entries in sidebar order.
   repeated RoomGroupItem items = 5;
+  // State and permissions resolved for the current user.
+  RoomGroupViewerState viewer_state = 6;
 }
 
 // Request for rooms visible to the current user.


### PR DESCRIPTION
This removes `admin.view-system` from grantable RBAC permission surfaces while keeping the key as an owner-only viewer capability. It also adds `RoomGroupViewerState.can_create_room` so clients can discover group-scoped room creation, then wires that state through ConnectRPC, generated types/docs, and the admin rooms UI. Tests and docs were updated for the new permission contract.

Verification:
- `mise codegen-proto`
- `mise codegen-types`
- `pnpm --dir packages/api-types run build`
- targeted Go/frontend tests for viewer permissions and room directory state
- `mise test-cli`
