### PR TITLE
fix(frontend): respect browser region in timestamps

### DIFF
--- a/apps/frontend/e2e/user-settings.test.ts
+++ b/apps/frontend/e2e/user-settings.test.ts
@@ -125,8 +125,16 @@ test.describe('User Settings - Display', () => {
       timeout: TIMEOUTS.UI_STANDARD
     });
 
-    // Select 24-hour format
+    const timezoneInput = page.getByTestId('timezone-input');
+    await timezoneInput.fill('Europe/Berlin');
+
+    const currentTime = page.getByText(/^Current time there:/);
+    await page.getByRole('button', { name: '12-hour' }).click();
+    await expect(currentTime).toContainText(/[AP]M$/);
+
+    // Select 24-hour format and verify the unsaved preview updates.
     await page.getByRole('button', { name: '24-hour' }).click();
+    await expect(currentTime).not.toContainText(/[AP]M$/);
 
     // Save
     const saveButton = page.getByRole('button', { name: 'Save Display Settings' });

--- a/apps/frontend/src/lib/i18n/runtime.ts
+++ b/apps/frontend/src/lib/i18n/runtime.ts
@@ -12,6 +12,14 @@ export function getLocale(): Locale {
   return getReactiveLocale();
 }
 
+export function getBrowserLocale(): string {
+  return (
+    globalThis.navigator?.languages?.[0] ??
+    globalThis.navigator?.language ??
+    new Intl.DateTimeFormat().resolvedOptions().locale
+  );
+}
+
 /**
  * Combine Chatto's selected language with the browser's region for Intl formatting.
  *
@@ -26,10 +34,7 @@ export function getFormattingLocale(locale: string = getLocale()): string {
     const languageLocale = new Intl.Locale(locale);
     if (languageLocale.region) return languageLocale.toString();
 
-    const browserLocale =
-      globalThis.navigator?.languages?.[0] ??
-      globalThis.navigator?.language ??
-      new Intl.DateTimeFormat().resolvedOptions().locale;
+    const browserLocale = getBrowserLocale();
     const browserRegion = new Intl.Locale(browserLocale).maximize().region;
     return browserRegion
       ? new Intl.Locale(languageLocale.baseName, { region: browserRegion }).toString()

--- a/apps/frontend/src/lib/i18n/runtime.ts
+++ b/apps/frontend/src/lib/i18n/runtime.ts
@@ -12,6 +12,33 @@ export function getLocale(): Locale {
   return getReactiveLocale();
 }
 
+/**
+ * Combine Chatto's selected language with the browser's region for Intl formatting.
+ *
+ * Paraglide locales are language-only (for example, `en`), which would otherwise
+ * make Intl fall back to US conventions instead of the browser's `en-GB` region.
+ * Explicit region-bearing locales are preserved for deterministic callers and tests.
+ */
+export function getFormattingLocale(locale: string = getLocale()): string {
+  if (typeof Intl.Locale !== 'function') return locale;
+
+  try {
+    const languageLocale = new Intl.Locale(locale);
+    if (languageLocale.region) return languageLocale.toString();
+
+    const browserLocale =
+      globalThis.navigator?.languages?.[0] ??
+      globalThis.navigator?.language ??
+      new Intl.DateTimeFormat().resolvedOptions().locale;
+    const browserRegion = new Intl.Locale(browserLocale).maximize().region;
+    return browserRegion
+      ? new Intl.Locale(languageLocale.baseName, { region: browserRegion }).toString()
+      : languageLocale.toString();
+  } catch {
+    return locale;
+  }
+}
+
 function applyDocumentLocale(locale: Locale): void {
   if (typeof document === 'undefined') return;
   document.documentElement.lang = locale;

--- a/apps/frontend/src/lib/state/userSettings.svelte.ts
+++ b/apps/frontend/src/lib/state/userSettings.svelte.ts
@@ -8,6 +8,12 @@
 import { createContext } from 'svelte';
 import { TimeFormat } from '$lib/render/types';
 
+export function hour12ForTimeFormat(timeFormat: TimeFormat): boolean | undefined {
+  if (timeFormat === TimeFormat.TwelveHour) return true;
+  if (timeFormat === TimeFormat.TwentyFourHour) return false;
+  return undefined;
+}
+
 export class UserSettingsState {
   /** IANA timezone name, or null for browser default. */
   timezone = $state<string | null>(null);
@@ -28,9 +34,7 @@ export class UserSettingsState {
    * Returns undefined when unset, which tells Intl to use locale default.
    */
   get effectiveHour12(): boolean | undefined {
-    if (this.timeFormat === TimeFormat.TwelveHour) return true;
-    if (this.timeFormat === TimeFormat.TwentyFourHour) return false;
-    return undefined;
+    return hour12ForTimeFormat(this.timeFormat);
   }
 
   /** Update from server settings data. */

--- a/apps/frontend/src/lib/utils/formatTime.spec.ts
+++ b/apps/frontend/src/lib/utils/formatTime.spec.ts
@@ -44,6 +44,11 @@ describe('formatMessageTime', () => {
     expect(formatMessageTime('2025-04-27T14:30:00Z', settings('UTC'), 'en')).toBe('02:30 PM');
   });
 
+  it('keeps the browser time cycle when the active language differs', () => {
+    setBrowserLocale('en-US');
+    expect(formatMessageTime('2025-04-27T14:30:00Z', settings('UTC'), 'de')).toBe('02:30 PM');
+  });
+
   it('formats UTC time in 24-hour format', () => {
     expect(formatMessageTime('2025-04-27T14:30:00Z', utc12, 'en-US')).toBe('14:30');
   });
@@ -70,7 +75,12 @@ describe('formatDate', () => {
 
   it('keeps translated date text while applying the browser region', () => {
     setBrowserLocale('en-GB');
-    expect(formatDate('2025-04-27T14:30:00Z', utc12, 'de')).toMatch(/27\. Apr\.? 2025/);
+    expect(formatDate('2025-04-27T14:30:00Z', utc12, 'de')).toBe('27 Apr. 2025');
+  });
+
+  it('keeps browser date ordering when the active language differs', () => {
+    setBrowserLocale('en-US');
+    expect(formatDate('2025-04-27T14:30:00Z', utc12, 'de')).toBe('Apr. 27, 2025');
   });
 
   it('formats a date in long-month/short style', () => {

--- a/apps/frontend/src/lib/utils/formatTime.spec.ts
+++ b/apps/frontend/src/lib/utils/formatTime.spec.ts
@@ -27,13 +27,29 @@ function settings(timezone: string | undefined, hour12?: boolean): UserSettingsS
 const utc12 = settings('UTC', false);
 const utc12h = settings('UTC', true);
 
+function setBrowserLocale(locale: string): void {
+  vi.stubGlobal('navigator', { languages: [locale], language: locale });
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
 describe('formatMessageTime', () => {
+  it('uses an en-GB browser region for the automatic time format', () => {
+    setBrowserLocale('en-GB');
+    expect(formatMessageTime('2025-04-27T14:30:00Z', settings('UTC'), 'en')).toBe('14:30');
+  });
+
+  it('uses an en-US browser region for the automatic time format', () => {
+    setBrowserLocale('en-US');
+    expect(formatMessageTime('2025-04-27T14:30:00Z', settings('UTC'), 'en')).toBe('02:30 PM');
+  });
+
   it('formats UTC time in 24-hour format', () => {
-    expect(formatMessageTime('2025-04-27T14:30:00Z', utc12)).toBe('14:30');
+    expect(formatMessageTime('2025-04-27T14:30:00Z', utc12, 'en-US')).toBe('14:30');
   });
 
   it('formats UTC time in 12-hour format with AM/PM', () => {
-    expect(formatMessageTime('2025-04-27T14:30:00Z', utc12h)).toBe('02:30 PM');
+    expect(formatMessageTime('2025-04-27T14:30:00Z', utc12h, 'en-GB')).toBe('02:30 pm');
   });
 
   it('respects timezone offsets', () => {
@@ -47,6 +63,16 @@ describe('formatMessageTime', () => {
 });
 
 describe('formatDate', () => {
+  it('uses the browser region with the active language', () => {
+    setBrowserLocale('en-GB');
+    expect(formatDate('2025-04-27T14:30:00Z', utc12, 'en')).toBe('27 Apr 2025');
+  });
+
+  it('keeps translated date text while applying the browser region', () => {
+    setBrowserLocale('en-GB');
+    expect(formatDate('2025-04-27T14:30:00Z', utc12, 'de')).toMatch(/27\. Apr\.? 2025/);
+  });
+
   it('formats a date in long-month/short style', () => {
     expect(formatDate('2025-04-27T14:30:00Z', utc12)).toMatch(/Apr\s*27,?\s*2025/);
   });
@@ -168,13 +194,13 @@ describe('firstDayOfWeekForLocale', () => {
   });
 
   it('uses the browser locale when no explicit locale is passed', () => {
-    vi.stubGlobal('navigator', { languages: ['en-US'], language: 'en-US' });
+    setBrowserLocale('en-US');
+    expect(firstDayOfWeekForLocale()).toBe(0);
+  });
 
-    try {
-      expect(firstDayOfWeekForLocale()).toBe(0);
-    } finally {
-      vi.unstubAllGlobals();
-    }
+  it('combines a language-only locale with the browser region', () => {
+    setBrowserLocale('en-GB');
+    expect(firstDayOfWeekForLocale('en')).toBe(1);
   });
 });
 

--- a/apps/frontend/src/lib/utils/formatTime.spec.ts
+++ b/apps/frontend/src/lib/utils/formatTime.spec.ts
@@ -83,6 +83,11 @@ describe('formatDate', () => {
     expect(formatDate('2025-04-27T14:30:00Z', utc12, 'de')).toBe('Apr. 27, 2025');
   });
 
+  it('uses one calendar when combining regional patterns with translated values', () => {
+    setBrowserLocale('en-US-u-ca-islamic');
+    expect(formatDate('2025-04-27T14:30:00Z', utc12, 'de')).toBe('Apr. 27, 2025');
+  });
+
   it('formats a date in long-month/short style', () => {
     expect(formatDate('2025-04-27T14:30:00Z', utc12)).toMatch(/Apr\s*27,?\s*2025/);
   });

--- a/apps/frontend/src/lib/utils/formatTime.ts
+++ b/apps/frontend/src/lib/utils/formatTime.ts
@@ -10,7 +10,7 @@
  */
 
 import type { UserSettingsState } from '$lib/state/userSettings.svelte';
-import { getFormattingLocale, getLocale } from '$lib/i18n/runtime';
+import { getBrowserLocale, getFormattingLocale, getLocale } from '$lib/i18n/runtime';
 import * as m from '$lib/i18n/messages';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -26,14 +26,46 @@ function getFormatter(
   locale: string | undefined,
   options: Intl.DateTimeFormatOptions
 ): Intl.DateTimeFormat {
-  const formattingLocale = locale ? getFormattingLocale(locale) : locale;
-  const key = `${formattingLocale ?? ''}:${JSON.stringify(options)}`;
+  const key = `${locale ?? ''}:${JSON.stringify(options)}`;
   let fmt = formatterCache.get(key);
   if (!fmt) {
-    fmt = new Intl.DateTimeFormat(formattingLocale, options);
+    fmt = new Intl.DateTimeFormat(locale, options);
     formatterCache.set(key, fmt);
   }
   return fmt;
+}
+
+function regionalLocale(locale: string): string {
+  try {
+    return new Intl.Locale(locale).region ? locale : getBrowserLocale();
+  } catch {
+    return locale;
+  }
+}
+
+/** Format translated values using the browser region's field order and punctuation. */
+function formatVisibleDateTime(
+  date: Date,
+  locale: string,
+  options: Intl.DateTimeFormatOptions
+): string {
+  const regionalFormatter = getFormatter(regionalLocale(locale), options);
+  const localizedOptions =
+    options.hour !== undefined && options.hour12 === undefined
+      ? { ...options, hour12: regionalFormatter.resolvedOptions().hour12 }
+      : options;
+  const localizedParts = getFormatter(locale, localizedOptions).formatToParts(date);
+  const localizedValues = new Map(
+    localizedParts.filter((part) => part.type !== 'literal').map((part) => [part.type, part.value])
+  );
+
+  return regionalFormatter
+    .formatToParts(date)
+    .map((part) =>
+      part.type === 'literal' ? part.value : (localizedValues.get(part.type) ?? part.value)
+    )
+    .join('')
+    .replace(/[\u00a0\u202f]/g, ' ');
 }
 
 function activeLocale(): string {
@@ -117,16 +149,15 @@ function startOfWeekSerial(parts: DateParts, firstDay: number): number {
  */
 export function formatMessageTime(
   date: Date | string,
-  settings: UserSettingsState,
+  settings: Pick<UserSettingsState, 'effectiveTimezone' | 'effectiveHour12'>,
   locale: string = activeLocale()
 ): string {
-  const fmt = getFormatter(locale, {
+  return formatVisibleDateTime(toDate(date), locale, {
     hour: '2-digit',
     minute: '2-digit',
     hour12: settings.effectiveHour12,
     timeZone: settings.effectiveTimezone
   });
-  return fmt.format(toDate(date));
 }
 
 /**
@@ -137,13 +168,12 @@ export function formatDate(
   settings: UserSettingsState,
   locale: string = activeLocale()
 ): string {
-  const fmt = getFormatter(locale, {
+  return formatVisibleDateTime(toDate(date), locale, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
     timeZone: settings.effectiveTimezone
   });
-  return fmt.format(toDate(date));
 }
 
 /**
@@ -154,7 +184,7 @@ export function formatDateTime(
   settings: UserSettingsState,
   locale: string = activeLocale()
 ): string {
-  const fmt = getFormatter(locale, {
+  return formatVisibleDateTime(toDate(date), locale, {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
@@ -163,7 +193,6 @@ export function formatDateTime(
     hour12: settings.effectiveHour12,
     timeZone: settings.effectiveTimezone
   });
-  return fmt.format(toDate(date));
 }
 
 /**
@@ -204,14 +233,13 @@ export function formatDayLabel(
   const yearFmt = getFormatter('en-US', { year: 'numeric', timeZone: tz });
   const sameYear = yearFmt.format(d) === yearFmt.format(now);
 
-  const labelFmt = getFormatter(locale, {
+  return formatVisibleDateTime(d, locale, {
     weekday: 'long',
     month: 'long',
     day: 'numeric',
     year: sameYear ? undefined : 'numeric',
     timeZone: tz
   });
-  return labelFmt.format(d);
 }
 
 export function formatMonthYear(
@@ -219,12 +247,11 @@ export function formatMonthYear(
   settings: UserSettingsState,
   locale: string = activeLocale()
 ): string {
-  const fmt = getFormatter(locale, {
+  return formatVisibleDateTime(toDate(date), locale, {
     month: 'long',
     year: 'numeric',
     timeZone: settings.effectiveTimezone
   });
-  return fmt.format(toDate(date));
 }
 
 export function fileDateGroup(

--- a/apps/frontend/src/lib/utils/formatTime.ts
+++ b/apps/frontend/src/lib/utils/formatTime.ts
@@ -10,7 +10,7 @@
  */
 
 import type { UserSettingsState } from '$lib/state/userSettings.svelte';
-import { getLocale } from '$lib/i18n/runtime';
+import { getFormattingLocale, getLocale } from '$lib/i18n/runtime';
 import * as m from '$lib/i18n/messages';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -26,10 +26,11 @@ function getFormatter(
   locale: string | undefined,
   options: Intl.DateTimeFormatOptions
 ): Intl.DateTimeFormat {
-  const key = `${locale ?? ''}:${JSON.stringify(options)}`;
+  const formattingLocale = locale ? getFormattingLocale(locale) : locale;
+  const key = `${formattingLocale ?? ''}:${JSON.stringify(options)}`;
   let fmt = formatterCache.get(key);
   if (!fmt) {
-    fmt = new Intl.DateTimeFormat(locale, options);
+    fmt = new Intl.DateTimeFormat(formattingLocale, options);
     formatterCache.set(key, fmt);
   }
   return fmt;
@@ -93,8 +94,7 @@ function normalizeFirstDay(firstDay: number | undefined): number | null {
 
 export function firstDayOfWeekForLocale(locale?: string): number {
   const fallback = 1;
-  const localeName =
-    locale ?? globalThis.navigator?.languages?.[0] ?? globalThis.navigator?.language;
+  const localeName = getFormattingLocale(locale ?? activeLocale());
   if (!localeName || typeof Intl.Locale !== 'function') return fallback;
 
   try {

--- a/apps/frontend/src/lib/utils/formatTime.ts
+++ b/apps/frontend/src/lib/utils/formatTime.ts
@@ -49,11 +49,13 @@ function formatVisibleDateTime(
   locale: string,
   options: Intl.DateTimeFormatOptions
 ): string {
-  const regionalFormatter = getFormatter(regionalLocale(locale), options);
+  const calendar = getFormatter(locale, options).resolvedOptions().calendar;
+  const sharedOptions = { ...options, calendar };
+  const regionalFormatter = getFormatter(regionalLocale(locale), sharedOptions);
   const localizedOptions =
     options.hour !== undefined && options.hour12 === undefined
-      ? { ...options, hour12: regionalFormatter.resolvedOptions().hour12 }
-      : options;
+      ? { ...sharedOptions, hour12: regionalFormatter.resolvedOptions().hour12 }
+      : sharedOptions;
   const localizedParts = getFormatter(locale, localizedOptions).formatToParts(date);
   const localizedValues = new Map(
     localizedParts.filter((part) => part.type !== 'literal').map((part) => [part.type, part.value])

--- a/apps/frontend/src/routes/chat/[serverId]/settings/preferences/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/preferences/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import * as m from '$lib/i18n/messages';
-  import { getFormattingLocale, getLocale, setLocale, type Locale } from '$lib/i18n/runtime';
+  import { getLocale, setLocale, type Locale } from '$lib/i18n/runtime';
   import { useConnection } from '$lib/state/server/connection.svelte';
   import { createAccountAPI } from '$lib/api-client/account';
   import { TimeFormat } from '$lib/render/types';
@@ -11,6 +11,7 @@
   import { PaneHeader, FormSection } from '$lib/ui';
   import { Button, FormError } from '$lib/ui/form';
   import { toast } from '$lib/ui/toast';
+  import { formatMessageTime } from '$lib/utils/formatTime';
 
   const userSettings = getUserSettings();
   const currentUser = $derived(serverRegistry.getStore(getActiveServer()).currentUser);
@@ -65,12 +66,14 @@
   const selectedTimezoneTime = $derived.by(() => {
     if (!selectedTimezone) return null;
 
-    return new Date().toLocaleTimeString(getFormattingLocale(activeLocale), {
-      timeZone: selectedTimezone,
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: hour12ForTimeFormat(selectedTimeFormat)
-    });
+    return formatMessageTime(
+      new Date(),
+      {
+        effectiveTimezone: selectedTimezone,
+        effectiveHour12: hour12ForTimeFormat(selectedTimeFormat)
+      },
+      activeLocale
+    );
   });
 
   function handleTimezoneInput(e: Event) {
@@ -363,7 +366,9 @@
           {/each}
           {#if filteredTimezones.length > 50}
             <li class="px-3 py-1.5 text-xs text-muted">
-              {m['settings.preferences.timezone.more_results']({ count: filteredTimezones.length - 50 })}
+              {m['settings.preferences.timezone.more_results']({
+                count: filteredTimezones.length - 50
+              })}
             </li>
           {/if}
         </ul>

--- a/apps/frontend/src/routes/chat/[serverId]/settings/preferences/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/preferences/+page.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import * as m from '$lib/i18n/messages';
-  import { getLocale, setLocale, type Locale } from '$lib/i18n/runtime';
+  import { getFormattingLocale, getLocale, setLocale, type Locale } from '$lib/i18n/runtime';
   import { useConnection } from '$lib/state/server/connection.svelte';
   import { createAccountAPI } from '$lib/api-client/account';
   import { TimeFormat } from '$lib/render/types';
-  import { getUserSettings } from '$lib/state/userSettings.svelte';
+  import { getUserSettings, hour12ForTimeFormat } from '$lib/state/userSettings.svelte';
   import { userPreferences, type DisplayTheme } from '$lib/state/userPreferences.svelte';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
@@ -65,11 +65,11 @@
   const selectedTimezoneTime = $derived.by(() => {
     if (!selectedTimezone) return null;
 
-    return new Date().toLocaleTimeString(activeLocale, {
+    return new Date().toLocaleTimeString(getFormattingLocale(activeLocale), {
       timeZone: selectedTimezone,
       hour: '2-digit',
       minute: '2-digit',
-      hour12: userSettings.effectiveHour12
+      hour12: hour12ForTimeFormat(selectedTimeFormat)
     });
   });
 


### PR DESCRIPTION
## Summary

- preserve the browser region's date ordering, punctuation, week rules, and hour cycle while keeping Chatto's selected UI language
- keep explicit 12-hour and 24-hour preferences authoritative
- update the timezone preview immediately for unsaved time-format selections
- keep regional and localized calendar parts consistent, including non-Gregorian browser locales

## Root cause

The localization integration passed Paraglide's language-only locale (for example, `en`) into `Intl.DateTimeFormat`. ICU resolved bare `en` with US conventions, so an `en-GB` browser incorrectly displayed AM/PM timestamps and US-style dates. Directly synthesizing cross-language region tags was also insufficient because ICU can fall back to the language default.

## User impact

Users now get their browser's regional date/time conventions under Browser default, without losing Chatto's selected interface language. Explicit time-format and timezone preferences continue to override defaults.

## Validation

- `pnpm run check` — 0 errors and 0 warnings
- focused date/time formatting suite — 40 tests passed
- full frontend suite — 1,861 tests passed
- user-settings E2E suite — 8 tests passed
- three-pass adversarial code review — no actionable findings remain

Closes #1382.
