### PR TITLE
fix(frontend): support remote-only sessions

### DIFF
--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -154,6 +154,8 @@ generated protobuf clients, Vitest browser tests, Playwright e2e, and Storybook.
   DOM/CSS/localStorage/drag behavior, context, and `$effect` runtime behavior
   need browser/component tests.
 - E2E is for real backend/NATS/WebSocket/multi-user/cross-route behavior.
+- When changing multi-server authentication or shared chat providers, cover an
+  authenticated remote server with an anonymous origin server.
 - Use helpers from `$lib/test-utils` rather than re-rolling connection/context
   mocks.
 - Use `expect.element(...)` for DOM assertions and flush after Svelte state

--- a/apps/frontend/e2e/server-flows.test.ts
+++ b/apps/frontend/e2e/server-flows.test.ts
@@ -264,7 +264,7 @@ test.describe('Add Server - Remote Auth Flow', () => {
    * click the static "Sign in" button on the preview.
    */
   async function driveAddServerToOAuth(page: Page, hostname: string): Promise<void> {
-    await page.getByTitle('Add Server').click();
+    await page.getByRole('button', { name: 'Add Server', exact: true }).click();
     await page.getByLabel('Server URL').fill(hostname);
     await page.getByRole('button', { name: 'Connect' }).click();
     await expect(page.getByRole('button', { name: 'Sign in', exact: true })).toBeVisible({
@@ -329,6 +329,42 @@ test.describe('Add Server - Remote Auth Flow', () => {
     await expect(
       page.locator(`[data-testid="server-icon"][href*="${remoteHostname}"]`).first()
     ).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+  });
+
+  test('signing in to a remote server works while the origin is anonymous', async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error.message));
+
+    await page.goto('/');
+    await expect(page).toHaveURL(routes.login);
+
+    const baseURL = remoteBaseURL(remoteServer);
+    const hostname = new URL(baseURL).host;
+    const remoteHostname = new URL(baseURL).hostname;
+    await createUserOnRemote(baseURL, 'remoteonlyuser', 'password123');
+
+    await driveAddServerToOAuth(page, hostname);
+    await expect(page).toHaveURL(/\/login\?redirect=/, {
+      timeout: TIMEOUTS.REALTIME_EVENT
+    });
+
+    await page.locator('input[autocomplete="username"]').fill('remoteonlyuser');
+    await page.locator('input[autocomplete="current-password"]').fill('password123');
+    await page.getByRole('button', { name: 'Sign In' }).click();
+    await expect(page).toHaveURL(/\/oauth\/consent/, {
+      timeout: TIMEOUTS.REALTIME_EVENT
+    });
+    await page.getByRole('button', { name: 'Allow Access' }).click();
+
+    const remoteHostnameEsc = remoteHostname.replace(/\./g, '\\.');
+    await page.waitForURL(new RegExp(`/chat/${remoteHostnameEsc}(/|$)`), {
+      timeout: TIMEOUTS.COMPLEX_OPERATION
+    });
+    await expect(
+      page.locator(`[data-testid="server-icon"][href*="${remoteHostname}"]`).first()
+    ).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+    await expect(page.getByTestId('server-subscription-active')).toBeAttached();
+    expect(pageErrors).toEqual([]);
   });
 
   test('invalid credentials show error on remote OAuth login page', async ({ page, chatPage }) => {

--- a/apps/frontend/src/routes/chat/+layout.svelte
+++ b/apps/frontend/src/routes/chat/+layout.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { fullscreenVideo } from '$lib/state/globals.svelte';
+  import { createPresenceCache } from '$lib/state/presenceCache.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { UserSettingsState, setUserSettings } from '$lib/state/userSettings.svelte';
+  import { createUserProfileCache } from '$lib/state/userProfiles.svelte';
 
   let { data, children } = $props();
   let authenticatedRootModule: Promise<typeof import('./AuthenticatedRoot.svelte')> | null = null;
@@ -19,6 +21,10 @@
     return fullscreenVideoOverlayModule;
   }
 
+  // Remote servers can be authenticated while the origin remains anonymous,
+  // so chat-wide caches must exist independently of the origin auth wrapper.
+  const profileCache = createUserProfileCache();
+  const presenceCache = createPresenceCache();
   const userSettings = new UserSettingsState();
   setUserSettings(userSettings);
 </script>
@@ -26,7 +32,7 @@
 {#if data.user && serverRegistry.originServer}
   {#key data.user.id}
     {#await loadAuthenticatedRoot() then { default: AuthenticatedRoot }}
-      <AuthenticatedRoot user={data.user} {userSettings}>
+      <AuthenticatedRoot user={data.user} {userSettings} {profileCache} {presenceCache}>
         {@render children?.()}
       </AuthenticatedRoot>
     {/await}

--- a/apps/frontend/src/routes/chat/AuthenticatedRoot.svelte
+++ b/apps/frontend/src/routes/chat/AuthenticatedRoot.svelte
@@ -4,26 +4,27 @@
   import AuthStatusNotice from '$lib/components/AuthStatusNotice.svelte';
   import NotificationSync from '$lib/components/NotificationSync.svelte';
   import { shouldPauseLiveEventsForStoredPresence } from '$lib/presenceTracking';
-  import { createPresenceCache } from '$lib/state/presenceCache.svelte';
+  import type { PresenceCache } from '$lib/state/presenceCache.svelte';
   import { serverConnectionManager } from '$lib/state/server/serverConnection.svelte';
   import { eventBusManager } from '$lib/state/server/eventBus.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { UserSettingsState } from '$lib/state/userSettings.svelte';
-  import { createUserProfileCache } from '$lib/state/userProfiles.svelte';
+  import type { createUserProfileCache } from '$lib/state/userProfiles.svelte';
   import AuthenticatedChatProvider from './AuthenticatedChatProvider.svelte';
 
   let {
     user,
     userSettings,
+    profileCache,
+    presenceCache,
     children
   }: {
     user: CurrentUser;
     userSettings: UserSettingsState;
+    profileCache: ReturnType<typeof createUserProfileCache>;
+    presenceCache: PresenceCache;
     children: Snippet;
   } = $props();
-
-  const profileCache = createUserProfileCache();
-  const presenceCache = createPresenceCache();
 
   function startAuthenticatedBuses() {
     if (shouldPauseLiveEventsForStoredPresence()) {


### PR DESCRIPTION
## Why

An authenticated remote server can mount the chat chrome while the origin remains anonymous, but the presence and user-profile contexts were previously created only inside the origin-authenticated wrapper. That caused an uncaught Svelte `missing_context` error and prevented the remote UI from stabilizing.

## What changed

- Create both chat-wide caches unconditionally at the `/chat` layout boundary and pass the same instances into the origin-authenticated provider.
- Add a real remote OAuth regression that starts from an anonymous origin, fails on uncaught page errors, and verifies the remote subscription UI mounts.
- Use the accessible Add Server button role in the shared OAuth helper so the flow works from both the login page and server gutter.
- Document that multi-server authentication and shared-provider changes must cover an authenticated remote server with an anonymous origin.

## Test plan

- Svelte autofixer: no issues in either changed layout.
- Prettier check: passed for all changed code files.
- Remote-auth Playwright describe: 4/4 tests passed.
- `mise test-frontend`: 245 files and 2,108 tests passed.
- Adversarial code review: no findings; independent Svelte check passed.
- Documentation update proofread and `git diff --check` passed.

## Compatibility

No public API, persistence, migration, security, or user-facing documentation changes are required. The relevant layout files match Chatto 0.4.10 closely, keeping the fix suitable for a 0.4 backport.

Closes #1529.
