### PR TITLE
fix: backfill sparse room timelines

### DIFF
--- a/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -341,6 +341,46 @@ describe('MessagesStore — room lifecycle ownership', () => {
     store.dispose();
   });
 
+  it('backfills the initial room window when the latest page has too few messages', async () => {
+    const join = roomSystemEvent('join-1', RoomEventKind.UserJoinedRoom);
+    const firstMessage = threadMessageEvent('m2');
+    const olderMessage = threadMessageEvent('m1');
+    const fake = new FakeQueryClient();
+    const timeline = fakeTimelineAPI({
+      getRoomEvents: vi
+        .fn()
+        .mockResolvedValueOnce({
+          events: [firstMessage as never, join as never],
+          startCursor: 'tl:cursor-join',
+          endCursor: 'tl:cursor-join',
+          hasOlder: true,
+          hasNewer: false
+        })
+        .mockResolvedValueOnce({
+          events: [olderMessage as never],
+          startCursor: 'tl:cursor-message',
+          endCursor: 'tl:cursor-message',
+          hasOlder: false,
+          hasNewer: true
+        })
+    });
+    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, timeline);
+
+    store.setRoom('room-1');
+
+    await vi.waitFor(() => {
+      expect(store.isInitialLoading).toBe(false);
+      expect(store.rootEvents.map((event) => event.id)).toEqual(['m1', 'join-1', 'm2']);
+    });
+    expect(timeline.getRoomEvents).toHaveBeenNthCalledWith(1, { roomId: 'room-1', limit: 50 });
+    expect(timeline.getRoomEvents).toHaveBeenNthCalledWith(2, {
+      roomId: 'room-1',
+      limit: 50,
+      before: 'tl:cursor-join'
+    });
+    store.dispose();
+  });
+
   it('does not refetch or clear events when setRoom is called for the current room', async () => {
     const loaded = threadMessageEvent('m1');
     const fake = new FakeQueryClient(
@@ -1530,6 +1570,68 @@ describe('MessagesStore — room lifecycle ownership', () => {
       'm7',
       'm8'
     ]);
+    store.dispose();
+  });
+
+  it('keeps backward pagination alive when an older page adds no new rows but has more history', async () => {
+    const currentWindow = Array.from({ length: 10 }, (_, index) =>
+      threadMessageEvent(`m${index + 10}`)
+    );
+    const fake = new FakeQueryClient();
+    const timeline = fakeTimelineAPI({
+      getRoomEvents: vi
+        .fn()
+        .mockResolvedValueOnce({
+          events: currentWindow as never[],
+          startCursor: 'tl:cursor-3',
+          endCursor: 'tl:cursor-3',
+          hasOlder: true,
+          hasNewer: false
+        })
+        .mockResolvedValueOnce({
+          events: [threadMessageEvent('m10') as never],
+          startCursor: 'tl:cursor-2',
+          endCursor: 'tl:cursor-2',
+          hasOlder: true,
+          hasNewer: false
+        })
+        .mockResolvedValueOnce({
+          events: [threadMessageEvent('m1') as never],
+          startCursor: 'tl:cursor-1',
+          endCursor: 'tl:cursor-1',
+          hasOlder: false,
+          hasNewer: true
+        })
+    });
+    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, timeline);
+
+    store.setRoom('room-1');
+    await settle();
+
+    await store.loadMore();
+    await settle();
+
+    expect(store.rootEvents.map((event) => event.id)).toEqual(currentWindow.map((event) => event.id));
+    expect(store.hasReachedStart).toBe(false);
+
+    await store.loadMore();
+    await settle();
+
+    expect(store.rootEvents.map((event) => event.id)).toEqual([
+      'm1',
+      ...currentWindow.map((event) => event.id)
+    ]);
+    expect(store.hasReachedStart).toBe(true);
+    expect(timeline.getRoomEvents).toHaveBeenNthCalledWith(2, {
+      roomId: 'room-1',
+      limit: 50,
+      before: 'tl:cursor-3'
+    });
+    expect(timeline.getRoomEvents).toHaveBeenNthCalledWith(3, {
+      roomId: 'room-1',
+      limit: 50,
+      before: 'tl:cursor-2'
+    });
     store.dispose();
   });
 

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -6,7 +6,7 @@ import { RoomEventKind, roomEventKind } from '$lib/render/eventKinds';
 import { createRoomTimelineAPI, type RoomTimelineAPI } from '$lib/api-client/roomTimeline';
 import type { ServerConnection } from '$lib/state/server/serverConnection.svelte';
 import type { JumpToMessageState } from '../composerContext.svelte';
