### PR TITLE
refactor(frontend): simplify timeline scroll convergence

### DIFF
--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -26,6 +26,7 @@
   import { useMayHaveMissedMessagesCallback } from '$lib/hooks/useMayHaveMissedMessagesCallback.svelte';
   import type { ResumeSignal } from '$lib/hooks/resumeCoordinator.svelte';
   import type { OpenThreadHandler, ThreadOpenOptions } from './threadOpenOptions';
+  import { convergeAtBottom } from './bottomScrollConvergence';
   import {
     scheduleNextTombstoneExpiry,
     shouldHideTombstone,
@@ -127,6 +128,7 @@
   let presentScrollRequest = $state(0);
   let presentScrollSequence = 0;
   let activePresentScrollRequest = 0;
+  let bottomScrollOperation = 0;
   let userScrollIntentAt = 0;
   const USER_SCROLL_INTENT_MS = 250;
 
@@ -260,6 +262,7 @@
     presentScrollSequence += 1;
     presentScrollRequest = 0;
     activePresentScrollRequest = 0;
+    cancelBottomScroll();
     initialScrollDone = false;
     setShouldScrollToBottom(true);
     lastSeenNewestId = null;
@@ -309,9 +312,7 @@
       }
       tick().then(() => {
         if (scrollContainer && shouldScrollToBottom) {
-          startScrollCorrection();
-          scrollContainer.scrollTop = scrollContainer.scrollHeight;
-          scrollFader?.refresh();
+          void requestBottomScroll();
         }
       });
     }
@@ -420,6 +421,53 @@
     }
   }
 
+  function cancelBottomScroll() {
+    bottomScrollOperation += 1;
+  }
+
+  async function requestBottomScroll(markInitialDone = false): Promise<boolean> {
+    if (!scrollContainer || !virtualizerHandle || virtualItems.length === 0) return false;
+
+    const operation = ++bottomScrollOperation;
+    const requestedRoomId = roomId;
+    const intentAtStart = userScrollIntentAt;
+    const converged = await convergeAtBottom({
+      continueWhile: () =>
+        operation === bottomScrollOperation &&
+        roomId === requestedRoomId &&
+        userScrollIntentAt === intentAtStart &&
+        !isJumpedMode &&
+        (alwaysScrollToBottom || shouldScrollToBottom) &&
+        Boolean(scrollContainer && virtualizerHandle),
+      waitForFrame: async () => {
+        await tick();
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+      },
+      scroll: () => {
+        if (!scrollContainer) return;
+        safeScrollToIndex(virtualItems.length - 1, { align: 'end' });
+        scrollContainer.scrollTop = scrollContainer.scrollHeight;
+        scrollFader?.refresh();
+      },
+      measure: () => {
+        if (!virtualizerHandle) return null;
+        return {
+          distanceFromBottom:
+            virtualizerHandle.getScrollSize() -
+            virtualizerHandle.getScrollOffset() -
+            virtualizerHandle.getViewportSize(),
+          scrollSize: virtualizerHandle.getScrollSize(),
+          viewportSize: virtualizerHandle.getViewportSize()
+        };
+      }
+    });
+
+    if (operation === bottomScrollOperation && markInitialDone) {
+      initialScrollDone = true;
+    }
+    return converged;
+  }
+
   // Register the scroll container with ScrollState so sibling components
   // (MessageComposer, TypingIndicator) can synchronously scroll without waiting
   // for ResizeObserver callbacks.
