### PR TITLE
fix(presence): handle constant wrong-sequence errors

### DIFF
--- a/cli/internal/connectapi/errors.go
+++ b/cli/internal/connectapi/errors.go
@@ -117,13 +117,14 @@ func invalidArgument(message string) error {
 }
 
 func connectInternalError(err error) error {
-	logInternalConnectError(err)
-	return connect.NewError(connect.CodeInternal, loggedInternalClientError{})
+	return connect.NewError(connect.CodeInternal, internalClientError{cause: err})
 }
 
-type loggedInternalClientError struct{}
+type internalClientError struct {
+	cause error
+}
 
-func (loggedInternalClientError) Error() string {
+func (internalClientError) Error() string {
 	return "internal server error"
 }
 
@@ -131,17 +132,20 @@ func internalErrorLoggingInterceptor() connect.Interceptor {
 	return connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 			res, err := next(ctx, req)
-			if err != nil && connect.CodeOf(err) == connect.CodeInternal && !internalErrorAlreadyLogged(err) {
-				logInternalConnectError(err, "procedure", req.Spec().Procedure)
+			if err != nil && connect.CodeOf(err) == connect.CodeInternal {
+				logInternalConnectError(internalServerCause(err), "procedure", req.Spec().Procedure)
 			}
 			return res, err
 		}
 	})
 }
 
