### PR TITLE
fix(frontend): separate input mode from viewport size

### DIFF
--- a/apps/frontend/e2e/message-kebab-menu.test.ts
+++ b/apps/frontend/e2e/message-kebab-menu.test.ts
@@ -25,6 +25,28 @@ test.describe('Message hover toolbar', () => {
     await expect(message.hoverToolbar.getByLabel('More actions')).toBeVisible();
   });
 
+  test('toolbar appears on hover in a narrow desktop window', async ({
+    page,
+    chatPage,
+    roomPage
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.enterRoom('general');
+
+    const testMessage = `Narrow toolbar test ${Date.now()}`;
+    const message = await roomPage.sendMessage(testMessage);
+
+    await page.setViewportSize({ width: 640, height: 720 });
+    await page.mouse.move(0, 0);
+    await expect(message.hoverToolbar).not.toBeVisible();
+
+    await message.locator.hover();
+    await expect(message.hoverToolbar).toBeVisible({ timeout: TIMEOUTS.UI_FAST });
+    await expect(message.hoverToolbar.getByLabel('More actions')).toBeVisible();
+  });
+
   test('can edit message directly through toolbar', async ({ page, chatPage, roomPage }) => {
     await createAndLoginTestUser(page);
     await chatPage.goto();

--- a/apps/frontend/e2e/threading.test.ts
+++ b/apps/frontend/e2e/threading.test.ts
@@ -707,7 +707,7 @@ test.describe('Message Threading', () => {
     const rootMessage = `Responsive test ${Date.now()}`;
     const message = await roomPage.sendMessage(rootMessage);
 
-    // Open thread at desktop size (toolbar requires pointer-fine / md breakpoint)
+    // Open thread at desktop size (hover toolbar is available on fine-pointer input)
     await message.openThread();
     await roomPage.expectThreadPaneVisible();
 
@@ -734,7 +734,7 @@ test.describe('Message Threading', () => {
     const rootMessage = `Back button test ${Date.now()}`;
     const message = await roomPage.sendMessage(rootMessage);
 
-    // Open thread at desktop size (toolbar requires pointer-fine / md breakpoint)
+    // Open thread at desktop size (hover toolbar is available on fine-pointer input)
     await message.openThread();
     await roomPage.expectThreadPaneVisible();
 

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -13,6 +13,8 @@
 /* Custom variant for desktop/mouse devices (fine pointer like mouse/trackpad).
    Usage: pointer-fine:select-text - enables selection only on desktop */
 @custom-variant pointer-fine (@media (pointer: fine));
+/* Hover affordances should follow input capability, not viewport width. */
+@custom-variant hover-actions (@media (any-hover: hover) and (any-pointer: fine));
 
 /*
  * Theme tokens.

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte
@@ -23,7 +23,7 @@ to the user settings page for the active server.
     setRoomSidebarPanel
   } from '$lib/storage/roomSidebarPanel';
   import { serverStorageKey } from '$lib/storage/serverStorage';
-  import { isTouchDevice } from '$lib/utils/isTouchDevice';
+  import { prefersTouchActions, supportsHoverActions } from '$lib/utils/inputCapabilities';
   import BottomSheet from '$lib/ui/BottomSheet.svelte';
   import ContextMenu from '$lib/ui/ContextMenu.svelte';
   import Dialog from '$lib/ui/Dialog.svelte';
@@ -73,7 +73,7 @@ to the user settings page for the active server.
   const compactCallButtonClass = 'btn-secondary h-10 w-10 shrink-0 !px-0 !py-0 text-xs';
   const compactCallActiveButtonClass = 'btn-success h-10 w-10 shrink-0 !px-0 !py-0 text-xs';
   const compactCallDangerButtonClass = 'btn-danger h-10 w-10 shrink-0 !px-0 !py-0 text-xs';
-  const isTouch = isTouchDevice();
+  const useSheetDialog = prefersTouchActions() && !supportsHoverActions();
   const presenceModes: PresenceMode[] = ['auto', 'away', 'doNotDisturb', 'invisible'];
   const presenceLabel = $derived.by(() => presenceModeLabel(presencePreference.mode));
   let statusMenuAnchor = $state<{ top: number; bottom: number; left: number } | null>(null);
@@ -372,7 +372,7 @@ to the user settings page for the active server.
 {/if}
 
 {#if activeServerUser}
-  {#if isTouch}
+  {#if useSheetDialog}
     <BottomSheet
       bind:visible={customStatusDialogVisible}
       onclose={() => (customStatusDialogVisible = false)}

--- a/apps/frontend/src/lib/components/EmojiPicker.svelte
+++ b/apps/frontend/src/lib/components/EmojiPicker.svelte
@@ -13,7 +13,7 @@ Uses the same section styling as MessageContextMenu (rounded-md bg-background se
 <script lang="ts">
   import * as m from '$lib/i18n/messages';
   import { searchEmojis, EMOJI_BY_CATEGORY } from '$lib/emoji';
-  import { isTouchDevice } from '$lib/utils/isTouchDevice';
+  import { supportsHoverActions } from '$lib/utils/inputCapabilities';
   import { getRecentEmojis, MAX_RECENT_EMOJIS } from '$lib/state/recentEmojis.svelte';
 
   let {
@@ -27,7 +27,7 @@ Uses the same section styling as MessageContextMenu (rounded-md bg-background se
   } = $props();
 
   let query = $state('');
-  const isTouch = isTouchDevice();
+  const canUseHoverActions = supportsHoverActions();
 
   const recentStore = $derived(getRecentEmojis(serverId));
   const recent = $derived(recentStore.recent.slice(0, MAX_RECENT_EMOJIS));
@@ -36,7 +36,7 @@ Uses the same section styling as MessageContextMenu (rounded-md bg-background se
   const isSearching = $derived(query.trim().length > 0);
 
   function focusSearchInput(node: HTMLInputElement) {
-    if (!isTouch) queueMicrotask(() => node.focus());
+    if (canUseHoverActions) queueMicrotask(() => node.focus());
   }
 
   function handleKeydown(e: KeyboardEvent) {

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -21,7 +21,7 @@
     type RoomMember
   } from '$lib/state/room';
   import { shouldAutoFocus } from '$lib/utils/shouldAutoFocus';
-  import { isTouchDevice } from '$lib/utils/isTouchDevice';
+  import { prefersTouchActions } from '$lib/utils/inputCapabilities';
   import { hasVisibleContent } from '$lib/validation';
   import { extractMentions, hasRoleOrVirtualMention } from '$lib/mentions';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
@@ -41,7 +41,7 @@
   };
 
   function getShortcutHints(): ShortcutHints | null {
-    if (typeof navigator === 'undefined' || isTouchDevice()) return null;
+    if (typeof navigator === 'undefined' || prefersTouchActions()) return null;
 
     const userAgentDataPlatform =
       'userAgentData' in navigator
@@ -743,7 +743,7 @@
       }
     }
 
-    if (event.key === 'Enter' && !event.ctrlKey && !event.metaKey && isTouchDevice()) {
+    if (event.key === 'Enter' && !event.ctrlKey && !event.metaKey && prefersTouchActions()) {
       return false;
     }
 

--- a/apps/frontend/src/lib/ui/ContextMenu.svelte
+++ b/apps/frontend/src/lib/ui/ContextMenu.svelte
@@ -1,9 +1,9 @@
 <!--
 @component
 
-A reusable floating menu/popover. On desktop, positions itself at a viewport point or anchored to
-an element. On touch devices, renders as a BottomSheet instead. Handles click-outside dismissal,
-Escape key, and scroll dismissal (desktop), or swipe-to-close (mobile).
+A reusable floating menu/popover. On hover-capable devices, positions itself at a viewport point or
+anchored to an element. On pure touch-primary devices, renders as a BottomSheet instead. Handles
+click-outside dismissal, Escape key, and scroll dismissal (floating), or swipe-to-close (sheet).
 
 Built on top of `FloatingPopover` — the desktop branch is just menu-specific styling and Escape
 handling around the shared positioning primitive.
@@ -13,10 +13,11 @@ handling around the shared positioning primitive.
 - `anchor` - Element rect {top, bottom, left} for anchor-based positioning (popovers)
 - `role` - ARIA role (default: "menu")
 - `ariaLabel` - ARIA label for the container
-- `class` - Additional CSS classes for the outer container (desktop only)
+- `presentation` - "auto" uses input capability, "floating" or "sheet" forces a mode
+- `class` - Additional CSS classes for the outer container (floating mode only)
 - `onclose` - Callback when the menu should be dismissed
 
-On desktop, exactly one of `position` or `anchor` must be provided. On touch devices, both are
+In floating mode, exactly one of `position` or `anchor` must be provided. In sheet mode, both are
 ignored (the BottomSheet handles its own positioning).
 -->
 <script lang="ts">
@@ -24,13 +25,16 @@ ignored (the BottomSheet handles its own positioning).
   import type { Snippet } from 'svelte';
   import BottomSheet from './BottomSheet.svelte';
   import FloatingPopover from './FloatingPopover.svelte';
-  import { isTouchDevice } from '$lib/utils/isTouchDevice';
+  import { prefersTouchActions, supportsHoverActions } from '$lib/utils/inputCapabilities';
+
+  type ContextMenuPresentation = 'auto' | 'floating' | 'sheet';
 
   let {
     position,
     anchor,
     role = 'menu',
     ariaLabel,
+    presentation = 'auto',
     class: className,
     onclose,
     onmouseenter,
@@ -41,6 +45,7 @@ ignored (the BottomSheet handles its own positioning).
     anchor?: { top: number; bottom: number; left: number } | null;
     role?: string;
     ariaLabel?: string;
+    presentation?: ContextMenuPresentation;
     class?: string;
     onclose: () => void;
     onmouseenter?: () => void;
@@ -48,11 +53,14 @@ ignored (the BottomSheet handles its own positioning).
     children: Snippet;
   } = $props();
 
-  const isTouch = isTouchDevice();
+  const useSheet = $derived(
+    presentation === 'sheet' ||
+      (presentation === 'auto' && prefersTouchActions() && !supportsHoverActions())
+  );
   let sheetVisible = $state(true);
 
   function handleKeydown(e: KeyboardEvent) {
-    if (isTouch) return;
+    if (useSheet) return;
     if (e.key === 'Escape') {
       e.stopPropagation();
       onclose();
@@ -62,7 +70,7 @@ ignored (the BottomSheet handles its own positioning).
 
 <svelte:window onkeydown={handleKeydown} />
 
-{#if isTouch}
+{#if useSheet}
   <BottomSheet bind:visible={sheetVisible} {onclose}>
     {@render children()}
   </BottomSheet>
@@ -72,7 +80,7 @@ ignored (the BottomSheet handles its own positioning).
     {anchor}
     {role}
     {ariaLabel}
-    class={['menu min-w-48', className]}
+    class={['min-w-48 menu', className]}
     {onclose}
     {onmouseenter}
     {onmouseleave}

--- a/apps/frontend/src/lib/ui/ContextMenu.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/ContextMenu.svelte.spec.ts
@@ -1,0 +1,85 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { q, testSnippet } from '$lib/test-utils';
+import ContextMenu from './ContextMenu.svelte';
+
+const inputCapabilities = vi.hoisted(() => ({
+  prefersTouchActions: vi.fn(() => false),
+  supportsHoverActions: vi.fn(() => true)
+}));
+
+vi.mock('$lib/utils/inputCapabilities', () => inputCapabilities);
+
+let originalShowPopover: typeof HTMLElement.prototype.showPopover;
+let originalHidePopover: typeof HTMLElement.prototype.hidePopover;
+let originalShowModal: typeof HTMLDialogElement.prototype.showModal;
+let originalClose: typeof HTMLDialogElement.prototype.close;
+
+function renderMenu(props: Record<string, unknown> = {}) {
+  return render(ContextMenu, {
+    props: {
+      position: { x: 24, y: 32 },
+      onclose: vi.fn(),
+      children: testSnippet('<span>Menu body</span>'),
+      ...props
+    }
+  });
+}
+
+beforeAll(() => {
+  originalShowPopover = HTMLElement.prototype.showPopover;
+  originalHidePopover = HTMLElement.prototype.hidePopover;
+  originalShowModal = HTMLDialogElement.prototype.showModal;
+  originalClose = HTMLDialogElement.prototype.close;
+
+  HTMLElement.prototype.showPopover = function showPopover() {
+    this.setAttribute('popover-open', '');
+  };
+  HTMLElement.prototype.hidePopover = function hidePopover() {
+    this.removeAttribute('popover-open');
+  };
+  HTMLDialogElement.prototype.showModal = function showModal() {
+    this.setAttribute('open', '');
+  };
+  HTMLDialogElement.prototype.close = function close() {
+    this.removeAttribute('open');
+    this.dispatchEvent(new Event('close'));
+  };
+});
+
+afterAll(() => {
+  HTMLElement.prototype.showPopover = originalShowPopover;
+  HTMLElement.prototype.hidePopover = originalHidePopover;
+  HTMLDialogElement.prototype.showModal = originalShowModal;
+  HTMLDialogElement.prototype.close = originalClose;
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  inputCapabilities.prefersTouchActions.mockReturnValue(false);
+  inputCapabilities.supportsHoverActions.mockReturnValue(true);
+});
+
+describe('ContextMenu', () => {
+  it('uses floating presentation on hybrid devices by default', async () => {
+    inputCapabilities.prefersTouchActions.mockReturnValue(true);
+    inputCapabilities.supportsHoverActions.mockReturnValue(true);
+
+    const { container } = renderMenu();
+
+    await expect.element(q(container, '[role="menu"]')).toBeInTheDocument();
+    expect(q(container, 'dialog')).toBeNull();
+    expect(container.textContent).toContain('Menu body');
+  });
+
+  it('can force sheet presentation for touch-initiated nested menus', async () => {
+    inputCapabilities.prefersTouchActions.mockReturnValue(true);
+    inputCapabilities.supportsHoverActions.mockReturnValue(true);
+
+    const { container } = renderMenu({ presentation: 'sheet' });
+
+    await expect.element(q(container, 'dialog.bottom-sheet')).toBeInTheDocument();
+    expect(q(container, '[role="menu"]')).toBeNull();
+    expect(container.textContent).toContain('Menu body');
+  });
+});

--- a/apps/frontend/src/lib/utils/inputCapabilities.spec.ts
+++ b/apps/frontend/src/lib/utils/inputCapabilities.spec.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  prefersTouchActions,
+  supportsAnyFinePointer,
+  supportsHoverActions
+} from './inputCapabilities';
+
+function mediaQueryList(query: string, matches: boolean): MediaQueryList {
+  return {
+    matches,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(() => false)
+  } as MediaQueryList;
+}
+
+function mockMedia(matches: Record<string, boolean>) {
+  vi.stubGlobal('window', {
+    matchMedia: vi.fn((query: string) => mediaQueryList(query, matches[query] ?? false))
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('input capabilities', () => {
+  it('treats touch-primary devices as preferring touch actions', () => {
+    mockMedia({
+      '(pointer: coarse)': true
+    });
+
+    expect(prefersTouchActions()).toBe(true);
+    expect(supportsHoverActions()).toBe(false);
+  });
+
+  it('supports hover actions independently of viewport size', () => {
+    mockMedia({
+      '(any-hover: hover)': true,
+      '(any-pointer: fine)': true
+    });
+
+    expect(prefersTouchActions()).toBe(false);
+    expect(supportsAnyFinePointer()).toBe(true);
+    expect(supportsHoverActions()).toBe(true);
+  });
+
+  it('allows hover actions on hybrid devices with a fine hover pointer', () => {
+    mockMedia({
+      '(pointer: coarse)': true,
+      '(any-hover: hover)': true,
+      '(any-pointer: fine)': true
+    });
+
+    expect(prefersTouchActions()).toBe(true);
+    expect(supportsHoverActions()).toBe(true);
+  });
+});

--- a/apps/frontend/src/lib/utils/inputCapabilities.ts
+++ b/apps/frontend/src/lib/utils/inputCapabilities.ts
@@ -1,0 +1,32 @@
+function mediaMatches(query: string): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+  return window.matchMedia(query).matches;
+}
+
+/**
+ * True when the primary pointer is coarse. Use this for behavior that should
+ * avoid surprising touch-primary users, such as autofocus that opens a virtual
+ * keyboard or Enter-to-send in the composer.
+ */
+export function prefersTouchActions(): boolean {
+  return mediaMatches('(pointer: coarse)');
+}
+
+/**
+ * True when at least one available input can use a fine pointer.
+ */
+export function supportsAnyFinePointer(): boolean {
+  return mediaMatches('(any-pointer: fine)') || mediaMatches('(pointer: fine)');
+}
+
+/**
+ * True when the current device can reasonably use hover-only affordances such
+ * as message action toolbars. This intentionally does not depend on viewport
+ * width; a small desktop window should still get desktop input behavior.
+ */
+export function supportsHoverActions(): boolean {
+  return (
+    (mediaMatches('(any-hover: hover)') && supportsAnyFinePointer()) ||
+    mediaMatches('(hover: hover) and (pointer: fine)')
+  );
+}

--- a/apps/frontend/src/lib/utils/isTouchDevice.ts
+++ b/apps/frontend/src/lib/utils/isTouchDevice.ts
@@ -1,9 +1,10 @@
+import { prefersTouchActions } from './inputCapabilities';
+
 /**
- * Returns true if the device's primary pointer is coarse (touch).
- * Uses the `(pointer: coarse)` media query, which reliably detects
- * touch-primary devices without relying on viewport width.
+ * Returns true if the device's primary pointer is coarse. Kept as a
+ * compatibility wrapper; new interaction decisions should prefer the explicit
+ * helpers in `inputCapabilities.ts`.
  */
 export function isTouchDevice(): boolean {
-  if (typeof window === 'undefined') return false;
-  return window.matchMedia('(pointer: coarse)').matches;
+  return prefersTouchActions();
 }

--- a/apps/frontend/src/lib/utils/shouldAutoFocus.ts
+++ b/apps/frontend/src/lib/utils/shouldAutoFocus.ts
@@ -1,4 +1,4 @@
-import { isTouchDevice } from './isTouchDevice';
+import { prefersTouchActions } from './inputCapabilities';
 
 /**
  * Returns true if autofocus should be enabled.
@@ -6,5 +6,5 @@ import { isTouchDevice } from './isTouchDevice';
  */
 export function shouldAutoFocus(): boolean {
   if (typeof window === 'undefined') return false;
-  return !isTouchDevice();
+  return !prefersTouchActions();
 }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -36,7 +36,7 @@
   import EmojiPicker from '$lib/components/EmojiPicker.svelte';
   import MessageAttachments from './MessageAttachments.svelte';
   import MessageMetaBar from './MessageMetaBar.svelte';
-  import { isTouchDevice } from '$lib/utils/isTouchDevice';
+  import { prefersTouchActions, supportsHoverActions } from '$lib/utils/inputCapabilities';
   import { getUserSettings } from '$lib/state/userSettings.svelte';
   import { formatMessageTime } from '$lib/utils/formatTime';
   import { getLocale } from '$lib/i18n/runtime';
@@ -87,7 +87,8 @@
   const jumpState = composerContext.jumpState;
   const userSettings = getUserSettings();
   const activeLocale = $derived(getLocale());
-  const isTouch = isTouchDevice();
+  const prefersTouch = prefersTouchActions();
+  const canUseHoverActions = supportsHoverActions();
   // Wrap in $derived to ensure reactivity when the member list changes
   const members = $derived(getRoomMembers());
   const mentionRoleHandles = $derived(
@@ -136,27 +137,32 @@
   let messageBodySelectionRoot = $state<HTMLElement>();
   let selectedReplyQuoteSnapshot = $state<QuoteInsertionContent | null>(null);
 
-  // Emoji picker state (position doubles as visibility flag; on mobile ContextMenu ignores it)
+  // Emoji picker state (position doubles as visibility flag in floating mode)
   let emojiPickerPos = $state<{ x: number; y: number } | null>(null);
+  let emojiPickerPresentation = $state<'auto' | 'sheet'>('auto');
   const emojiActions = useMessageActions();
 
-  function openEmojiPicker() {
-    // Capture context menu position before it closes
-    // On mobile, position is ignored by ContextMenu (renders as BottomSheet)
+  function openEmojiPicker(presentation: 'auto' | 'sheet' = 'auto') {
+    emojiPickerPresentation = presentation;
+    // Capture context menu position before it closes. Sheet presentation ignores
+    // this fallback, but ContextMenu still requires a visibility anchor.
     emojiPickerPos = contextMenuPos ?? { x: 0, y: 0 };
   }
 
   function openEmojiPickerFromEvent(e: MouseEvent) {
+    emojiPickerPresentation = 'auto';
     emojiPickerPos = { x: e.clientX, y: e.clientY };
   }
 
   function openEmojiPickerFromToolbar(e: MouseEvent) {
+    emojiPickerPresentation = 'auto';
     const button = e.currentTarget as HTMLElement;
     const rect = button.getBoundingClientRect();
     emojiPickerPos = { x: rect.left, y: rect.bottom + 4 };
   }
 
   async function handleEmojiSelect(emoji: string) {
+    emojiPickerPresentation = 'auto';
     emojiPickerPos = null;
 
     if (!msg) return;
@@ -174,6 +180,7 @@
   }
 
   function closeEmojiPicker() {
+    emojiPickerPresentation = 'auto';
     emojiPickerPos = null;
   }
 
@@ -216,10 +223,10 @@
     cancelLongPress();
   }
 
-  // Mouse handlers for touch devices that also have mouse input (e.g., tablet with mouse)
+  // Mouse fallback for pure touch-primary devices. Hybrid devices with a hover-capable
+  // pointer use the normal hover toolbar instead.
   function handleMouseDown(e: MouseEvent) {
-    // Skip on desktop - context menu handles mouse interaction
-    if (!isTouch) return;
+    if (!prefersTouch || canUseHoverActions) return;
     // Only handle left mouse button
     if (e.button !== 0) return;
     startLongPress();
@@ -869,8 +876,8 @@
           />
         {/if}
       </div>
-      <!-- Quick actions toolbar (desktop only — mobile uses long-press action sheet) -->
-      {#if !isDeleted && !isTouch}
+      <!-- Quick actions toolbar (hover-capable input; pure touch uses long-press sheet) -->
+      {#if !isDeleted && canUseHoverActions}
         <MessageHoverBar
           serverId={getActiveServer()}
           {roomId}
@@ -953,9 +960,13 @@
     </ContextMenu>
   {/if}
 
-  <!-- Emoji picker (ContextMenu handles desktop popup vs mobile BottomSheet) -->
+  <!-- Emoji picker (ContextMenu handles floating vs sheet presentation) -->
   {#if emojiPickerPos && !isDeleted}
-    <ContextMenu position={emojiPickerPos} onclose={closeEmojiPicker}>
+    <ContextMenu
+      position={emojiPickerPos}
+      presentation={emojiPickerPresentation}
+      onclose={closeEmojiPicker}
+    >
       <EmojiPicker
         serverId={getActiveServer()}
         onSelect={handleEmojiSelect}
@@ -985,7 +996,7 @@
         replyThreadLabel={replyThreadActionLabel}
         onReplyInRoom={canUseReplyAction ? handleReplyInRoom : undefined}
         onReply={canUseThreadAction ? handleOpenThread : undefined}
-        onOpenEmojiPicker={roomPermissions.canReact ? openEmojiPicker : undefined}
+        onOpenEmojiPicker={roomPermissions.canReact ? () => openEmojiPicker('sheet') : undefined}
         onClose={() => (showActionSheet = false)}
       />
     </BottomSheet>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.svelte
@@ -3,7 +3,7 @@
 
 Quick actions toolbar that appears on hover at the upper-right of a message.
 Shows quick reaction emoji and action icons (reply, edit, more menu) inline.
-Desktop only (pointer-fine); mobile uses the long-press action sheet instead.
+Hover-capable input only; pure touch devices use the long-press action sheet instead.
 
 **Props:**
 - `serverId` - Server ID (scopes the recent-emoji slots per server)
@@ -122,8 +122,8 @@ Desktop only (pointer-fine); mobile uses the long-press action sheet instead.
 
 <div
   class={[
-    'invisible absolute right-0 bottom-full z-10 mb-[-6px] hidden flex-row gap-0.5 rounded-t-md rounded-b-none border border-b-0 border-border bg-surface-100 p-0.5 md:flex',
-    'pointer-fine:group-hover:visible'
+    'invisible absolute right-0 bottom-full z-10 mb-[-6px] hidden flex-row gap-0.5 rounded-t-md rounded-b-none border border-b-0 border-border bg-surface-100 p-0.5 hover-actions:flex',
+    'hover-actions:group-hover:visible'
   ]}
   class:!visible={forceVisible}
   role="toolbar"


### PR DESCRIPTION
Separates input capability detection from viewport-driven layout state so hover/touch behavior no longer follows small-window breakpoints.
Message hover actions now use hover/fine-pointer capability checks, while pure touch-primary devices keep bottom-sheet and long-press behavior.
This fixes narrow desktop windows losing message hover actions and adds coverage for touch-primary, hybrid, and narrow desktop cases.
Validated with focused Vitest coverage, the message hover Playwright suite, and git diff whitespace checks.
