### PR TITLE
fix(backup): harden archive creation and restore

### DIFF
--- a/apps/docs-website/src/content/docs/guides/operations/backup-restore.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/backup-restore.mdx
@@ -69,6 +69,8 @@ chatto backup -c chatto.toml
 chatto backup -c chatto.toml -o /mnt/backups/chatto-daily.tar.gz
 ```
 
+Chatto stages snapshots in a private temporary directory next to the destination archive and removes the plaintext staging data whether archive creation succeeds or fails. The completed archive is written with owner-only permissions and moved into place atomically, so a failed run does not replace an existing backup with a partial file.
+
 ### Encrypted backups
 
 Use `--encrypt` to protect the backup archive with a passphrase. For small self-hosted servers, also pass `--include-keys` so the archive is self-contained:
@@ -99,6 +101,8 @@ vault kv get -field=passphrase secret/chatto | chatto backup -c chatto.toml --en
 <Aside type="caution">
   Make sure Chatto is **not running** before restoring. For embedded NATS setups, the restore command starts its own temporary NATS server. For external NATS, stop the Chatto application but keep NATS running.
 </Aside>
+
+Restore accepts regular files and directories only, rejects unsafe manifest and archive paths, and stops archives that exceed the built-in entry-count or expanded-size safety limits. These limits are intentionally generous for production backups while preventing malformed archives from expanding without a bound.
 
 <Aside type="tip">
   Keep the same `core.secret_key` in `chatto.toml` when restoring if you want existing bearer tokens, cookie-session handles, OAuth codes, and pending account-flow credentials to remain valid. Using a new value is a clean way to invalidate them during disaster recovery.

--- a/cli/cmd/backup.go
+++ b/cli/cmd/backup.go
@@ -57,6 +57,13 @@ var (
 	backupIncludeKeys bool
 )
 
+const (
+	maxRestoreArchiveCompressedBytes = int64(128 * 1024 * 1024 * 1024)
+	maxRestoreArchiveEntries         = 100_000
+	maxRestoreArchiveFileBytes       = int64(64 * 1024 * 1024 * 1024)
+	maxRestoreArchiveExpandedBytes   = int64(1024 * 1024 * 1024 * 1024)
+)
+
 var backupCmd = &cobra.Command{
 	Use:   "backup",
 	Short: "Create a backup of all Chatto data",
@@ -161,73 +168,10 @@ func runBackup(cmd *cobra.Command, args []string) {
 		log.Fatal("Failed to create output directory", "error", err)
 	}
 
-	// Create temporary working directory
-	backupDir := archivePath
-	backupDir = strings.TrimSuffix(backupDir, ".age")
-	backupDir = strings.TrimSuffix(backupDir, ".tar.gz")
-	streamsDir := filepath.Join(backupDir, "streams")
-
-	if err := os.MkdirAll(streamsDir, 0755); err != nil {
-		log.Fatal("Failed to create backup directory", "error", err)
-	}
-
-	// Enumerate all streams
-	streamNames, err := enumerateStreams(ctx, js)
+	manifest, err := createBackupArchive(ctx, js, mgr, archivePath, passphrase, backupEncrypt, backupIncludeKeys, startTime)
 	if err != nil {
-		log.Fatal("Failed to enumerate streams", "error", err)
-	}
-
-	log.Info("Found streams to backup", "count", len(streamNames))
-
-	// Backup each stream
-	manifest := BackupManifest{
-		Version:   1,
-		CreatedAt: startTime.UTC(),
-		Streams:   make([]StreamBackupInfo, 0),
-	}
-
-	for i, streamName := range streamNames {
-		info := backupStream(ctx, mgr, streamName, streamsDir, i+1, len(streamNames), backupIncludeKeys)
-		manifest.Streams = append(manifest.Streams, info)
-
-		if info.Error != "" {
-			manifest.Stats.Failed++
-		} else if info.Type == "skipped" {
-			manifest.Stats.Skipped++
-		} else {
-			manifest.Stats.TotalBytes += info.Bytes
-		}
-	}
-
-	manifest.Stats.TotalStreams = len(streamNames) - manifest.Stats.Skipped - manifest.Stats.Failed
-	manifest.Stats.DurationMs = time.Since(startTime).Milliseconds()
-
-	// Write manifest
-	manifestPath := filepath.Join(backupDir, "manifest.json")
-	manifestData, err := json.MarshalIndent(manifest, "", "  ")
-	if err != nil {
-		log.Fatal("Failed to marshal manifest", "error", err)
-	}
-	if err := os.WriteFile(manifestPath, manifestData, 0644); err != nil {
-		log.Fatal("Failed to write manifest", "error", err)
-	}
-
-	// Create archive (encrypted or plain)
-	var archiveErr error
-	if backupEncrypt {
-		archiveErr = createEncryptedTarGz(backupDir, archivePath, passphrase)
+		log.Fatal("Failed to create backup archive", "error", err)
 	} else {
-		archiveErr = createTarGz(backupDir, archivePath)
-	}
-
-	if archiveErr != nil {
-		log.Error("Failed to create archive", "error", archiveErr)
-		log.Warn("Backup directory preserved", "path", backupDir)
-	} else {
-		// Remove uncompressed directory
-		if err := os.RemoveAll(backupDir); err != nil {
-			log.Warn("Failed to remove backup directory", "path", backupDir, "error", err)
-		}
 		log.Info("Backup complete",
 			"streams", manifest.Stats.TotalStreams,
 			"skipped", manifest.Stats.Skipped,
@@ -245,6 +189,105 @@ func runBackup(cmd *cobra.Command, args []string) {
 				"Back up your encryption keys separately, or pass --include-keys to embed them.")
 		}
 	}
+}
+
+func createBackupArchive(ctx context.Context, js jetstream.JetStream, mgr *jsm.Manager, archivePath, passphrase string, encrypt, includeKeys bool, startTime time.Time) (BackupManifest, error) {
+	staging, err := newBackupStaging(archivePath)
+	if err != nil {
+		return BackupManifest{}, err
+	}
+	defer staging.cleanup()
+	backupDir, streamsDir := staging.backupDir, staging.streamsDir
+
+	streamNames, err := enumerateStreams(ctx, js)
+	if err != nil {
+		return BackupManifest{}, fmt.Errorf("failed to enumerate streams: %w", err)
+	}
+	log.Info("Found streams to backup", "count", len(streamNames))
+
+	manifest := BackupManifest{Version: 1, CreatedAt: startTime.UTC(), Streams: make([]StreamBackupInfo, 0, len(streamNames))}
+	for i, streamName := range streamNames {
+		info := backupStream(ctx, mgr, streamName, streamsDir, i+1, len(streamNames), includeKeys)
+		manifest.Streams = append(manifest.Streams, info)
+		switch {
+		case info.Error != "":
+			manifest.Stats.Failed++
+		case info.Type == "skipped":
+			manifest.Stats.Skipped++
+		default:
+			manifest.Stats.TotalBytes += info.Bytes
+		}
+	}
+	manifest.Stats.TotalStreams = len(streamNames) - manifest.Stats.Skipped - manifest.Stats.Failed
+	manifest.Stats.DurationMs = time.Since(startTime).Milliseconds()
+
+	manifestData, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return BackupManifest{}, fmt.Errorf("failed to marshal manifest: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(backupDir, "manifest.json"), manifestData, 0600); err != nil {
+		return BackupManifest{}, fmt.Errorf("failed to write manifest: %w", err)
+	}
+	if err := secureBackupStaging(backupDir); err != nil {
+		return BackupManifest{}, err
+	}
+
+	if encrypt {
+		err = createEncryptedTarGz(backupDir, archivePath, passphrase)
+	} else {
+		err = createTarGz(backupDir, archivePath)
+	}
+	if err != nil {
+		return BackupManifest{}, err
+	}
+	return manifest, nil
+}
+
+type backupStaging struct {
+	root       string
+	backupDir  string
+	streamsDir string
+}
+
+func newBackupStaging(archivePath string) (*backupStaging, error) {
+	root, err := os.MkdirTemp(filepath.Dir(archivePath), ".chatto-backup-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create private backup staging directory: %w", err)
+	}
+	staging := &backupStaging{root: root, backupDir: filepath.Join(root, "backup")}
+	staging.streamsDir = filepath.Join(staging.backupDir, "streams")
+	if err := os.MkdirAll(staging.streamsDir, 0700); err != nil {
+		_ = os.RemoveAll(root)
+		return nil, fmt.Errorf("failed to create backup staging layout: %w", err)
+	}
+	return staging, nil
+}
+
+func (s *backupStaging) cleanup() {
+	if s != nil {
+		_ = os.RemoveAll(s.root)
+	}
+}
+
+func secureBackupStaging(root string) error {
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		switch {
+		case info.IsDir():
+			if err := os.Chmod(path, 0700); err != nil {
+				return fmt.Errorf("failed to secure backup directory %s: %w", path, err)
+			}
+		case info.Mode().IsRegular():
+			if err := os.Chmod(path, 0600); err != nil {
+				return fmt.Errorf("failed to secure backup file %s: %w", path, err)
+			}
+		default:
+			return fmt.Errorf("unsupported file in backup staging: %s", path)
+		}
+		return nil
+	})
 }
 
 // enumerateStreams returns all stream names from JetStream
@@ -378,55 +421,71 @@ func classifyStream(name string) string {
 
 // createTarGz creates a .tar.gz archive from a directory.
 func createTarGz(sourceDir, destFile string) error {
-	outFile, err := os.Create(destFile)
-	if err != nil {
-		return fmt.Errorf("failed to create archive file: %w", err)
-	}
-	defer outFile.Close()
-
-	return writeTarGz(sourceDir, outFile)
+	return writeArchiveAtomically(destFile, func(outFile io.Writer) error {
+		return writeTarGz(sourceDir, outFile)
+	})
 }
 
 // createEncryptedTarGz creates an age-encrypted .tar.gz archive.
 func createEncryptedTarGz(sourceDir, destFile, passphrase string) error {
-	outFile, err := os.Create(destFile)
-	if err != nil {
-		return fmt.Errorf("failed to create archive file: %w", err)
-	}
-	defer outFile.Close()
-
 	recipient, err := age.NewScryptRecipient(passphrase)
 	if err != nil {
 		return fmt.Errorf("failed to create age recipient: %w", err)
 	}
 
-	ageWriter, err := age.Encrypt(outFile, recipient)
-	if err != nil {
-		return fmt.Errorf("failed to initialize encryption: %w", err)
-	}
+	return writeArchiveAtomically(destFile, func(outFile io.Writer) error {
+		ageWriter, err := age.Encrypt(outFile, recipient)
+		if err != nil {
+			return fmt.Errorf("failed to initialize encryption: %w", err)
+		}
+		if err := writeTarGz(sourceDir, ageWriter); err != nil {
+			return err
+		}
+		if err := ageWriter.Close(); err != nil {
+			return fmt.Errorf("failed to finalize encryption: %w", err)
+		}
+		return nil
+	})
+}
 
-	if err := writeTarGz(sourceDir, ageWriter); err != nil {
+func writeArchiveAtomically(destFile string, write func(io.Writer) error) (err error) {
+	tempFile, err := os.CreateTemp(filepath.Dir(destFile), "."+filepath.Base(destFile)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary archive file: %w", err)
+	}
+	tempPath := tempFile.Name()
+	defer func() {
+		_ = tempFile.Close()
+		if err != nil {
+			_ = os.Remove(tempPath)
+		}
+	}()
+	if err = tempFile.Chmod(0600); err != nil {
+		return fmt.Errorf("failed to secure temporary archive file: %w", err)
+	}
+	if err = write(tempFile); err != nil {
 		return err
 	}
-
-	if err := ageWriter.Close(); err != nil {
-		return fmt.Errorf("failed to finalize encryption: %w", err)
+	if err = tempFile.Sync(); err != nil {
+		return fmt.Errorf("failed to sync archive file: %w", err)
 	}
-
+	if err = tempFile.Close(); err != nil {
+		return fmt.Errorf("failed to close archive file: %w", err)
+	}
+	if err = os.Rename(tempPath, destFile); err != nil {
+		return fmt.Errorf("failed to publish archive atomically: %w", err)
+	}
 	return nil
 }
 
 // writeTarGz writes tar.gz content from a source directory to the provided writer.
 func writeTarGz(sourceDir string, w io.Writer) error {
 	gzWriter := gzip.NewWriter(w)
-	defer gzWriter.Close()
-
 	tarWriter := tar.NewWriter(gzWriter)
-	defer tarWriter.Close()
 
 	baseName := filepath.Base(sourceDir)
 
-	return filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
+	if err := filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -460,15 +519,26 @@ func writeTarGz(sourceDir string, w io.Writer) error {
 			if err != nil {
 				return fmt.Errorf("failed to open file %s: %w", path, err)
 			}
-			defer file.Close()
-
 			if _, err := io.Copy(tarWriter, file); err != nil {
+				file.Close()
 				return fmt.Errorf("failed to write file content for %s: %w", path, err)
+			}
+			if err := file.Close(); err != nil {
+				return fmt.Errorf("failed to close file %s: %w", path, err)
 			}
 		}
 
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+	if err := tarWriter.Close(); err != nil {
+		return fmt.Errorf("failed to finalize tar archive: %w", err)
+	}
+	if err := gzWriter.Close(); err != nil {
+		return fmt.Errorf("failed to finalize gzip archive: %w", err)
+	}
+	return nil
 }
 
 // extractTarGz extracts a .tar.gz archive into a destination directory.
@@ -484,6 +554,10 @@ func extractTarGz(archiveFile, destDir string) error {
 
 // readTarGz extracts tar.gz content from a reader into a destination directory.
 func readTarGz(r io.Reader, destDir string) error {
+	return readTarGzWithLimits(r, destDir, maxRestoreArchiveEntries, maxRestoreArchiveFileBytes, maxRestoreArchiveExpandedBytes)
+}
+
+func readTarGzWithLimits(r io.Reader, destDir string, maxEntries int, maxFileBytes, maxTotalBytes int64) error {
 	gzReader, err := gzip.NewReader(r)
 	if err != nil {
 		return fmt.Errorf("failed to create gzip reader: %w", err)
@@ -492,6 +566,8 @@ func readTarGz(r io.Reader, destDir string) error {
 
 	tarReader := tar.NewReader(gzReader)
 
+	entries := 0
+	var expandedBytes int64
 	for {
 		header, err := tarReader.Next()
 		if err == io.EOF {
@@ -499,6 +575,10 @@ func readTarGz(r io.Reader, destDir string) error {
 		}
 		if err != nil {
 			return fmt.Errorf("failed to read tar entry: %w", err)
+		}
+		entries++
+		if entries > maxEntries {
+			return fmt.Errorf("archive contains more than %d entries", maxEntries)
 		}
 
 		// Prevent path traversal attacks
@@ -509,14 +589,21 @@ func readTarGz(r io.Reader, destDir string) error {
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := os.MkdirAll(target, 0755); err != nil {
+			if err := os.MkdirAll(target, 0700); err != nil {
 				return fmt.Errorf("failed to create directory %s: %w", target, err)
 			}
-		case tar.TypeReg:
-			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+		case tar.TypeReg, tar.TypeRegA:
+			if header.Size < 0 || header.Size > maxFileBytes {
+				return fmt.Errorf("tar entry %q exceeds the per-file extraction limit", header.Name)
+			}
+			if header.Size > maxTotalBytes-expandedBytes {
+				return fmt.Errorf("archive exceeds the total extraction limit of %d bytes", maxTotalBytes)
+			}
+			expandedBytes += header.Size
+			if err := os.MkdirAll(filepath.Dir(target), 0700); err != nil {
 				return fmt.Errorf("failed to create parent directory for %s: %w", target, err)
 			}
-			outFile, err := os.Create(target)
+			outFile, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
 			if err != nil {
 				return fmt.Errorf("failed to create file %s: %w", target, err)
 			}
@@ -524,7 +611,11 @@ func readTarGz(r io.Reader, destDir string) error {
 				outFile.Close()
 				return fmt.Errorf("failed to write file %s: %w", target, err)
 			}
-			outFile.Close()
+			if err := outFile.Close(); err != nil {
+				return fmt.Errorf("failed to close file %s: %w", target, err)
+			}
+		default:
+			return fmt.Errorf("unsupported tar entry type %d for %q", header.Typeflag, header.Name)
 		}
 	}
 

--- a/cli/cmd/backup.go
+++ b/cli/cmd/backup.go
@@ -475,6 +475,17 @@ func writeArchiveAtomically(destFile string, write func(io.Writer) error) (err e
 	if err = os.Rename(tempPath, destFile); err != nil {
 		return fmt.Errorf("failed to publish archive atomically: %w", err)
 	}
+	parent, err := os.Open(filepath.Dir(destFile))
+	if err != nil {
+		return fmt.Errorf("failed to open archive directory for sync: %w", err)
+	}
+	if err = parent.Sync(); err != nil {
+		parent.Close()
+		return fmt.Errorf("failed to sync archive directory: %w", err)
+	}
+	if err = parent.Close(); err != nil {
+		return fmt.Errorf("failed to close archive directory: %w", err)
+	}
 	return nil
 }
 

--- a/cli/cmd/backup_test.go
+++ b/cli/cmd/backup_test.go
@@ -1,9 +1,14 @@
 package cmd
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,6 +21,139 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 	"hmans.de/chatto/internal/testutil"
 )
+
+func TestBackupStagingIsPrivateAndRemoved(t *testing.T) {
+	archivePath := filepath.Join(t.TempDir(), "backup.tar.gz")
+	staging, err := newBackupStaging(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := staging.root
+	for _, path := range []string{staging.root, staging.backupDir, staging.streamsDir} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := info.Mode().Perm(); got != 0700 {
+			t.Fatalf("%s mode = %o, want 700", path, got)
+		}
+	}
+	staging.cleanup()
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Fatalf("staging directory still exists after cleanup: %v", err)
+	}
+}
+
+func TestSecureBackupStagingRestrictsFiles(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "streams")
+	if err := os.Mkdir(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(dir, "snapshot.bin")
+	if err := os.WriteFile(file, []byte("secret"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := secureBackupStaging(root); err != nil {
+		t.Fatal(err)
+	}
+	for path, want := range map[string]os.FileMode{root: 0700, dir: 0700, file: 0600} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := info.Mode().Perm(); got != want {
+			t.Fatalf("%s mode = %o, want %o", path, got, want)
+		}
+	}
+}
+
+func TestWriteArchiveAtomically(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "backup.tar.gz")
+	if err := os.WriteFile(dest, []byte("old"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	wantErr := errors.New("write failed")
+	if err := writeArchiveAtomically(dest, func(w io.Writer) error {
+		_, _ = w.Write([]byte("partial"))
+		return wantErr
+	}); !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
+	if data, err := os.ReadFile(dest); err != nil || string(data) != "old" {
+		t.Fatalf("destination changed after failed write: data=%q err=%v", data, err)
+	}
+
+	if err := writeArchiveAtomically(dest, func(w io.Writer) error {
+		_, err := w.Write([]byte("complete"))
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Fatalf("archive mode = %o, want 600", info.Mode().Perm())
+	}
+	if matches, _ := filepath.Glob(filepath.Join(dir, ".backup.tar.gz.tmp-*")); len(matches) != 0 {
+		t.Fatalf("temporary archive files remain: %v", matches)
+	}
+}
+
+type testTarEntry struct {
+	name     string
+	typeflag byte
+	data     string
+}
+
+func makeTarGz(t *testing.T, entries ...testTarEntry) []byte {
+	t.Helper()
+	var out bytes.Buffer
+	gz := gzip.NewWriter(&out)
+	tw := tar.NewWriter(gz)
+	for _, entry := range entries {
+		header := &tar.Header{Name: entry.name, Typeflag: entry.typeflag, Mode: 0600, Size: int64(len(entry.data))}
+		if err := tw.WriteHeader(header); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(entry.data)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return out.Bytes()
+}
+
+func TestReadTarGzRejectsUnsafeOrOversizedArchives(t *testing.T) {
+	tests := []struct {
+		name       string
+		entries    []testTarEntry
+		maxEntries int
+		maxFile    int64
+		maxTotal   int64
+	}{
+		{name: "path traversal", entries: []testTarEntry{{name: "../escape", typeflag: tar.TypeReg, data: "x"}}, maxEntries: 10, maxFile: 10, maxTotal: 10},
+		{name: "symlink", entries: []testTarEntry{{name: "backup/link", typeflag: tar.TypeSymlink}}, maxEntries: 10, maxFile: 10, maxTotal: 10},
+		{name: "entry count", entries: []testTarEntry{{name: "backup/a", typeflag: tar.TypeReg}, {name: "backup/b", typeflag: tar.TypeReg}}, maxEntries: 1, maxFile: 10, maxTotal: 10},
+		{name: "file size", entries: []testTarEntry{{name: "backup/a", typeflag: tar.TypeReg, data: "12345"}}, maxEntries: 10, maxFile: 4, maxTotal: 10},
+		{name: "total size", entries: []testTarEntry{{name: "backup/a", typeflag: tar.TypeReg, data: "123"}, {name: "backup/b", typeflag: tar.TypeReg, data: "456"}}, maxEntries: 10, maxFile: 10, maxTotal: 5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := readTarGzWithLimits(bytes.NewReader(makeTarGz(t, tt.entries...)), t.TempDir(), tt.maxEntries, tt.maxFile, tt.maxTotal); err == nil {
+				t.Fatal("readTarGzWithLimits accepted unsafe archive")
+			}
+		})
+	}
+}
 
 func TestSkipReason(t *testing.T) {
 	tests := []struct {

--- a/cli/cmd/restore.go
+++ b/cli/cmd/restore.go
@@ -59,6 +59,9 @@ func init() {
 func runRestore(cmd *cobra.Command, args []string) {
 	archivePath := args[0]
 	startTime := time.Now()
+	if err := validateRestoreArchiveFile(archivePath); err != nil {
+		log.Fatal("Invalid restore archive", "error", err)
+	}
 
 	// Validate conflict flag
 	switch restoreConflict {
@@ -126,6 +129,9 @@ func runRestore(cmd *cobra.Command, args []string) {
 	var manifest BackupManifest
 	if err := json.Unmarshal(manifestData, &manifest); err != nil {
 		log.Fatal("Failed to parse manifest", "error", err)
+	}
+	if err := validateBackupManifest(manifest); err != nil {
+		log.Fatal("Invalid backup manifest", "error", err)
 	}
 
 	log.Info("Backup info",
@@ -309,6 +315,35 @@ func manifestIncludesEncryptionKeys(m BackupManifest) bool {
 		return s.Type != "skipped" && s.Error == ""
 	}
 	return false
+}
+
+func validateBackupManifest(manifest BackupManifest) error {
+	seen := make(map[string]struct{}, len(manifest.Streams))
+	for _, stream := range manifest.Streams {
+		name := stream.Name
+		if name == "" || filepath.IsAbs(name) || name != filepath.Base(name) || name == "." || name == ".." || strings.ContainsAny(name, "/\\.*> \t\r\n") {
+			return fmt.Errorf("invalid stream name %q", name)
+		}
+		if _, ok := seen[name]; ok {
+			return fmt.Errorf("duplicate stream name %q", name)
+		}
+		seen[name] = struct{}{}
+	}
+	return nil
+}
+
+func validateRestoreArchiveFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("restore archive must be a regular file")
+	}
+	if info.Size() > maxRestoreArchiveCompressedBytes {
+		return fmt.Errorf("restore archive exceeds the compressed-size limit of %d bytes", maxRestoreArchiveCompressedBytes)
+	}
+	return nil
 }
 
 // connectForRestore establishes a NATS connection for restore operations.

--- a/cli/cmd/restore.go
+++ b/cli/cmd/restore.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,7 +47,7 @@ Conflict handling:
   --conflict=skip      Skip streams that already exist
   --conflict=overwrite Delete and recreate existing streams`,
 	Args: cobra.ExactArgs(1),
