### PR TITLE
refactor(frontend): extract mobile sidebar chrome

### DIFF
--- a/apps/frontend/src/lib/components/MobileSidebarChrome.svelte
+++ b/apps/frontend/src/lib/components/MobileSidebarChrome.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import ServerGutter from '$lib/ServerGutter.svelte';
+  import {
+    SIDEBAR_PANEL_WIDTH_PX,
+    sidebarEdgeSwipe,
+    sidebarSwipe
+  } from '$lib/hooks/useSidebarSwipe.svelte';
+  import * as m from '$lib/i18n/messages';
+  import { sidebarNav } from '$lib/state/globals.svelte';
+
+  let { children }: { children?: Snippet } = $props();
+
+  const progress = $derived(sidebarNav.isMobile ? sidebarNav.progress : 1);
+  const dragging = $derived(sidebarNav.dragOffset !== null);
+  const mobileClosed = $derived(sidebarNav.isMobile && progress === 0 && !dragging);
+  const tx = $derived((progress - 1) * SIDEBAR_PANEL_WIDTH_PX);
+</script>
+
+{#if sidebarNav.isMobile}
+  <!--
+		Edge gesture zone (swipe-to-open). `touch-action: none` is essential:
+		without it, Chrome / iOS Safari fire pointercancel ~8px into a
+		horizontal drag (text-selection / back-navigation gesture detection).
+		Hidden when sidebar is open (the backdrop takes over). Plain taps are
+		intentionally swallowed here; this target exists only to start swipes.
+	-->
+  {#if !sidebarNav.isOpen || dragging}
+    <div
+      use:sidebarEdgeSwipe
+      data-app-sidebar="true"
+      data-testid="mobile-sidebar-edge"
+      class="fixed top-11 bottom-0 left-0 z-40 w-6 touch-none md:hidden"
+      aria-hidden="true"
+      onpointerdown={(event) => event.stopPropagation()}
+      onpointerup={(event) => event.stopPropagation()}
+      onclick={(event) => event.stopPropagation()}
+      oncontextmenu={(event) => event.stopPropagation()}
+    ></div>
+  {/if}
+
+  <button
+    type="button"
+    use:sidebarSwipe
+    data-app-sidebar="true"
+    data-testid="mobile-sidebar-backdrop"
+    class={[
+      'fixed inset-0 top-11 z-40 touch-none bg-black/50 md:hidden',
+      !dragging && 'transition-opacity duration-200',
+      mobileClosed && 'pointer-events-none'
+    ]}
+    style:opacity={progress}
+    disabled={mobileClosed}
+    tabindex={mobileClosed ? -1 : 0}
+    aria-hidden={mobileClosed}
+    onclick={() => sidebarNav.close()}
+    aria-label={m['common.close_sidebar']()}
+  ></button>
+{/if}
+
+<div class="flex min-h-0 flex-1 flex-row">
+  <div
+    use:sidebarSwipe
+    data-app-sidebar="true"
+    data-testid="mobile-sidebar-panel"
+    class={[
+      'z-50 min-h-0 flex-col self-stretch bg-background',
+      'max-md:fixed max-md:top-11 max-md:bottom-0 max-md:left-0 max-md:w-17 max-md:touch-pan-y',
+      // Mobile: always rendered so we can animate transform.
+      // Desktop: hide entirely when closed (no overlay; layout reflows).
+      sidebarNav.isMobile ? 'flex' : sidebarNav.isOpen ? 'flex' : 'hidden',
+      // Mobile-only: hide via `visibility: hidden` after the close
+      // transition, so Playwright / accessibility tooling correctly see
+      // the sidebar as not-visible while the slide-out animation works.
+      mobileClosed && 'sidebar-mobile-closed',
+      !dragging && 'sidebar-mobile-anim'
+    ]}
+    style:transform={sidebarNav.isMobile ? `translateX(${tx}px)` : undefined}
+  >
+    <ServerGutter />
+  </div>
+
+  {@render children?.()}
+</div>
+
+<style>
+  /*
+		Mobile sidebar animation — slide via transform, plus a delayed visibility
+		swap so the off-screen panel is reported as `visibility: hidden` (not just
+		visually hidden by transform) once the close animation finishes. This
+		matters for accessibility tooling and Playwright's `toBeVisible()`.
+
+		Open  → transform animates 200ms, visibility flips to `visible` immediately.
+		Close → transform animates 200ms, visibility flips to `hidden` AFTER 200ms.
+	*/
+  @media (max-width: 767px) {
+    :global(.sidebar-mobile-anim) {
+      visibility: visible;
+      transition:
+        transform 200ms ease-out,
+        visibility 0s linear 0s;
+    }
+    :global(.sidebar-mobile-anim.sidebar-mobile-closed) {
+      visibility: hidden;
+      transition:
+        transform 200ms ease-out,
+        visibility 0s linear 200ms;
+    }
+  }
+</style>

--- a/apps/frontend/src/lib/components/MobileSidebarChrome.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/MobileSidebarChrome.svelte.spec.ts
@@ -1,0 +1,111 @@
+import { flushSync } from 'svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { q, testSnippet } from '$lib/test-utils';
+import { sidebarNav } from '$lib/state/globals.svelte';
+import MobileSidebarChrome from './MobileSidebarChrome.svelte';
+
+function resetSidebar() {
+  sidebarNav.setMobile(false);
+  if (!sidebarNav.isOpen) sidebarNav.toggle();
+  sidebarNav.setMobile(true);
+}
+
+function renderChrome() {
+  return render(MobileSidebarChrome, {
+    props: {
+      children: testSnippet('<main data-testid="sidebar-child"></main>')
+    }
+  });
+}
+
+function pointer(type: string, x: number, y = 120) {
+  return new PointerEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    pointerId: 1,
+    clientX: x,
+    clientY: y
+  });
+}
+
+describe('MobileSidebarChrome', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetSidebar();
+  });
+
+  it('renders the gutter panel and children in the sidebar row', () => {
+    const { container } = renderChrome();
+
+    expect(q(container, '[data-testid="mobile-sidebar-panel"]')).not.toBeNull();
+    expect(q(container, '[data-testid="sidebar-child"]')).not.toBeNull();
+  });
+
+  it('marks mobile sidebar chrome as closed when the sidebar is closed', () => {
+    const { container } = renderChrome();
+
+    const panel = q(container, '[data-testid="mobile-sidebar-panel"]');
+    const backdrop = q(
+      container,
+      '[data-testid="mobile-sidebar-backdrop"]'
+    ) as HTMLButtonElement | null;
+    expect(panel).not.toBeNull();
+    expect(backdrop).not.toBeNull();
+    if (!panel || !backdrop) return;
+
+    expect(panel.classList.contains('sidebar-mobile-closed')).toBe(true);
+    expect(panel.style.transform).toBe('translateX(-324px)');
+    expect(backdrop.disabled).toBe(true);
+    expect(backdrop.getAttribute('aria-hidden')).toBe('true');
+    expect(backdrop.style.opacity).toBe('0');
+  });
+
+  it('opens and closes from the backdrop state without unmounting it', () => {
+    const { container } = renderChrome();
+
+    sidebarNav.toggle();
+    flushSync();
+
+    const panel = q(container, '[data-testid="mobile-sidebar-panel"]');
+    const backdrop = q(
+      container,
+      '[data-testid="mobile-sidebar-backdrop"]'
+    ) as HTMLButtonElement | null;
+    expect(panel).not.toBeNull();
+    expect(backdrop).not.toBeNull();
+    if (!panel || !backdrop) return;
+
+    expect(panel.classList.contains('sidebar-mobile-closed')).toBe(false);
+    expect(panel.style.transform).toBe('translateX(0px)');
+    expect(backdrop.disabled).toBe(false);
+    expect(backdrop.style.opacity).toBe('1');
+
+    backdrop.click();
+    flushSync();
+
+    expect(q(container, '[data-testid="mobile-sidebar-backdrop"]')).toBe(backdrop);
+    expect(panel.classList.contains('sidebar-mobile-closed')).toBe(true);
+    expect(panel.style.transform).toBe('translateX(-324px)');
+    expect(backdrop.disabled).toBe(true);
+    expect(backdrop.style.opacity).toBe('0');
+  });
+
+  it('keeps edge target pointer events from bubbling to window handlers', () => {
+    const { container } = renderChrome();
+    const onWindowPointerDown = vi.fn();
+    window.addEventListener('pointerdown', onWindowPointerDown);
+
+    try {
+      const edge = q(container, '[data-testid="mobile-sidebar-edge"]');
+      expect(edge).not.toBeNull();
+      if (!edge) return;
+
+      edge.dispatchEvent(pointer('pointerdown', 2));
+
+      expect(onWindowPointerDown).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('pointerdown', onWindowPointerDown);
+    }
+  });
+});

