### PR TITLE
fix(frontend): label deleted users consistently

### DIFF
--- a/apps/frontend/e2e/account-deletion.test.ts
+++ b/apps/frontend/e2e/account-deletion.test.ts
@@ -77,7 +77,7 @@ test.describe('Account Deletion', () => {
   });
 
   test.describe('Deleted User Effects', () => {
-    test('messages from deleted user show "Deleted User" and content is unavailable', async ({
+    test('messages from deleted users show an italicized placeholder and unavailable content', async ({
       page,
       chatPage,
       roomPage,
@@ -192,7 +192,7 @@ test.describe('Account Deletion', () => {
       );
     });
 
-    test('system events from deleted user show "Deleted User"', async ({
+    test('system events from deleted users show an italicized placeholder', async ({
       page,
       chatPage,
       browser,
@@ -228,10 +228,11 @@ test.describe('Account Deletion', () => {
           await page.reload();
           await waitForRoomReady(page, 'general');
 
-          // User A should now see "Deleted User joined the room"
-          await expect(page.getByText(/Deleted User joined the room/)).toBeVisible({
+          // User A should now see an italicized deleted-user placeholder.
+          await expect(page.getByText(/\[deleted user\] joined the room/)).toBeVisible({
             timeout: TIMEOUTS.REALTIME_EVENT
           });
+          await expect(page.locator('em').filter({ hasText: '[deleted user]' }).first()).toBeVisible();
 
           // User B's original display name should no longer be visible in system events
           await expect(page.getByText(new RegExp(`${userB.displayName} joined`))).not.toBeVisible();

--- a/apps/frontend/messages/de/common.json
+++ b/apps/frontend/messages/de/common.json
@@ -43,6 +43,7 @@
     "back": "Zurück",
     "clear": "Leeren",
     "unknown": "Unbekannt",
+    "deleted_user": "[gelöschter Benutzer]",
     "got_it": "Verstanden",
     "saved": "Gespeichert!",
     "rooms": "Räume",

--- a/apps/frontend/messages/de/message_preview.json
+++ b/apps/frontend/messages/de/message_preview.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "message_preview": {
-    "deleted_user": "Gelöschter Benutzer",
     "attachments_count": "{count} Anhänge",
     "attachment_image": "Bild",
     "attachment_video": "Video",

--- a/apps/frontend/messages/de/room.json
+++ b/apps/frontend/messages/de/room.json
@@ -132,7 +132,6 @@
       "jump_to_file": "Zu {filename} springen",
       "loading_files": "Dateien werden geladen...",
       "calls_unavailable": "Anrufe sind auf diesem Server nicht verfügbar.",
-      "deleted_user": "Gelöschter Benutzer",
       "view_profile": "Profil von {name} anzeigen",
       "in_voice_call": "In einem Sprachanruf",
       "in_video_call": "In einem Videoanruf",

--- a/apps/frontend/messages/de/room.json
+++ b/apps/frontend/messages/de/room.json
@@ -97,6 +97,42 @@
         "deleted": "Diese Nachricht wurde gelöscht."
       }
     },
+    "system_events": {
+      "joined": [
+        {
+          "declarations": ["input count", "local countPlural = count: plural"],
+          "selectors": ["countPlural"],
+          "match": {
+            "countPlural=one": "ist dem Raum beigetreten",
+            "countPlural=other": "sind dem Raum beigetreten"
+          }
+        }
+      ],
+      "left": [
+        {
+          "declarations": ["input count", "local countPlural = count: plural"],
+          "selectors": ["countPlural"],
+          "match": {
+            "countPlural=one": "hat den Raum verlassen",
+            "countPlural=other": "haben den Raum verlassen"
+          }
+        }
+      ],
+      "archived": "hat den Raum archiviert",
+      "unarchived": "hat die Archivierung des Raums aufgehoben",
+      "and": "und",
+      "other_people": [
+        {
+          "declarations": ["input count", "local countPlural = count: plural"],
+          "selectors": ["countPlural"],
+          "match": {
+            "countPlural=one": "weitere Person",
+            "countPlural=other": "weitere"
+          }
+        }
+      ],
+      "show_less": "weniger anzeigen"
+    },
     "attachment": {
       "delete_title": "Anhang löschen",
       "delete_prompt": "Möchtest du diesen Anhang wirklich löschen? Dies kann nicht rückgängig gemacht werden.",

--- a/apps/frontend/messages/en/common.json
+++ b/apps/frontend/messages/en/common.json
@@ -43,6 +43,7 @@
     "back": "Back",
     "clear": "Clear",
     "unknown": "Unknown",
+    "deleted_user": "[deleted user]",
     "got_it": "Got it",
     "saved": "Saved!",
     "rooms": "Rooms",

--- a/apps/frontend/messages/en/message_preview.json
+++ b/apps/frontend/messages/en/message_preview.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "message_preview": {
-    "deleted_user": "Deleted user",
     "attachments_count": "{count} attachments",
     "attachment_image": "Image",
     "attachment_video": "Video",

--- a/apps/frontend/messages/en/room.json
+++ b/apps/frontend/messages/en/room.json
@@ -132,7 +132,6 @@
       "jump_to_file": "Jump to {filename}",
       "loading_files": "Loading files...",
       "calls_unavailable": "Calls are not available on this server.",
-      "deleted_user": "Deleted User",
       "view_profile": "View profile of {name}",
       "in_voice_call": "In a voice call",
       "in_video_call": "In a video call",

--- a/apps/frontend/messages/en/room.json
+++ b/apps/frontend/messages/en/room.json
@@ -97,6 +97,42 @@
         "deleted": "This message has been deleted."
       }
     },
+    "system_events": {
+      "joined": [
+        {
+          "declarations": ["input count", "local countPlural = count: plural"],
+          "selectors": ["countPlural"],
+          "match": {
+            "countPlural=one": "joined the room",
+            "countPlural=other": "joined the room"
+          }
+        }
+      ],
+      "left": [
+        {
+          "declarations": ["input count", "local countPlural = count: plural"],
+          "selectors": ["countPlural"],
+          "match": {
+            "countPlural=one": "left the room",
+            "countPlural=other": "left the room"
+          }
+        }
+      ],
+      "archived": "archived the room",
+      "unarchived": "unarchived the room",
+      "and": "and",
+      "other_people": [
+        {
+          "declarations": ["input count", "local countPlural = count: plural"],
+          "selectors": ["countPlural"],
+          "match": {
+            "countPlural=one": "other",
+            "countPlural=other": "others"
+          }
+        }
+      ],
+      "show_less": "show less"
+    },
     "attachment": {
       "delete_title": "Delete Attachment",
       "delete_prompt": "Are you sure you want to delete this attachment? This cannot be undone.",

--- a/apps/frontend/src/lib/components/DeletedUserLabel.svelte
+++ b/apps/frontend/src/lib/components/DeletedUserLabel.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import * as m from '$lib/i18n/messages';
+</script>
+
+<em class="font-normal italic">{m['common.deleted_user']()}</em>

--- a/apps/frontend/src/lib/components/MessagePreviewCard.svelte
+++ b/apps/frontend/src/lib/components/MessagePreviewCard.svelte
@@ -41,6 +41,7 @@ unknown instance) the component renders nothing.
   import { assetUrlForServer } from '$lib/assets/assetUrls';
   import MessageContent from './MessageContent.svelte';
   import UserAvatar, { UserAvatarViewData } from './UserAvatar.svelte';
+  import DeletedUserLabel from './DeletedUserLabel.svelte';
 
   let {
     link,
@@ -391,13 +392,11 @@ unknown instance) the component renders nothing.
             </span>
           {/if}
           <div class="flex min-w-0 items-center gap-2">
-            {#if preview.actor}
+            {#if preview.actor && !preview.actor.deleted}
               <UserAvatar user={preview.actor} size="xs" />
               <span class="truncate text-sm font-medium">{displayName}</span>
             {:else}
-              <span class="truncate text-sm font-medium text-muted">
-                {m['message_preview.deleted_user']()}
-              </span>
+              <span class="truncate text-sm font-medium text-muted"><DeletedUserLabel /></span>
             {/if}
           </div>
         </div>

--- a/apps/frontend/src/lib/components/MessagePreviewCard.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/MessagePreviewCard.svelte.spec.ts
@@ -195,6 +195,20 @@ beforeEach(() => {
 });
 
 describe('MessagePreviewCard', () => {
+  it('renders a deleted author as an italicized placeholder', async () => {
+    timelineResults.push(bodyPreviewResult('A deleted user message'));
+
+    const { container } = render(MessagePreviewCard, {
+      props: { link: link(), showDismiss: false }
+    });
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('[data-testid="message-preview-card"] em')?.textContent).toBe(
+        '[deleted user]'
+      );
+    });
+  });
+
   it('renders the linked message body as markdown in a scrollable preview', async () => {
     timelineResults.push(
       bodyPreviewResult('# Release notes\n\n- **Breaking** change\n- More details')

--- a/apps/frontend/src/lib/i18n/messages.ts
+++ b/apps/frontend/src/lib/i18n/messages.ts
@@ -651,6 +651,19 @@ const msg_room_message_meta_copy_link_title = (): LocalizedString => messages().
 const msg_room_message_meta_in_reply_to = (): LocalizedString => messages().room_message_meta_in_reply_to(empty());
 const msg_room_message_meta_reply_preview_fallback = (): LocalizedString => messages().room_message_meta_reply_preview_fallback(empty());
 const msg_room_message_meta_deleted = (): LocalizedString => messages().room_message_meta_deleted(empty());
+const msg_room_system_events_joined = (
+  inputs: Parameters<LocaleMessages['room_system_events_joined']>[0]
+): LocalizedString => messages().room_system_events_joined(inputs);
+const msg_room_system_events_left = (
+  inputs: Parameters<LocaleMessages['room_system_events_left']>[0]
+): LocalizedString => messages().room_system_events_left(inputs);
+const msg_room_system_events_archived = (): LocalizedString => messages().room_system_events_archived(empty());
+const msg_room_system_events_unarchived = (): LocalizedString => messages().room_system_events_unarchived(empty());
+const msg_room_system_events_and = (): LocalizedString => messages().room_system_events_and(empty());
+const msg_room_system_events_other_people = (
+  inputs: Parameters<LocaleMessages['room_system_events_other_people']>[0]
+): LocalizedString => messages().room_system_events_other_people(inputs);
+const msg_room_system_events_show_less = (): LocalizedString => messages().room_system_events_show_less(empty());
 const msg_room_attachment_delete_title = (): LocalizedString => messages().room_attachment_delete_title(empty());
 const msg_room_attachment_delete_prompt = (): LocalizedString => messages().room_attachment_delete_prompt(empty());
 const msg_room_attachment_delete_label = (): LocalizedString => messages().room_attachment_delete_label(empty());
@@ -2000,6 +2013,13 @@ export { msg_room_message_meta_copy_link_title as 'room.message.meta.copy_link_t
 export { msg_room_message_meta_in_reply_to as 'room.message.meta.in_reply_to' };
 export { msg_room_message_meta_reply_preview_fallback as 'room.message.meta.reply_preview_fallback' };
 export { msg_room_message_meta_deleted as 'room.message.meta.deleted' };
+export { msg_room_system_events_joined as 'room.system_events.joined' };
+export { msg_room_system_events_left as 'room.system_events.left' };
+export { msg_room_system_events_archived as 'room.system_events.archived' };
+export { msg_room_system_events_unarchived as 'room.system_events.unarchived' };
+export { msg_room_system_events_and as 'room.system_events.and' };
+export { msg_room_system_events_other_people as 'room.system_events.other_people' };
+export { msg_room_system_events_show_less as 'room.system_events.show_less' };
 export { msg_room_attachment_delete_title as 'room.attachment.delete_title' };
 export { msg_room_attachment_delete_prompt as 'room.attachment.delete_prompt' };
 export { msg_room_attachment_delete_label as 'room.attachment.delete_label' };

--- a/apps/frontend/src/lib/i18n/messages.ts
+++ b/apps/frontend/src/lib/i18n/messages.ts
@@ -94,6 +94,7 @@ const msg_common_confirm = (): LocalizedString => messages().common_confirm(empt
 const msg_common_back = (): LocalizedString => messages().common_back(empty());
 const msg_common_clear = (): LocalizedString => messages().common_clear(empty());
 const msg_common_unknown = (): LocalizedString => messages().common_unknown(empty());
+const msg_common_deleted_user = (): LocalizedString => messages().common_deleted_user(empty());
 const msg_common_got_it = (): LocalizedString => messages().common_got_it(empty());
 const msg_common_saved = (): LocalizedString => messages().common_saved(empty());
 const msg_common_rooms = (): LocalizedString => messages().common_rooms(empty());
@@ -692,7 +693,6 @@ const msg_room_sidebar_jump_to_file = (
 ): LocalizedString => messages().room_sidebar_jump_to_file(inputs);
 const msg_room_sidebar_loading_files = (): LocalizedString => messages().room_sidebar_loading_files(empty());
 const msg_room_sidebar_calls_unavailable = (): LocalizedString => messages().room_sidebar_calls_unavailable(empty());
-const msg_room_sidebar_deleted_user = (): LocalizedString => messages().room_sidebar_deleted_user(empty());
 const msg_room_sidebar_view_profile = (
   inputs: Parameters<LocaleMessages['room_sidebar_view_profile']>[0]
 ): LocalizedString => messages().room_sidebar_view_profile(inputs);
@@ -838,7 +838,6 @@ const msg_preview_youtube_dismiss = (): LocalizedString => messages().preview_yo
 const msg_preview_youtube_delete = (): LocalizedString => messages().preview_youtube_delete(empty());
 const msg_preview_youtube_open = (): LocalizedString => messages().preview_youtube_open(empty());
 const msg_preview_youtube_delete_embed = (): LocalizedString => messages().preview_youtube_delete_embed(empty());
-const msg_message_preview_deleted_user = (): LocalizedString => messages().message_preview_deleted_user(empty());
 const msg_message_preview_attachments_count = (
   inputs: Parameters<LocaleMessages['message_preview_attachments_count']>[0]
 ): LocalizedString => messages().message_preview_attachments_count(inputs);
@@ -1520,6 +1519,7 @@ export { msg_common_confirm as 'common.confirm' };
 export { msg_common_back as 'common.back' };
 export { msg_common_clear as 'common.clear' };
 export { msg_common_unknown as 'common.unknown' };
+export { msg_common_deleted_user as 'common.deleted_user' };
 export { msg_common_got_it as 'common.got_it' };
 export { msg_common_saved as 'common.saved' };
 export { msg_common_rooms as 'common.rooms' };
@@ -2030,7 +2030,6 @@ export { msg_room_sidebar_call as 'room.sidebar.call' };
 export { msg_room_sidebar_jump_to_file as 'room.sidebar.jump_to_file' };
 export { msg_room_sidebar_loading_files as 'room.sidebar.loading_files' };
 export { msg_room_sidebar_calls_unavailable as 'room.sidebar.calls_unavailable' };
-export { msg_room_sidebar_deleted_user as 'room.sidebar.deleted_user' };
 export { msg_room_sidebar_view_profile as 'room.sidebar.view_profile' };
 export { msg_room_sidebar_in_voice_call as 'room.sidebar.in_voice_call' };
 export { msg_room_sidebar_in_video_call as 'room.sidebar.in_video_call' };
@@ -2162,7 +2161,6 @@ export { msg_preview_youtube_dismiss as 'preview.youtube_dismiss' };
 export { msg_preview_youtube_delete as 'preview.youtube_delete' };
 export { msg_preview_youtube_open as 'preview.youtube_open' };
 export { msg_preview_youtube_delete_embed as 'preview.youtube_delete_embed' };
-export { msg_message_preview_deleted_user as 'message_preview.deleted_user' };
 export { msg_message_preview_attachments_count as 'message_preview.attachments_count' };
 export { msg_message_preview_attachment_image as 'message_preview.attachment_image' };
 export { msg_message_preview_attachment_video as 'message_preview.attachment_video' };

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -52,6 +52,7 @@
   import { serverIdToSegment } from '$lib/navigation';
   import { extractURLs } from '$lib/linkPreview';
   import MessagePreviewCard from '$lib/components/MessagePreviewCard.svelte';
+  import DeletedUserLabel from '$lib/components/DeletedUserLabel.svelte';
   import { shouldHighlightCurrentUserMention } from './messageMentionHighlight';
   import { roomReplyTargetEventId } from './messageReplyTarget';
   import { selectedQuoteTextForMessageBody } from './selectedReplyQuote';
@@ -96,16 +97,19 @@
       .filter((role) => role.pingable && role.name !== 'everyone')
       .map((role) => role.name)
   );
-  // Actor may be null if the user has been deleted.
+  // Deleted actors may be absent or retained as a deleted reference.
   // Guard with event?. for Svelte 5 reactivity glitch during virtualizer data transitions.
   const actor = $derived(event?.actor ? useRenderData(UserAvatarViewData, event.actor) : null);
+  const deletedActor = $derived(!actor || actor.deleted);
 
   // Display name with live updates from profile cache
   const displayName = $derived(
-    actor ? getLiveDisplayName(actor.id, actor.displayName || actor.login) : 'Deleted User'
+    !deletedActor && actor
+      ? getLiveDisplayName(actor.id, actor.displayName || actor.login)
+      : m['common.deleted_user']()
   );
   const actorCallPresence = $derived(
-    actor ? activeCallRooms.getParticipantCallPresence(roomId, actor.id) : null
+    !deletedActor && actor ? activeCallRooms.getParticipantCallPresence(roomId, actor.id) : null
   );
 
   // Permission checks for message actions. Authors can always edit (within
@@ -409,16 +413,19 @@
     const replyToId = messageEvent?.inReplyTo;
     if (!replyToId) return null;
 
-    if (!replyTarget) return { name: 'a message', body: null as string | null, actor: null };
+    if (!replyTarget) {
+      return { name: 'a message', body: null as string | null, actor: null, deleted: false };
+    }
 
     const repliedActor = replyTarget.actor
       ? useRenderData(UserAvatarViewData, replyTarget.actor)
       : null;
-    const name = repliedActor
-      ? getLiveDisplayName(repliedActor.id, repliedActor.displayName || repliedActor.login)
-      : 'Deleted User';
+    const activeRepliedActor = repliedActor && !repliedActor.deleted ? repliedActor : null;
+    const name = activeRepliedActor
+      ? getLiveDisplayName(activeRepliedActor.id, activeRepliedActor.displayName || activeRepliedActor.login)
+      : m['common.deleted_user']();
     const body = isMessagePostedEvent(replyTarget.event) ? (replyTarget.event.body ?? null) : null;
-    return { name, body, actor: repliedActor };
+    return { name, body, actor: activeRepliedActor, deleted: !activeRepliedActor };
   });
 
   // Check if this thread has pending reply notifications
@@ -694,7 +701,7 @@
         <!-- Spacer maintains left column width; avatar is absolutely positioned
 					 so it doesn't inflate row height for short (single-line) messages -->
         <div class="w-11 shrink-0"></div>
-        {#if actor}
+        {#if !deletedActor && actor}
           <button
             type="button"
             class={['absolute left-2 z-10 cursor-pointer', replyPreview ? 'top-8' : 'top-1']}
@@ -726,7 +733,7 @@
         {#if replyPreview}
           {@const replyJumpText =
             replyPreview.body ??
-            (replyPreview.actor
+            (replyPreview.actor || replyPreview.deleted
               ? m['room.message.meta.reply_preview_fallback']()
               : replyPreview.name)}
           {@const replyJumpLabel = `${m['room.message.meta.in_reply_to']()} ${replyJumpText}`}
@@ -772,8 +779,8 @@
                 <strong class="truncate font-medium">{replyPreview.name}</strong>
                 {@render callPresenceIcon(replyCallPresence)}
               </button>
-            {:else if replyPreview.body}
-              <strong class="max-w-[45%] shrink-0 truncate font-medium">{replyPreview.name}</strong>
+            {:else if replyPreview.deleted}
+              <strong class="max-w-[45%] shrink-0 truncate font-medium"><DeletedUserLabel /></strong>
             {/if}
             <button
               type="button"
@@ -789,7 +796,7 @@
         <!-- Author and timestamp -->
         {#if !compact}
           <div class="flex min-w-0 items-center gap-2">
-            {#if actor}
+            {#if !deletedActor && actor}
               <button
                 type="button"
                 class="inline-flex shrink-0 cursor-pointer items-center gap-1.5 leading-none font-semibold hover:underline"
@@ -805,7 +812,7 @@
                 {@render callPresenceIcon(actorCallPresence)}
               </button>
             {:else}
-              <strong class="shrink-0 leading-none font-semibold text-muted">{displayName}</strong>
+              <strong class="shrink-0 leading-none font-semibold text-muted"><DeletedUserLabel /></strong>
             {/if}
             <a
               href={resolve('/chat/[serverId]/[roomId]/m/[messageId]', {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
@@ -15,6 +15,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
   import * as m from '$lib/i18n/messages';
   import { startDMWith } from '$lib/dm/startDM';
   import UserAvatar from '$lib/components/UserAvatar.svelte';
+  import DeletedUserLabel from '$lib/components/DeletedUserLabel.svelte';
   import UserCustomStatusBadge from '$lib/components/UserCustomStatusBadge.svelte';
   import UserContextMenu from '$lib/components/menus/UserContextMenu.svelte';
   import type { PresenceStatus } from '$lib/render/types';
@@ -459,13 +460,19 @@ calls, and similar room-specific panels can plug into the same shell. See the
       if (!member.deleted) togglePopover(member.id, e);
     }}
     title={member.deleted
-      ? m['room.sidebar.deleted_user']()
+      ? m['common.deleted_user']()
       : m['room.sidebar.view_profile']({ name: getLiveDisplayName(member.id, member.displayName) })}
   >
     <UserAvatar user={member} size="sm" showPresence />
     <div class="min-w-0 flex-1">
       <div class="flex min-w-0 items-center gap-1.5">
-        <span class="min-w-0 truncate">{getLiveDisplayName(member.id, member.displayName)}</span>
+        <span class="min-w-0 truncate">
+          {#if member.deleted}
+            <DeletedUserLabel />
+          {:else}
+            {getLiveDisplayName(member.id, member.displayName)}
+          {/if}
+        </span>
         <UserCustomStatusBadge
           status={getLiveCustomStatus(member.id, member.customStatus)}
           class="shrink-0 text-xs"

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -443,6 +443,19 @@ describe('RoomSidebar', () => {
     expect(container.querySelector('[data-testid="room-members-load-more-sentinel"]')).toBeFalsy();
   });
 
+  it('renders deleted members with an italicized placeholder', async () => {
+    mockRoomMembers([{ ...member(1), deleted: true }]);
+
+    const { container } = render(RoomSidebarTestHarness, {
+      props: { roomData: roomData([], 0, false) }
+    });
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('[deleted user]');
+    });
+    expect(container.querySelector('em')?.textContent).toBe('[deleted user]');
+  });
+
   it('shows call presence for members active in any room call on the server', async () => {
     mockRoomMembers([member(1), member(2)]);
     callStore.activeCallRooms.getParticipantCallPresenceInAnyRoom.mockImplementation(

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEvent.svelte
@@ -4,6 +4,7 @@
   import { useRenderData } from '$lib/render/data';
   import { RoomEventKind, roomEventKind } from '$lib/render/eventKinds';
   import { getLiveDisplayName } from '$lib/state/userProfiles.svelte';
+  import DeletedUserLabel from '$lib/components/DeletedUserLabel.svelte';
 
   let { event }: { event: RoomEventView } = $props();
 
@@ -19,7 +20,7 @@
 
   const subject = $derived.by<Subject>(() => {
     const actor = event?.actor ? useRenderData(UserAvatarViewData, event.actor) : null;
-    if (actor) {
+    if (actor && !actor.deleted) {
       return { id: actor.id, name: displayName(actor), user: actor };
     }
 
@@ -42,13 +43,9 @@
     }
   });
 
-  const message = $derived.by(() => {
-    if (!action) return null;
-    return `${subject.name} ${action}`;
-  });
 </script>
 
-{#if message}
+{#if action}
   <div class="mt-4 flex items-center gap-4 px-2 md:px-4" data-event-id={event.id}>
     <!-- Avatar column (w-11 matches MessageEvent avatar width) -->
     <div class="flex w-11 shrink-0 items-center justify-center">
@@ -64,6 +61,13 @@
       {/if}
     </div>
 
-    <span class="text-sm text-muted">{message}</span>
+    <span class="text-sm text-muted">
+      {#if subject.user}
+        {subject.name}
+      {:else}
+        <DeletedUserLabel />
+      {/if}
+      {action}
+    </span>
   </div>
 {/if}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEvent.svelte
@@ -5,6 +5,7 @@
   import { RoomEventKind, roomEventKind } from '$lib/render/eventKinds';
   import { getLiveDisplayName } from '$lib/state/userProfiles.svelte';
   import DeletedUserLabel from '$lib/components/DeletedUserLabel.svelte';
+  import * as m from '$lib/i18n/messages';
 
   let { event }: { event: RoomEventView } = $props();
 
@@ -31,13 +32,13 @@
     if (!event?.event) return null;
     switch (roomEventKind(event.event)) {
       case RoomEventKind.UserJoinedRoom:
-        return 'joined the room';
+        return m['room.system_events.joined']({ count: 1 });
       case RoomEventKind.UserLeftRoom:
-        return 'left the room';
+        return m['room.system_events.left']({ count: 1 });
       case RoomEventKind.RoomArchived:
-        return 'archived the room';
+        return m['room.system_events.archived']();
       case RoomEventKind.RoomUnarchived:
-        return 'unarchived the room';
+        return m['room.system_events.unarchived']();
       default:
         return null;
     }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEvent.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEvent.svelte.spec.ts
@@ -54,4 +54,14 @@ describe('SystemEvent', () => {
 
     expect(container.textContent).toContain('Alice left the room');
   });
+
+  it('renders a deleted actor as an italicized placeholder', () => {
+    const event = systemEvent(RoomEventKind.UserJoinedRoom);
+    event.actor = null;
+
+    const { container } = render(SystemEvent, { props: { event } });
+
+    expect(container.textContent).toContain('[deleted user] joined the room');
+    expect(container.querySelector('em')?.textContent).toBe('[deleted user]');
+  });
 });

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEvent.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEvent.svelte.spec.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import type { RoomEventView } from '$lib/render/types';
 import { RoomEventKind } from '$lib/render/eventKinds';
+import { loadLocaleMessages } from '$lib/i18n/messages';
+import { setReactiveLocale } from '$lib/i18n/state.svelte';
 import SystemEvent from './SystemEvent.svelte';
 
 vi.mock('$lib/state/userProfiles.svelte', () => ({
@@ -39,6 +41,11 @@ function systemEvent(
 }
 
 describe('SystemEvent', () => {
+  beforeEach(async () => {
+    await loadLocaleMessages('en');
+    setReactiveLocale('en');
+  });
+
   it('renders member join copy with the actor name', () => {
     const { container } = render(SystemEvent, {
       props: { event: systemEvent(RoomEventKind.UserJoinedRoom, 'Alice') }
@@ -63,5 +70,16 @@ describe('SystemEvent', () => {
 
     expect(container.textContent).toContain('[deleted user] joined the room');
     expect(container.querySelector('em')?.textContent).toBe('[deleted user]');
+  });
+
+  it('localizes event copy and deleted-user labels in German', async () => {
+    await loadLocaleMessages('de');
+    setReactiveLocale('de');
+    const event = systemEvent(RoomEventKind.UserJoinedRoom);
+    event.actor = null;
+
+    const { container } = render(SystemEvent, { props: { event } });
+
+    expect(container.textContent).toContain('[gelöschter Benutzer] ist dem Raum beigetreten');
   });
 });

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEventGroup.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEventGroup.svelte
@@ -5,6 +5,7 @@
   import { useRenderData } from '$lib/render/data';
   import { getLiveDisplayName } from '$lib/state/userProfiles.svelte';
   import DeletedUserLabel from '$lib/components/DeletedUserLabel.svelte';
+  import * as m from '$lib/i18n/messages';
 
   let {
     events,
@@ -14,12 +15,12 @@
     kind: SystemGroupKind;
   } = $props();
 
-  const action = $derived.by(() => {
+  const actionKind = $derived.by(() => {
     switch (kind) {
       case 'join':
-        return 'joined the room';
+        return 'joined';
       case 'leave':
-        return 'left the room';
+        return 'left';
     }
   });
 
@@ -60,14 +61,13 @@
 
   let expanded = $state(false);
 
-  function nameSeparator(index: number, total: number): string {
-    if (index === 0) return '';
-    if (index === total - 1) return total === 2 ? ' and ' : ', and ';
-    return ', ';
-  }
-
   const headActors = $derived(actors.slice(0, NAMES_BEFORE_TRUNCATION));
   const extraCount = $derived(Math.max(actors.length - NAMES_BEFORE_TRUNCATION, 0));
+  const action = $derived(
+    actionKind === 'joined'
+      ? m['room.system_events.joined']({ count: actors.length })
+      : m['room.system_events.left']({ count: actors.length })
+  );
 </script>
 
 {#snippet actorName(actor: Actor)}
@@ -80,7 +80,14 @@
 
 {#snippet actorNames(items: Actor[])}
   {#each items as actor, index (actor.id)}
-    {nameSeparator(index, items.length)}{@render actorName(actor)}
+    {#if index > 0}
+      {#if index === items.length - 1}
+        {items.length > 2 ? ', ' : ''}{m['room.system_events.and']()}
+      {:else}
+        ,
+      {/if}
+    {/if}
+    {@render actorName(actor)}
   {/each}
 {/snippet}
 
@@ -112,15 +119,15 @@
             class="ml-1 cursor-pointer underline decoration-dotted underline-offset-2 hover:text-text"
             onclick={() => (expanded = false)}
           >
-            show less
+            {m['room.system_events.show_less']()}
           </button>
         {/if}
       {:else}
-        {@render actorNames(headActors)}, and <button
+        {@render actorNames(headActors)}, {m['room.system_events.and']()} <button
           type="button"
           class="cursor-pointer underline decoration-dotted underline-offset-2 hover:text-text"
           onclick={() => (expanded = true)}
-        >{extraCount} {extraCount === 1 ? 'other' : 'others'}</button>
+        >{extraCount} {m['room.system_events.other_people']({ count: extraCount })}</button>
         {action}
       {/if}
     </span>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEventGroup.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEventGroup.svelte
@@ -4,6 +4,7 @@
   import UserAvatar, { UserAvatarViewData } from '$lib/components/UserAvatar.svelte';
   import { useRenderData } from '$lib/render/data';
   import { getLiveDisplayName } from '$lib/state/userProfiles.svelte';
+  import DeletedUserLabel from '$lib/components/DeletedUserLabel.svelte';
 
   let {
     events,
@@ -34,7 +35,7 @@
 
   function eventSubject(event: RoomEventView): Actor {
     const actor = event?.actor ? useRenderData(UserAvatarViewData, event.actor) : null;
-    if (actor) {
+    if (actor && !actor.deleted) {
       return { id: actor.id, name: displayName(actor), user: actor };
     }
 
@@ -59,17 +60,29 @@
 
   let expanded = $state(false);
 
-  function joinNames(names: string[]): string {
-    if (names.length === 0) return '';
-    if (names.length === 1) return names[0];
-    if (names.length === 2) return `${names[0]} and ${names[1]}`;
-    return `${names.slice(0, -1).join(', ')}, and ${names[names.length - 1]}`;
+  function nameSeparator(index: number, total: number): string {
+    if (index === 0) return '';
+    if (index === total - 1) return total === 2 ? ' and ' : ', and ';
+    return ', ';
   }
 
-  const allNames = $derived(joinNames(actors.map((a) => a.name)));
-  const headNames = $derived(actors.slice(0, NAMES_BEFORE_TRUNCATION).map((a) => a.name).join(', '));
+  const headActors = $derived(actors.slice(0, NAMES_BEFORE_TRUNCATION));
   const extraCount = $derived(Math.max(actors.length - NAMES_BEFORE_TRUNCATION, 0));
 </script>
+
+{#snippet actorName(actor: Actor)}
+  {#if actor.user}
+    {actor.name}
+  {:else}
+    <DeletedUserLabel />
+  {/if}
+{/snippet}
+
+{#snippet actorNames(items: Actor[])}
+  {#each items as actor, index (actor.id)}
+    {nameSeparator(index, items.length)}{@render actorName(actor)}
+  {/each}
+{/snippet}
 
 {#if actors.length > 0}
   <div class="mt-4 flex items-center gap-4 px-2 md:px-4" data-event-id={events[0].id}>
@@ -92,7 +105,7 @@
 
     <span class="text-sm text-muted">
       {#if !isTruncatable || expanded}
-        {allNames} {action}
+        {@render actorNames(actors)} {action}
         {#if isTruncatable}
           <button
             type="button"
@@ -103,7 +116,7 @@
           </button>
         {/if}
       {:else}
-        {headNames}, and <button
+        {@render actorNames(headActors)}, and <button
           type="button"
           class="cursor-pointer underline decoration-dotted underline-offset-2 hover:text-text"
           onclick={() => (expanded = true)}


### PR DESCRIPTION
## Summary

- Render deleted accounts as italicized, localized bracketed labels across messages, replies, system events, room members, and message previews.
- Treat both missing actors and retained `deleted: true` references as deleted users while leaving backend and public API placeholders unchanged.
- Consolidate the frontend copy into a shared Paraglide key and reusable label component.
- Localize room system-event copy and use Paraglide plural variants for singular and grouped German phrasing.

## Validation

- `mise x -- pnpm --dir apps/frontend exec vitest run src/routes/chat/'[serverId]'/'[roomId]'/SystemEvent.svelte.spec.ts src/routes/chat/'[serverId]'/'[roomId]'/RoomSidebar.svelte.spec.ts src/lib/components/MessagePreviewCard.svelte.spec.ts`
- `mise x -- pnpm --dir apps/frontend run check`
- `mise x -- pnpm --dir apps/frontend exec playwright test e2e/account-deletion.test.ts --retries=0`
- `mise x -- pnpm --dir apps/frontend exec vitest run src/routes/chat/'[serverId]'/'[roomId]'/SystemEvent.svelte.spec.ts`

`mise test-frontend` was attempted twice but Vitest/Vite reloaded suites during dependency optimization (`route.fulfill: Route is already handled`), so the full run did not complete.
