### PR TITLE
feat(frontend): render GFM tables

### DIFF
--- a/apps/docs-website/src/content/docs/guides/integrations/chatto-api.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/chatto-api.mdx
@@ -61,10 +61,16 @@ Realtime delivery uses the same room membership, RBAC, projection readiness, and
 
 ## Message Body Tokens
 
-Message bodies are plain text with Chatto's supported markdown subset. They may
-also contain inline timestamp tokens in the form `<t:UNIX_SECONDS:F>`. Render
-valid tokens as the referenced UTC instant in the viewer's locale and timezone,
-or leave the token literal if your client does not support inline timestamps.
+Message bodies are plain text with Chatto's supported Markdown subset: headings,
+emphasis, links and autolinks, inline and fenced code, blockquotes, ordered and
+unordered lists, and GFM pipe tables. Tables support the GFM delimiter-row
+alignment markers (`:---`, `:---:`, and `---:`), optional outer pipes, inline
+formatting in cells, and backslash-escaped pipes.
+
+Message bodies may also contain inline timestamp tokens in the form
+`<t:UNIX_SECONDS:F>`. Render valid tokens as the referenced UTC instant in the
+viewer's locale and timezone, or leave the token literal if your client does not
+support inline timestamps.
 
 ## Programmatic Safety
 

--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -166,6 +166,10 @@ generated protobuf clients, Vitest browser tests, Playwright e2e, and Storybook.
 ## Testing
 
 - `mise test-frontend` runs the frontend suite.
+- Run frontend verification commands that compile Paraglide sequentially. In
+  particular, do not run `mise lint-frontend` and `mise test-frontend` in
+  parallel: one process can read `src/lib/paraglide/` while the other is
+  rewriting it and report invalid generated-code diagnostics.
 - Unit and component specs live next to source. Route specs should not start
   with `+`; use descriptive names such as `members.page.svelte.spec.ts`.
 - Pure functions/classes can use Node Vitest. Mounted Svelte components,

--- a/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { userEvent } from 'vitest/browser';
 import { render } from 'vitest-browser-svelte';
 import '../../app.css';
 import { q } from '$lib/test-utils';
