### PR TITLE
fix(frontend): stabilize linked-message navigation

### DIFF
--- a/apps/frontend/e2e/jump-to-message.test.ts
+++ b/apps/frontend/e2e/jump-to-message.test.ts
@@ -10,6 +10,60 @@ import {
 import { TIMEOUTS } from './constants';
 import * as routes from './routes';
 
+const GET_ROOM_EVENTS_AROUND_ROUTE =
+  '**/api/connect/chatto.api.v1.RoomService/GetRoomEventsAround';
+
+type DeferredAroundRequest = {
+  waitUntilBlocked: () => Promise<void>;
+  release: () => void;
+};
+
+async function deferNextAroundRequest(page: Page): Promise<DeferredAroundRequest> {
+  let releaseRequest: (() => void) | undefined;
+  let markBlocked: (() => void) | undefined;
+  const releaseGate = new Promise<void>((resolve) => {
+    releaseRequest = resolve;
+  });
+  const blocked = new Promise<void>((resolve) => {
+    markBlocked = resolve;
+  });
+  let deferred = false;
+
+  await page.route(GET_ROOM_EVENTS_AROUND_ROUTE, async (route) => {
+    if (deferred) {
+      await route.continue();
+      return;
+    }
+
+    deferred = true;
+    const response = await route.fetch();
+    markBlocked?.();
+    await releaseGate;
+    await route.fulfill({ response });
+  });
+
+  return {
+    waitUntilBlocked: () => blocked,
+    release: () => releaseRequest?.()
+  };
+}
+
+async function expectMessageCentered(page: Page, eventId: string): Promise<void> {
+  const message = page.locator(`[data-event-id="${eventId}"]`);
+  const container = page.getByTestId('messages-container').first();
+  await expect(message).toBeVisible({ timeout: TIMEOUTS.COMPLEX_OPERATION });
+
+  await expect(async () => {
+    const messageBox = await message.boundingBox();
+    const containerBox = await container.boundingBox();
+    expect(messageBox).not.toBeNull();
+    expect(containerBox).not.toBeNull();
+    const messageCenter = messageBox!.y + messageBox!.height / 2;
+    const containerCenter = containerBox!.y + containerBox!.height / 2;
+    expect(Math.abs(messageCenter - containerCenter)).toBeLessThan(containerBox!.height / 3);
+  }).toPass({ timeout: TIMEOUTS.UI_STANDARD, intervals: [100, 250, 500] });
+}
+
 async function clickReplyAttributionJump(page: Page, replyBody: string): Promise<void> {
   const replyAttribution = page
     .locator('[role="article"]', { hasText: replyBody })
@@ -133,7 +187,7 @@ test.describe('jump to message', () => {
 
     // Should return to the latest messages
     await expect(page.getByText(`JTP filler 60 - ${timestamp}`)).toBeVisible({
-      timeout: TIMEOUTS.REALTIME_EVENT
+      timeout: TIMEOUTS.COMPLEX_OPERATION
     });
 
     // The "Jump to Present" button should disappear
@@ -241,5 +295,112 @@ test.describe('jump to message', () => {
 
     // "Jump to Present" should still not be visible
     await expect(page.getByTestId('jump-to-present')).not.toBeVisible();
+  });
+
+  test('direct permalink centers a target across a 200-message timeline', async ({
+    page,
+    chatPage
+  }) => {
+    test.setTimeout(120_000);
+    await page.setViewportSize({ width: 1280, height: 600 });
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.enterRoom('general');
+
+    const { roomId } = await getIdsFromUrlViaConnect(page);
+    const timestamp = Date.now();
+    const targetBody = `Large timeline permalink target - ${timestamp}`;
+    const targetEventId = await postMessageViaConnect(page, roomId, targetBody);
+    await postMessagesViaConnect(
+      page,
+      roomId,
+      Array.from({ length: 200 }, (_, index) => `Large timeline filler ${index + 1} - ${timestamp}`)
+    );
+
+    await page.goto(routes.messageLink(roomId, targetEventId));
+
+    await expectMessageCentered(page, targetEventId);
+    await expect(page.getByTestId('jump-to-present')).toBeVisible({
+      timeout: TIMEOUTS.UI_STANDARD
+    });
+    await expect(page.getByText(`Large timeline filler 200 - ${timestamp}`)).not.toBeVisible();
+  });
+
+  test('a newer permalink wins when an older jump response arrives last', async ({
+    page,
+    chatPage
+  }) => {
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.enterRoom('general');
+
+    const { roomId } = await getIdsFromUrlViaConnect(page);
+    const timestamp = Date.now();
+    const firstBody = `Superseded target A - ${timestamp}`;
+    const firstEventId = await postMessageViaConnect(page, roomId, firstBody);
+    await postMessagesViaConnect(
+      page,
+      roomId,
+      Array.from({ length: 60 }, (_, index) => `Supersession filler ${index + 1} - ${timestamp}`)
+    );
+    const secondBody = `Winning target B - ${timestamp}`;
+    const secondEventId = await postMessageViaConnect(page, roomId, secondBody);
+    await postMessagesViaConnect(
+      page,
+      roomId,
+      Array.from({ length: 60 }, (_, index) => `Later filler ${index + 1} - ${timestamp}`)
+    );
+
+    const deferred = await deferNextAroundRequest(page);
+    await page.goto(routes.messageLink(roomId, firstEventId));
+    await deferred.waitUntilBlocked();
+
+    await page.goto(routes.messageLink(roomId, secondEventId));
+    await expectMessageCentered(page, secondEventId);
+    deferred.release();
+
+    await expectMessageCentered(page, secondEventId);
+    await expect(page.locator(`[data-event-id="${firstEventId}"]`)).not.toBeVisible();
+    await expect(page.getByText('Could not jump to that message.')).toHaveCount(0);
+  });
+
+  test('permalink remains centered while variable-height rows are measured', async ({
+    page,
+    chatPage,
+    roomPage
+  }) => {
+    test.setTimeout(90_000);
+    await page.setViewportSize({ width: 1280, height: 600 });
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.enterRoom('general');
+
+    const { roomId } = await getIdsFromUrlViaConnect(page);
+    const timestamp = Date.now();
+    const targetBody = `Variable height target ${timestamp}\n${'A long wrapped line. '.repeat(30)}`;
+    const targetEventId = await postMessageViaConnect(page, roomId, targetBody);
+    await postReplyViaConnect(
+      page,
+      roomId,
+      `Reply attribution near variable target - ${timestamp}`,
+      targetEventId
+    );
+    await roomPage.sendAttachment(
+      'e2e/fixtures/brighton.jpg',
+      `Image near variable target - ${timestamp}`
+    );
+    await postMessagesViaConnect(
+      page,
+      roomId,
+      Array.from({ length: 80 }, (_, index) => `Variable filler ${index + 1} - ${timestamp}`)
+    );
+
+    await page.goto(routes.messageLink(roomId, targetEventId));
+
+    await expectMessageCentered(page, targetEventId);
+    await expect(page.locator(`[data-event-id="${targetEventId}"]`)).toContainText(
+      'A long wrapped line.'
+    );
+    await expect(page.getByTestId('jump-to-present')).toBeVisible();
   });
 });

--- a/apps/frontend/e2e/jump-to-message.test.ts
+++ b/apps/frontend/e2e/jump-to-message.test.ts
@@ -197,9 +197,19 @@ test.describe('jump to message', () => {
     await page.getByTestId('jump-to-present').evaluate((button: HTMLElement) => button.click());
 
     // Should return to the latest messages
-    await expect(page.getByText(`JTP filler 60 - ${timestamp}`)).toBeVisible({
+    await expect(page.getByText(replyBody)).toBeVisible({
       timeout: TIMEOUTS.COMPLEX_OPERATION
     });
+    const messagesContainer = page.getByTestId('messages-container').first();
+    await expect
+      .poll(
+        () =>
+          messagesContainer.evaluate(
+            (element) => element.scrollHeight - element.scrollTop - element.clientHeight
+          ),
+        { timeout: TIMEOUTS.UI_STANDARD }
+      )
+      .toBeLessThan(10);
 
     // The "Jump to Present" button should disappear
     await expect(page.getByTestId('jump-to-present')).not.toBeVisible({
@@ -356,11 +366,18 @@ test.describe('jump to message', () => {
     );
     const secondBody = `Winning target B - ${timestamp}`;
     const secondEventId = await postMessageViaConnect(page, roomId, secondBody);
+    const latestBody = `Later filler 60 - ${timestamp}`;
     await postMessagesViaConnect(
       page,
       roomId,
       Array.from({ length: 60 }, (_, index) => `Later filler ${index + 1} - ${timestamp}`)
     );
+
+    // An event append can complete before the room timeline projection has
+    // exposed every seeded row. Establish a fully projected latest window so
+    // this test only exercises response ordering, not projection convergence.
+    await page.reload();
+    await expect(page.getByText(latestBody)).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
 
     const deferred = await deferNextAroundRequest(page);
     await page.goto(routes.messageLink(roomId, firstEventId));

--- a/apps/frontend/e2e/jump-to-message.test.ts
+++ b/apps/frontend/e2e/jump-to-message.test.ts
@@ -15,17 +15,22 @@ const GET_ROOM_EVENTS_AROUND_ROUTE =
 
 type DeferredAroundRequest = {
   waitUntilBlocked: () => Promise<void>;
+  waitUntilDelivered: () => Promise<void>;
   release: () => void;
 };
 
 async function deferNextAroundRequest(page: Page): Promise<DeferredAroundRequest> {
   let releaseRequest: (() => void) | undefined;
   let markBlocked: (() => void) | undefined;
+  let markDelivered: (() => void) | undefined;
   const releaseGate = new Promise<void>((resolve) => {
     releaseRequest = resolve;
   });
   const blocked = new Promise<void>((resolve) => {
     markBlocked = resolve;
+  });
+  const delivered = new Promise<void>((resolve) => {
+    markDelivered = resolve;
   });
   let deferred = false;
 
@@ -40,10 +45,12 @@ async function deferNextAroundRequest(page: Page): Promise<DeferredAroundRequest
     markBlocked?.();
     await releaseGate;
     await route.fulfill({ response });
+    markDelivered?.();
   });
 
   return {
     waitUntilBlocked: () => blocked,
+    waitUntilDelivered: () => delivered,
     release: () => releaseRequest?.()
   };
 }
@@ -60,7 +67,7 @@ async function expectMessageCentered(page: Page, eventId: string): Promise<void>
     expect(containerBox).not.toBeNull();
     const messageCenter = messageBox!.y + messageBox!.height / 2;
     const containerCenter = containerBox!.y + containerBox!.height / 2;
-    expect(Math.abs(messageCenter - containerCenter)).toBeLessThan(containerBox!.height / 3);
+    expect(Math.abs(messageCenter - containerCenter)).toBeLessThan(containerBox!.height / 6);
   }).toPass({ timeout: TIMEOUTS.UI_STANDARD, intervals: [100, 250, 500] });
 }
 
@@ -358,6 +365,7 @@ test.describe('jump to message', () => {
     await page.goto(routes.messageLink(roomId, secondEventId));
     await expectMessageCentered(page, secondEventId);
     deferred.release();
+    await deferred.waitUntilDelivered();
 
     await expectMessageCentered(page, secondEventId);
     await expect(page.locator(`[data-event-id="${firstEventId}"]`)).not.toBeVisible();
@@ -378,6 +386,7 @@ test.describe('jump to message', () => {
     const { roomId } = await getIdsFromUrlViaConnect(page);
     const timestamp = Date.now();
     const targetBody = `Variable height target ${timestamp}\n${'A long wrapped line. '.repeat(30)}`;
+    const imageBody = `Image near variable target - ${timestamp}`;
     const targetEventId = await postMessageViaConnect(page, roomId, targetBody);
     await postReplyViaConnect(
       page,
@@ -387,7 +396,7 @@ test.describe('jump to message', () => {
     );
     await roomPage.sendAttachment(
       'e2e/fixtures/brighton.jpg',
-      `Image near variable target - ${timestamp}`
+      imageBody
     );
     await postMessagesViaConnect(
       page,
@@ -401,6 +410,17 @@ test.describe('jump to message', () => {
     await expect(page.locator(`[data-event-id="${targetEventId}"]`)).toContainText(
       'A long wrapped line.'
     );
+    const nearbyImage = page
+      .locator('[role="article"]', { hasText: imageBody })
+      .locator('img')
+      .first();
+    await expect(nearbyImage).toBeVisible({ timeout: TIMEOUTS.COMPLEX_OPERATION });
+    await expect(async () => {
+      expect(
+        await nearbyImage.evaluate((image: HTMLImageElement) => image.complete && image.naturalHeight > 0)
+      ).toBe(true);
+    }).toPass({ timeout: TIMEOUTS.COMPLEX_OPERATION, intervals: [100, 250, 500] });
+    await expectMessageCentered(page, targetEventId);
     await expect(page.getByTestId('jump-to-present')).toBeVisible();
   });
 });

--- a/apps/frontend/e2e/jump-to-message.test.ts
+++ b/apps/frontend/e2e/jump-to-message.test.ts
@@ -10,8 +10,7 @@ import {
 import { TIMEOUTS } from './constants';
 import * as routes from './routes';
 
-const GET_ROOM_EVENTS_AROUND_ROUTE =
-  '**/api/connect/chatto.api.v1.RoomService/GetRoomEventsAround';
+const GET_ROOM_EVENTS_AROUND_ROUTE = '**/api/connect/chatto.api.v1.RoomService/GetRoomEventsAround';
 const ASSET_ROUTE = '**/assets/**';
 
 type DeferredRequest = {
@@ -389,7 +388,10 @@ test.describe('jump to message', () => {
     await postMessagesViaConnect(
       page,
       roomId,
-      Array.from({ length: 60 }, (_, index) => `Interrupted room filler ${index + 1} - ${timestamp}`)
+      Array.from(
+        { length: 60 },
+        (_, index) => `Interrupted room filler ${index + 1} - ${timestamp}`
+      )
     );
 
     const deferred = await deferNextAroundRequest(page);
@@ -422,10 +424,7 @@ test.describe('jump to message', () => {
     const { roomId } = await getIdsFromUrlViaConnect(page);
     const timestamp = Date.now();
     const imageBody = `Image near variable target - ${timestamp}`;
-    await roomPage.sendAttachment(
-      'e2e/fixtures/brighton.jpg',
-      imageBody
-    );
+    await roomPage.sendAttachment('e2e/fixtures/brighton.jpg', imageBody);
     const targetBody = `Variable height target ${timestamp}\n${'A long wrapped line. '.repeat(30)}`;
     const targetEventId = await postMessageViaConnect(page, roomId, targetBody);
     await postReplyViaConnect(
@@ -457,7 +456,9 @@ test.describe('jump to message', () => {
     await expect(nearbyImage).toBeVisible({ timeout: TIMEOUTS.COMPLEX_OPERATION });
     await expect(async () => {
       expect(
-        await nearbyImage.evaluate((image: HTMLImageElement) => image.complete && image.naturalHeight > 0)
+        await nearbyImage.evaluate(
+          (image: HTMLImageElement) => image.complete && image.naturalHeight > 0
+        )
       ).toBe(true);
     }).toPass({ timeout: TIMEOUTS.COMPLEX_OPERATION, intervals: [100, 250, 500] });
     await expectMessageCentered(page, targetEventId);

--- a/apps/frontend/e2e/jump-to-message.test.ts
+++ b/apps/frontend/e2e/jump-to-message.test.ts
@@ -12,14 +12,15 @@ import * as routes from './routes';
 
 const GET_ROOM_EVENTS_AROUND_ROUTE =
   '**/api/connect/chatto.api.v1.RoomService/GetRoomEventsAround';
+const ASSET_ROUTE = '**/assets/**';
 
-type DeferredAroundRequest = {
+type DeferredRequest = {
   waitUntilBlocked: () => Promise<void>;
   waitUntilDelivered: () => Promise<void>;
   release: () => void;
 };
 
-async function deferNextAroundRequest(page: Page): Promise<DeferredAroundRequest> {
+async function deferNextResponse(page: Page, url: string): Promise<DeferredRequest> {
   let releaseRequest: (() => void) | undefined;
   let markBlocked: (() => void) | undefined;
   let markDelivered: (() => void) | undefined;
@@ -34,7 +35,7 @@ async function deferNextAroundRequest(page: Page): Promise<DeferredAroundRequest
   });
   let deferred = false;
 
-  await page.route(GET_ROOM_EVENTS_AROUND_ROUTE, async (route) => {
+  await page.route(url, async (route) => {
     if (deferred) {
       await route.continue();
       return;
@@ -53,6 +54,10 @@ async function deferNextAroundRequest(page: Page): Promise<DeferredAroundRequest
     waitUntilDelivered: () => delivered,
     release: () => releaseRequest?.()
   };
+}
+
+async function deferNextAroundRequest(page: Page): Promise<DeferredRequest> {
+  return deferNextResponse(page, GET_ROOM_EVENTS_AROUND_ROUTE);
 }
 
 async function expectMessageCentered(page: Page, eventId: string): Promise<void> {
@@ -372,6 +377,37 @@ test.describe('jump to message', () => {
     await expect(page.getByText('Could not jump to that message.')).toHaveCount(0);
   });
 
+  test('switching rooms wins over an unresolved historical jump', async ({ page, chatPage }) => {
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.enterRoom('general');
+
+    const { roomId } = await getIdsFromUrlViaConnect(page);
+    const timestamp = Date.now();
+    const targetBody = `Interrupted room target - ${timestamp}`;
+    const targetEventId = await postMessageViaConnect(page, roomId, targetBody);
+    await postMessagesViaConnect(
+      page,
+      roomId,
+      Array.from({ length: 60 }, (_, index) => `Interrupted room filler ${index + 1} - ${timestamp}`)
+    );
+
+    const deferred = await deferNextAroundRequest(page);
+    await page.goto(routes.messageLink(roomId, targetEventId));
+    await deferred.waitUntilBlocked();
+    await chatPage.enterRoom('announcements');
+    deferred.release();
+    await deferred.waitUntilDelivered();
+
+    await chatPage.enterRoom('general');
+    await expect(page.getByText(`Interrupted room filler 60 - ${timestamp}`)).toBeVisible({
+      timeout: TIMEOUTS.COMPLEX_OPERATION
+    });
+    await expect(page.locator(`[data-event-id="${targetEventId}"]`)).not.toBeVisible();
+    await expect(page.getByTestId('jump-to-present')).not.toBeVisible();
+    await expect(page.getByText('Could not jump to that message.')).toHaveCount(0);
+  });
+
   test('permalink remains centered while variable-height rows are measured', async ({
     page,
     chatPage,
@@ -385,8 +421,12 @@ test.describe('jump to message', () => {
 
     const { roomId } = await getIdsFromUrlViaConnect(page);
     const timestamp = Date.now();
-    const targetBody = `Variable height target ${timestamp}\n${'A long wrapped line. '.repeat(30)}`;
     const imageBody = `Image near variable target - ${timestamp}`;
+    await roomPage.sendAttachment(
+      'e2e/fixtures/brighton.jpg',
+      imageBody
+    );
+    const targetBody = `Variable height target ${timestamp}\n${'A long wrapped line. '.repeat(30)}`;
     const targetEventId = await postMessageViaConnect(page, roomId, targetBody);
     await postReplyViaConnect(
       page,
@@ -394,22 +434,22 @@ test.describe('jump to message', () => {
       `Reply attribution near variable target - ${timestamp}`,
       targetEventId
     );
-    await roomPage.sendAttachment(
-      'e2e/fixtures/brighton.jpg',
-      imageBody
-    );
     await postMessagesViaConnect(
       page,
       roomId,
       Array.from({ length: 80 }, (_, index) => `Variable filler ${index + 1} - ${timestamp}`)
     );
 
+    const deferredImage = await deferNextResponse(page, ASSET_ROUTE);
     await page.goto(routes.messageLink(roomId, targetEventId));
 
     await expectMessageCentered(page, targetEventId);
     await expect(page.locator(`[data-event-id="${targetEventId}"]`)).toContainText(
       'A long wrapped line.'
     );
+    await deferredImage.waitUntilBlocked();
+    deferredImage.release();
+    await deferredImage.waitUntilDelivered();
     const nearbyImage = page
       .locator('[role="article"]', { hasText: imageBody })
       .locator('img')

--- a/apps/frontend/e2e/pages/ChatPage.ts
+++ b/apps/frontend/e2e/pages/ChatPage.ts
@@ -67,8 +67,14 @@ export class ChatPage {
     // Check if already in this room (aria-current="page" indicates active link)
     const isActive = await link.getAttribute('aria-current');
     if (isActive !== 'page') {
-      await link.click();
-      await this.page.waitForURL(routes.patterns.anyRoom);
+      const href = await link.getAttribute('href');
+      if (!href) throw new Error(`Room link for ${roomName} has no href`);
+
+      const destination = new URL(href, this.page.url());
+      await Promise.all([
+        this.page.waitForURL((url) => url.pathname === destination.pathname),
+        link.click()
+      ]);
     }
 
     // Wait for room UI to be fully loaded (header and message input)

--- a/apps/frontend/messages/de/room.json
+++ b/apps/frontend/messages/de/room.json
@@ -152,6 +152,7 @@
       "reply_placeholder": "Im Thread antworten..."
     },
     "jump_to_present": "Zur Gegenwart springen",
+    "jump_failed": "Zu dieser Nachricht konnte nicht gesprungen werden.",
     "unread_separator": "Neue Nachrichten",
     "close_extras": "Raumdetails schließen"
   }

--- a/apps/frontend/messages/en/room.json
+++ b/apps/frontend/messages/en/room.json
@@ -152,6 +152,7 @@
       "reply_placeholder": "Reply in thread..."
     },
     "jump_to_present": "Jump to Present",
+    "jump_failed": "Could not jump to that message.",
     "unread_separator": "New messages",
     "close_extras": "Close room extras"
   }

--- a/apps/frontend/src/lib/i18n/messages.ts
+++ b/apps/frontend/src/lib/i18n/messages.ts
@@ -713,6 +713,7 @@ const msg_room_thread_close = (): LocalizedString => messages().room_thread_clos
 const msg_room_thread_not_found = (): LocalizedString => messages().room_thread_not_found(empty());
 const msg_room_thread_reply_placeholder = (): LocalizedString => messages().room_thread_reply_placeholder(empty());
 const msg_room_jump_to_present = (): LocalizedString => messages().room_jump_to_present(empty());
+const msg_room_jump_failed = (): LocalizedString => messages().room_jump_failed(empty());
 const msg_room_unread_separator = (): LocalizedString => messages().room_unread_separator(empty());
 const msg_room_close_extras = (): LocalizedString => messages().room_close_extras(empty());
 const msg_server_settings_loading = (): LocalizedString => messages().server_settings_loading(empty());
@@ -2044,6 +2045,7 @@ export { msg_room_thread_close as 'room.thread.close' };
 export { msg_room_thread_not_found as 'room.thread.not_found' };
 export { msg_room_thread_reply_placeholder as 'room.thread.reply_placeholder' };
 export { msg_room_jump_to_present as 'room.jump_to_present' };
+export { msg_room_jump_failed as 'room.jump_failed' };
 export { msg_room_unread_separator as 'room.unread_separator' };
 export { msg_room_close_extras as 'room.close_extras' };
 export { msg_server_settings_loading as 'server_settings.loading' };

--- a/apps/frontend/src/lib/state/room/composerContext.svelte.ts
+++ b/apps/frontend/src/lib/state/room/composerContext.svelte.ts
@@ -149,10 +149,10 @@ export class JumpToMessageState {
   hasOlderMessages = $state(false);
   isLoadingNewer = $state(false);
 
-  private _jumpFn: ((eventId: string) => Promise<void>) | null = null;
+  private _jumpFn: ((eventId: string) => Promise<boolean>) | null = null;
   private _loadNewerFn: (() => Promise<void>) | null = null;
 
-  setJumpHandler(fn: (eventId: string) => Promise<void>) {
+  setJumpHandler(fn: (eventId: string) => Promise<boolean>) {
     this._jumpFn = fn;
   }
 
@@ -160,10 +160,11 @@ export class JumpToMessageState {
     this._loadNewerFn = fn;
   }
 
-  async jumpToMessage(eventId: string): Promise<void> {
+  async jumpToMessage(eventId: string): Promise<boolean> {
     if (this._jumpFn) {
-      await this._jumpFn(eventId);
+      return this._jumpFn(eventId);
     }
+    return false;
   }
 
   async loadNewer(): Promise<void> {

--- a/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -319,6 +319,152 @@ function timelineFromFixtures(fake: FakeQueryClient): RoomTimelineAPI {
 }
 
 describe('MessagesStore — room lifecycle ownership', () => {
+  it('reports a successful jump when the target is already loaded', async () => {
+    const fake = new FakeQueryClient();
+    const timeline = fakeTimelineAPI();
+    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, timeline);
+    store.setRoom('room-1');
+    await settle();
+    store.events = [threadMessageEvent('m1') as never];
+
+    const jumpState = new JumpToMessageState();
+    const jumped = await store.jumpToMessage('m1', jumpState);
+
+    expect(jumped).toBe(true);
+    expect(jumpState.scrollToEventId).toBe('m1');
+    expect(timeline.getRoomEventsAround).not.toHaveBeenCalled();
+    store.dispose();
+  });
+
+  it('reports a successful jump after loading a room window around the target', async () => {
+    const fake = new FakeQueryClient();
+    const timeline = fakeTimelineAPI({
+      getRoomEventsAround: vi.fn(async () => ({
+        events: [
+          threadMessageEvent('m1') as never,
+          threadMessageEvent('m2') as never,
+          threadMessageEvent('m3') as never
+        ],
+        startCursor: 'tl:start',
+        endCursor: 'tl:end',
+        hasOlder: true,
+        hasNewer: true
+      }))
+    });
+    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, timeline);
+    store.setRoom('room-1');
+    await settle();
+
+    const jumpState = new JumpToMessageState();
+    const jumped = await store.jumpToMessage('m2', jumpState);
+
+    expect(jumped).toBe(true);
+    expect(timeline.getRoomEventsAround).toHaveBeenCalledWith({
+      roomId: 'room-1',
+      eventId: 'm2',
+      limit: 50
+    });
+    expect(store.rootEvents.map((event) => event.id)).toEqual(['m1', 'm2', 'm3']);
+    expect(jumpState.isJumpedMode).toBe(true);
+    expect(jumpState.hasReachedEnd).toBe(false);
+    expect(jumpState.hasOlderMessages).toBe(true);
+    expect(jumpState.scrollToEventId).toBe('m2');
+    expect(store.isInitialLoading).toBe(false);
+    store.dispose();
+  });
+
+  it('reports a failed jump when the around page omits the target', async () => {
+    const fake = new FakeQueryClient();
+    const timeline = fakeTimelineAPI({
+      getRoomEventsAround: vi.fn(async () => ({
+        events: [threadMessageEvent('m3') as never],
+        startCursor: 'tl:start',
+        endCursor: 'tl:end',
+        hasOlder: false,
+        hasNewer: false
+      }))
+    });
+    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, timeline);
+    store.setRoom('room-1');
+    await settle();
+    store.events = [threadMessageEvent('m1') as never];
+
+    const jumpState = new JumpToMessageState();
+    jumpState.isJumpedMode = true;
+    jumpState.scrollToEventId = 'previous';
+    const jumped = await store.jumpToMessage('m2', jumpState);
+
+    expect(jumped).toBe(false);
+    expect(store.rootEvents.map((event) => event.id)).toEqual(['m1']);
+    expect(jumpState.isJumpedMode).toBe(false);
+    expect(jumpState.scrollToEventId).toBeNull();
+    expect(store.isInitialLoading).toBe(false);
+    store.dispose();
+  });
+
+  it('reports a failed jump when loading the target window rejects', async () => {
+    const fake = new FakeQueryClient();
+    const timeline = fakeTimelineAPI({
+      getRoomEventsAround: vi.fn(async () => {
+        throw new Error('network failed');
+      })
+    });
+    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, timeline);
+    store.setRoom('room-1');
+    await settle();
+
+    const jumpState = new JumpToMessageState();
+    const jumped = await store.jumpToMessage('m2', jumpState);
+
+    expect(jumped).toBe(false);
+    expect(jumpState.scrollToEventId).toBeNull();
+    expect(store.isInitialLoading).toBe(false);
+    store.dispose();
+  });
+
+  it('discards a jump response superseded by a newer jump', async () => {
+    const fake = new FakeQueryClient();
+    type AroundPage = Awaited<ReturnType<RoomTimelineAPI['getRoomEventsAround']>>;
+    let resolveFirst: ((value: AroundPage) => void) | undefined;
+    const firstPage = new Promise<AroundPage>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const timeline = fakeTimelineAPI({
+      getRoomEventsAround: vi
+        .fn()
+        .mockReturnValueOnce(firstPage)
+        .mockResolvedValueOnce({
+          events: [threadMessageEvent('new-target') as never],
+          startCursor: 'tl:new',
+          endCursor: 'tl:new',
+          hasOlder: false,
+          hasNewer: false
+        })
+    });
+    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, timeline);
+    store.setRoom('room-1');
+    await settle();
+
+    const jumpState = new JumpToMessageState();
+    const firstJump = store.jumpToMessage('old-target', jumpState);
+    const secondJump = store.jumpToMessage('new-target', jumpState);
+    await expect(secondJump).resolves.toBe(true);
+
+    resolveFirst?.({
+      events: [threadMessageEvent('old-target') as never],
+      startCursor: 'tl:old',
+      endCursor: 'tl:old',
+      hasOlder: false,
+      hasNewer: false
+    });
+
+    await expect(firstJump).resolves.toBe(false);
+    expect(store.rootEvents.map((event) => event.id)).toEqual(['new-target']);
+    expect(jumpState.scrollToEventId).toBe('new-target');
+    expect(store.isInitialLoading).toBe(false);
+    store.dispose();
+  });
+
   it('loads room history through the injected timeline API', async () => {
     const fake = new FakeQueryClient();
     const timeline = fakeTimelineAPI({

--- a/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -557,6 +557,56 @@ describe('MessagesStore — room lifecycle ownership', () => {
     store.dispose();
   });
 
+  it('discards an in-flight jump after returning to the present', async () => {
+    const fake = new FakeQueryClient();
+    type AroundPage = Awaited<ReturnType<RoomTimelineAPI['getRoomEventsAround']>>;
+    let resolveAround: ((value: AroundPage) => void) | undefined;
+    const aroundPage = new Promise<AroundPage>((resolve) => {
+      resolveAround = resolve;
+    });
+    const timeline = fakeTimelineAPI({
+      getRoomEvents: vi
+        .fn()
+        .mockResolvedValueOnce({
+          events: [],
+          startCursor: null,
+          endCursor: null,
+          hasOlder: false,
+          hasNewer: false
+        })
+        .mockResolvedValueOnce({
+          events: [threadMessageEvent('present') as never],
+          startCursor: 'tl:present',
+          endCursor: 'tl:present',
+          hasOlder: true,
+          hasNewer: false
+        }),
+      getRoomEventsAround: vi.fn(() => aroundPage)
+    });
+    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, timeline);
+    store.setRoom('room-1');
+    await settle();
+
+    const jumpState = new JumpToMessageState();
+    const jumping = store.jumpToMessage('historical', jumpState);
+    store.jumpToPresent(jumpState);
+    await settle();
+
+    resolveAround?.({
+      events: [threadMessageEvent('historical') as never],
+      startCursor: 'tl:historical',
+      endCursor: 'tl:historical',
+      hasOlder: true,
+      hasNewer: true
+    });
+
+    await expect(jumping).resolves.toBe(false);
+    expect(store.rootEvents.map((event) => event.id)).toEqual(['present']);
+    expect(jumpState.isJumpedMode).toBe(false);
+    expect(jumpState.scrollToEventId).toBeNull();
+    store.dispose();
+  });
+
   it('loads room history through the injected timeline API', async () => {
     const fake = new FakeQueryClient();
     const timeline = fakeTimelineAPI({

--- a/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -465,6 +465,98 @@ describe('MessagesStore — room lifecycle ownership', () => {
     store.dispose();
   });
 
+  it('does not cancel the initial room load when jumping to an already-loaded event', async () => {
+    const fake = new FakeQueryClient();
+    type RoomPage = Awaited<ReturnType<RoomTimelineAPI['getRoomEvents']>>;
+    let resolveInitial: ((value: RoomPage) => void) | undefined;
+    const initialPage = new Promise<RoomPage>((resolve) => {
+      resolveInitial = resolve;
+    });
+    const timeline = fakeTimelineAPI({ getRoomEvents: vi.fn(() => initialPage) });
+    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, timeline);
+    store.setRoom('room-1');
+    store.events = [threadMessageEvent('linked-realtime') as never];
+
+    const jumpState = new JumpToMessageState();
+    await expect(store.jumpToMessage('linked-realtime', jumpState)).resolves.toBe(true);
+    expect(store.isInitialLoading).toBe(true);
+
+    resolveInitial?.({
+      events: [threadMessageEvent('authoritative') as never],
+      startCursor: null,
+      endCursor: null,
+      hasOlder: false,
+      hasNewer: false
+    });
+    await settle();
+
+    expect(store.rootEvents.map((event) => event.id)).toEqual([
+      'authoritative',
+      'linked-realtime'
+    ]);
+    expect(store.isInitialLoading).toBe(false);
+    store.dispose();
+  });
+
+  it('discards load-newer results from a replaced jump window', async () => {
+    const fake = new FakeQueryClient();
+    type RoomPage = Awaited<ReturnType<RoomTimelineAPI['getRoomEvents']>>;
+    let resolveNewer: ((value: RoomPage) => void) | undefined;
+    const newerPage = new Promise<RoomPage>((resolve) => {
+      resolveNewer = resolve;
+    });
+    const timeline = fakeTimelineAPI({
+      getRoomEvents: vi
+        .fn()
+        .mockResolvedValueOnce({
+          events: [],
+          startCursor: null,
+          endCursor: null,
+          hasOlder: false,
+          hasNewer: false
+        })
+        .mockReturnValueOnce(newerPage),
+      getRoomEventsAround: vi
+        .fn()
+        .mockResolvedValueOnce({
+          events: [threadMessageEvent('first-target') as never],
+          startCursor: 'tl:first',
+          endCursor: 'tl:first',
+          hasOlder: true,
+          hasNewer: true
+        })
+        .mockResolvedValueOnce({
+          events: [threadMessageEvent('second-target') as never],
+          startCursor: 'tl:second',
+          endCursor: 'tl:second',
+          hasOlder: true,
+          hasNewer: true
+        })
+    });
+    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, timeline);
+    store.setRoom('room-1');
+    await settle();
+
+    const jumpState = new JumpToMessageState();
+    await store.jumpToMessage('first-target', jumpState);
+    const loadingNewer = store.loadNewer(jumpState);
+    await store.jumpToMessage('second-target', jumpState);
+
+    resolveNewer?.({
+      events: [threadMessageEvent('stale-newer') as never],
+      startCursor: 'tl:stale',
+      endCursor: 'tl:stale',
+      hasOlder: false,
+      hasNewer: false
+    });
+    await loadingNewer;
+
+    expect(store.rootEvents.map((event) => event.id)).toEqual(['second-target']);
+    expect(jumpState.scrollToEventId).toBe('second-target');
+    expect(jumpState.isLoadingNewer).toBe(false);
+    store.dispose();
+  });
+
   it('loads room history through the injected timeline API', async () => {
     const fake = new FakeQueryClient();
     const timeline = fakeTimelineAPI({

--- a/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -607,6 +607,26 @@ describe('MessagesStore — room lifecycle ownership', () => {
     store.dispose();
   });
 
+  it('clears jump loading when an in-flight jump is superseded by a loaded target', async () => {
+    const fake = new FakeQueryClient();
+    type AroundPage = Awaited<ReturnType<RoomTimelineAPI['getRoomEventsAround']>>;
+    const unresolvedAround = new Promise<AroundPage>(() => {});
+    const timeline = fakeTimelineAPI({ getRoomEventsAround: vi.fn(() => unresolvedAround) });
+    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, timeline);
+    store.setRoom('room-1');
+    await settle();
+    store.events = [threadMessageEvent('loaded-target') as never];
+
+    const jumpState = new JumpToMessageState();
+    void store.jumpToMessage('missing-target', jumpState);
+    expect(store.isInitialLoading).toBe(true);
+
+    await expect(store.jumpToMessage('loaded-target', jumpState)).resolves.toBe(true);
+    expect(store.isInitialLoading).toBe(false);
+    expect(jumpState.scrollToEventId).toBe('loaded-target');
+    store.dispose();
+  });
+
   it('loads room history through the injected timeline API', async () => {
     const fake = new FakeQueryClient();
     const timeline = fakeTimelineAPI({

--- a/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -627,6 +627,33 @@ describe('MessagesStore — room lifecycle ownership', () => {
     store.dispose();
   });
 
+  it('releases initial-load ownership when a refresh supersedes it', async () => {
+    const fake = new FakeQueryClient();
+    type RoomPage = Awaited<ReturnType<RoomTimelineAPI['getRoomEvents']>>;
+    const unresolvedInitial = new Promise<RoomPage>(() => {});
+    const timeline = fakeTimelineAPI({
+      getRoomEvents: vi
+        .fn()
+        .mockReturnValueOnce(unresolvedInitial)
+        .mockResolvedValueOnce({
+          events: [threadMessageEvent('refreshed') as never],
+          startCursor: 'tl:refreshed',
+          endCursor: 'tl:refreshed',
+          hasOlder: false,
+          hasNewer: false
+        })
+    });
+    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, timeline);
+    store.setRoom('room-1');
+    expect(store.isInitialLoading).toBe(true);
+
+    await store.refreshCurrentWindow();
+
+    expect(store.rootEvents.map((event) => event.id)).toEqual(['refreshed']);
+    expect(store.isInitialLoading).toBe(false);
+    store.dispose();
+  });
+
   it('loads room history through the injected timeline API', async () => {
     const fake = new FakeQueryClient();
     const timeline = fakeTimelineAPI({

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -697,6 +697,8 @@ export class MessagesStore {
 
   jumpToPresent(jumpState: JumpToMessageState): void {
     if (this.scope !== 'room') return;
+    this.#jumpId++;
+    this.#windowId++;
     jumpState.reset();
     this.resetAndFetchLatest();
   }

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -187,6 +187,8 @@ export class MessagesStore {
   /** Increments on every load kickoff. Async callbacks compare against
    *  it via {@link isStale} to discard results from superseded loads. */
   #loadId = 0;
+  #jumpId = 0;
+  #windowId = 0;
 
   constructor(
     serverConnection: ServerConnection,
@@ -374,6 +376,8 @@ export class MessagesStore {
     if (this.scope === 'room' && this.roomId === roomId) return;
 
     this.scope = 'room';
+    this.#jumpId++;
+    this.#windowId++;
     this.roomId = roomId;
     this.threadRootEventId = '';
     this.resetAndFetchLatest();
@@ -389,6 +393,8 @@ export class MessagesStore {
     }
 
     this.scope = 'thread';
+    this.#jumpId++;
+    this.#windowId++;
     this.roomId = roomId;
     this.threadRootEventId = threadRootEventId;
 
@@ -587,16 +593,25 @@ export class MessagesStore {
     if (jumpState.isLoadingNewer || jumpState.hasReachedEnd) return;
     if (!this.newestCursor) return;
 
+    const roomId = this.roomId;
+    const windowId = this.#windowId;
     jumpState.isLoadingNewer = true;
     try {
       const page = await this.roomTimeline.getRoomEvents({
-        roomId: this.roomId,
+        roomId,
         limit: PAGE_SIZE,
         after: this.newestCursor
       });
 
       // User left jumped mode while in flight — abandon the result.
-      if (!jumpState.isJumpedMode) return;
+      if (
+        !jumpState.isJumpedMode ||
+        this.scope !== 'room' ||
+        this.roomId !== roomId ||
+        this.#windowId !== windowId
+      ) {
+        return;
+      }
 
       const newer = unmask(page.events);
       if (newer.length === 0) {
@@ -612,28 +627,32 @@ export class MessagesStore {
     } catch (error) {
       console.error('MessagesStore: loadNewer failed:', error);
     } finally {
-      jumpState.isLoadingNewer = false;
+      if (this.roomId === roomId && this.#windowId === windowId) {
+        jumpState.isLoadingNewer = false;
+      }
     }
   }
 
   async jumpToMessage(eventId: string, jumpState: JumpToMessageState): Promise<boolean> {
     if (this.scope !== 'room') return false;
-    const thisLoad = this.startLoad();
+    const jumpId = ++this.#jumpId;
+    const roomId = this.roomId;
     if (this.events.some((e) => e.id === eventId)) {
-      this.isInitialLoading = false;
       jumpState.scrollToEventId = eventId;
       return true;
     }
 
+    this.#windowId++;
+    jumpState.isLoadingNewer = false;
     this.isInitialLoading = true;
     try {
       const around = await this.roomTimeline.getRoomEventsAround({
-        roomId: this.roomId,
+        roomId,
         eventId,
         limit: PAGE_SIZE
       });
 
-      if (this.isStale(thisLoad)) return false;
+      if (this.#jumpId !== jumpId || this.scope !== 'room' || this.roomId !== roomId) return false;
 
       const { events: rawEvents, hasOlder, hasNewer, startCursor, endCursor } = around;
       const parsed = unmask(rawEvents);
@@ -645,6 +664,9 @@ export class MessagesStore {
         return false;
       }
 
+      // This replacement becomes the authoritative room window. Cancel any
+      // older latest-page load before installing it.
+      this.startLoad();
       for (const event of parsed) this.clearOptimisticVersionForEvent(event.id);
       this.events = [...parsed];
       this.seenIds = new SvelteSet(parsed.map((e) => e.id));
@@ -659,7 +681,7 @@ export class MessagesStore {
       jumpState.scrollToEventId = eventId;
       return true;
     } catch (error) {
-      if (this.isStale(thisLoad)) return false;
+      if (this.#jumpId !== jumpId || this.scope !== 'room' || this.roomId !== roomId) return false;
       console.error('MessagesStore: jumpToMessage failed:', error);
       jumpState.scrollToEventId = null;
       jumpState.isJumpedMode = false;
@@ -667,7 +689,9 @@ export class MessagesStore {
       jumpState.hasOlderMessages = false;
       return false;
     } finally {
-      if (!this.isStale(thisLoad)) this.isInitialLoading = false;
+      if (this.#jumpId === jumpId && this.scope === 'room' && this.roomId === roomId) {
+        this.isInitialLoading = false;
+      }
     }
   }
 

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -189,6 +189,8 @@ export class MessagesStore {
   #loadId = 0;
   #jumpId = 0;
   #windowId = 0;
+  #pendingAuthoritativeLoadId: number | null = null;
+  #pendingJumpId: number | null = null;
 
   constructor(
     serverConnection: ServerConnection,
@@ -378,6 +380,7 @@ export class MessagesStore {
     this.scope = 'room';
     this.#jumpId++;
     this.#windowId++;
+    this.#pendingJumpId = null;
     this.roomId = roomId;
     this.threadRootEventId = '';
     this.resetAndFetchLatest();
@@ -395,6 +398,7 @@ export class MessagesStore {
     this.scope = 'thread';
     this.#jumpId++;
     this.#windowId++;
+    this.#pendingJumpId = null;
     this.roomId = roomId;
     this.threadRootEventId = threadRootEventId;
 
@@ -638,11 +642,16 @@ export class MessagesStore {
     const jumpId = ++this.#jumpId;
     const roomId = this.roomId;
     if (this.events.some((e) => e.id === eventId)) {
+      if (this.#pendingJumpId !== null) {
+        this.#pendingJumpId = null;
+        if (this.#pendingAuthoritativeLoadId === null) this.isInitialLoading = false;
+      }
       jumpState.scrollToEventId = eventId;
       return true;
     }
 
     this.#windowId++;
+    this.#pendingJumpId = jumpId;
     jumpState.isLoadingNewer = false;
     this.isInitialLoading = true;
     try {
@@ -667,6 +676,7 @@ export class MessagesStore {
       // This replacement becomes the authoritative room window. Cancel any
       // older latest-page load before installing it.
       this.startLoad();
+      this.#pendingAuthoritativeLoadId = null;
       for (const event of parsed) this.clearOptimisticVersionForEvent(event.id);
       this.events = [...parsed];
       this.seenIds = new SvelteSet(parsed.map((e) => e.id));
@@ -690,7 +700,8 @@ export class MessagesStore {
       return false;
     } finally {
       if (this.#jumpId === jumpId && this.scope === 'room' && this.roomId === roomId) {
-        this.isInitialLoading = false;
+        this.#pendingJumpId = null;
+        this.isInitialLoading = this.#pendingAuthoritativeLoadId !== null;
       }
     }
   }
@@ -699,6 +710,7 @@ export class MessagesStore {
     if (this.scope !== 'room') return;
     this.#jumpId++;
     this.#windowId++;
+    this.#pendingJumpId = null;
     jumpState.reset();
     this.resetAndFetchLatest();
   }
@@ -1242,6 +1254,7 @@ export class MessagesStore {
 
   private resetAndFetchLatest(): void {
     const thisLoad = this.startLoad();
+    this.#pendingAuthoritativeLoadId = thisLoad;
     this.resetState();
     this.isInitialLoading = true;
     this.fetchLatest(thisLoad);
@@ -1262,11 +1275,13 @@ export class MessagesStore {
           await this.backfillInitialRoomWindow(thisLoad);
         }
         if (this.isStale(thisLoad)) return;
+        this.#pendingAuthoritativeLoadId = null;
         this.isInitialLoading = false;
       })
       .catch((error: unknown) => {
         if (this.isStale(thisLoad)) return;
         console.error('MessagesStore: fetchLatest failed:', error);
+        this.#pendingAuthoritativeLoadId = null;
         this.isInitialLoading = false;
       });
   }

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -616,11 +616,13 @@ export class MessagesStore {
     }
   }
 
-  async jumpToMessage(eventId: string, jumpState: JumpToMessageState): Promise<void> {
-    if (this.scope !== 'room') return;
+  async jumpToMessage(eventId: string, jumpState: JumpToMessageState): Promise<boolean> {
+    if (this.scope !== 'room') return false;
+    const thisLoad = this.startLoad();
     if (this.events.some((e) => e.id === eventId)) {
+      this.isInitialLoading = false;
       jumpState.scrollToEventId = eventId;
-      return;
+      return true;
     }
 
     this.isInitialLoading = true;
@@ -631,8 +633,17 @@ export class MessagesStore {
         limit: PAGE_SIZE
       });
 
+      if (this.isStale(thisLoad)) return false;
+
       const { events: rawEvents, hasOlder, hasNewer, startCursor, endCursor } = around;
       const parsed = unmask(rawEvents);
+      if (!parsed.some((event) => event.id === eventId)) {
+        jumpState.scrollToEventId = null;
+        jumpState.isJumpedMode = false;
+        jumpState.hasReachedEnd = false;
+        jumpState.hasOlderMessages = false;
+        return false;
+      }
 
       for (const event of parsed) this.clearOptimisticVersionForEvent(event.id);
       this.events = [...parsed];
@@ -646,8 +657,17 @@ export class MessagesStore {
       jumpState.hasReachedEnd = !hasNewer;
       jumpState.hasOlderMessages = hasOlder;
       jumpState.scrollToEventId = eventId;
+      return true;
+    } catch (error) {
+      if (this.isStale(thisLoad)) return false;
+      console.error('MessagesStore: jumpToMessage failed:', error);
+      jumpState.scrollToEventId = null;
+      jumpState.isJumpedMode = false;
+      jumpState.hasReachedEnd = false;
+      jumpState.hasOlderMessages = false;
+      return false;
     } finally {
-      this.isInitialLoading = false;
+      if (!this.isStale(thisLoad)) this.isInitialLoading = false;
     }
   }
 

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -357,6 +357,10 @@ export class MessagesStore {
 
   /** Allocate a new load id; pair with {@link isStale} in async callbacks. */
   private startLoad(): number {
+    if (this.#pendingAuthoritativeLoadId !== null) {
+      this.#pendingAuthoritativeLoadId = null;
+      this.isInitialLoading = false;
+    }
     return ++this.#loadId;
   }
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -332,8 +332,25 @@
 
       function complete(landed: boolean) {
         if (completed || scrollAttemptId !== attemptId) return;
-        completed = true;
-        onScrollToEventComplete?.(landed);
+        if (!landed) {
+          completed = true;
+          onScrollToEventComplete?.(false);
+          return;
+        }
+
+        // Check after the successful target scroll has settled. Starting this
+        // timer before the virtual row mounts can re-enable bottom scrolling
+        // based on the previous window's offset.
+        setTimeout(() => {
+          if (completed || !virtualizerHandle || scrollAttemptId !== attemptId) return;
+          const dist =
+            virtualizerHandle.getScrollSize() -
+            virtualizerHandle.getScrollOffset() -
+            virtualizerHandle.getViewportSize();
+          if (dist < 50) setShouldScrollToBottom(true);
+          completed = true;
+          onScrollToEventComplete?.(true);
+        }, 200);
       }
 
       function tryScrollAndHighlight() {
@@ -370,23 +387,11 @@
       }
 
       requestAnimationFrame(tryScrollAndHighlight);
-
-      // After the scroll and virtualizer measurement settle, restore
-      // shouldScrollToBottom if we landed at the bottom (e.g., linking to a
-      // recent message, or content doesn't overflow the viewport). Without this,
-      // the "Jump to Present" button appears spuriously because no scroll event
-      // fires when content is shorter than the viewport.
-      setTimeout(() => {
-        if (!virtualizerHandle || scrollAttemptId !== attemptId) return;
-        const dist =
-          virtualizerHandle.getScrollSize() -
-          virtualizerHandle.getScrollOffset() -
-          virtualizerHandle.getViewportSize();
-        if (dist < 50) {
-          setShouldScrollToBottom(true);
-        }
-      }, 200);
     });
+
+    return () => {
+      if (scrollAttemptId === attemptId) scrollAttemptId++;
+    };
   });
 
   // Scroll container and virtualizer handle

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -475,6 +475,12 @@
   }
 
   function handleJumpToPresentClick() {
+    // The replacement latest window must perform a fresh initial-style bottom
+    // scroll. Virtua otherwise preserves the historical window's offset when
+    // the keyed data is replaced and can leave the user stranded mid-window.
+    setShouldScrollToBottom(true);
+    initialScrollDone = false;
+    scrollUpLock = false;
     onReachedBottom?.();
     onJumpToPresent?.();
   }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -124,6 +124,11 @@
   };
 
   let initialScrollDone = $state(false);
+  let presentScrollRequest = $state(0);
+  let presentScrollSequence = 0;
+  let activePresentScrollRequest = 0;
+  let userScrollIntentAt = 0;
+  const USER_SCROLL_INTENT_MS = 250;
 
   // State for smart scroll behavior (when not alwaysScrollToBottom)
   let shouldScrollToBottom = $state(true);
@@ -252,6 +257,9 @@
   $effect(() => {
     void roomId;
 
+    presentScrollSequence += 1;
+    presentScrollRequest = 0;
+    activePresentScrollRequest = 0;
     initialScrollDone = false;
     setShouldScrollToBottom(true);
     lastSeenNewestId = null;
@@ -481,9 +489,70 @@
     setShouldScrollToBottom(true);
     initialScrollDone = false;
     scrollUpLock = false;
+    presentScrollRequest = ++presentScrollSequence;
     onReachedBottom?.();
     onJumpToPresent?.();
   }
+
+  // Replacing a historical window with the latest window can leave Virtua at
+  // the old numeric offset while it incrementally measures the replacement
+  // rows. Keep the explicit return-to-present request pinned to the bottom
+  // until measurements are stable across consecutive frames. A new request,
+  // room change, or user scroll intent cancels the previous attempt.
+  $effect(() => {
+    const request = presentScrollRequest;
+    void isJumpedMode;
+    void isLoading;
+    void virtualItems.length;
+    void virtualizerHandle;
+
+    if (request === 0 || request === activePresentScrollRequest) return;
+    if (isJumpedMode || isLoading || virtualItems.length === 0 || !virtualizerHandle) return;
+
+    activePresentScrollRequest = request;
+    const requestedRoomId = roomId;
+    const intentAtStart = userScrollIntentAt;
+
+    void (async () => {
+      let settledFrames = 0;
+      let previousScrollSize: number | null = null;
+      let previousViewportSize: number | null = null;
+      for (let frame = 0; frame < 30 && settledFrames < 6; frame++) {
+        await tick();
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+
+        if (
+          request !== presentScrollRequest ||
+          roomId !== requestedRoomId ||
+          isJumpedMode ||
+          userScrollIntentAt !== intentAtStart ||
+          !scrollContainer ||
+          !virtualizerHandle
+        ) {
+          return;
+        }
+
+        startScrollCorrection();
+        safeScrollToIndex(virtualItems.length - 1, { align: 'end' });
+        scrollContainer.scrollTop = scrollContainer.scrollHeight;
+        scrollFader?.refresh();
+
+        const bottomDistance = distanceFromBottom();
+        const scrollSize = virtualizerHandle.getScrollSize();
+        const viewportSize = virtualizerHandle.getViewportSize();
+        const measurementsUnchanged =
+          scrollSize === previousScrollSize && viewportSize === previousViewportSize;
+        settledFrames =
+          bottomDistance !== null && bottomDistance < 10 && measurementsUnchanged
+            ? settledFrames + 1
+            : 0;
+        previousScrollSize = scrollSize;
+        previousViewportSize = viewportSize;
+      }
+
+      initialScrollDone = true;
+    })();
+  });
 
   // Timer-based flag set by programmatic scrolls (auto-scroll effect, scroll-request
   // effect). During the window, handleVirtuaScroll will self-correct if the virtualizer
@@ -515,11 +584,23 @@
   // so virtua's internal scroll adjustments (re-measurement, $fixScrollJump),
   // composer-resize-driven scrollTop writes, and browser scroll clamping during
   // layout shifts never get misread as the user scrolling up.
-  let userScrollIntentAt = 0;
-  const USER_SCROLL_INTENT_MS = 250;
-
   function markUserScrollIntent() {
     userScrollIntentAt = Date.now();
+  }
+
+  function markKeyboardScrollIntent(event: KeyboardEvent) {
+    const target = event.target;
+    if (
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement ||
+      (target instanceof HTMLElement && target.isContentEditable)
+    ) {
+      return;
+    }
+
+    if (['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', ' '].includes(event.key)) {
+      markUserScrollIntent();
+    }
   }
 
   function distanceFromBottom(): number | null {
@@ -948,6 +1029,8 @@
   }
 </script>
 
+<svelte:window onkeydown={markKeyboardScrollIntent} />
+
 <div class="relative flex min-h-0 min-w-0 flex-1 flex-col pb-2">
   <!-- Gradient fade overlay at top -->
   <div
@@ -963,6 +1046,7 @@
     data-testid="messages-container"
     onwheel={markUserScrollIntent}
     ontouchmove={markUserScrollIntent}
+    onpointerdown={markUserScrollIntent}
   >
     <div class="mt-auto">
       {#if !isLoading && virtualItems.length === 0}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -105,7 +105,7 @@
     typingMembers?: RoomMember[];
     // Jump to message
     scrollToEventId?: string | null;
-    onScrollToEventComplete?: () => void;
+    onScrollToEventComplete?: (landed: boolean) => void;
     isJumpedMode?: boolean;
     isLoadingNewer?: boolean;
     hasReachedEnd?: boolean;
@@ -310,27 +310,66 @@
   });
 
   // Scroll to a specific event by ID (for jump-to-message)
+  let scrollAttemptId = 0;
   $effect(() => {
+    const attemptId = ++scrollAttemptId;
     const targetId = scrollToEventId;
     if (!targetId || !virtualizerHandle || virtualItems.length === 0) return;
-
-    // Find the target event's index in virtualItems
-    const targetIdx = virtualItems.findIndex(
-      (item) => item.type === 'event' && item.event.id === targetId
-    );
-    if (targetIdx === -1) return;
+    const targetEventId = targetId;
 
     // Disable auto-scroll so it doesn't race with the jump scroll.
     setShouldScrollToBottom(false);
     // Mark initial scroll as done so pending initial loading state cannot obscure the jump.
     initialScrollDone = true;
 
-    // Wait for render, then scroll and highlight.
-    // After a cache replacement (jump-to-message), virtua needs multiple frames
-    // to measure items and render the target element. Retry the highlight
-    // a few times to handle this latency.
+    // After a cache replacement, virtua can need several frames before the
+    // target item is indexed, measured, and mounted. Retry the full lookup +
+    // scroll path instead of giving up before the target is renderable.
     tick().then(() => {
-      safeScrollToIndex(targetIdx, { align: 'center' });
+      let attempts = 0;
+      const maxAttempts = 60;
+      let completed = false;
+
+      function complete(landed: boolean) {
+        if (completed || scrollAttemptId !== attemptId) return;
+        completed = true;
+        onScrollToEventComplete?.(landed);
+      }
+
+      function tryScrollAndHighlight() {
+        if (scrollAttemptId !== attemptId) return;
+
+        const targetIdx = virtualItems.findIndex(
+          (item) => item.type === 'event' && item.event.id === targetEventId
+        );
+        if (targetIdx !== -1) {
+          safeScrollToIndex(targetIdx, { align: 'center' });
+        }
+
+        // Scope to this EventList's scroll container so the thread pane
+        // highlights within the thread, not in the main room view.
+        const scope = scrollContainer ?? document;
+        const target = scope.querySelector(eventSelector(targetEventId));
+        if (target instanceof HTMLElement) {
+          target.classList.add('highlight-flash');
+          target.addEventListener(
+            'animationend',
+            () => target.classList.remove('highlight-flash'),
+            { once: true }
+          );
+          complete(true);
+          return;
+        }
+
+        if (attempts >= maxAttempts) {
+          complete(false);
+          return;
+        }
+        attempts++;
+        requestAnimationFrame(tryScrollAndHighlight);
+      }
+
+      requestAnimationFrame(tryScrollAndHighlight);
 
       // After the scroll and virtualizer measurement settle, restore
       // shouldScrollToBottom if we landed at the bottom (e.g., linking to a
@@ -338,7 +377,7 @@
       // the "Jump to Present" button appears spuriously because no scroll event
       // fires when content is shorter than the viewport.
       setTimeout(() => {
-        if (!virtualizerHandle) return;
+        if (!virtualizerHandle || scrollAttemptId !== attemptId) return;
         const dist =
           virtualizerHandle.getScrollSize() -
           virtualizerHandle.getScrollOffset() -
@@ -347,30 +386,6 @@
           setShouldScrollToBottom(true);
         }
       }, 200);
-
-      let attempts = 0;
-      function tryHighlight() {
-        // Scope to this EventList's scroll container so the thread pane
-        // highlights within the thread, not in the main room view.
-        const scope = scrollContainer ?? document;
-        const target = scope.querySelector(`[data-event-id="${targetId}"]`);
-        if (target instanceof HTMLElement) {
-          target.classList.add('highlight-flash');
-          target.addEventListener(
-            'animationend',
-            () => target.classList.remove('highlight-flash'),
-            { once: true }
-          );
-          onScrollToEventComplete?.();
-        } else if (attempts < 15) {
-          attempts++;
-          requestAnimationFrame(tryHighlight);
-        } else {
-          // Give up — element never appeared, still signal completion
-          onScrollToEventComplete?.();
-        }
-      }
-      requestAnimationFrame(tryHighlight);
     });
   });
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-svelte';
+import EventListTestHarness from './EventListTestHarness.svelte';
+
+vi.mock('virtua/svelte', async () => {
+  const { default: Virtualizer } = await import('./EventListVirtualizerMock.svelte');
+  return { Virtualizer };
+});
+
+vi.mock('./RoomEvent.svelte', async () => {
+  const { default: RoomEvent } = await import('./EventListRoomEventMock.svelte');
+  return { default: RoomEvent };
+});
+
+vi.mock('$lib/state/activeServer.svelte', () => ({
+  getActiveServer: () => 'server-1'
+}));
+
+vi.mock('$lib/state/server/registry.svelte', () => ({
+  serverRegistry: {
+    getStore: () => ({
+      currentUser: { user: { id: 'test-user' } },
+      serverInfo: { messageEditWindowSeconds: 300 }
+    })
+  }
+}));
+
+vi.mock('$lib/hooks/useTabResumeCallback.svelte', () => ({
+  useTabResumeCallback: () => {}
+}));
+
+vi.mock('$lib/hooks/useMayHaveMissedMessagesCallback.svelte', () => ({
+  useMayHaveMissedMessagesCallback: () => {}
+}));
+
+describe('EventList jump completion', () => {
+  it('signals completion after highlighting a rendered target', async () => {
+    const onComplete = vi.fn();
+    render(EventListTestHarness, {
+      props: {
+        eventIds: ['msg-target'],
+        scrollToEventId: 'msg-target',
+        onComplete
+      }
+    });
+
+    await expect.element(page.getByText('msg-target', { exact: true })).toBeInTheDocument();
+    await expect.element(page.getByTestId('virtualizer-scroll-index')).not.toHaveTextContent('');
+    await vi.waitFor(() => expect(onComplete).toHaveBeenCalledExactlyOnceWith(true));
+  });
+
+  it('signals completion after bounded retries when the target is not rendered', async () => {
+    const onComplete = vi.fn();
+    render(EventListTestHarness, {
+      props: {
+        eventIds: ['msg-other'],
+        scrollToEventId: 'msg-target',
+        onComplete
+      }
+    });
+
+    await vi.waitFor(() => expect(onComplete).toHaveBeenCalledExactlyOnceWith(false));
+  });
+
+  it('cancels completion for a superseded scroll target', async () => {
+    const onComplete = vi.fn();
+    const rendered = render(EventListTestHarness, {
+      props: {
+        eventIds: ['msg-new'],
+        scrollToEventId: 'msg-old',
+        onComplete
+      }
+    });
+
+    await rendered.rerender({
+      eventIds: ['msg-new'],
+      scrollToEventId: 'msg-new',
+      onComplete
+    });
+
+    await expect.element(page.getByText('msg-new', { exact: true })).toBeInTheDocument();
+    await vi.waitFor(() => expect(onComplete).toHaveBeenCalledExactlyOnceWith(true));
+  });
+});

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
@@ -84,7 +84,14 @@ describe('EventList jump completion', () => {
   });
 
   it('cancels a pending scroll attempt when unmounted', async () => {
-    vi.useFakeTimers();
+    const animationFrames: FrameRequestCallback[] = [];
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        animationFrames.push(callback);
+        return animationFrames.length;
+      })
+    );
     const onComplete = vi.fn();
     try {
       const rendered = render(EventListTestHarness, {
@@ -95,12 +102,15 @@ describe('EventList jump completion', () => {
         }
       });
 
+      await vi.waitFor(() => expect(animationFrames.length).toBeGreaterThan(0));
       rendered.unmount();
-      await vi.runAllTimersAsync();
+      for (let index = 0; index < 100 && animationFrames[index]; index++) {
+        animationFrames[index](index * 16);
+      }
 
       expect(onComplete).not.toHaveBeenCalled();
     } finally {
-      vi.useRealTimers();
+      vi.unstubAllGlobals();
     }
   });
 });

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
@@ -82,4 +82,21 @@ describe('EventList jump completion', () => {
     await expect.element(page.getByText('msg-new', { exact: true })).toBeInTheDocument();
     await vi.waitFor(() => expect(onComplete).toHaveBeenCalledExactlyOnceWith(true));
   });
+
+  it('cancels a pending scroll attempt when unmounted', async () => {
+    const onComplete = vi.fn();
+    const rendered = render(EventListTestHarness, {
+      props: {
+        eventIds: ['msg-other'],
+        scrollToEventId: 'msg-never-mounted',
+        onComplete
+      }
+    });
+
+    rendered.unmount();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onComplete).not.toHaveBeenCalled();
+  });
 });

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
@@ -60,7 +60,9 @@ describe('EventList jump completion', () => {
       }
     });
 
-    await vi.waitFor(() => expect(onComplete).toHaveBeenCalledExactlyOnceWith(false));
+    await vi.waitFor(() => expect(onComplete).toHaveBeenCalledExactlyOnceWith(false), {
+      timeout: 2_000
+    });
   });
 
   it('cancels completion for a superseded scroll target', async () => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
@@ -84,19 +84,23 @@ describe('EventList jump completion', () => {
   });
 
   it('cancels a pending scroll attempt when unmounted', async () => {
+    vi.useFakeTimers();
     const onComplete = vi.fn();
-    const rendered = render(EventListTestHarness, {
-      props: {
-        eventIds: ['msg-other'],
-        scrollToEventId: 'msg-never-mounted',
-        onComplete
-      }
-    });
+    try {
+      const rendered = render(EventListTestHarness, {
+        props: {
+          eventIds: ['msg-other'],
+          scrollToEventId: 'msg-never-mounted',
+          onComplete
+        }
+      });
 
-    rendered.unmount();
-    await Promise.resolve();
-    await Promise.resolve();
+      rendered.unmount();
+      await vi.runAllTimersAsync();
 
-    expect(onComplete).not.toHaveBeenCalled();
+      expect(onComplete).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListRoomEventMock.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListRoomEventMock.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import type { RoomEventView } from '$lib/render/types';
+
+  let { event }: { event: RoomEventView } = $props();
+</script>
+
+<div data-event-id={event.id}>{event.id}</div>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListTestHarness.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListTestHarness.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  import { RoomEventKind } from '$lib/render/eventKinds';
+  import type { RoomEventView } from '$lib/render/types';
+  import {
+    createComposerContext,
+    createRoomPermissions,
+    DEFAULT_ROOM_PERMISSIONS
+  } from '$lib/state/room';
+  import { setUserSettings, UserSettingsState } from '$lib/state/userSettings.svelte';
+  import EventList from './EventList.svelte';
+
+  let {
+    eventIds,
+    scrollToEventId,
+    onComplete
+  }: {
+    eventIds: string[];
+    scrollToEventId: string | null;
+    onComplete?: () => void;
+  } = $props();
+
+  createComposerContext({ scroll: true });
+  createRoomPermissions(() => DEFAULT_ROOM_PERMISSIONS);
+  setUserSettings(new UserSettingsState());
+
+  const events = $derived(
+    eventIds.map(
+      (id): RoomEventView => ({
+        id,
+        createdAt: '2026-06-17T10:47:00Z',
+        actorId: 'test-user',
+        actor: null,
+        event: {
+          kind: RoomEventKind.MessagePosted,
+          roomId: 'room-1',
+          body: id,
+          attachments: [],
+          linkPreview: null,
+          reactions: [],
+          updatedAt: null,
+          inReplyTo: null,
+          threadRootEventId: null,
+          echoOfEventId: null,
+          echoFromThreadRootEventId: null,
+          channelEchoEventId: null,
+          replyCount: 0,
+          lastReplyAt: null,
+          threadParticipants: [],
+          viewerIsFollowingThread: true
+        }
+      })
+    )
+  );
+
+  const messageStore = {
+    refreshCurrentWindow: async () => ({
+      hasOlder: false,
+      hasNewer: false,
+      refreshed: false,
+      changed: false
+    })
+  };
+</script>
+
+<EventList
+  roomId="room-1"
+  messageStore={messageStore as never}
+  {events}
+  isLoading={false}
+  {scrollToEventId}
+  onScrollToEventComplete={onComplete}
+/>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListVirtualizerMock.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListVirtualizerMock.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  let {
+    data,
+    children
+  }: {
+    data: unknown[];
+    children: Snippet<[unknown]>;
+  } = $props();
+
+  let renderedIndex = $state<number | null>(null);
+
+  export function scrollToIndex(index: number) {
+    renderedIndex = index;
+  }
+
+  export function getScrollSize() {
+    return 1_000;
+  }
+
+  export function getScrollOffset() {
+    return 400;
+  }
+
+  export function getViewportSize() {
+    return 300;
+  }
+
+  export function findItemIndex() {
+    return 0;
+  }
+</script>
+
+<output data-testid="virtualizer-scroll-index">{renderedIndex ?? ''}</output>
+{#if renderedIndex !== null && data[renderedIndex] !== undefined}
+  {@render children(data[renderedIndex])}
+{/if}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -71,6 +71,7 @@
 
   // Thread navigation functions (URL-driven state)
   let pendingThreadHighlight = $state<string | null>(null);
+  let pendingMainHighlightId = $state<string | null>(null);
   let pendingThreadQuote = $state<{ id: number; text: QuoteInsertionContent } | null>(null);
   let pendingThreadQuoteId = 0;
   let pendingThreadReply = $state<PendingThreadReplyRequest | null>(null);
@@ -290,8 +291,12 @@
     if (threadId) {
       pendingThreadHighlight = eventId;
     } else {
-      tick().then(() => {
-        jumpState.jumpToMessage(eventId);
+      pendingMainHighlightId = eventId;
+      tick().then(async () => {
+        const jumped = await jumpState.jumpToMessage(eventId);
+        if (!jumped && pendingMainHighlightId === eventId) {
+          pendingMainHighlightId = null;
+        }
       });
     }
   }
@@ -537,6 +542,10 @@
           onUnreadMarkerResolved={(eventId) => unread.setUnreadMarkerEventId(eventId)}
           onUnreadMarkerCleared={() => unread.clearUnreadMarker()}
           onOpenThread={openThread}
+          pendingHighlightId={pendingMainHighlightId}
+          onHighlightComplete={() => {
+            pendingMainHighlightId = null;
+          }}
           typingUserIds={typingIndicator.userIds}
           typingMembers={getRoomMembers()}
         />

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -73,6 +73,7 @@
   // Thread navigation functions (URL-driven state)
   let pendingThreadHighlight = $state<string | null>(null);
   let pendingMainHighlightId = $state<string | null>(null);
+  let mainHighlightRequestId = 0;
   let pendingThreadQuote = $state<{ id: number; text: QuoteInsertionContent } | null>(null);
   let pendingThreadQuoteId = 0;
   let pendingThreadReply = $state<PendingThreadReplyRequest | null>(null);
@@ -292,10 +293,15 @@
     if (threadId) {
       pendingThreadHighlight = eventId;
     } else {
+      const requestId = ++mainHighlightRequestId;
       pendingMainHighlightId = eventId;
       tick().then(async () => {
         const jumped = await jumpState.jumpToMessage(eventId);
-        if (!jumped && pendingMainHighlightId === eventId) {
+        if (
+          !jumped &&
+          mainHighlightRequestId === requestId &&
+          pendingMainHighlightId === eventId
+        ) {
           pendingMainHighlightId = null;
           toast.error(m['room.jump_failed']());
         }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -43,6 +43,7 @@
     type RoomSidebarPanel
   } from '$lib/storage/roomSidebarPanel';
   import { serverStorageKey } from '$lib/storage/serverStorage';
+  import { toast } from '$lib/ui/toast';
   import PageTitle from '$lib/ui/PageTitle.svelte';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
   import { isMessagePostedEvent } from '$lib/render/eventKinds';
@@ -296,6 +297,7 @@
         const jumped = await jumpState.jumpToMessage(eventId);
         if (!jumped && pendingMainHighlightId === eventId) {
           pendingMainHighlightId = null;
+          toast.error(m['room.jump_failed']());
         }
       });
     }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -3,6 +3,7 @@ import { render } from 'vitest-browser-svelte';
 import { tick } from 'svelte';
 import { q } from '$lib/test-utils';
 import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
+import { RoomEventKind } from '$lib/render/eventKinds';
 import {
   consumePendingRoomSidebarPanel,
   setPendingRoomSidebarPanel
@@ -56,6 +57,9 @@ const { mocks } = vi.hoisted(() => {
       getAppUiState: vi.fn(),
       activeCallRoomIds: new Set<string>(),
       joinedCallRoomIds: new Set<string>(),
+      pendingHighlightConsume: vi.fn(
+        (_roomId: string, _threadRootId: string | null): string | null => null
+      ),
       notifications: {
         notifications: [] as Array<{ id: string }>,
         dismissDMNotifications: vi.fn().mockResolvedValue({ byRoom: {} }),
@@ -170,7 +174,7 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
       },
       notifications: mocks.notifications,
       pendingHighlights: {
-        consume: vi.fn(() => null)
+        consume: mocks.pendingHighlightConsume
       },
       activeCallRooms: {
         has: vi.fn((roomId: string) => mocks.activeCallRoomIds.has(roomId))
@@ -280,6 +284,33 @@ function emptyTimelinePage() {
   };
 }
 
+function roomMessageEvent(id: string) {
+  return {
+    id,
+    createdAt: '2026-06-17T10:47:00Z',
+    actorId: 'test-user',
+    actor: null,
+    event: {
+      kind: RoomEventKind.MessagePosted,
+      roomId: 'room-1',
+      body: id,
+      attachments: [],
+      linkPreview: null,
+      reactions: [],
+      updatedAt: null,
+      inReplyTo: null,
+      threadRootEventId: null,
+      echoOfEventId: null,
+      echoFromThreadRootEventId: null,
+      channelEchoEventId: null,
+      replyCount: 0,
+      lastReplyAt: null,
+      threadParticipants: [],
+      viewerIsFollowingThread: true
+    }
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   localStorage.clear();
@@ -292,6 +323,8 @@ beforeEach(() => {
   mocks.livekitUrl = null;
   mocks.roomKind = RoomKind.CHANNEL;
   mocks.sidebarNav.isMobile = false;
+  mocks.pendingHighlightConsume.mockReset();
+  mocks.pendingHighlightConsume.mockReturnValue(null);
   appUi = new AppUiState();
   appUi.setActiveRoomScope('server-1', 'room-1');
   mocks.getAppUiState.mockReturnValue(appUi);
@@ -310,6 +343,59 @@ beforeEach(() => {
 });
 
 describe('Room local message echo', () => {
+  it('keeps root message-link highlights pending until the jump completes', async () => {
+    mocks.pendingHighlightConsume.mockReturnValueOnce('msg-linked');
+    mocks.timeline.getRoomEventsAround.mockResolvedValue({
+      events: [roomMessageEvent('msg-before'), roomMessageEvent('msg-linked')],
+      startCursor: 'tl:before',
+      endCursor: 'tl:linked',
+      hasOlder: true,
+      hasNewer: true
+    });
+
+    const { container } = render(Room, { props: { roomId: 'room-1' } });
+
+    await vi.waitFor(() => {
+      expect(mocks.timeline.getRoomEventsAround).toHaveBeenCalledWith({
+        roomId: 'room-1',
+        eventId: 'msg-linked',
+        limit: 50
+      });
+    });
+    await expect
+      .element(q(container, '[data-testid="pending-highlight-id"]'))
+      .toHaveTextContent('msg-linked');
+    await expect
+      .element(q(container, '[data-testid="room-event-ids"]'))
+      .toHaveTextContent('msg-before,msg-linked');
+
+    (q(container, '[data-testid="complete-highlight"]') as HTMLButtonElement).click();
+
+    await expect.element(q(container, '[data-testid="pending-highlight-id"]')).toHaveTextContent('');
+  });
+
+  it('clears root message-link highlights when the jump target cannot be loaded', async () => {
+    mocks.pendingHighlightConsume.mockReturnValueOnce('msg-missing-from-window');
+    mocks.timeline.getRoomEventsAround.mockResolvedValue({
+      events: [roomMessageEvent('msg-other')],
+      startCursor: 'tl:other',
+      endCursor: 'tl:other',
+      hasOlder: false,
+      hasNewer: false
+    });
+
+    const { container } = render(Room, { props: { roomId: 'room-1' } });
+
+    await vi.waitFor(() => {
+      expect(mocks.timeline.getRoomEventsAround).toHaveBeenCalledWith({
+        roomId: 'room-1',
+        eventId: 'msg-missing-from-window',
+        limit: 50
+      });
+    });
+    await expect.element(q(container, '[data-testid="pending-highlight-id"]')).toHaveTextContent('');
+  });
+
   it('inserts a returned main-room post into the same store rendered by the room timeline', async () => {
     const { container } = render(Room, { props: { roomId: 'room-1' } });
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomEventsPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomEventsPane.svelte
@@ -9,6 +9,8 @@
   import type { MessagesStore } from '$lib/state/room';
   import TimelineEventsPane from './TimelineEventsPane.svelte';
   import type { OpenThreadHandler } from './threadOpenOptions';
+  import * as m from '$lib/i18n/messages';
+  import { toast } from '$lib/ui/toast';
 
   type MessageRetractedEventPayload = {
     roomId?: string | null;
@@ -137,9 +139,10 @@
   {typingUserIds}
   {typingMembers}
   scrollToEventId={jumpState?.scrollToEventId ?? null}
-  onScrollToEventComplete={() => {
+  onScrollToEventComplete={(landed) => {
     if (jumpState) jumpState.scrollToEventId = null;
     onHighlightComplete?.();
+    if (!landed) toast.error(m['room.jump_failed']());
   }}
   isJumpedMode={jumpState?.isJumpedMode ?? false}
   isLoadingNewer={jumpState?.isLoadingNewer ?? false}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomEventsPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomEventsPane.svelte
@@ -31,6 +31,8 @@
     onUnreadMarkerResolved,
     onUnreadMarkerCleared,
     onOpenThread,
+    pendingHighlightId = null,
+    onHighlightComplete,
     typingUserIds = [],
     typingMembers = []
   }: {
@@ -41,6 +43,8 @@
     onUnreadMarkerResolved?: (eventId: string) => void;
     onUnreadMarkerCleared?: () => void;
     onOpenThread?: OpenThreadHandler;
+    pendingHighlightId?: string | null;
+    onHighlightComplete?: () => void;
     typingUserIds?: string[];
     typingMembers?: RoomMember[];
   } = $props();
@@ -135,6 +139,7 @@
   scrollToEventId={jumpState?.scrollToEventId ?? null}
   onScrollToEventComplete={() => {
     if (jumpState) jumpState.scrollToEventId = null;
+    onHighlightComplete?.();
   }}
   isJumpedMode={jumpState?.isJumpedMode ?? false}
   isLoadingNewer={jumpState?.isLoadingNewer ?? false}
@@ -144,4 +149,5 @@
   onReachedPresent={handleReachedPresent}
   {onUnreadMarkerCleared}
   onSoftRefresh={handleSoftRefresh}
+  {pendingHighlightId}
 />

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomLocalEchoRoomEventsPaneMock.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomLocalEchoRoomEventsPaneMock.svelte
@@ -1,13 +1,20 @@
 <script lang="ts">
-  import type { MessagesStore } from '$lib/state/room';
+  import { getComposerContext, type MessagesStore } from '$lib/state/room';
 
   let {
     roomId,
-    messageStore
+    messageStore,
+    pendingHighlightId = null,
+    onHighlightComplete
   }: {
     roomId: string;
     messageStore: MessagesStore;
+    pendingHighlightId?: string | null;
+    onHighlightComplete?: () => void;
   } = $props();
+
+  const jumpState = getComposerContext().jumpState;
+  jumpState.setJumpHandler((eventId: string) => messageStore.jumpToMessage(eventId, jumpState));
 
   $effect(() => {
     messageStore.setRoom(roomId);
@@ -17,3 +24,14 @@
 </script>
 
 <output data-testid="room-event-ids">{eventIds}</output>
+<output data-testid="pending-highlight-id">{pendingHighlightId ?? ''}</output>
+<button
+  type="button"
+  data-testid="complete-highlight"
+  onclick={() => {
+    jumpState.scrollToEventId = null;
+    onHighlightComplete?.();
+  }}
+>
+  complete highlight
+</button>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -120,6 +120,7 @@
   const jumpState = composerContext.jumpState;
   jumpState.setJumpHandler(async (eventId: string) => {
     jumpState.scrollToEventId = eventId;
+    return true;
   });
 
   let canPost = $derived(canPostInThread);

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/TimelineEventsPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/TimelineEventsPane.svelte
@@ -69,7 +69,7 @@
     typingUserIds?: string[];
     typingMembers?: RoomMember[];
     scrollToEventId?: string | null;
-    onScrollToEventComplete?: () => void;
+    onScrollToEventComplete?: (landed: boolean) => void;
     isJumpedMode?: boolean;
     isLoadingNewer?: boolean;
     hasReachedEnd?: boolean;


### PR DESCRIPTION
## Summary

- keep linked-message highlights pending until their room window and virtualized row have landed
- discard stale jump, pagination, room-change, and return-to-present responses using explicit request/window ownership
- retry virtualized target mounting with teardown-safe completion and localized failure feedback
- add focused store and browser-component coverage for success, failure, supersession, loading ownership, and unmount behavior

## Verification

- `mise x -- pnpm --filter chatto-frontend exec vitest --run 'src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts' 'src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts' src/lib/state/room/messages.svelte.spec.ts`
- `mise lint-frontend`
- Svelte autofixer analysis on all touched Svelte components (no issues)

Closes #1420.
