### PR TITLE
perf(connect): reuse DEKs across request hydration

### DIFF
--- a/cli/internal/connectapi/api.go
+++ b/cli/internal/connectapi/api.go
@@ -78,6 +78,7 @@ func handlerOptionsWithReadMax(readMaxBytes int, webserver config.WebserverConfi
 		connect.WithCompressMinBytes(compressionMinBytes),
 		connect.WithInterceptors(
 			internalErrorLoggingInterceptor(),
+			dekRequestCacheInterceptor(),
 			validate.NewInterceptor(),
 		),
 	}

--- a/cli/internal/connectapi/dek_request_cache.go
+++ b/cli/internal/connectapi/dek_request_cache.go
@@ -1,0 +1,19 @@
+package connectapi
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	"hmans.de/chatto/internal/core"
+)
+
+// dekRequestCacheInterceptor gives every unary Connect request one shared,
+// request-bounded cache for unwrapped user DEKs. Core hydration methods still
+// establish the cache defensively for callers outside Connect.
+func dekRequestCacheInterceptor() connect.Interceptor {
+	return connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			return next(core.WithDEKRequestCache(ctx), req)
+		}
+	})
+}

--- a/cli/internal/connectapi/dek_request_cache_test.go
+++ b/cli/internal/connectapi/dek_request_cache_test.go
@@ -2,6 +2,7 @@ package connectapi
 
 import (
 	"context"
+	"errors"
 	"net/http/httptest"
 	"testing"
 
@@ -16,7 +17,7 @@ func TestHandlerOptionsEstablishDEKRequestCache(t *testing.T) {
 		procedure,
 		func(ctx context.Context, _ *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error) {
 			if got := core.WithDEKRequestCache(ctx); got != ctx {
-				t.Fatal("handler context does not contain a DEK request cache")
+				return nil, connect.NewError(connect.CodeInternal, errors.New("handler context does not contain a DEK request cache"))
 			}
 			return connect.NewResponse(&emptypb.Empty{}), nil
 		},

--- a/cli/internal/connectapi/dek_request_cache_test.go
+++ b/cli/internal/connectapi/dek_request_cache_test.go
@@ -1,0 +1,46 @@
+package connectapi
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"hmans.de/chatto/internal/core"
+)
+
+func TestHandlerOptionsEstablishDEKRequestCache(t *testing.T) {
+	const procedure = "/chatto.test.v1.CacheService/Get"
+	handler := connect.NewUnaryHandler(
+		procedure,
+		func(ctx context.Context, _ *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error) {
+			if got := core.WithDEKRequestCache(ctx); got != ctx {
+				t.Fatal("handler context does not contain a DEK request cache")
+			}
+			return connect.NewResponse(&emptypb.Empty{}), nil
+		},
+		HandlerOptions()...,
+	)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	client := connect.NewClient[emptypb.Empty, emptypb.Empty](server.Client(), server.URL+procedure)
+	if _, err := client.CallUnary(context.Background(), connect.NewRequest(&emptypb.Empty{})); err != nil {
+		t.Fatalf("CallUnary: %v", err)
+	}
+}
+
+func TestDEKRequestCacheInterceptorPreservesExistingCache(t *testing.T) {
+	ctx := core.WithDEKRequestCache(context.Background())
+	wrapped := dekRequestCacheInterceptor().WrapUnary(func(got context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+		if got != ctx {
+			t.Fatal("interceptor replaced the existing DEK request cache context")
+		}
+		return nil, nil
+	})
+
+	if _, err := wrapped(ctx, nil); err != nil {
+		t.Fatalf("wrapped handler: %v", err)
+	}
+}


### PR DESCRIPTION
## Why

Message-body and user-PII hydration already share the same request-scoped
unwrapped-DEK cache, but Connect callers had to remember to establish that
scope themselves. Timeline assembly did so explicitly; other handlers could
create separate defensive cache scopes for sequential hydration operations in
one request.

## What changed

- establish `core.WithDEKRequestCache` once for every unary Connect request via
  the common handler interceptor chain
- retain the existing defensive cache scopes in core hydration methods for
  REST, background, test, and other non-Connect callers
- verify the real common handler options deliver a cache-enabled context and
  that the interceptor preserves an existing cache

Message-body and user-PII keys remain separate purpose-scoped DEKs. Reuse is
still limited to one request and keyed by user, purpose, epoch, and content-key
reference; crypto-shredding invalidation is unchanged.

## Compatibility and operations

- no EVT, protobuf, public API, storage, migration, configuration, or
  user-visible behavior changes
- no process-wide plaintext key cache; DEKs remain bounded to request lifetime
- streaming RPCs are intentionally excluded so long-lived streams do not retain
  plaintext keys

## Test plan

- `mise x -- go test ./internal/connectapi -timeout 120s` — passed
- focused interceptor tests after review hardening — passed
- `mise test-cli` — passed
- `mise lint` — passed with zero Svelte errors or warnings; ESLint passed
- adversarial review — two complete passes, no remaining actionable findings

Closes #1553.
