### PR TITLE
fix(notifications): clear read notifications server-side

### DIFF
--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/notifications.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/notifications.mdx
@@ -216,7 +216,8 @@ Lightweight pending notification check.
 
 ### DismissNotification
 
-Dismisses one pending notification.
+Dismisses one pending notification. Already-dismissed notifications are
+treated as idempotent success.
 
 ```http
 POST /api/connect/chatto.api.v1.NotificationService/DismissNotification
@@ -241,7 +242,7 @@ Result of dismissing one pending notification.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `dismissed` | `bool` | True when the notification existed and was dismissed. |
+| `dismissed` | `bool` | True when the notification is no longer pending. |
 
 
 <a id="chatto-api-v1-NotificationService-DismissAllNotifications"></a>

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -1543,7 +1543,8 @@ Lightweight pending notification check.
 
 ### DismissNotification
 
-Dismisses one pending notification.
+Dismisses one pending notification. Already-dismissed notifications are
+treated as idempotent success.
 
 ```http
 POST /api/connect/chatto.api.v1.NotificationService/DismissNotification
@@ -1568,7 +1569,7 @@ Result of dismissing one pending notification.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `dismissed` | `bool` | True when the notification existed and was dismissed. |
+| `dismissed` | `bool` | True when the notification is no longer pending. |
 
 
 <a id="chatto-api-v1-NotificationService-DismissAllNotifications"></a>

--- a/apps/frontend/src/lib/state/server/notifications.spec.ts
+++ b/apps/frontend/src/lib/state/server/notifications.spec.ts
@@ -225,7 +225,7 @@ describe('NotificationStore', () => {
     );
   });
 
