### PR TITLE
fix(read-state): reduce no-op read signals

### DIFF
--- a/apps/frontend/src/lib/hooks/UseUnreadMarkerHarness.svelte
+++ b/apps/frontend/src/lib/hooks/UseUnreadMarkerHarness.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import { useUnreadMarker, type UnreadMarkerWindow } from './useUnreadMarker.svelte';
+
+  type ReadResult = {
+    lastReadAt: string | null;
+    previousLastReadAt: string | null;
+  };
+
+  type UnreadMarkerHarnessAPI = ReturnType<typeof useUnreadMarker<ReadResult>>;
+
+  let {
+    targetId,
+    markAsRead,
+    onReady
+  }: {
+    targetId: string;
+    markAsRead: (targetId: string, upToEventId?: string) => Promise<ReadResult | null>;
+    onReady: (api: UnreadMarkerHarnessAPI) => void;
+  } = $props();
+
+  const unread = useUnreadMarker(() => targetId, {
+    markAsRead: (target, upToEventId) => markAsRead(target, upToEventId),
+    markerWindowFromReadResult: (result): UnreadMarkerWindow | null => {
+      if (!result.previousLastReadAt || !result.lastReadAt) return null;
+      return {
+        afterTime: result.previousLastReadAt,
+        beforeTime: result.lastReadAt
+      };
+    }
+  });
+
+  $effect(() => {
+    onReady(unread);
+  });
+</script>

--- a/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.spec.ts
@@ -8,6 +8,13 @@ type HarnessAPI = {
   noteAwayEvent(eventId: string): void;
 };
 
