### PR TITLE
refactor(frontend): make Return to Present direct

### DIFF
--- a/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -605,6 +605,51 @@ describe('MessagesStore — room lifecycle ownership', () => {
     store.dispose();
   });
 
+  it('resolves returning to present only after initial backfill completes', async () => {
+    const fake = new FakeQueryClient();
+    type RoomPage = Awaited<ReturnType<RoomTimelineAPI['getRoomEvents']>>;
+    let resolveOlder: ((page: RoomPage) => void) | undefined;
+    const olderPage = new Promise<RoomPage>((resolve) => {
+      resolveOlder = resolve;
+    });
+    const timeline = fakeTimelineAPI({
+      getRoomEvents: vi
+        .fn()
+        .mockResolvedValueOnce(emptyPage())
+        .mockResolvedValueOnce({
+          events: [threadMessageEvent('present') as never],
+          startCursor: 'tl:present',
+          endCursor: 'tl:present',
+          hasOlder: true,
+          hasNewer: false
+        })
+        .mockImplementationOnce(() => olderPage)
+    });
+    const store = new MessagesStore(fake as unknown as ServerConnection, () => null, timeline);
+    store.setRoom('room-1');
+    await settle();
+
+    let completed = false;
+    const returningToPresent = store.jumpToPresent(new JumpToMessageState()).then((loaded) => {
+      completed = true;
+      return loaded;
+    });
+    await settle();
+    expect(completed).toBe(false);
+
+    resolveOlder?.({
+      events: [threadMessageEvent('older') as never],
+      startCursor: 'tl:older',
+      endCursor: 'tl:older',
+      hasOlder: false,
+      hasNewer: true
+    });
+
+    await expect(returningToPresent).resolves.toBe(true);
+    expect(store.rootEvents.map((event) => event.id)).toEqual(['older', 'present']);
+    store.dispose();
+  });
+
   it('clears jump loading when an in-flight jump is superseded by a loaded target', async () => {
     const fake = new FakeQueryClient();
     type AroundPage = Awaited<ReturnType<RoomTimelineAPI['getRoomEventsAround']>>;

--- a/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -490,10 +490,7 @@ describe('MessagesStore — room lifecycle ownership', () => {
     });
     await settle();
 
-    expect(store.rootEvents.map((event) => event.id)).toEqual([
-      'authoritative',
-      'linked-realtime'
-    ]);
+    expect(store.rootEvents.map((event) => event.id)).toEqual(['authoritative', 'linked-realtime']);
     expect(store.isInitialLoading).toBe(false);
     store.dispose();
   });
@@ -578,7 +575,7 @@ describe('MessagesStore — room lifecycle ownership', () => {
           events: [threadMessageEvent('present') as never],
           startCursor: 'tl:present',
           endCursor: 'tl:present',
-          hasOlder: true,
+          hasOlder: false,
           hasNewer: false
         }),
       getRoomEventsAround: vi.fn(() => aroundPage)
