### PR TITLE
fix(frontend): render inline room join screen

### DIFF
--- a/apps/frontend/e2e/room-permissions.test.ts
+++ b/apps/frontend/e2e/room-permissions.test.ts
@@ -74,6 +74,10 @@ async function createRoomViaAPI(page: Page, name?: string): Promise<string> {
   return createRoomViaConnect(page, roomName, groupId);
 }
 
+function shortSuffix(): string {
+  return Date.now().toString(36).slice(-6);
+}
+
 async function getRoomByName(page: Page, roomName: string): Promise<string> {
   return getRoomIdByNameViaConnect(page, roomName);
 }
@@ -528,6 +532,59 @@ test.describe('Permission-only Resolution', () => {
       await expect(page.getByText('Hello from a regular member!')).toBeVisible();
     });
 
+    test('joining from an unjoined sidebar room shows inline join and enables posting', async ({
+      page,
+      roomPage
+    }) => {
+      await createAndLoginTestUser(page);
+      await usePrimaryServerViaAPI(page, `Inline Join ${Date.now()}`);
+      const roomId = await createRoomViaAPI(page, `inline-join-${Date.now()}`);
+
+      const member = await createSecondTestUser(page);
+      await logoutUser(page);
+      await loginUser(page, member.login, member.password);
+      await page.goto(routes.chat);
+
+      const roomLink = page.locator(`a[href="${routes.room(roomId)}"]`).first();
+      await expect(roomLink).toBeVisible();
+      await roomLink.click();
+
+      await expect(page).toHaveURL(new RegExp(`${routes.room(roomId)}$`));
+      await expect(page.getByRole('button', { name: 'Join Room' })).toBeVisible();
+      await expect(page.locator('dialog[open]')).toHaveCount(0);
+
+      await page.getByRole('button', { name: 'Join Room' }).click();
+      await expect(page.getByTestId('message-input')).toHaveAttribute('contenteditable', 'true');
+
+      const body = `Posted after inline join ${Date.now()}`;
+      await roomPage.sendMessage(body);
+      await expect(page.getByText(body)).toBeVisible();
+    });
+
+    test('message deep links to unjoined rooms preserve the target after inline join', async ({
+      page
+    }) => {
+      await createAndLoginTestUser(page);
+      await usePrimaryServerViaAPI(page, `Inline Message Link ${Date.now()}`);
+      const roomId = await createRoomViaAPI(page, `msg-link-${shortSuffix()}`);
+      await joinRoomViaAPI(page, roomId);
+      const targetBody = `Linked before join ${Date.now()}`;
+      const target = await postMessageViaAPI(page, roomId, targetBody);
+      expect(target).not.toBeNull();
+
+      const member = await createSecondTestUser(page);
+      await logoutUser(page);
+      await loginUser(page, member.login, member.password);
+
+      await page.goto(routes.messageLink(roomId, target!.id));
+      await expect(page.getByRole('button', { name: 'Join Room' })).toBeVisible();
+      await expect(page).toHaveURL(new RegExp(`${routes.messageLink(roomId, target!.id)}$`));
+
+      await page.getByRole('button', { name: 'Join Room' }).click();
+      await expect(page).toHaveURL(new RegExp(`${routes.room(roomId)}$`));
+      await expect(page.getByText(targetBody)).toBeVisible();
+    });
+
     test('muted members cannot post to #general (role denial wins)', async ({
       page,
       roomPage: _roomPage
@@ -796,6 +853,25 @@ test.describe('Permission-only Resolution', () => {
       // substring).
       await expect(row.getByText('Restricted', { exact: true })).toBeVisible();
       await expect(row.getByRole('button', { name: 'Join' })).toHaveCount(0);
+    });
+
+    test('restricted room direct links render inline access denial instead of a modal', async ({
+      page
+    }) => {
+      await createAndLoginTestUser(page);
+      await usePrimaryServerViaAPI(page);
+      const roomId = await createRoomViaAPI(page, `restrict-${shortSuffix()}`);
+      await denyRoomPermission(page, roomId, 'everyone', 'room.join');
+
+      const member = await createSecondTestUser(page);
+      await logoutUser(page);
+      await loginUser(page, member.login, member.password);
+
+      await page.goto(routes.room(roomId));
+      await expect(page.getByText('You do not have permission to join this room.')).toBeVisible();
+      await expect(page.getByRole('link', { name: 'Return to Server' })).toBeVisible();
+      await expect(page.locator('dialog[open]')).toHaveCount(0);
+      await expect(page.getByRole('button', { name: 'Join Room' })).toHaveCount(0);
     });
   });
 });

--- a/apps/frontend/messages/de/room.json
+++ b/apps/frontend/messages/de/room.json
@@ -20,6 +20,7 @@
       "title": "Raum beitreten",
       "action": "Raum beitreten",
       "prompt": "Tritt #{room} bei, um diesen Raum zu lesen und daran teilzunehmen.",
+      "inline_prompt": "Tritt diesem Raum bei, um ihn zu lesen und daran teilzunehmen.",
       "success": "#{room} beigetreten",
       "success_generic": "Raum beigetreten",
       "failed": "Raum konnte nicht beigetreten werden",

