### PR TITLE
fix(frontend): add optimistic reactions

### DIFF
--- a/apps/frontend/messages/de/room.json
+++ b/apps/frontend/messages/de/room.json
@@ -66,6 +66,7 @@
       "delete_title": "Nachricht löschen",
       "delete_prompt": "Möchtest du diese Nachricht wirklich löschen? Dies kann nicht rückgängig gemacht werden.",
       "delete_failed": "Nachricht konnte nicht gelöscht werden",
+      "reaction_failed": "Reaktion konnte nicht aktualisiert werden",
       "deleted": "Nachricht gelöscht",
       "actions": {
         "toolbar": "Nachrichtenaktionen",

--- a/apps/frontend/messages/en/room.json
+++ b/apps/frontend/messages/en/room.json
@@ -66,6 +66,7 @@
       "delete_title": "Delete Message",
       "delete_prompt": "Are you sure you want to delete this message? This cannot be undone.",
       "delete_failed": "Failed to delete message",
+      "reaction_failed": "Failed to update reaction",
       "deleted": "Message deleted",
       "actions": {
         "toolbar": "Message actions",

--- a/apps/frontend/src/lib/components/menus/MessageContextMenu.svelte
+++ b/apps/frontend/src/lib/components/menus/MessageContextMenu.svelte
@@ -21,6 +21,7 @@ Rendered inside a ContextMenu when right-clicking a message.
 <script lang="ts">
   import { useMessageActions, type MessageActionParams } from '$lib/hooks';
   import * as m from '$lib/i18n/messages';
+  import type { MessagesStore } from '$lib/state/room';
   import { getRecentEmojis } from '$lib/state/recentEmojis.svelte';
   import { getEmojiByName } from '$lib/emoji';
 
@@ -34,6 +35,7 @@ Rendered inside a ContextMenu when right-clicking a message.
     threadRootEventId = null,
     channelEchoEventId = null,
     canAddChannelEcho = false,
+    messageStore = null,
     reactions = [],
     canReact = false,
     canEdit = false,
@@ -54,6 +56,7 @@ Rendered inside a ContextMenu when right-clicking a message.
     threadRootEventId?: string | null;
     channelEchoEventId?: string | null;
     canAddChannelEcho?: boolean;
+    messageStore?: MessagesStore | null;
     reactions?: { emoji: string; hasReacted: boolean }[];
     canReact?: boolean;
     canEdit?: boolean;
@@ -84,7 +87,8 @@ Rendered inside a ContextMenu when right-clicking a message.
     messageBody,
     threadRootEventId,
     channelEchoEventId,
-    canAddChannelEcho
+    canAddChannelEcho,
+    messageStore
   });
 
   /** Set of Unicode emojis the current user has already reacted with (API returns shortcodes) */

--- a/apps/frontend/src/lib/hooks/index.ts
+++ b/apps/frontend/src/lib/hooks/index.ts
@@ -18,7 +18,7 @@ export {
 } from './useEvent.svelte';
 
 // Message actions
-export { useMessageActions } from './useMessageActions.svelte';
+export { useMessageActions, useReactionActions } from './useMessageActions.svelte';
 export type { MessageActionParams } from './useMessageActions.svelte';
 
 // Data hooks

--- a/apps/frontend/src/lib/hooks/useMessageActions.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useMessageActions.svelte.ts
@@ -1,10 +1,11 @@
 import { useConnection } from '$lib/state/server/connection.svelte';
 import { toast } from '$lib/ui/toast';
 import { pushState } from '$app/navigation';
-import { getComposerContext } from '$lib/state/room';
+import { getComposerContext, type MessagesStore } from '$lib/state/room';
 import { emojiToName } from '$lib/emoji';
 import { copyMessageLinkToClipboard } from '$lib/messageLinks';
 import { createReactionAPI } from '$lib/api-client/reactions';
