### PR TITLE
fix(frontend): add direct thread message routes

### DIFF
--- a/apps/frontend/src/lib/components/MessagePreviewCard.svelte
+++ b/apps/frontend/src/lib/components/MessagePreviewCard.svelte
@@ -13,7 +13,8 @@ unknown instance) the component renders nothing.
 -->
 <script lang="ts">
   import { goto } from '$app/navigation';
-  import { buildMessageLinkPath, type MessageLink } from '$lib/messageLinks';
+  import { resolve } from '$app/paths';
+  import type { MessageLink } from '$lib/messageLinks';
   import {
     FitMode,
     MessageAttachmentViewDocument,
@@ -22,6 +23,7 @@ unknown instance) the component renders nothing.
   } from '$lib/render/types';
   import { useRenderData } from '$lib/render/data';
   import { SvelteMap, SvelteSet } from 'svelte/reactivity';
+  import { serverIdToSegment } from '$lib/navigation';
   import * as m from '$lib/i18n/messages';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { getLiveDisplayName } from '$lib/state/userProfiles.svelte';
@@ -316,14 +318,7 @@ unknown instance) the component renders nothing.
     const target = event.target as HTMLElement;
     if (target.closest('a, button')) return;
 
-    goto(
-      buildMessageLinkPath(
-        preview.serverId,
-        preview.roomId,
-        preview.eventId,
-        preview.threadRootEventId
-      )
-    );
+    navigateToPreview();
   }
 
   function handlePreviewKeydown(event: KeyboardEvent) {
@@ -332,13 +327,30 @@ unknown instance) the component renders nothing.
     if (event.key !== 'Enter' && event.key !== ' ') return;
 
     event.preventDefault();
+    navigateToPreview();
+  }
+
+  function navigateToPreview() {
+    if (!preview) return;
+    const serverId = serverIdToSegment(preview.serverId);
+    if (preview.threadRootEventId) {
+      goto(
+        resolve('/chat/[serverId]/[roomId]/[threadId]/m/[messageId]', {
+          serverId,
+          roomId: preview.roomId,
+          threadId: preview.threadRootEventId,
+          messageId: preview.eventId
+        })
+      );
+      return;
+    }
+
     goto(
-      buildMessageLinkPath(
-        preview.serverId,
-        preview.roomId,
-        preview.eventId,
-        preview.threadRootEventId
-      )
+      resolve('/chat/[serverId]/[roomId]/m/[messageId]', {
+        serverId,
+        roomId: preview.roomId,
+        messageId: preview.eventId
+      })
     );
   }
 

--- a/apps/frontend/src/lib/components/MessagePreviewCard.svelte
+++ b/apps/frontend/src/lib/components/MessagePreviewCard.svelte
@@ -13,7 +13,7 @@ unknown instance) the component renders nothing.
 -->
 <script lang="ts">
   import { goto } from '$app/navigation';
-  import type { MessageLink } from '$lib/messageLinks';
+  import { buildMessageLinkPath, type MessageLink } from '$lib/messageLinks';
   import {
     FitMode,
     MessageAttachmentViewDocument,
@@ -21,9 +21,7 @@ unknown instance) the component renders nothing.
     type UserAvatarUserView
   } from '$lib/render/types';
   import { useRenderData } from '$lib/render/data';
-  import { resolve } from '$app/paths';
   import { SvelteMap, SvelteSet } from 'svelte/reactivity';
-  import { serverIdToSegment } from '$lib/navigation';
   import * as m from '$lib/i18n/messages';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { getLiveDisplayName } from '$lib/state/userProfiles.svelte';
@@ -65,6 +63,7 @@ unknown instance) the component renders nothing.
   let preview = $state<{
     serverId: string;
     roomId: string;
+    threadRootEventId?: string;
     eventId: string;
     body: string | null;
     attachments: Attachment[];
@@ -115,7 +114,7 @@ unknown instance) the component renders nothing.
   }
 
   $effect(() => {
-    const { serverId, roomId, messageId } = link;
+    const { serverId, roomId, threadRootEventId, messageId } = link;
 
     preview = null;
     if (!serverId) return;
@@ -156,6 +155,7 @@ unknown instance) the component renders nothing.
         preview = {
           serverId,
           roomId,
+          threadRootEventId,
           eventId: messageId,
           body: inner.body ?? null,
           attachments: attachments.map((a: MessageAttachmentView) => {
@@ -317,11 +317,12 @@ unknown instance) the component renders nothing.
     if (target.closest('a, button')) return;
 
     goto(
-      resolve('/chat/[serverId]/[roomId]/m/[messageId]', {
-        serverId: serverIdToSegment(preview.serverId),
-        roomId: preview.roomId,
-        messageId: preview.eventId
-      })
+      buildMessageLinkPath(
+        preview.serverId,
+        preview.roomId,
+        preview.eventId,
+        preview.threadRootEventId
+      )
     );
   }
 
@@ -332,11 +333,12 @@ unknown instance) the component renders nothing.
 
     event.preventDefault();
     goto(
-      resolve('/chat/[serverId]/[roomId]/m/[messageId]', {
-        serverId: serverIdToSegment(preview.serverId),
-        roomId: preview.roomId,
-        messageId: preview.eventId
-      })
+      buildMessageLinkPath(
+        preview.serverId,
+        preview.roomId,
+        preview.eventId,
+        preview.threadRootEventId
+      )
     );
   }
 

