### PR TITLE
fix(frontend): preserve video playback on reactions

### DIFF
--- a/apps/frontend/e2e/video-player.test.ts
+++ b/apps/frontend/e2e/video-player.test.ts
@@ -3,6 +3,7 @@ import { test } from './setup';
 import { createAndLoginTestUser } from './fixtures/testUser';
 import { withServerUser } from './fixtures/serverUser';
 import { TIMEOUTS } from './constants';
+import { MessageComponent } from './pages/MessageComponent';
 
 // Video processing (ffmpeg transcode) can take up to 45s for small test videos.
 const VIDEO_PROCESSING_TIMEOUT = 45_000;
@@ -73,6 +74,40 @@ test.describe('video player @ffmpeg', () => {
           );
           expect(computedDisplay).toBe('none');
         }
+
+        // Updating message reactions must not recreate the playing media node.
+        const videoMessageLocator = page
+          .locator('[role="article"]')
+          .filter({ has: roomPage.mediaPlayer });
+        const videoMessage = new MessageComponent(page, videoMessageLocator);
+        const inlineVideo = videoMessageLocator.locator('media-provider video');
+        await inlineVideo.evaluate(async (video) => {
+          video.dataset.reactionPlaybackMarker = 'preserve-me';
+          video.muted = true;
+          video.loop = true;
+          await video.play();
+        });
+        await expect(inlineVideo).not.toHaveJSProperty('paused', true);
+
+        const projectedRefresh = page.waitForResponse((response) =>
+          response.url().includes('/GetRoomEventsAround')
+        );
+        await videoMessage.reactViaToolbar('👍');
+        await videoMessage.expectReaction('👍', 1);
+        await projectedRefresh;
+
+        await expect(inlineVideo).toHaveAttribute('data-reaction-playback-marker', 'preserve-me');
+        await expect(inlineVideo).not.toHaveJSProperty('paused', true);
+
+        const projectedRemovalRefresh = page.waitForResponse((response) =>
+          response.url().includes('/GetRoomEventsAround')
+        );
+        await videoMessage.toggleReaction('👍');
+        await videoMessage.expectNoReaction('👍');
+        await projectedRemovalRefresh;
+
+        await expect(inlineVideo).toHaveAttribute('data-reaction-playback-marker', 'preserve-me');
+        await expect(inlineVideo).not.toHaveJSProperty('paused', true);
 
         // User 2: the asset processing completion event must also be delivered
         // via the subscription so that the second user sees the player without reloading.

--- a/apps/frontend/src/lib/attachments/attachmentUrls.test.ts
+++ b/apps/frontend/src/lib/attachments/attachmentUrls.test.ts
@@ -6,6 +6,7 @@ import {
   assetUrlExpiresAtMs,
   assetUrlNeedsRefresh,
   assetUrlRefreshAt,
+  createAssetUrlRetainer,
   earliestAssetUrlRefreshAt,
   mergeRefreshedAttachmentUrls,
   refreshAttachmentUrlsForAssets,
@@ -190,5 +191,40 @@ describe('asset URL expiry helpers', () => {
       '/assets/files/A?access=ticket&retry=123#view'
     );
     expect(withAssetUrlRetryParam('/assets/files/A', 'again')).toBe('/assets/files/A?retry=again');
+  });
+});
+
+describe('createAssetUrlRetainer', () => {
+  const now = Date.parse('2026-05-29T14:00:00Z');
+  const freshExpiry = '2026-05-29T15:00:00Z';
+
+  it('retains a usable URL when only its signature changes', () => {
+    const retain = createAssetUrlRetainer(() => now);
+    const initial = { url: '/assets/files/A?signature=first', expiresAt: freshExpiry };
+
+    expect(retain('attachment:video', initial)).toBe(initial);
+    expect(
+      retain('attachment:video', {
+        url: '/assets/files/A?signature=second',
+        expiresAt: freshExpiry
+      })
+    ).toBe(initial);
+  });
+
+  it('accepts explicit refreshes, expired URLs, and different assets', () => {
+    const retain = createAssetUrlRetainer(() => now);
+    const initial = { url: '/assets/files/A?signature=first', expiresAt: freshExpiry };
+    retain('attachment:video', initial);
+
+    const forced = { url: '/assets/files/A?signature=forced', expiresAt: freshExpiry };
+    expect(retain('attachment:video', forced, true)).toBe(forced);
+
+    const expired = { url: '/assets/files/A?signature=expired', expiresAt: '2026-05-29T13:00:00Z' };
+    retain('attachment:expired', expired);
+    const afterExpiry = { url: '/assets/files/A?signature=fresh', expiresAt: freshExpiry };
+    expect(retain('attachment:expired', afterExpiry)).toBe(afterExpiry);
+
+    const replacement = { url: '/assets/files/B?signature=fresh', expiresAt: freshExpiry };
+    expect(retain('attachment:video', replacement)).toBe(replacement);
   });
 });

--- a/apps/frontend/src/lib/attachments/attachmentUrls.ts
+++ b/apps/frontend/src/lib/attachments/attachmentUrls.ts
@@ -56,6 +56,44 @@ export function assetUrlNeedsRefresh(
   return refreshAt !== null && refreshAt <= now;
 }
 
