### PR TITLE
fix(cli): require explicit passphrase sources

### DIFF
--- a/apps/docs-website/src/content/docs/guides/operations/backup-restore.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/backup-restore.mdx
@@ -95,6 +95,7 @@ vault kv get -field=passphrase secret/chatto | \
 ```
 
 The legacy `--passphrase` argument is deprecated because command-line secrets can appear in shell history and process listings. Migrate unattended jobs to `--passphrase-file` or `--passphrase-stdin` before Chatto 0.5.
+Non-interactive commands do not consume stdin unless `--passphrase-stdin` is present; this prevents inherited pipes from hanging a backup or becoming an accidental secret source.
 
 <Aside type="caution">
   A backup made with `--include-keys` contains the keys needed to decrypt message bodies and durable user PII after restore. Always combine `--include-keys` with `--encrypt`, and treat the archive as sensitive material.

--- a/apps/docs-website/src/content/docs/guides/operations/backup-restore.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/backup-restore.mdx
@@ -83,14 +83,18 @@ You'll be prompted to enter and confirm the passphrase.
 
 Encrypted backups use `.tar.gz.age` as the file extension. The encryption format is [age](https://age-encryption.org) — a modern, audited file encryption tool. This means you can also inspect or decrypt your backups using the standalone `age` CLI if needed (see [Using the age CLI](#using-the-age-cli) below).
 
-For scripted or automated backups, pass the passphrase via flag or pipe it from stdin:
+For scripted or automated backups, read the passphrase from a restricted file or explicitly from stdin:
 
 ```bash
-chatto backup -c chatto.toml --encrypt --include-keys --passphrase "$BACKUP_PASSPHRASE"
+chatto backup -c chatto.toml --encrypt --include-keys \
+  --passphrase-file /run/secrets/chatto-backup-passphrase
 
 # Or pipe from a secrets manager
-vault kv get -field=passphrase secret/chatto | chatto backup -c chatto.toml --encrypt --include-keys
+vault kv get -field=passphrase secret/chatto | \
+  chatto backup -c chatto.toml --encrypt --include-keys --passphrase-stdin
 ```
+
+The legacy `--passphrase` argument is deprecated because command-line secrets can appear in shell history and process listings. Migrate unattended jobs to `--passphrase-file` or `--passphrase-stdin` before Chatto 0.5.
 
 <Aside type="caution">
   A backup made with `--include-keys` contains the keys needed to decrypt message bodies and durable user PII after restore. Always combine `--include-keys` with `--encrypt`, and treat the archive as sensitive material.
@@ -126,10 +130,11 @@ Restore accepts regular files and directories only, rejects unsafe manifest and 
    chatto restore backup.tar.gz.age -c chatto.toml
    ```
 
-   You can also pass the passphrase via flag:
+   For non-interactive restore, read it from a restricted file:
 
    ```bash
-   chatto restore backup.tar.gz.age -c chatto.toml --passphrase "$BACKUP_PASSPHRASE"
+   chatto restore backup.tar.gz.age -c chatto.toml \
+     --passphrase-file /run/secrets/chatto-backup-passphrase
    ```
 
 3. **Start Chatto normally**
@@ -174,13 +179,15 @@ chatto keys export -c chatto.toml -o keys.backup
 
 You'll be prompted for a passphrase. The export file is encrypted using age, so it's safe to store — but use a strong passphrase.
 
-For scripted/automated backups, pass the passphrase via flag or pipe it from stdin:
+For scripted/automated exports, read the passphrase from a restricted file or explicitly from stdin:
 
 ```bash
-chatto keys export -c chatto.toml -o keys.backup --passphrase "$KEY_BACKUP_PASSPHRASE"
+chatto keys export -c chatto.toml -o keys.backup \
+  --passphrase-file /run/secrets/chatto-key-passphrase
 
 # Or pipe from a secrets manager
-vault kv get -field=passphrase secret/chatto | chatto keys export -c chatto.toml -o keys.backup
+vault kv get -field=passphrase secret/chatto | \
+  chatto keys export -c chatto.toml -o keys.backup --passphrase-stdin
 ```
 
 ### Importing keys
