### PR TITLE
fix(assets): mark NATS streams as non-seekable

### DIFF
--- a/apps/docs-website/src/content/docs/guides/infrastructure/media-attachments.mdx
+++ b/apps/docs-website/src/content/docs/guides/infrastructure/media-attachments.mdx
@@ -56,7 +56,7 @@ Supported public Bluesky and Mastodon post URLs render as native Chatto cards. P
 | ---------- | ------------------- |
 | Small server with light uploads | NATS ObjectStore, the default. |
 | Active community with many files | S3-compatible storage. |
-| Video-heavy server | S3-compatible storage plus video processing. |
+| Video playback with seeking | S3-compatible storage plus video processing. |
 | Replicated NATS cluster | S3-compatible storage to avoid multiplying large binary storage. |
 
 Switching to S3 affects new assets. Existing NATS-stored assets continue to work because each asset records its own backend.
@@ -77,6 +77,10 @@ The official Docker image includes the required ffmpeg tools. Host installs need
 
 <Aside type="caution">
   Video processing is currently in-process and best-effort. Chatto records durable asset processing state and retries missed unmanifested video assets on boot, but operators should still treat transcoding as CPU-heavy background work.
+</Aside>
+
+<Aside type="caution">
+  NATS ObjectStore serves video as a complete, non-seekable response. Configure S3-compatible asset storage when members need reliable duration detection or timeline seeking; authorised S3-backed video redirects to object storage with byte-range support.
 </Aside>
 
 ## Active Document Safety

--- a/cli/internal/http_server/assets.go
+++ b/cli/internal/http_server/assets.go
@@ -197,6 +197,9 @@ func (s *HTTPServer) serveStableAttachment(c *gin.Context) {
 	c.Header("Cache-Control", protectedAssetCacheControl)
 	c.Header("ETag", fmt.Sprintf("\"%s\"", assetID))
 	c.Header("Vary", "Accept-Encoding, Authorization, Cookie")
+	// Chatto-backed streams are sequential. Seekable media delivery requires an
+	// S3 redirect, whose object server handles byte ranges directly.
+	c.Header("Accept-Ranges", "none")
 	c.DataFromReader(http.StatusOK, info.Size, contentType, reader, nil)
 }
 

--- a/cli/internal/http_server/assets_test.go
+++ b/cli/internal/http_server/assets_test.go
@@ -592,6 +592,9 @@ func TestAsset_OriginalAttachment_ServesCorrectly(t *testing.T) {
 	if originalResp.StatusCode != http.StatusOK {
 		t.Errorf("Expected 200 OK, got %d", originalResp.StatusCode)
 	}
+	if got := originalResp.Header.Get("Accept-Ranges"); got != "none" {
+		t.Errorf("Expected Accept-Ranges: none, got %q", got)
+	}
 
 	// Should have correct content type
 	contentType := originalResp.Header.Get("Content-Type")
@@ -606,6 +609,32 @@ func TestAsset_OriginalAttachment_ServesCorrectly(t *testing.T) {
 	}
 	if len(body) == 0 {
 		t.Error("Expected non-empty response body")
+	}
+
+	// Chatto-backed attachments intentionally ignore Range and return the full
+	// object. Deployments that need seekable media should use S3 redirects.
+	rangeRequest, err := http.NewRequest(http.MethodGet, env.server.URL+attachmentURL, nil)
+	if err != nil {
+		t.Fatalf("Failed to create range request: %v", err)
+	}
+	rangeRequest.Header.Set("Range", "bytes=1-2")
+	rangeResp, err := env.client.Do(rangeRequest)
+	if err != nil {
+		t.Fatalf("Failed to get ranged original attachment: %v", err)
+	}
+	defer rangeResp.Body.Close()
+	if rangeResp.StatusCode != http.StatusOK {
+		t.Fatalf("Expected full 200 response for Range request, got %d", rangeResp.StatusCode)
+	}
+	if got := rangeResp.Header.Get("Accept-Ranges"); got != "none" {
+		t.Fatalf("Expected Accept-Ranges: none, got %q", got)
+	}
+	rangeBody, err := io.ReadAll(rangeResp.Body)
+	if err != nil {
+		t.Fatalf("Failed to read ranged response body: %v", err)
+	}
+	if !bytes.Equal(rangeBody, imageData) {
+		t.Fatal("Range request did not return the complete attachment")
 	}
 }
 

