### PR TITLE
fix(api): bound message attachment asset IDs

### DIFF
--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/messages.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/messages.mdx
@@ -78,7 +78,7 @@ Request to create a message in a room or thread.
 | --- | --- | --- |
 | `room_id` | `string` | Required. Room where the message should be created. |
 | `body` | `string` | Message body text. Required unless attachment_asset_ids is non-empty. |
-| `attachment_asset_ids` | `repeated string` | Existing room-scoped attachment asset IDs to include with the message. At most 100 IDs may be supplied. |
+| `attachment_asset_ids` | `repeated string` | Existing room-scoped attachment asset IDs to include with the message. At most 10 IDs may be supplied. |
 | `thread_root_event_id` | `string` | Event ID of the thread root message when posting a thread reply. |
 | `in_reply_to` | `string` | Event ID this message replies to for attribution. |
 | `also_send_to_channel` | `bool` | True to also echo a thread reply into the main room timeline. |

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/messages.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/messages.mdx
@@ -78,7 +78,7 @@ Request to create a message in a room or thread.
 | --- | --- | --- |
 | `room_id` | `string` | Required. Room where the message should be created. |
 | `body` | `string` | Message body text. Required unless attachment_asset_ids is non-empty. |
-| `attachment_asset_ids` | `repeated string` | Existing room-scoped attachment asset IDs to include with the message. |
+| `attachment_asset_ids` | `repeated string` | Existing room-scoped attachment asset IDs to include with the message. At most 100 IDs may be supplied. |
 | `thread_root_event_id` | `string` | Event ID of the thread root message when posting a thread reply. |
 | `in_reply_to` | `string` | Event ID this message replies to for attribution. |
 | `also_send_to_channel` | `bool` | True to also echo a thread reply into the main room timeline. |

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -1042,7 +1042,7 @@ Request to create a message in a room or thread.
 | --- | --- | --- |
 | `room_id` | `string` | Required. Room where the message should be created. |
 | `body` | `string` | Message body text. Required unless attachment_asset_ids is non-empty. |
-| `attachment_asset_ids` | `repeated string` | Existing room-scoped attachment asset IDs to include with the message. |
+| `attachment_asset_ids` | `repeated string` | Existing room-scoped attachment asset IDs to include with the message. At most 100 IDs may be supplied. |
 | `thread_root_event_id` | `string` | Event ID of the thread root message when posting a thread reply. |
 | `in_reply_to` | `string` | Event ID this message replies to for attribution. |
 | `also_send_to_channel` | `bool` | True to also echo a thread reply into the main room timeline. |

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -1042,7 +1042,7 @@ Request to create a message in a room or thread.
 | --- | --- | --- |
 | `room_id` | `string` | Required. Room where the message should be created. |
 | `body` | `string` | Message body text. Required unless attachment_asset_ids is non-empty. |
-| `attachment_asset_ids` | `repeated string` | Existing room-scoped attachment asset IDs to include with the message. At most 100 IDs may be supplied. |
+| `attachment_asset_ids` | `repeated string` | Existing room-scoped attachment asset IDs to include with the message. At most 10 IDs may be supplied. |
 | `thread_root_event_id` | `string` | Event ID of the thread root message when posting a thread reply. |
 | `in_reply_to` | `string` | Event ID this message replies to for attribution. |
 | `also_send_to_channel` | `bool` | True to also echo a thread reply into the main room timeline. |

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -228,6 +228,45 @@ func TestPrivateHandlersRequireAuth(t *testing.T) {
 	requireConnectCode(t, err, connect.CodeUnauthenticated)
 }
 
