### PR TITLE
docs: update Pocket ID and erasure docs

### DIFF
--- a/apps/docs-website/src/content/docs/guides/integrations/pocket-id.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/pocket-id.mdx
@@ -14,6 +14,8 @@ import {
 
 Use Pocket ID as an OIDC provider to let people sign in to Chatto with their Pocket ID passkeys. Chatto uses Pocket ID's issuer discovery, client ID, and client secret; you do not need to enter its individual authorization or token endpoints.
 
+Learn more about Pocket ID on the [Pocket ID website](https://pocket-id.org/).
+
 This guide uses these example URLs:
 
 | Service | Public URL |

--- a/apps/docs-website/src/content/docs/guides/operations/privacy-erasure.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/privacy-erasure.mdx
@@ -9,6 +9,10 @@ Chatto applies field-level encryption to message text and selected account field
 
 It is not full-disk encryption, end-to-end encryption, or blanket encryption of every record and asset. A running Chatto server must be able to decrypt protected fields for authorized clients, and its built-in key-management implementation runs in the same server process.
 
+<Aside type="caution">
+  Chatto is alpha software. This page describes the encryption and erasure surface that is currently implemented; more changes to this model are planned.
+</Aside>
+
 ## Encryption Coverage
 
 | Data | Chatto application-layer protection |


### PR DESCRIPTION
## Summary
- Add a link from the Pocket ID integration guide to the official Pocket ID website.
- Add a caution to the encryption and erasure guide noting that Chatto is alpha software and the page describes the currently implemented surface.

## Validation
- `mise x -- pnpm --dir apps/docs-website build`
