### PR TITLE
fix(core): forbid threads in direct messages

### DIFF
--- a/apps/frontend/e2e/dm.test.ts
+++ b/apps/frontend/e2e/dm.test.ts
@@ -51,10 +51,18 @@ test.describe('Direct Messages (room-shaped)', () => {
       // and the new message renders without a reload.
       const roomA = new RoomPage(page);
       const postedBody = `dm round-trip ${Date.now()}`;
-      await roomA.sendMessage(postedBody);
+      const postedMessage = await roomA.sendMessage(postedBody);
       await expect(page.getByText(postedBody)).toBeVisible({
         timeout: TIMEOUTS.REALTIME_EVENT
       });
+
+      // DMs support flat reply attribution, but threads are a channel-room-only
+      // capability. The server-provided room capability must suppress thread
+      // actions on both desktop and mobile surfaces.
+      await postedMessage.revealHoverToolbar();
+      await expect(postedMessage.hoverToolbar.getByLabel('Reply', { exact: true })).toBeVisible();
+      await expect(postedMessage.hoverToolbar.getByLabel('Reply in thread')).toHaveCount(0);
+      await expect(postedMessage.hoverToolbar.getByLabel('Open thread')).toHaveCount(0);
 
       // Bug #2 (the reload-redirect): on reload the rooms store is briefly
       // unloaded — the layout must wait for it before resolving spaceId,

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionSheet.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionSheet.svelte.spec.ts
@@ -87,6 +87,12 @@ describe('MessageActionSheet', () => {
     expect(actionLabels(container)).toEqual(['Reply in thread', 'Open thread', 'Copy link']);
   });
 
+  it('keeps flat replies while omitting the thread action when threading is unavailable', () => {
+    const { container } = renderSheet({ onReplyInRoom: vi.fn() });
+
+    expect(actionLabels(container)).toEqual(['Reply', 'Copy link']);
+  });
+
   it('closes after invoking sheet actions', async () => {
     const onReplyInRoom = vi.fn();
     const onReply = vi.fn();

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -3376,7 +3376,7 @@ func TestConnectServicesRejectDMOutsiders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateMessage root: %v", err)
 	}
-	reply, err := env.core.PostMessage(env.ctx, core.KindDM, dm.Id, participant.Id, "private reply", nil, root.Id, "", nil, false)
+	reply, err := env.core.PostMessage(env.ctx, core.KindDM, dm.Id, participant.Id, "private reply", nil, "", root.Id, nil, false)
 	if err != nil {
 		t.Fatalf("CreateMessage reply: %v", err)
 	}
@@ -3555,7 +3555,10 @@ func TestRoomDirectoryServiceListRoomsVisibilityAndDMs(t *testing.T) {
 	if !apiRoomPermissionGranted(dmRoom, core.PermRoomList) {
 		t.Fatalf("DM CanListRoom = false, want true")
 	}
-	if apiRoomPermissionGranted(dmRoom, core.PermRoomJoin) || apiRoomPermissionGranted(dmRoom, core.PermRoomManage) || apiRoomPermissionGranted(dmRoom, core.PermRoomMemberBan) {
+	if apiRoomPermissionGranted(dmRoom, core.PermRoomJoin) ||
+		apiRoomPermissionGranted(dmRoom, core.PermRoomManage) ||
+		apiRoomPermissionGranted(dmRoom, core.PermRoomMemberBan) ||
+		apiRoomPermissionGranted(dmRoom, core.PermMessagePostInThread) {
 		t.Fatalf("DM exposes channel-only actions: %+v", dmRoom)
 	}
 	batchResp, err := env.directory.BatchGetRooms(withCaller(env.ctx, caller), connect.NewRequest(&apiv1.BatchGetRoomsRequest{
@@ -3583,6 +3586,17 @@ func TestRoomDirectoryServiceListRoomsVisibilityAndDMs(t *testing.T) {
 	}
 	if len(outsiderBatchResp.Msg.GetRooms()) != 0 {
 		t.Fatalf("outsider BatchGetRooms DM len = %d, want 0", len(outsiderBatchResp.Msg.GetRooms()))
+	}
+
+	if err := env.core.AssignOwnerRole(env.ctx, caller.Id); err != nil {
+		t.Fatalf("AssignOwnerRole caller: %v", err)
+	}
+	ownerResp, err := env.directory.GetRoom(withCaller(env.ctx, caller), connect.NewRequest(&apiv1.GetRoomRequest{RoomId: dm.Id}))
+	if err != nil {
+		t.Fatalf("owner GetRoom DM: %v", err)
+	}
+	if apiRoomPermissionGranted(ownerResp.Msg.GetRoom(), core.PermMessagePostInThread) {
+		t.Fatal("owner DM viewer state grants message.post-in-thread")
 	}
 }
 
@@ -4951,6 +4965,47 @@ func TestMessageServiceCreateMessageRequiresAuthMembershipAndPermission(t *testi
 	}
 	if _, err := env.messages.CreateMessage(withCaller(env.ctx, env.viewer), req); connect.CodeOf(err) != connect.CodePermissionDenied {
 		t.Fatalf("denied CreateMessage code = %v, want %v", connect.CodeOf(err), connect.CodePermissionDenied)
+	}
+}
+
+func TestMessageServiceRejectsDMThreads(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	participant, err := env.core.CreateUser(env.ctx, core.SystemActorID, "message-dm-thread-participant", "DM Thread Participant", "password")
+	if err != nil {
+		t.Fatalf("CreateUser participant: %v", err)
+	}
+	dm, _, err := env.core.FindOrCreateDM(env.ctx, env.viewer.Id, []string{participant.Id})
+	if err != nil {
+		t.Fatalf("FindOrCreateDM: %v", err)
+	}
+	root, err := env.messages.CreateMessage(withCaller(env.ctx, env.viewer), connect.NewRequest(&apiv1.CreateMessageRequest{
+		RoomId: dm.Id,
+		Body:   "DM root",
+	}))
+	if err != nil {
+		t.Fatalf("CreateMessage root: %v", err)
+	}
+	rootID := root.Msg.GetMessage().GetId()
+
+	_, err = env.messages.CreateMessage(withCaller(env.ctx, env.viewer), connect.NewRequest(&apiv1.CreateMessageRequest{
+		RoomId:            dm.Id,
+		Body:              "forbidden thread reply",
+		ThreadRootEventId: rootID,
+	}))
+	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+		t.Fatalf("CreateMessage DM thread code = %v, want invalid argument", got)
+	}
+
+	flat, err := env.messages.CreateMessage(withCaller(env.ctx, env.viewer), connect.NewRequest(&apiv1.CreateMessageRequest{
+		RoomId:    dm.Id,
+		Body:      "allowed flat reply",
+		InReplyTo: rootID,
+	}))
+	if err != nil {
+		t.Fatalf("CreateMessage flat DM reply: %v", err)
+	}
+	if got := flat.Msg.GetMessage(); got.GetThreadRootEventId() != "" || got.GetInReplyTo() != rootID {
+		t.Fatalf("flat DM reply = %+v, want reply attribution without thread", got)
 	}
 }
 
@@ -7416,9 +7471,6 @@ func TestThreadServiceListFollowedThreadsFiltersOtherRoomKinds(t *testing.T) {
 	root, err := env.core.PostMessage(env.ctx, core.KindDM, dm.Id, env.viewer.Id, "root body", nil, "", "", nil, false)
 	if err != nil {
 		t.Fatalf("PostMessage root: %v", err)
-	}
-	if _, err := env.core.PostMessage(env.ctx, core.KindDM, dm.Id, participant.Id, "reply body", nil, root.Id, "", nil, false); err != nil {
-		t.Fatalf("PostMessage reply: %v", err)
 	}
 	if err := env.core.FollowThread(env.ctx, core.KindDM, env.viewer.Id, dm.Id, root.Id); err != nil {
 		t.Fatalf("FollowThread: %v", err)

--- a/cli/internal/connectapi/errors.go
+++ b/cli/internal/connectapi/errors.go
@@ -51,6 +51,7 @@ func connectError(err error) error {
 		errors.Is(err, core.ErrCustomStatusTextTooLong) ||
 		errors.Is(err, core.ErrCustomStatusExpiryInPast) ||
 		errors.Is(err, core.ErrCannotBanDMRoomMember) ||
+		errors.Is(err, core.ErrDMThreadsUnsupported) ||
 		errors.Is(err, core.ErrExternalIdentityFlowWrongKind) ||
 		errors.Is(err, core.ErrExternalIdentityFlowUserBound) ||
 		errors.Is(err, core.ErrCurrentPasswordRequired) ||

--- a/cli/internal/core/can.go
+++ b/cli/internal/core/can.go
@@ -228,8 +228,12 @@ func (c *ChattoCore) CanPostMessage(ctx context.Context, userID string, kind Roo
 }
 
 // CanPostInThread checks if a user can post messages in a thread.
-// Uses room-level permission resolution (checks room overrides, then server defaults).
+// Threads are a channel-room-only capability; the room-kind invariant applies
+// even to effective owners before room-level permission resolution.
 func (c *ChattoCore) CanPostInThread(ctx context.Context, userID string, kind RoomKind, roomID string) (bool, error) {
+	if kind == KindDM {
+		return false, nil
+	}
 	return c.hasRoomPermission(ctx, kind, roomID, userID, PermMessagePostInThread)
 }
 

--- a/cli/internal/core/dm_test.go
+++ b/cli/internal/core/dm_test.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"hmans.de/chatto/internal/core/subjects"
+	"hmans.de/chatto/internal/events"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
@@ -129,6 +130,7 @@ func TestDMBoundaryDeniedPermissions(t *testing.T) {
 		PermMessageManage,
 		PermMessageEcho,
 		PermRoomCreate,
+		PermMessagePostInThread,
 	}
 
 	for _, perm := range denied {
@@ -145,7 +147,6 @@ func TestDMBoundaryDeniedPermissions(t *testing.T) {
 	notBoundaryDenied := []Permission{
 		PermRoomJoin,
 		PermMessagePost,
-		PermMessagePostInThread,
 		PermMessageAttach,
 		PermMessageReact,
 	}
@@ -902,101 +903,133 @@ func TestDMNotifications(t *testing.T) {
 	})
 }
 
-func TestDMThreadReplyEcho(t *testing.T) {
+func TestDMThreadsUnsupported(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	// Create two users
-	user1, err := core.CreateUser(ctx, "system", "dmecho1", "DM Echo User 1", "password123")
+	owner, err := core.CreateUser(ctx, SystemActorID, "dm-thread-owner", "DM Thread Owner", "password123")
 	if err != nil {
-		t.Fatalf("Failed to create user1: %v", err)
+		t.Fatalf("CreateUser owner: %v", err)
 	}
-	user2, err := core.CreateUser(ctx, "system", "dmecho2", "DM Echo User 2", "password123")
+	if err := core.AssignOwnerRole(ctx, owner.Id); err != nil {
+		t.Fatalf("AssignOwnerRole: %v", err)
+	}
+	member, err := core.CreateUser(ctx, SystemActorID, "dm-thread-member", "DM Thread Member", "password123")
 	if err != nil {
-		t.Fatalf("Failed to create user2: %v", err)
+		t.Fatalf("CreateUser member: %v", err)
 	}
-
-	// Create a DM conversation
-	room, _, err := core.FindOrCreateDM(ctx, user1.Id, []string{user2.Id})
+	room, _, err := core.FindOrCreateDM(ctx, owner.Id, []string{member.Id})
 	if err != nil {
-		t.Fatalf("Failed to create DM: %v", err)
+		t.Fatalf("FindOrCreateDM: %v", err)
 	}
 
-	t.Run("echo works in DM rooms", func(t *testing.T) {
-		// Post root message
-		rootEvent, err := core.PostMessage(ctx, KindDM, room.Id, user1.Id, "DM thread root", nil, "", "", nil, false)
-		if err != nil {
-			t.Fatalf("Failed to post root: %v", err)
-		}
-
-		// Post thread reply with echo
-		replyEvent, err := core.PostMessage(ctx, KindDM, room.Id, user1.Id, "DM thread reply echoed", nil, rootEvent.Id, "", nil, true)
-		if err != nil {
-			t.Fatalf("Failed to post echo reply in DM: %v", err)
-		}
-
-		reply := replyEvent.GetMessagePosted()
-		if reply == nil {
-			t.Fatal("Expected MessagePosted event for DM reply")
-		}
-
-		// Verify echo appears in room events
-		roomEventsResult, err := core.GetRoomEvents(ctx, KindDM, room.Id, 50, nil)
-		if err != nil {
-			t.Fatalf("Failed to get DM room events: %v", err)
-		}
-		roomEvents := roomEventsResult.Events
-
-		var foundEcho bool
-		for _, e := range roomEvents {
-			if msg := e.GetMessagePosted(); msg != nil && msg.EchoOfEventId == replyEvent.Id {
-				foundEcho = true
-				// The DM echo has its own envelope id and links back to the
-				// original reply via EchoOfEventId.
-				if msg.EchoFromThreadRootEventId != rootEvent.Id {
-					t.Errorf("DM echo ThreadRootEventId should be %q, got %q", rootEvent.Id, msg.EchoFromThreadRootEventId)
-				}
-				break
+	for name, userID := range map[string]string{"member": member.Id, "owner": owner.Id} {
+		t.Run(name+" cannot post in threads", func(t *testing.T) {
+			can, err := core.CanPostInThread(ctx, userID, KindDM, room.Id)
+			if err != nil {
+				t.Fatalf("CanPostInThread: %v", err)
 			}
-		}
-		if !foundEcho {
-			t.Error("Expected echo MessagePostedEvent in DM room events")
-		}
-	})
-
-	t.Run("echo does not appear in thread events", func(t *testing.T) {
-		// Post root and reply with echo
-		rootEvent, _ := core.PostMessage(ctx, KindDM, room.Id, user2.Id, "DM root for thread test", nil, "", "", nil, false)
-		_, err := core.PostMessage(ctx, KindDM, room.Id, user2.Id, "DM reply for thread test", nil, rootEvent.Id, "", nil, true)
-		if err != nil {
-			t.Fatalf("Failed to post echo reply: %v", err)
-		}
-
-		// Thread events should not contain the echo
-		threadEvents, err := core.GetThreadEvents(ctx, KindDM, room.Id, rootEvent.Id)
-		if err != nil {
-			t.Fatalf("Failed to get DM thread events: %v", err)
-		}
-		for _, e := range threadEvents {
-			if msg := e.GetMessagePosted(); msg != nil && msg.EchoOfEventId != "" {
-				t.Error("Echo MessagePostedEvent should NOT appear in DM thread events")
+			if can {
+				t.Fatal("CanPostInThread returned true for a DM")
 			}
-		}
-	})
+		})
+	}
+	ownerPermission, err := core.permissionResolver.HasRoomPermission(ctx, owner.Id, KindDM, room.Id, PermMessagePostInThread)
+	if err != nil {
+		t.Fatalf("resolve owner permission: %v", err)
+	}
+	if !ownerPermission {
+		t.Fatal("owner should retain the permission override even though the DM capability is unavailable")
+	}
 
-	t.Run("reply_count only increments once with echo in DM", func(t *testing.T) {
-		rootEvent, _ := core.PostMessage(ctx, KindDM, room.Id, user1.Id, "DM root for count", nil, "", "", nil, false)
-		_, err := core.PostMessage(ctx, KindDM, room.Id, user1.Id, "DM reply with echo", nil, rootEvent.Id, "", nil, true)
-		if err != nil {
-			t.Fatalf("Failed to post reply: %v", err)
-		}
+	root, err := core.PostMessage(ctx, KindDM, room.Id, owner.Id, "DM root", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage root: %v", err)
+	}
+	agg := events.RoomAggregate(room.Id)
+	before, _, err := core.EventPublisher.SubjectEvents(ctx, agg.Subject(events.EventMessagePosted))
+	if err != nil {
+		t.Fatalf("SubjectEvents before rejected post: %v", err)
+	}
+	threadsBefore, _, err := core.EventPublisher.SubjectEvents(ctx, agg.Subject(events.EventThreadCreated))
+	if err != nil {
+		t.Fatalf("ThreadCreated events before rejected post: %v", err)
+	}
+	if _, err := core.PostMessage(ctx, KindDM, room.Id, owner.Id, "forbidden thread reply", nil, root.Id, "", nil, false); !errors.Is(err, ErrDMThreadsUnsupported) {
+		t.Fatalf("PostMessage explicit DM thread error = %v, want ErrDMThreadsUnsupported", err)
+	}
+	after, _, err := core.EventPublisher.SubjectEvents(ctx, agg.Subject(events.EventMessagePosted))
+	if err != nil {
+		t.Fatalf("SubjectEvents after rejected post: %v", err)
+	}
+	if len(after) != len(before) {
+		t.Fatalf("rejected DM thread post published %d message events, want none", len(after)-len(before))
+	}
+	threadsAfter, _, err := core.EventPublisher.SubjectEvents(ctx, agg.Subject(events.EventThreadCreated))
+	if err != nil {
+		t.Fatalf("ThreadCreated events after rejected post: %v", err)
+	}
+	if len(threadsAfter) != len(threadsBefore) {
+		t.Fatalf("rejected DM thread post published %d thread events, want none", len(threadsAfter)-len(threadsBefore))
+	}
+	if _, err := core.Messages().PreflightPost(ctx, MessagePostInput{
+		ActorID:               owner.Id,
+		RoomID:                room.Id,
+		Body:                  "forbidden attachment reply",
+		HasPendingAttachments: true,
+		ThreadRootEventID:     root.Id,
+	}); !errors.Is(err, ErrDMThreadsUnsupported) {
+		t.Fatalf("PreflightPost explicit DM thread error = %v, want ErrDMThreadsUnsupported", err)
+	}
 
-		metadata, err := core.GetThreadMetadata(ctx, KindDM, room.Id, rootEvent.Id)
-		if err != nil {
-			t.Fatalf("Failed to get metadata: %v", err)
-		}
-		if metadata.ReplyCount != 1 {
-			t.Errorf("Expected ReplyCount=1 in DM (echo should not increment), got %d", metadata.ReplyCount)
-		}
-	})
+	flatReply, err := core.PostMessage(ctx, KindDM, room.Id, member.Id, "flat reply", nil, "", root.Id, nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage flat reply: %v", err)
+	}
+	if posted := flatReply.GetMessagePosted(); posted.GetInThread() != "" || posted.GetInReplyTo() != root.Id {
+		t.Fatalf("flat reply fields = in_thread %q in_reply_to %q", posted.GetInThread(), posted.GetInReplyTo())
+	}
+
+	// Seed a historical DM thread directly through EVT. Current writers must
+	// reject this shape, but projections and read/follow paths remain compatible
+	// with facts persisted by earlier versions.
+	threadCreated := newEvent(owner.Id, &corev1.Event{Event: &corev1.Event_ThreadCreated{
+		ThreadCreated: &corev1.ThreadCreatedEvent{RoomId: room.Id, ThreadRootEventId: root.Id},
+	}})
+	if _, err := core.EventPublisher.AppendEventually(ctx, agg.SubjectFor(threadCreated), threadCreated); err != nil {
+		t.Fatalf("append historical ThreadCreatedEvent: %v", err)
+	}
+	legacyReply := newEvent(owner.Id, &corev1.Event{Event: &corev1.Event_MessagePosted{
+		MessagePosted: &corev1.MessagePostedEvent{RoomId: room.Id, InThread: root.Id},
+	}})
+	legacySubject := agg.SubjectFor(legacyReply)
+	legacySeq, err := core.EventPublisher.AppendEventually(ctx, legacySubject, legacyReply)
+	if err != nil {
+		t.Fatalf("append historical thread reply: %v", err)
+	}
+	if err := core.rooms().waitForTimelineAndThreads(ctx, events.SubjectPosition(legacySubject, legacySeq)); err != nil {
+		t.Fatalf("wait for historical DM thread: %v", err)
+	}
+	threadEvents, err := core.GetThreadEvents(ctx, KindDM, room.Id, root.Id)
+	if err != nil {
+		t.Fatalf("GetThreadEvents historical DM thread: %v", err)
+	}
+	if len(threadEvents) != 2 || threadEvents[1].Id != legacyReply.Id {
+		t.Fatalf("historical DM thread events = %+v, want root plus %s", threadEvents, legacyReply.Id)
+	}
+	if err := core.FollowThread(ctx, KindDM, member.Id, room.Id, root.Id); err != nil {
+		t.Fatalf("FollowThread historical DM thread: %v", err)
+	}
+	if _, err := core.Messages().PreflightPost(ctx, MessagePostInput{
+		ActorID:               member.Id,
+		RoomID:                room.Id,
+		Body:                  "implicitly threaded attachment reply",
+		HasPendingAttachments: true,
+		InReplyTo:             legacyReply.Id,
+	}); !errors.Is(err, ErrDMThreadsUnsupported) {
+		t.Fatalf("PreflightPost inherited DM thread error = %v, want ErrDMThreadsUnsupported", err)
+	}
+	if _, err := core.PostMessage(ctx, KindDM, room.Id, member.Id, "implicitly threaded reply", nil, "", legacyReply.Id, nil, false); !errors.Is(err, ErrDMThreadsUnsupported) {
+		t.Fatalf("PostMessage inherited DM thread error = %v, want ErrDMThreadsUnsupported", err)
+	}
 }

--- a/cli/internal/core/errors.go
+++ b/cli/internal/core/errors.go
@@ -97,6 +97,11 @@ var (
 	// ErrMessageTooLong is returned when a message body exceeds the maximum length.
 	ErrMessageTooLong = errors.New("message body exceeds maximum length")
 
+	// ErrDMThreadsUnsupported is returned when a caller tries to create or
+	// extend a thread in a direct-message room. DMs support flat reply
+	// attribution, but thread containment is a channel-room-only capability.
+	ErrDMThreadsUnsupported = errors.New("threads are not supported in direct messages")
+
 	// ErrDisplayNameTooLong is returned when a display name exceeds the maximum length.
 	ErrDisplayNameTooLong = errors.New("display name exceeds maximum length")
 

--- a/cli/internal/core/message_model.go
+++ b/cli/internal/core/message_model.go
@@ -158,16 +158,6 @@ func (s *MessageModel) validatePostBeforeUpload(ctx context.Context, input Messa
 	if len(input.Body) > MaxMessageBodyLength {
 		return ErrMessageTooLong
 	}
-	if err := validateLinkPreview(input.LinkPreview); err != nil {
-		return err
-	}
-	if err := s.core.HydrateLinkPreviewImageAsset(ctx, input.LinkPreview); err != nil {
-		return err
-	}
-	if err := validateLinkPreview(input.LinkPreview); err != nil {
-		return err
-	}
-
 	if inReplyTo := strings.TrimSpace(input.InReplyTo); inReplyTo != "" {
 		targetEvent, err := s.core.GetRoomEventByEventID(ctx, authorization.Kind, authorization.Room.Id, inReplyTo)
 		if err != nil {
@@ -176,9 +166,23 @@ func (s *MessageModel) validatePostBeforeUpload(ctx context.Context, input Messa
 		if targetEvent == nil {
 			return invalidArgument("in_reply_to message not found in room")
 		}
-		if targetEvent.GetMessagePosted() == nil {
+		targetMessage := targetEvent.GetMessagePosted()
+		if targetMessage == nil {
 			return invalidArgument("in_reply_to target is not a message event")
 		}
+		if authorization.Kind == KindDM && targetMessage.GetInThread() != "" {
+			return ErrDMThreadsUnsupported
+		}
+	}
+
+	if err := validateLinkPreview(input.LinkPreview); err != nil {
+		return err
+	}
+	if err := s.core.HydrateLinkPreviewImageAsset(ctx, input.LinkPreview); err != nil {
+		return err
+	}
+	if err := validateLinkPreview(input.LinkPreview); err != nil {
+		return err
 	}
 
 	if input.ThreadRootEventID == "" {
@@ -232,6 +236,9 @@ func (s *MessageModel) AuthorizePost(ctx context.Context, input MessagePostAutho
 	}
 	if !isMember {
 		return nil, ErrNotRoomMember
+	}
+	if kind == KindDM && strings.TrimSpace(input.ThreadRootEventID) != "" {
+		return nil, ErrDMThreadsUnsupported
 	}
 
 	if input.ThreadRootEventID != "" {

--- a/cli/internal/core/messages.go
+++ b/cli/internal/core/messages.go
@@ -475,6 +475,9 @@ func (c *ChattoCore) PostMessage(ctx context.Context, kind RoomKind, room_id, us
 			}
 		}
 	}
+	if kind == KindDM && inThread != "" {
+		return nil, ErrDMThreadsUnsupported
+	}
 
 	// Validate thread root exists if posting to a thread.
 	if inThread != "" {

--- a/cli/internal/core/permission_resolver.go
+++ b/cli/internal/core/permission_resolver.go
@@ -338,8 +338,9 @@ var dmBoundaryDeniedPermissions = map[Permission]bool{
 	PermRoomMemberBan: true,
 	PermMessageManage: true,
 	PermMessageEcho:   true,
-	// DMs have their own creation / membership APIs.
-	PermRoomCreate: true,
+	// DMs have their own creation / membership APIs and do not support threads.
+	PermRoomCreate:          true,
+	PermMessagePostInThread: true,
 }
 
 func dmBoundaryDenies(perm Permission) bool {
@@ -347,11 +348,10 @@ func dmBoundaryDenies(perm Permission) bool {
 }
 
 var dmDefaultAllowedPermissions = map[Permission]bool{
-	PermRoomJoin:            true,
-	PermMessagePost:         true,
-	PermMessagePostInThread: true,
-	PermMessageAttach:       true,
-	PermMessageReact:        true,
+	PermRoomJoin:      true,
+	PermMessagePost:   true,
+	PermMessageAttach: true,
+	PermMessageReact:  true,
 }
 
 func dmDefaultAllows(perm Permission) bool {

--- a/cli/internal/core/permission_resolver_test.go
+++ b/cli/internal/core/permission_resolver_test.go
@@ -979,11 +979,11 @@ func TestPermissionResolver_DMContract(t *testing.T) {
 		{PermMessageManage, expected{false, false}, "DM privacy: no cross-user moderation"},
 		{PermMessageEcho, expected{false, false}, "echo channel-only"},
 		{PermRoomCreate, expected{false, false}, "DMs use FindOrCreateDM"},
+		{PermMessagePostInThread, expected{false, false}, "threads are channel-only"},
 
 		// === Resolvable, default-granted to everyone === (so regular passes)
 		{PermRoomJoin, expected{true, true}, "auto-join on DM creation; perm resolves"},
 		{PermMessagePost, expected{true, true}, "core DM capability"},
-		{PermMessagePostInThread, expected{true, true}, "core DM capability"},
 		{PermMessageAttach, expected{true, true}, "core DM capability"},
 		{PermMessageReact, expected{true, true}, "core DM capability"},
 	}

--- a/cli/internal/core/room_unread_test.go
+++ b/cli/internal/core/room_unread_test.go
@@ -59,11 +59,13 @@ func TestChattoCore_LastReadEventID(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
-	room, _ := core.CreateRoom(ctx, "test-user", KindChannel, "", "General", "General discussion")
-	user, _ := core.CreateUser(ctx, "system", "testuser", "testuser", "password123")
+	// This test only exercises the RUNTIME_STATE read marker. Using fresh IDs
+	// keeps it independent of room/user creation and projection timing.
+	roomID := NewRoomID()
+	userID := NewUserID()
 
 	// Initially: empty (never read)
-	id, err := core.GetLastReadEventID(ctx, KindChannel, user.Id, room.Id)
+	id, err := core.GetLastReadEventID(ctx, KindChannel, userID, roomID)
 	if err != nil {
 		t.Fatalf("Failed to get last read event id: %v", err)
 	}
@@ -72,10 +74,10 @@ func TestChattoCore_LastReadEventID(t *testing.T) {
 	}
 
 	// Set and read back
-	if err := core.SetLastReadEventID(ctx, KindChannel, user.Id, room.Id, "Eabcdefghij012"); err != nil {
+	if err := core.SetLastReadEventID(ctx, KindChannel, userID, roomID, "Eabcdefghij012"); err != nil {
 		t.Fatalf("Failed to set last read event id: %v", err)
 	}
-	id, err = core.GetLastReadEventID(ctx, KindChannel, user.Id, room.Id)
+	id, err = core.GetLastReadEventID(ctx, KindChannel, userID, roomID)
 	if err != nil {
 		t.Fatalf("Failed to get last read event id after set: %v", err)
 	}
@@ -84,10 +86,10 @@ func TestChattoCore_LastReadEventID(t *testing.T) {
 	}
 
 	// Overwrite
-	if err := core.SetLastReadEventID(ctx, KindChannel, user.Id, room.Id, "Exyzxyzxyzxyz9"); err != nil {
+	if err := core.SetLastReadEventID(ctx, KindChannel, userID, roomID, "Exyzxyzxyzxyz9"); err != nil {
 		t.Fatalf("Failed to update last read event id: %v", err)
 	}
-	id, err = core.GetLastReadEventID(ctx, KindChannel, user.Id, room.Id)
+	id, err = core.GetLastReadEventID(ctx, KindChannel, userID, roomID)
 	if err != nil {
 		t.Fatalf("Failed to get last read event id after update: %v", err)
 	}

--- a/docs/adr/ADR-037-dm-access-via-membership.md
+++ b/docs/adr/ADR-037-dm-access-via-membership.md
@@ -21,7 +21,9 @@ Remove both DM-specific permission strings as product and authorization concepts
 - Listing DMs returns the DM rooms the caller participates in.
 - Live DM events are filtered by room membership, the same as channel-room events.
 - Starting a DM and sending root messages in DM rooms are gated by `message.post`.
-- Thread replies in DM rooms are gated by `message.post-in-thread`.
+- DMs do not support threads. This is a room-kind invariant enforced by the
+  message operation model and low-level Core write path, not an RBAC decision.
+  Flat reply attribution remains available in DMs.
 - The DM privacy boundary remains: permissions such as `message.manage`, `room.manage`, `message.echo`, and channel-style `room.create` are denied inside DM rooms regardless of role grants.
 
 This decision does not make DMs globally visible. It removes the redundant read gate; the participant set remains the access boundary.
@@ -31,5 +33,9 @@ This decision does not make DMs globally visible. It removes the redundant read 
 - Operators can still stop DM abuse by revoking `message.post`, suspending the user, or removing the account.
 - Users do not lose read access to conversations they are already part of because an operator toggled a broad server permission.
 - The authorization model becomes easier to explain: membership answers "can read this room?", while `message.*` permissions answer "can perform this messaging capability?"
+- Effective owners still resolve every permission through the owner override,
+  but cannot bypass room-kind invariants such as the prohibition on DM threads.
+- Historical DM thread events remain readable for compatibility, but current
+  writers cannot create or extend them.
 - Subscription filtering and sidebar queries no longer need a second DM-specific read check on top of membership.
 - API fields, frontend guards, tests, and permission seed data that existed only for `dm.view` / `dm.write` have been removed.

--- a/docs/fdr/FDR-002-replies-and-threads.md
+++ b/docs/fdr/FDR-002-replies-and-threads.md
@@ -1,15 +1,16 @@
 # FDR-002: Replies & Threads
 
 **Status:** Active
-**Last reviewed:** 2026-07-14
+**Last reviewed:** 2026-07-16
 
 ## Overview
 
-Chatto messages can link to one another via reply attribution, and they can live inside threads — conversations branching off a root message. Replies and threads are independent concepts: a message can reply without being in a thread, or live in a thread without referencing a specific parent. Rooms can be configured to promote one shape over another.
+Chatto messages can link to one another via reply attribution, and channel-room messages can live inside threads — conversations branching off a root message. Replies and threads are independent concepts: a message can reply without being in a thread, or live in a thread without referencing a specific parent. Channel rooms can be configured to promote one shape over another; DMs support reply attribution but not threads.
 
 ## Behavior
 
 - A message in a room can optionally reference another message as the one it's in reply to.
+- DMs keep replies in their single room timeline and do not offer thread actions. Historical DM threads remain readable but cannot receive new replies.
 - A reply renders with a byline above the message body: the referenced author's small avatar, name, and a single-line excerpt of the referenced message.
 - Clicking the byline transports the user to the referenced message and briefly highlights it.
 - Clicking the avatar or name in the byline opens the user's context menu.
@@ -60,7 +61,7 @@ Chatto messages can link to one another via reply attribution, and they can live
 ## Permissions
 
 - `message.post` — post a root message (with or without `inReplyTo`) in a room.
-- `message.post-in-thread` — post a message in a thread (whether starting it or replying inside, with or without `inReplyTo`).
+- `message.post-in-thread` — post a message in a channel-room thread (whether starting it or replying inside, with or without `inReplyTo`). This permission does not make threads available in DMs.
 
 ## Related
 

--- a/docs/fdr/FDR-007-direct-messages.md
+++ b/docs/fdr/FDR-007-direct-messages.md
@@ -1,11 +1,11 @@
 # FDR-007: Direct Messages
 
 **Status:** Active
-**Last reviewed:** 2026-06-26
+**Last reviewed:** 2026-07-16
 
 ## Overview
 
-Users can start a direct conversation (1-to-1 or small group, up to 10 participants) with anyone they can see in a server. DMs are rooms with `kind: dm`: they use the same message, thread, reaction, attachment, notification, unread, and live-delivery machinery as channel rooms, while applying a smaller DM-specific creation and privacy policy. Each Chatto server has its own DM scope; there is currently no cross-server "unified DM inbox".
+Users can start a direct conversation (1-to-1 or small group, up to 10 participants) with anyone they can see in a server. DMs are rooms with `kind: dm`: they use the same message, reaction, attachment, notification, unread, and live-delivery machinery as channel rooms, while applying a smaller DM-specific creation and privacy policy. Each Chatto server has its own DM scope; there is currently no cross-server "unified DM inbox".
 
 ## Behavior
 
@@ -16,9 +16,10 @@ Users can start a direct conversation (1-to-1 or small group, up to 10 participa
 - Inside a DM room, the room extras sidebar is available but starts closed and does not show the Members panel. The current Files panel and future non-member panels are shared, while channel-style moderation actions such as banning/removing room members remain unavailable.
 - Maximum 10 participants per DM.
 - A user can read a DM if and only if they are a participant in that DM room. There is no separate "can view DMs" permission.
-- Operators can prevent a user from starting new DMs or sending root messages in existing DMs by revoking `message.post`; thread replies follow `message.post-in-thread`.
+- Operators can prevent a user from starting new DMs or sending messages in existing DMs by revoking `message.post`.
 - Operators cannot ban or remove participants from an existing DM room. Channel member bans are a `room.ban-member` action and are rejected for DMs.
-- Inside a DM room, ordinary message-related features apply: posting, replies, threads, reactions, edits, deletes, mentions, attachments.
+- Inside a DM room, ordinary message-related features apply: posting, flat reply attribution, reactions, edits, deletes, mentions, and attachments.
+- DMs do not support threads. The client does not offer thread actions, and the server rejects attempts to create or extend a DM thread even for owners. Thread data written by older versions remains readable but read-only.
 - Server admins / moderators cannot moderate DM contents — `message.manage`, `room.manage`, and `message.echo` are unconditionally denied in DM rooms regardless of role grants. The channel-style `room.create` is also denied inside DMs; DMs have their own creation and membership APIs.
 
 ## Design Decisions
@@ -26,28 +27,34 @@ Users can start a direct conversation (1-to-1 or small group, up to 10 participa
 ### 1. DMs are rooms, not a parallel messaging model
 
 **Decision:** A DM is a room with `kind: dm`, not a separate entity type, inbox stream, or hidden space.
-**Why:** Room infrastructure already models the hard parts: membership, messages, threads, reactions, attachments, unread state, live delivery, and notification fan-out. Reusing the room aggregate keeps DMs boring and makes the event-sourced room model apply uniformly. See ADR-033, ADR-034, and ADR-037.
+**Why:** Room infrastructure already models the hard parts: membership, messages, reactions, attachments, unread state, live delivery, and notification fan-out. Reusing the room aggregate keeps DMs boring and makes the event-sourced room model apply uniformly. See ADR-033, ADR-034, and ADR-037.
 **Tradeoff:** Some room code still has to branch on `kind` for DM-only policy, but those branches should be about behavior (creation, privacy boundary, presentation), not storage or delivery plumbing.
 
 ### 2. Reading is membership-based, writing uses message permissions
 
-**Decision:** DM read access comes only from room membership. Starting DMs and posting root messages in them use `message.post`; thread replies use `message.post-in-thread`.
+**Decision:** DM read access comes only from room membership. Starting DMs and posting messages in them use `message.post`. Reply attribution does not change that permission, and thread posting does not apply to DMs.
 **Why:** A user who is a participant in a private conversation should be able to read that conversation, and sending a DM is still just sending a message. Reusing the message permissions avoids a lonely DM-only permission while preserving the abuse-control lever. See ADR-037.
-**Tradeoff:** There is no soft "hide DMs from this user" switch, and revoking `message.post` blocks channel posting as well as DM starts / root posts. Operators who need a total messaging timeout can use that; finer abuse controls should be modeled separately if needed.
+**Tradeoff:** There is no soft "hide DMs from this user" switch, and revoking `message.post` blocks channel posting as well as DM starts / messages. Operators who need a total messaging timeout can use that; finer abuse controls should be modeled separately if needed.
 
-### 3. Deterministic room IDs
+### 3. Threads are channel-room-only
+
+**Decision:** DMs support reply attribution in the room timeline but do not support thread containment. The prohibition is a room-kind invariant rather than an RBAC restriction, so owner permission overrides cannot bypass it. Historical DM threads remain readable for compatibility.
+**Why:** A direct conversation is already a focused message timeline; branching it into parallel threads makes the conversation model and navigation unnecessarily complex. Enforcing the distinction in Core keeps every transport and privileged caller consistent.
+**Tradeoff:** Older DM thread history can still be opened but cannot receive new replies. Users who need threaded discussions should use a channel room.
+
+### 4. Deterministic room IDs
 
 **Decision:** A DM room ID is a hash of the sorted participant user IDs.
 **Why:** Find-or-create needs to be cheap and race-free. Hashing the participant set gives a content-addressable ID — starting a DM with the same group always lands in the same room without a database lookup.
 **Tradeoff:** Adding or removing a participant from a DM would change the room ID, which means group membership is fixed at creation. Acceptable: in practice, group DMs are short-lived and re-creating with the new set is fine. Users who need a different participant set start a new DM.
 
-### 4. Per-server scope (no unified inbox)
+### 5. Per-server scope (no unified inbox)
 
 **Decision:** Each Chatto server's DMs are scoped to that server. There's no cross-server aggregation that shows "all your DMs across all the servers you're connected to" in one inbox.
 **Why:** A unified inbox was tried and removed. The complexity of cross-server aggregation (auth, real-time aggregation, navigation routing) outweighed the benefit for the current user base, which mostly works in one server at a time.
 **Tradeoff:** Users in multiple servers have to switch servers to see DMs in each. If a unified inbox is reintroduced, this FDR needs a rewrite.
 
-### 5. Moderation deny-list inside DMs
+### 6. Moderation deny-list inside DMs
 
 **Decision:** Even users with admin/moderator roles cannot edit others' messages, delete others' messages, or otherwise moderate inside a DM room. The deny-list is unconditional regardless of role.
 **Why:** DMs are private by design. An admin who could moderate DMs would have a privacy boundary problem. Treating the deny as a static rule (not a configurable permission) prevents accidental misconfiguration.
@@ -55,11 +62,10 @@ Users can start a direct conversation (1-to-1 or small group, up to 10 participa
 
 ## Permissions
 
-- `message.post` — start DMs and send root messages in DM rooms.
-- `message.post-in-thread` — send thread replies in DM rooms.
+- `message.post` — start DMs and send messages in DM rooms.
 - `message.react` — add and remove reactions in DM rooms.
 
-DMs have no `dm.*` permissions. Message and reaction permissions apply inside DM rooms subject to the moderation deny-list above.
+DMs have no `dm.*` permissions. Message and reaction permissions apply inside DM rooms subject to the moderation deny-list above. `message.post-in-thread` is inapplicable to DMs regardless of the viewer's effective permissions.
 
 ## Related
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -11,12 +11,12 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | # | Feature | Status | Last reviewed |
 |---|---------|--------|---------------|
 | [FDR-001](FDR-001-roles-and-permissions.md) | Roles & Permissions (RBAC) | Active | 2026-07-15 |
-| [FDR-002](FDR-002-replies-and-threads.md) | Replies & Threads | Active | 2026-07-14 |
+| [FDR-002](FDR-002-replies-and-threads.md) | Replies & Threads | Active | 2026-07-16 |
 | [FDR-003](FDR-003-thread-reply-echo.md) | Thread Reply Echo | Active | 2026-06-01 |
 | [FDR-004](FDR-004-message-editing-and-deletion.md) | Message Editing & Deletion | Active | 2026-07-10 |
 | [FDR-005](FDR-005-reactions.md) | Reactions | Active | 2026-05-19 |
 | [FDR-006](FDR-006-mentions.md) | @Mentions | Active | 2026-06-15 |
-| [FDR-007](FDR-007-direct-messages.md) | Direct Messages | Active | 2026-05-31 |
+| [FDR-007](FDR-007-direct-messages.md) | Direct Messages | Active | 2026-07-16 |
 | [FDR-008](FDR-008-file-attachments-and-video.md) | File Attachments & Video Processing | Active | 2026-07-10 |
 | [FDR-009](FDR-009-link-previews.md) | Link Previews | Active | 2026-07-15 |
 | [FDR-010](FDR-010-typing-indicators.md) | Typing Indicators | Active | 2026-05-19 |


### PR DESCRIPTION
## Why

DM threading was accidentally enabled through default permissions, and effective owners could bypass RBAC denials; DMs must remain a flat conversation model.

## What changed

- Enforce the room-kind invariant in permission capabilities, message preflight, and the low-level Core writer, mapping violations to ConnectRPC `INVALID_ARGUMENT`.
- Preserve flat reply attribution and read/follow compatibility for historical DM threads, while hiding new thread actions through server-provided capabilities and documenting the decision in ADR-037, FDR-002, and FDR-007.

## Test plan

- `mise test-cli`; focused Core and Connect tests; the `MessageActionSheet` browser component test; and `pnpm exec playwright test e2e/dm.test.ts --retries=0` all pass.
