### PR TITLE
fix(frontend): keep emoji picker open on new messages

### DIFF
--- a/apps/frontend/src/lib/ui/ContextMenu.svelte
+++ b/apps/frontend/src/lib/ui/ContextMenu.svelte
@@ -15,7 +15,7 @@ handling around the shared positioning primitive.
 - `ariaLabel` - ARIA label for the container
 - `presentation` - "auto" uses input capability, "floating" or "sheet" forces a mode
 - `class` - Additional CSS classes for the outer container (floating mode only)
-- `dismissOnScroll` - Whether outside scrolling dismisses the floating presentation
+- `scrollDismissal` - Which outside scrolling interactions dismiss the floating presentation
 - `onclose` - Callback when the menu should be dismissed
 
 In floating mode, exactly one of `position` or `anchor` must be provided. In sheet mode, both are
@@ -37,7 +37,7 @@ ignored (the BottomSheet handles its own positioning).
     ariaLabel,
     presentation = 'auto',
     class: className,
-    dismissOnScroll = true,
+    scrollDismissal = 'all',
     onclose,
     onmouseenter,
     onmouseleave,
@@ -49,7 +49,7 @@ ignored (the BottomSheet handles its own positioning).
     ariaLabel?: string;
     presentation?: ContextMenuPresentation;
     class?: string;
-    dismissOnScroll?: boolean;
+    scrollDismissal?: 'all' | 'user' | 'none';
     onclose: () => void;
     onmouseenter?: () => void;
     onmouseleave?: () => void;
@@ -90,7 +90,7 @@ ignored (the BottomSheet handles its own positioning).
     {role}
     {ariaLabel}
     class={['min-w-48 menu', className]}
-    {dismissOnScroll}
+    {scrollDismissal}
     {onclose}
     {onmouseenter}
     {onmouseleave}

--- a/apps/frontend/src/lib/ui/ContextMenu.svelte
+++ b/apps/frontend/src/lib/ui/ContextMenu.svelte
@@ -15,6 +15,7 @@ handling around the shared positioning primitive.
 - `ariaLabel` - ARIA label for the container
 - `presentation` - "auto" uses input capability, "floating" or "sheet" forces a mode
 - `class` - Additional CSS classes for the outer container (floating mode only)
+- `dismissOnScroll` - Whether outside scrolling dismisses the floating presentation
 - `onclose` - Callback when the menu should be dismissed
 
 In floating mode, exactly one of `position` or `anchor` must be provided. In sheet mode, both are
@@ -36,6 +37,7 @@ ignored (the BottomSheet handles its own positioning).
     ariaLabel,
     presentation = 'auto',
     class: className,
+    dismissOnScroll = true,
     onclose,
     onmouseenter,
     onmouseleave,
@@ -47,6 +49,7 @@ ignored (the BottomSheet handles its own positioning).
     ariaLabel?: string;
     presentation?: ContextMenuPresentation;
     class?: string;
+    dismissOnScroll?: boolean;
     onclose: () => void;
     onmouseenter?: () => void;
     onmouseleave?: () => void;
@@ -87,6 +90,7 @@ ignored (the BottomSheet handles its own positioning).
     {role}
     {ariaLabel}
     class={['min-w-48 menu', className]}
+    {dismissOnScroll}
     {onclose}
     {onmouseenter}
     {onmouseleave}

--- a/apps/frontend/src/lib/ui/ContextMenu.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/ContextMenu.svelte.spec.ts
@@ -71,12 +71,46 @@ describe('ContextMenu', () => {
     expect(onclose).toHaveBeenCalledOnce();
   });
 
