### PR TITLE
fix(tls): secure autocert cache permissions

### DIFF
--- a/apps/docs-website/src/content/docs/guides/operations/security.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/security.mdx
@@ -112,6 +112,7 @@ Chatto encrypts message text and selected durable user-PII fields before writing
 Chatto has **built-in Let's Encrypt** support via Go's `autocert` package — no Caddy or external reverse proxy required for HTTPS. When `webserver.tls.enabled = true`:
 
 - Certificates are obtained and renewed automatically for the configured domain.
+- The autocert cache directory is restricted to the Chatto process owner (`0700`) at startup, including when the directory already exists.
 - `MinVersion: TLS 1.2` is enforced.
 - Plain HTTP requests are 301-redirected to HTTPS (except ACME challenges).
 

--- a/apps/docs-website/src/content/docs/guides/operations/security.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/security.mdx
@@ -112,7 +112,7 @@ Chatto encrypts message text and selected durable user-PII fields before writing
 Chatto has **built-in Let's Encrypt** support via Go's `autocert` package — no Caddy or external reverse proxy required for HTTPS. When `webserver.tls.enabled = true`:
 
 - Certificates are obtained and renewed automatically for the configured domain.
-- On Unix, the autocert cache directory must be owned by the Chatto process user and is restricted to `0700` at startup, including when the directory already exists. Symlinked cache paths and paths in group- or world-writable parent directories are rejected.
+- On Unix, the autocert cache directory must be owned by the Chatto process user and is restricted to `0700` at startup, including when the directory already exists. The cache directory and its immediate parent cannot be symlinks; the parent must be owned by the process user or root and cannot be group- or world-writable.
 - `MinVersion: TLS 1.2` is enforced.
 - Plain HTTP requests are 301-redirected to HTTPS (except ACME challenges).
 

--- a/apps/docs-website/src/content/docs/guides/operations/security.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/security.mdx
@@ -112,7 +112,7 @@ Chatto encrypts message text and selected durable user-PII fields before writing
 Chatto has **built-in Let's Encrypt** support via Go's `autocert` package — no Caddy or external reverse proxy required for HTTPS. When `webserver.tls.enabled = true`:
 
 - Certificates are obtained and renewed automatically for the configured domain.
-- The autocert cache directory is restricted to the Chatto process owner (`0700`) at startup, including when the directory already exists.
+- On Unix, the autocert cache directory must be owned by the Chatto process user and is restricted to `0700` at startup, including when the directory already exists. Symlinked cache paths and paths in group- or world-writable parent directories are rejected.
 - `MinVersion: TLS 1.2` is enforced.
 - Plain HTTP requests are 301-redirected to HTTPS (except ACME challenges).
 

