### PR TITLE
fix(api): log internal connect errors

### DIFF
--- a/cli/internal/connectapi/api.go
+++ b/cli/internal/connectapi/api.go
@@ -62,7 +62,10 @@ func HandlerOptions() []connect.HandlerOption {
 func handlerOptionsWithReadMax(readMaxBytes int) []connect.HandlerOption {
 	return []connect.HandlerOption{
 		connect.WithReadMaxBytes(readMaxBytes),
-		connect.WithInterceptors(validate.NewInterceptor()),
+		connect.WithInterceptors(
+			internalErrorLoggingInterceptor(),
+			validate.NewInterceptor(),
+		),
 	}
 }
 

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -32,6 +32,7 @@ import (
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/core"
 	"hmans.de/chatto/internal/core/linkpreview"
+	"hmans.de/chatto/internal/encryption"
 	"hmans.de/chatto/internal/events"
 	adminv1 "hmans.de/chatto/internal/pb/chatto/admin/v1"
 	"hmans.de/chatto/internal/pb/chatto/admin/v1/adminv1connect"
@@ -5939,6 +5940,131 @@ func TestRoomAndThreadTimelineHydratesMessagesWithoutClientNPlusOne(t *testing.T
 	}
 }
 
+func TestRoomTimelineKeepsDMReadableWhenMessageBodyCannotHydrate(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	ctx := withCaller(env.ctx, env.viewer)
+
+	participant, err := env.core.CreateUser(env.ctx, core.SystemActorID, "timeline-dm-corrupt", "Timeline DM Corrupt", "password")
+	if err != nil {
+		t.Fatalf("CreateUser participant: %v", err)
+	}
+	start, err := env.rooms.StartDM(ctx, connect.NewRequest(&apiv1.StartDMRequest{
+		ParticipantIds: []string{participant.Id},
+	}))
+	if err != nil {
+		t.Fatalf("StartDM: %v", err)
+	}
+	dm := start.Msg.GetRoom()
+
+	bad, err := env.core.PostMessage(env.ctx, core.KindDM, dm.Id, env.viewer.Id, "body that will be superseded", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage bad: %v", err)
+	}
+	corruptMessageBody(t, env, dm.Id, bad.Id, env.viewer.Id)
+	if _, err := env.core.GetFullMessageBodyByEventID(env.ctx, bad.Id); !errors.Is(err, core.ErrMessageBodyCorrupt) {
+		t.Fatalf("corrupt message body hydration error = %v, want ErrMessageBodyCorrupt", err)
+	}
+
+	goodResp, err := env.messages.CreateMessage(ctx, connect.NewRequest(&apiv1.CreateMessageRequest{
+		RoomId: dm.Id,
+		Body:   "good DM message",
+	}))
+	if err != nil {
+		t.Fatalf("CreateMessage good: %v", err)
+	}
+	good := goodResp.Msg.GetMessage()
+	if good == nil {
+		t.Fatalf("CreateMessage good message = nil")
+	}
+
+	resp, err := env.rooms.GetRoomEvents(ctx, connect.NewRequest(&apiv1.GetRoomEventsRequest{
+		RoomId: dm.Id,
+		Limit:  20,
+	}))
+	if err != nil {
+		t.Fatalf("GetRoomEvents with corrupt body: %v", err)
+	}
+
+	badTimelineEvent := timelinePageEvent(resp.Msg.GetPage(), bad.Id)
+	if badTimelineEvent == nil {
+		t.Fatalf("corrupt message %s missing from timeline", bad.Id)
+	}
+	badMessage := badTimelineEvent.GetMessagePosted().GetMessage()
+	if badMessage == nil {
+		t.Fatalf("corrupt message payload = nil")
+	}
+	if badMessage.Body != nil {
+		t.Fatalf("corrupt message body present = %q, want unavailable body", badMessage.GetBody())
+	}
+
+	goodTimelineEvent := timelinePageEvent(resp.Msg.GetPage(), good.GetId())
+	if goodTimelineEvent == nil {
+		t.Fatalf("good message %s missing from timeline", good.GetId())
+	}
+	goodMessage := goodTimelineEvent.GetMessagePosted().GetMessage()
+	if goodMessage == nil || goodMessage.GetBody() != "good DM message" {
+		t.Fatalf("good message = %+v, want body", goodMessage)
+	}
+}
+
+func TestRoomTimelineBodyHydrationPropagatesRequestErrors(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+
+	room := env.createJoinedRoom("timeline-body-canceled")
+	posted, err := env.core.PostMessage(env.ctx, core.KindChannel, room.Id, env.viewer.Id, "body should require hydration", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(env.ctx)
+	cancel()
+
+	h := &timelineHydrator{
+		api:                  env.api,
+		kind:                 core.KindChannel,
+		reactionsByMessageID: make(map[string][]core.ReactionSummary),
+		userIDs:              make(map[string]struct{}),
+	}
+	_, err = h.messagePosted(ctx, &core.RoomEvent{Event: posted}, posted.GetMessagePosted())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("messagePosted error = %v, want context cancellation", err)
+	}
+}
+
+func corruptMessageBody(t *testing.T, env *connectAPITestEnv, roomID, eventID, authorID string) {
+	t.Helper()
+
+	bodyEventID := core.NewEventID()
+	bodyEvent := &corev1.Event{
+		Id:        bodyEventID,
+		ActorId:   authorID,
+		CreatedAt: timestamppb.Now(),
+		Event: &corev1.Event_MessageBody{
+			MessageBody: &corev1.MessageBodyEvent{
+				RoomId:  roomID,
+				EventId: eventID,
+				Body: &corev1.MessageBody{
+					CreatedAt:         timestamppb.Now(),
+					AuthorId:          authorID,
+					EncryptedBody:     []byte("not a valid ciphertext"),
+					EncryptionNonce:   []byte("bad nonce"),
+					EncryptionVersion: encryption.EnvelopeVersionV2,
+					ContentKeyEpoch:   1,
+					BodyEventId:       bodyEventID,
+				},
+			},
+		},
+	}
+	subject := events.RoomAggregate(roomID).SubjectFor(bodyEvent)
+	seq, err := env.core.EventPublisher.AppendEventually(env.ctx, subject, bodyEvent)
+	if err != nil {
+		t.Fatalf("Append corrupt MessageBodyEvent: %v", err)
+	}
+	if err := env.core.RoomTimelineProjector.WaitFor(env.ctx, events.SubjectPosition(subject, seq)); err != nil {
+		t.Fatalf("WaitFor corrupt MessageBodyEvent: %v", err)
+	}
+}
+
 func TestRoomAndThreadTimelineGetThreadEventsIncludesRootAndPaginatesReplies(t *testing.T) {
 	env := newConnectAPITestEnv(t)
 	room := env.createJoinedRoom("timeline-thread")
@@ -6951,6 +7077,28 @@ func TestConnectErrorMapping(t *testing.T) {
 
 	if err := connectError(errors.New("boom")); strings.Contains(err.Error(), "boom") {
 		t.Fatalf("connectError leaked internal error: %v", err)
+	}
+}
+
+func TestSafeInternalErrorForLogRedactsSensitiveSubstrings(t *testing.T) {
+	err := errors.New("failed for email=person@example.test token=cht_ATabcdef123456 redirect=https://chat.example.test/callback?code=secret&state=s url=https://chat.example.test/path?code=secret&state=s and raw other@example.test")
+
+	got := safeInternalErrorForLog(err)
+	for _, forbidden := range []string{
+		"person@example.test",
+		"other@example.test",
+		"cht_ATabcdef123456",
+		"code=secret",
+		"state=s",
+	} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("safeInternalErrorForLog leaked %q in %q", forbidden, got)
+		}
+	}
+	for _, want := range []string{"email=[redacted]", "redirect=[redacted]", "token=[redacted]", "?[redacted]", "[redacted-email]"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("safeInternalErrorForLog = %q, want redaction marker %q", got, want)
+		}
 	}
 }
 

