### PR TITLE
fix(frontend): add optimistic room reads

### DIFF
--- a/apps/frontend/src/lib/RoomDirectory.svelte.spec.ts
+++ b/apps/frontend/src/lib/RoomDirectory.svelte.spec.ts
@@ -23,7 +23,6 @@ const listedRoom = (id: string, overrides: Partial<RoomsListItem> = {}): RoomsLi
   name: overrides.name ?? id,
   type: overrides.type ?? RoomType.Channel,
   isUniversal: overrides.isUniversal ?? false,
-  hasUnread: overrides.hasUnread ?? false,
   viewerIsMember: overrides.viewerIsMember ?? true,
   viewerCanJoinRoom: overrides.viewerCanJoinRoom ?? true,
   viewerNotificationCount: overrides.viewerNotificationCount ?? 0,

--- a/apps/frontend/src/lib/RoomList.svelte
+++ b/apps/frontend/src/lib/RoomList.svelte
@@ -63,6 +63,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   const appUi = getAppUiState();
 
   const roomsStore = $derived(stores.rooms);
+  const roomUnreadStore = $derived(stores.roomUnread);
 
   let activeRoomId = $derived(page.params.roomId);
 
@@ -177,7 +178,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   function isHighlighted(room: RoomsListItem): boolean {
     if (room.id === activeRoomId) return true;
     if (activeCallRooms.has(room.id)) return true;
-    if (room.hasUnread) return true;
+    if (roomUnreadStore.roomIsUnread(room.id)) return true;
     if (room.type === RoomType.Dm) {
       return room.viewerNotificationCount > 0;
     }
@@ -191,15 +192,6 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   }
 
   // --- Real-time event handlers ---
-
-  // Clear unread when entering a room while present. Navigation
-  // alone (e.g. clicking a notification while the tab is hidden) isn't
-  // enough — we wait until the user can actually see the room. The
-  // cross-tab `useRoomMarkedAsRead` handler below also clears the unread
-  // marker when useRoomUnread fires its mutation on presence-true.
-  $effect(() => {
-    if (activeRoomId && appState.isPresent) roomsStore.markRead(activeRoomId);
-  });
 
   // Handle server events that this component cares about beyond the store
   // refresh (which happens in ServerEventProvider): navigate away on leave,
@@ -253,7 +245,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
 
   // Marked-as-read from other tabs/devices.
   useRoomMarkedAsRead(({ roomId }) => {
-    roomsStore.markRead(roomId);
+    roomUnreadStore.setRoomUnread(roomId, false);
   });
 
   // New root messages → bump DM rows to the top + mark unread when the
@@ -280,7 +272,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     if (event.roomId === activeRoomId && appState.isPresent) return;
     if (serverEvent.actorId === currentUserState.user?.id) return;
     if (notificationLevelStore.isRoomMuted(event.roomId)) return;
