### PR TITLE
fix(pwa): use server name for installed app

### DIFF
--- a/apps/docs-website/src/content/docs/guides/operations/community-structure.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/community-structure.mdx
@@ -93,7 +93,7 @@ Use these fields deliberately:
 
 | Field | Operator use |
 | ----- | ------------ |
-| Server name | The human name members recognize. |
+| Server name | The human name members recognize, including the installed app name. |
 | Description | Link previews and server metadata. |
 | Welcome message | Login-page context, onboarding notes, terms, or support links. |
 | Message of the day | Short operational or community-wide notice for signed-in members. |

--- a/cli/internal/http_server/frontend.go
+++ b/cli/internal/http_server/frontend.go
@@ -147,6 +147,18 @@ func (s *HTTPServer) currentPWAIconURLs(ctx context.Context) *pwaServerIconURLs 
 	return icons
 }
 
+func (s *HTTPServer) currentPWAServerName(ctx context.Context) string {
+	if s.core == nil || s.core.ConfigManager() == nil {
+		return "Chatto"
+	}
+
+	name, err := s.core.ConfigManager().GetEffectiveServerName(ctx)
+	if err != nil || strings.TrimSpace(name) == "" {
+		return "Chatto"
+	}
+	return name
+}
+
 // sameOriginServerAssetURL keeps browser metadata on the frontend origin. General
 // asset URLs may use a configured asset base, but each Chatto frontend serves
 // its own public server assets and browsers must be able to fetch metadata
@@ -173,25 +185,25 @@ func pwaManifestIcons(icon192, icon512 string) []map[string]string {
 	}
 }
 
