### PR TITLE
fix(frontend): polish error and missing media states

### DIFF
--- a/apps/frontend/messages/de/error_page.json
+++ b/apps/frontend/messages/de/error_page.json
@@ -2,8 +2,10 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "error_page": {
     "title": "Etwas ist schiefgelaufen",
-    "description": "Beim Rendern dieser Seite ist ein unerwarteter Fehler aufgetreten.",
+    "description": "Diese Ansicht konnte nicht geöffnet werden. Du kannst zu Chatto zurückkehren und es dort erneut versuchen.",
     "unknown": "Unbekannter Fehler",
-    "home_link": "Zurück zur Startseite"
+    "home_link": "Zurück zu Chatto",
+    "missing_media_title": "Medium nicht verfügbar",
+    "missing_media_description": "Diese Datei konnte über diesen Link nicht geöffnet werden. Sie wurde möglicherweise entfernt oder der private Medienlink ist nicht mehr verfügbar."
   }
 }

--- a/apps/frontend/messages/en/error_page.json
+++ b/apps/frontend/messages/en/error_page.json
@@ -2,8 +2,10 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "error_page": {
     "title": "Something went wrong",
-    "description": "An unexpected error occurred while rendering this page.",
+    "description": "This view could not be opened. You can return to Chatto and try again from there.",
     "unknown": "Unknown error",
-    "home_link": "Go back to the home page"
+    "home_link": "Back to Chatto",
+    "missing_media_title": "Media unavailable",
+    "missing_media_description": "This file could not be opened from this link. It may have been removed, or the private media link is no longer available."
   }
 }

