### PR TITLE
fix(frontend): hydrate room lifecycle event actors

### DIFF
--- a/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -126,6 +126,28 @@ function callEvent(
   };
 }
 
+function roomSystemEvent(
+  id: string,
+  kind:
+    | typeof RoomEventKind.UserJoinedRoom
+    | typeof RoomEventKind.UserLeftRoom
+    | typeof RoomEventKind.RoomUpdated
+    | typeof RoomEventKind.RoomArchived
+    | typeof RoomEventKind.RoomUnarchived,
+  actor: unknown = null
+) {
+  return {
+    id,
+    createdAt: '2026-05-27T00:00:01Z',
+    actorId: 'u1',
+    actor,
+    event: {
+      kind,
+      roomId: 'room-1'
+    }
+  };
+}
+
 function roomEventsResult({
   events,
   startCursor,
@@ -570,6 +592,49 @@ describe('MessagesStore — room lifecycle ownership', () => {
 
     expect(store.rootEvents).toEqual([]);
     expect(fake.queryMock).not.toHaveBeenCalled();
+    store.dispose();
+  });
+
+  it('hydrates actorless live room lifecycle events before inserting them', async () => {
+    const hydratedArchive = roomSystemEvent('archive-1', RoomEventKind.RoomArchived, {
+      id: 'u1',
+      displayName: 'Alice'
+    });
+    const fake = new FakeQueryClient([
+      roomEventsResult({
+        events: [],
+        startCursor: null,
+        endCursor: null,
+        hasOlder: false,
+        hasNewer: false
+      }),
+      { room: { event: hydratedArchive } }
+    ]);
+    const store = new MessagesStore(
+      fake as unknown as ServerConnection,
+      () => null,
+      timelineFromFixtures(fake)
+    );
+
+    store.setRoom('room-1');
+    await settle();
+    fake.queryMock.mockClear();
+
+    store.ingestServerEvent(roomSystemEvent('archive-1', RoomEventKind.RoomArchived) as never);
+    await settle();
+
+    expect(fake.queryMock).toHaveBeenCalledOnce();
+    expect(fake.queryMock.mock.calls[0][1]).toEqual({
+      roomId: 'room-1',
+      eventId: 'archive-1',
+      limit: 1
+    });
+    expect(store.rootEvents).toHaveLength(1);
+    expect(store.rootEvents[0]).toMatchObject({
+      id: 'archive-1',
+      actor: { id: 'u1', displayName: 'Alice' },
+      event: { kind: RoomEventKind.RoomArchived, roomId: 'room-1' }
+    });
     store.dispose();
   });
 

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -362,9 +362,7 @@ export class MessagesStore {
       kind === RoomEventKind.RoomArchived ||
       kind === RoomEventKind.RoomUnarchived
     ) {
-      const isMembershipEvent =
-        kind === RoomEventKind.UserJoinedRoom || kind === RoomEventKind.UserLeftRoom;
-      if (!spaceEvent.actor && this.roomTimeline && isMembershipEvent) {
+      if (!spaceEvent.actor && this.roomTimeline) {
         void this.fetchAndIngestSystemEvent(spaceEvent.id);
         return;
       }


### PR DESCRIPTION
## Summary

Fixes live room lifecycle timeline events so actorless realtime archive/update/unarchive events are hydrated from the timeline API before insertion.

The root cause was that `MessagesStore` only refetched missing actors for join/leave events, so live archive events rendered the fallback "Deleted User" despite carrying the correct actor ID.

Adds a regression test covering an actorless live room archive event and confirming the hydrated actor is rendered.

## Validation

- `mise build-api-types`
- `mise x -- pnpm --dir apps/frontend exec vitest run src/lib/state/room/messages.svelte.spec.ts`