--- a/apps/frontend/src/lib/components/menus/MessageContextMenu.svelte
+++ b/apps/frontend/src/lib/components/menus/MessageContextMenu.svelte
@@ -32,6 +32,7 @@ Rendered inside a ContextMenu when right-clicking a message.
     eventId,
     deleteEventId = eventId,
     messageBody,
+    permalinkThreadRootEventId = null,
     threadRootEventId = null,
     channelEchoEventId = null,
     canAddChannelEcho = false,
@@ -53,6 +54,7 @@ Rendered inside a ContextMenu when right-clicking a message.
     eventId: string;
     deleteEventId?: string;
     messageBody: string;
+    permalinkThreadRootEventId?: string | null;
     threadRootEventId?: string | null;
     channelEchoEventId?: string | null;
     canAddChannelEcho?: boolean;
@@ -85,6 +87,7 @@ Rendered inside a ContextMenu when right-clicking a message.
     eventId,
     deleteEventId,
     messageBody,
+    permalinkThreadRootEventId,
     threadRootEventId,
     channelEchoEventId,
     canAddChannelEcho,

--- a/apps/frontend/src/lib/components/menus/MessageContextMenu.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/menus/MessageContextMenu.svelte.spec.ts
@@ -132,6 +132,7 @@ describe('MessageContextMenu', () => {
       canReact: true,
       canEdit: true,
       canDelete: true,
+      permalinkThreadRootEventId: 'thread-root-1',
       onReply
     });
 
