### PR TITLE
fix(reactions): canonicalize echo reaction targets

### DIFF
--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/messages.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/messages.mdx
@@ -340,10 +340,14 @@ POST /api/connect/chatto.api.v1.MessageService/AddReaction
 
 Request to add the current user's reaction to a message.
 
+When `message_event_id` names a channel echo of a thread reply, the server
+treats it as an alias for the original thread reply and stores the reaction
+on that original event.
+
 | Field | Type | Description |
 | --- | --- | --- |
 | `room_id` | `string` | Required. Room containing the message event. |
-| `message_event_id` | `string` | Required. Event ID of the message being reacted to. |
+| `message_event_id` | `string` | Required. Event ID of the message being reacted to, or a channel echo of the message. |
 | `emoji` | `string` | Required. Emoji shortcode name, such as "thumbsup" or "heart". |
 
 
@@ -376,10 +380,14 @@ POST /api/connect/chatto.api.v1.MessageService/RemoveReaction
 
 Request to remove the current user's reaction from a message.
 
+When `message_event_id` names a channel echo of a thread reply, the server
+treats it as an alias for the original thread reply and removes the reaction
+from that original event.
+
 | Field | Type | Description |
 | --- | --- | --- |
 | `room_id` | `string` | Required. Room containing the message event. |
-| `message_event_id` | `string` | Required. Event ID of the message whose reaction should be removed. |
+| `message_event_id` | `string` | Required. Event ID of the message whose reaction should be removed, or a channel echo of the message. |
 | `emoji` | `string` | Required. Emoji shortcode name, such as "thumbsup" or "heart". |
 
 

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/realtime.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/realtime.mdx
@@ -363,12 +363,15 @@ Reaction signal.
 Refresh or patch the affected message in its timeline window. Use
 `RoomService.GetRoomEventsAround` for room messages, or
 `ThreadService.GetThreadEventsAround` when the local message belongs to
-a thread.
+a thread. `message_event_id` is canonical: reactions made through a channel
+echo of a thread reply report the original reply event ID. Clients that show
+channel echoes should also refresh or patch visible echo rows whose
+`echo_of_event_id` matches this ID.
 
 | Field | Type | Description |
 | --- | --- | --- |
 | `room_id` | `string` | Room containing the reacted-to message. |
-| `message_event_id` | `string` | Event ID of the reacted-to message. |
+| `message_event_id` | `string` | Canonical event ID of the reacted-to message. |
 | `emoji` | `string` | Reaction emoji. |
 
 <a id="chatto-realtime-v1-RealtimeRoomEvent"></a>

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -1493,10 +1493,14 @@ POST /api/connect/chatto.api.v1.MessageService/AddReaction
 
 Request to add the current user's reaction to a message.
 
+When `message_event_id` names a channel echo of a thread reply, the server
+treats it as an alias for the original thread reply and stores the reaction
+on that original event.
+
 | Field | Type | Description |
 | --- | --- | --- |
 | `room_id` | `string` | Required. Room containing the message event. |
-| `message_event_id` | `string` | Required. Event ID of the message being reacted to. |
+| `message_event_id` | `string` | Required. Event ID of the message being reacted to, or a channel echo of the message. |
 | `emoji` | `string` | Required. Emoji shortcode name, such as "thumbsup" or "heart". |
 
 
@@ -1529,10 +1533,14 @@ POST /api/connect/chatto.api.v1.MessageService/RemoveReaction
 
 Request to remove the current user's reaction from a message.
 
+When `message_event_id` names a channel echo of a thread reply, the server
+treats it as an alias for the original thread reply and removes the reaction
+from that original event.
+
 | Field | Type | Description |
 | --- | --- | --- |
 | `room_id` | `string` | Required. Room containing the message event. |
-| `message_event_id` | `string` | Required. Event ID of the message whose reaction should be removed. |
+| `message_event_id` | `string` | Required. Event ID of the message whose reaction should be removed, or a channel echo of the message. |
 | `emoji` | `string` | Required. Emoji shortcode name, such as "thumbsup" or "heart". |
 
 

--- a/apps/docs-website/src/generated/connectrpc-api/realtime.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/realtime.raw.mdx
@@ -402,12 +402,15 @@ Reaction signal.
 Refresh or patch the affected message in its timeline window. Use
 `RoomService.GetRoomEventsAround` for room messages, or
 `ThreadService.GetThreadEventsAround` when the local message belongs to
-a thread.
+a thread. `message_event_id` is canonical: reactions made through a channel
+echo of a thread reply report the original reply event ID. Clients that show
+channel echoes should also refresh or patch visible echo rows whose
+`echo_of_event_id` matches this ID.
 
 | Field | Type | Description |
 | --- | --- | --- |
 | `room_id` | `string` | Room containing the reacted-to message. |
-| `message_event_id` | `string` | Event ID of the reacted-to message. |
+| `message_event_id` | `string` | Canonical event ID of the reacted-to message. |
 | `emoji` | `string` | Reaction emoji. |
 
 

--- a/apps/frontend/e2e/thread-reply-echo.test.ts
+++ b/apps/frontend/e2e/thread-reply-echo.test.ts
@@ -411,7 +411,7 @@ test.describe('Thread Reply Echo ("Also send to channel")', () => {
     );
   });
 
