### PR TITLE
fix(frontend): restore default text smoothing

### DIFF
--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -71,6 +71,9 @@ generated protobuf clients, Vitest browser tests, Playwright e2e, and Storybook.
 - Use Tailwind 4 utilities and established components; avoid one-off CSS.
 - Svelte files use tabs; match local style.
 - Use base text size by default. Reserve smaller text for metadata.
+- Use browser/platform default text rendering. Do not apply global font
+  smoothing such as Tailwind `antialiased`, `-webkit-font-smoothing`, or
+  `-moz-osx-font-smoothing`.
 - Clickable controls need `cursor-pointer`.
 - Do not use `{@html}` directly in feature components. Render trusted markdown
   HTML through `$lib/ui/MarkdownHtml.svelte`, which is the reviewed exception.

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -543,8 +543,6 @@
   html {
     height: 100%;
     overflow: hidden;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
     /* pan-y lets the browser own vertical scroll while reserving horizontal
        pans for our own gesture handling (mobile sidebar swipe). It also
        implicitly disables pinch-zoom and double-tap-zoom — same as the


### PR DESCRIPTION
Restores Chatto’s default browser/platform text rendering by removing the global font-smoothing CSS from the frontend root.
Adds frontend agent guidance so future UI polish work does not reintroduce Tailwind `antialiased`, `-webkit-font-smoothing`, or `-moz-osx-font-smoothing` globally.
Validated with `mise test-frontend`; also checked the rendered login page in headless Playwright and confirmed computed font smoothing is back to `auto`/unset.
