### PR TITLE
ci: cache dependencies and publish main images

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -44,7 +44,23 @@ runs:
 
     # pnpm is not available as a mise plugin, so install via npm (comes with Node)
     - name: Install pnpm
+      if: inputs.install-frontend-deps == 'true'
       uses: pnpm/action-setup@v5
+
+    - name: Resolve pnpm store path
+      if: inputs.install-frontend-deps == 'true'
+      id: pnpm-store
+      shell: bash
+      run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+    - name: Cache pnpm store
+      if: inputs.install-frontend-deps == 'true'
+      uses: actions/cache@v5
+      with:
+        path: ${{ steps.pnpm-store.outputs.path }}
+        key: pnpm-store-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          pnpm-store-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Install ffmpeg (required for video processing e2e tests)
       if: inputs.install-ffmpeg == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ permissions:
 jobs:
   build-assets:
     runs-on: ubuntu-latest
+    outputs:
+      image-version: ${{ steps.production-image-contexts.outputs.version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -40,10 +42,20 @@ jobs:
         run: mise build-e2e-server
 
       - name: Build production image contexts
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'ci-publish-image')
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        id: production-image-contexts
         shell: bash
         run: |
           set -euo pipefail
+
+          base_version="$(sed -n 's/.*Version = "\([^"]*\)".*/\1/p' cli/version.go)"
+          if [[ -z "$base_version" ]]; then
+            echo "::error::Could not read the base version from cli/version.go."
+            exit 1
+          fi
+
+          version="${base_version}+${GITHUB_SHA:0:12}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
           for arch in amd64 arm64; do
             context=".context/ci/docker/linux-${arch}"
@@ -55,7 +67,8 @@ jobs:
             cp NOTICE "$context/NOTICE"
             (
               cd cli
-              CGO_ENABLED=0 GOOS=linux GOARCH="$arch" go build -trimpath -ldflags="-s -w" \
+              CGO_ENABLED=0 GOOS=linux GOARCH="$arch" go build -trimpath \
+                -ldflags="-s -w -X main.Version=${version}" \
                 -o "../$context/chatto" .
             )
           done
@@ -76,7 +89,7 @@ jobs:
           retention-days: 1
 
       - name: Upload production image contexts
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'ci-publish-image')
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v7
         with:
           name: production-image-contexts
@@ -302,7 +315,7 @@ jobs:
           retention-days: 14
 
   publish-main-image:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'ci-publish-image')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs:
       - build-assets
       - license-check
@@ -342,6 +355,11 @@ jobs:
           tags: ghcr.io/chattocorp/chatto:${{ github.sha }}-amd64
           cache-from: type=gha,scope=chatto-main-amd64
           cache-to: type=gha,scope=chatto-main-amd64,mode=max
+          labels: |
+            org.opencontainers.image.source=https://github.com/chattocorp/chatto
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ needs.build-assets.outputs.image-version }}
+            org.opencontainers.image.licenses=AGPL-3.0-or-later
 
       - name: Build and push arm64 image
         uses: docker/build-push-action@v6
@@ -353,6 +371,11 @@ jobs:
           tags: ghcr.io/chattocorp/chatto:${{ github.sha }}-arm64
           cache-from: type=gha,scope=chatto-main-arm64
           cache-to: type=gha,scope=chatto-main-arm64,mode=max
+          labels: |
+            org.opencontainers.image.source=https://github.com/chattocorp/chatto
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ needs.build-assets.outputs.image-version }}
+            org.opencontainers.image.licenses=AGPL-3.0-or-later
 
       - name: Publish multi-platform commit image
         shell: bash
@@ -366,4 +389,6 @@ jobs:
             echo "### Main commit image"
             echo
             echo "\`ghcr.io/chattocorp/chatto:${GITHUB_SHA}\`"
+            echo
+            echo "Version: \`${{ needs.build-assets.outputs.image-version }}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: mise build-e2e-server
 
       - name: Build production image contexts
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'ci-publish-image')
         shell: bash
         run: |
           set -euo pipefail
@@ -76,7 +76,7 @@ jobs:
           retention-days: 1
 
       - name: Upload production image contexts
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'ci-publish-image')
         uses: actions/upload-artifact@v7
         with:
           name: production-image-contexts
