### PR TITLE
fix(release): restore Windows builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,7 @@ builds:
       - linux
       - freebsd
       - darwin
+      - windows
     goarch:
       - amd64
       - arm64
@@ -34,6 +35,10 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # Use native ZIP archives for Windows releases.
+    format_overrides:
+      - goos: windows
+        formats: [zip]
 
 changelog:
   # release-please now owns the changelog (CHANGELOG.md + the GitHub

--- a/cli/internal/http_server/file_owner_unix.go
+++ b/cli/internal/http_server/file_owner_unix.go
@@ -1,0 +1,16 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package http_server
+
+import (
+	"os"
+	"syscall"
+)
+
+func fileOwnerIDs(info os.FileInfo) (uint32, uint32, bool) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, 0, false
+	}
+	return stat.Uid, stat.Gid, true
+}

--- a/cli/internal/http_server/file_owner_windows.go
+++ b/cli/internal/http_server/file_owner_windows.go
@@ -1,0 +1,9 @@
+package http_server
+
+import "os"
+
+// Windows file metadata does not expose Unix user and group IDs. Returning
+// false makes the Unix-socket operator API fail closed if it is enabled.
+func fileOwnerIDs(os.FileInfo) (uint32, uint32, bool) {
+	return 0, 0, false
+}

--- a/cli/internal/http_server/server.go
+++ b/cli/internal/http_server/server.go
@@ -397,14 +397,6 @@ func validateOperatorAPISocketParent(parent string) error {
 	return nil
 }
 
-func fileOwnerIDs(info os.FileInfo) (uint32, uint32, bool) {
-	stat, ok := info.Sys().(*syscall.Stat_t)
-	if !ok {
-		return 0, 0, false
-	}
-	return stat.Uid, stat.Gid, true
-}
-
 func isStaleOperatorSocketError(err error) bool {
 	return errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, os.ErrNotExist)
 }


### PR DESCRIPTION
## Summary

Restore GoReleaser builds for Windows on amd64 and arm64, packaged as native ZIP archives.
Move Unix file-owner inspection behind platform-specific helpers so the CLI cross-compiles for Windows while the Unix-socket operator API continues to fail closed there.
This makes Windows binaries available again without changing public APIs or persisted data.

## Validation

Validated with `goreleaser check`, a snapshot release that produced both Windows ZIPs, the targeted operator-socket tests, `git diff --check`, and REUSE lint.
