### PR TITLE
docs: simplify permissions guide

### DIFF
--- a/apps/docs-website/src/content/docs/guides/operations/permissions.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/permissions.mdx
@@ -1,18 +1,20 @@
 ---
 title: Permissions & Roles
-description: How Chatto decides who can do what through roles, permissions, room overrides, and owner recovery.
+description: Control what people can do on your server and in individual rooms.
 ---
 
 import { Aside, LinkCard } from "@astrojs/starlight/components";
 
-Chatto's permissions system is built around two ideas: **roles** group people, and **permissions** describe capabilities. Every authenticated user has the implicit `everyone` role and may have additional roles such as `moderator`, `admin`, custom roles, or `owner`.
+Use **roles** to give the same permissions to several people. A **permission** controls one action, such as posting messages or managing rooms.
 
-The current model is intentionally simple:
+Every signed-in user belongs to the `everyone` role. You can also give them built-in roles such as `moderator` or `admin`, or create your own roles.
 
-- **Owners are always allowed.** A user is an owner if they have the durable `owner` role or a verified email listed in `owners.emails`.
-- **Named denies are restrictions.** Direct-user and explicitly assigned role decisions are combined first. A deny from any of those subjects wins.
-- **`everyone` is the scoped baseline.** A named or direct-user allow overrides an `everyone` deny only at the same or a nearer scope. A room baseline therefore contains unrelated server grants while still allowing a room-specific role exception.
-- **The nearest scope wins for each subject.** A room value replaces that same user or role's group and server values in the room; otherwise Chatto falls back through group to server.
+The main rules are:
+
+- **Owners can always do everything.** A user is an owner when they have the `owner` role or a verified email listed in `owners.emails`.
+- **A deny on a user or one of their assigned roles wins.** For example, a deny from a `suspended` role overrides an allow from `admin`.
+- **More specific settings replace broader ones for the same user or role.** Room settings replace room-group settings, and room-group settings replace server settings.
+- **`everyone` provides the default.** A user or role can override an `everyone` deny, but its allow must be at least as specific as the deny.
 
 ## Built-in roles
 
@@ -23,25 +25,30 @@ Every Chatto server starts with four system roles. You cannot delete them.
 | **everyone**  | Every authenticated user has this role. Fresh servers grant normal member defaults here: room discovery/joining, posting, thread posting, attaching files, reactions, echoing thread replies, and deleting your own account. |
 | **moderator** | Adds server-wide moderation defaults for managing messages and banning room members. |
 | **admin**     | Adds broad server administration defaults, including room administration, role management, user administration, audit access, and `message.manage`. Ordinary posting, attachments, threads, reactions, and echoing otherwise come from `everyone`. System diagnostics remain owner-only. |
-| **owner**     | Always has every permission virtually. Owner permissions are not stored as editable grants. |
+| **owner**     | Always has every permission. You cannot edit the owner's permission grants. |
 
-Roles still have a numeric position for display order and legacy event compatibility, but position is not an authorization rank.
+The order of roles in the admin UI does not affect which permissions win.
 
 ## How a permission check works
 
-When a user tries to do something, Chatto resolves the decision like this:
+When a user tries to do something, Chatto checks permissions in this order:
 
-1. **Owner override.** Effective owners are allowed every known RBAC permission. Membership checks still prevent owners from reading DMs they do not participate in.
-2. **DM boundary.** For non-owners, fixed privacy and category restrictions deny channel-style moderation and room-management actions inside DMs.
-3. **Nearest decision per subject.** For the direct user and each explicitly assigned named role, Chatto uses the nearest explicit value: room, then group, then server.
-4. **Combine named subjects.** Any deny among those decisions wins; otherwise Chatto keeps the nearest allow. Role position is not considered.
-5. **Apply the `everyone` baseline.** Chatto uses `everyone`'s nearest value. A named/direct allow beats an `everyone` deny only when the allow is at least as specific.
-6. **Default deny.** If nothing decides, the action is denied.
+1. Owners are allowed. DM membership rules still apply, so owners cannot read DMs they are not part of.
+2. For the user and each of their assigned roles, Chatto looks for the most specific setting: room first, then room group, then server.
+3. If any of those settings is **Deny**, the action is denied. Otherwise, Chatto keeps any **Allow** it found.
+4. Chatto compares that result with the most specific setting for `everyone`. An allow for the user or an assigned role can override an `everyone` deny only if it is at the same or a more specific scope.
+5. If no setting applies, the action is denied.
 
-For example, server `admin: allow` plus server `everyone: deny` resolves to **allow**. A room `everyone: deny` beats that less-specific admin grant until admin receives a room allow. `admin: allow` plus `suspended: deny` resolves to **deny**.
+Here are three common examples:
+
+| Settings | Result |
+| -------- | ------ |
+| Server `everyone`: Deny; server `admin`: Allow | **Allowed** for admins because both settings are at the same scope. |
+| Room `everyone`: Deny; server `admin`: Allow | **Denied** because the room setting is more specific. Add a room-level admin allow to make an exception. |
+| Server `admin`: Allow; server `suspended`: Deny | **Denied** because a deny on an assigned role wins. |
 
 <Aside type="tip">
