### PR TITLE
fix(frontend): sync presence badge across tabs

### DIFF
--- a/apps/frontend/e2e/presence-indicators.test.ts
+++ b/apps/frontend/e2e/presence-indicators.test.ts
@@ -1,4 +1,4 @@
-import { expect } from '@playwright/test';
+import { expect, type Locator, type Page } from '@playwright/test';
 import { TIMEOUTS } from './constants';
 import { createAndLoginTestUser } from './fixtures/testUser';
 import { withServerUser } from './fixtures/serverUser';
@@ -6,6 +6,15 @@ import { waitForRoomReady } from './fixtures/realtimeSync';
 import { test } from './setup';
 import { SettingsPage } from './pages';
 import * as routes from './routes';
+
+function currentUserPresenceDot(page: Page): Locator {
+  return page.getByTestId('current-user-presence-menu').getByTestId('presence-dot');
+}
+
+async function choosePresenceMode(page: Page, modeLabel: string): Promise<void> {
+  await page.getByTestId('current-user-presence-menu').click();
+  await page.getByRole('menuitemradio', { name: modeLabel }).click();
+}
 
 test.describe('Presence indicators', () => {
   test('shows online indicator when another user opens the server', async ({
@@ -91,6 +100,46 @@ test.describe('Presence indicators', () => {
     await expect(presenceDot).toHaveClass(/bg-presence-online/, {
       timeout: TIMEOUTS.REALTIME_EVENT
     });
+  });
+
+  test('same-user tab updates current user badge when away is cleared from another tab', async ({
+    page,
+    chatPage
+  }) => {
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await expect(page.getByTestId('current-user-presence-menu')).toBeVisible({
+      timeout: TIMEOUTS.REALTIME_EVENT
+    });
+
+    const otherTab = await page.context().newPage();
+    try {
+      await otherTab.goto(routes.chat);
+      await otherTab.waitForURL((url) => url.pathname.startsWith('/chat'));
+      await expect(otherTab.getByTestId('current-user-presence-menu')).toBeVisible({
+        timeout: TIMEOUTS.REALTIME_EVENT
+      });
+
+      await page.bringToFront();
+
+      await choosePresenceMode(page, 'Away');
+      await expect(currentUserPresenceDot(page)).toHaveClass(/bg-presence-away/, {
+        timeout: TIMEOUTS.REALTIME_EVENT
+      });
+      await expect(currentUserPresenceDot(otherTab)).toHaveClass(/bg-presence-away/, {
+        timeout: TIMEOUTS.REALTIME_EVENT
+      });
+
+      await choosePresenceMode(page, 'Online');
+      await expect(currentUserPresenceDot(page)).toHaveClass(/bg-presence-online/, {
+        timeout: TIMEOUTS.REALTIME_EVENT
+      });
+      await expect(currentUserPresenceDot(otherTab)).toHaveClass(/bg-presence-online/, {
+        timeout: TIMEOUTS.REALTIME_EVENT
+      });
+    } finally {
+      await otherTab.close();
+    }
   });
 });
 

--- a/apps/frontend/src/lib/presenceTracking.spec.ts
+++ b/apps/frontend/src/lib/presenceTracking.spec.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vite
 import { APIPresenceStatus } from '$lib/api-client/presence';
 import { PresenceStatus } from '$lib/render/types';
 import { presencePreference } from '$lib/state/presencePreference.svelte';
-import { initPresenceTracking, setPresenceMode } from './presenceTracking';
+import { __presenceTrackingTest, initPresenceTracking, setPresenceMode } from './presenceTracking';
 
 type UpdatePresence = (
 	status: APIPresenceStatus,
@@ -38,6 +38,15 @@ function dispatchDocumentEvent(type: string) {
 
 function dispatchWindowEvent(type: string) {
 	windowTarget.dispatchEvent(new Event(type));
+}
+
+function dispatchStorageMode(mode: string) {
+	const event = new Event('storage') as StorageEvent;
+	Object.defineProperties(event, {
+		key: { value: __presenceTrackingTest.PRESENCE_MODE_STORAGE_KEY },
+		newValue: { value: mode }
+	});
+	windowTarget.dispatchEvent(event);
 }
 
 function setVisibility(next: DocumentVisibilityState) {
@@ -191,6 +200,23 @@ describe('initPresenceTracking', () => {
 		expect(sentStatuses().slice(1)).not.toContain(APIPresenceStatus.ONLINE);
 		expect(sentUserSelectedFlags().at(1)).toBe(true);
 		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.Away);
+	});
+
+	it('returns online when another tab clears explicit away while this tab is hidden', () => {
+		startTracking();
+		setVisibility('hidden');
+		vi.advanceTimersByTime(10_000);
+		dispatchStorageMode('away');
+
+		expect(sentStatuses().at(-1)).toBe(APIPresenceStatus.AWAY);
+		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.Away);
+
+		dispatchStorageMode('auto');
+
+		expect(sentStatuses().at(-1)).toBe(APIPresenceStatus.ONLINE);
+		expect(sentUserSelectedFlags().at(-1)).toBe(true);
+		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.Online);
+		expect(presencePreference.effectiveStatus).toBe(PresenceStatus.Online);
 	});
 
 	it('keeps do not disturb through activity and refreshes it', () => {

--- a/apps/frontend/src/lib/presenceTracking.ts
+++ b/apps/frontend/src/lib/presenceTracking.ts
@@ -159,7 +159,7 @@ export function initPresenceTracking(
 		return state === 'active' ? PresenceStatus.Online : PresenceStatus.Away;
 	}
 
-	function applyMode(mode: PresenceMode, persist = false) {
+	function applyMode(mode: PresenceMode, persist = false, syncedFromStorage = false) {
 		currentMode = mode;
 		presencePreference.mode = mode;
 		if (persist) storeMode(mode);
@@ -176,7 +176,11 @@ export function initPresenceTracking(
 		options.onResumeLiveEvents?.();
 		if (mode === 'auto') {
 			currentState = document.visibilityState === 'hidden' ? 'hidden' : 'active';
-			reportStatus(statusForAutoState(currentState), persist);
+			const userSelected = persist || syncedFromStorage;
+			reportStatus(
+				userSelected ? PresenceStatus.Online : statusForAutoState(currentState),
+				userSelected
+			);
 			ensureRefreshTimer();
 			resetIdleTimer();
 			return;
@@ -248,7 +252,7 @@ export function initPresenceTracking(
 			event.newValue === 'doNotDisturb' ||
 			event.newValue === 'invisible'
 		) {
-			applyMode(event.newValue);
+			applyMode(event.newValue, false, true);
 		}
 	}
 


### PR DESCRIPTION
Fixes cross-tab presence mode syncing so clearing Away in one tab forces other tabs' current-user badge back to Online instead of recalculating from the receiving tab's hidden or idle state.

The root cause was storage-synced `auto` mode being treated like passive auto-presence instead of an explicit user action from another tab.

Adds a unit regression for storage-driven mode changes and an e2e regression for the same-user two-tab lower-left badge flow.

Validated with `mise x -- pnpm --dir apps/frontend exec vitest --run src/lib/presenceTracking.spec.ts` and `mise x -- pnpm --dir apps/frontend exec playwright test e2e/presence-indicators.test.ts -g "same-user tab updates current user badge" --retries=0`.