--- a/docs/architecture/interfaces.md
+++ b/docs/architecture/interfaces.md
@@ -2,6 +2,7 @@
 
 Key files: [`cli/internal/connectapi/api.go`](../../cli/internal/connectapi/api.go),
 [`cli/internal/http_server/connect.go`](../../cli/internal/http_server/connect.go),
+[`cli/internal/http_server/assets.go`](../../cli/internal/http_server/assets.go),
 [`cli/internal/http_server/realtime.go`](../../cli/internal/http_server/realtime.go),
 [`proto/chatto/`](../../proto/chatto/)
 
@@ -19,6 +20,7 @@ Related decisions: [ADR-044](../adr/ADR-044-connectrpc-service-conventions.md) a
 | ------- | ----- | -------- | --------------- |
 | Public ConnectRPC | `/api/connect/chatto.{auth,discovery,api,admin}.v1.*` | Unary Connect, gRPC, and gRPC-Web services | Explicit per-service public or authenticated-user policy; method-level authorization remains inside operation models |
 | Realtime WebSocket | `GET /api/realtime` | Binary `chatto.realtime.v1.Realtime*` frames | Bearer token in the hello frame or same-origin cookie; per-event authorization in `StreamMyEvents` |
+| Protected attachments | `GET /assets/files/{assetId}` and image transform variants | Stable per-user URLs; Chatto streams full responses, while passive S3-backed video, audio, and large files can redirect to short-lived presigned URLs | Signed `access` ticket, authenticated cookie, or bearer token; every request rechecks room membership before resolving storage or exposing binary bytes |
 | Operator ConnectRPC | `/api/connect/chatto.operator.v1.*` on the configured Unix socket | Root-equivalent local unary services | Unix-socket filesystem permissions; never mounted on the public listener |
 | Reflection | `/api/connect/grpc.reflection.v1*` and `v1alpha*` | Public service descriptors | Public; restricted resolver excludes internal `chatto.core.v1` persistence types |
 
@@ -62,3 +64,9 @@ Public URL generation prefers the configured `webserver.url`. Without it, the
 HTTP edge uses only the direct request TLS state and host; forwarded protocol
 headers are not implicitly trusted. `webserver.trusted_proxies` affects client
 IP attribution and realtime same-origin comparison, not public URL authority.
+
+Chatto-streamed protected attachments are sequential full responses. They
+advertise `Accept-Ranges: none` and ignore `Range`, returning `200` with the
+complete object. NATS-backed video is therefore not seekable. Passive S3-backed
+media redirects after authorization to a presigned object URL whose storage
+backend provides byte-range delivery.

--- a/docs/fdr/FDR-008-file-attachments-and-video.md
+++ b/docs/fdr/FDR-008-file-attachments-and-video.md
@@ -1,7 +1,7 @@
 # FDR-008: File Attachments & Video Processing
 
 **Status:** Active
-**Last reviewed:** 2026-07-10
+**Last reviewed:** 2026-07-19
 
 ## Overview
 
@@ -21,7 +21,7 @@ Users can attach files to messages — images, videos, documents — via drag-an
 - Processed video dimensions are display dimensions used for layout, not necessarily raw encoded storage pixels. Non-square-pixel and rotated sources should render in their intended orientation and aspect ratio. The room timeline displays every posted video uncropped at its measured aspect ratio, including unusual near-square dimensions and converted animated GIF loops. The player canvas is bounded to the available timeline width and a maximum height; for ratios beyond 9:16 or 16:9, it uses letterboxing so playback controls remain usable without cropping the video.
 - A thumbnail is generated from an early video frame using the same display dimensions, so non-square-pixel sources do not persist squished or pillarboxed poster images.
 - Opaque static attachment derivatives use JPEG quality 75. Derivatives that require transparency or animation use lossless WebP, and resized results can be held in the auto-expiring server cache.
