### PR TITLE
fix(frontend): stabilize tab resume catch-up

### DIFF
--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte
@@ -13,7 +13,7 @@
   import { notificationTarget } from '$lib/state/server/notifications.svelte';
   import { appState } from '$lib/state/globals.svelte';
   import ServerIcon from './ServerIcon.svelte';
-  import { useTabResumeCallback } from '$lib/hooks';
+  import { onMount } from 'svelte';
   import * as m from '$lib/i18n/messages';
 
   let {
@@ -134,8 +134,9 @@
     }
   }
 
-  // Load on mount and tab resume
-  useTabResumeCallback(() => void loadAll());
+  onMount(() => {
+    void loadAll();
+  });
 
   // Subscribe to server events. Use $effect (not onMount) so that if the
   // event bus isn't started yet on first run — possible when this component

--- a/apps/frontend/src/lib/eventBus.svelte.ts
+++ b/apps/frontend/src/lib/eventBus.svelte.ts
@@ -205,7 +205,12 @@ export type EventEnvelope = {
 
 export type EventHandler = (event: EventEnvelope) => void;
 export type EventBusCatchUpReason = 'subscription-ended' | 'ws-reconnected' | 'heartbeat-stalled';
-export type EventBusCatchUpHandler = (reason: EventBusCatchUpReason) => void;
+export type EventBusCatchUpPhase = 'immediate' | 'projection-grace';
+export type EventBusCatchUpSignal = {
+  reason: EventBusCatchUpReason;
+  phase: EventBusCatchUpPhase;
+};
+export type EventBusCatchUpHandler = (signal: EventBusCatchUpSignal) => void;
 
 export interface EventBus {
   handlers: SvelteSet<EventHandler>;

--- a/apps/frontend/src/lib/hooks/UseMayHaveMissedMessagesCallbackHarness.svelte
+++ b/apps/frontend/src/lib/hooks/UseMayHaveMissedMessagesCallbackHarness.svelte
@@ -1,16 +1,14 @@
 <script lang="ts">
-  import {
-    useMayHaveMissedMessagesCallback,
-    type MayHaveMissedMessagesReason
-  } from './useMayHaveMissedMessagesCallback.svelte';
+  import { useMayHaveMissedMessagesCallback } from './useMayHaveMissedMessagesCallback.svelte';
+  import type { ResumeSignal } from './resumeCoordinator.svelte';
 
   let {
     onSignal
   }: {
-    onSignal: (reason: MayHaveMissedMessagesReason) => boolean | void | Promise<boolean | void>;
+    onSignal: (signal: ResumeSignal) => boolean | void | Promise<boolean | void>;
   } = $props();
 
-  useMayHaveMissedMessagesCallback((reason) => onSignal(reason));
+  useMayHaveMissedMessagesCallback((signal) => onSignal(signal));
 </script>
 
 <div data-testid="maybe-missed-harness"></div>

--- a/apps/frontend/src/lib/hooks/index.ts
+++ b/apps/frontend/src/lib/hooks/index.ts
@@ -32,6 +32,7 @@ export {
   type MayHaveMissedMessagesReason
 } from './useMayHaveMissedMessagesCallback.svelte';
 export { useReconnectCallback, useReconnectTrigger } from './useReconnectCallback.svelte';
+export type { ResumeSignal } from './resumeCoordinator.svelte';
 export { createTypingIndicator } from './useTypingIndicator.svelte';
 export type { TypingIndicator, TypingUser } from './useTypingIndicator.svelte';
 

--- a/apps/frontend/src/lib/hooks/resumeCoordinator.svelte.ts
+++ b/apps/frontend/src/lib/hooks/resumeCoordinator.svelte.ts
@@ -1,0 +1,209 @@
+import { getActiveServer } from '$lib/state/activeServer.svelte';
+
+export type ResumeSignalReason =
+  | 'visibility'
+  | 'pageshow'
+  | 'online'
+  | 'reconnect'
+  | 'event-bus-subscription-ended'
+  | 'event-bus-ws-reconnected'
+  | 'event-bus-heartbeat-stalled'
+  | 'manual-shortcut';
+
+export type ResumeSignalPhase = 'immediate' | 'projection-grace';
+
+export type ResumeSignalSource = 'browser' | 'event-bus' | 'reconnect' | 'manual';
+
+export type ResumeSignal = {
+  serverId: string;
+  reason: ResumeSignalReason;
+  phase: ResumeSignalPhase;
+  source: ResumeSignalSource;
+  hiddenDurationMs: number | null;
+  epoch: number;
+  at: number;
+};
+
+type ResumeCallback = (signal: ResumeSignal) => void;
+
+type PendingResume = {
+  signal: ResumeSignal;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+const DEFAULT_RESUME_COALESCE_MS = 1_000;
+
+// Deliberately non-reactive: callbacks register from $effect cleanups. Using
+// SvelteMap/SvelteSet here makes registration itself retrigger those effects.
+// eslint-disable-next-line svelte/prefer-svelte-reactivity
+const callbacksByServer = new Map<string, Set<ResumeCallback>>();
+// eslint-disable-next-line svelte/prefer-svelte-reactivity
+const pendingByServer = new Map<string, PendingResume>();
+
+let hiddenStartedAt: number | null =
+  typeof document !== 'undefined' && document.visibilityState === 'hidden' ? Date.now() : null;
+let lastHiddenDurationMs: number | null = null;
+let epoch = 0;
+
+function priority(signal: Pick<ResumeSignal, 'source' | 'phase'>): number {
+  if (signal.source === 'manual') return 5;
+  if (signal.source === 'event-bus' && signal.phase === 'immediate') return 4;
+  if (signal.source === 'reconnect') return 3;
+  if (signal.source === 'event-bus') return 2;
+  return 1;
+}
+
+function mergeSignals(current: ResumeSignal, next: ResumeSignal): ResumeSignal {
+  const winner = priority(next) >= priority(current) ? next : current;
+  return {
+    ...winner,
+    hiddenDurationMs: Math.max(current.hiddenDurationMs ?? 0, next.hiddenDurationMs ?? 0) || null,
+    epoch: Math.max(current.epoch, next.epoch),
+    at: Math.max(current.at, next.at)
+  };
+}
+
+function emitNow(serverId: string, signal: ResumeSignal): void {
+  const callbacks = callbacksByServer.get(serverId);
+  if (!callbacks) return;
+  for (const callback of callbacks) {
+    try {
+      callback(signal);
+    } catch (err) {
+      console.error(`[resume:${serverId}] callback failed`, err);
+    }
+  }
+}
+
+function flush(serverId: string): void {
+  const pending = pendingByServer.get(serverId);
+  if (!pending) return;
+  pendingByServer.delete(serverId);
+  emitNow(serverId, pending.signal);
+}
+
+function signalFor(
+  serverId: string,
+  input: {
+    reason: ResumeSignalReason;
+    phase?: ResumeSignalPhase;
+    source: ResumeSignalSource;
+    hiddenDurationMs?: number | null;
+  }
+): ResumeSignal {
+  return {
+    serverId,
+    reason: input.reason,
+    phase: input.phase ?? 'immediate',
+    source: input.source,
+    hiddenDurationMs: input.hiddenDurationMs ?? lastHiddenDurationMs,
+    epoch: ++epoch,
+    at: Date.now()
+  };
+}
+
+export function emitServerResumeSignal(
+  serverId: string | null | undefined,
+  input: {
+    reason: ResumeSignalReason;
+    phase?: ResumeSignalPhase;
+    source: ResumeSignalSource;
+    hiddenDurationMs?: number | null;
+  },
+  options: { coalesceMs?: number } = {}
+): void {
+  if (!serverId) return;
+  if (!callbacksByServer.has(serverId)) return;
+
+  const next = signalFor(serverId, input);
+  const coalesceMs = options.coalesceMs ?? DEFAULT_RESUME_COALESCE_MS;
+  const pending = pendingByServer.get(serverId);
+  if (pending) {
+    pending.signal = mergeSignals(pending.signal, next);
+    return;
+  }
+
+  if (coalesceMs <= 0) {
+    emitNow(serverId, next);
+    return;
+  }
+
+  const timer = setTimeout(() => flush(serverId), coalesceMs);
+  pendingByServer.set(serverId, { signal: next, timer });
+}
+
+export function registerServerResumeCallback(
+  serverId: string | null | undefined,
+  callback: ResumeCallback
+): () => void {
+  if (!serverId) return () => {};
+  let callbacks = callbacksByServer.get(serverId);
+  if (!callbacks) {
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity
+    callbacks = new Set();
+    callbacksByServer.set(serverId, callbacks);
+  }
+  callbacks.add(callback);
+
+  return () => {
+    const current = callbacksByServer.get(serverId);
+    if (!current) return;
+    current.delete(callback);
+    if (current.size === 0) {
+      callbacksByServer.delete(serverId);
+      const pending = pendingByServer.get(serverId);
+      if (pending) {
+        clearTimeout(pending.timer);
+        pendingByServer.delete(serverId);
+      }
+    }
+  };
+}
+
+export function emitActiveServerResumeSignal(
+  input: {
+    reason: ResumeSignalReason;
+    phase?: ResumeSignalPhase;
+    source: ResumeSignalSource;
+    hiddenDurationMs?: number | null;
+  },
+  options?: { coalesceMs?: number }
+): void {
+  emitServerResumeSignal(getActiveServer(), input, options);
+}
+
+function emitToRegisteredServers(
+  reason: ResumeSignalReason,
+  hiddenDurationMs: number | null
+): void {
+  for (const serverId of callbacksByServer.keys()) {
+    emitServerResumeSignal(serverId, {
+      reason,
+      source: 'browser',
+      hiddenDurationMs
+    });
+  }
+}
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') {
+      hiddenStartedAt = Date.now();
+      return;
+    }
+
+    const hiddenDurationMs = hiddenStartedAt === null ? null : Date.now() - hiddenStartedAt;
+    lastHiddenDurationMs = hiddenDurationMs;
+    hiddenStartedAt = null;
+    emitToRegisteredServers('visibility', hiddenDurationMs);
+  });
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('pageshow', () => {
+    emitToRegisteredServers('pageshow', lastHiddenDurationMs);
+  });
+  window.addEventListener('online', () => {
+    emitToRegisteredServers('online', lastHiddenDurationMs);
+  });
+}

