### PR TITLE
perf(frontend): speed up Paraglide compilation

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -8,7 +8,7 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
-    "paraglide": "paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide --strategy localStorage preferredLanguage baseLocale --emit-ts-declarations --output-structure locale-modules --silent && node scripts/generate-i18n-facade.mjs",
+    "paraglide": "paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide --strategy localStorage preferredLanguage baseLocale --no-emit-ts-declarations --output-structure locale-modules --silent && node scripts/generate-i18n-facade.mjs",
     "prepare": "svelte-kit sync || echo ''",
     "check": "pnpm run check:design-system && pnpm run paraglide && svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:design-system": "node scripts/check-design-system.mjs",

--- a/apps/frontend/scripts/generate-i18n-facade.mjs
+++ b/apps/frontend/scripts/generate-i18n-facade.mjs
@@ -5,17 +5,30 @@ const settingsUrl = new URL('./project.inlang/settings.json', root);
 const settings = JSON.parse(readFileSync(settingsUrl, 'utf8'));
 const baseLocale = settings.baseLocale;
 const locales = settings.locales;
-const baseTypesUrl = new URL(`./src/lib/paraglide/messages/${baseLocale}.d.ts`, root);
+const baseMessagesUrl = new URL(`./src/lib/paraglide/messages/${baseLocale}.js`, root);
 const messageIndexUrl = new URL('./src/lib/paraglide/messages/_index.js', root);
 const outputUrl = new URL('./src/lib/i18n/messages.ts', root);
+
+function writeIfChanged(url, contents) {
+  try {
+    if (readFileSync(url, 'utf8') === contents) return;
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error;
+  }
+
+  writeFileSync(url, contents);
+}
 
 if (typeof baseLocale !== 'string' || !Array.isArray(locales) || !locales.includes(baseLocale)) {
   throw new Error('project.inlang/settings.json must define a baseLocale included in locales');
 }
 
-const source = readFileSync(baseTypesUrl, 'utf8');
+// Paraglide's generated JavaScript already contains complete JSDoc types. Reading
+// those avoids asking TypeScript to emit a duplicate declaration tree, which is
+// substantially more expensive for Chatto's large locale catalog.
+const source = readFileSync(baseMessagesUrl, 'utf8');
 const messageIndex = readFileSync(messageIndexUrl, 'utf8');
