### PR TITLE
fix(frontend): clarify echo reply actions

### DIFF
--- a/apps/frontend/e2e/pages/MessageComponent.ts
+++ b/apps/frontend/e2e/pages/MessageComponent.ts
@@ -87,6 +87,11 @@ export class MessageComponent {
    */
   async replyViaToolbar(): Promise<void> {
     await this.revealHoverToolbar();
+    const openThread = this.hoverToolbar.getByLabel('Open thread');
+    if ((await openThread.count()) > 0) {
+      await openThread.click();
+      return;
+    }
     await this.hoverToolbar.getByLabel('Reply in thread').click();
   }
 
@@ -204,8 +209,27 @@ export class MessageComponent {
    */
   async openThread(): Promise<void> {
     await this.openContextMenu();
+    const openThread = this.contextMenu.getByRole('menuitem', {
+      name: 'Open thread',
+      exact: true
+    });
+    if ((await openThread.count()) > 0) {
+      await openThread.click({ timeout: TIMEOUTS.REALTIME_EVENT });
+      return;
+    }
     await this.contextMenu
-      .getByRole('menuitem', { name: /Reply in thread/ })
+      .getByRole('menuitem', { name: 'Reply in thread', exact: true })
+      .click({ timeout: TIMEOUTS.REALTIME_EVENT });
+  }
+
+  /**
+   * Start a reply to an echoed thread message.
+   * Echo rows label this action "Reply in thread" and keep "Open thread" as navigation only.
+   */
+  async replyToEchoInThread(): Promise<void> {
+    await this.openContextMenu();
+    await this.contextMenu
+      .getByRole('menuitem', { name: 'Reply in thread', exact: true })
       .click({ timeout: TIMEOUTS.REALTIME_EVENT });
   }
 

--- a/apps/frontend/e2e/thread-reply-echo.test.ts
+++ b/apps/frontend/e2e/thread-reply-echo.test.ts
@@ -23,6 +23,31 @@ async function clickReplyAttributionJump(attribution: Locator): Promise<void> {
   await attribution.click({ position: { x: 8, y: 8 } });
 }
 
+async function selectTextInside(locator: Locator, selectedText: string): Promise<void> {
+  await locator.evaluate((root, text) => {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    let node: Node | null = walker.nextNode();
+
+    while (node) {
+      const value = node.textContent ?? '';
+      const index = value.indexOf(text);
+      if (index !== -1) {
+        const range = document.createRange();
+        range.setStart(node, index);
+        range.setEnd(node, index + text.length);
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+        return;
+      }
+
+      node = walker.nextNode();
+    }
+
+    throw new Error(`Could not find text to select: ${text}`);
+  }, selectedText);
+}
+
 test.describe('Thread Reply Echo ("Also send to channel")', () => {
   test('"Also send to channel" checkbox is visible in thread composer', async ({
     page,
@@ -230,6 +255,160 @@ test.describe('Thread Reply Echo ("Also send to channel")', () => {
       await roomPage.expectTextInThreadPane(rootMessage);
       await roomPage.expectTextInThreadPane(replyMessage);
     });
+  });
+
+  test('replying to an echo opens the thread composer with reply context', async ({
+    page,
+    chatPage,
+    roomPage
+  }) => {
+    await test.step('Setup: User loads the server and posts an echoed thread reply', async () => {
+      await createAndLoginTestUser(page);
+      await chatPage.goto();
+      await chatPage.enterRoom('general');
+    });
+
+    const timestamp = Date.now();
+    const rootMessage = `Root for echo reply UX ${timestamp}`;
+    const echoedReply = `Echoed reply target ${timestamp}`;
+    const followupReply = `Follow-up from echo reply ${timestamp}`;
+
+    const rootMessageComponent = await roomPage.sendMessage(rootMessage);
+
+    await test.step('Post a thread reply with a channel echo', async () => {
+      await rootMessageComponent.openThread();
+      await roomPage.expectThreadPaneVisible();
+      await roomPage.postThreadReplyWithEcho(echoedReply);
+      await roomPage.closeThread();
+      await roomPage.expectThreadRouteClosed();
+      await expect(page.locator('[role="article"]', { hasText: echoedReply })).toBeVisible({
+        timeout: TIMEOUTS.REALTIME_EVENT
+      });
+    });
+
+    await test.step('Use Reply on the echo and verify the thread composer is seeded', async () => {
+      const echoMessage = roomPage.getMessage(echoedReply);
+      await echoMessage.replyToEchoInThread();
+
+      await roomPage.expectThreadPaneVisible();
+      await expect(page.getByTestId('thread-pane').getByText('Replying to')).toBeVisible({
+        timeout: TIMEOUTS.UI_STANDARD
+      });
+      await expect(page.getByTestId('thread-reply-input')).toBeFocused({
+        timeout: TIMEOUTS.UI_STANDARD
+      });
+    });
+
+    await test.step('Send from the seeded composer and verify it stays in the thread', async () => {
+      await roomPage.postThreadReply(followupReply);
+
+      const threadReply = roomPage.getThreadMessage(followupReply);
+      await expect(threadReply.locator.getByTestId('reply-attribution')).toBeVisible({
+        timeout: TIMEOUTS.REALTIME_EVENT
+      });
+
+      await roomPage.closeThread();
+      await roomPage.expectThreadRouteClosed();
+      await expect(page.locator('[role="article"]', { hasText: followupReply })).toHaveCount(0, {
+        timeout: TIMEOUTS.UI_STANDARD
+      });
+    });
+  });
+
+  test('opening an echo thread does not preload selected text as a composer quote', async ({
+    page,
+    chatPage,
+    roomPage
+  }) => {
+    await test.step('Setup: User loads the server and posts an echoed thread reply', async () => {
+      await createAndLoginTestUser(page);
+      await chatPage.goto();
+      await chatPage.enterRoom('general');
+    });
+
+    const timestamp = Date.now();
+    const rootMessage = `Root for echo open quote ${timestamp}`;
+    const selectedText = `selected echo text ${timestamp}`;
+    const echoedReply = `Before ${selectedText} after`;
+    const rootMessageComponent = await roomPage.sendMessage(rootMessage);
+
+    await test.step('Post a thread reply with a channel echo', async () => {
+      await rootMessageComponent.openThread();
+      await roomPage.expectThreadPaneVisible();
+      await roomPage.postThreadReplyWithEcho(echoedReply);
+      await roomPage.closeThread();
+      await roomPage.expectThreadRouteClosed();
+    });
+
+    await test.step('Select echo text and open the thread as navigation only', async () => {
+      const echoMessage = roomPage.getMessage(echoedReply);
+      await selectTextInside(echoMessage.locator, selectedText);
+      await echoMessage.openThread();
+
+      await roomPage.expectThreadPaneVisible();
+      await expect(page.getByTestId('thread-reply-input').locator('blockquote')).toHaveCount(0);
+    });
+  });
+
+  test('read-only thread posters can still open an echo thread from message actions', async ({
+    page,
+    chatPage,
+    roomPage,
+    browser,
+    serverURL
+  }) => {
+    await test.step('User A loads the server and posts an echoed thread reply', async () => {
+      await createAndLoginTestUser(page);
+      await chatPage.goto();
+      await chatPage.enterRoom('general');
+    });
+
+    const timestamp = Date.now();
+    const rootMessage = `Root for echo open permission ${timestamp}`;
+    const echoedReply = `Echo open permission target ${timestamp}`;
+    const rootMessageComponent = await roomPage.sendMessage(rootMessage);
+
+    await rootMessageComponent.openThread();
+    await roomPage.expectThreadPaneVisible();
+    await roomPage.postThreadReplyWithEcho(echoedReply);
+    await roomPage.closeThread();
+    await roomPage.expectThreadRouteClosed();
+
+    await test.step('Deny message.post-in-thread on everyone for the seed room group', async () => {
+      await withBootstrapAdminRequest(serverURL, async (adminRequest) => {
+        const seedSetId = await getDefaultRoomGroupIdViaConnect(adminRequest);
+        const permission = 'message.post-in-thread';
+        const decision = 'PERMISSION_DECISION_DENY';
+        const scope = {
+          kind: 'PERMISSION_SCOPE_KIND_GROUP',
+          id: seedSetId
+        } as const;
+        const response = await connectPost<E2EPermissionDecisionUpdateResponse>(
+          adminRequest,
+          'chatto.admin.v1.AdminPermissionService/SetRolePermission',
+          {
+            roleName: 'everyone',
+            permission,
+            decision,
+            scope
+          }
+        );
+        expectPermissionDecisionUpdate(response, { permission, decision, scope });
+      });
+    });
+
+    await withServerUser(
+      browser!,
+      serverURL,
+      async ({ page: page2, chatPage: chatPage2, roomPage: roomPage2 }) => {
+        await chatPage2.enterRoom('general');
+        await waitForRoomReady(page2, 'general');
+
+        await roomPage2.expectMessageVisible(echoedReply);
+        await roomPage2.getMessage(echoedReply).openThread();
+        await roomPage2.expectThreadPaneVisible();
+      }
+    );
   });
 
   test('echo and original have independent reactions', async ({ page, chatPage, roomPage }) => {

--- a/apps/frontend/messages/de/room.json
+++ b/apps/frontend/messages/de/room.json
@@ -74,6 +74,7 @@
         "more_reactions": "Weitere Reaktionen",
         "reply": "Antworten",
         "reply_thread": "Im Thread antworten",
+        "open_thread": "Thread öffnen",
         "edit": "Nachricht bearbeiten",
         "more": "Weitere Aktionen",
         "edit_short": "Bearbeiten",

--- a/apps/frontend/messages/en/room.json
+++ b/apps/frontend/messages/en/room.json
@@ -74,6 +74,7 @@
         "more_reactions": "More reactions",
         "reply": "Reply",
         "reply_thread": "Reply in thread",
+        "open_thread": "Open thread",
         "edit": "Edit message",
         "more": "More actions",
         "edit_short": "Edit",

--- a/apps/frontend/src/lib/components/menus/MessageContextMenu.svelte
+++ b/apps/frontend/src/lib/components/menus/MessageContextMenu.svelte
@@ -38,6 +38,8 @@ Rendered inside a ContextMenu when right-clicking a message.
     canReact = false,
     canEdit = false,
     canDelete = false,
+    replyInRoomLabel,
+    replyThreadLabel,
     onReplyInRoom,
     onReply,
     onOpenEmojiPicker,
@@ -56,6 +58,8 @@ Rendered inside a ContextMenu when right-clicking a message.
     canReact?: boolean;
     canEdit?: boolean;
     canDelete?: boolean;
+    replyInRoomLabel?: string;
+    replyThreadLabel?: string;
     onReplyInRoom?: () => void;
     onReply?: () => void;
     onOpenEmojiPicker?: () => void;
@@ -65,6 +69,10 @@ Rendered inside a ContextMenu when right-clicking a message.
   const quickReactions = $derived(getRecentEmojis(serverId).quickReactions);
 
   const actions = useMessageActions();
+  const replyInRoomActionLabel = $derived(replyInRoomLabel ?? m['room.message.actions.reply']());
+  const replyThreadActionLabel = $derived(
+    replyThreadLabel ?? m['room.message.actions.reply_thread']()
+  );
 
   const params: MessageActionParams = $derived({
     serverId,
@@ -153,14 +161,14 @@ Rendered inside a ContextMenu when right-clicking a message.
     {#if onReplyInRoom}
       <button class="sidebar-item" onclick={handleReplyInRoom} role="menuitem">
         <span class="sidebar-icon iconify uil--corner-up-left"></span>
-        {m['room.message.actions.reply']()}
+        {replyInRoomActionLabel}
       </button>
     {/if}
 
     {#if onReply}
       <button class="sidebar-item" onclick={handleReply} role="menuitem">
         <span class="sidebar-icon iconify uil--comment-alt-lines"></span>
-        {m['room.message.actions.reply_thread']()}
+        {replyThreadActionLabel}
       </button>
     {/if}
 

--- a/apps/frontend/src/lib/components/menus/MessageContextMenu.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/menus/MessageContextMenu.svelte.spec.ts
@@ -69,6 +69,23 @@ describe('MessageContextMenu', () => {
     expect(container.textContent).toContain('Delete');
   });
 
+  it('uses custom reply action labels when provided', () => {
+    const { container } = renderMenu({
+      onReply: vi.fn(),
+      onReplyInRoom: vi.fn(),
+      replyInRoomLabel: 'Reply in thread',
+      replyThreadLabel: 'Open thread'
+    });
+
+    const actionLabels = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')
+    )
+      .map((button) => button.textContent?.trim())
+      .filter(Boolean);
+
+    expect(actionLabels).toEqual(['Reply in thread', 'Open thread', 'Copy link']);
+  });
+
   it('orders copy link between edit and delete', () => {
     const { container } = renderMenu({
       canEdit: true,

--- a/apps/frontend/src/lib/i18n/messages.ts
+++ b/apps/frontend/src/lib/i18n/messages.ts
@@ -620,6 +620,7 @@ const msg_room_message_actions_add_reaction = (): LocalizedString => messages().
 const msg_room_message_actions_more_reactions = (): LocalizedString => messages().room_message_actions_more_reactions(empty());
 const msg_room_message_actions_reply = (): LocalizedString => messages().room_message_actions_reply(empty());
 const msg_room_message_actions_reply_thread = (): LocalizedString => messages().room_message_actions_reply_thread(empty());
+const msg_room_message_actions_open_thread = (): LocalizedString => messages().room_message_actions_open_thread(empty());
 const msg_room_message_actions_edit = (): LocalizedString => messages().room_message_actions_edit(empty());
 const msg_room_message_actions_more = (): LocalizedString => messages().room_message_actions_more(empty());
 const msg_room_message_actions_edit_short = (): LocalizedString => messages().room_message_actions_edit_short(empty());
@@ -1938,6 +1939,7 @@ export { msg_room_message_actions_add_reaction as 'room.message.actions.add_reac
 export { msg_room_message_actions_more_reactions as 'room.message.actions.more_reactions' };
 export { msg_room_message_actions_reply as 'room.message.actions.reply' };
 export { msg_room_message_actions_reply_thread as 'room.message.actions.reply_thread' };
+export { msg_room_message_actions_open_thread as 'room.message.actions.open_thread' };
 export { msg_room_message_actions_edit as 'room.message.actions.edit' };
 export { msg_room_message_actions_more as 'room.message.actions.more' };
 export { msg_room_message_actions_edit_short as 'room.message.actions.edit_short' };

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -6,12 +6,7 @@
   import { getLocale } from '$lib/i18n/runtime';
   import type { RoomEventView } from '$lib/render/types';
   import { isMessagePostedEvent } from '$lib/render/eventKinds';
-  import type {
-    MessagesStore,
-    QuoteInsertionContent,
-    RefreshCurrentWindowResult,
-    RoomMember
-  } from '$lib/state/room';
+  import type { MessagesStore, RefreshCurrentWindowResult, RoomMember } from '$lib/state/room';
   import { getComposerContext, getRoomPermissions } from '$lib/state/room';
   import RoomEvent from './RoomEvent.svelte';
   import SystemEventGroup from './SystemEventGroup.svelte';
@@ -31,6 +26,7 @@
     useMayHaveMissedMessagesCallback,
     type MayHaveMissedMessagesReason
   } from '$lib/hooks/useMayHaveMissedMessagesCallback.svelte';
+  import type { OpenThreadHandler, ThreadOpenOptions } from './threadOpenOptions';
 
   let {
     roomId,
@@ -88,11 +84,7 @@
     // Event updates
     updateCounter?: number;
     // Threading
-    onOpenThread?: (
-      threadRootEventId: string,
-      highlightEventId?: string,
-      quoteText?: QuoteInsertionContent
-    ) => void;
+    onOpenThread?: OpenThreadHandler;
     // Filtering
     filterThreadReplies?: boolean;
     // Up-arrow-to-edit
@@ -732,20 +724,14 @@
     if (isMessagePostedEvent(eventData)) {
       // Echoes open the original thread
       if (eventData.echoOfEventId != null) {
-        return (
-          _threadRootEventId: string,
-          highlightEventId?: string,
-          quoteText?: QuoteInsertionContent
-        ) => onOpenThread(eventData.echoFromThreadRootEventId!, highlightEventId, quoteText);
+        return (_threadRootEventId: string, options: ThreadOpenOptions = {}) =>
+          onOpenThread(eventData.echoFromThreadRootEventId!, options);
       }
       // Thread replies don't open threads from the main channel
       if (eventData.threadRootEventId !== null) return undefined;
       // Root messages open their own thread
-      return (
-        _threadRootEventId?: string,
-        _highlightEventId?: string,
-        quoteText?: QuoteInsertionContent
-      ) => onOpenThread(event.id, undefined, quoteText);
+      return (_threadRootEventId?: string, options: ThreadOpenOptions = {}) =>
+        onOpenThread(event.id, options);
     }
 
     return undefined;

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionSheet.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionSheet.svelte
@@ -18,6 +18,8 @@
     canReact = false,
     canEdit = false,
     canDelete = false,
+    replyInRoomLabel,
+    replyThreadLabel,
     onReplyInRoom,
     onReply,
     onOpenEmojiPicker,
@@ -36,6 +38,8 @@
     canReact?: boolean;
     canEdit?: boolean;
     canDelete?: boolean;
+    replyInRoomLabel?: string;
+    replyThreadLabel?: string;
     onReplyInRoom?: () => void;
     onReply?: () => void;
     onOpenEmojiPicker?: () => void;
@@ -45,6 +49,10 @@
   const quickReactions = $derived(getRecentEmojis(serverId).quickReactions);
 
   const actions = useMessageActions();
+  const replyInRoomActionLabel = $derived(replyInRoomLabel ?? m['room.message.actions.reply']());
+  const replyThreadActionLabel = $derived(
+    replyThreadLabel ?? m['room.message.actions.reply_thread']()
+  );
 
   const params: MessageActionParams = $derived({
     serverId,
@@ -130,14 +138,14 @@
     {#if onReplyInRoom}
       <button class="sidebar-item min-h-11 gap-3 px-3 py-2.5 text-base" onclick={handleReplyInRoom}>
         <span class="sidebar-icon iconify uil--corner-up-left"></span>
-        {m['room.message.actions.reply']()}
+        {replyInRoomActionLabel}
       </button>
     {/if}
 
     {#if onReply}
       <button class="sidebar-item min-h-11 gap-3 px-3 py-2.5 text-base" onclick={handleReply}>
         <span class="sidebar-icon iconify uil--comment-alt-lines"></span>
-        {m['room.message.actions.reply_thread']()}
+        {replyThreadActionLabel}
       </button>
     {/if}
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionSheet.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionSheet.svelte.spec.ts
@@ -76,6 +76,17 @@ describe('MessageActionSheet', () => {
     ]);
   });
 
+  it('uses custom reply action labels when provided', () => {
+    const { container } = renderSheet({
+      onReply: vi.fn(),
+      onReplyInRoom: vi.fn(),
+      replyInRoomLabel: 'Reply in thread',
+      replyThreadLabel: 'Open thread'
+    });
+
+    expect(actionLabels(container)).toEqual(['Reply in thread', 'Open thread', 'Copy link']);
+  });
+
   it('closes after invoking sheet actions', async () => {
     const onReplyInRoom = vi.fn();
     const onReply = vi.fn();

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -55,6 +55,7 @@
   import { shouldHighlightCurrentUserMention } from './messageMentionHighlight';
   import { roomReplyTargetEventId } from './messageReplyTarget';
   import { selectedQuoteTextForMessageBody } from './selectedReplyQuote';
+  import type { OpenThreadHandler } from './threadOpenOptions';
   import { createThreadAPI } from '$lib/api-client/threads';
   import { createRoomCommandAPI } from '$lib/api-client/rooms';
   import { isMessagePostedEvent } from '$lib/render/eventKinds';
@@ -75,11 +76,7 @@
     compact?: boolean;
     roomId: string;
     messageStore?: MessagesStore | null;
-    onOpenThread?: (
-      threadRootEventId: string,
-      highlightEventId?: string,
-      quoteText?: QuoteInsertionContent
-    ) => void;
+    onOpenThread?: OpenThreadHandler;
   } = $props();
 
   const connection = useConnection();
@@ -301,6 +298,24 @@
   // Uses threadRootEventId (thread membership), not inReplyTo (attribution)
   const isRootMessage = $derived(!isEcho && messageEvent?.threadRootEventId == null);
   const hasReplies = $derived(isRootMessage && (messageEvent?.replyCount ?? 0) > 0);
+  const replyInRoomActionLabel = $derived(
+    isEcho ? m['room.message.actions.reply_thread']() : m['room.message.actions.reply']()
+  );
+  const replyThreadActionLabel = $derived(
+    isEcho ? m['room.message.actions.open_thread']() : m['room.message.actions.reply_thread']()
+  );
+  const canUseReplyAction = $derived(
+    isEcho
+      ? roomPermissions.canPostInThread &&
+          !!onOpenThread &&
+          !!messageEvent?.echoFromThreadRootEventId
+      : roomPermissions.canPostMessage
+  );
+  const canUseThreadAction = $derived(
+    isEcho
+      ? !!onOpenThread && !!messageEvent?.echoFromThreadRootEventId
+      : roomPermissions.canPostInThread && !!onOpenThread
+  );
 
   // Overridable derived state: backing event data is the default, while
   // mutations/live events can update the row immediately.
@@ -524,7 +539,9 @@
       messageEvent.echoFromThreadRootEventId &&
       onOpenThread
     ) {
-      onOpenThread(messageEvent.echoFromThreadRootEventId, messageEvent.inReplyTo);
+      onOpenThread(messageEvent.echoFromThreadRootEventId, {
+        highlightEventId: messageEvent.inReplyTo
+      });
       return;
     }
 
@@ -556,6 +573,18 @@
   function handleReplyInRoom() {
     const quote = takeSelectedReplyQuote();
     const excerpt = (msg?.body ?? '').slice(0, 80);
+    if (isEcho && messageEvent?.echoOfEventId && messageEvent.echoFromThreadRootEventId) {
+      onOpenThread?.(messageEvent.echoFromThreadRootEventId, {
+        highlightEventId: messageEvent.echoOfEventId,
+        quoteText: quote ?? undefined,
+        reply: {
+          eventId: messageEvent.echoOfEventId,
+          actorDisplayName: displayName,
+          excerpt
+        }
+      });
+      return;
+    }
     replyState.startReply(roomReplyTargetEventId(event), displayName, excerpt);
     if (quote) {
       composerContext.quoteInsertionState.requestInsertQuote(quote);
@@ -564,10 +593,15 @@
 
   function handleOpenThread() {
     if (onOpenThread) {
-      const quote = takeSelectedReplyQuote();
       // For echoes, use the original thread root event ID (not the echo's wrapper event ID)
       const threadRoot = (isEcho ? messageEvent?.echoFromThreadRootEventId : null) ?? event.id;
-      onOpenThread(threadRoot, undefined, quote ?? undefined);
+      if (isEcho) {
+        selectedReplyQuoteSnapshot = null;
+        onOpenThread(threadRoot);
+        return;
+      }
+      const quote = takeSelectedReplyQuote();
+      onOpenThread(threadRoot, { quoteText: quote ?? undefined });
       // Note: Thread notifications are dismissed by ThreadPane's $effect when it mounts,
       // which also handles direct URL navigation to threads.
     }
@@ -849,8 +883,10 @@
           canReact={roomPermissions.canReact}
           {canEdit}
           forceVisible={!!emojiPickerPos || !!contextMenuPos}
-          onReplyInRoom={roomPermissions.canPostMessage ? handleReplyInRoom : undefined}
-          onReply={roomPermissions.canPostInThread && onOpenThread ? handleOpenThread : undefined}
+          replyInRoomLabel={replyInRoomActionLabel}
+          replyThreadLabel={replyThreadActionLabel}
+          onReplyInRoom={canUseReplyAction ? handleReplyInRoom : undefined}
+          onReply={canUseThreadAction ? handleOpenThread : undefined}
           onOpenEmojiPicker={roomPermissions.canReact ? openEmojiPickerFromToolbar : undefined}
           onOpenMenu={openMenuFromToolbar}
         />
@@ -905,8 +941,10 @@
         canReact={roomPermissions.canReact}
         {canEdit}
         {canDelete}
-        onReplyInRoom={roomPermissions.canPostMessage ? handleReplyInRoom : undefined}
-        onReply={roomPermissions.canPostInThread && onOpenThread ? handleOpenThread : undefined}
+        replyInRoomLabel={replyInRoomActionLabel}
+        replyThreadLabel={replyThreadActionLabel}
+        onReplyInRoom={canUseReplyAction ? handleReplyInRoom : undefined}
+        onReply={canUseThreadAction ? handleOpenThread : undefined}
         onOpenEmojiPicker={roomPermissions.canReact ? openEmojiPicker : undefined}
         onClose={() => (contextMenuPos = null)}
       />
@@ -941,8 +979,10 @@
         canReact={roomPermissions.canReact}
         {canEdit}
         {canDelete}
-        onReplyInRoom={roomPermissions.canPostMessage ? handleReplyInRoom : undefined}
-        onReply={roomPermissions.canPostInThread && onOpenThread ? handleOpenThread : undefined}
+        replyInRoomLabel={replyInRoomActionLabel}
+        replyThreadLabel={replyThreadActionLabel}
+        onReplyInRoom={canUseReplyAction ? handleReplyInRoom : undefined}
+        onReply={canUseThreadAction ? handleOpenThread : undefined}
         onOpenEmojiPicker={roomPermissions.canReact ? openEmojiPicker : undefined}
         onClose={() => (showActionSheet = false)}
       />

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.svelte
@@ -18,6 +18,8 @@ Desktop only (pointer-fine); mobile uses the long-press action sheet instead.
 - `forceVisible` - Keep toolbar visible (e.g. while emoji picker is open)
 - `onReplyInRoom` - Callback to reply in room (attribution only, no thread)
 - `onReply` - Callback to open the thread pane
+- `replyInRoomLabel` - Accessible label for the reply-in-room action
+- `replyThreadLabel` - Accessible label for the thread action
 - `onOpenEmojiPicker` - Callback to open the full emoji picker
 - `onOpenMenu` - Callback to open the full context menu
 -->
@@ -41,6 +43,8 @@ Desktop only (pointer-fine); mobile uses the long-press action sheet instead.
     canReact = false,
     canEdit = false,
     forceVisible = false,
+    replyInRoomLabel,
+    replyThreadLabel,
     onReplyInRoom,
     onReply,
     onOpenEmojiPicker,
@@ -59,6 +63,8 @@ Desktop only (pointer-fine); mobile uses the long-press action sheet instead.
     canReact?: boolean;
     canEdit?: boolean;
     forceVisible?: boolean;
+    replyInRoomLabel?: string;
+    replyThreadLabel?: string;
     onReplyInRoom?: () => void;
     onReply?: () => void;
     onOpenEmojiPicker?: (e: MouseEvent) => void;
@@ -68,6 +74,10 @@ Desktop only (pointer-fine); mobile uses the long-press action sheet instead.
   const quickReactions = $derived(getRecentEmojis(serverId).quickReactions);
 
   const actions = useMessageActions();
+  const replyInRoomActionLabel = $derived(replyInRoomLabel ?? m['room.message.actions.reply']());
+  const replyThreadActionLabel = $derived(
+    replyThreadLabel ?? m['room.message.actions.reply_thread']()
+  );
 
   const params: MessageActionParams = $derived({
     serverId,
@@ -154,7 +164,7 @@ Desktop only (pointer-fine); mobile uses the long-press action sheet instead.
         <button
           class="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-muted hover:bg-surface-100 hover:text-text"
           onclick={handleReplyInRoom}
-          aria-label={m['room.message.actions.reply']()}
+          aria-label={replyInRoomActionLabel}
         >
           <span class="iconify text-base uil--corner-up-left"></span>
         </button>
@@ -164,7 +174,7 @@ Desktop only (pointer-fine); mobile uses the long-press action sheet instead.
         <button
           class="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-muted hover:bg-surface-100 hover:text-text"
           onclick={handleReply}
-          aria-label={m['room.message.actions.reply_thread']()}
+          aria-label={replyThreadActionLabel}
         >
           <span class="iconify text-base uil--comment-alt-lines"></span>
         </button>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.svelte.spec.ts
@@ -43,6 +43,8 @@ type MessageHoverBarProps = {
   canReact?: boolean;
   canEdit?: boolean;
   forceVisible?: boolean;
+  replyInRoomLabel?: string;
+  replyThreadLabel?: string;
   onReplyInRoom?: () => void;
   onReply?: () => void;
   onOpenEmojiPicker?: (e: MouseEvent) => void;
@@ -145,5 +147,17 @@ describe('MessageHoverBar', () => {
 
     (q(container, '[aria-label="More actions"]') as HTMLButtonElement).click();
     expect(onOpenMenu).toHaveBeenCalledOnce();
+  });
+
+  it('uses custom reply action labels when provided', async () => {
+    const { container } = renderBar({
+      onReplyInRoom: vi.fn(),
+      onReply: vi.fn(),
+      replyInRoomLabel: 'Reply in thread',
+      replyThreadLabel: 'Open thread'
+    });
+
+    await expect.element(q(container, '[aria-label="Reply in thread"]')).toBeInTheDocument();
+    await expect.element(q(container, '[aria-label="Open thread"]')).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -58,6 +58,7 @@
   } from './roomSidebarBehavior';
   import { RoomSidebarPanelsState } from './roomSidebarPanels.svelte';
   import ThreadPane from './ThreadPane.svelte';
+  import type { PendingThreadReplyRequest, ThreadOpenOptions } from './threadOpenOptions';
 
   let { roomId, threadId }: { roomId: string; threadId?: string } = $props();
 
@@ -73,14 +74,17 @@
   let pendingThreadHighlight = $state<string | null>(null);
   let pendingThreadQuote = $state<{ id: number; text: QuoteInsertionContent } | null>(null);
   let pendingThreadQuoteId = 0;
+  let pendingThreadReply = $state<PendingThreadReplyRequest | null>(null);
+  let pendingThreadReplyId = 0;
 
-  function openThread(
-    threadRootEventId: string,
-    highlightEventId?: string,
-    quoteText?: QuoteInsertionContent
-  ) {
-    pendingThreadHighlight = highlightEventId ?? null;
-    pendingThreadQuote = quoteText ? { id: ++pendingThreadQuoteId, text: quoteText } : null;
+  function openThread(threadRootEventId: string, options: ThreadOpenOptions = {}) {
+    pendingThreadHighlight = options.highlightEventId ?? null;
+    pendingThreadQuote = options.quoteText
+      ? { id: ++pendingThreadQuoteId, text: options.quoteText }
+      : null;
+    pendingThreadReply = options.reply
+      ? { id: ++pendingThreadReplyId, threadRootEventId, ...options.reply }
+      : null;
     goto(
       resolve('/chat/[serverId]/[roomId]/[threadId]', {
         serverId: serverSegment,
@@ -453,7 +457,7 @@
     closeMobile = false
   ): void {
     if (threadRootEventId) {
-      openThread(threadRootEventId, messageEventId);
+      openThread(threadRootEventId, { highlightEventId: messageEventId });
     } else {
       void jumpState.jumpToMessage(messageEventId);
     }
@@ -639,11 +643,15 @@
           canEchoMessage={room.roomData.canEchoMessage && room.roomData.canPostMessage}
           highlightEventId={pendingThreadHighlight}
           pendingQuote={pendingThreadQuote}
+          pendingReply={pendingThreadReply}
           onHighlightComplete={() => {
             pendingThreadHighlight = null;
           }}
           onQuoteConsumed={() => {
             pendingThreadQuote = null;
+          }}
+          onReplyConsumed={() => {
+            pendingThreadReply = null;
           }}
         />
       {/if}
@@ -684,10 +692,7 @@
 
     {#if activeRoomSidebarPanel}
       <div
-        class={[
-          'hidden min-h-0 min-w-0 lg:flex',
-          isDesktopCallMaximized ? 'flex-1' : 'shrink-0'
-        ]}
+        class={['hidden min-h-0 min-w-0 lg:flex', isDesktopCallMaximized ? 'flex-1' : 'shrink-0']}
         data-testid="room-sidebar-desktop-pane"
       >
         <RoomSidebar

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomEvent.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import type { RoomEventView } from '$lib/render/types';
-  import type { MessagesStore, QuoteInsertionContent } from '$lib/state/room';
+  import type { MessagesStore } from '$lib/state/room';
   import { isMessagePostedEvent } from '$lib/render/eventKinds';
   import MessageEvent from './MessageEvent.svelte';
   import SystemEvent from './SystemEvent.svelte';
+  import type { OpenThreadHandler } from './threadOpenOptions';
 
   let {
     event,
@@ -16,11 +17,7 @@
     compact?: boolean;
     roomId: string;
     messageStore?: MessagesStore | null;
-    onOpenThread?: (
-      threadRootEventId: string,
-      highlightEventId?: string,
-      quoteText?: QuoteInsertionContent
-    ) => void;
+    onOpenThread?: OpenThreadHandler;
   } = $props();
 
   // Join/leave events are confusing in DM 1:1 conversations. Post-PR(b) we

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomEventsPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomEventsPane.svelte
@@ -3,12 +3,12 @@
   import { RoomEventKind, roomEventKind, type RoomEventKindSource } from '$lib/render/eventKinds';
   import {
     getComposerContext,
-    type QuoteInsertionContent,
     type RefreshCurrentWindowResult,
     type RoomMember
   } from '$lib/state/room';
   import type { MessagesStore } from '$lib/state/room';
   import EventList from './EventList.svelte';
+  import type { OpenThreadHandler } from './threadOpenOptions';
 
   type MessageRetractedEventPayload = {
     roomId?: string | null;
@@ -36,11 +36,7 @@
     messageStore: MessagesStore;
     unreadAfterTime?: string | null;
     unreadBeforeTime?: string | null;
-    onOpenThread?: (
-      threadRootEventId: string,
-      highlightEventId?: string,
-      quoteText?: QuoteInsertionContent
-    ) => void;
+    onOpenThread?: OpenThreadHandler;
     typingUserIds?: string[];
     typingMembers?: RoomMember[];
   } = $props();

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -27,6 +27,7 @@
   } from '$lib/components/composer/MessageComposer.svelte';
   import EventList from './EventList.svelte';
   import { onThreadFollowChanged } from '$lib/eventBus.svelte';
+  import type { PendingThreadReplyRequest } from './threadOpenOptions';
 
   let {
     roomId,
@@ -38,8 +39,10 @@
     canEchoMessage = false,
     highlightEventId = null,
     pendingQuote = null,
+    pendingReply = null,
     onHighlightComplete,
-    onQuoteConsumed
+    onQuoteConsumed,
+    onReplyConsumed
   }: {
     roomId: string;
     roomName: string;
@@ -50,8 +53,10 @@
     canEchoMessage?: boolean;
     highlightEventId?: string | null;
     pendingQuote?: QuoteInsertionRequest | null;
+    pendingReply?: PendingThreadReplyRequest | null;
     onHighlightComplete?: () => void;
     onQuoteConsumed?: () => void;
+    onReplyConsumed?: () => void;
   } = $props();
 
   const connection = useConnection();
@@ -112,6 +117,7 @@
   const composerContext = createComposerContext({ scroll: true });
   const replyState = composerContext.replyState;
   let consumedQuoteId = 0;
+  let consumedReplyId = 0;
   let composerApi = $state<MessageComposerApi | null>(null);
 
   // Thread-scoped jump state so "in reply to" clicks scroll within the thread.
@@ -142,6 +148,24 @@
     consumedQuoteId = quote.id;
     composerContext.quoteInsertionState.requestInsertQuote(quote.text);
     onQuoteConsumed?.();
+  });
+
+  $effect(() => {
+    const reply = pendingReply;
+    const api = composerApi;
+    if (
+      !reply ||
+      reply.threadRootEventId !== threadRootEventId ||
+      !api ||
+      reply.id === consumedReplyId
+    ) {
+      return;
+    }
+
+    consumedReplyId = reply.id;
+    replyState.startReply(reply.eventId, reply.actorDisplayName, reply.excerpt);
+    api.focus();
+    onReplyConsumed?.();
   });
 
   // Subscribe to server events: clear typing indicator on a thread reply,

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/threadOpenOptions.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/threadOpenOptions.ts
@@ -1,0 +1,20 @@
+import type { QuoteInsertionContent } from '$lib/state/room';
+
+export type PendingThreadReply = {
+  eventId: string;
+  actorDisplayName: string;
+  excerpt: string;
+};
+
+export type PendingThreadReplyRequest = PendingThreadReply & {
+  id: number;
+  threadRootEventId: string;
+};
+
+export type ThreadOpenOptions = {
+  highlightEventId?: string;
+  quoteText?: QuoteInsertionContent;
+  reply?: PendingThreadReply;
+};
+
+export type OpenThreadHandler = (threadRootEventId: string, options?: ThreadOpenOptions) => void;


### PR DESCRIPTION
Echo message actions now distinguish replying in the original thread from simply opening it, preventing replies from disappearing into a thread without clear composer context.
The root cause was that echo rows reused the room reply affordance even though the backend correctly posted replies to the echoed thread message.
This PR adds thread-scoped pending reply options, keeps echo Open thread navigation-only, preserves read-only thread navigation, and updates English/German copy plus action tests.
Validation: frontend check, focused Vitest action specs, and the thread-reply-echo Playwright suite all pass.
