### PR TITLE
fix(frontend): harden login redirect path validation

### DIFF
--- a/apps/frontend/src/lib/navigation/safeInternalPath.spec.ts
+++ b/apps/frontend/src/lib/navigation/safeInternalPath.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { isSafeInternalPath } from './safeInternalPath';
+
+describe('isSafeInternalPath', () => {
+  it.each(['/chat', '/chat?tab=rooms', '/oauth/authorize?client_id=test', '/'])(
+    'accepts %s',
+    (value) => {
+      expect(isSafeInternalPath(value)).toBe(true);
+    }
+  );
+
+  it.each([
+    '',
+    null,
+    undefined,
+    'chat',
+    '//attacker.example/path',
+    '/\\attacker.example/path',
+    'https://attacker.example/path',
+    'http://attacker.example/path',
+    'javascript:alert(1)'
+  ])('rejects %s', (value) => {
+    expect(isSafeInternalPath(value)).toBe(false);
+  });
+});

--- a/apps/frontend/src/lib/navigation/safeInternalPath.ts
+++ b/apps/frontend/src/lib/navigation/safeInternalPath.ts
@@ -1,0 +1,16 @@
+/**
+ * Returns true when a value is safe to navigate to without validating against
+ * a server-side allow-list because it points to this origin.
+ *
+ * This accepts root-relative paths only. It rejects protocol-relative URLs,
+ * backslash variants that some routers normalize to protocol-relative URLs,
+ * absolute URLs, schemes such as `javascript:`, and empty values.
+ */
+export function isSafeInternalPath(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.startsWith('/') &&
+    !value.startsWith('//') &&
+    !value.startsWith('/\\')
+  );
+}

--- a/apps/frontend/src/routes/login/+page.svelte
+++ b/apps/frontend/src/routes/login/+page.svelte
@@ -3,6 +3,7 @@
   import { resolve } from '$app/paths';
   import AuthLayout from '$lib/components/AuthLayout.svelte';
   import * as m from '$lib/i18n/messages';
+  import { isSafeInternalPath } from '$lib/navigation/safeInternalPath';
   import type { AuthenticatedUserSummary } from '$lib/state/server/registry.svelte';
   import type { PublicAuthProvider } from '$lib/api-client/server';
   import Divider from '$lib/ui/Divider.svelte';
@@ -43,20 +44,6 @@
   const isStandalone = $derived(
     !data.serverInfo && data.serverInfoLoaded && data.redirectUrl === '/'
   );
-
-  /**
-   * Same-origin path check; mirrors the validator in +page.ts but applied
-   * to runtime values (sessionStorage.returnUrl) since +page.ts only sees
-   * the URL search params.
-   */
-  function isSafeInternalPath(value: string): boolean {
-    return (
-      typeof value === 'string' &&
-      value.startsWith('/') &&
-      !value.startsWith('//') &&
-      !value.startsWith('/\\')
-    );
-  }
 
   /**
    * Navigate after a successful login. Uses `window.location.href` for backend

--- a/apps/frontend/src/routes/login/+page.ts
+++ b/apps/frontend/src/routes/login/+page.ts
@@ -1,45 +1,24 @@
 import { redirect } from '@sveltejs/kit';
+import { isSafeInternalPath } from '$lib/navigation/safeInternalPath';
 import type { PageLoad } from './$types';
 
-/**
- * Returns true if `value` is safe to navigate to without validating against
- * a server-side allow-list — i.e. it points to *this* origin.
- *
- * Rejects:
- *   - protocol-relative URLs (`//attacker`)
- *   - backslash variants (`/\\attacker`, which some routers normalize to `//`)
- *   - absolute URLs (`https://...`, `http://...`, `javascript:...`, etc.)
- *   - empty / non-string values
- *
- * Without this check, `?redirect=https://evil.example/` chains with
- * `goto()` / `window.location.href = url` to phish credentials post-login.
- */
-function isSafeInternalPath(value: string): boolean {
-  return (
-    typeof value === 'string' &&
-    value.startsWith('/') &&
-    !value.startsWith('//') &&
-    !value.startsWith('/\\')
-  );
-}
-
 export const load: PageLoad = async ({ parent, url }) => {
-	const { user } = await parent();
-	const raw = url.searchParams.get('redirect') ?? '';
-	const redirectUrl = isSafeInternalPath(raw) ? raw : '/';
+  const { user } = await parent();
+  const raw = url.searchParams.get('redirect') ?? '';
+  const redirectUrl = isSafeInternalPath(raw) ? raw : '/';
 
-	if (user) {
-		redirect(302, redirectUrl.startsWith('/oauth/') ? redirectUrl : '/chat');
-	}
+  if (user) {
+    redirect(302, redirectUrl.startsWith('/oauth/') ? redirectUrl : '/chat');
+  }
 
-	return {
-		/** URL to redirect to after login (default: /). Must be a same-origin path. */
-		redirectUrl,
+  return {
+    /** URL to redirect to after login (default: /). Must be a same-origin path. */
+    redirectUrl,
 
-		/** Known provider/auth redirect error code to render on the login page. */
-		loginErrorCode: url.searchParams.get('error') ?? '',
+    /** Known provider/auth redirect error code to render on the login page. */
+    loginErrorCode: url.searchParams.get('error') ?? '',
 
-		/** Whether the user just completed a password reset */
-		passwordResetSuccess: url.searchParams.get('reset') === 'success'
-	};
+    /** Whether the user just completed a password reset */
+    passwordResetSuccess: url.searchParams.get('reset') === 'success'
+  };
 };


### PR DESCRIPTION
## Summary
- Extracted internal path validation into a shared `safeInternalPath` helper
- Reused the helper in both the login page load function and the login UI flow
- Added unit coverage for accepted and rejected redirect values

## Why
The login flow accepts a `redirect` parameter and also reads a runtime return URL. Centralizing the same-origin check avoids duplicated logic and reduces the chance of a future mismatch between server-side and client-side handling.

The helper only allows root-relative paths and rejects protocol-relative, backslash-normalized, absolute, and empty values. That prevents open-redirect style abuse after authentication.

## Testing
- Added `safeInternalPath.spec.ts` for safe and unsafe path cases
- Existing login behavior now uses the shared validator in both places