### PR TITLE
fix(frontend): make attachment remove control subtle

### DIFF
--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -346,6 +346,24 @@
   @apply absolute top-1 right-1 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full bg-black/60 text-white shadow-md ring-1 ring-white/30 transition-[background-color,opacity,scale] hover:bg-black/80 active:scale-[0.96] md:opacity-0;
 }
 
+@utility attachment-remove-button {
+  @apply absolute top-1 right-1 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full text-white/90 outline-none transition-[opacity,scale] active:scale-[0.96] focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:ring-offset-background md:opacity-0;
+
+  &::before {
+    content: '';
+    @apply absolute h-7 w-7 rounded-full bg-black/45 shadow-sm ring-1 ring-white/25 transition-[background-color];
+  }
+
+  &:hover::before,
+  &:focus-visible::before {
+    @apply bg-black/65;
+  }
+
+  & > .iconify {
+    @apply relative z-10 text-sm;
+  }
+}
+
 /* Skeleton loading utility */
 @utility skeleton {
   @apply relative overflow-hidden opacity-30;

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
@@ -452,7 +452,7 @@
           onkeydown={(e) => {
             if (e.key === 'Enter' || e.key === ' ') openDeleteConfirmation(attachment, e);
           }}
-          class="embed-control-button md:group-hover/attachment:opacity-100"
+          class="attachment-remove-button md:group-hover/attachment:opacity-100"
           aria-label={m['room.attachment.delete_label']()}
           title={m['room.attachment.delete_label']()}
         >
@@ -480,7 +480,7 @@
           <button
             type="button"
             onclick={(e) => openDeleteConfirmation(attachment, e)}
-            class="embed-control-button md:group-hover/attachment:opacity-100"
+            class="attachment-remove-button md:group-hover/attachment:opacity-100"
             aria-label={m['room.attachment.delete_label']()}
             title={m['room.attachment.delete_label']()}
           >
@@ -506,7 +506,7 @@
           <button
             type="button"
             onclick={(e) => openDeleteConfirmation(attachment, e)}
-            class="embed-control-button z-10 md:group-hover/attachment:opacity-100"
+            class="attachment-remove-button z-10 md:group-hover/attachment:opacity-100"
             aria-label={m['room.attachment.delete_label']()}
             title={m['room.attachment.delete_label']()}
           >
@@ -551,7 +551,7 @@
           <button
             type="button"
             onclick={(e) => openDeleteConfirmation(attachment, e)}
-            class="embed-control-button md:group-hover/attachment:opacity-100"
+            class="attachment-remove-button md:group-hover/attachment:opacity-100"
             aria-label={m['room.attachment.delete_label']()}
             title={m['room.attachment.delete_label']()}
           >
@@ -589,7 +589,7 @@
           <button
             type="button"
             onclick={(e) => openDeleteConfirmation(attachment, e)}
-            class="embed-control-button md:group-hover/attachment:opacity-100"
+            class="attachment-remove-button md:group-hover/attachment:opacity-100"
             aria-label={m['room.attachment.delete_label']()}
             title={m['room.attachment.delete_label']()}
           >

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
@@ -62,19 +62,26 @@ function fileAttachment(overrides: Partial<MessageAttachmentView>): MessageAttac
   };
 }
 
-function renderAttachments(attachments: MessageAttachmentView[]) {
+function renderAttachments(
+  attachments: MessageAttachmentView[],
+  options: { canDeleteAttachment?: boolean } = {}
+) {
   return render(MessageAttachments, {
     props: {
       attachments,
       serverId: 'server_1',
       roomId: 'room_1',
-      eventId: 'event_1'
+      eventId: 'event_1',
+      ...options
     }
   });
 }
 
-function renderAttachment(attachment: MessageAttachmentView) {
-  return renderAttachments([attachment]);
+function renderAttachment(
+  attachment: MessageAttachmentView,
+  options: { canDeleteAttachment?: boolean } = {}
+) {
+  return renderAttachments([attachment], options);
 }
 
 function imageFrame(container: HTMLElement, filename: string) {
@@ -140,6 +147,24 @@ describe('MessageAttachments', () => {
     expect(image.className).toContain('object-cover');
     expect(image.className).toContain('h-full');
     expect(image.className).toContain('w-full');
+  });
+
+  it('uses a subtle attachment remove control when deletion is allowed', () => {
+    const { container } = renderAttachment(
+      imageAttachment({
+        filename: 'delete-me.jpg'
+      }),
+      { canDeleteAttachment: true }
+    );
+
+    const deleteControl = container.querySelector<HTMLElement>(
+      '[aria-label="Delete attachment"]'
+    );
+
+    expect(deleteControl).not.toBeNull();
+    expect(deleteControl!.getAttribute('title')).toBe('Delete attachment');
+    expect(deleteControl!.className).toContain('attachment-remove-button');
+    expect(deleteControl!.className).not.toContain('embed-control-button');
   });
 
   it('renders multiple images inside a horizontal gallery with equal-height frames', () => {


### PR DESCRIPTION
## Summary
- Adds an attachment-specific remove button utility with a smaller visible circle while keeping a 40x40 hit target.
- Applies it only to posted message attachment delete controls, leaving other embed controls unchanged.
- Adds component coverage for the delete control class and accessible label/title.

## Validation
- Svelte autofixer reported no new component issues.
- `mise x -- pnpm --filter @chatto/api-types build`
- `mise x -- pnpm -C apps/frontend exec vitest --run 'src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts'`
- `git diff --check`
