### PR TITLE
fix(security): restrict public server assets

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,5 +37,7 @@ the issue.
 Public server assets and room-scoped files use separate HTTP authorization
 boundaries even when a deployment stores their bytes in shared infrastructure.
 `/assets/server/*` serves only positively classified public avatars, branding,
-and link-preview images. Room files remain behind ticket and current-membership
+and link-preview images. New NATS public assets use the explicit `public/`
+object namespace; historical flat-key public assets remain behind durable
+compatibility classification. Room files remain behind ticket and current-membership
 checks on `/assets/files/*`; transform signatures do not replace those checks.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,3 +31,11 @@ Reports about Chatto itself, the bundled frontend, Docker images, and deployment
 examples are in scope. Reports about third-party services or user-managed
 infrastructure are only in scope when Chatto's documented configuration creates
 the issue.
+
+## Asset Isolation
+
+Public server assets and room-scoped files use separate HTTP authorization
+boundaries even when a deployment stores their bytes in shared infrastructure.
+`/assets/server/*` serves only positively classified public avatars, branding,
+and link-preview images. Room files remain behind ticket and current-membership
+checks on `/assets/files/*`; transform signatures do not replace those checks.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -112,10 +112,13 @@ authorization, live events, backup/restore, and backend tests.
 
 ## Attachment URL Authorization
 
-- `/assets/server/{assetId}` is unauthenticated and may serve only positively
+- `/assets/server/*` is unauthenticated and may serve only positively
   classified public server assets: current/historical avatars, server branding,
   and server-fetched link-preview images. Classification must happen before
   transform-signature parsing, resize-cache lookup, object reads, or transforms.
+- New NATS public objects and URLs use `public/{assetId}`. Keep canonical
+  `{assetId}` aliases and the positive compatibility classifier for historical
+  flat-key public objects; never migrate content during an unauthenticated read.
 - `SERVER_ASSETS` is a mixed store. Never treat an opaque key, missing private
   metadata, or a valid transform signature as proof that an object is public.
   Deny room-asset declarations and tombstones, `Room-Id`/`Upload-Id` metadata,

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -112,6 +112,14 @@ authorization, live events, backup/restore, and backend tests.
 
 ## Attachment URL Authorization
 
