### PR TITLE
docs: direct bug reports to Chatto HQ

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,10 @@
 # Contributing
 
-Chatto is not accepting outside contributions at this time, but feedback, bug reports, and ideas are welcome by [email](mailto:hendrik.mans@chattocorp.eu), or just drop by our [Chatto HQ community server](https://chat.chatto.run/).
+Chatto is not accepting outside contributions at this time. Report bugs in the
+`#bug-reports` channel on the [Chatto HQ community
+server](https://chat.chatto.run/); maintainers will create GitHub issues for
+actionable reports. Other feedback and ideas are welcome there or by
+[email](mailto:hendrik.mans@chattocorp.eu).
 
 ## Agentic Engineering
 

--- a/apps/docs-website/src/content/docs/getting-started/faq.mdx
+++ b/apps/docs-website/src/content/docs/getting-started/faq.mdx
@@ -49,6 +49,6 @@ In the meantime, Chatto is an excellent Progressive Web App (PWA) on both deskto
 
 ## Where can I get help or report a problem?
 
-Join the [official Chatto community](https://chat.chatto.run) and visit the `#self-hosting-support` room for setup questions, operational help, or general feedback. You can report reproducible bugs through [GitHub Issues](https://github.com/chattocorp/chatto/issues).
+Join [Chatto HQ](https://chat.chatto.run/) and visit the `#self-hosting-support` channel for setup questions, operational help, or general feedback. Report bugs in the `#bug-reports` channel; maintainers will create GitHub issues for actionable reports.
 
 Do not open a public issue for a security vulnerability. Follow the repository's [security policy](https://github.com/chattocorp/chatto/blob/main/SECURITY.md) to report it privately instead.


### PR DESCRIPTION
## Why

GitHub Issues now accept reports from contributors only, so public bug-reporting guidance needs an accessible intake path.

## What changed

Direct bug reporters to the `#bug-reports` channel on Chatto HQ and explain that maintainers will create GitHub issues for actionable reports.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Not applicable.

Newer client → older server: Not applicable.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `git diff --check`
- `mise x -- pnpm --dir apps/docs-website build`
