### PR TITLE
fix(frontend): skip short browser resumes and soften message refreshes

### DIFF
--- a/apps/frontend/src/lib/hooks/useMayHaveMissedMessagesCallback.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/useMayHaveMissedMessagesCallback.svelte.spec.ts
@@ -22,6 +22,10 @@ vi.mock('$lib/state/server/connection.svelte', () => ({
   useConnection: () => () => ({ reconnectCount: 0 })
 }));
 
+vi.mock('$lib/hooks/useReconnectCallback.svelte', () => ({
+  useReconnectCallback: () => undefined
+}));
+
 class FakeServerConnection {
   reconnectCount = $state(0);
   realtimeUrl = 'ws://test-server/api/realtime';
@@ -33,11 +37,20 @@ class FakeServerConnection {
 
 const TEST_SERVER = 'test-server';
 
+function setVisibilityState(value: DocumentVisibilityState): void {
+  Object.defineProperty(document, 'visibilityState', {
+    value,
+    configurable: true
+  });
+  document.dispatchEvent(new Event('visibilitychange'));
+}
+
 describe('useMayHaveMissedMessagesCallback', () => {
   let consoleDebug: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     mocks.activeServerId = TEST_SERVER;
+    setVisibilityState('visible');
     setRealtimeSocketFactoryForTests(() => ({
       binaryType: 'arraybuffer',
       readyState: 0,
@@ -52,6 +65,7 @@ describe('useMayHaveMissedMessagesCallback', () => {
   });
 
   afterEach(() => {
+    setVisibilityState('visible');
     vi.useRealTimers();
     eventBusManager.stopBus(TEST_SERVER);
     setRealtimeSocketFactoryForTests(null);
@@ -83,6 +97,64 @@ describe('useMayHaveMissedMessagesCallback', () => {
         reason: 'event-bus-heartbeat-stalled',
         phase: 'immediate',
         source: 'event-bus'
+      })
+    );
+    rendered.unmount();
+  });
+
+  it('skips short browser visibility resumes', async () => {
+    vi.useFakeTimers();
+    const onSignal = vi.fn().mockResolvedValue(undefined);
+
+    const rendered = render(Harness, { props: { onSignal } });
+    flushSync();
+
+    setVisibilityState('hidden');
+    await vi.advanceTimersByTimeAsync(1_449);
+    setVisibilityState('visible');
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(onSignal).not.toHaveBeenCalled();
+    rendered.unmount();
+  });
+
+  it('skips short browser pageshow resumes with known hidden duration', async () => {
+    vi.useFakeTimers();
+    const onSignal = vi.fn().mockResolvedValue(undefined);
+
+    const rendered = render(Harness, { props: { onSignal } });
+    flushSync();
+
+    setVisibilityState('hidden');
+    await vi.advanceTimersByTimeAsync(1_449);
+    setVisibilityState('visible');
+    window.dispatchEvent(new Event('pageshow'));
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(onSignal).not.toHaveBeenCalled();
+    rendered.unmount();
+  });
+
+  it('runs the callback for longer browser visibility resumes', async () => {
+    vi.useFakeTimers();
+    const onSignal = vi.fn().mockResolvedValue(undefined);
+
+    const rendered = render(Harness, { props: { onSignal } });
+    flushSync();
+
+    setVisibilityState('hidden');
+    await vi.advanceTimersByTimeAsync(30_000);
+    setVisibilityState('visible');
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(onSignal).toHaveBeenCalledOnce();
+    expect(onSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverId: TEST_SERVER,
+        reason: 'visibility',
+        phase: 'immediate',
+        source: 'browser',
+        hiddenDurationMs: 30_000
       })
     );
     rendered.unmount();

--- a/apps/frontend/src/lib/hooks/useMayHaveMissedMessagesCallback.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useMayHaveMissedMessagesCallback.svelte.ts
@@ -21,9 +21,19 @@ export type MayHaveMissedMessagesReason =
   | 'manual-shortcut';
 
 const DEDUPE_MS = 1_000;
+const SHORT_BROWSER_RESUME_SKIP_MS = 30_000;
 
 function isEventBusReason(reason: MayHaveMissedMessagesReason): boolean {
   return reason.startsWith('event-bus-');
+}
+
+function shouldSkipShortBrowserResume(signal: ResumeSignal): boolean {
+  return (
+    signal.source === 'browser' &&
+    (signal.reason === 'visibility' || signal.reason === 'pageshow') &&
+    signal.hiddenDurationMs !== null &&
+    signal.hiddenDurationMs < SHORT_BROWSER_RESUME_SKIP_MS
+  );
 }
 
 function isEditableTarget(target: EventTarget | null): boolean {
@@ -89,6 +99,10 @@ function createRefreshRunner(
   return {
     trigger(signal: ResumeSignal): void {
       const now = Date.now();
+      if (shouldSkipShortBrowserResume(signal)) {
+        console.debug('[room-refresh] skipped short browser resume signal', signal);
+        return;
+      }
       if (inFlight) {
         queuedSignal = signal;
         console.debug('[room-refresh] queued maybe-missed signal while refresh is running', signal);

--- a/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -1009,6 +1009,68 @@ describe('MessagesStore — room lifecycle ownership', () => {
     store.dispose();
   });
 
+  it('soft-refreshes the latest room window without collapsing already-loaded history', async () => {
+    const initialLatest = Array.from({ length: 50 }, (_, index) =>
+      threadMessageEvent(`m${index + 51}`)
+    );
+    const older = Array.from({ length: 50 }, (_, index) => threadMessageEvent(`m${index + 1}`));
+    const refreshedLatest = Array.from({ length: 100 }, (_, index) => {
+      const id = `m${index + 2}`;
+      return id === 'm90' ? messageWithReaction(id, 'thumbsup') : threadMessageEvent(id);
+    });
+    const fake = new FakeQueryClient([
+      roomEventsResult({
+        events: initialLatest,
+        startCursor: 'tl:cursor-51',
+        endCursor: 'tl:cursor-100',
+        hasOlder: true,
+        hasNewer: false
+      }),
+      roomEventsResult({
+        events: older,
+        startCursor: 'tl:cursor-1',
+        endCursor: 'tl:cursor-50',
+        hasOlder: false,
+        hasNewer: true
+      }),
+      roomEventsResult({
+        events: refreshedLatest,
+        startCursor: 'tl:cursor-2',
+        endCursor: 'tl:cursor-101',
+        hasOlder: true,
+        hasNewer: false
+      })
+    ]);
+    const store = new MessagesStore(
+      fake as unknown as ServerConnection,
+      () => null,
+      timelineFromFixtures(fake)
+    );
+
+    store.setRoom('room-1');
+    await settle();
+    await store.loadMore();
+    await settle();
+    expect(store.rootEvents).toHaveLength(100);
+    fake.queryMock.mockClear();
+
+    await store.refreshCurrentWindow();
+    await settle();
+
+    expect(store.isInitialLoading).toBe(false);
+    expect(store.rootEvents.map((event) => event.id)).toEqual(
+      Array.from({ length: 101 }, (_, index) => `m${index + 1}`)
+    );
+    expect(store.rootEvents.find((event) => event.id === 'm90')?.event).toMatchObject({
+      reactions: [{ emoji: 'thumbsup', count: 1 }]
+    });
+    expect(store.hasReachedStart).toBe(true);
+    expect(fake.queryMock).toHaveBeenCalledOnce();
+    expect(fake.queryMock.mock.calls[0][1]).toEqual({ roomId: 'room-1', limit: 100 });
+    expect(fake.queryMock.mock.calls[0][2]).toEqual({ requestPolicy: 'network-only' });
+    store.dispose();
+  });
+
   it('soft-refreshes around an anchor event when one is provided', async () => {
     const fake = new FakeQueryClient([
       roomEventsResult({

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -11,6 +11,7 @@ import { isRootRoomEvent, isThreadEvent } from './filters';
 import { type EventConnectionPage, type RawEvent, getActorId, unmask } from './helpers';
 
 type MessageScope = 'room' | 'thread';
+type SnapshotCursorMode = 'replace' | 'preserve' | 'latest';
 type RoomEventPayload = NonNullable<RoomEventView['event']>;
 type MessagePostedPayload = Extract<RoomEventPayload, { kind: typeof RoomEventKind.MessagePosted }>;
 type MessageEditedPayload = Extract<RoomEventPayload, { kind: typeof RoomEventKind.MessageEdited }>;
@@ -32,6 +33,8 @@ export type RefreshCurrentWindowResult = {
   hasNewer: boolean;
   refreshed: boolean;
 };
+
+const MAX_SOFT_REFRESH_PAGE_SIZE = 500;
 
 function eventCacheKey(roomId: string, eventId: string): string {
   return `${roomId}\u0000${eventId}`;
@@ -238,6 +241,10 @@ export class MessagesStore {
   /** True if a newer load has started; caller should discard its result. */
   private isStale(thisLoad: number): boolean {
     return this.#loadId !== thisLoad;
+  }
+
+  private softRefreshLimit(): number {
+    return Math.min(Math.max(PAGE_SIZE, this.events.length), MAX_SOFT_REFRESH_PAGE_SIZE);
   }
 
   private previewKey(eventId: string): string {
@@ -888,7 +895,7 @@ export class MessagesStore {
       hasOlder?: boolean;
     },
     existingBeforeFetch: ReadonlySet<string>,
-    options: { preserveExistingWindow?: boolean } = {}
+    options: { cursorMode?: SnapshotCursorMode } = {}
   ): void {
     const fetched = unmask(connection.events);
     const newSeen = new SvelteSet<string>();
@@ -896,6 +903,7 @@ export class MessagesStore {
     const previousOldestCursor = this.oldestCursor;
     const previousNewestCursor = this.newestCursor;
     const previousHasReachedStart = this.hasReachedStart;
+    const cursorMode = options.cursorMode ?? 'replace';
 
     for (const e of fetched) {
       if (newSeen.has(e.id)) continue;
@@ -904,11 +912,11 @@ export class MessagesStore {
     }
 
     // Preserve subscription events that arrived while the refresh query was in
-    // flight. Anchored refreshes also preserve already-loaded rows outside the
-    // fetched window so returning from another tab does not visually collapse a
-    // long scrolled buffer.
+    // flight. Soft catch-up refreshes also preserve already-loaded rows outside
+    // the fetched window so returning from another tab does not visually
+    // collapse a long scrolled buffer.
     for (const e of this.events) {
-      if (!options.preserveExistingWindow && existingBeforeFetch.has(e.id)) continue;
+      if (cursorMode === 'replace' && existingBeforeFetch.has(e.id)) continue;
       if (newSeen.has(e.id)) continue;
       newSeen.add(e.id);
       merged.push(e);
@@ -917,7 +925,11 @@ export class MessagesStore {
     this.events = merged;
     if (this.scope === 'room') this.sortRoomEvents();
     this.seenIds = newSeen;
-    if (options.preserveExistingWindow) {
+    if (cursorMode === 'latest') {
+      this.oldestCursor = previousOldestCursor ?? connection.startCursor ?? undefined;
+      this.newestCursor = connection.endCursor ?? previousNewestCursor ?? undefined;
+      this.hasReachedStart = previousHasReachedStart || !(connection.hasOlder ?? false);
+    } else if (cursorMode === 'preserve') {
       this.oldestCursor = previousOldestCursor ?? connection.startCursor ?? undefined;
       this.newestCursor = previousNewestCursor ?? connection.endCursor ?? undefined;
       this.hasReachedStart = previousHasReachedStart || !(connection.hasOlder ?? false);
@@ -931,7 +943,8 @@ export class MessagesStore {
       preservedExistingCount: merged.length - fetched.length,
       eventCount: this.events.length,
       hasOlder: connection.hasOlder ?? false,
-      hasReachedStart: this.hasReachedStart
+      hasReachedStart: this.hasReachedStart,
+      cursorMode
     });
   }
 
@@ -941,11 +954,11 @@ export class MessagesStore {
   ): Promise<RefreshCurrentWindowResult> {
     const page = await this.roomTimeline.getRoomEvents({
       roomId: this.roomId,
-      limit: PAGE_SIZE
+      limit: this.softRefreshLimit()
     });
 
     if (this.isStale(thisLoad)) return { hasOlder: false, hasNewer: false, refreshed: false };
-    this.replaceWithSnapshotAndUpdateCursors(page, existingBeforeFetch);
+    this.replaceWithSnapshotAndUpdateCursors(page, existingBeforeFetch, { cursorMode: 'latest' });
     return { hasOlder: page.hasOlder, hasNewer: page.hasNewer, refreshed: true };
   }
 
@@ -961,9 +974,7 @@ export class MessagesStore {
     });
 
     if (this.isStale(thisLoad)) return { hasOlder: false, hasNewer: false, refreshed: false };
-    this.replaceWithSnapshotAndUpdateCursors(page, existingBeforeFetch, {
-      preserveExistingWindow: true
-    });
+    this.replaceWithSnapshotAndUpdateCursors(page, existingBeforeFetch, { cursorMode: 'preserve' });
     return { hasOlder: page.hasOlder, hasNewer: page.hasNewer, refreshed: true };
   }
 
@@ -982,11 +993,16 @@ export class MessagesStore {
       : await this.roomTimeline.getThreadEvents({
           roomId: this.roomId,
           threadRootEventId: this.threadRootEventId,
-          limit: PAGE_SIZE
+          limit: this.softRefreshLimit()
         });
     if (this.isStale(thisLoad)) return { hasOlder: false, hasNewer: false, refreshed: false };
     this.replaceWithSnapshotAndUpdateCursors(page, existingBeforeFetch, {
-      preserveExistingWindow: anchorEventId !== null && anchorEventId !== this.threadRootEventId
+      cursorMode:
+        anchorEventId === null
+          ? 'latest'
+          : anchorEventId !== this.threadRootEventId
+            ? 'preserve'
+            : 'replace'
     });
     this.sortThreadEvents();
     return { hasOlder: page.hasOlder, hasNewer: page.hasNewer, refreshed: true };


### PR DESCRIPTION
## What changed
- Skip `may-have-missed-messages` refreshes for short browser visibility/pageshow resumes when the tab was hidden for less than 30 seconds.
- Add coverage for short and long browser resume paths, including the pageshow case.
- Change room message refreshes to use a larger soft-refresh window so the latest timeline can be reloaded without collapsing already-loaded history.
- Introduce explicit cursor modes for snapshot replacement so refreshes can either replace, preserve, or advance the visible window depending on context.
- Add regression coverage for soft-refreshing the latest room window while keeping older loaded messages intact.

## Why
- Short tab switches and brief browser resumes were triggering unnecessary refresh work.
- Refreshing the latest room window with a small page size could drop already-loaded history from the UI, causing the timeline to visually jump or collapse.
- The new cursor handling keeps refresh behavior aligned with the intent of each refresh path and preserves the existing message buffer where appropriate.