--- a/apps/frontend/src/lib/hooks/useMayHaveMissedMessagesCallback.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/useMayHaveMissedMessagesCallback.svelte.spec.ts
@@ -60,6 +60,7 @@ describe('useMayHaveMissedMessagesCallback', () => {
   });
 
   it('runs the callback when the active event bus reports a catch-up gap', async () => {
+    vi.useFakeTimers();
     const fake = new FakeServerConnection();
     eventBusManager.startBus(TEST_SERVER, fake as unknown as ServerConnection);
     const onSignal = vi.fn();
@@ -72,39 +73,47 @@ describe('useMayHaveMissedMessagesCallback', () => {
     await vi.waitFor(() => expect(bus.catchUpHandlers.size).toBe(1));
 
     for (const handler of bus.catchUpHandlers) {
-      handler('heartbeat-stalled');
+      handler({ reason: 'heartbeat-stalled', phase: 'immediate' });
     }
+    await vi.advanceTimersByTimeAsync(1_000);
 
-    await vi.waitFor(() => expect(onSignal).toHaveBeenCalledWith('event-bus-heartbeat-stalled'));
+    expect(onSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverId: TEST_SERVER,
+        reason: 'event-bus-heartbeat-stalled',
+        phase: 'immediate',
+        source: 'event-bus'
+      })
+    );
     rendered.unmount();
   });
 
-  it('does not let a failed wake refresh suppress a queued online signal', async () => {
-    let resolveFirst!: (value: boolean) => void;
-    const firstRefresh = new Promise<boolean>((resolve) => {
-      resolveFirst = resolve;
-    });
-    const onSignal = vi
-      .fn()
-      .mockImplementationOnce(() => firstRefresh)
-      .mockResolvedValue(undefined);
+  it('coalesces a browser wake burst into one signal', async () => {
+    vi.useFakeTimers();
+    const onSignal = vi.fn().mockResolvedValue(undefined);
 
     const rendered = render(Harness, { props: { onSignal } });
     flushSync();
 
     window.dispatchEvent(new Event('pageshow'));
     window.dispatchEvent(new Event('online'));
-    expect(onSignal).toHaveBeenCalledTimes(1);
-    expect(onSignal).toHaveBeenNthCalledWith(1, 'pageshow');
+    expect(onSignal).not.toHaveBeenCalled();
 
-    resolveFirst(false);
-
-    await vi.waitFor(() => expect(onSignal).toHaveBeenCalledTimes(2));
-    expect(onSignal).toHaveBeenNthCalledWith(2, 'online');
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onSignal).toHaveBeenCalledOnce();
+    expect(onSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverId: TEST_SERVER,
+        reason: 'online',
+        phase: 'immediate',
+        source: 'browser'
+      })
+    );
     rendered.unmount();
   });
 
-  it('runs a queued event-bus catch-up even after the in-flight refresh succeeds', async () => {
+  it('runs a projection-grace event-bus catch-up after the in-flight refresh succeeds', async () => {
+    vi.useFakeTimers();
     const fake = new FakeServerConnection();
     eventBusManager.startBus(TEST_SERVER, fake as unknown as ServerConnection);
     let resolveFirst!: (value: boolean) => void;
@@ -124,16 +133,36 @@ describe('useMayHaveMissedMessagesCallback', () => {
     await vi.waitFor(() => expect(bus.catchUpHandlers.size).toBe(1));
 
     for (const handler of bus.catchUpHandlers) {
-      handler('subscription-ended');
-      handler('heartbeat-stalled');
+      handler({ reason: 'subscription-ended', phase: 'immediate' });
     }
+    await vi.advanceTimersByTimeAsync(1_000);
+
     expect(onSignal).toHaveBeenCalledTimes(1);
-    expect(onSignal).toHaveBeenNthCalledWith(1, 'event-bus-subscription-ended');
+    expect(onSignal).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        reason: 'event-bus-subscription-ended',
+        phase: 'immediate',
+        source: 'event-bus'
+      })
+    );
+
+    for (const handler of bus.catchUpHandlers) {
+      handler({ reason: 'subscription-ended', phase: 'projection-grace' });
+    }
+    await vi.advanceTimersByTimeAsync(1_000);
 
     resolveFirst(true);
 
     await vi.waitFor(() => expect(onSignal).toHaveBeenCalledTimes(2));
-    expect(onSignal).toHaveBeenNthCalledWith(2, 'event-bus-heartbeat-stalled');
+    expect(onSignal).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        reason: 'event-bus-subscription-ended',
+        phase: 'projection-grace',
+        source: 'event-bus'
+      })
+    );
     rendered.unmount();
   });
 });

--- a/apps/frontend/src/lib/hooks/useMayHaveMissedMessagesCallback.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useMayHaveMissedMessagesCallback.svelte.ts
@@ -1,8 +1,14 @@
 import { onMount } from 'svelte';
-import type { EventBusCatchUpReason } from '$lib/eventBus.svelte';
+import type { EventBusCatchUpReason, EventBusCatchUpSignal } from '$lib/eventBus.svelte';
 import { getActiveServer } from '$lib/state/activeServer.svelte';
 import { eventBusManager } from '$lib/state/server/eventBus.svelte';
 import { useReconnectCallback } from './useReconnectCallback.svelte';
