### PR TITLE
fix(api): tune room member page defaults

### DIFF
--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/rooms.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/rooms.mdx
@@ -315,7 +315,7 @@ Request for members of one room.
 | --- | --- | --- |
 | `room_id` | `string` | Required. Room whose explicit members should be listed. |
 | `search` | `string` | Optional case-insensitive search against login and display name. |
-| `page` | [`PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Page request. Defaults to 20 results when absent or limit is zero. |
+| `page` | [`PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Page request. Defaults to 250 results when absent or limit is zero. |
 
 
 <a id="chatto-api-v1-ListRoomMembersResponse"></a>

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -1652,7 +1652,7 @@ Request for members of one room.
 | --- | --- | --- |
 | `room_id` | `string` | Required. Room whose explicit members should be listed. |
 | `search` | `string` | Optional case-insensitive search against login and display name. |
-| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Page request. Defaults to 20 results when absent or limit is zero. |
+| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Page request. Defaults to 250 results when absent or limit is zero. |
 
 
 <a id="chatto-api-v1-ListRoomMembersResponse"></a>

--- a/apps/frontend/src/lib/api-client-tests/memberDirectory.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/memberDirectory.spec.ts
@@ -203,6 +203,22 @@ describe('createMemberDirectoryAPI', () => {
     );
   });
 
