### PR TITLE
fix(push): add declarative web push payloads

### DIFF
--- a/apps/docs-website/src/content/docs/guides/planning/notifications-web-push.mdx
+++ b/apps/docs-website/src/content/docs/guides/planning/notifications-web-push.mdx
@@ -89,6 +89,8 @@ Each browser or installed PWA creates its own subscription. A user can have mult
 
 When a user reopens Chatto, the app refreshes the server's stored subscription for that browser. Expired subscriptions are cleaned up automatically when push providers report them as gone.
 
+Chatto sends regular notifications in a declarative-compatible Web Push format, with a service-worker fallback for older browsers and already-installed app versions. Operators do not need to change VAPID keys or push configuration for this behavior.
+
 On iOS and iPadOS, Web Push works only for supported Home Screen web apps. Safari tabs that are not installed as an app may not receive native push.
 
 <Aside type="note">

--- a/apps/docs-website/src/content/docs/guides/planning/notifications-web-push.mdx
+++ b/apps/docs-website/src/content/docs/guides/planning/notifications-web-push.mdx
@@ -89,7 +89,7 @@ Each browser or installed PWA creates its own subscription. A user can have mult
 
 When a user reopens Chatto, the app refreshes the server's stored subscription for that browser. Expired subscriptions are cleaned up automatically when push providers report them as gone.
 
-Chatto sends regular notifications in a declarative-compatible Web Push format, with a service-worker fallback for older browsers and already-installed app versions. Operators do not need to change VAPID keys or push configuration for this behavior.
+Chatto sends regular notifications in a declarative-compatible Web Push format, with service-worker reconciliation where available and declarative display/badge fallback where supported. Operators do not need to change VAPID keys or push configuration for this behavior.
 
 On iOS and iPadOS, Web Push works only for supported Home Screen web apps. Safari tabs that are not installed as an app may not receive native push.
 

--- a/apps/frontend/src/lib/pwa/notificationBadge.worker.ts
+++ b/apps/frontend/src/lib/pwa/notificationBadge.worker.ts
@@ -224,6 +224,23 @@ export class ServiceWorkerBadgeCoordinator {
     await (badgeNavigator.setAppBadge?.().catch(() => {}) ?? Promise.resolve());
   }
 
