### PR TITLE
fix(pwa): stop preserving push badge hints

### DIFF
--- a/apps/frontend/e2e/service-worker.test.ts
+++ b/apps/frontend/e2e/service-worker.test.ts
@@ -22,7 +22,7 @@ type BadgeStateSnapshot = {
   serviceWorkerAppBadgeEnabled: boolean | null;
 };
 
-const BADGE_STATE_CACHE_NAME = 'chatto-badge-state-v1';
+const BADGE_STATE_CACHE_NAME = 'chatto-badge-state-v2';
 const BADGE_STATE_REQUEST = '/__chatto/foreground-notification-count';
 
 test('service worker caches only the app shell and serves it offline', async ({
@@ -94,8 +94,8 @@ test('browser-tab badge-state messages do not crash service worker badging', asy
     return {
       controlled: Boolean(navigator.serviceWorker.controller),
       pageBadgingApiPresent: 'setAppBadge' in navigator,
-      installedAppDisplayMode: standaloneDisplayModes.some((mode) =>
-        window.matchMedia(`(display-mode: ${mode})`).matches
+      installedAppDisplayMode: standaloneDisplayModes.some(
+        (mode) => window.matchMedia(`(display-mode: ${mode})`).matches
       )
     };
   });

--- a/apps/frontend/src/lib/pwa/notificationBadge.worker.spec.ts
+++ b/apps/frontend/src/lib/pwa/notificationBadge.worker.spec.ts
@@ -312,6 +312,74 @@ describe('ServiceWorkerBadgeCoordinator', () => {
     expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
   });
 
+  it('clears a push-only badge after clicking the only native notification', async () => {
+    const registration = {
+      getNotifications: vi.fn(async () => [])
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+    const coordinator = new ServiceWorkerBadgeCoordinator(registration, badgeNavigator);
+
+    coordinator.recordRegularPush();
+    await coordinator.setProvisionalPushFlagBadge();
+    await coordinator.reconcileAfterNotificationClick();
+
+    expect(badgeNavigator.setAppBadge).toHaveBeenCalledOnce();
+    expect(badgeNavigator.clearAppBadge).toHaveBeenCalledOnce();
+  });
+
+  it('sets push app badge counts immediately without preserving them after click', async () => {
+    const registration = {
+      getNotifications: vi.fn(async () => [])
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+    const coordinator = new ServiceWorkerBadgeCoordinator(registration, badgeNavigator);
+
+    await coordinator.setPushAppBadgeCount(1);
+    await coordinator.reconcileAfterNotificationClick();
+
+    expect(badgeNavigator.setAppBadge).toHaveBeenCalledWith(1);
+    expect(badgeNavigator.clearAppBadge).toHaveBeenCalledOnce();
+  });
+
+  it('does not persist push app badge counts as foreground state', async () => {
+    const registration = {
+      getNotifications: vi.fn(async () => [])
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+    const foregroundCountStorage = createMemoryForegroundCountStorage();
+
+    const firstCoordinator = new ServiceWorkerBadgeCoordinator(
+      registration,
+      badgeNavigator,
+      foregroundCountStorage
+    );
+    await firstCoordinator.applyForegroundNotificationCount(0, {
+      serviceWorkerAppBadgeEnabled: true
+    });
+    badgeNavigator.clearAppBadge.mockClear();
+    badgeNavigator.setAppBadge.mockClear();
+
+    await firstCoordinator.setPushAppBadgeCount(1);
+
+    await new ServiceWorkerBadgeCoordinator(
+      registration,
+      badgeNavigator,
+      foregroundCountStorage
+    ).reconcileAfterNotificationClick();
+
+    expect(badgeNavigator.setAppBadge).toHaveBeenCalledWith(1);
+    expect(badgeNavigator.clearAppBadge).toHaveBeenCalledOnce();
+  });
+
   it('does not preserve a cached foreground count after a dismiss push', async () => {
     const registration = {
       getNotifications: vi.fn(async () => [])

--- a/apps/frontend/src/lib/pwa/notificationBadge.worker.ts
+++ b/apps/frontend/src/lib/pwa/notificationBadge.worker.ts
@@ -193,14 +193,18 @@ export class ServiceWorkerBadgeCoordinator {
       count,
       await this.isServiceWorkerAppBadgeEnabled()
     );
-    await applyAuthoritativeBadgeState(this.registration, await this.badgeNavigatorIfEnabled(), count, {
-      isCurrent
-    });
+    await applyAuthoritativeBadgeState(
+      this.registration,
+      await this.badgeNavigatorIfEnabled(),
+      count,
+      {
+        isCurrent
+      }
+    );
   }
 
   recordRegularPush(): void {
     this.#gate.invalidate();
-    this.#foregroundNotificationCount = Math.max(this.#foregroundNotificationCount ?? 0, 1);
   }
 
   async reconcileAfterDismissPush(): Promise<void> {
@@ -214,9 +218,16 @@ export class ServiceWorkerBadgeCoordinator {
     this.#gate.invalidate();
     const persistedForegroundCount =
       (await this.foregroundCountStorage?.readForegroundNotificationCount()) ?? 0;
-    await syncBadgeFromNativeNotifications(this.registration, await this.badgeNavigatorIfEnabled(), {
-      minimumNotificationCount: Math.max(this.#foregroundNotificationCount ?? 0, persistedForegroundCount)
-    });
+    await syncBadgeFromNativeNotifications(
+      this.registration,
+      await this.badgeNavigatorIfEnabled(),
+      {
+        minimumNotificationCount: Math.max(
+          this.#foregroundNotificationCount ?? 0,
+          persistedForegroundCount
+        )
+      }
+    );
   }
 
   async setProvisionalPushFlagBadge(): Promise<void> {
@@ -227,11 +238,6 @@ export class ServiceWorkerBadgeCoordinator {
   async setPushAppBadgeCount(notificationCount: number): Promise<void> {
     this.#gate.invalidate();
     const count = normalizeBadgeCount(notificationCount);
-    this.#foregroundNotificationCount = count;
-    await this.foregroundCountStorage?.writeForegroundNotificationState(
-      count,
-      await this.isServiceWorkerAppBadgeEnabled()
-    );
 
     const badgeNavigator = await this.badgeNavigatorIfEnabled();
     if (count > 0) {

--- a/apps/frontend/src/service-worker.spec.ts
+++ b/apps/frontend/src/service-worker.spec.ts
@@ -222,6 +222,53 @@ describe('service worker badge orchestration', () => {
     });
   });
 
+  it('clears a declarative DM push app badge after clicking the only native notification', async () => {
+    const worker = await importServiceWorker();
+
+    await worker.dispatch('message', {
+      data: {
+        type: 'chatto-badge-state',
+        notificationCount: 0,
+        serviceWorkerAppBadgeEnabled: true
+      }
+    });
+    worker.clearAppBadge.mockClear();
+    worker.setAppBadge.mockClear();
+
+    await worker.dispatch('push', {
+      data: {
+        json: () => ({
+          web_push: 8030,
+          notification: {
+            title: 'New DM',
+            body: 'Hello from a DM',
+            tag: 'dm-event-1',
+            app_badge: '1',
+            navigate: 'https://chatto.example/chat/-/dm-room-1',
+            data: {
+              notificationId: 'notif-dm-1',
+              url: 'https://chatto.example/chat/-/dm-room-1'
+            }
+          }
+        })
+      }
+    });
+
+    const options = worker.registration.showNotification.mock.calls[0][1] as NotificationOptions;
+    worker.registration.getNotifications.mockResolvedValueOnce([]);
+
+    await worker.dispatch('notificationclick', {
+      notification: {
+        close: vi.fn(),
+        data: options.data as { url?: string }
+      }
+    });
+
+    expect(worker.setAppBadge).toHaveBeenCalledOnce();
+    expect(worker.setAppBadge).toHaveBeenCalledWith(1);
+    expect(worker.clearAppBadge).toHaveBeenCalledOnce();
+  });
+
   it('handles mutable declarative push events with event.notification and no payload data', async () => {
     const worker = await importServiceWorker();
 

--- a/apps/frontend/src/service-worker.ts
+++ b/apps/frontend/src/service-worker.ts
@@ -24,7 +24,7 @@ declare const self: ServiceWorkerGlobalScope;
 
 const CACHE_PREFIX = 'chatto-shell';
 const CACHE_NAME = `${CACHE_PREFIX}-${version}`;
-const BADGE_STATE_CACHE_NAME = 'chatto-badge-state-v1';
+const BADGE_STATE_CACHE_NAME = 'chatto-badge-state-v2';
 const SHELL_ASSETS = new Set([...build, ...files, OFFLINE_SHELL_PATH]);
 const PRECACHE_ASSETS = Array.from(new Set([...build, OFFLINE_SHELL_PATH, '/']));
 


### PR DESCRIPTION
## Summary

This fixes stale PWA icon badges by keeping push-provided `app_badge` values as immediate display hints instead of persisting them as foreground-authoritative notification counts. It bumps the service worker badge-state cache so old push-derived counts are ignored, and adds regression coverage for push-only badges plus a DM-shaped declarative push payload.

## Validation

- `mise x -- pnpm --filter @chatto/api-types build`
- `mise x -- pnpm exec vitest run src/lib/pwa/notificationBadge.worker.spec.ts src/service-worker.spec.ts src/lib/components/NotificationSync.svelte.spec.ts src/lib/notifications/appBadge.spec.ts`
- `mise x -- pnpm --filter chatto-frontend exec playwright test e2e/service-worker.test.ts --retries=0`
- `git diff --check`
- `mise x -- pnpm exec prettier --check src/lib/pwa/notificationBadge.worker.ts src/service-worker.ts src/lib/pwa/notificationBadge.worker.spec.ts src/service-worker.spec.ts`
- `mise x -- pnpm exec prettier --check e2e/service-worker.test.ts`

Note: `mise test-frontend` was attempted twice but failed on unrelated Vite dependency optimization reload/import failures and existing component test failures in `ServerSidebarEntry` and `AdminRoomLayoutEditor`.
