### PR TITLE
docs(deployment): expand Docker Compose guide

### DIFF
--- a/apps/docs-website/src/components/diagrams/DockerComposeDiagram.astro
+++ b/apps/docs-website/src/components/diagrams/DockerComposeDiagram.astro
@@ -24,7 +24,7 @@ import Dot from './Dot.astro';
   <path id="p-caddy-chatto" class="conn" d="M385,170 L463,170"/>
   <path id="p-caddy-livekit" class="conn" d="M385,185 L463,265"/>
   <path id="p-browser-livekit" class="conn-dash" d="M86,200 L86,270 L463,270"/>
-  <text class="proto" x="270" y="285" text-anchor="middle">UDP :3478, :50000–50200</text>
+  <text class="proto" x="270" y="285" text-anchor="middle">TCP :7881 · UDP :3478, :50000–50200</text>
 
   <path id="p-chatto-nats" class="conn" d="M541,140 L541,110"/>
   <path id="p-nats-chatto" class="conn" d="M549,110 L549,140"/>

--- a/apps/docs-website/src/content/docs/guides/deployment/docker-compose.mdx
+++ b/apps/docs-website/src/content/docs/guides/deployment/docker-compose.mdx
@@ -6,59 +6,42 @@ description: How to deploy Chatto using Docker Compose.
 import {
   Steps,
   Aside,
-  FileTree,
   LinkCard,
   CardGrid,
 } from "@astrojs/starlight/components";
 import ArchDiagram from "../../../../components/diagrams/DockerComposeDiagram.astro";
 
-## Introduction
+Docker Compose is the quickest way to run the complete Chatto stack on one
+server. The example includes Chatto, NATS for persistent data, LiveKit for
+calls, and Caddy for automatic HTTPS.
 
-This guide walks through deploying Chatto with Docker Compose, in a more fully-featured setup compared to what we set up in the [Standalone Binary](/guides/deployment/binary/) guide. Specifically, this includes:
+## Quick Start
 
-- A separate NATS server for Chatto to connect to (instead of using the embedded server.)
-- A working LiveKit service to power your voice and video calls.
-- A Caddy reverse proxy.
-- Configuration through environment variables instead of `chatto.toml`.
+You need Docker with Compose v2, a server with a public IP address, and SMTP
+credentials. The commands below use `chat.example.com` for Chatto and
+`livekit.chat.example.com` for calls.
 
-Consider all of these optional; if you don't want to use Caddy, feel free to replace it with something else; if you don't need calls, just leave LiveKit disabled. We do recommend, however, to separate Chatto from NATS at this point because it will make future production use cases (scaling, high availability, zero-downtime deployments) a lot easier.
-
-## Architecture
-
-<ArchDiagram />
-
-## Prerequisites
-
-- Docker and Docker Compose v2
-- A domain pointing to your server (e.g., `chat.example.com`)
-- A `livekit.*` subdomain pointing to the same server (e.g., `livekit.chat.example.com`)
-- Firewall allowing inbound TCP 80/443 and UDP 3478, 50000-50200
-- SMTP credentials for email/password registration, email verification, and password reset
-
-## Setup
+The LiveKit hostname is only an example. You can use any hostname you control,
+such as `calls.example.com`; pass your Chatto hostname to `init-env.sh`, then
+set `CHATTO_LIVEKIT_URL` and the matching proxy route to your chosen LiveKit
+hostname.
 
 <Steps>
 
-1. **Copy the Compose example**
-
-   From an existing Chatto checkout:
+1. **Get the example**
 
    ```bash
-   cp -R examples/dockercompose chatto
-   cd chatto
+   git clone --depth 1 https://github.com/chattocorp/chatto.git
+   cd chatto/examples/dockercompose
    ```
 
-   From GitHub without cloning the full repository:
+2. **Point both domains at your server**
 
-   ```bash
-   git clone --depth 1 --filter=blob:none --sparse https://github.com/chattocorp/chatto.git chatto-source
-   git -C chatto-source sparse-checkout set examples/dockercompose
-   cp -R chatto-source/examples/dockercompose chatto
-   rm -rf chatto-source
-   cd chatto
-   ```
+   Create DNS records for `chat.example.com` and
+   `livekit.chat.example.com`. Allow inbound TCP 80, 443, and 7881 plus UDP
+   3478 and 50000-50200 in your host and cloud firewalls.
 
