### PR TITLE
fix(docs): add community chat link

### DIFF
--- a/apps/docs-website/astro.config.mjs
+++ b/apps/docs-website/astro.config.mjs
@@ -32,6 +32,9 @@ export default defineConfig({
     starlight({
       title: "Chatto",
       customCss: ["./src/custom.css"],
+      components: {
+        SocialIcons: "./src/components/SocialIcons.astro",
+      },
       social: [
         {
           icon: "github",

--- a/apps/docs-website/src/components/SocialIcons.astro
+++ b/apps/docs-website/src/components/SocialIcons.astro
@@ -1,0 +1,56 @@
+---
+import config from "virtual:starlight/user-config";
+import { Icon } from "@astrojs/starlight/components";
+
+const links = config.social || [];
+const communityHref = "https://chat.chatto.run/";
+---
+
+{
+  links.length > 0 && (
+    <>
+      {links.map(({ label, href, icon }) => (
+        <a {href} rel="me" class="sl-flex icon-link">
+          <span class="sr-only">{label}</span>
+          <Icon name={icon} />
+        </a>
+      ))}
+    </>
+  )
+}
+<a href={communityHref} class="community-link">
+  <span class="sr-only">Official Chatto Community</span>
+  <span aria-hidden="true">Community</span>
+</a>
+
+<style>
+  @layer starlight.core {
+    a {
+      color: var(--sl-color-text-accent);
+      text-decoration: none;
+    }
+
+    a:hover {
+      color: var(--sl-color-white);
+    }
+
+    .icon-link {
+      padding: 0.5em;
+      margin: -0.5em;
+    }
+
+    .community-link {
+      border: 1px solid var(--sl-color-gray-5);
+      border-radius: 999rem;
+      font-size: var(--sl-text-sm);
+      font-weight: 600;
+      line-height: 1;
+      padding: 0.45rem 0.7rem;
+      white-space: nowrap;
+    }
+
+    .community-link:hover {
+      border-color: var(--sl-color-text-accent);
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- add a Starlight SocialIcons override for the docs header
- keep the existing GitHub icon and add a Community link to the official Chatto server

## Verification
- pnpm --dir apps/docs-website run build
- Chrome DevTools MCP: checked desktop header and mobile docs drawer links