@@ -302,7 +302,7 @@ jobs:
           retention-days: 14
 
   publish-main-image:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'ci-publish-image')
     needs:
       - build-assets
       - license-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
         with:
           name: frontend-bundle
           path: cli/internal/http_server/.client
+          include-hidden-files: true
           retention-days: 1
 
       - name: Upload E2E server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,8 @@ permissions:
   contents: read
 
 jobs:
-  build-assets:
+  build-main-image-contexts:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:
       image-version: ${{ steps.production-image-contexts.outputs.version }}
@@ -38,11 +39,10 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup
 
-      - name: Build shared frontend and E2E server
-        run: mise build-e2e-server
+      - name: Build frontend for production image
+        run: mise build-frontend
 
       - name: Build production image contexts
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         id: production-image-contexts
         shell: bash
         run: |
@@ -73,23 +73,7 @@ jobs:
             )
           done
 
-      - name: Upload frontend bundle
-        uses: actions/upload-artifact@v7
-        with:
-          name: frontend-bundle
-          path: cli/internal/http_server/.client
-          include-hidden-files: true
-          retention-days: 1
-
-      - name: Upload E2E server
-        uses: actions/upload-artifact@v7
-        with:
-          name: e2e-server
-          path: apps/frontend/e2e/fixtures/bin/chatto
-          retention-days: 1
-
       - name: Upload production image contexts
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v7
         with:
           name: production-image-contexts
@@ -197,7 +181,6 @@ jobs:
         run: pnpm run test:frontend
 
   test-cli:
-    needs: build-assets
     # runs-on: ubicloud-standard-4
     runs-on: ubuntu-latest
     steps:
@@ -206,20 +189,14 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/setup
-        with:
-          install-frontend-deps: "false"
 
-      - name: Download frontend bundle
-        uses: actions/download-artifact@v8
-        with:
-          name: frontend-bundle
-          path: cli/internal/http_server/.client
+      - name: Build frontend
+        run: mise build-frontend
 
       - name: Run Go tests
         run: cd cli && go test -trimpath -p 1 -tags test_endpoints ./...
 
   test-e2e:
-    needs: build-assets
     # runs-on: ubicloud-standard-4
     runs-on: ubuntu-latest
     name: test-e2e (${{ matrix.shard }}/4)
@@ -233,17 +210,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/setup
-        with:
-          install-cli-deps: "false"
-
-      - name: Download E2E server
-        uses: actions/download-artifact@v8
-        with:
-          name: e2e-server
-          path: apps/frontend/e2e/fixtures/bin
-
-      - name: Restore E2E server permissions
-        run: chmod +x apps/frontend/e2e/fixtures/bin/chatto
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5
@@ -256,6 +222,9 @@ jobs:
       - name: Install Playwright dependencies
         run: cd apps/frontend && pnpm exec playwright install chromium --with-deps
         timeout-minutes: 15
+
+      - name: Build E2E server
+        run: mise build-e2e-server
 
       - name: Run E2E tests
         run: cd apps/frontend && pnpm exec playwright test --grep-invert @ffmpeg --shard=${{ matrix.shard }}/4
@@ -269,7 +238,6 @@ jobs:
           retention-days: 14
 
   test-e2e-media:
-    needs: build-assets
     # runs-on: ubicloud-standard-4
     runs-on: ubuntu-latest
     steps:
@@ -280,16 +248,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           install-ffmpeg: "true"
-          install-cli-deps: "false"
-
-      - name: Download E2E server
-        uses: actions/download-artifact@v8
-        with:
-          name: e2e-server
-          path: apps/frontend/e2e/fixtures/bin
-
-      - name: Restore E2E server permissions
-        run: chmod +x apps/frontend/e2e/fixtures/bin/chatto
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5
@@ -302,6 +260,9 @@ jobs:
       - name: Install Playwright dependencies
         run: cd apps/frontend && pnpm exec playwright install chromium --with-deps
         timeout-minutes: 15
+
+      - name: Build E2E server
+        run: mise build-e2e-server
 
       - name: Run media E2E tests
         run: cd apps/frontend && pnpm exec playwright test --grep @ffmpeg
@@ -317,7 +278,7 @@ jobs:
   publish-main-image:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs:
-      - build-assets
+      - build-main-image-contexts
       - license-check
       - codegen-proto-drift
       - test-frontend-unit
