### PR TITLE
feat(frontend): refresh toast styling

### DIFF
--- a/apps/frontend/src/lib/ui/toast/Toast.stories.svelte
+++ b/apps/frontend/src/lib/ui/toast/Toast.stories.svelte
@@ -1,0 +1,48 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import Toast from './Toast.svelte';
+
+  const componentDescription = `
+    Transient toast notifications use the same compact menu shell as context menus and popups,
+    while preserving tone-specific icons and optional single-action affordances.
+  `.trim();
+
+  const { Story } = defineMeta({
+    title: 'UI/Toast',
+    component: Toast,
+    tags: ['autodocs'],
+    parameters: {
+      docs: {
+        description: { component: componentDescription }
+      }
+    }
+  });
+</script>
+
+<script lang="ts">
+  const dismiss = () => {};
+</script>
+
+<Story name="Tones" asChild>
+  <div
+    class="flex min-h-72 flex-col items-end justify-end gap-2 rounded-lg border border-border bg-background p-6"
+  >
+    <Toast tone="success" message="Profile settings saved" onDismiss={dismiss} />
+    <Toast tone="info" message="Connecting to the server..." onDismiss={dismiss} />
+    <Toast tone="warning" message="Some changes could not be applied" onDismiss={dismiss} />
+    <Toast tone="error" message="Failed to send message" onDismiss={dismiss} />
+  </div>
+</Story>
+
+<Story name="Action" asChild>
+  <div
+    class="flex min-h-40 items-end justify-end rounded-lg border border-border bg-background p-6"
+  >
+    <Toast
+      tone="info"
+      message="A new version is available"
+      action={{ label: 'Reload', onClick: () => {} }}
+      onDismiss={dismiss}
+    />
+  </div>
+</Story>

