### PR TITLE
fix(auth): preserve sessions during storage outages

### DIFF
--- a/apps/frontend/src/lib/auth/errors.spec.ts
+++ b/apps/frontend/src/lib/auth/errors.spec.ts
@@ -9,6 +9,14 @@ describe('isAuthenticationRequiredError', () => {
     ).toBe(true);
   });
 
+  it('does not classify typed unavailable errors by their message', () => {
+    expect(
+      isAuthenticationRequiredError(
+        new ConnectError('authentication required: storage unavailable', Code.Unavailable)
+      )
+    ).toBe(false);
+  });
+
   it('keeps the combined message fallback for older clients and transports', () => {
     expect(isAuthenticationRequiredError({ message: 'authentication required' })).toBe(true);
   });

--- a/apps/frontend/src/lib/auth/errors.ts
+++ b/apps/frontend/src/lib/auth/errors.ts
@@ -7,8 +7,8 @@ type MessageBearingError = {
 const AUTHENTICATION_REQUIRED_MESSAGE = 'authentication required';
 
 export function isAuthenticationRequiredError(error: unknown): boolean {
-  if (error instanceof ConnectError && error.code === Code.Unauthenticated) {
-    return true;
+  if (error instanceof ConnectError) {
+    return error.code === Code.Unauthenticated;
   }
 
   if (!error || typeof error !== 'object') return false;

--- a/apps/frontend/src/lib/auth/loadAuth.spec.ts
+++ b/apps/frontend/src/lib/auth/loadAuth.spec.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Code, ConnectError } from '@connectrpc/connect';
 
 const {
   getCurrentUserViaConnectMock,
@@ -127,5 +128,22 @@ describe('loadCurrentUser', () => {
 
     expect(await loadCurrentUser()).toEqual(user);
     expect(clearOriginAuthenticationMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps cached auth state for typed unavailable errors containing auth wording', async () => {
+    const { loadCurrentUser } = await loadModule();
+    const unavailable = new ConnectError(
+      'authentication required: storage unavailable',
+      Code.Unavailable
+    );
+    getCurrentUserViaConnectMock
+      .mockResolvedValueOnce(user)
+      .mockRejectedValueOnce(unavailable)
+      .mockRejectedValueOnce(unavailable);
+
+    expect(await loadCurrentUser()).toEqual(user);
+    expect(await loadCurrentUser()).toEqual(user);
+    expect(clearOriginAuthenticationMock).not.toHaveBeenCalled();
+    expect(handleAuthenticationRequiredMock).not.toHaveBeenCalled();
   });
 });

--- a/cli/internal/http_server/assets.go
+++ b/cli/internal/http_server/assets.go
@@ -358,6 +358,10 @@ func (s *HTTPServer) resolveStableAssetViewerID(c *gin.Context, assetID string, 
 	}
 
 	reqWithUser := s.injectUserIntoContext(c)
+	if authenticationValidationError(reqWithUser.Context()) != nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Authentication service temporarily unavailable"})
+		return "", false
+	}
 	user := authctx.ForContext(reqWithUser.Context())
 	if user == nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})

