### PR TITLE
fix(media): preserve video aspect ratios

### DIFF
--- a/apps/frontend/e2e/video-player.test.ts
+++ b/apps/frontend/e2e/video-player.test.ts
@@ -61,6 +61,10 @@ test.describe('video player @ffmpeg', () => {
         // Verify Vidstack rendered its default video layout with controls.
         await expect(roomPage.mediaControls).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
 
+        const mediaBox = await roomPage.mediaPlayer.boundingBox();
+        expect(mediaBox).not.toBeNull();
+        expect(mediaBox!.width / mediaBox!.height).toBeCloseTo(16 / 9, 1);
+
         // The settings menu should be hidden (via CSS).
         if ((await roomPage.videoSettingsMenu.count()) > 0) {
           const computedDisplay = await roomPage.videoSettingsMenu.evaluate(

--- a/apps/frontend/src/lib/components/chat/VideoPlayer.svelte
+++ b/apps/frontend/src/lib/components/chat/VideoPlayer.svelte
@@ -54,10 +54,54 @@
 
   const MAX_WIDTH = 480;
   const MAX_HEIGHT = 320;
+  const WIDESCREEN_RATIO = 16 / 9;
+  const NEAR_SQUARE_LANDSCAPE_MAX_RATIO = 1.5;
+
+  // Existing processed videos can carry stale encoded dimensions. Once the
+  // browser loads the media, prefer its intrinsic display size for the frame.
+  let measuredMedia = $state<{ src: string; width: number; height: number } | null>(null);
+
+  // Pick the best variant (highest quality available)
+  const selectedVariant = $derived(
+    variants.length > 0
+      ? variants.reduce((best, v) => (v.height > best.height ? v : best), variants[0])
+      : null
+  );
+
+  const sourceDimensions = $derived.by(() => {
+    if (measuredMedia && measuredMedia.src === selectedVariant?.url) {
+      return measuredMedia;
+    }
+    return {
+      width: positiveDimension(width) ?? positiveDimension(selectedVariant?.width) ?? 480,
+      height: positiveDimension(height) ?? positiveDimension(selectedVariant?.height) ?? 270
+    };
+  });
+
+  const frameDimensions = $derived.by(() => {
+    const w = sourceDimensions.width;
+    const h = sourceDimensions.height;
+    const ratio = w / h;
+
+    if (
+      status === 'COMPLETED' &&
+      selectedVariant &&
+      !autoLoop &&
+      ratio >= 1 &&
+      ratio < NEAR_SQUARE_LANDSCAPE_MAX_RATIO
+    ) {
+      return {
+        width: Math.round(h * WIDESCREEN_RATIO),
+        height: h
+      };
+    }
+
+    return { width: w, height: h };
+  });
 
   const displaySize = $derived.by(() => {
-    const w = width || 480;
-    const h = height || 270;
+    const w = frameDimensions.width;
+    const h = frameDimensions.height;
     const scale = Math.min(MAX_WIDTH / w, MAX_HEIGHT / h, 1);
     return {
       width: Math.round(w * scale),
@@ -65,11 +109,16 @@
     };
   });
 
-  // Pick the best variant (highest quality available)
-  const selectedVariant = $derived(
-    variants.length > 0
-      ? variants.reduce((best, v) => (v.height > best.height ? v : best), variants[0])
-      : null
+  const fitMode = $derived.by(() => {
+    if (status !== 'COMPLETED' || !selectedVariant || autoLoop) return 'contain';
+    return frameDimensions.width / frameDimensions.height >
+      sourceDimensions.width / sourceDimensions.height
+      ? 'cover'
+      : 'contain';
+  });
+
+  const frameStyle = $derived(
+    `width: ${displaySize.width}px; max-width: 100%; aspect-ratio: ${displaySize.width} / ${displaySize.height};`
   );
 
   // Vidstack auto-detects media type from URL extensions, but our attachment
@@ -89,6 +138,57 @@
         return null;
     }
   });
+
+  function positiveDimension(value: number | null | undefined): number | null {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : null;
+  }
+
+  function syncVideoDimensions(video: HTMLVideoElement) {
+    if (!selectedVariant) return;
+    const videoWidth = positiveDimension(video.videoWidth);
+    const videoHeight = positiveDimension(video.videoHeight);
+    if (!videoWidth || !videoHeight) return;
+    measuredMedia = {
+      src: selectedVariant.url,
+      width: videoWidth,
+      height: videoHeight
+    };
+  }
+
+  function handleVideoMetadata(event: Event) {
+    if (event.currentTarget instanceof HTMLVideoElement) {
+      syncVideoDimensions(event.currentTarget);
+    }
+  }
+
+  function observePlayerVideo(node: HTMLElement) {
+    let video: HTMLVideoElement | null = null;
+    let removeVideoListener: (() => void) | null = null;
+
+    function bindVideo() {
+      const nextVideo = node.querySelector('video');
+      if (nextVideo === video) return;
+
+      removeVideoListener?.();
+      video = nextVideo;
+      removeVideoListener = null;
+
+      if (!video) return;
+      const handleMetadata = () => syncVideoDimensions(video!);
+      video.addEventListener('loadedmetadata', handleMetadata);
+      removeVideoListener = () => video?.removeEventListener('loadedmetadata', handleMetadata);
+      syncVideoDimensions(video);
+    }
+
+    bindVideo();
+    const observer = new MutationObserver(bindVideo);
+    observer.observe(node, { childList: true, subtree: true });
+
+    return () => {
+      observer.disconnect();
+      removeVideoListener?.();
+    };
+  }
 
   // Intercept Vidstack's fullscreen request — the <media-player> lives inside
   // virtua's virtualized list, so native fullscreen would cause virtua to
@@ -119,11 +219,21 @@
       node.removeEventListener('media-enter-fullscreen-request', handleFullscreenRequest, true);
     };
   }
