### PR TITLE
fix(frontend): handle API auth failures gracefully

### DIFF
--- a/apps/frontend/messages/de/ui.json
+++ b/apps/frontend/messages/de/ui.json
@@ -10,6 +10,16 @@
     "reload": "Neu laden",
     "sign_out": "Abmelden",
     "close": "Schließen",
+    "auth_status": {
+      "origin_title": "Sitzung abgelaufen",
+      "origin_message": "Du kannst bereits geladene Inhalte weiter lesen. Melde dich erneut an, um Nachrichten zu senden und Daten zu aktualisieren.",
+      "origin_action": "Erneut anmelden",
+      "remote_title": "{server} benötigt eine Anmeldung",
+      "remote_message": "Dieser Server hat die gespeicherte Anmeldung abgelehnt. Verbinde ihn erneut, um Live-Aktualisierungen und Aktionen fortzusetzen.",
+      "remote_action": "Neu verbinden",
+      "remote_failed": "Neuverbinden konnte nicht gestartet werden",
+      "sidebar_reauth": "{server} benötigt eine Anmeldung"
+    },
     "access_denied": {
       "title": "Zugriff verweigert",
       "message": "Du hast keine Berechtigung, diese Seite aufzurufen.",

--- a/apps/frontend/messages/en/ui.json
+++ b/apps/frontend/messages/en/ui.json
@@ -10,6 +10,16 @@
     "reload": "Reload",
     "sign_out": "Sign out",
     "close": "Close",
+    "auth_status": {
+      "origin_title": "Session expired",
+      "origin_message": "You can keep reading what is already loaded. Sign in again to send messages and refresh data.",
+      "origin_action": "Sign in again",
+      "remote_title": "{server} needs sign-in",
+      "remote_message": "This server rejected the stored sign-in. Reconnect it to resume live updates and actions.",
+      "remote_action": "Reconnect",
+      "remote_failed": "Failed to start reconnect",
+      "sidebar_reauth": "{server} needs sign-in"
+    },
     "access_denied": {
       "title": "Access Denied",
       "message": "You do not have permission to access this page.",

--- a/apps/frontend/src/lib/ServerGutter.svelte
+++ b/apps/frontend/src/lib/ServerGutter.svelte
@@ -42,7 +42,7 @@ is connected to, plus the add-server button pinned to the bottom. See the
     <div class="flex flex-col gap-2 p-2 max-md:pl-3">
       {#each serverRegistry.servers as server (server.id)}
         {@const store = serverRegistry.tryGetStore(server.id)}
-        {#if store?.isAuthenticated}
+        {#if store && (store.isAuthenticated || server.reauthRequiredAt != null)}
           <ServerSidebarEntry serverId={server.id} currentUserId={store.currentUser.user?.id} />
         {/if}
       {/each}

--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte
@@ -14,6 +14,7 @@
   import { appState } from '$lib/state/globals.svelte';
   import ServerIcon from './ServerIcon.svelte';
   import { useTabResumeCallback } from '$lib/hooks';
+  import * as m from '$lib/i18n/messages';
 
   let {
     serverId,
@@ -64,9 +65,14 @@
       logoUrl: loaded ? logoUrl : (stores.serverInfo.iconUrl ?? registeredServer?.iconUrl)
     };
   });
-  const iconDimmed = $derived(!loaded || serverConnection.showConnectionLostIcon);
+  const needsReauth = $derived(registeredServer?.reauthRequiredAt != null);
+  const iconDimmed = $derived(!loaded || serverConnection.showConnectionLostIcon || needsReauth);
   const iconTitle = $derived(
-    iconDimmed ? `${iconServer.name} (connection unavailable)` : iconServer.name
+    needsReauth
+      ? m['ui.auth_status.sidebar_reauth']({ server: iconServer.name })
+      : iconDimmed
+        ? `${iconServer.name} (connection unavailable)`
+        : iconServer.name
   );
 
   // Single dispatcher for icon clicks — kind comes from serverIndicator()
@@ -77,6 +83,10 @@
   }
 
   async function loadAll() {
+    if (registeredServer?.reauthRequiredAt != null) {
+      loaded = true;
+      return;
+    }
     try {
       const [serverState, viewer, dmRooms] = await Promise.all([
         getAuthenticatedServerState(connectAPIConfig()),
@@ -114,6 +124,7 @@
 
   // Lightweight reload for server config changes (rename, logo, etc.).
   async function reloadServer() {
+    if (registeredServer?.reauthRequiredAt != null) return;
     try {
       const serverState = await getAuthenticatedServerState(connectAPIConfig());
       displayName = serverState.name;

--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
@@ -36,6 +36,7 @@ const { mocks } = vi.hoisted(() => {
         userLogin: 'alice',
         userDisplayName: 'Alice',
         userAvatarUrl: null,
+        reauthRequiredAt: null,
         addedAt: 0
       },
       store: {

--- a/apps/frontend/src/lib/api-client/viewer.ts
+++ b/apps/frontend/src/lib/api-client/viewer.ts
@@ -10,6 +10,7 @@ import {
 } from "./renderTypes.js";
 
 export type ViewerAPIConfig = {
+  serverId?: string;
   baseUrl: string;
   bearerToken: string | null;
   onAuthenticationRequired?: (serverId: string) => void;

--- a/apps/frontend/src/lib/apiClientHooks.ts
+++ b/apps/frontend/src/lib/apiClientHooks.ts
@@ -1,9 +1,13 @@
 import { configureApiClientHooks } from '$lib/api-client/hooks';
+import { isExplicitSignOutRedirectInProgress } from '$lib/auth/signOut';
 import { serverRegistry } from '$lib/state/server/registry.svelte';
 import { primeUserSummaryCache } from '$lib/state/userSummaries.svelte';
 
 configureApiClientHooks({
   onAuthenticationRequired(serverId) {
+    if (isExplicitSignOutRedirectInProgress() && serverRegistry.isOriginServer(serverId)) {
+      return;
+    }
     serverRegistry.handleAuthenticationRequired(serverId);
   },
   onUserSummaries(serverId, users) {

--- a/apps/frontend/src/lib/assets/assetUrls.test.ts
+++ b/apps/frontend/src/lib/assets/assetUrls.test.ts
@@ -26,6 +26,7 @@ function server(overrides: Partial<RegisteredServer> = {}): RegisteredServer {
     userLogin: 'alice',
     userDisplayName: 'Alice',
     userAvatarUrl: null,
+    reauthRequiredAt: null,
     addedAt: 1,
     ...overrides
   };

--- a/apps/frontend/src/lib/auth/currentUser.spec.ts
+++ b/apps/frontend/src/lib/auth/currentUser.spec.ts
@@ -1,17 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CurrentUserState } from './currentUser.svelte';
 
-const { gotoMock, clearCachedUserMock } = vi.hoisted(() => ({
-  gotoMock: vi.fn(() => Promise.resolve()),
+const { clearCachedUserMock } = vi.hoisted(() => ({
   clearCachedUserMock: vi.fn()
-}));
-
-vi.mock('$app/navigation', () => ({
-  goto: gotoMock
-}));
-
-vi.mock('$app/paths', () => ({
-  resolve: (path: string) => path
 }));
 
 vi.mock('./loadAuth', () => ({
@@ -52,22 +43,20 @@ describe('CurrentUserState', () => {
     expect(typeof CurrentUserState).toBe('function');
   });
 
-  it('does not revoke the server session by default for cookie auth failures', async () => {
-    const state = new CurrentUserState(true);
+  it('marks auth required without revoking the server session by default', async () => {
+    const onAuthenticationRequired = vi.fn();
+    const state = new CurrentUserState(true, undefined, undefined, onAuthenticationRequired);
 
     await state.handleAuthFailure();
 
     expect(fetch).not.toHaveBeenCalled();
-    expect(clearCachedUserMock).toHaveBeenCalledOnce();
-    expect(sessionStorage.setItem).toHaveBeenCalledWith(
-      'returnUrl',
-      '/chat/-/overview?tab=profile'
-    );
-    expect(gotoMock).toHaveBeenCalledWith('/', { invalidateAll: true });
+    expect(clearCachedUserMock).not.toHaveBeenCalled();
+    expect(onAuthenticationRequired).toHaveBeenCalledOnce();
   });
 
   it('revokes the server session when explicitly requested', async () => {
-    const state = new CurrentUserState(true);
+    const onAuthenticationRequired = vi.fn();
+    const state = new CurrentUserState(true, undefined, undefined, onAuthenticationRequired);
 
     await state.handleAuthFailure({ revokeServerSession: true });
 
@@ -75,6 +64,7 @@ describe('CurrentUserState', () => {
       method: 'POST',
       headers: expect.any(Headers)
     });
-    expect(gotoMock).toHaveBeenCalledWith('/', { invalidateAll: true });
+    expect(clearCachedUserMock).toHaveBeenCalledOnce();
+    expect(onAuthenticationRequired).toHaveBeenCalledOnce();
   });
 });

--- a/apps/frontend/src/lib/auth/currentUser.spec.ts
+++ b/apps/frontend/src/lib/auth/currentUser.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CurrentUserState } from './currentUser.svelte';
+import { PresenceStatus } from '$lib/render/types';
 
 const { clearCachedUserMock } = vi.hoisted(() => ({
   clearCachedUserMock: vi.fn()
@@ -54,9 +55,20 @@ describe('CurrentUserState', () => {
     expect(onAuthenticationRequired).toHaveBeenCalledOnce();
   });
 
-  it('revokes the server session when explicitly requested', async () => {
+  it('revokes the server session without marking reauth when explicitly requested', async () => {
     const onAuthenticationRequired = vi.fn();
     const state = new CurrentUserState(true, undefined, undefined, onAuthenticationRequired);
+    state.user = {
+      id: 'U1',
+      login: 'alice',
+      displayName: 'Alice',
+      avatarUrl: null,
+      presenceStatus: PresenceStatus.Online,
+      hasVerifiedEmail: true,
+      viewerCanDeleteAccount: false,
+      hasPassword: true,
+      settings: null
+    };
 
     await state.handleAuthFailure({ revokeServerSession: true });
 
@@ -64,7 +76,8 @@ describe('CurrentUserState', () => {
       method: 'POST',
       headers: expect.any(Headers)
     });
+    expect(state.user).toBeUndefined();
     expect(clearCachedUserMock).toHaveBeenCalledOnce();
-    expect(onAuthenticationRequired).toHaveBeenCalledOnce();
+    expect(onAuthenticationRequired).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/lib/auth/currentUser.svelte.ts
+++ b/apps/frontend/src/lib/auth/currentUser.svelte.ts
@@ -84,14 +84,17 @@ export class CurrentUserState {
 
     this.#isLoggingOut = true;
 
-    console.warn('[auth] handleAuthFailure: marking reauthentication required');
-    this.#onAuthenticationRequired?.();
-
     if (options.revokeServerSession) {
       await csrfFetch('/auth/logout', { method: 'POST' }).catch(() => {});
       this.user = undefined;
       clearCachedUser();
+      this.loading = false;
+      this.#isLoggingOut = false;
+      return;
     }
+
+    console.warn('[auth] handleAuthFailure: marking reauthentication required');
+    this.#onAuthenticationRequired?.();
 
     this.#isLoggingOut = false;
   }

--- a/apps/frontend/src/lib/auth/currentUser.svelte.ts
+++ b/apps/frontend/src/lib/auth/currentUser.svelte.ts
@@ -1,6 +1,8 @@
-import { goto } from '$app/navigation';
-import { resolve } from '$app/paths';
-import { getCurrentUserViaConnect, type CurrentUser, type ViewerAPIConfig } from '$lib/api-client/viewer';
+import {
+  getCurrentUserViaConnect,
+  type CurrentUser,
+  type ViewerAPIConfig
+} from '$lib/api-client/viewer';
 import { clearCachedUser } from './loadAuth';
 import { csrfFetch } from './csrf';
 import { isAuthenticationRequiredError } from './errors';
@@ -17,9 +19,9 @@ interface AuthFailureOptions {
  * instance via `serverRegistry.getStore(getServerId()).currentUser`, the
  * same way they reach every other per-server store.
  *
- * Cookie-authenticated instances (origin) handle auth failure by clearing
- * local state and redirecting. Bearer-authenticated
- * instances (remotes) just clear the local user state.
+ * Authentication-required failures are reported to the owning registry/store.
+ * The caller decides whether to prompt for reauthentication, revoke a session,
+ * or clear local state.
  */
 export class CurrentUserState {
   user = $state<CurrentUser | undefined>(undefined);
@@ -27,16 +29,19 @@ export class CurrentUserState {
   #cookieAuth: boolean;
   #apiConfig?: ViewerAPIConfig;
   #loadCurrentUser: (config: ViewerAPIConfig) => Promise<CurrentUser>;
+  #onAuthenticationRequired?: () => void;
   #isLoggingOut = false;
 
   constructor(
     cookieAuth: boolean = false,
     apiConfig?: ViewerAPIConfig,
-    loadCurrentUser = getCurrentUserViaConnect
+    loadCurrentUser = getCurrentUserViaConnect,
+    onAuthenticationRequired?: () => void
   ) {
     this.#cookieAuth = cookieAuth;
     this.#apiConfig = apiConfig;
     this.#loadCurrentUser = loadCurrentUser;
+    this.#onAuthenticationRequired = onAuthenticationRequired;
   }
 
   async load() {
@@ -47,7 +52,7 @@ export class CurrentUserState {
       this.user = await this.#loadCurrentUser(this.#apiConfig);
     } catch (err) {
       if (isAuthenticationRequiredError(err)) {
-        this.user = undefined;
+        this.#onAuthenticationRequired?.();
         this.loading = false;
         return;
       }
@@ -63,38 +68,31 @@ export class CurrentUserState {
 
   /**
    * Handle auth failure.
-   * Cookie auth (origin): clears local state and redirects to login. Explicit
-   * sign-out paths can request server-side session revocation.
-   * Bearer auth (remote): clears user state (instance becomes unauthenticated).
+   * Explicit sign-out paths can request server-side session revocation.
+   * Auth-expiry paths should use the registry's reauth-required state instead
+   * so the app can keep the current shell visible.
    */
   async handleAuthFailure(options: AuthFailureOptions = {}) {
     if (this.#isLoggingOut) return;
 
     if (!this.#cookieAuth) {
-      console.log('Remote instance auth failure — clearing user');
-      this.user = undefined;
+      console.log('Remote server auth failure — marking reauthentication required');
+      this.#onAuthenticationRequired?.();
       this.loading = false;
       return;
     }
 
     this.#isLoggingOut = true;
 
-    console.warn('[auth] handleAuthFailure -> /: clearing local session state and redirecting');
-    this.user = undefined;
-
-    clearCachedUser();
-
-    sessionStorage.setItem('returnUrl', window.location.pathname + window.location.search);
+    console.warn('[auth] handleAuthFailure: marking reauthentication required');
+    this.#onAuthenticationRequired?.();
 
     if (options.revokeServerSession) {
       await csrfFetch('/auth/logout', { method: 'POST' }).catch(() => {});
+      this.user = undefined;
+      clearCachedUser();
     }
 
-    // Redirect to / which handles both authenticated and unauthenticated users.
-    // invalidateAll forces SvelteKit to re-run all load functions so the root
-    // layout sees the cleared user state.
-    goto(resolve('/'), { invalidateAll: true }).finally(() => {
-      this.#isLoggingOut = false;
-    });
+    this.#isLoggingOut = false;
   }
 }

--- a/apps/frontend/src/lib/auth/loadAuth.spec.ts
+++ b/apps/frontend/src/lib/auth/loadAuth.spec.ts
@@ -1,8 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { getCurrentUserViaConnectMock, clearOriginAuthenticationMock } = vi.hoisted(() => ({
+const {
+  getCurrentUserViaConnectMock,
+  clearOriginAuthenticationMock,
+  handleAuthenticationRequiredMock,
+  clearAuthenticationRequiredMock
+} = vi.hoisted(() => ({
   getCurrentUserViaConnectMock: vi.fn(),
-  clearOriginAuthenticationMock: vi.fn()
+  clearOriginAuthenticationMock: vi.fn(),
+  handleAuthenticationRequiredMock: vi.fn(),
+  clearAuthenticationRequiredMock: vi.fn()
 }));
 
 vi.mock('$app/environment', () => ({
@@ -28,7 +35,12 @@ vi.mock('$lib/state/server/serverConnection.svelte', () => ({
 
 vi.mock('$lib/state/server/registry.svelte', () => ({
   serverRegistry: {
-    clearOriginAuthentication: clearOriginAuthenticationMock
+    get originServer() {
+      return { id: 'origin' };
+    },
+    clearOriginAuthentication: clearOriginAuthenticationMock,
+    handleAuthenticationRequired: handleAuthenticationRequiredMock,
+    clearAuthenticationRequired: clearAuthenticationRequiredMock
   }
 }));
 
@@ -61,6 +73,7 @@ describe('loadCurrentUser', () => {
     expect(await loadCurrentUser()).toEqual(user);
     expect(await loadCurrentUser()).toEqual({ ...user, displayName: 'Alice Fresh' });
     expect(getCurrentUserViaConnectMock).toHaveBeenCalledTimes(2);
+    expect(clearAuthenticationRequiredMock).toHaveBeenCalledWith('origin');
     expect(getCurrentUserViaConnectMock).toHaveBeenCalledWith({
       baseUrl: '/api/connect',
       bearerToken: null
@@ -78,15 +91,25 @@ describe('loadCurrentUser', () => {
     expect(await loadCurrentUser()).toEqual(user);
   });
 
-  it('clears the cached user on authentication-required errors', async () => {
+  it('keeps the cached user and marks reauth required on authentication-required errors', async () => {
     const { loadCurrentUser } = await loadModule();
     getCurrentUserViaConnectMock
       .mockResolvedValueOnce(user)
       .mockRejectedValueOnce({ message: 'authentication required' });
 
     expect(await loadCurrentUser()).toEqual(user);
+    expect(await loadCurrentUser()).toEqual(user);
+    expect(handleAuthenticationRequiredMock).toHaveBeenCalledWith('origin');
+    expect(clearOriginAuthenticationMock).not.toHaveBeenCalled();
+  });
+
+  it('clears origin auth on first-load authentication-required errors', async () => {
+    const { loadCurrentUser } = await loadModule();
+    getCurrentUserViaConnectMock.mockRejectedValueOnce({ message: 'authentication required' });
+
     expect(await loadCurrentUser()).toBeNull();
     expect(clearOriginAuthenticationMock).toHaveBeenCalledOnce();
+    expect(handleAuthenticationRequiredMock).not.toHaveBeenCalled();
   });
 
   it('returns null when the first load cannot determine a user', async () => {

--- a/apps/frontend/src/lib/auth/loadAuth.ts
+++ b/apps/frontend/src/lib/auth/loadAuth.ts
@@ -12,6 +12,7 @@ import { serverConnectionManager } from '$lib/state/server/serverConnection.svel
 import { serverRegistry } from '$lib/state/server/registry.svelte';
 import { getCurrentUserViaConnect, type CurrentUser } from '$lib/api-client/viewer';
 import { isAuthenticationRequiredError } from './errors';
+import { isExplicitSignOutRedirectInProgress } from './signOut';
 
 export type { CurrentUser };
 
@@ -34,6 +35,12 @@ export async function loadCurrentUser(): Promise<CurrentUser | null> {
     return null;
   }
 
+  if (isExplicitSignOutRedirectInProgress()) {
+    cachedUser = null;
+    serverRegistry.clearOriginAuthentication();
+    return null;
+  }
+
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
       cachedUser = await getCurrentUserViaConnect({
@@ -47,6 +54,11 @@ export async function loadCurrentUser(): Promise<CurrentUser | null> {
       return cachedUser;
     } catch (err) {
       if (isAuthenticationRequiredError(err)) {
+        if (isExplicitSignOutRedirectInProgress()) {
+          cachedUser = null;
+          serverRegistry.clearOriginAuthentication();
+          return null;
+        }
         const cached = cachedUser;
         if (cached) {
           const originId = serverRegistry.originServer?.id;

--- a/apps/frontend/src/lib/auth/loadAuth.ts
+++ b/apps/frontend/src/lib/auth/loadAuth.ts
@@ -40,9 +40,21 @@ export async function loadCurrentUser(): Promise<CurrentUser | null> {
         baseUrl: serverConnectionManager.originClient.connectBaseUrl,
         bearerToken: serverConnectionManager.originClient.bearerToken
       });
+      const originId = serverRegistry.originServer?.id;
+      if (originId) {
+        serverRegistry.clearAuthenticationRequired(originId);
+      }
       return cachedUser;
     } catch (err) {
       if (isAuthenticationRequiredError(err)) {
+        const cached = cachedUser;
+        if (cached) {
+          const originId = serverRegistry.originServer?.id;
+          if (originId) {
+            serverRegistry.handleAuthenticationRequired(originId);
+          }
+          return cached;
+        }
         cachedUser = null;
         serverRegistry.clearOriginAuthentication();
         return null;

--- a/apps/frontend/src/lib/auth/reauth.ts
+++ b/apps/frontend/src/lib/auth/reauth.ts
@@ -1,0 +1,65 @@
+import { goto } from '$app/navigation';
+import { resolve } from '$app/paths';
+import { getPublicServerInfo, type PublicServerInfo } from '$lib/api-client/server';
+import {
+  generateCodeChallenge,
+  generateCodeVerifier,
+  generateState,
+  saveFlowState
+} from '$lib/oauth/pkce';
+import { serverRegistry, type RegisteredServer } from '$lib/state/server/registry.svelte';
+import { clearCachedUser } from './loadAuth';
+
+export async function startServerOAuthFlow(
+  serverUrl: string,
+  serverInfo: Pick<PublicServerInfo, 'name' | 'authorizeUrl' | 'iconUrl'>
+): Promise<void> {
+  if (!serverInfo.authorizeUrl) {
+    throw new Error('This server does not support OAuth sign-in.');
+  }
+
+  const verifier = generateCodeVerifier();
+  const challenge = await generateCodeChallenge(verifier);
+  const state = generateState();
+  const redirectUri = `${window.location.origin}/servers/callback`;
+
+  saveFlowState({
+    verifier,
+    state,
+    remoteUrl: serverUrl,
+    serverName: serverInfo.name,
+    serverIconUrl: serverInfo.iconUrl ?? null
+  });
+
+  const params = new URLSearchParams({
+    response_type: 'code',
+    redirect_uri: redirectUri,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+    state
+  });
+
+  window.location.href = `${serverUrl}${serverInfo.authorizeUrl}?${params}`;
+}
+
+export async function startRemoteReauthentication(server: RegisteredServer): Promise<void> {
+  const info = await getPublicServerInfo(server.url, { signal: AbortSignal.timeout(10000) });
+  await startServerOAuthFlow(server.url, {
+    name: info.name || server.name,
+    authorizeUrl: info.authorizeUrl,
+    iconUrl: info.iconUrl ?? server.iconUrl
+  });
+}
+
+export function beginOriginReauthentication(): void {
+  const path = window.location.pathname + window.location.search;
+  sessionStorage.setItem('returnUrl', path);
+  clearCachedUser();
+  serverRegistry.clearOriginAuthentication();
+
+  const redirect = resolve('/login') + '?' + new URLSearchParams({
+    error: 'authentication_required',
+    redirect: path
+  });
+  void goto(redirect, { invalidateAll: true });
+}

--- a/apps/frontend/src/lib/auth/reauth.ts
+++ b/apps/frontend/src/lib/auth/reauth.ts
@@ -61,5 +61,6 @@ export function beginOriginReauthentication(): void {
     error: 'authentication_required',
     redirect: path
   });
+  // eslint-disable-next-line svelte/no-navigation-without-resolve -- base route is resolved above; query parameters preserve the current app path
   void goto(redirect, { invalidateAll: true });
 }

--- a/apps/frontend/src/lib/auth/signOut.spec.ts
+++ b/apps/frontend/src/lib/auth/signOut.spec.ts
@@ -12,6 +12,7 @@ const remoteServer: RegisteredServer = {
 	userLogin: 'alice',
 	userDisplayName: 'Alice',
 	userAvatarUrl: null,
+	reauthRequiredAt: null,
 	addedAt: 1
 };
 

--- a/apps/frontend/src/lib/auth/signOut.ts
+++ b/apps/frontend/src/lib/auth/signOut.ts
@@ -67,12 +67,9 @@ export function hardRedirectAfterSignOut(href = '/'): void {
 	try {
 		const target = new URL(href, window.location.href);
 		if (target.origin === window.location.origin) {
-			window.history.replaceState(
-				window.history.state,
-				'',
-				target.pathname + target.search + target.hash
-			);
-			window.setTimeout(() => window.location.reload(), 0);
+			window.setTimeout(() => {
+				window.location.replace(target.pathname + target.search + target.hash);
+			}, 0);
 			return;
 		}
 	} catch {

--- a/apps/frontend/src/lib/auth/signOut.ts
+++ b/apps/frontend/src/lib/auth/signOut.ts
@@ -3,6 +3,8 @@ import { csrfFetch } from './csrf';
 
 export const SIGN_OUT_TIMEOUT_MS = 5000;
 
+let explicitSignOutRedirectInProgress = false;
+
 function logoutUrl(server: RegisteredServer): string {
 	return new URL('/auth/logout', server.url).toString();
 }
@@ -48,6 +50,35 @@ export async function signOutServers(
 	);
 }
 
+export function isExplicitSignOutRedirectInProgress(): boolean {
+	return explicitSignOutRedirectInProgress;
+}
+
+export function beginExplicitSignOutRedirect(): void {
+	explicitSignOutRedirectInProgress = true;
+}
+
+export function cancelExplicitSignOutRedirect(): void {
+	explicitSignOutRedirectInProgress = false;
+}
+
 export function hardRedirectAfterSignOut(href = '/'): void {
-	window.location.href = href;
+	beginExplicitSignOutRedirect();
+	try {
+		const target = new URL(href, window.location.href);
+		if (target.origin === window.location.origin) {
+			window.history.replaceState(
+				window.history.state,
+				'',
+				target.pathname + target.search + target.hash
+			);
+			window.setTimeout(() => window.location.reload(), 0);
+			return;
+		}
+	} catch {
+		// Fall back to a regular document navigation below.
+	}
+	window.setTimeout(() => {
+		window.location.replace(href);
+	}, 0);
 }

--- a/apps/frontend/src/lib/components/AddServerDialog.svelte
+++ b/apps/frontend/src/lib/components/AddServerDialog.svelte
@@ -14,15 +14,10 @@ ADR-027 — only user-facing copy says "server".
 -->
 <script lang="ts">
   import { ConnectError } from '@connectrpc/connect';
+  import { startServerOAuthFlow } from '$lib/auth/reauth';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { getPublicServerInfo, type PublicServerInfo } from '$lib/api-client/server';
   import * as m from '$lib/i18n/messages';
-  import {
-    generateCodeChallenge,
-    generateCodeVerifier,
-    generateState,
-    saveFlowState
-  } from '$lib/oauth/pkce';
   import { TextInput } from '$lib/ui/form';
   import FormDialog from '$lib/ui/FormDialog.svelte';
 
@@ -162,28 +157,7 @@ ADR-027 — only user-facing copy says "server".
     connecting = true;
 
     try {
-      const verifier = generateCodeVerifier();
-      const challenge = await generateCodeChallenge(verifier);
-      const state = generateState();
-      const redirectUri = `${window.location.origin}/servers/callback`;
-
-      saveFlowState({
-        verifier,
-        state,
-        remoteUrl: probedUrl,
-        serverName: probedInfo.name,
-        serverIconUrl: probedInfo.iconUrl ?? null
-      });
-
-      const params = new URLSearchParams({
-        response_type: 'code',
-        redirect_uri: redirectUri,
-        code_challenge: challenge,
-        code_challenge_method: 'S256',
-        state
-      });
-
-      window.location.href = `${probedUrl}${probedInfo.authorizeUrl}?${params}`;
+      await startServerOAuthFlow(probedUrl, probedInfo);
     } catch (err) {
       connecting = false;
       formError = err instanceof Error ? err.message : m['add_server.start_failed']();

--- a/apps/frontend/src/lib/components/AddServerDialog.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/AddServerDialog.svelte.spec.ts
@@ -4,6 +4,14 @@ import { flushSync } from 'svelte';
 import AddServerDialog from './AddServerDialog.svelte';
 import { serverRegistry } from '$lib/state/server/registry.svelte';
 
+const { startServerOAuthFlowMock } = vi.hoisted(() => ({
+  startServerOAuthFlowMock: vi.fn()
+}));
+
+vi.mock('$lib/auth/reauth', () => ({
+  startServerOAuthFlow: startServerOAuthFlowMock
+}));
+
 const STORAGE_KEY = 'chatto:instances';
 
 function makeProbeResponse(body: object, ok = true, status = 200): Response {
@@ -19,6 +27,8 @@ describe('AddServerDialog', () => {
   beforeEach(() => {
     localStorage.removeItem(STORAGE_KEY);
     serverRegistry.servers = [];
+    startServerOAuthFlowMock.mockReset();
+    startServerOAuthFlowMock.mockResolvedValue(undefined);
     originalFetch = globalThis.fetch;
   });
 
@@ -137,6 +147,50 @@ describe('AddServerDialog', () => {
     expect(visible).toBe(true);
   });
 
+  it('starts the shared OAuth flow from the preview stage', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      makeProbeResponse({
+        profile: {
+          name: 'Remote Chatto',
+          version: '0.0.150',
+          logoUrl: 'https://chat.example.com/logo.png'
+        },
+        login: {
+          authorizeUrl: '/oauth/authorize'
+        }
+      })
+    ) as unknown as typeof fetch;
+
+    const { container } = render(AddServerDialog, {
+      props: { visible: true, onclose: () => {} }
+    });
+
+    const input = container.querySelector<HTMLInputElement>('#add-server-url')!;
+    input.value = 'https://chat.example.com';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+
+    container.querySelector('form')!.requestSubmit();
+
+    await vi.waitFor(() => {
+      expect(container.querySelector<HTMLButtonElement>('button[type="submit"]')?.textContent).toMatch(
+        /^\s*Sign in\s*$/
+      );
+    });
+
+    container.querySelector('form')!.requestSubmit();
+
+    await vi.waitFor(() => {
+      expect(startServerOAuthFlowMock).toHaveBeenCalledWith(
+        'https://chat.example.com',
+        expect.objectContaining({
+          name: 'Remote Chatto',
+          authorizeUrl: '/oauth/authorize'
+        })
+      );
+    });
+  });
+
   it('shows an error when the probe response is not a Chatto server', async () => {
     globalThis.fetch = vi.fn(async () =>
       makeProbeResponse({ unrelated: true })
@@ -170,6 +224,7 @@ describe('AddServerDialog', () => {
         userLogin: 'someone',
         userDisplayName: null,
         userAvatarUrl: null,
+        reauthRequiredAt: null,
         addedAt: 0
       }
     ];

--- a/apps/frontend/src/lib/components/AuthStatusNotice.svelte
+++ b/apps/frontend/src/lib/components/AuthStatusNotice.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import { getActiveServer } from '$lib/state/activeServer.svelte';
+  import { serverRegistry, type RegisteredServer } from '$lib/state/server/registry.svelte';
+  import { beginOriginReauthentication, startRemoteReauthentication } from '$lib/auth/reauth';
+  import { TopOverlayNotice } from '$lib/ui';
+  import { toast } from '$lib/ui/toast';
+  import * as m from '$lib/i18n/messages';
+
+  let reconnectingServerId = $state<string | null>(null);
+
+  const originServer = $derived(serverRegistry.originServer);
+  const originNeedsReauth = $derived(originServer?.reauthRequiredAt != null);
+  const activeServer = $derived(serverRegistry.getServer(getActiveServer()));
+  const activeRemoteNeedsReauth = $derived(
+    !!activeServer &&
+      activeServer.id !== originServer?.id &&
+      activeServer.reauthRequiredAt != null
+  );
+
+  const noticeServer = $derived.by<RegisteredServer | null>(() => {
+    if (originNeedsReauth && originServer) return originServer;
+    if (activeRemoteNeedsReauth && activeServer) return activeServer;
+    return null;
+  });
+  const isOriginNotice = $derived(noticeServer?.id === originServer?.id);
+
+  async function reconnectRemote(server: RegisteredServer) {
+    reconnectingServerId = server.id;
+    try {
+      await startRemoteReauthentication(server);
+    } catch (err) {
+      reconnectingServerId = null;
+      toast.error(err instanceof Error ? err.message : m['ui.auth_status.remote_failed']());
+    }
+  }
+</script>
+
+{#if noticeServer}
+  <TopOverlayNotice
+    tone="warning"
+    title={isOriginNotice
+      ? m['ui.auth_status.origin_title']()
+      : m['ui.auth_status.remote_title']({ server: noticeServer.name })}
+    message={isOriginNotice
+      ? m['ui.auth_status.origin_message']()
+      : m['ui.auth_status.remote_message']()}
+    loading={reconnectingServerId === noticeServer.id}
+    primaryAction={{
+      label: isOriginNotice
+        ? m['ui.auth_status.origin_action']()
+        : m['ui.auth_status.remote_action'](),
+      icon: 'uil--signin',
+      onclick: () => {
+        if (isOriginNotice) {
+          beginOriginReauthentication();
+          return;
+        }
+        void reconnectRemote(noticeServer);
+      }
+    }}
+  />
+{/if}

--- a/apps/frontend/src/lib/components/AuthStatusNotice.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/AuthStatusNotice.svelte.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import AuthStatusNotice from './AuthStatusNotice.svelte';
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    activeServerId: 'origin',
+    servers: [] as Array<{ id: string; name: string; reauthRequiredAt: number | null }>,
+    beginOriginReauthentication: vi.fn(),
+    startRemoteReauthentication: vi.fn(() => Promise.resolve()),
+    toastError: vi.fn()
+  }
+}));
+
+vi.mock('$lib/state/activeServer.svelte', () => ({
+  getActiveServer: () => mocks.activeServerId
+}));
+
+vi.mock('$lib/state/server/registry.svelte', () => ({
+  serverRegistry: {
+    get originServer() {
+      return mocks.servers.find((server) => server.id === 'origin');
+    },
+    getServer(id: string) {
+      return mocks.servers.find((server) => server.id === id);
+    }
+  }
+}));
+
+vi.mock('$lib/auth/reauth', () => ({
+  beginOriginReauthentication: mocks.beginOriginReauthentication,
+  startRemoteReauthentication: mocks.startRemoteReauthentication
+}));
+
+vi.mock('$lib/ui/toast', () => ({
+  toast: {
+    error: mocks.toastError
+  }
+}));
+
+describe('AuthStatusNotice', () => {
+  beforeEach(() => {
+    mocks.activeServerId = 'origin';
+    mocks.servers = [];
+    mocks.beginOriginReauthentication.mockReset();
+    mocks.startRemoteReauthentication.mockClear();
+    mocks.startRemoteReauthentication.mockResolvedValue(undefined);
+    mocks.toastError.mockReset();
+  });
+
+  it('shows an origin reauth notice with a sign-in action', async () => {
+    mocks.servers = [{ id: 'origin', name: 'Home', reauthRequiredAt: 123 }];
+
+    const { container } = render(AuthStatusNotice);
+
+    expect(container.textContent).toContain('Session expired');
+    const button = container.querySelector<HTMLButtonElement>('button');
+    expect(button?.textContent).toContain('Sign in again');
+
+    button?.click();
+
+    expect(mocks.beginOriginReauthentication).toHaveBeenCalledOnce();
+  });
+
+  it('shows an active remote reauth notice with a reconnect action', async () => {
+    mocks.activeServerId = 'remote';
+    const remote = { id: 'remote', name: 'Remote', reauthRequiredAt: 456 };
+    mocks.servers = [{ id: 'origin', name: 'Home', reauthRequiredAt: null }, remote];
+
+    const { container } = render(AuthStatusNotice);
+
+    expect(container.textContent).toContain('Remote needs sign-in');
+    const button = container.querySelector<HTMLButtonElement>('button');
+    expect(button?.textContent).toContain('Reconnect');
+
+    button?.click();
+
+    await vi.waitFor(() => {
+      expect(mocks.startRemoteReauthentication).toHaveBeenCalledWith(remote);
+    });
+  });
+});

--- a/apps/frontend/src/lib/components/ReturnUrlHandler.svelte
+++ b/apps/frontend/src/lib/components/ReturnUrlHandler.svelte
@@ -10,17 +10,21 @@ Include this component once in the authenticated layout.
 <script lang="ts">
   import { goto } from '$app/navigation';
 
+  const returnNavigationKey = 'returnUrl:navigating';
   const returnUrl = sessionStorage.getItem('returnUrl');
 
   if (returnUrl && returnUrl !== window.location.pathname + window.location.search) {
+    sessionStorage.setItem(returnNavigationKey, returnUrl);
+    sessionStorage.removeItem('returnUrl');
     // eslint-disable-next-line svelte/no-navigation-without-resolve -- dynamic return URL from sessionStorage
     goto(returnUrl)
-      .then(() => {
-        sessionStorage.removeItem('returnUrl');
-      })
       .catch((err) => {
-        console.warn('Return URL navigation failed, clearing:', err);
-        sessionStorage.removeItem('returnUrl');
+        console.warn('Return URL navigation failed:', err);
+      })
+      .finally(() => {
+        if (sessionStorage.getItem(returnNavigationKey) === returnUrl) {
+          sessionStorage.removeItem(returnNavigationKey);
+        }
       });
   } else {
     sessionStorage.removeItem('returnUrl');

--- a/apps/frontend/src/lib/components/chat/Chrome.svelte
+++ b/apps/frontend/src/lib/components/chat/Chrome.svelte
@@ -8,6 +8,7 @@
   import { getViewerStateViaConnect } from '$lib/api-client/viewer';
   import { useConnection } from '$lib/state/server/connection.svelte';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
+  import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { serverIdToSegment } from '$lib/navigation';
   import { clearLastRoom } from '$lib/storage/lastRoom';
   import { useActiveEvent, useReconnectCallback } from '$lib/hooks';
@@ -96,6 +97,10 @@
   // null if the server says it's not accessible, or 'transient' on network
   // failure (treat as "try again later", not as access denial).
   async function validateServer(): Promise<ServerChromeData | null | 'transient'> {
+    if (serverRegistry.getServer(getActiveServer())?.reauthRequiredAt != null) {
+      return 'transient';
+    }
+
     const currentConnection = connection();
     const config = {
       baseUrl: currentConnection.connectBaseUrl,

--- a/apps/frontend/src/lib/components/voice/VoiceCallPanelStoryHarness.svelte
+++ b/apps/frontend/src/lib/components/voice/VoiceCallPanelStoryHarness.svelte
@@ -169,6 +169,7 @@
 			userLogin: 'alice',
 			userDisplayName: 'Alice',
 			userAvatarUrl: null,
+			reauthRequiredAt: null,
 			addedAt: Date.now()
 		};
 		serverRegistry.addServer(server);

--- a/apps/frontend/src/lib/i18n/messages.ts
+++ b/apps/frontend/src/lib/i18n/messages.ts
@@ -760,6 +760,18 @@ const msg_ui_update_available = (): LocalizedString => messages().ui_update_avai
 const msg_ui_reload = (): LocalizedString => messages().ui_reload(empty());
 const msg_ui_sign_out = (): LocalizedString => messages().ui_sign_out(empty());
 const msg_ui_close = (): LocalizedString => messages().ui_close(empty());
+const msg_ui_auth_status_origin_title = (): LocalizedString => messages().ui_auth_status_origin_title(empty());
+const msg_ui_auth_status_origin_message = (): LocalizedString => messages().ui_auth_status_origin_message(empty());
+const msg_ui_auth_status_origin_action = (): LocalizedString => messages().ui_auth_status_origin_action(empty());
+const msg_ui_auth_status_remote_title = (
+  inputs: Parameters<LocaleMessages['ui_auth_status_remote_title']>[0]
+): LocalizedString => messages().ui_auth_status_remote_title(inputs);
+const msg_ui_auth_status_remote_message = (): LocalizedString => messages().ui_auth_status_remote_message(empty());
+const msg_ui_auth_status_remote_action = (): LocalizedString => messages().ui_auth_status_remote_action(empty());
+const msg_ui_auth_status_remote_failed = (): LocalizedString => messages().ui_auth_status_remote_failed(empty());
+const msg_ui_auth_status_sidebar_reauth = (
+  inputs: Parameters<LocaleMessages['ui_auth_status_sidebar_reauth']>[0]
+): LocalizedString => messages().ui_auth_status_sidebar_reauth(inputs);
 const msg_ui_access_denied_title = (): LocalizedString => messages().ui_access_denied_title(empty());
 const msg_ui_access_denied_message = (): LocalizedString => messages().ui_access_denied_message(empty());
 const msg_ui_access_denied_back = (): LocalizedString => messages().ui_access_denied_back(empty());
@@ -2059,6 +2071,14 @@ export { msg_ui_update_available as 'ui.update_available' };
 export { msg_ui_reload as 'ui.reload' };
 export { msg_ui_sign_out as 'ui.sign_out' };
 export { msg_ui_close as 'ui.close' };
+export { msg_ui_auth_status_origin_title as 'ui.auth_status.origin_title' };
+export { msg_ui_auth_status_origin_message as 'ui.auth_status.origin_message' };
+export { msg_ui_auth_status_origin_action as 'ui.auth_status.origin_action' };
+export { msg_ui_auth_status_remote_title as 'ui.auth_status.remote_title' };
+export { msg_ui_auth_status_remote_message as 'ui.auth_status.remote_message' };
+export { msg_ui_auth_status_remote_action as 'ui.auth_status.remote_action' };
+export { msg_ui_auth_status_remote_failed as 'ui.auth_status.remote_failed' };
+export { msg_ui_auth_status_sidebar_reauth as 'ui.auth_status.sidebar_reauth' };
 export { msg_ui_access_denied_title as 'ui.access_denied.title' };
 export { msg_ui_access_denied_message as 'ui.access_denied.message' };
 export { msg_ui_access_denied_back as 'ui.access_denied.back' };

--- a/apps/frontend/src/lib/pwa/assetProxy.test.ts
+++ b/apps/frontend/src/lib/pwa/assetProxy.test.ts
@@ -17,6 +17,7 @@ function server(overrides: Partial<RegisteredServer> = {}): RegisteredServer {
     userLogin: 'alice',
     userDisplayName: 'Alice',
     userAvatarUrl: null,
+    reauthRequiredAt: null,
     addedAt: 1,
     ...overrides
   };

--- a/apps/frontend/src/lib/state/server/eventBus.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/eventBus.svelte.spec.ts
@@ -4,6 +4,8 @@ import { createEventBusHandlerRegistrar, getRealtimeEventEnvelope } from '$lib/e
 import { RoomEventKind } from '$lib/render/eventKinds';
 import {
   RealtimeEventEnvelope,
+  RealtimeClose,
+  RealtimeError,
   RealtimeHeartbeat,
   RealtimeMentionNotificationEvent,
   RealtimeServerFrame,
@@ -313,6 +315,51 @@ describe('eventBusManager realtime transport', () => {
     expect(catchUp).toHaveBeenCalledWith('subscription-ended');
     await vi.advanceTimersByTimeAsync(0);
     expect(sockets).toHaveLength(2);
+  });
+
+  it('does not reconnect when the realtime stream reports authentication required', async () => {
+    vi.useFakeTimers();
+    const { fake, socket } = await startAndSubscribe();
+    const catchUp = vi.fn();
+    eventBusManager.getBus(TEST_SERVER)!.catchUpHandlers.add(catchUp);
+
+    await socket.receive(
+      serverFrame({
+        case: 'error',
+        value: new RealtimeError({
+          code: 'authentication_required',
+          message: 'session expired',
+          fatal: true
+        })
+      })
+    );
+
+    expect(fake.authRequiredCalls).toBe(1);
+    expect(fake.status).toBe('disconnected');
+    expect(catchUp).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(sockets).toHaveLength(1);
+  });
+
+  it('does not reconnect when the realtime stream closes for authentication required', async () => {
+    vi.useFakeTimers();
+    const { fake, socket } = await startAndSubscribe();
+
+    await socket.receive(
+      serverFrame({
+        case: 'close',
+        value: new RealtimeClose({
+          code: 'authentication_required',
+          message: 'session expired',
+          reconnect: true
+        })
+      })
+    );
+
+    expect(fake.authRequiredCalls).toBe(1);
+    expect(fake.status).toBe('disconnected');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(sockets).toHaveLength(1);
   });
 
   it('re-notifies catch-up handlers after the projection grace period', async () => {

--- a/apps/frontend/src/lib/state/server/eventBus.svelte.ts
+++ b/apps/frontend/src/lib/state/server/eventBus.svelte.ts
@@ -159,6 +159,19 @@ class EventBusManager {
       if (close) current.close(1000, 'replaced');
     };
 
+    const stopForAuthenticationRequired = (current: RealtimeSocket, reason: string) => {
+      console.warn(`[eventBus:${serverId}] realtime authentication required`, {
+        reason,
+        ...debugState()
+      });
+      stopped = true;
+      current.onclose = null;
+      if (socket === current) socket = null;
+      serverConnection.setRealtimeConnectionStatus('disconnected', reconnectAttempts);
+      current.close(1000, 'authentication_required');
+      serverConnection.handleAuthenticationRequired();
+    };
+
     const dispatchEvent = (event: EventEnvelope) => {
       dispatchedEventCount++;
       console.debug(
@@ -239,7 +252,8 @@ class EventBusManager {
                 fatal: frame.frame.value.fatal
               });
               if (frame.frame.value.code === 'authentication_required') {
-                serverConnection.handleAuthenticationRequired();
+                stopForAuthenticationRequired(nextSocket, 'error frame');
+                return;
               }
               if (frame.frame.value.fatal) {
                 nextSocket.close(1011, frame.frame.value.code || 'fatal realtime error');
@@ -247,7 +261,8 @@ class EventBusManager {
               return;
             case 'close':
               if (frame.frame.value.code === 'authentication_required') {
-                serverConnection.handleAuthenticationRequired();
+                stopForAuthenticationRequired(nextSocket, 'close frame');
+                return;
               }
               nextSocket.onclose = null;
               if (socket === nextSocket) socket = null;

--- a/apps/frontend/src/lib/state/server/permissions.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/permissions.svelte.spec.ts
@@ -20,6 +20,7 @@ function makeServer(overrides: Partial<RegisteredServer> = {}): RegisteredServer
     userLogin: null,
     userDisplayName: null,
     userAvatarUrl: null,
+    reauthRequiredAt: null,
     addedAt: 0,
     ...overrides
   };

--- a/apps/frontend/src/lib/state/server/registry.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/registry.svelte.spec.ts
@@ -14,6 +14,7 @@ function makeServer(overrides: Partial<RegisteredServer> = {}): RegisteredServer
 		userLogin: null,
 		userDisplayName: null,
 		userAvatarUrl: null,
+		reauthRequiredAt: null,
 		addedAt: 1000,
 		...overrides
 	};
@@ -197,7 +198,7 @@ describe('ServerRegistry', () => {
 	});
 
 	describe('handleAuthenticationRequired', () => {
-		it('removes remote instances instead of persisting unusable null-token auth', async () => {
+		it('marks remote instances as needing reauth without removing them', async () => {
 			const registry = await createRegistry();
 			registry.servers = [];
 
@@ -214,8 +215,23 @@ describe('ServerRegistry', () => {
 
 			registry.handleAuthenticationRequired('remote');
 
-			expect(registry.getServer('remote')).toBeUndefined();
-			expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toHaveLength(0);
+			expect(registry.getServer('remote')?.token).toBe('remote-token');
+			expect(registry.getServer('remote')?.reauthRequiredAt).toEqual(expect.any(Number));
+			const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+			expect(stored).toHaveLength(1);
+			expect(stored[0].reauthRequiredAt).toEqual(expect.any(Number));
+		});
+
+		it('clears reauth-required state explicitly', async () => {
+			const registry = await createRegistry();
+			registry.servers = [];
+
+			registry.addServer(makeServer({ id: 'remote', token: 'remote-token' }));
+			registry.handleAuthenticationRequired('remote');
+			registry.clearAuthenticationRequired('remote');
+
+			expect(registry.getServer('remote')?.reauthRequiredAt).toBeNull();
+			expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)[0].reauthRequiredAt).toBeNull();
 		});
 
 		it('keeps origin instances registered when clearing origin auth', async () => {

--- a/apps/frontend/src/lib/state/server/registry.svelte.ts
+++ b/apps/frontend/src/lib/state/server/registry.svelte.ts
@@ -28,6 +28,8 @@ export interface RegisteredServer {
 	userDisplayName: string | null;
 	/** Authenticated user's avatar URL on this server */
 	userAvatarUrl: string | null;
+	/** Epoch ms when this server last rejected auth, or null when auth is usable */
+	reauthRequiredAt: number | null;
 	/** When this server was added (epoch ms) */
 	addedAt: number;
 }
@@ -69,6 +71,13 @@ export function generateServerId(url: string, existingIds: string[] = []): strin
 // Storage key intentionally stays as 'instances' — renaming would lose users'
 // multi-server registrations (including remote bearer tokens that can't be
 // regenerated). The in-code rename is purely cosmetic.
+function normalizeRegisteredServer(server: RegisteredServer): RegisteredServer {
+	return {
+		...server,
+		reauthRequiredAt: server.reauthRequiredAt ?? null
+	};
+}
+
 const serversSlot = globalSlot(
 	'instances',
 	[] as RegisteredServer[],
@@ -92,7 +101,7 @@ const serversSlot = globalSlot(
  * and provided to components through Svelte context.
  */
 class ServerRegistry {
-	servers = $state<RegisteredServer[]>(serversSlot.get());
+	servers = $state<RegisteredServer[]>(serversSlot.get().map(normalizeRegisteredServer));
 	#stores = new SvelteMap<string, ServerStateStore>();
 
 	/**
@@ -204,6 +213,7 @@ class ServerRegistry {
 			userLogin: user?.login ?? null,
 			userDisplayName: user?.displayName ?? user?.login ?? null,
 			userAvatarUrl: user?.avatarUrl ?? null,
+			reauthRequiredAt: null,
 			addedAt: Date.now()
 		});
 	}
@@ -224,7 +234,8 @@ class ServerRegistry {
 			userId: user?.id ?? origin.userId,
 			userLogin: user?.login ?? origin.userLogin,
 			userDisplayName: user?.displayName ?? user?.login ?? origin.userDisplayName,
-			userAvatarUrl: user?.avatarUrl ?? origin.userAvatarUrl
+			userAvatarUrl: user?.avatarUrl ?? origin.userAvatarUrl,
+			reauthRequiredAt: null
 		});
 		this.originProbed = true;
 	}
@@ -248,7 +259,8 @@ class ServerRegistry {
 			userId: null,
 			userLogin: null,
 			userDisplayName: null,
-			userAvatarUrl: null
+			userAvatarUrl: null,
+			reauthRequiredAt: null
 		});
 		const store = this.tryGetStore(id);
 		if (store) {
@@ -266,16 +278,22 @@ class ServerRegistry {
 	handleAuthenticationRequired(id: string): void {
 		const server = this.getServer(id);
 		if (!server) return;
-		const isOrigin = this.isOriginServer(id);
-		if (isOrigin) {
-			this.clearServerAuthentication(id);
-		} else {
-			this.removeServer(id);
+		if (server.reauthRequiredAt !== null) return;
+
+		eventBusManager.stopBus(id);
+		server.reauthRequiredAt = Date.now();
+		serversSlot.set(this.servers);
+		const store = this.tryGetStore(id);
+		if (store) {
+			store.currentUser.loading = false;
 		}
-		if (isOrigin && typeof window !== 'undefined') {
-			sessionStorage.setItem('returnUrl', window.location.pathname + window.location.search);
-			window.location.href = '/';
-		}
+	}
+
+	clearAuthenticationRequired(id: string): void {
+		const server = this.getServer(id);
+		if (!server || server.reauthRequiredAt === null) return;
+		server.reauthRequiredAt = null;
+		serversSlot.set(this.servers);
 	}
 
 	/**
@@ -295,9 +313,10 @@ class ServerRegistry {
 		if (this.servers.some((s) => s.id === server.id)) {
 			return; // Already exists
 		}
-		this.servers.push(server);
+		const registered = normalizeRegisteredServer(server);
+		this.servers.push(registered);
 		serversSlot.set(this.servers);
-		const store = this.#createStore(server);
+		const store = this.#createStore(registered);
 
 		// Start the event bus eagerly for already-authenticated servers so
 		// child components (ServerSidebarEntry) can register handlers during
@@ -360,11 +379,21 @@ class ServerRegistry {
 		return true;
 	}
 
+	replaceServerAuthentication(
+		id: string,
+		data: Pick<
+			RegisteredServer,
+			'token' | 'userId' | 'userLogin' | 'userDisplayName' | 'userAvatarUrl' | 'reauthRequiredAt'
+		>
+	): boolean {
+		return this.#replaceServerAuth(id, data);
+	}
+
 	#replaceServerAuth(
 		id: string,
 		data: Pick<
 			RegisteredServer,
-			'token' | 'userId' | 'userLogin' | 'userDisplayName' | 'userAvatarUrl'
+			'token' | 'userId' | 'userLogin' | 'userDisplayName' | 'userAvatarUrl' | 'reauthRequiredAt'
 		>
 	): boolean {
 		const server = this.servers.find((s) => s.id === id);
@@ -378,7 +407,10 @@ class ServerRegistry {
 
 		Object.assign(server, data);
 		serversSlot.set(this.servers);
-		this.#createStore(server);
+		const store = this.#createStore(server);
+		if (store.isAuthenticated) {
+			eventBusManager.startBus(id, serverConnectionManager.getClient(id));
+		}
 		return true;
 	}
 
@@ -414,7 +446,9 @@ class ServerRegistry {
 	/** Create a state store for a server and wire up remote user sync. */
 	#createStore(server: RegisteredServer): ServerStateStore {
 		const serverConnection = serverConnectionManager.getClient(server.id);
-		const store = new ServerStateStore(server, serverConnection);
+		const store = new ServerStateStore(server, serverConnection, undefined, () => {
+			this.handleAuthenticationRequired(server.id);
+		});
 		this.#stores.set(server.id, store);
 
 		// Eagerly fetch server info (name, MOTD, upload limits, etc.).

--- a/apps/frontend/src/lib/state/server/serverConnection.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/serverConnection.svelte.spec.ts
@@ -130,7 +130,7 @@ describe('ServerConnection', () => {
     client.dispose();
   });
 
-  it('clears registered server auth on realtime authentication-required signals', () => {
+  it('notifies the registry on realtime authentication-required signals', () => {
     const client = new ServerConnection(makeConfig({ token: 'my-token', serverId: 'remote-1' }));
 
     client.handleAuthenticationRequired();

--- a/apps/frontend/src/lib/state/server/serverConnection.svelte.ts
+++ b/apps/frontend/src/lib/state/server/serverConnection.svelte.ts
@@ -1,3 +1,4 @@
+import { isExplicitSignOutRedirectInProgress } from '$lib/auth/signOut';
 import { serverRegistry } from './registry.svelte';
 
 export type ConnectionStatus = 'connected' | 'connecting' | 'disconnected';
@@ -165,6 +166,12 @@ export class ServerConnection {
 
   handleAuthenticationRequired(): void {
     if (this.#serverId) {
+      if (
+        isExplicitSignOutRedirectInProgress() &&
+        serverRegistry.isOriginServer(this.#serverId)
+      ) {
+        return;
+      }
       serverRegistry.handleAuthenticationRequired(this.#serverId);
     }
   }

--- a/apps/frontend/src/lib/state/server/store.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.spec.ts
@@ -250,6 +250,7 @@ const registered: RegisteredServer = {
   userLogin: 'alice',
   userDisplayName: 'Alice',
   userAvatarUrl: null,
+  reauthRequiredAt: null,
   addedAt: 1
 };
 
@@ -283,12 +284,14 @@ function connectUnavailable() {
 function makeStore(
   fake: FakeServerConnection,
   server: RegisteredServer = registered,
-  publicServerInfoLoader = connectUnavailable()
+  publicServerInfoLoader = connectUnavailable(),
+  onAuthenticationRequired?: () => void
 ): ServerStateStore {
   const store = new ServerStateStore(
     server,
     fake as unknown as ServerConnection,
-    publicServerInfoLoader
+    publicServerInfoLoader,
+    onAuthenticationRequired
   );
   stores.push(store);
   return store;
@@ -427,6 +430,24 @@ afterEach(() => {
   setRealtimeSocketFactoryForTests(null);
   soundMocks.playCallSound.mockClear();
   vi.restoreAllMocks();
+});
+
+describe('ServerStateStore authentication state', () => {
+  it('treats reauth-required servers as unauthenticated without clearing user data', () => {
+    const fake = new FakeServerConnection([]);
+    const store = makeStore(fake, {
+      ...registered,
+      reauthRequiredAt: 123
+    });
+    store.currentUser.user = {
+      id: 'U1',
+      login: 'alice',
+      displayName: 'Alice'
+    } as typeof store.currentUser.user;
+
+    expect(store.isAuthenticated).toBe(false);
+    expect(store.currentUser.user).toMatchObject({ id: 'U1' });
+  });
 });
 
 describe('ServerStateStore live server updates', () => {

--- a/apps/frontend/src/lib/state/server/store.svelte.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.ts
@@ -111,29 +111,30 @@ export class ServerStateStore {
   constructor(
     registered: RegisteredServer,
     serverConnection: ServerConnection,
-    publicServerInfoLoader?: (baseUrl: string) => Promise<PublicServerInfo>
+    publicServerInfoLoader?: (baseUrl: string) => Promise<PublicServerInfo>,
+    onAuthenticationRequired?: () => void
   ) {
     this.serverId = registered.id;
     this.#registered = registered;
     const cookieAuth = this.#cookieAuth;
 
     const connectAPIConfig = {
+      serverId: serverConnection.serverId ?? registered.id,
       baseUrl: serverConnection.connectBaseUrl,
       bearerToken: serverConnection.bearerToken
     };
     const notificationAPI = createNotificationAPI(connectAPIConfig);
     const voiceCallAPI = createVoiceCallAPI(connectAPIConfig);
-    const roomDirectoryAPI = createRoomDirectoryAPI({
-      serverId: serverConnection.serverId ?? registered.id,
-      ...connectAPIConfig
-    });
-    const adminRoomLayoutAPI = createAdminRoomLayoutAPI({
-      serverId: serverConnection.serverId ?? registered.id,
-      ...connectAPIConfig
-    });
+    const roomDirectoryAPI = createRoomDirectoryAPI(connectAPIConfig);
+    const adminRoomLayoutAPI = createAdminRoomLayoutAPI(connectAPIConfig);
     const adminEventLogAPI = createAdminEventLogAPI(connectAPIConfig);
     const memberDirectoryAPI = createMemberDirectoryAPI(connectAPIConfig);
-    this.currentUser = new CurrentUserState(cookieAuth, connectAPIConfig);
+    this.currentUser = new CurrentUserState(
+      cookieAuth,
+      connectAPIConfig,
+      undefined,
+      onAuthenticationRequired
+    );
     this.serverInfo = new ServerInfoState(registered.url, publicServerInfoLoader, connectAPIConfig);
     this.notifications = new NotificationStore(notificationAPI);
     this.roomUnread = new RoomUnreadStore();
@@ -361,6 +362,7 @@ export class ServerStateStore {
    * - Bearer auth (remote): true when an access token is registered.
    */
   get isAuthenticated(): boolean {
+    if (this.#registered.reauthRequiredAt !== null) return false;
     if (this.#cookieAuth) {
       return this.currentUser.user != null;
     }

--- a/apps/frontend/src/routes/chat/+page.svelte
+++ b/apps/frontend/src/routes/chat/+page.svelte
@@ -19,7 +19,9 @@
   // Authenticated → use $effect to wait for reactive state (instances, permissions)
   $effect(() => {
     if (!data.user) return;
-    if (sessionStorage.getItem('returnUrl')) return;
+    if (sessionStorage.getItem('returnUrl') || sessionStorage.getItem('returnUrl:navigating')) {
+      return;
+    }
 
     if (serverRegistry.servers.length === 0) {
       goto(resolve('/login'), { replaceState: true });

--- a/apps/frontend/src/routes/chat/AuthenticatedChatProvider.svelte
+++ b/apps/frontend/src/routes/chat/AuthenticatedChatProvider.svelte
@@ -18,6 +18,8 @@
     scheduleCustomStatusExpiry,
     type CustomUserStatus
   } from '$lib/state/userProfiles.svelte';
+  import { clearCachedUser } from '$lib/auth/loadAuth';
+  import { hardRedirectAfterSignOut, isExplicitSignOutRedirectInProgress } from '$lib/auth/signOut';
   import { initSessionChannel } from '$lib/auth/sessionChannel';
   import { initPresenceTracking } from '$lib/presenceTracking';
   import ReturnUrlHandler from '$lib/components/ReturnUrlHandler.svelte';
@@ -102,9 +104,16 @@
   // dropped no-op.
   const originServerId = serverRegistry.originServer?.id;
   if (originServerId) {
+    const authenticatedOriginServerId = originServerId;
     const originClient = serverConnectionManager.originClient;
-    eventBusManager.startBus(originServerId, originClient);
-    provideEventBus(() => originServerId);
+    eventBusManager.startBus(authenticatedOriginServerId, originClient);
+    provideEventBus(() => authenticatedOriginServerId);
+
+    function clearTerminatedOriginSession() {
+      clearCachedUser();
+      serverRegistry.clearServerAuthentication(authenticatedOriginServerId);
+      hardRedirectAfterSignOut('/login');
+    }
 
     // Subscribe to profile update events and populate the cache
     useUserProfileUpdate((update) => {
@@ -143,11 +152,17 @@
     // Handle session terminated events from server (logout from another tab/device, admin boot)
     useSessionTerminated((reason) => {
       console.log('Session terminated by server:', reason);
-      serverRegistry.handleAuthenticationRequired(originServerId);
+      if (isExplicitSignOutRedirectInProgress()) return;
+      clearTerminatedOriginSession();
     });
 
     // Handle logout from another tab in the same browser (instant, no server round-trip)
-    $effect(() => initSessionChannel(() => serverRegistry.handleAuthenticationRequired(originServerId)));
+    $effect(() =>
+      initSessionChannel(() => {
+        if (isExplicitSignOutRedirectInProgress()) return;
+        clearTerminatedOriginSession();
+      })
+    );
 
   }
 

--- a/apps/frontend/src/routes/chat/AuthenticatedChatProvider.svelte
+++ b/apps/frontend/src/routes/chat/AuthenticatedChatProvider.svelte
@@ -112,7 +112,7 @@
     function clearTerminatedOriginSession() {
       clearCachedUser();
       serverRegistry.clearServerAuthentication(authenticatedOriginServerId);
-      hardRedirectAfterSignOut('/login');
+      hardRedirectAfterSignOut('/');
     }
 
     // Subscribe to profile update events and populate the cache

--- a/apps/frontend/src/routes/chat/AuthenticatedRoot.svelte
+++ b/apps/frontend/src/routes/chat/AuthenticatedRoot.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import type { CurrentUser } from '$lib/auth/loadAuth';
+  import AuthStatusNotice from '$lib/components/AuthStatusNotice.svelte';
   import NotificationSync from '$lib/components/NotificationSync.svelte';
   import { shouldPauseLiveEventsForStoredPresence } from '$lib/presenceTracking';
   import { createPresenceCache } from '$lib/state/presenceCache.svelte';
@@ -48,6 +49,7 @@
 </script>
 
 <NotificationSync />
+<AuthStatusNotice />
 
 <AuthenticatedChatProvider {user} {userSettings} {profileCache} {presenceCache}>
   {@render children()}

--- a/apps/frontend/src/routes/chat/ModalContainer.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/ModalContainer.svelte.spec.ts
@@ -29,6 +29,7 @@ const { mocks } = vi.hoisted(() => ({
       | { id: string; url: string; name: string; token: string | null }
       | undefined,
     authenticated: {} as Record<string, boolean>,
+    beginExplicitSignOutRedirect: vi.fn(),
     signOutServer: vi.fn(),
     signOutServers: vi.fn(),
     hardRedirectAfterSignOut: vi.fn(),
@@ -127,6 +128,7 @@ vi.mock('$lib/auth/sessionChannel', () => ({
 }));
 
 vi.mock('$lib/auth/signOut', () => ({
+  beginExplicitSignOutRedirect: mocks.beginExplicitSignOutRedirect,
   signOutServer: mocks.signOutServer,
   signOutServers: mocks.signOutServers,
   hardRedirectAfterSignOut: mocks.hardRedirectAfterSignOut
@@ -324,6 +326,7 @@ describe('ModalContainer sign out modal', () => {
 
     await vi.waitFor(() => {
       expect(mocks.signOutServer).toHaveBeenCalledWith(mocks.originServer, true);
+      expect(mocks.beginExplicitSignOutRedirect).toHaveBeenCalledOnce();
       expect(mocks.clearServerAuthentication).toHaveBeenCalledWith('origin');
       expect(mocks.removeServer).not.toHaveBeenCalled();
       expect(mocks.notifyLogout).toHaveBeenCalledOnce();
@@ -345,6 +348,7 @@ describe('ModalContainer sign out modal', () => {
     clickButton(container, 'All Servers');
 
     await vi.waitFor(() => {
+      expect(mocks.beginExplicitSignOutRedirect).toHaveBeenCalledOnce();
       expect(mocks.signOutServers).toHaveBeenCalledWith(mocks.servers, expect.any(Function));
       expect(mocks.removeAll).toHaveBeenCalledOnce();
       expect(mocks.notifyLogout).toHaveBeenCalledOnce();
@@ -369,6 +373,7 @@ describe('ModalContainer sign out modal', () => {
     clickButton(container, 'All Servers');
 
     await vi.waitFor(() => {
+      expect(mocks.beginExplicitSignOutRedirect).toHaveBeenCalledOnce();
       expect(mocks.signOutServers).toHaveBeenCalledWith([], expect.any(Function));
       expect(mocks.removeAll).toHaveBeenCalledOnce();
       expect(mocks.hardRedirectAfterSignOut).toHaveBeenCalledWith('/');
@@ -391,6 +396,7 @@ describe('ModalContainer sign out modal', () => {
     clickButton(container, 'All Servers');
 
     await vi.waitFor(() => {
+      expect(mocks.beginExplicitSignOutRedirect).toHaveBeenCalledOnce();
       expect(mocks.signOutServers).toHaveBeenCalledWith(mocks.servers, expect.any(Function));
       expect(mocks.removeAll).toHaveBeenCalledOnce();
       expect(mocks.hardRedirectAfterSignOut).toHaveBeenCalledWith('/');

--- a/apps/frontend/src/routes/chat/SignOutDialog.svelte
+++ b/apps/frontend/src/routes/chat/SignOutDialog.svelte
@@ -7,7 +7,12 @@
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { clearLastRoom } from '$lib/storage/lastRoom';
   import { notifyLogout } from '$lib/auth/sessionChannel';
-  import { hardRedirectAfterSignOut, signOutServer, signOutServers } from '$lib/auth/signOut';
+  import {
+    beginExplicitSignOutRedirect,
+    hardRedirectAfterSignOut,
+    signOutServer,
+    signOutServers
+  } from '$lib/auth/signOut';
   import * as m from '$lib/i18n/messages';
   import Dialog from '$lib/ui/Dialog.svelte';
   import { Button } from '$lib/ui/form';
@@ -68,6 +73,10 @@
 
     signingOutCurrent = true;
 
+    if (serverRegistry.isOriginServer(signedOutServerId)) {
+      beginExplicitSignOutRedirect();
+    }
+
     await signOutServer(server, serverRegistry.isOriginServer(signedOutServerId)).catch(() => {});
 
     clearLastRoom(signedOutServerId);
@@ -84,6 +93,7 @@
 
   async function handleSignOutAllServers() {
     signingOutAll = true;
+    beginExplicitSignOutRedirect();
     await signOutServers([...serverRegistry.servers], (serverId) =>
       serverRegistry.isOriginServer(serverId)
     );

--- a/apps/frontend/src/routes/chat/[serverId]/+layout.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/+layout.svelte
@@ -58,10 +58,14 @@
 
   // Auth guard: redirect unauthenticated users to /login and save the return URL.
   const currentUserState = $derived(serverStore?.currentUser);
+  const reauthRequired = $derived(
+    !!serverStore && serverRegistry.getServer(serverId)?.reauthRequiredAt != null
+  );
   $effect(() => {
     if (!browser) return;
     if (!currentUserState) return; // No store — already redirecting above
     if (currentUserState.loading) return; // Still loading, wait
+    if (reauthRequired) return; // Session/token expired; AuthStatusNotice owns recovery.
     if (currentUserState.user) return; // Authenticated, allow
 
     // Not authenticated on this instance — save return URL and redirect
@@ -77,7 +81,7 @@
   });
 </script>
 
-{#if currentUserState?.user}
+{#if currentUserState?.user || reauthRequired}
   <Chrome>
     {@render children?.()}
   </Chrome>

--- a/apps/frontend/src/routes/chat/[serverId]/+layout.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/+layout.svelte
@@ -8,6 +8,7 @@
   import { provideConnection } from '$lib/state/server/connection.svelte';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { provideEventBus } from '$lib/eventBus.svelte';
+  import { hardRedirectAfterSignOut } from '$lib/auth/signOut';
   import Chrome from '$lib/components/chat/Chrome.svelte';
 
   let { children } = $props();
@@ -77,7 +78,7 @@
       from: currentUrl
     });
     sessionStorage.setItem('returnUrl', currentUrl);
-    goto(resolve('/login'), { replaceState: true });
+    hardRedirectAfterSignOut(resolve('/login'));
   });
 </script>
 

--- a/apps/frontend/src/routes/chat/[serverId]/+layout.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/+layout.svelte
@@ -8,7 +8,6 @@
   import { provideConnection } from '$lib/state/server/connection.svelte';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { provideEventBus } from '$lib/eventBus.svelte';
-  import { hardRedirectAfterSignOut } from '$lib/auth/signOut';
   import Chrome from '$lib/components/chat/Chrome.svelte';
 
   let { children } = $props();
@@ -78,7 +77,7 @@
       from: currentUrl
     });
     sessionStorage.setItem('returnUrl', currentUrl);
-    hardRedirectAfterSignOut(resolve('/login'));
+    goto(resolve('/login'), { replaceState: true });
   });
 </script>
 

--- a/apps/frontend/src/routes/chat/[serverId]/settings/account/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/account/+page.svelte
@@ -278,7 +278,7 @@
       clearCachedUser();
     }
     serverRegistry.clearServerAuthentication(signedOutServerId);
-    hardRedirectAfterSignOut('/login');
+    hardRedirectAfterSignOut('/');
     if (serverRegistry.isOriginServer(signedOutServerId)) {
       notifyLogout();
     }

--- a/apps/frontend/src/routes/chat/[serverId]/settings/account/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/account/+page.svelte
@@ -16,6 +16,12 @@
   import { toast } from '$lib/ui/toast/toastState.svelte';
   import { notifyLogout } from '$lib/auth/sessionChannel';
   import { csrfFetch } from '$lib/auth/csrf';
+  import { clearCachedUser } from '$lib/auth/loadAuth';
+  import {
+    beginExplicitSignOutRedirect,
+    cancelExplicitSignOutRedirect,
+    hardRedirectAfterSignOut
+  } from '$lib/auth/signOut';
   import * as m from '$lib/i18n/messages';
 
   const currentUser = $derived(serverRegistry.getStore(getActiveServer()).currentUser);
@@ -267,6 +273,17 @@
     await disconnectIdentity(disconnectTarget, currentPassword);
   }
 
+  function finishDisconnectedSession(signedOutServerId: string) {
+    if (serverRegistry.isOriginServer(signedOutServerId)) {
+      clearCachedUser();
+    }
+    serverRegistry.clearServerAuthentication(signedOutServerId);
+    hardRedirectAfterSignOut('/login');
+    if (serverRegistry.isOriginServer(signedOutServerId)) {
+      notifyLogout();
+    }
+  }
+
   async function disconnectIdentity(
     target: { subjectHash: string; providerLabel: string },
     currentPassword?: string
@@ -281,14 +298,16 @@
         baseUrl: client.connectBaseUrl,
         bearerToken: client.bearerToken
       });
+      beginExplicitSignOutRedirect();
       await api.disconnect(subjectHash, currentPassword);
       disconnectTarget = null;
       disconnectFreshAuthTarget = null;
       disconnectCurrentPassword = '';
       disconnectFreshAuthError = '';
-      serverRegistry.handleAuthenticationRequired(client.serverId ?? serverId);
+      finishDisconnectedSession(client.serverId ?? serverId);
     } catch (err) {
       if (err instanceof ConnectError && err.code === Code.FailedPrecondition) {
+        cancelExplicitSignOutRedirect();
         disconnectTarget = null;
         if (hasPassword) {
           disconnectFreshAuthTarget = { subjectHash, providerLabel };
@@ -297,10 +316,14 @@
         } else {
           ssoError = m['settings.account.sso.disconnect_fresh_auth_required']();
         }
+      } else if (err instanceof ConnectError && err.code === Code.Unauthenticated) {
+        finishDisconnectedSession(client.serverId ?? serverId);
       } else if (currentPassword !== undefined) {
+        cancelExplicitSignOutRedirect();
         disconnectFreshAuthError =
           err instanceof Error ? err.message : m['settings.account.sso.disconnect_failed']();
       } else {
+        cancelExplicitSignOutRedirect();
         ssoError =
           err instanceof Error ? err.message : m['settings.account.sso.disconnect_failed']();
         disconnectTarget = null;

--- a/apps/frontend/src/routes/servers/callback/+page.svelte
+++ b/apps/frontend/src/routes/servers/callback/+page.svelte
@@ -88,12 +88,15 @@
       if (existing) {
         serverRegistry.updateServer(existing.id, {
           name: flow.serverName ?? existing.name,
-          iconUrl: flow.serverIconUrl ?? existing.iconUrl,
+          iconUrl: flow.serverIconUrl ?? existing.iconUrl
+        });
+        serverRegistry.replaceServerAuthentication(existing.id, {
           token: result.access_token,
           userId: result.user?.id ?? null,
           userLogin: result.user?.login ?? null,
           userDisplayName: result.user?.displayName ?? null,
-          userAvatarUrl: result.user?.avatarUrl ?? null
+          userAvatarUrl: result.user?.avatarUrl ?? null,
+          reauthRequiredAt: null
         });
         serverId = existing.id;
       } else {
@@ -112,6 +115,7 @@
           userLogin: result.user?.login ?? null,
           userDisplayName: result.user?.displayName ?? null,
           userAvatarUrl: result.user?.avatarUrl ?? null,
+          reauthRequiredAt: null,
           addedAt: Date.now()
         });
         serverId = id;


### PR DESCRIPTION
Handle ConnectRPC and realtime auth failures as a recoverable reauthentication state instead of immediately clearing auth or navigating logged-in users to login.

This adds persisted per-server reauth state, a top auth-status notice with origin and remote reconnect actions, shared OAuth reconnect startup, and paused fetch/realtime loops while reauth is required.

Follow-up CI fix: explicit logout, cross-tab logout, and external identity disconnect flows now clear cached origin auth and use explicit signout redirects instead of falling into the passive reauth shell.

Validation: `mise x -- pnpm --filter @chatto/api-types build`, `mise x -- pnpm --dir apps/frontend run check`, focused Vitest auth/registry/realtime/store/AddServer/AuthStatusNotice suite, `mise x -- pnpm --dir apps/frontend exec playwright test e2e/cross-tab-signout.test.ts e2e/external-identities.test.ts --retries=0 --workers=2`, and `mise test-frontend` passed.
