### PR TITLE
ci: add remote server compatibility smoke test

### DIFF
--- a/.github/actions/prepare-released-chatto/action.yml
+++ b/.github/actions/prepare-released-chatto/action.yml
@@ -1,0 +1,96 @@
+name: Prepare Released Chatto
+description: Resolve, cache, download, and checksum-verify the latest stable Chatto release in a series
+inputs:
+  release-series:
+    description: Major.minor release series to resolve, such as 0.4
+    required: true
+  archive-name:
+    description: Release archive containing the executable
+    required: false
+    default: chatto_Linux_x86_64.tar.gz
+outputs:
+  tag:
+    description: Resolved release tag
+    value: ${{ steps.release.outputs.tag }}
+  version:
+    description: Resolved version without the leading v
+    value: ${{ steps.release.outputs.version }}
+  path:
+    description: Absolute path to the verified Chatto executable
+    value: ${{ steps.binary.outputs.path }}
+runs:
+  using: composite
+  steps:
+    - name: Resolve latest stable release
+      id: release
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        RELEASE_SERIES: ${{ inputs.release-series }}
+      run: |
+        set -euo pipefail
+        if [[ ! "$RELEASE_SERIES" =~ ^[0-9]+\.[0-9]+$ ]]; then
+          echo "::error::release-series must use major.minor format, got $RELEASE_SERIES"
+          exit 1
+        fi
+
+        escaped_series="${RELEASE_SERIES//./\\.}"
+        tag="$({
+          gh api --paginate repos/chattocorp/chatto/releases \
+            --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name'
+        } | grep -E "^v${escaped_series}\.[0-9]+$" | sort -V | tail -n 1)"
+        if [[ -z "$tag" ]]; then
+          echo "::error::Could not find a stable v$RELEASE_SERIES.x GitHub release."
+          exit 1
+        fi
+
+        echo "tag=$tag" >> "$GITHUB_OUTPUT"
+        echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+        {
+          echo "### Remote compatibility baseline"
+          echo
+          echo "Testing the current embedded frontend against Chatto $tag."
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Cache released executable
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/chatto-remote-compatibility/${{ steps.release.outputs.tag }}
+        key: chatto-remote-compatibility-${{ runner.os }}-${{ runner.arch }}-${{ steps.release.outputs.tag }}
+
+    - name: Download and verify released executable
+      id: binary
+      shell: bash
+      env:
+        ARCHIVE_NAME: ${{ inputs.archive-name }}
+        GH_TOKEN: ${{ github.token }}
+        TAG: ${{ steps.release.outputs.tag }}
+      run: |
+        set -euo pipefail
+
+        destination="$HOME/.cache/chatto-remote-compatibility/$TAG"
+        binary="$destination/chatto"
+        if [[ ! -x "$binary" ]]; then
+          download_dir="$(mktemp -d)"
+          trap 'rm -rf "$download_dir"' EXIT
+          gh release download "$TAG" \
+            --repo chattocorp/chatto \
+            --dir "$download_dir" \
+            --pattern "$ARCHIVE_NAME" \
+            --pattern 'chatto_*_checksums.txt'
+
+          archive="$download_dir/$ARCHIVE_NAME"
+          checksum_file="$(find "$download_dir" -maxdepth 1 -name 'chatto_*_checksums.txt' -print -quit)"
+          expected="$(awk -v archive="$ARCHIVE_NAME" '$2 == archive { print $1 }' "$checksum_file")"
+          if [[ -z "$expected" ]]; then
+            echo "::error::Release checksum file has no $ARCHIVE_NAME entry."
+            exit 1
+          fi
+          printf '%s  %s\n' "$expected" "$archive" | sha256sum --check --status
+
+          mkdir -p "$destination"
+          tar -xzf "$archive" -C "$destination" chatto
+          chmod +x "$binary"
+        fi
+
+        echo "path=$binary" >> "$GITHUB_OUTPUT"

--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -1,0 +1,16 @@
+name: Setup Playwright
+description: Cache and install the Chromium browser and system dependencies used by Playwright
+runs:
+  using: composite
+  steps:
+    - name: Cache Playwright browsers
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          playwright-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Install Playwright dependencies
+      shell: bash
+      run: pnpm --dir apps/frontend exec playwright install chromium --with-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,16 +178,8 @@ jobs:
         with:
           install-cli-deps: "false"
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Install Playwright dependencies
-        run: cd apps/frontend && pnpm exec playwright install chromium --with-deps
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
         timeout-minutes: 15
 
       - name: Run frontend typecheck
@@ -233,16 +225,8 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Install Playwright dependencies
-        run: cd apps/frontend && pnpm exec playwright install chromium --with-deps
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
         timeout-minutes: 15
 
       - name: Build E2E server
@@ -259,6 +243,49 @@ jobs:
           path: apps/frontend/playwright-report/
           retention-days: 14
 
+  test-e2e-remote-compatibility:
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup environment
+        uses: ./.github/actions/setup
+
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
+        timeout-minutes: 15
+
+      - name: Prepare latest stable 0.4.x release
+        id: release
+        uses: ./.github/actions/prepare-released-chatto
+        with:
+          release-series: "0.4"
+
+      - name: Build current production executable with embedded frontend
+        run: mise build-compatibility-server
+
+      - name: Run remote compatibility smoke test
+        working-directory: apps/frontend
+        env:
+          CHATTO_COMPAT_CURRENT_BINARY: ${{ github.workspace }}/apps/frontend/e2e/fixtures/bin/chatto-current
+          CHATTO_COMPAT_REMOTE_BINARY: ${{ steps.release.outputs.path }}
+          CHATTO_COMPAT_REMOTE_VERSION: ${{ steps.release.outputs.version }}
+        run: pnpm exec playwright test --config playwright.compat.config.ts
+
+      - name: Upload remote compatibility diagnostics
+        uses: actions/upload-artifact@v7
+        if: ${{ failure() }}
+        with:
+          name: playwright-report-remote-compatibility
+          path: |
+            apps/frontend/playwright-report-remote-compatibility/
+            apps/frontend/test-results/
+          retention-days: 14
+
   test-e2e-media:
     # runs-on: ubicloud-standard-4
     runs-on: ubuntu-latest
@@ -272,16 +299,8 @@ jobs:
         with:
           install-ffmpeg: "true"
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Install Playwright dependencies
-        run: cd apps/frontend && pnpm exec playwright install chromium --with-deps
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
         timeout-minutes: 15
 
       - name: Build E2E server
@@ -307,6 +326,7 @@ jobs:
       - test-frontend-unit
       - test-cli
       - test-e2e
+      - test-e2e-remote-compatibility
       - test-e2e-media
     runs-on: ubuntu-latest
     permissions:

--- a/apps/frontend/e2e/fixtures/multiServer.ts
+++ b/apps/frontend/e2e/fixtures/multiServer.ts
@@ -106,26 +106,14 @@ function postedEventId(
  * Uses parallelIndex + 5 to avoid port collisions with the primary server.
  */
 export async function startSecondServer(testInfo: TestInfo): Promise<ServerInfo> {
-  // Create a modified testInfo-like object with offset parallelIndex
-  // to get a different port range from the primary server
-  const modifiedTestInfo = {
-    ...testInfo,
-    parallelIndex: testInfo.parallelIndex + 5
-  } as TestInfo;
-
-  return startServer(modifiedTestInfo);
+  return startServer(testInfo, { instanceId: 'secondary', portOffset: 5 });
 }
 
 /**
  * Stops a second server and cleans up.
  */
 export async function stopSecondServer(server: ServerInfo, testInfo: TestInfo): Promise<void> {
-  const modifiedTestInfo = {
-    ...testInfo,
-    parallelIndex: testInfo.parallelIndex + 5
-  } as TestInfo;
-
-  await stopServer(server, modifiedTestInfo);
+  await stopServer(server, testInfo);
 }
 
 /**

--- a/apps/frontend/e2e/fixtures/productionServer.ts
+++ b/apps/frontend/e2e/fixtures/productionServer.ts
@@ -1,0 +1,84 @@
+import { spawn } from 'child_process';
+import type { TestInfo } from '@playwright/test';
+import { startServer, type ServerInfo } from './server';
+
+export interface ProductionUser {
+  login: string;
+  displayName: string;
+  password: string;
+  roles?: string[];
+}
+
+/**
+ * Start an unmodified production Chatto executable with an isolated embedded
+ * NATS store and local operator socket.
+ */
+export function startProductionServer(
+  testInfo: TestInfo,
+  executablePath: string,
+  instanceId: string,
+  portOffset: number,
+  hostname = 'localhost'
+): Promise<ServerInfo> {
+  return startServer(testInfo, {
+    executablePath,
+    hostname,
+    instanceId,
+    operatorApi: true,
+    portOffset
+  });
+}
+
+/** Create a test account through the production, Unix-socket-only operator API. */
+export async function createProductionUser(
+  server: ServerInfo,
+  user: ProductionUser
+): Promise<void> {
+  if (!server.operatorSocketPath) {
+    throw new Error('Production server was not started with its operator API enabled');
+  }
+
+  const args = [
+    'operator',
+    '--operator-socket',
+    server.operatorSocketPath,
+    'user',
+    'create',
+    '--login',
+    user.login,
+    '--display-name',
+    user.displayName,
+    '--password-stdin'
+  ];
+  for (const role of user.roles ?? ['owner']) {
+    args.push('--role', role);
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(server.executablePath, args, {
+      env: process.env,
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+    child.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+    child.once('error', reject);
+    child.once('close', (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(
+        new Error(
+          `chatto operator user create exited with code ${code}: ${stderr.trim() || stdout.trim()}`
+        )
+      );
+    });
+    child.stdin.end(`${user.password}\n`);
+  });
+}

--- a/apps/frontend/e2e/fixtures/server.ts
+++ b/apps/frontend/e2e/fixtures/server.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess } from 'child_process';
-import { existsSync, mkdirSync, rmSync } from 'fs';
+import { chmodSync, createWriteStream, existsSync, mkdirSync, mkdtempSync, rmSync } from 'fs';
+import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import type { TestInfo } from '@playwright/test';
@@ -11,6 +12,10 @@ export interface ServerInfo {
   baseURL: string;
   port: number;
   process: ChildProcess;
+  executablePath: string;
+  dataDir: string;
+  logPath: string;
+  operatorSocketPath?: string;
 }
 
 const PORT_STRIDE = 1;
@@ -47,11 +52,21 @@ function getPortsForTest(workerIndex: number, parallelIndex: number) {
  * Wait for the server to be ready by polling the readiness endpoint.
  * This verifies both NATS connectivity and JetStream initialization.
  */
-async function waitForServer(port: number, timeoutMs = 45000): Promise<void> {
+async function waitForServer(
+  baseURL: string,
+  process: ChildProcess,
+  logPath: string,
+  timeoutMs = 45000
+): Promise<void> {
   const start = Date.now();
-  const url = `http://localhost:${port}/readyz`;
+  const url = new URL('/readyz', baseURL);
 
   while (Date.now() - start < timeoutMs) {
+    if (process.exitCode !== null) {
+      throw new Error(
+        `Server exited with code ${process.exitCode} before becoming ready; see ${logPath}`
+      );
+    }
     try {
       const response = await fetch(url);
       if (response.ok) {
@@ -63,12 +78,28 @@ async function waitForServer(port: number, timeoutMs = 45000): Promise<void> {
     }
     await new Promise((r) => setTimeout(r, 25));
   }
-  throw new Error(`Server on port ${port} did not become ready within ${timeoutMs}ms`);
+  throw new Error(
+    `Server at ${baseURL} did not become ready within ${timeoutMs}ms; see ${logPath}`
+  );
 }
 
 export interface StartServerOptions {
   /** Additional environment variables for the server process */
   env?: Record<string, string>;
+  /** Chatto executable to launch. Defaults to the test-tagged E2E binary. */
+  executablePath?: string;
+  /** Stable suffix used to isolate this process's data, logs, and operator socket. */
+  instanceId?: string;
+  /** Port offset for additional servers started by the same Playwright test. */
+  portOffset?: number;
+  /** Hostname advertised to the browser. The server still listens on its configured port. */
+  hostname?: string;
+  /** Enable the local production operator API and expose its socket in ServerInfo. */
+  operatorApi?: boolean;
+}
+
+function safePathSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9-]/g, '-');
 }
 
 /**
@@ -79,70 +110,104 @@ export async function startServer(
   testInfo: TestInfo,
   options: StartServerOptions = {}
 ): Promise<ServerInfo> {
-  const ports = getPortsForTest(testInfo.workerIndex, testInfo.parallelIndex);
-  // Use testId for unique data directory per test
-  const dataDir = path.join(__dirname, `data-${testInfo.testId.replace(/[^a-zA-Z0-9]/g, '-')}`);
+  const ports = getPortsForTest(
+    testInfo.workerIndex,
+    testInfo.parallelIndex + (options.portOffset ?? 0)
+  );
+  const instanceId = safePathSegment(options.instanceId ?? 'primary');
+  const testId = safePathSegment(testInfo.testId);
+  const dataDir = path.join(__dirname, `data-${testId}-${instanceId}`);
+  const executablePath = options.executablePath ?? path.join(__dirname, 'bin', 'chatto');
+  const hostname = options.hostname ?? 'localhost';
+  const baseURL = `http://${hostname}:${ports.webserver}`;
+  const logPath = testInfo.outputPath(`${instanceId}-server.log`);
+  // Unix-domain socket paths are short (roughly 100 bytes on macOS/Linux), so
+  // keep operator sockets out of the potentially long workspace/test path.
+  const operatorDir = options.operatorApi
+    ? mkdtempSync(path.join(os.tmpdir(), 'chatto-e2e-operator-'))
+    : undefined;
+  const operatorSocketPath = operatorDir ? path.join(operatorDir, 'operator.sock') : undefined;
 
-  // Clean up and create data directory
   if (existsSync(dataDir)) {
     rmSync(dataDir, { recursive: true });
   }
   mkdirSync(dataDir, { recursive: true });
+  mkdirSync(path.dirname(logPath), { recursive: true });
+  const logStream = createWriteStream(logPath, { flags: 'w' });
 
-  // chatto.toml seeds the e2eadmin user via [bootstrap] for each fresh data dir.
-  const serverProcess = spawn(
-    path.join(__dirname, 'bin', 'chatto'),
-    ['start', '-c', 'chatto.toml'],
-    {
-      cwd: __dirname,
-      env: {
-        ...process.env,
-        CHATTO_VIDEO_ENABLED: 'false',
-        ...options.env,
-        CHATTO_WEBSERVER_PORT: String(ports.webserver),
-        CHATTO_WEBSERVER_URL: `http://localhost:${ports.webserver}`,
-        CHATTO_NATS_EMBEDDED_PORT: '0',
-        CHATTO_NATS_EMBEDDED_HTTP_PORT: '0',
-        CHATTO_NATS_EMBEDDED_DATA_DIR: dataDir,
-        CHATTO_TEST_EMAIL_ENDPOINT: 'true' // Enable test email endpoint for E2E tests
-      },
-      stdio: ['ignore', 'pipe', 'pipe']
-    }
-  );
+  if (operatorDir) {
+    chmodSync(operatorDir, 0o700);
+  }
 
-  // Log server output for debugging (prefix with test title)
-  const prefix = `[${testInfo.title}]`;
+  // The default test binary honors chatto.toml's bootstrap section. Production
+  // binaries ignore it and can instead be provisioned through the operator API.
+  const serverProcess = spawn(executablePath, ['start', '-c', 'chatto.toml'], {
+    cwd: __dirname,
+    env: {
+      ...process.env,
+      CHATTO_VIDEO_ENABLED: 'false',
+      CHATTO_TEST_EMAIL_ENDPOINT: 'true',
+      ...options.env,
+      CHATTO_WEBSERVER_PORT: String(ports.webserver),
+      CHATTO_WEBSERVER_URL: baseURL,
+      CHATTO_NATS_EMBEDDED_PORT: '0',
+      CHATTO_NATS_EMBEDDED_HTTP_PORT: '0',
+      CHATTO_NATS_EMBEDDED_DATA_DIR: dataDir,
+      ...(operatorSocketPath
+        ? {
+            CHATTO_OPERATOR_API_ENABLED: 'true',
+            CHATTO_OPERATOR_API_SOCKET_PATH: operatorSocketPath
+          }
+        : {})
+    },
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+
+  const prefix = `[${testInfo.title}:${instanceId}]`;
   serverProcess.stdout?.on('data', (data) => {
+    logStream.write(data);
     if (process.env.DEBUG_E2E) {
       console.log(`${prefix} ${data.toString().trim()}`);
     }
   });
   serverProcess.stderr?.on('data', (data) => {
+    logStream.write(data);
     if (process.env.DEBUG_E2E) {
       console.error(`${prefix} ${data.toString().trim()}`);
     }
   });
+  serverProcess.on('close', () => logStream.end());
 
-  // Wait for server to be ready. The admin user is created during startup via
-  // the [bootstrap] section in chatto.toml, so by the time the readiness check
-  // passes the user exists.
-  await waitForServer(ports.webserver);
-
-  return {
-    baseURL: `http://localhost:${ports.webserver}`,
+  const server = {
+    baseURL,
     port: ports.webserver,
-    process: serverProcess
+    process: serverProcess,
+    executablePath,
+    dataDir,
+    logPath,
+    operatorSocketPath
   };
+  try {
+    await waitForServer(baseURL, serverProcess, logPath);
+  } catch (error) {
+    await stopServer(server);
+    throw error;
+  }
+
+  return server;
 }
 
 /**
  * Stops a Chatto server and cleans up its data directory.
  */
-export async function stopServer(server: ServerInfo, testInfo: TestInfo): Promise<void> {
-  const dataDir = path.join(__dirname, `data-${testInfo.testId.replace(/[^a-zA-Z0-9]/g, '-')}`);
-
+export async function stopServer(server: ServerInfo, _testInfo?: TestInfo): Promise<void> {
   // Kill the server process
-  server.process.kill('SIGTERM');
+  if (server.process.exitCode === null) {
+    server.process.kill('SIGTERM');
+  } else {
+    cleanupServerDirectories(server);
+    return;
+  }
 
   // Wait for process to exit
   await new Promise<void>((resolve) => {
@@ -151,14 +216,23 @@ export async function stopServer(server: ServerInfo, testInfo: TestInfo): Promis
       resolve();
     }, 5000);
 
-    server.process.on('exit', () => {
+    server.process.once('exit', () => {
       clearTimeout(timeout);
       resolve();
     });
   });
 
-  // Clean up data directory
-  if (existsSync(dataDir)) {
-    rmSync(dataDir, { recursive: true });
+  cleanupServerDirectories(server);
+}
+
+function cleanupServerDirectories(server: ServerInfo): void {
+  if (existsSync(server.dataDir)) {
+    rmSync(server.dataDir, { recursive: true });
+  }
+  if (server.operatorSocketPath) {
+    const operatorDir = path.dirname(server.operatorSocketPath);
+    if (existsSync(operatorDir)) {
+      rmSync(operatorDir, { recursive: true });
+    }
   }
 }

--- a/apps/frontend/e2e/remote-compatibility.compat.ts
+++ b/apps/frontend/e2e/remote-compatibility.compat.ts
@@ -1,0 +1,136 @@
+import { test, expect } from './setup';
+import { TIMEOUTS } from './constants';
+import { getRoomOnRemote, postMessageOnRemote } from './fixtures/multiServer';
+import { createProductionUser, startProductionServer } from './fixtures/productionServer';
+import { stopServer, type ServerInfo } from './fixtures/server';
+
+const currentBinary = process.env.CHATTO_COMPAT_CURRENT_BINARY;
+const remoteBinary = process.env.CHATTO_COMPAT_REMOTE_BINARY;
+
+const originUser = {
+  login: 'compat-origin',
+  displayName: 'Compatibility Origin',
+  password: 'compat-origin-password123'
+};
+const remoteUser = {
+  login: 'compat-remote',
+  displayName: 'Compatibility Remote',
+  password: 'compat-remote-password123'
+};
+
+test.use({
+  serverOptions: {
+    executablePath: currentBinary,
+    instanceId: 'compat-current',
+    operatorApi: true
+  }
+});
+
+test.skip(
+  !currentBinary || !remoteBinary,
+  'Set CHATTO_COMPAT_CURRENT_BINARY and CHATTO_COMPAT_REMOTE_BINARY to production executables'
+);
+
+test('current frontend can connect to and use the latest 0.4.x server', async ({
+  page,
+  authPage,
+  chatPage,
+  roomPage,
+  server
+}, testInfo) => {
+  let remoteServer: ServerInfo | undefined;
+
+  try {
+    await createProductionUser(server, originUser);
+    remoteServer = await startProductionServer(
+      testInfo,
+      remoteBinary!,
+      'compat-remote-0-4',
+      5,
+      '127.0.0.1'
+    );
+    await createProductionUser(remoteServer, remoteUser);
+
+    // Sign in to the current production build and use its embedded frontend.
+    await authPage.gotoLogin();
+    await authPage.fillLoginForm(originUser.login, originUser.password);
+    await authPage.signInButton.click();
+    await page.waitForURL(
+      (url) => url.hostname === 'localhost' && url.pathname.startsWith('/chat')
+    );
+
+    // Discover the released server and complete its real OAuth + PKCE flow.
+    const remoteHost = new URL(remoteServer.baseURL).host;
+    await page.getByTitle('Add Server').click();
+    await page.getByLabel('Server URL').fill(remoteHost);
+    await page.getByRole('button', { name: 'Connect' }).click();
+    await expect(page.getByRole('button', { name: 'Sign in', exact: true })).toBeVisible({
+      timeout: TIMEOUTS.REALTIME_EVENT
+    });
+    await page.getByRole('button', { name: 'Sign in', exact: true }).click();
+
+    await expect(page).toHaveURL(/127\.0\.0\.1.*\/login\?redirect=/, {
+      timeout: TIMEOUTS.REALTIME_EVENT
+    });
+    await page.locator('input[autocomplete="username"]').fill(remoteUser.login);
+    await page.locator('input[autocomplete="current-password"]').fill(remoteUser.password);
+    await page.getByRole('button', { name: /Sign In/i }).click();
+    await expect(page).toHaveURL(/127\.0\.0\.1.*\/oauth\/consent/, {
+      timeout: TIMEOUTS.REALTIME_EVENT
+    });
+    await page.getByRole('button', { name: 'Allow Access' }).click();
+
+    await expect(page).toHaveURL(/localhost.*\/chat\/127\.0\.0\.1(\/|$)/, {
+      timeout: TIMEOUTS.COMPLEX_OPERATION
+    });
+    await expect(
+      page.locator(`[data-testid="server-icon"][href*="127.0.0.1"]`).first()
+    ).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+
+    // Exercise the current room directory and join flow against the released server.
+    const generalRoom = page.getByRole('listitem').filter({ hasText: '# general' });
+    await generalRoom.getByRole('button', { name: 'Join' }).click();
+    await expect(chatPage.roomList.getByRole('link', { name: '# general' })).toBeVisible({
+      timeout: TIMEOUTS.REALTIME_EVENT
+    });
+
+    // Exercise authenticated timeline/message APIs through the current UI.
+    await chatPage.enterRoom('general');
+    const sentMessage = `Compatibility UI message ${Date.now()}`;
+    await roomPage.sendMessage(sentMessage);
+
+    const remoteRegistration = await page.evaluate(() => {
+      const registrations = JSON.parse(localStorage.getItem('chatto:instances') || '[]') as Array<{
+        url?: string;
+        token?: string;
+      }>;
+      return registrations.find((registration) => registration.url?.includes('127.0.0.1'));
+    });
+    expect(remoteRegistration?.token).toBeTruthy();
+
+    const roomId = await getRoomOnRemote(
+      remoteServer.baseURL,
+      remoteRegistration!.token!,
+      'general'
+    );
+    const receivedMessage = `Compatibility realtime message ${Date.now()}`;
+    await postMessageOnRemote(
+      remoteServer.baseURL,
+      remoteRegistration!.token!,
+      roomId,
+      receivedMessage
+    );
+    await roomPage.expectMessageVisible(receivedMessage);
+
+    // A cold load must retain the remote registration and read persisted history.
+    await page.reload();
+    await expect(page).toHaveURL(/\/chat\/127\.0\.0\.1\//);
+    await roomPage.expectMessageVisible(sentMessage);
+    await roomPage.expectMessageVisible(receivedMessage);
+    await expect(page.getByTitle('Sign out')).toBeVisible();
+  } finally {
+    if (remoteServer) {
+      await stopServer(remoteServer);
+    }
+  }
+});

--- a/apps/frontend/playwright.compat.config.ts
+++ b/apps/frontend/playwright.compat.config.ts
@@ -1,0 +1,21 @@
+/// <reference types="node" />
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'e2e',
+  testMatch: 'remote-compatibility.compat.ts',
+  fullyParallel: false,
+  retries: 1,
+  workers: 1,
+  timeout: 90_000,
+  reporter: [
+    ['list'],
+    ['html', { open: 'never', outputFolder: 'playwright-report-remote-compatibility' }]
+  ],
+  expect: {
+    timeout: 15_000
+  },
+  use: {
+    trace: 'on-first-retry'
+  }
+});

--- a/mise.toml
+++ b/mise.toml
@@ -176,6 +176,19 @@ sources = [
 ]
 outputs = ["../apps/frontend/e2e/fixtures/bin/chatto"]
 
+[tasks.build-compatibility-server]
+description = "Build the production Chatto binary used as the current side of compatibility tests"
+depends = ["setup-cli", "build-frontend"]
+dir = "cli"
+run = "CGO_ENABLED=0 go build -trimpath -ldflags '-s -w' -o ../apps/frontend/e2e/fixtures/bin/chatto-current ."
+sources = [
+    "**/*.go",
+    "cmd/embedded/LICENSE",
+    "cmd/embedded/NOTICE",
+    "internal/http_server/.client/**/*",
+]
+outputs = ["../apps/frontend/e2e/fixtures/bin/chatto-current"]
+
 [tasks.storybook]
 description = "Run the Storybook design-system catalog on the workspace port"
 depends = ["setup-frontend", "build-api-types"]


### PR DESCRIPTION
## Why

Catch breaking changes between the current embedded frontend and supported 0.4.x remote servers before merge.

## What changed

- Added a blocking, single-run Playwright compatibility job that dynamically resolves and checksum-verifies the latest stable v0.4.x release.
- Generalized E2E process startup for executable selection and per-instance NATS/operator-socket isolation, then covered discovery, OAuth, messaging, realtime delivery, and reload persistence.
- Kept CI setup concise with reusable local actions for Playwright and released-binary preparation.

Compatibility impact: no product API, protobuf, storage, or user-visible behavior changes; operationally, CI downloads and caches one released Linux binary and uploads both server logs on failure.

## Test plan

- Dedicated production-binary compatibility scenario: passed against v0.4.10.
- Existing multi-server and server-flow E2E coverage: 24 passed with retries disabled.
- Frontend ESLint, Svelte/TypeScript checks, Prettier, actionlint, YAML parsing, REUSE license check, and `git diff --check`: passed.