--- a/cli/internal/connectapi/errors.go
+++ b/cli/internal/connectapi/errors.go
@@ -1,11 +1,23 @@
 package connectapi
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"regexp"
 
 	"connectrpc.com/connect"
+	"github.com/charmbracelet/log"
 	"github.com/nats-io/nats.go/jetstream"
 	"hmans.de/chatto/internal/core"
+)
+
+var (
+	errorLogEmailRE       = regexp.MustCompile(`[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}`)
+	errorLogTokenRE       = regexp.MustCompile(`cht_[A-Za-z0-9]{2}[A-Za-z0-9_-]+`)
+	errorLogURLQueryRE    = regexp.MustCompile(`(https?://[^\s?]+)\?[^ \t\n\r]+`)
+	errorLogQueryParamRE  = regexp.MustCompile(`(?i)\b(token|code|password|email|login|redirect|subject)=([^ \t\n\r&]+)`)
+	errorLogControlCharRE = regexp.MustCompile(`[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]`)
 )
 
 func connectError(err error) error {
@@ -96,9 +108,75 @@ func connectError(err error) error {
 		errors.Is(err, core.ErrSidebarLinkSourceChanged) {
 		return connect.NewError(connect.CodeFailedPrecondition, err)
 	}
-	return connect.NewError(connect.CodeInternal, errors.New("internal server error"))
+	return connectInternalError(err)
 }
 
 func invalidArgument(message string) error {
 	return connect.NewError(connect.CodeInvalidArgument, errors.New(message))
+}
+
+func connectInternalError(err error) error {
+	logInternalConnectError(err)
+	return connect.NewError(connect.CodeInternal, loggedInternalClientError{})
+}
+
+type loggedInternalClientError struct{}
+
+func (loggedInternalClientError) Error() string {
+	return "internal server error"
+}
+
+func internalErrorLoggingInterceptor() connect.Interceptor {
+	return connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			res, err := next(ctx, req)
+			if err != nil && connect.CodeOf(err) == connect.CodeInternal && !internalErrorAlreadyLogged(err) {
+				logInternalConnectError(err, "procedure", req.Spec().Procedure)
+			}
+			return res, err
+		}
+	})
+}
+
+func internalErrorAlreadyLogged(err error) bool {
+	var logged loggedInternalClientError
+	return errors.As(err, &logged)
+}
+
+func logInternalConnectError(err error, attrs ...any) {
+	attrs = append(attrs,
+		"error", safeInternalErrorForLog(err),
+		"error_type", fmt.Sprintf("%T", err),
+		"root_error_type", rootErrorType(err))
+	log.Error("Connect API internal error", attrs...)
+}
+
+func safeInternalErrorForLog(err error) string {
+	if err == nil {
+		return ""
+	}
+	message := err.Error()
+	message = errorLogURLQueryRE.ReplaceAllString(message, "$1?[redacted]")
+	message = errorLogQueryParamRE.ReplaceAllString(message, "$1=[redacted]")
+	message = errorLogEmailRE.ReplaceAllString(message, "[redacted-email]")
+	message = errorLogTokenRE.ReplaceAllString(message, "[redacted-token]")
+	message = errorLogControlCharRE.ReplaceAllString(message, "?")
+	const maxInternalErrorLogLength = 2048
+	if len(message) > maxInternalErrorLogLength {
+		message = message[:maxInternalErrorLogLength] + "...[truncated]"
+	}
+	return message
+}
+
+func rootErrorType(err error) string {
+	for {
+		if unwrapper, ok := err.(interface{ Unwrap() error }); ok {
+			unwrapped := unwrapper.Unwrap()
+			if unwrapped != nil {
+				err = unwrapped
+				continue
+			}
+		}
+		return fmt.Sprintf("%T", err)
+	}
 }

