### PR TITLE
docs(architecture): improve inventory readability

### DIFF
--- a/.agents/skills/chatto-architecture-inventory/SKILL.md
+++ b/.agents/skills/chatto-architecture-inventory/SKILL.md
@@ -158,6 +158,12 @@ comments and generated API docs.
 - Keep each file independently understandable but avoid repeating another
   category's tables or prose.
 - Prefer compact tables for repeated facts and short prose for invariants.
+- Keep prose paragraphs focused on one idea and normally below 100 words. Split
+  dense lifecycle or failure descriptions into short paragraphs, bullets, or
+  descriptive subheadings before they become wall-of-text summaries.
+- Treat paragraph length as a review signal, not a reason to fragment related
+  sentences or distort Markdown lists and tables. Rewrite for scanability; do
+  not merely insert arbitrary line breaks inside the same paragraph.
 - Add 2-5 authoritative relative source links near the start of each file.
 - Use repository terminology and update `docs/GLOSSARY.md` if canonical
   vocabulary changes.
@@ -179,6 +185,9 @@ Run checks proportional to the categories touched:
 - Compare mounted service names and auth policies with `API.Handlers()` and
   `API.OperatorHandlers()`; do not reconstruct an endpoint reference.
 - Verify relevant ADR/FDR links and `docs/architecture/INDEX.md` navigation.
+- Scan edited inventory prose for paragraphs over 100 words and shorten or
+  restructure any that do not have a clear reason to remain long. Tables and
+  compact lists are exempt.
 - Run `mise license-check` when files were added or moved across license
   boundaries.
 

--- a/docs/architecture/projections.md
+++ b/docs/architecture/projections.md
@@ -2,7 +2,26 @@
 
 Key files: [`cli/internal/core/core.go`](../../cli/internal/core/core.go), [`cli/internal/events/projector.go`](../../cli/internal/events/projector.go), [`cli/internal/core/projection_subjects_test.go`](../../cli/internal/core/projection_subjects_test.go)
 
-Projections are in-memory read models rebuilt from `EVT`. `NewChattoCore` registers each top-level projector once with a stable machine-readable key such as `content_keys` plus a human display name such as `Content Keys`; `ChattoCore.Run` replays `evt.>` through one process-local ordered consumer, decodes each event once, dispatches it to projections whose logical subject filters match, records each projection's initial replay startup duration, waits for them to become current at boot, and writers wait for the relevant projector sequence before returning read-your-writes. The projector framework owns JetStream message handling and passes stable stream sequence numbers into `Projection.Apply`; projection implementations do not inspect consumer sequence numbers or raw JetStream metadata. Projections that require event-envelope idempotency keep event-ID sets only through the captured startup target. Clean histories then release those sets and use the highest applied stream sequence as a constant-size steady-state guard; if startup replay observes a duplicate ID, only that projection retains its set and first-event-wins compatibility behavior. Projection diagnostics report both retained event-ID memory and whether compatibility mode is active.
+Projections are in-memory read models rebuilt from `EVT`. `NewChattoCore`
+registers each top-level projector once with a stable machine-readable key, such
+as `content_keys`, and a human display name, such as `Content Keys`.
+
+`ChattoCore.Run` replays `evt.>` through one process-local ordered consumer. It
+decodes each event once, dispatches it to projections whose logical subject
+filters match, records initial replay duration, and waits for projections to
+become current at boot. Writers wait for the relevant projector sequence before
+returning read-your-writes.
+
+The projector framework owns JetStream message handling and passes stable
+stream sequence numbers into `Projection.Apply`. Projection implementations do
+not inspect consumer sequence numbers or raw JetStream metadata.
+
+Projections that require event-envelope idempotency keep event-ID sets only
+through the captured startup target. Clean histories then release those sets
+and use the highest applied stream sequence as a constant-size steady-state
+guard. If startup replay observes a duplicate ID, only that projection retains
+its set and first-event-wins compatibility behaviour. Projection diagnostics
+report both retained event-ID memory and whether compatibility mode is active.
 
 Related decisions: [ADR-007](../adr/ADR-007-per-user-encryption-with-crypto-shredding.md),
 [ADR-033](../adr/ADR-033-event-sourced-state-with-projections.md), and
