### PR TITLE
chore(release): add FreeBSD release artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,29 +141,6 @@ jobs:
       - name: Run Go tests
         run: cd cli && go test -trimpath -p 1 -tags test_endpoints ./...
 
-  test-cli-freebsd-cross-compile:
-    # runs-on: ubicloud-standard-4
-    runs-on: ubuntu-latest
-    name: test-cli-freebsd-cross-compile (${{ matrix.goarch }})
-    strategy:
-      fail-fast: false
-      matrix:
-        goarch: [amd64, arm64]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Setup environment
-        uses: ./.github/actions/setup
-        with:
-          install-frontend-deps: "false"
-
-      - name: Build FreeBSD packages
-        run: cd cli && GOOS=freebsd GOARCH=${{ matrix.goarch }} CGO_ENABLED=0 go build -trimpath ./...
-
-      - name: Compile FreeBSD test packages
-        run: cd cli && GOOS=freebsd GOARCH=${{ matrix.goarch }} CGO_ENABLED=0 go test -run '^$' -exec /usr/bin/true ./...
-
   test-e2e:
     # runs-on: ubicloud-standard-4
     runs-on: ubuntu-latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,9 +26,10 @@ archives:
       - LICENSES/AGPL-3.0-or-later.txt
       - NOTICE
     # this name template makes the OS and Arch compatible with the results of `uname`.
+    # GoReleaser's `title` renders `freebsd` as `Freebsd`, but `uname` reports `FreeBSD`.
     name_template: >-
       {{ .ProjectName }}_
-      {{- title .Os }}_
+      {{- if eq .Os "freebsd" }}FreeBSD{{ else }}{{ title .Os }}{{ end }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}


### PR DESCRIPTION
## Summary
Adds FreeBSD `amd64` and `arm64` archives to the GoReleaser build matrix so GitHub Releases publish first-pass FreeBSD binaries.
Adds CI cross-compile coverage for FreeBSD packages and test packages without claiming native runtime support.
Updates the install and video-processing docs so FreeBSD users can find release archives and install `ffmpeg` with `pkg`.

## Validation
Ran `goreleaser check`, `actionlint`, FreeBSD `amd64`/`arm64` cross-builds, FreeBSD test-package compile checks, and `pnpm run build:docs`.
