### PR TITLE
fix(api): validate custom status emoji

### DIFF
--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -1053,7 +1053,7 @@ func TestUserServiceGetUserReadsPublicUsers(t *testing.T) {
 		t.Fatalf("offline profile presence = %v, want OFFLINE", offlineResp.Msg.GetUser().GetUser().GetPresenceStatus())
 	}
 
-	if _, err := env.core.SetUserCustomStatus(env.ctx, env.viewer.Id, "wave", "around", nil); err != nil {
+	if _, err := env.core.SetUserCustomStatus(env.ctx, env.viewer.Id, "👋", "around", nil); err != nil {
 		t.Fatalf("SetUserCustomStatus: %v", err)
 	}
 	if err := env.core.SetPresenceWithOptions(env.ctx, env.viewer.Id, "ONLINE", true); err != nil {
@@ -4045,6 +4045,14 @@ func TestMyAccountServiceSetAndDeleteCustomStatus(t *testing.T) {
 	}))
 	if connect.CodeOf(err) != connect.CodeInvalidArgument {
 		t.Fatalf("UpdateCustomStatus blank text error = %v, want InvalidArgument", err)
+	}
+
+	_, err = env.account.UpdateCustomStatus(ctx, connect.NewRequest(&apiv1.UpdateCustomStatusRequest{
+		Emoji: "e",
+		Text:  "Invalid emoji",
+	}))
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("UpdateCustomStatus invalid emoji error = %v, want InvalidArgument", err)
 	}
 
 	clearResp, err := env.account.DeleteCustomStatus(ctx, connect.NewRequest(&apiv1.DeleteCustomStatusRequest{}))

--- a/cli/internal/connectapi/errors.go
+++ b/cli/internal/connectapi/errors.go
@@ -45,6 +45,7 @@ func connectError(err error) error {
 		return connect.NewError(connect.CodeAlreadyExists, err)
 	}
 	if errors.Is(err, core.ErrCustomStatusEmojiRequired) ||
+		errors.Is(err, core.ErrCustomStatusEmojiInvalid) ||
 		errors.Is(err, core.ErrCustomStatusTextRequired) ||
 		errors.Is(err, core.ErrCustomStatusEmojiTooLong) ||
 		errors.Is(err, core.ErrCustomStatusTextTooLong) ||

--- a/cli/internal/core/emoji.go
+++ b/cli/internal/core/emoji.go
@@ -1,9 +1,26 @@
 package core
 
+var emojiUnicodeSet = func() map[string]struct{} {
+	set := make(map[string]struct{}, len(emojiNameToUnicode))
+	for _, emoji := range emojiNameToUnicode {
+		set[emoji] = struct{}{}
+	}
+	return set
+}()
+
 // IsValidEmojiName checks if a name is a known emoji shortcode.
 // Uses the generated emojiNameToUnicode map (from gemoji).
 func IsValidEmojiName(name string) bool {
 	_, ok := emojiNameToUnicode[name]
+	return ok
+}
+
+// IsValidUnicodeEmoji reports whether emoji is one complete emoji from the
+// bundled gemoji dataset. This includes multi-code-point emoji such as flags
+// and family sequences, while rejecting arbitrary text and multiple adjacent
+// emoji.
+func IsValidUnicodeEmoji(emoji string) bool {
+	_, ok := emojiUnicodeSet[emoji]
 	return ok
 }
 

