### PR TITLE
fix(frontend): restore branded PWA install icons

### DIFF
--- a/cli/internal/http_server/frontend.go
+++ b/cli/internal/http_server/frontend.go
@@ -10,6 +10,7 @@ import (
 	"io/fs"
 	"mime"
 	"net/http"
+	"net/url"
 	"path"
 	"path/filepath"
 	"strings"
@@ -137,7 +138,7 @@ func (s *HTTPServer) currentPWAIconURLs(ctx context.Context) *pwaServerIconURLs 
 			s.logger.Warn("failed to get server logo URL for PWA metadata", "error", err, "size", size)
 			return ""
 		}
-		return url
+		return sameOriginPWAAssetURL(url)
 	}
 
 	icons := &pwaServerIconURLs{
@@ -151,12 +152,29 @@ func (s *HTTPServer) currentPWAIconURLs(ctx context.Context) *pwaServerIconURLs 
 	return icons
 }
 
+// sameOriginPWAAssetURL keeps install metadata on the frontend origin. General
+// asset URLs may use a configured asset base, but each Chatto frontend serves
+// its own public server assets and browsers must be able to fetch manifest
+// images from the manifest's origin.
+func sameOriginPWAAssetURL(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Opaque != "" || !strings.HasPrefix(parsed.Path, "/assets/server/") {
+		return ""
+	}
+
+	result := parsed.EscapedPath()
+	if parsed.RawQuery != "" {
+		result += "?" + parsed.RawQuery
+	}
+	return result
+}
+
 func pwaManifestIcons(icon192, icon512 string) []map[string]string {
 	return []map[string]string{
-		{"src": icon192, "sizes": "192x192"},
-		{"src": icon512, "sizes": "512x512"},
-		{"src": icon192, "sizes": "192x192", "purpose": "maskable"},
-		{"src": icon512, "sizes": "512x512", "purpose": "maskable"},
+		{"src": icon192, "sizes": "192x192", "type": "image/png"},
+		{"src": icon512, "sizes": "512x512", "type": "image/png"},
+		{"src": icon192, "sizes": "192x192", "type": "image/png", "purpose": "maskable"},
+		{"src": icon512, "sizes": "512x512", "type": "image/png", "purpose": "maskable"},
 	}
 }
 
@@ -178,7 +196,7 @@ func dynamicPWAManifest(staticManifest []byte, icons *pwaServerIconURLs) ([]byte
 				continue
 			}
 			shortcutMap["icons"] = []map[string]string{
-				{"src": icons.Icon192, "sizes": "192x192"},
+				{"src": icons.Icon192, "sizes": "192x192", "type": "image/png"},
 			}
 		}
 	}

--- a/cli/internal/http_server/frontend_test.go
+++ b/cli/internal/http_server/frontend_test.go
@@ -229,15 +229,49 @@ func TestDynamicPWAManifest(t *testing.T) {
 		assert.Len(t, icons, 4)
 		assert.Equal(t, "/assets/server/logo/t/192", icons[0].(map[string]any)["src"])
 		assert.Equal(t, "192x192", icons[0].(map[string]any)["sizes"])
-		assert.Nil(t, icons[0].(map[string]any)["type"])
+		assert.Equal(t, "image/png", icons[0].(map[string]any)["type"])
 		assert.Equal(t, "/assets/server/logo/t/512", icons[1].(map[string]any)["src"])
+		assert.Equal(t, "image/png", icons[1].(map[string]any)["type"])
 		assert.Equal(t, "maskable", icons[2].(map[string]any)["purpose"])
+		assert.Equal(t, "image/png", icons[2].(map[string]any)["type"])
+		assert.Equal(t, "maskable", icons[3].(map[string]any)["purpose"])
+		assert.Equal(t, "image/png", icons[3].(map[string]any)["type"])
 
 		shortcuts := manifest["shortcuts"].([]any)
 		shortcutIcons := shortcuts[0].(map[string]any)["icons"].([]any)
 		assert.Equal(t, "/assets/server/logo/t/192", shortcutIcons[0].(map[string]any)["src"])
-		assert.Nil(t, shortcutIcons[0].(map[string]any)["type"])
+		assert.Equal(t, "image/png", shortcutIcons[0].(map[string]any)["type"])
 	})
+}
+
+func TestSameOriginPWAAssetURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "keeps relative server asset URL",
+			url:  "/assets/server/logo/t/signed",
+			want: "/assets/server/logo/t/signed",
+		},
+		{
+			name: "removes external asset origin",
+			url:  "https://assets.example.com/assets/server/logo/t/signed?variant=pwa",
+			want: "/assets/server/logo/t/signed?variant=pwa",
+		},
+		{
+			name: "rejects unrelated asset URL",
+			url:  "https://assets.example.com/assets/files/private",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sameOriginPWAAssetURL(tt.url))
+		})
+	}
 }
 
 func TestInjectAppleTouchIcon(t *testing.T) {
@@ -375,6 +409,7 @@ func TestServeSPAFallback(t *testing.T) {
 
 		server := newTestServer()
 		server.core = setupFrontendTestCoreWithLogo(t)
+		server.core.AssetBaseURL = "https://assets.example.com"
 		router := gin.New()
 		router.GET("/test", func(c *gin.Context) {
 			server.serveSPAFallback(c, mockFS)
@@ -386,6 +421,7 @@ func TestServeSPAFallback(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Contains(t, w.Body.String(), `href="/assets/server/logo-asset/t/`)
+		assert.NotContains(t, w.Body.String(), "assets.example.com")
 		assert.NotContains(t, w.Body.String(), defaultAppleTouchIconHref)
 	})
 
@@ -422,9 +458,11 @@ func TestServePWAWebManifestUsesServerLogoWhenAvailable(t *testing.T) {
 }`),
 		},
 	}
+	chattoCore := setupFrontendTestCoreWithLogo(t)
+	chattoCore.AssetBaseURL = "https://assets.example.com"
 	server := &HTTPServer{
 		config: config.ChattoConfig{Webserver: config.WebserverConfig{URL: "https://example.com"}},
-		core:   setupFrontendTestCoreWithLogo(t),
+		core:   chattoCore,
 		router: gin.New(),
 	}
 	server.router.GET("/manifest.webmanifest", func(c *gin.Context) {
@@ -444,8 +482,11 @@ func TestServePWAWebManifestUsesServerLogoWhenAvailable(t *testing.T) {
 	}
 	icons := manifest["icons"].([]any)
 	assert.True(t, strings.HasPrefix(icons[0].(map[string]any)["src"].(string), "/assets/server/logo-asset/t/"))
+	assert.NotContains(t, icons[0].(map[string]any)["src"], "assets.example.com")
 	assert.Equal(t, "192x192", icons[0].(map[string]any)["sizes"])
-	assert.Nil(t, icons[0].(map[string]any)["type"])
+	assert.Equal(t, "image/png", icons[0].(map[string]any)["type"])
+	assert.Equal(t, "maskable", icons[2].(map[string]any)["purpose"])
+	assert.Equal(t, "image/png", icons[2].(map[string]any)["type"])
 }
 
 func TestFrontendFallbackDoesNotServeReservedBackendPrefixes(t *testing.T) {


### PR DESCRIPTION
## Summary

Branded PWA metadata now keeps server-logo transforms on the frontend origin instead of emitting an external asset-base URL that can return 404 and make Chromium reject every install icon. Dynamic manifest and shortcut icons also declare their PNG MIME type while retaining regular and maskable variants. Tests cover external-origin normalization, query preservation, Apple touch metadata, MIME types, and fallback behavior.

## Verification

`mise test-cli`; `git diff --check`.