-  Prefer room permissions for local policy. Use `everyone` for ordinary-member defaults, named roles for reusable access, and a direct-user or restriction-role deny for a restriction. Avoid adding a nearer allow to the same user or restriction role.
+  Set ordinary member defaults on `everyone`. Use roles for rules shared by several people, and direct user settings for one-off exceptions. Put room-specific rules on the room.
 </Aside>
 
 ## Scopes
@@ -54,7 +61,7 @@ Permissions can be configured at different scopes:
 | **Group** | Defaults or restrictions for a room group. |
 | **Room** | Local exceptions for one room. |
 
-Each scope value has three states: **Allow**, **Deny**, and **Inherit**. Inherit means "use this same subject's next less-specific value"; it does not inherit a different role's value.
+Each setting can be **Allow**, **Deny**, or **Inherit**. Inherit means "use the next broader setting for this same user or role". For example, a room set to Inherit checks the room group, then the server. It never inherits a setting from another role.
 
 Room-relevant permissions such as `message.post`, `message.attach`, `message.react`, `message.manage`, `room.join`, and `room.ban-member` can be configured at room/group/server scope. Server-only permissions such as `server.manage`, `role.manage`, and `admin.view-audit` are configured only at server scope.
 
@@ -86,9 +93,9 @@ The full list is visible in the admin UI.
 
 ### Read-only announcements for normal members
 
-Fresh servers create announcements as a read-only room for normal members by denying `message.post` for `everyone` at room scope and allowing it for `admin` at the same scope.
+Fresh servers make announcement rooms read-only for normal members. At the room level, they deny `message.post` for `everyone` and allow it for `admin`.
 
-This blocks normal members, moderators, and named roles that only have less-specific posting grants. Owners and admins can post, and another named role with its own room-level `message.post` grant can post too.
+Normal members, moderators, and roles with only server-level posting access cannot post there. Owners and admins can post. You can let another role post by giving it a room-level `message.post` allow.
 
 If you also want to prevent thread replies or file uploads in announcements, deny `message.post-in-thread` or `message.attach` for `everyone` in that room.
 
@@ -99,35 +106,35 @@ To make a room available only to a role such as `engineering`:
 1. Create the `engineering` role and assign it to the intended members.
 2. In the room's permissions, deny `room.list` and `room.join` for `everyone`.
 3. In the same room, allow `room.list` and `room.join` for `engineering`.
-4. Enable **Universal** if role assignment should automatically make eligible users room members. Otherwise, eligible users can see the room and join it themselves.
+4. Enable **Universal** if people with the role should automatically join the room. Otherwise, they can see the room and choose to join it.
 5. Remove any explicit room members who should no longer have access. Existing explicit members can still see their joined room even when `room.list` is denied.
 
-Removing the role removes Universal-derived membership, but it does not delete an explicit membership record created by joining or by an admin.
+If **Universal** added someone to the room, removing their role also removes them from the room. If they joined themselves or an admin added them, removing the role does not remove that separate membership.
 
-Other named roles can enter only if they also have an allow at this room's scope. Their server/group grants do not bypass the room-level `everyone` deny. Effective owners remain able to access the room.
+Other roles need their own room-level allow. A server or room-group allow cannot override the room-level `everyone` deny. Owners can still access the room.
 
 ### Normal-member room lockdown
 
-To temporarily freeze a room for users who rely on the `everyone` baseline:
+To temporarily stop normal members from posting in a room:
 
 1. Open the room's permissions.
 2. Deny `message.post` for `everyone`.
 3. Optionally deny `message.post-in-thread`, `message.attach`, and `message.react` as well.
 
-Clear the room-level denials to restore the normal server defaults. Named roles or direct-user grants still allow posting; add a deny to the relevant restriction role or user if those subjects must also be blocked.
+Remove the room-level denies to restore the server defaults. A room-level allow on a user or role can still permit posting. If you must block those users too, deny the permission directly on the user or on a restriction role such as `suspended`.
 
 ### Suspending a non-owner user
 
 To stop one non-owner user from posting without changing their roles:
 
 1. Open the user's member details in the admin UI.
-2. Clear any direct-user group/room allows for the capability; a nearer value for the same user replaces their server value.
+2. Remove any room or room-group allows set directly on the user. A more specific allow would replace the server-level deny you add next.
 3. Under permission overrides, deny `message.post` at server scope.
 4. Optionally deny `message.post-in-thread`, `message.attach`, `message.react`, and `message.echo`.
 
-User-level denies beat named-role grants for non-owners. They do not restrict effective owners.
+For non-owners, a deny set directly on the user wins over their role allows. Owner permissions cannot be restricted.
 
