### PR TITLE
fix(metrics): track realtime websocket connections

### DIFF
--- a/cli/internal/http_server/metrics.go
+++ b/cli/internal/http_server/metrics.go
@@ -6,16 +6,31 @@ import (
 	"net"
 	"net/http"
 	"net/http/pprof"
+	"sync/atomic"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-type processMetrics struct{}
+type processMetrics struct {
+	realtimeWebSocketConnections atomic.Int64
+}
 
 func newProcessMetrics() *processMetrics {
 	return &processMetrics{}
+}
+
+func (m *processMetrics) realtimeWebSocketOpened() {
+	m.realtimeWebSocketConnections.Add(1)
+}
+
+func (m *processMetrics) realtimeWebSocketClosed() {
+	m.realtimeWebSocketConnections.Add(-1)
+}
+
+func (m *processMetrics) realtimeWebSocketConnectionCount() int64 {
+	return m.realtimeWebSocketConnections.Load()
 }
 
 func (s *HTTPServer) newMetricsServer() (*http.Server, error) {
@@ -53,6 +68,7 @@ type chattoCollector struct {
 
 	buildInfo               *prometheus.Desc
 	ready                   *prometheus.Desc
+	realtimeWebSockets      *prometheus.Desc
 	myEventsActive          *prometheus.Desc
 	myEventsDelivered       *prometheus.Desc
 	myEventsSlowDisconnects *prometheus.Desc
@@ -90,6 +106,12 @@ func newChattoCollector(server *HTTPServer) *chattoCollector {
 		ready: prometheus.NewDesc(
 			"chatto_ready",
 			"Whether this Chatto process is ready to serve application traffic.",
+			nil,
+			nil,
+		),
+		realtimeWebSockets: prometheus.NewDesc(
+			"chatto_realtime_websocket_connections",
+			"Current realtime WebSocket connections in this process.",
 			nil,
 			nil,
 		),
@@ -231,6 +253,7 @@ func newChattoCollector(server *HTTPServer) *chattoCollector {
 func (c *chattoCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.buildInfo
 	ch <- c.ready
+	ch <- c.realtimeWebSockets
 	ch <- c.myEventsActive
 	ch <- c.myEventsDelivered
 	ch <- c.myEventsSlowDisconnects
@@ -260,6 +283,7 @@ func (c *chattoCollector) Collect(ch chan<- prometheus.Metric) {
 		version = "unknown"
 	}
 	ch <- prometheus.MustNewConstMetric(c.buildInfo, prometheus.GaugeValue, 1, version)
+	ch <- prometheus.MustNewConstMetric(c.realtimeWebSockets, prometheus.GaugeValue, float64(c.server.metrics.realtimeWebSocketConnectionCount()))
 
 	c.collectNATSMetrics(ch)
 	c.collectCoreMetrics(ch)

--- a/cli/internal/http_server/metrics_test.go
+++ b/cli/internal/http_server/metrics_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"hmans.de/chatto/internal/config"
 )
@@ -46,6 +47,7 @@ func TestMetricsServerExposesPrometheusMetrics(t *testing.T) {
 
 	for _, want := range []string{
 		`chatto_build_info{version="test-version"} 1`,
+		`chatto_realtime_websocket_connections 0`,
 		`chatto_nats_connected 0`,
 		`chatto_ready 0`,
 	} {
@@ -176,4 +178,59 @@ func TestMetricsServerUsesProjectionAndModelKeys(t *testing.T) {
 	if strings.Contains(text, `model="Message Model"`) {
 		t.Fatalf("metrics body used human model name as label\n%s", text)
 	}
+}
+
+func TestMetricsServerTracksRealtimeWebSocketConnections(t *testing.T) {
+	env := setupWebSocketTestServer(t)
+
+	metricsServer, err := env.httpServer.newMetricsServer()
+	if err != nil {
+		t.Fatalf("newMetricsServer() error = %v", err)
+	}
+	ts := httptest.NewServer(metricsServer.Handler)
+	t.Cleanup(ts.Close)
+
+	assertMetricsContainsEventually(t, ts.URL+"/metrics", `chatto_realtime_websocket_connections 0`)
+
+	conn := env.connectRealtime(t)
+	assertMetricsContainsEventually(t, ts.URL+"/metrics", `chatto_realtime_websocket_connections 1`)
+
+	if err := conn.Close(); err != nil {
+		t.Fatalf("close realtime websocket: %v", err)
+	}
+	assertMetricsContainsEventually(t, ts.URL+"/metrics", `chatto_realtime_websocket_connections 0`)
+}
+
+func assertMetricsContainsEventually(t *testing.T, url, want string) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	var text string
+	for time.Now().Before(deadline) {
+		text = scrapeMetricsText(t, url)
+		if strings.Contains(text, want) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("metrics body missing %q\n%s", want, text)
+}
+
+func scrapeMetricsText(t *testing.T, url string) string {
+	t.Helper()
+
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET metrics error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET metrics status = %d, want 200", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read metrics body: %v", err)
+	}
+	return string(body)
 }

--- a/cli/internal/http_server/realtime.go
+++ b/cli/internal/http_server/realtime.go
@@ -36,6 +36,10 @@ var realtimeServerCapabilities = []string{
 }
 
 func (s *HTTPServer) setupRealtimeAPI(allowedOrigins []string) {
+	if s.metrics == nil {
+		s.metrics = newProcessMetrics()
+	}
+
 	upgrader := websocket.Upgrader{
 		EnableCompression: s.config.Webserver.WebSocketCompressionEnabled(),
 		CheckOrigin: func(r *http.Request) bool {
@@ -50,6 +54,8 @@ func (s *HTTPServer) setupRealtimeAPI(allowedOrigins []string) {
 			s.logger.Warn("Realtime WebSocket upgrade failed", "error", err)
 			return
 		}
+		s.metrics.realtimeWebSocketOpened()
+		defer s.metrics.realtimeWebSocketClosed()
 		defer conn.Close()
 
 		s.serveRealtimeWebSocket(req.Context(), conn)


### PR DESCRIPTION
## Summary
Adds a process-local Prometheus gauge, `chatto_realtime_websocket_connections`, for currently upgraded `/api/realtime` WebSocket connections.
The gauge increments immediately after a successful WebSocket upgrade and decrements when the realtime handler exits, while leaving `chatto_my_events_streams` as the subscribed live-event stream metric.

## Testing
- `mise x -- go test ./internal/http_server -run 'TestMetricsServer' -count=1`
- `mise x -- go test ./internal/http_server -run 'TestRealtimeWebSocket' -count=1`

Note: the full `./internal/http_server` package currently fails in this workspace because frontend fallback tests cannot find `200.html`, unrelated to this change.
