### PR TITLE
fix(frontend): default room sidebar to closed

### DIFF
--- a/apps/frontend/e2e/account-deletion.test.ts
+++ b/apps/frontend/e2e/account-deletion.test.ts
@@ -262,6 +262,8 @@ test.describe('Account Deletion', () => {
           // count among general's members.
           await page.reload();
           await waitForRoomReady(page, 'general');
+          await roomPage.openMembersPanel();
+          await roomPage2.openMembersPanel();
           await expect(roomPage.memberCount).toHaveText('Members (3)');
           await expect(roomPage2.memberCount).toHaveText('Members (3)');
 
@@ -276,6 +278,7 @@ test.describe('Account Deletion', () => {
           // User B refreshes to see updated state
           await page2.reload();
           await waitForRoomReady(page2, 'general');
+          await roomPage2.openMembersPanel();
 
           // User B should see e2eadmin + themselves (not 0, not 3)
           await expect(roomPage2.memberCount).toHaveText('Members (2)', {
@@ -292,6 +295,7 @@ test.describe('Account Deletion', () => {
             async ({ page: page3, user: userC, chatPage: chatPage3, roomPage: roomPage3 }) => {
               await chatPage3.enterRoom('general');
               await waitForRoomReady(page3, 'general');
+              await roomPage3.openMembersPanel();
 
               // User C should see 3 members (e2eadmin + User B + themselves)
               await expect(roomPage3.memberCount).toHaveText('Members (3)');
@@ -299,6 +303,7 @@ test.describe('Account Deletion', () => {
               // User B refreshes and should also see 3 members
               await page2.reload();
               await waitForRoomReady(page2, 'general');
+              await roomPage2.openMembersPanel();
               await expect(roomPage2.memberCount).toHaveText('Members (3)');
 
               // Both User B and User C should be visible in the member list

--- a/apps/frontend/e2e/pages/RoomPage.ts
+++ b/apps/frontend/e2e/pages/RoomPage.ts
@@ -110,6 +110,14 @@ export class RoomPage {
     return this.page.locator('aside[aria-label="Room extras"] nav[aria-label="Members"]');
   }
 
+  /** Open the room's Members panel when it is currently closed. */
+  async openMembersPanel(): Promise<void> {
+    if (await this.memberList.isVisible()) return;
+
+    await this.page.getByRole('button', { name: 'Show members' }).click();
+    await expect(this.memberList).toBeVisible();
+  }
+
   /**
    * Get a member's list item by their display name or login.
    */
@@ -365,6 +373,7 @@ export class RoomPage {
    * Assert that a member is visible in the member list.
    */
   async expectMemberVisible(name: string, options?: { timeout?: number }): Promise<void> {
+    await this.openMembersPanel();
     await expect(this.getMember(name)).toBeVisible(options);
   }
 
@@ -372,6 +381,7 @@ export class RoomPage {
    * Assert that a member has an avatar image (not initials).
    */
   async expectMemberHasAvatar(name: string, options?: { timeout?: number }): Promise<void> {
+    await this.openMembersPanel();
     await expect(this.getMemberAvatarImage(name)).toBeVisible(options);
   }
 
@@ -379,6 +389,7 @@ export class RoomPage {
    * Assert that a member has initials (no avatar image).
    */
   async expectMemberHasInitials(name: string, options?: { timeout?: number }): Promise<void> {
+    await this.openMembersPanel();
     await expect(this.getMemberAvatarInitials(name)).toBeVisible(options);
     await expect(this.getMemberAvatarImage(name)).not.toBeVisible();
   }
@@ -391,6 +402,7 @@ export class RoomPage {
     expectedDisplayName: string,
     options?: { timeout?: number }
   ): Promise<void> {
+    await this.openMembersPanel();
     await expect(this.getMemberDisplayName(memberIdentifier)).toHaveText(
       expectedDisplayName,
       options
@@ -405,6 +417,7 @@ export class RoomPage {
     expectedLogin: string,
     options?: { timeout?: number }
   ): Promise<void> {
+    await this.openMembersPanel();
     const usernameElement = this.getMemberUsername(memberIdentifier);
     await expect(usernameElement).toHaveText(`@${expectedLogin}`, options);
     await expect(usernameElement).toHaveClass(/text-muted/);
@@ -415,6 +428,7 @@ export class RoomPage {
    * Returns an array of display name strings.
    */
   async getMemberDisplayNamesInOrder(): Promise<string[]> {
+    await this.openMembersPanel();
     const memberItems = this.memberList.locator('button.sidebar-item');
     const count = await memberItems.count();
     const displayNames: string[] = [];

--- a/apps/frontend/e2e/presence-indicators.test.ts
+++ b/apps/frontend/e2e/presence-indicators.test.ts
@@ -31,7 +31,7 @@ test.describe('Presence indicators', () => {
     const roomPage = await chatPage.enterRoom('general');
 
     // User A should see themselves in the member list with online indicator
-    await expect(roomPage.memberList).toBeVisible();
+    await roomPage.openMembersPanel();
 
     // User A should be in the member list
     await roomPage.expectMemberVisible(userA.login);
@@ -300,6 +300,7 @@ test.describe('Member list grouping', () => {
     await chatPage.goto();
 
     const roomPage = await chatPage.enterRoom('general');
+    await roomPage.openMembersPanel();
 
     // Initially only User A is online; the bootstrap admin has no live
     // presence record.

--- a/apps/frontend/e2e/realtime-sync.test.ts
+++ b/apps/frontend/e2e/realtime-sync.test.ts
@@ -10,7 +10,7 @@ import {
 } from './fixtures/serverUser';
 import { waitForRoomReady } from './fixtures/realtimeSync';
 import { test } from './setup';
-import { SettingsPage } from './pages';
+import { RoomPage, SettingsPage } from './pages';
 
 test.describe('Real-time synchronization', () => {
   test('room list updates when user joins a room from another session', async ({
@@ -202,6 +202,8 @@ test.describe('Real-time synchronization', () => {
       // Join the room via Browse Rooms, then navigate to it
       await joinRoomFromOverview(page2, 'test-room');
       await chatPage2.enterRoom('test-room');
+      const roomPage2 = new RoomPage(page2);
+      await roomPage2.openMembersPanel();
 
       // User 1: Send a message now that both users are in the room
       await roomPage.sendMessage('Hello from User 1');
@@ -227,7 +229,7 @@ test.describe('Real-time synchronization', () => {
       // Note: Live events may take a few seconds to propagate across users
       // Poll for the update with a longer timeout since WebSocket events can be delayed
       await expect(async () => {
-        const memberListText = await page2.locator('[aria-label="Members"]').textContent();
+        const memberListText = await roomPage2.memberList.textContent();
         expect(memberListText).toContain(newDisplayName);
       }).toPass({ timeout: TIMEOUTS.POLLING_EXTENDED, intervals: [...POLLING_INTERVALS] });
 
@@ -272,6 +274,8 @@ test.describe('Real-time synchronization', () => {
       // Join the room via Browse Rooms, then navigate to it
       await joinRoomFromOverview(page2, 'error-test');
       await chatPage2.enterRoom('error-test');
+      const roomPage2 = new RoomPage(page2);
+      await roomPage2.openMembersPanel();
 
       // Wait for room to be ready (connection established)
       await expect(page2.getByText('Real-time updates paused')).not.toBeVisible({
@@ -287,7 +291,7 @@ test.describe('Real-time synchronization', () => {
       // Wait for the event to propagate to User 2
       // Check member list for the update
       await expect(async () => {
-        const memberListText = await page2.locator('[aria-label="Members"]').textContent();
+        const memberListText = await roomPage2.memberList.textContent();
         expect(memberListText).toContain(newDisplayName);
       }).toPass({ timeout: TIMEOUTS.POLLING_EXTENDED, intervals: [...POLLING_INTERVALS] });
 
@@ -320,7 +324,7 @@ test.describe('Real-time synchronization', () => {
     const roomPage = await chatPage.enterRoom('general');
 
     // User A should see themselves in the member list
-    await expect(roomPage.memberList).toBeVisible();
+    await roomPage.openMembersPanel();
     await roomPage.expectMemberVisible(userA.login);
 
     // User B: Create account and open the server

--- a/apps/frontend/src/lib/state/appUi.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/appUi.svelte.spec.ts
@@ -2,25 +2,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppUiState } from './appUi.svelte';
 
 const mocks = vi.hoisted(() => ({
-  roomSidebarPanel: new Map<string, string>(),
-  getRoomSidebarPanelState: vi.fn((serverId: string, roomId: string) => {
-    return mocks.roomSidebarPanel.get(`${serverId}:${roomId}`) ?? 'members';
-  }),
-  setRoomSidebarPanelState: vi.fn((serverId: string, roomId: string, panel: string | null) => {
-    if (panel) mocks.roomSidebarPanel.set(`${serverId}:${roomId}`, panel);
-  })
+  setRoomSidebarPanelState: vi.fn()
 }));
 
 vi.mock('$lib/storage/roomSidebarPanel', () => ({
-  ROOM_SIDEBAR_DEFAULT_PANEL: 'members',
-  getRoomSidebarPanelState: mocks.getRoomSidebarPanelState,
   setRoomSidebarPanelState: mocks.setRoomSidebarPanelState
 }));
 
 describe('AppUiState', () => {
   beforeEach(() => {
-    mocks.roomSidebarPanel.clear();
-    mocks.getRoomSidebarPanelState.mockClear();
     mocks.setRoomSidebarPanelState.mockClear();
   });
 
@@ -49,24 +39,38 @@ describe('AppUiState', () => {
     expect(appUi.isRoomCallWide).toBe(false);
   });
 
-  it('tracks the active room sidebar panel inside the active room scope', () => {
+  it('defaults each desktop room sidebar to closed for a fresh session', () => {
     const appUi = new AppUiState();
 
     appUi.setActiveRoomScope('server-a', 'room-1');
 
-    expect(appUi.selectedDesktopRoomSidebarPanel).toBe('members');
-    expect(appUi.activeDesktopRoomSidebarPanel).toBe('members');
+    expect(appUi.activeDesktopRoomSidebarPanel).toBe(null);
+
+    appUi.setActiveRoomScope('server-a', 'room-2');
+    expect(appUi.activeDesktopRoomSidebarPanel).toBe(null);
+  });
+
+  it('remembers explicit desktop sidebar state per room for the session', () => {
+    const appUi = new AppUiState();
+
+    appUi.setActiveRoomScope('server-a', 'room-1');
 
     appUi.openDesktopRoomSidebarPanel('files');
 
     expect(appUi.activeDesktopRoomSidebarPanel).toBe('files');
     expect(mocks.setRoomSidebarPanelState).toHaveBeenCalledWith('server-a', 'room-1', 'files');
 
-    appUi.closeDesktopRoomSidebarPanel();
-    expect(appUi.activeDesktopRoomSidebarPanel).toBe(null);
-
     appUi.setActiveRoomScope('server-a', 'room-2');
+    appUi.openDesktopRoomSidebarPanel('members');
     expect(appUi.activeDesktopRoomSidebarPanel).toBe('members');
+
+    appUi.setActiveRoomScope('server-a', 'room-1');
+    expect(appUi.activeDesktopRoomSidebarPanel).toBe('files');
+
+    appUi.closeDesktopRoomSidebarPanel();
+    appUi.setActiveRoomScope('server-a', 'room-2');
+    appUi.setActiveRoomScope('server-a', 'room-1');
+    expect(appUi.activeDesktopRoomSidebarPanel).toBe(null);
   });
 
   it('scopes mobile room sidebar state to the active room', () => {

--- a/apps/frontend/src/lib/state/appUi.svelte.ts
+++ b/apps/frontend/src/lib/state/appUi.svelte.ts
@@ -1,7 +1,5 @@
 import { createContext } from 'svelte';
 import {
-  getRoomSidebarPanelState,
-  ROOM_SIDEBAR_DEFAULT_PANEL,
   setRoomSidebarPanelState,
   type RoomSidebarPanel,
   type RoomSidebarPanelState
@@ -71,12 +69,10 @@ export class AppUiState {
     this.#activeRoomId = null;
   }
 
-  get selectedDesktopRoomSidebarPanel(): RoomSidebarPanel {
-    return this.#desktopRoomSidebarPanelForActiveRoom ?? ROOM_SIDEBAR_DEFAULT_PANEL;
-  }
-
   get activeDesktopRoomSidebarPanel(): RoomSidebarPanelState {
-    return this.#desktopRoomSidebarPanelForActiveRoom;
+    const scope = this.#activeRoomScopeKey;
+    if (!scope) return null;
+    return this.#desktopRoomSidebarSessionState[scope] ?? null;
   }
 
   get mobileRoomSidebarPanel(): RoomSidebarPanelState {
@@ -178,18 +174,6 @@ export class AppUiState {
   get #activeRoomScopeKey(): string | null {
     if (!this.#activeServerId || !this.#activeRoomId) return null;
     return roomScopeKey(this.#activeServerId, this.#activeRoomId);
-  }
-
-  get #desktopRoomSidebarPanelForActiveRoom(): RoomSidebarPanelState {
-    const scope = this.activeRoomScope;
-    if (!scope) return null;
-
-    const key = roomScopeKey(scope.serverId, scope.roomId);
-    if (key in this.#desktopRoomSidebarSessionState) {
-      return this.#desktopRoomSidebarSessionState[key] ?? null;
-    }
-
-    return getRoomSidebarPanelState(scope.serverId, scope.roomId);
   }
 
   #setDesktopRoomSidebarPanel(panel: RoomSidebarPanelState): void {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -503,6 +503,16 @@ describe('Room local message echo', () => {
     expect(consumePendingRoomSidebarPanel('server-1', 'room-1')).toBeNull();
   });
 
+  it('starts with the desktop room sidebar closed', async () => {
+    const { container } = render(Room, { props: { roomId: 'room-1' } });
+
+    await tick();
+
+    await expect
+      .element(q(container, '[data-testid="room-sidebar-desktop-pane"]'))
+      .not.toBeInTheDocument();
+  });
+
   it('does not load files selected only in the hidden mobile layout', async () => {
     appUi.openMobileRoomSidebarPanel('files');
 


### PR DESCRIPTION
## Why

The desktop room sidebar currently opens automatically in each room, reducing the space available for the conversation until the user closes it.

## What changed

- Default each desktop room sidebar to closed for a fresh app session.
- Remember explicit open and closed state independently per room while navigating during that session.
- Keep persisted panel writes for explicit cross-route and cross-tab Call opening, while removing the unused persisted-selection read path.
- Leave mobile sidebar behavior unchanged.
- Make member-list E2E helpers open the Members panel explicitly before interacting with it.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `mise x -- pnpm --filter chatto-frontend exec vitest --run src/lib/state/appUi.svelte.spec.ts 'src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts'` — 31 tests passed.
- `mise lint-frontend` — design-system checks, Svelte diagnostics, and ESLint passed with 0 errors and 0 warnings.
- `mise x -- pnpm exec playwright test e2e/presence-indicators.test.ts e2e/realtime-sync.test.ts e2e/typing-indicators.test.ts e2e/mention-rendering.test.ts e2e/user-context-menu.test.ts e2e/account-deletion.test.ts e2e/servers.test.ts --retries=0` — 48 tests passed.
- `mise test-cli` and focused `internal/http_server` Go tests passed locally; the original CI backend failure did not reproduce.
- Svelte autofixer reported no issues; `git diff --check` passed.
- Interactive browser verification remains outstanding because no browser was available in the workspace session.
