### PR TITLE
fix(frontend): preserve expanded timeline groups

### DIFF
--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { tick, untrack } from 'svelte';
+  import { SvelteSet } from 'svelte/reactivity';
   import { fade } from 'svelte/transition';
   import { Virtualizer, type VirtualizerHandle } from 'virtua/svelte';
   import * as m from '$lib/i18n/messages';
@@ -134,6 +135,22 @@
   let hasNewMessages = $state(false);
   let lastSeenNewestId = $state<string | null>(null);
   let firstVisibleAt = $state<string | null>(null);
+  const expandedSystemEventIds = new SvelteSet<string>();
+  let expandedStateRoomId: string | null = null;
+
+  function isSystemGroupExpanded(groupEvents: RoomEventView[]): boolean {
+    return groupEvents.some((event) => expandedSystemEventIds.has(event.id));
+  }
+
+  function setSystemGroupExpanded(groupEvents: RoomEventView[], expanded: boolean): void {
+    for (const event of groupEvents) {
+      if (expanded) {
+        expandedSystemEventIds.add(event.id);
+      } else {
+        expandedSystemEventIds.delete(event.id);
+      }
+    }
+  }
 
   function setShouldScrollToBottom(value: boolean) {
     shouldScrollToBottom = value;
@@ -262,6 +279,19 @@
     lastSeenNewestId = null;
     firstVisibleAt = null;
     previousOffset = null;
+  });
+
+  $effect(() => {
+    const currentRoomId = roomId;
+    if (expandedStateRoomId === null) {
+      expandedStateRoomId = currentRoomId;
+      return;
+    }
+    if (currentRoomId === expandedStateRoomId) return;
+    expandedStateRoomId = currentRoomId;
+    // This reset belongs exclusively to room navigation. Reading the reactive
+    // set here would also subscribe the effect to expansion changes.
+    untrack(() => expandedSystemEventIds.clear());
   });
 
   // When exiting jumped mode (returning to present), re-enable auto-scroll
@@ -1001,7 +1031,12 @@
               {@const groupEvents = item?.events}
               {@const groupKind = item?.kind}
               {#if groupEvents && groupKind && groupEvents.length > 0}
-                <SystemEventGroup events={groupEvents} kind={groupKind} />
+                <SystemEventGroup
+                  events={groupEvents}
+                  kind={groupKind}
+                  expanded={isSystemGroupExpanded(groupEvents)}
+                  onExpandedChange={(expanded) => setSystemGroupExpanded(groupEvents, expanded)}
+                />
               {/if}
             {:else}
               <!--

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
@@ -29,6 +29,18 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
   }
 }));
 
+vi.mock('$lib/state/userProfiles.svelte', () => ({
+  getLiveDisplayName: (_userId: string, fallback: string) => fallback,
+  getLiveAvatarUrl: (_userId: string, fallback: string | null) => fallback,
+  getLiveCustomStatus: (_userId: string, fallback: unknown) => fallback
+}));
+
+vi.mock('$lib/state/presenceCache.svelte', () => ({
+  getPresenceCache: () => ({
+    get: (_scope: { serverId: string; userId: string }, fallback: unknown) => fallback
+  })
+}));
+
 vi.mock('$lib/hooks/useTabResumeCallback.svelte', () => ({
   useTabResumeCallback: (callback: () => void) => resumeCallbacks.push(callback)
 }));
