### PR TITLE
fix(frontend): refresh recent emoji quick reactions

### DIFF
--- a/apps/frontend/e2e/recent-reactions.test.ts
+++ b/apps/frontend/e2e/recent-reactions.test.ts
@@ -23,14 +23,14 @@ test.describe('Recent reactions', () => {
 
     // React with a non-default emoji via the emoji picker
     const message1 = roomPage.getMessage('Message 1');
-    await message1.reactViaEmojiPicker('rocket', 'rocket');
-    await message1.expectReaction('🚀', 1);
+    await message1.reactViaEmojiPicker('check', 'white_check_mark');
+    await message1.expectReaction('✅', 1);
 
-    // Now hover message2 — rocket should be at the first non-pinned slot (4).
+    // Now hover message2 — the checkmark should be at the first non-pinned slot (4).
     // Pinned slots 0-3 are unchanged.
     const updatedReactions = await message2.getToolbarQuickReactions();
     expect(updatedReactions.slice(0, 4)).toEqual(['👍', '👋', '🤣', '🙏']);
-    expect(updatedReactions[4]).toBe('🚀');
+    expect(updatedReactions[4]).toBe('✅');
     expect(updatedReactions).toHaveLength(6);
     // The last fallback emoji should have been pushed off
     expect(updatedReactions).not.toContain('😂');

--- a/apps/frontend/src/lib/components/menus/MessageContextMenu.svelte
+++ b/apps/frontend/src/lib/components/menus/MessageContextMenu.svelte
@@ -66,7 +66,8 @@ Rendered inside a ContextMenu when right-clicking a message.
     onClose: () => void;
   } = $props();
 
-  const quickReactions = $derived(getRecentEmojis(serverId).quickReactions);
+  const recentEmojis = $derived(getRecentEmojis(serverId));
+  const quickReactions = $derived(recentEmojis.quickReactions);
 
   const actions = useMessageActions();
   const replyInRoomActionLabel = $derived(replyInRoomLabel ?? m['room.message.actions.reply']());

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionSheet.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionSheet.svelte
@@ -46,7 +46,8 @@
     onClose: () => void;
   } = $props();
 
-  const quickReactions = $derived(getRecentEmojis(serverId).quickReactions);
+  const recentEmojis = $derived(getRecentEmojis(serverId));
+  const quickReactions = $derived(recentEmojis.quickReactions);
 
   const actions = useMessageActions();
   const replyInRoomActionLabel = $derived(replyInRoomLabel ?? m['room.message.actions.reply']());

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.recentReactions.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.recentReactions.svelte.spec.ts
@@ -61,7 +61,7 @@ beforeEach(() => {
 });
 
 describe('MessageHoverBar recent reactions integration', () => {
-  it('uses an emoji selected in the picker as the first non-pinned quick reaction', async () => {
+  it('uses a checkmark emoji selected in the picker as the first non-pinned quick reaction', async () => {
     const bar = renderBar();
     expect(quickReactionLabels(bar.container)).toEqual(['👍', '👋', '🤣', '🙏', '❤️', '😂']);
 
@@ -72,14 +72,14 @@ describe('MessageHoverBar recent reactions integration', () => {
         onClose: vi.fn()
       }
     });
-    await searchEmoji(picker.container, 'rocket');
-    (picker.container.querySelector('button[title="rocket"]') as HTMLButtonElement).click();
+    await searchEmoji(picker.container, 'check');
+    (picker.container.querySelector('button[title="white_check_mark"]') as HTMLButtonElement).click();
     flushSync();
     await tick();
 
     const reactions = quickReactionLabels(bar.container);
     expect(reactions.slice(0, PINNED_REACTIONS.length)).toEqual([...PINNED_REACTIONS]);
-    expect(reactions[PINNED_REACTIONS.length]).toBe('🚀');
+    expect(reactions[PINNED_REACTIONS.length]).toBe('✅');
     expect(reactions).toHaveLength(6);
     expect(reactions).not.toContain('😂');
   });

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.svelte
@@ -71,7 +71,8 @@ Desktop only (pointer-fine); mobile uses the long-press action sheet instead.
     onOpenMenu?: (e: MouseEvent) => void;
   } = $props();
 
-  const quickReactions = $derived(getRecentEmojis(serverId).quickReactions);
+  const recentEmojis = $derived(getRecentEmojis(serverId));
+  const quickReactions = $derived(recentEmojis.quickReactions);
 
   const actions = useMessageActions();
   const replyInRoomActionLabel = $derived(replyInRoomLabel ?? m['room.message.actions.reply']());


### PR DESCRIPTION
Fixes the recent emoji quick-reaction toolbar so picker-selected non-pinned emoji update already-mounted quick-reaction surfaces immediately instead of only after reload.
The quick toolbar, message context menu, and mobile action sheet now derive quick reactions through the explicit per-server recent emoji store instance before reading its reactive quick-reactions list.
Coverage now exercises the green checkmark (`white_check_mark`) path in both browser component and e2e recent-reaction tests.
Validated with Svelte MCP autofixer, targeted Vitest browser specs for recent emoji behavior, and `e2e/recent-reactions.test.ts`.
