### PR TITLE
fix(frontend): restore POST server discovery

### DIFF
--- a/apps/frontend/src/lib/api-client-tests/server.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/server.spec.ts
@@ -56,8 +56,7 @@ describe('getPublicServerInfo', () => {
 
     expect(mocks.createConnectTransport).toHaveBeenCalledWith({
       baseUrl: 'https://chat.example.test/api/connect',
-      useBinaryFormat: false,
-      useHttpGet: true
+      useBinaryFormat: false
     });
     expect(mocks.getServer).toHaveBeenCalledWith({}, { signal: undefined });
     expect(info).toEqual({

--- a/apps/frontend/src/lib/api-client/connect.ts
+++ b/apps/frontend/src/lib/api-client/connect.ts
@@ -26,14 +26,11 @@ export function connectEndpoint(baseUrl: string): string {
 
 export function createChattoTransport(
   config: { baseUrl: string },
-  options: { useBinaryFormat?: boolean; useHttpGet?: boolean } = {},
+  options: { useBinaryFormat?: boolean } = {},
 ): Transport {
   return createConnectTransport({
     baseUrl: config.baseUrl,
     useBinaryFormat: options.useBinaryFormat ?? true,
-    ...(options.useHttpGet === undefined
-      ? {}
-      : { useHttpGet: options.useHttpGet }),
   });
 }
 
@@ -52,7 +49,7 @@ export function createPublicChattoClient<T extends ServiceType>(
     service,
     createChattoTransport(
       { baseUrl: connectEndpoint(baseUrl) },
-      { useBinaryFormat: false, useHttpGet: true },
+      { useBinaryFormat: false },
     ),
   );
 }

--- a/apps/frontend/src/lib/components/AddServerDialog.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/AddServerDialog.svelte.spec.ts
@@ -85,14 +85,10 @@ describe('AddServerDialog', () => {
     });
 
     const [requestUrl, requestInit] = vi.mocked(globalThis.fetch).mock.calls[0];
-    const parsedRequestUrl = new URL(String(requestUrl));
-    expect(`${parsedRequestUrl.origin}${parsedRequestUrl.pathname}`).toBe(
+    expect(requestUrl).toBe(
       'https://chat.example.com/api/connect/chatto.discovery.v1.ServerDiscoveryService/GetServer'
     );
-    expect(parsedRequestUrl.searchParams.get('connect')).toBe('v1');
-    expect(parsedRequestUrl.searchParams.get('encoding')).toBe('json');
-    expect(parsedRequestUrl.searchParams.get('message')).toBe('{}');
-    expect(requestInit?.method).toBe('GET');
+    expect(requestInit?.method).toBe('POST');
 
     // The server-supplied name appears in the (visually-marked) preview
     // card, not in any action button.


### PR DESCRIPTION
## Why

- Chatto 0.4 servers reject GET server discovery with `405 Method Not Allowed`, preventing remote login from the newer bundled frontend.

## What changed

- Restore Connect-Web's JSON POST default for public server discovery while leaving backend GET support intact.
- Update the transport unit test and mounted Add Server dialog coverage to assert POST behavior; re-enable GET later via #1527.

## Test plan

- `mise x -- pnpm run build:api-types`
- `mise x -- pnpm --filter chatto-frontend exec vitest --run src/lib/api-client-tests/server.spec.ts` — 2 tests passed.
- `mise test-frontend` — 245 files and 2,105 tests passed.
