### PR TITLE
feat(release): publish sortable main image tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,6 +306,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Derive immutable main image tag
+        id: main-image
+        shell: bash
+        run: echo "tag=main-$(date -u +%Y%m%dT%H%M%SZ)-${GITHUB_SHA:0:12}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push amd64 image
         uses: docker/build-push-action@v6
         with:
@@ -343,6 +348,7 @@ jobs:
         run: |
           docker buildx imagetools create \
             --tag "ghcr.io/chattocorp/chatto:${GITHUB_SHA}" \
+            --tag "ghcr.io/chattocorp/chatto:${{ steps.main-image.outputs.tag }}" \
             "ghcr.io/chattocorp/chatto:${GITHUB_SHA}-amd64" \
             "ghcr.io/chattocorp/chatto:${GITHUB_SHA}-arm64"
 
@@ -350,6 +356,7 @@ jobs:
             echo "### Main commit image"
             echo
             echo "\`ghcr.io/chattocorp/chatto:${GITHUB_SHA}\`"
+            echo "\`ghcr.io/chattocorp/chatto:${{ steps.main-image.outputs.tag }}\`"
             echo
             echo "Version: \`${{ needs.build-main-image-contexts.outputs.image-version }}\`"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- publish a sortable immutable `main-*` tag for every successful `main` image build
- keep the existing full commit SHA tag for direct pinning
- include both tags in the Actions job summary

## Why

Flux needs a changing, sortable, immutable image tag to advance the `dev` release stream while preserving rollout triggers, provenance, and simple Git rollback.

## Validation

- `mise x -- actionlint .github/workflows/ci.yml`
- verified the tag pattern and chronological lexical ordering
- `git diff --check`

BEGIN_COMMIT_OVERRIDE
fix(release): publish sortable main image tags
END_COMMIT_OVERRIDE
