### PR TITLE
fix(core): retry link previews across validated IPs

### DIFF
--- a/cli/internal/core/linkpreview/ssrf.go
+++ b/cli/internal/core/linkpreview/ssrf.go
@@ -2,6 +2,7 @@ package linkpreview
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -39,6 +40,10 @@ func init() {
 // built with the test_endpoints build tag.
 var allowLocalhost bool
 
+type ipResolver interface {
+	LookupIP(context.Context, string, string) ([]net.IP, error)
+}
+
 // isPrivateIP checks if an IP address is in a private/reserved range.
 func isPrivateIP(ip net.IP) bool {
 	if ip.IsLoopback() {
@@ -61,6 +66,10 @@ func isPrivateIP(ip net.IP) bool {
 // This prevents DNS rebinding attacks by checking the IP at connection time
 // (not in a separate pre-check that could be subject to TOCTOU races).
 func ssrfSafeDialContext(timeout time.Duration) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return ssrfSafeDialContextWithResolver(timeout, net.DefaultResolver)
+}
+
+func ssrfSafeDialContextWithResolver(timeout time.Duration, resolver ipResolver) func(ctx context.Context, network, addr string) (net.Conn, error) {
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
 		host, port, err := net.SplitHostPort(addr)
 		if err != nil {
@@ -75,9 +84,12 @@ func ssrfSafeDialContext(timeout time.Duration) func(ctx context.Context, networ
 		resolveCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
 
-		ips, err := net.DefaultResolver.LookupIP(resolveCtx, "ip", host)
+		ips, err := resolver.LookupIP(resolveCtx, "ip", host)
 		if err != nil {
 			return nil, fmt.Errorf("ssrf: failed to resolve hostname %s: %w", host, err)
+		}
+		if len(ips) == 0 {
+			return nil, fmt.Errorf("ssrf: hostname %s resolved to no addresses", host)
 		}
 
 		// Check all resolved IPs against the blocklist
@@ -87,12 +99,26 @@ func ssrfSafeDialContext(timeout time.Duration) func(ctx context.Context, networ
 			}
 		}
 
-		// Connect to the first validated IP directly, preventing any second DNS lookup
-		dialer := &net.Dialer{
-			Timeout:   timeout,
-			KeepAlive: 30 * time.Second,
+		// Connect to the already-validated addresses directly, preventing a second
+		// DNS lookup while still falling back when the first family is unreachable
+		// (for example, an IPv6-first result on an IPv4-only host).
+		attemptTimeout := timeout
+		if len(ips) > 1 {
+			attemptTimeout = min(timeout/2, 2*time.Second)
 		}
-		return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].String(), port))
+		var dialErrors []error
+		for _, ip := range ips {
+			dialer := &net.Dialer{
+				Timeout:   attemptTimeout,
+				KeepAlive: 30 * time.Second,
+			}
+			conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+			if err == nil {
+				return conn, nil
+			}
+			dialErrors = append(dialErrors, fmt.Errorf("%s: %w", ip, err))
+		}
+		return nil, fmt.Errorf("ssrf: failed to connect to %s: %w", host, errors.Join(dialErrors...))
 	}
 }
 

--- a/cli/internal/core/linkpreview/ssrf_test.go
+++ b/cli/internal/core/linkpreview/ssrf_test.go
@@ -1,11 +1,22 @@
 package linkpreview
 
 import (
+	"context"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type staticIPResolver struct {
+	ips []net.IP
+}
+
+func (r staticIPResolver) LookupIP(context.Context, string, string) ([]net.IP, error) {
+	return r.ips, nil
+}
 
 func TestIsPrivateIP(t *testing.T) {
 	// Ensure allowLocalhost is false for this test (may be true under test_endpoints tag)
@@ -74,4 +85,47 @@ func TestAllowLocalhost(t *testing.T) {
 
 	// Other private IPs remain blocked regardless
 	assert.True(t, isPrivateIP(private), "RFC1918 should still be blocked with allowLocalhost")
+}
+
+func TestSSRFSafeDialFallsBackAcrossValidatedAddresses(t *testing.T) {
+	orig := allowLocalhost
+	allowLocalhost = true
+	defer func() { allowLocalhost = orig }()
+
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr == nil {
+			_ = conn.Close()
+		}
+	}()
+
+	_, port, err := net.SplitHostPort(listener.Addr().String())
+	require.NoError(t, err)
+	dial := ssrfSafeDialContextWithResolver(time.Second, staticIPResolver{ips: []net.IP{
+		net.ParseIP("::1"),
+		net.ParseIP("127.0.0.1"),
+	}})
+
+	conn, err := dial(context.Background(), "tcp", net.JoinHostPort("preview.example", port))
+	require.NoError(t, err)
+	if conn != nil {
+		_ = conn.Close()
+	}
+}
+
+func TestSSRFSafeDialRejectsAllResultsWhenAnyAddressIsPrivate(t *testing.T) {
+	orig := allowLocalhost
+	allowLocalhost = false
+	defer func() { allowLocalhost = orig }()
+
+	dial := ssrfSafeDialContextWithResolver(time.Second, staticIPResolver{ips: []net.IP{
+		net.ParseIP("93.184.216.34"),
+		net.ParseIP("127.0.0.1"),
+	}})
+
+	_, err := dial(context.Background(), "tcp", "preview.example:443")
+	assert.ErrorContains(t, err, "resolves to private IP")
 }

--- a/cli/internal/core/linkpreview/ssrf_test.go
+++ b/cli/internal/core/linkpreview/ssrf_test.go
@@ -129,3 +129,10 @@ func TestSSRFSafeDialRejectsAllResultsWhenAnyAddressIsPrivate(t *testing.T) {
 	_, err := dial(context.Background(), "tcp", "preview.example:443")
 	assert.ErrorContains(t, err, "resolves to private IP")
 }
+
+func TestSSRFSafeDialRejectsEmptyDNSResults(t *testing.T) {
+	dial := ssrfSafeDialContextWithResolver(time.Second, staticIPResolver{})
+
+	_, err := dial(context.Background(), "tcp", "preview.example:443")
+	assert.ErrorContains(t, err, "resolved to no addresses")
+}


### PR DESCRIPTION
## What changed

- retry link-preview connections across all already-validated DNS addresses
- preserve the existing SSRF rule that rejects the entire lookup when any resolved address is private
- keep connections pinned to literal validated addresses, without a second DNS lookup
- add deterministic coverage for IPv6-first fallback and mixed public/private rejection

## Why

The SSRF-safe dialer validated every DNS result but connected only to the first address. Dual-stack sites that returned IPv6 first could therefore fail on an IPv4-only Chatto host even though a reachable IPv4 address was available. This affected ordinary Open Graph previews, including pages hosted on Chatto's dual-stack infrastructure.

## Impact

Link previews now fall back between validated address families while retaining the existing DNS-rebinding and private-address protections. This focused fix does not include social-post previews, protobuf changes, cache migrations, or frontend changes.

## Validation

- `mise x -- go test ./internal/core/linkpreview`
- `mise x -- go vet ./internal/core/linkpreview`
- `mise test-cli`
- `git diff --check`