--- a/cli/internal/connectapi/messages.go
+++ b/cli/internal/connectapi/messages.go
@@ -39,10 +39,10 @@ func (s *messageService) CreateMessage(ctx context.Context, req *connect.Request
 		return nil, connectError(err)
 	}
 	if result == nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.New("message create returned no result"))
+		return nil, connectInternalError(errors.New("message create returned no result"))
 	}
 	if result.Event == nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.New("message create returned no event"))
+		return nil, connectInternalError(errors.New("message create returned no event"))
 	}
 
 	roomID := result.Event.GetMessagePosted().GetRoomId()

--- a/cli/internal/connectapi/room_timeline_assembler.go
+++ b/cli/internal/connectapi/room_timeline_assembler.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/charmbracelet/log"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"hmans.de/chatto/internal/core"
 	"hmans.de/chatto/internal/parallel"
@@ -215,7 +216,17 @@ func (h *timelineHydrator) messagePosted(ctx context.Context, event *core.RoomEv
 
 	body, err := h.api.core.GetFullMessageBodyByEventID(ctx, event.Id)
 	if err != nil {
-		return nil, err
+		if !errors.Is(err, core.ErrMessageBodyCorrupt) {
+			return nil, err
+		}
+		// A single corrupt body envelope must not make the whole room history
+		// unreadable. Keep the message envelope renderable and let clients show
+		// the existing unavailable-message state.
+		log.Warn("Failed to hydrate room timeline message body",
+			"room_id", payload.GetRoomId(),
+			"message_event_id", event.Id,
+			"error", err)
+		body = nil
 	}
 	if body != nil {
 		message.Body = &body.Body

--- a/cli/internal/core/errors.go
+++ b/cli/internal/core/errors.go
@@ -76,6 +76,12 @@ var (
 	// ErrMessageNotFound is returned when a message body doesn't exist (already deleted).
 	ErrMessageNotFound = errors.New("message not found")
 
+	// ErrMessageBodyCorrupt is returned when a persisted message body envelope is
+	// malformed or cannot be authenticated. Callers may render the affected
+	// message as unavailable, but should not treat dependency or request errors
+	// as this sentinel.
+	ErrMessageBodyCorrupt = errors.New("message body corrupt")
+
 	// ErrMessageAttachmentNotFound is returned when a message does not contain
 	// the requested attachment.
 	ErrMessageAttachmentNotFound = errors.New("message attachment not found")

--- a/cli/internal/core/message_body.go
+++ b/cli/internal/core/message_body.go
@@ -129,11 +129,11 @@ func (c *ChattoCore) decryptMessageBody(ctx context.Context, eventID, roomID str
 	if msg.GetEncryptionVersion() >= encryption.EnvelopeVersionV2 || msg.GetContentKeyEpoch() > 0 {
 		version := msg.GetEncryptionVersion()
 		if version != encryption.EnvelopeVersionV2 {
-			return nil, fmt.Errorf("unsupported message body encryption version %d", version)
+			return nil, fmt.Errorf("%w: unsupported message body encryption version %d", ErrMessageBodyCorrupt, version)
 		}
 		epoch := msg.GetContentKeyEpoch()
 		if epoch <= 0 {
-			return nil, fmt.Errorf("missing content key epoch for v%d message body", version)
+			return nil, fmt.Errorf("%w: missing content key epoch for v%d message body", ErrMessageBodyCorrupt, version)
 		}
 		contentKeyEvent, ok := c.ContentKeys.Get(msg.GetAuthorId(), corev1.UserDEKPurpose_USER_DEK_PURPOSE_MESSAGE_BODY, epoch)
 		if !ok {
@@ -143,12 +143,16 @@ func (c *ChattoCore) decryptMessageBody(ctx context.Context, eventID, roomID str
 		if err != nil {
 			return nil, err
 		}
-		return encryption.DecryptWithContentKey(
+		plaintext, err := encryption.DecryptWithContentKey(
 			contentKey.key,
 			msg.GetEncryptedBody(),
 			msg.GetEncryptionNonce(),
 			messageBodyAAD(eventID, msg.GetBodyEventId(), roomID, msg.GetAuthorId(), epoch),
 		)
+		if err != nil {
+			return nil, messageBodyEnvelopeError(err)
+		}
+		return plaintext, nil
 	}
 
 	if c.encryption.legacyKeys == nil {
@@ -161,7 +165,19 @@ func (c *ChattoCore) decryptMessageBody(ctx context.Context, eventID, roomID str
 	if key == nil {
 		return nil, encryption.ErrKeyNotFound
 	}
-	return encryption.Decrypt(key, msg.GetEncryptedBody(), msg.GetEncryptionNonce())
+	plaintext, err := encryption.Decrypt(key, msg.GetEncryptedBody(), msg.GetEncryptionNonce())
+	if err != nil {
+		return nil, messageBodyEnvelopeError(err)
+	}
+	return plaintext, nil
+}
+
+func messageBodyEnvelopeError(err error) error {
+	if errors.Is(err, encryption.ErrDecryptionFailed) ||
+		errors.Is(err, encryption.ErrInvalidNonceSize) {
+		return fmt.Errorf("%w: %w", ErrMessageBodyCorrupt, err)
+	}
+	return err
 }
 
 // (eventIDFromBodyKey is defined in core.go and shared with the


### PR DESCRIPTION
## Summary
- log unmapped Connect API internal errors with sanitized server-side details while preserving generic client errors
- add a fallback Connect interceptor for direct internal errors and route message-create internals through the shared helper
- keep DM timelines readable when a message body cannot hydrate, with regression coverage for corrupt body events

## Validation
- `cd cli && mise x -- go test ./internal/connectapi -run 'TestConnectErrorMapping|TestSafeInternalErrorForLogRedactsSensitiveSubstrings|TestRoomTimelineKeepsDMReadableWhenMessageBodyCannotHydrate|TestRoomAndThreadTimelineHydratesMessagesWithoutClientNPlusOne' -count=1 -timeout 60s`
- `cd cli && mise x -- go test ./internal/connectapi -count=1 -timeout 120s`
- `cd cli && mise x -- go test ./internal/http_server -run 'TestConnect|TestAuthenticatedConnect' -count=1 -timeout 60s`
- `git diff --check`

Note: full `./internal/http_server` currently fails in `TestFrontendFallbackAllowsRoutesWithReservedPrefixNames` because the local test fixture is missing `200.html`, which is unrelated to these Connect API changes.
