### PR TITLE
fix(api): tolerate invalid presence user ids

### DIFF
--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -199,6 +199,18 @@ func TestRequireCaller(t *testing.T) {
 	})
 }
 
+func TestUserSummaryTreatsInvalidPresenceKeyAsOffline(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+
+	user, err := (&userService{api: env.api}).userSummary(env.ctx, core.DeletedUserReference("bad>"), nil)
+	if err != nil {
+		t.Fatalf("userSummary: %v", err)
+	}
+	if user.GetPresenceStatus() != apiv1.PresenceStatus_PRESENCE_STATUS_OFFLINE {
+		t.Fatalf("PresenceStatus = %v, want OFFLINE", user.GetPresenceStatus())
+	}
+}
+
 func TestPrivateHandlersRequireAuth(t *testing.T) {
 	api := New(nil, config.ChattoConfig{}, "test")
 	mux := http.NewServeMux()

--- a/cli/internal/core/presence.go
+++ b/cli/internal/core/presence.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/nats-io/nats.go/jetstream"
@@ -81,6 +82,10 @@ func parsePresenceKey(key string) (userID string, ok bool) {
 	return userID, true
 }
 
+func validPresenceUserID(userID string) bool {
+	return userID != "" && !strings.ContainsAny(userID, ".*>")
+}
+
 // ============================================================================
 // Presence Operations
 // ============================================================================
@@ -88,9 +93,12 @@ func parsePresenceKey(key string) (userID string, ok bool) {
 // GetUserPresence retrieves a user's current presence status.
 // Returns "OFFLINE" if the user has no presence entry (never connected or TTL expired).
 func (s *PresenceModel) GetUserPresence(ctx context.Context, userID string) (string, error) {
+	if !validPresenceUserID(userID) {
+		return PresenceStatusOffline, nil
+	}
 	entry, err := s.memoryCacheKV.Get(ctx, presenceKey(userID))
 	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
+		if errors.Is(err, jetstream.ErrKeyNotFound) || errors.Is(err, jetstream.ErrInvalidKey) {
 			return PresenceStatusOffline, nil
 		}
 		return PresenceStatusOffline, fmt.Errorf("failed to get presence: %w", err)

--- a/cli/internal/core/presence_model_test.go
+++ b/cli/internal/core/presence_model_test.go
@@ -128,6 +128,20 @@ func TestPresenceModelGetUserPresenceTreatsDeletesAndCorruptValuesAsOffline(t *t
 	}
 }
 
+func TestPresenceModelGetUserPresenceTreatsInvalidUserIDAsOffline(t *testing.T) {
+	service, _, _ := newTestPresenceModel(t)
+	ctx := testContext(t)
+
+	for _, userID := range []string{"", "bad>", ".bad", "bad."} {
+		t.Run(userID, func(t *testing.T) {
+			got, err := service.GetUserPresence(ctx, userID)
+			if err != nil || got != PresenceStatusOffline {
+				t.Fatalf("GetUserPresence(%q) = %q, %v; want %q, nil", userID, got, err, PresenceStatusOffline)
+			}
+		})
+	}
+}
+
 func TestPresenceModelRefreshMissingEntrySetsOnline(t *testing.T) {
 	service, _, _ := newTestPresenceModel(t)
 	ctx := testContext(t)


### PR DESCRIPTION
## Summary
- treat invalid presence user IDs as offline before reading the NATS KV bucket
- keep real presence storage failures propagating while avoiding 500s from invalid/tombstone user references in DM timelines
- add core and Connect API regressions for invalid presence keys during user summary hydration

## Validation
- `cd cli && mise x -- go test ./internal/core -run 'TestPresenceModelGetUserPresenceTreatsInvalidUserIDAsOffline|TestPresenceModelGetUserPresenceTreatsDeletesAndCorruptValuesAsOffline|TestPresenceModelSetAndGetPresence' -count=1 -timeout 60s`
- `cd cli && mise x -- go test ./internal/connectapi -run 'TestUserSummaryTreatsInvalidPresenceKeyAsOffline|TestRoomTimelineKeepsDMReadableWhenMessageBodyCannotHydrate|TestRoomTimelineBodyHydrationPropagatesRequestErrors' -count=1 -timeout 60s`
- `cd cli && mise x -- go test ./internal/connectapi -count=1 -timeout 120s`
- `cd cli && mise x -- go test ./internal/core -count=1 -timeout 120s`
- `git diff --check`