+  async setPushAppBadgeCount(notificationCount: number): Promise<void> {
+    this.#gate.invalidate();
+    const count = normalizeBadgeCount(notificationCount);
+    this.#foregroundNotificationCount = count;
+    await this.foregroundCountStorage?.writeForegroundNotificationState(
+      count,
+      await this.isServiceWorkerAppBadgeEnabled()
+    );
+
+    const badgeNavigator = await this.badgeNavigatorIfEnabled();
+    if (count > 0) {
+      await (badgeNavigator.setAppBadge?.(count).catch(() => {}) ?? Promise.resolve());
+    } else {
+      await (badgeNavigator.clearAppBadge?.().catch(() => {}) ?? Promise.resolve());
+    }
+  }
+
   private async isServiceWorkerAppBadgeEnabled(): Promise<boolean> {
     if (this.#serviceWorkerAppBadgeEnabled !== null) return this.#serviceWorkerAppBadgeEnabled;
     if (!this.foregroundCountStorage) return true;

--- a/apps/frontend/src/service-worker.spec.ts
+++ b/apps/frontend/src/service-worker.spec.ts
@@ -153,8 +153,83 @@ describe('service worker badge orchestration', () => {
     await Promise.all(messageDispatch.pending);
 
     expect(worker.registration.showNotification).toHaveBeenCalledOnce();
+    expect(worker.registration.showNotification).toHaveBeenCalledWith('New notification', {
+      body: 'Hello',
+      icon: '/icons/icon-192.png',
+      badge: '/icons/icon-192.png',
+      tag: 'notification-1',
+      data: {
+        notificationId: undefined,
+        url: 'https://chatto.example/chat/-/room-1'
+      }
+    });
     expect(nativeNotification.close).not.toHaveBeenCalled();
     expect(worker.clearAppBadge).not.toHaveBeenCalled();
+  });
+
+  it('uses declarative push notification fields when legacy root fields are absent', async () => {
+    const worker = await importServiceWorker();
+
+    await worker.dispatch('push', {
+      data: {
+        json: () => ({
+          web_push: 8030,
+          notification: {
+            title: 'Declarative notification',
+            body: 'Opened by the browser or worker fallback',
+            tag: 'notification-2',
+            icon: 'https://chatto.example/icons/icon-192.png',
+            badge: 'https://chatto.example/icons/icon-192.png',
+            navigate: 'https://chatto.example/chat/-/room-2?highlight=event-2',
+            data: {
+              notificationId: 'notif-2',
+              url: 'https://chatto.example/chat/-/room-2?highlight=event-2'
+            }
+          }
+        })
+      }
+    });
+
+    expect(worker.registration.showNotification).toHaveBeenCalledWith('Declarative notification', {
+      body: 'Opened by the browser or worker fallback',
+      icon: 'https://chatto.example/icons/icon-192.png',
+      badge: 'https://chatto.example/icons/icon-192.png',
+      tag: 'notification-2',
+      data: {
+        notificationId: 'notif-2',
+        url: 'https://chatto.example/chat/-/room-2?highlight=event-2'
+      }
+    });
+  });
+
+  it('uses declarative navigate as the fallback notification click URL', async () => {
+    const worker = await importServiceWorker();
+    const targetUrl = 'https://chatto.example/chat/-/room-2?highlight=event-2';
+
+    await worker.dispatch('push', {
+      data: {
+        json: () => ({
+          web_push: 8030,
+          notification: {
+            title: 'Declarative notification',
+            navigate: targetUrl,
+            data: {
+              notificationId: 'notif-2'
+            }
+          }
+        })
+      }
+    });
+
+    const options = worker.registration.showNotification.mock.calls[0][1] as NotificationOptions;
+    await worker.dispatch('notificationclick', {
+      notification: {
+        close: vi.fn(),
+        data: options.data as { url?: string }
+      }
+    });
+
+    expect(worker.clients.openWindow).toHaveBeenCalledWith(targetUrl);
   });
 
   it('preserves a foreground authoritative count after clicking the only native notification', async () => {

--- a/apps/frontend/src/service-worker.spec.ts
+++ b/apps/frontend/src/service-worker.spec.ts
@@ -64,7 +64,7 @@ async function importServiceWorker(cacheStorage = createMemoryCacheStorage()) {
     getNotifications: vi.fn(
       async (_options?: { tag?: string }): Promise<TestNativeNotification[]> => []
     ),
-    showNotification: vi.fn(async () => {})
+    showNotification: vi.fn(async (_title: string, _options?: NotificationOptions) => {})
   };
   const clients = {
     claim: vi.fn(async () => {}),

--- a/apps/frontend/src/service-worker.spec.ts
+++ b/apps/frontend/src/service-worker.spec.ts
@@ -8,7 +8,15 @@ vi.mock('$service-worker', () => ({
 
 type ServiceWorkerHandler = (event: {
   data?: { json: () => unknown };
-  notification?: { close: () => void; data?: { url?: string } };
+  notification?: {
+    title?: string;
+    body?: string;
+    icon?: string;
+    badge?: string;
+    tag?: string;
+    data?: { notificationId?: string; url?: string };
+    close?: () => void;
+  };
   waitUntil: (promise: Promise<unknown>) => void;
 }) => void;
 
@@ -200,6 +208,48 @@ describe('service worker badge orchestration', () => {
         url: 'https://chatto.example/chat/-/room-2?highlight=event-2'
       }
     });
+  });
+
+  it('handles mutable declarative push events with event.notification and no payload data', async () => {
+    const worker = await importServiceWorker();
+
+    await worker.dispatch('message', {
+      data: {
+        type: 'chatto-badge-state',
+        notificationCount: 0,
+        serviceWorkerAppBadgeEnabled: true
+      }
+    });
+    worker.setAppBadge.mockClear();
+
+    await worker.dispatch('push', {
+      notification: {
+        title: 'Mutable declarative notification',
+        body: 'Handled through PushEvent.notification',
+        tag: 'notification-3',
+        icon: 'https://chatto.example/icons/icon-192.png',
+        badge: 'https://chatto.example/icons/icon-192.png',
+        data: {
+          notificationId: 'notif-3',
+          url: 'https://chatto.example/chat/-/room-3?highlight=event-3'
+        }
+      }
+    });
+
+    expect(worker.registration.showNotification).toHaveBeenCalledWith(
+      'Mutable declarative notification',
+      {
+        body: 'Handled through PushEvent.notification',
+        icon: 'https://chatto.example/icons/icon-192.png',
+        badge: 'https://chatto.example/icons/icon-192.png',
+        tag: 'notification-3',
+        data: {
+          notificationId: 'notif-3',
+          url: 'https://chatto.example/chat/-/room-3?highlight=event-3'
+        }
+      }
+    );
+    expect(worker.setAppBadge).toHaveBeenCalledOnce();
   });
 
   it('uses declarative navigate as the fallback notification click URL', async () => {

--- a/apps/frontend/src/service-worker.spec.ts
+++ b/apps/frontend/src/service-worker.spec.ts
@@ -13,6 +13,7 @@ type ServiceWorkerHandler = (event: {
     body?: string;
     icon?: string;
     badge?: string;
+    app_badge?: string | number;
     tag?: string;
     data?: { notificationId?: string; url?: string };
     close?: () => void;
@@ -178,6 +179,15 @@ describe('service worker badge orchestration', () => {
   it('uses declarative push notification fields when legacy root fields are absent', async () => {
     const worker = await importServiceWorker();
 
+    await worker.dispatch('message', {
+      data: {
+        type: 'chatto-badge-state',
+        notificationCount: 0,
+        serviceWorkerAppBadgeEnabled: true
+      }
+    });
+    worker.setAppBadge.mockClear();
+
     await worker.dispatch('push', {
       data: {
         json: () => ({
@@ -188,6 +198,7 @@ describe('service worker badge orchestration', () => {
             tag: 'notification-2',
             icon: 'https://chatto.example/icons/icon-192.png',
             badge: 'https://chatto.example/icons/icon-192.png',
+            app_badge: '5',
             navigate: 'https://chatto.example/chat/-/room-2?highlight=event-2',
             data: {
               notificationId: 'notif-2',
@@ -198,6 +209,7 @@ describe('service worker badge orchestration', () => {
       }
     });
 
+    expect(worker.setAppBadge).toHaveBeenCalledWith(5);
     expect(worker.registration.showNotification).toHaveBeenCalledWith('Declarative notification', {
       body: 'Opened by the browser or worker fallback',
       icon: 'https://chatto.example/icons/icon-192.png',
@@ -229,6 +241,7 @@ describe('service worker badge orchestration', () => {
         tag: 'notification-3',
         icon: 'https://chatto.example/icons/icon-192.png',
         badge: 'https://chatto.example/icons/icon-192.png',
+        app_badge: 3,
         data: {
           notificationId: 'notif-3',
           url: 'https://chatto.example/chat/-/room-3?highlight=event-3'
@@ -249,7 +262,7 @@ describe('service worker badge orchestration', () => {
         }
       }
     );
-    expect(worker.setAppBadge).toHaveBeenCalledOnce();
+    expect(worker.setAppBadge).toHaveBeenCalledWith(3);
   });
 
   it('uses declarative navigate as the fallback notification click URL', async () => {

--- a/apps/frontend/src/service-worker.ts
+++ b/apps/frontend/src/service-worker.ts
@@ -151,6 +151,29 @@ interface PushPayload {
   action?: 'dismiss';
 }
 
+interface DeclarativePushPayload extends PushPayload {
+  web_push?: number;
+  notification?: DeclarativeNotificationPayload;
+}
+
+interface DeclarativeNotificationPayload {
+  title?: string;
+  body?: string;
+  icon?: string;
+  badge?: string;
+  tag?: string;
+  navigate?: string;
+  data?: {
+    notificationId?: string;
+    url?: string;
+  };
+}
+
+type NormalizedPushNotification = {
+  title: string;
+  options: NotificationOptions;
+};
+
 function handleBadgeStateMessage(event: ExtendableMessageEvent): boolean {
   const message = event.data as Record<string, unknown> | undefined;
   if (!message || message.type !== 'chatto-badge-state') return false;
@@ -164,6 +187,26 @@ function handleBadgeStateMessage(event: ExtendableMessageEvent): boolean {
   return true;
 }
 
+function normalizePushNotification(payload: DeclarativePushPayload): NormalizedPushNotification {
+  const notification = payload.notification;
+  const notificationId = payload.notificationId ?? notification?.data?.notificationId;
+  const url = payload.url ?? notification?.data?.url ?? notification?.navigate;
+
+  return {
+    title: payload.title ?? notification?.title ?? 'New notification',
+    options: {
+      body: payload.body ?? notification?.body,
+      icon: payload.icon ?? notification?.icon ?? '/icons/icon-192.png',
+      badge: payload.badge ?? notification?.badge ?? '/icons/icon-192.png',
+      tag: payload.tag ?? notification?.tag,
+      data: {
+        notificationId,
+        url
+      }
+    }
+  };
+}
+
 /**
  * Handle incoming push events.
  * Parse the payload and display a native notification, or dismiss existing ones.
@@ -174,9 +217,9 @@ self.addEventListener('push', (event) => {
     return;
   }
 
-  let payload: PushPayload;
+  let payload: DeclarativePushPayload;
   try {
-    payload = event.data.json() as PushPayload;
+    payload = event.data.json() as DeclarativePushPayload;
   } catch {
     console.error('Failed to parse push payload');
     return;
@@ -195,23 +238,11 @@ self.addEventListener('push', (event) => {
   }
 
   badgeCoordinator.recordRegularPush();
-
-  // Regular notification display
-  const options: NotificationOptions = {
-    body: payload.body,
-    icon: payload.icon ?? '/icons/icon-192.png',
-    badge: payload.badge ?? '/icons/icon-192.png',
-    tag: payload.tag,
-    // Pass notificationId and url in data for the click handler
-    data: {
-      notificationId: payload.notificationId,
-      url: payload.url
-    }
-  };
+  const notification = normalizePushNotification(payload);
 
   event.waitUntil(
     Promise.all([
-      self.registration.showNotification(payload.title ?? 'New notification', options),
+      self.registration.showNotification(notification.title, notification.options),
       badgeCoordinator.setProvisionalPushFlagBadge()
     ])
   );

--- a/apps/frontend/src/service-worker.ts
+++ b/apps/frontend/src/service-worker.ts
@@ -162,6 +162,7 @@ interface DeclarativeNotificationPayload {
   body?: string;
   icon?: string;
   badge?: string;
+  app_badge?: string | number;
   tag?: string;
   navigate?: string;
   data?: {
@@ -173,6 +174,7 @@ interface DeclarativeNotificationPayload {
 type NormalizedPushNotification = {
   title: string;
   options: NotificationOptions;
+  appBadgeCount: number | null;
 };
 
 type DeclarativePushEventNotification = Pick<
@@ -180,6 +182,7 @@ type DeclarativePushEventNotification = Pick<
   'title' | 'body' | 'icon' | 'tag' | 'data'
 > & {
   badge?: string;
+  app_badge?: string | number;
 };
 
 type PushEventWithDeclarativeNotification = PushEvent & {
@@ -215,7 +218,8 @@ function normalizePushNotification(payload: DeclarativePushPayload): NormalizedP
         notificationId,
         url
       }
-    }
+    },
+    appBadgeCount: declarativeAppBadgeCount(notification?.app_badge)
   };
 }
 
@@ -228,10 +232,21 @@ function declarativePayloadFromEventNotification(
       body: notification.body,
       icon: notification.icon,
       badge: notification.badge,
+      app_badge: notification.app_badge,
       tag: notification.tag,
       data: notificationData(notification.data)
     }
   };
+}
+
+function declarativeAppBadgeCount(appBadge: unknown): number | null {
+  if (typeof appBadge === 'number' && Number.isFinite(appBadge)) {
+    return Math.max(0, Math.floor(appBadge));
+  }
+  if (typeof appBadge !== 'string' || appBadge.trim() === '') return null;
+
+  const count = Number(appBadge);
+  return Number.isFinite(count) ? Math.max(0, Math.floor(count)) : null;
 }
 
 function notificationData(data: unknown): DeclarativeNotificationPayload['data'] {
@@ -286,7 +301,9 @@ self.addEventListener('push', (event) => {
   event.waitUntil(
     Promise.all([
       self.registration.showNotification(notification.title, notification.options),
-      badgeCoordinator.setProvisionalPushFlagBadge()
+      notification.appBadgeCount !== null
+        ? badgeCoordinator.setPushAppBadgeCount(notification.appBadgeCount)
+        : badgeCoordinator.setProvisionalPushFlagBadge()
     ])
   );
 });

--- a/apps/frontend/src/service-worker.ts
+++ b/apps/frontend/src/service-worker.ts
@@ -153,6 +153,7 @@ interface PushPayload {
 
 interface DeclarativePushPayload extends PushPayload {
   web_push?: number;
+  mutable?: boolean;
   notification?: DeclarativeNotificationPayload;
 }
 
@@ -172,6 +173,17 @@ interface DeclarativeNotificationPayload {
 type NormalizedPushNotification = {
   title: string;
   options: NotificationOptions;
+};
+
+type DeclarativePushEventNotification = Pick<
+  Notification,
+  'title' | 'body' | 'icon' | 'tag' | 'data'
+> & {
+  badge?: string;
+};
+
+type PushEventWithDeclarativeNotification = PushEvent & {
+  notification?: DeclarativePushEventNotification | null;
 };
 
 function handleBadgeStateMessage(event: ExtendableMessageEvent): boolean {
@@ -207,21 +219,52 @@ function normalizePushNotification(payload: DeclarativePushPayload): NormalizedP
   };
 }
 
+function declarativePayloadFromEventNotification(
+  notification: DeclarativePushEventNotification
+): DeclarativePushPayload {
+  return {
+    notification: {
+      title: notification.title,
+      body: notification.body,
+      icon: notification.icon,
+      badge: notification.badge,
+      tag: notification.tag,
+      data: notificationData(notification.data)
+    }
+  };
+}
+
+function notificationData(data: unknown): DeclarativeNotificationPayload['data'] {
+  if (typeof data !== 'object' || data === null) return undefined;
+  return {
+    notificationId: stringProperty(data, 'notificationId'),
+    url: stringProperty(data, 'url')
+  };
+}
+
+function stringProperty(record: object, key: string): string | undefined {
+  const value = (record as Record<string, unknown>)[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
 /**
  * Handle incoming push events.
  * Parse the payload and display a native notification, or dismiss existing ones.
  */
 self.addEventListener('push', (event) => {
-  if (!event.data) {
-    console.warn('Push event received with no data');
-    return;
-  }
-
+  const declarativeNotification = (event as PushEventWithDeclarativeNotification).notification;
   let payload: DeclarativePushPayload;
-  try {
-    payload = event.data.json() as DeclarativePushPayload;
-  } catch {
-    console.error('Failed to parse push payload');
+  if (event.data) {
+    try {
+      payload = event.data.json() as DeclarativePushPayload;
+    } catch {
+      console.error('Failed to parse push payload');
+      return;
+    }
+  } else if (declarativeNotification) {
+    payload = declarativePayloadFromEventNotification(declarativeNotification);
+  } else {
+    console.warn('Push event received with no data or declarative notification');
     return;
   }
 

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/log"
@@ -363,6 +364,13 @@ func setupPushNotifications(chattoCore *core.ChattoCore, cfg config.ChattoConfig
 
 		// Build and send push notification
 		payload := push.BuildPayloadFromNotification(notification, actorName, cfg.Webserver.URL, payloadCtx)
+		if count, err := chattoCore.GetNotificationCount(ctx, notification.RecipientId); err == nil {
+			payload.AppBadge = strconv.Itoa(count)
+		} else {
+			logger.Warn("Failed to get notification count for push app badge",
+				"user_id", notification.RecipientId,
+				"error", err)
+		}
 		results := sender.SendToMany(ctx, subscriptions, payload)
 
 		// Process results - clean up expired subscriptions

--- a/cli/internal/push/push.go
+++ b/cli/internal/push/push.go
@@ -30,6 +30,7 @@ const (
 	pushRecordSize                       uint32 = 2048
 	maxPushProviderResponseBodyBytes            = 2048
 	truncatedPushProviderResponseBodyMsg        = "…"
+	declarativeWebPushValue                     = 8030
 )
 
 // NewSender creates a new push notification sender.
@@ -55,6 +56,67 @@ type Payload struct {
 	URL            string `json:"url,omitempty"`
 	// Action is used for special payloads like "dismiss" to close notifications on other devices
 	Action string `json:"action,omitempty"`
+}
+
+type declarativeNotification struct {
+	Title    string                       `json:"title"`
+	Body     string                       `json:"body,omitempty"`
+	Navigate string                       `json:"navigate"`
+	Tag      string                       `json:"tag,omitempty"`
+	Icon     string                       `json:"icon,omitempty"`
+	Badge    string                       `json:"badge,omitempty"`
+	Data     *declarativeNotificationData `json:"data,omitempty"`
+}
+
+type declarativeNotificationData struct {
+	NotificationID string `json:"notificationId,omitempty"`
+	URL            string `json:"url,omitempty"`
+}
+
+func (p Payload) MarshalJSON() ([]byte, error) {
+	type payloadJSON struct {
+		Title          string                   `json:"title,omitempty"`
+		Body           string                   `json:"body,omitempty"`
+		Icon           string                   `json:"icon,omitempty"`
+		Badge          string                   `json:"badge,omitempty"`
+		Tag            string                   `json:"tag,omitempty"`
+		NotificationID string                   `json:"notificationId,omitempty"`
+		URL            string                   `json:"url,omitempty"`
+		Action         string                   `json:"action,omitempty"`
+		WebPush        int                      `json:"web_push,omitempty"`
+		Notification   *declarativeNotification `json:"notification,omitempty"`
+	}
+
+	out := payloadJSON{
+		Title:          p.Title,
+		Body:           p.Body,
+		Icon:           p.Icon,
+		Badge:          p.Badge,
+		Tag:            p.Tag,
+		NotificationID: p.NotificationID,
+		URL:            p.URL,
+		Action:         p.Action,
+	}
+	if p.declarativeNotificationEligible() {
+		out.WebPush = declarativeWebPushValue
+		out.Notification = &declarativeNotification{
+			Title:    p.Title,
+			Body:     p.Body,
+			Navigate: p.URL,
+			Tag:      p.Tag,
+			Icon:     p.Icon,
+			Badge:    p.Badge,
+			Data: &declarativeNotificationData{
+				NotificationID: p.NotificationID,
+				URL:            p.URL,
+			},
+		}
+	}
+	return json.Marshal(out)
+}
+
+func (p Payload) declarativeNotificationEligible() bool {
+	return p.Action == "" && p.Title != "" && p.URL != ""
 }
 
 // PayloadContext provides optional context for building push payloads.

--- a/cli/internal/push/push.go
+++ b/cli/internal/push/push.go
@@ -54,6 +54,7 @@ type Payload struct {
 	Tag            string `json:"tag,omitempty"`
 	NotificationID string `json:"notificationId,omitempty"`
 	URL            string `json:"url,omitempty"`
+	AppBadge       string `json:"-"`
 	// Action is used for special payloads like "dismiss" to close notifications on other devices
 	Action string `json:"action,omitempty"`
 }
@@ -65,6 +66,7 @@ type declarativeNotification struct {
 	Tag      string                       `json:"tag,omitempty"`
 	Icon     string                       `json:"icon,omitempty"`
 	Badge    string                       `json:"badge,omitempty"`
+	AppBadge string                       `json:"app_badge,omitempty"`
 	Data     *declarativeNotificationData `json:"data,omitempty"`
 }
 
@@ -84,6 +86,7 @@ func (p Payload) MarshalJSON() ([]byte, error) {
 		URL            string                   `json:"url,omitempty"`
 		Action         string                   `json:"action,omitempty"`
 		WebPush        int                      `json:"web_push,omitempty"`
+		Mutable        bool                     `json:"mutable,omitempty"`
 		Notification   *declarativeNotification `json:"notification,omitempty"`
 	}
 
@@ -99,6 +102,7 @@ func (p Payload) MarshalJSON() ([]byte, error) {
 	}
 	if p.declarativeNotificationEligible() {
 		out.WebPush = declarativeWebPushValue
+		out.Mutable = true
 		out.Notification = &declarativeNotification{
 			Title:    p.Title,
 			Body:     p.Body,
@@ -106,6 +110,7 @@ func (p Payload) MarshalJSON() ([]byte, error) {
 			Tag:      p.Tag,
 			Icon:     p.Icon,
 			Badge:    p.Badge,
+			AppBadge: p.AppBadge,
 			Data: &declarativeNotificationData{
 				NotificationID: p.NotificationID,
 				URL:            p.URL,

--- a/cli/internal/push/push_test.go
+++ b/cli/internal/push/push_test.go
@@ -107,6 +107,37 @@ func TestPayloadMarshal(t *testing.T) {
 		if result["url"] != "/chat/room/123" {
 			t.Errorf("Expected url '/chat/room/123', got %v", result["url"])
 		}
+		if result["web_push"] != float64(declarativeWebPushValue) {
+			t.Errorf("Expected web_push %d, got %v", declarativeWebPushValue, result["web_push"])
+		}
+
+		notification, ok := result["notification"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("Expected declarative notification object, got %T", result["notification"])
+		}
+		if notification["title"] != "Test Title" {
+			t.Errorf("Expected declarative title 'Test Title', got %v", notification["title"])
+		}
+		if notification["body"] != "Test Body" {
+			t.Errorf("Expected declarative body 'Test Body', got %v", notification["body"])
+		}
+		if notification["navigate"] != "/chat/room/123" {
+			t.Errorf("Expected declarative navigate '/chat/room/123', got %v", notification["navigate"])
+		}
+		if notification["tag"] != "test-tag" {
+			t.Errorf("Expected declarative tag 'test-tag', got %v", notification["tag"])
+		}
+
+		notificationData, ok := notification["data"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("Expected declarative notification data object, got %T", notification["data"])
+		}
+		if notificationData["notificationId"] != "notif-123" {
+			t.Errorf("Expected declarative notificationId 'notif-123', got %v", notificationData["notificationId"])
+		}
+		if notificationData["url"] != "/chat/room/123" {
+			t.Errorf("Expected declarative data url '/chat/room/123', got %v", notificationData["url"])
+		}
 	})
 
 	t.Run("omits empty optional fields", func(t *testing.T) {
@@ -130,6 +161,42 @@ func TestPayloadMarshal(t *testing.T) {
 		}
 		if _, ok := result["notificationId"]; ok {
 			t.Error("Expected notificationId to be omitted when empty")
+		}
+		if _, ok := result["web_push"]; ok {
+			t.Error("Expected web_push to be omitted when navigate URL is empty")
+		}
+		if _, ok := result["notification"]; ok {
+			t.Error("Expected declarative notification to be omitted when navigate URL is empty")
+		}
+	})
+
+	t.Run("dismiss payload stays imperative only", func(t *testing.T) {
+		payload := &Payload{
+			Action: "dismiss",
+			Tag:    "test-tag",
+		}
+
+		data, err := json.Marshal(payload)
+		if err != nil {
+			t.Fatalf("Failed to marshal payload: %v", err)
+		}
+
+		var result map[string]interface{}
+		if err := json.Unmarshal(data, &result); err != nil {
+			t.Fatalf("Failed to unmarshal: %v", err)
+		}
+
+		if result["action"] != "dismiss" {
+			t.Errorf("Expected dismiss action, got %v", result["action"])
+		}
+		if result["tag"] != "test-tag" {
+			t.Errorf("Expected tag 'test-tag', got %v", result["tag"])
+		}
+		if _, ok := result["web_push"]; ok {
+			t.Error("Expected dismiss payload to omit web_push")
+		}
+		if _, ok := result["notification"]; ok {
+			t.Error("Expected dismiss payload to omit declarative notification")
 		}
 	})
 }

--- a/cli/internal/push/push_test.go
+++ b/cli/internal/push/push_test.go
@@ -85,6 +85,7 @@ func TestPayloadMarshal(t *testing.T) {
 			Tag:            "test-tag",
 			NotificationID: "notif-123",
 			URL:            "/chat/room/123",
+			AppBadge:       "7",
 		}
 
 		data, err := json.Marshal(payload)
@@ -110,6 +111,9 @@ func TestPayloadMarshal(t *testing.T) {
 		if result["web_push"] != float64(declarativeWebPushValue) {
 			t.Errorf("Expected web_push %d, got %v", declarativeWebPushValue, result["web_push"])
 		}
+		if result["mutable"] != true {
+			t.Errorf("Expected mutable true, got %v", result["mutable"])
+		}
 
 		notification, ok := result["notification"].(map[string]interface{})
 		if !ok {
@@ -126,6 +130,9 @@ func TestPayloadMarshal(t *testing.T) {
 		}
 		if notification["tag"] != "test-tag" {
 			t.Errorf("Expected declarative tag 'test-tag', got %v", notification["tag"])
+		}
+		if notification["app_badge"] != "7" {
+			t.Errorf("Expected declarative app_badge '7', got %v", notification["app_badge"])
 		}
 
 		notificationData, ok := notification["data"].(map[string]interface{})
@@ -194,6 +201,9 @@ func TestPayloadMarshal(t *testing.T) {
 		}
 		if _, ok := result["web_push"]; ok {
 			t.Error("Expected dismiss payload to omit web_push")
+		}
+		if _, ok := result["mutable"]; ok {
+			t.Error("Expected dismiss payload to omit mutable")
 		}
 		if _, ok := result["notification"]; ok {
 			t.Error("Expected dismiss payload to omit declarative notification")

--- a/docs/fdr/FDR-013-web-push-notifications.md
+++ b/docs/fdr/FDR-013-web-push-notifications.md
@@ -17,7 +17,7 @@ Users can opt in to receive notifications through the browser's W3C Web Push sys
 - On iOS/iPadOS, Web Push is available only for Home Screen web apps on supported versions. Chatto treats Web Push as a notification trigger rather than authoritative app state and reconciles pending-notification count, native notifications, and dock badge state when the app is open.
 - Stored subscription fields are bounded: endpoint 4,096 bytes, public key 256 bytes, auth secret 128 bytes, and user agent 512 bytes.
 - A user can have multiple devices subscribed simultaneously — every device receives every push.
-- Push payloads include a title, a truncated message preview (max 100 chars, broken at word boundaries), and a navigation URL.
+- Push payloads include a declarative-compatible notification envelope with a title, a truncated message preview (max 100 chars, broken at word boundaries), and a navigation URL. The legacy root fields remain present so older Chatto service workers can display the same notification during upgrades.
 - Clicking a push notification navigates to the relevant room, thread, or DM.
 - Dismissing a notification in one place sends a "dismiss" action push to other devices, closing the system notification there too.
 - Expired or invalid subscriptions (browsers report 404/410 on push delivery) are cleaned up automatically.
@@ -73,6 +73,12 @@ Users can opt in to receive notifications through the browser's W3C Web Push sys
 **Decision:** Direct browser push registration is offered only for the Chatto server that served the installed web app.
 **Why:** A browser push subscription belongs to a service worker origin and is created with a single application server key. Registering arbitrary remote servers from another server's app origin would imply cross-origin routing and VAPID-key behavior that Chatto has not designed yet.
 **Tradeoff:** Users connected to remote servers do not get native OS notifications for those servers through this app origin. They still get realtime in-app badges and notification sounds while Chatto is open, and remote-native push can be revisited with an explicit relay or shared-key design.
+
+### 9. Declarative-compatible payloads with service-worker fallback
+
+**Decision:** Regular push notifications use the Declarative Web Push JSON envelope while keeping the older Chatto root fields in the same payload.
+**Why:** Modern browsers can display the standard declarative notification without relying on service-worker JavaScript, while older browsers and already-installed Chatto service workers keep using the existing fallback display and click-routing logic.
+**Tradeoff:** Payloads duplicate a small amount of title/body/navigation data. That is preferable to a flag-day service-worker rollout or a second subscription path.
 
 ## Permissions
 

--- a/docs/fdr/FDR-013-web-push-notifications.md
+++ b/docs/fdr/FDR-013-web-push-notifications.md
@@ -17,7 +17,7 @@ Users can opt in to receive notifications through the browser's W3C Web Push sys
 - On iOS/iPadOS, Web Push is available only for Home Screen web apps on supported versions. Chatto treats Web Push as a notification trigger rather than authoritative app state and reconciles pending-notification count, native notifications, and dock badge state when the app is open.
 - Stored subscription fields are bounded: endpoint 4,096 bytes, public key 256 bytes, auth secret 128 bytes, and user agent 512 bytes.
 - A user can have multiple devices subscribed simultaneously — every device receives every push.
-- Push payloads include a declarative-compatible notification envelope with a title, a truncated message preview (max 100 chars, broken at word boundaries), and a navigation URL. The legacy root fields remain present so older Chatto service workers can display the same notification during upgrades.
+- Push payloads include a mutable declarative-compatible notification envelope with a title, a truncated message preview (max 100 chars, broken at word boundaries), a navigation URL, and the pending app badge count when available. The legacy root fields remain present so older Chatto service workers can display the same notification during upgrades.
 - Clicking a push notification navigates to the relevant room, thread, or DM.
 - Dismissing a notification in one place sends a "dismiss" action push to other devices, closing the system notification there too.
 - Expired or invalid subscriptions (browsers report 404/410 on push delivery) are cleaned up automatically.
@@ -76,9 +76,9 @@ Users can opt in to receive notifications through the browser's W3C Web Push sys
 
 ### 9. Declarative-compatible payloads with service-worker fallback
 
-**Decision:** Regular push notifications use the Declarative Web Push JSON envelope while keeping the older Chatto root fields in the same payload.
-**Why:** Modern browsers can display the standard declarative notification without relying on service-worker JavaScript, while older browsers and already-installed Chatto service workers keep using the existing fallback display and click-routing logic.
-**Tradeoff:** Payloads duplicate a small amount of title/body/navigation data. That is preferable to a flag-day service-worker rollout or a second subscription path.
+**Decision:** Regular push notifications use a mutable Declarative Web Push JSON envelope while keeping the older Chatto root fields in the same payload.
+**Why:** Modern browsers can display the standard declarative notification if the service worker is unavailable, while browsers with the Chatto worker installed still dispatch a push event so the worker can keep badge and click reconciliation behavior intact. Older browsers and already-installed Chatto service workers keep using the legacy root fields.
+**Tradeoff:** Payloads duplicate a small amount of title/body/navigation data and include WebKit's `app_badge` field when the count is available. That is preferable to a flag-day service-worker rollout, a second subscription path, or losing badge reconciliation on declarative-capable installed PWAs.
 
 ## Permissions
 


### PR DESCRIPTION
## Summary

Adds Declarative Web Push-compatible JSON envelopes for regular notification payloads while preserving the existing root fields for already-installed service workers and older browsers.
The service worker now normalizes legacy and declarative payloads so fallback display and click routing continue to work, including `notification.navigate`.
Docs and FDR-013 now describe the compatibility behavior and clarify that operators do not need to change VAPID configuration.

## Validation

- `mise x -- go test -trimpath -tags test_endpoints ./internal/push`
- `mise x -- pnpm vitest --run src/service-worker.spec.ts`
