### PR TITLE
docs(livekit): document LAN-only configuration

### DIFF
--- a/apps/docs-website/src/content/docs/guides/deployment/docker-compose.mdx
+++ b/apps/docs-website/src/content/docs/guides/deployment/docker-compose.mdx
@@ -314,7 +314,7 @@ See [Voice & Video Calls](/guides/infrastructure/voice-calls/#turn-for-restricti
 
 **Container startup order** — `depends_on` with `condition: service_healthy` ensures NATS and LiveKit are ready before Chatto starts. If health checks fail, check the individual service logs.
 
-**Calls don't connect** — Verify the LiveKit API key/secret in `.env` matches the selected LiveKit config (`livekit.generated.yaml` or `livekit.yaml`). Ensure `CHATTO_LIVEKIT_URL` uses the public `wss://livekit.*` subdomain (browsers connect to it directly). Check that TCP 7881 and UDP 3478 and 50000-50200 are open in your firewall.
+**Calls don't connect** — Verify the LiveKit API key/secret in `.env` matches the selected LiveKit config (`livekit.generated.yaml` or `livekit.yaml`). Ensure `CHATTO_LIVEKIT_URL` uses the public `wss://livekit.*` subdomain (browsers connect to it directly). Check that TCP 7881 and UDP 3478 and 50000-50200 are open in your firewall. For a LAN-only host without an external IP address, set `rtc.use_external_ip: false` in `livekit.generated.yaml` before starting or restarting LiveKit.
 
 **Calls fail for some users** — Confirm the built-in TURN/UDP relay is reachable on UDP 3478. Users behind firewalls that block UDP entirely need TURN/TLS. See [TURN server for restrictive networks](#turn-server-for-restrictive-networks).
 

--- a/apps/docs-website/src/content/docs/guides/infrastructure/voice-calls.mdx
+++ b/apps/docs-website/src/content/docs/guides/infrastructure/voice-calls.mdx
@@ -130,6 +130,19 @@ The port range must match `rtc.port_range_start` and `rtc.port_range_end` in
 your LiveKit configuration. Do not route the TCP or UDP media ports through a
 normal HTTP reverse proxy.
 
+For a LAN-only deployment whose host has no external IP address, disable
+external IP discovery in the LiveKit configuration:
+
+```yaml
+rtc:
+  use_external_ip: false
+```
+
+The generated Docker Compose configuration enables this setting by default for
+internet-facing deployments. If you use that example on a private LAN, change
+`use_external_ip` to `false` in `livekit.generated.yaml` before starting or
+restarting LiveKit.
+
 <Aside type="tip">
   The [Docker Compose guide](/guides/deployment/docker-compose/) provides a
   complete working LiveKit configuration, firewall list, automatic HTTPS, and


### PR DESCRIPTION
## Summary

Document that LAN-only LiveKit hosts without an external IP must set `rtc.use_external_ip: false`. Add the guidance to both the voice and video calls guide and the Docker Compose troubleshooting section so operators can find it alongside the generated `livekit.generated.yaml` configuration. This prevents the internet-facing default from blocking LiveKit startup on private LAN deployments.

## Verification

- `git diff --check`
- `mise x -- pnpm --dir apps/docs-website build`