--- a/cli/internal/http_server/auth.go
+++ b/cli/internal/http_server/auth.go
@@ -75,7 +75,7 @@ func (s *HTTPServer) setupAuthRoutes() {
 
 		loggedOutUserIDs := make(map[string]struct{}, 2)
 		session := sessions.Default(c)
-		cookieCredential, cookieOK := s.cookiePresentedCredential(c)
+		cookieCredential, cookieOK, _ := s.cookiePresentedCredential(c)
 
 		if authHeader := c.GetHeader("Authorization"); authHeader != "" {
 			if token, ok := strings.CutPrefix(authHeader, "Bearer "); ok && strings.TrimSpace(token) != "" {
@@ -544,6 +544,10 @@ func (s *HTTPServer) setupAuthRoutes() {
 	// Authenticated email verification code request.
 	auth.POST("verify-email/request-code", func(c *gin.Context) {
 		req := s.injectUserIntoContext(c)
+		if authenticationValidationError(req.Context()) != nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Authentication service temporarily unavailable"})
+			return
+		}
 		user := authctx.ForContext(req.Context())
 		if user == nil {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
@@ -595,6 +599,10 @@ func (s *HTTPServer) setupAuthRoutes() {
 	// Authenticated email verification code confirmation.
 	auth.POST("verify-email/confirm-code", func(c *gin.Context) {
 		req := s.injectUserIntoContext(c)
+		if authenticationValidationError(req.Context()) != nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Authentication service temporarily unavailable"})
+			return
+		}
 		user := authctx.ForContext(req.Context())
 		if user == nil {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})

--- a/cli/internal/http_server/connect.go
+++ b/cli/internal/http_server/connect.go
@@ -2,10 +2,12 @@ package http_server
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/url"
 
 	"connectrpc.com/authn"
+	"connectrpc.com/connect"
 	"github.com/charmbracelet/log"
 	"github.com/gin-gonic/gin"
 	"hmans.de/chatto/internal/authctx"
@@ -78,6 +80,9 @@ func (s *HTTPServer) mountOperatorConnectHandler(router gin.IRouter, servicePath
 }
 
 func authenticateConnectRequest(ctx context.Context, _ *http.Request) (any, error) {
+	if err := authenticationValidationError(ctx); err != nil {
+		return nil, connect.NewError(connect.CodeUnavailable, errors.New("authentication service temporarily unavailable"))
+	}
 	user := authctx.ForContext(ctx)
 	if user == nil {
 		return nil, authn.Errorf("authentication required")

--- a/cli/internal/http_server/connect_test.go
+++ b/cli/internal/http_server/connect_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -692,6 +693,14 @@ func TestConnectAPIAuthenticatesBeforeValidation(t *testing.T) {
 }
 
 func TestAuthenticateConnectRequest(t *testing.T) {
+	t.Run("reports credential validation failures as unavailable", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), authenticationValidationErrorKey{}, errors.New("storage unavailable"))
+		_, err := authenticateConnectRequest(ctx, nil)
+		if connect.CodeOf(err) != connect.CodeUnavailable {
+			t.Fatalf("authenticateConnectRequest err = %v, want unavailable", err)
+		}
+	})
+
 	t.Run("rejects missing injected user", func(t *testing.T) {
 		_, err := authenticateConnectRequest(context.Background(), nil)
 		if connect.CodeOf(err) != connect.CodeUnauthenticated {
@@ -716,6 +725,29 @@ func TestAuthenticateConnectRequest(t *testing.T) {
 			t.Fatalf("caller = %+v, want user id only", caller)
 		}
 	})
+}
+
+func TestBearerPresentedCredentialPreservesStorageFailure(t *testing.T) {
+	s, _ := setupConnectTestServer(t, config.AuthConfig{})
+	ctx := context.Background()
+	user, err := s.core.CreateUser(ctx, core.SystemActorID, "auth-storage-failure", "Auth Storage Failure", "password")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	token, err := s.core.CreateAuthToken(ctx, user.Id)
+	if err != nil {
+		t.Fatalf("CreateAuthToken: %v", err)
+	}
+
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+	_, ok, err := s.bearerPresentedCredential(canceled, token)
+	if ok {
+		t.Fatal("bearerPresentedCredential authenticated with canceled storage context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("bearerPresentedCredential err = %v, want context canceled", err)
+	}
 }
 
 func TestConnectRequestBaseURLTrustModel(t *testing.T) {

--- a/cli/internal/http_server/cookie_sessions.go
+++ b/cli/internal/http_server/cookie_sessions.go
@@ -109,16 +109,16 @@ func cookieSessionIDs(session sessions.Session) (string, string, bool) {
 }
 
 func (s *HTTPServer) validateCookieSession(c *gin.Context) (string, string, *corev1.CookieSession, bool) {
-	credential, ok := s.cookiePresentedCredential(c)
+	credential, ok, _ := s.cookiePresentedCredential(c)
 	if !ok {
 		return "", "", nil, false
 	}
 	return credential.auth.UserID, credential.auth.Handle, credential.cookieRecord, true
 }
 
-func (s *HTTPServer) cookiePresentedCredential(c *gin.Context) (presentedRuntimeCredential, bool) {
+func (s *HTTPServer) cookiePresentedCredential(c *gin.Context) (presentedRuntimeCredential, bool, error) {
 	if _, ok := c.Get(sessions.DefaultKey); !ok {
-		return presentedRuntimeCredential{}, false
+		return presentedRuntimeCredential{}, false, nil
 	}
 	session := sessions.Default(c)
 	credential, ok := cookieCredentialFromSession(session)
@@ -128,7 +128,7 @@ func (s *HTTPServer) cookiePresentedCredential(c *gin.Context) (presentedRuntime
 			session.Get(sessionKeyCookieSessionID) != nil {
 			clearCookieSessionAuth(session)
 		}
-		return presentedRuntimeCredential{}, false
+		return presentedRuntimeCredential{}, false, nil
 	}
 
 	var record *corev1.CookieSession
@@ -141,21 +141,21 @@ func (s *HTTPServer) cookiePresentedCredential(c *gin.Context) (presentedRuntime
 	if err != nil {
 		if errors.Is(err, core.ErrCookieSessionNotFound) {
 			clearCookieSessionAuth(session)
-		} else {
-			log.Warn("Failed to validate cookie session", "error", err)
+			return presentedRuntimeCredential{}, false, nil
 		}
-		return presentedRuntimeCredential{}, false
+		log.Warn("Failed to validate cookie session", "error", err)
+		return presentedRuntimeCredential{}, false, err
 	}
 	userID := record.GetUserId()
 	if userID == "" {
 		clearCookieSessionAuth(session)
-		return presentedRuntimeCredential{}, false
+		return presentedRuntimeCredential{}, false, nil
 	}
 
 	user, err := s.core.GetUser(c.Request.Context(), userID)
 	if err != nil {
 		log.Warn("Failed to load user from cookie runtime credential", "userId", userID, "error", err)
-		return presentedRuntimeCredential{}, false
+		return presentedRuntimeCredential{}, false, nil
 	}
 
 	return presentedRuntimeCredential{
@@ -166,7 +166,7 @@ func (s *HTTPServer) cookiePresentedCredential(c *gin.Context) (presentedRuntime
 			Handle: credential.sessionID,
 		},
 		cookieRecord: record,
-	}, true
+	}, true, nil
 }
 
 func (s *HTTPServer) rotateCookieSessionIfNeeded(c *gin.Context, userID, oldSessionID string, record *corev1.CookieSession) {

--- a/cli/internal/http_server/csrf.go
+++ b/cli/internal/http_server/csrf.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/base64"
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
@@ -39,6 +40,10 @@ func (s *HTTPServer) csrfMiddleware() gin.HandlerFunc {
 		session := sessions.Default(c)
 		if isSafeHTTPMethod(c.Request.Method) && hasCookieCredential(session) {
 			if err := s.ensureCSRFToken(c); err != nil {
+				if errors.Is(err, errAuthenticationServiceUnavailable) {
+					c.AbortWithStatusJSON(http.StatusServiceUnavailable, gin.H{"error": "Authentication service temporarily unavailable"})
+					return
+				}
 				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Failed to prepare CSRF token"})
 				return
 			}
@@ -51,7 +56,7 @@ func (s *HTTPServer) csrfMiddleware() gin.HandlerFunc {
 func (s *HTTPServer) ensureCSRFToken(c *gin.Context) error {
 	binding, ok, err := s.csrfBinding(c)
 	if err != nil {
-		return err
+		return errAuthenticationServiceUnavailable
 	}
 	if !ok {
 		return nil

--- a/cli/internal/http_server/csrf.go
+++ b/cli/internal/http_server/csrf.go
@@ -24,9 +24,16 @@ const (
 
 func (s *HTTPServer) csrfMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if s.requiresCSRF(c) && !s.validCSRFToken(c) {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "CSRF token missing or invalid"})
-			return
+		if s.requiresCSRF(c) {
+			valid, err := s.validCSRFToken(c)
+			if err != nil {
+				c.AbortWithStatusJSON(http.StatusServiceUnavailable, gin.H{"error": "Authentication service temporarily unavailable"})
+				return
+			}
+			if !valid {
+				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "CSRF token missing or invalid"})
+				return
+			}
 		}
 
 		session := sessions.Default(c)
@@ -42,7 +49,10 @@ func (s *HTTPServer) csrfMiddleware() gin.HandlerFunc {
 }
 
 func (s *HTTPServer) ensureCSRFToken(c *gin.Context) error {
-	binding, ok := s.csrfBinding(c)
+	binding, ok, err := s.csrfBinding(c)
+	if err != nil {
+		return err
+	}
 	if !ok {
 		return nil
 	}
@@ -91,19 +101,22 @@ func isCSRFExemptUnsafePath(path string) bool {
 	}
 }
 
-func (s *HTTPServer) validCSRFToken(c *gin.Context) bool {
+func (s *HTTPServer) validCSRFToken(c *gin.Context) (bool, error) {
 	headerToken := c.GetHeader(csrfHeaderName)
 	cookieToken, err := c.Cookie(csrfCookieName)
 	if err != nil || headerToken == "" || cookieToken == "" {
-		return false
+		return false, nil
 	}
 
 	if subtle.ConstantTimeCompare([]byte(headerToken), []byte(cookieToken)) != 1 {
-		return false
+		return false, nil
 	}
 
-	binding, ok := s.csrfBinding(c)
-	return ok && s.validSignedCSRFToken(cookieToken, binding)
+	binding, ok, err := s.csrfBinding(c)
+	if err != nil {
+		return false, err
+	}
+	return ok && s.validSignedCSRFToken(cookieToken, binding), nil
 }
 
 type csrfBinding struct {
@@ -111,12 +124,15 @@ type csrfBinding struct {
 	authGeneration uint64
 }
 
-func (s *HTTPServer) csrfBinding(c *gin.Context) (csrfBinding, bool) {
-	credential, ok, _ := s.cookiePresentedCredential(c)
-	if !ok {
-		return csrfBinding{}, false
+func (s *HTTPServer) csrfBinding(c *gin.Context) (csrfBinding, bool, error) {
+	credential, ok, err := s.cookiePresentedCredential(c)
+	if err != nil {
+		return csrfBinding{}, false, err
 	}
-	return csrfBindingForSession(credential.auth.UserID, credential.cookieRecord), true
+	if !ok {
+		return csrfBinding{}, false, nil
+	}
+	return csrfBindingForSession(credential.auth.UserID, credential.cookieRecord), true, nil
 }
 
 func hasCookieCredential(session sessions.Session) bool {

--- a/cli/internal/http_server/csrf.go
+++ b/cli/internal/http_server/csrf.go
@@ -112,7 +112,7 @@ type csrfBinding struct {
 }
 
 func (s *HTTPServer) csrfBinding(c *gin.Context) (csrfBinding, bool) {
-	credential, ok := s.cookiePresentedCredential(c)
+	credential, ok, _ := s.cookiePresentedCredential(c)
 	if !ok {
 		return csrfBinding{}, false
 	}

--- a/cli/internal/http_server/csrf_test.go
+++ b/cli/internal/http_server/csrf_test.go
@@ -204,6 +204,28 @@ func TestCSRFMiddleware(t *testing.T) {
 		}
 	})
 
+	t.Run("returns unavailable when safe-request cookie validation fails", func(t *testing.T) {
+		server, client := setupCSRFTestServer(t)
+		csrfCookieValue(t, client, server.URL)
+
+		req, err := http.NewRequest(http.MethodGet, server.URL+"/csrf-refresh", nil)
+		if err != nil {
+			t.Fatalf("create safe request: %v", err)
+		}
+		req.Header.Set("X-Test-Cancel-Authentication", "true")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("safe request: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 503; body=%s", resp.StatusCode, body)
+		}
+	})
+
 	t.Run("exempts cookie ConnectRPC POST", func(t *testing.T) {
 		server, client := setupCSRFTestServer(t)
 		csrfCookieValue(t, client, server.URL)

--- a/cli/internal/http_server/csrf_test.go
+++ b/cli/internal/http_server/csrf_test.go
@@ -56,6 +56,14 @@ func setupCSRFTestServer(t *testing.T) (*httptest.Server, *http.Client) {
 		router: router,
 		core:   chattoCore,
 	}
+	router.Use(func(c *gin.Context) {
+		if c.GetHeader("X-Test-Cancel-Authentication") == "true" {
+			ctx, cancel := context.WithCancel(c.Request.Context())
+			cancel()
+			c.Request = c.Request.WithContext(ctx)
+		}
+		c.Next()
+	})
 	router.Use(s.csrfMiddleware())
 
 	router.GET("/login-test", func(c *gin.Context) {
@@ -169,6 +177,30 @@ func TestCSRFMiddleware(t *testing.T) {
 		if resp.StatusCode != http.StatusOK {
 			body, _ := io.ReadAll(resp.Body)
 			t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, body)
+		}
+	})
+
+	t.Run("returns unavailable when cookie validation storage fails", func(t *testing.T) {
+		server, client := setupCSRFTestServer(t)
+		token := csrfCookieValue(t, client, server.URL)
+
+		req, err := http.NewRequest(http.MethodPost, server.URL+"/auth/verify-email/request-code", strings.NewReader("{}"))
+		if err != nil {
+			t.Fatalf("create unsafe request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set(csrfHeaderName, token)
+		req.Header.Set("X-Test-Cancel-Authentication", "true")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("unsafe request: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 503; body=%s", resp.StatusCode, body)
 		}
 	})
 

--- a/cli/internal/http_server/frontend.go
+++ b/cli/internal/http_server/frontend.go
@@ -335,7 +335,7 @@ func (s *HTTPServer) setupFrontendRoutes() error {
 	// a session is created, so near-expiry sessions are rotated instead of
 	// "touched" in place.
 	refreshSessionIfAuthenticated := func(c *gin.Context) {
-		credential, ok := s.cookiePresentedCredential(c)
+		credential, ok, _ := s.cookiePresentedCredential(c)
 		if ok {
 			s.rotateCookieSessionIfNeeded(c, credential.auth.UserID, credential.auth.Handle, credential.cookieRecord)
 		}

--- a/cli/internal/http_server/oauth.go
+++ b/cli/internal/http_server/oauth.go
@@ -307,7 +307,7 @@ func (s *HTTPServer) setupOAuthRoutes() {
 }
 
 func (s *HTTPServer) oauthCookieCredential(c *gin.Context) (presentedRuntimeCredential, bool) {
-	credential, ok := s.cookiePresentedCredential(c)
+	credential, ok, _ := s.cookiePresentedCredential(c)
 	if !ok {
 		return presentedRuntimeCredential{}, false
 	}

--- a/cli/internal/http_server/oauth.go
+++ b/cli/internal/http_server/oauth.go
@@ -43,7 +43,12 @@ func (s *HTTPServer) setupOAuthRoutes() {
 		// query string is treated as a fresh authorize attempt and overwrites the
 		// pending session after validation below.
 		if c.Request.URL.RawQuery == "" {
-			if credential, ok := s.oauthCookieCredential(c); ok {
+			credential, ok, err := s.oauthCookieCredential(c)
+			if err != nil {
+				writeAuthenticationUnavailable(c)
+				return
+			}
+			if ok {
 				if hasPendingOAuthAuthorize(session) {
 					s.continueOAuthAuthorize(c, credential.auth.UserID, credential.cookieRecord.GetAuthGeneration())
 					return
@@ -106,7 +111,12 @@ func (s *HTTPServer) setupOAuthRoutes() {
 		session.Save()
 
 		// If user is already authenticated, generate code immediately
-		if credential, ok := s.oauthCookieCredential(c); ok {
+		credential, ok, err := s.oauthCookieCredential(c)
+		if err != nil {
+			writeAuthenticationUnavailable(c)
+			return
+		}
+		if ok {
 			s.continueOAuthAuthorize(c, credential.auth.UserID, credential.cookieRecord.GetAuthGeneration())
 			return
 		}
@@ -214,7 +224,11 @@ func (s *HTTPServer) setupOAuthRoutes() {
 	})
 
 	oauth.GET("consent/request", func(c *gin.Context) {
-		_, ok := s.oauthCookieCredential(c)
+		_, ok, err := s.oauthCookieCredential(c)
+		if err != nil {
+			writeAuthenticationUnavailable(c)
+			return
+		}
 		if !ok {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
 			return
@@ -238,7 +252,11 @@ func (s *HTTPServer) setupOAuthRoutes() {
 	})
 
 	oauth.POST("consent/approve", func(c *gin.Context) {
-		credential, ok := s.oauthCookieCredential(c)
+		credential, ok, err := s.oauthCookieCredential(c)
+		if err != nil {
+			writeAuthenticationUnavailable(c)
+			return
+		}
 		if !ok {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
 			return
@@ -270,7 +288,11 @@ func (s *HTTPServer) setupOAuthRoutes() {
 	})
 
 	oauth.POST("consent/deny", func(c *gin.Context) {
-		credential, ok := s.oauthCookieCredential(c)
+		credential, ok, err := s.oauthCookieCredential(c)
+		if err != nil {
+			writeAuthenticationUnavailable(c)
+			return
+		}
 		if !ok {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
 			return
@@ -306,13 +328,16 @@ func (s *HTTPServer) setupOAuthRoutes() {
 	})
 }
 
-func (s *HTTPServer) oauthCookieCredential(c *gin.Context) (presentedRuntimeCredential, bool) {
-	credential, ok, _ := s.cookiePresentedCredential(c)
+func (s *HTTPServer) oauthCookieCredential(c *gin.Context) (presentedRuntimeCredential, bool, error) {
+	credential, ok, err := s.cookiePresentedCredential(c)
+	if err != nil {
+		return presentedRuntimeCredential{}, false, err
+	}
 	if !ok {
-		return presentedRuntimeCredential{}, false
+		return presentedRuntimeCredential{}, false, nil
 	}
 	s.rotateCookieSessionIfNeeded(c, credential.auth.UserID, credential.auth.Handle, credential.cookieRecord)
-	return credential, true
+	return credential, true, nil
 }
 
 type oauthTokenRequest struct {

--- a/cli/internal/http_server/oauth_test.go
+++ b/cli/internal/http_server/oauth_test.go
@@ -142,6 +142,32 @@ func TestOAuthAuthorize_ValidParams(t *testing.T) {
 	}
 }
 
+func TestOAuthAuthorize_ReturnsUnavailableWhenCookieValidationStorageFails(t *testing.T) {
+	s := setupOAuthServer(t)
+	cookies, _ := loginOAuthTestUser(t, s, "oauth-storage-unavailable")
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+url.Values{
+		"response_type":         {"code"},
+		"redirect_uri":          {"https://chatto.example/servers/callback"},
+		"code_challenge":        {core.GenerateCodeChallenge("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")},
+		"code_challenge_method": {"S256"},
+	}.Encode(), nil)
+	addCookies(req, cookies)
+	canceled, cancel := context.WithCancel(req.Context())
+	cancel()
+	req = req.WithContext(canceled)
+
+	w := httptest.NewRecorder()
+	s.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("authorize status = %d, want 503: %s", w.Code, w.Body.String())
+	}
+	if location := w.Header().Get("Location"); location != "" {
+		t.Fatalf("authorize redirected during storage failure: %q", location)
+	}
+}
+
 func TestOAuthAuthorize_MissingParams(t *testing.T) {
 	s := setupOAuthServer(t)
 

--- a/cli/internal/http_server/realtime.go
+++ b/cli/internal/http_server/realtime.go
@@ -150,6 +150,11 @@ func (s *HTTPServer) serveRealtimeWebSocket(parent context.Context, conn *websoc
 	}
 	ctx, user, err := s.realtimeAuthenticatedUser(ctx, clientHello)
 	if err != nil {
+		if !errors.Is(err, core.ErrNotAuthenticated) {
+			writeError("temporarily_unavailable", "authentication service temporarily unavailable", true)
+			_ = conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseTryAgainLater, "temporarily unavailable"), time.Now().Add(time.Second))
+			return
+		}
 		writeError("authentication_required", "authentication required", true)
 		_ = conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.ClosePolicyViolation, "authentication required"), time.Now().Add(time.Second))
 		return
@@ -284,7 +289,10 @@ func (s *HTTPServer) readRealtimeControlFrames(ctx context.Context, cancel conte
 
 func (s *HTTPServer) realtimeAuthenticatedUser(ctx context.Context, hello *realtimev1.RealtimeClientHello) (context.Context, *corev1.User, error) {
 	if token := strings.TrimSpace(hello.GetBearerToken()); token != "" {
-		credential, ok := s.bearerPresentedCredential(ctx, token)
+		credential, ok, err := s.bearerPresentedCredential(ctx, token)
+		if err != nil {
+			return ctx, nil, err
+		}
 		if !ok {
 			return ctx, nil, core.ErrNotAuthenticated
 		}
@@ -294,6 +302,9 @@ func (s *HTTPServer) realtimeAuthenticatedUser(ctx context.Context, hello *realt
 	}
 	if user := authctx.ForContext(ctx); user != nil {
 		return ctx, user, nil
+	}
+	if err := authenticationValidationError(ctx); err != nil {
+		return ctx, nil, err
 	}
 	return ctx, nil, core.ErrNotAuthenticated
 }

--- a/cli/internal/http_server/realtime_test.go
+++ b/cli/internal/http_server/realtime_test.go
@@ -2,6 +2,7 @@ package http_server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -19,6 +20,20 @@ import (
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 	realtimev1 "hmans.de/chatto/internal/pb/chatto/realtime/v1"
 )
+
+func TestRealtimeAuthenticatedUserPreservesAuthenticationValidationError(t *testing.T) {
+	s := &HTTPServer{}
+	want := errors.New("storage unavailable")
+	ctx := context.WithValue(context.Background(), authenticationValidationErrorKey{}, want)
+
+	_, user, err := s.realtimeAuthenticatedUser(ctx, &realtimev1.RealtimeClientHello{})
+	if user != nil {
+		t.Fatalf("user = %v, want nil", user)
+	}
+	if !errors.Is(err, want) {
+		t.Fatalf("realtimeAuthenticatedUser err = %v, want %v", err, want)
+	}
+}
 
 type websocketWireRecorder struct {
 	net.Conn

--- a/cli/internal/http_server/request_auth.go
+++ b/cli/internal/http_server/request_auth.go
@@ -2,6 +2,7 @@ package http_server
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -11,12 +12,23 @@ import (
 	"hmans.de/chatto/internal/core"
 )
 
+type authenticationValidationErrorKey struct{}
+
+func authenticationValidationError(ctx context.Context) error {
+	err, _ := ctx.Value(authenticationValidationErrorKey{}).(error)
+	return err
+}
+
 // injectUserIntoContext extracts the authenticated user from either a bearer token
 // or the runtime credential handle in the Gin session cookie, and returns an updated http.Request with the user
 // injected into its context.
 // Returns the original request if no user is authenticated (allowing unauthenticated requests).
 func (s *HTTPServer) injectUserIntoContext(c *gin.Context) *http.Request {
-	credential, ok := s.presentedCredentialFromRequest(c)
+	credential, ok, err := s.presentedCredentialFromRequest(c)
+	if err != nil {
+		ctx := context.WithValue(c.Request.Context(), authenticationValidationErrorKey{}, err)
+		return c.Request.WithContext(ctx)
+	}
 	if !ok {
 		return c.Request
 	}
@@ -31,11 +43,11 @@ func (s *HTTPServer) injectUserIntoContext(c *gin.Context) *http.Request {
 	return c.Request.WithContext(ctx)
 }
 
-func (s *HTTPServer) presentedCredentialFromRequest(c *gin.Context) (presentedRuntimeCredential, bool) {
+func (s *HTTPServer) presentedCredentialFromRequest(c *gin.Context) (presentedRuntimeCredential, bool, error) {
 	if authHeader := c.GetHeader("Authorization"); authHeader != "" {
 		if token, ok := strings.CutPrefix(authHeader, "Bearer "); ok && strings.TrimSpace(token) != "" {
-			if credential, ok := s.bearerPresentedCredential(c.Request.Context(), strings.TrimSpace(token)); ok {
-				return credential, true
+			if credential, ok, err := s.bearerPresentedCredential(c.Request.Context(), strings.TrimSpace(token)); ok || err != nil {
+				return credential, ok, err
 			}
 		}
 	}
@@ -43,15 +55,18 @@ func (s *HTTPServer) presentedCredentialFromRequest(c *gin.Context) (presentedRu
 	return s.cookiePresentedCredential(c)
 }
 
-func (s *HTTPServer) bearerPresentedCredential(ctx context.Context, token string) (presentedRuntimeCredential, bool) {
+func (s *HTTPServer) bearerPresentedCredential(ctx context.Context, token string) (presentedRuntimeCredential, bool, error) {
 	credential, err := s.core.ValidatePresentedRuntimeCredential(ctx, token, core.AuthTokenPresentationBearer)
 	if err != nil {
-		return presentedRuntimeCredential{}, false
+		if errors.Is(err, core.ErrAuthTokenNotFound) {
+			return presentedRuntimeCredential{}, false, nil
+		}
+		return presentedRuntimeCredential{}, false, err
 	}
 	user, err := s.core.GetUser(ctx, credential.UserID)
 	if err != nil {
 		log.Warn("Bearer runtime credential valid but user not found", "userId", credential.UserID, "error", err)
-		return presentedRuntimeCredential{}, false
+		return presentedRuntimeCredential{}, false, nil
 	}
 	return presentedRuntimeCredential{
 		user: user,
@@ -60,5 +75,5 @@ func (s *HTTPServer) bearerPresentedCredential(ctx context.Context, token string
 			UserID: credential.UserID,
 			Handle: token,
 		},
-	}, true
+	}, true, nil
 }

--- a/cli/internal/http_server/request_auth.go
+++ b/cli/internal/http_server/request_auth.go
@@ -19,6 +19,10 @@ func authenticationValidationError(ctx context.Context) error {
 	return err
 }
 
+func writeAuthenticationUnavailable(c *gin.Context) {
+	c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Authentication service temporarily unavailable"})
+}
+
 // injectUserIntoContext extracts the authenticated user from either a bearer token
 // or the runtime credential handle in the Gin session cookie, and returns an updated http.Request with the user
 // injected into its context.

--- a/cli/internal/http_server/request_auth.go
+++ b/cli/internal/http_server/request_auth.go
@@ -14,6 +14,8 @@ import (
 
 type authenticationValidationErrorKey struct{}
 
+var errAuthenticationServiceUnavailable = errors.New("authentication service temporarily unavailable")
+
 func authenticationValidationError(ctx context.Context) error {
 	err, _ := ctx.Value(authenticationValidationErrorKey{}).(error)
 	return err


### PR DESCRIPTION
## Summary

- preserve operational credential-validation failures instead of treating them
  as missing or revoked credentials
- return retryable unavailable responses from ConnectRPC, realtime, asset,
  OAuth, CSRF, and authenticated REST paths
- keep browser bearer-token and reauthentication state intact for typed
  `Unavailable` errors

## Root cause

The core credential store already distinguished missing credentials from NATS
and JetStream failures. HTTP authentication helpers collapsed both outcomes
into anonymous requests, causing clients to interpret a brief JetStream outage
as an expired session. Some cookie-authenticated security paths similarly
returned 401, 403, redirects, or 500 responses for the same transient failure.

## Impact

Confirmed missing, malformed, expired, and revoked credentials remain
unauthenticated. Temporary authentication-storage failures now remain retryable
and do not clear cookie sessions, bearer tokens, OAuth state, or frontend
authentication state.

No protobuf, persisted-data, or storage-schema changes are included.

## Verification

- `mise test-cli`
- `mise test-frontend` (189 files, 1,908 tests)
- three independent code-review passes; all findings addressed

Closes #1430.