-  it('can remain open during outside scroll', async () => {
+  it('can remain open during programmatic outside scroll', async () => {
     const onclose = vi.fn();
-    renderMenu({ onclose, dismissOnScroll: false });
+    renderMenu({ onclose, scrollDismissal: 'user' });
 
     await new Promise((resolve) => requestAnimationFrame(resolve));
     document.body.dispatchEvent(new Event('scroll'));
+
+    expect(onclose).not.toHaveBeenCalled();
+  });
+
+  it('dismisses user-scroll mode on outside wheel input', async () => {
+    const onclose = vi.fn();
+    renderMenu({ onclose, scrollDismissal: 'user' });
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    document.body.dispatchEvent(new WheelEvent('wheel', { bubbles: true }));
+
+    expect(onclose).toHaveBeenCalledOnce();
+  });
+
+  it('dismisses user-scroll mode when an outside touch scroll starts', async () => {
+    const onclose = vi.fn();
+    renderMenu({ onclose, scrollDismissal: 'user' });
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    document.body.dispatchEvent(
+      new PointerEvent('pointerdown', { bubbles: true, pointerType: 'touch' })
+    );
+
+    expect(onclose).toHaveBeenCalledOnce();
+  });
+
+  it('keeps user-scroll mode open for wheel input inside the menu', async () => {
+    const onclose = vi.fn();
+    const { container } = renderMenu({ onclose, scrollDismissal: 'user' });
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    const menu = q(container, '[role="menu"]');
+    if (!menu) throw new Error('menu not rendered');
+    menu.dispatchEvent(new WheelEvent('wheel', { bubbles: true }));
 
     expect(onclose).not.toHaveBeenCalled();
   });

--- a/apps/frontend/src/lib/ui/ContextMenu.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/ContextMenu.svelte.spec.ts
@@ -61,6 +61,26 @@ beforeEach(() => {
 });
 
 describe('ContextMenu', () => {
+  it('dismisses on outside scroll by default', async () => {
+    const onclose = vi.fn();
+    renderMenu({ onclose });
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    document.body.dispatchEvent(new Event('scroll'));
+
+    expect(onclose).toHaveBeenCalledOnce();
+  });
+
+  it('can remain open during outside scroll', async () => {
+    const onclose = vi.fn();
+    renderMenu({ onclose, dismissOnScroll: false });
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    document.body.dispatchEvent(new Event('scroll'));
+
+    expect(onclose).not.toHaveBeenCalled();
+  });
+
   it('uses floating presentation on hybrid devices by default', async () => {
     inputCapabilities.prefersTouchActions.mockReturnValue(true);
     inputCapabilities.supportsHoverActions.mockReturnValue(true);

--- a/apps/frontend/src/lib/ui/FloatingPopover.svelte
+++ b/apps/frontend/src/lib/ui/FloatingPopover.svelte
@@ -26,10 +26,10 @@ scroll" can simply update the prop on scroll.
 
 If `onclose` is provided, the popover dismisses itself when the user
 clicks/taps outside or, by default, scrolls a container that isn't part
-of it. Set `dismissOnScroll` to false for interactions that should survive
-unrelated programmatic scrolling. The caller still owns Escape handling
-(the dismissal contract is different between tooltips and menus, and
-`onclose` here is intentionally pointer-only).
+of it. Set `scrollDismissal` to `"user"` for interactions that should
+survive programmatic scrolling but still close before an outside wheel,
+touch/pointer, scrollbar, or keyboard scroll. The caller still owns Escape
+handling because its dismissal contract varies between tooltips and menus.
 -->
 <script lang="ts">
   import type { Snippet } from 'svelte';
@@ -48,7 +48,7 @@ unrelated programmatic scrolling. The caller still owns Escape handling
     id,
     class: className,
     onclose,
-    dismissOnScroll = true,
+    scrollDismissal = 'all',
     onmouseenter,
     onmouseleave,
     children
@@ -67,8 +67,8 @@ unrelated programmatic scrolling. The caller still owns Escape handling
      * dismissal triggers are the caller's responsibility.
      */
     onclose?: () => void;
-    /** Whether scrolling outside the popover dismisses it. */
-    dismissOnScroll?: boolean;
+    /** Which outside scrolling interactions dismiss the popover. */
+    scrollDismissal?: 'all' | 'user' | 'none';
     onmouseenter?: () => void;
     onmouseleave?: () => void;
     children: Snippet;
@@ -175,7 +175,7 @@ unrelated programmatic scrolling. The caller still owns Escape handling
   // immediately close the popover).
   function closeOnOutsideInteraction(popover: HTMLDivElement) {
     if (!open || !onclose) return;
-    const shouldDismissOnScroll = dismissOnScroll;
+    const dismissalMode = scrollDismissal;
     const handlePointerDown = (e: PointerEvent) => {
       if (popover.contains(e.target as Node)) return;
       onclose();
@@ -184,17 +184,34 @@ unrelated programmatic scrolling. The caller still owns Escape handling
       if (popover.contains(e.target as Node)) return;
       onclose();
     };
+    const handleWheel = (e: WheelEvent) => {
+      if (popover.contains(e.target as Node)) return;
+      onclose();
+    };
+    const handleScrollKey = (e: KeyboardEvent) => {
+      if (popover.contains(e.target as Node)) return;
+      if (!['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', ' '].includes(e.key)) {
+        return;
+      }
+      onclose();
+    };
     const frame = requestAnimationFrame(() => {
       document.addEventListener('pointerdown', handlePointerDown);
-      if (shouldDismissOnScroll) {
+      if (dismissalMode === 'all') {
         window.addEventListener('scroll', handleScroll, { capture: true });
+      } else if (dismissalMode === 'user') {
+        document.addEventListener('wheel', handleWheel, { capture: true });
+        document.addEventListener('keydown', handleScrollKey, { capture: true });
       }
     });
     return () => {
       cancelAnimationFrame(frame);
       document.removeEventListener('pointerdown', handlePointerDown);
-      if (shouldDismissOnScroll) {
+      if (dismissalMode === 'all') {
         window.removeEventListener('scroll', handleScroll, { capture: true });
+      } else if (dismissalMode === 'user') {
+        document.removeEventListener('wheel', handleWheel, { capture: true });
+        document.removeEventListener('keydown', handleScrollKey, { capture: true });
       }
     };
   }

--- a/apps/frontend/src/lib/ui/FloatingPopover.svelte
+++ b/apps/frontend/src/lib/ui/FloatingPopover.svelte
@@ -25,10 +25,11 @@ popover repositions reactively — callers wanting "follow the trigger on
 scroll" can simply update the prop on scroll.
 
 If `onclose` is provided, the popover dismisses itself when the user
-clicks/taps outside or scrolls a container that isn't part of it. The
-caller still owns Escape handling (the dismissal contract is different
-between tooltips and menus, and `onclose` here is intentionally
-pointer-only).
+clicks/taps outside or, by default, scrolls a container that isn't part
+of it. Set `dismissOnScroll` to false for interactions that should survive
+unrelated programmatic scrolling. The caller still owns Escape handling
+(the dismissal contract is different between tooltips and menus, and
+`onclose` here is intentionally pointer-only).
 -->
 <script lang="ts">
   import type { Snippet } from 'svelte';
@@ -47,6 +48,7 @@ pointer-only).
     id,
     class: className,
     onclose,
+    dismissOnScroll = true,
     onmouseenter,
     onmouseleave,
     children
@@ -65,6 +67,8 @@ pointer-only).
      * dismissal triggers are the caller's responsibility.
      */
     onclose?: () => void;
+    /** Whether scrolling outside the popover dismisses it. */
+    dismissOnScroll?: boolean;
     onmouseenter?: () => void;
     onmouseleave?: () => void;
     children: Snippet;
@@ -171,6 +175,7 @@ pointer-only).
   // immediately close the popover).
   function closeOnOutsideInteraction(popover: HTMLDivElement) {
     if (!open || !onclose) return;
+    const shouldDismissOnScroll = dismissOnScroll;
     const handlePointerDown = (e: PointerEvent) => {
       if (popover.contains(e.target as Node)) return;
       onclose();
@@ -181,12 +186,16 @@ pointer-only).
     };
     const frame = requestAnimationFrame(() => {
       document.addEventListener('pointerdown', handlePointerDown);
-      window.addEventListener('scroll', handleScroll, { capture: true });
+      if (shouldDismissOnScroll) {
+        window.addEventListener('scroll', handleScroll, { capture: true });
+      }
     });
     return () => {
       cancelAnimationFrame(frame);
       document.removeEventListener('pointerdown', handlePointerDown);
-      window.removeEventListener('scroll', handleScroll, { capture: true });
+      if (shouldDismissOnScroll) {
+        window.removeEventListener('scroll', handleScroll, { capture: true });
+      }
     };
   }
 </script>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -1004,7 +1004,7 @@
     <ContextMenu
       position={emojiPickerPos}
       presentation={emojiPickerPresentation}
-      dismissOnScroll={false}
+      scrollDismissal="user"
       onclose={closeEmojiPicker}
     >
       <EmojiPicker

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -1004,6 +1004,7 @@
     <ContextMenu
       position={emojiPickerPos}
       presentation={emojiPickerPresentation}
+      dismissOnScroll={false}
       onclose={closeEmojiPicker}
     >
       <EmojiPicker


### PR DESCRIPTION
## Why

Automatic timeline scrolling for newly posted room messages dismissed an open reaction emoji picker, interrupting the user's selection.

## What changed

- Added explicit all-scroll, user-scroll, and no-scroll dismissal modes to the shared floating popover and context menu primitives while preserving the existing default.
- Configured the message reaction emoji picker to survive automatic timeline scrolling but dismiss before outside wheel, touch/pointer, scrollbar, or keyboard scrolling can detach it from its message.
- Added component coverage for default dismissal, programmatic scrolling, outside wheel and touch input, and internal picker scrolling.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Not applicable.

Newer client → older server: Not applicable.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `mise x -- pnpm --filter chatto-frontend exec vitest --run src/lib/ui/ContextMenu.svelte.spec.ts` — 7 tests passed.
- `mise x -- pnpm --filter chatto-frontend check` — design-system guardrails passed; Svelte reported 0 errors and 0 warnings.
- Svelte autofixer — no issues in the changed components.