--- a/cli/internal/core/reactions_test.go
+++ b/cli/internal/core/reactions_test.go
@@ -581,6 +581,24 @@ func TestReactionKey(t *testing.T) {
 }
 
 func TestEmoji(t *testing.T) {
+	t.Run("IsValidUnicodeEmoji accepts one complete emoji", func(t *testing.T) {
+		valid := []string{"🌿", "👍", "🇩🇪", "👨‍👩‍👧‍👦"}
+		for _, emoji := range valid {
+			if !IsValidUnicodeEmoji(emoji) {
+				t.Errorf("IsValidUnicodeEmoji(%q) = false, want true", emoji)
+			}
+		}
+	})
+
+	t.Run("IsValidUnicodeEmoji rejects text and multiple emoji", func(t *testing.T) {
+		invalid := []string{"", "e", "hello", "🌿🌿", "🌿 status"}
+		for _, emoji := range invalid {
+			if IsValidUnicodeEmoji(emoji) {
+				t.Errorf("IsValidUnicodeEmoji(%q) = true, want false", emoji)
+			}
+		}
+	})
+
 	t.Run("IsValidEmojiName accepts known names", func(t *testing.T) {
 		valid := []string{"thumbsup", "+1", "heart", "joy", "tada", "rocket", "fire", "grinning", "t-rex", "melting_face", "saluting_face"}
 		for _, name := range valid {

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -782,6 +782,7 @@ var ErrLoginAlreadyTaken = fmt.Errorf("login name is already taken")
 var ErrUsernameBlocked = fmt.Errorf("this username is not available")
 
 var ErrCustomStatusEmojiRequired = fmt.Errorf("custom status emoji is required")
+var ErrCustomStatusEmojiInvalid = fmt.Errorf("custom status emoji must be a single supported emoji")
 var ErrCustomStatusTextRequired = fmt.Errorf("custom status text is required")
 var ErrCustomStatusEmojiTooLong = fmt.Errorf("custom status emoji is too long")
 var ErrCustomStatusTextTooLong = fmt.Errorf("custom status text is too long")
@@ -1191,6 +1192,9 @@ func (c *ChattoCore) SetUserCustomStatus(ctx context.Context, userID, emoji, tex
 	}
 	if utf8.RuneCountInString(emoji) > MaxCustomStatusEmojiLength {
 		return nil, ErrCustomStatusEmojiTooLong
+	}
+	if !IsValidUnicodeEmoji(emoji) {
+		return nil, ErrCustomStatusEmojiInvalid
 	}
 	if utf8.RuneCountInString(text) > MaxCustomStatusTextLength {
 		return nil, ErrCustomStatusTextTooLong

--- a/cli/internal/core/users_test.go
+++ b/cli/internal/core/users_test.go
@@ -2039,6 +2039,12 @@ func TestChattoCore_SetAndClearUserCustomStatus(t *testing.T) {
 	if _, err := core.SetUserCustomStatus(ctx, user.Id, "🌿", "   ", nil); !errors.Is(err, ErrCustomStatusTextRequired) {
 		t.Fatalf("SetUserCustomStatus blank text error = %v, want ErrCustomStatusTextRequired", err)
 	}
+	if _, err := core.SetUserCustomStatus(ctx, user.Id, "e", "Invalid emoji", nil); !errors.Is(err, ErrCustomStatusEmojiInvalid) {
+		t.Fatalf("SetUserCustomStatus invalid emoji error = %v, want ErrCustomStatusEmojiInvalid", err)
+	}
+	if _, err := core.SetUserCustomStatus(ctx, user.Id, "🌿🌿", "Too many emoji", nil); !errors.Is(err, ErrCustomStatusEmojiInvalid) {
+		t.Fatalf("SetUserCustomStatus multiple emoji error = %v, want ErrCustomStatusEmojiInvalid", err)
+	}
 
 	statusEvents, _, err := core.EventPublisher.SubjectEvents(ctx, events.UserAggregate(user.Id).Subject(events.EventUserCustomStatusSet))
 	if err != nil {


### PR DESCRIPTION
## Summary

- validate custom-status emoji values against Chatto's bundled gemoji Unicode set
- reject plain text, mixed text, and multiple adjacent emoji at the core domain write boundary
- map invalid emoji values to ConnectRPC `InvalidArgument`
- add domain, emoji-sequence, and API regression coverage

## Root cause

`ChattoCore.SetUserCustomStatus` previously checked only that the emoji field was non-empty and no longer than 16 runes. As a result, API clients could persist arbitrary strings such as `e` as a status emoji.

## Impact

Custom-status writes now require exactly one supported emoji—the same set exposed by the frontend picker. Bundled multi-code-point values such as flags and family sequences remain valid. Validation happens before an EVT fact is appended, so alternate callers cannot bypass the invariant.

Historical events remain replay-compatible: projection application is intentionally unchanged and continues to accept previously stored values. This change does not alter protobuf messages, event payloads, subjects, projections, or persisted data.

## Verification

- `mise test-cli`
- full `cli/internal/core` package tests
- full `cli/internal/connectapi` package tests
- adversarial code review with no findings
- `git diff --check`

Closes #1402.