-  test('echo and original have independent reactions', async ({ page, chatPage, roomPage }) => {
+  test('echo and original share reactions', async ({ page, chatPage, roomPage }) => {
     await test.step('Setup: User loads the server and posts root message', async () => {
       await createAndLoginTestUser(page);
       await chatPage.goto();
@@ -435,7 +435,7 @@ test.describe('Thread Reply Echo ("Also send to channel")', () => {
       await threadReply.expectReaction('👍', 1);
     });
 
-    await test.step('Close thread and verify echo does not inherit the reaction', async () => {
+    await test.step('Close thread and verify echo shows the original reaction', async () => {
       await roomPage.closeThread();
       await roomPage.expectThreadRouteClosed();
 
@@ -443,10 +443,10 @@ test.describe('Thread Reply Echo ("Also send to channel")', () => {
       const echo = roomPage.getMessage(replyMessage);
       await expect(echo.locator).toBeVisible();
 
-      await echo.expectNoReaction('👍');
+      await echo.expectReaction('👍', 1);
     });
 
-    await test.step('React to echo and verify thread original stays independent', async () => {
+    await test.step('React to echo and verify thread original shows the echo reaction', async () => {
       const echo = roomPage.getMessage(replyMessage);
       await echo.react('❤️');
       await echo.expectReaction('❤️', 1);
@@ -456,7 +456,7 @@ test.describe('Thread Reply Echo ("Also send to channel")', () => {
 
       const threadReply = roomPage.getThreadMessage(replyMessage);
       await threadReply.expectReaction('👍', 1);
-      await threadReply.expectNoReaction('❤️');
+      await threadReply.expectReaction('❤️', 1);
     });
   });
 

--- a/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -623,6 +623,71 @@ describe('MessagesStore — room lifecycle ownership', () => {
     store.dispose();
   });
 
+  it('refetches a visible echo when a reaction event targets the original reply', async () => {
+    const baseEcho = threadMessageEvent('echo');
+    const echo = {
+      ...baseEcho,
+      event: {
+        ...baseEcho.event,
+        body: 'reply',
+        echoOfEventId: 'reply',
+        echoFromThreadRootEventId: 'root'
+      }
+    };
+    const updatedEcho = {
+      ...echo,
+      event: {
+        ...echo.event,
+        reactions: [{ emoji: 'heart', count: 1, hasReacted: false, users: [] }]
+      }
+    };
+    const fake = new FakeQueryClient([
+      roomEventsResult({
+        events: [echo],
+        startCursor: 'tl:cursor-1',
+        endCursor: 'tl:cursor-1',
+        hasOlder: false,
+        hasNewer: false
+      }),
+      { room: { event: updatedEcho } }
+    ]);
+    const store = new MessagesStore(
+      fake as unknown as ServerConnection,
+      () => null,
+      timelineFromFixtures(fake)
+    );
+
+    store.setRoom('room-1');
+    await settle();
+    fake.queryMock.mockClear();
+
+    store.ingestServerEvent({
+      id: 'reaction-echo',
+      createdAt: '2026-05-27T00:00:01Z',
+      actorId: 'u2',
+      actor: null,
+      event: {
+        kind: RoomEventKind.ReactionAdded,
+        roomId: 'room-1',
+        messageEventId: 'reply',
+        emoji: 'heart'
+      }
+    } as never);
+    await settle();
+
+    expect(fake.queryMock).toHaveBeenCalledOnce();
+    expect(fake.queryMock.mock.calls[0][1]).toEqual({
+      roomId: 'room-1',
+      eventId: 'echo',
+      limit: 1
+    });
+    expect(fake.queryMock.mock.calls[0][2]).toEqual({ requestPolicy: 'network-only' });
+    expect(store.rootEvents[0].event).toMatchObject({
+      reactions: [{ emoji: 'heart', count: 1 }]
+    });
+    store.dispose();
+  });
+
   it('hides only the echo when an echo is retracted', async () => {
     const fake = new FakeQueryClient({
       room: {

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -4625,6 +4625,80 @@ func TestMessageServiceAddAndRemoveResponseSemantics(t *testing.T) {
 	}
 }
 
+func TestMessageServiceReactionOnEchoCanonicalizesToOriginal(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	room := env.createJoinedRoom("reaction-echo")
+	ctx := withCaller(env.ctx, env.viewer)
+
+	root := env.post(room.Id, env.viewer.Id, "root", "")
+	reply, err := env.core.PostMessage(env.ctx, core.KindChannel, room.Id, env.viewer.Id, "reply", nil, root.Id, root.Id, nil, true)
+	if err != nil {
+		t.Fatalf("PostMessage reply with echo: %v", err)
+	}
+	echoID, ok := env.core.RoomTimeline.ChannelEchoEventID(reply.Id)
+	if !ok {
+		t.Fatal("expected channel echo for reply")
+	}
+
+	addResp, err := env.messages.AddReaction(ctx, connect.NewRequest(&apiv1.AddReactionRequest{
+		RoomId:         room.Id,
+		MessageEventId: echoID,
+		Emoji:          "thumbsup",
+	}))
+	if err != nil {
+		t.Fatalf("AddReaction via echo: %v", err)
+	}
+	if !addResp.Msg.GetAdded() {
+		t.Fatal("AddReaction via echo Added = false, want true")
+	}
+	if got := addResp.Msg.GetReaction(); got.GetEmoji() != "thumbsup" || got.GetCount() != 1 || !got.GetHasReacted() {
+		t.Fatalf("AddReaction via echo reaction = %+v, want thumbsup count 1 hasReacted", got)
+	}
+
+	dupResp, err := env.messages.AddReaction(ctx, connect.NewRequest(&apiv1.AddReactionRequest{
+		RoomId:         room.Id,
+		MessageEventId: reply.Id,
+		Emoji:          "thumbsup",
+	}))
+	if err != nil {
+		t.Fatalf("duplicate AddReaction via original: %v", err)
+	}
+	if dupResp.Msg.GetAdded() {
+		t.Fatal("duplicate AddReaction via original Added = true, want false")
+	}
+
+	roomResp, err := env.rooms.GetRoomEvents(ctx, connect.NewRequest(&apiv1.GetRoomEventsRequest{
+		RoomId: room.Id,
+		Limit:  10,
+	}))
+	if err != nil {
+		t.Fatalf("GetRoomEvents: %v", err)
+	}
+	echoEvent := timelinePageEvent(roomResp.Msg.GetPage(), echoID)
+	if echoEvent == nil || echoEvent.GetMessagePosted() == nil {
+		t.Fatalf("echo event %s missing from room page", echoID)
+	}
+	if got := echoEvent.GetMessagePosted().GetReactions(); len(got) != 1 || got[0].GetEmoji() != "thumbsup" || got[0].GetCount() != 1 || !got[0].GetHasReacted() {
+		t.Fatalf("echo reactions = %+v, want thumbsup count 1 hasReacted", got)
+	}
+
+	threadResp, err := env.threads.GetThreadEvents(ctx, connect.NewRequest(&apiv1.GetThreadEventsRequest{
+		RoomId:            room.Id,
+		ThreadRootEventId: root.Id,
+		Limit:             10,
+	}))
+	if err != nil {
+		t.Fatalf("GetThreadEvents: %v", err)
+	}
+	replyEvent := timelinePageEvent(threadResp.Msg.GetPage(), reply.Id)
+	if replyEvent == nil || replyEvent.GetMessagePosted() == nil {
+		t.Fatalf("reply event %s missing from thread page", reply.Id)
+	}
+	if got := replyEvent.GetMessagePosted().GetReactions(); len(got) != 1 || got[0].GetEmoji() != "thumbsup" || got[0].GetCount() != 1 || !got[0].GetHasReacted() {
+		t.Fatalf("reply reactions = %+v, want thumbsup count 1 hasReacted", got)
+	}
+}
+
 func TestMessageServiceValidatesEmoji(t *testing.T) {
 	env := newConnectAPITestEnv(t)
 	room := env.createJoinedRoom("reaction-validation")

--- a/cli/internal/core/reaction_projection.go
+++ b/cli/internal/core/reaction_projection.go
@@ -17,11 +17,12 @@ import (
 // known.
 type ReactionProjection struct {
 	events.MemoryProjection
-	byMessage   map[string]map[string]map[string]int64 // message event ID -> emoji -> user ID -> added timestamp
-	roomSeq     map[string]uint64
-	messageRoom map[string]string
-	assetRoom   map[string]string
-	seen        eventIDSet
+	byMessage    map[string]map[string]map[string]int64 // message event ID -> emoji -> user ID -> added timestamp
+	roomSeq      map[string]uint64
+	messageRoom  map[string]string
+	echoOriginal map[string]string
+	assetRoom    map[string]string
+	seen         eventIDSet
 }
 
 type ReactionMutationSnapshot struct {
@@ -31,11 +32,12 @@ type ReactionMutationSnapshot struct {
 
 func NewReactionProjection() *ReactionProjection {
 	return &ReactionProjection{
-		byMessage:   make(map[string]map[string]map[string]int64),
-		roomSeq:     make(map[string]uint64),
-		messageRoom: make(map[string]string),
-		assetRoom:   make(map[string]string),
-		seen:        newEventIDSet(),
+		byMessage:    make(map[string]map[string]map[string]int64),
+		roomSeq:      make(map[string]uint64),
+		messageRoom:  make(map[string]string),
+		echoOriginal: make(map[string]string),
+		assetRoom:    make(map[string]string),
+		seen:         newEventIDSet(),
 	}
 }
 
@@ -121,6 +123,9 @@ func (p *ReactionProjection) noteRoomOwnershipLocked(event *corev1.Event, roomID
 	case *corev1.Event_MessagePosted:
 		if event.GetId() != "" {
 			p.messageRoom[event.GetId()] = roomID
+			if originalID := e.MessagePosted.GetEchoOfEventId(); originalID != "" {
+				p.echoOriginal[event.GetId()] = originalID
+			}
 		}
 	case *corev1.Event_AssetCreated:
 		if assetID := e.AssetCreated.GetAsset().GetId(); assetID != "" {
@@ -135,10 +140,11 @@ func (p *ReactionProjection) applyAdded(e *corev1.ReactionAddedEvent, userID str
 	if e == nil || userID == "" || e.GetMessageEventId() == "" || e.GetEmoji() == "" {
 		return
 	}
-	byEmoji := p.byMessage[e.GetMessageEventId()]
+	messageEventID := p.canonicalMessageEventIDLocked(e.GetMessageEventId())
+	byEmoji := p.byMessage[messageEventID]
 	if byEmoji == nil {
 		byEmoji = make(map[string]map[string]int64)
-		p.byMessage[e.GetMessageEventId()] = byEmoji
+		p.byMessage[messageEventID] = byEmoji
 	}
 	byUser := byEmoji[e.GetEmoji()]
 	if byUser == nil {
@@ -154,7 +160,8 @@ func (p *ReactionProjection) applyRemoved(e *corev1.ReactionRemovedEvent, userID
 	if e == nil || userID == "" || e.GetMessageEventId() == "" || e.GetEmoji() == "" {
 		return
 	}
-	byEmoji := p.byMessage[e.GetMessageEventId()]
+	messageEventID := p.canonicalMessageEventIDLocked(e.GetMessageEventId())
+	byEmoji := p.byMessage[messageEventID]
 	if byEmoji == nil {
 		return
 	}
@@ -167,8 +174,15 @@ func (p *ReactionProjection) applyRemoved(e *corev1.ReactionRemovedEvent, userID
 		delete(byEmoji, e.GetEmoji())
 	}
 	if len(byEmoji) == 0 {
-		delete(p.byMessage, e.GetMessageEventId())
+		delete(p.byMessage, messageEventID)
 	}
+}
+
+func (p *ReactionProjection) canonicalMessageEventIDLocked(messageEventID string) string {
+	if originalID := p.echoOriginal[messageEventID]; originalID != "" {
+		return originalID
+	}
+	return messageEventID
 }
 
 func eventCreatedNanos(event *corev1.Event) int64 {
@@ -187,7 +201,7 @@ func (p *ReactionProjection) ReactionMutationSnapshot(roomID, messageEventID, em
 	defer p.RUnlock()
 
 	snapshot := ReactionMutationSnapshot{Seq: p.roomSeq[roomID]}
-	byEmoji := p.byMessage[messageEventID]
+	byEmoji := p.byMessage[p.canonicalMessageEventIDLocked(messageEventID)]
 	if byEmoji == nil {
 		return snapshot
 	}
@@ -202,7 +216,7 @@ func (p *ReactionProjection) ReactionMutationSnapshot(roomID, messageEventID, em
 func (p *ReactionProjection) Reactions(messageEventID string) []ReactionSummary {
 	p.RLock()
 	defer p.RUnlock()
-	return reactionSummariesForMessage(p.byMessage[messageEventID])
+	return reactionSummariesForMessage(p.byMessage[p.canonicalMessageEventIDLocked(messageEventID)])
 }
 
 func (p *ReactionProjection) ReactionsBatch(messageEventIDs []string) map[string][]ReactionSummary {
@@ -211,7 +225,7 @@ func (p *ReactionProjection) ReactionsBatch(messageEventIDs []string) map[string
 
 	result := make(map[string][]ReactionSummary, len(messageEventIDs))
 	for _, eventID := range messageEventIDs {
-		if byEmoji := p.byMessage[eventID]; byEmoji != nil {
+		if byEmoji := p.byMessage[p.canonicalMessageEventIDLocked(eventID)]; byEmoji != nil {
 			result[eventID] = reactionSummariesForMessage(byEmoji)
 		}
 	}

--- a/cli/internal/core/reaction_projection_test.go
+++ b/cli/internal/core/reaction_projection_test.go
@@ -66,6 +66,49 @@ func TestReactionProjection_IgnoresDuplicateEventID(t *testing.T) {
 	}
 }
 
+func TestReactionProjection_CanonicalizesEchoReactionReplay(t *testing.T) {
+	p := NewReactionProjection()
+
+	applyReactionProjectionEvent(t, p, messagePostedProjectionEvent("M1", ""))
+	applyReactionProjectionEvent(t, p, messagePostedProjectionEvent("ECHO1", "M1"))
+	applyReactionProjectionEvent(t, p, reactionAddedProjectionEvent("R1", "ECHO1", "U1", "thumbsup", 1))
+	applyReactionProjectionEvent(t, p, reactionAddedProjectionEvent("R2", "M1", "U1", "thumbsup", 2))
+	applyReactionProjectionEvent(t, p, reactionAddedProjectionEvent("R3", "M1", "U2", "heart", 3))
+
+	if !p.HasReaction("M1", "thumbsup", "U1") {
+		t.Fatal("expected echo-keyed add to appear on original")
+	}
+	if !p.HasReaction("ECHO1", "thumbsup", "U1") {
+		t.Fatal("expected echo reads to resolve to original reaction state")
+	}
+
+	summaries := p.Reactions("M1")
+	if len(summaries) != 2 {
+		t.Fatalf("Reactions(M1) len = %d, want 2", len(summaries))
+	}
+	for _, summary := range summaries {
+		if summary.Emoji == "thumbsup" && len(summary.UserIDs) != 1 {
+			t.Fatalf("thumbsup users = %v, want duplicate collapsed to one user", summary.UserIDs)
+		}
+	}
+
+	batch := p.ReactionsBatch([]string{"M1", "ECHO1"})
+	if len(batch["M1"]) != 2 || len(batch["ECHO1"]) != 2 {
+		t.Fatalf("batch = %+v, want original and echo keys hydrated", batch)
+	}
+
+	applyReactionProjectionEvent(t, p, reactionRemovedProjectionEvent("R4", "ECHO1", "U1", "thumbsup"))
+	if p.HasReaction("M1", "thumbsup", "U1") {
+		t.Fatal("expected echo-keyed remove to remove original reaction")
+	}
+	if p.HasReaction("ECHO1", "thumbsup", "U1") {
+		t.Fatal("expected echo reads to reflect removed original reaction")
+	}
+	if !p.HasReaction("M1", "heart", "U2") {
+		t.Fatal("expected unrelated original reaction to remain")
+	}
+}
+
 func TestReactionProjection_MutationSnapshotTracksRoomSeq(t *testing.T) {
 	p := NewReactionProjection()
 
@@ -218,6 +261,18 @@ func TestRoomLayoutProjection_ReorderCloneAndIgnore(t *testing.T) {
 	}
 	if got := p.Order(); len(got) != 2 || got[0] != "G1" || got[1] != "G2" {
 		t.Fatalf("order after unrelated event = %v, want [G1 G2]", got)
+	}
+}
+
+func messagePostedProjectionEvent(id, echoOfEventID string) *corev1.Event {
+	return &corev1.Event{
+		Id: id,
+		Event: &corev1.Event_MessagePosted{
+			MessagePosted: &corev1.MessagePostedEvent{
+				RoomId:        "R1",
+				EchoOfEventId: echoOfEventID,
+			},
+		},
 	}
 }
 

--- a/cli/internal/core/reactions.go
+++ b/cli/internal/core/reactions.go
@@ -62,6 +62,10 @@ func (c *ChattoCore) AddReaction(ctx context.Context, kind RoomKind, roomID, mes
 		return false, ErrRoomArchived
 	}
 
+	messageEventID, err = c.canonicalReactionMessageEventID(roomID, messageEventID)
+	if err != nil {
+		return false, err
+	}
 	event := newReactionAddedEvent(userID, roomID, messageEventID, emojiName)
 	added, err := c.publishReactionMutation(ctx, kind, roomID, messageEventID, emojiName, userID, event)
 	if err != nil {
@@ -92,6 +96,10 @@ func (c *ChattoCore) RemoveReaction(ctx context.Context, kind RoomKind, roomID, 
 		return false, err
 	}
 
+	messageEventID, err = c.canonicalReactionMessageEventID(roomID, messageEventID)
+	if err != nil {
+		return false, err
+	}
 	event := newReactionRemovedEvent(userID, roomID, messageEventID, emojiName)
 	removed, err := c.publishReactionMutation(ctx, kind, roomID, messageEventID, emojiName, userID, event)
 	if err != nil {
@@ -122,6 +130,7 @@ type ReactionSummary struct {
 // Returns a slice of ReactionSummary, each containing the shortcode name and list of user IDs.
 // Results are ordered by the time each emoji was first added (earliest first).
 func (c *ChattoCore) GetReactions(ctx context.Context, messageEventID string) ([]ReactionSummary, error) {
+	messageEventID, _ = c.canonicalReactionMessageEventID("", messageEventID)
 	return c.rooms().reactionsForMessage(messageEventID), nil
 }
 
@@ -131,7 +140,59 @@ func (c *ChattoCore) GetReactionsBatch(ctx context.Context, eventIDs []string) (
 	if len(eventIDs) == 0 {
 		return make(map[string][]ReactionSummary), nil
 	}
-	return c.rooms().reactionsBatch(eventIDs), nil
+	canonicalEventIDs := make([]string, 0, len(eventIDs))
+	requestedByCanonical := make(map[string][]string, len(eventIDs))
+	for _, eventID := range eventIDs {
+		canonicalID, _ := c.canonicalReactionMessageEventID("", eventID)
+		canonicalEventIDs = append(canonicalEventIDs, canonicalID)
+		requestedByCanonical[canonicalID] = append(requestedByCanonical[canonicalID], eventID)
+	}
+	canonicalReactions := c.rooms().reactionsBatch(canonicalEventIDs)
+	result := make(map[string][]ReactionSummary, len(canonicalReactions))
+	for canonicalID, summaries := range canonicalReactions {
+		for _, requestedID := range requestedByCanonical[canonicalID] {
+			result[requestedID] = summaries
+		}
+	}
+	return result, nil
+}
+
+// CanonicalReactionMessageEventID returns the original thread reply event ID
+// when messageEventID identifies a channel echo. Unknown IDs are returned
+// unchanged so legacy callers get the same behavior as direct projection reads.
+func (c *ChattoCore) CanonicalReactionMessageEventID(roomID, messageEventID string) string {
+	canonicalID, err := c.canonicalReactionMessageEventID(roomID, messageEventID)
+	if err != nil {
+		return messageEventID
+	}
+	return canonicalID
+}
+
+func (c *ChattoCore) canonicalReactionMessageEventID(roomID, messageEventID string) (string, error) {
+	if strings.TrimSpace(messageEventID) == "" {
+		return messageEventID, nil
+	}
+	if c == nil || c.RoomTimeline == nil {
+		return messageEventID, nil
+	}
+	entry, ok := c.RoomTimeline.Get(messageEventID)
+	if !ok || entry == nil || entry.Event == nil {
+		return messageEventID, nil
+	}
+	if roomID != "" && roomIDOfEvent(entry.Event) != roomID {
+		return "", ErrMessageNotFound
+	}
+	posted := entry.Event.GetMessagePosted()
+	if posted == nil || posted.GetEchoOfEventId() == "" {
+		return messageEventID, nil
+	}
+	originalID := posted.GetEchoOfEventId()
+	if roomID != "" {
+		if originalEntry, ok := c.RoomTimeline.Get(originalID); ok && originalEntry != nil && originalEntry.Event != nil && roomIDOfEvent(originalEntry.Event) != roomID {
+			return "", ErrMessageNotFound
+		}
+	}
+	return originalID, nil
 }
 
 // ============================================================================

--- a/cli/internal/core/reactions_test.go
+++ b/cli/internal/core/reactions_test.go
@@ -443,7 +443,7 @@ func TestChattoCore_GetReactionsBatch(t *testing.T) {
 	})
 }
 
-func TestChattoCore_EchoReactionsIndependent(t *testing.T) {
+func TestChattoCore_EchoReactionsCanonicalizeToOriginal(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
@@ -483,104 +483,61 @@ func TestChattoCore_EchoReactionsIndependent(t *testing.T) {
 		t.Fatal("Echo event not found in room events")
 	}
 
-	t.Run("reaction on echo is stored against echo", func(t *testing.T) {
-		added, err := core.AddReaction(ctx, KindChannel, room.Id, echoEventID, "thumbsup", user.Id)
-		if err != nil {
-			t.Fatalf("AddReaction on echo failed: %v", err)
-		}
-		if !added {
-			t.Error("Expected reaction to be added")
-		}
+	added, err := core.AddReaction(ctx, KindChannel, room.Id, echoEventID, "thumbsup", user.Id)
+	if err != nil {
+		t.Fatalf("AddReaction on echo failed: %v", err)
+	}
+	if !added {
+		t.Fatal("AddReaction on echo added = false, want true")
+	}
 
-		reactions, err := core.GetReactions(ctx, echoEventID)
-		if err != nil {
-			t.Fatalf("GetReactions on echo failed: %v", err)
-		}
-		if len(reactions) != 1 {
-			t.Fatalf("Expected 1 reaction on echo, got %d", len(reactions))
-		}
-		if reactions[0].Emoji != "thumbsup" {
-			t.Errorf("Expected thumbsup, got %q", reactions[0].Emoji)
-		}
+	reactions, err := core.GetReactions(ctx, replyEvent.Id)
+	if err != nil {
+		t.Fatalf("GetReactions on original failed: %v", err)
+	}
+	if len(reactions) != 1 || reactions[0].Emoji != "thumbsup" || len(reactions[0].UserIDs) != 1 || reactions[0].UserIDs[0] != user.Id {
+		t.Fatalf("original reactions = %+v, want thumbsup by user", reactions)
+	}
 
-		originalReactions, err := core.GetReactions(ctx, replyEvent.Id)
-		if err != nil {
-			t.Fatalf("GetReactions on original failed: %v", err)
-		}
-		if len(originalReactions) != 0 {
-			t.Fatalf("Expected no reactions on original, got %d", len(originalReactions))
-		}
-	})
+	echoReactions, err := core.GetReactions(ctx, echoEventID)
+	if err != nil {
+		t.Fatalf("GetReactions on echo failed: %v", err)
+	}
+	if len(echoReactions) != 1 || echoReactions[0].Emoji != "thumbsup" || len(echoReactions[0].UserIDs) != 1 || echoReactions[0].UserIDs[0] != user.Id {
+		t.Fatalf("echo reactions = %+v, want same thumbsup by user", echoReactions)
+	}
 
-	t.Run("reaction on original stays on original", func(t *testing.T) {
-		added, err := core.AddReaction(ctx, KindChannel, room.Id, replyEvent.Id, "heart", user.Id)
-		if err != nil {
-			t.Fatalf("AddReaction on original failed: %v", err)
-		}
-		if !added {
-			t.Error("Expected reaction to be added")
-		}
+	batch, err := core.GetReactionsBatch(ctx, []string{replyEvent.Id, echoEventID})
+	if err != nil {
+		t.Fatalf("GetReactionsBatch failed: %v", err)
+	}
+	if len(batch[replyEvent.Id]) != 1 || len(batch[echoEventID]) != 1 || batch[replyEvent.Id][0].Emoji != batch[echoEventID][0].Emoji {
+		t.Fatalf("batch reactions = %+v, want matching original and echo entries", batch)
+	}
 
-		reactions, err := core.GetReactions(ctx, replyEvent.Id)
-		if err != nil {
-			t.Fatalf("GetReactions on original failed: %v", err)
-		}
-		if len(reactions) != 1 {
-			t.Errorf("Expected 1 reaction on original, got %d", len(reactions))
-		}
+	added, err = core.AddReaction(ctx, KindChannel, room.Id, replyEvent.Id, "thumbsup", user.Id)
+	if err != nil {
+		t.Fatalf("duplicate AddReaction via original failed: %v", err)
+	}
+	if added {
+		t.Fatal("duplicate AddReaction via original added = true, want false")
+	}
 
-		echoReactions, err := core.GetReactions(ctx, echoEventID)
-		if err != nil {
-			t.Fatalf("GetReactions on echo failed: %v", err)
-		}
-		if len(echoReactions) != 1 || echoReactions[0].Emoji != "thumbsup" {
-			t.Errorf("Expected echo to keep only thumbsup, got %+v", echoReactions)
-		}
-	})
+	removed, err := core.RemoveReaction(ctx, KindChannel, room.Id, echoEventID, "thumbsup", user.Id)
+	if err != nil {
+		t.Fatalf("RemoveReaction via echo failed: %v", err)
+	}
+	if !removed {
+		t.Fatal("RemoveReaction via echo removed = false, want true")
+	}
 
-	t.Run("same emoji on original and echo is independent", func(t *testing.T) {
-		added, err := core.AddReaction(ctx, KindChannel, room.Id, replyEvent.Id, "thumbsup", user.Id)
-		if err != nil {
-			t.Fatalf("AddReaction failed: %v", err)
-		}
-		if !added {
-			t.Error("Expected same emoji on original to be independent from echo")
-		}
-	})
-
-	t.Run("remove reaction via echo", func(t *testing.T) {
-		removed, err := core.RemoveReaction(ctx, KindChannel, room.Id, echoEventID, "thumbsup", user.Id)
-		if err != nil {
-			t.Fatalf("RemoveReaction via echo failed: %v", err)
-		}
-		if !removed {
-			t.Error("Expected reaction to be removed")
-		}
-
-		reactions, err := core.GetReactions(ctx, echoEventID)
-		if err != nil {
-			t.Fatalf("GetReactions failed: %v", err)
-		}
-		for _, r := range reactions {
-			if r.Emoji == "thumbsup" {
-				t.Error("thumbsup should have been removed from echo")
-			}
-		}
-
-		originalReactions, err := core.GetReactions(ctx, replyEvent.Id)
-		if err != nil {
-			t.Fatalf("GetReactions on original failed: %v", err)
-		}
-		var originalHasThumbsup bool
-		for _, r := range originalReactions {
-			if r.Emoji == "thumbsup" {
-				originalHasThumbsup = true
-			}
-		}
-		if !originalHasThumbsup {
-			t.Error("thumbsup on original should remain independent")
-		}
-	})
+	reactions, err = core.GetReactions(ctx, replyEvent.Id)
+	if err != nil {
+		t.Fatalf("GetReactions after remove failed: %v", err)
+	}
+	if len(reactions) != 0 {
+		t.Fatalf("original reactions after remove = %+v, want none", reactions)
+	}
 }
 
 func TestReactionKey(t *testing.T) {

--- a/cli/internal/http_server/realtime.go
+++ b/cli/internal/http_server/realtime.go
@@ -325,12 +325,16 @@ func (s *HTTPServer) mapRealtimeEVT(envelope *realtimev1.RealtimeEventEnvelope, 
 	case *corev1.Event_ReactionAdded:
 		reaction := payload.ReactionAdded
 		envelope.Event = &realtimev1.RealtimeEventEnvelope_ReactionAdded{ReactionAdded: &realtimev1.RealtimeReactionEvent{
-			RoomId: reaction.GetRoomId(), MessageEventId: reaction.GetMessageEventId(), Emoji: reaction.GetEmoji(),
+			RoomId:         reaction.GetRoomId(),
+			MessageEventId: s.core.CanonicalReactionMessageEventID(reaction.GetRoomId(), reaction.GetMessageEventId()),
+			Emoji:          reaction.GetEmoji(),
 		}}
 	case *corev1.Event_ReactionRemoved:
 		reaction := payload.ReactionRemoved
 		envelope.Event = &realtimev1.RealtimeEventEnvelope_ReactionRemoved{ReactionRemoved: &realtimev1.RealtimeReactionEvent{
-			RoomId: reaction.GetRoomId(), MessageEventId: reaction.GetMessageEventId(), Emoji: reaction.GetEmoji(),
+			RoomId:         reaction.GetRoomId(),
+			MessageEventId: s.core.CanonicalReactionMessageEventID(reaction.GetRoomId(), reaction.GetMessageEventId()),
+			Emoji:          reaction.GetEmoji(),
 		}}
 	case *corev1.Event_RoomCreated:
 		envelope.Event = &realtimev1.RealtimeEventEnvelope_RoomCreated{RoomCreated: realtimeRoomEvent(payload.RoomCreated.GetRoomId())}

--- a/cli/internal/http_server/realtime_test.go
+++ b/cli/internal/http_server/realtime_test.go
@@ -153,6 +153,49 @@ func TestRealtimeMapperMapsThreadCreated(t *testing.T) {
 	}
 }
 
+func TestRealtimeMapperCanonicalizesEchoReactionMessageID(t *testing.T) {
+	timeline := core.NewRoomTimelineProjection()
+	if err := timeline.Apply(&corev1.Event{
+		Id: "M1",
+		Event: &corev1.Event_MessagePosted{MessagePosted: &corev1.MessagePostedEvent{
+			RoomId:   "R1",
+			InThread: "ROOT1",
+		}},
+	}, 1); err != nil {
+		t.Fatalf("apply original message: %v", err)
+	}
+	if err := timeline.Apply(&corev1.Event{
+		Id: "ECHO1",
+		Event: &corev1.Event_MessagePosted{MessagePosted: &corev1.MessagePostedEvent{
+			RoomId:        "R1",
+			EchoOfEventId: "M1",
+		}},
+	}, 2); err != nil {
+		t.Fatalf("apply echo message: %v", err)
+	}
+
+	server := &HTTPServer{core: &core.ChattoCore{RoomTimeline: timeline}}
+	frame, err := server.realtimeEventEnvelope(context.Background(), "", core.NewEVTEventEnvelope(&corev1.Event{
+		Id:      "reaction-1",
+		ActorId: "U1",
+		Event: &corev1.Event_ReactionAdded{ReactionAdded: &corev1.ReactionAddedEvent{
+			RoomId:         "R1",
+			MessageEventId: "ECHO1",
+			Emoji:          "thumbsup",
+		}},
+	}))
+	if err != nil {
+		t.Fatalf("realtimeEventEnvelope: %v", err)
+	}
+	reaction := frame.GetReactionAdded()
+	if reaction == nil {
+		t.Fatalf("event = %T, want reaction_added", frame.GetEvent())
+	}
+	if reaction.MessageEventId != "M1" {
+		t.Fatalf("reaction message_event_id = %q, want M1", reaction.MessageEventId)
+	}
+}
+
 func TestRealtimeMapperMapsCallEventSource(t *testing.T) {
 	frame, err := (&HTTPServer{}).realtimeEventEnvelope(context.Background(), "", core.NewEVTEventEnvelope(&corev1.Event{
 		Id:      "call-joined-1",

--- a/cli/internal/pb/chatto/api/v1/reactions.pb.go
+++ b/cli/internal/pb/chatto/api/v1/reactions.pb.go
@@ -23,11 +23,16 @@ const (
 )
 
 // Request to add the current user's reaction to a message.
+//
+// When `message_event_id` names a channel echo of a thread reply, the server
+// treats it as an alias for the original thread reply and stores the reaction
+// on that original event.
 type AddReactionRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Required. Room containing the message event.
 	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
-	// Required. Event ID of the message being reacted to.
+	// Required. Event ID of the message being reacted to, or a channel echo of
+	// the message.
 	MessageEventId string `protobuf:"bytes,2,opt,name=message_event_id,json=messageEventId,proto3" json:"message_event_id,omitempty"`
 	// Required. Emoji shortcode name, such as "thumbsup" or "heart".
 	Emoji         string `protobuf:"bytes,3,opt,name=emoji,proto3" json:"emoji,omitempty"`
@@ -142,11 +147,16 @@ func (x *AddReactionResponse) GetReaction() *RoomTimelineReaction {
 }
 
 // Request to remove the current user's reaction from a message.
+//
+// When `message_event_id` names a channel echo of a thread reply, the server
+// treats it as an alias for the original thread reply and removes the reaction
+// from that original event.
 type RemoveReactionRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Required. Room containing the message event.
 	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
-	// Required. Event ID of the message whose reaction should be removed.
+	// Required. Event ID of the message whose reaction should be removed, or a
+	// channel echo of the message.
 	MessageEventId string `protobuf:"bytes,2,opt,name=message_event_id,json=messageEventId,proto3" json:"message_event_id,omitempty"`
 	// Required. Emoji shortcode name, such as "thumbsup" or "heart".
 	Emoji         string `protobuf:"bytes,3,opt,name=emoji,proto3" json:"emoji,omitempty"`

--- a/cli/internal/pb/chatto/realtime/v1/realtime.pb.go
+++ b/cli/internal/pb/chatto/realtime/v1/realtime.pb.go
@@ -1792,12 +1792,15 @@ func (x *RealtimeMessageRetractedEvent) GetReason() string {
 // Refresh or patch the affected message in its timeline window. Use
 // `RoomService.GetRoomEventsAround` for room messages, or
 // `ThreadService.GetThreadEventsAround` when the local message belongs to
-// a thread.
+// a thread. `message_event_id` is canonical: reactions made through a channel
+// echo of a thread reply report the original reply event ID. Clients that show
+// channel echoes should also refresh or patch visible echo rows whose
+// `echo_of_event_id` matches this ID.
 type RealtimeReactionEvent struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Room containing the reacted-to message.
 	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
-	// Event ID of the reacted-to message.
+	// Canonical event ID of the reacted-to message.
 	MessageEventId string `protobuf:"bytes,2,opt,name=message_event_id,json=messageEventId,proto3" json:"message_event_id,omitempty"`
 	// Reaction emoji.
 	Emoji         string `protobuf:"bytes,3,opt,name=emoji,proto3" json:"emoji,omitempty"`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -125,7 +125,7 @@ Projections are in-memory read models rebuilt from `EVT`. `NewChattoCore` regist
 | Room timeline      | Room Timeline        | `evt.room.>`                                               | Visible room timeline, latest message bodies, hidden echoes, current attachment-bearing message index, direct message-post lookup, and message asset references |
 | Assets             | Assets               | `evt.asset.>`, legacy `evt.room.*.asset_*`                 | Asset creation metadata, room scope, processing manifests, derivative graph, deletion state, and legacy room-asset compatibility |
 | Threads            | Threads              | `evt.room.*.thread_created`, `evt.room.*.thread_followed`, `evt.room.*.thread_unfollowed`, `evt.room.*.message_posted`, `evt.room.*.message_edited`, `evt.room.*.message_retracted`, `evt.user.*.user_key_shredded` | Per-thread reply logs, summaries, participants, reply counts, and follow state             |
-| Reactions          | Reactions            | `evt.room.>`                                               | Current per-message reaction sets and room-scoped snapshot OCC positions; intentionally broad so reaction writes can OCC against the room tail |
+| Reactions          | Reactions            | `evt.room.>`                                               | Current canonical per-message reaction sets, echo-to-original reaction aliases, and room-scoped snapshot OCC positions; intentionally broad so reaction writes can OCC against the room tail |
 | Voice calls        | Call State           | `evt.room.>`                                               | Current LiveKit call session, participants, active room IDs, and room-scoped snapshot OCC positions |
 | Server/user config | Server Config        | `evt.config.>`, selected user cleanup/preference facts     | Server config, branding refs, user preferences, notification levels, blocked usernames     |
 | Users              | Users                | `evt.user.>`                                               | Account/profile/custom-status/auth lookup state, verified emails, external identity links, encrypted user PII |
@@ -783,7 +783,7 @@ Messages are persisted as durable `EVT` facts. Public timeline facts (`MessagePo
 
 **Message Identifiers:**
 
-- **Event ID**: NanoID (e.g., `E...`) on the EVT envelope. This is the durable message identity used for reactions, thread metadata, message-body lookup, attachments, and projections.
+- **Event ID**: NanoID (e.g., `E...`) on the EVT envelope. This is the durable message identity used for thread metadata, message-body lookup, attachments, and projections. Reactions use this event ID except that channel echo IDs canonicalize to the original thread reply event ID.
 - **Payload**: `MessagePostedEvent` is payload-only. It carries room/thread/echo fields, but not an event ID, message-body ID alias, or embedded body.
 
 **Write Path:**
@@ -798,7 +798,7 @@ Messages are persisted as durable `EVT` facts. Public timeline facts (`MessagePo
 - `in_reply_to` field stores the event ID of the parent message (empty for top-level messages)
 - `in_thread` field stores the event ID of the thread root (empty for top-level messages)
 - Thread replies are ordinary `MessagePostedEvent` facts on `evt.room.{roomId}.message_posted` with `in_thread` set to the root event ID.
-- Thread replies can be echoed to the room timeline at post time or during the author's edit window. Echoes are separate `MessagePostedEvent` facts with `echo_of_event_id`; removing an edit-time echo appends a normal `MessageRetractedEvent` for the echo artifact.
+- Thread replies can be echoed to the room timeline at post time or during the author's edit window. Echoes are separate `MessagePostedEvent` facts with `echo_of_event_id`; removing an edit-time echo appends a normal `MessageRetractedEvent` for the echo artifact. Reaction writes and reads accept the echo event ID but canonicalize reaction state to the original reply event ID.
 - Thread follow and unfollow choices are durable `ThreadFollowedEvent` / `ThreadUnfollowedEvent` facts on the room aggregate. `ThreadProjection` derives current follow state, follower fanout, followed-thread pages, reply counts, participants, and last-reply timestamps. During the migration window, startup seeds pre-EVT `thread_follow.*` runtime markers into that projection before replaying EVT.
 
 **Read Path:**

--- a/docs/fdr/FDR-003-thread-reply-echo.md
+++ b/docs/fdr/FDR-003-thread-reply-echo.md
@@ -1,7 +1,7 @@
 # FDR-003: Thread Reply Echo
 
 **Status:** Active
-**Last reviewed:** 2026-06-01
+**Last reviewed:** 2026-07-03
 
 ## Overview
 
@@ -16,7 +16,7 @@ When posting a reply inside a thread, the user can optionally "also send to chan
 - If the original reply was attributed to a specific message, the echo shows the same reply-attribution byline. Clicking the byline on the echo opens the thread and highlights the referenced message inside it.
 - Editing or deleting the original reply automatically affects the echo too — edit/delete events target the original reply, and read models apply the change to the linked echo.
 - Deleting the echo itself only hides that room-timeline copy. The original thread reply remains in the thread with its body readable.
-- Reactions on the original and the echo are independent — they're different events as far as reactions are concerned.
+- Reactions shown on the original reply and its channel echo are the same reaction set; reacting in either place targets the original reply.
 - The thread's reply count is not incremented by the echo; the echo represents the same reply, not an additional one.
 - Mention notifications fire once for the reply, not twice (the echo doesn't re-notify).
 - The main-room composer never shows the echo checkbox — the action only makes sense from inside a thread.
@@ -28,7 +28,7 @@ When posting a reply inside a thread, the user can optionally "also send to chan
 
 **Decision:** The echo and the original thread reply are two different EVT envelopes. The echo carries `echoOfEventId`, which points at the original reply envelope. The message identity itself lives on the envelope (`Event.id`), not inside the `MessagePostedEvent` payload.
 **Why:** Public timeline APIs and EVT now model the same wrapper/payload boundary. Echoes still render the same text, but edits and deletes are propagated through the event-link relationship instead of a shared `messageBodyId` payload crutch.
-**Tradeoff:** Read models have to keep the echo link when applying edit/delete state. Reactions remain naturally independent because they already key on the envelope event ID.
+**Tradeoff:** Read models have to keep the echo link when applying edit/delete and reaction state.
 
 ### 2. Echo deletion hides the echo artifact
 
@@ -36,11 +36,11 @@ When posting a reply inside a thread, the user can optionally "also send to chan
 **Why:** The echo is a first-class `MessagePostedEvent`, so its counterpart is the same delete/retract fact used for other messages. The special case is rendering policy: retracting an echo removes the copy, while retracting the original removes the underlying content.
 **Tradeoff:** Echo retractions are interpreted differently from original reply retractions. The projection has to know whether the target event is an echo.
 
-### 3. Reactions key on event ID, not body ID
+### 3. Reactions canonicalize to the original reply
 
-**Decision:** Reactions attach to the event ID, so the echo and original accumulate reactions independently.
-**Why:** People reacting in the channel timeline are reacting to the appearance there; people reacting in the thread are reacting to the contribution inside the thread. Conflating them would mute one of those signals.
-**Tradeoff:** Total reaction count on a "reply that was also sent to channel" is split — there's no single canonical number. In practice this matches the user's mental model.
+**Decision:** Reactions attach to the original thread reply event ID. Channel echo event IDs are accepted as aliases at API boundaries and during projection replay, but new durable reaction facts target the original reply.
+**Why:** The echo represents the same contribution in a second timeline context. A single reaction set keeps the room and thread views consistent and avoids users seeing different counts for one reply.
+**Tradeoff:** Reaction reads need the echo link to resolve aliases. Historical echo-keyed reaction facts are canonicalized during projection replay instead of rewriting EVT.
 
 ### 4. Mentions copy to the echo, but don't re-notify
 

--- a/docs/fdr/FDR-005-reactions.md
+++ b/docs/fdr/FDR-005-reactions.md
@@ -1,7 +1,7 @@
 # FDR-005: Reactions
 
 **Status:** Active
-**Last reviewed:** 2026-06-25
+**Last reviewed:** 2026-07-03
 
 ## Overview
 
@@ -17,11 +17,11 @@ Users can react to a message with emoji. Reactions are aggregated into pills sho
 
 ## Design Decisions
 
-### 1. Reactions key on message event ID
+### 1. Reactions key on canonical message event ID
 
-**Decision:** A reaction is keyed by the specific message event ID the user reacted to. A channel echo of a thread reply and the original thread reply are separate visible events, so they accumulate independent reaction state.
-**Why:** Message identity lives on the EVT envelope. Keeping reactions attached to the exact envelope matches the public timeline event model and avoids hidden canonicalization between two visible artifacts.
-**Tradeoff:** A reply echoed into the channel can show different reaction counts in the channel and thread views. That is intentional: people are reacting to the appearance they can see.
+**Decision:** A reaction is keyed by the canonical message event ID. For ordinary messages this is the visible event ID; for a channel echo of a thread reply, it is the original thread reply event ID. Echo event IDs remain accepted as aliases at API boundaries.
+**Why:** The echo and original render the same contribution in different views. Sharing one reaction set keeps counts, viewer state, and reactor previews consistent wherever the reply appears.
+**Tradeoff:** Reaction reads and replay need the room timeline's echo link to resolve aliases. Historical echo-keyed reaction facts are interpreted as reactions on the original reply without rewriting EVT.
 
 ### 2. Shortcodes, not raw Unicode
 
@@ -31,7 +31,7 @@ Users can react to a message with emoji. Reactions are aggregated into pills sho
 
 ### 3. Durable events, in-memory projection is source of truth
 
-**Decision:** Reaction add/remove changes append durable room-aggregate events to EVT (`evt.room.{roomId}.reaction_added` / `reaction_removed`). Current reaction state is derived by an in-memory projection keyed by message event ID, emoji shortcode, and actor/user ID. The projection consumes the room aggregate namespace so mutation snapshots can pair current reaction state with the room's applied OCC sequence. Live subscribers receive reactions through the EVT stream's `live.evt.>` republish path after projection readiness and authorization checks.
+**Decision:** Reaction add/remove changes append durable room-aggregate events to EVT (`evt.room.{roomId}.reaction_added` / `reaction_removed`). Current reaction state is derived by an in-memory projection keyed by canonical message event ID, emoji shortcode, and actor/user ID. The projection consumes the room aggregate namespace so mutation snapshots can pair current reaction state with the room's applied OCC sequence and so replay can resolve echo aliases from prior message facts. Live subscribers receive reactions through the EVT stream's `live.evt.>` republish path after projection readiness and authorization checks.
 **Why:** Reactions are durable room facts. Keeping them in the room stream makes add/remove ordering explicit, gives replayable state, removes the old KV bucket from the hot read/write path, and lets duplicate add/remove decisions retry safely under multi-replica contention.
 **Tradeoff:** The first projection version keeps all current reaction state in RAM and consumes more room facts than it derives. That is simple and correct; bounded or demand-loaded projections can follow once the rest of the event-sourcing architecture is in place and real access patterns are measured.
 

--- a/packages/api-types/src/chatto/api/v1/reactions_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/reactions_pb.ts
@@ -10,6 +10,10 @@ import { RoomTimelineReaction } from "./room_timeline_pb.js";
 /**
  * Request to add the current user's reaction to a message.
  *
+ * When `message_event_id` names a channel echo of a thread reply, the server
+ * treats it as an alias for the original thread reply and stores the reaction
+ * on that original event.
+ *
  * @generated from message chatto.api.v1.AddReactionRequest
  */
 export class AddReactionRequest extends Message<AddReactionRequest> {
@@ -21,7 +25,8 @@ export class AddReactionRequest extends Message<AddReactionRequest> {
   roomId = "";
 
   /**
-   * Required. Event ID of the message being reacted to.
+   * Required. Event ID of the message being reacted to, or a channel echo of
+   * the message.
    *
    * @generated from field: string message_event_id = 2;
    */
@@ -116,6 +121,10 @@ export class AddReactionResponse extends Message<AddReactionResponse> {
 /**
  * Request to remove the current user's reaction from a message.
  *
+ * When `message_event_id` names a channel echo of a thread reply, the server
+ * treats it as an alias for the original thread reply and removes the reaction
+ * from that original event.
+ *
  * @generated from message chatto.api.v1.RemoveReactionRequest
  */
 export class RemoveReactionRequest extends Message<RemoveReactionRequest> {
@@ -127,7 +136,8 @@ export class RemoveReactionRequest extends Message<RemoveReactionRequest> {
   roomId = "";
 
   /**
-   * Required. Event ID of the message whose reaction should be removed.
+   * Required. Event ID of the message whose reaction should be removed, or a
+   * channel echo of the message.
    *
    * @generated from field: string message_event_id = 2;
    */

--- a/packages/api-types/src/chatto/realtime/v1/realtime_pb.ts
+++ b/packages/api-types/src/chatto/realtime/v1/realtime_pb.ts
@@ -1257,7 +1257,10 @@ export class RealtimeMessageRetractedEvent extends Message<RealtimeMessageRetrac
  * Refresh or patch the affected message in its timeline window. Use
  * `RoomService.GetRoomEventsAround` for room messages, or
  * `ThreadService.GetThreadEventsAround` when the local message belongs to
- * a thread.
+ * a thread. `message_event_id` is canonical: reactions made through a channel
+ * echo of a thread reply report the original reply event ID. Clients that show
+ * channel echoes should also refresh or patch visible echo rows whose
+ * `echo_of_event_id` matches this ID.
  *
  * @generated from message chatto.realtime.v1.RealtimeReactionEvent
  */
@@ -1270,7 +1273,7 @@ export class RealtimeReactionEvent extends Message<RealtimeReactionEvent> {
   roomId = "";
 
   /**
-   * Event ID of the reacted-to message.
+   * Canonical event ID of the reacted-to message.
    *
    * @generated from field: string message_event_id = 2;
    */

--- a/proto/chatto/api/v1/reactions.proto
+++ b/proto/chatto/api/v1/reactions.proto
@@ -6,10 +6,15 @@ import "buf/validate/validate.proto";
 import "chatto/api/v1/room_timeline.proto";
 
 // Request to add the current user's reaction to a message.
+//
+// When `message_event_id` names a channel echo of a thread reply, the server
+// treats it as an alias for the original thread reply and stores the reaction
+// on that original event.
 message AddReactionRequest {
   // Required. Room containing the message event.
   string room_id = 1 [(buf.validate.field).string.min_len = 1];
-  // Required. Event ID of the message being reacted to.
+  // Required. Event ID of the message being reacted to, or a channel echo of
+  // the message.
   string message_event_id = 2 [(buf.validate.field).string.min_len = 1];
   // Required. Emoji shortcode name, such as "thumbsup" or "heart".
   string emoji = 3 [(buf.validate.field).string.min_len = 1];
@@ -24,10 +29,15 @@ message AddReactionResponse {
 }
 
 // Request to remove the current user's reaction from a message.
+//
+// When `message_event_id` names a channel echo of a thread reply, the server
+// treats it as an alias for the original thread reply and removes the reaction
+// from that original event.
 message RemoveReactionRequest {
   // Required. Room containing the message event.
   string room_id = 1 [(buf.validate.field).string.min_len = 1];
-  // Required. Event ID of the message whose reaction should be removed.
+  // Required. Event ID of the message whose reaction should be removed, or a
+  // channel echo of the message.
   string message_event_id = 2 [(buf.validate.field).string.min_len = 1];
   // Required. Emoji shortcode name, such as "thumbsup" or "heart".
   string emoji = 3 [(buf.validate.field).string.min_len = 1];

--- a/proto/chatto/realtime/v1/realtime.proto
+++ b/proto/chatto/realtime/v1/realtime.proto
@@ -271,11 +271,14 @@ message RealtimeMessageRetractedEvent {
 // Refresh or patch the affected message in its timeline window. Use
 // `RoomService.GetRoomEventsAround` for room messages, or
 // `ThreadService.GetThreadEventsAround` when the local message belongs to
-// a thread.
+// a thread. `message_event_id` is canonical: reactions made through a channel
+// echo of a thread reply report the original reply event ID. Clients that show
+// channel echoes should also refresh or patch visible echo rows whose
+// `echo_of_event_id` matches this ID.
 message RealtimeReactionEvent {
   // Room containing the reacted-to message.
   string room_id = 1;
-  // Event ID of the reacted-to message.
+  // Canonical event ID of the reacted-to message.
   string message_event_id = 2;
   // Reaction emoji.
   string emoji = 3;


### PR DESCRIPTION
## Summary

Echo reaction writes used the visible echo event ID, splitting reaction state from the original thread reply.
This canonicalizes echo IDs to the original reply for writes, reads, projection replay, and realtime invalidation while keeping echo IDs accepted as API aliases.
It updates room/thread hydration, frontend refresh expectations, e2e coverage, FDRs, and architecture docs to treat echo/original reactions as one shared set.

## Validation

- `mise x -- go test ./internal/core -run 'TestChattoCore_EchoReactions|TestReactionProjection' -timeout 30s`
- `mise x -- go test -tags test_endpoints ./internal/connectapi -run 'TestMessageService.*Reaction|TestRoomAndThreadTimeline' -timeout 30s`
- `mise x -- go test -tags test_endpoints ./internal/http_server -run 'TestRealtimeMapperCanonicalizesEchoReactionMessageID' -timeout 30s`
- `mise run build-api-types`
- `mise x -- pnpm vitest run src/lib/state/room/messages.svelte.spec.ts`