@@ -10,7 +29,51 @@ Related decisions: [ADR-007](../adr/ADR-007-per-user-encryption-with-crypto-shre
 
 ## Snapshot support
 
-`core.projection_snapshots` enables the ADR-050 Thread snapshot canary. The projector framework atomically captures projection state with its applied EVT sequence and can restore one projection while the shared `evt.>` consumer still replays from the beginning for all others. `ThreadProjection` uses the `threads-v1` protobuf codec; its encrypted generation bundle contains no message bodies or decrypted PII and rebuilds derived indexes on restore. One replica is elected through a `MEMORY_CACHE` lease after boot to publish a generation when Threads advanced. Generations are compressed and authenticated with XChaCha20-Poly1305 under an HKDF key derived from `core.secret_key`, then stored under a secret-derived opaque epoch in the dedicated NATS `PROJECTION_SNAPSHOTS` Object Store or configured S3 bucket. Their encrypted current/previous pointer lives in `RUNTIME_STATE` and uses KV revision OCC regardless of payload backend. The pointer carries cutoff, EVT incarnation, and projection compatibility metadata so publication rejects both an obsolete revision and a causally older capture. A new secret uses a different generation epoch, preventing its cleaner from deleting generations still used by old-secret replicas during a rolling change. Namespace `v1` is permanently limited to Threads and the repository rejects other keys, so older cleaners remain safe during mixed-version rollouts; adding another snapshotted projection requires a new namespace version. EVT carries a versioned opaque incarnation ID in stream metadata so snapshot compatibility survives process reconstruction and backup restore but changes when EVT is recreated. Missing IDs are deterministically derived once from the stream creation time so concurrent replicas converge, then persisted; runtime snapshot paths use the captured immutable value rather than concurrently refreshing NATS client metadata. A separately elected cleanup worker starts 5-10 minutes after boot, inventories only its private key epoch every six hours, and deletes at most 100 objects or 1 GiB per pass when unreferenced generations are at least 24 hours old. It collects that bounded batch during one complete read-only inventory, checks lease ownership once before deletion, and retries failed or deletion-limited passes after 30 minutes. Snapshot storage, EVT identity, projector configuration, load, validation, pointer publication, lease, inventory, and cleanup failures are logged, disable only snapshot functionality where necessary, and never affect core readiness or EVT-backed reconstruction. Pre-epoch canary objects are intentionally outside this cleaner and require provider lifecycle or explicit later migration tooling.
+`core.projection_snapshots` enables the ADR-050 Thread snapshot canary. The
+projector framework atomically captures projection state with its applied EVT
+sequence. It can restore one projection while the shared `evt.>` consumer still
+replays from the beginning for all others.
+
+`ThreadProjection` uses the `threads-v1` protobuf codec. Its encrypted
+generation bundle contains no message bodies or decrypted PII, and it rebuilds
+derived indexes on restore. After boot, one replica is elected through a
+`MEMORY_CACHE` lease to publish a generation whenever Threads has advanced.
+
+Generations are compressed and authenticated with XChaCha20-Poly1305 under an
+HKDF key derived from `core.secret_key`. They are stored under a secret-derived
+opaque epoch in either the NATS `PROJECTION_SNAPSHOTS` Object Store or the
+configured S3 bucket.
+
+The encrypted current/previous pointer lives in `RUNTIME_STATE` and uses KV
+revision OCC for either payload backend. It carries cutoff, EVT incarnation,
+and projection compatibility metadata, so publication rejects both an obsolete
+revision and a causally older capture.
+
+A new secret uses a different generation epoch. This prevents its cleaner from
+deleting generations still used by old-secret replicas during a rolling
+change. Namespace `v1` is permanently limited to Threads, and the repository
+rejects other keys. Adding another snapshotted projection requires a new
+namespace version so older cleaners remain safe during mixed-version rollouts.
+
+EVT carries a versioned opaque incarnation ID in stream metadata. Snapshot
+compatibility therefore survives process reconstruction and backup restore but
+changes when EVT is recreated. Missing IDs are deterministically derived once
+from stream creation time so concurrent replicas converge, then persisted.
+Runtime snapshot paths use the captured immutable value rather than refreshing
+NATS client metadata concurrently.
+
+A separately elected cleanup worker starts 5-10 minutes after boot and
+inventories only its private key epoch every six hours. Each pass deletes at
+most 100 objects or 1 GiB, and only when unreferenced generations are at least
+24 hours old. The worker collects the bounded batch during one complete
+read-only inventory, checks lease ownership once before deletion, and retries
+failed or deletion-limited passes after 30 minutes.
+
+Snapshot storage, EVT identity, projector configuration, load, validation,
+pointer publication, lease, inventory, and cleanup failures are logged. They
+disable only snapshot functionality where necessary and never affect core
+readiness or EVT-backed reconstruction. Pre-epoch canary objects are outside
+this cleaner and require provider lifecycle or later migration tooling.
 
 | Projection | Namespace | Codec | Payload store | Pointer store | Publication |
 | ---------- | --------- | ----- | ------------- | ------------- | ----------- |
@@ -33,7 +96,20 @@ Related decisions: [ADR-007](../adr/ADR-007-per-user-encryption-with-crypto-shre
 | RBAC               | RBAC                 | `evt.rbac.>`                                               | Roles, role order, assignments, scoped allow/deny decisions                                |
 | Mentions           | Mentionables         | `evt.>`                                                    | Global mention-handle ownership across users, roles, `@all`, and `@here`                  |
 
-Notes: registered projector keys are used by metrics and automation; registered projector names match the admin projection diagnostics. Composite projections expose nested read models, but only their parent projector is started by `ChattoCore.Run`. The shared replay fanout reduces duplicate replay delivery and protobuf decoding while keeping each projection's status, lag, failure, and read-your-writes waiters independent. `Subjects()` is the logical consumption and readiness contract; optional replay subjects are only the physical consumer filter. Focused logical filters are appropriate for stable derived indexes such as Threads, while broad filters remain intentional for projections whose snapshots expose room-tail OCC positions, such as Reactions and Call State. Threads reports the focused logical subjects above for waits and diagnostics; non-thread room facts are skipped before `Apply`.
+Registered projector keys are used by metrics and automation. Registered names
+match the admin projection diagnostics. Composite projections expose nested
+read models, but only their parent projector is started by `ChattoCore.Run`.
+
+The shared replay fanout reduces duplicate delivery and protobuf decoding while
+keeping each projection's status, lag, failure, and read-your-writes waiters
+independent. `Subjects()` is the logical consumption and readiness contract;
+optional replay subjects are only the physical consumer filter.
+
+Focused logical filters suit stable derived indexes such as Threads. Broad
+filters remain intentional for projections whose snapshots expose room-tail
+OCC positions, such as Reactions and Call State. Threads reports the focused
+logical subjects above for waits and diagnostics; non-thread room facts are
+skipped before `Apply`.
 
 `UserProjection` retains encrypted user fields and their AAD metadata. The user
 and mentionable projections decrypt login and email values only transiently

--- a/docs/architecture/realtime-delivery.md
+++ b/docs/architecture/realtime-delivery.md
@@ -4,9 +4,48 @@ Key files: [`proto/chatto/realtime/v1/realtime.proto`](../../proto/chatto/realti
 
 Related decision: [ADR-049](../adr/ADR-049-process-wide-realtime-event-hub.md).
 
-The protobuf realtime API is mounted at `GET /api/realtime` and upgrades to a binary WebSocket protocol. The first client frame must be `RealtimeClientFrame.hello`; the server accepts protocol version 1, authenticates either the hello bearer token or the existing cookie session, and replies with `RealtimeServerFrame.hello`. The second client frame must be `subscribe_events`, after which the server sends `subscribed` and starts forwarding authorized `RealtimeEventEnvelope` frames plus application-level heartbeats. Clients can send `ping` frames and receive `pong`. The v1 protocol is live-only and does not expose acknowledgement frames, resume requests, or event cursors.
+The protobuf realtime API is mounted at `GET /api/realtime` and upgrades to a
+binary WebSocket protocol. The first client frame must be
+`RealtimeClientFrame.hello`. The server accepts protocol version 1,
+authenticates either the hello bearer token or the existing cookie session, and
+replies with `RealtimeServerFrame.hello`.
 
-The HTTP handler does not implement independent room/RBAC filtering. After authentication it calls `core.StreamMyEventsWithOptions` with legacy presence touching disabled, then maps the already-authorized core envelope into public `chatto.realtime.v1` realtime frames. This keeps room membership, DM privacy, server/user/config event gates, projection readiness, live membership changes, slow-consumer shutdown, and session termination behavior shared with `core.StreamMyEvents`. A process-wide `MyEventsHub` owns one NATS Core subscription to `live.sync.>` and one to `live.evt.>`, classifies subjects before decoding, waits for projections once, and fans immutable decoded events into count- and byte-bounded session queues. Sessions for one user share room-visibility state. The process-wide PresenceHub retains the current presence snapshot and fans out only future status transitions; individual streams do not copy the server-wide snapshot. Queue overflow closes the affected stream so reconnect catch-up restores current projected or latest-value state. WebSocket connections use small read/write buffers and share a write-buffer pool so idle connections do not retain a full default transport buffer in each direction. When WebSocket compression is enabled, the server uses Huffman-only DEFLATE and compresses only frames of at least 1 KiB; the small invalidation and heartbeat frames that dominate realtime traffic remain uncompressed and therefore do not instantiate Gorilla's server-side compressor state. Realtime events are public API signals, not raw persisted `corev1.Event` or `corev1.LiveEvent` payloads. ID-only realtime payloads are invalidation signals; `proto/chatto/realtime/v1/realtime.proto` documents the intended `chatto.api.v1`/`chatto.admin.v1` ConnectRPC hydration path for each referenced resource so clients can recover missed live state through projected reads.
+The second client frame must be `subscribe_events`. The server then sends
+`subscribed` and starts forwarding authorized `RealtimeEventEnvelope` frames
+plus application-level heartbeats. Clients can send `ping` frames and receive
+`pong`. The v1 protocol is live-only and exposes no acknowledgement frames,
+resume requests, or event cursors.
+
+The HTTP handler does not implement independent room/RBAC filtering. After
+authentication it calls `core.StreamMyEventsWithOptions` with legacy presence
+touching disabled, then maps the already-authorized core envelope into public
+`chatto.realtime.v1` frames. Room membership, DM privacy, server/user/config
+event gates, projection readiness, live membership changes, slow-consumer
+shutdown, and session termination therefore remain shared with
+`core.StreamMyEvents`.
+
+A process-wide `MyEventsHub` owns one NATS Core subscription to `live.sync.>`
+and one to `live.evt.>`. It classifies subjects before decoding, waits for
+projections once, and fans immutable decoded events into count- and byte-bounded
+session queues. Sessions for one user share room-visibility state.
+
+The process-wide PresenceHub retains the current presence snapshot and fans out
+only future status transitions. Individual streams do not copy the server-wide
+snapshot. Queue overflow closes only the affected stream, allowing reconnect
+catch-up to restore current projected or latest-value state.
+
+WebSocket connections use small read/write buffers and share a write-buffer
+pool, so idle connections do not retain a full default transport buffer in each
+direction. When compression is enabled, the server uses Huffman-only DEFLATE
+and compresses only frames of at least 1 KiB. The small invalidation and
+heartbeat frames that dominate realtime traffic remain uncompressed and do not
+instantiate Gorilla's server-side compressor state.
+
+Realtime events are public API signals, not raw persisted `corev1.Event` or
+`corev1.LiveEvent` payloads. ID-only payloads are invalidation signals. The
+realtime protobuf documents the intended `chatto.api.v1` or `chatto.admin.v1`
+ConnectRPC hydration path for each referenced resource, so clients can recover
+missed live state through projected reads.
 
 Clients recover missed state with projected reads, the same projected-read catch-up model. There is no per-connection JetStream consumer and no public subscription replay cursor.
 

--- a/docs/architecture/runtime-state.md
+++ b/docs/architecture/runtime-state.md
@@ -25,7 +25,19 @@ Related decision: [ADR-036](../adr/ADR-036-runtime-state-kv-boundary.md).
 
 Notes: Excluded from backups so backup archives do not contain the KEKs needed to unwrap protected content or the per-call media keys needed to decrypt captured LiveKit media. Chatto core uses the in-process [`internal/kms`](../../cli/internal/kms/) boundary for KEK creation, DEK wrap/unwrap, call-key lookup, and key shredding. App-owned wrapped DEK records live in `RUNTIME_STATE` under `dek.{id}`; that complete key is the content-key ref.
 
-The backup CLI stages JetStream snapshots in an owner-only random directory beside the destination, always removes plaintext staging, and publishes owner-only archives through a same-directory temporary file and atomic rename. Backup, restore, and key export/import accept passphrases through hidden terminal prompts or explicit `--passphrase-file` / `--passphrase-stdin` automation sources; the process-argument `--passphrase` compatibility path is deprecated for removal in 0.5. Restore extracts into an owner-only temporary directory, rejects non-local manifest stream names and unsupported tar entry types, and bounds archive entry count, individual file size, and total expanded bytes before connecting restored paths to JetStream.
+The backup CLI stages JetStream snapshots in an owner-only random directory
+beside the destination and always removes plaintext staging. It publishes
+owner-only archives through a same-directory temporary file and atomic rename.
+
+Backup, restore, and key export/import accept passphrases through hidden
+terminal prompts or explicit `--passphrase-file` and `--passphrase-stdin`
+automation sources. The process-argument `--passphrase` compatibility path is
+deprecated for removal in 0.5.
+
+Restore extracts into an owner-only temporary directory. Before connecting
+restored paths to JetStream, it rejects non-local manifest stream names and
+unsupported tar entry types, and bounds archive entry count, individual file
+size, and total expanded bytes.
 
 **RUNTIME\_STATE keys:**
 
@@ -69,7 +81,20 @@ Token HMAC keys are derived with `[core].secret_key` and the token family as a d
 | `livekit.reconciliation.list_failures`      | Shared consecutive LiveKit listing failure counter reset by any successful elected reconciliation pass |
 | `asset_cleanup.status`                     | Privacy-safe JSON heartbeat from the elected physical asset-deletion worker. Records worker ownership, initial-scan/pass state, pending retry count and age, last pass/success times, and the last inspected EVT sequence. |
 
-Notes: Memory-based storage (not persisted, not backed up). Presence uses per-key TTL with 30-second client refresh and `LimitMarkerTTL` so NATS emits delete markers on TTL expiry. A single per-process **PresenceHub** watches `presence.>` and emits `PresenceChanged` only when a user's status changes. Clients refresh live status through ConnectRPC `MyAccountService.UpdatePresence`. On disconnect or "look offline", clients do not write `OFFLINE`; they stop refreshing and TTL handles expiry. Short-lived `lease.{name}` records coordinate singleton background work across replicas without adding durable state. Active voice call participants are served from the call-state projection over durable room EVT facts and reconciled against LiveKit by the elected reconciler; per-call LiveKit E2EE keys live behind the KMS boundary in `ENCRYPTION_KEYS`, and the retired `CALL_STATE` bucket is no longer imported.
+`MEMORY_CACHE` uses memory storage and is neither persisted nor backed up.
+
+Presence uses per-key TTL with a 30-second client refresh and `LimitMarkerTTL`,
+so NATS emits delete markers on expiry. A single per-process **PresenceHub**
+watches `presence.>` and emits `PresenceChanged` only when a user's status
+changes. Clients refresh through `MyAccountService.UpdatePresence`; disconnect
+and "look offline" stop refreshing instead of writing `OFFLINE`.
+
+Short-lived `lease.{name}` records coordinate singleton background work across
+replicas without adding durable state. Active voice call participants come from
+the call-state projection over durable room EVT facts and are reconciled
+against LiveKit by the elected reconciler. Per-call LiveKit E2EE keys remain
+behind the KMS boundary in `ENCRYPTION_KEYS`; the retired `CALL_STATE` bucket is
+no longer imported.
 
 ## Object Store buckets
 
@@ -111,18 +136,68 @@ Notes: Only created when `[core.assets.cache]` is enabled in config. Uses TTL fo
 
 Attachment upload storage: chunked uploads first store temporary `asset-upload.*` chunks in `SERVER_ASSETS`. Completion verifies the full SHA-256, stores the final attachment in NATS or S3, records SHA-256/uploader/pending-expiry/video hints in `AssetCreatedEvent`, and deletes temporary chunks. Completed but unclaimed pending attachment assets expire after 24 hours unless a message body claims them.
 
-Notes: Asset IDs are globally unique NanoIDs. New public NATS objects add the `public/` kind segment so their storage class is explicit; private attachments retain flat keys for compatibility. S3 stores logical, prefix-free keys; any configured `path_prefix` is applied only when talking to the S3 backend. Content-Type and original filename are stored in object headers where available. S2 compression is enabled for `SERVER_ASSETS`. `MediaModel` owns binary storage and serving helpers; `AssetModel` owns durable lifecycle facts and elected message-asset deletion recovery. Asset **metadata** (filename, dimensions, duration, storage pointer, …) is created in `AssetCreatedEvent` on `evt.asset.{assetId}.asset_created`; room scope and ownership context lives on the event (`message`, `derivative`, `user_avatar`, or `server_branding`) rather than inside `Asset`. The `asset_cleanup` lease holder incrementally replays canonical `AssetDeletedEvent` facts, locates the matching creation fact through the asset ID, and idempotently deletes source/derivative bytes and transform-cache entries. Beta room-scoped histories without a canonical asset aggregate remain readable by projections but are not guessed at by the cleanup worker. New message bodies reference message-owned assets by ID. Link preview images are server-scoped persisted assets and are embedded in message bodies as `LinkPreview.image_asset` (`AssetRecord`) so the body records whether the image lives in S3 or `SERVER_ASSETS`; `image_asset_id` remains for compatibility with clients and older stored previews. Processing events refer to created asset IDs and are appended under the same `evt.asset.{assetId}.*` aggregate. The asset projection also reads beta-era `evt.room.{roomId}.asset_*` facts so existing 0.1.0 histories continue to replay without a stream rewrite. Message posting asks the process-local video service to spawn video/animated-GIF processing after appending asset creation and processing-started events; there is no transient NATS Core worker subject or `video_processed` live signal. Boot recovery derives missed work from the EVT projections and calls the same local path. Video processing success records thumbnail/variant asset IDs, while each derivative binary is separately declared with `AssetCreatedEvent` and an owner pointing at the original asset. `AssetProcessingFailedEvent.failure_code` records failed/unavailable outcomes. Account deletion follows the projected message asset graph and appends `AssetDeletedEvent` for source assets and derivative children before deleting backing bytes.
+### Asset storage and ownership
+
+Asset IDs are globally unique NanoIDs. New public NATS objects use the
+`public/` kind segment to make their storage class explicit; private attachments
+retain flat keys for compatibility. S3 stores logical, prefix-free keys, with
+any configured `path_prefix` applied only at the S3 boundary. Object headers
+hold Content-Type and the original filename where available.
+
+S2 compression is enabled for `SERVER_ASSETS`. `MediaModel` owns binary storage
+and serving helpers. `AssetModel` owns durable lifecycle facts and elected
+message-asset deletion recovery.
+
+Asset metadata is created in `AssetCreatedEvent` on
+`evt.asset.{assetId}.asset_created`. Room scope and ownership context live on
+the event as `message`, `derivative`, `user_avatar`, or `server_branding`, not
+inside `Asset`. New message bodies reference message-owned assets by ID.
+
+Link preview images are server-scoped persisted assets embedded in message
+bodies as `LinkPreview.image_asset` (`AssetRecord`). The body records whether
+the image lives in S3 or `SERVER_ASSETS`; `image_asset_id` remains for older
+clients and stored previews.
+
+### Asset lifecycle and compatibility
+
+The `asset_cleanup` lease holder incrementally replays canonical
+`AssetDeletedEvent` facts. It locates creation metadata by asset ID and
+idempotently deletes source and derivative bytes plus transform-cache entries.
+Beta room-scoped histories without a canonical asset aggregate remain readable
+by projections but are not guessed at by the cleanup worker.
+
+Processing events use the same `evt.asset.{assetId}.*` aggregate. The asset
+projection also reads beta-era `evt.room.{roomId}.asset_*` facts, allowing 0.1.0
+histories to replay without a stream rewrite.
+
+After appending creation and processing-started events, message posting asks
+the process-local video service to start video or animated-GIF processing.
+There is no transient NATS Core worker subject or `video_processed` live
+signal. Boot recovery derives missed work from EVT projections and calls the
+same local path.
+
+Successful processing records thumbnail and variant asset IDs. Each derivative
+binary is separately declared with `AssetCreatedEvent` and an owner pointing to
+the original asset. `AssetProcessingFailedEvent.failure_code` records failed or
+unavailable outcomes.
+
+Account deletion follows the projected message asset graph. It appends
+`AssetDeletedEvent` for source assets and derivative children before deleting
+their backing bytes.
 
 `/assets/server/*` is an unauthenticated route limited to positively classified
 public server assets. New NATS-backed URLs use
 `/assets/server/public/{assetId}` and map directly to the explicit
 `public/{assetId}` object namespace. Canonical `/assets/server/{assetId}` URLs
-remain aliases for those objects and preserve historical flat-key URLs. Before
-transform signature parsing, resize-cache access, object reads, or image
+remain aliases and preserve historical flat-key URLs.
+
+Before transform signature parsing, resize-cache access, object reads, or image
 transformation, the handler rejects unknown namespaces, every live or deleted
 `AssetProjection` declaration, and private NATS metadata (`Room-Id` or
-`Upload-Id`). Historical avatars and branding are recognized through their
-current durable pointers, while historical link-preview images are recognized
-through durable message-body references. S3 public delivery probes only
-`instance/{assetId}`; private current and historical attachment prefixes are
-never probed by this route. Disallowed classes return 404.
+`Upload-Id`). Historical avatars and branding are recognized through current
+durable pointers. Historical link-preview images are recognized through
+durable message-body references.
+
+S3 public delivery probes only `instance/{assetId}`. This route never probes
+private current or historical attachment prefixes. Disallowed classes return
+404.

--- a/docs/architecture/subjects-and-events.md
+++ b/docs/architecture/subjects-and-events.md
@@ -54,7 +54,46 @@ User-facing live delivery is built from two internal NATS Core subject roots:
 2. **Direct Live Publish** (transient):
    - Transient UI sync signals publish as `corev1.LiveEvent` via NATS Core to `live.sync.>` — no stream storage.
 
-`MyEventsModel` is owned behind the `ChattoCore.StreamMyEvents` facade. Its process-wide `MyEventsHub` subscribes once to each of `live.sync.>` and `live.evt.>`. It rejects non-deliverable event types from their subjects before protobuf decoding, including private `message_body` facts, then decodes and waits for the required local projections once. RBAC facts wait for the matching RBAC projection position and rebuild each connected user's shared effective-room cache before later events are considered, so role and permission changes revoke implicit universal-room visibility without reconnecting. Deliverable events are authorized per user and fanned as shared immutable pointers to independent session queues. New sessions hydrate visibility outside the dispatcher lock against stable authoritative room-visibility/RBAC EVT tails, then register through a dispatcher-owned channel after ingress already received by the process has been drained. Ordinary room chatter does not participate in the stable-tail check. Visibility changes processed during hydration force a retry, while late cross-publisher facts already covered by the snapshot are suppressed by EVT stream sequence; admission does not assume global NATS publisher ordering. Asset lifecycle events resolve their room authorization through `AssetProjection`, using the room scope on `AssetCreatedEvent` and inherited parent scope for derivatives. Transient `LiveEvent` messages are adapted at this API boundary into public protobuf `/api/realtime` frames. Both surfaces are live-only; missed state is recovered by projected reads. Subscriber overflow closes only that session. Process-wide ingress loss or projection-readiness failure quarantines admission, closes every current session, flushes and drains the old subscriptions, and opens a fresh ingress generation so no session continues or reconnects across an unobservable gap. The bundled web client opens `/api/realtime`, watches server heartbeats for silent stalls, refetches server-scoped projected state after reconnect gaps, and refetches the current room or thread window from projections after browser wake, WebSocket reconnect, socket end, or heartbeat-stall catch-up notifications. There is no per-connection JetStream consumer and no public subscription replay cursor. See [ADR-049](../adr/ADR-049-process-wide-realtime-event-hub.md).
+`MyEventsModel` sits behind the `ChattoCore.StreamMyEvents` facade. Its
+process-wide `MyEventsHub` subscribes once to each of `live.sync.>` and
+`live.evt.>`.
+
+Ingress rejects non-deliverable event types from their subjects before protobuf
+decoding, including private `message_body` facts. It then decodes each event and
+waits once for the required local projections. RBAC facts wait for the matching
+RBAC projection and rebuild each connected user's shared effective-room cache
+before later events are considered. Role and permission changes can therefore
+revoke implicit universal-room visibility without reconnecting.
+
+Deliverable events are authorized per user and fanned as shared immutable
+pointers to independent session queues. Asset lifecycle events resolve room
+authorization through `AssetProjection`, using the scope on `AssetCreatedEvent`
+and inherited parent scope for derivatives.
+
+New sessions hydrate visibility outside the dispatcher lock against stable
+authoritative room-visibility and RBAC EVT tails. They register through a
+dispatcher-owned channel after the process drains ingress already received.
+Ordinary room chatter does not participate in the stable-tail check.
+
+Visibility changes processed during hydration force a retry. Late
+cross-publisher facts already covered by the snapshot are suppressed by EVT
+stream sequence; admission does not assume global NATS publisher ordering.
+
+Transient `LiveEvent` messages are adapted at this boundary into public
+protobuf `/api/realtime` frames. Both surfaces are live-only, and missed state
+is recovered by projected reads. Subscriber overflow closes only that session.
+
+Process-wide ingress loss or projection-readiness failure quarantines
+admission, closes every current session, flushes and drains the old
+subscriptions, and opens a fresh ingress generation. No session continues or
+reconnects across an unobservable gap.
+
+The bundled web client watches server heartbeats for silent stalls. It
+refetches server-scoped projected state after reconnect gaps, and refetches the
+current room or thread window after browser wake, WebSocket reconnect, socket
+end, or heartbeat-stall catch-up notifications. There is no per-connection
+JetStream consumer or public subscription replay cursor. See
+[ADR-049](../adr/ADR-049-process-wide-realtime-event-hub.md).
 
 ## EVT subject patterns
 
@@ -226,11 +265,45 @@ Patterns: `live.sync.>` for transient `LiveEvent` pubsub and `live.evt.>` for ra
 | `live.sync.member.deleted`                                | Server-level membership invalidation after account deletion |
 | `live.sync.room.{kind}.{roomId}.user_typing`             | User typing in a room        |
 
-Voice call lifecycle and participant transitions are durable room EVT facts under `evt.room.{roomId}.call_started`, `evt.room.{roomId}.call_joined`, `evt.room.{roomId}.call_left`, and `evt.room.{roomId}.call_ended`, republished to `live.evt.>` for realtime subscription delivery. They drive active-call state and indicators but are hidden from normal room history timelines. LiveKit room names include the active Chatto call ID suffix so LiveKit participant and room-finished observations are applied only to the matching call session. Only the replica holding the `MEMORY_CACHE` lease `lease.livekit_reconciler` runs the periodic LiveKit reconciliation loop. LiveKit reconciliation appends `RECONCILIATION` facts for participant mismatches in the matching call session. It disconnects participants from LiveKit rooms that no longer match a projected active call, and replays durable `call_ended` facts on startup to retry any per-call E2EE key shredding that did not complete after the original commit. Missing LiveKit rooms and observed empty rooms end projected calls immediately after a successful listing; per-room LiveKit `not_found` responses while listing participants are treated as that room being gone/empty so other rooms can still reconcile. Pre-threshold LiveKit listing failures increment shared `MEMORY_CACHE` key `livekit.reconciliation.list_failures` and are retried on the normal reconciliation ticker, and listing failures only end projected active calls after three consecutive failed elected reconciliation cycles. A successful elected reconcile pass deletes that failure counter. `VoiceCallService.GetActiveCall`, `BatchGetActiveCalls`, `GetCallToken`, and `ListCallParticipants` expose the active call ID so clients can ignore stale leave/end facts from previous calls in the same room; realtime `call_*` events carrying a room/call ID pair can be hydrated through `GetActiveCall` or `BatchGetActiveCalls`. Room membership remains the authorization boundary for live delivery.
+Voice call lifecycle and participant transitions are durable room EVT facts:
+`evt.room.{roomId}.call_started`, `evt.room.{roomId}.call_joined`,
+`evt.room.{roomId}.call_left`, and `evt.room.{roomId}.call_ended`. JetStream
+republishes them to `live.evt.>` for realtime delivery. They drive active-call
+state and indicators but remain hidden from normal room history timelines.
+
+LiveKit room names include the active Chatto call ID suffix. Participant and
+room-finished observations therefore apply only to the matching call session.
+Only the replica holding `lease.livekit_reconciler` in `MEMORY_CACHE` runs the
+periodic reconciliation loop.
+
+Reconciliation appends `RECONCILIATION` facts for participant mismatches in the
+matching call session. It disconnects participants from rooms that no longer
+match a projected active call. At startup, it also replays durable `call_ended`
+facts to retry any per-call E2EE key shredding that did not complete after the
+original commit.
+
+Missing or observed-empty LiveKit rooms end projected calls immediately after
+a successful listing. A per-room `not_found` while listing participants is
+treated as that room being gone or empty, so other rooms can still reconcile.
+
+Listing failures increment the shared
+`livekit.reconciliation.list_failures` key and retry on the normal ticker. They
+end projected calls only after three consecutive failed elected reconciliation
+cycles. A successful elected pass deletes the counter.
+
+`VoiceCallService.GetActiveCall`, `BatchGetActiveCalls`, `GetCallToken`, and
+`ListCallParticipants` expose the active call ID. Clients can ignore stale
+leave or end facts from previous calls in the same room, and hydrate realtime
+`call_*` events through `GetActiveCall` or `BatchGetActiveCalls`. Room
+membership remains the authorization boundary for live delivery.
 
 The `/api/realtime` WebSocket is backed by the single core stream `StreamMyEvents`, which combines:
 
-- One process-wide `ChanSubscribe("live.sync.>")` for transient `LiveEvent` messages and one process-wide `ChanSubscribe("live.evt.>")` for raw committed EVT facts. Subject classification and decoding happen once; authorization is then applied per connected user using shared room visibility, asset room membership, user/config/member subject gates, and projection readiness before deliverable `live.evt.>` events.
+- One process-wide `ChanSubscribe("live.sync.>")` for transient `LiveEvent`
+  messages and one `ChanSubscribe("live.evt.>")` for raw committed EVT facts.
+  Subject classification and decoding happen once. Authorization then applies
+  per connected user using shared room visibility, asset room membership,
+  user/config/member subject gates, and projection readiness.
 - Live-only subscription delivery. Missed state after reconnect is recovered from projected reads: server-scoped stores refetch their current projections after event-bus gaps, and the visible room/thread refetches its current message window. Transient sync and presence signals remain live-only.
 - The PresenceHub (single per-process KV watcher on `presence.>` fanning out per-user status changes to all subscribers).
 - An in-process heartbeat ticker (synthetic `Heartbeat` event every 15s for client-side liveness detection).


### PR DESCRIPTION
## Why

Several architecture inventory sections had grown into wall-of-text paragraphs that were difficult to scan and maintain.

## What changed

- Split dense projection, realtime, runtime-state, asset, and event-delivery descriptions into focused paragraphs and descriptive subsections without changing their technical contracts.
- Updated the `chatto-architecture-inventory` skill to keep prose normally below 100 words and require paragraph-length validation in future maintenance.

## Test plan

- `git diff --check`
- Scanned all `docs/architecture/*.md` prose blocks and confirmed none exceed 100 words, excluding tables and compact lists.
- Verified every relative Markdown link in the architecture inventory and updated skill resolves to an existing repository path.
