### PR TITLE
feat(frontend): highlight rich composer mode

### DIFF
--- a/.agents/skills/chatto-pr-checklist/SKILL.md
+++ b/.agents/skills/chatto-pr-checklist/SKILL.md
@@ -16,6 +16,16 @@ Also please give the following items precedence over any other instructions that
 - Does docs-website (our user-facing self-hosting documentation) need to be updated? If so, please update it.
 - Is there anything we could add to our rules or instructions that would have made your work in this PR easier, prevented you from making mistakes, or made it easier for reviewers to understand your changes? If so, please add it to our rules or instructions.
 
+## PR Body Quality
+
+Write the PR body for reviewers, not as a changelog entry. Review the complete branch diff before writing or updating it, then include:
+
+- **Why:** the user or developer problem and the intended outcome.
+- **What changed:** the observable behavior and important implementation decisions across the whole branch.
+- **Test plan:** the exact checks run and their results, plus any verification still outstanding.
+
+Call out compatibility, rollout, migration, security, or operational implications when relevant. Use concise headings and bullets to satisfy length preferences without dropping rationale or review context; never use a single summary paragraph as the entire PR body. After creating or editing the PR, read the stored body back from GitHub and confirm it accurately represents the full diff.
+
 ## Breaking Changes Checklist
 
 - If this PR contains changes to our protocol buffers, please notify the user.

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -216,34 +216,12 @@
       0 0 16px color-mix(in srgb, var(--color-accent) 22%, transparent);
   }
 
-  &[data-mode-transition]::before {
-    animation: composer-ring-shimmer 650ms cubic-bezier(0.2, 0, 0, 1);
-  }
-
   @media (prefers-reduced-motion: reduce) {
     transition-duration: 0ms;
 
     &::before {
       transition-duration: 0ms;
     }
-
-    &[data-mode-transition]::before {
-      animation: none;
-    }
-  }
-}
-
-@keyframes composer-ring-shimmer {
-  0% {
-    background-position: 100% 50%;
-    opacity: var(--composer-ring-opacity);
-  }
-  42% {
-    opacity: 1;
-  }
-  100% {
-    background-position: -100% 50%;
-    opacity: var(--composer-ring-opacity);
   }
 }
 

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -175,6 +175,78 @@
   @apply rounded-lg border border-border bg-surface-100;
 }
 