-const functionNames = [...source.matchAll(/^export const ([A-Za-z0-9_]+):/gm)].map(
+const functionNames = [...source.matchAll(/^export const ([A-Za-z0-9_]+) =/gm)].map(
   ([, name]) => name
 );
 const aliases = new Map(
@@ -26,15 +39,36 @@ const aliases = new Map(
 
 if (functionNames.length === 0) {
   throw new Error(
-    `No Paraglide message functions found in src/lib/paraglide/messages/${baseLocale}.d.ts`
+    `No Paraglide message functions found in src/lib/paraglide/messages/${baseLocale}.js`
   );
 }
 
 const typeNames = new Map(
-  [...source.matchAll(/^export type ([A-Za-z0-9_]+Inputs) = ([\s\S]*?);\n/gm)].map(
-    ([, typeName, body]) => [typeName, body.trim()]
+  [...source.matchAll(/^\/\*\* @typedef \{(.*)} ([A-Za-z0-9_]+Inputs) \*\/$/gm)].map(
+    ([, body, typeName]) => [typeName, body.trim()]
   )
 );
+
+const declarationLines = [
+  'export type LocalizedString = import("../runtime.js").LocalizedString;',
+  ...[...typeNames].map(([typeName, body]) => `export type ${typeName} = ${body};`),
+  ...functionNames.map((functionName) => {
+    const inputsName = inputTypeName(functionName);
+    return `export const ${functionName}: (inputs: ${inputsName}) => LocalizedString;`;
+  })
+];
+
+for (const locale of locales) {
+  writeIfChanged(
+    new URL(`./src/lib/paraglide/messages/${locale}.d.ts`, root),
+    `${declarationLines.join('\n')}\n`
+  );
+}
+
+// The app deliberately avoids Paraglide's eager all-locale index. An adjacent
+// declaration keeps TypeScript from parsing its generated message previews as
+// JSDoc (where literal strings such as "@{login}" look like malformed tags).
+writeIfChanged(new URL('./src/lib/paraglide/messages/_index.d.ts', root), 'export {};\n');
 
 function inputTypeName(functionName) {
   return `${functionName
@@ -112,7 +146,11 @@ const lines = [
 for (const functionName of functionNames) {
   const constName = `msg_${functionName}`;
   const inputsName = inputTypeName(functionName);
-  const isEmpty = typeNames.get(inputsName) === '{}';
+  const inputType = typeNames.get(inputsName);
+  if (inputType === undefined) {
+    throw new Error(`No generated Paraglide input type found for ${functionName}`);
+  }
+  const isEmpty = inputType === '{}';
 
   if (isEmpty) {
     lines.push(`const ${constName} = (): LocalizedString => messages().${functionName}(empty());`);
@@ -133,4 +171,4 @@ for (const functionName of functionNames) {
   lines.push(`export { msg_${functionName} as '${alias}' };`);
 }
 
-writeFileSync(outputUrl, `${lines.join('\n')}\n`);
+writeIfChanged(outputUrl, `${lines.join('\n')}\n`);

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -1,6 +1,8 @@
 /// <reference types="vitest/config" />
+import { execFile } from 'node:child_process';
 import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
 import devtoolsJson from 'vite-plugin-devtools-json';
 import tailwindcss from '@tailwindcss/vite';
 import { paraglideVitePlugin } from '@inlang/paraglide-js';
@@ -17,6 +19,7 @@ const backendTarget =
 const tiptapDeps = ['@tiptap/pm/state'];
 const highlightLanguageMetadataModule = 'virtual:chatto-highlight-language-metadata';
 const resolvedHighlightLanguageMetadataModule = `\0${highlightLanguageMetadataModule}`;
+const execFileAsync = promisify(execFile);
 const i18nSettings = JSON.parse(
   readFileSync(new URL('./project.inlang/settings.json', import.meta.url), 'utf8')
 ) as { baseLocale: string };
@@ -120,6 +123,21 @@ function highlightLanguageMetadata(): Plugin {
   };
 }
 
+function i18nFacade(): Plugin {
+  return {
+    name: 'chatto-i18n-facade',
+    buildStart: {
+      order: 'post',
+      sequential: true,
+      async handler() {
+        await execFileAsync(process.execPath, [
+          fileURLToPath(new URL('./scripts/generate-i18n-facade.mjs', import.meta.url))
+        ]);
+      }
+    }
+  };
+}
+
 export default defineConfig({
   clearScreen: false,
   plugins: [
@@ -129,9 +147,10 @@ export default defineConfig({
       project: './project.inlang',
       outdir: './src/lib/paraglide',
       strategy: ['localStorage', 'preferredLanguage', 'baseLocale'],
-      emitTsDeclarations: true,
+      emitTsDeclarations: false,
       outputStructure: 'locale-modules'
     }),
+    i18nFacade(),
     sveltekit(),
     devtoolsJson()
   ],


### PR DESCRIPTION
## Why

Paraglide compilation took about 14.5 seconds and 1.23 GB of peak memory because it ran TypeScript declaration emission across the generated locale catalog.

## What changed

- Disable Paraglide's expensive declaration emitter and derive equivalent lightweight message declarations from its generated JSDoc types.
- Generate the typed i18n facade after Paraglide in Vite, avoid unchanged writes, and fail when expected message input types are absent.
- This reduces the measured compile to about 4.0 seconds and 425 MB peak memory without changing runtime messages, locale validation, or fallback behaviour.

## Test plan

- [x] `mise x -- pnpm --dir apps/frontend exec prettier --check package.json vite.config.ts scripts/generate-i18n-facade.mjs`
- [x] `mise x -- pnpm --dir apps/frontend run check` — 0 errors and 0 warnings
- [x] `mise x -- pnpm --dir apps/frontend run build`
