### PR TITLE
docs(api): fix integration guide service references

### DIFF
--- a/apps/docs-website/src/content/docs/guides/integrations/chatto-api.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/chatto-api.mdx
@@ -50,10 +50,10 @@ Realtime delivery uses the same room membership, RBAC, projection readiness, and
 | Goal | Recommended API |
 | ---- | --------------- |
 | Render room navigation | `RoomDirectoryService` |
-| Read room history | `RoomTimelineService` |
+| Read room history | `RoomService.GetRoomEvents` and `RoomService.GetRoomEventsAround` |
 | Post, edit, or delete messages | `MessageService` |
 | React to messages | `ReactionService` |
-| Track unread state | `ReadStateService` |
+| Track unread state | `RoomService.MarkRoomAsRead` and `ThreadService.MarkThreadAsRead` |
 | Start DMs | `RoomService` |
 | Read members and profiles | `UserDirectoryService` and `MemberDirectoryService` |
 | Manage roles or permissions | `chatto.admin.v1` role and permission services |


### PR DESCRIPTION
## Summary
Fixes the Chatto API integration guide so the integration-pattern table points to real room timeline and read-state RPCs.

The old entries referenced nonexistent `RoomTimelineService` and `ReadStateService`; the guide now names the concrete `RoomService` and `ThreadService` methods integrators should use.

Validation: reviewed `git diff origin/main...` and grepped docs/protos for remaining stale service references.
