### PR TITLE
fix(frontend): keep video close button within iOS safe area

### DIFF
--- a/apps/frontend/src/lib/components/chat/FullscreenVideoOverlay.svelte
+++ b/apps/frontend/src/lib/components/chat/FullscreenVideoOverlay.svelte
@@ -73,7 +73,8 @@
     onfullscreenchange={handleFullscreenChange}
   >
     <button
-      class="absolute top-4 right-4 z-10 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full bg-white/10 text-white transition-colors hover:bg-white/20"
+      type="button"
+      class="absolute top-[calc(env(safe-area-inset-top,0px)+1rem)] right-[calc(env(safe-area-inset-right,0px)+1rem)] z-10 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full bg-white/10 text-white transition-colors hover:bg-white/20"
       onclick={close}
       aria-label={m['media.close_fullscreen_video']()}
     >

--- a/apps/frontend/src/lib/components/chat/FullscreenVideoOverlay.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/chat/FullscreenVideoOverlay.svelte.spec.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { fullscreenVideo } from '$lib/state/globals.svelte';
+import FullscreenVideoOverlay from './FullscreenVideoOverlay.svelte';
+
+afterEach(() => {
+  fullscreenVideo.close();
+});
+
+describe('FullscreenVideoOverlay', () => {
+  it('keeps the close button inside iOS safe areas', async () => {
+    fullscreenVideo.open('https://chat.example.test/clip.mp4', null, 0);
+    const { container } = render(FullscreenVideoOverlay);
+
+    await expect.poll(() => container.querySelector('button')).toBeTruthy();
+    const closeButton = container.querySelector<HTMLButtonElement>('button')!;
+
+    expect(closeButton.className).toContain('safe-area-inset-top');
+    expect(closeButton.className).toContain('safe-area-inset-right');
+    expect(closeButton.type).toBe('button');
+
+    closeButton.click();
+    expect(fullscreenVideo.isOpen).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

On iOS, the fullscreen video overlay placed its close control under the status-bar safe area, making it difficult or impossible to tap.

## What changed

- Offset the close control by the top and right safe-area insets while preserving the existing spacing elsewhere.
- Mark the close control explicitly as a non-submit button.
- Add browser-component coverage for safe-area positioning and dismissal.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Not applicable.

Newer client → older server: Not applicable.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `vitest --run --project=client src/lib/components/chat/FullscreenVideoOverlay.svelte.spec.ts` — passed.
- Frontend ESLint and Prettier checks — passed.
- Frontend design-system checks and `svelte-check` — passed with 0 errors and 0 warnings.
- Svelte autofixer — passed with no issues or suggestions.
- Live iOS visual verification remains outstanding because no browser was available in the agent environment.
