### PR TITLE
fix(frontend): keep realtime active while looking offline

### DIFF
--- a/apps/frontend/e2e/presence-indicators.test.ts
+++ b/apps/frontend/e2e/presence-indicators.test.ts
@@ -141,6 +141,29 @@ test.describe('Presence indicators', () => {
       await otherTab.close();
     }
   });
+
+  test('continues receiving realtime messages while looking offline', async ({
+    page,
+    chatPage,
+    browser,
+    serverURL
+  }) => {
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    const roomPage = await chatPage.enterRoom('general');
+    await waitForRoomReady(page, 'general');
+
+    await choosePresenceMode(page, 'Look offline');
+    await expect(currentUserPresenceDot(page)).toHaveClass(/bg-presence-offline/);
+
+    const message = `Realtime while offline ${Date.now()}`;
+    await withServerUser(browser!, serverURL, async ({ chatPage: senderChatPage }) => {
+      const senderRoomPage = await senderChatPage.enterRoom('general');
+      await senderRoomPage.sendMessage(message);
+    });
+
+    await roomPage.expectMessageVisible(message, { timeout: TIMEOUTS.REALTIME_EVENT });
+  });
 });
 
 test.describe('Message avatar presence', () => {

--- a/apps/frontend/src/lib/presenceTracking.spec.ts
+++ b/apps/frontend/src/lib/presenceTracking.spec.ts
@@ -29,8 +29,6 @@ let windowTarget: EventTarget;
 let visibilityState: DocumentVisibilityState;
 let cleanup: (() => void) | null;
 let onStatusChange: Mock<PresenceStatusHandler>;
-let onPauseLiveEvents: Mock<() => void>;
-let onResumeLiveEvents: Mock<() => void>;
 
 function dispatchDocumentEvent(type: string) {
 	documentTarget.dispatchEvent(new Event(type));
@@ -56,12 +54,9 @@ function setVisibility(next: DocumentVisibilityState) {
 
 function startTracking() {
 	onStatusChange = vi.fn<PresenceStatusHandler>();
-	onPauseLiveEvents = vi.fn();
-	onResumeLiveEvents = vi.fn();
 	cleanup = initPresenceTracking(
 		() => [{ serverId: 'origin', baseUrl: 'https://chat.example.test/api/connect', bearerToken: 't' }],
-		onStatusChange,
-		{ onPauseLiveEvents, onResumeLiveEvents }
+		onStatusChange
 	);
 }
 
@@ -235,7 +230,7 @@ describe('initPresenceTracking', () => {
 		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.DoNotDisturb);
 	});
 
-	it('does not update presence while invisible and pauses live events', () => {
+	it('does not update presence while invisible and returns online when automatic mode resumes', () => {
 		startTracking();
 		setPresenceMode('invisible');
 		vi.advanceTimersByTime(60_000);
@@ -243,12 +238,20 @@ describe('initPresenceTracking', () => {
 
 		expect(sentStatuses()).toEqual([APIPresenceStatus.ONLINE]);
 		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.Offline);
-		expect(onPauseLiveEvents).toHaveBeenCalledOnce();
 
 		setPresenceMode('auto');
 
-		expect(onResumeLiveEvents).toHaveBeenCalled();
 		expect(sentStatuses()).toEqual([APIPresenceStatus.ONLINE, APIPresenceStatus.ONLINE]);
 		expect(sentUserSelectedFlags()).toEqual([false, true]);
+	});
+
+	it('starts without reporting presence when look offline was persisted', () => {
+		localStorage.setItem(__presenceTrackingTest.PRESENCE_MODE_STORAGE_KEY, 'invisible');
+
+		startTracking();
+		vi.advanceTimersByTime(60_000);
+
+		expect(sentStatuses()).toEqual([]);
+		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.Offline);
 	});
 });

--- a/apps/frontend/src/lib/presenceTracking.ts
+++ b/apps/frontend/src/lib/presenceTracking.ts
@@ -12,11 +12,6 @@ type ActivityState = 'active' | 'idle' | 'hidden';
 
 export type PresenceReporterConfig = PresenceAPIConfig;
 
-export type PresenceTrackingOptions = {
-	onPauseLiveEvents?: () => void;
-	onResumeLiveEvents?: () => void;
-};
-
 let initialized = false;
 let applyModeFromUI: ((mode: PresenceMode) => void) | null = null;
 
@@ -69,10 +64,6 @@ function readStoredMode(): PresenceMode {
 	return 'auto';
 }
 
-export function shouldPauseLiveEventsForStoredPresence(): boolean {
-	return readStoredMode() === 'invisible';
-}
-
 function storeMode(mode: PresenceMode) {
 	if (typeof localStorage === 'undefined') return;
 	localStorage.setItem(PRESENCE_MODE_STORAGE_KEY, mode);
@@ -86,8 +77,7 @@ export function setPresenceMode(mode: PresenceMode) {
 
 export function initPresenceTracking(
 	getReporters: () => PresenceReporterConfig[],
-	onStatusChange?: (status: PresenceStatus) => void,
-	options: PresenceTrackingOptions = {}
+	onStatusChange?: (status: PresenceStatus) => void
 ): () => void {
 	if (initialized) return () => {};
 	initialized = true;
@@ -169,11 +159,9 @@ export function initPresenceTracking(
 			reportRevision++;
 			currentVisibleStatus = null;
 			emitLocalStatus(PresenceStatus.Offline);
-			options.onPauseLiveEvents?.();
 			return;
 		}
 
-		options.onResumeLiveEvents?.();
 		if (mode === 'auto') {
 			currentState = document.visibilityState === 'hidden' ? 'hidden' : 'active';
 			const userSelected = persist || syncedFromStorage;

--- a/apps/frontend/src/lib/state/server/eventBus.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/eventBus.svelte.spec.ts
@@ -208,7 +208,6 @@ describe('eventBusManager realtime transport', () => {
   });
 
   afterEach(() => {
-    eventBusManager.resumeAll();
     eventBusManager.stopBus(TEST_SERVER);
     setRealtimeSocketFactoryForTests(null);
     consoleError.mockRestore();
@@ -519,23 +518,5 @@ describe('eventBusManager realtime transport', () => {
 
     expect(sockets).toHaveLength(1);
     expect(sockets[0].closeCalls).toHaveLength(1);
-  });
-
-  it('pauseAll stops active buses and blocks later startBus calls until resumeAll', async () => {
-    const fake = new FakeServerConnection();
-    await startAndSubscribe(fake);
-    expect(sockets).toHaveLength(1);
-
-    eventBusManager.pauseAll();
-    expect(eventBusManager.getBus(TEST_SERVER)).toBeUndefined();
-
-    eventBusManager.startBus(TEST_SERVER, fake as unknown as ServerConnection);
-    expect(sockets).toHaveLength(1);
-    expect(eventBusManager.getBus(TEST_SERVER)).toBeUndefined();
-
-    eventBusManager.resumeAll();
-    eventBusManager.startBus(TEST_SERVER, fake as unknown as ServerConnection);
-    expect(sockets).toHaveLength(2);
-    expect(eventBusManager.getBus(TEST_SERVER)).toBeDefined();
   });
 });

--- a/apps/frontend/src/lib/state/server/eventBus.svelte.ts
+++ b/apps/frontend/src/lib/state/server/eventBus.svelte.ts
@@ -91,14 +91,12 @@ class EventBusManager {
   #buses = new SvelteMap<string, EventBus>();
   #subscriptions = new Map<string, { unsubscribe: () => void }>();
   #cleanups = new Map<string, () => void>();
-  #paused = false;
 
   /**
    * Start an event bus for the given server. Creates the realtime socket and
    * stores the bus. If a bus already exists for this server, returns a no-op.
    */
   startBus(serverId: string, serverConnection: ServerConnection): () => void {
-    if (this.#paused) return () => {};
     if (this.#buses.has(serverId)) return () => {};
 
     const handlers = new SvelteSet<EventHandler>();
@@ -405,17 +403,6 @@ class EventBusManager {
     for (const serverId of [...this.#buses.keys()]) {
       this.stopBus(serverId);
     }
-  }
-
-  /** Stop all event streams and block new starts until resumeAll() is called. */
-  pauseAll(): void {
-    this.#paused = true;
-    this.stopAll();
-  }
-
-  /** Allow event streams to be started again. Callers decide which buses to restart. */
-  resumeAll(): void {
-    this.#paused = false;
   }
 }
 

--- a/apps/frontend/src/routes/chat/AuthenticatedChatProvider.svelte
+++ b/apps/frontend/src/routes/chat/AuthenticatedChatProvider.svelte
@@ -190,19 +190,6 @@
         currentUserPresenceStores(),
         status
       );
-    },
-    {
-      onPauseLiveEvents: () => {
-        eventBusManager.pauseAll();
-      },
-      onResumeLiveEvents: () => {
-        eventBusManager.resumeAll();
-        for (const server of serverRegistry.servers) {
-          if (serverRegistry.tryGetStore(server.id)?.isAuthenticated) {
-            eventBusManager.startBus(server.id, serverConnectionManager.getClient(server.id));
-          }
-        }
-      }
     }
   );
   onDestroy(stopPresenceTracking);

--- a/apps/frontend/src/routes/chat/AuthenticatedRoot.svelte
+++ b/apps/frontend/src/routes/chat/AuthenticatedRoot.svelte
@@ -3,7 +3,6 @@
   import type { CurrentUser } from '$lib/auth/loadAuth';
   import AuthStatusNotice from '$lib/components/AuthStatusNotice.svelte';
   import NotificationSync from '$lib/components/NotificationSync.svelte';
-  import { shouldPauseLiveEventsForStoredPresence } from '$lib/presenceTracking';
   import type { PresenceCache } from '$lib/state/presenceCache.svelte';
   import { serverConnectionManager } from '$lib/state/server/serverConnection.svelte';
   import { eventBusManager } from '$lib/state/server/eventBus.svelte';
@@ -27,11 +26,6 @@
   } = $props();
 
   function startAuthenticatedBuses() {
-    if (shouldPauseLiveEventsForStoredPresence()) {
-      eventBusManager.pauseAll();
-      return;
-    }
-
     for (const server of serverRegistry.servers) {
       const store = serverRegistry.tryGetStore(server.id);
       if (store?.isAuthenticated) {

--- a/docs/architecture/realtime-delivery.md
+++ b/docs/architecture/realtime-delivery.md
@@ -1,6 +1,12 @@
 # Realtime Delivery Inventory
 
-Key files: [`proto/chatto/realtime/v1/realtime.proto`](../../proto/chatto/realtime/v1/realtime.proto), [`cli/internal/http_server/realtime.go`](../../cli/internal/http_server/realtime.go), [`cli/internal/core/my_events_model.go`](../../cli/internal/core/my_events_model.go)
+Key files:
+
+- [`proto/chatto/realtime/v1/realtime.proto`](../../proto/chatto/realtime/v1/realtime.proto)
+- [`cli/internal/http_server/realtime.go`](../../cli/internal/http_server/realtime.go)
+- [`cli/internal/core/my_events_model.go`](../../cli/internal/core/my_events_model.go)
+- [`apps/frontend/src/lib/state/server/eventBus.svelte.ts`](../../apps/frontend/src/lib/state/server/eventBus.svelte.ts)
+- [`apps/frontend/src/lib/presenceTracking.ts`](../../apps/frontend/src/lib/presenceTracking.ts)
 
 Related decision: [ADR-049](../adr/ADR-049-process-wide-realtime-event-hub.md).
 
@@ -23,6 +29,11 @@ touching disabled, then maps the already-authorized core envelope into public
 event gates, projection readiness, live membership changes, slow-consumer
 shutdown, and session termination therefore remain shared with
 `core.StreamMyEvents`.
+
+The frontend keeps an authenticated server's realtime stream connected
+independently of the local presence mode. "Look offline" stops presence
+refreshes and lets the live presence record expire; it does not pause event
+delivery. Realtime connection establishment itself does not touch presence.
 
 A process-wide `MyEventsHub` owns one NATS Core subscription to `live.sync.>`
 and one to `live.evt.>`. It classifies subjects before decoding, waits for

--- a/docs/fdr/FDR-011-user-presence.md
+++ b/docs/fdr/FDR-011-user-presence.md
@@ -1,7 +1,7 @@
 # FDR-011: User Presence
 
 **Status:** Active
-**Last reviewed:** 2026-07-14
+**Last reviewed:** 2026-07-18
 
 ## Overview
 
@@ -16,7 +16,7 @@ Every user has a presence status visible to others as a colored dot on their ava
 - Users can explicitly set Away. Explicit Away does not auto-return to Online on activity.
 - Users can set Do Not Disturb for their current live server presence. While DND is active, new notifications are still recorded for that user, but notification sounds and web push are suppressed (see FDR-012). Presence state is not persisted as server-side user/account state.
 - Explicit Away and Do Not Disturb are marked as manually selected in the live presence record. Automatic Online/Away reports from other clients do not overwrite that manual state; an explicit Online selection clears it.
-- Users can choose "Look offline" locally. The client does not report an Offline status; it stops reporting presence to the server and pauses live event subscriptions so the existing presence record expires normally.
+- Users can choose "Look offline" locally. The client does not report an Offline status; it stops reporting presence so the existing presence record expires normally while messages and other realtime updates continue working.
 - Disconnecting (closing the tab, network drop) does not send an active Offline signal. After 60 seconds without a heartbeat refresh, the presence entry expires and the user appears Offline.
 - The presence dot updates across the UI as other users' statuses change, in real time.
 - If a live connection falls behind presence updates, it reconnects and recovers current presence instead of remaining silently stale.
@@ -55,9 +55,9 @@ Every user has a presence status visible to others as a colored dot on their ava
 
 ### 6. Invisible mode is client-local privacy behavior
 
-**Decision:** "Look offline" is not a server status. The client stops refreshing presence and stops receiving live event streams while the local mode is active. The server and other users only see the existing presence record expire.
-**Why:** Reporting an explicit invisible/offline status would make the server aware of the user's privacy choice and could leak it to other clients or operators through logs, admin tooling, or future APIs. Absence of reporting preserves the privacy property.
-**Tradeoff:** The user's own client loses realtime updates while invisible and must catch up from projected reads after returning to a reporting mode.
+**Decision:** "Look offline" is not a server status. The client stops refreshing presence while keeping its realtime event streams active. The server and other users only see the existing presence record expire.
+**Why:** Reporting an explicit invisible/offline status would make the server aware of the user's privacy choice and could leak it as presence state. Keeping realtime delivery independent from presence lets the app remain fully functional without reporting the user's availability choice.
+**Tradeoff:** The server can still observe ordinary authenticated activity, including API requests and an active realtime connection. "Look offline" controls the presence shown to other users; it is not an anonymity mode. Another active browser or device can also keep the user visibly present.
 
 ### 7. Per-server tracking, with frontend coordination across servers
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -20,7 +20,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-008](FDR-008-file-attachments-and-video.md) | File Attachments & Video Processing | Active | 2026-07-10 |
 | [FDR-009](FDR-009-link-previews.md) | Link Previews | Active | 2026-07-15 |
 | [FDR-010](FDR-010-typing-indicators.md) | Typing Indicators | Active | 2026-05-19 |
-| [FDR-011](FDR-011-user-presence.md) | User Presence | Active | 2026-07-14 |
+| [FDR-011](FDR-011-user-presence.md) | User Presence | Active | 2026-07-18 |
 | [FDR-012](FDR-012-notifications.md) | Notifications | Active | 2026-07-01 |
 | [FDR-013](FDR-013-web-push-notifications.md) | Web Push Notifications | Active | 2026-07-10 |
 | [FDR-014](FDR-014-jump-to-present.md) | Jump to Present | Active | 2026-05-19 |


### PR DESCRIPTION
## Why

Choosing "Look offline" stopped every realtime event bus, leaving the app unable to receive messages or other live updates. Looking offline should affect the presence shown to other members without disabling core application functionality.

## What changed

- Keep authenticated realtime streams connected when the local presence mode is invisible.
- Remove the obsolete presence-driven event-bus pause and resume lifecycle.
- Document that "Look offline" suppresses presence refreshes but is not an anonymity mode.
- Add unit coverage for persisted invisible mode and a browser regression proving messages still arrive in realtime.

## API compatibility

- No public API or protocol behaviour changed.
- This is frontend-only and works with existing servers; no capability discovery or minimum server version is required.
- The implementation closely matches the `v0.4.13` source layout and is suitable for a later 0.4.x backport.

## Test plan

- `mise x -- pnpm --filter chatto-frontend check` — passed with 0 errors and 0 warnings.
- Targeted ESLint for all changed frontend source and test files — passed.
- Focused Vitest suite for presence tracking and the realtime event bus — 25 tests passed.
- Playwright regression `continues receiving realtime messages while looking offline` — passed.
- `git diff --check origin/main...HEAD` — passed.