-- Browser media uses direct signed asset URLs. Relative attachment URLs are resolved against the server that owns the message or room-file item, so remote-server images, audio, and video can load without cross-site cookies or bearer headers.
+- Browser media uses direct signed asset URLs. Relative attachment URLs are resolved against the server that owns the message or room-file item, so remote-server images, audio, and video can load without cross-site cookies or bearer headers. Chatto-streamed NATS objects are full, non-seekable responses; S3-backed passive media redirects to object storage for byte-range delivery.
 - Clients refresh expiring attachment URL fields through room-scoped `AssetService.GetAsset` / `BatchGetAssets`, or by refetching the relevant timeline or room attachment-list page. The timeline, previews, lightbox, downloads, and room-files surfaces refresh before expiry and retry after media load errors.
 - Active document attachment types such as HTML, XHTML, SVG, and XML can still be uploaded and viewed inline, but original-file responses are delivered in a browser sandbox so uploaded scripts do not run as trusted Chatto application code.
 - The room sidebar Files panel lists current accessible attachments from both root messages and thread replies, grouped by date as Today, Yesterday, This week, This month, then older calendar months. Rows show a thumbnail or file-type icon, filename, and upload time; selecting a root-message attachment jumps the room timeline to that message, while selecting a thread-reply attachment opens the thread pane and highlights the reply.
@@ -39,7 +39,7 @@ Users can attach files to messages — images, videos, documents — via drag-an
 
 **Decision:** Attachments can be stored in NATS ObjectStore (default, good for development and small deployments) or in an S3-compatible bucket (production-grade). Each asset records its storage backend and logical key at upload time; S3 deployments may add a configurable object-key prefix that is applied only at the S3 client boundary.
 **Why:** Self-hosters running a single binary shouldn't have to spin up S3 just to send a screenshot. Larger operators need durable, replicated object storage. Supporting both lets us serve both ends of the spectrum. See ADR-021.
-**Tradeoff:** Migration between backends or S3 prefixes is operator-managed. Stored asset keys remain prefix-free so moving objects between S3 base paths does not require rewriting Chatto metadata.
+**Tradeoff:** Migration between backends or S3 prefixes is operator-managed. Stored asset keys remain prefix-free so moving objects between S3 base paths does not require rewriting Chatto metadata. NATS ObjectStore does not expose offset-aware reads, so Chatto serves those videos as complete non-seekable responses; deployments that require reliable duration detection and seeking must use S3.
 
 ### 3. Video processing is in-process and best-effort
 


### PR DESCRIPTION
## Why

NATS ObjectStore exposes sequential reads, so emulating byte ranges added substantial complexity and created read-amplification and failure-recovery risks; this takes the deliberately simpler, backportable path for #1589 while #668 tracks HLS for 0.5.0.

## What changed

- Chatto-streamed protected attachments advertise `Accept-Ranges: none` and continue to answer `Range` requests with the complete `200` response after authorization; cache, security, CORS, content type, and reader cleanup behavior remain unchanged.
- S3 redirects remain unchanged and continue to provide seekable byte-range delivery, while architecture, feature, and operator documentation now explain the backend tradeoff.

## API compatibility

Behavioural and compatible public HTTP clarification: existing clients keep receiving the same full response from Chatto-backed storage, with an additive `Accept-Ranges: none` header; no protobuf, generated client, persistence, discovery, or frontend API changes are involved, and the single commit is suitable for a 0.4.x cherry-pick.

## Test plan

- `mise x -- go test -tags test_endpoints ./internal/http_server -count=1`
- `mise lint`
- `mise x -- pnpm exec playwright test e2e/video-player.test.ts --retries=0`

Closes #1589.
