### PR TITLE
fix(config): configure API response compression

### DIFF
--- a/apps/docs-website/src/content/docs/reference/environment-variables.mdx
+++ b/apps/docs-website/src/content/docs/reference/environment-variables.mdx
@@ -35,6 +35,14 @@ Every `chatto.toml` setting can be overridden with an environment variable. The 
   Optional hex secret for encrypting session cookies after signing. Must decode to 16, 24, or 32 bytes. Generate an AES-256 key with `openssl rand -hex 32`.
 </EnvVar>
 
+<EnvVar name="CHATTO_WEBSERVER_API_COMPRESSION" toml="webserver.api_compression" default="true">
+  Compress eligible ConnectRPC API responses with gzip. Disable this to reduce compressor memory and CPU at the cost of higher network usage. Chatto continues to accept compressed API requests.
+</EnvVar>
+
+<EnvVar name="CHATTO_WEBSERVER_API_COMPRESSION_MIN_BYTES" toml="webserver.api_compression_min_bytes" default="1024">
+  Minimum uncompressed ConnectRPC response size, in bytes, eligible for gzip compression. Increase this threshold when small API responses do not save enough bandwidth to justify compressor memory and CPU.
+</EnvVar>
+
 <EnvVar name="CHATTO_WEBSERVER_WEBSOCKET_COMPRESSION" toml="webserver.websocket_compression" default="true">
   Negotiate WebSocket compression. The realtime server compresses frames of at least 1 KiB with a Huffman-only encoder; smaller invalidation and heartbeat frames stay uncompressed and do not instantiate server-side compressor state.
 </EnvVar>

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -74,6 +74,8 @@ type WebserverConfig struct {
 	AllowedOrigins         []string      `toml:"allowed_origins" env:"CHATTO_WEBSERVER_ALLOWED_ORIGINS" comment:"Origins allowed for cross-server browser API access. Use [\"*\"] to allow bearer-token clients without cookies; use exact origins to allow credentialed CORS/WebSocket access. Exact non-wildcard entries are also trusted for OAuth redirect callbacks."`
 	OAuthRedirectOrigins   []string      `toml:"oauth_redirect_origins" env:"CHATTO_WEBSERVER_OAUTH_REDIRECT_ORIGINS" comment:"Additional origins trusted only for OAuth redirect callbacks. Leave empty unless another web origin must complete OAuth. Use exact HTTPS origins in production; loopback development origins may use HTTP."`
 	TrustedProxies         []string      `toml:"trusted_proxies,commented" env:"CHATTO_WEBSERVER_TRUSTED_PROXIES" comment:"IP addresses or CIDR ranges of reverse proxies allowed to supply forwarded host and client-IP headers. Default: none."`
+	APICompression         *bool         `toml:"api_compression" env:"CHATTO_WEBSERVER_API_COMPRESSION" comment:"Compress eligible ConnectRPC API responses with gzip. Disable to reduce compressor memory and CPU at the cost of higher network usage. Default: true."`
+	APICompressionMinBytes *int          `toml:"api_compression_min_bytes" env:"CHATTO_WEBSERVER_API_COMPRESSION_MIN_BYTES" comment:"Minimum uncompressed ConnectRPC response size eligible for gzip compression. Default: 1024."`
 	WebSocketCompression   *bool         `toml:"websocket_compression" env:"CHATTO_WEBSERVER_WEBSOCKET_COMPRESSION" comment:"Enable WebSocket compression for eligible realtime frames. Default: true."`
 	RequestLogging         *bool         `toml:"request_logging" env:"CHATTO_WEBSERVER_REQUEST_LOGGING" comment:"Log HTTP requests. Successful requests are debug-level; 4xx responses are warnings; 5xx responses are errors. Useful for debugging but can be noisy in production. Default: false."`
 	CookieSigningSecret    string        `toml:"cookie_signing_secret" env:"CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET" comment:"Secret for signing session cookies. NEVER SHARE THIS!\nIf it leaks, change it immediately, but please note that all existing sessions will become invalid."`
@@ -288,6 +290,26 @@ func (c *WebserverConfig) WebSocketCompressionEnabled() bool {
 		return true
 	}
 	return *c.WebSocketCompression
+}
+
+const defaultAPICompressionMinBytes = 1024
+
+// APICompressionEnabled returns whether ConnectRPC responses may be
+// compressed, defaulting to true. Compressed requests remain supported.
+func (c *WebserverConfig) APICompressionEnabled() bool {
+	if c.APICompression == nil {
+		return true
+	}
+	return *c.APICompression
+}
+
+// APICompressionMinBytesOrDefault returns the smallest uncompressed
+// ConnectRPC response eligible for compression.
+func (c *WebserverConfig) APICompressionMinBytesOrDefault() int {
+	if c.APICompressionMinBytes == nil {
+		return defaultAPICompressionMinBytes
+	}
+	return *c.APICompressionMinBytes
 }
 
 // RequestLoggingEnabled returns whether HTTP request logging is enabled (default: false)
