### PR TITLE
fix(frontend): collapse invisible markdown spacing

### DIFF
--- a/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
@@ -352,6 +352,16 @@ describe('renderMarkdown', () => {
 });
 
 describe('MessageContent component', () => {
+  it('does not render encoded non-breaking spaces as tall message content', async () => {
+    const body = `Magnets, how\n\ndo they work?\n\n- ONCE\n- TWICE\n- THRICE\n\nA haiku by a professional chef,\n\nthis was\n${'&nbsp;\n'.repeat(500)}`;
+    const { container } = renderMessage(body);
+
+    await expect.poll(() => q(container, '.prose p')).toBeTruthy();
+    const content = q(container, '.prose')!;
+    expect(content.textContent).not.toContain('&nbsp;');
+    expect(content.clientHeight).toBeLessThan(500);
+  });
+
   // Wait for the markdown renderer to initialize before running tests
   beforeAll(async () => {
     await rendererReady;

--- a/apps/frontend/src/lib/markdown.test.ts
+++ b/apps/frontend/src/lib/markdown.test.ts
@@ -8,6 +8,45 @@ import {
 } from './codeHighlighting';
 
 describe('renderMarkdown', () => {
+  describe('invisible spacing', () => {
+    it('collapses lines made from encoded non-breaking spaces', async () => {
+      const html = await renderMarkdown(`before\n${'&nbsp;\n'.repeat(500)}after`);
+
+      expect(html).toContain('before');
+      expect(html).toContain('after');
+      expect(html).not.toContain('&nbsp;');
+      expect(html.match(/<br>/g)).toHaveLength(1);
+    });
+
+    it('preserves word separation when normalizing non-breaking spaces', async () => {
+      const html = await renderMarkdown('bread&nbsp;and&#160;butter');
+
+      expect(html).toContain('<p>bread and butter</p>');
+    });
+
+    it('removes paragraphs made only from encoded non-breaking spaces', async () => {
+      const html = await renderMarkdown(`before\n\n${'&nbsp;\n\n'.repeat(500)}after`);
+
+      expect(html.match(/<p>/g)).toHaveLength(2);
+      expect(html).toContain('<p>before</p>');
+      expect(html).toContain('<p>after</p>');
+    });
+
+    it('preserves non-breaking-space entity source in code', async () => {
+      const html = await renderMarkdown('`&nbsp;`\n\n```text\n&nbsp;\n```');
+
+      expect(html).toContain('<code>&amp;nbsp;</code>');
+      expect(html).toContain('<span class="line">&amp;nbsp;</span>');
+    });
+
+    it('preserves entity spellings Markdown-it does not decode', async () => {
+      const html = await renderMarkdown('&NBSP;\n&#00000160;');
+
+      expect(html).toContain('&amp;NBSP;');
+      expect(html).toContain('&amp;#00000160;');
+    });
+  });
+
   describe('literal backslashes', () => {
     it('preserves the backslash in the shrug kaomoji', async () => {
       const html = await renderMarkdown('¯\\_(ツ)_/¯');

--- a/apps/frontend/src/lib/markdown.ts
+++ b/apps/frontend/src/lib/markdown.ts
@@ -1,5 +1,7 @@
 import MarkdownIt from 'markdown-it';
 import type StateInline from 'markdown-it/lib/rules_inline/state_inline.mjs';
+import type StateCore from 'markdown-it/lib/rules_core/state_core.mjs';
+import type Token from 'markdown-it/lib/token.mjs';
 import tlds from 'tlds';
 import { classifyMessageBodyChatLink } from '$lib/messageLinks';
 
@@ -245,6 +247,45 @@ function extractFenceLanguages(markdown: string): string[] {
   return [...languages];
 }
 
+function isLineBreakToken(token: Token): boolean {
+  return token.type === 'softbreak' || token.type === 'hardbreak';
+}
+
+function isWhitespaceOnlyInlineSegment(tokens: Token[]): boolean {
+  return tokens.every((token) => {
+    if (token.type === 'text' || token.type === 'text_special') {
+      return token.content.trim().length === 0;
+    }
+    return token.type.endsWith('_open') || token.type.endsWith('_close');
+  });
+}
+
+function lineAfterBreakIsWhitespaceOnly(tokens: Token[], idx: number): boolean {
+  let lineEnd = idx + 1;
+  while (lineEnd < tokens.length && !isLineBreakToken(tokens[lineEnd])) lineEnd++;
+  return isWhitespaceOnlyInlineSegment(tokens.slice(idx + 1, lineEnd));
+}
+
+function renderChatLineBreak(tokens: Token[], idx: number): string {
+  return lineAfterBreakIsWhitespaceOnly(tokens, idx) ? '' : '<br>\n';
+}
+
+function normalizeInlineNonBreakingSpaces(state: StateCore): void {
+  for (let i = 0; i < state.tokens.length; i++) {
+    const token = state.tokens[i];
+    if (token.type !== 'inline') continue;
+    for (const child of token.children ?? []) {
+      if (child.type === 'text' || child.type === 'text_special') {
+        child.content = child.content.replaceAll('\u00A0', ' ');
+      }
+    }
+    if (isWhitespaceOnlyInlineSegment(token.children ?? [])) {
+      if (state.tokens[i - 1]?.type === 'paragraph_open') state.tokens[i - 1].hidden = true;
+      if (state.tokens[i + 1]?.type === 'paragraph_close') state.tokens[i + 1].hidden = true;
+    }
+  }
+}
+
 async function ensureFenceLanguagesLoaded(languages: string[]): Promise<void> {
   if (languages.length === 0) return;
 
@@ -279,6 +320,14 @@ function initialize(): void {
   // as italics. Inserted before the `emphasis` rule so non-boundary marker
   // runs are consumed as literal text.
   md.inline.ruler.before('emphasis', 'word_boundary_emphasis', wordBoundaryEmphasis);
+
+  // CommonMark decodes entities in prose but leaves them literal in code. Turn
+  // decoded NBSPs into collapsible spaces only in ordinary inline text so long
+  // `&nbsp;` runs cannot create giant blank message rows without corrupting
+  // code samples that intentionally contain the entity source.
+  md.core.ruler.after('inline', 'normalize_non_breaking_spaces', normalizeInlineNonBreakingSpaces);
+  md.renderer.rules.softbreak = renderChatLineBreak;
+  md.renderer.rules.hardbreak = renderChatLineBreak;
 
   // Customize link rendering for security
   const defaultLinkRender =

--- a/apps/frontend/src/lib/validation/content.spec.ts
+++ b/apps/frontend/src/lib/validation/content.spec.ts
@@ -105,6 +105,11 @@ describe('hasVisibleContent', () => {
       expect(hasVisibleContent('!!!')).toBe(true);
     });
 
+    test('literal entity-like text', () => {
+      expect(hasVisibleContent('&NBSP;')).toBe(true);
+      expect(hasVisibleContent('&#00000160;')).toBe(true);
+    });
+
     test('text with leading space', () => {
       expect(hasVisibleContent(' hello')).toBe(true);
     });


### PR DESCRIPTION
## Why

Messages containing repeated decoded `&nbsp;` lines could render as enormous blank timeline rows.

## What changed

- Normalize decoded non-breaking spaces in the shared Markdown token pipeline and suppress whitespace-only line breaks and paragraph wrappers.
- Preserve entity source inside code and entity-like text that Markdown-it does not decode.
- Cover the reported payload, numeric entities, empty paragraphs, code, literal entity-like text, and rendered component height.

## Test plan

- `mise test-frontend`
- `mise lint-frontend`
