### PR TITLE
fix(security): restrict public server assets

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,3 +31,11 @@ Reports about Chatto itself, the bundled frontend, Docker images, and deployment
 examples are in scope. Reports about third-party services or user-managed
 infrastructure are only in scope when Chatto's documented configuration creates
 the issue.
+
+## Asset Isolation
+
+Public server assets and room-scoped files use separate HTTP authorization
+boundaries even when a deployment stores their bytes in shared infrastructure.
+`/assets/server/*` serves only positively classified public avatars, branding,
+and link-preview images. Room files remain behind ticket and current-membership
+checks on `/assets/files/*`; transform signatures do not replace those checks.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -112,6 +112,14 @@ authorization, live events, backup/restore, and backend tests.
 
 ## Attachment URL Authorization
 
+- `/assets/server/{assetId}` is unauthenticated and may serve only positively
+  classified public server assets: current/historical avatars, server branding,
+  and server-fetched link-preview images. Classification must happen before
+  transform-signature parsing, resize-cache lookup, object reads, or transforms.
+- `SERVER_ASSETS` is a mixed store. Never treat an opaque key, missing private
+  metadata, or a valid transform signature as proof that an object is public.
+  Deny room-asset declarations and tombstones, `Room-Id`/`Upload-Id` metadata,
+  reserved namespaces, and unknown object classes with the same 404 response.
 - Stable asset URLs use `/assets/files/{assetId}` and image transform variants.
 - Browser-facing ConnectRPC attachment URL fields append a signed per-user
   `access` ticket and expose expiry in the API asset URL object.

--- a/cli/internal/core/attachments.go
+++ b/cli/internal/core/attachments.go
@@ -18,6 +18,13 @@ import (
 	"hmans.de/chatto/pkg/signedurl"
 )
 
+const (
+	// ServerAssetVisibilityHeader positively marks NATS objects that may be
+	// served by the unauthenticated public server-asset route.
+	ServerAssetVisibilityHeader = "Chatto-Asset-Visibility"
+	ServerAssetVisibilityPublic = "public"
+)
+
 // ============================================================================
 // Attachment Operations
 // ============================================================================
