### PR TITLE
fix(frontend): preserve optimistic reads across refresh

### DIFF
--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte
@@ -94,6 +94,7 @@
       loaded = true;
       return;
     }
+    const unreadSnapshotRevision = roomUnreadStore.captureSnapshotRevision();
     try {
       const [serverState, viewer, rooms] = await Promise.all([
         getAuthenticatedServerState(connectAPIConfig()),
@@ -115,7 +116,8 @@
       );
       roomUnreadStore.initRooms(
         rooms,
-        serverState.viewerHasUnreadRooms && !hasUnreadChannel
+        serverState.viewerHasUnreadRooms && !hasUnreadChannel,
+        unreadSnapshotRevision
       );
 
       displayName = serverState.name;
@@ -244,8 +246,9 @@
     let roomId = roomUnreadStore.getFirstUnreadRoomId();
 
     if (!roomId) {
+      const unreadSnapshotRevision = roomUnreadStore.captureSnapshotRevision();
       const rooms = await roomDirectoryAPI().listRooms(RoomDirectoryScope.CHANNELS);
-      roomUnreadStore.updateRooms(rooms);
+      roomUnreadStore.updateRooms(rooms, unreadSnapshotRevision);
       roomUnreadStore.resolveUnknownUnread();
       roomId = roomUnreadStore.getFirstUnreadRoomId();
     }

--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
@@ -55,6 +55,7 @@ const { mocks } = vi.hoisted(() => {
           getCleanPath: vi.fn().mockReturnValue('/chat/remote.example.com/room-1')
         },
         roomUnread: {
+          captureSnapshotRevision: vi.fn().mockReturnValue(0),
           clear: vi.fn(),
           initRooms: vi.fn(),
           updateRooms: vi.fn(),
@@ -237,6 +238,8 @@ describe('ServerSidebarEntry', () => {
     mocks.store.notifications.dismiss.mockClear();
     mocks.store.notifications.getCleanPath.mockReturnValue('/chat/remote.example.com/room-1');
     mocks.store.roomUnread.clear.mockClear();
+    mocks.store.roomUnread.captureSnapshotRevision.mockClear();
+    mocks.store.roomUnread.captureSnapshotRevision.mockReturnValue(0);
     mocks.store.roomUnread.initRooms.mockClear();
     mocks.store.roomUnread.updateRooms.mockClear();
     mocks.store.roomUnread.resolveUnknownUnread.mockClear();
@@ -341,7 +344,8 @@ describe('ServerSidebarEntry', () => {
     );
     expect(mocks.store.roomUnread.initRooms).toHaveBeenCalledWith(
       [{ id: 'dm-1', kind: 2, hasUnread: true }],
-      true
+      true,
+      0
     );
   });
 

--- a/apps/frontend/src/lib/state/server/roomUnread.spec.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.spec.ts
@@ -41,6 +41,57 @@ describe('RoomUnreadStore', () => {
     expect(store.hasAnyUnread).toBe(true);
   });
 
+  it('preserves an optimistic read across a stale directory refresh', () => {
+    const store = new RoomUnreadStore();
+    store.setRoomUnread('room-1', true);
+    const snapshotRevision = store.captureSnapshotRevision();
+
+    const read = store.beginOptimisticRead('room-1');
+    store.initRooms([{ id: 'room-1', hasUnread: true }], false, snapshotRevision);
+
+    expect(store.roomIsUnread('room-1')).toBe(false);
+
+    read.commit();
+
+    expect(store.roomIsUnread('room-1')).toBe(false);
+  });
+
+  it('reveals refreshed unread state when an optimistic read rolls back', () => {
+    const store = new RoomUnreadStore();
+    const snapshotRevision = store.captureSnapshotRevision();
+
+    const read = store.beginOptimisticRead('room-1');
+    store.initRooms([{ id: 'room-1', hasUnread: true }], false, snapshotRevision);
+    read.rollback();
+
+    expect(store.roomIsUnread('room-1')).toBe(true);
+  });
+
+  it('does not let a stale directory refresh overwrite a successful read', () => {
+    const store = new RoomUnreadStore();
+    store.setRoomUnread('room-1', true);
+    const snapshotRevision = store.captureSnapshotRevision();
+
+    const read = store.beginOptimisticRead('room-1');
+    read.commit();
+    store.initRooms([{ id: 'room-1', hasUnread: true }], false, snapshotRevision);
+
+    expect(store.roomIsUnread('room-1')).toBe(false);
+  });
+
+  it('does not let a stale directory refresh overwrite a live read event', () => {
+    const store = new RoomUnreadStore();
+    store.setRoomUnread('room-1', true);
+    const snapshotRevision = store.captureSnapshotRevision();
+
+    const read = store.beginOptimisticRead('room-1');
+    store.setRoomUnread('room-1', false);
+    store.initRooms([{ id: 'room-1', hasUnread: true }], false, snapshotRevision);
+    read.rollback();
+
+    expect(store.roomIsUnread('room-1')).toBe(false);
+  });
+
   it('does not let rollback erase a newer unread message', () => {
     const store = new RoomUnreadStore();
     store.setRoomUnread('room-1', true);

--- a/apps/frontend/src/lib/state/server/roomUnread.spec.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.spec.ts
@@ -79,19 +79,6 @@ describe('RoomUnreadStore', () => {
     expect(store.roomIsUnread('room-1')).toBe(false);
   });
 
-  it('does not let a stale directory refresh restore an unknown unread after a read', () => {
-    const store = new RoomUnreadStore();
-    store.setRoomUnread('room-1', true);
-    const snapshotRevision = store.captureSnapshotRevision();
-
-    const read = store.beginOptimisticRead('room-1');
-    read.commit();
-    store.initRooms([{ id: 'room-1', hasUnread: false }], true, snapshotRevision);
-
-    expect(store.roomIsUnread('room-1')).toBe(false);
-    expect(store.hasAnyUnread).toBe(false);
-  });
-
   it('does not let a stale directory refresh overwrite a live read event', () => {
     const store = new RoomUnreadStore();
     store.setRoomUnread('room-1', true);
@@ -103,18 +90,6 @@ describe('RoomUnreadStore', () => {
     read.rollback();
 
     expect(store.roomIsUnread('room-1')).toBe(false);
-  });
-
-  it('does not let a stale directory refresh restore an unknown unread after a live read', () => {
-    const store = new RoomUnreadStore();
-    store.setRoomUnread('room-1', true);
-    const snapshotRevision = store.captureSnapshotRevision();
-
-    store.setRoomUnread('room-1', false);
-    store.initRooms([{ id: 'room-1', hasUnread: false }], true, snapshotRevision);
-
-    expect(store.roomIsUnread('room-1')).toBe(false);
-    expect(store.hasAnyUnread).toBe(false);
   });
 
   it('does not let rollback erase a newer unread message', () => {

--- a/apps/frontend/src/lib/state/server/roomUnread.spec.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.spec.ts
@@ -79,6 +79,19 @@ describe('RoomUnreadStore', () => {
     expect(store.roomIsUnread('room-1')).toBe(false);
   });
 
+  it('does not let a stale directory refresh restore an unknown unread after a read', () => {
+    const store = new RoomUnreadStore();
+    store.setRoomUnread('room-1', true);
+    const snapshotRevision = store.captureSnapshotRevision();
+
+    const read = store.beginOptimisticRead('room-1');
+    read.commit();
+    store.initRooms([{ id: 'room-1', hasUnread: false }], true, snapshotRevision);
+
+    expect(store.roomIsUnread('room-1')).toBe(false);
+    expect(store.hasAnyUnread).toBe(false);
+  });
+
   it('does not let a stale directory refresh overwrite a live read event', () => {
     const store = new RoomUnreadStore();
     store.setRoomUnread('room-1', true);
@@ -90,6 +103,18 @@ describe('RoomUnreadStore', () => {
     read.rollback();
 
     expect(store.roomIsUnread('room-1')).toBe(false);
+  });
+
+  it('does not let a stale directory refresh restore an unknown unread after a live read', () => {
+    const store = new RoomUnreadStore();
+    store.setRoomUnread('room-1', true);
+    const snapshotRevision = store.captureSnapshotRevision();
+
+    store.setRoomUnread('room-1', false);
+    store.initRooms([{ id: 'room-1', hasUnread: false }], true, snapshotRevision);
+
+    expect(store.roomIsUnread('room-1')).toBe(false);
+    expect(store.hasAnyUnread).toBe(false);
   });
 
   it('does not let rollback erase a newer unread message', () => {

--- a/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
@@ -26,6 +26,7 @@ export class RoomUnreadStore {
   private optimisticReadRooms = new SvelteSet<string>();
   private optimisticReads = new OptimisticMutationRegistry();
   private roomRevisions = new SvelteMap<string, number>();
+  private revision = 0;
   // Server-level unknown-unread flag (set when we know there's unread but
   // not which room — e.g. on initial load before rooms are queried).
   private serverHasUnknownUnread = $state(false);
@@ -38,6 +39,11 @@ export class RoomUnreadStore {
     return this.roomRevisions.get(roomId) ?? 0;
   }
 
+  private advanceRoomRevision(roomId: string): void {
+    this.revision += 1;
+    this.roomRevisions.set(roomId, this.revision);
+  }
+
   private invalidateOptimisticRead(roomId: string): void {
     this.optimisticReads.clear(this.optimisticReadKey(roomId));
     this.optimisticReadRooms.delete(roomId);
@@ -47,7 +53,7 @@ export class RoomUnreadStore {
    * Set unread status for a specific room.
    */
   setRoomUnread(roomId: string, unread: boolean): void {
-    this.roomRevisions.set(roomId, this.roomRevision(roomId) + 1);
+    this.advanceRoomRevision(roomId);
     this.invalidateOptimisticRead(roomId);
 
     if (unread) {
@@ -74,6 +80,7 @@ export class RoomUnreadStore {
         if (!this.optimisticReads.isCurrent(key, token)) return;
         if (this.roomRevision(roomId) !== roomRevision) return;
 
+        this.advanceRoomRevision(roomId);
         this.unreadRooms.delete(roomId);
         this.optimisticReads.clear(key);
         this.optimisticReadRooms.delete(roomId);
@@ -114,28 +121,38 @@ export class RoomUnreadStore {
     return this.unreadRooms.has(roomId) && !this.optimisticReadRooms.has(roomId);
   }
 
+  /** Capture before loading a snapshot so newer room events win on arrival. */
+  captureSnapshotRevision(): number {
+    return this.revision;
+  }
+
   /**
    * Initialize unread state from room data.
    * Call this when loading rooms.
    */
   initRooms(
     rooms: Array<{ id: string; hasUnread: boolean }>,
-    serverHasUnknownUnread = false
+    serverHasUnknownUnread = false,
+    snapshotRevision = this.captureSnapshotRevision()
   ): void {
-    this.optimisticReads.clearAll();
-    this.optimisticReadRooms.clear();
-    this.roomRevisions.clear();
-    this.unreadRooms.clear();
-    this.serverHasUnknownUnread = false;
-    this.updateRooms(rooms);
+    const snapshotRoomIds = new SvelteSet(rooms.map((room) => room.id));
+    for (const roomId of this.unreadRooms) {
+      if (!snapshotRoomIds.has(roomId) && this.roomRevision(roomId) <= snapshotRevision) {
+        this.unreadRooms.delete(roomId);
+      }
+    }
+
+    this.updateRooms(rooms, snapshotRevision);
     this.serverHasUnknownUnread = serverHasUnknownUnread;
   }
 
   /** Merge an authoritative partial room snapshot without dropping other rooms. */
-  updateRooms(rooms: Array<{ id: string; hasUnread: boolean }>): void {
+  updateRooms(
+    rooms: Array<{ id: string; hasUnread: boolean }>,
+    snapshotRevision = this.captureSnapshotRevision()
+  ): void {
     for (const room of rooms) {
-      this.roomRevisions.set(room.id, this.roomRevision(room.id) + 1);
-      this.invalidateOptimisticRead(room.id);
+      if (this.roomRevision(room.id) > snapshotRevision) continue;
       if (room.hasUnread) this.unreadRooms.add(room.id);
       else this.unreadRooms.delete(room.id);
     }
@@ -168,6 +185,7 @@ export class RoomUnreadStore {
     this.optimisticReads.clearAll();
     this.optimisticReadRooms.clear();
     this.roomRevisions.clear();
+    this.revision = 0;
     this.unreadRooms.clear();
     this.serverHasUnknownUnread = false;
   }

--- a/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
@@ -143,7 +143,8 @@ export class RoomUnreadStore {
     }
 
     this.updateRooms(rooms, snapshotRevision);
-    this.serverHasUnknownUnread = serverHasUnknownUnread;
+    this.serverHasUnknownUnread =
+      serverHasUnknownUnread && this.revision <= snapshotRevision;
   }
 
   /** Merge an authoritative partial room snapshot without dropping other rooms. */

--- a/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
@@ -143,8 +143,7 @@ export class RoomUnreadStore {
     }
 
     this.updateRooms(rooms, snapshotRevision);
-    this.serverHasUnknownUnread =
-      serverHasUnknownUnread && this.revision <= snapshotRevision;
+    this.serverHasUnknownUnread = serverHasUnknownUnread;
   }
 
   /** Merge an authoritative partial room snapshot without dropping other rooms. */

--- a/apps/frontend/src/lib/state/server/rooms.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/rooms.svelte.spec.ts
@@ -439,6 +439,30 @@ describe('RoomsStore - refresh', () => {
     expect(roomUnread.roomIsUnread('random')).toBe(true);
   });
 
+  it('does not cancel an optimistic read when an older refresh completes', async () => {
+    let resolveRooms!: (value: DirectoryRoomSummary[]) => void;
+    const roomDirectoryAPI = {
+      listRooms: vi.fn(
+        () => new Promise<DirectoryRoomSummary[]>((resolve) => (resolveRooms = resolve))
+      ),
+      listRoomGroups: vi.fn().mockResolvedValue([])
+    } as unknown as RoomDirectoryAPI;
+    const roomUnread = new RoomUnreadStore();
+    roomUnread.setRoomUnread('general', true);
+    const store = makeStore({ roomDirectoryAPI, roomUnread });
+
+    const refresh = store.refresh();
+    const read = roomUnread.beginOptimisticRead('general');
+    resolveRooms([makeRoom('general', { hasUnread: true })]);
+    await refresh;
+
+    expect(roomUnread.roomIsUnread('general')).toBe(false);
+
+    read.commit();
+
+    expect(roomUnread.roomIsUnread('general')).toBe(false);
+  });
+
   it('only replaces rooms whose notification counts changed', async () => {
     const notificationAPI = makeNotificationAPI({ general: 1, random: 0 });
     const store = makeStore({

--- a/apps/frontend/src/lib/state/server/rooms.svelte.ts
+++ b/apps/frontend/src/lib/state/server/rooms.svelte.ts
@@ -234,6 +234,7 @@ export class RoomsStore {
 
   async refresh(): Promise<void> {
     const thisLoad = ++this.loadId;
+    const unreadSnapshotRevision = this.roomUnread.captureSnapshotRevision();
     const [viewer, rooms, roomGroups] = await Promise.all([
       this.viewerStateLoader(),
       this.roomDirectoryAPI.listRooms(RoomDirectoryScope.ALL),
@@ -279,7 +280,7 @@ export class RoomsStore {
       ...visibleDms.map((room) => this.roomListItem(room, dmMembersByRoomId.get(room.id) ?? []))
     ];
     this.applyRooms(nextRooms);
-    this.roomUnread.initRooms([...visibleChannels, ...visibleDms]);
+    this.roomUnread.initRooms([...visibleChannels, ...visibleDms], false, unreadSnapshotRevision);
     void this.refreshNotificationCounts();
 
     const nextRoomGroups = roomGroups.map((group) => ({


### PR DESCRIPTION
## Summary

- Preserve pending optimistic room reads while older directory snapshots reconcile their server-backed state.
- Stamp async room snapshots at request start so successful reads and newer live events win over stale rows and removals.
- Cover refresh-before-commit, refresh-after-commit, rollback, and authoritative live-read interleavings.

## Testing

- `mise lint-frontend`
- `mise test-frontend`

Closes chattocorp/chatto#1390.