+function getApi(api: HarnessAPI | undefined): HarnessAPI {
+  if (!api) {
+    throw new Error('Unread marker harness API was not initialized');
+  }
+  return api;
+}
+
 function setVisibility(value: DocumentVisibilityState): void {
   Object.defineProperty(document, 'visibilityState', {
     value,
@@ -35,15 +42,12 @@ describe('useUnreadMarker', () => {
 
   it('does not mark the same target as read again on refocus without an away event', async () => {
     const markAsRead = vi.fn().mockResolvedValue(null);
-    let api: HarnessAPI | null = null;
 
     const rendered = render(Harness, {
       props: {
         targetId: 'room-1',
         markAsRead,
-        onReady: (nextApi: HarnessAPI) => {
-          api = nextApi;
-        }
+        onReady: () => {}
       }
     });
     flushSync();
@@ -52,14 +56,13 @@ describe('useUnreadMarker', () => {
     setPresent(false);
     setPresent(true);
 
-    expect(api).not.toBeNull();
     expect(markAsRead).toHaveBeenCalledOnce();
     rendered.unmount();
   });
 
   it('marks the same target as read on refocus when an away event was captured', async () => {
     const markAsRead = vi.fn().mockResolvedValue(null);
-    let api: HarnessAPI | null = null;
+    let api: HarnessAPI | undefined;
 
     const rendered = render(Harness, {
       props: {
@@ -74,12 +77,13 @@ describe('useUnreadMarker', () => {
     await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledOnce());
 
     setPresent(false);
-    api?.noteAwayEvent('event-2');
+    const currentApi = getApi(api);
+    currentApi.noteAwayEvent('event-2');
     setPresent(true);
 
     await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledTimes(2));
     expect(markAsRead).toHaveBeenLastCalledWith('room-1', undefined);
-    expect(api?.unreadMarkerEventId).toBe('event-2');
+    expect(currentApi.unreadMarkerEventId).toBe('event-2');
     rendered.unmount();
   });
 

--- a/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.spec.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync } from 'svelte';
+import { render } from 'vitest-browser-svelte';
+import Harness from './UseUnreadMarkerHarness.svelte';
+
+type HarnessAPI = {
+  readonly unreadMarkerEventId: string | null;
+  noteAwayEvent(eventId: string): void;
+};
+
+function setVisibility(value: DocumentVisibilityState): void {
+  Object.defineProperty(document, 'visibilityState', {
+    value,
+    writable: true,
+    configurable: true
+  });
+  document.dispatchEvent(new Event('visibilitychange'));
+}
+
+function setPresent(present: boolean): void {
+  window.dispatchEvent(new Event(present ? 'focus' : 'blur'));
+  setVisibility(present ? 'visible' : 'hidden');
+  flushSync();
+}
+
+describe('useUnreadMarker', () => {
+  beforeEach(() => {
+    setPresent(true);
+  });
+
+  afterEach(() => {
+    setPresent(true);
+    vi.restoreAllMocks();
+  });
+
+  it('does not mark the same target as read again on refocus without an away event', async () => {
+    const markAsRead = vi.fn().mockResolvedValue(null);
+    let api: HarnessAPI | null = null;
+
+    const rendered = render(Harness, {
+      props: {
+        targetId: 'room-1',
+        markAsRead,
+        onReady: (nextApi: HarnessAPI) => {
+          api = nextApi;
+        }
+      }
+    });
+    flushSync();
+    await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledOnce());
+
+    setPresent(false);
+    setPresent(true);
+
+    expect(api).not.toBeNull();
+    expect(markAsRead).toHaveBeenCalledOnce();
+    rendered.unmount();
+  });
+
+  it('marks the same target as read on refocus when an away event was captured', async () => {
+    const markAsRead = vi.fn().mockResolvedValue(null);
+    let api: HarnessAPI | null = null;
+
+    const rendered = render(Harness, {
+      props: {
+        targetId: 'room-1',
+        markAsRead,
+        onReady: (nextApi: HarnessAPI) => {
+          api = nextApi;
+        }
+      }
+    });
+    flushSync();
+    await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledOnce());
+
+    setPresent(false);
+    api?.noteAwayEvent('event-2');
+    setPresent(true);
+
+    await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledTimes(2));
+    expect(markAsRead).toHaveBeenLastCalledWith('room-1', undefined);
+    expect(api?.unreadMarkerEventId).toBe('event-2');
+    rendered.unmount();
+  });
+
+  it('marks a new target as read when the target changes', async () => {
+    const markAsRead = vi.fn().mockResolvedValue(null);
+
+    const rendered = render(Harness, {
+      props: {
+        targetId: 'room-1',
+        markAsRead,
+        onReady: () => {}
+      }
+    });
+    flushSync();
+    await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledOnce());
+
+    await rendered.rerender({
+      targetId: 'room-2',
+      markAsRead,
+      onReady: () => {}
+    });
+    flushSync();
+
+    await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledTimes(2));
+    expect(markAsRead).toHaveBeenLastCalledWith('room-2', undefined);
+    rendered.unmount();
+  });
+});

--- a/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.ts
@@ -62,19 +62,22 @@ export function useUnreadMarker<TReadResult>(
       return;
     }
 
-    if (wasPresent && lastFiredTargetId === targetId) return;
-
     const isTargetChange = lastFiredTargetId !== targetId;
+    const awayEventId = pendingAwayEventId;
+
+    if (wasPresent && !isTargetChange) return;
+
     wasPresent = true;
     lastFiredTargetId = targetId;
 
     if (isTargetChange) {
       clearUnreadMarker();
-    } else if (pendingAwayEventId) {
-      setUnreadMarkerEventId(pendingAwayEventId);
+    } else if (awayEventId) {
+      setUnreadMarkerEventId(awayEventId);
       pendingAwayEventId = null;
     } else {
       pendingAwayEventId = null;
+      return;
     }
 
     const markedAtMs = Date.now();

--- a/cli/internal/core/read_state_model.go
+++ b/cli/internal/core/read_state_model.go
@@ -68,21 +68,26 @@ func (s *ReadStateModel) MarkRoomAsRead(ctx context.Context, actorID, roomID, up
 		return nil, err
 	}
 
+	markerUpdated := false
 	if hasLast {
 		advance, err := s.core.AdvanceLastReadEventID(ctx, kind, actorID, room.Id, lastEventID)
 		if err != nil {
 			return nil, err
 		}
+		markerUpdated = advance.Updated
 		if advance.CurrentEventID != "" {
 			lastEventID = advance.CurrentEventID
 			lastTime = advance.CurrentTime
 		}
 	}
 
+	dismissedNotifications := 0
 	if hasLast && !lastTime.IsZero() {
-		s.core.DismissRoomReadNotifications(ctx, kind, actorID, room.Id, lastTime)
+		dismissedNotifications = s.core.DismissRoomReadNotifications(ctx, kind, actorID, room.Id, lastTime)
 	}
-	s.core.NotifyRoomMarkedAsRead(ctx, actorID, kind, room.Id)
+	if markerUpdated || dismissedNotifications > 0 {
+		s.core.NotifyRoomMarkedAsRead(ctx, actorID, kind, room.Id)
+	}
 
 	result := &MarkRoomAsReadResult{}
 	if hasLast && !lastTime.IsZero() {

--- a/cli/internal/core/read_state_model_test.go
+++ b/cli/internal/core/read_state_model_test.go
@@ -1,0 +1,174 @@
+package core
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"google.golang.org/protobuf/proto"
+
+	"hmans.de/chatto/internal/core/subjects"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+func subscribeRoomReadLiveEvents(t *testing.T, nc *nats.Conn, userID string) *nats.Subscription {
+	t.Helper()
+
+	sub, err := nc.SubscribeSync(subjects.LiveSyncUserEvent(userID, "room_read"))
+	if err != nil {
+		t.Fatalf("SubscribeSync room_read: %v", err)
+	}
+	if err := nc.Flush(); err != nil {
+		t.Fatalf("Flush subscription: %v", err)
+	}
+	return sub
+}
+
+func expectRoomReadLiveEvent(t *testing.T, sub *nats.Subscription, roomID string) {
+	t.Helper()
+
+	msg, err := sub.NextMsg(2 * time.Second)
+	if err != nil {
+		t.Fatalf("waiting for room_read live event: %v", err)
+	}
+	var live corev1.LiveEvent
+	if err := proto.Unmarshal(msg.Data, &live); err != nil {
+		t.Fatalf("unmarshal room_read live event: %v", err)
+	}
+	event := live.GetRoomMarkedAsRead()
+	if event == nil {
+		t.Fatalf("expected RoomMarkedAsReadEvent, got %T", live.Event)
+	}
+	if event.GetRoomId() != roomID {
+		t.Fatalf("room_read room id = %q, want %q", event.GetRoomId(), roomID)
+	}
+}
+
+func expectNoRoomReadLiveEvent(t *testing.T, sub *nats.Subscription) {
+	t.Helper()
+
+	if msg, err := sub.NextMsg(200 * time.Millisecond); err == nil {
+		var live corev1.LiveEvent
+		if unmarshalErr := proto.Unmarshal(msg.Data, &live); unmarshalErr != nil {
+			t.Fatalf("unexpected room_read live event with invalid payload: %v", unmarshalErr)
+		}
+		t.Fatalf("unexpected room_read live event: %T", live.Event)
+	} else if !errors.Is(err, nats.ErrTimeout) {
+		t.Fatalf("waiting for absent room_read live event: %v", err)
+	}
+}
+
+func TestReadStateModel_MarkRoomAsReadSkipsLiveEventWhenCursorUnchanged(t *testing.T) {
+	core, nc := setupTestCore(t)
+	ctx := testContext(t)
+
+	room, _ := core.CreateRoom(ctx, "test-user", KindChannel, "", "General", "General discussion")
+	poster, _ := core.CreateUser(ctx, "system", "read-signal-poster", "Read Signal Poster", "password123")
+	reader, _ := core.CreateUser(ctx, "system", "read-signal-reader", "Read Signal Reader", "password123")
+	if _, err := core.JoinRoom(ctx, poster.Id, KindChannel, poster.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom poster: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, reader.Id, KindChannel, reader.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom reader: %v", err)
+	}
+
+	posted, err := core.PostMessage(ctx, KindChannel, room.Id, poster.Id, "already read", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage: %v", err)
+	}
+	if err := core.SetLastReadEventID(ctx, KindChannel, reader.Id, room.Id, posted.Id); err != nil {
+		t.Fatalf("SetLastReadEventID: %v", err)
+	}
+
+	sub := subscribeRoomReadLiveEvents(t, nc, reader.Id)
+	if _, err := core.ReadState().MarkRoomAsRead(ctx, reader.Id, room.Id, ""); err != nil {
+		t.Fatalf("MarkRoomAsRead: %v", err)
+	}
+
+	expectNoRoomReadLiveEvent(t, sub)
+}
+
+func TestReadStateModel_MarkRoomAsReadPublishesLiveEventWhenCursorAdvances(t *testing.T) {
+	core, nc := setupTestCore(t)
+	ctx := testContext(t)
+
+	room, _ := core.CreateRoom(ctx, "test-user", KindChannel, "", "General", "General discussion")
+	poster, _ := core.CreateUser(ctx, "system", "read-advance-poster", "Read Advance Poster", "password123")
+	reader, _ := core.CreateUser(ctx, "system", "read-advance-reader", "Read Advance Reader", "password123")
+	if _, err := core.JoinRoom(ctx, poster.Id, KindChannel, poster.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom poster: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, reader.Id, KindChannel, reader.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom reader: %v", err)
+	}
+
+	first, err := core.PostMessage(ctx, KindChannel, room.Id, poster.Id, "first", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage first: %v", err)
+	}
+	if err := core.SetLastReadEventID(ctx, KindChannel, reader.Id, room.Id, first.Id); err != nil {
+		t.Fatalf("SetLastReadEventID: %v", err)
+	}
+	if _, err := core.PostMessage(ctx, KindChannel, room.Id, poster.Id, "second", nil, "", "", nil, false); err != nil {
+		t.Fatalf("PostMessage second: %v", err)
+	}
+
+	sub := subscribeRoomReadLiveEvents(t, nc, reader.Id)
+	if _, err := core.ReadState().MarkRoomAsRead(ctx, reader.Id, room.Id, ""); err != nil {
+		t.Fatalf("MarkRoomAsRead: %v", err)
+	}
+
+	expectRoomReadLiveEvent(t, sub, room.Id)
+}
+
+func TestReadStateModel_MarkRoomAsReadPublishesLiveEventWhenNotificationsDismissed(t *testing.T) {
+	core, nc := setupTestCore(t)
+	ctx := testContext(t)
+
+	room, _ := core.CreateRoom(ctx, "test-user", KindChannel, "", "General", "General discussion")
+	poster, _ := core.CreateUser(ctx, "system", "read-notify-poster", "Read Notify Poster", "password123")
+	reader, _ := core.CreateUser(ctx, "system", "read-notify-reader", "Read Notify Reader", "password123")
+	if _, err := core.JoinRoom(ctx, poster.Id, KindChannel, poster.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom poster: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, reader.Id, KindChannel, reader.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom reader: %v", err)
+	}
+
+	first, err := core.PostMessage(ctx, KindChannel, room.Id, poster.Id, "first", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage first: %v", err)
+	}
+	second, err := core.PostMessage(ctx, KindChannel, room.Id, poster.Id, "second", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage second: %v", err)
+	}
+	if err := core.SetLastReadEventID(ctx, KindChannel, reader.Id, room.Id, second.Id); err != nil {
+		t.Fatalf("SetLastReadEventID: %v", err)
+	}
+	notification, err := core.CreateNotification(ctx, reader.Id, poster.Id, &corev1.Notification{
+		Notification: &corev1.Notification_Mention{
+			Mention: &corev1.MentionNotification{RoomId: room.Id, EventId: first.Id},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateNotification: %v", err)
+	}
+
+	sub := subscribeRoomReadLiveEvents(t, nc, reader.Id)
+	if _, err := core.ReadState().MarkRoomAsRead(ctx, reader.Id, room.Id, ""); err != nil {
+		t.Fatalf("MarkRoomAsRead: %v", err)
+	}
+
+	expectRoomReadLiveEvent(t, sub, room.Id)
+	remaining, err := core.GetNotifications(ctx, reader.Id)
+	if err != nil {
+		t.Fatalf("GetNotifications: %v", err)
+	}
+	for _, item := range remaining {
+		if item.GetId() == notification.GetId() {
+			t.Fatalf("notification %s was not dismissed", notification.GetId())
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Suppress same-room refocus mark-read RPCs when no away event was captured.
- Publish `roomMarkedAsRead` only when the room read cursor advances or covered notifications are dismissed.
- Add focused frontend hook coverage and core live-event side-effect coverage.

## Validation
- `mise x -- pnpm --filter @chatto/api-types build`
- `mise x -- pnpm --dir apps/frontend exec vitest --run src/lib/hooks/useUnreadMarker.svelte.spec.ts`
- `mise x -- go test ./internal/core ./internal/connectapi -run 'MarkRoomAsRead|ReadState|Unread|Notification' -timeout 60s`