@@ -450,24 +498,7 @@
     if (virtualItems.length > 0 && virtualizerHandle) {
       const shouldScroll = untrack(() => alwaysScrollToBottom || shouldScrollToBottom);
       if (shouldScroll) {
-        // Wait for Svelte to flush DOM updates so the virtualizer has
-        // accurate measurements for the new items before scrolling.
-        tick().then(() => {
-          if (!virtualizerHandle) return;
-          if (!untrack(() => alwaysScrollToBottom || shouldScrollToBottom)) return;
-          startScrollCorrection();
-          safeScrollToIndex(virtualItems.length - 1, { align: 'end' });
-          scrollFader?.refresh();
-          if (!untrack(() => initialScrollDone)) {
-            // Give virtua time to measure actual item heights and settle the
-            // scroll position.
-            setTimeout(() => {
-              safeScrollToIndex(virtualItems.length - 1, { align: 'end' });
-              scrollFader?.refresh();
-              initialScrollDone = true;
-            }, 80);
-          }
-        });
+        void requestBottomScroll(!untrack(() => initialScrollDone));
       }
     }
   });
@@ -476,10 +507,7 @@
   function scrollToBottom() {
     setShouldScrollToBottom(true);
     onReachedBottom?.();
-    if (virtualizerHandle) {
-      safeScrollToIndex(virtualItems.length - 1, { align: 'end' });
-      scrollFader?.refresh();
-    }
+    void requestBottomScroll();
   }
 
   function handleJumpToPresentClick() {
@@ -510,67 +538,8 @@
     if (isJumpedMode || isLoading || virtualItems.length === 0 || !virtualizerHandle) return;
 
     activePresentScrollRequest = request;
-    const requestedRoomId = roomId;
-    const intentAtStart = userScrollIntentAt;
-
-    void (async () => {
-      let settledFrames = 0;
-      let previousScrollSize: number | null = null;
-      let previousViewportSize: number | null = null;
-      for (let frame = 0; frame < 30 && settledFrames < 6; frame++) {
-        await tick();
-        await new Promise((resolve) => requestAnimationFrame(resolve));
-
-        if (
-          request !== presentScrollRequest ||
-          roomId !== requestedRoomId ||
-          isJumpedMode ||
-          userScrollIntentAt !== intentAtStart ||
-          !scrollContainer ||
-          !virtualizerHandle
-        ) {
-          return;
-        }
-
-        startScrollCorrection();
-        safeScrollToIndex(virtualItems.length - 1, { align: 'end' });
-        scrollContainer.scrollTop = scrollContainer.scrollHeight;
-        scrollFader?.refresh();
-
-        const bottomDistance = distanceFromBottom();
-        const scrollSize = virtualizerHandle.getScrollSize();
-        const viewportSize = virtualizerHandle.getViewportSize();
-        const measurementsUnchanged =
-          scrollSize === previousScrollSize && viewportSize === previousViewportSize;
-        settledFrames =
-          bottomDistance !== null && bottomDistance < 10 && measurementsUnchanged
-            ? settledFrames + 1
-            : 0;
-        previousScrollSize = scrollSize;
-        previousViewportSize = viewportSize;
-      }
-
-      initialScrollDone = true;
-    })();
+    void requestBottomScroll(true);
   });
-
-  // Timer-based flag set by programmatic scrolls (auto-scroll effect, scroll-request
-  // effect). During the window, handleVirtuaScroll will self-correct if the virtualizer
-  // re-measures items (changing scrollHeight) and leaves position short of bottom.
-  // Uses a timeout because the virtualizer may settle over multiple frames — a simple
-  // distance check clears too early (first scroll reaches bottom, flag clears, then
-  // virtualizer re-renders and grows scrollHeight).
-  let pendingScrollCorrection = false;
-  let scrollCorrectionTimer: ReturnType<typeof setTimeout> | null = null;
-
-  function startScrollCorrection() {
-    pendingScrollCorrection = true;
-    if (scrollCorrectionTimer) clearTimeout(scrollCorrectionTimer);
-    scrollCorrectionTimer = setTimeout(() => {
-      pendingScrollCorrection = false;
-      scrollCorrectionTimer = null;
-    }, 500);
-  }
 
   // Lock to prevent virtua's scroll corrections from immediately re-enabling
   // auto-scroll after we detect a user scroll-up. Without this, $fixScrollJump
