### PR TITLE
fix(frontend): stabilize unread and resume refresh

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -50,22 +50,8 @@ runs:
       if: inputs.install-ffmpeg == 'true'
       shell: bash
       run: |
-        if command -v ffmpeg >/dev/null 2>&1 && command -v ffprobe >/dev/null 2>&1; then
-          ffmpeg -version | head -n 1
-          ffprobe -version | head -n 1
-          exit 0
-        fi
-
-        sudo apt-get update \
-          -o Acquire::Retries=5 \
-          -o Acquire::http::Timeout=30 \
-          -o Acquire::https::Timeout=30 \
-          -qq
-        sudo apt-get install -y -qq --no-install-recommends \
-          -o Acquire::Retries=5 \
-          -o Acquire::http::Timeout=30 \
-          -o Acquire::https::Timeout=30 \
-          ffmpeg
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq ffmpeg
 
     - name: Set up CLI
       if: inputs.install-cli-deps == 'true'

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -50,8 +50,22 @@ runs:
       if: inputs.install-ffmpeg == 'true'
       shell: bash
       run: |
-        sudo apt-get update -qq
-        sudo apt-get install -y -qq ffmpeg
+        if command -v ffmpeg >/dev/null 2>&1 && command -v ffprobe >/dev/null 2>&1; then
+          ffmpeg -version | head -n 1
+          ffprobe -version | head -n 1
+          exit 0
+        fi
+
+        sudo apt-get update \
+          -o Acquire::Retries=5 \
+          -o Acquire::http::Timeout=30 \
+          -o Acquire::https::Timeout=30 \
+          -qq
+        sudo apt-get install -y -qq --no-install-recommends \
+          -o Acquire::Retries=5 \
+          -o Acquire::http::Timeout=30 \
+          -o Acquire::https::Timeout=30 \
+          ffmpeg
 
     - name: Set up CLI
       if: inputs.install-cli-deps == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,8 +112,8 @@ jobs:
           restore-keys: |
             playwright-${{ runner.os }}-${{ runner.arch }}-
 
-      - name: Install Playwright browser
-        run: cd apps/frontend && pnpm exec playwright install chromium --only-shell
+      - name: Install Playwright dependencies
+        run: cd apps/frontend && pnpm exec playwright install chromium --with-deps
         timeout-minutes: 15
 
       - name: Run frontend typecheck
@@ -164,8 +164,8 @@ jobs:
           restore-keys: |
             playwright-${{ runner.os }}-${{ runner.arch }}-
 
-      - name: Install Playwright browser
-        run: cd apps/frontend && pnpm exec playwright install chromium --only-shell
+      - name: Install Playwright dependencies
+        run: cd apps/frontend && pnpm exec playwright install chromium --with-deps
         timeout-minutes: 15
 
       - name: Build E2E server
@@ -202,8 +202,8 @@ jobs:
           restore-keys: |
             playwright-${{ runner.os }}-${{ runner.arch }}-
 
-      - name: Install Playwright browser
-        run: cd apps/frontend && pnpm exec playwright install chromium --only-shell
+      - name: Install Playwright dependencies
+        run: cd apps/frontend && pnpm exec playwright install chromium --with-deps
         timeout-minutes: 15
 
       - name: Build E2E server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,8 +112,8 @@ jobs:
           restore-keys: |
             playwright-${{ runner.os }}-${{ runner.arch }}-
 
-      - name: Install Playwright dependencies
-        run: cd apps/frontend && pnpm exec playwright install chromium --with-deps
+      - name: Install Playwright browser
+        run: cd apps/frontend && pnpm exec playwright install chromium --only-shell
         timeout-minutes: 15
 
       - name: Run frontend typecheck
@@ -164,8 +164,8 @@ jobs:
           restore-keys: |
             playwright-${{ runner.os }}-${{ runner.arch }}-
 
-      - name: Install Playwright dependencies
-        run: cd apps/frontend && pnpm exec playwright install chromium --with-deps
+      - name: Install Playwright browser
+        run: cd apps/frontend && pnpm exec playwright install chromium --only-shell
         timeout-minutes: 15
 
       - name: Build E2E server
@@ -202,8 +202,8 @@ jobs:
           restore-keys: |
             playwright-${{ runner.os }}-${{ runner.arch }}-
 
-      - name: Install Playwright dependencies
-        run: cd apps/frontend && pnpm exec playwright install chromium --with-deps
+      - name: Install Playwright browser
+        run: cd apps/frontend && pnpm exec playwright install chromium --only-shell
         timeout-minutes: 15
 
       - name: Build E2E server

--- a/apps/frontend/e2e/service-worker.test.ts
+++ b/apps/frontend/e2e/service-worker.test.ts
@@ -18,12 +18,12 @@ type ServiceWorkerRegistrationSnapshot = {
 
 type BadgeStateSnapshot = {
   cacheExists: boolean;
-  notificationCount: number | null;
+  badgeIntent: { kind: 'clear' } | { kind: 'flag' } | { kind: 'count'; count: number } | null;
   serviceWorkerAppBadgeEnabled: boolean | null;
 };
 
 const BADGE_STATE_CACHE_NAME = 'chatto-badge-state-v2';
-const BADGE_STATE_REQUEST = '/__chatto/foreground-notification-count';
+const BADGE_STATE_REQUEST = '/__chatto/foreground-badge-intent';
 
 test('service worker caches only the app shell and serves it offline', async ({
   page,
@@ -115,7 +115,7 @@ test('browser-tab badge-state messages do not crash service worker badging', asy
   });
   await expectBadgeState(page, {
     cacheExists: true,
-    notificationCount: 3,
+    badgeIntent: { kind: 'count', count: 3 },
     serviceWorkerAppBadgeEnabled: false
   });
   await expectPageStillResponsive(page);
@@ -125,7 +125,7 @@ test('browser-tab badge-state messages do not crash service worker badging', asy
   await ensureServiceWorkerControlsPage(page);
   await expectBadgeState(page, {
     cacheExists: true,
-    notificationCount: 3,
+    badgeIntent: { kind: 'count', count: 3 },
     serviceWorkerAppBadgeEnabled: false
   });
 
@@ -135,7 +135,7 @@ test('browser-tab badge-state messages do not crash service worker badging', asy
   });
   await expectBadgeState(page, {
     cacheExists: true,
-    notificationCount: 2,
+    badgeIntent: { kind: 'count', count: 2 },
     serviceWorkerAppBadgeEnabled: false
   });
   await expectPageStillResponsive(page);
@@ -147,7 +147,7 @@ test('browser-tab badge-state messages do not crash service worker badging', asy
   });
   await expectBadgeState(page, {
     cacheExists: true,
-    notificationCount: 0,
+    badgeIntent: { kind: 'clear' },
     serviceWorkerAppBadgeEnabled: false
   });
   await expectPageStillResponsive(page);
@@ -258,24 +258,35 @@ async function readBadgeState(page: Page): Promise<BadgeStateSnapshot> {
       if (!response) {
         return {
           cacheExists: false,
-          notificationCount: null,
+          badgeIntent: null,
           serviceWorkerAppBadgeEnabled: null
         };
       }
 
       const payload = (await response.json()) as {
+        badgeIntent?: unknown;
         notificationCount?: unknown;
         serviceWorkerAppBadgeEnabled?: unknown;
       };
       return {
         cacheExists: true,
-        notificationCount:
-          typeof payload.notificationCount === 'number' ? payload.notificationCount : null,
+        badgeIntent: normalizeBadgeIntent(payload.badgeIntent),
         serviceWorkerAppBadgeEnabled:
           typeof payload.serviceWorkerAppBadgeEnabled === 'boolean'
             ? payload.serviceWorkerAppBadgeEnabled
             : null
       };
+
+      function normalizeBadgeIntent(value: unknown): BadgeStateSnapshot['badgeIntent'] {
+        if (!value || typeof value !== 'object') return null;
+        const intent = value as { kind?: unknown; count?: unknown };
+        if (intent.kind === 'clear') return { kind: 'clear' };
+        if (intent.kind === 'flag') return { kind: 'flag' };
+        if (intent.kind === 'count' && typeof intent.count === 'number') {
+          return { kind: 'count', count: intent.count };
+        }
+        return null;
+      }
     },
     { cacheName: BADGE_STATE_CACHE_NAME, request: BADGE_STATE_REQUEST }
   );

--- a/apps/frontend/e2e/unread-indicators.test.ts
+++ b/apps/frontend/e2e/unread-indicators.test.ts
@@ -530,7 +530,7 @@ test.describe('Room unread separator', () => {
     );
   });
 
