### PR TITLE
fix(frontend): show server logo before login

### DIFF
--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte
@@ -70,7 +70,10 @@
     const refreshedName = stores.serverInfo.name !== 'Chatto' ? stores.serverInfo.name : undefined;
     return {
       name: displayName || refreshedName || registeredServer?.name || stores.serverInfo.name,
-      logoUrl: loaded ? logoUrl : (stores.serverInfo.iconUrl ?? registeredServer?.iconUrl)
+      logoUrl:
+        stores.isAuthenticated && privateDataLoaded
+          ? logoUrl
+          : (stores.serverInfo.iconUrl ?? registeredServer?.iconUrl)
     };
   });
   const needsReauth = $derived(registeredServer?.reauthRequiredAt != null);

--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
@@ -262,6 +262,7 @@ describe('ServerSidebarEntry', () => {
 
   it('renders an unauthenticated server without loading private sidebar state', async () => {
     mocks.store.isAuthenticated = false;
+    mocks.store.serverInfo.iconUrl = 'https://remote.example.com/assets/server/logo.webp';
 
     const { container } = render(ServerSidebarEntry, {
       props: {
@@ -272,6 +273,9 @@ describe('ServerSidebarEntry', () => {
     const icon = q(container, '[data-testid="server-icon"]');
     await expect.element(icon).toBeInTheDocument();
     await expect.element(icon).toHaveAttribute('href', '/chat/remote.example.com');
+    await expect
+      .element(icon.querySelector('img'))
+      .toHaveAttribute('src', 'https://remote.example.com/assets/server/logo.webp');
     expect(mocks.getAuthenticatedServerState).not.toHaveBeenCalled();
     expect(mocks.getViewerStateViaConnect).not.toHaveBeenCalled();
     expect(mocks.store.notifications.fetch).not.toHaveBeenCalled();
@@ -299,11 +303,15 @@ describe('ServerSidebarEntry', () => {
   });
 
   it('removes the dimmed state after sidebar init succeeds', async () => {
+    mocks.store.serverInfo.iconUrl = 'https://remote.example.com/assets/server/public-logo.webp';
     mocks.store.notifications.fetch.mockImplementationOnce(async () => {
       mocks.store.notifications.setUnreadNotificationCount(3);
     });
     mocks.getAuthenticatedServerState.mockResolvedValue(
-      serverState({ viewerHasUnreadRooms: true })
+      serverState({
+        logoUrl: 'https://remote.example.com/assets/server/private-logo.webp',
+        viewerHasUnreadRooms: true
+      })
     );
     mocks.getViewerStateViaConnect.mockResolvedValue(
       viewerState({
@@ -334,7 +342,9 @@ describe('ServerSidebarEntry', () => {
     await expect.element(icon).toBeInTheDocument();
     await expect.element(icon).not.toHaveClass('opacity-40');
     await expect.element(icon).toHaveAttribute('title', 'Loaded Remote');
-    expect(container.textContent).toContain('L');
+    await expect
+      .element(icon.querySelector('img'))
+      .toHaveAttribute('src', 'https://remote.example.com/assets/server/private-logo.webp');
     await vi.waitFor(() => {
       expect(mocks.store.notifications.setUnreadNotificationCount).toHaveBeenLastCalledWith(3);
     });

--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
@@ -74,7 +74,7 @@ const { mocks } = vi.hoisted(() => {
         pendingHighlights: { set: vi.fn() },
         serverInfo: {
           name: 'Chatto',
-          iconUrl: null
+          iconUrl: null as string | null
         },
         setPermissions: vi.fn(),
         serverIndicator: vi.fn().mockReturnValue(null)
@@ -271,10 +271,11 @@ describe('ServerSidebarEntry', () => {
     });
 
     const icon = q(container, '[data-testid="server-icon"]');
+    const image = q(container, '[data-testid="server-icon"] img');
     await expect.element(icon).toBeInTheDocument();
     await expect.element(icon).toHaveAttribute('href', '/chat/remote.example.com');
     await expect
-      .element(icon.querySelector('img'))
+      .element(image)
       .toHaveAttribute('src', 'https://remote.example.com/assets/server/logo.webp');
     expect(mocks.getAuthenticatedServerState).not.toHaveBeenCalled();
     expect(mocks.getViewerStateViaConnect).not.toHaveBeenCalled();
@@ -339,11 +340,12 @@ describe('ServerSidebarEntry', () => {
     });
 
     const icon = q(container, '[data-testid="server-icon"]');
+    const image = q(container, '[data-testid="server-icon"] img');
     await expect.element(icon).toBeInTheDocument();
     await expect.element(icon).not.toHaveClass('opacity-40');
     await expect.element(icon).toHaveAttribute('title', 'Loaded Remote');
     await expect
-      .element(icon.querySelector('img'))
+      .element(image)
       .toHaveAttribute('src', 'https://remote.example.com/assets/server/private-logo.webp');
     await vi.waitFor(() => {
       expect(mocks.store.notifications.setUnreadNotificationCount).toHaveBeenLastCalledWith(3);


### PR DESCRIPTION
## Summary

Show the publicly discovered server logo in the sidebar for unauthenticated users while preserving authenticated server state as authoritative after it loads.

The anonymous sidebar was recently made visible, but its icon selection treated anonymous state as fully loaded and therefore selected an uninitialized private logo instead of the public discovery fallback. This adds browser regression coverage for anonymous rendering without private API calls and for authenticated metadata replacing the fallback.

## Verification
- `mise x -- pnpm --dir apps/frontend exec vitest run --project client src/lib/ServerSidebarEntry.svelte.spec.ts` (6 tests passed)

- Svelte autofixer (no issues)

- `git diff --check`


