### PR TITLE
fix(frontend): avoid blank line when enabling rich mode

### DIFF
--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -170,6 +170,17 @@ generated protobuf clients, Vitest browser tests, Playwright e2e, and Storybook.
   mocks.
 - Use `expect.element(...)` for DOM assertions and flush after Svelte state
   mutations when needed.
+- For focused component tests, filter to the relevant test instead of initially
+  running the entire spec. Use a plain substring without regular-expression
+  characters such as `+`:
+
+```sh
+mise x -- pnpm --filter chatto-frontend exec vitest --run \
+  src/path/Component.svelte.spec.ts -t 'plain substring'
+```
+
+- If Vite reloads after first-run dependency optimization and then stops making
+  progress, terminate the test and rerun it once with the warmed cache.
 - E2E runs locally without Docker/Tilt/OrbStack; Playwright starts its own
   embedded-NATS Chatto binary.
 - Prefer targeted e2e runs before the full suite:

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -751,7 +751,9 @@
         if (isRichComposer) {
           handleSubmit(); // Fire-and-forget (async, but keydown must return sync)
         } else {
-          editorApi?.insertBlockBreak();
+          if (hasVisibleContent(message)) {
+            editorApi?.insertBlockBreak();
+          }
           // TipTap reports an empty document while inserting the first block break,
           // so commit manual rich mode after that update has had a chance to clear it.
           manualRichMode = true;

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -575,6 +575,8 @@ describe('MessageComposer', () => {
       await vi.waitFor(() => {
         expect(surface?.getAttribute('data-composer-mode')).toBe('rich');
       });
+      expect(editor.querySelectorAll(':scope > p')).toHaveLength(1);
+      expect(editor.textContent).toBe('');
       expect(mutationMock).not.toHaveBeenCalled();
     });
 

--- a/mise.toml
+++ b/mise.toml
@@ -14,7 +14,11 @@ _.file = '.env'
 
 [tasks.setup]
 description = "Set up the development environment"
-run = [{ task = "setup-cli" }, { task = "setup-frontend" }]
+run = [
+    { task = "setup-cli" },
+    { task = "setup-frontend" },
+    { task = "build-api-types" },
+]
 
 # =============================================================================
 # Dependencies


### PR DESCRIPTION
## Why

Cmd/Ctrl+Enter on an empty composer entered rich mode but also split TipTap's default paragraph, leaving an unwanted blank line.

## What changed

- Split the editor block only when the composer has visible content, while still latching manual rich mode for an empty composer.
- Extend the component regression test to assert that the editor stays empty with one paragraph.
- Build API types during `mise setup` and document the focused Vitest workflow discovered while verifying the fix.

## Test plan

- `mise x -- pnpm --filter chatto-frontend exec vitest --run src/lib/components/composer/MessageComposer.svelte.spec.ts -t 'empty composer'` — passed in Chromium (1 test).
- `mise setup` — passed, including API-types compilation.
- Svelte autofixer — no issues; `git diff --check` — passed.