-func dynamicPWAManifest(staticManifest []byte, icons *pwaServerIconURLs) ([]byte, error) {
-	if icons == nil {
-		return staticManifest, nil
-	}
-
+func dynamicPWAManifest(staticManifest []byte, serverName string, icons *pwaServerIconURLs) ([]byte, error) {
 	var manifest map[string]any
 	if err := json.Unmarshal(staticManifest, &manifest); err != nil {
 		return nil, err
 	}
 
-	manifest["icons"] = pwaManifestIcons(icons.Icon192, icons.Icon512)
-	if shortcuts, ok := manifest["shortcuts"].([]any); ok {
-		for _, shortcut := range shortcuts {
-			shortcutMap, ok := shortcut.(map[string]any)
-			if !ok {
-				continue
-			}
-			shortcutMap["icons"] = []map[string]string{
-				{"src": icons.Icon192, "sizes": "192x192", "type": "image/png"},
+	manifest["name"] = serverName
+	manifest["short_name"] = serverName
+	if icons != nil {
+		manifest["icons"] = pwaManifestIcons(icons.Icon192, icons.Icon512)
+		if shortcuts, ok := manifest["shortcuts"].([]any); ok {
+			for _, shortcut := range shortcuts {
+				shortcutMap, ok := shortcut.(map[string]any)
+				if !ok {
+					continue
+				}
+				shortcutMap["icons"] = []map[string]string{
+					{"src": icons.Icon192, "sizes": "192x192", "type": "image/png"},
+				}
 			}
 		}
 	}
@@ -252,7 +264,11 @@ func (s *HTTPServer) servePWAWebManifest(c *gin.Context, clientFS fs.FS) {
 		c.Status(http.StatusInternalServerError)
 		return
 	}
-	content, err = dynamicPWAManifest(content, s.currentPWAIconURLs(c.Request.Context()))
+	content, err = dynamicPWAManifest(
+		content,
+		s.currentPWAServerName(c.Request.Context()),
+		s.currentPWAIconURLs(c.Request.Context()),
+	)
 	if err != nil {
 		s.logger.Warn("failed to generate dynamic PWA manifest", "error", err)
 		c.Status(http.StatusInternalServerError)

--- a/cli/internal/http_server/frontend_test.go
+++ b/cli/internal/http_server/frontend_test.go
@@ -192,6 +192,7 @@ func TestServiceWorkerETag(t *testing.T) {
 func TestDynamicPWAManifest(t *testing.T) {
 	staticManifest := []byte(`{
   "name": "Chatto",
+  "short_name": "Chatto",
   "icons": [
     { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
     { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" }
@@ -204,16 +205,23 @@ func TestDynamicPWAManifest(t *testing.T) {
   ]
 }`)
 
-	t.Run("keeps static manifest when no server logo is available", func(t *testing.T) {
-		got, err := dynamicPWAManifest(staticManifest, nil)
+	t.Run("uses server name without requiring a server logo", func(t *testing.T) {
+		got, err := dynamicPWAManifest(staticManifest, "Engineering", nil)
 		if err != nil {
 			t.Fatalf("dynamicPWAManifest: %v", err)
 		}
-		assert.Equal(t, string(staticManifest), string(got))
+
+		var manifest map[string]any
+		if err := json.Unmarshal(got, &manifest); err != nil {
+			t.Fatalf("unmarshal manifest: %v", err)
+		}
+		assert.Equal(t, "Engineering", manifest["name"])
+		assert.Equal(t, "Engineering", manifest["short_name"])
+		assert.Len(t, manifest["icons"], 2)
 	})
 
 	t.Run("replaces install and shortcut icons with server logo URLs", func(t *testing.T) {
-		got, err := dynamicPWAManifest(staticManifest, &pwaServerIconURLs{
+		got, err := dynamicPWAManifest(staticManifest, "Engineering", &pwaServerIconURLs{
 			Icon192: "/assets/server/logo/t/192",
 			Icon512: "/assets/server/logo/t/512",
 		})
@@ -225,6 +233,8 @@ func TestDynamicPWAManifest(t *testing.T) {
 		if err := json.Unmarshal(got, &manifest); err != nil {
 			t.Fatalf("unmarshal manifest: %v", err)
 		}
+		assert.Equal(t, "Engineering", manifest["name"])
+		assert.Equal(t, "Engineering", manifest["short_name"])
 
 		icons := manifest["icons"].([]any)
 		assert.Len(t, icons, 4)
@@ -498,6 +508,7 @@ func TestServePWAWebManifestUsesServerLogoWhenAvailable(t *testing.T) {
 		},
 	}
 	chattoCore := setupFrontendTestCoreWithLogo(t)
+	setTestServerName(t, context.Background(), chattoCore, "Engineering")
 	chattoCore.AssetBaseURL = "https://assets.example.com"
 	server := &HTTPServer{
 		config: config.ChattoConfig{Webserver: config.WebserverConfig{URL: "https://example.com"}},
@@ -519,6 +530,8 @@ func TestServePWAWebManifestUsesServerLogoWhenAvailable(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &manifest); err != nil {
 		t.Fatalf("unmarshal manifest: %v", err)
 	}
+	assert.Equal(t, "Engineering", manifest["name"])
+	assert.Equal(t, "Engineering", manifest["short_name"])
 	icons := manifest["icons"].([]any)
 	assert.True(t, strings.HasPrefix(icons[0].(map[string]any)["src"].(string), "/assets/server/logo-asset/t/"))
 	assert.NotContains(t, icons[0].(map[string]any)["src"], "assets.example.com")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -801,7 +801,7 @@ never probed by this route. Disallowed classes return 404.
 
 ### Dynamic Image Transformation
 
-Chatto supports on-the-fly image transformation for attachments and user avatars, allowing clients to request images at specific dimensions without pre-generating all possible sizes. Public server branding images expose canonical asset URLs instead of accepting arbitrary transform dimensions; the HTTP frontend server uses fixed 32/180/192/512px cover transforms of the current server logo for favicon, Apple touch icon, and web-manifest install metadata. Stable favicon and Apple touch icon routes redirect to the current same-origin transform or the corresponding bundled icon, while all dynamic branding metadata remains network-served so service-worker caches do not pin stale branding.
+Chatto supports on-the-fly image transformation for attachments and user avatars, allowing clients to request images at specific dimensions without pre-generating all possible sizes. Public server branding images expose canonical asset URLs instead of accepting arbitrary transform dimensions; the HTTP frontend server generates the web manifest with the current server name and uses fixed 32/180/192/512px cover transforms of the current server logo for favicon, Apple touch icon, and web-manifest install metadata. Stable favicon and Apple touch icon routes redirect to the current same-origin transform or the corresponding bundled icon, while all dynamic branding metadata remains network-served so service-worker caches do not pin stale branding.
 
 **URL Structure:**
 

--- a/docs/fdr/FDR-020-server-branding-and-configuration.md
+++ b/docs/fdr/FDR-020-server-branding-and-configuration.md
@@ -1,7 +1,7 @@
 # FDR-020: Server Branding & Configuration
 
 **Status:** Active
-**Last reviewed:** 2026-06-06
+**Last reviewed:** 2026-07-14
 
 ## Overview
 
@@ -9,7 +9,7 @@ Operators can customize how their Chatto server presents itself. The server's na
 
 ## Behavior
 
-- **Server name** — appears in page titles, the chat header, and OG metadata. Defaults to "Chatto".
+- **Server name** — appears in page titles, the chat header, installed app metadata, and OG metadata. Defaults to "Chatto".
 - **Description** — used in OG metadata for link previews when sharing the server URL.
 - **Welcome message** — shown on the login page. Markdown is supported.
 - **MOTD (message of the day)** — appears in a banner across the top of the chat surface for all members. Broadcasts to live clients when changed.

--- a/docs/fdr/FDR-027-pwa-shell-and-service-worker.md
+++ b/docs/fdr/FDR-027-pwa-shell-and-service-worker.md
@@ -1,7 +1,7 @@
 # FDR-027: PWA Shell & Service Worker
 
 **Status:** Active
-**Last reviewed:** 2026-07-13
+**Last reviewed:** 2026-07-14
 
 ## Overview
 
@@ -17,7 +17,7 @@ Reconnect catch-up is owned by the foreground web app, not the service worker. W
 - On install, the worker caches the SPA fallback shell and SvelteKit build assets required to boot it.
 - On activate, old Chatto shell caches are deleted and the new worker claims open clients.
 - Known shell assets are served cache-first from the versioned cache; static PWA assets other than the web manifest are cached lazily on first request.
-- The served web manifest, favicon, and Apple touch icon metadata use the uploaded server logo when one exists, falling back to bundled Chatto icons otherwise.
+- The served web manifest uses the server name as the installed app name. Its icons, along with favicon and Apple touch icon metadata, use the uploaded server logo when one exists and fall back to bundled Chatto icons otherwise.
 - Same-origin navigations are network-first, falling back to the cached SPA shell only when the network fails.
 - API, auth, OAuth, webhook, uploaded-asset, dynamic branding metadata, non-GET, and cross-origin requests are network-only.
 - Protected uploaded asset loads use direct signed asset URLs owned by the foreground app. The worker does not receive registered-server API bearer tokens, does not proxy asset requests, and does not cache protected asset bodies.
@@ -52,9 +52,9 @@ Reconnect catch-up is owned by the foreground web app, not the service worker. W
 
 ### 5. Install metadata follows server branding
 
-**Decision:** The HTTP frontend server generates the web manifest from the bundled manifest and swaps in transformed server-logo URLs for install icons when a logo is configured. Stable favicon and Apple touch icon endpoints redirect to purpose-sized transforms of the current server logo, or to the bundled Chatto icons when no logo is configured.
+**Decision:** The HTTP frontend server generates the web manifest from the bundled manifest, uses the current server name for the installed app name, and swaps in transformed server-logo URLs for install icons when a logo is configured. Stable favicon and Apple touch icon endpoints redirect to purpose-sized transforms of the current server logo, or to the bundled Chatto icons when no logo is configured.
 **Why:** Self-hosted servers should install with their own visible identity without requiring a custom frontend build.
-**Tradeoff:** Browsers decide when to refresh installed PWA metadata and may cache browser icons aggressively, so existing installs or tabs may keep the previous icon until the browser revalidates the metadata or the user reinstalls the app.
+**Tradeoff:** Browsers decide when to refresh installed PWA metadata and may cache it aggressively, so existing installs or tabs may keep the previous name or icon until the browser revalidates the metadata or the user reinstalls the app.
 
 ## Related
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -29,13 +29,13 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-017](FDR-017-room-groups-and-sidebar-layout.md) | Room Groups & Sidebar Layout | Active | 2026-06-18 |
 | [FDR-018](FDR-018-account-lifecycle.md) | Account Lifecycle | Active | 2026-07-13 |
 | [FDR-019](FDR-019-room-lifecycle.md) | Room Lifecycle | Active | 2026-07-04 |
-| [FDR-020](FDR-020-server-branding-and-configuration.md) | Server Branding & Configuration | Active | 2026-06-06 |
+| [FDR-020](FDR-020-server-branding-and-configuration.md) | Server Branding & Configuration | Active | 2026-07-14 |
 | [FDR-021](FDR-021-admin-dashboard.md) | Admin Dashboard & System Monitoring | Active | 2026-06-15 |
 | [FDR-022](FDR-022-user-profile.md) | User Profile | Active | 2026-06-23 |
 | [FDR-023](FDR-023-authentication-and-sessions.md) | Authentication & Sessions | Active | 2026-06-19 |
 | [FDR-024](FDR-024-permission-inspection-tool.md) | Permission Inspection Tool | Active | 2026-06-15 |
 | [FDR-025](FDR-025-user-search-and-member-directory.md) | User Search & Member Directory | Active | 2026-05-19 |
 | [FDR-026](FDR-026-last-room-memory.md) | Last-Room Memory | Active | 2026-05-19 |
-| [FDR-027](FDR-027-pwa-shell-and-service-worker.md) | PWA Shell & Service Worker | Active | 2026-07-05 |
+| [FDR-027](FDR-027-pwa-shell-and-service-worker.md) | PWA Shell & Service Worker | Active | 2026-07-14 |
 | [FDR-028](FDR-028-operator-api-and-cli.md) | Operator API & CLI | Active | 2026-06-29 |
 | [FDR-029](FDR-029-chatto-shields.md) | Chatto Shields | Active | 2026-07-12 |


### PR DESCRIPTION
## Why

Installed PWAs were always labelled “Chatto” instead of using the configured server name, which made self-hosted servers lose their identity at the operating-system level.

## What changed

- Generate both manifest app-name fields from the effective server name, independently of custom-logo availability, while retaining “Chatto” as the fallback.
- Cover the dynamic manifest and HTTP response paths with regression tests, and align the architecture inventory, FDRs, and operator guide; existing installs may retain cached metadata until their browser refreshes it or the app is reinstalled.

## Test plan

- `mise x -- go test -tags test_endpoints ./internal/http_server -run 'TestDynamicPWAManifest|TestServePWAWebManifestUsesServerLogoWhenAvailable' -count=1 -timeout 60s` — passes.
- `mise x -- pnpm run build` in `apps/docs-website` — passes; the full HTTP-server package remains blocked by its existing missing embedded `.client/200.html` fixture in `TestFrontendFallbackAllowsRoutesWithReservedPrefixNames`.
