### PR TITLE
fix(frontend): improve chat link navigation

### DIFF
--- a/apps/frontend/src/app.d.ts
+++ b/apps/frontend/src/app.d.ts
@@ -23,6 +23,8 @@ declare global {
         roomId?: string;
         roomName?: string;
         viewerCanJoinRoom?: boolean;
+        afterJoinPath?: string;
+        closePath?: string;
         spaceName?: string;
         eventId?: string;
         attachmentId?: string;

--- a/apps/frontend/src/lib/components/MessageContent.svelte
+++ b/apps/frontend/src/lib/components/MessageContent.svelte
@@ -9,7 +9,7 @@
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { renderMarkdown as renderMd } from '$lib/markdown';
   import MarkdownHtml from '$lib/ui/MarkdownHtml.svelte';
-  import { classifyMessageBodyChatLink, buildMessageLinkPath } from '$lib/messageLinks';
+  import { classifyMessageBodyChatLink } from '$lib/messageLinks';
   import { wrapValidMentions, type RoomMember } from '$lib/mentions';
   import { parseTrustedMarkdownHtml } from '$lib/security/trustedHtml';
 
@@ -93,11 +93,6 @@
       event.preventDefault();
 
       const chatLink = classifyMessageBodyChatLink(anchor.href);
-      if (chatLink?.kind === 'message') {
-        // eslint-disable-next-line svelte/no-navigation-without-resolve -- buildMessageLinkPath returns a resolved app route.
-        goto(buildMessageLinkPath(chatLink.serverId, chatLink.roomId, chatLink.messageId));
-        return;
-      }
       if (chatLink) {
         // eslint-disable-next-line svelte/no-navigation-without-resolve -- classifyMessageBodyChatLink returns an allow-listed resolved app path.
         goto(chatLink.path);

--- a/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
@@ -20,7 +20,8 @@ vi.mock('$app/navigation', () => ({
 }));
 
 vi.mock('$lib/navigation', () => ({
-  serverIdToSegment: (serverId: string) => (serverId === 'origin' ? '-' : serverId),
+  serverIdToSegment: (serverId: string) =>
+    serverId === 'origin' ? '-' : serverId === 'chatto-run' ? 'chat.chatto.run' : serverId,
   segmentToServerId: mocks.segmentToServerId
 }));
 
@@ -32,7 +33,17 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
   serverRegistry: {
     tryGetStore: () => mocks.store,
     getServer: (serverId: string) =>
-      serverId === 'origin' ? { id: 'origin', url: window.location.origin } : undefined
+      serverId === 'origin'
+        ? { id: 'origin', url: window.location.origin }
+        : serverId === 'chatto-run'
+          ? { id: 'chatto-run', url: 'https://chat.chatto.run' }
+          : undefined,
+    get servers() {
+      return [
+        { id: 'origin', url: window.location.origin },
+        { id: 'chatto-run', url: 'https://chat.chatto.run' }
+      ];
+    }
   }
 }));
 