-import { PAGE_SIZE } from './queries';
+import { INITIAL_ROOM_MESSAGE_BACKFILL_TARGET, PAGE_SIZE } from './queries';
 import { isRootRoomEvent, isThreadEvent } from './filters';
 import { type EventConnectionPage, type RawEvent, getActorId, unmask } from './helpers';
 
@@ -763,14 +763,21 @@ export class MessagesStore {
 
       const olderEvents = unmask(page.events);
       if (olderEvents.length === 0) {
-        this.hasReachedStart = true;
+        if (page.startCursor) {
+          this.oldestCursor = page.startCursor;
+        }
+        if (!page.hasOlder || !page.startCursor || page.startCursor === before) {
+          this.hasReachedStart = true;
+        }
       } else {
         if (page.startCursor) {
           this.oldestCursor = page.startCursor;
         }
         const added = this.prependEvents(olderEvents);
         this.afterOlderPagePrepended();
-        if (added === 0) this.hasReachedStart = true;
+        if (added === 0 && (!page.hasOlder || !page.startCursor || page.startCursor === before)) {
+          this.hasReachedStart = true;
+        }
       }
 
       if (!page.hasOlder) this.hasReachedStart = true;
@@ -811,6 +818,22 @@ export class MessagesStore {
   private afterOlderPagePrepended(): void {
     if (this.scope === 'thread') {
       this.sortThreadEvents();
+    }
+  }
+
+  private roomWindowMessageCount(): number {
+    return this.rootEvents.filter((event) => isMessagePostedPayload(event.event)).length;
+  }
+
+  private async backfillInitialRoomWindow(thisLoad: number): Promise<void> {
+    while (
+      !this.isStale(thisLoad) &&
+      this.scope === 'room' &&
+      !this.hasReachedStart &&
+      this.oldestCursor &&
+      this.roomWindowMessageCount() < INITIAL_ROOM_MESSAGE_BACKFILL_TARGET
+    ) {
+      await this.loadMore();
     }
   }
 
@@ -1433,12 +1456,14 @@ export class MessagesStore {
     });
 
     promise
-      .then((page) => {
+      .then(async (page) => {
         if (this.isStale(thisLoad)) return;
         if (page) {
           this.replaceWithFetchedAndUpdateCursors(page);
           this.hasReachedStart = !page.hasOlder;
+          await this.backfillInitialRoomWindow(thisLoad);
         }
+        if (this.isStale(thisLoad)) return;
         this.isInitialLoading = false;
       })
       .catch((error: unknown) => {

--- a/apps/frontend/src/lib/state/room/messages/queries.ts
+++ b/apps/frontend/src/lib/state/room/messages/queries.ts
@@ -1,1 +1,2 @@
 export const PAGE_SIZE = 50;
+export const INITIAL_ROOM_MESSAGE_BACKFILL_TARGET = 10;

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -20,6 +20,7 @@
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { getUserSettings } from '$lib/state/userSettings.svelte';
+  import { INITIAL_ROOM_MESSAGE_BACKFILL_TARGET } from '$lib/state/room/messages/queries';
   import { formatDayLabel } from '$lib/utils/formatTime';
   import { useTabResumeCallback } from '$lib/hooks/useTabResumeCallback.svelte';
   import { useMayHaveMissedMessagesCallback } from '$lib/hooks/useMayHaveMissedMessagesCallback.svelte';
@@ -158,6 +159,9 @@
       // Deleted messages (body === null) are always shown with placeholder
       return true;
     })
+  );
+  let messageEventCount = $derived(
+    filteredEvents.filter((event) => isMessagePostedEvent(event.event)).length
   );
 
   // Apply message grouping and day separators
@@ -618,6 +622,7 @@
   });
 
   let forwardLoadInFlight = false;