@@ -358,7 +319,7 @@ jobs:
           labels: |
             org.opencontainers.image.source=https://github.com/chattocorp/chatto
             org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ needs.build-assets.outputs.image-version }}
+            org.opencontainers.image.version=${{ needs.build-main-image-contexts.outputs.image-version }}
             org.opencontainers.image.licenses=AGPL-3.0-or-later
 
       - name: Build and push arm64 image
@@ -374,7 +335,7 @@ jobs:
           labels: |
             org.opencontainers.image.source=https://github.com/chattocorp/chatto
             org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ needs.build-assets.outputs.image-version }}
+            org.opencontainers.image.version=${{ needs.build-main-image-contexts.outputs.image-version }}
             org.opencontainers.image.licenses=AGPL-3.0-or-later
 
       - name: Publish multi-platform commit image
@@ -390,5 +351,5 @@ jobs:
             echo
             echo "\`ghcr.io/chattocorp/chatto:${GITHUB_SHA}\`"
             echo
-            echo "Version: \`${{ needs.build-assets.outputs.image-version }}\`"
+            echo "Version: \`${{ needs.build-main-image-contexts.outputs.image-version }}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,70 @@ on:
       - 'release-[0-9]*'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # PRs share a group so superseded revisions are cancelled. Pushes use their
+  # immutable commit SHA so every main commit can publish an image.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
 
 jobs:
+  build-assets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup environment
+        uses: ./.github/actions/setup
+
+      - name: Build shared frontend and E2E server
+        run: mise build-e2e-server
+
+      - name: Build production image contexts
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          for arch in amd64 arm64; do
+            context=".context/ci/docker/linux-${arch}"
+            mkdir -p "$context/docker" "$context/LICENSES"
+            cp docker/Dockerfile.goreleaser "$context/Dockerfile"
+            cp docker/docker-entrypoint.sh "$context/docker/docker-entrypoint.sh"
+            cp docker/nats-wrapper.sh "$context/docker/nats-wrapper.sh"
+            cp LICENSES/AGPL-3.0-or-later.txt "$context/LICENSES/AGPL-3.0-or-later.txt"
+            cp NOTICE "$context/NOTICE"
+            (
+              cd cli
+              CGO_ENABLED=0 GOOS=linux GOARCH="$arch" go build -trimpath -ldflags="-s -w" \
+                -o "../$context/chatto" .
+            )
+          done
+
+      - name: Upload frontend bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: frontend-bundle
+          path: cli/internal/http_server/.client
+          retention-days: 1
+
+      - name: Upload E2E server
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-server
+          path: apps/frontend/e2e/fixtures/bin/chatto
+          retention-days: 1
+
+      - name: Upload production image contexts
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v7
+        with:
+          name: production-image-contexts
+          path: .context/ci/docker
+          retention-days: 1
+
   license-check:
     # runs-on: ubicloud-standard-4
     runs-on: ubuntu-latest
@@ -126,6 +183,7 @@ jobs:
         run: pnpm run test:frontend
 
   test-cli:
+    needs: build-assets
     # runs-on: ubicloud-standard-4
     runs-on: ubuntu-latest
     steps:
@@ -134,14 +192,20 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/setup
+        with:
+          install-frontend-deps: "false"
 
-      - name: Build frontend
-        run: mise build-frontend
+      - name: Download frontend bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: frontend-bundle
+          path: cli/internal/http_server/.client
 
       - name: Run Go tests
         run: cd cli && go test -trimpath -p 1 -tags test_endpoints ./...
 
   test-e2e:
+    needs: build-assets
     # runs-on: ubicloud-standard-4
     runs-on: ubuntu-latest
     name: test-e2e (${{ matrix.shard }}/4)
@@ -155,6 +219,17 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/setup
+        with:
+          install-cli-deps: "false"
+
+      - name: Download E2E server
+        uses: actions/download-artifact@v8
+        with:
+          name: e2e-server
+          path: apps/frontend/e2e/fixtures/bin
+
+      - name: Restore E2E server permissions
+        run: chmod +x apps/frontend/e2e/fixtures/bin/chatto
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5
@@ -167,9 +242,6 @@ jobs:
       - name: Install Playwright dependencies
         run: cd apps/frontend && pnpm exec playwright install chromium --with-deps
         timeout-minutes: 15
