### PR TITLE
fix(dockercompose): use muxed LiveKit UDP port

### DIFF
--- a/apps/docs-website/src/content/docs/guides/deployment/docker-compose.mdx
+++ b/apps/docs-website/src/content/docs/guides/deployment/docker-compose.mdx
@@ -39,7 +39,7 @@ hostname.
 
    Create DNS records for `chat.example.com` and
    `livekit.chat.example.com`. Allow inbound TCP 80, 443, and 7881 plus UDP
-   3478 and 50000-50200 in your host and cloud firewalls.
+   3478 and 7882 in your host and cloud firewalls.
 
 3. **Generate the configuration**
 
@@ -210,7 +210,7 @@ to the host:
 | TCP 443 | Caddy | HTTPS and secure WebSocket traffic for both domains |
 | TCP 7881 | LiveKit 7881 | WebRTC media fallback when UDP is unavailable |
 | UDP 3478 | LiveKit 3478 | Embedded TURN/STUN relay |
-| UDP 50000-50200 | Same LiveKit ports | Direct WebRTC media |
+| UDP 7882 | LiveKit 7882 | Direct WebRTC media |
 
 The standard Caddy image does not include the optional Caddy L4 plugin, and this
 single-host setup does not need it. Open the matching host and cloud firewall
@@ -270,11 +270,11 @@ You won't need the `livekit.*` subdomain, TCP 7881, or the LiveKit UDP ports.
 
 ## TURN Server for Restrictive Networks
 
-The default setup exposes LiveKit's direct UDP media range and its embedded TURN/UDP relay:
+The default setup exposes LiveKit's muxed direct UDP media port and its embedded TURN/UDP relay:
 
 ```yaml
 ports:
-  - "50000-50200:50000-50200/udp"
+  - "7882:7882/udp"
   - "7881:7881/tcp"
   - "3478:3478/udp"
 ```
@@ -285,6 +285,7 @@ and relay:
 ```yaml
 rtc:
   tcp_port: 7881
+  udp_port: 7882
 
 turn:
   enabled: true
@@ -318,7 +319,7 @@ See [Voice & Video Calls](/guides/infrastructure/voice-calls/#turn-for-restricti
 
 **Container startup order** — `depends_on` with `condition: service_healthy` ensures NATS and LiveKit are ready before Chatto starts. If health checks fail, check the individual service logs.
 
-**Calls don't connect** — Verify the LiveKit API key/secret in `.env` matches the selected LiveKit config (`livekit.generated.yaml` or `livekit.yaml`). Ensure `CHATTO_LIVEKIT_URL` uses the public `wss://livekit.*` subdomain (browsers connect to it directly). Check that TCP 7881 and UDP 3478 and 50000-50200 are open in your firewall. For a LAN-only host without an external IP address, set `rtc.use_external_ip: false` in `livekit.generated.yaml` before starting or restarting LiveKit.
+**Calls don't connect** — Verify the LiveKit API key/secret in `.env` matches the selected LiveKit config (`livekit.generated.yaml` or `livekit.yaml`). Ensure `CHATTO_LIVEKIT_URL` uses the public `wss://livekit.*` subdomain (browsers connect to it directly). Check that TCP 7881 and UDP 3478 and 7882 are open in your firewall. For a LAN-only host without an external IP address, set `rtc.use_external_ip: false` in `livekit.generated.yaml` before starting or restarting LiveKit.
 
 **LiveKit reports `could not resolve external IP`** — Allow DNS and outbound UDP from the LiveKit container to every endpoint in `rtc.stun_servers`. If public STUN is not acceptable, configure private STUN servers or set a stable public `rtc.node_ip` with `rtc.use_external_ip: false`.
 

--- a/apps/docs-website/src/content/docs/guides/infrastructure/voice-calls.mdx
+++ b/apps/docs-website/src/content/docs/guides/infrastructure/voice-calls.mdx
@@ -124,10 +124,10 @@ reverse proxy:
 | TCP 443 | Secure LiveKit API and WebSocket signaling, proxied to TCP 7880 |
 | TCP 7881 | ICE/TCP media fallback when UDP is unavailable |
 | UDP 3478 | Optional embedded TURN/STUN relay |