+  let underfilledBackfillInFlight = false;
 
   function exitJumpedModeAtPresent(bottomDistance: number): boolean {
     if (!isJumpedMode || !hasReachedEnd || bottomDistance >= 50 || !onReachedPresent) return false;
@@ -650,6 +655,64 @@
       forwardLoadInFlight = false;
     }
   }
+
+  async function loadOlderIfTimelineNeedsBackfill(): Promise<void> {
+    if (
+      !enablePagination ||
+      !onLoadMore ||
+      isLoading ||
+      isLoadingMore ||
+      hasReachedStart ||
+      isJumpedMode ||
+      underfilledBackfillInFlight ||
+      !virtualizerHandle ||
+      virtualItems.length === 0
+    ) {
+      return;
+    }
+
+    underfilledBackfillInFlight = true;
+    try {
+      await tick();
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      if (
+        !virtualizerHandle ||
+        isLoading ||
+        isLoadingMore ||
+        hasReachedStart ||
+        isJumpedMode ||
+        virtualItems.length === 0
+      ) {
+        return;
+      }
+
+      const scrollSize = virtualizerHandle.getScrollSize();
+      const viewportSize = virtualizerHandle.getViewportSize();
+      const lacksInitialRoomMessages =
+        filterThreadReplies &&
+        filteredEvents.length > 0 &&
+        messageEventCount < INITIAL_ROOM_MESSAGE_BACKFILL_TARGET;
+      if (scrollSize <= viewportSize + 50 || lacksInitialRoomMessages) {
+        await onLoadMore();
+      }
+    } finally {
+      underfilledBackfillInFlight = false;
+    }
+  }
+
+  $effect(() => {
+    void virtualItems.length;
+    void filteredEvents.length;
+    void messageEventCount;
+    void enablePagination;
+    void isLoading;
+    void isLoadingMore;
+    void hasReachedStart;
+    void isJumpedMode;
+    void virtualizerHandle;
+
+    void loadOlderIfTimelineNeedsBackfill();
+  });
 
   // Handle scroll events from virtua to detect user intent and trigger pagination.
   // virtua's shift=true handles scroll restoration during pagination automatically,