+import {
+  emitActiveServerResumeSignal,
+  emitServerResumeSignal,
+  registerServerResumeCallback,
+  type ResumeSignal
+} from './resumeCoordinator.svelte';
 
 export type MayHaveMissedMessagesReason =
   | 'visibility'
@@ -43,58 +49,56 @@ function reasonForEventBusCatchUp(reason: EventBusCatchUpReason): MayHaveMissedM
 }
 
 function createRefreshRunner(
-  callback: (reason: MayHaveMissedMessagesReason) => boolean | void | Promise<boolean | void>
+  callback: (signal: ResumeSignal) => boolean | void | Promise<boolean | void>
 ) {
   let lastSucceededAt = 0;
   let inFlight = false;
-  let queuedReason: MayHaveMissedMessagesReason | null = null;
+  let queuedSignal: ResumeSignal | null = null;
 
-  async function run(reason: MayHaveMissedMessagesReason): Promise<void> {
+  async function run(signal: ResumeSignal): Promise<void> {
     inFlight = true;
     let succeeded = false;
-    let nextReason: MayHaveMissedMessagesReason | null = null;
-    console.debug('[room-refresh] maybe-missed signal', { reason });
+    let nextSignal: ResumeSignal | null = null;
+    console.debug('[room-refresh] maybe-missed signal', signal);
     try {
-      const refreshed = await callback(reason);
+      const refreshed = await callback(signal);
       if (refreshed !== false) {
         lastSucceededAt = Date.now();
         succeeded = true;
       }
     } catch (error) {
-      console.debug('[room-refresh] maybe-missed callback failed', { reason, error });
+      console.debug('[room-refresh] maybe-missed callback failed', { signal, error });
     } finally {
       inFlight = false;
-      nextReason = queuedReason;
-      queuedReason = null;
+      nextSignal = queuedSignal;
+      queuedSignal = null;
     }
 
-    if (nextReason) {
-      if (!succeeded || isEventBusReason(nextReason)) {
-        console.debug('[room-refresh] running queued maybe-missed signal', { reason: nextReason });
-        void run(nextReason);
+    if (nextSignal) {
+      if (!succeeded || isEventBusReason(nextSignal.reason)) {
+        console.debug('[room-refresh] running queued maybe-missed signal', nextSignal);
+        void run(nextSignal);
       } else {
         console.debug('[room-refresh] skipped queued duplicate after successful refresh', {
-          reason: nextReason
+          signal: nextSignal
         });
       }
     }
   }
 
   return {
-    trigger(reason: MayHaveMissedMessagesReason): void {
+    trigger(signal: ResumeSignal): void {
       const now = Date.now();
       if (inFlight) {
-        queuedReason = reason;
-        console.debug('[room-refresh] queued maybe-missed signal while refresh is running', {
-          reason
-        });
+        queuedSignal = signal;
+        console.debug('[room-refresh] queued maybe-missed signal while refresh is running', signal);
         return;
       }
       if (now - lastSucceededAt < DEDUPE_MS) {
-        console.debug('[room-refresh] skipped duplicate maybe-missed signal', { reason });
+        console.debug('[room-refresh] skipped duplicate maybe-missed signal', signal);
         return;
       }
-      void run(reason);
+      void run(signal);
     }
   };
 }
@@ -105,12 +109,23 @@ function createRefreshRunner(
  * unlock does not fan out several identical room refreshes.
  */
 export function useMayHaveMissedMessagesCallback(
-  callback: (reason: MayHaveMissedMessagesReason) => boolean | void | Promise<boolean | void>
+  callback: (signal: ResumeSignal) => boolean | void | Promise<boolean | void>
 ): void {
   const runner = createRefreshRunner(callback);
-  const trigger = (reason: MayHaveMissedMessagesReason) => runner.trigger(reason);
 
-  useReconnectCallback(() => trigger('reconnect'));
+  useReconnectCallback(() =>
+    emitActiveServerResumeSignal({
+      reason: 'reconnect',
+      source: 'reconnect'
+    })
+  );
+
+  $effect(() => {
+    const serverId = getActiveServer();
+    if (!serverId) return;
+
+    return registerServerResumeCallback(serverId, (signal) => runner.trigger(signal));
+  });
 
   $effect(() => {
     const serverId = getActiveServer();
@@ -119,8 +134,12 @@ export function useMayHaveMissedMessagesCallback(
     const bus = eventBusManager.getBus(serverId);
     if (!bus) return;
 
-    const catchUpHandler = (reason: EventBusCatchUpReason) => {
-      trigger(reasonForEventBusCatchUp(reason));
+    const catchUpHandler = (signal: EventBusCatchUpSignal) => {
+      emitServerResumeSignal(serverId, {
+        reason: reasonForEventBusCatchUp(signal.reason),
+        phase: signal.phase,
+        source: 'event-bus'
+      });
     };
     bus.catchUpHandlers.add(catchUpHandler);
     return () => {
@@ -129,30 +148,31 @@ export function useMayHaveMissedMessagesCallback(
   });
 
   onMount(() => {
-    const onVisibilityChange = () => {
-      if (document.visibilityState === 'visible') trigger('visibility');
-    };
-    const onPageShow = () => trigger('pageshow');
-    const onOnline = () => trigger('online');
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.repeat || isEditableTarget(event.target)) return;
 
       // Temporary manual refresh shortcut for visual artifact testing.
-      if (event.ctrlKey && event.altKey && event.shiftKey && !event.metaKey && event.code === 'KeyR') {
+      if (
+        event.ctrlKey &&
+        event.altKey &&
+        event.shiftKey &&
+        !event.metaKey &&
+        event.code === 'KeyR'
+      ) {
         event.preventDefault();
-        trigger('manual-shortcut');
+        emitActiveServerResumeSignal(
+          {
+            reason: 'manual-shortcut',
+            source: 'manual'
+          },
+          { coalesceMs: 0 }
+        );
       }
     };
 
-    document.addEventListener('visibilitychange', onVisibilityChange);
-    window.addEventListener('pageshow', onPageShow);
-    window.addEventListener('online', onOnline);
     window.addEventListener('keydown', onKeyDown);
 
     return () => {
-      document.removeEventListener('visibilitychange', onVisibilityChange);
-      window.removeEventListener('pageshow', onPageShow);
-      window.removeEventListener('online', onOnline);
       window.removeEventListener('keydown', onKeyDown);
     };
   });

--- a/apps/frontend/src/lib/hooks/useTabResumeCallback.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useTabResumeCallback.svelte.ts
@@ -1,15 +1,6 @@
 import { onMount } from 'svelte';
-
-// eslint-disable-next-line svelte/prefer-svelte-reactivity -- module-level callback registry, not read reactively
-const callbacks = new Set<() => void>();
-
-if (typeof document !== 'undefined') {
-	document.addEventListener('visibilitychange', () => {
-		if (document.visibilityState === 'visible') {
-			for (const cb of callbacks) cb();
-		}
-	});
-}
+import { getActiveServer } from '$lib/state/activeServer.svelte';
+import { registerServerResumeCallback } from './resumeCoordinator.svelte';
 
 /**
  * Run a callback on mount and whenever the browser tab becomes visible again.
@@ -21,10 +12,8 @@ if (typeof document !== 'undefined') {
  * Must be called during component initialization.
  */
 export function useTabResumeCallback(callback: () => void) {
-	onMount(() => {
-		callback();
-		callbacks.add(callback);
-		return () => callbacks.delete(callback);
-	});
+  onMount(() => {
+    callback();
+    return registerServerResumeCallback(getActiveServer(), () => callback());
+  });
 }
-

--- a/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -985,9 +985,9 @@ describe('MessagesStore — room lifecycle ownership', () => {
     await store.refreshCurrentWindow('m2');
     await settle();
 
-    expect(store.rootEvents.map((event) => event.id)).toEqual(['m2']);
-    expect(store.hasReachedStart).toBe(false);
-    expect(store.rootEvents[0].event).toMatchObject({
+    expect(store.rootEvents.map((event) => event.id)).toEqual(['m1', 'm2', 'm3']);
+    expect(store.hasReachedStart).toBe(true);
+    expect(store.rootEvents.find((event) => event.id === 'm2')?.event).toMatchObject({
       reactions: [{ emoji: 'thumbsup', count: 1 }]
     });
     expect(fake.queryMock.mock.calls[0][1]).toEqual({
@@ -1054,14 +1054,23 @@ describe('MessagesStore — room lifecycle ownership', () => {
 
     await refresh;
     await settle();
-    expect(store.rootEvents.map((event) => event.id)).toEqual(['m3', 'm4', 'm5', 'm8']);
+    expect(store.rootEvents.map((event) => event.id)).toEqual(['m1', 'm2', 'm3', 'm4', 'm5', 'm8']);
 
     const jumpState = new JumpToMessageState();
     jumpState.isJumpedMode = true;
     await store.loadNewer(jumpState);
     await settle();
 
-    expect(store.rootEvents.map((event) => event.id)).toEqual(['m3', 'm4', 'm5', 'm6', 'm7', 'm8']);
+    expect(store.rootEvents.map((event) => event.id)).toEqual([
+      'm1',
+      'm2',
+      'm3',
+      'm4',
+      'm5',
+      'm6',
+      'm7',
+      'm8'
+    ]);
     store.dispose();
   });
 
@@ -1102,7 +1111,7 @@ describe('MessagesStore — room lifecycle ownership', () => {
     await store.refreshCurrentWindow('r20');
     await settle();
 
-    expect(store.threadEvents.map((event) => event.id)).toEqual(['t1', 'r19', 'r20', 'r21']);
+    expect(store.threadEvents.map((event) => event.id)).toEqual(['t1', 'r18', 'r19', 'r20', 'r21']);
     expect(store.hasReachedStart).toBe(false);
     expect(store.threadEvents.find((event) => event.id === 'r20')?.event).toMatchObject({
       reactions: [{ emoji: 'thumbsup', count: 1 }]
@@ -1244,7 +1253,7 @@ describe('MessagesStore — thread lifecycle ownership', () => {
       limit: 50
     });
     expect(fake.queryMock).not.toHaveBeenCalled();
-    expect(store.threadEvents.map((event) => event.id)).toEqual(['t1', 'r19', 'r20', 'r21']);
+    expect(store.threadEvents.map((event) => event.id)).toEqual(['t1', 'r18', 'r19', 'r20', 'r21']);
     expect(store.threadEvents.find((event) => event.id === 'r20')?.event).toMatchObject({
       reactions: [{ emoji: 'thumbsup', count: 1 }]
     });

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -889,11 +889,15 @@ export class MessagesStore {
       endCursor?: string | null;
       hasOlder?: boolean;
     },
-    existingBeforeFetch: ReadonlySet<string>
+    existingBeforeFetch: ReadonlySet<string>,
+    options: { preserveExistingWindow?: boolean } = {}
   ): void {
     const fetched = unmask(connection.events);
     const newSeen = new SvelteSet<string>();
     const merged: RoomEventView[] = [];
+    const previousOldestCursor = this.oldestCursor;
+    const previousNewestCursor = this.newestCursor;
+    const previousHasReachedStart = this.hasReachedStart;
 
     for (const e of fetched) {
       if (newSeen.has(e.id)) continue;
@@ -902,10 +906,12 @@ export class MessagesStore {
     }
 
     // Preserve subscription events that arrived while the refresh query was in
-    // flight. Older pre-refresh rows outside the fetched window are deliberately
-    // dropped: this is a projected-state reload of the current window.
+    // flight. Anchored refreshes also preserve already-loaded rows outside the
+    // fetched window so returning from another tab does not visually collapse a
+    // long scrolled buffer.
     for (const e of this.events) {
-      if (existingBeforeFetch.has(e.id) || newSeen.has(e.id)) continue;
+      if (!options.preserveExistingWindow && existingBeforeFetch.has(e.id)) continue;
+      if (newSeen.has(e.id)) continue;
       newSeen.add(e.id);
       merged.push(e);
     }
@@ -913,12 +919,18 @@ export class MessagesStore {
     this.events = merged;
     if (this.scope === 'room') this.sortRoomEvents();
     this.seenIds = newSeen;
-    this.oldestCursor = connection.startCursor ?? undefined;
-    this.newestCursor = connection.endCursor ?? undefined;
-    this.hasReachedStart = !(connection.hasOlder ?? false);
+    if (options.preserveExistingWindow) {
+      this.oldestCursor = previousOldestCursor ?? connection.startCursor ?? undefined;
+      this.newestCursor = previousNewestCursor ?? connection.endCursor ?? undefined;
+      this.hasReachedStart = previousHasReachedStart || !(connection.hasOlder ?? false);
+    } else {
+      this.oldestCursor = connection.startCursor ?? undefined;
+      this.newestCursor = connection.endCursor ?? undefined;
+      this.hasReachedStart = !(connection.hasOlder ?? false);
+    }
     console.debug('[room-refresh] snapshot applied', {
       fetchedCount: fetched.length,
-      preservedInFlightCount: merged.length - fetched.length,
+      preservedExistingCount: merged.length - fetched.length,
       eventCount: this.events.length,
       hasOlder: connection.hasOlder ?? false,
       hasReachedStart: this.hasReachedStart
@@ -951,7 +963,9 @@ export class MessagesStore {
     });
 
     if (this.isStale(thisLoad)) return { hasOlder: false, hasNewer: false, refreshed: false };
-    this.replaceWithSnapshotAndUpdateCursors(page, existingBeforeFetch);
+    this.replaceWithSnapshotAndUpdateCursors(page, existingBeforeFetch, {
+      preserveExistingWindow: true
+    });
     return { hasOlder: page.hasOlder, hasNewer: page.hasNewer, refreshed: true };
   }
 
@@ -973,7 +987,9 @@ export class MessagesStore {
           limit: PAGE_SIZE
         });
     if (this.isStale(thisLoad)) return { hasOlder: false, hasNewer: false, refreshed: false };
-    this.replaceWithSnapshotAndUpdateCursors(page, existingBeforeFetch);
+    this.replaceWithSnapshotAndUpdateCursors(page, existingBeforeFetch, {
+      preserveExistingWindow: anchorEventId !== null && anchorEventId !== this.threadRootEventId
+    });
     this.sortThreadEvents();
     return { hasOlder: page.hasOlder, hasNewer: page.hasNewer, refreshed: true };
   }

--- a/apps/frontend/src/lib/state/server/eventBus.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/eventBus.svelte.spec.ts
@@ -312,7 +312,10 @@ describe('eventBusManager realtime transport', () => {
     socket.serverClose();
 
     expect(fake.status).toBe('disconnected');
-    expect(catchUp).toHaveBeenCalledWith('subscription-ended');
+    expect(catchUp).toHaveBeenCalledWith({
+      reason: 'subscription-ended',
+      phase: 'immediate'
+    });
     await vi.advanceTimersByTimeAsync(0);
     expect(sockets).toHaveLength(2);
   });
@@ -375,7 +378,10 @@ describe('eventBusManager realtime transport', () => {
     expect(catchUp).toHaveBeenCalledTimes(1);
     await vi.advanceTimersByTimeAsync(1);
     expect(catchUp).toHaveBeenCalledTimes(2);
-    expect(catchUp).toHaveBeenNthCalledWith(2, 'subscription-ended');
+    expect(catchUp).toHaveBeenNthCalledWith(2, {
+      reason: 'subscription-ended',
+      phase: 'projection-grace'
+    });
   });
 
   it('reconnects when the ServerConnection retry bridge requests it', async () => {
@@ -386,7 +392,10 @@ describe('eventBusManager realtime transport', () => {
 
     fake.forceReconnect('user retry');
 
-    expect(catchUp).toHaveBeenCalledWith('ws-reconnected');
+    expect(catchUp).toHaveBeenCalledWith({
+      reason: 'ws-reconnected',
+      phase: 'immediate'
+    });
     await vi.advanceTimersByTimeAsync(0);
     expect(sockets).toHaveLength(2);
   });
@@ -399,7 +408,10 @@ describe('eventBusManager realtime transport', () => {
 
     await vi.advanceTimersByTimeAsync(90_000);
 
-    expect(catchUp).toHaveBeenCalledWith('heartbeat-stalled');
+    expect(catchUp).toHaveBeenCalledWith({
+      reason: 'heartbeat-stalled',
+      phase: 'immediate'
+    });
     expect(sockets).toHaveLength(2);
   });
 

--- a/apps/frontend/src/lib/state/server/eventBus.svelte.ts
+++ b/apps/frontend/src/lib/state/server/eventBus.svelte.ts
@@ -8,6 +8,9 @@
 import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 import type {
   EventBusCatchUpReason,
+  EventBusCatchUpPhase,
+  EventBusCatchUpSignal,
+  EventBusCatchUpHandler,
   EventHandler,
   EventBus,
   EventEnvelope
@@ -92,7 +95,7 @@ class EventBusManager {
     if (this.#buses.has(serverId)) return () => {};
 
     const handlers = new SvelteSet<EventHandler>();
-    const catchUpHandlers = new SvelteSet<(reason: EventBusCatchUpReason) => void>();
+    const catchUpHandlers = new SvelteSet<EventBusCatchUpHandler>();
     const bus: EventBus = { handlers, catchUpHandlers };
     let lastEventAt = Date.now();
     let heartbeatCount = 0;
@@ -116,8 +119,9 @@ class EventBusManager {
 
     const notifyCatchUpHandlers = (
       reason: EventBusCatchUpReason,
-      phase: 'immediate' | 'projection-grace' = 'immediate'
+      phase: EventBusCatchUpPhase = 'immediate'
     ) => {
+      const signal: EventBusCatchUpSignal = { reason, phase };
       console.debug(`[eventBus:${serverId}] notifying catch-up handlers`, {
         reason,
         phase,
@@ -126,7 +130,7 @@ class EventBusManager {
       });
       for (const handler of catchUpHandlers) {
         try {
-          handler(reason);
+          handler(signal);
         } catch (err) {
           console.error(`[eventBus:${serverId}] catch-up handler threw`, err);
         }

--- a/apps/frontend/src/lib/state/server/rooms.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/rooms.svelte.spec.ts
@@ -384,6 +384,91 @@ describe('RoomsStore - refresh', () => {
     expect(store.rooms).toMatchObject([{ id: 'general', viewerNotificationCount: 0 }]);
   });
 
+  it('preserves unchanged room rows and array identity during refresh', async () => {
+    const roomDirectoryAPI = makeRoomDirectoryAPI([makeRoom('general'), makeRoom('random')]);
+    const store = makeStore({
+      roomDirectoryAPI,
+      notificationAPI: makeNotificationAPI({ general: 1, random: 0 })
+    });
+
+    await store.refresh();
+    await vi.waitFor(() => {
+      expect(store.rooms[0]?.viewerNotificationCount).toBe(1);
+    });
+
+    const rooms = store.rooms;
+    const general = store.rooms[0];
+    const random = store.rooms[1];
+    vi.mocked(roomDirectoryAPI.listRooms).mockResolvedValue([
+      makeRoom('general'),
+      makeRoom('random')
+    ]);
+
+    await store.refresh();
+    await settle();
+
+    expect(store.rooms).toBe(rooms);
+    expect(store.rooms[0]).toBe(general);
+    expect(store.rooms[1]).toBe(random);
+  });
+
+  it('patches changed room rows without replacing unchanged neighbors', async () => {
+    const roomDirectoryAPI = makeRoomDirectoryAPI([makeRoom('general'), makeRoom('random')]);
+    const store = makeStore({
+      roomDirectoryAPI,
+      notificationAPI: makeNotificationAPI()
+    });
+
+    await store.refresh();
+    await settle();
+
+    const general = store.rooms[0];
+    const random = store.rooms[1];
+    vi.mocked(roomDirectoryAPI.listRooms).mockResolvedValue([
+      makeRoom('general'),
+      makeRoom('random', { hasUnread: true })
+    ]);
+
+    await store.refresh();
+    await settle();
+
+    expect(store.rooms[0]).toBe(general);
+    expect(store.rooms[1]).not.toBe(random);
+    expect(store.rooms[1]).toMatchObject({ id: 'random', hasUnread: true });
+  });
+
+  it('only replaces rooms whose notification counts changed', async () => {
+    const notificationAPI = makeNotificationAPI({ general: 1, random: 0 });
+    const store = makeStore({
+      roomDirectoryAPI: makeRoomDirectoryAPI([makeRoom('general'), makeRoom('random')]),
+      notificationAPI
+    });
+
+    await store.refresh();
+    await vi.waitFor(() => {
+      expect(store.rooms[0]?.viewerNotificationCount).toBe(1);
+    });
+
+    const rooms = store.rooms;
+    const general = store.rooms[0];
+    const random = store.rooms[1];
+
+    await store.refreshNotificationCounts();
+
+    expect(store.rooms).toBe(rooms);
+    expect(store.rooms[0]).toBe(general);
+    expect(store.rooms[1]).toBe(random);
+
+    vi.mocked(notificationAPI.listNotificationCounts).mockResolvedValue({ general: 1, random: 3 });
+
+    await store.refreshNotificationCounts();
+
+    expect(store.rooms).not.toBe(rooms);
+    expect(store.rooms[0]).toBe(general);
+    expect(store.rooms[1]).not.toBe(random);
+    expect(store.rooms[1]).toMatchObject({ id: 'random', viewerNotificationCount: 3 });
+  });
+
   it('discards out-of-order notification count refresh responses', async () => {
     let countQueries = 0;
     let resolveOlder!: (value: Record<string, number>) => void;

--- a/apps/frontend/src/lib/state/server/rooms.svelte.ts
+++ b/apps/frontend/src/lib/state/server/rooms.svelte.ts
@@ -91,6 +91,92 @@ function avatarUserFromDirectoryMember(member: DirectoryMember): UserAvatarUserV
   };
 }
 
+function sameStringArray(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((value, index) => value === b[index]);
+}
+
+function sameAvatarUser(a: UserAvatarUserView, b: UserAvatarUserView): boolean {
+  return (
+    a.id === b.id &&
+    a.login === b.login &&
+    a.displayName === b.displayName &&
+    a.deleted === b.deleted &&
+    a.avatarUrl === b.avatarUrl &&
+    a.presenceStatus === b.presenceStatus &&
+    a.customStatus?.emoji === b.customStatus?.emoji &&
+    a.customStatus?.text === b.customStatus?.text &&
+    a.customStatus?.expiresAt === b.customStatus?.expiresAt
+  );
+}
+
+function sameAvatarUsers(
+  a: readonly UserAvatarUserView[],
+  b: readonly UserAvatarUserView[]
+): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((value, index) => {
+    const other = b[index];
+    return other !== undefined && sameAvatarUser(value, other);
+  });
+}
+
+function sameRoomListItem(a: RoomsListItem, b: RoomsListItem): boolean {
+  return (
+    a.id === b.id &&
+    a.name === b.name &&
+    a.type === b.type &&
+    a.isUniversal === b.isUniversal &&
+    a.hasUnread === b.hasUnread &&
+    a.viewerIsMember === b.viewerIsMember &&
+    a.viewerCanJoinRoom === b.viewerCanJoinRoom &&
+    a.viewerNotificationCount === b.viewerNotificationCount &&
+    sameAvatarUsers(a.members, b.members)
+  );
+}
+
+function sameSidebarLink(a: SidebarLinkListItem, b: SidebarLinkListItem): boolean {
+  return a.id === b.id && a.label === b.label && a.url === b.url;
+}
+
+function sameRoomGroupItem(a: RoomsListGroupItem, b: RoomsListGroupItem): boolean {
+  if (a.type !== b.type || a.id !== b.id) return false;
+  if (a.type === 'room' && b.type === 'room') return a.roomId === b.roomId;
+  if (a.type === 'link' && b.type === 'link') return sameSidebarLink(a.link, b.link);
+  return false;
+}
+
+function sameRoomGroupItems(
+  a: readonly RoomsListGroupItem[],
+  b: readonly RoomsListGroupItem[]
+): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((value, index) => {
+    const other = b[index];
+    return other !== undefined && sameRoomGroupItem(value, other);
+  });
+}
+
+function sameRoomGroup(a: RoomsListGroup, b: RoomsListGroup): boolean {
+  return (
+    a.id === b.id &&
+    a.name === b.name &&
+    sameStringArray(a.roomIds, b.roomIds) &&
+    sameRoomGroupItems(a.items ?? [], b.items ?? [])
+  );
+}
+
+function sameRoomGroups(
+  a: readonly RoomsListGroup[] | null,
+  b: readonly RoomsListGroup[]
+): boolean {
+  if (!a || a.length !== b.length) return false;
+  return a.every((value, index) => {
+    const other = b[index];
+    return other !== undefined && sameRoomGroup(value, other);
+  });
+}
+
 const roomStateRefreshEvents = new Set<RoomEventKind>([
   RoomEventKind.RoomCreated,
   RoomEventKind.RoomDeleted,
@@ -191,19 +277,23 @@ export class RoomsStore {
     );
     if (this.loadId !== thisLoad) return;
 
-    this.rooms = [
+    const nextRooms = [
       ...visibleChannels.map((room) => this.roomListItem(room, [])),
       ...visibleDms.map((room) => this.roomListItem(room, dmMembersByRoomId.get(room.id) ?? []))
     ];
+    this.applyRooms(nextRooms);
     this.roomUnread.initRooms([...visibleChannels, ...visibleDms]);
     void this.refreshNotificationCounts();
 
-    this.roomGroups = roomGroups.map((group) => ({
+    const nextRoomGroups = roomGroups.map((group) => ({
       id: group.id,
       name: group.name,
       roomIds: group.roomIds,
       items: group.items.map(roomGroupItem)
     }));
+    if (!sameRoomGroups(this.roomGroups, nextRoomGroups)) {
+      this.roomGroups = nextRoomGroups;
+    }
 
     this.isInitialLoading = false;
   }
@@ -222,6 +312,31 @@ export class RoomsStore {
     };
   }
 
+  private applyRooms(nextRooms: RoomsListItem[]): void {
+    const previousById = new SvelteMap(this.rooms.map((room) => [room.id, room]));
+    let changed = this.rooms.length !== nextRooms.length;
+    const merged = nextRooms.map((room, index) => {
+      const previous = previousById.get(room.id);
+      const next = {
+        ...room,
+        viewerNotificationCount: previous?.viewerNotificationCount ?? room.viewerNotificationCount
+      };
+      if (!previous) {
+        changed = true;
+        return next;
+      }
+      if (this.rooms[index]?.id !== room.id || !sameRoomListItem(previous, next)) {
+        changed = true;
+        return next;
+      }
+      return previous;
+    });
+
+    if (changed) {
+      this.rooms = merged;
+    }
+  }
+
   async refreshNotificationCounts(): Promise<void> {
     const loadId = this.loadId;
     const notificationCountsLoadId = ++this.notificationCountsLoadId;
@@ -233,10 +348,14 @@ export class RoomsStore {
       }
 
       untrack(() => {
-        this.rooms = this.rooms.map((room) => ({
-          ...room,
-          viewerNotificationCount: countsByRoomId[room.id] ?? 0
-        }));
+        let changed = false;
+        const rooms = this.rooms.map((room) => {
+          const viewerNotificationCount = countsByRoomId[room.id] ?? 0;
+          if (room.viewerNotificationCount === viewerNotificationCount) return room;
+          changed = true;
+          return { ...room, viewerNotificationCount };
+        });
+        if (changed) this.rooms = rooms;
       });
     } catch (err) {
       if (this.loadId === loadId && this.notificationCountsLoadId === notificationCountsLoadId) {

--- a/apps/frontend/src/lib/state/server/store.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.spec.ts
@@ -3,6 +3,7 @@ import { flushSync } from 'svelte';
 import type { PublicServerInfo } from '$lib/api-client/server';
 import type { AuthenticatedServerState } from '$lib/api-client/serverState';
 import { RoomEventKind } from '$lib/render/eventKinds';
+import type { EventBusCatchUpReason, EventBusCatchUpSignal } from '$lib/eventBus.svelte';
 
 const { soundMocks, apiMocks } = vi.hoisted(() => ({
   soundMocks: {
@@ -271,6 +272,13 @@ function deferred<T = void>(): {
     reject = rej;
   });
   return { promise, resolve, reject };
+}
+
+function catchUpSignal(
+  reason: EventBusCatchUpReason,
+  phase: EventBusCatchUpSignal['phase'] = 'immediate'
+): EventBusCatchUpSignal {
+  return { reason, phase };
 }
 
 const stores: ServerStateStore[] = [];
@@ -807,7 +815,7 @@ describe('ServerStateStore live server updates', () => {
     if (!bus) throw new Error('event bus did not start');
 
     for (const handler of bus.catchUpHandlers) {
-      handler('ws-reconnected');
+      handler(catchUpSignal('ws-reconnected'));
     }
     await Promise.resolve();
 
@@ -838,7 +846,7 @@ describe('ServerStateStore live server updates', () => {
     if (!bus) throw new Error('event bus did not start');
 
     for (const handler of bus.catchUpHandlers) {
-      handler('ws-reconnected');
+      handler(catchUpSignal('ws-reconnected'));
     }
     await Promise.resolve();
 
@@ -869,14 +877,80 @@ describe('ServerStateStore live server updates', () => {
     if (!bus) throw new Error('event bus did not start');
 
     for (const handler of bus.catchUpHandlers) {
-      handler('ws-reconnected');
+      handler(catchUpSignal('ws-reconnected'));
     }
     await Promise.resolve();
 
     expect(store.adminRoomLayout.refresh).toHaveBeenCalledOnce();
   });
 
-  it('runs one queued projected-state refresh after an in-flight catch-up succeeds', async () => {
+  it('runs projection-grace full catch-up after immediate catch-up succeeds', async () => {
+    const fake = new FakeServerConnection([]);
+    const store = makeStore(fake);
+    store.serverInfo.refreshProfile = vi.fn().mockResolvedValue(undefined);
+    store.serverInfo.refreshAuthenticatedSettings = vi.fn().mockResolvedValue(undefined);
+    store.notifications.fetch = vi.fn().mockResolvedValue(undefined);
+    store.rooms.refresh = vi.fn().mockResolvedValue(undefined);
+    store.roomDirectory.refresh = vi.fn().mockResolvedValue(undefined);
+    store.adminRoomLayout.refresh = vi.fn().mockResolvedValue(undefined);
+
+    eventBusManager.startBus(registered.id, fake as unknown as ServerConnection);
+    flushSync();
+    const bus = eventBusManager.getBus(registered.id);
+    if (!bus) throw new Error('event bus did not start');
+
+    for (const handler of bus.catchUpHandlers) {
+      handler(catchUpSignal('subscription-ended', 'immediate'));
+    }
+    await flushPromises();
+
+    for (const handler of bus.catchUpHandlers) {
+      handler(catchUpSignal('subscription-ended', 'projection-grace'));
+    }
+    await flushPromises();
+
+    expect(store.serverInfo.refreshProfile).toHaveBeenCalledTimes(2);
+    expect(store.serverInfo.refreshAuthenticatedSettings).toHaveBeenCalledTimes(2);
+    expect(store.notifications.fetch).toHaveBeenCalledTimes(2);
+    expect(store.rooms.refresh).toHaveBeenCalledTimes(2);
+    expect(store.roomDirectory.refresh).toHaveBeenCalledTimes(2);
+    expect(store.adminRoomLayout.refresh).not.toHaveBeenCalled();
+  });
+
+  it('skips duplicate immediate full catch-up after recent success', async () => {
+    const fake = new FakeServerConnection([]);
+    const store = makeStore(fake);
+    store.serverInfo.refreshProfile = vi.fn().mockResolvedValue(undefined);
+    store.serverInfo.refreshAuthenticatedSettings = vi.fn().mockResolvedValue(undefined);
+    store.notifications.fetch = vi.fn().mockResolvedValue(undefined);
+    store.rooms.refresh = vi.fn().mockResolvedValue(undefined);
+    store.roomDirectory.refresh = vi.fn().mockResolvedValue(undefined);
+    store.adminRoomLayout.refresh = vi.fn().mockResolvedValue(undefined);
+
+    eventBusManager.startBus(registered.id, fake as unknown as ServerConnection);
+    flushSync();
+    const bus = eventBusManager.getBus(registered.id);
+    if (!bus) throw new Error('event bus did not start');
+
+    for (const handler of bus.catchUpHandlers) {
+      handler(catchUpSignal('subscription-ended'));
+    }
+    await flushPromises();
+
+    for (const handler of bus.catchUpHandlers) {
+      handler(catchUpSignal('ws-reconnected'));
+    }
+    await flushPromises();
+
+    expect(store.serverInfo.refreshProfile).toHaveBeenCalledOnce();
+    expect(store.serverInfo.refreshAuthenticatedSettings).toHaveBeenCalledOnce();
+    expect(store.notifications.fetch).toHaveBeenCalledOnce();
+    expect(store.rooms.refresh).toHaveBeenCalledOnce();
+    expect(store.roomDirectory.refresh).toHaveBeenCalledOnce();
+    expect(store.adminRoomLayout.refresh).not.toHaveBeenCalled();
+  });
+
+  it('runs a queued projected-state refresh after an in-flight catch-up succeeds', async () => {
     const fake = new FakeServerConnection([]);
     const store = makeStore(fake);
     const rooms = deferred();
@@ -893,8 +967,9 @@ describe('ServerStateStore live server updates', () => {
     if (!bus) throw new Error('event bus did not start');
 
     for (const handler of bus.catchUpHandlers) {
-      handler('subscription-ended');
-      handler('ws-reconnected');
+      handler(catchUpSignal('subscription-ended'));
+      await Promise.resolve();
+      handler(catchUpSignal('heartbeat-stalled'));
     }
     await Promise.resolve();
 
@@ -928,8 +1003,8 @@ describe('ServerStateStore live server updates', () => {
     if (!bus) throw new Error('event bus did not start');
 
     for (const handler of bus.catchUpHandlers) {
-      handler('subscription-ended');
-      handler('ws-reconnected');
+      handler(catchUpSignal('subscription-ended'));
+      handler(catchUpSignal('ws-reconnected'));
     }
     await Promise.resolve();
 
@@ -969,12 +1044,12 @@ describe('ServerStateStore live server updates', () => {
     if (!bus) throw new Error('event bus did not start');
 
     for (const handler of bus.catchUpHandlers) {
-      handler('heartbeat-stalled');
+      handler(catchUpSignal('heartbeat-stalled'));
     }
     await flushPromises();
 
     for (const handler of bus.catchUpHandlers) {
-      handler('ws-reconnected');
+      handler(catchUpSignal('ws-reconnected'));
     }
     await flushPromises();
 

--- a/apps/frontend/src/lib/state/server/store.svelte.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.ts
@@ -27,7 +27,7 @@ import { createAdminEventLogAPI } from '$lib/api-client/adminEventLog';
 import { createMemberDirectoryAPI } from '$lib/api-client/memberDirectory';
 import { getViewerStateViaConnect } from '$lib/api-client/viewer';
 import { eventBusManager } from './eventBus.svelte';
-import type { EventBusCatchUpReason, EventHandler } from '$lib/eventBus.svelte';
+import type { EventBusCatchUpSignal, EventHandler } from '$lib/eventBus.svelte';
 import type { ServerConnection } from './serverConnection.svelte';
 import type { RegisteredServer } from './registry.svelte';
 import { playCallSound } from '$lib/audio/callSounds';
@@ -72,7 +72,7 @@ const EMPTY_PERMISSIONS: ServerPermissions = {
   canAdminViewAudit: false
 };
 
-const CATCH_UP_REFRESH_DEDUPE_MS = 1_000;
+const CATCH_UP_REFRESH_DEDUPE_MS = 5_000;
 
 export class ServerStateStore {
   readonly serverId: string;
@@ -106,7 +106,7 @@ export class ServerStateStore {
   #adminRoomLayoutSubscriptions = 0;
   #lastSuccessfulCatchUpRefreshAt = 0;
   #catchUpRefreshInFlight = false;
-  #queuedCatchUpRefreshReason: EventBusCatchUpReason | null = null;
+  #queuedCatchUpRefreshSignal: EventBusCatchUpSignal | null = null;
 
   constructor(
     registered: RegisteredServer,
@@ -217,7 +217,9 @@ export class ServerStateStore {
           } else if (eventKind === RoomEventKind.CallParticipantJoined) {
             const callEvent = callTransitionEventPayload(event.event);
             if (!callEvent || !callEvent.callId) return;
-            const actor = event.actor ? useRenderData(UserAvatarUserViewDocument, event.actor) : null;
+            const actor = event.actor
+              ? useRenderData(UserAvatarUserViewDocument, event.actor)
+              : null;
             void this.activeCallRooms.handleJoin(callEvent.roomId, callEvent.callId, actor);
             this.playCallTransitionSound(
               event.id,
@@ -229,7 +231,11 @@ export class ServerStateStore {
           } else if (eventKind === RoomEventKind.CallParticipantLeft) {
             const callEvent = callTransitionEventPayload(event.event);
             if (!callEvent) return;
-            this.activeCallRooms.handleLeave(callEvent.roomId, callEvent.callId, event.actorId ?? null);
+            this.activeCallRooms.handleLeave(
+              callEvent.roomId,
+              callEvent.callId,
+              event.actorId ?? null
+            );
             this.playCallTransitionSound(
               event.id,
               'leave',
@@ -252,8 +258,8 @@ export class ServerStateStore {
             this.voiceCall.handleCallEndedEvent(callEvent.roomId, callEvent.callId);
           }
         };
-        const catchUpHandler = (reason: EventBusCatchUpReason) => {
-          void this.refreshProjectedStateAfterMissedEvents(reason);
+        const catchUpHandler = (signal: EventBusCatchUpSignal) => {
+          void this.refreshProjectedStateAfterMissedEvents(signal);
         };
         bus.handlers.add(handler);
         bus.catchUpHandlers.add(catchUpHandler);
@@ -266,26 +272,30 @@ export class ServerStateStore {
   }
 
   private async refreshProjectedStateAfterMissedEvents(
-    reason: EventBusCatchUpReason,
-    force = false
+    signal: EventBusCatchUpSignal,
+    options: { bypassDedupe?: boolean } = {}
   ): Promise<void> {
     if (!this.isAuthenticated) return;
 
     if (this.#catchUpRefreshInFlight) {
-      this.#queuedCatchUpRefreshReason = reason;
+      this.#queuedCatchUpRefreshSignal = signal;
       console.debug(
         `[server:${this.#registered.url}] queued catch-up refresh while one is running`,
         {
-          reason
+          signal
         }
       );
       return;
     }
 
     const now = Date.now();
-    if (!force && now - this.#lastSuccessfulCatchUpRefreshAt < CATCH_UP_REFRESH_DEDUPE_MS) {
+    const canDedupe =
+      !options.bypassDedupe &&
+      signal.phase !== 'projection-grace' &&
+      now - this.#lastSuccessfulCatchUpRefreshAt < CATCH_UP_REFRESH_DEDUPE_MS;
+    if (canDedupe) {
       console.debug(`[server:${this.#registered.url}] skipped duplicate catch-up refresh`, {
-        reason
+        signal
       });
       return;
     }
@@ -297,7 +307,7 @@ export class ServerStateStore {
       console.debug(
         `[server:${this.#registered.url}] refreshing projected state after event bus gap`,
         {
-          reason
+          signal
         }
       );
 
@@ -330,19 +340,19 @@ export class ServerStateStore {
         console.debug(
           `[server:${this.#registered.url}] projected state catch-up refresh completed`,
           {
-            reason
+            signal
           }
         );
       }
     } finally {
       this.#catchUpRefreshInFlight = false;
-      const queuedReason = this.#queuedCatchUpRefreshReason;
-      this.#queuedCatchUpRefreshReason = null;
-      if (queuedReason) {
+      const queuedSignal = this.#queuedCatchUpRefreshSignal;
+      this.#queuedCatchUpRefreshSignal = null;
+      if (queuedSignal) {
         console.debug(`[server:${this.#registered.url}] running queued catch-up refresh`, {
-          reason: queuedReason
+          signal: queuedSignal
         });
-        void this.refreshProjectedStateAfterMissedEvents(queuedReason, true);
+        void this.refreshProjectedStateAfterMissedEvents(queuedSignal, { bypassDedupe: true });
       }
     }
   }

--- a/apps/frontend/src/lib/state/server/useServerRegistry.svelte.ts
+++ b/apps/frontend/src/lib/state/server/useServerRegistry.svelte.ts
@@ -1,4 +1,7 @@
 import { serverRegistry } from './registry.svelte';
+import { registerServerResumeCallback } from '$lib/hooks/resumeCoordinator.svelte';
+
+const SERVER_INFO_RESUME_REFRESH_MIN_MS = 60_000;
 
 /**
  * Bootstrap the server registry: create stores, probe the origin,
@@ -10,34 +13,40 @@ import { serverRegistry } from './registry.svelte';
  *   falsy = probe needed). Passed as a getter so reads happen inside `$effect`.
  */
 export function useServerRegistry(getUser: () => unknown): void {
-	serverRegistry.init();
-	const hasUser = !!getUser();
-	serverRegistry.probeOrigin(hasUser);
-	if (!hasUser) {
-		serverRegistry.settleOriginUnauthenticated();
-	}
+  serverRegistry.init();
+  const hasUser = !!getUser();
+  serverRegistry.probeOrigin(hasUser);
+  if (!hasUser) {
+    serverRegistry.settleOriginUnauthenticated();
+  }
 
-	// Re-fetch server info when the tab becomes visible
-	$effect(() => {
-		const originId = serverRegistry.originServer?.id;
-		if (!originId) return;
+  // Re-fetch server info after meaningful tab resumes. Quick tab switches do
+  // not need another metadata/settings round trip.
+  $effect(() => {
+    const originId = serverRegistry.originServer?.id;
+    if (!originId) return;
+    let lastResumeRefreshAt = Date.now();
 
-		const onVisibilityChange = () => {
-			if (document.visibilityState === 'visible') {
-				const store = serverRegistry.getStore(originId);
-				void store.serverInfo.init();
-				if (store.isAuthenticated) {
-					store.serverInfo.refreshAuthenticatedSettings().catch((err) => {
-						console.error(
-							`[server:${store.serverId}] failed to refresh authenticated server settings`,
-							err
-						);
-					});
-				}
-			}
-		};
+    return registerServerResumeCallback(originId, (signal) => {
+      const now = Date.now();
+      if (
+        (signal.hiddenDurationMs ?? 0) < 30_000 &&
+        now - lastResumeRefreshAt < SERVER_INFO_RESUME_REFRESH_MIN_MS
+      ) {
+        return;
+      }
+      lastResumeRefreshAt = now;
 
-		document.addEventListener('visibilitychange', onVisibilityChange);
-		return () => document.removeEventListener('visibilitychange', onVisibilityChange);
-	});
+      const store = serverRegistry.getStore(originId);
+      void store.serverInfo.init();
+      if (store.isAuthenticated) {
+        store.serverInfo.refreshAuthenticatedSettings().catch((err) => {
+          console.error(
+            `[server:${store.serverId}] failed to refresh authenticated server settings`,
+            err
+          );
+        });
+      }
+    });
+  });
 }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -22,10 +22,8 @@
   import { getUserSettings } from '$lib/state/userSettings.svelte';
   import { formatDayLabel } from '$lib/utils/formatTime';
   import { useTabResumeCallback } from '$lib/hooks/useTabResumeCallback.svelte';
-  import {
-    useMayHaveMissedMessagesCallback,
-    type MayHaveMissedMessagesReason
-  } from '$lib/hooks/useMayHaveMissedMessagesCallback.svelte';
+  import { useMayHaveMissedMessagesCallback } from '$lib/hooks/useMayHaveMissedMessagesCallback.svelte';
+  import type { ResumeSignal } from '$lib/hooks/resumeCoordinator.svelte';
   import type { OpenThreadHandler, ThreadOpenOptions } from './threadOpenOptions';
 
   let {
@@ -480,7 +478,7 @@
 
   let softRefreshInFlight = false;
 
-  async function refreshAfterPossibleMiss(reason: MayHaveMissedMessagesReason): Promise<boolean> {
+  async function refreshAfterPossibleMiss(signal: ResumeSignal): Promise<boolean> {
     if (softRefreshInFlight) return false;
     if (isLoading && virtualItems.length === 0) return false;
 
@@ -494,7 +492,10 @@
     try {
       console.debug('[room-refresh] event list refresh started', {
         roomId,
-        reason,
+        reason: signal.reason,
+        phase: signal.phase,
+        hiddenDurationMs: signal.hiddenDurationMs,
+        epoch: signal.epoch,
         mode: wasAtBottom ? 'latest' : 'anchored',
         bottomDistance,
         anchorEventId: anchor?.eventId ?? null,
@@ -504,7 +505,8 @@
       if (!result.refreshed) {
         console.debug('[room-refresh] event list refresh skipped after store refresh failed', {
           roomId,
-          reason,
+          reason: signal.reason,
+          phase: signal.phase,
           result
         });
         return false;
@@ -558,7 +560,7 @@
     }
   }
 
-  useMayHaveMissedMessagesCallback((reason) => refreshAfterPossibleMiss(reason));
+  useMayHaveMissedMessagesCallback((signal) => refreshAfterPossibleMiss(signal));
 
   // Re-evaluate "are we at the bottom?" when the tab regains visibility — the
   // browser may have throttled virtua's measurements or our auto-scroll effect


### PR DESCRIPTION
Coalesces browser resume, online, reconnect, and event-bus gap signals through a per-server resume coordinator so returning to a tab no longer fans out overlapping refreshes.

Event-bus catch-up now carries immediate vs projection-grace phase metadata, and projected server-state refreshes skip duplicate full catch-ups after a recent successful run while still retrying after failures.

Room and message refreshes now preserve unchanged room rows, notification-count identities, and already loaded anchored message windows so resume refreshes do not visually rebuild the UI.

Validated with focused Vitest coverage for the changed stores/hooks/components and `pnpm run check:frontend`.
