### PR TITLE
fix(frontend): scope thread click-outside dismissal

### DIFF
--- a/apps/frontend/e2e/threading.test.ts
+++ b/apps/frontend/e2e/threading.test.ts
@@ -1198,7 +1198,7 @@ test.describe('Message Threading', () => {
     await roomPage.expectThreadRouteClosed();
   });
 
-  test('clicking outside thread pane closes it (sidebar area)', async ({
+  test('clicking the room list keeps the thread open', async ({
     page,
     chatPage,
     roomPage
@@ -1218,9 +1218,9 @@ test.describe('Message Threading', () => {
     const sidebar = page.locator('.room-list');
     await sidebar.click({ position: { x: 10, y: 10 } });
 
-    // Thread should close
-    await roomPage.expectThreadRouteClosed();
-    await expect(page.getByRole('heading', { name: /^Thread in #/ })).not.toBeVisible();
+    // App navigation is outside the thread's dimmed room dismissal surface.
+    await roomPage.expectThreadRouteActive();
+    await roomPage.expectThreadPaneVisible();
   });
 
   test('thread reply does not scroll main chat to bottom', async ({ page, chatPage, roomPage }) => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -14,7 +14,7 @@
     usePresenceChange,
     createTypingIndicator
   } from '$lib/hooks';
-  import { appState, sidebarNav } from '$lib/state/globals.svelte';
+  import { appState } from '$lib/state/globals.svelte';
   import * as m from '$lib/i18n/messages';
   import {
     createComposerContext,
@@ -478,7 +478,11 @@
     if (!threadId || e.button !== 0) return;
     const target = e.target as HTMLElement;
     if (target.closest('[data-testid="thread-pane"], dialog')) return;
-    if (sidebarNav.isMobile && target.closest('[data-app-sidebar]')) return;
+    // A thread is an overlay over the room view, so only the dimmed room
+    // surface behind it should behave as a click-outside dismissal target.
+    // Controls elsewhere in the app (such as the room extras sidebar) manage
+    // their own state and must not close the thread as a side effect.
+    if (!target.closest('[data-thread-dismiss-surface]')) return;
     closeThread();
   }}
 />
@@ -504,6 +508,7 @@
         isDesktopCallMaximized ? 'lg:hidden' : ''
       ]}
       data-testid="room-view-region"
+      data-thread-dismiss-surface
     >
       <div
         class={[

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -51,9 +51,6 @@ const { mocks } = vi.hoisted(() => {
       },
       livekitUrl: null as string | null,
       roomKind: 1,
-      sidebarNav: {
-        isMobile: false
-      },
       getAppUiState: vi.fn(),
       activeCallRoomIds: new Set<string>(),
       joinedCallRoomIds: new Set<string>(),
@@ -197,8 +194,7 @@ vi.mock('$lib/state/globals.svelte', () => ({
   appState: {
     isFocused: true,
     isPresent: true
-  },
-  sidebarNav: mocks.sidebarNav
+  }
 }));
 
 vi.mock('$lib/state/appUi.svelte', async (importActual) => {
@@ -322,7 +318,6 @@ beforeEach(() => {
   mocks.timeline.getThreadEventsAround.mockResolvedValue(emptyTimelinePage());
   mocks.livekitUrl = null;
   mocks.roomKind = RoomKind.CHANNEL;
-  mocks.sidebarNav.isMobile = false;
   mocks.pendingHighlightConsume.mockReset();
   mocks.pendingHighlightConsume.mockReturnValue(null);
   appUi = new AppUiState();
@@ -478,8 +473,7 @@ describe('Room local message echo', () => {
     expect(consumePendingRoomSidebarPanel('server-1', 'room-1')).toBeNull();
   });
 
-  it('keeps the thread open when pressing the app sidebar surface on mobile', async () => {
-    mocks.sidebarNav.isMobile = true;
+  it('keeps the thread open when pressing the app sidebar surface', async () => {
     render(Room, { props: { roomId: 'room-1', threadId: 'thread-root' } });
     await tick();
     mocks.goto.mockClear();
@@ -502,27 +496,39 @@ describe('Room local message echo', () => {
     }
   });
 
-  it('closes the thread when pressing the desktop app sidebar surface', async () => {
-    render(Room, { props: { roomId: 'room-1', threadId: 'thread-root' } });
+  it('closes the thread when pressing the room view behind it', async () => {
+    const { container } = render(Room, {
+      props: { roomId: 'room-1', threadId: 'thread-root' }
+    });
     await tick();
     mocks.goto.mockClear();
 
-    const appSidebar = document.createElement('div');
-    appSidebar.dataset.appSidebar = 'true';
-    document.body.append(appSidebar);
+    q(container, '[data-testid="room-view-region"]')!.dispatchEvent(
+      new PointerEvent('pointerdown', { bubbles: true, button: 0 })
+    );
 
-    try {
-      appSidebar.dispatchEvent(
-        new PointerEvent('pointerdown', {
-          bubbles: true,
-          button: 0
-        })
-      );
+    expect(mocks.goto).toHaveBeenCalledWith('/chat/-/room-1');
+  });
 
-      expect(mocks.goto).toHaveBeenCalledWith('/chat/-/room-1');
-    } finally {
-      appSidebar.remove();
-    }
+  it('closes the desktop members sidebar without closing the thread', async () => {
+    appUi.openDesktopRoomSidebarPanel('members');
+    const { container } = render(Room, {
+      props: { roomId: 'room-1', threadId: 'thread-root' }
+    });
+    await tick();
+    mocks.goto.mockClear();
+
+    const closeSidebar = q(
+      container,
+      '[data-testid="close-room-sidebar"]'
+    ) as HTMLButtonElement;
+    closeSidebar.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, button: 0 }));
+    closeSidebar.click();
+
+    await expect
+      .element(q(container, '[data-testid="room-sidebar-desktop-pane"]'))
+      .not.toBeInTheDocument();
+    expect(mocks.goto).not.toHaveBeenCalled();
   });
 
   it('lets a maximized desktop call sidebar fill the room route content area', async () => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomLocalEchoRoomSidebarMock.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomLocalEchoRoomSidebarMock.svelte
@@ -1,13 +1,18 @@
 <script lang="ts">
   let {
     maximized = false,
-    onToggleMaximized
+    onToggleMaximized,
+    onClose
   }: {
     maximized?: boolean;
     onToggleMaximized?: () => void;
+    onClose?: () => void;
   } = $props();
 </script>
 
+<button type="button" data-testid="close-room-sidebar" onclick={() => onClose?.()}>
+  Close sidebar
+</button>
 <button
   type="button"
   data-testid="toggle-maximized-call"


### PR DESCRIPTION
## Why

PR #1592 intentionally limited thread click-outside dismissal to the dimmed room surface, so app navigation and the room list no longer close an active thread. Its E2E coverage still asserted the previous behavior, causing `test-e2e (4/4)` to fail on every retry.

## What changed

- Apply the thread dismissal scoping change from release commit `6bde91357` to `main`.
- Keep threads open when users interact with the room list or other app navigation.
- Update the stale threading E2E assertion to cover the intended behavior.
- Preserve backdrop dismissal coverage in the component tests.

No public API, persistence, migration, security, or operational behavior changes are involved.

## Test plan

- `mise x -- pnpm exec playwright test e2e/threading.test.ts --grep "clicking the room list keeps the thread open" --retries=0` — passed.
- `mise x -- pnpm exec eslint e2e/threading.test.ts` — passed.
- Full required CI suite will run on this PR.
