### PR TITLE
fix(frontend): embed main build version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:
-      image-version: ${{ steps.production-image-contexts.outputs.version }}
+      image-version: ${{ steps.image-version.outputs.version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -39,11 +39,8 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup
 
-      - name: Build frontend for production image
-        run: mise build-frontend
-
-      - name: Build production image contexts
-        id: production-image-contexts
+      - name: Derive main image version
+        id: image-version
         shell: bash
         run: |
           set -euo pipefail
@@ -54,8 +51,28 @@ jobs:
             exit 1
           fi
 
-          version="${base_version}+${GITHUB_SHA:0:12}"
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "version=${base_version}+${GITHUB_SHA:0:12}" >> "$GITHUB_OUTPUT"
+
+      - name: Build frontend for production image
+        env:
+          CHATTO_BUILD_VERSION: ${{ steps.image-version.outputs.version }}
+        run: mise build-frontend
+
+      - name: Verify frontend build version
+        env:
+          EXPECTED_VERSION: ${{ steps.image-version.outputs.version }}
+        shell: bash
+        run: |
+          jq -e --arg expected "$EXPECTED_VERSION" \
+            '.version == $expected' \
+            apps/frontend/build/_app/version.json
+
+      - name: Build production image contexts
+        shell: bash
+        env:
+          VERSION: ${{ steps.image-version.outputs.version }}
+        run: |
+          set -euo pipefail
 
           for arch in amd64 arm64; do
             context=".context/ci/docker/linux-${arch}"
@@ -68,7 +85,7 @@ jobs:
             (
               cd cli
               CGO_ENABLED=0 GOOS=linux GOARCH="$arch" go build -trimpath \
-                -ldflags="-s -w -X main.Version=${version}" \
+                -ldflags="-s -w -X main.Version=${VERSION}" \
                 -o "../$context/chatto" .
             )
           done

--- a/apps/frontend/svelte.config.js
+++ b/apps/frontend/svelte.config.js
@@ -5,6 +5,7 @@ import { execSync } from 'node:child_process';
 const precompress = process.env.CHATTO_FRONTEND_PRECOMPRESS === '1';
 
 function buildVersionName() {
+  if (process.env.CHATTO_BUILD_VERSION) return process.env.CHATTO_BUILD_VERSION;
   if (process.env.npm_package_version) return process.env.npm_package_version;
 
   try {
@@ -25,8 +26,9 @@ const config = {
       precompress
     }),
     version: {
-      // Use package version when run through package scripts, or the current
-      // commit hash when launched directly by local dev tooling.
+      // Production image builds inject the same version as the server binary.
+      // Other package-script builds use the package version; direct local
+      // tooling falls back to the current commit hash.
       name: buildVersionName(),
       // Check for new version every 60 seconds
       pollInterval: 60000


### PR DESCRIPTION
## Summary

- allow production frontend builds to override SvelteKit's application version with `CHATTO_BUILD_VERSION`
- derive the main-image version before building either the frontend or Go server
- use the same `x.y.z+<short-sha>` value for both artifacts
- assert the generated SvelteKit `version.json` matches before publishing an image

## Root cause

Main images already compiled the Go server with build metadata, but the frontend was built first and used `apps/frontend/package.json`. The app header therefore displayed `v0.4.7` while public server discovery correctly returned `0.4.7+<short-sha>`.

## User impact

Development images will display their full build identity in the existing header, while stable and prerelease builds retain their normal package versions. SvelteKit update detection remains string-based and does not require monotonically increasing hashes.

## Validation

- real production frontend build with `CHATTO_BUILD_VERSION=0.4.7+verify123456`
- asserted both `apps/frontend/build/_app/version.json` and the copied embedded client contain the sentinel version
- confirmed the compiled client bundle contains the sentinel version
- verified override precedence and package-version fallback
- `mise x -- actionlint .github/workflows/ci.yml`
- `pnpm run check:frontend`
- `pnpm run lint:frontend`
- Svelte autofixer analysis of `AppHeader.svelte`
- `git diff --check`
