### PR TITLE
fix(auth): reject usernames ending in dots

### DIFF
--- a/apps/frontend/messages/de/common.json
+++ b/apps/frontend/messages/de/common.json
@@ -29,6 +29,7 @@
       "username_min": "Muss mindestens 2 Zeichen lang sein",
       "username_max": "Darf höchstens 32 Zeichen lang sein",
       "username_charset": "Nur Buchstaben, Zahlen, Punkte, Bindestriche und Unterstriche",
+      "username_end_alphanumeric": "Muss mit einem Buchstaben oder einer Zahl enden",
       "username_no_consecutive_periods": "Keine aufeinanderfolgenden Punkte erlaubt",
       "passwords_match": "Passwörter stimmen nicht überein",
       "fix_errors": "Bitte behebe die Fehler oben"

--- a/apps/frontend/messages/en/common.json
+++ b/apps/frontend/messages/en/common.json
@@ -29,6 +29,7 @@
       "username_min": "Must be at least 2 characters",
       "username_max": "Must be at most 32 characters",
       "username_charset": "Only letters, numbers, dots, dashes, underscores",
+      "username_end_alphanumeric": "Must end with a letter or number",
       "username_no_consecutive_periods": "No consecutive periods allowed",
       "passwords_match": "Passwords do not match",
       "fix_errors": "Please fix the errors above"

--- a/apps/frontend/src/lib/i18n/messages.ts
+++ b/apps/frontend/src/lib/i18n/messages.ts
@@ -83,6 +83,7 @@ const msg_common_validation_password_min = (): LocalizedString => messages().com
 const msg_common_validation_username_min = (): LocalizedString => messages().common_validation_username_min(empty());
 const msg_common_validation_username_max = (): LocalizedString => messages().common_validation_username_max(empty());
 const msg_common_validation_username_charset = (): LocalizedString => messages().common_validation_username_charset(empty());
+const msg_common_validation_username_end_alphanumeric = (): LocalizedString => messages().common_validation_username_end_alphanumeric(empty());
 const msg_common_validation_username_no_consecutive_periods = (): LocalizedString => messages().common_validation_username_no_consecutive_periods(empty());
 const msg_common_validation_passwords_match = (): LocalizedString => messages().common_validation_passwords_match(empty());
 const msg_common_validation_fix_errors = (): LocalizedString => messages().common_validation_fix_errors(empty());