--- a/cli/internal/http_server/server.go
+++ b/cli/internal/http_server/server.go
@@ -259,10 +259,11 @@ func (s *HTTPServer) Run(ctx context.Context) error {
 	if s.config.Webserver.TLS.Enabled {
 		tlsConfig := s.config.Webserver.TLS
 
-		// Ensure certificate cache directory exists
+		// Ensure certificate cache directory exists and remains private even when
+		// reusing a path created with more permissive permissions.
 		cacheDir := tlsConfig.CacheDirOrDefault()
-		if err := os.MkdirAll(cacheDir, 0700); err != nil {
-			return fmt.Errorf("failed to create certificate cache directory: %w", err)
+		if err := ensureAutocertCacheDir(cacheDir); err != nil {
+			return err
 		}
 
 		// Create autocert manager for Let's Encrypt
@@ -360,6 +361,34 @@ func (s *HTTPServer) Run(ctx context.Context) error {
 		}
 		return nil
 	}
+}
+
+const autocertCacheDirMode os.FileMode = 0o700
+
+func ensureAutocertCacheDir(cacheDir string) error {
+	if err := os.MkdirAll(cacheDir, autocertCacheDirMode); err != nil {
+		return fmt.Errorf("failed to create certificate cache directory: %w", err)
+	}
+
+	info, err := os.Stat(cacheDir)
+	if err != nil {
+		return fmt.Errorf("failed to inspect certificate cache directory: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("certificate cache path %q is not a directory", cacheDir)
+	}
+
+	if err := os.Chmod(cacheDir, autocertCacheDirMode); err != nil {
+		return fmt.Errorf("failed to secure certificate cache directory: %w", err)
+	}
+	info, err = os.Stat(cacheDir)
+	if err != nil {
+		return fmt.Errorf("failed to verify certificate cache directory permissions: %w", err)
+	}
+	if got := info.Mode().Perm(); got != autocertCacheDirMode {
+		return fmt.Errorf("certificate cache directory has mode %04o after securing, want %04o", got, autocertCacheDirMode)
+	}
+	return nil
 }
 
 func metricsServerURL(addr, path string) string {

--- a/cli/internal/http_server/server.go
+++ b/cli/internal/http_server/server.go
@@ -390,6 +390,13 @@ func ensureAutocertCacheDir(cacheDir string) error {
 		if parentInfo.Mode()&os.ModeSymlink != 0 || !parentInfo.IsDir() {
 			return fmt.Errorf("certificate cache parent path %q is not a directory", parent)
 		}
+		parentUID, _, ok := fileOwnerIDs(parentInfo)
+		if !ok {
+			return fmt.Errorf("failed to inspect owner of certificate cache parent directory %q", parent)
+		}
+		if parentUID != uint32(os.Geteuid()) && parentUID != 0 {
+			return fmt.Errorf("certificate cache parent directory %q is owned by uid %d, want uid %d or root", parent, parentUID, os.Geteuid())
+		}
 		if got := parentInfo.Mode().Perm(); got&0o022 != 0 {
 			return fmt.Errorf("certificate cache parent directory %q is writable by group or other users; mode is %04o", parent, got)
 		}

--- a/cli/internal/http_server/server.go
+++ b/cli/internal/http_server/server.go
@@ -370,22 +370,45 @@ func ensureAutocertCacheDir(cacheDir string) error {
 		return fmt.Errorf("failed to create certificate cache directory: %w", err)
 	}
 
-	info, err := os.Stat(cacheDir)
+	info, err := os.Lstat(cacheDir)
 	if err != nil {
 		return fmt.Errorf("failed to inspect certificate cache directory: %w", err)
 	}
-	if !info.IsDir() {
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
 		return fmt.Errorf("certificate cache path %q is not a directory", cacheDir)
+	}
+	uid, _, ownerAvailable := fileOwnerIDs(info)
+	if ownerAvailable && uid != uint32(os.Geteuid()) {
+		return fmt.Errorf("certificate cache directory %q is owned by uid %d, want uid %d", cacheDir, uid, os.Geteuid())
+	}
+	if ownerAvailable {
+		parent := filepath.Dir(filepath.Clean(cacheDir))
+		parentInfo, err := os.Lstat(parent)
+		if err != nil {
+			return fmt.Errorf("failed to inspect certificate cache parent directory: %w", err)
+		}
+		if parentInfo.Mode()&os.ModeSymlink != 0 || !parentInfo.IsDir() {
+			return fmt.Errorf("certificate cache parent path %q is not a directory", parent)
+		}
+		if got := parentInfo.Mode().Perm(); got&0o022 != 0 {
+			return fmt.Errorf("certificate cache parent directory %q is writable by group or other users; mode is %04o", parent, got)
+		}
 	}
 
 	if err := os.Chmod(cacheDir, autocertCacheDirMode); err != nil {
 		return fmt.Errorf("failed to secure certificate cache directory: %w", err)
 	}
-	info, err = os.Stat(cacheDir)
+	info, err = os.Lstat(cacheDir)
 	if err != nil {
 		return fmt.Errorf("failed to verify certificate cache directory permissions: %w", err)
 	}
-	if got := info.Mode().Perm(); got != autocertCacheDirMode {
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("certificate cache path %q changed while securing it", cacheDir)
+	}
+	if verifiedUID, _, ok := fileOwnerIDs(info); ownerAvailable && (!ok || verifiedUID != uint32(os.Geteuid())) {
+		return fmt.Errorf("certificate cache directory ownership changed while securing it")
+	}
+	if got := info.Mode().Perm(); ownerAvailable && got != autocertCacheDirMode {
 		return fmt.Errorf("certificate cache directory has mode %04o after securing, want %04o", got, autocertCacheDirMode)
 	}
 	return nil

--- a/cli/internal/http_server/server_test.go
+++ b/cli/internal/http_server/server_test.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -27,6 +29,59 @@ import (
 	configv1 "hmans.de/chatto/internal/pb/chatto/config/v1"
 	"hmans.de/chatto/internal/testutil"
 )
+
+func TestEnsureAutocertCacheDir(t *testing.T) {
+	t.Run("creates a private directory", func(t *testing.T) {
+		cacheDir := filepath.Join(t.TempDir(), "nested", "autocert")
+		if err := ensureAutocertCacheDir(cacheDir); err != nil {
+			t.Fatalf("ensureAutocertCacheDir() error = %v", err)
+		}
+		assertPathMode(t, cacheDir, autocertCacheDirMode)
+	})
+
+	t.Run("preserves a private directory", func(t *testing.T) {
+		cacheDir := filepath.Join(t.TempDir(), "autocert")
+		if err := os.Mkdir(cacheDir, autocertCacheDirMode); err != nil {
+			t.Fatalf("Mkdir() error = %v", err)
+		}
+		if err := ensureAutocertCacheDir(cacheDir); err != nil {
+			t.Fatalf("ensureAutocertCacheDir() error = %v", err)
+		}
+		assertPathMode(t, cacheDir, autocertCacheDirMode)
+	})
+
+	t.Run("repairs a permissive directory", func(t *testing.T) {
+		cacheDir := filepath.Join(t.TempDir(), "autocert")
+		if err := os.Mkdir(cacheDir, 0o755); err != nil {
+			t.Fatalf("Mkdir() error = %v", err)
+		}
+		if err := ensureAutocertCacheDir(cacheDir); err != nil {
+			t.Fatalf("ensureAutocertCacheDir() error = %v", err)
+		}
+		assertPathMode(t, cacheDir, autocertCacheDirMode)
+	})
+
+	t.Run("rejects a non-directory path", func(t *testing.T) {
+		cacheDir := filepath.Join(t.TempDir(), "autocert")
+		if err := os.WriteFile(cacheDir, []byte("not a directory"), 0o600); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+		if err := ensureAutocertCacheDir(cacheDir); err == nil {
+			t.Fatal("ensureAutocertCacheDir() error = nil, want non-directory error")
+		}
+	})
+}
+
+func assertPathMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(%q) error = %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("mode = %04o, want %04o", got, want)
+	}
+}
 
 // ============================================================================
 // Content Type Detection Tests

--- a/cli/internal/http_server/server_test.go
+++ b/cli/internal/http_server/server_test.go
@@ -115,6 +115,23 @@ func TestEnsureAutocertCacheDir(t *testing.T) {
 			t.Fatalf("ensureAutocertCacheDir() error = %v, want ownership rejection", err)
 		}
 	})
