### PR TITLE
perf(frontend): speed up large room member loading

### DIFF
--- a/apps/frontend/src/lib/components/QuickSwitcher.svelte
+++ b/apps/frontend/src/lib/components/QuickSwitcher.svelte
@@ -11,19 +11,11 @@
   import { getGradientForName } from '$lib/utils/gradients';
   import { recentQuickSwitcher } from '$lib/state/recentQuickSwitcher.svelte';
   import { quickSwitcher } from '$lib/state/globals.svelte';
-  import { ROOM_MEMBERS_PAGE_SIZE } from '$lib/state/room/members.svelte';
+  import { RoomType } from '$lib/render/types';
   import * as m from '$lib/i18n/messages';
   import { toast } from '$lib/ui/toast';
   import { createRoomCommandAPI } from '$lib/api-client/rooms';
-  import {
-    createMemberDirectoryAPI,
-    type DirectoryMember
-  } from '$lib/api-client/memberDirectory';
-  import {
-    createRoomDirectoryAPI,
-    RoomDirectoryScope,
-    RoomKind
-  } from '$lib/api-client/roomDirectory';
+  import { createMemberDirectoryAPI, type DirectoryMember } from '$lib/api-client/memberDirectory';
 
   type ServerLogo = { name: string; logoUrl?: string | null };
   type AvatarUser = Pick<DirectoryMember, 'id' | 'login' | 'displayName' | 'deleted'> & {
@@ -59,82 +51,64 @@
 
   // --- Data loading ---
 
-  async function loadAll() {
+  function loadAll() {
     loading = true;
     const instances = serverRegistry.servers;
     const multiInstance = instances.length > 1;
     const items: ResultItem[] = [];
 
-    await Promise.allSettled(
-      instances.map(async (instance) => {
-        const serverConnection = serverConnectionManager.getClient(instance.id);
-        const store = serverRegistry.tryGetStore(instance.id);
-        const serverName = store?.serverInfo.name || instance.name || getHostname(instance.url);
-        const serverLabel = multiInstance ? serverName : '';
-        const currentUserId = store?.currentUser.user?.id ?? undefined;
-        const directory = createRoomDirectoryAPI({
-          serverId: instance.id,
-          baseUrl: serverConnection.connectBaseUrl,
-          bearerToken: serverConnection.bearerToken
-        });
-        const members = createMemberDirectoryAPI({
-          baseUrl: serverConnection.connectBaseUrl,
-          bearerToken: serverConnection.bearerToken
-        });
+    for (const instance of instances) {
+      const store = serverRegistry.tryGetStore(instance.id);
+      const serverName = store?.serverInfo.name || instance.name || getHostname(instance.url);
+      const serverLabel = multiInstance ? serverName : '';
+      const currentUserId = store?.currentUser.user?.id ?? undefined;
+      const logo: ServerLogo = {
+        name: serverName,
+        logoUrl: store?.serverInfo.iconUrl ?? null
+      };
 
-        const logo: ServerLogo = {
-          name: serverName,
-          logoUrl: store?.serverInfo.iconUrl ?? null
-        };
+      items.push({
+        kind: 'server',
+        id: `server-${instance.id}`,
+        label: logo.name,
+        detail: '',
+        serverId: instance.id,
+        serverName: logo.name,
+        serverLogo: logo,
+        href: resolve('/chat/[serverId]/overview', { serverId: serverIdToSegment(instance.id) }),
+        score: 0
+      });
 
+      for (const room of store?.rooms.rooms ?? []) {
+        if (room.type === RoomType.Dm) {
+          const participants = room.members.map(avatarUser);
+          items.push({
+            kind: 'dm',
+            id: room.id,
+            label: dmLabel(participants, currentUserId),
+            detail: serverLabel,
+            serverId: instance.id,
+            serverName,
+            participants,
+            currentUserId,
+            score: 0
+          });
+          continue;
+        }
+
+        if (!room.viewerIsMember) continue;
         items.push({
-          kind: 'server',
-          id: `server-${instance.id}`,
-          label: logo.name,
-          detail: '',
+          kind: 'room',
+          id: room.id,
+          label: room.name,
+          detail: serverLabel || logo.name,
           serverId: instance.id,
-          serverName: logo.name,
+          serverName,
           serverLogo: logo,
-          href: resolve('/chat/[serverId]/overview', { serverId: serverIdToSegment(instance.id) }),
           score: 0
         });
-
-        const rooms = await directory.listRooms(RoomDirectoryScope.ALL);
-        await Promise.all(
-          rooms.map(async (room) => {
-            if (room.kind === RoomKind.DM) {
-              const participants = (
-                await members.listRoomMembers(room.id, '', ROOM_MEMBERS_PAGE_SIZE, 0)
-              ).members.map(avatarUser);
-              items.push({
-                kind: 'dm',
-                id: room.id,
-                label: dmLabel(participants, currentUserId),
-                detail: serverLabel,
-                serverId: instance.id,
-                serverName,
-                participants,
-                currentUserId,
-                score: 0
-              });
-              return;
-            }
-
-            if (!room.isMember) return;
-            items.push({
-              kind: 'room',
-              id: room.id,
-              label: room.name,
-              detail: serverLabel || logo.name,
-              serverId: instance.id,
-              serverName,
-              serverLogo: logo,
-              score: 0
-            });
-          })
-        );
-      })
-    );
+      }
+    }
 
     items.push({
       kind: 'destination',
@@ -327,8 +301,6 @@
         userItems = [];
         scheduleUserSearch('');
         if (!node.open) node.showModal();
-        requestAnimationFrame(() => inputEl?.focus());
-        loadAll();
       } else {
         if (userSearchTimer) clearTimeout(userSearchTimer);
         userItems = [];
@@ -339,8 +311,24 @@
     });
   }
 
+  // Rebuild from the canonical per-server room stores when the switcher opens or a store refreshes.
+  $effect(() => {
+    if (!quickSwitcher.visible) return;
+    void serverRegistry.servers;
+    for (const instance of serverRegistry.servers) {
+      const store = serverRegistry.tryGetStore(instance.id);
+      void store?.rooms.rooms;
+      void store?.rooms.isInitialLoading;
+    }
+    untrack(loadAll);
+  });
+
   function registerInput(node: HTMLInputElement) {
     inputEl = node;
+    queueMicrotask(() => node.focus());
+    return () => {
+      if (inputEl === node) inputEl = undefined;
+    };
   }
 
   // --- Navigation ---

--- a/apps/frontend/src/lib/components/QuickSwitcher.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/QuickSwitcher.svelte.spec.ts
@@ -2,7 +2,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { render } from 'vitest-browser-svelte';
 import { flushSync } from 'svelte';
 import { q } from '$lib/test-utils';
-import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
+import { RoomType } from '$lib/render/types';
 import { quickSwitcher } from '$lib/state/globals.svelte';
 
 const mocks = vi.hoisted(() => ({
@@ -39,6 +39,16 @@ const mocks = vi.hoisted(() => ({
       user: {
         id: 'user-current'
       }
+    },
+    rooms: {
+      rooms: [] as Array<{
+        id: string;
+        name: string;
+        type: RoomType;
+        viewerIsMember: boolean;
+        members: User[];
+      }>,
+      isInitialLoading: false
     }
   }
 }));
@@ -155,34 +165,29 @@ let originalClose: typeof HTMLDialogElement.prototype.close;
 
 function installQueryMocks() {
   mocks.startDM.mockResolvedValue({ id: 'dm-new' });
-  mocks.listRooms.mockResolvedValue([
+  mocks.store.rooms.rooms = [
     {
       id: 'room-general',
       name: 'general',
-      kind: RoomKind.CHANNEL,
-      isMember: true,
-      hasUnread: false
+      type: RoomType.Channel,
+      viewerIsMember: true,
+      members: []
     },
     {
       id: 'room-xylophone',
       name: 'xylophone-chat',
-      kind: RoomKind.CHANNEL,
-      isMember: true,
-      hasUnread: false
+      type: RoomType.Channel,
+      viewerIsMember: true,
+      members: []
     },
     {
       id: 'dm-existing',
       name: '',
-      kind: RoomKind.DM,
-      isMember: true,
-      hasUnread: false
+      type: RoomType.Dm,
+      viewerIsMember: true,
+      members: [currentUser, teammate]
     }
-  ]);
-  mocks.listRoomMembers.mockImplementation(async (roomId: string) => ({
-    members: roomId === 'dm-existing' ? [currentUser, teammate] : [],
-    totalCount: roomId === 'dm-existing' ? 2 : 0,
-    hasMore: false
-  }));
+  ];
   mocks.listUsers.mockImplementation(async (search: string) => ({
     members:
       search === 'river-login' ? [user('user-river-login', 'river-login', 'River Login')] : [],
@@ -287,6 +292,8 @@ describe('QuickSwitcher', () => {
     expect(container.textContent).toContain('general');
     expect(container.textContent).toContain('River Teammate');
     expect(input(container)).toBe(document.activeElement);
+    expect(mocks.listRooms).not.toHaveBeenCalled();
+    expect(mocks.listRoomMembers).not.toHaveBeenCalled();
   });
 
   it('fuzzy-filters rooms and shows no results for misses', async () => {

--- a/apps/frontend/src/lib/state/room/members.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/members.svelte.spec.ts
@@ -143,15 +143,46 @@ describe('RoomMembersStore', () => {
     const loading = store.loadInitial();
     await vi.waitFor(() => expect(store.hasFirstPage).toBe(true));
 
-    await expect(store.searchMembers('cor')).resolves.toMatchObject([{ id: 'u3' }]);
+    await store.setSearch('cor');
     expect(fakeAPI.listRoomMembers).toHaveBeenNthCalledWith(3, 'room-1', 'cor', 10, 0);
-    expect(store.members.map((member) => member.login)).toEqual(['alice', 'cora']);
+    expect(store.filteredMembers.map((member) => member.login)).toEqual(['cora']);
+    expect(store.members.map((member) => member.login)).toEqual(['alice']);
 
     backgroundPage.resolve(pageResult([user('u2', 'boris'), user('u3', 'cora')], false, 3));
     await loading;
 
     expect(store.members.map((member) => member.login)).toEqual(['alice', 'boris', 'cora']);
     expect(new Set(store.members.map((member) => member.id)).size).toBe(3);
+  });
+
+  it('discards an in-flight search when a same-room refresh starts', async () => {
+    const backgroundPage = deferred<MemberDirectoryPage>();
+    const staleSearch = deferred<MemberDirectoryPage>();
+    const refreshedPage = deferred<MemberDirectoryPage>();
+    const fakeAPI = new FakeMemberDirectoryAPI([
+      pageResult([user('u1', 'alice')], true, 2),
+      backgroundPage.promise,
+      staleSearch.promise,
+      refreshedPage.promise
+    ]);
+    const store = new RoomMembersStore(fakeAPI);
+
+    store.setRoom('room-1');
+    const initialLoad = store.loadInitial();
+    await vi.waitFor(() => expect(store.hasFirstPage).toBe(true));
+
+    const searching = store.searchMembers('departed');
+    const refreshing = store.refresh();
+    refreshedPage.resolve(pageResult([user('u1', 'alice')], false, 1));
+    await refreshing;
+
+    staleSearch.resolve(pageResult([user('u2', 'departed')], false, 1));
+    await expect(searching).resolves.toEqual([]);
+    expect(store.members.map((member) => member.login)).toEqual(['alice']);
+
+    backgroundPage.resolve(pageResult([user('u2', 'departed')], false, 2));
+    await initialLoad;
+    expect(store.members.map((member) => member.login)).toEqual(['alice']);
   });
 
   it('records failed initial loads to avoid immediate ensureLoaded retries', async () => {

--- a/apps/frontend/src/lib/state/room/members.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/members.svelte.spec.ts
@@ -73,15 +73,26 @@ describe('RoomMembersStore', () => {
     expect(ROOM_MEMBERS_PAGE_SIZE).toBe(250);
   });
 
-  it('eagerly loads every room member page into the canonical member list', async () => {
+  it('publishes the first page before hydrating the canonical member list in the background', async () => {
+    const backgroundPage = deferred<MemberDirectoryPage>();
     const fakeAPI = new FakeMemberDirectoryAPI([
       pageResult([user('u1', 'alice')], true, 3),
-      pageResult([user('u2', 'boris'), user('u3', 'cora')], false, 3)
+      backgroundPage.promise
     ]);
     const store = new RoomMembersStore(fakeAPI);
 
     store.setRoom('room-1');
-    await store.loadInitial();
+    const loading = store.loadInitial();
+
+    await vi.waitFor(() => {
+      expect(store.hasFirstPage).toBe(true);
+      expect(store.isInitialLoading).toBe(false);
+      expect(store.isBackgroundLoading).toBe(true);
+      expect(store.members.map((member) => member.login)).toEqual(['alice']);
+    });
+
+    backgroundPage.resolve(pageResult([user('u2', 'boris'), user('u3', 'cora')], false, 3));
+    await loading;
 
     expect(fakeAPI.listRoomMembers).toHaveBeenNthCalledWith(
       1,
@@ -101,6 +112,8 @@ describe('RoomMembersStore', () => {
     expect(store.filteredMembers.map((member) => member.login)).toEqual(['alice', 'boris', 'cora']);
     expect(store.totalCount).toBe(3);
     expect(store.hasLoaded).toBe(true);
+    expect(store.hasLoadedAll).toBe(true);
+    expect(store.isBackgroundLoading).toBe(false);
   });
 
   it('filters loaded members locally without changing the canonical count', async () => {
@@ -117,7 +130,31 @@ describe('RoomMembersStore', () => {
     expect(store.totalCount).toBe(3);
   });
 
-  it('marks failed initial loads as loaded to avoid immediate ensureLoaded retries', async () => {
+  it('searches the server for an unhydrated member and merges the result', async () => {
+    const backgroundPage = deferred<MemberDirectoryPage>();
+    const fakeAPI = new FakeMemberDirectoryAPI([
+      pageResult([user('u1', 'alice')], true, 3),
+      backgroundPage.promise,
+      pageResult([user('u3', 'cora')], false, 1)
+    ]);
+    const store = new RoomMembersStore(fakeAPI);
+
+    store.setRoom('room-1');
+    const loading = store.loadInitial();
+    await vi.waitFor(() => expect(store.hasFirstPage).toBe(true));
+
+    await expect(store.searchMembers('cor')).resolves.toMatchObject([{ id: 'u3' }]);
+    expect(fakeAPI.listRoomMembers).toHaveBeenNthCalledWith(3, 'room-1', 'cor', 10, 0);
+    expect(store.members.map((member) => member.login)).toEqual(['alice', 'cora']);
+
+    backgroundPage.resolve(pageResult([user('u2', 'boris'), user('u3', 'cora')], false, 3));
+    await loading;
+
+    expect(store.members.map((member) => member.login)).toEqual(['alice', 'boris', 'cora']);
+    expect(new Set(store.members.map((member) => member.id)).size).toBe(3);
+  });
+
+  it('records failed initial loads to avoid immediate ensureLoaded retries', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const fakeAPI = new FakeMemberDirectoryAPI([Promise.reject(new Error('network failed'))]);
     const store = new RoomMembersStore(fakeAPI);
@@ -127,7 +164,7 @@ describe('RoomMembersStore', () => {
       store.ensureLoaded();
 
       await vi.waitFor(() => {
-        expect(store.hasLoaded).toBe(true);
+        expect(store.loadError).toBe('network failed');
         expect(store.isInitialLoading).toBe(false);
       });
 
@@ -139,7 +176,7 @@ describe('RoomMembersStore', () => {
     }
   });
 
-  it('does not expose partial members when a later eager page fails', async () => {
+  it('keeps the published first page when background hydration fails', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const fakeAPI = new FakeMemberDirectoryAPI([
       pageResult([user('u1', 'alice')], true, 3),
@@ -151,11 +188,11 @@ describe('RoomMembersStore', () => {
       store.setRoom('room-1');
       await store.loadInitial();
 
-      expect(store.members).toEqual([]);
-      expect(store.totalCount).toBe(0);
-      expect(store.hasLoaded).toBe(true);
-      expect(store.filteredMembers).toEqual([]);
-      expect(await store.searchMembers('alice')).toEqual([]);
+      expect(store.members.map((member) => member.login)).toEqual(['alice']);
+      expect(store.totalCount).toBe(3);
+      expect(store.hasFirstPage).toBe(true);
+      expect(store.hasLoadedAll).toBe(false);
+      expect(store.loadError).toBe('network failed');
       expect(fakeAPI.listRoomMembers).toHaveBeenCalledTimes(2);
     } finally {
       consoleErrorSpy.mockRestore();
@@ -236,7 +273,7 @@ describe('RoomMembersStore', () => {
     });
   });
 
-  it('preserves the previous complete snapshot when refresh fails mid-load', async () => {
+  it('publishes a refreshed first page when later refresh hydration fails', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const fakeAPI = new FakeMemberDirectoryAPI([
       pageResult([user('u1', 'initial')], false, 1),
@@ -250,9 +287,10 @@ describe('RoomMembersStore', () => {
       await store.loadInitial();
       await store.refresh();
 
-      expect(store.members.map((member) => member.login)).toEqual(['initial']);
-      expect(store.totalCount).toBe(1);
-      expect(store.hasLoaded).toBe(true);
+      expect(store.members.map((member) => member.login)).toEqual(['refresh-a']);
+      expect(store.totalCount).toBe(3);
+      expect(store.hasLoadedAll).toBe(false);
+      expect(store.loadError).toBe('network failed');
     } finally {
       consoleErrorSpy.mockRestore();
     }

--- a/apps/frontend/src/lib/state/room/members.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/members.svelte.spec.ts
@@ -144,7 +144,13 @@ describe('RoomMembersStore', () => {
     await vi.waitFor(() => expect(store.hasFirstPage).toBe(true));
 
     await store.setSearch('cor');
-    expect(fakeAPI.listRoomMembers).toHaveBeenNthCalledWith(3, 'room-1', 'cor', 10, 0);
+    expect(fakeAPI.listRoomMembers).toHaveBeenNthCalledWith(
+      3,
+      'room-1',
+      'cor',
+      ROOM_MEMBERS_PAGE_SIZE,
+      0
+    );
     expect(store.filteredMembers.map((member) => member.login)).toEqual(['cora']);
     expect(store.members.map((member) => member.login)).toEqual(['alice']);
 
@@ -183,6 +189,42 @@ describe('RoomMembersStore', () => {
     backgroundPage.resolve(pageResult([user('u2', 'departed')], false, 2));
     await initialLoad;
     expect(store.members.map((member) => member.login)).toEqual(['alice']);
+  });
+
+  it('pages through every sidebar search match while hydration is incomplete', async () => {
+    const backgroundPage = deferred<MemberDirectoryPage>();
+    const fakeAPI = new FakeMemberDirectoryAPI([
+      pageResult([user('u1', 'alice')], true, 3),
+      backgroundPage.promise,
+      pageResult([user('u2', 'match-a')], true, 2),
+      pageResult([user('u3', 'match-b')], false, 2)
+    ]);
+    const store = new RoomMembersStore(fakeAPI);
+
+    store.setRoom('room-1');
+    const loading = store.loadInitial();
+    await vi.waitFor(() => expect(store.hasFirstPage).toBe(true));
+
+    await store.setSearch('match');
+
+    expect(fakeAPI.listRoomMembers).toHaveBeenNthCalledWith(
+      3,
+      'room-1',
+      'match',
+      ROOM_MEMBERS_PAGE_SIZE,
+      0
+    );
+    expect(fakeAPI.listRoomMembers).toHaveBeenNthCalledWith(
+      4,
+      'room-1',
+      'match',
+      ROOM_MEMBERS_PAGE_SIZE,
+      1
+    );
+    expect(store.filteredMembers.map((member) => member.login)).toEqual(['match-a', 'match-b']);
+
+    backgroundPage.resolve(pageResult([user('u2', 'match-a'), user('u3', 'match-b')], false, 3));
+    await loading;
   });
 
   it('records failed initial loads to avoid immediate ensureLoaded retries', async () => {

--- a/apps/frontend/src/lib/state/room/members.svelte.ts
+++ b/apps/frontend/src/lib/state/room/members.svelte.ts
@@ -38,6 +38,11 @@ export type RoomMembersPage = {
   hasMore: boolean;
 };
 
+type MemberSearchCacheEntry = {
+  members: RoomMember[];
+  complete: boolean;
+};
+
 function memberMatchesSearch(member: RoomMember, search: string): boolean {
   const query = search.trim().toLowerCase();
   if (!query) return true;
@@ -83,7 +88,7 @@ export class RoomMembersStore {
   private readonly api: MemberDirectoryAPI | null;
   private roomId = '';
   #loadId = 0;
-  #searchCache = new SvelteMap<string, RoomMember[]>();
+  #searchCache = new SvelteMap<string, MemberSearchCacheEntry>();
 
   constructor(source?: ServerConnection | MemberDirectoryAPI | null) {
     if (!source) {
@@ -108,7 +113,7 @@ export class RoomMembersStore {
     const query = this.activeSearch.trim().toLowerCase();
     if (query && !this.hasLoadedAll) {
       const searched = this.#searchCache.get(query);
-      if (searched) return searched;
+      if (searched) return searched.members;
     }
     return this.filterLoadedMembers(this.activeSearch);
   }
@@ -136,7 +141,7 @@ export class RoomMembersStore {
     if (nextSearch === this.activeSearch) return;
     this.activeSearch = nextSearch;
     if (nextSearch && !this.hasLoadedAll) {
-      await this.searchMembers(nextSearch);
+      await this.searchAllMembers(nextSearch);
     }
   }
 
@@ -193,7 +198,9 @@ export class RoomMembersStore {
     const roomId = this.roomId;
     const loadId = this.#loadId;
     const cached = this.#searchCache.get(normalizedSearch.toLowerCase());
-    if (cached) return cached.slice(0, limit);
+    if (cached && (cached.complete || cached.members.length >= limit)) {
+      return cached.members.slice(0, limit);
+    }
     let page: RoomMembersPage;
     try {
       page = await this.fetchPage(0, limit, normalizedSearch);
@@ -202,8 +209,40 @@ export class RoomMembersStore {
       return this.filteredLoadedMembers(normalizedSearch, limit);
     }
     if (roomId !== this.roomId || loadId !== this.#loadId) return [];
-    this.#searchCache.set(normalizedSearch.toLowerCase(), page.members);
+    this.#searchCache.set(normalizedSearch.toLowerCase(), {
+      members: page.members,
+      complete: !page.hasMore
+    });
     return page.members.slice(0, limit);
+  }
+
+  private async searchAllMembers(search: string): Promise<void> {
+    const query = search.trim().toLowerCase();
+    const loadId = this.#loadId;
+    let members: RoomMember[] = [];
+    let offset = 0;
+    let hasMore = true;
+
+    while (hasMore) {
+      let page: RoomMembersPage;
+      try {
+        page = await this.fetchPage(offset, ROOM_MEMBERS_PAGE_SIZE, search);
+      } catch (error) {
+        console.error('Failed to search room members:', error);
+        return;
+      }
+      if (
+        loadId !== this.#loadId ||
+        query !== this.activeSearch.trim().toLowerCase() ||
+        !this.roomId
+      )
+        return;
+
+      members = appendPageMembers(members, page.members);
+      hasMore = page.hasMore && page.members.length > 0;
+      offset += page.members.length;
+      this.#searchCache.set(query, { members, complete: !hasMore });
+    }
   }
 
   ingestServerEvent(serverEvent: EventEnvelope): void {

--- a/apps/frontend/src/lib/state/room/members.svelte.ts
+++ b/apps/frontend/src/lib/state/room/members.svelte.ts
@@ -62,11 +62,10 @@ function eventRoomId(eventData: EventEnvelope['event']): string | null {
 /**
  * Room member store for the current room.
  *
- * The store uses the paginated Connect member directory API internally, but room initialization
- * eagerly fills `members` with the complete room member list. Message rendering,
- * mention highlighting, popovers, and moderation checks all treat this as
- * canonical room context, not as a lazy sidebar page. Partial page results are
- * never exposed as canonical state.
+ * The store publishes the first paginated Connect response immediately, then fills `members` with
+ * the remaining pages in the background. `hasFirstPage` marks interactive readiness while
+ * `hasLoadedAll` marks complete membership for mention rendering and other exhaustive consumers.
+ * Searches use a separate cache until their matching directory page enters canonical order.
  */
 export class RoomMembersStore {
   members = $state.raw<RoomMember[]>([]);
@@ -84,6 +83,7 @@ export class RoomMembersStore {
   private readonly api: MemberDirectoryAPI | null;
   private roomId = '';
   #loadId = 0;
+  #searchCache = new SvelteMap<string, RoomMember[]>();
 
   constructor(source?: ServerConnection | MemberDirectoryAPI | null) {
     if (!source) {
@@ -105,6 +105,11 @@ export class RoomMembersStore {
   }
 
   get filteredMembers(): RoomMember[] {
+    const query = this.activeSearch.trim().toLowerCase();
+    if (query && !this.hasLoadedAll) {
+      const searched = this.#searchCache.get(query);
+      if (searched) return searched;
+    }
     return this.filterLoadedMembers(this.activeSearch);
   }
 
@@ -163,6 +168,7 @@ export class RoomMembersStore {
     this.isBackgroundLoading = false;
     this.hasLoadedAll = false;
     this.loadError = null;
+    this.#searchCache.clear();
     try {
       await this.loadPages(loadId);
     } catch (error) {
@@ -185,6 +191,9 @@ export class RoomMembersStore {
     }
 
     const roomId = this.roomId;
+    const loadId = this.#loadId;
+    const cached = this.#searchCache.get(normalizedSearch.toLowerCase());
+    if (cached) return cached.slice(0, limit);
     let page: RoomMembersPage;
     try {
       page = await this.fetchPage(0, limit, normalizedSearch);
@@ -192,8 +201,8 @@ export class RoomMembersStore {
       console.error('Failed to search room members:', error);
       return this.filteredLoadedMembers(normalizedSearch, limit);
     }
-    if (roomId !== this.roomId) return [];
-    this.members = mergeMembersSorted(this.members, page.members);
+    if (roomId !== this.roomId || loadId !== this.#loadId) return [];
+    this.#searchCache.set(normalizedSearch.toLowerCase(), page.members);
     return page.members.slice(0, limit);
   }
 
@@ -274,37 +283,16 @@ export class RoomMembersStore {
     this.loadError = null;
     this.searchInput = '';
     this.activeSearch = '';
+    this.#searchCache.clear();
     this.livePresence.clear();
     this.presenceVersion = 0;
   }
-}
-
-function appendUniqueMembers(current: RoomMember[], incoming: RoomMember[]): RoomMember[] {
-  if (incoming.length === 0) return current;
-
-  const byId = new SvelteMap(current.map((member) => [member.id, member]));
-  for (const member of incoming) byId.set(member.id, member);
-  return [...byId.values()];
 }
 
 function appendPageMembers(current: RoomMember[], incoming: RoomMember[]): RoomMember[] {
   if (incoming.length === 0) return current;
   const incomingIds = new Set(incoming.map((member) => member.id));
   return [...current.filter((member) => !incomingIds.has(member.id)), ...incoming];
-}
-
-function mergeMembersSorted(current: RoomMember[], incoming: RoomMember[]): RoomMember[] {
-  return appendUniqueMembers(current, incoming).sort(compareMembers);
-}
-
-function compareMembers(left: RoomMember, right: RoomMember): number {
-  const leftDisplayName = left.displayName.toLowerCase();
-  const rightDisplayName = right.displayName.toLowerCase();
-  if (leftDisplayName < rightDisplayName) return -1;
-  if (leftDisplayName > rightDisplayName) return 1;
-  const leftLogin = left.login.toLowerCase();
-  const rightLogin = right.login.toLowerCase();
-  return leftLogin < rightLogin ? -1 : leftLogin > rightLogin ? 1 : 0;
 }
 
 const [getMembersStoreContext, setMembersStoreContext] = createContext<RoomMembersStore>();

--- a/apps/frontend/src/lib/state/room/members.svelte.ts
+++ b/apps/frontend/src/lib/state/room/members.svelte.ts
@@ -71,8 +71,11 @@ function eventRoomId(eventData: EventEnvelope['event']): string | null {
 export class RoomMembersStore {
   members = $state.raw<RoomMember[]>([]);
   totalCount = $state(0);
-  hasLoaded = $state(false);
+  hasFirstPage = $state(false);
+  hasLoadedAll = $state(false);
   isInitialLoading = $state(false);
+  isBackgroundLoading = $state(false);
+  loadError = $state<string | null>(null);
   searchInput = $state('');
   activeSearch = $state('');
   livePresence = new SvelteMap<string, PresenceStatus>();
@@ -105,8 +108,20 @@ export class RoomMembersStore {
     return this.filterLoadedMembers(this.activeSearch);
   }
 
+  /** Compatibility alias for consumers that only care whether hydration is complete. */
+  get hasLoaded(): boolean {
+    return this.hasLoadedAll;
+  }
+
   ensureLoaded(): void {
-    if (!this.roomId || this.isInitialLoading || this.hasLoaded) return;
+    if (
+      !this.roomId ||
+      this.isInitialLoading ||
+      this.isBackgroundLoading ||
+      this.hasLoadedAll ||
+      this.loadError
+    )
+      return;
     void this.loadInitial();
   }
 
@@ -115,26 +130,28 @@ export class RoomMembersStore {
     this.searchInput = search;
     if (nextSearch === this.activeSearch) return;
     this.activeSearch = nextSearch;
+    if (nextSearch && !this.hasLoadedAll) {
+      await this.searchMembers(nextSearch);
+    }
   }
 
   async loadInitial(): Promise<void> {
     if (!this.roomId || !this.api) return;
     const loadId = ++this.#loadId;
     this.isInitialLoading = true;
+    this.isBackgroundLoading = false;
+    this.loadError = null;
     try {
-      const page = await this.fetchAllPages();
-      if (loadId !== this.#loadId) return;
-      this.members = page.members;
-      this.totalCount = page.totalCount;
-      this.hasLoaded = true;
+      await this.loadPages(loadId);
     } catch (error) {
       if (loadId === this.#loadId) {
+        this.loadError = error instanceof Error ? error.message : 'Failed to load room members';
         console.error('Failed to load room members:', error);
       }
     } finally {
       if (loadId === this.#loadId) {
-        this.hasLoaded = true;
         this.isInitialLoading = false;
+        this.isBackgroundLoading = false;
       }
     }
   }
@@ -143,21 +160,41 @@ export class RoomMembersStore {
     if (!this.roomId || !this.api) return;
     const loadId = ++this.#loadId;
     this.isInitialLoading = false;
+    this.isBackgroundLoading = false;
+    this.hasLoadedAll = false;
+    this.loadError = null;
     try {
-      const page = await this.fetchAllPages();
-      if (loadId !== this.#loadId) return;
-      this.members = page.members;
-      this.totalCount = page.totalCount;
-      this.hasLoaded = true;
+      await this.loadPages(loadId);
     } catch (error) {
       if (loadId === this.#loadId) {
+        this.loadError = error instanceof Error ? error.message : 'Failed to refresh room members';
         console.error('Failed to refresh room members:', error);
+      }
+    } finally {
+      if (loadId === this.#loadId) {
+        this.isInitialLoading = false;
+        this.isBackgroundLoading = false;
       }
     }
   }
 
   async searchMembers(search: string, limit = MENTION_MEMBER_SEARCH_LIMIT): Promise<RoomMember[]> {
-    return this.filteredLoadedMembers(search, limit);
+    const normalizedSearch = search.trim();
+    if (!normalizedSearch || this.hasLoadedAll || !this.roomId || !this.api) {
+      return this.filteredLoadedMembers(normalizedSearch, limit);
+    }
+
+    const roomId = this.roomId;
+    let page: RoomMembersPage;
+    try {
+      page = await this.fetchPage(0, limit, normalizedSearch);
+    } catch (error) {
+      console.error('Failed to search room members:', error);
+      return this.filteredLoadedMembers(normalizedSearch, limit);
+    }
+    if (roomId !== this.roomId) return [];
+    this.members = mergeMembersSorted(this.members, page.members);
+    return page.members.slice(0, limit);
   }
 
   ingestServerEvent(serverEvent: EventEnvelope): void {
@@ -178,25 +215,38 @@ export class RoomMembersStore {
     this.presenceVersion++;
   }
 
-  private async fetchAllPages(): Promise<RoomMembersPage> {
-    const members: RoomMember[] = [];
-    let totalCount = 0;
-    let hasMore = true;
+  private async loadPages(loadId: number): Promise<void> {
     let nextOffset = 0;
+    let hasMore = true;
+    let firstPage = true;
 
     while (hasMore) {
       const page = await this.fetchPage(nextOffset, ROOM_MEMBERS_PAGE_SIZE, '');
-      members.push(...page.members);
-      totalCount = page.totalCount;
+      if (loadId !== this.#loadId) return;
+
+      this.members = firstPage ? page.members : appendPageMembers(this.members, page.members);
+      this.totalCount = page.totalCount;
       hasMore = page.hasMore;
       nextOffset += page.members.length;
 
+      if (firstPage) {
+        firstPage = false;
+        this.hasFirstPage = true;
+        this.hasLoadedAll = !hasMore;
+        this.isInitialLoading = false;
+        this.isBackgroundLoading = hasMore;
+      }
+
       if (page.members.length === 0) {
+        hasMore = false;
         break;
       }
     }
 
-    return { members, totalCount, hasMore };
+    if (loadId === this.#loadId) {
+      this.hasLoadedAll = true;
+      this.isBackgroundLoading = false;
+    }
   }
 
   private async fetchPage(offset: number, limit: number, search: string): Promise<RoomMembersPage> {
@@ -217,13 +267,44 @@ export class RoomMembersStore {
     this.#loadId++;
     this.members = [];
     this.totalCount = 0;
-    this.hasLoaded = false;
+    this.hasFirstPage = false;
+    this.hasLoadedAll = false;
     this.isInitialLoading = false;
+    this.isBackgroundLoading = false;
+    this.loadError = null;
     this.searchInput = '';
     this.activeSearch = '';
     this.livePresence.clear();
     this.presenceVersion = 0;
   }
+}
+
+function appendUniqueMembers(current: RoomMember[], incoming: RoomMember[]): RoomMember[] {
+  if (incoming.length === 0) return current;
+
+  const byId = new SvelteMap(current.map((member) => [member.id, member]));
+  for (const member of incoming) byId.set(member.id, member);
+  return [...byId.values()];
+}
+
+function appendPageMembers(current: RoomMember[], incoming: RoomMember[]): RoomMember[] {
+  if (incoming.length === 0) return current;
+  const incomingIds = new Set(incoming.map((member) => member.id));
+  return [...current.filter((member) => !incomingIds.has(member.id)), ...incoming];
+}
+
+function mergeMembersSorted(current: RoomMember[], incoming: RoomMember[]): RoomMember[] {
+  return appendUniqueMembers(current, incoming).sort(compareMembers);
+}
+
+function compareMembers(left: RoomMember, right: RoomMember): number {
+  const leftDisplayName = left.displayName.toLowerCase();
+  const rightDisplayName = right.displayName.toLowerCase();
+  if (leftDisplayName < rightDisplayName) return -1;
+  if (leftDisplayName > rightDisplayName) return 1;
+  const leftLogin = left.login.toLowerCase();
+  const rightLogin = right.login.toLowerCase();
+  return leftLogin < rightLogin ? -1 : leftLogin > rightLogin ? 1 : 0;
 }
 
 const [getMembersStoreContext, setMembersStoreContext] = createContext<RoomMembersStore>();

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
@@ -333,7 +333,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
         </div>
       </div>
 
-      {#if loading || membersStore.isInitialLoading}
+      {#if (loading || membersStore.isInitialLoading) && !membersStore.hasFirstPage}
         <ul role="list">
           {#each Array(8) as _, i (i)}
             <li class="flex items-center gap-2 rounded-md px-2 py-1.5">

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
@@ -142,26 +142,28 @@ calls, and similar room-specific panels can plug into the same shell. See the
     return status !== 'OFFLINE';
   }
 
-  // Sort members alphabetically by display name within each presence group.
-  // Reading presenceVersion ensures $derived re-runs on any presence change —
-  // SvelteMap.size only changes when keys are added/removed, not when existing
-  // values change, so it would miss updates like OFFLINE→ONLINE.
+  // Sort names once when membership/search/profile data changes. Presence updates only repartition
+  // this stable ordering below, avoiding two full O(n log n) sorts per update.
   function sortByName(list: RoomMember[]): RoomMember[] {
     return [...list].sort((a, b) =>
       getLiveDisplayName(a.id, a.displayName).localeCompare(getLiveDisplayName(b.id, b.displayName))
     );
   }
 
-  const onlineMembers = $derived(
-    (presenceCache.version,
-    membersStore.presenceVersion,
-    sortByName(members.filter((m) => isOnlineStatus(getPresence(m)))))
-  );
-  const offlineMembers = $derived(
-    (presenceCache.version,
-    membersStore.presenceVersion,
-    sortByName(members.filter((m) => !isOnlineStatus(getPresence(m)))))
-  );
+  const sortedMembers = $derived(sortByName(members));
+  const groupedMembers = $derived.by(() => {
+    // Explicit versions include value-only presence transitions such as OFFLINE→ONLINE.
+    void presenceCache.version;
+    void membersStore.presenceVersion;
+    const online: RoomMember[] = [];
+    const offline: RoomMember[] = [];
+    for (const member of sortedMembers) {
+      (isOnlineStatus(getPresence(member)) ? online : offline).push(member);
+    }
+    return { online, offline };
+  });
+  const onlineMembers = $derived(groupedMembers.online);
+  const offlineMembers = $derived(groupedMembers.offline);
 
   // Look up the selected member for the popover (rendered outside the {#each} loop
   // to avoid Svelte reactivity cycles between the popover's $effect and onlineMembers' $derived)

--- a/cli/internal/core/room_membership.go
+++ b/cli/internal/core/room_membership.go
@@ -700,15 +700,14 @@ func (c *ChattoCore) ListRoomMemberReferences(ctx context.Context, actorID, room
 		return nil, err
 	}
 
+	userIDs := make([]string, len(memberships))
+	for i, membership := range memberships {
+		userIDs[i] = membership.GetUserId()
+	}
 	users := make([]*corev1.User, 0, len(memberships))
-	for _, membership := range memberships {
-		user, err := c.GetUserReference(ctx, membership.GetUserId())
-		if err != nil {
-			if errors.Is(err, ErrNotFound) {
-				user = DeletedUserReference(membership.GetUserId())
-			} else {
-				return nil, err
-			}
+	for i, user := range c.Users.GetReferences(userIDs) {
+		if user == nil {
+			user = DeletedUserReference(userIDs[i])
 		}
 		if user != nil {
 			users = append(users, user)

--- a/cli/internal/core/user_projection.go
+++ b/cli/internal/core/user_projection.go
@@ -551,6 +551,27 @@ func (p *UserProjection) GetReference(userID string) (*corev1.User, bool) {
 	return cloneUserWithActiveStatus(u.user, time.Now()), true
 }
 
+// GetReferences returns public user references aligned with userIDs. Unknown users are nil.
+func (p *UserProjection) GetReferences(userIDs []string) []*corev1.User {
+	p.RLock()
+	defer p.RUnlock()
+
+	now := time.Now()
+	users := make([]*corev1.User, len(userIDs))
+	for i, userID := range userIDs {
+		u := p.users[userID]
+		if u == nil {
+			continue
+		}
+		if u.deleted || u.user == nil || u.user.GetLogin() == "" || u.user.GetDisplayName() == "" {
+			users[i] = DeletedUserReference(userID)
+			continue
+		}
+		users[i] = cloneUserWithActiveStatus(u.user, now)
+	}
+	return users
+}
+
 func (p *UserProjection) GetByLogin(login string) (*corev1.User, bool) {
 	p.RLock()
 	userID := p.loginIndex[strings.ToLower(strings.TrimSpace(login))]

--- a/cli/internal/core/user_projection_test.go
+++ b/cli/internal/core/user_projection_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -13,6 +14,28 @@ import (
 	"hmans.de/chatto/internal/kms"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
+
+func BenchmarkUserProjectionGetReferences(b *testing.B) {
+	const memberCount = 10_000
+	p := &UserProjection{users: make(map[string]*projectedUser, memberCount)}
+	userIDs := make([]string, memberCount)
+	for i := range memberCount {
+		userID := fmt.Sprintf("user-%05d", i)
+		userIDs[i] = userID
+		p.users[userID] = &projectedUser{user: &corev1.User{
+			Id:          userID,
+			Login:       userID,
+			DisplayName: userID,
+		}}
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if got := p.GetReferences(userIDs); len(got) != memberCount {
+			b.Fatalf("GetReferences() returned %d users, want %d", len(got), memberCount)
+		}
+	}
+}
 
 func userEvent(id string, ts time.Time, event *corev1.Event) *corev1.Event {
 	event.Id = id


### PR DESCRIPTION
## Summary

- publish the first room-member page immediately and hydrate remaining members in the background
- use generation-safe, paginated server search while membership hydration is incomplete
- build Quick Switcher room and DM destinations from the existing per-server RoomsStore
- batch user projection reference reads for large room directory requests
- avoid re-sorting the complete sidebar membership on presence-only updates

## Testing

- `mise lint-frontend`
- `mise test-frontend` (187 files, 1,884 tests)
- `mise test-cli`
- `mise x -- go test ./internal/core -run '^$' -bench '^BenchmarkUserProjectionGetReferences$' -benchtime=1x` (from `cli/`)
- Svelte autofixer on changed Svelte components/modules

Closes #1422.