@@ -586,6 +555,7 @@
   // layout shifts never get misread as the user scrolling up.
   function markUserScrollIntent() {
     userScrollIntentAt = Date.now();
+    cancelBottomScroll();
   }
 
   function markKeyboardScrollIntent(event: KeyboardEvent) {
@@ -734,13 +704,7 @@
 
       if (wasAtBottom) {
         setShouldScrollToBottom(true);
-        initialScrollDone = true;
-        startScrollCorrection();
-        scrollContainer?.scrollTo({ top: scrollContainer.scrollHeight });
-        if (virtualItems.length > 0) {
-          safeScrollToIndex(virtualItems.length - 1, { align: 'end' });
-        }
-        scrollFader?.refresh();
+        await requestBottomScroll(true);
         console.debug('[room-refresh] event list refresh completed at bottom', {
           roomId,
           result,
@@ -928,34 +892,13 @@
         distanceFromBottom > 20
       ) {
         setShouldScrollToBottom(false);
-        pendingScrollCorrection = false;
-        if (scrollCorrectionTimer) {
-          clearTimeout(scrollCorrectionTimer);
-          scrollCorrectionTimer = null;
-        }
+        cancelBottomScroll();
         scrollUpLock = true;
         if (scrollUpLockTimer) clearTimeout(scrollUpLockTimer);
         scrollUpLockTimer = setTimeout(() => {
           scrollUpLock = false;
         }, 150);
       }
-    }
-
-    // Self-correcting scroll: after a programmatic scroll, the virtualizer may
-    // re-measure items (changing scrollHeight), leaving the position short of
-    // the bottom. Re-scroll to the true bottom. Only fires during the short
-    // window after a programmatic scroll set the flag — never during user scrolling.
-    // Also gated on shouldScrollToBottom so a stale correction window from the
-    // initial auto-scroll doesn't yank the user back to the bottom after a
-    // jump-to-message takes them to an old event within those 500ms.
-    if (
-      pendingScrollCorrection &&
-      (alwaysScrollToBottom || shouldScrollToBottom) &&
-      distanceFromBottom > 50 &&
-      scrollContainer
-    ) {
-      scrollContainer.scrollTop = scrollContainer.scrollHeight;
-      scrollFader?.refresh();
     }
 
     previousOffset = offset;

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -127,7 +127,6 @@
   let initialScrollDone = $state(false);
   let presentScrollRequest = $state(0);
   let presentScrollSequence = 0;
-  let activePresentScrollRequest = 0;
   let bottomScrollOperation = 0;
   let userScrollIntentAt = 0;
   const USER_SCROLL_INTENT_MS = 250;
@@ -261,7 +260,6 @@
 
     presentScrollSequence += 1;
     presentScrollRequest = 0;
-    activePresentScrollRequest = 0;
     cancelBottomScroll();
     initialScrollDone = false;
     setShouldScrollToBottom(true);
@@ -533,7 +531,7 @@
     void virtualizerHandle;
     void scrollContainer;
 
-    if (request === 0 || request === activePresentScrollRequest) return;
+    if (request === 0) return;
     if (
       isJumpedMode ||
       isLoading ||
@@ -546,7 +544,6 @@
 
     const bottomScroll = requestBottomScroll();
     if (!bottomScroll) return;
-    activePresentScrollRequest = request;
     void bottomScroll;
   });
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -425,13 +425,13 @@
     bottomScrollOperation += 1;
   }
 
