### PR TITLE
fix(frontend): add notifications return navigation

### DIFF
--- a/apps/frontend/e2e/notifications.test.ts
+++ b/apps/frontend/e2e/notifications.test.ts
@@ -523,6 +523,41 @@ test.describe('Notification Dismissal', () => {
 });
 
 test.describe('Navigation from Notifications', () => {
+  test('returns to the originating room with browser back and the header arrow', async ({
+    page,
+    chatPage,
+    notificationsPage
+  }) => {
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.enterRoom('announcements');
+    const originatingRoomUrl = page.url();
+
+    await notificationsPage.goto();
+    await page.goBack();
+    await expect(page).toHaveURL(originatingRoomUrl);
+
+    await notificationsPage.goto();
+    await notificationsPage.backButton.click();
+    await expect(page).toHaveURL(originatingRoomUrl);
+  });
+
+  test('returns to the last room from a direct notifications entry', async ({
+    page,
+    chatPage,
+    notificationsPage
+  }) => {
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.enterRoom('announcements');
+    const lastRoomUrl = page.url();
+
+    await notificationsPage.gotoDirectly();
+    await notificationsPage.backButton.click();
+
+    await expect(page).toHaveURL(lastRoomUrl);
+  });
+
   test('clicking mention notification navigates to the room', async ({
     page,
     chatPage,

--- a/apps/frontend/e2e/pages/NotificationsPage.ts
+++ b/apps/frontend/e2e/pages/NotificationsPage.ts
@@ -29,6 +29,11 @@ export class NotificationsPage {
     return this.page.getByRole('heading', { name: 'Notifications' });
   }
 
+  /** Return to the chat view that opened the notifications page. */
+  get backButton(): Locator {
+    return this.page.getByRole('button', { name: 'Back to chat' });
+  }
+
   /** The "Clear all" button */
   get clearAllButton(): Locator {
     return this.page.getByRole('button', { name: 'Clear all' });

--- a/apps/frontend/messages/de/chat.json
+++ b/apps/frontend/messages/de/chat.json
@@ -4,6 +4,7 @@
     "notifications": {
       "title": "Benachrichtigungen",
       "subtitle": "Das ist neu",
+      "back_to_chat": "Zurück zum Chat",
       "clear_all": "Alle löschen",
       "empty_title": "Keine Benachrichtigungen",
       "empty_body": "Du bist auf dem neuesten Stand!",

--- a/apps/frontend/messages/en/chat.json
+++ b/apps/frontend/messages/en/chat.json
@@ -4,6 +4,7 @@
     "notifications": {
       "title": "Notifications",
       "subtitle": "Here's what's new",
+      "back_to_chat": "Back to chat",
       "clear_all": "Clear all",
       "empty_title": "No notifications",
       "empty_body": "You're all caught up!",

--- a/apps/frontend/src/lib/i18n/messages.ts
+++ b/apps/frontend/src/lib/i18n/messages.ts
@@ -499,6 +499,7 @@ const msg_error_page_missing_media_title = (): LocalizedString => messages().err
 const msg_error_page_missing_media_description = (): LocalizedString => messages().error_page_missing_media_description(empty());
 const msg_chat_notifications_title = (): LocalizedString => messages().chat_notifications_title(empty());
 const msg_chat_notifications_subtitle = (): LocalizedString => messages().chat_notifications_subtitle(empty());
+const msg_chat_notifications_back_to_chat = (): LocalizedString => messages().chat_notifications_back_to_chat(empty());
 const msg_chat_notifications_clear_all = (): LocalizedString => messages().chat_notifications_clear_all(empty());
 const msg_chat_notifications_empty_title = (): LocalizedString => messages().chat_notifications_empty_title(empty());
 const msg_chat_notifications_empty_body = (): LocalizedString => messages().chat_notifications_empty_body(empty());
@@ -1902,6 +1903,7 @@ export { msg_error_page_missing_media_title as 'error_page.missing_media_title' 
 export { msg_error_page_missing_media_description as 'error_page.missing_media_description' };
 export { msg_chat_notifications_title as 'chat.notifications.title' };
 export { msg_chat_notifications_subtitle as 'chat.notifications.subtitle' };
+export { msg_chat_notifications_back_to_chat as 'chat.notifications.back_to_chat' };
 export { msg_chat_notifications_clear_all as 'chat.notifications.clear_all' };
 export { msg_chat_notifications_empty_title as 'chat.notifications.empty_title' };
 export { msg_chat_notifications_empty_body as 'chat.notifications.empty_body' };

--- a/apps/frontend/src/routes/chat/notifications/+page.svelte
+++ b/apps/frontend/src/routes/chat/notifications/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
+  import { afterNavigate, goto } from '$app/navigation';
+  import { resolve } from '$app/paths';
   import { PaneHeader, EmptyState } from '$lib/ui';
   import { Button } from '$lib/ui/form';
   import * as m from '$lib/i18n/messages';
@@ -17,6 +18,25 @@
   const userSettings = getUserSettings();
   const activeLocale = $derived(getLocale());
   const appUi = getAppUiState();
+  let canReturnThroughHistory = false;
+
+  afterNavigate(({ from, type }) => {
+    canReturnThroughHistory =
+      type !== 'enter' &&
+      from !== null &&
+      from.url.origin === window.location.origin &&
+      (from.route.id === '/chat' || from.route.id?.startsWith('/chat/') === true) &&
+      from.route.id !== '/chat/notifications';
+  });
+
+  function handleBack() {
+    if (canReturnThroughHistory) {
+      history.back();
+      return;
+    }
+
+    void goto(resolve('/chat'), { replaceState: true });
+  }
 
   // Collect notification stores from all authenticated instances
   type ServerNotification = {
@@ -151,6 +171,8 @@
   <PaneHeader
     title={m['chat.notifications.title']()}
     subtitle={m['chat.notifications.subtitle']()}
+    onBack={handleBack}
+    backLabel={m['chat.notifications.back_to_chat']()}
     showMobileNav
   >
     {#snippet actions()}

--- a/apps/frontend/src/routes/chat/notifications/notifications.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/notifications/notifications.page.svelte.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { q } from '$lib/test-utils';
 import { loadLocaleMessages } from '$lib/i18n/messages';
@@ -6,6 +6,7 @@ import { setReactiveLocale } from '$lib/i18n/state.svelte';
 
 const { mocks } = vi.hoisted(() => ({
   mocks: {
+    afterNavigate: vi.fn(),
     goto: vi.fn(),
     appUi: {
       disableRoomCallWideFor: vi.fn()
@@ -47,6 +48,7 @@ const { mocks } = vi.hoisted(() => ({
 }));
 
 vi.mock('$app/navigation', () => ({
+  afterNavigate: mocks.afterNavigate,
   goto: mocks.goto,
   pushState: vi.fn(),
   replaceState: vi.fn()
@@ -70,6 +72,10 @@ vi.mock('$lib/state/userSettings.svelte', () => ({
 import NotificationsPage from './+page.svelte';
 
 describe('notifications page', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   beforeEach(async () => {
     vi.clearAllMocks();
     await loadLocaleMessages('en');
@@ -102,5 +108,42 @@ describe('notifications page', () => {
       expect(mocks.store.notifications.dismiss).toHaveBeenCalledWith('mention-1');
       expect(mocks.goto).toHaveBeenCalledWith('/chat/-/room-1/thread-1');
     });
+  });
+
+  it('renders an accessible back button and returns through history for in-app navigation', async () => {
+    const historyBack = vi.spyOn(history, 'back').mockImplementation(() => {});
+    const { container } = render(NotificationsPage);
+
+    const callback = mocks.afterNavigate.mock.calls.at(-1)?.[0];
+    if (!callback) throw new Error('afterNavigate callback was not registered');
+    callback({
+      type: 'link',
+      from: {
+        url: new URL('/chat/-/room-1', window.location.origin),
+        route: { id: '/chat/[serverId]/[roomId]' }
+      }
+    });
+
+    const backButton = q(container, 'button[aria-label="Back to chat"]') as HTMLButtonElement;
+    await expect.element(backButton).toBeInTheDocument();
+    backButton.click();
+
+    expect(historyBack).toHaveBeenCalledOnce();
+    expect(mocks.goto).not.toHaveBeenCalled();
+  });
+
+  it('returns to chat with replacement after a direct page entry', async () => {
+    const historyBack = vi.spyOn(history, 'back').mockImplementation(() => {});
+    const { container } = render(NotificationsPage);
+
+    const callback = mocks.afterNavigate.mock.calls.at(-1)?.[0];
+    if (!callback) throw new Error('afterNavigate callback was not registered');
+    callback({ type: 'enter', from: null });
+
+    const backButton = q(container, 'button[aria-label="Back to chat"]') as HTMLButtonElement;
+    backButton.click();
+
+    expect(historyBack).not.toHaveBeenCalled();
+    expect(mocks.goto).toHaveBeenCalledWith('/chat', { replaceState: true });
   });
 });


### PR DESCRIPTION
## Summary

Adds an accessible back arrow to the notifications page so users can return to the chat view that opened it.
Uses browser history for in-app navigation and falls back to the last chat position after direct entry.
Includes English and German labels plus component and end-to-end navigation coverage.

## Verification

- `pnpm exec vitest run src/routes/chat/notifications/notifications.page.svelte.spec.ts`
- `pnpm run check`
- `pnpm exec playwright test e2e/notifications.test.ts --grep 'returns to' --retries=0`
