### PR TITLE
fix(frontend): support file drops in threads

### DIFF
--- a/apps/frontend/e2e/drag-drop-upload.test.ts
+++ b/apps/frontend/e2e/drag-drop-upload.test.ts
@@ -18,4 +18,27 @@ test.describe('drag and drop image upload', () => {
     await roomPage.expectMessageVisible(testMessage);
     await expect(roomPage.attachmentImage).toBeVisible();
   });
+
+  test('drops an image into the thread composer', async ({ page, chatPage, roomPage }) => {
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.enterRoom('general');
+
+    const rootText = `Thread drag drop root ${Date.now()}`;
+    const rootMessage = await roomPage.sendMessage(rootText);
+    await rootMessage.openThread();
+    await roomPage.expectThreadPaneVisible();
+
+    await roomPage.dropFileInThread('e2e/fixtures/brighton.jpg');
+    await expect(roomPage.roomAttachmentPreview).toHaveCount(0);
+
+    const replyText = `Thread drag drop reply ${Date.now()}`;
+    await roomPage.threadReplyInput.fill(replyText);
+    await roomPage.threadReplyInput.press('Enter');
+
+    await expect(roomPage.threadAttachmentPreview).toHaveCount(0);
+    const reply = roomPage.getMessage(replyText);
+    await expect(reply.locator).toBeVisible();
+    await expect(reply.attachmentImage).toBeVisible();
+  });
 });

--- a/apps/frontend/e2e/pages/RoomPage.ts
+++ b/apps/frontend/e2e/pages/RoomPage.ts
@@ -34,6 +34,16 @@ export class RoomPage {
     return this.page.locator('img.h-16.w-16');
   }
 
+  /** Attachment preview staged in the main room composer. */
+  get roomAttachmentPreview(): Locator {
+    return this.roomDropZone.locator('img.h-16.w-16');
+  }
+
+  /** Attachment preview staged in the thread composer. */
+  get threadAttachmentPreview(): Locator {
+    return this.threadDropZone.locator('img.h-16.w-16');
+  }
+
   /** The attach file button */
   get attachButton(): Locator {
     return this.page.getByTitle('Attach file');
@@ -892,6 +902,11 @@ export class RoomPage {
     });
   }
 
+  /** The active thread pane, which owns its thread-scoped drop zone. */
+  get threadDropZone(): Locator {
+    return this.page.getByTestId('thread-pane');
+  }
+
   /**
    * Simulate dragging files over the room drop zone.
    * This triggers the dragenter event with file types.
@@ -935,6 +950,15 @@ export class RoomPage {
    * Uses a real file from the e2e fixtures.
    */
   async simulateFileDrop(filePath: string): Promise<void> {
+    await this.simulateFileDropOn(this.roomDropZone, filePath);
+  }
+
+  /** Simulate dropping a file on the active thread pane. */
+  async simulateThreadFileDrop(filePath: string): Promise<void> {
+    await this.simulateFileDropOn(this.threadDropZone, filePath);
+  }
+
+  private async simulateFileDropOn(dropTarget: Locator, filePath: string): Promise<void> {
     // Read the file and convert to base64
     const fs = await import('fs/promises');
     const path = await import('path');
@@ -963,7 +987,7 @@ export class RoomPage {
     };
     const mimeType = mimeTypes[ext] || 'application/octet-stream';
 
-    await this.roomDropZone.evaluate(
+    await dropTarget.evaluate(
       (el, { base64Data, fileName, mimeType }) => {
         // Convert base64 to Uint8Array
         const binaryString = atob(base64Data);
@@ -1013,5 +1037,12 @@ export class RoomPage {
     const currentCount = await this.attachmentPreview.count();
     await this.simulateFileDrop(filePath);
     await expect(this.attachmentPreview).toHaveCount(currentCount + 1);
+  }
+
+  /** Drop a file into the thread composer and wait for its preview. */
+  async dropFileInThread(filePath: string): Promise<void> {
+    const currentCount = await this.threadAttachmentPreview.count();
+    await this.simulateThreadFileDrop(filePath);
+    await expect(this.threadAttachmentPreview).toHaveCount(currentCount + 1);
   }
 }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -9,6 +9,8 @@
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { isMessagePostedEvent } from '$lib/render/eventKinds';
   import * as m from '$lib/i18n/messages';
+  import { dropZone } from '$lib/attachments/dropZone.svelte';
+  import DropZoneOverlay from '$lib/attachments/DropZoneOverlay.svelte';
 
   import { appState } from '$lib/state/globals.svelte';
   import {
@@ -102,6 +104,17 @@
   let consumedQuoteId = 0;
   let consumedReplyId = 0;
   let composerApi = $state<MessageComposerApi | null>(null);
+  let isDraggingFiles = $state(false);
+
+  const threadDropZone = $derived(
+    canPostInThread && canAttach
+      ? dropZone({
+          onDrop: (files) => composerApi?.addFiles(files),
+          onDragStateChange: (dragging) => (isDraggingFiles = dragging),
+          acceptedTypes: ['image/*', 'video/*', 'audio/*']
+        })
+      : undefined
+  );
 
   // Thread-scoped jump state so "in reply to" clicks scroll within the thread.
   const jumpState = composerContext.jumpState;
@@ -281,7 +294,9 @@
   class="absolute inset-y-0 right-0 z-10 flex min-h-0 w-full min-w-0 flex-col overflow-hidden border-l border-border bg-background shadow-[-4px_0_12px_rgba(0,0,0,0.15)] sm:w-[90%]"
   data-testid="thread-pane"
   transition:fly={{ x: 300, duration: 200 }}
+  {@attach threadDropZone}
 >
+  <DropZoneOverlay visible={isDraggingFiles} />
   <PaneHeader
     title={m['room.thread.title']({ room: roomName })}
     onBack={onClose}


### PR DESCRIPTION
## Summary

Fix drag-and-drop attachments in thread panes by giving the active thread its own permission-aware drop target and overlay. The root cause was that only the inert room composer had drop handling, so files dropped over an open thread never reached the thread composer. Add thread-scoped Playwright helpers and regression coverage that verifies the attachment posts in the thread while the room composer remains unchanged.

## Testing

- `mise x -- pnpm exec playwright test e2e/drag-drop-upload.test.ts --retries=0`
- Svelte autofixer and Prettier checks
