### PR TITLE
perf(core): slim timeline projection memory

### DIFF
--- a/cli/internal/core/my_events_model.go
+++ b/cli/internal/core/my_events_model.go
@@ -179,9 +179,10 @@ func (s *MyEventsModel) StreamMyEvents(ctx context.Context, userID string, optio
 		heartbeatTicker := time.NewTicker(25 * time.Second)
 		defer heartbeatTicker.Stop()
 
-		lastKnownPresence := make(map[string]string, len(presenceSub.Snapshot))
-		for k, v := range presenceSub.Snapshot {
-			lastKnownPresence[k] = v
+		lastKnownPresence := presenceSub.Snapshot
+		presenceSub.Snapshot = nil
+		if lastKnownPresence == nil {
+			lastKnownPresence = make(map[string]string)
 		}
 
 		defer func() {

--- a/cli/internal/core/projection_admin.go
+++ b/cli/internal/core/projection_admin.go
@@ -11,6 +11,7 @@ import (
 const (
 	projectionMapEntryOverhead   int64 = 64
 	projectionSliceEntryOverhead int64 = 24
+	projectionIntIndexBytes      int64 = 8
 )
 
 // ProjectionAdminState is the operator-facing runtime state for one
@@ -317,7 +318,8 @@ func (p *RoomTimelineProjection) adminProjectionEstimate() (int64, int64, []Proj
 	timelineEventIDs := make(map[string]struct{}, len(p.byEventID))
 	for _, roomEntries := range p.byRoom {
 		var roomBytes int64
-		for _, entry := range roomEntries {
+		for _, idx := range roomEntries {
+			entry := p.entryAtLocked(idx)
 			entries++
 			eventBytes := timelineEntryEstimatedBytes(entry)
 			roomBytes += eventBytes
@@ -332,16 +334,17 @@ func (p *RoomTimelineProjection) adminProjectionEstimate() (int64, int64, []Proj
 	for roomID, roomEntries := range p.messagePostsByRoom {
 		messagePostIndexBytes += projectionMapEntryOverhead + int64(len(roomID))
 		messagePosts += int64(len(roomEntries))
-		messagePostIndexBytes += int64(len(roomEntries)) * projectionSliceEntryOverhead
+		messagePostIndexBytes += int64(len(roomEntries)) * projectionIntIndexBytes
 	}
 
 	var eventIndexBytes, eventIndexRetainedEntryBytes, eventIndexRetainedEntries int64
-	for eventID, entry := range p.byEventID {
+	for eventID, idx := range p.byEventID {
 		eventIndexBytes += projectionMapEntryOverhead + int64(len(eventID))
 		if _, counted := timelineEventIDs[eventID]; counted {
 			continue
 		}
 		eventIndexRetainedEntries++
+		entry := p.entryAtLocked(idx)
 		eventIndexRetainedEntryBytes += timelineEntryEstimatedBytes(entry)
 	}
 	appliedEventIDsBytes := estimateStringSetBytes(p.appliedEventIDs)
@@ -445,16 +448,13 @@ func (p *ThreadProjection) adminProjectionEstimate() (int64, int64, []Projection
 	defer p.RUnlock()
 	var entries, rawBytes, replies int64
 	for _, threadEntries := range p.byThread {
-		var threadBytes int64
 		for _, entry := range threadEntries {
 			entries++
-			eventBytes := timelineEntryEstimatedBytes(entry)
-			threadBytes += eventBytes
-			if entry != nil && entry.Event.GetMessagePosted() != nil {
+			rawBytes += projectionSliceEntryOverhead + int64(len(entry.EventID)) + 8
+			if entry.EventID != "" {
 				replies++
 			}
 		}
-		rawBytes += threadBytes
 	}
 	var indexBytes int64
 	for eventID, threadID := range p.messageToThread {

--- a/cli/internal/core/projection_string_interner.go
+++ b/cli/internal/core/projection_string_interner.go
@@ -1,0 +1,18 @@
+package core
+
+type projectionStringInterner map[string]string
+
+func newProjectionStringInterner() projectionStringInterner {
+	return make(projectionStringInterner)
+}
+
+func (i projectionStringInterner) intern(value string) string {
+	if value == "" {
+		return ""
+	}
+	if existing, ok := i[value]; ok {
+		return existing
+	}
+	i[value] = value
+	return value
+}

--- a/cli/internal/core/room_model.go
+++ b/cli/internal/core/room_model.go
@@ -265,7 +265,22 @@ func (m *RoomModel) threadExists(rootEventID string) bool {
 }
 
 func (m *RoomModel) threadEvents(rootEventID string) []*TimelineEntry {
-	return m.threads.ThreadEvents(rootEventID)
+	refs := m.threads.ThreadEvents(rootEventID)
+	if len(refs) == 0 {
+		return nil
+	}
+	out := make([]*TimelineEntry, 0, len(refs))
+	for _, ref := range refs {
+		entry, ok := m.timeline.Get(ref.EventID)
+		if !ok || entry == nil {
+			continue
+		}
+		if ref.StreamSeq != 0 && entry.StreamSeq != ref.StreamSeq {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
 }
 
 func (m *RoomModel) threadMetadata(rootEventID string) *ThreadMetadata {

--- a/cli/internal/core/room_timeline_assets.go
+++ b/cli/internal/core/room_timeline_assets.go
@@ -217,13 +217,13 @@ func (idx *roomTimelineAssetIndex) assetMessageOwner(assetID string) (roomID, me
 	return owner.roomID, owner.messageEventID, true
 }
 
-func (idx *roomTimelineAssetIndex) messageAssetsByAuthor(userID string, byEventID map[string]*TimelineEntry) []MessageAssetRef {
+func (idx *roomTimelineAssetIndex) messageAssetsByAuthor(userID string, entryByEventID func(string) (*TimelineEntry, bool)) []MessageAssetRef {
 	if idx == nil || userID == "" {
 		return nil
 	}
 	out := make([]MessageAssetRef, 0)
 	for assetID, owner := range idx.messageOwners {
-		entry := byEventID[owner.messageEventID]
+		entry, _ := entryByEventID(owner.messageEventID)
 		if entry == nil || entry.Event == nil || messageAuthorID(entry.Event) != userID {
 			continue
 		}

--- a/cli/internal/core/room_timeline_projection.go
+++ b/cli/internal/core/room_timeline_projection.go
@@ -15,10 +15,12 @@ import (
 // timeline readers walk on every page load.
 type RoomTimelineProjection struct {
 	events.MemoryProjection
-	byRoom             map[string][]*TimelineEntry
-	byEventID          map[string]*TimelineEntry
-	messagePostsByRoom map[string][]*TimelineEntry
+	entries            []TimelineEntry
+	byRoom             map[string][]int
+	byEventID          map[string]int
+	messagePostsByRoom map[string][]int
 	appliedEventIDs    eventIDSet
+	strings            projectionStringInterner
 	// latestBody is the derived current-body index. Updated as
 	// MessageEdited / MessageRetracted entries are applied so that
 	// LatestBody resolves in O(1) instead of an O(room size) walk
@@ -67,13 +69,43 @@ type projectedRoomAttachmentMessage struct {
 	Body  *corev1.MessageBody
 }
 
+func (p *RoomTimelineProjection) intern(value string) string {
+	return p.strings.intern(value)
+}
+
+func (p *RoomTimelineProjection) appendEntryLocked(seq uint64, event *corev1.Event) int {
+	idx := len(p.entries)
+	p.entries = append(p.entries, TimelineEntry{StreamSeq: seq, Event: event})
+	return idx
+}
+
+func (p *RoomTimelineProjection) entryAtLocked(idx int) *TimelineEntry {
+	if idx < 0 || idx >= len(p.entries) {
+		return nil
+	}
+	return &p.entries[idx]
+}
+
+func (p *RoomTimelineProjection) entryByEventIDLocked(eventID string) (*TimelineEntry, bool) {
+	idx, ok := p.byEventID[eventID]
+	if !ok {
+		return nil, false
+	}
+	entry := p.entryAtLocked(idx)
+	if entry == nil {
+		return nil, false
+	}
+	return entry, true
+}
+
 // NewRoomTimelineProjection returns an empty projection.
 func NewRoomTimelineProjection() *RoomTimelineProjection {
 	return &RoomTimelineProjection{
-		byRoom:                     make(map[string][]*TimelineEntry),
-		byEventID:                  make(map[string]*TimelineEntry),
-		messagePostsByRoom:         make(map[string][]*TimelineEntry),
+		byRoom:                     make(map[string][]int),
+		byEventID:                  make(map[string]int),
+		messagePostsByRoom:         make(map[string][]int),
 		appliedEventIDs:            newEventIDSet(),
+		strings:                    newProjectionStringInterner(),
 		latestBody:                 make(map[string]*corev1.MessageBody),
 		bodyEventSeqs:              make(map[string][]uint64),
 		currentBodySeq:             make(map[string]uint64),
@@ -110,7 +142,7 @@ func (p *RoomTimelineProjection) Apply(event *corev1.Event, seq uint64) error {
 		return nil
 	}
 
-	roomID := p.roomIDOfEventLocked(event)
+	roomID := p.intern(p.roomIDOfEventLocked(event))
 	if roomID == "" {
 		return nil
 	}
@@ -126,7 +158,7 @@ func (p *RoomTimelineProjection) Apply(event *corev1.Event, seq uint64) error {
 	}
 
 	if ev := event.GetMessageBody(); ev != nil {
-		targetID := ev.GetEventId()
+		targetID := p.intern(ev.GetEventId())
 		body := ev.GetBody()
 		if targetID != "" && body != nil {
 			if body.GetBodyEventId() != "" && body.GetBodyEventId() != event.GetId() {
@@ -154,31 +186,31 @@ func (p *RoomTimelineProjection) Apply(event *corev1.Event, seq uint64) error {
 		return nil
 	}
 
-	var entry *TimelineEntry
+	entryIdx := -1
 	if shouldIndexRoomTimelineEvent(event) {
-		entry = &TimelineEntry{StreamSeq: seq, Event: event}
-		if eid := event.GetId(); eid != "" {
-			p.byEventID[eid] = entry
+		entryIdx = p.appendEntryLocked(seq, event)
+		if eid := p.intern(event.GetId()); eid != "" {
+			p.byEventID[eid] = entryIdx
 		}
 	}
 	if event.GetMessagePosted() != nil {
-		if entry == nil {
-			entry = &TimelineEntry{StreamSeq: seq, Event: event}
+		if entryIdx < 0 {
+			entryIdx = p.appendEntryLocked(seq, event)
 		}
-		p.messagePostsByRoom[roomID] = append(p.messagePostsByRoom[roomID], entry)
+		p.messagePostsByRoom[roomID] = append(p.messagePostsByRoom[roomID], entryIdx)
 	}
 	if isVisibleRoomTimelineEntry(event) {
-		if entry == nil {
-			entry = &TimelineEntry{StreamSeq: seq, Event: event}
+		if entryIdx < 0 {
+			entryIdx = p.appendEntryLocked(seq, event)
 		}
-		p.byRoom[roomID] = append(p.byRoom[roomID], entry)
+		p.byRoom[roomID] = append(p.byRoom[roomID], entryIdx)
 	}
 
 	// Maintain the latest-body / retracted-flag derived index so
 	// LatestBody is O(1) instead of an O(room) walk per lookup.
 	switch ev := event.GetEvent().(type) {
 	case *corev1.Event_MessagePosted:
-		targetID := event.GetId()
+		targetID := p.intern(event.GetId())
 		if targetID != "" {
 			authorID := messageAuthorID(event)
 			if _, shredded := p.shreddedUsers[authorID]; shredded {
@@ -193,11 +225,11 @@ func (p *RoomTimelineProjection) Apply(event *corev1.Event, seq uint64) error {
 		// Track echo links so edits on either side can fan out to the
 		// other, and so original retractions can be reflected when
 		// rendering echoes.
-		if origID := ev.MessagePosted.GetEchoOfEventId(); origID != "" && targetID != "" {
+		if origID := p.intern(ev.MessagePosted.GetEchoOfEventId()); origID != "" && targetID != "" {
 			p.echoLinks[origID] = append(p.echoLinks[origID], targetID)
 		}
 	case *corev1.Event_MessageRetracted:
-		targetID := ev.MessageRetracted.GetEventId()
+		targetID := p.intern(ev.MessageRetracted.GetEventId())
 		if targetID != "" {
 			if origID := p.echoOriginalIDLocked(targetID); origID != "" {
 				if _, originalRetracted := p.retractedFlags[origID]; !originalRetracted {
@@ -233,8 +265,10 @@ func (p *RoomTimelineProjection) applyUserKeyShreddedLocked(userID string) {
 	if userID == "" {
 		return
 	}
+	userID = p.intern(userID)
 	p.shreddedUsers[userID] = struct{}{}
-	for eventID, entry := range p.byEventID {
+	for eventID, idx := range p.byEventID {
+		entry := p.entryAtLocked(idx)
 		if entry == nil || entry.Event == nil {
 			continue
 		}
@@ -272,13 +306,16 @@ func (p *RoomTimelineProjection) RoomEvents(roomID string, limit int, beforeStre
 	}
 	p.RLock()
 	defer p.RUnlock()
-	entries := p.byRoom[roomID]
-	if len(entries) == 0 {
+	entryIndexes := p.byRoom[roomID]
+	if len(entryIndexes) == 0 {
 		return nil
 	}
 	out := make([]*TimelineEntry, 0, limit)
-	for i := len(entries) - 1; i >= 0 && len(out) < limit; i-- {
-		e := entries[i]
+	for i := len(entryIndexes) - 1; i >= 0 && len(out) < limit; i-- {
+		e := p.entryAtLocked(entryIndexes[i])
+		if e == nil {
+			continue
+		}
 		if beforeStreamSeq > 0 && e.StreamSeq >= beforeStreamSeq {
 			continue
 		}
@@ -300,7 +337,8 @@ func (p *RoomTimelineProjection) VisibleRoomEventCount(roomID string) int {
 	p.RLock()
 	defer p.RUnlock()
 	n := 0
-	for _, entry := range p.byRoom[roomID] {
+	for _, idx := range p.byRoom[roomID] {
+		entry := p.entryAtLocked(idx)
 		if p.isHiddenEchoEntryLocked(entry) {
 			continue
 		}
@@ -340,8 +378,7 @@ func shouldIndexRoomTimelineEvent(event *corev1.Event) bool {
 func (p *RoomTimelineProjection) Get(eventID string) (*TimelineEntry, bool) {
 	p.RLock()
 	defer p.RUnlock()
-	e, ok := p.byEventID[eventID]
-	return e, ok
+	return p.entryByEventIDLocked(eventID)
 }
 
 // LastRoomMessageEntry returns the newest non-hidden MessagePostedEvent in a
@@ -349,9 +386,12 @@ func (p *RoomTimelineProjection) Get(eventID string) (*TimelineEntry, bool) {
 func (p *RoomTimelineProjection) LastRoomMessageEntry(roomID string) (*TimelineEntry, bool) {
 	p.RLock()
 	defer p.RUnlock()
-	entries := p.messagePostsByRoom[roomID]
-	for i := len(entries) - 1; i >= 0; i-- {
-		e := entries[i]
+	entryIndexes := p.messagePostsByRoom[roomID]
+	for i := len(entryIndexes) - 1; i >= 0; i-- {
+		e := p.entryAtLocked(entryIndexes[i])
+		if e == nil {
+			continue
+		}
 		if p.isHiddenEchoEntryLocked(e) {
 			continue
 		}
@@ -408,7 +448,7 @@ func (p *RoomTimelineProjection) CurrentRoomAttachmentMessages(roomID string) []
 	out := make([]projectedRoomAttachmentMessage, 0, len(ids))
 	for i := len(ids) - 1; i >= 0; i-- {
 		eventID := ids[i]
-		entry := p.byEventID[eventID]
+		entry, _ := p.entryByEventIDLocked(eventID)
 		if entry == nil || entry.Event == nil || p.isHiddenEchoEntryLocked(entry) {
 			continue
 		}
@@ -440,7 +480,7 @@ func (p *RoomTimelineProjection) refreshAttachmentMessageLocked(roomID, eventID 
 		p.removeAttachmentMessageLocked(eventID)
 		return
 	}
-	entry := p.byEventID[eventID]
+	entry, _ := p.entryByEventIDLocked(eventID)
 	if entry == nil || entry.Event == nil || p.isHiddenEchoEntryLocked(entry) {
 		return
 	}
@@ -461,7 +501,7 @@ func (p *RoomTimelineProjection) addAttachmentMessageLocked(roomID, eventID stri
 	ids := p.attachmentMessageIDsByRoom[roomID]
 	insertAt := len(ids)
 	if len(ids) > 0 {
-		last := p.byEventID[ids[len(ids)-1]]
+		last, _ := p.entryByEventIDLocked(ids[len(ids)-1])
 		if last != nil && last.StreamSeq <= streamSeq {
 			ids = append(ids, eventID)
 			p.attachmentMessageIDsByRoom[roomID] = ids
@@ -469,7 +509,7 @@ func (p *RoomTimelineProjection) addAttachmentMessageLocked(roomID, eventID stri
 			return
 		}
 		for i, existingID := range ids {
-			existing := p.byEventID[existingID]
+			existing, _ := p.entryByEventIDLocked(existingID)
 			if existing == nil || existing.StreamSeq > streamSeq {
 				insertAt = i
 				break
@@ -582,8 +622,8 @@ func (p *RoomTimelineProjection) AllObsoleteBodyEventSeqs() []uint64 {
 }
 
 func (p *RoomTimelineProjection) echoOriginalIDLocked(eventID string) string {
-	entry := p.byEventID[eventID]
-	if entry == nil || entry.Event == nil {
+	entry, ok := p.entryByEventIDLocked(eventID)
+	if !ok || entry == nil || entry.Event == nil {
 		return ""
 	}
 	posted := entry.Event.GetMessagePosted()
@@ -627,7 +667,7 @@ func (p *RoomTimelineProjection) ChannelEchoEventID(originalEventID string) (str
 		if _, retracted := p.retractedFlags[echoID]; retracted {
 			continue
 		}
-		if _, ok := p.byEventID[echoID]; !ok {
+		if _, ok := p.entryByEventIDLocked(echoID); !ok {
 			continue
 		}
 		if origID := p.echoOriginalIDLocked(echoID); origID != originalEventID {
@@ -678,7 +718,7 @@ func (p *RoomTimelineProjection) AssetMessageOwner(assetID string) (roomID, mess
 func (p *RoomTimelineProjection) MessageAssetsByAuthor(userID string) []MessageAssetRef {
 	p.RLock()
 	defer p.RUnlock()
-	return p.assets.messageAssetsByAuthor(userID, p.byEventID)
+	return p.assets.messageAssetsByAuthor(userID, p.entryByEventIDLocked)
 }
 
 func (p *RoomTimelineProjection) MessageAssetOwners() []MessageAssetRef {
@@ -761,7 +801,7 @@ func (p *RoomTimelineProjection) LinkedEventIDs(eventID string) []string {
 	}
 
 	// Backward: if this event IS an echo, include the original.
-	if entry, ok := p.byEventID[eventID]; ok {
+	if entry, ok := p.entryByEventIDLocked(eventID); ok {
 		if posted := entry.Event.GetMessagePosted(); posted != nil {
 			if origID := posted.GetEchoOfEventId(); origID != "" && origID != eventID {
 				linked = append(linked, origID)
@@ -790,9 +830,12 @@ func (p *RoomTimelineProjection) LastVisibleRoomEntry(
 ) (*TimelineEntry, bool) {
 	p.RLock()
 	defer p.RUnlock()
-	entries := p.byRoom[roomID]
-	for i := len(entries) - 1; i >= 0; i-- {
-		e := entries[i]
+	entryIndexes := p.byRoom[roomID]
+	for i := len(entryIndexes) - 1; i >= 0; i-- {
+		e := p.entryAtLocked(entryIndexes[i])
+		if e == nil {
+			continue
+		}
 		if p.isHiddenEchoEntryLocked(e) {
 			continue
 		}
@@ -826,10 +869,13 @@ func (p *RoomTimelineProjection) VisibleRoomTimeline(
 	}
 	p.RLock()
 	defer p.RUnlock()
-	entries := p.byRoom[roomID]
+	entryIndexes := p.byRoom[roomID]
 	out := make([]*TimelineEntry, 0, limit)
-	for i := len(entries) - 1; i >= 0 && len(out) < limit; i-- {
-		e := entries[i]
+	for i := len(entryIndexes) - 1; i >= 0 && len(out) < limit; i-- {
+		e := p.entryAtLocked(entryIndexes[i])
+		if e == nil {
+			continue
+		}
 		if beforeStreamSeq > 0 && e.StreamSeq >= beforeStreamSeq {
 			continue
 		}
@@ -859,9 +905,13 @@ func (p *RoomTimelineProjection) VisibleRoomTimelineAfter(
 	}
 	p.RLock()
 	defer p.RUnlock()
-	entries := p.byRoom[roomID]
+	entryIndexes := p.byRoom[roomID]
 	out := make([]*TimelineEntry, 0, limit)
-	for _, e := range entries {
+	for _, idx := range entryIndexes {
+		e := p.entryAtLocked(idx)
+		if e == nil {
+			continue
+		}
 		if e.StreamSeq <= afterStreamSeq {
 			continue
 		}
@@ -896,7 +946,8 @@ func (p *RoomTimelineProjection) VisibleRoomTimelineAround(
 	roomEntries := p.byRoom[roomID]
 	targetVisibleIndex := -1
 	visibleCount := 0
-	for _, entry := range roomEntries {
+	for _, idx := range roomEntries {
+		entry := p.entryAtLocked(idx)
 		if p.isHiddenEchoEntryLocked(entry) {
 			continue
 		}
@@ -924,7 +975,8 @@ func (p *RoomTimelineProjection) VisibleRoomTimelineAround(
 
 	out := make([]*TimelineEntry, 0, end-start)
 	visibleIndex := 0
-	for _, entry := range roomEntries {
+	for _, idx := range roomEntries {
+		entry := p.entryAtLocked(idx)
 		if p.isHiddenEchoEntryLocked(entry) {
 			continue
 		}

--- a/cli/internal/core/thread_projection.go
+++ b/cli/internal/core/thread_projection.go
@@ -34,6 +34,11 @@ type threadFollowRef struct {
 	threadRootEventID string
 }
 
+type ThreadTimelineEntry struct {
+	EventID   string
+	StreamSeq uint64
+}
+
 // ThreadProjection holds an append-only event log per thread,
 // derived from the same evt.room.> firehose RoomTimelineProjection
 // consumes.
@@ -58,7 +63,7 @@ type threadFollowRef struct {
 // iterate later.
 type ThreadProjection struct {
 	events.MemoryProjection
-	byThread        map[string][]*TimelineEntry
+	byThread        map[string][]ThreadTimelineEntry
 	messageToThread map[string]string // reply event_id → thread root event_id
 	replySummaries  map[string]*threadReplySummary
 	summaryByThread map[string]*threadSummary
@@ -67,12 +72,13 @@ type ThreadProjection struct {
 	followedByUser  map[string]map[string]threadFollowRef
 	appliedEventIDs eventIDSet
 	shreddedUsers   map[string]struct{}
+	strings         projectionStringInterner
 }
 
 // NewThreadProjection returns an empty projection.
 func NewThreadProjection() *ThreadProjection {
 	return &ThreadProjection{
-		byThread:        make(map[string][]*TimelineEntry),
+		byThread:        make(map[string][]ThreadTimelineEntry),
 		messageToThread: make(map[string]string),
 		replySummaries:  make(map[string]*threadReplySummary),
 		summaryByThread: make(map[string]*threadSummary),
@@ -81,7 +87,12 @@ func NewThreadProjection() *ThreadProjection {
 		followedByUser:  make(map[string]map[string]threadFollowRef),
 		appliedEventIDs: newEventIDSet(),
 		shreddedUsers:   make(map[string]struct{}),
+		strings:         newProjectionStringInterner(),
 	}
+}
+
+func (p *ThreadProjection) intern(value string) string {
+	return p.strings.intern(value)
 }
 
 // Subjects implements events.Projection. Threads only need thread lifecycle
@@ -136,7 +147,7 @@ func (p *ThreadProjection) Apply(event *corev1.Event, seq uint64) error {
 
 	switch e := event.GetEvent().(type) {
 	case *corev1.Event_UserKeyShredded:
-		if userID := e.UserKeyShredded.GetUserId(); userID != "" {
+		if userID := p.intern(e.UserKeyShredded.GetUserId()); userID != "" {
 			p.shreddedUsers[userID] = struct{}{}
 			for threadRoot := range p.summaryByThread {
 				p.recomputeSummaryLocked(threadRoot)
@@ -145,7 +156,7 @@ func (p *ThreadProjection) Apply(event *corev1.Event, seq uint64) error {
 		}
 
 	case *corev1.Event_ThreadCreated:
-		threadRoot := e.ThreadCreated.GetThreadRootEventId()
+		threadRoot := p.intern(e.ThreadCreated.GetThreadRootEventId())
 		if threadRoot == "" {
 			return nil
 		}
@@ -169,18 +180,18 @@ func (p *ThreadProjection) Apply(event *corev1.Event, seq uint64) error {
 
 	case *corev1.Event_MessagePosted:
 		m := e.MessagePosted
-		threadRoot := m.GetInThread()
+		threadRoot := p.intern(m.GetInThread())
 		if threadRoot == "" {
 			return nil // root-level message; not in any thread bucket
 		}
-		replyID := event.GetId()
+		replyID := p.intern(event.GetId())
 		if replyID == "" {
 			return nil
 		}
-		p.byThread[threadRoot] = append(p.byThread[threadRoot], &TimelineEntry{StreamSeq: seq, Event: event})
+		p.byThread[threadRoot] = append(p.byThread[threadRoot], ThreadTimelineEntry{EventID: replyID, StreamSeq: seq})
 		p.messageToThread[replyID] = threadRoot
 		p.replySummaries[replyID] = &threadReplySummary{
-			actorID:   messageAuthorID(event),
+			actorID:   p.intern(messageAuthorID(event)),
 			createdAt: eventCreatedAt(event),
 		}
 		summary := p.summaryByThread[threadRoot]
@@ -193,20 +204,19 @@ func (p *ThreadProjection) Apply(event *corev1.Event, seq uint64) error {
 		markApplied()
 
 	case *corev1.Event_MessageEdited:
-		threadRoot, ok := p.messageToThread[e.MessageEdited.GetEventId()]
+		_, ok := p.messageToThread[e.MessageEdited.GetEventId()]
 		if !ok {
 			return nil // target isn't a known thread reply
 		}
-		p.byThread[threadRoot] = append(p.byThread[threadRoot], &TimelineEntry{StreamSeq: seq, Event: event})
 		markApplied()
 
 	case *corev1.Event_MessageRetracted:
-		threadRoot, ok := p.messageToThread[e.MessageRetracted.GetEventId()]
+		targetID := p.intern(e.MessageRetracted.GetEventId())
+		threadRoot, ok := p.messageToThread[targetID]
 		if !ok {
 			return nil
 		}
-		p.byThread[threadRoot] = append(p.byThread[threadRoot], &TimelineEntry{StreamSeq: seq, Event: event})
-		if reply := p.replySummaries[e.MessageRetracted.GetEventId()]; reply != nil {
+		if reply := p.replySummaries[targetID]; reply != nil {
 			reply.retracted = true
 			// Retractions are rare and can invalidate last-reply or participant
 			// ordering, so recomputing the affected thread keeps the hot reply
@@ -226,6 +236,9 @@ func (p *ThreadProjection) setThreadFollowStateLocked(userID, roomID, threadRoot
 	if userID == "" || roomID == "" || threadRootEventID == "" {
 		return
 	}
+	userID = p.intern(userID)
+	roomID = p.intern(roomID)
+	threadRootEventID = p.intern(threadRootEventID)
 	key := threadFollowKeyPart(roomID, threadRootEventID)
 	stateKey := userID + "\x00" + key
 	previous := p.followState[stateKey]
@@ -340,20 +353,20 @@ func (p *ThreadProjection) applyReplyToSummaryLocked(summary *threadSummary, rep
 	}
 }
 
-// ThreadEvents returns the full timeline of a thread (replies +
-// any edits / retracts targeting them) in stream order. Returns
-// nil if no replies have landed.
+// ThreadEvents returns reply event references for a thread in stream order.
+// Edit and retract facts are folded into the projection's summaries and latest
+// body state instead of being retained as separate rows.
 //
 // The root message is NOT included — resolvers fetch it from
 // RoomTimelineProjection.Get(rootEventID) and prepend.
-func (p *ThreadProjection) ThreadEvents(rootEventID string) []*TimelineEntry {
+func (p *ThreadProjection) ThreadEvents(rootEventID string) []ThreadTimelineEntry {
 	p.RLock()
 	defer p.RUnlock()
 	entries := p.byThread[rootEventID]
 	if len(entries) == 0 {
 		return nil
 	}
-	out := make([]*TimelineEntry, len(entries))
+	out := make([]ThreadTimelineEntry, len(entries))
 	copy(out, entries)
 	return out
 }
@@ -451,7 +464,7 @@ func (p *ThreadProjection) Stats() (threads int, entries int, replies int) {
 	for _, threadEntries := range p.byThread {
 		entries += len(threadEntries)
 		for _, entry := range threadEntries {
-			if entry != nil && entry.Event.GetMessagePosted() != nil {
+			if entry.EventID != "" {
 				replies++
 			}
 		}

--- a/cli/internal/core/thread_projection.go
+++ b/cli/internal/core/thread_projection.go
@@ -43,13 +43,11 @@ type ThreadTimelineEntry struct {
 // derived from the same evt.room.> firehose RoomTimelineProjection
 // consumes.
 //
-// "Per thread" means: events whose semantic scope is a single
-// thread — reply posts (MessagePostedEvent with in_thread != "")
-// and edits / retracts targeting those replies. The thread root
-// message itself is NOT stored here; the thread-view resolver
-// fetches the root from RoomTimelineProjection.Get(rootEventID)
-// and concatenates. This keeps each projection's "what's in here?"
-// answer trivial.
+// "Per thread" means: reply posts (MessagePostedEvent with in_thread != "").
+// The thread root message itself is NOT stored here; the thread-view resolver
+// fetches the root from RoomTimelineProjection.Get(rootEventID) and
+// concatenates. Reply rows retain only event IDs and stream sequences, and
+// resolvers hydrate the full event from RoomTimelineProjection.
 //
 // To route edits and retracts to the right thread, we maintain a
 // secondary index mapping reply event_id → thread root event_id,
@@ -58,9 +56,8 @@ type ThreadTimelineEntry struct {
 // are silently skipped here; they'll be handled at the room-
 // timeline level.
 //
-// Same v1-shape framing as RoomTimelineProjection: dead simple,
-// append-only, no fold logic, full event protos preserved. We
-// iterate later.
+// Edits and retractions targeting replies are folded into cached summaries and
+// latest-body state instead of being retained as separate thread rows.
 type ThreadProjection struct {
 	events.MemoryProjection
 	byThread        map[string][]ThreadTimelineEntry
@@ -126,8 +123,10 @@ func (p *ThreadProjection) ReplaySubjects() []string {
 //     thread's slice, remember its event_id → thread mapping.
 //   - ThreadCreatedEvent → initialise the thread's bucket even before
 //     replies land.
-//   - MessageEditedEvent / MessageRetractedEvent whose target
-//     event_id is a known thread reply → append to that thread.
+//   - MessageEditedEvent whose target event_id is a known thread reply → mark
+//     the fact applied; latest body state lives in RoomTimelineProjection.
+//   - MessageRetractedEvent whose target event_id is a known thread reply →
+//     fold the retraction into the thread summary.
 //
 // Everything else (root messages, room lifecycle, memberships,
 // edits/retracts of non-reply messages) is silently ignored.

--- a/cli/internal/core/thread_projection_test.go
+++ b/cli/internal/core/thread_projection_test.go
@@ -12,6 +12,14 @@ import (
 // ThreadProjection
 // =============================================================================
 
+func threadEventIDs(entries []ThreadTimelineEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, entry.EventID)
+	}
+	return out
+}
+
 func TestThreadProjection_Empty(t *testing.T) {
 	p := NewThreadProjection()
 	if got := p.ThreadEvents("ROOT"); got != nil {
@@ -71,8 +79,8 @@ func TestThreadProjection_RepliesAppended(t *testing.T) {
 	if len(entries) != 2 {
 		t.Fatalf("ThreadEvents(ROOT) len = %d, want 2", len(entries))
 	}
-	if entries[0].Event.GetId() != "ENV-R1" || entries[1].Event.GetId() != "ENV-R2" {
-		t.Errorf("ThreadEvents order = %v, want [ENV-R1, ENV-R2]", timelineEventIDs(entries))
+	if entries[0].EventID != "ENV-R1" || entries[1].EventID != "ENV-R2" {
+		t.Errorf("ThreadEvents order = %v, want [ENV-R1, ENV-R2]", threadEventIDs(entries))
 	}
 	if got := p.ReplyCount("ROOT"); got != 2 {
 		t.Errorf("ReplyCount = %d, want 2", got)
@@ -101,14 +109,11 @@ func TestThreadProjection_ApplyDoesNotMutateInputEvent(t *testing.T) {
 	if len(entries) != 1 {
 		t.Fatalf("ThreadEvents(ROOT) len = %d, want 1", len(entries))
 	}
-	if got := entries[0].Event.GetId(); got != "ENV-R1" {
+	if got := entries[0].EventID; got != "ENV-R1" {
 		t.Fatalf("reply id = %q, want ENV-R1", got)
 	}
-	if got := entries[0].Event.GetMessagePosted().GetRoomId(); got != "R1" {
-		t.Fatalf("reply room id = %q, want R1", got)
-	}
-	if got := entries[0].Event.GetMessagePosted().GetInThread(); got != "ROOT" {
-		t.Fatalf("reply thread root = %q, want ROOT", got)
+	if got := entries[0].StreamSeq; got != 1 {
+		t.Fatalf("reply stream seq = %d, want 1", got)
 	}
 }
 
@@ -121,18 +126,18 @@ func TestThreadProjection_ReplyWithLegacyEmptyPayloadEventID(t *testing.T) {
 	})
 
 	entries := p.ThreadEvents("ROOT")
-	if len(entries) != 2 {
-		t.Fatalf("ThreadEvents(ROOT) len = %d, want 2", len(entries))
+	if len(entries) != 1 {
+		t.Fatalf("ThreadEvents(ROOT) len = %d, want 1 reply ref", len(entries))
 	}
 	if got := p.ReplyCount("ROOT"); got != 1 {
 		t.Errorf("ReplyCount = %d, want 1", got)
 	}
-	if entries[1].Event.GetMessageEdited() == nil {
-		t.Error("expected edit to route through envelope-id fallback")
+	if got := len(p.appliedEventIDs); got != 2 {
+		t.Errorf("appliedEventIDs = %d, want 2 to confirm edit routed through envelope-id fallback", got)
 	}
 }
 
-func TestThreadProjection_EditOfReplyAppendedToThread(t *testing.T) {
+func TestThreadProjection_EditOfReplyDoesNotAddThreadRow(t *testing.T) {
 	p := NewThreadProjection()
 	applyAll(t, p, []*corev1.Event{
 		postedEvent(postedOpts{envelopeID: "ENV-ROOT", eventID: "ROOT", roomID: "R1", actorID: "U1", at: 1}),
@@ -141,11 +146,8 @@ func TestThreadProjection_EditOfReplyAppendedToThread(t *testing.T) {
 	})
 
 	entries := p.ThreadEvents("ROOT")
-	if len(entries) != 2 {
-		t.Fatalf("expected post + edit, got %d entries", len(entries))
-	}
-	if entries[1].Event.GetMessageEdited() == nil {
-		t.Error("expected entries[1] to be a MessageEditedEvent")
+	if len(entries) != 1 {
+		t.Fatalf("expected only the reply row after edit, got %d entries", len(entries))
 	}
 	// Reply count counts MessagePostedEvent only.
 	if got := p.ReplyCount("ROOT"); got != 1 {
@@ -153,7 +155,7 @@ func TestThreadProjection_EditOfReplyAppendedToThread(t *testing.T) {
 	}
 }
 
-func TestThreadProjection_RetractOfReplyAppendedToThread(t *testing.T) {
+func TestThreadProjection_RetractOfReplyFoldsIntoSummary(t *testing.T) {
 	p := NewThreadProjection()
 	applyAll(t, p, []*corev1.Event{
 		postedEvent(postedOpts{envelopeID: "ENV-ROOT", eventID: "ROOT", roomID: "R1", actorID: "U1", at: 1}),
@@ -162,11 +164,8 @@ func TestThreadProjection_RetractOfReplyAppendedToThread(t *testing.T) {
 	})
 
 	entries := p.ThreadEvents("ROOT")
-	if len(entries) != 2 {
-		t.Fatalf("expected post + retract, got %d entries", len(entries))
-	}
-	if entries[1].Event.GetMessageRetracted() == nil {
-		t.Error("expected entries[1] to be a MessageRetractedEvent")
+	if len(entries) != 1 {
+		t.Fatalf("expected only the reply row after retract, got %d entries", len(entries))
 	}
 	if got := p.ReplyCount("ROOT"); got != 0 {
 		t.Errorf("ReplyCount after retract = %d, want 0", got)
@@ -194,8 +193,8 @@ func TestThreadProjection_EditOfRootMessageNotInThreadBucket(t *testing.T) {
 	if len(entries) != 1 {
 		t.Fatalf("expected only the reply, got %d entries", len(entries))
 	}
-	if entries[0].Event.GetId() != "ENV-R1" {
-		t.Errorf("entry = %q, want ENV-R1", entries[0].Event.GetId())
+	if entries[0].EventID != "ENV-R1" {
+		t.Errorf("entry = %q, want ENV-R1", entries[0].EventID)
 	}
 }
 


### PR DESCRIPTION
## Summary

- compact `RoomTimelineProjection` retained-entry storage by using a contiguous entry slab plus integer indexes for room/message/event lookup paths
- make `ThreadProjection` retain compact reply references while continuing to fold edit/retract facts into summaries and latest-body state
- add projection-owned string interning for repeated IDs and remove the duplicate retained presence snapshot map per realtime event stream

Closes #1286.

## Verification

- `mise x -- go test ./internal/core -run 'Test(RoomTimeline|Thread|Projection|RoomEvents|Messages|Asset)' -timeout 60s`
- `mise x -- go test ./internal/core -run 'Test(Presence|MyEvents|RoomTimeline|Thread|Projection|RoomEvents|Messages|Asset)' -timeout 60s`
- `mise x -- go test ./internal/core -timeout 120s`
- `mise x -- go test -tags test_endpoints ./internal/http_server -run 'TestRealtime' -timeout 90s`
- `mise test-cli`

## Notes

- Persisted EVT protobufs, subjects, public API shape, authorization, and read-your-writes sequencing are unchanged.
- Realtime WebSocket memory is still dominated by fixed Gorilla/NATS buffers plus per-stream `memberRooms` and presence dedupe maps; this pass removes one duplicate presence map per stream.