-    roomsStore.setUnread(event.roomId);
+    roomUnreadStore.setRoomUnread(event.roomId, true);
   });
 
   function wasCallIconClick(event: MouseEvent): boolean {
@@ -405,10 +397,11 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
 
 {#snippet roomLink(room: RoomsListItem)}
   {@const hasActiveCall = activeCallRooms.has(room.id)}
+  {@const hasUnread = roomUnreadStore.roomIsUnread(room.id)}
   {@const isJoined = room.viewerIsMember}
   {@const hasUnreadAttention =
     isJoined &&
-    room.hasUnread &&
+    hasUnread &&
     room.id !== activeRoomId &&
     !notificationLevelStore.isRoomMuted(room.id)}
   {@const rowClass = [
@@ -453,7 +446,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
         {m['room_list.notifications']({ count: room.viewerNotificationCount })}
       </span>
       <!-- Unread Indicator (subtle) -->
-    {:else if isJoined && room.hasUnread && !notificationLevelStore.isRoomMuted(room.id)}
+    {:else if isJoined && hasUnread && !notificationLevelStore.isRoomMuted(room.id)}
       <UnreadDot color="primary" testid="room-unread-dot" />
       <span class="sr-only">{m['room_list.unread_messages']()}</span>
     {/if}
@@ -462,7 +455,8 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
 
 {#snippet dmLink(room: RoomsListItem)}
   {@const hasActiveCall = activeCallRooms.has(room.id)}
-  {@const hasUnreadAttention = room.hasUnread && room.id !== activeRoomId}
+  {@const hasUnread = roomUnreadStore.roomIsUnread(room.id)}
+  {@const hasUnreadAttention = hasUnread && room.id !== activeRoomId}
   <a
     href={resolve('/chat/[serverId]/[roomId]', { serverId: serverSegment, roomId: room.id })}
     class={[
@@ -499,7 +493,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
       <span class="sr-only">
         {m['room_list.new_direct_messages']({ count: room.viewerNotificationCount })}
       </span>
-    {:else if room.hasUnread}
+    {:else if hasUnread}
       <UnreadDot color="primary" testid="dm-unread-dot" />
       <span class="sr-only">{m['room_list.unread_messages']()}</span>
     {/if}

--- a/apps/frontend/src/lib/RoomList.svelte.spec.ts
+++ b/apps/frontend/src/lib/RoomList.svelte.spec.ts
@@ -17,6 +17,7 @@ const { mocks } = vi.hoisted(() => ({
   mocks: {
     activeCallRoomIds: new Set<string>(),
     callParticipants: new Map<string, unknown[]>(),
+    unreadRoomIds: new Set<string>(),
     pushState: vi.fn(),
     goto: vi.fn(),
     appUi: {
@@ -45,6 +46,13 @@ const { mocks } = vi.hoisted(() => ({
       notificationLevels: {
         isRoomMuted: vi.fn().mockReturnValue(false)
       },
+      roomUnread: {
+        roomIsUnread: vi.fn((roomId: string) => mocks.unreadRoomIds.has(roomId)),
+        setRoomUnread: vi.fn((roomId: string, unread: boolean) => {
+          if (unread) mocks.unreadRoomIds.add(roomId);
+          else mocks.unreadRoomIds.delete(roomId);
+        })
+      },
       activeCallRooms: {
         load: vi.fn().mockResolvedValue(undefined),
         has: vi.fn((roomId: string) => mocks.activeCallRoomIds.has(roomId)),
@@ -66,9 +74,7 @@ const { mocks } = vi.hoisted(() => ({
         roomGroups: null as RoomsListGroup[] | null,
         isInitialLoading: false,
         currentUserId: 'me',
-        markRead: vi.fn(),
         bumpRoom: vi.fn(),
-        setUnread: vi.fn(),
         clearUnreadNotifications: vi.fn(),
         decrementUnreadNotification: vi.fn(),
         incrementUnreadNotification: vi.fn(),
@@ -185,7 +191,6 @@ function setRooms() {
       name: 'general',
       type: RoomType.Channel,
       isUniversal: false,
-      hasUnread: false,
       viewerIsMember: true,
       viewerCanJoinRoom: true,
       viewerNotificationCount: 0,
@@ -196,7 +201,6 @@ function setRooms() {
       name: 'joinable',
       type: RoomType.Channel,
       isUniversal: false,
-      hasUnread: false,
       viewerIsMember: false,
       viewerCanJoinRoom: true,
       viewerNotificationCount: 0,
@@ -207,7 +211,6 @@ function setRooms() {
       name: 'restricted',
       type: RoomType.Channel,
       isUniversal: false,
-      hasUnread: false,
       viewerIsMember: false,
       viewerCanJoinRoom: false,
       viewerNotificationCount: 0,
@@ -218,7 +221,6 @@ function setRooms() {
       name: '',
       type: RoomType.Dm,
       isUniversal: false,
-      hasUnread: false,
       viewerIsMember: true,
       viewerCanJoinRoom: true,
       viewerNotificationCount: 0,
@@ -229,7 +231,6 @@ function setRooms() {
       name: '',
       type: RoomType.Dm,
       isUniversal: false,
-      hasUnread: false,
       viewerIsMember: true,
       viewerCanJoinRoom: true,
       viewerNotificationCount: 0,
@@ -249,13 +250,8 @@ function setRoomNotificationCount(roomId: string, count: number) {
 }
 
 function setRoomUnread(roomId: string, hasUnread: boolean) {
-  const rooms = mocks.store.rooms.rooms as Array<{
-    id: string;
-    hasUnread: boolean;
-  }>;
-  const room = rooms.find((item) => item.id === roomId);
-  if (!room) throw new Error(`Missing mocked room ${roomId}`);
-  room.hasUnread = hasUnread;
+  if (hasUnread) mocks.unreadRoomIds.add(roomId);
+  else mocks.unreadRoomIds.delete(roomId);
 }
 
 function dispatchRoomListEvent(handlerIndex: number, event: Record<string, unknown>) {
@@ -275,6 +271,7 @@ beforeEach(() => {
   sessionStorage.clear();
   mocks.activeCallRoomIds = new Set();
   mocks.callParticipants = new Map();
+  mocks.unreadRoomIds = new Set();
   mocks.store.rooms.roomGroups = null;
   mocks.store.rooms.isInitialLoading = false;
   mocks.store.rooms.currentUserId = 'me';
@@ -467,7 +464,7 @@ describe('RoomList', () => {
     });
 
     expect(mocks.store.rooms.bumpRoom).toHaveBeenCalledWith('channel-1');
-    expect(mocks.store.rooms.setUnread).toHaveBeenCalledWith('channel-1');
+    expect(mocks.store.roomUnread.setRoomUnread).toHaveBeenCalledWith('channel-1', true);
   });
 
   it.each([

--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte
@@ -91,10 +91,10 @@
       return;
     }
     try {
-      const [serverState, viewer, dmRooms] = await Promise.all([
+      const [serverState, viewer, rooms] = await Promise.all([
         getAuthenticatedServerState(connectAPIConfig()),
         getViewerStateViaConnect(connectAPIConfig()),
-        roomDirectoryAPI().listRooms(RoomDirectoryScope.DMS),
+        roomDirectoryAPI().listRooms(RoomDirectoryScope.ALL),
         notificationStore.fetch()
       ]);
 
@@ -106,8 +106,7 @@
 
       const pref = viewer.serverNotificationPreference;
       notificationLevelStore.setServerPreference(pref.level, pref.effectiveLevel);
-      roomUnreadStore.updateRooms(dmRooms);
-      roomUnreadStore.setServerHasUnread(serverState.viewerHasUnreadRooms);
+      roomUnreadStore.initRooms(rooms, serverState.viewerHasUnreadRooms);
 
       displayName = serverState.name;
       logoUrl = serverState.logoUrl;

--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte
@@ -9,7 +9,11 @@
   import { isMessagePostedEvent, RoomEventKind, roomEventKind } from '$lib/render/eventKinds';
   import { getAuthenticatedServerState } from '$lib/api-client/serverState';
   import { getViewerStateViaConnect } from '$lib/api-client/viewer';
-  import { createRoomDirectoryAPI, RoomDirectoryScope } from '$lib/api-client/roomDirectory';
+  import {
+    createRoomDirectoryAPI,
+    RoomDirectoryScope,
+    RoomKind
+  } from '$lib/api-client/roomDirectory';
   import { notificationTarget } from '$lib/state/server/notifications.svelte';
   import { prepareUiForNotificationTarget } from '$lib/notifications/notificationNavigationUi';
   import { getAppUiState } from '$lib/state/appUi.svelte';
@@ -106,7 +110,13 @@
 
       const pref = viewer.serverNotificationPreference;
       notificationLevelStore.setServerPreference(pref.level, pref.effectiveLevel);
-      roomUnreadStore.initRooms(rooms, serverState.viewerHasUnreadRooms);
+      const hasUnreadChannel = rooms.some(
+        (room) => room.kind === RoomKind.CHANNEL && room.hasUnread
+      );
+      roomUnreadStore.initRooms(
+        rooms,
+        serverState.viewerHasUnreadRooms && !hasUnreadChannel
+      );
 
       displayName = serverState.name;
       logoUrl = serverState.logoUrl;

--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte
@@ -106,16 +106,8 @@
 
       const pref = viewer.serverNotificationPreference;
       notificationLevelStore.setServerPreference(pref.level, pref.effectiveLevel);
-      roomUnreadStore.clear();
+      roomUnreadStore.updateRooms(dmRooms);
       roomUnreadStore.setServerHasUnread(serverState.viewerHasUnreadRooms);
-
-      // Populate DM unread status. Channel and DM rooms now share the same
-      // per-room unread map.
-      for (const room of dmRooms) {
-        if (room.hasUnread) {
-          roomUnreadStore.setRoomUnread(room.id, true);
-        }
-      }
 
       displayName = serverState.name;
       logoUrl = serverState.logoUrl;
@@ -244,8 +236,9 @@
 
     if (!roomId) {
       const rooms = await roomDirectoryAPI().listRooms(RoomDirectoryScope.CHANNELS);
-      roomUnreadStore.initRooms(rooms);
-      roomId = rooms.find((r) => r.hasUnread)?.id ?? null;
+      roomUnreadStore.updateRooms(rooms);
+      roomUnreadStore.resolveUnknownUnread();
+      roomId = roomUnreadStore.getFirstUnreadRoomId();
     }
 
     if (roomId) {

--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
@@ -143,6 +143,7 @@ vi.mock('$lib/api-client/viewer', () => ({
 
 vi.mock('$lib/api-client/roomDirectory', () => ({
   RoomDirectoryScope: {
+    ALL: 1,
     CHANNELS: 2,
     DMS: 3
   },
@@ -334,10 +335,10 @@ describe('ServerSidebarEntry', () => {
       NotificationLevel.Muted,
       NotificationLevel.Muted
     );
-    expect(mocks.store.roomUnread.setServerHasUnread).toHaveBeenCalledWith(true);
-    expect(mocks.store.roomUnread.updateRooms).toHaveBeenCalledWith([
-      { id: 'dm-1', hasUnread: true }
-    ]);
+    expect(mocks.store.roomUnread.initRooms).toHaveBeenCalledWith(
+      [{ id: 'dm-1', hasUnread: true }],
+      true
+    );
   });
 
   it('keeps sidebar init usable when notification fetch returns no count changes', async () => {

--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
@@ -147,6 +147,10 @@ vi.mock('$lib/api-client/roomDirectory', () => ({
     CHANNELS: 2,
     DMS: 3
   },
+  RoomKind: {
+    CHANNEL: 1,
+    DM: 2
+  },
   createRoomDirectoryAPI: mocks.createRoomDirectoryAPI
 }));
 
@@ -295,7 +299,7 @@ describe('ServerSidebarEntry', () => {
         ]
       })
     );
-    mocks.listRooms.mockResolvedValue([{ id: 'dm-1', hasUnread: true }]);
+    mocks.listRooms.mockResolvedValue([{ id: 'dm-1', kind: 2, hasUnread: true }]);
 
     const { container } = render(ServerSidebarEntry, {
       props: {
@@ -336,7 +340,7 @@ describe('ServerSidebarEntry', () => {
       NotificationLevel.Muted
     );
     expect(mocks.store.roomUnread.initRooms).toHaveBeenCalledWith(
-      [{ id: 'dm-1', hasUnread: true }],
+      [{ id: 'dm-1', kind: 2, hasUnread: true }],
       true
     );
   });

--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
@@ -56,6 +56,9 @@ const { mocks } = vi.hoisted(() => {
         },
         roomUnread: {
           clear: vi.fn(),
+          initRooms: vi.fn(),
+          updateRooms: vi.fn(),
+          resolveUnknownUnread: vi.fn(),
           setServerHasUnread: vi.fn(),
           setRoomUnread: vi.fn(),
           getFirstUnreadRoomId: vi.fn().mockReturnValue(null)
@@ -229,6 +232,9 @@ describe('ServerSidebarEntry', () => {
     mocks.store.notifications.dismiss.mockClear();
     mocks.store.notifications.getCleanPath.mockReturnValue('/chat/remote.example.com/room-1');
     mocks.store.roomUnread.clear.mockClear();
+    mocks.store.roomUnread.initRooms.mockClear();
+    mocks.store.roomUnread.updateRooms.mockClear();
+    mocks.store.roomUnread.resolveUnknownUnread.mockClear();
     mocks.store.roomUnread.setServerHasUnread.mockClear();
     mocks.store.roomUnread.setRoomUnread.mockClear();
     mocks.store.notificationLevels.setServerPreference.mockClear();
@@ -329,7 +335,9 @@ describe('ServerSidebarEntry', () => {
       NotificationLevel.Muted
     );
     expect(mocks.store.roomUnread.setServerHasUnread).toHaveBeenCalledWith(true);
-    expect(mocks.store.roomUnread.setRoomUnread).toHaveBeenCalledWith('dm-1', true);
+    expect(mocks.store.roomUnread.updateRooms).toHaveBeenCalledWith([
+      { id: 'dm-1', hasUnread: true }
+    ]);
   });
 
   it('keeps sidebar init usable when notification fetch returns no count changes', async () => {

--- a/apps/frontend/src/lib/hooks/UseRoomUnreadHarness.svelte
+++ b/apps/frontend/src/lib/hooks/UseRoomUnreadHarness.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { useRoomUnread } from './useRoomUnread.svelte';
+
+  let {
+    roomId,
+    onReady
+  }: {
+    roomId: string;
+    onReady: (api: ReturnType<typeof useRoomUnread>) => void;
+  } = $props();
+
+  const unread = useRoomUnread(() => ({ roomId }));
+
+  $effect(() => {
+    onReady(unread);
+  });
+</script>

--- a/apps/frontend/src/lib/hooks/useRoomUnread.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/useRoomUnread.svelte.spec.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync } from 'svelte';
+import { render } from 'vitest-browser-svelte';
+import { RoomUnreadStore } from '$lib/state/server/roomUnread.svelte';
+import Harness from './UseRoomUnreadHarness.svelte';
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    markRoomAsRead: vi.fn(),
+    roomUnread: null as RoomUnreadStore | null
+  }
+}));
+
+vi.mock('$lib/api-client/readState', () => ({
+  createReadStateAPI: () => ({ markRoomAsRead: mocks.markRoomAsRead })
+}));
+
+vi.mock('$lib/state/server/connection.svelte', () => ({
+  useConnection: () => () => ({
+    serverId: 'server-1',
+    connectBaseUrl: '/api/connect',
+    bearerToken: 'token'
+  })
+}));
+
+vi.mock('$lib/state/activeServer.svelte', () => ({
+  getActiveServer: () => 'server-1'
+}));
+
+vi.mock('$lib/state/server/registry.svelte', () => ({
+  serverRegistry: {
+    getStore: () => ({ roomUnread: mocks.roomUnread })
+  }
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function setPresent(): void {
+  window.dispatchEvent(new Event('focus'));
+  Object.defineProperty(document, 'visibilityState', {
+    value: 'visible',
+    writable: true,
+    configurable: true
+  });
+  document.dispatchEvent(new Event('visibilitychange'));
+  flushSync();
+}
+
+describe('useRoomUnread', () => {
+  beforeEach(() => {
+    mocks.roomUnread = new RoomUnreadStore();
+    mocks.markRoomAsRead.mockReset();
+    setPresent();
+  });
+
+  it('rolls back the optimistic read when the RPC fails', async () => {
+    const request = deferred<never>();
+    mocks.markRoomAsRead.mockReturnValue(request.promise);
+    mocks.roomUnread!.setRoomUnread('room-1', true);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const rendered = render(Harness, {
+      props: { roomId: 'room-1', onReady: () => {} }
+    });
+    flushSync();
+
+    await vi.waitFor(() => expect(mocks.markRoomAsRead).toHaveBeenCalledOnce());
+    expect(mocks.roomUnread!.roomIsUnread('room-1')).toBe(false);
+
+    request.reject(new Error('network down'));
+    await vi.waitFor(() => expect(mocks.roomUnread!.roomIsUnread('room-1')).toBe(true));
+    rendered.unmount();
+  });
+
+  it('preserves a newer unread message when the earlier read succeeds', async () => {
+    const request = deferred<{ lastReadAt: string; previousLastReadAt: null }>();
+    mocks.markRoomAsRead.mockReturnValue(request.promise);
+    mocks.roomUnread!.setRoomUnread('room-1', true);
+
+    const rendered = render(Harness, {
+      props: { roomId: 'room-1', onReady: () => {} }
+    });
+    flushSync();
+
+    await vi.waitFor(() => expect(mocks.markRoomAsRead).toHaveBeenCalledOnce());
+    mocks.roomUnread!.setRoomUnread('room-1', true);
+    request.resolve({ lastReadAt: '2026-07-10T20:00:00.000Z', previousLastReadAt: null });
+    await request.promise;
+    await Promise.resolve();
+    flushSync();
+
+    expect(mocks.roomUnread!.roomIsUnread('room-1')).toBe(true);
+    rendered.unmount();
+  });
+});

--- a/apps/frontend/src/lib/hooks/useRoomUnread.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useRoomUnread.svelte.ts
@@ -17,16 +17,19 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
 
   const unread = useUnreadMarker(() => getProps().roomId, {
     markAsRead: async (targetRoomId: string, upToEventId?: string) => {
-      roomUnreadStore.setRoomUnread(targetRoomId, false);
+      const optimisticRead = roomUnreadStore.beginOptimisticRead(targetRoomId);
 
       try {
         const conn = connection();
-        return await createReadStateAPI({
+        const result = await createReadStateAPI({
           serverId: conn.serverId ?? getActiveServer(),
           baseUrl: conn.connectBaseUrl,
           bearerToken: conn.bearerToken
         }).markRoomAsRead({ roomId: targetRoomId, upToEventId });
+        optimisticRead.commit();
+        return result;
       } catch (err) {
+        optimisticRead.rollback();
         console.error('Failed to mark room as read:', err);
         return null;
       }

--- a/apps/frontend/src/lib/navigation/roomLinkAccess.spec.ts
+++ b/apps/frontend/src/lib/navigation/roomLinkAccess.spec.ts
@@ -9,7 +9,6 @@ function room(overrides: Partial<RoomsListItem> = {}): RoomsListItem {
     name: 'general',
     type: RoomType.Channel,
     isUniversal: false,
-    hasUnread: false,
     viewerIsMember: true,
     viewerCanJoinRoom: true,
     viewerNotificationCount: 0,

--- a/apps/frontend/src/lib/state/server/roomUnread.spec.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.spec.ts
@@ -80,15 +80,19 @@ describe('RoomUnreadStore', () => {
     expect(store.roomIsUnread('room-1')).toBe(false);
   });
 
-  it('restores an unknown server unread signal when an optimistic read fails', () => {
+  it('preserves an unrelated unknown unread during a room read', () => {
     const store = new RoomUnreadStore();
     store.setServerHasUnread(true);
 
     const read = store.beginOptimisticRead('room-1');
-    expect(store.hasAnyUnread).toBe(false);
-
-    read.rollback();
+    expect(store.roomIsUnread('room-1')).toBe(false);
     expect(store.hasAnyUnread).toBe(true);
+
+    read.commit();
+    expect(store.hasAnyUnread).toBe(true);
+
+    store.resolveUnknownUnread();
+    expect(store.hasAnyUnread).toBe(false);
   });
 
   it('keeps a room read optimistic when a coarse unread signal arrives', () => {

--- a/apps/frontend/src/lib/state/server/roomUnread.spec.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.spec.ts
@@ -82,7 +82,7 @@ describe('RoomUnreadStore', () => {
 
   it('preserves an unrelated unknown unread during a room read', () => {
     const store = new RoomUnreadStore();
-    store.setServerHasUnread(true);
+    store.initRooms([{ id: 'room-1', hasUnread: false }], true);
 
     const read = store.beginOptimisticRead('room-1');
     expect(store.roomIsUnread('room-1')).toBe(false);
@@ -92,6 +92,19 @@ describe('RoomUnreadStore', () => {
     expect(store.hasAnyUnread).toBe(true);
 
     store.resolveUnknownUnread();
+    expect(store.hasAnyUnread).toBe(false);
+  });
+
+  it('does not add an unknown sentinel when the aggregate is represented', () => {
+    const store = new RoomUnreadStore();
+    store.initRooms([{ id: 'dm', hasUnread: true }], true);
+
+    const read = store.beginOptimisticRead('dm');
+
+    expect(store.roomIsUnread('dm')).toBe(false);
+    expect(store.hasAnyUnread).toBe(false);
+
+    read.commit();
     expect(store.hasAnyUnread).toBe(false);
   });
 

--- a/apps/frontend/src/lib/state/server/roomUnread.spec.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.spec.ts
@@ -90,4 +90,17 @@ describe('RoomUnreadStore', () => {
     read.rollback();
     expect(store.hasAnyUnread).toBe(true);
   });
+
+  it('keeps a room read optimistic when a coarse unread signal arrives', () => {
+    const store = new RoomUnreadStore();
+    store.setRoomUnread('room-1', true);
+
+    const read = store.beginOptimisticRead('room-1');
+    store.setServerHasUnread(true);
+
+    expect(store.roomIsUnread('room-1')).toBe(false);
+
+    read.rollback();
+    expect(store.roomIsUnread('room-1')).toBe(true);
+  });
 });

--- a/apps/frontend/src/lib/state/server/roomUnread.spec.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { RoomUnreadStore } from './roomUnread.svelte';
+
+describe('RoomUnreadStore', () => {
+  it('initializes room unread state from an authoritative directory snapshot', () => {
+    const store = new RoomUnreadStore();
+
+    store.initRooms([
+      { id: 'read', hasUnread: false },
+      { id: 'unread', hasUnread: true }
+    ]);
+
+    expect(store.roomIsUnread('read')).toBe(false);
+    expect(store.roomIsUnread('unread')).toBe(true);
+    expect(store.getFirstUnreadRoomId()).toBe('unread');
+    expect(store.hasAnyUnread).toBe(true);
+  });
+
+  it('merges partial room snapshots without dropping other known unread rooms', () => {
+    const store = new RoomUnreadStore();
+    store.initRooms([{ id: 'channel', hasUnread: true }]);
+
+    store.updateRooms([{ id: 'dm', hasUnread: true }]);
+
+    expect(store.roomIsUnread('channel')).toBe(true);
+    expect(store.roomIsUnread('dm')).toBe(true);
+  });
+
+  it('hides unread state immediately and restores it on rollback', () => {
+    const store = new RoomUnreadStore();
+    store.setRoomUnread('room-1', true);
+
+    const read = store.beginOptimisticRead('room-1');
+
+    expect(store.roomIsUnread('room-1')).toBe(false);
+    expect(store.hasAnyUnread).toBe(false);
+
+    read.rollback();
+
+    expect(store.roomIsUnread('room-1')).toBe(true);
+    expect(store.hasAnyUnread).toBe(true);
+  });
+
+  it('does not let rollback erase a newer unread message', () => {
+    const store = new RoomUnreadStore();
+    store.setRoomUnread('room-1', true);
+
+    const read = store.beginOptimisticRead('room-1');
+    store.setRoomUnread('room-1', true);
+    read.rollback();
+
+    expect(store.roomIsUnread('room-1')).toBe(true);
+  });
+
+  it('does not let rollback restore unread after an authoritative read event', () => {
+    const store = new RoomUnreadStore();
+    store.setRoomUnread('room-1', true);
+
+    const read = store.beginOptimisticRead('room-1');
+    store.setRoomUnread('room-1', false);
+    read.rollback();
+
+    expect(store.roomIsUnread('room-1')).toBe(false);
+  });
+
+  it('lets only the latest overlapping read settle the optimistic state', () => {
+    const store = new RoomUnreadStore();
+    store.setRoomUnread('room-1', true);
+
+    const first = store.beginOptimisticRead('room-1');
+    const second = store.beginOptimisticRead('room-1');
+    first.commit();
+    second.rollback();
+
+    expect(store.roomIsUnread('room-1')).toBe(true);
+
+    const latest = store.beginOptimisticRead('room-1');
+    latest.commit();
+
+    expect(store.roomIsUnread('room-1')).toBe(false);
+  });
+
+  it('restores an unknown server unread signal when an optimistic read fails', () => {
+    const store = new RoomUnreadStore();
+    store.setServerHasUnread(true);
+
+    const read = store.beginOptimisticRead('room-1');
+    expect(store.hasAnyUnread).toBe(false);
+
+    read.rollback();
+    expect(store.hasAnyUnread).toBe(true);
+  });
+});

--- a/apps/frontend/src/lib/state/server/roomUnread.spec.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.spec.ts
@@ -97,15 +97,28 @@ describe('RoomUnreadStore', () => {
 
   it('does not add an unknown sentinel when the aggregate is represented', () => {
     const store = new RoomUnreadStore();
+    store.initRooms([{ id: 'channel', hasUnread: true }]);
+
+    const read = store.beginOptimisticRead('channel');
+
+    expect(store.roomIsUnread('channel')).toBe(false);
+    expect(store.hasAnyUnread).toBe(false);
+
+    read.commit();
+    expect(store.hasAnyUnread).toBe(false);
+  });
+
+  it('keeps a channel aggregate when only a DM unread is concrete', () => {
+    const store = new RoomUnreadStore();
     store.initRooms([{ id: 'dm', hasUnread: true }], true);
 
     const read = store.beginOptimisticRead('dm');
 
     expect(store.roomIsUnread('dm')).toBe(false);
-    expect(store.hasAnyUnread).toBe(false);
+    expect(store.hasAnyUnread).toBe(true);
 
     read.commit();
-    expect(store.hasAnyUnread).toBe(false);
+    expect(store.hasAnyUnread).toBe(true);
   });
 
   it('keeps a room read optimistic when a coarse unread signal arrives', () => {

--- a/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
@@ -29,7 +29,6 @@ export class RoomUnreadStore {
   // Server-level unknown-unread flag (set when we know there's unread but
   // not which room — e.g. on initial load before rooms are queried).
   private serverHasUnknownUnread = $state(false);
-  private unknownUnreadRevision = 0;
 
   private optimisticReadKey(roomId: string): string {
     return `room:${roomId}`;
@@ -55,10 +54,6 @@ export class RoomUnreadStore {
       this.unreadRooms.add(roomId);
     } else {
       this.unreadRooms.delete(roomId);
-      // Reading a specific room implies we now have concrete knowledge —
-      // drop the unknown-unread flag.
-      this.serverHasUnknownUnread = false;
-      this.unknownUnreadRevision++;
     }
   }
 
@@ -69,7 +64,6 @@ export class RoomUnreadStore {
   beginOptimisticRead(roomId: string): OptimisticRoomReadHandle {
     const token = this.optimisticReads.createToken();
     const roomRevision = this.roomRevision(roomId);
-    const unknownUnreadRevision = this.unknownUnreadRevision;
     const key = this.optimisticReadKey(roomId);
 
     this.optimisticReads.mark(key, token);
@@ -81,10 +75,6 @@ export class RoomUnreadStore {
         if (this.roomRevision(roomId) !== roomRevision) return;
 
         this.unreadRooms.delete(roomId);
-        if (this.unknownUnreadRevision === unknownUnreadRevision) {
-          this.serverHasUnknownUnread = false;
-          this.unknownUnreadRevision++;
-        }
         this.optimisticReads.clear(key);
         this.optimisticReadRooms.delete(roomId);
       },
@@ -103,7 +93,7 @@ export class RoomUnreadStore {
     for (const roomId of this.unreadRooms) {
       if (!this.optimisticReadRooms.has(roomId)) return true;
     }
-    return this.serverHasUnknownUnread && this.optimisticReadRooms.size === 0;
+    return this.serverHasUnknownUnread;
   }
 
   /**
@@ -134,7 +124,6 @@ export class RoomUnreadStore {
     this.roomRevisions.clear();
     this.unreadRooms.clear();
     this.serverHasUnknownUnread = false;
-    this.unknownUnreadRevision++;
     this.updateRooms(rooms);
   }
 
@@ -151,7 +140,6 @@ export class RoomUnreadStore {
   /** Clear the server-level sentinel after all relevant room scopes are known. */
   resolveUnknownUnread(): void {
     this.serverHasUnknownUnread = false;
-    this.unknownUnreadRevision++;
   }
 
   /**
@@ -159,7 +147,6 @@ export class RoomUnreadStore {
    * signal is known (initial load, before rooms are queried).
    */
   setServerHasUnread(hasUnread: boolean): void {
-    this.unknownUnreadRevision++;
     if (hasUnread) {
       this.serverHasUnknownUnread = true;
     } else {
@@ -179,6 +166,5 @@ export class RoomUnreadStore {
     this.roomRevisions.clear();
     this.unreadRooms.clear();
     this.serverHasUnknownUnread = false;
-    this.unknownUnreadRevision++;
   }
 }

--- a/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
@@ -118,13 +118,17 @@ export class RoomUnreadStore {
    * Initialize unread state from room data.
    * Call this when loading rooms.
    */
-  initRooms(rooms: Array<{ id: string; hasUnread: boolean }>): void {
+  initRooms(
+    rooms: Array<{ id: string; hasUnread: boolean }>,
+    serverHasUnread = false
+  ): void {
     this.optimisticReads.clearAll();
     this.optimisticReadRooms.clear();
     this.roomRevisions.clear();
     this.unreadRooms.clear();
     this.serverHasUnknownUnread = false;
     this.updateRooms(rooms);
+    this.serverHasUnknownUnread = serverHasUnread && this.unreadRooms.size === 0;
   }
 
   /** Merge an authoritative partial room snapshot without dropping other rooms. */

--- a/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
@@ -1,4 +1,10 @@
-import { SvelteSet } from 'svelte/reactivity';
+import { SvelteMap, SvelteSet } from 'svelte/reactivity';
+import { OptimisticMutationRegistry } from '$lib/state/optimisticMutations';
+
+export type OptimisticRoomReadHandle = {
+  commit(): void;
+  rollback(): void;
+};
 
 /**
  * Tracks which rooms on the server have unread messages.
@@ -14,16 +20,37 @@ import { SvelteSet } from 'svelte/reactivity';
  * - Initial load with only a server-level signal → `setServerHasUnread`
  */
 export class RoomUnreadStore {
-  // Specific rooms known to be unread.
+  // Specific rooms authoritatively known to be unread.
   private unreadRooms = new SvelteSet<string>();
+  // Provisional reads hide the underlying unread fact until they settle.
+  private optimisticReadRooms = new SvelteSet<string>();
+  private optimisticReads = new OptimisticMutationRegistry();
+  private roomRevisions = new SvelteMap<string, number>();
   // Server-level unknown-unread flag (set when we know there's unread but
   // not which room — e.g. on initial load before rooms are queried).
   private serverHasUnknownUnread = $state(false);
+  private unknownUnreadRevision = 0;
+
+  private optimisticReadKey(roomId: string): string {
+    return `room:${roomId}`;
+  }
+
+  private roomRevision(roomId: string): number {
+    return this.roomRevisions.get(roomId) ?? 0;
+  }
+
+  private invalidateOptimisticRead(roomId: string): void {
+    this.optimisticReads.clear(this.optimisticReadKey(roomId));
+    this.optimisticReadRooms.delete(roomId);
+  }
 
   /**
    * Set unread status for a specific room.
    */
   setRoomUnread(roomId: string, unread: boolean): void {
+    this.roomRevisions.set(roomId, this.roomRevision(roomId) + 1);
+    this.invalidateOptimisticRead(roomId);
+
     if (unread) {
       this.unreadRooms.add(roomId);
     } else {
@@ -31,14 +58,52 @@ export class RoomUnreadStore {
       // Reading a specific room implies we now have concrete knowledge —
       // drop the unknown-unread flag.
       this.serverHasUnknownUnread = false;
+      this.unknownUnreadRevision++;
     }
+  }
+
+  /**
+   * Provisionally mark a room read while retaining the underlying unread fact.
+   * New room state invalidates the handle so rollback cannot overwrite it.
+   */
+  beginOptimisticRead(roomId: string): OptimisticRoomReadHandle {
+    const token = this.optimisticReads.createToken();
+    const roomRevision = this.roomRevision(roomId);
+    const unknownUnreadRevision = this.unknownUnreadRevision;
+    const key = this.optimisticReadKey(roomId);
+
+    this.optimisticReads.mark(key, token);
+    this.optimisticReadRooms.add(roomId);
+
+    return {
+      commit: () => {
+        if (!this.optimisticReads.isCurrent(key, token)) return;
+        if (this.roomRevision(roomId) !== roomRevision) return;
+
+        this.unreadRooms.delete(roomId);
+        if (this.unknownUnreadRevision === unknownUnreadRevision) {
+          this.serverHasUnknownUnread = false;
+          this.unknownUnreadRevision++;
+        }
+        this.optimisticReads.clear(key);
+        this.optimisticReadRooms.delete(roomId);
+      },
+      rollback: () => {
+        if (!this.optimisticReads.isCurrent(key, token)) return;
+        this.optimisticReads.clear(key);
+        this.optimisticReadRooms.delete(roomId);
+      }
+    };
   }
 
   /**
    * Check if the server has any unread rooms (or is flagged with unknown unread).
    */
   get hasAnyUnread(): boolean {
-    return this.unreadRooms.size > 0 || this.serverHasUnknownUnread;
+    for (const roomId of this.unreadRooms) {
+      if (!this.optimisticReadRooms.has(roomId)) return true;
+    }
+    return this.serverHasUnknownUnread && this.optimisticReadRooms.size === 0;
   }
 
   /**
@@ -46,7 +111,9 @@ export class RoomUnreadStore {
    * flag is set (no specific rooms).
    */
   getFirstUnreadRoomId(): string | null {
-    for (const roomId of this.unreadRooms) return roomId;
+    for (const roomId of this.unreadRooms) {
+      if (!this.optimisticReadRooms.has(roomId)) return roomId;
+    }
     return null;
   }
 
@@ -54,7 +121,7 @@ export class RoomUnreadStore {
    * Check if a specific room is unread.
    */
   roomIsUnread(roomId: string): boolean {
-    return this.unreadRooms.has(roomId);
+    return this.unreadRooms.has(roomId) && !this.optimisticReadRooms.has(roomId);
   }
 
   /**
@@ -62,11 +129,29 @@ export class RoomUnreadStore {
    * Call this when loading rooms.
    */
   initRooms(rooms: Array<{ id: string; hasUnread: boolean }>): void {
+    this.optimisticReads.clearAll();
+    this.optimisticReadRooms.clear();
+    this.roomRevisions.clear();
     this.unreadRooms.clear();
     this.serverHasUnknownUnread = false;
+    this.unknownUnreadRevision++;
+    this.updateRooms(rooms);
+  }
+
+  /** Merge an authoritative partial room snapshot without dropping other rooms. */
+  updateRooms(rooms: Array<{ id: string; hasUnread: boolean }>): void {
     for (const room of rooms) {
+      this.roomRevisions.set(room.id, this.roomRevision(room.id) + 1);
+      this.invalidateOptimisticRead(room.id);
       if (room.hasUnread) this.unreadRooms.add(room.id);
+      else this.unreadRooms.delete(room.id);
     }
+  }
+
+  /** Clear the server-level sentinel after all relevant room scopes are known. */
+  resolveUnknownUnread(): void {
+    this.serverHasUnknownUnread = false;
+    this.unknownUnreadRevision++;
   }
 
   /**
@@ -74,6 +159,9 @@ export class RoomUnreadStore {
    * signal is known (initial load, before rooms are queried).
    */
   setServerHasUnread(hasUnread: boolean): void {
+    this.optimisticReads.clearAll();
+    this.optimisticReadRooms.clear();
+    this.unknownUnreadRevision++;
     if (hasUnread) {
       this.serverHasUnknownUnread = true;
     } else {
@@ -86,7 +174,11 @@ export class RoomUnreadStore {
    * Clear all unread state.
    */
   clear(): void {
+    this.optimisticReads.clearAll();
+    this.optimisticReadRooms.clear();
+    this.roomRevisions.clear();
     this.unreadRooms.clear();
     this.serverHasUnknownUnread = false;
+    this.unknownUnreadRevision++;
   }
 }

--- a/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
@@ -120,7 +120,7 @@ export class RoomUnreadStore {
    */
   initRooms(
     rooms: Array<{ id: string; hasUnread: boolean }>,
-    serverHasUnread = false
+    serverHasUnknownUnread = false
   ): void {
     this.optimisticReads.clearAll();
     this.optimisticReadRooms.clear();
@@ -128,7 +128,7 @@ export class RoomUnreadStore {
     this.unreadRooms.clear();
     this.serverHasUnknownUnread = false;
     this.updateRooms(rooms);
-    this.serverHasUnknownUnread = serverHasUnread && this.unreadRooms.size === 0;
+    this.serverHasUnknownUnread = serverHasUnknownUnread;
   }
 
   /** Merge an authoritative partial room snapshot without dropping other rooms. */

--- a/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
@@ -159,12 +159,12 @@ export class RoomUnreadStore {
    * signal is known (initial load, before rooms are queried).
    */
   setServerHasUnread(hasUnread: boolean): void {
-    this.optimisticReads.clearAll();
-    this.optimisticReadRooms.clear();
     this.unknownUnreadRevision++;
     if (hasUnread) {
       this.serverHasUnknownUnread = true;
     } else {
+      this.optimisticReads.clearAll();
+      this.optimisticReadRooms.clear();
       this.serverHasUnknownUnread = false;
       this.unreadRooms.clear();
     }

--- a/apps/frontend/src/lib/state/server/rooms.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/rooms.svelte.spec.ts
@@ -412,11 +412,13 @@ describe('RoomsStore - refresh', () => {
     expect(store.rooms[1]).toBe(random);
   });
 
-  it('patches changed room rows without replacing unchanged neighbors', async () => {
+  it('refreshes unread state without replacing room rows', async () => {
     const roomDirectoryAPI = makeRoomDirectoryAPI([makeRoom('general'), makeRoom('random')]);
+    const roomUnread = new RoomUnreadStore();
     const store = makeStore({
       roomDirectoryAPI,
-      notificationAPI: makeNotificationAPI()
+      notificationAPI: makeNotificationAPI(),
+      roomUnread
     });
 
     await store.refresh();
@@ -433,8 +435,8 @@ describe('RoomsStore - refresh', () => {
     await settle();
 
     expect(store.rooms[0]).toBe(general);
-    expect(store.rooms[1]).not.toBe(random);
-    expect(store.rooms[1]).toMatchObject({ id: 'random', hasUnread: true });
+    expect(store.rooms[1]).toBe(random);
+    expect(roomUnread.roomIsUnread('random')).toBe(true);
   });
 
   it('only replaces rooms whose notification counts changed', async () => {

--- a/apps/frontend/src/lib/state/server/rooms.svelte.ts
+++ b/apps/frontend/src/lib/state/server/rooms.svelte.ts
@@ -25,7 +25,6 @@ export type RoomsListItem = {
   name: string;
   type: RoomType;
   isUniversal: boolean;
-  hasUnread: boolean;
   viewerIsMember: boolean;
   viewerCanJoinRoom: boolean;
   viewerNotificationCount: number;
@@ -127,7 +126,6 @@ function sameRoomListItem(a: RoomsListItem, b: RoomsListItem): boolean {
     a.name === b.name &&
     a.type === b.type &&
     a.isUniversal === b.isUniversal &&
-    a.hasUnread === b.hasUnread &&
     a.viewerIsMember === b.viewerIsMember &&
     a.viewerCanJoinRoom === b.viewerCanJoinRoom &&
     a.viewerNotificationCount === b.viewerNotificationCount &&
@@ -196,15 +194,14 @@ export function isRoomStateRefreshEvent(event: RoomEventKindSource): boolean {
 
 /**
  * Reactive store for a server's joined-room list, layout, and per-room
- * unread/mention state. One store per registered server, owned by
+ * notification counts. One store per registered server, owned by
  * `ServerStateStore` — consumers (RoomList sidebar, the `/[serverId]` redirect
  * page, etc.) reach the active server's store via
  * `serverRegistry.getStore(activeServerId).rooms`, so the reactivity follows
  * the URL automatically when the user switches servers.
  *
- * Per-room flag mutations (markRead, setUnread, ...) are exposed as methods
- * so components can react to local UI events (entering a room) and to other
- * subscriptions (mentions, marked-as-read across tabs).
+ * Room read state is owned separately by `RoomUnreadStore` so the room list
+ * and server indicator cannot maintain competing unread projections.
  *
  * Subscription events are forwarded via {@link ingestServerEvent}; the
  * server bundle forwards events from every server's bus so each server's
@@ -304,7 +301,6 @@ export class RoomsStore {
       name: room.name,
       type: roomType(room.kind),
       isUniversal: room.isUniversal,
-      hasUnread: room.hasUnread,
       viewerIsMember: room.isMember,
       viewerCanJoinRoom: room.canJoinRoom,
       viewerNotificationCount: 0,
@@ -368,14 +364,6 @@ export class RoomsStore {
   // Per-room flag mutations
   // -------------------------------------------------------------------------
 
-  markRead(roomId: string): void {
-    this.patchRoom(roomId, { hasUnread: false });
-  }
-
-  setUnread(roomId: string): void {
-    this.patchRoom(roomId, { hasUnread: true });
-  }
-
   incrementUnreadNotification(roomId: string): void {
     const room = this.rooms.find((r) => r.id === roomId);
     if (!room) return;
@@ -420,9 +408,8 @@ export class RoomsStore {
 
   private patchRoom(roomId: string, patch: Partial<RoomsListItem>): void {
     // Wrapped in untrack so callers can invoke from within a $effect without
-    // creating a read+write loop on `rooms` (e.g. `$effect(() =>
-    // store.markRead(activeRoomId))`). Reactivity for other consumers still
-    // fires from the assignment.
+    // creating a read+write loop on `rooms`. Reactivity for other consumers
+    // still fires from the assignment.
     untrack(() => {
       const idx = this.rooms.findIndex((r) => r.id === roomId);
       if (idx === -1) return;

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/room-route.layout.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/room-route.layout.svelte.spec.ts
@@ -84,7 +84,6 @@ function room(overrides: Partial<RoomsListItem> = {}): RoomsListItem {
     name: 'development',
     type: RoomType.Channel,
     isUniversal: false,
-    hasUnread: false,
     viewerIsMember: true,
     viewerCanJoinRoom: true,
     viewerNotificationCount: 0,

--- a/docs/adr/ADR-048-frontend-optimistic-ui.md
+++ b/docs/adr/ADR-048-frontend-optimistic-ui.md
@@ -24,6 +24,11 @@ optimistically changed. When projected server rows are fetched or refetched, the
 projected row remains authoritative and clears pending optimistic mutations for
 the affected row.
 
+For state such as room unread markers, the provisional patch may be a render
+overlay rather than a mutation of the underlying server fact. This lets a failed
+read reveal the previous unread state without allowing rollback to erase a newer
+message or an authoritative read event.
+
 Components should route a given optimistic action family through one shared
 frontend action path instead of mixing direct RPC calls with local patches.
 


### PR DESCRIPTION
## Summary

Makes room read indicators update immediately while keeping server snapshots and live events authoritative. Consolidates channel and DM unread ownership in `RoomUnreadStore`, with scoped optimistic overlays that roll back on RPC failure without overwriting newer messages or cross-tab read events. Updates [ADR-048](https://github.com/chattocorp/chatto/blob/main/docs/adr/ADR-048-frontend-optimistic-ui.md), adds focused store, mounted-hook, sidebar, navigation, and cross-tab coverage, and relates to the broader push-state work in #118.

## Validation

Validated with `mise lint-frontend`, `mise test-frontend` (1,865 tests), and targeted Playwright unread navigation and `RoomMarkedAsReadEvent` synchronization scenarios.

Closes #1383.
