### PR TITLE
fix(frontend): hide deleted users from membership events

### DIFF
--- a/apps/frontend/e2e/account-deletion.test.ts
+++ b/apps/frontend/e2e/account-deletion.test.ts
@@ -192,7 +192,7 @@ test.describe('Account Deletion', () => {
       );
     });
 
-    test('system events from deleted users show an italicized placeholder', async ({
+    test('join events from deleted users are hidden', async ({
       page,
       chatPage,
       browser,
@@ -228,13 +228,9 @@ test.describe('Account Deletion', () => {
           await page.reload();
           await waitForRoomReady(page, 'general');
 
-          // User A should now see an italicized deleted-user placeholder.
-          await expect(page.getByText(/\[deleted user\] joined the room/)).toBeVisible({
-            timeout: TIMEOUTS.REALTIME_EVENT
-          });
-          await expect(page.locator('em').filter({ hasText: '[deleted user]' }).first()).toBeVisible();
-
-          // User B's original display name should no longer be visible in system events
+          // The historical membership fact remains stored, but its deleted actor
+          // provides no useful timeline context and should not be rendered.
+          await expect(page.getByText(/\[deleted user\] joined the room/)).not.toBeVisible();
           await expect(page.getByText(new RegExp(`${userB.displayName} joined`))).not.toBeVisible();
         }
       );

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEvent.svelte
@@ -28,9 +28,10 @@
     return { id: event?.actorId ?? 'unknown', name: 'Deleted User', user: null };
   });
 
+  const eventKind = $derived(event?.event ? roomEventKind(event.event) : null);
+
   const action = $derived.by(() => {
-    if (!event?.event) return null;
-    switch (roomEventKind(event.event)) {
+    switch (eventKind) {
       case RoomEventKind.UserJoinedRoom:
         return m['room.system_events.joined']({ count: 1 });
       case RoomEventKind.UserLeftRoom:
@@ -44,9 +45,13 @@
     }
   });
 
+  const isDeletedJoinLeave = $derived(
+    !subject.user &&
+      (eventKind === RoomEventKind.UserJoinedRoom || eventKind === RoomEventKind.UserLeftRoom)
+  );
 </script>
 
-{#if action}
+{#if action && !isDeletedJoinLeave}
   <div class="mt-4 flex items-center gap-4 px-2 md:px-4" data-event-id={event.id}>
     <!-- Avatar column (w-11 matches MessageEvent avatar width) -->
     <div class="flex w-11 shrink-0 items-center justify-center">

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEvent.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEvent.svelte.spec.ts
@@ -19,7 +19,10 @@ vi.mock('$lib/state/presenceCache.svelte', () => ({
 }));
 
 function systemEvent(
-  kind: typeof RoomEventKind.UserJoinedRoom | typeof RoomEventKind.UserLeftRoom,
+  kind:
+    | typeof RoomEventKind.UserJoinedRoom
+    | typeof RoomEventKind.UserLeftRoom
+    | typeof RoomEventKind.RoomArchived,
   actorName = 'Alice'
 ): RoomEventView {
   return {
@@ -62,24 +65,43 @@ describe('SystemEvent', () => {
     expect(container.textContent).toContain('Alice left the room');
   });
 
-  it('renders a deleted actor as an italicized placeholder', () => {
+  it.each([RoomEventKind.UserJoinedRoom, RoomEventKind.UserLeftRoom])(
+    'does not render a missing actor for %s events',
+    (kind) => {
+      const event = systemEvent(kind);
+      event.actor = null;
+
+      const { container } = render(SystemEvent, { props: { event } });
+
+      expect(container.querySelector('[data-event-id]')).toBeNull();
+    }
+  );
+
+  it('does not render an actor marked as deleted', () => {
     const event = systemEvent(RoomEventKind.UserJoinedRoom);
-    event.actor = null;
+    if (event.actor) event.actor.deleted = true;
 
     const { container } = render(SystemEvent, { props: { event } });
 
-    expect(container.textContent).toContain('[deleted user] joined the room');
-    expect(container.querySelector('em')?.textContent).toBe('[deleted user]');
+    expect(container.querySelector('[data-event-id]')).toBeNull();
   });
 
-  it('localizes event copy and deleted-user labels in German', async () => {
-    await loadLocaleMessages('de');
-    setReactiveLocale('de');
-    const event = systemEvent(RoomEventKind.UserJoinedRoom);
-    event.actor = null;
+  it('preserves deleted-user placeholders for other system event types', () => {
+    const event = systemEvent(RoomEventKind.RoomArchived);
+    if (event.actor) event.actor.deleted = true;
 
     const { container } = render(SystemEvent, { props: { event } });
 
-    expect(container.textContent).toContain('[gelöschter Benutzer] ist dem Raum beigetreten');
+    expect(container.textContent).toContain('[deleted user] archived the room');
+  });
+
+  it('localizes event copy in German', async () => {
+    await loadLocaleMessages('de');
+    setReactiveLocale('de');
+    const event = systemEvent(RoomEventKind.UserJoinedRoom, 'Alice');
+
+    const { container } = render(SystemEvent, { props: { event } });
+
+    expect(container.textContent).toContain('Alice ist dem Raum beigetreten');
   });
 });

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEventGroup.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEventGroup.svelte
@@ -4,7 +4,6 @@
   import UserAvatar, { UserAvatarViewData } from '$lib/components/UserAvatar.svelte';
   import { useRenderData } from '$lib/render/data';
   import { getLiveDisplayName } from '$lib/state/userProfiles.svelte';
-  import DeletedUserLabel from '$lib/components/DeletedUserLabel.svelte';
   import * as m from '$lib/i18n/messages';
 
   let {
@@ -31,27 +30,29 @@
   type Actor = {
     id: string;
     name: string;
-    user: UserAvatarUserView | null;
+    user: UserAvatarUserView;
   };
 
   function displayName(user: UserAvatarUserView): string {
     return getLiveDisplayName(user.id, user.displayName || user.login);
   }
 
-  function eventSubject(event: RoomEventView): Actor {
+  function eventSubject(event: RoomEventView): Actor | null {
     const actor = event?.actor ? useRenderData(UserAvatarViewData, event.actor) : null;
     if (actor && !actor.deleted) {
       return { id: actor.id, name: displayName(actor), user: actor };
     }
 
-    return { id: event.actorId ?? 'unknown', name: 'Deleted User', user: null };
+    return null;
   }
 
-  // Deduplicate by actor so batched join/leave events stay compact.
+  // Deleted actors add no useful membership context. Filter them before
+  // deduplicating so names, avatars, counts, and truncation stay consistent.
   const actors = $derived.by<Actor[]>(() => {
     const result: Actor[] = [];
     for (const event of events) {
       const subject = eventSubject(event);
+      if (!subject) continue;
       if (result.some((a) => a.id === subject.id)) continue;
       result.push(subject);
     }
@@ -73,11 +74,7 @@
 </script>
 
 {#snippet actorName(actor: Actor)}
-  {#if actor.user}
-    {actor.name}
-  {:else}
-    <DeletedUserLabel />
-  {/if}
+  {actor.name}
 {/snippet}
 
 {#snippet actorNames(items: Actor[])}
@@ -99,15 +96,7 @@
     <div class="flex w-11 shrink-0 items-center justify-center">
       <div class="flex -space-x-1.5">
         {#each visibleAvatars as actor (actor.id)}
-          {#if actor.user}
-            <UserAvatar user={actor.user} size="xs" />
-          {:else}
-            <div
-              class="flex h-5 w-5 items-center justify-center rounded-full bg-surface-200 text-muted ring-1 ring-background"
-            >
-              <span class="iconify text-xs uil--user-times"></span>
-            </div>
-          {/if}
+          <UserAvatar user={actor.user} size="xs" />
         {/each}
       </div>
     </div>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEventGroup.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/SystemEventGroup.svelte.spec.ts
@@ -91,6 +91,58 @@ describe('SystemEventGroup', () => {
     expect(renderedCopy(container)).toBe('Alice and Bob left the room');
   });
 
+  it('filters deleted actors before formatting names and pluralization', () => {
+    const events = systemEvents(['Alice', 'Deleted User']);
+    if (events[1].actor) events[1].actor.deleted = true;
+
+    const { container } = render(SystemEventGroup, {
+      props: {
+        events,
+        kind: 'join',
+        expanded: false,
+        onExpandedChange: vi.fn()
+      }
+    });
+
+    expect(renderedCopy(container)).toBe('Alice joined the room');
+    expect(container.querySelector('[aria-label="alice"]')).not.toBeNull();
+    expect(container.textContent).not.toContain('Deleted User');
+  });
+
+  it('omits missing actors from mixed groups', () => {
+    const events = systemEvents(['Alice', 'Deleted User', 'Bob']);
+    events[1].actor = null;
+
+    const { container } = render(SystemEventGroup, {
+      props: {
+        events,
+        kind: 'join',
+        expanded: false,
+        onExpandedChange: vi.fn()
+      }
+    });
+
+    expect(renderedCopy(container)).toBe('Alice and Bob joined the room');
+    expect(container.textContent).not.toContain('[deleted user]');
+  });
+
+  it('renders no row when every actor is deleted or missing', () => {
+    const events = systemEvents(['Deleted User', 'Missing User']);
+    if (events[0].actor) events[0].actor.deleted = true;
+    events[1].actor = null;
+
+    const { container } = render(SystemEventGroup, {
+      props: {
+        events,
+        kind: 'leave',
+        expanded: false,
+        onExpandedChange: vi.fn()
+      }
+    });
+
+    expect(container.querySelector('[data-event-id]')).toBeNull();
+  });
+
   it('localizes the conjunction and plural action wording in German', async () => {
     await loadLocaleMessages('de');
     setReactiveLocale('de');

--- a/docs/fdr/FDR-018-account-lifecycle.md
+++ b/docs/fdr/FDR-018-account-lifecycle.md
@@ -1,7 +1,7 @@
 # FDR-018: Account Lifecycle
 
 **Status:** Active
-**Last reviewed:** 2026-07-10
+**Last reviewed:** 2026-07-13
 
 ## Overview
 
@@ -33,6 +33,7 @@ This FDR covers the user account from registration through deletion: signup, ema
 - The account deletion confirmation token itself lives in `RUNTIME_STATE` under an HMAC-derived key with a 15-minute per-key TTL.
 - On deletion, the server: removes the user's profile data, deletes their avatar, shreds the user's app-owned DEK refs from `RUNTIME_STATE` and KMS wrapping-key refs from `ENCRYPTION_KEYS`, records `UserKeyShreddedEvent` on the user aggregate, records durable deletion facts for message-owned assets and derivatives, and revokes all their sessions and bearer tokens. An elected cleanup worker retries physical removal for current message-owned asset deletion facts.
 - After deletion, all messages the user ever posted are tombstoned by projection before decryption and cryptographically unreadable. Timeline clients apply the normal deleted-message retention rule, so placeholders without current attachments, previews, reactions, or thread replies disappear after one hour.
+- Historical room join and leave facts remain stored, but timeline messages omit deleted users from membership activity. Grouped activity includes only visible actors, and the row is hidden when none remain.
 - New durable user events store login, display name, and verified email as encrypted PII payloads. Projections decrypt them while the user's key exists and skip rebuilding them after crypto-shredding.
 - The login is freed up for re-use.
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -27,7 +27,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-015](FDR-015-quick-switcher.md) | Quick Switcher (Cmd-K) | Active | 2026-05-31 |
 | [FDR-016](FDR-016-voice-calls.md) | Voice Calls | Active | 2026-07-01 |
 | [FDR-017](FDR-017-room-groups-and-sidebar-layout.md) | Room Groups & Sidebar Layout | Active | 2026-06-18 |
-| [FDR-018](FDR-018-account-lifecycle.md) | Account Lifecycle | Active | 2026-07-10 |
+| [FDR-018](FDR-018-account-lifecycle.md) | Account Lifecycle | Active | 2026-07-13 |
 | [FDR-019](FDR-019-room-lifecycle.md) | Room Lifecycle | Active | 2026-07-04 |
 | [FDR-020](FDR-020-server-branding-and-configuration.md) | Server Branding & Configuration | Active | 2026-06-06 |
 | [FDR-021](FDR-021-admin-dashboard.md) | Admin Dashboard & System Monitoring | Active | 2026-06-15 |


### PR DESCRIPTION
## Why

Deleted accounts have no useful identity context for historical room join and leave messages, so rendering a deleted-user placeholder adds timeline noise.

## What changed

- Hide standalone membership rows when their actor is deleted or unavailable.
- Filter deleted actors out of grouped membership rows before names, avatars, counts, and truncation are calculated; retain durable history and other deleted-user placeholders.
- Document the behavior in FDR-018.

## Test plan

- `vitest` focused component suite: 15 tests passed.
- `svelte-check`: 0 errors and 0 warnings; Svelte autofixer, ESLint, Prettier, and diff checks passed.
- Targeted account-deletion Playwright scenario: 1 test passed, including the production frontend build.
