### PR TITLE
refactor(frontend): improve optimistic UI plumbing

### DIFF
--- a/apps/frontend/src/lib/state/optimisticMutations.ts
+++ b/apps/frontend/src/lib/state/optimisticMutations.ts
@@ -1,0 +1,41 @@
+export type OptimisticMutationToken = number;
+
+/**
+ * Tracks pending optimistic mutations by a caller-defined key.
+ * Callers keep the domain-specific patch and rollback logic; this registry
+ * only answers whether an async completion still belongs to the latest
+ * optimistic mutation for that key.
+ */
+export class OptimisticMutationRegistry {
+  private nextToken = 0;
+  private tokens = new Map<string, OptimisticMutationToken>();
+
+  createToken(): OptimisticMutationToken {
+    this.nextToken += 1;
+    return this.nextToken;
+  }
+
+  mark(key: string, token: OptimisticMutationToken): void {
+    this.tokens.set(key, token);
+  }
+
+  isCurrent(key: string, token: OptimisticMutationToken): boolean {
+    return this.tokens.get(key) === token;
+  }
+
+  clear(key: string): void {
+    this.tokens.delete(key);
+  }
+
+  clearPrefixes(prefixes: readonly string[]): void {
+    for (const key of this.tokens.keys()) {
+      if (prefixes.some((prefix) => key.startsWith(prefix))) {
+        this.tokens.delete(key);
+      }
+    }
+  }
+
+  clearAll(): void {
+    this.tokens.clear();
+  }
+}

--- a/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -776,142 +776,6 @@ describe('MessagesStore — room lifecycle ownership', () => {
     store.dispose();
   });
 
