### PR TITLE
fix(ci): use pushed branch as protobuf base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,12 +124,12 @@ jobs:
 
       - name: Fetch protobuf breaking base
         run: |
-          base_ref="${GITHUB_BASE_REF:-main}"
+          base_ref="${GITHUB_BASE_REF:-${GITHUB_REF_NAME}}"
           git fetch --no-tags --depth=1 origin "${base_ref}:refs/remotes/origin/${base_ref}"
 
       - name: Check storage and internal protobuf breaking changes
         run: |
-          base_ref="${GITHUB_BASE_REF:-main}"
+          base_ref="${GITHUB_BASE_REF:-${GITHUB_REF_NAME}}"
           cd proto
           mise x -- buf breaking . --against "../.git#branch=origin/${base_ref},subdir=proto" \
             --exclude-imports \
@@ -142,7 +142,7 @@ jobs:
       - name: Check public API protobuf breaking changes
         if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'api-breaking-change') }}
         run: |
-          base_ref="${GITHUB_BASE_REF:-main}"
+          base_ref="${GITHUB_BASE_REF:-${GITHUB_REF_NAME}}"
           cd proto
           mise x -- buf breaking . --against "../.git#branch=origin/${base_ref},subdir=proto" \
             --path chatto/discovery/v1 \


### PR DESCRIPTION
## Summary

- use the pushed branch as the protobuf compatibility base for push-triggered CI
- preserve the pull request target branch as the compatibility base for PR-triggered CI

## Root cause

`GITHUB_BASE_REF` is empty on push events, so the workflow defaulted every push to `main`. Push CI on `release-0.4` consequently compared the older stable schema against newer development schemas and failed after a green pull request, preventing Release Please from running.

## Impact

Maintenance branch pushes no longer produce false protobuf breaking-change failures against `main`. Pull request compatibility checks continue to compare against their actual target branch.

## Verification

- `git diff --check`
- `mise x -- actionlint .github/workflows/ci.yml`