-	Run:  runRestore,
+	RunE: runRestore,
 }
 
 func init() {
@@ -56,24 +57,26 @@ func init() {
 	restoreCmd.Flags().StringVar(&restorePassphrase, "passphrase", "", "decryption passphrase for encrypted backups (if not set, prompts interactively)")
 }
 
-func runRestore(cmd *cobra.Command, args []string) {
+func runRestore(cmd *cobra.Command, args []string) error {
 	archivePath := args[0]
 	startTime := time.Now()
-	if err := validateRestoreArchiveFile(archivePath); err != nil {
-		log.Fatal("Invalid restore archive", "error", err)
+	archive, err := openRestoreArchive(archivePath)
+	if err != nil {
+		return fmt.Errorf("invalid restore archive: %w", err)
 	}
+	defer archive.Close()
 
 	// Validate conflict flag
 	switch restoreConflict {
 	case "error", "skip", "overwrite":
 		// valid
 	default:
-		log.Fatal("Invalid --conflict value, must be: error, skip, overwrite", "value", restoreConflict)
+		return fmt.Errorf("invalid --conflict value %q, must be: error, skip, overwrite", restoreConflict)
 	}
 
 	cfg, err := config.ReadConfig(restoreConfigFile)
 	if err != nil {
-		log.Fatal("Failed to read configuration", "error", err)
+		return fmt.Errorf("failed to read configuration: %w", err)
 	}
 
 	log.Info("Starting restore", "archive", archivePath, "conflict", restoreConflict)
@@ -86,36 +89,36 @@ func runRestore(cmd *cobra.Command, args []string) {
 	defer os.RemoveAll(tempDir)
 
 	// Check if the archive is age-encrypted
-	encrypted, err := isAgeEncrypted(archivePath)
+	encrypted, err := isAgeEncryptedReader(archive)
 	if err != nil {
-		log.Fatal("Failed to check archive encryption", "error", err)
+		return fmt.Errorf("failed to check archive encryption: %w", err)
 	}
 
 	if encrypted {
 		log.Info("Archive is encrypted, decryption required")
 		passphrase, err := getPassphrase(restorePassphrase, "Enter passphrase for backup decryption: ", false)
 		if err != nil {
-			log.Fatal("Failed to read passphrase", "error", err)
+			return fmt.Errorf("failed to read passphrase: %w", err)
 		}
 
 		log.Info("Decrypting and extracting archive...")
-		if err := extractEncryptedTarGz(archivePath, tempDir, passphrase); err != nil {
-			log.Fatal("Failed to decrypt/extract archive", "error", err)
+		if err := extractEncryptedTarGzReader(archive, tempDir, passphrase); err != nil {
+			return fmt.Errorf("failed to decrypt/extract archive: %w", err)
 		}
 	} else {
 		log.Info("Extracting archive...")
-		if err := extractTarGz(archivePath, tempDir); err != nil {
-			log.Fatal("Failed to extract archive", "error", err)
+		if err := readTarGz(io.LimitReader(archive, maxRestoreArchiveCompressedBytes+1), tempDir); err != nil {
+			return fmt.Errorf("failed to extract archive: %w", err)
 		}
 	}
 
 	// Find the backup directory inside the temp dir (archive contains a timestamp-named dir)
 	entries, err := os.ReadDir(tempDir)
 	if err != nil {
-		log.Fatal("Failed to read temp directory", "error", err)
+		return fmt.Errorf("failed to read temp directory: %w", err)
 	}
 	if len(entries) != 1 || !entries[0].IsDir() {
-		log.Fatal("Unexpected archive structure: expected a single directory")
+		return fmt.Errorf("unexpected archive structure: expected a single directory")
 	}
 	backupDir := filepath.Join(tempDir, entries[0].Name())
 
@@ -123,15 +126,15 @@ func runRestore(cmd *cobra.Command, args []string) {
 	manifestPath := filepath.Join(backupDir, "manifest.json")
 	manifestData, err := os.ReadFile(manifestPath)
 	if err != nil {
-		log.Fatal("Failed to read manifest", "error", err)
+		return fmt.Errorf("failed to read manifest: %w", err)
 	}
 
 	var manifest BackupManifest
 	if err := json.Unmarshal(manifestData, &manifest); err != nil {
-		log.Fatal("Failed to parse manifest", "error", err)
+		return fmt.Errorf("failed to parse manifest: %w", err)
 	}
 	if err := validateBackupManifest(manifest); err != nil {
-		log.Fatal("Invalid backup manifest", "error", err)
+		return fmt.Errorf("invalid backup manifest: %w", err)
 	}
 
 	log.Info("Backup info",
@@ -143,7 +146,7 @@ func runRestore(cmd *cobra.Command, args []string) {
 	// Connect to NATS
 	nc, embeddedServer, err := connectForRestore(cfg)
 	if err != nil {
-		log.Fatal("Failed to connect to NATS", "error", err)
+		return fmt.Errorf("failed to connect to NATS: %w", err)
 	}
 	defer nc.Close()
 	if embeddedServer != nil {
@@ -158,12 +161,12 @@ func runRestore(cmd *cobra.Command, args []string) {
 
 	js, err := jetstream.New(nc)
 	if err != nil {
-		log.Fatal("Failed to create JetStream context", "error", err)
+		return fmt.Errorf("failed to create JetStream context: %w", err)
 	}
 
 	mgr, err := jsm.New(nc)
 	if err != nil {
-		log.Fatal("Failed to create JSM manager", "error", err)
+		return fmt.Errorf("failed to create JSM manager: %w", err)
 	}
 
 	// Build set of existing streams for conflict detection.
@@ -173,7 +176,7 @@ func runRestore(cmd *cobra.Command, args []string) {
 		existingStreams[info.Config.Name] = true
 	}
 	if err := streamLister.Err(); err != nil {
-		log.Fatal("Failed to enumerate existing streams", "error", err)
+		return fmt.Errorf("failed to enumerate existing streams: %w", err)
 	}
 
 	// Restore each stream from the manifest
@@ -203,7 +206,7 @@ func runRestore(cmd *cobra.Command, args []string) {
 		if existingStreams[streamInfo.Name] {
 			switch restoreConflict {
 			case "error":
-				log.Fatal(fmt.Sprintf("Stream %q already exists. Use --conflict=skip or --conflict=overwrite", streamInfo.Name))
+				return fmt.Errorf("stream %q already exists; use --conflict=skip or --conflict=overwrite", streamInfo.Name)
 			case "skip":
 				log.Info(fmt.Sprintf("%s Skipping %s (already exists)", prefix, streamInfo.Name))
 				skipped++
@@ -267,6 +270,7 @@ func runRestore(cmd *cobra.Command, args []string) {
 			"Encrypted message bodies cannot be decrypted without them — restore your " +
 			"encryption keys separately, or recreate the backup with --include-keys.")
 	}
+	return nil
 }
 
 type restoreConfigOverride struct {
@@ -332,18 +336,32 @@ func validateBackupManifest(manifest BackupManifest) error {
 	return nil
 }
 
-func validateRestoreArchiveFile(path string) error {
-	info, err := os.Stat(path)
+func openRestoreArchive(path string) (*os.File, error) {
+	pathInfo, err := os.Lstat(path)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	if !info.Mode().IsRegular() {
-		return fmt.Errorf("restore archive must be a regular file")
+	if !pathInfo.Mode().IsRegular() {
+		return nil, fmt.Errorf("restore archive must be a regular file, not a symlink or special file")
 	}
-	if info.Size() > maxRestoreArchiveCompressedBytes {
-		return fmt.Errorf("restore archive exceeds the compressed-size limit of %d bytes", maxRestoreArchiveCompressedBytes)
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
 	}
-	return nil
+	fileInfo, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, err
+	}
+	if !fileInfo.Mode().IsRegular() || !os.SameFile(pathInfo, fileInfo) {
+		file.Close()
+		return nil, fmt.Errorf("restore archive changed while it was being opened")
+	}
+	if fileInfo.Size() > maxRestoreArchiveCompressedBytes {
+		file.Close()
+		return nil, fmt.Errorf("restore archive exceeds the compressed-size limit of %d bytes", maxRestoreArchiveCompressedBytes)
+	}
+	return file, nil
 }
 
 // connectForRestore establishes a NATS connection for restore operations.
@@ -399,14 +417,23 @@ func connectForRestore(cfg config.ChattoConfig) (*nats.Conn, *server.Server, err
 
 // isAgeEncrypted checks if a file starts with the age encryption header.
 func isAgeEncrypted(filePath string) (bool, error) {
-	f, err := os.Open(filePath)
+	f, err := openRestoreArchive(filePath)
 	if err != nil {
 		return false, err
 	}
 	defer f.Close()
+	return isAgeEncryptedReader(f)
+}
 
+func isAgeEncryptedReader(r io.ReadSeeker) (bool, error) {
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
+		return false, err
+	}
 	header := make([]byte, 30)
-	n, err := f.Read(header)
+	n, err := r.Read(header)
+	if _, seekErr := r.Seek(0, io.SeekStart); seekErr != nil {
+		return false, seekErr
+	}
 	if n == 0 || err != nil {
 		return false, nil
 	}
@@ -416,18 +443,21 @@ func isAgeEncrypted(filePath string) (bool, error) {
 
 // extractEncryptedTarGz decrypts an age-encrypted .tar.gz archive and extracts it.
 func extractEncryptedTarGz(archiveFile, destDir, passphrase string) error {
-	inFile, err := os.Open(archiveFile)
+	inFile, err := openRestoreArchive(archiveFile)
 	if err != nil {
 		return fmt.Errorf("failed to open archive: %w", err)
 	}
 	defer inFile.Close()
+	return extractEncryptedTarGzReader(inFile, destDir, passphrase)
+}
 
+func extractEncryptedTarGzReader(r io.Reader, destDir, passphrase string) error {
 	identity, err := age.NewScryptIdentity(passphrase)
 	if err != nil {
 		return fmt.Errorf("failed to create age identity: %w", err)
 	}
 
-	ageReader, err := age.Decrypt(inFile, identity)
+	ageReader, err := age.Decrypt(io.LimitReader(r, maxRestoreArchiveCompressedBytes+1), identity)
 	if err != nil {
 		return fmt.Errorf("decryption failed (wrong passphrase?): %w", err)
 	}

--- a/cli/cmd/restore_test.go
+++ b/cli/cmd/restore_test.go
@@ -82,19 +82,31 @@ func TestValidateBackupManifest(t *testing.T) {
 	}
 }
 
-func TestValidateRestoreArchiveFile(t *testing.T) {
+func TestOpenRestoreArchive(t *testing.T) {
 	file := filepath.Join(t.TempDir(), "backup.tar.gz")
 	if err := os.WriteFile(file, []byte("archive"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	if err := validateRestoreArchiveFile(file); err != nil {
+	opened, err := openRestoreArchive(file)
+	if err != nil {
 		t.Fatalf("valid archive rejected: %v", err)
 	}
-	if err := validateRestoreArchiveFile(t.TempDir()); err == nil {
+	opened.Close()
+	if opened, err := openRestoreArchive(t.TempDir()); err == nil {
+		opened.Close()
 		t.Fatal("directory accepted as restore archive")
 	}
-	if err := validateRestoreArchiveFile(filepath.Join(t.TempDir(), "missing")); err == nil {
+	if opened, err := openRestoreArchive(filepath.Join(t.TempDir(), "missing")); err == nil {
+		opened.Close()
 		t.Fatal("missing archive accepted")
+	}
+	symlink := filepath.Join(t.TempDir(), "backup-link")
+	if err := os.Symlink(file, symlink); err != nil {
+		t.Fatal(err)
+	}
+	if opened, err := openRestoreArchive(symlink); err == nil {
+		opened.Close()
+		t.Fatal("symlink accepted as restore archive")
 	}
 	large := filepath.Join(t.TempDir(), "too-large.tar.gz")
 	largeFile, err := os.Create(large)
@@ -108,7 +120,8 @@ func TestValidateRestoreArchiveFile(t *testing.T) {
 	if err := largeFile.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if err := validateRestoreArchiveFile(large); err == nil {
+	if opened, err := openRestoreArchive(large); err == nil {
+		opened.Close()
 		t.Fatal("oversized compressed archive accepted")
 	}
 }

--- a/cli/cmd/restore_test.go
+++ b/cli/cmd/restore_test.go
@@ -58,6 +58,61 @@ func TestManifestIncludesEncryptionKeys(t *testing.T) {
 	}
 }
 
+func TestValidateBackupManifest(t *testing.T) {
+	tests := []struct {
+		name    string
+		streams []StreamBackupInfo
+		wantErr bool
+	}{
+		{name: "valid", streams: []StreamBackupInfo{{Name: "EVT"}, {Name: "KV_RUNTIME_STATE"}}},
+		{name: "empty", streams: []StreamBackupInfo{{Name: ""}}, wantErr: true},
+		{name: "parent traversal", streams: []StreamBackupInfo{{Name: "../../outside"}}, wantErr: true},
+		{name: "absolute", streams: []StreamBackupInfo{{Name: "/tmp/outside"}}, wantErr: true},
+		{name: "windows separator", streams: []StreamBackupInfo{{Name: `..\outside`}}, wantErr: true},
+		{name: "invalid NATS punctuation", streams: []StreamBackupInfo{{Name: "bad.name"}}, wantErr: true},
+		{name: "duplicate", streams: []StreamBackupInfo{{Name: "EVT"}, {Name: "EVT"}}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateBackupManifest(BackupManifest{Streams: tt.streams})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateBackupManifest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateRestoreArchiveFile(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "backup.tar.gz")
+	if err := os.WriteFile(file, []byte("archive"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateRestoreArchiveFile(file); err != nil {
+		t.Fatalf("valid archive rejected: %v", err)
+	}
+	if err := validateRestoreArchiveFile(t.TempDir()); err == nil {
+		t.Fatal("directory accepted as restore archive")
+	}
+	if err := validateRestoreArchiveFile(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatal("missing archive accepted")
+	}
+	large := filepath.Join(t.TempDir(), "too-large.tar.gz")
+	largeFile, err := os.Create(large)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := largeFile.Truncate(maxRestoreArchiveCompressedBytes + 1); err != nil {
+		largeFile.Close()
+		t.Fatal(err)
+	}
+	if err := largeFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateRestoreArchiveFile(large); err == nil {
+		t.Fatal("oversized compressed archive accepted")
+	}
+}
+
 func TestRestoreConfigForTargetOverridesReplicas(t *testing.T) {
 	streamDir := t.TempDir()
 	writeRestoreMetadata(t, streamDir, api.JSApiStreamRestoreRequest{

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -699,6 +699,8 @@ The `/api/realtime` WebSocket is backed by the single core stream `StreamMyEvent
 
 Notes: Excluded from backups so backup archives do not contain the KEKs needed to unwrap protected content or the per-call media keys needed to decrypt captured LiveKit media. Chatto core uses the in-process `internal/kms` boundary for KEK creation, DEK wrap/unwrap, call-key lookup, and key shredding. App-owned wrapped DEK records live in `RUNTIME_STATE` under `dek.{contentKeyRef}`.
 
+The backup CLI stages JetStream snapshots in an owner-only random directory beside the destination, always removes plaintext staging, and publishes owner-only archives through a same-directory temporary file and atomic rename. Restore extracts into an owner-only temporary directory, rejects non-local manifest stream names and unsupported tar entry types, and bounds archive entry count, individual file size, and total expanded bytes before connecting restored paths to JetStream.
+
 **RUNTIME\_STATE keys:**
 
 `RUNTIME_STATE` is the persisted home for latest-value runtime state that


### PR DESCRIPTION
## Summary

- stage JetStream snapshots in randomized owner-only directories, restrict every staged file, and always remove plaintext staging
- publish owner-only backup archives through a synced same-directory temporary file, atomic rename, and destination-directory fsync
- validate and reuse one restore archive descriptor, reject unsafe manifests and tar entries, and bound compressed and expanded archive resources
- convert restore failures to returned errors so deferred decrypted-staging cleanup always runs

## Validation

- `mise x -- go test ./cmd -count=1 -timeout 120s`
- `mise x -- pnpm --dir apps/docs-website build`
- `mise test-cli`
- two adversarial review passes, with no remaining findings

Closes #1434.
