### PR TITLE
fix(frontend): use semantic presence colors

### DIFF
--- a/apps/frontend/e2e/presence-indicators.test.ts
+++ b/apps/frontend/e2e/presence-indicators.test.ts
@@ -30,7 +30,7 @@ test.describe('Presence indicators', () => {
     // User A's presence dot should be green (online)
     // Use a longer timeout as presence update requires subscription establishment
     const userAPresenceDot = roomPage.getMemberPresenceDot(userA.login);
-    await expect(userAPresenceDot).toHaveClass(/bg-green-500/, {
+    await expect(userAPresenceDot).toHaveClass(/bg-presence-online/, {
       timeout: TIMEOUTS.REALTIME_EVENT
     });
 
@@ -52,7 +52,7 @@ test.describe('Presence indicators', () => {
 
         // User B's presence dot should be green (online)
         const userBPresenceDot = roomPage.getMemberPresenceDot(userB.login);
-        await expect(userBPresenceDot).toHaveClass(/bg-green-500/, {
+        await expect(userBPresenceDot).toHaveClass(/bg-presence-online/, {
           timeout: TIMEOUTS.UI_STANDARD
         });
       }
@@ -69,7 +69,7 @@ test.describe('Presence indicators', () => {
 
     // User B should still show as online (TTL hasn't expired yet)
     const userBPresenceDot = roomPage.getMemberPresenceDot(userBLogin!);
-    await expect(userBPresenceDot).toHaveClass(/bg-green-500/, {
+    await expect(userBPresenceDot).toHaveClass(/bg-presence-online/, {
       timeout: TIMEOUTS.UI_STANDARD
     });
   });
@@ -88,7 +88,7 @@ test.describe('Presence indicators', () => {
     // User's presence dot should be green (online)
     // Use a longer timeout as presence update requires subscription establishment
     const presenceDot = roomPage.getMemberPresenceDot(user.login);
-    await expect(presenceDot).toHaveClass(/bg-green-500/, {
+    await expect(presenceDot).toHaveClass(/bg-presence-online/, {
       timeout: TIMEOUTS.REALTIME_EVENT
     });
   });

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -58,6 +58,11 @@
   --color-danger: var(--color-red-600);
   --color-error: var(--color-red-600);
   --color-server: var(--color-indigo-600);
+  --color-presence-online: var(--color-green-500);
+  --color-presence-away: var(--color-yellow-500);
+  --color-presence-do-not-disturb: var(--color-red-500);
+  --color-presence-offline: var(--color-gray-500);
+  --color-presence-invisible: var(--color-gray-400);
 
   /* Panel header band tint + 1px inset highlight just under the divider.
      Tint matches the outer app frame (`bg-surface-100`) so the header
@@ -141,6 +146,11 @@
   --color-danger: var(--color-danger);
   --color-error: var(--color-error);
   --color-server: var(--color-server);
+  --color-presence-online: var(--color-presence-online);
+  --color-presence-away: var(--color-presence-away);
+  --color-presence-do-not-disturb: var(--color-presence-do-not-disturb);
+  --color-presence-offline: var(--color-presence-offline);
+  --color-presence-invisible: var(--color-presence-invisible);
 
   --color-panel-tint: var(--color-panel-tint);
   --color-panel-highlight: var(--color-panel-highlight);

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte
@@ -109,13 +109,13 @@ to the user settings page for the active server.
   function presenceModeDotClass(mode: PresenceMode): string {
     switch (mode) {
       case 'away':
-        return 'bg-orange-500';
+        return 'bg-presence-away';
       case 'doNotDisturb':
-        return 'bg-red-500';
+        return 'bg-presence-do-not-disturb';
       case 'invisible':
-        return 'bg-gray-400';
+        return 'bg-presence-invisible';
       default:
-        return 'bg-green-500';
+        return 'bg-presence-online';
     }
   }
 

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
@@ -12,6 +12,15 @@ import {
 import { serverStorageKey } from '$lib/storage/serverStorage';
 import CurrentUserBarTestHarness from './CurrentUserBarTestHarness.svelte';
 
+function computedBackgroundColor(color: string): string {
+  const element = document.createElement('span');
+  element.style.backgroundColor = color;
+  document.body.append(element);
+  const computed = window.getComputedStyle(element).backgroundColor;
+  element.remove();
+  return computed;
+}
+
 type MockRoomMember = {
   id: string;
   login: string;
@@ -157,7 +166,7 @@ describe('CurrentUserBar', () => {
       container,
       '[data-testid="current-user-presence-menu"] [aria-label="Online"] span'
     )!;
-    expect(presenceDot.className).toContain('bg-green-500');
+    expect(presenceDot.className).toContain('bg-presence-online');
     expect(container.textContent).toContain('Alice');
     expect(container.textContent).toContain('@alice');
   });
@@ -187,6 +196,28 @@ describe('CurrentUserBar', () => {
       expect(q(container, '[data-testid="custom-status-editor"]')).toBeFalsy();
     });
     expect(q(container, '[data-testid="current-user-edit-status"]')).toBeFalsy();
+  });
+
+  it('renders the away presence menu dot in yellow', async () => {
+    const { container } = render(CurrentUserBarTestHarness);
+
+    (q(container, '[data-testid="current-user-presence-menu"]') as HTMLButtonElement).click();
+
+    await vi.waitFor(() => {
+      const awayOption = Array.from(container.querySelectorAll('[role="menuitemradio"]')).find(
+        (item) => item.textContent?.includes('Away')
+      )!;
+      const awayDot = awayOption.querySelector('.rounded-full')!;
+      const yellow500 = window
+        .getComputedStyle(document.documentElement)
+        .getPropertyValue('--color-yellow-500')
+        .trim();
+
+      expect(awayDot.className).toContain('bg-presence-away');
+      expect(window.getComputedStyle(awayDot).backgroundColor).toBe(
+        computedBackgroundColor(yellow500)
+      );
+    });
   });
 
   it('closes the presence menu after choosing a presence mode', async () => {

--- a/apps/frontend/src/lib/components/UserAvatar.svelte
+++ b/apps/frontend/src/lib/components/UserAvatar.svelte
@@ -32,10 +32,10 @@
   };
 
   const presenceDotColorClasses: Record<PresenceStatus, string> = {
-    [PresenceStatus.Online]: 'bg-green-500',
-    [PresenceStatus.Away]: 'bg-orange-500',
-    [PresenceStatus.DoNotDisturb]: 'bg-red-500',
-    [PresenceStatus.Offline]: 'bg-gray-500'
+    [PresenceStatus.Online]: 'bg-presence-online',
+    [PresenceStatus.Away]: 'bg-presence-away',
+    [PresenceStatus.DoNotDisturb]: 'bg-presence-do-not-disturb',
+    [PresenceStatus.Offline]: 'bg-presence-offline'
   };
 
   const presenceDotSizeClasses: Record<Size, string> = {

--- a/apps/frontend/src/lib/components/UserAvatar.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/UserAvatar.svelte.spec.ts
@@ -1,7 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import { render } from 'vitest-browser-svelte';
+import '../../app.css';
+import { PresenceStatus } from '$lib/render/types';
 import { q } from '$lib/test-utils';
 import UserAvatarTestHarness from './UserAvatarTestHarness.svelte';
+
+function computedBackgroundColor(color: string): string {
+  const element = document.createElement('span');
+  element.style.backgroundColor = color;
+  document.body.append(element);
+  const computed = window.getComputedStyle(element).backgroundColor;
+  element.remove();
+  return computed;
+}
 
 describe('UserAvatar', () => {
   it('renders medium avatars as circles without presence by default', () => {
@@ -32,14 +43,32 @@ describe('UserAvatar', () => {
     const { container } = render(UserAvatarTestHarness, { size: 'sm', showPresence: true });
     const presenceDot = q(container, '[aria-label="Online"] span')!;
 
-    expect(presenceDot.className).toContain('bg-green-500');
+    expect(presenceDot.className).toContain('bg-presence-online');
   });
 
   it('shows presence dots on medium avatars when explicitly requested', () => {
     const { container } = render(UserAvatarTestHarness, { size: 'md', showPresence: true });
     const presenceDot = q(container, '[aria-label="Online"] span')!;
 
-    expect(presenceDot.className).toContain('bg-green-500');
+    expect(presenceDot.className).toContain('bg-presence-online');
+  });
+
+  it('renders away presence dots in yellow', () => {
+    const { container } = render(UserAvatarTestHarness, {
+      size: 'md',
+      showPresence: true,
+      presenceStatus: PresenceStatus.Away
+    });
+    const presenceDot = q(container, '[aria-label="Away"] span')!;
+    const yellow500 = window
+      .getComputedStyle(document.documentElement)
+      .getPropertyValue('--color-yellow-500')
+      .trim();
+
+    expect(presenceDot.className).toContain('bg-presence-away');
+    expect(window.getComputedStyle(presenceDot).backgroundColor).toBe(
+      computedBackgroundColor(yellow500)
+    );
   });
 
   it('keeps extra-small avatars free of presence overlays', () => {

--- a/apps/frontend/src/lib/components/UserAvatarTestHarness.svelte
+++ b/apps/frontend/src/lib/components/UserAvatarTestHarness.svelte
@@ -9,26 +9,28 @@
   let {
     size = 'md',
     showPresence = false,
-    showStatus = false
+    showStatus = false,
+    presenceStatus = PresenceStatus.Online
   }: {
     size?: Size;
     showPresence?: boolean;
     showStatus?: boolean;
+    presenceStatus?: PresenceStatus;
   } = $props();
 
-  const user: UserAvatarUserView = {
+  const user = $derived({
     id: 'user-1',
     login: 'alice',
     displayName: 'Alice',
     deleted: false,
     avatarUrl: null,
-    presenceStatus: PresenceStatus.Online,
+    presenceStatus,
     customStatus: {
       emoji: '🍜',
       text: 'chatto:status:out_for_lunch',
       expiresAt: null
     }
-  };
+  } satisfies UserAvatarUserView);
 
   createUserProfileCache();
   createPresenceCache();


### PR DESCRIPTION
## Summary

Adds semantic Tailwind presence color tokens and uses them for avatar dots and the current-user presence menu.
This also changes away indicators from orange to yellow while keeping online, DND, offline, and invisible colors centralized.
Updates component and e2e assertions to check the semantic classes and adds coverage that away dots resolve to the yellow token.

## Tests

- `mise x -- pnpm --dir apps/frontend exec vitest --run src/lib/components/UserAvatar.svelte.spec.ts src/lib/components/CurrentUserBar.svelte.spec.ts`
