### PR TITLE
fix(docker): support read-only root filesystems

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -65,6 +65,7 @@ jobs:
           cp docker/Dockerfile.goreleaser "$context/Dockerfile"
           mkdir -p "$context/docker"
           cp docker/docker-entrypoint.sh "$context/docker/docker-entrypoint.sh"
+          cp docker/nats-wrapper.sh "$context/docker/nats-wrapper.sh"
           mkdir -p "$context/LICENSES"
           cp LICENSES/AGPL-3.0-or-later.txt "$context/LICENSES/AGPL-3.0-or-later.txt"
           cp NOTICE "$context/NOTICE"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,6 +46,7 @@ dockers:
     dockerfile: docker/Dockerfile.goreleaser
     extra_files:
       - docker/docker-entrypoint.sh
+      - docker/nats-wrapper.sh
       - LICENSES/AGPL-3.0-or-later.txt
       - NOTICE
     build_flag_templates:
@@ -65,6 +66,7 @@ dockers:
     dockerfile: docker/Dockerfile.goreleaser
     extra_files:
       - docker/docker-entrypoint.sh
+      - docker/nats-wrapper.sh
       - LICENSES/AGPL-3.0-or-later.txt
       - NOTICE
     build_flag_templates:

--- a/docker/Dockerfile.goreleaser
+++ b/docker/Dockerfile.goreleaser
@@ -5,9 +5,6 @@ ARG TARGETARCH
 ARG CHATTO_UID=1000
 ARG CHATTO_GID=1000
 
-# Tell the nats CLI which context to use by default. The file itself is
-# written at container start by docker-entrypoint.sh.
-ENV NATS_CONTEXT=chatto
 ENV HOME=/home/chatto
 
 # Runtime dependencies:
@@ -22,8 +19,9 @@ RUN set -eux; \
       su-exec \
       tzdata
 
-# Bundle the nats CLI so operators can inspect the same NATS server Chatto uses
-# with `docker exec <container> nats ...`. The entrypoint writes its context.
+# Bundle the NATS CLI so operators can inspect the same NATS server Chatto uses
+# with `docker exec <container> nats ...`. A wrapper maps Chatto's connection
+# environment to the CLI without writing runtime configuration files.
 RUN set -eux; \
  apk add --no-cache --virtual .build-deps curl unzip; \
  case "$TARGETARCH" in \
@@ -38,8 +36,9 @@ RUN set -eux; \
       "https://github.com/nats-io/natscli/releases/download/v${NATS_CLI_VERSION}/SHA256SUMS"; \
  cd /tmp; \
  grep "  ${archive}$" nats-SHA256SUMS | sha256sum -c -; \
- unzip -j "/tmp/${archive}" "*/nats" -d /usr/local/bin/; \
- chmod +x /usr/local/bin/nats; \
+ mkdir -p /usr/local/libexec; \
+ unzip -j "/tmp/${archive}" "*/nats" -d /usr/local/libexec/; \
+ chmod +x /usr/local/libexec/nats; \
  rm "/tmp/${archive}" /tmp/nats-SHA256SUMS; \
  apk del .build-deps
 
@@ -55,14 +54,15 @@ RUN set -eux; \
 # `chatto`; the release image only packages that binary and the entrypoint.
 COPY chatto /chatto
 COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY docker/nats-wrapper.sh /usr/local/bin/nats
 COPY LICENSES/AGPL-3.0-or-later.txt /usr/share/doc/chatto/LICENSE
 COPY NOTICE /usr/share/doc/chatto/NOTICE
-RUN chmod +x /chatto /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /chatto /usr/local/bin/docker-entrypoint.sh /usr/local/bin/nats
 
 WORKDIR /
 EXPOSE 4000
 
