### PR TITLE
refactor(events): extract incremental effect consumer

### DIFF
--- a/cli/internal/core/call_model.go
+++ b/cli/internal/core/call_model.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	lkauth "github.com/livekit/protocol/auth"
@@ -60,9 +59,7 @@ type CallModel struct {
 	reconcileLease *lease.Lease
 	memoryCacheKV  jetstream.KeyValue
 	logger         events.Logger
-	cleanupMu      sync.Mutex
-	pendingKeyRefs map[string]struct{}
-	cleanupSeq     uint64
+	keyCleanup     *events.IncrementalEffectConsumer
 }
 
 type liveKitFailureCleanupSummary struct {
@@ -118,7 +115,7 @@ func NewCallModel(
 	memoryCacheKV jetstream.KeyValue,
 	logger events.Logger,
 ) *CallModel {
-	return &CallModel{
+	model := &CallModel{
 		publisher:      publisher,
 		projection:     projection,
 		projector:      projector,
@@ -127,8 +124,13 @@ func NewCallModel(
 		reconcileLease: reconcileLease,
 		memoryCacheKV:  memoryCacheKV,
 		logger:         logger,
-		pendingKeyRefs: make(map[string]struct{}),
 	}
+	model.keyCleanup = events.NewIncrementalEffectConsumer(
+		publisher,
+		events.RoomEventTypeFilter(events.EventCallEnded),
+		model.cleanupEndedCallKey,
+	)
+	return model
 }
 
 func (c *ChattoCore) EnableLiveKitCallReconciliation(cfg config.LiveKitConfig) error {
@@ -298,15 +300,6 @@ func (s *CallModel) RemoveLiveKitParticipant(ctx context.Context, spaceID, roomI
 	return remover.RemoveCallParticipant(ctx, spaceID, roomID, callID, userID)
 }
 
-func (s *CallModel) queueEndedCallKeyCleanup(keyRef string) {
-	if keyRef == "" {
-		return
-	}
-	s.cleanupMu.Lock()
-	s.pendingKeyRefs[keyRef] = struct{}{}
-	s.cleanupMu.Unlock()
-}
-
 func (s *CallModel) cleanupQueuedCallKey(ctx context.Context, keyRef string) error {
 	if keyRef == "" {
 		return nil
@@ -317,60 +310,21 @@ func (s *CallModel) cleanupQueuedCallKey(ctx context.Context, keyRef string) err
 	if err := s.callKeys.ShredCallKey(context.WithoutCancel(ctx), keyRef); err != nil {
 		return err
 	}
-	s.cleanupMu.Lock()
-	delete(s.pendingKeyRefs, keyRef)
-	s.cleanupMu.Unlock()
 	return nil
 }
 
 func (s *CallModel) cleanupEndedCallKeys(ctx context.Context) error {
-	if s.callKeys == nil {
-		return fmt.Errorf("call key store is not initialized")
-	}
-	if err := s.loadEndedCallKeyCleanup(ctx); err != nil {
-		return err
-	}
-
-	s.cleanupMu.Lock()
-	keyRefs := make([]string, 0, len(s.pendingKeyRefs))
-	for keyRef := range s.pendingKeyRefs {
-		keyRefs = append(keyRefs, keyRef)
-	}
-	s.cleanupMu.Unlock()
-	sort.Strings(keyRefs)
-
-	var cleanupErr error
-	for _, keyRef := range keyRefs {
-		if err := s.callKeys.ShredCallKey(context.WithoutCancel(ctx), keyRef); err != nil {
-			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("shred ended call key %s: %w", keyRef, err))
-			continue
-		}
-		s.cleanupMu.Lock()
-		delete(s.pendingKeyRefs, keyRef)
-		s.cleanupMu.Unlock()
-	}
-	return cleanupErr
+	return s.keyCleanup.Consume(ctx)
 }
 
-func (s *CallModel) loadEndedCallKeyCleanup(ctx context.Context) error {
-	s.cleanupMu.Lock()
-	afterSeq := s.cleanupSeq
-	s.cleanupMu.Unlock()
-
-	ended, lastSeq, err := s.publisher.SubjectEventsAfter(ctx, events.RoomEventTypeFilter(events.EventCallEnded), afterSeq)
-	if err != nil {
-		return fmt.Errorf("load ended calls for key cleanup: %w", err)
+func (s *CallModel) cleanupEndedCallKey(ctx context.Context, event *corev1.Event) error {
+	callID := event.GetVoiceCallEnded().GetCallId()
+	if callID == "" {
+		return nil
 	}
-
-	s.cleanupMu.Lock()
-	defer s.cleanupMu.Unlock()
-	for _, event := range ended {
-		if callID := event.GetVoiceCallEnded().GetCallId(); callID != "" {
-			s.pendingKeyRefs[kms.CallKeyRef(callID)] = struct{}{}
-		}
-	}
-	if lastSeq > s.cleanupSeq {
-		s.cleanupSeq = lastSeq
+	keyRef := kms.CallKeyRef(callID)
+	if err := s.cleanupQueuedCallKey(ctx, keyRef); err != nil {
+		return fmt.Errorf("shred ended call key %s: %w", keyRef, err)
 	}
 	return nil
 }
@@ -411,7 +365,6 @@ func (s *CallModel) appendParticipantTransition(ctx context.Context, roomID, use
 		if err == nil {
 			seq := seqs[len(seqs)-1]
 			if endedKeyRef != "" {
-				s.queueEndedCallKeyCleanup(endedKeyRef)
 				if err := s.cleanupQueuedCallKey(ctx, endedKeyRef); err != nil {
 					return fmt.Errorf("shred ended call key: %w", err)
 				}
@@ -733,7 +686,6 @@ func (s *CallModel) cleanupUnmatchedLiveKitSnapshot(ctx context.Context, snapsho
 		return err
 	}
 	keyRef := kms.CallKeyRef(snapshot.CallID)
-	s.queueEndedCallKeyCleanup(keyRef)
 	for _, userID := range snapshot.UserIDs {
 		if userID == "" {
 			continue

--- a/cli/internal/core/room_membership.go
+++ b/cli/internal/core/room_membership.go
@@ -425,7 +425,6 @@ func (c *ChattoCore) appendRoomLeaveBatch(ctx context.Context, kind RoomKind, ro
 		if c.callModel == nil || c.callModel.callKeys == nil {
 			cleanupErr = fmt.Errorf("call key store is not initialized")
 		} else {
-			c.callModel.queueEndedCallKeyCleanup(cleanup.endedKeyRef)
 			if err := c.callModel.cleanupQueuedCallKey(ctx, cleanup.endedKeyRef); err != nil {
 				cleanupErr = fmt.Errorf("shred ended call key: %w", err)
 			}

--- a/cli/internal/events/events_test.go
+++ b/cli/internal/events/events_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -87,6 +88,119 @@ func makeMessagePostedEvent(roomID, userID string) *corev1.Event {
 				RoomId: roomID,
 			},
 		},
+	}
+}
+
+func TestIncrementalEffectConsumer_RetriesOnlyFailedEffectsAndAdvances(t *testing.T) {
+	js, stream := setupTestStream(t)
+	pub := NewPublisher(js, stream, testLogger())
+	ctx := testContext(t)
+	subject := RoomAggregate("R-consumer").Subject(EventUserJoinedRoom)
+
+	for _, userID := range []string{"U1", "U2"} {
+		if _, err := pub.AppendEventually(ctx, subject, makeEvent("R-consumer", userID)); err != nil {
+			t.Fatalf("AppendEventually %s: %v", userID, err)
+		}
+	}
+
+	fail := true
+	var handled []string
+	consumer := NewIncrementalEffectConsumer(pub, subject, func(_ context.Context, event *corev1.Event) error {
+		handled = append(handled, event.GetActorId())
+		if fail && event.GetActorId() == "U2" {
+			return errors.New("effect unavailable")
+		}
+		return nil
+	})
+
+	if err := consumer.Consume(ctx); err == nil {
+		t.Fatal("Consume returned nil for failed effect batch")
+	}
+	fail = false
+	if err := consumer.Consume(ctx); err != nil {
+		t.Fatalf("Consume retry: %v", err)
+	}
+	if _, err := pub.AppendEventually(ctx, subject, makeEvent("R-consumer", "U3")); err != nil {
+		t.Fatalf("AppendEventually U3: %v", err)
+	}
+	if err := consumer.Consume(ctx); err != nil {
+		t.Fatalf("Consume incremental event: %v", err)
+	}
+
+	want := []string{"U1", "U2", "U2", "U3"}
+	if !slices.Equal(handled, want) {
+		t.Fatalf("handled actors = %v, want %v", handled, want)
+	}
+}
+
+func TestIncrementalEffectConsumer_PermanentFailureDoesNotBlockLaterEffects(t *testing.T) {
+	js, stream := setupTestStream(t)
+	pub := NewPublisher(js, stream, testLogger())
+	ctx := testContext(t)
+	subject := RoomAggregate("R-independent").Subject(EventUserJoinedRoom)
+	for _, userID := range []string{"U1", "U2"} {
+		if _, err := pub.AppendEventually(ctx, subject, makeEvent("R-independent", userID)); err != nil {
+			t.Fatalf("AppendEventually %s: %v", userID, err)
+		}
+	}
+
+	var handled []string
+	consumer := NewIncrementalEffectConsumer(pub, subject, func(_ context.Context, event *corev1.Event) error {
+		handled = append(handled, event.GetActorId())
+		if event.GetActorId() == "U1" {
+			return errors.New("permanent effect failure")
+		}
+		return nil
+	})
+	if err := consumer.Consume(ctx); err == nil {
+		t.Fatal("Consume returned nil for permanent effect failure")
+	}
+	if _, err := pub.AppendEventually(ctx, subject, makeEvent("R-independent", "U3")); err != nil {
+		t.Fatalf("AppendEventually U3: %v", err)
+	}
+	if err := consumer.Consume(ctx); err == nil {
+		t.Fatal("Consume retry returned nil for permanent effect failure")
+	}
+
+	want := []string{"U1", "U2", "U1", "U3"}
+	if !slices.Equal(handled, want) {
+		t.Fatalf("handled actors = %v, want %v", handled, want)
+	}
+}
+
+func TestIncrementalEffectConsumer_SerializesConcurrentConsume(t *testing.T) {
+	js, stream := setupTestStream(t)
+	pub := NewPublisher(js, stream, testLogger())
+	ctx := testContext(t)
+	subject := RoomAggregate("R-serialized").Subject(EventUserJoinedRoom)
+	if _, err := pub.AppendEventually(ctx, subject, makeEvent("R-serialized", "U1")); err != nil {
+		t.Fatalf("AppendEventually: %v", err)
+	}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	calls := 0
+	consumer := NewIncrementalEffectConsumer(pub, subject, func(context.Context, *corev1.Event) error {
+		calls++
+		if calls == 1 {
+			close(started)
+			<-release
+		}
+		return nil
+	})
+
+	errCh := make(chan error, 2)
+	go func() { errCh <- consumer.Consume(ctx) }()
+	<-started
+	go func() { errCh <- consumer.Consume(ctx) }()
+	close(release)
+	for range 2 {
+		if err := <-errCh; err != nil {
+			t.Fatalf("Consume: %v", err)
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("handler calls = %d, want 1", calls)
 	}
 }
 

--- a/cli/internal/events/incremental_effect_consumer.go
+++ b/cli/internal/events/incremental_effect_consumer.go
@@ -1,0 +1,71 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+// IncrementalEffectConsumer processes independent effects derived from events
+// matching one subject filter. Its cursor and failed-work queue are process-local:
+// a new consumer replays the full matching history. Successful effects are not
+// repeated within one process, while failed effects remain queued without
+// blocking later events. Handlers must be idempotent.
+type IncrementalEffectConsumer struct {
+	publisher *Publisher
+	subject   string
+	handle    func(context.Context, *corev1.Event) error
+
+	mu       sync.Mutex
+	afterSeq uint64
+	pending  []*corev1.Event
+}
+
+// NewIncrementalEffectConsumer constructs an incremental consumer. Lifecycle,
+// polling cadence, lease ownership, and retry backoff remain domain concerns.
+func NewIncrementalEffectConsumer(
+	publisher *Publisher,
+	subject string,
+	handle func(context.Context, *corev1.Event) error,
+) *IncrementalEffectConsumer {
+	return &IncrementalEffectConsumer{
+		publisher: publisher,
+		subject:   subject,
+		handle:    handle,
+	}
+}
+
+// Consume discovers new events and attempts every pending effect. Concurrent
+// calls are serialized so they cannot race cursor or queue advancement.
+func (c *IncrementalEffectConsumer) Consume(ctx context.Context) error {
+	if c == nil || c.publisher == nil || c.handle == nil || c.subject == "" {
+		return fmt.Errorf("incremental effect consumer is not configured")
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	events, lastSeq, readErr := c.publisher.SubjectEventsAfter(ctx, c.subject, c.afterSeq)
+	if readErr == nil {
+		c.pending = append(c.pending, events...)
+		if lastSeq > c.afterSeq {
+			c.afterSeq = lastSeq
+		}
+	} else {
+		readErr = fmt.Errorf("read incremental effects for %s: %w", c.subject, readErr)
+	}
+
+	remaining := c.pending[:0]
+	var handleErr error
+	for _, event := range c.pending {
+		if err := c.handle(ctx, event); err != nil {
+			remaining = append(remaining, event)
+			handleErr = errors.Join(handleErr, fmt.Errorf("handle incremental effect %s for %s: %w", event.GetId(), c.subject, err))
+		}
+	}
+	c.pending = remaining
+	return errors.Join(readErr, handleErr)
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -374,13 +374,19 @@ auth workflow audit facts.
 
 ### Durable Effect Inventory
 
-Key files: [`cli/internal/core/call_model.go`](../cli/internal/core/call_model.go), [`cli/internal/core/asset_model.go`](../cli/internal/core/asset_model.go), [`cli/internal/core/message_body_cleanup.go`](../cli/internal/core/message_body_cleanup.go), [`cli/internal/core/core.go`](../cli/internal/core/core.go), [`cli/internal/video/service.go`](../cli/internal/video/service.go)
+Key files: [`cli/internal/events/incremental_effect_consumer.go`](../cli/internal/events/incremental_effect_consumer.go), [`cli/internal/core/call_model.go`](../cli/internal/core/call_model.go), [`cli/internal/core/asset_model.go`](../cli/internal/core/asset_model.go), [`cli/internal/core/message_body_cleanup.go`](../cli/internal/core/message_body_cleanup.go), [`cli/internal/video/service.go`](../cli/internal/video/service.go)
 
 Some durable facts require work in a different storage system or external
 service. The table records the current execution and recovery contract. A
 durable trigger means unfinished work can be rediscovered after a crash; it
 does not by itself guarantee that every implementation currently performs that
 recovery.
+
+`IncrementalEffectConsumer` provides the shared low-level mechanism for
+process-local cursoring and independent failed-effect retries over a filtered
+EVT lane. Domain models still own lease selection, polling cadence, backoff,
+idempotent handlers, logging, and lifecycle; call-key cleanup is the first
+consumer, and a second domain must validate the boundary before broader use.
 
 | Effect | Durable fact or invariant | Immediate execution | Restart and multi-replica behavior | Current status |
 | ------ | ------------------------- | ------------------- | ---------------------------------- | -------------- |


### PR DESCRIPTION
## Summary

Extract a reusable `IncrementalEffectConsumer` for filtered EVT lanes, with serialized polling, process-local cursoring, and independent retry queues so one permanent failure cannot starve later effects.
Migrate ended-call key shredding from its custom cursor and pending map while preserving immediate cleanup, restart replay, lease ownership, and cross-replica recovery behavior.
Add retry, permanent-failure, concurrency, restart, race, and call-integration coverage, and document the deliberately narrow shared-mechanics boundary from #1377.

## Validation

`mise x -- go test ./internal/events ./internal/core ./internal/connectapi -count=1 -timeout 180s`

`mise x -- go test -race ./internal/events ./internal/core -run 'TestIncrementalEffectConsumer|TestCallState_(RoomLeaveRetriesCommittedKeyCleanupDuringReconciliation|LeaseHolderDiscoversLaterReplicaKeyCleanup|ReconciliationCleansHistoricalMembershipOnlyLeave)' -count=1 -timeout 120s`

`mise license-check`
