### PR TITLE
fix: forward-port 0.4.9 changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,12 +124,12 @@ jobs:
 
       - name: Fetch protobuf breaking base
         run: |
-          base_ref="${GITHUB_BASE_REF:-main}"
+          base_ref="${GITHUB_BASE_REF:-${GITHUB_REF_NAME}}"
           git fetch --no-tags --depth=1 origin "${base_ref}:refs/remotes/origin/${base_ref}"
 
       - name: Check storage and internal protobuf breaking changes
         run: |
-          base_ref="${GITHUB_BASE_REF:-main}"
+          base_ref="${GITHUB_BASE_REF:-${GITHUB_REF_NAME}}"
           cd proto
           mise x -- buf breaking . --against "../.git#branch=origin/${base_ref},subdir=proto" \
             --exclude-imports \
@@ -142,7 +142,7 @@ jobs:
       - name: Check public API protobuf breaking changes
         if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'api-breaking-change') }}
         run: |
-          base_ref="${GITHUB_BASE_REF:-main}"
+          base_ref="${GITHUB_BASE_REF:-${GITHUB_REF_NAME}}"
           cd proto
           mise x -- buf breaking . --against "../.git#branch=origin/${base_ref},subdir=proto" \
             --path chatto/discovery/v1 \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
                 source_branch="${ref#refs/remotes/origin/}"
                 break
               fi
-            done < <(git for-each-ref --format='%(refname)' refs/remotes/origin/release-)
+            done < <(git for-each-ref --format='%(refname)' 'refs/remotes/origin/release-*')
           fi
 
           if [[ -z "$source_branch" ]]; then

--- a/apps/frontend/messages/de/common.json
+++ b/apps/frontend/messages/de/common.json
@@ -29,6 +29,7 @@
       "username_min": "Muss mindestens 2 Zeichen lang sein",
       "username_max": "Darf höchstens 32 Zeichen lang sein",
       "username_charset": "Nur Buchstaben, Zahlen, Punkte, Bindestriche und Unterstriche",
+      "username_end_alphanumeric": "Muss mit einem Buchstaben oder einer Zahl enden",
       "username_no_consecutive_periods": "Keine aufeinanderfolgenden Punkte erlaubt",
       "passwords_match": "Passwörter stimmen nicht überein",
       "fix_errors": "Bitte behebe die Fehler oben"

--- a/apps/frontend/messages/en/common.json
+++ b/apps/frontend/messages/en/common.json
@@ -29,6 +29,7 @@
       "username_min": "Must be at least 2 characters",
       "username_max": "Must be at most 32 characters",
       "username_charset": "Only letters, numbers, dots, dashes, underscores",
+      "username_end_alphanumeric": "Must end with a letter or number",
       "username_no_consecutive_periods": "No consecutive periods allowed",
       "passwords_match": "Passwords do not match",
       "fix_errors": "Please fix the errors above"

--- a/apps/frontend/src/lib/i18n/messages.ts
+++ b/apps/frontend/src/lib/i18n/messages.ts
@@ -83,6 +83,7 @@ const msg_common_validation_password_min = (): LocalizedString => messages().com
 const msg_common_validation_username_min = (): LocalizedString => messages().common_validation_username_min(empty());
 const msg_common_validation_username_max = (): LocalizedString => messages().common_validation_username_max(empty());
 const msg_common_validation_username_charset = (): LocalizedString => messages().common_validation_username_charset(empty());
+const msg_common_validation_username_end_alphanumeric = (): LocalizedString => messages().common_validation_username_end_alphanumeric(empty());
 const msg_common_validation_username_no_consecutive_periods = (): LocalizedString => messages().common_validation_username_no_consecutive_periods(empty());
 const msg_common_validation_passwords_match = (): LocalizedString => messages().common_validation_passwords_match(empty());
 const msg_common_validation_fix_errors = (): LocalizedString => messages().common_validation_fix_errors(empty());
