### PR TITLE
style(frontend): apply interface polish rules

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -17,7 +17,7 @@
     "test": "npm run test:unit -- --run && npm run test:e2e",
     "test:e2e": "playwright test",
     "storybook": "storybook dev -p 6006 --no-open",
-    "build-storybook": "storybook build"
+    "build-storybook": "pnpm --filter @chatto/api-types build && storybook build"
   },
   "devDependencies": {
     "@eslint/compat": "^1.4.1",

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -65,6 +65,7 @@
      (bright in light, barely-there in dark) — see dark override. */
   --color-panel-tint: var(--color-surface-100);
   --color-panel-highlight: rgba(255, 255, 255, 0.7);
+  --color-image-outline: rgba(0, 0, 0, 0.1);
 
   /* Shimmer hover effect gradient */
   --shimmer-gradient: linear-gradient(
@@ -108,6 +109,7 @@
   --color-server: var(--color-indigo-400);
 
   --color-panel-highlight: rgba(255, 255, 255, 0.04);
+  --color-image-outline: rgba(255, 255, 255, 0.1);
 }
 
 @theme {
@@ -186,8 +188,8 @@
  * via opacity.
  */
 @utility btn {
-  @apply inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-lg px-4 py-2 font-medium;
-  @apply transition-all duration-150;
+  @apply inline-flex min-h-10 min-w-10 cursor-pointer items-center justify-center gap-1.5 rounded-lg px-4 py-2 font-medium;
+  @apply transition-[background-color,color,box-shadow,scale,--tw-gradient-from,--tw-gradient-to] duration-150 active:scale-[0.96];
   @apply disabled:cursor-not-allowed disabled:opacity-50;
 }
 
@@ -331,7 +333,7 @@
 }
 
 @utility embed-control-button {
-  @apply absolute top-1 right-1 flex h-6 w-6 cursor-pointer items-center justify-center rounded-full bg-black/60 text-white shadow-md ring-1 ring-white/30 transition-opacity hover:bg-black/80 md:opacity-0;
+  @apply absolute top-1 right-1 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full bg-black/60 text-white shadow-md ring-1 ring-white/30 transition-[background-color,opacity,scale] hover:bg-black/80 active:scale-[0.96] md:opacity-0;
 }
 
 /* Skeleton loading utility */
@@ -376,7 +378,7 @@
    Resting inactive state is intentionally transparent; pair with
    `pane-header-icon-button-active` for selected/toggled backgrounds. */
 @utility pane-header-icon-button {
-  @apply inline-flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-sm bg-transparent leading-none text-muted transition-colors;
+  @apply inline-flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center rounded-sm bg-transparent leading-none text-muted transition-[background-color,color,scale] active:scale-[0.96];
   @apply hover:!text-text-top disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:!opacity-100;
 }
 
@@ -442,7 +444,7 @@
 /* Icon button in the app header: 44px tap target, negative margin to keep
    visual alignment tight, subtle hover/active feedback. */
 @utility app-header-icon {
-  @apply -m-2 flex h-11 w-11 cursor-pointer items-center justify-center rounded hover:text-text active:bg-surface-200;
+  @apply -m-2 flex h-11 w-11 cursor-pointer items-center justify-center rounded transition-[background-color,color,scale] hover:text-text active:scale-[0.96] active:bg-surface-200;
 }
 
 /* Compact inline icon-only action for row/input affordances such as copy,
@@ -450,7 +452,7 @@
  * pane-header-icon-button instead.
  */
 @utility icon-action {
-  @apply inline-flex cursor-pointer items-center justify-center rounded p-1 text-muted transition-colors;
+  @apply inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded text-muted transition-[background-color,color,scale] active:scale-[0.96];
   @apply hover:bg-surface-200 hover:text-text;
   @apply disabled:cursor-not-allowed disabled:opacity-50;
 }
@@ -497,7 +499,7 @@
 }
 
 @utility menu-item {
-  @apply flex w-full cursor-pointer items-center gap-3 rounded px-3 py-1.5 text-left hover:bg-surface-100;
+  @apply flex min-h-10 w-full cursor-pointer items-center gap-3 rounded px-3 py-1.5 text-left transition-[background-color,scale] hover:bg-surface-100 active:scale-[0.96];
 }
 
 @utility menu-item-active {
@@ -513,6 +515,8 @@
   html {
     height: 100%;
     overflow: hidden;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
     /* pan-y lets the browser own vertical scroll while reserving horizontal
        pans for our own gesture handling (mobile sidebar swipe). It also
        implicitly disables pinch-zoom and double-tap-zoom — same as the
@@ -523,6 +527,27 @@
        fire pointercancel mid-drag, killing our sidebar swipe handler. */
     overscroll-behavior-x: none;
     background-color: var(--color-background);
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    text-wrap: balance;
+  }
+
+  p,
+  li,
+  figcaption,
+  blockquote {
+    text-wrap: pretty;
+  }
+
+  img {
+    outline: 1px solid var(--color-image-outline);
+    outline-offset: -1px;
   }
 
   body {

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte
@@ -71,9 +71,9 @@ to the user settings page for the active server.
     }
     return `# ${room.name}`;
   });