-func internalErrorAlreadyLogged(err error) bool {
-	var logged loggedInternalClientError
-	return errors.As(err, &logged)
+func internalServerCause(err error) error {
+	var internal internalClientError
+	if errors.As(err, &internal) && internal.cause != nil {
+		return internal.cause
+	}
+	return err
 }
 
 func logInternalConnectError(err error, attrs ...any) {

--- a/cli/internal/connectapi/errors_test.go
+++ b/cli/internal/connectapi/errors_test.go
@@ -1,0 +1,59 @@
+package connectapi
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/charmbracelet/log"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+func TestInternalErrorLoggingIncludesProcedureWithoutExposingCause(t *testing.T) {
+	var logs bytes.Buffer
+	previousLogger := log.Default()
+	log.SetDefault(log.New(&logs))
+	t.Cleanup(func() { log.SetDefault(previousLogger) })
+
+	const procedure = "/chatto.test.v1.ErrorService/Fail"
+	cause := errors.New("database exploded for email=person@example.test")
+	handler := connect.NewUnaryHandler(
+		procedure,
+		func(context.Context, *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error) {
+			return nil, connectError(cause)
+		},
+		connect.WithInterceptors(internalErrorLoggingInterceptor()),
+	)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	client := connect.NewClient[emptypb.Empty, emptypb.Empty](
+		server.Client(),
+		server.URL+procedure,
+	)
+	_, err := client.CallUnary(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+	if connect.CodeOf(err) != connect.CodeInternal {
+		t.Fatalf("CallUnary code = %v, want internal (err=%v)", connect.CodeOf(err), err)
+	}
+	if strings.Contains(err.Error(), "database exploded") || strings.Contains(err.Error(), "person@example.test") {
+		t.Fatalf("client error exposed internal cause: %v", err)
+	}
+	if !strings.Contains(err.Error(), "internal server error") {
+		t.Fatalf("client error = %v, want generic internal message", err)
+	}
+
+	gotLogs := logs.String()
+	if count := strings.Count(gotLogs, "Connect API internal error"); count != 1 {
+		t.Fatalf("internal error log count = %d, want 1; logs=%q", count, gotLogs)
+	}
+	if !strings.Contains(gotLogs, procedure) || !strings.Contains(gotLogs, "database exploded") {
+		t.Fatalf("internal error log missing procedure or cause: %q", gotLogs)
+	}
+	if strings.Contains(gotLogs, "person@example.test") || !strings.Contains(gotLogs, "[redacted]") {
+		t.Fatalf("internal error log did not preserve redaction: %q", gotLogs)
+	}
+}

--- a/cli/internal/core/call_model.go
+++ b/cli/internal/core/call_model.go
@@ -18,6 +18,7 @@ import (
 
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/events"
+	"hmans.de/chatto/internal/jetstreamutil"
 	"hmans.de/chatto/internal/kms"
 	"hmans.de/chatto/internal/lease"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
@@ -751,7 +752,7 @@ func (s *CallModel) recordLiveKitListFailure(ctx context.Context) (int, error) {
 					return 0, err
 				}
 				if _, err := s.memoryCacheKV.Create(ctx, liveKitReconcileFailureKey, data); err != nil {
-					if errors.Is(err, jetstream.ErrKeyExists) {
+					if jetstreamutil.IsSequenceConflict(err) {
 						continue
 					}
 					return 0, err
@@ -772,7 +773,7 @@ func (s *CallModel) recordLiveKitListFailure(ctx context.Context) (int, error) {
 			return 0, err
 		}
 		if _, err := s.memoryCacheKV.Update(ctx, liveKitReconcileFailureKey, data, entry.Revision()); err != nil {
-			if errors.Is(err, jetstream.ErrKeyExists) {
+			if jetstreamutil.IsSequenceConflict(err) {
 				continue
 			}
 			return 0, err

--- a/cli/internal/core/email_otp.go
+++ b/cli/internal/core/email_otp.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/nats-io/nats.go/jetstream"
+
+	"hmans.de/chatto/internal/jetstreamutil"
 )
 
 const (
@@ -110,7 +112,7 @@ func (c *ChattoCore) createEmailOTP(ctx context.Context, scope, subject string, 
 
 		codeKey = c.emailOTPCodeKey(scope, subject, code)
 		codeRevision, err = c.storage.runtimeStateKV.Create(ctx, codeKey, data, jetstream.KeyTTL(ttl))
-		if errors.Is(err, jetstream.ErrKeyExists) {
+		if jetstreamutil.IsSequenceConflict(err) {
 			continue
 		}
 		if err != nil {
@@ -199,7 +201,7 @@ func (c *ChattoCore) reserveEmailOTPIssuance(ctx context.Context, scope, subject
 			if err == nil {
 				return key, revision, true, nil
 			}
-			if errors.Is(err, jetstream.ErrKeyExists) {
+			if jetstreamutil.IsSequenceConflict(err) {
 				continue
 			}
 			return "", 0, false, fmt.Errorf("failed to create email otp challenge: %w", err)

--- a/cli/internal/core/linkpreview/cache.go
+++ b/cli/internal/core/linkpreview/cache.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 	"google.golang.org/protobuf/proto"
 
+	"hmans.de/chatto/internal/jetstreamutil"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
@@ -124,7 +125,7 @@ func (c *Cache) setWithTTL(ctx context.Context, key string, data []byte, ttl tim
 	for attempt := 0; attempt < 3; attempt++ {
 		if _, err := c.kv.Create(ctx, key, data, jetstream.KeyTTL(ttl)); err == nil {
 			return nil
-		} else if !errors.Is(err, jetstream.ErrKeyExists) {
+		} else if !jetstreamutil.IsSequenceConflict(err) {
 			return err
 		} else {
 			lastErr = err

--- a/cli/internal/core/notifications.go
+++ b/cli/internal/core/notifications.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"hmans.de/chatto/internal/core/subjects"
+	"hmans.de/chatto/internal/jetstreamutil"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
@@ -184,7 +185,7 @@ func (c *ChattoCore) DismissNotification(ctx context.Context, userID, notificati
 	// replica then become an idempotent no-op instead of publishing duplicate
 	// live events and push-dismiss callbacks.
 	err = c.storage.runtimeStateKV.Delete(ctx, key, jetstream.LastRevision(entry.Revision()))
-	if errors.Is(err, jetstream.ErrKeyExists) || errors.Is(err, jetstream.ErrKeyNotFound) {
+	if jetstreamutil.IsSequenceConflict(err) || errors.Is(err, jetstream.ErrKeyNotFound) {
 		return false, nil
 	}
 	if err != nil {
@@ -245,7 +246,7 @@ func (c *ChattoCore) DismissAllNotifications(ctx context.Context, userID string)
 		}
 
 		if err := c.storage.runtimeStateKV.Delete(ctx, key, jetstream.LastRevision(entry.Revision())); err != nil {
-			if errors.Is(err, jetstream.ErrKeyExists) || errors.Is(err, jetstream.ErrKeyNotFound) {
+			if jetstreamutil.IsSequenceConflict(err) || errors.Is(err, jetstream.ErrKeyNotFound) {
 				continue
 			}
 			return deleted, fmt.Errorf("failed to delete notification: %w", err)

--- a/cli/internal/core/password_reset.go
+++ b/cli/internal/core/password_reset.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 
 	"hmans.de/chatto/internal/events"
+	"hmans.de/chatto/internal/jetstreamutil"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
@@ -96,7 +97,7 @@ func (c *ChattoCore) CreatePasswordResetToken(ctx context.Context, email string)
 	tokenKey := c.passwordResetTokenKey(token)
 	requestKey := c.passwordResetRequestKey(user.Id)
 	requestRevision, err := c.storage.runtimeStateKV.Create(ctx, requestKey, []byte(tokenKey), jetstream.KeyTTL(PasswordResetRequestThrottleTTL))
-	if errors.Is(err, jetstream.ErrKeyExists) {
+	if jetstreamutil.IsSequenceConflict(err) {
 		return "", ErrPasswordResetRequestThrottled
 	}
 	if err != nil {

--- a/cli/internal/core/presence.go
+++ b/cli/internal/core/presence.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 	"google.golang.org/protobuf/proto"
 
+	"hmans.de/chatto/internal/jetstreamutil"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
@@ -161,11 +162,11 @@ func (s *PresenceModel) refreshPresence(ctx context.Context, userID string) erro
 	// Re-put the same value to refresh TTL using optimistic locking.
 	// If a concurrent SetPresence modified the entry, Update fails and
 	// the newer status is preserved — which is the correct behavior.
-	_, err = s.putPresenceWithTTL(ctx, key, entry.Value(), entry.Revision())
+	_, err = s.putWithTTL(ctx, key, entry.Value(), entry.Revision())
 	if err != nil {
-		// ErrKeyExists means the revision changed (concurrent write) — that's fine,
+		// A sequence conflict means the revision changed (concurrent write) — that's fine,
 		// the newer value already has a fresh TTL from the concurrent Put.
-		if errors.Is(err, jetstream.ErrKeyExists) {
+		if jetstreamutil.IsSequenceConflict(err) {
 			return nil
 		}
 		return fmt.Errorf("failed to refresh presence: %w", err)
@@ -179,7 +180,7 @@ func (s *PresenceModel) writePresence(ctx context.Context, key string, data []by
 		if err != nil {
 			if errors.Is(err, jetstream.ErrKeyNotFound) {
 				_, err = s.memoryCacheKV.Create(ctx, key, data, jetstream.KeyTTL(PresenceTTL))
-				if errors.Is(err, jetstream.ErrKeyExists) {
+				if jetstreamutil.IsSequenceConflict(err) {
 					continue
 				}
 				return err
@@ -191,11 +192,11 @@ func (s *PresenceModel) writePresence(ctx context.Context, key string, data []by
 			return nil
 		}
 
-		_, err = s.putPresenceWithTTL(ctx, key, data, entry.Revision())
+		_, err = s.putWithTTL(ctx, key, data, entry.Revision())
 		if err == nil {
 			return nil
 		}
-		if errors.Is(err, jetstream.ErrKeyExists) {
+		if jetstreamutil.IsSequenceConflict(err) {
 			continue
 		}
 		return err

--- a/cli/internal/core/presence_model.go
+++ b/cli/internal/core/presence_model.go
@@ -13,15 +13,18 @@ type PresenceModel struct {
 	memoryCacheKV jetstream.KeyValue
 	logger        *log.Logger
 	hub           *PresenceHub
+	putWithTTL    func(context.Context, string, []byte, uint64) (uint64, error)
 }
 
 func NewPresenceModel(js jetstream.JetStream, memoryCacheKV jetstream.KeyValue, logger *log.Logger) *PresenceModel {
-	return &PresenceModel{
+	model := &PresenceModel{
 		js:            js,
 		memoryCacheKV: memoryCacheKV,
 		logger:        logger,
 		hub:           NewPresenceHub(memoryCacheKV, logger),
 	}
+	model.putWithTTL = model.putPresenceWithTTL
+	return model
 }
 
 func (s *PresenceModel) Run(ctx context.Context) error {

--- a/cli/internal/core/presence_model_test.go
+++ b/cli/internal/core/presence_model_test.go
@@ -155,6 +155,73 @@ func TestPresenceModelRefreshMissingEntrySetsOnline(t *testing.T) {
 	}
 }
 
+func TestPresenceModelWriteRetriesSequenceConflictVariants(t *testing.T) {
+	tests := []struct {
+		name string
+		code jetstream.ErrorCode
+	}{
+		{name: "detailed form", code: jetstream.ErrorCode(10071)},
+		{name: "constant form", code: jetstream.ErrorCode(10164)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service, _, _ := newTestPresenceModel(t)
+			ctx := testContext(t)
+			if err := service.SetPresence(ctx, "U-conflict", PresenceStatusOnline); err != nil {
+				t.Fatalf("seed presence: %v", err)
+			}
+
+			putWithTTL := service.putWithTTL
+			attempts := 0
+			service.putWithTTL = func(ctx context.Context, key string, data []byte, revision uint64) (uint64, error) {
+				attempts++
+				if attempts == 1 {
+					return 0, &jetstream.APIError{Code: 400, ErrorCode: tt.code, Description: "wrong last sequence"}
+				}
+				return putWithTTL(ctx, key, data, revision)
+			}
+
+			if err := service.SetPresence(ctx, "U-conflict", PresenceStatusAway); err != nil {
+				t.Fatalf("SetPresence after conflict: %v", err)
+			}
+			if attempts != 2 {
+				t.Fatalf("put attempts = %d, want 2", attempts)
+			}
+			if got, err := service.GetUserPresence(ctx, "U-conflict"); err != nil || got != PresenceStatusAway {
+				t.Fatalf("GetUserPresence = %q, %v; want %q, nil", got, err, PresenceStatusAway)
+			}
+		})
+	}
+}
+
+func TestPresenceModelRefreshIgnoresSequenceConflictVariants(t *testing.T) {
+	tests := []struct {
+		name string
+		code jetstream.ErrorCode
+	}{
+		{name: "detailed form", code: jetstream.ErrorCode(10071)},
+		{name: "constant form", code: jetstream.ErrorCode(10164)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service, _, _ := newTestPresenceModel(t)
+			ctx := testContext(t)
+			if err := service.SetPresence(ctx, "U-refresh-conflict", PresenceStatusOnline); err != nil {
+				t.Fatalf("seed presence: %v", err)
+			}
+			service.putWithTTL = func(context.Context, string, []byte, uint64) (uint64, error) {
+				return 0, &jetstream.APIError{Code: 400, ErrorCode: tt.code, Description: "wrong last sequence"}
+			}
+
+			if err := service.refreshPresence(ctx, "U-refresh-conflict"); err != nil {
+				t.Fatalf("refreshPresence returned conflict: %v", err)
+			}
+		})
+	}
+}
+
 func TestPresenceModelKeyHelpers(t *testing.T) {
 	if got := presenceKey("U-key"); got != "presence.U-key" {
 		t.Fatalf("presenceKey = %q, want %q", got, "presence.U-key")

--- a/cli/internal/core/push.go
+++ b/cli/internal/core/push.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"hmans.de/chatto/internal/jetstreamutil"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
@@ -129,7 +130,7 @@ func (c *ChattoCore) claimPushEndpointOwnership(ctx context.Context, userID, end
 					return nil
 				}
 				continue
-			} else if errors.Is(err, jetstream.ErrKeyExists) {
+			} else if jetstreamutil.IsSequenceConflict(err) {
 				continue
 			} else {
 				return fmt.Errorf("failed to create push endpoint owner: %w", err)
@@ -153,7 +154,7 @@ func (c *ChattoCore) claimPushEndpointOwnership(ctx context.Context, userID, end
 				return nil
 			}
 			continue
-		} else if errors.Is(err, jetstream.ErrKeyExists) {
+		} else if jetstreamutil.IsSequenceConflict(err) {
 			continue
 		} else {
 			return fmt.Errorf("failed to update push endpoint owner: %w", err)
@@ -240,7 +241,7 @@ func (c *ChattoCore) releasePushEndpointOwnership(ctx context.Context, userID, e
 		if err == nil || isPushRuntimeStateKeyAbsent(err) {
 			return nil
 		}
-		if errors.Is(err, jetstream.ErrKeyExists) {
+		if jetstreamutil.IsSequenceConflict(err) {
 			continue
 		}
 		return fmt.Errorf("failed to delete push endpoint owner: %w", err)
@@ -281,7 +282,7 @@ func (c *ChattoCore) DeletePushSubscription(ctx context.Context, userID, endpoin
 
 	if entry != nil {
 		err = c.storage.runtimeStateKV.Delete(ctx, key, jetstream.LastRevision(entry.Revision()))
-		if err != nil && !isPushRuntimeStateKeyAbsent(err) && !errors.Is(err, jetstream.ErrKeyExists) {
+		if err != nil && !isPushRuntimeStateKeyAbsent(err) && !jetstreamutil.IsSequenceConflict(err) {
 			return fmt.Errorf("failed to delete push subscription: %w", err)
 		}
 	}
@@ -370,7 +371,7 @@ func (c *ChattoCore) DeleteAllUserPushSubscriptions(ctx context.Context, userID 
 
 		err = c.storage.runtimeStateKV.Delete(ctx, key, jetstream.LastRevision(entry.Revision()))
 		if err != nil {
-			if !isPushRuntimeStateKeyAbsent(err) && !errors.Is(err, jetstream.ErrKeyExists) {
+			if !isPushRuntimeStateKeyAbsent(err) && !jetstreamutil.IsSequenceConflict(err) {
 				c.logger.Warn("Failed to delete push subscription", "key", key, "error", err)
 			}
 			continue

--- a/cli/internal/core/registration.go
+++ b/cli/internal/core/registration.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/nats-io/nats.go/jetstream"
+
+	"hmans.de/chatto/internal/jetstreamutil"
 )
 
 // ============================================================================
@@ -188,7 +190,7 @@ func (c *ChattoCore) CancelRegistrationCode(ctx context.Context, email, code str
 }
 
 func isRuntimeStateRevisionConflict(err error) bool {
-	return errors.Is(err, jetstream.ErrKeyExists)
+	return jetstreamutil.IsSequenceConflict(err)
 }
 
 func isRuntimeStateKeyAbsent(err error) bool {

--- a/cli/internal/core/room_unread.go
+++ b/cli/internal/core/room_unread.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 
 	"hmans.de/chatto/internal/core/subjects"
+	"hmans.de/chatto/internal/jetstreamutil"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
@@ -117,7 +118,7 @@ func (c *ChattoCore) GetLastReadEventID(ctx context.Context, kind RoomKind, user
 	// (PostMessage auto-mark, MarkRoomAsRead) may have set a real marker
 	// between our Get and our write, and we must not clobber it.
 	if _, err := bucket.Create(ctx, key, []byte(lastID)); err != nil {
-		if errors.Is(err, jetstream.ErrKeyExists) {
+		if jetstreamutil.IsSequenceConflict(err) {
 			entry, getErr := bucket.Get(ctx, key)
 			if getErr != nil {
 				return "", fmt.Errorf("failed to re-read read marker after concurrent init: %w", getErr)
@@ -177,7 +178,7 @@ func (c *ChattoCore) AdvanceLastReadEventID(ctx context.Context, kind RoomKind, 
 					return &LastReadEventIDAdvance{}, nil
 				}
 				if _, err := bucket.Create(ctx, key, []byte(eventID)); err != nil {
-					if errors.Is(err, jetstream.ErrKeyExists) {
+					if jetstreamutil.IsSequenceConflict(err) {
 						continue
 					}
 					return nil, fmt.Errorf("failed to create read marker: %w", err)
@@ -209,7 +210,7 @@ func (c *ChattoCore) AdvanceLastReadEventID(ctx context.Context, kind RoomKind, 
 		}
 
 		if _, err := bucket.Update(ctx, key, []byte(eventID), entry.Revision()); err != nil {
-			if errors.Is(err, jetstream.ErrKeyExists) {
+			if jetstreamutil.IsSequenceConflict(err) {
 				continue
 			}
 			return nil, fmt.Errorf("failed to advance read marker: %w", err)

--- a/cli/internal/core/threads.go
+++ b/cli/internal/core/threads.go
@@ -13,6 +13,7 @@ import (
 
 	"hmans.de/chatto/internal/core/subjects"
 	"hmans.de/chatto/internal/events"
+	"hmans.de/chatto/internal/jetstreamutil"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
@@ -453,7 +454,7 @@ func (c *ChattoCore) SetThreadLastReadEventID(ctx context.Context, kind RoomKind
 					return time.Time{}, nil
 				}
 				if _, err := bucket.Create(ctx, key, []byte(eventID)); err != nil {
-					if errors.Is(err, jetstream.ErrKeyExists) {
+					if jetstreamutil.IsSequenceConflict(err) {
 						continue
 					}
 					return time.Time{}, fmt.Errorf("failed to create thread last opened: %w", err)
@@ -473,7 +474,7 @@ func (c *ChattoCore) SetThreadLastReadEventID(ctx context.Context, kind RoomKind
 		}
 
 		if _, err := bucket.Update(ctx, key, []byte(eventID), entry.Revision()); err != nil {
-			if errors.Is(err, jetstream.ErrKeyExists) {
+			if jetstreamutil.IsSequenceConflict(err) {
 				continue
 			}
 			return time.Time{}, fmt.Errorf("failed to set thread last opened: %w", err)
@@ -504,7 +505,7 @@ func (c *ChattoCore) SetThreadLastOpenedAt(ctx context.Context, kind RoomKind, u
 				buf := make([]byte, 8)
 				binary.BigEndian.PutUint64(buf, uint64(ts.UnixNano()))
 				if _, err := bucket.Create(ctx, key, buf); err != nil {
-					if errors.Is(err, jetstream.ErrKeyExists) {
+					if jetstreamutil.IsSequenceConflict(err) {
 						continue
 					}
 					return time.Time{}, fmt.Errorf("failed to create thread last opened: %w", err)
@@ -526,7 +527,7 @@ func (c *ChattoCore) SetThreadLastOpenedAt(ctx context.Context, kind RoomKind, u
 		buf := make([]byte, 8)
 		binary.BigEndian.PutUint64(buf, uint64(ts.UnixNano()))
 		if _, err := bucket.Update(ctx, key, buf, entry.Revision()); err != nil {
-			if errors.Is(err, jetstream.ErrKeyExists) {
+			if jetstreamutil.IsSequenceConflict(err) {
 				continue
 			}
 			return time.Time{}, fmt.Errorf("failed to set thread last opened: %w", err)

--- a/cli/internal/dekstore/store.go
+++ b/cli/internal/dekstore/store.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"hmans.de/chatto/internal/encryption"
+	"hmans.de/chatto/internal/jetstreamutil"
 	"hmans.de/chatto/internal/kms"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
@@ -109,7 +110,7 @@ func (s *Store) Create(ctx context.Context, dek *corev1.UserDataEncryptionKey) (
 			return "", err
 		}
 		if _, err := s.kv.Create(ctx, ref, data); err != nil {
-			if errors.Is(err, jetstream.ErrKeyExists) {
+			if jetstreamutil.IsSequenceConflict(err) {
 				continue
 			}
 			return "", fmt.Errorf("failed to store content key: %w", err)

--- a/cli/internal/events/publisher.go
+++ b/cli/internal/events/publisher.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 	"google.golang.org/protobuf/proto"
 
+	"hmans.de/chatto/internal/jetstreamutil"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
@@ -249,15 +250,21 @@ func (p *Publisher) publishAt(ctx context.Context, subject string, data []byte, 
 		return ack.Sequence, nil
 	}
 
-	var apiErr *jetstream.APIError
-	if errors.As(err, &apiErr) && apiErr.ErrorCode == jetstream.JSErrCodeStreamWrongLastSequence {
-		target := subject
-		if filter != "" {
-			target = "filter " + filter
-		}
-		return 0, fmt.Errorf("%s at expected seq %d: %w", target, expectedSeq, ErrConflict)
+	target := subject
+	if filter != "" {
+		target = "filter " + filter
+	}
+	if conflictErr := sequenceConflictError(err, target, expectedSeq); conflictErr != nil {
+		return 0, conflictErr
 	}
 	return 0, fmt.Errorf("publish: %w", err)
+}
+
+func sequenceConflictError(err error, target string, expectedSeq uint64) error {
+	if !jetstreamutil.IsSequenceConflict(err) {
+		return nil
+	}
+	return fmt.Errorf("%s at expected seq %d: %w", target, expectedSeq, ErrConflict)
 }
 
 // BatchEntry is one event in an atomic publish batch (AppendBatch).
@@ -390,12 +397,17 @@ func decodeBatchAck(resp *nats.Msg, e BatchEntry) (uint64, error) {
 		return 0, fmt.Errorf("decode ack: %w", err)
 	}
 	if env.Error != nil {
-		if env.Error.ErrCode == uint16(jetstream.JSErrCodeStreamWrongLastSequence) {
-			target := e.Subject
-			if e.FilterSubject != "" {
-				target = "filter " + e.FilterSubject
-			}
-			return 0, fmt.Errorf("%s at expected seq %d: %w", target, e.ExpectedSeq, ErrConflict)
+		apiErr := &jetstream.APIError{
+			Code:        env.Error.Code,
+			ErrorCode:   jetstream.ErrorCode(env.Error.ErrCode),
+			Description: env.Error.Description,
+		}
+		target := e.Subject
+		if e.FilterSubject != "" {
+			target = "filter " + e.FilterSubject
+		}
+		if conflictErr := sequenceConflictError(apiErr, target, e.ExpectedSeq); conflictErr != nil {
+			return 0, conflictErr
 		}
 		return 0, fmt.Errorf("server: %s (err_code=%d)", env.Error.Description, env.Error.ErrCode)
 	}

--- a/cli/internal/events/publisher_conflict_test.go
+++ b/cli/internal/events/publisher_conflict_test.go
@@ -1,0 +1,42 @@
+package events
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func TestSequenceConflictErrorTranslatesWrongLastSequenceVariants(t *testing.T) {
+	tests := []struct {
+		name string
+		code jetstream.ErrorCode
+		want bool
+	}{
+		{name: "detailed form", code: jetstream.ErrorCode(10071), want: true},
+		{name: "constant form", code: jetstream.ErrorCode(10164), want: true},
+		{name: "unrelated", code: jetstream.JSErrCodeJetStreamNotEnabled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := sequenceConflictError(
+				&jetstream.APIError{Code: 400, ErrorCode: tt.code},
+				"evt.room.R1.message_sent",
+				42,
+			)
+			if got := errors.Is(err, ErrConflict); got != tt.want {
+				t.Fatalf("errors.Is(sequenceConflictError, ErrConflict) = %v, want %v (err=%v)", got, tt.want, err)
+			}
+		})
+	}
+}
+
+func TestDecodeBatchAckTranslatesConstantWrongLastSequence(t *testing.T) {
+	msg := &nats.Msg{Data: []byte(`{"error":{"code":400,"err_code":10164,"description":"wrong last sequence"}}`)}
+	_, err := decodeBatchAck(msg, BatchEntry{Subject: "evt.room.R1.message_sent", ExpectedSeq: 42})
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("decodeBatchAck error = %v, want ErrConflict", err)
+	}
+}

--- a/cli/internal/jetstreamutil/errors.go
+++ b/cli/internal/jetstreamutil/errors.go
@@ -1,0 +1,30 @@
+// Package jetstreamutil contains shared helpers for interpreting JetStream
+// behavior that is not yet consistently exposed by nats.go.
+package jetstreamutil
+
+import (
+	"errors"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// constantWrongLastSequenceErrorCode is returned by newer NATS Server versions
+// for a wrong expected last sequence without sequence details. nats.go v1.52.0
+// only exposes and maps the older detailed form (10071) to ErrKeyExists, so keep
+// the constant-form code centralized here until the client library classifies it.
+const constantWrongLastSequenceErrorCode jetstream.ErrorCode = 10164
+
+// IsSequenceConflict reports whether err is a JetStream optimistic-concurrency
+// conflict caused by an expected-last-sequence mismatch.
+func IsSequenceConflict(err error) bool {
+	if errors.Is(err, jetstream.ErrKeyExists) {
+		return true
+	}
+
+	var apiErr *jetstream.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	return apiErr.ErrorCode == jetstream.JSErrCodeStreamWrongLastSequence ||
+		apiErr.ErrorCode == constantWrongLastSequenceErrorCode
+}

--- a/cli/internal/jetstreamutil/errors_test.go
+++ b/cli/internal/jetstreamutil/errors_test.go
@@ -1,0 +1,57 @@
+package jetstreamutil
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func TestIsSequenceConflict(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nats.go key exists sentinel",
+			err:  jetstream.ErrKeyExists,
+			want: true,
+		},
+		{
+			name: "detailed wrong last sequence",
+			err:  &jetstream.APIError{Code: 400, ErrorCode: jetstream.ErrorCode(10071)},
+			want: true,
+		},
+		{
+			name: "constant wrong last sequence",
+			err:  &jetstream.APIError{Code: 400, ErrorCode: jetstream.ErrorCode(10164)},
+			want: true,
+		},
+		{
+			name: "wrapped constant wrong last sequence",
+			err:  fmt.Errorf("publish presence: %w", &jetstream.APIError{Code: 400, ErrorCode: jetstream.ErrorCode(10164)}),
+			want: true,
+		},
+		{
+			name: "unrelated API error",
+			err:  &jetstream.APIError{Code: 503, ErrorCode: jetstream.JSErrCodeJetStreamNotEnabled},
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("boom"),
+		},
+		{
+			name: "nil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsSequenceConflict(tt.err); got != tt.want {
+				t.Fatalf("IsSequenceConflict(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/internal/kms/builtin.go
+++ b/cli/internal/kms/builtin.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"hmans.de/chatto/internal/encryption"
+	"hmans.de/chatto/internal/jetstreamutil"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
@@ -233,7 +234,7 @@ func (b *Builtin) CreateKey(ctx context.Context, owner string) (string, error) {
 			return "", err
 		}
 		if _, err := b.kv.Create(ctx, keyPath(keyRef), data); err != nil {
-			if errors.Is(err, jetstream.ErrKeyExists) {
+			if jetstreamutil.IsSequenceConflict(err) {
 				continue
 			}
 			return "", fmt.Errorf("failed to store encryption key: %w", err)
@@ -277,7 +278,7 @@ func (b *Builtin) CreateCallKey(ctx context.Context, callID string) (string, str
 		return "", "", fmt.Errorf("failed to encode call key: %w", err)
 	}
 	if _, err := b.kv.Create(ctx, keyPath(keyRef), data); err != nil {
-		if errors.Is(err, jetstream.ErrKeyExists) {
+		if jetstreamutil.IsSequenceConflict(err) {
 			return "", "", fmt.Errorf("call key already exists: %w", err)
 		}
 		return "", "", fmt.Errorf("failed to store call key: %w", err)

--- a/cli/internal/lease/lease.go
+++ b/cli/internal/lease/lease.go
@@ -18,6 +18,8 @@ import (
 	"time"
 
 	"github.com/nats-io/nats.go/jetstream"
+
+	"hmans.de/chatto/internal/jetstreamutil"
 )
 
 const (
@@ -178,7 +180,7 @@ func (l *Lease) TryAcquire(ctx context.Context) (bool, error) {
 	if _, err := l.kv.Create(ctx, l.key, data, jetstream.KeyTTL(l.ttl)); err == nil {
 		l.logDebug("lease acquired")
 		return true, nil
-	} else if !errors.Is(err, jetstream.ErrKeyExists) {
+	} else if !jetstreamutil.IsSequenceConflict(err) {
 		return false, fmt.Errorf("create lease %s: %w", l.name, err)
 	}
 
@@ -225,7 +227,7 @@ func (l *Lease) Release(ctx context.Context) error {
 		return err
 	}
 	if err := l.kv.Delete(ctx, l.key, jetstream.LastRevision(entry.Revision())); err != nil {
-		if isMissingKey(err) || errors.Is(err, jetstream.ErrKeyExists) {
+		if isMissingKey(err) || jetstreamutil.IsSequenceConflict(err) {
 			return nil
 		}
 		return fmt.Errorf("release lease %s: %w", l.name, err)
@@ -325,7 +327,7 @@ func (l *Lease) renewAtRevision(ctx context.Context, revision uint64, acquiredAt
 		jetstream.WithMsgTTL(l.ttl),
 	)
 	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyExists) || isMissingKey(err) {
+		if jetstreamutil.IsSequenceConflict(err) || isMissingKey(err) {
 			return ErrLost
 		}
 		return fmt.Errorf("renew lease %s: %w", l.name, err)


### PR DESCRIPTION
## Summary

- classify both JetStream wrong-last-sequence responses (`10071` and `10164`)
  through one shared helper
- preserve OCC retry/no-op semantics across presence, event publishing, leases,
  and revision-conditional KV operations
- log Connect internal errors once with the RPC procedure while keeping the
  underlying cause out of client responses
- add deterministic regressions for both error forms and log redaction

## Root cause

NATS Server can return constant-form wrong-last-sequence error code `10164`,
while nats.go v1.52.0 only exposes and maps the detailed `10071` form to
`jetstream.ErrKeyExists`. Chatto therefore treated expected presence OCC races
as unclassified failures and returned Connect internal errors.

## Impact

Concurrent presence heartbeats and explicit presence changes now retain their
existing optimistic-concurrency behavior under either NATS response form.
Event publisher retries and lease-loss handling are likewise consistent. No
storage model, protobuf, frontend, production resource, or release-stream
changes are included.

## Verification

- focused Go tests for all changed packages
- `mise test-cli`
- independent adversarial diff review (no findings)

Closes #1510.
