### PR TITLE
fix(frontend): reset inline code state when composer clears

### DIFF
--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -1403,6 +1403,33 @@ describe('MessageComposer', () => {
       });
     });
 
+    it('clears inline code formatting after an inline-code-only draft is deleted', async () => {
+      const { container, roomId } = renderMessageComposer({ roomId: 'room_456' });
+      const editor = await findEditor(container);
+
+      await typeEditorKeys(editor, '`code`');
+      await vi.waitFor(() => expect(editor.querySelector('p code')?.textContent).toBe('code'));
+
+      document.execCommand('selectAll');
+      document.execCommand('delete');
+      await tick();
+      await vi.waitFor(() => expect(editor.textContent).toBe(''));
+
+      await insertEditorLiteralText(editor, 'plain');
+      await vi.waitFor(() => {
+        expect(editor.textContent).toBe('plain');
+        expect(editor.querySelector('p code')).toBeNull();
+      });
+
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({
+        roomId,
+        body: 'plain'
+      });
+    });
+
     it('posts markdown after typed markdown link syntax is applied', async () => {
       const { container, roomId } = renderMessageComposer({ roomId: 'room_456' });
       const editor = await findEditor(container);

--- a/apps/frontend/src/lib/components/composer/TipTapEditor.svelte
+++ b/apps/frontend/src/lib/components/composer/TipTapEditor.svelte
@@ -65,6 +65,12 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     return node.textBetween(0, node.content.size, '\n', '\n');
   }
 
+  function isDefaultEmptyDocument(doc: ProseMirrorNode): boolean {
+    if (doc.childCount !== 1) return false;
+    const firstChild = doc.firstChild;
+    return firstChild?.type.name === 'paragraph' && firstChild.content.size === 0;
+  }
+
   function createParagraphFromText(schema: Schema, text: string) {
     const paragraph = schema.nodes.paragraph;
     const hardBreak = schema.nodes.hardBreak;
@@ -327,6 +333,25 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
             if (!paragraph || !lastChild || lastChild.type.name !== 'codeBlock') return null;
 
             return newState.tr.insert(newState.doc.content.size, paragraph.create());
+          }
+        })
+      ];
+    }
+  });
+
+  const ClearMarksOnEmptyDocument = Extension.create({
+    name: 'clearMarksOnEmptyDocument',
+
+    addProseMirrorPlugins() {
+      return [
+        new Plugin({
+          key: new PluginKey('clearMarksOnEmptyDocument'),
+          appendTransaction: (transactions, _oldState, newState) => {
+            if (!transactions.some((transaction) => transaction.docChanged)) return null;
+            if (!isDefaultEmptyDocument(newState.doc)) return null;
+            if ((newState.storedMarks?.length ?? 0) === 0) return null;
+
+            return newState.tr.setStoredMarks([]);
           }
         })
       ];
@@ -619,9 +644,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
   }
 
   function hasDefaultEmptyDocument(e: Editor): boolean {
-    if (e.state.doc.childCount !== 1) return false;
-    const firstChild = e.state.doc.firstChild;
-    return firstChild?.type.name === 'paragraph' && firstChild.content.size === 0;
+    return isDefaultEmptyDocument(e.state.doc);
   }
 
   function isSelectionInTrailingEmptyParagraph(e: Editor): boolean {
@@ -1097,6 +1120,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
             CompletedMarkdownCodeFence,
             MarkdownListMarkerAfterHardBreak,
             TrailingParagraphAfterCodeBlock,
+            ClearMarksOnEmptyDocument,
             Placeholder.configure({ placeholder })
           ],
           content: '',


### PR DESCRIPTION
Fixes a mobile composer edge case where deleting an inline-code-only draft could leave TipTap's stored code mark active, causing the next text to stay in code formatting.

The editor now clears stored marks when a doc-changing transaction leaves the default empty paragraph.

Added a browser composer regression test covering inline code deletion, plain text re-entry, and submission.

Validation: built @chatto/api-types for local dist, ran the targeted composer Vitest spec (95 passed), and ran the Svelte autofixer on TipTapEditor.svelte.