@@ -1546,6 +1547,7 @@ export { msg_common_validation_password_min as 'common.validation.password_min' 
 export { msg_common_validation_username_min as 'common.validation.username_min' };
 export { msg_common_validation_username_max as 'common.validation.username_max' };
 export { msg_common_validation_username_charset as 'common.validation.username_charset' };
+export { msg_common_validation_username_end_alphanumeric as 'common.validation.username_end_alphanumeric' };
 export { msg_common_validation_username_no_consecutive_periods as 'common.validation.username_no_consecutive_periods' };
 export { msg_common_validation_passwords_match as 'common.validation.passwords_match' };
 export { msg_common_validation_fix_errors as 'common.validation.fix_errors' };

--- a/apps/frontend/src/lib/validation/login.spec.ts
+++ b/apps/frontend/src/lib/validation/login.spec.ts
@@ -65,6 +65,12 @@ describe('validateLogin', () => {
       expect(result.error).toContain('start with');
     });
 
+    it.each(['alice.', 'alice..', 'a.'])('rejects a trailing period in %s', (login) => {
+      const result = validateLogin(login);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('end with');
+    });
+
     it('rejects spaces', () => {
       const result = validateLogin('alice bob');
       expect(result.valid).toBe(false);

--- a/apps/frontend/src/lib/validation/login.ts
+++ b/apps/frontend/src/lib/validation/login.ts
@@ -2,7 +2,7 @@
  * Login/username validation matching the backend rules.
  *
  * Allowed: ASCII letters, digits, periods, underscores, hyphens.
- * Must start with a letter or digit.
+ * Must start with a letter or digit and must not end with a period.
  * Length: 2-32 characters.
  * Mixed case is preserved; uniqueness and login are case-insensitive.
  */
@@ -49,6 +49,10 @@ export function validateLogin(login: string): ValidationResult {
       valid: false,
       error: 'Username can only contain letters, numbers, periods, underscores, and hyphens'
     };
+  }
+
+  if (login.endsWith('.')) {
+    return { valid: false, error: 'Username must end with a letter or number' };
   }
 
   return { valid: true };

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEventGroup.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEventGroup.svelte
@@ -82,7 +82,7 @@
   {#each items as actor, index (actor.id)}
     {#if index > 0}
       {#if index === items.length - 1}
-        {items.length > 2 ? ', ' : ''}{m['room.system_events.and']()}
+        {items.length > 2 ? ', ' : ' '}{m['room.system_events.and']()}
       {:else}
         ,
       {/if}
@@ -112,7 +112,8 @@
 
     <span class="text-sm text-muted">
       {#if !isTruncatable || expanded}
-        {@render actorNames(actors)} {action}
+        {@render actorNames(actors)}
+        {action}
         {#if isTruncatable}
           <button
             type="button"
@@ -123,11 +124,13 @@
           </button>
         {/if}
       {:else}
-        {@render actorNames(headActors)}, {m['room.system_events.and']()} <button
+        {@render actorNames(headActors)}, {m['room.system_events.and']()}
+        <button
           type="button"
           class="cursor-pointer underline decoration-dotted underline-offset-2 hover:text-text"
           onclick={() => (expanded = true)}
-        >{extraCount} {m['room.system_events.other_people']({ count: extraCount })}</button>
+          >{extraCount} {m['room.system_events.other_people']({ count: extraCount })}</button
+        >
         {action}
       {/if}
     </span>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEventGroup.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEventGroup.svelte.spec.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import type { RoomEventView } from '$lib/render/types';
+import { RoomEventKind } from '$lib/render/eventKinds';
+import { loadLocaleMessages } from '$lib/i18n/messages';
+import { setReactiveLocale } from '$lib/i18n/state.svelte';
+import SystemEventGroup from './SystemEventGroup.svelte';
+
+vi.mock('$lib/state/userProfiles.svelte', () => ({
+  getLiveDisplayName: (_userId: string, fallback: string) => fallback,
+  getLiveAvatarUrl: (_userId: string, fallback: string | null) => fallback,
+  getLiveCustomStatus: (_userId: string, fallback: unknown) => fallback
+}));
+
+vi.mock('$lib/state/presenceCache.svelte', () => ({
+  getPresenceCache: () => ({
+    get: (_scope: { serverId: string; userId: string }, fallback: unknown) => fallback
+  })
+}));
+
+function systemEvents(actorNames: string[]): RoomEventView[] {
+  return actorNames.map(
+    (actorName, index) =>
+      ({
+        id: `event-${index}`,
+        createdAt: `2026-06-15T12:00:0${index}Z`,
+        actorId: `user-${index}`,
+        actor: {
+          id: `user-${index}`,
+          login: actorName.toLowerCase(),
+          displayName: actorName,
+          avatarUrl: null,
+          presenceStatus: null
+        },
+        event: {
+          kind: RoomEventKind.UserJoinedRoom,
+          roomId: 'room-1'
+        }
+      }) as unknown as RoomEventView
+  );
+}
+
+function renderedCopy(container: HTMLElement): string {
+  const copy = container.querySelector<HTMLElement>('[data-event-id] > span');
+  return copy?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+}
+
+describe('SystemEventGroup', () => {
+  beforeEach(async () => {
+    await loadLocaleMessages('en');
+    setReactiveLocale('en');
+  });
+
+  it('separates two actors with the localized conjunction', () => {
+    const { container } = render(SystemEventGroup, {
+      props: { events: systemEvents(['Alice', 'Bob']), kind: 'join' }
+    });
+
+    expect(renderedCopy(container)).toBe('Alice and Bob joined the room');
+  });
+
+  it('uses comma-separated formatting for three actors', () => {
+    const { container } = render(SystemEventGroup, {
+      props: { events: systemEvents(['Alice', 'Bob', 'Charlie']), kind: 'join' }
+    });
+
+    expect(renderedCopy(container)).toBe('Alice, Bob, and Charlie joined the room');
+  });
+
+  it('renders grouped leave wording', () => {
+    const { container } = render(SystemEventGroup, {
+      props: { events: systemEvents(['Alice', 'Bob']), kind: 'leave' }
+    });
+
+    expect(renderedCopy(container)).toBe('Alice and Bob left the room');
+  });
+
+  it('localizes the conjunction and plural action wording in German', async () => {
+    await loadLocaleMessages('de');
+    setReactiveLocale('de');
+    const { container } = render(SystemEventGroup, {
+      props: { events: systemEvents(['Alice', 'Bob']), kind: 'join' }
+    });
+
+    expect(renderedCopy(container)).toBe('Alice und Bob sind dem Raum beigetreten');
+  });
+});

--- a/apps/frontend/src/routes/register/+page.svelte
+++ b/apps/frontend/src/routes/register/+page.svelte
@@ -32,6 +32,7 @@
     .min(2, m['common.validation.username_min']())
     .max(32, m['common.validation.username_max']())
     .regex(/^[a-zA-Z0-9._-]+$/, m['common.validation.username_charset']())
+    .refine((val) => !val.endsWith('.'), m['common.validation.username_end_alphanumeric']())
     .refine((val) => !val.includes('..'), m['common.validation.username_no_consecutive_periods']());
   const passwordSchema = z.string().min(8, m['common.validation.password_min']());
 

--- a/apps/frontend/src/routes/register/complete/+page.svelte
+++ b/apps/frontend/src/routes/register/complete/+page.svelte
@@ -25,6 +25,7 @@
     .min(2, m['common.validation.username_min']())
     .max(32, m['common.validation.username_max']())
     .regex(/^[a-zA-Z0-9._-]+$/, m['common.validation.username_charset']())
+    .refine((val) => !val.endsWith('.'), m['common.validation.username_end_alphanumeric']())
     .refine((val) => !val.includes('..'), m['common.validation.username_no_consecutive_periods']());
   const passwordSchema = z.string().min(8, m['common.validation.password_min']());
 

--- a/apps/frontend/src/routes/sso/confirm/+page.svelte
+++ b/apps/frontend/src/routes/sso/confirm/+page.svelte
@@ -30,6 +30,7 @@
     .min(2, m['common.validation.username_min']())
     .max(32, m['common.validation.username_max']())
     .regex(/^[a-zA-Z0-9._-]+$/, m['common.validation.username_charset']())
+    .refine((val) => !val.endsWith('.'), m['common.validation.username_end_alphanumeric']())
     .refine((val) => !val.includes('..'), m['common.validation.username_no_consecutive_periods']());
 
   const loginError = $derived(login ? validate(loginSchema, login) : undefined);

--- a/cli/internal/core/validation.go
+++ b/cli/internal/core/validation.go
@@ -108,7 +108,7 @@ func NormalizeDisplayName(name string) string {
 
 // ValidateLogin validates a login/username for allowed characters and length.
 // Allowed: ASCII letters, digits, periods, underscores, hyphens.
-// Must start with a letter or digit.
+// Must start with a letter or digit and must not end with a period.
 // Length: MinLoginLength to MaxLoginLength characters.
 func ValidateLogin(login string) error {
 	if len(login) < MinLoginLength {
@@ -128,6 +128,10 @@ func ValidateLogin(login string) error {
 		if !isLetterOrDigit && r != '.' && r != '_' && r != '-' {
 			return ErrLoginInvalidCharacter
 		}
+	}
+
+	if strings.HasSuffix(login, ".") {
+		return ErrLoginInvalidCharacter
 	}
 
 	return nil

--- a/cli/internal/core/validation_test.go
+++ b/cli/internal/core/validation_test.go
@@ -213,6 +213,9 @@ func TestValidateLogin(t *testing.T) {
 		{"starts with period", ".alice", ErrLoginInvalidCharacter},
 		{"starts with underscore", "_alice", ErrLoginInvalidCharacter},
 		{"starts with hyphen", "-alice", ErrLoginInvalidCharacter},
+		{"ends with period", "alice.", ErrLoginInvalidCharacter},
+		{"ends with consecutive periods", "alice..", ErrLoginInvalidCharacter},
+		{"minimum length ending with period", "a.", ErrLoginInvalidCharacter},
 
 		// Invalid - disallowed characters
 		{"with space", "alice bob", ErrLoginInvalidCharacter},

--- a/cli/internal/events/projector.go
+++ b/cli/internal/events/projector.go
@@ -27,6 +27,12 @@ var ErrProjectionSubjectNotConsumed = errors.New("projection does not consume su
 // one supplied by the caller.
 var ErrProjectionSequenceSubjectMismatch = errors.New("projection wait sequence subject mismatch")
 
+// Projection replay is a sequential bulk read. NATS defaults to a 500-message
+// client buffer, which turns histories of many small EVT records into many
+// latency-bound pull requests on a remote JetStream cluster. A byte window
+// keeps those pulls large while bounding client-side memory.
+const projectionPullMaxBytes = 16 * 1024 * 1024
+
 // MemoryProjection is an embeddable base for projections whose state
 // lives entirely in process memory. It contributes a sync.RWMutex that
 // subclasses use for read/write coordination, plus no-op
@@ -593,6 +599,7 @@ func (p *Projector) Run(ctx context.Context) error {
 	// quiet when idle. See the perf-investigation notes accompanying
 	// this change.
 	cc, err := cons.Consume(p.handleMessage,
+		jetstream.PullMaxBytes(projectionPullMaxBytes),
 		jetstream.ConsumeErrHandler(p.handleConsumeErr),
 	)
 	if err != nil {
@@ -803,11 +810,12 @@ func runProjectorsOnSubjects(ctx context.Context, subjects []string, projectors 
 	failedCh := make(chan struct{}, 1)
 	cc, err := cons.Consume(func(msg jetstream.Msg) {
 		handleSharedProjectorMessage(msg, projectors, failedCh)
-	}, jetstream.ConsumeErrHandler(func(cc jetstream.ConsumeContext, err error) {
-		for _, projector := range projectors {
-			projector.handleConsumeErr(cc, err)
-		}
-	}))
+	}, jetstream.PullMaxBytes(projectionPullMaxBytes),
+		jetstream.ConsumeErrHandler(func(cc jetstream.ConsumeContext, err error) {
+			for _, projector := range projectors {
+				projector.handleConsumeErr(cc, err)
+			}
+		}))
 	if err != nil {
 		return fmt.Errorf("start consume: %w", err)
 	}

--- a/cli/internal/http_server/auth.go
+++ b/cli/internal/http_server/auth.go
@@ -431,7 +431,7 @@ func (s *HTTPServer) setupAuthRoutes() {
 
 		// Validate login format
 		if !isValidLogin(req.Login) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Login must be 2-32 characters, using only letters, numbers, dots, dashes, or underscores (no consecutive periods)"})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Login must be 2-32 characters, using only letters, numbers, dots, dashes, or underscores (no consecutive or trailing periods)"})
 			return
 		}
 
@@ -745,12 +745,15 @@ func (s *HTTPServer) setupAuthRoutes() {
 
 // isValidLogin validates that a login name meets the requirements:
 // 2-32 characters, alphanumeric with dots, dashes, or underscores.
-// Consecutive periods (..) are not allowed.
+// Consecutive periods (..) and a trailing period are not allowed.
 func isValidLogin(login string) bool {
 	if len(login) < 2 || len(login) > 32 {
 		return false
 	}
 	if strings.Contains(login, "..") {
+		return false
+	}
+	if strings.HasSuffix(login, ".") {
 		return false
 	}
 	return validLoginRegex.MatchString(login)

--- a/cli/internal/http_server/auth_test.go
+++ b/cli/internal/http_server/auth_test.go
@@ -80,6 +80,8 @@ func TestIsValidLogin(t *testing.T) {
 		{"consecutive periods start", "..john", false},
 		{"consecutive periods end", "john..", false},
 		{"triple periods", "john...doe", false},
+		{"trailing period", "john.", false},
+		{"minimum length trailing period", "j.", false},
 
 		// Invalid - length
 		{"too short", "a", false},

--- a/cli/internal/http_server/server_test.go
+++ b/cli/internal/http_server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -1173,25 +1174,31 @@ func TestAuthRoutes_RegisterComplete_InvalidLogin(t *testing.T) {
 	ts, client, chattoCore, _ := setupTestHTTPServerWithMailer(t)
 	ctx := testContext(t)
 
-	token, _ := chattoCore.CreateRegistrationToken(ctx, "invalid@example.com")
+	for i, login := range []string{"a", "alice."} {
+		t.Run(login, func(t *testing.T) {
+			token, err := chattoCore.CreateRegistrationToken(ctx, fmt.Sprintf("invalid-%d@example.com", i))
+			if err != nil {
+				t.Fatalf("CreateRegistrationToken: %v", err)
+			}
 
-	// Test with invalid login (too short)
-	reqBody := map[string]string{
-		"token":                token,
-		"login":                "a",
-		"password":             "password123",
-		"passwordConfirmation": "password123",
-	}
-	body, _ := json.Marshal(reqBody)
+			reqBody := map[string]string{
+				"token":                token,
+				"login":                login,
+				"password":             "password123",
+				"passwordConfirmation": "password123",
+			}
+			body, _ := json.Marshal(reqBody)
 
-	resp, err := client.Post(ts.URL+"/auth/register/complete", "application/json", bytes.NewReader(body))
-	if err != nil {
-		t.Fatalf("Failed to send request: %v", err)
-	}
-	defer resp.Body.Close()
+			resp, err := client.Post(ts.URL+"/auth/register/complete", "application/json", bytes.NewReader(body))
+			if err != nil {
+				t.Fatalf("Failed to send request: %v", err)
+			}
+			defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Errorf("Expected status 400, got %d", resp.StatusCode)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Errorf("Expected status 400, got %d", resp.StatusCode)
+			}
+		})
 	}
 }
 

--- a/cli/internal/http_server/test_endpoints.go
+++ b/cli/internal/http_server/test_endpoints.go
@@ -128,7 +128,7 @@ func registerTestEndpoints(auth *gin.RouterGroup, s *HTTPServer) {
 			return
 		}
 		if !isValidLogin(req.Login) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Login must be 2-32 characters, using only letters, numbers, dots, dashes, or underscores (no consecutive periods)"})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Login must be 2-32 characters, using only letters, numbers, dots, dashes, or underscores (no consecutive or trailing periods)"})
 			return
 		}
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -48,7 +48,16 @@ Stable releases publish `latest` only when they are the highest stable version.
 
 ## Maintain a stable release
 
-Apply urgent fixes for an existing stable series to its `release-x.y` branch.
-Use conventional `fix:` commits so release-please prepares the next patch
-release, such as `0.5.1`. Forward-port each applicable fix to `main` so future
-versions contain it as well.
+When a fix applies to both current development and a stable series, land it on
+`main` first and backport that commit through a pull request targeting
+`release-x.y`. Use conventional `fix:` commits so release-please prepares the
+next patch release, such as `0.5.1`.
+
+If a bug exists only in the stable series, fix it directly on `release-x.y`.
+Forward-port a release-first fix through a separate `main` pull request only
+when current development also needs it.
+
+Never merge a `release-x.y` branch wholesale into `main`. Stable branches carry
+their own release-please configuration, manifests, changelog commits, and
+embedded stable versions. Backport or forward-port the applicable product and
+automation commits instead.

--- a/docs/fdr/FDR-022-user-profile.md
+++ b/docs/fdr/FDR-022-user-profile.md
@@ -1,7 +1,7 @@
 # FDR-022: User Profile
 
 **Status:** Active
-**Last reviewed:** 2026-06-23
+**Last reviewed:** 2026-07-12
 
 ## Overview
 
@@ -10,7 +10,7 @@ A user's profile carries the public identity they present to the rest of the ser
 ## Behavior
 
 - **Display name** — freely editable by the user. Shown in messages, member lists, mention autocomplete, etc.
-- **Login (username)** — editable by the user with a 30-day cooldown between changes. Each successful change records a timestamp; subsequent changes within the window are rejected with a clear error message.
+- **Login (username)** — editable by the user with a 30-day cooldown between changes. Logins start with a letter or number and cannot end with a period; periods remain valid within a login. Each successful change records a timestamp; subsequent changes within the window are rejected with a clear error message.
 - **Case-only changes** (e.g., `alice` → `Alice`) bypass the cooldown.
 - **Avatar** — users upload an image; the server resizes to 256×256 max and stores it as lossless WebP. The old avatar is deleted after the new one is committed. Users can also delete their avatar (falling back to an initial-letter placeholder).
 - **Custom status** — users can set an emoji plus short text. The emoji is shown next to their name; the text is shown alongside it where space allows and as hover/accessible text in compact places.


### PR DESCRIPTION
## Why

The 0.4.9 maintenance fixes landed on `release-0.4` after `main` entered the
0.5 prerelease line. Current development needs the applicable product fixes and
release automation corrections without inheriting stable release metadata.

## What changed

- Forward-port the grouped-system-event spacing fix.
- Reject new usernames ending in dots across backend and frontend paths while
  continuing to accept existing stored usernames.
- Increase the bounded projection replay pull window to improve remote
  JetStream startup throughput.
- Carry the CI push-base and release-ref enumeration fixes to `main`.
- Document that applicable fixes land on `main` first and move to maintenance
  branches through focused backport PRs.

### Compatibility and release history

This PR does not merge `release-0.4` and does not include either 0.4.9 Release Please commit or the temporary 0.4.9 metadata rollback. The prerelease configuration and current `main` version files remain unchanged.

There are no protobuf, ConnectRPC, realtime protocol, persisted event-shape,
storage migration, or deployment configuration changes. New username writes
are intentionally stricter; existing stored usernames remain valid.

## Test plan

- [x] Svelte autofixer on all affected components
- [x] 38 targeted frontend tests
- [x] Frontend typecheck: 0 errors and 0 warnings
- [x] Frontend ESLint
- [x] `go test ./internal/events -timeout 90s`
- [x] Focused core username validation tests
- [x] Focused HTTP authentication and registration tests
- [x] `actionlint` for CI and release workflows
- [x] `git diff --check`
- [x] Protected GitHub CI on the final branch head