@@ -204,5 +216,47 @@ describe('EventList jump completion', () => {
       setVirtualizerScrollOffset(700);
       vi.unstubAllGlobals();
     }
+  });
+
+  it('preserves an expanded system group across virtual row remounts and resets it by room', async () => {
+    const initialEventIds = ['join-1', 'join-2', 'join-3', 'join-4', 'join-5'];
+    const rendered = render(EventListTestHarness, {
+      props: {
+        eventIds: initialEventIds,
+        eventKind: 'join',
+        scrollToEventId: null,
+        updateCounter: initialEventIds.length
+      }
+    });
+
+    await page.getByRole('button', { name: '2 others' }).click();
+    await expect.element(page.getByRole('button', { name: 'show less' })).toBeVisible();
+
+    // Extending the group changes its virtual-item key, forcing the mock
+    // virtualizer to remount the row just like forward pagination can.
+    const extendedEventIds = [...initialEventIds, 'join-6'];
+    await rendered.rerender({
+      eventIds: extendedEventIds,
+      eventKind: 'join',
+      scrollToEventId: null,
+      updateCounter: extendedEventIds.length
+    });
+    await expect
+      .element(page.getByTestId('virtualizer-rendered-key'))
+      .toHaveAttribute('data-rendered-key', 'system-group-join-6');
+    await expect.element(page.getByRole('button', { name: 'show less' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'show less' }).click();
+    await expect.element(page.getByRole('button', { name: '3 others' })).toBeVisible();
+
+    await page.getByRole('button', { name: '3 others' }).click();
+    await rendered.rerender({
+      eventIds: extendedEventIds,
+      roomId: 'room-2',
+      eventKind: 'join',
+      scrollToEventId: null,
+      updateCounter: extendedEventIds.length
+    });
+    await expect.element(page.getByRole('button', { name: '3 others' })).toBeVisible();
   });
 });

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListTestHarness.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListTestHarness.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { RoomEventKind } from '$lib/render/eventKinds';
-  import type { RoomEventView } from '$lib/render/types';
+  import { PresenceStatus, type RoomEventView } from '$lib/render/types';
   import {
     createComposerContext,
     createRoomPermissions,
@@ -11,6 +11,8 @@
 
   let {
     eventIds,
+    roomId = 'room-1',
+    eventKind = 'message',
     scrollToEventId,
     onComplete,
     isLoading = false,
@@ -20,6 +22,8 @@
     pendingHighlightId = null
   }: {
     eventIds: string[];
+    roomId?: string;
+    eventKind?: 'message' | 'join';
     scrollToEventId: string | null;
     onComplete?: () => void;
     isLoading?: boolean;
@@ -34,15 +38,34 @@
   setUserSettings(new UserSettingsState());
 
   const events = $derived(
-    eventIds.map(
-      (id): RoomEventView => ({
+    eventIds.map((id, index): RoomEventView => {
+      const base = {
         id,
-        createdAt: '2026-06-17T10:47:00Z',
-        actorId: 'test-user',
-        actor: null,
+        createdAt: `2026-06-17T10:47:${String(index).padStart(2, '0')}Z`,
+        actorId: `user-${id}`,
+        actor: {
+          id: `user-${id}`,
+          login: id,
+          displayName: `User ${id}`,
+          deleted: false,
+          avatarUrl: null,
+          presenceStatus: PresenceStatus.Offline
+        }
+      };
+      if (eventKind === 'join') {
+        return {
+          ...base,
+          event: {
+            kind: RoomEventKind.UserJoinedRoom,
+            roomId
+          }
+        } as unknown as RoomEventView;
+      }
+      return {
+        ...base,
         event: {
           kind: RoomEventKind.MessagePosted,
-          roomId: 'room-1',
+          roomId,
           body: id,
           attachments: [],
           linkPreview: null,
@@ -58,8 +81,8 @@
           threadParticipants: [],
           viewerIsFollowingThread: true
         }
-      })
-    )
+      } as RoomEventView;
+    })
   );
 
   const messageStore = {
@@ -73,7 +96,7 @@
 </script>
 
 <EventList
-  roomId="room-1"
+  {roomId}
   messageStore={messageStore as never}
   {events}
   {isLoading}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListVirtualizerMock.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListVirtualizerMock.svelte
@@ -20,6 +20,10 @@
   let renderedIndex = $state<number | null>(null);
   let scrollCalls = $state(0);
   let lastAlignment = $state('');
+  let renderedItem = $derived(renderedIndex === null ? undefined : data[renderedIndex]);
+  let renderedKey = $derived(
+    (renderedItem as { key?: string } | undefined)?.key ?? renderedIndex ?? 'empty'
+  );
 
   export function scrollToIndex(index: number, options?: { align?: string }) {
     renderedIndex = index;
@@ -47,6 +51,9 @@
 <output data-testid="virtualizer-scroll-index">{renderedIndex ?? ''}</output>
 <output data-testid="virtualizer-scroll-calls">{scrollCalls}</output>
 <output data-testid="virtualizer-scroll-alignment">{lastAlignment}</output>
-{#if renderedIndex !== null && data[renderedIndex] !== undefined}
-  {@render children(data[renderedIndex])}
+<output data-testid="virtualizer-rendered-key" data-rendered-key={renderedKey}></output>
+{#if renderedItem !== undefined}
+  {#key renderedKey}
+    {@render children(renderedItem)}
+  {/key}
 {/if}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEventGroup.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEventGroup.svelte
@@ -9,10 +9,14 @@
 
   let {
     events,
-    kind
+    kind,
+    expanded,
+    onExpandedChange
   }: {
     events: RoomEventView[];
     kind: SystemGroupKind;
+    expanded: boolean;
+    onExpandedChange: (expanded: boolean) => void;
   } = $props();
 
   const actionKind = $derived.by(() => {
@@ -58,8 +62,6 @@
   const NAMES_BEFORE_TRUNCATION = 3;
   const visibleAvatars = $derived(actors.slice(0, MAX_AVATARS));
   const isTruncatable = $derived(actors.length > NAMES_BEFORE_TRUNCATION + 1);
-
-  let expanded = $state(false);
 
   const headActors = $derived(actors.slice(0, NAMES_BEFORE_TRUNCATION));
   const extraCount = $derived(Math.max(actors.length - NAMES_BEFORE_TRUNCATION, 0));
@@ -118,7 +120,7 @@
           <button
             type="button"
             class="ml-1 cursor-pointer underline decoration-dotted underline-offset-2 hover:text-text"
-            onclick={() => (expanded = false)}
+            onclick={() => onExpandedChange(false)}
           >
             {m['room.system_events.show_less']()}
           </button>
@@ -128,7 +130,7 @@
         <button
           type="button"
           class="cursor-pointer underline decoration-dotted underline-offset-2 hover:text-text"
-          onclick={() => (expanded = true)}
+          onclick={() => onExpandedChange(true)}
           >{extraCount} {m['room.system_events.other_people']({ count: extraCount })}</button
         >
         {action}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEventGroup.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEventGroup.svelte.spec.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
 import { render } from 'vitest-browser-svelte';
 import type { RoomEventView } from '$lib/render/types';
 import { RoomEventKind } from '$lib/render/eventKinds';
@@ -53,7 +54,12 @@ describe('SystemEventGroup', () => {
 
   it('separates two actors with the localized conjunction', () => {
     const { container } = render(SystemEventGroup, {
-      props: { events: systemEvents(['Alice', 'Bob']), kind: 'join' }
+      props: {
+        events: systemEvents(['Alice', 'Bob']),
+        kind: 'join',
+        expanded: false,
+        onExpandedChange: vi.fn()
+      }
     });
 
     expect(renderedCopy(container)).toBe('Alice and Bob joined the room');
@@ -61,7 +67,12 @@ describe('SystemEventGroup', () => {
 
   it('uses comma-separated formatting for three actors', () => {
     const { container } = render(SystemEventGroup, {
-      props: { events: systemEvents(['Alice', 'Bob', 'Charlie']), kind: 'join' }
+      props: {
+        events: systemEvents(['Alice', 'Bob', 'Charlie']),
+        kind: 'join',
+        expanded: false,
+        onExpandedChange: vi.fn()
+      }
     });
 
     expect(renderedCopy(container)).toBe('Alice, Bob, and Charlie joined the room');
@@ -69,7 +80,12 @@ describe('SystemEventGroup', () => {
 
   it('renders grouped leave wording', () => {
     const { container } = render(SystemEventGroup, {
-      props: { events: systemEvents(['Alice', 'Bob']), kind: 'leave' }
+      props: {
+        events: systemEvents(['Alice', 'Bob']),
+        kind: 'leave',
+        expanded: false,
+        onExpandedChange: vi.fn()
+      }
     });
 
     expect(renderedCopy(container)).toBe('Alice and Bob left the room');
@@ -79,9 +95,30 @@ describe('SystemEventGroup', () => {
     await loadLocaleMessages('de');
     setReactiveLocale('de');
     const { container } = render(SystemEventGroup, {
-      props: { events: systemEvents(['Alice', 'Bob']), kind: 'join' }
+      props: {
+        events: systemEvents(['Alice', 'Bob']),
+        kind: 'join',
+        expanded: false,
+        onExpandedChange: vi.fn()
+      }
     });
 
     expect(renderedCopy(container)).toBe('Alice und Bob sind dem Raum beigetreten');
+  });
+
+  it('reports expansion changes through its controlled interface', async () => {
+    const onExpandedChange = vi.fn();
+    const events = systemEvents(['Alice', 'Bob', 'Charlie', 'Dora', 'Eve']);
+    const rendered = render(SystemEventGroup, {
+      props: { events, kind: 'join', expanded: false, onExpandedChange }
+    });
+
+    await page.getByRole('button', { name: '2 others' }).click();
+    expect(onExpandedChange).toHaveBeenCalledExactlyOnceWith(true);
+
+    await rendered.rerender({ events, kind: 'join', expanded: true, onExpandedChange });
+    expect(renderedCopy(rendered.container)).toContain('Eve');
+    await page.getByRole('button', { name: 'show less' }).click();
+    expect(onExpandedChange).toHaveBeenLastCalledWith(false);
   });
 });


### PR DESCRIPTION
## Summary

- keep expanded grouped join/leave timeline events open across virtualizer row remounts
- reset the transient expansion state when navigating to another room
- add browser-component coverage that forces the virtual row key to change and verifies the original failure mode

## Root cause

`SystemEventGroup` owned its expanded state locally. Forward pagination can extend a grouped timeline item, changing its virtualizer key and remounting the row. The new component instance therefore returned to its default folded state even though the user had expanded the previous row.

The room-level event list now owns expansion state by constituent event ID. A reconstructed or extended group remains expanded when it overlaps an event from the previously expanded group.

## Impact

This preserves a user's temporary timeline UI choice while they return from historical content to the present. The state remains local to the current room and does not affect timeline fetching, persistence, APIs, or compatibility.

## Verification

- `mise x -- pnpm --dir apps/frontend check`
- `mise x -- pnpm --dir apps/frontend exec vitest run 'src/routes/chat/[serverId]/[roomId]/SystemEventGroup.svelte.spec.ts' 'src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts'`
- Prettier checks for all changed frontend files
- `git diff --check`

Closes #1482.