@@ -236,14 +243,12 @@ BACKUP_DIR="/mnt/backups/chatto"
 PASSPHRASE_FILE="/etc/chatto/backup-passphrase"  # chmod 600
 RETENTION_DAYS=14
 
-# Read passphrase from file
-PASSPHRASE=$(cat "$PASSPHRASE_FILE")
-
 # Create timestamped encrypted backup with keys included
 TIMESTAMP=$(date -u +%Y-%m-%dT%H-%M-%SZ)
 BACKUP_FILE="$BACKUP_DIR/$TIMESTAMP.tar.gz.age"
 
-chatto backup -c "$CONFIG" --encrypt --include-keys --passphrase "$PASSPHRASE" -o "$BACKUP_FILE"
+chatto backup -c "$CONFIG" --encrypt --include-keys \
+  --passphrase-file "$PASSPHRASE_FILE" -o "$BACKUP_FILE"
 
 # Remove backups older than retention period
 find "$BACKUP_DIR" -name "*.age" -mtime +$RETENTION_DAYS -delete
@@ -254,8 +259,9 @@ echo "Backup complete: $BACKUP_FILE"
 For split data and key backups, run a key export with the same retention policy:
 
 ```bash
-chatto backup -c "$CONFIG" --encrypt --passphrase "$PASSPHRASE" -o "$BACKUP_FILE"
-chatto keys export -c "$CONFIG" -o "$BACKUP_DIR/$TIMESTAMP-keys.age" --passphrase "$PASSPHRASE"
+chatto backup -c "$CONFIG" --encrypt --passphrase-file "$PASSPHRASE_FILE" -o "$BACKUP_FILE"
+chatto keys export -c "$CONFIG" -o "$BACKUP_DIR/$TIMESTAMP-keys.age" \
+  --passphrase-file "$PASSPHRASE_FILE"
 ```
 
 ## Using the age CLI