--- a/cli/internal/core/event_facts_test.go
+++ b/cli/internal/core/event_facts_test.go
@@ -46,6 +46,22 @@ func TestEventFactsRoomIDAndVisibility(t *testing.T) {
 			visible: false,
 		},
 		{
+			name: "room member joined",
+			event: &corev1.Event{Event: &corev1.Event_UserJoinedRoom{
+				UserJoinedRoom: &corev1.UserJoinedRoomEvent{RoomId: "R1"},
+			}},
+			roomID:  "R1",
+			visible: true,
+		},
+		{
+			name: "room member left",
+			event: &corev1.Event{Event: &corev1.Event_UserLeftRoom{
+				UserLeftRoom: &corev1.UserLeftRoomEvent{RoomId: "R1"},
+			}},
+			roomID:  "R1",
+			visible: true,
+		},
+		{
 			name: "voice call started",
 			event: &corev1.Event{Event: &corev1.Event_VoiceCallStarted{
 				VoiceCallStarted: &corev1.CallStartedEvent{RoomId: "R1"},

--- a/cli/internal/core/room_events_test.go
+++ b/cli/internal/core/room_events_test.go
@@ -26,7 +26,7 @@ func TestChattoCore_GetRoomEvents(t *testing.T) {
 	core.PostMessage(ctx, KindChannel, room.Id, user2.Id, "Message 2", nil, "", "", nil, false)
 	core.PostMessage(ctx, KindChannel, room.Id, user1.Id, "Message 3", nil, "", "", nil, false)
 
-	// Get room events (returns all RoomEvents: messages + room membership + room lifecycle)
+	// Get room events (returns visible room events: messages + room membership + room lifecycle)
 	eventsResult, err := core.GetRoomEvents(ctx, KindChannel, room.Id, 50, nil)
 	if err != nil {
 		t.Fatalf("Failed to get room events: %v", err)
@@ -37,7 +37,6 @@ func TestChattoCore_GetRoomEvents(t *testing.T) {
 	// - 1 RoomCreated event
 	// - 2 UserJoinedRoom events (user1 and user2)
 	// - 3 MessagePosted events
-	// Note: With unified space stream, room lifecycle events are now included
 	if len(events) != 6 {
 		t.Errorf("Expected 6 room events (1 created + 2 joins + 3 messages), got %d", len(events))
 	}
@@ -88,14 +87,13 @@ func TestChattoCore_GetRoomEvents_JoinAndLeaveEvents(t *testing.T) {
 		t.Fatalf("Failed to leave room: %v", err)
 	}
 
-	// Get room events - should include join and leave events
+	// Get room events - should include join and leave events.
 	eventsResult, err := core.GetRoomEvents(ctx, KindChannel, room.Id, 50, nil)
 	if err != nil {
 		t.Fatalf("Failed to get room events: %v", err)
 	}
 	events := eventsResult.Events
 
-	// Count event types
 	joinCount := 0
 	leaveCount := 0
 	roomCreatedCount := 0
@@ -111,7 +109,6 @@ func TestChattoCore_GetRoomEvents_JoinAndLeaveEvents(t *testing.T) {
 		}
 	}
 
-	// Verify events: 1 RoomCreated + 1 UserJoinedRoom + 1 UserLeftRoom = 3 total
 	if len(events) != 3 {
 		t.Errorf("Expected 3 events (1 created + 1 join + 1 leave), got %d", len(events))
 		for _, e := range events {
@@ -127,6 +124,9 @@ func TestChattoCore_GetRoomEvents_JoinAndLeaveEvents(t *testing.T) {
 	}
 	if leaveCount != 1 {
 		t.Errorf("Expected 1 UserLeftRoom event, got %d", leaveCount)
+	}
+	if exists, err := core.RoomMembershipExists(ctx, KindChannel, user.Id, room.Id); err != nil || exists {
+		t.Fatalf("RoomMembershipExists after leave = %v, %v; want false, nil", exists, err)
 	}
 }
 
@@ -209,14 +209,13 @@ func TestChattoCore_GetRoomEvents_JoinAfterLastMessage(t *testing.T) {
 	}
 
 	// Get room events - should include user2's join event even though it
-	// happened after the last message
+	// happened after the last message.
 	eventsResult, err := core.GetRoomEvents(ctx, KindChannel, room.Id, 50, nil)
 	if err != nil {
 		t.Fatalf("Failed to get room events: %v", err)
 	}
 	events := eventsResult.Events
 
-	// Find user2's join event
 	foundUser2Join := false
 	for _, event := range events {
 		joinEvent := event.GetUserJoinedRoom()


### PR DESCRIPTION
## Summary

- Backfill the initial room timeline until it has a useful floor of root message events, instead of stopping after a latest page with mostly join/leave events.
- Keep backward pagination alive when an older page advances the cursor but adds no new rendered rows.
- Add an EventList fallback that loads older pages when the virtualized timeline is underfilled or has too few initial room messages.
- Preserve visible join/leave room events and add backend tests that lock in that behavior.

## Root Cause

Some rooms had latest timeline pages dominated by presence/join/leave events. The frontend treated a sparse page with one message as good enough, so initial pagination could stop before the actual conversation history was loaded. Resume/catch-up refreshes could later mask the problem by preserving and extending the window.

## Validation

- `pnpm vitest --run src/lib/state/room/messages.svelte.spec.ts`
- `pnpm run check`
- `pnpm run lint`
- `GOCACHE=/private/tmp/chatto-go-cache mise x -- go test ./internal/core -run 'Test(EventFactsRoomIDAndVisibility|EventFactsAssetLifecycle|ChattoCore_GetRoomEvents)' -count=1 -timeout 60s`
- `git diff --check`