-  async function requestBottomScroll(markInitialDone = false): Promise<boolean> {
-    if (!scrollContainer || !virtualizerHandle || virtualItems.length === 0) return false;
+  function requestBottomScroll(): Promise<boolean> | undefined {
+    if (!scrollContainer || !virtualizerHandle || virtualItems.length === 0) return undefined;
 
     const operation = ++bottomScrollOperation;
     const requestedRoomId = roomId;
     const intentAtStart = userScrollIntentAt;
-    const converged = await convergeAtBottom({
+    return convergeAtBottom({
       continueWhile: () =>
         operation === bottomScrollOperation &&
         roomId === requestedRoomId &&
@@ -460,12 +460,10 @@
           viewportSize: virtualizerHandle.getViewportSize()
         };
       }
+    }).then((converged) => {
+      if (operation === bottomScrollOperation) initialScrollDone = true;
+      return converged;
     });
-
-    if (operation === bottomScrollOperation && markInitialDone) {
-      initialScrollDone = true;
-    }
-    return converged;
   }
 
   // Register the scroll container with ScrollState so sibling components
@@ -498,7 +496,7 @@
     if (virtualItems.length > 0 && virtualizerHandle) {
       const shouldScroll = untrack(() => alwaysScrollToBottom || shouldScrollToBottom);
       if (shouldScroll) {
-        void requestBottomScroll(!untrack(() => initialScrollDone));
+        void requestBottomScroll();
       }
     }
   });
@@ -533,12 +531,23 @@
     void isLoading;
     void virtualItems.length;
     void virtualizerHandle;
+    void scrollContainer;
 
     if (request === 0 || request === activePresentScrollRequest) return;
-    if (isJumpedMode || isLoading || virtualItems.length === 0 || !virtualizerHandle) return;
+    if (
+      isJumpedMode ||
+      isLoading ||
+      virtualItems.length === 0 ||
+      !virtualizerHandle ||
+      !scrollContainer
+    ) {
+      return;
+    }
 
+    const bottomScroll = requestBottomScroll();
+    if (!bottomScroll) return;
     activePresentScrollRequest = request;
-    void requestBottomScroll(true);
+    void bottomScroll;
   });
 
   // Lock to prevent virtua's scroll corrections from immediately re-enabling