-  it('applies and rolls back an optimistic reaction add', async () => {
-    const fake = new FakeQueryClient();
-    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, fakeTimelineAPI());
-    store.setRoom('room-1');
-    await settle();
-    store.events = [messageWithReaction('m1', 'heart') as never];
-
-    const optimistic = store.beginOptimisticReaction({
-      messageEventId: 'm1',
-      emoji: 'heart',
-      action: 'add'
-    });
-
-    expect(reactionsOf(store.rootEvents[0])).toMatchObject([
-      { emoji: 'heart', count: 2, hasReacted: true }
-    ]);
-
-    optimistic.rollback();
-
-    expect(reactionsOf(store.rootEvents[0])).toMatchObject([
-      { emoji: 'heart', count: 1, hasReacted: false }
-    ]);
-    store.dispose();
-  });
-
-  it('applies and rolls back an optimistic reaction remove', async () => {
-    const fake = new FakeQueryClient();
-    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, fakeTimelineAPI());
-    store.setRoom('room-1');
-    await settle();
-    store.events = [
-      messageWithReactionState('m1', { emoji: 'heart', count: 2, hasReacted: true }) as never
-    ];
-
-    const optimistic = store.beginOptimisticReaction({
-      messageEventId: 'm1',
-      emoji: 'heart',
-      action: 'remove'
-    });
-
-    expect(reactionsOf(store.rootEvents[0])).toMatchObject([
-      { emoji: 'heart', count: 1, hasReacted: false }
-    ]);
-
-    optimistic.rollback();
-
-    expect(reactionsOf(store.rootEvents[0])).toMatchObject([
-      { emoji: 'heart', count: 2, hasReacted: true }
-    ]);
-    store.dispose();
-  });
-
-  it('tracks independent optimistic reactions per emoji', async () => {
-    const fake = new FakeQueryClient();
-    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, fakeTimelineAPI());
-    store.setRoom('room-1');
-    await settle();
-    store.events = [threadMessageEvent('m1') as never];
-
-    const heart = store.beginOptimisticReaction({
-      messageEventId: 'm1',
-      emoji: 'heart',
-      action: 'add'
-    });
-    store.beginOptimisticReaction({
-      messageEventId: 'm1',
-      emoji: 'thumbsup',
-      action: 'add'
-    });
-
-    heart.rollback();
-
-    expect(reactionsOf(store.rootEvents[0])).toMatchObject([
-      { emoji: 'thumbsup', count: 1, hasReacted: true }
-    ]);
-    store.dispose();
-  });
-
-  it('rolls back only the touched reaction summary', async () => {
-    const fake = new FakeQueryClient();
-    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, fakeTimelineAPI());
-    store.setRoom('room-1');
-    await settle();
-    store.events = [messageWithReaction('m1', 'heart') as never];
-
-    const optimistic = store.beginOptimisticReaction({
-      messageEventId: 'm1',
-      emoji: 'heart',
-      action: 'add'
-    });
-    const current = store.rootEvents[0];
-    if (current.event?.kind !== RoomEventKind.MessagePosted) throw new Error('expected message');
-    store.events[0] = {
-      ...current,
-      event: {
-        ...current.event,
-        body: 'edited while reaction was pending',
-        reactions: [
-          ...current.event.reactions,
-          { emoji: 'thumbsup', count: 1, hasReacted: true, users: [] }
-        ]
-      }
-    } as never;
-
-    optimistic.rollback();
-
-    const rolledBack = store.rootEvents[0];
-    expect(rolledBack.event).toMatchObject({ body: 'edited while reaction was pending' });
-    expect(reactionsOf(rolledBack)).toMatchObject([
-      { emoji: 'heart', count: 1, hasReacted: false },
-      { emoji: 'thumbsup', count: 1, hasReacted: true }
-    ]);
-    store.dispose();
-  });
-
-  it('reconciles an optimistic reaction from the RPC response', async () => {
-    const fake = new FakeQueryClient();
-    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, fakeTimelineAPI());
-    store.setRoom('room-1');
-    await settle();
-    store.events = [messageWithReaction('m1', 'heart') as never];
-
-    const optimistic = store.beginOptimisticReaction({
-      messageEventId: 'm1',
-      emoji: 'heart',
-      action: 'add'
-    });
-    optimistic.applyServerReaction({ emoji: 'heart', count: 5, hasReacted: true });
-    optimistic.rollback();
-
-    expect(reactionsOf(store.rootEvents[0])).toMatchObject([
-      { emoji: 'heart', count: 5, hasReacted: true }
-    ]);
-    store.dispose();
-  });
-
   it('does not let a stale rollback overwrite an authoritative reaction refetch', async () => {
     const updated = messageWithReactionState('m1', {
       emoji: 'heart',
@@ -960,37 +824,38 @@ describe('MessagesStore — room lifecycle ownership', () => {
     store.dispose();
   });
 
-  it('patches loaded original and echo messages before the original has an echo backlink', async () => {
+  it('does not let a stale thread-follow rollback overwrite an authoritative refetch', async () => {
+    const event = threadMessageEvent('m1');
+    const updated = {
+      ...event,
+      event: {
+        ...event.event,
+        viewerIsFollowingThread: true
+      }
+    };
     const fake = new FakeQueryClient();
-    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, fakeTimelineAPI());
-    const original = threadMessageEvent('reply');
-    const echo = threadMessageEvent('echo');
+    const timeline = fakeTimelineAPI({
+      getRoomEvents: vi.fn(async () => ({
+        events: [threadMessageEvent('m1') as never],
+        startCursor: 'tl:cursor-1',
+        endCursor: 'tl:cursor-1',
+        hasOlder: false,
+        hasNewer: false
+      })),
+      getRoomEventsAround: vi.fn(async () => pageFromEvent(updated))
+    });
+    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, timeline);
     store.setRoom('room-1');
     await settle();
-    store.events = [
-      original as never,
-      {
-        ...echo,
-        event: {
-          ...echo.event,
-          echoOfEventId: 'reply',
-          echoFromThreadRootEventId: 'root'
-        }
-      } as never
-    ];
 
-    store.beginOptimisticReaction({
-      messageEventId: 'echo',
-      emoji: 'heart',
-      action: 'add'
+    const optimistic = store.beginOptimisticThreadFollow('m1', true);
+
+    await store.refreshCurrentWindow('m1');
+    optimistic.rollback();
+
+    expect(store.rootEvents[0].event).toMatchObject({
+      viewerIsFollowingThread: true
     });
-
-    expect(reactionsOf(store.rootEvents[0])).toMatchObject([
-      { emoji: 'heart', count: 1, hasReacted: true }
-    ]);
-    expect(reactionsOf(store.rootEvents[1])).toMatchObject([
-      { emoji: 'heart', count: 1, hasReacted: true }
-    ]);
     store.dispose();
   });
 

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -268,11 +268,12 @@ export class MessagesStore {
   }): OptimisticReactionHandle {
     return beginOptimisticReactionPatch({
       ...input,
-      events: this.events,
+      getEvents: () => this.events,
       previews: this.previewEvents,
       registry: this.optimisticReactions,
-      setEvent: (index, event) => {
-        this.events[index] = event;
+      setEvent: (eventId, event) => {
+        const index = this.events.findIndex((candidate) => candidate.id === eventId);
+        if (index !== -1) this.events[index] = event;
       },
       setPreview: (key, event) => {
         this.previewEvents.set(key, event);
@@ -292,10 +293,11 @@ export class MessagesStore {
     return beginOptimisticThreadFollowPatch({
       threadRootEventId,
       isFollowing,
-      events: this.events,
+      getEvents: () => this.events,
       registry: this.optimisticThreadFollows,
-      setEvent: (index, event) => {
-        this.events[index] = event;
+      setEvent: (eventId, event) => {
+        const index = this.events.findIndex((candidate) => candidate.id === eventId);
+        if (index !== -1) this.events[index] = event;
       }
     });
   }
@@ -361,11 +363,7 @@ export class MessagesStore {
   }
 
   private clearOptimisticVersionForEvent(eventId: string): void {
-    clearOptimisticReactionsForEvent(
-      this.optimisticReactions,
-      eventId,
-      this.previewKey(eventId)
-    );
+    clearOptimisticReactionsForEvent(this.optimisticReactions, eventId, this.previewKey(eventId));
     clearOptimisticThreadFollowForEvent(this.optimisticThreadFollows, eventId);
   }
 

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -9,6 +9,25 @@ import type { JumpToMessageState } from '../composerContext.svelte';
 import { PAGE_SIZE } from './queries';
 import { isRootRoomEvent, isThreadEvent } from './filters';
 import { type EventConnectionPage, type RawEvent, getActorId, unmask } from './helpers';
+import { OptimisticMutationRegistry } from '$lib/state/optimisticMutations';
+import {
+  beginOptimisticReaction as beginOptimisticReactionPatch,
+  clearOptimisticReactionsForEvent,
+  type OptimisticReactionAction,
+  type OptimisticReactionHandle
+} from './optimisticReactions';
+import {
+  beginOptimisticThreadFollow as beginOptimisticThreadFollowPatch,
+  clearOptimisticThreadFollowForEvent,
+  type OptimisticThreadFollowHandle
+} from './optimisticThreadFollow';
+
+export type {
+  OptimisticReactionAction,
+  OptimisticReactionHandle,
+  OptimisticReactionServerSummary
+} from './optimisticReactions';
+export type { OptimisticThreadFollowHandle } from './optimisticThreadFollow';
 
 type MessageScope = 'room' | 'thread';
 type RoomEventPayload = NonNullable<RoomEventView['event']>;
@@ -21,40 +40,17 @@ type MessageRetractedPayload = Extract<
 type ReactionMutationPayload =
   | Extract<RoomEventPayload, { kind: typeof RoomEventKind.ReactionAdded }>
   | Extract<RoomEventPayload, { kind: typeof RoomEventKind.ReactionRemoved }>;
-type MessageReactionSummary = MessagePostedPayload['reactions'][number];
 type AssetProcessingPayload =
   | Extract<RoomEventPayload, { kind: typeof RoomEventKind.AssetProcessingStarted }>
   | Extract<RoomEventPayload, { kind: typeof RoomEventKind.AssetProcessingSucceeded }>
   | Extract<RoomEventPayload, { kind: typeof RoomEventKind.AssetProcessingFailed }>;
 type RoomDeletedPayload = Extract<RoomEventPayload, { kind: typeof RoomEventKind.RoomDeleted }>;
 
-export type OptimisticReactionAction = 'add' | 'remove';
-
-export type OptimisticReactionServerSummary = {
-  emoji: string;
-  count: number;
-  hasReacted: boolean;
-} | null;
-
-export type OptimisticReactionHandle = {
-  applyServerReaction(reaction: OptimisticReactionServerSummary): void;
-  rollback(): void;
-};
-
 export type RefreshCurrentWindowResult = {
   hasOlder: boolean;
   hasNewer: boolean;
   refreshed: boolean;
   changed: boolean;
-};
-
-type OptimisticReactionSnapshot = {
-  key: string;
-  emoji: string;
-  previousReaction: MessageReactionSummary | null;
-  source: 'events' | 'preview';
-  eventId?: string;
-  previewKey?: string;
 };
 
 function eventCacheKey(roomId: string, eventId: string): string {
@@ -185,8 +181,8 @@ export class MessagesStore {
   private roomId = '';
   private oldestCursor: string | undefined;
   private newestCursor: string | undefined;
-  private optimisticReactionVersion = 0;
-  private optimisticReactionVersions = new SvelteMap<string, number>();
+  private optimisticReactions = new OptimisticMutationRegistry();
+  private optimisticThreadFollows = new OptimisticMutationRegistry();
 
   /** Increments on every load kickoff. Async callbacks compare against
    *  it via {@link isStale} to discard results from superseded loads. */
@@ -270,66 +266,43 @@ export class MessagesStore {
     emoji: string;
     action: OptimisticReactionAction;
   }): OptimisticReactionHandle {
-    const token = ++this.optimisticReactionVersion;
-    const targetIds = this.optimisticReactionTargetIds(input.messageEventId);
-    const snapshots: OptimisticReactionSnapshot[] = [];
-
-    const record = (snapshot: OptimisticReactionSnapshot) => {
-      snapshots.push(snapshot);
-      this.optimisticReactionVersions.set(snapshot.key, token);
-    };
-
-    for (let i = 0; i < this.events.length; i++) {
-      const event = this.events[i];
-      if (!this.isReactionTarget(event, targetIds)) continue;
-      const updated = this.eventWithOptimisticReaction(event, input.emoji, input.action);
-      if (!updated) continue;
-      const key = this.optimisticEventKey(event.id, input.emoji);
-      record({
-        key,
-        emoji: input.emoji,
-        previousReaction: this.reactionSummary(event, input.emoji),
-        source: 'events',
-        eventId: event.id
-      });
-      this.events[i] = updated;
-    }
-
-    for (const [previewKey, event] of this.previewEvents) {
-      if (!event || !this.isReactionTarget(event, targetIds)) continue;
-      const updated = this.eventWithOptimisticReaction(event, input.emoji, input.action);
-      if (!updated) continue;
-      const key = this.optimisticPreviewKey(previewKey, input.emoji);
-      record({
-        key,
-        emoji: input.emoji,
-        previousReaction: this.reactionSummary(event, input.emoji),
-        source: 'preview',
-        previewKey
-      });
-      this.previewEvents.set(previewKey, updated);
-    }
-
-    return {
-      applyServerReaction: (reaction) => {
-        for (const snapshot of snapshots) {
-          if (this.optimisticReactionVersions.get(snapshot.key) !== token) continue;
-          this.applyServerReactionSnapshot(snapshot, input.emoji, reaction);
-          this.optimisticReactionVersions.delete(snapshot.key);
-        }
+    return beginOptimisticReactionPatch({
+      ...input,
+      events: this.events,
+      previews: this.previewEvents,
+      registry: this.optimisticReactions,
+      setEvent: (index, event) => {
+        this.events[index] = event;
       },
-      rollback: () => {
-        for (const snapshot of snapshots) {
-          if (this.optimisticReactionVersions.get(snapshot.key) !== token) continue;
-          this.restoreOptimisticReactionSnapshot(snapshot);
-          this.optimisticReactionVersions.delete(snapshot.key);
-        }
+      setPreview: (key, event) => {
+        this.previewEvents.set(key, event);
       }
-    };
+    });
+  }
+
+  /**
+   * Apply a provisional local thread follow-state update on a known thread root.
+   * Projected server rows and live follow events remain authoritative and clear
+   * the pending optimistic mutation for the affected root row.
+   */
+  beginOptimisticThreadFollow(
+    threadRootEventId: string,
+    isFollowing: boolean
+  ): OptimisticThreadFollowHandle {
+    return beginOptimisticThreadFollowPatch({
+      threadRootEventId,
+      isFollowing,
+      events: this.events,
+      registry: this.optimisticThreadFollows,
+      setEvent: (index, event) => {
+        this.events[index] = event;
+      }
+    });
   }
 
   /** Update the viewer's thread follow state on a known thread root event. */
   setThreadRootFollowState(threadRootEventId: string, isFollowing: boolean): void {
+    clearOptimisticThreadFollowForEvent(this.optimisticThreadFollows, threadRootEventId);
     const idx = this.events.findIndex((e) => e.id === threadRootEventId);
     if (idx === -1) return;
 
@@ -387,242 +360,13 @@ export class MessagesStore {
     return eventCacheKey(this.roomId, eventId);
   }
 
-  private optimisticEventKey(eventId: string, emoji: string): string {
-    return `${this.optimisticEventKeyPrefix(eventId)}${emoji}`;
-  }
-
-  private optimisticEventKeyPrefix(eventId: string): string {
-    return `events:${eventId}\u0000`;
-  }
-
-  private optimisticPreviewKey(previewKey: string, emoji: string): string {
-    return `${this.optimisticPreviewKeyPrefix(previewKey)}${emoji}`;
-  }
-
-  private optimisticPreviewKeyPrefix(previewKey: string): string {
-    return `preview:${previewKey}\u0000`;
-  }
-
   private clearOptimisticVersionForEvent(eventId: string): void {
-    const eventPrefix = this.optimisticEventKeyPrefix(eventId);
-    const previewPrefix = this.optimisticPreviewKeyPrefix(this.previewKey(eventId));
-    for (const key of this.optimisticReactionVersions.keys()) {
-      if (key.startsWith(eventPrefix) || key.startsWith(previewPrefix)) {
-        this.optimisticReactionVersions.delete(key);
-      }
-    }
-  }
-
-  private optimisticReactionTargetIds(messageEventId: string): SvelteSet<string> {
-    const targetIds = new SvelteSet([messageEventId]);
-    let changed = true;
-
-    while (changed) {
-      changed = false;
-      for (const event of this.events) {
-        changed = this.addLinkedReactionTargetIds(event, targetIds) || changed;
-      }
-      for (const event of this.previewEvents.values()) {
-        if (event) changed = this.addLinkedReactionTargetIds(event, targetIds) || changed;
-      }
-    }
-
-    return targetIds;
-  }
-
-  private addLinkedReactionTargetIds(event: RoomEventView, targetIds: SvelteSet<string>): boolean {
-    const payload = event.event;
-    if (!isMessagePostedPayload(payload)) return false;
-
-    const before = targetIds.size;
-    if (targetIds.has(event.id)) {
-      if (payload.echoOfEventId) targetIds.add(payload.echoOfEventId);
-      if (payload.channelEchoEventId) targetIds.add(payload.channelEchoEventId);
-    }
-    if (payload.echoOfEventId && targetIds.has(payload.echoOfEventId)) targetIds.add(event.id);
-    if (payload.channelEchoEventId && targetIds.has(payload.channelEchoEventId)) {
-      targetIds.add(event.id);
-    }
-    return targetIds.size !== before;
-  }
-
-  private isReactionTarget(event: RoomEventView, targetIds: SvelteSet<string>): boolean {
-    if (targetIds.has(event.id)) return true;
-    const payload = event.event;
-    return (
-      isMessagePostedPayload(payload) &&
-      Boolean(
-        (payload.echoOfEventId && targetIds.has(payload.echoOfEventId)) ||
-          (payload.channelEchoEventId && targetIds.has(payload.channelEchoEventId))
-      )
+    clearOptimisticReactionsForEvent(
+      this.optimisticReactions,
+      eventId,
+      this.previewKey(eventId)
     );
-  }
-
-  private eventWithOptimisticReaction(
-    event: RoomEventView,
-    emoji: string,
-    action: OptimisticReactionAction
-  ): RoomEventView | null {
-    const payload = event.event;
-    if (!isMessagePostedPayload(payload)) return null;
-    return {
-      ...event,
-      event: {
-        ...payload,
-        reactions: this.optimisticReactions(payload.reactions, emoji, action)
-      }
-    };
-  }
-
-  private reactionSummary(event: RoomEventView, emoji: string): MessageReactionSummary | null {
-    const payload = event.event;
-    if (!isMessagePostedPayload(payload)) return null;
-    return payload.reactions.find((reaction) => reaction.emoji === emoji) ?? null;
-  }
-
-  private eventWithReactionSummary(
-    event: RoomEventView,
-    emoji: string,
-    reaction: MessageReactionSummary | null
-  ): RoomEventView | null {
-    const payload = event.event;
-    if (!isMessagePostedPayload(payload)) return null;
-    return {
-      ...event,
-      event: {
-        ...payload,
-        reactions: this.reactionsWithSummary(payload.reactions, emoji, reaction)
-      }
-    };
-  }
-
-  private optimisticReactions(
-    reactions: readonly MessageReactionSummary[],
-    emoji: string,
-    action: OptimisticReactionAction
-  ): MessageReactionSummary[] {
-    const existingIndex = reactions.findIndex((reaction) => reaction.emoji === emoji);
-    if (action === 'add') {
-      if (existingIndex === -1) {
-        return [...reactions, { emoji, count: 1, hasReacted: true, users: [] }];
-      }
-
-      return reactions.map((reaction, index) =>
-        index === existingIndex
-          ? {
-              ...reaction,
-              count: reaction.hasReacted ? reaction.count : reaction.count + 1,
-              hasReacted: true
-            }
-          : reaction
-      );
-    }
-
-    if (existingIndex === -1) return [...reactions];
-
-    return reactions.flatMap((reaction, index) => {
-      if (index !== existingIndex) return [reaction];
-      const count = reaction.hasReacted ? Math.max(0, reaction.count - 1) : reaction.count;
-      if (count === 0) return [];
-      return [{ ...reaction, count, hasReacted: false }];
-    });
-  }
-
-  private reactionsWithSummary(
-    reactions: readonly MessageReactionSummary[],
-    emoji: string,
-    reaction: MessageReactionSummary | null
-  ): MessageReactionSummary[] {
-    if (!reaction || reaction.count <= 0) {
-      return reactions.filter((existing) => existing.emoji !== emoji);
-    }
-
-    const existingIndex = reactions.findIndex((existing) => existing.emoji === emoji);
-    const nextReaction = {
-      ...reaction,
-      users: [...reaction.users]
-    };
-    if (existingIndex === -1) return [...reactions, nextReaction];
-    return reactions.map((existing, index) => (index === existingIndex ? nextReaction : existing));
-  }
-
-  private serverReactions(
-    reactions: readonly MessageReactionSummary[],
-    emoji: string,
-    reaction: OptimisticReactionServerSummary
-  ): MessageReactionSummary[] {
-    if (!reaction || reaction.count <= 0) {
-      return reactions.filter((existing) => existing.emoji !== emoji);
-    }
-
-    const existingIndex = reactions.findIndex((existing) => existing.emoji === emoji);
-    const nextReaction = (existing?: MessageReactionSummary): MessageReactionSummary => ({
-      emoji: reaction.emoji,
-      count: reaction.count,
-      hasReacted: reaction.hasReacted,
-      users: existing?.users ?? []
-    });
-
-    if (existingIndex === -1) return [...reactions, nextReaction()];
-    return reactions.map((existing, index) =>
-      index === existingIndex ? nextReaction(existing) : existing
-    );
-  }
-
-  private applyServerReactionSnapshot(
-    snapshot: OptimisticReactionSnapshot,
-    emoji: string,
-    reaction: OptimisticReactionServerSummary
-  ): void {
-    const apply = (event: RoomEventView): RoomEventView | null => {
-      const payload = event.event;
-      if (!isMessagePostedPayload(payload)) return null;
-      return {
-        ...event,
-        event: {
-          ...payload,
-          reactions: this.serverReactions(payload.reactions, emoji, reaction)
-        }
-      };
-    };
-
-    if (snapshot.source === 'events') {
-      const index = this.events.findIndex((event) => event.id === snapshot.eventId);
-      if (index === -1) return;
-      const updated = apply(this.events[index]);
-      if (updated) this.events[index] = updated;
-      return;
-    }
-
-    if (!snapshot.previewKey) return;
-    const event = this.previewEvents.get(snapshot.previewKey);
-    if (!event) return;
-    const updated = apply(event);
-    if (updated) this.previewEvents.set(snapshot.previewKey, updated);
-  }
-
-  private restoreOptimisticReactionSnapshot(snapshot: OptimisticReactionSnapshot): void {
-    if (snapshot.source === 'events') {
-      const index = this.events.findIndex((event) => event.id === snapshot.eventId);
-      if (index === -1) return;
-      const updated = this.eventWithReactionSummary(
-        this.events[index],
-        snapshot.emoji,
-        snapshot.previousReaction
-      );
-      if (updated) this.events[index] = updated;
-      return;
-    }
-
-    if (!snapshot.previewKey) return;
-    const event = this.previewEvents.get(snapshot.previewKey);
-    if (!event) return;
-    const updated = this.eventWithReactionSummary(
-      event,
-      snapshot.emoji,
-      snapshot.previousReaction
-    );
-    if (updated) this.previewEvents.set(snapshot.previewKey, updated);
+    clearOptimisticThreadFollowForEvent(this.optimisticThreadFollows, eventId);
   }
 
   setRoom(roomId: string): void {
@@ -1249,7 +993,8 @@ export class MessagesStore {
     this.seenIds = new SvelteSet();
     this.previewEvents.clear();
     this.pendingPreviewFetches.clear();
-    this.optimisticReactionVersions.clear();
+    this.optimisticReactions.clearAll();
+    this.optimisticThreadFollows.clearAll();
     this.oldestCursor = undefined;
     this.newestCursor = undefined;
     this.hasReachedStart = false;

--- a/apps/frontend/src/lib/state/room/messages/optimisticMutations.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages/optimisticMutations.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { OptimisticMutationRegistry } from '$lib/state/optimisticMutations';
+
+describe('OptimisticMutationRegistry', () => {
+  it('tracks the latest token per key', () => {
+    const registry = new OptimisticMutationRegistry();
+    const first = registry.createToken();
+    const second = registry.createToken();
+
+    registry.mark('event:m1', first);
+    expect(registry.isCurrent('event:m1', first)).toBe(true);
+
+    registry.mark('event:m1', second);
+    expect(registry.isCurrent('event:m1', first)).toBe(false);
+    expect(registry.isCurrent('event:m1', second)).toBe(true);
+  });
+
+  it('clears groups of keys by prefix', () => {
+    const registry = new OptimisticMutationRegistry();
+    const token = registry.createToken();
+
+    registry.mark('events:m1\u0000heart', token);
+    registry.mark('events:m1\u0000thumbsup', token);
+    registry.mark('events:m2\u0000heart', token);
+
+    registry.clearPrefixes(['events:m1\u0000']);
+
+    expect(registry.isCurrent('events:m1\u0000heart', token)).toBe(false);
+    expect(registry.isCurrent('events:m1\u0000thumbsup', token)).toBe(false);
+    expect(registry.isCurrent('events:m2\u0000heart', token)).toBe(true);
+  });
+});

--- a/apps/frontend/src/lib/state/room/messages/optimisticReactions.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages/optimisticReactions.spec.ts
@@ -68,11 +68,12 @@ function begin(input: {
     messageEventId: input.messageEventId,
     emoji: input.emoji,
     action: input.action,
-    events,
+    getEvents: () => events,
     previews,
     registry: new OptimisticMutationRegistry(),
-    setEvent: (index, event) => {
-      events[index] = event;
+    setEvent: (eventId, event) => {
+      const index = events.findIndex((candidate) => candidate.id === eventId);
+      if (index !== -1) events[index] = event;
     },
     setPreview: (key, event) => {
       previews.set(key, event);
@@ -119,11 +120,12 @@ describe('optimistic reactions', () => {
     const events = [messageEvent('m1')];
     const registry = new OptimisticMutationRegistry();
     const input = {
-      events,
+      getEvents: () => events,
       previews: new Map<string, RoomEventView | null>(),
       registry,
-      setEvent: (index: number, event: RoomEventView) => {
-        events[index] = event;
+      setEvent: (eventId: string, event: RoomEventView) => {
+        const index = events.findIndex((candidate) => candidate.id === eventId);
+        if (index !== -1) events[index] = event;
       },
       setPreview: () => {}
     };
@@ -161,6 +163,30 @@ describe('optimistic reactions', () => {
     optimistic.rollback();
 
     expect(reactionsOf(events[0])).toMatchObject([{ emoji: 'heart', count: 5, hasReacted: true }]);
+  });
+
+  it('resolves the target by ID after the events array is replaced', () => {
+    let events = [messageEvent('m1', [reaction('heart', 1, false)]), messageEvent('m2')];
+    const optimistic = beginOptimisticReaction({
+      messageEventId: 'm1',
+      emoji: 'heart',
+      action: 'add',
+      getEvents: () => events,
+      previews: new Map(),
+      registry: new OptimisticMutationRegistry(),
+      setEvent: (eventId, event) => {
+        const index = events.findIndex((candidate) => candidate.id === eventId);
+        if (index !== -1) events[index] = event;
+      },
+      setPreview: () => {}
+    });
+
+    events = [messageEvent('new'), ...events];
+    optimistic.applyServerReaction({ emoji: 'heart', count: 5, hasReacted: true });
+
+    expect(events.map((event) => event.id)).toEqual(['new', 'm1', 'm2']);
+    expect(reactionsOf(events[1])).toMatchObject([{ emoji: 'heart', count: 5, hasReacted: true }]);
+    expect(reactionsOf(events[0])).toEqual([]);
   });
 
   it('rolls back only the touched reaction summary', () => {

--- a/apps/frontend/src/lib/state/room/messages/optimisticReactions.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages/optimisticReactions.spec.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest';
+import type { RoomEventView } from '$lib/render/types';
+import { RoomEventKind } from '$lib/render/eventKinds';
+import { OptimisticMutationRegistry } from '$lib/state/optimisticMutations';
+import { beginOptimisticReaction } from './optimisticReactions';
+
+type ReactionSummary = Extract<
+  NonNullable<RoomEventView['event']>,
+  { kind: typeof RoomEventKind.MessagePosted }
+>['reactions'][number];
+
+function messageEvent(
+  id: string,
+  reactions: ReactionSummary[] = [],
+  links: Partial<
+    Pick<
+      Extract<NonNullable<RoomEventView['event']>, { kind: typeof RoomEventKind.MessagePosted }>,
+      'echoOfEventId' | 'echoFromThreadRootEventId' | 'channelEchoEventId'
+    >
+  > = {}
+): RoomEventView {
+  return {
+    id,
+    createdAt: '2026-05-27T00:00:00Z',
+    actorId: 'u1',
+    actor: null,
+    event: {
+      kind: RoomEventKind.MessagePosted,
+      roomId: 'room-1',
+      body: id,
+      attachments: [],
+      linkPreview: null,
+      updatedAt: null,
+      inReplyTo: null,
+      threadRootEventId: null,
+      echoOfEventId: null,
+      echoFromThreadRootEventId: null,
+      channelEchoEventId: null,
+      replyCount: 0,
+      lastReplyAt: null,
+      threadParticipants: [],
+      viewerIsFollowingThread: null,
+      reactions,
+      ...links
+    }
+  };
+}
+
+function reaction(emoji: string, count: number, hasReacted: boolean): ReactionSummary {
+  return { emoji, count, hasReacted, users: [] };
+}
+
+function reactionsOf(event: RoomEventView): ReactionSummary[] {
+  if (event.event?.kind !== RoomEventKind.MessagePosted) throw new Error('expected message');
+  return event.event.reactions;
+}
+
+function begin(input: {
+  events?: RoomEventView[];
+  previews?: Map<string, RoomEventView | null>;
+  messageEventId: string;
+  emoji: string;
+  action: 'add' | 'remove';
+}) {
+  const events = input.events ?? [];
+  const previews = input.previews ?? new Map<string, RoomEventView | null>();
+  return beginOptimisticReaction({
+    messageEventId: input.messageEventId,
+    emoji: input.emoji,
+    action: input.action,
+    events,
+    previews,
+    registry: new OptimisticMutationRegistry(),
+    setEvent: (index, event) => {
+      events[index] = event;
+    },
+    setPreview: (key, event) => {
+      previews.set(key, event);
+    }
+  });
+}
+
+describe('optimistic reactions', () => {
+  it('applies and rolls back an add', () => {
+    const events = [messageEvent('m1', [reaction('heart', 1, false)])];
+
+    const optimistic = begin({
+      events,
+      messageEventId: 'm1',
+      emoji: 'heart',
+      action: 'add'
+    });
+
+    expect(reactionsOf(events[0])).toMatchObject([{ emoji: 'heart', count: 2, hasReacted: true }]);
+
+    optimistic.rollback();
+
+    expect(reactionsOf(events[0])).toMatchObject([{ emoji: 'heart', count: 1, hasReacted: false }]);
+  });
+
+  it('applies and rolls back a remove', () => {
+    const events = [messageEvent('m1', [reaction('heart', 2, true)])];
+
+    const optimistic = begin({
+      events,
+      messageEventId: 'm1',
+      emoji: 'heart',
+      action: 'remove'
+    });
+
+    expect(reactionsOf(events[0])).toMatchObject([{ emoji: 'heart', count: 1, hasReacted: false }]);
+
+    optimistic.rollback();
+
+    expect(reactionsOf(events[0])).toMatchObject([{ emoji: 'heart', count: 2, hasReacted: true }]);
+  });
+
+  it('tracks independent pending reactions per emoji', () => {
+    const events = [messageEvent('m1')];
+    const registry = new OptimisticMutationRegistry();
+    const input = {
+      events,
+      previews: new Map<string, RoomEventView | null>(),
+      registry,
+      setEvent: (index: number, event: RoomEventView) => {
+        events[index] = event;
+      },
+      setPreview: () => {}
+    };
+
+    const heart = beginOptimisticReaction({
+      ...input,
+      messageEventId: 'm1',
+      emoji: 'heart',
+      action: 'add'
+    });
+    beginOptimisticReaction({
+      ...input,
+      messageEventId: 'm1',
+      emoji: 'thumbsup',
+      action: 'add'
+    });
+
+    heart.rollback();
+
+    expect(reactionsOf(events[0])).toMatchObject([
+      { emoji: 'thumbsup', count: 1, hasReacted: true }
+    ]);
+  });
+
+  it('reconciles the touched emoji from the RPC response', () => {
+    const events = [messageEvent('m1', [reaction('heart', 1, false)])];
+
+    const optimistic = begin({
+      events,
+      messageEventId: 'm1',
+      emoji: 'heart',
+      action: 'add'
+    });
+    optimistic.applyServerReaction({ emoji: 'heart', count: 5, hasReacted: true });
+    optimistic.rollback();
+
+    expect(reactionsOf(events[0])).toMatchObject([{ emoji: 'heart', count: 5, hasReacted: true }]);
+  });
+
+  it('rolls back only the touched reaction summary', () => {
+    const events = [messageEvent('m1', [reaction('heart', 1, false)])];
+
+    const optimistic = begin({
+      events,
+      messageEventId: 'm1',
+      emoji: 'heart',
+      action: 'add'
+    });
+    const event = events[0].event;
+    if (event?.kind !== RoomEventKind.MessagePosted) throw new Error('expected message');
+    events[0] = {
+      ...events[0],
+      event: {
+        ...event,
+        body: 'edited while reaction was pending',
+        reactions: [...reactionsOf(events[0]), reaction('thumbsup', 1, true)]
+      }
+    };
+
+    optimistic.rollback();
+
+    expect(events[0].event).toMatchObject({ body: 'edited while reaction was pending' });
+    expect(reactionsOf(events[0])).toMatchObject([
+      { emoji: 'heart', count: 1, hasReacted: false },
+      { emoji: 'thumbsup', count: 1, hasReacted: true }
+    ]);
+  });
+
+  it('patches loaded original and echo messages before the original has an echo backlink', () => {
+    const events = [
+      messageEvent('reply'),
+      messageEvent('echo', [], { echoOfEventId: 'reply', echoFromThreadRootEventId: 'root' })
+    ];
+
+    begin({
+      events,
+      messageEventId: 'echo',
+      emoji: 'heart',
+      action: 'add'
+    });
+
+    expect(reactionsOf(events[0])).toMatchObject([{ emoji: 'heart', count: 1, hasReacted: true }]);
+    expect(reactionsOf(events[1])).toMatchObject([{ emoji: 'heart', count: 1, hasReacted: true }]);
+  });
+
+  it('patches and rolls back preview cache rows', () => {
+    const previews = new Map<string, RoomEventView | null>([
+      ['room-1\u0000preview', messageEvent('preview', [reaction('heart', 1, false)])]
+    ]);
+
+    const optimistic = begin({
+      previews,
+      messageEventId: 'preview',
+      emoji: 'heart',
+      action: 'add'
+    });
+
+    expect(reactionsOf(previews.get('room-1\u0000preview')!)).toMatchObject([
+      { emoji: 'heart', count: 2, hasReacted: true }
+    ]);
+
+    optimistic.rollback();
+
+    expect(reactionsOf(previews.get('room-1\u0000preview')!)).toMatchObject([
+      { emoji: 'heart', count: 1, hasReacted: false }
+    ]);
+  });
+});

--- a/apps/frontend/src/lib/state/room/messages/optimisticReactions.ts
+++ b/apps/frontend/src/lib/state/room/messages/optimisticReactions.ts
@@ -32,16 +32,19 @@ type BeginOptimisticReactionInput = {
   messageEventId: string;
   emoji: string;
   action: OptimisticReactionAction;
-  events: readonly RoomEventView[];
+  getEvents(): readonly RoomEventView[];
   previews: Iterable<readonly [string, RoomEventView | null]>;
   registry: OptimisticMutationRegistry;
-  setEvent(index: number, event: RoomEventView): void;
+  setEvent(eventId: string, event: RoomEventView): void;
   setPreview(key: string, event: RoomEventView): void;
 };
 
-export function beginOptimisticReaction(input: BeginOptimisticReactionInput): OptimisticReactionHandle {
+export function beginOptimisticReaction(
+  input: BeginOptimisticReactionInput
+): OptimisticReactionHandle {
   const token = input.registry.createToken();
-  const targetIds = optimisticReactionTargetIds(input.messageEventId, input.events, input.previews);
+  const events = input.getEvents();
+  const targetIds = optimisticReactionTargetIds(input.messageEventId, events, input.previews);
   const snapshots: OptimisticReactionSnapshot[] = [];
 
   const record = (snapshot: OptimisticReactionSnapshot) => {
@@ -49,7 +52,7 @@ export function beginOptimisticReaction(input: BeginOptimisticReactionInput): Op
     input.registry.mark(snapshot.key, token);
   };
 
-  input.events.forEach((event, index) => {
+  events.forEach((event) => {
     if (!isReactionTarget(event, targetIds)) return;
     const updated = eventWithOptimisticReaction(event, input.emoji, input.action);
     if (!updated) return;
@@ -61,7 +64,7 @@ export function beginOptimisticReaction(input: BeginOptimisticReactionInput): Op
       source: 'events',
       eventId: event.id
     });
-    input.setEvent(index, updated);
+    input.setEvent(event.id, updated);
   });
 
   for (const [previewKey, event] of input.previews) {
@@ -168,7 +171,7 @@ function isReactionTarget(event: RoomEventView, targetIds: Set<string>): boolean
     isMessagePostedPayload(payload) &&
     Boolean(
       (payload.echoOfEventId && targetIds.has(payload.echoOfEventId)) ||
-        (payload.channelEchoEventId && targetIds.has(payload.channelEchoEventId))
+      (payload.channelEchoEventId && targetIds.has(payload.channelEchoEventId))
     )
   );
 }
@@ -309,10 +312,10 @@ function applyServerReactionSnapshot(
   };
 
   if (snapshot.source === 'events') {
-    const index = input.events.findIndex((event) => event.id === snapshot.eventId);
-    if (index === -1) return;
-    const updated = apply(input.events[index]);
-    if (updated) input.setEvent(index, updated);
+    const event = input.getEvents().find((event) => event.id === snapshot.eventId);
+    if (!event) return;
+    const updated = apply(event);
+    if (updated) input.setEvent(event.id, updated);
     return;
   }
 
@@ -328,14 +331,10 @@ function restoreOptimisticReactionSnapshot(
   input: BeginOptimisticReactionInput
 ): void {
   if (snapshot.source === 'events') {
-    const index = input.events.findIndex((event) => event.id === snapshot.eventId);
-    if (index === -1) return;
-    const updated = eventWithReactionSummary(
-      input.events[index],
-      snapshot.emoji,
-      snapshot.previousReaction
-    );
-    if (updated) input.setEvent(index, updated);
+    const event = input.getEvents().find((event) => event.id === snapshot.eventId);
+    if (!event) return;
+    const updated = eventWithReactionSummary(event, snapshot.emoji, snapshot.previousReaction);
+    if (updated) input.setEvent(event.id, updated);
     return;
   }
 

--- a/apps/frontend/src/lib/state/room/messages/optimisticReactions.ts
+++ b/apps/frontend/src/lib/state/room/messages/optimisticReactions.ts
@@ -1,0 +1,357 @@
+import type { RoomEventView } from '$lib/render/types';
+import { RoomEventKind } from '$lib/render/eventKinds';
+import type { OptimisticMutationRegistry } from '$lib/state/optimisticMutations';
+
+type RoomEventPayload = NonNullable<RoomEventView['event']>;
+type MessagePostedPayload = Extract<RoomEventPayload, { kind: typeof RoomEventKind.MessagePosted }>;
+type MessageReactionSummary = MessagePostedPayload['reactions'][number];
+
+export type OptimisticReactionAction = 'add' | 'remove';
+
+export type OptimisticReactionServerSummary = {
+  emoji: string;
+  count: number;
+  hasReacted: boolean;
+} | null;
+
+export type OptimisticReactionHandle = {
+  applyServerReaction(reaction: OptimisticReactionServerSummary): void;
+  rollback(): void;
+};
+
+type OptimisticReactionSnapshot = {
+  key: string;
+  emoji: string;
+  previousReaction: MessageReactionSummary | null;
+  source: 'events' | 'preview';
+  eventId?: string;
+  previewKey?: string;
+};
+
+type BeginOptimisticReactionInput = {
+  messageEventId: string;
+  emoji: string;
+  action: OptimisticReactionAction;
+  events: readonly RoomEventView[];
+  previews: Iterable<readonly [string, RoomEventView | null]>;
+  registry: OptimisticMutationRegistry;
+  setEvent(index: number, event: RoomEventView): void;
+  setPreview(key: string, event: RoomEventView): void;
+};
+
+export function beginOptimisticReaction(input: BeginOptimisticReactionInput): OptimisticReactionHandle {
+  const token = input.registry.createToken();
+  const targetIds = optimisticReactionTargetIds(input.messageEventId, input.events, input.previews);
+  const snapshots: OptimisticReactionSnapshot[] = [];
+
+  const record = (snapshot: OptimisticReactionSnapshot) => {
+    snapshots.push(snapshot);
+    input.registry.mark(snapshot.key, token);
+  };
+
+  input.events.forEach((event, index) => {
+    if (!isReactionTarget(event, targetIds)) return;
+    const updated = eventWithOptimisticReaction(event, input.emoji, input.action);
+    if (!updated) return;
+
+    record({
+      key: optimisticReactionEventKey(event.id, input.emoji),
+      emoji: input.emoji,
+      previousReaction: reactionSummary(event, input.emoji),
+      source: 'events',
+      eventId: event.id
+    });
+    input.setEvent(index, updated);
+  });
+
+  for (const [previewKey, event] of input.previews) {
+    if (!event || !isReactionTarget(event, targetIds)) continue;
+    const updated = eventWithOptimisticReaction(event, input.emoji, input.action);
+    if (!updated) continue;
+
+    record({
+      key: optimisticReactionPreviewKey(previewKey, input.emoji),
+      emoji: input.emoji,
+      previousReaction: reactionSummary(event, input.emoji),
+      source: 'preview',
+      previewKey
+    });
+    input.setPreview(previewKey, updated);
+  }
+
+  return {
+    applyServerReaction: (reaction) => {
+      for (const snapshot of snapshots) {
+        if (!input.registry.isCurrent(snapshot.key, token)) continue;
+        applyServerReactionSnapshot(snapshot, input.emoji, reaction, input);
+        input.registry.clear(snapshot.key);
+      }
+    },
+    rollback: () => {
+      for (const snapshot of snapshots) {
+        if (!input.registry.isCurrent(snapshot.key, token)) continue;
+        restoreOptimisticReactionSnapshot(snapshot, input);
+        input.registry.clear(snapshot.key);
+      }
+    }
+  };
+}
+
+export function clearOptimisticReactionsForEvent(
+  registry: OptimisticMutationRegistry,
+  eventId: string,
+  previewKey: string
+): void {
+  registry.clearPrefixes([
+    optimisticReactionEventKeyPrefix(eventId),
+    optimisticReactionPreviewKeyPrefix(previewKey)
+  ]);
+}
+
+function optimisticReactionEventKey(eventId: string, emoji: string): string {
+  return `${optimisticReactionEventKeyPrefix(eventId)}${emoji}`;
+}
+
+function optimisticReactionEventKeyPrefix(eventId: string): string {
+  return `events:${eventId}\u0000`;
+}
+
+function optimisticReactionPreviewKey(previewKey: string, emoji: string): string {
+  return `${optimisticReactionPreviewKeyPrefix(previewKey)}${emoji}`;
+}
+
+function optimisticReactionPreviewKeyPrefix(previewKey: string): string {
+  return `preview:${previewKey}\u0000`;
+}
+
+function optimisticReactionTargetIds(
+  messageEventId: string,
+  events: readonly RoomEventView[],
+  previews: Iterable<readonly [string, RoomEventView | null]>
+): Set<string> {
+  const targetIds = new Set([messageEventId]);
+  let changed = true;
+
+  while (changed) {
+    changed = false;
+    for (const event of events) {
+      changed = addLinkedReactionTargetIds(event, targetIds) || changed;
+    }
+    for (const [, event] of previews) {
+      if (event) changed = addLinkedReactionTargetIds(event, targetIds) || changed;
+    }
+  }
+
+  return targetIds;
+}
+
+function addLinkedReactionTargetIds(event: RoomEventView, targetIds: Set<string>): boolean {
+  const payload = event.event;
+  if (!isMessagePostedPayload(payload)) return false;
+
+  const before = targetIds.size;
+  if (targetIds.has(event.id)) {
+    if (payload.echoOfEventId) targetIds.add(payload.echoOfEventId);
+    if (payload.channelEchoEventId) targetIds.add(payload.channelEchoEventId);
+  }
+  if (payload.echoOfEventId && targetIds.has(payload.echoOfEventId)) targetIds.add(event.id);
+  if (payload.channelEchoEventId && targetIds.has(payload.channelEchoEventId)) {
+    targetIds.add(event.id);
+  }
+  return targetIds.size !== before;
+}
+
+function isReactionTarget(event: RoomEventView, targetIds: Set<string>): boolean {
+  if (targetIds.has(event.id)) return true;
+  const payload = event.event;
+  return (
+    isMessagePostedPayload(payload) &&
+    Boolean(
+      (payload.echoOfEventId && targetIds.has(payload.echoOfEventId)) ||
+        (payload.channelEchoEventId && targetIds.has(payload.channelEchoEventId))
+    )
+  );
+}
+
+function isMessagePostedPayload(
+  event: RoomEventView['event'] | null | undefined
+): event is MessagePostedPayload {
+  return event?.kind === RoomEventKind.MessagePosted;
+}
+
+function eventWithOptimisticReaction(
+  event: RoomEventView,
+  emoji: string,
+  action: OptimisticReactionAction
+): RoomEventView | null {
+  const payload = event.event;
+  if (!isMessagePostedPayload(payload)) return null;
+  return {
+    ...event,
+    event: {
+      ...payload,
+      reactions: optimisticReactions(payload.reactions, emoji, action)
+    }
+  };
+}
+
+function reactionSummary(event: RoomEventView, emoji: string): MessageReactionSummary | null {
+  const payload = event.event;
+  if (!isMessagePostedPayload(payload)) return null;
+  return payload.reactions.find((reaction) => reaction.emoji === emoji) ?? null;
+}
+
+function eventWithReactionSummary(
+  event: RoomEventView,
+  emoji: string,
+  reaction: MessageReactionSummary | null
+): RoomEventView | null {
+  const payload = event.event;
+  if (!isMessagePostedPayload(payload)) return null;
+  return {
+    ...event,
+    event: {
+      ...payload,
+      reactions: reactionsWithSummary(payload.reactions, emoji, reaction)
+    }
+  };
+}
+
+function optimisticReactions(
+  reactions: readonly MessageReactionSummary[],
+  emoji: string,
+  action: OptimisticReactionAction
+): MessageReactionSummary[] {
+  const existingIndex = reactions.findIndex((reaction) => reaction.emoji === emoji);
+  if (action === 'add') {
+    if (existingIndex === -1) {
+      return [...reactions, { emoji, count: 1, hasReacted: true, users: [] }];
+    }
+
+    return reactions.map((reaction, index) =>
+      index === existingIndex
+        ? {
+            ...reaction,
+            count: reaction.hasReacted ? reaction.count : reaction.count + 1,
+            hasReacted: true
+          }
+        : reaction
+    );
+  }
+
+  if (existingIndex === -1) return [...reactions];
+
+  return reactions.flatMap((reaction, index) => {
+    if (index !== existingIndex) return [reaction];
+    const count = reaction.hasReacted ? Math.max(0, reaction.count - 1) : reaction.count;
+    if (count === 0) return [];
+    return [{ ...reaction, count, hasReacted: false }];
+  });
+}
+
+function reactionsWithSummary(
+  reactions: readonly MessageReactionSummary[],
+  emoji: string,
+  reaction: MessageReactionSummary | null
+): MessageReactionSummary[] {
+  if (!reaction || reaction.count <= 0) {
+    return reactions.filter((existing) => existing.emoji !== emoji);
+  }
+
+  const existingIndex = reactions.findIndex((existing) => existing.emoji === emoji);
+  const nextReaction = {
+    ...reaction,
+    users: [...reaction.users]
+  };
+  if (existingIndex === -1) return [...reactions, nextReaction];
+  return reactions.map((existing, index) => (index === existingIndex ? nextReaction : existing));
+}
+
+function serverReactions(
+  reactions: readonly MessageReactionSummary[],
+  emoji: string,
+  reaction: OptimisticReactionServerSummary
+): MessageReactionSummary[] {
+  if (!reaction || reaction.count <= 0) {
+    return reactions.filter((existing) => existing.emoji !== emoji);
+  }
+
+  const existingIndex = reactions.findIndex((existing) => existing.emoji === emoji);
+  const nextReaction = (existing?: MessageReactionSummary): MessageReactionSummary => ({
+    emoji: reaction.emoji,
+    count: reaction.count,
+    hasReacted: reaction.hasReacted,
+    users: existing?.users ?? []
+  });
+
+  if (existingIndex === -1) return [...reactions, nextReaction()];
+  return reactions.map((existing, index) =>
+    index === existingIndex ? nextReaction(existing) : existing
+  );
+}
+
+function applyServerReactionSnapshot(
+  snapshot: OptimisticReactionSnapshot,
+  emoji: string,
+  reaction: OptimisticReactionServerSummary,
+  input: BeginOptimisticReactionInput
+): void {
+  const apply = (event: RoomEventView): RoomEventView | null => {
+    const payload = event.event;
+    if (!isMessagePostedPayload(payload)) return null;
+    return {
+      ...event,
+      event: {
+        ...payload,
+        reactions: serverReactions(payload.reactions, emoji, reaction)
+      }
+    };
+  };
+
+  if (snapshot.source === 'events') {
+    const index = input.events.findIndex((event) => event.id === snapshot.eventId);
+    if (index === -1) return;
+    const updated = apply(input.events[index]);
+    if (updated) input.setEvent(index, updated);
+    return;
+  }
+
+  if (!snapshot.previewKey) return;
+  const event = previewEvent(input.previews, snapshot.previewKey);
+  if (!event) return;
+  const updated = apply(event);
+  if (updated) input.setPreview(snapshot.previewKey, updated);
+}
+
+function restoreOptimisticReactionSnapshot(
+  snapshot: OptimisticReactionSnapshot,
+  input: BeginOptimisticReactionInput
+): void {
+  if (snapshot.source === 'events') {
+    const index = input.events.findIndex((event) => event.id === snapshot.eventId);
+    if (index === -1) return;
+    const updated = eventWithReactionSummary(
+      input.events[index],
+      snapshot.emoji,
+      snapshot.previousReaction
+    );
+    if (updated) input.setEvent(index, updated);
+    return;
+  }
+
+  if (!snapshot.previewKey) return;
+  const event = previewEvent(input.previews, snapshot.previewKey);
+  if (!event) return;
+  const updated = eventWithReactionSummary(event, snapshot.emoji, snapshot.previousReaction);
+  if (updated) input.setPreview(snapshot.previewKey, updated);
+}
+
+function previewEvent(
+  previews: Iterable<readonly [string, RoomEventView | null]>,
+  previewKey: string
+): RoomEventView | null {
+  for (const [key, event] of previews) {
+    if (key === previewKey) return event;
+  }
+  return null;
+}

--- a/apps/frontend/src/lib/state/room/messages/optimisticThreadFollow.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages/optimisticThreadFollow.spec.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import type { RoomEventView } from '$lib/render/types';
+import { RoomEventKind } from '$lib/render/eventKinds';
+import { OptimisticMutationRegistry } from '$lib/state/optimisticMutations';
+import { beginOptimisticThreadFollow, clearOptimisticThreadFollowForEvent } from './optimisticThreadFollow';
+
+function messageEvent(id: string, isFollowing: boolean | null): RoomEventView {
+  return {
+    id,
+    createdAt: '2026-05-27T00:00:00Z',
+    actorId: 'u1',
+    actor: null,
+    event: {
+      kind: RoomEventKind.MessagePosted,
+      roomId: 'room-1',
+      body: id,
+      attachments: [],
+      linkPreview: null,
+      updatedAt: null,
+      inReplyTo: null,
+      threadRootEventId: null,
+      echoOfEventId: null,
+      echoFromThreadRootEventId: null,
+      channelEchoEventId: null,
+      replyCount: 1,
+      lastReplyAt: null,
+      threadParticipants: [],
+      viewerIsFollowingThread: isFollowing,
+      reactions: []
+    }
+  };
+}
+
+function followState(event: RoomEventView): boolean | null | undefined {
+  if (event.event?.kind !== RoomEventKind.MessagePosted) throw new Error('expected message');
+  return event.event.viewerIsFollowingThread;
+}
+
+function begin(input: {
+  events: RoomEventView[];
+  registry?: OptimisticMutationRegistry;
+  threadRootEventId?: string;
+  isFollowing: boolean;
+}) {
+  const registry = input.registry ?? new OptimisticMutationRegistry();
+  return beginOptimisticThreadFollow({
+    threadRootEventId: input.threadRootEventId ?? 'root',
+    isFollowing: input.isFollowing,
+    events: input.events,
+    registry,
+    setEvent: (index, event) => {
+      input.events[index] = event;
+    }
+  });
+}
+
+describe('optimistic thread follow', () => {
+  it('applies and rolls back only viewer follow state', () => {
+    const events = [messageEvent('root', false)];
+
+    const optimistic = begin({ events, isFollowing: true });
+
+    expect(followState(events[0])).toBe(true);
+
+    const event = events[0].event;
+    if (event?.kind !== RoomEventKind.MessagePosted) throw new Error('expected message');
+    events[0] = {
+      ...events[0],
+      event: {
+        ...event,
+        replyCount: 3
+      }
+    };
+
+    optimistic.rollback();
+
+    expect(followState(events[0])).toBe(false);
+    expect(events[0].event).toMatchObject({ replyCount: 3 });
+  });
+
+  it('reconciles from the server response', () => {
+    const events = [messageEvent('root', false)];
+
+    const optimistic = begin({ events, isFollowing: true });
+    optimistic.applyServerState(false);
+    optimistic.rollback();
+
+    expect(followState(events[0])).toBe(false);
+  });
+
+  it('keeps independent rapid toggles from rolling each other back', () => {
+    const events = [messageEvent('root', false)];
+    const registry = new OptimisticMutationRegistry();
+
+    const first = begin({ events, registry, isFollowing: true });
+    begin({ events, registry, isFollowing: false });
+
+    first.rollback();
+
+    expect(followState(events[0])).toBe(false);
+  });
+
+  it('clears stale rollback when an authoritative row arrives', () => {
+    const events = [messageEvent('root', false)];
+    const registry = new OptimisticMutationRegistry();
+
+    const optimistic = begin({ events, registry, isFollowing: true });
+    clearOptimisticThreadFollowForEvent(registry, 'root');
+    events[0] = messageEvent('root', true);
+    optimistic.rollback();
+
+    expect(followState(events[0])).toBe(true);
+  });
+});

--- a/apps/frontend/src/lib/state/room/messages/optimisticThreadFollow.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages/optimisticThreadFollow.spec.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 import type { RoomEventView } from '$lib/render/types';
 import { RoomEventKind } from '$lib/render/eventKinds';
 import { OptimisticMutationRegistry } from '$lib/state/optimisticMutations';
-import { beginOptimisticThreadFollow, clearOptimisticThreadFollowForEvent } from './optimisticThreadFollow';
+import {
+  beginOptimisticThreadFollow,
+  clearOptimisticThreadFollowForEvent
+} from './optimisticThreadFollow';
 
 function messageEvent(id: string, isFollowing: boolean | null): RoomEventView {
   return {
@@ -46,10 +49,11 @@ function begin(input: {
   return beginOptimisticThreadFollow({
     threadRootEventId: input.threadRootEventId ?? 'root',
     isFollowing: input.isFollowing,
-    events: input.events,
+    getEvents: () => input.events,
     registry,
-    setEvent: (index, event) => {
-      input.events[index] = event;
+    setEvent: (eventId, event) => {
+      const index = input.events.findIndex((candidate) => candidate.id === eventId);
+      if (index !== -1) input.events[index] = event;
     }
   });
 }
@@ -78,14 +82,19 @@ describe('optimistic thread follow', () => {
     expect(events[0].event).toMatchObject({ replyCount: 3 });
   });
 
-  it('reconciles from the server response', () => {
-    const events = [messageEvent('root', false)];
+  it('resolves the root by ID after the events array is replaced', () => {
+    const input = {
+      events: [messageEvent('root', false), messageEvent('other', null)],
+      isFollowing: true
+    };
+    const optimistic = begin(input);
 
-    const optimistic = begin({ events, isFollowing: true });
-    optimistic.applyServerState(false);
+    input.events = [messageEvent('new', null), ...input.events];
     optimistic.rollback();
 
-    expect(followState(events[0])).toBe(false);
+    expect(input.events.map((event) => event.id)).toEqual(['new', 'root', 'other']);
+    expect(followState(input.events[1])).toBe(false);
+    expect(followState(input.events[0])).toBeNull();
   });
 
   it('keeps independent rapid toggles from rolling each other back', () => {

--- a/apps/frontend/src/lib/state/room/messages/optimisticThreadFollow.ts
+++ b/apps/frontend/src/lib/state/room/messages/optimisticThreadFollow.ts
@@ -8,16 +8,15 @@ type MessagePostedPayload = Extract<
 >;
 
 export type OptimisticThreadFollowHandle = {
-  applyServerState(isFollowing: boolean): void;
   rollback(): void;
 };
 
 type BeginOptimisticThreadFollowInput = {
   threadRootEventId: string;
   isFollowing: boolean;
-  events: readonly RoomEventView[];
+  getEvents(): readonly RoomEventView[];
   registry: OptimisticMutationRegistry;
-  setEvent(index: number, event: RoomEventView): void;
+  setEvent(eventId: string, event: RoomEventView): void;
 };
 
 export function beginOptimisticThreadFollow(
@@ -25,8 +24,7 @@ export function beginOptimisticThreadFollow(
 ): OptimisticThreadFollowHandle {
   const token = input.registry.createToken();
   const key = optimisticThreadFollowKey(input.threadRootEventId);
-  const index = input.events.findIndex((event) => event.id === input.threadRootEventId);
-  const event = index === -1 ? null : input.events[index];
+  const event = input.getEvents().find((event) => event.id === input.threadRootEventId) ?? null;
   const previousState = isMessagePostedPayload(event?.event)
     ? (event.event.viewerIsFollowingThread ?? null)
     : null;
@@ -35,26 +33,17 @@ export function beginOptimisticThreadFollow(
     const updated = eventWithThreadFollowState(event, input.isFollowing);
     if (updated) {
       input.registry.mark(key, token);
-      input.setEvent(index, updated);
+      input.setEvent(event.id, updated);
     }
   }
 
   return {
-    applyServerState: (isFollowing) => {
-      if (!input.registry.isCurrent(key, token)) return;
-      const currentIndex = input.events.findIndex((event) => event.id === input.threadRootEventId);
-      if (currentIndex !== -1) {
-        const updated = eventWithThreadFollowState(input.events[currentIndex], isFollowing);
-        if (updated) input.setEvent(currentIndex, updated);
-      }
-      input.registry.clear(key);
-    },
     rollback: () => {
       if (!input.registry.isCurrent(key, token)) return;
-      const currentIndex = input.events.findIndex((event) => event.id === input.threadRootEventId);
-      if (currentIndex !== -1) {
-        const updated = eventWithThreadFollowState(input.events[currentIndex], previousState);
-        if (updated) input.setEvent(currentIndex, updated);
+      const event = input.getEvents().find((event) => event.id === input.threadRootEventId);
+      if (event) {
+        const updated = eventWithThreadFollowState(event, previousState);
+        if (updated) input.setEvent(event.id, updated);
       }
       input.registry.clear(key);
     }

--- a/apps/frontend/src/lib/state/room/messages/optimisticThreadFollow.ts
+++ b/apps/frontend/src/lib/state/room/messages/optimisticThreadFollow.ts
@@ -1,0 +1,94 @@
+import type { RoomEventView } from '$lib/render/types';
+import { RoomEventKind } from '$lib/render/eventKinds';
+import type { OptimisticMutationRegistry } from '$lib/state/optimisticMutations';
+
+type MessagePostedPayload = Extract<
+  NonNullable<RoomEventView['event']>,
+  { kind: typeof RoomEventKind.MessagePosted }
+>;
+
+export type OptimisticThreadFollowHandle = {
+  applyServerState(isFollowing: boolean): void;
+  rollback(): void;
+};
+
+type BeginOptimisticThreadFollowInput = {
+  threadRootEventId: string;
+  isFollowing: boolean;
+  events: readonly RoomEventView[];
+  registry: OptimisticMutationRegistry;
+  setEvent(index: number, event: RoomEventView): void;
+};
+
+export function beginOptimisticThreadFollow(
+  input: BeginOptimisticThreadFollowInput
+): OptimisticThreadFollowHandle {
+  const token = input.registry.createToken();
+  const key = optimisticThreadFollowKey(input.threadRootEventId);
+  const index = input.events.findIndex((event) => event.id === input.threadRootEventId);
+  const event = index === -1 ? null : input.events[index];
+  const previousState = isMessagePostedPayload(event?.event)
+    ? (event.event.viewerIsFollowingThread ?? null)
+    : null;
+
+  if (event) {
+    const updated = eventWithThreadFollowState(event, input.isFollowing);
+    if (updated) {
+      input.registry.mark(key, token);
+      input.setEvent(index, updated);
+    }
+  }
+
+  return {
+    applyServerState: (isFollowing) => {
+      if (!input.registry.isCurrent(key, token)) return;
+      const currentIndex = input.events.findIndex((event) => event.id === input.threadRootEventId);
+      if (currentIndex !== -1) {
+        const updated = eventWithThreadFollowState(input.events[currentIndex], isFollowing);
+        if (updated) input.setEvent(currentIndex, updated);
+      }
+      input.registry.clear(key);
+    },
+    rollback: () => {
+      if (!input.registry.isCurrent(key, token)) return;
+      const currentIndex = input.events.findIndex((event) => event.id === input.threadRootEventId);
+      if (currentIndex !== -1) {
+        const updated = eventWithThreadFollowState(input.events[currentIndex], previousState);
+        if (updated) input.setEvent(currentIndex, updated);
+      }
+      input.registry.clear(key);
+    }
+  };
+}
+
+export function clearOptimisticThreadFollowForEvent(
+  registry: OptimisticMutationRegistry,
+  threadRootEventId: string
+): void {
+  registry.clear(optimisticThreadFollowKey(threadRootEventId));
+}
+
+function optimisticThreadFollowKey(threadRootEventId: string): string {
+  return `thread-follow:${threadRootEventId}`;
+}
+
+function isMessagePostedPayload(
+  event: RoomEventView['event'] | null | undefined
+): event is MessagePostedPayload {
+  return event?.kind === RoomEventKind.MessagePosted;
+}
+
+function eventWithThreadFollowState(
+  event: RoomEventView,
+  isFollowing: boolean | null
+): RoomEventView | null {
+  const payload = event.event;
+  if (!isMessagePostedPayload(payload)) return null;
+  return {
+    ...event,
+    event: {
+      ...payload,
+      viewerIsFollowingThread: isFollowing
+    }
+  };
+}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -21,7 +21,6 @@
     type RoomMember
   } from '$lib/state/room';
   import { useConnection } from '$lib/state/server/connection.svelte';
-  import { OptimisticMutationRegistry } from '$lib/state/optimisticMutations';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { getServerPermissions } from '$lib/state/server/permissions.svelte';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
@@ -329,15 +328,13 @@
   // Overridable derived state: backing event data is the default, while
   // mutations/live events can update the row immediately.
   let isFollowingThread = $derived(messageEvent?.viewerIsFollowingThread ?? false);
-  const threadFollowOptimism = new OptimisticMutationRegistry();
-
-  function threadFollowKey(threadRootEventId: string): string {
-    return `message-thread-follow:${threadRootEventId}`;
-  }
+  let threadFollowRequestId = 0;
+  let isThreadFollowPending = $state(false);
 
   function setThreadFollowState(value: boolean) {
     if (!event) return;
-    threadFollowOptimism.clear(threadFollowKey(event.id));
+    threadFollowRequestId += 1;
+    isThreadFollowPending = false;
     isFollowingThread = value;
     messageStore?.setThreadRootFollowState(event.id, value);
   }
@@ -352,15 +349,14 @@
 
   async function toggleThreadFollow(e: MouseEvent) {
     e.stopPropagation();
-    if (!event) return;
+    if (!event || isThreadFollowPending) return;
 
     const wasFollowing = isFollowingThread;
     const nextFollowing = !wasFollowing;
-    const key = threadFollowKey(event.id);
-    const token = threadFollowOptimism.createToken();
+    const requestId = ++threadFollowRequestId;
     const optimistic = messageStore?.beginOptimisticThreadFollow(event.id, nextFollowing);
 
-    threadFollowOptimism.mark(key, token);
+    isThreadFollowPending = true;
     isFollowingThread = nextFollowing;
 
     try {
@@ -370,27 +366,15 @@
         baseUrl: conn.connectBaseUrl,
         bearerToken: conn.bearerToken
       });
-      if (wasFollowing) {
-        const result = await api.unfollowThread({ roomId, threadRootEventId: event.id });
-        if (threadFollowOptimism.isCurrent(key, token)) {
-          isFollowingThread = result.following;
-          optimistic?.applyServerState(result.following);
-          threadFollowOptimism.clear(key);
-        }
-      } else {
-        const result = await api.followThread({ roomId, threadRootEventId: event.id });
-        if (threadFollowOptimism.isCurrent(key, token)) {
-          isFollowingThread = result.following;
-          optimistic?.applyServerState(result.following);
-          threadFollowOptimism.clear(key);
-        }
-      }
+      const input = { roomId, threadRootEventId: event.id };
+      const result = wasFollowing ? await api.unfollowThread(input) : await api.followThread(input);
+      if (threadFollowRequestId !== requestId) return;
+      setThreadFollowState(result.following);
     } catch {
-      if (threadFollowOptimism.isCurrent(key, token)) {
-        isFollowingThread = wasFollowing;
-        optimistic?.rollback();
-        threadFollowOptimism.clear(key);
-      }
+      if (threadFollowRequestId !== requestId) return;
+      isThreadFollowPending = false;
+      isFollowingThread = wasFollowing;
+      optimistic?.rollback();
     }
   }
 
@@ -898,6 +882,7 @@
             canReact={roomPermissions.canReact}
             {messageStore}
             {isFollowingThread}
+            {isThreadFollowPending}
             onToggleThreadFollow={hasReplies ? toggleThreadFollow : undefined}
             onOpenThread={onOpenThread ? handleOpenThread : undefined}
             onOpenEmojiPicker={roomPermissions.canReact ? openEmojiPickerFromEvent : undefined}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -21,6 +21,7 @@
     type RoomMember
   } from '$lib/state/room';
   import { useConnection } from '$lib/state/server/connection.svelte';
+  import { OptimisticMutationRegistry } from '$lib/state/optimisticMutations';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { getServerPermissions } from '$lib/state/server/permissions.svelte';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
@@ -328,9 +329,15 @@
   // Overridable derived state: backing event data is the default, while
   // mutations/live events can update the row immediately.
   let isFollowingThread = $derived(messageEvent?.viewerIsFollowingThread ?? false);
+  const threadFollowOptimism = new OptimisticMutationRegistry();
+
+  function threadFollowKey(threadRootEventId: string): string {
+    return `message-thread-follow:${threadRootEventId}`;
+  }
 
   function setThreadFollowState(value: boolean) {
     if (!event) return;
+    threadFollowOptimism.clear(threadFollowKey(event.id));
     isFollowingThread = value;
     messageStore?.setThreadRootFollowState(event.id, value);
   }
@@ -345,9 +352,16 @@
 
   async function toggleThreadFollow(e: MouseEvent) {
     e.stopPropagation();
+    if (!event) return;
+
     const wasFollowing = isFollowingThread;
     const nextFollowing = !wasFollowing;
-    setThreadFollowState(nextFollowing);
+    const key = threadFollowKey(event.id);
+    const token = threadFollowOptimism.createToken();
+    const optimistic = messageStore?.beginOptimisticThreadFollow(event.id, nextFollowing);
+
+    threadFollowOptimism.mark(key, token);
+    isFollowingThread = nextFollowing;
 
     try {
       const conn = connection();
@@ -357,13 +371,26 @@
         bearerToken: conn.bearerToken
       });
       if (wasFollowing) {
-        await api.unfollowThread({ roomId, threadRootEventId: event.id });
+        const result = await api.unfollowThread({ roomId, threadRootEventId: event.id });
+        if (threadFollowOptimism.isCurrent(key, token)) {
+          isFollowingThread = result.following;
+          optimistic?.applyServerState(result.following);
+          threadFollowOptimism.clear(key);
+        }
       } else {
-        await api.followThread({ roomId, threadRootEventId: event.id });
+        const result = await api.followThread({ roomId, threadRootEventId: event.id });
+        if (threadFollowOptimism.isCurrent(key, token)) {
+          isFollowingThread = result.following;
+          optimistic?.applyServerState(result.following);
+          threadFollowOptimism.clear(key);
+        }
       }
-      setThreadFollowState(nextFollowing);
     } catch {
-      setThreadFollowState(wasFollowing);
+      if (threadFollowOptimism.isCurrent(key, token)) {
+        isFollowingThread = wasFollowing;
+        optimistic?.rollback();
+        threadFollowOptimism.clear(key);
+      }
     }
   }
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte
@@ -54,6 +54,7 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
     canReact = false,
     messageStore = null,
     isFollowingThread = false,
+    isThreadFollowPending = false,
     onToggleThreadFollow,
     onOpenThread,
     onOpenEmojiPicker,
@@ -70,6 +71,7 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
     canReact?: boolean;
     messageStore?: MessagesStore | null;
     isFollowingThread?: boolean;
+    isThreadFollowPending?: boolean;
     onToggleThreadFollow?: (e: MouseEvent) => void;
     onOpenThread?: () => void;
     onOpenEmojiPicker?: (e: MouseEvent) => void;
@@ -214,6 +216,7 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
           isFollowingThread ? 'text-text' : ''
         ]}
         onclick={onToggleThreadFollow}
+        disabled={isThreadFollowPending}
         title={isFollowingThread
           ? m['room.message.meta.unfollow_thread']()
           : m['room.message.meta.follow_thread']()}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts
@@ -188,6 +188,25 @@ describe('MessageMetaBar', () => {
     expect(followButton?.closest('a')).toBeNull();
   });
 
+  it('disables the follow toggle while a request is pending', () => {
+    const onToggleThreadFollow = vi.fn();
+    const { container } = render(MessageMetaBar, {
+      props: {
+        ...baseProps,
+        replyCount: 1,
+        isFollowingThread: true,
+        isThreadFollowPending: true,
+        onToggleThreadFollow
+      }
+    });
+
+    const followButton = q(container, 'button[title="Unfollow thread"]') as HTMLButtonElement;
+    followButton.click();
+
+    expect(followButton.disabled).toBe(true);
+    expect(onToggleThreadFollow).not.toHaveBeenCalled();
+  });
+
   it('shows reaction tooltips with the readable reaction name and reacting users', () => {
     const { container } = render(MessageMetaBar, {
       props: {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -3,7 +3,6 @@
   import { fly } from 'svelte/transition';
   import { createReadStateAPI, type MarkThreadAsReadResult } from '$lib/api-client/readState';
   import { createThreadAPI } from '$lib/api-client/threads';
-  import { OptimisticMutationRegistry } from '$lib/state/optimisticMutations';
   import { useEvent, createTypingIndicator, useUnreadMarker } from '$lib/hooks';
   import { useConnection } from '$lib/state/server/connection.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
@@ -187,14 +186,12 @@
   let isFollowingThread = $state(false);
   let _followSeededForThread = '';
   let _followSubFiredForThread = '';
-  const threadFollowOptimism = new OptimisticMutationRegistry();
+  let threadFollowRequestId = 0;
+  let isThreadFollowPending = $state(false);
 
-  function threadFollowKey(threadId: string): string {
-    return `thread-pane-follow:${threadId}`;
-  }
-
-  function setAuthoritativeThreadFollowState(threadId: string, value: boolean) {
-    threadFollowOptimism.clear(threadFollowKey(threadId));
+  function setAuthoritativeThreadFollowState(value: boolean) {
+    threadFollowRequestId += 1;
+    isThreadFollowPending = false;
     isFollowingThread = value;
   }
 
@@ -202,12 +199,13 @@
     const threadId = threadRootEventId;
 
     if (threadId !== _followSeededForThread) {
-      threadFollowOptimism.clearAll();
+      threadFollowRequestId += 1;
+      isThreadFollowPending = false;
       // Only reset if the subscription hasn't already authoritatively set the
       // state for this thread (auto-follow can fire before the initial query
       // resolves).
       if (_followSubFiredForThread !== threadId) {
-        setAuthoritativeThreadFollowState(threadId, false);
+        setAuthoritativeThreadFollowState(false);
       }
 
       // Wait until data has loaded before reading follow state
@@ -216,10 +214,7 @@
         if (_followSubFiredForThread !== threadId) {
           const rootEvent = threadEvents.find((e) => e.id === threadId);
           if (isMessagePostedEvent(rootEvent?.event)) {
-            setAuthoritativeThreadFollowState(
-              threadId,
-              rootEvent.event.viewerIsFollowingThread ?? false
-            );
+            setAuthoritativeThreadFollowState(rootEvent.event.viewerIsFollowingThread ?? false);
           }
         }
       }
@@ -227,12 +222,13 @@
   });
 
   async function toggleThreadFollow() {
+    if (isThreadFollowPending) return;
+
     const wasFollowing = isFollowingThread;
     const nextFollowing = !wasFollowing;
-    const key = threadFollowKey(threadRootEventId);
-    const token = threadFollowOptimism.createToken();
+    const requestId = ++threadFollowRequestId;
 
-    threadFollowOptimism.mark(key, token);
+    isThreadFollowPending = true;
     isFollowingThread = nextFollowing;
 
     try {
@@ -242,22 +238,14 @@
         baseUrl: conn.connectBaseUrl,
         bearerToken: conn.bearerToken
       });
-      if (wasFollowing) {
-        const result = await api.unfollowThread({ roomId, threadRootEventId });
-        if (threadFollowOptimism.isCurrent(key, token)) {
-          setAuthoritativeThreadFollowState(threadRootEventId, result.following);
-        }
-      } else {
-        const result = await api.followThread({ roomId, threadRootEventId });
-        if (threadFollowOptimism.isCurrent(key, token)) {
-          setAuthoritativeThreadFollowState(threadRootEventId, result.following);
-        }
-      }
+      const input = { roomId, threadRootEventId };
+      const result = wasFollowing ? await api.unfollowThread(input) : await api.followThread(input);
+      if (threadFollowRequestId !== requestId) return;
+      setAuthoritativeThreadFollowState(result.following);
     } catch {
-      if (threadFollowOptimism.isCurrent(key, token)) {
-        isFollowingThread = wasFollowing;
-        threadFollowOptimism.clear(key);
-      }
+      if (threadFollowRequestId !== requestId) return;
+      isThreadFollowPending = false;
+      isFollowingThread = wasFollowing;
     }
   }
 
@@ -265,7 +253,7 @@
   $effect(() =>
     onThreadFollowChanged((update) => {
       if (update.threadRootEventId === threadRootEventId) {
-        setAuthoritativeThreadFollowState(update.threadRootEventId, update.isFollowing);
+        setAuthoritativeThreadFollowState(update.isFollowing);
         _followSubFiredForThread = update.threadRootEventId;
       }
     })
@@ -305,6 +293,7 @@
         label={isFollowingThread ? m['room.thread.unfollow']() : m['room.thread.follow']()}
         tone={isFollowingThread ? 'active' : 'default'}
         onclick={toggleThreadFollow}
+        disabled={isThreadFollowPending}
       />
       <HeaderIconButton icon="uil--times" label={m['room.thread.close']()} onclick={onClose} />
     {/snippet}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -3,6 +3,7 @@
   import { fly } from 'svelte/transition';
   import { createReadStateAPI, type MarkThreadAsReadResult } from '$lib/api-client/readState';
   import { createThreadAPI } from '$lib/api-client/threads';
+  import { OptimisticMutationRegistry } from '$lib/state/optimisticMutations';
   import { useEvent, createTypingIndicator, useUnreadMarker } from '$lib/hooks';
   import { useConnection } from '$lib/state/server/connection.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
@@ -186,16 +187,27 @@
   let isFollowingThread = $state(false);
   let _followSeededForThread = '';
   let _followSubFiredForThread = '';
+  const threadFollowOptimism = new OptimisticMutationRegistry();
+
+  function threadFollowKey(threadId: string): string {
+    return `thread-pane-follow:${threadId}`;
+  }
+
+  function setAuthoritativeThreadFollowState(threadId: string, value: boolean) {
+    threadFollowOptimism.clear(threadFollowKey(threadId));
+    isFollowingThread = value;
+  }
 
   $effect(() => {
     const threadId = threadRootEventId;
 
     if (threadId !== _followSeededForThread) {
+      threadFollowOptimism.clearAll();
       // Only reset if the subscription hasn't already authoritatively set the
       // state for this thread (auto-follow can fire before the initial query
       // resolves).
       if (_followSubFiredForThread !== threadId) {
-        isFollowingThread = false;
+        setAuthoritativeThreadFollowState(threadId, false);
       }
 
       // Wait until data has loaded before reading follow state
@@ -204,7 +216,10 @@
         if (_followSubFiredForThread !== threadId) {
           const rootEvent = threadEvents.find((e) => e.id === threadId);
           if (isMessagePostedEvent(rootEvent?.event)) {
-            isFollowingThread = rootEvent.event.viewerIsFollowingThread ?? false;
+            setAuthoritativeThreadFollowState(
+              threadId,
+              rootEvent.event.viewerIsFollowingThread ?? false
+            );
           }
         }
       }
@@ -213,7 +228,12 @@
 
   async function toggleThreadFollow() {
     const wasFollowing = isFollowingThread;
-    isFollowingThread = !wasFollowing;
+    const nextFollowing = !wasFollowing;
+    const key = threadFollowKey(threadRootEventId);
+    const token = threadFollowOptimism.createToken();
+
+    threadFollowOptimism.mark(key, token);
+    isFollowingThread = nextFollowing;
 
     try {
       const conn = connection();
@@ -223,12 +243,21 @@
         bearerToken: conn.bearerToken
       });
       if (wasFollowing) {
-        await api.unfollowThread({ roomId, threadRootEventId });
+        const result = await api.unfollowThread({ roomId, threadRootEventId });
+        if (threadFollowOptimism.isCurrent(key, token)) {
+          setAuthoritativeThreadFollowState(threadRootEventId, result.following);
+        }
       } else {
-        await api.followThread({ roomId, threadRootEventId });
+        const result = await api.followThread({ roomId, threadRootEventId });
+        if (threadFollowOptimism.isCurrent(key, token)) {
+          setAuthoritativeThreadFollowState(threadRootEventId, result.following);
+        }
       }
     } catch {
-      isFollowingThread = wasFollowing;
+      if (threadFollowOptimism.isCurrent(key, token)) {
+        isFollowingThread = wasFollowing;
+        threadFollowOptimism.clear(key);
+      }
     }
   }
 
@@ -236,7 +265,7 @@
   $effect(() =>
     onThreadFollowChanged((update) => {
       if (update.threadRootEventId === threadRootEventId) {
-        isFollowingThread = update.isFollowing;
+        setAuthoritativeThreadFollowState(update.threadRootEventId, update.isFollowing);
         _followSubFiredForThread = update.threadRootEventId;
       }
     })

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
+import { q } from '$lib/test-utils';
 import ThreadPane from './ThreadPane.svelte';
 
 const { mocks } = vi.hoisted(() => {
@@ -156,6 +157,14 @@ describe('ThreadPane', () => {
       previousReadAt: null,
       lastReadAt: '2026-07-04T13:00:00Z'
     });
+    mocks.followThread.mockResolvedValue({
+      following: true,
+      state: { roomId: 'room-1', threadRootEventId: 'thread-root', following: true }
+    });
+    mocks.unfollowThread.mockResolvedValue({
+      following: false,
+      state: { roomId: 'room-1', threadRootEventId: 'thread-root', following: false }
+    });
   });
 
   it('marks the thread as read without directly dismissing thread notifications', async () => {
@@ -179,5 +188,45 @@ describe('ThreadPane', () => {
     expect(mocks.setThread).toHaveBeenCalledWith('room-1', 'thread-root');
     expect(mocks.notifications.dismissThreadNotifications).not.toHaveBeenCalled();
     expect(mocks.rooms.decrementUnreadNotification).not.toHaveBeenCalled();
+  });
+
+  it('updates the thread follow button optimistically while the RPC is pending', async () => {
+    let resolveFollow!: (value: {
+      following: boolean;
+      state: { roomId: string; threadRootEventId: string; following: boolean };
+    }) => void;
+    mocks.followThread.mockReturnValue(
+      new Promise((resolve) => {
+        resolveFollow = resolve;
+      })
+    );
+
+    const { container } = render(ThreadPane, {
+      props: {
+        roomId: 'room-1',
+        roomName: 'General',
+        threadRootEventId: 'thread-root',
+        onClose: mocks.onClose
+      }
+    });
+
+    (q(container, 'button[aria-label="Follow thread"]') as HTMLButtonElement).click();
+
+    await vi.waitFor(() => {
+      expect(q(container, 'button[aria-label="Unfollow thread"]')).toBeTruthy();
+    });
+    expect(mocks.followThread).toHaveBeenCalledWith({
+      roomId: 'room-1',
+      threadRootEventId: 'thread-root'
+    });
+
+    resolveFollow({
+      following: true,
+      state: { roomId: 'room-1', threadRootEventId: 'thread-root', following: true }
+    });
+
+    await vi.waitFor(() => {
+      expect(q(container, 'button[aria-label="Unfollow thread"]')).toBeTruthy();
+    });
   });
 });

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
@@ -215,6 +215,9 @@ describe('ThreadPane', () => {
     await vi.waitFor(() => {
       expect(q(container, 'button[aria-label="Unfollow thread"]')).toBeTruthy();
     });
+    expect(
+      (q(container, 'button[aria-label="Unfollow thread"]') as HTMLButtonElement).disabled
+    ).toBe(true);
     expect(mocks.followThread).toHaveBeenCalledWith({
       roomId: 'room-1',
       threadRootEventId: 'thread-root'
@@ -226,7 +229,46 @@ describe('ThreadPane', () => {
     });
 
     await vi.waitFor(() => {
+      expect(
+        (q(container, 'button[aria-label="Unfollow thread"]') as HTMLButtonElement).disabled
+      ).toBe(false);
+    });
+  });
+
+  it('ignores another follow toggle while the first request is pending', async () => {
+    let rejectFollow!: (error: Error) => void;
+    mocks.followThread.mockReturnValue(
+      new Promise((_, reject) => {
+        rejectFollow = reject;
+      })
+    );
+
+    const { container } = render(ThreadPane, {
+      props: {
+        roomId: 'room-1',
+        roomName: 'General',
+        threadRootEventId: 'thread-root',
+        onClose: mocks.onClose
+      }
+    });
+
+    (q(container, 'button[aria-label="Follow thread"]') as HTMLButtonElement).click();
+    await vi.waitFor(() => {
       expect(q(container, 'button[aria-label="Unfollow thread"]')).toBeTruthy();
+    });
+    const pendingButton = q(container, 'button[aria-label="Unfollow thread"]') as HTMLButtonElement;
+    pendingButton.click();
+
+    expect(pendingButton.disabled).toBe(true);
+    expect(mocks.followThread).toHaveBeenCalledOnce();
+    expect(mocks.unfollowThread).not.toHaveBeenCalled();
+
+    rejectFollow(new Error('request failed'));
+
+    await vi.waitFor(() => {
+      expect(
+        (q(container, 'button[aria-label="Follow thread"]') as HTMLButtonElement).disabled
+      ).toBe(false);
     });
   });
 });

--- a/docs/adr/ADR-048-frontend-optimistic-ui.md
+++ b/docs/adr/ADR-048-frontend-optimistic-ui.md
@@ -1,0 +1,39 @@
+# ADR-048: Frontend Optimistic UI Uses Scoped Provisional Patches
+
+**Date:** 2026-07-09
+
+## Context
+
+Chatto's web client increasingly needs interactions that feel instant, such as
+message reactions and small per-viewer state changes. The authoritative state
+still comes from ConnectRPC projected rows and live/refetch delivery. If
+optimistic UI code mutates projected rows directly without a shared convention,
+independent pending actions can invalidate each other or roll back unrelated
+message state that changed while an RPC was in flight.
+
+## Decision
+
+Frontend optimistic updates are provisional patches layered onto the currently
+loaded client state. Each pending mutation is keyed by the smallest state slice
+it owns, such as rendered message row plus reaction emoji, and receives a token
+so stale RPC success/failure handlers cannot update a newer optimistic patch.
+
+Optimistic rollback restores only the state slice touched by that mutation. It
+must not replace an entire projected row when only one field or summary was
+optimistically changed. When projected server rows are fetched or refetched, the
+projected row remains authoritative and clears pending optimistic mutations for
+the affected row.
+
+Components should route a given optimistic action family through one shared
+frontend action path instead of mixing direct RPC calls with local patches.
+
+## Consequences
+
+- Optimistic interactions can feel immediate while preserving the server's
+  projected state as the source of truth.
+- Concurrent optimistic actions on the same rendered resource can settle
+  independently when their keys differ.
+- Rollbacks are more work than whole-row restoration because each optimistic
+  action must define the exact state slice it owns.
+- Shared helpers can provide mutation tokens and stale checks, but domain
+  modules still own their patch, reconcile, and rollback semantics.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -55,3 +55,4 @@ For more about ADRs, see [Michael Nygard's article](https://cognitect.com/blog/2
 | [ADR-045](ADR-045-public-api-stability-tiers.md) | Public API Stability Tiers | 2026-06-28 |
 | [ADR-046](ADR-046-typed-runtime-credentials.md) | Typed Runtime Credentials | 2026-06-30 |
 | [ADR-047](ADR-047-direct-ticketed-asset-urls.md) | Direct Ticketed Asset URLs for Browser Media | 2026-07-05 |
+| [ADR-048](ADR-048-frontend-optimistic-ui.md) | Frontend Optimistic UI Uses Scoped Provisional Patches | 2026-07-09 |

--- a/docs/fdr/FDR-005-reactions.md
+++ b/docs/fdr/FDR-005-reactions.md
@@ -65,5 +65,5 @@ Users can react to a message with emoji. Reactions are aggregated into pills sho
 
 ## Related
 
-- **ADRs:** ADR-026 (event identity via NanoID), ADR-033 (event-sourced state with projections), ADR-034 (single event stream), ADR-035 (per-aggregate migration), ADR-042 (protobuf-first public API), ADR-044 (ConnectRPC service conventions)
+- **ADRs:** ADR-026 (event identity via NanoID), ADR-033 (event-sourced state with projections), ADR-034 (single event stream), ADR-035 (per-aggregate migration), ADR-042 (protobuf-first public API), ADR-044 (ConnectRPC service conventions), ADR-048 (frontend optimistic UI)
 - **FDRs:** FDR-003 (Thread Reply Echo)


### PR DESCRIPTION
## Summary
Extracts shared optimistic mutation token tracking and moves reaction optimistic patch/reconcile/rollback logic out of `MessagesStore`.
Applies the same scoped optimistic pattern to thread follow/unfollow in message rows and the open thread pane while keeping projected server rows authoritative.
Adds ADR-048 for frontend optimistic UI conventions, links FDR-005, and moves/extends tests for reactions, thread follow, and stale rollback behavior.

## Validation
Ran `mise lint-frontend`, focused optimistic UI tests, full `mise test-frontend`, `mise license-check`, and Svelte autofixer on changed Svelte components.