--- a/apps/frontend/src/lib/ui/toast/Toast.svelte
+++ b/apps/frontend/src/lib/ui/toast/Toast.svelte
@@ -15,17 +15,17 @@
   } = $props();
 
   const icons: Record<ToastTone, string> = {
-    error: 'iconify mdi--alert-circle',
-    success: 'iconify mdi--check-circle',
-    info: 'iconify mdi--information',
-    warning: 'iconify mdi--alert'
+    error: 'uil--times-circle',
+    success: 'uil--check-circle',
+    info: 'uil--info-circle',
+    warning: 'uil--exclamation-triangle'
   };
 
   const iconColors: Record<ToastTone, string> = {
-    error: 'text-red-500',
-    success: 'text-green-500',
-    info: 'text-blue-500',
-    warning: 'text-amber-500'
+    error: 'text-error',
+    success: 'text-success',
+    info: 'text-accent',
+    warning: 'text-warning'
   };
 
   function handleActionClick(e: MouseEvent) {
@@ -44,19 +44,21 @@
 
 <!-- Using div instead of button to allow nesting the action button (nested buttons are invalid HTML) -->
 <div
-  class="flex max-w-96 min-w-64 cursor-pointer items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3 text-left shadow-lg transition-colors hover:bg-surface-highlighted"
+  class="flex w-full max-w-96 min-w-0 cursor-pointer items-center gap-3 rounded-lg border border-text/10 bg-surface-100 px-3 py-2.5 text-left text-sm text-text shadow-xl transition-[background-color,scale] hover:bg-surface-200 active:scale-[0.99] sm:min-w-64"
   onclick={onDismiss}
   onkeydown={handleKeyDown}
   role="button"
   tabindex="0"
   aria-label={m['ui.toast.dismiss']()}
 >
-  <span class="{icons[tone]} {iconColors[tone]} size-5 shrink-0"></span>
-  <span class="flex-1 text-sm text-text">{message}</span>
+  <span class="flex size-6 shrink-0 items-center justify-center rounded bg-background">
+    <span class={['iconify size-4', icons[tone], iconColors[tone]]} aria-hidden="true"></span>
+  </span>
+  <span class="min-w-0 flex-1 leading-snug break-words">{message}</span>
   {#if action}
     <button
       type="button"
-      class="shrink-0 cursor-pointer rounded bg-primary px-3 py-1 text-xs font-medium text-white hover:bg-primary/80"
+      class="btn-secondary h-8 min-h-0 min-w-0 shrink-0 !rounded-md !px-3 !py-1 text-xs"
       onclick={handleActionClick}
     >
       {action.label}

--- a/apps/frontend/src/lib/ui/toast/Toast.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/toast/Toast.svelte.spec.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import Toast from './Toast.svelte';
+import type { ToastTone } from './toastState.svelte';
+
+function toastButton(container: Element): HTMLElement {
+  const button = container.querySelector('[role="button"]') as HTMLElement | null;
+  if (!button) throw new Error('Toast button not found');
+  return button;
+}
+
+function actionButton(container: Element, label: string): HTMLButtonElement {
+  const button = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+    (candidate) => candidate.textContent?.trim() === label
+  );
+  if (!button) throw new Error(`Action button "${label}" not found`);
+  return button;
+}
+
+describe('Toast', () => {
+  it.each([
+    ['error', 'text-error'],
+    ['success', 'text-success'],
+    ['info', 'text-accent'],
+    ['warning', 'text-warning']
+  ] satisfies Array<[ToastTone, string]>)('renders %s with semantic tone color', (tone, color) => {
+    const { container } = render(Toast, {
+      props: {
+        tone,
+        message: `${tone} message`,
+        onDismiss: vi.fn()
+      }
+    });
+
+    const icon = container.querySelector('.iconify');
+    expect(icon).not.toBeNull();
+    expect(icon?.classList.contains(color)).toBe(true);
+    expect(toastButton(container).classList.contains('bg-surface-100')).toBe(true);
+    expect(toastButton(container).classList.contains('border-text/10')).toBe(true);
+  });
+
+  it('renders message and compact action styling', async () => {
+    const onClick = vi.fn();
+    const { container } = render(Toast, {
+      props: {
+        tone: 'info',
+        message: 'A new version is available',
+        action: { label: 'Reload', onClick },
+        onDismiss: vi.fn()
+      }
+    });
+
+    await expect.element(toastButton(container)).toHaveTextContent('A new version is available');
+    await expect.element(actionButton(container, 'Reload')).toHaveClass('btn-secondary');
+    await expect.element(actionButton(container, 'Reload')).toHaveClass('h-8');
+  });
+
+  it('dismisses when clicked', () => {
+    const onDismiss = vi.fn();
+    const { container } = render(Toast, {
+      props: {
+        tone: 'success',
+        message: 'Saved',
+        onDismiss
+      }
+    });
+
+    toastButton(container).click();
+
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it('dismisses from keyboard activation', () => {
+    const onDismiss = vi.fn();
+    const { container } = render(Toast, {
+      props: {
+        tone: 'warning',
+        message: 'Check your input',
+        onDismiss
+      }
+    });
+
+    toastButton(container).dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    toastButton(container).dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+
+    expect(onDismiss).toHaveBeenCalledTimes(2);
+  });
+
+  it('runs action and dismisses once when action is clicked', () => {
+    const onClick = vi.fn();
+    const onDismiss = vi.fn();
+    const { container } = render(Toast, {
+      props: {
+        tone: 'info',
+        message: 'A new version is available',
+        action: { label: 'Reload', onClick },
+        onDismiss
+      }
+    });
+
+    actionButton(container, 'Reload').click();
+
+    expect(onClick).toHaveBeenCalledOnce();
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/frontend/src/lib/ui/toast/ToastContainer.svelte
+++ b/apps/frontend/src/lib/ui/toast/ToastContainer.svelte
@@ -12,7 +12,7 @@
   announced, just at the next natural break.
 -->
 <div
-  class="fixed right-4 bottom-4 z-50 flex flex-col gap-2 pointer-events-none"
+  class="pointer-events-none fixed right-3 bottom-[calc(env(safe-area-inset-bottom,0px)+0.75rem)] left-3 z-50 flex flex-col items-stretch gap-2 sm:right-4 sm:bottom-[calc(env(safe-area-inset-bottom,0px)+1rem)] sm:left-auto sm:items-end"
   role="status"
   aria-live="polite"
   aria-atomic="false"
@@ -31,17 +31,33 @@
 
 <style>
   .toast-enter {
-    animation: slide-in 150ms ease-out;
+    animation: toast-in 160ms cubic-bezier(0.2, 0, 0, 1);
+    transform-origin: right bottom;
   }
 
-  @keyframes slide-in {
+  @keyframes toast-in {
     from {
       opacity: 0;
-      transform: translateX(100%);
+      transform: translate3d(0.5rem, 0.25rem, 0) scale(0.98);
     }
     to {
       opacity: 1;
-      transform: translateX(0);
+      transform: translate3d(0, 0, 0) scale(1);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .toast-enter {
+      animation: toast-fade-in 120ms ease-out;
+    }
+
+    @keyframes toast-fade-in {
+      from {
+        opacity: 0;
+      }
+      to {
+        opacity: 1;
+      }
     }
   }
 </style>


### PR DESCRIPTION
Refreshes transient toast styling to match the app's menu/popover surface language with semantic tone icons, balanced padding, compact action buttons, and safer mobile/safe-area positioning.

Adds Storybook coverage for toast tones/actions and browser component coverage for tone rendering, dismiss behavior, keyboard activation, and action handling.

Validated with `mise run lint-frontend`, `mise test-frontend`, targeted `mise x -- pnpm vitest --run src/lib/ui/toast`, Svelte autofixer, and Storybook visual checks in light/dark desktop/mobile states.
