### PR TITLE
fix(frontend): align message footer row spacing

### DIFF
--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -347,7 +347,7 @@
 }
 
 @utility attachment-remove-button {
-  @apply absolute top-1 right-1 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full text-white/90 outline-none transition-[opacity,scale] active:scale-[0.96] focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:ring-offset-background md:opacity-0;
+  @apply absolute top-1 right-1 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full text-white/90 transition-[opacity,scale] outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:ring-offset-background active:scale-[0.96] md:opacity-0;
 
   &::before {
     content: '';
@@ -400,6 +400,20 @@
 @utility meta-badge {
   @apply inline-flex items-center rounded-sm border leading-none;
   @apply bg-surface group-hover/badges:bg-surface-200 hover:bg-surface-300;
+}
+
+/* Chat message row primitives. These keep the hover-highlight shell and its
+   child content stack aligned across the app and Storybook fixtures. */
+@utility message-row {
+  @apply relative flex gap-4 px-2 pt-1 pb-1 select-none hover:bg-surface-100 md:mx-2 md:rounded-md md:pr-8;
+}
+
+@utility message-row-footer {
+  @apply pb-0.5;
+}
+
+@utility message-content-stack {
+  @apply min-w-0 flex-1 space-y-1;
 }
 
 /* Pane header icon button — fixed padded hit area for icon-only controls in PaneHeader.

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.stories.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.stories.svelte
@@ -1,0 +1,34 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  const { Story } = defineMeta({
+    title: 'Chat/Message rows',
+    parameters: {
+      layout: 'fullscreen'
+    }
+  });
+</script>
+
+<script lang="ts">
+  import MessageRowStoryFrame from './MessageRowStoryFrame.svelte';
+</script>
+
+<Story name="Plain message" asChild>
+  <MessageRowStoryFrame variant="plain" />
+</Story>
+
+<Story name="Message with meta bar" asChild>
+  <MessageRowStoryFrame variant="with-meta-bar" />
+</Story>
+
+<Story name="Footer comparison" asChild>
+  <MessageRowStoryFrame variant="footer-comparison" />
+</Story>
+
+<Story name="Compact grouped message" asChild>
+  <MessageRowStoryFrame variant="compact-grouped" />
+</Story>
+
+<Story name="Deleted message" asChild>
+  <MessageRowStoryFrame variant="deleted" />
+</Story>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -406,6 +406,11 @@
   const hasThreadNotification = $derived(
     hasReplies && event && notificationStore.hasThreadNotification(event.id)
   );
+  const hasMessageFooter = $derived(
+    (isEcho && !!onOpenThread) ||
+      (hasReplies && !!onOpenThread) ||
+      (msg?.reactions?.length ?? 0) > 0
+  );
 
   // Check if current user is mentioned (but not by themselves)
   const isCurrentUserMentioned = $derived(
@@ -636,7 +641,8 @@
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
       class={[
-        'group/msg group/badges relative flex gap-4 px-2 py-1 select-none hover:bg-surface-100 md:mx-2 md:rounded-md md:pr-8',
+        'group/msg group/badges message-row',
+        hasMessageFooter ? 'message-row-footer' : '',
         compact && msg?.body ? 'items-baseline' : 'items-start',
         longPressActive || showActionSheet || contextMenuPos ? 'bg-surface-100' : ''
       ]}
@@ -681,11 +687,7 @@
               showPopoverForActor(e);
             }}
           >
-            <UserAvatar
-              user={actor}
-              size="md"
-              class="!h-11 !w-11 shadow-md"
-            />
+            <UserAvatar user={actor} size="md" class="!h-11 !w-11 shadow-md" />
           </button>
         {:else}
           <!-- Deleted user placeholder avatar -->
@@ -701,7 +703,7 @@
       {/if}
 
       <!-- Message content column -->
-      <div class="min-w-0 flex-1 space-y-1">
+      <div class="message-content-stack">
         {#if replyPreview}
           {@const replyJumpText =
             replyPreview.body ??
@@ -848,7 +850,7 @@
         {/each}
 
         <!-- Thread echo indicator, thread replies, and reactions -->
-        {#if (isEcho && onOpenThread) || (hasReplies && onOpenThread) || (msg?.reactions?.length ?? 0) > 0}
+        {#if hasMessageFooter}
           <MessageMetaBar
             {roomId}
             messageEventId={event.id}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.stories.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.stories.svelte
@@ -1,0 +1,34 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import MessageMetaBar from './MessageMetaBar.svelte';
+
+  const { Story } = defineMeta({
+    title: 'Chat/Message meta bar',
+    component: MessageMetaBar,
+    tags: ['autodocs']
+  });
+</script>
+
+<script lang="ts">
+  import MessageMetaBarStoryFrame from './MessageMetaBarStoryFrame.svelte';
+</script>
+
+<Story name="Reactions" asChild>
+  <MessageMetaBarStoryFrame variant="reactions" />
+</Story>
+
+<Story name="Replies and reactions" asChild>
+  <MessageMetaBarStoryFrame variant="replies-and-reactions" />
+</Story>
+
+<Story name="Unread followed thread" asChild>
+  <MessageMetaBarStoryFrame variant="unread-followed-thread" />
+</Story>
+
+<Story name="Thread echo" asChild>
+  <MessageMetaBarStoryFrame variant="thread-echo" />
+</Story>
+
+<Story name="Read-only reactions" asChild>
+  <MessageMetaBarStoryFrame variant="read-only-reactions" />
+</Story>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBarStoryFrame.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBarStoryFrame.svelte
@@ -1,0 +1,149 @@
+<script lang="ts">
+  import MessageMetaBar from './MessageMetaBar.svelte';
+  import { ServerConnection } from '$lib/state/server/serverConnection.svelte';
+  import { provideConnection } from '$lib/state/server/connection.svelte';
+  import { createPresenceCache } from '$lib/state/presenceCache.svelte';
+  import { createUserProfileCache } from '$lib/state/userProfiles.svelte';
+  import {
+    PresenceStatus,
+    type ReactionSummaryView,
+    type UserAvatarUserView
+  } from '$lib/render/types';
+
+  type Variant =
+    | 'reactions'
+    | 'replies-and-reactions'
+    | 'unread-followed-thread'
+    | 'thread-echo'
+    | 'read-only-reactions';
+
+  let { variant }: { variant: Variant } = $props();
+
+  const storyConnection = new ServerConnection({
+    serverUrl: 'http://localhost:5173',
+    token: null,
+    serverId: 'storybook'
+  });
+  storyConnection.setRealtimeConnectionStatus('connected');
+  provideConnection(() => storyConnection);
+  createPresenceCache();
+  createUserProfileCache();
+
+  const roomId = 'room-design';
+  const messageEventId = 'evt-root';
+  const serverSegment = '-';
+  const threadRootEventId = 'evt-root';
+
+  const alice: UserAvatarUserView = {
+    id: 'user-alice',
+    login: 'alice',
+    displayName: 'Alice',
+    deleted: false,
+    avatarUrl: null,
+    presenceStatus: PresenceStatus.Online
+  };
+  const jordan: UserAvatarUserView = {
+    id: 'user-jordan',
+    login: 'jordan',
+    displayName: 'Jordan',
+    deleted: false,
+    avatarUrl: null,
+    presenceStatus: PresenceStatus.Away
+  };
+  const mika: UserAvatarUserView = {
+    id: 'user-mika',
+    login: 'mika',
+    displayName: 'Mika',
+    deleted: false,
+    avatarUrl: null,
+    presenceStatus: PresenceStatus.Offline
+  };
+
+  const reactions: ReactionSummaryView[] = [
+    {
+      emoji: 'joy',
+      count: 1,
+      hasReacted: true,
+      users: [{ id: 'user-current', displayName: 'You' }]
+    },
+    {
+      emoji: 'thumbsup',
+      count: 4,
+      hasReacted: false,
+      users: [
+        { id: 'user-alice', displayName: 'Alice' },
+        { id: 'user-jordan', displayName: 'Jordan' },
+        { id: 'user-mika', displayName: 'Mika' },
+        { id: 'user-lee', displayName: 'Lee' }
+      ]
+    }
+  ];
+
+  function noop() {}
+</script>
+
+<div class="group/badges inline-flex rounded-md bg-background p-4 text-text">
+  {#if variant === 'reactions'}
+    <MessageMetaBar
+      {roomId}
+      {messageEventId}
+      {serverSegment}
+      {threadRootEventId}
+      {reactions}
+      canReact
+      onOpenEmojiPicker={noop}
+    />
+  {:else if variant === 'replies-and-reactions'}
+    <MessageMetaBar
+      {roomId}
+      {messageEventId}
+      {serverSegment}
+      {threadRootEventId}
+      {reactions}
+      replyCount={2}
+      threadParticipants={[alice, jordan, mika]}
+      canReact
+      isFollowingThread
+      onToggleThreadFollow={noop}
+      onOpenThread={noop}
+      onOpenEmojiPicker={noop}
+    />
+  {:else if variant === 'unread-followed-thread'}
+    <MessageMetaBar
+      {roomId}
+      {messageEventId}
+      {serverSegment}
+      {threadRootEventId}
+      reactions={[]}
+      replyCount={5}
+      threadParticipants={[alice, jordan, mika]}
+      hasThreadNotification
+      canReact
+      isFollowingThread
+      onToggleThreadFollow={noop}
+      onOpenThread={noop}
+      onOpenEmojiPicker={noop}
+    />
+  {:else if variant === 'thread-echo'}
+    <MessageMetaBar
+      {roomId}
+      {messageEventId}
+      {serverSegment}
+      {threadRootEventId}
+      reactions={reactions.slice(0, 1)}
+      canReact
+      isEchoEvent
+      onOpenThread={noop}
+      onOpenEmojiPicker={noop}
+    />
+  {:else}
+    <MessageMetaBar
+      {roomId}
+      {messageEventId}
+      {serverSegment}
+      {threadRootEventId}
+      {reactions}
+      canReact={false}
+    />
+  {/if}
+</div>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageRowStoryFrame.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageRowStoryFrame.svelte
@@ -1,0 +1,177 @@
+<script lang="ts">
+  import MessageMetaBar from './MessageMetaBar.svelte';
+  import { ServerConnection } from '$lib/state/server/serverConnection.svelte';
+  import { provideConnection } from '$lib/state/server/connection.svelte';
+  import { createPresenceCache } from '$lib/state/presenceCache.svelte';
+  import { createUserProfileCache } from '$lib/state/userProfiles.svelte';
+  import {
+    PresenceStatus,
+    type ReactionSummaryView,
+    type UserAvatarUserView
+  } from '$lib/render/types';
+
+  type Variant = 'plain' | 'with-meta-bar' | 'footer-comparison' | 'compact-grouped' | 'deleted';
+
+  let { variant }: { variant: Variant } = $props();
+
+  const storyConnection = new ServerConnection({
+    serverUrl: 'http://localhost:5173',
+    token: null,
+    serverId: 'storybook'
+  });
+  storyConnection.setRealtimeConnectionStatus('connected');
+  provideConnection(() => storyConnection);
+  createPresenceCache();
+  createUserProfileCache();
+
+  const roomId = 'room-design';
+  const messageEventId = 'evt-root';
+  const serverSegment = '-';
+  const threadRootEventId = 'evt-root';
+
+  const threadParticipants: UserAvatarUserView[] = [
+    {
+      id: 'user-alice',
+      login: 'alice',
+      displayName: 'Alice',
+      deleted: false,
+      avatarUrl: null,
+      presenceStatus: PresenceStatus.Online
+    },
+    {
+      id: 'user-jordan',
+      login: 'jordan',
+      displayName: 'Jordan',
+      deleted: false,
+      avatarUrl: null,
+      presenceStatus: PresenceStatus.Away
+    }
+  ];
+
+  const reactions: ReactionSummaryView[] = [
+    {
+      emoji: 'joy',
+      count: 1,
+      hasReacted: true,
+      users: [{ id: 'user-current', displayName: 'You' }]
+    },
+    {
+      emoji: 'wave',
+      count: 2,
+      hasReacted: false,
+      users: [
+        { id: 'user-alice', displayName: 'Alice' },
+        { id: 'user-jordan', displayName: 'Jordan' }
+      ]
+    }
+  ];
+
+  function noop() {}
+</script>
+
+{#snippet avatar(initials: string)}
+  <div
+    class="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-surface-200 text-lg font-semibold text-muted shadow-md"
+  >
+    {initials}
+  </div>
+{/snippet}
+
+{#snippet header(name: string, time: string)}
+  <div class="flex min-w-0 items-center gap-2">
+    <strong class="shrink-0 leading-none font-semibold">{name}</strong>
+    <span class="shrink-0 text-xs leading-none text-muted">{time}</span>
+  </div>
+{/snippet}
+
+{#snippet body(text: string)}
+  <p class="leading-snug text-text">{text}</p>
+{/snippet}
+
+{#snippet metaBar(replyCount = 2)}
+  <MessageMetaBar
+    {roomId}
+    {messageEventId}
+    {serverSegment}
+    {threadRootEventId}
+    {reactions}
+    {replyCount}
+    {threadParticipants}
+    canReact
+    isFollowingThread
+    onToggleThreadFollow={noop}
+    onOpenThread={noop}
+    onOpenEmojiPicker={noop}
+  />
+{/snippet}
+
+<div class="min-h-screen bg-background p-10 text-text">
+  <div
+    class="max-w-2xl {variant === 'footer-comparison' ? 'space-y-3' : ''} {variant ===
+    'compact-grouped'
+      ? 'space-y-0.5'
+      : ''}"
+  >
+    {#if variant === 'plain'}
+      <div class="group/msg group/badges message-row items-start bg-surface-100">
+        {@render avatar('A')}
+        <div class="message-content-stack">
+          {@render header('Alice', '10:23')}
+          {@render body('Hello!')}
+        </div>
+      </div>
+    {:else if variant === 'with-meta-bar'}
+      <div class="group/msg group/badges message-row items-start bg-surface-100 message-row-footer">
+        {@render avatar('A')}
+        <div class="message-content-stack">
+          {@render header('Alice', '10:23')}
+          {@render body('Hello!')}
+          {@render metaBar(2)}
+        </div>
+      </div>
+    {:else if variant === 'footer-comparison'}
+      <div class="group/msg group/badges message-row items-start bg-surface-100">
+        {@render avatar('A')}
+        <div class="message-content-stack">
+          {@render header('Alice', '10:23')}
+          {@render body('No footer: the hover shell keeps the default row padding.')}
+        </div>
+      </div>
+
+      <div class="group/msg group/badges message-row items-start bg-surface-100 message-row-footer">
+        {@render avatar('B')}
+        <div class="message-content-stack">
+          {@render header('Bea', '10:24')}
+          {@render body('With footer: the hover shell uses the footer row padding primitive.')}
+          {@render metaBar(1)}
+        </div>
+      </div>
+    {:else if variant === 'compact-grouped'}
+      <div class="group/msg group/badges message-row items-start">
+        {@render avatar('A')}
+        <div class="message-content-stack">
+          {@render header('Alice', '10:23')}
+          {@render body('First message in a short burst.')}
+        </div>
+      </div>
+
+      <div
+        class="group/msg group/badges message-row items-baseline bg-surface-100 message-row-footer"
+      >
+        <div class="flex w-11 shrink-0 items-center justify-center text-xs text-muted">10:24</div>
+        <div class="message-content-stack">
+          {@render body('Grouped follow-up with reactions.')}
+          {@render metaBar(0)}
+        </div>
+      </div>
+    {:else}
+      <div class="group/msg group/badges message-row items-start bg-surface-100">
+        {@render avatar('D')}
+        <div class="message-content-stack">
+          {@render header('Deleted User', '10:25')}
+          <span class="text-muted/50 italic">Message deleted</span>
+        </div>
+      </div>
+    {/if}
+  </div>
+</div>


### PR DESCRIPTION
## Summary

Fixes the hover-highlight padding for messages that render a footer by moving row spacing into shared message-row utilities instead of one-off inline classes.
Adds Storybook coverage for plain message rows, footer-bearing rows, compact grouped rows, deleted rows, and the message meta bar variants.
This makes the footer spacing easier to review visually and keeps message row styling reusable across the app and fixtures.

## Validation

- `mise x -- pnpm -C apps/frontend exec prettier --check 'src/routes/chat/[serverId]/[roomId]/MessageEvent.stories.svelte' 'src/routes/chat/[serverId]/[roomId]/MessageMetaBar.stories.svelte' 'src/routes/chat/[serverId]/[roomId]/MessageMetaBarStoryFrame.svelte' 'src/routes/chat/[serverId]/[roomId]/MessageRowStoryFrame.svelte' 'src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte' 'src/app.css'`
- `mise x -- pnpm --dir apps/frontend run build-storybook`
- `mise x -- pnpm --dir apps/frontend exec vitest run 'src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts' 'src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts'`