--- a/cli/cmd/backup.go
+++ b/cli/cmd/backup.go
@@ -50,11 +50,13 @@ type BackupStats struct {
 }
 
 var (
-	backupConfigFile  string
-	backupOutput      string
-	backupEncrypt     bool
-	backupPassphrase  string
-	backupIncludeKeys bool
+	backupConfigFile      string
+	backupOutput          string
+	backupEncrypt         bool
+	backupPassphrase      string
+	backupPassphraseFile  string
+	backupPassphraseStdin bool
+	backupIncludeKeys     bool
 )
 
 const (
@@ -100,6 +102,9 @@ func init() {
 	backupCmd.Flags().StringVarP(&backupOutput, "output", "o", "", "output path for the backup archive (default: backups/<timestamp>.tar.gz)")
 	backupCmd.Flags().BoolVar(&backupEncrypt, "encrypt", false, "encrypt the backup with a passphrase (age encryption)")
 	backupCmd.Flags().StringVar(&backupPassphrase, "passphrase", "", "encryption passphrase (if not set, prompts interactively)")
+	_ = backupCmd.Flags().MarkDeprecated("passphrase", "use --passphrase-stdin or --passphrase-file so the secret is not exposed in process arguments")
+	backupCmd.Flags().StringVar(&backupPassphraseFile, "passphrase-file", "", "file containing the encryption passphrase")
+	backupCmd.Flags().BoolVar(&backupPassphraseStdin, "passphrase-stdin", false, "read the encryption passphrase from stdin")
 	backupCmd.Flags().BoolVar(&backupIncludeKeys, "include-keys", false, "include KV_ENCRYPTION_KEYS in the archive (treat the archive as sensitive)")
 }
 
@@ -115,7 +120,12 @@ func runBackup(cmd *cobra.Command, args []string) {
 	var passphrase string
 	if backupEncrypt {
 		var err error
-		passphrase, err = getPassphrase(backupPassphrase, "Enter passphrase for backup encryption: ", true)
+		passphrase, err = getPassphrase(passphraseInput{
+			argument:    backupPassphrase,
+			argumentSet: cmd.Flags().Changed("passphrase"),
+			file:        backupPassphraseFile,
+			stdin:       backupPassphraseStdin,
+		}, "Enter passphrase for backup encryption: ", true)
 		if err != nil {
 			log.Fatal("Failed to read passphrase", "error", err)
 		}

--- a/cli/cmd/keys.go
+++ b/cli/cmd/keys.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -435,16 +434,8 @@ func getPassphrase(input passphraseInput, prompt string, confirm bool) (string, 
 		return requirePassphrase(passphrase)
 	}
 
-	// Preserve the existing implicit one-line stdin behavior for compatibility.
 	if !term.IsTerminal(int(syscall.Stdin)) {
-		scanner := bufio.NewScanner(os.Stdin)
-		if !scanner.Scan() {
-			if err := scanner.Err(); err != nil {
-				return "", fmt.Errorf("failed to read passphrase from stdin: %w", err)
-			}
-			return "", fmt.Errorf("passphrase cannot be empty")
-		}
-		return requirePassphrase(scanner.Text())
+		return "", fmt.Errorf("non-interactive passphrase input requires --passphrase-stdin or --passphrase-file")
 	}
 
 	// Interactive: prompt with hidden input.

--- a/cli/cmd/keys.go
+++ b/cli/cmd/keys.go
@@ -405,8 +405,8 @@ type passphraseInput struct {
 	stdin       bool
 }
 
-// getPassphrase reads one validated passphrase from an explicit source, a
-// compatibility stdin pipe, or a hidden interactive prompt.
+// getPassphrase reads one validated passphrase from an explicit source or a
+// hidden interactive prompt.
 func getPassphrase(input passphraseInput, prompt string, confirm bool) (string, error) {
 	if err := validateSecretSources(
 		"--passphrase", input.argumentSet,

--- a/cli/cmd/keys.go
+++ b/cli/cmd/keys.go
@@ -41,9 +41,11 @@ type ExportedKey struct {
 }
 
 var (
-	keysConfigFile string
-	keysOutput     string
-	keysPassphrase string
+	keysConfigFile      string
+	keysOutput          string
+	keysPassphrase      string
+	keysPassphraseFile  string
+	keysPassphraseStdin bool
 )
 
 var keysCmd = &cobra.Command{
@@ -92,10 +94,16 @@ func init() {
 	keysExportCmd.Flags().StringVarP(&keysConfigFile, "config", "c", "", "path to configuration file (default: chatto.toml)")
 	keysExportCmd.Flags().StringVarP(&keysOutput, "output", "o", "", "output file path (required)")
 	keysExportCmd.Flags().StringVar(&keysPassphrase, "passphrase", "", "encryption passphrase (if not set, prompts interactively)")
+	_ = keysExportCmd.Flags().MarkDeprecated("passphrase", "use --passphrase-stdin or --passphrase-file so the secret is not exposed in process arguments")
+	keysExportCmd.Flags().StringVar(&keysPassphraseFile, "passphrase-file", "", "file containing the encryption passphrase")
+	keysExportCmd.Flags().BoolVar(&keysPassphraseStdin, "passphrase-stdin", false, "read the encryption passphrase from stdin")
 	_ = keysExportCmd.MarkFlagRequired("output")
 
 	keysImportCmd.Flags().StringVarP(&keysConfigFile, "config", "c", "", "path to configuration file (default: chatto.toml)")
 	keysImportCmd.Flags().StringVar(&keysPassphrase, "passphrase", "", "decryption passphrase (if not set, prompts interactively)")
+	_ = keysImportCmd.Flags().MarkDeprecated("passphrase", "use --passphrase-stdin or --passphrase-file so the secret is not exposed in process arguments")
+	keysImportCmd.Flags().StringVar(&keysPassphraseFile, "passphrase-file", "", "file containing the decryption passphrase")
+	keysImportCmd.Flags().BoolVar(&keysPassphraseStdin, "passphrase-stdin", false, "read the decryption passphrase from stdin")
 }
 
 func runKeysExport(cmd *cobra.Command, args []string) {
@@ -104,7 +112,12 @@ func runKeysExport(cmd *cobra.Command, args []string) {
 		log.Fatal("Failed to read configuration", "error", err)
 	}
 
-	passphrase, err := getPassphrase(keysPassphrase, "Enter passphrase for key export: ", true)
+	passphrase, err := getPassphrase(passphraseInput{
+		argument:    keysPassphrase,
+		argumentSet: cmd.Flags().Changed("passphrase"),
+		file:        keysPassphraseFile,
+		stdin:       keysPassphraseStdin,
+	}, "Enter passphrase for key export: ", true)
 	if err != nil {
 		log.Fatal("Failed to read passphrase", "error", err)
 	}
@@ -154,7 +167,12 @@ func runKeysImport(cmd *cobra.Command, args []string) {
 		log.Fatal("Failed to read configuration", "error", err)
 	}
 
-	passphrase, err := getPassphrase(keysPassphrase, "Enter passphrase for key import: ", false)
+	passphrase, err := getPassphrase(passphraseInput{
+		argument:    keysPassphrase,
+		argumentSet: cmd.Flags().Changed("passphrase"),
+		file:        keysPassphraseFile,
+		stdin:       keysPassphraseStdin,
+	}, "Enter passphrase for key import: ", false)
 	if err != nil {
 		log.Fatal("Failed to read passphrase", "error", err)
 	}
@@ -381,14 +399,43 @@ func decryptKeysFromFile(filePath, passphrase string) ([]ExportedKey, error) {
 	return export.Keys, nil
 }
 
-// getPassphrase reads a passphrase from the flag value, stdin pipe, or interactive prompt.
-// If confirm is true, prompts for confirmation (export use case) — only in interactive mode.
-func getPassphrase(flagValue string, prompt string, confirm bool) (string, error) {
-	if flagValue != "" {
-		return flagValue, nil
+type passphraseInput struct {
+	argument    string
+	argumentSet bool
+	file        string
+	stdin       bool
+}
+
+// getPassphrase reads one validated passphrase from an explicit source, a
+// compatibility stdin pipe, or a hidden interactive prompt.
+func getPassphrase(input passphraseInput, prompt string, confirm bool) (string, error) {
+	if err := validateSecretSources(
+		"--passphrase", input.argumentSet,
+		"--passphrase-file", input.file != "",
+		"--passphrase-stdin", input.stdin,
+	); err != nil {
+		return "", err
 	}
 
-	// If stdin is piped, read a single line from it (no confirmation possible).
+	if input.argumentSet {
+		return requirePassphrase(input.argument)
+	}
+	if input.file != "" {
+		passphrase, err := readSecretFile(input.file)
+		if err != nil {
+			return "", fmt.Errorf("failed to read passphrase file: %w", err)
+		}
+		return requirePassphrase(passphrase)
+	}
+	if input.stdin {
+		passphrase, err := readSecretStdin()
+		if err != nil {
+			return "", fmt.Errorf("failed to read passphrase from stdin: %w", err)
+		}
+		return requirePassphrase(passphrase)
+	}
+
+	// Preserve the existing implicit one-line stdin behavior for compatibility.
 	if !term.IsTerminal(int(syscall.Stdin)) {
 		scanner := bufio.NewScanner(os.Stdin)
 		if !scanner.Scan() {
@@ -397,11 +444,7 @@ func getPassphrase(flagValue string, prompt string, confirm bool) (string, error
 			}
 			return "", fmt.Errorf("passphrase cannot be empty")
 		}
-		pass := strings.TrimRight(scanner.Text(), "\r\n")
-		if pass == "" {
-			return "", fmt.Errorf("passphrase cannot be empty")
-		}
-		return pass, nil
+		return requirePassphrase(scanner.Text())
 	}
 
 	// Interactive: prompt with hidden input.
@@ -429,6 +472,13 @@ func getPassphrase(flagValue string, prompt string, confirm bool) (string, error
 	}
 
 	return string(pass), nil
+}
+
+func requirePassphrase(passphrase string) (string, error) {
+	if passphrase == "" {
+		return "", fmt.Errorf("passphrase cannot be empty")
+	}
+	return passphrase, nil
 }
 
 // connectForKeys connects to NATS for key operations (same pattern as backup).

--- a/cli/cmd/passphrase_test.go
+++ b/cli/cmd/passphrase_test.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestGetPassphraseExplicitSources(t *testing.T) {
+	t.Run("file trims trailing newline", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "passphrase")
+		if err := os.WriteFile(path, []byte("file-secret\r\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		got, err := getPassphrase(passphraseInput{file: path}, "unused", true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "file-secret" {
+			t.Fatalf("passphrase from file = %q", got)
+		}
+	})
+
+	t.Run("stdin trims trailing newline", func(t *testing.T) {
+		withTestStdin(t, "stdin-secret\n", func() {
+			got, err := getPassphrase(passphraseInput{stdin: true}, "unused", true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != "stdin-secret" {
+				t.Fatalf("passphrase from stdin = %q", got)
+			}
+		})
+	})
+
+	t.Run("argument remains compatible", func(t *testing.T) {
+		got, err := getPassphrase(passphraseInput{argument: "argument-secret", argumentSet: true}, "unused", false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "argument-secret" {
+			t.Fatalf("passphrase from deprecated argument = %q", got)
+		}
+	})
+}
+
+func TestGetPassphraseRejectsUnsafeSourceCombinationsAndEmptyValues(t *testing.T) {
+	secret := "must-not-appear"
+	_, err := getPassphrase(passphraseInput{
+		argument:    secret,
+		argumentSet: true,
+		file:        "/tmp/passphrase",
+	}, "unused", false)
+	if err == nil || !strings.Contains(err.Error(), "provide only one") {
+		t.Fatalf("conflicting sources error = %v", err)
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("conflicting sources error leaked passphrase: %v", err)
+	}
+
+	if _, err := getPassphrase(passphraseInput{argumentSet: true}, "unused", false); err == nil || err.Error() != "passphrase cannot be empty" {
+		t.Fatalf("empty argument error = %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "empty-passphrase")
+	if err := os.WriteFile(path, []byte("\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := getPassphrase(passphraseInput{file: path}, "unused", false); err == nil || err.Error() != "passphrase cannot be empty" {
+		t.Fatalf("empty file error = %v", err)
+	}
+}
+
+func TestPassphraseCommandsExposeSecureSourcesAndDeprecateArgument(t *testing.T) {
+	for _, cmd := range []*cobra.Command{backupCmd, restoreCmd, keysExportCmd, keysImportCmd} {
+		if cmd.Flags().Lookup("passphrase-file") == nil || cmd.Flags().Lookup("passphrase-stdin") == nil {
+			t.Errorf("%s is missing secure passphrase flags", cmd.CommandPath())
+		}
+		flag := cmd.Flags().Lookup("passphrase")
+		if flag == nil || flag.Deprecated == "" {
+			t.Errorf("%s --passphrase is not deprecated", cmd.CommandPath())
+		}
+	}
+}
+
+func withTestStdin(t *testing.T, input string, fn func()) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.WriteString(input); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	oldStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = oldStdin
+		_ = r.Close()
+	})
+	fn()
+}

--- a/cli/cmd/passphrase_test.go
+++ b/cli/cmd/passphrase_test.go
@@ -74,6 +74,14 @@ func TestGetPassphraseRejectsUnsafeSourceCombinationsAndEmptyValues(t *testing.T
 	}
 }
 
+func TestGetPassphraseNonInteractiveRequiresExplicitSource(t *testing.T) {
+	withTestStdin(t, "must-not-be-consumed\n", func() {
+		if _, err := getPassphrase(passphraseInput{}, "unused", false); err == nil || err.Error() != "non-interactive passphrase input requires --passphrase-stdin or --passphrase-file" {
+			t.Fatalf("non-interactive source error = %v", err)
+		}
+	})
+}
+
 func TestPassphraseCommandsExposeSecureSourcesAndDeprecateArgument(t *testing.T) {
 	for _, cmd := range []*cobra.Command{backupCmd, restoreCmd, keysExportCmd, keysImportCmd} {
 		if cmd.Flags().Lookup("passphrase-file") == nil || cmd.Flags().Lookup("passphrase-stdin") == nil {

--- a/cli/cmd/restore.go
+++ b/cli/cmd/restore.go
@@ -24,9 +24,11 @@ import (
 )
 
 var (
-	restoreConfigFile string
-	restoreConflict   string
-	restorePassphrase string
+	restoreConfigFile      string
+	restoreConflict        string
+	restorePassphrase      string
+	restorePassphraseFile  string
+	restorePassphraseStdin bool
 )
 
 var restoreCmd = &cobra.Command{
@@ -55,6 +57,9 @@ func init() {
 	restoreCmd.Flags().StringVarP(&restoreConfigFile, "config", "c", "", "path to configuration file (default: chatto.toml)")
 	restoreCmd.Flags().StringVar(&restoreConflict, "conflict", "error", "conflict handling: error, skip, overwrite")
 	restoreCmd.Flags().StringVar(&restorePassphrase, "passphrase", "", "decryption passphrase for encrypted backups (if not set, prompts interactively)")
+	_ = restoreCmd.Flags().MarkDeprecated("passphrase", "use --passphrase-stdin or --passphrase-file so the secret is not exposed in process arguments")
+	restoreCmd.Flags().StringVar(&restorePassphraseFile, "passphrase-file", "", "file containing the decryption passphrase")
+	restoreCmd.Flags().BoolVar(&restorePassphraseStdin, "passphrase-stdin", false, "read the decryption passphrase from stdin")
 }
 
 func runRestore(cmd *cobra.Command, args []string) error {
@@ -96,7 +101,12 @@ func runRestore(cmd *cobra.Command, args []string) error {
 
 	if encrypted {
 		log.Info("Archive is encrypted, decryption required")
-		passphrase, err := getPassphrase(restorePassphrase, "Enter passphrase for backup decryption: ", false)
+		passphrase, err := getPassphrase(passphraseInput{
+			argument:    restorePassphrase,
+			argumentSet: cmd.Flags().Changed("passphrase"),
+			file:        restorePassphraseFile,
+			stdin:       restorePassphraseStdin,
+		}, "Enter passphrase for backup decryption: ", false)
 		if err != nil {
 			return fmt.Errorf("failed to read passphrase: %w", err)
 		}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -701,7 +701,7 @@ The `/api/realtime` WebSocket is backed by the single core stream `StreamMyEvent
 
 Notes: Excluded from backups so backup archives do not contain the KEKs needed to unwrap protected content or the per-call media keys needed to decrypt captured LiveKit media. Chatto core uses the in-process `internal/kms` boundary for KEK creation, DEK wrap/unwrap, call-key lookup, and key shredding. App-owned wrapped DEK records live in `RUNTIME_STATE` under `dek.{contentKeyRef}`.
 
-The backup CLI stages JetStream snapshots in an owner-only random directory beside the destination, always removes plaintext staging, and publishes owner-only archives through a same-directory temporary file and atomic rename. Restore extracts into an owner-only temporary directory, rejects non-local manifest stream names and unsupported tar entry types, and bounds archive entry count, individual file size, and total expanded bytes before connecting restored paths to JetStream.
+The backup CLI stages JetStream snapshots in an owner-only random directory beside the destination, always removes plaintext staging, and publishes owner-only archives through a same-directory temporary file and atomic rename. Backup, restore, and key export/import accept passphrases through hidden terminal prompts or explicit `--passphrase-file` / `--passphrase-stdin` automation sources; the process-argument `--passphrase` compatibility path is deprecated for removal in 0.5. Restore extracts into an owner-only temporary directory, rejects non-local manifest stream names and unsupported tar entry types, and bounds archive entry count, individual file size, and total expanded bytes before connecting restored paths to JetStream.
 
 **RUNTIME\_STATE keys:**
 


### PR DESCRIPTION
## Summary

Adds `--passphrase-file` and `--passphrase-stdin` to backup, restore, and key export/import, while deprecating argv-based `--passphrase` for removal in 0.5. Non-interactive commands now fail immediately unless a secure source is explicitly selected, preventing inherited pipes from hanging jobs or becoming accidental secrets; this is a breaking change for implicit stdin pipelines, which must add `--passphrase-stdin`. All shipped scripts and documentation now avoid putting passphrases in process arguments, and #1450 tracks final removal of the deprecated flag. Closes #1448.

## Verification

- `mise test-cli`
- Full `cli/cmd` tests
- Docs website production build
- Adversarial review completed with no remaining findings
