### PR TITLE
fix(frontend): improve reaction user popovers

### DIFF
--- a/apps/frontend/messages/de/room.json
+++ b/apps/frontend/messages/de/room.json
@@ -88,6 +88,7 @@
         "unfollow_thread": "Thread nicht mehr folgen",
         "add_reaction_label": "{emoji}-Reaktion hinzufügen ({count})",
         "remove_reaction_label": "{emoji}-Reaktion entfernen ({count})",
+        "reaction_users_more": "+ {count} weitere",
         "copy_link_title": "Klicken, um den Link zu dieser Nachricht zu kopieren",
         "in_reply_to": "als Antwort auf",
         "reply_preview_fallback": "Nachricht",

--- a/apps/frontend/messages/en/room.json
+++ b/apps/frontend/messages/en/room.json
@@ -88,6 +88,7 @@
         "unfollow_thread": "Unfollow thread",
         "add_reaction_label": "Add {emoji} reaction ({count})",
         "remove_reaction_label": "Remove {emoji} reaction ({count})",
+        "reaction_users_more": "+ {count} more",
         "copy_link_title": "Click to copy link to this message",
         "in_reply_to": "in reply to",
         "reply_preview_fallback": "Message",

--- a/apps/frontend/src/lib/i18n/messages.ts
+++ b/apps/frontend/src/lib/i18n/messages.ts
@@ -640,6 +640,9 @@ const msg_room_message_meta_add_reaction_label = (
 const msg_room_message_meta_remove_reaction_label = (
   inputs: Parameters<LocaleMessages['room_message_meta_remove_reaction_label']>[0]
 ): LocalizedString => messages().room_message_meta_remove_reaction_label(inputs);
+const msg_room_message_meta_reaction_users_more = (
+  inputs: Parameters<LocaleMessages['room_message_meta_reaction_users_more']>[0]
+): LocalizedString => messages().room_message_meta_reaction_users_more(inputs);
 const msg_room_message_meta_copy_link_title = (): LocalizedString => messages().room_message_meta_copy_link_title(empty());
 const msg_room_message_meta_in_reply_to = (): LocalizedString => messages().room_message_meta_in_reply_to(empty());
 const msg_room_message_meta_reply_preview_fallback = (): LocalizedString => messages().room_message_meta_reply_preview_fallback(empty());
@@ -1985,6 +1988,7 @@ export { msg_room_message_meta_follow_thread as 'room.message.meta.follow_thread
 export { msg_room_message_meta_unfollow_thread as 'room.message.meta.unfollow_thread' };
 export { msg_room_message_meta_add_reaction_label as 'room.message.meta.add_reaction_label' };
 export { msg_room_message_meta_remove_reaction_label as 'room.message.meta.remove_reaction_label' };
+export { msg_room_message_meta_reaction_users_more as 'room.message.meta.reaction_users_more' };
 export { msg_room_message_meta_copy_link_title as 'room.message.meta.copy_link_title' };
 export { msg_room_message_meta_in_reply_to as 'room.message.meta.in_reply_to' };
 export { msg_room_message_meta_reply_preview_fallback as 'room.message.meta.reply_preview_fallback' };

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.stories.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.stories.svelte
@@ -1,0 +1,91 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import MessageMetaBar from './MessageMetaBar.svelte';
+
+  const { Story } = defineMeta({
+    title: 'Routes/Chat/MessageMetaBar',
+    component: MessageMetaBar,
+    tags: ['autodocs'],
+    parameters: {
+      docs: {
+        description: {
+          component:
+            'Message metadata row with thread controls, reaction pills, and capped reaction-user popovers.'
+        }
+      }
+    }
+  });
+
+  type ReactionSummary = {
+    emoji: string;
+    count: number;
+    hasReacted: boolean;
+    users: { id: string; displayName: string }[];
+  };
+
+  const shortReaction: ReactionSummary = {
+    emoji: 'thumbsup',
+    count: 2,
+    hasReacted: false,
+    users: [
+      { id: 'alice', displayName: 'Alice' },
+      { id: 'bob', displayName: 'Bob' }
+    ]
+  };
+
+  const highCountReaction: ReactionSummary = {
+    emoji: 'heart',
+    count: 72,
+    hasReacted: false,
+    users: [
+      { id: 'azerbaijan', displayName: 'Azerbaijan' },
+      { id: 'german-noob', displayName: 'German_Noob_With_An_Absurdly_Long_Name' },
+      { id: '2tap2b', displayName: '2tap2b' },
+      { id: 'muchtin', displayName: 'muchtin' },
+      { id: 'patry', displayName: 'patry' }
+    ]
+  };
+</script>
+
+<script lang="ts">
+  import { provideConnection } from '$lib/state/server/connection.svelte';
+  import { ServerConnection } from '$lib/state/server/serverConnection.svelte';
+
+  const storyConnection = new ServerConnection({
+    serverId: 'storybook-server',
+    serverUrl: 'http://localhost:4000',
+    token: null
+  });
+
+  provideConnection(() => storyConnection);
+
+  const commonProps = {
+    roomId: 'storybook-room',
+    messageEventId: 'storybook-message',
+    serverSegment: '-',
+    threadRootEventId: null,
+    replyCount: 0,
+    canReact: false
+  };
+</script>
+
+{#snippet storyFrame(reactions: ReactionSummary[])}
+  <div class="min-h-40 w-96 rounded-md bg-background p-6 text-text">
+    <div class="rounded-md bg-surface px-4 py-3 shadow-sm">
+      <div class="mb-2 flex items-baseline gap-2">
+        <strong class="text-sm font-semibold">Hendrik Mans</strong>
+        <span class="text-xs text-muted">19:23</span>
+      </div>
+      <p class="text-sm text-text">Reaction summary preview</p>
+      <MessageMetaBar {...commonProps} {reactions} />
+    </div>
+  </div>
+{/snippet}
+
+<Story name="Short Reaction Popover" asChild>
+  {@render storyFrame([shortReaction])}
+</Story>
+
+<Story name="High Count Reaction Popover" asChild>
+  {@render storyFrame([highCountReaction])}
+</Story>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte
@@ -29,7 +29,7 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
   import { useRenderData } from '$lib/render/data';
   import { useConnection } from '$lib/state/server/connection.svelte';
   import { toast } from '$lib/ui/toast';
-  import FloatingTooltip from '$lib/ui/FloatingTooltip.svelte';
+  import FloatingPopover from '$lib/ui/FloatingPopover.svelte';
   import { getEmojiByName, getEmojiDisplayName } from '$lib/emoji';
   import { createReactionAPI } from '$lib/api-client/reactions';
   import * as m from '$lib/i18n/messages';
@@ -87,16 +87,19 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
   const tooltipReaction = $derived(
     tooltipReactionEmoji ? (reactions.find((r) => r.emoji === tooltipReactionEmoji) ?? null) : null
   );
+  const REACTION_TOOLTIP_USER_LIMIT = 5;
 
-  function formatReactionUsers(users: { displayName: string }[], count: number): string {
-    const maxDisplay = 5;
-    const names = users.slice(0, maxDisplay).map((u) => u.displayName);
-    const remaining = Math.max(0, count - names.length);
-
-    if (remaining > 0) {
-      return names.join(', ') + ` + ${remaining}`;
-    }
-    return names.join(', ');
+  function reactionTooltipUsers(reaction: ReactionSummary): {
+    names: string[];
+    remaining: number;
+  } {
+    const names = reaction.users
+      .slice(0, REACTION_TOOLTIP_USER_LIMIT)
+      .map((user) => user.displayName);
+    return {
+      names,
+      remaining: Math.max(0, reaction.count - names.length)
+    };
   }
 
   function showReactionTooltip(e: MouseEvent | FocusEvent, reaction: ReactionSummary) {
@@ -274,15 +277,27 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
   {/if}
 </div>
 
-<FloatingTooltip
+<FloatingPopover
   open={!!tooltipReaction && !!tooltipAnchor}
   anchor={tooltipAnchor}
+  role="tooltip"
   id={reactionTooltipId}
+  class="pointer-events-none w-64 menu"
 >
   {#if tooltipReaction}
-    <span class="whitespace-nowrap">
+    {@const tooltipUsers = reactionTooltipUsers(tooltipReaction)}
+    <div class="flex min-w-0 flex-col gap-1 menu-section px-3 py-2 text-xs">
       <strong class="font-semibold">{getEmojiDisplayName(tooltipReaction.emoji)}</strong>
-      <span> · {formatReactionUsers(tooltipReaction.users, tooltipReaction.count)}</span>
-    </span>
+      <span class="flex min-w-0 flex-col gap-0.5 text-muted">
+        {#each tooltipUsers.names as name (name)}
+          <span class="break-words" data-testid="reaction-tooltip-user">{name}</span>
+        {/each}
+        {#if tooltipUsers.remaining > 0}
+          <span class="text-muted/80">
+            {m['room.message.meta.reaction_users_more']({ count: tooltipUsers.remaining })}
+          </span>
+        {/if}
+      </span>
+    </div>
   {/if}
-</FloatingTooltip>
+</FloatingPopover>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts
@@ -186,17 +186,76 @@ describe('MessageMetaBar', () => {
 
     const tooltip = q(container, '[role="tooltip"]')!;
     const reactionName = q(tooltip, 'strong')!;
+    const userNames = Array.from(
+      tooltip.querySelectorAll<HTMLElement>('[data-testid="reaction-tooltip-user"]')
+    ).map((el) => el.textContent?.trim());
 
-    expect(tooltip.textContent?.trim()).toBe('Thumbs up · Alice, Bob');
     expect(reactionName.textContent?.trim()).toBe('Thumbs up');
+    expect(userNames).toEqual(['Alice', 'Bob']);
+    expect(tooltip.classList.contains('menu')).toBe(true);
+    expect(q(tooltip, '.menu-section')).not.toBeNull();
+    expect(
+      Array.from(
+        tooltip.querySelectorAll<HTMLElement>('[data-testid="reaction-tooltip-user"]')
+      ).every((el) => el.classList.contains('break-words'))
+    ).toBe(true);
     expect(reactionName.classList.contains('font-semibold')).toBe(true);
+    expect(tooltip.innerHTML).not.toContain('whitespace-nowrap');
+  });
+
+  it('caps long reacting user lists and summarizes the remaining users', () => {
+    const { container } = render(MessageMetaBar, {
+      props: {
+        ...baseProps,
+        reactions: [
+          reaction({
+            count: 72,
+            users: [
+              { id: 'user-1', displayName: 'Azerbaijan' },
+              { id: 'user-2', displayName: 'German_Noob_With_An_Absurdly_Long_Name' },
+              { id: 'user-3', displayName: '2tap2b' },
+              { id: 'user-4', displayName: 'muchtin' },
+              { id: 'user-5', displayName: 'patry' }
+            ]
+          })
+        ]
+      }
+    });
+
+    const wrapper = q(container, 'button[aria-label="Add 👍 reaction (72)"]')!
+      .parentElement as HTMLElement;
+
+    wrapper.dispatchEvent(new MouseEvent('mouseenter'));
+    flushSync();
+
+    const tooltip = q(container, '[role="tooltip"]')!;
+    const content = q(tooltip, '.menu-section')!;
+    const reactingUsers = q(tooltip, 'span.text-muted')!;
+    const userNames = Array.from(
+      tooltip.querySelectorAll<HTMLElement>('[data-testid="reaction-tooltip-user"]')
+    ).map((el) => el.textContent?.trim());
+
+    expect(content.classList.contains('min-w-0')).toBe(true);
+    expect(tooltip.classList.contains('menu')).toBe(true);
+    expect(tooltip.classList.contains('w-64')).toBe(true);
+    expect(reactingUsers.classList.contains('min-w-0')).toBe(true);
+    expect(userNames).toEqual([
+      'Azerbaijan',
+      'German_Noob_With_An_Absurdly_Long_Name',
+      '2tap2b',
+      'muchtin',
+      'patry'
+    ]);
+    expect(reactingUsers.textContent).toContain('+ 67 more');
   });
 
   it('keeps the reaction tooltip available when the reaction button is disabled', () => {
     const { container } = render(MessageMetaBar, {
       props: {
         ...baseProps,
-        reactions: [reaction({ emoji: 'heart', count: 1, users: [{ id: 'user-1', displayName: 'Alice' }] })],
+        reactions: [
+          reaction({ emoji: 'heart', count: 1, users: [{ id: 'user-1', displayName: 'Alice' }] })
+        ],
         canReact: false
       }
     });
@@ -210,6 +269,7 @@ describe('MessageMetaBar', () => {
     flushSync();
 
     const tooltip = q(container, '[role="tooltip"]')!;
-    expect(tooltip.textContent?.trim()).toBe('Heart · Alice');
+    expect(q(tooltip, 'strong')?.textContent?.trim()).toBe('Heart');
+    expect(q(tooltip, '[data-testid="reaction-tooltip-user"]')?.textContent?.trim()).toBe('Alice');
   });
 });


### PR DESCRIPTION
## Summary
- Rework reaction user details into a design-system `menu`/`menu-section` popover.
- Cap displayed reacting users at five and show a localized `+ N more` overflow row.
- Add MessageMetaBar Storybook stories for short and high-count reaction popovers, plus focused browser tests.

## Verification
- `pnpm run paraglide`
- `npx @sveltejs/mcp svelte-autofixer apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte`
- `pnpm exec vitest run --project client 'src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts'`
- `pnpm exec storybook build`
- `git diff --check`