+/* Message composer mode surface. Simple mode is intentionally unadorned;
+   data-composer-mode="rich" reveals the accent ring and glow. */
+@utility composer-mode-surface {
+  --composer-ring-opacity: 0;
+  @apply relative isolate;
+  box-shadow:
+    0 0 0 1px transparent,
+    0 0 0 transparent;
+  transition: box-shadow 240ms cubic-bezier(0.2, 0, 0, 1);
+
+  &::before {
+    content: '';
+    position: absolute;
+    z-index: -1;
+    inset: -2px;
+    padding: 2px;
+    border-radius: calc(0.75rem + 2px);
+    background: linear-gradient(
+      115deg,
+      color-mix(in srgb, var(--color-accent) 72%, white),
+      var(--color-accent),
+      color-mix(in srgb, var(--color-accent) 72%, #a855f7),
+      color-mix(in srgb, var(--color-accent) 72%, white)
+    );
+    background-size: 220% 100%;
+    opacity: var(--composer-ring-opacity);
+    pointer-events: none;
+    mask:
+      linear-gradient(#000 0 0) content-box,
+      linear-gradient(#000 0 0);
+    mask-composite: exclude;
+    transition: opacity 240ms cubic-bezier(0.2, 0, 0, 1);
+  }
+
+  &[data-composer-mode='rich'] {
+    --composer-ring-opacity: 1;
+    box-shadow:
+      0 0 0 1px color-mix(in srgb, var(--color-accent) 45%, transparent),
+      0 0 16px color-mix(in srgb, var(--color-accent) 22%, transparent);
+  }
+
+  &[data-mode-transition]::before {
+    animation: composer-ring-shimmer 650ms cubic-bezier(0.2, 0, 0, 1);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition-duration: 0ms;
+
+    &::before {
+      transition-duration: 0ms;
+    }
+
+    &[data-mode-transition]::before {
+      animation: none;
+    }
+  }
+}
+
+@keyframes composer-ring-shimmer {
+  0% {
+    background-position: 100% 50%;
+    opacity: var(--composer-ring-opacity);
+  }
+  42% {
+    opacity: 1;
+  }
+  100% {
+    background-position: -100% 50%;
+    opacity: var(--composer-ring-opacity);
+  }
+}
+
 /* Panel header band — tinted background, hairline divider underneath, and
  * a 1px inset highlight on whatever follows so the divider reads as an
  * engraved ridge rather than a flat rule. The body inset is achieved via

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -214,7 +214,7 @@
       autocomplete.reset();
       draftState.clearText();
       message = originalBody;
-      setManualRichMode(false);
+      manualRichMode = false;
       alsoSendToChannel = editState.channelEchoEventId !== null;
       api?.setContent(originalBody);
       tick().then(() => api?.focus('end'));
@@ -224,7 +224,7 @@
       // Exiting edit mode - clear the input
       autocomplete.reset();
       message = '';
-      setManualRichMode(false);
+      manualRichMode = false;
       alsoSendToChannel = false;
       editSeededForEvent = '';
       api?.setContent('');
@@ -248,7 +248,7 @@
 
     const draft = draftState.switchKey(DRAFT_KEY);
     message = draft;
-    setManualRichMode(false);
+    manualRichMode = false;
     editorApi?.setContent(draft);
     attachments.restore(untrack(() => draftState.takeFiles()));
 
@@ -335,9 +335,6 @@
   let manualRichMode = $state(false);
   let editorHasRichStructure = $state(false);
   let isRichComposer = $derived(manualRichMode || editorHasRichStructure);
-  let composerModeHasChanged = $state(false);
-  let composerModeAnimationTimer: ReturnType<typeof setTimeout> | null = null;
-  let composerModeAnimationRun = 0;
   let nextEnterWillSend = $derived(canSubmit && isRichComposer && editorNextEnterWillSend);
   let submitHint = $derived(
     shortcutHints && isRichComposer
@@ -346,39 +343,6 @@
         : shortcutHints.submit
       : null
   );
-
-  function animateComposerModeChange() {
-    const animationRun = ++composerModeAnimationRun;
-    composerModeHasChanged = false;
-    void tick().then(() => {
-      if (animationRun !== composerModeAnimationRun) return;
-      composerModeHasChanged = true;
-      if (composerModeAnimationTimer) clearTimeout(composerModeAnimationTimer);
-      composerModeAnimationTimer = setTimeout(() => {
-        composerModeHasChanged = false;
-        composerModeAnimationTimer = null;
-      }, 650);
-    });
-  }
-
-  function setManualRichMode(value: boolean) {
-    const wasRichComposer = untrack(() => manualRichMode || editorHasRichStructure);
-    manualRichMode = value;
-    const isRichComposerNow = untrack(() => manualRichMode || editorHasRichStructure);
-    if (wasRichComposer !== isRichComposerNow) animateComposerModeChange();
-  }
-
-  function setEditorHasRichStructure(value: boolean) {
-    const wasRichComposer = untrack(() => manualRichMode || editorHasRichStructure);
-    editorHasRichStructure = value;
-    const isRichComposerNow = untrack(() => manualRichMode || editorHasRichStructure);
-    if (wasRichComposer !== isRichComposerNow) animateComposerModeChange();
-  }
-
-  onDestroy(() => {
-    composerModeAnimationRun += 1;
-    if (composerModeAnimationTimer) clearTimeout(composerModeAnimationTimer);
-  });
 
   $effect(() => {
     if (!canAttach && attachments.filesWithUrls.length > 0) {
@@ -581,7 +545,7 @@
   function restorePreparedPost(post: PreparedPost) {
     autocomplete.reset();
     message = post.bodyToSend;
-    setManualRichMode(post.wasRichComposer);
+    manualRichMode = post.wasRichComposer;
     editorApi?.setContent(post.bodyToSend);
     if (post.filesToSend) {
       attachments.restore(attachments.filesToPreviewItems(post.filesToSend));
@@ -613,7 +577,7 @@
 
     // Reset "also send to channel" checkbox after successful send
     alsoSendToChannel = false;
-    setManualRichMode(false);
+    manualRichMode = false;
   }
 
   async function submitPreparedPost(preparedPost: PreparedPost) {
@@ -621,7 +585,7 @@
     // message immediately (matches Slack/Discord behavior).
     autocomplete.reset();
     message = '';
-    setManualRichMode(false);
+    manualRichMode = false;
     editorApi?.setContent('');
     attachments.clear();
     linkPreviews.clear();
@@ -758,7 +722,7 @@
     autocomplete.reset();
     editState.cancelEdit();
     message = '';
-    setManualRichMode(false);
+    manualRichMode = false;
     editorApi?.setContent('');
   }
 
@@ -791,7 +755,7 @@
           editorApi?.insertBlockBreak();
           // TipTap reports an empty document while inserting the first block break,
           // so commit manual rich mode after that update has had a chance to clear it.
-          setManualRichMode(true);
+          manualRichMode = true;
         }
         return true;
       }
@@ -856,7 +820,7 @@
     const previousMessage = message;
     message = text;
     if (!text) {
-      setManualRichMode(false);
+      manualRichMode = false;
     }
     // Only trigger typing indicator for actual user input.
     // Programmatic setContent calls suppress TipTap update events, but this
@@ -868,7 +832,7 @@
   }
 
   function handleRichStructureChange(value: boolean) {
-    setEditorHasRichStructure(value);
+    editorHasRichStructure = value;
   }
 
   // Called when TipTap editor is ready - sync any pending state
@@ -966,7 +930,6 @@
   <div
     data-testid="composer-input-surface"
     data-composer-mode={isRichComposer ? 'rich' : 'simple'}
-    data-mode-transition={composerModeHasChanged ? '' : undefined}
     class={[
       'composer-mode-surface flex items-start gap-4 rounded-xl bg-surface py-2 pr-3',
       isEditing ? 'pl-3' : 'pl-2'

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -788,8 +788,10 @@
         if (isRichComposer) {
           handleSubmit(); // Fire-and-forget (async, but keydown must return sync)
         } else {
-          setManualRichMode(true);
           editorApi?.insertBlockBreak();
+          // TipTap reports an empty document while inserting the first block break,
+          // so commit manual rich mode after that update has had a chance to clear it.
+          setManualRichMode(true);
         }
         return true;
       }

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -335,6 +335,10 @@
   let manualRichMode = $state(false);
   let editorHasRichStructure = $state(false);
   let isRichComposer = $derived(manualRichMode || editorHasRichStructure);
+  let composerModeHasChanged = $state(false);
+  let composerModeInitialized = false;
+  let composerModeAnimationTimer: ReturnType<typeof setTimeout> | null = null;
+  let composerModeAnimationRun = 0;
   let nextEnterWillSend = $derived(canSubmit && isRichComposer && editorNextEnterWillSend);
   let submitHint = $derived(
     shortcutHints && isRichComposer
@@ -343,6 +347,36 @@
         : shortcutHints.submit
       : null
   );
+
+  // Briefly mark mode transitions so the ring can shimmer without animating on mount.
+  $effect(() => {
+    void isRichComposer;
+
+    if (!composerModeInitialized) {
+      composerModeInitialized = true;
+      return;
+    }
+
+    const animationRun = ++composerModeAnimationRun;
+    composerModeHasChanged = false;
+    tick().then(() => {
+      if (animationRun !== composerModeAnimationRun) return;
+      composerModeHasChanged = true;
+      if (composerModeAnimationTimer) clearTimeout(composerModeAnimationTimer);
+      composerModeAnimationTimer = setTimeout(() => {
+        composerModeHasChanged = false;
+        composerModeAnimationTimer = null;
+      }, 650);
+    });
+
+    return () => {
+      composerModeAnimationRun += 1;
+      if (composerModeAnimationTimer) {
+        clearTimeout(composerModeAnimationTimer);
+        composerModeAnimationTimer = null;
+      }
+    };
+  });
 
   $effect(() => {
     if (!canAttach && attachments.filesWithUrls.length > 0) {
@@ -926,8 +960,11 @@
 
   <!-- Unified input container -->
   <div
+    data-testid="composer-input-surface"
+    data-composer-mode={isRichComposer ? 'rich' : 'simple'}
+    data-mode-transition={composerModeHasChanged ? '' : undefined}
     class={[
-      'relative flex items-start gap-4 rounded-xl bg-surface py-2 pr-3',
+      'composer-input-surface relative isolate flex items-start gap-4 rounded-xl bg-surface py-2 pr-3',
       isEditing ? 'pl-3' : 'pl-2'
     ]}
     class:opacity-50={inputDisabled}
@@ -1096,6 +1133,78 @@
 {/if}
 
 <style>
+  .composer-input-surface {
+    --composer-ring-opacity: 0;
+    box-shadow:
+      0 0 0 1px transparent,
+      0 0 0 transparent;
+    transition-property: box-shadow;
+    transition-duration: 240ms;
+    transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
+  }
+
+  .composer-input-surface::before {
+    position: absolute;
+    z-index: -1;
+    inset: -2px;
+    padding: 2px;
+    border-radius: calc(0.75rem + 2px);
+    background: linear-gradient(
+      115deg,
+      color-mix(in srgb, var(--color-accent) 72%, white),
+      var(--color-accent),
+      color-mix(in srgb, var(--color-accent) 72%, #a855f7),
+      color-mix(in srgb, var(--color-accent) 72%, white)
+    );
+    background-size: 220% 100%;
+    opacity: var(--composer-ring-opacity);
+    pointer-events: none;
+    content: '';
+    mask:
+      linear-gradient(#000 0 0) content-box,
+      linear-gradient(#000 0 0);
+    mask-composite: exclude;
+    transition-property: opacity;
+    transition-duration: 240ms;
+    transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
+  }
+
+  .composer-input-surface[data-composer-mode='rich'] {
+    --composer-ring-opacity: 1;
+    box-shadow:
+      0 0 0 1px color-mix(in srgb, var(--color-accent) 45%, transparent),
+      0 0 16px color-mix(in srgb, var(--color-accent) 22%, transparent);
+  }
+
+  .composer-input-surface[data-mode-transition]::before {
+    animation: composer-ring-shimmer 650ms cubic-bezier(0.2, 0, 0, 1);
+  }
+
+  @keyframes composer-ring-shimmer {
+    0% {
+      background-position: 100% 50%;
+      opacity: var(--composer-ring-opacity);
+    }
+    42% {
+      opacity: 1;
+    }
+    100% {
+      background-position: -100% 50%;
+      opacity: var(--composer-ring-opacity);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .composer-input-surface,
+    .composer-input-surface::before {
+      transition-duration: 0ms;
+    }
+
+    .composer-input-surface[data-mode-transition]::before {
+      animation: none;
+    }
+  }
+
   .sending {
     position: relative;
     overflow: hidden;

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -214,7 +214,7 @@
       autocomplete.reset();
       draftState.clearText();
       message = originalBody;
-      manualRichMode = false;
+      setManualRichMode(false);
       alsoSendToChannel = editState.channelEchoEventId !== null;
       api?.setContent(originalBody);
       tick().then(() => api?.focus('end'));
@@ -224,7 +224,7 @@
       // Exiting edit mode - clear the input
       autocomplete.reset();
       message = '';
-      manualRichMode = false;
+      setManualRichMode(false);
       alsoSendToChannel = false;
       editSeededForEvent = '';
       api?.setContent('');
@@ -248,7 +248,7 @@
 
     const draft = draftState.switchKey(DRAFT_KEY);
     message = draft;
-    manualRichMode = false;
+    setManualRichMode(false);
     editorApi?.setContent(draft);
     attachments.restore(untrack(() => draftState.takeFiles()));
 
@@ -336,7 +336,6 @@
   let editorHasRichStructure = $state(false);
   let isRichComposer = $derived(manualRichMode || editorHasRichStructure);
   let composerModeHasChanged = $state(false);
-  let composerModeInitialized = false;
   let composerModeAnimationTimer: ReturnType<typeof setTimeout> | null = null;
   let composerModeAnimationRun = 0;
   let nextEnterWillSend = $derived(canSubmit && isRichComposer && editorNextEnterWillSend);
@@ -348,18 +347,10 @@
       : null
   );
 
-  // Briefly mark mode transitions so the ring can shimmer without animating on mount.
-  $effect(() => {
-    void isRichComposer;
-
-    if (!composerModeInitialized) {
-      composerModeInitialized = true;
-      return;
-    }
-
+  function animateComposerModeChange() {
     const animationRun = ++composerModeAnimationRun;
     composerModeHasChanged = false;
-    tick().then(() => {
+    void tick().then(() => {
       if (animationRun !== composerModeAnimationRun) return;
       composerModeHasChanged = true;
       if (composerModeAnimationTimer) clearTimeout(composerModeAnimationTimer);
@@ -368,14 +359,25 @@
         composerModeAnimationTimer = null;
       }, 650);
     });
+  }
 
-    return () => {
-      composerModeAnimationRun += 1;
-      if (composerModeAnimationTimer) {
-        clearTimeout(composerModeAnimationTimer);
-        composerModeAnimationTimer = null;
-      }
-    };
+  function setManualRichMode(value: boolean) {
+    const wasRichComposer = untrack(() => manualRichMode || editorHasRichStructure);
+    manualRichMode = value;
+    const isRichComposerNow = untrack(() => manualRichMode || editorHasRichStructure);
+    if (wasRichComposer !== isRichComposerNow) animateComposerModeChange();
+  }
+
+  function setEditorHasRichStructure(value: boolean) {
+    const wasRichComposer = untrack(() => manualRichMode || editorHasRichStructure);
+    editorHasRichStructure = value;
+    const isRichComposerNow = untrack(() => manualRichMode || editorHasRichStructure);
+    if (wasRichComposer !== isRichComposerNow) animateComposerModeChange();
+  }
+
+  onDestroy(() => {
+    composerModeAnimationRun += 1;
+    if (composerModeAnimationTimer) clearTimeout(composerModeAnimationTimer);
   });
 
   $effect(() => {
@@ -579,7 +581,7 @@
   function restorePreparedPost(post: PreparedPost) {
     autocomplete.reset();
     message = post.bodyToSend;
-    manualRichMode = post.wasRichComposer;
+    setManualRichMode(post.wasRichComposer);
     editorApi?.setContent(post.bodyToSend);
     if (post.filesToSend) {
       attachments.restore(attachments.filesToPreviewItems(post.filesToSend));
@@ -611,7 +613,7 @@
 
     // Reset "also send to channel" checkbox after successful send
     alsoSendToChannel = false;
-    manualRichMode = false;
+    setManualRichMode(false);
   }
 
   async function submitPreparedPost(preparedPost: PreparedPost) {
@@ -619,7 +621,7 @@
     // message immediately (matches Slack/Discord behavior).
     autocomplete.reset();
     message = '';
-    manualRichMode = false;
+    setManualRichMode(false);
     editorApi?.setContent('');
     attachments.clear();
     linkPreviews.clear();
@@ -756,7 +758,7 @@
     autocomplete.reset();
     editState.cancelEdit();
     message = '';
-    manualRichMode = false;
+    setManualRichMode(false);
     editorApi?.setContent('');
   }
 
@@ -786,7 +788,7 @@
         if (isRichComposer) {
           handleSubmit(); // Fire-and-forget (async, but keydown must return sync)
         } else {
-          manualRichMode = true;
+          setManualRichMode(true);
           editorApi?.insertBlockBreak();
         }
         return true;
@@ -852,7 +854,7 @@
     const previousMessage = message;
     message = text;
     if (!text) {
-      manualRichMode = false;
+      setManualRichMode(false);
     }
     // Only trigger typing indicator for actual user input.
     // Programmatic setContent calls suppress TipTap update events, but this
@@ -864,7 +866,7 @@
   }
 
   function handleRichStructureChange(value: boolean) {
-    editorHasRichStructure = value;
+    setEditorHasRichStructure(value);
   }
 
   // Called when TipTap editor is ready - sync any pending state
@@ -964,7 +966,7 @@
     data-composer-mode={isRichComposer ? 'rich' : 'simple'}
     data-mode-transition={composerModeHasChanged ? '' : undefined}
     class={[
-      'composer-input-surface relative isolate flex items-start gap-4 rounded-xl bg-surface py-2 pr-3',
+      'composer-mode-surface flex items-start gap-4 rounded-xl bg-surface py-2 pr-3',
       isEditing ? 'pl-3' : 'pl-2'
     ]}
     class:opacity-50={inputDisabled}
@@ -1133,78 +1135,6 @@
 {/if}
 
 <style>
-  .composer-input-surface {
-    --composer-ring-opacity: 0;
-    box-shadow:
-      0 0 0 1px transparent,
-      0 0 0 transparent;
-    transition-property: box-shadow;
-    transition-duration: 240ms;
-    transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
-  }
-
-  .composer-input-surface::before {
-    position: absolute;
-    z-index: -1;
-    inset: -2px;
-    padding: 2px;
-    border-radius: calc(0.75rem + 2px);
-    background: linear-gradient(
-      115deg,
-      color-mix(in srgb, var(--color-accent) 72%, white),
-      var(--color-accent),
-      color-mix(in srgb, var(--color-accent) 72%, #a855f7),
-      color-mix(in srgb, var(--color-accent) 72%, white)
-    );
-    background-size: 220% 100%;
-    opacity: var(--composer-ring-opacity);
-    pointer-events: none;
-    content: '';
-    mask:
-      linear-gradient(#000 0 0) content-box,
-      linear-gradient(#000 0 0);
-    mask-composite: exclude;
-    transition-property: opacity;
-    transition-duration: 240ms;
-    transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
-  }
-
-  .composer-input-surface[data-composer-mode='rich'] {
-    --composer-ring-opacity: 1;
-    box-shadow:
-      0 0 0 1px color-mix(in srgb, var(--color-accent) 45%, transparent),
-      0 0 16px color-mix(in srgb, var(--color-accent) 22%, transparent);
-  }
-
-  .composer-input-surface[data-mode-transition]::before {
-    animation: composer-ring-shimmer 650ms cubic-bezier(0.2, 0, 0, 1);
-  }
-
-  @keyframes composer-ring-shimmer {
-    0% {
-      background-position: 100% 50%;
-      opacity: var(--composer-ring-opacity);
-    }
-    42% {
-      opacity: 1;
-    }
-    100% {
-      background-position: -100% 50%;
-      opacity: var(--composer-ring-opacity);
-    }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .composer-input-surface,
-    .composer-input-surface::before {
-      transition-duration: 0ms;
-    }
-
-    .composer-input-surface[data-mode-transition]::before {
-      animation: none;
-    }
-  }
-
   .sending {
     position: relative;
     overflow: hidden;

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -567,6 +567,20 @@ describe('MessageComposer', () => {
       });
     });
 
+    it('keeps an empty composer in rich mode after Ctrl+Enter', async () => {
+      const { container } = renderMessageComposer({ roomId: 'room_456' });
+      const editor = await findEditor(container);
+      const surface = q(container, '[data-testid="composer-input-surface"]');
+
+      await pressEditorKey(editor, 'Enter', { ctrlKey: true });
+
+      await vi.waitFor(() => {
+        expect(surface?.getAttribute('data-composer-mode')).toBe('rich');
+        expect(surface?.hasAttribute('data-mode-transition')).toBe(true);
+      });
+      expect(mutationMock).not.toHaveBeenCalled();
+    });
+
     it('tracks rich structure and returns to simple mode when cleared', async () => {
       const { container } = renderMessageComposer({ roomId: 'room_456' });
       const editor = await findEditor(container);

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -550,6 +550,45 @@ describe('MessageComposer', () => {
       expect(q(container, '[title$="Return to Send"]')).toBeNull();
     });
 
+    it('exposes simple and rich visual modes without animating on mount', async () => {
+      const { container } = renderMessageComposer({ roomId: 'room_456' });
+      const editor = await findEditor(container);
+      const surface = q(container, '[data-testid="composer-input-surface"]');
+
+      expect(surface?.getAttribute('data-composer-mode')).toBe('simple');
+      expect(surface?.hasAttribute('data-mode-transition')).toBe(false);
+
+      await typeEditorLiteralText(editor, 'make this rich');
+      await pressEditorKey(editor, 'Enter', { ctrlKey: true });
+
+      await vi.waitFor(() => {
+        expect(surface?.getAttribute('data-composer-mode')).toBe('rich');
+        expect(surface?.hasAttribute('data-mode-transition')).toBe(true);
+      });
+    });
+
+    it('tracks rich structure and returns to simple mode when cleared', async () => {
+      const { container } = renderMessageComposer({ roomId: 'room_456' });
+      const editor = await findEditor(container);
+      const surface = q(container, '[data-testid="composer-input-surface"]');
+
+      await typeEditorLiteralText(editor, '- ');
+      await vi.waitFor(() => {
+        expect(editor.querySelector('ul li')).toBeTruthy();
+        expect(surface?.getAttribute('data-composer-mode')).toBe('rich');
+      });
+
+      editor.focus();
+      document.execCommand('selectAll');
+      document.execCommand('delete');
+      await tick();
+
+      await vi.waitFor(() => {
+        expect(surface?.getAttribute('data-composer-mode')).toBe('simple');
+        expect(surface?.hasAttribute('data-mode-transition')).toBe(true);
+      });
+    });
+
     it('shows the enter-again hint after manually activating rich mode', async () => {
       const { container } = renderMessageComposer({ roomId: 'room_456' });
       const editor = await findEditor(container);

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -550,20 +550,18 @@ describe('MessageComposer', () => {
       expect(q(container, '[title$="Return to Send"]')).toBeNull();
     });
 
-    it('exposes simple and rich visual modes without animating on mount', async () => {
+    it('exposes simple and rich visual modes', async () => {
       const { container } = renderMessageComposer({ roomId: 'room_456' });
       const editor = await findEditor(container);
       const surface = q(container, '[data-testid="composer-input-surface"]');
 
       expect(surface?.getAttribute('data-composer-mode')).toBe('simple');
-      expect(surface?.hasAttribute('data-mode-transition')).toBe(false);
 
       await typeEditorLiteralText(editor, 'make this rich');
       await pressEditorKey(editor, 'Enter', { ctrlKey: true });
 
       await vi.waitFor(() => {
         expect(surface?.getAttribute('data-composer-mode')).toBe('rich');
-        expect(surface?.hasAttribute('data-mode-transition')).toBe(true);
       });
     });
 
@@ -576,7 +574,6 @@ describe('MessageComposer', () => {
 
       await vi.waitFor(() => {
         expect(surface?.getAttribute('data-composer-mode')).toBe('rich');
-        expect(surface?.hasAttribute('data-mode-transition')).toBe(true);
       });
       expect(mutationMock).not.toHaveBeenCalled();
     });
@@ -599,7 +596,6 @@ describe('MessageComposer', () => {
 
       await vi.waitFor(() => {
         expect(surface?.getAttribute('data-composer-mode')).toBe('simple');
-        expect(surface?.hasAttribute('data-mode-transition')).toBe(true);
       });
     });
 

--- a/apps/frontend/src/lib/ui/Utilities.stories.svelte
+++ b/apps/frontend/src/lib/ui/Utilities.stories.svelte
@@ -21,6 +21,46 @@
 </script>
 
 <Story
+  name="composer mode surface"
+  asChild
+  parameters={{
+    docs: {
+      description: {
+        story:
+          '`composer-mode-surface` keeps simple mode unadorned and adds an accent-gradient ring when `data-composer-mode="rich"` is present.'
+      }
+    }
+  }}
+>
+  <div class="flex max-w-2xl flex-col gap-5">
+    <p class="max-w-prose text-sm text-muted">
+      The composer uses the same surface in both modes. Rich mode adds emphasis without changing
+      layout; the live composer briefly shimmers when moving between these states.
+    </p>
+    <div class="grid gap-5 sm:grid-cols-2">
+      <section>
+        <p class="mb-2 text-sm font-medium text-muted">Simple mode</p>
+        <div
+          class="flex min-h-12 items-center rounded-xl bg-surface px-4 composer-mode-surface"
+          data-composer-mode="simple"
+        >
+          <span class="text-muted">Write a message…</span>
+        </div>
+      </section>
+      <section>
+        <p class="mb-2 text-sm font-medium text-muted">Rich mode</p>
+        <div
+          class="flex min-h-12 items-center rounded-xl bg-surface px-4 composer-mode-surface"
+          data-composer-mode="rich"
+        >
+          <span class="text-text">A message with multiple paragraphs</span>
+        </div>
+      </section>
+    </div>
+  </div>
+</Story>
+
+<Story
   name="link"
   asChild
   parameters={{

--- a/apps/frontend/src/lib/ui/Utilities.stories.svelte
+++ b/apps/frontend/src/lib/ui/Utilities.stories.svelte
@@ -35,7 +35,7 @@
   <div class="flex max-w-2xl flex-col gap-5">
     <p class="max-w-prose text-sm text-muted">
       The composer uses the same surface in both modes. Rich mode adds emphasis without changing
-      layout; the live composer briefly shimmers when moving between these states.
+      layout, and fades cleanly as the composer moves between these states.
     </p>
     <div class="grid gap-5 sm:grid-cols-2">
       <section>


### PR DESCRIPTION
## Why

The composer already switches from “Enter sends” to multiline rich mode when formatting appears or the user presses Cmd/Ctrl+Enter, but that behavioral change was only communicated by a small keyboard hint. This makes the mode change immediately legible without adding visual noise to the normal single-line composer.

## What changed

- Keep simple mode visually unchanged.
- Add an accent-gradient ring and soft glow while rich mode is active.
- Fade the ring and glow in and out with CSS transitions, disabling motion for `prefers-reduced-motion`.
- Preserve rich mode when Cmd/Ctrl+Enter activates it from an empty composer.
- Keep animation entirely in CSS with no `$effect`, timers, or transition-only component state.
- Package the treatment as the reusable `composer-mode-surface` Tailwind utility and document both states in Storybook.
- Strengthen the Chatto PR checklist so future PR bodies must explain why, the complete change, and exact validation instead of reading like changelog entries.

## Test plan

- [x] `mise x -- pnpm --dir apps/frontend exec vitest run src/lib/components/composer/MessageComposer.svelte.spec.ts` — 102 passed
- [x] `mise x -- pnpm --dir apps/frontend build-storybook`
- [x] Svelte autofixer on the composer and Storybook story
- [x] Skill validator for `.agents/skills/chatto-pr-checklist`