-2. **Create `.env` and LiveKit secrets**
+3. **Generate the configuration**
 
    ```bash
    ./init-env.sh chat.example.com admin@example.com
@@ -66,9 +49,7 @@ Consider all of these optional; if you don't want to use Caddy, feel free to rep
 
    Replace `chat.example.com` with your Chatto domain and `admin@example.com` with the email address you will use for the first account. The script generates `.env` and `livekit.generated.yaml` with matching NATS, Chatto, and LiveKit secrets.
 
-   If you prefer to manage every value yourself, copy `.env.example` to `.env`, replace all placeholder secrets with output from `openssl rand -hex 32`, and edit `livekit.yaml` so its key, secret, and webhook URL match `.env`.
-
-3. **Configure SMTP**
+4. **Configure SMTP**
 
    Edit `.env` and replace the `CHATTO_SMTP_*` placeholders with your provider settings. Direct email/password registration, email verification, and password reset require SMTP.
 
@@ -76,7 +57,7 @@ Consider all of these optional; if you don't want to use Caddy, feel free to rep
 
    Set `CHATTO_OWNERS_EMAILS` to the email address you will use for the first account. Registration sends a code by email and creates the account with that email already verified; if it matches this list, Chatto assigns the owner role automatically.
 
-4. **Start the stack**
+5. **Start Chatto**
 
    ```bash
    docker compose up -d
@@ -85,6 +66,46 @@ Consider all of these optional; if you don't want to use Caddy, feel free to rep
    Caddy will automatically obtain TLS certificates for both domains. Visit `https://chat.example.com` to create your first account with the email address from `CHATTO_OWNERS_EMAILS`.
 
 </Steps>
+
+That is enough for a complete single-server deployment. The remaining sections
+explain how the pieces fit together and how to customize them.
+
+## Understand the Stack
+
+<ArchDiagram />
+
+- **Chatto** serves the web app and APIs.
+- **NATS** stores Chatto's persistent data. Running it separately is the
+  recommended production topology: you can restart or replace Chatto without
+  restarting its data store, run multiple Chatto replicas against the same
+  data, and grow into a NATS cluster later.
+- **LiveKit** provides voice and video calls. Remove it if you do not need
+  calls.
+- **Caddy** provides automatic HTTPS and reverse proxying. Replace it if you
+  already use another proxy.
+
+### Why a Separate NATS Server?
+
+The standalone-binary setup embeds NATS inside Chatto, which is wonderfully
+simple for one process. Compose runs the same NATS JetStream storage as its own
+small container. This keeps the app and its data lifecycle separate and avoids
+a migration before adding Chatto replicas or zero-downtime app updates.
+
+This choice does not lock in your data. `chatto backup` creates a portable
+JetStream archive that `chatto restore` can load into either embedded or
+external NATS. You can therefore move between the standalone-binary, Compose,
+and clustered deployment models without rebuilding your community. See
+[Backup & Restore](/guides/operations/backup-restore/) for the commands and key
+handling guidance.
+
+### Prefer to Configure It by Hand?
+
+You usually do not need to: `init-env.sh` generates the secrets and config files
+for you. If you manage secrets elsewhere, start with `.env.example`, fill in its
+placeholders, and make sure the LiveKit key and secret are the same in `.env`
+and `livekit.yaml`.
+
+### Container and Operator Details
 
 The image runs Chatto as a non-root user. By default that user is `1000:1000`; set `PUID` and `PGID` in your shell or Compose environment if the files mounted into `/config` or `/data` are owned by a different host user or group. The entrypoint does not recursively change ownership of mounted directories, so make sure writable mounts are owned by the configured IDs.
 
@@ -125,6 +146,75 @@ Back up `nats_data` regularly. By default, file attachments and media are also s
     description="Run multiple Chatto replicas for high availability."
   />
 </CardGrid>