-# The entrypoint handles optional PUID/PGID remapping, writes the nats CLI
-# context, then execs `/chatto start -c /config/chatto.toml` by default.
+# The entrypoint handles optional PUID/PGID remapping, then execs
+# `/chatto start -c /config/chatto.toml` by default.
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["start", "-c", "/config/chatto.toml"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,10 +10,15 @@ automation.
   `/config/chatto.toml` as its default config path and `/data` as the embedded
   NATS data directory. It defaults the runtime user to `1000:1000` and supports
   `PUID`/`PGID` environment variables for matching host volume ownership.
-- `docker-entrypoint.sh` is copied into the backend release image. It writes a
-  NATS CLI context from Chatto's runtime NATS environment, applies the runtime
-  user/group, and drops privileges before starting the `chatto` binary. It does
-  not recursively change ownership of mounted operator directories.
+- `docker-entrypoint.sh` is copied into the backend release image. It applies
+  the runtime user/group and drops privileges before starting the `chatto`
+  binary. It does not recursively change ownership of mounted operator
+  directories.
+- `nats-wrapper.sh` makes the bundled NATS CLI use Chatto's runtime NATS
+  environment without writing a CLI context. Explicit `NATS_URL` or
+  `NATS_CONTEXT` settings leave connection configuration under operator control.
+- `nats-wrapper_test.sh` verifies the wrapper's derived connection settings and
+  explicit operator overrides.
 - `Dockerfile.frontend.prebuilt` packages the already-built frontend static
   files into the release-only `ghcr.io/chattocorp/chatto-client` image.
 - `Dockerfile.dev` is the backend development image for containerized local or

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
-# Materialize a nats CLI context from Chatto's env vars so that
-# `docker exec <container> nats ...` connects to the same NATS that chatto
-# itself is using. Runs once per container start.
+# Apply the configured runtime user and start Chatto.
 set -eu
 
 if [ "$(id -u)" = "0" ]; then
@@ -30,35 +28,7 @@ if [ "$(id -u)" = "0" ]; then
     export HOME=/home/chatto
 fi
 
-if [ -n "${CHATTO_NATS_CLIENT_URL:-}" ]; then
-    nats_dir="${HOME:-/home/chatto}/.config/nats"
-    mkdir -p "$nats_dir/context"
-
-    # jq isn't in the image; build the JSON by hand. Values come from
-    # operator-controlled env vars and Chatto's own config validation
-    # rejects malformed URLs, so plain interpolation is acceptable here.
-    {
-        printf '{\n'
-        printf '  "description": "chatto runtime",\n'
-        printf '  "url": "%s"' "$CHATTO_NATS_CLIENT_URL"
-        if [ -n "${CHATTO_NATS_CLIENT_CREDENTIALS_FILE:-}" ]; then
-            printf ',\n  "creds": "%s"' "$CHATTO_NATS_CLIENT_CREDENTIALS_FILE"
-        fi
-        printf '\n}\n'
-    } > "$nats_dir/context/chatto.json"
-
-    # Mark chatto as the default context so `nats <cmd>` works without
-    # also needing $NATS_CONTEXT (e.g. `nats context info`, which is a
-    # context-management command and ignores the env var).
-    printf 'chatto\n' > "$nats_dir/context.txt"
-fi
-
 if [ "$(id -u)" = "0" ]; then
-    if [ -d "${HOME:-/home/chatto}/.config" ]; then
-        # The entrypoint writes this internal CLI context before su-exec.
-        # Keep that generated container state readable by the runtime user.
-        chown -R chatto:chatto "${HOME:-/home/chatto}/.config"
-    fi
     exec su-exec chatto:chatto /chatto "$@"
 fi
 

--- a/docker/nats-wrapper.sh
+++ b/docker/nats-wrapper.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Make the bundled NATS CLI use Chatto's connection settings without writing a
+# CLI context into the container. Explicit NATS connection settings take
+# precedence and leave the entire connection setup under operator control.
+set -eu
+
+if [ -z "${NATS_URL:-}" ] && [ -z "${NATS_CONTEXT:-}" ]; then
+    if [ -n "${CHATTO_NATS_CLIENT_URL:-}" ]; then
+        export NATS_URL="$CHATTO_NATS_CLIENT_URL"
+    fi
+    if [ -z "${NATS_CREDS:-}" ] && [ -n "${CHATTO_NATS_CLIENT_CREDENTIALS_FILE:-}" ]; then
+        export NATS_CREDS="$CHATTO_NATS_CLIENT_CREDENTIALS_FILE"
+    fi
+fi
+
+exec /usr/local/libexec/nats "$@"

--- a/docker/nats-wrapper_test.sh
+++ b/docker/nats-wrapper_test.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -eu
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/chatto-nats-wrapper-test.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+
+# Replace only the final exec so the wrapper's environment can be asserted
+# without requiring the image's private NATS CLI binary on the host.
+sed 's|^exec /usr/local/libexec/nats "$@"$|printf "url=%s\\ncreds=%s\\ncontext=%s\\nargs=%s\\n" "${NATS_URL:-}" "${NATS_CREDS:-}" "${NATS_CONTEXT:-}" "$*"|' \
+    "$(dirname "$0")/nats-wrapper.sh" > "$tmp/nats-wrapper.sh"
+
+assert_wrapper() {
+    expected="$1"
+    shift
+
+    actual="$(env -i PATH="$PATH" "$@" sh "$tmp/nats-wrapper.sh" stream ls)"
+    [ "$actual" = "$expected" ] || {
+        printf 'unexpected wrapper environment:\n%s\n' "$actual" >&2
+        exit 1
+    }
+}
+
+assert_wrapper 'url=nats://chatto:4222
+creds=/run/chatto.creds
+context=
+args=stream ls' \
+    CHATTO_NATS_CLIENT_URL="nats://chatto:4222" \
+    CHATTO_NATS_CLIENT_CREDENTIALS_FILE="/run/chatto.creds"
+
+assert_wrapper 'url=nats://operator:4222
+creds=
+context=
+args=stream ls' \
+    CHATTO_NATS_CLIENT_URL="nats://chatto:4222" \
+    CHATTO_NATS_CLIENT_CREDENTIALS_FILE="/run/chatto.creds" \
+    NATS_URL="nats://operator:4222"
+
+assert_wrapper 'url=
+creds=
+context=operator
+args=stream ls' \
+    CHATTO_NATS_CLIENT_URL="nats://chatto:4222" \
+    CHATTO_NATS_CLIENT_CREDENTIALS_FILE="/run/chatto.creds" \
+    NATS_CONTEXT="operator"

--- a/mise.toml
+++ b/mise.toml
@@ -375,6 +375,8 @@ goreleaser check
 
 actionlint .github/workflows/*.yml
 
+docker/nats-wrapper_test.sh
+
 docker buildx build --check --build-arg TARGETARCH=amd64 -f docker/Dockerfile.dev .
 docker buildx build --check -f docker/Dockerfile.frontend.dev .
 docker buildx build --check -f docker/Dockerfile.frontend.prebuilt .
@@ -385,6 +387,10 @@ context="$tmp/linux-amd64"
 mkdir -p "$context/docker"
 cp docker/Dockerfile.goreleaser "$context/Dockerfile"
 cp docker/docker-entrypoint.sh "$context/docker/docker-entrypoint.sh"
+cp docker/nats-wrapper.sh "$context/docker/nats-wrapper.sh"
+mkdir -p "$context/LICENSES"
+cp LICENSES/AGPL-3.0-or-later.txt "$context/LICENSES/AGPL-3.0-or-later.txt"
+cp NOTICE "$context/NOTICE"
 printf '#!/bin/sh\necho chatto dummy\n' > "$context/chatto"
 chmod +x "$context/chatto"
 docker buildx build --build-arg TARGETARCH=amd64 -f "$context/Dockerfile" "$context"


### PR DESCRIPTION
## Summary

The release entrypoint no longer writes a NATS CLI context under `/home/chatto/.config`, allowing hardened containers to start with a read-only root filesystem.
The bundled `nats` command now uses a no-write wrapper that derives `NATS_URL` and `NATS_CREDS` from Chatto's environment while respecting explicit operator overrides.
The root cause was an operator-debugging convenience that materialized runtime context files during every container start and made that optional tooling a startup requirement.
Validation includes wrapper regression tests, `mise verify-docker`, a real NATS connection from a read-only container, GoReleaser and workflow checks, shell syntax checks, and the REUSE license check.
