### PR TITLE
fix(docs): correct deployment guide redirect

### DIFF
--- a/apps/docs-website/nginx.conf
+++ b/apps/docs-website/nginx.conf
@@ -2,6 +2,9 @@ server {
   listen 8080;
   server_name _;
 
+  # Preserve the public origin when a reverse proxy fronts this container.
+  absolute_redirect off;
+
   root /usr/share/nginx/html;
   index index.html;
 

--- a/apps/docs-website/src/content/docs/guides/deployment/docker-compose.mdx
+++ b/apps/docs-website/src/content/docs/guides/deployment/docker-compose.mdx
@@ -14,7 +14,7 @@ import ArchDiagram from "../../../../components/diagrams/DockerComposeDiagram.as
 
 ## Introduction
 
-This guide walks through deploying Chatto with Docker Compose, in a more fully-featured setup compared to what we set up in the [Standalone Binary](/guides/deployment/binary) guide. Specifically, this includes:
+This guide walks through deploying Chatto with Docker Compose, in a more fully-featured setup compared to what we set up in the [Standalone Binary](/guides/deployment/binary/) guide. Specifically, this includes:
 
 - A separate NATS server for Chatto to connect to (instead of using the embedded server.)
 - A working LiveKit service to power your voice and video calls.


### PR DESCRIPTION
## Summary

- Add the canonical trailing slash to the standalone binary link in the Docker Compose guide.
- Configure the docs nginx container to emit relative redirects so reverse proxies preserve the public HTTPS origin instead of exposing the internal HTTP port.

## Verification

- `mise x -- pnpm --filter docs-website build`
- Built the docs Docker image and verified `/guides/deployment/binary` redirects to `/guides/deployment/binary/`, which returns `200 OK`.

Closes #1360.
