### PR TITLE
chore(release): add FreeBSD release artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,29 @@ jobs:
       - name: Run Go tests
         run: cd cli && go test -trimpath -p 1 -tags test_endpoints ./...
 
+  test-cli-freebsd-cross-compile:
+    # runs-on: ubicloud-standard-4
+    runs-on: ubuntu-latest
+    name: test-cli-freebsd-cross-compile (${{ matrix.goarch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        goarch: [amd64, arm64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup environment
+        uses: ./.github/actions/setup
+        with:
+          install-frontend-deps: "false"
+
+      - name: Build FreeBSD packages
+        run: cd cli && GOOS=freebsd GOARCH=${{ matrix.goarch }} CGO_ENABLED=0 go build -trimpath ./...
+
+      - name: Compile FreeBSD test packages
+        run: cd cli && GOOS=freebsd GOARCH=${{ matrix.goarch }} CGO_ENABLED=0 go test -run '^$' -exec /usr/bin/true ./...
+
   test-e2e:
     # runs-on: ubicloud-standard-4
     runs-on: ubuntu-latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,7 @@ builds:
     dir: ./cli
     goos:
       - linux
+      - freebsd
       - darwin
     goarch:
       - amd64

--- a/apps/docs-website/src/content/docs/getting-started/quick-start.mdx
+++ b/apps/docs-website/src/content/docs/getting-started/quick-start.mdx
@@ -32,7 +32,7 @@ The quickest and easiest way to give Chatto a try is to just download the execut
    brew install chattocorp/tap/chatto
    ```
 
-   If you don't have Homebrew, just download the binary for your platform from [GitHub Releases](https://github.com/chattocorp/chatto/releases). Support for more package managers will be added with time!
+   If you don't have Homebrew, download the Linux, macOS, or FreeBSD archive for your platform from [GitHub Releases](https://github.com/chattocorp/chatto/releases). Support for more package managers will be added with time!
 
 2. **Generate a configuration file:**
 

--- a/apps/docs-website/src/content/docs/guides/deployment/binary.mdx
+++ b/apps/docs-website/src/content/docs/guides/deployment/binary.mdx
@@ -30,7 +30,7 @@ The Chatto binary includes an embedded NATS server with JetStream for storage. I
 
 ## Prerequisites
 
-- A server with Chatto installed. Use `brew install chattocorp/tap/chatto` on macOS or Linux with Homebrew, or download the binary from [GitHub Releases](https://github.com/chattocorp/chatto/releases).
+- A server with Chatto installed. Use `brew install chattocorp/tap/chatto` on macOS or Linux with Homebrew, or download the Linux, macOS, or FreeBSD archive from [GitHub Releases](https://github.com/chattocorp/chatto/releases).
 - A domain pointing to your server (e.g., `chat.example.com`)
 - Firewall allowing inbound TCP 80 and 443
 

--- a/apps/docs-website/src/content/docs/guides/infrastructure/video-processing.mdx
+++ b/apps/docs-website/src/content/docs/guides/infrastructure/video-processing.mdx
@@ -22,6 +22,9 @@ brew install ffmpeg
 
 # Alpine
 apk add ffmpeg
+
+# FreeBSD
+pkg install ffmpeg
 ```
 
 ## Enabling Video Processing


### PR DESCRIPTION
## Summary
Adds FreeBSD `amd64` and `arm64` archives to the GoReleaser build matrix so GitHub Releases publish first-pass FreeBSD binaries.
Adds CI cross-compile coverage for FreeBSD packages and test packages without claiming native runtime support.
Updates the install and video-processing docs so FreeBSD users can find release archives and install `ffmpeg` with `pkg`.

## Validation
Ran `goreleaser check`, `actionlint`, FreeBSD `amd64`/`arm64` cross-builds, FreeBSD test-package compile checks, and `pnpm run build:docs`.
