### PR TITLE
fix(frontend): allow app-wide mobile sidebar swipes

### DIFF
--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -93,6 +93,10 @@ generated protobuf clients, Vitest browser tests, Playwright e2e, and Storybook.
 - Prefer native browser scrolling for scrollable regions and galleries; do not
   intercept wheel, touch, or pointer scrolling unless the interaction is
   explicitly custom and approved.
+- App-wide pan gestures must yield to horizontal scrollers, form and media
+  controls, custom drag surfaces, and browser top-layer UI such as dialogs,
+  popovers, and fullscreen elements. Mark custom surfaces with the gesture's
+  explicit opt-out and cover both pointer and touch paths in tests.
 - Do not double-nest `Panel`.
 - `PaneHeader` actions are icon affordances. Put primary actions such as Save,
   Cancel, and Create in the page body or form area.

--- a/apps/frontend/e2e/mobile-nav.test.ts
+++ b/apps/frontend/e2e/mobile-nav.test.ts
@@ -117,7 +117,7 @@ test.describe('Mobile Navigation', () => {
     await expect(roomList).not.toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
   });
 
-  test('sidebar opens on a rightward mobile edge swipe', async ({ page, chatPage }) => {
+  test('sidebar opens on a rightward mobile swipe from app content', async ({ page, chatPage }) => {
     await createAndLoginTestUser(page);
     await chatPage.goto();
     const roomPage = await chatPage.enterRoom('general');
@@ -130,7 +130,7 @@ test.describe('Mobile Navigation', () => {
     await expect(hamburger).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
     await expect(roomList).not.toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
 
-    await touchDrag(page, 2, 220, 160);
+    await touchDrag(page, 100, 320, 160);
 
     await expect(roomList).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
   });

--- a/apps/frontend/e2e/threading.test.ts
+++ b/apps/frontend/e2e/threading.test.ts
@@ -741,8 +741,12 @@ test.describe('Message Threading', () => {
     // Resize to mobile viewport — thread pane switches to slideover mode
     await page.setViewportSize({ width: 375, height: 667 });
 
-    // Close thread using back button
-    await roomPage.closeThreadWithBackButton();
+    // Click the leftmost part of the back button. This area must remain usable
+    // now that sidebar swipes no longer rely on a fixed edge target.
+    const backButtonBox = await roomPage.threadBackButton.boundingBox();
+    expect(backButtonBox).not.toBeNull();
+    if (!backButtonBox) return;
+    await roomPage.threadBackButton.click({ position: { x: 2, y: backButtonBox.height / 2 } });
     await roomPage.expectThreadRouteClosed();
 
     // Room view should be visible again

--- a/apps/frontend/src/lib/components/MobileSidebarChrome.svelte
+++ b/apps/frontend/src/lib/components/MobileSidebarChrome.svelte
@@ -1,11 +1,7 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import ServerGutter from '$lib/ServerGutter.svelte';
-  import {
-    SIDEBAR_PANEL_WIDTH_PX,
-    sidebarEdgeSwipe,
-    sidebarSwipe
-  } from '$lib/hooks/useSidebarSwipe.svelte';
+  import { SIDEBAR_PANEL_WIDTH_PX } from '$lib/hooks/useSidebarSwipe.svelte';
   import * as m from '$lib/i18n/messages';
   import { sidebarNav } from '$lib/state/globals.svelte';
 
@@ -18,30 +14,8 @@
 </script>
 
 {#if sidebarNav.isMobile}
-  <!--
-		Edge gesture zone (swipe-to-open). `touch-action: none` is essential:
-		without it, Chrome / iOS Safari fire pointercancel ~8px into a
-		horizontal drag (text-selection / back-navigation gesture detection).
-		Hidden when sidebar is open (the backdrop takes over). Plain taps are
-		intentionally swallowed here; this target exists only to start swipes.
-	-->
-  {#if !sidebarNav.isOpen || dragging}
-    <div
-      use:sidebarEdgeSwipe
-      data-app-sidebar="true"
-      data-testid="mobile-sidebar-edge"
-      class="fixed top-11 bottom-0 left-0 z-40 w-6 touch-none md:hidden"
-      aria-hidden="true"
-      onpointerdown={(event) => event.stopPropagation()}
-      onpointerup={(event) => event.stopPropagation()}
-      onclick={(event) => event.stopPropagation()}
-      oncontextmenu={(event) => event.stopPropagation()}
-    ></div>
-  {/if}
-
   <button
     type="button"
-    use:sidebarSwipe
     data-app-sidebar="true"
     data-testid="mobile-sidebar-backdrop"
     class={[
@@ -60,7 +34,6 @@
 
 <div class="flex min-h-0 flex-1 flex-row">
   <div
-    use:sidebarSwipe
     data-app-sidebar="true"
     data-testid="mobile-sidebar-panel"
     class={[

--- a/apps/frontend/src/lib/components/MobileSidebarChrome.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/MobileSidebarChrome.svelte.spec.ts
@@ -19,16 +19,6 @@ function renderChrome() {
   });
 }
 
-function pointer(type: string, x: number, y = 120) {
-  return new PointerEvent(type, {
-    bubbles: true,
-    cancelable: true,
-    pointerId: 1,
-    clientX: x,
-    clientY: y
-  });
-}
-
 describe('MobileSidebarChrome', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -40,6 +30,7 @@ describe('MobileSidebarChrome', () => {
 
     expect(q(container, '[data-testid="mobile-sidebar-panel"]')).not.toBeNull();
     expect(q(container, '[data-testid="sidebar-child"]')).not.toBeNull();
+    expect(q(container, '[data-testid="mobile-sidebar-edge"]')).toBeNull();
   });
 
   it('marks mobile sidebar chrome as closed when the sidebar is closed', () => {
@@ -89,23 +80,5 @@ describe('MobileSidebarChrome', () => {
     expect(panel.style.transform).toBe('translateX(-324px)');
     expect(backdrop.disabled).toBe(true);
     expect(backdrop.style.opacity).toBe('0');
-  });
-
-  it('keeps edge target pointer events from bubbling to window handlers', () => {
-    const { container } = renderChrome();
-    const onWindowPointerDown = vi.fn();
-    window.addEventListener('pointerdown', onWindowPointerDown);
-
-    try {
-      const edge = q(container, '[data-testid="mobile-sidebar-edge"]');
-      expect(edge).not.toBeNull();
-      if (!edge) return;
-
-      edge.dispatchEvent(pointer('pointerdown', 2));
-
-      expect(onWindowPointerDown).not.toHaveBeenCalled();
-    } finally {
-      window.removeEventListener('pointerdown', onWindowPointerDown);
-    }
   });
 });

--- a/apps/frontend/src/lib/components/ServerSidebar.svelte
+++ b/apps/frontend/src/lib/components/ServerSidebar.svelte
@@ -11,7 +11,7 @@ See the "UI" section of `docs/GLOSSARY.md`.
 -->
 <script lang="ts">
   import type { Snippet } from 'svelte';
-  import { SIDEBAR_PANEL_WIDTH_PX, sidebarSwipe } from '$lib/hooks/useSidebarSwipe.svelte';
+  import { SIDEBAR_PANEL_WIDTH_PX } from '$lib/hooks/useSidebarSwipe.svelte';
   import { sidebarNav } from '$lib/state/globals.svelte';
   import { serverSidebarWidth } from '$lib/state/serverSidebarWidth.svelte';
   import {
@@ -45,7 +45,6 @@ See the "UI" section of `docs/GLOSSARY.md`.
 </script>
 
 <div
-  use:sidebarSwipe
   data-app-sidebar="true"
   data-testid="server-sidebar"
   class={[

--- a/apps/frontend/src/lib/hooks/panGesture.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/panGesture.svelte.spec.ts
@@ -81,7 +81,7 @@ describe('panGesture', () => {
     window.dispatchEvent(pointer('pointermove', 120));
     window.dispatchEvent(pointer('pointerup', 120));
 
-    expect(enabled).toHaveBeenCalledWith(child);
+    expect(enabled).toHaveBeenCalledWith(expect.objectContaining({ target: child }));
     expect(onStart).not.toHaveBeenCalled();
 
     action.destroy();

--- a/apps/frontend/src/lib/hooks/panGesture.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/panGesture.svelte.spec.ts
@@ -65,6 +65,28 @@ describe('panGesture', () => {
     action.destroy();
   });
 
+  it('passes the originating element to the start gate', () => {
+    const host = hostElement();
+    const child = document.createElement('button');
+    host.append(child);
+    const enabled = vi.fn(() => false);
+    const onStart = vi.fn();
+    const action = panGesture(host, {
+      axis: 'x',
+      enabled,
+      onStart
+    });
+
+    child.dispatchEvent(pointer('pointerdown', 20));
+    window.dispatchEvent(pointer('pointermove', 120));
+    window.dispatchEvent(pointer('pointerup', 120));
+
+    expect(enabled).toHaveBeenCalledWith(child);
+    expect(onStart).not.toHaveBeenCalled();
+
+    action.destroy();
+  });
+
   it('tracks touch drags and prevents default after claiming', () => {
     const host = hostElement();
     const onStart = vi.fn();

--- a/apps/frontend/src/lib/hooks/panGesture.svelte.ts
+++ b/apps/frontend/src/lib/hooks/panGesture.svelte.ts
@@ -33,9 +33,9 @@ const LONG_PRESS_CANCEL_PX = 4;
 export type PanGestureConfig = {
   /** The axis the gesture tracks. The other axis is treated as perpendicular. */
   axis: 'x' | 'y';
-  /** Optional gate evaluated on every `pointerdown`; if it returns false, the
-   *  press is ignored entirely. */
-  enabled?: () => boolean;
+  /** Optional gate evaluated when a pointer or touch starts. Receives the
+   *  originating event target; if it returns false, the press is ignored. */
+  enabled?: (target: EventTarget | null) => boolean;
   /** Final claim predicate, called once the direction lock has fired. Receives
    *  the primary-axis delta (signed). Return false to abandon the gesture. */
   shouldClaim?: (delta: number) => boolean;
@@ -177,7 +177,7 @@ export function panGesture(node: HTMLElement, config: PanGestureConfig) {
   function onDown(e: PointerEvent) {
     if (e.pointerType === 'touch') return;
     if (pointerId !== null || touchId !== null) return;
-    if (cfg.enabled && !cfg.enabled()) return;
+    if (cfg.enabled && !cfg.enabled(e.target)) return;
     pointerId = e.pointerId;
     begin(e.clientX, e.clientY, e.timeStamp);
     window.addEventListener('pointermove', onMove, true);
@@ -212,7 +212,7 @@ export function panGesture(node: HTMLElement, config: PanGestureConfig) {
 
   function onTouchStart(e: TouchEvent) {
     if (pointerId !== null || touchId !== null) return;
-    if (cfg.enabled && !cfg.enabled()) return;
+    if (cfg.enabled && !cfg.enabled(e.target)) return;
     const touch = e.changedTouches.item(0);
     if (!touch) return;
     touchId = touch.identifier;

--- a/apps/frontend/src/lib/hooks/panGesture.svelte.ts
+++ b/apps/frontend/src/lib/hooks/panGesture.svelte.ts
@@ -34,8 +34,9 @@ export type PanGestureConfig = {
   /** The axis the gesture tracks. The other axis is treated as perpendicular. */
   axis: 'x' | 'y';
   /** Optional gate evaluated when a pointer or touch starts. Receives the
-   *  originating event target; if it returns false, the press is ignored. */
-  enabled?: (target: EventTarget | null) => boolean;
+   *  originating event so callers can inspect its composed path; if it returns
+   *  false, the press is ignored. */
+  enabled?: (event: PointerEvent | TouchEvent) => boolean;
   /** Final claim predicate, called once the direction lock has fired. Receives
    *  the primary-axis delta (signed). Return false to abandon the gesture. */
   shouldClaim?: (delta: number) => boolean;
@@ -177,7 +178,7 @@ export function panGesture(node: HTMLElement, config: PanGestureConfig) {
   function onDown(e: PointerEvent) {
     if (e.pointerType === 'touch') return;
     if (pointerId !== null || touchId !== null) return;
-    if (cfg.enabled && !cfg.enabled(e.target)) return;
+    if (cfg.enabled && !cfg.enabled(e)) return;
     pointerId = e.pointerId;
     begin(e.clientX, e.clientY, e.timeStamp);
     window.addEventListener('pointermove', onMove, true);
@@ -212,7 +213,7 @@ export function panGesture(node: HTMLElement, config: PanGestureConfig) {
 
   function onTouchStart(e: TouchEvent) {
     if (pointerId !== null || touchId !== null) return;
-    if (cfg.enabled && !cfg.enabled(e.target)) return;
+    if (cfg.enabled && !cfg.enabled(e)) return;
     const touch = e.changedTouches.item(0);
     if (!touch) return;
     touchId = touch.identifier;

--- a/apps/frontend/src/lib/hooks/useSidebarSwipe.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/useSidebarSwipe.svelte.spec.ts
@@ -176,6 +176,26 @@ describe('sidebarSwipe', () => {
     action.destroy();
   });
 
+  it('ignores gestures inside modal dialog fallbacks that are not in the top layer', () => {
+    const { host } = makeGestureHost();
+    const modal = document.createElement('div');
+    const control = document.createElement('button');
+    modal.setAttribute('role', 'dialog');
+    modal.setAttribute('aria-modal', 'true');
+    modal.append(control);
+    host.append(modal);
+    const action = sidebarSwipe(host);
+
+    control.dispatchEvent(pointer('pointerdown', 100));
+    window.dispatchEvent(pointer('pointermove', 310));
+    window.dispatchEvent(pointer('pointerup', 310));
+
+    expect(sidebarNav.isOpen).toBe(false);
+    expect(sidebarNav.dragOffset).toBeNull();
+
+    action.destroy();
+  });
+
   it('ignores gestures that start inside the fullscreen top layer', () => {
     const { host } = makeGestureHost();
     const fullscreenSurface = document.createElement('div');

--- a/apps/frontend/src/lib/hooks/useSidebarSwipe.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/useSidebarSwipe.svelte.spec.ts
@@ -24,6 +24,7 @@ function pointer(type: string, x: number, y = 24) {
   return new PointerEvent(type, {
     bubbles: true,
     cancelable: true,
+    composed: true,
     pointerId: 1,
     clientX: x,
     clientY: y
@@ -31,7 +32,11 @@ function pointer(type: string, x: number, y = 24) {
 }
 
 function touch(type: string, x: number, y = 24) {
-  const event = new Event(type, { bubbles: true, cancelable: true }) as TouchEvent;
+  const event = new Event(type, {
+    bubbles: true,
+    cancelable: true,
+    composed: true
+  }) as TouchEvent;
   const item = { identifier: 1, clientX: x, clientY: y };
   const currentTouches = type === 'touchend' || type === 'touchcancel' ? [] : [item];
   const touchList = (items: typeof currentTouches) =>
@@ -95,6 +100,69 @@ describe('sidebarSwipe', () => {
     const action = sidebarSwipe(host);
 
     child.dispatchEvent(pointer('pointerdown', 100));
+    window.dispatchEvent(pointer('pointermove', 310));
+    window.dispatchEvent(pointer('pointerup', 310));
+
+    expect(sidebarNav.isOpen).toBe(false);
+    expect(sidebarNav.dragOffset).toBeNull();
+
+    action.destroy();
+  });
+
+  it('ignores rightward pointer drags that start on native form controls', () => {
+    const { host } = makeGestureHost();
+    const range = document.createElement('input');
+    range.type = 'range';
+    host.append(range);
+    const action = sidebarSwipe(host);
+
+    range.dispatchEvent(pointer('pointerdown', 100));
+    window.dispatchEvent(pointer('pointermove', 310));
+    window.dispatchEvent(pointer('pointerup', 310));
+
+    expect(sidebarNav.isOpen).toBe(false);
+    expect(sidebarNav.dragOffset).toBeNull();
+
+    action.destroy();
+  });
+
+  it('ignores leftward touch drags inside shadow-DOM media controls', () => {
+    const { host } = makeGestureHost();
+    const mediaPlayer = document.createElement('media-player');
+    const control = document.createElement('button');
+    mediaPlayer.attachShadow({ mode: 'open' }).append(control);
+    host.append(mediaPlayer);
+    sidebarNav.isOpen = true;
+    const action = sidebarSwipe(host);
+
+    control.dispatchEvent(touch('touchstart', 320));
+    const move = touch('touchmove', 0);
+    window.dispatchEvent(move);
+    window.dispatchEvent(touch('touchend', 0));
+
+    expect(move.defaultPrevented).toBe(false);
+    expect(sidebarNav.isOpen).toBe(true);
+    expect(sidebarNav.dragOffset).toBeNull();
+
+    action.destroy();
+  });
+
+  it('ignores gestures that start inside dialogs and popovers', () => {
+    const { host } = makeGestureHost();
+    const dialog = document.createElement('dialog');
+    const dialogControl = document.createElement('button');
+    dialog.append(dialogControl);
+    const popover = document.createElement('div');
+    const popoverControl = document.createElement('button');
+    popover.setAttribute('popover', 'auto');
+    popover.append(popoverControl);
+    host.append(dialog, popover);
+    const action = sidebarSwipe(host);
+
+    dialogControl.dispatchEvent(pointer('pointerdown', 100));
+    window.dispatchEvent(pointer('pointermove', 310));
+    window.dispatchEvent(pointer('pointerup', 310));
+    popoverControl.dispatchEvent(pointer('pointerdown', 100));
     window.dispatchEvent(pointer('pointermove', 310));
     window.dispatchEvent(pointer('pointerup', 310));
 

--- a/apps/frontend/src/lib/hooks/useSidebarSwipe.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/useSidebarSwipe.svelte.spec.ts
@@ -56,6 +56,10 @@ describe('sidebarSwipe', () => {
   });
 
   afterEach(() => {
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      value: null
+    });
     document.body.replaceChildren();
   });
 
@@ -163,6 +167,28 @@ describe('sidebarSwipe', () => {
     window.dispatchEvent(pointer('pointermove', 310));
     window.dispatchEvent(pointer('pointerup', 310));
     popoverControl.dispatchEvent(pointer('pointerdown', 100));
+    window.dispatchEvent(pointer('pointermove', 310));
+    window.dispatchEvent(pointer('pointerup', 310));
+
+    expect(sidebarNav.isOpen).toBe(false);
+    expect(sidebarNav.dragOffset).toBeNull();
+
+    action.destroy();
+  });
+
+  it('ignores gestures that start inside the fullscreen top layer', () => {
+    const { host } = makeGestureHost();
+    const fullscreenSurface = document.createElement('div');
+    const control = document.createElement('button');
+    fullscreenSurface.append(control);
+    host.append(fullscreenSurface);
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      value: fullscreenSurface
+    });
+    const action = sidebarSwipe(host);
+
+    control.dispatchEvent(pointer('pointerdown', 100));
     window.dispatchEvent(pointer('pointermove', 310));
     window.dispatchEvent(pointer('pointerup', 310));
 

--- a/apps/frontend/src/lib/hooks/useSidebarSwipe.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/useSidebarSwipe.svelte.spec.ts
@@ -1,8 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { sidebarEdgeSwipe, sidebarSwipe } from './useSidebarSwipe.svelte';
+import { sidebarSwipe } from './useSidebarSwipe.svelte';
 import { sidebarNav } from '$lib/state/globals.svelte';
-
-const originalElementsFromPoint = document.elementsFromPoint;
 
 function resetSidebar() {
   sidebarNav.setMobile(false);
@@ -10,20 +8,16 @@ function resetSidebar() {
   sidebarNav.setMobile(true);
 }
 
-function makeEdgeGestureHost() {
-  const edge = document.createElement('div');
-  const underlying = document.createElement('button');
+function makeGestureHost() {
+  const host = document.createElement('main');
+  const child = document.createElement('button');
 
-  edge.setPointerCapture = vi.fn();
-  edge.releasePointerCapture = vi.fn();
-  document.body.append(underlying, edge);
+  host.setPointerCapture = vi.fn();
+  host.releasePointerCapture = vi.fn();
+  host.append(child);
+  document.body.append(host);
 
-  Object.defineProperty(document, 'elementsFromPoint', {
-    configurable: true,
-    value: vi.fn(() => [edge, underlying])
-  });
-
-  return { edge, underlying };
+  return { host, child };
 }
 
 function pointer(type: string, x: number, y = 24) {
@@ -51,70 +45,71 @@ function touch(type: string, x: number, y = 24) {
   return event;
 }
 
-describe('sidebarEdgeSwipe', () => {
+describe('sidebarSwipe', () => {
   beforeEach(() => {
     resetSidebar();
   });
 
   afterEach(() => {
-    Object.defineProperty(document, 'elementsFromPoint', {
-      configurable: true,
-      value: originalElementsFromPoint
-    });
     document.body.replaceChildren();
   });
 
-  it('does not synthesize taps into the content behind the edge target', () => {
-    const { edge, underlying } = makeEdgeGestureHost();
-    const onUnderlyingPointerDown = vi.fn();
-    const onUnderlyingClick = vi.fn();
-    underlying.addEventListener('pointerdown', onUnderlyingPointerDown);
-    underlying.addEventListener('click', onUnderlyingClick);
+  it('leaves taps on child controls to normal browser event flow', () => {
+    const { host, child } = makeGestureHost();
+    const onClick = vi.fn();
+    child.addEventListener('click', onClick);
+    const action = sidebarSwipe(host);
 
-    const action = sidebarEdgeSwipe(edge);
-    edge.dispatchEvent(pointer('pointerdown', 2));
-    edge.dispatchEvent(pointer('pointerup', 2));
+    child.dispatchEvent(pointer('pointerdown', 4));
+    window.dispatchEvent(pointer('pointerup', 4));
+    child.click();
 
-    expect(onUnderlyingPointerDown).not.toHaveBeenCalled();
-    expect(onUnderlyingClick).not.toHaveBeenCalled();
+    expect(onClick).toHaveBeenCalledOnce();
     expect(sidebarNav.isOpen).toBe(false);
 
     action.destroy();
   });
 
-  it('still opens the mobile sidebar on a rightward edge drag', () => {
-    const { edge } = makeEdgeGestureHost();
-    const action = sidebarEdgeSwipe(edge);
+  it('opens the mobile sidebar from a rightward drag on app content', () => {
+    const { host, child } = makeGestureHost();
+    const action = sidebarSwipe(host);
 
-    edge.dispatchEvent(pointer('pointerdown', 2));
-    window.dispatchEvent(pointer('pointermove', 210));
-    window.dispatchEvent(pointer('pointerup', 210));
+    child.dispatchEvent(pointer('pointerdown', 100));
+    window.dispatchEvent(pointer('pointermove', 310));
+    window.dispatchEvent(pointer('pointerup', 310));
 
     expect(sidebarNav.isOpen).toBe(true);
 
     action.destroy();
   });
 
-  it('still closes the mobile sidebar on a leftward drag', () => {
-    const { edge } = makeEdgeGestureHost();
-    sidebarNav.isOpen = true;
-    const action = sidebarSwipe(edge);
+  it('ignores drags that start inside horizontally scrollable content', () => {
+    const { host } = makeGestureHost();
+    const scroller = document.createElement('div');
+    const child = document.createElement('button');
+    scroller.style.overflowX = 'auto';
+    Object.defineProperty(scroller, 'clientWidth', { value: 100 });
+    Object.defineProperty(scroller, 'scrollWidth', { value: 300 });
+    scroller.append(child);
+    host.append(scroller);
+    const action = sidebarSwipe(host);
 
-    edge.dispatchEvent(pointer('pointerdown', 320));
-    window.dispatchEvent(pointer('pointermove', 0));
-    window.dispatchEvent(pointer('pointerup', 0));
+    child.dispatchEvent(pointer('pointerdown', 100));
+    window.dispatchEvent(pointer('pointermove', 310));
+    window.dispatchEvent(pointer('pointerup', 310));
 
     expect(sidebarNav.isOpen).toBe(false);
+    expect(sidebarNav.dragOffset).toBeNull();
 
     action.destroy();
   });
 
   it('closes the mobile sidebar on a leftward touch drag', () => {
-    const { edge } = makeEdgeGestureHost();
+    const { host, child } = makeGestureHost();
     sidebarNav.isOpen = true;
-    const action = sidebarSwipe(edge);
+    const action = sidebarSwipe(host);
 
-    edge.dispatchEvent(touch('touchstart', 320));
+    child.dispatchEvent(touch('touchstart', 320));
     const move = touch('touchmove', 0);
     window.dispatchEvent(move);
     window.dispatchEvent(touch('touchend', 0));

--- a/apps/frontend/src/lib/hooks/useSidebarSwipe.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useSidebarSwipe.svelte.ts
@@ -3,82 +3,43 @@ import { panGesture } from './panGesture.svelte';
 
 /**
  * Svelte action: drives the mobile sidebar's open/close state from a
- * horizontal pointer drag on the host element.
+ * horizontal pointer drag anywhere inside the app-shell host.
  *
  * Ignored on desktop (gated by `sidebarNav.isMobile`). When closed, only
- * rightward drags claim; when open, only leftward drags claim. Taps and
- * long-presses are forwarded to the element directly underneath the host so
- * dedicated overlay zones still let underlying content receive clicks and
- * context menus. Use {@link sidebarEdgeSwipe} for the screen-edge open target:
- * edge taps are too ambiguous and must not synthesize clicks into overlays.
- *
- * The host MUST have `touch-action: none` along the X axis — without it,
- * Chrome / iOS Safari fire `pointercancel` ~8px in when they decide a touch
- * is a back-navigation / text-selection drag.
+ * rightward drags claim; when open, only leftward drags claim. Gestures that
+ * begin inside horizontally scrollable content are ignored so galleries and
+ * wide tables retain their native scrolling. Unclaimed taps, long presses,
+ * and vertical movement continue through normal browser event flow.
  */
-function createSidebarSwipe(node: HTMLElement, passthrough: boolean) {
-  function elementBelow(x: number, y: number) {
-    return document.elementsFromPoint(x, y).find((el) => el !== node && !node.contains(el));
+function startsInsideHorizontalScroller(target: EventTarget | null, host: HTMLElement): boolean {
+  let element = target instanceof Element ? target : null;
+
+  while (element && element !== host) {
+    if (element instanceof HTMLElement) {
+      const { overflowX } = getComputedStyle(element);
+      if (
+        (overflowX === 'auto' || overflowX === 'scroll') &&
+        element.scrollWidth > element.clientWidth
+      ) {
+        return true;
+      }
+    }
+    element = element.parentElement;
   }
 
-  function tappedChild(x: number, y: number) {
-    const target = document.elementFromPoint(x, y);
-    return target !== null && target !== node && node.contains(target);
-  }
+  return false;
+}
 
-  function forwardLongPress(x: number, y: number) {
-    if (tappedChild(x, y)) return;
-
-    elementBelow(x, y)?.dispatchEvent(
-      new MouseEvent('contextmenu', {
-        bubbles: true,
-        cancelable: true,
-        clientX: x,
-        clientY: y,
-        button: 2
-      })
-    );
-  }
-
-  function forwardTap(x: number, y: number) {
-    if (tappedChild(x, y)) return;
-
-    const target = elementBelow(x, y);
-    if (!target) return;
-    const opts: MouseEventInit = {
-      bubbles: true,
-      cancelable: true,
-      composed: true,
-      clientX: x,
-      clientY: y,
-      button: 0
-    };
-    target.dispatchEvent(new PointerEvent('pointerdown', opts));
-    target.dispatchEvent(new MouseEvent('mousedown', opts));
-    target.dispatchEvent(new PointerEvent('pointerup', opts));
-    target.dispatchEvent(new MouseEvent('mouseup', opts));
-    target.dispatchEvent(new MouseEvent('click', opts));
-  }
-
+export function sidebarSwipe(node: HTMLElement) {
   return panGesture(node, {
     axis: 'x',
-    enabled: () => sidebarNav.isMobile,
+    enabled: (target) => sidebarNav.isMobile && !startsInsideHorizontalScroller(target, node),
     shouldClaim: (dx) => (sidebarNav.isOpen ? dx < 0 : dx > 0),
     onStart: () => sidebarNav.startDrag(),
     onUpdate: (dx) => sidebarNav.updateDrag(dx),
     onEnd: (_dx, vx) => sidebarNav.endDrag(vx),
-    onCancel: () => sidebarNav.endDrag(0),
-    onTap: passthrough ? forwardTap : undefined,
-    onLongPress: passthrough ? forwardLongPress : undefined
+    onCancel: () => sidebarNav.endDrag(0)
   });
-}
-
-export function sidebarSwipe(node: HTMLElement) {
-  return createSidebarSwipe(node, true);
-}
-
-export function sidebarEdgeSwipe(node: HTMLElement) {
-  return createSidebarSwipe(node, false);
 }
 
 export { SIDEBAR_PANEL_WIDTH_PX };

--- a/apps/frontend/src/lib/hooks/useSidebarSwipe.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useSidebarSwipe.svelte.ts
@@ -25,7 +25,7 @@ function startsInsideExcludedSurface(event: PointerEvent | TouchEvent, host: HTM
       element instanceof HTMLDialogElement ||
       element.hasAttribute('popover') ||
       element.matches(
-        'input, textarea, select, [contenteditable]:not([contenteditable="false"]), audio, video, media-player, [data-sidebar-swipe-ignore]'
+        'input, textarea, select, [contenteditable]:not([contenteditable="false"]), audio, video, media-player, [role="dialog"][aria-modal="true"], [data-sidebar-swipe-ignore]'
       )
     ) {
       return true;

--- a/apps/frontend/src/lib/hooks/useSidebarSwipe.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useSidebarSwipe.svelte.ts
@@ -8,14 +8,16 @@ import { panGesture } from './panGesture.svelte';
  * Ignored on desktop (gated by `sidebarNav.isMobile`). When closed, only
  * rightward drags claim; when open, only leftward drags claim. Gestures that
  * begin inside horizontally scrollable content are ignored so galleries and
- * wide tables retain their native scrolling. Dialogs, popovers, form fields,
- * media controls, and elements marked with `data-sidebar-swipe-ignore` also
- * retain their own gestures. Unclaimed taps, long presses, and vertical
- * movement continue through normal browser event flow.
+ * wide tables retain their native scrolling. Dialogs, popovers, fullscreen
+ * surfaces, form fields, media controls, and elements marked with
+ * `data-sidebar-swipe-ignore` also retain their own gestures. Unclaimed taps,
+ * long presses, and vertical movement continue through normal browser event
+ * flow.
  */
 function startsInsideExcludedSurface(event: PointerEvent | TouchEvent, host: HTMLElement): boolean {
   for (const pathEntry of event.composedPath()) {
     if (pathEntry === host) return false;
+    if (pathEntry === document.fullscreenElement) return true;
     if (!(pathEntry instanceof HTMLElement)) continue;
 
     const element = pathEntry;

--- a/apps/frontend/src/lib/hooks/useSidebarSwipe.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useSidebarSwipe.svelte.ts
@@ -8,23 +8,34 @@ import { panGesture } from './panGesture.svelte';
  * Ignored on desktop (gated by `sidebarNav.isMobile`). When closed, only
  * rightward drags claim; when open, only leftward drags claim. Gestures that
  * begin inside horizontally scrollable content are ignored so galleries and
- * wide tables retain their native scrolling. Unclaimed taps, long presses,
- * and vertical movement continue through normal browser event flow.
+ * wide tables retain their native scrolling. Dialogs, popovers, form fields,
+ * media controls, and elements marked with `data-sidebar-swipe-ignore` also
+ * retain their own gestures. Unclaimed taps, long presses, and vertical
+ * movement continue through normal browser event flow.
  */
-function startsInsideHorizontalScroller(target: EventTarget | null, host: HTMLElement): boolean {
-  let element = target instanceof Element ? target : null;
+function startsInsideExcludedSurface(event: PointerEvent | TouchEvent, host: HTMLElement): boolean {
+  for (const pathEntry of event.composedPath()) {
+    if (pathEntry === host) return false;
+    if (!(pathEntry instanceof HTMLElement)) continue;
 
-  while (element && element !== host) {
-    if (element instanceof HTMLElement) {
-      const { overflowX } = getComputedStyle(element);
-      if (
-        (overflowX === 'auto' || overflowX === 'scroll') &&
-        element.scrollWidth > element.clientWidth
-      ) {
-        return true;
-      }
+    const element = pathEntry;
+    if (
+      element instanceof HTMLDialogElement ||
+      element.hasAttribute('popover') ||
+      element.matches(
+        'input, textarea, select, [contenteditable]:not([contenteditable="false"]), audio, video, media-player, [data-sidebar-swipe-ignore]'
+      )
+    ) {
+      return true;
     }
-    element = element.parentElement;
+
+    const { overflowX } = getComputedStyle(element);
+    if (
+      (overflowX === 'auto' || overflowX === 'scroll') &&
+      element.scrollWidth > element.clientWidth
+    ) {
+      return true;
+    }
   }
 
   return false;
@@ -33,7 +44,7 @@ function startsInsideHorizontalScroller(target: EventTarget | null, host: HTMLEl
 export function sidebarSwipe(node: HTMLElement) {
   return panGesture(node, {
     axis: 'x',
-    enabled: (target) => sidebarNav.isMobile && !startsInsideHorizontalScroller(target, node),
+    enabled: (event) => sidebarNav.isMobile && !startsInsideExcludedSurface(event, node),
     shouldClaim: (dx) => (sidebarNav.isOpen ? dx < 0 : dx > 0),
     onStart: () => sidebarNav.startDrag(),
     onUpdate: (dx) => sidebarNav.updateDrag(dx),

--- a/apps/frontend/src/lib/ui/Dialog.svelte
+++ b/apps/frontend/src/lib/ui/Dialog.svelte
@@ -28,9 +28,9 @@
   // that began inside (e.g. text selection) from closing on release outside.
   // Defaults to `true` so a click that reaches the dialog without an observed
   // pointerdown is treated as "not a backdrop click" and ignored — only a
-  // real pointerdown on the backdrop arms the close path. Required on mobile,
-  // where the sidebar's tap-forwarding (`useSidebarSwipe`) can synthesize a
-  // stray click that bubbles to the dialog right as it opens.
+  // real pointerdown on the backdrop arms the close path. This also protects
+  // against programmatic or keyboard-synthesized clicks being mistaken for a
+  // backdrop dismissal.
   let pressStartedInside = true;
 
   // Stable per-instance id for the title (so screen readers announce it
@@ -63,9 +63,7 @@
             'input:not([type="hidden"]):not([disabled]),textarea:not([disabled]),select:not([disabled])';
           const active = document.activeElement;
           const alreadyOnField =
-            active instanceof HTMLElement &&
-            node.contains(active) &&
-            active.matches(fieldSelector);
+            active instanceof HTMLElement && node.contains(active) && active.matches(fieldSelector);
           if (alreadyOnField) return;
           const target =
             node.querySelector<HTMLElement>(fieldSelector) ??

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -12,6 +12,7 @@
   import MobileSidebarChrome from '$lib/components/MobileSidebarChrome.svelte';
   import UpdateNotifier from '$lib/components/UpdateNotifier.svelte';
   import { usePageTitle, usePinchZoomPrevention, useVisualViewport } from '$lib/hooks';
+  import { sidebarSwipe } from '$lib/hooks/useSidebarSwipe.svelte';
   import { chatRoomIdFromRoute } from '$lib/navigation/chatRoomRoute';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { sidebarNav } from '$lib/state/globals.svelte';
@@ -85,6 +86,7 @@
 
 {#snippet frame()}
   <div
+    use:sidebarSwipe
     class="flex h-full w-full flex-col overscroll-y-contain bg-surface-100 pt-[env(safe-area-inset-top,0px)] md:p-3 md:pt-0"
   >
     <ConnectionIndicator />

--- a/apps/frontend/src/routes/layout.svelte.spec.ts
+++ b/apps/frontend/src/routes/layout.svelte.spec.ts
@@ -155,24 +155,42 @@ describe('root layout mobile sidebar animation', () => {
     resetSidebar();
   });
 
-  it('keeps edge target presses from bubbling to app-level outside-click handlers', async () => {
+  it('keeps the left edge free for normal app controls', async () => {
     const { container } = renderLayout();
-    const onWindowPointerDown = vi.fn();
-    window.addEventListener('pointerdown', onWindowPointerDown);
+    await tick();
 
-    try {
-      await tick();
+    const child = q(container, '[data-testid="layout-child"]');
+    expect(child).not.toBeNull();
+    if (!child) return;
+    const onClick = vi.fn();
+    child.addEventListener('click', onClick);
 
-      const edge = q(container, '[data-testid="mobile-sidebar-edge"]');
-      expect(edge).not.toBeNull();
-      if (!edge) return;
+    child.dispatchEvent(pointer('pointerdown', 2));
+    window.dispatchEvent(pointer('pointerup', 2));
+    child.click();
 
-      edge.dispatchEvent(pointer('pointerdown', 2));
+    expect(q(container, '[data-testid="mobile-sidebar-edge"]')).toBeNull();
+    expect(onClick).toHaveBeenCalledOnce();
+    expect(sidebarNav.isOpen).toBe(false);
+  });
 
-      expect(onWindowPointerDown).not.toHaveBeenCalled();
-    } finally {
-      window.removeEventListener('pointerdown', onWindowPointerDown);
-    }
+  it('opens the mobile sidebar from a rightward drag in app content', async () => {
+    const { container } = renderLayout();
+    await tick();
+
+    const child = q(container, '[data-testid="layout-child"]');
+    expect(child).not.toBeNull();
+    if (!child) return;
+
+    child.dispatchEvent(pointer('pointerdown', 100));
+    window.dispatchEvent(pointer('pointermove', 310));
+    window.dispatchEvent(pointer('pointerup', 310));
+    await tick();
+
+    expect(sidebarNav.isOpen).toBe(true);
+    expect(q(container, '[data-testid="mobile-sidebar-panel"]')?.style.transform).toBe(
+      'translateX(0px)'
+    );
   });
 
   it('keeps the sidebar and backdrop mounted while the mobile close animation runs', async () => {


### PR DESCRIPTION
## Why

The mobile sidebar used a fixed 24px-wide edge gesture target that swallowed normal taps. Controls near the left edge—most visibly the thread-pane back button—therefore had a smaller effective hit area.

The intended result is to make the full mobile app shell available for sidebar swipes while preserving ordinary interaction with nested controls and browser-managed surfaces.

## What changed

- Removed the dedicated edge target and its synthetic tap/context-menu forwarding.
- Attached one mobile sidebar gesture recognizer to the app shell, preserving the existing direction lock, drag animation, velocity threshold, backdrop, and hamburger behavior.
- Made the recognizer yield to horizontal scrollers, form and media controls, custom opt-out surfaces, shadow-DOM media players, dialogs, popovers, fullscreen elements, and ARIA modal fallbacks.
- Extended the shared pan primitive's start gate with the original event so gesture owners can inspect the composed path.
- Added component and browser regressions for app-content swipes, native control preservation, modal/top-layer exclusions, and the full left edge of the thread back button.
- Documented the nested-control and top-layer requirements for future app-wide gestures.

This is an internal frontend interaction change. It does not alter public APIs, persisted data, compatibility behavior, deployment, security, or operational behavior.

## Test plan

- `mise x -- pnpm --dir apps/frontend run check` — passed with 0 Svelte errors and 0 warnings.
- Targeted Vitest browser/component suite covering pan gestures, sidebar gestures/chrome/layout, and dialogs — 41 tests passed.
- Targeted Playwright mobile sidebar-open and thread back-button scenarios — 2 tests passed.
- Full `e2e/mobile-nav.test.ts` suite — 11 tests passed.
- Targeted ESLint and Svelte autofixer checks for changed frontend files — passed.
- Adversarial branch review loop — no remaining findings.

Closes #1533.