-  const compactCallButtonClass = 'btn-secondary h-7 w-7 shrink-0 !px-0 !py-0 text-xs';
-  const compactCallActiveButtonClass = 'btn-success h-7 w-7 shrink-0 !px-0 !py-0 text-xs';
-  const compactCallDangerButtonClass = 'btn-danger h-7 w-7 shrink-0 !px-0 !py-0 text-xs';
+  const compactCallButtonClass = 'btn-secondary h-10 w-10 shrink-0 !px-0 !py-0 text-xs';
+  const compactCallActiveButtonClass = 'btn-success h-10 w-10 shrink-0 !px-0 !py-0 text-xs';
+  const compactCallDangerButtonClass = 'btn-danger h-10 w-10 shrink-0 !px-0 !py-0 text-xs';
   const isTouch = isTouchDevice();
   const presenceModes: PresenceMode[] = ['auto', 'away', 'doNotDisturb', 'invisible'];
   const presenceLabel = $derived.by(() => presenceModeLabel(presencePreference.mode));
@@ -316,7 +316,7 @@ to the user settings page for the active server.
         href={resolve('/chat/[serverId]/settings', { serverId: serverSegment })}
         title={m['voice.user_settings']()}
         aria-label={m['voice.user_settings']()}
-        class="flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center text-muted hover:text-text"
+        class="flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center rounded text-muted transition-[background-color,color,scale] hover:bg-surface-100 hover:text-text active:scale-[0.96]"
       >
         <span class="iconify text-lg uil--setting" aria-hidden="true"></span>
       </a>
@@ -395,7 +395,7 @@ to the user settings page for the active server.
           <button
             type="button"
             onclick={() => (customStatusDialogVisible = false)}
-            class="-m-1 grid h-8 w-8 shrink-0 cursor-pointer place-items-center rounded-md text-text/50 transition-colors hover:bg-surface-100 hover:text-text"
+            class="grid h-10 w-10 shrink-0 cursor-pointer place-items-center rounded-md text-text/50 transition-[background-color,color,scale] hover:bg-surface-100 hover:text-text active:scale-[0.96]"
             aria-label={m['ui.close']()}
           >
             <span class="iconify text-xl uil--times"></span>

--- a/apps/frontend/src/lib/components/ServerLogo.svelte
+++ b/apps/frontend/src/lib/components/ServerLogo.svelte
@@ -26,7 +26,7 @@
 	Used by ServerIcon for the server gutter icon.
 -->
 <div
