### PR TITLE
fix(conductor): use workspace port for Storybook

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -10,7 +10,7 @@ url = "http://localhost:$CONDUCTOR_PORT+9"
 
 [[preview_urls]]
 name = "Storybook"
-url = "http://localhost:$CONDUCTOR_PORT+10"
+url = "http://localhost:$CONDUCTOR_PORT"
 
 [scripts]
 setup = "mise trust && mise setup"

--- a/mise.toml
+++ b/mise.toml
@@ -167,11 +167,11 @@ sources = [
 outputs = ["../apps/frontend/e2e/fixtures/bin/chatto"]
 
 [tasks.storybook]
-description = "Run the Storybook design-system catalog with workspace-safe ports"
+description = "Run the Storybook design-system catalog on the workspace port"
 depends = ["setup-frontend", "build-api-types"]
 dir = "apps/frontend"
 env = {
-  CHATTO_STORYBOOK_PORT = "{{env.CHATTO_STORYBOOK_PORT | default(value=env.CONDUCTOR_PORT | default(value=env.PASEO_PORT | default(value='4000')) | int + 10)}}",
+  CHATTO_STORYBOOK_PORT = "{{env.CHATTO_STORYBOOK_PORT | default(value=env.CONDUCTOR_PORT | default(value=env.PASEO_PORT | default(value='4000')))}}",
 }
 run = "exec pnpm exec storybook dev --host 127.0.0.1 --port \"$CHATTO_STORYBOOK_PORT\" --no-open"
 


### PR DESCRIPTION
## Summary

Storybook now uses the Conductor workspace base port instead of reserving `$CONDUCTOR_PORT + 10`.

The Conductor preview URL was updated to match the task, which makes the separate Storybook run task open on the same workspace port as other single-run tasks.

## Validation

- `CONDUCTOR_PORT=5123 mise run storybook` started Storybook on `http://localhost:5123/`