+
+## Use Your Existing Reverse Proxy
+
+Already running Caddy, nginx, Apache, Traefik, or another user-facing web
+server? You can keep it. Chatto needs only two HTTP reverse-proxy routes:
+
+- Your Chatto HTTPS hostname routes to Chatto on port 4000.
+- Your chosen LiveKit secure WebSocket hostname routes to LiveKit on port 7880.
+
+For example, the hostnames could be `chat.example.com` and
+`calls.example.com`. They do not need to share a parent domain or use the name
+`livekit`. Both need publicly trusted TLS certificates.
+
+If your proxy joins the Compose network, route directly to `chatto:4000` and
+`livekit:7880`. If it runs on the Docker host, replace those services' `expose`
+entries with loopback-only mappings such as `127.0.0.1:4000:4000` and
+`127.0.0.1:7880:7880`. Then remove the `caddy` service and its volumes from
+`compose.yml`.
+
+<Aside type="note">
+  Keep LiveKit's TCP and UDP `ports` entries. WebRTC media connects directly to
+  LiveKit and does not pass through a normal HTTP reverse proxy.
+</Aside>
+
+### What the Included Caddy Does
+
+If you do not already have a proxy, the included Caddy configuration obtains
+certificates, creates both routes, and load-balances Chatto replicas:
+
+```text
+chat.example.com {
+  reverse_proxy {
+    dynamic a chatto 4000 {
+      refresh 5s
+      versions ipv4
+    }
+    lb_policy round_robin
+  }
+}
+
+livekit.chat.example.com {
+  reverse_proxy livekit:7880
+}
+```
+
+The first route carries the Chatto web app, APIs, realtime connections, and
+LiveKit webhooks. The second carries LiveKit's API and WebSocket signaling.
+Caddy handles WebSocket upgrades automatically.
+
+The dynamic DNS upstream discovers each scaled Chatto container separately.
+Caddy refreshes the list and distributes new requests across healthy replicas;
+existing realtime connections stay with the replica that accepted them.
+
+### Network Ports
+
+The example publishes LiveKit's Layer 4 media ports directly from its container
+to the host:
+
+| Public port | Destination | Protocol and purpose |
+| ----------- | ----------- | -------------------- |
+| TCP 80 | Caddy | HTTP redirect and ACME HTTP challenge |
+| TCP 443 | Caddy | HTTPS and secure WebSocket traffic for both domains |
+| TCP 7881 | LiveKit 7881 | WebRTC media fallback when UDP is unavailable |
+| UDP 3478 | LiveKit 3478 | Embedded TURN/STUN relay |
+| UDP 50000-50200 | Same LiveKit ports | Direct WebRTC media |
+
+The standard Caddy image does not include the optional Caddy L4 plugin, and this
+single-host setup does not need it. Open the matching host and cloud firewall
+rules, and do not expose NATS port 4222 publicly.
 
 ## Optional Features
 
@@ -172,7 +262,7 @@ If you don't need voice and video calls, simplify the stack by:
 3. Removing the `livekit.*` block from the `Caddyfile`
 4. Removing the `CHATTO_LIVEKIT_*` variables from `.env`
 
-You won't need the `livekit.*` subdomain or the LiveKit UDP ports.
+You won't need the `livekit.*` subdomain, TCP 7881, or the LiveKit UDP ports.
 
 ## TURN Server for Restrictive Networks
 
@@ -181,18 +271,26 @@ The default setup exposes LiveKit's direct UDP media range and its embedded TURN
 ```yaml
 ports:
   - "50000-50200:50000-50200/udp"
+  - "7881:7881/tcp"
   - "3478:3478/udp"
 ```
 
-The generated and checked-in LiveKit configs enable the matching relay:
+The generated and checked-in LiveKit configs enable the matching TCP fallback
+and relay:
 
 ```yaml
+rtc:
+  tcp_port: 7881
+
 turn:
   enabled: true
   udp_port: 3478
 ```
 
-This helps with symmetric NATs and many mobile, Firefox, and restrictive-network failures while keeping the Compose example certificate-free.
+Direct UDP provides the best media path. TCP 7881 gives LiveKit an ICE/TCP
+fallback when UDP is unavailable, while TURN/UDP helps with symmetric NATs and
+many mobile, Firefox, and restrictive-network failures. This keeps the Compose
+example certificate-free beyond the HTTPS certificates managed by Caddy.
 
 Networks that block UDP entirely still need TURN/TLS. Add that only when you also provide a TURN domain plus certificate/key, or run LiveKit behind L4 TLS forwarding that terminates TLS before LiveKit.
 