--- a/apps/frontend/messages/en/room.json
+++ b/apps/frontend/messages/en/room.json
@@ -20,6 +20,7 @@
       "title": "Join Room",
       "action": "Join Room",
       "prompt": "Join #{room} to read and participate in this room.",
+      "inline_prompt": "Join this room to read and participate.",
       "success": "Joined #{room}",
       "success_generic": "Joined room",
       "failed": "Failed to join room",

--- a/apps/frontend/src/app.d.ts
+++ b/apps/frontend/src/app.d.ts
@@ -12,7 +12,6 @@ declare global {
         type:
           | 'createRoom'
           | 'logout'
-          | 'joinRoom'
           | 'leaveRoom'
           | 'deleteMessage'
           | 'leaveServer'
@@ -22,9 +21,6 @@ declare global {
         spaceId?: string;
         roomId?: string;
         roomName?: string;
-        viewerCanJoinRoom?: boolean;
-        afterJoinPath?: string;
-        closePath?: string;
         spaceName?: string;
         eventId?: string;
         attachmentId?: string;

--- a/apps/frontend/src/lib/RoomList.svelte
+++ b/apps/frontend/src/lib/RoomList.svelte
@@ -5,7 +5,7 @@ Renders the room list in the server sidebar. When a room layout is configured,
 rooms are organized into collapsible sections. Otherwise, rooms display alphabetically.
 -->
 <script lang="ts">
-  import { goto, pushState } from '$app/navigation';
+  import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
   import { serverIdToSegment } from '$lib/navigation';
@@ -283,17 +283,6 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     roomsStore.setUnread(event.roomId);
   });
 
