### PR TITLE
feat(calls): share browser tab audio

### DIFF
--- a/apps/docs-website/src/content/docs/guides/infrastructure/voice-calls.mdx
+++ b/apps/docs-website/src/content/docs/guides/infrastructure/voice-calls.mdx
@@ -16,7 +16,9 @@ LiveKit runs as a **separate service** alongside Chatto. Chatto handles authenti
 3. The user's browser connects directly to the LiveKit server using the token and a per-call E2EE key from Chatto.
 4. Other room members see active call indicators update in real time.
 
-Calls are **implicit** — there's no "start call" action. The first person to join creates the call and a fresh E2EE key; when the last person leaves, the call ends and Chatto shreds that key.
+The first person to select **Start call** and join creates the call and a fresh E2EE key. When the last person leaves, the call ends and Chatto shreds that key.
+
+Screen sharing can include audio from a browser tab when the browser supports it. In Chrome, select a browser tab and enable **Share tab audio** in the browser picker. Chatto does not request whole-system audio because that could capture remote call playback and feed it back into the room.
 
 Chatto records call start/join/leave/end facts durably and reconciles active participants against LiveKit webhooks, so call indicators recover after server restarts. These call facts update the active call UI without appearing as room timeline messages. LiveKit media is end-to-end encrypted by current Chatto clients; older clients that do not support this call encryption cannot decode encrypted media.
 