@@ -216,7 +314,7 @@ See [Voice & Video Calls](/guides/infrastructure/voice-calls/#turn-for-restricti
 
 **Container startup order** — `depends_on` with `condition: service_healthy` ensures NATS and LiveKit are ready before Chatto starts. If health checks fail, check the individual service logs.
 
-**Calls don't connect** — Verify the LiveKit API key/secret in `.env` matches the selected LiveKit config (`livekit.generated.yaml` or `livekit.yaml`). Ensure `CHATTO_LIVEKIT_URL` uses the public `wss://livekit.*` subdomain (browsers connect to it directly). Check that UDP 3478 and 50000-50200 are open in your firewall.
+**Calls don't connect** — Verify the LiveKit API key/secret in `.env` matches the selected LiveKit config (`livekit.generated.yaml` or `livekit.yaml`). Ensure `CHATTO_LIVEKIT_URL` uses the public `wss://livekit.*` subdomain (browsers connect to it directly). Check that TCP 7881 and UDP 3478 and 50000-50200 are open in your firewall.
 
 **Calls fail for some users** — Confirm the built-in TURN/UDP relay is reachable on UDP 3478. Users behind firewalls that block UDP entirely need TURN/TLS. See [TURN server for restrictive networks](#turn-server-for-restrictive-networks).
 

--- a/apps/docs-website/src/content/docs/guides/infrastructure/voice-calls.mdx
+++ b/apps/docs-website/src/content/docs/guides/infrastructure/voice-calls.mdx
@@ -3,7 +3,7 @@ title: Voice & Video Calls
 description: How to set up and configure voice and video call capabilities in Chatto using LiveKit.
 ---
 
-import { Steps, Tabs, TabItem } from "@astrojs/starlight/components";
+import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
 
 Chatto supports real-time voice and video calls inside rooms using [LiveKit](https://livekit.io/), an open-source WebRTC media server. When enabled, any room member can start or join a call directly from the room header.
 
@@ -106,11 +106,35 @@ Chatto records call start/join/leave/end facts durably and reconciles active par
 Use `wss://` (WebSocket Secure) URLs in production. Plain `ws://` should only be used for local development.
 :::
 
-- **Network**: Users connect directly to the LiveKit server from their browsers. Make sure your LiveKit server is reachable from the public internet (or your private network, for internal deployments).
+- **Network**: Users connect directly to the LiveKit server from their browsers. Make sure your LiveKit server is reachable from the public internet (or your private network, for internal deployments). HTTPS/WebSocket signaling and WebRTC media use different routes, as described below.
 - **TURN/STUN**: LiveKit includes a built-in TURN server for NAT traversal. TURN/UDP on port 3478 helps many NAT traversal failures; networks that block UDP entirely need TURN/TLS, often on port 443.
 - **Scaling**: A single LiveKit server handles hundreds of concurrent participants for typical small deployments. For larger deployments, LiveKit supports multi-node clustering with Redis.
 - **End-to-end encryption**: Chatto enables LiveKit E2EE automatically for clients. No additional LiveKit server configuration is required.
 - **API Secret**: Keep your API secret confidential. It's used to sign JWT tokens and should never be exposed to clients.
+
+### Network Paths and Ports
+
+Put LiveKit's API and WebSocket signaling endpoint behind a reverse proxy with
+a publicly trusted certificate. Route `wss://livekit.example.com` on TCP 443 to
+LiveKit port 7880. Media travels directly to LiveKit instead of through the HTTP
+reverse proxy:
+
+| Public port | Purpose |
+| ----------- | ------- |
+| TCP 443 | Secure LiveKit API and WebSocket signaling, proxied to TCP 7880 |
+| TCP 7881 | ICE/TCP media fallback when UDP is unavailable |
+| UDP 3478 | Optional embedded TURN/STUN relay |
+| UDP media range | Direct WebRTC media; the Compose example uses 50000-50200 |
+
+The port range must match `rtc.port_range_start` and `rtc.port_range_end` in
+your LiveKit configuration. Do not route the TCP or UDP media ports through a
+normal HTTP reverse proxy.
+
+<Aside type="tip">
+  The [Docker Compose guide](/guides/deployment/docker-compose/) provides a
+  complete working LiveKit configuration, firewall list, automatic HTTPS, and
+  generated matching secrets.
+</Aside>
 
 ## TURN for Restrictive Networks
 
@@ -124,7 +148,12 @@ turn:
   udp_port: 3478
 ```
 
-Expose UDP 3478 on the LiveKit host and keep the UDP media range open. Networks that block UDP entirely need TURN/TLS instead. If your users can only reach outbound TCP 443, LiveKit or TURN needs a dedicated IP address or host so it can listen on 443 without conflicting with your HTTPS reverse proxy, and the TURN TLS certificate must match the advertised TURN domain.
+Expose UDP 3478 on the LiveKit host, keep the UDP media range open, and enable
+ICE/TCP on port 7881 as a fallback when UDP is unavailable. Networks that also
+block this TCP fallback need TURN/TLS. If your users can only reach outbound TCP
+443, LiveKit or TURN needs a dedicated IP address or host so it can listen on
+443 without conflicting with your HTTPS reverse proxy, and the TURN TLS
+certificate must match the advertised TURN domain.
 
 Use a dedicated TURN server such as [coturn](https://github.com/coturn/coturn) when you need tighter network separation, a shared TURN service for multiple LiveKit deployments, or TURN/TLS on port 443 without moving LiveKit itself. Configure static credentials on the TURN server and list it under LiveKit's `rtc.turn_servers` configuration.
 
@@ -146,4 +175,6 @@ To disable voice and video calls, either remove the `[livekit]` section from `ch
 enabled = false
 ```
 
-When disabled, call controls are hidden and all call API endpoints return `null`.
+When disabled, call controls are hidden. Call APIs return their normal
+not-configured results: lists are empty, join and leave report `false`, and a
+singular active-call lookup returns `NOT_FOUND`.

--- a/examples/dockercompose/Caddyfile
+++ b/examples/dockercompose/Caddyfile
@@ -1,6 +1,12 @@
 {$PUBLIC_URL:chat.example.com} {
-	reverse_proxy chatto:4000 {
-		# Load balance across replicas
+	reverse_proxy {
+		# Discover all Chatto replicas through Docker's internal DNS.
+		dynamic a chatto 4000 {
+			refresh 5s
+			versions ipv4
+		}
+
+		# Distribute new requests across the discovered replicas.
 		lb_policy round_robin
 
 		# Passive health checks (mark unhealthy after failures)

--- a/examples/dockercompose/README.md
+++ b/examples/dockercompose/README.md
@@ -3,16 +3,100 @@
 This example deploys a clustered Chatto setup with:
 
 - **NATS** - Message broker with JetStream persistence
-- **LiveKit** - WebRTC media server for voice calls
+- **LiveKit** - WebRTC media server for voice and video calls
 - **Chatto** - App server connecting to external NATS
 - **Caddy** - Reverse proxy with automatic HTTPS and load balancing
+
+## Quick Start
+
+Point `chat.example.com` and `livekit.chat.example.com` at your server, open the
+ports listed below, then run:
+
+```bash
+./init-env.sh chat.example.com admin@example.com
+# Replace the CHATTO_SMTP_* placeholders in .env, then:
+docker compose up -d
+```
+
+Visit `https://chat.example.com` and register with `admin@example.com`. Caddy
+obtains the HTTPS certificates automatically. The rest of this README explains
+the stack and the available customization options.
+
+`livekit.chat.example.com` is only an example. You can use any hostname you
+control, such as `calls.example.com`; update `CHATTO_LIVEKIT_URL` and the
+matching proxy route when using a different name.
 
 ## Prerequisites
 
 - Docker and Docker Compose (v2) installed
 - A domain pointing to your server (for automatic HTTPS)
 - A `livekit.` subdomain pointing to the same server (e.g., `livekit.chat.example.com`)
-- Firewall allowing inbound TCP 80/443 and UDP 3478, 50000-50200
+- Firewall allowing inbound TCP 80, 443, and 7881 plus UDP 3478 and 50000-50200
+
+## Why This Example Runs NATS Separately
+
+Chatto can embed NATS in its own process, which is ideal for the smallest binary
+setup. This Compose example runs NATS JetStream separately so you can restart or
+replace Chatto without restarting its data store, scale Chatto to multiple
+replicas, and move to a NATS cluster later.
+
+You are not locked into either model. Chatto's backup command creates a portable
+JetStream archive that can be restored into embedded or external NATS, making it
+straightforward to move between binary, Compose, and clustered deployments. See
+the [Backup & Restore guide](https://docs.chatto.run/guides/operations/backup-restore/) for
+the migration workflow and encryption-key guidance.
+
+## Using Your Existing Reverse Proxy
+
+The included Caddy service is a convenient default, not a requirement. If you
+already run Caddy, nginx, Apache, Traefik, or another public web server, keep it
+and configure two routes:
+
+| Public endpoint | Destination | Purpose |
+| --- | --- | --- |
+| Your Chatto HTTPS hostname | `chatto:4000` | Chatto web app, ConnectRPC APIs, realtime connections, and the LiveKit webhook |
+| Your LiveKit secure WebSocket hostname | `livekit:7880` | LiveKit API and WebSocket signaling |
+
+The hostnames can be any names you control. Both need publicly trusted TLS
+certificates. If your proxy is on the Compose network, use the service names
+above. If it runs on the Docker host, publish both upstreams on loopback:
+
+```yaml
+services:
+  chatto:
+    ports:
+      - "127.0.0.1:4000:4000"
+  livekit:
+    ports:
+      - "127.0.0.1:7880:7880"
+```
+
+Then remove the `caddy` service and its volumes from `compose.yml`. Keep the
+LiveKit media `ports` mappings described below.
+
+## What the Included Caddy Does
+
+When you do not already have a proxy, the included Caddy service obtains the
+certificates, configures both HTTP routes, and load-balances Chatto replicas.
+It does not carry WebRTC media. The standard Caddy image is an HTTP server and
+does not include the optional Caddy L4 plugin.
+
+Preserve these public ports when using Caddy or your own proxy:
+
+| Public endpoint | Destination | Purpose |
+| --- | --- | --- |
+| Your Chatto and LiveKit hostnames (TCP 443) | Your HTTP proxy | HTTPS and secure WebSocket traffic |
+| TCP 7881 | `livekit:7881` | WebRTC media fallback when direct UDP is unavailable |
+| UDP 3478 | `livekit:3478` | LiveKit's embedded TURN/STUN relay |
+| UDP 50000-50200 | Same ports on `livekit` | Direct WebRTC media |
+
+TCP 80 is also published in this example so Caddy can redirect HTTP and solve
+the ACME HTTP challenge. Your replacement proxy may use a different certificate
+flow. TLS for both HTTPS endpoints must use a publicly trusted certificate.
+
+The Compose `ports` entries publish LiveKit media directly on the host, so no L4
+Caddy configuration is needed. Do not expose NATS port 4222 publicly; Chatto and
+NATS communicate only over the private Compose network.
 
 ## Configuration
 
@@ -49,18 +133,16 @@ This example deploys a clustered Chatto setup with:
 
 3. Configure SMTP settings if you use direct email/password registration.
 
-### Manual setup fallback
+### Prefer to configure it by hand?
 
-Use this only if you cannot run `init-env.sh` or need to maintain secrets
-outside this folder:
+You usually do not need to. If you manage secrets elsewhere, start with:
 
 ```bash
 cp .env.example .env
 ```
 
-Then edit `.env`, replace every placeholder secret with output from
-`openssl rand -hex 32`, and edit `livekit.yaml` so the API key, API secret, and
-webhook URL match `.env`. LiveKit requires the API secret to be at least 32
+Fill in the placeholders and make sure the LiveKit key and secret are the same
+in `.env` and `livekit.yaml`. LiveKit requires its API secret to be at least 32
 characters.
 
 ## Usage
@@ -91,6 +173,28 @@ docker compose down -v
 # Scale to 5 replicas
 docker compose up -d --scale chatto=5
 ```
+
+Caddy discovers the replicas through Docker's internal DNS and distributes new
+requests across them. Existing realtime connections remain on the replica that
+accepted them.
+
+## Verify the Deployment
+
+```bash
+# Validate and render the Compose configuration
+docker compose config
+
+# Confirm all containers are running or healthy
+docker compose ps
+
+# Check both HTTPS endpoints
+curl --fail --silent --show-error --output /dev/null https://chat.example.com
+curl --fail --silent --show-error --output /dev/null https://livekit.chat.example.com
+```
+
+The HTTPS checks verify routing and LiveKit signaling, but not WebRTC media.
+Join a call from two different networks or devices to exercise TCP 7881 and the
+UDP media ports.
 
 ## Inspecting NATS
 
@@ -133,9 +237,9 @@ Data is persisted in Docker volumes:
 - `caddy_data` - TLS certificates
 - `caddy_config` - Caddy configuration cache
 
-## Disabling Voice Calls
+## Disabling Voice and Video Calls
 
-If you don't need voice calls, remove the `livekit` service from `compose.yml`, delete the selected LiveKit config (`livekit.generated.yaml` or `livekit.yaml`), and remove the LiveKit environment variables from `.env`.
+If you don't need calls, remove the `livekit` service from `compose.yml`, delete the selected LiveKit config (`livekit.generated.yaml` or `livekit.yaml`), remove the `livekit.*` block from the `Caddyfile`, remove LiveKit from `chatto.depends_on` and `caddy.depends_on`, and remove the LiveKit environment variables from `.env`. You can then close TCP 7881 and UDP 3478 and 50000-50200 and remove the `livekit.*` DNS record.
 
 ## Troubleshooting
 
@@ -149,8 +253,8 @@ If you don't need voice calls, remove the `livekit` service from `compose.yml`, 
 
 **Container startup order issues**: The `depends_on` with `condition: service_healthy` ensures NATS and LiveKit are ready before Chatto starts.
 
-**Voice calls not working**: Ensure the LiveKit API key/secret in `.env` matches the `keys:` section in the selected LiveKit config (`livekit.generated.yaml` or `livekit.yaml`). Also verify the webhook URL points to your Chatto instance. Make sure `CHATTO_LIVEKIT_URL` uses the public `wss://livekit.` subdomain (not the internal Docker hostname), since browsers connect to it directly.
+**Calls not working**: Ensure the LiveKit API key/secret in `.env` matches the `keys:` section in the selected LiveKit config (`livekit.generated.yaml` or `livekit.yaml`). Also verify the webhook URL points to your Chatto instance. Make sure `CHATTO_LIVEKIT_URL` uses the public `wss://livekit.` subdomain (not the internal Docker hostname), since browsers connect to it directly.
 
-**LiveKit UDP ports**: The example exposes UDP 50000-50200 for direct WebRTC media and UDP 3478 for LiveKit's embedded TURN/STUN relay. Ensure your firewall allows inbound UDP on both.
+**LiveKit media ports**: The example exposes UDP 50000-50200 for direct WebRTC media, UDP 3478 for LiveKit's embedded TURN/STUN relay, and TCP 7881 as a media fallback. Ensure your firewall allows all three.
 
 **Calls fail for some users**: The built-in TURN/UDP relay helps with symmetric NATs and some mobile, Firefox, and restrictive-network cases. Networks that block UDP entirely still need an advanced TURN/TLS setup, such as a dedicated TURN host or L4 TLS forwarding with matching certificates.

--- a/examples/dockercompose/compose.yml
+++ b/examples/dockercompose/compose.yml
@@ -17,6 +17,7 @@ services:
       - /etc/livekit.yaml
     ports:
       - "50000-50200:50000-50200/udp"  # WebRTC media (UDP, must be direct)
+      - "7881:7881/tcp"  # WebRTC media fallback when UDP is unavailable
       - "3478:3478/udp"  # TURN/STUN relay for NAT traversal
     expose:
       - "7880"  # WebSocket signaling (proxied through Caddy)

--- a/examples/dockercompose/init-env.sh
+++ b/examples/dockercompose/init-env.sh
@@ -127,6 +127,7 @@ EOF
 cat > livekit.generated.yaml <<EOF
 port: 7880
 rtc:
+  tcp_port: 7881
   port_range_start: 50000
   port_range_end: 50200
   use_external_ip: true

--- a/examples/dockercompose/livekit.yaml
+++ b/examples/dockercompose/livekit.yaml
@@ -1,5 +1,6 @@
 port: 7880
 rtc:
+  tcp_port: 7881
   port_range_start: 50000
   port_range_end: 50200
   use_external_ip: true


### PR DESCRIPTION
## Summary

Expands the Docker Compose documentation with a beginner-friendly quick start, clearer explanations of dedicated NATS and portable JetStream backups, and guidance for existing reverse proxies and custom LiveKit hostnames.
Completes the example's LiveKit networking with ICE/TCP port 7881 and updates the architecture diagram and voice/video call guide accordingly.
Updates Caddy to discover and load-balance scaled Chatto replicas through Docker DNS, while documenting direct WebRTC media routing and deployment verification.
Validated with Caddy config adaptation, generated environment and LiveKit config checks, `docker compose config`, the docs website build, and `git diff --check`.
