### PR TITLE
fix(frontend): share unread marker lifecycle with threads

### DIFF
--- a/apps/frontend/e2e/threading.test.ts
+++ b/apps/frontend/e2e/threading.test.ts
@@ -955,7 +955,7 @@ test.describe('Message Threading', () => {
     );
   });
 
-  test('thread unread separator appears in real time while the tab is hidden', async ({
+  test('thread unread separator is deferred until the hidden tab returns', async ({
     page,
     chatPage,
     roomPage,
@@ -992,8 +992,9 @@ test.describe('Message Threading', () => {
           await roomPage2.expectNoUnreadSeparatorInThreadPane();
         }).toPass({ timeout: TIMEOUTS.UI_STANDARD, intervals: [100, 250, 500, 1000] });
 
-        // User B's tab goes to the background. They stay in the thread; presence
-        // just drops, which anchors the unread separator at "now".
+        // User B's tab goes to the background. They stay in the thread; the
+        // missed reply is collected as pending state, but the rendered
+        // separator must not move until the user returns.
         await page2.evaluate(() => {
           Object.defineProperty(document, 'visibilityState', {
             value: 'hidden',
@@ -1007,10 +1008,22 @@ test.describe('Message Threading', () => {
         const replyMessage = `Reply while hidden ${Date.now()}`;
         await roomPage.postThreadReply(replyMessage);
 
-        // The reply streams in over the live subscription, and because the
-        // separator was anchored the moment presence dropped, it shows up
-        // immediately — without User B re-opening the thread.
+        // The reply streams in over the live subscription, but while hidden
+        // it should not render a separator yet.
         await roomPage2.expectTextInThreadPane(replyMessage);
+        await expect(async () => {
+          await roomPage2.expectNoUnreadSeparatorInThreadPane();
+        }).toPass({ timeout: TIMEOUTS.UI_STANDARD, intervals: [100, 250, 500, 1000] });
+
+        await page2.evaluate(() => {
+          Object.defineProperty(document, 'visibilityState', {
+            value: 'visible',
+            writable: true,
+            configurable: true
+          });
+          document.dispatchEvent(new Event('visibilitychange'));
+        });
+
         await roomPage2.expectUnreadSeparatorInThreadPane();
       }
     );

--- a/apps/frontend/e2e/unread-indicators.test.ts
+++ b/apps/frontend/e2e/unread-indicators.test.ts
@@ -759,10 +759,9 @@ test.describe('Room unread separator', () => {
     // Regression test for: user posts a message, backgrounds the tab,
     // refocuses (same room, no navigation), then posts another message —
     // a "New messages" separator must NOT appear between the two own
-    // messages. The presence-false branch in useRoomUnread anchors the
-    // open-window separator at lastCursor; without advancing that anchor
-    // on subsequent own posts, the second message renders below the
-    // separator even though the user obviously saw their first message.
+    // messages. The unread marker is now driven by actual missed event ids,
+    // so a blur/refocus cycle without another user's event must not create
+    // a separator.
     await createAndLoginTestUser(page);
     await chatPage.goto();
 
@@ -770,8 +769,8 @@ test.describe('Room unread separator', () => {
     await waitForRoomReady(page, 'general');
     const generalRoomId = await getRoomIdByNameViaConnect(page, 'general');
 
-    // First own message — establishes a real client-side lastCursor that
-    // the presence-false branch will anchor on.
+    // First own message — establishes a real server read cursor, but no
+    // missed event id.
     const firstMessage = `First own message ${Date.now()}`;
     await roomPage.sendMessage(firstMessage);
     await roomPage.expectMessageVisible(firstMessage);
@@ -789,9 +788,8 @@ test.describe('Room unread separator', () => {
       document.dispatchEvent(new Event('visibilitychange'));
     });
 
-    // Refocus. The effect's presence-true branch does NOT overwrite the
-    // open-bound separator (intentional — preserves "you missed messages"
-    // markers across blur/focus cycles).
+    // Refocus. No missed event id was captured while hidden, so the marker
+    // should stay absent.
     await page.evaluate(() => {
       Object.defineProperty(document, 'visibilityState', {
         value: 'visible',
@@ -801,8 +799,8 @@ test.describe('Room unread separator', () => {
       document.dispatchEvent(new Event('visibilitychange'));
     });
 
-    // Second own message — the bug case. Pre-fix this would render below
-    // a "New messages" separator anchored at the first message's time.
+    // Second own message — the bug case. It must not render below a
+    // separator created from a blur/refocus cycle alone.
     const secondMessage = `Second own message ${Date.now()}`;
     await roomPage.sendMessage(secondMessage);
     await roomPage.expectMessageVisible(secondMessage);

--- a/apps/frontend/src/lib/hooks/index.ts
+++ b/apps/frontend/src/lib/hooks/index.ts
@@ -24,7 +24,8 @@ export type { MessageActionParams } from './useMessageActions.svelte';
 // Data hooks
 export { useRoomData } from './useRoomData.svelte';
 export { useRoomUnread } from './useRoomUnread.svelte';
-export type { UnreadMarkerWindow } from './useRoomUnread.svelte';
+export { useUnreadMarker } from './useUnreadMarker.svelte';
+export type { UnreadMarkerWindow } from './useUnreadMarker.svelte';
 
 // Lifecycle hooks
 export { useTabResumeCallback } from './useTabResumeCallback.svelte';

--- a/apps/frontend/src/lib/hooks/useRoomUnread.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useRoomUnread.svelte.ts
@@ -1,19 +1,13 @@
-import { createReadStateAPI } from '$lib/api-client/readState';
+import { createReadStateAPI, type MarkRoomAsReadResult } from '$lib/api-client/readState';
 import { useConnection } from '$lib/state/server/connection.svelte';
 import { serverRegistry } from '$lib/state/server/registry.svelte';
 import { getActiveServer } from '$lib/state/activeServer.svelte';
-import { appState } from '$lib/state/globals.svelte';
-
-export type UnreadMarkerWindow = {
-  afterTime: string;
-  beforeTime: string;
-};
+import { useUnreadMarker } from './useUnreadMarker.svelte';
 
 /**
- * Manages room unread state: marks the room as read on entry and every time
- * the user transitions back to "present" on the room (window refocus, tab
- * reveal). The rendered unread separator is an explicit event-id marker:
- * once visible, late read-state responses and background events do not move it.
+ * Room-specific unread marker wrapper. The shared unread marker hook owns the
+ * focus/refocus lifecycle; this wrapper only wires room read-state mutation
+ * and room-list unread clearing.
  *
  * Must be called during component initialization (uses context).
  */
@@ -21,119 +15,41 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
   const connection = useConnection();
   const roomUnreadStore = serverRegistry.getStore(getActiveServer()).roomUnread;
 
-  let unreadMarkerEventId = $state<string | null>(null);
-  let unreadMarkerWindow = $state<UnreadMarkerWindow | null>(null);
+  const unread = useUnreadMarker(() => getProps().roomId, {
+    markAsRead: async (targetRoomId: string, upToEventId?: string) => {
+      roomUnreadStore.setRoomUnread(targetRoomId, false);
 
-  // The server's most recent read cursor (`lastReadAt`) for this room.
-  let lastCursor: string | null = null;
-  // Captured while hidden/unfocused and revealed only when the user returns.
-  let pendingAwayEventId: string | null = null;
-
-  async function markRoomAsRead(targetRoomId: string, upToEventId?: string) {
-    roomUnreadStore.setRoomUnread(targetRoomId, false);
-
-    try {
-      const conn = connection();
-      const data = await createReadStateAPI({
-        serverId: conn.serverId ?? getActiveServer(),
-        baseUrl: conn.connectBaseUrl,
-        bearerToken: conn.bearerToken
-      }).markRoomAsRead({ roomId: targetRoomId, upToEventId });
-
-      if (data?.lastReadAt && getProps().roomId === targetRoomId) {
-        lastCursor = data.lastReadAt;
+      try {
+        const conn = connection();
+        return await createReadStateAPI({
+          serverId: conn.serverId ?? getActiveServer(),
+          baseUrl: conn.connectBaseUrl,
+          bearerToken: conn.bearerToken
+        }).markRoomAsRead({ roomId: targetRoomId, upToEventId });
+      } catch (err) {
+        console.error('Failed to mark room as read:', err);
+        return null;
       }
-      return data;
-    } catch (err) {
-      console.error('Failed to mark room as read:', err);
-      return null;
+    },
+    markerWindowFromReadResult: (result: MarkRoomAsReadResult) => {
+      if (!result.previousLastReadAt || !result.lastReadAt) return null;
+      return {
+        afterTime: result.previousLastReadAt,
+        beforeTime: result.lastReadAt
+      };
     }
-  }
-
-  /**
-   * Advance the tracked read cursor without issuing a mutation. Used when
-   * the read cursor moves server-side without a markRoomAsRead call from
-   * this hook, notably when the user posts their own message.
-   */
-  function noteReadCursor(timestamp: string) {
-    const ts = Date.parse(timestamp);
-    if (lastCursor && ts <= Date.parse(lastCursor)) return;
-    lastCursor = timestamp;
-  }
-
-  function noteAwayEvent(eventId: string) {
-    if (unreadMarkerEventId !== null || pendingAwayEventId !== null) return;
-    pendingAwayEventId = eventId;
-  }
-
-  function setUnreadMarkerEventId(eventId: string | null) {
-    unreadMarkerEventId = eventId;
-    if (eventId !== null) {
-      unreadMarkerWindow = null;
-    }
-  }
-
-  function clearUnreadMarker() {
-    unreadMarkerEventId = null;
-    unreadMarkerWindow = null;
-    pendingAwayEventId = null;
-  }
-
-  // Fire markRoomAsRead on every presence-true edge (fresh entry OR
-  // refocus/tab-reveal) and on room changes while present. Fresh room entry
-  // may produce a timestamp window; RoomEventsPane resolves it once to an
-  // explicit event id. Same-room refocus reveals only the pending event id.
-  let lastFiredRoomId = '';
-  let wasPresent = false;
-
-  $effect(() => {
-    const { roomId } = getProps();
-    const present = appState.isPresent;
-
-    if (!present) {
-      wasPresent = false;
-      return;
-    }
-
-    if (wasPresent && lastFiredRoomId === roomId) return;
-
-    const isRoomChange = lastFiredRoomId !== roomId;
-    wasPresent = true;
-    lastFiredRoomId = roomId;
-
-    if (isRoomChange) {
-      clearUnreadMarker();
-    } else if (pendingAwayEventId) {
-      setUnreadMarkerEventId(pendingAwayEventId);
-      pendingAwayEventId = null;
-    } else {
-      pendingAwayEventId = null;
-    }
-
-    markRoomAsRead(roomId).then((result) => {
-      const current = getProps();
-      if (current.roomId !== roomId || !result) return;
-
-      if (isRoomChange && result.previousLastReadAt && result.lastReadAt) {
-        unreadMarkerWindow = {
-          afterTime: result.previousLastReadAt,
-          beforeTime: result.lastReadAt
-        };
-      }
-    });
   });
 
   return {
     get unreadMarkerEventId() {
-      return unreadMarkerEventId;
+      return unread.unreadMarkerEventId;
     },
     get unreadMarkerWindow() {
-      return unreadMarkerWindow;
+      return unread.unreadMarkerWindow;
     },
-    markRoomAsRead,
-    noteReadCursor,
-    noteAwayEvent,
-    setUnreadMarkerEventId,
-    clearUnreadMarker
+    markRoomAsRead: unread.markAsRead,
+    noteAwayEvent: unread.noteAwayEvent,
+    setUnreadMarkerEventId: unread.setUnreadMarkerEventId,
+    clearUnreadMarker: unread.clearUnreadMarker
   };
 }

--- a/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.ts
@@ -1,0 +1,101 @@
+import { appState } from '$lib/state/globals.svelte';
+
+export type UnreadMarkerWindow = {
+  afterTime: string;
+  beforeTime: string | number;
+};
+
+type UseUnreadMarkerOptions<TReadResult> = {
+  markAsRead: (targetId: string, upToEventId?: string) => Promise<TReadResult | null>;
+  markerWindowFromReadResult: (
+    result: TReadResult,
+    markedAtMs: number
+  ) => UnreadMarkerWindow | null;
+};
+
+/**
+ * Shared unread separator lifecycle for room and thread timelines.
+ *
+ * The rendered separator is always a concrete event id. Server read-state
+ * timestamp windows are resolved once by the timeline pane, and same-target
+ * refocuses only reveal deferred event ids captured while the user was away.
+ */
+export function useUnreadMarker<TReadResult>(
+  getTargetId: () => string,
+  { markAsRead, markerWindowFromReadResult }: UseUnreadMarkerOptions<TReadResult>
+) {
+  let unreadMarkerEventId = $state<string | null>(null);
+  let unreadMarkerWindow = $state<UnreadMarkerWindow | null>(null);
+  let pendingAwayEventId: string | null = null;
+
+  async function markTargetAsRead(targetId: string, upToEventId?: string) {
+    return markAsRead(targetId, upToEventId);
+  }
+
+  function noteAwayEvent(eventId: string) {
+    if (unreadMarkerEventId !== null || pendingAwayEventId !== null) return;
+    pendingAwayEventId = eventId;
+  }
+
+  function setUnreadMarkerEventId(eventId: string | null) {
+    unreadMarkerEventId = eventId;
+    if (eventId !== null) {
+      unreadMarkerWindow = null;
+    }
+  }
+
+  function clearUnreadMarker() {
+    unreadMarkerEventId = null;
+    unreadMarkerWindow = null;
+    pendingAwayEventId = null;
+  }
+
+  let lastFiredTargetId = '';
+  let wasPresent = false;
+
+  $effect(() => {
+    const targetId = getTargetId();
+    const present = appState.isPresent;
+
+    if (!present) {
+      wasPresent = false;
+      return;
+    }
+
+    if (wasPresent && lastFiredTargetId === targetId) return;
+
+    const isTargetChange = lastFiredTargetId !== targetId;
+    wasPresent = true;
+    lastFiredTargetId = targetId;
+
+    if (isTargetChange) {
+      clearUnreadMarker();
+    } else if (pendingAwayEventId) {
+      setUnreadMarkerEventId(pendingAwayEventId);
+      pendingAwayEventId = null;
+    } else {
+      pendingAwayEventId = null;
+    }
+
+    const markedAtMs = Date.now();
+    markTargetAsRead(targetId).then((result) => {
+      if (getTargetId() !== targetId || !result) return;
+      if (!isTargetChange) return;
+
+      unreadMarkerWindow = markerWindowFromReadResult(result, markedAtMs);
+    });
+  });
+
+  return {
+    get unreadMarkerEventId() {
+      return unreadMarkerEventId;
+    },
+    get unreadMarkerWindow() {
+      return unreadMarkerWindow;
+    },
+    markAsRead: markTargetAsRead,
+    noteAwayEvent,
+    setUnreadMarkerEventId,
+    clearUnreadMarker
+  };
+}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -325,14 +325,9 @@
     }
   }
 
-  // Keep the read cursor in sync with incoming root messages:
-  // - Other users' messages mark the room read (with explicit event ID, so
-  //   the server cursor matches what the client rendered) while the user is
-  //   actually present (focused + visible).
-  // - The user's own posts already auto-mark the room read server-side, so
-  //   we just mirror that onto the local cursor — without it, backgrounding
-  //   the tab would strand the user's own latest message below the unread
-  //   separator.
+  // Keep the server read cursor in sync with incoming root messages. Other
+  // users' messages mark the room read while the user is actually present;
+  // own messages are already auto-marked read by the post mutation.
   useEvent((event) => {
     roomFilesStore.ingestServerEvent(event);
     roomMembersStore.ingestServerEvent(event);
@@ -352,9 +347,7 @@
       }
 
       if (!event.event.threadRootEventId && currentUser.user) {
-        if (actorId === currentUser.user.id) {
-          unread.noteReadCursor(event.createdAt);
-        } else if (appState.isPresent) {
+        if (actorId !== currentUser.user.id && appState.isPresent) {
           unread.markRoomAsRead(roomId, event.id);
         }
       }
@@ -595,13 +588,6 @@
             typingIndicator?.resetDebounce();
             if (event) {
               roomMessageStore.ingestEvent(event);
-              if (
-                isMessagePostedEvent(event.event) &&
-                event.event.roomId === roomId &&
-                !event.event.threadRootEventId
-              ) {
-                unread.noteReadCursor(event.createdAt);
-              }
             } else {
               void roomMessageStore.refreshCurrentWindow(null);
             }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -32,7 +32,6 @@ const { mocks } = vi.hoisted(() => {
       goto: vi.fn(),
       pushState: vi.fn(),
       replaceState: vi.fn(),
-      noteReadCursor: vi.fn(),
       noteAwayEvent: vi.fn(),
       markRoomAsRead: vi.fn(),
       resetTypingDebounce: vi.fn(),
@@ -125,7 +124,6 @@ vi.mock('$lib/hooks', () => ({
     unreadMarkerEventId: null,
     unreadMarkerWindow: null,
     markRoomAsRead: mocks.markRoomAsRead,
-    noteReadCursor: mocks.noteReadCursor,
     noteAwayEvent: mocks.noteAwayEvent,
     setUnreadMarkerEventId: vi.fn(),
     clearUnreadMarker: vi.fn()
@@ -320,7 +318,6 @@ describe('Room local message echo', () => {
       .element(q(container, '[data-testid="room-event-ids"]'))
       .toHaveTextContent('msg-local');
     expect(mocks.resetTypingDebounce).toHaveBeenCalledOnce();
-    expect(mocks.noteReadCursor).toHaveBeenCalledWith('2026-06-17T10:47:00Z');
   });
 
   it('does not advance the current room read cursor for a stale returned post from another room', async () => {
@@ -332,7 +329,6 @@ describe('Room local message echo', () => {
 
     await expect.element(q(container, '[data-testid="room-event-ids"]')).toHaveTextContent('');
     expect(mocks.resetTypingDebounce).toHaveBeenCalledOnce();
-    expect(mocks.noteReadCursor).not.toHaveBeenCalled();
   });
 
   it('clears pending in-room reply state when the room changes', async () => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomEventsPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomEventsPane.svelte
@@ -7,7 +7,7 @@
     type RoomMember
   } from '$lib/state/room';
   import type { MessagesStore } from '$lib/state/room';
-  import EventList from './EventList.svelte';
+  import TimelineEventsPane from './TimelineEventsPane.svelte';
   import type { OpenThreadHandler } from './threadOpenOptions';
 
   type MessageRetractedEventPayload = {
@@ -51,27 +51,6 @@
 
   let roomEvents = $derived(store.rootEvents);
   let updateCounter = $derived(roomEvents.length);
-
-  // Resolve a fresh-entry server timestamp window once, then commit the
-  // concrete event id back to the unread hook. EventList only renders an
-  // explicit event-id marker.
-  let resolvedUnreadMarkerEventId = $derived.by(() => {
-    if (unreadMarkerWindow === null) return null;
-    const afterMs = new Date(unreadMarkerWindow.afterTime).getTime();
-    const beforeMs = new Date(unreadMarkerWindow.beforeTime).getTime();
-    for (const event of roomEvents) {
-      const eventMs = new Date(event.createdAt).getTime();
-      if (eventMs > afterMs && eventMs <= beforeMs) {
-        return event.id;
-      }
-    }
-    return null;
-  });
-
-  $effect(() => {
-    if (!resolvedUnreadMarkerEventId) return;
-    onUnreadMarkerResolved?.(resolvedUnreadMarkerEventId);
-  });
 
   // Wire jumpState handlers to the store
   if (jumpState) {
@@ -134,7 +113,7 @@
   }
 </script>
 
-<EventList
+<TimelineEventsPane
   {roomId}
   messageStore={store}
   events={roomEvents}
@@ -148,7 +127,9 @@
   {onOpenThread}
   enableLastEditableFinder={true}
   isLoading={store.isInitialLoading}
-  unreadAfterEventId={unreadMarkerEventId}
+  {unreadMarkerEventId}
+  {unreadMarkerWindow}
+  {onUnreadMarkerResolved}
   {typingUserIds}
   {typingMembers}
   scrollToEventId={jumpState?.scrollToEventId ?? null}
@@ -161,6 +142,6 @@
   onLoadNewer={() => store.loadNewer(jumpState)}
   onJumpToPresent={() => store.jumpToPresent(jumpState)}
   onReachedPresent={handleReachedPresent}
-  onReachedBottom={onUnreadMarkerCleared}
+  {onUnreadMarkerCleared}
   onSoftRefresh={handleSoftRefresh}
 />

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
   import { fly } from 'svelte/transition';
-  import { createReadStateAPI } from '$lib/api-client/readState';
+  import { createReadStateAPI, type MarkThreadAsReadResult } from '$lib/api-client/readState';
   import { createThreadAPI } from '$lib/api-client/threads';
-  import { useEvent, createTypingIndicator } from '$lib/hooks';
+  import { useEvent, createTypingIndicator, useUnreadMarker } from '$lib/hooks';
   import { useConnection } from '$lib/state/server/connection.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
@@ -23,7 +23,7 @@
   import MessageComposer, {
     type MessageComposerApi
   } from '$lib/components/composer/MessageComposer.svelte';
-  import EventList from './EventList.svelte';
+  import TimelineEventsPane from './TimelineEventsPane.svelte';
   import { onThreadFollowChanged } from '$lib/eventBus.svelte';
   import type { PendingThreadReplyRequest } from './threadOpenOptions';
 
@@ -80,25 +80,10 @@
   let threadEvents = $derived(store.threadEvents);
   let updateCounter = $derived(threadEvents.length);
 
-  // Track the timestamp when the thread was last opened (for unread separator)
-  let unreadAfterTime = $state<Date | null>(null);
-  // Upper bound - messages arriving after we opened the thread don't show the separator
-  let unreadBeforeTime = $state<Date | null>(null);
-
-  // Resolve time-based unread boundary to an event ID for EventList
-  let unreadAfterEventId = $derived.by(() => {
-    if (unreadAfterTime === null) return null;
-    const currentUserId = currentUser.user?.id ?? null;
-    const afterTime = unreadAfterTime.getTime();
-    const beforeTime = unreadBeforeTime?.getTime() ?? Infinity;
-    for (const event of threadEvents) {
-      if (currentUserId && event.actorId === currentUserId) continue;
-      const eventTime = new Date(event.createdAt).getTime();
-      if (eventTime > afterTime && eventTime <= beforeTime) {
-        return event.id;
-      }
-    }
-    return null;
+  const unread = useUnreadMarker(() => threadRootEventId, {
+    markAsRead: markThreadAsRead,
+    markerWindowFromReadResult: (result, markedAtMs) =>
+      result.previousReadAt ? { afterTime: result.previousReadAt, beforeTime: markedAtMs } : null
   });
 
   // Typing indicator for this thread
@@ -183,8 +168,12 @@
         typingIndicator.removeTypingUser(actorId);
       }
 
-      if (currentUser.user && actorId !== currentUser.user.id && appState.isPresent) {
-        void markThreadAsRead(threadRootEventId, serverEvent.id);
+      if (currentUser.user && actorId !== currentUser.user.id) {
+        if (appState.isPresent) {
+          void unread.markAsRead(threadRootEventId, serverEvent.id);
+        } else {
+          unread.noteAwayEvent(serverEvent.id);
+        }
       }
     }
 
@@ -255,7 +244,10 @@
     })
   );
 
-  async function markThreadAsRead(currentThreadId: string, upToEventId?: string) {
+  async function markThreadAsRead(
+    currentThreadId: string,
+    upToEventId?: string
+  ): Promise<MarkThreadAsReadResult | null> {
     try {
       const conn = connection();
       return await createReadStateAPI({
@@ -268,46 +260,6 @@
       return null;
     }
   }
-
-  // Fire mark-thread-as-read on every presence-true edge (fresh open or
-  // refocus/tab-reveal) and on thread changes while present. The result
-  // drives the unread separator so a refocus shows what arrived during
-  // the away period.
-  let lastFiredThreadId = '';
-  let wasPresentThread = false;
-
-  $effect(() => {
-    const currentThreadId = threadRootEventId;
-    const present = appState.isPresent;
-
-    if (!present) {
-      // Presence-false edge: anchor the unread separator at "now" with no
-      // upper bound so replies arriving while the user is away show up
-      // below the marker in real time, rather than only on return. The
-      // presence-true edge below refines it when the user comes back.
-      if (wasPresentThread) {
-        unreadAfterTime = new Date();
-        unreadBeforeTime = null;
-      }
-      wasPresentThread = false;
-      return;
-    }
-
-    if (wasPresentThread && lastFiredThreadId === currentThreadId) return;
-    wasPresentThread = true;
-    lastFiredThreadId = currentThreadId;
-
-    unreadAfterTime = null;
-    unreadBeforeTime = null;
-
-    const openedAt = new Date();
-    markThreadAsRead(currentThreadId).then((data) => {
-      if (!data) return;
-      const prevTime = data.previousReadAt;
-      unreadAfterTime = prevTime ? new Date(prevTime) : null;
-      unreadBeforeTime = openedAt;
-    });
-  });
 </script>
 
 <div
@@ -331,7 +283,7 @@
     {/snippet}
   </PaneHeader>
 
-  <EventList
+  <TimelineEventsPane
     {roomId}
     messageStore={store}
     events={threadEvents}
@@ -347,7 +299,11 @@
     enableLastEditableFinder={true}
     isLoading={store.isInitialLoading}
     emptyMessage={m['room.thread.not_found']()}
-    {unreadAfterEventId}
+    unreadMarkerEventId={unread.unreadMarkerEventId}
+    unreadMarkerWindow={unread.unreadMarkerWindow}
+    unreadMarkerSkipActorId={currentUser.user?.id ?? null}
+    onUnreadMarkerResolved={(eventId) => unread.setUnreadMarkerEventId(eventId)}
+    onUnreadMarkerCleared={() => unread.clearUnreadMarker()}
     typingUserIds={typingIndicator.userIds}
     typingMembers={members}
     scrollToEventId={jumpState.scrollToEventId}
@@ -378,7 +334,7 @@
       typingIndicator?.resetDebounce();
       if (event) {
         store.ingestEvent(event);
-        void markThreadAsRead(threadRootEventId, event.id);
+        void unread.markAsRead(threadRootEventId, event.id);
       } else {
         void store.refreshCurrentWindow(null);
       }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
@@ -48,6 +48,20 @@ vi.mock('$lib/api-client/threads', () => ({
 
 vi.mock('$lib/hooks', () => ({
   useEvent: vi.fn(),
+  useUnreadMarker: (
+    getTargetId: () => string,
+    options: { markAsRead: (targetId: string, upToEventId?: string) => unknown }
+  ) => {
+    void options.markAsRead(getTargetId());
+    return {
+      unreadMarkerEventId: null,
+      unreadMarkerWindow: null,
+      markAsRead: options.markAsRead,
+      noteAwayEvent: vi.fn(),
+      setUnreadMarkerEventId: vi.fn(),
+      clearUnreadMarker: vi.fn()
+    };
+  },
   createTypingIndicator: () => ({
     userIds: [],
     removeTypingUser: mocks.removeTypingUser,
@@ -125,7 +139,7 @@ vi.mock('$lib/eventBus.svelte', () => ({
   onThreadFollowChanged: vi.fn(() => vi.fn())
 }));
 
-vi.mock('./EventList.svelte', async () => {
+vi.mock('./TimelineEventsPane.svelte', async () => {
   const { default: EmptyMock } = await import('./RoomLocalEchoEmptyMock.svelte');
   return { default: EmptyMock };
 });

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/TimelineEventsPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/TimelineEventsPane.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+  import type { UnreadMarkerWindow } from '$lib/hooks';
+  import * as m from '$lib/i18n/messages';
+  import type { RoomEventView } from '$lib/render/types';
+  import {
+    type MessagesStore,
+    type RefreshCurrentWindowResult,
+    type RoomMember
+  } from '$lib/state/room';
+  import EventList from './EventList.svelte';
+  import type { OpenThreadHandler } from './threadOpenOptions';
+
+  let {
+    roomId,
+    messageStore,
+    events,
+    updateCounter = events.length,
+    unreadMarkerEventId = null,
+    unreadMarkerWindow = null,
+    unreadMarkerSkipActorId = null,
+    onUnreadMarkerResolved,
+    onUnreadMarkerCleared,
+    alwaysScrollToBottom = false,
+    showNewMessagesIndicator = true,
+    enablePagination = false,
+    isLoadingMore = false,
+    hasReachedStart = false,
+    showStartMarker = true,
+    onLoadMore,
+    onOpenThread,
+    filterThreadReplies = true,
+    enableLastEditableFinder = false,
+    isLoading = false,
+    emptyMessage = m['room.message.empty'](),
+    typingUserIds = [],
+    typingMembers = [],
+    scrollToEventId = null,
+    onScrollToEventComplete,
+    isJumpedMode = false,
+    isLoadingNewer = false,
+    hasReachedEnd = false,
+    onLoadNewer,
+    onJumpToPresent,
+    onReachedPresent,
+    onSoftRefresh,
+    pendingHighlightId = null
+  }: {
+    roomId: string;
+    messageStore: MessagesStore;
+    events: RoomEventView[];
+    updateCounter?: number;
+    unreadMarkerEventId?: string | null;
+    unreadMarkerWindow?: UnreadMarkerWindow | null;
+    unreadMarkerSkipActorId?: string | null;
+    onUnreadMarkerResolved?: (eventId: string) => void;
+    onUnreadMarkerCleared?: () => void;
+    alwaysScrollToBottom?: boolean;
+    showNewMessagesIndicator?: boolean;
+    enablePagination?: boolean;
+    isLoadingMore?: boolean;
+    hasReachedStart?: boolean;
+    showStartMarker?: boolean;
+    onLoadMore?: () => Promise<void>;
+    onOpenThread?: OpenThreadHandler;
+    filterThreadReplies?: boolean;
+    enableLastEditableFinder?: boolean;
+    isLoading?: boolean;
+    emptyMessage?: string;
+    typingUserIds?: string[];
+    typingMembers?: RoomMember[];
+    scrollToEventId?: string | null;
+    onScrollToEventComplete?: () => void;
+    isJumpedMode?: boolean;
+    isLoadingNewer?: boolean;
+    hasReachedEnd?: boolean;
+    onLoadNewer?: () => Promise<void>;
+    onJumpToPresent?: () => void;
+    onReachedPresent?: () => void;
+    onSoftRefresh?: (result: RefreshCurrentWindowResult, anchored: boolean) => void;
+    pendingHighlightId?: string | null;
+  } = $props();
+
+  // Resolve a fresh-entry server timestamp window once, then commit the
+  // concrete event id back to the unread hook. EventList only renders an
+  // explicit event-id marker.
+  let resolvedUnreadMarkerEventId = $derived.by(() => {
+    if (unreadMarkerWindow === null) return null;
+    const afterMs = Date.parse(unreadMarkerWindow.afterTime);
+    const beforeMs =
+      typeof unreadMarkerWindow.beforeTime === 'number'
+        ? unreadMarkerWindow.beforeTime
+        : Date.parse(unreadMarkerWindow.beforeTime);
+
+    for (const event of events) {
+      if (unreadMarkerSkipActorId && event.actorId === unreadMarkerSkipActorId) continue;
+
+      const eventMs = Date.parse(event.createdAt);
+      if (eventMs > afterMs && eventMs <= beforeMs) {
+        return event.id;
+      }
+    }
+    return null;
+  });
+
+  $effect(() => {
+    if (!resolvedUnreadMarkerEventId) return;
+    onUnreadMarkerResolved?.(resolvedUnreadMarkerEventId);
+  });
+</script>
+
+<EventList
+  {roomId}
+  {messageStore}
+  {events}
+  {alwaysScrollToBottom}
+  {showNewMessagesIndicator}
+  {enablePagination}
+  {isLoadingMore}
+  {hasReachedStart}
+  {showStartMarker}
+  {onLoadMore}
+  {onOpenThread}
+  {filterThreadReplies}
+  {updateCounter}
+  {enableLastEditableFinder}
+  {isLoading}
+  {emptyMessage}
+  unreadAfterEventId={unreadMarkerEventId}
+  {typingUserIds}
+  {typingMembers}
+  {scrollToEventId}
+  {onScrollToEventComplete}
+  {isJumpedMode}
+  {isLoadingNewer}
+  {hasReachedEnd}
+  {onLoadNewer}
+  {onJumpToPresent}
+  {onReachedPresent}
+  onReachedBottom={onUnreadMarkerCleared}
+  {onSoftRefresh}
+  {pendingHighlightId}
+/>


### PR DESCRIPTION
## Summary

This simplifies unread separator handling by moving the shared room/thread lifecycle into `useUnreadMarker` and by routing both `RoomEventsPane` and `ThreadPane` through the same `TimelineEventsPane` wrapper.
The separator is still rendered from a concrete event id, while timestamp read windows are resolved once and background events only become visible when the user returns.
This removes the old room read-cursor mirror path and updates thread panes to match main room behavior.

## Validation

Ran Svelte autofixer, targeted ESLint, `pnpm --dir apps/frontend check`, targeted Vitest browser specs, and targeted Playwright room/thread unread separator suites.
