### PR TITLE
feat(api)!: consolidate shared api shapes

### DIFF
--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
@@ -319,12 +319,8 @@ requests.
 | `echo_of_event_id` | `string` | Event ID this event echoes into the current view, when applicable. Echoes allow thread activity to appear in another timeline context. |
 | `echo_from_thread_root_event_id` | `string` | Thread root ID of the echoed event, when applicable. |
 | `channel_echo_event_id` | `string` | Channel timeline event ID for a thread echo, when applicable. |
-| `reply_count` | `int32` | Number of replies in this message's thread. |
-| `last_reply_at` | `google.protobuf.Timestamp` | Creation time of the most recent reply in this message's thread. |
-| `thread_participant_preview_user_ids` | `repeated string` | Preview of up to five user IDs that have participated in this message's thread. |
-| `thread_participant_count` | `int32` | Total number of distinct users that have participated in this message's thread. |
-| `viewer_is_following_thread` | `optional bool` | Whether the current user follows this message's thread, when known. |
 | `reactions` | repeated [`MessageReaction`](#chatto-api-v1-MessageReaction) | Reaction summaries for this message. |
+| `thread` | [`ThreadSummary`](#chatto-api-v1-ThreadSummary) | Aggregated thread state, when known for a thread root message. |
 
 <a id="chatto-api-v1-MessageAssetUrl"></a>
 
@@ -411,6 +407,32 @@ One transcoded video rendition.
 | `size` | `int64` | Rendition size in bytes. |
 | `asset_url` | [`MessageAssetUrl`](#chatto-api-v1-MessageAssetUrl) | Signed URL for the rendition. |
 
+<a id="chatto-api-v1-ThreadSummary"></a>
+
+### ThreadSummary
+
+Aggregated state for one message thread.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `thread_root_event_id` | `string` | Event ID of the root message for the thread. |
+| `reply_count` | `int32` | Number of replies in this message's thread. |
+| `last_reply_at` | `google.protobuf.Timestamp` | Creation time of the most recent reply in this message's thread. |
+| `participant_preview_user_ids` | `repeated string` | Preview of up to five user IDs that have participated in this message's thread. |
+| `participant_count` | `int32` | Total number of distinct users that have participated in this message's thread. |
+| `viewer_state` | [`ThreadViewerState`](#chatto-api-v1-ThreadViewerState) | State resolved for the current user. |
+
+<a id="chatto-api-v1-ThreadViewerState"></a>
+
+### ThreadViewerState
+
+Viewer-specific state for one message thread.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `is_following` | `optional bool` | Whether the current user follows this message's thread, when known. |
+| `has_unread` | `optional bool` | True when the thread has unread replies for the current user, when known. |
+
 <a id="chatto-api-v1-RoomAttachmentListItem"></a>
 
 ### RoomAttachmentListItem
@@ -459,106 +481,6 @@ surfaces.
 | `user` | [`User`](#chatto-api-v1-User) | Public user fields. |
 | `roles` | `repeated string` | Explicit roles assigned to the user. Member listings include the virtual `everyone` role for parity with Chatto's permission model. |
 | `created_at` | `google.protobuf.Timestamp` | Account creation time when known. |
-
-<a id="chatto-api-v1-DirectMessageNotification"></a>
-
-### DirectMessageNotification
-
-Direct-message notification payload.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `room_id` | `string` | DM room where the message was posted. |
-| `event_id` | `string` | Message event ID. |
-
-<a id="chatto-api-v1-MentionNotification"></a>
-
-### MentionNotification
-
-Mention notification payload.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `room` | [`NotificationRoom`](#chatto-api-v1-NotificationRoom) | Room where the mention occurred. |
-| `event_id` | `string` | Message event ID. |
-| `thread_root_event_id` | `optional string` | Thread root event ID when the mention happened inside a thread. |
-
-<a id="chatto-api-v1-NotificationItem"></a>
-
-### NotificationItem
-
-One pending notification for the authenticated viewer.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `id` | `string` | Stable notification ID. |
-| `created_at` | `google.protobuf.Timestamp` | Creation time. |
-| `actor` | [`User`](#chatto-api-v1-User) | User who triggered the notification, when still resolvable. |
-| `kind.direct_message` | [`DirectMessageNotification`](#chatto-api-v1-DirectMessageNotification) | Direct-message notification. |
-| `kind.mention` | [`MentionNotification`](#chatto-api-v1-MentionNotification) | Mention notification. |
-| `kind.reply` | [`ReplyNotification`](#chatto-api-v1-ReplyNotification) | Reply notification. |
-| `kind.room_message` | [`RoomMessageNotification`](#chatto-api-v1-RoomMessageNotification) | All-messages room notification. |
-
-<a id="chatto-api-v1-NotificationRoom"></a>
-
-### NotificationRoom
-
-Room summary embedded in notification responses.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `id` | `string` | Stable room ID. |
-| `name` | `string` | Room display name. Empty for DM rooms. |
-
-<a id="chatto-api-v1-ReplyNotification"></a>
-
-### ReplyNotification
-
-Reply notification payload.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `room` | [`NotificationRoom`](#chatto-api-v1-NotificationRoom) | Room where the reply occurred. |
-| `event_id` | `string` | Reply event ID. |
-| `in_reply_to_id` | `string` | Event ID of the message being replied to. |
-| `thread_root_event_id` | `optional string` | Thread root event ID when the reply happened inside a thread. |
-
-<a id="chatto-api-v1-RoomMessageNotification"></a>
-
-### RoomMessageNotification
-
-All-messages room notification payload.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `room` | [`NotificationRoom`](#chatto-api-v1-NotificationRoom) | Room where the message was posted. |
-| `event_id` | `string` | Message event ID. |
-
-<a id="chatto-api-v1-RoomNotificationCount"></a>
-
-### RoomNotificationCount
-
-Pending notification count for one room.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `room_id` | `string` | Room ID. |
-| `total_count` | `int32` | Pending notification count for the authenticated viewer in this room. |
-
-<a id="chatto-api-v1-Role"></a>
-
-### Role
-
-Public role metadata used for rendering role mentions, labels, and catalogs.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `name` | `string` | Stable role name used in permission and assignment records. |
-| `display_name` | `string` | Display name shown in user-facing role UIs. |
-| `description` | `string` | Optional role description. |
-| `is_system` | `bool` | Whether this is a built-in role. |
-| `position` | `int32` | Display/order position. |
-| `pingable` | `bool` | Whether messages may notify users assigned to this role. |
 
 <a id="chatto-api-v1-RoomMessagePosted"></a>
 
@@ -670,6 +592,107 @@ Active channel room ban with optional hydrated room and user references.
 | `created_at` | `google.protobuf.Timestamp` | Time the ban was created. |
 | `expires_at` | `google.protobuf.Timestamp` | Optional future time when the ban expires. |
 
+<a id="chatto-api-v1-RoomSummary"></a>
+
+### RoomSummary
+
+Lightweight room reference for cross-resource rows.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | Stable room ID. |
+| `kind` | [`RoomKind`](#chatto-api-v1-RoomKind) | Room kind. |
+| `name` | `string` | Room name. Direct-message rooms may have an empty name because clients derive their display label from participants. |
+
+<a id="chatto-api-v1-DirectMessageNotification"></a>
+
+### DirectMessageNotification
+
+Direct-message notification payload.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `event_id` | `string` | Message event ID. |
+| `room` | [`RoomSummary`](#chatto-api-v1-RoomSummary) | DM room where the message was posted. |
+
+<a id="chatto-api-v1-MentionNotification"></a>
+
+### MentionNotification
+
+Mention notification payload.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room` | [`RoomSummary`](#chatto-api-v1-RoomSummary) | Room where the mention occurred. |
+| `event_id` | `string` | Message event ID. |
+| `thread_root_event_id` | `optional string` | Thread root event ID when the mention happened inside a thread. |
+
+<a id="chatto-api-v1-NotificationItem"></a>
+
+### NotificationItem
+
+One pending notification for the authenticated viewer.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | Stable notification ID. |
+| `created_at` | `google.protobuf.Timestamp` | Creation time. |
+| `actor` | [`User`](#chatto-api-v1-User) | User who triggered the notification, when still resolvable. |
+| `kind.direct_message` | [`DirectMessageNotification`](#chatto-api-v1-DirectMessageNotification) | Direct-message notification. |
+| `kind.mention` | [`MentionNotification`](#chatto-api-v1-MentionNotification) | Mention notification. |
+| `kind.reply` | [`ReplyNotification`](#chatto-api-v1-ReplyNotification) | Reply notification. |
+| `kind.room_message` | [`RoomMessageNotification`](#chatto-api-v1-RoomMessageNotification) | All-messages room notification. |
+
+<a id="chatto-api-v1-ReplyNotification"></a>
+
+### ReplyNotification
+
+Reply notification payload.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room` | [`RoomSummary`](#chatto-api-v1-RoomSummary) | Room where the reply occurred. |
+| `event_id` | `string` | Reply event ID. |
+| `in_reply_to_id` | `string` | Event ID of the message being replied to. |
+| `thread_root_event_id` | `optional string` | Thread root event ID when the reply happened inside a thread. |
+
+<a id="chatto-api-v1-RoomMessageNotification"></a>
+
+### RoomMessageNotification
+
+All-messages room notification payload.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room` | [`RoomSummary`](#chatto-api-v1-RoomSummary) | Room where the message was posted. |
+| `event_id` | `string` | Message event ID. |
+
+<a id="chatto-api-v1-RoomNotificationCount"></a>
+
+### RoomNotificationCount
+
+Pending notification count for one room.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room_id` | `string` | Room ID. |
+| `total_count` | `int32` | Pending notification count for the authenticated viewer in this room. |
+
+<a id="chatto-api-v1-Role"></a>
+
+### Role
+
+Public role metadata used for rendering role mentions, labels, and catalogs.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `name` | `string` | Stable role name used in permission and assignment records. |
+| `display_name` | `string` | Display name shown in user-facing role UIs. |
+| `description` | `string` | Optional role description. |
+| `is_system` | `bool` | Whether this is a built-in role. |
+| `position` | `int32` | Display/order position. |
+| `pingable` | `bool` | Whether messages may notify users assigned to this role. |
+
 <a id="chatto-api-v1-RoomGroup"></a>
 
 ### RoomGroup
@@ -703,7 +726,19 @@ Viewer-specific state for one room group.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `can_create_room` | `bool` | True when the current user can create rooms in this group. |
+| `permissions` | repeated [`PermissionGrant`](#chatto-api-v1-PermissionGrant) | Effective group-scoped permission decisions after group state constraints. |
+
+<a id="chatto-api-v1-RoomViewerState"></a>
+
+### RoomViewerState
+
+Viewer-specific state and permission decisions for one room.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `is_member` | `bool` | True when the current user is an effective room member. |
+| `has_unread` | `bool` | True when the room has unread root messages for the current user. |
+| `permissions` | repeated [`PermissionGrant`](#chatto-api-v1-PermissionGrant) | Effective room-scoped permission decisions after room state constraints. |
 
 <a id="chatto-api-v1-RoomWithViewerState"></a>
 
@@ -715,18 +750,7 @@ viewer.
 | Field | Type | Description |
 | --- | --- | --- |
 | `room` | [`Room`](#chatto-api-v1-Room) | Public room metadata. |
-| `is_member` | `bool` | True when the current user is an effective room member. |
-| `has_unread` | `bool` | True when the room has unread root messages for the current user. |
-| `can_list_room` | `bool` | True when the room can appear in directory surfaces for the current user. |
-| `can_join_room` | `bool` | True when the current user can join this room. |
-| `can_post_message` | `bool` | True when the current user can post new root messages. |
-| `can_post_in_thread` | `bool` | True when the current user can post thread replies. |
-| `can_attach` | `bool` | True when the current user can attach files to messages. |
-| `can_react` | `bool` | True when the current user can add and remove reactions. |
-| `can_echo_message` | `bool` | True when the current user can echo thread replies to the main room. |
-| `can_manage_others_message` | `bool` | True when the current user can edit or delete other users' messages. |
-| `can_manage_room` | `bool` | True when the current user can configure this room. |
-| `can_ban_room_members` | `bool` | True when the current user can ban members from this room. |
+| `viewer_state` | [`RoomViewerState`](#chatto-api-v1-RoomViewerState) | State and permission decisions resolved for the current user. |
 
 <a id="chatto-api-v1-SidebarLink"></a>
 
@@ -802,13 +826,9 @@ One followed thread for the current user.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `room_id` | `string` | Room containing the thread. |
-| `room_name` | `string` | Current display name of the room. |
-| `thread_root_event_id` | `string` | Event ID of the root message for the thread. |
 | `root_message` | [`Message`](#chatto-api-v1-Message) | Renderable root message, when the root is still visible. |
-| `reply_count` | `int32` | Number of replies in the thread. |
-| `last_reply_at` | `google.protobuf.Timestamp` | Creation time of the latest reply, when the thread has replies. |
-| `has_unread` | `bool` | True when the current user has unread replies in the thread. |
+| `room` | [`RoomSummary`](#chatto-api-v1-RoomSummary) | Room containing the thread. |
+| `thread` | [`ThreadSummary`](#chatto-api-v1-ThreadSummary) | Aggregated thread state. |
 
 <a id="chatto-api-v1-ThreadFollowState"></a>
 

--- a/apps/docs-website/src/content/docs/releases/0-4-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-4-0.mdx
@@ -129,9 +129,21 @@ import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
   `RoomService.ListMembers`, `GetMember`, and `BatchGetMembers`. Room moderation RPCs
   were also shortened from `RoomService.ListRoomBans`, `BanRoomMember`, and
   `UnbanRoomMember` to `ListBans`, `BanMember`, and `UnbanMember`.
-- Room directory responses now return `RoomWithViewerState` entries with viewer
-  state and capability fields next to `room`. Replace `DirectoryRoom.viewer_state.*`
-  reads with direct fields such as `is_member`, `has_unread`, and `can_join_room`.
+- Room directory responses now return `RoomWithViewerState` entries containing
+  `room` plus `viewer_state`. Durable viewer state such as `is_member` and
+  `has_unread` lives on `viewer_state`; action availability is reported as
+  `viewer_state.permissions` entries keyed by permission name.
+- `Message` thread metadata moved under `Message.thread`. Replace direct reads
+  such as `reply_count`, `last_reply_at`, `thread_participant_preview_user_ids`,
+  `thread_participant_count`, and `viewer_is_following_thread` with the
+  corresponding `ThreadSummary` and `ThreadViewerState` fields.
+- Followed thread rows now return `room` as `RoomSummary` and thread metadata
+  under `thread`. Replace `FollowedThread.room_id`, `room_name`,
+  `thread_root_event_id`, `reply_count`, `last_reply_at`, and `has_unread` with
+  `FollowedThread.room.*` and `FollowedThread.thread.*`.
+- Notification room references now use the shared `RoomSummary` shape.
+  `DirectMessageNotification.room_id` was replaced by
+  `DirectMessageNotification.room.id`.
 - Message attachment URL refreshes moved to room-scoped asset reads: replace
   `MessageService.RefreshMessageAttachmentUrls` with `AssetService.GetAsset` and
   `MessageService.BatchRefreshMessageAttachmentUrls` with `AssetService.BatchGetAssets`.

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -1383,440 +1383,6 @@ Result of removing a reaction.
 | `reaction` | [`MessageReaction`](#chatto-api-v1-MessageReaction) | Updated aggregate reaction state for this emoji. Empty when no reactions for the emoji remain. |
 
 
-<a id="chatto-api-v1-NotificationService"></a>
-
-## NotificationService
-
-Reads and dismisses pending notifications for the authenticated viewer.
-
-<a id="chatto-api-v1-NotificationService-ListNotifications"></a>
-
-### ListNotifications
-
-Lists the authenticated viewer's pending notifications.
-
-```http
-POST /api/connect/chatto.api.v1.NotificationService/ListNotifications
-```
-
-<a id="chatto-api-v1-ListNotificationsRequest"></a>
-
-#### Input: ListNotificationsRequest
-
-Request for the authenticated viewer's pending notifications.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Page request. Defaults to 50 results when absent or limit is zero. |
-
-
-<a id="chatto-api-v1-ListNotificationsResponse"></a>
-
-#### Result: ListNotificationsResponse
-
-Pending notification page.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `notifications` | repeated [`NotificationItem`](#chatto-api-v1-NotificationItem) | Page notifications, newest first. |
-| `page` | [`PageInfo`](#chatto-api-v1-PageInfo) | Page metadata. |
-
-
-<a id="chatto-api-v1-NotificationService-GetNotification"></a>
-
-### GetNotification
-
-Gets one pending notification. Returns NOT_FOUND when the notification is
-unknown or has been dismissed.
-
-```http
-POST /api/connect/chatto.api.v1.NotificationService/GetNotification
-```
-
-<a id="chatto-api-v1-GetNotificationRequest"></a>
-
-#### Input: GetNotificationRequest
-
-Request one pending notification for the authenticated viewer.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `notification_id` | `string` | Required notification ID. |
-
-
-<a id="chatto-api-v1-GetNotificationResponse"></a>
-
-#### Result: GetNotificationResponse
-
-Pending notification response.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `notification` | [`NotificationItem`](#chatto-api-v1-NotificationItem) | Requested notification. |
-
-
-<a id="chatto-api-v1-NotificationService-BatchGetNotifications"></a>
-
-### BatchGetNotifications
-
-Gets pending notifications by ID.
-
-```http
-POST /api/connect/chatto.api.v1.NotificationService/BatchGetNotifications
-```
-
-<a id="chatto-api-v1-BatchGetNotificationsRequest"></a>
-
-#### Input: BatchGetNotificationsRequest
-
-Request pending notifications for a set of stable notification IDs.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `notification_ids` | `repeated string` | Required notification IDs. Unknown or dismissed IDs are omitted from the response. |
-
-
-<a id="chatto-api-v1-BatchGetNotificationsResponse"></a>
-
-#### Result: BatchGetNotificationsResponse
-
-Batch pending notification response.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `notifications` | repeated [`NotificationItem`](#chatto-api-v1-NotificationItem) | Found notifications. The server preserves first-seen request order and de-duplicates repeated IDs. |
-
-
-<a id="chatto-api-v1-NotificationService-ListRoomNotifications"></a>
-
-### ListRoomNotifications
-
-Lists pending notifications for one room. Non-members receive an empty page.
-
-```http
-POST /api/connect/chatto.api.v1.NotificationService/ListRoomNotifications
-```
-
-<a id="chatto-api-v1-ListRoomNotificationsRequest"></a>
-
-#### Input: ListRoomNotificationsRequest
-
-Request for pending notifications scoped to one room.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `room_id` | `string` | Required. Room whose notifications should be listed. |
-| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Page request. Defaults to 50 results when absent or limit is zero. |
-
-
-<a id="chatto-api-v1-ListRoomNotificationsResponse"></a>
-
-#### Result: ListRoomNotificationsResponse
-
-Pending notification page scoped to one room.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `notifications` | repeated [`NotificationItem`](#chatto-api-v1-NotificationItem) | Page notifications, newest first. |
-| `page` | [`PageInfo`](#chatto-api-v1-PageInfo) | Page metadata. |
-
-
-<a id="chatto-api-v1-NotificationService-ListRoomNotificationCounts"></a>
-
-### ListRoomNotificationCounts
-
-Lists pending notification counts grouped by room as a finite snapshot.
-
-```http
-POST /api/connect/chatto.api.v1.NotificationService/ListRoomNotificationCounts
-```
-
-<a id="chatto-api-v1-ListRoomNotificationCountsRequest"></a>
-
-#### Input: ListRoomNotificationCountsRequest
-
-Request for pending notification counts grouped by room.
-
-
-<a id="chatto-api-v1-ListRoomNotificationCountsResponse"></a>
-
-#### Result: ListRoomNotificationCountsResponse
-
-Finite snapshot of pending notification counts grouped by room.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `room_counts` | repeated [`RoomNotificationCount`](#chatto-api-v1-RoomNotificationCount) | Counts for rooms with at least one pending notification. |
-
-
-<a id="chatto-api-v1-NotificationService-HasNotifications"></a>
-
-### HasNotifications
-
-Checks whether the authenticated viewer has any pending notifications.
-
-```http
-POST /api/connect/chatto.api.v1.NotificationService/HasNotifications
-```
-
-<a id="chatto-api-v1-HasNotificationsRequest"></a>
-
-#### Input: HasNotificationsRequest
-
-Request for a lightweight pending notification check.
-
-
-<a id="chatto-api-v1-HasNotificationsResponse"></a>
-
-#### Result: HasNotificationsResponse
-
-Lightweight pending notification check.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `has_notifications` | `bool` | True when the authenticated viewer has at least one pending notification. |
-
-
-<a id="chatto-api-v1-NotificationService-DismissNotification"></a>
-
-### DismissNotification
-
-Dismisses one pending notification. Already-dismissed notifications are
-treated as idempotent success.
-
-```http
-POST /api/connect/chatto.api.v1.NotificationService/DismissNotification
-```
-
-<a id="chatto-api-v1-DismissNotificationRequest"></a>
-
-#### Input: DismissNotificationRequest
-
-Request to dismiss one pending notification.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `notification_id` | `string` | Required. Notification to dismiss. |
-
-
-<a id="chatto-api-v1-DismissNotificationResponse"></a>
-
-#### Result: DismissNotificationResponse
-
-Result of dismissing one pending notification.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `dismissed` | `bool` | True when the notification is no longer pending. |
-
-
-<a id="chatto-api-v1-NotificationService-DismissAllNotifications"></a>
-
-### DismissAllNotifications
-
-Dismisses all pending notifications.
-
-```http
-POST /api/connect/chatto.api.v1.NotificationService/DismissAllNotifications
-```
-
-<a id="chatto-api-v1-DismissAllNotificationsRequest"></a>
-
-#### Input: DismissAllNotificationsRequest
-
-Request to dismiss all pending notifications.
-
-
-<a id="chatto-api-v1-DismissAllNotificationsResponse"></a>
-
-#### Result: DismissAllNotificationsResponse
-
-Result of dismissing all pending notifications.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `dismissed_count` | `int32` | Number of notifications dismissed. |
-
-
-<a id="chatto-api-v1-PushNotificationService"></a>
-
-## PushNotificationService
-
-Browser Web Push subscription commands for the current user.
-
-<a id="chatto-api-v1-PushNotificationService-Subscribe"></a>
-
-### Subscribe
-
-Stores or updates the caller's browser push subscription.
-
-The server must have Web Push configured. Clients normally call this after
-the browser grants notification permission and returns a PushSubscription.
-
-```http
-POST /api/connect/chatto.api.v1.PushNotificationService/Subscribe
-```
-
-<a id="chatto-api-v1-SubscribePushRequest"></a>
-
-#### Input: SubscribePushRequest
-
-Request to store a PushSubscription returned by the browser Push API.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `endpoint` | `string` | Push service endpoint URL. |
-| `p256dh` | `string` | Client P-256 ECDH public key from PushSubscription.keys.p256dh. |
-| `auth` | `string` | Authentication secret from PushSubscription.keys.auth. |
-| `user_agent` | `optional string` | Optional browser user-agent string for device identification. |
-
-
-<a id="chatto-api-v1-SubscribePushResponse"></a>
-
-#### Result: SubscribePushResponse
-
-Response from storing a browser push subscription.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `subscribed` | `bool` | True when the subscription was stored. |
-
-
-<a id="chatto-api-v1-PushNotificationService-Unsubscribe"></a>
-
-### Unsubscribe
-
-Removes the caller's browser push subscription by endpoint.
-
-The call is idempotent: removing an unknown endpoint still succeeds.
-
-```http
-POST /api/connect/chatto.api.v1.PushNotificationService/Unsubscribe
-```
-
-<a id="chatto-api-v1-UnsubscribePushRequest"></a>
-
-#### Input: UnsubscribePushRequest
-
-Request to remove a browser push subscription.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `endpoint` | `string` | Push service endpoint URL to remove. |
-
-
-<a id="chatto-api-v1-UnsubscribePushResponse"></a>
-
-#### Result: UnsubscribePushResponse
-
-Response from removing a browser push subscription.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `unsubscribed` | `bool` | True when the request completed. |
-
-
-<a id="chatto-api-v1-RoleService"></a>
-
-## RoleService
-
-Provides authenticated reads for public role metadata.
-
-<a id="chatto-api-v1-RoleService-ListRoles"></a>
-
-### ListRoles
-
-Lists the current role catalog as a finite snapshot. Requires an
-authenticated user.
-
-```http
-POST /api/connect/chatto.api.v1.RoleService/ListRoles
-```
-
-<a id="chatto-api-v1-ListRolesRequest"></a>
-
-#### Input: ListRolesRequest
-
-Request the current role catalog.
-
-
-<a id="chatto-api-v1-ListRolesResponse"></a>
-
-#### Result: ListRolesResponse
-
-Snapshot of the role catalog visible to the authenticated viewer.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `roles` | repeated [`Role`](#chatto-api-v1-Role) | Roles sorted by position. |
-
-
-<a id="chatto-api-v1-RoleService-GetRole"></a>
-
-### GetRole
-
-Gets one public role by stable name. Returns NOT_FOUND when the role is
-unknown.
-
-```http
-POST /api/connect/chatto.api.v1.RoleService/GetRole
-```
-
-<a id="chatto-api-v1-GetRoleRequest"></a>
-
-#### Input: GetRoleRequest
-
-Request one public role by stable role name.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `name` | `string` | Required stable role name. |
-
-
-<a id="chatto-api-v1-GetRoleResponse"></a>
-
-#### Result: GetRoleResponse
-
-Public role lookup response.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `role` | [`Role`](#chatto-api-v1-Role) | Requested role. |
-
-
-<a id="chatto-api-v1-RoleService-BatchGetRoles"></a>
-
-### BatchGetRoles
-
-Gets public role records for multiple role names referenced by member rows,
-mentions, or integration clients.
-
-```http
-POST /api/connect/chatto.api.v1.RoleService/BatchGetRoles
-```
-
-<a id="chatto-api-v1-BatchGetRolesRequest"></a>
-
-#### Input: BatchGetRolesRequest
-
-Request public role records for a set of stable role names.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `names` | `repeated string` | Required role names. Unknown names are omitted from the response. |
-
-
-<a id="chatto-api-v1-BatchGetRolesResponse"></a>
-
-#### Result: BatchGetRolesResponse
-
-Batch public role response.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `roles` | repeated [`Role`](#chatto-api-v1-Role) | Found roles. The server preserves first-seen request order and de-duplicates repeated names. |
-
-
 <a id="chatto-api-v1-RoomService"></a>
 
 ## RoomService
@@ -2567,6 +2133,440 @@ Result of removing a room ban.
 | Field | Type | Description |
 | --- | --- | --- |
 | `unbanned` | `bool` | True when the unban operation completed. |
+
+
+<a id="chatto-api-v1-NotificationService"></a>
+
+## NotificationService
+
+Reads and dismisses pending notifications for the authenticated viewer.
+
+<a id="chatto-api-v1-NotificationService-ListNotifications"></a>
+
+### ListNotifications
+
+Lists the authenticated viewer's pending notifications.
+
+```http
+POST /api/connect/chatto.api.v1.NotificationService/ListNotifications
+```
+
+<a id="chatto-api-v1-ListNotificationsRequest"></a>
+
+#### Input: ListNotificationsRequest
+
+Request for the authenticated viewer's pending notifications.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Page request. Defaults to 50 results when absent or limit is zero. |
+
+
+<a id="chatto-api-v1-ListNotificationsResponse"></a>
+
+#### Result: ListNotificationsResponse
+
+Pending notification page.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `notifications` | repeated [`NotificationItem`](#chatto-api-v1-NotificationItem) | Page notifications, newest first. |
+| `page` | [`PageInfo`](#chatto-api-v1-PageInfo) | Page metadata. |
+
+
+<a id="chatto-api-v1-NotificationService-GetNotification"></a>
+
+### GetNotification
+
+Gets one pending notification. Returns NOT_FOUND when the notification is
+unknown or has been dismissed.
+
+```http
+POST /api/connect/chatto.api.v1.NotificationService/GetNotification
+```
+
+<a id="chatto-api-v1-GetNotificationRequest"></a>
+
+#### Input: GetNotificationRequest
+
+Request one pending notification for the authenticated viewer.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `notification_id` | `string` | Required notification ID. |
+
+
+<a id="chatto-api-v1-GetNotificationResponse"></a>
+
+#### Result: GetNotificationResponse
+
+Pending notification response.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `notification` | [`NotificationItem`](#chatto-api-v1-NotificationItem) | Requested notification. |
+
+
+<a id="chatto-api-v1-NotificationService-BatchGetNotifications"></a>
+
+### BatchGetNotifications
+
+Gets pending notifications by ID.
+
+```http
+POST /api/connect/chatto.api.v1.NotificationService/BatchGetNotifications
+```
+
+<a id="chatto-api-v1-BatchGetNotificationsRequest"></a>
+
+#### Input: BatchGetNotificationsRequest
+
+Request pending notifications for a set of stable notification IDs.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `notification_ids` | `repeated string` | Required notification IDs. Unknown or dismissed IDs are omitted from the response. |
+
+
+<a id="chatto-api-v1-BatchGetNotificationsResponse"></a>
+
+#### Result: BatchGetNotificationsResponse
+
+Batch pending notification response.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `notifications` | repeated [`NotificationItem`](#chatto-api-v1-NotificationItem) | Found notifications. The server preserves first-seen request order and de-duplicates repeated IDs. |
+
+
+<a id="chatto-api-v1-NotificationService-ListRoomNotifications"></a>
+
+### ListRoomNotifications
+
+Lists pending notifications for one room. Non-members receive an empty page.
+
+```http
+POST /api/connect/chatto.api.v1.NotificationService/ListRoomNotifications
+```
+
+<a id="chatto-api-v1-ListRoomNotificationsRequest"></a>
+
+#### Input: ListRoomNotificationsRequest
+
+Request for pending notifications scoped to one room.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room_id` | `string` | Required. Room whose notifications should be listed. |
+| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Page request. Defaults to 50 results when absent or limit is zero. |
+
+
+<a id="chatto-api-v1-ListRoomNotificationsResponse"></a>
+
+#### Result: ListRoomNotificationsResponse
+
+Pending notification page scoped to one room.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `notifications` | repeated [`NotificationItem`](#chatto-api-v1-NotificationItem) | Page notifications, newest first. |
+| `page` | [`PageInfo`](#chatto-api-v1-PageInfo) | Page metadata. |
+
+
+<a id="chatto-api-v1-NotificationService-ListRoomNotificationCounts"></a>
+
+### ListRoomNotificationCounts
+
+Lists pending notification counts grouped by room as a finite snapshot.
+
+```http
+POST /api/connect/chatto.api.v1.NotificationService/ListRoomNotificationCounts
+```
+
+<a id="chatto-api-v1-ListRoomNotificationCountsRequest"></a>
+
+#### Input: ListRoomNotificationCountsRequest
+
+Request for pending notification counts grouped by room.
+
+
+<a id="chatto-api-v1-ListRoomNotificationCountsResponse"></a>
+
+#### Result: ListRoomNotificationCountsResponse
+
+Finite snapshot of pending notification counts grouped by room.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room_counts` | repeated [`RoomNotificationCount`](#chatto-api-v1-RoomNotificationCount) | Counts for rooms with at least one pending notification. |
+
+
+<a id="chatto-api-v1-NotificationService-HasNotifications"></a>
+
+### HasNotifications
+
+Checks whether the authenticated viewer has any pending notifications.
+
+```http
+POST /api/connect/chatto.api.v1.NotificationService/HasNotifications
+```
+
+<a id="chatto-api-v1-HasNotificationsRequest"></a>
+
+#### Input: HasNotificationsRequest
+
+Request for a lightweight pending notification check.
+
+
+<a id="chatto-api-v1-HasNotificationsResponse"></a>
+
+#### Result: HasNotificationsResponse
+
+Lightweight pending notification check.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `has_notifications` | `bool` | True when the authenticated viewer has at least one pending notification. |
+
+
+<a id="chatto-api-v1-NotificationService-DismissNotification"></a>
+
+### DismissNotification
+
+Dismisses one pending notification. Already-dismissed notifications are
+treated as idempotent success.
+
+```http
+POST /api/connect/chatto.api.v1.NotificationService/DismissNotification
+```
+
+<a id="chatto-api-v1-DismissNotificationRequest"></a>
+
+#### Input: DismissNotificationRequest
+
+Request to dismiss one pending notification.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `notification_id` | `string` | Required. Notification to dismiss. |
+
+
+<a id="chatto-api-v1-DismissNotificationResponse"></a>
+
+#### Result: DismissNotificationResponse
+
+Result of dismissing one pending notification.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `dismissed` | `bool` | True when the notification is no longer pending. |
+
+
+<a id="chatto-api-v1-NotificationService-DismissAllNotifications"></a>
+
+### DismissAllNotifications
+
+Dismisses all pending notifications.
+
+```http
+POST /api/connect/chatto.api.v1.NotificationService/DismissAllNotifications
+```
+
+<a id="chatto-api-v1-DismissAllNotificationsRequest"></a>
+
+#### Input: DismissAllNotificationsRequest
+
+Request to dismiss all pending notifications.
+
+
+<a id="chatto-api-v1-DismissAllNotificationsResponse"></a>
+
+#### Result: DismissAllNotificationsResponse
+
+Result of dismissing all pending notifications.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `dismissed_count` | `int32` | Number of notifications dismissed. |
+
+
+<a id="chatto-api-v1-PushNotificationService"></a>
+
+## PushNotificationService
+
+Browser Web Push subscription commands for the current user.
+
+<a id="chatto-api-v1-PushNotificationService-Subscribe"></a>
+
+### Subscribe
+
+Stores or updates the caller's browser push subscription.
+
+The server must have Web Push configured. Clients normally call this after
+the browser grants notification permission and returns a PushSubscription.
+
+```http
+POST /api/connect/chatto.api.v1.PushNotificationService/Subscribe
+```
+
+<a id="chatto-api-v1-SubscribePushRequest"></a>
+
+#### Input: SubscribePushRequest
+
+Request to store a PushSubscription returned by the browser Push API.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `endpoint` | `string` | Push service endpoint URL. |
+| `p256dh` | `string` | Client P-256 ECDH public key from PushSubscription.keys.p256dh. |
+| `auth` | `string` | Authentication secret from PushSubscription.keys.auth. |
+| `user_agent` | `optional string` | Optional browser user-agent string for device identification. |
+
+
+<a id="chatto-api-v1-SubscribePushResponse"></a>
+
+#### Result: SubscribePushResponse
+
+Response from storing a browser push subscription.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `subscribed` | `bool` | True when the subscription was stored. |
+
+
+<a id="chatto-api-v1-PushNotificationService-Unsubscribe"></a>
+
+### Unsubscribe
+
+Removes the caller's browser push subscription by endpoint.
+
+The call is idempotent: removing an unknown endpoint still succeeds.
+
+```http
+POST /api/connect/chatto.api.v1.PushNotificationService/Unsubscribe
+```
+
+<a id="chatto-api-v1-UnsubscribePushRequest"></a>
+
+#### Input: UnsubscribePushRequest
+
+Request to remove a browser push subscription.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `endpoint` | `string` | Push service endpoint URL to remove. |
+
+
+<a id="chatto-api-v1-UnsubscribePushResponse"></a>
+
+#### Result: UnsubscribePushResponse
+
+Response from removing a browser push subscription.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `unsubscribed` | `bool` | True when the request completed. |
+
+
+<a id="chatto-api-v1-RoleService"></a>
+
+## RoleService
+
+Provides authenticated reads for public role metadata.
+
+<a id="chatto-api-v1-RoleService-ListRoles"></a>
+
+### ListRoles
+
+Lists the current role catalog as a finite snapshot. Requires an
+authenticated user.
+
+```http
+POST /api/connect/chatto.api.v1.RoleService/ListRoles
+```
+
+<a id="chatto-api-v1-ListRolesRequest"></a>
+
+#### Input: ListRolesRequest
+
+Request the current role catalog.
+
+
+<a id="chatto-api-v1-ListRolesResponse"></a>
+
+#### Result: ListRolesResponse
+
+Snapshot of the role catalog visible to the authenticated viewer.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `roles` | repeated [`Role`](#chatto-api-v1-Role) | Roles sorted by position. |
+
+
+<a id="chatto-api-v1-RoleService-GetRole"></a>
+
+### GetRole
+
+Gets one public role by stable name. Returns NOT_FOUND when the role is
+unknown.
+
+```http
+POST /api/connect/chatto.api.v1.RoleService/GetRole
+```
+
+<a id="chatto-api-v1-GetRoleRequest"></a>
+
+#### Input: GetRoleRequest
+
+Request one public role by stable role name.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `name` | `string` | Required stable role name. |
+
+
+<a id="chatto-api-v1-GetRoleResponse"></a>
+
+#### Result: GetRoleResponse
+
+Public role lookup response.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `role` | [`Role`](#chatto-api-v1-Role) | Requested role. |
+
+
+<a id="chatto-api-v1-RoleService-BatchGetRoles"></a>
+
+### BatchGetRoles
+
+Gets public role records for multiple role names referenced by member rows,
+mentions, or integration clients.
+
+```http
+POST /api/connect/chatto.api.v1.RoleService/BatchGetRoles
+```
+
+<a id="chatto-api-v1-BatchGetRolesRequest"></a>
+
+#### Input: BatchGetRolesRequest
+
+Request public role records for a set of stable role names.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `names` | `repeated string` | Required role names. Unknown names are omitted from the response. |
+
+
+<a id="chatto-api-v1-BatchGetRolesResponse"></a>
+
+#### Result: BatchGetRolesResponse
+
+Batch public role response.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `roles` | repeated [`Role`](#chatto-api-v1-Role) | Found roles. The server preserves first-seen request order and de-duplicates repeated names. |
 
 
 <a id="chatto-api-v1-RoomDirectoryService"></a>
@@ -3651,12 +3651,8 @@ requests.
 | `echo_of_event_id` | `string` | Event ID this event echoes into the current view, when applicable. Echoes allow thread activity to appear in another timeline context. |
 | `echo_from_thread_root_event_id` | `string` | Thread root ID of the echoed event, when applicable. |
 | `channel_echo_event_id` | `string` | Channel timeline event ID for a thread echo, when applicable. |
-| `reply_count` | `int32` | Number of replies in this message's thread. |
-| `last_reply_at` | `google.protobuf.Timestamp` | Creation time of the most recent reply in this message's thread. |
-| `thread_participant_preview_user_ids` | `repeated string` | Preview of up to five user IDs that have participated in this message's thread. |
-| `thread_participant_count` | `int32` | Total number of distinct users that have participated in this message's thread. |
-| `viewer_is_following_thread` | `optional bool` | Whether the current user follows this message's thread, when known. |
 | `reactions` | repeated [`MessageReaction`](#chatto-api-v1-MessageReaction) | Reaction summaries for this message. |
+| `thread` | [`ThreadSummary`](#chatto-api-v1-ThreadSummary) | Aggregated thread state, when known for a thread root message. |
 
 
 
@@ -3755,6 +3751,36 @@ One transcoded video rendition.
 
 
 
+<a id="chatto-api-v1-ThreadSummary"></a>
+
+### ThreadSummary
+
+Aggregated state for one message thread.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `thread_root_event_id` | `string` | Event ID of the root message for the thread. |
+| `reply_count` | `int32` | Number of replies in this message's thread. |
+| `last_reply_at` | `google.protobuf.Timestamp` | Creation time of the most recent reply in this message's thread. |
+| `participant_preview_user_ids` | `repeated string` | Preview of up to five user IDs that have participated in this message's thread. |
+| `participant_count` | `int32` | Total number of distinct users that have participated in this message's thread. |
+| `viewer_state` | [`ThreadViewerState`](#chatto-api-v1-ThreadViewerState) | State resolved for the current user. |
+
+
+
+<a id="chatto-api-v1-ThreadViewerState"></a>
+
+### ThreadViewerState
+
+Viewer-specific state for one message thread.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `is_following` | `optional bool` | Whether the current user follows this message's thread, when known. |
+| `has_unread` | `optional bool` | True when the thread has unread replies for the current user, when known. |
+
+
+
 <a id="chatto-api-v1-RoomAttachmentListItem"></a>
 
 ### RoomAttachmentListItem
@@ -3809,122 +3835,6 @@ surfaces.
 | `user` | [`User`](#chatto-api-v1-User) | Public user fields. |
 | `roles` | `repeated string` | Explicit roles assigned to the user. Member listings include the virtual `everyone` role for parity with Chatto's permission model. |
 | `created_at` | `google.protobuf.Timestamp` | Account creation time when known. |
-
-
-
-<a id="chatto-api-v1-DirectMessageNotification"></a>
-
-### DirectMessageNotification
-
-Direct-message notification payload.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `room_id` | `string` | DM room where the message was posted. |
-| `event_id` | `string` | Message event ID. |
-
-
-
-<a id="chatto-api-v1-MentionNotification"></a>
-
-### MentionNotification
-
-Mention notification payload.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `room` | [`NotificationRoom`](#chatto-api-v1-NotificationRoom) | Room where the mention occurred. |
-| `event_id` | `string` | Message event ID. |
-| `thread_root_event_id` | `optional string` | Thread root event ID when the mention happened inside a thread. |
-
-
-
-<a id="chatto-api-v1-NotificationItem"></a>
-
-### NotificationItem
-
-One pending notification for the authenticated viewer.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `id` | `string` | Stable notification ID. |
-| `created_at` | `google.protobuf.Timestamp` | Creation time. |
-| `actor` | [`User`](#chatto-api-v1-User) | User who triggered the notification, when still resolvable. |
-| `kind.direct_message` | [`DirectMessageNotification`](#chatto-api-v1-DirectMessageNotification) | Direct-message notification. |
-| `kind.mention` | [`MentionNotification`](#chatto-api-v1-MentionNotification) | Mention notification. |
-| `kind.reply` | [`ReplyNotification`](#chatto-api-v1-ReplyNotification) | Reply notification. |
-| `kind.room_message` | [`RoomMessageNotification`](#chatto-api-v1-RoomMessageNotification) | All-messages room notification. |
-
-
-
-<a id="chatto-api-v1-NotificationRoom"></a>
-
-### NotificationRoom
-
-Room summary embedded in notification responses.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `id` | `string` | Stable room ID. |
-| `name` | `string` | Room display name. Empty for DM rooms. |
-
-
-
-<a id="chatto-api-v1-ReplyNotification"></a>
-
-### ReplyNotification
-
-Reply notification payload.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `room` | [`NotificationRoom`](#chatto-api-v1-NotificationRoom) | Room where the reply occurred. |
-| `event_id` | `string` | Reply event ID. |
-| `in_reply_to_id` | `string` | Event ID of the message being replied to. |
-| `thread_root_event_id` | `optional string` | Thread root event ID when the reply happened inside a thread. |
-
-
-
-<a id="chatto-api-v1-RoomMessageNotification"></a>
-
-### RoomMessageNotification
-
-All-messages room notification payload.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `room` | [`NotificationRoom`](#chatto-api-v1-NotificationRoom) | Room where the message was posted. |
-| `event_id` | `string` | Message event ID. |
-
-
-
-<a id="chatto-api-v1-RoomNotificationCount"></a>
-
-### RoomNotificationCount
-
-Pending notification count for one room.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `room_id` | `string` | Room ID. |
-| `total_count` | `int32` | Pending notification count for the authenticated viewer in this room. |
-
-
-
-<a id="chatto-api-v1-Role"></a>
-
-### Role
-
-Public role metadata used for rendering role mentions, labels, and catalogs.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `name` | `string` | Stable role name used in permission and assignment records. |
-| `display_name` | `string` | Display name shown in user-facing role UIs. |
-| `description` | `string` | Optional role description. |
-| `is_system` | `bool` | Whether this is a built-in role. |
-| `position` | `int32` | Display/order position. |
-| `pingable` | `bool` | Whether messages may notify users assigned to this role. |
 
 
 
@@ -4052,6 +3962,123 @@ Active channel room ban with optional hydrated room and user references.
 
 
 
+<a id="chatto-api-v1-RoomSummary"></a>
+
+### RoomSummary
+
+Lightweight room reference for cross-resource rows.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | Stable room ID. |
+| `kind` | [`RoomKind`](#chatto-api-v1-RoomKind) | Room kind. |
+| `name` | `string` | Room name. Direct-message rooms may have an empty name because clients derive their display label from participants. |
+
+
+
+<a id="chatto-api-v1-DirectMessageNotification"></a>
+
+### DirectMessageNotification
+
+Direct-message notification payload.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `event_id` | `string` | Message event ID. |
+| `room` | [`RoomSummary`](#chatto-api-v1-RoomSummary) | DM room where the message was posted. |
+
+
+
+<a id="chatto-api-v1-MentionNotification"></a>
+
+### MentionNotification
+
+Mention notification payload.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room` | [`RoomSummary`](#chatto-api-v1-RoomSummary) | Room where the mention occurred. |
+| `event_id` | `string` | Message event ID. |
+| `thread_root_event_id` | `optional string` | Thread root event ID when the mention happened inside a thread. |
+
+
+
+<a id="chatto-api-v1-NotificationItem"></a>
+
+### NotificationItem
+
+One pending notification for the authenticated viewer.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | Stable notification ID. |
+| `created_at` | `google.protobuf.Timestamp` | Creation time. |
+| `actor` | [`User`](#chatto-api-v1-User) | User who triggered the notification, when still resolvable. |
+| `kind.direct_message` | [`DirectMessageNotification`](#chatto-api-v1-DirectMessageNotification) | Direct-message notification. |
+| `kind.mention` | [`MentionNotification`](#chatto-api-v1-MentionNotification) | Mention notification. |
+| `kind.reply` | [`ReplyNotification`](#chatto-api-v1-ReplyNotification) | Reply notification. |
+| `kind.room_message` | [`RoomMessageNotification`](#chatto-api-v1-RoomMessageNotification) | All-messages room notification. |
+
+
+
+<a id="chatto-api-v1-ReplyNotification"></a>
+
+### ReplyNotification
+
+Reply notification payload.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room` | [`RoomSummary`](#chatto-api-v1-RoomSummary) | Room where the reply occurred. |
+| `event_id` | `string` | Reply event ID. |
+| `in_reply_to_id` | `string` | Event ID of the message being replied to. |
+| `thread_root_event_id` | `optional string` | Thread root event ID when the reply happened inside a thread. |
+
+
+
+<a id="chatto-api-v1-RoomMessageNotification"></a>
+
+### RoomMessageNotification
+
+All-messages room notification payload.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room` | [`RoomSummary`](#chatto-api-v1-RoomSummary) | Room where the message was posted. |
+| `event_id` | `string` | Message event ID. |
+
+
+
+<a id="chatto-api-v1-RoomNotificationCount"></a>
+
+### RoomNotificationCount
+
+Pending notification count for one room.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room_id` | `string` | Room ID. |
+| `total_count` | `int32` | Pending notification count for the authenticated viewer in this room. |
+
+
+
+<a id="chatto-api-v1-Role"></a>
+
+### Role
+
+Public role metadata used for rendering role mentions, labels, and catalogs.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `name` | `string` | Stable role name used in permission and assignment records. |
+| `display_name` | `string` | Display name shown in user-facing role UIs. |
+| `description` | `string` | Optional role description. |
+| `is_system` | `bool` | Whether this is a built-in role. |
+| `position` | `int32` | Display/order position. |
+| `pingable` | `bool` | Whether messages may notify users assigned to this role. |
+
+
+
 <a id="chatto-api-v1-RoomGroup"></a>
 
 ### RoomGroup
@@ -4089,7 +4116,21 @@ Viewer-specific state for one room group.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `can_create_room` | `bool` | True when the current user can create rooms in this group. |
+| `permissions` | repeated [`PermissionGrant`](#chatto-api-v1-PermissionGrant) | Effective group-scoped permission decisions after group state constraints. |
+
+
+
+<a id="chatto-api-v1-RoomViewerState"></a>
+
+### RoomViewerState
+
+Viewer-specific state and permission decisions for one room.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `is_member` | `bool` | True when the current user is an effective room member. |
+| `has_unread` | `bool` | True when the room has unread root messages for the current user. |
+| `permissions` | repeated [`PermissionGrant`](#chatto-api-v1-PermissionGrant) | Effective room-scoped permission decisions after room state constraints. |
 
 
 
@@ -4103,18 +4144,7 @@ viewer.
 | Field | Type | Description |
 | --- | --- | --- |
 | `room` | [`Room`](#chatto-api-v1-Room) | Public room metadata. |
-| `is_member` | `bool` | True when the current user is an effective room member. |
-| `has_unread` | `bool` | True when the room has unread root messages for the current user. |
-| `can_list_room` | `bool` | True when the room can appear in directory surfaces for the current user. |
-| `can_join_room` | `bool` | True when the current user can join this room. |
-| `can_post_message` | `bool` | True when the current user can post new root messages. |
-| `can_post_in_thread` | `bool` | True when the current user can post thread replies. |
-| `can_attach` | `bool` | True when the current user can attach files to messages. |
-| `can_react` | `bool` | True when the current user can add and remove reactions. |
-| `can_echo_message` | `bool` | True when the current user can echo thread replies to the main room. |
-| `can_manage_others_message` | `bool` | True when the current user can edit or delete other users' messages. |
-| `can_manage_room` | `bool` | True when the current user can configure this room. |
-| `can_ban_room_members` | `bool` | True when the current user can ban members from this room. |
+| `viewer_state` | [`RoomViewerState`](#chatto-api-v1-RoomViewerState) | State and permission decisions resolved for the current user. |
 
 
 
@@ -4202,13 +4232,9 @@ One followed thread for the current user.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `room_id` | `string` | Room containing the thread. |
-| `room_name` | `string` | Current display name of the room. |
-| `thread_root_event_id` | `string` | Event ID of the root message for the thread. |
 | `root_message` | [`Message`](#chatto-api-v1-Message) | Renderable root message, when the root is still visible. |
-| `reply_count` | `int32` | Number of replies in the thread. |
-| `last_reply_at` | `google.protobuf.Timestamp` | Creation time of the latest reply, when the thread has replies. |
-| `has_unread` | `bool` | True when the current user has unread replies in the thread. |
+| `room` | [`RoomSummary`](#chatto-api-v1-RoomSummary) | Room containing the thread. |
+| `thread` | [`ThreadSummary`](#chatto-api-v1-ThreadSummary) | Aggregated thread state. |
 
 
 

--- a/apps/frontend/e2e/fixtures/connectHelpers.ts
+++ b/apps/frontend/e2e/fixtures/connectHelpers.ts
@@ -64,7 +64,10 @@ interface NotificationPreferenceResponse {
 }
 
 interface ListRoomsResponse {
-  rooms?: Array<{ room?: { id?: string; name?: string }; hasUnread?: boolean }>;
+  rooms?: Array<{
+    room?: { id?: string; name?: string };
+    viewerState?: { hasUnread?: boolean };
+  }>;
 }
 
 interface ListRoomGroupsResponse {
@@ -191,7 +194,7 @@ async function getRoomUnreadViaConnect(client: ConnectClient, roomId: string): P
   if (!room) {
     throw new Error(`Room "${roomId}" not found`);
   }
-  return room.hasUnread ?? false;
+  return room.viewerState?.hasUnread ?? false;
 }
 
 export async function waitForServerUnreadViaConnect(
@@ -200,10 +203,7 @@ export async function waitForServerUnreadViaConnect(
   timeout = DEFAULT_POLL_TIMEOUT
 ): Promise<void> {
   await expect(async () => {
-    const data = await connectPost<ViewerResponse>(
-      page,
-      'chatto.api.v1.ViewerService/GetViewer'
-    );
+    const data = await connectPost<ViewerResponse>(page, 'chatto.api.v1.ViewerService/GetViewer');
     expect(data.viewerState?.hasUnreadRooms ?? false).toBe(expected);
   }).toPass({ timeout, intervals: [100, 250, 500, 1000] });
 }

--- a/apps/frontend/src/lib/api-client-tests/messages.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/messages.spec.ts
@@ -94,7 +94,7 @@ describe('createMessageAPI', () => {
           createdAt: Timestamp.fromDate(new Date('2026-06-20T10:00:00Z')),
           roomId: 'room-1',
           body: 'hello',
-          viewerIsFollowingThread: true
+          thread: { viewerState: { isFollowing: true } }
         })
       })
     );

--- a/apps/frontend/src/lib/api-client-tests/notifications.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/notifications.spec.ts
@@ -128,7 +128,10 @@ describe('createNotificationAPI', () => {
       notifications: [
         {
           id: 'n2',
-          kind: { case: 'directMessage', value: { roomId: 'dm-1', eventId: 'event-2' } }
+          kind: {
+            case: 'directMessage',
+            value: { room: { id: 'dm-1', name: 'Alice' }, eventId: 'event-2' }
+          }
         }
       ]
     });

--- a/apps/frontend/src/lib/api-client-tests/roomDirectory.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/roomDirectory.spec.ts
@@ -5,6 +5,19 @@ import { RoomDirectoryScope } from '@chatto/api-types/api/v1/room_directory_pb';
 import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
 import { createRoomDirectoryAPI } from '$lib/api-client/roomDirectory';
 
+const Permission = {
+  Attach: 'message.attach',
+  BanMember: 'room.ban-member',
+  CreateRoom: 'room.create',
+  EchoMessage: 'message.echo',
+  JoinRoom: 'room.join',
+  ManageMessage: 'message.manage',
+  ManageRoom: 'room.manage',
+  PostInThread: 'message.post-in-thread',
+  PostMessage: 'message.post',
+  React: 'message.react'
+} as const;
+
 const mocks = vi.hoisted(() => ({
   createClient: vi.fn(),
   createConnectTransport: vi.fn(),
@@ -65,9 +78,11 @@ describe('createRoomDirectoryAPI', () => {
             archived: false,
             universal: true
           },
-          isMember: true,
-          hasUnread: true,
-          canJoinRoom: false
+          viewerState: roomViewerState({
+            isMember: true,
+            hasUnread: true,
+            [Permission.JoinRoom]: false
+          })
         },
         {
           room: {
@@ -77,9 +92,11 @@ describe('createRoomDirectoryAPI', () => {
             archived: true,
             universal: false
           },
-          isMember: true,
-          hasUnread: false,
-          canJoinRoom: true
+          viewerState: roomViewerState({
+            isMember: true,
+            hasUnread: false,
+            [Permission.JoinRoom]: true
+          })
         },
         { hasUnread: true }
       ]
@@ -137,17 +154,19 @@ describe('createRoomDirectoryAPI', () => {
           archived: false,
           universal: true
         },
-        isMember: true,
-        hasUnread: true,
-        canJoinRoom: false,
-        canPostMessage: true,
-        canPostInThread: true,
-        canAttach: false,
-        canReact: true,
-        canEchoMessage: true,
-        canManageOthersMessage: false,
-        canManageRoom: true,
-        canBanRoomMembers: false
+        viewerState: roomViewerState({
+          isMember: true,
+          hasUnread: true,
+          [Permission.JoinRoom]: false,
+          [Permission.PostMessage]: true,
+          [Permission.PostInThread]: true,
+          [Permission.Attach]: false,
+          [Permission.React]: true,
+          [Permission.EchoMessage]: true,
+          [Permission.ManageMessage]: false,
+          [Permission.ManageRoom]: true,
+          [Permission.BanMember]: false
+        })
       }
     });
 
@@ -221,17 +240,19 @@ describe('createRoomDirectoryAPI', () => {
             archived: false,
             universal: true
           },
-          isMember: true,
-          hasUnread: false,
-          canJoinRoom: false,
-          canPostMessage: true,
-          canPostInThread: false,
-          canAttach: true,
-          canReact: true,
-          canEchoMessage: false,
-          canManageOthersMessage: false,
-          canManageRoom: false,
-          canBanRoomMembers: false
+          viewerState: roomViewerState({
+            isMember: true,
+            hasUnread: false,
+            [Permission.JoinRoom]: false,
+            [Permission.PostMessage]: true,
+            [Permission.PostInThread]: false,
+            [Permission.Attach]: true,
+            [Permission.React]: true,
+            [Permission.EchoMessage]: false,
+            [Permission.ManageMessage]: false,
+            [Permission.ManageRoom]: false,
+            [Permission.BanMember]: false
+          })
         }
       ]
     });
@@ -260,7 +281,7 @@ describe('createRoomDirectoryAPI', () => {
         {
           id: 'g1',
           name: 'Lobby',
-          viewerState: { canCreateRoom: true },
+          viewerState: groupViewerState(true),
           items: [
             {
               item: {
@@ -331,7 +352,7 @@ describe('createRoomDirectoryAPI', () => {
         {
           id: 'g1',
           name: 'Lobby',
-          viewerState: { canCreateRoom: false },
+          viewerState: groupViewerState(false),
           items: []
         }
       ]
@@ -357,7 +378,7 @@ describe('createRoomDirectoryAPI', () => {
     const group = {
       id: 'g1',
       name: 'Lobby',
-      viewerState: { canCreateRoom: true },
+      viewerState: groupViewerState(true),
       items: [
         {
           item: {
@@ -429,3 +450,28 @@ describe('createRoomDirectoryAPI', () => {
     expect(mocks.handleAuthenticationRequired).toHaveBeenCalledWith('remote');
   });
 });
+
+function roomViewerState(
+  input: Record<string, boolean> & { isMember: boolean; hasUnread: boolean }
+) {
+  const { isMember, hasUnread, ...permissions } = input;
+  return {
+    isMember,
+    hasUnread,
+    permissions: Object.entries(permissions).map(([permission, granted]) => ({
+      permission,
+      granted
+    }))
+  };
+}
+
+function groupViewerState(canCreateRoom: boolean) {
+  return {
+    permissions: [
+      {
+        permission: Permission.CreateRoom,
+        granted: canCreateRoom
+      }
+    ]
+  };
+}

--- a/apps/frontend/src/lib/api-client-tests/roomTimeline.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/roomTimeline.spec.ts
@@ -290,10 +290,12 @@ describe('roomTimelinePageToEventConnectionPage', () => {
                     })
                   })
                 ],
-                replyCount: 1,
-                threadParticipantPreviewUserIds: ['u2'],
-                threadParticipantCount: 1,
-                viewerIsFollowingThread: true,
+                thread: {
+                  replyCount: 1,
+                  participantPreviewUserIds: ['u2'],
+                  participantCount: 1,
+                  viewerState: { isFollowing: true }
+                },
                 reactions: [
                   {
                     emoji: 'thumbsup',

--- a/apps/frontend/src/lib/api-client-tests/threads.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/threads.spec.ts
@@ -47,13 +47,14 @@ describe('createThreadAPI', () => {
     mocks.listFollowedThreads.mockResolvedValue({
       threads: [
         {
-          roomId: 'room-1',
-          roomName: 'general',
-          threadRootEventId: 'root-1',
-          rootMessage: undefined,
-          replyCount: 2,
-          lastReplyAt: { toDate: () => lastReplyAt },
-          hasUnread: true
+          room: { id: 'room-1', name: 'general' },
+          thread: {
+            threadRootEventId: 'root-1',
+            replyCount: 2,
+            lastReplyAt: { toDate: () => lastReplyAt },
+            viewerState: { hasUnread: true }
+          },
+          rootMessage: undefined
         }
       ],
       page: { totalCount: 3n, hasMore: true },

--- a/apps/frontend/src/lib/api-client/notifications.ts
+++ b/apps/frontend/src/lib/api-client/notifications.ts
@@ -1,18 +1,13 @@
-import {
-  authHeaders,
-  Code,
-  ConnectError,
-  createChattoClient,
-} from "./connect.js";
-import { NotificationService } from "@chatto/api-types/api/v1/notifications_connect";
+import { authHeaders, Code, ConnectError, createChattoClient } from './connect.js';
+import { NotificationService } from '@chatto/api-types/api/v1/notifications_connect';
 import type {
   ListRoomNotificationsResponse,
   ListNotificationsResponse,
-  NotificationItem as APINotificationItem,
-} from "@chatto/api-types/api/v1/notifications_pb";
-import type { User as APIUser } from "@chatto/api-types/api/v1/users_pb";
-import { PresenceStatus as APIPresenceStatus } from "@chatto/api-types/api/v1/presence_pb";
-import { PresenceStatus } from "./renderTypes.js";
+  NotificationItem as APINotificationItem
+} from '@chatto/api-types/api/v1/notifications_pb';
+import type { User as APIUser } from '@chatto/api-types/api/v1/users_pb';
+import { PresenceStatus as APIPresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+import { PresenceStatus } from './renderTypes.js';
 
 export type NotificationAPIConfig = {
   baseUrl: string;
@@ -35,14 +30,13 @@ export type NotificationActor = {
 };
 
 export const NotificationItemKind = {
-  DirectMessage: "directMessage",
-  Mention: "mention",
-  Reply: "reply",
-  RoomMessage: "roomMessage",
+  DirectMessage: 'directMessage',
+  Mention: 'mention',
+  Reply: 'reply',
+  RoomMessage: 'roomMessage'
 } as const;
 
-export type NotificationItemKind =
-  (typeof NotificationItemKind)[keyof typeof NotificationItemKind];
+export type NotificationItemKind = (typeof NotificationItemKind)[keyof typeof NotificationItemKind];
 
 export type DirectMessageNotificationItem = {
   kind: typeof NotificationItemKind.DirectMessage;
@@ -101,54 +95,33 @@ export type NotificationPage = {
 export function createNotificationAPI(config: NotificationAPIConfig) {
   const client = createChattoClient(NotificationService, config);
   const headers = () => authHeaders(config);
-  const listRoomNotificationCounts = async (): Promise<
-    Record<string, number>
-  > => {
-    const response = await client.listRoomNotificationCounts(
-      {},
-      { headers: headers() },
-    );
+  const listRoomNotificationCounts = async (): Promise<Record<string, number>> => {
+    const response = await client.listRoomNotificationCounts({}, { headers: headers() });
     return Object.fromEntries(
-      response.roomCounts.map(
-        (count) => [count.roomId, count.totalCount] as const,
-      ),
+      response.roomCounts.map((count) => [count.roomId, count.totalCount] as const)
     );
   };
 
   return {
     async listNotifications(limit = 50, offset = 0): Promise<NotificationPage> {
       return notificationPage(
-        await client.listNotifications(
-          { page: { limit, offset } },
-          { headers: headers() },
-        ),
+        await client.listNotifications({ page: { limit, offset } }, { headers: headers() })
       );
     },
 
-    async listRoomNotifications(
-      roomId: string,
-      limit = 1,
-      offset = 0,
-    ): Promise<NotificationPage> {
+    async listRoomNotifications(roomId: string, limit = 1, offset = 0): Promise<NotificationPage> {
       return notificationPage(
         await client.listRoomNotifications(
           { roomId, page: { limit, offset } },
-          { headers: headers() },
-        ),
+          { headers: headers() }
+        )
       );
     },
 
-    async getNotification(
-      notificationId: string,
-    ): Promise<NotificationItem | null> {
+    async getNotification(notificationId: string): Promise<NotificationItem | null> {
       try {
-        const response = await client.getNotification(
-          { notificationId },
-          { headers: headers() },
-        );
-        return response.notification
-          ? notificationItem(response.notification)
-          : null;
+        const response = await client.getNotification({ notificationId }, { headers: headers() });
+        return response.notification ? notificationItem(response.notification) : null;
       } catch (err) {
         if (err instanceof ConnectError && err.code === Code.NotFound) {
           return null;
@@ -157,12 +130,10 @@ export function createNotificationAPI(config: NotificationAPIConfig) {
       }
     },
 
-    async batchGetNotifications(
-      notificationIds: string[],
-    ): Promise<NotificationItem[]> {
+    async batchGetNotifications(notificationIds: string[]): Promise<NotificationItem[]> {
       const response = await client.batchGetNotifications(
         { notificationIds },
-        { headers: headers() },
+        { headers: headers() }
       );
       return response.notifications.flatMap((item) => {
         const mapped = notificationItem(item);
@@ -171,8 +142,7 @@ export function createNotificationAPI(config: NotificationAPIConfig) {
     },
 
     async hasNotifications(): Promise<boolean> {
-      return (await client.hasNotifications({}, { headers: headers() }))
-        .hasNotifications;
+      return (await client.hasNotifications({}, { headers: headers() })).hasNotifications;
     },
 
     async listRoomNotificationCounts(): Promise<Record<string, number>> {
@@ -184,25 +154,20 @@ export function createNotificationAPI(config: NotificationAPIConfig) {
     },
 
     async dismissNotification(notificationId: string): Promise<boolean> {
-      return (
-        await client.dismissNotification(
-          { notificationId },
-          { headers: headers() },
-        )
-      ).dismissed;
+      return (await client.dismissNotification({ notificationId }, { headers: headers() }))
+        .dismissed;
     },
 
     async dismissAllNotifications(): Promise<number> {
-      return (await client.dismissAllNotifications({}, { headers: headers() }))
-        .dismissedCount;
-    },
+      return (await client.dismissAllNotifications({}, { headers: headers() })).dismissedCount;
+    }
   };
 }
 
 export type NotificationAPI = ReturnType<typeof createNotificationAPI>;
 
 function notificationPage(
-  response: ListNotificationsResponse | ListRoomNotificationsResponse,
+  response: ListNotificationsResponse | ListRoomNotificationsResponse
 ): NotificationPage {
   return {
     items: response.notifications.flatMap((item) => {
@@ -210,7 +175,7 @@ function notificationPage(
       return mapped ? [mapped] : [];
     }),
     totalCount: Number(response.page?.totalCount ?? 0),
-    hasMore: response.page?.hasMore ?? false,
+    hasMore: response.page?.hasMore ?? false
   };
 }
 
@@ -218,20 +183,19 @@ function notificationItem(item: APINotificationItem): NotificationItem | null {
   const actor = notificationActor(item.actor);
   const base = {
     id: item.id,
-    createdAt:
-      item.createdAt?.toDate().toISOString() ?? new Date(0).toISOString(),
-    actor,
+    createdAt: item.createdAt?.toDate().toISOString() ?? new Date(0).toISOString(),
+    actor
   };
 
   switch (item.kind.case) {
-    case "directMessage":
+    case 'directMessage':
       return {
         kind: NotificationItemKind.DirectMessage,
         ...base,
         summary: notificationSummary(actor, NotificationItemKind.DirectMessage),
-        room: { id: item.kind.value.roomId },
+        room: { id: item.kind.value.room?.id ?? '' }
       };
-    case "mention":
+    case 'mention':
       return {
         kind: NotificationItemKind.Mention,
         ...base,
@@ -240,9 +204,9 @@ function notificationItem(item: APINotificationItem): NotificationItem | null {
           ? { id: item.kind.value.room.id, name: item.kind.value.room.name }
           : null,
         mentionEventId: item.kind.value.eventId,
-        mentionInThread: item.kind.value.threadRootEventId ?? null,
+        mentionInThread: item.kind.value.threadRootEventId ?? null
       };
-    case "reply":
+    case 'reply':
       return {
         kind: NotificationItemKind.Reply,
         ...base,
@@ -252,9 +216,9 @@ function notificationItem(item: APINotificationItem): NotificationItem | null {
           : null,
         replyEventId: item.kind.value.eventId,
         inReplyToId: item.kind.value.inReplyToId,
-        replyInThread: item.kind.value.threadRootEventId ?? null,
+        replyInThread: item.kind.value.threadRootEventId ?? null
       };
-    case "roomMessage":
+    case 'roomMessage':
       return {
         kind: NotificationItemKind.RoomMessage,
         ...base,
@@ -262,35 +226,28 @@ function notificationItem(item: APINotificationItem): NotificationItem | null {
         roomMsgRoom: item.kind.value.room
           ? { id: item.kind.value.room.id, name: item.kind.value.room.name }
           : null,
-        roomMsgEventId: item.kind.value.eventId,
+        roomMsgEventId: item.kind.value.eventId
       };
     default:
       return null;
   }
 }
 
-function notificationSummary(
-  actor: NotificationActor | null,
-  kind: NotificationItemKind,
-): string {
+function notificationSummary(actor: NotificationActor | null, kind: NotificationItemKind): string {
   const actorName = actor?.displayName || null;
   switch (kind) {
     case NotificationItemKind.DirectMessage:
-      return actorName ? `${actorName} sent you a message` : "New message";
+      return actorName ? `${actorName} sent you a message` : 'New message';
     case NotificationItemKind.Mention:
-      return actorName ? `${actorName} mentioned you` : "You were mentioned";
+      return actorName ? `${actorName} mentioned you` : 'You were mentioned';
     case NotificationItemKind.Reply:
-      return actorName
-        ? `${actorName} replied to your message`
-        : "New reply to your message";
+      return actorName ? `${actorName} replied to your message` : 'New reply to your message';
     case NotificationItemKind.RoomMessage:
-      return actorName ? `${actorName} posted a message` : "New message";
+      return actorName ? `${actorName} posted a message` : 'New message';
   }
 }
 
-function notificationActor(
-  actor: APIUser | undefined,
-): NotificationActor | null {
+function notificationActor(actor: APIUser | undefined): NotificationActor | null {
   if (!actor) return null;
   return {
     id: actor.id,
@@ -303,10 +260,9 @@ function notificationActor(
       ? {
           emoji: actor.customStatus.emoji,
           text: actor.customStatus.text,
-          expiresAt:
-            actor.customStatus.expiresAt?.toDate().toISOString() ?? null,
+          expiresAt: actor.customStatus.expiresAt?.toDate().toISOString() ?? null
         }
-      : null,
+      : null
   };
 }
 

--- a/apps/frontend/src/lib/api-client/roomDirectory.ts
+++ b/apps/frontend/src/lib/api-client/roomDirectory.ts
@@ -10,6 +10,8 @@ import { RoomDirectoryService } from '@chatto/api-types/api/v1/room_directory_co
 import type {
   RoomGroup,
   RoomGroupItem,
+  RoomGroupViewerState,
+  RoomViewerState,
   RoomWithViewerState
 } from '@chatto/api-types/api/v1/room_directory_pb';
 import { RoomDirectoryScope } from '@chatto/api-types/api/v1/room_directory_pb';
@@ -69,6 +71,19 @@ export type DirectoryRoomGroup = {
 
 export { RoomDirectoryScope };
 export { RoomKind };
+
+const RoomPermission = {
+  Attach: 'message.attach',
+  BanMember: 'room.ban-member',
+  CreateRoom: 'room.create',
+  EchoMessage: 'message.echo',
+  JoinRoom: 'room.join',
+  ManageMessage: 'message.manage',
+  ManageRoom: 'room.manage',
+  PostInThread: 'message.post-in-thread',
+  PostMessage: 'message.post',
+  React: 'message.react'
+} as const;
 
 export function createRoomDirectoryAPI(config: RoomDirectoryAPIConfig) {
   const directory = createChattoClient(RoomDirectoryService, config);
@@ -152,14 +167,14 @@ function mapDirectoryRoomDetails(
 
   return {
     ...summary,
-    canPostMessage: entry.canPostMessage,
-    canPostInThread: entry.canPostInThread,
-    canAttach: entry.canAttach,
-    canReact: entry.canReact,
-    canEchoMessage: entry.canEchoMessage,
-    canManageOthersMessage: entry.canManageOthersMessage,
-    canManageRoom: entry.canManageRoom,
-    canBanRoomMembers: entry.canBanRoomMembers
+    canPostMessage: hasRoomPermission(entry.viewerState, RoomPermission.PostMessage),
+    canPostInThread: hasRoomPermission(entry.viewerState, RoomPermission.PostInThread),
+    canAttach: hasRoomPermission(entry.viewerState, RoomPermission.Attach),
+    canReact: hasRoomPermission(entry.viewerState, RoomPermission.React),
+    canEchoMessage: hasRoomPermission(entry.viewerState, RoomPermission.EchoMessage),
+    canManageOthersMessage: hasRoomPermission(entry.viewerState, RoomPermission.ManageMessage),
+    canManageRoom: hasRoomPermission(entry.viewerState, RoomPermission.ManageRoom),
+    canBanRoomMembers: hasRoomPermission(entry.viewerState, RoomPermission.BanMember)
   };
 }
 
@@ -172,9 +187,9 @@ function mapDirectoryRoom(entry: RoomWithViewerState): DirectoryRoomSummary | nu
     kind: entry.room.kind,
     archived: entry.room.archived,
     isUniversal: entry.room.universal,
-    isMember: entry.isMember,
-    hasUnread: entry.hasUnread,
-    canJoinRoom: entry.canJoinRoom
+    isMember: entry.viewerState?.isMember ?? false,
+    hasUnread: entry.viewerState?.hasUnread ?? false,
+    canJoinRoom: hasRoomPermission(entry.viewerState, RoomPermission.JoinRoom)
   };
 }
 
@@ -182,10 +197,25 @@ function mapRoomGroup(group: RoomGroup): DirectoryRoomGroup {
   return {
     id: group.id,
     name: group.name,
-    canCreateRoom: group.viewerState?.canCreateRoom ?? false,
+    canCreateRoom: hasRoomGroupPermission(group.viewerState, RoomPermission.CreateRoom),
     roomIds: uniqueRoomIds(group.items),
     items: sidebarItemsFromAPI(group)
   };
+}
+
+function hasRoomPermission(state: RoomViewerState | undefined, permission: string): boolean {
+  return (
+    state?.permissions.some((grant) => grant.permission === permission && grant.granted) ?? false
+  );
+}
+
+function hasRoomGroupPermission(
+  state: RoomGroupViewerState | undefined,
+  permission: string
+): boolean {
+  return (
+    state?.permissions.some((grant) => grant.permission === permission && grant.granted) ?? false
+  );
 }
 
 function uniqueRoomIds(items: readonly RoomGroupItem[]): string[] {

--- a/apps/frontend/src/lib/api-client/roomTimeline.ts
+++ b/apps/frontend/src/lib/api-client/roomTimeline.ts
@@ -1,38 +1,29 @@
-import { notifyUserSummaries } from "./hooks.js";
-import { authHeaders, createChattoClient, handleAuthError } from "./connect.js";
-import type {
-  RawEvent,
-  EventConnectionPage,
-  UserSummaryForCache,
-} from "./events.js";
-import { RoomEventKind } from "./eventKinds.js";
-import { PresenceStatus, type RoomEventView } from "./renderTypes.js";
-import { MessageService } from "@chatto/api-types/api/v1/messages_connect";
-import { RoomService } from "@chatto/api-types/api/v1/rooms_connect";
-import { ThreadService } from "@chatto/api-types/api/v1/threads_connect";
-import { createUserAPI } from "./users.js";
-import { RoomTimelinePage } from "@chatto/api-types/api/v1/room_timeline_pb";
-import type { LinkPreview } from "@chatto/api-types/api/v1/link_previews_pb";
-import { MessageVideoProcessingStatus } from "@chatto/api-types/api/v1/message_types_pb";
+import { notifyUserSummaries } from './hooks.js';
+import { authHeaders, createChattoClient, handleAuthError } from './connect.js';
+import type { RawEvent, EventConnectionPage, UserSummaryForCache } from './events.js';
+import { RoomEventKind } from './eventKinds.js';
+import { PresenceStatus, type RoomEventView } from './renderTypes.js';
+import { MessageService } from '@chatto/api-types/api/v1/messages_connect';
+import { RoomService } from '@chatto/api-types/api/v1/rooms_connect';
+import { ThreadService } from '@chatto/api-types/api/v1/threads_connect';
+import { createUserAPI } from './users.js';
+import { RoomTimelinePage } from '@chatto/api-types/api/v1/room_timeline_pb';
+import type { LinkPreview } from '@chatto/api-types/api/v1/link_previews_pb';
+import { MessageVideoProcessingStatus } from '@chatto/api-types/api/v1/message_types_pb';
 import type {
   Message,
   MessageAssetUrl,
-  MessageVideoProcessing,
-} from "@chatto/api-types/api/v1/message_types_pb";
-import type {
-  RoomTimelineEvent,
-} from "@chatto/api-types/api/v1/room_timeline_pb";
-import type { User } from "@chatto/api-types/api/v1/users_pb";
+  MessageVideoProcessing
+} from '@chatto/api-types/api/v1/message_types_pb';
+import type { RoomTimelineEvent } from '@chatto/api-types/api/v1/room_timeline_pb';
+import type { User } from '@chatto/api-types/api/v1/users_pb';
 
 export type RoomTimelineAPIConfig = {
   serverId?: string;
   baseUrl: string;
   bearerToken: string | null;
   onAuthenticationRequired?: (serverId: string) => void;
-  onUserSummaries?: (
-    serverId: string | undefined,
-    users: UserSummaryForCache[],
-  ) => void;
+  onUserSummaries?: (serverId: string | undefined, users: UserSummaryForCache[]) => void;
 };
 
 export type RoomTimelineAPI = {
@@ -47,10 +38,7 @@ export type RoomTimelineAPI = {
     eventId: string;
     limit: number;
   }): Promise<EventConnectionPage>;
-  getMessage(input: {
-    roomId: string;
-    eventId: string;
-  }): Promise<RawEvent | null>;
+  getMessage(input: { roomId: string; eventId: string }): Promise<RawEvent | null>;
   getThreadEvents(input: {
     roomId: string;
     threadRootEventId: string;
@@ -66,9 +54,7 @@ export type RoomTimelineAPI = {
   }): Promise<EventConnectionPage>;
 };
 
-export function createRoomTimelineAPI(
-  config: RoomTimelineAPIConfig,
-): RoomTimelineAPI {
+export function createRoomTimelineAPI(config: RoomTimelineAPIConfig): RoomTimelineAPI {
   const messages = createChattoClient(MessageService, config);
   const rooms = createChattoClient(RoomService, config);
   const threads = createChattoClient(ThreadService, config);
@@ -81,17 +67,15 @@ export function createRoomTimelineAPI(
             roomId,
             limit,
             cursor: before
-              ? { case: "before", value: before }
+              ? { case: 'before', value: before }
               : after
-                ? { case: "after", value: after }
-                : { case: undefined },
+                ? { case: 'after', value: after }
+                : { case: undefined }
           },
-          { headers: headers() },
+          { headers: headers() }
         );
         primeTimelineUserIncludes(config, response.page?.includes?.users ?? {});
-        return roomTimelinePageToEventConnectionPage(
-          response.page ?? new RoomTimelinePage(),
-        );
+        return roomTimelinePageToEventConnectionPage(response.page ?? new RoomTimelinePage());
       } catch (err) {
         return handleAuthError(config, err);
       }
@@ -100,7 +84,7 @@ export function createRoomTimelineAPI(
       try {
         const response = await rooms.getRoomEventsAround(
           { roomId, eventId, limit },
-          { headers: headers() },
+          { headers: headers() }
         );
         if (!response.page) return emptyEventConnectionPage();
         primeTimelineUserIncludes(config, response.page.includes?.users ?? {});
@@ -111,17 +95,12 @@ export function createRoomTimelineAPI(
     },
     async getMessage({ roomId, eventId }) {
       try {
-        const response = await messages.getMessage(
-          { roomId, eventId },
-          { headers: headers() },
-        );
+        const response = await messages.getMessage({ roomId, eventId }, { headers: headers() });
         const users = await timelineUsersForMessages(
           config,
-          response.message ? [response.message] : [],
+          response.message ? [response.message] : []
         );
-        return response.message
-          ? messageToRawEvent(response.message, users)
-          : null;
+        return response.message ? messageToRawEvent(response.message, users) : null;
       } catch (err) {
         return handleAuthError(config, err);
       }
@@ -134,17 +113,15 @@ export function createRoomTimelineAPI(
             threadRootEventId,
             limit,
             cursor: before
-              ? { case: "before", value: before }
+              ? { case: 'before', value: before }
               : after
-                ? { case: "after", value: after }
-                : { case: undefined },
+                ? { case: 'after', value: after }
+                : { case: undefined }
           },
-          { headers: headers() },
+          { headers: headers() }
         );
         primeTimelineUserIncludes(config, response.page?.includes?.users ?? {});
-        return roomTimelinePageToEventConnectionPage(
-          response.page ?? new RoomTimelinePage(),
-        );
+        return roomTimelinePageToEventConnectionPage(response.page ?? new RoomTimelinePage());
       } catch (err) {
         return handleAuthError(config, err);
       }
@@ -153,7 +130,7 @@ export function createRoomTimelineAPI(
       try {
         const response = await threads.getThreadEventsAround(
           { roomId, threadRootEventId, eventId, limit },
-          { headers: headers() },
+          { headers: headers() }
         );
         if (!response.page) return emptyEventConnectionPage();
         primeTimelineUserIncludes(config, response.page.includes?.users ?? {});
@@ -161,13 +138,13 @@ export function createRoomTimelineAPI(
       } catch (err) {
         return handleAuthError(config, err);
       }
-    },
+    }
   };
 }
 
 export async function timelineUsersForEvents(
   config: RoomTimelineAPIConfig,
-  events: RoomTimelineEvent[],
+  events: RoomTimelineEvent[]
 ): Promise<Record<string, User>> {
   const userIds = messageUserIds(messagesFromTimelineEvents(events));
   return batchTimelineUsers(config, userIds);
@@ -175,7 +152,7 @@ export async function timelineUsersForEvents(
 
 export async function timelineUsersForMessages(
   config: RoomTimelineAPIConfig,
-  messages: Message[],
+  messages: Message[]
 ): Promise<Record<string, User>> {
   const userIds = messageUserIds(messages);
   return batchTimelineUsers(config, userIds);
@@ -183,7 +160,7 @@ export async function timelineUsersForMessages(
 
 async function batchTimelineUsers(
   config: RoomTimelineAPIConfig,
-  userIds: string[],
+  userIds: string[]
 ): Promise<Record<string, User>> {
   if (userIds.length === 0) return {};
 
@@ -196,7 +173,7 @@ async function batchTimelineUsers(
         login: summary.login,
         displayName: summary.displayName,
         deleted: summary.deleted,
-        avatarUrl: summary.avatarUrl ?? undefined,
+        avatarUrl: summary.avatarUrl ?? undefined
       } as User;
     }
     primeTimelineUserIncludes(config, users);
@@ -209,7 +186,7 @@ async function batchTimelineUsers(
 function messagesFromTimelineEvents(events: RoomTimelineEvent[]): Message[] {
   const messages: Message[] = [];
   for (const event of events) {
-    if (event.event.case !== "messagePosted") continue;
+    if (event.event.case !== 'messagePosted') continue;
     if (event.event.value.message) messages.push(event.event.value.message);
   }
   return messages;
@@ -219,7 +196,7 @@ function messageUserIds(messages: Message[]): string[] {
   const ids = new Set<string>();
   for (const message of messages) {
     if (message.actorId) ids.add(message.actorId);
-    for (const userId of message.threadParticipantPreviewUserIds) {
+    for (const userId of message.thread?.participantPreviewUserIds ?? []) {
       if (userId) ids.add(userId);
     }
     for (const reaction of message.reactions) {
@@ -231,10 +208,7 @@ function messageUserIds(messages: Message[]): string[] {
   return [...ids];
 }
 
-function primeTimelineUserIncludes(
-  config: RoomTimelineAPIConfig,
-  users: Record<string, User>,
-) {
+function primeTimelineUserIncludes(config: RoomTimelineAPIConfig, users: Record<string, User>) {
   notifyUserSummaries(
     config.serverId,
     Object.values(users).map((user) => ({
@@ -242,9 +216,9 @@ function primeTimelineUserIncludes(
       login: user.login,
       displayName: user.displayName,
       deleted: user.deleted,
-      avatarUrl: user.avatarUrl || null,
+      avatarUrl: user.avatarUrl || null
     })),
-    config.onUserSummaries,
+    config.onUserSummaries
   );
 }
 
@@ -254,13 +228,11 @@ function emptyEventConnectionPage(): EventConnectionPage {
     startCursor: null,
     endCursor: null,
     hasOlder: false,
-    hasNewer: false,
+    hasNewer: false
   };
 }
 
-export function roomTimelinePageToEventConnectionPage(
-  page: RoomTimelinePage,
-): EventConnectionPage {
+export function roomTimelinePageToEventConnectionPage(page: RoomTimelinePage): EventConnectionPage {
   const users = page.includes?.users ?? {};
   return {
     events: page.events
@@ -269,13 +241,13 @@ export function roomTimelinePageToEventConnectionPage(
     startCursor: page.startCursor || null,
     endCursor: page.endCursor || null,
     hasOlder: page.hasOlder,
-    hasNewer: page.hasNewer,
+    hasNewer: page.hasNewer
   };
 }
 
 export function roomTimelineEventToRawEvent(
   event: RoomTimelineEvent,
-  users: Record<string, User>,
+  users: Record<string, User>
 ): RawEvent | null {
   const payload = timelinePayload(event, users);
   if (!payload) return null;
@@ -284,14 +256,11 @@ export function roomTimelineEventToRawEvent(
     createdAt: timestampToISO(event.createdAt),
     actorId: event.actorId,
     actor: userView(event.actorId, users),
-    event: payload,
+    event: payload
   } as unknown as RawEvent;
 }
 
-export function messageToRawEvent(
-  message: Message,
-  users: Record<string, User>,
-): RawEvent | null {
+export function messageToRawEvent(message: Message, users: Record<string, User>): RawEvent | null {
   const payload = messagePostedPayload(message, users);
   if (!payload) return null;
   return {
@@ -299,65 +268,60 @@ export function messageToRawEvent(
     createdAt: timestampToISO(message.createdAt),
     actorId: message.actorId,
     actor: userView(message.actorId, users),
-    event: payload,
+    event: payload
   } as unknown as RawEvent;
 }
 
 function timelinePayload(
   event: RoomTimelineEvent,
-  users: Record<string, User>,
-): RoomEventView["event"] | null {
+  users: Record<string, User>
+): RoomEventView['event'] | null {
   switch (event.event.case) {
-    case "messagePosted":
+    case 'messagePosted':
       if (!event.event.value.message) return null;
-      return messagePostedPayload(
-        event.event.value.message,
-        users,
-      ) as RoomEventView["event"];
-    case "roomCreated":
+      return messagePostedPayload(event.event.value.message, users) as RoomEventView['event'];
+    case 'roomCreated':
       return {
         kind: RoomEventKind.RoomCreated,
-        roomId: event.event.value.roomId,
+        roomId: event.event.value.roomId
       } as never;
-    case "roomUpdated":
+    case 'roomUpdated':
       return {
         kind: RoomEventKind.RoomUpdated,
-        roomId: event.event.value.roomId,
+        roomId: event.event.value.roomId
       } as never;
-    case "roomDeleted":
+    case 'roomDeleted':
       return {
         kind: RoomEventKind.RoomDeleted,
-        roomId: event.event.value.roomId,
+        roomId: event.event.value.roomId
       } as never;
-    case "roomArchived":
+    case 'roomArchived':
       return {
         kind: RoomEventKind.RoomArchived,
-        roomId: event.event.value.roomId,
+        roomId: event.event.value.roomId
       } as never;
-    case "roomUnarchived":
+    case 'roomUnarchived':
       return {
         kind: RoomEventKind.RoomUnarchived,
-        roomId: event.event.value.roomId,
+        roomId: event.event.value.roomId
       } as never;
-    case "userJoinedRoom":
+    case 'userJoinedRoom':
       return {
         kind: RoomEventKind.UserJoinedRoom,
-        roomId: event.event.value.roomId,
+        roomId: event.event.value.roomId
       } as never;
-    case "userLeftRoom":
+    case 'userLeftRoom':
       return {
         kind: RoomEventKind.UserLeftRoom,
-        roomId: event.event.value.roomId,
+        roomId: event.event.value.roomId
       } as never;
     default:
       return null;
   }
 }
 
-function messagePostedPayload(
-  message: Message,
-  users: Record<string, User>,
-) {
+function messagePostedPayload(message: Message, users: Record<string, User>) {
+  const thread = message.thread;
   return {
     kind: RoomEventKind.MessagePosted,
     roomId: message.roomId,
@@ -370,30 +334,22 @@ function messagePostedPayload(
     echoOfEventId: message.echoOfEventId || null,
     echoFromThreadRootEventId: message.echoFromThreadRootEventId || null,
     channelEchoEventId: message.channelEchoEventId || null,
-    replyCount: message.replyCount,
-    lastReplyAt: timestampToISOOrNull(message.lastReplyAt),
-    threadParticipantCount: message.threadParticipantCount,
-    threadParticipants: message.threadParticipantPreviewUserIds
+    replyCount: thread?.replyCount ?? 0,
+    lastReplyAt: timestampToISOOrNull(thread?.lastReplyAt),
+    threadParticipantCount: thread?.participantCount ?? 0,
+    threadParticipants: (thread?.participantPreviewUserIds ?? [])
       .map((id) => userView(id, users))
-      .filter(
-        (user): user is NonNullable<ReturnType<typeof userView>> =>
-          user !== null,
-      ),
+      .filter((user): user is NonNullable<ReturnType<typeof userView>> => user !== null),
     viewerIsFollowingThread:
-      message.viewerIsFollowingThread !== undefined
-        ? message.viewerIsFollowingThread
-        : null,
+      thread?.viewerState?.isFollowing !== undefined ? thread.viewerState.isFollowing : null,
     reactions: message.reactions.map((reaction) => ({
       emoji: reaction.emoji,
       count: reaction.count,
       hasReacted: reaction.hasReacted,
       users: reaction.previewUserIds
         .map((id) => userView(id, users))
-        .filter(
-          (user): user is NonNullable<ReturnType<typeof userView>> =>
-            user !== null,
-        ),
-    })),
+        .filter((user): user is NonNullable<ReturnType<typeof userView>> => user !== null)
+    }))
   };
 }
 
@@ -403,11 +359,11 @@ function userView(userId: string, users: Record<string, User>) {
   if (!user) {
     return {
       id: userId,
-      login: "",
-      displayName: "Deleted User",
+      login: '',
+      displayName: 'Deleted User',
       deleted: true,
       avatarUrl: null,
-      presenceStatus: PresenceStatus.Offline,
+      presenceStatus: PresenceStatus.Offline
     };
   }
   return {
@@ -416,7 +372,7 @@ function userView(userId: string, users: Record<string, User>) {
     displayName: user.displayName,
     deleted: user.deleted,
     avatarUrl: user.avatarUrl || null,
-    presenceStatus: PresenceStatus.Offline,
+    presenceStatus: PresenceStatus.Offline
   };
 }
 
@@ -438,7 +394,7 @@ function attachmentView(attachment: {
     height: attachment.height,
     assetUrl: assetUrlView(attachment.assetUrl),
     thumbnailAssetUrl: assetUrlView(attachment.thumbnailAssetUrl),
-    videoProcessing: videoProcessingView(attachment.videoProcessing),
+    videoProcessing: videoProcessingView(attachment.videoProcessing)
   };
 }
 
@@ -460,19 +416,19 @@ function videoProcessingView(processing?: MessageVideoProcessing) {
       width: variant.width,
       height: variant.height,
       size: Number(variant.size),
-      assetUrl: assetUrlView(variant.assetUrl),
-    })),
+      assetUrl: assetUrlView(variant.assetUrl)
+    }))
   };
 }
 
 function videoProcessingStatusView(status: MessageVideoProcessingStatus) {
   switch (status) {
     case MessageVideoProcessingStatus.PROCESSING:
-      return "PROCESSING";
+      return 'PROCESSING';
     case MessageVideoProcessingStatus.COMPLETED:
-      return "COMPLETED";
+      return 'COMPLETED';
     case MessageVideoProcessingStatus.FAILED:
-      return "FAILED";
+      return 'FAILED';
     default:
       return null;
   }
@@ -487,7 +443,7 @@ function linkPreviewView(preview?: LinkPreview) {
     siteName: preview.siteName || null,
     imageUrl: preview.imageUrl || null,
     embedType: preview.embedType || null,
-    embedId: preview.embedId || null,
+    embedId: preview.embedId || null
   };
 }
 
@@ -495,7 +451,7 @@ function assetUrlView(assetUrl?: MessageAssetUrl) {
   if (!assetUrl) return null;
   return {
     url: assetUrl.url,
-    expiresAt: timestampToISOOrNull(assetUrl.expiresAt),
+    expiresAt: timestampToISOOrNull(assetUrl.expiresAt)
   };
 }
 
@@ -503,8 +459,6 @@ function timestampToISO(timestamp: { toDate(): Date } | undefined): string {
   return timestampToISOOrNull(timestamp) ?? new Date(0).toISOString();
 }
 
-function timestampToISOOrNull(
-  timestamp: { toDate(): Date } | undefined,
-): string | null {
+function timestampToISOOrNull(timestamp: { toDate(): Date } | undefined): string | null {
   return timestamp ? timestamp.toDate().toISOString() : null;
 }

--- a/apps/frontend/src/lib/api-client/threads.ts
+++ b/apps/frontend/src/lib/api-client/threads.ts
@@ -1,8 +1,8 @@
-import { authHeaders, createChattoClient, handleAuthError } from "./connect.js";
-import { ThreadService } from "@chatto/api-types/api/v1/threads_connect";
-import type { User } from "@chatto/api-types/api/v1/users_pb";
-import type { RawEvent } from "./events.js";
-import { messageToRawEvent } from "./roomTimeline.js";
+import { authHeaders, createChattoClient, handleAuthError } from './connect.js';
+import { ThreadService } from '@chatto/api-types/api/v1/threads_connect';
+import type { User } from '@chatto/api-types/api/v1/users_pb';
+import type { RawEvent } from './events.js';
+import { messageToRawEvent } from './roomTimeline.js';
 
 export type ConnectAPIConfig = {
   serverId?: string;
@@ -49,26 +49,23 @@ export function createThreadAPI(config: ConnectAPIConfig) {
       try {
         const response = await client.listFollowedThreads(
           { page: { limit: input.limit, offset: input.offset } },
-          { headers: headers() },
+          { headers: headers() }
         );
         const users = response.includes?.users ?? {};
         return {
           threads: response.threads.map((thread) => ({
-            roomId: thread.roomId,
-            roomName: thread.roomName,
-            threadRootEventId: thread.threadRootEventId,
+            roomId: thread.room?.id ?? '',
+            roomName: thread.room?.name ?? '',
+            threadRootEventId: thread.thread?.threadRootEventId ?? '',
             rootMessage: thread.rootMessage
-              ? messageToRawEvent(
-                  thread.rootMessage,
-                  users as Record<string, User>,
-                )
+              ? messageToRawEvent(thread.rootMessage, users as Record<string, User>)
               : null,
-            replyCount: thread.replyCount,
-            lastReplyAt: timestampToISOOrNull(thread.lastReplyAt),
-            hasUnread: thread.hasUnread,
+            replyCount: thread.thread?.replyCount ?? 0,
+            lastReplyAt: timestampToISOOrNull(thread.thread?.lastReplyAt),
+            hasUnread: thread.thread?.viewerState?.hasUnread ?? false
           })),
           totalCount: Number(response.page?.totalCount ?? 0),
-          hasMore: response.page?.hasMore ?? false,
+          hasMore: response.page?.hasMore ?? false
         };
       } catch (err) {
         return handleAuthError(config, err);
@@ -81,11 +78,11 @@ export function createThreadAPI(config: ConnectAPIConfig) {
     }): Promise<ThreadFollowResult> {
       try {
         const response = await client.followThread(input, {
-          headers: headers(),
+          headers: headers()
         });
         return {
           following: response.following,
-          state: response.state ? mapThreadFollowState(response.state) : null,
+          state: response.state ? mapThreadFollowState(response.state) : null
         };
       } catch (err) {
         return handleAuthError(config, err);
@@ -98,16 +95,16 @@ export function createThreadAPI(config: ConnectAPIConfig) {
     }): Promise<ThreadFollowResult> {
       try {
         const response = await client.unfollowThread(input, {
-          headers: headers(),
+          headers: headers()
         });
         return {
           following: response.following,
-          state: response.state ? mapThreadFollowState(response.state) : null,
+          state: response.state ? mapThreadFollowState(response.state) : null
         };
       } catch (err) {
         return handleAuthError(config, err);
       }
-    },
+    }
   };
 }
 
@@ -119,12 +116,10 @@ function mapThreadFollowState(state: {
   return {
     roomId: state.roomId,
     threadRootEventId: state.threadRootEventId,
-    following: state.following,
+    following: state.following
   };
 }
 
-function timestampToISOOrNull(
-  timestamp: { toDate(): Date } | undefined,
-): string | null {
+function timestampToISOOrNull(timestamp: { toDate(): Date } | undefined): string | null {
   return timestamp ? timestamp.toDate().toISOString() : null;
 }

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -3481,13 +3481,13 @@ func TestRoomDirectoryServiceListRoomsVisibilityAndDMs(t *testing.T) {
 	if dmRoom.GetRoom().GetKind() != apiv1.RoomKind_ROOM_KIND_DM {
 		t.Fatalf("DM kind = %v, want DM", dmRoom.GetRoom().GetKind())
 	}
-	if !dmRoom.GetIsMember() {
+	if !dmRoom.GetViewerState().GetIsMember() {
 		t.Fatalf("DM IsMember = false, want true")
 	}
-	if !dmRoom.GetCanListRoom() {
+	if !apiRoomPermissionGranted(dmRoom, core.PermRoomList) {
 		t.Fatalf("DM CanListRoom = false, want true")
 	}
-	if dmRoom.GetCanJoinRoom() || dmRoom.GetCanManageRoom() || dmRoom.GetCanBanRoomMembers() {
+	if apiRoomPermissionGranted(dmRoom, core.PermRoomJoin) || apiRoomPermissionGranted(dmRoom, core.PermRoomManage) || apiRoomPermissionGranted(dmRoom, core.PermRoomMemberBan) {
 		t.Fatalf("DM exposes channel-only actions: %+v", dmRoom)
 	}
 	batchResp, err := env.directory.BatchGetRooms(withCaller(env.ctx, caller), connect.NewRequest(&apiv1.BatchGetRoomsRequest{
@@ -3566,18 +3566,18 @@ func TestRoomDirectoryServiceViewerStateMatchesWritePreconditions(t *testing.T) 
 	if visibleRoom == nil {
 		t.Fatalf("visible room %s missing from directory response", visible.Id)
 	}
-	if visibleRoom.GetIsMember() {
+	if visibleRoom.GetViewerState().GetIsMember() {
 		t.Fatalf("visible room IsMember = true, want false")
 	}
-	if !visibleRoom.GetCanJoinRoom() {
+	if !apiRoomPermissionGranted(visibleRoom, core.PermRoomJoin) {
 		t.Fatalf("visible non-member CanJoinRoom = false, want true")
 	}
-	if visibleRoom.GetCanPostMessage() ||
-		visibleRoom.GetCanPostInThread() ||
-		visibleRoom.GetCanAttach() ||
-		visibleRoom.GetCanReact() ||
-		visibleRoom.GetCanEchoMessage() ||
-		visibleRoom.GetCanManageOthersMessage() {
+	if apiRoomPermissionGranted(visibleRoom, core.PermMessagePost) ||
+		apiRoomPermissionGranted(visibleRoom, core.PermMessagePostInThread) ||
+		apiRoomPermissionGranted(visibleRoom, core.PermMessageAttach) ||
+		apiRoomPermissionGranted(visibleRoom, core.PermMessageReact) ||
+		apiRoomPermissionGranted(visibleRoom, core.PermMessageEcho) ||
+		apiRoomPermissionGranted(visibleRoom, core.PermMessageManage) {
 		t.Fatalf("visible non-member exposes member-only actions: %+v", visibleRoom)
 	}
 	if _, ok := rooms[memberArchived.Id]; ok {
@@ -3600,18 +3600,18 @@ func TestRoomDirectoryServiceViewerStateMatchesWritePreconditions(t *testing.T) 
 		t.Fatalf("BatchGetRooms archived rooms = %+v, want archived member room", got)
 	}
 	archivedRoom := archivedResp.Msg.GetRoom()
-	if !archivedRoom.GetIsMember() {
+	if !archivedRoom.GetViewerState().GetIsMember() {
 		t.Fatalf("archived room IsMember = false, want true")
 	}
-	if archivedRoom.GetCanJoinRoom() ||
-		archivedRoom.GetCanPostMessage() ||
-		archivedRoom.GetCanPostInThread() ||
-		archivedRoom.GetCanAttach() ||
-		archivedRoom.GetCanReact() ||
-		archivedRoom.GetCanEchoMessage() {
+	if apiRoomPermissionGranted(archivedRoom, core.PermRoomJoin) ||
+		apiRoomPermissionGranted(archivedRoom, core.PermMessagePost) ||
+		apiRoomPermissionGranted(archivedRoom, core.PermMessagePostInThread) ||
+		apiRoomPermissionGranted(archivedRoom, core.PermMessageAttach) ||
+		apiRoomPermissionGranted(archivedRoom, core.PermMessageReact) ||
+		apiRoomPermissionGranted(archivedRoom, core.PermMessageEcho) {
 		t.Fatalf("archived room exposes unavailable actions: %+v", archivedRoom)
 	}
-	if !archivedRoom.GetCanManageOthersMessage() {
+	if !apiRoomPermissionGranted(archivedRoom, core.PermMessageManage) {
 		t.Fatalf("archived room CanManageOthersMessage = false, want true")
 	}
 }
@@ -3655,7 +3655,7 @@ func TestRoomDirectoryServiceListRoomGroupsFiltersHiddenRoomsAndKeepsLinks(t *te
 	if group == nil {
 		t.Fatalf("group %s missing from response", groupID)
 	}
-	if group.GetViewerState().GetCanCreateRoom() {
+	if apiRoomGroupPermissionGranted(group, core.PermRoomCreate) {
 		t.Fatalf("group CanCreateRoom = true before group grant, want false")
 	}
 	if !roomGroupItemsContainRoom(group.GetItems(), visible.Id) {
@@ -3704,7 +3704,7 @@ func TestRoomDirectoryServiceListRoomGroupsFiltersHiddenRoomsAndKeepsLinks(t *te
 	if getGroup.GetId() != groupID {
 		t.Fatalf("GetRoomGroup id = %q, want %q", getGroup.GetId(), groupID)
 	}
-	if !getGroup.GetViewerState().GetCanCreateRoom() {
+	if !apiRoomGroupPermissionGranted(getGroup, core.PermRoomCreate) {
 		t.Fatalf("group CanCreateRoom = false after group grant, want true")
 	}
 	if !roomGroupItemsContainRoom(getGroup.GetItems(), visible.Id) ||
@@ -5936,13 +5936,14 @@ func TestRoomAndThreadTimelineHydratesMessagesWithoutClientNPlusOne(t *testing.T
 	if message.Body == nil || message.GetBody() != "root" {
 		t.Fatalf("message body present/body = %v/%q, want true/root", message.Body != nil, message.GetBody())
 	}
-	if message.ReplyCount != 1 {
-		t.Fatalf("reply count = %d, want 1", message.ReplyCount)
+	thread := message.GetThread()
+	if thread.GetReplyCount() != 1 {
+		t.Fatalf("reply count = %d, want 1", thread.GetReplyCount())
 	}
-	if got := message.ThreadParticipantCount; got != 1 {
+	if got := thread.GetParticipantCount(); got != 1 {
 		t.Fatalf("thread participant count = %d, want 1", got)
 	}
-	if got := message.ThreadParticipantPreviewUserIds; len(got) != 1 || got[0] != replier.Id {
+	if got := thread.GetParticipantPreviewUserIds(); len(got) != 1 || got[0] != replier.Id {
 		t.Fatalf("thread participant preview = %v, want [%s]", got, replier.Id)
 	}
 	if len(message.Reactions) != 1 {
@@ -6836,11 +6837,11 @@ func TestThreadServiceListFollowedThreadsReturnsHydratedPage(t *testing.T) {
 	}
 
 	thread := resp.Msg.GetThreads()[0]
-	if thread.GetRoomId() != room.Id || thread.GetRoomName() != room.Name || thread.GetThreadRootEventId() != root.Id {
-		t.Fatalf("followed thread identity = room %q name %q root %q, want room %q name %q root %q", thread.GetRoomId(), thread.GetRoomName(), thread.GetThreadRootEventId(), room.Id, room.Name, root.Id)
+	if thread.GetRoom().GetId() != room.Id || thread.GetRoom().GetName() != room.Name || thread.GetThread().GetThreadRootEventId() != root.Id {
+		t.Fatalf("followed thread identity = room %q name %q root %q, want room %q name %q root %q", thread.GetRoom().GetId(), thread.GetRoom().GetName(), thread.GetThread().GetThreadRootEventId(), room.Id, room.Name, root.Id)
 	}
-	if thread.GetReplyCount() != 1 || !thread.GetHasUnread() || thread.GetLastReplyAt() == nil {
-		t.Fatalf("followed thread metadata = replies %d unread %v lastReplyAt %v, want replies 1 unread true lastReplyAt set", thread.GetReplyCount(), thread.GetHasUnread(), thread.GetLastReplyAt())
+	if thread.GetThread().GetReplyCount() != 1 || !thread.GetThread().GetViewerState().GetHasUnread() || thread.GetThread().GetLastReplyAt() == nil {
+		t.Fatalf("followed thread metadata = replies %d unread %v lastReplyAt %v, want replies 1 unread true lastReplyAt set", thread.GetThread().GetReplyCount(), thread.GetThread().GetViewerState().GetHasUnread(), thread.GetThread().GetLastReplyAt())
 	}
 	rootMessage := thread.GetRootMessage()
 	if rootMessage == nil || rootMessage.GetId() != root.Id {
@@ -7202,6 +7203,23 @@ func apiPermissionGrantPresent(grants []*apiv1.PermissionGrant, permission strin
 	for _, grant := range grants {
 		if grant.GetPermission() == permission {
 			return true
+		}
+	}
+	return false
+}
+
+func apiRoomPermissionGranted(room *apiv1.RoomWithViewerState, permission core.Permission) bool {
+	return apiPermissionGranted(room.GetViewerState().GetPermissions(), string(permission))
+}
+
+func apiRoomGroupPermissionGranted(group *apiv1.RoomGroup, permission core.Permission) bool {
+	return apiPermissionGranted(group.GetViewerState().GetPermissions(), string(permission))
+}
+
+func apiPermissionGranted(grants []*apiv1.PermissionGrant, permission string) bool {
+	for _, grant := range grants {
+		if grant.GetPermission() == permission {
+			return grant.GetGranted()
 		}
 	}
 	return false

--- a/cli/internal/connectapi/notification_assembler.go
+++ b/cli/internal/connectapi/notification_assembler.go
@@ -58,10 +58,14 @@ func (a *notificationAssembler) item(ctx context.Context, notification *corev1.N
 
 	switch payload := notification.GetNotification().(type) {
 	case *corev1.Notification_DmMessage:
+		room, err := a.room(ctx, payload.DmMessage.GetRoomId())
+		if err != nil {
+			return nil, err
+		}
 		item.Kind = &apiv1.NotificationItem_DirectMessage{
 			DirectMessage: &apiv1.DirectMessageNotification{
-				RoomId:  payload.DmMessage.GetRoomId(),
 				EventId: payload.DmMessage.GetEventId(),
+				Room:    room,
 			},
 		}
 	case *corev1.Notification_Mention:
@@ -127,16 +131,16 @@ func (a *notificationAssembler) actor(ctx context.Context, userID string) (*apiv
 	return actor, nil
 }
 
-func (a *notificationAssembler) room(ctx context.Context, roomID string) (*apiv1.NotificationRoom, error) {
+func (a *notificationAssembler) room(ctx context.Context, roomID string) (*apiv1.RoomSummary, error) {
 	if roomID == "" {
 		return nil, nil
 	}
 	room, err := a.api.core.FindRoomByID(ctx, roomID)
 	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			return &apiv1.RoomSummary{Id: roomID}, nil
+		}
 		return nil, err
 	}
-	return &apiv1.NotificationRoom{
-		Id:   room.GetId(),
-		Name: room.GetName(),
-	}, nil
+	return apiRoomSummary(room), nil
 }

--- a/cli/internal/connectapi/room_directory.go
+++ b/cli/internal/connectapi/room_directory.go
@@ -121,19 +121,23 @@ func apiRoomWithViewerState(room *core.DirectoryRoom) *apiv1.RoomWithViewerState
 	}
 	state := room.ViewerState
 	return &apiv1.RoomWithViewerState{
-		Room:                   apiRoom(room.Room),
-		IsMember:               state.IsMember,
-		HasUnread:              state.HasUnread,
-		CanListRoom:            state.CanListRoom,
-		CanJoinRoom:            state.CanJoinRoom,
-		CanPostMessage:         state.CanPostMessage,
-		CanPostInThread:        state.CanPostInThread,
-		CanAttach:              state.CanAttach,
-		CanReact:               state.CanReact,
-		CanEchoMessage:         state.CanEchoMessage,
-		CanManageOthersMessage: state.CanManageOthersMessage,
-		CanManageRoom:          state.CanManageRoom,
-		CanBanRoomMembers:      state.CanBanRoomMembers,
+		Room: apiRoom(room.Room),
+		ViewerState: &apiv1.RoomViewerState{
+			IsMember:  state.IsMember,
+			HasUnread: state.HasUnread,
+			Permissions: permissionGrants(
+				permissionGrant(core.PermRoomList, state.CanListRoom),
+				permissionGrant(core.PermRoomJoin, state.CanJoinRoom),
+				permissionGrant(core.PermMessagePost, state.CanPostMessage),
+				permissionGrant(core.PermMessagePostInThread, state.CanPostInThread),
+				permissionGrant(core.PermMessageAttach, state.CanAttach),
+				permissionGrant(core.PermMessageReact, state.CanReact),
+				permissionGrant(core.PermMessageEcho, state.CanEchoMessage),
+				permissionGrant(core.PermMessageManage, state.CanManageOthersMessage),
+				permissionGrant(core.PermRoomManage, state.CanManageRoom),
+				permissionGrant(core.PermRoomMemberBan, state.CanBanRoomMembers),
+			),
+		},
 	}
 }
 
@@ -146,7 +150,7 @@ func apiRoomGroup(group *core.DirectoryRoomGroup) *apiv1.RoomGroup {
 		Name:        group.Group.GetName(),
 		Description: group.Group.GetDescription(),
 		ViewerState: &apiv1.RoomGroupViewerState{
-			CanCreateRoom: group.ViewerState.CanCreateRoom,
+			Permissions: permissionGrants(permissionGrant(core.PermRoomCreate, group.ViewerState.CanCreateRoom)),
 		},
 	}
 	for _, item := range group.Items {
@@ -162,6 +166,17 @@ func apiRoomGroup(group *core.DirectoryRoomGroup) *apiv1.RoomGroup {
 		}
 	}
 	return apiGroup
+}
+
+func permissionGrant(permission core.Permission, granted bool) *apiv1.PermissionGrant {
+	return &apiv1.PermissionGrant{
+		Permission: string(permission),
+		Granted:    granted,
+	}
+}
+
+func permissionGrants(grants ...*apiv1.PermissionGrant) []*apiv1.PermissionGrant {
+	return grants
 }
 
 func roomDirectoryScopeIncludesChannels(scope apiv1.RoomDirectoryScope) bool {

--- a/cli/internal/connectapi/room_timeline_assembler.go
+++ b/cli/internal/connectapi/room_timeline_assembler.go
@@ -227,24 +227,28 @@ func (h *timelineHydrator) messagePosted(ctx context.Context, event *core.RoomEv
 	}
 
 	if payload.GetInThread() == "" {
+		thread := &apiv1.ThreadSummary{
+			ThreadRootEventId: event.Id,
+		}
 		metadata, err := h.api.core.GetThreadMetadata(ctx, h.kind, payload.GetRoomId(), event.Id)
 		if err != nil && !errors.Is(err, core.ErrNotFound) {
 			return nil, err
 		}
 		if metadata != nil {
-			message.ReplyCount = int32(metadata.ReplyCount)
+			thread.ReplyCount = int32(metadata.ReplyCount)
 			if metadata.LastReplyAt != nil {
-				message.LastReplyAt = timestamppb.New(*metadata.LastReplyAt)
+				thread.LastReplyAt = timestamppb.New(*metadata.LastReplyAt)
 			}
-			message.ThreadParticipantPreviewUserIds = firstN(metadata.ParticipantIDs, 5)
-			message.ThreadParticipantCount = int32(len(metadata.ParticipantIDs))
-			h.addUserIDs(message.ThreadParticipantPreviewUserIds)
+			thread.ParticipantPreviewUserIds = firstN(metadata.ParticipantIDs, 5)
+			thread.ParticipantCount = int32(len(metadata.ParticipantIDs))
+			h.addUserIDs(thread.ParticipantPreviewUserIds)
 		}
 		following, err := h.api.core.IsFollowingThread(ctx, h.kind, h.viewerID, payload.GetRoomId(), event.Id)
 		if err != nil {
 			return nil, err
 		}
-		message.ViewerIsFollowingThread = &following
+		thread.ViewerState = &apiv1.ThreadViewerState{IsFollowing: &following}
+		message.Thread = thread
 	}
 
 	return message, nil

--- a/cli/internal/connectapi/rooms.go
+++ b/cli/internal/connectapi/rooms.go
@@ -356,6 +356,17 @@ func apiRoom(room *corev1.Room) *apiv1.Room {
 	}
 }
 
+func apiRoomSummary(room *corev1.Room) *apiv1.RoomSummary {
+	if room == nil {
+		return nil
+	}
+	return &apiv1.RoomSummary{
+		Id:   room.GetId(),
+		Kind: apiRoomKind(room.GetKind()),
+		Name: room.GetName(),
+	}
+}
+
 func apiRoomKind(kind corev1.RoomKind) apiv1.RoomKind {
 	switch kind {
 	case corev1.RoomKind_ROOM_KIND_CHANNEL:

--- a/cli/internal/connectapi/thread_assembler.go
+++ b/cli/internal/connectapi/thread_assembler.go
@@ -73,14 +73,24 @@ func (a *threadAssembler) followedThreadsResponse(ctx context.Context, viewerID 
 		if thread.LastReplyAt != nil {
 			lastReplyAt = timestamppb.New(*thread.LastReplyAt)
 		}
+		participantPreviewUserIDs := firstN(thread.ParticipantIDs, 5)
+		h.addUserIDs(participantPreviewUserIDs)
+		following := true
+		hasUnread := thread.HasUnread
 		return &apiv1.FollowedThread{
-			RoomId:            thread.RoomID,
-			RoomName:          room.GetName(),
-			ThreadRootEventId: thread.ThreadRootEventID,
-			RootMessage:       rootMessage,
-			ReplyCount:        int32(thread.ReplyCount),
-			LastReplyAt:       lastReplyAt,
-			HasUnread:         thread.HasUnread,
+			RootMessage: rootMessage,
+			Room:        apiRoomSummary(room),
+			Thread: &apiv1.ThreadSummary{
+				ThreadRootEventId:         thread.ThreadRootEventID,
+				ReplyCount:                int32(thread.ReplyCount),
+				LastReplyAt:               lastReplyAt,
+				ParticipantPreviewUserIds: participantPreviewUserIDs,
+				ParticipantCount:          int32(len(thread.ParticipantIDs)),
+				ViewerState: &apiv1.ThreadViewerState{
+					IsFollowing: &following,
+					HasUnread:   &hasUnread,
+				},
+			},
 		}, nil
 	})
 	if err != nil {

--- a/cli/internal/pb/chatto/api/v1/message_types.pb.go
+++ b/cli/internal/pb/chatto/api/v1/message_types.pb.go
@@ -520,6 +520,154 @@ func (x *MessageReaction) GetPreviewUserIds() []string {
 	return nil
 }
 
+// Viewer-specific state for one message thread.
+type ThreadViewerState struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Whether the current user follows this message's thread, when known.
+	IsFollowing *bool `protobuf:"varint,1,opt,name=is_following,json=isFollowing,proto3,oneof" json:"is_following,omitempty"`
+	// True when the thread has unread replies for the current user, when known.
+	HasUnread     *bool `protobuf:"varint,2,opt,name=has_unread,json=hasUnread,proto3,oneof" json:"has_unread,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ThreadViewerState) Reset() {
+	*x = ThreadViewerState{}
+	mi := &file_chatto_api_v1_message_types_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ThreadViewerState) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ThreadViewerState) ProtoMessage() {}
+
+func (x *ThreadViewerState) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_api_v1_message_types_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ThreadViewerState.ProtoReflect.Descriptor instead.
+func (*ThreadViewerState) Descriptor() ([]byte, []int) {
+	return file_chatto_api_v1_message_types_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *ThreadViewerState) GetIsFollowing() bool {
+	if x != nil && x.IsFollowing != nil {
+		return *x.IsFollowing
+	}
+	return false
+}
+
+func (x *ThreadViewerState) GetHasUnread() bool {
+	if x != nil && x.HasUnread != nil {
+		return *x.HasUnread
+	}
+	return false
+}
+
+// Aggregated state for one message thread.
+type ThreadSummary struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Event ID of the root message for the thread.
+	ThreadRootEventId string `protobuf:"bytes,1,opt,name=thread_root_event_id,json=threadRootEventId,proto3" json:"thread_root_event_id,omitempty"`
+	// Number of replies in this message's thread.
+	ReplyCount int32 `protobuf:"varint,2,opt,name=reply_count,json=replyCount,proto3" json:"reply_count,omitempty"`
+	// Creation time of the most recent reply in this message's thread.
+	LastReplyAt *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=last_reply_at,json=lastReplyAt,proto3" json:"last_reply_at,omitempty"`
+	// Preview of up to five user IDs that have participated in this message's
+	// thread.
+	ParticipantPreviewUserIds []string `protobuf:"bytes,4,rep,name=participant_preview_user_ids,json=participantPreviewUserIds,proto3" json:"participant_preview_user_ids,omitempty"`
+	// Total number of distinct users that have participated in this message's
+	// thread.
+	ParticipantCount int32 `protobuf:"varint,5,opt,name=participant_count,json=participantCount,proto3" json:"participant_count,omitempty"`
+	// State resolved for the current user.
+	ViewerState   *ThreadViewerState `protobuf:"bytes,6,opt,name=viewer_state,json=viewerState,proto3" json:"viewer_state,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ThreadSummary) Reset() {
+	*x = ThreadSummary{}
+	mi := &file_chatto_api_v1_message_types_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ThreadSummary) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ThreadSummary) ProtoMessage() {}
+
+func (x *ThreadSummary) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_api_v1_message_types_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ThreadSummary.ProtoReflect.Descriptor instead.
+func (*ThreadSummary) Descriptor() ([]byte, []int) {
+	return file_chatto_api_v1_message_types_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *ThreadSummary) GetThreadRootEventId() string {
+	if x != nil {
+		return x.ThreadRootEventId
+	}
+	return ""
+}
+
+func (x *ThreadSummary) GetReplyCount() int32 {
+	if x != nil {
+		return x.ReplyCount
+	}
+	return 0
+}
+
+func (x *ThreadSummary) GetLastReplyAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastReplyAt
+	}
+	return nil
+}
+
+func (x *ThreadSummary) GetParticipantPreviewUserIds() []string {
+	if x != nil {
+		return x.ParticipantPreviewUserIds
+	}
+	return nil
+}
+
+func (x *ThreadSummary) GetParticipantCount() int32 {
+	if x != nil {
+		return x.ParticipantCount
+	}
+	return 0
+}
+
+func (x *ThreadSummary) GetViewerState() *ThreadViewerState {
+	if x != nil {
+		return x.ViewerState
+	}
+	return nil
+}
+
 // Renderable message data.
 //
 // The same shape is used for top-level room messages, thread replies, and
@@ -556,27 +704,17 @@ type Message struct {
 	EchoFromThreadRootEventId string `protobuf:"bytes,12,opt,name=echo_from_thread_root_event_id,json=echoFromThreadRootEventId,proto3" json:"echo_from_thread_root_event_id,omitempty"`
 	// Channel timeline event ID for a thread echo, when applicable.
 	ChannelEchoEventId string `protobuf:"bytes,13,opt,name=channel_echo_event_id,json=channelEchoEventId,proto3" json:"channel_echo_event_id,omitempty"`
-	// Number of replies in this message's thread.
-	ReplyCount int32 `protobuf:"varint,14,opt,name=reply_count,json=replyCount,proto3" json:"reply_count,omitempty"`
-	// Creation time of the most recent reply in this message's thread.
-	LastReplyAt *timestamppb.Timestamp `protobuf:"bytes,15,opt,name=last_reply_at,json=lastReplyAt,proto3" json:"last_reply_at,omitempty"`
-	// Preview of up to five user IDs that have participated in this message's
-	// thread.
-	ThreadParticipantPreviewUserIds []string `protobuf:"bytes,16,rep,name=thread_participant_preview_user_ids,json=threadParticipantPreviewUserIds,proto3" json:"thread_participant_preview_user_ids,omitempty"`
-	// Total number of distinct users that have participated in this message's
-	// thread.
-	ThreadParticipantCount int32 `protobuf:"varint,17,opt,name=thread_participant_count,json=threadParticipantCount,proto3" json:"thread_participant_count,omitempty"`
-	// Whether the current user follows this message's thread, when known.
-	ViewerIsFollowingThread *bool `protobuf:"varint,18,opt,name=viewer_is_following_thread,json=viewerIsFollowingThread,proto3,oneof" json:"viewer_is_following_thread,omitempty"`
 	// Reaction summaries for this message.
-	Reactions     []*MessageReaction `protobuf:"bytes,19,rep,name=reactions,proto3" json:"reactions,omitempty"`
+	Reactions []*MessageReaction `protobuf:"bytes,19,rep,name=reactions,proto3" json:"reactions,omitempty"`
+	// Aggregated thread state, when known for a thread root message.
+	Thread        *ThreadSummary `protobuf:"bytes,20,opt,name=thread,proto3" json:"thread,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Message) Reset() {
 	*x = Message{}
-	mi := &file_chatto_api_v1_message_types_proto_msgTypes[5]
+	mi := &file_chatto_api_v1_message_types_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -588,7 +726,7 @@ func (x *Message) String() string {
 func (*Message) ProtoMessage() {}
 
 func (x *Message) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_message_types_proto_msgTypes[5]
+	mi := &file_chatto_api_v1_message_types_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -601,7 +739,7 @@ func (x *Message) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Message.ProtoReflect.Descriptor instead.
 func (*Message) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_message_types_proto_rawDescGZIP(), []int{5}
+	return file_chatto_api_v1_message_types_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *Message) GetId() string {
@@ -695,44 +833,16 @@ func (x *Message) GetChannelEchoEventId() string {
 	return ""
 }
 
-func (x *Message) GetReplyCount() int32 {
-	if x != nil {
-		return x.ReplyCount
-	}
-	return 0
-}
-
-func (x *Message) GetLastReplyAt() *timestamppb.Timestamp {
-	if x != nil {
-		return x.LastReplyAt
-	}
-	return nil
-}
-
-func (x *Message) GetThreadParticipantPreviewUserIds() []string {
-	if x != nil {
-		return x.ThreadParticipantPreviewUserIds
-	}
-	return nil
-}
-
-func (x *Message) GetThreadParticipantCount() int32 {
-	if x != nil {
-		return x.ThreadParticipantCount
-	}
-	return 0
-}
-
-func (x *Message) GetViewerIsFollowingThread() bool {
-	if x != nil && x.ViewerIsFollowingThread != nil {
-		return *x.ViewerIsFollowingThread
-	}
-	return false
-}
-
 func (x *Message) GetReactions() []*MessageReaction {
 	if x != nil {
 		return x.Reactions
+	}
+	return nil
+}
+
+func (x *Message) GetThread() *ThreadSummary {
+	if x != nil {
+		return x.Thread
 	}
 	return nil
 }
@@ -777,7 +887,21 @@ const file_chatto_api_v1_message_types_proto_rawDesc = "" +
 	"\x05count\x18\x02 \x01(\x05R\x05count\x12\x1f\n" +
 	"\vhas_reacted\x18\x03 \x01(\bR\n" +
 	"hasReacted\x12(\n" +
-	"\x10preview_user_ids\x18\x04 \x03(\tR\x0epreviewUserIds\"\xe0\a\n" +
+	"\x10preview_user_ids\x18\x04 \x03(\tR\x0epreviewUserIds\"\x7f\n" +
+	"\x11ThreadViewerState\x12&\n" +
+	"\fis_following\x18\x01 \x01(\bH\x00R\visFollowing\x88\x01\x01\x12\"\n" +
+	"\n" +
+	"has_unread\x18\x02 \x01(\bH\x01R\thasUnread\x88\x01\x01B\x0f\n" +
+	"\r_is_followingB\r\n" +
+	"\v_has_unread\"\xd4\x02\n" +
+	"\rThreadSummary\x12/\n" +
+	"\x14thread_root_event_id\x18\x01 \x01(\tR\x11threadRootEventId\x12\x1f\n" +
+	"\vreply_count\x18\x02 \x01(\x05R\n" +
+	"replyCount\x12>\n" +
+	"\rlast_reply_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\vlastReplyAt\x12?\n" +
+	"\x1cparticipant_preview_user_ids\x18\x04 \x03(\tR\x19participantPreviewUserIds\x12+\n" +
+	"\x11participant_count\x18\x05 \x01(\x05R\x10participantCount\x12C\n" +
+	"\fviewer_state\x18\x06 \x01(\v2 .chatto.api.v1.ThreadViewerStateR\vviewerState\"\xc9\x06\n" +
 	"\aMessage\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x17\n" +
 	"\aroom_id\x18\x02 \x01(\tR\x06roomId\x129\n" +
@@ -794,16 +918,10 @@ const file_chatto_api_v1_message_types_proto_rawDesc = "" +
 	" \x01(\tR\x11threadRootEventId\x12'\n" +
 	"\x10echo_of_event_id\x18\v \x01(\tR\rechoOfEventId\x12A\n" +
 	"\x1eecho_from_thread_root_event_id\x18\f \x01(\tR\x19echoFromThreadRootEventId\x121\n" +
-	"\x15channel_echo_event_id\x18\r \x01(\tR\x12channelEchoEventId\x12\x1f\n" +
-	"\vreply_count\x18\x0e \x01(\x05R\n" +
-	"replyCount\x12>\n" +
-	"\rlast_reply_at\x18\x0f \x01(\v2\x1a.google.protobuf.TimestampR\vlastReplyAt\x12L\n" +
-	"#thread_participant_preview_user_ids\x18\x10 \x03(\tR\x1fthreadParticipantPreviewUserIds\x128\n" +
-	"\x18thread_participant_count\x18\x11 \x01(\x05R\x16threadParticipantCount\x12@\n" +
-	"\x1aviewer_is_following_thread\x18\x12 \x01(\bH\x01R\x17viewerIsFollowingThread\x88\x01\x01\x12<\n" +
-	"\treactions\x18\x13 \x03(\v2\x1e.chatto.api.v1.MessageReactionR\treactionsB\a\n" +
-	"\x05_bodyB\x1d\n" +
-	"\x1b_viewer_is_following_thread*\xda\x01\n" +
+	"\x15channel_echo_event_id\x18\r \x01(\tR\x12channelEchoEventId\x12<\n" +
+	"\treactions\x18\x13 \x03(\v2\x1e.chatto.api.v1.MessageReactionR\treactions\x124\n" +
+	"\x06thread\x18\x14 \x01(\v2\x1c.chatto.api.v1.ThreadSummaryR\x06threadB\a\n" +
+	"\x05_bodyJ\x04\b\x0e\x10\x13R\vreply_countR\rlast_reply_atR#thread_participant_preview_user_idsR\x18thread_participant_countR\x1aviewer_is_following_thread*\xda\x01\n" +
 	"\x1cMessageVideoProcessingStatus\x12/\n" +
 	"+MESSAGE_VIDEO_PROCESSING_STATUS_UNSPECIFIED\x10\x00\x12.\n" +
 	"*MESSAGE_VIDEO_PROCESSING_STATUS_PROCESSING\x10\x01\x12-\n" +
@@ -824,7 +942,7 @@ func file_chatto_api_v1_message_types_proto_rawDescGZIP() []byte {
 }
 
 var file_chatto_api_v1_message_types_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_chatto_api_v1_message_types_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_chatto_api_v1_message_types_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_chatto_api_v1_message_types_proto_goTypes = []any{
 	(MessageVideoProcessingStatus)(0), // 0: chatto.api.v1.MessageVideoProcessingStatus
 	(*MessageAssetUrl)(nil),           // 1: chatto.api.v1.MessageAssetUrl
@@ -832,12 +950,14 @@ var file_chatto_api_v1_message_types_proto_goTypes = []any{
 	(*MessageVideoProcessing)(nil),    // 3: chatto.api.v1.MessageVideoProcessing
 	(*MessageAttachment)(nil),         // 4: chatto.api.v1.MessageAttachment
 	(*MessageReaction)(nil),           // 5: chatto.api.v1.MessageReaction
-	(*Message)(nil),                   // 6: chatto.api.v1.Message
-	(*timestamppb.Timestamp)(nil),     // 7: google.protobuf.Timestamp
-	(*LinkPreview)(nil),               // 8: chatto.api.v1.LinkPreview
+	(*ThreadViewerState)(nil),         // 6: chatto.api.v1.ThreadViewerState
+	(*ThreadSummary)(nil),             // 7: chatto.api.v1.ThreadSummary
+	(*Message)(nil),                   // 8: chatto.api.v1.Message
+	(*timestamppb.Timestamp)(nil),     // 9: google.protobuf.Timestamp
+	(*LinkPreview)(nil),               // 10: chatto.api.v1.LinkPreview
 }
 var file_chatto_api_v1_message_types_proto_depIdxs = []int32{
-	7,  // 0: chatto.api.v1.MessageAssetUrl.expires_at:type_name -> google.protobuf.Timestamp
+	9,  // 0: chatto.api.v1.MessageAssetUrl.expires_at:type_name -> google.protobuf.Timestamp
 	1,  // 1: chatto.api.v1.MessageVideoVariant.asset_url:type_name -> chatto.api.v1.MessageAssetUrl
 	0,  // 2: chatto.api.v1.MessageVideoProcessing.status:type_name -> chatto.api.v1.MessageVideoProcessingStatus
 	1,  // 3: chatto.api.v1.MessageVideoProcessing.thumbnail_asset_url:type_name -> chatto.api.v1.MessageAssetUrl
@@ -845,17 +965,19 @@ var file_chatto_api_v1_message_types_proto_depIdxs = []int32{
 	1,  // 5: chatto.api.v1.MessageAttachment.asset_url:type_name -> chatto.api.v1.MessageAssetUrl
 	1,  // 6: chatto.api.v1.MessageAttachment.thumbnail_asset_url:type_name -> chatto.api.v1.MessageAssetUrl
 	3,  // 7: chatto.api.v1.MessageAttachment.video_processing:type_name -> chatto.api.v1.MessageVideoProcessing
-	7,  // 8: chatto.api.v1.Message.created_at:type_name -> google.protobuf.Timestamp
-	4,  // 9: chatto.api.v1.Message.attachments:type_name -> chatto.api.v1.MessageAttachment
-	8,  // 10: chatto.api.v1.Message.link_preview:type_name -> chatto.api.v1.LinkPreview
-	7,  // 11: chatto.api.v1.Message.updated_at:type_name -> google.protobuf.Timestamp
-	7,  // 12: chatto.api.v1.Message.last_reply_at:type_name -> google.protobuf.Timestamp
-	5,  // 13: chatto.api.v1.Message.reactions:type_name -> chatto.api.v1.MessageReaction
-	14, // [14:14] is the sub-list for method output_type
-	14, // [14:14] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	9,  // 8: chatto.api.v1.ThreadSummary.last_reply_at:type_name -> google.protobuf.Timestamp
+	6,  // 9: chatto.api.v1.ThreadSummary.viewer_state:type_name -> chatto.api.v1.ThreadViewerState
+	9,  // 10: chatto.api.v1.Message.created_at:type_name -> google.protobuf.Timestamp
+	4,  // 11: chatto.api.v1.Message.attachments:type_name -> chatto.api.v1.MessageAttachment
+	10, // 12: chatto.api.v1.Message.link_preview:type_name -> chatto.api.v1.LinkPreview
+	9,  // 13: chatto.api.v1.Message.updated_at:type_name -> google.protobuf.Timestamp
+	5,  // 14: chatto.api.v1.Message.reactions:type_name -> chatto.api.v1.MessageReaction
+	7,  // 15: chatto.api.v1.Message.thread:type_name -> chatto.api.v1.ThreadSummary
+	16, // [16:16] is the sub-list for method output_type
+	16, // [16:16] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_chatto_api_v1_message_types_proto_init() }
@@ -865,13 +987,14 @@ func file_chatto_api_v1_message_types_proto_init() {
 	}
 	file_chatto_api_v1_link_previews_proto_init()
 	file_chatto_api_v1_message_types_proto_msgTypes[5].OneofWrappers = []any{}
+	file_chatto_api_v1_message_types_proto_msgTypes[7].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_api_v1_message_types_proto_rawDesc), len(file_chatto_api_v1_message_types_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   6,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/cli/internal/pb/chatto/api/v1/notifications.pb.go
+++ b/cli/internal/pb/chatto/api/v1/notifications.pb.go
@@ -23,75 +23,20 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// Room summary embedded in notification responses.
-type NotificationRoom struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Stable room ID.
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	// Room display name. Empty for DM rooms.
-	Name          string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *NotificationRoom) Reset() {
-	*x = NotificationRoom{}
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[0]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *NotificationRoom) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*NotificationRoom) ProtoMessage() {}
-
-func (x *NotificationRoom) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[0]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use NotificationRoom.ProtoReflect.Descriptor instead.
-func (*NotificationRoom) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{0}
-}
-
-func (x *NotificationRoom) GetId() string {
-	if x != nil {
-		return x.Id
-	}
-	return ""
-}
-
-func (x *NotificationRoom) GetName() string {
-	if x != nil {
-		return x.Name
-	}
-	return ""
-}
-
 // Direct-message notification payload.
 type DirectMessageNotification struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// DM room where the message was posted.
-	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
 	// Message event ID.
-	EventId       string `protobuf:"bytes,2,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	EventId string `protobuf:"bytes,2,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	// DM room where the message was posted.
+	Room          *RoomSummary `protobuf:"bytes,3,opt,name=room,proto3" json:"room,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *DirectMessageNotification) Reset() {
 	*x = DirectMessageNotification{}
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[1]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -103,7 +48,7 @@ func (x *DirectMessageNotification) String() string {
 func (*DirectMessageNotification) ProtoMessage() {}
 
 func (x *DirectMessageNotification) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[1]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -116,14 +61,7 @@ func (x *DirectMessageNotification) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DirectMessageNotification.ProtoReflect.Descriptor instead.
 func (*DirectMessageNotification) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{1}
-}
-
-func (x *DirectMessageNotification) GetRoomId() string {
-	if x != nil {
-		return x.RoomId
-	}
-	return ""
+	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *DirectMessageNotification) GetEventId() string {
@@ -133,11 +71,18 @@ func (x *DirectMessageNotification) GetEventId() string {
 	return ""
 }
 
+func (x *DirectMessageNotification) GetRoom() *RoomSummary {
+	if x != nil {
+		return x.Room
+	}
+	return nil
+}
+
 // Mention notification payload.
 type MentionNotification struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Room where the mention occurred.
-	Room *NotificationRoom `protobuf:"bytes,1,opt,name=room,proto3" json:"room,omitempty"`
+	Room *RoomSummary `protobuf:"bytes,1,opt,name=room,proto3" json:"room,omitempty"`
 	// Message event ID.
 	EventId string `protobuf:"bytes,2,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
 	// Thread root event ID when the mention happened inside a thread.
@@ -148,7 +93,7 @@ type MentionNotification struct {
 
 func (x *MentionNotification) Reset() {
 	*x = MentionNotification{}
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[2]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -160,7 +105,7 @@ func (x *MentionNotification) String() string {
 func (*MentionNotification) ProtoMessage() {}
 
 func (x *MentionNotification) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[2]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -173,10 +118,10 @@ func (x *MentionNotification) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MentionNotification.ProtoReflect.Descriptor instead.
 func (*MentionNotification) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{2}
+	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{1}
 }
 
-func (x *MentionNotification) GetRoom() *NotificationRoom {
+func (x *MentionNotification) GetRoom() *RoomSummary {
 	if x != nil {
 		return x.Room
 	}
@@ -201,7 +146,7 @@ func (x *MentionNotification) GetThreadRootEventId() string {
 type ReplyNotification struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Room where the reply occurred.
-	Room *NotificationRoom `protobuf:"bytes,1,opt,name=room,proto3" json:"room,omitempty"`
+	Room *RoomSummary `protobuf:"bytes,1,opt,name=room,proto3" json:"room,omitempty"`
 	// Reply event ID.
 	EventId string `protobuf:"bytes,2,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
 	// Event ID of the message being replied to.
@@ -214,7 +159,7 @@ type ReplyNotification struct {
 
 func (x *ReplyNotification) Reset() {
 	*x = ReplyNotification{}
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[3]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -226,7 +171,7 @@ func (x *ReplyNotification) String() string {
 func (*ReplyNotification) ProtoMessage() {}
 
 func (x *ReplyNotification) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[3]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -239,10 +184,10 @@ func (x *ReplyNotification) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplyNotification.ProtoReflect.Descriptor instead.
 func (*ReplyNotification) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{3}
+	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{2}
 }
 
-func (x *ReplyNotification) GetRoom() *NotificationRoom {
+func (x *ReplyNotification) GetRoom() *RoomSummary {
 	if x != nil {
 		return x.Room
 	}
@@ -274,7 +219,7 @@ func (x *ReplyNotification) GetThreadRootEventId() string {
 type RoomMessageNotification struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Room where the message was posted.
-	Room *NotificationRoom `protobuf:"bytes,1,opt,name=room,proto3" json:"room,omitempty"`
+	Room *RoomSummary `protobuf:"bytes,1,opt,name=room,proto3" json:"room,omitempty"`
 	// Message event ID.
 	EventId       string `protobuf:"bytes,2,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -283,7 +228,7 @@ type RoomMessageNotification struct {
 
 func (x *RoomMessageNotification) Reset() {
 	*x = RoomMessageNotification{}
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[4]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -295,7 +240,7 @@ func (x *RoomMessageNotification) String() string {
 func (*RoomMessageNotification) ProtoMessage() {}
 
 func (x *RoomMessageNotification) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[4]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -308,10 +253,10 @@ func (x *RoomMessageNotification) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomMessageNotification.ProtoReflect.Descriptor instead.
 func (*RoomMessageNotification) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{4}
+	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{3}
 }
 
-func (x *RoomMessageNotification) GetRoom() *NotificationRoom {
+func (x *RoomMessageNotification) GetRoom() *RoomSummary {
 	if x != nil {
 		return x.Room
 	}
@@ -347,7 +292,7 @@ type NotificationItem struct {
 
 func (x *NotificationItem) Reset() {
 	*x = NotificationItem{}
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[5]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -359,7 +304,7 @@ func (x *NotificationItem) String() string {
 func (*NotificationItem) ProtoMessage() {}
 
 func (x *NotificationItem) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[5]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -372,7 +317,7 @@ func (x *NotificationItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NotificationItem.ProtoReflect.Descriptor instead.
 func (*NotificationItem) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{5}
+	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *NotificationItem) GetId() string {
@@ -482,7 +427,7 @@ type ListNotificationsRequest struct {
 
 func (x *ListNotificationsRequest) Reset() {
 	*x = ListNotificationsRequest{}
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[6]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -494,7 +439,7 @@ func (x *ListNotificationsRequest) String() string {
 func (*ListNotificationsRequest) ProtoMessage() {}
 
 func (x *ListNotificationsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[6]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -507,7 +452,7 @@ func (x *ListNotificationsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNotificationsRequest.ProtoReflect.Descriptor instead.
 func (*ListNotificationsRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{6}
+	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ListNotificationsRequest) GetPage() *PageRequest {
@@ -530,7 +475,7 @@ type ListRoomNotificationsRequest struct {
 
 func (x *ListRoomNotificationsRequest) Reset() {
 	*x = ListRoomNotificationsRequest{}
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[7]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -542,7 +487,7 @@ func (x *ListRoomNotificationsRequest) String() string {
 func (*ListRoomNotificationsRequest) ProtoMessage() {}
 
 func (x *ListRoomNotificationsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[7]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -555,7 +500,7 @@ func (x *ListRoomNotificationsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoomNotificationsRequest.ProtoReflect.Descriptor instead.
 func (*ListRoomNotificationsRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{7}
+	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ListRoomNotificationsRequest) GetRoomId() string {
@@ -585,7 +530,7 @@ type ListNotificationsResponse struct {
 
 func (x *ListNotificationsResponse) Reset() {
 	*x = ListNotificationsResponse{}
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[8]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -597,7 +542,7 @@ func (x *ListNotificationsResponse) String() string {
 func (*ListNotificationsResponse) ProtoMessage() {}
 
 func (x *ListNotificationsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[8]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -610,7 +555,7 @@ func (x *ListNotificationsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNotificationsResponse.ProtoReflect.Descriptor instead.
 func (*ListNotificationsResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{8}
+	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ListNotificationsResponse) GetNotifications() []*NotificationItem {
@@ -638,7 +583,7 @@ type GetNotificationRequest struct {
 
 func (x *GetNotificationRequest) Reset() {
 	*x = GetNotificationRequest{}
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[9]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -650,7 +595,7 @@ func (x *GetNotificationRequest) String() string {
 func (*GetNotificationRequest) ProtoMessage() {}
 
 func (x *GetNotificationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[9]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -663,7 +608,7 @@ func (x *GetNotificationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNotificationRequest.ProtoReflect.Descriptor instead.
 func (*GetNotificationRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{9}
+	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *GetNotificationRequest) GetNotificationId() string {
@@ -684,7 +629,7 @@ type GetNotificationResponse struct {
 
 func (x *GetNotificationResponse) Reset() {
 	*x = GetNotificationResponse{}
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[10]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -696,7 +641,7 @@ func (x *GetNotificationResponse) String() string {
 func (*GetNotificationResponse) ProtoMessage() {}
 
 func (x *GetNotificationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[10]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -709,7 +654,7 @@ func (x *GetNotificationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNotificationResponse.ProtoReflect.Descriptor instead.
 func (*GetNotificationResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{10}
+	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *GetNotificationResponse) GetNotification() *NotificationItem {
@@ -731,7 +676,7 @@ type BatchGetNotificationsRequest struct {
 
 func (x *BatchGetNotificationsRequest) Reset() {
 	*x = BatchGetNotificationsRequest{}
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[11]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -743,7 +688,7 @@ func (x *BatchGetNotificationsRequest) String() string {
 func (*BatchGetNotificationsRequest) ProtoMessage() {}
 
 func (x *BatchGetNotificationsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[11]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -756,7 +701,7 @@ func (x *BatchGetNotificationsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BatchGetNotificationsRequest.ProtoReflect.Descriptor instead.
 func (*BatchGetNotificationsRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{11}
+	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *BatchGetNotificationsRequest) GetNotificationIds() []string {
@@ -778,7 +723,7 @@ type BatchGetNotificationsResponse struct {
 
 func (x *BatchGetNotificationsResponse) Reset() {
 	*x = BatchGetNotificationsResponse{}
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[12]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -790,7 +735,7 @@ func (x *BatchGetNotificationsResponse) String() string {
 func (*BatchGetNotificationsResponse) ProtoMessage() {}
 
 func (x *BatchGetNotificationsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[12]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -803,7 +748,7 @@ func (x *BatchGetNotificationsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BatchGetNotificationsResponse.ProtoReflect.Descriptor instead.
 func (*BatchGetNotificationsResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{12}
+	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *BatchGetNotificationsResponse) GetNotifications() []*NotificationItem {
@@ -826,7 +771,7 @@ type ListRoomNotificationsResponse struct {
 
 func (x *ListRoomNotificationsResponse) Reset() {
 	*x = ListRoomNotificationsResponse{}
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[13]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -838,7 +783,7 @@ func (x *ListRoomNotificationsResponse) String() string {
 func (*ListRoomNotificationsResponse) ProtoMessage() {}
 
 func (x *ListRoomNotificationsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[13]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -851,7 +796,7 @@ func (x *ListRoomNotificationsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoomNotificationsResponse.ProtoReflect.Descriptor instead.
 func (*ListRoomNotificationsResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{13}
+	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ListRoomNotificationsResponse) GetNotifications() []*NotificationItem {
@@ -877,7 +822,7 @@ type HasNotificationsRequest struct {
 
 func (x *HasNotificationsRequest) Reset() {
 	*x = HasNotificationsRequest{}
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[14]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -889,7 +834,7 @@ func (x *HasNotificationsRequest) String() string {
 func (*HasNotificationsRequest) ProtoMessage() {}
 
 func (x *HasNotificationsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[14]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -902,7 +847,7 @@ func (x *HasNotificationsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HasNotificationsRequest.ProtoReflect.Descriptor instead.
 func (*HasNotificationsRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{14}
+	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{13}
 }
 
 // Lightweight pending notification check.
@@ -916,7 +861,7 @@ type HasNotificationsResponse struct {
 
 func (x *HasNotificationsResponse) Reset() {
 	*x = HasNotificationsResponse{}
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[15]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -928,7 +873,7 @@ func (x *HasNotificationsResponse) String() string {
 func (*HasNotificationsResponse) ProtoMessage() {}
 
 func (x *HasNotificationsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[15]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -941,7 +886,7 @@ func (x *HasNotificationsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HasNotificationsResponse.ProtoReflect.Descriptor instead.
 func (*HasNotificationsResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{15}
+	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *HasNotificationsResponse) GetHasNotifications() bool {
@@ -964,7 +909,7 @@ type RoomNotificationCount struct {
 
 func (x *RoomNotificationCount) Reset() {
 	*x = RoomNotificationCount{}
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[16]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -976,7 +921,7 @@ func (x *RoomNotificationCount) String() string {
 func (*RoomNotificationCount) ProtoMessage() {}
 
 func (x *RoomNotificationCount) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[16]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -989,7 +934,7 @@ func (x *RoomNotificationCount) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomNotificationCount.ProtoReflect.Descriptor instead.
 func (*RoomNotificationCount) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{16}
+	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *RoomNotificationCount) GetRoomId() string {
@@ -1015,7 +960,7 @@ type ListRoomNotificationCountsRequest struct {
 
 func (x *ListRoomNotificationCountsRequest) Reset() {
 	*x = ListRoomNotificationCountsRequest{}
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[17]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1027,7 +972,7 @@ func (x *ListRoomNotificationCountsRequest) String() string {
 func (*ListRoomNotificationCountsRequest) ProtoMessage() {}
 
 func (x *ListRoomNotificationCountsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[17]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1040,7 +985,7 @@ func (x *ListRoomNotificationCountsRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use ListRoomNotificationCountsRequest.ProtoReflect.Descriptor instead.
 func (*ListRoomNotificationCountsRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{17}
+	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{16}
 }
 
 // Finite snapshot of pending notification counts grouped by room.
@@ -1054,7 +999,7 @@ type ListRoomNotificationCountsResponse struct {
 
 func (x *ListRoomNotificationCountsResponse) Reset() {
 	*x = ListRoomNotificationCountsResponse{}
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[18]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1066,7 +1011,7 @@ func (x *ListRoomNotificationCountsResponse) String() string {
 func (*ListRoomNotificationCountsResponse) ProtoMessage() {}
 
 func (x *ListRoomNotificationCountsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[18]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1079,7 +1024,7 @@ func (x *ListRoomNotificationCountsResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use ListRoomNotificationCountsResponse.ProtoReflect.Descriptor instead.
 func (*ListRoomNotificationCountsResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{18}
+	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ListRoomNotificationCountsResponse) GetRoomCounts() []*RoomNotificationCount {
@@ -1100,7 +1045,7 @@ type DismissNotificationRequest struct {
 
 func (x *DismissNotificationRequest) Reset() {
 	*x = DismissNotificationRequest{}
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[19]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1112,7 +1057,7 @@ func (x *DismissNotificationRequest) String() string {
 func (*DismissNotificationRequest) ProtoMessage() {}
 
 func (x *DismissNotificationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[19]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1125,7 +1070,7 @@ func (x *DismissNotificationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DismissNotificationRequest.ProtoReflect.Descriptor instead.
 func (*DismissNotificationRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{19}
+	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *DismissNotificationRequest) GetNotificationId() string {
@@ -1146,7 +1091,7 @@ type DismissNotificationResponse struct {
 
 func (x *DismissNotificationResponse) Reset() {
 	*x = DismissNotificationResponse{}
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[20]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1158,7 +1103,7 @@ func (x *DismissNotificationResponse) String() string {
 func (*DismissNotificationResponse) ProtoMessage() {}
 
 func (x *DismissNotificationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[20]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1171,7 +1116,7 @@ func (x *DismissNotificationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DismissNotificationResponse.ProtoReflect.Descriptor instead.
 func (*DismissNotificationResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{20}
+	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *DismissNotificationResponse) GetDismissed() bool {
@@ -1190,7 +1135,7 @@ type DismissAllNotificationsRequest struct {
 
 func (x *DismissAllNotificationsRequest) Reset() {
 	*x = DismissAllNotificationsRequest{}
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[21]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1202,7 +1147,7 @@ func (x *DismissAllNotificationsRequest) String() string {
 func (*DismissAllNotificationsRequest) ProtoMessage() {}
 
 func (x *DismissAllNotificationsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[21]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1215,7 +1160,7 @@ func (x *DismissAllNotificationsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DismissAllNotificationsRequest.ProtoReflect.Descriptor instead.
 func (*DismissAllNotificationsRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{21}
+	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{20}
 }
 
 // Result of dismissing all pending notifications.
@@ -1229,7 +1174,7 @@ type DismissAllNotificationsResponse struct {
 
 func (x *DismissAllNotificationsResponse) Reset() {
 	*x = DismissAllNotificationsResponse{}
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[22]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1241,7 +1186,7 @@ func (x *DismissAllNotificationsResponse) String() string {
 func (*DismissAllNotificationsResponse) ProtoMessage() {}
 
 func (x *DismissAllNotificationsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_notifications_proto_msgTypes[22]
+	mi := &file_chatto_api_v1_notifications_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1254,7 +1199,7 @@ func (x *DismissAllNotificationsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DismissAllNotificationsResponse.ProtoReflect.Descriptor instead.
 func (*DismissAllNotificationsResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{22}
+	return file_chatto_api_v1_notifications_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *DismissAllNotificationsResponse) GetDismissedCount() int32 {
@@ -1268,26 +1213,23 @@ var File_chatto_api_v1_notifications_proto protoreflect.FileDescriptor
 
 const file_chatto_api_v1_notifications_proto_rawDesc = "" +
 	"\n" +
-	"!chatto/api/v1/notifications.proto\x12\rchatto.api.v1\x1a\x1bbuf/validate/validate.proto\x1a\x1echatto/api/v1/pagination.proto\x1a\x19chatto/api/v1/users.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"6\n" +
-	"\x10NotificationRoom\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
-	"\x04name\x18\x02 \x01(\tR\x04name\"O\n" +
-	"\x19DirectMessageNotification\x12\x17\n" +
-	"\aroom_id\x18\x01 \x01(\tR\x06roomId\x12\x19\n" +
-	"\bevent_id\x18\x02 \x01(\tR\aeventId\"\xb4\x01\n" +
-	"\x13MentionNotification\x123\n" +
-	"\x04room\x18\x01 \x01(\v2\x1f.chatto.api.v1.NotificationRoomR\x04room\x12\x19\n" +
+	"!chatto/api/v1/notifications.proto\x12\rchatto.api.v1\x1a\x1bbuf/validate/validate.proto\x1a\x1echatto/api/v1/pagination.proto\x1a\x19chatto/api/v1/rooms.proto\x1a\x19chatto/api/v1/users.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"u\n" +
+	"\x19DirectMessageNotification\x12\x19\n" +
+	"\bevent_id\x18\x02 \x01(\tR\aeventId\x12.\n" +
+	"\x04room\x18\x03 \x01(\v2\x1a.chatto.api.v1.RoomSummaryR\x04roomJ\x04\b\x01\x10\x02R\aroom_id\"\xaf\x01\n" +
+	"\x13MentionNotification\x12.\n" +
+	"\x04room\x18\x01 \x01(\v2\x1a.chatto.api.v1.RoomSummaryR\x04room\x12\x19\n" +
 	"\bevent_id\x18\x02 \x01(\tR\aeventId\x124\n" +
 	"\x14thread_root_event_id\x18\x03 \x01(\tH\x00R\x11threadRootEventId\x88\x01\x01B\x17\n" +
-	"\x15_thread_root_event_id\"\xd7\x01\n" +
-	"\x11ReplyNotification\x123\n" +
-	"\x04room\x18\x01 \x01(\v2\x1f.chatto.api.v1.NotificationRoomR\x04room\x12\x19\n" +
+	"\x15_thread_root_event_id\"\xd2\x01\n" +
+	"\x11ReplyNotification\x12.\n" +
+	"\x04room\x18\x01 \x01(\v2\x1a.chatto.api.v1.RoomSummaryR\x04room\x12\x19\n" +
 	"\bevent_id\x18\x02 \x01(\tR\aeventId\x12#\n" +
 	"\x0ein_reply_to_id\x18\x03 \x01(\tR\vinReplyToId\x124\n" +
 	"\x14thread_root_event_id\x18\x04 \x01(\tH\x00R\x11threadRootEventId\x88\x01\x01B\x17\n" +
-	"\x15_thread_root_event_id\"i\n" +
-	"\x17RoomMessageNotification\x123\n" +
-	"\x04room\x18\x01 \x01(\v2\x1f.chatto.api.v1.NotificationRoomR\x04room\x12\x19\n" +
+	"\x15_thread_root_event_id\"d\n" +
+	"\x17RoomMessageNotification\x12.\n" +
+	"\x04room\x18\x01 \x01(\v2\x1a.chatto.api.v1.RoomSummaryR\x04room\x12\x19\n" +
 	"\bevent_id\x18\x02 \x01(\tR\aeventId\"\xb9\x03\n" +
 	"\x10NotificationItem\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x129\n" +
@@ -1361,76 +1303,77 @@ func file_chatto_api_v1_notifications_proto_rawDescGZIP() []byte {
 	return file_chatto_api_v1_notifications_proto_rawDescData
 }
 
-var file_chatto_api_v1_notifications_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
+var file_chatto_api_v1_notifications_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
 var file_chatto_api_v1_notifications_proto_goTypes = []any{
-	(*NotificationRoom)(nil),                   // 0: chatto.api.v1.NotificationRoom
-	(*DirectMessageNotification)(nil),          // 1: chatto.api.v1.DirectMessageNotification
-	(*MentionNotification)(nil),                // 2: chatto.api.v1.MentionNotification
-	(*ReplyNotification)(nil),                  // 3: chatto.api.v1.ReplyNotification
-	(*RoomMessageNotification)(nil),            // 4: chatto.api.v1.RoomMessageNotification
-	(*NotificationItem)(nil),                   // 5: chatto.api.v1.NotificationItem
-	(*ListNotificationsRequest)(nil),           // 6: chatto.api.v1.ListNotificationsRequest
-	(*ListRoomNotificationsRequest)(nil),       // 7: chatto.api.v1.ListRoomNotificationsRequest
-	(*ListNotificationsResponse)(nil),          // 8: chatto.api.v1.ListNotificationsResponse
-	(*GetNotificationRequest)(nil),             // 9: chatto.api.v1.GetNotificationRequest
-	(*GetNotificationResponse)(nil),            // 10: chatto.api.v1.GetNotificationResponse
-	(*BatchGetNotificationsRequest)(nil),       // 11: chatto.api.v1.BatchGetNotificationsRequest
-	(*BatchGetNotificationsResponse)(nil),      // 12: chatto.api.v1.BatchGetNotificationsResponse
-	(*ListRoomNotificationsResponse)(nil),      // 13: chatto.api.v1.ListRoomNotificationsResponse
-	(*HasNotificationsRequest)(nil),            // 14: chatto.api.v1.HasNotificationsRequest
-	(*HasNotificationsResponse)(nil),           // 15: chatto.api.v1.HasNotificationsResponse
-	(*RoomNotificationCount)(nil),              // 16: chatto.api.v1.RoomNotificationCount
-	(*ListRoomNotificationCountsRequest)(nil),  // 17: chatto.api.v1.ListRoomNotificationCountsRequest
-	(*ListRoomNotificationCountsResponse)(nil), // 18: chatto.api.v1.ListRoomNotificationCountsResponse
-	(*DismissNotificationRequest)(nil),         // 19: chatto.api.v1.DismissNotificationRequest
-	(*DismissNotificationResponse)(nil),        // 20: chatto.api.v1.DismissNotificationResponse
-	(*DismissAllNotificationsRequest)(nil),     // 21: chatto.api.v1.DismissAllNotificationsRequest
-	(*DismissAllNotificationsResponse)(nil),    // 22: chatto.api.v1.DismissAllNotificationsResponse
+	(*DirectMessageNotification)(nil),          // 0: chatto.api.v1.DirectMessageNotification
+	(*MentionNotification)(nil),                // 1: chatto.api.v1.MentionNotification
+	(*ReplyNotification)(nil),                  // 2: chatto.api.v1.ReplyNotification
+	(*RoomMessageNotification)(nil),            // 3: chatto.api.v1.RoomMessageNotification
+	(*NotificationItem)(nil),                   // 4: chatto.api.v1.NotificationItem
+	(*ListNotificationsRequest)(nil),           // 5: chatto.api.v1.ListNotificationsRequest
+	(*ListRoomNotificationsRequest)(nil),       // 6: chatto.api.v1.ListRoomNotificationsRequest
+	(*ListNotificationsResponse)(nil),          // 7: chatto.api.v1.ListNotificationsResponse
+	(*GetNotificationRequest)(nil),             // 8: chatto.api.v1.GetNotificationRequest
+	(*GetNotificationResponse)(nil),            // 9: chatto.api.v1.GetNotificationResponse
+	(*BatchGetNotificationsRequest)(nil),       // 10: chatto.api.v1.BatchGetNotificationsRequest
+	(*BatchGetNotificationsResponse)(nil),      // 11: chatto.api.v1.BatchGetNotificationsResponse
+	(*ListRoomNotificationsResponse)(nil),      // 12: chatto.api.v1.ListRoomNotificationsResponse
+	(*HasNotificationsRequest)(nil),            // 13: chatto.api.v1.HasNotificationsRequest
+	(*HasNotificationsResponse)(nil),           // 14: chatto.api.v1.HasNotificationsResponse
+	(*RoomNotificationCount)(nil),              // 15: chatto.api.v1.RoomNotificationCount
+	(*ListRoomNotificationCountsRequest)(nil),  // 16: chatto.api.v1.ListRoomNotificationCountsRequest
+	(*ListRoomNotificationCountsResponse)(nil), // 17: chatto.api.v1.ListRoomNotificationCountsResponse
+	(*DismissNotificationRequest)(nil),         // 18: chatto.api.v1.DismissNotificationRequest
+	(*DismissNotificationResponse)(nil),        // 19: chatto.api.v1.DismissNotificationResponse
+	(*DismissAllNotificationsRequest)(nil),     // 20: chatto.api.v1.DismissAllNotificationsRequest
+	(*DismissAllNotificationsResponse)(nil),    // 21: chatto.api.v1.DismissAllNotificationsResponse
+	(*RoomSummary)(nil),                        // 22: chatto.api.v1.RoomSummary
 	(*timestamppb.Timestamp)(nil),              // 23: google.protobuf.Timestamp
 	(*User)(nil),                               // 24: chatto.api.v1.User
 	(*PageRequest)(nil),                        // 25: chatto.api.v1.PageRequest
 	(*PageInfo)(nil),                           // 26: chatto.api.v1.PageInfo
 }
 var file_chatto_api_v1_notifications_proto_depIdxs = []int32{
-	0,  // 0: chatto.api.v1.MentionNotification.room:type_name -> chatto.api.v1.NotificationRoom
-	0,  // 1: chatto.api.v1.ReplyNotification.room:type_name -> chatto.api.v1.NotificationRoom
-	0,  // 2: chatto.api.v1.RoomMessageNotification.room:type_name -> chatto.api.v1.NotificationRoom
-	23, // 3: chatto.api.v1.NotificationItem.created_at:type_name -> google.protobuf.Timestamp
-	24, // 4: chatto.api.v1.NotificationItem.actor:type_name -> chatto.api.v1.User
-	1,  // 5: chatto.api.v1.NotificationItem.direct_message:type_name -> chatto.api.v1.DirectMessageNotification
-	2,  // 6: chatto.api.v1.NotificationItem.mention:type_name -> chatto.api.v1.MentionNotification
-	3,  // 7: chatto.api.v1.NotificationItem.reply:type_name -> chatto.api.v1.ReplyNotification
-	4,  // 8: chatto.api.v1.NotificationItem.room_message:type_name -> chatto.api.v1.RoomMessageNotification
-	25, // 9: chatto.api.v1.ListNotificationsRequest.page:type_name -> chatto.api.v1.PageRequest
-	25, // 10: chatto.api.v1.ListRoomNotificationsRequest.page:type_name -> chatto.api.v1.PageRequest
-	5,  // 11: chatto.api.v1.ListNotificationsResponse.notifications:type_name -> chatto.api.v1.NotificationItem
-	26, // 12: chatto.api.v1.ListNotificationsResponse.page:type_name -> chatto.api.v1.PageInfo
-	5,  // 13: chatto.api.v1.GetNotificationResponse.notification:type_name -> chatto.api.v1.NotificationItem
-	5,  // 14: chatto.api.v1.BatchGetNotificationsResponse.notifications:type_name -> chatto.api.v1.NotificationItem
-	5,  // 15: chatto.api.v1.ListRoomNotificationsResponse.notifications:type_name -> chatto.api.v1.NotificationItem
-	26, // 16: chatto.api.v1.ListRoomNotificationsResponse.page:type_name -> chatto.api.v1.PageInfo
-	16, // 17: chatto.api.v1.ListRoomNotificationCountsResponse.room_counts:type_name -> chatto.api.v1.RoomNotificationCount
-	6,  // 18: chatto.api.v1.NotificationService.ListNotifications:input_type -> chatto.api.v1.ListNotificationsRequest
-	9,  // 19: chatto.api.v1.NotificationService.GetNotification:input_type -> chatto.api.v1.GetNotificationRequest
-	11, // 20: chatto.api.v1.NotificationService.BatchGetNotifications:input_type -> chatto.api.v1.BatchGetNotificationsRequest
-	7,  // 21: chatto.api.v1.NotificationService.ListRoomNotifications:input_type -> chatto.api.v1.ListRoomNotificationsRequest
-	17, // 22: chatto.api.v1.NotificationService.ListRoomNotificationCounts:input_type -> chatto.api.v1.ListRoomNotificationCountsRequest
-	14, // 23: chatto.api.v1.NotificationService.HasNotifications:input_type -> chatto.api.v1.HasNotificationsRequest
-	19, // 24: chatto.api.v1.NotificationService.DismissNotification:input_type -> chatto.api.v1.DismissNotificationRequest
-	21, // 25: chatto.api.v1.NotificationService.DismissAllNotifications:input_type -> chatto.api.v1.DismissAllNotificationsRequest
-	8,  // 26: chatto.api.v1.NotificationService.ListNotifications:output_type -> chatto.api.v1.ListNotificationsResponse
-	10, // 27: chatto.api.v1.NotificationService.GetNotification:output_type -> chatto.api.v1.GetNotificationResponse
-	12, // 28: chatto.api.v1.NotificationService.BatchGetNotifications:output_type -> chatto.api.v1.BatchGetNotificationsResponse
-	13, // 29: chatto.api.v1.NotificationService.ListRoomNotifications:output_type -> chatto.api.v1.ListRoomNotificationsResponse
-	18, // 30: chatto.api.v1.NotificationService.ListRoomNotificationCounts:output_type -> chatto.api.v1.ListRoomNotificationCountsResponse
-	15, // 31: chatto.api.v1.NotificationService.HasNotifications:output_type -> chatto.api.v1.HasNotificationsResponse
-	20, // 32: chatto.api.v1.NotificationService.DismissNotification:output_type -> chatto.api.v1.DismissNotificationResponse
-	22, // 33: chatto.api.v1.NotificationService.DismissAllNotifications:output_type -> chatto.api.v1.DismissAllNotificationsResponse
-	26, // [26:34] is the sub-list for method output_type
-	18, // [18:26] is the sub-list for method input_type
-	18, // [18:18] is the sub-list for extension type_name
-	18, // [18:18] is the sub-list for extension extendee
-	0,  // [0:18] is the sub-list for field type_name
+	22, // 0: chatto.api.v1.DirectMessageNotification.room:type_name -> chatto.api.v1.RoomSummary
+	22, // 1: chatto.api.v1.MentionNotification.room:type_name -> chatto.api.v1.RoomSummary
+	22, // 2: chatto.api.v1.ReplyNotification.room:type_name -> chatto.api.v1.RoomSummary
+	22, // 3: chatto.api.v1.RoomMessageNotification.room:type_name -> chatto.api.v1.RoomSummary
+	23, // 4: chatto.api.v1.NotificationItem.created_at:type_name -> google.protobuf.Timestamp
+	24, // 5: chatto.api.v1.NotificationItem.actor:type_name -> chatto.api.v1.User
+	0,  // 6: chatto.api.v1.NotificationItem.direct_message:type_name -> chatto.api.v1.DirectMessageNotification
+	1,  // 7: chatto.api.v1.NotificationItem.mention:type_name -> chatto.api.v1.MentionNotification
+	2,  // 8: chatto.api.v1.NotificationItem.reply:type_name -> chatto.api.v1.ReplyNotification
+	3,  // 9: chatto.api.v1.NotificationItem.room_message:type_name -> chatto.api.v1.RoomMessageNotification
+	25, // 10: chatto.api.v1.ListNotificationsRequest.page:type_name -> chatto.api.v1.PageRequest
+	25, // 11: chatto.api.v1.ListRoomNotificationsRequest.page:type_name -> chatto.api.v1.PageRequest
+	4,  // 12: chatto.api.v1.ListNotificationsResponse.notifications:type_name -> chatto.api.v1.NotificationItem
+	26, // 13: chatto.api.v1.ListNotificationsResponse.page:type_name -> chatto.api.v1.PageInfo
+	4,  // 14: chatto.api.v1.GetNotificationResponse.notification:type_name -> chatto.api.v1.NotificationItem
+	4,  // 15: chatto.api.v1.BatchGetNotificationsResponse.notifications:type_name -> chatto.api.v1.NotificationItem
+	4,  // 16: chatto.api.v1.ListRoomNotificationsResponse.notifications:type_name -> chatto.api.v1.NotificationItem
+	26, // 17: chatto.api.v1.ListRoomNotificationsResponse.page:type_name -> chatto.api.v1.PageInfo
+	15, // 18: chatto.api.v1.ListRoomNotificationCountsResponse.room_counts:type_name -> chatto.api.v1.RoomNotificationCount
+	5,  // 19: chatto.api.v1.NotificationService.ListNotifications:input_type -> chatto.api.v1.ListNotificationsRequest
+	8,  // 20: chatto.api.v1.NotificationService.GetNotification:input_type -> chatto.api.v1.GetNotificationRequest
+	10, // 21: chatto.api.v1.NotificationService.BatchGetNotifications:input_type -> chatto.api.v1.BatchGetNotificationsRequest
+	6,  // 22: chatto.api.v1.NotificationService.ListRoomNotifications:input_type -> chatto.api.v1.ListRoomNotificationsRequest
+	16, // 23: chatto.api.v1.NotificationService.ListRoomNotificationCounts:input_type -> chatto.api.v1.ListRoomNotificationCountsRequest
+	13, // 24: chatto.api.v1.NotificationService.HasNotifications:input_type -> chatto.api.v1.HasNotificationsRequest
+	18, // 25: chatto.api.v1.NotificationService.DismissNotification:input_type -> chatto.api.v1.DismissNotificationRequest
+	20, // 26: chatto.api.v1.NotificationService.DismissAllNotifications:input_type -> chatto.api.v1.DismissAllNotificationsRequest
+	7,  // 27: chatto.api.v1.NotificationService.ListNotifications:output_type -> chatto.api.v1.ListNotificationsResponse
+	9,  // 28: chatto.api.v1.NotificationService.GetNotification:output_type -> chatto.api.v1.GetNotificationResponse
+	11, // 29: chatto.api.v1.NotificationService.BatchGetNotifications:output_type -> chatto.api.v1.BatchGetNotificationsResponse
+	12, // 30: chatto.api.v1.NotificationService.ListRoomNotifications:output_type -> chatto.api.v1.ListRoomNotificationsResponse
+	17, // 31: chatto.api.v1.NotificationService.ListRoomNotificationCounts:output_type -> chatto.api.v1.ListRoomNotificationCountsResponse
+	14, // 32: chatto.api.v1.NotificationService.HasNotifications:output_type -> chatto.api.v1.HasNotificationsResponse
+	19, // 33: chatto.api.v1.NotificationService.DismissNotification:output_type -> chatto.api.v1.DismissNotificationResponse
+	21, // 34: chatto.api.v1.NotificationService.DismissAllNotifications:output_type -> chatto.api.v1.DismissAllNotificationsResponse
+	27, // [27:35] is the sub-list for method output_type
+	19, // [19:27] is the sub-list for method input_type
+	19, // [19:19] is the sub-list for extension type_name
+	19, // [19:19] is the sub-list for extension extendee
+	0,  // [0:19] is the sub-list for field type_name
 }
 
 func init() { file_chatto_api_v1_notifications_proto_init() }
@@ -1439,10 +1382,11 @@ func file_chatto_api_v1_notifications_proto_init() {
 		return
 	}
 	file_chatto_api_v1_pagination_proto_init()
+	file_chatto_api_v1_rooms_proto_init()
 	file_chatto_api_v1_users_proto_init()
+	file_chatto_api_v1_notifications_proto_msgTypes[1].OneofWrappers = []any{}
 	file_chatto_api_v1_notifications_proto_msgTypes[2].OneofWrappers = []any{}
-	file_chatto_api_v1_notifications_proto_msgTypes[3].OneofWrappers = []any{}
-	file_chatto_api_v1_notifications_proto_msgTypes[5].OneofWrappers = []any{
+	file_chatto_api_v1_notifications_proto_msgTypes[4].OneofWrappers = []any{
 		(*NotificationItem_DirectMessage)(nil),
 		(*NotificationItem_Mention)(nil),
 		(*NotificationItem_Reply)(nil),
@@ -1454,7 +1398,7 @@ func file_chatto_api_v1_notifications_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_api_v1_notifications_proto_rawDesc), len(file_chatto_api_v1_notifications_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   23,
+			NumMessages:   22,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/cli/internal/pb/chatto/api/v1/room_directory.pb.go
+++ b/cli/internal/pb/chatto/api/v1/room_directory.pb.go
@@ -79,43 +79,85 @@ func (RoomDirectoryScope) EnumDescriptor() ([]byte, []int) {
 	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{0}
 }
 
+// Viewer-specific state and permission decisions for one room.
+type RoomViewerState struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// True when the current user is an effective room member.
+	IsMember bool `protobuf:"varint,1,opt,name=is_member,json=isMember,proto3" json:"is_member,omitempty"`
+	// True when the room has unread root messages for the current user.
+	HasUnread bool `protobuf:"varint,2,opt,name=has_unread,json=hasUnread,proto3" json:"has_unread,omitempty"`
+	// Effective room-scoped permission decisions after room state constraints.
+	Permissions   []*PermissionGrant `protobuf:"bytes,3,rep,name=permissions,proto3" json:"permissions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RoomViewerState) Reset() {
+	*x = RoomViewerState{}
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RoomViewerState) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RoomViewerState) ProtoMessage() {}
+
+func (x *RoomViewerState) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RoomViewerState.ProtoReflect.Descriptor instead.
+func (*RoomViewerState) Descriptor() ([]byte, []int) {
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *RoomViewerState) GetIsMember() bool {
+	if x != nil {
+		return x.IsMember
+	}
+	return false
+}
+
+func (x *RoomViewerState) GetHasUnread() bool {
+	if x != nil {
+		return x.HasUnread
+	}
+	return false
+}
+
+func (x *RoomViewerState) GetPermissions() []*PermissionGrant {
+	if x != nil {
+		return x.Permissions
+	}
+	return nil
+}
+
 // Room metadata plus state and capabilities resolved for the authenticated
 // viewer.
 type RoomWithViewerState struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Public room metadata.
 	Room *Room `protobuf:"bytes,1,opt,name=room,proto3" json:"room,omitempty"`
-	// True when the current user is an effective room member.
-	IsMember bool `protobuf:"varint,2,opt,name=is_member,json=isMember,proto3" json:"is_member,omitempty"`
-	// True when the room has unread root messages for the current user.
-	HasUnread bool `protobuf:"varint,3,opt,name=has_unread,json=hasUnread,proto3" json:"has_unread,omitempty"`
-	// True when the room can appear in directory surfaces for the current user.
-	CanListRoom bool `protobuf:"varint,4,opt,name=can_list_room,json=canListRoom,proto3" json:"can_list_room,omitempty"`
-	// True when the current user can join this room.
-	CanJoinRoom bool `protobuf:"varint,5,opt,name=can_join_room,json=canJoinRoom,proto3" json:"can_join_room,omitempty"`
-	// True when the current user can post new root messages.
-	CanPostMessage bool `protobuf:"varint,6,opt,name=can_post_message,json=canPostMessage,proto3" json:"can_post_message,omitempty"`
-	// True when the current user can post thread replies.
-	CanPostInThread bool `protobuf:"varint,7,opt,name=can_post_in_thread,json=canPostInThread,proto3" json:"can_post_in_thread,omitempty"`
-	// True when the current user can attach files to messages.
-	CanAttach bool `protobuf:"varint,8,opt,name=can_attach,json=canAttach,proto3" json:"can_attach,omitempty"`
-	// True when the current user can add and remove reactions.
-	CanReact bool `protobuf:"varint,9,opt,name=can_react,json=canReact,proto3" json:"can_react,omitempty"`
-	// True when the current user can echo thread replies to the main room.
-	CanEchoMessage bool `protobuf:"varint,10,opt,name=can_echo_message,json=canEchoMessage,proto3" json:"can_echo_message,omitempty"`
-	// True when the current user can edit or delete other users' messages.
-	CanManageOthersMessage bool `protobuf:"varint,11,opt,name=can_manage_others_message,json=canManageOthersMessage,proto3" json:"can_manage_others_message,omitempty"`
-	// True when the current user can configure this room.
-	CanManageRoom bool `protobuf:"varint,12,opt,name=can_manage_room,json=canManageRoom,proto3" json:"can_manage_room,omitempty"`
-	// True when the current user can ban members from this room.
-	CanBanRoomMembers bool `protobuf:"varint,13,opt,name=can_ban_room_members,json=canBanRoomMembers,proto3" json:"can_ban_room_members,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// State and permission decisions resolved for the current user.
+	ViewerState   *RoomViewerState `protobuf:"bytes,14,opt,name=viewer_state,json=viewerState,proto3" json:"viewer_state,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *RoomWithViewerState) Reset() {
 	*x = RoomWithViewerState{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[0]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -127,7 +169,7 @@ func (x *RoomWithViewerState) String() string {
 func (*RoomWithViewerState) ProtoMessage() {}
 
 func (x *RoomWithViewerState) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[0]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -140,7 +182,7 @@ func (x *RoomWithViewerState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomWithViewerState.ProtoReflect.Descriptor instead.
 func (*RoomWithViewerState) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{0}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *RoomWithViewerState) GetRoom() *Room {
@@ -150,88 +192,11 @@ func (x *RoomWithViewerState) GetRoom() *Room {
 	return nil
 }
 
-func (x *RoomWithViewerState) GetIsMember() bool {
+func (x *RoomWithViewerState) GetViewerState() *RoomViewerState {
 	if x != nil {
-		return x.IsMember
+		return x.ViewerState
 	}
-	return false
-}
-
-func (x *RoomWithViewerState) GetHasUnread() bool {
-	if x != nil {
-		return x.HasUnread
-	}
-	return false
-}
-
-func (x *RoomWithViewerState) GetCanListRoom() bool {
-	if x != nil {
-		return x.CanListRoom
-	}
-	return false
-}
-
-func (x *RoomWithViewerState) GetCanJoinRoom() bool {
-	if x != nil {
-		return x.CanJoinRoom
-	}
-	return false
-}
-
-func (x *RoomWithViewerState) GetCanPostMessage() bool {
-	if x != nil {
-		return x.CanPostMessage
-	}
-	return false
-}
-
-func (x *RoomWithViewerState) GetCanPostInThread() bool {
-	if x != nil {
-		return x.CanPostInThread
-	}
-	return false
-}
-
-func (x *RoomWithViewerState) GetCanAttach() bool {
-	if x != nil {
-		return x.CanAttach
-	}
-	return false
-}
-
-func (x *RoomWithViewerState) GetCanReact() bool {
-	if x != nil {
-		return x.CanReact
-	}
-	return false
-}
-
-func (x *RoomWithViewerState) GetCanEchoMessage() bool {
-	if x != nil {
-		return x.CanEchoMessage
-	}
-	return false
-}
-
-func (x *RoomWithViewerState) GetCanManageOthersMessage() bool {
-	if x != nil {
-		return x.CanManageOthersMessage
-	}
-	return false
-}
-
-func (x *RoomWithViewerState) GetCanManageRoom() bool {
-	if x != nil {
-		return x.CanManageRoom
-	}
-	return false
-}
-
-func (x *RoomWithViewerState) GetCanBanRoomMembers() bool {
-	if x != nil {
-		return x.CanBanRoomMembers
-	}
-	return false
+	return nil
 }
 
 // Sidebar link metadata for room group navigation.
@@ -249,7 +214,7 @@ type SidebarLink struct {
 
 func (x *SidebarLink) Reset() {
 	*x = SidebarLink{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[1]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -261,7 +226,7 @@ func (x *SidebarLink) String() string {
 func (*SidebarLink) ProtoMessage() {}
 
 func (x *SidebarLink) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[1]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -274,7 +239,7 @@ func (x *SidebarLink) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SidebarLink.ProtoReflect.Descriptor instead.
 func (*SidebarLink) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{1}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *SidebarLink) GetId() string {
@@ -312,7 +277,7 @@ type RoomGroupItem struct {
 
 func (x *RoomGroupItem) Reset() {
 	*x = RoomGroupItem{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[2]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -324,7 +289,7 @@ func (x *RoomGroupItem) String() string {
 func (*RoomGroupItem) ProtoMessage() {}
 
 func (x *RoomGroupItem) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[2]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -337,7 +302,7 @@ func (x *RoomGroupItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomGroupItem.ProtoReflect.Descriptor instead.
 func (*RoomGroupItem) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{2}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *RoomGroupItem) GetItem() isRoomGroupItem_Item {
@@ -386,15 +351,15 @@ func (*RoomGroupItem_SidebarLink) isRoomGroupItem_Item() {}
 // Viewer-specific state for one room group.
 type RoomGroupViewerState struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when the current user can create rooms in this group.
-	CanCreateRoom bool `protobuf:"varint,1,opt,name=can_create_room,json=canCreateRoom,proto3" json:"can_create_room,omitempty"`
+	// Effective group-scoped permission decisions after group state constraints.
+	Permissions   []*PermissionGrant `protobuf:"bytes,2,rep,name=permissions,proto3" json:"permissions,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *RoomGroupViewerState) Reset() {
 	*x = RoomGroupViewerState{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[3]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -406,7 +371,7 @@ func (x *RoomGroupViewerState) String() string {
 func (*RoomGroupViewerState) ProtoMessage() {}
 
 func (x *RoomGroupViewerState) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[3]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -419,14 +384,14 @@ func (x *RoomGroupViewerState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomGroupViewerState.ProtoReflect.Descriptor instead.
 func (*RoomGroupViewerState) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{3}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{4}
 }
 
-func (x *RoomGroupViewerState) GetCanCreateRoom() bool {
+func (x *RoomGroupViewerState) GetPermissions() []*PermissionGrant {
 	if x != nil {
-		return x.CanCreateRoom
+		return x.Permissions
 	}
-	return false
+	return nil
 }
 
 // Ordered group of channel rooms and sidebar links.
@@ -448,7 +413,7 @@ type RoomGroup struct {
 
 func (x *RoomGroup) Reset() {
 	*x = RoomGroup{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[4]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -460,7 +425,7 @@ func (x *RoomGroup) String() string {
 func (*RoomGroup) ProtoMessage() {}
 
 func (x *RoomGroup) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[4]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -473,7 +438,7 @@ func (x *RoomGroup) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomGroup.ProtoReflect.Descriptor instead.
 func (*RoomGroup) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{4}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *RoomGroup) GetId() string {
@@ -522,7 +487,7 @@ type ListRoomsRequest struct {
 
 func (x *ListRoomsRequest) Reset() {
 	*x = ListRoomsRequest{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[5]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -534,7 +499,7 @@ func (x *ListRoomsRequest) String() string {
 func (*ListRoomsRequest) ProtoMessage() {}
 
 func (x *ListRoomsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[5]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -547,7 +512,7 @@ func (x *ListRoomsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoomsRequest.ProtoReflect.Descriptor instead.
 func (*ListRoomsRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{5}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ListRoomsRequest) GetScope() RoomDirectoryScope {
@@ -568,7 +533,7 @@ type ListRoomsResponse struct {
 
 func (x *ListRoomsResponse) Reset() {
 	*x = ListRoomsResponse{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[6]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -580,7 +545,7 @@ func (x *ListRoomsResponse) String() string {
 func (*ListRoomsResponse) ProtoMessage() {}
 
 func (x *ListRoomsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[6]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -593,7 +558,7 @@ func (x *ListRoomsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoomsResponse.ProtoReflect.Descriptor instead.
 func (*ListRoomsResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{6}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ListRoomsResponse) GetRooms() []*RoomWithViewerState {
@@ -612,7 +577,7 @@ type ListRoomGroupsRequest struct {
 
 func (x *ListRoomGroupsRequest) Reset() {
 	*x = ListRoomGroupsRequest{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[7]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -624,7 +589,7 @@ func (x *ListRoomGroupsRequest) String() string {
 func (*ListRoomGroupsRequest) ProtoMessage() {}
 
 func (x *ListRoomGroupsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[7]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -637,7 +602,7 @@ func (x *ListRoomGroupsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoomGroupsRequest.ProtoReflect.Descriptor instead.
 func (*ListRoomGroupsRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{7}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{8}
 }
 
 // Finite snapshot of ordered room groups visible to the current user.
@@ -651,7 +616,7 @@ type ListRoomGroupsResponse struct {
 
 func (x *ListRoomGroupsResponse) Reset() {
 	*x = ListRoomGroupsResponse{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[8]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -663,7 +628,7 @@ func (x *ListRoomGroupsResponse) String() string {
 func (*ListRoomGroupsResponse) ProtoMessage() {}
 
 func (x *ListRoomGroupsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[8]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -676,7 +641,7 @@ func (x *ListRoomGroupsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoomGroupsResponse.ProtoReflect.Descriptor instead.
 func (*ListRoomGroupsResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{8}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ListRoomGroupsResponse) GetGroups() []*RoomGroup {
@@ -697,7 +662,7 @@ type GetRoomGroupRequest struct {
 
 func (x *GetRoomGroupRequest) Reset() {
 	*x = GetRoomGroupRequest{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[9]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -709,7 +674,7 @@ func (x *GetRoomGroupRequest) String() string {
 func (*GetRoomGroupRequest) ProtoMessage() {}
 
 func (x *GetRoomGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[9]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -722,7 +687,7 @@ func (x *GetRoomGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoomGroupRequest.ProtoReflect.Descriptor instead.
 func (*GetRoomGroupRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{9}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *GetRoomGroupRequest) GetGroupId() string {
@@ -743,7 +708,7 @@ type GetRoomGroupResponse struct {
 
 func (x *GetRoomGroupResponse) Reset() {
 	*x = GetRoomGroupResponse{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[10]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -755,7 +720,7 @@ func (x *GetRoomGroupResponse) String() string {
 func (*GetRoomGroupResponse) ProtoMessage() {}
 
 func (x *GetRoomGroupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[10]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -768,7 +733,7 @@ func (x *GetRoomGroupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoomGroupResponse.ProtoReflect.Descriptor instead.
 func (*GetRoomGroupResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{10}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *GetRoomGroupResponse) GetGroup() *RoomGroup {
@@ -789,7 +754,7 @@ type BatchGetRoomGroupsRequest struct {
 
 func (x *BatchGetRoomGroupsRequest) Reset() {
 	*x = BatchGetRoomGroupsRequest{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[11]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -801,7 +766,7 @@ func (x *BatchGetRoomGroupsRequest) String() string {
 func (*BatchGetRoomGroupsRequest) ProtoMessage() {}
 
 func (x *BatchGetRoomGroupsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[11]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -814,7 +779,7 @@ func (x *BatchGetRoomGroupsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BatchGetRoomGroupsRequest.ProtoReflect.Descriptor instead.
 func (*BatchGetRoomGroupsRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{11}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *BatchGetRoomGroupsRequest) GetGroupIds() []string {
@@ -835,7 +800,7 @@ type BatchGetRoomGroupsResponse struct {
 
 func (x *BatchGetRoomGroupsResponse) Reset() {
 	*x = BatchGetRoomGroupsResponse{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[12]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -847,7 +812,7 @@ func (x *BatchGetRoomGroupsResponse) String() string {
 func (*BatchGetRoomGroupsResponse) ProtoMessage() {}
 
 func (x *BatchGetRoomGroupsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[12]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -860,7 +825,7 @@ func (x *BatchGetRoomGroupsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BatchGetRoomGroupsResponse.ProtoReflect.Descriptor instead.
 func (*BatchGetRoomGroupsResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{12}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *BatchGetRoomGroupsResponse) GetGroups() []*RoomGroup {
@@ -881,7 +846,7 @@ type GetRoomRequest struct {
 
 func (x *GetRoomRequest) Reset() {
 	*x = GetRoomRequest{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[13]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -893,7 +858,7 @@ func (x *GetRoomRequest) String() string {
 func (*GetRoomRequest) ProtoMessage() {}
 
 func (x *GetRoomRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[13]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -906,7 +871,7 @@ func (x *GetRoomRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoomRequest.ProtoReflect.Descriptor instead.
 func (*GetRoomRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{13}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *GetRoomRequest) GetRoomId() string {
@@ -927,7 +892,7 @@ type GetRoomResponse struct {
 
 func (x *GetRoomResponse) Reset() {
 	*x = GetRoomResponse{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[14]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -939,7 +904,7 @@ func (x *GetRoomResponse) String() string {
 func (*GetRoomResponse) ProtoMessage() {}
 
 func (x *GetRoomResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[14]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -952,7 +917,7 @@ func (x *GetRoomResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoomResponse.ProtoReflect.Descriptor instead.
 func (*GetRoomResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{14}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *GetRoomResponse) GetRoom() *RoomWithViewerState {
@@ -975,7 +940,7 @@ type BatchGetRoomsRequest struct {
 
 func (x *BatchGetRoomsRequest) Reset() {
 	*x = BatchGetRoomsRequest{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[15]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -987,7 +952,7 @@ func (x *BatchGetRoomsRequest) String() string {
 func (*BatchGetRoomsRequest) ProtoMessage() {}
 
 func (x *BatchGetRoomsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[15]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1000,7 +965,7 @@ func (x *BatchGetRoomsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BatchGetRoomsRequest.ProtoReflect.Descriptor instead.
 func (*BatchGetRoomsRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{15}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *BatchGetRoomsRequest) GetRoomIds() []string {
@@ -1021,7 +986,7 @@ type BatchGetRoomsResponse struct {
 
 func (x *BatchGetRoomsResponse) Reset() {
 	*x = BatchGetRoomsResponse{}
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[16]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1033,7 +998,7 @@ func (x *BatchGetRoomsResponse) String() string {
 func (*BatchGetRoomsResponse) ProtoMessage() {}
 
 func (x *BatchGetRoomsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[16]
+	mi := &file_chatto_api_v1_room_directory_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1046,7 +1011,7 @@ func (x *BatchGetRoomsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BatchGetRoomsResponse.ProtoReflect.Descriptor instead.
 func (*BatchGetRoomsResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{16}
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *BatchGetRoomsResponse) GetRooms() []*RoomWithViewerState {
@@ -1060,24 +1025,17 @@ var File_chatto_api_v1_room_directory_proto protoreflect.FileDescriptor
 
 const file_chatto_api_v1_room_directory_proto_rawDesc = "" +
 	"\n" +
-	"\"chatto/api/v1/room_directory.proto\x12\rchatto.api.v1\x1a\x1bbuf/validate/validate.proto\x1a\x19chatto/api/v1/rooms.proto\"\x93\x04\n" +
+	"\"chatto/api/v1/room_directory.proto\x12\rchatto.api.v1\x1a\x1bbuf/validate/validate.proto\x1a\x1fchatto/api/v1/permissions.proto\x1a\x19chatto/api/v1/rooms.proto\"\x8f\x01\n" +
+	"\x0fRoomViewerState\x12\x1b\n" +
+	"\tis_member\x18\x01 \x01(\bR\bisMember\x12\x1d\n" +
+	"\n" +
+	"has_unread\x18\x02 \x01(\bR\thasUnread\x12@\n" +
+	"\vpermissions\x18\x03 \x03(\v2\x1e.chatto.api.v1.PermissionGrantR\vpermissions\"\xcd\x02\n" +
 	"\x13RoomWithViewerState\x12'\n" +
-	"\x04room\x18\x01 \x01(\v2\x13.chatto.api.v1.RoomR\x04room\x12\x1b\n" +
-	"\tis_member\x18\x02 \x01(\bR\bisMember\x12\x1d\n" +
-	"\n" +
-	"has_unread\x18\x03 \x01(\bR\thasUnread\x12\"\n" +
-	"\rcan_list_room\x18\x04 \x01(\bR\vcanListRoom\x12\"\n" +
-	"\rcan_join_room\x18\x05 \x01(\bR\vcanJoinRoom\x12(\n" +
-	"\x10can_post_message\x18\x06 \x01(\bR\x0ecanPostMessage\x12+\n" +
-	"\x12can_post_in_thread\x18\a \x01(\bR\x0fcanPostInThread\x12\x1d\n" +
-	"\n" +
-	"can_attach\x18\b \x01(\bR\tcanAttach\x12\x1b\n" +
-	"\tcan_react\x18\t \x01(\bR\bcanReact\x12(\n" +
-	"\x10can_echo_message\x18\n" +
-	" \x01(\bR\x0ecanEchoMessage\x129\n" +
-	"\x19can_manage_others_message\x18\v \x01(\bR\x16canManageOthersMessage\x12&\n" +
-	"\x0fcan_manage_room\x18\f \x01(\bR\rcanManageRoom\x12/\n" +
-	"\x14can_ban_room_members\x18\r \x01(\bR\x11canBanRoomMembers\"E\n" +
+	"\x04room\x18\x01 \x01(\v2\x13.chatto.api.v1.RoomR\x04room\x12A\n" +
+	"\fviewer_state\x18\x0e \x01(\v2\x1e.chatto.api.v1.RoomViewerStateR\vviewerStateJ\x04\b\x02\x10\x0eR\tis_memberR\n" +
+	"has_unreadR\rcan_list_roomR\rcan_join_roomR\x10can_post_messageR\x12can_post_in_threadR\n" +
+	"can_attachR\tcan_reactR\x10can_echo_messageR\x19can_manage_others_messageR\x0fcan_manage_roomR\x14can_ban_room_members\"E\n" +
 	"\vSidebarLink\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
 	"\x05label\x18\x02 \x01(\tR\x05label\x12\x10\n" +
@@ -1085,9 +1043,9 @@ const file_chatto_api_v1_room_directory_proto_rawDesc = "" +
 	"\rRoomGroupItem\x128\n" +
 	"\x04room\x18\x01 \x01(\v2\".chatto.api.v1.RoomWithViewerStateH\x00R\x04room\x12?\n" +
 	"\fsidebar_link\x18\x02 \x01(\v2\x1a.chatto.api.v1.SidebarLinkH\x00R\vsidebarLinkB\x06\n" +
-	"\x04item\">\n" +
-	"\x14RoomGroupViewerState\x12&\n" +
-	"\x0fcan_create_room\x18\x01 \x01(\bR\rcanCreateRoom\"\xda\x01\n" +
+	"\x04item\"o\n" +
+	"\x14RoomGroupViewerState\x12@\n" +
+	"\vpermissions\x18\x02 \x03(\v2\x1e.chatto.api.v1.PermissionGrantR\vpermissionsJ\x04\b\x01\x10\x02R\x0fcan_create_room\"\xda\x01\n" +
 	"\tRoomGroup\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
@@ -1146,58 +1104,63 @@ func file_chatto_api_v1_room_directory_proto_rawDescGZIP() []byte {
 }
 
 var file_chatto_api_v1_room_directory_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_chatto_api_v1_room_directory_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_chatto_api_v1_room_directory_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_chatto_api_v1_room_directory_proto_goTypes = []any{
 	(RoomDirectoryScope)(0),            // 0: chatto.api.v1.RoomDirectoryScope
-	(*RoomWithViewerState)(nil),        // 1: chatto.api.v1.RoomWithViewerState
-	(*SidebarLink)(nil),                // 2: chatto.api.v1.SidebarLink
-	(*RoomGroupItem)(nil),              // 3: chatto.api.v1.RoomGroupItem
-	(*RoomGroupViewerState)(nil),       // 4: chatto.api.v1.RoomGroupViewerState
-	(*RoomGroup)(nil),                  // 5: chatto.api.v1.RoomGroup
-	(*ListRoomsRequest)(nil),           // 6: chatto.api.v1.ListRoomsRequest
-	(*ListRoomsResponse)(nil),          // 7: chatto.api.v1.ListRoomsResponse
-	(*ListRoomGroupsRequest)(nil),      // 8: chatto.api.v1.ListRoomGroupsRequest
-	(*ListRoomGroupsResponse)(nil),     // 9: chatto.api.v1.ListRoomGroupsResponse
-	(*GetRoomGroupRequest)(nil),        // 10: chatto.api.v1.GetRoomGroupRequest
-	(*GetRoomGroupResponse)(nil),       // 11: chatto.api.v1.GetRoomGroupResponse
-	(*BatchGetRoomGroupsRequest)(nil),  // 12: chatto.api.v1.BatchGetRoomGroupsRequest
-	(*BatchGetRoomGroupsResponse)(nil), // 13: chatto.api.v1.BatchGetRoomGroupsResponse
-	(*GetRoomRequest)(nil),             // 14: chatto.api.v1.GetRoomRequest
-	(*GetRoomResponse)(nil),            // 15: chatto.api.v1.GetRoomResponse
-	(*BatchGetRoomsRequest)(nil),       // 16: chatto.api.v1.BatchGetRoomsRequest
-	(*BatchGetRoomsResponse)(nil),      // 17: chatto.api.v1.BatchGetRoomsResponse
-	(*Room)(nil),                       // 18: chatto.api.v1.Room
+	(*RoomViewerState)(nil),            // 1: chatto.api.v1.RoomViewerState
+	(*RoomWithViewerState)(nil),        // 2: chatto.api.v1.RoomWithViewerState
+	(*SidebarLink)(nil),                // 3: chatto.api.v1.SidebarLink
+	(*RoomGroupItem)(nil),              // 4: chatto.api.v1.RoomGroupItem
+	(*RoomGroupViewerState)(nil),       // 5: chatto.api.v1.RoomGroupViewerState
+	(*RoomGroup)(nil),                  // 6: chatto.api.v1.RoomGroup
+	(*ListRoomsRequest)(nil),           // 7: chatto.api.v1.ListRoomsRequest
+	(*ListRoomsResponse)(nil),          // 8: chatto.api.v1.ListRoomsResponse
+	(*ListRoomGroupsRequest)(nil),      // 9: chatto.api.v1.ListRoomGroupsRequest
+	(*ListRoomGroupsResponse)(nil),     // 10: chatto.api.v1.ListRoomGroupsResponse
+	(*GetRoomGroupRequest)(nil),        // 11: chatto.api.v1.GetRoomGroupRequest
+	(*GetRoomGroupResponse)(nil),       // 12: chatto.api.v1.GetRoomGroupResponse
+	(*BatchGetRoomGroupsRequest)(nil),  // 13: chatto.api.v1.BatchGetRoomGroupsRequest
+	(*BatchGetRoomGroupsResponse)(nil), // 14: chatto.api.v1.BatchGetRoomGroupsResponse
+	(*GetRoomRequest)(nil),             // 15: chatto.api.v1.GetRoomRequest
+	(*GetRoomResponse)(nil),            // 16: chatto.api.v1.GetRoomResponse
+	(*BatchGetRoomsRequest)(nil),       // 17: chatto.api.v1.BatchGetRoomsRequest
+	(*BatchGetRoomsResponse)(nil),      // 18: chatto.api.v1.BatchGetRoomsResponse
+	(*PermissionGrant)(nil),            // 19: chatto.api.v1.PermissionGrant
+	(*Room)(nil),                       // 20: chatto.api.v1.Room
 }
 var file_chatto_api_v1_room_directory_proto_depIdxs = []int32{
-	18, // 0: chatto.api.v1.RoomWithViewerState.room:type_name -> chatto.api.v1.Room
-	1,  // 1: chatto.api.v1.RoomGroupItem.room:type_name -> chatto.api.v1.RoomWithViewerState
-	2,  // 2: chatto.api.v1.RoomGroupItem.sidebar_link:type_name -> chatto.api.v1.SidebarLink
-	3,  // 3: chatto.api.v1.RoomGroup.items:type_name -> chatto.api.v1.RoomGroupItem
-	4,  // 4: chatto.api.v1.RoomGroup.viewer_state:type_name -> chatto.api.v1.RoomGroupViewerState
-	0,  // 5: chatto.api.v1.ListRoomsRequest.scope:type_name -> chatto.api.v1.RoomDirectoryScope
-	1,  // 6: chatto.api.v1.ListRoomsResponse.rooms:type_name -> chatto.api.v1.RoomWithViewerState
-	5,  // 7: chatto.api.v1.ListRoomGroupsResponse.groups:type_name -> chatto.api.v1.RoomGroup
-	5,  // 8: chatto.api.v1.GetRoomGroupResponse.group:type_name -> chatto.api.v1.RoomGroup
-	5,  // 9: chatto.api.v1.BatchGetRoomGroupsResponse.groups:type_name -> chatto.api.v1.RoomGroup
-	1,  // 10: chatto.api.v1.GetRoomResponse.room:type_name -> chatto.api.v1.RoomWithViewerState
-	1,  // 11: chatto.api.v1.BatchGetRoomsResponse.rooms:type_name -> chatto.api.v1.RoomWithViewerState
-	6,  // 12: chatto.api.v1.RoomDirectoryService.ListRooms:input_type -> chatto.api.v1.ListRoomsRequest
-	8,  // 13: chatto.api.v1.RoomDirectoryService.ListRoomGroups:input_type -> chatto.api.v1.ListRoomGroupsRequest
-	10, // 14: chatto.api.v1.RoomDirectoryService.GetRoomGroup:input_type -> chatto.api.v1.GetRoomGroupRequest
-	12, // 15: chatto.api.v1.RoomDirectoryService.BatchGetRoomGroups:input_type -> chatto.api.v1.BatchGetRoomGroupsRequest
-	14, // 16: chatto.api.v1.RoomDirectoryService.GetRoom:input_type -> chatto.api.v1.GetRoomRequest
-	16, // 17: chatto.api.v1.RoomDirectoryService.BatchGetRooms:input_type -> chatto.api.v1.BatchGetRoomsRequest
-	7,  // 18: chatto.api.v1.RoomDirectoryService.ListRooms:output_type -> chatto.api.v1.ListRoomsResponse
-	9,  // 19: chatto.api.v1.RoomDirectoryService.ListRoomGroups:output_type -> chatto.api.v1.ListRoomGroupsResponse
-	11, // 20: chatto.api.v1.RoomDirectoryService.GetRoomGroup:output_type -> chatto.api.v1.GetRoomGroupResponse
-	13, // 21: chatto.api.v1.RoomDirectoryService.BatchGetRoomGroups:output_type -> chatto.api.v1.BatchGetRoomGroupsResponse
-	15, // 22: chatto.api.v1.RoomDirectoryService.GetRoom:output_type -> chatto.api.v1.GetRoomResponse
-	17, // 23: chatto.api.v1.RoomDirectoryService.BatchGetRooms:output_type -> chatto.api.v1.BatchGetRoomsResponse
-	18, // [18:24] is the sub-list for method output_type
-	12, // [12:18] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	19, // 0: chatto.api.v1.RoomViewerState.permissions:type_name -> chatto.api.v1.PermissionGrant
+	20, // 1: chatto.api.v1.RoomWithViewerState.room:type_name -> chatto.api.v1.Room
+	1,  // 2: chatto.api.v1.RoomWithViewerState.viewer_state:type_name -> chatto.api.v1.RoomViewerState
+	2,  // 3: chatto.api.v1.RoomGroupItem.room:type_name -> chatto.api.v1.RoomWithViewerState
+	3,  // 4: chatto.api.v1.RoomGroupItem.sidebar_link:type_name -> chatto.api.v1.SidebarLink
+	19, // 5: chatto.api.v1.RoomGroupViewerState.permissions:type_name -> chatto.api.v1.PermissionGrant
+	4,  // 6: chatto.api.v1.RoomGroup.items:type_name -> chatto.api.v1.RoomGroupItem
+	5,  // 7: chatto.api.v1.RoomGroup.viewer_state:type_name -> chatto.api.v1.RoomGroupViewerState
+	0,  // 8: chatto.api.v1.ListRoomsRequest.scope:type_name -> chatto.api.v1.RoomDirectoryScope
+	2,  // 9: chatto.api.v1.ListRoomsResponse.rooms:type_name -> chatto.api.v1.RoomWithViewerState
+	6,  // 10: chatto.api.v1.ListRoomGroupsResponse.groups:type_name -> chatto.api.v1.RoomGroup
+	6,  // 11: chatto.api.v1.GetRoomGroupResponse.group:type_name -> chatto.api.v1.RoomGroup
+	6,  // 12: chatto.api.v1.BatchGetRoomGroupsResponse.groups:type_name -> chatto.api.v1.RoomGroup
+	2,  // 13: chatto.api.v1.GetRoomResponse.room:type_name -> chatto.api.v1.RoomWithViewerState
+	2,  // 14: chatto.api.v1.BatchGetRoomsResponse.rooms:type_name -> chatto.api.v1.RoomWithViewerState
+	7,  // 15: chatto.api.v1.RoomDirectoryService.ListRooms:input_type -> chatto.api.v1.ListRoomsRequest
+	9,  // 16: chatto.api.v1.RoomDirectoryService.ListRoomGroups:input_type -> chatto.api.v1.ListRoomGroupsRequest
+	11, // 17: chatto.api.v1.RoomDirectoryService.GetRoomGroup:input_type -> chatto.api.v1.GetRoomGroupRequest
+	13, // 18: chatto.api.v1.RoomDirectoryService.BatchGetRoomGroups:input_type -> chatto.api.v1.BatchGetRoomGroupsRequest
+	15, // 19: chatto.api.v1.RoomDirectoryService.GetRoom:input_type -> chatto.api.v1.GetRoomRequest
+	17, // 20: chatto.api.v1.RoomDirectoryService.BatchGetRooms:input_type -> chatto.api.v1.BatchGetRoomsRequest
+	8,  // 21: chatto.api.v1.RoomDirectoryService.ListRooms:output_type -> chatto.api.v1.ListRoomsResponse
+	10, // 22: chatto.api.v1.RoomDirectoryService.ListRoomGroups:output_type -> chatto.api.v1.ListRoomGroupsResponse
+	12, // 23: chatto.api.v1.RoomDirectoryService.GetRoomGroup:output_type -> chatto.api.v1.GetRoomGroupResponse
+	14, // 24: chatto.api.v1.RoomDirectoryService.BatchGetRoomGroups:output_type -> chatto.api.v1.BatchGetRoomGroupsResponse
+	16, // 25: chatto.api.v1.RoomDirectoryService.GetRoom:output_type -> chatto.api.v1.GetRoomResponse
+	18, // 26: chatto.api.v1.RoomDirectoryService.BatchGetRooms:output_type -> chatto.api.v1.BatchGetRoomsResponse
+	21, // [21:27] is the sub-list for method output_type
+	15, // [15:21] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_chatto_api_v1_room_directory_proto_init() }
@@ -1205,8 +1168,9 @@ func file_chatto_api_v1_room_directory_proto_init() {
 	if File_chatto_api_v1_room_directory_proto != nil {
 		return
 	}
+	file_chatto_api_v1_permissions_proto_init()
 	file_chatto_api_v1_rooms_proto_init()
-	file_chatto_api_v1_room_directory_proto_msgTypes[2].OneofWrappers = []any{
+	file_chatto_api_v1_room_directory_proto_msgTypes[3].OneofWrappers = []any{
 		(*RoomGroupItem_Room)(nil),
 		(*RoomGroupItem_SidebarLink)(nil),
 	}
@@ -1216,7 +1180,7 @@ func file_chatto_api_v1_room_directory_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_api_v1_room_directory_proto_rawDesc), len(file_chatto_api_v1_room_directory_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   17,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/cli/internal/pb/chatto/api/v1/rooms.pb.go
+++ b/cli/internal/pb/chatto/api/v1/rooms.pb.go
@@ -177,6 +177,71 @@ func (x *Room) GetUniversal() bool {
 	return false
 }
 
+// Lightweight room reference for cross-resource rows.
+type RoomSummary struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Stable room ID.
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// Room kind.
+	Kind RoomKind `protobuf:"varint,2,opt,name=kind,proto3,enum=chatto.api.v1.RoomKind" json:"kind,omitempty"`
+	// Room name. Direct-message rooms may have an empty name because clients
+	// derive their display label from participants.
+	Name          string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RoomSummary) Reset() {
+	*x = RoomSummary{}
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RoomSummary) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RoomSummary) ProtoMessage() {}
+
+func (x *RoomSummary) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RoomSummary.ProtoReflect.Descriptor instead.
+func (*RoomSummary) Descriptor() ([]byte, []int) {
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *RoomSummary) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *RoomSummary) GetKind() RoomKind {
+	if x != nil {
+		return x.Kind
+	}
+	return RoomKind_ROOM_KIND_UNSPECIFIED
+}
+
+func (x *RoomSummary) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
 // Request to create a channel room.
 type CreateRoomRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -195,7 +260,7 @@ type CreateRoomRequest struct {
 
 func (x *CreateRoomRequest) Reset() {
 	*x = CreateRoomRequest{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[1]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -207,7 +272,7 @@ func (x *CreateRoomRequest) String() string {
 func (*CreateRoomRequest) ProtoMessage() {}
 
 func (x *CreateRoomRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[1]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -220,7 +285,7 @@ func (x *CreateRoomRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateRoomRequest.ProtoReflect.Descriptor instead.
 func (*CreateRoomRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{1}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *CreateRoomRequest) GetName() string {
@@ -262,7 +327,7 @@ type CreateRoomResponse struct {
 
 func (x *CreateRoomResponse) Reset() {
 	*x = CreateRoomResponse{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[2]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -274,7 +339,7 @@ func (x *CreateRoomResponse) String() string {
 func (*CreateRoomResponse) ProtoMessage() {}
 
 func (x *CreateRoomResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[2]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -287,7 +352,7 @@ func (x *CreateRoomResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateRoomResponse.ProtoReflect.Descriptor instead.
 func (*CreateRoomResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{2}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *CreateRoomResponse) GetRoom() *Room {
@@ -315,7 +380,7 @@ type UpdateRoomRequest struct {
 
 func (x *UpdateRoomRequest) Reset() {
 	*x = UpdateRoomRequest{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[3]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -327,7 +392,7 @@ func (x *UpdateRoomRequest) String() string {
 func (*UpdateRoomRequest) ProtoMessage() {}
 
 func (x *UpdateRoomRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[3]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -340,7 +405,7 @@ func (x *UpdateRoomRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateRoomRequest.ProtoReflect.Descriptor instead.
 func (*UpdateRoomRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{3}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *UpdateRoomRequest) GetRoomId() string {
@@ -382,7 +447,7 @@ type UpdateRoomResponse struct {
 
 func (x *UpdateRoomResponse) Reset() {
 	*x = UpdateRoomResponse{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[4]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -394,7 +459,7 @@ func (x *UpdateRoomResponse) String() string {
 func (*UpdateRoomResponse) ProtoMessage() {}
 
 func (x *UpdateRoomResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[4]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -407,7 +472,7 @@ func (x *UpdateRoomResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateRoomResponse.ProtoReflect.Descriptor instead.
 func (*UpdateRoomResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{4}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *UpdateRoomResponse) GetRoom() *Room {
@@ -428,7 +493,7 @@ type ArchiveRoomRequest struct {
 
 func (x *ArchiveRoomRequest) Reset() {
 	*x = ArchiveRoomRequest{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[5]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -440,7 +505,7 @@ func (x *ArchiveRoomRequest) String() string {
 func (*ArchiveRoomRequest) ProtoMessage() {}
 
 func (x *ArchiveRoomRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[5]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -453,7 +518,7 @@ func (x *ArchiveRoomRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArchiveRoomRequest.ProtoReflect.Descriptor instead.
 func (*ArchiveRoomRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{5}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ArchiveRoomRequest) GetRoomId() string {
@@ -474,7 +539,7 @@ type ArchiveRoomResponse struct {
 
 func (x *ArchiveRoomResponse) Reset() {
 	*x = ArchiveRoomResponse{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[6]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -486,7 +551,7 @@ func (x *ArchiveRoomResponse) String() string {
 func (*ArchiveRoomResponse) ProtoMessage() {}
 
 func (x *ArchiveRoomResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[6]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -499,7 +564,7 @@ func (x *ArchiveRoomResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArchiveRoomResponse.ProtoReflect.Descriptor instead.
 func (*ArchiveRoomResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{6}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ArchiveRoomResponse) GetRoom() *Room {
@@ -520,7 +585,7 @@ type UnarchiveRoomRequest struct {
 
 func (x *UnarchiveRoomRequest) Reset() {
 	*x = UnarchiveRoomRequest{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[7]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -532,7 +597,7 @@ func (x *UnarchiveRoomRequest) String() string {
 func (*UnarchiveRoomRequest) ProtoMessage() {}
 
 func (x *UnarchiveRoomRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[7]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -545,7 +610,7 @@ func (x *UnarchiveRoomRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnarchiveRoomRequest.ProtoReflect.Descriptor instead.
 func (*UnarchiveRoomRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{7}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *UnarchiveRoomRequest) GetRoomId() string {
@@ -566,7 +631,7 @@ type UnarchiveRoomResponse struct {
 
 func (x *UnarchiveRoomResponse) Reset() {
 	*x = UnarchiveRoomResponse{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[8]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -578,7 +643,7 @@ func (x *UnarchiveRoomResponse) String() string {
 func (*UnarchiveRoomResponse) ProtoMessage() {}
 
 func (x *UnarchiveRoomResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[8]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -591,7 +656,7 @@ func (x *UnarchiveRoomResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnarchiveRoomResponse.ProtoReflect.Descriptor instead.
 func (*UnarchiveRoomResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{8}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *UnarchiveRoomResponse) GetRoom() *Room {
@@ -612,7 +677,7 @@ type JoinRoomRequest struct {
 
 func (x *JoinRoomRequest) Reset() {
 	*x = JoinRoomRequest{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[9]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -624,7 +689,7 @@ func (x *JoinRoomRequest) String() string {
 func (*JoinRoomRequest) ProtoMessage() {}
 
 func (x *JoinRoomRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[9]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -637,7 +702,7 @@ func (x *JoinRoomRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinRoomRequest.ProtoReflect.Descriptor instead.
 func (*JoinRoomRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{9}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *JoinRoomRequest) GetRoomId() string {
@@ -658,7 +723,7 @@ type JoinRoomResponse struct {
 
 func (x *JoinRoomResponse) Reset() {
 	*x = JoinRoomResponse{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[10]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -670,7 +735,7 @@ func (x *JoinRoomResponse) String() string {
 func (*JoinRoomResponse) ProtoMessage() {}
 
 func (x *JoinRoomResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[10]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -683,7 +748,7 @@ func (x *JoinRoomResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinRoomResponse.ProtoReflect.Descriptor instead.
 func (*JoinRoomResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{10}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *JoinRoomResponse) GetRoom() *Room {
@@ -704,7 +769,7 @@ type JoinRoomGroupRequest struct {
 
 func (x *JoinRoomGroupRequest) Reset() {
 	*x = JoinRoomGroupRequest{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[11]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -716,7 +781,7 @@ func (x *JoinRoomGroupRequest) String() string {
 func (*JoinRoomGroupRequest) ProtoMessage() {}
 
 func (x *JoinRoomGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[11]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -729,7 +794,7 @@ func (x *JoinRoomGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinRoomGroupRequest.ProtoReflect.Descriptor instead.
 func (*JoinRoomGroupRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{11}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *JoinRoomGroupRequest) GetGroupId() string {
@@ -750,7 +815,7 @@ type JoinRoomGroupResponse struct {
 
 func (x *JoinRoomGroupResponse) Reset() {
 	*x = JoinRoomGroupResponse{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[12]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -762,7 +827,7 @@ func (x *JoinRoomGroupResponse) String() string {
 func (*JoinRoomGroupResponse) ProtoMessage() {}
 
 func (x *JoinRoomGroupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[12]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -775,7 +840,7 @@ func (x *JoinRoomGroupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinRoomGroupResponse.ProtoReflect.Descriptor instead.
 func (*JoinRoomGroupResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{12}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *JoinRoomGroupResponse) GetJoinedRoomIds() []string {
@@ -798,7 +863,7 @@ type StartDMRequest struct {
 
 func (x *StartDMRequest) Reset() {
 	*x = StartDMRequest{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[13]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -810,7 +875,7 @@ func (x *StartDMRequest) String() string {
 func (*StartDMRequest) ProtoMessage() {}
 
 func (x *StartDMRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[13]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -823,7 +888,7 @@ func (x *StartDMRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartDMRequest.ProtoReflect.Descriptor instead.
 func (*StartDMRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{13}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *StartDMRequest) GetParticipantIds() []string {
@@ -844,7 +909,7 @@ type StartDMResponse struct {
 
 func (x *StartDMResponse) Reset() {
 	*x = StartDMResponse{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[14]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -856,7 +921,7 @@ func (x *StartDMResponse) String() string {
 func (*StartDMResponse) ProtoMessage() {}
 
 func (x *StartDMResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[14]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -869,7 +934,7 @@ func (x *StartDMResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartDMResponse.ProtoReflect.Descriptor instead.
 func (*StartDMResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{14}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *StartDMResponse) GetRoom() *Room {
@@ -890,7 +955,7 @@ type LeaveRoomRequest struct {
 
 func (x *LeaveRoomRequest) Reset() {
 	*x = LeaveRoomRequest{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[15]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -902,7 +967,7 @@ func (x *LeaveRoomRequest) String() string {
 func (*LeaveRoomRequest) ProtoMessage() {}
 
 func (x *LeaveRoomRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[15]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -915,7 +980,7 @@ func (x *LeaveRoomRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeaveRoomRequest.ProtoReflect.Descriptor instead.
 func (*LeaveRoomRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{15}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *LeaveRoomRequest) GetRoomId() string {
@@ -936,7 +1001,7 @@ type LeaveRoomResponse struct {
 
 func (x *LeaveRoomResponse) Reset() {
 	*x = LeaveRoomResponse{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[16]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -948,7 +1013,7 @@ func (x *LeaveRoomResponse) String() string {
 func (*LeaveRoomResponse) ProtoMessage() {}
 
 func (x *LeaveRoomResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[16]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -961,7 +1026,7 @@ func (x *LeaveRoomResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeaveRoomResponse.ProtoReflect.Descriptor instead.
 func (*LeaveRoomResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{16}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *LeaveRoomResponse) GetLeft() bool {
@@ -984,7 +1049,7 @@ type AddMemberRequest struct {
 
 func (x *AddMemberRequest) Reset() {
 	*x = AddMemberRequest{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[17]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -996,7 +1061,7 @@ func (x *AddMemberRequest) String() string {
 func (*AddMemberRequest) ProtoMessage() {}
 
 func (x *AddMemberRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[17]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1009,7 +1074,7 @@ func (x *AddMemberRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddMemberRequest.ProtoReflect.Descriptor instead.
 func (*AddMemberRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{17}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *AddMemberRequest) GetRoomId() string {
@@ -1037,7 +1102,7 @@ type AddMemberResponse struct {
 
 func (x *AddMemberResponse) Reset() {
 	*x = AddMemberResponse{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[18]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1049,7 +1114,7 @@ func (x *AddMemberResponse) String() string {
 func (*AddMemberResponse) ProtoMessage() {}
 
 func (x *AddMemberResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[18]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1062,7 +1127,7 @@ func (x *AddMemberResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddMemberResponse.ProtoReflect.Descriptor instead.
 func (*AddMemberResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{18}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *AddMemberResponse) GetMember() *DirectoryMember {
@@ -1085,7 +1150,7 @@ type RemoveMemberRequest struct {
 
 func (x *RemoveMemberRequest) Reset() {
 	*x = RemoveMemberRequest{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[19]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1097,7 +1162,7 @@ func (x *RemoveMemberRequest) String() string {
 func (*RemoveMemberRequest) ProtoMessage() {}
 
 func (x *RemoveMemberRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[19]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1110,7 +1175,7 @@ func (x *RemoveMemberRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveMemberRequest.ProtoReflect.Descriptor instead.
 func (*RemoveMemberRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{19}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *RemoveMemberRequest) GetRoomId() string {
@@ -1138,7 +1203,7 @@ type RemoveMemberResponse struct {
 
 func (x *RemoveMemberResponse) Reset() {
 	*x = RemoveMemberResponse{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[20]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1150,7 +1215,7 @@ func (x *RemoveMemberResponse) String() string {
 func (*RemoveMemberResponse) ProtoMessage() {}
 
 func (x *RemoveMemberResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[20]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1163,7 +1228,7 @@ func (x *RemoveMemberResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveMemberResponse.ProtoReflect.Descriptor instead.
 func (*RemoveMemberResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{20}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *RemoveMemberResponse) GetRemoved() bool {
@@ -1190,7 +1255,7 @@ type BanMemberRequest struct {
 
 func (x *BanMemberRequest) Reset() {
 	*x = BanMemberRequest{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[21]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1202,7 +1267,7 @@ func (x *BanMemberRequest) String() string {
 func (*BanMemberRequest) ProtoMessage() {}
 
 func (x *BanMemberRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[21]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1215,7 +1280,7 @@ func (x *BanMemberRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BanMemberRequest.ProtoReflect.Descriptor instead.
 func (*BanMemberRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{21}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *BanMemberRequest) GetRoomId() string {
@@ -1257,7 +1322,7 @@ type BanMemberResponse struct {
 
 func (x *BanMemberResponse) Reset() {
 	*x = BanMemberResponse{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[22]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1269,7 +1334,7 @@ func (x *BanMemberResponse) String() string {
 func (*BanMemberResponse) ProtoMessage() {}
 
 func (x *BanMemberResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[22]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1282,7 +1347,7 @@ func (x *BanMemberResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BanMemberResponse.ProtoReflect.Descriptor instead.
 func (*BanMemberResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{22}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *BanMemberResponse) GetBanned() bool {
@@ -1307,7 +1372,7 @@ type UnbanMemberRequest struct {
 
 func (x *UnbanMemberRequest) Reset() {
 	*x = UnbanMemberRequest{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[23]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1319,7 +1384,7 @@ func (x *UnbanMemberRequest) String() string {
 func (*UnbanMemberRequest) ProtoMessage() {}
 
 func (x *UnbanMemberRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[23]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1332,7 +1397,7 @@ func (x *UnbanMemberRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnbanMemberRequest.ProtoReflect.Descriptor instead.
 func (*UnbanMemberRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{23}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *UnbanMemberRequest) GetRoomId() string {
@@ -1367,7 +1432,7 @@ type UnbanMemberResponse struct {
 
 func (x *UnbanMemberResponse) Reset() {
 	*x = UnbanMemberResponse{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[24]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1379,7 +1444,7 @@ func (x *UnbanMemberResponse) String() string {
 func (*UnbanMemberResponse) ProtoMessage() {}
 
 func (x *UnbanMemberResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[24]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1392,7 +1457,7 @@ func (x *UnbanMemberResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnbanMemberResponse.ProtoReflect.Descriptor instead.
 func (*UnbanMemberResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{24}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *UnbanMemberResponse) GetUnbanned() bool {
@@ -1431,7 +1496,7 @@ type RoomBan struct {
 
 func (x *RoomBan) Reset() {
 	*x = RoomBan{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[25]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1443,7 +1508,7 @@ func (x *RoomBan) String() string {
 func (*RoomBan) ProtoMessage() {}
 
 func (x *RoomBan) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[25]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1456,7 +1521,7 @@ func (x *RoomBan) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomBan.ProtoReflect.Descriptor instead.
 func (*RoomBan) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{25}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *RoomBan) GetId() string {
@@ -1542,7 +1607,7 @@ type ListBansRequest struct {
 
 func (x *ListBansRequest) Reset() {
 	*x = ListBansRequest{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[26]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1554,7 +1619,7 @@ func (x *ListBansRequest) String() string {
 func (*ListBansRequest) ProtoMessage() {}
 
 func (x *ListBansRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[26]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1567,7 +1632,7 @@ func (x *ListBansRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBansRequest.ProtoReflect.Descriptor instead.
 func (*ListBansRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{26}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ListBansRequest) GetRoomId() string {
@@ -1597,7 +1662,7 @@ type ListBansResponse struct {
 
 func (x *ListBansResponse) Reset() {
 	*x = ListBansResponse{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[27]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1609,7 +1674,7 @@ func (x *ListBansResponse) String() string {
 func (*ListBansResponse) ProtoMessage() {}
 
 func (x *ListBansResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[27]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1622,7 +1687,7 @@ func (x *ListBansResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBansResponse.ProtoReflect.Descriptor instead.
 func (*ListBansResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{27}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ListBansResponse) GetBans() []*RoomBan {
@@ -1654,7 +1719,7 @@ type ListRoomAttachmentsRequest struct {
 
 func (x *ListRoomAttachmentsRequest) Reset() {
 	*x = ListRoomAttachmentsRequest{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[28]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1666,7 +1731,7 @@ func (x *ListRoomAttachmentsRequest) String() string {
 func (*ListRoomAttachmentsRequest) ProtoMessage() {}
 
 func (x *ListRoomAttachmentsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[28]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1679,7 +1744,7 @@ func (x *ListRoomAttachmentsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoomAttachmentsRequest.ProtoReflect.Descriptor instead.
 func (*ListRoomAttachmentsRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{28}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ListRoomAttachmentsRequest) GetRoomId() string {
@@ -1716,7 +1781,7 @@ type ListRoomAttachmentsResponse struct {
 
 func (x *ListRoomAttachmentsResponse) Reset() {
 	*x = ListRoomAttachmentsResponse{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[29]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1728,7 +1793,7 @@ func (x *ListRoomAttachmentsResponse) String() string {
 func (*ListRoomAttachmentsResponse) ProtoMessage() {}
 
 func (x *ListRoomAttachmentsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[29]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1741,7 +1806,7 @@ func (x *ListRoomAttachmentsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoomAttachmentsResponse.ProtoReflect.Descriptor instead.
 func (*ListRoomAttachmentsResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{29}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ListRoomAttachmentsResponse) GetAttachments() []*RoomAttachmentListItem {
@@ -1771,7 +1836,7 @@ type UpdateTypingIndicatorRequest struct {
 
 func (x *UpdateTypingIndicatorRequest) Reset() {
 	*x = UpdateTypingIndicatorRequest{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[30]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1783,7 +1848,7 @@ func (x *UpdateTypingIndicatorRequest) String() string {
 func (*UpdateTypingIndicatorRequest) ProtoMessage() {}
 
 func (x *UpdateTypingIndicatorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[30]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1796,7 +1861,7 @@ func (x *UpdateTypingIndicatorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateTypingIndicatorRequest.ProtoReflect.Descriptor instead.
 func (*UpdateTypingIndicatorRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{30}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *UpdateTypingIndicatorRequest) GetRoomId() string {
@@ -1824,7 +1889,7 @@ type UpdateTypingIndicatorResponse struct {
 
 func (x *UpdateTypingIndicatorResponse) Reset() {
 	*x = UpdateTypingIndicatorResponse{}
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[31]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1836,7 +1901,7 @@ func (x *UpdateTypingIndicatorResponse) String() string {
 func (*UpdateTypingIndicatorResponse) ProtoMessage() {}
 
 func (x *UpdateTypingIndicatorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_api_v1_rooms_proto_msgTypes[31]
+	mi := &file_chatto_api_v1_rooms_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1849,7 +1914,7 @@ func (x *UpdateTypingIndicatorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateTypingIndicatorResponse.ProtoReflect.Descriptor instead.
 func (*UpdateTypingIndicatorResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{31}
+	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *UpdateTypingIndicatorResponse) GetUpdated() bool {
@@ -1871,7 +1936,11 @@ const file_chatto_api_v1_rooms_proto_rawDesc = "" +
 	"\vdescription\x18\x04 \x01(\tR\vdescription\x12\x1a\n" +
 	"\barchived\x18\x05 \x01(\bR\barchived\x12\x19\n" +
 	"\bgroup_id\x18\x06 \x01(\tR\agroupId\x12\x1c\n" +
-	"\tuniversal\x18\a \x01(\bR\tuniversal\"\xa0\x01\n" +
+	"\tuniversal\x18\a \x01(\bR\tuniversal\"^\n" +
+	"\vRoomSummary\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12+\n" +
+	"\x04kind\x18\x02 \x01(\x0e2\x17.chatto.api.v1.RoomKindR\x04kind\x12\x12\n" +
+	"\x04name\x18\x03 \x01(\tR\x04name\"\xa0\x01\n" +
 	"\x11CreateRoomRequest\x12\x1d\n" +
 	"\x04name\x18\x01 \x01(\tB\t\xbaH\x06r\x04\x10\x01\x18\x1eR\x04name\x12*\n" +
 	"\vdescription\x18\x02 \x01(\tB\b\xbaH\x05r\x03\x18\xf4\x03R\vdescription\x12\"\n" +
@@ -2016,129 +2085,131 @@ func file_chatto_api_v1_rooms_proto_rawDescGZIP() []byte {
 }
 
 var file_chatto_api_v1_rooms_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_chatto_api_v1_rooms_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
+var file_chatto_api_v1_rooms_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
 var file_chatto_api_v1_rooms_proto_goTypes = []any{
 	(RoomKind)(0),                         // 0: chatto.api.v1.RoomKind
 	(*Room)(nil),                          // 1: chatto.api.v1.Room
-	(*CreateRoomRequest)(nil),             // 2: chatto.api.v1.CreateRoomRequest
-	(*CreateRoomResponse)(nil),            // 3: chatto.api.v1.CreateRoomResponse
-	(*UpdateRoomRequest)(nil),             // 4: chatto.api.v1.UpdateRoomRequest
-	(*UpdateRoomResponse)(nil),            // 5: chatto.api.v1.UpdateRoomResponse
-	(*ArchiveRoomRequest)(nil),            // 6: chatto.api.v1.ArchiveRoomRequest
-	(*ArchiveRoomResponse)(nil),           // 7: chatto.api.v1.ArchiveRoomResponse
-	(*UnarchiveRoomRequest)(nil),          // 8: chatto.api.v1.UnarchiveRoomRequest
-	(*UnarchiveRoomResponse)(nil),         // 9: chatto.api.v1.UnarchiveRoomResponse
-	(*JoinRoomRequest)(nil),               // 10: chatto.api.v1.JoinRoomRequest
-	(*JoinRoomResponse)(nil),              // 11: chatto.api.v1.JoinRoomResponse
-	(*JoinRoomGroupRequest)(nil),          // 12: chatto.api.v1.JoinRoomGroupRequest
-	(*JoinRoomGroupResponse)(nil),         // 13: chatto.api.v1.JoinRoomGroupResponse
-	(*StartDMRequest)(nil),                // 14: chatto.api.v1.StartDMRequest
-	(*StartDMResponse)(nil),               // 15: chatto.api.v1.StartDMResponse
-	(*LeaveRoomRequest)(nil),              // 16: chatto.api.v1.LeaveRoomRequest
-	(*LeaveRoomResponse)(nil),             // 17: chatto.api.v1.LeaveRoomResponse
-	(*AddMemberRequest)(nil),              // 18: chatto.api.v1.AddMemberRequest
-	(*AddMemberResponse)(nil),             // 19: chatto.api.v1.AddMemberResponse
-	(*RemoveMemberRequest)(nil),           // 20: chatto.api.v1.RemoveMemberRequest
-	(*RemoveMemberResponse)(nil),          // 21: chatto.api.v1.RemoveMemberResponse
-	(*BanMemberRequest)(nil),              // 22: chatto.api.v1.BanMemberRequest
-	(*BanMemberResponse)(nil),             // 23: chatto.api.v1.BanMemberResponse
-	(*UnbanMemberRequest)(nil),            // 24: chatto.api.v1.UnbanMemberRequest
-	(*UnbanMemberResponse)(nil),           // 25: chatto.api.v1.UnbanMemberResponse
-	(*RoomBan)(nil),                       // 26: chatto.api.v1.RoomBan
-	(*ListBansRequest)(nil),               // 27: chatto.api.v1.ListBansRequest
-	(*ListBansResponse)(nil),              // 28: chatto.api.v1.ListBansResponse
-	(*ListRoomAttachmentsRequest)(nil),    // 29: chatto.api.v1.ListRoomAttachmentsRequest
-	(*ListRoomAttachmentsResponse)(nil),   // 30: chatto.api.v1.ListRoomAttachmentsResponse
-	(*UpdateTypingIndicatorRequest)(nil),  // 31: chatto.api.v1.UpdateTypingIndicatorRequest
-	(*UpdateTypingIndicatorResponse)(nil), // 32: chatto.api.v1.UpdateTypingIndicatorResponse
-	(*DirectoryMember)(nil),               // 33: chatto.api.v1.DirectoryMember
-	(*timestamppb.Timestamp)(nil),         // 34: google.protobuf.Timestamp
-	(*PageRequest)(nil),                   // 35: chatto.api.v1.PageRequest
-	(*PageInfo)(nil),                      // 36: chatto.api.v1.PageInfo
-	(*ImageTransformOptions)(nil),         // 37: chatto.api.v1.ImageTransformOptions
-	(*RoomAttachmentListItem)(nil),        // 38: chatto.api.v1.RoomAttachmentListItem
-	(*ListRoomMembersRequest)(nil),        // 39: chatto.api.v1.ListRoomMembersRequest
-	(*GetRoomMemberRequest)(nil),          // 40: chatto.api.v1.GetRoomMemberRequest
-	(*BatchGetRoomMembersRequest)(nil),    // 41: chatto.api.v1.BatchGetRoomMembersRequest
-	(*GetRoomEventsRequest)(nil),          // 42: chatto.api.v1.GetRoomEventsRequest
-	(*GetRoomEventsAroundRequest)(nil),    // 43: chatto.api.v1.GetRoomEventsAroundRequest
-	(*MarkRoomAsReadRequest)(nil),         // 44: chatto.api.v1.MarkRoomAsReadRequest
-	(*ListRoomMembersResponse)(nil),       // 45: chatto.api.v1.ListRoomMembersResponse
-	(*GetRoomMemberResponse)(nil),         // 46: chatto.api.v1.GetRoomMemberResponse
-	(*BatchGetRoomMembersResponse)(nil),   // 47: chatto.api.v1.BatchGetRoomMembersResponse
-	(*GetRoomEventsResponse)(nil),         // 48: chatto.api.v1.GetRoomEventsResponse
-	(*GetRoomEventsAroundResponse)(nil),   // 49: chatto.api.v1.GetRoomEventsAroundResponse
-	(*MarkRoomAsReadResponse)(nil),        // 50: chatto.api.v1.MarkRoomAsReadResponse
+	(*RoomSummary)(nil),                   // 2: chatto.api.v1.RoomSummary
+	(*CreateRoomRequest)(nil),             // 3: chatto.api.v1.CreateRoomRequest
+	(*CreateRoomResponse)(nil),            // 4: chatto.api.v1.CreateRoomResponse
+	(*UpdateRoomRequest)(nil),             // 5: chatto.api.v1.UpdateRoomRequest
+	(*UpdateRoomResponse)(nil),            // 6: chatto.api.v1.UpdateRoomResponse
+	(*ArchiveRoomRequest)(nil),            // 7: chatto.api.v1.ArchiveRoomRequest
+	(*ArchiveRoomResponse)(nil),           // 8: chatto.api.v1.ArchiveRoomResponse
+	(*UnarchiveRoomRequest)(nil),          // 9: chatto.api.v1.UnarchiveRoomRequest
+	(*UnarchiveRoomResponse)(nil),         // 10: chatto.api.v1.UnarchiveRoomResponse
+	(*JoinRoomRequest)(nil),               // 11: chatto.api.v1.JoinRoomRequest
+	(*JoinRoomResponse)(nil),              // 12: chatto.api.v1.JoinRoomResponse
+	(*JoinRoomGroupRequest)(nil),          // 13: chatto.api.v1.JoinRoomGroupRequest
+	(*JoinRoomGroupResponse)(nil),         // 14: chatto.api.v1.JoinRoomGroupResponse
+	(*StartDMRequest)(nil),                // 15: chatto.api.v1.StartDMRequest
+	(*StartDMResponse)(nil),               // 16: chatto.api.v1.StartDMResponse
+	(*LeaveRoomRequest)(nil),              // 17: chatto.api.v1.LeaveRoomRequest
+	(*LeaveRoomResponse)(nil),             // 18: chatto.api.v1.LeaveRoomResponse
+	(*AddMemberRequest)(nil),              // 19: chatto.api.v1.AddMemberRequest
+	(*AddMemberResponse)(nil),             // 20: chatto.api.v1.AddMemberResponse
+	(*RemoveMemberRequest)(nil),           // 21: chatto.api.v1.RemoveMemberRequest
+	(*RemoveMemberResponse)(nil),          // 22: chatto.api.v1.RemoveMemberResponse
+	(*BanMemberRequest)(nil),              // 23: chatto.api.v1.BanMemberRequest
+	(*BanMemberResponse)(nil),             // 24: chatto.api.v1.BanMemberResponse
+	(*UnbanMemberRequest)(nil),            // 25: chatto.api.v1.UnbanMemberRequest
+	(*UnbanMemberResponse)(nil),           // 26: chatto.api.v1.UnbanMemberResponse
+	(*RoomBan)(nil),                       // 27: chatto.api.v1.RoomBan
+	(*ListBansRequest)(nil),               // 28: chatto.api.v1.ListBansRequest
+	(*ListBansResponse)(nil),              // 29: chatto.api.v1.ListBansResponse
+	(*ListRoomAttachmentsRequest)(nil),    // 30: chatto.api.v1.ListRoomAttachmentsRequest
+	(*ListRoomAttachmentsResponse)(nil),   // 31: chatto.api.v1.ListRoomAttachmentsResponse
+	(*UpdateTypingIndicatorRequest)(nil),  // 32: chatto.api.v1.UpdateTypingIndicatorRequest
+	(*UpdateTypingIndicatorResponse)(nil), // 33: chatto.api.v1.UpdateTypingIndicatorResponse
+	(*DirectoryMember)(nil),               // 34: chatto.api.v1.DirectoryMember
+	(*timestamppb.Timestamp)(nil),         // 35: google.protobuf.Timestamp
+	(*PageRequest)(nil),                   // 36: chatto.api.v1.PageRequest
+	(*PageInfo)(nil),                      // 37: chatto.api.v1.PageInfo
+	(*ImageTransformOptions)(nil),         // 38: chatto.api.v1.ImageTransformOptions
+	(*RoomAttachmentListItem)(nil),        // 39: chatto.api.v1.RoomAttachmentListItem
+	(*ListRoomMembersRequest)(nil),        // 40: chatto.api.v1.ListRoomMembersRequest
+	(*GetRoomMemberRequest)(nil),          // 41: chatto.api.v1.GetRoomMemberRequest
+	(*BatchGetRoomMembersRequest)(nil),    // 42: chatto.api.v1.BatchGetRoomMembersRequest
+	(*GetRoomEventsRequest)(nil),          // 43: chatto.api.v1.GetRoomEventsRequest
+	(*GetRoomEventsAroundRequest)(nil),    // 44: chatto.api.v1.GetRoomEventsAroundRequest
+	(*MarkRoomAsReadRequest)(nil),         // 45: chatto.api.v1.MarkRoomAsReadRequest
+	(*ListRoomMembersResponse)(nil),       // 46: chatto.api.v1.ListRoomMembersResponse
+	(*GetRoomMemberResponse)(nil),         // 47: chatto.api.v1.GetRoomMemberResponse
+	(*BatchGetRoomMembersResponse)(nil),   // 48: chatto.api.v1.BatchGetRoomMembersResponse
+	(*GetRoomEventsResponse)(nil),         // 49: chatto.api.v1.GetRoomEventsResponse
+	(*GetRoomEventsAroundResponse)(nil),   // 50: chatto.api.v1.GetRoomEventsAroundResponse
+	(*MarkRoomAsReadResponse)(nil),        // 51: chatto.api.v1.MarkRoomAsReadResponse
 }
 var file_chatto_api_v1_rooms_proto_depIdxs = []int32{
 	0,  // 0: chatto.api.v1.Room.kind:type_name -> chatto.api.v1.RoomKind
-	1,  // 1: chatto.api.v1.CreateRoomResponse.room:type_name -> chatto.api.v1.Room
-	1,  // 2: chatto.api.v1.UpdateRoomResponse.room:type_name -> chatto.api.v1.Room
-	1,  // 3: chatto.api.v1.ArchiveRoomResponse.room:type_name -> chatto.api.v1.Room
-	1,  // 4: chatto.api.v1.UnarchiveRoomResponse.room:type_name -> chatto.api.v1.Room
-	1,  // 5: chatto.api.v1.JoinRoomResponse.room:type_name -> chatto.api.v1.Room
-	1,  // 6: chatto.api.v1.StartDMResponse.room:type_name -> chatto.api.v1.Room
-	33, // 7: chatto.api.v1.AddMemberResponse.member:type_name -> chatto.api.v1.DirectoryMember
-	34, // 8: chatto.api.v1.BanMemberRequest.expires_at:type_name -> google.protobuf.Timestamp
-	1,  // 9: chatto.api.v1.RoomBan.room:type_name -> chatto.api.v1.Room
-	33, // 10: chatto.api.v1.RoomBan.user:type_name -> chatto.api.v1.DirectoryMember
-	33, // 11: chatto.api.v1.RoomBan.moderator:type_name -> chatto.api.v1.DirectoryMember
-	34, // 12: chatto.api.v1.RoomBan.created_at:type_name -> google.protobuf.Timestamp
-	34, // 13: chatto.api.v1.RoomBan.expires_at:type_name -> google.protobuf.Timestamp
-	35, // 14: chatto.api.v1.ListBansRequest.page:type_name -> chatto.api.v1.PageRequest
-	26, // 15: chatto.api.v1.ListBansResponse.bans:type_name -> chatto.api.v1.RoomBan
-	36, // 16: chatto.api.v1.ListBansResponse.page:type_name -> chatto.api.v1.PageInfo
-	37, // 17: chatto.api.v1.ListRoomAttachmentsRequest.thumbnail:type_name -> chatto.api.v1.ImageTransformOptions
-	35, // 18: chatto.api.v1.ListRoomAttachmentsRequest.page:type_name -> chatto.api.v1.PageRequest
-	38, // 19: chatto.api.v1.ListRoomAttachmentsResponse.attachments:type_name -> chatto.api.v1.RoomAttachmentListItem
-	36, // 20: chatto.api.v1.ListRoomAttachmentsResponse.page:type_name -> chatto.api.v1.PageInfo
-	2,  // 21: chatto.api.v1.RoomService.CreateRoom:input_type -> chatto.api.v1.CreateRoomRequest
-	4,  // 22: chatto.api.v1.RoomService.UpdateRoom:input_type -> chatto.api.v1.UpdateRoomRequest
-	6,  // 23: chatto.api.v1.RoomService.ArchiveRoom:input_type -> chatto.api.v1.ArchiveRoomRequest
-	8,  // 24: chatto.api.v1.RoomService.UnarchiveRoom:input_type -> chatto.api.v1.UnarchiveRoomRequest
-	10, // 25: chatto.api.v1.RoomService.JoinRoom:input_type -> chatto.api.v1.JoinRoomRequest
-	12, // 26: chatto.api.v1.RoomService.JoinRoomGroup:input_type -> chatto.api.v1.JoinRoomGroupRequest
-	14, // 27: chatto.api.v1.RoomService.StartDM:input_type -> chatto.api.v1.StartDMRequest
-	16, // 28: chatto.api.v1.RoomService.LeaveRoom:input_type -> chatto.api.v1.LeaveRoomRequest
-	39, // 29: chatto.api.v1.RoomService.ListMembers:input_type -> chatto.api.v1.ListRoomMembersRequest
-	40, // 30: chatto.api.v1.RoomService.GetMember:input_type -> chatto.api.v1.GetRoomMemberRequest
-	41, // 31: chatto.api.v1.RoomService.BatchGetMembers:input_type -> chatto.api.v1.BatchGetRoomMembersRequest
-	18, // 32: chatto.api.v1.RoomService.AddMember:input_type -> chatto.api.v1.AddMemberRequest
-	20, // 33: chatto.api.v1.RoomService.RemoveMember:input_type -> chatto.api.v1.RemoveMemberRequest
-	27, // 34: chatto.api.v1.RoomService.ListBans:input_type -> chatto.api.v1.ListBansRequest
-	29, // 35: chatto.api.v1.RoomService.ListRoomAttachments:input_type -> chatto.api.v1.ListRoomAttachmentsRequest
-	31, // 36: chatto.api.v1.RoomService.UpdateTypingIndicator:input_type -> chatto.api.v1.UpdateTypingIndicatorRequest
-	42, // 37: chatto.api.v1.RoomService.GetRoomEvents:input_type -> chatto.api.v1.GetRoomEventsRequest
-	43, // 38: chatto.api.v1.RoomService.GetRoomEventsAround:input_type -> chatto.api.v1.GetRoomEventsAroundRequest
-	44, // 39: chatto.api.v1.RoomService.MarkRoomAsRead:input_type -> chatto.api.v1.MarkRoomAsReadRequest
-	22, // 40: chatto.api.v1.RoomService.BanMember:input_type -> chatto.api.v1.BanMemberRequest
-	24, // 41: chatto.api.v1.RoomService.UnbanMember:input_type -> chatto.api.v1.UnbanMemberRequest
-	3,  // 42: chatto.api.v1.RoomService.CreateRoom:output_type -> chatto.api.v1.CreateRoomResponse
-	5,  // 43: chatto.api.v1.RoomService.UpdateRoom:output_type -> chatto.api.v1.UpdateRoomResponse
-	7,  // 44: chatto.api.v1.RoomService.ArchiveRoom:output_type -> chatto.api.v1.ArchiveRoomResponse
-	9,  // 45: chatto.api.v1.RoomService.UnarchiveRoom:output_type -> chatto.api.v1.UnarchiveRoomResponse
-	11, // 46: chatto.api.v1.RoomService.JoinRoom:output_type -> chatto.api.v1.JoinRoomResponse
-	13, // 47: chatto.api.v1.RoomService.JoinRoomGroup:output_type -> chatto.api.v1.JoinRoomGroupResponse
-	15, // 48: chatto.api.v1.RoomService.StartDM:output_type -> chatto.api.v1.StartDMResponse
-	17, // 49: chatto.api.v1.RoomService.LeaveRoom:output_type -> chatto.api.v1.LeaveRoomResponse
-	45, // 50: chatto.api.v1.RoomService.ListMembers:output_type -> chatto.api.v1.ListRoomMembersResponse
-	46, // 51: chatto.api.v1.RoomService.GetMember:output_type -> chatto.api.v1.GetRoomMemberResponse
-	47, // 52: chatto.api.v1.RoomService.BatchGetMembers:output_type -> chatto.api.v1.BatchGetRoomMembersResponse
-	19, // 53: chatto.api.v1.RoomService.AddMember:output_type -> chatto.api.v1.AddMemberResponse
-	21, // 54: chatto.api.v1.RoomService.RemoveMember:output_type -> chatto.api.v1.RemoveMemberResponse
-	28, // 55: chatto.api.v1.RoomService.ListBans:output_type -> chatto.api.v1.ListBansResponse
-	30, // 56: chatto.api.v1.RoomService.ListRoomAttachments:output_type -> chatto.api.v1.ListRoomAttachmentsResponse
-	32, // 57: chatto.api.v1.RoomService.UpdateTypingIndicator:output_type -> chatto.api.v1.UpdateTypingIndicatorResponse
-	48, // 58: chatto.api.v1.RoomService.GetRoomEvents:output_type -> chatto.api.v1.GetRoomEventsResponse
-	49, // 59: chatto.api.v1.RoomService.GetRoomEventsAround:output_type -> chatto.api.v1.GetRoomEventsAroundResponse
-	50, // 60: chatto.api.v1.RoomService.MarkRoomAsRead:output_type -> chatto.api.v1.MarkRoomAsReadResponse
-	23, // 61: chatto.api.v1.RoomService.BanMember:output_type -> chatto.api.v1.BanMemberResponse
-	25, // 62: chatto.api.v1.RoomService.UnbanMember:output_type -> chatto.api.v1.UnbanMemberResponse
-	42, // [42:63] is the sub-list for method output_type
-	21, // [21:42] is the sub-list for method input_type
-	21, // [21:21] is the sub-list for extension type_name
-	21, // [21:21] is the sub-list for extension extendee
-	0,  // [0:21] is the sub-list for field type_name
+	0,  // 1: chatto.api.v1.RoomSummary.kind:type_name -> chatto.api.v1.RoomKind
+	1,  // 2: chatto.api.v1.CreateRoomResponse.room:type_name -> chatto.api.v1.Room
+	1,  // 3: chatto.api.v1.UpdateRoomResponse.room:type_name -> chatto.api.v1.Room
+	1,  // 4: chatto.api.v1.ArchiveRoomResponse.room:type_name -> chatto.api.v1.Room
+	1,  // 5: chatto.api.v1.UnarchiveRoomResponse.room:type_name -> chatto.api.v1.Room
+	1,  // 6: chatto.api.v1.JoinRoomResponse.room:type_name -> chatto.api.v1.Room
+	1,  // 7: chatto.api.v1.StartDMResponse.room:type_name -> chatto.api.v1.Room
+	34, // 8: chatto.api.v1.AddMemberResponse.member:type_name -> chatto.api.v1.DirectoryMember
+	35, // 9: chatto.api.v1.BanMemberRequest.expires_at:type_name -> google.protobuf.Timestamp
+	1,  // 10: chatto.api.v1.RoomBan.room:type_name -> chatto.api.v1.Room
+	34, // 11: chatto.api.v1.RoomBan.user:type_name -> chatto.api.v1.DirectoryMember
+	34, // 12: chatto.api.v1.RoomBan.moderator:type_name -> chatto.api.v1.DirectoryMember
+	35, // 13: chatto.api.v1.RoomBan.created_at:type_name -> google.protobuf.Timestamp
+	35, // 14: chatto.api.v1.RoomBan.expires_at:type_name -> google.protobuf.Timestamp
+	36, // 15: chatto.api.v1.ListBansRequest.page:type_name -> chatto.api.v1.PageRequest
+	27, // 16: chatto.api.v1.ListBansResponse.bans:type_name -> chatto.api.v1.RoomBan
+	37, // 17: chatto.api.v1.ListBansResponse.page:type_name -> chatto.api.v1.PageInfo
+	38, // 18: chatto.api.v1.ListRoomAttachmentsRequest.thumbnail:type_name -> chatto.api.v1.ImageTransformOptions
+	36, // 19: chatto.api.v1.ListRoomAttachmentsRequest.page:type_name -> chatto.api.v1.PageRequest
+	39, // 20: chatto.api.v1.ListRoomAttachmentsResponse.attachments:type_name -> chatto.api.v1.RoomAttachmentListItem
+	37, // 21: chatto.api.v1.ListRoomAttachmentsResponse.page:type_name -> chatto.api.v1.PageInfo
+	3,  // 22: chatto.api.v1.RoomService.CreateRoom:input_type -> chatto.api.v1.CreateRoomRequest
+	5,  // 23: chatto.api.v1.RoomService.UpdateRoom:input_type -> chatto.api.v1.UpdateRoomRequest
+	7,  // 24: chatto.api.v1.RoomService.ArchiveRoom:input_type -> chatto.api.v1.ArchiveRoomRequest
+	9,  // 25: chatto.api.v1.RoomService.UnarchiveRoom:input_type -> chatto.api.v1.UnarchiveRoomRequest
+	11, // 26: chatto.api.v1.RoomService.JoinRoom:input_type -> chatto.api.v1.JoinRoomRequest
+	13, // 27: chatto.api.v1.RoomService.JoinRoomGroup:input_type -> chatto.api.v1.JoinRoomGroupRequest
+	15, // 28: chatto.api.v1.RoomService.StartDM:input_type -> chatto.api.v1.StartDMRequest
+	17, // 29: chatto.api.v1.RoomService.LeaveRoom:input_type -> chatto.api.v1.LeaveRoomRequest
+	40, // 30: chatto.api.v1.RoomService.ListMembers:input_type -> chatto.api.v1.ListRoomMembersRequest
+	41, // 31: chatto.api.v1.RoomService.GetMember:input_type -> chatto.api.v1.GetRoomMemberRequest
+	42, // 32: chatto.api.v1.RoomService.BatchGetMembers:input_type -> chatto.api.v1.BatchGetRoomMembersRequest
+	19, // 33: chatto.api.v1.RoomService.AddMember:input_type -> chatto.api.v1.AddMemberRequest
+	21, // 34: chatto.api.v1.RoomService.RemoveMember:input_type -> chatto.api.v1.RemoveMemberRequest
+	28, // 35: chatto.api.v1.RoomService.ListBans:input_type -> chatto.api.v1.ListBansRequest
+	30, // 36: chatto.api.v1.RoomService.ListRoomAttachments:input_type -> chatto.api.v1.ListRoomAttachmentsRequest
+	32, // 37: chatto.api.v1.RoomService.UpdateTypingIndicator:input_type -> chatto.api.v1.UpdateTypingIndicatorRequest
+	43, // 38: chatto.api.v1.RoomService.GetRoomEvents:input_type -> chatto.api.v1.GetRoomEventsRequest
+	44, // 39: chatto.api.v1.RoomService.GetRoomEventsAround:input_type -> chatto.api.v1.GetRoomEventsAroundRequest
+	45, // 40: chatto.api.v1.RoomService.MarkRoomAsRead:input_type -> chatto.api.v1.MarkRoomAsReadRequest
+	23, // 41: chatto.api.v1.RoomService.BanMember:input_type -> chatto.api.v1.BanMemberRequest
+	25, // 42: chatto.api.v1.RoomService.UnbanMember:input_type -> chatto.api.v1.UnbanMemberRequest
+	4,  // 43: chatto.api.v1.RoomService.CreateRoom:output_type -> chatto.api.v1.CreateRoomResponse
+	6,  // 44: chatto.api.v1.RoomService.UpdateRoom:output_type -> chatto.api.v1.UpdateRoomResponse
+	8,  // 45: chatto.api.v1.RoomService.ArchiveRoom:output_type -> chatto.api.v1.ArchiveRoomResponse
+	10, // 46: chatto.api.v1.RoomService.UnarchiveRoom:output_type -> chatto.api.v1.UnarchiveRoomResponse
+	12, // 47: chatto.api.v1.RoomService.JoinRoom:output_type -> chatto.api.v1.JoinRoomResponse
+	14, // 48: chatto.api.v1.RoomService.JoinRoomGroup:output_type -> chatto.api.v1.JoinRoomGroupResponse
+	16, // 49: chatto.api.v1.RoomService.StartDM:output_type -> chatto.api.v1.StartDMResponse
+	18, // 50: chatto.api.v1.RoomService.LeaveRoom:output_type -> chatto.api.v1.LeaveRoomResponse
+	46, // 51: chatto.api.v1.RoomService.ListMembers:output_type -> chatto.api.v1.ListRoomMembersResponse
+	47, // 52: chatto.api.v1.RoomService.GetMember:output_type -> chatto.api.v1.GetRoomMemberResponse
+	48, // 53: chatto.api.v1.RoomService.BatchGetMembers:output_type -> chatto.api.v1.BatchGetRoomMembersResponse
+	20, // 54: chatto.api.v1.RoomService.AddMember:output_type -> chatto.api.v1.AddMemberResponse
+	22, // 55: chatto.api.v1.RoomService.RemoveMember:output_type -> chatto.api.v1.RemoveMemberResponse
+	29, // 56: chatto.api.v1.RoomService.ListBans:output_type -> chatto.api.v1.ListBansResponse
+	31, // 57: chatto.api.v1.RoomService.ListRoomAttachments:output_type -> chatto.api.v1.ListRoomAttachmentsResponse
+	33, // 58: chatto.api.v1.RoomService.UpdateTypingIndicator:output_type -> chatto.api.v1.UpdateTypingIndicatorResponse
+	49, // 59: chatto.api.v1.RoomService.GetRoomEvents:output_type -> chatto.api.v1.GetRoomEventsResponse
+	50, // 60: chatto.api.v1.RoomService.GetRoomEventsAround:output_type -> chatto.api.v1.GetRoomEventsAroundResponse
+	51, // 61: chatto.api.v1.RoomService.MarkRoomAsRead:output_type -> chatto.api.v1.MarkRoomAsReadResponse
+	24, // 62: chatto.api.v1.RoomService.BanMember:output_type -> chatto.api.v1.BanMemberResponse
+	26, // 63: chatto.api.v1.RoomService.UnbanMember:output_type -> chatto.api.v1.UnbanMemberResponse
+	43, // [43:64] is the sub-list for method output_type
+	22, // [22:43] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_chatto_api_v1_rooms_proto_init() }
@@ -2152,14 +2223,14 @@ func file_chatto_api_v1_rooms_proto_init() {
 	file_chatto_api_v1_pagination_proto_init()
 	file_chatto_api_v1_read_state_proto_init()
 	file_chatto_api_v1_room_timeline_proto_init()
-	file_chatto_api_v1_rooms_proto_msgTypes[3].OneofWrappers = []any{}
+	file_chatto_api_v1_rooms_proto_msgTypes[4].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_api_v1_rooms_proto_rawDesc), len(file_chatto_api_v1_rooms_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   32,
+			NumMessages:   33,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/cli/internal/pb/chatto/api/v1/threads.pb.go
+++ b/cli/internal/pb/chatto/api/v1/threads.pb.go
@@ -10,7 +10,6 @@ import (
 	_ "buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go/buf/validate"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -310,20 +309,12 @@ func (x *UnfollowThreadResponse) GetState() *ThreadFollowState {
 // One followed thread for the current user.
 type FollowedThread struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Room containing the thread.
-	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
-	// Current display name of the room.
-	RoomName string `protobuf:"bytes,2,opt,name=room_name,json=roomName,proto3" json:"room_name,omitempty"`
-	// Event ID of the root message for the thread.
-	ThreadRootEventId string `protobuf:"bytes,3,opt,name=thread_root_event_id,json=threadRootEventId,proto3" json:"thread_root_event_id,omitempty"`
 	// Renderable root message, when the root is still visible.
 	RootMessage *Message `protobuf:"bytes,4,opt,name=root_message,json=rootMessage,proto3" json:"root_message,omitempty"`
-	// Number of replies in the thread.
-	ReplyCount int32 `protobuf:"varint,5,opt,name=reply_count,json=replyCount,proto3" json:"reply_count,omitempty"`
-	// Creation time of the latest reply, when the thread has replies.
-	LastReplyAt *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=last_reply_at,json=lastReplyAt,proto3" json:"last_reply_at,omitempty"`
-	// True when the current user has unread replies in the thread.
-	HasUnread     bool `protobuf:"varint,7,opt,name=has_unread,json=hasUnread,proto3" json:"has_unread,omitempty"`
+	// Room containing the thread.
+	Room *RoomSummary `protobuf:"bytes,8,opt,name=room,proto3" json:"room,omitempty"`
+	// Aggregated thread state.
+	Thread        *ThreadSummary `protobuf:"bytes,9,opt,name=thread,proto3" json:"thread,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -358,27 +349,6 @@ func (*FollowedThread) Descriptor() ([]byte, []int) {
 	return file_chatto_api_v1_threads_proto_rawDescGZIP(), []int{5}
 }
 
-func (x *FollowedThread) GetRoomId() string {
-	if x != nil {
-		return x.RoomId
-	}
-	return ""
-}
-
-func (x *FollowedThread) GetRoomName() string {
-	if x != nil {
-		return x.RoomName
-	}
-	return ""
-}
-
-func (x *FollowedThread) GetThreadRootEventId() string {
-	if x != nil {
-		return x.ThreadRootEventId
-	}
-	return ""
-}
-
 func (x *FollowedThread) GetRootMessage() *Message {
 	if x != nil {
 		return x.RootMessage
@@ -386,25 +356,18 @@ func (x *FollowedThread) GetRootMessage() *Message {
 	return nil
 }
 
-func (x *FollowedThread) GetReplyCount() int32 {
+func (x *FollowedThread) GetRoom() *RoomSummary {
 	if x != nil {
-		return x.ReplyCount
-	}
-	return 0
-}
-
-func (x *FollowedThread) GetLastReplyAt() *timestamppb.Timestamp {
-	if x != nil {
-		return x.LastReplyAt
+		return x.Room
 	}
 	return nil
 }
 
-func (x *FollowedThread) GetHasUnread() bool {
+func (x *FollowedThread) GetThread() *ThreadSummary {
 	if x != nil {
-		return x.HasUnread
+		return x.Thread
 	}
-	return false
+	return nil
 }
 
 // Request for a page of followed threads for the current user.
@@ -521,7 +484,7 @@ var File_chatto_api_v1_threads_proto protoreflect.FileDescriptor
 
 const file_chatto_api_v1_threads_proto_rawDesc = "" +
 	"\n" +
-	"\x1bchatto/api/v1/threads.proto\x12\rchatto.api.v1\x1a\x1bbuf/validate/validate.proto\x1a!chatto/api/v1/message_types.proto\x1a\x1echatto/api/v1/pagination.proto\x1a\x1echatto/api/v1/read_state.proto\x1a!chatto/api/v1/room_timeline.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"{\n" +
+	"\x1bchatto/api/v1/threads.proto\x12\rchatto.api.v1\x1a\x1bbuf/validate/validate.proto\x1a!chatto/api/v1/message_types.proto\x1a\x1echatto/api/v1/pagination.proto\x1a\x1echatto/api/v1/read_state.proto\x1a!chatto/api/v1/room_timeline.proto\x1a\x19chatto/api/v1/rooms.proto\"{\n" +
 	"\x11ThreadFollowState\x12\x17\n" +
 	"\aroom_id\x18\x01 \x01(\tR\x06roomId\x12/\n" +
 	"\x14thread_root_event_id\x18\x02 \x01(\tR\x11threadRootEventId\x12\x1c\n" +
@@ -537,17 +500,12 @@ const file_chatto_api_v1_threads_proto_rawDesc = "" +
 	"\x14thread_root_event_id\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x11threadRootEventId\"n\n" +
 	"\x16UnfollowThreadResponse\x12\x1c\n" +
 	"\tfollowing\x18\x01 \x01(\bR\tfollowing\x126\n" +
-	"\x05state\x18\x02 \x01(\v2 .chatto.api.v1.ThreadFollowStateR\x05state\"\xb2\x02\n" +
-	"\x0eFollowedThread\x12\x17\n" +
-	"\aroom_id\x18\x01 \x01(\tR\x06roomId\x12\x1b\n" +
-	"\troom_name\x18\x02 \x01(\tR\broomName\x12/\n" +
-	"\x14thread_root_event_id\x18\x03 \x01(\tR\x11threadRootEventId\x129\n" +
-	"\froot_message\x18\x04 \x01(\v2\x16.chatto.api.v1.MessageR\vrootMessage\x12\x1f\n" +
-	"\vreply_count\x18\x05 \x01(\x05R\n" +
-	"replyCount\x12>\n" +
-	"\rlast_reply_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\vlastReplyAt\x12\x1d\n" +
-	"\n" +
-	"has_unread\x18\a \x01(\bR\thasUnread\"g\n" +
+	"\x05state\x18\x02 \x01(\v2 .chatto.api.v1.ThreadFollowStateR\x05state\"\x8f\x02\n" +
+	"\x0eFollowedThread\x129\n" +
+	"\froot_message\x18\x04 \x01(\v2\x16.chatto.api.v1.MessageR\vrootMessage\x12.\n" +
+	"\x04room\x18\b \x01(\v2\x1a.chatto.api.v1.RoomSummaryR\x04room\x124\n" +
+	"\x06thread\x18\t \x01(\v2\x1c.chatto.api.v1.ThreadSummaryR\x06threadJ\x04\b\x01\x10\x04J\x04\b\x05\x10\bR\aroom_idR\troom_nameR\x14thread_root_event_idR\vreply_countR\rlast_reply_atR\n" +
+	"has_unread\"g\n" +
 	"\x1aListFollowedThreadsRequest\x12.\n" +
 	"\x04page\x18\x03 \x01(\v2\x1a.chatto.api.v1.PageRequestR\x04pageJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03R\x05limitR\x06offset\"\xe7\x01\n" +
 	"\x1bListFollowedThreadsResponse\x127\n" +
@@ -586,43 +544,45 @@ var file_chatto_api_v1_threads_proto_goTypes = []any{
 	(*ListFollowedThreadsRequest)(nil),    // 6: chatto.api.v1.ListFollowedThreadsRequest
 	(*ListFollowedThreadsResponse)(nil),   // 7: chatto.api.v1.ListFollowedThreadsResponse
 	(*Message)(nil),                       // 8: chatto.api.v1.Message
-	(*timestamppb.Timestamp)(nil),         // 9: google.protobuf.Timestamp
-	(*PageRequest)(nil),                   // 10: chatto.api.v1.PageRequest
-	(*RoomTimelineIncludes)(nil),          // 11: chatto.api.v1.RoomTimelineIncludes
-	(*PageInfo)(nil),                      // 12: chatto.api.v1.PageInfo
-	(*GetThreadEventsRequest)(nil),        // 13: chatto.api.v1.GetThreadEventsRequest
-	(*GetThreadEventsAroundRequest)(nil),  // 14: chatto.api.v1.GetThreadEventsAroundRequest
-	(*MarkThreadAsReadRequest)(nil),       // 15: chatto.api.v1.MarkThreadAsReadRequest
-	(*GetThreadEventsResponse)(nil),       // 16: chatto.api.v1.GetThreadEventsResponse
-	(*GetThreadEventsAroundResponse)(nil), // 17: chatto.api.v1.GetThreadEventsAroundResponse
-	(*MarkThreadAsReadResponse)(nil),      // 18: chatto.api.v1.MarkThreadAsReadResponse
+	(*RoomSummary)(nil),                   // 9: chatto.api.v1.RoomSummary
+	(*ThreadSummary)(nil),                 // 10: chatto.api.v1.ThreadSummary
+	(*PageRequest)(nil),                   // 11: chatto.api.v1.PageRequest
+	(*RoomTimelineIncludes)(nil),          // 12: chatto.api.v1.RoomTimelineIncludes
+	(*PageInfo)(nil),                      // 13: chatto.api.v1.PageInfo
+	(*GetThreadEventsRequest)(nil),        // 14: chatto.api.v1.GetThreadEventsRequest
+	(*GetThreadEventsAroundRequest)(nil),  // 15: chatto.api.v1.GetThreadEventsAroundRequest
+	(*MarkThreadAsReadRequest)(nil),       // 16: chatto.api.v1.MarkThreadAsReadRequest
+	(*GetThreadEventsResponse)(nil),       // 17: chatto.api.v1.GetThreadEventsResponse
+	(*GetThreadEventsAroundResponse)(nil), // 18: chatto.api.v1.GetThreadEventsAroundResponse
+	(*MarkThreadAsReadResponse)(nil),      // 19: chatto.api.v1.MarkThreadAsReadResponse
 }
 var file_chatto_api_v1_threads_proto_depIdxs = []int32{
 	0,  // 0: chatto.api.v1.FollowThreadResponse.state:type_name -> chatto.api.v1.ThreadFollowState
 	0,  // 1: chatto.api.v1.UnfollowThreadResponse.state:type_name -> chatto.api.v1.ThreadFollowState
 	8,  // 2: chatto.api.v1.FollowedThread.root_message:type_name -> chatto.api.v1.Message
-	9,  // 3: chatto.api.v1.FollowedThread.last_reply_at:type_name -> google.protobuf.Timestamp
-	10, // 4: chatto.api.v1.ListFollowedThreadsRequest.page:type_name -> chatto.api.v1.PageRequest
-	5,  // 5: chatto.api.v1.ListFollowedThreadsResponse.threads:type_name -> chatto.api.v1.FollowedThread
-	11, // 6: chatto.api.v1.ListFollowedThreadsResponse.includes:type_name -> chatto.api.v1.RoomTimelineIncludes
-	12, // 7: chatto.api.v1.ListFollowedThreadsResponse.page:type_name -> chatto.api.v1.PageInfo
-	6,  // 8: chatto.api.v1.ThreadService.ListFollowedThreads:input_type -> chatto.api.v1.ListFollowedThreadsRequest
-	1,  // 9: chatto.api.v1.ThreadService.FollowThread:input_type -> chatto.api.v1.FollowThreadRequest
-	3,  // 10: chatto.api.v1.ThreadService.UnfollowThread:input_type -> chatto.api.v1.UnfollowThreadRequest
-	13, // 11: chatto.api.v1.ThreadService.GetThreadEvents:input_type -> chatto.api.v1.GetThreadEventsRequest
-	14, // 12: chatto.api.v1.ThreadService.GetThreadEventsAround:input_type -> chatto.api.v1.GetThreadEventsAroundRequest
-	15, // 13: chatto.api.v1.ThreadService.MarkThreadAsRead:input_type -> chatto.api.v1.MarkThreadAsReadRequest
-	7,  // 14: chatto.api.v1.ThreadService.ListFollowedThreads:output_type -> chatto.api.v1.ListFollowedThreadsResponse
-	2,  // 15: chatto.api.v1.ThreadService.FollowThread:output_type -> chatto.api.v1.FollowThreadResponse
-	4,  // 16: chatto.api.v1.ThreadService.UnfollowThread:output_type -> chatto.api.v1.UnfollowThreadResponse
-	16, // 17: chatto.api.v1.ThreadService.GetThreadEvents:output_type -> chatto.api.v1.GetThreadEventsResponse
-	17, // 18: chatto.api.v1.ThreadService.GetThreadEventsAround:output_type -> chatto.api.v1.GetThreadEventsAroundResponse
-	18, // 19: chatto.api.v1.ThreadService.MarkThreadAsRead:output_type -> chatto.api.v1.MarkThreadAsReadResponse
-	14, // [14:20] is the sub-list for method output_type
-	8,  // [8:14] is the sub-list for method input_type
-	8,  // [8:8] is the sub-list for extension type_name
-	8,  // [8:8] is the sub-list for extension extendee
-	0,  // [0:8] is the sub-list for field type_name
+	9,  // 3: chatto.api.v1.FollowedThread.room:type_name -> chatto.api.v1.RoomSummary
+	10, // 4: chatto.api.v1.FollowedThread.thread:type_name -> chatto.api.v1.ThreadSummary
+	11, // 5: chatto.api.v1.ListFollowedThreadsRequest.page:type_name -> chatto.api.v1.PageRequest
+	5,  // 6: chatto.api.v1.ListFollowedThreadsResponse.threads:type_name -> chatto.api.v1.FollowedThread
+	12, // 7: chatto.api.v1.ListFollowedThreadsResponse.includes:type_name -> chatto.api.v1.RoomTimelineIncludes
+	13, // 8: chatto.api.v1.ListFollowedThreadsResponse.page:type_name -> chatto.api.v1.PageInfo
+	6,  // 9: chatto.api.v1.ThreadService.ListFollowedThreads:input_type -> chatto.api.v1.ListFollowedThreadsRequest
+	1,  // 10: chatto.api.v1.ThreadService.FollowThread:input_type -> chatto.api.v1.FollowThreadRequest
+	3,  // 11: chatto.api.v1.ThreadService.UnfollowThread:input_type -> chatto.api.v1.UnfollowThreadRequest
+	14, // 12: chatto.api.v1.ThreadService.GetThreadEvents:input_type -> chatto.api.v1.GetThreadEventsRequest
+	15, // 13: chatto.api.v1.ThreadService.GetThreadEventsAround:input_type -> chatto.api.v1.GetThreadEventsAroundRequest
+	16, // 14: chatto.api.v1.ThreadService.MarkThreadAsRead:input_type -> chatto.api.v1.MarkThreadAsReadRequest
+	7,  // 15: chatto.api.v1.ThreadService.ListFollowedThreads:output_type -> chatto.api.v1.ListFollowedThreadsResponse
+	2,  // 16: chatto.api.v1.ThreadService.FollowThread:output_type -> chatto.api.v1.FollowThreadResponse
+	4,  // 17: chatto.api.v1.ThreadService.UnfollowThread:output_type -> chatto.api.v1.UnfollowThreadResponse
+	17, // 18: chatto.api.v1.ThreadService.GetThreadEvents:output_type -> chatto.api.v1.GetThreadEventsResponse
+	18, // 19: chatto.api.v1.ThreadService.GetThreadEventsAround:output_type -> chatto.api.v1.GetThreadEventsAroundResponse
+	19, // 20: chatto.api.v1.ThreadService.MarkThreadAsRead:output_type -> chatto.api.v1.MarkThreadAsReadResponse
+	15, // [15:21] is the sub-list for method output_type
+	9,  // [9:15] is the sub-list for method input_type
+	9,  // [9:9] is the sub-list for extension type_name
+	9,  // [9:9] is the sub-list for extension extendee
+	0,  // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_chatto_api_v1_threads_proto_init() }
@@ -634,6 +594,7 @@ func file_chatto_api_v1_threads_proto_init() {
 	file_chatto_api_v1_pagination_proto_init()
 	file_chatto_api_v1_read_state_proto_init()
 	file_chatto_api_v1_room_timeline_proto_init()
+	file_chatto_api_v1_rooms_proto_init()
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/packages/api-types/src/chatto/api/v1/message_types_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/message_types_pb.ts
@@ -444,6 +444,138 @@ export class MessageReaction extends Message$1<MessageReaction> {
 }
 
 /**
+ * Viewer-specific state for one message thread.
+ *
+ * @generated from message chatto.api.v1.ThreadViewerState
+ */
+export class ThreadViewerState extends Message$1<ThreadViewerState> {
+  /**
+   * Whether the current user follows this message's thread, when known.
+   *
+   * @generated from field: optional bool is_following = 1;
+   */
+  isFollowing?: boolean;
+
+  /**
+   * True when the thread has unread replies for the current user, when known.
+   *
+   * @generated from field: optional bool has_unread = 2;
+   */
+  hasUnread?: boolean;
+
+  constructor(data?: PartialMessage<ThreadViewerState>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.api.v1.ThreadViewerState";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "is_following", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
+    { no: 2, name: "has_unread", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ThreadViewerState {
+    return new ThreadViewerState().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ThreadViewerState {
+    return new ThreadViewerState().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ThreadViewerState {
+    return new ThreadViewerState().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ThreadViewerState | PlainMessage<ThreadViewerState> | undefined, b: ThreadViewerState | PlainMessage<ThreadViewerState> | undefined): boolean {
+    return proto3.util.equals(ThreadViewerState, a, b);
+  }
+}
+
+/**
+ * Aggregated state for one message thread.
+ *
+ * @generated from message chatto.api.v1.ThreadSummary
+ */
+export class ThreadSummary extends Message$1<ThreadSummary> {
+  /**
+   * Event ID of the root message for the thread.
+   *
+   * @generated from field: string thread_root_event_id = 1;
+   */
+  threadRootEventId = "";
+
+  /**
+   * Number of replies in this message's thread.
+   *
+   * @generated from field: int32 reply_count = 2;
+   */
+  replyCount = 0;
+
+  /**
+   * Creation time of the most recent reply in this message's thread.
+   *
+   * @generated from field: google.protobuf.Timestamp last_reply_at = 3;
+   */
+  lastReplyAt?: Timestamp;
+
+  /**
+   * Preview of up to five user IDs that have participated in this message's
+   * thread.
+   *
+   * @generated from field: repeated string participant_preview_user_ids = 4;
+   */
+  participantPreviewUserIds: string[] = [];
+
+  /**
+   * Total number of distinct users that have participated in this message's
+   * thread.
+   *
+   * @generated from field: int32 participant_count = 5;
+   */
+  participantCount = 0;
+
+  /**
+   * State resolved for the current user.
+   *
+   * @generated from field: chatto.api.v1.ThreadViewerState viewer_state = 6;
+   */
+  viewerState?: ThreadViewerState;
+
+  constructor(data?: PartialMessage<ThreadSummary>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.api.v1.ThreadSummary";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "thread_root_event_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "reply_count", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
+    { no: 3, name: "last_reply_at", kind: "message", T: Timestamp },
+    { no: 4, name: "participant_preview_user_ids", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+    { no: 5, name: "participant_count", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
+    { no: 6, name: "viewer_state", kind: "message", T: ThreadViewerState },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ThreadSummary {
+    return new ThreadSummary().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ThreadSummary {
+    return new ThreadSummary().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ThreadSummary {
+    return new ThreadSummary().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ThreadSummary | PlainMessage<ThreadSummary> | undefined, b: ThreadSummary | PlainMessage<ThreadSummary> | undefined): boolean {
+    return proto3.util.equals(ThreadSummary, a, b);
+  }
+}
+
+/**
  * Renderable message data.
  *
  * The same shape is used for top-level room messages, thread replies, and
@@ -548,48 +680,18 @@ export class Message extends Message$1<Message> {
   channelEchoEventId = "";
 
   /**
-   * Number of replies in this message's thread.
-   *
-   * @generated from field: int32 reply_count = 14;
-   */
-  replyCount = 0;
-
-  /**
-   * Creation time of the most recent reply in this message's thread.
-   *
-   * @generated from field: google.protobuf.Timestamp last_reply_at = 15;
-   */
-  lastReplyAt?: Timestamp;
-
-  /**
-   * Preview of up to five user IDs that have participated in this message's
-   * thread.
-   *
-   * @generated from field: repeated string thread_participant_preview_user_ids = 16;
-   */
-  threadParticipantPreviewUserIds: string[] = [];
-
-  /**
-   * Total number of distinct users that have participated in this message's
-   * thread.
-   *
-   * @generated from field: int32 thread_participant_count = 17;
-   */
-  threadParticipantCount = 0;
-
-  /**
-   * Whether the current user follows this message's thread, when known.
-   *
-   * @generated from field: optional bool viewer_is_following_thread = 18;
-   */
-  viewerIsFollowingThread?: boolean;
-
-  /**
    * Reaction summaries for this message.
    *
    * @generated from field: repeated chatto.api.v1.MessageReaction reactions = 19;
    */
   reactions: MessageReaction[] = [];
+
+  /**
+   * Aggregated thread state, when known for a thread root message.
+   *
+   * @generated from field: chatto.api.v1.ThreadSummary thread = 20;
+   */
+  thread?: ThreadSummary;
 
   constructor(data?: PartialMessage<Message>) {
     super();
@@ -612,12 +714,8 @@ export class Message extends Message$1<Message> {
     { no: 11, name: "echo_of_event_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 12, name: "echo_from_thread_root_event_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 13, name: "channel_echo_event_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 14, name: "reply_count", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
-    { no: 15, name: "last_reply_at", kind: "message", T: Timestamp },
-    { no: 16, name: "thread_participant_preview_user_ids", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
-    { no: 17, name: "thread_participant_count", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
-    { no: 18, name: "viewer_is_following_thread", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
     { no: 19, name: "reactions", kind: "message", T: MessageReaction, repeated: true },
+    { no: 20, name: "thread", kind: "message", T: ThreadSummary },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Message {

--- a/packages/api-types/src/chatto/api/v1/notifications_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/notifications_pb.ts
@@ -5,57 +5,9 @@
 
 import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
 import { Message, proto3, Timestamp } from "@bufbuild/protobuf";
+import { RoomSummary } from "./rooms_pb.js";
 import { User } from "./users_pb.js";
 import { PageInfo, PageRequest } from "./pagination_pb.js";
-
-/**
- * Room summary embedded in notification responses.
- *
- * @generated from message chatto.api.v1.NotificationRoom
- */
-export class NotificationRoom extends Message<NotificationRoom> {
-  /**
-   * Stable room ID.
-   *
-   * @generated from field: string id = 1;
-   */
-  id = "";
-
-  /**
-   * Room display name. Empty for DM rooms.
-   *
-   * @generated from field: string name = 2;
-   */
-  name = "";
-
-  constructor(data?: PartialMessage<NotificationRoom>) {
-    super();
-    proto3.util.initPartial(data, this);
-  }
-
-  static readonly runtime: typeof proto3 = proto3;
-  static readonly typeName = "chatto.api.v1.NotificationRoom";
-  static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-  ]);
-
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): NotificationRoom {
-    return new NotificationRoom().fromBinary(bytes, options);
-  }
-
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): NotificationRoom {
-    return new NotificationRoom().fromJson(jsonValue, options);
-  }
-
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): NotificationRoom {
-    return new NotificationRoom().fromJsonString(jsonString, options);
-  }
-
-  static equals(a: NotificationRoom | PlainMessage<NotificationRoom> | undefined, b: NotificationRoom | PlainMessage<NotificationRoom> | undefined): boolean {
-    return proto3.util.equals(NotificationRoom, a, b);
-  }
-}
 
 /**
  * Direct-message notification payload.
@@ -64,18 +16,18 @@ export class NotificationRoom extends Message<NotificationRoom> {
  */
 export class DirectMessageNotification extends Message<DirectMessageNotification> {
   /**
-   * DM room where the message was posted.
-   *
-   * @generated from field: string room_id = 1;
-   */
-  roomId = "";
-
-  /**
    * Message event ID.
    *
    * @generated from field: string event_id = 2;
    */
   eventId = "";
+
+  /**
+   * DM room where the message was posted.
+   *
+   * @generated from field: chatto.api.v1.RoomSummary room = 3;
+   */
+  room?: RoomSummary;
 
   constructor(data?: PartialMessage<DirectMessageNotification>) {
     super();
@@ -85,8 +37,8 @@ export class DirectMessageNotification extends Message<DirectMessageNotification
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.api.v1.DirectMessageNotification";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "room_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "event_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "room", kind: "message", T: RoomSummary },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DirectMessageNotification {
@@ -115,9 +67,9 @@ export class MentionNotification extends Message<MentionNotification> {
   /**
    * Room where the mention occurred.
    *
-   * @generated from field: chatto.api.v1.NotificationRoom room = 1;
+   * @generated from field: chatto.api.v1.RoomSummary room = 1;
    */
-  room?: NotificationRoom;
+  room?: RoomSummary;
 
   /**
    * Message event ID.
@@ -141,7 +93,7 @@ export class MentionNotification extends Message<MentionNotification> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.api.v1.MentionNotification";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "room", kind: "message", T: NotificationRoom },
+    { no: 1, name: "room", kind: "message", T: RoomSummary },
     { no: 2, name: "event_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "thread_root_event_id", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
   ]);
@@ -172,9 +124,9 @@ export class ReplyNotification extends Message<ReplyNotification> {
   /**
    * Room where the reply occurred.
    *
-   * @generated from field: chatto.api.v1.NotificationRoom room = 1;
+   * @generated from field: chatto.api.v1.RoomSummary room = 1;
    */
-  room?: NotificationRoom;
+  room?: RoomSummary;
 
   /**
    * Reply event ID.
@@ -205,7 +157,7 @@ export class ReplyNotification extends Message<ReplyNotification> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.api.v1.ReplyNotification";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "room", kind: "message", T: NotificationRoom },
+    { no: 1, name: "room", kind: "message", T: RoomSummary },
     { no: 2, name: "event_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "in_reply_to_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 4, name: "thread_root_event_id", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -237,9 +189,9 @@ export class RoomMessageNotification extends Message<RoomMessageNotification> {
   /**
    * Room where the message was posted.
    *
-   * @generated from field: chatto.api.v1.NotificationRoom room = 1;
+   * @generated from field: chatto.api.v1.RoomSummary room = 1;
    */
-  room?: NotificationRoom;
+  room?: RoomSummary;
 
   /**
    * Message event ID.
@@ -256,7 +208,7 @@ export class RoomMessageNotification extends Message<RoomMessageNotification> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.api.v1.RoomMessageNotification";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "room", kind: "message", T: NotificationRoom },
+    { no: 1, name: "room", kind: "message", T: RoomSummary },
     { no: 2, name: "event_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 

--- a/packages/api-types/src/chatto/api/v1/room_directory_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/room_directory_pb.ts
@@ -5,6 +5,7 @@
 
 import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
 import { Message, proto3 } from "@bufbuild/protobuf";
+import { PermissionGrant } from "./permissions_pb.js";
 import { Room } from "./rooms_pb.js";
 
 /**
@@ -50,6 +51,63 @@ proto3.util.setEnumType(RoomDirectoryScope, "chatto.api.v1.RoomDirectoryScope", 
 ]);
 
 /**
+ * Viewer-specific state and permission decisions for one room.
+ *
+ * @generated from message chatto.api.v1.RoomViewerState
+ */
+export class RoomViewerState extends Message<RoomViewerState> {
+  /**
+   * True when the current user is an effective room member.
+   *
+   * @generated from field: bool is_member = 1;
+   */
+  isMember = false;
+
+  /**
+   * True when the room has unread root messages for the current user.
+   *
+   * @generated from field: bool has_unread = 2;
+   */
+  hasUnread = false;
+
+  /**
+   * Effective room-scoped permission decisions after room state constraints.
+   *
+   * @generated from field: repeated chatto.api.v1.PermissionGrant permissions = 3;
+   */
+  permissions: PermissionGrant[] = [];
+
+  constructor(data?: PartialMessage<RoomViewerState>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.api.v1.RoomViewerState";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "is_member", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 2, name: "has_unread", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 3, name: "permissions", kind: "message", T: PermissionGrant, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RoomViewerState {
+    return new RoomViewerState().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): RoomViewerState {
+    return new RoomViewerState().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): RoomViewerState {
+    return new RoomViewerState().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: RoomViewerState | PlainMessage<RoomViewerState> | undefined, b: RoomViewerState | PlainMessage<RoomViewerState> | undefined): boolean {
+    return proto3.util.equals(RoomViewerState, a, b);
+  }
+}
+
+/**
  * Room metadata plus state and capabilities resolved for the authenticated
  * viewer.
  *
@@ -64,88 +122,11 @@ export class RoomWithViewerState extends Message<RoomWithViewerState> {
   room?: Room;
 
   /**
-   * True when the current user is an effective room member.
+   * State and permission decisions resolved for the current user.
    *
-   * @generated from field: bool is_member = 2;
+   * @generated from field: chatto.api.v1.RoomViewerState viewer_state = 14;
    */
-  isMember = false;
-
-  /**
-   * True when the room has unread root messages for the current user.
-   *
-   * @generated from field: bool has_unread = 3;
-   */
-  hasUnread = false;
-
-  /**
-   * True when the room can appear in directory surfaces for the current user.
-   *
-   * @generated from field: bool can_list_room = 4;
-   */
-  canListRoom = false;
-
-  /**
-   * True when the current user can join this room.
-   *
-   * @generated from field: bool can_join_room = 5;
-   */
-  canJoinRoom = false;
-
-  /**
-   * True when the current user can post new root messages.
-   *
-   * @generated from field: bool can_post_message = 6;
-   */
-  canPostMessage = false;
-
-  /**
-   * True when the current user can post thread replies.
-   *
-   * @generated from field: bool can_post_in_thread = 7;
-   */
-  canPostInThread = false;
-
-  /**
-   * True when the current user can attach files to messages.
-   *
-   * @generated from field: bool can_attach = 8;
-   */
-  canAttach = false;
-
-  /**
-   * True when the current user can add and remove reactions.
-   *
-   * @generated from field: bool can_react = 9;
-   */
-  canReact = false;
-
-  /**
-   * True when the current user can echo thread replies to the main room.
-   *
-   * @generated from field: bool can_echo_message = 10;
-   */
-  canEchoMessage = false;
-
-  /**
-   * True when the current user can edit or delete other users' messages.
-   *
-   * @generated from field: bool can_manage_others_message = 11;
-   */
-  canManageOthersMessage = false;
-
-  /**
-   * True when the current user can configure this room.
-   *
-   * @generated from field: bool can_manage_room = 12;
-   */
-  canManageRoom = false;
-
-  /**
-   * True when the current user can ban members from this room.
-   *
-   * @generated from field: bool can_ban_room_members = 13;
-   */
-  canBanRoomMembers = false;
+  viewerState?: RoomViewerState;
 
   constructor(data?: PartialMessage<RoomWithViewerState>) {
     super();
@@ -156,18 +137,7 @@ export class RoomWithViewerState extends Message<RoomWithViewerState> {
   static readonly typeName = "chatto.api.v1.RoomWithViewerState";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "room", kind: "message", T: Room },
-    { no: 2, name: "is_member", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
-    { no: 3, name: "has_unread", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
-    { no: 4, name: "can_list_room", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
-    { no: 5, name: "can_join_room", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
-    { no: 6, name: "can_post_message", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
-    { no: 7, name: "can_post_in_thread", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
-    { no: 8, name: "can_attach", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
-    { no: 9, name: "can_react", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
-    { no: 10, name: "can_echo_message", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
-    { no: 11, name: "can_manage_others_message", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
-    { no: 12, name: "can_manage_room", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
-    { no: 13, name: "can_ban_room_members", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 14, name: "viewer_state", kind: "message", T: RoomViewerState },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RoomWithViewerState {
@@ -307,11 +277,11 @@ export class RoomGroupItem extends Message<RoomGroupItem> {
  */
 export class RoomGroupViewerState extends Message<RoomGroupViewerState> {
   /**
-   * True when the current user can create rooms in this group.
+   * Effective group-scoped permission decisions after group state constraints.
    *
-   * @generated from field: bool can_create_room = 1;
+   * @generated from field: repeated chatto.api.v1.PermissionGrant permissions = 2;
    */
-  canCreateRoom = false;
+  permissions: PermissionGrant[] = [];
 
   constructor(data?: PartialMessage<RoomGroupViewerState>) {
     super();
@@ -321,7 +291,7 @@ export class RoomGroupViewerState extends Message<RoomGroupViewerState> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.api.v1.RoomGroupViewerState";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "can_create_room", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 2, name: "permissions", kind: "message", T: PermissionGrant, repeated: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RoomGroupViewerState {

--- a/packages/api-types/src/chatto/api/v1/rooms_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/rooms_pb.ts
@@ -135,6 +135,64 @@ export class Room extends Message<Room> {
 }
 
 /**
+ * Lightweight room reference for cross-resource rows.
+ *
+ * @generated from message chatto.api.v1.RoomSummary
+ */
+export class RoomSummary extends Message<RoomSummary> {
+  /**
+   * Stable room ID.
+   *
+   * @generated from field: string id = 1;
+   */
+  id = "";
+
+  /**
+   * Room kind.
+   *
+   * @generated from field: chatto.api.v1.RoomKind kind = 2;
+   */
+  kind = RoomKind.UNSPECIFIED;
+
+  /**
+   * Room name. Direct-message rooms may have an empty name because clients
+   * derive their display label from participants.
+   *
+   * @generated from field: string name = 3;
+   */
+  name = "";
+
+  constructor(data?: PartialMessage<RoomSummary>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.api.v1.RoomSummary";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "kind", kind: "enum", T: proto3.getEnumType(RoomKind) },
+    { no: 3, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RoomSummary {
+    return new RoomSummary().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): RoomSummary {
+    return new RoomSummary().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): RoomSummary {
+    return new RoomSummary().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: RoomSummary | PlainMessage<RoomSummary> | undefined, b: RoomSummary | PlainMessage<RoomSummary> | undefined): boolean {
+    return proto3.util.equals(RoomSummary, a, b);
+  }
+}
+
+/**
  * Request to create a channel room.
  *
  * @generated from message chatto.api.v1.CreateRoomRequest

--- a/packages/api-types/src/chatto/api/v1/threads_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/threads_pb.ts
@@ -4,8 +4,9 @@
 // @ts-nocheck
 
 import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
-import { Message, proto3, Timestamp } from "@bufbuild/protobuf";
-import { Message as Message$1 } from "./message_types_pb.js";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import { Message as Message$1, ThreadSummary } from "./message_types_pb.js";
+import { RoomSummary } from "./rooms_pb.js";
 import { PageInfo, PageRequest } from "./pagination_pb.js";
 import { RoomTimelineIncludes } from "./room_timeline_pb.js";
 
@@ -269,27 +270,6 @@ export class UnfollowThreadResponse extends Message<UnfollowThreadResponse> {
  */
 export class FollowedThread extends Message<FollowedThread> {
   /**
-   * Room containing the thread.
-   *
-   * @generated from field: string room_id = 1;
-   */
-  roomId = "";
-
-  /**
-   * Current display name of the room.
-   *
-   * @generated from field: string room_name = 2;
-   */
-  roomName = "";
-
-  /**
-   * Event ID of the root message for the thread.
-   *
-   * @generated from field: string thread_root_event_id = 3;
-   */
-  threadRootEventId = "";
-
-  /**
    * Renderable root message, when the root is still visible.
    *
    * @generated from field: chatto.api.v1.Message root_message = 4;
@@ -297,25 +277,18 @@ export class FollowedThread extends Message<FollowedThread> {
   rootMessage?: Message$1;
 
   /**
-   * Number of replies in the thread.
+   * Room containing the thread.
    *
-   * @generated from field: int32 reply_count = 5;
+   * @generated from field: chatto.api.v1.RoomSummary room = 8;
    */
-  replyCount = 0;
+  room?: RoomSummary;
 
   /**
-   * Creation time of the latest reply, when the thread has replies.
+   * Aggregated thread state.
    *
-   * @generated from field: google.protobuf.Timestamp last_reply_at = 6;
+   * @generated from field: chatto.api.v1.ThreadSummary thread = 9;
    */
-  lastReplyAt?: Timestamp;
-
-  /**
-   * True when the current user has unread replies in the thread.
-   *
-   * @generated from field: bool has_unread = 7;
-   */
-  hasUnread = false;
+  thread?: ThreadSummary;
 
   constructor(data?: PartialMessage<FollowedThread>) {
     super();
@@ -325,13 +298,9 @@ export class FollowedThread extends Message<FollowedThread> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.api.v1.FollowedThread";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "room_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "room_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 3, name: "thread_root_event_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 4, name: "root_message", kind: "message", T: Message$1 },
-    { no: 5, name: "reply_count", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
-    { no: 6, name: "last_reply_at", kind: "message", T: Timestamp },
-    { no: 7, name: "has_unread", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 8, name: "room", kind: "message", T: RoomSummary },
+    { no: 9, name: "thread", kind: "message", T: ThreadSummary },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): FollowedThread {

--- a/proto/chatto/api/v1/message_types.proto
+++ b/proto/chatto/api/v1/message_types.proto
@@ -104,6 +104,32 @@ message MessageReaction {
   repeated string preview_user_ids = 4;
 }
 
+// Viewer-specific state for one message thread.
+message ThreadViewerState {
+  // Whether the current user follows this message's thread, when known.
+  optional bool is_following = 1;
+  // True when the thread has unread replies for the current user, when known.
+  optional bool has_unread = 2;
+}
+
+// Aggregated state for one message thread.
+message ThreadSummary {
+  // Event ID of the root message for the thread.
+  string thread_root_event_id = 1;
+  // Number of replies in this message's thread.
+  int32 reply_count = 2;
+  // Creation time of the most recent reply in this message's thread.
+  google.protobuf.Timestamp last_reply_at = 3;
+  // Preview of up to five user IDs that have participated in this message's
+  // thread.
+  repeated string participant_preview_user_ids = 4;
+  // Total number of distinct users that have participated in this message's
+  // thread.
+  int32 participant_count = 5;
+  // State resolved for the current user.
+  ThreadViewerState viewer_state = 6;
+}
+
 // Renderable message data.
 //
 // The same shape is used for top-level room messages, thread replies, and
@@ -111,6 +137,9 @@ message MessageReaction {
 // thread participants, and follow state without additional per-message
 // requests.
 message Message {
+  reserved 14 to 18;
+  reserved "reply_count", "last_reply_at", "thread_participant_preview_user_ids", "thread_participant_count", "viewer_is_following_thread";
+
   // Stable message event ID.
   string id = 1;
   // Room containing the message.
@@ -139,18 +168,8 @@ message Message {
   string echo_from_thread_root_event_id = 12;
   // Channel timeline event ID for a thread echo, when applicable.
   string channel_echo_event_id = 13;
-  // Number of replies in this message's thread.
-  int32 reply_count = 14;
-  // Creation time of the most recent reply in this message's thread.
-  google.protobuf.Timestamp last_reply_at = 15;
-  // Preview of up to five user IDs that have participated in this message's
-  // thread.
-  repeated string thread_participant_preview_user_ids = 16;
-  // Total number of distinct users that have participated in this message's
-  // thread.
-  int32 thread_participant_count = 17;
-  // Whether the current user follows this message's thread, when known.
-  optional bool viewer_is_following_thread = 18;
   // Reaction summaries for this message.
   repeated MessageReaction reactions = 19;
+  // Aggregated thread state, when known for a thread root message.
+  ThreadSummary thread = 20;
 }

--- a/proto/chatto/api/v1/notifications.proto
+++ b/proto/chatto/api/v1/notifications.proto
@@ -4,29 +4,25 @@ package chatto.api.v1;
 
 import "buf/validate/validate.proto";
 import "chatto/api/v1/pagination.proto";
+import "chatto/api/v1/rooms.proto";
 import "chatto/api/v1/users.proto";
 import "google/protobuf/timestamp.proto";
 
-// Room summary embedded in notification responses.
-message NotificationRoom {
-  // Stable room ID.
-  string id = 1;
-  // Room display name. Empty for DM rooms.
-  string name = 2;
-}
-
 // Direct-message notification payload.
 message DirectMessageNotification {
-  // DM room where the message was posted.
-  string room_id = 1;
+  reserved 1;
+  reserved "room_id";
+
   // Message event ID.
   string event_id = 2;
+  // DM room where the message was posted.
+  RoomSummary room = 3;
 }
 
 // Mention notification payload.
 message MentionNotification {
   // Room where the mention occurred.
-  NotificationRoom room = 1;
+  RoomSummary room = 1;
   // Message event ID.
   string event_id = 2;
   // Thread root event ID when the mention happened inside a thread.
@@ -36,7 +32,7 @@ message MentionNotification {
 // Reply notification payload.
 message ReplyNotification {
   // Room where the reply occurred.
-  NotificationRoom room = 1;
+  RoomSummary room = 1;
   // Reply event ID.
   string event_id = 2;
   // Event ID of the message being replied to.
@@ -48,7 +44,7 @@ message ReplyNotification {
 // All-messages room notification payload.
 message RoomMessageNotification {
   // Room where the message was posted.
-  NotificationRoom room = 1;
+  RoomSummary room = 1;
   // Message event ID.
   string event_id = 2;
 }

--- a/proto/chatto/api/v1/room_directory.proto
+++ b/proto/chatto/api/v1/room_directory.proto
@@ -3,7 +3,18 @@ syntax = "proto3";
 package chatto.api.v1;
 
 import "buf/validate/validate.proto";
+import "chatto/api/v1/permissions.proto";
 import "chatto/api/v1/rooms.proto";
+
+// Viewer-specific state and permission decisions for one room.
+message RoomViewerState {
+  // True when the current user is an effective room member.
+  bool is_member = 1;
+  // True when the room has unread root messages for the current user.
+  bool has_unread = 2;
+  // Effective room-scoped permission decisions after room state constraints.
+  repeated PermissionGrant permissions = 3;
+}
 
 // Room kinds to include in directory responses.
 enum RoomDirectoryScope {
@@ -20,32 +31,13 @@ enum RoomDirectoryScope {
 // Room metadata plus state and capabilities resolved for the authenticated
 // viewer.
 message RoomWithViewerState {
+  reserved 2 to 13;
+  reserved "is_member", "has_unread", "can_list_room", "can_join_room", "can_post_message", "can_post_in_thread", "can_attach", "can_react", "can_echo_message", "can_manage_others_message", "can_manage_room", "can_ban_room_members";
+
   // Public room metadata.
   Room room = 1;
-  // True when the current user is an effective room member.
-  bool is_member = 2;
-  // True when the room has unread root messages for the current user.
-  bool has_unread = 3;
-  // True when the room can appear in directory surfaces for the current user.
-  bool can_list_room = 4;
-  // True when the current user can join this room.
-  bool can_join_room = 5;
-  // True when the current user can post new root messages.
-  bool can_post_message = 6;
-  // True when the current user can post thread replies.
-  bool can_post_in_thread = 7;
-  // True when the current user can attach files to messages.
-  bool can_attach = 8;
-  // True when the current user can add and remove reactions.
-  bool can_react = 9;
-  // True when the current user can echo thread replies to the main room.
-  bool can_echo_message = 10;
-  // True when the current user can edit or delete other users' messages.
-  bool can_manage_others_message = 11;
-  // True when the current user can configure this room.
-  bool can_manage_room = 12;
-  // True when the current user can ban members from this room.
-  bool can_ban_room_members = 13;
+  // State and permission decisions resolved for the current user.
+  RoomViewerState viewer_state = 14;
 }
 
 // Sidebar link metadata for room group navigation.
@@ -70,8 +62,11 @@ message RoomGroupItem {
 
 // Viewer-specific state for one room group.
 message RoomGroupViewerState {
-  // True when the current user can create rooms in this group.
-  bool can_create_room = 1;
+  reserved 1;
+  reserved "can_create_room";
+
+  // Effective group-scoped permission decisions after group state constraints.
+  repeated PermissionGrant permissions = 2;
 }
 
 // Ordered group of channel rooms and sidebar links.

--- a/proto/chatto/api/v1/rooms.proto
+++ b/proto/chatto/api/v1/rooms.proto
@@ -40,6 +40,17 @@ message Room {
   bool universal = 7;
 }
 
+// Lightweight room reference for cross-resource rows.
+message RoomSummary {
+  // Stable room ID.
+  string id = 1;
+  // Room kind.
+  RoomKind kind = 2;
+  // Room name. Direct-message rooms may have an empty name because clients
+  // derive their display label from participants.
+  string name = 3;
+}
+
 // Request to create a channel room.
 message CreateRoomRequest {
   // Required. Name of the new channel room.

--- a/proto/chatto/api/v1/threads.proto
+++ b/proto/chatto/api/v1/threads.proto
@@ -7,7 +7,7 @@ import "chatto/api/v1/message_types.proto";
 import "chatto/api/v1/pagination.proto";
 import "chatto/api/v1/read_state.proto";
 import "chatto/api/v1/room_timeline.proto";
-import "google/protobuf/timestamp.proto";
+import "chatto/api/v1/rooms.proto";
 
 // Current follow state for one thread and viewer.
 message ThreadFollowState {
@@ -53,20 +53,15 @@ message UnfollowThreadResponse {
 
 // One followed thread for the current user.
 message FollowedThread {
-  // Room containing the thread.
-  string room_id = 1;
-  // Current display name of the room.
-  string room_name = 2;
-  // Event ID of the root message for the thread.
-  string thread_root_event_id = 3;
+  reserved 1 to 3, 5 to 7;
+  reserved "room_id", "room_name", "thread_root_event_id", "reply_count", "last_reply_at", "has_unread";
+
   // Renderable root message, when the root is still visible.
   Message root_message = 4;
-  // Number of replies in the thread.
-  int32 reply_count = 5;
-  // Creation time of the latest reply, when the thread has replies.
-  google.protobuf.Timestamp last_reply_at = 6;
-  // True when the current user has unread replies in the thread.
-  bool has_unread = 7;
+  // Room containing the thread.
+  RoomSummary room = 8;
+  // Aggregated thread state.
+  ThreadSummary thread = 9;
 }
 
 // Request for a page of followed threads for the current user.


### PR DESCRIPTION
## Summary

Consolidates several overlapping `chatto.api.v1` response shapes around shared resources:

- adds `RoomSummary` for cross-resource room references and uses it in notifications and followed threads
- moves room directory viewer state into `RoomViewerState` / `RoomGroupViewerState`, with action availability represented as keyed `PermissionGrant` entries
- adds `ThreadSummary` / `ThreadViewerState` and moves message and followed-thread thread metadata under that shared shape
- updates ConnectRPC assemblers, frontend API adapters, API-client tests, generated Go/TypeScript protobuf outputs, generated API docs, e2e raw Connect helpers, and 0.4.0 upgrade notes

## Notes

This is a breaking pre-0.4 API cleanup. Earlier beta clients should regenerate API bindings and update direct field reads for room directory entries, message thread metadata, followed thread rows, and direct-message notification room IDs.

The independent review found and this PR fixes a wrong frontend permission key for `room.ban-member`, and makes `ThreadViewerState.has_unread` optional so message/timeline responses do not imply false when unread state is unknown.

## Verification

- `mise codegen-proto`
- `mise x -- pnpm --dir packages/api-types build`
- `mise x -- go test ./internal/connectapi` from `cli/`
- `mise x -- pnpm --dir apps/frontend exec vitest run src/lib/api-client-tests/roomDirectory.spec.ts src/lib/api-client-tests/roomTimeline.spec.ts src/lib/api-client-tests/threads.spec.ts src/lib/api-client-tests/notifications.spec.ts src/lib/api-client-tests/messages.spec.ts`
- `mise x -- pnpm --dir apps/frontend run check`
- `mise x -- pnpm --dir apps/frontend exec playwright test e2e/unread-indicators.test.ts`
