### PR TITLE
fix(frontend): compress displayed images

### DIFF
--- a/apps/frontend/e2e/messages.test.ts
+++ b/apps/frontend/e2e/messages.test.ts
@@ -188,13 +188,10 @@ test('image attachment refreshes URL after an expired lazy-load request', async 
 
   let refreshQueryCount = 0;
 
-  await page.route(
-    '**/api/connect/chatto.api.v1.AssetService/BatchGetAssets',
-    async (route) => {
-      refreshQueryCount += 1;
-      await route.continue();
-    }
-  );
+  await page.route('**/api/connect/chatto.api.v1.AssetService/BatchGetAssets', async (route) => {
+    refreshQueryCount += 1;
+    await route.continue();
+  });
 
   let failedAssetLoad = false;
   await page.route('**/assets/files/**', async (route) => {
@@ -760,6 +757,10 @@ test('image lightbox supports keyboard navigation with multiple images', async (
 
   // Wait for all attachment images to appear in the message
   await expect(roomPage.attachmentImage).toHaveCount(5, { timeout: TIMEOUTS.COMPLEX_OPERATION });
+  await expect(roomPage.attachmentImage.first()).toHaveAttribute(
+    'src',
+    /\/image\/960x400\/contain\?/
+  );
 
   const gallery = page.getByTestId('message-image-gallery');
   await expect(gallery).toBeVisible();
@@ -831,6 +832,11 @@ test('image lightbox supports keyboard navigation with multiple images', async (
   const dialog = page.locator('dialog[open]');
   await expect(dialog).toBeVisible();
   await expect(dialog.getByText('1 / 5')).toBeVisible();
+  await expect(dialog.locator('img')).toHaveAttribute('src', /\/image\/2048x2048\/contain\?/);
+  await expect(dialog.getByRole('link', { name: 'Open original' })).toHaveAttribute(
+    'href',
+    /\/assets\/files\/[^/?]+\?/
+  );
 
   // Verify the "brighton.jpg" filename is shown
   await expect(dialog.getByText('brighton.jpg')).toBeVisible();

--- a/apps/frontend/src/app.d.ts
+++ b/apps/frontend/src/app.d.ts
@@ -26,7 +26,13 @@ declare global {
         attachmentId?: string;
         attachmentFilename?: string;
         previewUrl?: string;
-        imageItems?: Array<{ id?: string; src: string; alt?: string; filename?: string }>;
+        imageItems?: Array<{
+          id?: string;
+          src: string;
+          originalSrc?: string;
+          alt?: string;
+          filename?: string;
+        }>;
         imageIndex?: number;
       };
     }

--- a/apps/frontend/src/lib/attachments/attachmentUrls.test.ts
+++ b/apps/frontend/src/lib/attachments/attachmentUrls.test.ts
@@ -60,15 +60,14 @@ describe('refreshAttachmentUrlsForAssets', () => {
     ]);
     const refreshAssetUrls = vi.fn().mockResolvedValue(urlsFromAPI);
 
-    const urls = await refreshAttachmentUrlsForAssets(
-      apiWithRefresh(refreshAssetUrls),
-      'room_1',
-      ['att_1', 'att_2']
-    );
+    const urls = await refreshAttachmentUrlsForAssets(apiWithRefresh(refreshAssetUrls), 'room_1', [
+      'att_1',
+      'att_2'
+    ]);
 
     expect(refreshAssetUrls).toHaveBeenCalledWith('room_1', ['att_1', 'att_2'], {
       width: 960,
-      height: 800,
+      height: 400,
       fit: FitMode.Contain
     });
     expect(urls.get('att_1')?.assetUrl?.url).toBe('https://cdn.example.com/fresh-1.jpg');
@@ -84,16 +83,11 @@ describe('refreshAttachmentUrlsForAssets', () => {
   it('passes caller-selected thumbnail shape to the attachment API', async () => {
     const refreshAssetUrls = vi.fn().mockResolvedValue(new Map());
 
-    await refreshAttachmentUrlsForAssets(
-      apiWithRefresh(refreshAssetUrls),
-      'room_1',
-      ['att_1'],
-      {
-        width: 120,
-        height: 120,
-        fit: FitMode.Cover
-      }
-    );
+    await refreshAttachmentUrlsForAssets(apiWithRefresh(refreshAssetUrls), 'room_1', ['att_1'], {
+      width: 120,
+      height: 120,
+      fit: FitMode.Cover
+    });
 
     expect(refreshAssetUrls).toHaveBeenCalledWith('room_1', ['att_1'], {
       width: 120,
@@ -105,11 +99,9 @@ describe('refreshAttachmentUrlsForAssets', () => {
   it('returns an empty map when the refresh request fails', async () => {
     const refreshAssetUrls = vi.fn().mockRejectedValue(new Error('network failed'));
 
-    const urls = await refreshAttachmentUrlsForAssets(
-      apiWithRefresh(refreshAssetUrls),
-      'room_1',
-      ['att_1']
-    );
+    const urls = await refreshAttachmentUrlsForAssets(apiWithRefresh(refreshAssetUrls), 'room_1', [
+      'att_1'
+    ]);
 
     expect(urls.size).toBe(0);
   });

--- a/apps/frontend/src/lib/attachments/attachmentUrls.ts
+++ b/apps/frontend/src/lib/attachments/attachmentUrls.ts
@@ -21,7 +21,13 @@ export type AttachmentThumbnailRefreshOptions = {
 
 export const DEFAULT_ATTACHMENT_THUMBNAIL_REFRESH: AttachmentThumbnailRefreshOptions = {
   width: 960,
-  height: 800,
+  height: 400,
+  fit: FitMode.Contain
+};
+
+export const LIGHTBOX_ATTACHMENT_IMAGE_REFRESH: AttachmentThumbnailRefreshOptions = {
+  width: 2048,
+  height: 2048,
   fit: FitMode.Contain
 };
 

--- a/apps/frontend/src/lib/ui/ImageModal.svelte
+++ b/apps/frontend/src/lib/ui/ImageModal.svelte
@@ -5,6 +5,7 @@
   export type ImageItem = {
     id?: string;
     src: string;
+    originalSrc?: string;
     alt?: string;
     filename?: string;
   };
@@ -100,7 +101,7 @@
 
         <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external image URL -->
         <a
-          href={current.src}
+          href={current.originalSrc ?? current.src}
           target="_blank"
           rel="noopener noreferrer"
           class="flex items-center gap-1 text-sm text-white/60 hover:text-white"

--- a/apps/frontend/src/lib/ui/ImageModal.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/ImageModal.svelte.spec.ts
@@ -8,7 +8,8 @@ describe('ImageModal', () => {
       props: {
         items: [
           {
-            src: 'https://cdn.example.com/current.jpg',
+            src: 'https://cdn.example.com/display.jpg',
+            originalSrc: 'https://cdn.example.com/original.jpg',
             filename: 'image.jpg'
           }
         ],
@@ -18,8 +19,21 @@ describe('ImageModal', () => {
 
     const link = container.querySelector<HTMLAnchorElement>('a')!;
 
-    await expect.element(link).toHaveAttribute('href', 'https://cdn.example.com/current.jpg');
+    await expect.element(link).toHaveAttribute('href', 'https://cdn.example.com/original.jpg');
     await expect.element(link).toHaveAttribute('target', '_blank');
     await expect.element(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('falls back to the display image when no separate original URL exists', async () => {
+    const { container } = render(ImageModal, {
+      props: {
+        items: [{ src: 'https://cdn.example.com/display.jpg', filename: 'image.jpg' }],
+        onclose: () => {}
+      }
+    });
+
+    await expect
+      .element(container.querySelector<HTMLAnchorElement>('a')!)
+      .toHaveAttribute('href', 'https://cdn.example.com/display.jpg');
   });
 });

--- a/apps/frontend/src/routes/chat/ModalContainer.svelte
+++ b/apps/frontend/src/routes/chat/ModalContainer.svelte
@@ -20,7 +20,11 @@
 
   import ImageModal from '$lib/ui/ImageModal.svelte';
 
-  import { refreshAttachmentUrlsForAssets } from '$lib/attachments/attachmentUrls';
+  import {
+    LIGHTBOX_ATTACHMENT_IMAGE_REFRESH,
+    refreshAttachmentUrlsForAssets
+  } from '$lib/attachments/attachmentUrls';
+  import { assetUrlForServer } from '$lib/assets/assetUrls';
   import { toast } from '$lib/ui/toast';
   import { clearLastRoom } from '$lib/storage/lastRoom';
   import { notifyRoomMessageMutated } from '$lib/state/room/messageMutationEvents';
@@ -162,7 +166,8 @@
     const freshUrls = await refreshAttachmentUrlsForAssets(
       getActiveAttachmentAPI(),
       refreshRoomId,
-      modal.imageItems.map((item) => item.id).filter((id): id is string => !!id)
+      modal.imageItems.map((item) => item.id).filter((id): id is string => !!id),
+      LIGHTBOX_ATTACHMENT_IMAGE_REFRESH
     );
     if (freshUrls.size === 0) {
       return;
@@ -177,13 +182,18 @@
       return;
     }
     const imageItems = currentModal.imageItems
-      .map((item) => ({
-        ...item,
-        src:
-          item.id && freshUrls.has(item.id)
-            ? (freshUrls.get(item.id)!.assetUrl?.url ?? '')
-            : item.src
-      }))
+      .map((item) => {
+        const refreshed = item.id ? freshUrls.get(item.id) : undefined;
+        return {
+          ...item,
+          src: refreshed
+            ? (assetUrlForServer(activeInstanceId, refreshed.thumbnailAssetUrl?.url) ?? '')
+            : item.src,
+          originalSrc: refreshed
+            ? (assetUrlForServer(activeInstanceId, refreshed.assetUrl?.url) ?? undefined)
+            : item.originalSrc
+        };
+      })
       .filter((item) => item.src !== '');
     if (imageItems.length === 0) {
       closeModal();

--- a/apps/frontend/src/routes/chat/ModalContainer.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/ModalContainer.svelte.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { q } from '$lib/test-utils';
 
@@ -9,6 +9,8 @@ const { mocks } = vi.hoisted(() => ({
     } as Record<string, unknown> | undefined,
     closeModal: vi.fn(),
     goto: vi.fn(),
+    replaceState: vi.fn(),
+    refreshAttachmentUrlsForAssets: vi.fn(),
     toastSuccess: vi.fn(),
     toastError: vi.fn(),
     deleteMessage: vi.fn(),
@@ -50,7 +52,7 @@ vi.mock('$app/state', () => ({
 
 vi.mock('$app/navigation', () => ({
   goto: mocks.goto,
-  replaceState: vi.fn()
+  replaceState: mocks.replaceState
 }));
 
 vi.mock('$app/paths', () => ({
@@ -122,7 +124,12 @@ vi.mock('$lib/auth/signOut', () => ({
 }));
 
 vi.mock('$lib/attachments/attachmentUrls', () => ({
-  refreshAttachmentUrlsForAssets: vi.fn()
+  LIGHTBOX_ATTACHMENT_IMAGE_REFRESH: {
+    width: 2048,
+    height: 2048,
+    fit: 'contain'
+  },
+  refreshAttachmentUrlsForAssets: mocks.refreshAttachmentUrlsForAssets
 }));
 
 vi.mock('$lib/CreateRoom.svelte', () => ({
@@ -135,10 +142,6 @@ vi.mock('$lib/api-client/messages', () => ({
     deleteAttachment: mocks.deleteAttachment,
     deleteLinkPreview: mocks.deleteLinkPreview
   })
-}));
-
-vi.mock('$lib/ui/ImageModal.svelte', () => ({
-  default: {}
 }));
 
 vi.mock('$lib/ui/ConfirmDialog.svelte', async () => {
@@ -182,6 +185,7 @@ beforeEach(() => {
   mocks.deleteMessage.mockResolvedValue(true);
   mocks.deleteAttachment.mockResolvedValue(true);
   mocks.deleteLinkPreview.mockResolvedValue(true);
+  mocks.refreshAttachmentUrlsForAssets.mockResolvedValue(new Map());
   mocks.mutation.mockReturnValue({
     toPromise: () => Promise.resolve({ data: {}, error: null })
   });
@@ -198,6 +202,67 @@ beforeEach(() => {
   mocks.servers = [mocks.originServer];
   mocks.authenticated = { origin: true };
   vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('ModalContainer image viewer', () => {
+  it('refreshes compressed display and original URLs independently', async () => {
+    vi.useFakeTimers();
+    mocks.modal = {
+      type: 'imageViewer',
+      roomId: 'room_1',
+      eventId: 'event_1',
+      imageItems: [
+        {
+          id: 'att_1',
+          src: '/assets/files/att_1/image/2048x2048/contain?access=old',
+          originalSrc: '/assets/files/att_1?access=old',
+          filename: 'image.jpg'
+        }
+      ],
+      imageIndex: 0
+    };
+    mocks.refreshAttachmentUrlsForAssets.mockResolvedValue(
+      new Map([
+        [
+          'att_1',
+          {
+            assetUrl: { url: '/assets/files/att_1?access=fresh' },
+            thumbnailAssetUrl: {
+              url: '/assets/files/att_1/image/2048x2048/contain?access=fresh'
+            }
+          }
+        ]
+      ])
+    );
+
+    render(ModalContainer);
+    await vi.advanceTimersByTimeAsync(23 * 60 * 60 * 1000);
+
+    expect(mocks.refreshAttachmentUrlsForAssets).toHaveBeenCalledWith(
+      expect.anything(),
+      'room_1',
+      ['att_1'],
+      { width: 2048, height: 2048, fit: 'contain' }
+    );
+    expect(mocks.replaceState).toHaveBeenCalledWith('', {
+      modal: {
+        ...mocks.modal,
+        imageItems: [
+          {
+            id: 'att_1',
+            src: 'https://origin.example.test/assets/files/att_1/image/2048x2048/contain?access=fresh',
+            originalSrc: 'https://origin.example.test/assets/files/att_1?access=fresh',
+            filename: 'image.jpg'
+          }
+        ],
+        imageIndex: 0
+      }
+    });
+  });
 });
 
 describe('ModalContainer sign out modal', () => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
@@ -21,6 +21,7 @@
   import {
     assetUrlNeedsRefresh,
     earliestAssetUrlRefreshAt,
+    LIGHTBOX_ATTACHMENT_IMAGE_REFRESH,
     mergeRefreshedAttachmentUrls,
     refreshAttachmentUrlsForAssets,
     withAssetUrlRetryParam,
@@ -364,28 +365,45 @@
   });
 
   async function refreshUrlsForMessage(): Promise<Map<string, RefreshedAttachmentUrls>> {
-    const conn = connection();
     return refreshAttachmentUrlsForAssets(
-      createAttachmentAPI({
-        serverId: conn.serverId,
-        baseUrl: conn.connectBaseUrl,
-        bearerToken: conn.bearerToken
-      }),
+      currentAttachmentAPI(),
       roomId,
       attachments.map((attachment) => attachment.id)
+    );
+  }
+
+  function currentAttachmentAPI() {
+    const conn = connection();
+    return createAttachmentAPI({
+      serverId: conn.serverId,
+      baseUrl: conn.connectBaseUrl,
+      bearerToken: conn.bearerToken
+    });
+  }
+
+  async function refreshLightboxUrls(): Promise<Map<string, RefreshedAttachmentUrls>> {
+    return refreshAttachmentUrlsForAssets(
+      currentAttachmentAPI(),
+      roomId,
+      imageAttachments.map((attachment) => attachment.id),
+      LIGHTBOX_ATTACHMENT_IMAGE_REFRESH
     );
   }
 
   async function openImageModal(attachment: Attachment) {
     // Refresh in one round-trip so navigating between images in the
     // lightbox can't hit an expired URL mid-session.
-    const freshUrls = await refreshAndApplyUrls();
+    const freshUrls = await refreshLightboxUrls();
     const imageItems: ImageItem[] = imageAttachments
       .map((a) => ({
         id: a.id,
         src:
-          normalizeAssetUrl(freshUrls.has(a.id) ? freshUrls.get(a.id)!.assetUrl : a.assetUrl)
-            ?.url ?? '',
+          normalizeAssetUrl(
+            freshUrls.has(a.id) ? freshUrls.get(a.id)!.thumbnailAssetUrl : a.thumbnailAssetUrl
+          )?.url ?? '',
+        originalSrc: normalizeAssetUrl(
+          freshUrls.has(a.id) ? freshUrls.get(a.id)!.assetUrl : a.assetUrl
+        )?.url,
         alt: a.filename,
         filename: a.filename
       }))

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import MessageAttachments from './MessageAttachments.svelte';
-import type { MessageAttachmentView } from '$lib/render/types';
+import { FitMode, type MessageAttachmentView } from '$lib/render/types';
 import type { RefreshedAttachmentUrls } from '$lib/attachments/attachmentUrls';
 
 const attachmentMocks = vi.hoisted(() => ({
@@ -202,9 +202,7 @@ describe('MessageAttachments', () => {
   });
 
   it('clears stale image URLs when refresh returns null asset URLs', async () => {
-    attachmentMocks.refreshAssetUrls.mockResolvedValue(
-      new Map([['att_1', emptyRefreshedUrls()]])
-    );
+    attachmentMocks.refreshAssetUrls.mockResolvedValue(new Map([['att_1', emptyRefreshedUrls()]]));
     const { container } = renderAttachment(
       imageAttachment({
         filename: 'expired.jpg',
@@ -246,6 +244,56 @@ describe('MessageAttachments', () => {
       expect(container.querySelector('img[alt="cleared.jpg"]')).toBeNull();
     });
     expect(attachmentMocks.pushState).not.toHaveBeenCalled();
+  });
+
+  it('opens the lightbox with a compressed display URL and a separate original URL', async () => {
+    attachmentMocks.refreshAssetUrls.mockResolvedValue(
+      new Map([
+        [
+          'att_1',
+          {
+            assetUrl: {
+              url: 'https://cdn.example.test/original.jpg',
+              expiresAt: '2027-05-29T15:00:00Z'
+            },
+            thumbnailAssetUrl: {
+              url: 'https://cdn.example.test/lightbox.jpg',
+              expiresAt: '2027-05-29T15:00:00Z'
+            },
+            videoThumbnailAssetUrl: null,
+            variantAssetUrls: new Map()
+          }
+        ]
+      ])
+    );
+    const { container } = renderAttachment(imageAttachment({ filename: 'large.jpg' }));
+
+    imageFrame(container, 'large.jpg').button.click();
+
+    await vi.waitFor(() => {
+      expect(attachmentMocks.refreshAssetUrls).toHaveBeenCalledWith('room_1', ['att_1'], {
+        width: 2048,
+        height: 2048,
+        fit: FitMode.Contain
+      });
+      expect(attachmentMocks.pushState).toHaveBeenCalledWith('', {
+        modal: {
+          type: 'imageViewer',
+          roomId: 'room_1',
+          eventId: 'event_1',
+          imageItems: [
+            {
+              id: 'att_1',
+              src: 'https://cdn.example.test/lightbox.jpg',
+              originalSrc: 'https://cdn.example.test/original.jpg',
+              alt: 'large.jpg',
+              filename: 'large.jpg'
+            }
+          ],
+          imageIndex: 0
+        }
+      });
+    });
   });
 
   it('renders multiple images inside a horizontal gallery with equal-height frames', () => {

--- a/cli/internal/assets/images.go
+++ b/cli/internal/assets/images.go
@@ -28,9 +28,10 @@ const (
 	MaxBannerWidth = 768
 	// MaxBannerHeight is the maximum height for space banner images (4:3 aspect ratio).
 	MaxBannerHeight = 576
-	// ThumbnailQuality is the JPEG quality for transformed thumbnails (1-100).
+	// DefaultTransformJPEGQuality is the JPEG quality used by transformed images
+	// unless the caller selects a surface-specific quality (1-100).
 	// 80 provides a good balance between file size and visual quality.
-	ThumbnailQuality = 80
+	DefaultTransformJPEGQuality = 80
 )
 
 // Config holds configuration for asset processing.
@@ -69,6 +70,12 @@ type TransformResult struct {
 	Reader io.Reader
 	// ContentType is the MIME type of the output ("image/webp" or "image/jpeg")
 	ContentType string
+}
+
+// TransformOptions controls image derivative encoding.
+type TransformOptions struct {
+	// JPEGQuality is used for opaque static images. It must be between 1 and 100.
+	JPEGQuality int
 }
 
 // DetectImageContentType returns the MIME type of image data based on magic bytes.
@@ -326,6 +333,17 @@ func hasTransparency(img image.Image) bool {
 // For images with transparency, returns WebP to preserve alpha.
 // For opaque images, returns JPEG for smaller file sizes.
 func TransformImage(data []byte, width, height int, fit FitMode) (*TransformResult, error) {
+	return TransformImageWithOptions(data, width, height, fit, TransformOptions{
+		JPEGQuality: DefaultTransformJPEGQuality,
+	})
+}
+
+// TransformImageWithOptions transforms an image with explicit encoding options.
+func TransformImageWithOptions(data []byte, width, height int, fit FitMode, options TransformOptions) (*TransformResult, error) {
+	if options.JPEGQuality < 1 || options.JPEGQuality > 100 {
+		return nil, fmt.Errorf("invalid JPEG quality: %d", options.JPEGQuality)
+	}
+
 	// Check if this is an animated GIF - handle specially to preserve animation
 	if IsAnimatedGIF(data) {
 		return transformAnimatedGIF(data, width, height, fit)
@@ -369,7 +387,7 @@ func TransformImage(data []byte, width, height int, fit FitMode) (*TransformResu
 		}, nil
 	}
 
-	if err := jpeg.Encode(&buf, transformed, &jpeg.Options{Quality: ThumbnailQuality}); err != nil {
+	if err := jpeg.Encode(&buf, transformed, &jpeg.Options{Quality: options.JPEGQuality}); err != nil {
 		return nil, fmt.Errorf("failed to encode to jpeg: %w", err)
 	}
 
@@ -518,7 +536,7 @@ func compositeGIFFrames(g *gif.GIF) []*image.NRGBA {
 			if previous != nil {
 				copy(canvas.Pix, previous.Pix)
 			}
-		// DisposalNone (0x01) and unspecified (0x00): leave canvas as-is
+			// DisposalNone (0x01) and unspecified (0x00): leave canvas as-is
 		}
 	}
 

--- a/cli/internal/assets/images_test.go
+++ b/cli/internal/assets/images_test.go
@@ -466,6 +466,57 @@ func TestTransformImage_OutputFormat(t *testing.T) {
 	}
 }
 
+func TestTransformImageWithOptions_UsesSelectedJPEGQuality(t *testing.T) {
+	testImg := createTestImage(1200, 800)
+
+	defaultResult, err := TransformImage(testImg, 960, 400, FitContain)
+	if err != nil {
+		t.Fatalf("TransformImage failed: %v", err)
+	}
+	defaultData, err := io.ReadAll(defaultResult.Reader)
+	if err != nil {
+		t.Fatalf("Failed to read default transform: %v", err)
+	}
+
+	explicitDefaultResult, err := TransformImageWithOptions(testImg, 960, 400, FitContain, TransformOptions{
+		JPEGQuality: DefaultTransformJPEGQuality,
+	})
+	if err != nil {
+		t.Fatalf("TransformImageWithOptions default quality failed: %v", err)
+	}
+	explicitDefaultData, err := io.ReadAll(explicitDefaultResult.Reader)
+	if err != nil {
+		t.Fatalf("Failed to read explicit default transform: %v", err)
+	}
+	if !bytes.Equal(defaultData, explicitDefaultData) {
+		t.Fatal("TransformImage did not preserve the default JPEG quality")
+	}
+
+	compressedResult, err := TransformImageWithOptions(testImg, 960, 400, FitContain, TransformOptions{
+		JPEGQuality: 75,
+	})
+	if err != nil {
+		t.Fatalf("TransformImageWithOptions quality 75 failed: %v", err)
+	}
+	compressedData, err := io.ReadAll(compressedResult.Reader)
+	if err != nil {
+		t.Fatalf("Failed to read compressed transform: %v", err)
+	}
+	if len(compressedData) >= len(defaultData) {
+		t.Fatalf("quality 75 output size = %d, want less than quality %d output size %d", len(compressedData), DefaultTransformJPEGQuality, len(defaultData))
+	}
+}
+
+func TestTransformImageWithOptions_RejectsInvalidJPEGQuality(t *testing.T) {
+	testImg := createTestImage(100, 100)
+	if _, err := TransformImageWithOptions(testImg, 50, 50, FitContain, TransformOptions{}); err == nil {
+		t.Fatal("TransformImageWithOptions accepted zero JPEG quality")
+	}
+	if _, err := TransformImageWithOptions(testImg, 50, 50, FitContain, TransformOptions{JPEGQuality: 101}); err == nil {
+		t.Fatal("TransformImageWithOptions accepted JPEG quality above 100")
+	}
+}
+
 func TestTransformImage_TransparentPNG_OutputsWebP(t *testing.T) {
 	// Create a PNG with transparent pixels
 	testImg := createTransparentTestImage(200, 200)

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -6374,8 +6374,8 @@ func TestRoomAndThreadTimelineHydratesProcessedVideoAttachments(t *testing.T) {
 	if len(attachments) != 1 {
 		t.Fatalf("attachments = %d, want 1", len(attachments))
 	}
-	if got := attachments[0].GetThumbnailAssetUrl().GetUrl(); !strings.Contains(got, "/960x800/contain") {
-		t.Fatalf("attachment thumbnail URL = %q, want 960x800 contain transform", got)
+	if got := attachments[0].GetThumbnailAssetUrl().GetUrl(); !strings.Contains(got, "/960x400/contain") {
+		t.Fatalf("attachment thumbnail URL = %q, want 960x400 contain transform", got)
 	}
 	processing := attachments[0].GetVideoProcessing()
 	if processing == nil {

--- a/cli/internal/connectapi/room_timeline_assembler.go
+++ b/cli/internal/connectapi/room_timeline_assembler.go
@@ -27,7 +27,7 @@ func newRoomTimelineAssembler(api *API) *roomTimelineAssembler {
 func defaultTimelineAttachmentThumbnail() attachmentThumbnailRequest {
 	return attachmentThumbnailRequest{
 		width:  960,
-		height: 800,
+		height: 400,
 		fit:    "contain",
 	}
 }

--- a/cli/internal/core/attachments.go
+++ b/cli/internal/core/attachments.go
@@ -638,9 +638,15 @@ func (c *MediaModel) probePresignedAttachmentURL(ctx context.Context, attachment
 	return "", fmt.Errorf("attachment %s not found in S3", attachmentID)
 }
 
-// AttachmentSignResource is the image-cache namespace for stable attachment
-// transforms. Keep it stable so cached resize keys survive deployments.
+// AttachmentSignResource binds legacy signed attachment transforms and remains
+// a cache-cleanup namespace for derivatives written before stable asset paths.
 const AttachmentSignResource = "attachment"
+
+// AttachmentDerivativeCacheResource versions the current attachment image
+// encoding profile independently from the stable public URL shape.
+const AttachmentDerivativeCacheResource = "attachment-stable-v2"
+
+const attachmentLegacyStableCacheResource = "attachment-stable"
 
 // ServerAssetSignResource is the first resource component fed to the
 // signed-URL signer for server asset transform URLs and the cache prefix for
@@ -811,12 +817,24 @@ func (c *MediaModel) StoreCachedResize(ctx context.Context, key string, data []b
 
 // DeleteCachedResizesForAttachment deletes all cached resizes for an
 // attachment. Returns the number of deleted cache entries and any error
-// encountered. Does nothing if the cache is disabled. Pre-ADR-030-Phase-4
-// cache entries written under a {server|DM} prefix are not cleaned up
-// and are left to age out — the transform-URL signer always uses the
-// kind-less prefix now, so no lookups land on them.
+// encountered. Does nothing if the cache is disabled. Current and earlier
+// stable attachment cache namespaces are removed; older room-kind prefixes
+// remain unaddressable and age out through the configured TTL.
 func (c *MediaModel) DeleteCachedResizesForAttachment(ctx context.Context, attachmentID string) (int, error) {
-	return c.DeleteCachedResizesForKey(ctx, AttachmentSignResource, attachmentID)
+	prefixes := []string{
+		AttachmentDerivativeCacheResource,
+		AttachmentSignResource,
+		attachmentLegacyStableCacheResource,
+	}
+	deleted := 0
+	for _, prefix := range prefixes {
+		count, err := c.DeleteCachedResizesForKey(ctx, prefix, attachmentID)
+		deleted += count
+		if err != nil {
+			return deleted, err
+		}
+	}
+	return deleted, nil
 }
 
 // DeleteCachedResizesForServerAsset deletes all cached resizes for a server

--- a/cli/internal/core/attachments_test.go
+++ b/cli/internal/core/attachments_test.go
@@ -1004,12 +1004,12 @@ func TestChattoCore_DeleteAttachment_CleansUpCache(t *testing.T) {
 		t.Fatalf("Failed to upload attachment: %v", err)
 	}
 
-	// Simulate cached resizes by storing them directly. The HTTP handler
-	// signs transform URLs with AttachmentSignResource and the cache uses
-	// that same prefix.
+	// Simulate cached resizes from both the original cache namespace and the
+	// current versioned attachment derivative namespace.
 	cacheKey1 := ImageCacheKey(AttachmentSignResource, attachment.Id, 200, 150, "contain")
 	cacheKey2 := ImageCacheKey(AttachmentSignResource, attachment.Id, 400, 300, "cover")
 	cacheKey3 := ImageCacheKey(AttachmentSignResource, attachment.Id, 100, 100, "contain")
+	cacheKey4 := ImageCacheKey(AttachmentDerivativeCacheResource, attachment.Id, 960, 400, "contain")
 
 	// Store fake cached data
 	fakeWebP := []byte("fake webp data")
@@ -1022,9 +1022,12 @@ func TestChattoCore_DeleteAttachment_CleansUpCache(t *testing.T) {
 	if err := core.StoreCachedResize(ctx, cacheKey3, fakeWebP); err != nil {
 		t.Fatalf("Failed to store cached resize 3: %v", err)
 	}
+	if err := core.StoreCachedResize(ctx, cacheKey4, fakeWebP); err != nil {
+		t.Fatalf("Failed to store cached resize 4: %v", err)
+	}
 
 	// Verify cache entries exist
-	for _, key := range []string{cacheKey1, cacheKey2, cacheKey3} {
+	for _, key := range []string{cacheKey1, cacheKey2, cacheKey3, cacheKey4} {
 		data, err := core.GetCachedResize(ctx, key)
 		if err != nil {
 			t.Fatalf("Failed to get cached resize %s: %v", key, err)
@@ -1040,7 +1043,7 @@ func TestChattoCore_DeleteAttachment_CleansUpCache(t *testing.T) {
 	}
 
 	// Verify all cache entries are deleted
-	for _, key := range []string{cacheKey1, cacheKey2, cacheKey3} {
+	for _, key := range []string{cacheKey1, cacheKey2, cacheKey3, cacheKey4} {
 		data, err := core.GetCachedResize(ctx, key)
 		if err != nil {
 			t.Fatalf("Unexpected error getting cached resize %s: %v", key, err)

--- a/cli/internal/http_server/assets.go
+++ b/cli/internal/http_server/assets.go
@@ -43,6 +43,8 @@ type transformRequest struct {
 	CachePrefix string
 	// AssetID is used for ETag generation and logging
 	AssetID string
+	// JPEGQuality overrides the default quality for opaque static derivatives.
+	JPEGQuality int
 	// FetchAsset returns the asset data and content type.
 	// The reader will be closed if it implements io.Closer.
 	FetchAsset func(ctx context.Context) (io.Reader, string, error)
@@ -231,6 +233,7 @@ func (s *HTTPServer) serveStableTransformedAttachment(c *gin.Context) {
 	s.serveTransformedAssetWithParams(c, transformRequest{
 		CachePrefix: AttachmentStableCachePrefix,
 		AssetID:     assetID,
+		JPEGQuality: AttachmentDerivativeJPEGQuality,
 		FetchAsset: func(ctx context.Context) (io.Reader, string, error) {
 			reader, info, err := s.core.GetAttachmentReader(ctx, attachment)
 			if err != nil {
@@ -242,7 +245,14 @@ func (s *HTTPServer) serveStableTransformedAttachment(c *gin.Context) {
 	}, params)
 }
 
-const AttachmentStableCachePrefix = "attachment-stable"
+const (
+	// AttachmentDerivativeJPEGQuality keeps displayed attachment images compact
+	// without changing the encoding quality of public server assets.
+	AttachmentDerivativeJPEGQuality = 75
+	// AttachmentStableCachePrefix is versioned whenever attachment derivative
+	// encoding changes so older cached bytes cannot be reused.
+	AttachmentStableCachePrefix = core.AttachmentDerivativeCacheResource
+)
 
 func parseStableTransformParams(dimensions, fit string) (*signedurl.TransformParams, error) {
 	widthText, heightText, ok := strings.Cut(dimensions, "x")
@@ -431,7 +441,14 @@ func (s *HTTPServer) serveTransformedAssetWithParams(c *gin.Context, req transfo
 	}
 
 	// Transform the image
-	result, err := assets.TransformImage(data, params.Width, params.Height, assets.FitMode(params.Fit))
+	var result *assets.TransformResult
+	if req.JPEGQuality > 0 {
+		result, err = assets.TransformImageWithOptions(data, params.Width, params.Height, assets.FitMode(params.Fit), assets.TransformOptions{
+			JPEGQuality: req.JPEGQuality,
+		})
+	} else {
+		result, err = assets.TransformImage(data, params.Width, params.Height, assets.FitMode(params.Fit))
+	}
 	if err != nil {
 		s.logger.Error("Failed to transform image", "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to transform image"})

--- a/cli/internal/http_server/assets_test.go
+++ b/cli/internal/http_server/assets_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-gonic/gin"
+	"hmans.de/chatto/internal/assets"
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/core"
 	"hmans.de/chatto/internal/email"
@@ -336,6 +337,69 @@ func TestAsset_TransformedImage_CacheHitMiss(t *testing.T) {
 	xCache := transformResp2.Header.Get("X-Cache")
 	if xCache != "HIT" {
 		t.Errorf("Expected X-Cache: HIT, got: %s", xCache)
+	}
+}
+
+func TestAsset_TransformedAttachmentUsesCompressedProfileAndVersionedCache(t *testing.T) {
+	env := setupAssetTestServer(t)
+
+	user, err := env.core.CreateUser(env.ctx, "system", "compressedimageuser", "Compressed Image User", "password123")
+	if err != nil {
+		t.Fatalf("Failed to create user: %v", err)
+	}
+	room, err := env.core.CreateRoom(env.ctx, user.Id, "channel", "", "compressed-images", "Compressed Images")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	if _, err := env.core.JoinRoom(env.ctx, user.Id, "channel", user.Id, room.Id); err != nil {
+		t.Fatalf("Failed to join room: %v", err)
+	}
+	env.login(t, "compressedimageuser", "password123")
+
+	imageData := createAssetTestPNG(t, 1200, 800)
+	_, attachment := env.postAssetMessageWithAttachment(t, room.Id, "compressed image", imageData, "compressed.png")
+	thumbnailURL := attachment.GetThumbnailAssetUrl().GetUrl()
+	if !strings.Contains(thumbnailURL, "/960x400/contain") {
+		t.Fatalf("thumbnail URL = %q, want 960x400 contain transform", thumbnailURL)
+	}
+	oldCacheKey := core.ImageCacheKey("attachment-stable", attachment.GetId(), 960, 400, "contain")
+	if err := env.core.StoreCachedResize(env.ctx, oldCacheKey, []byte("old-quality-cache-entry")); err != nil {
+		t.Fatalf("Failed to seed old attachment cache namespace: %v", err)
+	}
+
+	resp, err := env.client.Get(env.server.URL + thumbnailURL)
+	if err != nil {
+		t.Fatalf("Failed to get transformed attachment: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Expected 200 OK, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("X-Cache"); got != "MISS" {
+		t.Fatalf("X-Cache = %q, want MISS for old cache namespace", got)
+	}
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed to read transformed attachment: %v", err)
+	}
+
+	wantResult, err := assets.TransformImageWithOptions(imageData, 960, 400, assets.FitContain, assets.TransformOptions{
+		JPEGQuality: AttachmentDerivativeJPEGQuality,
+	})
+	if err != nil {
+		t.Fatalf("Failed to build expected transform: %v", err)
+	}
+	want, err := io.ReadAll(wantResult.Reader)
+	if err != nil {
+		t.Fatalf("Failed to read expected transform: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatal("attachment derivative did not use the compressed attachment profile")
+	}
+
+	cacheKey := core.ImageCacheKey(AttachmentStableCachePrefix, attachment.GetId(), 960, 400, "contain")
+	if !strings.HasPrefix(cacheKey, "attachment-stable-v2.") {
+		t.Fatalf("cache key = %q, want versioned attachment-stable-v2 prefix", cacheKey)
 	}
 }
 
@@ -909,7 +973,7 @@ func TestAsset_StableURLAcceptsAccessTicketAndBearerAuth(t *testing.T) {
 		t.Fatalf("Expected stable thumbnail request with access ticket to return 200, got %d", thumbResp.StatusCode)
 	}
 
-	mutatedThumbnailURL := strings.Replace(thumbnailURL, "960x800", "961x800", 1)
+	mutatedThumbnailURL := strings.Replace(thumbnailURL, "960x400", "961x400", 1)
 	if mutatedThumbnailURL == thumbnailURL {
 		t.Fatalf("Expected thumbnail URL to contain transform dimensions, got %q", thumbnailURL)
 	}
@@ -991,6 +1055,42 @@ func TestAsset_ServerAsset_HasCacheHeaders(t *testing.T) {
 	vary := resp.Header.Get("Vary")
 	if vary != "Accept-Encoding" {
 		t.Errorf("Expected Vary: Accept-Encoding, got: %s", vary)
+	}
+}
+
+func TestAsset_ServerAssetTransformKeepsDefaultQuality(t *testing.T) {
+	env := setupAssetTestServer(t)
+
+	imageData := createAssetTestPNG(t, 400, 300)
+	assetPath := "branding/default-quality.png"
+	if _, err := env.core.ServerStore().PutBytes(env.ctx, assetPath, imageData); err != nil {
+		t.Fatalf("Failed to store server asset: %v", err)
+	}
+
+	transformURL := env.core.GetTransformedServerAssetURL(assetPath, 200, 200, "contain")
+	resp, err := env.client.Get(env.server.URL + transformURL)
+	if err != nil {
+		t.Fatalf("Failed to get transformed server asset: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Expected 200 OK, got %d", resp.StatusCode)
+	}
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed to read transformed server asset: %v", err)
+	}
+
+	wantResult, err := assets.TransformImage(imageData, 200, 200, assets.FitContain)
+	if err != nil {
+		t.Fatalf("Failed to build expected server transform: %v", err)
+	}
+	want, err := io.ReadAll(wantResult.Reader)
+	if err != nil {
+		t.Fatalf("Failed to read expected server transform: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatal("server asset transform did not retain the default image quality")
 	}
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -687,12 +687,12 @@ Notes: Memory-based storage (not persisted, not backed up). Presence uses per-ke
 
 **ASSET_CACHE keys:**
 
-| Key                                       | Description                                  |
-| ----------------------------------------- | -------------------------------------------- |
-| `attachment.{attachmentId}.{paramsHash}`  | Cached WebP image at specific dimensions     |
-| `server.{assetId}.{paramsHash}`           | Cached WebP transform of a server asset      |
+| Key                                                  | Description                                      |
+| ---------------------------------------------------- | ------------------------------------------------ |
+| `attachment-stable-v2.{attachmentId}.{paramsHash}`   | Cached attachment derivative at specific bounds |
+| `server.{assetId}.{paramsHash}`                      | Cached transform of a server asset               |
 
-Notes: Only created when `[core.assets.cache]` is enabled in config. Uses TTL for automatic expiration (default 7 days). Current cache entries for deleted assets are also evicted from the active prefix (`attachment` or `server`) during binary cleanup. `paramsHash` is first 16 hex chars of SHA256(`{width}x{height}_{fit}`). Animated GIFs are not cached (served directly). S2 compression enabled.
+Notes: Only created when `[core.assets.cache]` is enabled in config. Uses TTL for automatic expiration (default 7 days). Current cache entries for deleted assets are also evicted from the active attachment or server prefix during binary cleanup. Attachment cache namespaces are versioned when encoding changes so older bytes are not reused. `paramsHash` is first 16 hex chars of SHA256(`{width}x{height}_{fit}`). S2 compression enabled.
 
 **SERVER\_ASSETS keys:**
 
@@ -768,6 +768,11 @@ URLs are signed with HMAC-SHA256 using a dedicated `signing_secret` (configured 
 
 `RoomService`, `MessageService.CreateMessage`, `MessageService` message read RPCs, `AssetService` asset read RPCs, and `RoomService.ListRoomAttachments` return `MessageAssetUrl` objects for attachment URLs and thumbnails, including the embedded access-ticket expiry so clients can use `AssetService` to refresh assets before lazy loads or media startup hit an expired ticket. Public server profile image fields intentionally return canonical asset URLs without arbitrary transform arguments so anonymous server discovery cannot mint unbounded resize variants.
 
+The bundled frontend requests 960×400 `contain` derivatives for room timeline
+images and separate 2048×2048 `contain` derivatives for the lightbox. The
+lightbox retains the original asset URL for its Open original action instead of
+using the display derivative as a download replacement.
+
 **Caching:**
 
 Transformed images are generated on-demand. Public server assets can be cached
@@ -781,7 +786,10 @@ ticket expiry and room-membership revocation must be checked on every fetch:
 
 **Output Format:**
 
-All transformed images are encoded as WebP for optimal compression and quality.
+Opaque static transforms are encoded as JPEG. Attachment derivatives use
+quality 75; server-scoped transforms retain the default quality 80.
+Transforms that need transparency, along with animated GIF transforms, use
+lossless WebP so their alpha or animation semantics are preserved.
 
 ### Messages
 

--- a/docs/fdr/FDR-008-file-attachments-and-video.md
+++ b/docs/fdr/FDR-008-file-attachments-and-video.md
@@ -1,7 +1,7 @@
 # FDR-008: File Attachments & Video Processing
 
 **Status:** Active
-**Last reviewed:** 2026-07-06
+**Last reviewed:** 2026-07-10
 
 ## Overview
 
@@ -15,11 +15,12 @@ Users can attach files to messages — images, videos, documents — via drag-an
 - Default upload size limits: 25 MB for general files, 100 MB for videos when video processing is enabled.
 - Video uploads require server-side video processing to be enabled. When it is disabled, the composer rejects `video/*` files immediately and the message-post API rejects them before storage.
 - Images are inspected for dimensions at upload time and can be resized at render time via URL parameters (width, height, fit mode). Public attachment and avatar APIs expose transform parameters; public server branding images expose canonical URLs only.
+- The room timeline loads attachment images within 960×400 bounds, while the lightbox loads a separate derivative within 2048×2048 bounds. The untouched upload remains available through Open original and file-download actions.
 - When enabled, videos and animated GIFs are processed by the current server process after asset creation and message submission scheduling. This is best-effort and intentionally simple until a real durable worker queue exists.
 - Processing status: durable STARTED / COMPLETED / FAILED outcomes are stored as asset aggregate events (`evt.asset.{assetId}.*`) and delivered through the normal live EVT subscription path after room-membership authorization. There is no separate `video_processed` live event or new runtime KV state for video progress; failed videos still show the original message, and the UI falls back to the original upload when it is available.
 - Processed video dimensions are display dimensions used for layout, not necessarily raw encoded storage pixels. Non-square-pixel and rotated sources should render in their intended orientation and aspect ratio. In the room timeline, ordinary posted landscape videos with near-square metadata are presented in a widescreen frame so common screen recordings do not appear as tall 4:3 embeds; converted animated GIF loops preserve their measured dimensions.
 - A thumbnail is generated from an early video frame using the same display dimensions, so non-square-pixel sources do not persist squished or pillarboxed poster images.
-- Resized images can be cached as WebP with an auto-expiring cache.
+- Opaque static attachment derivatives use JPEG quality 75. Derivatives that require transparency or animation use lossless WebP, and resized results can be held in the auto-expiring server cache.
 - Browser media uses direct signed asset URLs. Relative attachment URLs are resolved against the server that owns the message or room-file item, so remote-server images, audio, and video can load without cross-site cookies or bearer headers.
 - Clients refresh expiring attachment URL fields through room-scoped `AssetService.GetAsset` / `BatchGetAssets`, or by refetching the relevant timeline or room attachment-list page. The timeline, previews, lightbox, downloads, and room-files surfaces refresh before expiry and retry after media load errors.
 - Active document attachment types such as HTML, XHTML, SVG, and XML can still be uploaded and viewed inline, but original-file responses are delivered in a browser sandbox so uploaded scripts do not run as trusted Chatto application code.
@@ -80,6 +81,12 @@ Users can attach files to messages — images, videos, documents — via drag-an
 **Decision:** `Room.attachments` exposes a paginated list of current message attachments for a room. The read walks the visible room timeline projection, folds current message bodies, includes thread replies, preserves attachment order within each message, and sorts by newest message first.
 **Why:** Files should disappear from the sidebar when their message body is retracted or the attachment is removed. Deriving the list from the existing room/message projections keeps the panel consistent with the timeline without adding duplicate durable state.
 **Tradeoff:** There is no search or media filtering in this iteration. Clients page through the current list and refresh it after attachment-affecting live events.
+
+### 10. Displayed images use bounded derivatives
+
+**Decision:** Timeline images fit within 960×400 bounds and lightbox images fit within 2048×2048 bounds. Opaque static derivatives use JPEG quality 75, while transparency and animation continue to use lossless WebP. Original uploads remain unchanged and available separately.
+**Why:** Timeline frames are much smaller than typical camera and screenshot uploads, and even full-screen viewing rarely benefits from transferring the source resolution. Separate display sizes reduce bandwidth without sacrificing the original file-sharing behavior.
+**Tradeoff:** Opaque displayed images are lossy and capped in resolution. Transparent and animated images may see smaller savings because preserving their behavior requires lossless encoding.
 
 ## Permissions
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -17,7 +17,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-005](FDR-005-reactions.md) | Reactions | Active | 2026-05-19 |
 | [FDR-006](FDR-006-mentions.md) | @Mentions | Active | 2026-06-15 |
 | [FDR-007](FDR-007-direct-messages.md) | Direct Messages | Active | 2026-05-31 |
-| [FDR-008](FDR-008-file-attachments-and-video.md) | File Attachments & Video Processing | Active | 2026-07-06 |
+| [FDR-008](FDR-008-file-attachments-and-video.md) | File Attachments & Video Processing | Active | 2026-07-10 |
 | [FDR-009](FDR-009-link-previews.md) | Link Previews | Active | 2026-07-04 |
 | [FDR-010](FDR-010-typing-indicators.md) | Typing Indicators | Active | 2026-05-19 |
 | [FDR-011](FDR-011-user-presence.md) | User Presence | Active | 2026-06-23 |


### PR DESCRIPTION
## Summary

- Compresses opaque attachment derivatives at JPEG quality 75 and versions their internal cache while leaving public server transforms at quality 80.
- Uses 960×400 timeline derivatives and separate 2048×2048 lightbox derivatives while preserving untouched originals for opening and downloading.
- Updates FDR-008 and the architecture inventory, with expanded Go, component, URL-refresh, and browser coverage.
- Validated with `mise test-cli`, `mise test-frontend`, `mise lint-frontend`, the targeted Playwright lightbox test, Svelte analysis, and `mise license-check`.