+- `/assets/server/{assetId}` is unauthenticated and may serve only positively
+  classified public server assets: current/historical avatars, server branding,
+  and server-fetched link-preview images. Classification must happen before
+  transform-signature parsing, resize-cache lookup, object reads, or transforms.
+- `SERVER_ASSETS` is a mixed store. Never treat an opaque key, missing private
+  metadata, or a valid transform signature as proof that an object is public.
+  Deny room-asset declarations and tombstones, `Room-Id`/`Upload-Id` metadata,
+  reserved namespaces, and unknown object classes with the same 404 response.
 - Stable asset URLs use `/assets/files/{assetId}` and image transform variants.
 - Browser-facing ConnectRPC attachment URL fields append a signed per-user
   `access` ticket and expose expiry in the API asset URL object.

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -4775,6 +4775,9 @@ func TestMessageServiceFetchLinkPreviewRequiresAuthMapsPreviewAndPostsToken(t *t
 	if !strings.Contains(preview.GetImageUrl(), preview.GetImageAssetId()) {
 		t.Fatalf("ImageUrl %q does not contain asset id %q", preview.GetImageUrl(), preview.GetImageAssetId())
 	}
+	if !strings.Contains(preview.GetImageUrl(), "/assets/server/"+core.PublicServerAssetObjectPrefix) {
+		t.Fatalf("ImageUrl %q does not use the public NATS namespace", preview.GetImageUrl())
+	}
 	if resp.Msg.GetPreviewToken() == "" {
 		t.Fatalf("PreviewToken is empty")
 	}

--- a/cli/internal/connectapi/link_previews.go
+++ b/cli/internal/connectapi/link_previews.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"connectrpc.com/connect"
+	"hmans.de/chatto/internal/core"
 	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
@@ -41,13 +42,15 @@ func apiLinkPreview(api *API, preview *corev1.LinkPreview) *apiv1.LinkPreview {
 	}
 
 	imageAssetID := preview.GetImageAssetId()
+	imageAssetKey := imageAssetID
 	if image := preview.GetImageAsset(); image != nil && image.GetId() != "" {
 		imageAssetID = image.GetId()
+		imageAssetKey = core.ServerAssetDeliveryKey(image)
 	}
 
 	imageURL := ""
-	if imageAssetID != "" {
-		imageURL = api.core.GetTransformedServerAssetURL(imageAssetID, 600, 314, "contain")
+	if imageAssetKey != "" {
+		imageURL = api.core.GetTransformedServerAssetURL(imageAssetKey, 600, 314, "contain")
 	}
 
 	out := &apiv1.LinkPreview{

--- a/cli/internal/core/attachments.go
+++ b/cli/internal/core/attachments.go
@@ -18,6 +18,13 @@ import (
 	"hmans.de/chatto/pkg/signedurl"
 )
 
+const (
+	// ServerAssetVisibilityHeader positively marks NATS objects that may be
+	// served by the unauthenticated public server-asset route.
+	ServerAssetVisibilityHeader = "Chatto-Asset-Visibility"
+	ServerAssetVisibilityPublic = "public"
+)
+
 // ============================================================================
 // Attachment Operations
 // ============================================================================
@@ -385,6 +392,19 @@ func attachmentFromAsset(asset *corev1.AssetRecord) *corev1.Attachment {
 // Attachment view used by API response mapping and asset URL helpers.
 func AttachmentFromAsset(asset *corev1.AssetRecord) *corev1.Attachment {
 	return attachmentFromAsset(asset)
+}
+
+func assetRecordMatchesKey(asset *corev1.AssetRecord, key string) bool {
+	if asset == nil || key == "" {
+		return false
+	}
+	if asset.GetId() == key {
+		return true
+	}
+	if stored := asset.GetNats(); stored != nil && stored.GetKey() == key {
+		return true
+	}
+	return asset.GetS3() != nil && asset.GetS3().GetKey() == key
 }
 
 func applyDeprecatedAssetFromAttachmentStorage(asset *corev1.AssetRecord, storage *corev1.DeprecatedAsset) {

--- a/cli/internal/core/attachments.go
+++ b/cli/internal/core/attachments.go
@@ -22,8 +22,10 @@ const (
 	// ServerAssetVisibilityHeader positively marks legacy flat NATS objects that
 	// may be served by the unauthenticated public server-asset route. New public
 	// objects use PublicServerAssetObjectPrefix instead.
-	ServerAssetVisibilityHeader = "Chatto-Asset-Visibility"
-	ServerAssetVisibilityPublic = "public"
+	ServerAssetVisibilityHeader       = "Chatto-Asset-Visibility"
+	ServerAssetVisibilityPublic       = "public"
+	ServerAssetVisibilityNUIDHeader   = "Chatto-Asset-Public-NUID"
+	ServerAssetVisibilityDigestHeader = "Chatto-Asset-Public-Digest"
 
 	// PublicServerAssetObjectPrefix is the explicit SERVER_ASSETS namespace for
 	// newly written unauthenticated public assets. Historical public objects use

--- a/cli/internal/core/attachments.go
+++ b/cli/internal/core/attachments.go
@@ -19,11 +19,39 @@ import (
 )
 
 const (
-	// ServerAssetVisibilityHeader positively marks NATS objects that may be
-	// served by the unauthenticated public server-asset route.
+	// ServerAssetVisibilityHeader positively marks legacy flat NATS objects that
+	// may be served by the unauthenticated public server-asset route. New public
+	// objects use PublicServerAssetObjectPrefix instead.
 	ServerAssetVisibilityHeader = "Chatto-Asset-Visibility"
 	ServerAssetVisibilityPublic = "public"
+
+	// PublicServerAssetObjectPrefix is the explicit SERVER_ASSETS namespace for
+	// newly written unauthenticated public assets. Historical public objects use
+	// flat asset-ID keys and remain available through the legacy classifier.
+	PublicServerAssetObjectPrefix = "public/"
 )
+
+// PublicServerAssetObjectKey returns the NATS object key for a new public
+// server asset while keeping its logical asset ID stable.
+func PublicServerAssetObjectKey(assetID string) string {
+	return PublicServerAssetObjectPrefix + assetID
+}
+
+// ServerAssetDeliveryKey returns the storage-aware key used in public server
+// asset URLs. New NATS assets carry their explicit public/ object key, while
+// S3 and historical records continue to use their logical asset ID.
+func ServerAssetDeliveryKey(asset *corev1.AssetRecord) string {
+	if asset == nil {
+		return ""
+	}
+	if stored := asset.GetNats(); stored != nil && stored.GetKey() != "" {
+		return stored.GetKey()
+	}
+	if stored := asset.GetS3(); stored != nil && stored.GetKey() != "" {
+		return stored.GetKey()
+	}
+	return asset.GetId()
+}
 
 // ============================================================================
 // Attachment Operations

--- a/cli/internal/core/attachments_test.go
+++ b/cli/internal/core/attachments_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/events"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
@@ -1234,5 +1235,39 @@ func TestChattoCore_DeleteCachedResizesForAttachment_EmptyCache(t *testing.T) {
 	}
 	if deleted != 0 {
 		t.Errorf("Should return 0 deleted on empty cache, got %d", deleted)
+	}
+}
+
+func TestChattoCore_PublicServerAssetLocationDoesNotFallback(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+	assetID := NewAssetID()
+	publicKey := PublicServerAssetObjectKey(assetID)
+
+	if _, err := core.storage.serverAssets.Put(ctx, jetstream.ObjectMeta{
+		Name:    publicKey,
+		Headers: map[string][]string{"Content-Type": {"image/png"}},
+	}, bytes.NewReader([]byte("public"))); err != nil {
+		t.Fatalf("store public fixture: %v", err)
+	}
+	if _, err := core.storage.serverAssets.Put(ctx, jetstream.ObjectMeta{
+		Name: assetID,
+		Headers: map[string][]string{
+			"Content-Type": {"image/png"},
+			"Room-Id":      {"Rprivate"},
+		},
+	}, bytes.NewReader([]byte("private"))); err != nil {
+		t.Fatalf("store private fallback fixture: %v", err)
+	}
+
+	location, ok := core.ResolvePublicServerAsset(ctx, assetID)
+	if !ok {
+		t.Fatal("logical ID did not resolve to namespaced public object")
+	}
+	if err := core.storage.serverAssets.Delete(ctx, publicKey); err != nil {
+		t.Fatalf("delete classified public object: %v", err)
+	}
+	if _, _, err := core.GetPublicServerAsset(ctx, location); err == nil {
+		t.Fatal("classified location fell through to a different flat object")
 	}
 }

--- a/cli/internal/core/attachments_test.go
+++ b/cli/internal/core/attachments_test.go
@@ -1271,3 +1271,39 @@ func TestChattoCore_PublicServerAssetLocationDoesNotFallback(t *testing.T) {
 		t.Fatal("classified location fell through to a different flat object")
 	}
 }
+
+func TestChattoCore_PublicServerAssetLocationRejectsReplacementGeneration(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+	assetID := NewAssetID()
+	publicKey := PublicServerAssetObjectKey(assetID)
+
+	first, err := core.storage.serverAssets.Put(ctx, jetstream.ObjectMeta{
+		Name:    publicKey,
+		Headers: map[string][]string{"Content-Type": {"image/png"}},
+	}, bytes.NewReader([]byte("public")))
+	if err != nil {
+		t.Fatalf("store public fixture: %v", err)
+	}
+	location, ok := core.ResolvePublicServerAsset(ctx, publicKey)
+	if !ok {
+		t.Fatal("public generation did not resolve")
+	}
+
+	replacement, err := core.storage.serverAssets.Put(ctx, jetstream.ObjectMeta{
+		Name: publicKey,
+		Headers: map[string][]string{
+			"Content-Type": {"image/png"},
+			"Room-Id":      {"Rprivate"},
+		},
+	}, bytes.NewReader([]byte("private")))
+	if err != nil {
+		t.Fatalf("replace public fixture: %v", err)
+	}
+	if replacement.NUID == first.NUID && replacement.Digest == first.Digest {
+		t.Fatal("replacement unexpectedly retained both generation identifiers")
+	}
+	if _, _, err := core.GetPublicServerAsset(ctx, location); err == nil {
+		t.Fatal("classified location served a replacement object generation")
+	}
+}

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -662,11 +662,11 @@ func (c *ChattoCore) storeLinkPreviewImage(ctx context.Context, assetID string, 
 		return asset, nil
 	}
 
+	objectKey := PublicServerAssetObjectKey(assetID)
 	meta := jetstream.ObjectMeta{
-		Name: assetID,
+		Name: objectKey,
 		Headers: map[string][]string{
-			"Content-Type":              {contentType},
-			ServerAssetVisibilityHeader: {ServerAssetVisibilityPublic},
+			"Content-Type": {contentType},
 		},
 	}
 	info, err := c.storage.serverAssets.Put(ctx, meta, bytes.NewReader(data))
@@ -674,7 +674,7 @@ func (c *ChattoCore) storeLinkPreviewImage(ctx context.Context, assetID string, 
 		return nil, fmt.Errorf("upload link preview image to SERVER_ASSETS: %w", err)
 	}
 	asset.Size = int64(info.Size)
-	asset.Storage = &corev1.AssetRecord_Nats{Nats: &corev1.NATSAsset{Key: assetID}}
+	asset.Storage = &corev1.AssetRecord_Nats{Nats: &corev1.NATSAsset{Key: objectKey}}
 	c.logger.Debug("Stored link preview image in SERVER_ASSETS", "asset_id", assetID, "size", len(data))
 	return asset, nil
 }
@@ -685,104 +685,187 @@ type ServerAssetInfo struct {
 	ContentType string
 }
 
-// IsReservedServerAssetKey rejects namespaces used by private or internal
-// objects before public-route transform parsing or backend probing.
-func IsReservedServerAssetKey(key string) bool {
-	key = strings.TrimSpace(key)
-	if key == "" || strings.HasPrefix(key, "/") || strings.Contains(key, "\\") {
-		return true
-	}
-	for _, segment := range strings.Split(key, "/") {
-		if segment == "" || segment == "." || segment == ".." {
-			return true
-		}
-	}
-	for _, prefix := range []string{
-		assetUploadTempObjectPrefix,
-		"attachments/",
-		"spaces/server/attachments/",
-		"spaces/DM/attachments/",
-	} {
-		if strings.HasPrefix(key, prefix) {
-			return true
-		}
-	}
-	// Every public server-asset producer, including historical migrations, uses
-	// the canonical opaque asset-ID grammar. Namespace-shaped and unknown keys
-	// are not public object classes.
-	if len(key) != idLength+1 || key[0] != 'A' {
-		return true
-	}
-	for _, ch := range key[1:] {
-		if !strings.ContainsRune(idAlphabet, ch) {
-			return true
-		}
-	}
-	return false
+// PublicServerAssetLocation binds a successful public classification to one
+// exact backend object. Its fields stay private so callers cannot manufacture
+// a location that bypasses ResolvePublicServerAsset.
+type PublicServerAssetLocation struct {
+	natsKey string
+	s3Key   string
 }
 
-// IsPublicServerAsset positively classifies an object before the public
-// /assets/server route performs cache access, content reads, or transforms.
-// SERVER_ASSETS is shared with private binaries, so absence of a private marker
-// is never enough: unknown objects fail closed.
-func (c *ChattoCore) IsPublicServerAsset(ctx context.Context, key string) bool {
-	if IsReservedServerAssetKey(key) {
-		return false
+// serverAssetRequestKey recognizes the explicit public/ namespace used by new
+// NATS objects and the flat canonical IDs used by historical NATS objects and
+// current S3 instance/ objects. Every other namespace fails closed.
+func serverAssetRequestKey(key string) (assetID string, namespaced bool, ok bool) {
+	if key == "" || key != strings.TrimSpace(key) || strings.HasPrefix(key, "/") || strings.Contains(key, "\\") {
+		return "", false, false
+	}
+	if strings.HasPrefix(key, PublicServerAssetObjectPrefix) {
+		namespaced = true
+		assetID = strings.TrimPrefix(key, PublicServerAssetObjectPrefix)
+	} else {
+		assetID = key
+	}
+	if len(assetID) != idLength+1 || assetID[0] != 'A' || strings.Contains(assetID, "/") {
+		return "", false, false
+	}
+	for _, ch := range assetID[1:] {
+		if !strings.ContainsRune(idAlphabet, ch) {
+			return "", false, false
+		}
+	}
+	return assetID, namespaced, true
+}
+
+func serverAssetNATSObjectKeys(key string) (logicalID string, namespaced bool, objectKeys []string, ok bool) {
+	logicalID, namespaced, ok = serverAssetRequestKey(key)
+	if !ok {
+		return "", false, nil, false
+	}
+	if namespaced {
+		return logicalID, true, []string{key}, true
+	}
+	return logicalID, false, []string{PublicServerAssetObjectKey(logicalID), logicalID}, true
+}
+
+// IsReservedServerAssetKey rejects private, internal, and unknown namespaces
+// before public-route transform parsing or backend probing.
+func IsReservedServerAssetKey(key string) bool {
+	_, _, ok := serverAssetRequestKey(key)
+	return !ok
+}
+
+// ResolvePublicServerAsset positively classifies an object and binds the
+// decision to one exact backend key before the public route performs cache
+// access, content reads, or transforms. Unknown objects fail closed.
+func (c *ChattoCore) ResolvePublicServerAsset(ctx context.Context, key string) (*PublicServerAssetLocation, bool) {
+	assetID, namespaced, ok := serverAssetRequestKey(key)
+	if !ok {
+		return nil, false
 	}
 
 	// Durable room-scoped declarations take precedence over every public hint,
 	// including stale metadata or a colliding current public reference.
 	if c.Assets != nil {
-		if _, declared := c.Assets.AssetCreation(key); declared {
-			return false
+		if _, declared := c.Assets.AssetCreation(assetID); declared {
+			return nil, false
 		}
-		if c.Assets.AssetDeleted(key) {
-			return false
+		if c.Assets.AssetDeleted(assetID) {
+			return nil, false
 		}
+	}
+
+	// The public/ namespace is itself the positive declaration for new NATS
+	// objects. Metadata-only inspection still rejects an object misplaced there
+	// by a private writer before any content or derivative cache is opened.
+	if namespaced {
+		info, err := c.storage.serverAssets.GetInfo(ctx, key)
+		if err != nil || info == nil || info.Headers.Get("Room-Id") != "" || info.Headers.Get("Upload-Id") != "" {
+			return nil, false
+		}
+		return &PublicServerAssetLocation{natsKey: key}, true
+	}
+
+	// Canonical-ID URLs remain aliases for new namespaced objects. This keeps
+	// stored API references and clients that retained the logical ID working.
+	if info, err := c.storage.serverAssets.GetInfo(ctx, PublicServerAssetObjectKey(assetID)); err == nil && info != nil {
+		if info.Headers.Get("Room-Id") != "" || info.Headers.Get("Upload-Id") != "" {
+			return nil, false
+		}
+		return &PublicServerAssetLocation{natsKey: PublicServerAssetObjectKey(assetID)}, true
 	}
 
 	// Object metadata is safe to inspect for classification; object content is
 	// not opened until this method has returned true.
-	if info, err := c.storage.serverAssets.GetInfo(ctx, key); err == nil && info != nil {
+	var legacyNATSExists bool
+	if info, err := c.storage.serverAssets.GetInfo(ctx, assetID); err == nil && info != nil {
+		legacyNATSExists = true
 		if info.Headers.Get("Room-Id") != "" || info.Headers.Get("Upload-Id") != "" {
-			return false
+			return nil, false
 		}
 		if info.Headers.Get(ServerAssetVisibilityHeader) == ServerAssetVisibilityPublic {
-			return true
+			return &PublicServerAssetLocation{natsKey: assetID}, true
 		}
 	}
 
 	// Historical public objects predate the explicit visibility header. Their
 	// durable/current public references provide the positive declaration.
-	if c.Users != nil && c.Users.IsPublicAvatarAsset(key) {
-		return true
-	}
+	legacyDeclaredPublic := c.Users != nil && c.Users.IsPublicAvatarAsset(assetID)
 	if c.ServerConfig != nil {
 		logo, _, _ := c.ServerConfig.ServerLogo()
 		banner, _, _ := c.ServerConfig.ServerBanner()
-		if assetRecordMatchesKey(logo, key) || assetRecordMatchesKey(banner, key) {
-			return true
+		if assetRecordMatchesKey(logo, assetID) || assetRecordMatchesKey(banner, assetID) {
+			legacyDeclaredPublic = true
 		}
 	}
-	if c.RoomTimeline != nil && c.RoomTimeline.IsPublicLinkPreviewAsset(key) {
-		return true
+	if c.RoomTimeline != nil && c.RoomTimeline.IsPublicLinkPreviewAsset(assetID) {
+		legacyDeclaredPublic = true
+	}
+	if legacyDeclaredPublic && legacyNATSExists {
+		return &PublicServerAssetLocation{natsKey: assetID}, true
 	}
 
 	// S3 server assets live exclusively below instance/. Private current and
 	// historical attachments use attachments/ or spaces/*/attachments/.
-	if c.s3Client != nil && !strings.Contains(key, "/") {
-		_, err := c.s3Client.StatObject(ctx, S3KeyServerAsset(key))
-		return err == nil
+	if c.s3Client != nil {
+		s3Key := S3KeyServerAsset(assetID)
+		if _, err := c.s3Client.StatObject(ctx, s3Key); err == nil {
+			return &PublicServerAssetLocation{s3Key: s3Key}, true
+		}
 	}
-	return false
+	return nil, false
+}
+
+// IsPublicServerAsset reports whether ResolvePublicServerAsset can bind the
+// request key to an explicitly public object. Prefer the resolver in delivery
+// paths so classification cannot fall through to a different backend object.
+func (c *ChattoCore) IsPublicServerAsset(ctx context.Context, key string) bool {
+	_, ok := c.ResolvePublicServerAsset(ctx, key)
+	return ok
+}
+
+// GetPublicServerAsset opens only the exact object previously classified by
+// ResolvePublicServerAsset. It never probes a fallback backend or key.
+func (c *ChattoCore) GetPublicServerAsset(ctx context.Context, location *PublicServerAssetLocation) (io.Reader, *ServerAssetInfo, error) {
+	if location == nil {
+		return nil, nil, jetstream.ErrObjectNotFound
+	}
+	if location.natsKey != "" {
+		obj, err := c.storage.serverAssets.Get(ctx, location.natsKey)
+		if err != nil {
+			return nil, nil, err
+		}
+		info, _ := obj.Info()
+		return obj, &ServerAssetInfo{
+			Size:        int64(info.Size),
+			ContentType: info.Headers.Get("Content-Type"),
+		}, nil
+	}
+	if location.s3Key != "" && c.s3Client != nil {
+		reader, info, err := c.s3Client.GetObject(ctx, location.s3Key)
+		if err != nil {
+			return nil, nil, err
+		}
+		return reader, &ServerAssetInfo{Size: info.Size, ContentType: info.ContentType}, nil
+	}
+	return nil, nil, jetstream.ErrObjectNotFound
 }
 
 // ServerAssetRecordFromAnyBackend builds an AssetRecord by probing the
 // server-asset backends. It is primarily for legacy ID-only server-scoped
 // assets that need to be rehydrated into richer metadata.
 func (c *ChattoCore) ServerAssetRecordFromAnyBackend(ctx context.Context, assetID, filename string) (*corev1.AssetRecord, error) {
-	obj, err := c.storage.serverAssets.Get(ctx, assetID)
-	if err == nil {
+	logicalID, namespaced, natsKeys, ok := serverAssetNATSObjectKeys(assetID)
+	if !ok {
+		return nil, jetstream.ErrObjectNotFound
+	}
+	var natsErr error
+	for _, objectKey := range natsKeys {
+		obj, err := c.storage.serverAssets.Get(ctx, objectKey)
+		if err != nil {
+			natsErr = err
+			continue
+		}
 		if closer, ok := obj.(io.Closer); ok {
 			defer closer.Close()
 		}
@@ -792,39 +875,39 @@ func (c *ChattoCore) ServerAssetRecordFromAnyBackend(ctx context.Context, assetI
 			contentType = "application/octet-stream"
 		}
 		return &corev1.AssetRecord{
-			Id:          assetID,
+			Id:          logicalID,
 			Filename:    filename,
 			ContentType: contentType,
 			Size:        int64(info.Size),
-			Storage:     &corev1.AssetRecord_Nats{Nats: &corev1.NATSAsset{Key: assetID}},
+			Storage:     &corev1.AssetRecord_Nats{Nats: &corev1.NATSAsset{Key: objectKey}},
 		}, nil
 	}
 
-	if c.s3Client != nil {
-		s3Info, s3Err := c.s3Client.StatObject(ctx, S3KeyServerAsset(assetID))
+	if c.s3Client != nil && !namespaced {
+		s3Info, s3Err := c.s3Client.StatObject(ctx, S3KeyServerAsset(logicalID))
 		if s3Err == nil {
 			contentType := s3Info.ContentType
 			if contentType == "" {
 				contentType = "application/octet-stream"
 			}
 			return &corev1.AssetRecord{
-				Id:          assetID,
+				Id:          logicalID,
 				Filename:    filename,
 				ContentType: contentType,
 				Size:        s3Info.Size,
 				Storage: &corev1.AssetRecord_S3{S3: &corev1.S3Asset{
-					Key:    assetID,
+					Key:    logicalID,
 					Bucket: proto.String(c.s3Client.Bucket()),
 				}},
 			}, nil
 		}
 		c.logger.Debug("Server asset record not found in either backend",
-			"asset_id", assetID,
-			"nats_error", err,
+			"asset_id", logicalID,
+			"nats_error", natsErr,
 			"s3_error", s3Err)
 	}
 
-	return nil, err
+	return nil, natsErr
 }
 
 // GetServerAssetFromAnyBackend retrieves a server asset by probing both NATS and S3 backends.
@@ -832,8 +915,17 @@ func (c *ChattoCore) ServerAssetRecordFromAnyBackend(ctx context.Context, assetI
 // Returns a reader for the asset content and metadata.
 // The caller is responsible for closing the reader if it implements io.Closer.
 func (c *ChattoCore) GetServerAssetFromAnyBackend(ctx context.Context, assetID string) (io.Reader, *ServerAssetInfo, error) {
-	obj, err := c.storage.serverAssets.Get(ctx, assetID)
-	if err == nil {
+	logicalID, namespaced, natsKeys, ok := serverAssetNATSObjectKeys(assetID)
+	if !ok {
+		return nil, nil, jetstream.ErrObjectNotFound
+	}
+	var natsErr error
+	for _, objectKey := range natsKeys {
+		obj, err := c.storage.serverAssets.Get(ctx, objectKey)
+		if err != nil {
+			natsErr = err
+			continue
+		}
 		info, _ := obj.Info()
 		return obj, &ServerAssetInfo{
 			Size:        int64(info.Size),
@@ -842,8 +934,8 @@ func (c *ChattoCore) GetServerAssetFromAnyBackend(ctx context.Context, assetID s
 	}
 
 	// If NATS failed and S3 is configured, try S3
-	if c.s3Client != nil {
-		s3Key := S3KeyServerAsset(assetID)
+	if c.s3Client != nil && !namespaced {
+		s3Key := S3KeyServerAsset(logicalID)
 		reader, s3Info, s3Err := c.s3Client.GetObject(ctx, s3Key)
 		if s3Err == nil {
 			return reader, &ServerAssetInfo{
@@ -853,12 +945,12 @@ func (c *ChattoCore) GetServerAssetFromAnyBackend(ctx context.Context, assetID s
 		}
 		// Log S3 error but return the original NATS error
 		c.logger.Debug("Instance asset not found in either backend",
-			"asset_id", assetID,
-			"nats_error", err,
+			"asset_id", logicalID,
+			"nats_error", natsErr,
 			"s3_error", s3Err)
 	}
 
-	return nil, nil, err
+	return nil, nil, natsErr
 }
 
 // CleanupAsset deletes an asset from the server object store.
@@ -913,7 +1005,21 @@ func (c *ChattoCore) deleteAsset(ctx context.Context, asset *corev1.DeprecatedAs
 }
 
 func (c *ChattoCore) deleteCachedResizesForServerAsset(ctx context.Context, assetID, assetType, ownerID string) {
-	deletedCount, cacheErr := c.DeleteCachedResizesForServerAsset(ctx, assetID)
+	assetKeys := []string{assetID}
+	if logicalID, namespaced, ok := serverAssetRequestKey(assetID); ok {
+		if namespaced {
+			assetKeys = append(assetKeys, logicalID)
+		} else {
+			assetKeys = append(assetKeys, PublicServerAssetObjectKey(logicalID))
+		}
+	}
+	deletedCount := 0
+	var cacheErr error
+	for _, assetKey := range assetKeys {
+		count, err := c.DeleteCachedResizesForServerAsset(ctx, assetKey)
+		deletedCount += count
+		cacheErr = errors.Join(cacheErr, err)
+	}
 	if cacheErr != nil {
 		c.logger.Warn("Failed to delete cached resizes for server asset",
 			"asset_id", assetID,

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -665,7 +665,8 @@ func (c *ChattoCore) storeLinkPreviewImage(ctx context.Context, assetID string, 
 	meta := jetstream.ObjectMeta{
 		Name: assetID,
 		Headers: map[string][]string{
-			"Content-Type": {contentType},
+			"Content-Type":              {contentType},
+			ServerAssetVisibilityHeader: {ServerAssetVisibilityPublic},
 		},
 	}
 	info, err := c.storage.serverAssets.Put(ctx, meta, bytes.NewReader(data))
@@ -682,6 +683,98 @@ func (c *ChattoCore) storeLinkPreviewImage(ctx context.Context, assetID string, 
 type ServerAssetInfo struct {
 	Size        int64
 	ContentType string
+}
+
+// IsReservedServerAssetKey rejects namespaces used by private or internal
+// objects before public-route transform parsing or backend probing.
+func IsReservedServerAssetKey(key string) bool {
+	key = strings.TrimSpace(key)
+	if key == "" || strings.HasPrefix(key, "/") || strings.Contains(key, "\\") {
+		return true
+	}
+	for _, segment := range strings.Split(key, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return true
+		}
+	}
+	for _, prefix := range []string{
+		assetUploadTempObjectPrefix,
+		"attachments/",
+		"spaces/server/attachments/",
+		"spaces/DM/attachments/",
+	} {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	// Every public server-asset producer, including historical migrations, uses
+	// the canonical opaque asset-ID grammar. Namespace-shaped and unknown keys
+	// are not public object classes.
+	if len(key) != idLength+1 || key[0] != 'A' {
+		return true
+	}
+	for _, ch := range key[1:] {
+		if !strings.ContainsRune(idAlphabet, ch) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsPublicServerAsset positively classifies an object before the public
+// /assets/server route performs cache access, content reads, or transforms.
+// SERVER_ASSETS is shared with private binaries, so absence of a private marker
+// is never enough: unknown objects fail closed.
+func (c *ChattoCore) IsPublicServerAsset(ctx context.Context, key string) bool {
+	if IsReservedServerAssetKey(key) {
+		return false
+	}
+
+	// Durable room-scoped declarations take precedence over every public hint,
+	// including stale metadata or a colliding current public reference.
+	if c.Assets != nil {
+		if _, declared := c.Assets.AssetCreation(key); declared {
+			return false
+		}
+		if c.Assets.AssetDeleted(key) {
+			return false
+		}
+	}
+
+	// Object metadata is safe to inspect for classification; object content is
+	// not opened until this method has returned true.
+	if info, err := c.storage.serverAssets.GetInfo(ctx, key); err == nil && info != nil {
+		if info.Headers.Get("Room-Id") != "" || info.Headers.Get("Upload-Id") != "" {
+			return false
+		}
+		if info.Headers.Get(ServerAssetVisibilityHeader) == ServerAssetVisibilityPublic {
+			return true
+		}
+	}
+
+	// Historical public objects predate the explicit visibility header. Their
+	// durable/current public references provide the positive declaration.
+	if c.Users != nil && c.Users.IsPublicAvatarAsset(key) {
+		return true
+	}
+	if c.ServerConfig != nil {
+		logo, _, _ := c.ServerConfig.ServerLogo()
+		banner, _, _ := c.ServerConfig.ServerBanner()
+		if assetRecordMatchesKey(logo, key) || assetRecordMatchesKey(banner, key) {
+			return true
+		}
+	}
+	if c.RoomTimeline != nil && c.RoomTimeline.IsPublicLinkPreviewAsset(key) {
+		return true
+	}
+
+	// S3 server assets live exclusively below instance/. Private current and
+	// historical attachments use attachments/ or spaces/*/attachments/.
+	if c.s3Client != nil && !strings.Contains(key, "/") {
+		_, err := c.s3Client.StatObject(ctx, S3KeyServerAsset(key))
+		return err == nil
+	}
+	return false
 }
 
 // ServerAssetRecordFromAnyBackend builds an AssetRecord by probing the

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -639,6 +639,8 @@ func (c *ChattoCore) markCachedLegacyLinkPreviewPublic(ctx context.Context, prev
 		headers = make(nats.Header)
 	}
 	headers.Set(ServerAssetVisibilityHeader, ServerAssetVisibilityPublic)
+	headers.Set(ServerAssetVisibilityNUIDHeader, info.NUID)
+	headers.Set(ServerAssetVisibilityDigestHeader, info.Digest)
 	if err := c.storage.serverAssets.UpdateMeta(ctx, assetID, jetstream.ObjectMeta{
 		Name:        assetID,
 		Description: info.Description,
@@ -646,6 +648,14 @@ func (c *ChattoCore) markCachedLegacyLinkPreviewPublic(ctx context.Context, prev
 		Metadata:    maps.Clone(info.Metadata),
 	}); err != nil {
 		return fmt.Errorf("mark legacy preview object public: %w", err)
+	}
+	updated, err := c.storage.serverAssets.GetInfo(ctx, assetID)
+	if err != nil {
+		return fmt.Errorf("verify legacy preview object metadata: %w", err)
+	}
+	if updated.Headers.Get("Room-Id") != "" || updated.Headers.Get("Upload-Id") != "" ||
+		!serverAssetVisibilityMarkerMatches(updated) {
+		return fmt.Errorf("legacy preview object generation changed during metadata update")
 	}
 	return nil
 }
@@ -747,8 +757,28 @@ type ServerAssetInfo struct {
 // exact backend object. Its fields stay private so callers cannot manufacture
 // a location that bypasses ResolvePublicServerAsset.
 type PublicServerAssetLocation struct {
-	natsKey string
-	s3Key   string
+	natsKey    string
+	natsNUID   string
+	natsDigest string
+	s3Key      string
+}
+
+func publicNATSServerAssetLocation(key string, info *jetstream.ObjectInfo) (*PublicServerAssetLocation, bool) {
+	if key == "" || info == nil || info.NUID == "" || info.Digest == "" {
+		return nil, false
+	}
+	return &PublicServerAssetLocation{
+		natsKey:    key,
+		natsNUID:   info.NUID,
+		natsDigest: info.Digest,
+	}, true
+}
+
+func serverAssetVisibilityMarkerMatches(info *jetstream.ObjectInfo) bool {
+	return info != nil && info.NUID != "" && info.Digest != "" &&
+		info.Headers.Get(ServerAssetVisibilityHeader) == ServerAssetVisibilityPublic &&
+		info.Headers.Get(ServerAssetVisibilityNUIDHeader) == info.NUID &&
+		info.Headers.Get(ServerAssetVisibilityDigestHeader) == info.Digest
 }
 
 // serverAssetRequestKey recognizes the explicit public/ namespace used by new
@@ -821,7 +851,7 @@ func (c *ChattoCore) ResolvePublicServerAsset(ctx context.Context, key string) (
 		if err != nil || info == nil || info.Headers.Get("Room-Id") != "" || info.Headers.Get("Upload-Id") != "" {
 			return nil, false
 		}
-		return &PublicServerAssetLocation{natsKey: key}, true
+		return publicNATSServerAssetLocation(key, info)
 	}
 
 	// Canonical-ID URLs remain aliases for new namespaced objects. This keeps
@@ -830,7 +860,7 @@ func (c *ChattoCore) ResolvePublicServerAsset(ctx context.Context, key string) (
 		if info.Headers.Get("Room-Id") != "" || info.Headers.Get("Upload-Id") != "" {
 			return nil, false
 		}
-		return &PublicServerAssetLocation{natsKey: PublicServerAssetObjectKey(assetID)}, true
+		return publicNATSServerAssetLocation(PublicServerAssetObjectKey(assetID), info)
 	}
 
 	// Object metadata is safe to inspect for classification; object content is
@@ -841,8 +871,8 @@ func (c *ChattoCore) ResolvePublicServerAsset(ctx context.Context, key string) (
 		if info.Headers.Get("Room-Id") != "" || info.Headers.Get("Upload-Id") != "" {
 			return nil, false
 		}
-		if info.Headers.Get(ServerAssetVisibilityHeader) == ServerAssetVisibilityPublic {
-			return &PublicServerAssetLocation{natsKey: assetID}, true
+		if serverAssetVisibilityMarkerMatches(info) {
+			return publicNATSServerAssetLocation(assetID, info)
 		}
 	}
 
@@ -860,7 +890,11 @@ func (c *ChattoCore) ResolvePublicServerAsset(ctx context.Context, key string) (
 		legacyDeclaredPublic = true
 	}
 	if legacyDeclaredPublic && legacyNATSExists {
-		return &PublicServerAssetLocation{natsKey: assetID}, true
+		info, err := c.storage.serverAssets.GetInfo(ctx, assetID)
+		if err != nil || info == nil || info.Headers.Get("Room-Id") != "" || info.Headers.Get("Upload-Id") != "" {
+			return nil, false
+		}
+		return publicNATSServerAssetLocation(assetID, info)
 	}
 
 	// S3 server assets live exclusively below instance/. Private current and
@@ -893,7 +927,11 @@ func (c *ChattoCore) GetPublicServerAsset(ctx context.Context, location *PublicS
 		if err != nil {
 			return nil, nil, err
 		}
-		info, _ := obj.Info()
+		info, err := obj.Info()
+		if err != nil || info == nil || info.NUID != location.natsNUID || info.Digest != location.natsDigest {
+			_ = obj.Close()
+			return nil, nil, jetstream.ErrObjectNotFound
+		}
 		return obj, &ServerAssetInfo{
 			Size:        int64(info.Size),
 			ContentType: info.Headers.Get("Content-Type"),

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"strings"
 	"time"
 
@@ -568,6 +569,9 @@ func (c *ChattoCore) GetLinkPreview(ctx context.Context, url string) (*corev1.Li
 		// Continue to fetch - don't fail on cache errors
 	}
 	if cached != nil {
+		if err := c.markCachedLegacyLinkPreviewPublic(ctx, cached); err != nil {
+			c.logger.Warn("Failed to preserve cached legacy link-preview image", "asset_id", cached.GetImageAssetId(), "error", err)
+		}
 		return cached, nil
 	}
 
@@ -590,6 +594,60 @@ func (c *ChattoCore) GetLinkPreview(ctx context.Context, url string) (*corev1.Li
 	}
 
 	return preview, nil
+}
+
+// markCachedLegacyLinkPreviewPublic preserves a pre-namespace link-preview
+// image that is still referenced by the server's runtime cache but has not yet
+// appeared in durable message history. The cached server-issued AssetRecord
+// must bind one exact canonical flat NATS key; private declarations and metadata
+// always win. Only object metadata is updated—the object body is never opened.
+func (c *ChattoCore) markCachedLegacyLinkPreviewPublic(ctx context.Context, preview *corev1.LinkPreview) error {
+	if preview == nil || c.Assets == nil {
+		return nil
+	}
+	asset := preview.GetImageAsset()
+	assetID := preview.GetImageAssetId()
+	if asset == nil || assetID == "" || asset.GetId() != assetID {
+		return nil
+	}
+	natsAsset := asset.GetNats()
+	if natsAsset == nil || natsAsset.GetKey() != assetID {
+		return nil
+	}
+	logicalID, namespaced, ok := serverAssetRequestKey(natsAsset.GetKey())
+	if !ok || namespaced || logicalID != assetID {
+		return nil
+	}
+	if _, declared := c.Assets.AssetCreation(assetID); declared || c.Assets.AssetDeleted(assetID) {
+		return nil
+	}
+
+	info, err := c.storage.serverAssets.GetInfo(ctx, assetID)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrObjectNotFound) {
+			return nil
+		}
+		return fmt.Errorf("inspect legacy preview object metadata: %w", err)
+	}
+	if info.Headers.Get("Room-Id") != "" || info.Headers.Get("Upload-Id") != "" ||
+		info.Headers.Get(ServerAssetVisibilityHeader) == ServerAssetVisibilityPublic {
+		return nil
+	}
+
+	headers := maps.Clone(info.Headers)
+	if headers == nil {
+		headers = make(nats.Header)
+	}
+	headers.Set(ServerAssetVisibilityHeader, ServerAssetVisibilityPublic)
+	if err := c.storage.serverAssets.UpdateMeta(ctx, assetID, jetstream.ObjectMeta{
+		Name:        assetID,
+		Description: info.Description,
+		Headers:     headers,
+		Metadata:    maps.Clone(info.Metadata),
+	}); err != nil {
+		return fmt.Errorf("mark legacy preview object public: %w", err)
+	}
+	return nil
 }
 
 // HydrateLinkPreviewImageAsset ensures a posted LinkPreview carries the

--- a/cli/internal/core/linkpreview_test.go
+++ b/cli/internal/core/linkpreview_test.go
@@ -1,16 +1,135 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/require"
 	"hmans.de/chatto/internal/core/linkpreview"
+	"hmans.de/chatto/internal/events"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
+
+func TestGetLinkPreviewPromotesCachedLegacyNATSImage(t *testing.T) {
+	ctx := context.Background()
+	core, _ := setupTestCore(t)
+	assetID := NewAssetID()
+	url := "https://legacy-preview.example/article"
+	data := []byte("legacy-preview-image")
+
+	_, err := core.storage.serverAssets.Put(ctx, jetstream.ObjectMeta{
+		Name:        assetID,
+		Description: "legacy preview",
+		Headers: map[string][]string{
+			"Content-Type":  {"image/webp"},
+			"X-Legacy-Test": {"preserved"},
+		},
+		Metadata: map[string]string{"source": "legacy-cache"},
+	}, bytes.NewReader(data))
+	require.NoError(t, err)
+	require.NoError(t, core.linkPreviewCache.Set(ctx, url, &corev1.LinkPreview{
+		Url:          url,
+		ImageAssetId: &assetID,
+		ImageAsset: &corev1.AssetRecord{
+			Id:          assetID,
+			ContentType: "image/webp",
+			Storage:     &corev1.AssetRecord_Nats{Nats: &corev1.NATSAsset{Key: assetID}},
+		},
+	}))
+
+	preview, err := core.GetLinkPreview(ctx, url)
+	require.NoError(t, err)
+	require.Equal(t, assetID, preview.GetImageAssetId())
+
+	info, err := core.storage.serverAssets.GetInfo(ctx, assetID)
+	require.NoError(t, err)
+	require.Equal(t, ServerAssetVisibilityPublic, info.Headers.Get(ServerAssetVisibilityHeader))
+	require.Equal(t, "image/webp", info.Headers.Get("Content-Type"))
+	require.Equal(t, "preserved", info.Headers.Get("X-Legacy-Test"))
+	require.Equal(t, "legacy preview", info.Description)
+	require.Equal(t, "legacy-cache", info.Metadata["source"])
+	require.True(t, core.IsPublicServerAsset(ctx, assetID))
+
+	stored, err := core.storage.serverAssets.GetBytes(ctx, assetID)
+	require.NoError(t, err)
+	require.Equal(t, data, stored)
+}
+
+func TestGetLinkPreviewDoesNotPromotePrivateCachedNATSImage(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string][]string
+		declare func(t *testing.T, core *ChattoCore, assetID string)
+	}{
+		{name: "room metadata", headers: map[string][]string{"Room-Id": {"Rprivatepreview"}}},
+		{name: "upload metadata", headers: map[string][]string{"Upload-Id": {"Uprivatepreview"}}},
+		{name: "durable declaration", declare: func(t *testing.T, core *ChattoCore, assetID string) {
+			event := newEvent(SystemActorID, &corev1.Event{
+				Event: &corev1.Event_AssetCreated{AssetCreated: &corev1.AssetCreatedEvent{
+					Asset: &corev1.AssetRecord{Id: assetID},
+				}},
+			})
+			_, err := core.AssetsProjector.AppendEventuallyAndWait(
+				testContext(t), core.EventPublisher, events.AssetAggregate(assetID), event,
+			)
+			require.NoError(t, err)
+		}},
+		{name: "durable tombstone", declare: func(t *testing.T, core *ChattoCore, assetID string) {
+			event := newEvent(SystemActorID, &corev1.Event{
+				Event: &corev1.Event_AssetDeleted{AssetDeleted: &corev1.AssetDeletedEvent{
+					AssetId: assetID,
+				}},
+			})
+			_, err := core.AssetsProjector.AppendEventuallyAndWait(
+				testContext(t), core.EventPublisher, events.AssetAggregate(assetID), event,
+			)
+			require.NoError(t, err)
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			core, _ := setupTestCore(t)
+			assetID := NewAssetID()
+			url := "https://private-preview.example/" + assetID
+			headers := map[string][]string{"Content-Type": {"image/webp"}}
+			for name, values := range test.headers {
+				headers[name] = values
+			}
+
+			_, err := core.storage.serverAssets.Put(ctx, jetstream.ObjectMeta{
+				Name:    assetID,
+				Headers: headers,
+			}, bytes.NewReader([]byte("private-image")))
+			require.NoError(t, err)
+			if test.declare != nil {
+				test.declare(t, core, assetID)
+			}
+			require.NoError(t, core.linkPreviewCache.Set(ctx, url, &corev1.LinkPreview{
+				Url:          url,
+				ImageAssetId: &assetID,
+				ImageAsset: &corev1.AssetRecord{
+					Id:      assetID,
+					Storage: &corev1.AssetRecord_Nats{Nats: &corev1.NATSAsset{Key: assetID}},
+				},
+			}))
+
+			preview, err := core.GetLinkPreview(ctx, url)
+			require.NoError(t, err)
+			require.Equal(t, assetID, preview.GetImageAssetId())
+			info, err := core.storage.serverAssets.GetInfo(ctx, assetID)
+			require.NoError(t, err)
+			require.Empty(t, info.Headers.Get(ServerAssetVisibilityHeader))
+			require.False(t, core.IsPublicServerAsset(ctx, assetID))
+		})
+	}
+}
 
 func TestLinkPreviewImageStorageAndRetrieval(t *testing.T) {
 	ctx := context.Background()

--- a/cli/internal/core/linkpreview_test.go
+++ b/cli/internal/core/linkpreview_test.go
@@ -49,6 +49,8 @@ func TestGetLinkPreviewPromotesCachedLegacyNATSImage(t *testing.T) {
 	info, err := core.storage.serverAssets.GetInfo(ctx, assetID)
 	require.NoError(t, err)
 	require.Equal(t, ServerAssetVisibilityPublic, info.Headers.Get(ServerAssetVisibilityHeader))
+	require.Equal(t, info.NUID, info.Headers.Get(ServerAssetVisibilityNUIDHeader))
+	require.Equal(t, info.Digest, info.Headers.Get(ServerAssetVisibilityDigestHeader))
 	require.Equal(t, "image/webp", info.Headers.Get("Content-Type"))
 	require.Equal(t, "preserved", info.Headers.Get("X-Legacy-Test"))
 	require.Equal(t, "legacy preview", info.Description)

--- a/cli/internal/core/linkpreview_test.go
+++ b/cli/internal/core/linkpreview_test.go
@@ -58,9 +58,11 @@ func TestLinkPreviewImageStorageAndRetrieval(t *testing.T) {
 	require.Equal(t, preview.GetImageAssetId(), preview.GetImageAsset().GetId())
 	require.Equal(t, "image/webp", preview.GetImageAsset().GetContentType())
 	require.NotNil(t, preview.GetImageAsset().GetNats(), "NATS-backed preview should carry NATS storage pointer")
-	storedInfo, err := core.storage.serverAssets.GetInfo(ctx, preview.GetImageAssetId())
+	objectKey := PublicServerAssetObjectKey(preview.GetImageAssetId())
+	require.Equal(t, objectKey, preview.GetImageAsset().GetNats().GetKey())
+	storedInfo, err := core.storage.serverAssets.GetInfo(ctx, objectKey)
 	require.NoError(t, err)
-	require.Equal(t, ServerAssetVisibilityPublic, storedInfo.Headers.Get(ServerAssetVisibilityHeader))
+	require.Empty(t, storedInfo.Headers.Get(ServerAssetVisibilityHeader), "new public namespace should not need a visibility marker")
 	require.True(t, core.IsPublicServerAsset(ctx, preview.GetImageAssetId()))
 
 	idOnlyPreview := &corev1.LinkPreview{Url: url, ImageAssetId: preview.ImageAssetId}

--- a/cli/internal/core/linkpreview_test.go
+++ b/cli/internal/core/linkpreview_test.go
@@ -58,6 +58,10 @@ func TestLinkPreviewImageStorageAndRetrieval(t *testing.T) {
 	require.Equal(t, preview.GetImageAssetId(), preview.GetImageAsset().GetId())
 	require.Equal(t, "image/webp", preview.GetImageAsset().GetContentType())
 	require.NotNil(t, preview.GetImageAsset().GetNats(), "NATS-backed preview should carry NATS storage pointer")
+	storedInfo, err := core.storage.serverAssets.GetInfo(ctx, preview.GetImageAssetId())
+	require.NoError(t, err)
+	require.Equal(t, ServerAssetVisibilityPublic, storedInfo.Headers.Get(ServerAssetVisibilityHeader))
+	require.True(t, core.IsPublicServerAsset(ctx, preview.GetImageAssetId()))
 
 	idOnlyPreview := &corev1.LinkPreview{Url: url, ImageAssetId: preview.ImageAssetId}
 	require.NoError(t, core.HydrateLinkPreviewImageAsset(ctx, idOnlyPreview))

--- a/cli/internal/core/room_timeline_assets.go
+++ b/cli/internal/core/room_timeline_assets.go
@@ -20,6 +20,10 @@ type roomTimelineAssetIndex struct {
 	assetChildren  map[string][]string
 	videoManifests map[string]*VideoAttachmentManifest
 	messageOwners  map[string]assetMessageRef
+	// publicLinkPreviewAssets remembers server-fetched preview images referenced
+	// by durable message bodies. Link-preview images are intentionally public,
+	// unlike message attachment assets tracked by messageOwners.
+	publicLinkPreviewAssets map[string]struct{}
 }
 
 // assetMessageRef is the room + message that owns an asset, captured from the
@@ -54,10 +58,11 @@ type VideoProcessingRequest struct {
 
 func newRoomTimelineAssetIndex() *roomTimelineAssetIndex {
 	return &roomTimelineAssetIndex{
-		assetCreations: make(map[string]*corev1.AssetCreatedEvent),
-		assetChildren:  make(map[string][]string),
-		videoManifests: make(map[string]*VideoAttachmentManifest),
-		messageOwners:  make(map[string]assetMessageRef),
+		assetCreations:          make(map[string]*corev1.AssetCreatedEvent),
+		assetChildren:           make(map[string][]string),
+		videoManifests:          make(map[string]*VideoAttachmentManifest),
+		messageOwners:           make(map[string]assetMessageRef),
+		publicLinkPreviewAssets: make(map[string]struct{}),
 	}
 }
 
@@ -74,6 +79,23 @@ func (idx *roomTimelineAssetIndex) rememberMessageBodyAssets(roomID, messageEven
 		}
 		idx.messageOwners[assetID] = assetMessageRef{roomID: roomID, messageEventID: messageEventID}
 	}
+	if preview := body.GetLinkPreview(); preview != nil {
+		assetID := preview.GetImageAssetId()
+		if preview.GetImageAsset() != nil && preview.GetImageAsset().GetId() != "" {
+			assetID = preview.GetImageAsset().GetId()
+		}
+		if assetID != "" {
+			idx.publicLinkPreviewAssets[assetID] = struct{}{}
+		}
+	}
+}
+
+func (idx *roomTimelineAssetIndex) isPublicLinkPreviewAsset(assetID string) bool {
+	if idx == nil || assetID == "" {
+		return false
+	}
+	_, ok := idx.publicLinkPreviewAssets[assetID]
+	return ok
 }
 
 func (idx *roomTimelineAssetIndex) applyLifecycleEvent(event *corev1.Event) {

--- a/cli/internal/core/room_timeline_projection.go
+++ b/cli/internal/core/room_timeline_projection.go
@@ -499,6 +499,15 @@ func (p *RoomTimelineProjection) CurrentRoomAttachmentMessages(roomID string) []
 	return out
 }
 
+// IsPublicLinkPreviewAsset reports whether durable message history references
+// assetID as a server-fetched link-preview image. Preview images are public
+// server assets; ordinary message attachments are deliberately excluded.
+func (p *RoomTimelineProjection) IsPublicLinkPreviewAsset(assetID string) bool {
+	p.RLock()
+	defer p.RUnlock()
+	return p.assets.isPublicLinkPreviewAsset(assetID)
+}
+
 func (p *RoomTimelineProjection) refreshAttachmentMessageLocked(roomID, eventID string, body *corev1.MessageBody) {
 	if roomID == "" || eventID == "" {
 		return

--- a/cli/internal/core/server_branding.go
+++ b/cli/internal/core/server_branding.go
@@ -84,6 +84,7 @@ func (c *ChattoCore) uploadServerAsset(ctx context.Context, webpData []byte, kin
 
 	headers := nats.Header{}
 	headers.Set("Content-Type", "image/webp")
+	headers.Set(ServerAssetVisibilityHeader, ServerAssetVisibilityPublic)
 	meta := jetstream.ObjectMeta{
 		Name:    assetID,
 		Headers: headers,

--- a/cli/internal/core/server_branding.go
+++ b/cli/internal/core/server_branding.go
@@ -84,9 +84,9 @@ func (c *ChattoCore) uploadServerAsset(ctx context.Context, webpData []byte, kin
 
 	headers := nats.Header{}
 	headers.Set("Content-Type", "image/webp")
-	headers.Set(ServerAssetVisibilityHeader, ServerAssetVisibilityPublic)
+	objectKey := PublicServerAssetObjectKey(assetID)
 	meta := jetstream.ObjectMeta{
-		Name:    assetID,
+		Name:    objectKey,
 		Headers: headers,
 	}
 	info, err := c.storage.serverAssets.Put(ctx, meta, bytes.NewReader(webpData))
@@ -95,7 +95,7 @@ func (c *ChattoCore) uploadServerAsset(ctx context.Context, webpData []byte, kin
 	}
 	c.logger.Info("Uploaded server "+kind, "asset_id", assetID, "size", info.Size)
 	asset.Size = int64(info.Size)
-	asset.Storage = &corev1.AssetRecord_Nats{Nats: &corev1.NATSAsset{Key: assetID}}
+	asset.Storage = &corev1.AssetRecord_Nats{Nats: &corev1.NATSAsset{Key: objectKey}}
 	return asset, nil
 }
 
@@ -210,17 +210,17 @@ func (c *ChattoCore) GetServerBannerURL(ctx context.Context, width, height *int,
 // serverAssetURL builds the public URL for an server-scoped asset,
 // optionally with transform parameters.
 func (c *ChattoCore) serverAssetURL(asset *corev1.AssetRecord, width, height *int, fit string) string {
-	assetID := asset.GetId()
-	if assetID == "" {
+	assetKey := ServerAssetDeliveryKey(asset)
+	if assetKey == "" {
 		return ""
 	}
 	if width != nil && height != nil {
 		if fit == "" {
 			fit = "cover"
 		}
-		return c.GetTransformedServerAssetURL(assetID, *width, *height, fit)
+		return c.GetTransformedServerAssetURL(assetKey, *width, *height, fit)
 	}
-	return c.assetURL(fmt.Sprintf("/assets/server/%s", assetID))
+	return c.assetURL(fmt.Sprintf("/assets/server/%s", assetKey))
 }
 
 // DeleteServerLogo clears the server's logo pointer and object-store asset.

--- a/cli/internal/core/server_branding_test.go
+++ b/cli/internal/core/server_branding_test.go
@@ -73,6 +73,9 @@ func TestChattoCore_DeleteServerBranding_CleansUpCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UploadServerLogo failed: %v", err)
 	}
+	if want := PublicServerAssetObjectKey(logo.GetId()); logo.GetNats().GetKey() != want {
+		t.Fatalf("logo NATS key = %q, want %q", logo.GetNats().GetKey(), want)
+	}
 	if err := core.SetServerLogo(ctx, "admin", logo); err != nil {
 		t.Fatalf("SetServerLogo failed: %v", err)
 	}

--- a/cli/internal/core/user_projection.go
+++ b/cli/internal/core/user_projection.go
@@ -675,6 +675,25 @@ func (p *UserProjection) Avatar(userID string) (*corev1.AssetRecord, bool) {
 	return proto.Clone(u.avatar).(*corev1.AssetRecord), true
 }
 
+// IsPublicAvatarAsset reports whether assetID or key is the current avatar of
+// a non-deleted user. User avatars are intentionally public server assets.
+func (p *UserProjection) IsPublicAvatarAsset(assetID string) bool {
+	p.RLock()
+	defer p.RUnlock()
+	if assetID == "" {
+		return false
+	}
+	for _, u := range p.users {
+		if u == nil || u.deleted || u.avatar == nil {
+			continue
+		}
+		if assetRecordMatchesKey(u.avatar, assetID) {
+			return true
+		}
+	}
+	return false
+}
+
 func (p *UserProjection) Preferences(userID string) (*corev1.ServerUserPreferences, bool) {
 	p.RLock()
 	defer p.RUnlock()

--- a/cli/internal/core/user_projection.go
+++ b/cli/internal/core/user_projection.go
@@ -25,6 +25,7 @@ type UserProjection struct {
 	loginIndex    map[string]string
 	emailIndex    map[string]string
 	identityIndex map[string]string
+	avatarIndex   map[string]int
 	replayGuard   projectionReplayGuard
 	dekResolver   *unwrappedDEKResolver
 	dekEvents     map[string]map[corev1.UserDEKPurpose]map[int32]*corev1.UserDEKGeneratedEvent
@@ -57,6 +58,7 @@ func newUserProjectionWithDEKResolver(dekResolver *unwrappedDEKResolver) *UserPr
 		loginIndex:    make(map[string]string),
 		emailIndex:    make(map[string]string),
 		identityIndex: make(map[string]string),
+		avatarIndex:   make(map[string]int),
 		replayGuard:   newProjectionReplayGuard(),
 		dekResolver:   dekResolver,
 		dekEvents:     make(map[string]map[corev1.UserDEKPurpose]map[int32]*corev1.UserDEKGeneratedEvent),
@@ -233,7 +235,7 @@ func (p *UserProjection) applyAvatarSet(e *corev1.UserAvatarSetEvent) {
 	if e.GetAvatar() == nil {
 		return
 	}
-	u.avatar = assetFromDeprecatedAsset(e.GetAvatar(), "avatar.webp", "image/webp")
+	p.replaceAvatarLocked(u, assetFromDeprecatedAsset(e.GetAvatar(), "avatar.webp", "image/webp"))
 }
 
 func (p *UserProjection) applyAssetCreated(e *corev1.AssetCreatedEvent) {
@@ -241,7 +243,7 @@ func (p *UserProjection) applyAssetCreated(e *corev1.AssetCreatedEvent) {
 		return
 	}
 	u := p.ensureUserLocked(e.GetUserId())
-	u.avatar = proto.Clone(e.GetAsset()).(*corev1.AssetRecord)
+	p.replaceAvatarLocked(u, proto.Clone(e.GetAsset()).(*corev1.AssetRecord))
 }
 
 func (p *UserProjection) applyAssetDeleted(e *corev1.AssetDeletedEvent) {
@@ -250,7 +252,7 @@ func (p *UserProjection) applyAssetDeleted(e *corev1.AssetDeletedEvent) {
 	}
 	for _, u := range p.users {
 		if u != nil && u.avatar != nil && u.avatar.GetId() == e.GetAssetId() {
-			u.avatar = nil
+			p.replaceAvatarLocked(u, nil)
 		}
 	}
 }
@@ -260,7 +262,7 @@ func (p *UserProjection) applyAvatarCleared(e *corev1.UserAvatarClearedEvent) {
 		return
 	}
 	u := p.ensureUserLocked(e.GetUserId())
-	u.avatar = nil
+	p.replaceAvatarLocked(u, nil)
 }
 
 func (p *UserProjection) applyVerifiedEmailAdded(eventID string, e *corev1.UserVerifiedEmailAddedEvent, envelopeCreatedAt *timestamppb.Timestamp) {
@@ -438,7 +440,7 @@ func (p *UserProjection) applyAccountDeleted(e *corev1.UserAccountDeletedEvent, 
 			delete(p.identityIndex, hash)
 		}
 	}
-	u.avatar = nil
+	p.replaceAvatarLocked(u, nil)
 	u.passwordHash = nil
 	u.passwordSetAt = time.Time{}
 	u.preferences = nil
@@ -676,22 +678,48 @@ func (p *UserProjection) Avatar(userID string) (*corev1.AssetRecord, bool) {
 }
 
 // IsPublicAvatarAsset reports whether assetID or key is the current avatar of
-// a non-deleted user. User avatars are intentionally public server assets.
+// a non-deleted user. User avatars are intentionally public server assets. The
+// replay-built index keeps this unauthenticated request-path check O(1).
 func (p *UserProjection) IsPublicAvatarAsset(assetID string) bool {
 	p.RLock()
 	defer p.RUnlock()
-	if assetID == "" {
-		return false
+	return assetID != "" && p.avatarIndex[assetID] > 0
+}
+
+func (p *UserProjection) replaceAvatarLocked(u *projectedUser, avatar *corev1.AssetRecord) {
+	if u == nil {
+		return
 	}
-	for _, u := range p.users {
-		if u == nil || u.deleted || u.avatar == nil {
-			continue
-		}
-		if assetRecordMatchesKey(u.avatar, assetID) {
-			return true
+	if p.avatarIndex == nil {
+		p.avatarIndex = make(map[string]int)
+	}
+	for key := range assetRecordKeys(u.avatar) {
+		if p.avatarIndex[key] <= 1 {
+			delete(p.avatarIndex, key)
+		} else {
+			p.avatarIndex[key]--
 		}
 	}
-	return false
+	u.avatar = avatar
+	if u.deleted {
+		return
+	}
+	for key := range assetRecordKeys(avatar) {
+		p.avatarIndex[key]++
+	}
+}
+
+func assetRecordKeys(asset *corev1.AssetRecord) map[string]struct{} {
+	keys := make(map[string]struct{}, 3)
+	if asset == nil {
+		return keys
+	}
+	for _, key := range []string{asset.GetId(), asset.GetNats().GetKey(), asset.GetS3().GetKey()} {
+		if key != "" {
+			keys[key] = struct{}{}
+		}
+	}
+	return keys
 }
 
 func (p *UserProjection) Preferences(userID string) (*corev1.ServerUserPreferences, bool) {

--- a/cli/internal/core/user_projection_test.go
+++ b/cli/internal/core/user_projection_test.go
@@ -324,3 +324,45 @@ func TestUserProjection_VerifiedEmailAvatarOIDCAndDelete(t *testing.T) {
 	_, ok = p.GetByExternalIdentity("github-main", "12345")
 	require.False(t, ok)
 }
+
+func TestUserProjection_PublicAvatarIndexTracksLifecycle(t *testing.T) {
+	p := NewUserProjection(staticProjectionKeyWrapper{}, staticProjectionDEKStore{})
+
+	legacy := &corev1.Event{Event: &corev1.Event_UserAvatarSet{UserAvatarSet: &corev1.UserAvatarSetEvent{
+		UserId: "U1",
+		Avatar: &corev1.DeprecatedAsset{Asset: &corev1.DeprecatedAsset_S3{S3: &corev1.S3Asset{Key: "legacy-avatar-key"}}},
+	}}}
+	replacement := &corev1.AssetRecord{
+		Id:      "A-replacement",
+		Storage: &corev1.AssetRecord_Nats{Nats: &corev1.NATSAsset{Key: "replacement-storage-key"}},
+	}
+
+	require.NoError(t, p.Apply(legacy, 1))
+	require.True(t, p.IsPublicAvatarAsset("legacy-avatar-key"))
+
+	require.NoError(t, p.Apply(&corev1.Event{Event: &corev1.Event_AssetCreated{AssetCreated: &corev1.AssetCreatedEvent{
+		UserId: "U1",
+		Asset:  replacement,
+	}}}, 2))
+	require.False(t, p.IsPublicAvatarAsset("legacy-avatar-key"))
+	require.True(t, p.IsPublicAvatarAsset("A-replacement"))
+	require.True(t, p.IsPublicAvatarAsset("replacement-storage-key"))
+
+	require.NoError(t, p.Apply(&corev1.Event{Event: &corev1.Event_AssetDeleted{AssetDeleted: &corev1.AssetDeletedEvent{
+		AssetId: "A-replacement",
+	}}}, 3))
+	require.False(t, p.IsPublicAvatarAsset("A-replacement"))
+	require.False(t, p.IsPublicAvatarAsset("replacement-storage-key"))
+
+	require.NoError(t, p.Apply(legacy, 4))
+	require.NoError(t, p.Apply(&corev1.Event{Event: &corev1.Event_UserAvatarCleared{UserAvatarCleared: &corev1.UserAvatarClearedEvent{
+		UserId: "U1",
+	}}}, 5))
+	require.False(t, p.IsPublicAvatarAsset("legacy-avatar-key"))
+
+	require.NoError(t, p.Apply(legacy, 6))
+	require.NoError(t, p.Apply(&corev1.Event{Event: &corev1.Event_UserAccountDeleted{UserAccountDeleted: &corev1.UserAccountDeletedEvent{
+		UserId: "U1",
+	}}}, 7))
+	require.False(t, p.IsPublicAvatarAsset("legacy-avatar-key"))
+}

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -577,6 +577,7 @@ func (c *ChattoCore) UploadUserAvatar(ctx context.Context, userID string, reader
 		// Upload to NATS ObjectStore
 		headers := nats.Header{}
 		headers.Set("Content-Type", "image/webp")
+		headers.Set(ServerAssetVisibilityHeader, ServerAssetVisibilityPublic)
 		meta := jetstream.ObjectMeta{
 			Name:    assetID,
 			Headers: headers,

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -577,9 +577,9 @@ func (c *ChattoCore) UploadUserAvatar(ctx context.Context, userID string, reader
 		// Upload to NATS ObjectStore
 		headers := nats.Header{}
 		headers.Set("Content-Type", "image/webp")
-		headers.Set(ServerAssetVisibilityHeader, ServerAssetVisibilityPublic)
+		objectKey := PublicServerAssetObjectKey(assetID)
 		meta := jetstream.ObjectMeta{
-			Name:    assetID,
+			Name:    objectKey,
 			Headers: headers,
 		}
 		info, err := c.storage.serverAssets.Put(ctx, meta, bytes.NewReader(webpData))
@@ -588,7 +588,7 @@ func (c *ChattoCore) UploadUserAvatar(ctx context.Context, userID string, reader
 		}
 		asset.Storage = &corev1.AssetRecord_Nats{
 			Nats: &corev1.NATSAsset{
-				Key: assetID,
+				Key: objectKey,
 			},
 		}
 		c.logger.Info("Uploaded avatar", "user_id", userID, "size", info.Size)
@@ -751,14 +751,8 @@ func (c *ChattoCore) GetUserAvatarURL(ctx context.Context, userID string, width,
 		return "", nil
 	}
 
-	// Get the asset ID (same format for both NATS and S3)
-	var assetID string
-	switch {
-	case avatar.GetNats() != nil:
-		assetID = avatar.GetNats().GetKey()
-	case avatar.GetS3() != nil:
-		assetID = avatar.GetS3().GetKey()
-	default:
+	assetKey := ServerAssetDeliveryKey(avatar)
+	if assetKey == "" {
 		return "", fmt.Errorf("unknown asset type")
 	}
 
@@ -767,9 +761,9 @@ func (c *ChattoCore) GetUserAvatarURL(ctx context.Context, userID string, width,
 		if fit == "" {
 			fit = "cover"
 		}
-		return c.GetTransformedServerAssetURL(assetID, *width, *height, fit), nil
+		return c.GetTransformedServerAssetURL(assetKey, *width, *height, fit), nil
 	}
-	return c.assetURL(fmt.Sprintf("/assets/server/%s", assetID)), nil
+	return c.assetURL(fmt.Sprintf("/assets/server/%s", assetKey)), nil
 }
 
 // ============================================================================

--- a/cli/internal/core/users_test.go
+++ b/cli/internal/core/users_test.go
@@ -2114,6 +2114,9 @@ func TestChattoCore_UploadUserAvatar(t *testing.T) {
 	if natsAsset.Key == "" {
 		t.Error("Expected asset key to be set")
 	}
+	if want := PublicServerAssetObjectKey(asset.GetId()); natsAsset.GetKey() != want {
+		t.Errorf("avatar NATS key = %q, want %q", natsAsset.GetKey(), want)
+	}
 }
 
 func TestChattoCore_SetUserAvatar(t *testing.T) {

--- a/cli/internal/http_server/assets.go
+++ b/cli/internal/http_server/assets.go
@@ -104,7 +104,8 @@ func (s *HTTPServer) serveServerAsset(c *gin.Context) {
 		key = path[:idx]
 		signedPath = path[idx+3:]
 	}
-	if key == "" || !s.core.IsPublicServerAsset(c.Request.Context(), key) {
+	location, public := s.core.ResolvePublicServerAsset(c.Request.Context(), key)
+	if key == "" || !public {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Asset not found"})
 		return
 	}
@@ -116,14 +117,14 @@ func (s *HTTPServer) serveServerAsset(c *gin.Context) {
 	// Check if this is a transform request: path ends with /t/{signedPath}
 	// Pattern: {key}/t/{signedPath}
 	if transformRequest {
-		s.serveTransformedServerAsset(c, key, signedPath)
+		s.serveTransformedServerAsset(c, key, signedPath, location)
 		return
 	}
 
 	s.logger.Debug("Serving server asset", "asset_id", key)
 
 	// Probe both NATS and S3 backends
-	reader, info, err := s.core.GetServerAssetFromAnyBackend(c.Request.Context(), key)
+	reader, info, err := s.core.GetPublicServerAsset(c.Request.Context(), location)
 	if err != nil {
 		s.logger.Error("Failed to get server asset", "error", err, "asset_id", key)
 		c.JSON(http.StatusNotFound, gin.H{"error": "Asset not found"})
@@ -520,8 +521,8 @@ func transformedAssetVary(public bool) string {
 // serveTransformedServerAsset serves a dynamically transformed version of an server asset.
 // URL format: /assets/server/{key}/t/{signedPath}
 // Called by serveServerAsset when it detects a transform pattern in the path.
-// Probes both NATS and S3 backends for the asset.
-func (s *HTTPServer) serveTransformedServerAsset(c *gin.Context, key, signedPath string) {
+// Opens only the backend object bound by pre-cache public classification.
+func (s *HTTPServer) serveTransformedServerAsset(c *gin.Context, key, signedPath string, location *core.PublicServerAssetLocation) {
 	s.logger.Debug("Serving transformed server asset", "asset_id", key, "signed_path", signedPath)
 
 	s.serveTransformedAsset(c, transformRequest{
@@ -531,8 +532,7 @@ func (s *HTTPServer) serveTransformedServerAsset(c *gin.Context, key, signedPath
 		CachePrefix: core.ServerAssetSignResource,
 		AssetID:     key,
 		FetchAsset: func(ctx context.Context) (io.Reader, string, error) {
-			// Probe both NATS and S3 backends
-			reader, info, err := s.core.GetServerAssetFromAnyBackend(ctx, key)
+			reader, info, err := s.core.GetPublicServerAsset(ctx, location)
 			if err != nil {
 				s.logger.Debug("Failed to fetch server asset",
 					"asset_id", key,

--- a/cli/internal/http_server/assets.go
+++ b/cli/internal/http_server/assets.go
@@ -92,23 +92,40 @@ func (s *HTTPServer) serveServerAsset(c *gin.Context) {
 		path = path[1:]
 	}
 
-	// Check if this is a transform request: path ends with /t/{signedPath}
-	// Pattern: {key}/t/{signedPath}
+	// /assets/server/* is intentionally unauthenticated and may only serve
+	// explicitly public, server-scoped assets. Classify the base key before
+	// transform signature parsing, derivative-cache access, object reads, or
+	// image transformation so shared-store private objects always look absent.
+	key := path
+	signedPath := ""
+	transformRequest := false
 	if idx := strings.LastIndex(path, "/t/"); idx != -1 {
-		key := path[:idx]
-		signedPath := path[idx+3:] // skip "/t/"
-		if key != "" && signedPath != "" {
-			s.serveTransformedServerAsset(c, key, signedPath)
-			return
-		}
+		transformRequest = true
+		key = path[:idx]
+		signedPath = path[idx+3:]
+	}
+	if key == "" || !s.core.IsPublicServerAsset(c.Request.Context(), key) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Asset not found"})
+		return
+	}
+	if transformRequest && signedPath == "" {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Asset not found"})
+		return
 	}
 
-	s.logger.Debug("Serving server asset", "asset_id", path)
+	// Check if this is a transform request: path ends with /t/{signedPath}
+	// Pattern: {key}/t/{signedPath}
+	if transformRequest {
+		s.serveTransformedServerAsset(c, key, signedPath)
+		return
+	}
+
+	s.logger.Debug("Serving server asset", "asset_id", key)
 
 	// Probe both NATS and S3 backends
-	reader, info, err := s.core.GetServerAssetFromAnyBackend(c.Request.Context(), path)
+	reader, info, err := s.core.GetServerAssetFromAnyBackend(c.Request.Context(), key)
 	if err != nil {
-		s.logger.Error("Failed to get server asset", "error", err, "asset_id", path)
+		s.logger.Error("Failed to get server asset", "error", err, "asset_id", key)
 		c.JSON(http.StatusNotFound, gin.H{"error": "Asset not found"})
 		return
 	}
@@ -120,12 +137,12 @@ func (s *HTTPServer) serveServerAsset(c *gin.Context) {
 	// Get content type, fall back to extension-based detection
 	contentType := info.ContentType
 	if contentType == "" {
-		contentType = getContentType(path)
+		contentType = getContentType(key)
 	}
 
 	// Immutable asset - cache forever
 	c.Header("Cache-Control", "public, max-age=31536000, immutable")
-	c.Header("ETag", fmt.Sprintf("\"%s\"", path))
+	c.Header("ETag", fmt.Sprintf("\"%s\"", key))
 	c.Header("Vary", "Accept-Encoding")
 
 	c.DataFromReader(

--- a/cli/internal/http_server/assets_test.go
+++ b/cli/internal/http_server/assets_test.go
@@ -25,11 +25,13 @@ import (
 	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-gonic/gin"
 	"github.com/nats-io/nats.go/jetstream"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"hmans.de/chatto/internal/assets"
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/core"
 	"hmans.de/chatto/internal/core/linkpreview"
 	"hmans.de/chatto/internal/email"
+	"hmans.de/chatto/internal/events"
 	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
 	"hmans.de/chatto/internal/pb/chatto/api/v1/apiv1connect"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
@@ -210,6 +212,54 @@ func createAssetTestPNG(t *testing.T, width, height int) []byte {
 		t.Fatalf("Failed to encode PNG: %v", err)
 	}
 	return buf.Bytes()
+}
+
+func markPublicServerAssetForTest(t *testing.T, env *assetTestEnv, assetID string) {
+	t.Helper()
+	store := env.core.ServerStore()
+	info, err := store.GetInfo(env.ctx, assetID)
+	if err != nil {
+		t.Fatalf("GetInfo public marker fixture: %v", err)
+	}
+	headers := maps.Clone(info.Headers)
+	if headers == nil {
+		headers = make(map[string][]string)
+	}
+	headers.Set(core.ServerAssetVisibilityHeader, core.ServerAssetVisibilityPublic)
+	headers.Set(core.ServerAssetVisibilityNUIDHeader, info.NUID)
+	headers.Set(core.ServerAssetVisibilityDigestHeader, info.Digest)
+	if err := store.UpdateMeta(env.ctx, assetID, jetstream.ObjectMeta{
+		Name:        assetID,
+		Description: info.Description,
+		Headers:     headers,
+		Metadata:    maps.Clone(info.Metadata),
+	}); err != nil {
+		t.Fatalf("UpdateMeta public marker fixture: %v", err)
+	}
+}
+
+func appendRoomTimelineAssetTestEvent(t *testing.T, env *assetTestEnv, roomID string, event *corev1.Event) {
+	t.Helper()
+	event.Id = core.NewEventID()
+	event.ActorId = core.SystemActorID
+	event.CreatedAt = timestamppb.Now()
+	if _, err := env.core.RoomTimelineProjector.AppendEventuallyAndWait(
+		env.ctx, env.core.EventPublisher, events.RoomAggregate(roomID), event,
+	); err != nil {
+		t.Fatalf("append room timeline fixture: %v", err)
+	}
+}
+
+func appendAssetProjectionTestEvent(t *testing.T, env *assetTestEnv, assetID string, event *corev1.Event) {
+	t.Helper()
+	event.Id = core.NewEventID()
+	event.ActorId = core.SystemActorID
+	event.CreatedAt = timestamppb.Now()
+	if _, err := env.core.AssetsProjector.AppendEventuallyAndWait(
+		env.ctx, env.core.EventPublisher, events.AssetAggregate(assetID), event,
+	); err != nil {
+		t.Fatalf("append asset fixture: %v", err)
+	}
 }
 
 func (env *assetTestEnv) postAssetMessageWithAttachment(t *testing.T, roomID, body string, fileData []byte, fileName string) (string, *apiv1.MessageAttachment) {
@@ -1196,8 +1246,7 @@ func TestAsset_LegacyFlatPublicAssetsRemainAvailable(t *testing.T) {
 
 	previewID := core.NewAssetID()
 	legacyRecord(previewID, "link-preview.webp")
-	if err := env.core.RoomTimeline.Apply(&corev1.Event{
-		Id: "Elegacynamespacepreview",
+	appendRoomTimelineAssetTestEvent(t, env, "Rlegacynamespace", &corev1.Event{
 		Event: &corev1.Event_MessageBody{MessageBody: &corev1.MessageBodyEvent{
 			RoomId:  "Rlegacynamespace",
 			EventId: "Elegacynamespacemessage",
@@ -1205,9 +1254,7 @@ func TestAsset_LegacyFlatPublicAssetsRemainAvailable(t *testing.T) {
 				ImageAssetId: &previewID,
 			}},
 		}},
-	}, 999_100); err != nil {
-		t.Fatalf("project legacy link-preview fixture: %v", err)
-	}
+	})
 	assertOK(env.core.GetTransformedServerAssetURL(previewID, 64, 64, "cover"))
 }
 
@@ -1249,15 +1296,22 @@ func TestAsset_CacheOnlyLegacyLinkPreviewRemainsAvailable(t *testing.T) {
 
 	assetPath := "/assets/server/" + assetID
 	assertStatus(assetPath, http.StatusNotFound)
-	preview, err := env.core.GetLinkPreview(env.ctx, previewURL)
+	user, err := env.core.CreateUser(env.ctx, core.SystemActorID, "legacypreviewuser", "Legacy Preview User", "password123")
 	if err != nil {
-		t.Fatalf("GetLinkPreview cached legacy preview: %v", err)
+		t.Fatalf("CreateUser legacy preview: %v", err)
 	}
+	env.login(t, user.GetLogin(), "password123")
+	messages := apiv1connect.NewMessageServiceClient(env.client, env.server.URL+connectAPIPrefix)
+	previewResp, err := messages.FetchLinkPreview(env.ctx, connect.NewRequest(&apiv1.FetchLinkPreviewRequest{Url: previewURL}))
+	if err != nil {
+		t.Fatalf("FetchLinkPreview cached legacy preview: %v", err)
+	}
+	preview := previewResp.Msg.GetPreview()
 	if preview.GetImageAssetId() != assetID {
 		t.Fatalf("cached preview asset ID = %q, want %q", preview.GetImageAssetId(), assetID)
 	}
 	assertStatus(assetPath, http.StatusOK)
-	assertStatus(env.core.GetTransformedServerAssetURL(assetID, 64, 64, "cover"), http.StatusOK)
+	assertStatus(preview.GetImageUrl(), http.StatusOK)
 
 	info, err := store.GetInfo(env.ctx, assetID)
 	if err != nil {
@@ -1336,14 +1390,11 @@ func TestAsset_PublicServerRouteRejectsPrivateAndUnknownNATSObjects(t *testing.T
 		t.Fatalf("UpdateMeta legacy fixture: %v", err)
 	}
 	assertStatus("/assets/server/"+assetID, http.StatusNotFound)
-	if err := env.core.Assets.Apply(&corev1.Event{
-		Id: "Edeletedprivate",
+	appendAssetProjectionTestEvent(t, env, assetID, &corev1.Event{
 		Event: &corev1.Event_AssetDeleted{AssetDeleted: &corev1.AssetDeletedEvent{
 			AssetId: assetID,
 		}},
-	}, 999_002); err != nil {
-		t.Fatalf("project private asset tombstone: %v", err)
-	}
+	})
 	assertStatus("/assets/server/"+assetID, http.StatusNotFound)
 
 	// Exercise the real resumable-upload producer and discover its temporary
@@ -1430,14 +1481,12 @@ func TestAsset_PublicLinkPreviewMarkerServesWithoutAuthentication(t *testing.T) 
 	}
 
 	if _, err := env.core.ServerStore().Put(env.ctx, jetstream.ObjectMeta{
-		Name: assetID,
-		Headers: map[string][]string{
-			"Content-Type":                   {"image/png"},
-			core.ServerAssetVisibilityHeader: {core.ServerAssetVisibilityPublic},
-		},
+		Name:    assetID,
+		Headers: map[string][]string{"Content-Type": {"image/png"}},
 	}, bytes.NewReader(imageData)); err != nil {
 		t.Fatalf("store marked link-preview image: %v", err)
 	}
+	markPublicServerAssetForTest(t, env, assetID)
 
 	resp, err := (&http.Client{}).Get(env.server.URL + "/assets/server/" + assetID)
 	if err != nil {
@@ -1457,8 +1506,7 @@ func TestAsset_PublicLinkPreviewMarkerServesWithoutAuthentication(t *testing.T) 
 	}, bytes.NewReader(imageData)); err != nil {
 		t.Fatalf("store historical link-preview image: %v", err)
 	}
-	if err := env.core.RoomTimeline.Apply(&corev1.Event{
-		Id: "Epreviewhistory",
+	appendRoomTimelineAssetTestEvent(t, env, "Rpreviewhistory", &corev1.Event{
 		Event: &corev1.Event_MessageBody{MessageBody: &corev1.MessageBodyEvent{
 			RoomId:  "Rpreviewhistory",
 			EventId: "Epreviewmessage",
@@ -1467,9 +1515,7 @@ func TestAsset_PublicLinkPreviewMarkerServesWithoutAuthentication(t *testing.T) 
 				ImageAsset:   &corev1.AssetRecord{Id: legacyID},
 			}},
 		}},
-	}, 999_001); err != nil {
-		t.Fatalf("project historical link-preview reference: %v", err)
-	}
+	})
 	legacyResp, err := (&http.Client{}).Get(env.server.URL + "/assets/server/" + legacyID)
 	if err != nil {
 		t.Fatalf("GET historical link-preview image: %v", err)

--- a/cli/internal/http_server/assets_test.go
+++ b/cli/internal/http_server/assets_test.go
@@ -1026,7 +1026,16 @@ func TestAsset_ServerAsset_HasCacheHeaders(t *testing.T) {
 	if err := env.core.SetUserAvatar(env.ctx, user.Id, avatar); err != nil {
 		t.Fatalf("Failed to set avatar: %v", err)
 	}
-	avatarPath := avatar.GetId()
+	avatarPath := core.ServerAssetDeliveryKey(avatar)
+	if !strings.HasPrefix(avatarPath, core.PublicServerAssetObjectPrefix) {
+		t.Fatalf("new NATS avatar key = %q, want public namespace", avatarPath)
+	}
+	if _, err := env.core.ServerStore().GetInfo(env.ctx, avatarPath); err != nil {
+		t.Fatalf("new NATS avatar object %q: %v", avatarPath, err)
+	}
+	if _, err := env.core.ServerStore().GetInfo(env.ctx, avatar.GetId()); err == nil {
+		t.Fatalf("new NATS avatar unexpectedly retained flat object %q", avatar.GetId())
+	}
 
 	// Get the server asset (avatars are public, no auth needed)
 	resp, err := env.client.Get(env.server.URL + "/assets/server/" + avatarPath)
@@ -1037,6 +1046,14 @@ func TestAsset_ServerAsset_HasCacheHeaders(t *testing.T) {
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("Expected 200 OK, got %d", resp.StatusCode)
+	}
+	aliasResp, err := env.client.Get(env.server.URL + "/assets/server/" + avatar.GetId())
+	if err != nil {
+		t.Fatalf("Failed to get new server asset through logical-ID alias: %v", err)
+	}
+	aliasResp.Body.Close()
+	if aliasResp.StatusCode != http.StatusOK {
+		t.Fatalf("logical-ID alias status = %d, want 200", aliasResp.StatusCode)
 	}
 
 	// Verify caching headers
@@ -1072,7 +1089,10 @@ func TestAsset_ServerAssetTransformKeepsDefaultQuality(t *testing.T) {
 	if err := env.core.SetServerBanner(env.ctx, "system", branding); err != nil {
 		t.Fatalf("Failed to set server branding: %v", err)
 	}
-	assetPath := branding.GetId()
+	assetPath := core.ServerAssetDeliveryKey(branding)
+	if !strings.HasPrefix(assetPath, core.PublicServerAssetObjectPrefix) {
+		t.Fatalf("new NATS branding key = %q, want public namespace", assetPath)
+	}
 
 	transformURL := env.core.GetTransformedServerAssetURL(assetPath, 200, 200, "contain")
 	resp, err := env.client.Get(env.server.URL + transformURL)
@@ -1099,6 +1119,85 @@ func TestAsset_ServerAssetTransformKeepsDefaultQuality(t *testing.T) {
 	if !bytes.Equal(got, want) {
 		t.Fatal("server asset transform did not retain the default image quality")
 	}
+}
+
+func TestAsset_LegacyFlatPublicAssetsRemainAvailable(t *testing.T) {
+	env := setupAssetTestServer(t)
+	imageData := createAssetTestPNG(t, 120, 80)
+	store := env.core.ServerStore()
+
+	legacyRecord := func(assetID, filename string) *corev1.AssetRecord {
+		if _, err := store.Put(env.ctx, jetstream.ObjectMeta{
+			Name:    assetID,
+			Headers: map[string][]string{"Content-Type": {"image/png"}},
+		}, bytes.NewReader(imageData)); err != nil {
+			t.Fatalf("store legacy public object %q: %v", assetID, err)
+		}
+		return &corev1.AssetRecord{
+			Id:          assetID,
+			Filename:    filename,
+			ContentType: "image/png",
+			Size:        int64(len(imageData)),
+			Storage:     &corev1.AssetRecord_Nats{Nats: &corev1.NATSAsset{Key: assetID}},
+		}
+	}
+	assertOK := func(path string) {
+		t.Helper()
+		resp, err := (&http.Client{}).Get(env.server.URL + path)
+		if err != nil {
+			t.Fatalf("GET %q: %v", path, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET %q status = %d, want 200", path, resp.StatusCode)
+		}
+	}
+
+	user, err := env.core.CreateUser(env.ctx, "system", "legacyassetuser", "Legacy Asset User", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	avatar := legacyRecord(core.NewAssetID(), "avatar.webp")
+	if err := env.core.SetUserAvatar(env.ctx, user.GetId(), avatar); err != nil {
+		t.Fatalf("SetUserAvatar legacy fixture: %v", err)
+	}
+	avatarURL, err := env.core.GetUserAvatarURL(env.ctx, user.GetId(), nil, nil, "")
+	if err != nil {
+		t.Fatalf("GetUserAvatarURL: %v", err)
+	}
+	if strings.Contains(avatarURL, core.PublicServerAssetObjectPrefix) {
+		t.Fatalf("legacy avatar URL unexpectedly changed: %q", avatarURL)
+	}
+	assertOK(avatarURL)
+
+	logo := legacyRecord(core.NewAssetID(), "logo.webp")
+	if err := env.core.SetServerLogo(env.ctx, "system", logo); err != nil {
+		t.Fatalf("SetServerLogo legacy fixture: %v", err)
+	}
+	logoURL, err := env.core.GetServerLogoURL(env.ctx, nil, nil, "")
+	if err != nil {
+		t.Fatalf("GetServerLogoURL: %v", err)
+	}
+	if strings.Contains(logoURL, core.PublicServerAssetObjectPrefix) {
+		t.Fatalf("legacy logo URL unexpectedly changed: %q", logoURL)
+	}
+	assertOK(logoURL)
+
+	previewID := core.NewAssetID()
+	legacyRecord(previewID, "link-preview.webp")
+	if err := env.core.RoomTimeline.Apply(&corev1.Event{
+		Id: "Elegacynamespacepreview",
+		Event: &corev1.Event_MessageBody{MessageBody: &corev1.MessageBodyEvent{
+			RoomId:  "Rlegacynamespace",
+			EventId: "Elegacynamespacemessage",
+			Body: &corev1.MessageBody{LinkPreview: &corev1.LinkPreview{
+				ImageAssetId: &previewID,
+			}},
+		}},
+	}, 999_100); err != nil {
+		t.Fatalf("project legacy link-preview fixture: %v", err)
+	}
+	assertOK(env.core.GetTransformedServerAssetURL(previewID, 64, 64, "cover"))
 }
 
 func TestAsset_PublicServerRouteRejectsPrivateAndUnknownNATSObjects(t *testing.T) {
@@ -1227,6 +1326,7 @@ func TestAsset_PublicServerRouteRejectsPrivateAndUnknownNATSObjects(t *testing.T
 		{key: "attachments/" + assetID},
 		{key: "spaces/server/attachments/" + assetID},
 		{key: "Aroommetadata00", headers: map[string][]string{"Room-Id": {room.Id}}},
+		{key: core.PublicServerAssetObjectKey("Aprivatepublic0"), headers: map[string][]string{"Room-Id": {room.Id}}},
 		{key: "Aunknownobject0"},
 	}
 	for _, fixture := range fixtures {
@@ -1242,6 +1342,25 @@ func TestAsset_PublicLinkPreviewMarkerServesWithoutAuthentication(t *testing.T) 
 	env := setupAssetTestServer(t)
 	assetID := core.NewAssetID()
 	imageData := createAssetTestPNG(t, 120, 80)
+	namespacedID := core.NewAssetID()
+	namespacedKey := core.PublicServerAssetObjectKey(namespacedID)
+	if _, err := env.core.ServerStore().Put(env.ctx, jetstream.ObjectMeta{
+		Name:    namespacedKey,
+		Headers: map[string][]string{"Content-Type": {"image/png"}},
+	}, bytes.NewReader(imageData)); err != nil {
+		t.Fatalf("store namespaced public image: %v", err)
+	}
+	for _, path := range []string{namespacedKey, namespacedID} {
+		resp, err := (&http.Client{}).Get(env.server.URL + "/assets/server/" + path)
+		if err != nil {
+			t.Fatalf("GET namespaced public image through %q: %v", path, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("namespaced public image through %q status = %d, want 200", path, resp.StatusCode)
+		}
+	}
+
 	if _, err := env.core.ServerStore().Put(env.ctx, jetstream.ObjectMeta{
 		Name: assetID,
 		Headers: map[string][]string{

--- a/cli/internal/http_server/assets_test.go
+++ b/cli/internal/http_server/assets_test.go
@@ -10,6 +10,7 @@ import (
 	"image/color"
 	"image/png"
 	"io"
+	"maps"
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
@@ -23,6 +24,7 @@ import (
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-gonic/gin"
+	"github.com/nats-io/nats.go/jetstream"
 	"hmans.de/chatto/internal/assets"
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/core"
@@ -1015,15 +1017,16 @@ func TestAsset_ServerAsset_HasCacheHeaders(t *testing.T) {
 		t.Fatalf("Failed to create user: %v", err)
 	}
 
-	// Upload an avatar for the user
+	// Upload and durably select an avatar through the production public producer.
 	avatarData := createAssetTestPNG(t, 200, 200)
-	avatarPath := fmt.Sprintf("avatar/%s.png", user.Id)
-
-	store := env.core.ServerStore()
-	_, err = store.PutBytes(env.ctx, avatarPath, avatarData)
+	avatar, err := env.core.UploadUserAvatar(env.ctx, user.Id, bytes.NewReader(avatarData))
 	if err != nil {
 		t.Fatalf("Failed to upload avatar: %v", err)
 	}
+	if err := env.core.SetUserAvatar(env.ctx, user.Id, avatar); err != nil {
+		t.Fatalf("Failed to set avatar: %v", err)
+	}
+	avatarPath := avatar.GetId()
 
 	// Get the server asset (avatars are public, no auth needed)
 	resp, err := env.client.Get(env.server.URL + "/assets/server/" + avatarPath)
@@ -1062,10 +1065,14 @@ func TestAsset_ServerAssetTransformKeepsDefaultQuality(t *testing.T) {
 	env := setupAssetTestServer(t)
 
 	imageData := createAssetTestPNG(t, 400, 300)
-	assetPath := "branding/default-quality.png"
-	if _, err := env.core.ServerStore().PutBytes(env.ctx, assetPath, imageData); err != nil {
-		t.Fatalf("Failed to store server asset: %v", err)
+	branding, err := env.core.UploadServerBanner(env.ctx, bytes.NewReader(imageData))
+	if err != nil {
+		t.Fatalf("Failed to upload server branding: %v", err)
 	}
+	if err := env.core.SetServerBanner(env.ctx, "system", branding); err != nil {
+		t.Fatalf("Failed to set server branding: %v", err)
+	}
+	assetPath := branding.GetId()
 
 	transformURL := env.core.GetTransformedServerAssetURL(assetPath, 200, 200, "contain")
 	resp, err := env.client.Get(env.server.URL + transformURL)
@@ -1091,6 +1098,198 @@ func TestAsset_ServerAssetTransformKeepsDefaultQuality(t *testing.T) {
 	}
 	if !bytes.Equal(got, want) {
 		t.Fatal("server asset transform did not retain the default image quality")
+	}
+}
+
+func TestAsset_PublicServerRouteRejectsPrivateAndUnknownNATSObjects(t *testing.T) {
+	env := setupAssetTestServer(t)
+
+	user, err := env.core.CreateUser(env.ctx, "system", "publicrouteuser", "Public Route User", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	room, err := env.core.CreateRoom(env.ctx, user.Id, "channel", "", "public-route-private", "Private Assets")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	if _, err := env.core.JoinRoom(env.ctx, user.Id, "channel", user.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom: %v", err)
+	}
+	env.login(t, "publicrouteuser", "password123")
+
+	imageData := createAssetTestPNG(t, 320, 240)
+	_, attachment := env.postAssetMessageWithAttachment(t, room.Id, "private image", imageData, "private.png")
+	assetID := attachment.GetId()
+	if assetID == "" {
+		t.Fatal("attachment asset id is empty")
+	}
+
+	assertStatus := func(path string, want int) *http.Response {
+		t.Helper()
+		resp, err := (&http.Client{}).Get(env.server.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != want {
+			t.Fatalf("GET %s status = %d, want %d", path, resp.StatusCode, want)
+		}
+		return resp
+	}
+
+	// The public original and transform routes must not expose a declared room
+	// attachment, while its ticketed protected route remains usable.
+	assertStatus("/assets/server/"+assetID, http.StatusNotFound)
+	privateTransform := env.core.GetTransformedServerAssetURL(assetID, 64, 64, "cover")
+	assertStatus(privateTransform, http.StatusNotFound)
+	assertStatus("/assets/server/"+assetID+"/t/not-a-valid-signature", http.StatusNotFound)
+	assertStatus(attachment.GetAssetUrl().GetUrl(), http.StatusOK)
+	assertStatus(attachment.GetThumbnailAssetUrl().GetUrl(), http.StatusOK)
+
+	// A pre-populated public-transform cache entry cannot bypass classification.
+	cacheKey := core.ImageCacheKey(core.ServerAssetSignResource, assetID, 64, 64, "cover")
+	if err := env.core.StoreCachedResize(env.ctx, cacheKey, createAssetTestPNG(t, 64, 64)); err != nil {
+		t.Fatalf("seed private server-transform cache: %v", err)
+	}
+	resp := assertStatus(privateTransform, http.StatusNotFound)
+	if got := resp.Header.Get("X-Cache"); got != "" {
+		t.Fatalf("private transform exposed cache state %q", got)
+	}
+
+	// Model a supported legacy attachment whose object lacks modern Room-Id
+	// metadata. Its durable AssetProjection declaration must still deny it.
+	store := env.core.ServerStore()
+	info, err := store.GetInfo(env.ctx, assetID)
+	if err != nil {
+		t.Fatalf("GetInfo legacy fixture: %v", err)
+	}
+	headers := maps.Clone(info.Headers)
+	headers.Del("Room-Id")
+	if err := store.UpdateMeta(env.ctx, assetID, jetstream.ObjectMeta{Name: assetID, Headers: headers}); err != nil {
+		t.Fatalf("UpdateMeta legacy fixture: %v", err)
+	}
+	assertStatus("/assets/server/"+assetID, http.StatusNotFound)
+	if err := env.core.Assets.Apply(&corev1.Event{
+		Id: "Edeletedprivate",
+		Event: &corev1.Event_AssetDeleted{AssetDeleted: &corev1.AssetDeletedEvent{
+			AssetId: assetID,
+		}},
+	}, 999_002); err != nil {
+		t.Fatalf("project private asset tombstone: %v", err)
+	}
+	assertStatus("/assets/server/"+assetID, http.StatusNotFound)
+
+	// Exercise the real resumable-upload producer and discover its temporary
+	// object key without completing (and therefore deleting) the upload.
+	uploadClient := apiv1connect.NewAssetUploadServiceClient(env.client, env.server.URL+connectAPIPrefix)
+	chunkData := []byte("private resumable chunk")
+	chunkSum := sha256.Sum256(chunkData)
+	createdUpload, err := uploadClient.CreateUpload(env.ctx, connect.NewRequest(&apiv1.CreateUploadRequest{
+		RoomId:      room.Id,
+		Filename:    "pending.txt",
+		ContentType: "text/plain",
+		Size:        int64(len(chunkData)),
+		Sha256:      hex.EncodeToString(chunkSum[:]),
+	}))
+	if err != nil {
+		t.Fatalf("create resumable upload fixture: %v", err)
+	}
+	if _, err := uploadClient.UploadChunk(env.ctx, connect.NewRequest(&apiv1.UploadChunkRequest{
+		UploadId:    createdUpload.Msg.GetUpload().GetUploadId(),
+		Content:     chunkData,
+		ChunkSha256: hex.EncodeToString(chunkSum[:]),
+	})); err != nil {
+		t.Fatalf("upload resumable chunk fixture: %v", err)
+	}
+	objects, err := store.List(env.ctx)
+	if err != nil {
+		t.Fatalf("list upload chunk fixture: %v", err)
+	}
+	chunkKey := ""
+	for _, object := range objects {
+		if object != nil && strings.HasPrefix(object.Name, "asset-upload."+createdUpload.Msg.GetUpload().GetUploadId()+".") {
+			chunkKey = object.Name
+			break
+		}
+	}
+	if chunkKey == "" {
+		t.Fatal("resumable upload chunk object was not found")
+	}
+	assertStatus("/assets/server/"+chunkKey, http.StatusNotFound)
+	assertStatus(env.core.GetTransformedServerAssetURL(chunkKey, 32, 32, "cover"), http.StatusNotFound)
+
+	// Temporary, reserved, private-metadata, and unknown canonical objects all
+	// look absent through both original and transformed public paths.
+	fixtures := []struct {
+		key     string
+		headers map[string][]string
+	}{
+		{key: "attachments/" + assetID},
+		{key: "spaces/server/attachments/" + assetID},
+		{key: "Aroommetadata00", headers: map[string][]string{"Room-Id": {room.Id}}},
+		{key: "Aunknownobject0"},
+	}
+	for _, fixture := range fixtures {
+		if _, err := store.Put(env.ctx, jetstream.ObjectMeta{Name: fixture.key, Headers: fixture.headers}, bytes.NewReader(imageData)); err != nil {
+			t.Fatalf("store fixture %q: %v", fixture.key, err)
+		}
+		assertStatus("/assets/server/"+fixture.key, http.StatusNotFound)
+		assertStatus(env.core.GetTransformedServerAssetURL(fixture.key, 32, 32, "cover"), http.StatusNotFound)
+	}
+}
+
+func TestAsset_PublicLinkPreviewMarkerServesWithoutAuthentication(t *testing.T) {
+	env := setupAssetTestServer(t)
+	assetID := core.NewAssetID()
+	imageData := createAssetTestPNG(t, 120, 80)
+	if _, err := env.core.ServerStore().Put(env.ctx, jetstream.ObjectMeta{
+		Name: assetID,
+		Headers: map[string][]string{
+			"Content-Type":                   {"image/png"},
+			core.ServerAssetVisibilityHeader: {core.ServerAssetVisibilityPublic},
+		},
+	}, bytes.NewReader(imageData)); err != nil {
+		t.Fatalf("store marked link-preview image: %v", err)
+	}
+
+	resp, err := (&http.Client{}).Get(env.server.URL + "/assets/server/" + assetID)
+	if err != nil {
+		t.Fatalf("GET public link-preview image: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("public link-preview status = %d, want 200", resp.StatusCode)
+	}
+
+	// Historical preview objects did not carry the marker. Durable message-body
+	// references rebuild the positive public declaration during projection replay.
+	legacyID := core.NewAssetID()
+	if _, err := env.core.ServerStore().Put(env.ctx, jetstream.ObjectMeta{
+		Name:    legacyID,
+		Headers: map[string][]string{"Content-Type": {"image/png"}},
+	}, bytes.NewReader(imageData)); err != nil {
+		t.Fatalf("store historical link-preview image: %v", err)
+	}
+	if err := env.core.RoomTimeline.Apply(&corev1.Event{
+		Id: "Epreviewhistory",
+		Event: &corev1.Event_MessageBody{MessageBody: &corev1.MessageBodyEvent{
+			RoomId:  "Rpreviewhistory",
+			EventId: "Epreviewmessage",
+			Body: &corev1.MessageBody{LinkPreview: &corev1.LinkPreview{
+				ImageAssetId: &legacyID,
+				ImageAsset:   &corev1.AssetRecord{Id: legacyID},
+			}},
+		}},
+	}, 999_001); err != nil {
+		t.Fatalf("project historical link-preview reference: %v", err)
+	}
+	legacyResp, err := (&http.Client{}).Get(env.server.URL + "/assets/server/" + legacyID)
+	if err != nil {
+		t.Fatalf("GET historical link-preview image: %v", err)
+	}
+	legacyResp.Body.Close()
+	if legacyResp.StatusCode != http.StatusOK {
+		t.Fatalf("historical link-preview status = %d, want 200", legacyResp.StatusCode)
 	}
 }
 
@@ -1217,6 +1416,26 @@ func TestAsset_StableURLOnS3IsCapability(t *testing.T) {
 	if transformResp.StatusCode != http.StatusOK {
 		t.Errorf("S3 transform URL: expected 200 with access ticket, got %d", transformResp.StatusCode)
 	}
+
+	// The public server route probes only the separate instance/ namespace and
+	// must never fall through to S3 attachments/ objects.
+	publicOriginal, err := unauthClient.Get(env.server.URL + "/assets/server/" + attachment.GetId())
+	if err != nil {
+		t.Fatalf("S3 public original probe: %v", err)
+	}
+	publicOriginal.Body.Close()
+	if publicOriginal.StatusCode != http.StatusNotFound {
+		t.Fatalf("S3 public original probe status = %d, want 404", publicOriginal.StatusCode)
+	}
+	publicTransformURL := env.core.GetTransformedServerAssetURL(attachment.GetId(), 64, 64, "cover")
+	publicTransform, err := unauthClient.Get(env.server.URL + publicTransformURL)
+	if err != nil {
+		t.Fatalf("S3 public transform probe: %v", err)
+	}
+	publicTransform.Body.Close()
+	if publicTransform.StatusCode != http.StatusNotFound {
+		t.Fatalf("S3 public transform probe status = %d, want 404", publicTransform.StatusCode)
+	}
 }
 
 // TestAsset_RevokedMembership_RevokesStableURL covers the "kick / leave"
@@ -1240,6 +1459,7 @@ func TestAsset_RevokedMembership_RevokesStableURL(t *testing.T) {
 	imageData := createAssetTestPNG(t, 400, 300)
 	_, attachment := env.postAssetMessageWithAttachment(t, room.Id, "private", imageData, "private.png")
 	attachmentURL := attachment.GetAssetUrl().GetUrl()
+	thumbnailURL := attachment.GetThumbnailAssetUrl().GetUrl()
 
 	// Sanity check: owner can fetch their own URL without a cookie because the
 	// access ticket is the capability.
@@ -1256,6 +1476,14 @@ func TestAsset_RevokedMembership_RevokesStableURL(t *testing.T) {
 	if r.StatusCode != http.StatusOK {
 		t.Fatalf("expected stable URL to work pre-leave, got %d", r.StatusCode)
 	}
+	thumb, err := plainClient.Get(env.server.URL + thumbnailURL)
+	if err != nil {
+		t.Fatalf("pre-leave thumbnail GET: %v", err)
+	}
+	thumb.Body.Close()
+	if thumb.StatusCode != http.StatusOK {
+		t.Fatalf("expected stable thumbnail to work pre-leave, got %d", thumb.StatusCode)
+	}
 
 	// Owner leaves the room, so their stable access-ticket URL should stop working.
 	if err := env.core.LeaveRoom(env.ctx, owner.Id, "channel", owner.Id, room.Id); err != nil {
@@ -1269,5 +1497,13 @@ func TestAsset_RevokedMembership_RevokesStableURL(t *testing.T) {
 	r2.Body.Close()
 	if r2.StatusCode != http.StatusForbidden {
 		t.Errorf("expected 403 after ticket user left the room, got %d", r2.StatusCode)
+	}
+	thumb2, err := plainClient.Get(env.server.URL + thumbnailURL)
+	if err != nil {
+		t.Fatalf("post-leave thumbnail GET: %v", err)
+	}
+	thumb2.Body.Close()
+	if thumb2.StatusCode != http.StatusForbidden {
+		t.Errorf("expected cached thumbnail ticket to fail after leave, got %d", thumb2.StatusCode)
 	}
 }

--- a/cli/internal/http_server/assets_test.go
+++ b/cli/internal/http_server/assets_test.go
@@ -28,6 +28,7 @@ import (
 	"hmans.de/chatto/internal/assets"
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/core"
+	"hmans.de/chatto/internal/core/linkpreview"
 	"hmans.de/chatto/internal/email"
 	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
 	"hmans.de/chatto/internal/pb/chatto/api/v1/apiv1connect"
@@ -42,10 +43,11 @@ import (
 
 // assetTestEnv holds all test dependencies for asset tests
 type assetTestEnv struct {
-	server *httptest.Server
-	client *http.Client
-	core   *core.ChattoCore
-	ctx    context.Context
+	server   *httptest.Server
+	client   *http.Client
+	core     *core.ChattoCore
+	ctx      context.Context
+	previews *linkpreview.Cache
 }
 
 // setupAssetTestServer creates a test server for asset testing with caching enabled.
@@ -109,6 +111,14 @@ func setupAssetTestServerWithOptions(t *testing.T, useS3 bool, videoEnabled bool
 		t.Fatalf("Failed to create ChattoCore: %v", err)
 	}
 	startCoreServices(t, chattoCore)
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatalf("Create JetStream test client: %v", err)
+	}
+	runtimeState, err := js.KeyValue(ctx, "RUNTIME_STATE")
+	if err != nil {
+		t.Fatalf("Open RUNTIME_STATE test cache: %v", err)
+	}
 
 	// Create router with session middleware
 	router := gin.New()
@@ -159,10 +169,11 @@ func setupAssetTestServerWithOptions(t *testing.T, useS3 bool, videoEnabled bool
 	}
 
 	return &assetTestEnv{
-		server: ts,
-		client: client,
-		core:   chattoCore,
-		ctx:    ctx,
+		server:   ts,
+		client:   client,
+		core:     chattoCore,
+		ctx:      ctx,
+		previews: linkpreview.NewCache(runtimeState),
 	}
 }
 
@@ -1198,6 +1209,63 @@ func TestAsset_LegacyFlatPublicAssetsRemainAvailable(t *testing.T) {
 		t.Fatalf("project legacy link-preview fixture: %v", err)
 	}
 	assertOK(env.core.GetTransformedServerAssetURL(previewID, 64, 64, "cover"))
+}
+
+func TestAsset_CacheOnlyLegacyLinkPreviewRemainsAvailable(t *testing.T) {
+	env := setupAssetTestServer(t)
+	assetID := core.NewAssetID()
+	previewURL := "https://legacy-cache-only.example/article"
+	imageData := createAssetTestPNG(t, 120, 80)
+	store := env.core.ServerStore()
+	if _, err := store.Put(env.ctx, jetstream.ObjectMeta{
+		Name:    assetID,
+		Headers: map[string][]string{"Content-Type": {"image/png"}},
+	}, bytes.NewReader(imageData)); err != nil {
+		t.Fatalf("store cache-only legacy preview: %v", err)
+	}
+	if err := env.previews.Set(env.ctx, previewURL, &corev1.LinkPreview{
+		Url:          previewURL,
+		ImageAssetId: &assetID,
+		ImageAsset: &corev1.AssetRecord{
+			Id:          assetID,
+			ContentType: "image/png",
+			Storage:     &corev1.AssetRecord_Nats{Nats: &corev1.NATSAsset{Key: assetID}},
+		},
+	}); err != nil {
+		t.Fatalf("cache legacy preview metadata: %v", err)
+	}
+
+	assertStatus := func(path string, want int) {
+		t.Helper()
+		resp, err := http.Get(env.server.URL + path)
+		if err != nil {
+			t.Fatalf("GET %q: %v", path, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != want {
+			t.Fatalf("GET %q status = %d, want %d", path, resp.StatusCode, want)
+		}
+	}
+
+	assetPath := "/assets/server/" + assetID
+	assertStatus(assetPath, http.StatusNotFound)
+	preview, err := env.core.GetLinkPreview(env.ctx, previewURL)
+	if err != nil {
+		t.Fatalf("GetLinkPreview cached legacy preview: %v", err)
+	}
+	if preview.GetImageAssetId() != assetID {
+		t.Fatalf("cached preview asset ID = %q, want %q", preview.GetImageAssetId(), assetID)
+	}
+	assertStatus(assetPath, http.StatusOK)
+	assertStatus(env.core.GetTransformedServerAssetURL(assetID, 64, 64, "cover"), http.StatusOK)
+
+	info, err := store.GetInfo(env.ctx, assetID)
+	if err != nil {
+		t.Fatalf("GetInfo promoted legacy preview: %v", err)
+	}
+	if got := info.Headers.Get(core.ServerAssetVisibilityHeader); got != core.ServerAssetVisibilityPublic {
+		t.Fatalf("legacy preview visibility = %q, want %q", got, core.ServerAssetVisibilityPublic)
+	}
 }
 
 func TestAsset_PublicServerRouteRejectsPrivateAndUnknownNATSObjects(t *testing.T) {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -769,7 +769,7 @@ Notes: Only created when `[core.assets.cache]` is enabled in config. Uses TTL fo
 
 | Key         | Description                                    |
 | ----------- | ---------------------------------------------- |
-| `{assetId}` | Persisted asset binary by ID when stored in NATS |
+| `{assetId}` | Persisted asset binary by ID when stored in NATS; new public server assets carry `Chatto-Asset-Visibility: public` |
 | `asset-upload.{uploadId}.{offset}` | Temporary attachment upload chunk before completion |
 
 **S3 asset keys:**
@@ -781,7 +781,20 @@ Notes: Only created when `[core.assets.cache]` is enabled in config. Uses TTL fo
 
 Attachment upload storage: chunked uploads first store temporary `asset-upload.*` chunks in `SERVER_ASSETS`. Completion verifies the full SHA-256, stores the final attachment in NATS or S3, records SHA-256/uploader/pending-expiry/video hints in `AssetCreatedEvent`, and deletes temporary chunks. Completed but unclaimed pending attachment assets expire after 24 hours unless a message body claims them.
 
-Notes: Asset IDs are globally unique (NanoID), so NATS-backed assets do not need a kind segment. S3 stores logical, prefix-free keys; any configured `path_prefix` is applied only when talking to the S3 backend. Content-Type and original filename stored in object headers where available. S2 compression enabled for `SERVER_ASSETS`. `MediaModel` owns binary storage and serving helpers; `AssetModel` owns durable lifecycle facts and elected message-asset deletion recovery. Asset **metadata** (filename, dimensions, duration, storage pointer, …) is created in `AssetCreatedEvent` on `evt.asset.{assetId}.asset_created`; room scope and ownership context lives on the event (`message`, `derivative`, `user_avatar`, or `server_branding`) rather than inside `Asset`. The `asset_cleanup` lease holder incrementally replays canonical `AssetDeletedEvent` facts, locates the matching creation fact through the asset ID, and idempotently deletes source/derivative bytes and transform-cache entries. Beta room-scoped histories without a canonical asset aggregate remain readable by projections but are not guessed at by the cleanup worker. New message bodies reference message-owned assets by ID. Link preview images are server-scoped persisted assets and are embedded in message bodies as `LinkPreview.image_asset` (`AssetRecord`) so the body records whether the image lives in S3 or `SERVER_ASSETS`; `image_asset_id` remains for compatibility with clients and older stored previews. Processing events refer to created asset IDs and are appended under the same `evt.asset.{assetId}.*` aggregate. The asset projection also reads beta-era `evt.room.{roomId}.asset_*` facts so existing 0.1.0 histories continue to replay without a stream rewrite. Message posting asks the process-local video service to spawn video/animated-GIF processing after appending asset creation and processing-started events; there is no transient NATS Core worker subject or `video_processed` live signal. Boot recovery derives missed work from the EVT projections and calls the same local path. Video processing success records thumbnail/variant asset IDs, while each derivative binary is separately declared with `AssetCreatedEvent` and an owner pointing at the original asset. `AssetProcessingFailedEvent.failure_code` records failed/unavailable outcomes. Account deletion follows the projected message asset graph and appends `AssetDeletedEvent` for source assets and derivative children before deleting backing bytes. The asset HTTP handler doesn't look up a separate index bucket; stable asset URLs resolve metadata and room scope from `AssetProjection`, while legacy locator URLs carry the body-or-video-manifest locator in the URL itself (see "Dynamic Image Transformation" below).
+Notes: Asset IDs are globally unique (NanoID), so NATS-backed assets do not need a kind segment. S3 stores logical, prefix-free keys; any configured `path_prefix` is applied only when talking to the S3 backend. Content-Type and original filename are stored in object headers where available. S2 compression is enabled for `SERVER_ASSETS`. `MediaModel` owns binary storage and serving helpers; `AssetModel` owns durable lifecycle facts and elected message-asset deletion recovery. Asset **metadata** (filename, dimensions, duration, storage pointer, …) is created in `AssetCreatedEvent` on `evt.asset.{assetId}.asset_created`; room scope and ownership context lives on the event (`message`, `derivative`, `user_avatar`, or `server_branding`) rather than inside `Asset`. The `asset_cleanup` lease holder incrementally replays canonical `AssetDeletedEvent` facts, locates the matching creation fact through the asset ID, and idempotently deletes source/derivative bytes and transform-cache entries. Beta room-scoped histories without a canonical asset aggregate remain readable by projections but are not guessed at by the cleanup worker. New message bodies reference message-owned assets by ID. Link preview images are server-scoped persisted assets and are embedded in message bodies as `LinkPreview.image_asset` (`AssetRecord`) so the body records whether the image lives in S3 or `SERVER_ASSETS`; `image_asset_id` remains for compatibility with clients and older stored previews. Processing events refer to created asset IDs and are appended under the same `evt.asset.{assetId}.*` aggregate. The asset projection also reads beta-era `evt.room.{roomId}.asset_*` facts so existing 0.1.0 histories continue to replay without a stream rewrite. Message posting asks the process-local video service to spawn video/animated-GIF processing after appending asset creation and processing-started events; there is no transient NATS Core worker subject or `video_processed` live signal. Boot recovery derives missed work from the EVT projections and calls the same local path. Video processing success records thumbnail/variant asset IDs, while each derivative binary is separately declared with `AssetCreatedEvent` and an owner pointing at the original asset. `AssetProcessingFailedEvent.failure_code` records failed/unavailable outcomes. Account deletion follows the projected message asset graph and appends `AssetDeletedEvent` for source assets and derivative children before deleting backing bytes.
+
+`/assets/server/{assetId}` is an unauthenticated route limited to canonical,
+positively classified public server assets. Before transform signature parsing,
+resize-cache access, object reads, or image transformation, the handler rejects
+reserved namespaces, every live or deleted `AssetProjection` declaration,
+private NATS metadata (`Room-Id` or `Upload-Id`), and unknown NATS objects.
+Current NATS public writes carry an explicit public visibility header;
+historical avatars and branding are recognized through their current durable
+pointers, while historical link-preview images are recognized through durable
+message-body references. S3 public delivery probes only `instance/{assetId}`;
+private current and historical attachment prefixes are never probed by this
+route. Disallowed classes return 404. A dedicated public object store or
+namespace remains the preferred long-term physical boundary.
 
 ### Dynamic Image Transformation
 
@@ -834,6 +847,11 @@ URL plus `AssetURL.expiresAt` shape.
 **Security:**
 
 URLs are signed with HMAC-SHA256 using a dedicated `signing_secret` (configured in `[core.assets]` section, separate from session secret). The signature covers the full path to prevent parameter tampering. ConnectRPC room timeline responses, `MessageService` message read responses, `AssetService` asset read responses, and `RoomService` attachment list responses generate valid signed URLs.
+
+The public server-asset transform signature authorizes only the requested
+transform parameters; it does not authorize a viewer or classify the source as
+public. Public/private classification runs independently on every request,
+including internal resize-cache hits.
 
 **ConnectRPC Integration:**
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -769,7 +769,8 @@ Notes: Only created when `[core.assets.cache]` is enabled in config. Uses TTL fo
 
 | Key         | Description                                    |
 | ----------- | ---------------------------------------------- |
-| `{assetId}` | Persisted asset binary by ID when stored in NATS; new public server assets carry `Chatto-Asset-Visibility: public` |
+| `public/{assetId}` | New public avatars, server branding, and link-preview images |
+| `{assetId}` | Private attachment binaries and historical flat-key public assets |
 | `asset-upload.{uploadId}.{offset}` | Temporary attachment upload chunk before completion |
 
 **S3 asset keys:**
@@ -781,20 +782,21 @@ Notes: Only created when `[core.assets.cache]` is enabled in config. Uses TTL fo
 
 Attachment upload storage: chunked uploads first store temporary `asset-upload.*` chunks in `SERVER_ASSETS`. Completion verifies the full SHA-256, stores the final attachment in NATS or S3, records SHA-256/uploader/pending-expiry/video hints in `AssetCreatedEvent`, and deletes temporary chunks. Completed but unclaimed pending attachment assets expire after 24 hours unless a message body claims them.
 
-Notes: Asset IDs are globally unique (NanoID), so NATS-backed assets do not need a kind segment. S3 stores logical, prefix-free keys; any configured `path_prefix` is applied only when talking to the S3 backend. Content-Type and original filename are stored in object headers where available. S2 compression is enabled for `SERVER_ASSETS`. `MediaModel` owns binary storage and serving helpers; `AssetModel` owns durable lifecycle facts and elected message-asset deletion recovery. Asset **metadata** (filename, dimensions, duration, storage pointer, …) is created in `AssetCreatedEvent` on `evt.asset.{assetId}.asset_created`; room scope and ownership context lives on the event (`message`, `derivative`, `user_avatar`, or `server_branding`) rather than inside `Asset`. The `asset_cleanup` lease holder incrementally replays canonical `AssetDeletedEvent` facts, locates the matching creation fact through the asset ID, and idempotently deletes source/derivative bytes and transform-cache entries. Beta room-scoped histories without a canonical asset aggregate remain readable by projections but are not guessed at by the cleanup worker. New message bodies reference message-owned assets by ID. Link preview images are server-scoped persisted assets and are embedded in message bodies as `LinkPreview.image_asset` (`AssetRecord`) so the body records whether the image lives in S3 or `SERVER_ASSETS`; `image_asset_id` remains for compatibility with clients and older stored previews. Processing events refer to created asset IDs and are appended under the same `evt.asset.{assetId}.*` aggregate. The asset projection also reads beta-era `evt.room.{roomId}.asset_*` facts so existing 0.1.0 histories continue to replay without a stream rewrite. Message posting asks the process-local video service to spawn video/animated-GIF processing after appending asset creation and processing-started events; there is no transient NATS Core worker subject or `video_processed` live signal. Boot recovery derives missed work from the EVT projections and calls the same local path. Video processing success records thumbnail/variant asset IDs, while each derivative binary is separately declared with `AssetCreatedEvent` and an owner pointing at the original asset. `AssetProcessingFailedEvent.failure_code` records failed/unavailable outcomes. Account deletion follows the projected message asset graph and appends `AssetDeletedEvent` for source assets and derivative children before deleting backing bytes.
+Notes: Asset IDs are globally unique NanoIDs. New public NATS objects add the `public/` kind segment so their storage class is explicit; private attachments retain flat keys for compatibility. S3 stores logical, prefix-free keys; any configured `path_prefix` is applied only when talking to the S3 backend. Content-Type and original filename are stored in object headers where available. S2 compression is enabled for `SERVER_ASSETS`. `MediaModel` owns binary storage and serving helpers; `AssetModel` owns durable lifecycle facts and elected message-asset deletion recovery. Asset **metadata** (filename, dimensions, duration, storage pointer, …) is created in `AssetCreatedEvent` on `evt.asset.{assetId}.asset_created`; room scope and ownership context lives on the event (`message`, `derivative`, `user_avatar`, or `server_branding`) rather than inside `Asset`. The `asset_cleanup` lease holder incrementally replays canonical `AssetDeletedEvent` facts, locates the matching creation fact through the asset ID, and idempotently deletes source/derivative bytes and transform-cache entries. Beta room-scoped histories without a canonical asset aggregate remain readable by projections but are not guessed at by the cleanup worker. New message bodies reference message-owned assets by ID. Link preview images are server-scoped persisted assets and are embedded in message bodies as `LinkPreview.image_asset` (`AssetRecord`) so the body records whether the image lives in S3 or `SERVER_ASSETS`; `image_asset_id` remains for compatibility with clients and older stored previews. Processing events refer to created asset IDs and are appended under the same `evt.asset.{assetId}.*` aggregate. The asset projection also reads beta-era `evt.room.{roomId}.asset_*` facts so existing 0.1.0 histories continue to replay without a stream rewrite. Message posting asks the process-local video service to spawn video/animated-GIF processing after appending asset creation and processing-started events; there is no transient NATS Core worker subject or `video_processed` live signal. Boot recovery derives missed work from the EVT projections and calls the same local path. Video processing success records thumbnail/variant asset IDs, while each derivative binary is separately declared with `AssetCreatedEvent` and an owner pointing at the original asset. `AssetProcessingFailedEvent.failure_code` records failed/unavailable outcomes. Account deletion follows the projected message asset graph and appends `AssetDeletedEvent` for source assets and derivative children before deleting backing bytes.
 
-`/assets/server/{assetId}` is an unauthenticated route limited to canonical,
-positively classified public server assets. Before transform signature parsing,
-resize-cache access, object reads, or image transformation, the handler rejects
-reserved namespaces, every live or deleted `AssetProjection` declaration,
-private NATS metadata (`Room-Id` or `Upload-Id`), and unknown NATS objects.
-Current NATS public writes carry an explicit public visibility header;
-historical avatars and branding are recognized through their current durable
-pointers, while historical link-preview images are recognized through durable
-message-body references. S3 public delivery probes only `instance/{assetId}`;
-private current and historical attachment prefixes are never probed by this
-route. Disallowed classes return 404. A dedicated public object store or
-namespace remains the preferred long-term physical boundary.
+`/assets/server/*` is an unauthenticated route limited to positively classified
+public server assets. New NATS-backed URLs use
+`/assets/server/public/{assetId}` and map directly to the explicit
+`public/{assetId}` object namespace. Canonical `/assets/server/{assetId}` URLs
+remain aliases for those objects and preserve historical flat-key URLs. Before
+transform signature parsing, resize-cache access, object reads, or image
+transformation, the handler rejects unknown namespaces, every live or deleted
+`AssetProjection` declaration, and private NATS metadata (`Room-Id` or
+`Upload-Id`). Historical avatars and branding are recognized through their
+current durable pointers, while historical link-preview images are recognized
+through durable message-body references. S3 public delivery probes only
+`instance/{assetId}`; private current and historical attachment prefixes are
+never probed by this route. Disallowed classes return 404.
 
 ### Dynamic Image Transformation
 


### PR DESCRIPTION
## Why

The unauthenticated server-asset endpoint needs a positive public-delivery
boundary. Public and private NATS objects historically shared `SERVER_ASSETS`,
and the route accepted opaque keys without first proving that the referenced
object was intended for public delivery. Private, internal, and unknown objects
must look absent before cache, storage-read, or transformation paths.

## What changed

- New NATS-backed avatars, server branding, and link-preview images use the
  explicit `public/{assetID}` namespace in the existing object store. S3 public
  objects remain under `instance/{assetID}`; private S3 attachments remain in
  their separate attachment prefixes.
- The route resolves an exact backend and key before transform parsing, cache
  lookup, object reads, or image processing. Reserved namespaces, durable
  room-asset declarations, private upload metadata, tombstones, and unknown
  object classes uniformly return 404.
- Historical flat-key avatars, branding, and link-preview images remain
  available through durable/current public references and the prior explicit
  public marker. Canonical asset-ID URLs also remain aliases for newly
  namespaced NATS objects.
- Cache-only pre-upgrade link-preview images are promoted with a metadata-only
  marker when their complete cached asset record exactly identifies a safe flat
  NATS object. The marker and resolved object locator are bound to that object's
  NUID and digest, so a same-key replacement fails closed.
- The protected attachment route retains its ticket and current-membership
  checks. Adjacent asset routes were reviewed for equivalent alternate paths.
- The public/private invariant is documented in `SECURITY.md`, `cli/AGENTS.md`,
  and the architecture inventory.

## Compatibility and rollout

- No object-content migration, protobuf change, public API change, or new object
  store is required. Previously uploaded public assets retain their existing
  URLs and continue to work.
- The NATS producers in every stable release from `v0.4.0` through `v0.4.10`
  were audited: public assets use canonical flat `A…` keys and private room
  attachments/chunks carry durable room declarations or private metadata. The
  compatibility resolver and mounted HTTP fixtures cover those persisted
  shapes.
- Roll out as a coordinated security update: drain or stop old replicas before
  admitting patched traffic, and avoid branding/link-preview writes during the
  transition. An unpatched serving replica is not part of the protected state.
- No flat-key compatibility copies are written for new objects. This preserves
  the unambiguous namespace and avoids dual-write cleanup/failure modes.
- The change is independent of projection-snapshot work and remains a focused
  five-commit series suitable for release-branch cherry-picking.

## Test plan

- Focused mounted HTTP/core/ConnectRPC asset tests after rebasing onto current
  `main` — pass
- `mise test-cli` — pass
- `mise test-e2e` — pass, 629 tests; two unrelated sign-out tests passed on
  retry
- `mise lint` — pass, 0 Svelte errors/warnings
- `mise license-check` — pass
- Adversarial review and follow-up disposition review — no unresolved
  significant findings