@@ -445,6 +456,19 @@ describe('MessageContent component', () => {
     q(container, 'a')!.click();
 
     expect(mocks.goto).toHaveBeenCalledWith(`/chat/-/${channelRoomId}/m/${messageId}`);
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it('navigates registered external Chatto message URLs in the current tab', async () => {
+    const href = `https://chat.chatto.run/chat/-/${channelRoomId}/m/${messageId}`;
+    const { container } = renderMessage(`[message](${href})`);
+
+    await expect.poll(() => q(container, 'a')).toBeTruthy();
+    q(container, 'a')!.click();
+
+    expect(mocks.goto).toHaveBeenCalledWith(
+      `/chat/chat.chatto.run/${channelRoomId}/m/${messageId}`
+    );
     expect(window.open).not.toHaveBeenCalled();
   });
 

--- a/apps/frontend/src/lib/messageLinks.spec.ts
+++ b/apps/frontend/src/lib/messageLinks.spec.ts
@@ -3,6 +3,7 @@ import { getToasts, toast } from '$lib/ui/toast';
 import { classifyMessageBodyChatLink, copyMessageLinkToClipboard } from './messageLinks';
 
 const origin = 'https://chat.example.test';
+const registeredRemoteOrigin = 'https://chat.chatto.run';
 const channelRoomId = 'R123456789abcde';
 const dmRoomId = 'abcdef12345678';
 const messageId = 'Eabc123DEF456gh';
@@ -14,8 +15,25 @@ function resolveServerSegment(segment: string): string | null {
   return null;
 }
 
+function resolveUrlOrigin(urlOrigin: string): string | null {
+  if (urlOrigin === registeredRemoteOrigin) return 'chatto-run';
+  return null;
+}
+
+function serverSegmentForId(serverId: string): string {
+  if (serverId === 'origin') return '-';
+  if (serverId === 'remote') return 'remote.example.test';
+  if (serverId === 'chatto-run') return 'chat.chatto.run';
+  return serverId;
+}
+
 function classify(input: string) {
-  return classifyMessageBodyChatLink(input, { origin, resolveServerSegment });
+  return classifyMessageBodyChatLink(input, {
+    origin,
+    resolveServerSegment,
+    resolveUrlOrigin,
+    serverSegmentForId
+  });
 }
 
 describe('copyMessageLinkToClipboard', () => {
@@ -92,6 +110,35 @@ describe('classifyMessageBodyChatLink', () => {
     });
   });
 
+  it('maps registered-server absolute room URLs back to local app routes', () => {
+    expect(classify(`${registeredRemoteOrigin}/chat/-/${channelRoomId}`)).toMatchObject({
+      kind: 'room',
+      serverId: 'chatto-run',
+      serverSegment: 'chat.chatto.run',
+      roomId: channelRoomId,
+      path: `/chat/chat.chatto.run/${channelRoomId}`
+    });
+  });
+
+  it('maps registered-server absolute message URLs back to local app routes', () => {
+    expect(
+      classify(`${registeredRemoteOrigin}/chat/-/${channelRoomId}/m/${messageId}`)
+    ).toMatchObject({
+      kind: 'message',
+      serverId: 'chatto-run',
+      serverSegment: 'chat.chatto.run',
+      roomId: channelRoomId,
+      messageId,
+      path: `/chat/chat.chatto.run/${channelRoomId}/m/${messageId}`
+    });
+  });
+
+  it('preserves search and hash when mapping registered-server links', () => {
+    expect(classify(`${registeredRemoteOrigin}/chat/-/${channelRoomId}?a=1#bottom`)).toMatchObject({
+      path: `/chat/chat.chatto.run/${channelRoomId}?a=1#bottom`
+    });
+  });
+
   it('rejects same-origin non-chat and reserved chat URLs', () => {
     const rejected = [
       `${origin}/chat/-/settings`,
@@ -124,7 +171,7 @@ describe('classifyMessageBodyChatLink', () => {
     expect(classify(`${origin}/chat/unknown.example.test/${channelRoomId}`)).toBeNull();
   });
 
-  it('rejects cross-origin URLs', () => {
+  it('rejects unregistered cross-origin URLs', () => {
     expect(classify(`https://other.example.test/chat/-/${channelRoomId}`)).toBeNull();
   });
 });

--- a/apps/frontend/src/lib/messageLinks.ts
+++ b/apps/frontend/src/lib/messageLinks.ts
@@ -46,6 +46,8 @@ export type MessageBodyChatLink =
 export interface MessageBodyChatLinkOptions {
   origin?: string;
   resolveServerSegment?: (segment: string) => string | null;
+  resolveUrlOrigin?: (origin: string) => string | null;
+  serverSegmentForId?: (serverId: string) => string;
 }
 
 const channelRoomIdPattern = /^R[a-zA-Z0-9]{14}$/;
@@ -54,6 +56,87 @@ const eventIdPattern = /^E[a-zA-Z0-9]{14}$/;
 
 function isMessageRoomId(value: string): boolean {
   return channelRoomIdPattern.test(value) || dmRoomIdPattern.test(value);
+}
+
+function serverIdForUrlOrigin(origin: string): string | null {
+  for (const server of serverRegistry.servers) {
+    try {
+      if (new URL(server.url).origin === origin) {
+        return server.id;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+function routeSuffix(url: URL): string {
+  return `${url.search}${url.hash}`;
+}
+
+function roomPath(
+  serverId: string,
+  roomId: string,
+  suffix: string,
+  options: MessageBodyChatLinkOptions
+): string {
+  const serverSegment = options.serverSegmentForId?.(serverId) ?? serverIdToSegment(serverId);
+  return `${resolve('/chat/[serverId]/[roomId]', { serverId: serverSegment, roomId })}${suffix}`;
+}
+
+function threadPath(
+  serverId: string,
+  roomId: string,
+  threadRootEventId: string,
+  suffix: string,
+  options: MessageBodyChatLinkOptions
+): string {
+  const serverSegment = options.serverSegmentForId?.(serverId) ?? serverIdToSegment(serverId);
+  return `${resolve('/chat/[serverId]/[roomId]/[threadId]', {
+    serverId: serverSegment,
+    roomId,
+    threadId: threadRootEventId
+  })}${suffix}`;
+}
+
+function messagePath(
+  serverId: string,
+  roomId: string,
+  messageId: string,
+  suffix: string,
+  options: MessageBodyChatLinkOptions
+): string {
+  const serverSegment = options.serverSegmentForId?.(serverId) ?? serverIdToSegment(serverId);
+  return `${resolve('/chat/[serverId]/[roomId]/m/[messageId]', {
+    serverId: serverSegment,
+    roomId,
+    messageId
+  })}${suffix}`;
+}
+
+function resolveChatLinkServerId(
+  url: URL,
+  serverSegment: string,
+  origin: string,
+  options: MessageBodyChatLinkOptions
+): string | null {
+  const resolveServerSegment = options.resolveServerSegment ?? segmentToServerId;
+
+  if (url.origin === origin) {
+    return resolveServerSegment(serverSegment);
+  }
+
+  const resolveUrlOrigin = options.resolveUrlOrigin ?? serverIdForUrlOrigin;
+  const urlOriginServerId = resolveUrlOrigin(url.origin);
+  if (!urlOriginServerId) return null;
+
+  if (serverSegment === '-') {
+    return urlOriginServerId;
+  }
+
+  return resolveServerSegment(serverSegment);
 }
 
 export function buildMessageLinkPath(serverId: string, roomId: string, messageId: string): string {
@@ -100,9 +183,9 @@ export async function copyMessageLinkToClipboard(
 /**
  * Classify message-body URLs that may navigate in the current tab.
  *
- * This deliberately allows only same-origin Chatto room, thread, and message
- * URLs with Chatto-looking IDs. Other same-origin URLs, such as settings or
- * admin pages, should keep opening out-of-band like external links.
+ * This deliberately allows only registered-server Chatto room, thread, and
+ * message URLs with Chatto-looking IDs. Other URLs, such as settings or admin
+ * pages, should keep opening out-of-band like external links.
  */
 export function classifyMessageBodyChatLink(
   input: string,
@@ -119,8 +202,6 @@ export function classifyMessageBodyChatLink(
     return null;
   }
 
-  if (url.origin !== origin) return null;
-
   const parts = url.pathname.split('/').filter(Boolean);
   if (parts[0] !== 'chat') return null;
   if (parts.length !== 3 && parts.length !== 4 && parts.length !== 5) return null;
@@ -128,14 +209,20 @@ export function classifyMessageBodyChatLink(
   const [, serverSegment, roomId] = parts;
   if (!serverSegment || !isMessageRoomId(roomId)) return null;
 
-  const resolveServerSegment = options.resolveServerSegment ?? segmentToServerId;
-  const serverId = resolveServerSegment(serverSegment);
+  const serverId = resolveChatLinkServerId(url, serverSegment, origin, options);
   if (!serverId) return null;
 
-  const path = `${url.pathname}${url.search}${url.hash}`;
+  const suffix = routeSuffix(url);
+  const localServerSegment = options.serverSegmentForId?.(serverId) ?? serverIdToSegment(serverId);
 
   if (parts.length === 3) {
-    return { kind: 'room', serverSegment, serverId, roomId, path };
+    return {
+      kind: 'room',
+      serverSegment: localServerSegment,
+      serverId,
+      roomId,
+      path: roomPath(serverId, roomId, suffix, options)
+    };
   }
 
   if (parts.length === 4) {
@@ -143,17 +230,24 @@ export function classifyMessageBodyChatLink(
     if (!eventIdPattern.test(threadRootEventId)) return null;
     return {
       kind: 'thread',
-      serverSegment,
+      serverSegment: localServerSegment,
       serverId,
       roomId,
       threadRootEventId,
-      path
+      path: threadPath(serverId, roomId, threadRootEventId, suffix, options)
     };
   }
 
   const [, , , marker, messageId] = parts;
   if (marker !== 'm' || !eventIdPattern.test(messageId)) return null;
-  return { kind: 'message', serverSegment, serverId, roomId, messageId, path };
+  return {
+    kind: 'message',
+    serverSegment: localServerSegment,
+    serverId,
+    roomId,
+    messageId,
+    path: messagePath(serverId, roomId, messageId, suffix, options)
+  };
 }
 
 /**

--- a/apps/frontend/src/lib/navigation/roomLinkAccess.spec.ts
+++ b/apps/frontend/src/lib/navigation/roomLinkAccess.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { RoomType } from '$lib/render/types';
+import type { RoomsListItem } from '$lib/state/server/rooms.svelte';
+import { roomLinkAccessRedirect } from './roomLinkAccess';
+
+function room(overrides: Partial<RoomsListItem> = {}): RoomsListItem {
+  return {
+    id: 'room-1',
+    name: 'general',
+    type: RoomType.Channel,
+    isUniversal: false,
+    hasUnread: false,
+    viewerIsMember: true,
+    viewerCanJoinRoom: true,
+    viewerNotificationCount: 0,
+    members: [],
+    ...overrides
+  };
+}
+
+describe('roomLinkAccessRedirect', () => {
+  it('allows access when the viewer is already a member', () => {
+    expect(
+      roomLinkAccessRedirect({
+        rooms: [room()],
+        roomId: 'room-1',
+        targetPath: '/chat/-/room-1',
+        fallbackPath: '/chat/-'
+      })
+    ).toEqual({ kind: 'allow' });
+  });
+
+  it('allows unknown rooms to fall through to room data loading', () => {
+    expect(
+      roomLinkAccessRedirect({
+        rooms: [],
+        roomId: 'room-1',
+        targetPath: '/chat/-/room-1',
+        fallbackPath: '/chat/-'
+      })
+    ).toEqual({ kind: 'allow' });
+  });
+
+  it('redirects nonmember rooms with a join modal and original target', () => {
+    expect(
+      roomLinkAccessRedirect({
+        rooms: [room({ viewerIsMember: false })],
+        roomId: 'room-1',
+        targetPath: '/chat/-/room-1/m/message-1',
+        fallbackPath: '/chat/-'
+      })
+    ).toEqual({
+      kind: 'redirect',
+      path: '/chat/-',
+      state: {
+        modal: {
+          type: 'joinRoom',
+          roomId: 'room-1',
+          roomName: 'general',
+          viewerCanJoinRoom: true,
+          afterJoinPath: '/chat/-/room-1/m/message-1',
+          closePath: '/chat/-'
+        }
+      }
+    });
+  });
+
+  it('uses the same modal shape for non-joinable rooms', () => {
+    expect(
+      roomLinkAccessRedirect({
+        rooms: [room({ viewerIsMember: false, viewerCanJoinRoom: false })],
+        roomId: 'room-1',
+        targetPath: '/chat/-/room-1',
+        fallbackPath: '/chat/-'
+      })
+    ).toMatchObject({
+      kind: 'redirect',
+      state: {
+        modal: {
+          type: 'joinRoom',
+          viewerCanJoinRoom: false
+        }
+      }
+    });
+  });
+});

--- a/apps/frontend/src/lib/navigation/roomLinkAccess.ts
+++ b/apps/frontend/src/lib/navigation/roomLinkAccess.ts
@@ -1,0 +1,45 @@
+import type { RoomsListItem } from '$lib/state/server/rooms.svelte';
+
+export type RoomLinkAccessRedirect =
+  | {
+      kind: 'allow';
+    }
+  | {
+      kind: 'redirect';
+      path: string;
+      state: App.PageState;
+    };
+
+export interface RoomLinkAccessOptions {
+  rooms: readonly RoomsListItem[];
+  roomId: string;
+  targetPath: string;
+  fallbackPath: string;
+}
+
+export function roomLinkAccessRedirect(options: RoomLinkAccessOptions): RoomLinkAccessRedirect {
+  const room = options.rooms.find((candidate) => candidate.id === options.roomId);
+
+  if (!room) {
+    return { kind: 'allow' };
+  }
+
+  if (room.viewerIsMember) {
+    return { kind: 'allow' };
+  }
+
+  return {
+    kind: 'redirect',
+    path: options.fallbackPath,
+    state: {
+      modal: {
+        type: 'joinRoom',
+        roomId: room.id,
+        roomName: room.name,
+        viewerCanJoinRoom: room.viewerCanJoinRoom,
+        afterJoinPath: options.targetPath,
+        closePath: options.fallbackPath
+      }
+    }
+  };
+}

--- a/apps/frontend/src/routes/chat/ModalContainer.svelte
+++ b/apps/frontend/src/routes/chat/ModalContainer.svelte
@@ -27,6 +27,12 @@
   import { notifyRoomMessageMutated } from '$lib/state/room/messageMutationEvents';
 
   function closeModal() {
+    const closePath = page.state.modal?.closePath;
+    if (closePath) {
+      // eslint-disable-next-line svelte/no-navigation-without-resolve -- closePath is set by route guards from resolved app routes.
+      goto(closePath, { replaceState: true });
+      return;
+    }
     history.back();
   }
 
@@ -104,6 +110,12 @@
         : m['room.join.success_generic']()
     );
     await stores.rooms.refresh();
+    const afterJoinPath = page.state.modal?.afterJoinPath;
+    if (afterJoinPath) {
+      // eslint-disable-next-line svelte/no-navigation-without-resolve -- afterJoinPath is set by route guards from resolved app routes.
+      goto(afterJoinPath);
+      return;
+    }
     goto(resolve('/chat/[serverId]/[roomId]', { serverId: serverSegment, roomId }));
   }
 

--- a/apps/frontend/src/routes/chat/ModalContainer.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/ModalContainer.svelte.spec.ts
@@ -235,6 +235,43 @@ describe('ModalContainer join room modal', () => {
     });
   });
 
+  it('joins and navigates to a deep-link target when provided', async () => {
+    mocks.modal = {
+      type: 'joinRoom',
+      roomId: 'room-1',
+      roomName: 'general',
+      viewerCanJoinRoom: true,
+      afterJoinPath: '/chat/-/room-1/m/message-1',
+      closePath: '/chat/-'
+    };
+
+    const { container } = render(ModalContainer);
+    (q(container, 'button[type="submit"]') as HTMLButtonElement).click();
+
+    await vi.waitFor(() => {
+      expect(mocks.joinRoom).toHaveBeenCalledWith('room-1');
+      expect(mocks.refreshRooms).toHaveBeenCalledOnce();
+      expect(mocks.goto).toHaveBeenCalledWith('/chat/-/room-1/m/message-1');
+    });
+  });
+
+  it('closes deep-link join prompts to their fallback path', async () => {
+    mocks.modal = {
+      type: 'joinRoom',
+      roomId: 'room-1',
+      roomName: 'general',
+      viewerCanJoinRoom: true,
+      afterJoinPath: '/chat/-/room-1/m/message-1',
+      closePath: '/chat/-'
+    };
+
+    const { container } = render(ModalContainer);
+    clickButton(container, 'Cancel');
+
+    expect(mocks.goto).toHaveBeenCalledWith('/chat/-', { replaceState: true });
+    expect(window.history.back).not.toHaveBeenCalled();
+  });
+
   it('shows an error toast when joining fails', async () => {
     mocks.joinRoom.mockResolvedValue({ ok: false, error: new Error('denied') });
 

--- a/apps/frontend/src/routes/chat/ModalContainerConfirmDialogMock.svelte
+++ b/apps/frontend/src/routes/chat/ModalContainerConfirmDialogMock.svelte
@@ -10,16 +10,21 @@ Tiny test double for ConfirmDialog used by ModalContainer specs.
     children,
     title,
     actionLabel,
-    onconfirm
+    onconfirm,
+    onclose
   }: {
     children: Snippet;
     title: string;
     actionLabel: string;
     onconfirm: () => void;
+    onclose?: () => void;
   } = $props();
 </script>
 
 <dialog open aria-label={title}>
   <div>{@render children()}</div>
+  {#if onclose}
+    <button type="button" onclick={onclose}>Cancel</button>
+  {/if}
   <button type="submit" onclick={onconfirm}>{actionLabel}</button>
 </dialog>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/+layout.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/+layout.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
+  import { goto } from '$app/navigation';
+  import { resolve } from '$app/paths';
   import { page } from '$app/state';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
+  import { roomLinkAccessRedirect } from '$lib/navigation/roomLinkAccess';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import Room from './Room.svelte';
 
@@ -16,13 +19,37 @@
   // decided whether the room exists, briefly showing the not-found redirect.
   const roomsStore = $derived(serverRegistry.getStore(activeServerId).rooms);
   const ready = $derived(!roomsStore.isInitialLoading);
+  const fallbackPath = $derived(resolve('/chat/[serverId]', { serverId: data.serverSegment }));
+  const targetPath = $derived(`${page.url.pathname}${page.url.search}${page.url.hash}`);
 
   let threadId = $derived(page.params.threadId);
 
   const isMessageLinkMode = $derived(/\/m\/[^/]+$/.test(page.url.pathname));
+  const roomAccess = $derived.by(() => {
+    if (!ready || !roomId) return { kind: 'allow' } as const;
+    return roomLinkAccessRedirect({
+      rooms: roomsStore.rooms,
+      roomId,
+      targetPath,
+      fallbackPath
+    });
+  });
+  const canRenderRoom = $derived(ready && roomId && roomAccess.kind === 'allow');
+
+  let lastAccessRedirectKey = $state<string | null>(null);
+
+  $effect(() => {
+    if (!ready || !roomId || roomAccess.kind !== 'redirect') return;
+
+    const key = JSON.stringify([roomAccess.path, roomAccess.state]);
+    if (lastAccessRedirectKey === key) return;
+    lastAccessRedirectKey = key;
+    // eslint-disable-next-line svelte/no-navigation-without-resolve -- roomAccess.path is the resolved server fallback path.
+    goto(roomAccess.path, { replaceState: true, state: roomAccess.state });
+  });
 </script>
 
-{#if ready && roomId}
+{#if canRenderRoom && roomId}
   {#if isMessageLinkMode}
     <!-- Message link resolver: renders +page.svelte which fetches + redirects -->
     {@render children?.()}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomRouteLayoutRoomMock.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomRouteLayoutRoomMock.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  let { roomId, threadId }: { roomId: string; threadId?: string } = $props();
+</script>
+
+<div data-testid="room-layout-room" data-room-id={roomId} data-thread-id={threadId ?? ''}></div>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/room-route.layout.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/room-route.layout.svelte.spec.ts
@@ -1,0 +1,152 @@
+import { tick } from 'svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { q, testSnippet } from '$lib/test-utils';
+import { RoomType } from '$lib/render/types';
+import type { RoomsListItem } from '$lib/state/server/rooms.svelte';
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    goto: vi.fn(),
+    page: {
+      params: { serverId: '-', roomId: 'room-1' } as Record<string, string | undefined>,
+      state: {},
+      url: new URL('https://chat.example.test/chat/-/room-1')
+    },
+    roomsStore: {
+      rooms: [] as RoomsListItem[],
+      isInitialLoading: false
+    }
+  }
+}));
+
+vi.mock('$app/state', () => ({
+  page: mocks.page
+}));
+
+vi.mock('$app/navigation', () => ({
+  goto: mocks.goto
+}));
+
+vi.mock('$app/paths', () => ({
+  resolve: (path: string, params?: Record<string, string>) =>
+    path
+      .replace('[serverId]', params?.serverId ?? '')
+      .replace('[roomId]', params?.roomId ?? '')
+      .replace('[threadId]', params?.threadId ?? '')
+      .replace('[messageId]', params?.messageId ?? '')
+}));
+
+vi.mock('$lib/state/activeServer.svelte', () => ({
+  getActiveServer: () => 'origin'
+}));
+
+vi.mock('$lib/state/server/registry.svelte', () => ({
+  serverRegistry: {
+    getStore: () => ({
+      rooms: mocks.roomsStore
+    })
+  }
+}));
+
+vi.mock('./Room.svelte', async () => {
+  const { default: RoomMock } = await import('./RoomRouteLayoutRoomMock.svelte');
+  return { default: RoomMock };
+});
+
+import Layout from './+layout.svelte';
+
+function room(overrides: Partial<RoomsListItem> = {}): RoomsListItem {
+  return {
+    id: 'room-1',
+    name: 'development',
+    type: RoomType.Channel,
+    isUniversal: false,
+    hasUnread: false,
+    viewerIsMember: true,
+    viewerCanJoinRoom: true,
+    viewerNotificationCount: 0,
+    members: [],
+    ...overrides
+  };
+}
+
+function renderLayout() {
+  return render(Layout, {
+    props: {
+      data: {
+        user: null,
+        serverInfo: null,
+        serverInfoLoaded: true,
+        serverSegment: '-',
+        roomId: 'room-1'
+      },
+      children: testSnippet('<div data-testid="message-resolver"></div>')
+    }
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.page.params = { serverId: '-', roomId: 'room-1' };
+  mocks.page.state = {};
+  mocks.page.url = new URL('https://chat.example.test/chat/-/room-1');
+  mocks.roomsStore.rooms = [room()];
+  mocks.roomsStore.isInitialLoading = false;
+});
+
+describe('room route layout access handling', () => {
+  it('renders the room without redirecting when the viewer is already a member', async () => {
+    const { container } = renderLayout();
+
+    await tick();
+
+    expect(mocks.goto).not.toHaveBeenCalled();
+    expect(q(container, '[data-testid="room-layout-room"]')?.dataset.roomId).toBe('room-1');
+  });
+
+  it('opens the join modal for a room deep link when the viewer is not a member', async () => {
+    mocks.roomsStore.rooms = [room({ viewerIsMember: false })];
+
+    renderLayout();
+
+    await vi.waitFor(() => {
+      expect(mocks.goto).toHaveBeenCalledWith('/chat/-', {
+        replaceState: true,
+        state: {
+          modal: {
+            type: 'joinRoom',
+            roomId: 'room-1',
+            roomName: 'development',
+            viewerCanJoinRoom: true,
+            afterJoinPath: '/chat/-/room-1',
+            closePath: '/chat/-'
+          }
+        }
+      });
+    });
+  });
+
+  it('opens the join modal with the original message link target for message deep links', async () => {
+    mocks.page.url = new URL('https://chat.example.test/chat/-/room-1/m/Eabc123DEF456gh');
+    mocks.roomsStore.rooms = [room({ viewerIsMember: false })];
+
+    renderLayout();
+
+    await vi.waitFor(() => {
+      expect(mocks.goto).toHaveBeenCalledWith('/chat/-', {
+        replaceState: true,
+        state: {
+          modal: {
+            type: 'joinRoom',
+            roomId: 'room-1',
+            roomName: 'development',
+            viewerCanJoinRoom: true,
+            afterJoinPath: '/chat/-/room-1/m/Eabc123DEF456gh',
+            closePath: '/chat/-'
+          }
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes Chatto room and message link handling so registered-server Chatto URLs stay in-app and deep links to rooms the viewer has not joined open the existing join/access prompt.

Raw markdown links now share the same registered-server route mapping as preview-card navigation, and join prompts preserve the original room or message target after a successful join.

Added focused classifier, markdown click, modal, helper, and route-layout tests for the new behavior.

## Verification

- `mise test-frontend`
- `mise lint-frontend`
- `mise license-check`
- `mise x -- pnpm exec playwright test e2e/server-flows.test.ts e2e/realtime-protobuf.test.ts --retries=0`
