### PR TITLE
docs(livekit): document outbound STUN requirements

### DIFF
--- a/apps/docs-website/src/content/docs/guides/deployment/docker-compose.mdx
+++ b/apps/docs-website/src/content/docs/guides/deployment/docker-compose.mdx
@@ -216,6 +216,10 @@ The standard Caddy image does not include the optional Caddy L4 plugin, and this
 single-host setup does not need it. Open the matching host and cloud firewall
 rules, and do not expose NATS port 4222 publicly.
 
+LiveKit also needs DNS and outbound UDP for STUN-based public-IP discovery. See
+[Voice & Video Calls](/guides/infrastructure/voice-calls/#network-paths-and-ports)
+for private STUN and fixed-IP alternatives.
+
 ## Optional Features
 
 ### Direct Registration and SMTP
@@ -292,7 +296,7 @@ fallback when UDP is unavailable, while TURN/UDP helps with symmetric NATs and
 many mobile, Firefox, and restrictive-network failures. This keeps the Compose
 example certificate-free beyond the HTTPS certificates managed by Caddy.
 
-Networks that block UDP entirely still need TURN/TLS. Add that only when you also provide a TURN domain plus certificate/key, or run LiveKit behind L4 TLS forwarding that terminates TLS before LiveKit.
+Networks that block UDP entirely still need TURN/TLS.
 
 <Aside>
   Some networks only allow outbound traffic on TCP 443. If you need TURN on
@@ -315,6 +319,8 @@ See [Voice & Video Calls](/guides/infrastructure/voice-calls/#turn-for-restricti
 **Container startup order** — `depends_on` with `condition: service_healthy` ensures NATS and LiveKit are ready before Chatto starts. If health checks fail, check the individual service logs.
 
 **Calls don't connect** — Verify the LiveKit API key/secret in `.env` matches the selected LiveKit config (`livekit.generated.yaml` or `livekit.yaml`). Ensure `CHATTO_LIVEKIT_URL` uses the public `wss://livekit.*` subdomain (browsers connect to it directly). Check that TCP 7881 and UDP 3478 and 50000-50200 are open in your firewall. For a LAN-only host without an external IP address, set `rtc.use_external_ip: false` in `livekit.generated.yaml` before starting or restarting LiveKit.
+
+**LiveKit reports `could not resolve external IP`** — Allow DNS and outbound UDP from the LiveKit container to every endpoint in `rtc.stun_servers`. If public STUN is not acceptable, configure private STUN servers or set a stable public `rtc.node_ip` with `rtc.use_external_ip: false`.
 
 **Calls fail for some users** — Confirm the built-in TURN/UDP relay is reachable on UDP 3478. Users behind firewalls that block UDP entirely need TURN/TLS. See [TURN server for restrictive networks](#turn-server-for-restrictive-networks).
 

--- a/apps/docs-website/src/content/docs/guides/infrastructure/voice-calls.mdx
+++ b/apps/docs-website/src/content/docs/guides/infrastructure/voice-calls.mdx
@@ -130,6 +130,18 @@ The port range must match `rtc.port_range_start` and `rtc.port_range_end` in
 your LiveKit configuration. Do not route the TCP or UDP media ports through a
 normal HTTP reverse proxy.
 
+When `rtc.use_external_ip` is enabled, the LiveKit server also uses outbound
+UDP STUN requests at startup to discover the public IP it advertises. Allow DNS
+and outbound UDP to LiveKit's default STUN services, or point
+`rtc.stun_servers` at a self-hosted
+[coturn](https://github.com/coturn/coturn) instance or another STUN service you
+operate. If discovery fails, LiveKit logs `could not resolve external IP` and
+cannot start.
+
+These server-side discovery requests are separate from browser ICE. When the
+embedded TURN/UDP service is enabled, LiveKit advertises that service to
+browsers instead of falling back to public STUN servers.
+
 For a LAN-only deployment whose host has no external IP address, disable
 external IP discovery in the LiveKit configuration:
 
@@ -142,6 +154,15 @@ The generated Docker Compose configuration enables this setting by default for
 internet-facing deployments. If you use that example on a private LAN, change
 `use_external_ip` to `false` in `livekit.generated.yaml` before starting or
 restarting LiveKit.
+
+For an internet-facing host with a stable public IP, you can avoid STUN-based
+discovery by configuring the address explicitly:
+
+```yaml
+rtc:
+  use_external_ip: false
+  node_ip: 203.0.113.10
+```
 
 <Aside type="tip">
   The [Docker Compose guide](/guides/deployment/docker-compose/) provides a
@@ -168,7 +189,7 @@ block this TCP fallback need TURN/TLS. If your users can only reach outbound TCP
 443 without conflicting with your HTTPS reverse proxy, and the TURN TLS
 certificate must match the advertised TURN domain.
 
-Use a dedicated TURN server such as [coturn](https://github.com/coturn/coturn) when you need tighter network separation, a shared TURN service for multiple LiveKit deployments, or TURN/TLS on port 443 without moving LiveKit itself. Configure static credentials on the TURN server and list it under LiveKit's `rtc.turn_servers` configuration.
+Use a dedicated TURN server such as [coturn](https://github.com/coturn/coturn) when you need tighter network separation, a shared TURN service for multiple LiveKit deployments, or TURN/TLS on port 443 without moving LiveKit itself. Configure static credentials on the TURN server and list it under LiveKit's `rtc.turn_servers` configuration. The same coturn deployment can provide the private STUN endpoint listed in `rtc.stun_servers`, but these settings serve different paths: `stun_servers` discovers the LiveKit host's public IP, while `turn_servers` gives browsers a media relay.
 
 ## Features
 

--- a/examples/dockercompose/README.md
+++ b/examples/dockercompose/README.md
@@ -32,6 +32,8 @@ matching proxy route when using a different name.
 - A domain pointing to your server (for automatic HTTPS)
 - A `livekit.` subdomain pointing to the same server (e.g., `livekit.chat.example.com`)
 - Firewall allowing inbound TCP 80, 443, and 7881 plus UDP 3478 and 50000-50200
+- DNS resolution and outbound UDP from LiveKit for STUN-based public-IP
+  discovery
 
 ## Why This Example Runs NATS Separately
 
@@ -89,6 +91,21 @@ Preserve these public ports when using Caddy or your own proxy:
 | TCP 7881 | `livekit:7881` | WebRTC media fallback when direct UDP is unavailable |
 | UDP 3478 | `livekit:3478` | LiveKit's embedded TURN/STUN relay |
 | UDP 50000-50200 | Same ports on `livekit` | Direct WebRTC media |
+
+With `rtc.use_external_ip: true`, the LiveKit server sends STUN requests at
+startup to discover the public address it should advertise. Allow DNS and
+outbound UDP from the LiveKit container to LiveKit's default STUN services.
+These are server-side requests; browsers use the embedded TURN/STUN service
+advertised by this deployment.
+
+The example already enables LiveKit's built-in TURN/UDP server for browsers; no
+separate TURN service is required for the common case. If public STUN is not
+acceptable for server-side IP discovery, point `rtc.stun_servers` at a
+self-hosted [coturn](https://github.com/coturn/coturn) instance or another STUN
+service you operate. If the host has a stable public IP, you can instead set
+`rtc.use_external_ip: false` and `rtc.node_ip` to that address, which avoids
+STUN-based discovery. A private LAN deployment can set only
+`rtc.use_external_ip: false` and let LiveKit advertise its local address.
 
 TCP 80 is also published in this example so Caddy can redirect HTTP and solve
 the ACME HTTP challenge. Your replacement proxy may use a different certificate
@@ -257,4 +274,9 @@ If you don't need calls, remove the `livekit` service from `compose.yml`, delete
 
 **LiveKit media ports**: The example exposes UDP 50000-50200 for direct WebRTC media, UDP 3478 for LiveKit's embedded TURN/STUN relay, and TCP 7881 as a media fallback. Ensure your firewall allows all three.
 
-**Calls fail for some users**: The built-in TURN/UDP relay helps with symmetric NATs and some mobile, Firefox, and restrictive-network cases. Networks that block UDP entirely still need an advanced TURN/TLS setup, such as a dedicated TURN host or L4 TLS forwarding with matching certificates.
+**LiveKit fails to start with `could not resolve external IP`**: With
+`rtc.use_external_ip: true`, allow DNS and outbound UDP to every endpoint in
+`rtc.stun_servers`. Alternatively, configure private STUN servers or disable
+external-IP discovery and set `rtc.node_ip` to the host's stable public IP.
+
+**Calls fail for some users**: The built-in TURN/UDP relay helps with symmetric NATs and some mobile, Firefox, and restrictive-network cases. Networks that block UDP entirely still need TURN/TLS. Run coturn on a dedicated host or configure LiveKit's built-in TURN/TLS listener with a matching domain and certificate.


### PR DESCRIPTION
## Why

- Restrictive egress policies can prevent LiveKit from discovering its public IP, but the deployment docs only described inbound media ports.

## What changed

- Document outbound DNS and UDP requirements for LiveKit's default STUN discovery, distinguish server discovery from browser TURN, and cover coturn, fixed-public-IP, and TURN/TLS alternatives without pinning LiveKit's third-party defaults in Chatto configuration.

## Test plan

- `mise x -- pnpm --dir apps/docs-website build` and `git diff --check` pass; `mise license-check` remains unverified because the local REUSE installation lacks an encoding-detection dependency.
