### PR TITLE
fix(frontend): stabilize new messages separator

### DIFF
--- a/apps/frontend/e2e/unread-indicators.test.ts
+++ b/apps/frontend/e2e/unread-indicators.test.ts
@@ -777,9 +777,9 @@ test.describe('Room unread separator', () => {
     await roomPage.expectMessageVisible(firstMessage);
     await waitForRoomReadViaConnect(page, generalRoomId);
 
-    // Background the tab. useRoomUnread's effect fires presence-false and
-    // anchors unreadAfterTime = lastCursor, unreadBeforeTime = null (the
-    // open-upper-bound window).
+    // Background the tab. useRoomUnread records only actual missed event ids,
+    // so a blur/refocus cycle with no other user's event must not create a
+    // separator.
     await page.evaluate(() => {
       Object.defineProperty(document, 'visibilityState', {
         value: 'hidden',

--- a/apps/frontend/src/lib/hooks/index.ts
+++ b/apps/frontend/src/lib/hooks/index.ts
@@ -24,6 +24,7 @@ export type { MessageActionParams } from './useMessageActions.svelte';
 // Data hooks
 export { useRoomData } from './useRoomData.svelte';
 export { useRoomUnread } from './useRoomUnread.svelte';
+export type { UnreadMarkerWindow } from './useRoomUnread.svelte';
 
 // Lifecycle hooks
 export { useTabResumeCallback } from './useTabResumeCallback.svelte';

--- a/apps/frontend/src/lib/hooks/useRoomUnread.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useRoomUnread.svelte.ts
@@ -4,11 +4,16 @@ import { serverRegistry } from '$lib/state/server/registry.svelte';
 import { getActiveServer } from '$lib/state/activeServer.svelte';
 import { appState } from '$lib/state/globals.svelte';
 
+export type UnreadMarkerWindow = {
+  afterTime: string;
+  beforeTime: string;
+};
+
 /**
  * Manages room unread state: marks the room as read on entry and every time
  * the user transitions back to "present" on the room (window refocus, tab
- * reveal). Tracks the unread separator position so a refocus shows what
- * arrived while the user was away.
+ * reveal). The rendered unread separator is an explicit event-id marker:
+ * once visible, late read-state responses and background events do not move it.
  *
  * Must be called during component initialization (uses context).
  */
@@ -16,19 +21,13 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
   const connection = useConnection();
   const roomUnreadStore = serverRegistry.getStore(getActiveServer()).roomUnread;
 
-  let unreadAfterTime = $state<string | null>(null);
-  let unreadBeforeTime = $state<string | null>(null);
+  let unreadMarkerEventId = $state<string | null>(null);
+  let unreadMarkerWindow = $state<UnreadMarkerWindow | null>(null);
 
   // The server's most recent read cursor (`lastReadAt`) for this room.
-  // Updated from every markRoomAsRead result; used to capture where the
-  // unread separator should be anchored when the user leaves.
   let lastCursor: string | null = null;
-  // Captured while the app is hidden/unfocused, but intentionally not exposed
-  // to the timeline until the user returns. This lets unread dots update in
-  // the background without repainting the open room's separator while the user
-  // is looking at another app.
-  let pendingAwayAfterTime: string | null = null;
-  let pendingAwayHasEvents = false;
+  // Captured while hidden/unfocused and revealed only when the user returns.
+  let pendingAwayEventId: string | null = null;
 
   async function markRoomAsRead(targetRoomId: string, upToEventId?: string) {
     roomUnreadStore.setRoomUnread(targetRoomId, false);
@@ -54,57 +53,36 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
   /**
    * Advance the tracked read cursor without issuing a mutation. Used when
    * the read cursor moves server-side without a markRoomAsRead call from
-   * this hook — notably when the user posts their own message, since
-   * PostMessage auto-marks the room read on the server.
-   *
-   * Also advances open-upper-bound separator anchors past the new cursor
-   * whenever it lands beyond the anchor, regardless of presence. Two scenarios
-   * both need this:
-   *
-   * 1. Own message lands while away (e.g. posted from another device): the
-   *    presence-false anchor was set from a stale cursor; without this the
-   *    separator would render above the user's own latest message on
-   *    refocus.
-   * 2. Own message lands after a background → refocus → post sequence on
-   *    the same room: the presence-true effect deliberately doesn't
-   *    overwrite the separator on a same-room refocus, so without this the
-   *    separator stays stuck at the prior cursor and renders BETWEEN the
-   *    user's two own posts (one before bg, one after refocus).
-   *
-   * Gating the visible anchor on `unreadBeforeTime === null` keeps the closed
-   * (after, before] window from a fresh room entry intact — that window
-   * represents "this is what you missed last time", and the user posting
-   * doesn't change what they previously hadn't seen.
+   * this hook, notably when the user posts their own message.
    */
   function noteReadCursor(timestamp: string) {
     const ts = Date.parse(timestamp);
     if (lastCursor && ts <= Date.parse(lastCursor)) return;
     lastCursor = timestamp;
+  }
 
-    if (pendingAwayAfterTime !== null && ts > Date.parse(pendingAwayAfterTime)) {
-      pendingAwayAfterTime = timestamp;
-    }
+  function noteAwayEvent(eventId: string) {
+    if (unreadMarkerEventId !== null || pendingAwayEventId !== null) return;
+    pendingAwayEventId = eventId;
+  }
 
-    if (
-      unreadAfterTime !== null &&
-      unreadBeforeTime === null &&
-      ts > Date.parse(unreadAfterTime)
-    ) {
-      unreadAfterTime = timestamp;
+  function setUnreadMarkerEventId(eventId: string | null) {
+    unreadMarkerEventId = eventId;
+    if (eventId !== null) {
+      unreadMarkerWindow = null;
     }
   }
 
-  function noteAwayEvent() {
-    if (pendingAwayAfterTime !== null) {
-      pendingAwayHasEvents = true;
-    }
+  function clearUnreadMarker() {
+    unreadMarkerEventId = null;
+    unreadMarkerWindow = null;
+    pendingAwayEventId = null;
   }
 
   // Fire markRoomAsRead on every presence-true edge (fresh entry OR
-  // refocus/tab-reveal) and on room changes while present. The mutation
-  // result drives the unread separator on room entry; same-room refocus uses
-  // the deferred away anchor so the separator does not appear in the
-  // background before the user returns.
+  // refocus/tab-reveal) and on room changes while present. Fresh room entry
+  // may produce a timestamp window; RoomEventsPane resolves it once to an
+  // explicit event id. Same-room refocus reveals only the pending event id.
   let lastFiredRoomId = '';
   let wasPresent = false;
 
@@ -113,14 +91,6 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
     const present = appState.isPresent;
 
     if (!present) {
-      // Presence-false edge: capture the current read cursor, but do not
-      // expose it to the rendered timeline yet. Messages can keep streaming
-      // in and sidebar unread dots can light up while the user is away; the
-      // in-room separator appears only on the presence-true edge below.
-      if (wasPresent && lastCursor) {
-        pendingAwayAfterTime = lastCursor;
-        pendingAwayHasEvents = false;
-      }
       wasPresent = false;
       return;
     }
@@ -131,52 +101,39 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
     wasPresent = true;
     lastFiredRoomId = roomId;
 
-    // On a room change, clear the previous room's separator so it can't
-    // flash in the new room while the mutation below is in flight. On a
-    // refocus of the *same* room, reveal any deferred away anchor and leave
-    // the mutation result ignored below so the marker stays stable.
     if (isRoomChange) {
-      pendingAwayAfterTime = null;
-      pendingAwayHasEvents = false;
-      unreadAfterTime = null;
-      unreadBeforeTime = null;
-    } else if (pendingAwayAfterTime && pendingAwayHasEvents) {
-      unreadAfterTime = pendingAwayAfterTime;
-      unreadBeforeTime = null;
-      pendingAwayAfterTime = null;
-      pendingAwayHasEvents = false;
+      clearUnreadMarker();
+    } else if (pendingAwayEventId) {
+      setUnreadMarkerEventId(pendingAwayEventId);
+      pendingAwayEventId = null;
     } else {
-      pendingAwayAfterTime = null;
-      pendingAwayHasEvents = false;
+      pendingAwayEventId = null;
     }
 
     markRoomAsRead(roomId).then((result) => {
       const current = getProps();
-      if (current.roomId === roomId && result) {
-        // Only adopt the server's (previousLastReadAt, lastReadAt] window on
-        // a fresh room entry. On a same-room refocus the separator was just
-        // revealed from the deferred away anchor with an open upper bound —
-        // overwriting it here collapses the window to empty whenever the
-        // server cursor hasn't moved (e.g. only non-message events like
-        // joins/leaves arrived while away), making the separator vanish on
-        // focus and reappear on every blur.
-        if (isRoomChange && result.previousLastReadAt && result.lastReadAt) {
-          unreadAfterTime = result.previousLastReadAt;
-          unreadBeforeTime = result.lastReadAt;
-        }
+      if (current.roomId !== roomId || !result) return;
+
+      if (isRoomChange && result.previousLastReadAt && result.lastReadAt) {
+        unreadMarkerWindow = {
+          afterTime: result.previousLastReadAt,
+          beforeTime: result.lastReadAt
+        };
       }
     });
   });
 
   return {
-    get unreadAfterTime() {
-      return unreadAfterTime;
+    get unreadMarkerEventId() {
+      return unreadMarkerEventId;
     },
-    get unreadBeforeTime() {
-      return unreadBeforeTime;
+    get unreadMarkerWindow() {
+      return unreadMarkerWindow;
     },
     markRoomAsRead,
     noteReadCursor,
-    noteAwayEvent
+    noteAwayEvent,
+    setUnreadMarkerEventId,
+    clearUnreadMarker
   };
 }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -64,6 +64,7 @@
     onLoadNewer,
     onJumpToPresent,
     onReachedPresent,
+    onReachedBottom,
     onSoftRefresh,
     pendingHighlightId = null
   }: {
@@ -104,6 +105,7 @@
     onLoadNewer?: () => Promise<void>;
     onJumpToPresent?: () => void;
     onReachedPresent?: () => void;
+    onReachedBottom?: () => void;
     onSoftRefresh?: (result: RefreshCurrentWindowResult, anchored: boolean) => void;
     // Suppress auto-scroll while a highlight is pending (used by ThreadPane)
     pendingHighlightId?: string | null;
@@ -391,10 +393,16 @@
   // Scroll to bottom when clicking the new messages indicator
   function scrollToBottom() {
     setShouldScrollToBottom(true);
+    onReachedBottom?.();
     if (virtualizerHandle) {
       safeScrollToIndex(virtualItems.length - 1, { align: 'end' });
       scrollFader?.refresh();
     }
+  }
+
+  function handleJumpToPresentClick() {
+    onReachedBottom?.();
+    onJumpToPresent?.();
   }
 
   // Timer-based flag set by programmatic scrolls (auto-scroll effect, scroll-request
@@ -582,6 +590,7 @@
     if (!isJumpedMode || !hasReachedEnd || bottomDistance >= 50 || !onReachedPresent) return false;
 
     setShouldScrollToBottom(true);
+    onReachedBottom?.();
     console.debug('[room-refresh] reached present after forward pagination', {
       roomId,
       bottomDistance,
@@ -623,7 +632,11 @@
     if (!alwaysScrollToBottom) {
       // Re-enable auto-scroll if we're at the bottom (and not locked)
       if (distanceFromBottom < 10 && !scrollUpLock) {
+        const wasScrolledUp = !shouldScrollToBottom;
         setShouldScrollToBottom(true);
+        if (wasScrolledUp && Date.now() - userScrollIntentAt < USER_SCROLL_INTENT_MS) {
+          onReachedBottom?.();
+        }
       }
       // Disable auto-scroll if user scrolled up (and clearly not near the bottom).
       // Gated on a recent wheel/touchmove signal so virtua's internal scroll
@@ -820,7 +833,7 @@
   {#if isJumpedMode && !shouldScrollToBottom && onJumpToPresent}
     <button
       transition:fade={{ duration: 150 }}
-      onclick={onJumpToPresent}
+      onclick={handleJumpToPresentClick}
       data-testid="jump-to-present"
       class="absolute bottom-4 left-1/2 -translate-x-1/2 cursor-pointer menu whitespace-nowrap"
     >

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -339,7 +339,7 @@
     if (!event.event) return;
 
     if (!appState.isPresent && shouldRevealAwaySeparator(event)) {
-      unread.noteAwayEvent();
+      unread.noteAwayEvent(event.id);
     }
 
     if (isMessagePostedEvent(event.event) && event.event.roomId === roomId) {
@@ -571,8 +571,10 @@
         <RoomEventsPane
           {roomId}
           messageStore={roomMessageStore}
-          unreadAfterTime={unread.unreadAfterTime}
-          unreadBeforeTime={unread.unreadBeforeTime}
+          unreadMarkerEventId={unread.unreadMarkerEventId}
+          unreadMarkerWindow={unread.unreadMarkerWindow}
+          onUnreadMarkerResolved={(eventId) => unread.setUnreadMarkerEventId(eventId)}
+          onUnreadMarkerCleared={() => unread.clearUnreadMarker()}
           onOpenThread={openThread}
           typingUserIds={typingIndicator.userIds}
           typingMembers={getRoomMembers()}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -122,11 +122,13 @@ vi.mock('$lib/hooks', () => ({
     isRoomLoading: false
   }),
   useRoomUnread: () => ({
-    unreadAfterTime: null,
-    unreadBeforeTime: null,
+    unreadMarkerEventId: null,
+    unreadMarkerWindow: null,
     markRoomAsRead: mocks.markRoomAsRead,
     noteReadCursor: mocks.noteReadCursor,
-    noteAwayEvent: mocks.noteAwayEvent
+    noteAwayEvent: mocks.noteAwayEvent,
+    setUnreadMarkerEventId: vi.fn(),
+    clearUnreadMarker: vi.fn()
   }),
   useEvent: vi.fn(),
   usePresenceChange: vi.fn(),
@@ -378,7 +380,10 @@ describe('Room local message echo', () => {
 
     const roomRegion = q(container, '[data-testid="room-view-region"]')!;
     const desktopSidebarPane = q(container, '[data-testid="room-sidebar-desktop-pane"]')!;
-    const maximizeButton = q(container, '[data-testid="toggle-maximized-call"]') as HTMLButtonElement;
+    const maximizeButton = q(
+      container,
+      '[data-testid="toggle-maximized-call"]'
+    ) as HTMLButtonElement;
 
     await expect.element(desktopSidebarPane).toBeInTheDocument();
     expect(roomRegion.className).not.toContain('lg:hidden');
@@ -402,7 +407,10 @@ describe('Room local message echo', () => {
 
     const roomRegion = q(container, '[data-testid="room-view-region"]')!;
     const desktopSidebarPane = q(container, '[data-testid="room-sidebar-desktop-pane"]')!;
-    const maximizeButton = q(container, '[data-testid="toggle-maximized-call"]') as HTMLButtonElement;
+    const maximizeButton = q(
+      container,
+      '[data-testid="toggle-maximized-call"]'
+    ) as HTMLButtonElement;
 
     maximizeButton.click();
 
@@ -428,7 +436,10 @@ describe('Room local message echo', () => {
 
     const roomRegion = q(container, '[data-testid="room-view-region"]')!;
     const desktopSidebarPane = q(container, '[data-testid="room-sidebar-desktop-pane"]')!;
-    const maximizeButton = q(container, '[data-testid="toggle-maximized-call"]') as HTMLButtonElement;
+    const maximizeButton = q(
+      container,
+      '[data-testid="toggle-maximized-call"]'
+    ) as HTMLButtonElement;
 
     maximizeButton.click();
 
@@ -454,7 +465,10 @@ describe('Room local message echo', () => {
 
     const roomRegion = q(container, '[data-testid="room-view-region"]')!;
     const desktopSidebarPane = q(container, '[data-testid="room-sidebar-desktop-pane"]')!;
-    const maximizeButton = q(container, '[data-testid="toggle-maximized-call"]') as HTMLButtonElement;
+    const maximizeButton = q(
+      container,
+      '[data-testid="toggle-maximized-call"]'
+    ) as HTMLButtonElement;
 
     maximizeButton.click();
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomEventsPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomEventsPane.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { useEvent } from '$lib/hooks';
+  import { useEvent, type UnreadMarkerWindow } from '$lib/hooks';
   import { RoomEventKind, roomEventKind, type RoomEventKindSource } from '$lib/render/eventKinds';
   import {
     getComposerContext,
@@ -26,16 +26,20 @@
   let {
     roomId,
     messageStore: store,
-    unreadAfterTime = null,
-    unreadBeforeTime = null,
+    unreadMarkerEventId = null,
+    unreadMarkerWindow = null,
+    onUnreadMarkerResolved,
+    onUnreadMarkerCleared,
     onOpenThread,
     typingUserIds = [],
     typingMembers = []
   }: {
     roomId: string;
     messageStore: MessagesStore;
-    unreadAfterTime?: string | null;
-    unreadBeforeTime?: string | null;
+    unreadMarkerEventId?: string | null;
+    unreadMarkerWindow?: UnreadMarkerWindow | null;
+    onUnreadMarkerResolved?: (eventId: string) => void;
+    onUnreadMarkerCleared?: () => void;
     onOpenThread?: OpenThreadHandler;
     typingUserIds?: string[];
     typingMembers?: RoomMember[];
@@ -48,11 +52,13 @@
   let roomEvents = $derived(store.rootEvents);
   let updateCounter = $derived(roomEvents.length);
 
-  // Resolve time-based unread boundary to an event ID for EventList
-  let unreadAfterEventId = $derived.by(() => {
-    if (unreadAfterTime === null) return null;
-    const afterMs = new Date(unreadAfterTime).getTime();
-    const beforeMs = unreadBeforeTime ? new Date(unreadBeforeTime).getTime() : Infinity;
+  // Resolve a fresh-entry server timestamp window once, then commit the
+  // concrete event id back to the unread hook. EventList only renders an
+  // explicit event-id marker.
+  let resolvedUnreadMarkerEventId = $derived.by(() => {
+    if (unreadMarkerWindow === null) return null;
+    const afterMs = new Date(unreadMarkerWindow.afterTime).getTime();
+    const beforeMs = new Date(unreadMarkerWindow.beforeTime).getTime();
     for (const event of roomEvents) {
       const eventMs = new Date(event.createdAt).getTime();
       if (eventMs > afterMs && eventMs <= beforeMs) {
@@ -60,6 +66,11 @@
       }
     }
     return null;
+  });
+
+  $effect(() => {
+    if (!resolvedUnreadMarkerEventId) return;
+    onUnreadMarkerResolved?.(resolvedUnreadMarkerEventId);
   });
 
   // Wire jumpState handlers to the store
@@ -137,7 +148,7 @@
   {onOpenThread}
   enableLastEditableFinder={true}
   isLoading={store.isInitialLoading}
-  {unreadAfterEventId}
+  unreadAfterEventId={unreadMarkerEventId}
   {typingUserIds}
   {typingMembers}
   scrollToEventId={jumpState?.scrollToEventId ?? null}
@@ -150,5 +161,6 @@
   onLoadNewer={() => store.loadNewer(jumpState)}
   onJumpToPresent={() => store.jumpToPresent(jumpState)}
   onReachedPresent={handleReachedPresent}
+  onReachedBottom={onUnreadMarkerCleared}
   onSoftRefresh={handleSoftRefresh}
 />

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/virtualItems.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/virtualItems.spec.ts
@@ -148,7 +148,10 @@ describe('buildVirtualItems', () => {
 
     const e2Index = items.findIndex((i) => i.type === 'event' && i.key === 'e2');
     expect(e2Index).toBeGreaterThan(0);
-    expect(items[e2Index - 1]).toMatchObject({ type: 'unread-separator' });
+    expect(items[e2Index - 1]).toMatchObject({
+      type: 'unread-separator',
+      key: 'unread-separator-e2'
+    });
   });
 
   it('does not emit unread-separator when firstUnreadEventId is null', () => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/virtualItems.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/virtualItems.ts
@@ -99,7 +99,7 @@ export function buildVirtualItems(
     if (hasUnreadSeparator) {
       items.push({
         type: 'unread-separator',
-        key: 'unread-separator'
+        key: `unread-separator-${event.id}`
       });
     }
 


### PR DESCRIPTION
Stabilizes the room timeline New Messages separator by turning the rendered marker into an explicit event-id anchor instead of a timestamp window that can be rewritten by focus/resume and read-state races.

The room pane still resolves fresh-entry read windows from server timestamps, but only once, then commits the concrete event id for EventList to render with a target-specific virtualizer key.

This should stop jumpy marker movement and unexpected timeline rebuilds when background events, non-message events, or late mark-read responses arrive.

Validation: Svelte autofixer on touched Svelte files, Prettier check for edited files, `virtualItems.spec.ts`, `Room.svelte.spec.ts`, and targeted unread-separator Playwright coverage for hidden tab, blur/focus, non-message refocus, fixed marker position, and own-post-after-refocus cases.
