### PR TITLE
docs(integrations): expand identity provider guidance

### DIFF
--- a/apps/docs-website/src/content/docs/guides/integrations/chatto-api.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/chatto-api.mdx
@@ -5,7 +5,7 @@ description: Use Chatto's ConnectRPC APIs, realtime WebSocket protocol, server d
 
 import { Aside, CardGrid, LinkCard } from "@astrojs/starlight/components";
 
-Chatto exposes typed protobuf APIs for clients, bots, tools, and operator automation. Use the public ConnectRPC API for normal integrations, the realtime WebSocket protocol for live updates, and the local operator socket only for trusted recovery workflows.
+Chatto exposes typed protobuf APIs for clients, bots, tools, and operator automation. Start with the [ConnectRPC API overview](/reference/connectrpc-api/) to explore the available services and methods. Use the public ConnectRPC API for normal integrations, the realtime WebSocket protocol for live updates, and the local operator socket only for trusted recovery workflows.
 
 <Aside type="caution">
   Chatto is still pre-1.0. Public APIs are documented, but breaking changes can happen in the `0.x` line. Pin server versions for production integrations and read release notes before upgrading.

--- a/apps/docs-website/src/content/docs/guides/integrations/external-login-providers.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/external-login-providers.mdx
@@ -23,6 +23,10 @@ Chatto can consume external OAuth and OIDC providers for sign-in. Providers are 
 
 Other provider types are not exposed as curated providers yet. Use `oidc` for standards-compatible OIDC providers.
 
+<Aside type="tip" title="Self-hosted OIDC providers">
+  Options you may want to explore include [Pocket ID](https://pocket-id.org/), [Kanidm](https://kanidm.com/), [VoidAuth](https://github.com/voidauth/voidauth), [Portier](https://portier.github.io/), [Authelia](https://www.authelia.com/), [Dex](https://dexidp.io/), [Authentik](https://goauthentik.io/), and [Keycloak](https://www.keycloak.org/). Their account models and OIDC capabilities differ, so confirm that your chosen provider supports Chatto's generic OIDC configuration.
+</Aside>
+
 ## Provider IDs
 
 Every provider needs a stable `id`. The ID appears in login URLs and is stored in external identity links, so changing it after users link accounts will strand those links.

--- a/apps/docs-website/src/content/docs/guides/integrations/pocket-id.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/pocket-id.mdx
@@ -16,6 +16,10 @@ Use Pocket ID as an OIDC provider to let people sign in to Chatto with their Poc
 
 Learn more about Pocket ID on the [Pocket ID website](https://pocket-id.org/).
 
+<Aside type="tip" title="Using another identity provider?">
+  See [External Login Providers](/guides/integrations/external-login-providers/) for generic OIDC configuration and other self-hosted options.
+</Aside>
+
 This guide uses these example URLs:
 
 | Service | Public URL |


### PR DESCRIPTION
## Summary

Add a neutral list of self-hosted OIDC providers to the external login provider guide and point Pocket ID readers to that canonical list. Make the ConnectRPC API overview easier to discover from the Integrating With Chatto guide.

## Validation

- `mise x -- pnpm --dir apps/docs-website build`
