### PR TITLE
fix(frontend): enforce mono voice call audio

### DIFF
--- a/apps/frontend/src/lib/state/server/voiceCall.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/voiceCall.svelte.spec.ts
@@ -284,6 +284,20 @@ describe('VoiceCallState', () => {
     expect(calls.indexOf('setE2EEEnabled:true')).toBeLessThan(calls.indexOf('connect'));
   });
 
+  it('configures microphone capture and publication as mono', async () => {
+    const client = createVoiceCallClient();
+    const state = new VoiceCallState(client);
+
+    await state.join('wss://livekit.example.test', 'R1');
+
+    expect(lastRoomOptions?.audioCaptureDefaults).toMatchObject({
+      channelCount: { ideal: 1 }
+    });
+    expect(lastRoomOptions?.publishDefaults).toMatchObject({
+      forceStereo: false
+    });
+  });
+
   it('does not play a join sound without the participant join event', async () => {
     const client = createVoiceCallClient();
     const state = new VoiceCallState(client);

--- a/apps/frontend/src/lib/state/server/voiceCall.svelte.ts
+++ b/apps/frontend/src/lib/state/server/voiceCall.svelte.ts
@@ -386,6 +386,7 @@ export class VoiceCallState {
           worker: this.e2eeWorker
         },
         audioCaptureDefaults: {
+          channelCount: { ideal: 1 },
           autoGainControl: true,
           echoCancellation: true,
           noiseSuppression: true
@@ -395,6 +396,7 @@ export class VoiceCallState {
         },
         publishDefaults: {
           audioPreset: AudioPresets.speech,
+          forceStereo: false,
           dtx: true,
           red: true,
           simulcast: true


### PR DESCRIPTION
## Why

Voice-call participants reported speech sometimes appearing to drift into one
headphone channel. Chatto does not intentionally pan remote tracks, and
operating-system spatial audio may still be responsible, but our mono voice
contract was partly implicit: LiveKit disabled stereo by default while browser
capture was free to expose multiple microphone channels.

Making both sides explicit hardens voice publication against unusual stereo
microphone layouts without introducing a custom Web Audio pipeline or changing
receive-side playback behavior.

## What changed

- Request single-channel microphone capture for LiveKit voice calls.
- Explicitly disable stereo publication for speech tracks.
- Cover the mono capture and publication contract with a focused regression test.

Voice calls continue to use the existing speech codec settings, noise
suppression, echo cancellation, DTX, RED, and E2EE. Browsers are asked to prefer
one capture channel, and LiveKit is prevented from publishing the microphone as
stereo. There are no API, persistence, migration, security, or operational
changes.

## Test plan

- `mise x -- pnpm --dir apps/frontend exec vitest run src/lib/state/server/voiceCall.svelte.spec.ts` (28 passed)
- `mise lint-frontend` (0 Svelte errors or warnings; ESLint passed)
- Svelte autofixer on `voiceCall.svelte.ts` (no issues or suggestions)
- adversarial review of the authored diff (no findings)
- Full `mise test-frontend` remains for CI: local cold-cache runs were interrupted
  by Vite dependency-optimizer reloads and browser-harness errors before a stable
  suite result was available.

Closes #1487.
