### PR TITLE
fix(realtime): align heartbeat cadence with client stall detection

### DIFF
--- a/apps/frontend/src/lib/state/server/eventBus.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/eventBus.svelte.spec.ts
@@ -103,13 +103,13 @@ function serverFrame(frame: RealtimeServerFrame['frame']): RealtimeServerFrame {
   return new RealtimeServerFrame({ frame });
 }
 
-function helloFrame(): RealtimeServerFrame {
+function helloFrame(heartbeatIntervalSeconds = 10): RealtimeServerFrame {
   return serverFrame({
     case: 'hello',
     value: new RealtimeServerHello({
       protocolVersion: 1,
       serverVersion: 'test',
-      heartbeatIntervalSeconds: 10
+      heartbeatIntervalSeconds
     })
   });
 }
@@ -172,6 +172,20 @@ async function startAndSubscribe(fake = new FakeServerConnection()): Promise<{
   if (!socket) throw new Error('expected realtime socket');
   socket.open();
   await socket.receive(helloFrame());
+  await socket.receive(subscribedFrame());
+  return { fake, socket };
+}
+
+async function startAndSubscribeWithHeartbeatInterval(heartbeatIntervalSeconds: number): Promise<{
+  fake: FakeServerConnection;
+  socket: FakeRealtimeSocket;
+}> {
+  const fake = new FakeServerConnection();
+  eventBusManager.startBus(TEST_SERVER, fake as unknown as ServerConnection);
+  const socket = sockets.at(-1);
+  if (!socket) throw new Error('expected realtime socket');
+  socket.open();
+  await socket.receive(helloFrame(heartbeatIntervalSeconds));
   await socket.receive(subscribedFrame());
   return { fake, socket };
 }
@@ -402,16 +416,22 @@ describe('eventBusManager realtime transport', () => {
 
   it('reconnects and notifies catch-up handlers when heartbeats stall', async () => {
     vi.useFakeTimers();
-    await startAndSubscribe();
+    await startAndSubscribeWithHeartbeatInterval(15);
     const catchUp = vi.fn();
     eventBusManager.getBus(TEST_SERVER)!.catchUpHandlers.add(catchUp);
 
-    await vi.advanceTimersByTimeAsync(90_000);
+    await vi.advanceTimersByTimeAsync(44_999);
+
+    expect(catchUp).not.toHaveBeenCalled();
+    expect(sockets).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(1);
 
     expect(catchUp).toHaveBeenCalledWith({
       reason: 'heartbeat-stalled',
       phase: 'immediate'
     });
+    await vi.advanceTimersByTimeAsync(1);
     expect(sockets).toHaveLength(2);
   });
 

--- a/apps/frontend/src/lib/state/server/eventBus.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/eventBus.svelte.spec.ts
@@ -435,6 +435,25 @@ describe('eventBusManager realtime transport', () => {
     expect(sockets).toHaveLength(2);
   });
 
+  it('falls back to the previous stall timeout when heartbeat interval is omitted', async () => {
+    vi.useFakeTimers();
+    await startAndSubscribeWithHeartbeatInterval(0);
+    const catchUp = vi.fn();
+    eventBusManager.getBus(TEST_SERVER)!.catchUpHandlers.add(catchUp);
+
+    await vi.advanceTimersByTimeAsync(74_999);
+
+    expect(catchUp).not.toHaveBeenCalled();
+    expect(sockets).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(catchUp).toHaveBeenCalledWith({
+      reason: 'heartbeat-stalled',
+      phase: 'immediate'
+    });
+  });
+
   it('does not dispatch heartbeat frames to handlers', async () => {
     const { socket } = await startAndSubscribe();
     const handler = vi.fn();

--- a/apps/frontend/src/lib/state/server/eventBus.svelte.ts
+++ b/apps/frontend/src/lib/state/server/eventBus.svelte.ts
@@ -81,6 +81,7 @@ function subscribeEventsFrame(): Uint8Array {
 }
 
 function heartbeatStallMsForInterval(seconds: number): number {
+  if (seconds <= 0) return DEFAULT_HEARTBEAT_STALL_MS;
   return Math.max(MIN_HEARTBEAT_STALL_MS, seconds * MISSED_HEARTBEATS_BEFORE_STALL * 1000);
 }
 

--- a/apps/frontend/src/lib/state/server/eventBus.svelte.ts
+++ b/apps/frontend/src/lib/state/server/eventBus.svelte.ts
@@ -26,7 +26,9 @@ import {
 } from '@chatto/api-types/realtime/v1/realtime_pb';
 import type { ServerConnection } from './serverConnection.svelte';
 
-const HEARTBEAT_STALL_MS = 75_000;
+const DEFAULT_HEARTBEAT_STALL_MS = 75_000;
+const MIN_HEARTBEAT_STALL_MS = 30_000;
+const MISSED_HEARTBEATS_BEFORE_STALL = 3;
 const HEARTBEAT_WATCHDOG_MS = 15_000;
 const CATCH_UP_RETRY_MS = 2_500;
 const RECONNECT_WAIT_MS = 5_000;
@@ -78,6 +80,10 @@ function subscribeEventsFrame(): Uint8Array {
   }).toBinary();
 }
 
+function heartbeatStallMsForInterval(seconds: number): number {
+  return Math.max(MIN_HEARTBEAT_STALL_MS, seconds * MISSED_HEARTBEATS_BEFORE_STALL * 1000);
+}
+
 class EventBusManager {
   // SvelteMap so getBus() is a reactive read — consumers like NotificationSync
   // re-run their $effect when a bus is started/stopped, avoiding mount races.
@@ -98,6 +104,7 @@ class EventBusManager {
     const catchUpHandlers = new SvelteSet<EventBusCatchUpHandler>();
     const bus: EventBus = { handlers, catchUpHandlers };
     let lastEventAt = Date.now();
+    let heartbeatStallMs = DEFAULT_HEARTBEAT_STALL_MS;
     let heartbeatCount = 0;
     let dispatchedEventCount = 0;
     let reconnectCount = 0;
@@ -114,6 +121,7 @@ class EventBusManager {
       events: dispatchedEventCount,
       heartbeats: heartbeatCount,
       reconnects: reconnectCount,
+      heartbeatStallMs,
       lastEventAgeMs: Date.now() - lastEventAt
     });
 
@@ -229,6 +237,9 @@ class EventBusManager {
           lastEventAt = Date.now();
           switch (frame.frame.case) {
             case 'hello':
+              heartbeatStallMs = heartbeatStallMsForInterval(
+                frame.frame.value.heartbeatIntervalSeconds
+              );
               nextSocket.send(subscribeEventsFrame());
               return;
             case 'subscribed':
@@ -345,7 +356,7 @@ class EventBusManager {
       if (stopped) return;
       if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
       const ageMs = Date.now() - lastEventAt;
-      if (ageMs < HEARTBEAT_STALL_MS) return;
+      if (ageMs < heartbeatStallMs) return;
       console.warn(`[eventBus:${serverId}] heartbeat stalled`, {
         ageMs,
         ...debugState()

--- a/cli/internal/core/my_events_model.go
+++ b/cli/internal/core/my_events_model.go
@@ -16,12 +16,18 @@ import (
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
-// liveEVTProjectionWaitTimeout bounds the causal barrier between JetStream's
-// raw EVT republish and realtime delivery. In the normal case the local
-// projectors have already advanced and WaitFor returns immediately; the
-// timeout covers replica lag or a stuck projector without wedging a
-// subscription goroutine forever.
-const liveEVTProjectionWaitTimeout = 2 * time.Second
+const (
+	// liveEVTProjectionWaitTimeout bounds the causal barrier between JetStream's
+	// raw EVT republish and realtime delivery. In the normal case the local
+	// projectors have already advanced and WaitFor returns immediately; the
+	// timeout covers replica lag or a stuck projector without wedging a
+	// subscription goroutine forever.
+	liveEVTProjectionWaitTimeout = 2 * time.Second
+
+	// MyEventsHeartbeatInterval controls the synthetic heartbeat cadence used by
+	// StreamMyEvents and advertised by the realtime WebSocket protocol.
+	MyEventsHeartbeatInterval = 15 * time.Second
+)
 
 // MyEventsModel owns the server-side myEvents live stream machinery.
 //
@@ -105,7 +111,7 @@ func (s *MyEventsModel) Metrics() MyEventsMetrics {
 //
 // The subscription also tracks presence liveness: subscribing implies the user
 // is online, and a ticker refreshes the KV TTL while the connection lives. A
-// synthetic Heartbeat is emitted every 25s so clients can detect a dead
+// synthetic Heartbeat is emitted every 15s so clients can detect a dead
 // subscription on an otherwise-healthy WebSocket.
 //
 // The returned channel closes when the context is cancelled or when a
@@ -176,7 +182,7 @@ func (s *MyEventsModel) StreamMyEvents(ctx context.Context, userID string, optio
 			defer presenceTicker.Stop()
 		}
 
-		heartbeatTicker := time.NewTicker(25 * time.Second)
+		heartbeatTicker := time.NewTicker(MyEventsHeartbeatInterval)
 		defer heartbeatTicker.Stop()
 
 		lastKnownPresence := presenceSub.Snapshot

--- a/cli/internal/http_server/realtime.go
+++ b/cli/internal/http_server/realtime.go
@@ -26,7 +26,7 @@ const (
 	realtimeReadLimitBytes           = 64 << 10
 	realtimeHandshakeTimeout         = 10 * time.Second
 	realtimeWriteTimeout             = 10 * time.Second
-	realtimeHeartbeatIntervalSeconds = 25
+	realtimeHeartbeatIntervalSeconds = uint32(core.MyEventsHeartbeatInterval / time.Second)
 )
 
 var realtimeServerCapabilities = []string{

--- a/cli/internal/http_server/realtime_test.go
+++ b/cli/internal/http_server/realtime_test.go
@@ -82,6 +82,8 @@ func subscribeRealtime(t *testing.T, conn *websocket.Conn, token string) {
 		t.Fatalf("first realtime frame = %T, want hello", hello.GetFrame())
 	} else if got.ProtocolVersion != realtimeProtocolVersion || got.ServerVersion == "" {
 		t.Fatalf("unexpected realtime hello: %+v", got)
+	} else if got.HeartbeatIntervalSeconds != uint32(core.MyEventsHeartbeatInterval/time.Second) {
+		t.Fatalf("heartbeat interval = %d, want %d", got.HeartbeatIntervalSeconds, core.MyEventsHeartbeatInterval/time.Second)
 	} else if !slices.Equal(got.GetCapabilities(), realtimeServerCapabilities) {
 		t.Fatalf("realtime capabilities = %v, want %v", got.GetCapabilities(), realtimeServerCapabilities)
 	}

--- a/cli/internal/pb/chatto/core/v1/live_events.pb.go
+++ b/cli/internal/pb/chatto/core/v1/live_events.pb.go
@@ -443,7 +443,7 @@ func (*LiveEvent_RoomGroupsUpdated) isLiveEvent_Event() {}
 func (*LiveEvent_SessionTerminated) isLiveEvent_Event() {}
 
 // HeartbeatEvent is a synthetic event with no payload. StreamMyEvents
-// emits one every ~25 seconds so clients can detect a dead subscription
+// emits one every ~15 seconds so clients can detect a dead subscription
 // on an otherwise-healthy WebSocket. It is never persisted and never
 // travels over NATS.
 type HeartbeatEvent struct {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -621,7 +621,7 @@ The `/api/realtime` WebSocket is backed by the single core stream `StreamMyEvent
 - One `ChanSubscribe("live.sync.>")` for transient `LiveEvent` messages, and one `ChanSubscribe("live.evt.>")` for raw committed EVT facts. Authorization is applied per event: room membership for room subjects, asset room membership for asset subjects, `isAuthorizedForLiveEvent` for user/config/member subjects, and projection readiness before deliverable `live.evt.>` events.
 - Live-only subscription delivery. Missed state after reconnect is recovered from projected reads: server-scoped stores refetch their current projections after event-bus gaps, and the visible room/thread refetches its current message window. Transient sync and presence signals remain live-only.
 - The PresenceHub (single per-process KV watcher on `presence.>` fanning out per-user status changes to all subscribers).
-- An in-process heartbeat ticker (synthetic `Heartbeat` event every 25s for client-side liveness detection).
+- An in-process heartbeat ticker (synthetic `Heartbeat` event every 15s for client-side liveness detection).
 
 ### KV Buckets (backed by streams)
 

--- a/proto/chatto/core/v1/live_events.proto
+++ b/proto/chatto/core/v1/live_events.proto
@@ -92,7 +92,7 @@ message LiveEvent {
 // ============================================================================
 
 // HeartbeatEvent is a synthetic event with no payload. StreamMyEvents
-// emits one every ~25 seconds so clients can detect a dead subscription
+// emits one every ~15 seconds so clients can detect a dead subscription
 // on an otherwise-healthy WebSocket. It is never persisted and never
 // travels over NATS.
 message HeartbeatEvent {}


### PR DESCRIPTION
## Summary
- Reduce the server-side `Heartbeat` cadence for `StreamMyEvents` from 25s to 15s.
- Advertise the new heartbeat interval in the realtime WebSocket hello frame.
- Update the frontend event bus to derive its stall timeout from the negotiated heartbeat interval instead of a fixed 75s threshold.
- Refresh docs and tests to cover the new timing.

## Why
The realtime client was assuming a fixed stall window that did not track the server’s advertised heartbeat cadence. By making the stall detection interval depend on the negotiated heartbeat interval, reconnect behavior stays consistent if the server heartbeat changes again.

## Changes
- `cli/internal/core/my_events_model.go`
  - Introduce a shared `MyEventsHeartbeatInterval` constant and use it for synthetic heartbeats.
- `cli/internal/http_server/realtime.go`
  - Send the heartbeat interval from the shared constant in the realtime hello frame.
- `apps/frontend/src/lib/state/server/eventBus.svelte.ts`
  - Compute the heartbeat stall threshold from the server-provided interval, with a minimum floor.
- `apps/frontend/src/lib/state/server/eventBus.svelte.spec.ts`
  - Add coverage for reconnect timing based on a shorter negotiated heartbeat interval.
- `cli/internal/http_server/realtime_test.go`
  - Assert the hello frame advertises the expected interval.
- `proto/chatto/core/v1/live_events.proto`, `cli/internal/pb/chatto/core/v1/live_events.pb.go`, `docs/ARCHITECTURE.md`
  - Update comments and architecture docs to reflect the 15s heartbeat cadence.