-  test('refocus keeps the separator stable when only non-message events arrived while hidden', async ({
+  test('refocus keeps the separator hidden when only non-message events arrived while hidden', async ({
     page,
     chatPage,
     roomPage,
@@ -539,13 +539,9 @@ test.describe('Room unread separator', () => {
   }) => {
     test.setTimeout(60000); // Multi-user test with real-time events needs more time
 
-    // Regression test for the bug where the "New messages" separator would
-    // flicker out on tab refocus when the only thing that arrived while the
-    // tab was hidden was a non-message room event (join, leave). The server-
-    // side read cursor only tracks root messages, so a refocus mutation
-    // round-trip returned previousLastReadAt === lastReadAt and the bounded
-    // window collapsed to empty. The marker is now deferred until refocus,
-    // and the same-room refocus must not overwrite that deferred anchor.
+    // The server-side read cursor only tracks root messages. Non-message room
+    // events such as joins and leaves should not create an unread separator on
+    // refocus because there is no unread message window to anchor.
 
     // User A: Create account, enter general, post the initial message
     // so User B has a real read cursor anchored on a root message.
@@ -570,8 +566,7 @@ test.describe('Room unread separator', () => {
         await waitForRoomReadViaConnect(page2, generalRoomId);
         await roomPage2.expectNoUnreadSeparator();
 
-        // User B's tab goes hidden. The unread anchor is captured, but the
-        // rendered separator is deferred until User B returns.
+        // User B's tab goes hidden.
         await page2.evaluate(() => {
           Object.defineProperty(document, 'visibilityState', {
             value: 'hidden',
@@ -596,11 +591,9 @@ test.describe('Room unread separator', () => {
           await roomPage2.expectNoUnreadSeparator();
         }).toPass({ timeout: TIMEOUTS.UI_STANDARD, intervals: POLLING_INTERVALS });
 
-        // User B's tab returns to the foreground. With the bug, this refocus
-        // would fire markRoomAsRead which returns previousLastReadAt ===
-        // lastReadAt (server cursor never moved), the .then() would overwrite
-        // the deferred open-bound anchor with an empty window, and the
-        // separator would blink out.
+        // User B's tab returns to the foreground. Since the server read cursor
+        // did not see any newer root messages, there is no marker window and
+        // no separator should appear.
         await page2.evaluate(() => {
           Object.defineProperty(document, 'visibilityState', {
             value: 'visible',
@@ -610,15 +603,11 @@ test.describe('Room unread separator', () => {
           document.dispatchEvent(new Event('visibilitychange'));
         });
 
-        // Separator must remain visible across the focus transition — it
-        // shouldn't toggle just because the user came back to the tab.
         await expect(async () => {
-          await roomPage2.expectUnreadSeparator();
+          await roomPage2.expectNoUnreadSeparator();
         }).toPass({ timeout: TIMEOUTS.UI_STANDARD, intervals: POLLING_INTERVALS });
 
-        // A second hide/show cycle to be sure: with the old code the marker
-        // would reappear on blur and vanish again on focus, so a second
-        // refocus must also leave it in place.
+        // A second hide/show cycle should not synthesize a separator either.
         await page2.evaluate(() => {
           Object.defineProperty(document, 'visibilityState', {
             value: 'hidden',
@@ -627,7 +616,7 @@ test.describe('Room unread separator', () => {
           });
           document.dispatchEvent(new Event('visibilitychange'));
         });
-        await roomPage2.expectUnreadSeparator();
+        await roomPage2.expectNoUnreadSeparator();
 
         await page2.evaluate(() => {
           Object.defineProperty(document, 'visibilityState', {
@@ -638,7 +627,7 @@ test.describe('Room unread separator', () => {
           document.dispatchEvent(new Event('visibilitychange'));
         });
         await expect(async () => {
-          await roomPage2.expectUnreadSeparator();
+          await roomPage2.expectNoUnreadSeparator();
         }).toPass({ timeout: TIMEOUTS.UI_STANDARD, intervals: POLLING_INTERVALS });
       }
     );

--- a/apps/frontend/src/lib/components/NotificationSync.svelte
+++ b/apps/frontend/src/lib/components/NotificationSync.svelte
@@ -19,10 +19,12 @@ Include this component once in the chat layout (unconditionally).
   import {
     updateBadge,
     clearBadge,
-    syncServiceWorkerNotificationBadgeState
+    syncServiceWorkerNotificationBadgeState,
+    type AppBadgeIntent
   } from '$lib/notifications/appBadge';
   import type { EventEnvelope, EventHandler } from '$lib/eventBus.svelte';
   import { RoomEventKind, roomEventKind } from '$lib/render/eventKinds';
+  import { NotificationItemKind } from '$lib/api-client/notifications';
 
   function notificationCreatedEvent(event: EventEnvelope['event']): { silent?: boolean } | null {
     if (!event || !('silent' in event)) return null;
@@ -97,29 +99,37 @@ Include this component once in the chat layout (unconditionally).
     };
   });
 
-  let badgeState = $derived.by(() => {
-    let count = 0;
+  let badgeState = $derived.by((): { intent: AppBadgeIntent; allStoresLoaded: boolean } => {
+    let dmCount = 0;
+    let hasNotification = false;
     let allStoresLoaded = true;
 
     for (const instance of serverRegistry.servers) {
       const stores = serverRegistry.getStore(instance.id);
       if (!stores.isAuthenticated) continue;
       if (!stores.notifications.hasLoaded) allStoresLoaded = false;
-      count += Math.max(stores.notifications.unreadNotificationCount, stores.notifications.count);
+
+      const notifications = stores.notifications.notifications;
+      dmCount += notifications.filter((n) => n.kind === NotificationItemKind.DirectMessage).length;
+      if (notifications.length > 0 || stores.notifications.unreadNotificationCount > 0) {
+        hasNotification = true;
+      }
     }
 
-    return { count, allStoresLoaded };
+    if (dmCount > 0) return { intent: { kind: 'count', count: dmCount }, allStoresLoaded };
+    if (hasNotification) return { intent: { kind: 'flag' }, allStoresLoaded };
+    return { intent: { kind: 'clear' }, allStoresLoaded };
   });
 
   // Update PWA dock badge based on pending notifications only. Plain unread
   // rooms stay in-app so users can choose notification levels for important rooms.
   $effect(() => {
-    if (badgeState.count === 0 && !badgeState.allStoresLoaded) return;
+    if (badgeState.intent.kind === 'clear' && !badgeState.allStoresLoaded) return;
 
-    syncServiceWorkerNotificationBadgeState(badgeState.count);
+    syncServiceWorkerNotificationBadgeState(badgeState.intent);
 
-    if (badgeState.count > 0) {
-      updateBadge(badgeState.count);
+    if (badgeState.intent.kind !== 'clear') {
+      updateBadge(badgeState.intent);
     } else {
       clearBadge();
     }

--- a/apps/frontend/src/lib/components/NotificationSync.svelte
+++ b/apps/frontend/src/lib/components/NotificationSync.svelte
@@ -101,6 +101,7 @@ Include this component once in the chat layout (unconditionally).
 
   let badgeState = $derived.by((): { intent: AppBadgeIntent; allStoresLoaded: boolean } => {
     let dmCount = 0;
+    let canUseNumericDmCount = true;
     let hasNotification = false;
     let allStoresLoaded = true;
 
@@ -110,13 +111,19 @@ Include this component once in the chat layout (unconditionally).
       if (!stores.notifications.hasLoaded) allStoresLoaded = false;
 
       const notifications = stores.notifications.notifications;
+      const notificationTotal = stores.notifications.unreadNotificationCount;
       dmCount += notifications.filter((n) => n.kind === NotificationItemKind.DirectMessage).length;
-      if (notifications.length > 0 || stores.notifications.unreadNotificationCount > 0) {
+      if (notificationTotal > notifications.length) {
+        canUseNumericDmCount = false;
+      }
+      if (notifications.length > 0 || notificationTotal > 0) {
         hasNotification = true;
       }
     }
 
-    if (dmCount > 0) return { intent: { kind: 'count', count: dmCount }, allStoresLoaded };
+    if (dmCount > 0 && canUseNumericDmCount) {
+      return { intent: { kind: 'count', count: dmCount }, allStoresLoaded };
+    }
     if (hasNotification) return { intent: { kind: 'flag' }, allStoresLoaded };
     return { intent: { kind: 'clear' }, allStoresLoaded };
   });

--- a/apps/frontend/src/lib/components/NotificationSync.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/NotificationSync.svelte.spec.ts
@@ -12,6 +12,7 @@ const { mocks } = vi.hoisted(() => {
   const store = {
     isAuthenticated: true,
     notifications: {
+      notifications: [] as Array<{ kind: string }>,
       count: 0,
       unreadNotificationCount: 0,
       hasLoaded: true,
@@ -106,6 +107,7 @@ describe('NotificationSync', () => {
     vi.clearAllMocks();
 
     mocks.store.isAuthenticated = true;
+    mocks.store.notifications.notifications = [];
     mocks.store.notifications.count = 0;
     mocks.store.notifications.unreadNotificationCount = 0;
     mocks.store.notifications.hasLoaded = true;
@@ -185,14 +187,32 @@ describe('NotificationSync', () => {
     expect(mocks.store.rooms.refresh).not.toHaveBeenCalled();
   });
 
-  it('uses the authoritative notification count when the cached list is lower', async () => {
+  it('uses a numeric app badge for loaded DM notifications', async () => {
+    mocks.store.notifications.notifications = [{ kind: 'directMessage' }];
     mocks.store.notifications.count = 1;
     mocks.store.notifications.unreadNotificationCount = 3;
 
     await renderAndWaitForSubscription();
 
-    await vi.waitFor(() => expect(mocks.updateBadge).toHaveBeenCalledWith(3));
-    expect(mocks.syncServiceWorkerNotificationBadgeState).toHaveBeenCalledWith(3);
+    await vi.waitFor(() =>
+      expect(mocks.updateBadge).toHaveBeenCalledWith({ kind: 'count', count: 1 })
+    );
+    expect(mocks.syncServiceWorkerNotificationBadgeState).toHaveBeenCalledWith({
+      kind: 'count',
+      count: 1
+    });
+    expect(mocks.clearBadge).not.toHaveBeenCalled();
+  });
+
+  it('uses a flag app badge for channel notifications', async () => {
+    mocks.store.notifications.notifications = [{ kind: 'mention' }];
+    mocks.store.notifications.count = 1;
+    mocks.store.notifications.unreadNotificationCount = 1;
+
+    await renderAndWaitForSubscription();
+
+    await vi.waitFor(() => expect(mocks.updateBadge).toHaveBeenCalledWith({ kind: 'flag' }));
+    expect(mocks.syncServiceWorkerNotificationBadgeState).toHaveBeenCalledWith({ kind: 'flag' });
     expect(mocks.clearBadge).not.toHaveBeenCalled();
   });
 
@@ -200,7 +220,7 @@ describe('NotificationSync', () => {
     await renderAndWaitForSubscription();
 
     await vi.waitFor(() => expect(mocks.clearBadge).toHaveBeenCalledOnce());
-    expect(mocks.syncServiceWorkerNotificationBadgeState).toHaveBeenCalledWith(0);
+    expect(mocks.syncServiceWorkerNotificationBadgeState).toHaveBeenCalledWith({ kind: 'clear' });
     expect(mocks.updateBadge).not.toHaveBeenCalled();
   });
 
@@ -220,8 +240,8 @@ describe('NotificationSync', () => {
 
     await renderAndWaitForSubscription();
 
-    await vi.waitFor(() => expect(mocks.updateBadge).toHaveBeenCalledWith(2));
-    expect(mocks.syncServiceWorkerNotificationBadgeState).toHaveBeenCalledWith(2);
+    await vi.waitFor(() => expect(mocks.updateBadge).toHaveBeenCalledWith({ kind: 'flag' }));
+    expect(mocks.syncServiceWorkerNotificationBadgeState).toHaveBeenCalledWith({ kind: 'flag' });
     expect(mocks.clearBadge).not.toHaveBeenCalled();
   });
 
@@ -231,7 +251,7 @@ describe('NotificationSync', () => {
     await renderAndWaitForSubscription();
 
     await vi.waitFor(() => expect(mocks.clearBadge).toHaveBeenCalledOnce());
-    expect(mocks.syncServiceWorkerNotificationBadgeState).toHaveBeenCalledWith(0);
+    expect(mocks.syncServiceWorkerNotificationBadgeState).toHaveBeenCalledWith({ kind: 'clear' });
     expect(mocks.updateBadge).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/lib/components/NotificationSync.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/NotificationSync.svelte.spec.ts
@@ -190,7 +190,7 @@ describe('NotificationSync', () => {
   it('uses a numeric app badge for loaded DM notifications', async () => {
     mocks.store.notifications.notifications = [{ kind: 'directMessage' }];
     mocks.store.notifications.count = 1;
-    mocks.store.notifications.unreadNotificationCount = 3;
+    mocks.store.notifications.unreadNotificationCount = 1;
 
     await renderAndWaitForSubscription();
 
@@ -201,6 +201,18 @@ describe('NotificationSync', () => {
       kind: 'count',
       count: 1
     });
+    expect(mocks.clearBadge).not.toHaveBeenCalled();
+  });
+
+  it('uses a flag instead of a capped DM count when notifications are not fully loaded', async () => {
+    mocks.store.notifications.notifications = [{ kind: 'directMessage' }];
+    mocks.store.notifications.count = 1;
+    mocks.store.notifications.unreadNotificationCount = 3;
+
+    await renderAndWaitForSubscription();
+
+    await vi.waitFor(() => expect(mocks.updateBadge).toHaveBeenCalledWith({ kind: 'flag' }));
+    expect(mocks.syncServiceWorkerNotificationBadgeState).toHaveBeenCalledWith({ kind: 'flag' });
     expect(mocks.clearBadge).not.toHaveBeenCalled();
   });
 

--- a/apps/frontend/src/lib/hooks/UseUnreadMarkerHarness.svelte
+++ b/apps/frontend/src/lib/hooks/UseUnreadMarkerHarness.svelte
@@ -20,11 +20,12 @@
 
   const unread = useUnreadMarker(() => targetId, {
     markAsRead: (target, upToEventId) => markAsRead(target, upToEventId),
-    markerWindowFromReadResult: (result): UnreadMarkerWindow | null => {
+    markerWindowFromReadResult: (result, markedAtMs): UnreadMarkerWindow | null => {
       if (!result.previousLastReadAt || !result.lastReadAt) return null;
+      if (result.previousLastReadAt === result.lastReadAt) return null;
       return {
         afterTime: result.previousLastReadAt,
-        beforeTime: result.lastReadAt
+        beforeTime: markedAtMs
       };
     }
   });

--- a/apps/frontend/src/lib/hooks/useMayHaveMissedMessagesCallback.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/useMayHaveMissedMessagesCallback.svelte.spec.ts
@@ -6,6 +6,7 @@ import {
   setRealtimeSocketFactoryForTests
 } from '$lib/state/server/eventBus.svelte';
 import type { ServerConnection } from '$lib/state/server/serverConnection.svelte';
+import { emitServerResumeSignal } from './resumeCoordinator.svelte';
 import Harness from './UseMayHaveMissedMessagesCallbackHarness.svelte';
 
 const { mocks } = vi.hoisted(() => ({
@@ -107,6 +108,45 @@ describe('useMayHaveMissedMessagesCallback', () => {
         reason: 'online',
         phase: 'immediate',
         source: 'browser'
+      })
+    );
+    rendered.unmount();
+  });
+
+  it('does not dedupe event-bus catch-up after a skipped refresh', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-08T12:00:00Z'));
+    const onSignal = vi.fn().mockResolvedValueOnce(false).mockResolvedValue(undefined);
+
+    const rendered = render(Harness, { props: { onSignal } });
+    flushSync();
+
+    emitServerResumeSignal(
+      TEST_SERVER,
+      {
+        reason: 'visibility',
+        source: 'browser',
+        hiddenDurationMs: 1_000
+      },
+      { coalesceMs: 0 }
+    );
+    await vi.waitFor(() => expect(onSignal).toHaveBeenCalledTimes(1));
+
+    emitServerResumeSignal(
+      TEST_SERVER,
+      {
+        reason: 'event-bus-ws-reconnected',
+        source: 'event-bus'
+      },
+      { coalesceMs: 0 }
+    );
+
+    await vi.waitFor(() => expect(onSignal).toHaveBeenCalledTimes(2));
+    expect(onSignal).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        reason: 'event-bus-ws-reconnected',
+        source: 'event-bus'
       })
     );
     rendered.unmount();

--- a/apps/frontend/src/lib/hooks/useRoomUnread.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useRoomUnread.svelte.ts
@@ -48,7 +48,6 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
       return unread.unreadMarkerWindow;
     },
     markRoomAsRead: unread.markAsRead,
-    noteAwayEvent: unread.noteAwayEvent,
     setUnreadMarkerEventId: unread.setUnreadMarkerEventId,
     clearUnreadMarker: unread.clearUnreadMarker
   };

--- a/apps/frontend/src/lib/hooks/useRoomUnread.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useRoomUnread.svelte.ts
@@ -31,11 +31,12 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
         return null;
       }
     },
-    markerWindowFromReadResult: (result: MarkRoomAsReadResult) => {
+    markerWindowFromReadResult: (result: MarkRoomAsReadResult, markedAtMs: number) => {
       if (!result.previousLastReadAt || !result.lastReadAt) return null;
+      if (result.previousLastReadAt === result.lastReadAt) return null;
       return {
         afterTime: result.previousLastReadAt,
-        beforeTime: result.lastReadAt
+        beforeTime: markedAtMs
       };
     }
   });

--- a/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.spec.ts
@@ -5,7 +5,11 @@ import Harness from './UseUnreadMarkerHarness.svelte';
 
 type HarnessAPI = {
   readonly unreadMarkerEventId: string | null;
-  noteAwayEvent(eventId: string): void;
+  readonly unreadMarkerWindow: {
+    afterTime: string;
+    beforeTime: string | number;
+  } | null;
+  setUnreadMarkerEventId(eventId: string | null): void;
 };
 
 function getApi(api: HarnessAPI | undefined): HarnessAPI {
@@ -40,7 +44,7 @@ describe('useUnreadMarker', () => {
     vi.restoreAllMocks();
   });
 
-  it('does not mark the same target as read again on refocus without an away event', async () => {
+  it('marks the same target as read again on refocus', async () => {
     const markAsRead = vi.fn().mockResolvedValue(null);
 
     const rendered = render(Harness, {
@@ -56,12 +60,19 @@ describe('useUnreadMarker', () => {
     setPresent(false);
     setPresent(true);
 
-    expect(markAsRead).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledTimes(2));
+    expect(markAsRead).toHaveBeenLastCalledWith('room-1', undefined);
     rendered.unmount();
   });
 
-  it('marks the same target as read on refocus when an away event was captured', async () => {
-    const markAsRead = vi.fn().mockResolvedValue(null);
+  it('uses the read-state window returned on refocus', async () => {
+    const markAsRead = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        previousLastReadAt: '2026-07-08T09:00:00.000Z',
+        lastReadAt: '2026-07-08T10:00:00.000Z'
+      });
     let api: HarnessAPI | undefined;
 
     const rendered = render(Harness, {
@@ -78,12 +89,57 @@ describe('useUnreadMarker', () => {
 
     setPresent(false);
     const currentApi = getApi(api);
-    currentApi.noteAwayEvent('event-2');
     setPresent(true);
 
     await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledTimes(2));
-    expect(markAsRead).toHaveBeenLastCalledWith('room-1', undefined);
-    expect(currentApi.unreadMarkerEventId).toBe('event-2');
+    await vi.waitFor(() =>
+      expect(currentApi.unreadMarkerWindow).toEqual({
+        afterTime: '2026-07-08T09:00:00.000Z',
+        beforeTime: '2026-07-08T10:00:00.000Z'
+      })
+    );
+    expect(currentApi.unreadMarkerEventId).toBeNull();
+    rendered.unmount();
+  });
+
+  it('clears the marker when refocus returns no previous read state', async () => {
+    const markAsRead = vi
+      .fn()
+      .mockResolvedValueOnce({
+        previousLastReadAt: '2026-07-08T09:00:00.000Z',
+        lastReadAt: '2026-07-08T10:00:00.000Z'
+      })
+      .mockResolvedValueOnce({
+        previousLastReadAt: null,
+        lastReadAt: '2026-07-08T10:05:00.000Z'
+      });
+    let api: HarnessAPI | undefined;
+
+    const rendered = render(Harness, {
+      props: {
+        targetId: 'room-1',
+        markAsRead,
+        onReady: (nextApi: HarnessAPI) => {
+          api = nextApi;
+        }
+      }
+    });
+    flushSync();
+    const currentApi = getApi(api);
+    await vi.waitFor(() =>
+      expect(currentApi.unreadMarkerWindow).toEqual({
+        afterTime: '2026-07-08T09:00:00.000Z',
+        beforeTime: '2026-07-08T10:00:00.000Z'
+      })
+    );
+
+    currentApi.setUnreadMarkerEventId('event-2');
+    setPresent(false);
+    setPresent(true);
+
+    await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(currentApi.unreadMarkerWindow).toBeNull());
+    expect(currentApi.unreadMarkerEventId).toBeNull();
     rendered.unmount();
   });
 

--- a/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.spec.ts
@@ -9,6 +9,7 @@ type HarnessAPI = {
     afterTime: string;
     beforeTime: string | number;
   } | null;
+  markAsRead(targetId: string, upToEventId?: string): Promise<unknown>;
   setUnreadMarkerEventId(eventId: string | null): void;
 };
 
@@ -139,6 +140,56 @@ describe('useUnreadMarker', () => {
 
     await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledTimes(2));
     await vi.waitFor(() => expect(currentApi.unreadMarkerWindow).toBeNull());
+    expect(currentApi.unreadMarkerEventId).toBeNull();
+    rendered.unmount();
+  });
+
+  it('ignores a stale refocus read after a newer explicit read', async () => {
+    let resolveRefocus!: (value: {
+      previousLastReadAt: string;
+      lastReadAt: string;
+    }) => void;
+    const refocusRead = new Promise<{
+      previousLastReadAt: string;
+      lastReadAt: string;
+    }>((resolve) => {
+      resolveRefocus = resolve;
+    });
+    const markAsRead = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockReturnValueOnce(refocusRead)
+      .mockResolvedValueOnce(null);
+    let api: HarnessAPI | undefined;
+
+    const rendered = render(Harness, {
+      props: {
+        targetId: 'room-1',
+        markAsRead,
+        onReady: (nextApi: HarnessAPI) => {
+          api = nextApi;
+        }
+      }
+    });
+    flushSync();
+    const currentApi = getApi(api);
+    await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledOnce());
+
+    setPresent(false);
+    setPresent(true);
+    await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledTimes(2));
+
+    await currentApi.markAsRead('room-1', 'event-2');
+    expect(markAsRead).toHaveBeenCalledTimes(3);
+
+    resolveRefocus({
+      previousLastReadAt: '2026-07-08T09:00:00.000Z',
+      lastReadAt: '2026-07-08T10:00:00.000Z'
+    });
+    await Promise.resolve();
+    flushSync();
+
+    expect(currentApi.unreadMarkerWindow).toBeNull();
     expect(currentApi.unreadMarkerEventId).toBeNull();
     rendered.unmount();
   });

--- a/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.spec.ts
@@ -67,6 +67,8 @@ describe('useUnreadMarker', () => {
   });
 
   it('uses the read-state window returned on refocus', async () => {
+    const markedAtMs = Date.UTC(2026, 6, 8, 10, 0, 30);
+    vi.spyOn(Date, 'now').mockReturnValue(markedAtMs);
     const markAsRead = vi
       .fn()
       .mockResolvedValueOnce(null)
@@ -96,7 +98,7 @@ describe('useUnreadMarker', () => {
     await vi.waitFor(() =>
       expect(currentApi.unreadMarkerWindow).toEqual({
         afterTime: '2026-07-08T09:00:00.000Z',
-        beforeTime: '2026-07-08T10:00:00.000Z'
+        beforeTime: markedAtMs
       })
     );
     expect(currentApi.unreadMarkerEventId).toBeNull();
@@ -104,6 +106,8 @@ describe('useUnreadMarker', () => {
   });
 
   it('clears the marker when refocus returns no previous read state', async () => {
+    const markedAtMs = Date.UTC(2026, 6, 8, 10, 0, 30);
+    vi.spyOn(Date, 'now').mockReturnValue(markedAtMs);
     const markAsRead = vi
       .fn()
       .mockResolvedValueOnce({
@@ -130,7 +134,7 @@ describe('useUnreadMarker', () => {
     await vi.waitFor(() =>
       expect(currentApi.unreadMarkerWindow).toEqual({
         afterTime: '2026-07-08T09:00:00.000Z',
-        beforeTime: '2026-07-08T10:00:00.000Z'
+        beforeTime: markedAtMs
       })
     );
 
@@ -144,7 +148,34 @@ describe('useUnreadMarker', () => {
     rendered.unmount();
   });
 
-  it('ignores a stale refocus read after a newer explicit read', async () => {
+  it('does not create a marker window when the read cursor did not advance', async () => {
+    const markAsRead = vi.fn().mockResolvedValueOnce({
+      previousLastReadAt: '2026-07-08T09:00:00.000Z',
+      lastReadAt: '2026-07-08T09:00:00.000Z'
+    });
+    let api: HarnessAPI | undefined;
+
+    const rendered = render(Harness, {
+      props: {
+        targetId: 'room-1',
+        markAsRead,
+        onReady: (nextApi: HarnessAPI) => {
+          api = nextApi;
+        }
+      }
+    });
+    flushSync();
+    const currentApi = getApi(api);
+
+    await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledOnce());
+    expect(currentApi.unreadMarkerWindow).toBeNull();
+    expect(currentApi.unreadMarkerEventId).toBeNull();
+    rendered.unmount();
+  });
+
+  it('preserves a pending refocus marker after a newer explicit read', async () => {
+    const markedAtMs = Date.UTC(2026, 6, 8, 10, 0, 30);
+    vi.spyOn(Date, 'now').mockReturnValue(markedAtMs);
     let resolveRefocus!: (value: {
       previousLastReadAt: string;
       lastReadAt: string;
@@ -189,7 +220,10 @@ describe('useUnreadMarker', () => {
     await Promise.resolve();
     flushSync();
 
-    expect(currentApi.unreadMarkerWindow).toBeNull();
+    expect(currentApi.unreadMarkerWindow).toEqual({
+      afterTime: '2026-07-08T09:00:00.000Z',
+      beforeTime: markedAtMs
+    });
     expect(currentApi.unreadMarkerEventId).toBeNull();
     rendered.unmount();
   });

--- a/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.ts
@@ -17,8 +17,8 @@ type UseUnreadMarkerOptions<TReadResult> = {
  * Shared unread separator lifecycle for room and thread timelines.
  *
  * The rendered separator is always a concrete event id. Server read-state
- * timestamp windows are resolved once by the timeline pane, and same-target
- * refocuses only reveal deferred event ids captured while the user was away.
+ * timestamp windows are resolved once by the timeline pane. The server read
+ * cursor is the source of truth on entry, target changes, and refocus.
  */
 export function useUnreadMarker<TReadResult>(
   getTargetId: () => string,
@@ -26,15 +26,9 @@ export function useUnreadMarker<TReadResult>(
 ) {
   let unreadMarkerEventId = $state<string | null>(null);
   let unreadMarkerWindow = $state<UnreadMarkerWindow | null>(null);
-  let pendingAwayEventId: string | null = null;
 
   async function markTargetAsRead(targetId: string, upToEventId?: string) {
     return markAsRead(targetId, upToEventId);
-  }
-
-  function noteAwayEvent(eventId: string) {
-    if (unreadMarkerEventId !== null || pendingAwayEventId !== null) return;
-    pendingAwayEventId = eventId;
   }
 
   function setUnreadMarkerEventId(eventId: string | null) {
@@ -47,11 +41,11 @@ export function useUnreadMarker<TReadResult>(
   function clearUnreadMarker() {
     unreadMarkerEventId = null;
     unreadMarkerWindow = null;
-    pendingAwayEventId = null;
   }
 
   let lastFiredTargetId = '';
   let wasPresent = false;
+  let readMarkerGeneration = 0;
 
   $effect(() => {
     const targetId = getTargetId();
@@ -63,7 +57,6 @@ export function useUnreadMarker<TReadResult>(
     }
 
     const isTargetChange = lastFiredTargetId !== targetId;
-    const awayEventId = pendingAwayEventId;
 
     if (wasPresent && !isTargetChange) return;
 
@@ -72,19 +65,15 @@ export function useUnreadMarker<TReadResult>(
 
     if (isTargetChange) {
       clearUnreadMarker();
-    } else if (awayEventId) {
-      setUnreadMarkerEventId(awayEventId);
-      pendingAwayEventId = null;
-    } else {
-      pendingAwayEventId = null;
-      return;
     }
 
     const markedAtMs = Date.now();
+    const generation = ++readMarkerGeneration;
     markTargetAsRead(targetId).then((result) => {
+      if (generation !== readMarkerGeneration) return;
       if (getTargetId() !== targetId || !result) return;
-      if (!isTargetChange) return;
 
+      unreadMarkerEventId = null;
       unreadMarkerWindow = markerWindowFromReadResult(result, markedAtMs);
     });
   });
@@ -97,7 +86,6 @@ export function useUnreadMarker<TReadResult>(
       return unreadMarkerWindow;
     },
     markAsRead: markTargetAsRead,
-    noteAwayEvent,
     setUnreadMarkerEventId,
     clearUnreadMarker
   };

--- a/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.ts
@@ -27,8 +27,20 @@ export function useUnreadMarker<TReadResult>(
   let unreadMarkerEventId = $state<string | null>(null);
   let unreadMarkerWindow = $state<UnreadMarkerWindow | null>(null);
 
+  let lastFiredTargetId = '';
+  let wasPresent = false;
+  let readMarkerGeneration = 0;
+
+  function startReadRequest(targetId: string, upToEventId?: string) {
+    const generation = ++readMarkerGeneration;
+    return {
+      generation,
+      promise: markAsRead(targetId, upToEventId)
+    };
+  }
+
   async function markTargetAsRead(targetId: string, upToEventId?: string) {
-    return markAsRead(targetId, upToEventId);
+    return startReadRequest(targetId, upToEventId).promise;
   }
 
   function setUnreadMarkerEventId(eventId: string | null) {
@@ -42,10 +54,6 @@ export function useUnreadMarker<TReadResult>(
     unreadMarkerEventId = null;
     unreadMarkerWindow = null;
   }
-
-  let lastFiredTargetId = '';
-  let wasPresent = false;
-  let readMarkerGeneration = 0;
 
   $effect(() => {
     const targetId = getTargetId();
@@ -68,8 +76,8 @@ export function useUnreadMarker<TReadResult>(
     }
 
     const markedAtMs = Date.now();
-    const generation = ++readMarkerGeneration;
-    markTargetAsRead(targetId).then((result) => {
+    const { generation, promise } = startReadRequest(targetId);
+    promise.then((result) => {
       if (generation !== readMarkerGeneration) return;
       if (getTargetId() !== targetId || !result) return;
 

--- a/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.ts
@@ -31,16 +31,8 @@ export function useUnreadMarker<TReadResult>(
   let wasPresent = false;
   let readMarkerGeneration = 0;
 
-  function startReadRequest(targetId: string, upToEventId?: string) {
-    const generation = ++readMarkerGeneration;
-    return {
-      generation,
-      promise: markAsRead(targetId, upToEventId)
-    };
-  }
-
   async function markTargetAsRead(targetId: string, upToEventId?: string) {
-    return startReadRequest(targetId, upToEventId).promise;
+    return markAsRead(targetId, upToEventId);
   }
 
   function setUnreadMarkerEventId(eventId: string | null) {
@@ -76,8 +68,8 @@ export function useUnreadMarker<TReadResult>(
     }
 
     const markedAtMs = Date.now();
-    const { generation, promise } = startReadRequest(targetId);
-    promise.then((result) => {
+    const generation = ++readMarkerGeneration;
+    markAsRead(targetId).then((result) => {
       if (generation !== readMarkerGeneration) return;
       if (getTargetId() !== targetId || !result) return;
 

--- a/apps/frontend/src/lib/notifications/appBadge.spec.ts
+++ b/apps/frontend/src/lib/notifications/appBadge.spec.ts
@@ -27,10 +27,11 @@ describe('syncServiceWorkerNotificationBadgeState', () => {
   it('tells the service worker to skip worker-side badging in a browser tab', () => {
     const { postMessage } = stubBadgeEnvironment({ installed: false });
 
-    syncServiceWorkerNotificationBadgeState(3);
+    syncServiceWorkerNotificationBadgeState({ kind: 'count', count: 3 });
 
     expect(postMessage).toHaveBeenCalledWith({
       type: 'chatto-badge-state',
+      badgeIntent: { kind: 'count', count: 3 },
       notificationCount: 3,
       serviceWorkerAppBadgeEnabled: false
     });
@@ -39,11 +40,12 @@ describe('syncServiceWorkerNotificationBadgeState', () => {
   it('allows worker-side badging in an installed app display mode', () => {
     const { postMessage } = stubBadgeEnvironment({ installed: true });
 
-    syncServiceWorkerNotificationBadgeState(3);
+    syncServiceWorkerNotificationBadgeState({ kind: 'flag' });
 
     expect(postMessage).toHaveBeenCalledWith({
       type: 'chatto-badge-state',
-      notificationCount: 3,
+      badgeIntent: { kind: 'flag' },
+      notificationCount: 1,
       serviceWorkerAppBadgeEnabled: true
     });
   });

--- a/apps/frontend/src/lib/notifications/appBadge.ts
+++ b/apps/frontend/src/lib/notifications/appBadge.ts
@@ -1,11 +1,16 @@
 /**
  * App Badge API helper for PWA dock badges.
  *
- * Shows notification count on the app icon when installed as PWA.
+ * Shows notification attention on the app icon when installed as PWA.
  * Safari requires notification permission; Chrome/Edge work without it.
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Badging_API
  */
+
+export type AppBadgeIntent =
+  | { kind: 'clear' }
+  | { kind: 'flag' }
+  | { kind: 'count'; count: number };
 
 /**
  * Check if the Badging API is supported in this browser context.
@@ -17,51 +22,86 @@ export function isSupported(): boolean {
 function isInstalledAppContext(): boolean {
   if (typeof window === 'undefined') return false;
 
-  const standaloneDisplayModes = ['standalone', 'fullscreen', 'minimal-ui', 'window-controls-overlay'];
-  if (standaloneDisplayModes.some((mode) => window.matchMedia?.(`(display-mode: ${mode})`).matches)) {
+  const standaloneDisplayModes = [
+    'standalone',
+    'fullscreen',
+    'minimal-ui',
+    'window-controls-overlay'
+  ];
+  if (
+    standaloneDisplayModes.some((mode) => window.matchMedia?.(`(display-mode: ${mode})`).matches)
+  ) {
     return true;
   }
 
   return (navigator as Navigator & { standalone?: boolean }).standalone === true;
 }
 
-function normalizeBadgeCount(notificationCount: number): number {
-  if (!Number.isFinite(notificationCount)) return 0;
-  return Math.max(0, Math.floor(notificationCount));
+export function normalizeBadgeCount(count: number): number {
+  if (!Number.isFinite(count)) return 0;
+  return Math.max(0, Math.floor(count));
+}
+
+export function normalizeBadgeIntent(intent: AppBadgeIntent): AppBadgeIntent {
+  if (intent.kind !== 'count') return intent;
+  const count = normalizeBadgeCount(intent.count);
+  return count > 0 ? { kind: 'count', count } : { kind: 'clear' };
+}
+
+function legacyNotificationCount(intent: AppBadgeIntent): number {
+  switch (intent.kind) {
+    case 'count':
+      return normalizeBadgeCount(intent.count);
+    case 'flag':
+      return 1;
+    case 'clear':
+      return 0;
+  }
 }
 
 /**
- * Share the foreground notification count with the service worker so stale
+ * Share the foreground badge intent with the service worker so stale
  * push/native notification badge state can be reconciled against the app's
  * authoritative pending-notification state.
  */
-export function syncServiceWorkerNotificationBadgeState(notificationCount: number): void {
+export function syncServiceWorkerNotificationBadgeState(intent: AppBadgeIntent): void {
   if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return;
 
+  const normalized = normalizeBadgeIntent(intent);
   navigator.serviceWorker.controller?.postMessage({
     type: 'chatto-badge-state',
-    notificationCount: normalizeBadgeCount(notificationCount),
+    badgeIntent: normalized,
+    // Kept as a best-effort fallback for older active service workers.
+    notificationCount: legacyNotificationCount(normalized),
     serviceWorkerAppBadgeEnabled: isSupported() && isInstalledAppContext()
   });
 }
 
 /**
- * Update the app badge with the given count.
- * Sets a numeric badge if count > 0, clears it otherwise.
+ * Update the app badge for the given intent.
+ * Sets a numeric badge for DMs, a flag/dot for channel notifications, and
+ * clears it when notifications are handled.
  *
  * Silently fails if:
  * - Badging API not supported
  * - App not installed as PWA
  * - Safari without notification permission
  */
-export async function updateBadge(count: number): Promise<void> {
+export async function updateBadge(intent: AppBadgeIntent): Promise<void> {
   if (!isSupported()) return;
 
   try {
-    if (count > 0) {
-      await navigator.setAppBadge(count);
-    } else {
-      await navigator.clearAppBadge();
+    const normalized = normalizeBadgeIntent(intent);
+    switch (normalized.kind) {
+      case 'count':
+        await navigator.setAppBadge(normalized.count);
+        break;
+      case 'flag':
+        await navigator.setAppBadge();
+        break;
+      case 'clear':
+        await navigator.clearAppBadge();
+        break;
     }
   } catch (e) {
     // Silently fail - badge API may not work in all contexts

--- a/apps/frontend/src/lib/pwa/notificationBadge.worker.spec.ts
+++ b/apps/frontend/src/lib/pwa/notificationBadge.worker.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   applyAuthoritativeBadgeState,
   BadgeStateVersionGate,
-  type ForegroundNotificationCountStorage,
+  type ForegroundBadgeIntentStorage,
   ServiceWorkerBadgeCoordinator,
   syncBadgeFromNativeNotifications
 } from './notificationBadge.worker';
@@ -15,28 +15,29 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
-function createMemoryForegroundCountStorage(): ForegroundNotificationCountStorage {
-  let notificationCount: number | null = null;
+function createMemoryBadgeIntentStorage(): ForegroundBadgeIntentStorage {
+  let badgeIntent: { kind: 'clear' } | { kind: 'flag' } | { kind: 'count'; count: number } | null =
+    null;
   let serviceWorkerAppBadgeEnabled = false;
   return {
-    async readForegroundNotificationCount() {
-      return notificationCount;
+    async readForegroundBadgeIntent() {
+      return badgeIntent;
     },
     async readServiceWorkerAppBadgeEnabled() {
       return serviceWorkerAppBadgeEnabled;
     },
-    async writeForegroundNotificationState(count, enabled) {
-      notificationCount = count;
+    async writeForegroundNotificationState(intent, enabled) {
+      badgeIntent = intent;
       serviceWorkerAppBadgeEnabled = enabled;
     },
-    async clearForegroundNotificationCount() {
-      notificationCount = null;
+    async clearForegroundBadgeIntent() {
+      badgeIntent = null;
     }
   };
 }
 
 describe('syncBadgeFromNativeNotifications', () => {
-  it('sets the app badge to the remaining native notification count', async () => {
+  it('sets a flag app badge when native notifications remain', async () => {
     const registration = {
       getNotifications: vi.fn(async () => [{}, {}])
     };
@@ -48,11 +49,11 @@ describe('syncBadgeFromNativeNotifications', () => {
     await syncBadgeFromNativeNotifications(registration, badgeNavigator);
 
     expect(registration.getNotifications).toHaveBeenCalledOnce();
-    expect(badgeNavigator.setAppBadge).toHaveBeenCalledWith(2);
+    expect(badgeNavigator.setAppBadge).toHaveBeenCalledWith();
     expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
   });
 
-  it('uses the foreground notification count as a lower bound when requested', async () => {
+  it('uses the foreground count intent when requested', async () => {
     const registration = {
       getNotifications: vi.fn(async () => [])
     };
@@ -62,7 +63,7 @@ describe('syncBadgeFromNativeNotifications', () => {
     };
 
     await syncBadgeFromNativeNotifications(registration, badgeNavigator, {
-      minimumNotificationCount: 3
+      minimumBadgeIntent: { kind: 'count', count: 3 }
     });
 
     expect(registration.getNotifications).toHaveBeenCalledOnce();
@@ -104,7 +105,7 @@ describe('syncBadgeFromNativeNotifications', () => {
     expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
   });
 
-  it('preserves the foreground lower bound when native notification listing fails', async () => {
+  it('preserves the foreground intent when native notification listing fails', async () => {
     const registration = {
       getNotifications: vi.fn(async () => {
         throw new Error('notification store unavailable');
@@ -116,7 +117,7 @@ describe('syncBadgeFromNativeNotifications', () => {
     };
 
     await syncBadgeFromNativeNotifications(registration, badgeNavigator, {
-      minimumNotificationCount: 3
+      minimumBadgeIntent: { kind: 'count', count: 3 }
     });
 
     expect(registration.getNotifications).toHaveBeenCalledOnce();
@@ -135,7 +136,7 @@ describe('applyAuthoritativeBadgeState', () => {
       clearAppBadge: vi.fn(async () => {})
     };
 
-    await applyAuthoritativeBadgeState(registration, badgeNavigator, 3);
+    await applyAuthoritativeBadgeState(registration, badgeNavigator, { kind: 'count', count: 3 });
 
     expect(badgeNavigator.setAppBadge).toHaveBeenCalledWith(3);
     expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
@@ -151,9 +152,14 @@ describe('applyAuthoritativeBadgeState', () => {
       clearAppBadge: vi.fn(async () => {})
     };
 
-    await applyAuthoritativeBadgeState(registration, badgeNavigator, 3, {
-      isCurrent: () => false
-    });
+    await applyAuthoritativeBadgeState(
+      registration,
+      badgeNavigator,
+      { kind: 'count', count: 3 },
+      {
+        isCurrent: () => false
+      }
+    );
 
     expect(badgeNavigator.setAppBadge).not.toHaveBeenCalled();
     expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
@@ -170,7 +176,7 @@ describe('applyAuthoritativeBadgeState', () => {
       clearAppBadge: vi.fn(async () => {})
     };
 
-    await applyAuthoritativeBadgeState(registration, badgeNavigator, 0);
+    await applyAuthoritativeBadgeState(registration, badgeNavigator, { kind: 'clear' });
 
     expect(registration.getNotifications).toHaveBeenCalledOnce();
     expect(nativeNotifications[0].close).toHaveBeenCalledOnce();
@@ -189,9 +195,14 @@ describe('applyAuthoritativeBadgeState', () => {
       clearAppBadge: vi.fn(async () => {})
     };
 
-    await applyAuthoritativeBadgeState(registration, badgeNavigator, 0, {
-      isCurrent: () => false
-    });
+    await applyAuthoritativeBadgeState(
+      registration,
+      badgeNavigator,
+      { kind: 'clear' },
+      {
+        isCurrent: () => false
+      }
+    );
 
     expect(registration.getNotifications).toHaveBeenCalledOnce();
     expect(nativeNotifications[0].close).not.toHaveBeenCalled();
@@ -212,9 +223,14 @@ describe('applyAuthoritativeBadgeState', () => {
     };
     const gate = new BadgeStateVersionGate();
 
-    const pending = applyAuthoritativeBadgeState(registration, badgeNavigator, 0, {
-      isCurrent: gate.next()
-    });
+    const pending = applyAuthoritativeBadgeState(
+      registration,
+      badgeNavigator,
+      { kind: 'clear' },
+      {
+        isCurrent: gate.next()
+      }
+    );
     gate.invalidate();
     listing.resolve(nativeNotifications);
     await pending;
@@ -236,7 +252,7 @@ describe('applyAuthoritativeBadgeState', () => {
       clearAppBadge: vi.fn(async () => {})
     };
 
-    await applyAuthoritativeBadgeState(registration, badgeNavigator, 0);
+    await applyAuthoritativeBadgeState(registration, badgeNavigator, { kind: 'clear' });
 
     expect(registration.getNotifications).toHaveBeenCalledOnce();
     expect(badgeNavigator.clearAppBadge).toHaveBeenCalledOnce();
@@ -270,18 +286,18 @@ describe('ServiceWorkerBadgeCoordinator', () => {
       setAppBadge: vi.fn(async () => {}),
       clearAppBadge: vi.fn(async () => {})
     };
-    const foregroundCountStorage = createMemoryForegroundCountStorage();
+    const foregroundBadgeIntentStorage = createMemoryBadgeIntentStorage();
 
     await new ServiceWorkerBadgeCoordinator(
       registration,
       badgeNavigator,
-      foregroundCountStorage
+      foregroundBadgeIntentStorage
     ).applyForegroundNotificationCount(3, { serviceWorkerAppBadgeEnabled: true });
 
     await new ServiceWorkerBadgeCoordinator(
       registration,
       badgeNavigator,
-      foregroundCountStorage
+      foregroundBadgeIntentStorage
     ).reconcileAfterNotificationClick();
 
     expect(badgeNavigator.setAppBadge).toHaveBeenLastCalledWith(3);
@@ -296,12 +312,12 @@ describe('ServiceWorkerBadgeCoordinator', () => {
       setAppBadge: vi.fn(async () => {}),
       clearAppBadge: vi.fn(async () => {})
     };
-    const foregroundCountStorage = createMemoryForegroundCountStorage();
+    const foregroundBadgeIntentStorage = createMemoryBadgeIntentStorage();
 
     const coordinator = new ServiceWorkerBadgeCoordinator(
       registration,
       badgeNavigator,
-      foregroundCountStorage
+      foregroundBadgeIntentStorage
     );
 
     await coordinator.applyForegroundNotificationCount(3, { serviceWorkerAppBadgeEnabled: false });
@@ -355,12 +371,12 @@ describe('ServiceWorkerBadgeCoordinator', () => {
       setAppBadge: vi.fn(async () => {}),
       clearAppBadge: vi.fn(async () => {})
     };
-    const foregroundCountStorage = createMemoryForegroundCountStorage();
+    const foregroundBadgeIntentStorage = createMemoryBadgeIntentStorage();
 
     const firstCoordinator = new ServiceWorkerBadgeCoordinator(
       registration,
       badgeNavigator,
-      foregroundCountStorage
+      foregroundBadgeIntentStorage
     );
     await firstCoordinator.applyForegroundNotificationCount(0, {
       serviceWorkerAppBadgeEnabled: true
@@ -373,7 +389,7 @@ describe('ServiceWorkerBadgeCoordinator', () => {
     await new ServiceWorkerBadgeCoordinator(
       registration,
       badgeNavigator,
-      foregroundCountStorage
+      foregroundBadgeIntentStorage
     ).reconcileAfterNotificationClick();
 
     expect(badgeNavigator.setAppBadge).toHaveBeenCalledWith(1);
@@ -405,12 +421,12 @@ describe('ServiceWorkerBadgeCoordinator', () => {
       setAppBadge: vi.fn(async () => {}),
       clearAppBadge: vi.fn(async () => {})
     };
-    const foregroundCountStorage = createMemoryForegroundCountStorage();
+    const foregroundBadgeIntentStorage = createMemoryBadgeIntentStorage();
 
     const coordinator = new ServiceWorkerBadgeCoordinator(
       registration,
       badgeNavigator,
-      foregroundCountStorage
+      foregroundBadgeIntentStorage
     );
     await coordinator.applyForegroundNotificationCount(3, { serviceWorkerAppBadgeEnabled: true });
     await coordinator.reconcileAfterDismissPush();
@@ -418,7 +434,7 @@ describe('ServiceWorkerBadgeCoordinator', () => {
     await new ServiceWorkerBadgeCoordinator(
       registration,
       badgeNavigator,
-      foregroundCountStorage
+      foregroundBadgeIntentStorage
     ).reconcileAfterNotificationClick();
 
     expect(badgeNavigator.clearAppBadge).toHaveBeenLastCalledWith();

--- a/apps/frontend/src/lib/pwa/notificationBadge.worker.spec.ts
+++ b/apps/frontend/src/lib/pwa/notificationBadge.worker.spec.ts
@@ -108,6 +108,24 @@ describe('syncBadgeFromNativeNotifications', () => {
     expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
   });
 
+  it('treats a clear foreground intent as no lower bound when native notifications remain', async () => {
+    const registration = {
+      getNotifications: vi.fn(async () => [{}, {}])
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+
+    await syncBadgeFromNativeNotifications(registration, badgeNavigator, {
+      minimumBadgeIntent: { kind: 'clear' }
+    });
+
+    expect(registration.getNotifications).toHaveBeenCalledOnce();
+    expect(badgeNavigator.setAppBadge).toHaveBeenCalledWith();
+    expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
+  });
+
   it('clears the app badge when no native notifications remain', async () => {
     const registration = {
       getNotifications: vi.fn(async () => [])
@@ -398,6 +416,35 @@ describe('ServiceWorkerBadgeCoordinator', () => {
 
     expect(badgeNavigator.setAppBadge).toHaveBeenCalledWith(1);
     expect(badgeNavigator.clearAppBadge).toHaveBeenCalledOnce();
+  });
+
+  it('does not let a persisted foreground clear hide remaining native notifications', async () => {
+    const registration = {
+      getNotifications: vi.fn(async () => [])
+    };
+    const badgeNavigator = {
+      setAppBadge: vi.fn(async () => {}),
+      clearAppBadge: vi.fn(async () => {})
+    };
+    const foregroundBadgeIntentStorage = createMemoryBadgeIntentStorage();
+
+    await new ServiceWorkerBadgeCoordinator(
+      registration,
+      badgeNavigator,
+      foregroundBadgeIntentStorage
+    ).applyForegroundNotificationCount(0, { serviceWorkerAppBadgeEnabled: true });
+    registration.getNotifications.mockResolvedValue([{}]);
+    badgeNavigator.clearAppBadge.mockClear();
+    badgeNavigator.setAppBadge.mockClear();
+
+    await new ServiceWorkerBadgeCoordinator(
+      registration,
+      badgeNavigator,
+      foregroundBadgeIntentStorage
+    ).reconcileAfterNotificationClick();
+
+    expect(badgeNavigator.setAppBadge).toHaveBeenCalledWith();
+    expect(badgeNavigator.clearAppBadge).not.toHaveBeenCalled();
   });
 
   it('does not persist push app badge counts as foreground state', async () => {

--- a/apps/frontend/src/lib/pwa/notificationBadge.worker.spec.ts
+++ b/apps/frontend/src/lib/pwa/notificationBadge.worker.spec.ts
@@ -4,6 +4,7 @@ import {
   BadgeStateVersionGate,
   createCacheForegroundBadgeIntentStorage,
   type ForegroundBadgeIntentStorage,
+  type NativeNotificationLike,
   ServiceWorkerBadgeCoordinator,
   syncBadgeFromNativeNotifications
 } from './notificationBadge.worker';
@@ -419,8 +420,9 @@ describe('ServiceWorkerBadgeCoordinator', () => {
   });
 
   it('does not let a persisted foreground clear hide remaining native notifications', async () => {
+    const nativeNotifications: NativeNotificationLike[] = [{}];
     const registration = {
-      getNotifications: vi.fn(async () => [])
+      getNotifications: vi.fn(async (): Promise<NativeNotificationLike[]> => [])
     };
     const badgeNavigator = {
       setAppBadge: vi.fn(async () => {}),
@@ -433,7 +435,7 @@ describe('ServiceWorkerBadgeCoordinator', () => {
       badgeNavigator,
       foregroundBadgeIntentStorage
     ).applyForegroundNotificationCount(0, { serviceWorkerAppBadgeEnabled: true });
-    registration.getNotifications.mockResolvedValue([{}]);
+    registration.getNotifications.mockResolvedValue(nativeNotifications);
     badgeNavigator.clearAppBadge.mockClear();
     badgeNavigator.setAppBadge.mockClear();
 

--- a/apps/frontend/src/lib/pwa/notificationBadge.worker.spec.ts
+++ b/apps/frontend/src/lib/pwa/notificationBadge.worker.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   applyAuthoritativeBadgeState,
   BadgeStateVersionGate,
+  createCacheForegroundBadgeIntentStorage,
   type ForegroundBadgeIntentStorage,
   ServiceWorkerBadgeCoordinator,
   syncBadgeFromNativeNotifications
@@ -35,6 +36,42 @@ function createMemoryBadgeIntentStorage(): ForegroundBadgeIntentStorage {
     }
   };
 }
+
+function createMemoryCacheStorage(): CacheStorage {
+  const entries = new Map<string, Response>();
+  return {
+    open: vi.fn(async () => ({
+      match: vi.fn(async (request: RequestInfo | URL) => entries.get(request.toString())?.clone()),
+      put: vi.fn(async (request: RequestInfo | URL, response: Response) => {
+        entries.set(request.toString(), response.clone());
+      })
+    }))
+  } as unknown as CacheStorage;
+}
+
+describe('createCacheForegroundBadgeIntentStorage', () => {
+  it('reads legacy foreground notification count cache entries', async () => {
+    const caches = createMemoryCacheStorage();
+    const cache = await caches.open('badge-state');
+    await cache.put(
+      '/__chatto/foreground-notification-count',
+      new Response(
+        JSON.stringify({
+          notificationCount: 3,
+          serviceWorkerAppBadgeEnabled: true
+        })
+      )
+    );
+
+    const storage = createCacheForegroundBadgeIntentStorage(caches, 'badge-state');
+
+    await expect(storage.readForegroundBadgeIntent()).resolves.toEqual({
+      kind: 'count',
+      count: 3
+    });
+    await expect(storage.readServiceWorkerAppBadgeEnabled()).resolves.toBe(true);
+  });
+});
 
 describe('syncBadgeFromNativeNotifications', () => {
   it('sets a flag app badge when native notifications remain', async () => {

--- a/apps/frontend/src/lib/pwa/notificationBadge.worker.ts
+++ b/apps/frontend/src/lib/pwa/notificationBadge.worker.ts
@@ -3,6 +3,11 @@ export interface BadgeCapableNavigator {
   clearAppBadge?: () => Promise<void>;
 }
 
+export type ServiceWorkerBadgeIntent =
+  | { kind: 'clear' }
+  | { kind: 'flag' }
+  | { kind: 'count'; count: number };
+
 export interface NativeNotificationLike {
   close?: () => void;
 }
@@ -11,59 +16,92 @@ export interface NotificationListingRegistration {
   getNotifications(options?: { tag?: string }): Promise<readonly NativeNotificationLike[]>;
 }
 
-export interface ForegroundNotificationCountStorage {
-  readForegroundNotificationCount(): Promise<number | null>;
+export interface ForegroundBadgeIntentStorage {
+  readForegroundBadgeIntent(): Promise<ServiceWorkerBadgeIntent | null>;
   readServiceWorkerAppBadgeEnabled(): Promise<boolean>;
   writeForegroundNotificationState(
-    notificationCount: number,
+    badgeIntent: ServiceWorkerBadgeIntent,
     serviceWorkerAppBadgeEnabled: boolean
   ): Promise<void>;
-  clearForegroundNotificationCount(): Promise<void>;
+  clearForegroundBadgeIntent(): Promise<void>;
 }
 
-const FOREGROUND_NOTIFICATION_COUNT_REQUEST = '/__chatto/foreground-notification-count';
+const FOREGROUND_BADGE_INTENT_REQUEST = '/__chatto/foreground-badge-intent';
 
 function normalizeBadgeCount(notificationCount: number): number {
   if (!Number.isFinite(notificationCount)) return 0;
   return Math.max(0, Math.floor(notificationCount));
 }
 
+export function normalizeBadgeIntent(intent: ServiceWorkerBadgeIntent): ServiceWorkerBadgeIntent {
+  if (intent.kind !== 'count') return intent;
+  const count = normalizeBadgeCount(intent.count);
+  return count > 0 ? { kind: 'count', count } : { kind: 'clear' };
+}
+
 interface StoredForegroundBadgeState {
-  notificationCount: number | null;
+  badgeIntent: ServiceWorkerBadgeIntent | null;
   serviceWorkerAppBadgeEnabled: boolean;
 }
 
 function normalizeStoredForegroundBadgeState(value: unknown): StoredForegroundBadgeState {
   if (!value || typeof value !== 'object') {
-    return { notificationCount: null, serviceWorkerAppBadgeEnabled: false };
+    return { badgeIntent: null, serviceWorkerAppBadgeEnabled: false };
   }
 
   const state = value as {
+    badgeIntent?: unknown;
     notificationCount?: unknown;
     serviceWorkerAppBadgeEnabled?: unknown;
   };
+
+  const badgeIntent = normalizeUnknownBadgeIntent(state.badgeIntent);
+  const legacyCount =
+    typeof state.notificationCount === 'number'
+      ? badgeIntentFromCount(state.notificationCount)
+      : null;
   return {
-    notificationCount:
-      typeof state.notificationCount === 'number'
-        ? normalizeBadgeCount(state.notificationCount)
-        : null,
+    badgeIntent: badgeIntent ?? legacyCount,
     serviceWorkerAppBadgeEnabled: state.serviceWorkerAppBadgeEnabled === true
   };
 }
 
-export function createCacheForegroundNotificationCountStorage(
+export function normalizeUnknownBadgeIntent(value: unknown): ServiceWorkerBadgeIntent | null {
+  if (!value || typeof value !== 'object') return null;
+
+  const intent = value as { kind?: unknown; count?: unknown };
+  switch (intent.kind) {
+    case 'clear':
+      return { kind: 'clear' };
+    case 'flag':
+      return { kind: 'flag' };
+    case 'count':
+      return typeof intent.count === 'number'
+        ? normalizeBadgeIntent({ kind: 'count', count: intent.count })
+        : null;
+    default:
+      return null;
+  }
+}
+
+function badgeIntentFromCount(notificationCount: number): ServiceWorkerBadgeIntent {
+  const count = normalizeBadgeCount(notificationCount);
+  return count > 0 ? { kind: 'count', count } : { kind: 'clear' };
+}
+
+export function createCacheForegroundBadgeIntentStorage(
   caches: CacheStorage,
   cacheName: string
-): ForegroundNotificationCountStorage {
+): ForegroundBadgeIntentStorage {
   async function readState(): Promise<StoredForegroundBadgeState> {
     try {
       const cache = await caches.open(cacheName);
-      const response = await cache.match(FOREGROUND_NOTIFICATION_COUNT_REQUEST);
-      if (!response) return { notificationCount: null, serviceWorkerAppBadgeEnabled: false };
+      const response = await cache.match(FOREGROUND_BADGE_INTENT_REQUEST);
+      if (!response) return { badgeIntent: null, serviceWorkerAppBadgeEnabled: false };
 
       return normalizeStoredForegroundBadgeState(await response.json());
     } catch {
-      return { notificationCount: null, serviceWorkerAppBadgeEnabled: false };
+      return { badgeIntent: null, serviceWorkerAppBadgeEnabled: false };
     }
   }
 
@@ -71,7 +109,7 @@ export function createCacheForegroundNotificationCountStorage(
     try {
       const cache = await caches.open(cacheName);
       await cache.put(
-        FOREGROUND_NOTIFICATION_COUNT_REQUEST,
+        FOREGROUND_BADGE_INTENT_REQUEST,
         new Response(JSON.stringify(state), {
           headers: { 'content-type': 'application/json' }
         })
@@ -83,21 +121,21 @@ export function createCacheForegroundNotificationCountStorage(
   }
 
   return {
-    async readForegroundNotificationCount() {
-      return (await readState()).notificationCount;
+    async readForegroundBadgeIntent() {
+      return (await readState()).badgeIntent;
     },
     async readServiceWorkerAppBadgeEnabled() {
       return (await readState()).serviceWorkerAppBadgeEnabled;
     },
-    async writeForegroundNotificationState(notificationCount, serviceWorkerAppBadgeEnabled) {
+    async writeForegroundNotificationState(badgeIntent, serviceWorkerAppBadgeEnabled) {
       await writeState({
-        notificationCount: normalizeBadgeCount(notificationCount),
+        badgeIntent: normalizeBadgeIntent(badgeIntent),
         serviceWorkerAppBadgeEnabled
       });
     },
-    async clearForegroundNotificationCount() {
+    async clearForegroundBadgeIntent() {
       const state = await readState();
-      await writeState({ ...state, notificationCount: null });
+      await writeState({ ...state, badgeIntent: null });
     }
   };
 }
@@ -118,38 +156,40 @@ export class BadgeStateVersionGate {
 export async function syncBadgeFromNativeNotifications(
   registration: NotificationListingRegistration,
   badgeNavigator: BadgeCapableNavigator,
-  options: { minimumNotificationCount?: number } = {}
+  options: { minimumBadgeIntent?: ServiceWorkerBadgeIntent } = {}
 ): Promise<void> {
-  const minimumNotificationCount = normalizeBadgeCount(options.minimumNotificationCount ?? 0);
+  const minimumBadgeIntent = options.minimumBadgeIntent
+    ? normalizeBadgeIntent(options.minimumBadgeIntent)
+    : null;
   let notifications: readonly NativeNotificationLike[];
   try {
     notifications = await registration.getNotifications();
   } catch {
-    if (minimumNotificationCount > 0) {
-      await (badgeNavigator.setAppBadge?.(minimumNotificationCount).catch(() => {}) ??
-        Promise.resolve());
+    if (minimumBadgeIntent) {
+      await applyBadgeIntent(badgeNavigator, minimumBadgeIntent);
     }
     return;
   }
 
-  const count = Math.max(notifications.length, minimumNotificationCount);
-  if (count > 0) {
-    await (badgeNavigator.setAppBadge?.(count).catch(() => {}) ?? Promise.resolve());
+  if (minimumBadgeIntent) {
+    await applyBadgeIntent(badgeNavigator, minimumBadgeIntent);
+  } else if (notifications.length > 0) {
+    await applyBadgeIntent(badgeNavigator, { kind: 'flag' });
   } else {
-    await (badgeNavigator.clearAppBadge?.().catch(() => {}) ?? Promise.resolve());
+    await applyBadgeIntent(badgeNavigator, { kind: 'clear' });
   }
 }
 
 export async function applyAuthoritativeBadgeState(
   registration: NotificationListingRegistration,
   badgeNavigator: BadgeCapableNavigator,
-  notificationCount: number,
+  badgeIntent: ServiceWorkerBadgeIntent,
   options: { isCurrent?: () => boolean } = {}
 ): Promise<void> {
-  const count = normalizeBadgeCount(notificationCount);
-  if (count > 0) {
+  const intent = normalizeBadgeIntent(badgeIntent);
+  if (intent.kind !== 'clear') {
     if (options.isCurrent && !options.isCurrent()) return;
-    await (badgeNavigator.setAppBadge?.(count).catch(() => {}) ?? Promise.resolve());
+    await applyBadgeIntent(badgeNavigator, intent);
     return;
   }
 
@@ -157,7 +197,7 @@ export async function applyAuthoritativeBadgeState(
   try {
     notifications = await registration.getNotifications();
   } catch {
-    // Still clear the badge below; the foreground app's zero count is the
+    // Still clear the badge below; the foreground app's clear intent is the
     // authoritative notification state even if native listing is unavailable.
   }
 
@@ -165,38 +205,63 @@ export async function applyAuthoritativeBadgeState(
   for (const notification of notifications) {
     notification.close?.();
   }
-  await (badgeNavigator.clearAppBadge?.().catch(() => {}) ?? Promise.resolve());
+  await applyBadgeIntent(badgeNavigator, intent);
+}
+
+export async function applyBadgeIntent(
+  badgeNavigator: BadgeCapableNavigator,
+  badgeIntent: ServiceWorkerBadgeIntent
+): Promise<void> {
+  const intent = normalizeBadgeIntent(badgeIntent);
+  switch (intent.kind) {
+    case 'count':
+      await (badgeNavigator.setAppBadge?.(intent.count).catch(() => {}) ?? Promise.resolve());
+      break;
+    case 'flag':
+      await (badgeNavigator.setAppBadge?.().catch(() => {}) ?? Promise.resolve());
+      break;
+    case 'clear':
+      await (badgeNavigator.clearAppBadge?.().catch(() => {}) ?? Promise.resolve());
+      break;
+  }
 }
 
 export class ServiceWorkerBadgeCoordinator {
-  #foregroundNotificationCount: number | null = null;
+  #foregroundBadgeIntent: ServiceWorkerBadgeIntent | null = null;
   #serviceWorkerAppBadgeEnabled: boolean | null = null;
   #gate = new BadgeStateVersionGate();
 
   constructor(
     private readonly registration: NotificationListingRegistration,
     private readonly badgeNavigator: BadgeCapableNavigator,
-    private readonly foregroundCountStorage?: ForegroundNotificationCountStorage
+    private readonly foregroundBadgeIntentStorage?: ForegroundBadgeIntentStorage
   ) {}
 
   async applyForegroundNotificationCount(
     notificationCount: number,
     options: { serviceWorkerAppBadgeEnabled?: boolean } = {}
   ): Promise<void> {
-    const count = normalizeBadgeCount(notificationCount);
-    this.#foregroundNotificationCount = count;
+    await this.applyForegroundBadgeIntent(badgeIntentFromCount(notificationCount), options);
+  }
+
+  async applyForegroundBadgeIntent(
+    badgeIntent: ServiceWorkerBadgeIntent,
+    options: { serviceWorkerAppBadgeEnabled?: boolean } = {}
+  ): Promise<void> {
+    const intent = normalizeBadgeIntent(badgeIntent);
+    this.#foregroundBadgeIntent = intent;
     if (options.serviceWorkerAppBadgeEnabled !== undefined) {
       this.#serviceWorkerAppBadgeEnabled = options.serviceWorkerAppBadgeEnabled;
     }
     const isCurrent = this.#gate.next();
-    await this.foregroundCountStorage?.writeForegroundNotificationState(
-      count,
+    await this.foregroundBadgeIntentStorage?.writeForegroundNotificationState(
+      intent,
       await this.isServiceWorkerAppBadgeEnabled()
     );
     await applyAuthoritativeBadgeState(
       this.registration,
       await this.badgeNavigatorIfEnabled(),
-      count,
+      intent,
       {
         isCurrent
       }
@@ -209,50 +274,42 @@ export class ServiceWorkerBadgeCoordinator {
 
   async reconcileAfterDismissPush(): Promise<void> {
     this.#gate.invalidate();
-    this.#foregroundNotificationCount = null;
-    await this.foregroundCountStorage?.clearForegroundNotificationCount();
+    this.#foregroundBadgeIntent = null;
+    await this.foregroundBadgeIntentStorage?.clearForegroundBadgeIntent();
     await syncBadgeFromNativeNotifications(this.registration, await this.badgeNavigatorIfEnabled());
   }
 
   async reconcileAfterNotificationClick(): Promise<void> {
     this.#gate.invalidate();
-    const persistedForegroundCount =
-      (await this.foregroundCountStorage?.readForegroundNotificationCount()) ?? 0;
+    const persistedForegroundIntent =
+      (await this.foregroundBadgeIntentStorage?.readForegroundBadgeIntent()) ?? null;
     await syncBadgeFromNativeNotifications(
       this.registration,
       await this.badgeNavigatorIfEnabled(),
       {
-        minimumNotificationCount: Math.max(
-          this.#foregroundNotificationCount ?? 0,
-          persistedForegroundCount
-        )
+        minimumBadgeIntent: this.#foregroundBadgeIntent ?? persistedForegroundIntent ?? undefined
       }
     );
   }
 
   async setProvisionalPushFlagBadge(): Promise<void> {
-    const badgeNavigator = await this.badgeNavigatorIfEnabled();
-    await (badgeNavigator.setAppBadge?.().catch(() => {}) ?? Promise.resolve());
+    await applyBadgeIntent(await this.badgeNavigatorIfEnabled(), { kind: 'flag' });
   }
 
   async setPushAppBadgeCount(notificationCount: number): Promise<void> {
     this.#gate.invalidate();
-    const count = normalizeBadgeCount(notificationCount);
-
-    const badgeNavigator = await this.badgeNavigatorIfEnabled();
-    if (count > 0) {
-      await (badgeNavigator.setAppBadge?.(count).catch(() => {}) ?? Promise.resolve());
-    } else {
-      await (badgeNavigator.clearAppBadge?.().catch(() => {}) ?? Promise.resolve());
-    }
+    await applyBadgeIntent(
+      await this.badgeNavigatorIfEnabled(),
+      badgeIntentFromCount(notificationCount)
+    );
   }
 
   private async isServiceWorkerAppBadgeEnabled(): Promise<boolean> {
     if (this.#serviceWorkerAppBadgeEnabled !== null) return this.#serviceWorkerAppBadgeEnabled;
-    if (!this.foregroundCountStorage) return true;
+    if (!this.foregroundBadgeIntentStorage) return true;
 
     this.#serviceWorkerAppBadgeEnabled =
-      await this.foregroundCountStorage.readServiceWorkerAppBadgeEnabled();
+      await this.foregroundBadgeIntentStorage.readServiceWorkerAppBadgeEnabled();
     return this.#serviceWorkerAppBadgeEnabled;
   }
 

--- a/apps/frontend/src/lib/pwa/notificationBadge.worker.ts
+++ b/apps/frontend/src/lib/pwa/notificationBadge.worker.ts
@@ -27,6 +27,7 @@ export interface ForegroundBadgeIntentStorage {
 }
 
 const FOREGROUND_BADGE_INTENT_REQUEST = '/__chatto/foreground-badge-intent';
+const LEGACY_FOREGROUND_NOTIFICATION_COUNT_REQUEST = '/__chatto/foreground-notification-count';
 
 function normalizeBadgeCount(notificationCount: number): number {
   if (!Number.isFinite(notificationCount)) return 0;
@@ -96,7 +97,9 @@ export function createCacheForegroundBadgeIntentStorage(
   async function readState(): Promise<StoredForegroundBadgeState> {
     try {
       const cache = await caches.open(cacheName);
-      const response = await cache.match(FOREGROUND_BADGE_INTENT_REQUEST);
+      const response =
+        (await cache.match(FOREGROUND_BADGE_INTENT_REQUEST)) ??
+        (await cache.match(LEGACY_FOREGROUND_NOTIFICATION_COUNT_REQUEST));
       if (!response) return { badgeIntent: null, serviceWorkerAppBadgeEnabled: false };
 
       return normalizeStoredForegroundBadgeState(await response.json());

--- a/apps/frontend/src/lib/pwa/notificationBadge.worker.ts
+++ b/apps/frontend/src/lib/pwa/notificationBadge.worker.ts
@@ -174,8 +174,9 @@ export async function syncBadgeFromNativeNotifications(
     return;
   }
 
-  if (minimumBadgeIntent) {
-    await applyBadgeIntent(badgeNavigator, minimumBadgeIntent);
+  const listedMinimumBadgeIntent = minimumBadgeIntent?.kind === 'clear' ? null : minimumBadgeIntent;
+  if (listedMinimumBadgeIntent) {
+    await applyBadgeIntent(badgeNavigator, listedMinimumBadgeIntent);
   } else if (notifications.length > 0) {
     await applyBadgeIntent(badgeNavigator, { kind: 'flag' });
   } else {

--- a/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -1079,6 +1079,61 @@ describe('MessagesStore — room lifecycle ownership', () => {
     store.dispose();
   });
 
+  it('replaces a disjoint latest room refresh so older pagination can bridge gaps', async () => {
+    const fake = new FakeQueryClient([
+      roomEventsResult({
+        events: [threadMessageEvent('m1'), threadMessageEvent('m2')],
+        startCursor: 'tl:cursor-1',
+        endCursor: 'tl:cursor-2',
+        hasOlder: false,
+        hasNewer: false
+      }),
+      roomEventsResult({
+        events: [threadMessageEvent('m5'), threadMessageEvent('m6')],
+        startCursor: 'tl:cursor-5',
+        endCursor: 'tl:cursor-6',
+        hasOlder: true,
+        hasNewer: false
+      }),
+      roomEventsResult({
+        events: [threadMessageEvent('m3'), threadMessageEvent('m4')],
+        startCursor: 'tl:cursor-3',
+        endCursor: 'tl:cursor-4',
+        hasOlder: false,
+        hasNewer: true
+      })
+    ]);
+    const store = new MessagesStore(
+      fake as unknown as ServerConnection,
+      () => null,
+      timelineFromFixtures(fake)
+    );
+
+    store.setRoom('room-1');
+    await settle();
+    fake.queryMock.mockClear();
+
+    const result = await store.refreshCurrentWindow();
+    await settle();
+
+    expect(result).toMatchObject({ refreshed: true, changed: true });
+    expect(store.rootEvents.map((event) => event.id)).toEqual(['m5', 'm6']);
+    expect(store.hasReachedStart).toBe(false);
+
+    await store.loadMore();
+    await settle();
+
+    expect(fake.queryMock.mock.calls[1][0]).toBe('timeline:before');
+    expect(fake.queryMock.mock.calls[1][1]).toEqual({
+      roomId: 'room-1',
+      limit: 50,
+      before: 'tl:cursor-5'
+    });
+    expect(store.rootEvents.map((event) => event.id)).toEqual(['m3', 'm4', 'm5', 'm6']);
+    expect(store.hasReachedStart).toBe(true);
+    store.dispose();
+  });
+
   it('soft-refreshes around an anchor event when one is provided', async () => {
     const fake = new FakeQueryClient([
       roomEventsResult({
@@ -1300,6 +1355,72 @@ describe('MessagesStore — room lifecycle ownership', () => {
       eventId: 't1',
       limit: 50
     });
+    expect(fake.queryMock).not.toHaveBeenCalled();
+    store.dispose();
+  });
+
+  it('replaces a disjoint latest thread refresh so older pagination can bridge gaps', async () => {
+    const fake = new FakeQueryClient();
+    const timeline = fakeTimelineAPI({
+      getThreadEvents: vi
+        .fn()
+        .mockResolvedValueOnce({
+          events: [
+            threadMessageEvent('t1') as never,
+            threadMessageEvent('r1', 't1') as never,
+            threadMessageEvent('r2', 't1') as never
+          ],
+          startCursor: 'tl:cursor-1',
+          endCursor: 'tl:cursor-2',
+          hasOlder: false,
+          hasNewer: false
+        })
+        .mockResolvedValueOnce({
+          events: [
+            threadMessageEvent('t1') as never,
+            threadMessageEvent('r5', 't1') as never,
+            threadMessageEvent('r6', 't1') as never
+          ],
+          startCursor: 'tl:cursor-5',
+          endCursor: 'tl:cursor-6',
+          hasOlder: true,
+          hasNewer: false
+        })
+        .mockResolvedValueOnce({
+          events: [
+            threadMessageEvent('r3', 't1') as never,
+            threadMessageEvent('r4', 't1') as never
+          ],
+          startCursor: 'tl:cursor-3',
+          endCursor: 'tl:cursor-4',
+          hasOlder: false,
+          hasNewer: true
+        })
+    });
+    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, timeline);
+
+    store.setThread('room-1', 't1');
+    await settle();
+
+    const result = await store.refreshCurrentWindow(null);
+    await settle();
+
+    expect(result).toMatchObject({ refreshed: true, changed: true });
+    expect(store.threadEvents.map((event) => event.id)).toEqual(['t1', 'r5', 'r6']);
+    expect(store.hasReachedStart).toBe(false);
+
+    await store.loadMore();
+    await settle();
+
+    expect(timeline.getThreadEvents).toHaveBeenCalledTimes(3);
+    expect(timeline.getThreadEvents).toHaveBeenLastCalledWith({
+      roomId: 'room-1',
+      threadRootEventId: 't1',
+      limit: 50,
+      before: 'tl:cursor-5'
+    });
+    expect(store.threadEvents.map((event) => event.id)).toEqual(['t1', 'r3', 'r4', 'r5', 'r6']);
+    expect(store.hasReachedStart).toBe(true);
     expect(fake.queryMock).not.toHaveBeenCalled();
     store.dispose();
   });

--- a/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -1009,6 +1009,76 @@ describe('MessagesStore — room lifecycle ownership', () => {
     store.dispose();
   });
 
+  it('keeps the event array stable when a latest soft-refresh is unchanged', async () => {
+    const fake = new FakeQueryClient([
+      roomEventsResult({
+        events: [threadMessageEvent('m1'), threadMessageEvent('m2')],
+        startCursor: 'tl:cursor-1',
+        endCursor: 'tl:cursor-2',
+        hasOlder: false,
+        hasNewer: false
+      }),
+      roomEventsResult({
+        events: [threadMessageEvent('m1'), threadMessageEvent('m2')],
+        startCursor: 'tl:cursor-1',
+        endCursor: 'tl:cursor-2',
+        hasOlder: false,
+        hasNewer: false
+      })
+    ]);
+    const store = new MessagesStore(
+      fake as unknown as ServerConnection,
+      () => null,
+      timelineFromFixtures(fake)
+    );
+
+    store.setRoom('room-1');
+    await settle();
+    const previousEvents = store.events;
+
+    const result = await store.refreshCurrentWindow();
+    await settle();
+
+    expect(result).toMatchObject({ refreshed: true, changed: false });
+    expect(store.events).toBe(previousEvents);
+    expect(store.rootEvents.map((event) => event.id)).toEqual(['m1', 'm2']);
+    store.dispose();
+  });
+
+  it('preserves the loaded room window when a latest soft-refresh adds newer events', async () => {
+    const fake = new FakeQueryClient([
+      roomEventsResult({
+        events: [threadMessageEvent('m1'), threadMessageEvent('m2'), threadMessageEvent('m3')],
+        startCursor: 'tl:cursor-1',
+        endCursor: 'tl:cursor-3',
+        hasOlder: false,
+        hasNewer: false
+      }),
+      roomEventsResult({
+        events: [threadMessageEvent('m3'), threadMessageEvent('m4')],
+        startCursor: 'tl:cursor-3',
+        endCursor: 'tl:cursor-4',
+        hasOlder: true,
+        hasNewer: false
+      })
+    ]);
+    const store = new MessagesStore(
+      fake as unknown as ServerConnection,
+      () => null,
+      timelineFromFixtures(fake)
+    );
+
+    store.setRoom('room-1');
+    await settle();
+
+    const result = await store.refreshCurrentWindow();
+    await settle();
+
+    expect(result).toMatchObject({ refreshed: true, changed: true });
+    expect(store.rootEvents.map((event) => event.id)).toEqual(['m1', 'm2', 'm3', 'm4']);
+    store.dispose();
+  });
+
   it('soft-refreshes around an anchor event when one is provided', async () => {
     const fake = new FakeQueryClient([
       roomEventsResult({

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -77,6 +77,14 @@ function sameEventList(a: readonly RoomEventView[], b: readonly RoomEventView[])
   return true;
 }
 
+function isContinuityEvent(
+  event: RoomEventView,
+  scope: MessageScope | null,
+  threadRootEventId: string
+): boolean {
+  return scope !== 'thread' || event.id !== threadRootEventId;
+}
+
 function skippedRefreshResult(): RefreshCurrentWindowResult {
   return { hasOlder: false, hasNewer: false, refreshed: false, changed: false };
 }
@@ -936,6 +944,22 @@ export class MessagesStore {
     const previousOldestCursor = this.oldestCursor;
     const previousNewestCursor = this.newestCursor;
     const previousHasReachedStart = this.hasReachedStart;
+    const hasExistingContinuityEvents = this.events.some(
+      (event) =>
+        existingBeforeFetch.has(event.id) &&
+        isContinuityEvent(event, this.scope, this.threadRootEventId)
+    );
+    const hasFetchedOverlap = fetched.some(
+      (event) =>
+        existingBeforeFetch.has(event.id) &&
+        isContinuityEvent(event, this.scope, this.threadRootEventId)
+    );
+    const discontinuousLatestSnapshot =
+      !!options.preserveExistingWindow &&
+      !!options.latestSnapshot &&
+      !!connection.hasOlder &&
+      hasExistingContinuityEvents &&
+      !hasFetchedOverlap;
 
     for (const e of fetched) {
       if (newSeen.has(e.id)) continue;
@@ -948,7 +972,12 @@ export class MessagesStore {
     // fetched window so returning from another tab does not visually collapse a
     // long scrolled buffer.
     for (const e of this.events) {
-      if (!options.preserveExistingWindow && existingBeforeFetch.has(e.id)) continue;
+      if (
+        (!options.preserveExistingWindow || discontinuousLatestSnapshot) &&
+        existingBeforeFetch.has(e.id)
+      ) {
+        continue;
+      }
       if (newSeen.has(e.id)) continue;
       newSeen.add(e.id);
       merged.push(e);
@@ -967,7 +996,7 @@ export class MessagesStore {
       this.seenIds = newSeen;
     }
 
-    if (options.preserveExistingWindow) {
+    if (options.preserveExistingWindow && !discontinuousLatestSnapshot) {
       this.oldestCursor = previousOldestCursor ?? connection.startCursor ?? undefined;
       this.newestCursor = options.latestSnapshot
         ? (connection.endCursor ?? previousNewestCursor ?? undefined)
@@ -982,6 +1011,7 @@ export class MessagesStore {
       fetchedCount: fetched.length,
       preservedExistingCount: nextEvents.length - fetched.length,
       changed,
+      discontinuousLatestSnapshot,
       eventCount: this.events.length,
       hasOlder: connection.hasOlder ?? false,
       hasReachedStart: this.hasReachedStart

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -31,6 +31,7 @@ export type RefreshCurrentWindowResult = {
   hasOlder: boolean;
   hasNewer: boolean;
   refreshed: boolean;
+  changed: boolean;
 };
 
 function eventCacheKey(roomId: string, eventId: string): string {
@@ -39,6 +40,45 @@ function eventCacheKey(roomId: string, eventId: string): string {
 
 function compareEventCreatedAt(a: RoomEventView, b: RoomEventView): number {
   return Date.parse(a.createdAt) - Date.parse(b.createdAt);
+}
+
+function sortRoomEventList(events: RoomEventView[]): RoomEventView[] {
+  return events
+    .map((event, index) => ({ event, index }))
+    .sort((a, b) => compareEventCreatedAt(a.event, b.event) || a.index - b.index)
+    .map(({ event }) => event);
+}
+
+function sortThreadEventList(events: RoomEventView[], threadRootEventId: string): RoomEventView[] {
+  return events
+    .map((event, index) => ({ event, index }))
+    .sort((a, b) => {
+      const aIsRoot = a.event.id === threadRootEventId;
+      const bIsRoot = b.event.id === threadRootEventId;
+      if (aIsRoot && !bIsRoot) return -1;
+      if (!aIsRoot && bIsRoot) return 1;
+
+      const byCreatedAt = compareEventCreatedAt(a.event, b.event);
+      return byCreatedAt || a.index - b.index;
+    })
+    .map(({ event }) => event);
+}
+
+function eventFingerprint(event: RoomEventView): string {
+  return JSON.stringify(event);
+}
+
+function sameEventList(a: readonly RoomEventView[], b: readonly RoomEventView[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].id !== b[i].id) return false;
+    if (eventFingerprint(a[i]) !== eventFingerprint(b[i])) return false;
+  }
+  return true;
+}
+
+function skippedRefreshResult(): RefreshCurrentWindowResult {
+  return { hasOlder: false, hasNewer: false, refreshed: false, changed: false };
 }
 
 function isMessagePostedPayload(
@@ -513,7 +553,7 @@ export class MessagesStore {
    * have missed subscription events.
    */
   async refreshCurrentWindow(anchorEventId?: string | null): Promise<RefreshCurrentWindowResult> {
-    if (!this.scope || !this.roomId) return { hasOlder: false, hasNewer: false, refreshed: false };
+    if (!this.scope || !this.roomId) return skippedRefreshResult();
 
     const thisLoad = this.startLoad();
     const existingBeforeFetch = new SvelteSet(this.events.map((e) => e.id));
@@ -575,9 +615,9 @@ export class MessagesStore {
       });
       return result;
     } catch (error) {
-      if (this.isStale(thisLoad)) return { hasOlder: false, hasNewer: false, refreshed: false };
+      if (this.isStale(thisLoad)) return skippedRefreshResult();
       console.error('MessagesStore: refreshCurrentWindow failed:', error);
-      return { hasOlder: false, hasNewer: false, refreshed: false };
+      return skippedRefreshResult();
     }
   }
 
@@ -888,8 +928,8 @@ export class MessagesStore {
       hasOlder?: boolean;
     },
     existingBeforeFetch: ReadonlySet<string>,
-    options: { preserveExistingWindow?: boolean } = {}
-  ): void {
+    options: { preserveExistingWindow?: boolean; latestSnapshot?: boolean } = {}
+  ): boolean {
     const fetched = unmask(connection.events);
     const newSeen = new SvelteSet<string>();
     const merged: RoomEventView[] = [];
@@ -914,12 +954,24 @@ export class MessagesStore {
       merged.push(e);
     }
 
-    this.events = merged;
-    if (this.scope === 'room') this.sortRoomEvents();
-    this.seenIds = newSeen;
+    const nextEvents =
+      this.scope === 'room'
+        ? sortRoomEventList(merged)
+        : this.scope === 'thread'
+          ? sortThreadEventList(merged, this.threadRootEventId)
+          : merged;
+    const changed = !sameEventList(this.events, nextEvents);
+
+    if (changed) {
+      this.events = nextEvents;
+      this.seenIds = newSeen;
+    }
+
     if (options.preserveExistingWindow) {
       this.oldestCursor = previousOldestCursor ?? connection.startCursor ?? undefined;
-      this.newestCursor = previousNewestCursor ?? connection.endCursor ?? undefined;
+      this.newestCursor = options.latestSnapshot
+        ? (connection.endCursor ?? previousNewestCursor ?? undefined)
+        : (previousNewestCursor ?? connection.endCursor ?? undefined);
       this.hasReachedStart = previousHasReachedStart || !(connection.hasOlder ?? false);
     } else {
       this.oldestCursor = connection.startCursor ?? undefined;
@@ -928,11 +980,13 @@ export class MessagesStore {
     }
     console.debug('[room-refresh] snapshot applied', {
       fetchedCount: fetched.length,
-      preservedExistingCount: merged.length - fetched.length,
+      preservedExistingCount: nextEvents.length - fetched.length,
+      changed,
       eventCount: this.events.length,
       hasOlder: connection.hasOlder ?? false,
       hasReachedStart: this.hasReachedStart
     });
+    return changed;
   }
 
   private async refreshRoomLatest(
@@ -944,9 +998,12 @@ export class MessagesStore {
       limit: PAGE_SIZE
     });
 
-    if (this.isStale(thisLoad)) return { hasOlder: false, hasNewer: false, refreshed: false };
-    this.replaceWithSnapshotAndUpdateCursors(page, existingBeforeFetch);
-    return { hasOlder: page.hasOlder, hasNewer: page.hasNewer, refreshed: true };
+    if (this.isStale(thisLoad)) return skippedRefreshResult();
+    const changed = this.replaceWithSnapshotAndUpdateCursors(page, existingBeforeFetch, {
+      preserveExistingWindow: true,
+      latestSnapshot: true
+    });
+    return { hasOlder: page.hasOlder, hasNewer: page.hasNewer, refreshed: true, changed };
   }
 
   private async refreshRoomAround(
@@ -960,11 +1017,11 @@ export class MessagesStore {
       limit: PAGE_SIZE
     });
 
-    if (this.isStale(thisLoad)) return { hasOlder: false, hasNewer: false, refreshed: false };
-    this.replaceWithSnapshotAndUpdateCursors(page, existingBeforeFetch, {
+    if (this.isStale(thisLoad)) return skippedRefreshResult();
+    const changed = this.replaceWithSnapshotAndUpdateCursors(page, existingBeforeFetch, {
       preserveExistingWindow: true
     });
-    return { hasOlder: page.hasOlder, hasNewer: page.hasNewer, refreshed: true };
+    return { hasOlder: page.hasOlder, hasNewer: page.hasNewer, refreshed: true, changed };
   }
 
   private async refreshThreadWindow(
@@ -984,12 +1041,12 @@ export class MessagesStore {
           threadRootEventId: this.threadRootEventId,
           limit: PAGE_SIZE
         });
-    if (this.isStale(thisLoad)) return { hasOlder: false, hasNewer: false, refreshed: false };
-    this.replaceWithSnapshotAndUpdateCursors(page, existingBeforeFetch, {
-      preserveExistingWindow: anchorEventId !== null && anchorEventId !== this.threadRootEventId
+    if (this.isStale(thisLoad)) return skippedRefreshResult();
+    const changed = this.replaceWithSnapshotAndUpdateCursors(page, existingBeforeFetch, {
+      preserveExistingWindow: anchorEventId === null || anchorEventId !== this.threadRootEventId,
+      latestSnapshot: anchorEventId === null
     });
-    this.sortThreadEvents();
-    return { hasOlder: page.hasOlder, hasNewer: page.hasNewer, refreshed: true };
+    return { hasOlder: page.hasOlder, hasNewer: page.hasNewer, refreshed: true, changed };
   }
 
   private resetAndFetchLatest(): void {
@@ -1089,24 +1146,10 @@ export class MessagesStore {
   }
 
   private sortThreadEvents(): void {
-    this.events = this.events
-      .map((event, index) => ({ event, index }))
-      .sort((a, b) => {
-        const aIsRoot = a.event.id === this.threadRootEventId;
-        const bIsRoot = b.event.id === this.threadRootEventId;
-        if (aIsRoot && !bIsRoot) return -1;
-        if (!aIsRoot && bIsRoot) return 1;
-
-        const byCreatedAt = compareEventCreatedAt(a.event, b.event);
-        return byCreatedAt || a.index - b.index;
-      })
-      .map(({ event }) => event);
+    this.events = sortThreadEventList(this.events, this.threadRootEventId);
   }
 
   private sortRoomEvents(): void {
-    this.events = this.events
-      .map((event, index) => ({ event, index }))
-      .sort((a, b) => compareEventCreatedAt(a.event, b.event) || a.index - b.index)
-      .map(({ event }) => event);
+    this.events = sortRoomEventList(this.events);
   }
 }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -506,7 +506,7 @@
         hiddenDurationMs: signal.hiddenDurationMs,
         epoch: signal.epoch
       });
-      return true;
+      return false;
     }
 
     const bottomDistance = distanceFromBottom();

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -485,10 +485,29 @@
   }
 
   let softRefreshInFlight = false;
+  const MIN_BROWSER_WAKE_REFRESH_HIDDEN_MS = 5_000;
+
+  function isShortBrowserWake(signal: ResumeSignal): boolean {
+    if (signal.source !== 'browser') return false;
+    if (signal.reason !== 'visibility' && signal.reason !== 'pageshow') return false;
+    return (
+      signal.hiddenDurationMs !== null &&
+      signal.hiddenDurationMs < MIN_BROWSER_WAKE_REFRESH_HIDDEN_MS
+    );
+  }
 
   async function refreshAfterPossibleMiss(signal: ResumeSignal): Promise<boolean> {
     if (softRefreshInFlight) return false;
     if (isLoading && virtualItems.length === 0) return false;
+    if (isShortBrowserWake(signal)) {
+      console.debug('[room-refresh] skipped short browser wake refresh', {
+        roomId,
+        reason: signal.reason,
+        hiddenDurationMs: signal.hiddenDurationMs,
+        epoch: signal.epoch
+      });
+      return true;
+    }
 
     const bottomDistance = distanceFromBottom();
     const wasAtBottom =
@@ -526,6 +545,14 @@
         return false;
       }
       onSoftRefresh?.(result, anchor !== null);
+      if (!result.changed) {
+        console.debug('[room-refresh] event list refresh completed unchanged', {
+          roomId,
+          result,
+          itemCount: virtualItems.length
+        });
+        return true;
+      }
       await tick();
       await new Promise((resolve) => requestAnimationFrame(resolve));
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -6,7 +6,6 @@
   import MessageComposer, {
     type MessageComposerApi
   } from '$lib/components/composer/MessageComposer.svelte';
-  import type { EventEnvelope } from '$lib/eventBus.svelte';
   import { createRoleAPI } from '$lib/api-client/roles';
   import {
     useRoomData,
@@ -46,7 +45,7 @@
   import { serverStorageKey } from '$lib/storage/serverStorage';
   import PageTitle from '$lib/ui/PageTitle.svelte';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
-  import { isMessagePostedEvent, RoomEventKind, roomEventKind } from '$lib/render/eventKinds';
+  import { isMessagePostedEvent } from '$lib/render/eventKinds';
   import { onDestroy, tick } from 'svelte';
   import { fly } from 'svelte/transition';
   import RoomEventsPane from './RoomEventsPane.svelte';
@@ -297,34 +296,6 @@
     }
   }
 
-  function scopedRoomId(event: EventEnvelope['event']): string | null {
-    if (!event || !('roomId' in event) || typeof event.roomId !== 'string') return null;
-    return event.roomId;
-  }
-
-  function shouldRevealAwaySeparator(event: EventEnvelope): boolean {
-    const eventData = event.event;
-    if (!eventData) return false;
-    if (event.actorId === currentUser.user?.id) return false;
-
-    switch (roomEventKind(eventData)) {
-      case RoomEventKind.MessagePosted:
-        if (!isMessagePostedEvent(eventData)) return false;
-        return (
-          eventData.roomId === roomId && (!!eventData.echoOfEventId || !eventData.threadRootEventId)
-        );
-      case RoomEventKind.UserJoinedRoom:
-      case RoomEventKind.UserLeftRoom:
-      case RoomEventKind.RoomUpdated:
-      case RoomEventKind.RoomDeleted:
-      case RoomEventKind.RoomArchived:
-      case RoomEventKind.RoomUnarchived:
-        return scopedRoomId(eventData) === roomId;
-      default:
-        return false;
-    }
-  }
-
   // Keep the server read cursor in sync with incoming root messages. Other
   // users' messages mark the room read while the user is actually present;
   // own messages are already auto-marked read by the post mutation.
@@ -332,10 +303,6 @@
     roomFilesStore.ingestServerEvent(event);
     roomMembersStore.ingestServerEvent(event);
     if (!event.event) return;
-
-    if (!appState.isPresent && shouldRevealAwaySeparator(event)) {
-      unread.noteAwayEvent(event.id);
-    }
 
     if (isMessagePostedEvent(event.event) && event.event.roomId === roomId) {
       const actorId = event.actorId;

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -32,7 +32,6 @@ const { mocks } = vi.hoisted(() => {
       goto: vi.fn(),
       pushState: vi.fn(),
       replaceState: vi.fn(),
-      noteAwayEvent: vi.fn(),
       markRoomAsRead: vi.fn(),
       resetTypingDebounce: vi.fn(),
       query: vi.fn(() => ({
@@ -127,7 +126,6 @@ vi.mock('$lib/hooks', () => ({
     unreadMarkerEventId: null,
     unreadMarkerWindow: null,
     markRoomAsRead: mocks.markRoomAsRead,
-    noteAwayEvent: mocks.noteAwayEvent,
     setUnreadMarkerEventId: vi.fn(),
     clearUnreadMarker: vi.fn()
   }),

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -171,8 +171,6 @@
       if (currentUser.user && actorId !== currentUser.user.id) {
         if (appState.isPresent) {
           void unread.markAsRead(threadRootEventId, serverEvent.id);
-        } else {
-          unread.noteAwayEvent(serverEvent.id);
         }
       }
     }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
@@ -57,7 +57,6 @@ vi.mock('$lib/hooks', () => ({
       unreadMarkerEventId: null,
       unreadMarkerWindow: null,
       markAsRead: options.markAsRead,
-      noteAwayEvent: vi.fn(),
       setUnreadMarkerEventId: vi.fn(),
       clearUnreadMarker: vi.fn()
     };

--- a/apps/frontend/src/service-worker.ts
+++ b/apps/frontend/src/service-worker.ts
@@ -16,8 +16,10 @@ import {
   type NotificationClickClients
 } from '$lib/pwa/notificationClick.worker';
 import {
+  normalizeUnknownBadgeIntent,
   ServiceWorkerBadgeCoordinator,
-  createCacheForegroundNotificationCountStorage
+  createCacheForegroundBadgeIntentStorage,
+  type ServiceWorkerBadgeIntent
 } from '$lib/pwa/notificationBadge.worker';
 
 declare const self: ServiceWorkerGlobalScope;
@@ -36,7 +38,7 @@ type ServiceWorkerAppBadgeNavigator = WorkerNavigator & {
 const badgeCoordinator = new ServiceWorkerBadgeCoordinator(
   self.registration,
   navigator as ServiceWorkerAppBadgeNavigator,
-  createCacheForegroundNotificationCountStorage(caches, BADGE_STATE_CACHE_NAME)
+  createCacheForegroundBadgeIntentStorage(caches, BADGE_STATE_CACHE_NAME)
 );
 
 /**
@@ -174,7 +176,7 @@ interface DeclarativeNotificationPayload {
 type NormalizedPushNotification = {
   title: string;
   options: NotificationOptions;
-  appBadgeCount: number | null;
+  appBadgeIntent: ServiceWorkerBadgeIntent;
 };
 
 type DeclarativePushEventNotification = Pick<
@@ -192,10 +194,16 @@ type PushEventWithDeclarativeNotification = PushEvent & {
 function handleBadgeStateMessage(event: ExtendableMessageEvent): boolean {
   const message = event.data as Record<string, unknown> | undefined;
   if (!message || message.type !== 'chatto-badge-state') return false;
-  if (typeof message.notificationCount !== 'number') return false;
+
+  const badgeIntent =
+    normalizeUnknownBadgeIntent(message.badgeIntent) ??
+    (typeof message.notificationCount === 'number'
+      ? legacyBadgeIntentFromCount(message.notificationCount)
+      : null);
+  if (!badgeIntent) return false;
 
   event.waitUntil(
-    badgeCoordinator.applyForegroundNotificationCount(message.notificationCount, {
+    badgeCoordinator.applyForegroundBadgeIntent(badgeIntent, {
       serviceWorkerAppBadgeEnabled: message.serviceWorkerAppBadgeEnabled === true
     })
   );
@@ -219,7 +227,7 @@ function normalizePushNotification(payload: DeclarativePushPayload): NormalizedP
         url
       }
     },
-    appBadgeCount: declarativeAppBadgeCount(notification?.app_badge)
+    appBadgeIntent: declarativeAppBadgeIntent(notification?.app_badge)
   };
 }
 
@@ -239,14 +247,23 @@ function declarativePayloadFromEventNotification(
   };
 }
 
-function declarativeAppBadgeCount(appBadge: unknown): number | null {
+function legacyBadgeIntentFromCount(notificationCount: number): ServiceWorkerBadgeIntent {
+  if (!Number.isFinite(notificationCount)) return { kind: 'clear' };
+  const count = Math.max(0, Math.floor(notificationCount));
+  return count > 0 ? { kind: 'count', count } : { kind: 'clear' };
+}
+
+function declarativeAppBadgeIntent(appBadge: unknown): ServiceWorkerBadgeIntent {
   if (typeof appBadge === 'number' && Number.isFinite(appBadge)) {
-    return Math.max(0, Math.floor(appBadge));
+    const count = Math.max(0, Math.floor(appBadge));
+    return count > 0 ? { kind: 'count', count } : { kind: 'clear' };
   }
-  if (typeof appBadge !== 'string' || appBadge.trim() === '') return null;
+  if (typeof appBadge !== 'string' || appBadge.trim() === '') return { kind: 'flag' };
 
   const count = Number(appBadge);
-  return Number.isFinite(count) ? Math.max(0, Math.floor(count)) : null;
+  if (!Number.isFinite(count)) return { kind: 'flag' };
+  const normalized = Math.max(0, Math.floor(count));
+  return normalized > 0 ? { kind: 'count', count: normalized } : { kind: 'clear' };
 }
 
 function notificationData(data: unknown): DeclarativeNotificationPayload['data'] {
@@ -301,9 +318,11 @@ self.addEventListener('push', (event) => {
   event.waitUntil(
     Promise.all([
       self.registration.showNotification(notification.title, notification.options),
-      notification.appBadgeCount !== null
-        ? badgeCoordinator.setPushAppBadgeCount(notification.appBadgeCount)
-        : badgeCoordinator.setProvisionalPushFlagBadge()
+      notification.appBadgeIntent.kind === 'count'
+        ? badgeCoordinator.setPushAppBadgeCount(notification.appBadgeIntent.count)
+        : notification.appBadgeIntent.kind === 'flag'
+          ? badgeCoordinator.setProvisionalPushFlagBadge()
+          : badgeCoordinator.setPushAppBadgeCount(0)
     ])
   );
 });

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -364,12 +364,14 @@ func setupPushNotifications(chattoCore *core.ChattoCore, cfg config.ChattoConfig
 
 		// Build and send push notification
 		payload := push.BuildPayloadFromNotification(notification, actorName, cfg.Webserver.URL, payloadCtx)
-		if count, err := chattoCore.GetNotificationCount(ctx, notification.RecipientId); err == nil {
-			payload.AppBadge = strconv.Itoa(count)
-		} else {
-			logger.Warn("Failed to get notification count for push app badge",
-				"user_id", notification.RecipientId,
-				"error", err)
+		if pushNotificationUsesCountBadge(notification) {
+			if count, err := chattoCore.GetNotificationCount(ctx, notification.RecipientId); err == nil {
+				payload.AppBadge = strconv.Itoa(count)
+			} else {
+				logger.Warn("Failed to get notification count for push app badge",
+					"user_id", notification.RecipientId,
+					"error", err)
+			}
 		}
 		results := sender.SendToMany(ctx, subscriptions, payload)
 
@@ -526,4 +528,9 @@ func fetchPayloadContext(ctx context.Context, chattoCore *core.ChattoCore, notif
 	}
 
 	return payloadCtx
+}
+
+func pushNotificationUsesCountBadge(notification *corev1.Notification) bool {
+	_, ok := notification.GetNotification().(*corev1.Notification_DmMessage)
+	return ok
 }

--- a/cli/cmd/run_test.go
+++ b/cli/cmd/run_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/nats-io/nats.go"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 	"hmans.de/chatto/internal/runtimeunit"
 	"hmans.de/chatto/internal/testutil"
 )
@@ -44,6 +45,59 @@ func TestShouldPrintBannerOnlyForTextLogs(t *testing.T) {
 	}
 	if shouldPrintBanner("auto", false) {
 		t.Fatal("expected auto logs off terminal to suppress banner")
+	}
+}
+
+func TestPushNotificationUsesCountBadgeOnlyForDMs(t *testing.T) {
+	tests := []struct {
+		name         string
+		notification *corev1.Notification
+		want         bool
+	}{
+		{
+			name: "direct message",
+			notification: &corev1.Notification{
+				Notification: &corev1.Notification_DmMessage{
+					DmMessage: &corev1.DMMessageNotification{RoomId: "dm-room", EventId: "event-1"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "mention",
+			notification: &corev1.Notification{
+				Notification: &corev1.Notification_Mention{
+					Mention: &corev1.MentionNotification{RoomId: "room-1", EventId: "event-1"},
+				},
+			},
+		},
+		{
+			name: "reply",
+			notification: &corev1.Notification{
+				Notification: &corev1.Notification_Reply{
+					Reply: &corev1.ReplyNotification{RoomId: "room-1", EventId: "event-1"},
+				},
+			},
+		},
+		{
+			name: "room message",
+			notification: &corev1.Notification{
+				Notification: &corev1.Notification_RoomMessage{
+					RoomMessage: &corev1.RoomMessageNotification{
+						RoomId:  "room-1",
+						EventId: "event-1",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pushNotificationUsesCountBadge(tt.notification); got != tt.want {
+				t.Fatalf("pushNotificationUsesCountBadge() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR simplifies unread separator placement so the server read cursor is the source of truth on room/thread entry, target changes, and tab refocus.
It also reduces tab-return timeline churn by preserving loaded message windows during catch-up refreshes, reporting unchanged refreshes, and skipping short browser-only wake refetches.
The root cause was that a brief visibility bounce could replace a 100-message window with the latest 50-message page, causing virtualizer remounts and visible UI blips.

## Validation

- `mise x -- pnpm --dir apps/frontend exec vitest src/lib/state/room/messages.svelte.spec.ts src/lib/hooks/useUnreadMarker.svelte.spec.ts 'src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts' 'src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts' --run`
- `pnpm run check:frontend`
- `git diff --check`