--- a/apps/frontend/src/lib/state/server/voiceCall.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/voiceCall.svelte.spec.ts
@@ -190,7 +190,12 @@ vi.mock('livekit-client', () => {
     },
     Track: {
       Kind: { Audio: 'audio' },
-      Source: { Microphone: 'microphone', Camera: 'camera', ScreenShare: 'screen_share' }
+      Source: {
+        Microphone: 'microphone',
+        Camera: 'camera',
+        ScreenShare: 'screen_share',
+        ScreenShareAudio: 'screen_share_audio'
+      }
     },
     AudioPresets: {
       speech: { maxBitrate: 24_000 },
@@ -786,9 +791,23 @@ describe('VoiceCallState', () => {
   });
 
   it('attaches and detaches subscribed screen-share audio', async () => {
+    const setVolume = vi.fn();
+    mockRemoteParticipants.set('remote-user', {
+      identity: 'remote-user',
+      name: 'Remote User',
+      metadata: '',
+      connectionQuality: 'good',
+      isSpeaking: false,
+      audioLevel: 0,
+      setVolume,
+      trackPublications: new Map(),
+      getTrackPublications: vi.fn(() => [{ isMuted: false, track: { source: 'microphone' } }])
+    });
     const client = createVoiceCallClient();
     const state = new VoiceCallState(client);
     await state.join('wss://livekit.example.test', 'R1');
+    state.toggleParticipantLocalMute('remote-user');
+    setVolume.mockClear();
     const screenShareAudio = {
       kind: 'audio',
       source: 'screen_share_audio',
@@ -799,6 +818,8 @@ describe('VoiceCallState', () => {
     roomEventHandlers.get('TrackSubscribed')?.(screenShareAudio, {});
 
     expect(screenShareAudio.attach).toHaveBeenCalledOnce();
+    expect(setVolume).toHaveBeenCalledWith(0, 'microphone');
+    expect(setVolume).toHaveBeenCalledWith(0, 'screen_share_audio');
 
     roomEventHandlers.get('TrackUnsubscribed')?.(screenShareAudio, {});
 
@@ -827,7 +848,8 @@ describe('VoiceCallState', () => {
     state.toggleParticipantLocalMute('remote-user');
 
     expect(state.isParticipantLocallyMuted('remote-user')).toBe(true);
-    expect(setVolume).toHaveBeenLastCalledWith(0);
+    expect(setVolume).toHaveBeenCalledWith(0, 'microphone');
+    expect(setVolume).toHaveBeenCalledWith(0, 'screen_share_audio');
     expect(state.participants.find((p) => p.identity === 'remote-user')).toMatchObject({
       isLocallyMuted: true
     });
@@ -835,7 +857,8 @@ describe('VoiceCallState', () => {
     state.toggleParticipantLocalMute('remote-user');
 
     expect(state.isParticipantLocallyMuted('remote-user')).toBe(false);
-    expect(setVolume).toHaveBeenLastCalledWith(1);
+    expect(setVolume).toHaveBeenCalledWith(1, 'microphone');
+    expect(setVolume).toHaveBeenCalledWith(1, 'screen_share_audio');
 
     state.toggleParticipantLocalMute('local-user');
     expect(state.isParticipantLocallyMuted('local-user')).toBe(false);

--- a/apps/frontend/src/lib/state/server/voiceCall.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/voiceCall.svelte.spec.ts
@@ -192,7 +192,10 @@ vi.mock('livekit-client', () => {
       Kind: { Audio: 'audio' },
       Source: { Microphone: 'microphone', Camera: 'camera', ScreenShare: 'screen_share' }
     },
-    AudioPresets: { speech: {} },
+    AudioPresets: {
+      speech: { maxBitrate: 24_000 },
+      musicStereo: { maxBitrate: 64_000 }
+    },
     VideoPresets: { h720: { resolution: {} } }
   };
 });
@@ -486,14 +489,26 @@ describe('VoiceCallState', () => {
     expect(state.matchesActiveCall('R1', null)).toBe(false);
   });
 
-  it('toggles video-only screen sharing through LiveKit', async () => {
+  it('toggles screen sharing with browser-tab audio through LiveKit', async () => {
     const client = createVoiceCallClient();
     const state = new VoiceCallState(client);
     await state.join('wss://livekit.example.test', 'R1');
 
     await state.toggleScreenShare();
 
-    expect(lastRoom?.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(true);
+    expect(lastRoom?.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(
+      true,
+      {
+        audio: true,
+        systemAudio: 'exclude'
+      },
+      {
+        audioPreset: { maxBitrate: 64_000 },
+        forceStereo: true,
+        dtx: false,
+        red: false
+      }
+    );
     expect(state.isScreenShareEnabled).toBe(true);
     expect(state.participants[0]).toMatchObject({
       identity: 'local-user',
@@ -505,7 +520,11 @@ describe('VoiceCallState', () => {
 
     await state.toggleScreenShare();
 
-    expect(lastRoom?.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(false);
+    expect(lastRoom?.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(
+      false,
+      undefined,
+      undefined
+    );
     expect(state.isScreenShareEnabled).toBe(false);
     expect(state.participants[0].screenShareTrack).toBeNull();
   });
@@ -581,7 +600,19 @@ describe('VoiceCallState', () => {
 
     expect(state.isScreenSharePending).toBe(true);
     expect(state.isScreenShareEnabled).toBe(false);
-    expect(lastRoom?.localParticipant.setScreenShareEnabled).toHaveBeenLastCalledWith(true);
+    expect(lastRoom?.localParticipant.setScreenShareEnabled).toHaveBeenLastCalledWith(
+      true,
+      {
+        audio: true,
+        systemAudio: 'exclude'
+      },
+      {
+        audioPreset: { maxBitrate: 64_000 },
+        forceStereo: true,
+        dtx: false,
+        red: false
+      }
+    );
 
     screenShareGate.resolve();
     await toggle;
@@ -598,7 +629,19 @@ describe('VoiceCallState', () => {
 
     await state.toggleScreenShare();
 
-    expect(lastRoom?.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(true);
+    expect(lastRoom?.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(
+      true,
+      {
+        audio: true,
+        systemAudio: 'exclude'
+      },
+      {
+        audioPreset: { maxBitrate: 64_000 },
+        forceStereo: true,
+        dtx: false,
+        red: false
+      }
+    );
     expect(state.isScreenShareEnabled).toBe(false);
     expect(state.isInAnyCall).toBe(true);
     expect(state.roomId).toBe('R1');
@@ -740,6 +783,26 @@ describe('VoiceCallState', () => {
 
     expect(state.isScreenShareEnabled).toBe(false);
     expect(state.participants[0].screenShareTrack).toBeNull();
+  });
+
+  it('attaches and detaches subscribed screen-share audio', async () => {
+    const client = createVoiceCallClient();
+    const state = new VoiceCallState(client);
+    await state.join('wss://livekit.example.test', 'R1');
+    const screenShareAudio = {
+      kind: 'audio',
+      source: 'screen_share_audio',
+      attach: vi.fn(),
+      detach: vi.fn()
+    };
+
+    roomEventHandlers.get('TrackSubscribed')?.(screenShareAudio, {});
+
+    expect(screenShareAudio.attach).toHaveBeenCalledOnce();
+
+    roomEventHandlers.get('TrackUnsubscribed')?.(screenShareAudio, {});
+
+    expect(screenShareAudio.detach).toHaveBeenCalledOnce();
   });
 
   it('locally mutes and unmutes remote participant audio for the current session only', async () => {

--- a/apps/frontend/src/lib/state/server/voiceCall.svelte.ts
+++ b/apps/frontend/src/lib/state/server/voiceCall.svelte.ts
@@ -891,7 +891,9 @@ export class VoiceCallState {
   }
 
   private applyRemoteParticipantAudioVolume(participant: RemoteParticipant): void {
-    participant.setVolume(this.isParticipantLocallyMuted(participant.identity) ? 0 : 1);
+    const volume = this.isParticipantLocallyMuted(participant.identity) ? 0 : 1;
+    participant.setVolume(volume, Track.Source.Microphone);
+    participant.setVolume(volume, Track.Source.ScreenShareAudio);
   }
 
   /**

--- a/apps/frontend/src/lib/state/server/voiceCall.svelte.ts
+++ b/apps/frontend/src/lib/state/server/voiceCall.svelte.ts
@@ -632,7 +632,25 @@ export class VoiceCallState {
     const newEnabled = !this.isScreenShareEnabled;
     try {
       await this.runExplicitMediaDeviceOperation(() =>
-        room.localParticipant.setScreenShareEnabled(newEnabled)
+        room.localParticipant.setScreenShareEnabled(
+          newEnabled,
+          newEnabled
+            ? {
+                audio: true,
+                // Tab audio is useful shared media; whole-system audio can feed
+                // remote call playback back into the room.
+                systemAudio: 'exclude'
+              }
+            : undefined,
+          newEnabled
+            ? {
+                audioPreset: AudioPresets.musicStereo,
+                forceStereo: true,
+                dtx: false,
+                red: false
+              }
+            : undefined
+        )
       );
       if (this.room !== room) return;
 

--- a/docs/fdr/FDR-016-voice-calls.md
+++ b/docs/fdr/FDR-016-voice-calls.md
@@ -1,11 +1,11 @@
 # FDR-016: Voice Calls
 
 **Status:** Active
-**Last reviewed:** 2026-07-01
+**Last reviewed:** 2026-07-15
 
 ## Overview
 
-Rooms support real-time voice conversations with optional camera video and video-only screen/window/tab sharing. A phone tab in the room sidebar lets members start or join the room call; the call panel shows screen-share tiles first, then video-enabled participant cards, then compact voice-only participant cards, and provides mute, camera, screen-share, device-selection, and hang-up controls. Audio and video are routed through LiveKit (an external WebRTC service); Chatto only handles authorization, participant state, and the UI.
+Rooms support real-time voice conversations with optional camera video and screen/window/tab sharing. Supported browsers can include audio from a shared browser tab. A phone tab in the room sidebar lets members start or join the room call; the call panel shows screen-share tiles first, then video-enabled participant cards, then compact voice-only participant cards, and provides mute, camera, screen-share, device-selection, and hang-up controls. Audio and video are routed through LiveKit (an external WebRTC service); Chatto only handles authorization, participant state, and the UI.
 
 ## Behavior
 
@@ -25,7 +25,7 @@ Rooms support real-time voice conversations with optional camera video and video
 - The first join starts a call session, creates fresh per-call E2EE key material, and records durable call lifecycle facts. The final leave ends the call, records the end fact, and shreds the call key.
 - Hanging up disconnects from LiveKit and clears the participant from everyone else's view.
 - New clients always enable LiveKit E2EE before connecting. Chatto distributes a KMS-backed per-call shared key with the LiveKit join token; the raw key is never written to EVT and is shredded when the call ends.
-- Screen sharing is video-only in Chatto's UI. Browser tab audio sharing is not published by Chatto today.
+- Screen sharing requests browser-tab audio when the browser supports it. In Chrome, the presenter must select a browser tab and enable **Share tab audio** in the browser picker. Chatto excludes whole-system audio so remote call playback is not captured and fed back into the room.
 - Screen-share state is LiveKit track state only. Users who have not joined the call still see who is in the active call, but they do not see whether a participant is sharing a screen.
 - When LiveKit is not configured on the server, all voice UI is hidden — no button, no panel, no indicator.
 
@@ -63,9 +63,9 @@ Rooms support real-time voice conversations with optional camera video and video
 
 ### 6. Screen sharing is joined-client LiveKit track state
 
-**Decision:** Screen/window/tab sharing uses LiveKit's browser screen-share publishing path and is represented only by `Track.Source.ScreenShare` on joined clients. Chatto does not persist separate screen-share events, add public API fields, or expose screen-share state to call observers before they join.
+**Decision:** Screen/window/tab sharing uses LiveKit's browser screen-share publishing path and is represented by screen-share video plus optional browser-provided tab audio on joined clients. Chatto requests tab audio, publishes it with media-oriented stereo settings, and excludes whole-system audio. Chatto does not persist separate screen-share events, add public API fields, or expose screen-share state to call observers before they join.
 **Why:** Screen sharing is media-session state, and the existing durable room facts already answer the server-owned question of who is in the call. Keeping screen-share state inside LiveKit avoids adding durable state that can become stale when browser capture ends.
-**Tradeoff:** Non-joined observers know a call is active and who is in it, but not whether someone is sharing. Browser-tab audio sharing is also out of scope for this version.
+**Tradeoff:** Non-joined observers know a call is active and who is in it, but not whether someone is sharing. Audio capture remains browser- and surface-dependent, and presenters must opt into tab audio in the browser picker.
 
 ### 7. Big-call mode is a desktop pane state, not a separate route
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -25,7 +25,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-013](FDR-013-web-push-notifications.md) | Web Push Notifications | Active | 2026-07-10 |
 | [FDR-014](FDR-014-jump-to-present.md) | Jump to Present | Active | 2026-05-19 |
 | [FDR-015](FDR-015-quick-switcher.md) | Quick Switcher (Cmd-K) | Active | 2026-05-31 |
-| [FDR-016](FDR-016-voice-calls.md) | Voice Calls | Active | 2026-07-01 |
+| [FDR-016](FDR-016-voice-calls.md) | Voice Calls | Active | 2026-07-15 |
 | [FDR-017](FDR-017-room-groups-and-sidebar-layout.md) | Room Groups & Sidebar Layout | Active | 2026-06-18 |
 | [FDR-018](FDR-018-account-lifecycle.md) | Account Lifecycle | Active | 2026-07-13 |
 | [FDR-019](FDR-019-room-lifecycle.md) | Room Lifecycle | Active | 2026-07-15 |


### PR DESCRIPTION
## Why

Chatto started LiveKit screen shares without requesting browser audio, so Chrome users could not include sound from a shared tab. Screen-share audio also needs media-oriented publication settings and must follow the same viewer-local mute behavior as microphone audio.

## What changed

- Requests browser-tab audio when enabling a screen share while excluding whole-system audio to avoid feeding remote call playback back into the room.
- Publishes captured tab audio with LiveKit's stereo music preset, with DTX and RED disabled for continuous shared media.
- Applies viewer-local participant volume to both microphone and screen-share audio sources.
- Adds coverage for enable/disable options, pending and failure paths, subscribed audio attachment, and mute-before-subscribe behavior.
- Updates FDR-016 and the public calls guide with the supported behavior and Chrome picker requirement.

There are no API, persistence, permission, migration, rollout, or operator configuration changes.

## Test plan

- `mise test-frontend` — 257 test files, 2,184 tests passed.
- `mise x -- pnpm --filter chatto-frontend check` — 0 errors and 0 warnings.
- `mise x -- pnpm --dir apps/docs-website build` — 59 pages built successfully.
- `mise x -- npx @sveltejs/mcp svelte-autofixer apps/frontend/src/lib/state/server/voiceCall.svelte.ts --svelte-version 5` — no issues or suggestions.
- `git diff --check` — clean.

Closes #1575.

BEGIN_COMMIT_OVERRIDE
fix(calls): share browser tab audio
END_COMMIT_OVERRIDE