### PR TITLE
fix(pwa): use server logo for install icons

### DIFF
--- a/apps/frontend/src/lib/pwa/serviceWorkerPolicy.spec.ts
+++ b/apps/frontend/src/lib/pwa/serviceWorkerPolicy.spec.ts
@@ -27,14 +27,21 @@ function classify(pathOrUrl: string, method = 'GET', mode: RequestMode = 'same-o
 
 describe('classifyServiceWorkerRequest', () => {
   it('marks same-origin app shell assets as cacheable', () => {
-    expect(classify('/manifest.webmanifest')).toEqual({
+    expect(classify('/icons/icon-192.png')).toMatchObject({
       cacheableShellAsset: true,
-      navigationRequest: false,
       networkOnly: false
     });
     expect(classify('/_app/immutable/app.js')).toMatchObject({
       cacheableShellAsset: true,
       networkOnly: false
+    });
+  });
+
+  it('keeps the web manifest network-only because server branding can change it', () => {
+    expect(classify('/manifest.webmanifest')).toEqual({
+      cacheableShellAsset: false,
+      navigationRequest: false,
+      networkOnly: true
     });
   });
 
@@ -44,16 +51,13 @@ describe('classifyServiceWorkerRequest', () => {
     '/oauth/authorize',
     '/assets/avatar.png',
     '/webhooks/livekit'
-  ])(
-    'keeps %s network-only',
-    (path) => {
-      expect(classify(path)).toMatchObject({
-        cacheableShellAsset: false,
-        navigationRequest: false,
-        networkOnly: true
-      });
-    }
-  );
+  ])('keeps %s network-only', (path) => {
+    expect(classify(path)).toMatchObject({
+      cacheableShellAsset: false,
+      navigationRequest: false,
+      networkOnly: true
+    });
+  });
 
   it('keeps cross-origin and non-GET requests network-only', () => {
     expect(classify('https://other.example/manifest.webmanifest')).toMatchObject({

--- a/apps/frontend/src/lib/pwa/serviceWorkerPolicy.ts
+++ b/apps/frontend/src/lib/pwa/serviceWorkerPolicy.ts
@@ -1,5 +1,6 @@
 export const OFFLINE_SHELL_PATH = '/200.html';
 
+const NETWORK_ONLY_PATHS = ['/manifest.webmanifest'];
 const NETWORK_ONLY_PREFIXES = ['/api', '/auth', '/oauth', '/assets', '/webhooks'];
 
 export interface ServiceWorkerPolicy {
@@ -28,6 +29,7 @@ export function classifyServiceWorkerRequest(
   const networkOnly =
     request.method !== 'GET' ||
     !sameOrigin ||
+    NETWORK_ONLY_PATHS.includes(url.pathname) ||
     NETWORK_ONLY_PREFIXES.some(
       (prefix) => url.pathname === prefix || url.pathname.startsWith(`${prefix}/`)
     );

--- a/cli/internal/http_server/frontend.go
+++ b/cli/internal/http_server/frontend.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"crypto/sha256"
 	"embed"
+	"encoding/json"
 	"fmt"
+	"html"
 	"io/fs"
 	"mime"
 	"net/http"
@@ -32,6 +34,14 @@ const (
 	// violations during development/staging before we consider enforcement.
 	contentSecurityPolicyReportOnly = "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: http: https:; media-src 'self' blob: http: https:; connect-src 'self' http: https: ws: wss:; frame-src https://www.youtube-nocookie.com; worker-src 'self'; require-trusted-types-for 'script'; trusted-types chatto-markdown-html"
 )
+
+const defaultAppleTouchIconHref = "/icons/apple-touch-icon.png"
+
+type pwaServerIconURLs struct {
+	AppleTouch180 string
+	Icon192       string
+	Icon512       string
+}
 
 func setFrontendSecurityHeaders(c *gin.Context) {
 	c.Header("X-Content-Type-Options", "nosniff")
@@ -115,6 +125,79 @@ func setFrontendCacheHeaders(c *gin.Context) {
 	c.Next()
 }
 
+func (s *HTTPServer) currentPWAIconURLs(ctx context.Context) *pwaServerIconURLs {
+	if s.core == nil {
+		return nil
+	}
+
+	sizeURL := func(size int) string {
+		width, height := size, size
+		url, err := s.core.GetServerLogoURL(ctx, &width, &height, "cover")
+		if err != nil {
+			s.logger.Warn("failed to get server logo URL for PWA metadata", "error", err, "size", size)
+			return ""
+		}
+		return url
+	}
+
+	icons := &pwaServerIconURLs{
+		AppleTouch180: sizeURL(180),
+		Icon192:       sizeURL(192),
+		Icon512:       sizeURL(512),
+	}
+	if icons.AppleTouch180 == "" || icons.Icon192 == "" || icons.Icon512 == "" {
+		return nil
+	}
+	return icons
+}
+
+func pwaManifestIcons(icon192, icon512 string) []map[string]string {
+	return []map[string]string{
+		{"src": icon192, "sizes": "192x192"},
+		{"src": icon512, "sizes": "512x512"},
+		{"src": icon192, "sizes": "192x192", "purpose": "maskable"},
+		{"src": icon512, "sizes": "512x512", "purpose": "maskable"},
+	}
+}
+
+func dynamicPWAManifest(staticManifest []byte, icons *pwaServerIconURLs) ([]byte, error) {
+	if icons == nil {
+		return staticManifest, nil
+	}
+
+	var manifest map[string]any
+	if err := json.Unmarshal(staticManifest, &manifest); err != nil {
+		return nil, err
+	}
+
+	manifest["icons"] = pwaManifestIcons(icons.Icon192, icons.Icon512)
+	if shortcuts, ok := manifest["shortcuts"].([]any); ok {
+		for _, shortcut := range shortcuts {
+			shortcutMap, ok := shortcut.(map[string]any)
+			if !ok {
+				continue
+			}
+			shortcutMap["icons"] = []map[string]string{
+				{"src": icons.Icon192, "sizes": "192x192"},
+			}
+		}
+	}
+
+	return json.MarshalIndent(manifest, "", "  ")
+}
+
+func injectAppleTouchIcon(content []byte, iconURL string) []byte {
+	if iconURL == "" {
+		return content
+	}
+	escaped := html.EscapeString(iconURL)
+	return []byte(strings.ReplaceAll(
+		string(content),
+		`href="`+defaultAppleTouchIconHref+`"`,
+		`href="`+escaped+`"`,
+	))
+}
+
 // clientAcceptsEncoding checks if the client accepts a specific encoding.
 // It parses the Accept-Encoding header and looks for the encoding name.
 func clientAcceptsEncoding(acceptEncoding, encoding string) bool {
@@ -149,9 +232,27 @@ func (s *HTTPServer) serveSPAFallback(c *gin.Context, clientFS fs.FS) bool {
 	defer cancel()
 
 	content = s.injectOpenGraphTags(ctx, content, c.Request.URL.Path)
+	if icons := s.currentPWAIconURLs(ctx); icons != nil {
+		content = injectAppleTouchIcon(content, icons.AppleTouch180)
+	}
 
 	c.Data(http.StatusOK, "text/html; charset=utf-8", content)
 	return true
+}
+
+func (s *HTTPServer) servePWAWebManifest(c *gin.Context, clientFS fs.FS) {
+	content, err := fs.ReadFile(clientFS, "manifest.webmanifest")
+	if err != nil {
+		c.Status(http.StatusInternalServerError)
+		return
+	}
+	content, err = dynamicPWAManifest(content, s.currentPWAIconURLs(c.Request.Context()))
+	if err != nil {
+		s.logger.Warn("failed to generate dynamic PWA manifest", "error", err)
+		c.Status(http.StatusInternalServerError)
+		return
+	}
+	c.Data(http.StatusOK, "application/manifest+json", content)
 }
 
 // servePrecompressedFile attempts to serve a precompressed version of a file.
@@ -274,6 +375,11 @@ func (s *HTTPServer) setupFrontendRoutes() error {
 			if setServiceWorkerETag(c, content) {
 				return
 			}
+		}
+
+		if filePath == "manifest.webmanifest" {
+			s.servePWAWebManifest(c, clientFS)
+			return
 		}
 
 		// Try to serve precompressed version first

--- a/cli/internal/http_server/frontend_test.go
+++ b/cli/internal/http_server/frontend_test.go
@@ -1,17 +1,23 @@
 package http_server
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"hmans.de/chatto/internal/config"
+	"hmans.de/chatto/internal/core"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+	"hmans.de/chatto/internal/testutil"
 )
 
 func TestExtractImmutableETag(t *testing.T) {
@@ -182,6 +188,67 @@ func TestServiceWorkerETag(t *testing.T) {
 	})
 }
 
+func TestDynamicPWAManifest(t *testing.T) {
+	staticManifest := []byte(`{
+  "name": "Chatto",
+  "icons": [
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" }
+  ],
+  "shortcuts": [
+    {
+      "name": "Open Chatto",
+      "icons": [{ "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" }]
+    }
+  ]
+}`)
+
+	t.Run("keeps static manifest when no server logo is available", func(t *testing.T) {
+		got, err := dynamicPWAManifest(staticManifest, nil)
+		if err != nil {
+			t.Fatalf("dynamicPWAManifest: %v", err)
+		}
+		assert.Equal(t, string(staticManifest), string(got))
+	})
+
+	t.Run("replaces install and shortcut icons with server logo URLs", func(t *testing.T) {
+		got, err := dynamicPWAManifest(staticManifest, &pwaServerIconURLs{
+			Icon192: "/assets/server/logo/t/192",
+			Icon512: "/assets/server/logo/t/512",
+		})
+		if err != nil {
+			t.Fatalf("dynamicPWAManifest: %v", err)
+		}
+
+		var manifest map[string]any
+		if err := json.Unmarshal(got, &manifest); err != nil {
+			t.Fatalf("unmarshal manifest: %v", err)
+		}
+
+		icons := manifest["icons"].([]any)
+		assert.Len(t, icons, 4)
+		assert.Equal(t, "/assets/server/logo/t/192", icons[0].(map[string]any)["src"])
+		assert.Equal(t, "192x192", icons[0].(map[string]any)["sizes"])
+		assert.Nil(t, icons[0].(map[string]any)["type"])
+		assert.Equal(t, "/assets/server/logo/t/512", icons[1].(map[string]any)["src"])
+		assert.Equal(t, "maskable", icons[2].(map[string]any)["purpose"])
+
+		shortcuts := manifest["shortcuts"].([]any)
+		shortcutIcons := shortcuts[0].(map[string]any)["icons"].([]any)
+		assert.Equal(t, "/assets/server/logo/t/192", shortcutIcons[0].(map[string]any)["src"])
+		assert.Nil(t, shortcutIcons[0].(map[string]any)["type"])
+	})
+}
+
+func TestInjectAppleTouchIcon(t *testing.T) {
+	content := []byte(`<link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" />`)
+
+	got := injectAppleTouchIcon(content, "/assets/server/logo/t/180?a=1&b=2")
+
+	assert.Contains(t, string(got), `href="/assets/server/logo/t/180?a=1&amp;b=2"`)
+	assert.NotContains(t, string(got), defaultAppleTouchIconHref)
+}
+
 func TestClientAcceptsEncoding(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -299,6 +366,29 @@ func TestServeSPAFallback(t *testing.T) {
 		assert.NotContains(t, w.Body.String(), "OG_META_PLACEHOLDER")
 	})
 
+	t.Run("injects server logo apple touch icon when server logo exists", func(t *testing.T) {
+		mockFS := fstest.MapFS{
+			"200.html": &fstest.MapFile{
+				Data: []byte(`<!DOCTYPE html><html><head><!-- OG_META_PLACEHOLDER --><link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" /></head><body>SPA</body></html>`),
+			},
+		}
+
+		server := newTestServer()
+		server.core = setupFrontendTestCoreWithLogo(t)
+		router := gin.New()
+		router.GET("/test", func(c *gin.Context) {
+			server.serveSPAFallback(c, mockFS)
+		})
+
+		req := httptest.NewRequest("GET", "/test", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), `href="/assets/server/logo-asset/t/`)
+		assert.NotContains(t, w.Body.String(), defaultAppleTouchIconHref)
+	})
+
 	t.Run("returns 500 when 200.html is missing", func(t *testing.T) {
 		// Empty filesystem - no 200.html
 		mockFS := fstest.MapFS{}
@@ -316,6 +406,46 @@ func TestServeSPAFallback(t *testing.T) {
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
 		assert.Equal(t, "Failed to load application", w.Body.String())
 	})
+}
+
+func TestServePWAWebManifestUsesServerLogoWhenAvailable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mockFS := fstest.MapFS{
+		"manifest.webmanifest": &fstest.MapFile{
+			Data: []byte(`{
+  "name": "Chatto",
+  "icons": [{ "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" }],
+  "shortcuts": [
+    { "name": "Open Chatto", "icons": [{ "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" }] }
+  ]
+}`),
+		},
+	}
+	server := &HTTPServer{
+		config: config.ChattoConfig{Webserver: config.WebserverConfig{URL: "https://example.com"}},
+		core:   setupFrontendTestCoreWithLogo(t),
+		router: gin.New(),
+	}
+	server.router.GET("/manifest.webmanifest", func(c *gin.Context) {
+		server.servePWAWebManifest(c, mockFS)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/manifest.webmanifest", nil)
+	w := httptest.NewRecorder()
+	server.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/manifest+json", w.Header().Get("Content-Type"))
+
+	var manifest map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &manifest); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	icons := manifest["icons"].([]any)
+	assert.True(t, strings.HasPrefix(icons[0].(map[string]any)["src"].(string), "/assets/server/logo-asset/t/"))
+	assert.Equal(t, "192x192", icons[0].(map[string]any)["sizes"])
+	assert.Nil(t, icons[0].(map[string]any)["type"])
 }
 
 func TestFrontendFallbackDoesNotServeReservedBackendPrefixes(t *testing.T) {
@@ -346,6 +476,36 @@ func TestFrontendFallbackDoesNotServeReservedBackendPrefixes(t *testing.T) {
 			assert.NotContains(t, w.Body.String(), "<!DOCTYPE html>")
 		})
 	}
+}
+
+func setupFrontendTestCoreWithLogo(t *testing.T) *core.ChattoCore {
+	t.Helper()
+
+	_, nc := testutil.StartSharedNATS(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	chattoCore, err := core.NewChattoCore(ctx, nc, config.CoreConfig{
+		SecretKey: "test-core-secret",
+		Assets: config.AssetsConfig{
+			SigningSecret: "test-signing-secret",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewChattoCore: %v", err)
+	}
+	startCoreServices(t, chattoCore)
+
+	logo := &corev1.AssetRecord{
+		Id:          "logo-asset",
+		Filename:    "logo.webp",
+		ContentType: "image/webp",
+		Storage:     &corev1.AssetRecord_Nats{Nats: &corev1.NATSAsset{Key: "logo-asset"}},
+	}
+	if err := chattoCore.SetServerLogo(ctx, core.SystemActorID, logo); err != nil {
+		t.Fatalf("SetServerLogo: %v", err)
+	}
+	return chattoCore
 }
 
 func TestFrontendFallbackAllowsRoutesWithReservedPrefixNames(t *testing.T) {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -714,7 +714,7 @@ Notes: Asset IDs are globally unique (NanoID), so NATS-backed assets do not need
 
 ### Dynamic Image Transformation
 
-Chatto supports on-the-fly image transformation for attachments and user avatars, allowing clients to request images at specific dimensions without pre-generating all possible sizes. Public server branding images expose canonical asset URLs instead of accepting arbitrary transform dimensions.
+Chatto supports on-the-fly image transformation for attachments and user avatars, allowing clients to request images at specific dimensions without pre-generating all possible sizes. Public server branding images expose canonical asset URLs instead of accepting arbitrary transform dimensions; the HTTP frontend server uses fixed 180/192/512px cover transforms of the current server logo for Apple touch icon and web-manifest install metadata, and keeps the web manifest network-served so service-worker caches do not pin stale branding.
 
 **URL Structure:**
 

--- a/docs/fdr/FDR-027-pwa-shell-and-service-worker.md
+++ b/docs/fdr/FDR-027-pwa-shell-and-service-worker.md
@@ -1,11 +1,11 @@
 # FDR-027: PWA Shell & Service Worker
 
 **Status:** Active
-**Last reviewed:** 2026-07-05
+**Last reviewed:** 2026-07-09
 
 ## Overview
 
-Chatto ships a service worker so the installed web app can launch reliably and handle push notifications. The worker caches the SPA fallback shell and SvelteKit build assets during install, then caches static PWA assets when the browser actually requests them. It deliberately does not cache chat data, API responses, live-event traffic, or protected uploaded asset bodies.
+Chatto ships a service worker so the installed web app can launch reliably and handle push notifications. The worker caches the SPA fallback shell and SvelteKit build assets during install, then caches static PWA assets when the browser actually requests them. The web manifest stays network-only because the server may generate it from current public server branding. The worker deliberately does not cache chat data, API responses, live-event traffic, or protected uploaded asset bodies.
 
 Offline support means the app can open and show its normal disconnected state instead of the browser's generic offline page. It does not mean offline message history, offline search, or an outbox for composing messages while disconnected.
 
@@ -16,9 +16,10 @@ Reconnect catch-up is owned by the foreground web app, not the service worker. W
 - The service worker is registered by SvelteKit in production builds.
 - On install, the worker caches the SPA fallback shell and SvelteKit build assets required to boot it.
 - On activate, old Chatto shell caches are deleted and the new worker claims open clients.
-- Known shell assets are served cache-first from the versioned cache; static PWA assets are cached lazily on first request.
+- Known shell assets are served cache-first from the versioned cache; static PWA assets other than the web manifest are cached lazily on first request.
+- The served web manifest and Apple touch icon metadata use the uploaded server logo when one exists, falling back to bundled Chatto icons otherwise.
 - Same-origin navigations are network-first, falling back to the cached SPA shell only when the network fails.
-- API, auth, OAuth, webhook, uploaded-asset, non-GET, and cross-origin requests are network-only.
+- API, auth, OAuth, webhook, uploaded-asset, web-manifest, non-GET, and cross-origin requests are network-only.
 - Protected uploaded asset loads use direct signed asset URLs owned by the foreground app. The worker does not receive registered-server API bearer tokens, does not proxy asset requests, and does not cache protected asset bodies.
 - Push notifications continue to display native OS notifications and route notification clicks into the SPA.
 - Push dismiss payloads still close matching visible notifications on the device.
@@ -27,9 +28,9 @@ Reconnect catch-up is owned by the foreground web app, not the service worker. W
 
 ### 1. Shell-only caching
 
-**Decision:** Cache only the app shell and static PWA assets. Build assets required to boot the shell are cached during install, while static PWA assets are cached lazily after install.
+**Decision:** Cache only the app shell and static PWA assets that do not depend on current server state. Build assets required to boot the shell are cached during install, while static PWA assets are cached lazily after install. The web manifest remains network-only.
 **Why:** Chatto is a real-time chat app. Serving stale messages, permissions, assets, or notification state as if they were live would be worse than showing the disconnected state.
-**Tradeoff:** Offline launches do not show recent rooms or messages unless the live app already has that state in memory, and full static asset coverage accumulates as the app requests assets. This keeps the data model honest while avoiding install-time requests for icons, manifests, and unrelated static files.
+**Tradeoff:** Offline launches do not show recent rooms or messages unless the live app already has that state in memory, and full static asset coverage accumulates as the app requests assets. The install manifest may be unavailable while offline, but installed apps already have their manifest metadata. This keeps the data model honest while avoiding install-time requests for icons and unrelated static files.
 
 ### 2. Versioned cache names
 
@@ -48,6 +49,12 @@ Reconnect catch-up is owned by the foreground web app, not the service worker. W
 **Decision:** Protected uploaded assets are loaded through direct signed asset URLs and refreshed by foreground components when they approach expiry or fail to load. The service worker treats uploaded assets as network-only and never proxies or caches their bodies.
 **Why:** The asset tickets and `AssetService` refresh flow are the actual reliability and authorization mechanism. Keeping asset routing out of the worker removes hidden worker/client state and keeps the service worker focused on shell availability and notifications.
 **Tradeoff:** Ticketed asset URLs are visible in normal page markup. Their exposure is bounded by the ticket expiry and by the server's room-membership check on every fetch.
+
+### 5. Install metadata follows server branding
+
+**Decision:** The HTTP frontend server generates the web manifest from the bundled manifest and swaps in transformed server-logo URLs for install icons when a logo is configured. The served HTML similarly replaces the Apple touch icon link with a fixed-size server-logo transform.
+**Why:** Self-hosted servers should install with their own visible identity without requiring a custom frontend build.
+**Tradeoff:** Browsers decide when to refresh installed PWA metadata, so existing installs may keep the previous icon until the browser updates the manifest or the user reinstalls the app.
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Generate PWA manifest and Apple touch icon metadata from the configured server logo when available.
- Keep the web manifest network-only in the service worker so branding updates are not pinned in Cache Storage.
- Document the dynamic install metadata behavior in FDR-027 and architecture notes.

Closes #1358.

## Tests

- `mise x -- go test ./internal/http_server -run 'Test(DynamicPWAManifest|InjectAppleTouchIcon|ServeSPAFallback|ServePWAWebManifestUsesServerLogoWhenAvailable)'`
- `mise x -- pnpm --dir apps/frontend exec vitest run src/lib/pwa/serviceWorkerPolicy.spec.ts`
- `mise x -- pnpm --dir apps/frontend exec prettier --check src/lib/pwa/serviceWorkerPolicy.ts src/lib/pwa/serviceWorkerPolicy.spec.ts`