@@ -589,8 +586,9 @@ describe('MessagesStore — room lifecycle ownership', () => {
 
     const jumpState = new JumpToMessageState();
     const jumping = store.jumpToMessage('historical', jumpState);
-    store.jumpToPresent(jumpState);
+    const returningToPresent = store.jumpToPresent(jumpState);
     await settle();
+    await expect(returningToPresent).resolves.toBe(true);
 
     resolveAround?.({
       events: [threadMessageEvent('historical') as never],
@@ -1823,7 +1821,9 @@ describe('MessagesStore — room lifecycle ownership', () => {
     await store.loadMore();
     await settle();
 
-    expect(store.rootEvents.map((event) => event.id)).toEqual(currentWindow.map((event) => event.id));
+    expect(store.rootEvents.map((event) => event.id)).toEqual(
+      currentWindow.map((event) => event.id)
+    );
     expect(store.hasReachedStart).toBe(false);
 
     await store.loadMore();

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -387,7 +387,7 @@ export class MessagesStore {
     this.#pendingJumpId = null;
     this.roomId = roomId;
     this.threadRootEventId = '';
-    this.resetAndFetchLatest();
+    void this.resetAndFetchLatest();
   }
 
   setThread(roomId: string, threadRootEventId: string): void {
@@ -710,13 +710,13 @@ export class MessagesStore {
     }
   }
 
-  jumpToPresent(jumpState: JumpToMessageState): void {
-    if (this.scope !== 'room') return;
+  jumpToPresent(jumpState: JumpToMessageState): Promise<boolean> {
+    if (this.scope !== 'room') return Promise.resolve(false);
     this.#jumpId++;
     this.#windowId++;
     this.#pendingJumpId = null;
     jumpState.reset();
-    this.resetAndFetchLatest();
+    return this.resetAndFetchLatest();
   }
 
   /**
@@ -1256,37 +1256,39 @@ export class MessagesStore {
     return { hasOlder: page.hasOlder, hasNewer: page.hasNewer, refreshed: true, changed };
   }
 
-  private resetAndFetchLatest(): void {
+  private resetAndFetchLatest(): Promise<boolean> {
     const thisLoad = this.startLoad();
     this.#pendingAuthoritativeLoadId = thisLoad;
     this.resetState();
     this.isInitialLoading = true;
-    this.fetchLatest(thisLoad);
+    return this.fetchLatest(thisLoad);
   }
 
-  private fetchLatest(thisLoad: number): void {
+  private fetchLatest(thisLoad: number): Promise<boolean> {
     const promise = this.roomTimeline.getRoomEvents({
       roomId: this.roomId,
       limit: PAGE_SIZE
     });
 
-    promise
+    return promise
       .then(async (page) => {
-        if (this.isStale(thisLoad)) return;
+        if (this.isStale(thisLoad)) return false;
         if (page) {
           this.replaceWithFetchedAndUpdateCursors(page);
           this.hasReachedStart = !page.hasOlder;
           await this.backfillInitialRoomWindow(thisLoad);
         }
-        if (this.isStale(thisLoad)) return;
+        if (this.isStale(thisLoad)) return false;
         this.#pendingAuthoritativeLoadId = null;
         this.isInitialLoading = false;
+        return true;
       })
       .catch((error: unknown) => {
-        if (this.isStale(thisLoad)) return;
+        if (this.isStale(thisLoad)) return false;
         console.error('MessagesStore: fetchLatest failed:', error);
         this.#pendingAuthoritativeLoadId = null;
         this.isInitialLoading = false;
+        return false;
       });
   }
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -111,7 +111,7 @@
     isLoadingNewer?: boolean;
     hasReachedEnd?: boolean;
     onLoadNewer?: () => Promise<void>;
-    onJumpToPresent?: () => void;
+    onJumpToPresent?: () => Promise<boolean>;
     onReachedPresent?: () => void;
     onReachedBottom?: () => void;
     onSoftRefresh?: (result: RefreshCurrentWindowResult, anchored: boolean) => void;
@@ -125,8 +125,6 @@
   };
 
   let initialScrollDone = $state(false);
-  let presentScrollRequest = $state(0);
-  let presentScrollSequence = 0;
   let bottomScrollOperation = 0;
   let userScrollIntentAt = 0;
   const USER_SCROLL_INTENT_MS = 250;
@@ -258,8 +256,6 @@
   $effect(() => {
     void roomId;
 
-    presentScrollSequence += 1;
-    presentScrollRequest = 0;
     cancelBottomScroll();
     initialScrollDone = false;
     setShouldScrollToBottom(true);
@@ -506,47 +502,21 @@
     void requestBottomScroll();
   }
 
-  function handleJumpToPresentClick() {
+  async function handleJumpToPresentClick() {
     // The replacement latest window must perform a fresh initial-style bottom
     // scroll. Virtua otherwise preserves the historical window's offset when
     // the keyed data is replaced and can leave the user stranded mid-window.
     setShouldScrollToBottom(true);
     initialScrollDone = false;
     scrollUpLock = false;
-    presentScrollRequest = ++presentScrollSequence;
     onReachedBottom?.();
-    onJumpToPresent?.();
+    const requestedRoomId = roomId;
+    const intentAtStart = userScrollIntentAt;
+    if (!(await onJumpToPresent?.())) return;
+    await tick();
+    if (roomId !== requestedRoomId || userScrollIntentAt !== intentAtStart) return;
+    void requestBottomScroll();
   }
-
-  // Replacing a historical window with the latest window can leave Virtua at
-  // the old numeric offset while it incrementally measures the replacement
-  // rows. Keep the explicit return-to-present request pinned to the bottom
-  // until measurements are stable across consecutive frames. A new request,
-  // room change, or user scroll intent cancels the previous attempt.
-  $effect(() => {
-    const request = presentScrollRequest;
-    void isJumpedMode;
-    void isLoading;
-    void virtualItems.length;
-    void virtualizerHandle;
-    void scrollContainer;
-
-    if (request === 0) return;
-    if (
-      isJumpedMode ||
-      isLoading ||
-      virtualItems.length === 0 ||
-      !virtualizerHandle ||
-      !scrollContainer
-    ) {
-      return;
-    }
-
-    const bottomScroll = requestBottomScroll();
-    if (!bottomScroll) return;
-    presentScrollRequest = 0;
-    void bottomScroll;
-  });
 
   // Lock to prevent virtua's scroll corrections from immediately re-enabling
   // auto-scroll after we detect a user scroll-up. Without this, $fixScrollJump

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
@@ -139,7 +139,7 @@ describe('EventList jump completion', () => {
     await expect
       .element(page.getByTestId('virtualizer-scroll-alignment'))
       .toHaveTextContent('center');
-    await page.getByTestId('jump-to-present').click();
+    page.getByTestId('jump-to-present').element().click();
     expect(onJumpToPresent).toHaveBeenCalledOnce();
     await expect
       .element(page.getByTestId('virtualizer-scroll-alignment'))

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
@@ -119,8 +119,12 @@ describe('EventList jump completion', () => {
     }
   });
 
-  it('starts a pending return-to-present scroll when loading finishes', async () => {
-    const onJumpToPresent = vi.fn();
+  it('scrolls to present after the latest window finishes loading', async () => {
+    let finishLoading: ((loaded: boolean) => void) | undefined;
+    const latestLoaded = new Promise<boolean>((resolve) => {
+      finishLoading = resolve;
+    });
+    const onJumpToPresent = vi.fn(() => latestLoaded);
     const rendered = render(EventListTestHarness, {
       props: {
         eventIds: ['msg-target'],
@@ -132,35 +136,24 @@ describe('EventList jump completion', () => {
     });
 
     await expect.element(page.getByTestId('jump-to-present')).toBeVisible();
-    const callsBeforeJump = Number(
-      page.getByTestId('virtualizer-scroll-calls').element().textContent
-    );
+    await expect
+      .element(page.getByTestId('virtualizer-scroll-alignment'))
+      .toHaveTextContent('center');
     await page.getByTestId('jump-to-present').click();
     expect(onJumpToPresent).toHaveBeenCalledOnce();
+    await expect
+      .element(page.getByTestId('virtualizer-scroll-alignment'))
+      .toHaveTextContent('center');
 
+    finishLoading?.(true);
     await rendered.rerender({
       eventIds: ['msg-target'],
       scrollToEventId: null,
       isJumpedMode: false,
-      isLoading: true,
       onJumpToPresent,
       pendingHighlightId: 'suppress-normal-auto-scroll'
     });
-    await expect.element(page.getByTestId('virtualizer-scroll-calls')).not.toBeInTheDocument();
-
-    await rendered.rerender({
-      eventIds: ['msg-target'],
-      scrollToEventId: null,
-      isJumpedMode: false,
-      isLoading: false,
-      onJumpToPresent,
-      pendingHighlightId: 'suppress-normal-auto-scroll'
-    });
-    await vi.waitFor(() =>
-      expect(
-        Number(page.getByTestId('virtualizer-scroll-calls').element().textContent)
-      ).toBeGreaterThan(callsBeforeJump)
-    );
+    await expect.element(page.getByTestId('virtualizer-scroll-alignment')).toHaveTextContent('end');
   });
 
   it('completes initialization when a bottom scroll supersedes the initial request', async () => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
@@ -139,7 +139,7 @@ describe('EventList jump completion', () => {
     await expect
       .element(page.getByTestId('virtualizer-scroll-alignment'))
       .toHaveTextContent('center');
-    page.getByTestId('jump-to-present').element().click();
+    (page.getByTestId('jump-to-present').element() as HTMLButtonElement).click();
     expect(onJumpToPresent).toHaveBeenCalledOnce();
     await expect
       .element(page.getByTestId('virtualizer-scroll-alignment'))

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListTestHarness.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListTestHarness.svelte
@@ -24,7 +24,7 @@
     onComplete?: () => void;
     isLoading?: boolean;
     isJumpedMode?: boolean;
-    onJumpToPresent?: () => void;
+    onJumpToPresent?: () => Promise<boolean>;
     updateCounter?: number;
     pendingHighlightId?: string | null;
   } = $props();

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListVirtualizerMock.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListVirtualizerMock.svelte
@@ -19,10 +19,12 @@
 
   let renderedIndex = $state<number | null>(null);
   let scrollCalls = $state(0);
+  let lastAlignment = $state('');
 
-  export function scrollToIndex(index: number) {
+  export function scrollToIndex(index: number, options?: { align?: string }) {
     renderedIndex = index;
     scrollCalls += 1;
+    lastAlignment = options?.align ?? '';
   }
 
   export function getScrollSize() {
@@ -44,6 +46,7 @@
 
 <output data-testid="virtualizer-scroll-index">{renderedIndex ?? ''}</output>
 <output data-testid="virtualizer-scroll-calls">{scrollCalls}</output>
+<output data-testid="virtualizer-scroll-alignment">{lastAlignment}</output>
 {#if renderedIndex !== null && data[renderedIndex] !== undefined}
   {@render children(data[renderedIndex])}
 {/if}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/TimelineEventsPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/TimelineEventsPane.svelte
@@ -74,7 +74,7 @@
     isLoadingNewer?: boolean;
     hasReachedEnd?: boolean;
     onLoadNewer?: () => Promise<void>;
-    onJumpToPresent?: () => void;
+    onJumpToPresent?: () => Promise<boolean>;
     onReachedPresent?: () => void;
     onSoftRefresh?: (result: RefreshCurrentWindowResult, anchored: boolean) => void;
     pendingHighlightId?: string | null;


### PR DESCRIPTION
## Summary

- make `MessagesStore.jumpToPresent()` resolve after the authoritative latest window and its initial backfill are applied
- await that transition directly in `EventList`, then invoke the existing bottom-scroll convergence after a single Svelte flush
- remove the dedicated Return to Present request state, sequence counter, and readiness effect
- preserve cancellation when the room changes or the user scrolls during loading

## Testing

- `mise x -- pnpm --dir apps/frontend exec vitest run 'src/routes/chat/[serverId]/[roomId]/bottomScrollConvergence.spec.ts' 'src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts' src/lib/state/room/messages.svelte.spec.ts`
- `mise x -- pnpm --dir apps/frontend exec playwright test e2e/jump-to-message.test.ts e2e/auto-scroll.test.ts --workers=4 --retries=0`
- `mise lint-frontend`
- Svelte autofixer on changed Svelte components: no issues

Closes #1428.