-  function openJoinRoomModal(room: RoomsListItem) {
-    pushState('', {
-      modal: {
-        type: 'joinRoom',
-        roomId: room.id,
-        roomName: room.name,
-        viewerCanJoinRoom: room.viewerCanJoinRoom
-      }
-    });
-  }
-
   function wasCallIconClick(event: MouseEvent): boolean {
     const target = event.target;
     return target instanceof Element && target.closest('[data-testid="room-call-icon"]') !== null;
@@ -312,13 +301,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   }
 
   function handleRoomLinkClick(event: MouseEvent, room: RoomsListItem): void {
-    if (!room.viewerIsMember) {
-      event.preventDefault();
-      openJoinRoomModal(room);
-      return;
-    }
-
-    if (activeCallRooms.has(room.id) && wasCallIconClick(event)) {
+    if (room.viewerIsMember && activeCallRooms.has(room.id) && wasCallIconClick(event)) {
       event.preventDefault();
       void openRoomCallPanel(room.id);
     }

--- a/apps/frontend/src/lib/RoomList.svelte.spec.ts
+++ b/apps/frontend/src/lib/RoomList.svelte.spec.ts
@@ -497,26 +497,21 @@ describe('RoomList', () => {
     }
   );
 
-  it('opens a join modal for a faded joinable non-member channel row', async () => {
+  it('lets faded joinable non-member channel rows navigate to the room route', async () => {
     const { container } = render(RoomList);
 
     const row = q(container, '[href="/chat/-/joinable-channel"]') as HTMLAnchorElement;
     await expect.element(row).toBeInTheDocument();
     expect(row.className).toContain('opacity-60');
 
-    row.click();
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    const wasNotCanceled = row.dispatchEvent(event);
 
-    expect(mocks.pushState).toHaveBeenCalledWith('', {
-      modal: {
-        type: 'joinRoom',
-        roomId: 'joinable-channel',
-        roomName: 'joinable',
-        viewerCanJoinRoom: true
-      }
-    });
+    expect(wasNotCanceled).toBe(true);
+    expect(mocks.pushState).not.toHaveBeenCalled();
   });
 
-  it('opens an access-info modal for a faded non-joinable channel row', async () => {
+  it('lets faded non-joinable channel rows navigate to the inline access screen', async () => {
     const { container } = render(RoomList);
 
     const row = q(container, '[href="/chat/-/restricted-channel"]') as HTMLAnchorElement;
@@ -526,16 +521,11 @@ describe('RoomList', () => {
     expect(icon?.classList.contains('uil--lock')).toBe(true);
     expect(row.querySelectorAll('.uil--lock')).toHaveLength(1);
 
-    row.click();
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    const wasNotCanceled = row.dispatchEvent(event);
 
-    expect(mocks.pushState).toHaveBeenCalledWith('', {
-      modal: {
-        type: 'joinRoom',
-        roomId: 'restricted-channel',
-        roomName: 'restricted',
-        viewerCanJoinRoom: false
-      }
-    });
+    expect(wasNotCanceled).toBe(true);
+    expect(mocks.pushState).not.toHaveBeenCalled();
   });
 
   it('renders unread channel rows and icons in full-contrast text', async () => {

--- a/apps/frontend/src/lib/i18n/messages.ts
+++ b/apps/frontend/src/lib/i18n/messages.ts
@@ -555,6 +555,7 @@ const msg_room_join_action = (): LocalizedString => messages().room_join_action(
 const msg_room_join_prompt = (
   inputs: Parameters<LocaleMessages['room_join_prompt']>[0]
 ): LocalizedString => messages().room_join_prompt(inputs);
+const msg_room_join_inline_prompt = (): LocalizedString => messages().room_join_inline_prompt(empty());
 const msg_room_join_success = (
   inputs: Parameters<LocaleMessages['room_join_success']>[0]
 ): LocalizedString => messages().room_join_success(inputs);
@@ -1931,6 +1932,7 @@ export { msg_room_create_submit as 'room.create.submit' };
 export { msg_room_join_title as 'room.join.title' };
 export { msg_room_join_action as 'room.join.action' };
 export { msg_room_join_prompt as 'room.join.prompt' };
+export { msg_room_join_inline_prompt as 'room.join.inline_prompt' };
 export { msg_room_join_success as 'room.join.success' };
 export { msg_room_join_success_generic as 'room.join.success_generic' };
 export { msg_room_join_failed as 'room.join.failed' };

--- a/apps/frontend/src/lib/navigation/roomLinkAccess.spec.ts
+++ b/apps/frontend/src/lib/navigation/roomLinkAccess.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { RoomType } from '$lib/render/types';
 import type { RoomsListItem } from '$lib/state/server/rooms.svelte';
-import { roomLinkAccessRedirect } from './roomLinkAccess';
+import { roomRouteAccess } from './roomLinkAccess';
 
 function room(overrides: Partial<RoomsListItem> = {}): RoomsListItem {
   return {
@@ -18,68 +18,47 @@ function room(overrides: Partial<RoomsListItem> = {}): RoomsListItem {
   };
 }
 
-describe('roomLinkAccessRedirect', () => {
-  it('allows access when the viewer is already a member', () => {
+describe('roomRouteAccess', () => {
+  it('classifies members as allowed room viewers', () => {
     expect(
-      roomLinkAccessRedirect({
+      roomRouteAccess({
         rooms: [room()],
-        roomId: 'room-1',
-        targetPath: '/chat/-/room-1',
-        fallbackPath: '/chat/-'
+        roomId: 'room-1'
       })
-    ).toEqual({ kind: 'allow' });
+    ).toEqual({ kind: 'member' });
   });
 
   it('allows unknown rooms to fall through to room data loading', () => {
     expect(
-      roomLinkAccessRedirect({
+      roomRouteAccess({
         rooms: [],
-        roomId: 'room-1',
-        targetPath: '/chat/-/room-1',
-        fallbackPath: '/chat/-'
+        roomId: 'room-1'
       })
-    ).toEqual({ kind: 'allow' });
+    ).toEqual({ kind: 'unknown' });
   });
 
-  it('redirects nonmember rooms with a join modal and original target', () => {
+  it('classifies joinable nonmember rooms for inline joining', () => {
     expect(
-      roomLinkAccessRedirect({
+      roomRouteAccess({
         rooms: [room({ viewerIsMember: false })],
-        roomId: 'room-1',
-        targetPath: '/chat/-/room-1/m/message-1',
-        fallbackPath: '/chat/-'
+        roomId: 'room-1'
       })
     ).toEqual({
-      kind: 'redirect',
-      path: '/chat/-',
-      state: {
-        modal: {
-          type: 'joinRoom',
-          roomId: 'room-1',
-          roomName: 'general',
-          viewerCanJoinRoom: true,
-          afterJoinPath: '/chat/-/room-1/m/message-1',
-          closePath: '/chat/-'
-        }
-      }
+      kind: 'nonmember',
+      room: room({ viewerIsMember: false })
     });
   });
 
-  it('uses the same modal shape for non-joinable rooms', () => {
+  it('classifies restricted nonmember rooms for inline access denial', () => {
     expect(
-      roomLinkAccessRedirect({
+      roomRouteAccess({
         rooms: [room({ viewerIsMember: false, viewerCanJoinRoom: false })],
-        roomId: 'room-1',
-        targetPath: '/chat/-/room-1',
-        fallbackPath: '/chat/-'
+        roomId: 'room-1'
       })
     ).toMatchObject({
-      kind: 'redirect',
-      state: {
-        modal: {
-          type: 'joinRoom',
-          viewerCanJoinRoom: false
-        }
+      kind: 'nonmember',
+      room: {
+        viewerCanJoinRoom: false
       }
     });
   });

--- a/apps/frontend/src/lib/navigation/roomLinkAccess.ts
+++ b/apps/frontend/src/lib/navigation/roomLinkAccess.ts
@@ -1,45 +1,29 @@
 import type { RoomsListItem } from '$lib/state/server/rooms.svelte';
 
-export type RoomLinkAccessRedirect =
+export type RoomRouteAccess =
   | {
-      kind: 'allow';
+      kind: 'unknown' | 'member';
     }
   | {
-      kind: 'redirect';
-      path: string;
-      state: App.PageState;
+      kind: 'nonmember';
+      room: RoomsListItem;
     };
 
 export interface RoomLinkAccessOptions {
   rooms: readonly RoomsListItem[];
   roomId: string;
-  targetPath: string;
-  fallbackPath: string;
 }
 
-export function roomLinkAccessRedirect(options: RoomLinkAccessOptions): RoomLinkAccessRedirect {
+export function roomRouteAccess(options: RoomLinkAccessOptions): RoomRouteAccess {
   const room = options.rooms.find((candidate) => candidate.id === options.roomId);
 
   if (!room) {
-    return { kind: 'allow' };
+    return { kind: 'unknown' };
   }
 
   if (room.viewerIsMember) {
-    return { kind: 'allow' };
+    return { kind: 'member' };
   }
 
-  return {
-    kind: 'redirect',
-    path: options.fallbackPath,
-    state: {
-      modal: {
-        type: 'joinRoom',
-        roomId: room.id,
-        roomName: room.name,
-        viewerCanJoinRoom: room.viewerCanJoinRoom,
-        afterJoinPath: options.targetPath,
-        closePath: options.fallbackPath
-      }
-    }
-  };
+  return { kind: 'nonmember', room };
 }

--- a/apps/frontend/src/routes/chat/ModalContainer.svelte
+++ b/apps/frontend/src/routes/chat/ModalContainer.svelte
@@ -13,7 +13,6 @@
   const serverSegment = $derived(serverIdToSegment(activeInstanceId));
   import Dialog from '$lib/ui/Dialog.svelte';
   import ConfirmDialog from '$lib/ui/ConfirmDialog.svelte';
-  import { Button } from '$lib/ui/form';
   import CreateRoom from '$lib/CreateRoom.svelte';
   import { createRoomCommandAPI } from '$lib/api-client/rooms';
   import { createMessageAPI } from '$lib/api-client/messages';
@@ -27,12 +26,6 @@
   import { notifyRoomMessageMutated } from '$lib/state/room/messageMutationEvents';
 
   function closeModal() {
-    const closePath = page.state.modal?.closePath;
-    if (closePath) {
-      // eslint-disable-next-line svelte/no-navigation-without-resolve -- closePath is set by route guards from resolved app routes.
-      goto(closePath, { replaceState: true });
-      return;
-    }
     history.back();
   }
 
@@ -59,7 +52,6 @@
   }
 
   let leavingRoom = $state(false);
-  let joiningRoom = $state(false);
   let leavingServer = $state(false);
   let deletingMessage = $state(false);
   let deletingLinkPreview = $state(false);
@@ -89,34 +81,6 @@
 
     clearLastRoom(activeInstanceId);
     goto(resolve('/chat/[serverId]', { serverId: serverSegment }));
-  }
-
-  async function handleJoinRoom(roomId: string) {
-    joiningRoom = true;
-    const stores = serverRegistry.getStore(activeInstanceId);
-    const result = await stores.roomDirectory.joinRoom(roomId);
-    joiningRoom = false;
-
-    if (!result.ok) {
-      toast.error(m['room.join.failed']());
-      console.error('Error joining room:', result.error);
-      closeModal();
-      return;
-    }
-
-    toast.success(
-      result.room
-        ? m['room.join.success']({ room: result.room.name })
-        : m['room.join.success_generic']()
-    );
-    await stores.rooms.refresh();
-    const afterJoinPath = page.state.modal?.afterJoinPath;
-    if (afterJoinPath) {
-      // eslint-disable-next-line svelte/no-navigation-without-resolve -- afterJoinPath is set by route guards from resolved app routes.
-      goto(afterJoinPath);
-      return;
-    }
-    goto(resolve('/chat/[serverId]/[roomId]', { serverId: serverSegment, roomId }));
   }
 
   async function handleLeaveServer() {
@@ -275,33 +239,6 @@
   </Dialog>
 {:else if modalType === 'logout'}
   <SignOutDialog onclose={closeModal} />
-{:else if modalType === 'joinRoom' && roomId}
-  {#if page.state.modal?.viewerCanJoinRoom}
-    <ConfirmDialog
-      title={m['room.join.title']()}
-      tone="info"
-      actionLabel={m['room.join.action']()}
-      actionIcon="iconify uil--plus"
-      loading={joiningRoom}
-      onconfirm={() => handleJoinRoom(roomId)}
-      onclose={closeModal}
-    >
-      {m['room.join.prompt']({ room: roomName ?? '' })}
-    </ConfirmDialog>
-  {:else}
-    <Dialog visible title={m['room.join.access_title']()} size="sm" onclose={closeModal}>
-      {#snippet footer()}
-        <div class="flex justify-end">
-          <Button variant="accent" onclick={closeModal}>
-            <span class="iconify uil--check"></span>
-            {m['common.got_it']()}
-          </Button>
-        </div>
-      {/snippet}
-
-      <p class="text-muted">{m['room.join.access_denied']()}</p>
-    </Dialog>
-  {/if}
 {:else if modalType === 'leaveRoom' && roomId}
   <ConfirmDialog
     title={m['room.leave.title']()}

--- a/apps/frontend/src/routes/chat/ModalContainer.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/ModalContainer.svelte.spec.ts
@@ -5,20 +5,15 @@ import { q } from '$lib/test-utils';
 const { mocks } = vi.hoisted(() => ({
   mocks: {
     modal: {
-      type: 'joinRoom',
-      roomId: 'room-1',
-      roomName: 'general',
-      viewerCanJoinRoom: true
+      type: 'logout'
     } as Record<string, unknown> | undefined,
     closeModal: vi.fn(),
     goto: vi.fn(),
     toastSuccess: vi.fn(),
     toastError: vi.fn(),
-    joinRoom: vi.fn(),
     deleteMessage: vi.fn(),
     deleteAttachment: vi.fn(),
     deleteLinkPreview: vi.fn(),
-    refreshRooms: vi.fn(),
     mutation: vi.fn(() => ({
       toPromise: () => Promise.resolve({ data: {}, error: null })
     })),
@@ -76,14 +71,6 @@ vi.mock('$lib/state/activeServer.svelte', () => ({
 
 vi.mock('$lib/state/server/registry.svelte', () => ({
   serverRegistry: {
-    getStore: vi.fn(() => ({
-      roomDirectory: {
-        joinRoom: mocks.joinRoom
-      },
-      rooms: {
-        refresh: mocks.refreshRooms
-      }
-    })),
     getServer: vi.fn((id: string) => mocks.servers.find((server) => server.id === id)),
     isOriginServer: vi.fn((id: string) => mocks.originServer?.id === id),
     isAuthenticated: vi.fn((id: string) => mocks.authenticated[id] === true),
@@ -190,19 +177,14 @@ function clickButton(container: HTMLElement, label: string): void {
 beforeEach(() => {
   vi.spyOn(window.history, 'back').mockImplementation(() => undefined);
   mocks.modal = {
-    type: 'joinRoom',
-    roomId: 'room-1',
-    roomName: 'general',
-    viewerCanJoinRoom: true
+    type: 'logout'
   };
-  mocks.joinRoom.mockResolvedValue({ ok: true, room: { id: 'room-1', name: 'general' } });
   mocks.deleteMessage.mockResolvedValue(true);
   mocks.deleteAttachment.mockResolvedValue(true);
   mocks.deleteLinkPreview.mockResolvedValue(true);
   mocks.mutation.mockReturnValue({
     toPromise: () => Promise.resolve({ data: {}, error: null })
   });
-  mocks.refreshRooms.mockResolvedValue(undefined);
   mocks.signOutServer.mockResolvedValue(new Response('{}', { status: 200 }));
   mocks.signOutServers.mockResolvedValue(undefined);
   mocks.activeServer = 'origin';
@@ -216,95 +198,6 @@ beforeEach(() => {
   mocks.servers = [mocks.originServer];
   mocks.authenticated = { origin: true };
   vi.clearAllMocks();
-});
-
-describe('ModalContainer join room modal', () => {
-  it('joins and navigates from a joinable room modal', async () => {
-    const { container } = render(ModalContainer);
-
-    await expect
-      .element(q(container, 'dialog'))
-      .toHaveTextContent('Join #general to read and participate in this room.');
-    (q(container, 'button[type="submit"]') as HTMLButtonElement).click();
-
-    await vi.waitFor(() => {
-      expect(mocks.joinRoom).toHaveBeenCalledWith('room-1');
-      expect(mocks.refreshRooms).toHaveBeenCalledOnce();
-      expect(mocks.toastSuccess).toHaveBeenCalledWith('Joined #general');
-      expect(mocks.goto).toHaveBeenCalledWith('/chat/-/room-1');
-    });
-  });
-
-  it('joins and navigates to a deep-link target when provided', async () => {
-    mocks.modal = {
-      type: 'joinRoom',
-      roomId: 'room-1',
-      roomName: 'general',
-      viewerCanJoinRoom: true,
-      afterJoinPath: '/chat/-/room-1/m/message-1',
-      closePath: '/chat/-'
-    };
-
-    const { container } = render(ModalContainer);
-    (q(container, 'button[type="submit"]') as HTMLButtonElement).click();
-
-    await vi.waitFor(() => {
-      expect(mocks.joinRoom).toHaveBeenCalledWith('room-1');
-      expect(mocks.refreshRooms).toHaveBeenCalledOnce();
-      expect(mocks.goto).toHaveBeenCalledWith('/chat/-/room-1/m/message-1');
-    });
-  });
-
-  it('closes deep-link join prompts to their fallback path', async () => {
-    mocks.modal = {
-      type: 'joinRoom',
-      roomId: 'room-1',
-      roomName: 'general',
-      viewerCanJoinRoom: true,
-      afterJoinPath: '/chat/-/room-1/m/message-1',
-      closePath: '/chat/-'
-    };
-
-    const { container } = render(ModalContainer);
-    clickButton(container, 'Cancel');
-
-    expect(mocks.goto).toHaveBeenCalledWith('/chat/-', { replaceState: true });
-    expect(window.history.back).not.toHaveBeenCalled();
-  });
-
-  it('shows an error toast when joining fails', async () => {
-    mocks.joinRoom.mockResolvedValue({ ok: false, error: new Error('denied') });
-
-    const { container } = render(ModalContainer);
-    (q(container, 'button[type="submit"]') as HTMLButtonElement).click();
-
-    await vi.waitFor(() => {
-      expect(mocks.toastError).toHaveBeenCalledWith('Failed to join room');
-      expect(mocks.refreshRooms).not.toHaveBeenCalled();
-      expect(mocks.goto).not.toHaveBeenCalled();
-    });
-  });
-
-  it('renders a non-mutating access message for non-joinable rooms', async () => {
-    mocks.modal = {
-      type: 'joinRoom',
-      roomId: 'room-1',
-      roomName: 'private',
-      viewerCanJoinRoom: false
-    };
-
-    const { container } = render(ModalContainer);
-
-    await expect
-      .element(q(container, 'dialog'))
-      .toHaveTextContent('You do not have permission to join this room.');
-    expect(
-      [...container.querySelectorAll('button')].map((button) => button.textContent?.trim())
-    ).toEqual(['Got it']);
-    (q(container, 'button') as HTMLButtonElement).click();
-
-    expect(mocks.joinRoom).not.toHaveBeenCalled();
-  });
 });
 
 describe('ModalContainer sign out modal', () => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/+layout.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/+layout.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
-  import { resolve } from '$app/paths';
   import { page } from '$app/state';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
-  import { roomLinkAccessRedirect } from '$lib/navigation/roomLinkAccess';
+  import { roomRouteAccess } from '$lib/navigation/roomLinkAccess';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import Room from './Room.svelte';
+  import RoomJoinScreen from './RoomJoinScreen.svelte';
 
   let { data, children } = $props();
 
@@ -19,37 +18,25 @@
   // decided whether the room exists, briefly showing the not-found redirect.
   const roomsStore = $derived(serverRegistry.getStore(activeServerId).rooms);
   const ready = $derived(!roomsStore.isInitialLoading);
-  const fallbackPath = $derived(resolve('/chat/[serverId]', { serverId: data.serverSegment }));
-  const targetPath = $derived(`${page.url.pathname}${page.url.search}${page.url.hash}`);
 
   let threadId = $derived(page.params.threadId);
 
   const isMessageLinkMode = $derived(/\/m\/[^/]+$/.test(page.url.pathname));
   const roomAccess = $derived.by(() => {
-    if (!ready || !roomId) return { kind: 'allow' } as const;
-    return roomLinkAccessRedirect({
+    if (!ready || !roomId) return { kind: 'unknown' } as const;
+    return roomRouteAccess({
       rooms: roomsStore.rooms,
-      roomId,
-      targetPath,
-      fallbackPath
+      roomId
     });
   });
-  const canRenderRoom = $derived(ready && roomId && roomAccess.kind === 'allow');
-
-  let lastAccessRedirectKey = $state<string | null>(null);
-
-  $effect(() => {
-    if (!ready || !roomId || roomAccess.kind !== 'redirect') return;
-
-    const key = JSON.stringify([roomAccess.path, roomAccess.state]);
-    if (lastAccessRedirectKey === key) return;
-    lastAccessRedirectKey = key;
-    // eslint-disable-next-line svelte/no-navigation-without-resolve -- roomAccess.path is the resolved server fallback path.
-    goto(roomAccess.path, { replaceState: true, state: roomAccess.state });
-  });
+  const canRenderRoom = $derived(
+    ready && roomId && (roomAccess.kind === 'member' || roomAccess.kind === 'unknown')
+  );
 </script>
 
-{#if canRenderRoom && roomId}
+{#if ready && roomId && roomAccess.kind === 'nonmember'}
+  <RoomJoinScreen room={roomAccess.room} serverSegment={data.serverSegment} />
+{:else if canRenderRoom && roomId}
   {#if isMessageLinkMode}
     <!-- Message link resolver: renders +page.svelte which fetches + redirects -->
     {@render children?.()}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts
@@ -115,6 +115,11 @@ describe('MessageMetaBar', () => {
     });
 
     const link = q(container, 'a[href="/chat/-/room-1/thread-1"]') as HTMLAnchorElement;
+    let preventedByComponent: boolean | undefined;
+    link.addEventListener('click', (event) => {
+      preventedByComponent = event.defaultPrevented;
+      event.preventDefault();
+    });
     const event = new MouseEvent('click', {
       bubbles: true,
       cancelable: true,
@@ -122,10 +127,9 @@ describe('MessageMetaBar', () => {
       metaKey: true
     });
 
-    const allowed = link.dispatchEvent(event);
+    link.dispatchEvent(event);
 
-    expect(allowed).toBe(true);
-    expect(event.defaultPrevented).toBe(false);
+    expect(preventedByComponent).toBe(false);
     expect(onOpenThread).not.toHaveBeenCalled();
   });
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomJoinScreen.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomJoinScreen.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import * as m from '$lib/i18n/messages';
+  import { getActiveServer } from '$lib/state/activeServer.svelte';
+  import { serverRegistry } from '$lib/state/server/registry.svelte';
+  import { Button } from '$lib/ui/form';
+  import { toast } from '$lib/ui/toast';
+  import PageTitle from '$lib/ui/PageTitle.svelte';
+  import type { RoomsListItem } from '$lib/state/server/rooms.svelte';
+
+  let {
+    room,
+    serverSegment
+  }: {
+    room: RoomsListItem;
+    serverSegment: string;
+  } = $props();
+
+  const activeServerId = $derived(getActiveServer());
+  const stores = $derived(serverRegistry.getStore(activeServerId));
+  const overviewPath = $derived(resolve('/chat/[serverId]', { serverId: serverSegment }));
+  const title = $derived(`#${room.name}`);
+  let joining = $state(false);
+
+  async function joinRoom(): Promise<void> {
+    if (joining || !room.viewerCanJoinRoom) return;
+
+    joining = true;
+    try {
+      const result = await stores.roomDirectory.joinRoom(room.id);
+
+      if (!result.ok) {
+        toast.error(m['room.join.failed']());
+        console.error('Error joining room:', result.error);
+        return;
+      }
+
+      toast.success(
+        result.room
+          ? m['room.join.success']({ room: result.room.name })
+          : m['room.join.success_generic']()
+      );
+      await stores.rooms.refresh();
+    } finally {
+      joining = false;
+    }
+  }
+</script>
+
+<PageTitle {title} />
+
+<section class="flex min-h-0 min-w-0 flex-1 items-center justify-center bg-background px-6 py-10">
+  <div class="flex w-full max-w-md flex-col items-center text-center">
+    <div
+      class={[
+        'mb-5 flex h-12 w-12 items-center justify-center rounded-full border',
+        room.viewerCanJoinRoom
+          ? 'border-primary/30 bg-primary/10 text-primary'
+          : 'border-border bg-surface text-muted'
+      ]}
+      aria-hidden="true"
+    >
+      {#if room.viewerCanJoinRoom}
+        <span class="iconify uil--plus text-2xl"></span>
+      {:else}
+        <span class="iconify uil--lock text-2xl"></span>
+      {/if}
+    </div>
+
+    <h1 class="text-2xl font-semibold text-text">
+      {title}
+    </h1>
+    <p class="mt-3 text-base leading-7 text-muted">
+      {#if room.viewerCanJoinRoom}
+        {m['room.join.inline_prompt']()}
+      {:else}
+        {m['room.join.access_denied']()}
+      {/if}
+    </p>
+
+    <div class="mt-6 flex flex-wrap justify-center gap-2">
+      {#if room.viewerCanJoinRoom}
+        <Button loading={joining} onclick={() => void joinRoom()}>
+          <span class="iconify uil--plus"></span>
+          {m['room.join.action']()}
+        </Button>
+      {:else}
+        <Button href={overviewPath} variant="secondary">
+          <span class="iconify uil--arrow-left"></span>
+          {m['ui.access_denied.back_to_server']()}
+        </Button>
+      {/if}
+    </div>
+  </div>
+</section>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/room-route.layout.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/room-route.layout.svelte.spec.ts
@@ -16,7 +16,11 @@ const { mocks } = vi.hoisted(() => ({
     roomsStore: {
       rooms: [] as RoomsListItem[],
       isInitialLoading: false
-    }
+    },
+    joinRoom: vi.fn(),
+    refreshRooms: vi.fn(),
+    toastSuccess: vi.fn(),
+    toastError: vi.fn()
   }
 }));
 
@@ -44,8 +48,26 @@ vi.mock('$lib/state/activeServer.svelte', () => ({
 vi.mock('$lib/state/server/registry.svelte', () => ({
   serverRegistry: {
     getStore: () => ({
-      rooms: mocks.roomsStore
+      rooms: {
+        get rooms() {
+          return mocks.roomsStore.rooms;
+        },
+        get isInitialLoading() {
+          return mocks.roomsStore.isInitialLoading;
+        },
+        refresh: mocks.refreshRooms
+      },
+      roomDirectory: {
+        joinRoom: mocks.joinRoom
+      }
     })
+  }
+}));
+
+vi.mock('$lib/ui/toast', () => ({
+  toast: {
+    success: mocks.toastSuccess,
+    error: mocks.toastError
   }
 }));
 
@@ -93,6 +115,8 @@ beforeEach(() => {
   mocks.page.url = new URL('https://chat.example.test/chat/-/room-1');
   mocks.roomsStore.rooms = [room()];
   mocks.roomsStore.isInitialLoading = false;
+  mocks.joinRoom.mockResolvedValue({ ok: true, room: { id: 'room-1', name: 'development' } });
+  mocks.refreshRooms.mockResolvedValue(undefined);
 });
 
 describe('room route layout access handling', () => {
@@ -105,48 +129,72 @@ describe('room route layout access handling', () => {
     expect(q(container, '[data-testid="room-layout-room"]')?.dataset.roomId).toBe('room-1');
   });
 
-  it('opens the join modal for a room deep link when the viewer is not a member', async () => {
+  it('renders an inline join screen for a room deep link when the viewer is not a member', async () => {
     mocks.roomsStore.rooms = [room({ viewerIsMember: false })];
 
-    renderLayout();
+    const { container } = renderLayout();
 
-    await vi.waitFor(() => {
-      expect(mocks.goto).toHaveBeenCalledWith('/chat/-', {
-        replaceState: true,
-        state: {
-          modal: {
-            type: 'joinRoom',
-            roomId: 'room-1',
-            roomName: 'development',
-            viewerCanJoinRoom: true,
-            afterJoinPath: '/chat/-/room-1',
-            closePath: '/chat/-'
-          }
-        }
-      });
-    });
+    await expect.element(q(container, 'h1')).toHaveTextContent('#development');
+    await expect
+      .element(q(container, 'section'))
+      .toHaveTextContent('Join this room to read and participate.');
+    expect(q(container, '[data-testid="room-layout-room"]')).toBeNull();
+    expect(mocks.goto).not.toHaveBeenCalled();
   });
 
-  it('opens the join modal with the original message link target for message deep links', async () => {
+  it('renders the inline join screen instead of the message resolver for nonmember message links', async () => {
     mocks.page.url = new URL('https://chat.example.test/chat/-/room-1/m/Eabc123DEF456gh');
     mocks.roomsStore.rooms = [room({ viewerIsMember: false })];
 
-    renderLayout();
+    const { container } = renderLayout();
+
+    await expect.element(q(container, 'h1')).toHaveTextContent('#development');
+    await expect
+      .element(q(container, 'section'))
+      .toHaveTextContent('Join this room to read and participate.');
+    expect(q(container, '[data-testid="message-resolver"]')).toBeNull();
+    expect(mocks.goto).not.toHaveBeenCalled();
+  });
+
+  it('joins a nonmember room inline and refreshes room membership without changing URLs', async () => {
+    mocks.roomsStore.rooms = [room({ viewerIsMember: false })];
+
+    const { container } = renderLayout();
+    (q(container, 'button') as HTMLButtonElement).click();
 
     await vi.waitFor(() => {
-      expect(mocks.goto).toHaveBeenCalledWith('/chat/-', {
-        replaceState: true,
-        state: {
-          modal: {
-            type: 'joinRoom',
-            roomId: 'room-1',
-            roomName: 'development',
-            viewerCanJoinRoom: true,
-            afterJoinPath: '/chat/-/room-1/m/Eabc123DEF456gh',
-            closePath: '/chat/-'
-          }
-        }
-      });
+      expect(mocks.joinRoom).toHaveBeenCalledWith('room-1');
+      expect(mocks.toastSuccess).toHaveBeenCalledWith('Joined #development');
+      expect(mocks.refreshRooms).toHaveBeenCalledOnce();
     });
+    expect(mocks.goto).not.toHaveBeenCalled();
+  });
+
+  it('renders inline access denial for restricted nonmember rooms', async () => {
+    mocks.roomsStore.rooms = [room({ viewerIsMember: false, viewerCanJoinRoom: false })];
+
+    const { container } = renderLayout();
+
+    await expect
+      .element(q(container, 'section'))
+      .toHaveTextContent('You do not have permission to join this room.');
+    await expect.element(q(container, 'a[href="/chat/-"]')).toHaveTextContent('Return to Server');
+    expect(q(container, 'button')).toBeNull();
+    expect(mocks.joinRoom).not.toHaveBeenCalled();
+    expect(mocks.goto).not.toHaveBeenCalled();
+  });
+
+  it('renders the target thread after joining has made the viewer a member', async () => {
+    mocks.page.params = { serverId: '-', roomId: 'room-1', threadId: 'Ethread123ABC456' };
+    mocks.page.url = new URL('https://chat.example.test/chat/-/room-1/Ethread123ABC456');
+    mocks.roomsStore.rooms = [room()];
+
+    const { container } = renderLayout();
+
+    await tick();
+
+    const renderedRoom = q(container, '[data-testid="room-layout-room"]') as HTMLElement;
+    expect(renderedRoom?.dataset.roomId).toBe('room-1');
+    expect(renderedRoom?.dataset.threadId).toBe('Ethread123ABC456');
   });
 });

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -3759,6 +3759,47 @@ func TestRoomServiceJoinRoomGroup(t *testing.T) {
 	}
 }
 
+func TestRoomServiceJoinRoomKeepsNormalPostingPermissions(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+
+	room, err := env.core.CreateRoom(env.ctx, env.viewer.Id, core.KindChannel, "", "join-posts", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	caller, err := env.core.CreateUser(env.ctx, core.SystemActorID, "join-posts-caller", "Join Posts Caller", "password")
+	if err != nil {
+		t.Fatalf("CreateUser caller: %v", err)
+	}
+	callerCtx := withCaller(env.ctx, caller)
+
+	if _, err := env.rooms.JoinRoom(callerCtx, connect.NewRequest(&apiv1.JoinRoomRequest{
+		RoomId: room.Id,
+	})); err != nil {
+		t.Fatalf("JoinRoom: %v", err)
+	}
+
+	getResp, err := env.directory.GetRoom(callerCtx, connect.NewRequest(&apiv1.GetRoomRequest{
+		RoomId: room.Id,
+	}))
+	if err != nil {
+		t.Fatalf("GetRoom: %v", err)
+	}
+	if !apiRoomPermissionGranted(getResp.Msg.GetRoom(), core.PermMessagePost) {
+		t.Fatalf("joined room message.post = false, room = %+v", getResp.Msg.GetRoom())
+	}
+
+	createResp, err := env.messages.CreateMessage(callerCtx, connect.NewRequest(&apiv1.CreateMessageRequest{
+		RoomId: room.Id,
+		Body:   "hello after joining",
+	}))
+	if err != nil {
+		t.Fatalf("CreateMessage after join: %v", err)
+	}
+	if createResp.Msg.GetMessage().GetBody() != "hello after joining" {
+		t.Fatalf("CreateMessage body = %q, want posted body", createResp.Msg.GetMessage().GetBody())
+	}
+}
+
 func TestUserServiceListUsers(t *testing.T) {
 	env := newConnectAPITestEnv(t)
 


### PR DESCRIPTION
## Summary

Replaces room-join modals for unjoined room, message, and thread links with an inline room view that keeps the user on the target URL and refreshes membership after joining.
Updates sidebar room clicks to navigate to that inline state, removes the deep-link modal state fields, and keeps restricted rooms on the room URL with inline access-denied copy.
Adds English and German i18n for the inline prompt, restores normal posting after joining by waiting for refreshed room state, and covers the permission regression with backend tests.

## Verification

Ran `git diff --check`, `mise license-check`, `mise test-frontend`, `mise test-cli`, targeted Vitest route/sidebar/modal/navigation tests, targeted Go Connect API tests, and targeted Playwright room-permission/link tests.
