### PR TITLE
fix(frontend): unify user card presence source

### DIFF
--- a/apps/frontend/messages/de/settings.json
+++ b/apps/frontend/messages/de/settings.json
@@ -97,6 +97,7 @@
         "auto": "Online",
         "away": "Abwesend",
         "do_not_disturb": "Nicht stören",
+        "offline": "Offline",
         "invisible": "Offline anzeigen"
       },
       "saved": "Profil erfolgreich aktualisiert",

--- a/apps/frontend/messages/en/settings.json
+++ b/apps/frontend/messages/en/settings.json
@@ -97,6 +97,7 @@
         "auto": "Online",
         "away": "Away",
         "do_not_disturb": "Do Not Disturb",
+        "offline": "Offline",
         "invisible": "Look offline"
       },
       "saved": "Profile updated successfully",

--- a/apps/frontend/src/lib/RoomList.svelte.spec.ts
+++ b/apps/frontend/src/lib/RoomList.svelte.spec.ts
@@ -132,7 +132,7 @@ vi.mock('$lib/state/appUi.svelte', () => ({
 
 vi.mock('$lib/state/presenceCache.svelte', () => ({
   getPresenceCache: () => ({
-    get: (_userId: string, fallback: string) => fallback
+    get: (_scope: { serverId: string; userId: string }, fallback: string) => fallback
   })
 }));
 

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte
@@ -16,7 +16,8 @@ to the user settings page for the active server.
   import { getLiveDisplayName, type CustomUserStatus } from '$lib/state/userProfiles.svelte';
   import { setPresenceMode } from '$lib/presenceTracking';
   import { presencePreference, type PresenceMode } from '$lib/state/presencePreference.svelte';
-  import { RoomType } from '$lib/render/types';
+  import { PresenceStatus, RoomType } from '$lib/render/types';
+  import { getPresenceCache } from '$lib/state/presenceCache.svelte';
   import {
     roomSidebarPanelStorageSuffix,
     setPendingRoomSidebarPanel,
@@ -32,6 +33,7 @@ to the user settings page for the active server.
   import UserCustomStatusEditor from './UserCustomStatusEditor.svelte';
 
   const connection = useConnection();
+  const presenceCache = getPresenceCache();
   const activeServerId = $derived(getActiveServer());
   const serverSegment = $derived(serverIdToSegment(activeServerId));
   const activeStore = $derived(serverRegistry.tryGetStore(activeServerId));
@@ -75,7 +77,14 @@ to the user settings page for the active server.
   const compactCallDangerButtonClass = 'btn-danger h-10 w-10 shrink-0 !px-0 !py-0 text-xs';
   const isTouch = isTouchDevice();
   const presenceModes: PresenceMode[] = ['auto', 'away', 'doNotDisturb', 'invisible'];
-  const presenceLabel = $derived.by(() => presenceModeLabel(presencePreference.mode));
+  const currentPresence = $derived.by(() => {
+    if (!activeServerUser) return PresenceStatus.Offline;
+    return presenceCache.get(
+      { serverId: activeServerId, userId: activeServerUser.id },
+      activeServerUser.presenceStatus
+    );
+  });
+  const presenceLabel = $derived.by(() => presenceStatusLabel(currentPresence));
   let statusMenuAnchor = $state<{ top: number; bottom: number; left: number } | null>(null);
   let customStatusDialogVisible = $state(false);
 
@@ -101,6 +110,19 @@ to the user settings page for the active server.
         return m['settings.profile.presence.do_not_disturb']();
       case 'invisible':
         return m['settings.profile.presence.invisible']();
+      default:
+        return m['settings.profile.presence.auto']();
+    }
+  }
+
+  function presenceStatusLabel(status: PresenceStatus): string {
+    switch (status) {
+      case PresenceStatus.Away:
+        return m['settings.profile.presence.away']();
+      case PresenceStatus.DoNotDisturb:
+        return m['settings.profile.presence.do_not_disturb']();
+      case PresenceStatus.Offline:
+        return m['settings.profile.presence.offline']();
       default:
         return m['settings.profile.presence.auto']();
     }
@@ -289,7 +311,6 @@ to the user settings page for the active server.
           user={activeServerUser}
           size="sm"
           showPresence
-          presenceOverride={presencePreference.effectiveStatus}
         />
       </button>
       <div

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
@@ -171,6 +171,35 @@ describe('CurrentUserBar', () => {
     expect(container.textContent).toContain('@alice');
   });
 
+  it('uses the presence cache instead of local presence preference for the current user dot', () => {
+    presencePreference.effectiveStatus = PresenceStatus.Away;
+
+    const { container } = render(CurrentUserBarTestHarness);
+
+    expect(q(container, '[aria-label="Presence: Online"]')).toBeTruthy();
+    const presenceDot = q(
+      container,
+      '[data-testid="current-user-presence-menu"] [aria-label="Online"] span'
+    )!;
+    expect(presenceDot.className).toContain('bg-presence-online');
+    expect(presenceDot.className).not.toContain('bg-presence-away');
+  });
+
+  it('renders the current user dot from the seeded away presence cache value', () => {
+    presencePreference.effectiveStatus = PresenceStatus.Online;
+
+    const { container } = render(CurrentUserBarTestHarness, {
+      cachedPresence: PresenceStatus.Away
+    });
+
+    expect(q(container, '[aria-label="Presence: Away"]')).toBeTruthy();
+    const presenceDot = q(
+      container,
+      '[data-testid="current-user-presence-menu"] [aria-label="Away"] span'
+    )!;
+    expect(presenceDot.className).toContain('bg-presence-away');
+  });
+
   it('keeps the username line when display name and username match', () => {
     currentUserState.user = {
       ...currentUserState.user!,

--- a/apps/frontend/src/lib/components/CurrentUserBarTestHarness.svelte
+++ b/apps/frontend/src/lib/components/CurrentUserBarTestHarness.svelte
@@ -9,8 +9,11 @@ before the bar mounts so specs can exercise first-login presence fallbacks.
   import { createPresenceCache } from '$lib/state/presenceCache.svelte';
   import CurrentUserBar from './CurrentUserBar.svelte';
 
+  let { cachedPresence = PresenceStatus.Online }: { cachedPresence?: PresenceStatus } = $props();
+
   const presenceCache = createPresenceCache();
-  presenceCache.update('user-1', PresenceStatus.Online);
+  // svelte-ignore state_referenced_locally
+  presenceCache.update({ serverId: 'origin', userId: 'user-1' }, cachedPresence);
 </script>
 
 <CurrentUserBar />

--- a/apps/frontend/src/lib/components/QuickSwitcher.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/QuickSwitcher.svelte.spec.ts
@@ -89,7 +89,7 @@ vi.mock('$lib/state/recentQuickSwitcher.svelte', () => ({
 
 vi.mock('$lib/state/presenceCache.svelte', () => ({
   getPresenceCache: () => ({
-    get: (_userId: string, fallback: string) => fallback
+    get: (_scope: { serverId: string; userId: string }, fallback: string) => fallback
   })
 }));
 

--- a/apps/frontend/src/lib/components/UserAvatar.svelte
+++ b/apps/frontend/src/lib/components/UserAvatar.svelte
@@ -6,6 +6,7 @@
 
 <script lang="ts">
   import { PresenceStatus, type UserAvatarUserView } from '$lib/render/types';
+  import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { getLiveAvatarUrl, getLiveCustomStatus } from '$lib/state/userProfiles.svelte';
   import { getPresenceCache } from '$lib/state/presenceCache.svelte';
   import { getAvatarInitials } from '$lib/utils/initials';
@@ -65,19 +66,18 @@
     user,
     size = 'md',
     showPresence = false,
-    presenceOverride = null,
     showStatus = false,
     class: className = ''
   }: {
     user: AvatarUser;
     size?: Size;
     showPresence?: boolean;
-    presenceOverride?: PresenceStatus | null;
     showStatus?: boolean;
     class?: string;
   } = $props();
 
   const presenceCache = getPresenceCache();
+  const serverId = $derived(getActiveServer());
 
   // Guard all derived computations against null user — during tab resume/reconnect,
   // fragment data can be transiently null. An unguarded crash here poisons Svelte 5's
@@ -93,7 +93,7 @@
   // newly-mounted ones like popovers — see the latest presence immediately.
   const presence = $derived.by(() => {
     if (!user || user.deleted) return undefined;
-    return presenceOverride ?? presenceCache.get(user.id, user.presenceStatus);
+    return presenceCache.get({ serverId, userId: user.id }, user.presenceStatus);
   });
 
   const customStatus = $derived(

--- a/apps/frontend/src/lib/components/chat/ServerEventProvider.svelte
+++ b/apps/frontend/src/lib/components/chat/ServerEventProvider.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
   import { provideEventBus } from '$lib/eventBus.svelte';
   import { usePresenceChange, useReconnectCallback } from '$lib/hooks';
+  import { presencePreference } from '$lib/state/presencePreference.svelte';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
-  import { getPresenceCache } from '$lib/state/presenceCache.svelte';
+  import {
+    authenticatedCurrentUserPresenceEntries,
+    getPresenceCache
+  } from '$lib/state/presenceCache.svelte';
+  import { serverRegistry } from '$lib/state/server/registry.svelte';
   import type { Snippet } from 'svelte';
 
   let { children }: { children: Snippet } = $props();
@@ -27,14 +32,32 @@
   // Clear presence cache after WebSocket reconnection
   useReconnectCallback(() => {
     console.log('WebSocket reconnected, clearing presence cache');
-    presenceCache.clear();
+    presenceCache.clear(
+      authenticatedCurrentUserPresenceEntries(
+        currentUserPresenceStores(),
+        presencePreference.effectiveStatus
+      )
+    );
   });
 
   // Populate global presence cache from server events so that any UserAvatar
   // (including newly-mounted ones like popovers) sees the latest presence.
   usePresenceChange((userId, status) => {
-    presenceCache.update(userId, status);
+    presenceCache.update({ serverId: getActiveServer(), userId }, status);
   });
+
+  function currentUserPresenceStores() {
+    return serverRegistry.servers.map((server) => {
+      const store = serverRegistry.tryGetStore(server.id);
+      return store
+        ? {
+            serverId: server.id,
+            isAuthenticated: store.isAuthenticated,
+            currentUser: store.currentUser
+          }
+        : null;
+    });
+  }
 </script>
 
 <div data-testid="server-subscription-active" class="hidden"></div>

--- a/apps/frontend/src/lib/components/menus/UserContextMenu.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/menus/UserContextMenu.svelte.spec.ts
@@ -17,7 +17,7 @@ vi.mock('$lib/state/userProfiles.svelte', () => ({
 
 vi.mock('$lib/state/presenceCache.svelte', () => ({
   getPresenceCache: () => ({
-    get: (_userId: string, fallback: string) => fallback
+    get: (_scope: { serverId: string; userId: string }, fallback: string) => fallback
   })
 }));
 

--- a/apps/frontend/src/lib/i18n/messages.ts
+++ b/apps/frontend/src/lib/i18n/messages.ts
@@ -181,6 +181,7 @@ const msg_settings_profile_presence_title = (): LocalizedString => messages().se
 const msg_settings_profile_presence_auto = (): LocalizedString => messages().settings_profile_presence_auto(empty());
 const msg_settings_profile_presence_away = (): LocalizedString => messages().settings_profile_presence_away(empty());
 const msg_settings_profile_presence_do_not_disturb = (): LocalizedString => messages().settings_profile_presence_do_not_disturb(empty());
+const msg_settings_profile_presence_offline = (): LocalizedString => messages().settings_profile_presence_offline(empty());
 const msg_settings_profile_presence_invisible = (): LocalizedString => messages().settings_profile_presence_invisible(empty());
 const msg_settings_profile_saved = (): LocalizedString => messages().settings_profile_saved(empty());
 const msg_settings_profile_save_failed = (): LocalizedString => messages().settings_profile_save_failed(empty());
@@ -1595,6 +1596,7 @@ export { msg_settings_profile_presence_title as 'settings.profile.presence.title
 export { msg_settings_profile_presence_auto as 'settings.profile.presence.auto' };
 export { msg_settings_profile_presence_away as 'settings.profile.presence.away' };
 export { msg_settings_profile_presence_do_not_disturb as 'settings.profile.presence.do_not_disturb' };
+export { msg_settings_profile_presence_offline as 'settings.profile.presence.offline' };
 export { msg_settings_profile_presence_invisible as 'settings.profile.presence.invisible' };
 export { msg_settings_profile_saved as 'settings.profile.saved' };
 export { msg_settings_profile_save_failed as 'settings.profile.save_failed' };

--- a/apps/frontend/src/lib/state/presenceCache.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/presenceCache.svelte.spec.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import { PresenceStatus } from '$lib/render/types';
+import {
+  authenticatedCurrentUserPresenceEntries,
+  PresenceCache,
+  updateAuthenticatedCurrentUserPresenceEntries
+} from './presenceCache.svelte';
+
+describe('PresenceCache', () => {
+  it('isolates entries by server id and user id', () => {
+    const cache = new PresenceCache();
+
+    cache.update({ serverId: 'origin', userId: 'same-user-id' }, PresenceStatus.Away);
+    cache.update({ serverId: 'remote', userId: 'same-user-id' }, PresenceStatus.DoNotDisturb);
+
+    expect(cache.get({ serverId: 'origin', userId: 'same-user-id' }, PresenceStatus.Online)).toBe(
+      PresenceStatus.Away
+    );
+    expect(cache.get({ serverId: 'remote', userId: 'same-user-id' }, PresenceStatus.Online)).toBe(
+      PresenceStatus.DoNotDisturb
+    );
+  });
+
+  it('clears stale entries while retaining provided current-user presence', () => {
+    const cache = new PresenceCache();
+    cache.update({ serverId: 'origin', userId: 'current-user' }, PresenceStatus.Online);
+    cache.update({ serverId: 'origin', userId: 'other-user' }, PresenceStatus.Away);
+
+    cache.clear([
+      [{ serverId: 'origin', userId: 'current-user' }, PresenceStatus.DoNotDisturb]
+    ]);
+
+    expect(cache.get({ serverId: 'origin', userId: 'current-user' }, PresenceStatus.Online)).toBe(
+      PresenceStatus.DoNotDisturb
+    );
+    expect(cache.get({ serverId: 'origin', userId: 'other-user' }, PresenceStatus.Online)).toBe(
+      PresenceStatus.Online
+    );
+  });
+
+  it('updates current-user presence entries across authenticated servers', () => {
+    const cache = new PresenceCache();
+    const lateStore = {
+      serverId: 'late-remote',
+      isAuthenticated: true,
+      currentUser: { user: null as { id: string } | null }
+    };
+    cache.update({ serverId: 'origin', userId: 'origin-user' }, PresenceStatus.Online);
+    cache.update({ serverId: 'remote', userId: 'remote-user' }, PresenceStatus.Online);
+    cache.update({ serverId: 'late-remote', userId: 'late-remote-user' }, PresenceStatus.Online);
+    cache.update({ serverId: 'signed-out', userId: 'signed-out-user' }, PresenceStatus.Online);
+
+    updateAuthenticatedCurrentUserPresenceEntries(
+      cache,
+      [
+        {
+          serverId: 'origin',
+          isAuthenticated: true,
+          currentUser: { user: { id: 'origin-user' } }
+        },
+        {
+          serverId: 'remote',
+          isAuthenticated: true,
+          currentUser: { user: { id: 'remote-user' } }
+        },
+        {
+          serverId: 'signed-out',
+          isAuthenticated: false,
+          currentUser: { user: { id: 'signed-out-user' } }
+        },
+        lateStore
+      ],
+      PresenceStatus.Offline
+    );
+
+    expect(cache.get({ serverId: 'origin', userId: 'origin-user' }, PresenceStatus.Online)).toBe(
+      PresenceStatus.Offline
+    );
+    expect(cache.get({ serverId: 'remote', userId: 'remote-user' }, PresenceStatus.Online)).toBe(
+      PresenceStatus.Offline
+    );
+    expect(
+      cache.get({ serverId: 'late-remote', userId: 'late-remote-user' }, PresenceStatus.Away)
+    ).toBe(PresenceStatus.Online);
+    expect(
+      cache.get({ serverId: 'signed-out', userId: 'signed-out-user' }, PresenceStatus.Away)
+    ).toBe(PresenceStatus.Online);
+
+    lateStore.currentUser.user = { id: 'late-remote-user' };
+    updateAuthenticatedCurrentUserPresenceEntries(cache, [lateStore], PresenceStatus.Offline);
+
+    expect(
+      cache.get({ serverId: 'late-remote', userId: 'late-remote-user' }, PresenceStatus.Online)
+    ).toBe(PresenceStatus.Offline);
+  });
+
+  it('retains all authenticated current-user entries when clearing stale presence', () => {
+    const cache = new PresenceCache();
+    const stores = [
+      {
+        serverId: 'origin',
+        isAuthenticated: true,
+        currentUser: { user: { id: 'origin-user' } }
+      },
+      {
+        serverId: 'remote',
+        isAuthenticated: true,
+        currentUser: { user: { id: 'remote-user' } }
+      },
+      {
+        serverId: 'signed-out',
+        isAuthenticated: false,
+        currentUser: { user: { id: 'signed-out-user' } }
+      }
+    ];
+
+    cache.update({ serverId: 'origin', userId: 'origin-user' }, PresenceStatus.Online);
+    cache.update({ serverId: 'remote', userId: 'remote-user' }, PresenceStatus.Online);
+    cache.update({ serverId: 'signed-out', userId: 'signed-out-user' }, PresenceStatus.Online);
+    cache.update({ serverId: 'origin', userId: 'other-user' }, PresenceStatus.Away);
+
+    cache.clear(authenticatedCurrentUserPresenceEntries(stores, PresenceStatus.DoNotDisturb));
+
+    expect(cache.get({ serverId: 'origin', userId: 'origin-user' }, PresenceStatus.Online)).toBe(
+      PresenceStatus.DoNotDisturb
+    );
+    expect(cache.get({ serverId: 'remote', userId: 'remote-user' }, PresenceStatus.Online)).toBe(
+      PresenceStatus.DoNotDisturb
+    );
+    expect(
+      cache.get({ serverId: 'signed-out', userId: 'signed-out-user' }, PresenceStatus.Away)
+    ).toBe(PresenceStatus.Away);
+    expect(cache.get({ serverId: 'origin', userId: 'other-user' }, PresenceStatus.Online)).toBe(
+      PresenceStatus.Online
+    );
+  });
+});

--- a/apps/frontend/src/lib/state/presenceCache.svelte.ts
+++ b/apps/frontend/src/lib/state/presenceCache.svelte.ts
@@ -2,39 +2,78 @@ import { createContext } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 import type { PresenceStatus } from '$lib/render/types';
 
+export type PresenceCacheScope = {
+  serverId: string;
+  userId: string;
+};
+
 /**
- * Global cache for live user presence updates.
+ * Server-scoped cache for live user presence updates.
  *
- * Solves the problem where newly-mounted UserAvatar components (e.g., in popovers)
- * show stale presence from the initial server snapshot because they missed earlier
- * PresenceChangedEvents. By writing all presence updates to a shared cache,
- * any component can read the most recently observed status at mount time.
- *
- * The chat layout calls createPresenceCache() during initialization,
- * ServerEventProvider populates it, and components read via get().
+ * Presence is server-wide, not global across Chatto servers. A user can have
+ * different ids on different servers, and two servers can also contain the
+ * same user id string. Cache entries therefore include both server id and user
+ * id so avatar dots always read the presence for the active server.
  */
 export class PresenceCache {
   #entries = new SvelteMap<string, PresenceStatus>();
   #version = $state(0);
 
-  update(userId: string, status: PresenceStatus) {
-    this.#entries.set(userId, status);
+  update(scope: PresenceCacheScope, status: PresenceStatus) {
+    this.#entries.set(presenceCacheKey(scope), status);
     this.#version++;
   }
 
-  clear() {
+  clear(retainedEntries: Iterable<readonly [PresenceCacheScope, PresenceStatus]> = []) {
     this.#entries.clear();
+    for (const [scope, status] of retainedEntries) {
+      this.#entries.set(presenceCacheKey(scope), status);
+    }
     this.#version++;
   }
 
-  get(userId: string, fallback: PresenceStatus): PresenceStatus {
+  get(scope: PresenceCacheScope, fallback: PresenceStatus): PresenceStatus {
     void this.#version;
-    return this.#entries.get(userId) ?? fallback;
+    return this.#entries.get(presenceCacheKey(scope)) ?? fallback;
   }
 
   get version() {
     return this.#version;
   }
+}
+
+export type PresenceCacheCurrentUserStore = {
+  serverId: string;
+  isAuthenticated: boolean;
+  currentUser: {
+    user?: { id: string } | null;
+  };
+};
+
+export function authenticatedCurrentUserPresenceEntries(
+  stores: Iterable<PresenceCacheCurrentUserStore | undefined | null>,
+  status: PresenceStatus
+): Array<readonly [PresenceCacheScope, PresenceStatus]> {
+  const entries: Array<readonly [PresenceCacheScope, PresenceStatus]> = [];
+  for (const store of stores) {
+    if (!store?.isAuthenticated || !store.currentUser.user) continue;
+    entries.push([{ serverId: store.serverId, userId: store.currentUser.user.id }, status]);
+  }
+  return entries;
+}
+
+export function updateAuthenticatedCurrentUserPresenceEntries(
+  presenceCache: PresenceCache,
+  stores: Iterable<PresenceCacheCurrentUserStore | undefined | null>,
+  status: PresenceStatus
+) {
+  for (const [scope, retainedStatus] of authenticatedCurrentUserPresenceEntries(stores, status)) {
+    presenceCache.update(scope, retainedStatus);
+  }
+}
+
+function presenceCacheKey({ serverId, userId }: PresenceCacheScope): string {
+  return `${serverId}\u0000${userId}`;
 }
 
 const [getCache, setCache] = createContext<PresenceCache>();

--- a/apps/frontend/src/lib/state/presenceCache.svelte.ts
+++ b/apps/frontend/src/lib/state/presenceCache.svelte.ts
@@ -1,4 +1,4 @@
-import { createContext } from 'svelte';
+import { createContext, untrack } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 import type { PresenceStatus } from '$lib/render/types';
 
@@ -20,16 +20,20 @@ export class PresenceCache {
   #version = $state(0);
 
   update(scope: PresenceCacheScope, status: PresenceStatus) {
-    this.#entries.set(presenceCacheKey(scope), status);
-    this.#version++;
+    untrack(() => {
+      this.#entries.set(presenceCacheKey(scope), status);
+      this.#version++;
+    });
   }
 
   clear(retainedEntries: Iterable<readonly [PresenceCacheScope, PresenceStatus]> = []) {
-    this.#entries.clear();
-    for (const [scope, status] of retainedEntries) {
-      this.#entries.set(presenceCacheKey(scope), status);
-    }
-    this.#version++;
+    untrack(() => {
+      this.#entries.clear();
+      for (const [scope, status] of retainedEntries) {
+        this.#entries.set(presenceCacheKey(scope), status);
+      }
+      this.#version++;
+    });
   }
 
   get(scope: PresenceCacheScope, fallback: PresenceStatus): PresenceStatus {

--- a/apps/frontend/src/routes/chat/AuthenticatedChatProvider.svelte
+++ b/apps/frontend/src/routes/chat/AuthenticatedChatProvider.svelte
@@ -2,7 +2,11 @@
   import { onDestroy, type Snippet } from 'svelte';
   import type { CurrentUser } from '$lib/auth/loadAuth';
   import { PresenceStatus } from '$lib/render/types';
-  import type { PresenceCache } from '$lib/state/presenceCache.svelte';
+  import {
+    updateAuthenticatedCurrentUserPresenceEntries,
+    type PresenceCache
+  } from '$lib/state/presenceCache.svelte';
+  import { presencePreference } from '$lib/state/presencePreference.svelte';
   import type { UserSettingsState } from '$lib/state/userSettings.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { serverConnectionManager } from '$lib/state/server/serverConnection.svelte';
@@ -70,7 +74,7 @@
     }
   });
   // svelte-ignore state_referenced_locally
-  presenceCache.update(user.id, PresenceStatus.Online);
+  presenceCache.update({ serverId: originServer.id, userId: user.id }, PresenceStatus.Online);
 
   // Initialize user settings from the user's settings data
   // svelte-ignore state_referenced_locally
@@ -181,9 +185,11 @@
           };
         }),
     (status) => {
-      if (currentUserState.user) {
-        presenceCache.update(currentUserState.user.id, status);
-      }
+      updateAuthenticatedCurrentUserPresenceEntries(
+        presenceCache,
+        currentUserPresenceStores(),
+        status
+      );
     },
     {
       onPauseLiveEvents: () => {
@@ -200,6 +206,27 @@
     }
   );
   onDestroy(stopPresenceTracking);
+
+  $effect(() => {
+    updateAuthenticatedCurrentUserPresenceEntries(
+      presenceCache,
+      currentUserPresenceStores(),
+      presencePreference.effectiveStatus
+    );
+  });
+
+  function currentUserPresenceStores() {
+    return serverRegistry.servers.map((server) => {
+      const store = serverRegistry.tryGetStore(server.id);
+      return store
+        ? {
+            serverId: server.id,
+            isAuthenticated: store.isAuthenticated,
+            currentUser: store.currentUser
+          }
+        : null;
+    });
+  }
 </script>
 
 <ReturnUrlHandler />

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
@@ -78,6 +78,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
 
   const connection = useConnection();
   const presenceCache = getPresenceCache();
+  const activeServerId = $derived(getActiveServer());
   const activeCallRooms = serverRegistry.getStore(getActiveServer()).activeCallRooms;
 
   const members = $derived(membersStore.filteredMembers);
@@ -130,7 +131,10 @@ calls, and similar room-specific panels can plug into the same shell. See the
 
   // Get effective presence for a member (live update or fall back to initial value)
   function getPresence(member: RoomMember): PresenceStatus {
-    return presenceCache.get(member.id, member.presenceStatus);
+    return presenceCache.get(
+      { serverId: activeServerId, userId: member.id },
+      member.presenceStatus
+    );
   }
 
   // Check if a presence status counts as "online" (connected to the system)

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -1334,13 +1334,13 @@ describe('RoomSidebar', () => {
     await vi.waitFor(() => {
       expect(presenceCache).toBeTruthy();
     });
-    presenceCache!.update(user.id, PresenceStatus.Away);
+    presenceCache!.update({ serverId: 'test-server', userId: user.id }, PresenceStatus.Away);
     await tick();
 
     expect(presenceBadge(container, 'Away')).toBeTruthy();
     expect(buttonByText(container, 'Online (1)')).toBeTruthy();
 
-    presenceCache!.update(user.id, PresenceStatus.Online);
+    presenceCache!.update({ serverId: 'test-server', userId: user.id }, PresenceStatus.Online);
     await tick();
 
     expect(presenceBadge(container, 'Online')).toBeTruthy();

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEvent.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEvent.svelte.spec.ts
@@ -12,7 +12,7 @@ vi.mock('$lib/state/userProfiles.svelte', () => ({
 
 vi.mock('$lib/state/presenceCache.svelte', () => ({
   getPresenceCache: () => ({
-    get: (_userId: string, fallback: unknown) => fallback
+    get: (_scope: { serverId: string; userId: string }, fallback: unknown) => fallback
   })
 }));
 


### PR DESCRIPTION
## Summary
- Make `PresenceCache` server-scoped with `{ serverId, userId }` keys so avatar dots cannot mix origin and remote-server presence.
- Read current-user and member-list avatar presence from the same scoped cache, and remove the `UserAvatar` presence override path.
- Seed and retain current-user presence entries for all authenticated origin and remote servers, including reconnect, invisible-mode, and late-loaded bearer-auth users.
- Prevent presence cache writes from self-subscribing to the cache version counter when they run inside reactive seeding effects.
- Add explicit English and German `Offline` labels for effective presence copy.

## Validation
- `mise x -- pnpm --dir apps/frontend exec vitest run src/lib/state/presenceCache.svelte.spec.ts src/lib/presenceTracking.spec.ts --browser.headless`
- `mise x -- pnpm --dir apps/frontend exec vitest run src/lib/components/CurrentUserBar.svelte.spec.ts src/lib/components/UserAvatar.svelte.spec.ts --browser.headless`
- `mise x -- pnpm --dir apps/frontend exec vitest run 'src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts' --browser.headless`
- `mise x -- pnpm --dir apps/frontend exec vitest run src/lib/RoomList.svelte.spec.ts src/lib/components/QuickSwitcher.svelte.spec.ts src/lib/components/menus/UserContextMenu.svelte.spec.ts 'src/routes/chat/[serverId]/[roomId]/SystemEvent.svelte.spec.ts' --browser.headless`
- `mise x -- pnpm --dir apps/frontend exec vitest run src/lib/state/presenceCache.svelte.spec.ts src/lib/presenceTracking.spec.ts src/lib/components/CurrentUserBar.svelte.spec.ts src/lib/components/UserAvatar.svelte.spec.ts --browser.headless`
- `mise x -- pnpm --dir apps/frontend exec playwright test e2e/quick-switcher.test.ts e2e/room-auto-join.test.ts --retries=0 --workers=1`
- `mise x -- pnpm --dir apps/frontend exec playwright test e2e/video-player.test.ts --retries=0 --workers=1`
- `mise lint-frontend`
