### PR TITLE
feat(docs): publish stable and development channels

### DIFF
--- a/.github/workflows/build-docs-image.yml
+++ b/.github/workflows/build-docs-image.yml
@@ -11,8 +11,26 @@ on:
       - "pnpm-workspace.yaml"
       - "LICENSES/Apache-2.0.txt"
       - "NOTICE"
+  workflow_call:
+    inputs:
+      channel:
+        description: "Documentation channel to publish."
+        required: true
+        type: string
+      ref:
+        description: "Git ref or SHA to build."
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
+      channel:
+        description: "Documentation channel to publish."
+        required: true
+        default: dev
+        type: choice
+        options:
+          - dev
+          - stable
       ref:
         description: "Git ref or SHA to build. Defaults to the selected workflow ref."
         required: false
@@ -34,35 +52,46 @@ jobs:
 
       - name: Resolve image metadata
         id: image
+        env:
+          CHANNEL: ${{ inputs.channel || 'dev' }}
         run: |
           set -euo pipefail
 
           sha="$(git rev-parse HEAD)"
-          docs_tag="$(node --input-type=module <<'NODE'
-          import { execFileSync } from "node:child_process";
-
-          const sha = execFileSync("git", ["rev-parse", "HEAD"]).toString("utf8").trim();
-          const commitDate = execFileSync("git", ["show", "-s", "--format=%cI", "HEAD"])
-            .toString("utf8")
-            .trim();
-          const stamp = new Date(commitDate)
-            .toISOString()
-            .replace(/[-:]/g, "")
-            .replace(/\.\d{3}Z$/, "Z");
-
-          process.stdout.write(`docs-${stamp}-${sha.slice(0, 12)}`);
-          NODE
-          )"
+          case "$CHANNEL" in
+            dev)
+              docs_tag="main-$(date -u +%Y%m%dT%H%M%SZ)-${sha:0:12}"
+              docs_version="main"
+              site_url="https://dev-docs.chatto.run"
+              ;;
+            stable)
+              docs_tag="$(git describe --tags --exact-match --match 'v[0-9]*' HEAD)"
+              if [[ ! "$docs_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                echo "::error::Stable docs must be built from an exact stable vX.Y.Z tag; received ${docs_tag}."
+                exit 1
+              fi
+              docs_version="$docs_tag"
+              site_url="https://docs.chatto.run"
+              ;;
+            *)
+              echo "::error::Unknown documentation channel: ${CHANNEL}"
+              exit 1
+              ;;
+          esac
 
           echo "sha=${sha}" >> "$GITHUB_OUTPUT"
           echo "docs_tag=${docs_tag}" >> "$GITHUB_OUTPUT"
+          echo "docs_version=${docs_version}" >> "$GITHUB_OUTPUT"
+          echo "site_url=${site_url}" >> "$GITHUB_OUTPUT"
 
           {
             echo "### Docs image"
             echo
+            echo "- Channel: \`${CHANNEL}\`"
+            echo "- Version: \`${docs_version}\`"
             echo "- Commit: \`${sha}\`"
-            echo "- Image: \`ghcr.io/chattocorp/chatto-docs:${sha}\`"
-            echo "- Docs tag: \`ghcr.io/chattocorp/chatto-docs:${docs_tag}\`"
+            echo "- Image: \`ghcr.io/chattocorp/chatto-docs:${docs_tag}\`"
+            echo "- Site: \`${site_url}\`"
             echo "- Platform: \`linux/amd64\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -84,13 +113,16 @@ jobs:
           file: ./apps/docs-website/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64
-          tags: |
-            ghcr.io/chattocorp/chatto-docs:${{ steps.image.outputs.sha }}
-            ghcr.io/chattocorp/chatto-docs:${{ steps.image.outputs.docs_tag }}
+          tags: ghcr.io/chattocorp/chatto-docs:${{ steps.image.outputs.docs_tag }}
+          build-args: |
+            CHATTO_DOCS_CHANNEL=${{ inputs.channel || 'dev' }}
+            CHATTO_DOCS_VERSION=${{ steps.image.outputs.docs_version }}
+            CHATTO_DOCS_REVISION=${{ steps.image.outputs.sha }}
+            CHATTO_DOCS_SITE_URL=${{ steps.image.outputs.site_url }}
           cache-from: type=gha,scope=chatto-docs-amd64
           cache-to: type=gha,mode=max,scope=chatto-docs-amd64
           labels: |
             org.opencontainers.image.source=https://github.com/chattocorp/chatto
             org.opencontainers.image.revision=${{ steps.image.outputs.sha }}
-            org.opencontainers.image.version=${{ steps.image.outputs.docs_tag }}
+            org.opencontainers.image.version=${{ steps.image.outputs.docs_version }}
             org.opencontainers.image.licenses=Apache-2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
   release:
     # runs-on: ubicloud-standard-4
     runs-on: ubuntu-latest
+    outputs:
+      is_stable: ${{ steps.release_meta.outputs.is_stable }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -80,7 +82,9 @@ jobs:
 
           version="${GITHUB_REF_NAME#v}"
           push_latest=false
+          is_stable=false
           if [[ "$version" != *-* ]]; then
+            is_stable=true
             highest_stable="$(
               git tag --list 'v[0-9]*.[0-9]*.[0-9]*' |
                 sed 's/^v//' |
@@ -95,6 +99,7 @@ jobs:
           fi
 
           echo "push_latest=${push_latest}" >> "$GITHUB_OUTPUT"
+          echo "is_stable=${is_stable}" >> "$GITHUB_OUTPUT"
 
       - name: Setup environment
         uses: ./.github/actions/setup
@@ -273,3 +278,12 @@ jobs:
           git -C "${tap_dir}" add Formula/chatto.rb
           git -C "${tap_dir}" commit -m "chore: update chatto to v${VERSION}"
           git -C "${tap_dir}" push origin HEAD:main
+
+  publish-stable-docs:
+    needs: release
+    if: ${{ needs.release.outputs.is_stable == 'true' }}
+    uses: ./.github/workflows/build-docs-image.yml
+    with:
+      channel: stable
+      ref: ${{ github.ref }}
+    secrets: inherit

--- a/apps/docs-website/Dockerfile
+++ b/apps/docs-website/Dockerfile
@@ -10,7 +10,15 @@ RUN pnpm install --frozen-lockfile --filter docs-website...
 
 COPY apps/docs-website apps/docs-website
 WORKDIR /app/apps/docs-website
-RUN pnpm build
+ARG CHATTO_DOCS_CHANNEL=dev
+ARG CHATTO_DOCS_VERSION=main
+ARG CHATTO_DOCS_REVISION=local
+ARG CHATTO_DOCS_SITE_URL=https://dev-docs.chatto.run
+RUN CHATTO_DOCS_CHANNEL="$CHATTO_DOCS_CHANNEL" \
+    CHATTO_DOCS_VERSION="$CHATTO_DOCS_VERSION" \
+    CHATTO_DOCS_REVISION="$CHATTO_DOCS_REVISION" \
+    CHATTO_DOCS_SITE_URL="$CHATTO_DOCS_SITE_URL" \
+    pnpm build
 
 FROM nginxinc/nginx-unprivileged:1.29-alpine
 

--- a/apps/docs-website/astro.config.mjs
+++ b/apps/docs-website/astro.config.mjs
@@ -1,10 +1,11 @@
 // @ts-check
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
+import { docsSiteUrl } from "./src/docsMetadata.ts";
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://docs.chatto.run",
+  site: docsSiteUrl,
   redirects: {
     "/getting-started/overview": "/getting-started/introduction",
     "/guides/deployment-read-this-first": "/guides/deployment/read-this-first",
@@ -35,6 +36,8 @@ export default defineConfig({
       customCss: ["./src/custom.css"],
       routeMiddleware: "./src/routeData.ts",
       components: {
+        Banner: "./src/components/DocsBanner.astro",
+        SiteTitle: "./src/components/DocsSiteTitle.astro",
         SocialIcons: "./src/components/SocialIcons.astro",
       },
       social: [

--- a/apps/docs-website/src/components/DocsBanner.astro
+++ b/apps/docs-website/src/components/DocsBanner.astro
@@ -1,0 +1,83 @@
+---
+import {
+  docsChannel,
+  docsDisplayVersion,
+} from "../docsMetadata";
+---
+
+{
+  docsChannel === "dev" && (
+    <aside class="docs-banner" data-pagefind-ignore aria-label="Documentation channel">
+      <span class="channel">Development docs</span>
+      <span>
+        These docs describe unreleased changes from <code>{docsDisplayVersion}</code>.
+      </span>
+      <a href="https://docs.chatto.run">View stable docs</a>
+    </aside>
+  )
+}
+
+<style>
+  @layer starlight.core {
+    .docs-banner {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-wrap: wrap;
+      gap: 0.45rem 0.8rem;
+      padding: 0.7rem var(--sl-nav-pad-x);
+      border-block: 1px solid hsl(37, 90%, 62%);
+      background:
+        linear-gradient(90deg, hsl(43, 100%, 94%), hsl(37, 100%, 90%));
+      color: hsl(30, 62%, 22%);
+      font-size: var(--sl-text-sm);
+      line-height: 1.4;
+      text-align: center;
+      text-wrap: balance;
+    }
+
+    .channel {
+      padding: 0.12rem 0.48rem;
+      border-radius: 999px;
+      background: hsl(34, 76%, 31%);
+      color: white;
+      font-size: var(--sl-text-xs);
+      font-weight: 700;
+      letter-spacing: 0.035em;
+      text-transform: uppercase;
+    }
+
+    code {
+      padding: 0.08rem 0.3rem;
+      border: 1px solid hsl(34, 65%, 71%);
+      border-radius: 0.25rem;
+      background: hsl(42, 100%, 97%);
+      color: inherit;
+      font-size: 0.92em;
+    }
+
+    a {
+      color: inherit;
+      font-weight: 700;
+      text-decoration-thickness: 0.08em;
+      text-underline-offset: 0.18em;
+    }
+
+    :global(:root[data-theme="dark"]) .docs-banner {
+      border-block-color: hsl(36, 55%, 38%);
+      background:
+        linear-gradient(90deg, hsl(31, 38%, 15%), hsl(35, 42%, 18%));
+      color: hsl(42, 80%, 84%);
+    }
+
+    :global(:root[data-theme="dark"]) .channel {
+      background: hsl(40, 84%, 72%);
+      color: hsl(30, 60%, 14%);
+    }
+
+    :global(:root[data-theme="dark"]) code {
+      border-color: hsl(35, 38%, 34%);
+      background: hsl(30, 34%, 12%);
+    }
+  }
+</style>

--- a/apps/docs-website/src/components/DocsSiteTitle.astro
+++ b/apps/docs-website/src/components/DocsSiteTitle.astro
@@ -1,0 +1,119 @@
+---
+import { logos } from "virtual:starlight/user-images";
+import config from "virtual:starlight/user-config";
+import {
+  docsChannel,
+  docsDisplayVersion,
+  docsRevision,
+} from "../docsMetadata";
+
+const { siteTitle, siteTitleHref } = Astro.locals.starlightRoute;
+const badgeTitle =
+  docsChannel === "stable"
+    ? `Documentation for ${docsDisplayVersion}, built from commit ${docsRevision}`
+    : `Unreleased documentation built from commit ${docsRevision}`;
+---
+
+<div class="title-group">
+  <a href={siteTitleHref} class="site-title sl-flex">
+    {
+      config.logo && logos.dark && (
+        <>
+          <img
+            class:list={{ "light:sl-hidden print:hidden": !("src" in config.logo) }}
+            alt={config.logo.alt}
+            src={logos.dark.src}
+            width={logos.dark.width}
+            height={logos.dark.height}
+          />
+          {
+            !("src" in config.logo) && (
+              <img
+                class="dark:sl-hidden print:block"
+                alt={config.logo.alt}
+                src={logos.light?.src}
+                width={logos.light?.width}
+                height={logos.light?.height}
+              />
+            )
+          }
+        </>
+      )
+    }
+    <span class:list={{ "sr-only": config.logo?.replacesTitle }} translate="no">
+      {siteTitle}
+    </span>
+  </a>
+  <span class:list={["docs-version", { dev: docsChannel === "dev" }]} title={badgeTitle}>
+    {docsDisplayVersion}
+  </span>
+</div>
+
+<style>
+  @layer starlight.core {
+    .title-group {
+      display: flex;
+      align-items: center;
+      gap: 0.55rem;
+      min-width: 0;
+    }
+
+    .site-title {
+      align-items: center;
+      gap: var(--sl-nav-gap);
+      min-width: 0;
+      color: var(--sl-color-text-accent);
+      font-size: var(--sl-text-h4);
+      font-weight: 600;
+      text-decoration: none;
+      white-space: nowrap;
+    }
+
+    .site-title span {
+      overflow: hidden;
+    }
+
+    .site-title img {
+      width: auto;
+      max-width: 100%;
+      height: calc(var(--sl-nav-height) - 2 * var(--sl-nav-pad-y));
+      object-fit: contain;
+      object-position: 0 50%;
+    }
+
+    .docs-version {
+      flex: none;
+      max-width: 12rem;
+      overflow: hidden;
+      padding: 0.18rem 0.48rem;
+      border: 1px solid var(--sl-color-gray-5);
+      border-radius: 999px;
+      color: var(--sl-color-gray-2);
+      font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+      font-size: 0.68rem;
+      font-weight: 650;
+      letter-spacing: -0.015em;
+      line-height: 1.2;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .docs-version.dev {
+      border-color: hsl(35, 72%, 52%);
+      background: hsl(42, 100%, 92%);
+      color: hsl(31, 70%, 25%);
+    }
+
+    :global(:root[data-theme="dark"]) .docs-version.dev {
+      border-color: hsl(36, 52%, 42%);
+      background: hsl(33, 35%, 17%);
+      color: hsl(42, 80%, 80%);
+    }
+
+    @media (max-width: 24rem) {
+      .docs-version {
+        max-width: 7.5rem;
+      }
+    }
+  }
+</style>

--- a/apps/docs-website/src/docsMetadata.ts
+++ b/apps/docs-website/src/docsMetadata.ts
@@ -1,0 +1,36 @@
+const channels = ["stable", "dev"] as const;
+
+export type DocsChannel = (typeof channels)[number];
+
+const configuredChannel = process.env.CHATTO_DOCS_CHANNEL ?? "dev";
+
+if (!channels.includes(configuredChannel as DocsChannel)) {
+  throw new Error(
+    `CHATTO_DOCS_CHANNEL must be one of ${channels.join(", ")}; received ${configuredChannel}`,
+  );
+}
+
+export const docsChannel = configuredChannel as DocsChannel;
+export const docsVersion =
+  process.env.CHATTO_DOCS_VERSION ?? (docsChannel === "stable" ? undefined : "main");
+export const docsRevision = process.env.CHATTO_DOCS_REVISION ?? "local";
+export const docsSiteUrl =
+  process.env.CHATTO_DOCS_SITE_URL ??
+  (docsChannel === "stable"
+    ? "https://docs.chatto.run"
+    : "https://dev-docs.chatto.run");
+
+if (!docsVersion) {
+  throw new Error("CHATTO_DOCS_VERSION is required for stable documentation builds");
+}
+
+if (docsChannel === "stable" && !/^v\d+\.\d+\.\d+$/.test(docsVersion)) {
+  throw new Error(
+    `Stable CHATTO_DOCS_VERSION must be a stable Git tag such as v0.5.0; received ${docsVersion}`,
+  );
+}
+
+export const docsShortRevision =
+  docsRevision === "local" ? docsRevision : docsRevision.slice(0, 12);
+export const docsDisplayVersion =
+  docsChannel === "stable" ? docsVersion : `main@${docsShortRevision}`;

--- a/apps/docs-website/src/pages/robots.txt.ts
+++ b/apps/docs-website/src/pages/robots.txt.ts
@@ -1,0 +1,13 @@
+import type { APIRoute } from "astro";
+import { docsChannel, docsSiteUrl } from "../docsMetadata";
+
+export const GET: APIRoute = () => {
+  const body =
+    docsChannel === "stable"
+      ? `User-agent: *\nAllow: /\nSitemap: ${docsSiteUrl}/sitemap-index.xml\n`
+      : "User-agent: *\nDisallow: /\n";
+
+  return new Response(body, {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+};

--- a/apps/docs-website/src/routeData.ts
+++ b/apps/docs-website/src/routeData.ts
@@ -1,5 +1,6 @@
 import { defineRouteMiddleware } from "@astrojs/starlight/route-data";
 import type { StarlightRouteData } from "@astrojs/starlight/route-data";
+import { docsChannel } from "./docsMetadata";
 
 type Head = StarlightRouteData["head"];
 
@@ -46,4 +47,8 @@ export const onRequest = defineRouteMiddleware(({ locals, site }) => {
   upsertMeta(route.head, "name", "twitter:description", description);
   upsertMeta(route.head, "name", "twitter:image", imageUrl);
   upsertMeta(route.head, "name", "twitter:image:alt", imageAlt);
+
+  if (docsChannel === "dev") {
+    upsertMeta(route.head, "name", "robots", "noindex, nofollow");
+  }
 });

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -6,6 +6,28 @@ same `.release-please-config.json` and `.release-please-manifest.json` paths; th
 configuration committed to that branch determines whether it produces
 prereleases or stable releases.
 
+## Documentation channels
+
+The public documentation has two independently deployed channels:
+
+- `https://docs.chatto.run` serves the highest stable Chatto release.
+- `https://dev-docs.chatto.run` serves the newest documentation build from
+  `main`.
+
+Relevant pushes to `main` publish an immutable docs image tagged as
+`main-<UTC timestamp>-<short SHA>`. Flux deploys the newest sortable tag to the
+development docs site. The site identifies itself as unreleased, displays the
+source revision, and opts out of search indexing.
+
+After a stable `vX.Y.Z` release completes successfully, the release workflow
+builds the docs from that exact tag and publishes
+`ghcr.io/chattocorp/chatto-docs:vX.Y.Z`. Flux selects the highest stable SemVer
+tag for `docs.chatto.run`. Prerelease tags never update the stable docs site.
+
+Stable docs images are immutable release snapshots. Corrections to the stable
+documentation ship with the next Chatto patch release rather than replacing an
+existing `vX.Y.Z` image.
+
 ## Prereleases from main
 
 The release-please configuration on `main` uses prerelease versioning. Feature


### PR DESCRIPTION
## Summary

- publish documentation from `main` as immutable, sortable `main-<timestamp>-<sha>` images for `dev-docs.chatto.run`
- publish stable documentation as `vX.Y.Z` images only after the corresponding stable release workflow succeeds
- pass the channel, version, revision, and canonical site URL into the Astro image build
- show the documentation version on every page and add an unreleased warning banner to development builds
- prevent development docs from being indexed through page metadata and `robots.txt`
- document the stable/dev publishing model and immutable stable-docs correction policy

## Why

Documentation changes for unreleased features currently deploy directly to `docs.chatto.run`. This separates released documentation from the current `main` documentation while retaining immutable, attributable images for both channels.

The companion clusters change will add the Flux policies and route `dev-docs.chatto.run`. It should land after this PR publishes the first `main-*` image and a stable `v0.4.9` image has been seeded.

## Validation

- built the Astro site as a stable `v0.4.9` build
- built the Astro site as a development build with a full Git revision
- verified canonical URLs, version labels, development banner, `noindex`, and channel-specific `robots.txt`
- ran `actionlint` for the modified GitHub Actions workflows
- ran `git diff --check`

Visual browser QA was unavailable in the local tool session. The repository REUSE task was also blocked by the local `reuse` installation missing a supported encoding module; it did not report a source-level license violation.
