### PR TITLE
feat(frontend): add Trusted Types markdown policy

### DIFF
--- a/apps/frontend/nginx.conf
+++ b/apps/frontend/nginx.conf
@@ -5,7 +5,7 @@ server {
     root /usr/share/nginx/html;
     index 200.html;
 
-    set $chatto_csp_report_only "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: http: https:; media-src 'self' blob: http: https:; connect-src 'self' http: https: ws: wss:; frame-src https://www.youtube-nocookie.com; worker-src 'self'; require-trusted-types-for 'script'; trusted-types default";
+    set $chatto_csp_report_only "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: http: https:; media-src 'self' blob: http: https:; connect-src 'self' http: https: ws: wss:; frame-src https://www.youtube-nocookie.com; worker-src 'self'";
 
     # Security headers
     add_header X-Content-Type-Options "nosniff" always;

--- a/apps/frontend/nginx.conf
+++ b/apps/frontend/nginx.conf
@@ -5,7 +5,7 @@ server {
     root /usr/share/nginx/html;
     index 200.html;
 
-    set $chatto_csp_report_only "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: http: https:; media-src 'self' blob: http: https:; connect-src 'self' http: https: ws: wss:; frame-src https://www.youtube-nocookie.com; worker-src 'self'";
+    set $chatto_csp_report_only "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: http: https:; media-src 'self' blob: http: https:; connect-src 'self' http: https: ws: wss:; frame-src https://www.youtube-nocookie.com; worker-src 'self'; require-trusted-types-for 'script'; trusted-types chatto-markdown-html";
 
     # Security headers
     add_header X-Content-Type-Options "nosniff" always;

--- a/apps/frontend/src/lib/components/MessageContent.svelte
+++ b/apps/frontend/src/lib/components/MessageContent.svelte
@@ -11,6 +11,7 @@
   import MarkdownHtml from '$lib/ui/MarkdownHtml.svelte';
   import { classifyMessageBodyChatLink, buildMessageLinkPath } from '$lib/messageLinks';
   import { wrapValidMentions, type RoomMember } from '$lib/mentions';
+  import { parseTrustedMarkdownHtml } from '$lib/security/trustedHtml';
 
   let {
     body,
@@ -36,7 +37,7 @@
   );
 
   function injectEditedMarker(html: string): string {
-    const doc = new DOMParser().parseFromString(`<div>${html}</div>`, 'text/html');
+    const doc = parseTrustedMarkdownHtml(`<div>${html}</div>`);
     const root = doc.body.firstElementChild;
     if (!root) return html;
     const badge = doc.createElement('span');

--- a/apps/frontend/src/lib/mentions.ts
+++ b/apps/frontend/src/lib/mentions.ts
@@ -1,6 +1,7 @@
 import MarkdownIt from 'markdown-it';
 import type { RoomMember } from '$lib/state/room';
 import type StateInline from 'markdown-it/lib/rules_inline/state_inline.mjs';
+import { parseTrustedMarkdownHtml } from '$lib/security/trustedHtml';
 
 // Re-export for convenience
 export type { RoomMember };
@@ -195,9 +196,8 @@ export function wrapValidMentions(
     return html;
   }
 
-  // Parse HTML into a DOM tree
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(html, 'text/html');
+  // Parse HTML into a DOM tree.
+  const doc = parseTrustedMarkdownHtml(html);
 
   // Collect all text nodes that need processing
   const textNodes: Text[] = [];

--- a/apps/frontend/src/lib/security/trustedHtml.ts
+++ b/apps/frontend/src/lib/security/trustedHtml.ts
@@ -1,0 +1,52 @@
+const MARKDOWN_POLICY_NAME = 'chatto-markdown-html';
+const POLICY_CACHE_KEY = '__chattoMarkdownTrustedTypesPolicy';
+
+type TrustedHTMLValue = string | { toString(): string };
+
+type TrustedTypePolicy = {
+  createHTML(html: string): TrustedHTMLValue;
+};
+
+type TrustedTypesGlobal = typeof globalThis & {
+  trustedTypes?: {
+    createPolicy(
+      name: string,
+      policy: {
+        createHTML(html: string): string;
+      }
+    ): TrustedTypePolicy;
+  };
+  [POLICY_CACHE_KEY]?: TrustedTypePolicy;
+};
+
+const trustedTypesGlobal = globalThis as TrustedTypesGlobal;
+
+function getMarkdownPolicy(): TrustedTypePolicy | null {
+  if (!trustedTypesGlobal.trustedTypes) return null;
+
+  trustedTypesGlobal[POLICY_CACHE_KEY] ??= trustedTypesGlobal.trustedTypes.createPolicy(
+    MARKDOWN_POLICY_NAME,
+    {
+      createHTML(html) {
+        return html;
+      }
+    }
+  );
+  return trustedTypesGlobal[POLICY_CACHE_KEY];
+}
+
+/**
+ * Trusts HTML produced by Chatto's markdown renderer and its reviewed
+ * post-processing steps. Do not use this for raw user-authored HTML.
+ */
+export function trustedMarkdownHtml(html: string): TrustedHTMLValue {
+  return getMarkdownPolicy()?.createHTML(html) ?? html;
+}
+
+/**
+ * DOMParser is also a Trusted Types sink in Chromium. The cast is compile-time
+ * only; browsers receive the TrustedHTML object when Trusted Types are present.
+ */
+export function parseTrustedMarkdownHtml(html: string): Document {
+  return new DOMParser().parseFromString(trustedMarkdownHtml(html) as string, 'text/html');
+}

--- a/apps/frontend/src/lib/ui/MarkdownHtml.svelte
+++ b/apps/frontend/src/lib/ui/MarkdownHtml.svelte
@@ -5,15 +5,20 @@ Single audited sink for HTML produced by `$lib/markdown`.
 
 The markdown renderer disables source HTML and owns every tag/attribute it emits.
 Keep all rendered markdown HTML flowing through this component so raw HTML usage
-does not spread into feature components.
+does not spread into feature components. Callers may pass only markdown renderer
+output, plus the mention and edited-marker post-processing in the message path.
 -->
 <script lang="ts">
+  import { trustedMarkdownHtml } from '$lib/security/trustedHtml';
+
   let {
     html
   }: {
     html: string;
   } = $props();
+
+  const trusted = $derived(trustedMarkdownHtml(html));
 </script>
 
 <!-- eslint-disable-next-line svelte/no-at-html-tags -- rendered markdown from `$lib/markdown`; see component docs above -->
-{@html html}
+{@html trusted}

--- a/apps/frontend/svelte.config.js
+++ b/apps/frontend/svelte.config.js
@@ -33,6 +33,7 @@ const config = {
     }
   },
   compilerOptions: {
+    fragments: 'tree',
     experimental: {
       async: true
     }

--- a/cli/internal/http_server/frontend.go
+++ b/cli/internal/http_server/frontend.go
@@ -30,7 +30,7 @@ const (
 	cacheControlImmutable = "public, max-age=31536000, immutable"
 	// Report-only CSP preserves Chatto's multi-server client model while surfacing
 	// violations during development/staging before we consider enforcement.
-	contentSecurityPolicyReportOnly = "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: http: https:; media-src 'self' blob: http: https:; connect-src 'self' http: https: ws: wss:; frame-src https://www.youtube-nocookie.com; worker-src 'self'; require-trusted-types-for 'script'; trusted-types default"
+	contentSecurityPolicyReportOnly = "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: http: https:; media-src 'self' blob: http: https:; connect-src 'self' http: https: ws: wss:; frame-src https://www.youtube-nocookie.com; worker-src 'self'"
 )
 
 func setFrontendSecurityHeaders(c *gin.Context) {

--- a/cli/internal/http_server/frontend.go
+++ b/cli/internal/http_server/frontend.go
@@ -30,7 +30,7 @@ const (
 	cacheControlImmutable = "public, max-age=31536000, immutable"
 	// Report-only CSP preserves Chatto's multi-server client model while surfacing
 	// violations during development/staging before we consider enforcement.
-	contentSecurityPolicyReportOnly = "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: http: https:; media-src 'self' blob: http: https:; connect-src 'self' http: https: ws: wss:; frame-src https://www.youtube-nocookie.com; worker-src 'self'"
+	contentSecurityPolicyReportOnly = "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: http: https:; media-src 'self' blob: http: https:; connect-src 'self' http: https: ws: wss:; frame-src https://www.youtube-nocookie.com; worker-src 'self'; require-trusted-types-for 'script'; trusted-types chatto-markdown-html"
 )
 
 func setFrontendSecurityHeaders(c *gin.Context) {

--- a/cli/internal/http_server/frontend_test.go
+++ b/cli/internal/http_server/frontend_test.go
@@ -410,7 +410,8 @@ func TestSecurityHeaders(t *testing.T) {
 		assert.Contains(t, csp, "img-src 'self' data: blob: http: https:")
 		assert.Contains(t, csp, "media-src 'self' blob: http: https:")
 		assert.Contains(t, csp, "frame-src https://www.youtube-nocookie.com")
-		assert.NotContains(t, csp, "require-trusted-types-for")
-		assert.NotContains(t, csp, "trusted-types")
+		assert.Contains(t, csp, "require-trusted-types-for 'script'")
+		assert.Contains(t, csp, "trusted-types chatto-markdown-html")
+		assert.NotContains(t, csp, "trusted-types default")
 	})
 }

--- a/cli/internal/http_server/frontend_test.go
+++ b/cli/internal/http_server/frontend_test.go
@@ -410,7 +410,7 @@ func TestSecurityHeaders(t *testing.T) {
 		assert.Contains(t, csp, "img-src 'self' data: blob: http: https:")
 		assert.Contains(t, csp, "media-src 'self' blob: http: https:")
 		assert.Contains(t, csp, "frame-src https://www.youtube-nocookie.com")
-		assert.Contains(t, csp, "require-trusted-types-for 'script'")
-		assert.Contains(t, csp, "trusted-types default")
+		assert.NotContains(t, csp, "require-trusted-types-for")
+		assert.NotContains(t, csp, "trusted-types")
 	})
 }


### PR DESCRIPTION
## Summary
- Keep Trusted Types report-only CSP enabled with a narrow `chatto-markdown-html` policy instead of the broad `default` policy.
- Switch Svelte to `fragments: 'tree'` so compiled fragments do not rely on `innerHTML` under Trusted Types.
- Route the reviewed markdown render/parse sinks through a small Trusted Types helper.

## Validation
- Svelte autofixer on `MarkdownHtml.svelte`
- `svelte-check --tsconfig ./tsconfig.json`
- `pnpm exec vitest run src/lib/markdown.test.ts src/lib/mentions.svelte.test.ts src/lib/components/MessageContent.svelte.spec.ts`
- `mise lint-frontend`
- `mise build-frontend`
- `mise test-frontend`
- `go test ./internal/http_server -run TestSecurityHeaders -count=1`