+func TestCreateMessageAttachmentAssetIDsValidateThroughConnectHandler(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	mux := http.NewServeMux()
+	path, handler := apiv1connect.NewMessageServiceHandler(env.messages, HandlerOptions()...)
+	mux.Handle(path, handler)
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	client := apiv1connect.NewMessageServiceClient(ts.Client(), ts.URL)
+	maxIDs := make([]string, core.MaxMessageAttachmentAssetIDs)
+	for i := range maxIDs {
+		maxIDs[i] = strings.Repeat("A", core.MaxMessageAttachmentAssetIDLength)
+	}
+
+	tests := []struct {
+		name     string
+		assetIDs []string
+		wantCode connect.Code
+	}{
+		{name: "at limits reaches authentication", assetIDs: maxIDs, wantCode: connect.CodeUnauthenticated},
+		{name: "too many", assetIDs: append(append([]string(nil), maxIDs...), "A"), wantCode: connect.CodeInvalidArgument},
+		{name: "empty", assetIDs: []string{""}, wantCode: connect.CodeInvalidArgument},
+		{name: "too long", assetIDs: []string{strings.Repeat("A", core.MaxMessageAttachmentAssetIDLength+1)}, wantCode: connect.CodeInvalidArgument},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := client.CreateMessage(context.Background(), connect.NewRequest(&apiv1.CreateMessageRequest{
+				RoomId:             "room",
+				Body:               "hello",
+				AttachmentAssetIds: tt.assetIDs,
+			}))
+			if connect.CodeOf(err) != tt.wantCode {
+				t.Fatalf("CreateMessage() code = %v, want %v", connect.CodeOf(err), tt.wantCode)
+			}
+		})
+	}
+}
+
 func TestBatchGetResourceRequestsValidateThroughConnectHandlers(t *testing.T) {
 	env := newConnectAPITestEnv(t)
 	mux := http.NewServeMux()

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -251,6 +251,7 @@ func TestCreateMessageAttachmentAssetIDsValidateThroughConnectHandler(t *testing
 		{name: "too many", assetIDs: append(append([]string(nil), maxIDs...), "A"), wantCode: connect.CodeInvalidArgument},
 		{name: "empty", assetIDs: []string{""}, wantCode: connect.CodeInvalidArgument},
 		{name: "too long", assetIDs: []string{strings.Repeat("A", core.MaxMessageAttachmentAssetIDLength+1)}, wantCode: connect.CodeInvalidArgument},
+		{name: "too many multibyte bytes", assetIDs: []string{strings.Repeat("é", core.MaxMessageAttachmentAssetIDLength/2+1)}, wantCode: connect.CodeInvalidArgument},
 	}
 
 	for _, tt := range tests {

--- a/cli/internal/core/errors.go
+++ b/cli/internal/core/errors.go
@@ -295,4 +295,10 @@ const (
 
 	// MaxLinkPreviewImageAssetIDLength is the maximum length of a client-provided link preview image asset ID in bytes.
 	MaxLinkPreviewImageAssetIDLength = 15
+
+	// MaxMessageAttachmentAssetIDs is the maximum number of attachment asset IDs accepted for one message.
+	MaxMessageAttachmentAssetIDs = 100
+
+	// MaxMessageAttachmentAssetIDLength is the maximum length of a message attachment asset ID in bytes.
+	MaxMessageAttachmentAssetIDLength = 15
 )

--- a/cli/internal/core/errors.go
+++ b/cli/internal/core/errors.go
@@ -297,7 +297,7 @@ const (
 	MaxLinkPreviewImageAssetIDLength = 15
 
 	// MaxMessageAttachmentAssetIDs is the maximum number of attachment asset IDs accepted for one message.
-	MaxMessageAttachmentAssetIDs = 100
+	MaxMessageAttachmentAssetIDs = 10
 
 	// MaxMessageAttachmentAssetIDLength is the maximum length of a message attachment asset ID in bytes.
 	MaxMessageAttachmentAssetIDLength = 15

--- a/cli/internal/core/messages.go
+++ b/cli/internal/core/messages.go
@@ -388,6 +388,10 @@ func (c *ChattoCore) appendMessageWithOptionalThreadCreated(ctx context.Context,
 func (c *ChattoCore) PostMessage(ctx context.Context, kind RoomKind, room_id, user_id, body string, assetIDs []string, inThread, inReplyTo string, linkPreview *corev1.LinkPreview, alsoSendToChannel bool, opts ...PostMessageOption) (*corev1.Event, error) {
 	options := collectPostMessageOptions(opts)
 
+	if err := validateMessageAttachmentAssetIDs(assetIDs); err != nil {
+		return nil, err
+	}
+
 	// Validate message body length to prevent DoS via oversized messages
 	if len(body) > MaxMessageBodyLength {
 		return nil, ErrMessageTooLong
@@ -751,6 +755,21 @@ func (c *ChattoCore) PostMessage(ctx context.Context, kind RoomKind, room_id, us
 	}
 
 	return event, nil
+}
+
+func validateMessageAttachmentAssetIDs(assetIDs []string) error {
+	if len(assetIDs) > MaxMessageAttachmentAssetIDs {
+		return invalidArgument(fmt.Sprintf("message attachment asset IDs exceed maximum count of %d", MaxMessageAttachmentAssetIDs))
+	}
+	for _, assetID := range assetIDs {
+		if assetID == "" {
+			return invalidArgument("message attachment asset ID must not be empty")
+		}
+		if len(assetID) > MaxMessageAttachmentAssetIDLength {
+			return invalidArgument(fmt.Sprintf("message attachment asset ID exceeds maximum length of %d bytes", MaxMessageAttachmentAssetIDLength))
+		}
+	}
+	return nil
 }
 
 // notifyAllMessageSubscribers creates notifications for room members who have the

--- a/cli/internal/core/messages_test.go
+++ b/cli/internal/core/messages_test.go
@@ -519,6 +519,59 @@ func TestChattoCore_PostMessage_BodyTooLong(t *testing.T) {
 	})
 }
 
+func TestValidateMessageAttachmentAssetIDs(t *testing.T) {
+	maxIDs := make([]string, MaxMessageAttachmentAssetIDs)
+	for i := range maxIDs {
+		maxIDs[i] = strings.Repeat("A", MaxMessageAttachmentAssetIDLength)
+	}
+
+	tests := []struct {
+		name     string
+		assetIDs []string
+		wantErr  bool
+	}{
+		{name: "none"},
+		{name: "at limits", assetIDs: maxIDs},
+		{name: "too many", assetIDs: append(append([]string(nil), maxIDs...), "A"), wantErr: true},
+		{name: "empty", assetIDs: []string{""}, wantErr: true},
+		{name: "too long", assetIDs: []string{strings.Repeat("A", MaxMessageAttachmentAssetIDLength+1)}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateMessageAttachmentAssetIDs(tt.assetIDs)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateMessageAttachmentAssetIDs() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && !errors.Is(err, ErrInvalidArgument) {
+				t.Fatalf("validateMessageAttachmentAssetIDs() error = %v, want ErrInvalidArgument", err)
+			}
+		})
+	}
+}
+
+func TestChattoCore_PostMessageRejectsInvalidAttachmentAssetIDs(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	tests := []struct {
+		name     string
+		assetIDs []string
+	}{
+		{name: "too many", assetIDs: make([]string, MaxMessageAttachmentAssetIDs+1)},
+		{name: "too long", assetIDs: []string{strings.Repeat("A", MaxMessageAttachmentAssetIDLength+1)}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := core.PostMessage(ctx, KindChannel, "missing-room", "missing-user", "body", tt.assetIDs, "", "", nil, false)
+			if !errors.Is(err, ErrInvalidArgument) {
+				t.Fatalf("PostMessage() error = %v, want ErrInvalidArgument", err)
+			}
+		})
+	}
+}
+
 func TestChattoCore_EditMessage_BodyTooLong(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)

--- a/cli/internal/core/messages_test.go
+++ b/cli/internal/core/messages_test.go
@@ -535,6 +535,7 @@ func TestValidateMessageAttachmentAssetIDs(t *testing.T) {
 		{name: "too many", assetIDs: append(append([]string(nil), maxIDs...), "A"), wantErr: true},
 		{name: "empty", assetIDs: []string{""}, wantErr: true},
 		{name: "too long", assetIDs: []string{strings.Repeat("A", MaxMessageAttachmentAssetIDLength+1)}, wantErr: true},
+		{name: "too many multibyte bytes", assetIDs: []string{strings.Repeat("é", MaxMessageAttachmentAssetIDLength/2+1)}, wantErr: true},
 	}
 
 	for _, tt := range tests {
@@ -560,6 +561,7 @@ func TestChattoCore_PostMessageRejectsInvalidAttachmentAssetIDs(t *testing.T) {
 	}{
 		{name: "too many", assetIDs: make([]string, MaxMessageAttachmentAssetIDs+1)},
 		{name: "too long", assetIDs: []string{strings.Repeat("A", MaxMessageAttachmentAssetIDLength+1)}},
+		{name: "too many multibyte bytes", assetIDs: []string{strings.Repeat("é", MaxMessageAttachmentAssetIDLength/2+1)}},
 	}
 
 	for _, tt := range tests {

--- a/cli/internal/pb/chatto/api/v1/messages.pb.go
+++ b/cli/internal/pb/chatto/api/v1/messages.pb.go
@@ -30,7 +30,7 @@ type CreateMessageRequest struct {
 	// Message body text. Required unless attachment_asset_ids is non-empty.
 	Body string `protobuf:"bytes,2,opt,name=body,proto3" json:"body,omitempty"`
 	// Existing room-scoped attachment asset IDs to include with the message.
-	// At most 100 IDs may be supplied.
+	// At most 10 IDs may be supplied.
 	AttachmentAssetIds []string `protobuf:"bytes,3,rep,name=attachment_asset_ids,json=attachmentAssetIds,proto3" json:"attachment_asset_ids,omitempty"`
 	// Event ID of the thread root message when posting a thread reply.
 	ThreadRootEventId string `protobuf:"bytes,4,opt,name=thread_root_event_id,json=threadRootEventId,proto3" json:"thread_root_event_id,omitempty"`
@@ -823,7 +823,8 @@ const file_chatto_api_v1_messages_proto_rawDesc = "" +
 	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\x12\x12\n" +
 	"\x04body\x18\x02 \x01(\tR\x04body\x12B\n" +
 	"\x14attachment_asset_ids\x18\x03 \x03(\tB\x10\xbaH\r\x92\x01\n" +
-	"\x10d\"\x06r\x04\x10\x01(\x0fR\x12attachmentAssetIds\x12/\n" +
+	"\x10\n" +
+	"\"\x06r\x04\x10\x01(\x0fR\x12attachmentAssetIds\x12/\n" +
 	"\x14thread_root_event_id\x18\x04 \x01(\tR\x11threadRootEventId\x12\x1e\n" +
 	"\vin_reply_to\x18\x05 \x01(\tR\tinReplyTo\x12/\n" +
 	"\x14also_send_to_channel\x18\x06 \x01(\bR\x11alsoSendToChannel\x12,\n" +

--- a/cli/internal/pb/chatto/api/v1/messages.pb.go
+++ b/cli/internal/pb/chatto/api/v1/messages.pb.go
@@ -823,7 +823,7 @@ const file_chatto_api_v1_messages_proto_rawDesc = "" +
 	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\x12\x12\n" +
 	"\x04body\x18\x02 \x01(\tR\x04body\x12B\n" +
 	"\x14attachment_asset_ids\x18\x03 \x03(\tB\x10\xbaH\r\x92\x01\n" +
-	"\x10d\"\x06r\x04\x10\x01\x18\x0fR\x12attachmentAssetIds\x12/\n" +
+	"\x10d\"\x06r\x04\x10\x01(\x0fR\x12attachmentAssetIds\x12/\n" +
 	"\x14thread_root_event_id\x18\x04 \x01(\tR\x11threadRootEventId\x12\x1e\n" +
 	"\vin_reply_to\x18\x05 \x01(\tR\tinReplyTo\x12/\n" +
 	"\x14also_send_to_channel\x18\x06 \x01(\bR\x11alsoSendToChannel\x12,\n" +

--- a/cli/internal/pb/chatto/api/v1/messages.pb.go
+++ b/cli/internal/pb/chatto/api/v1/messages.pb.go
@@ -30,6 +30,7 @@ type CreateMessageRequest struct {
 	// Message body text. Required unless attachment_asset_ids is non-empty.
 	Body string `protobuf:"bytes,2,opt,name=body,proto3" json:"body,omitempty"`
 	// Existing room-scoped attachment asset IDs to include with the message.
+	// At most 100 IDs may be supplied.
 	AttachmentAssetIds []string `protobuf:"bytes,3,rep,name=attachment_asset_ids,json=attachmentAssetIds,proto3" json:"attachment_asset_ids,omitempty"`
 	// Event ID of the thread root message when posting a thread reply.
 	ThreadRootEventId string `protobuf:"bytes,4,opt,name=thread_root_event_id,json=threadRootEventId,proto3" json:"thread_root_event_id,omitempty"`
@@ -817,11 +818,12 @@ var File_chatto_api_v1_messages_proto protoreflect.FileDescriptor
 
 const file_chatto_api_v1_messages_proto_rawDesc = "" +
 	"\n" +
-	"\x1cchatto/api/v1/messages.proto\x12\rchatto.api.v1\x1a\x1bbuf/validate/validate.proto\x1a!chatto/api/v1/link_previews.proto\x1a!chatto/api/v1/message_types.proto\x1a\x1dchatto/api/v1/reactions.proto\"\xf7\x02\n" +
+	"\x1cchatto/api/v1/messages.proto\x12\rchatto.api.v1\x1a\x1bbuf/validate/validate.proto\x1a!chatto/api/v1/link_previews.proto\x1a!chatto/api/v1/message_types.proto\x1a\x1dchatto/api/v1/reactions.proto\"\x89\x03\n" +
 	"\x14CreateMessageRequest\x12 \n" +
 	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\x12\x12\n" +
-	"\x04body\x18\x02 \x01(\tR\x04body\x120\n" +
-	"\x14attachment_asset_ids\x18\x03 \x03(\tR\x12attachmentAssetIds\x12/\n" +
+	"\x04body\x18\x02 \x01(\tR\x04body\x12B\n" +
+	"\x14attachment_asset_ids\x18\x03 \x03(\tB\x10\xbaH\r\x92\x01\n" +
+	"\x10d\"\x06r\x04\x10\x01\x18\x0fR\x12attachmentAssetIds\x12/\n" +
 	"\x14thread_root_event_id\x18\x04 \x01(\tR\x11threadRootEventId\x12\x1e\n" +
 	"\vin_reply_to\x18\x05 \x01(\tR\tinReplyTo\x12/\n" +
 	"\x14also_send_to_channel\x18\x06 \x01(\bR\x11alsoSendToChannel\x12,\n" +

--- a/packages/api-types/src/chatto/api/v1/messages_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/messages_pb.ts
@@ -29,7 +29,7 @@ export class CreateMessageRequest extends Message<CreateMessageRequest> {
 
   /**
    * Existing room-scoped attachment asset IDs to include with the message.
-   * At most 100 IDs may be supplied.
+   * At most 10 IDs may be supplied.
    *
    * @generated from field: repeated string attachment_asset_ids = 3;
    */

--- a/packages/api-types/src/chatto/api/v1/messages_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/messages_pb.ts
@@ -29,6 +29,7 @@ export class CreateMessageRequest extends Message<CreateMessageRequest> {
 
   /**
    * Existing room-scoped attachment asset IDs to include with the message.
+   * At most 100 IDs may be supplied.
    *
    * @generated from field: repeated string attachment_asset_ids = 3;
    */

--- a/proto/chatto/api/v1/messages.proto
+++ b/proto/chatto/api/v1/messages.proto
@@ -34,7 +34,7 @@ message CreateMessageRequest {
     items: {
       string: {
         min_len: 1
-        max_len: 15
+        max_bytes: 15
       }
     }
   }];

--- a/proto/chatto/api/v1/messages.proto
+++ b/proto/chatto/api/v1/messages.proto
@@ -28,9 +28,9 @@ message CreateMessageRequest {
   // Message body text. Required unless attachment_asset_ids is non-empty.
   string body = 2;
   // Existing room-scoped attachment asset IDs to include with the message.
-  // At most 100 IDs may be supplied.
+  // At most 10 IDs may be supplied.
   repeated string attachment_asset_ids = 3 [(buf.validate.field).repeated = {
-    max_items: 100
+    max_items: 10
     items: {
       string: {
         min_len: 1

--- a/proto/chatto/api/v1/messages.proto
+++ b/proto/chatto/api/v1/messages.proto
@@ -28,7 +28,16 @@ message CreateMessageRequest {
   // Message body text. Required unless attachment_asset_ids is non-empty.
   string body = 2;
   // Existing room-scoped attachment asset IDs to include with the message.
-  repeated string attachment_asset_ids = 3;
+  // At most 100 IDs may be supplied.
+  repeated string attachment_asset_ids = 3 [(buf.validate.field).repeated = {
+    max_items: 100
+    items: {
+      string: {
+        min_len: 1
+        max_len: 15
+      }
+    }
+  }];
   // Event ID of the thread root message when posting a thread reply.
   string thread_root_event_id = 4;
   // Event ID this message replies to for attribution.


### PR DESCRIPTION
## Summary

Bound `CreateMessageRequest.attachment_asset_ids` to 10 non-empty IDs of at most 15 bytes, with the same invariant enforced inside core before asset lookups. This closes the low-severity unbounded attachment-ID processing item from the security review while preserving the protobuf wire shape and stored event format. Generated Go, TypeScript, and public ConnectRPC reference outputs are included, alongside transport/core boundary and multibyte regression tests.

## Verification

- `mise test-cli`
- `mise codegen-proto`
- Targeted core and Connect handler boundary tests
- Adversarial review, including a clean follow-up pass

Closes #1457.
