### PR TITLE
fix(api): skip invalid followed-thread rooms

### DIFF
--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -7170,6 +7170,61 @@ func TestThreadServiceListFollowedThreadsFiltersMembershipLoss(t *testing.T) {
 	}
 }
 
+func TestThreadServiceListFollowedThreadsFiltersOtherRoomKinds(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	participant, err := env.core.CreateUser(env.ctx, core.SystemActorID, "thread-dm-participant", "Thread DM Participant", "password")
+	if err != nil {
+		t.Fatalf("CreateUser participant: %v", err)
+	}
+	dm, _, err := env.core.FindOrCreateDM(env.ctx, env.viewer.Id, []string{participant.Id})
+	if err != nil {
+		t.Fatalf("FindOrCreateDM: %v", err)
+	}
+	root, err := env.core.PostMessage(env.ctx, core.KindDM, dm.Id, env.viewer.Id, "root body", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage root: %v", err)
+	}
+	if _, err := env.core.PostMessage(env.ctx, core.KindDM, dm.Id, participant.Id, "reply body", nil, root.Id, "", nil, false); err != nil {
+		t.Fatalf("PostMessage reply: %v", err)
+	}
+	if err := env.core.FollowThread(env.ctx, core.KindDM, env.viewer.Id, dm.Id, root.Id); err != nil {
+		t.Fatalf("FollowThread: %v", err)
+	}
+
+	resp, err := env.threads.ListFollowedThreads(withCaller(env.ctx, env.viewer), connect.NewRequest(&apiv1.ListFollowedThreadsRequest{
+		Page: &apiv1.PageRequest{Limit: 20},
+	}))
+	if err != nil {
+		t.Fatalf("ListFollowedThreads: %v", err)
+	}
+	if got := len(resp.Msg.GetThreads()); got != 0 {
+		t.Fatalf("ListFollowedThreads returned %d DM threads in the channel list, want 0", got)
+	}
+	if resp.Msg.GetPage().GetTotalCount() != 0 || resp.Msg.GetPage().GetHasMore() {
+		t.Fatalf("ListFollowedThreads page metadata = total %d hasMore %v, want total 0 hasMore false", resp.Msg.GetPage().GetTotalCount(), resp.Msg.GetPage().GetHasMore())
+	}
+}
+
+func TestFollowedThreadsResponseOmitsUnavailableRooms(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	page := &core.FollowedThreadsPage{
+		Threads: []*core.FollowedThread{{
+			SpaceID:           core.LegacySpaceIDForRoomKind(core.KindChannel),
+			RoomID:            "missing-room",
+			ThreadRootEventID: "missing-root",
+		}},
+		TotalCount: 1,
+	}
+
+	resp, err := newThreadAssembler(env.api).followedThreadsResponse(env.ctx, env.viewer.Id, page)
+	if err != nil {
+		t.Fatalf("followedThreadsResponse: %v", err)
+	}
+	if got := len(resp.GetThreads()); got != 0 {
+		t.Fatalf("followedThreadsResponse returned %d unavailable threads, want 0", got)
+	}
+}
+
 func TestNotificationLevelMapping(t *testing.T) {
 	valid := []struct {
 		name string

--- a/cli/internal/connectapi/thread_assembler.go
+++ b/cli/internal/connectapi/thread_assembler.go
@@ -2,7 +2,9 @@ package connectapi
 
 import (
 	"context"
+	"errors"
 
+	"github.com/nats-io/nats.go/jetstream"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"hmans.de/chatto/internal/core"
 	"hmans.de/chatto/internal/parallel"
@@ -53,6 +55,11 @@ func (a *threadAssembler) followedThreadsResponse(ctx context.Context, viewerID 
 		kind := core.RoomKindFromLegacySpaceID(thread.SpaceID)
 		room, err := a.api.core.GetRoom(ctx, kind, thread.RoomID)
 		if err != nil {
+			// List responses omit resources that disappear between the core page
+			// snapshot and response hydration instead of failing the whole page.
+			if errors.Is(err, core.ErrNotFound) || errors.Is(err, jetstream.ErrKeyNotFound) || errors.Is(err, jetstream.ErrKeyDeleted) {
+				return nil, nil
+			}
 			return nil, err
 		}
 

--- a/cli/internal/core/threads.go
+++ b/cli/internal/core/threads.go
@@ -871,6 +871,15 @@ func (c *ChattoCore) listFollowedThreadsInSpace(ctx context.Context, userID stri
 		roomID := ref.roomID
 		threadRootEventID := ref.threadRootEventID
 
+		room, err := c.FindRoomByID(ctx, roomID)
+		if err != nil {
+			c.logger.Warn("Skipping followed thread with unavailable room", "error", err, "room_id", roomID, "thread_root_event_id", threadRootEventID)
+			continue
+		}
+		if KindOfRoom(room) != kind {
+			continue
+		}
+
 		following, err := c.IsFollowingThread(ctx, kind, userID, roomID, threadRootEventID)
 		if err != nil {
 			c.logger.Warn("Failed to check thread follow state while listing", "error", err, "room_id", roomID, "thread_root_event_id", threadRootEventID)


### PR DESCRIPTION
## Summary

- Resolve each followed-thread room before pagination and filter references whose actual room kind does not match the requested list.
- Skip stale references to rooms that no longer exist instead of returning an error for the entire page.
- Tolerate rooms disappearing between core pagination and ConnectRPC response hydration.
- Add regression coverage for followed DM references leaking into the channel list and unavailable rooms during hydration.

## Root cause

Legacy thread-follow records do not encode the room kind. An explicit DM membership could therefore let a DM thread reference enter the channel-thread page. Response hydration then looked up that room as a channel and returned `room not found: nats: key not found`, causing My Threads to fail completely.

## Impact

My Threads now returns the valid channel threads available to the viewer even when their stored follow state includes wrong-kind or stale room references.

## Validation

- `mise x -- go test ./internal/connectapi ./internal/core -count=1 -timeout 5m`