@@ -704,7 +713,7 @@
 
       if (wasAtBottom) {
         setShouldScrollToBottom(true);
-        await requestBottomScroll(true);
+        await requestBottomScroll();
         console.debug('[room-refresh] event list refresh completed at bottom', {
           roomId,
           result,

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -544,6 +544,7 @@
 
     const bottomScroll = requestBottomScroll();
     if (!bottomScroll) return;
+    presentScrollRequest = 0;
     void bottomScroll;
   });
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
@@ -2,6 +2,9 @@ import { describe, expect, it, vi } from 'vitest';
 import { page } from 'vitest/browser';
 import { render } from 'vitest-browser-svelte';
 import EventListTestHarness from './EventListTestHarness.svelte';
+import { setVirtualizerScrollOffset } from './EventListVirtualizerMock.svelte';
+
+const resumeCallbacks = vi.hoisted(() => [] as Array<() => void>);
 
 vi.mock('virtua/svelte', async () => {
   const { default: Virtualizer } = await import('./EventListVirtualizerMock.svelte');
@@ -27,7 +30,7 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
 }));
 
 vi.mock('$lib/hooks/useTabResumeCallback.svelte', () => ({
-  useTabResumeCallback: () => {}
+  useTabResumeCallback: (callback: () => void) => resumeCallbacks.push(callback)
 }));
 
 vi.mock('$lib/hooks/useMayHaveMissedMessagesCallback.svelte', () => ({
@@ -112,6 +115,97 @@ describe('EventList jump completion', () => {
 
       expect(onComplete).not.toHaveBeenCalled();
     } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('starts a pending return-to-present scroll when loading finishes', async () => {
+    const onJumpToPresent = vi.fn();
+    const rendered = render(EventListTestHarness, {
+      props: {
+        eventIds: ['msg-target'],
+        scrollToEventId: 'msg-target',
+        isJumpedMode: true,
+        onJumpToPresent
+      }
+    });
+
+    await expect.element(page.getByTestId('jump-to-present')).toBeVisible();
+    const callsBeforeJump = Number(
+      page.getByTestId('virtualizer-scroll-calls').element().textContent
+    );
+    await page.getByTestId('jump-to-present').click();
+    expect(onJumpToPresent).toHaveBeenCalledOnce();
+
+    await rendered.rerender({
+      eventIds: ['msg-target'],
+      scrollToEventId: null,
+      isJumpedMode: false,
+      isLoading: true,
+      onJumpToPresent
+    });
+    await expect.element(page.getByTestId('virtualizer-scroll-calls')).not.toBeInTheDocument();
+
+    await rendered.rerender({
+      eventIds: ['msg-target'],
+      scrollToEventId: null,
+      isJumpedMode: false,
+      isLoading: false,
+      onJumpToPresent
+    });
+    await vi.waitFor(() =>
+      expect(
+        Number(page.getByTestId('virtualizer-scroll-calls').element().textContent)
+      ).toBeGreaterThan(callsBeforeJump)
+    );
+  });
+
+  it('completes initialization when a bottom scroll supersedes the initial request', async () => {
+    const animationFrames: FrameRequestCallback[] = [];
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        animationFrames.push(callback);
+        return animationFrames.length;
+      })
+    );
+    try {
+      const rendered = render(EventListTestHarness, {
+        props: {
+          eventIds: ['msg-target'],
+          scrollToEventId: null,
+          updateCounter: 0
+        }
+      });
+
+      await vi.waitFor(() => expect(animationFrames.length).toBeGreaterThan(0));
+      await rendered.rerender({
+        eventIds: ['msg-target'],
+        scrollToEventId: null,
+        updateCounter: 1
+      });
+
+      for (let frame = 0; frame < 50; frame++) {
+        await vi.waitFor(() => expect(animationFrames.length).toBeGreaterThan(0));
+        animationFrames.shift()?.(frame * 16);
+        if (Number(page.getByTestId('virtualizer-scroll-calls').element().textContent) >= 7) {
+          break;
+        }
+      }
+      await vi.waitFor(() =>
+        expect(
+          Number(page.getByTestId('virtualizer-scroll-calls').element().textContent)
+        ).toBeGreaterThanOrEqual(7)
+      );
+      await Promise.resolve();
+
+      const resume = resumeCallbacks.at(-1);
+      expect(resume).toBeDefined();
+      setVirtualizerScrollOffset(400);
+      resume?.();
+      await expect.element(page.getByTestId('jump-to-present')).toBeVisible();
+    } finally {
+      setVirtualizerScrollOffset(700);
       vi.unstubAllGlobals();
     }
   });

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
@@ -126,7 +126,8 @@ describe('EventList jump completion', () => {
         eventIds: ['msg-target'],
         scrollToEventId: 'msg-target',
         isJumpedMode: true,
-        onJumpToPresent
+        onJumpToPresent,
+        pendingHighlightId: 'suppress-normal-auto-scroll'
       }
     });
 
@@ -142,7 +143,8 @@ describe('EventList jump completion', () => {
       scrollToEventId: null,
       isJumpedMode: false,
       isLoading: true,
-      onJumpToPresent
+      onJumpToPresent,
+      pendingHighlightId: 'suppress-normal-auto-scroll'
     });
     await expect.element(page.getByTestId('virtualizer-scroll-calls')).not.toBeInTheDocument();
 
