### PR TITLE
fix(frontend): show pending permission updates

### DIFF
--- a/apps/frontend/src/lib/components/rbac/MatrixCell.svelte
+++ b/apps/frontend/src/lib/components/rbac/MatrixCell.svelte
@@ -93,6 +93,7 @@ to render an inert "—" cell with an explanation tooltip.
     type="button"
     class={[
       'inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-md transition-[scale] active:scale-[0.96]',
+      updating ? 'bg-action/15 ring-2 ring-inset ring-action/40' : '',
       disabled || updating ? 'cursor-not-allowed' : '',
       disabled ? 'opacity-60' : ''
     ]}
@@ -110,7 +111,7 @@ to render an inert "—" cell with an explanation tooltip.
       ]}
     >
       {#if updating}
-        <span class="iconify h-3 w-3 animate-spin uil--spinner" aria-hidden="true"></span>
+        <span class="iconify h-4 w-4 animate-spin uil--spinner" aria-hidden="true"></span>
       {:else}
         <span class={['iconify h-3 w-3', icon]}></span>
       {/if}

--- a/apps/frontend/src/lib/components/rbac/MatrixCell.svelte
+++ b/apps/frontend/src/lib/components/rbac/MatrixCell.svelte
@@ -10,6 +10,9 @@ Click cycles the override through `neutral → allow → deny → neutral`. The
 inherited indicator persists faded behind the override (so you can see what
 the role would do without the override at this scope).
 
+While a change is being saved, the state icon is replaced with a spinner and
+the cell is temporarily non-interactive.
+
 When the permission is not applicable to the role at this scope (e.g. a
 room-only permission queried at instance scope), pass `applicable={false}`
 to render an inert "—" cell with an explanation tooltip.
@@ -44,7 +47,7 @@ to render an inert "—" cell with an explanation tooltip.
   }
 
   function handleClick() {
-    if (disabled || !applicable) return;
+    if (disabled || updating || !applicable) return;
     onCycle(nextState());
   }
 
@@ -90,12 +93,13 @@ to render an inert "—" cell with an explanation tooltip.
     type="button"
     class={[
       'inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-md transition-[scale] active:scale-[0.96]',
-      updating ? 'animate-pulse' : '',
-      disabled ? 'cursor-not-allowed opacity-60' : ''
+      disabled || updating ? 'cursor-not-allowed' : '',
+      disabled ? 'opacity-60' : ''
     ]}
-    {disabled}
+    disabled={disabled || updating}
     {title}
     aria-label={ariaLabel}
+    aria-busy={updating || undefined}
     aria-pressed={isOverride}
     onclick={handleClick}
   >
@@ -105,7 +109,11 @@ to render an inert "—" cell with an explanation tooltip.
         surfaceClasses
       ]}
     >
