### PR TITLE
fix(frontend): preserve pasted message line breaks

### DIFF
--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -228,9 +228,10 @@ function pasteFile(target: HTMLElement, file: File) {
   );
 }
 
-function pasteText(target: HTMLElement, text: string) {
+function pasteText(target: HTMLElement, text: string, html?: string) {
   const dataTransfer = new DataTransfer();
   dataTransfer.setData('text/plain', text);
+  if (html !== undefined) dataTransfer.setData('text/html', html);
   target.dispatchEvent(
     new ClipboardEvent('paste', {
       bubbles: true,
@@ -288,6 +289,17 @@ async function placeCaretAtEditorEnd(editor: HTMLElement) {
   range.collapse(false);
   selection?.removeAllRanges();
   selection?.addRange(range);
+  await tick();
+}
+
+async function selectEditorContents(editor: HTMLElement) {
+  editor.focus();
+  const selection = window.getSelection();
+  const range = document.createRange();
+  range.selectNodeContents(editor);
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+  document.dispatchEvent(new Event('selectionchange'));
   await tick();
 }
 
@@ -1573,6 +1585,187 @@ describe('MessageComposer', () => {
       expect(mutationMock.mock.calls[0][1].input).toMatchObject({
         roomId,
         body: '[example](https://example.com)'
+      });
+    });
+
+    it('preserves a single pasted line break without creating separate paragraphs', async () => {
+      const { container, roomId } = renderMessageComposer({ roomId: 'room_456' });
+      const editor = await findEditor(container);
+
+      editor.focus();
+      pasteText(editor, 'test line one\ntest line two');
+
+      await vi.waitFor(() => {
+        expect(editor.querySelectorAll(':scope > p')).toHaveLength(1);
+        expect(editor.querySelectorAll('br')).toHaveLength(1);
+      });
+
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({
+        roomId,
+        body: 'test line one  \ntest line two'
+      });
+    });
+
+    it('preserves active inline formatting when pasting plain text', async () => {
+      const { container, roomId } = renderMessageComposer({ roomId: 'room_456' });
+      const editor = await findEditor(container);
+
+      editor.focus();
+      await pressEditorKey(
+        editor,
+        'b',
+        navigator.platform.startsWith('Mac') ? { metaKey: true } : { ctrlKey: true }
+      );
+      pasteText(editor, 'pasted text');
+
+      await vi.waitFor(() => {
+        expect(editor.querySelector('strong')?.textContent).toBe('pasted text');
+      });
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({
+        roomId,
+        body: '**pasted text**'
+      });
+    });
+
+    it('combines active inline formatting with a pasted autolink', async () => {
+      const url = 'https://example.com/';
+      const { container } = renderMessageComposer({ roomId: 'room_456' });
+      const editor = await findEditor(container);
+
+      editor.focus();
+      await pressEditorKey(
+        editor,
+        'b',
+        navigator.platform.startsWith('Mac') ? { metaKey: true } : { ctrlKey: true }
+      );
+      pasteText(editor, url);
+
+      await vi.waitFor(() => {
+        expect(editor.querySelector('a')?.textContent).toBe(url);
+        expect(editor.querySelector('strong')?.textContent).toBe(url);
+      });
+    });
+
+    it('pastes unsupported Markdown syntax literally over selected text', async () => {
+      const { container } = renderMessageComposer({ roomId: 'room_456' });
+      const editor = await findEditor(container);
+
+      await typeInEditor(editor, 'replace me');
+      await selectEditorContents(editor);
+      pasteText(editor, '---');
+
+      await vi.waitFor(() => {
+        expect(editor.textContent).toBe('---');
+        expect(editor.querySelector('hr')).toBeNull();
+      });
+    });
+
+    it('preserves an intentional blank line in pasted text', async () => {
+      const body = 'first paragraph\n\nsecond paragraph';
+      const { container, roomId } = renderMessageComposer({ roomId: 'room_456' });
+      const editor = await findEditor(container);
+
+      editor.focus();
+      pasteText(editor, body);
+
+      await vi.waitFor(() => expect(editor.querySelectorAll(':scope > p')).toHaveLength(2));
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({ roomId, body });
+    });
+
+    it('preserves pasted fenced code without adding line breaks between source lines', async () => {
+      const body = [
+        '```go',
+        'type Conn struct {',
+        '\trwc     io.ReadWriteCloser',
+        '\terr     error',
+        '\tr, w, x sync.Mutex',
+        '}',
+        '```'
+      ].join('\n');
+      const { container, roomId } = renderMessageComposer({ roomId: 'room_456' });
+      const editor = await findEditor(container);
+
+      editor.focus();
+      pasteText(editor, body);
+
+      await vi.waitFor(() => {
+        expect(editor.querySelector('pre code')?.textContent).toBe(
+          'type Conn struct {\n\trwc     io.ReadWriteCloser\n\terr     error\n\tr, w, x sync.Mutex\n}'
+        );
+      });
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({ roomId, body });
+    });
+
+    it('prefers plain text when pasted clipboard data also contains HTML', async () => {
+      const { container, roomId } = renderMessageComposer({ roomId: 'room_456' });
+      const editor = await findEditor(container);
+
+      editor.focus();
+      pasteText(editor, 'plain line one\nplain line two', '<p>wrong HTML</p><p>content</p>');
+
+      await vi.waitFor(() => {
+        expect(editor.textContent).toBe('plain line oneplain line two');
+        expect(editor.querySelectorAll(':scope > p')).toHaveLength(1);
+      });
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({
+        roomId,
+        body: 'plain line one  \nplain line two'
+      });
+    });
+
+    it('preserves multiline text pasted while editing', async () => {
+      roomStateMock.editState.eventId = 'evt_edit';
+      roomStateMock.editState.originalBody = 'original body';
+      const { container } = renderMessageComposer({ roomId: 'room_456' });
+      const editor = await findEditor(container);
+
+      await vi.waitFor(() => expect(editor.textContent).toBe('original body'));
+      await placeCaretAtEditorEnd(editor);
+      pasteText(editor, 'edited line one\nedited line two');
+
+      await vi.waitFor(() => expect(editor.querySelectorAll('br')).toHaveLength(1));
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(updateMessageConnectMock).toHaveBeenCalledOnce());
+      expect(updateMessageConnectMock).toHaveBeenCalledWith({
+        roomId: expect.any(String),
+        eventId: 'evt_edit',
+        body: 'original bodyedited line one  \nedited line two'
+      });
+    });
+
+    it('pastes multiline text literally inside an active code block', async () => {
+      const { container, roomId } = renderMessageComposer({ roomId: 'room_456' });
+      const editor = await findEditor(container);
+
+      await typeEditorLiteralText(editor, '```go ');
+      await vi.waitFor(() => expect(editor.querySelector('pre code')).toBeTruthy());
+      pasteText(editor, 'line one\nline two');
+
+      await vi.waitFor(() => {
+        expect(editor.querySelector('pre code')?.textContent).toBe('line one\nline two');
+      });
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({
+        roomId,
+        body: '```go\nline one\nline two\n```'
       });
     });
 

--- a/apps/frontend/src/lib/components/composer/TipTapEditor.svelte
+++ b/apps/frontend/src/lib/components/composer/TipTapEditor.svelte
@@ -19,7 +19,13 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
 <script lang="ts">
   import { tick, untrack } from 'svelte';
   import { Editor, Extension, InputRule, mergeAttributes, type JSONContent } from '@tiptap/core';
-  import type { Node as ProseMirrorNode, Schema } from '@tiptap/pm/model';
+  import {
+    Fragment,
+    Slice,
+    type Mark,
+    type Node as ProseMirrorNode,
+    type Schema
+  } from '@tiptap/pm/model';
   import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state';
   import StarterKit from '@tiptap/starter-kit';
   import Link from '@tiptap/extension-link';
@@ -643,6 +649,58 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     );
   }
 
+  function createLiteralClipboardContent(
+    text: string,
+    schema: Schema,
+    destinationMarks: readonly Mark[]
+  ): Fragment {
+    const paragraphType = schema.nodes.paragraph;
+    const hardBreakType = schema.nodes.hardBreak;
+    const paragraphMarks = paragraphType.allowedMarks(destinationMarks);
+
+    return Fragment.fromArray(
+      text.split(/\n{2,}/).map((paragraphText) => {
+        const inlineNodes: ProseMirrorNode[] = [];
+        const lines = paragraphText.split('\n');
+
+        lines.forEach((line, index) => {
+          if (line) inlineNodes.push(schema.text(line, paragraphMarks));
+          if (index < lines.length - 1) inlineNodes.push(hardBreakType.create());
+        });
+
+        return paragraphType.create(null, inlineNodes);
+      })
+    );
+  }
+
+  function parseCompleteFencedCodeBlock(
+    text: string,
+    schema: Schema,
+    parseMarkdown: (markdown: string) => JSONContent
+  ): Fragment | null {
+    const lines = text.split('\n');
+    if (lines.at(-1) === '') lines.pop();
+    if (lines.length < 2) return null;
+
+    const openingFence = lines[0]?.match(/^ {0,3}(`{3,}|~{3,})[^\n]*$/)?.[1];
+    if (!openingFence) return null;
+
+    const fenceCharacter = openingFence[0];
+    const closingFence = lines.at(-1)?.match(/^ {0,3}(`+|~+)[ \t]*$/)?.[1];
+    if (
+      !closingFence ||
+      closingFence[0] !== fenceCharacter ||
+      closingFence.length < openingFence.length
+    ) {
+      return null;
+    }
+
+    const document = schema.nodeFromJSON(parseMarkdown(escapeMarkdownHtml(text)));
+    if (document.childCount !== 1 || document.firstChild?.type.name !== 'codeBlock') return null;
+
+    return document.content;
+  }
+
   function hasDefaultEmptyDocument(e: Editor): boolean {
     return isDefaultEmptyDocument(e.state.doc);
   }
@@ -1220,8 +1278,35 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
             handleKeyDown: (_view, event) => {
               return onKeyDown?.(event) ?? false;
             },
-            handlePaste: (_view, event) => {
-              return onPaste?.(event) ?? false;
+            clipboardTextParser: (text, context, _plain, view) => {
+              const normalizedText = text.replace(/\r\n?/g, '\n');
+              const markdown = editor?.markdown;
+              const destinationMarks = view.state.storedMarks ?? context.marks();
+              const fencedCode = markdown
+                ? parseCompleteFencedCodeBlock(
+                    normalizedText,
+                    view.state.schema,
+                    markdown.parse.bind(markdown)
+                  )
+                : null;
+
+              // Keep ordinary clipboard text literal. ProseMirror's default parser turns every
+              // pasted line into a paragraph, which creates an extra rendered blank line.
+              const content =
+                fencedCode ??
+                createLiteralClipboardContent(normalizedText, view.state.schema, destinationMarks);
+              return Slice.maxOpen(content);
+            },
+            handlePaste: (view, event) => {
+              if (onPaste?.(event)) return true;
+
+              const text = event.clipboardData?.getData('text/plain');
+              const html = event.clipboardData?.getData('text/html');
+              if (!text || !html || editor?.isActive('codeBlock')) return false;
+
+              // Prefer the textual Markdown representation when the source also supplies HTML.
+              view.pasteText(text);
+              return true;
             }
           },
           onUpdate: ({ editor: ed }) => {


### PR DESCRIPTION
## Why

Pasting multiline text into the composer currently turns each source line into a separate paragraph, producing unexpected blank lines and breaking fenced code blocks. Closes #1591.

## What changed

- Insert ordinary plain-text clipboard content literally, mapping single newlines to hard breaks and intentional blank lines to paragraph boundaries without running unsupported syntax through the Markdown parser.
- Parse only a complete, supported fenced code block as Markdown; prefer plain text when HTML is also present while retaining attachment handling and literal paste behaviour inside an existing code block.
- Preserve active destination marks on pasted text so formatting composes with autolink marks.
- Cover line breaks, unsupported Markdown replacement, fenced code, mixed clipboard data, editing, active formatting, links, code-block insertion, and attachments with browser-component tests.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Not applicable.

Newer client → older server: Not applicable.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `MessageComposer.svelte.spec.ts`: 115 tests passed in Chromium on `main`.
- Frontend `check`: design-system guardrails passed; `svelte-check` found 0 errors and 0 warnings.
- Svelte autofixer reported no issues in the edited component.
- The single commit cherry-picked cleanly onto `origin/release-0.4`; its shared composer suite passed all 108 tests there.