@@ -964,6 +986,9 @@ func (c *ChattoConfig) Validate() error {
 	}
 	if c.Webserver.Port == 0 && !c.Webserver.TLS.Enabled {
 		errs = append(errs, "webserver.port is required when TLS is disabled")
+	}
+	if c.Webserver.APICompressionMinBytes != nil && *c.Webserver.APICompressionMinBytes < 0 {
+		errs = append(errs, "webserver.api_compression_min_bytes must not be negative")
 	}
 	if c.Metrics.Enabled {
 		if c.Metrics.Port < 0 || c.Metrics.Port > 65535 {

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -24,6 +24,8 @@ func TestReadConfig_WithoutConfigFile(t *testing.T) {
 	t.Setenv("CHATTO_WEBSERVER_PORT", "4000")
 	t.Setenv("CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
 	t.Setenv("CHATTO_WEBSERVER_COOKIE_ENCRYPTION_SECRET", "000102030405060708090a0b0c0d0e0f")
+	t.Setenv("CHATTO_WEBSERVER_API_COMPRESSION", "false")
+	t.Setenv("CHATTO_WEBSERVER_API_COMPRESSION_MIN_BYTES", "8192")
 	t.Setenv("CHATTO_CORE_SECRET_KEY", "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789")
 	t.Setenv("CHATTO_CORE_ASSETS_SIGNING_SECRET", "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff")
 
@@ -42,6 +44,12 @@ func TestReadConfig_WithoutConfigFile(t *testing.T) {
 	}
 	if cfg.Webserver.CookieEncryptionSecret != "000102030405060708090a0b0c0d0e0f" {
 		t.Errorf("expected cookie encryption secret to be set from env var")
+	}
+	if cfg.Webserver.APICompressionEnabled() {
+		t.Error("expected API response compression disabled from env var")
+	}
+	if got := cfg.Webserver.APICompressionMinBytesOrDefault(); got != 8192 {
+		t.Errorf("APICompressionMinBytesOrDefault() = %d, want 8192", got)
 	}
 	if cfg.Core.SecretKey != "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789" {
 		t.Errorf("expected core secret to be set from env var")
@@ -921,6 +929,61 @@ func TestWebserverConfig_WebSocketCompressionEnabled(t *testing.T) {
 				t.Errorf("WebSocketCompressionEnabled() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestWebserverConfig_APICompression(t *testing.T) {
+	tests := []struct {
+		name        string
+		compression *bool
+		minBytes    *int
+		wantEnabled bool
+		wantMin     int
+	}{
+		{
+			name:        "defaults to enabled above one KiB",
+			wantEnabled: true,
+			wantMin:     1024,
+		},
+		{
+			name:        "explicitly disabled with custom threshold",
+			compression: boolPtr(false),
+			minBytes:    intPtr(8192),
+			wantEnabled: false,
+			wantMin:     8192,
+		},
+		{
+			name:        "zero threshold compresses every non-empty response",
+			compression: boolPtr(true),
+			minBytes:    intPtr(0),
+			wantEnabled: true,
+			wantMin:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := WebserverConfig{
+				APICompression:         tt.compression,
+				APICompressionMinBytes: tt.minBytes,
+			}
+			if got := cfg.APICompressionEnabled(); got != tt.wantEnabled {
+				t.Errorf("APICompressionEnabled() = %v, want %v", got, tt.wantEnabled)
+			}
+			if got := cfg.APICompressionMinBytesOrDefault(); got != tt.wantMin {
+				t.Errorf("APICompressionMinBytesOrDefault() = %d, want %d", got, tt.wantMin)
+			}
+		})
+	}
+}
+
+func TestChattoConfig_Validate_APICompressionMinBytes(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.Webserver.APICompressionMinBytes = intPtr(-1)
+
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "webserver.api_compression_min_bytes must not be negative") {
+		t.Fatalf("Validate() error = %v, want negative API compression threshold error", err)
 	}
 }
 

--- a/cli/internal/connectapi/api.go
+++ b/cli/internal/connectapi/api.go
@@ -1,6 +1,7 @@
 package connectapi
 
 import (
+	"math"
 	"net/http"
 
 	"connectrpc.com/connect"
@@ -56,12 +57,25 @@ func New(core *core.ChattoCore, config config.ChattoConfig, version string) *API
 // public API. HTTP middleware that writes Connect errors should use the same
 // options so errors are encoded consistently with the generated handlers.
 func HandlerOptions() []connect.HandlerOption {
-	return handlerOptionsWithReadMax(MaxRequestMessageBytes)
+	return HandlerOptionsForWebserver(config.WebserverConfig{})
 }
 
-func handlerOptionsWithReadMax(readMaxBytes int) []connect.HandlerOption {
+// HandlerOptionsForWebserver returns the common Connect handler options with
+// the webserver's response-compression policy applied.
+func HandlerOptionsForWebserver(webserver config.WebserverConfig) []connect.HandlerOption {
+	return handlerOptionsWithReadMax(MaxRequestMessageBytes, webserver)
+}
+
+func handlerOptionsWithReadMax(readMaxBytes int, webserver config.WebserverConfig) []connect.HandlerOption {
+	compressionMinBytes := webserver.APICompressionMinBytesOrDefault()
+	if !webserver.APICompressionEnabled() {
+		// Keep gzip request decoding available while making response compression
+		// unreachable for any message representable by Connect's int-sized buffer.
+		compressionMinBytes = math.MaxInt
+	}
 	return []connect.HandlerOption{
 		connect.WithReadMaxBytes(readMaxBytes),
+		connect.WithCompressMinBytes(compressionMinBytes),
 		connect.WithInterceptors(
 			internalErrorLoggingInterceptor(),
 			validate.NewInterceptor(),
@@ -70,12 +84,12 @@ func handlerOptionsWithReadMax(readMaxBytes int) []connect.HandlerOption {
 }
 
 func (a *API) Handlers() []Handler {
-	options := HandlerOptions()
+	options := HandlerOptionsForWebserver(a.config.Webserver)
 	uploadOptions := options
 	assetUploadOptions := options
 	if a.core != nil {
-		uploadOptions = handlerOptionsWithReadMax(uploadRequestMaxBytes(a.core.AssetsConfig().MaxUploadSize))
-		assetUploadOptions = handlerOptionsWithReadMax(assetUploadRequestMaxBytes())
+		uploadOptions = handlerOptionsWithReadMax(uploadRequestMaxBytes(a.core.AssetsConfig().MaxUploadSize), a.config.Webserver)
+		assetUploadOptions = handlerOptionsWithReadMax(assetUploadRequestMaxBytes(), a.config.Webserver)
 	}
 
 	accountPath, accountHandler := apiv1connect.NewMyAccountServiceHandler(&accountService{api: a}, uploadOptions...)
@@ -134,7 +148,7 @@ func (a *API) Handlers() []Handler {
 // OperatorHandlers returns the local, root-equivalent operator API surface.
 // These handlers must only be mounted on the operator Unix socket.
 func (a *API) OperatorHandlers() []Handler {
-	options := HandlerOptions()
+	options := HandlerOptionsForWebserver(a.config.Webserver)
 	userPath, userHandler := operatorv1connect.NewOperatorUserServiceHandler(&operatorUserService{api: a}, options...)
 	return []Handler{
 		{ServicePath: userPath, Handler: userHandler, AuthPolicy: AuthPolicyPublic},

--- a/cli/internal/connectapi/compression_test.go
+++ b/cli/internal/connectapi/compression_test.go
@@ -1,0 +1,100 @@
+package connectapi
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	"hmans.de/chatto/internal/config"
+)
+
+func TestHandlerOptionsForWebserver_ResponseCompression(t *testing.T) {
+	tests := []struct {
+		name                string
+		compression         bool
+		minBytes            int
+		compressedRequest   bool
+		wantContentEncoding string
+	}{
+		{
+			name:                "compresses response above threshold",
+			compression:         true,
+			minBytes:            1024,
+			wantContentEncoding: "gzip",
+		},
+		{
+			name:        "leaves response below threshold uncompressed",
+			compression: true,
+			minBytes:    4096,
+		},
+		{
+			name:              "accepts compressed request but leaves response uncompressed when disabled",
+			minBytes:          0,
+			compressedRequest: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			procedure := "/chatto.test.v1.CompressionService/GetPayload"
+			handler := connect.NewUnaryHandler(
+				procedure,
+				func(context.Context, *connect.Request[emptypb.Empty]) (*connect.Response[wrapperspb.StringValue], error) {
+					return connect.NewResponse(wrapperspb.String(strings.Repeat("a", 2048))), nil
+				},
+				HandlerOptionsForWebserver(config.WebserverConfig{
+					APICompression:         &tt.compression,
+					APICompressionMinBytes: &tt.minBytes,
+				})...,
+			)
+			server := httptest.NewServer(handler)
+			t.Cleanup(server.Close)
+
+			var body bytes.Buffer
+			if tt.compressedRequest {
+				writer := gzip.NewWriter(&body)
+				if _, err := writer.Write([]byte("{}")); err != nil {
+					t.Fatalf("compressing request: %v", err)
+				}
+				if err := writer.Close(); err != nil {
+					t.Fatalf("closing request compressor: %v", err)
+				}
+			} else {
+				body.WriteString("{}")
+			}
+			request, err := http.NewRequest(http.MethodPost, server.URL+procedure, &body)
+			if err != nil {
+				t.Fatalf("NewRequest() error = %v", err)
+			}
+			request.Header.Set("Content-Type", "application/json")
+			request.Header.Set("Connect-Protocol-Version", "1")
+			request.Header.Set("Accept-Encoding", "gzip")
+			if tt.compressedRequest {
+				request.Header.Set("Content-Encoding", "gzip")
+			}
+
+			response, err := http.DefaultClient.Do(request)
+			if err != nil {
+				t.Fatalf("Do() error = %v", err)
+			}
+			t.Cleanup(func() { response.Body.Close() })
+			if _, err := io.Copy(io.Discard, response.Body); err != nil {
+				t.Fatalf("reading response body: %v", err)
+			}
+			if response.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusOK)
+			}
+			if got := response.Header.Get("Content-Encoding"); got != tt.wantContentEncoding {
+				t.Errorf("Content-Encoding = %q, want %q", got, tt.wantContentEncoding)
+			}
+		})
+	}
+}

--- a/cli/internal/http_server/connect.go
+++ b/cli/internal/http_server/connect.go
@@ -38,7 +38,7 @@ func (s *HTTPServer) newOperatorAPIServer() *http.Server {
 
 func (s *HTTPServer) setupConnectAPIOnRouter(router gin.IRouter) {
 	api := connectapi.New(s.core, s.config, s.version)
-	authMiddleware := authn.NewMiddleware(authenticateConnectRequest, connectapi.HandlerOptions()...)
+	authMiddleware := authn.NewMiddleware(authenticateConnectRequest, connectapi.HandlerOptionsForWebserver(s.config.Webserver)...)
 	for _, handler := range api.Handlers() {
 		serviceHandler := handler.Handler
 		switch handler.AuthPolicy {


### PR DESCRIPTION
## Summary

- add `webserver.api_compression` / `CHATTO_WEBSERVER_API_COMPRESSION` to disable ConnectRPC response gzip without disabling compressed request support
- add `webserver.api_compression_min_bytes` / `CHATTO_WEBSERVER_API_COMPRESSION_MIN_BYTES` with a 1 KiB default
- apply the response-compression policy consistently to public API, authentication, upload, and operator handlers
- add transport-level coverage for enabled, thresholded, and disabled response compression, including compressed-request compatibility
- document both settings for server operators

## Why

Production memory profiling attributed roughly 20–50 MiB of retained heap per replica, plus substantial allocation churn, to ConnectRPC's gzip compressor pool. ConnectRPC's default compression threshold is zero, so even small eligible responses can instantiate compressor state. These controls let operators measure the RAM/CPU versus network-bandwidth tradeoff and avoid compressing tiny responses by default.

## Validation

- `GOCACHE=/tmp/chatto-go-build-cache mise x -- go test ./internal/config ./internal/connectapi -timeout 2m`
- `GOCACHE=/tmp/chatto-go-build-cache mise x -- go test -tags test_endpoints ./internal/http_server -run '^$' -timeout 30s`
- `pnpm run build:docs`
- `mise x uv@latest -- uvx --from 'reuse[charset-normalizer]' reuse lint`