--- a/apps/frontend/src/lib/i18n/messages.ts
+++ b/apps/frontend/src/lib/i18n/messages.ts
@@ -492,6 +492,8 @@ const msg_error_page_title = (): LocalizedString => messages().error_page_title(
 const msg_error_page_description = (): LocalizedString => messages().error_page_description(empty());
 const msg_error_page_unknown = (): LocalizedString => messages().error_page_unknown(empty());
 const msg_error_page_home_link = (): LocalizedString => messages().error_page_home_link(empty());
+const msg_error_page_missing_media_title = (): LocalizedString => messages().error_page_missing_media_title(empty());
+const msg_error_page_missing_media_description = (): LocalizedString => messages().error_page_missing_media_description(empty());
 const msg_chat_notifications_title = (): LocalizedString => messages().chat_notifications_title(empty());
 const msg_chat_notifications_subtitle = (): LocalizedString => messages().chat_notifications_subtitle(empty());
 const msg_chat_notifications_clear_all = (): LocalizedString => messages().chat_notifications_clear_all(empty());
@@ -1845,6 +1847,8 @@ export { msg_error_page_title as 'error_page.title' };
 export { msg_error_page_description as 'error_page.description' };
 export { msg_error_page_unknown as 'error_page.unknown' };
 export { msg_error_page_home_link as 'error_page.home_link' };
+export { msg_error_page_missing_media_title as 'error_page.missing_media_title' };
+export { msg_error_page_missing_media_description as 'error_page.missing_media_description' };
 export { msg_chat_notifications_title as 'chat.notifications.title' };
 export { msg_chat_notifications_subtitle as 'chat.notifications.subtitle' };
 export { msg_chat_notifications_clear_all as 'chat.notifications.clear_all' };

--- a/apps/frontend/src/lib/pwa/assetProxy.worker.test.ts
+++ b/apps/frontend/src/lib/pwa/assetProxy.worker.test.ts
@@ -86,6 +86,18 @@ async function fetchVirtualAsset(): Promise<Response> {
   return handleAssetProxyFetch(new Request(VIRTUAL_URL), proxyRequest!);
 }
 
+function navigationRequest(url = VIRTUAL_URL): Request {
+  const request = new Request(url);
+  Object.defineProperty(request, 'mode', { value: 'navigate' });
+  return request;
+}
+
+function navigationFallbackResponse(): Response {
+  return new Response('<!doctype html><title>Chatto</title>', {
+    headers: { 'Content-Type': 'text/html' }
+  });
+}
+
 describe('service worker asset proxy fetch', () => {
   beforeEach(() => {
     stubCacheStorage();
@@ -114,6 +126,21 @@ describe('service worker asset proxy fetch', () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it('falls back to the app shell for navigation to an unresolved virtual asset', async () => {
+    vi.stubGlobal('fetch', vi.fn());
+    const proxyRequest = parseAssetProxyRequest(VIRTUAL_URL, ORIGIN);
+    expect(proxyRequest).not.toBeNull();
+
+    const response = await handleAssetProxyFetch(navigationRequest(), proxyRequest!, {
+      navigationFallback: async () => navigationFallbackResponse()
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('text/html');
+    await expect(response.text()).resolves.toContain('<title>Chatto</title>');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it('proxies registered asset targets without attaching bearer Authorization or caching', async () => {
     await syncServer();
     await registerTarget('https://remote.example/assets/files/asset-1?access=ticket-a');
@@ -137,6 +164,51 @@ describe('service worker asset proxy fetch', () => {
       'asset bytes'
     );
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps direct navigation to a valid virtual asset on the asset response', async () => {
+    await syncServer();
+    await registerTarget('https://remote.example/assets/files/asset-1?access=ticket-a');
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        return new Response('asset bytes', {
+          status: 200,
+          headers: { 'Content-Type': 'image/png', 'Cache-Control': 'private, no-store' }
+        });
+      })
+    );
+
+    const proxyRequest = parseAssetProxyRequest(VIRTUAL_URL, ORIGIN);
+    expect(proxyRequest).not.toBeNull();
+    const response = await handleAssetProxyFetch(navigationRequest(), proxyRequest!, {
+      navigationFallback: async () => navigationFallbackResponse()
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('image/png');
+    await expect(response.text()).resolves.toBe('asset bytes');
+  });
+
+  it('falls back to the app shell for navigation when the target asset returns an error', async () => {
+    await syncServer();
+    await registerTarget('https://remote.example/assets/files/asset-1?access=ticket-a');
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('missing', { status: 404 }))
+    );
+
+    const proxyRequest = parseAssetProxyRequest(VIRTUAL_URL, ORIGIN);
+    expect(proxyRequest).not.toBeNull();
+    const response = await handleAssetProxyFetch(navigationRequest(), proxyRequest!, {
+      navigationFallback: async () => navigationFallbackResponse()
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('text/html');
+    await expect(response.text()).resolves.toContain('<title>Chatto</title>');
   });
 
   it('uses the refreshed registered target URL for later fetches', async () => {

--- a/apps/frontend/src/lib/pwa/assetProxy.worker.ts
+++ b/apps/frontend/src/lib/pwa/assetProxy.worker.ts
@@ -20,6 +20,10 @@ export type AssetProxyRequest = {
   assetPath: string;
 };
 
+type AssetProxyFetchOptions = {
+  navigationFallback?: () => Promise<Response | undefined>;
+};
+
 export function handleAssetProxyMessage(event: ExtendableMessageEvent): boolean {
   const message = event.data as Record<string, unknown> | undefined;
   if (!message || typeof message.type !== 'string') return false;
@@ -78,10 +82,11 @@ export function parseAssetProxyRequest(
 
 export async function handleAssetProxyFetch(
   request: Request,
-  proxyRequest: AssetProxyRequest
+  proxyRequest: AssetProxyRequest,
+  options: AssetProxyFetchOptions = {}
 ): Promise<Response> {
   if (request.method !== 'GET') {
-    return new Response('Method not allowed', { status: 405 });
+    return assetProxyErrorResponse(request, options, 'Method not allowed', 405);
   }
 
   let server = assetProxyServers.get(proxyRequest.serverId);
@@ -92,13 +97,13 @@ export async function handleAssetProxyFetch(
     registered = matchingRegisteredAssetTarget(proxyRequest);
   }
   if (!server) {
-    return new Response('Asset target is not registered', { status: 404 });
+    return assetProxyErrorResponse(request, options, 'Asset target is not registered', 404);
   }
 
   const targetUrl =
     registered?.targetUrl ?? buildFallbackAssetTarget(server, proxyRequest.assetPath);
   if (!targetUrl) {
-    return new Response('Asset target is not registered', { status: 404 });
+    return assetProxyErrorResponse(request, options, 'Asset target is not registered', 404);
   }
 
   const rangeHeader = request.headers.get('Range');
@@ -109,11 +114,22 @@ export async function handleAssetProxyFetch(
   const headers = new Headers();
   headers.set('X-Chatto-Asset-Proxy', '1');
 
-  const networkResponse = await fetch(targetUrl, {
-    headers,
-    credentials: sameOrigin(targetUrl, self.location.origin) ? 'include' : 'omit',
-    redirect: 'follow'
-  });
+  let networkResponse: Response;
+  try {
+    networkResponse = await fetch(targetUrl, {
+      headers,
+      credentials: sameOrigin(targetUrl, self.location.origin) ? 'include' : 'omit',
+      redirect: 'follow'
+    });
+  } catch {
+    return assetProxyErrorResponse(request, options, 'Asset target is not available', 502);
+  }
+
+  if (request.mode === 'navigate' && !networkResponse.ok) {
+    const fallback = await options.navigationFallback?.();
+    if (fallback) return fallback;
+  }
+
   return new Response(networkResponse.body, {
     status: networkResponse.status,
     statusText: networkResponse.statusText,
@@ -121,13 +137,23 @@ export async function handleAssetProxyFetch(
   });
 }
 
+async function assetProxyErrorResponse(
+  request: Request,
+  options: AssetProxyFetchOptions,
+  message: string,
+  status: number
+): Promise<Response> {
+  if (request.mode === 'navigate') {
+    const fallback = await options.navigationFallback?.();
+    if (fallback) return fallback;
+  }
+  return new Response(message, { status });
+}
+
 function isAssetProxyServerMessage(value: unknown): value is AssetProxyServer {
   if (!value || typeof value !== 'object') return false;
   const server = value as Partial<AssetProxyServer>;
-  return (
-    typeof server.id === 'string' &&
-    typeof server.url === 'string'
-  );
+  return typeof server.id === 'string' && typeof server.url === 'string';
 }
 
 function isAssetProxyTargetMessage(value: unknown): value is AssetProxyTarget {
@@ -159,7 +185,9 @@ function registerAssetProxyTarget(target: AssetProxyTarget): void {
   registeredAssetTargets.set(target.virtualPath, target);
 }
 
-function matchingRegisteredAssetTarget(proxyRequest: AssetProxyRequest): AssetProxyTarget | undefined {
+function matchingRegisteredAssetTarget(
+  proxyRequest: AssetProxyRequest
+): AssetProxyTarget | undefined {
   const registered = registeredAssetTargets.get(proxyRequest.virtualPath);
   if (registered?.serverId !== proxyRequest.serverId) return undefined;
   return registered;

--- a/apps/frontend/src/lib/ui/AppHeader.svelte
+++ b/apps/frontend/src/lib/ui/AppHeader.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { pushState } from '$app/navigation';
-  import { resolve } from '$app/paths';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { serverConnectionManager } from '$lib/state/server/serverConnection.svelte';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
@@ -48,7 +47,7 @@
 
     <!-- Notification bell - 44px tap target for mobile accessibility -->
     <a
-      href={resolve('/chat/notifications')}
+      href="/chat/notifications"
       aria-label={m['ui.notifications']()}
       title={m['ui.notifications']()}
       class="relative app-header-icon"

--- a/apps/frontend/src/lib/ui/AppHeader.svelte
+++ b/apps/frontend/src/lib/ui/AppHeader.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { pushState } from '$app/navigation';
+  import { resolve } from '$app/paths';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { serverConnectionManager } from '$lib/state/server/serverConnection.svelte';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
@@ -47,7 +48,7 @@
 
     <!-- Notification bell - 44px tap target for mobile accessibility -->
     <a
-      href="/chat/notifications"
+      href={resolve('/chat/notifications')}
       aria-label={m['ui.notifications']()}
       title={m['ui.notifications']()}
       class="relative app-header-icon"

--- a/apps/frontend/src/routes/+error.svelte
+++ b/apps/frontend/src/routes/+error.svelte
@@ -1,24 +1,36 @@
 <script lang="ts">
-  import { resolve } from '$app/paths';
   import { page } from '$app/state';
-  import { dev } from '$app/environment';
   import * as m from '$lib/i18n/messages';
-  import EmptyState from '$lib/ui/EmptyState.svelte';
+  import { Button } from '$lib/ui/form';
 
-  const status = $derived(page.status);
-  const message = $derived(page.error?.message ?? m['error_page.unknown']());
+  const isMissingMedia = $derived(page.url.pathname.startsWith('/__chatto/assets/'));
+  const icon = $derived(isMissingMedia ? 'uil--image-slash' : 'uil--exclamation-triangle');
+  const title = $derived(
+    isMissingMedia ? m['error_page.missing_media_title']() : m['error_page.title']()
+  );
+  const description = $derived(
+    isMissingMedia ? m['error_page.missing_media_description']() : m['error_page.description']()
+  );
 </script>
 
-<div class="flex h-full flex-col">
-  <EmptyState icon="uil--exclamation-triangle" title={m['error_page.title']()}>
-    <p>{m['error_page.description']()}</p>
-    {#if dev}
-      <pre
-        class="mt-3 max-w-xl overflow-auto rounded-md bg-surface-200 p-3 text-left text-xs">Status: {status}
-{message}</pre>
-    {/if}
-    <p class="mt-4">
-      <a class="underline" href={resolve('/')}>{m['error_page.home_link']()}</a>
-    </p>
-  </EmptyState>
+<div class="flex min-h-full flex-1 items-center justify-center px-6 py-12 text-center">
+  <section class="flex max-w-md flex-col items-center gap-5" aria-labelledby="error-page-title">
+    <div
+      class="flex h-14 w-14 items-center justify-center rounded-2xl bg-surface-100 text-muted ring-1 ring-text/5"
+      aria-hidden="true"
+    >
+      <span class={['iconify text-3xl', icon]}></span>
+    </div>
+
+    <div class="flex flex-col gap-2">
+      <h1 id="error-page-title" class="text-xl font-semibold text-balance text-text-top">
+        {title}
+      </h1>
+      <p class="leading-7 text-pretty text-muted">
+        {description}
+      </p>
+    </div>
+
+    <Button href="/" variant="secondary">{m['error_page.home_link']()}</Button>
+  </section>
 </div>

--- a/apps/frontend/src/routes/__chatto/assets/[serverId]/[...assetPath]/+page.svelte
+++ b/apps/frontend/src/routes/__chatto/assets/[serverId]/[...assetPath]/+page.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import * as m from '$lib/i18n/messages';
+  import { Button } from '$lib/ui/form';
+</script>
+
+<div class="flex min-h-full flex-1 items-center justify-center px-6 py-12 text-center">
+  <section class="flex max-w-md flex-col items-center gap-5" aria-labelledby="missing-media-title">
+    <div
+      class="flex h-14 w-14 items-center justify-center rounded-2xl bg-surface-100 text-muted ring-1 ring-text/5"
+      aria-hidden="true"
+    >
+      <span class="iconify text-3xl uil--image-slash"></span>
+    </div>
+
+    <div class="flex flex-col gap-2">
+      <h1 id="missing-media-title" class="text-xl font-semibold text-balance text-text-top">
+        {m['error_page.missing_media_title']()}
+      </h1>
+      <p class="leading-7 text-pretty text-muted">
+        {m['error_page.missing_media_description']()}
+      </p>
+    </div>
+
+    <Button href="/" variant="secondary">{m['error_page.home_link']()}</Button>
+  </section>
+</div>

--- a/apps/frontend/src/service-worker.ts
+++ b/apps/frontend/src/service-worker.ts
@@ -88,7 +88,14 @@ self.addEventListener('message', (event) => {
 self.addEventListener('fetch', (event) => {
   const assetProxyRequest = parseAssetProxyRequest(event.request.url, self.location.origin);
   if (assetProxyRequest) {
-    event.respondWith(handleAssetProxyFetch(event.request, assetProxyRequest));
+    event.respondWith(
+      handleAssetProxyFetch(event.request, assetProxyRequest, {
+        navigationFallback: async () => {
+          const cache = await caches.open(CACHE_NAME);
+          return getCachedOfflineShell(cache);
+        }
+      })
+    );
     return;
   }
 


### PR DESCRIPTION
## Summary

Polishes the global frontend error state and adds a dedicated missing-media state for direct `/__chatto/assets/...` visits.
Asset proxy navigation failures now fall back to the app shell while normal embedded media fetch behavior is preserved.

## Verification

- `mise x -- pnpm --filter chatto-frontend exec vitest --run src/lib/pwa/assetProxy.worker.test.ts`
- `mise x -- pnpm run check:frontend`
- `mise x -- pnpm run lint:frontend`
- Chrome DevTools MCP visual checks for desktop/mobile generic error and missing-media routes