+import * as m from '$lib/i18n/messages';
 
 export type MessageActionParams = {
   serverId: string;
@@ -16,23 +17,29 @@ export type MessageActionParams = {
   threadRootEventId?: string | null;
   channelEchoEventId?: string | null;
   canAddChannelEcho?: boolean;
+  messageStore?: MessagesStore | null;
 };
 
-/**
- * Shared message action handlers for context menu and action sheet.
- * Must be called during component initialization (uses getEditState context).
- */
-export function useMessageActions() {
-  const editState = getComposerContext().editState;
+/** Shared reaction mutation handlers for all message reaction controls. */
+export function useReactionActions() {
   const connection = useConnection();
 
-  async function addReaction(params: MessageActionParams, emoji: string) {
-    const name = emojiToName(emoji);
+  function reactionName(emojiOrName: string): string | null {
+    return emojiToName(emojiOrName) ?? emojiOrName;
+  }
+
+  async function addReaction(params: MessageActionParams, emojiOrName: string) {
+    const name = reactionName(emojiOrName);
     if (!name) return;
+    const optimistic = params.messageStore?.beginOptimisticReaction({
+      messageEventId: params.messageEventId,
+      emoji: name,
+      action: 'add'
+    });
 
     try {
       const conn = connection();
-      await createReactionAPI({
+      const result = await createReactionAPI({
         serverId: conn.serverId ?? params.serverId,
         baseUrl: conn.connectBaseUrl,
         bearerToken: conn.bearerToken
@@ -41,18 +48,25 @@ export function useMessageActions() {
         messageEventId: params.messageEventId,
         emoji: name
       });
+      optimistic?.applyServerReaction(result.reaction);
     } catch {
-      toast.error('Failed to add reaction');
+      optimistic?.rollback();
+      toast.error(m['room.message.reaction_failed']());
     }
   }
 
-  async function removeReaction(params: MessageActionParams, emoji: string) {
-    const name = emojiToName(emoji);
+  async function removeReaction(params: MessageActionParams, emojiOrName: string) {
+    const name = reactionName(emojiOrName);
     if (!name) return;
+    const optimistic = params.messageStore?.beginOptimisticReaction({
+      messageEventId: params.messageEventId,
+      emoji: name,
+      action: 'remove'
+    });
 
     try {
       const conn = connection();
-      await createReactionAPI({
+      const result = await createReactionAPI({
         serverId: conn.serverId ?? params.serverId,
         baseUrl: conn.connectBaseUrl,
         bearerToken: conn.bearerToken
@@ -61,8 +75,10 @@ export function useMessageActions() {
         messageEventId: params.messageEventId,
         emoji: name
       });
+      optimistic?.applyServerReaction(result.reaction);
     } catch {
-      toast.error('Failed to remove reaction');
+      optimistic?.rollback();
+      toast.error(m['room.message.reaction_failed']());
     }
   }
 
@@ -73,6 +89,21 @@ export function useMessageActions() {
       await addReaction(params, emoji);
     }
   }
+
+  return {
+    addReaction,
+    removeReaction,
+    toggleReaction
+  };
+}
+
+/**
+ * Shared message action handlers for context menu and action sheet.
+ * Must be called during component initialization (uses getEditState context).
+ */
+export function useMessageActions() {
+  const editState = getComposerContext().editState;
+  const reactionActions = useReactionActions();
 
   function startEdit(params: MessageActionParams) {
     editState.startEdit(params.eventId, params.messageBody, {
@@ -97,9 +128,7 @@ export function useMessageActions() {
   }
 
   return {
-    addReaction,
-    removeReaction,
-    toggleReaction,
+    ...reactionActions,
     startEdit,
     openDeleteConfirmation,
     copyMessageLink

--- a/apps/frontend/src/lib/i18n/messages.ts
+++ b/apps/frontend/src/lib/i18n/messages.ts
@@ -612,6 +612,7 @@ const msg_room_message_empty = (): LocalizedString => messages().room_message_em
 const msg_room_message_delete_title = (): LocalizedString => messages().room_message_delete_title(empty());
 const msg_room_message_delete_prompt = (): LocalizedString => messages().room_message_delete_prompt(empty());
 const msg_room_message_delete_failed = (): LocalizedString => messages().room_message_delete_failed(empty());
+const msg_room_message_reaction_failed = (): LocalizedString => messages().room_message_reaction_failed(empty());
 const msg_room_message_deleted = (): LocalizedString => messages().room_message_deleted(empty());
 const msg_room_message_actions_toolbar = (): LocalizedString => messages().room_message_actions_toolbar(empty());
 const msg_room_message_actions_react_with = (
@@ -1972,6 +1973,7 @@ export { msg_room_message_empty as 'room.message.empty' };
 export { msg_room_message_delete_title as 'room.message.delete_title' };
 export { msg_room_message_delete_prompt as 'room.message.delete_prompt' };
 export { msg_room_message_delete_failed as 'room.message.delete_failed' };
+export { msg_room_message_reaction_failed as 'room.message.reaction_failed' };
 export { msg_room_message_deleted as 'room.message.deleted' };
 export { msg_room_message_actions_toolbar as 'room.message.actions.toolbar' };
 export { msg_room_message_actions_react_with as 'room.message.actions.react_with' };

--- a/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -86,6 +86,35 @@ function messageWithReaction(id: string, emoji: string) {
   };
 }
 
+function messageWithReactionState(
+  id: string,
+  reaction: {
+    emoji: string;
+    count: number;
+    hasReacted: boolean;
+    users?: { id: string; displayName: string }[];
+  }
+) {
+  const event = threadMessageEvent(id);
+  return {
+    ...event,
+    event: {
+      ...event.event,
+      reactions: [
+        {
+          users: [],
+          ...reaction
+        }
+      ]
+    }
+  };
+}
+
+function reactionsOf(event: { event?: { kind?: string; reactions?: unknown[] } | null }) {
+  if (event.event?.kind !== RoomEventKind.MessagePosted) throw new Error('expected message event');
+  return event.event.reactions ?? [];
+}
+
 function threadMessageWithReaction(id: string, threadRootEventId: string, emoji: string) {
   const event = threadMessageEvent(id, threadRootEventId);
   return {
@@ -744,6 +773,252 @@ describe('MessagesStore — room lifecycle ownership', () => {
     expect(store.rootEvents[0].event).toMatchObject({
       reactions: [{ emoji: 'heart', count: 1 }]
     });
+    store.dispose();
+  });
+
+  it('applies and rolls back an optimistic reaction add', async () => {
+    const fake = new FakeQueryClient();
+    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, fakeTimelineAPI());
+    store.setRoom('room-1');
+    await settle();
+    store.events = [messageWithReaction('m1', 'heart') as never];
+
+    const optimistic = store.beginOptimisticReaction({
+      messageEventId: 'm1',
+      emoji: 'heart',
+      action: 'add'
+    });
+
+    expect(reactionsOf(store.rootEvents[0])).toMatchObject([
+      { emoji: 'heart', count: 2, hasReacted: true }
+    ]);
+
+    optimistic.rollback();
+
+    expect(reactionsOf(store.rootEvents[0])).toMatchObject([
+      { emoji: 'heart', count: 1, hasReacted: false }
+    ]);
+    store.dispose();
+  });
+
+  it('applies and rolls back an optimistic reaction remove', async () => {
+    const fake = new FakeQueryClient();
+    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, fakeTimelineAPI());
+    store.setRoom('room-1');
+    await settle();
+    store.events = [
+      messageWithReactionState('m1', { emoji: 'heart', count: 2, hasReacted: true }) as never
+    ];
+
+    const optimistic = store.beginOptimisticReaction({
+      messageEventId: 'm1',
+      emoji: 'heart',
+      action: 'remove'
+    });
+
+    expect(reactionsOf(store.rootEvents[0])).toMatchObject([
+      { emoji: 'heart', count: 1, hasReacted: false }
+    ]);
+
+    optimistic.rollback();
+
+    expect(reactionsOf(store.rootEvents[0])).toMatchObject([
+      { emoji: 'heart', count: 2, hasReacted: true }
+    ]);
+    store.dispose();
+  });
+
+  it('tracks independent optimistic reactions per emoji', async () => {
+    const fake = new FakeQueryClient();
+    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, fakeTimelineAPI());
+    store.setRoom('room-1');
+    await settle();
+    store.events = [threadMessageEvent('m1') as never];
+
+    const heart = store.beginOptimisticReaction({
+      messageEventId: 'm1',
+      emoji: 'heart',
+      action: 'add'
+    });
+    store.beginOptimisticReaction({
+      messageEventId: 'm1',
+      emoji: 'thumbsup',
+      action: 'add'
+    });
+
+    heart.rollback();
+
+    expect(reactionsOf(store.rootEvents[0])).toMatchObject([
+      { emoji: 'thumbsup', count: 1, hasReacted: true }
+    ]);
+    store.dispose();
+  });
+
+  it('rolls back only the touched reaction summary', async () => {
+    const fake = new FakeQueryClient();
+    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, fakeTimelineAPI());
+    store.setRoom('room-1');
+    await settle();
+    store.events = [messageWithReaction('m1', 'heart') as never];
+
+    const optimistic = store.beginOptimisticReaction({
+      messageEventId: 'm1',
+      emoji: 'heart',
+      action: 'add'
+    });
+    const current = store.rootEvents[0];
+    if (current.event?.kind !== RoomEventKind.MessagePosted) throw new Error('expected message');
+    store.events[0] = {
+      ...current,
+      event: {
+        ...current.event,
+        body: 'edited while reaction was pending',
+        reactions: [
+          ...current.event.reactions,
+          { emoji: 'thumbsup', count: 1, hasReacted: true, users: [] }
+        ]
+      }
+    } as never;
+
+    optimistic.rollback();
+
+    const rolledBack = store.rootEvents[0];
+    expect(rolledBack.event).toMatchObject({ body: 'edited while reaction was pending' });
+    expect(reactionsOf(rolledBack)).toMatchObject([
+      { emoji: 'heart', count: 1, hasReacted: false },
+      { emoji: 'thumbsup', count: 1, hasReacted: true }
+    ]);
+    store.dispose();
+  });
+
+  it('reconciles an optimistic reaction from the RPC response', async () => {
+    const fake = new FakeQueryClient();
+    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, fakeTimelineAPI());
+    store.setRoom('room-1');
+    await settle();
+    store.events = [messageWithReaction('m1', 'heart') as never];
+
+    const optimistic = store.beginOptimisticReaction({
+      messageEventId: 'm1',
+      emoji: 'heart',
+      action: 'add'
+    });
+    optimistic.applyServerReaction({ emoji: 'heart', count: 5, hasReacted: true });
+    optimistic.rollback();
+
+    expect(reactionsOf(store.rootEvents[0])).toMatchObject([
+      { emoji: 'heart', count: 5, hasReacted: true }
+    ]);
+    store.dispose();
+  });
+
+  it('does not let a stale rollback overwrite an authoritative reaction refetch', async () => {
+    const updated = messageWithReactionState('m1', {
+      emoji: 'heart',
+      count: 7,
+      hasReacted: true
+    });
+    const fake = new FakeQueryClient();
+    const timeline = fakeTimelineAPI({
+      getRoomEvents: vi.fn(async () => ({
+        events: [messageWithReaction('m1', 'heart') as never],
+        startCursor: 'tl:cursor-1',
+        endCursor: 'tl:cursor-1',
+        hasOlder: false,
+        hasNewer: false
+      })),
+      getRoomEventsAround: vi.fn(async () => pageFromEvent(updated))
+    });
+    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, timeline);
+    store.setRoom('room-1');
+    await settle();
+
+    const optimistic = store.beginOptimisticReaction({
+      messageEventId: 'm1',
+      emoji: 'heart',
+      action: 'add'
+    });
+
+    store.ingestServerEvent({
+      id: 'reaction-authoritative',
+      createdAt: '2026-05-27T00:00:01Z',
+      actorId: 'u2',
+      actor: null,
+      event: {
+        kind: RoomEventKind.ReactionAdded,
+        roomId: 'room-1',
+        messageEventId: 'm1',
+        emoji: 'heart'
+      }
+    } as never);
+    await settle();
+    optimistic.rollback();
+
+    expect(reactionsOf(store.rootEvents[0])).toMatchObject([
+      { emoji: 'heart', count: 7, hasReacted: true }
+    ]);
+    store.dispose();
+  });
+
+  it('patches loaded original and echo messages before the original has an echo backlink', async () => {
+    const fake = new FakeQueryClient();
+    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, fakeTimelineAPI());
+    const original = threadMessageEvent('reply');
+    const echo = threadMessageEvent('echo');
+    store.setRoom('room-1');
+    await settle();
+    store.events = [
+      original as never,
+      {
+        ...echo,
+        event: {
+          ...echo.event,
+          echoOfEventId: 'reply',
+          echoFromThreadRootEventId: 'root'
+        }
+      } as never
+    ];
+
+    store.beginOptimisticReaction({
+      messageEventId: 'echo',
+      emoji: 'heart',
+      action: 'add'
+    });
+
+    expect(reactionsOf(store.rootEvents[0])).toMatchObject([
+      { emoji: 'heart', count: 1, hasReacted: true }
+    ]);
+    expect(reactionsOf(store.rootEvents[1])).toMatchObject([
+      { emoji: 'heart', count: 1, hasReacted: true }
+    ]);
+    store.dispose();
+  });
+
+  it('patches and rolls back optimistic reactions in the preview cache', async () => {
+    const fake = new FakeQueryClient();
+    const timeline = fakeTimelineAPI({
+      getRoomEventsAround: vi.fn(async () => pageFromEvent(messageWithReaction('preview', 'heart')))
+    });
+    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, timeline);
+    store.setRoom('room-1');
+    await settle();
+    await store.ensureEvent('preview');
+
+    const optimistic = store.beginOptimisticReaction({
+      messageEventId: 'preview',
+      emoji: 'heart',
+      action: 'add'
+    });
+
+    expect(reactionsOf(store.getEventById('preview')!)).toMatchObject([
+      { emoji: 'heart', count: 2, hasReacted: true }
+    ]);
+
+    optimistic.rollback();
+
+    expect(reactionsOf(store.getEventById('preview')!)).toMatchObject([
+      { emoji: 'heart', count: 1, hasReacted: false }
+    ]);
     store.dispose();
   });
 

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -21,16 +21,39 @@ type MessageRetractedPayload = Extract<
 type ReactionMutationPayload =
   | Extract<RoomEventPayload, { kind: typeof RoomEventKind.ReactionAdded }>
   | Extract<RoomEventPayload, { kind: typeof RoomEventKind.ReactionRemoved }>;
+type MessageReactionSummary = MessagePostedPayload['reactions'][number];
 type AssetProcessingPayload =
   | Extract<RoomEventPayload, { kind: typeof RoomEventKind.AssetProcessingStarted }>
   | Extract<RoomEventPayload, { kind: typeof RoomEventKind.AssetProcessingSucceeded }>
   | Extract<RoomEventPayload, { kind: typeof RoomEventKind.AssetProcessingFailed }>;
 type RoomDeletedPayload = Extract<RoomEventPayload, { kind: typeof RoomEventKind.RoomDeleted }>;
 
+export type OptimisticReactionAction = 'add' | 'remove';
+
+export type OptimisticReactionServerSummary = {
+  emoji: string;
+  count: number;
+  hasReacted: boolean;
+} | null;
+
+export type OptimisticReactionHandle = {
+  applyServerReaction(reaction: OptimisticReactionServerSummary): void;
+  rollback(): void;
+};
+
 export type RefreshCurrentWindowResult = {
   hasOlder: boolean;
   hasNewer: boolean;
   refreshed: boolean;
+};
+
+type OptimisticReactionSnapshot = {
+  key: string;
+  emoji: string;
+  previousReaction: MessageReactionSummary | null;
+  source: 'events' | 'preview';
+  eventId?: string;
+  previewKey?: string;
 };
 
 function eventCacheKey(roomId: string, eventId: string): string {
@@ -114,6 +137,8 @@ export class MessagesStore {
   private roomId = '';
   private oldestCursor: string | undefined;
   private newestCursor: string | undefined;
+  private optimisticReactionVersion = 0;
+  private optimisticReactionVersions = new SvelteMap<string, number>();
 
   /** Increments on every load kickoff. Async callbacks compare against
    *  it via {@link isStale} to discard results from superseded loads. */
@@ -186,6 +211,75 @@ export class MessagesStore {
     this.applyDeletion(messageEventId);
   }
 
+  /**
+   * Apply a provisional local reaction update. The returned handle can
+   * reconcile the touched emoji from the RPC response or roll back if the
+   * request fails. Projected server rows remain authoritative and clear the
+   * optimistic version before a stale rollback can restore old state.
+   */
+  beginOptimisticReaction(input: {
+    messageEventId: string;
+    emoji: string;
+    action: OptimisticReactionAction;
+  }): OptimisticReactionHandle {
+    const token = ++this.optimisticReactionVersion;
+    const targetIds = this.optimisticReactionTargetIds(input.messageEventId);
+    const snapshots: OptimisticReactionSnapshot[] = [];
+
+    const record = (snapshot: OptimisticReactionSnapshot) => {
+      snapshots.push(snapshot);
+      this.optimisticReactionVersions.set(snapshot.key, token);
+    };
+
+    for (let i = 0; i < this.events.length; i++) {
+      const event = this.events[i];
+      if (!this.isReactionTarget(event, targetIds)) continue;
+      const updated = this.eventWithOptimisticReaction(event, input.emoji, input.action);
+      if (!updated) continue;
+      const key = this.optimisticEventKey(event.id, input.emoji);
+      record({
+        key,
+        emoji: input.emoji,
+        previousReaction: this.reactionSummary(event, input.emoji),
+        source: 'events',
+        eventId: event.id
+      });
+      this.events[i] = updated;
+    }
+
+    for (const [previewKey, event] of this.previewEvents) {
+      if (!event || !this.isReactionTarget(event, targetIds)) continue;
+      const updated = this.eventWithOptimisticReaction(event, input.emoji, input.action);
+      if (!updated) continue;
+      const key = this.optimisticPreviewKey(previewKey, input.emoji);
+      record({
+        key,
+        emoji: input.emoji,
+        previousReaction: this.reactionSummary(event, input.emoji),
+        source: 'preview',
+        previewKey
+      });
+      this.previewEvents.set(previewKey, updated);
+    }
+
+    return {
+      applyServerReaction: (reaction) => {
+        for (const snapshot of snapshots) {
+          if (this.optimisticReactionVersions.get(snapshot.key) !== token) continue;
+          this.applyServerReactionSnapshot(snapshot, input.emoji, reaction);
+          this.optimisticReactionVersions.delete(snapshot.key);
+        }
+      },
+      rollback: () => {
+        for (const snapshot of snapshots) {
+          if (this.optimisticReactionVersions.get(snapshot.key) !== token) continue;
+          this.restoreOptimisticReactionSnapshot(snapshot);
+          this.optimisticReactionVersions.delete(snapshot.key);
+        }
+      }
+    };
+  }
+
   /** Update the viewer's thread follow state on a known thread root event. */
   setThreadRootFollowState(threadRootEventId: string, isFollowing: boolean): void {
     const idx = this.events.findIndex((e) => e.id === threadRootEventId);
@@ -217,6 +311,7 @@ export class MessagesStore {
 
     const promise = this.fetchEventById(eventId)
       .then((event) => {
+        if (event) this.clearOptimisticVersionForEvent(event.id);
         this.previewEvents.set(key, event);
       })
       .catch((error: unknown) => {
@@ -242,6 +337,244 @@ export class MessagesStore {
 
   private previewKey(eventId: string): string {
     return eventCacheKey(this.roomId, eventId);
+  }
+
+  private optimisticEventKey(eventId: string, emoji: string): string {
+    return `${this.optimisticEventKeyPrefix(eventId)}${emoji}`;
+  }
+
+  private optimisticEventKeyPrefix(eventId: string): string {
+    return `events:${eventId}\u0000`;
+  }
+
+  private optimisticPreviewKey(previewKey: string, emoji: string): string {
+    return `${this.optimisticPreviewKeyPrefix(previewKey)}${emoji}`;
+  }
+
+  private optimisticPreviewKeyPrefix(previewKey: string): string {
+    return `preview:${previewKey}\u0000`;
+  }
+
+  private clearOptimisticVersionForEvent(eventId: string): void {
+    const eventPrefix = this.optimisticEventKeyPrefix(eventId);
+    const previewPrefix = this.optimisticPreviewKeyPrefix(this.previewKey(eventId));
+    for (const key of this.optimisticReactionVersions.keys()) {
+      if (key.startsWith(eventPrefix) || key.startsWith(previewPrefix)) {
+        this.optimisticReactionVersions.delete(key);
+      }
+    }
+  }
+
+  private optimisticReactionTargetIds(messageEventId: string): SvelteSet<string> {
+    const targetIds = new SvelteSet([messageEventId]);
+    let changed = true;
+
+    while (changed) {
+      changed = false;
+      for (const event of this.events) {
+        changed = this.addLinkedReactionTargetIds(event, targetIds) || changed;
+      }
+      for (const event of this.previewEvents.values()) {
+        if (event) changed = this.addLinkedReactionTargetIds(event, targetIds) || changed;
+      }
+    }
+
+    return targetIds;
+  }
+
+  private addLinkedReactionTargetIds(event: RoomEventView, targetIds: SvelteSet<string>): boolean {
+    const payload = event.event;
+    if (!isMessagePostedPayload(payload)) return false;
+
+    const before = targetIds.size;
+    if (targetIds.has(event.id)) {
+      if (payload.echoOfEventId) targetIds.add(payload.echoOfEventId);
+      if (payload.channelEchoEventId) targetIds.add(payload.channelEchoEventId);
+    }
+    if (payload.echoOfEventId && targetIds.has(payload.echoOfEventId)) targetIds.add(event.id);
+    if (payload.channelEchoEventId && targetIds.has(payload.channelEchoEventId)) {
+      targetIds.add(event.id);
+    }
+    return targetIds.size !== before;
+  }
+
+  private isReactionTarget(event: RoomEventView, targetIds: SvelteSet<string>): boolean {
+    if (targetIds.has(event.id)) return true;
+    const payload = event.event;
+    return (
+      isMessagePostedPayload(payload) &&
+      Boolean(
+        (payload.echoOfEventId && targetIds.has(payload.echoOfEventId)) ||
+          (payload.channelEchoEventId && targetIds.has(payload.channelEchoEventId))
+      )
+    );
+  }
+
+  private eventWithOptimisticReaction(
+    event: RoomEventView,
+    emoji: string,
+    action: OptimisticReactionAction
+  ): RoomEventView | null {
+    const payload = event.event;
+    if (!isMessagePostedPayload(payload)) return null;
+    return {
+      ...event,
+      event: {
+        ...payload,
+        reactions: this.optimisticReactions(payload.reactions, emoji, action)
+      }
+    };
+  }
+
+  private reactionSummary(event: RoomEventView, emoji: string): MessageReactionSummary | null {
+    const payload = event.event;
+    if (!isMessagePostedPayload(payload)) return null;
+    return payload.reactions.find((reaction) => reaction.emoji === emoji) ?? null;
+  }
+
+  private eventWithReactionSummary(
+    event: RoomEventView,
+    emoji: string,
+    reaction: MessageReactionSummary | null
+  ): RoomEventView | null {
+    const payload = event.event;
+    if (!isMessagePostedPayload(payload)) return null;
+    return {
+      ...event,
+      event: {
+        ...payload,
+        reactions: this.reactionsWithSummary(payload.reactions, emoji, reaction)
+      }
+    };
+  }
+
+  private optimisticReactions(
+    reactions: readonly MessageReactionSummary[],
+    emoji: string,
+    action: OptimisticReactionAction
+  ): MessageReactionSummary[] {
+    const existingIndex = reactions.findIndex((reaction) => reaction.emoji === emoji);
+    if (action === 'add') {
+      if (existingIndex === -1) {
+        return [...reactions, { emoji, count: 1, hasReacted: true, users: [] }];
+      }
+
+      return reactions.map((reaction, index) =>
+        index === existingIndex
+          ? {
+              ...reaction,
+              count: reaction.hasReacted ? reaction.count : reaction.count + 1,
+              hasReacted: true
+            }
+          : reaction
+      );
+    }
+
+    if (existingIndex === -1) return [...reactions];
+
+    return reactions.flatMap((reaction, index) => {
+      if (index !== existingIndex) return [reaction];
+      const count = reaction.hasReacted ? Math.max(0, reaction.count - 1) : reaction.count;
+      if (count === 0) return [];
+      return [{ ...reaction, count, hasReacted: false }];
+    });
+  }
+
+  private reactionsWithSummary(
+    reactions: readonly MessageReactionSummary[],
+    emoji: string,
+    reaction: MessageReactionSummary | null
+  ): MessageReactionSummary[] {
+    if (!reaction || reaction.count <= 0) {
+      return reactions.filter((existing) => existing.emoji !== emoji);
+    }
+
+    const existingIndex = reactions.findIndex((existing) => existing.emoji === emoji);
+    const nextReaction = {
+      ...reaction,
+      users: [...reaction.users]
+    };
+    if (existingIndex === -1) return [...reactions, nextReaction];
+    return reactions.map((existing, index) => (index === existingIndex ? nextReaction : existing));
+  }
+
+  private serverReactions(
+    reactions: readonly MessageReactionSummary[],
+    emoji: string,
+    reaction: OptimisticReactionServerSummary
+  ): MessageReactionSummary[] {
+    if (!reaction || reaction.count <= 0) {
+      return reactions.filter((existing) => existing.emoji !== emoji);
+    }
+
+    const existingIndex = reactions.findIndex((existing) => existing.emoji === emoji);
+    const nextReaction = (existing?: MessageReactionSummary): MessageReactionSummary => ({
+      emoji: reaction.emoji,
+      count: reaction.count,
+      hasReacted: reaction.hasReacted,
+      users: existing?.users ?? []
+    });
+
+    if (existingIndex === -1) return [...reactions, nextReaction()];
+    return reactions.map((existing, index) =>
+      index === existingIndex ? nextReaction(existing) : existing
+    );
+  }
+
+  private applyServerReactionSnapshot(
+    snapshot: OptimisticReactionSnapshot,
+    emoji: string,
+    reaction: OptimisticReactionServerSummary
+  ): void {
+    const apply = (event: RoomEventView): RoomEventView | null => {
+      const payload = event.event;
+      if (!isMessagePostedPayload(payload)) return null;
+      return {
+        ...event,
+        event: {
+          ...payload,
+          reactions: this.serverReactions(payload.reactions, emoji, reaction)
+        }
+      };
+    };
+
+    if (snapshot.source === 'events') {
+      const index = this.events.findIndex((event) => event.id === snapshot.eventId);
+      if (index === -1) return;
+      const updated = apply(this.events[index]);
+      if (updated) this.events[index] = updated;
+      return;
+    }
+
+    if (!snapshot.previewKey) return;
+    const event = this.previewEvents.get(snapshot.previewKey);
+    if (!event) return;
+    const updated = apply(event);
+    if (updated) this.previewEvents.set(snapshot.previewKey, updated);
+  }
+
+  private restoreOptimisticReactionSnapshot(snapshot: OptimisticReactionSnapshot): void {
+    if (snapshot.source === 'events') {
+      const index = this.events.findIndex((event) => event.id === snapshot.eventId);
+      if (index === -1) return;
+      const updated = this.eventWithReactionSummary(
+        this.events[index],
+        snapshot.emoji,
+        snapshot.previousReaction
+      );
+      if (updated) this.events[index] = updated;
+      return;
+    }
+
+    if (!snapshot.previewKey) return;
+    const event = this.previewEvents.get(snapshot.previewKey);
+    if (!event) return;
+    const updated = this.eventWithReactionSummary(
+      event,
+      snapshot.emoji,
+      snapshot.previousReaction
+    );
+    if (updated) this.previewEvents.set(snapshot.previewKey, updated);
   }
 
   setRoom(roomId: string): void {
@@ -485,6 +818,7 @@ export class MessagesStore {
       const { events: rawEvents, hasOlder, hasNewer, startCursor, endCursor } = around;
       const parsed = unmask(rawEvents);
 
+      for (const event of parsed) this.clearOptimisticVersionForEvent(event.id);
       this.events = [...parsed];
       this.seenIds = new SvelteSet(parsed.map((e) => e.id));
       this.oldestCursor = startCursor ?? undefined;
@@ -666,6 +1000,7 @@ export class MessagesStore {
       this.scope === 'thread' && eventId !== this.threadRootEventId ? this.threadRootEventId : null
     );
     if (!updated) return;
+    this.clearOptimisticVersionForEvent(updated.id);
     const idx = this.events.findIndex((e) => e.id === eventId);
     if (idx !== -1) this.events[idx] = updated;
   }
@@ -818,6 +1153,7 @@ export class MessagesStore {
   private appendMany(events: RoomEventView[]): void {
     let added = false;
     for (const e of events) {
+      this.clearOptimisticVersionForEvent(e.id);
       added = this.addEvent(e, { sortRoom: false }) || added;
     }
     if (added && this.scope === 'room') this.sortRoomEvents();
@@ -825,6 +1161,7 @@ export class MessagesStore {
 
   private prependEvents(olderEvents: RoomEventView[]): number {
     const newOnes = olderEvents.filter((e) => !this.seenIds.has(e.id));
+    for (const e of newOnes) this.clearOptimisticVersionForEvent(e.id);
     for (const e of newOnes) this.seenIds.add(e.id);
     this.events.unshift(...newOnes);
     return newOnes.length;
@@ -845,6 +1182,7 @@ export class MessagesStore {
     const merged: RoomEventView[] = [];
     for (const e of fetched) {
       if (newSeen.has(e.id)) continue;
+      this.clearOptimisticVersionForEvent(e.id);
       newSeen.add(e.id);
       merged.push(e);
     }
@@ -863,6 +1201,7 @@ export class MessagesStore {
     this.seenIds = new SvelteSet();
     this.previewEvents.clear();
     this.pendingPreviewFetches.clear();
+    this.optimisticReactionVersions.clear();
     this.oldestCursor = undefined;
     this.newestCursor = undefined;
     this.hasReachedStart = false;
@@ -899,6 +1238,7 @@ export class MessagesStore {
 
     for (const e of fetched) {
       if (newSeen.has(e.id)) continue;
+      this.clearOptimisticVersionForEvent(e.id);
       newSeen.add(e.id);
       merged.push(e);
     }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionSheet.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionSheet.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { useMessageActions, type MessageActionParams } from '$lib/hooks';
+  import type { MessagesStore } from '$lib/state/room';
   import { getRecentEmojis } from '$lib/state/recentEmojis.svelte';
   import { getEmojiByName } from '$lib/emoji';
   import * as m from '$lib/i18n/messages';
@@ -14,6 +15,7 @@
     threadRootEventId = null,
     channelEchoEventId = null,
     canAddChannelEcho = false,
+    messageStore = null,
     reactions = [],
     canReact = false,
     canEdit = false,
@@ -34,6 +36,7 @@
     threadRootEventId?: string | null;
     channelEchoEventId?: string | null;
     canAddChannelEcho?: boolean;
+    messageStore?: MessagesStore | null;
     reactions?: { emoji: string; hasReacted: boolean }[];
     canReact?: boolean;
     canEdit?: boolean;
@@ -64,7 +67,8 @@
     messageBody,
     threadRootEventId,
     channelEchoEventId,
-    canAddChannelEcho
+    canAddChannelEcho,
+    messageStore
   });
 
   /** Set of Unicode emojis the current user has already reacted with (API returns shortcodes) */

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -172,7 +172,8 @@
       roomId,
       messageEventId: event.id,
       eventId: isEcho ? messageEvent!.echoOfEventId! : event.id,
-      messageBody: msg.body ?? ''
+      messageBody: msg.body ?? '',
+      messageStore
     };
     const name = emojiToName(emoji);
     const alreadyReacted = msg.reactions.some((r) => r.emoji === name && r.hasReacted);
@@ -868,6 +869,7 @@
             threadParticipants={messageEvent?.threadParticipants}
             {hasThreadNotification}
             canReact={roomPermissions.canReact}
+            {messageStore}
             {isFollowingThread}
             onToggleThreadFollow={hasReplies ? toggleThreadFollow : undefined}
             onOpenThread={onOpenThread ? handleOpenThread : undefined}
@@ -888,6 +890,7 @@
           threadRootEventId={editThreadRootEventId}
           channelEchoEventId={editChannelEchoEventId}
           canAddChannelEcho={canReconcileChannelEcho}
+          {messageStore}
           reactions={msg?.reactions ?? []}
           canReact={roomPermissions.canReact}
           {canEdit}
@@ -946,6 +949,7 @@
         threadRootEventId={editThreadRootEventId}
         channelEchoEventId={editChannelEchoEventId}
         canAddChannelEcho={canReconcileChannelEcho}
+        {messageStore}
         reactions={msg?.reactions ?? []}
         canReact={roomPermissions.canReact}
         {canEdit}
@@ -988,6 +992,7 @@
         threadRootEventId={editThreadRootEventId}
         channelEchoEventId={editChannelEchoEventId}
         canAddChannelEcho={canReconcileChannelEcho}
+        {messageStore}
         reactions={msg?.reactions ?? []}
         canReact={roomPermissions.canReact}
         {canEdit}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.svelte
@@ -26,6 +26,7 @@ Hover-capable input only; pure touch devices use the long-press action sheet ins
 <script lang="ts">
   import { useMessageActions, type MessageActionParams } from '$lib/hooks';
   import * as m from '$lib/i18n/messages';
+  import type { MessagesStore } from '$lib/state/room';
   import { getRecentEmojis } from '$lib/state/recentEmojis.svelte';
   import { getEmojiByName } from '$lib/emoji';
 
@@ -39,6 +40,7 @@ Hover-capable input only; pure touch devices use the long-press action sheet ins
     threadRootEventId = null,
     channelEchoEventId = null,
     canAddChannelEcho = false,
+    messageStore = null,
     reactions = [],
     canReact = false,
     canEdit = false,
@@ -59,6 +61,7 @@ Hover-capable input only; pure touch devices use the long-press action sheet ins
     threadRootEventId?: string | null;
     channelEchoEventId?: string | null;
     canAddChannelEcho?: boolean;
+    messageStore?: MessagesStore | null;
     reactions?: { emoji: string; hasReacted: boolean }[];
     canReact?: boolean;
     canEdit?: boolean;
@@ -89,7 +92,8 @@ Hover-capable input only; pure touch devices use the long-press action sheet ins
     messageBody,
     threadRootEventId,
     channelEchoEventId,
-    canAddChannelEcho
+    canAddChannelEcho,
+    messageStore
   });
 
   const hasActions = $derived(!!onReplyInRoom || !!onReply || canEdit || !!onOpenMenu);

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte
@@ -26,12 +26,11 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
   import type { RoomEventView } from '$lib/render/types';
   import UserAvatar, { UserAvatarViewData } from '$lib/components/UserAvatar.svelte';
   import UnreadDot from '$lib/ui/UnreadDot.svelte';
+  import { useReactionActions, type MessageActionParams } from '$lib/hooks';
   import { useRenderData } from '$lib/render/data';
-  import { useConnection } from '$lib/state/server/connection.svelte';
-  import { toast } from '$lib/ui/toast';
+  import type { MessagesStore } from '$lib/state/room';
   import FloatingPopover from '$lib/ui/FloatingPopover.svelte';
   import { getEmojiByName, getEmojiDisplayName } from '$lib/emoji';
-  import { createReactionAPI } from '$lib/api-client/reactions';
   import * as m from '$lib/i18n/messages';
 
   // Extract the MessagePostedEvent type from the union
@@ -53,6 +52,7 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
     threadParticipants,
     hasThreadNotification = false,
     canReact = false,
+    messageStore = null,
     isFollowingThread = false,
     onToggleThreadFollow,
     onOpenThread,
@@ -68,6 +68,7 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
     threadParticipants?: MessagePostedEvent['threadParticipants'];
     hasThreadNotification?: boolean;
     canReact?: boolean;
+    messageStore?: MessagesStore | null;
     isFollowingThread?: boolean;
     onToggleThreadFollow?: (e: MouseEvent) => void;
     onOpenThread?: () => void;
@@ -75,7 +76,7 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
     isEchoEvent?: boolean;
   } = $props();
 
-  const connection = useConnection();
+  const reactionActions = useReactionActions();
   const replyCountLabel = $derived(
     replyCount === 1
       ? m['room.message.meta.reply_count_one']()
@@ -88,6 +89,15 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
     tooltipReactionEmoji ? (reactions.find((r) => r.emoji === tooltipReactionEmoji) ?? null) : null
   );
   const REACTION_TOOLTIP_USER_LIMIT = 5;
+  const reactionParams: MessageActionParams = $derived({
+    serverId: serverSegment,
+    roomId,
+    messageEventId,
+    eventId: messageEventId,
+    messageBody: '',
+    threadRootEventId,
+    messageStore
+  });
 
   function reactionTooltipUsers(reaction: ReactionSummary): {
     names: string[];
@@ -117,22 +127,7 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
   }
 
   async function toggleReaction(reaction: ReactionSummary) {
-    try {
-      const conn = connection();
-      const api = createReactionAPI({
-        serverId: conn.serverId ?? serverSegment,
-        baseUrl: conn.connectBaseUrl,
-        bearerToken: conn.bearerToken
-      });
-      const input = { roomId, messageEventId, emoji: reaction.emoji };
-      if (reaction.hasReacted) {
-        await api.removeReaction(input);
-      } else {
-        await api.addReaction(input);
-      }
-    } catch {
-      toast.error('Failed to update reaction');
-    }
+    await reactionActions.toggleReaction(reactionParams, reaction.emoji, reaction.hasReacted);
   }
 
   function openThreadFromLink(e: MouseEvent) {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts
@@ -1,8 +1,18 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync } from 'svelte';
 import { render } from 'vitest-browser-svelte';
 import { q } from '$lib/test-utils';
 import MessageMetaBar from './MessageMetaBar.svelte';
+
+const mocks = vi.hoisted(() => ({
+  reactionActions: {
+    toggleReaction: vi.fn()
+  }
+}));
+
+vi.mock('$lib/hooks', () => ({
+  useReactionActions: () => mocks.reactionActions
+}));
 
 vi.mock('$app/paths', () => ({
   assets: '',
@@ -56,6 +66,10 @@ function reaction(
 }
 
 describe('MessageMetaBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('renders the reply count badge as a native thread link', async () => {
     const { container } = render(MessageMetaBar, {
       props: {
@@ -275,5 +289,31 @@ describe('MessageMetaBar', () => {
     const tooltip = q(container, '[role="tooltip"]')!;
     expect(q(tooltip, 'strong')?.textContent?.trim()).toBe('Heart');
     expect(q(tooltip, '[data-testid="reaction-tooltip-user"]')?.textContent?.trim()).toBe('Alice');
+  });
+
+  it('routes reaction pill clicks through shared reaction actions', async () => {
+    const messageStore = { beginOptimisticReaction: vi.fn() };
+    const { container } = render(MessageMetaBar, {
+      props: {
+        ...baseProps,
+        reactions: [reaction({ hasReacted: true })],
+        canReact: true,
+        messageStore: messageStore as never
+      }
+    });
+
+    (q(container, 'button[aria-label="Remove 👍 reaction (2)"]') as HTMLButtonElement).click();
+
+    await vi.waitFor(() => {
+      expect(mocks.reactionActions.toggleReaction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          roomId: 'room-1',
+          messageEventId: 'thread-1',
+          messageStore
+        }),
+        'thumbsup',
+        true
+      );
+    });
   });
 });

--- a/docs/fdr/FDR-005-reactions.md
+++ b/docs/fdr/FDR-005-reactions.md
@@ -53,6 +53,12 @@ Users can react to a message with emoji. Reactions are aggregated into pills sho
 **Why:** Reactions mutate existing message rows. Refetching projected message rows updates reactions, edits, retractions, attachment processing state, and newly posted messages through one path, while avoiding fragile reconnect replay state in the browser.
 **Tradeoff:** Message-row catch-up is scoped to the room/thread the user is actually viewing. Other rooms catch up through normal queries when opened, while server-scoped projected state such as notifications, unread/sidebar state, room layout, server profile/settings, and active-call indicators is refetched after event-bus gaps. The `myEvents` subscription is intentionally live-only and no longer exposes a replay cursor.
 
+### 7. Web client reaction clicks are optimistic
+
+**Decision:** The web client applies add/remove reaction clicks to the visible message store immediately, then reconciles the touched emoji from the ConnectRPC response. The server remains authoritative: live reaction events and reconnect refreshes refetch the projected message row and replace the local optimistic state.
+**Why:** Reaction clicks should feel instant without changing the durable event model or public API.
+**Tradeoff:** Reactor-name tooltips are best-effort during the optimistic window and become exact after the projected row refresh.
+
 ## Permissions
 
 - `message.react` — add or remove a reaction on a message. Scoped at server, group, and room.


### PR DESCRIPTION
## Summary
Adds frontend-only optimistic reaction updates so add/remove clicks patch visible message reactions immediately while projected server rows remain authoritative.
Routes reaction pills, quick reactions, context menus, action sheets, and emoji picker selections through shared reaction actions with localized failure feedback.
Extends MessagesStore coverage for optimistic add/remove, rollback, RPC reconciliation, authoritative refetch replacement, preview cache updates, and original/echo patching, and documents the behavior in FDR-005.

## Validation
Ran `mise lint-frontend`, focused reaction/component Vitest coverage, full `mise test-frontend`, and browser smoke checks for room and thread reactions with delayed AddReaction RPCs.
