### PR TITLE
docs: add 0.5 roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ path-specific guidance.
 - Chatto is public, self-hosted, and has real user data.
 - The project is pre-1.0, but people are already self-hosting Chatto, so we want to avoid breaking changes where possible. For new API surface, prefer new protobuf fields on existing protobuf types, then new protobuf types. Only implement _breaking_ API changes if absolutely necessary, but discuss this with the user first. Changes to the `core` protobuf messages (used by our persistence layer) must never be breaking.
 - Assume that mixed versions are in use in the wider ecosystem; but self-hosters have been advised to track `:latest`, or upgrade to newly released versions quickly.
+- The next planned version is `0.5.0`. There's a 0.5.0 milestone on GitHub, but also we're locally tracking planned features and changes for 0.5.0 in `docs/TODO-0-5.md`. Please use these for guidance, and update them as we cross off features from the list. Do not add to the list unless the user specifically asks you to.
 
 ## Prime Directives
 

--- a/docs/TODO-0-5.md
+++ b/docs/TODO-0-5.md
@@ -1,0 +1,87 @@
+## CHATTO 0.5
+
+Notes and TODOs:
+
+- **Configuration System**
+	- [ ] Configuration keys that can be set in three tiers:
+		- Server-scope
+		- Room Group-scope
+		- Room-scope
+		- [ ] Per-role and per-user overrides?
+	- Potential settings:
+		- [ ] Max characters/lines per message
+		- [ ] Max Message Age for Editing
+		- [ ] Slow Mode
+		- [ ] Show Joins/Leaves
+		- [ ] Encourage Threads
+- **Chatto CLI structure, each component is optional:**
+	- [ ] Chat Server (what we have today; in 0.5.0, can be disabled, ironically)
+	- [ ] Chat UI + Auth + Push Server
+- **Client Refresh**
+	- **Design Refresh & Cleanup**
+		- [ ] Design system consolidation
+			- [ ] Get serious about atoms, elements etc.
+			- [ ] brush up our frontend skills so the robots 100% follow the system
+		- [ ] New DM UI?
+		- [ ] New typing indicators
+		- [ ] Find a new name for "room groups"
+	- **Refactor room data loading**
+		- [ ] Keep all room state, not just the one you're viewing currently
+		- [ ] Switching rooms should just render a different part of the store
+		- [ ] Event-based; catchup mechanism should be able to just ask the server for all events since datetime/sequence/event ID, etc.
+	- **Make it fully instance agnostic**
+		- [ ] We must be able to ship it as a desktop and native app
+		- [ ] **This implicitly conflicts with our plans for "Chatto Neighbors", so we need to figure out how we can cut this so there's no more conflict**
+		- [ ] Only connect websocket to the currently active instance; periodically poll other instances
+	- **Server Sidebar Refresh**
+		- [ ] Context menu (right click/long-tap)
+			- [ ] Server Version (with warning icon if incompatible?)
+			- [ ] Leave Server
+	- **Room Sidebar Refresh**
+		- [ ] Have a tabbed interface, where members, calls and files can be visible at the same time (expanding/collapsing sections)
+		- [ ] Rework room members
+			- [ ] It doesn't need to _immediately_ update; in busy rooms, this will currently lead to a lot of movement in the sidebar. Maybe we can pull 15s deltas?
+			- [ ] Universal rooms! Maybe this will also be easier with the 15s deltas.
+	- **Notifications Refresh**
+		- [ ] Allow user to configure that notifications don't include message and/or user name
+		- [ ] Don't delete notifications as soon as they are dismissed; keep old notifications, but mark them as "read"/handled, and allow the user to manually delete them.
+		- [ ] Make sure notifications never play a sound/actively ping the user if the user is currently viewing the location where the notification originated. (This is currently a bug)
+		- [ ] Notifications for received emoji reactions. Ideally these are buffered in some fashion - the user will not want to receive 100 notifications because 100 users posted a reaction under one of their messages.
+		- [ ] Notification when someone starts a call in a room you're in
+	- **Threading Refresh**
+		- [ ] URL so we can link to a thread (*with the thread open* -- this is currently not possible)
+		- [ ] Thread pane opens to the side, viewport size allowing
+		- [ ] Allow the OP of a root message to explicitly open a thread
+		- [ ] With a thread open, replying to that message will automatically happen inside the thread
+		- [ ] Maybe even existing replies will be pulled into the thread (this can happen in the projections)
+			- Side note/brain fart: we don't really need the thread structure for persistence anymore, since now the read model entirely lives in projections. Cool!
+		- [ ] Authors can move their message into another thread
+			- [ ] If the message itself is a thread root, it'll merge the threads
+			- [ ] a one-time operation per message, or on a cooldown per message
+- **Chatto Neighbors**
+	- [ ] Significant upgrade to server discovery/add server screen
+		- [ ] With hints on how to set up your own server
+	- [ ] Any remote server added initiates a handshake with the origin server to establish a verified connection
+	- [ ] Server admins can view known remote servers and either "trust" or "block" them
+	- [ ] Orthogonally to that, remote servers can be placed into the origin server's directory, where they will be advertised prominently (eg. in "Add Server", or in the leftmost sidebar)
+	- [ ] Origin server provides a push notification gateway for connected remote servers
+- **Search**
+	- [ ] A first iteration, local, Bleve
+	- `in:#testing from:freakynit "bot" AND "awesome"`
+- **Safety Features**
+	- [ ] Slow Mode
+	- [ ] Suspend User (already have a PR)
+	- Moderation
+		- [ ] Report Message
+		- [ ] Moderation Dashboard
+		- [ ] Moderation Log (part of the event log)
+- [ ] **Sign in with AT Proto?**
+	- For visibility
+	- But also it's a good external verification factor
+- **Performance Pass**
+	- [ ] proper pprof profiling to get a better idea of where we can optimize
+- **Configuration Pass**
+	- [ ] Review config structure for sanity and scalability/maintainability
+	- [ ] Review the ENV variables are named as expected
+- **Operations Goodies**
+	- [ ] Seeding system: a separate file that contains definitions for users, rooms, permissions that Chatto can seed idempotently


### PR DESCRIPTION
## Why

Keep the planned Chatto 0.5 work visible in the repository as a shared, agent-readable checklist.

## What changed

- Added `docs/TODO-0-5.md` with the current release ideas expressed as trackable tasks.
- Updated `AGENTS.md` to point agents at the GitHub milestone and local roadmap, and to prevent unsolicited additions.

## Test plan

- `git diff --check origin/main...HEAD` — passed.
- `mise x uv@latest -- uvx --with charset-normalizer reuse lint` — passed; this supplies the encoding extra missing from the local `mise license-check` wrapper environment.
