### PR TITLE
fix(frontend): use origin host for message links

### DIFF
--- a/apps/frontend/src/lib/messageLinks.spec.ts
+++ b/apps/frontend/src/lib/messageLinks.spec.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getToasts, toast } from '$lib/ui/toast';
+import { serverRegistry, type RegisteredServer } from '$lib/state/server/registry.svelte';
 import {
+  buildMessageLinkURL,
   classifyMessageBodyChatLink,
   copyMessageLinkToClipboard,
   parseMessageLink
@@ -12,6 +14,20 @@ const channelRoomId = 'R123456789abcde';
 const dmRoomId = 'abcdef12345678';
 const messageId = 'Eabc123DEF456gh';
 const threadRootEventId = 'Ethread12345678';
+
+const remoteServer: RegisteredServer = {
+  id: 'remote',
+  url: 'https://remote.example.test',
+  name: 'Remote',
+  iconUrl: null,
+  token: null,
+  userId: null,
+  userLogin: null,
+  userDisplayName: null,
+  userAvatarUrl: null,
+  reauthRequiredAt: null,
+  addedAt: 1
+};
 
 function resolveServerSegment(segment: string): string | null {
   if (segment === '-') return 'origin';
@@ -39,6 +55,43 @@ function classify(input: string) {
     serverSegmentForId
   });
 }
+
+describe('buildMessageLinkURL', () => {
+  beforeEach(() => {
+    vi.stubGlobal('window', { location: { origin } });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the SPA origin and home segment for an origin-server message', () => {
+    vi.spyOn(serverRegistry, 'isOriginServer').mockReturnValue(true);
+
+    expect(buildMessageLinkURL('origin', 'room-1', 'message-1')).toBe(
+      `${origin}/chat/-/room-1/m/message-1`
+    );
+  });
+
+  it('uses the SPA origin and remote hostname for a remote-server message', () => {
+    vi.spyOn(serverRegistry, 'isOriginServer').mockReturnValue(false);
+    vi.spyOn(serverRegistry, 'getServer').mockReturnValue(remoteServer);
+
+    expect(buildMessageLinkURL('remote', 'room-1', 'message-1')).toBe(
+      `${origin}/chat/remote.example.test/room-1/m/message-1`
+    );
+  });
+
+  it('preserves the thread root in a remote-server message link', () => {
+    vi.spyOn(serverRegistry, 'isOriginServer').mockReturnValue(false);
+    vi.spyOn(serverRegistry, 'getServer').mockReturnValue(remoteServer);
+
+    expect(buildMessageLinkURL('remote', 'room-1', 'message-1', 'thread-root-1')).toBe(
+      `${origin}/chat/remote.example.test/room-1/thread-root-1/m/message-1`
+    );
+  });
+});
 
 describe('copyMessageLinkToClipboard', () => {
   const writeText = vi.fn();

--- a/apps/frontend/src/lib/messageLinks.ts
+++ b/apps/frontend/src/lib/messageLinks.ts
@@ -171,7 +171,10 @@ export function buildMessageLinkPath(
   return messagePath(serverId, roomId, messageId, '', {}, threadRootEventId);
 }
 
-/** Absolute URL for clipboard copy. */
+/**
+ * Absolute URL for clipboard copy, anchored to the server hosting the SPA.
+ * Remote servers are identified by their hostname in the generated path.
+ */
 export function buildMessageLinkURL(
   serverId: string,
   roomId: string,
@@ -179,15 +182,6 @@ export function buildMessageLinkURL(
   threadRootEventId?: string | null
 ): string {
   const path = buildMessageLinkPath(serverId, roomId, messageId, threadRootEventId);
-
-  const server = serverRegistry.getServer(serverId);
-  if (server) {
-    try {
-      return new URL(path, server.url).toString();
-    } catch {
-      // fall through to window.location.origin
-    }
-  }
 
   if (typeof window !== 'undefined') {
     return new URL(path, window.location.origin).toString();


### PR DESCRIPTION
## Why

Copied links for messages on connected remote servers incorrectly used the remote server as the URL host, preventing the origin SPA from resolving the remote hostname path as intended.

## What changed

- Resolve absolute message links against the SPA origin while retaining `-` for origin messages and the connected server hostname for remote messages.
- Add exact regression coverage for origin, remote, and remote-thread message links.

## Test plan

- `mise x -- pnpm --dir apps/frontend exec vitest --run --project=server src/lib/messageLinks.spec.ts` — 20 tests passed.
- `mise test-frontend` — 245 files and 2,105 tests passed.