@@ -385,6 +392,19 @@ func attachmentFromAsset(asset *corev1.AssetRecord) *corev1.Attachment {
 // Attachment view used by API response mapping and asset URL helpers.
 func AttachmentFromAsset(asset *corev1.AssetRecord) *corev1.Attachment {
 	return attachmentFromAsset(asset)
+}
+
+func assetRecordMatchesKey(asset *corev1.AssetRecord, key string) bool {
+	if asset == nil || key == "" {
+		return false
+	}
+	if asset.GetId() == key {
+		return true
+	}
+	if stored := asset.GetNats(); stored != nil && stored.GetKey() == key {
+		return true
+	}
+	return asset.GetS3() != nil && asset.GetS3().GetKey() == key
 }
 
 func applyDeprecatedAssetFromAttachmentStorage(asset *corev1.AssetRecord, storage *corev1.DeprecatedAsset) {

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -662,7 +662,8 @@ func (c *ChattoCore) storeLinkPreviewImage(ctx context.Context, assetID string, 
 	meta := jetstream.ObjectMeta{
 		Name: assetID,
 		Headers: map[string][]string{
-			"Content-Type": {contentType},
+			"Content-Type":              {contentType},
+			ServerAssetVisibilityHeader: {ServerAssetVisibilityPublic},
 		},
 	}
 	info, err := c.storage.serverAssets.Put(ctx, meta, bytes.NewReader(data))
@@ -679,6 +680,98 @@ func (c *ChattoCore) storeLinkPreviewImage(ctx context.Context, assetID string, 
 type ServerAssetInfo struct {
 	Size        int64
 	ContentType string
+}
+
+// IsReservedServerAssetKey rejects namespaces used by private or internal
+// objects before public-route transform parsing or backend probing.
+func IsReservedServerAssetKey(key string) bool {
+	key = strings.TrimSpace(key)
+	if key == "" || strings.HasPrefix(key, "/") || strings.Contains(key, "\\") {
+		return true
+	}
+	for _, segment := range strings.Split(key, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return true
+		}
+	}
+	for _, prefix := range []string{
+		assetUploadTempObjectPrefix,
+		"attachments/",
+		"spaces/server/attachments/",
+		"spaces/DM/attachments/",
+	} {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	// Every public server-asset producer, including historical migrations, uses
+	// the canonical opaque asset-ID grammar. Namespace-shaped and unknown keys
+	// are not public object classes.
+	if len(key) != idLength+1 || key[0] != 'A' {
+		return true
+	}
+	for _, ch := range key[1:] {
+		if !strings.ContainsRune(idAlphabet, ch) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsPublicServerAsset positively classifies an object before the public
+// /assets/server route performs cache access, content reads, or transforms.
+// SERVER_ASSETS is shared with private binaries, so absence of a private marker
+// is never enough: unknown objects fail closed.
+func (c *ChattoCore) IsPublicServerAsset(ctx context.Context, key string) bool {
+	if IsReservedServerAssetKey(key) {
+		return false
+	}
+
+	// Durable room-scoped declarations take precedence over every public hint,
+	// including stale metadata or a colliding current public reference.
+	if c.Assets != nil {
+		if _, declared := c.Assets.AssetCreation(key); declared {
+			return false
+		}
+		if c.Assets.AssetDeleted(key) {
+			return false
+		}
+	}
+
+	// Object metadata is safe to inspect for classification; object content is
+	// not opened until this method has returned true.
+	if info, err := c.storage.serverAssets.GetInfo(ctx, key); err == nil && info != nil {
+		if info.Headers.Get("Room-Id") != "" || info.Headers.Get("Upload-Id") != "" {
+			return false
+		}
+		if info.Headers.Get(ServerAssetVisibilityHeader) == ServerAssetVisibilityPublic {
+			return true
+		}
+	}
+
+	// Historical public objects predate the explicit visibility header. Their
+	// durable/current public references provide the positive declaration.
+	if c.Users != nil && c.Users.IsPublicAvatarAsset(key) {
+		return true
+	}
+	if c.ServerConfig != nil {
+		logo, _, _ := c.ServerConfig.ServerLogo()
+		banner, _, _ := c.ServerConfig.ServerBanner()
+		if assetRecordMatchesKey(logo, key) || assetRecordMatchesKey(banner, key) {
+			return true
+		}
+	}
+	if c.RoomTimeline != nil && c.RoomTimeline.IsPublicLinkPreviewAsset(key) {
+		return true
+	}
+
+	// S3 server assets live exclusively below instance/. Private current and
+	// historical attachments use attachments/ or spaces/*/attachments/.
+	if c.s3Client != nil && !strings.Contains(key, "/") {
+		_, err := c.s3Client.StatObject(ctx, S3KeyServerAsset(key))
+		return err == nil
+	}
+	return false
 }
 
 // ServerAssetRecordFromAnyBackend builds an AssetRecord by probing the

--- a/cli/internal/core/linkpreview_test.go
+++ b/cli/internal/core/linkpreview_test.go
@@ -58,6 +58,10 @@ func TestLinkPreviewImageStorageAndRetrieval(t *testing.T) {
 	require.Equal(t, preview.GetImageAssetId(), preview.GetImageAsset().GetId())
 	require.Equal(t, "image/webp", preview.GetImageAsset().GetContentType())
 	require.NotNil(t, preview.GetImageAsset().GetNats(), "NATS-backed preview should carry NATS storage pointer")
+	storedInfo, err := core.storage.serverAssets.GetInfo(ctx, preview.GetImageAssetId())
+	require.NoError(t, err)
+	require.Equal(t, ServerAssetVisibilityPublic, storedInfo.Headers.Get(ServerAssetVisibilityHeader))
+	require.True(t, core.IsPublicServerAsset(ctx, preview.GetImageAssetId()))
 
 	idOnlyPreview := &corev1.LinkPreview{Url: url, ImageAssetId: preview.ImageAssetId}
 	require.NoError(t, core.HydrateLinkPreviewImageAsset(ctx, idOnlyPreview))

--- a/cli/internal/core/room_timeline_assets.go
+++ b/cli/internal/core/room_timeline_assets.go
@@ -20,6 +20,10 @@ type roomTimelineAssetIndex struct {
 	assetChildren  map[string][]string
 	videoManifests map[string]*VideoAttachmentManifest
 	messageOwners  map[string]assetMessageRef
+	// publicLinkPreviewAssets remembers server-fetched preview images referenced
+	// by durable message bodies. Link-preview images are intentionally public,
+	// unlike message attachment assets tracked by messageOwners.
+	publicLinkPreviewAssets map[string]struct{}
 }
 
 // assetMessageRef is the room + message that owns an asset, captured from the
@@ -54,10 +58,11 @@ type VideoProcessingRequest struct {
 
 func newRoomTimelineAssetIndex() *roomTimelineAssetIndex {
 	return &roomTimelineAssetIndex{
-		assetCreations: make(map[string]*corev1.AssetCreatedEvent),
-		assetChildren:  make(map[string][]string),
-		videoManifests: make(map[string]*VideoAttachmentManifest),
-		messageOwners:  make(map[string]assetMessageRef),
+		assetCreations:          make(map[string]*corev1.AssetCreatedEvent),
+		assetChildren:           make(map[string][]string),
+		videoManifests:          make(map[string]*VideoAttachmentManifest),
+		messageOwners:           make(map[string]assetMessageRef),
+		publicLinkPreviewAssets: make(map[string]struct{}),
 	}
 }
 
@@ -74,6 +79,23 @@ func (idx *roomTimelineAssetIndex) rememberMessageBodyAssets(roomID, messageEven
 		}
 		idx.messageOwners[assetID] = assetMessageRef{roomID: roomID, messageEventID: messageEventID}
 	}
+	if preview := body.GetLinkPreview(); preview != nil {
+		assetID := preview.GetImageAssetId()
+		if preview.GetImageAsset() != nil && preview.GetImageAsset().GetId() != "" {
+			assetID = preview.GetImageAsset().GetId()
+		}
+		if assetID != "" {
+			idx.publicLinkPreviewAssets[assetID] = struct{}{}
+		}
+	}
+}
+
+func (idx *roomTimelineAssetIndex) isPublicLinkPreviewAsset(assetID string) bool {
+	if idx == nil || assetID == "" {
+		return false
+	}
+	_, ok := idx.publicLinkPreviewAssets[assetID]
+	return ok
 }
 
 func (idx *roomTimelineAssetIndex) applyLifecycleEvent(event *corev1.Event) {

--- a/cli/internal/core/room_timeline_projection.go
+++ b/cli/internal/core/room_timeline_projection.go
@@ -499,6 +499,15 @@ func (p *RoomTimelineProjection) CurrentRoomAttachmentMessages(roomID string) []
 	return out
 }
 
+// IsPublicLinkPreviewAsset reports whether durable message history references
+// assetID as a server-fetched link-preview image. Preview images are public
+// server assets; ordinary message attachments are deliberately excluded.
+func (p *RoomTimelineProjection) IsPublicLinkPreviewAsset(assetID string) bool {
+	p.RLock()
+	defer p.RUnlock()
+	return p.assets.isPublicLinkPreviewAsset(assetID)
+}
+
 func (p *RoomTimelineProjection) refreshAttachmentMessageLocked(roomID, eventID string, body *corev1.MessageBody) {
 	if roomID == "" || eventID == "" {
 		return

--- a/cli/internal/core/server_branding.go
+++ b/cli/internal/core/server_branding.go
@@ -84,6 +84,7 @@ func (c *ChattoCore) uploadServerAsset(ctx context.Context, webpData []byte, kin
 
 	headers := nats.Header{}
 	headers.Set("Content-Type", "image/webp")
+	headers.Set(ServerAssetVisibilityHeader, ServerAssetVisibilityPublic)
 	meta := jetstream.ObjectMeta{
 		Name:    assetID,
 		Headers: headers,

--- a/cli/internal/core/user_projection.go
+++ b/cli/internal/core/user_projection.go
@@ -675,6 +675,25 @@ func (p *UserProjection) Avatar(userID string) (*corev1.AssetRecord, bool) {
 	return proto.Clone(u.avatar).(*corev1.AssetRecord), true
 }
 
+// IsPublicAvatarAsset reports whether assetID or key is the current avatar of
+// a non-deleted user. User avatars are intentionally public server assets.
+func (p *UserProjection) IsPublicAvatarAsset(assetID string) bool {
+	p.RLock()
+	defer p.RUnlock()
+	if assetID == "" {
+		return false
+	}
+	for _, u := range p.users {
+		if u == nil || u.deleted || u.avatar == nil {
+			continue
+		}
+		if assetRecordMatchesKey(u.avatar, assetID) {
+			return true
+		}
+	}
+	return false
+}
+
 func (p *UserProjection) Preferences(userID string) (*corev1.ServerUserPreferences, bool) {
 	p.RLock()
 	defer p.RUnlock()

--- a/cli/internal/core/user_projection.go
+++ b/cli/internal/core/user_projection.go
@@ -25,6 +25,7 @@ type UserProjection struct {
 	loginIndex    map[string]string
 	emailIndex    map[string]string
 	identityIndex map[string]string
+	avatarIndex   map[string]int
 	replayGuard   projectionReplayGuard
 	dekResolver   *unwrappedDEKResolver
 	dekEvents     map[string]map[corev1.UserDEKPurpose]map[int32]*corev1.UserDEKGeneratedEvent
@@ -57,6 +58,7 @@ func newUserProjectionWithDEKResolver(dekResolver *unwrappedDEKResolver) *UserPr
 		loginIndex:    make(map[string]string),
 		emailIndex:    make(map[string]string),
 		identityIndex: make(map[string]string),
+		avatarIndex:   make(map[string]int),
 		replayGuard:   newProjectionReplayGuard(),
 		dekResolver:   dekResolver,
 		dekEvents:     make(map[string]map[corev1.UserDEKPurpose]map[int32]*corev1.UserDEKGeneratedEvent),
@@ -233,7 +235,7 @@ func (p *UserProjection) applyAvatarSet(e *corev1.UserAvatarSetEvent) {
 	if e.GetAvatar() == nil {
 		return
 	}
-	u.avatar = assetFromDeprecatedAsset(e.GetAvatar(), "avatar.webp", "image/webp")
+	p.replaceAvatarLocked(u, assetFromDeprecatedAsset(e.GetAvatar(), "avatar.webp", "image/webp"))
 }
 
 func (p *UserProjection) applyAssetCreated(e *corev1.AssetCreatedEvent) {
@@ -241,7 +243,7 @@ func (p *UserProjection) applyAssetCreated(e *corev1.AssetCreatedEvent) {
 		return
 	}
 	u := p.ensureUserLocked(e.GetUserId())
-	u.avatar = proto.Clone(e.GetAsset()).(*corev1.AssetRecord)
+	p.replaceAvatarLocked(u, proto.Clone(e.GetAsset()).(*corev1.AssetRecord))
 }
 
 func (p *UserProjection) applyAssetDeleted(e *corev1.AssetDeletedEvent) {
@@ -250,7 +252,7 @@ func (p *UserProjection) applyAssetDeleted(e *corev1.AssetDeletedEvent) {
 	}
 	for _, u := range p.users {
 		if u != nil && u.avatar != nil && u.avatar.GetId() == e.GetAssetId() {
-			u.avatar = nil
+			p.replaceAvatarLocked(u, nil)
 		}
 	}
 }
@@ -260,7 +262,7 @@ func (p *UserProjection) applyAvatarCleared(e *corev1.UserAvatarClearedEvent) {
 		return
 	}
 	u := p.ensureUserLocked(e.GetUserId())
-	u.avatar = nil
+	p.replaceAvatarLocked(u, nil)
 }
 
 func (p *UserProjection) applyVerifiedEmailAdded(eventID string, e *corev1.UserVerifiedEmailAddedEvent, envelopeCreatedAt *timestamppb.Timestamp) {
@@ -438,7 +440,7 @@ func (p *UserProjection) applyAccountDeleted(e *corev1.UserAccountDeletedEvent, 
 			delete(p.identityIndex, hash)
 		}
 	}
-	u.avatar = nil
+	p.replaceAvatarLocked(u, nil)
 	u.passwordHash = nil
 	u.passwordSetAt = time.Time{}
 	u.preferences = nil
@@ -676,22 +678,48 @@ func (p *UserProjection) Avatar(userID string) (*corev1.AssetRecord, bool) {
 }
 
 // IsPublicAvatarAsset reports whether assetID or key is the current avatar of
-// a non-deleted user. User avatars are intentionally public server assets.
+// a non-deleted user. User avatars are intentionally public server assets. The
+// replay-built index keeps this unauthenticated request-path check O(1).
 func (p *UserProjection) IsPublicAvatarAsset(assetID string) bool {
 	p.RLock()
 	defer p.RUnlock()
-	if assetID == "" {
-		return false
+	return assetID != "" && p.avatarIndex[assetID] > 0
+}
+
+func (p *UserProjection) replaceAvatarLocked(u *projectedUser, avatar *corev1.AssetRecord) {
+	if u == nil {
+		return
 	}
-	for _, u := range p.users {
-		if u == nil || u.deleted || u.avatar == nil {
-			continue
-		}
-		if assetRecordMatchesKey(u.avatar, assetID) {
-			return true
+	if p.avatarIndex == nil {
+		p.avatarIndex = make(map[string]int)
+	}
+	for key := range assetRecordKeys(u.avatar) {
+		if p.avatarIndex[key] <= 1 {
+			delete(p.avatarIndex, key)
+		} else {
+			p.avatarIndex[key]--
 		}
 	}
-	return false
+	u.avatar = avatar
+	if u.deleted {
+		return
+	}
+	for key := range assetRecordKeys(avatar) {
+		p.avatarIndex[key]++
+	}
+}
+
+func assetRecordKeys(asset *corev1.AssetRecord) map[string]struct{} {
+	keys := make(map[string]struct{}, 3)
+	if asset == nil {
+		return keys
+	}
+	for _, key := range []string{asset.GetId(), asset.GetNats().GetKey(), asset.GetS3().GetKey()} {
+		if key != "" {
+			keys[key] = struct{}{}
+		}
+	}
+	return keys
 }
 
 func (p *UserProjection) Preferences(userID string) (*corev1.ServerUserPreferences, bool) {

--- a/cli/internal/core/user_projection_test.go
+++ b/cli/internal/core/user_projection_test.go
@@ -324,3 +324,45 @@ func TestUserProjection_VerifiedEmailAvatarOIDCAndDelete(t *testing.T) {
 	_, ok = p.GetByExternalIdentity("github-main", "12345")
 	require.False(t, ok)
 }
+
+func TestUserProjection_PublicAvatarIndexTracksLifecycle(t *testing.T) {
+	p := NewUserProjection(staticProjectionKeyWrapper{}, staticProjectionDEKStore{})
+
+	legacy := &corev1.Event{Event: &corev1.Event_UserAvatarSet{UserAvatarSet: &corev1.UserAvatarSetEvent{
+		UserId: "U1",
+		Avatar: &corev1.DeprecatedAsset{Asset: &corev1.DeprecatedAsset_S3{S3: &corev1.S3Asset{Key: "legacy-avatar-key"}}},
+	}}}
+	replacement := &corev1.AssetRecord{
+		Id:      "A-replacement",
+		Storage: &corev1.AssetRecord_Nats{Nats: &corev1.NATSAsset{Key: "replacement-storage-key"}},
+	}
+
+	require.NoError(t, p.Apply(legacy, 1))
+	require.True(t, p.IsPublicAvatarAsset("legacy-avatar-key"))
+
+	require.NoError(t, p.Apply(&corev1.Event{Event: &corev1.Event_AssetCreated{AssetCreated: &corev1.AssetCreatedEvent{
+		UserId: "U1",
+		Asset:  replacement,
+	}}}, 2))
+	require.False(t, p.IsPublicAvatarAsset("legacy-avatar-key"))
+	require.True(t, p.IsPublicAvatarAsset("A-replacement"))
+	require.True(t, p.IsPublicAvatarAsset("replacement-storage-key"))
+
+	require.NoError(t, p.Apply(&corev1.Event{Event: &corev1.Event_AssetDeleted{AssetDeleted: &corev1.AssetDeletedEvent{
+		AssetId: "A-replacement",
+	}}}, 3))
+	require.False(t, p.IsPublicAvatarAsset("A-replacement"))
+	require.False(t, p.IsPublicAvatarAsset("replacement-storage-key"))
+
+	require.NoError(t, p.Apply(legacy, 4))
+	require.NoError(t, p.Apply(&corev1.Event{Event: &corev1.Event_UserAvatarCleared{UserAvatarCleared: &corev1.UserAvatarClearedEvent{
+		UserId: "U1",
+	}}}, 5))
+	require.False(t, p.IsPublicAvatarAsset("legacy-avatar-key"))
+
+	require.NoError(t, p.Apply(legacy, 6))
+	require.NoError(t, p.Apply(&corev1.Event{Event: &corev1.Event_UserAccountDeleted{UserAccountDeleted: &corev1.UserAccountDeletedEvent{
+		UserId: "U1",
+	}}}, 7))
+	require.False(t, p.IsPublicAvatarAsset("legacy-avatar-key"))
+}

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -577,6 +577,7 @@ func (c *ChattoCore) UploadUserAvatar(ctx context.Context, userID string, reader
 		// Upload to NATS ObjectStore
 		headers := nats.Header{}
 		headers.Set("Content-Type", "image/webp")
+		headers.Set(ServerAssetVisibilityHeader, ServerAssetVisibilityPublic)
 		meta := jetstream.ObjectMeta{
 			Name:    assetID,
 			Headers: headers,

--- a/cli/internal/http_server/assets.go
+++ b/cli/internal/http_server/assets.go
@@ -92,23 +92,40 @@ func (s *HTTPServer) serveServerAsset(c *gin.Context) {
 		path = path[1:]
 	}
 
-	// Check if this is a transform request: path ends with /t/{signedPath}
-	// Pattern: {key}/t/{signedPath}
+	// /assets/server/* is intentionally unauthenticated and may only serve
+	// explicitly public, server-scoped assets. Classify the base key before
+	// transform signature parsing, derivative-cache access, object reads, or
+	// image transformation so shared-store private objects always look absent.
+	key := path
+	signedPath := ""
+	transformRequest := false
 	if idx := strings.LastIndex(path, "/t/"); idx != -1 {
-		key := path[:idx]
-		signedPath := path[idx+3:] // skip "/t/"
-		if key != "" && signedPath != "" {
-			s.serveTransformedServerAsset(c, key, signedPath)
-			return
-		}
+		transformRequest = true
+		key = path[:idx]
+		signedPath = path[idx+3:]
+	}
+	if key == "" || !s.core.IsPublicServerAsset(c.Request.Context(), key) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Asset not found"})
+		return
+	}
+	if transformRequest && signedPath == "" {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Asset not found"})
+		return
 	}
 
-	s.logger.Debug("Serving server asset", "asset_id", path)
+	// Check if this is a transform request: path ends with /t/{signedPath}
+	// Pattern: {key}/t/{signedPath}
+	if transformRequest {
+		s.serveTransformedServerAsset(c, key, signedPath)
+		return
+	}
+
+	s.logger.Debug("Serving server asset", "asset_id", key)
 
 	// Probe both NATS and S3 backends
-	reader, info, err := s.core.GetServerAssetFromAnyBackend(c.Request.Context(), path)
+	reader, info, err := s.core.GetServerAssetFromAnyBackend(c.Request.Context(), key)
 	if err != nil {
-		s.logger.Error("Failed to get server asset", "error", err, "asset_id", path)
+		s.logger.Error("Failed to get server asset", "error", err, "asset_id", key)
 		c.JSON(http.StatusNotFound, gin.H{"error": "Asset not found"})
 		return
 	}
@@ -120,12 +137,12 @@ func (s *HTTPServer) serveServerAsset(c *gin.Context) {
 	// Get content type, fall back to extension-based detection
 	contentType := info.ContentType
 	if contentType == "" {
-		contentType = getContentType(path)
+		contentType = getContentType(key)
 	}
 
 	// Immutable asset - cache forever
 	c.Header("Cache-Control", "public, max-age=31536000, immutable")
-	c.Header("ETag", fmt.Sprintf("\"%s\"", path))
+	c.Header("ETag", fmt.Sprintf("\"%s\"", key))
 	c.Header("Vary", "Accept-Encoding")
 
 	c.DataFromReader(

--- a/cli/internal/http_server/assets_test.go
+++ b/cli/internal/http_server/assets_test.go
@@ -10,6 +10,7 @@ import (
 	"image/color"
 	"image/png"
 	"io"
+	"maps"
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
@@ -23,6 +24,7 @@ import (
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-gonic/gin"
+	"github.com/nats-io/nats.go/jetstream"
 	"hmans.de/chatto/internal/assets"
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/core"
@@ -1015,15 +1017,16 @@ func TestAsset_ServerAsset_HasCacheHeaders(t *testing.T) {
 		t.Fatalf("Failed to create user: %v", err)
 	}
 
-	// Upload an avatar for the user
+	// Upload and durably select an avatar through the production public producer.
 	avatarData := createAssetTestPNG(t, 200, 200)
-	avatarPath := fmt.Sprintf("avatar/%s.png", user.Id)
-
-	store := env.core.ServerStore()
-	_, err = store.PutBytes(env.ctx, avatarPath, avatarData)
+	avatar, err := env.core.UploadUserAvatar(env.ctx, user.Id, bytes.NewReader(avatarData))
 	if err != nil {
 		t.Fatalf("Failed to upload avatar: %v", err)
 	}
+	if err := env.core.SetUserAvatar(env.ctx, user.Id, avatar); err != nil {
+		t.Fatalf("Failed to set avatar: %v", err)
+	}
+	avatarPath := avatar.GetId()
 
 	// Get the server asset (avatars are public, no auth needed)
 	resp, err := env.client.Get(env.server.URL + "/assets/server/" + avatarPath)
@@ -1062,10 +1065,14 @@ func TestAsset_ServerAssetTransformKeepsDefaultQuality(t *testing.T) {
 	env := setupAssetTestServer(t)
 
 	imageData := createAssetTestPNG(t, 400, 300)
-	assetPath := "branding/default-quality.png"
-	if _, err := env.core.ServerStore().PutBytes(env.ctx, assetPath, imageData); err != nil {
-		t.Fatalf("Failed to store server asset: %v", err)
+	branding, err := env.core.UploadServerBanner(env.ctx, bytes.NewReader(imageData))
+	if err != nil {
+		t.Fatalf("Failed to upload server branding: %v", err)
 	}
+	if err := env.core.SetServerBanner(env.ctx, "system", branding); err != nil {
+		t.Fatalf("Failed to set server branding: %v", err)
+	}
+	assetPath := branding.GetId()
 
 	transformURL := env.core.GetTransformedServerAssetURL(assetPath, 200, 200, "contain")
 	resp, err := env.client.Get(env.server.URL + transformURL)
@@ -1091,6 +1098,198 @@ func TestAsset_ServerAssetTransformKeepsDefaultQuality(t *testing.T) {
 	}
 	if !bytes.Equal(got, want) {
 		t.Fatal("server asset transform did not retain the default image quality")
+	}
+}
+
+func TestAsset_PublicServerRouteRejectsPrivateAndUnknownNATSObjects(t *testing.T) {
+	env := setupAssetTestServer(t)
+
+	user, err := env.core.CreateUser(env.ctx, "system", "publicrouteuser", "Public Route User", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	room, err := env.core.CreateRoom(env.ctx, user.Id, "channel", "", "public-route-private", "Private Assets")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	if _, err := env.core.JoinRoom(env.ctx, user.Id, "channel", user.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom: %v", err)
+	}
+	env.login(t, "publicrouteuser", "password123")
+
+	imageData := createAssetTestPNG(t, 320, 240)
+	_, attachment := env.postAssetMessageWithAttachment(t, room.Id, "private image", imageData, "private.png")
+	assetID := attachment.GetId()
+	if assetID == "" {
+		t.Fatal("attachment asset id is empty")
+	}
+
+	assertStatus := func(path string, want int) *http.Response {
+		t.Helper()
+		resp, err := (&http.Client{}).Get(env.server.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != want {
+			t.Fatalf("GET %s status = %d, want %d", path, resp.StatusCode, want)
+		}
+		return resp
+	}
+
+	// The public original and transform routes must not expose a declared room
+	// attachment, while its ticketed protected route remains usable.
+	assertStatus("/assets/server/"+assetID, http.StatusNotFound)
+	privateTransform := env.core.GetTransformedServerAssetURL(assetID, 64, 64, "cover")
+	assertStatus(privateTransform, http.StatusNotFound)
+	assertStatus("/assets/server/"+assetID+"/t/not-a-valid-signature", http.StatusNotFound)
+	assertStatus(attachment.GetAssetUrl().GetUrl(), http.StatusOK)
+	assertStatus(attachment.GetThumbnailAssetUrl().GetUrl(), http.StatusOK)
+
+	// A pre-populated public-transform cache entry cannot bypass classification.
+	cacheKey := core.ImageCacheKey(core.ServerAssetSignResource, assetID, 64, 64, "cover")
+	if err := env.core.StoreCachedResize(env.ctx, cacheKey, createAssetTestPNG(t, 64, 64)); err != nil {
+		t.Fatalf("seed private server-transform cache: %v", err)
+	}
+	resp := assertStatus(privateTransform, http.StatusNotFound)
+	if got := resp.Header.Get("X-Cache"); got != "" {
+		t.Fatalf("private transform exposed cache state %q", got)
+	}
+
+	// Model a supported legacy attachment whose object lacks modern Room-Id
+	// metadata. Its durable AssetProjection declaration must still deny it.
+	store := env.core.ServerStore()
+	info, err := store.GetInfo(env.ctx, assetID)
+	if err != nil {
+		t.Fatalf("GetInfo legacy fixture: %v", err)
+	}
+	headers := maps.Clone(info.Headers)
+	headers.Del("Room-Id")
+	if err := store.UpdateMeta(env.ctx, assetID, jetstream.ObjectMeta{Name: assetID, Headers: headers}); err != nil {
+		t.Fatalf("UpdateMeta legacy fixture: %v", err)
+	}
+	assertStatus("/assets/server/"+assetID, http.StatusNotFound)
+	if err := env.core.Assets.Apply(&corev1.Event{
+		Id: "Edeletedprivate",
+		Event: &corev1.Event_AssetDeleted{AssetDeleted: &corev1.AssetDeletedEvent{
+			AssetId: assetID,
+		}},
+	}, 999_002); err != nil {
+		t.Fatalf("project private asset tombstone: %v", err)
+	}
+	assertStatus("/assets/server/"+assetID, http.StatusNotFound)
+
+	// Exercise the real resumable-upload producer and discover its temporary
+	// object key without completing (and therefore deleting) the upload.
+	uploadClient := apiv1connect.NewAssetUploadServiceClient(env.client, env.server.URL+connectAPIPrefix)
+	chunkData := []byte("private resumable chunk")
+	chunkSum := sha256.Sum256(chunkData)
+	createdUpload, err := uploadClient.CreateUpload(env.ctx, connect.NewRequest(&apiv1.CreateUploadRequest{
+		RoomId:      room.Id,
+		Filename:    "pending.txt",
+		ContentType: "text/plain",
+		Size:        int64(len(chunkData)),
+		Sha256:      hex.EncodeToString(chunkSum[:]),
+	}))
+	if err != nil {
+		t.Fatalf("create resumable upload fixture: %v", err)
+	}
+	if _, err := uploadClient.UploadChunk(env.ctx, connect.NewRequest(&apiv1.UploadChunkRequest{
+		UploadId:    createdUpload.Msg.GetUpload().GetUploadId(),
+		Content:     chunkData,
+		ChunkSha256: hex.EncodeToString(chunkSum[:]),
+	})); err != nil {
+		t.Fatalf("upload resumable chunk fixture: %v", err)
+	}
+	objects, err := store.List(env.ctx)
+	if err != nil {
+		t.Fatalf("list upload chunk fixture: %v", err)
+	}
+	chunkKey := ""
+	for _, object := range objects {
+		if object != nil && strings.HasPrefix(object.Name, "asset-upload."+createdUpload.Msg.GetUpload().GetUploadId()+".") {
+			chunkKey = object.Name
+			break
+		}
+	}
+	if chunkKey == "" {
+		t.Fatal("resumable upload chunk object was not found")
+	}
+	assertStatus("/assets/server/"+chunkKey, http.StatusNotFound)
+	assertStatus(env.core.GetTransformedServerAssetURL(chunkKey, 32, 32, "cover"), http.StatusNotFound)
+
+	// Temporary, reserved, private-metadata, and unknown canonical objects all
+	// look absent through both original and transformed public paths.
+	fixtures := []struct {
+		key     string
+		headers map[string][]string
+	}{
+		{key: "attachments/" + assetID},
+		{key: "spaces/server/attachments/" + assetID},
+		{key: "Aroommetadata00", headers: map[string][]string{"Room-Id": {room.Id}}},
+		{key: "Aunknownobject0"},
+	}
+	for _, fixture := range fixtures {
+		if _, err := store.Put(env.ctx, jetstream.ObjectMeta{Name: fixture.key, Headers: fixture.headers}, bytes.NewReader(imageData)); err != nil {
+			t.Fatalf("store fixture %q: %v", fixture.key, err)
+		}
+		assertStatus("/assets/server/"+fixture.key, http.StatusNotFound)
+		assertStatus(env.core.GetTransformedServerAssetURL(fixture.key, 32, 32, "cover"), http.StatusNotFound)
+	}
+}
+
+func TestAsset_PublicLinkPreviewMarkerServesWithoutAuthentication(t *testing.T) {
+	env := setupAssetTestServer(t)
+	assetID := core.NewAssetID()
+	imageData := createAssetTestPNG(t, 120, 80)
+	if _, err := env.core.ServerStore().Put(env.ctx, jetstream.ObjectMeta{
+		Name: assetID,
+		Headers: map[string][]string{
+			"Content-Type":                   {"image/png"},
+			core.ServerAssetVisibilityHeader: {core.ServerAssetVisibilityPublic},
+		},
+	}, bytes.NewReader(imageData)); err != nil {
+		t.Fatalf("store marked link-preview image: %v", err)
+	}
+
+	resp, err := (&http.Client{}).Get(env.server.URL + "/assets/server/" + assetID)
+	if err != nil {
+		t.Fatalf("GET public link-preview image: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("public link-preview status = %d, want 200", resp.StatusCode)
+	}
+
+	// Historical preview objects did not carry the marker. Durable message-body
+	// references rebuild the positive public declaration during projection replay.
+	legacyID := core.NewAssetID()
+	if _, err := env.core.ServerStore().Put(env.ctx, jetstream.ObjectMeta{
+		Name:    legacyID,
+		Headers: map[string][]string{"Content-Type": {"image/png"}},
+	}, bytes.NewReader(imageData)); err != nil {
+		t.Fatalf("store historical link-preview image: %v", err)
+	}
+	if err := env.core.RoomTimeline.Apply(&corev1.Event{
+		Id: "Epreviewhistory",
+		Event: &corev1.Event_MessageBody{MessageBody: &corev1.MessageBodyEvent{
+			RoomId:  "Rpreviewhistory",
+			EventId: "Epreviewmessage",
+			Body: &corev1.MessageBody{LinkPreview: &corev1.LinkPreview{
+				ImageAssetId: &legacyID,
+				ImageAsset:   &corev1.AssetRecord{Id: legacyID},
+			}},
+		}},
+	}, 999_001); err != nil {
+		t.Fatalf("project historical link-preview reference: %v", err)
+	}
+	legacyResp, err := (&http.Client{}).Get(env.server.URL + "/assets/server/" + legacyID)
+	if err != nil {
+		t.Fatalf("GET historical link-preview image: %v", err)
+	}
+	legacyResp.Body.Close()
+	if legacyResp.StatusCode != http.StatusOK {
+		t.Fatalf("historical link-preview status = %d, want 200", legacyResp.StatusCode)
 	}
 }
 
@@ -1217,6 +1416,26 @@ func TestAsset_StableURLOnS3IsCapability(t *testing.T) {
 	if transformResp.StatusCode != http.StatusOK {
 		t.Errorf("S3 transform URL: expected 200 with access ticket, got %d", transformResp.StatusCode)
 	}
+
+	// The public server route probes only the separate instance/ namespace and
+	// must never fall through to S3 attachments/ objects.
+	publicOriginal, err := unauthClient.Get(env.server.URL + "/assets/server/" + attachment.GetId())
+	if err != nil {
+		t.Fatalf("S3 public original probe: %v", err)
+	}
+	publicOriginal.Body.Close()
+	if publicOriginal.StatusCode != http.StatusNotFound {
+		t.Fatalf("S3 public original probe status = %d, want 404", publicOriginal.StatusCode)
+	}
+	publicTransformURL := env.core.GetTransformedServerAssetURL(attachment.GetId(), 64, 64, "cover")
+	publicTransform, err := unauthClient.Get(env.server.URL + publicTransformURL)
+	if err != nil {
+		t.Fatalf("S3 public transform probe: %v", err)
+	}
+	publicTransform.Body.Close()
+	if publicTransform.StatusCode != http.StatusNotFound {
+		t.Fatalf("S3 public transform probe status = %d, want 404", publicTransform.StatusCode)
+	}
 }
 
 // TestAsset_RevokedMembership_RevokesStableURL covers the "kick / leave"
@@ -1240,6 +1459,7 @@ func TestAsset_RevokedMembership_RevokesStableURL(t *testing.T) {
 	imageData := createAssetTestPNG(t, 400, 300)
 	_, attachment := env.postAssetMessageWithAttachment(t, room.Id, "private", imageData, "private.png")
 	attachmentURL := attachment.GetAssetUrl().GetUrl()
+	thumbnailURL := attachment.GetThumbnailAssetUrl().GetUrl()
 
 	// Sanity check: owner can fetch their own URL without a cookie because the
 	// access ticket is the capability.
@@ -1256,6 +1476,14 @@ func TestAsset_RevokedMembership_RevokesStableURL(t *testing.T) {
 	if r.StatusCode != http.StatusOK {
 		t.Fatalf("expected stable URL to work pre-leave, got %d", r.StatusCode)
 	}
+	thumb, err := plainClient.Get(env.server.URL + thumbnailURL)
+	if err != nil {
+		t.Fatalf("pre-leave thumbnail GET: %v", err)
+	}
+	thumb.Body.Close()
+	if thumb.StatusCode != http.StatusOK {
+		t.Fatalf("expected stable thumbnail to work pre-leave, got %d", thumb.StatusCode)
+	}
 
 	// Owner leaves the room, so their stable access-ticket URL should stop working.
 	if err := env.core.LeaveRoom(env.ctx, owner.Id, "channel", owner.Id, room.Id); err != nil {
@@ -1269,5 +1497,13 @@ func TestAsset_RevokedMembership_RevokesStableURL(t *testing.T) {
 	r2.Body.Close()
 	if r2.StatusCode != http.StatusForbidden {
 		t.Errorf("expected 403 after ticket user left the room, got %d", r2.StatusCode)
+	}
+	thumb2, err := plainClient.Get(env.server.URL + thumbnailURL)
+	if err != nil {
+		t.Fatalf("post-leave thumbnail GET: %v", err)
+	}
+	thumb2.Body.Close()
+	if thumb2.StatusCode != http.StatusForbidden {
+		t.Errorf("expected cached thumbnail ticket to fail after leave, got %d", thumb2.StatusCode)
 	}
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -763,7 +763,7 @@ Notes: Only created when `[core.assets.cache]` is enabled in config. Uses TTL fo
 
 | Key         | Description                                    |
 | ----------- | ---------------------------------------------- |
-| `{assetId}` | Persisted asset binary by ID when stored in NATS |
+| `{assetId}` | Persisted asset binary by ID when stored in NATS; new public server assets carry `Chatto-Asset-Visibility: public` |
 | `asset-upload.{uploadId}.{offset}` | Temporary attachment upload chunk before completion |
 
 **S3 asset keys:**
@@ -775,7 +775,20 @@ Notes: Only created when `[core.assets.cache]` is enabled in config. Uses TTL fo
 
 Attachment upload storage: chunked uploads first store temporary `asset-upload.*` chunks in `SERVER_ASSETS`. Completion verifies the full SHA-256, stores the final attachment in NATS or S3, records SHA-256/uploader/pending-expiry/video hints in `AssetCreatedEvent`, and deletes temporary chunks. Completed but unclaimed pending attachment assets expire after 24 hours unless a message body claims them.
 
-Notes: Asset IDs are globally unique (NanoID), so NATS-backed assets do not need a kind segment. S3 stores logical, prefix-free keys; any configured `path_prefix` is applied only when talking to the S3 backend. Content-Type and original filename stored in object headers where available. S2 compression enabled for `SERVER_ASSETS`. `MediaModel` owns binary storage and serving helpers; `AssetModel` owns durable lifecycle facts and elected message-asset deletion recovery. Asset **metadata** (filename, dimensions, duration, storage pointer, …) is created in `AssetCreatedEvent` on `evt.asset.{assetId}.asset_created`; room scope and ownership context lives on the event (`message`, `derivative`, `user_avatar`, or `server_branding`) rather than inside `Asset`. The `asset_cleanup` lease holder incrementally replays canonical `AssetDeletedEvent` facts, locates the matching creation fact through the asset ID, and idempotently deletes source/derivative bytes and transform-cache entries. Beta room-scoped histories without a canonical asset aggregate remain readable by projections but are not guessed at by the cleanup worker. New message bodies reference message-owned assets by ID. Link preview images are server-scoped persisted assets and are embedded in message bodies as `LinkPreview.image_asset` (`AssetRecord`) so the body records whether the image lives in S3 or `SERVER_ASSETS`; `image_asset_id` remains for compatibility with clients and older stored previews. Processing events refer to created asset IDs and are appended under the same `evt.asset.{assetId}.*` aggregate. The asset projection also reads beta-era `evt.room.{roomId}.asset_*` facts so existing 0.1.0 histories continue to replay without a stream rewrite. Message posting asks the process-local video service to spawn video/animated-GIF processing after appending asset creation and processing-started events; there is no transient NATS Core worker subject or `video_processed` live signal. Boot recovery derives missed work from the EVT projections and calls the same local path. Video processing success records thumbnail/variant asset IDs, while each derivative binary is separately declared with `AssetCreatedEvent` and an owner pointing at the original asset. `AssetProcessingFailedEvent.failure_code` records failed/unavailable outcomes. Account deletion follows the projected message asset graph and appends `AssetDeletedEvent` for source assets and derivative children before deleting backing bytes. The asset HTTP handler doesn't look up a separate index bucket; stable asset URLs resolve metadata and room scope from `AssetProjection`, while legacy locator URLs carry the body-or-video-manifest locator in the URL itself (see "Dynamic Image Transformation" below).
+Notes: Asset IDs are globally unique (NanoID), so NATS-backed assets do not need a kind segment. S3 stores logical, prefix-free keys; any configured `path_prefix` is applied only when talking to the S3 backend. Content-Type and original filename are stored in object headers where available. S2 compression is enabled for `SERVER_ASSETS`. `MediaModel` owns binary storage and serving helpers; `AssetModel` owns durable lifecycle facts and elected message-asset deletion recovery. Asset **metadata** (filename, dimensions, duration, storage pointer, …) is created in `AssetCreatedEvent` on `evt.asset.{assetId}.asset_created`; room scope and ownership context lives on the event (`message`, `derivative`, `user_avatar`, or `server_branding`) rather than inside `Asset`. The `asset_cleanup` lease holder incrementally replays canonical `AssetDeletedEvent` facts, locates the matching creation fact through the asset ID, and idempotently deletes source/derivative bytes and transform-cache entries. Beta room-scoped histories without a canonical asset aggregate remain readable by projections but are not guessed at by the cleanup worker. New message bodies reference message-owned assets by ID. Link preview images are server-scoped persisted assets and are embedded in message bodies as `LinkPreview.image_asset` (`AssetRecord`) so the body records whether the image lives in S3 or `SERVER_ASSETS`; `image_asset_id` remains for compatibility with clients and older stored previews. Processing events refer to created asset IDs and are appended under the same `evt.asset.{assetId}.*` aggregate. The asset projection also reads beta-era `evt.room.{roomId}.asset_*` facts so existing 0.1.0 histories continue to replay without a stream rewrite. Message posting asks the process-local video service to spawn video/animated-GIF processing after appending asset creation and processing-started events; there is no transient NATS Core worker subject or `video_processed` live signal. Boot recovery derives missed work from the EVT projections and calls the same local path. Video processing success records thumbnail/variant asset IDs, while each derivative binary is separately declared with `AssetCreatedEvent` and an owner pointing at the original asset. `AssetProcessingFailedEvent.failure_code` records failed/unavailable outcomes. Account deletion follows the projected message asset graph and appends `AssetDeletedEvent` for source assets and derivative children before deleting backing bytes.
+
+`/assets/server/{assetId}` is an unauthenticated route limited to canonical,
+positively classified public server assets. Before transform signature parsing,
+resize-cache access, object reads, or image transformation, the handler rejects
+reserved namespaces, every live or deleted `AssetProjection` declaration,
+private NATS metadata (`Room-Id` or `Upload-Id`), and unknown NATS objects.
+Current NATS public writes carry an explicit public visibility header;
+historical avatars and branding are recognized through their current durable
+pointers, while historical link-preview images are recognized through durable
+message-body references. S3 public delivery probes only `instance/{assetId}`;
+private current and historical attachment prefixes are never probed by this
+route. Disallowed classes return 404. A dedicated public object store or
+namespace remains the preferred long-term physical boundary.
 
 ### Dynamic Image Transformation
 
@@ -828,6 +841,11 @@ URL plus `AssetURL.expiresAt` shape.
 **Security:**
 
 URLs are signed with HMAC-SHA256 using a dedicated `signing_secret` (configured in `[core.assets]` section, separate from session secret). The signature covers the full path to prevent parameter tampering. ConnectRPC room timeline responses, `MessageService` message read responses, `AssetService` asset read responses, and `RoomService` attachment list responses generate valid signed URLs.
+
+The public server-asset transform signature authorizes only the requested
+transform parameters; it does not authorize a viewer or classify the source as
+public. Public/private classification runs independently on every request,
+including internal resize-cache hits.
 
 **ConnectRPC Integration:**
 


### PR DESCRIPTION
## Why

Backport the positive public-delivery boundary from #1499 to the current `release-0.4` line.

## What changed

- clean cherry-pick of both focused security-fix commits from the mainline PR
- no conflict resolutions, release-only adaptations, protobuf changes, or migrations
- preserves historical public asset compatibility while denying private, internal, and unknown object classes before cache or storage access

Rollout: all serving replicas must be updated before the deployment is considered protected.

## Test plan

- mounted HTTP asset regression suite on `release-0.4` — pass
- avatar projection lifecycle regression tests on `release-0.4` — pass
- `mise test-cli` on `release-0.4` — pass
- mainline PR CI — pass, including all E2E shards and media E2E
