### PR TITLE
fix(frontend): allow any file in attachment picker

### DIFF
--- a/apps/frontend/e2e/upload-config.test.ts
+++ b/apps/frontend/e2e/upload-config.test.ts
@@ -33,7 +33,7 @@ test.describe('upload configuration', () => {
     await chatPage.goto();
     await chatPage.enterRoom('general');
 
-    await expect(roomPage.fileInput).toHaveAttribute('accept', 'image/*,audio/*');
+    await expect(roomPage.fileInput).not.toHaveAttribute('accept');
     await roomPage.fileInput.setInputFiles('e2e/fixtures/test-video.mp4');
 
     await expect(page.getByText('Video uploads are disabled on this server.')).toBeVisible({

--- a/apps/frontend/src/lib/components/MessagePreviewCard.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/MessagePreviewCard.svelte.spec.ts
@@ -14,7 +14,9 @@ const { getRoomEventsAroundMock, timelineResults, refreshAssetUrlsMock } = vi.ho
   })
 );
 
-const transparentGif = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+function testImageUrl(label: string): string {
+  return `/icons/favicon.png?label=${label}`;
+}
 
 vi.mock('$lib/api-client/roomTimeline', () => ({
   createRoomTimelineAPI: vi.fn(() => ({
@@ -218,10 +220,8 @@ describe('MessagePreviewCard', () => {
   });
 
   it('refreshes attachment thumbnail asset URLs after image load failure', async () => {
-    timelineResults.push(previewResult(transparentGif));
-    refreshAssetUrlsMock.mockResolvedValueOnce(
-      refreshResult(`${transparentGif}#fresh-image`)
-    );
+    timelineResults.push(previewResult(testImageUrl('old-image')));
+    refreshAssetUrlsMock.mockResolvedValueOnce(refreshResult(testImageUrl('fresh-image')));
 
     const { container } = render(MessagePreviewCard, {
       props: { link: link(), showDismiss: false }
@@ -237,7 +237,7 @@ describe('MessagePreviewCard', () => {
 
     await vi.waitFor(() => {
       const refreshed = container.querySelector<HTMLImageElement>('img[alt="photo.jpg"]');
-      expect(refreshed?.getAttribute('src')).toContain('#fresh-image');
+      expect(refreshed?.getAttribute('src')).toContain('fresh-image');
     });
     expect(refreshAssetUrlsMock).toHaveBeenCalledWith('room_1', ['att_1'], {
       width: 120,
@@ -247,25 +247,29 @@ describe('MessagePreviewCard', () => {
   });
 
   it('clears stale preview thumbnail asset URLs when refresh returns null', async () => {
-    timelineResults.push(previewResult(`${transparentGif}#old-image`));
+    timelineResults.push(previewResult(testImageUrl('old-image')));
     refreshAssetUrlsMock.mockResolvedValueOnce(clearedRefreshResult('att_1'));
 
     const { container } = render(MessagePreviewCard, {
       props: { link: link(), showDismiss: false }
     });
 
-    await vi.waitFor(() => {
-      expect(refreshAssetUrlsMock).toHaveBeenCalled();
+    const img = await vi.waitFor(() => {
+      const current = container.querySelector<HTMLImageElement>('img[alt="photo.jpg"]');
+      expect(current).not.toBeNull();
+      return current!;
     });
+    img.dispatchEvent(new Event('error'));
 
     await vi.waitFor(() => {
+      expect(refreshAssetUrlsMock).toHaveBeenCalled();
       expect(container.querySelector('img[alt="photo.jpg"]')).toBeNull();
     });
     expect(container.textContent).toContain('Image');
   });
 
   it('renders video attachment thumbnails for linked message previews', async () => {
-    timelineResults.push(videoPreviewResult(`${transparentGif}#old-video`));
+    timelineResults.push(videoPreviewResult(testImageUrl('old-video')));
 
     const { container } = render(MessagePreviewCard, {
       props: { link: link(), showDismiss: false }
@@ -276,15 +280,13 @@ describe('MessagePreviewCard', () => {
     });
 
     const img = container.querySelector<HTMLImageElement>('img[alt="clip.mp4"]');
-    expect(img?.getAttribute('src')).toContain('#old-video');
+    expect(img?.getAttribute('src')).toContain('old-video');
     expect(container.querySelector('.uil--play')).not.toBeNull();
   });
 
   it('refreshes video attachment thumbnail asset URLs after image load failure', async () => {
-    timelineResults.push(videoPreviewResult(`${transparentGif}#old-video`));
-    refreshAssetUrlsMock.mockResolvedValueOnce(
-      videoRefreshResult(`${transparentGif}#fresh-video`)
-    );
+    timelineResults.push(videoPreviewResult(testImageUrl('old-video')));
+    refreshAssetUrlsMock.mockResolvedValueOnce(videoRefreshResult(testImageUrl('fresh-video')));
 
     const { container } = render(MessagePreviewCard, {
       props: { link: link(), showDismiss: false }
@@ -300,33 +302,35 @@ describe('MessagePreviewCard', () => {
 
     await vi.waitFor(() => {
       const refreshed = container.querySelector<HTMLImageElement>('img[alt="clip.mp4"]');
-      expect(refreshed?.getAttribute('src')).toContain('#fresh-video');
+      expect(refreshed?.getAttribute('src')).toContain('fresh-video');
     });
   });
 
   it('clears stale preview video thumbnail asset URLs when refresh returns null', async () => {
-    timelineResults.push(videoPreviewResult(`${transparentGif}#old-video`));
+    timelineResults.push(videoPreviewResult(testImageUrl('old-video')));
     refreshAssetUrlsMock.mockResolvedValueOnce(clearedRefreshResult('att_video'));
 
     const { container } = render(MessagePreviewCard, {
       props: { link: link(), showDismiss: false }
     });
 
-    await vi.waitFor(() => {
-      expect(refreshAssetUrlsMock).toHaveBeenCalled();
+    const img = await vi.waitFor(() => {
+      const current = container.querySelector<HTMLImageElement>('img[alt="clip.mp4"]');
+      expect(current).not.toBeNull();
+      return current!;
     });
+    img.dispatchEvent(new Event('error'));
 
     await vi.waitFor(() => {
+      expect(refreshAssetUrlsMock).toHaveBeenCalled();
       expect(container.querySelector('img[alt="clip.mp4"]')).toBeNull();
     });
     expect(container.querySelector('.uil--play')).not.toBeNull();
   });
 
   it('falls back to a video tile when the refreshed video thumbnail also fails', async () => {
-    timelineResults.push(videoPreviewResult(`${transparentGif}#old-video`));
-    refreshAssetUrlsMock.mockResolvedValueOnce(
-      videoRefreshResult(`${transparentGif}#fresh-video`)
-    );
+    timelineResults.push(videoPreviewResult(testImageUrl('old-video')));
+    refreshAssetUrlsMock.mockResolvedValueOnce(videoRefreshResult(testImageUrl('fresh-video')));
 
     const { container } = render(MessagePreviewCard, {
       props: { link: link(), showDismiss: false }
@@ -342,7 +346,7 @@ describe('MessagePreviewCard', () => {
 
     await vi.waitFor(() => {
       expect(container.querySelector<HTMLImageElement>('img[alt="clip.mp4"]')?.src).toContain(
-        '#fresh-video'
+        'fresh-video'
       );
     });
 

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -894,7 +894,10 @@
               <span class="iconify text-lg text-muted uil--music"></span>
             </div>
           {:else}
-            <div class="flex h-16 w-16 items-center justify-center rounded-md bg-surface-200">
+            <div
+              data-testid="file-attachment-preview"
+              class="flex h-16 w-16 items-center justify-center rounded-md bg-surface-200"
+            >
               <span class="text-xs text-muted">{file.name.split('.').pop()}</span>
             </div>
           {/if}
@@ -915,7 +918,6 @@
     <input
       bind:this={fileInputElement}
       type="file"
-      accept={attachments.accept}
       multiple
       onchange={handleFileSelect}
       class="hidden"

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -431,21 +431,21 @@ describe('MessageComposer', () => {
   });
 
   describe('file input configuration', () => {
-    it('accepts image and audio files when video processing is disabled', async () => {
+    it('allows selecting any file type', async () => {
       const { container } = renderMessageComposer({ roomId: 'room_456' });
 
-      await expect
-        .element(q(container, 'input[type="file"]'))
-        .toHaveAttribute('accept', 'image/*,audio/*');
+      await expect.element(q(container, 'input[type="file"]')).not.toHaveAttribute('accept');
     });
 
-    it('accepts image, video, and audio files when video processing is enabled', async () => {
-      mockInstanceStores.serverInfo.videoProcessingEnabled = true;
+    it('stages selected document files', async () => {
       const { container } = renderMessageComposer({ roomId: 'room_456' });
+      const input = q(container, 'input[type="file"]') as HTMLInputElement;
+
+      selectFiles(input, [new File(['document'], 'report.pdf', { type: 'application/pdf' })]);
 
       await expect
-        .element(q(container, 'input[type="file"]'))
-        .toHaveAttribute('accept', 'image/*,video/*,audio/*');
+        .poll(() => q(container, '[data-testid="file-attachment-preview"]')?.textContent)
+        .toBe('pdf');
     });
 
     it('allows multiple file selection', async () => {

--- a/apps/frontend/src/lib/components/composer/attachments.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/attachments.svelte.spec.ts
@@ -16,6 +16,10 @@ function videoFile(name = 'clip.mp4', bytes = 3): File {
   return new File([new Uint8Array(bytes)], name, { type: 'video/mp4' });
 }
 
+function documentFile(name = 'document.pdf', bytes = 3): File {
+  return new File([new Uint8Array(bytes)], name, { type: 'application/pdf' });
+}
+
 describe('AttachmentsState', () => {
   let limits: AttachmentLimits;
   let state: AttachmentsState;
@@ -40,12 +44,12 @@ describe('AttachmentsState', () => {
     });
   });
 
-  it('reflects whether video uploads are accepted', () => {
-    expect(state.accept).toBe('image/*,audio/*');
+  it('accepts non-media files', async () => {
+    const file = documentFile();
 
-    limits.videoProcessingEnabled = true;
+    await state.stageFiles([file]);
 
-    expect(state.accept).toBe('image/*,video/*,audio/*');
+    expect(state.selectedFiles).toEqual([file]);
   });
 
   it('stages prepared files and appends subsequent files', async () => {

--- a/apps/frontend/src/lib/components/composer/attachments.svelte.ts
+++ b/apps/frontend/src/lib/components/composer/attachments.svelte.ts
@@ -25,10 +25,6 @@ export class AttachmentsState {
     return this.filesWithUrls.map((f) => f.file);
   }
 
-  get accept(): string {
-    return this.getLimits().videoProcessingEnabled ? 'image/*,video/*,audio/*' : 'image/*,audio/*';
-  }
-
   restore(files: FileWithUrl[]): void {
     this.filesWithUrls = files;
   }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
@@ -382,12 +382,16 @@
   }
 
   async function refreshLightboxUrls(): Promise<Map<string, RefreshedAttachmentUrls>> {
-    return refreshAttachmentUrlsForAssets(
+    const freshUrls = await refreshAttachmentUrlsForAssets(
       currentAttachmentAPI(),
       roomId,
       imageAttachments.map((attachment) => attachment.id),
       LIGHTBOX_ATTACHMENT_IMAGE_REFRESH
     );
+    if (freshUrls.size > 0) {
+      refreshedAttachmentUrls = mergeRefreshedAttachmentUrls(refreshedAttachmentUrls, freshUrls);
+    }
+    return freshUrls;
   }
 
   async function openImageModal(attachment: Attachment) {


### PR DESCRIPTION
## Summary

The message composer incorrectly restricted the native file picker to media types even though Chatto supports arbitrary file attachments.
This removes the picker filter while preserving video-processing and upload-size validation, and adds coverage for staging document files and rendering their generic preview.
Avatar, server-branding, and drag-and-drop filters remain unchanged.

## Tests

- `mise test-frontend` (1,814 tests)
- `mise x -- pnpm exec playwright test e2e/upload-config.test.ts --retries=0`
- Svelte autofixer (no issues)