-| UDP media range | Direct WebRTC media; the Compose example uses 50000-50200 |
+| UDP 7882 | Direct WebRTC media in the Compose example |
 
-The port range must match `rtc.port_range_start` and `rtc.port_range_end` in
-your LiveKit configuration. Do not route the TCP or UDP media ports through a
+The Compose example sets `rtc.udp_port` to `7882` so LiveKit can multiplex
+direct UDP media on one port. Do not route the TCP or UDP media ports through a
 normal HTTP reverse proxy.
 
 When `rtc.use_external_ip` is enabled, the LiveKit server also uses outbound
@@ -182,11 +182,11 @@ turn:
   udp_port: 3478
 ```
 
-Expose UDP 3478 on the LiveKit host, keep the UDP media range open, and enable
-ICE/TCP on port 7881 as a fallback when UDP is unavailable. Networks that also
-block this TCP fallback need TURN/TLS. If your users can only reach outbound TCP
-443, LiveKit or TURN needs a dedicated IP address or host so it can listen on
-443 without conflicting with your HTTPS reverse proxy, and the TURN TLS
+Expose UDP 3478 on the LiveKit host, keep the direct UDP media port open, and
+enable ICE/TCP on port 7881 as a fallback when UDP is unavailable. Networks that
+also block this TCP fallback need TURN/TLS. If your users can only reach outbound
+TCP 443, LiveKit or TURN needs a dedicated IP address or host so it can listen
+on 443 without conflicting with your HTTPS reverse proxy, and the TURN TLS
 certificate must match the advertised TURN domain.
 
 Use a dedicated TURN server such as [coturn](https://github.com/coturn/coturn) when you need tighter network separation, a shared TURN service for multiple LiveKit deployments, or TURN/TLS on port 443 without moving LiveKit itself. Configure static credentials on the TURN server and list it under LiveKit's `rtc.turn_servers` configuration. The same coturn deployment can provide the private STUN endpoint listed in `rtc.stun_servers`, but these settings serve different paths: `stun_servers` discovers the LiveKit host's public IP, while `turn_servers` gives browsers a media relay.

--- a/examples/dockercompose/README.md
+++ b/examples/dockercompose/README.md
@@ -31,7 +31,7 @@ matching proxy route when using a different name.
 - Docker and Docker Compose (v2) installed
 - A domain pointing to your server (for automatic HTTPS)
 - A `livekit.` subdomain pointing to the same server (e.g., `livekit.chat.example.com`)
-- Firewall allowing inbound TCP 80, 443, and 7881 plus UDP 3478 and 50000-50200
+- Firewall allowing inbound TCP 80, 443, and 7881 plus UDP 3478 and 7882
 - DNS resolution and outbound UDP from LiveKit for STUN-based public-IP
   discovery
 
@@ -90,7 +90,7 @@ Preserve these public ports when using Caddy or your own proxy:
 | Your Chatto and LiveKit hostnames (TCP 443) | Your HTTP proxy | HTTPS and secure WebSocket traffic |
 | TCP 7881 | `livekit:7881` | WebRTC media fallback when direct UDP is unavailable |
 | UDP 3478 | `livekit:3478` | LiveKit's embedded TURN/STUN relay |
-| UDP 50000-50200 | Same ports on `livekit` | Direct WebRTC media |
+| UDP 7882 | `livekit:7882` | Direct WebRTC media |
 
 With `rtc.use_external_ip: true`, the LiveKit server sends STUN requests at
 startup to discover the public address it should advertise. Allow DNS and
@@ -211,7 +211,7 @@ curl --fail --silent --show-error --output /dev/null https://livekit.chat.exampl
 
 The HTTPS checks verify routing and LiveKit signaling, but not WebRTC media.
 Join a call from two different networks or devices to exercise TCP 7881 and the
-UDP media ports.
+UDP media ports 3478 and 7882.
 
 ## Inspecting NATS
 
@@ -256,7 +256,7 @@ Data is persisted in Docker volumes:
 
 ## Disabling Voice and Video Calls
 
-If you don't need calls, remove the `livekit` service from `compose.yml`, delete the selected LiveKit config (`livekit.generated.yaml` or `livekit.yaml`), remove the `livekit.*` block from the `Caddyfile`, remove LiveKit from `chatto.depends_on` and `caddy.depends_on`, and remove the LiveKit environment variables from `.env`. You can then close TCP 7881 and UDP 3478 and 50000-50200 and remove the `livekit.*` DNS record.
+If you don't need calls, remove the `livekit` service from `compose.yml`, delete the selected LiveKit config (`livekit.generated.yaml` or `livekit.yaml`), remove the `livekit.*` block from the `Caddyfile`, remove LiveKit from `chatto.depends_on` and `caddy.depends_on`, and remove the LiveKit environment variables from `.env`. You can then close TCP 7881 and UDP 3478 and 7882 and remove the `livekit.*` DNS record.
 
 ## Troubleshooting
 
@@ -272,7 +272,7 @@ If you don't need calls, remove the `livekit` service from `compose.yml`, delete
 
 **Calls not working**: Ensure the LiveKit API key/secret in `.env` matches the `keys:` section in the selected LiveKit config (`livekit.generated.yaml` or `livekit.yaml`). Also verify the webhook URL points to your Chatto instance. Make sure `CHATTO_LIVEKIT_URL` uses the public `wss://livekit.` subdomain (not the internal Docker hostname), since browsers connect to it directly.
 