-  it('routes and dismisses notifications using notification item kind', async () => {
+  it('routes notifications using notification item kind', () => {
     const threadReply = {
       kind: NotificationItemKind.Reply,
       id: 'thread-reply-kind',
@@ -246,15 +246,7 @@ describe('NotificationStore', () => {
       room: { id: 'dm-room' }
     } as unknown as NotificationItem;
 
-    const dismissedIds: string[] = [];
-    const store = new NotificationStore(
-      makeAPI({
-        dismissNotification: (notificationId) => {
-          dismissedIds.push(notificationId);
-          return true;
-        }
-      })
-    );
+    const store = new NotificationStore(makeAPI());
     store.notifications = [threadReply, dm];
 
     expect(notificationTarget(threadReply)).toMatchObject({
@@ -265,11 +257,6 @@ describe('NotificationStore', () => {
     });
     expect(store.hasThreadNotification('thread-root')).toBe(true);
     expect(store.hasDMRoomNotification('dm-room')).toBe(true);
-
-    await store.dismissThreadNotifications('thread-root');
-
-    expect(dismissedIds).toEqual(['thread-reply-kind']);
-    expect(store.notifications.map((n) => n.id)).toEqual(['dm-kind']);
   });
 
   it('retains existing notifications when the server returns an API error', async () => {
@@ -305,133 +292,6 @@ describe('NotificationStore', () => {
     // Existing notifications survive a network blip too.
     expect(store.notifications).toHaveLength(1);
     expect(store.error).toBe('network down');
-  });
-
-  // Mentions inside a thread must NOT be dismissed when the user enters the
-  // parent room — they should only clear when the thread itself is opened
-  // (via dismissThreadNotifications), mirroring how thread replies behave.
-  it('dismissMentionNotifications skips mentions that are inside a thread', async () => {
-    const roomMention = {
-      kind: NotificationItemKind.Mention,
-      id: 'room-mention',
-      createdAt: new Date().toISOString(),
-      actor: {
-        id: 'a',
-        login: 't',
-        displayName: 't',
-        avatarUrl: null,
-        presenceStatus: 'OFFLINE'
-      },
-      summary: 'mentioned you',
-      mentionSpace: { id: 's1', name: 'S' },
-      mentionRoom: { id: 'r1', name: 'r' },
-      mentionEventId: 'e1',
-      mentionInThread: null
-    } as unknown as NotificationItem;
-    const threadMention = {
-      kind: NotificationItemKind.Mention,
-      id: 'thread-mention',
-      createdAt: new Date().toISOString(),
-      actor: {
-        id: 'a',
-        login: 't',
-        displayName: 't',
-        avatarUrl: null,
-        presenceStatus: 'OFFLINE'
-      },
-      summary: 'mentioned you',
-      mentionSpace: { id: 's1', name: 'S' },
-      mentionRoom: { id: 'r1', name: 'r' },
-      mentionEventId: 'e2',
-      mentionInThread: 'thread-root'
-    } as unknown as NotificationItem;
-
-    const dismissedIds: string[] = [];
-    const store = new NotificationStore(
-      makeAPI({
-        dismissNotification: (notificationId) => {
-          dismissedIds.push(notificationId);
-          return true;
-        }
-      })
-    );
-    store.notifications = [roomMention, threadMention];
-
-    await store.dismissMentionNotifications('r1');
-
-    expect(dismissedIds).toEqual(['room-mention']);
-    expect(store.notifications.map((n) => n.id)).toEqual(['thread-mention']);
-  });
-
-  it('dismissMentionNotifications reports dismissed counts by room', async () => {
-    const roomMentionA = {
-      kind: NotificationItemKind.Mention,
-      id: 'room-mention-a',
-      createdAt: new Date().toISOString(),
-      actor: {
-        id: 'a',
-        login: 't',
-        displayName: 't',
-        avatarUrl: null,
-        presenceStatus: 'OFFLINE'
-      },
-      summary: 'mentioned you',
-      mentionRoom: { id: 'r1', name: 'r' },
-      mentionEventId: 'e1',
-      mentionInThread: null
-    } as unknown as NotificationItem;
-    const roomMentionB = {
-      ...roomMentionA,
-      id: 'room-mention-b',
-      mentionEventId: 'e2'
-    } as unknown as NotificationItem;
-
-    const store = new NotificationStore(makeAPI());
-    store.notifications = [roomMentionA, roomMentionB];
-    store.setUnreadNotificationCount(2);
-
-    const counts = await store.dismissMentionNotifications('r1');
-
-    expect(counts).toEqual({ total: 2, byRoom: { r1: 2 } });
-    expect(store.unreadNotificationCount).toBe(0);
-  });
-
-  // Opening the thread clears both thread-replies AND thread-mentions in one
-  // pass (the code path called from ThreadPane).
-  it('dismissThreadNotifications clears thread-scoped mentions too', async () => {
-    const threadMention = {
-      kind: NotificationItemKind.Mention,
-      id: 'thread-mention',
-      createdAt: new Date().toISOString(),
-      actor: {
-        id: 'a',
-        login: 't',
-        displayName: 't',
-        avatarUrl: null,
-        presenceStatus: 'OFFLINE'
-      },
-      summary: 'mentioned you',
-      mentionSpace: { id: 's1', name: 'S' },
-      mentionRoom: { id: 'r1', name: 'r' },
-      mentionEventId: 'e2',
-      mentionInThread: 'thread-root'
-    } as unknown as NotificationItem;
-
-    const dismissedIds: string[] = [];
-    const store = new NotificationStore(
-      makeAPI({
-        dismissNotification: (notificationId) => {
-          dismissedIds.push(notificationId);
-          return true;
-        }
-      })
-    );
-    store.notifications = [threadMention];
-
-    await store.dismissThreadNotifications('thread-root');
-
-    expect(dismissedIds).toEqual(['thread-mention']);
-    expect(store.notifications).toHaveLength(0);
   });
 
   it('suppresses live echo refreshes for locally dismissed notifications', async () => {

--- a/apps/frontend/src/lib/state/server/notifications.svelte.ts
+++ b/apps/frontend/src/lib/state/server/notifications.svelte.ts
@@ -28,11 +28,6 @@ export type NotificationTarget = {
   threadRootId: string | null;
 };
 
-export type NotificationDismissalCounts = {
-  total: number;
-  byRoom: Record<string, number>;
-};
-
 export type RoomNotificationLookup = {
   ok: boolean;
   totalCount: number | null;
@@ -42,11 +37,6 @@ export type RoomNotificationLookup = {
 export type RoomNotificationResolveOptions = {
   isDM?: boolean;
 };
-
-const emptyDismissalCounts = (): NotificationDismissalCounts => ({
-  total: 0,
-  byRoom: {}
-});
 
 function isDMNotification(
   notification: NotificationItem
@@ -264,72 +254,6 @@ export class NotificationStore {
   }
 
   /**
-   * Dismiss all thread-scoped notifications (replies + mentions) for a thread.
-   * Called when a user opens a thread to clear the notification indicator.
-   */
-  async dismissThreadNotifications(threadRootId: string): Promise<NotificationDismissalCounts> {
-    const threadNotifications = this.notifications.filter(
-      (n) =>
-        (isReplyNotification(n) && n.replyInThread === threadRootId) ||
-        (isMentionNotification(n) && n.mentionInThread === threadRootId)
-    );
-
-    return this.#dismissNotifications(threadNotifications);
-  }
-
-  /**
-   * Dismiss room-level mention notifications for a specific room.
-   * Called when a user enters a room. Thread-scoped mentions are NOT dismissed
-   * here — they're dismissed when the user opens the specific thread (via
-   * dismissThreadNotifications), matching the symmetry with reply notifications.
-   */
-  async dismissMentionNotifications(roomId: string): Promise<NotificationDismissalCounts> {
-    const mentionNotifications = this.notifications.filter(
-      (n) => isMentionNotification(n) && !n.mentionInThread && n.mentionRoom?.id === roomId
-    );
-
-    return this.#dismissNotifications(mentionNotifications);
-  }
-
-  /**
-   * Dismiss room-level reply notifications for a specific room.
-   * Called when a user enters a room to clear reply notification indicators.
-   * Only dismisses room-level replies (not thread replies, which are dismissed
-   * separately when opening the specific thread via dismissThreadNotifications).
-   */
-  async dismissRoomReplyNotifications(roomId: string): Promise<NotificationDismissalCounts> {
-    const roomReplyNotifications = this.notifications.filter(
-      (n) => isReplyNotification(n) && !n.replyInThread && n.replyRoom?.id === roomId
-    );
-
-    return this.#dismissNotifications(roomReplyNotifications);
-  }
-
-  /**
-   * Dismiss all room message notifications for a specific room.
-   * Called when a user enters a room to clear "all messages" notification indicators.
-   */
-  async dismissRoomMessageNotifications(roomId: string): Promise<NotificationDismissalCounts> {
-    const roomMsgNotifications = this.notifications.filter(
-      (n) => isRoomMessageNotification(n) && n.roomMsgRoom?.id === roomId
-    );
-
-    return this.#dismissNotifications(roomMsgNotifications);
-  }
-
-  /**
-   * Dismiss all DM notifications for a specific conversation.
-   * Called when a user enters a DM conversation to clear notification indicators.
-   */
-  async dismissDMNotifications(roomId: string): Promise<NotificationDismissalCounts> {
-    const dmNotifications = this.notifications.filter(
-      (n) => isDMNotification(n) && n.room.id === roomId
-    );
-
-    return this.#dismissNotifications(dmNotifications);
-  }
-
-  /**
    * Fetch all notifications from the server.
    *
    * Resilience contract: a server-side error (e.g. a schema mismatch on a
@@ -489,28 +413,6 @@ export class NotificationStore {
     if (typeof timeout === 'object' && timeout !== null && 'unref' in timeout) {
       (timeout as { unref: () => void }).unref();
     }
-  }
-
-  async #dismissNotifications(
-    notifications: NotificationItem[]
-  ): Promise<NotificationDismissalCounts> {
-    if (notifications.length === 0) return emptyDismissalCounts();
-
-    const results = await Promise.all(
-      notifications.map(async (notification) => ({
-        target: notificationTarget(notification),
-        dismissed: await this.dismiss(notification.id)
-      }))
-    );
-
-    const counts = emptyDismissalCounts();
-    for (const result of results) {
-      if (!result.dismissed) continue;
-      counts.total += 1;
-      const roomId = result.target.roomId;
-      if (roomId) counts.byRoom[roomId] = (counts.byRoom[roomId] ?? 0) + 1;
-    }
-    return counts;
   }
 
   /**

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -68,7 +68,6 @@
   const serverSegment = $derived(serverIdToSegment(getActiveServer()));
   const stores = serverRegistry.getStore(getActiveServer());
   const serverInfo = stores.serverInfo;
-  const notificationStore = stores.notifications;
   const appUi = getAppUiState();
 
   // Thread navigation functions (URL-driven state)
@@ -241,37 +240,6 @@
       return `#${room.roomData.room.name} - ${room.roomData.spaceName}`;
     }
     return title;
-  });
-
-  // Dismiss notifications when entering the room, and when new notifications
-  // arrive for a room the viewer is already present in.
-  $effect(() => {
-    if (!appState.isFocused) return;
-
-    const currentRoomId = roomId;
-    const currentRoomData = room.roomData;
-    if (!currentRoomData || currentRoomData.room.id !== currentRoomId) return;
-    const notificationRevision = notificationStore.notifications.map((n) => n.id).join('\0');
-    void notificationRevision;
-
-    void (async () => {
-      const results = room.isDM
-        ? [await notificationStore.dismissDMNotifications(currentRoomId)]
-        : await Promise.all([
-            notificationStore.dismissMentionNotifications(currentRoomId),
-            notificationStore.dismissRoomReplyNotifications(currentRoomId),
-            notificationStore.dismissRoomMessageNotifications(currentRoomId)
-          ]);
-
-      const dismissedForRoom = results.reduce(
-        (sum, counts) => sum + (counts.byRoom[currentRoomId] ?? 0),
-        0
-      );
-      if (dismissedForRoom > 0) {
-        stores.rooms.decrementUnreadNotification(currentRoomId, dismissedForRoom);
-        void stores.rooms.refreshNotificationCounts();
-      }
-    })();
   });
 
   // Remember this room as the last visited (for the chat-root → last-room

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -471,29 +471,16 @@ describe('Room local message echo', () => {
     expect(desktopSidebarPane.className).toContain('flex-1');
   });
 
-  it('refreshes room notification counts after active-room notifications auto-dismiss', async () => {
-    mocks.notifications.dismissMentionNotifications.mockResolvedValue({ byRoom: { 'room-1': 1 } });
-
+  it('does not directly dismiss room notifications on room entry', async () => {
     render(Room, { props: { roomId: 'room-1' } });
 
-    await vi.waitFor(() => {
-      expect(mocks.rooms.decrementUnreadNotification).toHaveBeenCalledWith('room-1', 1);
-      expect(mocks.rooms.refreshNotificationCounts).toHaveBeenCalledOnce();
-    });
-  });
+    await tick();
 
-  it('dismisses active DM notifications and refreshes room notification counts', async () => {
-    mocks.roomKind = RoomKind.DM;
-    mocks.notifications.dismissDMNotifications.mockResolvedValue({ byRoom: { 'room-1': 2 } });
-
-    render(Room, { props: { roomId: 'room-1' } });
-
-    await vi.waitFor(() => {
-      expect(mocks.notifications.dismissDMNotifications).toHaveBeenCalledWith('room-1');
-      expect(mocks.notifications.dismissMentionNotifications).not.toHaveBeenCalled();
-      expect(mocks.rooms.decrementUnreadNotification).toHaveBeenCalledWith('room-1', 2);
-      expect(mocks.rooms.refreshNotificationCounts).toHaveBeenCalledOnce();
-    });
+    expect(mocks.notifications.dismissDMNotifications).not.toHaveBeenCalled();
+    expect(mocks.notifications.dismissMentionNotifications).not.toHaveBeenCalled();
+    expect(mocks.notifications.dismissRoomReplyNotifications).not.toHaveBeenCalled();
+    expect(mocks.notifications.dismissRoomMessageNotifications).not.toHaveBeenCalled();
+    expect(mocks.rooms.decrementUnreadNotification).not.toHaveBeenCalled();
   });
 
   it('refreshes the visible room window after a local link-preview deletion succeeds', async () => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -10,8 +10,6 @@
   import { isMessagePostedEvent } from '$lib/render/eventKinds';
   import * as m from '$lib/i18n/messages';
 
-  const stores = serverRegistry.getStore(getActiveServer());
-  const notificationStore = stores.notifications;
   import { appState } from '$lib/state/globals.svelte';
   import {
     getRoomMembers,
@@ -256,20 +254,6 @@
       }
     })
   );
-
-  // Dismiss reply notifications when viewing this thread (only when window is focused)
-  $effect(() => {
-    if (!appState.isFocused) return;
-    const threadId = threadRootEventId;
-    const currentRoomId = roomId;
-    void notificationStore.dismissThreadNotifications(threadId).then((counts) => {
-      const dismissedForRoom = counts.byRoom[currentRoomId] ?? 0;
-      if (dismissedForRoom > 0) {
-        stores.rooms.decrementUnreadNotification(currentRoomId, dismissedForRoom);
-        void stores.rooms.refreshNotificationCounts();
-      }
-    });
-  });
 
   async function markThreadAsRead(currentThreadId: string, upToEventId?: string) {
     try {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import ThreadPane from './ThreadPane.svelte';
+
+const { mocks } = vi.hoisted(() => {
+  return {
+    mocks: {
+      markThreadAsRead: vi.fn(),
+      followThread: vi.fn(),
+      unfollowThread: vi.fn(),
+      setThread: vi.fn(),
+      disposeMessagesStore: vi.fn(),
+      ingestServerEvent: vi.fn(),
+      ingestEvent: vi.fn(),
+      refreshCurrentWindow: vi.fn(),
+      loadMore: vi.fn(),
+      applyLocalMessageDeletion: vi.fn(),
+      refreshAnchorForMessageMutation: vi.fn(),
+      removeTypingUser: vi.fn(),
+      sendTypingIndicator: vi.fn(),
+      resetTypingDebounce: vi.fn(),
+      onClose: vi.fn(),
+      notifications: {
+        dismissThreadNotifications: vi.fn().mockResolvedValue({ byRoom: {} })
+      },
+      rooms: {
+        decrementUnreadNotification: vi.fn()
+      },
+      appState: {
+        isPresent: true
+      }
+    }
+  };
+});
+
+vi.mock('$lib/api-client/readState', () => ({
+  createReadStateAPI: () => ({
+    markThreadAsRead: mocks.markThreadAsRead
+  })
+}));
+
+vi.mock('$lib/api-client/threads', () => ({
+  createThreadAPI: () => ({
+    followThread: mocks.followThread,
+    unfollowThread: mocks.unfollowThread
+  })
+}));
+
+vi.mock('$lib/hooks', () => ({
+  useEvent: vi.fn(),
+  createTypingIndicator: () => ({
+    userIds: [],
+    removeTypingUser: mocks.removeTypingUser,
+    sendTypingIndicator: mocks.sendTypingIndicator,
+    resetDebounce: mocks.resetTypingDebounce
+  })
+}));
+
+vi.mock('$lib/state/server/connection.svelte', () => ({
+  useConnection: () => () => ({
+    serverId: 'server-1',
+    connectBaseUrl: 'http://localhost/api/connect',
+    bearerToken: null
+  })
+}));
+
+vi.mock('$lib/state/server/registry.svelte', () => ({
+  serverRegistry: {
+    getStore: () => ({
+      currentUser: { user: { id: 'test-user', login: 'testuser' }, loading: false },
+      notifications: mocks.notifications,
+      rooms: mocks.rooms
+    })
+  }
+}));
+
+vi.mock('$lib/state/activeServer.svelte', () => ({
+  getActiveServer: () => 'server-1'
+}));
+
+vi.mock('$lib/state/globals.svelte', () => ({
+  appState: mocks.appState
+}));
+
+vi.mock('$lib/state/room', () => ({
+  getRoomMembers: () => [],
+  createComposerContext: () => ({
+    replyState: {
+      messageEventId: null,
+      actorDisplayName: '',
+      excerpt: '',
+      startReply: vi.fn(),
+      cancelReply: vi.fn()
+    },
+    quoteInsertionState: {
+      requestInsertQuote: vi.fn()
+    },
+    jumpState: {
+      scrollToEventId: null,
+      setJumpHandler: vi.fn(),
+      jumpToMessage: vi.fn()
+    }
+  }),
+  MessagesStore: class {
+    threadEvents = [];
+    isInitialLoading = false;
+    isLoadingMore = false;
+    hasReachedStart = true;
+    setThread = mocks.setThread;
+    dispose = mocks.disposeMessagesStore;
+    ingestServerEvent = mocks.ingestServerEvent;
+    ingestEvent = mocks.ingestEvent;
+    refreshCurrentWindow = mocks.refreshCurrentWindow;
+    loadMore = mocks.loadMore;
+    applyLocalMessageDeletion = mocks.applyLocalMessageDeletion;
+    refreshAnchorForMessageMutation = mocks.refreshAnchorForMessageMutation;
+  }
+}));
+
+vi.mock('$lib/state/room/messageMutationEvents', () => ({
+  onRoomMessageMutated: vi.fn(() => vi.fn())
+}));
+
+vi.mock('$lib/eventBus.svelte', () => ({
+  onThreadFollowChanged: vi.fn(() => vi.fn())
+}));
+
+vi.mock('./EventList.svelte', async () => {
+  const { default: EmptyMock } = await import('./RoomLocalEchoEmptyMock.svelte');
+  return { default: EmptyMock };
+});
+
+vi.mock('$lib/components/composer/MessageComposer.svelte', async () => {
+  const { default: EmptyMock } = await import('./RoomLocalEchoEmptyMock.svelte');
+  return { default: EmptyMock };
+});
+
+describe('ThreadPane', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.appState.isPresent = true;
+    mocks.markThreadAsRead.mockResolvedValue({
+      previousReadAt: null,
+      lastReadAt: '2026-07-04T13:00:00Z'
+    });
+  });
+
+  it('marks the thread as read without directly dismissing thread notifications', async () => {
+    render(ThreadPane, {
+      props: {
+        roomId: 'room-1',
+        roomName: 'General',
+        threadRootEventId: 'thread-root',
+        onClose: mocks.onClose
+      }
+    });
+
+    await vi.waitFor(() =>
+      expect(mocks.markThreadAsRead).toHaveBeenCalledWith({
+        roomId: 'room-1',
+        threadRootEventId: 'thread-root',
+        upToEventId: undefined
+      })
+    );
+
+    expect(mocks.setThread).toHaveBeenCalledWith('room-1', 'thread-root');
+    expect(mocks.notifications.dismissThreadNotifications).not.toHaveBeenCalled();
+    expect(mocks.rooms.decrementUnreadNotification).not.toHaveBeenCalled();
+  });
+});

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -4092,8 +4092,8 @@ func TestNotificationServiceListsAndDismissesNotifications(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DismissNotification again: %v", err)
 	}
-	if dismissAgainResp.Msg.GetDismissed() {
-		t.Fatal("DismissNotification again dismissed = true, want false")
+	if !dismissAgainResp.Msg.GetDismissed() {
+		t.Fatal("DismissNotification again dismissed = false, want idempotent true")
 	}
 	if _, err := env.notifications.GetNotification(ctx, connect.NewRequest(&apiv1.GetNotificationRequest{NotificationId: mention.Id})); connect.CodeOf(err) != connect.CodeNotFound {
 		t.Fatalf("dismissed GetNotification code = %v, want not_found", connect.CodeOf(err))
@@ -6233,6 +6233,40 @@ func TestRoomAndThreadServicesMarkRoomAsReadAnchorsAndDoesNotRegress(t *testing.
 	}
 	e2 := env.post(room.Id, env.viewer.Id, "two", "")
 	e3 := env.post(room.Id, env.viewer.Id, "three", "")
+	roomMention, err := env.core.CreateNotification(env.ctx, reader.Id, env.viewer.Id, &corev1.Notification{
+		Notification: &corev1.Notification_Mention{
+			Mention: &corev1.MentionNotification{RoomId: room.Id, EventId: e1.Id},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateNotification room mention: %v", err)
+	}
+	roomReply, err := env.core.CreateNotification(env.ctx, reader.Id, env.viewer.Id, &corev1.Notification{
+		Notification: &corev1.Notification_Reply{
+			Reply: &corev1.ReplyNotification{RoomId: room.Id, EventId: e2.Id, InReplyToId: e1.Id},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateNotification room reply: %v", err)
+	}
+	futureRoomNotification, err := env.core.CreateNotification(env.ctx, reader.Id, env.viewer.Id, &corev1.Notification{
+		Notification: &corev1.Notification_RoomMessage{
+			RoomMessage: &corev1.RoomMessageNotification{RoomId: room.Id, EventId: e3.Id},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateNotification future room message: %v", err)
+	}
+	threadRoot := env.post(room.Id, env.viewer.Id, "thread root", "")
+	threadReply := env.post(room.Id, env.viewer.Id, "thread reply", threadRoot.Id)
+	threadNotification, err := env.core.CreateNotification(env.ctx, reader.Id, env.viewer.Id, &corev1.Notification{
+		Notification: &corev1.Notification_Reply{
+			Reply: &corev1.ReplyNotification{RoomId: room.Id, EventId: threadReply.Id, InReplyToId: threadRoot.Id, InThread: threadRoot.Id},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateNotification thread reply: %v", err)
+	}
 
 	ctx := withCaller(env.ctx, reader)
 	resp, err := env.rooms.MarkRoomAsRead(ctx, connect.NewRequest(&apiv1.MarkRoomAsReadRequest{
@@ -6248,6 +6282,11 @@ func TestRoomAndThreadServicesMarkRoomAsReadAnchorsAndDoesNotRegress(t *testing.
 	if got, err := env.core.GetLastReadEventID(env.ctx, core.KindChannel, reader.Id, room.Id); err != nil || got != e2.Id {
 		t.Fatalf("marker after e2 = %q, %v; want %s", got, err, e2.Id)
 	}
+	assertAPINotifications(t, env, ctx,
+		[]string{futureRoomNotification.Id, threadNotification.Id},
+		[]string{roomMention.Id, roomReply.Id},
+	)
+	assertRoomNotificationCount(t, env, ctx, room.Id, 2)
 
 	if _, err := env.rooms.MarkRoomAsRead(ctx, connect.NewRequest(&apiv1.MarkRoomAsReadRequest{
 		RoomId:      room.Id,
@@ -6258,6 +6297,10 @@ func TestRoomAndThreadServicesMarkRoomAsReadAnchorsAndDoesNotRegress(t *testing.
 	if got, err := env.core.GetLastReadEventID(env.ctx, core.KindChannel, reader.Id, room.Id); err != nil || got != e2.Id {
 		t.Fatalf("marker after stale e1 = %q, %v; want %s", got, err, e2.Id)
 	}
+	assertAPINotifications(t, env, ctx,
+		[]string{futureRoomNotification.Id, threadNotification.Id},
+		[]string{roomMention.Id, roomReply.Id},
+	)
 
 	reply := env.post(room.Id, env.viewer.Id, "reply", e2.Id)
 	if _, err := env.rooms.MarkRoomAsRead(ctx, connect.NewRequest(&apiv1.MarkRoomAsReadRequest{
@@ -6285,9 +6328,14 @@ func TestRoomAndThreadServicesMarkRoomAsReadAnchorsAndDoesNotRegress(t *testing.
 	})); err != nil {
 		t.Fatalf("MarkRoomAsRead omitted anchor: %v", err)
 	}
-	if got, err := env.core.GetLastReadEventID(env.ctx, core.KindChannel, reader.Id, room.Id); err != nil || got != e3.Id {
-		t.Fatalf("marker after omitted anchor = %q, %v; want %s", got, err, e3.Id)
+	if got, err := env.core.GetLastReadEventID(env.ctx, core.KindChannel, reader.Id, room.Id); err != nil || got != threadRoot.Id {
+		t.Fatalf("marker after omitted anchor = %q, %v; want %s", got, err, threadRoot.Id)
 	}
+	assertAPINotifications(t, env, ctx,
+		[]string{threadNotification.Id},
+		[]string{futureRoomNotification.Id, roomMention.Id, roomReply.Id},
+	)
+	assertRoomNotificationCount(t, env, ctx, room.Id, 1)
 }
 
 func TestRoomAndThreadServicesMarkRoomAsReadRejectsMissingAnchorWithoutLazyMarker(t *testing.T) {
@@ -6354,6 +6402,49 @@ func TestRoomAndThreadServicesMarkThreadAsReadAnchorsAndDoesNotRegress(t *testin
 	root := env.post(room.Id, env.viewer.Id, "root", "")
 	reply1 := env.post(room.Id, env.viewer.Id, "reply one", root.Id)
 	reply2 := env.post(room.Id, env.viewer.Id, "reply two", root.Id)
+	threadReplyNotification, err := env.core.CreateNotification(env.ctx, reader.Id, env.viewer.Id, &corev1.Notification{
+		Notification: &corev1.Notification_Reply{
+			Reply: &corev1.ReplyNotification{RoomId: room.Id, EventId: reply1.Id, InReplyToId: root.Id, InThread: root.Id},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateNotification thread reply: %v", err)
+	}
+	threadMentionNotification, err := env.core.CreateNotification(env.ctx, reader.Id, env.viewer.Id, &corev1.Notification{
+		Notification: &corev1.Notification_Mention{
+			Mention: &corev1.MentionNotification{RoomId: room.Id, EventId: reply2.Id, InThread: root.Id},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateNotification thread mention: %v", err)
+	}
+	reply3 := env.post(room.Id, env.viewer.Id, "reply three", root.Id)
+	futureThreadNotification, err := env.core.CreateNotification(env.ctx, reader.Id, env.viewer.Id, &corev1.Notification{
+		Notification: &corev1.Notification_Reply{
+			Reply: &corev1.ReplyNotification{RoomId: room.Id, EventId: reply3.Id, InReplyToId: root.Id, InThread: root.Id},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateNotification future thread reply: %v", err)
+	}
+	otherRoot := env.post(room.Id, env.viewer.Id, "other root", "")
+	otherReply := env.post(room.Id, env.viewer.Id, "other reply", otherRoot.Id)
+	otherThreadNotification, err := env.core.CreateNotification(env.ctx, reader.Id, env.viewer.Id, &corev1.Notification{
+		Notification: &corev1.Notification_Reply{
+			Reply: &corev1.ReplyNotification{RoomId: room.Id, EventId: otherReply.Id, InReplyToId: otherRoot.Id, InThread: otherRoot.Id},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateNotification other thread reply: %v", err)
+	}
+	roomNotification, err := env.core.CreateNotification(env.ctx, reader.Id, env.viewer.Id, &corev1.Notification{
+		Notification: &corev1.Notification_Mention{
+			Mention: &corev1.MentionNotification{RoomId: room.Id, EventId: root.Id},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateNotification room mention: %v", err)
+	}
 
 	ctx := withCaller(env.ctx, reader)
 	resp, err := env.threads.MarkThreadAsRead(ctx, connect.NewRequest(&apiv1.MarkThreadAsReadRequest{
@@ -6371,6 +6462,11 @@ func TestRoomAndThreadServicesMarkThreadAsReadAnchorsAndDoesNotRegress(t *testin
 	if err != nil {
 		t.Fatalf("GetThreadLastOpened after reply2: %v", err)
 	}
+	assertAPINotifications(t, env, ctx,
+		[]string{futureThreadNotification.Id, otherThreadNotification.Id, roomNotification.Id},
+		[]string{threadReplyNotification.Id, threadMentionNotification.Id},
+	)
+	assertRoomNotificationCount(t, env, ctx, room.Id, 3)
 
 	resp, err = env.threads.MarkThreadAsRead(ctx, connect.NewRequest(&apiv1.MarkThreadAsReadRequest{
 		RoomId:            room.Id,
@@ -6390,9 +6486,11 @@ func TestRoomAndThreadServicesMarkThreadAsReadAnchorsAndDoesNotRegress(t *testin
 	if !markerAfter.Equal(marker2) {
 		t.Fatalf("thread marker regressed from %v to %v", marker2, markerAfter)
 	}
+	assertAPINotifications(t, env, ctx,
+		[]string{futureThreadNotification.Id, otherThreadNotification.Id, roomNotification.Id},
+		[]string{threadReplyNotification.Id, threadMentionNotification.Id},
+	)
 
-	otherRoot := env.post(room.Id, env.viewer.Id, "other root", "")
-	otherReply := env.post(room.Id, env.viewer.Id, "other reply", otherRoot.Id)
 	if _, err := env.threads.MarkThreadAsRead(ctx, connect.NewRequest(&apiv1.MarkThreadAsReadRequest{
 		RoomId:            room.Id,
 		ThreadRootEventId: root.Id,
@@ -6421,6 +6519,48 @@ func TestRoomAndThreadServicesMarkThreadAsReadAnchorsAndDoesNotRegress(t *testin
 	}
 	if !markerAfterMissing.Equal(marker2) {
 		t.Fatalf("thread marker changed after missing anchor from %v to %v", marker2, markerAfterMissing)
+	}
+}
+
+func assertAPINotifications(t *testing.T, env *connectAPITestEnv, ctx context.Context, present []string, absent []string) {
+	t.Helper()
+	resp, err := env.notifications.ListNotifications(ctx, connect.NewRequest(&apiv1.ListNotificationsRequest{
+		Page: &apiv1.PageRequest{Limit: 100},
+	}))
+	if err != nil {
+		t.Fatalf("ListNotifications: %v", err)
+	}
+	ids := map[string]bool{}
+	for _, notification := range resp.Msg.GetNotifications() {
+		ids[notification.GetId()] = true
+	}
+	for _, id := range present {
+		if !ids[id] {
+			t.Fatalf("notification %s missing from API list; got %v", id, ids)
+		}
+	}
+	for _, id := range absent {
+		if ids[id] {
+			t.Fatalf("notification %s still present in API list; got %v", id, ids)
+		}
+	}
+}
+
+func assertRoomNotificationCount(t *testing.T, env *connectAPITestEnv, ctx context.Context, roomID string, want int32) {
+	t.Helper()
+	resp, err := env.notifications.ListRoomNotificationCounts(ctx, connect.NewRequest(&apiv1.ListRoomNotificationCountsRequest{}))
+	if err != nil {
+		t.Fatalf("ListRoomNotificationCounts: %v", err)
+	}
+	got := int32(0)
+	for _, count := range resp.Msg.GetRoomCounts() {
+		if count.GetRoomId() == roomID {
+			got = count.GetTotalCount()
+			break
+		}
+	}
+	if got != want {
+		t.Fatalf("room notification count for %s = %d, want %d", roomID, got, want)
 	}
 }
 

--- a/cli/internal/connectapi/notifications.go
+++ b/cli/internal/connectapi/notifications.go
@@ -151,11 +151,11 @@ func (s *notificationService) DismissNotification(ctx context.Context, req *conn
 	if req.Msg.NotificationId == "" {
 		return nil, invalidArgument("notification_id is required")
 	}
-	dismissed, err := s.api.core.DismissNotification(ctx, caller.UserID, req.Msg.NotificationId)
+	_, err = s.api.core.DismissNotification(ctx, caller.UserID, req.Msg.NotificationId)
 	if err != nil {
 		return nil, connectError(err)
 	}
-	return connect.NewResponse(&apiv1.DismissNotificationResponse{Dismissed: dismissed}), nil
+	return connect.NewResponse(&apiv1.DismissNotificationResponse{Dismissed: true}), nil
 }
 
 func (s *notificationService) DismissAllNotifications(ctx context.Context, _ *connect.Request[apiv1.DismissAllNotificationsRequest]) (*connect.Response[apiv1.DismissAllNotificationsResponse], error) {

--- a/cli/internal/core/notifications.go
+++ b/cli/internal/core/notifications.go
@@ -333,6 +333,131 @@ func (c *ChattoCore) GetRoomNotificationsForMember(ctx context.Context, actorID,
 	return filtered, nil
 }
 
+// DismissRoomReadNotifications clears pending room-level notifications covered
+// by a room read marker and emits the same cross-device dismissal side effects
+// as explicit notification dismissal.
+func (c *ChattoCore) DismissRoomReadNotifications(ctx context.Context, kind RoomKind, userID, roomID string, readThrough time.Time) int {
+	if readThrough.IsZero() {
+		return 0
+	}
+	count, err := c.dismissMatchingNotifications(ctx, userID, func(notification *corev1.Notification) bool {
+		switch payload := notification.GetNotification().(type) {
+		case *corev1.Notification_DmMessage:
+			return payload.DmMessage.GetRoomId() == roomID &&
+				c.notificationEventAtOrBefore(ctx, kind, roomID, payload.DmMessage.GetEventId(), readThrough)
+		case *corev1.Notification_Mention:
+			return payload.Mention.GetRoomId() == roomID &&
+				payload.Mention.GetInThread() == "" &&
+				c.notificationEventAtOrBefore(ctx, kind, roomID, payload.Mention.GetEventId(), readThrough)
+		case *corev1.Notification_Reply:
+			return payload.Reply.GetRoomId() == roomID &&
+				payload.Reply.GetInThread() == "" &&
+				c.notificationEventAtOrBefore(ctx, kind, roomID, payload.Reply.GetEventId(), readThrough)
+		case *corev1.Notification_RoomMessage:
+			return payload.RoomMessage.GetRoomId() == roomID &&
+				c.notificationEventAtOrBefore(ctx, kind, roomID, payload.RoomMessage.GetEventId(), readThrough)
+		default:
+			return false
+		}
+	})
+	if err != nil {
+		c.logger.Warn("Failed to dismiss read room notifications",
+			"user_id", userID,
+			"room_id", roomID,
+			"error", err)
+	}
+	return count
+}
+
+// DismissThreadReadNotifications clears pending thread-scoped notifications
+// covered by a thread read marker and emits the same cross-device dismissal
+// side effects as explicit notification dismissal.
+func (c *ChattoCore) DismissThreadReadNotifications(ctx context.Context, kind RoomKind, userID, roomID, threadRootEventID string, readThrough time.Time) int {
+	if readThrough.IsZero() {
+		return 0
+	}
+	count, err := c.dismissMatchingNotifications(ctx, userID, func(notification *corev1.Notification) bool {
+		switch payload := notification.GetNotification().(type) {
+		case *corev1.Notification_Mention:
+			return payload.Mention.GetRoomId() == roomID &&
+				payload.Mention.GetInThread() == threadRootEventID &&
+				c.notificationEventAtOrBefore(ctx, kind, roomID, payload.Mention.GetEventId(), readThrough)
+		case *corev1.Notification_Reply:
+			return payload.Reply.GetRoomId() == roomID &&
+				payload.Reply.GetInThread() == threadRootEventID &&
+				c.notificationEventAtOrBefore(ctx, kind, roomID, payload.Reply.GetEventId(), readThrough)
+		default:
+			return false
+		}
+	})
+	if err != nil {
+		c.logger.Warn("Failed to dismiss read thread notifications",
+			"user_id", userID,
+			"room_id", roomID,
+			"thread_root_event_id", threadRootEventID,
+			"error", err)
+	}
+	return count
+}
+
+func (c *ChattoCore) dismissMatchingNotifications(ctx context.Context, userID string, match func(*corev1.Notification) bool) (int, error) {
+	prefix := notificationKeyFilter(userID)
+	lister, err := c.storage.runtimeStateKV.ListKeysFiltered(ctx, prefix)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("failed to list notification keys: %w", err)
+	}
+
+	notificationIDs := []string{}
+	for key := range lister.Keys() {
+		entry, err := c.storage.runtimeStateKV.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			return len(notificationIDs), fmt.Errorf("failed to get notification: %w", err)
+		}
+
+		var notification corev1.Notification
+		if err := proto.Unmarshal(entry.Value(), &notification); err != nil {
+			return len(notificationIDs), fmt.Errorf("failed to unmarshal notification: %w", err)
+		}
+		if match(&notification) {
+			notificationIDs = append(notificationIDs, notification.GetId())
+		}
+	}
+
+	dismissed := 0
+	for _, notificationID := range notificationIDs {
+		ok, err := c.DismissNotification(ctx, userID, notificationID)
+		if err != nil {
+			return dismissed, err
+		}
+		if ok {
+			dismissed++
+		}
+	}
+	return dismissed, nil
+}
+
+func (c *ChattoCore) notificationEventAtOrBefore(ctx context.Context, kind RoomKind, roomID, eventID string, cutoff time.Time) bool {
+	if eventID == "" || cutoff.IsZero() {
+		return false
+	}
+	eventTime, err := c.GetEventTimestamp(ctx, kind, roomID, eventID)
+	if err != nil {
+		c.logger.Warn("Failed to resolve notification event timestamp",
+			"kind", kind,
+			"room_id", roomID,
+			"event_id", eventID,
+			"error", err)
+		return false
+	}
+	return !eventTime.IsZero() && !eventTime.After(cutoff)
+}
+
 // ============================================================================
 // Real-time Sync Events
 // ============================================================================

--- a/cli/internal/core/notifications_test.go
+++ b/cli/internal/core/notifications_test.go
@@ -468,6 +468,348 @@ func TestDismissAllNotifications(t *testing.T) {
 	})
 }
 
+func TestReadMarkerNotificationDismissalPublishesSyncAndPushDismissal(t *testing.T) {
+	core, nc := setupTestCore(t)
+	ctx := testContext(t)
+
+	author, err := core.CreateUser(ctx, SystemActorID, "read-notification-author", "Read Notification Author", "password")
+	if err != nil {
+		t.Fatalf("CreateUser author: %v", err)
+	}
+	reader, err := core.CreateUser(ctx, SystemActorID, "read-notification-reader", "Read Notification Reader", "password")
+	if err != nil {
+		t.Fatalf("CreateUser reader: %v", err)
+	}
+	room, err := core.CreateRoom(ctx, author.Id, KindChannel, "", "read-notification-room", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, author.Id, KindChannel, author.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom author: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, reader.Id, KindChannel, reader.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom reader: %v", err)
+	}
+
+	root, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "root", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage root: %v", err)
+	}
+	reply1, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "reply one", nil, root.Id, "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage reply1: %v", err)
+	}
+	reply2, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "reply two", nil, root.Id, "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage reply2: %v", err)
+	}
+	reply3, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "reply three", nil, root.Id, "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage reply3: %v", err)
+	}
+
+	dismissedPush := make(chan string, 3)
+	core.OnNotificationDismissed = func(ctx context.Context, userID string, notification *corev1.Notification) {
+		dismissedPush <- notification.GetId()
+	}
+
+	subject := subjects.LiveSyncUserEvent(reader.Id, "notification_dismissed")
+	sub, err := nc.SubscribeSync(subject)
+	if err != nil {
+		t.Fatalf("SubscribeSync(%s): %v", subject, err)
+	}
+	defer sub.Unsubscribe()
+	if err := nc.Flush(); err != nil {
+		t.Fatalf("Flush subscription: %v", err)
+	}
+
+	coveredReply, err := core.CreateNotification(ctx, reader.Id, author.Id, &corev1.Notification{
+		Notification: &corev1.Notification_Reply{
+			Reply: &corev1.ReplyNotification{
+				RoomId:      room.Id,
+				EventId:     reply1.Id,
+				InReplyToId: root.Id,
+				InThread:    root.Id,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateNotification covered reply: %v", err)
+	}
+	coveredMention, err := core.CreateNotification(ctx, reader.Id, author.Id, &corev1.Notification{
+		Notification: &corev1.Notification_Mention{
+			Mention: &corev1.MentionNotification{
+				RoomId:   room.Id,
+				EventId:  reply2.Id,
+				InThread: root.Id,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateNotification covered mention: %v", err)
+	}
+	futureReply, err := core.CreateNotification(ctx, reader.Id, author.Id, &corev1.Notification{
+		Notification: &corev1.Notification_Reply{
+			Reply: &corev1.ReplyNotification{
+				RoomId:      room.Id,
+				EventId:     reply3.Id,
+				InReplyToId: root.Id,
+				InThread:    root.Id,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateNotification future reply: %v", err)
+	}
+
+	cutoff, err := core.GetEventTimestamp(ctx, KindChannel, room.Id, reply2.Id)
+	if err != nil {
+		t.Fatalf("GetEventTimestamp: %v", err)
+	}
+	if got := core.DismissThreadReadNotifications(ctx, KindChannel, reader.Id, room.Id, root.Id, cutoff); got != 2 {
+		t.Fatalf("DismissThreadReadNotifications = %d, want 2", got)
+	}
+
+	remaining, err := core.GetNotifications(ctx, reader.Id)
+	if err != nil {
+		t.Fatalf("GetNotifications: %v", err)
+	}
+	if len(remaining) != 1 || remaining[0].GetId() != futureReply.GetId() {
+		t.Fatalf("remaining notifications = %+v, want only %s", remaining, futureReply.GetId())
+	}
+
+	wantIDs := map[string]bool{
+		coveredReply.GetId():   true,
+		coveredMention.GetId(): true,
+	}
+	for i := 0; i < 2; i++ {
+		msg, err := sub.NextMsg(2 * time.Second)
+		if err != nil {
+			t.Fatalf("waiting for notification_dismissed live event %d: %v", i+1, err)
+		}
+		var live corev1.LiveEvent
+		if err := proto.Unmarshal(msg.Data, &live); err != nil {
+			t.Fatalf("unmarshal live event: %v", err)
+		}
+		event := live.GetNotificationDismissed()
+		if event == nil {
+			t.Fatalf("expected NotificationDismissedEvent, got %T", live.Event)
+		}
+		if !wantIDs[event.GetNotificationId()] {
+			t.Fatalf("unexpected live dismissal id %s", event.GetNotificationId())
+		}
+		delete(wantIDs, event.GetNotificationId())
+	}
+	if len(wantIDs) != 0 {
+		t.Fatalf("missing live dismissal ids: %v", wantIDs)
+	}
+
+	wantPushIDs := map[string]bool{
+		coveredReply.GetId():   true,
+		coveredMention.GetId(): true,
+	}
+	for i := 0; i < 2; i++ {
+		select {
+		case id := <-dismissedPush:
+			if !wantPushIDs[id] {
+				t.Fatalf("unexpected push dismissal id %s", id)
+			}
+			delete(wantPushIDs, id)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("waiting for push dismissal callback %d", i+1)
+		}
+	}
+	if len(wantPushIDs) != 0 {
+		t.Fatalf("missing push dismissal ids: %v", wantPushIDs)
+	}
+}
+
+func TestRoomReadNotificationDismissalPublishesSyncAndPushDismissal(t *testing.T) {
+	core, nc := setupTestCore(t)
+	ctx := testContext(t)
+
+	author, err := core.CreateUser(ctx, SystemActorID, "room-read-notification-author", "Room Read Notification Author", "password")
+	if err != nil {
+		t.Fatalf("CreateUser author: %v", err)
+	}
+	reader, err := core.CreateUser(ctx, SystemActorID, "room-read-notification-reader", "Room Read Notification Reader", "password")
+	if err != nil {
+		t.Fatalf("CreateUser reader: %v", err)
+	}
+	room, err := core.CreateRoom(ctx, author.Id, KindChannel, "", "room-read-notification-room", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, author.Id, KindChannel, author.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom author: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, reader.Id, KindChannel, reader.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom reader: %v", err)
+	}
+
+	root, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "root", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage root: %v", err)
+	}
+	threadReply, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "thread reply", nil, root.Id, "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage thread reply: %v", err)
+	}
+	dmEvent, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "dm branch", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage dm branch: %v", err)
+	}
+	mentionEvent, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "mention branch", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage mention branch: %v", err)
+	}
+	replyEvent, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "reply branch", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage reply branch: %v", err)
+	}
+	roomMessageEvent, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "room message branch", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage room message branch: %v", err)
+	}
+	futureEvent, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "future room message", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage future room message: %v", err)
+	}
+
+	dismissedPush := make(chan string, 4)
+	core.OnNotificationDismissed = func(ctx context.Context, userID string, notification *corev1.Notification) {
+		dismissedPush <- notification.GetId()
+	}
+
+	subject := subjects.LiveSyncUserEvent(reader.Id, "notification_dismissed")
+	sub, err := nc.SubscribeSync(subject)
+	if err != nil {
+		t.Fatalf("SubscribeSync(%s): %v", subject, err)
+	}
+	defer sub.Unsubscribe()
+	if err := nc.Flush(); err != nil {
+		t.Fatalf("Flush subscription: %v", err)
+	}
+
+	coveredDM, err := core.CreateNotification(ctx, reader.Id, author.Id, &corev1.Notification{
+		Notification: &corev1.Notification_DmMessage{
+			DmMessage: &corev1.DMMessageNotification{RoomId: room.Id, EventId: dmEvent.Id},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateNotification covered dm: %v", err)
+	}
+	coveredMention, err := core.CreateNotification(ctx, reader.Id, author.Id, &corev1.Notification{
+		Notification: &corev1.Notification_Mention{
+			Mention: &corev1.MentionNotification{RoomId: room.Id, EventId: mentionEvent.Id},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateNotification covered mention: %v", err)
+	}
+	coveredReply, err := core.CreateNotification(ctx, reader.Id, author.Id, &corev1.Notification{
+		Notification: &corev1.Notification_Reply{
+			Reply: &corev1.ReplyNotification{RoomId: room.Id, EventId: replyEvent.Id, InReplyToId: root.Id},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateNotification covered reply: %v", err)
+	}
+	coveredRoomMessage, err := core.CreateNotification(ctx, reader.Id, author.Id, &corev1.Notification{
+		Notification: &corev1.Notification_RoomMessage{
+			RoomMessage: &corev1.RoomMessageNotification{RoomId: room.Id, EventId: roomMessageEvent.Id},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateNotification covered room message: %v", err)
+	}
+	threadMention, err := core.CreateNotification(ctx, reader.Id, author.Id, &corev1.Notification{
+		Notification: &corev1.Notification_Mention{
+			Mention: &corev1.MentionNotification{RoomId: room.Id, EventId: threadReply.Id, InThread: root.Id},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateNotification thread mention: %v", err)
+	}
+	futureRoomMessage, err := core.CreateNotification(ctx, reader.Id, author.Id, &corev1.Notification{
+		Notification: &corev1.Notification_RoomMessage{
+			RoomMessage: &corev1.RoomMessageNotification{RoomId: room.Id, EventId: futureEvent.Id},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateNotification future room message: %v", err)
+	}
+
+	cutoff, err := core.GetEventTimestamp(ctx, KindChannel, room.Id, roomMessageEvent.Id)
+	if err != nil {
+		t.Fatalf("GetEventTimestamp: %v", err)
+	}
+	if got := core.DismissRoomReadNotifications(ctx, KindChannel, reader.Id, room.Id, cutoff); got != 4 {
+		t.Fatalf("DismissRoomReadNotifications = %d, want 4", got)
+	}
+
+	remaining, err := core.GetNotifications(ctx, reader.Id)
+	if err != nil {
+		t.Fatalf("GetNotifications: %v", err)
+	}
+	remainingIDs := map[string]bool{}
+	for _, notification := range remaining {
+		remainingIDs[notification.GetId()] = true
+	}
+	if !remainingIDs[threadMention.GetId()] || !remainingIDs[futureRoomMessage.GetId()] || len(remainingIDs) != 2 {
+		t.Fatalf("remaining notifications = %v, want thread %s and future room %s", remainingIDs, threadMention.GetId(), futureRoomMessage.GetId())
+	}
+
+	wantIDs := map[string]bool{
+		coveredDM.GetId():          true,
+		coveredMention.GetId():     true,
+		coveredReply.GetId():       true,
+		coveredRoomMessage.GetId(): true,
+	}
+	for i := 0; i < 4; i++ {
+		msg, err := sub.NextMsg(2 * time.Second)
+		if err != nil {
+			t.Fatalf("waiting for notification_dismissed live event %d: %v", i+1, err)
+		}
+		var live corev1.LiveEvent
+		if err := proto.Unmarshal(msg.Data, &live); err != nil {
+			t.Fatalf("unmarshal live event: %v", err)
+		}
+		event := live.GetNotificationDismissed()
+		if event == nil {
+			t.Fatalf("expected NotificationDismissedEvent, got %T", live.Event)
+		}
+		if !wantIDs[event.GetNotificationId()] {
+			t.Fatalf("unexpected live dismissal id %s", event.GetNotificationId())
+		}
+		delete(wantIDs, event.GetNotificationId())
+	}
+	if len(wantIDs) != 0 {
+		t.Fatalf("missing live dismissal ids: %v", wantIDs)
+	}
+
+	wantPushIDs := map[string]bool{
+		coveredDM.GetId():          true,
+		coveredMention.GetId():     true,
+		coveredReply.GetId():       true,
+		coveredRoomMessage.GetId(): true,
+	}
+	for i := 0; i < 4; i++ {
+		select {
+		case id := <-dismissedPush:
+			if !wantPushIDs[id] {
+				t.Fatalf("unexpected push dismissal id %s", id)
+			}
+			delete(wantPushIDs, id)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("waiting for push dismissal callback %d", i+1)
+		}
+	}
+	if len(wantPushIDs) != 0 {
+		t.Fatalf("missing push dismissal ids: %v", wantPushIDs)
+	}
+}
+
 func TestHasUnreadNotifications(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := context.Background()

--- a/cli/internal/core/read_state_model.go
+++ b/cli/internal/core/read_state_model.go
@@ -79,6 +79,9 @@ func (s *ReadStateModel) MarkRoomAsRead(ctx context.Context, actorID, roomID, up
 		}
 	}
 
+	if hasLast && !lastTime.IsZero() {
+		s.core.DismissRoomReadNotifications(ctx, kind, actorID, room.Id, lastTime)
+	}
 	s.core.NotifyRoomMarkedAsRead(ctx, actorID, kind, room.Id)
 
 	result := &MarkRoomAsReadResult{}
@@ -125,6 +128,11 @@ func (s *ReadStateModel) MarkThreadAsRead(ctx context.Context, actorID, roomID, 
 	previousReadAt, err := s.core.SetThreadLastReadEventID(ctx, kind, actorID, room.Id, threadRootEventID, markerEventID)
 	if err != nil {
 		return nil, err
+	}
+	if markerEventID != "" {
+		if markerTime, err := s.core.GetEventTimestamp(ctx, kind, room.Id, markerEventID); err == nil && !markerTime.IsZero() {
+			s.core.DismissThreadReadNotifications(ctx, kind, actorID, room.Id, threadRootEventID, markerTime)
+		}
 	}
 	return &MarkThreadAsReadResult{PreviousReadAt: previousReadAt}, nil
 }

--- a/cli/internal/pb/chatto/api/v1/apiv1connect/notifications.connect.go
+++ b/cli/internal/pb/chatto/api/v1/apiv1connect/notifications.connect.go
@@ -74,7 +74,8 @@ type NotificationServiceClient interface {
 	ListRoomNotificationCounts(context.Context, *connect.Request[v1.ListRoomNotificationCountsRequest]) (*connect.Response[v1.ListRoomNotificationCountsResponse], error)
 	// Checks whether the authenticated viewer has any pending notifications.
 	HasNotifications(context.Context, *connect.Request[v1.HasNotificationsRequest]) (*connect.Response[v1.HasNotificationsResponse], error)
-	// Dismisses one pending notification.
+	// Dismisses one pending notification. Already-dismissed notifications are
+	// treated as idempotent success.
 	DismissNotification(context.Context, *connect.Request[v1.DismissNotificationRequest]) (*connect.Response[v1.DismissNotificationResponse], error)
 	// Dismisses all pending notifications.
 	DismissAllNotifications(context.Context, *connect.Request[v1.DismissAllNotificationsRequest]) (*connect.Response[v1.DismissAllNotificationsResponse], error)
@@ -209,7 +210,8 @@ type NotificationServiceHandler interface {
 	ListRoomNotificationCounts(context.Context, *connect.Request[v1.ListRoomNotificationCountsRequest]) (*connect.Response[v1.ListRoomNotificationCountsResponse], error)
 	// Checks whether the authenticated viewer has any pending notifications.
 	HasNotifications(context.Context, *connect.Request[v1.HasNotificationsRequest]) (*connect.Response[v1.HasNotificationsResponse], error)
-	// Dismisses one pending notification.
+	// Dismisses one pending notification. Already-dismissed notifications are
+	// treated as idempotent success.
 	DismissNotification(context.Context, *connect.Request[v1.DismissNotificationRequest]) (*connect.Response[v1.DismissNotificationResponse], error)
 	// Dismisses all pending notifications.
 	DismissAllNotifications(context.Context, *connect.Request[v1.DismissAllNotificationsRequest]) (*connect.Response[v1.DismissAllNotificationsResponse], error)

--- a/cli/internal/pb/chatto/api/v1/notifications.pb.go
+++ b/cli/internal/pb/chatto/api/v1/notifications.pb.go
@@ -1174,7 +1174,7 @@ func (x *DismissNotificationRequest) GetNotificationId() string {
 // Result of dismissing one pending notification.
 type DismissNotificationResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when the notification existed and was dismissed.
+	// True when the notification is no longer pending.
 	Dismissed     bool `protobuf:"varint,1,opt,name=dismissed,proto3" json:"dismissed,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/packages/api-types/src/chatto/api/v1/notifications_connect.ts
+++ b/packages/api-types/src/chatto/api/v1/notifications_connect.ts
@@ -82,7 +82,8 @@ export const NotificationService = {
       kind: MethodKind.Unary,
     },
     /**
-     * Dismisses one pending notification.
+     * Dismisses one pending notification. Already-dismissed notifications are
+     * treated as idempotent success.
      *
      * @generated from rpc chatto.api.v1.NotificationService.DismissNotification
      */

--- a/packages/api-types/src/chatto/api/v1/notifications_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/notifications_pb.ts
@@ -1006,7 +1006,7 @@ export class DismissNotificationRequest extends Message<DismissNotificationReque
  */
 export class DismissNotificationResponse extends Message<DismissNotificationResponse> {
   /**
-   * True when the notification existed and was dismissed.
+   * True when the notification is no longer pending.
    *
    * @generated from field: bool dismissed = 1;
    */

--- a/proto/chatto/api/v1/notifications.proto
+++ b/proto/chatto/api/v1/notifications.proto
@@ -193,7 +193,7 @@ message DismissNotificationRequest {
 
 // Result of dismissing one pending notification.
 message DismissNotificationResponse {
-  // True when the notification existed and was dismissed.
+  // True when the notification is no longer pending.
   bool dismissed = 1;
 }
 
@@ -221,7 +221,8 @@ service NotificationService {
   rpc ListRoomNotificationCounts(ListRoomNotificationCountsRequest) returns (ListRoomNotificationCountsResponse);
   // Checks whether the authenticated viewer has any pending notifications.
   rpc HasNotifications(HasNotificationsRequest) returns (HasNotificationsResponse);
-  // Dismisses one pending notification.
+  // Dismisses one pending notification. Already-dismissed notifications are
+  // treated as idempotent success.
   rpc DismissNotification(DismissNotificationRequest) returns (DismissNotificationResponse);
   // Dismisses all pending notifications.
   rpc DismissAllNotifications(DismissAllNotificationsRequest) returns (DismissAllNotificationsResponse);


### PR DESCRIPTION
## Summary

- make room/thread read markers authoritatively clear matching pending notifications on the backend
- reuse the existing notification dismissal path so `notification_dismissed` realtime sync and push-dismiss callbacks fire per cleared notification
- remove frontend automatic scoped notification dismissals from room/thread open paths and keep explicit manual dismiss behavior intact

## Root Cause

The frontend was clearing some notification indicators locally by explicitly dismissing notifications when a room or thread opened. That could clear the room badge while leaving server-owned notification state pending, so other notification surfaces and devices could keep showing dots.

## Behavior

- `MarkThreadAsRead` clears covered thread-scoped mention/reply notifications for the selected thread only.
- `MarkRoomAsRead` clears covered room-level notifications, DM message notifications, room-level replies, and all-message room notifications.
- Plain room reads do not clear thread-scoped notifications.
- Notifications targeting events newer than the selected read marker remain pending.

Closes #1296.

## Verification

- `mise x -- go test ./internal/core -run 'Test(ReadMarkerNotificationDismissalPublishesSyncAndPushDismissal|RoomReadNotificationDismissalPublishesSyncAndPushDismissal|DismissNotification|DismissAllNotifications)' -timeout 60s`
- `mise x -- go test ./internal/connectapi -run 'TestRoomAndThreadServicesMark(Room|Thread)AsReadAnchorsAndDoesNotRegress' -timeout 60s`
- `mise x -- go test ./internal/core ./internal/connectapi -timeout 120s`
- `mise x -- pnpm --dir apps/frontend exec vitest run 'src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts'`
- `mise x -- pnpm --dir apps/frontend exec vitest run 'src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts'`
- `mise x -- pnpm --dir apps/frontend exec vitest run src/lib/state/server/notifications.spec.ts`
- `mise x -- pnpm --dir apps/frontend exec vitest run 'src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts' 'src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts' src/lib/state/server/notifications.spec.ts`
- `mise x -- pnpm --filter chatto-frontend check`
- `git diff --check`