@@ -151,7 +153,8 @@ describe('EventList jump completion', () => {
       scrollToEventId: null,
       isJumpedMode: false,
       isLoading: false,
-      onJumpToPresent
+      onJumpToPresent,
+      pendingHighlightId: 'suppress-normal-auto-scroll'
     });
     await vi.waitFor(() =>
       expect(

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListTestHarness.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListTestHarness.svelte
@@ -16,7 +16,8 @@
     isLoading = false,
     isJumpedMode = false,
     onJumpToPresent,
-    updateCounter = 0
+    updateCounter = 0,
+    pendingHighlightId = null
   }: {
     eventIds: string[];
     scrollToEventId: string | null;
@@ -25,6 +26,7 @@
     isJumpedMode?: boolean;
     onJumpToPresent?: () => void;
     updateCounter?: number;
+    pendingHighlightId?: string | null;
   } = $props();
 
   createComposerContext({ scroll: true });
@@ -78,6 +80,7 @@
   {isJumpedMode}
   {onJumpToPresent}
   {updateCounter}
+  {pendingHighlightId}
   {scrollToEventId}
   onScrollToEventComplete={onComplete}
 />

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListTestHarness.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListTestHarness.svelte
@@ -12,11 +12,19 @@
   let {
     eventIds,
     scrollToEventId,
-    onComplete
+    onComplete,
+    isLoading = false,
+    isJumpedMode = false,
+    onJumpToPresent,
+    updateCounter = 0
   }: {
     eventIds: string[];
     scrollToEventId: string | null;
     onComplete?: () => void;
+    isLoading?: boolean;
+    isJumpedMode?: boolean;
+    onJumpToPresent?: () => void;
+    updateCounter?: number;
   } = $props();
 
   createComposerContext({ scroll: true });
@@ -66,7 +74,10 @@
   roomId="room-1"
   messageStore={messageStore as never}
   {events}
-  isLoading={false}
+  {isLoading}
+  {isJumpedMode}
+  {onJumpToPresent}
+  {updateCounter}
   {scrollToEventId}
   onScrollToEventComplete={onComplete}
 />

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListVirtualizerMock.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListVirtualizerMock.svelte
@@ -1,3 +1,11 @@
+<script module lang="ts">
+  let scrollOffset = 700;
+
+  export function setVirtualizerScrollOffset(offset: number) {
+    scrollOffset = offset;
+  }
+</script>
+
 <script lang="ts">
   import type { Snippet } from 'svelte';
 
@@ -10,9 +18,11 @@
   } = $props();
 
   let renderedIndex = $state<number | null>(null);
