### PR TITLE
fix(notifications): harden delivery and synchronization

### DIFF
--- a/apps/frontend/src/lib/components/NotificationSync.svelte
+++ b/apps/frontend/src/lib/components/NotificationSync.svelte
@@ -26,9 +26,18 @@ Include this component once in the chat layout (unconditionally).
   import { RoomEventKind, roomEventKind } from '$lib/render/eventKinds';
   import { NotificationItemKind } from '$lib/api-client/notifications';
 
-  function notificationCreatedEvent(event: EventEnvelope['event']): { silent?: boolean } | null {
-    if (!event || !('silent' in event)) return null;
-    return { silent: event.silent === true };
+  function notificationCreatedEvent(
+    event: EventEnvelope['event']
+  ): { notificationId: string; silent?: boolean } | null {
+    if (
+      !event ||
+      !('notificationId' in event) ||
+      typeof event.notificationId !== 'string' ||
+      !('silent' in event)
+    ) {
+      return null;
+    }
+    return { notificationId: event.notificationId, silent: event.silent === true };
   }
 
   function notificationDismissedEvent(
@@ -62,7 +71,7 @@ Include this component once in the chat layout (unconditionally).
             const notification = notificationCreatedEvent(event.event);
             if (!notification) break;
             void Promise.allSettled([
-              notificationStore.addNotification(),
+              notificationStore.addNotification(notification.notificationId),
               stores.rooms.refreshNotificationCounts()
             ]);
             if (!notification.silent) {

--- a/apps/frontend/src/lib/components/NotificationSync.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/NotificationSync.svelte.spec.ts
@@ -132,6 +132,7 @@ describe('NotificationSync', () => {
     });
 
     expect(mocks.store.notifications.addNotification).toHaveBeenCalledOnce();
+    expect(mocks.store.notifications.addNotification).toHaveBeenCalledWith('n1');
     expect(mocks.store.rooms.refreshNotificationCounts).toHaveBeenCalledOnce();
     expect(mocks.store.rooms.incrementUnreadNotification).not.toHaveBeenCalled();
     expect(mocks.playNotificationSound).toHaveBeenCalledOnce();
@@ -150,6 +151,7 @@ describe('NotificationSync', () => {
     });
 
     expect(mocks.store.notifications.addNotification).toHaveBeenCalledOnce();
+    expect(mocks.store.notifications.addNotification).toHaveBeenCalledWith('n1');
     expect(mocks.store.rooms.refreshNotificationCounts).toHaveBeenCalledOnce();
     expect(mocks.playNotificationSound).not.toHaveBeenCalled();
   });

--- a/apps/frontend/src/lib/state/server/notifications.spec.ts
+++ b/apps/frontend/src/lib/state/server/notifications.spec.ts
@@ -30,12 +30,23 @@ function page(items: NotificationItem[], totalCount = items.length): Notificatio
   };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 function makeAPI(
   options: {
     notifications?: NotificationPage;
     roomNotifications?: NotificationPage;
     notificationsError?: Error;
     roomNotificationsError?: Error;
+    getNotification?: (
+      notificationId: string
+    ) => Promise<NotificationItem | null> | NotificationItem | null;
     dismissNotification?: (notificationId: string) => Promise<boolean> | boolean;
     dismissAllNotifications?: () => Promise<number> | number;
   } = {}
@@ -45,7 +56,11 @@ function makeAPI(
       if (options.notificationsError) throw options.notificationsError;
       return options.notifications ?? page([]);
     }),