-      <span class={['iconify h-3 w-3', icon]}></span>
+      {#if updating}
+        <span class="iconify h-3 w-3 animate-spin uil--spinner" aria-hidden="true"></span>
+      {:else}
+        <span class={['iconify h-3 w-3', icon]}></span>
+      {/if}
     </span>
   </button>
 {/if}

--- a/apps/frontend/src/lib/components/rbac/MatrixCell.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/rbac/MatrixCell.svelte.spec.ts
@@ -97,7 +97,8 @@ describe('MatrixCell', () => {
 
     expect(button.disabled).toBe(true);
     expect(button.getAttribute('aria-busy')).toBe('true');
-    expect(button.querySelector('.animate-spin.uil--spinner')).not.toBeNull();
+    expect(button.className).toContain('ring-action/40');
+    expect(button.querySelector('.h-4.w-4.animate-spin.uil--spinner')).not.toBeNull();
     expect(button.querySelector('.uil--minus')).toBeNull();
 
     button.click();

--- a/apps/frontend/src/lib/components/rbac/MatrixCell.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/rbac/MatrixCell.svelte.spec.ts
@@ -90,6 +90,21 @@ describe('MatrixCell', () => {
     expect(onCycle).not.toHaveBeenCalled();
   });
 
+  it('shows a spinner and prevents repeat clicks while updating', async () => {
+    const onCycle = vi.fn();
+    const { container } = renderCell({ updating: true, onCycle });
+    const button = container.querySelector('button') as HTMLButtonElement;
+
+    expect(button.disabled).toBe(true);
+    expect(button.getAttribute('aria-busy')).toBe('true');
+    expect(button.querySelector('.animate-spin.uil--spinner')).not.toBeNull();
+    expect(button.querySelector('.uil--minus')).toBeNull();
+
+    button.click();
+    flushSync();
+    expect(onCycle).not.toHaveBeenCalled();
+  });
+
   it('shows the allow icon when override is allow', async () => {
     const { container } = renderCell({ override: 'allow' });
     expect(container.querySelector('.uil--check')).not.toBeNull();

--- a/apps/frontend/src/lib/components/rbac/PermissionMatrix.svelte
+++ b/apps/frontend/src/lib/components/rbac/PermissionMatrix.svelte
@@ -144,7 +144,7 @@ focusing a cell highlights its permission row and role column.
   let data = $state<TierRoles | null>(null);
   let loading = $state(true);
   let error = $state<string | null>(null);
-  let updating = $state<string | null>(null); // "{roleName}::{permission}" while a mutation is in flight
+  let updating = $state<string[]>([]); // "{roleName}::{permission}" entries with mutations in flight
   let hoveredCell = $state<MatrixCoordinate | null>(null);
   let focusedCell = $state<MatrixCoordinate | null>(null);
   const highlightedCell = $derived(hoveredCell ?? focusedCell);
@@ -286,14 +286,15 @@ focusing a cell highlights its permission row and role column.
   async function cycle(role: TierRole, permission: string, next: State) {
     if (!data) return;
     const cellKey = `${role.roleName}::${permission}`;
-    updating = cellKey;
+    if (updating.includes(cellKey)) return;
+    updating = [...updating, cellKey];
     error = null;
 
     const result = await setRolePermission(permissionAPI(), scopeFor(role), permission, next);
     if (result.error) {
       error = result.error;
       toast.error(result.error);
-      updating = null;
+      updating = updating.filter((key) => key !== cellKey);
       return;
     }
 
@@ -307,7 +308,7 @@ focusing a cell highlights its permission row and role column.
     } else if (next === 'deny') {
       role.override.permissionDenials = [...role.override.permissionDenials, permission];
     }
-    updating = null;
+    updating = updating.filter((key) => key !== cellKey);
   }
 </script>
 
@@ -401,7 +402,7 @@ focusing a cell highlights its permission row and role column.
                 {@const displayOverride = virtualOwner ? 'allow' : ov}
                 {@const displayInherited = virtualOwner ? 'neutral' : inh}
                 {@const cellKey = `${role.roleName}::${permission}`}
-                {@const isUpdating = updating === cellKey}
+                {@const isUpdating = updating.includes(cellKey)}
                 {@const ariaParts = virtualOwner
                   ? [`Owner is always granted ${permission}`]
                   : [

--- a/apps/frontend/src/lib/components/rbac/PermissionMatrix.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/rbac/PermissionMatrix.svelte.spec.ts
@@ -220,6 +220,31 @@ describe('PermissionMatrix', () => {
     expect(modMessagePost?.querySelector('.uil--check')).not.toBeNull();
   });
 
+  it('shows feedback immediately until a permission update completes', async () => {
+    let resolveUpdate: (() => void) | undefined;
+    permissionMocks.setRolePermission.mockImplementation(
+      () => new Promise<void>((resolve) => (resolveUpdate = resolve))
+    );
+    const { container } = render(PermissionMatrix, { props: { spaceId: 'space-1' } });
+    await settle();
+
+    const button = container.querySelector(
+      'button[aria-label*="Moderator"][aria-label*="room.create"]'
+    ) as HTMLButtonElement;
+    button.click();
+    flushSync();
+
+    expect(button.getAttribute('aria-busy')).toBe('true');
+    expect(button.querySelector('.animate-spin.uil--spinner')).not.toBeNull();
+
+    resolveUpdate?.();
+    await settle();
+
+    expect(button.hasAttribute('aria-busy')).toBe(false);
+    expect(button.querySelector('.animate-spin.uil--spinner')).toBeNull();
+    expect(button.querySelector('.uil--minus')).not.toBeNull();
+  });
+
   it('invokes onRoleClick when a column header is clicked', async () => {
     const onRoleClick = vi.fn();
     const { container } = render(PermissionMatrix, {


### PR DESCRIPTION
## Why

Permission matrix changes previously appeared unresponsive while waiting for the server, making checkbox interactions feel laggy.

## What changed

- Replace the clicked cell's state icon with an immediate, action-highlighted spinner, expose its pending state with `aria-busy`, and prevent duplicate clicks until the response arrives.
- Track pending cells independently so concurrent permission updates retain accurate feedback.

## Test plan

- `mise x -- pnpm --dir apps/frontend exec vitest --run src/lib/components/rbac/MatrixCell.svelte.spec.ts src/lib/components/rbac/PermissionMatrix.svelte.spec.ts` — 20 tests passed.
- `mise x -- pnpm --dir apps/frontend run check` — design-system guardrails passed and Svelte reported 0 errors and 0 warnings.
