### PR TITLE
fix(frontend): use full-width image galleries

### DIFF
--- a/apps/frontend/e2e/messages.test.ts
+++ b/apps/frontend/e2e/messages.test.ts
@@ -697,22 +697,30 @@ test('image lightbox supports keyboard navigation with multiple images', async (
   await chatPage.goto();
   await chatPage.enterRoom('general');
 
-  const thirdImage = await sharp({
-    create: {
-      width: 1600,
-      height: 900,
-      channels: 3,
-      background: { r: 190, g: 210, b: 235 }
-    }
-  })
-    .png()
-    .toBuffer();
+  const [thirdImage, fourthImage, fifthImage] = await Promise.all(
+    [
+      { r: 190, g: 210, b: 235 },
+      { r: 210, g: 225, b: 195 },
+      { r: 230, g: 205, b: 195 }
+    ].map((background) =>
+      sharp({
+        create: {
+          width: 1600,
+          height: 900,
+          channels: 3,
+          background
+        }
+      })
+        .png()
+        .toBuffer()
+    )
+  );
   const [brightonImage, brighton2Image] = await Promise.all([
     readFile('e2e/fixtures/brighton.jpg'),
     readFile('e2e/fixtures/brighton2.jpg')
   ]);
 
-  // Upload three images in a single message so the desktop gallery overflows its viewport.
+  // Upload enough images in a single message so the full-width desktop gallery still overflows.
   await roomPage.fileInput.setInputFiles([
     {
       name: 'brighton.jpg',
@@ -728,23 +736,33 @@ test('image lightbox supports keyboard navigation with multiple images', async (
       name: 'generated-gallery-third.png',
       mimeType: 'image/png',
       buffer: thirdImage
+    },
+    {
+      name: 'generated-gallery-fourth.png',
+      mimeType: 'image/png',
+      buffer: fourthImage
+    },
+    {
+      name: 'generated-gallery-fifth.png',
+      mimeType: 'image/png',
+      buffer: fifthImage
     }
   ]);
 
   // Wait for all attachment previews to appear
-  await expect(roomPage.attachmentPreview).toHaveCount(3);
+  await expect(roomPage.attachmentPreview).toHaveCount(5);
 
   // Send the message
   await roomPage.messageInput.press('Enter');
 
   // Wait for all attachment images to appear in the message
-  await expect(roomPage.attachmentImage).toHaveCount(3, { timeout: TIMEOUTS.COMPLEX_OPERATION });
+  await expect(roomPage.attachmentImage).toHaveCount(5, { timeout: TIMEOUTS.COMPLEX_OPERATION });
 
   const gallery = page.getByTestId('message-image-gallery');
   await expect(gallery).toBeVisible();
   await expect.poll(() => gallery.evaluate((el) => getComputedStyle(el).columnGap)).toBe('12px');
   const galleryImages = gallery.locator('button[aria-label^="View"]');
-  await expect(galleryImages).toHaveCount(3);
+  await expect(galleryImages).toHaveCount(5);
   await expect.poll(() => gallery.evaluate((el) => el.scrollWidth > el.clientWidth)).toBe(true);
   await gallery.evaluate((el) => {
     el.scrollLeft = 0;
@@ -763,7 +781,7 @@ test('image lightbox supports keyboard navigation with multiple images', async (
       return { width: rect.width, height: rect.height };
     })
   );
-  expect(galleryBoxes).toHaveLength(3);
+  expect(galleryBoxes).toHaveLength(5);
   expect(Math.abs(galleryBoxes[0].height - galleryBoxes[1].height)).toBeLessThanOrEqual(1);
   expect(galleryBoxes[0].height).toBeGreaterThan(0);
   expect(Math.max(...galleryBoxes.map((box) => box.width))).toBeLessThanOrEqual(321);
@@ -786,7 +804,7 @@ test('image lightbox supports keyboard navigation with multiple images', async (
       return { width: rect.width, height: rect.height };
     })
   );
-  expect(narrowGalleryBoxes).toHaveLength(3);
+  expect(narrowGalleryBoxes).toHaveLength(5);
   expect(Math.abs(narrowGalleryBoxes[0].height - narrowGalleryBoxes[1].height)).toBeLessThanOrEqual(
     1
   );
@@ -806,33 +824,41 @@ test('image lightbox supports keyboard navigation with multiple images', async (
   // Click the first image to open the lightbox
   await roomPage.attachmentImage.first().click();
 
-  // Verify lightbox is open with counter showing "1 / 3"
+  // Verify lightbox is open with counter showing "1 / 5"
   const dialog = page.locator('dialog[open]');
   await expect(dialog).toBeVisible();
-  await expect(dialog.getByText('1 / 3')).toBeVisible();
+  await expect(dialog.getByText('1 / 5')).toBeVisible();
 
   // Verify the "brighton.jpg" filename is shown
   await expect(dialog.getByText('brighton.jpg')).toBeVisible();
 
   // Press ArrowRight to go to the next image
   await page.keyboard.press('ArrowRight');
-  await expect(dialog.getByText('2 / 3')).toBeVisible();
+  await expect(dialog.getByText('2 / 5')).toBeVisible();
   await expect(dialog.getByText('brighton2.jpg')).toBeVisible();
 
   // Press ArrowRight again to go to the third image
   await page.keyboard.press('ArrowRight');
-  await expect(dialog.getByText('3 / 3')).toBeVisible();
+  await expect(dialog.getByText('3 / 5')).toBeVisible();
   await expect(dialog.getByText('generated-gallery-third.png')).toBeVisible();
+
+  // Advance to the last image before wrapping around.
+  await page.keyboard.press('ArrowRight');
+  await expect(dialog.getByText('4 / 5')).toBeVisible();
+  await expect(dialog.getByText('generated-gallery-fourth.png')).toBeVisible();
+  await page.keyboard.press('ArrowRight');
+  await expect(dialog.getByText('5 / 5')).toBeVisible();
+  await expect(dialog.getByText('generated-gallery-fifth.png')).toBeVisible();
 
   // Press ArrowRight again to wrap around to the first image
   await page.keyboard.press('ArrowRight');
-  await expect(dialog.getByText('1 / 3')).toBeVisible();
+  await expect(dialog.getByText('1 / 5')).toBeVisible();
   await expect(dialog.getByText('brighton.jpg')).toBeVisible();
 
   // Press ArrowLeft to wrap backwards to the last image
   await page.keyboard.press('ArrowLeft');
-  await expect(dialog.getByText('3 / 3')).toBeVisible();
-  await expect(dialog.getByText('generated-gallery-third.png')).toBeVisible();
+  await expect(dialog.getByText('5 / 5')).toBeVisible();
+  await expect(dialog.getByText('generated-gallery-fifth.png')).toBeVisible();
 
   // Verify navigation buttons are present
   await expect(dialog.getByRole('button', { name: 'Previous image' })).toBeVisible();
@@ -840,7 +866,7 @@ test('image lightbox supports keyboard navigation with multiple images', async (
 
   // Click the "Next image" button
   await dialog.getByRole('button', { name: 'Next image' }).click();
-  await expect(dialog.getByText('1 / 3')).toBeVisible();
+  await expect(dialog.getByText('1 / 5')).toBeVisible();
 
   // Close with Escape
   await page.keyboard.press('Escape');

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
@@ -133,7 +133,6 @@
   const GALLERY_THUMB_HEIGHT = 180;
   const GALLERY_THUMB_MIN_WIDTH = 72;
   const GALLERY_THUMB_MAX_WIDTH = 320;
-  const GALLERY_VIEWPORT_MAX_WIDTH = 680;
 
   type ThumbDisplay = {
     width: number;
@@ -176,7 +175,10 @@
         GALLERY_THUMB_MAX_WIDTH
       ),
       height: GALLERY_THUMB_HEIGHT,
-      fit: 'contain'
+      fit:
+        aspectRatio >= EXTREME_ASPECT_RATIO || aspectRatio <= 1 / EXTREME_ASPECT_RATIO
+          ? 'contain'
+          : 'cover'
     };
   }
 
@@ -200,10 +202,6 @@
       return `width: ${display.width}px; height: ${display.height}px`;
     }
     return `width: ${display.width}px; max-width: 100%; aspect-ratio: ${display.width} / ${display.height}`;
-  }
-
-  function galleryViewportStyle(): string {
-    return `width: min(100%, ${GALLERY_VIEWPORT_MAX_WIDTH}px)`;
   }
 
   function updateGalleryScrollEdges(el: HTMLElement) {
@@ -604,10 +602,10 @@
 
   {#if hasImageGallery}
     <div class="mt-2 flex min-w-0 flex-col gap-2 first:mt-0">
-      <div class="relative max-w-full min-w-0" style={galleryViewportStyle()}>
+      <div class="relative w-full max-w-full min-w-0">
         <div
           {@attach trackGalleryScrollEdges}
-          class="flex w-full gap-3 overflow-x-auto overscroll-x-contain pb-1"
+          class="flex w-full gap-3 overflow-x-auto overscroll-x-contain p-1"
           data-testid="message-image-gallery"
         >
           {#each imageAttachments as attachment (attachment.id)}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
@@ -163,6 +163,9 @@ describe('MessageAttachments', () => {
     expect(gallery!.className).toContain('overflow-x-auto');
     expect(gallery!.className).toContain('overscroll-x-contain');
     expect(gallery!.className).toContain('gap-3');
+    expect(gallery!.className).toContain('p-1');
+    expect(gallery!.parentElement?.className).toContain('w-full');
+    expect(gallery!.parentElement?.getAttribute('style')).toBeNull();
     expect(
       container.querySelector('[data-testid="message-image-gallery-left-fade"]')
     ).not.toBeNull();
@@ -174,6 +177,56 @@ describe('MessageAttachments', () => {
     expect(buttons).toHaveLength(2);
     expect(buttons.map((button) => button.style.height)).toEqual(['180px', '180px']);
     expect(buttons.every((button) => Number.parseFloat(button.style.width) <= 320)).toBe(true);
+  });
+
+  it('fills moderately wide gallery image frames', () => {
+    const { container } = renderAttachments([
+      imageAttachment({
+        id: 'moderately-wide',
+        filename: 'moderately-wide.jpg',
+        width: 1200,
+        height: 600
+      }),
+      imageAttachment({
+        id: 'ordinary',
+        filename: 'ordinary.jpg',
+        width: 800,
+        height: 600
+      })
+    ]);
+
+    const { image, button } = imageFrame(container, 'moderately-wide.jpg');
+
+    expect(button.closest('[data-testid="message-image-gallery"]')).not.toBeNull();
+    expect(button.getAttribute('style')).toContain('width: 320px');
+    expect(button.getAttribute('style')).toContain('height: 180px');
+    expect(image.className).toContain('object-cover');
+    expect(image.className).not.toContain('object-contain');
+  });
+
+  it('fills moderately tall gallery image frames', () => {
+    const { container } = renderAttachments([
+      imageAttachment({
+        id: 'moderately-tall',
+        filename: 'moderately-tall.jpg',
+        width: 400,
+        height: 1000
+      }),
+      imageAttachment({
+        id: 'ordinary',
+        filename: 'ordinary.jpg',
+        width: 800,
+        height: 600
+      })
+    ]);
+
+    const { image, button } = imageFrame(container, 'moderately-tall.jpg');
+
+    expect(button.closest('[data-testid="message-image-gallery"]')).not.toBeNull();
+    expect(button.getAttribute('style')).toContain('width: 72px');
+    expect(button.getAttribute('style')).toContain('height: 180px');
+    expect(image.className).toContain('object-cover');
+    expect(image.className).not.toContain('object-contain');
   });
 
   it('contains ultra-wide gallery images instead of creating shallow thumbnails', () => {
@@ -196,6 +249,31 @@ describe('MessageAttachments', () => {
 
     expect(button.closest('[data-testid="message-image-gallery"]')).not.toBeNull();
     expect(button.getAttribute('style')).toContain('width: 320px');
+    expect(button.getAttribute('style')).toContain('height: 180px');
+    expect(image.className).toContain('object-contain');
+    expect(image.className).not.toContain('object-cover');
+  });
+
+  it('contains ultra-tall gallery images instead of cropping them', () => {
+    const { container } = renderAttachments([
+      imageAttachment({
+        id: 'ultra-tall',
+        filename: 'ultra-tall.jpg',
+        width: 320,
+        height: 1600
+      }),
+      imageAttachment({
+        id: 'ordinary',
+        filename: 'ordinary.jpg',
+        width: 1600,
+        height: 900
+      })
+    ]);
+
+    const { image, button } = imageFrame(container, 'ultra-tall.jpg');
+
+    expect(button.closest('[data-testid="message-image-gallery"]')).not.toBeNull();
+    expect(button.getAttribute('style')).toContain('width: 72px');
     expect(button.getAttribute('style')).toContain('height: 180px');
     expect(image.className).toContain('object-contain');
     expect(image.className).not.toContain('object-cover');


### PR DESCRIPTION
## Summary

Image galleries now fill the available message column width instead of stopping at an internal 680px cap.
Gallery thumbnails use cropping for normal ratios and reserve letterboxing for extreme wide or tall images.
The gallery/lightbox tests now cover the wider viewport and the selective letterboxing behavior.

## Checks

- `mise x -- pnpm exec vitest run 'src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts'`
- `mise x -- npx @sveltejs/mcp svelte-autofixer 'src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte' --svelte-version 5`
- `mise x -- pnpm exec playwright test e2e/messages.test.ts -g "image lightbox supports keyboard navigation with multiple images" --retries=0`
