### PR TITLE
fix(frontend): keep signed-out servers navigable

### DIFF
--- a/apps/frontend/src/lib/ServerGutter.svelte
+++ b/apps/frontend/src/lib/ServerGutter.svelte
@@ -43,7 +43,11 @@ is connected to, plus the add-server button pinned to the bottom. See the
       {#each serverRegistry.servers as server (server.id)}
         {@const store = serverRegistry.tryGetStore(server.id)}
         {#if store}
-          <ServerSidebarEntry serverId={server.id} currentUserId={store.currentUser.user?.id} />
+          <!-- Authentication changes replace the per-server store. Remount the
+               entry so its one-time private-data load follows the new state. -->
+          {#key store.isAuthenticated}
+            <ServerSidebarEntry serverId={server.id} currentUserId={store.currentUser.user?.id} />
+          {/key}
         {/if}
       {/each}
     </div>

--- a/apps/frontend/src/lib/ServerGutter.svelte
+++ b/apps/frontend/src/lib/ServerGutter.svelte
@@ -42,7 +42,7 @@ is connected to, plus the add-server button pinned to the bottom. See the
     <div class="flex flex-col gap-2 p-2 max-md:pl-3">
       {#each serverRegistry.servers as server (server.id)}
         {@const store = serverRegistry.tryGetStore(server.id)}
-        {#if store && (store.isAuthenticated || server.reauthRequiredAt != null)}
+        {#if store}
           <ServerSidebarEntry serverId={server.id} currentUserId={store.currentUser.user?.id} />
         {/if}
       {/each}

--- a/apps/frontend/src/lib/ServerGutter.svelte.spec.ts
+++ b/apps/frontend/src/lib/ServerGutter.svelte.spec.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+
+type ServerMock = {
+  id: string;
+  reauthRequiredAt: number | null;
+};
+
+type StoreMock = {
+  isAuthenticated: boolean;
+  currentUser: { user?: { id: string } };
+};
+
+const mocks = vi.hoisted(() => ({
+  servers: [] as ServerMock[],
+  stores: new Map<string, StoreMock>()
+}));
+
+vi.mock('$lib/state/server/registry.svelte', () => ({
+  serverRegistry: {
+    get servers() {
+      return mocks.servers;
+    },
+    tryGetStore: (serverId: string) => mocks.stores.get(serverId)
+  }
+}));
+
+vi.mock('./ServerSidebarEntry.svelte', async () => ({
+  default: (await import('./ServerGutterEntryMock.svelte')).default
+}));
+
+vi.mock('$lib/ui/ScrollFader.svelte', async () => ({
+  default: (await import('./ServerGutterScrollFaderMock.svelte')).default
+}));
+
+import ServerGutter from './ServerGutter.svelte';
+
+beforeEach(() => {
+  mocks.servers = [];
+  mocks.stores = new Map();
+});
+
+describe('ServerGutter', () => {
+  it('keeps an unauthenticated registered server available for navigation', () => {
+    mocks.servers = [{ id: 'origin', reauthRequiredAt: null }];
+    mocks.stores.set('origin', {
+      isAuthenticated: false,
+      currentUser: {}
+    });
+
+    const { container } = render(ServerGutter);
+
+    expect(container.querySelector('[data-testid="server-entry"]')?.textContent).toBe('origin');
+  });
+
+  it('does not render a server until its state store exists', () => {
+    mocks.servers = [{ id: 'origin', reauthRequiredAt: null }];
+
+    const { container } = render(ServerGutter);
+
+    expect(container.querySelector('[data-testid="server-entry"]')).toBeNull();
+  });
+});

--- a/apps/frontend/src/lib/ServerGutterEntryMock.svelte
+++ b/apps/frontend/src/lib/ServerGutterEntryMock.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  let { serverId }: { serverId: string } = $props();
+</script>
+
+<span data-testid="server-entry">{serverId}</span>

--- a/apps/frontend/src/lib/ServerGutterScrollFaderMock.svelte
+++ b/apps/frontend/src/lib/ServerGutterScrollFaderMock.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  let { children }: { children?: Snippet } = $props();
+</script>
+
+{@render children?.()}

--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte
@@ -19,7 +19,7 @@
   import { getAppUiState } from '$lib/state/appUi.svelte';
   import { appState } from '$lib/state/globals.svelte';
   import ServerIcon from './ServerIcon.svelte';
-  import { untrack } from 'svelte';
+  import { onMount } from 'svelte';
   import * as m from '$lib/i18n/messages';
 
   let {
@@ -137,12 +137,8 @@
     }
   }
 
-  // Keep registered servers available as navigation targets even before the
-  // viewer signs in. Once authentication becomes available, load the private
-  // sidebar state without requiring this keyed entry to remount.
-  $effect(() => {
-    if (!stores.isAuthenticated) return;
-    untrack(() => void loadAll());
+  onMount(() => {
+    if (stores.isAuthenticated) void loadAll();
   });
 
   // Subscribe to server events. Use $effect (not onMount) so that if the

--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte
@@ -19,7 +19,7 @@
   import { getAppUiState } from '$lib/state/appUi.svelte';
   import { appState } from '$lib/state/globals.svelte';
   import ServerIcon from './ServerIcon.svelte';
-  import { onMount } from 'svelte';
+  import { untrack } from 'svelte';
   import * as m from '$lib/i18n/messages';
 
   let {
@@ -63,7 +63,8 @@
 
   let displayName = $state('');
   let logoUrl = $state<string | null>(null);
-  let loaded = $state(false);
+  let privateDataLoaded = $state(false);
+  const loaded = $derived(!stores.isAuthenticated || privateDataLoaded);
 
   const iconServer = $derived.by(() => {
     const refreshedName = stores.serverInfo.name !== 'Chatto' ? stores.serverInfo.name : undefined;
@@ -90,10 +91,6 @@
   }
 
   async function loadAll() {
-    if (registeredServer?.reauthRequiredAt != null) {
-      loaded = true;
-      return;
-    }
     const unreadSnapshotRevision = roomUnreadStore.captureSnapshotRevision();
     try {
       const [serverState, viewer, rooms] = await Promise.all([
@@ -122,7 +119,7 @@
 
       displayName = serverState.name;
       logoUrl = serverState.logoUrl;
-      loaded = true;
+      privateDataLoaded = true;
     } catch (err) {
       console.error(`[server:${serverId}] failed to load sidebar icon data`, err);
     }
@@ -140,8 +137,12 @@
     }
   }
 
-  onMount(() => {
-    void loadAll();
+  // Keep registered servers available as navigation targets even before the
+  // viewer signs in. Once authentication becomes available, load the private
+  // sidebar state without requiring this keyed entry to remount.
+  $effect(() => {
+    if (!stores.isAuthenticated) return;
+    untrack(() => void loadAll());
   });
 
   // Subscribe to server events. Use $effect (not onMount) so that if the

--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
@@ -45,6 +45,7 @@ const { mocks } = vi.hoisted(() => {
         addedAt: 0
       },
       store: {
+        isAuthenticated: true,
         notifications: {
           fetch: vi.fn().mockResolvedValue(undefined),
           setUnreadNotificationCount: vi.fn(),
@@ -227,6 +228,7 @@ describe('ServerSidebarEntry', () => {
     mocks.registrar.onNotificationLevelChanged.mockClear();
     mocks.getAuthenticatedServerState.mockResolvedValue(serverState());
     mocks.getViewerStateViaConnect.mockResolvedValue(viewerState());
+    mocks.store.isAuthenticated = true;
     mocks.listRooms.mockResolvedValue([]);
     mocks.createRoomDirectoryAPI.mockReturnValue({ listRooms: mocks.listRooms });
     mocks.store.notifications.fetch.mockClear();
@@ -256,6 +258,23 @@ describe('ServerSidebarEntry', () => {
   afterEach(() => {
     consoleErrorSpy.mockRestore();
     consoleWarnSpy.mockRestore();
+  });
+
+  it('renders an unauthenticated server without loading private sidebar state', async () => {
+    mocks.store.isAuthenticated = false;
+
+    const { container } = render(ServerSidebarEntry, {
+      props: {
+        serverId: 'remote'
+      }
+    });
+
+    const icon = q(container, '[data-testid="server-icon"]');
+    await expect.element(icon).toBeInTheDocument();
+    await expect.element(icon).toHaveAttribute('href', '/chat/remote.example.com');
+    expect(mocks.getAuthenticatedServerState).not.toHaveBeenCalled();
+    expect(mocks.getViewerStateViaConnect).not.toHaveBeenCalled();
+    expect(mocks.store.notifications.fetch).not.toHaveBeenCalled();
   });
 
   it('keeps a failed server in the gutter as a dimmed icon', async () => {


### PR DESCRIPTION
## Summary

Keep registered servers visible in the server gutter while signed out, so users can leave the global notifications screen and return to that server's login flow. Private sidebar state remains authentication-gated and loads automatically after authentication becomes available.

Regression coverage verifies both gutter visibility and that signed-out entries do not call authenticated APIs. Validated with the full frontend suite (1,881 tests), Svelte checks, focused ESLint, and the REUSE license check.

Closes #1351.