+/**
+ * Retain usable signed URLs across DTO refreshes when they still identify the
+ * same asset. This prevents media elements from reloading on signature-only
+ * changes while still accepting explicit refreshes, expiry, and new assets.
+ */
+export function createAssetUrlRetainer(now: () => number = Date.now) {
+  const retained = new Map<string, ExpiringAssetUrl>();
+
+  return (
+    key: string,
+    next: ExpiringAssetUrl | null,
+    forceNext = false
+  ): ExpiringAssetUrl | null => {
+    if (!next) {
+      retained.delete(key);
+      return null;
+    }
+
+    const current = retained.get(key);
+    if (
+      !forceNext &&
+      current &&
+      !assetUrlNeedsRefresh(current, now()) &&
+      assetResource(current.url) === assetResource(next.url)
+    ) {
+      return current;
+    }
+
+    retained.set(key, next);
+    return next;
+  };
+}
+
+function assetResource(url: string): string {
+  const suffixStart = url.search(/[?#]/);
+  return suffixStart === -1 ? url : url.slice(0, suffixStart);
+}
+
 export function earliestAssetUrlRefreshAt(
   assetUrls: Iterable<ExpiringAssetUrl | null | undefined>,
   leadMs = ASSET_URL_REFRESH_LEAD_MS

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
@@ -20,6 +20,7 @@
   import { toast } from '$lib/ui/toast';
   import {
     assetUrlNeedsRefresh,
+    createAssetUrlRetainer,
     earliestAssetUrlRefreshAt,
     LIGHTBOX_ATTACHMENT_IMAGE_REFRESH,
     mergeRefreshedAttachmentUrls,
@@ -49,6 +50,7 @@
   const assetRetrySalts = new SvelteMap<string, number>();
   let refreshPromise: Promise<Map<string, RefreshedAttachmentUrls>> | null = null;
   const failedAssetRefreshKeys = new SvelteSet<string>();
+  const retainAssetUrl = createAssetUrlRetainer();
   let galleryScrolledFromLeft = $state(false);
   let galleryScrolledFromRight = $state(false);
 
@@ -80,21 +82,24 @@
 
   function normalizeAttachment(attachment: RawAttachment) {
     const refreshed = refreshedAttachmentUrls.get(attachment.id);
-    const assetUrl = withRetrySalt(
-      normalizeAssetUrl(refreshed ? refreshed.assetUrl : attachment.assetUrl),
-      attachment.id,
-      'asset'
+    const resolveUrl = (
+      role: string,
+      value: ExpiringAssetUrl | null | undefined,
+      retryRole = role
+    ) =>
+      retainAssetUrl(
+        `${attachment.id}:${role}`,
+        withRetrySalt(normalizeAssetUrl(value), attachment.id, retryRole),
+        refreshed !== undefined || assetRetrySalts.has(`${attachment.id}:${retryRole}`)
+      );
+    const assetUrl = resolveUrl('asset', refreshed ? refreshed.assetUrl : attachment.assetUrl);
+    const thumbnailAssetUrl = resolveUrl(
+      'thumbnail',
+      refreshed ? refreshed.thumbnailAssetUrl : attachment.thumbnailAssetUrl
     );
-    const thumbnailAssetUrl = withRetrySalt(
-      normalizeAssetUrl(refreshed ? refreshed.thumbnailAssetUrl : attachment.thumbnailAssetUrl),
-      attachment.id,
-      'thumbnail'
-    );
-    const videoThumbnailAssetUrl = withRetrySalt(
-      normalizeAssetUrl(
-        refreshed ? refreshed.videoThumbnailAssetUrl : attachment.videoProcessing?.thumbnailAssetUrl
-      ),
-      attachment.id,
+    const videoThumbnailAssetUrl = resolveUrl(
+      'video-thumbnail',
+      refreshed ? refreshed.videoThumbnailAssetUrl : attachment.videoProcessing?.thumbnailAssetUrl,
       'video'
     );
 
@@ -110,11 +115,9 @@
             thumbnailAssetUrl: videoThumbnailAssetUrl,
             thumbnailUrl: videoThumbnailAssetUrl?.url ?? null,
             variants: attachment.videoProcessing.variants.flatMap((variant) => {
-              const variantAssetUrl = withRetrySalt(
-                normalizeAssetUrl(
-                  refreshedVariantAssetUrl(refreshed, variant.quality, variant.assetUrl)
-                ),
-                attachment.id,
+              const variantAssetUrl = resolveUrl(
+                `variant:${variant.quality}`,
+                refreshedVariantAssetUrl(refreshed, variant.quality, variant.assetUrl),
                 'video'
               );
               if (!variantAssetUrl) return [];


### PR DESCRIPTION
## Summary

Reaction updates refetch the containing message, and freshly signed attachment URLs caused Vidstack to reload an otherwise unchanged video and stop playback.
This retains usable signed URLs for the same attachment resource while still accepting explicit refreshes, expiry, retries, and asset replacements.
Unit coverage exercises the retention rules, and the uploaded-video E2E verifies that adding and removing a reaction preserves both the media element and active playback.

## Validation

`vitest`, ESLint, Prettier, `svelte-check`, and the focused Playwright video test all pass.
