### PR TITLE
fix(frontend): adopt menu shell for toasts

### DIFF
--- a/apps/frontend/src/lib/ui/toast/Toast.svelte
+++ b/apps/frontend/src/lib/ui/toast/Toast.svelte
@@ -44,24 +44,27 @@
 
 <!-- Using div instead of button to allow nesting the action button (nested buttons are invalid HTML) -->
 <div
-  class="flex w-full max-w-96 min-w-0 cursor-pointer items-center gap-3 rounded-lg border border-text/10 bg-surface-100 px-3 py-2.5 text-left text-sm text-text shadow-xl transition-[background-color,scale] hover:bg-surface-200 active:scale-[0.99] sm:min-w-64"
+  class="menu w-full max-w-96 min-w-0 cursor-pointer text-left transition-[scale] active:scale-[0.96] sm:w-auto"
   onclick={onDismiss}
   onkeydown={handleKeyDown}
   role="button"
   tabindex="0"
   aria-label={m['ui.toast.dismiss']()}
 >
-  <span class="flex size-6 shrink-0 items-center justify-center rounded bg-background">
-    <span class={['iconify size-4', icons[tone], iconColors[tone]]} aria-hidden="true"></span>
-  </span>
-  <span class="min-w-0 flex-1 leading-snug break-words">{message}</span>
-  {#if action}
-    <button
-      type="button"
-      class="btn-secondary h-8 min-h-0 min-w-0 shrink-0 !rounded-md !px-3 !py-1 text-xs"
-      onclick={handleActionClick}
-    >
-      {action.label}
-    </button>
-  {/if}
+  <div class="menu-section flex min-h-10 items-center gap-3 px-3 py-2">
+    <span
+      class={['iconify size-5 shrink-0', icons[tone], iconColors[tone]]}
+      aria-hidden="true"
+    ></span>
+    <span class="min-w-0 flex-1 leading-snug break-words">{message}</span>
+    {#if action}
+      <button
+        type="button"
+        class="btn-secondary h-8 min-h-0 min-w-0 shrink-0 !rounded-md !px-3 !py-1 text-xs"
+        onclick={handleActionClick}
+      >
+        {action.label}
+      </button>
+    {/if}
+  </div>
 </div>

--- a/apps/frontend/src/lib/ui/toast/Toast.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/toast/Toast.svelte.spec.ts
@@ -17,6 +17,12 @@ function actionButton(container: Element, label: string): HTMLButtonElement {
   return button;
 }
 
+function toastSection(container: Element): HTMLElement {
+  const section = container.querySelector('.menu-section') as HTMLElement | null;
+  if (!section) throw new Error('Toast menu section not found');
+  return section;
+}
+
 describe('Toast', () => {
   it.each([
     ['error', 'text-error'],
@@ -35,8 +41,8 @@ describe('Toast', () => {
     const icon = container.querySelector('.iconify');
     expect(icon).not.toBeNull();
     expect(icon?.classList.contains(color)).toBe(true);
-    expect(toastButton(container).classList.contains('bg-surface-100')).toBe(true);
-    expect(toastButton(container).classList.contains('border-text/10')).toBe(true);
+    expect(toastButton(container).classList.contains('menu')).toBe(true);
+    expect(toastSection(container).classList.contains('menu-section')).toBe(true);
   });
 
   it('renders message and compact action styling', async () => {


### PR DESCRIPTION
## Summary

Adopts the shared `.menu` and `.menu-section` shell for transient toasts so they match the app's floating menu/dialog surfaces.
Removes the old one-off toast surface and icon tile while preserving click, keyboard, and action-button dismissal behavior.
Updates the toast component spec to assert the shared shell contract and semantic icon tone classes.

## Validation

- `mise x -- pnpm exec vitest run src/lib/ui/toast/Toast.svelte.spec.ts`
- Svelte autofixer reported no issues during implementation.
- Storybook/Playwright visual checks covered light, dark, action, and mobile toast variants.