+
+	t.Run("rejects a parent directory owned by another user", func(t *testing.T) {
+		if os.Geteuid() != 0 {
+			t.Skip("changing directory ownership requires root")
+		}
+		parent := t.TempDir()
+		cacheDir := filepath.Join(parent, "autocert")
+		if err := os.Mkdir(cacheDir, autocertCacheDirMode); err != nil {
+			t.Fatalf("Mkdir() error = %v", err)
+		}
+		if err := os.Chown(parent, 1, -1); err != nil {
+			t.Fatalf("Chown() error = %v", err)
+		}
+		if err := ensureAutocertCacheDir(cacheDir); err == nil || !strings.Contains(err.Error(), "parent directory") || !strings.Contains(err.Error(), "is owned by uid") {
+			t.Fatalf("ensureAutocertCacheDir() error = %v, want parent ownership rejection", err)
+		}
+	})
 }
 
 func assertPathMode(t *testing.T, path string, want os.FileMode) {

--- a/cli/internal/http_server/server_test.go
+++ b/cli/internal/http_server/server_test.go
@@ -70,6 +70,51 @@ func TestEnsureAutocertCacheDir(t *testing.T) {
 			t.Fatal("ensureAutocertCacheDir() error = nil, want non-directory error")
 		}
 	})
+
+	t.Run("rejects a symlink", func(t *testing.T) {
+		parent := t.TempDir()
+		target := filepath.Join(parent, "target")
+		if err := os.Mkdir(target, autocertCacheDirMode); err != nil {
+			t.Fatalf("Mkdir() error = %v", err)
+		}
+		cacheDir := filepath.Join(parent, "autocert")
+		if err := os.Symlink(target, cacheDir); err != nil {
+			t.Fatalf("Symlink() error = %v", err)
+		}
+		if err := ensureAutocertCacheDir(cacheDir); err == nil || !strings.Contains(err.Error(), "is not a directory") {
+			t.Fatalf("ensureAutocertCacheDir() error = %v, want symlink rejection", err)
+		}
+	})
+
+	t.Run("rejects a replaceable cache path", func(t *testing.T) {
+		parent := t.TempDir()
+		cacheDir := filepath.Join(parent, "autocert")
+		if err := os.Mkdir(cacheDir, autocertCacheDirMode); err != nil {
+			t.Fatalf("Mkdir() error = %v", err)
+		}
+		if err := os.Chmod(parent, 0o777); err != nil {
+			t.Fatalf("Chmod() error = %v", err)
+		}
+		if err := ensureAutocertCacheDir(cacheDir); err == nil || !strings.Contains(err.Error(), "writable by group or other users") {
+			t.Fatalf("ensureAutocertCacheDir() error = %v, want unsafe-parent rejection", err)
+		}
+	})
+
+	t.Run("rejects a directory owned by another user", func(t *testing.T) {
+		if os.Geteuid() != 0 {
+			t.Skip("changing directory ownership requires root")
+		}
+		cacheDir := filepath.Join(t.TempDir(), "autocert")
+		if err := os.Mkdir(cacheDir, autocertCacheDirMode); err != nil {
+			t.Fatalf("Mkdir() error = %v", err)
+		}
+		if err := os.Chown(cacheDir, 1, -1); err != nil {
+			t.Fatalf("Chown() error = %v", err)
+		}
+		if err := ensureAutocertCacheDir(cacheDir); err == nil || !strings.Contains(err.Error(), "is owned by uid") {
+			t.Fatalf("ensureAutocertCacheDir() error = %v, want ownership rejection", err)
+		}
+	})
 }
 
 func assertPathMode(t *testing.T, path string, want os.FileMode) {


### PR DESCRIPTION
## Summary

Secure the built-in TLS autocert cache at startup by enforcing owner-only permissions, verifying cache ownership, rejecting final symlinks, and rejecting replaceable immediate parent directories. This closes the low-severity autocert permission-hardening item from the security review while leaving certificate formats and TLS configuration unchanged. Filesystem regression tests cover creation, repair, invalid paths, symlinks, unsafe parents, and ownership where the platform permits, and the operator security guide documents the behavior.

## Verification

- `mise test-cli`
- Docs website production build
- Focused autocert filesystem tests
- Adversarial review with a clean final pass

Closes #1459.