-For reusable suspensions, prefer a named role such as `suspended` containing server-level denies, and do not add group/room allows to that same restriction role. Its denies beat grants from the user's other named roles.
+If you suspend users regularly, create a `suspended` role with server-level denies. Do not add room or room-group allows to that role, because those more specific settings would replace its server-level denies. The role's denies override allows from the user's other roles.
 
 ### Giving one user a room-specific moderation grant
 
@@ -136,7 +143,7 @@ To let one non-owner user moderate one room:
 1. Open the user's member details.
 2. Grant `message.manage` scoped to that room.
 
-This works as long as no named role or direct-user decision denies `message.manage`. If `everyone` denies it, the direct-user grant must be at the same or a nearer scope.
+This works unless the user or one of their roles denies `message.manage`. If `everyone` denies it, the direct user allow must be at the same or a more specific scope.
 
 ### Custom roles
 
@@ -146,22 +153,22 @@ Use custom roles for repeated patterns across multiple users:
 2. Assign permissions to that role.
 3. Assign the role to users.
 
-Custom roles are permission bundles. They can override the `everyone` baseline, but they do not take precedence over other named roles. A deny from another named role the user also has still wins.
+Custom roles are reusable sets of permissions. They can override `everyone`, but they do not outrank other roles. If any assigned role denies an action, the deny wins.
 
 ## Owner vs admin
 
 Owners and admins are deliberately different:
 
-- **Owners** always receive all permissions and cannot be locked out through RBAC state. Owner permission rows are shown as read-only green checks in the UI.
-- **Admins** receive broad default grants, but they are still ordinary non-owner users for permission resolution. Any direct-user deny or deny from another named role restricts an admin. Otherwise, an `everyone` deny beats less-specific direct-user and named-role allows, while an allow at the same or a nearer scope overrides that baseline.
+- **Owners** always have every permission. You cannot lock them out by changing roles or permission settings. Their permission rows appear as read-only green checks in the UI.
+- **Admins** receive broad default permissions, but you can still restrict them. A deny set directly on the admin or on one of their roles wins. An `everyone` deny also applies unless the admin has an allow at the same or a more specific scope.
 
-Use `owners.emails` in `chatto.toml` as the recovery path. The email must be verified before it makes the user an effective owner.
+Use `owners.emails` in `chatto.toml` to recover owner access if needed. The user must verify the listed email before becoming an owner.
 
 ## DM privacy
 
-DMs use the same permission names where they make sense, but Chatto keeps a hard boundary around private conversations. For non-owners, channel-style actions such as `message.manage`, `message.echo`, `room.manage`, `room.ban-member`, `room.create`, and `message.post-in-thread` are denied in DMs regardless of role grants.
+DMs use the same permission names where they make sense, but private conversations have extra protection. For non-owners, Chatto always blocks channel management actions in DMs, including `message.manage`, `message.echo`, `room.manage`, `room.ban-member`, `room.create`, and `message.post-in-thread`. Role grants cannot enable them.
 
-Access to a DM comes from being a participant in that conversation. Owners cannot read into DMs or moderate DM contents unless they are a participant and the action is a normal participant action.
+Only participants can access a DM. Owners cannot read or moderate a DM they are not part of.
 
 ## Where to configure permissions
 
@@ -175,11 +182,11 @@ Access to a DM comes from being a participant in that conversation. Owners canno
 | Set per-user overrides | Admin UI -> **Members -> [user]** |
 
 <Aside type="caution">
-  Treat `owners.emails` as the lockout recovery path. Chatto does not expose an operator command to wipe and reseed RBAC state in normal deployments.
+  Keep `owners.emails` configured as your lockout recovery option. Chatto has no operator command to reset all roles and permissions in a normal deployment.
 </Aside>
 
 <Aside type="caution" title="Authorization behavior changed">
-  When upgrading from the older literal deny-wins resolver, review configurations that combine an `everyone` deny with a named-role or direct-user allow. Same-scope or nearer allows can now widen access; the change does not newly narrow access. For suspensions, clear nearer decisions on the same user or restriction role.
+  If you are upgrading from the old deny-wins system, review any setup that combines an `everyone` deny with an allow on a user or role. An allow at the same or a more specific scope can now override the `everyone` deny. For suspended users, remove more specific allows from the user or suspension role.
 </Aside>
 
 <LinkCard


### PR DESCRIPTION
## Why

The permissions guide explained the resolver accurately, but relied on internal terms such as “subjects”, “scoped baseline”, and “nearest scope”. This made a common operator task harder to understand than necessary.

## What changed

- Introduced roles and permissions in plain language.
- Reframed resolution as defaults, restrictions, and increasingly specific scopes.
- Replaced the densest resolver example with a compact outcome table.
- Simplified the guidance for announcement rooms, private role-based rooms, lockdowns, suspensions, owner recovery, and DM privacy.
- Preserved the existing permission semantics and operational edge cases.

This is a documentation-only change. It does not change authorization behaviour, APIs, configuration, rollout, or migration requirements.

## Test plan

- `git diff --check`
- `mise x -- pnpm --filter docs-website build` — passed