@@ -555,6 +556,19 @@ describe('MessageContent component', () => {
     expect(styles.borderLeftColor).not.toBe(computedBorderColorFor('--color-border'));
     expect(styles.backgroundImage).toBe('none');
     expect(styles.color).not.toBe(computedColorFor('--color-muted'));
+  });
+
+  it('shows an inset focus indicator on keyboard-scrollable tables', async () => {
+    const { container } = renderMessage('| Name | Role |\n| --- | --- |\n| Ada | Admin |');
+
+    await expect.poll(() => q(container, '.table-scroll')).toBeTruthy();
+    const scroller = q(container, '.table-scroll')!;
+    await userEvent.tab();
+
+    expect(document.activeElement).toBe(scroller);
+    expect(window.getComputedStyle(scroller).overflowX).toBe('auto');
+    expect(window.getComputedStyle(scroller).outlineStyle).toBe('solid');
+    expect(window.getComputedStyle(scroller).outlineOffset).toBe('-2px');
   });
 
   it('renders links with security attributes', async () => {

--- a/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
@@ -315,9 +315,11 @@ describe('renderMarkdown', () => {
       expect(html).not.toContain('<hr');
     });
 
-    it('does not render tables', async () => {
+    it('renders GFM tables', async () => {
       const html = await renderMarkdown('| a | b |\n|---|---|\n| 1 | 2 |');
-      expect(html).not.toContain('<table');
+      expect(html).toContain('<div class="table-scroll" tabindex="0"><table>');
+      expect(html).toContain('<th>a</th>');
+      expect(html).toContain('<td>1</td>');
     });
   });
 

--- a/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
@@ -559,10 +559,15 @@ describe('MessageContent component', () => {
   });
 
   it('shows an inset focus indicator on keyboard-scrollable tables', async () => {
-    const { container } = renderMessage('| Name | Role |\n| --- | --- |\n| Ada | Admin |');
+    const { container } = renderMessage(
+      '| Name | Role | Location |\n| --- | --- | --- |\n| Ada Lovelace | Administrator | London, United Kingdom |'
+    );
 
     await expect.poll(() => q(container, '.table-scroll')).toBeTruthy();
+    const wrapper = q(container, '.prose')!;
     const scroller = q(container, '.table-scroll')!;
+    wrapper.setAttribute('style', 'width: 240px');
+    await expect.poll(() => scroller.scrollWidth).toBeGreaterThan(scroller.clientWidth);
     await userEvent.tab();
 
     expect(document.activeElement).toBe(scroller);

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -1210,7 +1210,7 @@ describe('MessageComposer', () => {
     });
 
     it('preserves literal HTML-looking text when restoring and saving an edit', async () => {
-      const body = '<script>alert(1)</script> & <b>bold?</b>';
+      const body = '<script>alert(1)</script> & <b>bold?</b> &#45;';
       const editedBody = `${body}!`;
       roomStateMock.editState.eventId = 'evt_edit';
       roomStateMock.editState.originalBody = body;
@@ -1230,6 +1230,31 @@ describe('MessageComposer', () => {
         eventId: 'evt_edit',
         body: editedBody
       });
+    });
+
+    it('keeps an existing GFM table renderable after editing and saving', async () => {
+      const body = '| Name | Role |\n| --- | --- |\n| Ada | Admin |';
+      roomStateMock.editState.eventId = 'evt_table';
+      roomStateMock.editState.originalBody = body;
+      const { container } = renderMessageComposer({ roomId: 'room_456' });
+      const editor = await findEditor(container);
+
+      await expect.element(editor).toHaveTextContent('| Name | Role |');
+      await placeCaretAtEditorEnd(editor);
+      document.execCommand('insertText', false, '!');
+      await vi.waitFor(() => expect(editor.textContent).toContain('| Ada | Admin |!'));
+
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(updateMessageConnectMock).toHaveBeenCalledOnce());
+      const submittedBody = updateMessageConnectMock.mock.calls[0][0].body as string;
+      expect(updateMessageConnectMock).toHaveBeenCalledWith({
+        roomId: expect.any(String),
+        eventId: 'evt_table',
+        body: submittedBody
+      });
+      expect(submittedBody).toBe(`${body}!`);
+      expect(await renderMarkdown(submittedBody)).toContain('<table>');
     });
 
     it('clears staged attachments when edit mode is active at mount', async () => {

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -8,6 +8,7 @@ import { getToasts, toast } from '$lib/ui/toast';
 import type { QuoteInsertionContent, RoomMember } from '$lib/state/room';
 import { PresenceStatus } from '$lib/render/types';
 import { RoomEventKind } from '$lib/render/eventKinds';
+import { renderMarkdown } from '$lib/markdown';
 
 function postedMessageEvent(
   id = 'msg_123',
@@ -1607,6 +1608,23 @@ describe('MessageComposer', () => {
         roomId,
         body: 'test line one  \ntest line two'
       });
+    });
+
+    it('submits pasted GFM table syntax in a renderable form', async () => {
+      const body = '| Name | Role |\n| --- | --- |\n| Ada | Admin |';
+      const { container, roomId } = renderMessageComposer({ roomId: 'room_456' });
+      const editor = await findEditor(container);
+
+      editor.focus();
+      pasteText(editor, body);
+
+      await vi.waitFor(() => expect(editor.querySelectorAll('br')).toHaveLength(2));
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      const submittedBody = mutationMock.mock.calls[0][1].input.body as string;
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({ roomId });
+      expect(await renderMarkdown(submittedBody)).toContain('<table>');
     });
 
     it('preserves active inline formatting when pasting plain text', async () => {

--- a/apps/frontend/src/lib/components/composer/TipTapEditor.svelte
+++ b/apps/frontend/src/lib/components/composer/TipTapEditor.svelte
@@ -609,6 +609,46 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     });
   }
 
+  function hasUnescapedPipe(line: string): boolean {
+    for (let index = 0; index < line.length; index++) {
+      if (line[index] === '|' && line[index - 1] !== '\\') return true;
+    }
+    return false;
+  }
+
+  function isGfmTableDelimiter(line: string): boolean {
+    const content = line.replace(/^(?: {0,3}> ?)+/, '').trim();
+    const cells = content.split('|');
+    if (cells[0]?.trim() === '') cells.shift();
+    if (cells.at(-1)?.trim() === '') cells.pop();
+    return cells.length > 0 && cells.every((cell) => /^:?-+:?$/.test(cell.trim()));
+  }
+
+  function escapeGfmTablesForEditor(markdown: string): string {
+    return transformMarkdownOutsideCode(
+      markdown,
+      (text) => {
+        const lines = text.split('\n');
+        for (let index = 1; index < lines.length; index++) {
+          const header = lines[index - 1].replace(/^(?: {0,3}> ?)+/, '').trim();
+          if (!hasUnescapedPipe(header) || !isGfmTableDelimiter(lines[index])) continue;
+
+          // The composer intentionally has no table node. Keep the source as
+          // editable prose by making the delimiter invisible to TipTap's GFM
+          // parser. The word joiner is invisible and is removed again when
+          // serializing, so the delimiter remains visually unchanged.
+          lines[index] = lines[index].replace('-', '-\u2060');
+        }
+        return lines.join('\n');
+      },
+      { preserveInlineCode: false }
+    );
+  }
+
+  function prepareMarkdownForEditor(markdown: string): string {
+    return escapeGfmTablesForEditor(escapeMarkdownHtml(markdown));
+  }
+
   function decodeSerializedMarkdownText(markdown: string): string {
     return transformMarkdownOutsideCode(markdown, decodeSerializedTextEntities);
   }
@@ -628,6 +668,31 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     return markdown.replace(/ {2,}(\n\s*\n\s*(?:[-+*]|\d{1,9}[.)])\s)/g, '$1');
   }
 
+  function normalizeSerializedGfmTableHardBreaks(markdown: string): string {
+    return transformMarkdownOutsideCode(
+      markdown,
+      (text) => {
+        const lines = text.split('\n');
+        for (let index = 1; index < lines.length; index++) {
+          const header = lines[index - 1].replace(/ {2,}$/, '');
+          const delimiter = lines[index].replace(/ {2,}$/, '');
+          const unescapedDelimiter = delimiter.replace('\u2060', '');
+          if (!hasUnescapedPipe(header) || !isGfmTableDelimiter(unescapedDelimiter)) continue;
+
+          lines[index - 1] = header;
+          lines[index] = unescapedDelimiter;
+          for (let rowIndex = index + 1; rowIndex < lines.length; rowIndex++) {
+            const row = lines[rowIndex].replace(/ {2,}$/, '');
+            if (!hasUnescapedPipe(row)) break;
+            lines[rowIndex] = row;
+          }
+        }
+        return lines.join('\n');
+      },
+      { preserveInlineCode: false }
+    );
+  }
+
   function encodeSerializedHeadingClosingHashes(markdown: string): string {
     return transformMarkdownOutsideCode(
       markdown,
@@ -643,8 +708,10 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
 
   function getSerializedMarkdown(e: Editor): string {
     return normalizeSerializedHardBreaksBeforeLists(
-      encodeSerializedHeadingClosingHashes(
-        trimSerializedTrailingEmptyParagraph(decodeSerializedMarkdownText(e.getMarkdown()), e)
+      normalizeSerializedGfmTableHardBreaks(
+        encodeSerializedHeadingClosingHashes(
+          trimSerializedTrailingEmptyParagraph(decodeSerializedMarkdownText(e.getMarkdown()), e)
+        )
       )
     );
   }
@@ -1125,7 +1192,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
 
       setContent: (markdown: string) => {
         if (e.isDestroyed) return;
-        e.commands.setContent(escapeMarkdownHtml(markdown), {
+        e.commands.setContent(prepareMarkdownForEditor(markdown), {
           contentType: 'markdown',
           emitUpdate: false
         });

--- a/apps/frontend/src/lib/markdown.test.ts
+++ b/apps/frontend/src/lib/markdown.test.ts
@@ -54,6 +54,36 @@ describe('renderMarkdown', () => {
 
       expect(html).not.toContain('<table>');
     });
+
+    it('does not expand adversarial short rows into an oversized table', async () => {
+      const columns = 256;
+      const rows = 256;
+      const body = [
+        Array.from({ length: columns }, (_, index) => `h${index}`).join('|'),
+        Array.from({ length: columns }, () => '---').join('|'),
+        ...Array.from({ length: rows }, () => '|')
+      ].join('\n');
+
+      const html = await renderMarkdown(body);
+
+      expect(html).not.toContain('<table>');
+      expect(html).not.toContain('<td>');
+      expect(html.length).toBeLessThan(20_000);
+    });
+
+    it('applies table expansion limits inside blockquotes', async () => {
+      const columns = 128;
+      const rows = 128;
+      const lines = [
+        Array.from({ length: columns }, (_, index) => `h${index}`).join('|'),
+        Array.from({ length: columns }, () => '---').join('|'),
+        ...Array.from({ length: rows }, () => '|')
+      ];
+      const html = await renderMarkdown(lines.map((line) => `> ${line}`).join('\n'));
+
+      expect(html).not.toContain('<table>');
+      expect(html).not.toContain('<td>');
+    });
   });
 
   describe('invisible spacing', () => {

--- a/apps/frontend/src/lib/markdown.test.ts
+++ b/apps/frontend/src/lib/markdown.test.ts
@@ -7,6 +7,14 @@ import {
   lowlight
 } from './codeHighlighting';
 
+function tableSource(columns: number, bodyRows: number): string {
+  return [
+    Array.from({ length: columns }, (_, index) => `h${index}`).join('|'),
+    Array.from({ length: columns }, () => '---').join('|'),
+    ...Array.from({ length: bodyRows }, () => '|')
+  ].join('\n');
+}
+
 describe('renderMarkdown', () => {
   describe('GFM tables', () => {
     it('renders a pipe table with semantic sections', async () => {
@@ -56,13 +64,7 @@ describe('renderMarkdown', () => {
     });
 
     it('does not expand adversarial short rows into an oversized table', async () => {
-      const columns = 256;
-      const rows = 256;
-      const body = [
-        Array.from({ length: columns }, (_, index) => `h${index}`).join('|'),
-        Array.from({ length: columns }, () => '---').join('|'),
-        ...Array.from({ length: rows }, () => '|')
-      ].join('\n');
+      const body = tableSource(256, 256);
 
       const html = await renderMarkdown(body);
 
@@ -71,14 +73,44 @@ describe('renderMarkdown', () => {
       expect(html.length).toBeLessThan(20_000);
     });
 
+    it('accepts the column limit and rejects one additional column', async () => {
+      const atLimit = await renderMarkdown(tableSource(64, 1));
+      const overLimit = await renderMarkdown(tableSource(65, 1));
+
+      expect(atLimit).toContain('<table>');
+      expect(overLimit).not.toContain('<table>');
+    });
+
+    it('accepts the row limit and rejects one additional row', async () => {
+      // The header counts as one of the 256 rows.
+      const atLimit = await renderMarkdown(tableSource(2, 255));
+      const overLimit = await renderMarkdown(tableSource(2, 256));
+
+      expect(atLimit).toContain('<table>');
+      expect(overLimit).not.toContain('<table>');
+    });
+
+    it('accepts the per-table cell limit and rejects one additional row of cells', async () => {
+      // 64 columns × 64 rows, including the header, is exactly 4,096 cells.
+      const atLimit = await renderMarkdown(tableSource(64, 63));
+      const overLimit = await renderMarkdown(tableSource(64, 64));
+
+      expect(atLimit).toContain('<table>');
+      expect(overLimit).not.toContain('<table>');
+    });
+
+    it('limits cumulative table cells across one message', async () => {
+      const maximumTable = tableSource(64, 63);
+      const html = await renderMarkdown(
+        `${maximumTable}\n\n${maximumTable}\n\n| Extra | Table |\n| --- | --- |\n| x | y |`
+      );
+
+      expect(html.match(/<table>/g)).toHaveLength(2);
+      expect(html).toContain('| Extra | Table |');
+    });
+
     it('applies table expansion limits inside blockquotes', async () => {
-      const columns = 128;
-      const rows = 128;
-      const lines = [
-        Array.from({ length: columns }, (_, index) => `h${index}`).join('|'),
-        Array.from({ length: columns }, () => '---').join('|'),
-        ...Array.from({ length: rows }, () => '|')
-      ];
+      const lines = tableSource(128, 128).split('\n');
       const html = await renderMarkdown(lines.map((line) => `> ${line}`).join('\n'));
 
       expect(html).not.toContain('<table>');

--- a/apps/frontend/src/lib/markdown.test.ts
+++ b/apps/frontend/src/lib/markdown.test.ts
@@ -8,6 +8,54 @@ import {
 } from './codeHighlighting';
 
 describe('renderMarkdown', () => {
+  describe('GFM tables', () => {
+    it('renders a pipe table with semantic sections', async () => {
+      const html = await renderMarkdown('| Name | Role |\n| --- | --- |\n| Ada | Admin |');
+
+      expect(html).toContain('<div class="table-scroll" tabindex="0"><table>');
+      expect(html).toContain('<thead>');
+      expect(html).toContain('<th>Name</th>');
+      expect(html).toContain('<tbody>');
+      expect(html).toContain('<td>Ada</td>');
+      expect(html).toContain('</table></div>');
+    });
+
+    it('renders tables without outer pipes', async () => {
+      const html = await renderMarkdown('Name | Role\n--- | ---\nAda | Admin');
+
+      expect(html).toContain('<table>');
+      expect(html).toContain('<td>Ada</td>');
+    });
+
+    it('honours GFM column alignment', async () => {
+      const html = await renderMarkdown(
+        '| Left | Centre | Right |\n| :--- | :---: | ---: |\n| a | b | c |'
+      );
+
+      expect(html).toContain('<th style="text-align:left">Left</th>');
+      expect(html).toContain('<th style="text-align:center">Centre</th>');
+      expect(html).toContain('<th style="text-align:right">Right</th>');
+      expect(html).toContain('<td style="text-align:center">b</td>');
+    });
+
+    it('renders inline Markdown and escaped pipes inside cells', async () => {
+      const html = await renderMarkdown(
+        '| Value | Notes |\n| --- | --- |\n| **bold** | one \\| two |\n| `a\\|b` | [link](https://example.com) |'
+      );
+
+      expect(html).toContain('<strong>bold</strong>');
+      expect(html).toContain('<td>one | two</td>');
+      expect(html).toContain('<code>a|b</code>');
+      expect(html).toContain('href="https://example.com"');
+    });
+
+    it('leaves table-like text literal without a valid delimiter row', async () => {
+      const html = await renderMarkdown('| Name | Role |\n| Ada | Admin |');
+
+      expect(html).not.toContain('<table>');
+    });
+  });
+
   describe('invisible spacing', () => {
     it('collapses lines made from encoded non-breaking spaces', async () => {
       const html = await renderMarkdown(`before\n${'&nbsp;\n'.repeat(500)}after`);

--- a/apps/frontend/src/lib/markdown.ts
+++ b/apps/frontend/src/lib/markdown.ts
@@ -1,6 +1,7 @@
 import MarkdownIt from 'markdown-it';
 import type StateInline from 'markdown-it/lib/rules_inline/state_inline.mjs';
 import type StateCore from 'markdown-it/lib/rules_core/state_core.mjs';
+import type StateBlock from 'markdown-it/lib/rules_block/state_block.mjs';
 import type Token from 'markdown-it/lib/token.mjs';
 import tlds from 'tlds';
 import { classifyMessageBodyChatLink } from '$lib/messageLinks';
@@ -26,6 +27,115 @@ const DISABLED_RULES = [
 ] as const;
 
 const ALPHANUMERIC = /[a-zA-Z0-9]/;
+const MAX_TABLE_COLUMNS = 64;
+const MAX_TABLE_ROWS = 256;
+const MAX_TABLE_CELLS = 4_096;
+const MAX_TABLE_CELLS_PER_MESSAGE = 8_192;
+const tableCellCountKey = Symbol('tableCellCount');
+
+type MarkdownBlockRule = (
+  state: StateBlock,
+  startLine: number,
+  endLine: number,
+  silent: boolean
+) => boolean;
+
+function getBlockLine(state: StateBlock, line: number): string {
+  const start = state.bMarks[line] + state.tShift[line];
+  return state.src.slice(start, state.eMarks[line]);
+}
+
+function splitEscapedTableRow(row: string): string[] {
+  const cells: string[] = [];
+  let lastPosition = 0;
+  let current = '';
+  let escaped = false;
+
+  for (let position = 0; position < row.length; position++) {
+    const char = row[position];
+    if (char === '|' && !escaped) {
+      cells.push(current + row.slice(lastPosition, position));
+      current = '';
+      lastPosition = position + 1;
+    } else if (char === '|' && escaped) {
+      current += row.slice(lastPosition, position - 1);
+      lastPosition = position;
+    }
+
+    escaped = char === '\\';
+  }
+  cells.push(current + row.slice(lastPosition));
+
+  return cells;
+}
+
+function tableColumnCount(state: StateBlock, startLine: number, endLine: number): number | null {
+  if (startLine + 2 > endLine) return null;
+
+  const delimiterLine = getBlockLine(state, startLine + 1);
+  if (!/^[|:\-\t ]+$/.test(delimiterLine)) return null;
+
+  const delimiters = delimiterLine.split('|');
+  if (delimiters[0]?.trim() === '') delimiters.shift();
+  if (delimiters.at(-1)?.trim() === '') delimiters.pop();
+  if (delimiters.length === 0 || delimiters.some((cell) => !/^:?-+:?$/.test(cell.trim()))) {
+    return null;
+  }
+
+  const headerLine = getBlockLine(state, startLine).trim();
+  if (!headerLine.includes('|')) return null;
+
+  const headers = splitEscapedTableRow(headerLine);
+  if (headers[0] === '') headers.shift();
+  if (headers.at(-1) === '') headers.pop();
+
+  return headers.length === delimiters.length ? headers.length : null;
+}
+
+function countTableCells(
+  state: StateBlock,
+  startLine: number,
+  endLine: number,
+  columnCount: number
+): number {
+  let rowCount = 1;
+  const terminatorRules = state.md.block.ruler.getRules('blockquote');
+
+  for (let line = startLine + 2; line < endLine; line++) {
+    if (state.sCount[line] < state.blkIndent) break;
+    if (state.sCount[line] - state.blkIndent >= 4) break;
+    if (terminatorRules.some((rule) => rule(state, line, endLine, true))) break;
+    if (!getBlockLine(state, line).trim()) break;
+
+    rowCount++;
+    if (rowCount > MAX_TABLE_ROWS || rowCount * columnCount > MAX_TABLE_CELLS) {
+      return MAX_TABLE_CELLS + 1;
+    }
+  }
+
+  return rowCount * columnCount;
+}
+
+function boundedTableRule(tableRule: MarkdownBlockRule): MarkdownBlockRule {
+  return (state, startLine, endLine, silent) => {
+    const columnCount = tableColumnCount(state, startLine, endLine);
+    if (columnCount === null) return false;
+    if (columnCount > MAX_TABLE_COLUMNS) return false;
+
+    const cellCount = countTableCells(state, startLine, endLine, columnCount);
+    const renderedCellCount = (state.env[tableCellCountKey] as number | undefined) ?? 0;
+    if (
+      cellCount > MAX_TABLE_CELLS ||
+      renderedCellCount + cellCount > MAX_TABLE_CELLS_PER_MESSAGE
+    ) {
+      return false;
+    }
+
+    const parsed = tableRule(state, startLine, endLine, silent);
+    if (parsed && !silent) state.env[tableCellCountKey] = renderedCellCount + cellCount;
+    return parsed;
+  };
+}
 
 /**
  * Inline rule that consumes `*` or `_` marker runs as literal text when they
@@ -309,6 +419,18 @@ function initialize(): void {
   // Update linkify-it's TLD list so bare-domain URLs with newer TLDs
   // (.dev, .app, .io, etc.) are auto-linked
   md.linkify.tlds(tlds);
+
+  // markdown-it pads short table rows to the header width. Without a guard, a
+  // tiny table source can therefore expand into hundreds of thousands of DOM
+  // nodes. Resolve the built-in rule through the public ruler API, then bound
+  // it before token allocation while preserving its normal parsing behavior.
+  const tableRules = new MarkdownIt().block.ruler;
+  tableRules.enableOnly(['table']);
+  const tableRule = tableRules.getRules('')[0] as MarkdownBlockRule | undefined;
+  if (!tableRule) throw new Error('markdown-it table rule is unavailable');
+  md.block.ruler.at('table', boundedTableRule(tableRule), {
+    alt: ['paragraph', 'reference']
+  });
 
   // Disable unwanted syntax - only keep what we explicitly want
   md.disable([...DISABLED_RULES]);

--- a/apps/frontend/src/lib/markdown.ts
+++ b/apps/frontend/src/lib/markdown.ts
@@ -14,7 +14,6 @@ const DISABLED_RULES = [
   // Block-level
   'lheading',
   'hr',
-  'table',
   'reference',
   // Inline
   'image',
@@ -328,6 +327,8 @@ function initialize(): void {
   md.core.ruler.after('inline', 'normalize_non_breaking_spaces', normalizeInlineNonBreakingSpaces);
   md.renderer.rules.softbreak = renderChatLineBreak;
   md.renderer.rules.hardbreak = renderChatLineBreak;
+  md.renderer.rules.table_open = () => '<div class="table-scroll" tabindex="0"><table>\n';
+  md.renderer.rules.table_close = () => '</table></div>\n';
 
   // Customize link rendering for security
   const defaultLinkRender =

--- a/apps/frontend/src/lib/ui/MarkdownHtml.stories.svelte
+++ b/apps/frontend/src/lib/ui/MarkdownHtml.stories.svelte
@@ -1,0 +1,31 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import MarkdownHtml from './MarkdownHtml.svelte';
+
+  const { Story } = defineMeta({
+    title: 'UI/MarkdownHtml',
+    component: MarkdownHtml,
+    tags: ['autodocs']
+  });
+</script>
+
+<script lang="ts">
+  import { renderMarkdown } from '$lib/markdown';
+
+  const tableHtml = renderMarkdown(`| Release | Status | Owner | Compatibility | Notes |
+| :--- | :---: | ---: | :--- | :--- |
+| 0.4.8 | **Stable** | Core team | Server and bundled client | Current production release |
+| 0.5.0-alpha.1 | Testing | Contributors | Mixed-version clients | Previewing the next release |`);
+</script>
+
+<Story name="GFM table" asChild>
+  <div class="w-80 rounded-md border border-border bg-surface p-3">
+    <div class="prose max-w-none min-w-0">
+      {#await tableHtml}
+        <span class="text-muted">Rendering table…</span>
+      {:then html}
+        <MarkdownHtml {html} />
+      {/await}
+    </div>
+  </div>
+</Story>

--- a/apps/frontend/src/prose.css
+++ b/apps/frontend/src/prose.css
@@ -206,6 +206,11 @@
   & .table-scroll {
     max-width: 100%;
     overflow-x: auto;
+
+    &:focus-visible {
+      outline: 2px solid var(--color-action);
+      outline-offset: -2px;
+    }
   }
 
   & table {

--- a/apps/frontend/src/prose.css
+++ b/apps/frontend/src/prose.css
@@ -203,8 +203,14 @@
   }
 
   /* Tables */
+  & .table-scroll {
+    max-width: 100%;
+    overflow-x: auto;
+  }
+
   & table {
-    width: 100%;
+    width: max-content;
+    min-width: 100%;
     border-collapse: collapse;
     font-size: 0.875em;
   }

--- a/docs/fdr/FDR-032-message-formatting.md
+++ b/docs/fdr/FDR-032-message-formatting.md
@@ -1,0 +1,42 @@
+# FDR-032: Message Formatting
+
+**Status:** Active
+**Last reviewed:** 2026-07-19
+
+## Overview
+
+Message bodies are stored and exchanged as plain text while bundled clients render a deliberately limited Markdown subset. This gives people useful structure for chat, code, and compact tabular data without making message content depend on a client-specific rich-text document format.
+
+## Behavior
+
+- Messages support paragraphs, ATX headings, emphasis, links and autolinks, inline and fenced code, blockquotes, and ordered and unordered lists.
+- Messages support GFM pipe tables with a header delimiter row, optional outer pipes, left/centre/right column alignment, inline formatting, and escaped pipes inside cells.
+- Wide tables scroll horizontally inside the message instead of widening or clipping the conversation layout.
+- Message source HTML, images, horizontal rules, reference-style links, and setext headings render as literal text rather than active formatting.
+- Backslashes normally remain literal so common chat text such as Windows paths and kaomoji is not unexpectedly changed. An escaped pipe inside a GFM table cell is still interpreted as cell content rather than a column boundary.
+- Inline timestamp tokens render in the viewer's locale and timezone when supported by the client.
+- Editing a message preserves the plain-text Markdown body contract; the bundled composer does not provide a spreadsheet-like table editor.
+
+## Design Decisions
+
+### 1. Plain-text Markdown is the interchange format
+
+**Decision:** Message formatting is represented by Markdown in the existing plain-text body rather than by a client-specific rich-text document.
+**Why:** Plain text remains portable across API clients, server versions, exports, and clients that implement only a subset of formatting. Unsupported syntax can still be displayed instead of making the message unreadable.
+**Tradeoff:** Clients must implement compatible rendering themselves, and a rich composer cannot represent every valid source construct as a dedicated editing control.
+
+### 2. The supported syntax is deliberately constrained
+
+**Decision:** The bundled renderer enables common conversational structure and GFM tables while keeping source HTML, images, and several lower-value block constructs disabled.
+**Why:** A small reviewed output surface is easier to keep predictable and safe in user-authored messages. File attachments already provide the supported path for images.
+**Tradeoff:** Markdown copied from other applications may contain valid constructs that Chatto intentionally shows as literal text.
+
+### 3. Tables favour readable data over layout control
+
+**Decision:** Tables use semantic rows, headers, cells, and GFM column alignment, with native horizontal scrolling when their content is wider than the message.
+**Why:** Tables are useful for compact comparisons and status data, but message authors should not be able to use them to force the conversation column wider or create arbitrary page layouts.
+**Tradeoff:** Large tables require horizontal scrolling on narrow screens and are less convenient to author in the bundled rich composer than ordinary prose.
+
+## Related
+
+- **FDRs:** FDR-004 (Message Editing & Deletion), FDR-006 (@Mentions), FDR-030 (Inline Message Timestamps)

--- a/docs/fdr/FDR-032-message-formatting.md
+++ b/docs/fdr/FDR-032-message-formatting.md
@@ -12,7 +12,7 @@ Message bodies are stored and exchanged as plain text while bundled clients rend
 - Messages support paragraphs, ATX headings, emphasis, links and autolinks, inline and fenced code, blockquotes, and ordered and unordered lists.
 - Messages support GFM pipe tables with a header delimiter row, optional outer pipes, left/centre/right column alignment, inline formatting, and escaped pipes inside cells.
 - Wide tables scroll horizontally inside the message instead of widening or clipping the conversation layout.
-- Message source HTML, images, horizontal rules, reference-style links, and setext headings render as literal text rather than active formatting.
+- Message source HTML, horizontal rules, reference-style links, and setext headings render as literal text rather than active formatting. Image syntax never loads or displays an image; its label and destination can fall back to an ordinary link.
 - Backslashes normally remain literal so common chat text such as Windows paths and kaomoji is not unexpectedly changed. An escaped pipe inside a GFM table cell is still interpreted as cell content rather than a column boundary.
 - Inline timestamp tokens render in the viewer's locale and timezone when supported by the client.
 - Editing a message preserves the plain-text Markdown body contract; the bundled composer does not provide a spreadsheet-like table editor.

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -41,3 +41,4 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-029](FDR-029-chatto-shields.md) | Chatto Shields | Active | 2026-07-12 |
 | [FDR-030](FDR-030-inline-message-timestamps.md) | Inline Message Timestamps | Active | 2026-07-12 |
 | [FDR-031](FDR-031-client-server-compatibility-discovery.md) | Client–Server Compatibility Discovery | Experimental | 2026-07-16 |
+| [FDR-032](FDR-032-message-formatting.md) | Message Formatting | Active | 2026-07-19 |


### PR DESCRIPTION
## What changed

- render GFM pipe tables in message Markdown, including alignment, inline formatting, escaped pipes, and optional outer pipes
- keep wide tables inside the message layout with native horizontal scrolling and a visible keyboard focus indicator
- bound table columns, rows, per-table cells, and per-message cells before Markdown-it allocates tokens
- preserve existing table source when a message is loaded into the composer, edited, and saved
- document the supported Markdown contract in FDR-032 and the public API integration guide
- document that Paraglide-generating frontend checks must run sequentially

## Why

Pipe-table syntax previously rendered as literal text even though Chatto already shipped dormant table styles. Enabling Markdown-it's built-in rule directly also exposed a compact-input amplification risk because short rows are padded to the header width; the bounded wrapper prevents untrusted message bodies from expanding into excessive DOM and accessibility-tree nodes.

This is a bundled-client rendering change only. Message bodies remain plain Markdown strings, so there is no persisted-data, protobuf, ConnectRPC, or mixed-version server compatibility change. The composer preserves pasted and existing table source without adding a spreadsheet-like table editor.

## Test plan

- `mise test-frontend` — 264 files, 2,257 tests passed
- `mise lint-frontend` — design-system checks, Svelte/TypeScript checks, and ESLint passed with zero diagnostics
- focused renderer and mounted component tests cover exact column, row, per-table-cell, and per-message-cell boundaries
- composer tests cover pasted and existing-message edit/save round-trips, including preservation of literal entities
- Chromium component tests verify actual horizontal overflow at a 240px container width, keyboard focus, and the visible inset focus indicator
- Storybook Chromium story and automated accessibility audit passed
- `mise x -- pnpm --filter docs-website build` — 60 pages built
- `mise x uv@latest -- uvx --with charset-normalizer reuse lint` — REUSE compliant

## Documentation

- [FDR-032: Message Formatting](docs/fdr/FDR-032-message-formatting.md)
- supported Markdown subset in the Chatto API integration guide

Closes #1610.