@@ -172,7 +173,8 @@ describe('MessageContextMenu', () => {
       expect.objectContaining({
         serverId: 'server-1',
         roomId: 'room-1',
-        messageEventId: 'message-event-1'
+        messageEventId: 'message-event-1',
+        permalinkThreadRootEventId: 'thread-root-1'
       })
     );
     await vi.waitFor(() => {

--- a/apps/frontend/src/lib/hooks/useMessageActions.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useMessageActions.svelte.ts
@@ -14,6 +14,8 @@ export type MessageActionParams = {
   eventId: string;
   deleteEventId?: string;
   messageBody: string;
+  /** Thread root to preserve when copying a link from the thread pane. */
+  permalinkThreadRootEventId?: string | null;
   threadRootEventId?: string | null;
   channelEchoEventId?: string | null;
   canAddChannelEcho?: boolean;
@@ -124,7 +126,12 @@ export function useMessageActions() {
   }
 
   async function copyMessageLink(params: MessageActionParams) {
-    await copyMessageLinkToClipboard(params.serverId, params.roomId, params.messageEventId);
+    await copyMessageLinkToClipboard(
+      params.serverId,
+      params.roomId,
+      params.messageEventId,
+      params.permalinkThreadRootEventId
+    );
   }
 
   return {

--- a/apps/frontend/src/lib/messageLinks.spec.ts
+++ b/apps/frontend/src/lib/messageLinks.spec.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getToasts, toast } from '$lib/ui/toast';
-import { classifyMessageBodyChatLink, copyMessageLinkToClipboard } from './messageLinks';
+import {
+  classifyMessageBodyChatLink,
+  copyMessageLinkToClipboard,
+  parseMessageLink
+} from './messageLinks';
 
 const origin = 'https://chat.example.test';
 const registeredRemoteOrigin = 'https://chat.chatto.run';
@@ -64,6 +68,16 @@ describe('copyMessageLinkToClipboard', () => {
 
     expect(getToasts().map((t) => t.message)).toContain('Failed to copy link');
   });
+
+  it('copies a nested thread message link when a thread root is provided', async () => {
+    writeText.mockResolvedValue(undefined);
+
+    await copyMessageLinkToClipboard('server-1', 'room-1', 'message-1', 'thread-root-1');
+
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining('/chat/-/room-1/thread-root-1/m/message-1')
+    );
+  });
 });
 
 describe('classifyMessageBodyChatLink', () => {
@@ -99,6 +113,20 @@ describe('classifyMessageBodyChatLink', () => {
       roomId: channelRoomId,
       messageId,
       path: `/chat/-/${channelRoomId}/m/${messageId}`
+    });
+  });
+
+  it('accepts same-origin thread message URLs', () => {
+    expect(
+      classify(
+        `${origin}/chat/-/${channelRoomId}/${threadRootEventId}/m/${messageId}?focus=1#message`
+      )
+    ).toMatchObject({
+      kind: 'thread-message',
+      roomId: channelRoomId,
+      threadRootEventId,
+      messageId,
+      path: `/chat/-/${channelRoomId}/${threadRootEventId}/m/${messageId}?focus=1#message`
     });
   });
 
@@ -159,7 +187,8 @@ describe('classifyMessageBodyChatLink', () => {
       `${origin}/chat/-/room-1`,
       `${origin}/chat/-/R123/m/${messageId}`,
       `${origin}/chat/-/${channelRoomId}/m/message-1`,
-      `${origin}/chat/-/${channelRoomId}/thread-1`
+      `${origin}/chat/-/${channelRoomId}/thread-1`,
+      `${origin}/chat/-/${channelRoomId}/${threadRootEventId}/m/message-1`
     ];
 
     for (const url of rejected) {
@@ -173,5 +202,17 @@ describe('classifyMessageBodyChatLink', () => {
 
   it('rejects unregistered cross-origin URLs', () => {
     expect(classify(`https://other.example.test/chat/-/${channelRoomId}`)).toBeNull();
+  });
+});
+
+describe('parseMessageLink', () => {
+  it('preserves the thread root from a nested message link', () => {
+    expect(
+      parseMessageLink(`/chat/-/${channelRoomId}/${threadRootEventId}/m/${messageId}`)
+    ).toMatchObject({
+      roomId: channelRoomId,
+      threadRootEventId,
+      messageId
+    });
   });
 });

--- a/apps/frontend/src/lib/messageLinks.ts
+++ b/apps/frontend/src/lib/messageLinks.ts
@@ -1,5 +1,8 @@
 /**
- * Message link URL format: `/chat/<serverSegment>/<roomId>/m/<messageId>`.
+ * Message link URL formats:
+ * - Room message: `/chat/<serverSegment>/<roomId>/m/<messageId>`
+ * - Thread message: `/chat/<serverSegment>/<roomId>/<threadRootEventId>/m/<messageId>`
+ *
  * The `m/` prefix distinguishes message URLs from the `[threadId]` route that sits
  * at the same level (thread IDs and message IDs share the same ID space).
  */
@@ -15,6 +18,8 @@ export interface MessageLink {
   /** Resolved server ID, or null if the segment doesn't match a registered server. */
   serverId: string | null;
   roomId: string;
+  /** Thread to open when following this message link. */
+  threadRootEventId?: string;
   messageId: string;
 }
 
@@ -39,6 +44,15 @@ export type MessageBodyChatLink =
       serverSegment: string;
       serverId: string;
       roomId: string;
+      messageId: string;
+      path: string;
+    }
+  | {
+      kind: 'thread-message';
+      serverSegment: string;
+      serverId: string;
+      roomId: string;
+      threadRootEventId: string;
       messageId: string;
       path: string;
     };
@@ -106,9 +120,18 @@ function messagePath(
   roomId: string,
   messageId: string,
   suffix: string,
-  options: MessageBodyChatLinkOptions
+  options: MessageBodyChatLinkOptions,
+  threadRootEventId?: string | null
 ): string {
   const serverSegment = options.serverSegmentForId?.(serverId) ?? serverIdToSegment(serverId);
+  if (threadRootEventId) {
+    return `${resolve('/chat/[serverId]/[roomId]/[threadId]/m/[messageId]', {
+      serverId: serverSegment,
+      roomId,
+      threadId: threadRootEventId,
+      messageId
+    })}${suffix}`;
+  }
   return `${resolve('/chat/[serverId]/[roomId]/m/[messageId]', {
     serverId: serverSegment,
     roomId,
@@ -139,17 +162,23 @@ function resolveChatLinkServerId(
   return resolveServerSegment(serverSegment);
 }
 
-export function buildMessageLinkPath(serverId: string, roomId: string, messageId: string): string {
-  return resolve('/chat/[serverId]/[roomId]/m/[messageId]', {
-    serverId: serverIdToSegment(serverId),
-    roomId,
-    messageId
-  });
+export function buildMessageLinkPath(
+  serverId: string,
+  roomId: string,
+  messageId: string,
+  threadRootEventId?: string | null
+): string {
+  return messagePath(serverId, roomId, messageId, '', {}, threadRootEventId);
 }
 
 /** Absolute URL for clipboard copy. */
-export function buildMessageLinkURL(serverId: string, roomId: string, messageId: string): string {
-  const path = buildMessageLinkPath(serverId, roomId, messageId);
+export function buildMessageLinkURL(
+  serverId: string,
+  roomId: string,
+  messageId: string,
+  threadRootEventId?: string | null
+): string {
+  const path = buildMessageLinkPath(serverId, roomId, messageId, threadRootEventId);
 
   const server = serverRegistry.getServer(serverId);
   if (server) {
@@ -170,10 +199,13 @@ export function buildMessageLinkURL(serverId: string, roomId: string, messageId:
 export async function copyMessageLinkToClipboard(
   serverId: string,
   roomId: string,
-  messageId: string
+  messageId: string,
+  threadRootEventId?: string | null
 ): Promise<void> {
   try {
-    await navigator.clipboard.writeText(buildMessageLinkURL(serverId, roomId, messageId));
+    await navigator.clipboard.writeText(
+      buildMessageLinkURL(serverId, roomId, messageId, threadRootEventId)
+    );
     toast.success('Message link copied');
   } catch {
     toast.error('Failed to copy link');
@@ -204,7 +236,7 @@ export function classifyMessageBodyChatLink(
 
   const parts = url.pathname.split('/').filter(Boolean);
   if (parts[0] !== 'chat') return null;
-  if (parts.length !== 3 && parts.length !== 4 && parts.length !== 5) return null;
+  if (parts.length < 3 || parts.length > 6) return null;
 
   const [, serverSegment, roomId] = parts;
   if (!serverSegment || !isMessageRoomId(roomId)) return null;
@@ -235,6 +267,26 @@ export function classifyMessageBodyChatLink(
       roomId,
       threadRootEventId,
       path: threadPath(serverId, roomId, threadRootEventId, suffix, options)
+    };
+  }
+
+  if (parts.length === 6) {
+    const [, , , threadRootEventId, marker, messageId] = parts;
+    if (
+      marker !== 'm' ||
+      !eventIdPattern.test(threadRootEventId) ||
+      !eventIdPattern.test(messageId)
+    ) {
+      return null;
+    }
+    return {
+      kind: 'thread-message',
+      serverSegment: localServerSegment,
+      serverId,
+      roomId,
+      threadRootEventId,
+      messageId,
+      path: messagePath(serverId, roomId, messageId, suffix, options, threadRootEventId)
     };
   }
 
@@ -275,17 +327,23 @@ export function parseMessageLink(input: string): MessageLink | null {
   }
 
   const parts = pathname.split('/').filter(Boolean);
-  // Expected: ['chat', serverSegment, roomId, 'm', messageId]
-  if (parts.length !== 5) return null;
-  if (parts[0] !== 'chat' || parts[3] !== 'm') return null;
+  // Expected room link: ['chat', serverSegment, roomId, 'm', messageId]
+  // Expected thread link: ['chat', serverSegment, roomId, threadRootEventId, 'm', messageId]
+  if (parts.length !== 5 && parts.length !== 6) return null;
+  if (parts[0] !== 'chat') return null;
 
-  const [, serverSegment, roomId, , messageId] = parts;
+  const [, serverSegment, roomId] = parts;
+  const threadRootEventId = parts.length === 6 ? parts[3] : undefined;
+  const marker = parts.length === 6 ? parts[4] : parts[3];
+  const messageId = parts.length === 6 ? parts[5] : parts[4];
+  if (marker !== 'm' || !messageId) return null;
   const effectiveSegment = hostnameSegment ?? serverSegment;
 
   return {
     serverSegment: effectiveSegment,
     serverId: segmentToServerId(effectiveSegment),
     roomId,
+    threadRootEventId,
     messageId
   };
 }

--- a/apps/frontend/src/lib/navigation/chatRoomRoute.spec.ts
+++ b/apps/frontend/src/lib/navigation/chatRoomRoute.spec.ts
@@ -2,21 +2,22 @@ import { describe, expect, it } from 'vitest';
 import { chatRoomIdFromRoute } from './chatRoomRoute';
 
 describe('chatRoomIdFromRoute', () => {
-	it('returns the room id for chat room routes', () => {
-		expect(chatRoomIdFromRoute('/chat/[serverId]/[roomId]', 'room-1')).toBe('room-1');
-		expect(chatRoomIdFromRoute('/chat/[serverId]/[roomId]/[threadId]', 'room-1')).toBe(
-			'room-1'
-		);
-	});
+  it('returns the room id for chat room routes', () => {
+    expect(chatRoomIdFromRoute('/chat/[serverId]/[roomId]', 'room-1')).toBe('room-1');
+    expect(chatRoomIdFromRoute('/chat/[serverId]/[roomId]/[threadId]', 'room-1')).toBe('room-1');
+    expect(
+      chatRoomIdFromRoute('/chat/[serverId]/[roomId]/[threadId]/m/[messageId]', 'room-1')
+    ).toBe('room-1');
+  });
 
-	it('ignores non-room routes that also use a roomId param', () => {
-		expect(
-			chatRoomIdFromRoute('/chat/[serverId]/server-admin/rooms/room/[roomId]', 'room-1')
-		).toBe(null);
-	});
+  it('ignores non-room routes that also use a roomId param', () => {
+    expect(chatRoomIdFromRoute('/chat/[serverId]/server-admin/rooms/room/[roomId]', 'room-1')).toBe(
+      null
+    );
+  });
 
-	it('ignores chat routes without a room id', () => {
-		expect(chatRoomIdFromRoute('/chat/[serverId]', undefined)).toBe(null);
-		expect(chatRoomIdFromRoute('/chat/notifications', undefined)).toBe(null);
-	});
+  it('ignores chat routes without a room id', () => {
+    expect(chatRoomIdFromRoute('/chat/[serverId]', undefined)).toBe(null);
+    expect(chatRoomIdFromRoute('/chat/notifications', undefined)).toBe(null);
+  });
 });

--- a/apps/frontend/src/lib/navigation/chatRoomRoute.ts
+++ b/apps/frontend/src/lib/navigation/chatRoomRoute.ts
@@ -1,9 +1,13 @@
-const CHAT_ROOM_ROUTE_IDS = new Set(['/chat/[serverId]/[roomId]', '/chat/[serverId]/[roomId]/[threadId]']);
+const CHAT_ROOM_ROUTE_IDS = new Set([
+  '/chat/[serverId]/[roomId]',
+  '/chat/[serverId]/[roomId]/[threadId]',
+  '/chat/[serverId]/[roomId]/[threadId]/m/[messageId]'
+]);
 
 export function chatRoomIdFromRoute(
-	routeId: string | null,
-	roomId: string | undefined
+  routeId: string | null,
+  roomId: string | undefined
 ): string | null {
-	if (!routeId || !CHAT_ROOM_ROUTE_IDS.has(routeId)) return null;
-	return roomId || null;
+  if (!routeId || !CHAT_ROOM_ROUTE_IDS.has(routeId)) return null;
+  return roomId || null;
 }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/+layout.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/+layout.svelte
@@ -21,7 +21,7 @@
 
   let threadId = $derived(page.params.threadId);
 
-  const isMessageLinkMode = $derived(/\/m\/[^/]+$/.test(page.url.pathname));
+  const isMessageLinkMode = $derived(page.route.id === '/chat/[serverId]/[roomId]/m/[messageId]');
   const roomAccess = $derived.by(() => {
     if (!ready || !roomId) return { kind: 'unknown' } as const;
     return roomRouteAccess({
@@ -46,7 +46,7 @@
 			between room and thread URLs. This prevents unnecessary reloads.
 		-->
     {#key activeServerId}
-      <Room {roomId} {threadId} />
+      <Room {roomId} {threadId} routeMessageId={page.params.messageId} />
     {/key}
   {/if}
 {/if}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -37,6 +37,7 @@
 
   let {
     roomId,
+    permalinkThreadRootEventId = null,
     messageStore,
     events,
     // Scroll behavior
@@ -78,6 +79,7 @@
     pendingHighlightId = null
   }: {
     roomId: string;
+    permalinkThreadRootEventId?: string | null;
     messageStore: MessagesStore;
     events: RoomEventView[];
     // Scroll behavior
@@ -1051,6 +1053,7 @@
                   event={eventData}
                   compact={!item.isFirstInGroup}
                   {roomId}
+                  {permalinkThreadRootEventId}
                   {messageStore}
                   onOpenThread={getOpenThreadHandler(eventData)}
                 />

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionSheet.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionSheet.svelte
@@ -12,6 +12,7 @@
     eventId,
     deleteEventId = eventId,
     messageBody,
+    permalinkThreadRootEventId = null,
     threadRootEventId = null,
     channelEchoEventId = null,
     canAddChannelEcho = false,
@@ -33,6 +34,7 @@
     eventId: string;
     deleteEventId?: string;
     messageBody: string;
+    permalinkThreadRootEventId?: string | null;
     threadRootEventId?: string | null;
     channelEchoEventId?: string | null;
     canAddChannelEcho?: boolean;
@@ -65,6 +67,7 @@
     eventId,
     deleteEventId,
     messageBody,
+    permalinkThreadRootEventId,
     threadRootEventId,
     channelEchoEventId,
     canAddChannelEcho,

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -70,12 +70,14 @@
     event,
     compact = false,
     roomId,
+    permalinkThreadRootEventId = null,
     messageStore = null,
     onOpenThread
   }: {
     event: RoomEventView;
     compact?: boolean;
     roomId: string;
+    permalinkThreadRootEventId?: string | null;
     messageStore?: MessagesStore | null;
     onOpenThread?: OpenThreadHandler;
   } = $props();
@@ -300,7 +302,12 @@
     if (!event) return;
     e.preventDefault();
     e.stopPropagation();
-    await copyMessageLinkToClipboard(getActiveServer(), roomId, event.id);
+    await copyMessageLinkToClipboard(
+      getActiveServer(),
+      roomId,
+      event.id,
+      permalinkThreadRootEventId
+    );
   }
 
   // Check if message has been edited (updatedAt is non-null)
@@ -971,6 +978,7 @@
         eventId={editEventId}
         deleteEventId={event.id}
         messageBody={msg.body ?? ''}
+        {permalinkThreadRootEventId}
         threadRootEventId={editThreadRootEventId}
         channelEchoEventId={editChannelEchoEventId}
         canAddChannelEcho={canReconcileChannelEcho}
@@ -1014,6 +1022,7 @@
         eventId={editEventId}
         deleteEventId={event.id}
         messageBody={msg.body ?? ''}
+        {permalinkThreadRootEventId}
         threadRootEventId={editThreadRootEventId}
         channelEchoEventId={editChannelEchoEventId}
         canAddChannelEcho={canReconcileChannelEcho}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -60,7 +60,11 @@
   import ThreadPane from './ThreadPane.svelte';
   import type { PendingThreadReplyRequest, ThreadOpenOptions } from './threadOpenOptions';
 
-  let { roomId, threadId }: { roomId: string; threadId?: string } = $props();
+  let {
+    roomId,
+    threadId,
+    routeMessageId
+  }: { roomId: string; threadId?: string; routeMessageId?: string } = $props();
 
   const connection = useConnection();
   const roomFilesStore = new RoomFilesStore(connection());
@@ -78,6 +82,7 @@
   let pendingThreadQuoteId = 0;
   let pendingThreadReply = $state<PendingThreadReplyRequest | null>(null);
   let pendingThreadReplyId = 0;
+  let appliedThreadMessageRoute: string | null = null;
 
   function openThread(threadRootEventId: string, options: ThreadOpenOptions = {}) {
     pendingThreadHighlight = options.highlightEventId ?? null;
@@ -265,6 +270,15 @@
     // until the new room's data has actually loaded.
     if (room.roomData.room.id !== roomId) return;
 
+    if (threadId && routeMessageId) {
+      const threadMessageRoute = `${roomId}:${threadId}:${routeMessageId}`;
+      if (appliedThreadMessageRoute === threadMessageRoute) return;
+      appliedThreadMessageRoute = threadMessageRoute;
+      applyHighlight(routeMessageId);
+      return;
+    }
+    appliedThreadMessageRoute = null;
+
     const pending = stores.pendingHighlights.consume(roomId, threadId ?? null);
     if (pending) {
       applyHighlight(pending);
@@ -297,11 +311,7 @@
       pendingMainHighlightId = eventId;
       tick().then(async () => {
         const jumped = await jumpState.jumpToMessage(eventId);
-        if (
-          !jumped &&
-          mainHighlightRequestId === requestId &&
-          pendingMainHighlightId === eventId
-        ) {
+        if (!jumped && mainHighlightRequestId === requestId && pendingMainHighlightId === eventId) {
           pendingMainHighlightId = null;
           toast.error(m['room.jump_failed']());
         }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -230,8 +230,8 @@ vi.mock('./RoomEventsPane.svelte', async () => {
 });
 
 vi.mock('./ThreadPane.svelte', async () => {
-  const { default: EmptyMock } = await import('./RoomLocalEchoEmptyMock.svelte');
-  return { default: EmptyMock };
+  const { default: ThreadPaneMock } = await import('./RoomThreadPaneMock.svelte');
+  return { default: ThreadPaneMock };
 });
 
 vi.mock('./RoomSidebar.svelte', async () => {
@@ -343,6 +343,24 @@ beforeEach(() => {
 });
 
 describe('Room local message echo', () => {
+  it('opens and highlights the explicit message from a nested thread route', async () => {
+    const { container } = render(Room, {
+      props: {
+        roomId: 'room-1',
+        threadId: 'thread-root',
+        routeMessageId: 'thread-message'
+      }
+    });
+
+    await expect
+      .element(q(container, '[data-testid="thread-pane-root-id"]'))
+      .toHaveTextContent('thread-root');
+    await expect
+      .element(q(container, '[data-testid="thread-pane-highlight-id"]'))
+      .toHaveTextContent('thread-message');
+    expect(mocks.pendingHighlightConsume).not.toHaveBeenCalled();
+  });
+
   it('keeps root message-link highlights pending until the jump completes', async () => {
     mocks.pendingHighlightConsume.mockReturnValueOnce('msg-linked');
     mocks.timeline.getRoomEventsAround.mockResolvedValue({
@@ -371,7 +389,9 @@ describe('Room local message echo', () => {
 
     (q(container, '[data-testid="complete-highlight"]') as HTMLButtonElement).click();
 
-    await expect.element(q(container, '[data-testid="pending-highlight-id"]')).toHaveTextContent('');
+    await expect
+      .element(q(container, '[data-testid="pending-highlight-id"]'))
+      .toHaveTextContent('');
   });
 
   it('clears root message-link highlights when the jump target cannot be loaded', async () => {
@@ -393,7 +413,9 @@ describe('Room local message echo', () => {
         limit: 50
       });
     });
-    await expect.element(q(container, '[data-testid="pending-highlight-id"]')).toHaveTextContent('');
+    await expect
+      .element(q(container, '[data-testid="pending-highlight-id"]'))
+      .toHaveTextContent('');
   });
 
   it('inserts a returned main-room post into the same store rendered by the room timeline', async () => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomEvent.svelte
@@ -10,12 +10,14 @@
     event,
     compact = false,
     roomId,
+    permalinkThreadRootEventId = null,
     messageStore = null,
     onOpenThread
   }: {
     event: RoomEventView;
     compact?: boolean;
     roomId: string;
+    permalinkThreadRootEventId?: string | null;
     messageStore?: MessagesStore | null;
     onOpenThread?: OpenThreadHandler;
   } = $props();
@@ -31,7 +33,14 @@
 {#if !event?.event || isDMJoinLeave}
   <!-- Skip unknown event types, stale virtualizer items, and join/leave events in DM rooms -->
 {:else if isMessagePostedEvent(event.event)}
-  <MessageEvent {event} {compact} {roomId} {messageStore} {onOpenThread} />
+  <MessageEvent
+    {event}
+    {compact}
+    {roomId}
+    {permalinkThreadRootEventId}
+    {messageStore}
+    {onOpenThread}
+  />
 {:else}
   <SystemEvent {event} />
 {/if}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomRouteLayoutRoomMock.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomRouteLayoutRoomMock.svelte
@@ -1,5 +1,14 @@
 <script lang="ts">
-  let { roomId, threadId }: { roomId: string; threadId?: string } = $props();
+  let {
+    roomId,
+    threadId,
+    routeMessageId
+  }: { roomId: string; threadId?: string; routeMessageId?: string } = $props();
 </script>
 
-<div data-testid="room-layout-room" data-room-id={roomId} data-thread-id={threadId ?? ''}></div>
+<div
+  data-testid="room-layout-room"
+  data-room-id={roomId}
+  data-thread-id={threadId ?? ''}
+  data-route-message-id={routeMessageId ?? ''}
+></div>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomThreadPaneMock.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomThreadPaneMock.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  let {
+    threadRootEventId,
+    highlightEventId = null
+  }: { threadRootEventId: string; highlightEventId?: string | null } = $props();
+</script>
+
+<div data-testid="thread-pane-root-id">{threadRootEventId}</div>
+<div data-testid="thread-pane-highlight-id">{highlightEventId ?? ''}</div>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -317,6 +317,7 @@
 
   <TimelineEventsPane
     {roomId}
+    permalinkThreadRootEventId={threadRootEventId}
     messageStore={store}
     events={threadEvents}
     alwaysScrollToBottom={false}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -131,10 +131,38 @@
     store.setThread(roomId, threadRootEventId);
   });
 
-  // Jump to a specific message when highlightEventId prop is set
+  // Load a permalink target outside the latest page before asking the
+  // virtualized timeline to scroll to it.
+  let handledHighlightKey: string | null = null;
+  let highlightRequestId = 0;
   $effect(() => {
-    if (!highlightEventId || store.isInitialLoading) return;
-    jumpState.jumpToMessage(highlightEventId);
+    const targetEventId = highlightEventId;
+    const targetThreadRootEventId = threadRootEventId;
+    if (!targetEventId) {
+      handledHighlightKey = null;
+      highlightRequestId += 1;
+      return;
+    }
+    if (store.isInitialLoading) return;
+
+    const highlightKey = `${targetThreadRootEventId}:${targetEventId}`;
+    if (handledHighlightKey === highlightKey) return;
+    handledHighlightKey = highlightKey;
+    const requestId = ++highlightRequestId;
+
+    void (async () => {
+      if (!threadEvents.some((event) => event.id === targetEventId)) {
+        await store.refreshCurrentWindow(targetEventId);
+      }
+      if (
+        requestId !== highlightRequestId ||
+        threadRootEventId !== targetThreadRootEventId ||
+        highlightEventId !== targetEventId
+      ) {
+        return;
+      }
+      await jumpState.jumpToMessage(targetEventId);
+    })();
   });
 
   $effect(() => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
@@ -20,6 +20,7 @@ const { mocks } = vi.hoisted(() => {
       removeTypingUser: vi.fn(),
       sendTypingIndicator: vi.fn(),
       resetTypingDebounce: vi.fn(),
+      jumpToMessage: vi.fn(),
       onClose: vi.fn(),
       notifications: {
         dismissThreadNotifications: vi.fn().mockResolvedValue({ byRoom: {} })
@@ -112,7 +113,7 @@ vi.mock('$lib/state/room', () => ({
     jumpState: {
       scrollToEventId: null,
       setJumpHandler: vi.fn(),
-      jumpToMessage: vi.fn()
+      jumpToMessage: mocks.jumpToMessage
     }
   }),
   MessagesStore: class {
@@ -188,6 +189,44 @@ describe('ThreadPane', () => {
     expect(mocks.setThread).toHaveBeenCalledWith('room-1', 'thread-root');
     expect(mocks.notifications.dismissThreadNotifications).not.toHaveBeenCalled();
     expect(mocks.rooms.decrementUnreadNotification).not.toHaveBeenCalled();
+  });
+
+  it('loads a highlighted reply outside the latest thread page before jumping to it', async () => {
+    let resolveRefresh!: (result: {
+      hasOlder: boolean;
+      hasNewer: boolean;
+      refreshed: boolean;
+      changed: boolean;
+    }) => void;
+    mocks.refreshCurrentWindow.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRefresh = resolve;
+      })
+    );
+
+    render(ThreadPane, {
+      props: {
+        roomId: 'room-1',
+        roomName: 'General',
+        threadRootEventId: 'thread-root',
+        highlightEventId: 'older-reply',
+        onClose: mocks.onClose
+      }
+    });
+
+    await vi.waitFor(() => expect(mocks.refreshCurrentWindow).toHaveBeenCalledWith('older-reply'));
+    expect(mocks.jumpToMessage).not.toHaveBeenCalled();
+
+    resolveRefresh({
+      hasOlder: true,
+      hasNewer: true,
+      refreshed: true,
+      changed: true
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.jumpToMessage).toHaveBeenCalledWith('older-reply');
+    });
   });
 
   it('updates the thread follow button optimistically while the RPC is pending', async () => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/TimelineEventsPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/TimelineEventsPane.svelte
@@ -12,6 +12,7 @@
 
   let {
     roomId,
+    permalinkThreadRootEventId = null,
     messageStore,
     events,
     updateCounter = events.length,
@@ -46,6 +47,7 @@
     pendingHighlightId = null
   }: {
     roomId: string;
+    permalinkThreadRootEventId?: string | null;
     messageStore: MessagesStore;
     events: RoomEventView[];
     updateCounter?: number;
@@ -110,6 +112,7 @@
 
 <EventList
   {roomId}
+  {permalinkThreadRootEventId}
   {messageStore}
   {events}
   {alwaysScrollToBottom}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/[threadId]/m/[messageId]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/[threadId]/m/[messageId]/+page.svelte
@@ -1,0 +1,1 @@
+<!-- Room and its selected thread message are rendered by the parent +layout.svelte. -->

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/room-route.layout.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/room-route.layout.svelte.spec.ts
@@ -10,6 +10,7 @@ const { mocks } = vi.hoisted(() => ({
     goto: vi.fn(),
     page: {
       params: { serverId: '-', roomId: 'room-1' } as Record<string, string | undefined>,
+      route: { id: '/chat/[serverId]/[roomId]' as string | null },
       state: {},
       url: new URL('https://chat.example.test/chat/-/room-1')
     },
@@ -110,6 +111,7 @@ function renderLayout() {
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.page.params = { serverId: '-', roomId: 'room-1' };
+  mocks.page.route.id = '/chat/[serverId]/[roomId]';
   mocks.page.state = {};
   mocks.page.url = new URL('https://chat.example.test/chat/-/room-1');
   mocks.roomsStore.rooms = [room()];
@@ -181,6 +183,27 @@ describe('room route layout access handling', () => {
     expect(q(container, 'button')).toBeNull();
     expect(mocks.joinRoom).not.toHaveBeenCalled();
     expect(mocks.goto).not.toHaveBeenCalled();
+  });
+
+  it('renders a nested thread message route with its thread and message targets', async () => {
+    mocks.page.params = {
+      serverId: '-',
+      roomId: 'room-1',
+      threadId: 'Ethread123ABC456',
+      messageId: 'Ereply123ABC4567'
+    };
+    mocks.page.route.id = '/chat/[serverId]/[roomId]/[threadId]/m/[messageId]';
+    mocks.page.url = new URL(
+      'https://chat.example.test/chat/-/room-1/Ethread123ABC456/m/Ereply123ABC4567'
+    );
+
+    const { container } = renderLayout();
+    await tick();
+
+    const renderedRoom = q(container, '[data-testid="room-layout-room"]') as HTMLElement;
+    expect(renderedRoom?.dataset.threadId).toBe('Ethread123ABC456');
+    expect(renderedRoom?.dataset.routeMessageId).toBe('Ereply123ABC4567');
+    expect(q(container, '[data-testid="message-resolver"]')).toBeNull();
   });
 
   it('renders the target thread after joining has made the viewer a member', async () => {

--- a/docs/fdr/FDR-002-replies-and-threads.md
+++ b/docs/fdr/FDR-002-replies-and-threads.md
@@ -1,7 +1,7 @@
 # FDR-002: Replies & Threads
 
 **Status:** Active
-**Last reviewed:** 2026-05-19
+**Last reviewed:** 2026-07-14
 
 ## Overview
 
@@ -16,6 +16,7 @@ Chatto messages can link to one another via reply attribution, and they can live
 - If the user selects text inside a message body before choosing Reply or Reply in thread, the target composer inserts that selected plain text as a Markdown blockquote while preserving any existing draft text.
 - A thread is a sequence of messages starting from a root message and continuing inside a dedicated thread pane. Threads can contain plain messages or reply-attributed messages; both are valid.
 - Thread badges in the room timeline are normal links to the thread URL, so users can copy or open the thread link through browser-native link actions.
+- Links copied from messages inside a thread reopen that thread and focus the linked message. A root message can be opened in its thread pane before the thread has any replies.
 - A user can post a plain message into a room, a reply into the room timeline, a plain message into a thread, or a reply inside a thread — each gated by separate permissions, so a room can be configured for many threading styles.
 
 ## Design Decisions
@@ -49,6 +50,12 @@ Chatto messages can link to one another via reply attribution, and they can live
 **Decision:** `MessagePostedEvent.threadRepliesAround(eventId, limit)` returns a reply page centered around a reply event ID, or around the top of the thread when the root event ID is supplied. The root event itself is still resolved separately and is not included in the reply connection.
 **Why:** Reconnect and wake refreshes need to reload the current thread window without jumping the reader to the newest replies. Anchoring by event ID lets the UI preserve scroll position in the same way room timelines use `eventsAround`.
 **Tradeoff:** This adds a second thread read shape, but keeps the existing forward/backward pagination API simple and avoids teaching cursor pagination how to express "refresh around this visible row."
+
+### 6. Thread message links identify both the thread and focused message
+
+**Decision:** A link copied from the thread pane preserves the thread root separately from the message it focuses. Opening the link shows the thread pane even when the focused message is the root and no replies exist.
+**Why:** A message identifier alone can locate a reply's thread after a lookup, but it cannot express that a root message should open as an empty thread. Carrying both identities makes the intended view explicit and directly shareable.
+**Tradeoff:** Thread message links contain two event identifiers, making them longer than ordinary room message links.
 
 ## Permissions
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -11,7 +11,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | # | Feature | Status | Last reviewed |
 |---|---------|--------|---------------|
 | [FDR-001](FDR-001-roles-and-permissions.md) | Roles & Permissions (RBAC) | Active | 2026-06-16 |
-| [FDR-002](FDR-002-replies-and-threads.md) | Replies & Threads | Active | 2026-05-19 |
+| [FDR-002](FDR-002-replies-and-threads.md) | Replies & Threads | Active | 2026-07-14 |
 | [FDR-003](FDR-003-thread-reply-echo.md) | Thread Reply Echo | Active | 2026-06-01 |
 | [FDR-004](FDR-004-message-editing-and-deletion.md) | Message Editing & Deletion | Active | 2026-07-10 |
 | [FDR-005](FDR-005-reactions.md) | Reactions | Active | 2026-05-19 |


### PR DESCRIPTION
## Why

Message permalinks can currently locate a message, but a root-message link opens only the room timeline. Recipients must still discover and click the thread badge, and a root message with no replies has no shareable way to open its empty thread pane. Thread conversations therefore cannot be linked directly and consistently.

## What changed

- add nested message permalinks that explicitly carry both the thread root and focused message
- open and highlight nested thread-message routes even when the thread has no replies
- make copy-link actions inside the thread pane emit nested permalinks while preserving existing room-message links
- preserve nested route intent in pasted message-link previews
- load older linked replies around their anchor before highlighting them, while retaining the latest thread window
- document the behavior and rationale in FDR-002

## Compatibility and rollout

- additive frontend route; existing room, thread, and `/m/<message>` links remain compatible
- no protobuf, ConnectRPC, persisted-data, permission, migration, security, or operational changes

## Test plan

- `mise test-frontend` — 245 files and 2,096 tests passed
- targeted route, message-link, room, ThreadPane, MessagesStore, preview, menu, action-sheet, hover, and EventList tests passed
- `mise lint-frontend` — passed with 0 Svelte errors or warnings and clean ESLint
- `mise license-check` — REUSE compliance passed
- Svelte autofixer — no issues in edited components
- manual in-app browser verification remains unavailable because this workspace exposes no browser backend; mounted Chromium component coverage exercises the route and thread behavior

Closes #1523.
