### PR TITLE
fix(frontend): use server logo for browser icons

### DIFF
--- a/apps/docs-website/src/content/docs/guides/operations/community-structure.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/community-structure.mdx
@@ -97,7 +97,8 @@ Use these fields deliberately:
 | Description | Link previews and server metadata. |
 | Welcome message | Login-page context, onboarding notes, terms, or support links. |
 | Message of the day | Short operational or community-wide notice for signed-in members. |
-| Logo and banner | Visual identity for the server and login page. |
+| Logo | Visual identity in browser tabs, installed apps, server navigation, and the login page. |
+| Banner | Large-format branding on the login page and link previews. |
 | Blocked usernames | Prevent impersonation, reserved names, or offensive handles before signup. |
 
 ## Related Guides

--- a/apps/frontend/src/app.html
+++ b/apps/frontend/src/app.html
@@ -78,8 +78,8 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="manifest" href="/manifest.webmanifest" />
-    <link rel="icon" href="/favicon.png" sizes="32x32" type="image/png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="icon" href="/favicon" sizes="32x32" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon" />
     %sveltekit.head%
   </head>
   <body>

--- a/apps/frontend/src/app.html
+++ b/apps/frontend/src/app.html
@@ -78,8 +78,8 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="manifest" href="/manifest.webmanifest" />
-    <link rel="icon" href="/icons/favicon.png" type="image/png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" />
+    <link rel="icon" href="/favicon.png" sizes="32x32" type="image/png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     %sveltekit.head%
   </head>
   <body>