-**LiveKit media ports**: The example exposes UDP 50000-50200 for direct WebRTC media, UDP 3478 for LiveKit's embedded TURN/STUN relay, and TCP 7881 as a media fallback. Ensure your firewall allows all three.
+**LiveKit media ports**: The example exposes UDP 7882 for direct WebRTC media, UDP 3478 for LiveKit's embedded TURN/STUN relay, and TCP 7881 as a media fallback. Ensure your firewall allows all three.
 
 **LiveKit fails to start with `could not resolve external IP`**: With
 `rtc.use_external_ip: true`, allow DNS and outbound UDP to every endpoint in

--- a/examples/dockercompose/compose.yml
+++ b/examples/dockercompose/compose.yml
@@ -16,7 +16,7 @@ services:
       - --config
       - /etc/livekit.yaml
     ports:
-      - "50000-50200:50000-50200/udp"  # WebRTC media (UDP, must be direct)
+      - "7882:7882/udp"  # WebRTC media (UDP, must be direct)
       - "7881:7881/tcp"  # WebRTC media fallback when UDP is unavailable
       - "3478:3478/udp"  # TURN/STUN relay for NAT traversal
     expose:

--- a/examples/dockercompose/init-env.sh
+++ b/examples/dockercompose/init-env.sh
@@ -128,8 +128,7 @@ cat > livekit.generated.yaml <<EOF
 port: 7880
 rtc:
   tcp_port: 7881
-  port_range_start: 50000
-  port_range_end: 50200
+  udp_port: 7882
   use_external_ip: true
 
 turn:

--- a/examples/dockercompose/livekit.yaml
+++ b/examples/dockercompose/livekit.yaml
@@ -1,8 +1,7 @@
 port: 7880
 rtc:
   tcp_port: 7881
-  port_range_start: 50000
-  port_range_end: 50200
+  udp_port: 7882
   use_external_ip: true
 
 turn:


### PR DESCRIPTION
## Why

Self-hosted operators should not need to expose a broad UDP range when LiveKit supports multiplexing direct WebRTC media on one port.

## What changed

- Configure the checked-in and generated Docker Compose LiveKit setup to use `rtc.udp_port: 7882` and publish UDP 7882 while retaining TURN/UDP 3478 and ICE/TCP 7881.
- Update the example README and docs website deployment guidance, firewall tables, and troubleshooting text to match.

## Test plan

- Passed `sh -n init-env.sh`, generated a disposable environment, and validated it with `docker compose config --quiet`.
- Passed `mise x -- pnpm --filter docs-website build` and `git diff --check`.