-
-      - name: Build E2E server
-        run: mise build-e2e-server
 
       - name: Run E2E tests
         run: cd apps/frontend && pnpm exec playwright test --grep-invert @ffmpeg --shard=${{ matrix.shard }}/4
@@ -183,6 +255,7 @@ jobs:
           retention-days: 14
 
   test-e2e-media:
+    needs: build-assets
     # runs-on: ubicloud-standard-4
     runs-on: ubuntu-latest
     steps:
@@ -193,6 +266,16 @@ jobs:
         uses: ./.github/actions/setup
         with:
           install-ffmpeg: "true"
+          install-cli-deps: "false"
+
+      - name: Download E2E server
+        uses: actions/download-artifact@v8
+        with:
+          name: e2e-server
+          path: apps/frontend/e2e/fixtures/bin
+
+      - name: Restore E2E server permissions
+        run: chmod +x apps/frontend/e2e/fixtures/bin/chatto
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5
@@ -206,9 +289,6 @@ jobs:
         run: cd apps/frontend && pnpm exec playwright install chromium --with-deps
         timeout-minutes: 15
 
-      - name: Build E2E server
-        run: mise build-e2e-server
-
       - name: Run media E2E tests
         run: cd apps/frontend && pnpm exec playwright test --grep @ffmpeg
 
@@ -219,3 +299,70 @@ jobs:
           name: playwright-report-media
           path: apps/frontend/playwright-report/
           retention-days: 14
+
+  publish-main-image:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs:
+      - build-assets
+      - license-check
+      - codegen-proto-drift
+      - test-frontend-unit
+      - test-cli
+      - test-e2e
+      - test-e2e-media
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download production image contexts
+        uses: actions/download-artifact@v8
+        with:
+          name: production-image-contexts
+          path: docker-contexts
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push amd64 image
+        uses: docker/build-push-action@v6
+        with:
+          context: docker-contexts/linux-amd64
+          file: docker-contexts/linux-amd64/Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: ghcr.io/chattocorp/chatto:${{ github.sha }}-amd64
+          cache-from: type=gha,scope=chatto-main-amd64
+          cache-to: type=gha,scope=chatto-main-amd64,mode=max
+
+      - name: Build and push arm64 image
+        uses: docker/build-push-action@v6
+        with:
+          context: docker-contexts/linux-arm64
+          file: docker-contexts/linux-arm64/Dockerfile
+          push: true
+          platforms: linux/arm64
+          tags: ghcr.io/chattocorp/chatto:${{ github.sha }}-arm64
+          cache-from: type=gha,scope=chatto-main-arm64
+          cache-to: type=gha,scope=chatto-main-arm64,mode=max
+
+      - name: Publish multi-platform commit image
+        shell: bash
+        run: |
+          docker buildx imagetools create \
+            --tag "ghcr.io/chattocorp/chatto:${GITHUB_SHA}" \
+            "ghcr.io/chattocorp/chatto:${GITHUB_SHA}-amd64" \
+            "ghcr.io/chattocorp/chatto:${GITHUB_SHA}-arm64"
+
+          {
+            echo "### Main commit image"
+            echo
+            echo "\`ghcr.io/chattocorp/chatto:${GITHUB_SHA}\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- cache the pnpm store across workflow runs
- keep CLI and E2E jobs fully parallel for fast PR feedback
- build production image contexts alongside the test suite only on pushes to `main`
- publish a multi-platform `ghcr.io/chattocorp/chatto:<full-sha>` image after every successful push to `main`
- identify commit builds in the CLI and UI as `<stable-version>+<short-sha>` without moving `:latest`
- retain PR cancellation while allowing every `main` commit to complete its image publication

## Why

The previous workflow lacked a deployable image for each commit on `main` and did not preserve the pnpm package store between CI runs. This change improves dependency reuse while creating an immutable image identity suitable for a future automated `dev` release-stream update.

Production image contexts are compiled only for `main` pushes and in parallel with the existing test jobs. Publication remains gated on the complete CI suite. Test jobs continue building independently so artifact fan-out does not delay the PR critical path.

## Validation

- `mise x -- actionlint .github/workflows/*.yml`
- `git diff --check`
- `mise build-e2e-server`
- cross-compiled production binaries with `CGO_ENABLED=0` for Linux amd64 and arm64
- explicitly published and inspected a multi-platform test image from the PR workflow