+  it('defaults room member pages to 250 members', async () => {
+    mocks.listRoomMembers.mockResolvedValue({
+      members: [],
+      page: { totalCount: 0n, hasMore: false }
+    });
+
+    const api = createMemberDirectoryAPI({ baseUrl: '/api/connect', bearerToken: null });
+
+    await api.listRoomMembers('room-1');
+
+    expect(mocks.listRoomMembers).toHaveBeenCalledWith(
+      { roomId: 'room-1', search: '', page: { limit: 250, offset: 0 } },
+      { headers: undefined }
+    );
+  });
+
   it('gets and batch gets room members', async () => {
     const member = {
       user: {

--- a/apps/frontend/src/lib/api-client/memberDirectory.ts
+++ b/apps/frontend/src/lib/api-client/memberDirectory.ts
@@ -98,7 +98,7 @@ export function createMemberDirectoryAPI(config: MemberDirectoryAPIConfig) {
     async listRoomMembers(
       roomId: string,
       search = "",
-      limit = 20,
+      limit = 250,
       offset = 0,
     ): Promise<MemberDirectoryPage> {
       const response = await rooms.listMembers(

--- a/apps/frontend/src/lib/state/room/members.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/members.svelte.spec.ts
@@ -69,6 +69,10 @@ function createStore(results: Array<MemberDirectoryPage | Promise<MemberDirector
 }
 
 describe('RoomMembersStore', () => {
+  it('requests room members in 250-member pages', () => {
+    expect(ROOM_MEMBERS_PAGE_SIZE).toBe(250);
+  });
+
   it('eagerly loads every room member page into the canonical member list', async () => {
     const fakeAPI = new FakeMemberDirectoryAPI([
       pageResult([user('u1', 'alice')], true, 3),

--- a/apps/frontend/src/lib/state/room/members.svelte.ts
+++ b/apps/frontend/src/lib/state/room/members.svelte.ts
@@ -12,7 +12,7 @@ import { RoomEventKind, roomEventKind } from '$lib/render/eventKinds';
 import type { ServerConnection } from '$lib/state/server/serverConnection.svelte';
 import type { CustomUserStatus } from '$lib/state/userProfiles.svelte';
 
-export const ROOM_MEMBERS_PAGE_SIZE = 500;
+export const ROOM_MEMBERS_PAGE_SIZE = 250;
 const MENTION_MEMBER_SEARCH_LIMIT = 10;
 const roomMemberInvalidatingEventKinds = new Set<RoomEventKind>([
   RoomEventKind.UserJoinedRoom,

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -3980,10 +3980,25 @@ func TestRoomServiceListMembersRequiresMembership(t *testing.T) {
 	}
 }
 
-func TestMemberDirectoryOversizedPagesClampTo500(t *testing.T) {
-	limit, offset := apiPagination(&apiv1.PageRequest{Limit: 9999}, defaultMemberDirectoryLimit, maxMemberDirectoryLimit)
+func TestMemberDirectoryPaginationDefaultsAndClamps(t *testing.T) {
+	userLimit, userOffset := userDirectoryPagination(nil)
+	if userLimit != 20 || userOffset != 0 {
+		t.Fatalf("userDirectoryPagination nil page = %d, %d; want 20, 0", userLimit, userOffset)
+	}
+
+	roomLimit, roomOffset := roomMemberDirectoryPagination(nil)
+	if roomLimit != 250 || roomOffset != 0 {
+		t.Fatalf("roomMemberDirectoryPagination nil page = %d, %d; want 250, 0", roomLimit, roomOffset)
+	}
+
+	roomZeroLimit, roomZeroOffset := roomMemberDirectoryPagination(&apiv1.PageRequest{Limit: 0, Offset: 7})
+	if roomZeroLimit != 250 || roomZeroOffset != 7 {
+		t.Fatalf("roomMemberDirectoryPagination zero-limit page = %d, %d; want 250, 7", roomZeroLimit, roomZeroOffset)
+	}
+
+	limit, offset := roomMemberDirectoryPagination(&apiv1.PageRequest{Limit: 9999})
 	if limit != 500 || offset != 0 {
-		t.Fatalf("apiPagination limit, offset = %d, %d; want 500, 0", limit, offset)
+		t.Fatalf("roomMemberDirectoryPagination oversized page = %d, %d; want 500, 0", limit, offset)
 	}
 
 	users := make([]*corev1.User, 501)

--- a/cli/internal/connectapi/member_directory.go
+++ b/cli/internal/connectapi/member_directory.go
@@ -13,16 +13,25 @@ import (
 )
 
 const (
-	defaultMemberDirectoryLimit = 20
-	maxMemberDirectoryLimit     = 500
+	defaultUserDirectoryLimit       = 20
+	defaultRoomMemberDirectoryLimit = 250
+	maxMemberDirectoryLimit         = 500
 )
+
+func userDirectoryPagination(page *apiv1.PageRequest) (int, int) {
+	return apiPagination(page, defaultUserDirectoryLimit, maxMemberDirectoryLimit)
+}
+
+func roomMemberDirectoryPagination(page *apiv1.PageRequest) (int, int) {
+	return apiPagination(page, defaultRoomMemberDirectoryLimit, maxMemberDirectoryLimit)
+}
 
 func (s *userService) ListUsers(ctx context.Context, req *connect.Request[apiv1.ListUsersRequest]) (*connect.Response[apiv1.ListUsersResponse], error) {
 	if _, err := requireCaller(ctx); err != nil {
 		return nil, err
 	}
 
-	limit, offset := apiPagination(req.Msg.GetPage(), defaultMemberDirectoryLimit, maxMemberDirectoryLimit)
+	limit, offset := userDirectoryPagination(req.Msg.GetPage())
 	members, totalCount, err := s.api.core.GetServerMembers(ctx, req.Msg.GetSearch(), limit, offset)
 	if err != nil {
 		return nil, connectError(err)
@@ -138,7 +147,7 @@ func (s *roomService) ListMembers(ctx context.Context, req *connect.Request[apiv
 		return left < right
 	})
 
-	limit, offset := apiPagination(req.Msg.GetPage(), defaultMemberDirectoryLimit, maxMemberDirectoryLimit)
+	limit, offset := roomMemberDirectoryPagination(req.Msg.GetPage())
 	page, totalCount, hasMore := paginateDirectoryUsers(users, limit, offset)
 	out := make([]*apiv1.DirectoryMember, 0, len(page))
 	for _, user := range page {

--- a/cli/internal/pb/chatto/api/v1/member_directory.pb.go
+++ b/cli/internal/pb/chatto/api/v1/member_directory.pb.go
@@ -430,7 +430,7 @@ type ListRoomMembersRequest struct {
 	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
 	// Optional case-insensitive search against login and display name.
 	Search string `protobuf:"bytes,2,opt,name=search,proto3" json:"search,omitempty"`
-	// Page request. Defaults to 20 results when absent or limit is zero.
+	// Page request. Defaults to 250 results when absent or limit is zero.
 	Page          *PageRequest `protobuf:"bytes,5,opt,name=page,proto3" json:"page,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/packages/api-types/src/chatto/api/v1/member_directory_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/member_directory_pb.ts
@@ -366,7 +366,7 @@ export class ListRoomMembersRequest extends Message<ListRoomMembersRequest> {
   search = "";
 
   /**
-   * Page request. Defaults to 20 results when absent or limit is zero.
+   * Page request. Defaults to 250 results when absent or limit is zero.
    *
    * @generated from field: chatto.api.v1.PageRequest page = 5;
    */

--- a/proto/chatto/api/v1/member_directory.proto
+++ b/proto/chatto/api/v1/member_directory.proto
@@ -85,7 +85,7 @@ message ListRoomMembersRequest {
   string room_id = 1 [(buf.validate.field).string.min_len = 1];
   // Optional case-insensitive search against login and display name.
   string search = 2 [(buf.validate.field).string.max_len = 100];
-  // Page request. Defaults to 20 results when absent or limit is zero.
+  // Page request. Defaults to 250 results when absent or limit is zero.
   PageRequest page = 5;
 }
 


### PR DESCRIPTION
## Summary

This changes room member pagination defaults to load 250 members per request instead of the previous split behavior.
The active room member store and frontend room-member API wrapper now request 250-member pages, while the broader server user directory keeps its 20-user default.
The ConnectRPC room member default, generated API docs, Go protobuf output, and TypeScript API types now all document the 250-member room default while preserving the 500 max for explicit requests.

## Validation

- `mise codegen-proto`
- `mise x -- npx @sveltejs/mcp svelte-autofixer apps/frontend/src/lib/state/room/members.svelte.ts`
- `cd cli && mise x -- go test ./internal/connectapi`
- `mise x -- pnpm --dir packages/api-types run build`
- `mise x -- pnpm --dir apps/frontend exec vitest run src/lib/api-client-tests/memberDirectory.spec.ts src/lib/state/room/members.svelte.spec.ts`
- `git diff --check`