--- a/apps/frontend/src/lib/components/ServerSidebar.svelte
+++ b/apps/frontend/src/lib/components/ServerSidebar.svelte
@@ -61,7 +61,7 @@ See the "UI" section of `docs/GLOSSARY.md`.
     // Desktop: hide entirely when closed.
     sidebarNav.isMobile ? '' : sidebarNav.isOpen ? '' : 'hidden',
     // Mobile-only: become `visibility: hidden` once the slide-out animation
-    // completes (see .sidebar-mobile-anim styles in routes/+layout.svelte) so
+    // completes (see .sidebar-mobile-anim styles in MobileSidebarChrome.svelte) so
     // accessibility tools and Playwright `toBeVisible()` agree the panel is
     // hidden, not just translated off-screen.
     mobileClosed && 'sidebar-mobile-closed',

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -2,22 +2,16 @@
   import { afterNavigate, goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
-  import * as m from '$lib/i18n/messages';
   import { onNotificationClick } from '$lib/notifications/pushNotifications';
   import { prepareUiForNotificationPath } from '$lib/notifications/notificationNavigationUi';
-  import ServerGutter from '$lib/ServerGutter.svelte';
   import { setAuthServerInfo } from '$lib/components/authServerInfo';
   import ConnectionIndicator from '$lib/components/ConnectionIndicator.svelte';
   import ConnectionProvider from '$lib/components/ConnectionProvider.svelte';
   import GlobalKeyboardShortcuts from '$lib/components/GlobalKeyboardShortcuts.svelte';
   import IdleTracker from '$lib/components/IdleTracker.svelte';
+  import MobileSidebarChrome from '$lib/components/MobileSidebarChrome.svelte';
   import UpdateNotifier from '$lib/components/UpdateNotifier.svelte';
   import { usePageTitle, usePinchZoomPrevention, useVisualViewport } from '$lib/hooks';
-  import {
-    SIDEBAR_PANEL_WIDTH_PX,
-    sidebarEdgeSwipe,
-    sidebarSwipe
-  } from '$lib/hooks/useSidebarSwipe.svelte';
   import { chatRoomIdFromRoute } from '$lib/navigation/chatRoomRoute';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { sidebarNav } from '$lib/state/globals.svelte';
@@ -75,10 +69,6 @@
 
   const getFullTitle = usePageTitle();
   const fullTitle = $derived(getFullTitle());
-
-  function stopPropagation(event: Event) {
-    event.stopPropagation();
-  }
 </script>
 
 <GlobalKeyboardShortcuts />
@@ -94,10 +84,6 @@
 </ConnectionProvider>
 
 {#snippet frame()}
-  {@const progress = sidebarNav.isMobile ? sidebarNav.progress : 1}
-  {@const dragging = sidebarNav.dragOffset !== null}
-  {@const mobileClosed = sidebarNav.isMobile && progress === 0 && !dragging}
-  {@const tx = (progress - 1) * SIDEBAR_PANEL_WIDTH_PX}
   <div
     class="flex h-full w-full flex-col overscroll-y-contain bg-surface-100 pt-[env(safe-area-inset-top,0px)] md:p-3 md:pt-0"
   >
@@ -106,71 +92,9 @@
     <AppHeader />
 
     <Frame class="relative flex-col">
-      {#if sidebarNav.isMobile}
-        <!--
-          Edge gesture zone (swipe-to-open). `touch-action: none` is essential:
-          without it, Chrome / iOS Safari fire pointercancel ~8px into a
-          horizontal drag (text-selection / back-navigation gesture detection).
-          Hidden when sidebar is open (the backdrop takes over). Plain taps are
-          intentionally swallowed here; this target exists only to start swipes.
-        -->
-        {#if !sidebarNav.isOpen || dragging}
-          <div
-            use:sidebarEdgeSwipe
-            data-app-sidebar="true"
-            data-testid="mobile-sidebar-edge"
-            class="fixed top-11 bottom-0 left-0 z-40 w-6 touch-none md:hidden"
-            aria-hidden="true"
-            onpointerdown={stopPropagation}
-            onpointerup={stopPropagation}
-            onclick={stopPropagation}
-            oncontextmenu={stopPropagation}
-          ></div>
-        {/if}
-
-        <button
-          type="button"
-          use:sidebarSwipe
-          data-app-sidebar="true"
-          data-testid="mobile-sidebar-backdrop"
-          class={[
-            'fixed inset-0 top-11 z-40 touch-none bg-black/50 md:hidden',
-            !dragging && 'transition-opacity duration-200',
-            mobileClosed && 'pointer-events-none'
-          ]}
-          style:opacity={progress}
-          disabled={mobileClosed}
-          tabindex={mobileClosed ? -1 : 0}
-          aria-hidden={mobileClosed}
-          onclick={() => sidebarNav.close()}
-          aria-label={m['common.close_sidebar']()}
-        ></button>
-      {/if}
-
-      <div class="flex min-h-0 flex-1 flex-row">
-        <div
-          use:sidebarSwipe
-          data-app-sidebar="true"
-          data-testid="mobile-sidebar-panel"
-          class={[
-            'z-50 min-h-0 flex-col self-stretch bg-background',
-            'max-md:fixed max-md:top-11 max-md:bottom-0 max-md:left-0 max-md:w-17 max-md:touch-pan-y',
-            // Mobile: always rendered so we can animate transform.
-            // Desktop: hide entirely when closed (no overlay; layout reflows).
-            sidebarNav.isMobile ? 'flex' : sidebarNav.isOpen ? 'flex' : 'hidden',
-            // Mobile-only: hide via `visibility: hidden` after the close
-            // transition, so Playwright / accessibility tooling correctly see
-            // the sidebar as not-visible while the slide-out animation works.
-            mobileClosed && 'sidebar-mobile-closed',
-            !dragging && 'sidebar-mobile-anim'
-          ]}
-          style:transform={sidebarNav.isMobile ? `translateX(${tx}px)` : undefined}
-        >
-          <ServerGutter />
-        </div>
-
+      <MobileSidebarChrome>
         {@render children?.()}
-      </div>
+      </MobileSidebarChrome>
     </Frame>
   </div>
 {/snippet}
@@ -182,29 +106,3 @@
 {/if}
 
 <ToastContainer />
-
-<style>
-  /*
-    Mobile sidebar animation — slide via transform, plus a delayed visibility
-    swap so the off-screen panel is reported as `visibility: hidden` (not just
-    visually hidden by transform) once the close animation finishes. This
-    matters for accessibility tooling and Playwright's `toBeVisible()`.
-
-    Open  → transform animates 200ms, visibility flips to `visible` immediately.
-    Close → transform animates 200ms, visibility flips to `hidden` AFTER 200ms.
-  */
-  @media (max-width: 767px) {
-    :global(.sidebar-mobile-anim) {
-      visibility: visible;
-      transition:
-        transform 200ms ease-out,
-        visibility 0s linear 0s;
-    }
-    :global(.sidebar-mobile-anim.sidebar-mobile-closed) {
-      visibility: hidden;
-      transition:
-        transform 200ms ease-out,
-        visibility 0s linear 200ms;
-    }
-  }
-</style>


### PR DESCRIPTION
## Summary

Extracts the mobile sidebar edge target, backdrop, panel, and delayed-visibility CSS from the root layout into `MobileSidebarChrome`.
Keeps the existing sidebar gesture hooks and DOM/test selectors intact while making `+layout.svelte` responsible only for app shell composition.
Adds a focused browser component spec for the new sidebar chrome behavior, including closed/open state and edge-target propagation.

## Verification

Ran Svelte autofixer, focused Vitest sidebar/gesture specs, mobile navigation Playwright e2e, `chatto-frontend check`, and `mise license-check`.
