### PR TITLE
fix(release): publish release before updating tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,44 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Build frontend Docker tags
+        id: frontend_tags
+        shell: bash
+        run: |
+          {
+            echo "tags<<EOF"
+            echo "ghcr.io/chattocorp/chatto-client:${{ steps.version.outputs.version }}"
+            if [[ "${{ steps.version.outputs.version }}" == *-* ]]; then
+              echo "ghcr.io/chattocorp/chatto-client:next"
+            elif [[ "${{ steps.release_meta.outputs.push_latest }}" == "true" ]]; then
+              echo "ghcr.io/chattocorp/chatto-client:latest"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push frontend Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.frontend.prebuilt
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.frontend_tags.outputs.tags }}
+          cache-from: type=gha,scope=chatto-client
+          cache-to: type=gha,scope=chatto-client,mode=max
+
+      - name: Publish GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          gh release edit "v${VERSION}" \
+            --repo chattocorp/chatto \
+            --draft=false
+
       - name: Update Homebrew tap
         if: ${{ !contains(steps.version.outputs.version, '-') }}
         shell: bash
@@ -230,29 +268,3 @@ jobs:
           git -C "${tap_dir}" add Formula/chatto.rb
           git -C "${tap_dir}" commit -m "chore: update chatto to v${VERSION}"
           git -C "${tap_dir}" push origin HEAD:main
-
-      - name: Build frontend Docker tags
-        id: frontend_tags
-        shell: bash
-        run: |
-          {
-            echo "tags<<EOF"
-            echo "ghcr.io/chattocorp/chatto-client:${{ steps.version.outputs.version }}"
-            if [[ "${{ steps.version.outputs.version }}" == *-* ]]; then
-              echo "ghcr.io/chattocorp/chatto-client:next"
-            elif [[ "${{ steps.release_meta.outputs.push_latest }}" == "true" ]]; then
-              echo "ghcr.io/chattocorp/chatto-client:latest"
-            fi
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Build and push frontend Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: docker/Dockerfile.frontend.prebuilt
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.frontend_tags.outputs.tags }}
-          cache-from: type=gha,scope=chatto-client
-          cache-to: type=gha,scope=chatto-client,mode=max

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -117,9 +117,13 @@ release:
   github:
     owner: chattocorp
     name: chatto
-  # release-please creates the GitHub Release with its changelog body.
-  # GoReleaser must NOT overwrite it — `keep-existing` makes GoReleaser
-  # only attach artifacts to the existing release.
+  # release-please creates a draft GitHub Release with its changelog body.
+  # GoReleaser must NOT overwrite it: it should attach artifacts to that
+  # draft and leave publication to the workflow step that runs after release
+  # artifacts and container images have been pushed.
+  draft: true
+  use_existing_draft: true
+  replace_existing_artifacts: true
   mode: keep-existing
   # `auto` marks the GitHub Release as prerelease when the tag carries
   # a prerelease suffix (e.g. v0.1.0-alpha.1). release-please-action

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -6,6 +6,8 @@
   "versioning": "prerelease",
   "prerelease": true,
   "prerelease-type": "beta.1",
+  "draft": true,
+  "force-tag-creation": true,
   "include-component-in-tag": false,
   "include-v-in-tag": true,
   "packages": {


### PR DESCRIPTION
## Summary

Configure release-please to create draft releases with immediate tag creation, and configure GoReleaser to attach artifacts to the existing draft without replacing the release notes.
Move GitHub release publication after the release artifacts and frontend container image are pushed, then update the Homebrew tap only after the release assets are public.
This prevents stable Homebrew formula updates from temporarily or permanently pointing users at draft-only GitHub release assets.

## Validation

- `mise x -- actionlint .github/workflows/release.yml .github/workflows/release-please.yml`
- `mise x -- goreleaser check`
- `git diff --check HEAD -- .github/workflows/release.yml .goreleaser.yml .release-please-config.json`
