### PR TITLE
fix(frontend): simplify room resume catch-up

### DIFF
--- a/apps/frontend/src/lib/state/server/serverConnection.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/serverConnection.svelte.spec.ts
@@ -16,7 +16,11 @@ vi.mock('./registry.svelte', () => ({
   }
 }));
 
-import { httpToWsUrl, ServerConnection, type ServerConnectionConfig } from './serverConnection.svelte';
+import {
+  httpToWsUrl,
+  ServerConnection,
+  type ServerConnectionConfig
+} from './serverConnection.svelte';
 
 function makeConfig(overrides: Partial<ServerConnectionConfig> = {}): ServerConnectionConfig {
   return {
@@ -127,6 +131,18 @@ describe('ServerConnection', () => {
     client.forceReconnect('second');
 
     expect(reconnect).not.toHaveBeenCalled();
+    client.dispose();
+  });
+
+  it('forces reconnect on browser online events even while marked connected', () => {
+    const client = new ServerConnection(makeConfig());
+    const reconnect = vi.fn();
+
+    client.setRealtimeConnectionStatus('connected');
+    client.registerRealtimeReconnect(reconnect);
+    window.dispatchEvent(new Event('online'));
+
+    expect(reconnect).toHaveBeenCalledWith('network came back online');
     client.dispose();
   });
 

--- a/apps/frontend/src/lib/state/server/serverConnection.svelte.ts
+++ b/apps/frontend/src/lib/state/server/serverConnection.svelte.ts
@@ -166,10 +166,7 @@ export class ServerConnection {
 
   handleAuthenticationRequired(): void {
     if (this.#serverId) {
-      if (
-        isExplicitSignOutRedirectInProgress() &&
-        serverRegistry.isOriginServer(this.#serverId)
-      ) {
+      if (isExplicitSignOutRedirectInProgress() && serverRegistry.isOriginServer(this.#serverId)) {
         return;
       }
       serverRegistry.handleAuthenticationRequired(this.#serverId);
@@ -184,31 +181,20 @@ export class ServerConnection {
     this.#token = token;
     this.#serverId = serverId;
 
-    // Reconnect when tab becomes visible after being backgrounded.
-    // If the tab was hidden for >30s, force-terminate the WebSocket regardless of
-    // reported status. This catches silently-dead connections where the OS killed
-    // the socket during sleep but the client never received a close event.
+    // Track tab visibility for diagnostics. Browser resume signals are handled
+    // by resumeCoordinator; liveness stays with actual close events and the
+    // heartbeat watchdog so a healthy hidden-tab socket is not torn down.
     if (typeof document !== 'undefined') {
       this.#visibilityHandler = () => {
         if (document.visibilityState === 'visible') {
           const hiddenDuration = Date.now() - this.#lastVisibleAt;
 
-          if (this.status === 'disconnected' || hiddenDuration > 30_000) {
-            console.debug(
-              '[ws:%s] visibility=visible after %ds hidden, status=%s → forceReconnect',
-              this.#host,
-              Math.round(hiddenDuration / 1000),
-              this.status
-            );
-            this.forceReconnect(`tab visible after ${Math.round(hiddenDuration / 1000)}s hidden`);
-          } else {
-            console.debug(
-              '[ws:%s] visibility=visible after %ds hidden, status=%s → no reconnect',
-              this.#host,
-              Math.round(hiddenDuration / 1000),
-              this.status
-            );
-          }
+          console.debug(
+            '[ws:%s] visibility=visible after %ds hidden, status=%s',
+            this.#host,
+            Math.round(hiddenDuration / 1000),
+            this.status
+          );
 
           this.#lastVisibleAt = Date.now();
         } else {
@@ -224,8 +210,8 @@ export class ServerConnection {
     //
     // Background-tab throttling produces the same signal (Chrome/Firefox
     // throttle setInterval to ~1/min in hidden tabs), so the gap is only
-    // meaningful while the tab is visible. The visibility handler covers
-    // the hidden case on resume.
+    // meaningful while the tab is visible. If the socket still reports
+    // connected, the heartbeat watchdog owns silent-dead detection.
     if (typeof window !== 'undefined') {
       let lastTick = Date.now();
       this.#suspendDetectorInterval = setInterval(() => {
@@ -233,7 +219,7 @@ export class ServerConnection {
         const gap = now - lastTick;
         lastTick = now;
         if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return;
-        if (gap > 30_000) {
+        if (gap > 30_000 && this.status !== 'connected') {
           console.debug(
             '[ws:%s] Suspend detector fired (timer gap %ds)',
             this.#host,

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -501,20 +501,26 @@
       console.debug('[room-refresh] event list refresh started', {
         roomId,
         reason: signal.reason,
+        source: signal.source,
         phase: signal.phase,
         hiddenDurationMs: signal.hiddenDurationMs,
         epoch: signal.epoch,
         mode: wasAtBottom ? 'latest' : 'anchored',
+        wasAtBottom,
         bottomDistance,
         anchorEventId: anchor?.eventId ?? null,
         itemCount: virtualItems.length
       });
-      const result = await messageStore.refreshCurrentWindow(anchor?.eventId ?? null);
+      const result = await messageStore.refreshCurrentWindow(
+        wasAtBottom ? null : (anchor?.eventId ?? null)
+      );
       if (!result.refreshed) {
         console.debug('[room-refresh] event list refresh skipped after store refresh failed', {
           roomId,
           reason: signal.reason,
+          source: signal.source,
           phase: signal.phase,
+          wasAtBottom,
           result
         });
         return false;


### PR DESCRIPTION
## Summary

Simplifies room resume catch-up by refreshing the latest visible window when the user is already at the bottom, so folded timeline updates can be rehydrated without cursor-draining special cases.
Reduces aggressive realtime reconnects by making visibility resume diagnostic-only while still forcing reconnects on browser `online` events, and keeps heartbeat/projected catch-up paths responsible for stale sockets.
Adds focused coverage for the connected-but-online reconnect case.

## Validation

- `mise x -- pnpm exec vitest run src/lib/state/server/serverConnection.svelte.spec.ts`
- `mise x -- pnpm exec vitest run src/lib/state/server/serverConnection.svelte.spec.ts src/lib/state/room/messages.svelte.spec.ts`
- `mise x -- pnpm exec svelte-check --tsconfig ./tsconfig.json`
- `git diff --check`