@@ -1521,6 +1522,7 @@ export { msg_common_validation_password_min as 'common.validation.password_min' 
 export { msg_common_validation_username_min as 'common.validation.username_min' };
 export { msg_common_validation_username_max as 'common.validation.username_max' };
 export { msg_common_validation_username_charset as 'common.validation.username_charset' };
+export { msg_common_validation_username_end_alphanumeric as 'common.validation.username_end_alphanumeric' };
 export { msg_common_validation_username_no_consecutive_periods as 'common.validation.username_no_consecutive_periods' };
 export { msg_common_validation_passwords_match as 'common.validation.passwords_match' };
 export { msg_common_validation_fix_errors as 'common.validation.fix_errors' };

--- a/apps/frontend/src/lib/validation/login.spec.ts
+++ b/apps/frontend/src/lib/validation/login.spec.ts
@@ -65,6 +65,12 @@ describe('validateLogin', () => {
       expect(result.error).toContain('start with');
     });
 
+    it.each(['alice.', 'alice..', 'a.'])('rejects a trailing period in %s', (login) => {
+      const result = validateLogin(login);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('end with');
+    });
+
     it('rejects spaces', () => {
       const result = validateLogin('alice bob');
       expect(result.valid).toBe(false);

--- a/apps/frontend/src/lib/validation/login.ts
+++ b/apps/frontend/src/lib/validation/login.ts
@@ -2,7 +2,7 @@
  * Login/username validation matching the backend rules.
  *
  * Allowed: ASCII letters, digits, periods, underscores, hyphens.
- * Must start with a letter or digit.
+ * Must start with a letter or digit and must not end with a period.
  * Length: 2-32 characters.
  * Mixed case is preserved; uniqueness and login are case-insensitive.
  */
@@ -49,6 +49,10 @@ export function validateLogin(login: string): ValidationResult {
       valid: false,
       error: 'Username can only contain letters, numbers, periods, underscores, and hyphens'
     };
+  }
+
+  if (login.endsWith('.')) {
+    return { valid: false, error: 'Username must end with a letter or number' };
   }
 
   return { valid: true };

--- a/apps/frontend/src/routes/register/+page.svelte
+++ b/apps/frontend/src/routes/register/+page.svelte
@@ -32,6 +32,7 @@
     .min(2, m['common.validation.username_min']())
     .max(32, m['common.validation.username_max']())
     .regex(/^[a-zA-Z0-9._-]+$/, m['common.validation.username_charset']())
+    .refine((val) => !val.endsWith('.'), m['common.validation.username_end_alphanumeric']())
     .refine((val) => !val.includes('..'), m['common.validation.username_no_consecutive_periods']());
   const passwordSchema = z.string().min(8, m['common.validation.password_min']());
 

--- a/apps/frontend/src/routes/register/complete/+page.svelte
+++ b/apps/frontend/src/routes/register/complete/+page.svelte
@@ -25,6 +25,7 @@
     .min(2, m['common.validation.username_min']())
     .max(32, m['common.validation.username_max']())
     .regex(/^[a-zA-Z0-9._-]+$/, m['common.validation.username_charset']())
+    .refine((val) => !val.endsWith('.'), m['common.validation.username_end_alphanumeric']())
     .refine((val) => !val.includes('..'), m['common.validation.username_no_consecutive_periods']());
   const passwordSchema = z.string().min(8, m['common.validation.password_min']());
 

--- a/apps/frontend/src/routes/sso/confirm/+page.svelte
+++ b/apps/frontend/src/routes/sso/confirm/+page.svelte
@@ -30,6 +30,7 @@
     .min(2, m['common.validation.username_min']())
     .max(32, m['common.validation.username_max']())
     .regex(/^[a-zA-Z0-9._-]+$/, m['common.validation.username_charset']())
+    .refine((val) => !val.endsWith('.'), m['common.validation.username_end_alphanumeric']())
     .refine((val) => !val.includes('..'), m['common.validation.username_no_consecutive_periods']());
 
   const loginError = $derived(login ? validate(loginSchema, login) : undefined);

--- a/cli/internal/core/validation.go
+++ b/cli/internal/core/validation.go
@@ -108,7 +108,7 @@ func NormalizeDisplayName(name string) string {
 
 // ValidateLogin validates a login/username for allowed characters and length.
 // Allowed: ASCII letters, digits, periods, underscores, hyphens.
-// Must start with a letter or digit.
+// Must start with a letter or digit and must not end with a period.
 // Length: MinLoginLength to MaxLoginLength characters.
 func ValidateLogin(login string) error {
 	if len(login) < MinLoginLength {
@@ -128,6 +128,10 @@ func ValidateLogin(login string) error {
 		if !isLetterOrDigit && r != '.' && r != '_' && r != '-' {
 			return ErrLoginInvalidCharacter
 		}
+	}
+
+	if strings.HasSuffix(login, ".") {
+		return ErrLoginInvalidCharacter
 	}
 
 	return nil

--- a/cli/internal/core/validation_test.go
+++ b/cli/internal/core/validation_test.go
@@ -213,6 +213,9 @@ func TestValidateLogin(t *testing.T) {
 		{"starts with period", ".alice", ErrLoginInvalidCharacter},
 		{"starts with underscore", "_alice", ErrLoginInvalidCharacter},
 		{"starts with hyphen", "-alice", ErrLoginInvalidCharacter},
+		{"ends with period", "alice.", ErrLoginInvalidCharacter},
+		{"ends with consecutive periods", "alice..", ErrLoginInvalidCharacter},
+		{"minimum length ending with period", "a.", ErrLoginInvalidCharacter},
 
 		// Invalid - disallowed characters
 		{"with space", "alice bob", ErrLoginInvalidCharacter},

--- a/cli/internal/http_server/auth.go
+++ b/cli/internal/http_server/auth.go
@@ -431,7 +431,7 @@ func (s *HTTPServer) setupAuthRoutes() {
 
 		// Validate login format
 		if !isValidLogin(req.Login) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Login must be 2-32 characters, using only letters, numbers, dots, dashes, or underscores (no consecutive periods)"})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Login must be 2-32 characters, using only letters, numbers, dots, dashes, or underscores (no consecutive or trailing periods)"})
 			return
 		}
 
@@ -745,12 +745,15 @@ func (s *HTTPServer) setupAuthRoutes() {
 
 // isValidLogin validates that a login name meets the requirements:
 // 2-32 characters, alphanumeric with dots, dashes, or underscores.
-// Consecutive periods (..) are not allowed.
+// Consecutive periods (..) and a trailing period are not allowed.
 func isValidLogin(login string) bool {
 	if len(login) < 2 || len(login) > 32 {
 		return false
 	}
 	if strings.Contains(login, "..") {
+		return false
+	}
+	if strings.HasSuffix(login, ".") {
 		return false
 	}
 	return validLoginRegex.MatchString(login)

--- a/cli/internal/http_server/auth_test.go
+++ b/cli/internal/http_server/auth_test.go
@@ -80,6 +80,8 @@ func TestIsValidLogin(t *testing.T) {
 		{"consecutive periods start", "..john", false},
 		{"consecutive periods end", "john..", false},
 		{"triple periods", "john...doe", false},
+		{"trailing period", "john.", false},
+		{"minimum length trailing period", "j.", false},
 
 		// Invalid - length
 		{"too short", "a", false},

--- a/cli/internal/http_server/server_test.go
+++ b/cli/internal/http_server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -1173,25 +1174,31 @@ func TestAuthRoutes_RegisterComplete_InvalidLogin(t *testing.T) {
 	ts, client, chattoCore, _ := setupTestHTTPServerWithMailer(t)
 	ctx := testContext(t)
 
-	token, _ := chattoCore.CreateRegistrationToken(ctx, "invalid@example.com")
+	for i, login := range []string{"a", "alice."} {
+		t.Run(login, func(t *testing.T) {
+			token, err := chattoCore.CreateRegistrationToken(ctx, fmt.Sprintf("invalid-%d@example.com", i))
+			if err != nil {
+				t.Fatalf("CreateRegistrationToken: %v", err)
+			}
 
-	// Test with invalid login (too short)
-	reqBody := map[string]string{
-		"token":                token,
-		"login":                "a",
-		"password":             "password123",
-		"passwordConfirmation": "password123",
-	}
-	body, _ := json.Marshal(reqBody)
+			reqBody := map[string]string{
+				"token":                token,
+				"login":                login,
+				"password":             "password123",
+				"passwordConfirmation": "password123",
+			}
+			body, _ := json.Marshal(reqBody)
 
-	resp, err := client.Post(ts.URL+"/auth/register/complete", "application/json", bytes.NewReader(body))
-	if err != nil {
-		t.Fatalf("Failed to send request: %v", err)
-	}
-	defer resp.Body.Close()
+			resp, err := client.Post(ts.URL+"/auth/register/complete", "application/json", bytes.NewReader(body))
+			if err != nil {
+				t.Fatalf("Failed to send request: %v", err)
+			}
+			defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Errorf("Expected status 400, got %d", resp.StatusCode)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Errorf("Expected status 400, got %d", resp.StatusCode)
+			}
+		})
 	}
 }
 

--- a/cli/internal/http_server/test_endpoints.go
+++ b/cli/internal/http_server/test_endpoints.go
@@ -128,7 +128,7 @@ func registerTestEndpoints(auth *gin.RouterGroup, s *HTTPServer) {
 			return
 		}
 		if !isValidLogin(req.Login) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Login must be 2-32 characters, using only letters, numbers, dots, dashes, or underscores (no consecutive periods)"})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Login must be 2-32 characters, using only letters, numbers, dots, dashes, or underscores (no consecutive or trailing periods)"})
 			return
 		}
 

--- a/docs/fdr/FDR-022-user-profile.md
+++ b/docs/fdr/FDR-022-user-profile.md
@@ -1,7 +1,7 @@
 # FDR-022: User Profile
 
 **Status:** Active
-**Last reviewed:** 2026-06-23
+**Last reviewed:** 2026-07-12
 
 ## Overview
 
@@ -10,7 +10,7 @@ A user's profile carries the public identity they present to the rest of the ser
 ## Behavior
 
 - **Display name** — freely editable by the user. Shown in messages, member lists, mention autocomplete, etc.
-- **Login (username)** — editable by the user with a 30-day cooldown between changes. Each successful change records a timestamp; subsequent changes within the window are rejected with a clear error message.
+- **Login (username)** — editable by the user with a 30-day cooldown between changes. Logins start with a letter or number and cannot end with a period; periods remain valid within a login. Each successful change records a timestamp; subsequent changes within the window are rejected with a clear error message.
 - **Case-only changes** (e.g., `alice` → `Alice`) bypass the cooldown.
 - **Avatar** — users upload an image; the server resizes to 256×256 max and stores it as lossless WebP. The old avatar is deleted after the new one is committed. Users can also delete their avatar (falling back to an initial-letter placeholder).
 - **Custom status** — users can set an emoji plus short text. The emoji is shown next to their name; the text is shown alongside it where space allows and as hover/accessible text in compact places.


### PR DESCRIPTION
## Summary

Reject usernames ending in a dot across core validation, direct registration, external-identity account creation, profile edits, and admin edits while grandfathering existing stored usernames. Align the frontend validators and legacy HTTP error responses, with localized English and German guidance. Add focused core, HTTP helper, registration endpoint, and frontend validation coverage, and document the rule in FDR-022.

## Validation

Targeted Go core and HTTP tests pass, all 34 frontend username-validation tests pass, Paraglide generation succeeds, and the Svelte analyzer reports no issues introduced by this change. Full `svelte-check` remains blocked by missing generated `@chatto/api-types` modules in this worktree.
