### PR TITLE
fix(ci): time out media environment setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,7 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/setup
+        timeout-minutes: 15
         with:
           install-ffmpeg: "true"
 


### PR DESCRIPTION
## Summary

Add a 15-minute timeout to the media E2E job's environment setup step. This prevents a wedged runner or dependency installation from leaving the required check pending indefinitely and instead produces a clear, retryable CI failure. The limit matches the existing timeout used for Playwright dependency installation. Validated with `actionlint .github/workflows/ci.yml` and `git diff --check`.