+
+  function attachMediaPlayer(node: HTMLElement) {
+    const cleanupFullscreen = interceptFullscreenRequest(node);
+    const cleanupVideoObserver = observePlayerVideo(node);
+
+    return () => {
+      cleanupFullscreen();
+      cleanupVideoObserver();
+    };
+  }
 </script>
 
 {#if status === 'COMPLETED' && selectedVariant && autoLoop}
   <!-- Converted GIFs use a native <video> for reliable autoplay + loop behavior. -->
-  <div class="embed-frame" style="width: {displaySize.width}px; max-width: 100%;">
+  <div class="embed-frame" style={frameStyle}>
     <video
       autoplay
       loop
@@ -131,19 +241,21 @@
       playsinline
       data-autoloop
       onerror={onMediaError}
-      style="aspect-ratio: {displaySize.width} / {displaySize.height}; width: 100%;"
+      onloadedmetadata={handleVideoMetadata}
+      class="block h-full w-full object-contain"
     >
       <source src={selectedVariant.url} type="video/mp4" onerror={onMediaError} />
     </video>
   </div>
 {:else if status === 'COMPLETED' && selectedVariant && elementsReady}
-  <div class="embed-frame" style="width: {displaySize.width}px; max-width: 100%;">
+  <div class="embed-frame" style={frameStyle}>
     <media-player
-      {@attach interceptFullscreenRequest}
+      {@attach attachMediaPlayer}
       src={videoSrc}
       playsinline
       onerror={onMediaError}
-      style="aspect-ratio: {displaySize.width} / {displaySize.height};"
+      data-fit={fitMode}
+      class="block h-full w-full"
     >
       <media-provider>
         {#if thumbnailUrl}
@@ -155,20 +267,14 @@
     </media-player>
   </div>
 {:else if status === 'PENDING' || status === 'PROCESSING'}
-  <div
-    class="embed-frame flex items-center gap-3 px-4 py-3"
-    style="width: {displaySize.width}px; max-width: 100%;"
-  >
+  <div class="embed-frame flex items-center gap-3 px-4 py-3" style={frameStyle}>
     <div class="h-5 w-5 animate-spin rounded-full border-2 border-muted border-t-transparent"></div>
     <div class="text-sm text-muted">
       {status === 'PENDING' ? m['media.video_queued']() : m['media.video_processing']()}
     </div>
   </div>
 {:else if status === 'FAILED'}
-  <div
-    class="embed-frame flex items-center gap-3 px-4 py-3"
-    style="width: {displaySize.width}px; max-width: 100%;"
-  >
+  <div class="embed-frame flex items-center gap-3 px-4 py-3" style={frameStyle}>
     <span class="iconify text-lg text-red-400 uil--exclamation-triangle"></span>
     <div class="text-sm text-muted">
       {m['media.video_processing_failed']()}
@@ -189,5 +295,21 @@
   :global(media-player .vds-settings-menu),
   :global(media-player .vds-chapters-menu) {
     display: none !important;
+  }
+
+  :global(media-player[data-fit='cover'] media-provider),
+  :global(media-player[data-fit='cover'] [data-media-provider]),
+  :global(media-player[data-fit='cover'] video),
+  :global(media-player[data-fit='cover'] .vds-poster),
+  :global(media-player[data-fit='cover'] .vds-poster img) {
+    height: 100%;
+    width: 100%;
+  }
+
+  :global(media-player[data-fit='cover'] video),
+  :global(media-player[data-fit='cover'] .vds-poster),
+  :global(media-player[data-fit='cover'] .vds-poster img) {
+    object-fit: cover;
+    object-position: top center;
   }
 </style>

--- a/apps/frontend/src/lib/components/chat/VideoPlayer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/chat/VideoPlayer.svelte.spec.ts
@@ -1,0 +1,122 @@
+import { tick } from 'svelte';
+import { describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import VideoPlayer from './VideoPlayer.svelte';
+
+const TRANSPARENT_THUMBNAIL =
+  'data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=';
+
+function renderAutoLoopVideo({ width, height }: { width: number; height: number }) {
+  return render(VideoPlayer, {
+    props: {
+      status: 'COMPLETED',
+      filename: 'clip.mp4',
+      autoLoop: true,
+      variants: [
+        {
+          url: 'https://chat.example.test/clip.mp4',
+          quality: `${height}p`,
+          width,
+          height,
+          size: 1024
+        }
+      ]
+    }
+  });
+}
+
+function renderPostedVideo({
+  width,
+  height,
+  thumbnailUrl = null
+}: {
+  width: number;
+  height: number;
+  thumbnailUrl?: string | null;
+}) {
+  return render(VideoPlayer, {
+    props: {
+      status: 'COMPLETED',
+      filename: 'clip.mp4',
+      width,
+      height,
+      thumbnailUrl,
+      variants: [
+        {
+          url: 'https://chat.example.test/clip.mp4',
+          quality: `${height}p`,
+          width,
+          height,
+          size: 1024
+        }
+      ]
+    }
+  });
+}
+
+function frame(container: HTMLElement): HTMLElement {
+  const element = container.querySelector<HTMLElement>('.embed-frame');
+  expect(element).not.toBeNull();
+  return element!;
+}
+
+function video(container: HTMLElement): HTMLVideoElement {
+  const element = container.querySelector<HTMLVideoElement>('video[data-autoloop]');
+  expect(element).not.toBeNull();
+  return element!;
+}
+
+async function mediaPlayer(container: HTMLElement): Promise<HTMLElement> {
+  await expect.poll(() => container.querySelector('media-player')).toBeTruthy();
+  return container.querySelector<HTMLElement>('media-player')!;
+}
+
+async function posterImage(container: HTMLElement): Promise<HTMLImageElement> {
+  await expect.poll(() => container.querySelector('.vds-poster img')).toBeTruthy();
+  return container.querySelector<HTMLImageElement>('.vds-poster img')!;
+}
+
+describe('VideoPlayer', () => {
+  it('frames 16:9 videos as 16:9 embeds', () => {
+    const { container } = renderAutoLoopVideo({ width: 1600, height: 900 });
+
+    expect(frame(container).getAttribute('style')).toContain('aspect-ratio: 480 / 270');
+    expect(video(container).className).toContain('h-full');
+    expect(video(container).className).toContain('w-full');
+  });
+
+  it('preserves 4:3 autoloop videos instead of forcing 16:9', () => {
+    const { container } = renderAutoLoopVideo({ width: 640, height: 480 });
+
+    expect(frame(container).getAttribute('style')).toContain('aspect-ratio: 427 / 320');
+  });
+
+  it('presents near-square posted landscape videos in a 16:9 frame', async () => {
+    const { container } = renderPostedVideo({
+      width: 1024,
+      height: 768,
+      thumbnailUrl: TRANSPARENT_THUMBNAIL
+    });
+
+    const player = await mediaPlayer(container);
+    const poster = await posterImage(container);
+
+    expect(frame(container).getAttribute('style')).toContain('aspect-ratio: 480 / 270');
+    expect(player.dataset.fit).toBe('cover');
+    expect(getComputedStyle(poster).objectFit).toBe('cover');
+  });
+
+  it('corrects stale metadata after the browser loads intrinsic video dimensions', async () => {
+    const { container } = renderAutoLoopVideo({ width: 1024, height: 768 });
+    const media = video(container);
+
+    expect(frame(container).getAttribute('style')).toContain('aspect-ratio: 427 / 320');
+
+    Object.defineProperty(media, 'videoWidth', { configurable: true, value: 1920 });
+    Object.defineProperty(media, 'videoHeight', { configurable: true, value: 1080 });
+    media.dispatchEvent(new Event('loadedmetadata'));
+    await tick();
+
+    expect(frame(container).getAttribute('style')).toContain('aspect-ratio: 480 / 270');
+  });
+});

--- a/apps/frontend/src/lib/components/chat/VideoPlayer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/chat/VideoPlayer.svelte.spec.ts
@@ -1,6 +1,7 @@
 import { tick } from 'svelte';
 import { describe, expect, it } from 'vitest';
 import { render } from 'vitest-browser-svelte';
+import { VideoProcessingStatus } from '$lib/render/types';
 import VideoPlayer from './VideoPlayer.svelte';
 
 const TRANSPARENT_THUMBNAIL =
@@ -9,7 +10,7 @@ const TRANSPARENT_THUMBNAIL =
 function renderAutoLoopVideo({ width, height }: { width: number; height: number }) {
   return render(VideoPlayer, {
     props: {
-      status: 'COMPLETED',
+      status: VideoProcessingStatus.Completed,
       filename: 'clip.mp4',
       autoLoop: true,
       variants: [
@@ -36,7 +37,7 @@ function renderPostedVideo({
 }) {
   return render(VideoPlayer, {
     props: {
-      status: 'COMPLETED',
+      status: VideoProcessingStatus.Completed,
       filename: 'clip.mp4',
       width,
       height,

--- a/cli/internal/core/attachments.go
+++ b/cli/internal/core/attachments.go
@@ -182,9 +182,30 @@ func (c *MediaModel) UploadDerivativeAttachment(
 	contentType string,
 	reader io.Reader,
 ) (*corev1.Attachment, error) {
+	return c.UploadDerivativeAttachmentWithDimensions(ctx, parentAssetID, derivativeRole, roomID, filename, contentType, reader, 0, 0)
+}
+
+// UploadDerivativeAttachmentWithDimensions is UploadDerivativeAttachment with
+// explicit media dimensions supplied by the worker for generated non-image
+// derivatives such as transcoded video variants.
+func (c *MediaModel) UploadDerivativeAttachmentWithDimensions(
+	ctx context.Context,
+	parentAssetID string,
+	derivativeRole corev1.AssetDerivativeRole,
+	roomID string,
+	filename string,
+	contentType string,
+	reader io.Reader,
+	width int32,
+	height int32,
+) (*corev1.Attachment, error) {
 	attachment, err := c.uploadAttachmentBinary(ctx, roomID, filename, contentType, reader)
 	if err != nil {
 		return nil, err
+	}
+	if width > 0 && height > 0 {
+		attachment.Width = width
+		attachment.Height = height
 	}
 	if err := c.assetLifecycle().RecordDerivativeAsset(ctx, parentAssetID, derivativeRole, roomID, attachment); err != nil {
 		return nil, err

--- a/cli/internal/core/attachments_facade.go
+++ b/cli/internal/core/attachments_facade.go
@@ -47,6 +47,20 @@ func (c *ChattoCore) UploadDerivativeAttachment(
 	return c.media().UploadDerivativeAttachment(ctx, parentAssetID, derivativeRole, roomID, filename, contentType, reader)
 }
 
+func (c *ChattoCore) UploadDerivativeAttachmentWithDimensions(
+	ctx context.Context,
+	parentAssetID string,
+	derivativeRole corev1.AssetDerivativeRole,
+	roomID string,
+	filename string,
+	contentType string,
+	reader io.Reader,
+	width int32,
+	height int32,
+) (*corev1.Attachment, error) {
+	return c.media().UploadDerivativeAttachmentWithDimensions(ctx, parentAssetID, derivativeRole, roomID, filename, contentType, reader, width, height)
+}
+
 func (c *ChattoCore) GetAttachment(ctx context.Context, attachmentID string) (io.Reader, *jetstream.ObjectInfo, error) {
 	return c.media().GetAttachment(ctx, attachmentID)
 }

--- a/cli/internal/core/media_model_test.go
+++ b/cli/internal/core/media_model_test.go
@@ -145,6 +145,39 @@ func TestMediaModelUploadDerivativeAttachmentProjectsParentage(t *testing.T) {
 	}
 }
 
+func TestMediaModelUploadDerivativeAttachmentWithDimensionsProjectsAssetDimensions(t *testing.T) {
+	core, _ := setupTestCore(t)
+	service := core.mediaModel
+	ctx := testContext(t)
+
+	room, err := core.CreateRoom(ctx, SystemActorID, KindChannel, "", "media-derivative-dimensions", "Media derivative dimensions")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	derivative, err := service.UploadDerivativeAttachmentWithDimensions(
+		ctx,
+		"A-parent",
+		corev1.AssetDerivativeRole_ASSET_DERIVATIVE_ROLE_VIDEO_VARIANT,
+		room.Id,
+		"clip-720p.mp4",
+		"video/mp4",
+		bytes.NewReader([]byte("video bytes")),
+		1280,
+		720,
+	)
+	if err != nil {
+		t.Fatalf("UploadDerivativeAttachmentWithDimensions returned error: %v", err)
+	}
+
+	declared, ok := core.Assets.AssetCreation(derivative.GetId())
+	if !ok {
+		t.Fatal("derivative asset creation was not projected")
+	}
+	if declared.GetAsset().GetWidth() != 1280 || declared.GetAsset().GetHeight() != 720 {
+		t.Fatalf("projected dimensions = %dx%d, want 1280x720", declared.GetAsset().GetWidth(), declared.GetAsset().GetHeight())
+	}
+}
+
 func TestMediaModelCacheOperations(t *testing.T) {
 	core, _ := setupTestCoreWithCache(t)
 	service := core.mediaModel

--- a/cli/internal/video/processor.go
+++ b/cli/internal/video/processor.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -34,11 +36,19 @@ type ffprobeOutput struct {
 }
 
 type ffprobeStream struct {
-	CodecType string `json:"codec_type"`
-	CodecName string `json:"codec_name"`
-	Width     int32  `json:"width"`
-	Height    int32  `json:"height"`
-	Duration  string `json:"duration"`
+	CodecType          string            `json:"codec_type"`
+	CodecName          string            `json:"codec_name"`
+	Width              int32             `json:"width"`
+	Height             int32             `json:"height"`
+	Duration           string            `json:"duration"`
+	DisplayAspectRatio string            `json:"display_aspect_ratio"`
+	SampleAspectRatio  string            `json:"sample_aspect_ratio"`
+	Tags               map[string]string `json:"tags"`
+	SideDataList       []ffprobeSideData `json:"side_data_list"`
+}
+
+type ffprobeSideData struct {
+	Rotation json.RawMessage `json:"rotation"`
 }
 
 type ffprobeFormat struct {
@@ -88,8 +98,7 @@ func (s *Service) probe(ctx context.Context, inputPath string, contentType strin
 	for _, stream := range probe.Streams {
 		switch stream.CodecType {
 		case "video":
-			result.Width = stream.Width
-			result.Height = stream.Height
+			result.Width, result.Height = videoDisplayDimensions(stream)
 			result.VideoCodec = stream.CodecName
 			codecParts = append(codecParts, strings.ToUpper(stream.CodecName))
 			// Use stream-level duration as fallback (e.g., when -show_format is
@@ -111,10 +120,102 @@ func (s *Service) probe(ctx context.Context, inputPath string, contentType strin
 	return result, nil
 }
 
+func videoDisplayDimensions(stream ffprobeStream) (int32, int32) {
+	width := stream.Width
+	height := stream.Height
+	if width <= 0 || height <= 0 {
+		return width, height
+	}
+
+	displayRatio := float64(width) / float64(height)
+	if ratio, ok := parseAspectRatio(stream.DisplayAspectRatio); ok {
+		displayRatio = ratio
+	} else if ratio, ok := parseAspectRatio(stream.SampleAspectRatio); ok {
+		displayRatio *= ratio
+	}
+
+	if displayRatio > 0 {
+		rawRatio := float64(width) / float64(height)
+		if displayRatio >= rawRatio {
+			width = int32(math.Round(float64(height) * displayRatio))
+		} else {
+			height = int32(math.Round(float64(width) / displayRatio))
+		}
+	}
+
+	if videoRotatedByQuarterTurn(stream) {
+		width, height = height, width
+	}
+
+	return width, height
+}
+
+func parseAspectRatio(value string) (float64, bool) {
+	parts := strings.Split(strings.TrimSpace(value), ":")
+	if len(parts) != 2 {
+		return 0, false
+	}
+	numerator, err := strconv.ParseFloat(parts[0], 64)
+	if err != nil || numerator <= 0 {
+		return 0, false
+	}
+	denominator, err := strconv.ParseFloat(parts[1], 64)
+	if err != nil || denominator <= 0 {
+		return 0, false
+	}
+	return numerator / denominator, true
+}
+
+func videoRotatedByQuarterTurn(stream ffprobeStream) bool {
+	if stream.Tags != nil {
+		if rotation, ok := parseRotation(stream.Tags["rotate"]); ok {
+			return rotation%180 != 0
+		}
+	}
+	for _, data := range stream.SideDataList {
+		if rotation, ok := parseRotationRaw(data.Rotation); ok && rotation%180 != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func parseRotation(value string) (int, bool) {
+	rotation, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil {
+		return 0, false
+	}
+	return normalizeRotation(rotation), true
+}
+
+func parseRotationRaw(value json.RawMessage) (int, bool) {
+	raw := strings.TrimSpace(string(value))
+	if raw == "" || raw == "null" {
+		return 0, false
+	}
+	var rotation int
+	if err := json.Unmarshal(value, &rotation); err == nil {
+		return normalizeRotation(rotation), true
+	}
+	var text string
+	if err := json.Unmarshal(value, &text); err == nil {
+		return parseRotation(text)
+	}
+	return 0, false
+}
+
+func normalizeRotation(rotation int) int {
+	rotation %= 360
+	if rotation < 0 {
+		rotation += 360
+	}
+	return rotation
+}
+
 // generateThumbnail captures a frame from the video as a JPEG thumbnail.
 // Captures at 1 second or 10% into the video, whichever is earlier.
 // inputOpts are placed before -i (e.g., "-ignore_loop 1" for GIF input).
-func (s *Service) generateThumbnail(ctx context.Context, inputPath, outputPath string, durationMs int64, inputOpts []string) error {
+func (s *Service) generateThumbnail(ctx context.Context, inputPath, outputPath string, durationMs int64, inputOpts []string, displayWidth, displayHeight int32) error {
 	// Seek to 1 second or 10% of duration, whichever is earlier
 	seekMs := int64(1000)
 	if tenPercent := durationMs / 10; tenPercent < seekMs && tenPercent > 0 {
@@ -127,7 +228,7 @@ func (s *Service) generateThumbnail(ctx context.Context, inputPath, outputPath s
 		"-ss", seekTime,
 		"-i", inputPath,
 		"-vframes", "1",
-		"-vf", "scale='min(640,iw)':-2",
+		"-vf", thumbnailScaleFilter(displayWidth, displayHeight),
 		"-q:v", "3",
 		"-y",
 		outputPath,
@@ -139,6 +240,23 @@ func (s *Service) generateThumbnail(ctx context.Context, inputPath, outputPath s
 	}
 
 	return nil
+}
+
+func thumbnailScaleFilter(displayWidth, displayHeight int32) string {
+	width, height, ok := thumbnailDimensions(displayWidth, displayHeight)
+	if !ok {
+		return "scale='min(640,iw)':-2"
+	}
+	return fmt.Sprintf("scale=%d:%d,setsar=1", width, height)
+}
+
+func thumbnailDimensions(displayWidth, displayHeight int32) (int32, int32, bool) {
+	if displayWidth <= 0 || displayHeight <= 0 {
+		return 0, 0, false
+	}
+	const maxWidth = 640
+	scale := math.Min(float64(maxWidth)/float64(displayWidth), 1)
+	return int32(math.Round(float64(displayWidth) * scale)), int32(math.Round(float64(displayHeight) * scale)), true
 }
 
 // transcode converts a video to H.264 MP4 at the specified height.
@@ -246,7 +364,7 @@ func (s *Service) processVideo(ctx context.Context, req processRequest) error {
 
 	// Generate thumbnail
 	thumbPath := filepath.Join(tmpDir, "thumb.jpg")
-	if err := s.generateThumbnail(ctx, inputPath, thumbPath, probeResult.DurationMs, inputOpts); err != nil {
+	if err := s.generateThumbnail(ctx, inputPath, thumbPath, probeResult.DurationMs, inputOpts, probeResult.Width, probeResult.Height); err != nil {
 		s.logger.Warn("Thumbnail generation failed, continuing without thumbnail", "error", err)
 		thumbPath = "" // Non-fatal
 	}
@@ -289,27 +407,26 @@ func (s *Service) processVideo(ctx context.Context, req processRequest) error {
 			continue
 		}
 
+		variantProbe, err := s.probe(ctx, outputPath, "video/mp4")
+		if err != nil {
+			s.logger.Error("Failed to probe transcoded variant", "height", h, "error", err)
+			continue
+		}
+
 		// Upload variant as attachment
 		quality := fmt.Sprintf("%dp", h)
 		filename := fmt.Sprintf("%s_%s.mp4", strings.TrimSuffix(req.AssetID, filepath.Ext(req.AssetID)), quality)
-		variant, err := s.uploadDerivativeFile(ctx, req.AssetID, corev1.AssetDerivativeRole_ASSET_DERIVATIVE_ROLE_VIDEO_VARIANT, req.RoomID, filename, "video/mp4", outputPath)
+		variant, err := s.uploadDerivativeFileWithDimensions(ctx, req.AssetID, corev1.AssetDerivativeRole_ASSET_DERIVATIVE_ROLE_VIDEO_VARIANT, req.RoomID, filename, "video/mp4", outputPath, variantProbe.Width, variantProbe.Height)
 		if err != nil {
 			s.logger.Error("Failed to upload variant", "height", h, "error", err)
 			continue
 		}
 
-		// Calculate output width, rounding up to the nearest even number to match
-		// ffmpeg's scale=-2:HEIGHT behavior (which always outputs even dimensions).
-		variantWidth := probeResult.Width * int32(h) / probeResult.Height
-		if variantWidth%2 != 0 {
-			variantWidth++
-		}
-
 		variants = append(variants, &corev1.VideoVariant{
 			AttachmentId: variant.Id,
 			Quality:      quality,
-			Width:        variantWidth,
-			Height:       int32(h),
+			Width:        variantProbe.Width,
+			Height:       variantProbe.Height,
 			Size:         info.Size(),
 			Attachment:   variant,
 		})
@@ -385,11 +502,15 @@ func (s *Service) downloadAttachment(ctx context.Context, attachment *corev1.Att
 // AssetCreatedEvent emitted carries the parent + role so the projection
 // links the derivative to its origin immediately.
 func (s *Service) uploadDerivativeFile(ctx context.Context, parentAssetID string, derivativeRole corev1.AssetDerivativeRole, roomID, filename, contentType, srcPath string) (*corev1.Attachment, error) {
+	return s.uploadDerivativeFileWithDimensions(ctx, parentAssetID, derivativeRole, roomID, filename, contentType, srcPath, 0, 0)
+}
+
+func (s *Service) uploadDerivativeFileWithDimensions(ctx context.Context, parentAssetID string, derivativeRole corev1.AssetDerivativeRole, roomID, filename, contentType, srcPath string, width, height int32) (*corev1.Attachment, error) {
 	f, err := os.Open(srcPath)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
 
-	return s.core.UploadDerivativeAttachment(ctx, parentAssetID, derivativeRole, roomID, filename, contentType, f)
+	return s.core.UploadDerivativeAttachmentWithDimensions(ctx, parentAssetID, derivativeRole, roomID, filename, contentType, f, width, height)
 }

--- a/cli/internal/video/processor_test.go
+++ b/cli/internal/video/processor_test.go
@@ -73,62 +73,124 @@ func TestSelectVariantHeights(t *testing.T) {
 	}
 }
 
-func TestVariantWidthCalculation(t *testing.T) {
-	// Verifies that the width calculation rounds up to the nearest even number,
-	// matching ffmpeg's scale=-2:HEIGHT behavior.
+func TestVideoDisplayDimensions(t *testing.T) {
 	tests := []struct {
-		name         string
-		sourceWidth  int32
-		sourceHeight int32
-		targetHeight int
-		wantWidth    int32
+		name       string
+		stream     ffprobeStream
+		wantWidth  int32
+		wantHeight int32
 	}{
 		{
-			name:         "1920x1080 to 480p: should be 854 (even), not 853",
-			sourceWidth:  1920,
-			sourceHeight: 1080,
-			targetHeight: 480,
-			wantWidth:    854, // 1920*480/1080 = 853.33 → rounded up to even: 854
+			name: "plain 16:9 stays unchanged",
+			stream: ffprobeStream{
+				Width:  1920,
+				Height: 1080,
+			},
+			wantWidth:  1920,
+			wantHeight: 1080,
 		},
 		{
-			name:         "1280x720 to 480p: should be 854 (even)",
-			sourceWidth:  1280,
-			sourceHeight: 720,
-			targetHeight: 480,
-			wantWidth:    854, // 1280*480/720 = 853.33 → rounded up to even: 854
+			name: "display aspect ratio expands anamorphic storage pixels",
+			stream: ffprobeStream{
+				Width:              1440,
+				Height:             1080,
+				DisplayAspectRatio: "16:9",
+			},
+			wantWidth:  1920,
+			wantHeight: 1080,
 		},
 		{
-			name:         "1920x1080 to 720p: stays 1280 (already even)",
-			sourceWidth:  1920,
-			sourceHeight: 1080,
-			targetHeight: 720,
-			wantWidth:    1280, // 1920*720/1080 = 1280 exactly
+			name: "sample aspect ratio expands anamorphic storage pixels",
+			stream: ffprobeStream{
+				Width:             1440,
+				Height:            1080,
+				SampleAspectRatio: "4:3",
+			},
+			wantWidth:  1920,
+			wantHeight: 1080,
 		},
 		{
-			name:         "odd calculated width rounds up to even",
-			sourceWidth:  853,
-			sourceHeight: 480,
-			targetHeight: 480,
-			wantWidth:    854, // 853*480/480 = 853 (odd) → 854
+			name: "quarter-turn rotation swaps display dimensions",
+			stream: ffprobeStream{
+				Width:  1920,
+				Height: 1080,
+				Tags:   map[string]string{"rotate": "90"},
+			},
+			wantWidth:  1080,
+			wantHeight: 1920,
 		},
 		{
-			name:         "even calculated width stays as-is",
-			sourceWidth:  1280,
-			sourceHeight: 720,
-			targetHeight: 720,
-			wantWidth:    1280, // exact match
+			name: "invalid aspect ratio falls back to storage dimensions",
+			stream: ffprobeStream{
+				Width:              1280,
+				Height:             720,
+				DisplayAspectRatio: "0:0",
+				SampleAspectRatio:  "not-a-ratio",
+			},
+			wantWidth:  1280,
+			wantHeight: 720,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			w := tt.sourceWidth * int32(tt.targetHeight) / tt.sourceHeight
-			if w%2 != 0 {
-				w++
+			gotWidth, gotHeight := videoDisplayDimensions(tt.stream)
+			if gotWidth != tt.wantWidth || gotHeight != tt.wantHeight {
+				t.Fatalf("videoDisplayDimensions() = %dx%d, want %dx%d", gotWidth, gotHeight, tt.wantWidth, tt.wantHeight)
 			}
-			if w != tt.wantWidth {
-				t.Errorf("width calculation for %dx%d→%dp = %d, want %d",
-					tt.sourceWidth, tt.sourceHeight, tt.targetHeight, w, tt.wantWidth)
+		})
+	}
+}
+
+func TestThumbnailDimensions(t *testing.T) {
+	tests := []struct {
+		name       string
+		width      int32
+		height     int32
+		wantWidth  int32
+		wantHeight int32
+		wantOK     bool
+	}{
+		{
+			name:       "16:9 display dimensions scale to square-pixel thumbnail",
+			width:      1920,
+			height:     1080,
+			wantWidth:  640,
+			wantHeight: 360,
+			wantOK:     true,
+		},
+		{
+			name:       "4:3 display dimensions stay 4:3",
+			width:      1024,
+			height:     768,
+			wantWidth:  640,
+			wantHeight: 480,
+			wantOK:     true,
+		},
+		{
+			name:       "small display dimensions are not upscaled",
+			width:      320,
+			height:     180,
+			wantWidth:  320,
+			wantHeight: 180,
+			wantOK:     true,
+		},
+		{
+			name:   "invalid display dimensions fall back to legacy filter",
+			width:  0,
+			height: 1080,
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotWidth, gotHeight, gotOK := thumbnailDimensions(tt.width, tt.height)
+			if gotOK != tt.wantOK {
+				t.Fatalf("thumbnailDimensions() ok = %v, want %v", gotOK, tt.wantOK)
+			}
+			if gotOK && (gotWidth != tt.wantWidth || gotHeight != tt.wantHeight) {
+				t.Fatalf("thumbnailDimensions() = %dx%d, want %dx%d", gotWidth, gotHeight, tt.wantWidth, tt.wantHeight)
 			}
 		})
 	}

--- a/docs/fdr/FDR-008-file-attachments-and-video.md
+++ b/docs/fdr/FDR-008-file-attachments-and-video.md
@@ -1,7 +1,7 @@
 # FDR-008: File Attachments & Video Processing
 
 **Status:** Active
-**Last reviewed:** 2026-06-17
+**Last reviewed:** 2026-07-02
 
 ## Overview
 
@@ -16,7 +16,8 @@ Users can attach files to messages — images, videos, documents — via drag-an
 - Images are inspected for dimensions at upload time and can be resized at render time via URL parameters (width, height, fit mode). Public attachment and avatar APIs expose transform parameters; public server branding images expose canonical URLs only.
 - When enabled, videos and animated GIFs are processed by the current server process after asset creation and message submission scheduling. This is best-effort and intentionally simple until a real durable worker queue exists.
 - Processing status: durable STARTED / COMPLETED / FAILED outcomes are stored as asset aggregate events (`evt.asset.{assetId}.*`) and delivered through the normal live EVT subscription path after room-membership authorization. There is no separate `video_processed` live event or new runtime KV state for video progress; failed videos still show the original message, and the UI falls back to the original upload when it is available.
-- A thumbnail is generated from an early video frame.
+- Processed video dimensions are display dimensions used for layout, not necessarily raw encoded storage pixels. Non-square-pixel and rotated sources should render in their intended orientation and aspect ratio. In the room timeline, ordinary posted landscape videos with near-square metadata are presented in a widescreen frame so common screen recordings do not appear as tall 4:3 embeds; converted animated GIF loops preserve their measured dimensions.
+- A thumbnail is generated from an early video frame using the same display dimensions, so non-square-pixel sources do not persist squished or pillarboxed poster images.
 - Resized images can be cached as WebP with an auto-expiring cache.
 - In Service Worker-controlled browser sessions, stable asset URLs are rendered as same-origin virtual URLs and proxied to the owning server with the user's registered server credentials. Successful full responses are cached privately in the browser; media `Range` requests bypass that cache.
 - Active document attachment types such as HTML, XHTML, SVG, and XML can still be uploaded and viewed inline, but original-file responses are delivered in a browser sandbox so uploaded scripts do not run as trusted Chatto application code.
@@ -44,9 +45,9 @@ Users can attach files to messages — images, videos, documents — via drag-an
 
 ### 4. Quality variants are selected per source
 
-**Decision:** Transcoding produces multiple H.264 MP4 variants whose target resolutions are derived from the source resolution. A 1080p source might yield 720p and 480p; a 480p source skips the higher tiers.
+**Decision:** Transcoding produces multiple H.264 MP4 variants whose target resolutions are derived from the source display resolution. A 1080p source might yield 720p and 480p; a 480p source skips the higher tiers. Processing metadata records display dimensions so clients can reserve the correct frame for sources with non-square pixels or rotation metadata. Generated thumbnails are rendered at display dimensions with square pixels. The chat timeline treats ambiguous near-square landscape video metadata as a widescreen presentation case for ordinary uploaded videos.
 **Why:** Producing tiers higher than the source is pointless (upscaling is lossy without benefit). Producing tiers near the source is bandwidth waste for the common case.
-**Tradeoff:** No HLS / adaptive bitrate streaming yet — the frontend picks a variant based on viewport and connection at the time of play. Adaptive streaming is tracked separately in GitHub issue #668.
+**Tradeoff:** No HLS / adaptive bitrate streaming yet — the frontend picks a variant based on viewport and connection at the time of play. Historical processed-video manifests are not rewritten when display-dimension handling improves; clients can still correct the rendered frame after media metadata loads. The widescreen presentation heuristic can crop truly 4:3 uploaded videos in the timeline, but avoids the more common failure where screen recordings appear in a tall padded frame. Adaptive streaming is tracked separately in GitHub issue #668.
 
 ### 5. Attachments are declared content; derivative manifests are durable events
 
@@ -57,7 +58,7 @@ Users can attach files to messages — images, videos, documents — via drag-an
 ### 6. Attachment URLs are per-user signed capabilities
 
 **Decision:** Public attachment APIs expose attachment media as stable asset paths plus per-user access tickets: `/assets/files/{assetId}?access={ticket}` for originals and `/assets/files/{assetId}/image/{width}x{height}/{fit}?access={ticket}` for image derivatives. Attachment, thumbnail, video thumbnail, and variant URLs also expose the ticket expiry so the client can refresh before or after a lazy-load miss. Every fetch verifies the signed user is still a member of the asset's room.
-**Why:** Cross-origin `<img>` tags (used when the SPA loads attachments from a *remote* registered server) can't carry session cookies (SameSite) or Authorization headers. A signed per-user access ticket lets browsers load remote attachments directly, while the room-membership check still auto-revokes access on kick/leave.
+**Why:** Cross-origin `<img>` tags (used when the SPA loads attachments from a _remote_ registered server) can't carry session cookies (SameSite) or Authorization headers. A signed per-user access ticket lets browsers load remote attachments directly, while the room-membership check still auto-revokes access on kick/leave.
 **Tradeoff:** The access ticket is still a bearer capability — anyone holding it can fetch until the expiry passes or the signed user loses room membership. `core.AssetAccessTicketTTL` is currently **1 hour** so normal rendering, lazy loading, media startup, and lightbox use are reliable; clients refresh URL fields through projected timeline/attachment reads when tickets approach expiry or a media load fails. In Service Worker-controlled sessions, the DOM uses non-portable same-origin virtual URLs under `/__chatto/assets/{serverId}/...`; the worker keeps the ticketed target URL out of markup, fetches through the registered server credentials when possible, and caches full successful responses in a private per-browser cache. This removes the "lazy copy URL grants access" problem for the main web app, while keeping ticketed URLs as fallback for non-Service-Worker clients and for media `Range` redirects. Legacy `/assets/attachments/{signedLocator}` URLs remain supported for compatibility/internal fallback and use the shorter 5-minute locator TTL. Rotating `[core.assets].signing_secret` invalidates all outstanding tickets and legacy locators at once.
 
 ### 7. Active document attachments render in a browser sandbox


### PR DESCRIPTION
## Summary

Fix video embeds so display aspect ratios survive both in newly processed metadata and in the browser for existing stale metadata.
The frontend now owns the embed frame ratio, corrects from loaded video metadata, and overrides Vidstack poster/video fitting for the widescreen fallback path.
The processor now reads ffprobe display metadata, probes transcoded outputs, stores dimensions for generated variants, and renders thumbnails at display dimensions.
Updated backend, component, e2e, and FDR coverage document and verify the behavior.

## Checks

- `npx @sveltejs/mcp svelte-autofixer apps/frontend/src/lib/components/chat/VideoPlayer.svelte --svelte-version 5`
- `mise x -- pnpm exec vitest run 'src/lib/components/chat/VideoPlayer.svelte.spec.ts' 'src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts'`
- `mise x -- go test ./internal/video ./internal/core`
- `mise run build-e2e-server`
- `mise x -- pnpm exec playwright test e2e/video-player.test.ts --retries=0`
- `git diff --check`