-  class="shimmer-hover flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-xl text-3xl font-black transition-all duration-100"
+  class="shimmer-hover flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-xl text-3xl font-black transition-[background-color,color] duration-100"
   style:background={gradientStyle}
 >
   {#if server.logoUrl}

--- a/apps/frontend/src/lib/components/UserCustomStatusEditor.svelte
+++ b/apps/frontend/src/lib/components/UserCustomStatusEditor.svelte
@@ -424,7 +424,7 @@
       <div class="flex min-w-0 items-center gap-1">
         <button
           type="button"
-          class="grid h-8 w-8 shrink-0 cursor-pointer place-items-center rounded-md hover:bg-surface-100 disabled:cursor-not-allowed disabled:opacity-60"
+          class="grid h-10 w-10 shrink-0 cursor-pointer place-items-center rounded-md transition-[background-color,scale] hover:bg-surface-100 active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-60"
           title={m['settings.profile.status.emoji.choose']()}
           aria-label={m['settings.profile.status.emoji.choose']()}
           disabled={isSaving || isClearing}
@@ -445,7 +445,7 @@
         />
         <button
           type="submit"
-          class="btn-accent h-8 w-8 shrink-0 !px-0 !py-0 text-sm"
+          class="btn-accent h-10 w-10 shrink-0 !px-0 !py-0 text-sm"
           title={m['settings.profile.status.save_button']()}
           aria-label={m['settings.profile.status.save_button']()}
           disabled={!isModified || isSaving}
@@ -476,7 +476,7 @@
     >
       <button
         type="button"
-        class="grid h-8 w-8 shrink-0 cursor-pointer place-items-center rounded-md text-lg hover:bg-surface-100 disabled:cursor-not-allowed disabled:opacity-60"
+        class="grid h-10 w-10 shrink-0 cursor-pointer place-items-center rounded-md text-lg transition-[background-color,scale] hover:bg-surface-100 active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-60"
         title={m['settings.profile.status.emoji.choose']()}
         aria-label={m['settings.profile.status.emoji.choose']()}
         disabled={isSaving || isClearing}
@@ -499,7 +499,7 @@
       {#if statusText || hasActiveStatus}
         <button
           type="button"
-          class="grid h-7 w-7 shrink-0 cursor-pointer place-items-center rounded-full text-muted hover:bg-surface-100 hover:text-text disabled:cursor-not-allowed disabled:opacity-60"
+          class="grid h-10 w-10 shrink-0 cursor-pointer place-items-center rounded-full text-muted transition-[background-color,color,scale] hover:bg-surface-100 hover:text-text active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-60"
           title={m['settings.profile.status.clear_button']()}
           aria-label={m['settings.profile.status.clear_button']()}
           disabled={isSaving || isClearing}

--- a/apps/frontend/src/lib/components/admin/StatCard.svelte
+++ b/apps/frontend/src/lib/components/admin/StatCard.svelte
@@ -29,7 +29,7 @@
       <span class="{icon} text-2xl {colorClasses[color].text}"></span>
     </div>
     <div class="min-w-0">
-      <div class="text-3xl font-bold">{value}</div>
+      <div class="text-3xl font-bold tabular-nums">{value}</div>
       <div class="text-sm text-muted">{label}</div>
       {#if subtitle}
         <div class="text-xs text-muted">{subtitle}</div>

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -943,7 +943,7 @@
         type="button"
         onclick={() => fileInputElement?.click()}
         disabled={inputDisabled}
-        class="flex h-8 w-11 shrink-0 cursor-pointer items-center justify-center rounded text-muted transition-colors duration-100 enabled:hover:text-text disabled:cursor-not-allowed"
+        class="flex h-10 w-11 shrink-0 cursor-pointer items-center justify-center rounded text-muted transition-[color,scale] duration-100 active:scale-[0.96] enabled:hover:text-text disabled:cursor-not-allowed"
         title={m['composer.attach_file']()}
       >
         <span class="iconify text-xl uil--image-upload"></span>
@@ -968,7 +968,7 @@
       />
     {/await}
 
-    <div class="flex h-8 shrink-0 items-center gap-2">
+    <div class="flex h-10 shrink-0 items-center gap-2">
       {#if submitHint && canSubmit}
         <span
           aria-hidden="true"
@@ -985,7 +985,7 @@
         onpointerdown={(e) => e.preventDefault()}
         onclick={handleSubmit}
         disabled={!canSubmit}
-        class="flex h-8 w-8 cursor-pointer items-center justify-center rounded text-muted transition-colors duration-100 enabled:hover:text-text disabled:cursor-not-allowed disabled:opacity-50"
+        class="flex h-10 w-10 cursor-pointer items-center justify-center rounded text-muted transition-[color,scale] duration-100 active:scale-[0.96] enabled:hover:text-text disabled:cursor-not-allowed disabled:opacity-50"
         aria-label={m['composer.send']()}
         title={isRichComposer ? m['composer.send_ctrl_enter']() : m['composer.send_enter']()}
       >

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -943,7 +943,7 @@
         type="button"
         onclick={() => fileInputElement?.click()}
         disabled={inputDisabled}
-        class="flex h-10 w-11 shrink-0 cursor-pointer items-center justify-center rounded text-muted transition-[color,scale] duration-100 active:scale-[0.96] enabled:hover:text-text disabled:cursor-not-allowed"
+        class="flex h-8 w-11 shrink-0 cursor-pointer items-center justify-center rounded text-muted transition-[color,scale] duration-100 active:scale-[0.96] enabled:hover:text-text disabled:cursor-not-allowed"
         title={m['composer.attach_file']()}
       >
         <span class="iconify text-xl uil--image-upload"></span>
@@ -968,7 +968,7 @@
       />
     {/await}
 
-    <div class="flex h-10 shrink-0 items-center gap-2">
+    <div class="flex h-8 shrink-0 items-center gap-2">
       {#if submitHint && canSubmit}
         <span
           aria-hidden="true"
@@ -985,7 +985,7 @@
         onpointerdown={(e) => e.preventDefault()}
         onclick={handleSubmit}
         disabled={!canSubmit}
-        class="flex h-10 w-10 cursor-pointer items-center justify-center rounded text-muted transition-[color,scale] duration-100 active:scale-[0.96] enabled:hover:text-text disabled:cursor-not-allowed disabled:opacity-50"
+        class="flex h-8 w-8 cursor-pointer items-center justify-center rounded text-muted transition-[color,scale] duration-100 active:scale-[0.96] enabled:hover:text-text disabled:cursor-not-allowed disabled:opacity-50"
         aria-label={m['composer.send']()}
         title={isRichComposer ? m['composer.send_ctrl_enter']() : m['composer.send_enter']()}
       >

--- a/apps/frontend/src/lib/components/composer/TipTapEditor.svelte
+++ b/apps/frontend/src/lib/components/composer/TipTapEditor.svelte
@@ -1209,7 +1209,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
             }
           }}
           onblur={applyLinkHref}
-          class="h-6 w-48 min-w-0 rounded border border-border bg-surface-200 px-2 text-xs text-text outline-none hover:bg-surface-300 focus:border-accent disabled:cursor-not-allowed disabled:opacity-50"
+          class="h-10 w-48 min-w-0 rounded border border-border bg-surface-200 px-2 text-xs text-text transition-[background-color,border-color] outline-none hover:bg-surface-300 focus:border-accent disabled:cursor-not-allowed disabled:opacity-50"
         />
         <button
           type="button"
@@ -1217,7 +1217,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
           title={m['composer.open_link']()}
           disabled={!activeLinkHref}
           onclick={openActiveLink}
-          class="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted hover:bg-surface-300 hover:text-text"
+          class="flex h-10 w-10 cursor-pointer items-center justify-center rounded text-muted transition-[background-color,color,scale] hover:bg-surface-300 hover:text-text active:scale-[0.96]"
         >
           <span class="iconify text-base uil--external-link-alt"></span>
         </button>
@@ -1227,7 +1227,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
           title={m['composer.remove_link']()}
           disabled={!editable}
           onclick={removeLink}
-          class="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted hover:bg-surface-300 hover:text-text disabled:cursor-not-allowed disabled:opacity-50"
+          class="flex h-10 w-10 cursor-pointer items-center justify-center rounded text-muted transition-[background-color,color,scale] hover:bg-surface-300 hover:text-text active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-50"
         >
           <span class="iconify text-base uil--link-broken"></span>
         </button>

--- a/apps/frontend/src/lib/components/menus/MessageContextMenu.svelte
+++ b/apps/frontend/src/lib/components/menus/MessageContextMenu.svelte
@@ -131,7 +131,7 @@ Rendered inside a ContextMenu when right-clicking a message.
     <div class="flex justify-between">
       {#each quickReactions as emoji (emoji)}
         <button
-          class="flex h-8 w-8 cursor-pointer items-center justify-center rounded text-base hover:bg-surface-100"
+          class="flex h-10 w-10 cursor-pointer items-center justify-center rounded text-base transition-[background-color,scale] hover:bg-surface-100 active:scale-[0.96]"
           onclick={() => handleReaction(emoji)}
           aria-label={m['room.message.actions.react_with']({ emoji })}
           role="menuitem"
@@ -141,7 +141,7 @@ Rendered inside a ContextMenu when right-clicking a message.
       {/each}
       {#if onOpenEmojiPicker}
         <button
-          class="flex h-8 w-8 cursor-pointer items-center justify-center rounded text-base text-muted hover:bg-surface-100"
+          class="flex h-10 w-10 cursor-pointer items-center justify-center rounded text-base text-muted transition-[background-color,scale] hover:bg-surface-100 active:scale-[0.96]"
           onclick={() => {
             onOpenEmojiPicker();
             onClose();

--- a/apps/frontend/src/lib/components/rbac/MatrixCell.svelte
+++ b/apps/frontend/src/lib/components/rbac/MatrixCell.svelte
@@ -62,16 +62,14 @@ to render an inert "—" cell with an explanation tooltip.
   const overrideClasses: Record<State, string> = {
     allow:
       'bg-gradient-to-br from-success/65 to-success/95 text-white hover:from-success/75 hover:to-success',
-    deny:
-      'bg-gradient-to-br from-danger/65 to-danger/95 text-white hover:from-danger/75 hover:to-danger',
+    deny: 'bg-gradient-to-br from-danger/65 to-danger/95 text-white hover:from-danger/75 hover:to-danger',
     // Unreachable — neutral isn't an override state, but keep a value for type safety.
     neutral: ''
   };
   const inheritedClasses: Record<State, string> = {
     allow:
       'bg-gradient-to-br from-success/15 to-success/30 text-success/85 hover:from-success/25 hover:to-success/40',
-    deny:
-      'bg-gradient-to-br from-danger/15 to-danger/30 text-danger/85 hover:from-danger/25 hover:to-danger/40',
+    deny: 'bg-gradient-to-br from-danger/15 to-danger/30 text-danger/85 hover:from-danger/25 hover:to-danger/40',
     neutral:
       'bg-gradient-to-br from-surface-200/40 to-surface-300/60 text-muted/60 hover:from-surface-200/60 hover:to-surface-300/80'
   };
@@ -87,7 +85,7 @@ to render an inert "—" cell with an explanation tooltip.
 
 {#if !applicable}
   <span
-    class="inline-flex h-5 w-5 items-center justify-center text-xs text-muted/30"
+    class="inline-flex h-10 w-10 items-center justify-center text-xs text-muted/30"
     {title}
     aria-label={ariaLabel}
   >
@@ -97,8 +95,7 @@ to render an inert "—" cell with an explanation tooltip.
   <button
     type="button"
     class={[
-      'inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded-md transition-all',
-      surfaceClasses,
+      'inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-md transition-[scale] active:scale-[0.96]',
       updating ? 'animate-pulse' : '',
       disabled ? 'cursor-not-allowed opacity-60' : ''
     ]}
@@ -108,6 +105,13 @@ to render an inert "—" cell with an explanation tooltip.
     aria-pressed={isOverride}
     onclick={handleClick}
   >
-    <span class={['iconify h-3 w-3', icon]}></span>
+    <span
+      class={[
+        'inline-flex h-5 w-5 items-center justify-center rounded-md transition-[background-color,color,box-shadow,--tw-gradient-from,--tw-gradient-to]',
+        surfaceClasses
+      ]}
+    >
+      <span class={['iconify h-3 w-3', icon]}></span>
+    </span>
   </button>
 {/if}

--- a/apps/frontend/src/lib/components/rbac/PermissionMatrix.svelte
+++ b/apps/frontend/src/lib/components/rbac/PermissionMatrix.svelte
@@ -388,7 +388,7 @@ under it. Column headers are clickable when `onRoleClick` is provided
                     ].filter(Boolean)}
                 <td
                   class="px-0 py-2 text-center"
-                  style="width: 2rem; min-width: 2rem"
+                  style="width: 2.5rem; min-width: 2.5rem"
                   data-role={role.roleName}
                   data-permission={permission}
                 >

--- a/apps/frontend/src/lib/components/rbac/SubjectPermissionsMatrix.svelte
+++ b/apps/frontend/src/lib/components/rbac/SubjectPermissionsMatrix.svelte
@@ -252,7 +252,7 @@ apply at that scope's tier).
                 {@const isUpdating = updatingKey === cellKey}
                 <td
                   class={['px-0 py-2 text-center', scopeColumnClass(scope.kind)]}
-                  style="width: 2rem; min-width: 2rem"
+                  style="width: 2.5rem; min-width: 2.5rem"
                   data-scope={scope.id}
                   data-permission={permission}
                 >
@@ -290,7 +290,7 @@ apply at that scope's tier).
                       onCycle={(next) => onCycle(scope, permission, next)}
                     />
                   {:else}
-                    <span class="inline-block h-5 w-5" aria-hidden="true"></span>
+                    <span class="inline-block h-10 w-10" aria-hidden="true"></span>
                   {/if}
                 </td>
               {/each}

--- a/apps/frontend/src/lib/components/voice/CallTileActionButton.svelte
+++ b/apps/frontend/src/lib/components/voice/CallTileActionButton.svelte
@@ -24,7 +24,7 @@ for the current viewer.
 <button
   type="button"
   class={[
-    'pointer-events-auto flex h-7 w-7 cursor-pointer items-center justify-center rounded text-muted transition-colors hover:bg-surface-200 hover:text-text focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-primary',
+    'pointer-events-auto flex h-10 w-10 cursor-pointer items-center justify-center rounded text-muted transition-[background-color,color,scale] hover:bg-surface-200 hover:text-text focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-primary active:scale-[0.96]',
     active && 'bg-surface-200 text-text'
   ]}
   title={label}

--- a/apps/frontend/src/lib/ui/PaneHeader.svelte
+++ b/apps/frontend/src/lib/ui/PaneHeader.svelte
@@ -84,7 +84,7 @@ choice).
         title={backLabel}
         aria-label={backLabel}
       >
-        <span class="pane-header-icon-glyph uil--arrow-left" aria-hidden="true"></span>
+        <span class="pane-header-icon-glyph text-xl uil--arrow-left" aria-hidden="true"></span>
       </button>
     {:else if backHref}
       <a
@@ -93,7 +93,7 @@ choice).
         title={backLabel}
         aria-label={backLabel}
       >
-        <span class="pane-header-icon-glyph uil--arrow-left" aria-hidden="true"></span>
+        <span class="pane-header-icon-glyph text-xl uil--arrow-left" aria-hidden="true"></span>
       </a>
     {/if}
     <div class="flex min-w-0 flex-1 flex-col gap-1 md:flex-row md:items-baseline md:gap-3">

--- a/apps/frontend/src/lib/ui/ToggleChip.svelte
+++ b/apps/frontend/src/lib/ui/ToggleChip.svelte
@@ -52,7 +52,7 @@ iconify icon in the slot:
     tone?: Tone;
     /**
      * Render as a square icon-only chip (no horizontal padding, fixed
-     * 28×28). Use for icon-only affordances so they don't gain bonus
+     * 40×40). Use for icon-only affordances so they don't gain bonus
      * width from `px-2.5`.
      */
     square?: boolean;
@@ -85,13 +85,10 @@ iconify icon in the slot:
     'bg-gradient-to-br from-surface-100/80 to-surface-200/80 text-muted ring-1 ring-text/5';
 
   const inactiveHover: Record<Tone, string> = {
-    success:
-      'hover:from-success/10 hover:to-success/20 hover:text-success hover:ring-success/20',
+    success: 'hover:from-success/10 hover:to-success/20 hover:text-success hover:ring-success/20',
     danger: 'hover:from-danger/10 hover:to-danger/20 hover:text-danger hover:ring-danger/20',
-    warning:
-      'hover:from-warning/10 hover:to-warning/20 hover:text-warning hover:ring-warning/20',
-    primary:
-      'hover:from-primary/10 hover:to-primary/20 hover:text-primary hover:ring-primary/20',
+    warning: 'hover:from-warning/10 hover:to-warning/20 hover:text-warning hover:ring-warning/20',
+    primary: 'hover:from-primary/10 hover:to-primary/20 hover:text-primary hover:ring-primary/20',
     neutral: 'hover:from-surface-200 hover:to-surface-300 hover:text-text hover:ring-text/10'
   };
 </script>
@@ -99,8 +96,8 @@ iconify icon in the slot:
 <button
   type="button"
   class={[
-    'inline-flex h-7 cursor-pointer items-center justify-center gap-1.5 rounded-md text-xs font-medium transition-all duration-150',
-    square ? 'w-7' : 'min-w-7 px-2.5',
+    'inline-flex min-h-10 cursor-pointer items-center justify-center gap-1.5 rounded-md text-xs font-medium transition-[background-color,color,box-shadow,scale,--tw-gradient-from,--tw-gradient-to] duration-150 active:scale-[0.96]',
+    square ? 'w-10' : 'min-w-10 px-2.5',
     pressed ? pressedClasses[tone] : [inactiveClasses, inactiveHover[tone]],
     disabled ? 'cursor-not-allowed opacity-60' : ''
   ]}

--- a/apps/frontend/src/lib/ui/Typography.stories.svelte
+++ b/apps/frontend/src/lib/ui/Typography.stories.svelte
@@ -19,16 +19,40 @@
   </div>
 </Story>
 
+<Story name="Polish rules" asChild>
+  <div class="flex max-w-prose flex-col gap-5">
+    <section class="flex flex-col gap-2">
+      <div class="text-xs text-muted uppercase">balanced headings</div>
+      <h2 class="max-w-sm text-2xl font-semibold">
+        Server administration controls that stay readable on narrow panes
+      </h2>
+    </section>
+
+    <section class="flex flex-col gap-2">
+      <div class="text-xs text-muted uppercase">pretty body copy</div>
+      <p class="max-w-md text-muted">
+        Short interface descriptions should avoid lonely trailing words while keeping natural line
+        lengths in cards, dialogs, settings panels, and empty states.
+      </p>
+    </section>
+
+    <section class="flex flex-col gap-2">
+      <div class="text-xs text-muted uppercase">tabular numbers</div>
+      <div class="font-mono text-lg tabular-nums">713 · 48,221 · 3</div>
+    </section>
+  </div>
+</Story>
+
 <Story name="Families" asChild>
   <div class="flex flex-col gap-3">
     <div>
-      <div class="text-xs uppercase text-muted">font-sans (default)</div>
+      <div class="text-xs text-muted uppercase">font-sans (default)</div>
       <p class="font-sans text-lg">
         IBM Plex Sans Variable — The quick brown fox jumps over the lazy dog. 0123456789
       </p>
     </div>
     <div>
-      <div class="text-xs uppercase text-muted">font-mono</div>
+      <div class="text-xs text-muted uppercase">font-mono</div>
       <p class="font-mono text-lg">
         IBM Plex Mono — The quick brown fox jumps over the lazy dog. 0123456789
       </p>

--- a/apps/frontend/src/lib/ui/form/Combobox.svelte
+++ b/apps/frontend/src/lib/ui/form/Combobox.svelte
@@ -159,7 +159,7 @@
       {#if text}
         <button
           type="button"
-          class="pane-header-icon-button h-7 w-7"
+          class="pane-header-icon-button"
           aria-label={clearLabel}
           title={clearLabel}
           {disabled}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.svelte
@@ -137,7 +137,7 @@ Desktop only (pointer-fine); mobile uses the long-press action sheet instead.
     <div class="flex items-center menu-section-sm">
       {#each quickReactions as emoji (emoji)}
         <button
-          class="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-base hover:bg-surface-100"
+          class="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-base transition-[background-color,scale] hover:bg-surface-100 active:scale-[0.96]"
           onclick={() => handleReaction(emoji)}
           aria-label={hasReacted(emoji)
             ? m['room.message.actions.remove_reaction']({ emoji })
@@ -148,7 +148,7 @@ Desktop only (pointer-fine); mobile uses the long-press action sheet instead.
       {/each}
       {#if onOpenEmojiPicker}
         <button
-          class="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-muted hover:bg-surface-100 hover:text-text"
+          class="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-muted transition-[background-color,color,scale] hover:bg-surface-100 hover:text-text active:scale-[0.96]"
           onclick={onOpenEmojiPicker}
           aria-label={m['room.message.actions.more_reactions']()}
         >
@@ -162,7 +162,7 @@ Desktop only (pointer-fine); mobile uses the long-press action sheet instead.
     <div class="flex items-center menu-section-sm">
       {#if onReplyInRoom}
         <button
-          class="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-muted hover:bg-surface-100 hover:text-text"
+          class="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-muted transition-[background-color,color,scale] hover:bg-surface-100 hover:text-text active:scale-[0.96]"
           onclick={handleReplyInRoom}
           aria-label={replyInRoomActionLabel}
         >
@@ -172,7 +172,7 @@ Desktop only (pointer-fine); mobile uses the long-press action sheet instead.
 
       {#if onReply}
         <button
-          class="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-muted hover:bg-surface-100 hover:text-text"
+          class="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-muted transition-[background-color,color,scale] hover:bg-surface-100 hover:text-text active:scale-[0.96]"
           onclick={handleReply}
           aria-label={replyThreadActionLabel}
         >
@@ -182,7 +182,7 @@ Desktop only (pointer-fine); mobile uses the long-press action sheet instead.
 
       {#if canEdit}
         <button
-          class="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-muted hover:bg-surface-100 hover:text-text"
+          class="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-muted transition-[background-color,color,scale] hover:bg-surface-100 hover:text-text active:scale-[0.96]"
           onclick={handleEdit}
           aria-label={m['room.message.actions.edit']()}
         >
@@ -192,7 +192,7 @@ Desktop only (pointer-fine); mobile uses the long-press action sheet instead.
 
       {#if onOpenMenu}
         <button
-          class="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-muted hover:bg-surface-100 hover:text-text"
+          class="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-muted transition-[background-color,color,scale] hover:bg-surface-100 hover:text-text active:scale-[0.96]"
           onclick={onOpenMenu}
           aria-label={m['room.message.actions.more']()}
         >

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
@@ -309,14 +309,14 @@ calls, and similar room-specific panels can plug into the same shell. See the
             oninput={scheduleMemberSearch}
             placeholder={m['room.sidebar.search_members_placeholder']()}
             class={[
-              'room-member-search-input h-8 w-full rounded-md bg-surface py-1 pl-8 text-sm transition-colors outline-none placeholder:text-muted',
-              membersStore.searchInput ? 'pr-8' : 'pr-2'
+              'room-member-search-input h-10 w-full rounded-md bg-surface py-1 pl-8 text-sm transition-colors outline-none placeholder:text-muted',
+              membersStore.searchInput ? 'pr-12' : 'pr-2'
             ]}
           />
           {#if membersStore.searchInput}
             <button
               type="button"
-              class="pane-header-icon-button absolute top-1/2 right-1 h-6 w-6 -translate-y-1/2"
+              class="absolute top-1/2 right-1 pane-header-icon-button -translate-y-1/2"
               aria-label={m['room.sidebar.clear_member_search']()}
               title={m['room.sidebar.clear_member_search']()}
               onclick={clearMemberSearch}
@@ -412,14 +412,6 @@ calls, and similar room-specific panels can plug into the same shell. See the
   {/if}
 </aside>
 
-<style>
-  .room-member-search-input::-webkit-search-cancel-button {
-    -webkit-appearance: none;
-    appearance: none;
-    display: none;
-  }
-</style>
-
 {#snippet memberRow(member: RoomMember)}
   {@const isOnline = isOnlineStatus(getPresence(member))}
   <button
@@ -454,3 +446,11 @@ calls, and similar room-specific panels can plug into the same shell. See the
     </div>
   </button>
 {/snippet}
+
+<style>
+  .room-member-search-input::-webkit-search-cancel-button {
+    -webkit-appearance: none;
+    appearance: none;
+    display: none;
+  }
+</style>


### PR DESCRIPTION
## Summary

- Applies the interface polish rules from the recent frontend review: explicit transitions, 40px touch targets for shared controls, press feedback, font smoothing, balanced/pretty text wrapping, image outlines, and tabular admin numbers.
- Tightens dense controls in composer, RBAC matrices, message actions, room sidebar search, voice controls, and shared Storybook utilities.
- Makes `build-storybook` prebuild `@chatto/api-types` so Storybook works from a fresh workspace.

## Validation

- `mise x -- pnpm --dir apps/frontend check`
- `mise x -- pnpm --dir apps/frontend exec vitest --run src/lib/components/rbac/MatrixCell.svelte.spec.ts src/lib/components/rbac/PermissionMatrix.svelte.spec.ts 'src/routes/chat/[serverId]/[roomId]/MessageHoverBar.svelte.spec.ts' 'src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts' -t 'clears the member search|MatrixCell|PermissionMatrix|MessageHoverBar'`
- `mise x -- pnpm --dir apps/frontend build-storybook`
- `mise x -- pnpm --dir apps/frontend exec playwright test e2e/recent-reactions.test.ts`
- Chrome DevTools MCP spot checks against built Storybook for button sizing/transitions, typography wrapping/tabular numbers, and image outline colors.