--- a/apps/frontend/src/appHtml.spec.ts
+++ b/apps/frontend/src/appHtml.spec.ts
@@ -120,8 +120,15 @@ describe('app.html metadata', () => {
   it('declares the Safari apple touch icon with an explicit size', () => {
     const tag = linkTag('apple-touch-icon');
 
-    expect(attributeValue(tag, 'href')).toBe('/icons/apple-touch-icon.png');
+    expect(attributeValue(tag, 'href')).toBe('/apple-touch-icon.png');
     expect(attributeValue(tag, 'sizes')).toBe('180x180');
+  });
+
+  it('declares the browser favicon with an explicit size', () => {
+    const tag = linkTag('icon');
+
+    expect(attributeValue(tag, 'href')).toBe('/favicon.png');
+    expect(attributeValue(tag, 'sizes')).toBe('32x32');
   });
 
   it('keeps manifest icon paths pointed at the generated PWA assets', () => {

--- a/apps/frontend/src/appHtml.spec.ts
+++ b/apps/frontend/src/appHtml.spec.ts
@@ -120,15 +120,16 @@ describe('app.html metadata', () => {
   it('declares the Safari apple touch icon with an explicit size', () => {
     const tag = linkTag('apple-touch-icon');
 
-    expect(attributeValue(tag, 'href')).toBe('/apple-touch-icon.png');
+    expect(attributeValue(tag, 'href')).toBe('/apple-touch-icon');
     expect(attributeValue(tag, 'sizes')).toBe('180x180');
   });
 
   it('declares the browser favicon with an explicit size', () => {
     const tag = linkTag('icon');
 
-    expect(attributeValue(tag, 'href')).toBe('/favicon.png');
+    expect(attributeValue(tag, 'href')).toBe('/favicon');
     expect(attributeValue(tag, 'sizes')).toBe('32x32');
+    expect(attributeValue(tag, 'type')).toBeNull();
   });
 
   it('keeps manifest icon paths pointed at the generated PWA assets', () => {

--- a/apps/frontend/src/lib/pwa/serviceWorkerPolicy.spec.ts
+++ b/apps/frontend/src/lib/pwa/serviceWorkerPolicy.spec.ts
@@ -37,13 +37,16 @@ describe('classifyServiceWorkerRequest', () => {
     });
   });
 
-  it('keeps the web manifest network-only because server branding can change it', () => {
-    expect(classify('/manifest.webmanifest')).toEqual({
-      cacheableShellAsset: false,
-      navigationRequest: false,
-      networkOnly: true
-    });
-  });
+  it.each(['/manifest.webmanifest', '/favicon.png', '/apple-touch-icon.png'])(
+    'keeps dynamic server branding path %s network-only',
+    (path) => {
+      expect(classify(path)).toEqual({
+        cacheableShellAsset: false,
+        navigationRequest: false,
+        networkOnly: true
+      });
+    }
+  );
 
   it.each([
     '/api/connect',

--- a/apps/frontend/src/lib/pwa/serviceWorkerPolicy.spec.ts
+++ b/apps/frontend/src/lib/pwa/serviceWorkerPolicy.spec.ts
@@ -37,7 +37,7 @@ describe('classifyServiceWorkerRequest', () => {
     });
   });
 
-  it.each(['/manifest.webmanifest', '/favicon.png', '/apple-touch-icon.png'])(
+  it.each(['/manifest.webmanifest', '/favicon', '/apple-touch-icon'])(
     'keeps dynamic server branding path %s network-only',
     (path) => {
       expect(classify(path)).toEqual({

--- a/apps/frontend/src/lib/pwa/serviceWorkerPolicy.ts
+++ b/apps/frontend/src/lib/pwa/serviceWorkerPolicy.ts
@@ -1,6 +1,6 @@
 export const OFFLINE_SHELL_PATH = '/200.html';
 
-const NETWORK_ONLY_PATHS = ['/manifest.webmanifest', '/favicon.png', '/apple-touch-icon.png'];
+const NETWORK_ONLY_PATHS = ['/manifest.webmanifest', '/favicon', '/apple-touch-icon'];
 const NETWORK_ONLY_PREFIXES = ['/api', '/auth', '/oauth', '/assets', '/webhooks'];
 
 export interface ServiceWorkerPolicy {

--- a/apps/frontend/src/lib/pwa/serviceWorkerPolicy.ts
+++ b/apps/frontend/src/lib/pwa/serviceWorkerPolicy.ts
@@ -1,6 +1,6 @@
 export const OFFLINE_SHELL_PATH = '/200.html';
 
-const NETWORK_ONLY_PATHS = ['/manifest.webmanifest'];
+const NETWORK_ONLY_PATHS = ['/manifest.webmanifest', '/favicon.png', '/apple-touch-icon.png'];
 const NETWORK_ONLY_PREFIXES = ['/api', '/auth', '/oauth', '/assets', '/webhooks'];
 
 export interface ServiceWorkerPolicy {

--- a/cli/internal/http_server/frontend.go
+++ b/cli/internal/http_server/frontend.go
@@ -339,10 +339,10 @@ func (s *HTTPServer) setupFrontendRoutes() error {
 	// Browser icon metadata uses stable semantic URLs. Each request resolves the
 	// current server logo so changing or removing branding does not require a
 	// frontend rebuild. The cache middleware keeps these redirects temporary.
-	s.router.Match([]string{"GET", "HEAD"}, "/favicon.png", func(c *gin.Context) {
+	s.router.Match([]string{"GET", "HEAD"}, "/favicon", func(c *gin.Context) {
 		s.redirectBrowserIcon(c, 32, "/icons/favicon.png")
 	})
-	s.router.Match([]string{"GET", "HEAD"}, "/apple-touch-icon.png", func(c *gin.Context) {
+	s.router.Match([]string{"GET", "HEAD"}, "/apple-touch-icon", func(c *gin.Context) {
 		s.redirectBrowserIcon(c, 180, "/icons/apple-touch-icon.png")
 	})
 

--- a/cli/internal/http_server/frontend.go
+++ b/cli/internal/http_server/frontend.go
@@ -6,7 +6,6 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
-	"html"
 	"io/fs"
 	"mime"
 	"net/http"
@@ -36,12 +35,9 @@ const (
 	contentSecurityPolicyReportOnly = "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: http: https:; media-src 'self' blob: http: https:; connect-src 'self' http: https: ws: wss:; frame-src https://www.youtube-nocookie.com; worker-src 'self'; require-trusted-types-for 'script'; trusted-types chatto-markdown-html"
 )
 
-const defaultAppleTouchIconHref = "/icons/apple-touch-icon.png"
-
 type pwaServerIconURLs struct {
-	AppleTouch180 string
-	Icon192       string
-	Icon512       string
+	Icon192 string
+	Icon512 string
 }
 
 func setFrontendSecurityHeaders(c *gin.Context) {
@@ -126,37 +122,36 @@ func setFrontendCacheHeaders(c *gin.Context) {
 	c.Next()
 }
 
-func (s *HTTPServer) currentPWAIconURLs(ctx context.Context) *pwaServerIconURLs {
+func (s *HTTPServer) currentServerIconURL(ctx context.Context, size int) string {
 	if s.core == nil {
-		return nil
+		return ""
 	}
 
-	sizeURL := func(size int) string {
-		width, height := size, size
-		url, err := s.core.GetServerLogoURL(ctx, &width, &height, "cover")
-		if err != nil {
-			s.logger.Warn("failed to get server logo URL for PWA metadata", "error", err, "size", size)
-			return ""
-		}
-		return sameOriginPWAAssetURL(url)
+	width, height := size, size
+	iconURL, err := s.core.GetServerLogoURL(ctx, &width, &height, "cover")
+	if err != nil {
+		s.logger.Warn("failed to get server logo URL for browser metadata", "error", err, "size", size)
+		return ""
 	}
+	return sameOriginServerAssetURL(iconURL)
+}
 
+func (s *HTTPServer) currentPWAIconURLs(ctx context.Context) *pwaServerIconURLs {
 	icons := &pwaServerIconURLs{
-		AppleTouch180: sizeURL(180),
-		Icon192:       sizeURL(192),
-		Icon512:       sizeURL(512),
+		Icon192: s.currentServerIconURL(ctx, 192),
+		Icon512: s.currentServerIconURL(ctx, 512),
 	}
-	if icons.AppleTouch180 == "" || icons.Icon192 == "" || icons.Icon512 == "" {
+	if icons.Icon192 == "" || icons.Icon512 == "" {
 		return nil
 	}
 	return icons
 }
 
-// sameOriginPWAAssetURL keeps install metadata on the frontend origin. General
+// sameOriginServerAssetURL keeps browser metadata on the frontend origin. General
 // asset URLs may use a configured asset base, but each Chatto frontend serves
-// its own public server assets and browsers must be able to fetch manifest
-// images from the manifest's origin.
-func sameOriginPWAAssetURL(rawURL string) string {
+// its own public server assets and browsers must be able to fetch metadata
+// images from the frontend's origin.
+func sameOriginServerAssetURL(rawURL string) string {
 	parsed, err := url.Parse(rawURL)
 	if err != nil || parsed.Opaque != "" || !strings.HasPrefix(parsed.Path, "/assets/server/") {
 		return ""
@@ -204,18 +199,6 @@ func dynamicPWAManifest(staticManifest []byte, icons *pwaServerIconURLs) ([]byte
 	return json.MarshalIndent(manifest, "", "  ")
 }
 
-func injectAppleTouchIcon(content []byte, iconURL string) []byte {
-	if iconURL == "" {
-		return content
-	}
-	escaped := html.EscapeString(iconURL)
-	return []byte(strings.ReplaceAll(
-		string(content),
-		`href="`+defaultAppleTouchIconHref+`"`,
-		`href="`+escaped+`"`,
-	))
-}
-
 // clientAcceptsEncoding checks if the client accepts a specific encoding.
 // It parses the Accept-Encoding header and looks for the encoding name.
 func clientAcceptsEncoding(acceptEncoding, encoding string) bool {
@@ -250,12 +233,17 @@ func (s *HTTPServer) serveSPAFallback(c *gin.Context, clientFS fs.FS) bool {
 	defer cancel()
 
 	content = s.injectOpenGraphTags(ctx, content, c.Request.URL.Path)
-	if icons := s.currentPWAIconURLs(ctx); icons != nil {
-		content = injectAppleTouchIcon(content, icons.AppleTouch180)
-	}
 
 	c.Data(http.StatusOK, "text/html; charset=utf-8", content)
 	return true
+}
+
+func (s *HTTPServer) redirectBrowserIcon(c *gin.Context, size int, fallbackURL string) {
+	iconURL := s.currentServerIconURL(c.Request.Context(), size)
+	if iconURL == "" {
+		iconURL = fallbackURL
+	}
+	c.Redirect(http.StatusTemporaryRedirect, iconURL)
 }
 
 func (s *HTTPServer) servePWAWebManifest(c *gin.Context, clientFS fs.FS) {
@@ -347,6 +335,16 @@ func (s *HTTPServer) setupFrontendRoutes() error {
 	// Other files under /_app/ (like version.json, env.js) are NOT content-hashed
 	// and must not be cached immutably.
 	s.router.Use(setFrontendCacheHeaders)
+
+	// Browser icon metadata uses stable semantic URLs. Each request resolves the
+	// current server logo so changing or removing branding does not require a
+	// frontend rebuild. The cache middleware keeps these redirects temporary.
+	s.router.Match([]string{"GET", "HEAD"}, "/favicon.png", func(c *gin.Context) {
+		s.redirectBrowserIcon(c, 32, "/icons/favicon.png")
+	})
+	s.router.Match([]string{"GET", "HEAD"}, "/apple-touch-icon.png", func(c *gin.Context) {
+		s.redirectBrowserIcon(c, 180, "/icons/apple-touch-icon.png")
+	})
 
 	// refreshSessionIfAuthenticated validates and rotates authenticated
 	// cookie-session records for active SPA browsing. KV TTL is set only when

--- a/cli/internal/http_server/frontend_test.go
+++ b/cli/internal/http_server/frontend_test.go
@@ -18,6 +18,7 @@ import (
 	"hmans.de/chatto/internal/core"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 	"hmans.de/chatto/internal/testutil"
+	"hmans.de/chatto/pkg/signedurl"
 )
 
 func TestExtractImmutableETag(t *testing.T) {
@@ -244,7 +245,7 @@ func TestDynamicPWAManifest(t *testing.T) {
 	})
 }
 
-func TestSameOriginPWAAssetURL(t *testing.T) {
+func TestSameOriginServerAssetURL(t *testing.T) {
 	tests := []struct {
 		name string
 		url  string
@@ -269,18 +270,9 @@ func TestSameOriginPWAAssetURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, sameOriginPWAAssetURL(tt.url))
+			assert.Equal(t, tt.want, sameOriginServerAssetURL(tt.url))
 		})
 	}
-}
-
-func TestInjectAppleTouchIcon(t *testing.T) {
-	content := []byte(`<link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" />`)
-
-	got := injectAppleTouchIcon(content, "/assets/server/logo/t/180?a=1&b=2")
-
-	assert.Contains(t, string(got), `href="/assets/server/logo/t/180?a=1&amp;b=2"`)
-	assert.NotContains(t, string(got), defaultAppleTouchIconHref)
 }
 
 func TestClientAcceptsEncoding(t *testing.T) {
@@ -400,31 +392,6 @@ func TestServeSPAFallback(t *testing.T) {
 		assert.NotContains(t, w.Body.String(), "OG_META_PLACEHOLDER")
 	})
 
-	t.Run("injects server logo apple touch icon when server logo exists", func(t *testing.T) {
-		mockFS := fstest.MapFS{
-			"200.html": &fstest.MapFile{
-				Data: []byte(`<!DOCTYPE html><html><head><!-- OG_META_PLACEHOLDER --><link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" /></head><body>SPA</body></html>`),
-			},
-		}
-
-		server := newTestServer()
-		server.core = setupFrontendTestCoreWithLogo(t)
-		server.core.AssetBaseURL = "https://assets.example.com"
-		router := gin.New()
-		router.GET("/test", func(c *gin.Context) {
-			server.serveSPAFallback(c, mockFS)
-		})
-
-		req := httptest.NewRequest("GET", "/test", nil)
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
-
-		assert.Equal(t, http.StatusOK, w.Code)
-		assert.Contains(t, w.Body.String(), `href="/assets/server/logo-asset/t/`)
-		assert.NotContains(t, w.Body.String(), "assets.example.com")
-		assert.NotContains(t, w.Body.String(), defaultAppleTouchIconHref)
-	})
-
 	t.Run("returns 500 when 200.html is missing", func(t *testing.T) {
 		// Empty filesystem - no 200.html
 		mockFS := fstest.MapFS{}
@@ -441,6 +408,78 @@ func TestServeSPAFallback(t *testing.T) {
 
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
 		assert.Equal(t, "Failed to load application", w.Body.String())
+	})
+}
+
+func TestBrowserIconRoutes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	newServer := func(t *testing.T, chattoCore *core.ChattoCore) *HTTPServer {
+		t.Helper()
+		server := &HTTPServer{
+			config: config.ChattoConfig{Webserver: config.WebserverConfig{URL: "https://example.com"}},
+			core:   chattoCore,
+			router: gin.New(),
+		}
+		if err := server.setupFrontendRoutes(); err != nil {
+			t.Fatalf("setupFrontendRoutes: %v", err)
+		}
+		return server
+	}
+
+	t.Run("redirects to distinct same-origin server logo transforms", func(t *testing.T) {
+		chattoCore := setupFrontendTestCoreWithLogo(t)
+		chattoCore.AssetBaseURL = "https://assets.example.com"
+		server := newServer(t, chattoCore)
+
+		expectedSizes := map[string]int{
+			"/favicon.png":          32,
+			"/apple-touch-icon.png": 180,
+		}
+		locations := make(map[string]string)
+		for iconPath, expectedSize := range expectedSizes {
+			req := httptest.NewRequest(http.MethodGet, iconPath, nil)
+			w := httptest.NewRecorder()
+			server.router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusTemporaryRedirect, w.Code)
+			assert.Equal(t, cacheControlNoCache, w.Header().Get("Cache-Control"))
+			location := w.Header().Get("Location")
+			assert.True(t, strings.HasPrefix(location, "/assets/server/logo-asset/t/"))
+			assert.NotContains(t, location, "assets.example.com")
+
+			signedPath := strings.TrimPrefix(location, "/assets/server/logo-asset/t/")
+			params, err := signedurl.ParseSignedTransformPath(
+				"test-signing-secret",
+				core.ServerAssetSignResource,
+				"logo-asset",
+				signedPath,
+			)
+			if err != nil {
+				t.Fatalf("parse transform for %s: %v", iconPath, err)
+			}
+			assert.Equal(t, expectedSize, params.Width)
+			assert.Equal(t, expectedSize, params.Height)
+			assert.Equal(t, "cover", params.Fit)
+			locations[iconPath] = location
+		}
+		assert.NotEqual(t, locations["/favicon.png"], locations["/apple-touch-icon.png"])
+	})
+
+	t.Run("redirects to embedded icons when no server logo exists", func(t *testing.T) {
+		server := newServer(t, nil)
+		tests := map[string]string{
+			"/favicon.png":          "/icons/favicon.png",
+			"/apple-touch-icon.png": "/icons/apple-touch-icon.png",
+		}
+		for iconPath, fallbackPath := range tests {
+			req := httptest.NewRequest(http.MethodGet, iconPath, nil)
+			w := httptest.NewRecorder()
+			server.router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusTemporaryRedirect, w.Code)
+			assert.Equal(t, fallbackPath, w.Header().Get("Location"))
+		}
 	})
 }
 

--- a/cli/internal/http_server/frontend_test.go
+++ b/cli/internal/http_server/frontend_test.go
@@ -433,8 +433,8 @@ func TestBrowserIconRoutes(t *testing.T) {
 		server := newServer(t, chattoCore)
 
 		expectedSizes := map[string]int{
-			"/favicon.png":          32,
-			"/apple-touch-icon.png": 180,
+			"/favicon":          32,
+			"/apple-touch-icon": 180,
 		}
 		locations := make(map[string]string)
 		for iconPath, expectedSize := range expectedSizes {
@@ -463,14 +463,14 @@ func TestBrowserIconRoutes(t *testing.T) {
 			assert.Equal(t, "cover", params.Fit)
 			locations[iconPath] = location
 		}
-		assert.NotEqual(t, locations["/favicon.png"], locations["/apple-touch-icon.png"])
+		assert.NotEqual(t, locations["/favicon"], locations["/apple-touch-icon"])
 	})
 
 	t.Run("redirects to embedded icons when no server logo exists", func(t *testing.T) {
 		server := newServer(t, nil)
 		tests := map[string]string{
-			"/favicon.png":          "/icons/favicon.png",
-			"/apple-touch-icon.png": "/icons/apple-touch-icon.png",
+			"/favicon":          "/icons/favicon.png",
+			"/apple-touch-icon": "/icons/apple-touch-icon.png",
 		}
 		for iconPath, fallbackPath := range tests {
 			req := httptest.NewRequest(http.MethodGet, iconPath, nil)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -800,7 +800,7 @@ never probed by this route. Disallowed classes return 404.
 
 ### Dynamic Image Transformation
 
-Chatto supports on-the-fly image transformation for attachments and user avatars, allowing clients to request images at specific dimensions without pre-generating all possible sizes. Public server branding images expose canonical asset URLs instead of accepting arbitrary transform dimensions; the HTTP frontend server uses fixed 180/192/512px cover transforms of the current server logo for Apple touch icon and web-manifest install metadata, and keeps the web manifest network-served so service-worker caches do not pin stale branding.
+Chatto supports on-the-fly image transformation for attachments and user avatars, allowing clients to request images at specific dimensions without pre-generating all possible sizes. Public server branding images expose canonical asset URLs instead of accepting arbitrary transform dimensions; the HTTP frontend server uses fixed 32/180/192/512px cover transforms of the current server logo for favicon, Apple touch icon, and web-manifest install metadata. Stable favicon and Apple touch icon routes redirect to the current same-origin transform or the corresponding bundled icon, while all dynamic branding metadata remains network-served so service-worker caches do not pin stale branding.
 
 **URL Structure:**
 

--- a/docs/fdr/FDR-027-pwa-shell-and-service-worker.md
+++ b/docs/fdr/FDR-027-pwa-shell-and-service-worker.md
@@ -1,7 +1,7 @@
 # FDR-027: PWA Shell & Service Worker
 
 **Status:** Active
-**Last reviewed:** 2026-07-09
+**Last reviewed:** 2026-07-13
 
 ## Overview
 
@@ -17,9 +17,9 @@ Reconnect catch-up is owned by the foreground web app, not the service worker. W
 - On install, the worker caches the SPA fallback shell and SvelteKit build assets required to boot it.
 - On activate, old Chatto shell caches are deleted and the new worker claims open clients.
 - Known shell assets are served cache-first from the versioned cache; static PWA assets other than the web manifest are cached lazily on first request.
-- The served web manifest and Apple touch icon metadata use the uploaded server logo when one exists, falling back to bundled Chatto icons otherwise.
+- The served web manifest, favicon, and Apple touch icon metadata use the uploaded server logo when one exists, falling back to bundled Chatto icons otherwise.
 - Same-origin navigations are network-first, falling back to the cached SPA shell only when the network fails.
-- API, auth, OAuth, webhook, uploaded-asset, web-manifest, non-GET, and cross-origin requests are network-only.
+- API, auth, OAuth, webhook, uploaded-asset, dynamic branding metadata, non-GET, and cross-origin requests are network-only.
 - Protected uploaded asset loads use direct signed asset URLs owned by the foreground app. The worker does not receive registered-server API bearer tokens, does not proxy asset requests, and does not cache protected asset bodies.
 - Push notifications continue to display native OS notifications and route notification clicks into the SPA.
 - Push dismiss payloads still close matching visible notifications on the device.
@@ -52,9 +52,9 @@ Reconnect catch-up is owned by the foreground web app, not the service worker. W
 
 ### 5. Install metadata follows server branding
 
-**Decision:** The HTTP frontend server generates the web manifest from the bundled manifest and swaps in transformed server-logo URLs for install icons when a logo is configured. The served HTML similarly replaces the Apple touch icon link with a fixed-size server-logo transform.
+**Decision:** The HTTP frontend server generates the web manifest from the bundled manifest and swaps in transformed server-logo URLs for install icons when a logo is configured. Stable favicon and Apple touch icon endpoints redirect to purpose-sized transforms of the current server logo, or to the bundled Chatto icons when no logo is configured.
 **Why:** Self-hosted servers should install with their own visible identity without requiring a custom frontend build.
-**Tradeoff:** Browsers decide when to refresh installed PWA metadata, so existing installs may keep the previous icon until the browser updates the manifest or the user reinstalls the app.
+**Tradeoff:** Browsers decide when to refresh installed PWA metadata and may cache browser icons aggressively, so existing installs or tabs may keep the previous icon until the browser revalidates the metadata or the user reinstalls the app.
 
 ## Related
 


### PR DESCRIPTION
## Why

Chatto’s frontend shell referenced the bundled favicon directly, so self-hosted servers kept Chatto’s browser icon even after an operator uploaded custom branding. Server logos should consistently identify the community in browser tabs, Apple home-screen shortcuts, and installed PWAs without requiring a custom frontend build.

## What changed

- Point `rel="icon"` and `rel="apple-touch-icon"` at stable, format-neutral `/favicon` and `/apple-touch-icon` routes with explicit 32×32 and 180×180 sizes.
- Resolve each request against the current uploaded server logo and temporarily redirect to the corresponding signed, same-origin transform.
- Redirect to the existing bundled Chatto icon when no custom logo is configured or branding metadata is unavailable.
- Keep both dynamic routes network-only in the service worker and return the existing no-store frontend cache policy so stale redirects are not pinned.
- Remove the previous Apple touch icon HTML rewriting path; the PWA manifest continues to use its dedicated 192×192 and 512×512 transforms.
- Update FDR-027, the architecture inventory, and the public community-branding guide.

There are no persisted-data, protobuf, public API, permission, migration, or rollout changes. Redirect targets are constrained to same-origin public server-asset paths.

## Test plan

Completed locally:

- `mise build-frontend`
- `mise test-frontend` — 1,940 tests passed
- `mise lint-frontend` — Svelte check reported 0 errors and 0 warnings; ESLint passed
- `mise x -- go test -tags test_endpoints ./internal/http_server -timeout 120s`
- `mise x -- pnpm --filter docs-website build`
- independent adversarial review — one MIME-contract issue fixed; two subsequent full-diff reviews returned no findings

Completed in GitHub Actions:

- frontend typecheck, lint, and all 1,940 unit tests
- CLI tests, all E2E shards, and media E2E tests
- protobuf drift and license checks

Closes #1505.