-    getNotification: vi.fn().mockResolvedValue(null),
+    getNotification: vi
+      .fn()
+      .mockImplementation(async (notificationId: string) =>
+        options.getNotification ? options.getNotification(notificationId) : null
+      ),
     batchGetNotifications: vi.fn().mockResolvedValue([]),
     listRoomNotifications: vi.fn().mockImplementation(async () => {
       if (options.roomNotificationsError) throw options.roomNotificationsError;
@@ -100,6 +115,59 @@ describe('NotificationStore', () => {
     expect(store.notifications).toHaveLength(2);
     expect(store.error).toBeNull();
     expect(store.hasLoaded).toBe(true);
+  });
+
+  it('discards an older full-list response that arrives after a newer response', async () => {
+    const older = deferred<NotificationPage>();
+    const newer = deferred<NotificationPage>();
+    const api = makeAPI();
+    api.listNotifications.mockReturnValueOnce(older.promise).mockReturnValueOnce(newer.promise);
+    const store = new NotificationStore(api);
+
+    const olderFetch = store.fetch();
+    const newerFetch = store.fetch();
+
+    newer.resolve(page([mention('newer')]));
+    await newerFetch;
+    older.resolve(page([mention('older')]));
+    await olderFetch;
+
+    expect(store.notifications.map((notification) => notification.id)).toEqual(['newer']);
+  });
+
+  it('hydrates one realtime notification by ID without refetching the full list', async () => {
+    const liveNotification = mention('live');
+    const api = makeAPI({
+      getNotification: (notificationId) =>
+        notificationId === liveNotification.id ? liveNotification : null
+    });
+    const store = new NotificationStore(api);
+
+    await store.addNotification(liveNotification.id);
+    await store.addNotification(liveNotification.id);
+
+    expect(api.getNotification).toHaveBeenCalledTimes(2);
+    expect(api.listNotifications).not.toHaveBeenCalled();
+    expect(store.notifications.map((notification) => notification.id)).toEqual(['live']);
+    expect(store.unreadNotificationCount).toBe(1);
+  });
+
+  it('does not let an in-flight fetch restore an optimistically dismissed notification', async () => {
+    const response = deferred<NotificationPage>();
+    const api = makeAPI();
+    api.listNotifications.mockReturnValueOnce(response.promise);
+    const store = new NotificationStore(api);
+    store.notifications = [mention('dismiss-me')];
+    store.unreadNotificationCount = 1;
+
+    const fetch = store.fetch();
+    await store.dismiss('dismiss-me');
+    response.resolve(page([mention('dismiss-me')]));
+    await fetch;
+
+    expect(api.listNotifications).toHaveBeenCalledTimes(2);
+    expect(store.notifications).toEqual([]);
+    expect(store.unreadNotificationCount).toBe(0);
   });
 
   it('fetchRoomNotification returns the newest room-scoped notification and caches it', async () => {

--- a/apps/frontend/src/lib/state/server/notifications.svelte.ts
+++ b/apps/frontend/src/lib/state/server/notifications.svelte.ts
@@ -124,6 +124,7 @@ export function notificationTarget(n: NotificationItem): NotificationTarget {
 export class NotificationStore {
   #api: NotificationAPI;
   #locallyDismissedNotificationIds = new SvelteSet<string>();
+  #fetchGeneration = 0;
   notifications = $state<NotificationItem[]>([]);
   unreadNotificationCount = $state(0);
   loading = $state(false);
@@ -258,19 +259,29 @@ export class NotificationStore {
    * must not erase already-loaded notifications on others.
    */
   async fetch() {
+    const generation = ++this.#fetchGeneration;
     this.loading = true;
     this.error = null;
 
     try {
       const page = await this.#api.listNotifications(50);
-      this.notifications = page.items;
-      this.unreadNotificationCount = page.totalCount;
+      if (generation !== this.#fetchGeneration) return;
+
+      const notifications = page.items.filter(
+        (notification) => !this.#locallyDismissedNotificationIds.has(notification.id)
+      );
+      const locallyDismissedPageItems = page.items.length - notifications.length;
+      this.notifications = notifications;
+      this.unreadNotificationCount = Math.max(0, page.totalCount - locallyDismissedPageItems);
       this.hasLoaded = true;
     } catch (e) {
+      if (generation !== this.#fetchGeneration) return;
       this.error = e instanceof Error ? e.message : 'Failed to fetch notifications';
       console.error('Failed to fetch notifications:', e);
     } finally {
-      this.loading = false;
+      if (generation === this.#fetchGeneration) {
+        this.loading = false;
+      }
     }
   }
 
@@ -332,6 +343,7 @@ export class NotificationStore {
     const removed = this.notifications.find((n) => n.id === notificationId);
     if (!removed) return false;
 
+    this.#invalidateFetch();
     this.notifications = this.notifications.filter((n) => n.id !== notificationId);
     this.unreadNotificationCount = Math.max(0, this.unreadNotificationCount - 1);
     this.#markLocalDismissal(notificationId);
@@ -360,8 +372,9 @@ export class NotificationStore {
   async dismissAll(): Promise<number> {
     const original = this.notifications;
     const originalCount = this.unreadNotificationCount;
-    if (original.length === 0) return 0;
+    if (original.length === 0 && originalCount === 0) return 0;
 
+    this.#invalidateFetch();
     this.notifications = [];
     this.unreadNotificationCount = 0;
     for (const notification of original) {
@@ -377,6 +390,7 @@ export class NotificationStore {
       }
       this.notifications = original;
       this.unreadNotificationCount = originalCount;
+      await this.fetch();
       return 0;
     }
   }
@@ -389,11 +403,30 @@ export class NotificationStore {
     this.#upsertNotification(notification);
   }
 
-  #upsertNotification(notification: NotificationItem): void {
+  #upsertNotification(notification: NotificationItem): boolean {
+    const existed = this.notifications.some((candidate) => candidate.id === notification.id);
+    this.#invalidateFetch();
     this.notifications = [
       ...this.notifications.filter((n) => n.id !== notification.id),
       notification
-    ].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    ]
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+      .slice(0, 50);
+    return !existed;
+  }
+
+  #invalidateFetch(): void {
+    const shouldRestart = this.loading;
+    this.#fetchGeneration++;
+    this.loading = false;
+    if (shouldRestart) {
+      const invalidatedGeneration = this.#fetchGeneration;
+      queueMicrotask(() => {
+        if (this.#fetchGeneration === invalidatedGeneration && !this.loading) {
+          void this.fetch();
+        }
+      });
+    }
   }
 
   #markLocalDismissal(notificationId: string): void {
@@ -409,11 +442,26 @@ export class NotificationStore {
 
   /**
    * Add a notification (for real-time updates from instance events).
-   * Triggers a refetch to get full notification data.
+   * Hydrates the event's notification ID directly, with a full-list fallback
+   * for older or temporarily incompatible servers.
    */
-  async addNotification() {
-    // Refetch to get the new notification with full data
-    await this.fetch();
+  async addNotification(notificationId?: string) {
+    if (!notificationId) {
+      await this.fetch();
+      return;
+    }
+
+    try {
+      const notification = await this.#api.getNotification(notificationId);
+      if (!notification || this.#locallyDismissedNotificationIds.has(notificationId)) return;
+
+      if (this.#upsertNotification(notification)) {
+        this.unreadNotificationCount++;
+      }
+    } catch (e) {
+      console.error('Failed to hydrate notification:', e);
+      await this.fetch();
+    }
   }
 
   /**
@@ -421,6 +469,7 @@ export class NotificationStore {
    */
   removeNotification(notificationId: string) {
     const removed = this.notifications.find((n) => n.id === notificationId);
+    this.#invalidateFetch();
     this.notifications = this.notifications.filter((n) => n.id !== notificationId);
     if (removed) {
       this.unreadNotificationCount = Math.max(0, this.unreadNotificationCount - 1);

--- a/cli/internal/core/notifications.go
+++ b/cli/internal/core/notifications.go
@@ -180,9 +180,14 @@ func (c *ChattoCore) DismissNotification(ctx context.Context, userID, notificati
 		return false, fmt.Errorf("failed to unmarshal notification: %w", err)
 	}
 
-	// Delete
-	err = c.storage.runtimeStateKV.Delete(ctx, key)
-	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+	// Delete only the revision we fetched. Concurrent dismissals on another
+	// replica then become an idempotent no-op instead of publishing duplicate
+	// live events and push-dismiss callbacks.
+	err = c.storage.runtimeStateKV.Delete(ctx, key, jetstream.LastRevision(entry.Revision()))
+	if errors.Is(err, jetstream.ErrKeyExists) || errors.Is(err, jetstream.ErrKeyNotFound) {
+		return false, nil
+	}
+	if err != nil {
 		return false, fmt.Errorf("failed to delete notification: %w", err)
 	}
 
@@ -226,32 +231,37 @@ func (c *ChattoCore) DismissAllNotifications(ctx context.Context, userID string)
 		var notif *corev1.Notification
 		entry, err := c.storage.runtimeStateKV.Get(ctx, key)
 		if err != nil {
-			if !errors.Is(err, jetstream.ErrKeyNotFound) {
-				c.logger.Warn("Failed to get notification before dismissing", "key", key, "error", err)
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
 			}
-		} else {
-			var decoded corev1.Notification
-			if err := proto.Unmarshal(entry.Value(), &decoded); err != nil {
-				c.logger.Warn("Failed to unmarshal notification before dismissing", "key", key, "error", err)
-			} else {
-				notif = &decoded
-			}
+			return deleted, fmt.Errorf("failed to get notification before dismissing: %w", err)
 		}
 
-		if err := c.storage.runtimeStateKV.Delete(ctx, key); err != nil {
-			if !errors.Is(err, jetstream.ErrKeyNotFound) {
-				c.logger.Warn("Failed to delete notification", "key", key, "error", err)
+		var decoded corev1.Notification
+		if err := proto.Unmarshal(entry.Value(), &decoded); err != nil {
+			c.logger.Warn("Failed to unmarshal notification before dismissing", "key", key, "error", err)
+		} else {
+			notif = &decoded
+		}
+
+		if err := c.storage.runtimeStateKV.Delete(ctx, key, jetstream.LastRevision(entry.Revision())); err != nil {
+			if errors.Is(err, jetstream.ErrKeyExists) || errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
 			}
+			return deleted, fmt.Errorf("failed to delete notification: %w", err)
+		}
+
+		keyPrefix := notificationKeyPrefix + userID + "."
+		notificationID := strings.TrimPrefix(key, keyPrefix)
+		if notificationID == key {
+			return deleted, fmt.Errorf("invalid notification key %q", key)
+		}
+		if notificationID == "" {
 			continue
 		}
 		deleted++
 
-		// Extract notification ID from key and publish sync event
-		// Key format: notification.{userId}.{notificationId}
-		keyPrefix := notificationKeyPrefix + userID + "."
-		if notificationID := strings.TrimPrefix(key, keyPrefix); notificationID != key {
-			c.publishNotificationDismissedEvent(ctx, userID, notificationID)
-		}
+		c.publishNotificationDismissedEvent(ctx, userID, notificationID)
 
 		if notif != nil && c.OnNotificationDismissed != nil {
 			go c.OnNotificationDismissed(context.WithoutCancel(ctx), userID, notif)

--- a/cli/internal/core/notifications_test.go
+++ b/cli/internal/core/notifications_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -373,6 +374,69 @@ func TestDismissNotification(t *testing.T) {
 		}
 		if dismissed {
 			t.Error("Expected false when dismissing already dismissed notification")
+		}
+	})
+
+	t.Run("concurrent dismissals publish side effects once", func(t *testing.T) {
+		created, err := core.CreateNotification(ctx, userID, "actor", &corev1.Notification{
+			Notification: &corev1.Notification_DmMessage{
+				DmMessage: &corev1.DMMessageNotification{RoomId: "concurrent-dismiss"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("CreateNotification: %v", err)
+		}
+
+		callbacks := make(chan struct{}, 2)
+		core.OnNotificationDismissed = func(context.Context, string, *corev1.Notification) {
+			callbacks <- struct{}{}
+		}
+		t.Cleanup(func() { core.OnNotificationDismissed = nil })
+
+		const attempts = 8
+		start := make(chan struct{})
+		results := make(chan bool, attempts)
+		errs := make(chan error, attempts)
+		var wg sync.WaitGroup
+		wg.Add(attempts)
+		for range attempts {
+			go func() {
+				defer wg.Done()
+				<-start
+				dismissed, err := core.DismissNotification(ctx, userID, created.Id)
+				results <- dismissed
+				errs <- err
+			}()
+		}
+		close(start)
+		wg.Wait()
+		close(results)
+		close(errs)
+
+		for err := range errs {
+			if err != nil {
+				t.Fatalf("DismissNotification: %v", err)
+			}
+		}
+		dismissedCount := 0
+		for dismissed := range results {
+			if dismissed {
+				dismissedCount++
+			}
+		}
+		if dismissedCount != 1 {
+			t.Fatalf("successful dismissals = %d, want 1", dismissedCount)
+		}
+
+		select {
+		case <-callbacks:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for dismissal callback")
+		}
+		select {
+		case <-callbacks:
+			t.Fatal("dismissal callback ran more than once")
+		case <-time.After(100 * time.Millisecond):
 		}
 	})
 }

--- a/cli/internal/push/push.go
+++ b/cli/internal/push/push.go
@@ -9,8 +9,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"strings"
+	"sync"
+	"time"
 
 	webpush "github.com/SherClockHolmes/webpush-go"
 	"github.com/charmbracelet/log"
@@ -21,9 +24,10 @@ import (
 
 // Sender sends Web Push notifications.
 type Sender struct {
-	config     config.PushConfig
-	logger     *log.Logger
-	httpClient webpush.HTTPClient
+	config       config.PushConfig
+	logger       *log.Logger
+	httpClient   webpush.HTTPClient
+	requestSlots chan struct{}
 }
 
 const (
@@ -31,6 +35,8 @@ const (
 	maxPushProviderResponseBodyBytes            = 2048
 	truncatedPushProviderResponseBodyMsg        = "…"
 	declarativeWebPushValue                     = 8030
+	pushRequestTimeout                          = 10 * time.Second
+	maxConcurrentPushRequests                   = 16
 )
 
 // NewSender creates a new push notification sender.
@@ -40,8 +46,10 @@ func NewSender(cfg config.PushConfig, logger *log.Logger) *Sender {
 		return nil
 	}
 	return &Sender{
-		config: cfg,
-		logger: logger,
+		config:       cfg,
+		logger:       logger,
+		httpClient:   &http.Client{Timeout: pushRequestTimeout},
+		requestSlots: make(chan struct{}, maxConcurrentPushRequests),
 	}
 }
 
@@ -165,6 +173,19 @@ func (s *Sender) Send(ctx context.Context, sub *corev1.PushSubscription, payload
 	result := &SendResult{
 		Endpoint: sub.Endpoint,
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, pushRequestTimeout)
+	defer cancel()
+
+	select {
+	case s.requestSlots <- struct{}{}:
+		defer func() { <-s.requestSlots }()
+	case <-requestCtx.Done():
+		result.Error = requestCtx.Err()
+		return result
+	}
 
 	// Marshal payload to JSON
 	payloadJSON, err := json.Marshal(payload)
@@ -183,7 +204,7 @@ func (s *Sender) Send(ctx context.Context, sub *corev1.PushSubscription, payload
 	}
 
 	// Send the push notification
-	resp, err := webpush.SendNotification(payloadJSON, subscription, &webpush.Options{
+	resp, err := webpush.SendNotificationWithContext(requestCtx, payloadJSON, subscription, &webpush.Options{
 		Subscriber:      normalizeVAPIDSubject(s.config.VAPIDSubject),
 		VAPIDPublicKey:  s.config.VAPIDPublicKey,
 		VAPIDPrivateKey: s.config.VAPIDPrivateKey,
@@ -262,9 +283,27 @@ func EndpointLogID(endpoint string) string {
 // Returns results for each subscription.
 func (s *Sender) SendToMany(ctx context.Context, subscriptions []*corev1.PushSubscription, payload *Payload) []*SendResult {
 	results := make([]*SendResult, len(subscriptions))
-	for i, sub := range subscriptions {
-		results[i] = s.Send(ctx, sub, payload)
+	if len(subscriptions) == 0 {
+		return results
 	}
+
+	workerCount := min(len(subscriptions), maxConcurrentPushRequests)
+	jobs := make(chan int)
+	var workers sync.WaitGroup
+	workers.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer workers.Done()
+			for i := range jobs {
+				results[i] = s.Send(ctx, subscriptions[i], payload)
+			}
+		}()
+	}
+	for i := range subscriptions {
+		jobs <- i
+	}
+	close(jobs)
+	workers.Wait()
 	return results
 }
 

--- a/cli/internal/push/push_test.go
+++ b/cli/internal/push/push_test.go
@@ -6,12 +6,15 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	webpush "github.com/SherClockHolmes/webpush-go"
 	"github.com/charmbracelet/log"
@@ -20,6 +23,39 @@ import (
 	"hmans.de/chatto/internal/config"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
+
+type contextBlockingHTTPClient struct {
+	started chan struct{}
+}
+
+func (c *contextBlockingHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	close(c.started)
+	<-req.Context().Done()
+	return nil, req.Context().Err()
+}
+
+type concurrencyTrackingHTTPClient struct {
+	current atomic.Int32
+	maximum atomic.Int32
+	calls   atomic.Int32
+}
+
+func (c *concurrencyTrackingHTTPClient) Do(*http.Request) (*http.Response, error) {
+	current := c.current.Add(1)
+	c.calls.Add(1)
+	for {
+		maximum := c.maximum.Load()
+		if current <= maximum || c.maximum.CompareAndSwap(maximum, current) {
+			break
+		}
+	}
+	time.Sleep(5 * time.Millisecond)
+	c.current.Add(-1)
+	return &http.Response{
+		StatusCode: http.StatusCreated,
+		Body:       io.NopCloser(strings.NewReader("")),
+	}, nil
+}
 
 func TestNewSender(t *testing.T) {
 	logger := log.New(nil)
@@ -694,6 +730,33 @@ func TestSendResult(t *testing.T) {
 }
 
 func TestSend(t *testing.T) {
+	t.Run("cancels an in-flight provider request with the caller context", func(t *testing.T) {
+		client := &contextBlockingHTTPClient{started: make(chan struct{})}
+		sender := newTestSender(t, client)
+		subscription := newTestPushSubscription(t, "https://push.example.com/context")
+		ctx, cancel := context.WithCancel(context.Background())
+		resultCh := make(chan *SendResult, 1)
+
+		go func() {
+			resultCh <- sender.Send(ctx, subscription, &Payload{Title: "Test"})
+		}()
+		select {
+		case <-client.started:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for provider request")
+		}
+		cancel()
+
+		select {
+		case result := <-resultCh:
+			if !errors.Is(result.Error, context.Canceled) {
+				t.Fatalf("Send error = %v, want context.Canceled", result.Error)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("Send did not return after context cancellation")
+		}
+	})
+
 	t.Run("sends compact encrypted request", func(t *testing.T) {
 		var bodyLen int
 		var contentEncoding string
@@ -815,48 +878,36 @@ func TestSend(t *testing.T) {
 	})
 }
 
-// TestSendToMany tests the SendToMany method with invalid subscription material.
 func TestSendToMany(t *testing.T) {
-	// Create a mock push service that returns various statuses
-	callCount := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
-		switch callCount {
-		case 1:
-			w.WriteHeader(http.StatusCreated) // Success
-		case 2:
-			w.WriteHeader(http.StatusGone) // Subscription expired
-		case 3:
-			w.WriteHeader(http.StatusInternalServerError) // Server error
-		}
-	}))
-	defer server.Close()
+	client := &concurrencyTrackingHTTPClient{}
+	sender := newTestSender(t, client)
+	subscription := newTestPushSubscription(t, "https://push.example.com/many")
+	subscriptions := make([]*corev1.PushSubscription, maxConcurrentPushRequests*2)
+	for i := range subscriptions {
+		subscriptions[i] = subscription
+	}
 
-	t.Run("SendToMany returns results for each subscription", func(t *testing.T) {
-		logger := log.New(nil)
-		cfg := config.PushConfig{
-			Enabled:         true,
-			VAPIDPublicKey:  "BNJxJYL1iGKBrQaZHCbYoCHjFzHY3JLNbN6jl0GCvYpJxQKmJe_J6_yNKLlZj3xBLt0EZLsHx2XUcJDBj5vWVKY",
-			VAPIDPrivateKey: "LxZ3z5E3D3X3Y3Z3A3B3C3D3E3F3G3H3I3J3K3L3M3N",
-			VAPIDSubject:    "mailto:test@example.com",
-		}
-		sender := NewSender(cfg, logger)
-		if sender == nil {
-			t.Skip("Sender creation failed (expected with test keys)")
-		}
-
-		subscriptions := []*corev1.PushSubscription{
-			{Endpoint: server.URL + "/1", P256Dh: "key1", Auth: "auth1"},
-			{Endpoint: server.URL + "/2", P256Dh: "key2", Auth: "auth2"},
-		}
-		payload := &Payload{Title: "Test", Body: "Test body"}
-
-		results := sender.SendToMany(context.Background(), subscriptions, payload)
-
-		if len(results) != len(subscriptions) {
-			t.Errorf("Expected %d results, got %d", len(subscriptions), len(results))
-		}
+	results := sender.SendToMany(context.Background(), subscriptions, &Payload{
+		Title: "Test",
+		Body:  "Test body",
 	})
+
+	if len(results) != len(subscriptions) {
+		t.Fatalf("results = %d, want %d", len(results), len(subscriptions))
+	}
+	for i, result := range results {
+		if result == nil || !result.Success || result.Error != nil {
+			t.Fatalf("result[%d] = %+v, want success", i, result)
+		}
+	}
+	if got := int(client.calls.Load()); got != len(subscriptions) {
+		t.Fatalf("provider calls = %d, want %d", got, len(subscriptions))
+	}
+	if got := int(client.maximum.Load()); got > maxConcurrentPushRequests {
+		t.Fatalf("maximum concurrent requests = %d, want at most %d", got, maxConcurrentPushRequests)
+	} else if got < 2 {
+		t.Fatalf("maximum concurrent requests = %d, want concurrent fanout", got)
+	}
 }
 
 func newTestSender(t *testing.T, client webpush.HTTPClient) *Sender {


### PR DESCRIPTION
Hardens notification and Web Push delivery against stalled providers, concurrent dismissals, and stale frontend refreshes.
Push requests now honor cancellation, time out after 10 seconds, and fan out concurrently within a 16-request process-wide cap.
Notification dismissals use KV revision checks, while realtime clients hydrate notification IDs directly and guard canonical refreshes against out-of-order responses.
Validated with affected Go package tests, race-enabled notification and push tests, focused frontend suites, Svelte checks, ESLint, and `git diff --check`.