+  let scrollCalls = $state(0);
 
   export function scrollToIndex(index: number) {
     renderedIndex = index;
+    scrollCalls += 1;
   }
 
   export function getScrollSize() {
@@ -20,7 +30,7 @@
   }
 
   export function getScrollOffset() {
-    return 400;
+    return scrollOffset;
   }
 
   export function getViewportSize() {
@@ -33,6 +43,7 @@
 </script>
 
 <output data-testid="virtualizer-scroll-index">{renderedIndex ?? ''}</output>
+<output data-testid="virtualizer-scroll-calls">{scrollCalls}</output>
 {#if renderedIndex !== null && data[renderedIndex] !== undefined}
   {@render children(data[renderedIndex])}
 {/if}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/bottomScrollConvergence.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/bottomScrollConvergence.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import { convergeAtBottom, type BottomScrollMeasurement } from './bottomScrollConvergence';
+
+describe('convergeAtBottom', () => {
+  it('waits for virtualizer measurements to remain stable', async () => {
+    const measurements: BottomScrollMeasurement[] = [
+      { distanceFromBottom: 0, scrollSize: 1_000, viewportSize: 400 },
+      { distanceFromBottom: 0, scrollSize: 1_000, viewportSize: 400 },
+      { distanceFromBottom: 80, scrollSize: 1_080, viewportSize: 400 },
+      { distanceFromBottom: 0, scrollSize: 1_080, viewportSize: 400 },
+      { distanceFromBottom: 0, scrollSize: 1_080, viewportSize: 400 },
+      { distanceFromBottom: 0, scrollSize: 1_080, viewportSize: 400 }
+    ];
+    let frame = -1;
+    const scroll = vi.fn();
+
+    const converged = await convergeAtBottom({
+      continueWhile: () => true,
+      measure: () => measurements[frame] ?? measurements.at(-1)!,
+      scroll,
+      waitForFrame: async () => {
+        frame += 1;
+      },
+      requiredStableFrames: 2
+    });
+
+    expect(converged).toBe(true);
+    expect(scroll).toHaveBeenCalledTimes(5);
+  });
+
+  it('stops without scrolling again when superseded', async () => {
+    let active = true;
+    const scroll = vi.fn();
+
+    const converged = await convergeAtBottom({
+      continueWhile: () => active,
+      measure: () => ({ distanceFromBottom: 0, scrollSize: 1_000, viewportSize: 400 }),
+      scroll,
+      waitForFrame: async () => {
+        active = false;
+      }
+    });
+
+    expect(converged).toBe(false);
+    expect(scroll).not.toHaveBeenCalled();
+  });
+
+  it('returns false when measurements never settle within the frame budget', async () => {
+    let frame = 0;
+
+    const converged = await convergeAtBottom({
+      continueWhile: () => true,
+      measure: () => ({ distanceFromBottom: 0, scrollSize: frame++, viewportSize: 400 }),
+      scroll: vi.fn(),
+      waitForFrame: async () => {},
+      maxFrames: 4,
+      requiredStableFrames: 2
+    });
+
+    expect(converged).toBe(false);
+  });
+});

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/bottomScrollConvergence.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/bottomScrollConvergence.ts
@@ -1,0 +1,53 @@
+export type BottomScrollMeasurement = {
+  distanceFromBottom: number;
+  scrollSize: number;
+  viewportSize: number;
+};
+
+type ConvergeAtBottomOptions = {
+  continueWhile: () => boolean;
+  measure: () => BottomScrollMeasurement | null;
+  scroll: () => void;
+  waitForFrame: () => Promise<void>;
+  maxFrames?: number;
+  requiredStableFrames?: number;
+  tolerancePx?: number;
+};
+
+/**
+ * Keep scrolling a virtualized list to its bottom until its measurements stop
+ * changing. Returns false when superseded or when convergence exceeds the
+ * bounded frame budget.
+ */
+export async function convergeAtBottom({
+  continueWhile,
+  measure,
+  scroll,
+  waitForFrame,
+  maxFrames = 30,
+  requiredStableFrames = 6,
+  tolerancePx = 10
+}: ConvergeAtBottomOptions): Promise<boolean> {
+  let stableFrames = 0;
+  let previousScrollSize: number | null = null;
+  let previousViewportSize: number | null = null;
+
+  for (let frame = 0; frame < maxFrames && stableFrames < requiredStableFrames; frame++) {
+    await waitForFrame();
+    if (!continueWhile()) return false;
+
+    scroll();
+    const measurement = measure();
+    if (!measurement) return false;
+
+    const measurementsUnchanged =
+      measurement.scrollSize === previousScrollSize &&
+      measurement.viewportSize === previousViewportSize;
+    stableFrames =
+      measurement.distanceFromBottom < tolerancePx && measurementsUnchanged ? stableFrames + 1 : 0;
+    previousScrollSize = measurement.scrollSize;
+    previousViewportSize = measurement.viewportSize;
+  }
+
+  return stableFrames >= requiredStableFrames;
+}


### PR DESCRIPTION
## Summary

- consolidate all programmatic timeline bottom scrolling behind one cancellable convergence path
- remove the overlapping fixed-delay retry and timer-based correction window from `EventList`
- extract the measurement-driven convergence algorithm for direct unit testing
- add component coverage for delayed Return to Present readiness and superseded initial scrolling

## Testing

- `mise x -- pnpm --dir apps/frontend exec vitest run 'src/routes/chat/[serverId]/[roomId]/bottomScrollConvergence.spec.ts' 'src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts'`
- `mise x -- pnpm --dir apps/frontend exec playwright test e2e/jump-to-message.test.ts e2e/auto-scroll.test.ts --workers=4 --retries=0`
- `mise lint-frontend`
- Svelte autofixer on all changed Svelte components: no issues

Closes #1426.
