### PR TITLE
chore(release): always update release pull requests

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -3,6 +3,7 @@
   "release-type": "simple",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
+  "always-update": true,
   "draft": true,
   "force-tag-creation": true,
   "include-component-in-tag": false,


### PR DESCRIPTION
Adds `always-update: true` to the release-please configuration so release PRs are refreshed even when there are no new releasable commits.

This keeps release automation state current for the existing Chatto release workflow. Validation: `mise x -- jq empty .release-please-config.json` and `git diff origin/main...` confirmed the PR contains only the intended config change.
