### PR TITLE
fix(dm): hide empty conversations until first message

### DIFF
--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/realtime.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/realtime.mdx
@@ -333,6 +333,7 @@ Canonical lightweight room state retained by a server-scoped projection.
 | `room` | `chatto.api.v1.RoomWithViewerState` | Public room metadata and viewer-specific state. |
 | `member_user_ids` | `repeated string` | Current room membership expressed as references into the projection's server-wide user directory. DM participants are always present. Channel membership is empty in a cold room summary and complete after that room's timeline has been materialised. |
 | `viewer_notification_count` | `uint32` | Current pending notifications targeting this room for the viewer. |
+| `has_message_history` | `optional bool` | Whether this DM room has ever received a root message. False means the durable room exists only so its initiator can compose the first message. Once true, message deletion does not reset it. Absent for channel rooms and servers that predate this field. |
 
 <a id="chatto-realtime-v1-RealtimeProjectionRoomActivity"></a>
 

--- a/apps/docs-website/src/generated/connectrpc-api/realtime.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/realtime.raw.mdx
@@ -374,6 +374,7 @@ Canonical lightweight room state retained by a server-scoped projection.
 | `room` | `chatto.api.v1.RoomWithViewerState` | Public room metadata and viewer-specific state. |
 | `member_user_ids` | `repeated string` | Current room membership expressed as references into the projection's server-wide user directory. DM participants are always present. Channel membership is empty in a cold room summary and complete after that room's timeline has been materialised. |
 | `viewer_notification_count` | `uint32` | Current pending notifications targeting this room for the viewer. |
+| `has_message_history` | `optional bool` | Whether this DM room has ever received a root message. False means the durable room exists only so its initiator can compose the first message. Once true, message deletion does not reset it. Absent for channel rooms and servers that predate this field. |
 
 
 

--- a/apps/frontend/e2e/dm.test.ts
+++ b/apps/frontend/e2e/dm.test.ts
@@ -24,6 +24,27 @@ import { TIMEOUTS } from './constants';
  */
 
 test.describe('Direct Messages (room-shaped)', () => {
+  test('an empty DM stays hidden until its first attachment-only message', async ({
+    page,
+    browser,
+    serverURL
+  }) => {
+    const userA = await createAndLoginTestUser(page);
+
+    await withServerUser(browser, serverURL, async ({ page: pageB, user: userB }) => {
+      const roomB = await new DMPage(pageB).startConversation(userA.login);
+
+      await page.goto(routes.browseRooms);
+      await page.waitForURL(routes.browseRooms);
+      const conversation = new DMPage(page).getConversation(userB.displayName);
+      await expect(conversation).not.toBeVisible();
+
+      await roomB.sendAttachment('e2e/fixtures/brighton.jpg');
+
+      await expect(conversation).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+    });
+  });
+
   test('post a DM message, reload, and stay on the conversation', async ({
     page,
     browser,

--- a/apps/frontend/src/lib/RoomList.svelte
+++ b/apps/frontend/src/lib/RoomList.svelte
@@ -33,6 +33,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   import { getAppUiState } from '$lib/state/appUi.svelte';
   import { getLiveDisplayName } from '$lib/state/userProfiles.svelte';
   import {
+    isNavigationVisibleRoom,
     type RoomsListItem,
     type RoomsListGroup,
     type RoomsListGroupItem
@@ -101,7 +102,9 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   // Room sets only apply to channels — DM rooms always render in their
   // own group below.
   let channels = $derived(roomsStore.rooms.filter((r) => r.type === RoomType.Channel));
-  let dmRooms = $derived(roomsStore.rooms.filter((r) => r.type === RoomType.Dm));
+  let dmRooms = $derived(
+    roomsStore.rooms.filter((r) => r.type === RoomType.Dm && isNavigationVisibleRoom(r))
+  );
 
   let channelMap = $derived(new Map(channels.map((r) => [r.id, r])));
 

--- a/apps/frontend/src/lib/RoomList.svelte.spec.ts
+++ b/apps/frontend/src/lib/RoomList.svelte.spec.ts
@@ -275,6 +275,18 @@ beforeEach(() => {
 });
 
 describe('RoomList', () => {
+  it('hides only DMs explicitly projected without message history', async () => {
+    const empty = mocks.store.rooms.rooms.find(
+      (room: { id: string }) => room.id === 'dm-with-participants'
+    ) as unknown as { hasMessageHistory?: boolean };
+    empty.hasMessageHistory = false;
+
+    const { container } = render(RoomList);
+
+    expect(container.querySelector('[href="/chat/-/dm-with-participants"]')).toBeNull();
+    await expect.element(q(container, '[href="/chat/-/dm-phone-only"]')).toBeInTheDocument();
+  });
+
   it('opens room actions on right-click and marks an unread room as read', async () => {
     setRoomUnread('channel-1', true);
     const { container } = render(RoomList);

--- a/apps/frontend/src/lib/components/QuickSwitcher.svelte
+++ b/apps/frontend/src/lib/components/QuickSwitcher.svelte
@@ -12,6 +12,7 @@
   import { recentQuickSwitcher } from '$lib/state/recentQuickSwitcher.svelte';
   import { quickSwitcher } from '$lib/state/globals.svelte';
   import { RoomType } from '$lib/render/types';
+  import { isNavigationVisibleRoom } from '$lib/state/server/rooms.svelte';
   import * as m from '$lib/i18n/messages';
   import { toast } from '$lib/ui/toast';
   import { createRoomCommandAPI } from '$lib/api-client/rooms';
@@ -81,6 +82,7 @@
 
       for (const room of store?.rooms.rooms ?? []) {
         if (room.type === RoomType.Dm) {
+          if (!isNavigationVisibleRoom(room)) continue;
           const participants = room.members.map(avatarUser);
           items.push({
             kind: 'dm',

--- a/apps/frontend/src/lib/components/QuickSwitcher.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/QuickSwitcher.svelte.spec.ts
@@ -46,6 +46,7 @@ const mocks = vi.hoisted(() => ({
         name: string;
         type: RoomType;
         viewerIsMember: boolean;
+        hasMessageHistory?: boolean | null;
         members: User[];
       }>,
       isInitialLoading: false
@@ -186,6 +187,14 @@ function installQueryMocks() {
       type: RoomType.Dm,
       viewerIsMember: true,
       members: [currentUser, teammate]
+    },
+    {
+      id: 'dm-empty',
+      name: '',
+      type: RoomType.Dm,
+      viewerIsMember: true,
+      hasMessageHistory: false,
+      members: [currentUser, user('user-empty', 'empty', 'Empty Conversation')]
     }
   ];
   mocks.listUsers.mockImplementation(async (search: string) => ({
@@ -291,6 +300,7 @@ describe('QuickSwitcher', () => {
     expect(container.textContent).toContain('Workspace Server');
     expect(container.textContent).toContain('general');
     expect(container.textContent).toContain('River Teammate');
+    expect(container.textContent).not.toContain('Empty Conversation');
     expect(input(container)).toBe(document.activeElement);
     expect(mocks.listRooms).not.toHaveBeenCalled();
     expect(mocks.listRoomMembers).not.toHaveBeenCalled();

--- a/apps/frontend/src/lib/state/server/projection.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/projection.svelte.spec.ts
@@ -506,7 +506,8 @@ describe('ServerProjectionStore', () => {
         operation({
           case: 'roomUpsert',
           value: new RealtimeProjectionRoom({
-            room: new RoomWithViewerState({ room: new Room({ id: 'R2' }) })
+            room: new RoomWithViewerState({ room: new Room({ id: 'R2' }) }),
+            hasMessageHistory: false
           })
         }),
         operation({
@@ -531,6 +532,7 @@ describe('ServerProjectionStore', () => {
     );
 
     expect([...store.rooms.keys()]).toEqual(['R2', 'R1']);
+    expect(store.rooms.get('R2')?.hasMessageHistory).toBe(true);
 
     store.apply(
       eventWithId(
@@ -561,7 +563,8 @@ describe('ServerProjectionStore', () => {
         operation({
           case: 'roomUpsert',
           value: new RealtimeProjectionRoom({
-            room: new RoomWithViewerState({ room: new Room({ id: 'R2' }) })
+            room: new RoomWithViewerState({ room: new Room({ id: 'R2' }) }),
+            hasMessageHistory: false
           })
         })
       )
@@ -577,6 +580,7 @@ describe('ServerProjectionStore', () => {
     );
 
     expect([...store.rooms.keys()]).toEqual(['R2', 'R1']);
+    expect(store.rooms.get('R2')?.hasMessageHistory).toBe(true);
     expect(store.timelines.has('R2')).toBe(false);
   });
 

--- a/apps/frontend/src/lib/state/server/projection.svelte.ts
+++ b/apps/frontend/src/lib/state/server/projection.svelte.ts
@@ -141,7 +141,8 @@ export class ServerProjectionStore {
               new RealtimeProjectionRoom({
                 room: current.room,
                 memberUserIds: [...current.memberUserIds],
-                viewerNotificationCount: Math.max(0, counts[roomId] ?? 0)
+                viewerNotificationCount: Math.max(0, counts[roomId] ?? 0),
+                hasMessageHistory: current.hasMessageHistory
               })
             );
           }
@@ -159,7 +160,8 @@ export class ServerProjectionStore {
                   viewerState: replacement.viewerState
                 }),
                 memberUserIds: [...current.memberUserIds],
-                viewerNotificationCount: current.viewerNotificationCount
+                viewerNotificationCount: current.viewerNotificationCount,
+                hasMessageHistory: current.hasMessageHistory
               })
             );
           }
@@ -230,7 +232,7 @@ export class ServerProjectionStore {
           break;
         }
         case 'roomActivity':
-          this.bumpRoom(operation.operation.value.roomId);
+          this.activateRoom(operation.operation.value.roomId);
           break;
         case undefined:
           throw new Error('unsupported realtime projection operation');
@@ -250,7 +252,8 @@ export class ServerProjectionStore {
       new RealtimeProjectionRoom({
         room: room.room,
         memberUserIds: [],
-        viewerNotificationCount: room.viewerNotificationCount
+        viewerNotificationCount: room.viewerNotificationCount,
+        hasMessageHistory: room.hasMessageHistory
       })
     );
   }
@@ -285,7 +288,8 @@ export class ServerProjectionStore {
         new RealtimeProjectionRoom({
           room: room.room,
           memberUserIds: room.memberUserIds.filter((candidate) => candidate !== userId),
-          viewerNotificationCount: room.viewerNotificationCount
+          viewerNotificationCount: room.viewerNotificationCount,
+          hasMessageHistory: room.hasMessageHistory
         })
       );
     }
@@ -390,10 +394,20 @@ export class ServerProjectionStore {
     );
   }
 
-  /** Retain newest-activity-first DM ordering across later room-state replacements. */
-  private bumpRoom(roomId: string): void {
-    const room = this.rooms.get(roomId);
-    if (!room || this.rooms.keys().next().value === roomId) return;
+  /** Activate first-message visibility and retain newest-activity-first ordering. */
+  private activateRoom(roomId: string): void {
+    const current = this.rooms.get(roomId);
+    if (!current) return;
+    const room = new RealtimeProjectionRoom({
+      room: current.room,
+      memberUserIds: [...current.memberUserIds],
+      viewerNotificationCount: current.viewerNotificationCount,
+      hasMessageHistory: true
+    });
+    if (this.rooms.keys().next().value === roomId) {
+      this.rooms.set(roomId, room);
+      return;
+    }
     const remaining = [...this.rooms.entries()].filter(([id]) => id !== roomId);
     this.rooms.clear();
     this.rooms.set(roomId, room);

--- a/apps/frontend/src/lib/state/server/rooms.svelte.ts
+++ b/apps/frontend/src/lib/state/server/rooms.svelte.ts
@@ -24,9 +24,16 @@ export type RoomsListItem = {
   viewerIsMember: boolean;
   viewerCanJoinRoom: boolean;
   viewerNotificationCount: number;
+  // Null means the connected server predates projection support for this
+  // distinction; only an explicit false hides an empty DM from navigation.
+  hasMessageHistory?: boolean | null;
   // Populated for DM rooms only — used to derive the display name in the sidebar.
   members: UserAvatarUserView[];
 };
+
+export function isNavigationVisibleRoom(room: RoomsListItem): boolean {
+  return room.type !== RoomType.Dm || room.hasMessageHistory !== false;
+}
 
 export type RoomsListGroup = {
   id: string;
@@ -126,6 +133,7 @@ function sameRoomListItem(a: RoomsListItem, b: RoomsListItem): boolean {
     a.viewerIsMember === b.viewerIsMember &&
     a.viewerCanJoinRoom === b.viewerCanJoinRoom &&
     a.viewerNotificationCount === b.viewerNotificationCount &&
+    a.hasMessageHistory === b.hasMessageHistory &&
     sameAvatarUsers(a.members, b.members)
   );
 }
@@ -281,7 +289,8 @@ export class RoomsStore {
     rooms: DirectoryRoomSummary[],
     roomGroups: DirectoryRoomGroup[],
     membersByRoomId: ReadonlyMap<string, UserAvatarUserView[]> = new SvelteMap(),
-    notificationCountsByRoomId: ReadonlyMap<string, number> = new SvelteMap()
+    notificationCountsByRoomId: ReadonlyMap<string, number> = new SvelteMap(),
+    messageHistoryByRoomId: ReadonlyMap<string, boolean | null> = new SvelteMap()
   ): void {
     this.loadId++;
     this.currentUserId = viewer.user.id;
@@ -297,7 +306,9 @@ export class RoomsStore {
     this.applyRooms(
       visibleRooms.map((room) => ({
         ...this.roomListItem(room, membersByRoomId.get(room.id) ?? []),
-        viewerNotificationCount: notificationCountsByRoomId.get(room.id) ?? 0
+        viewerNotificationCount: notificationCountsByRoomId.get(room.id) ?? 0,
+        hasMessageHistory:
+          room.kind === RoomKind.DM ? (messageHistoryByRoomId.get(room.id) ?? null) : null
       })),
       false
     );
@@ -331,6 +342,7 @@ export class RoomsStore {
       viewerIsMember: room.isMember,
       viewerCanJoinRoom: room.canJoinRoom,
       viewerNotificationCount: 0,
+      hasMessageHistory: room.kind === RoomKind.DM ? true : null,
       members
     };
   }

--- a/apps/frontend/src/lib/state/server/store.svelte.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.ts
@@ -531,6 +531,7 @@ export class ServerStateStore {
       ReturnType<typeof avatarUserFromDirectoryMember>[]
     >();
     const notificationCountsByRoomId = new SvelteMap<string, number>();
+    const messageHistoryByRoomId = new SvelteMap<string, boolean | null>();
     for (const entry of this.projection.rooms.values()) {
       const roomId = entry.room?.room?.id;
       if (!roomId) continue;
@@ -540,13 +541,15 @@ export class ServerStateStore {
       });
       membersByRoomId.set(roomId, members);
       notificationCountsByRoomId.set(roomId, entry.viewerNotificationCount);
+      messageHistoryByRoomId.set(roomId, entry.hasMessageHistory ?? null);
     }
     this.rooms.replaceProjection(
       viewer,
       rooms,
       groups,
       membersByRoomId,
-      notificationCountsByRoomId
+      notificationCountsByRoomId,
+      messageHistoryByRoomId
     );
     this.roomDirectory.replaceProjection(rooms);
   }

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -6594,10 +6594,30 @@ func TestRealtimeProjectionSnapshotIncludesEmptyJoinedDM(t *testing.T) {
 			if len(room.MemberUserIDs) != 2 {
 				t.Fatalf("empty DM member references = %v, want two members", room.MemberUserIDs)
 			}
-			return
+			if room.HasMessageHistory == nil || *room.HasMessageHistory {
+				t.Fatalf("empty DM has_message_history = %v, want explicit false", room.HasMessageHistory)
+			}
+			goto foundEmpty
 		}
 	}
 	t.Fatalf("empty joined DM %s missing from realtime projection snapshot", dm.Id)
+
+foundEmpty:
+	message, err := env.core.PostMessage(env.ctx, core.KindDM, dm.Id, env.viewer.Id, "first DM message", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage: %v", err)
+	}
+	if err := env.core.DeleteMessage(env.ctx, env.viewer.Id, core.KindDM, dm.Id, message.Id); err != nil {
+		t.Fatalf("DeleteMessage: %v", err)
+	}
+
+	room, err := env.api.BuildRealtimeProjectionRoomSummary(env.ctx, env.viewer.Id, dm.Id)
+	if err != nil {
+		t.Fatalf("BuildRealtimeProjectionRoomSummary: %v", err)
+	}
+	if room.HasMessageHistory == nil || !*room.HasMessageHistory {
+		t.Fatalf("used DM has_message_history = %v, want true after message retraction", room.HasMessageHistory)
+	}
 }
 
 func TestRealtimeProjectionLatestValueViewerStatesConverge(t *testing.T) {

--- a/cli/internal/connectapi/realtime_projection.go
+++ b/cli/internal/connectapi/realtime_projection.go
@@ -47,6 +47,7 @@ type RealtimeProjectionRoom struct {
 	Room                    *apiv1.RoomWithViewerState
 	MemberUserIDs           []string
 	ViewerNotificationCount uint32
+	HasMessageHistory       *bool
 }
 
 // RealtimeProjectionRoomTimeline identifies one compacted recent room window.
@@ -390,14 +391,22 @@ func (a *API) realtimeProjectionRoom(ctx context.Context, userID string, room *c
 	if room == nil || room.Room == nil {
 		return nil, core.ErrNotFound
 	}
+	var hasMessageHistory *bool
+	if core.KindOfRoom(room.Room) == core.KindDM {
+		_, _, exists, err := a.core.GetRoomLastEvent(ctx, core.KindDM, room.Room.GetId())
+		if err != nil {
+			return nil, err
+		}
+		hasMessageHistory = &exists
+	}
 	// Directory-visible rooms are part of the server projection even before
 	// the viewer joins. Their member list is not authorized at that point and
 	// is not needed until the room becomes a joined-room projection.
 	if !room.ViewerState.IsMember {
-		return &RealtimeProjectionRoom{Room: apiRoomWithViewerState(room), ViewerNotificationCount: notificationCount}, nil
+		return &RealtimeProjectionRoom{Room: apiRoomWithViewerState(room), ViewerNotificationCount: notificationCount, HasMessageHistory: hasMessageHistory}, nil
 	}
 	if room.Room.GetKind() != corev1.RoomKind_ROOM_KIND_DM && !includeChannelMembership {
-		return &RealtimeProjectionRoom{Room: apiRoomWithViewerState(room), ViewerNotificationCount: notificationCount}, nil
+		return &RealtimeProjectionRoom{Room: apiRoomWithViewerState(room), ViewerNotificationCount: notificationCount, HasMessageHistory: hasMessageHistory}, nil
 	}
 	members, err := a.core.ListRoomMemberReferencesForList(ctx, userID, room.Room.GetId())
 	if err != nil {
@@ -409,7 +418,7 @@ func (a *API) realtimeProjectionRoom(ctx context.Context, userID string, room *c
 			memberIDs = append(memberIDs, member.GetId())
 		}
 	}
-	return &RealtimeProjectionRoom{Room: apiRoomWithViewerState(room), MemberUserIDs: memberIDs, ViewerNotificationCount: notificationCount}, nil
+	return &RealtimeProjectionRoom{Room: apiRoomWithViewerState(room), MemberUserIDs: memberIDs, ViewerNotificationCount: notificationCount, HasMessageHistory: hasMessageHistory}, nil
 }
 
 func (a *API) realtimeProjectionNotificationCounts(ctx context.Context, userID string) (map[string]uint32, error) {

--- a/cli/internal/http_server/realtime_projection.go
+++ b/cli/internal/http_server/realtime_projection.go
@@ -775,6 +775,7 @@ func realtimeProjectionRoom(room *connectapi.RealtimeProjectionRoom) *realtimev1
 		Room:                    room.Room,
 		MemberUserIds:           append([]string(nil), room.MemberUserIDs...),
 		ViewerNotificationCount: room.ViewerNotificationCount,
+		HasMessageHistory:       room.HasMessageHistory,
 	}
 }
 

--- a/cli/internal/pb/chatto/realtime/v1/realtime.pb.go
+++ b/cli/internal/pb/chatto/realtime/v1/realtime.pb.go
@@ -1363,8 +1363,13 @@ type RealtimeProjectionRoom struct {
 	MemberUserIds []string `protobuf:"bytes,2,rep,name=member_user_ids,json=memberUserIds,proto3" json:"member_user_ids,omitempty"`
 	// Current pending notifications targeting this room for the viewer.
 	ViewerNotificationCount uint32 `protobuf:"varint,3,opt,name=viewer_notification_count,json=viewerNotificationCount,proto3" json:"viewer_notification_count,omitempty"`
-	unknownFields           protoimpl.UnknownFields
-	sizeCache               protoimpl.SizeCache
+	// Whether this DM room has ever received a root message. False means the
+	// durable room exists only so its initiator can compose the first message.
+	// Once true, message deletion does not reset it. Absent for channel rooms
+	// and servers that predate this field.
+	HasMessageHistory *bool `protobuf:"varint,4,opt,name=has_message_history,json=hasMessageHistory,proto3,oneof" json:"has_message_history,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *RealtimeProjectionRoom) Reset() {
@@ -1416,6 +1421,13 @@ func (x *RealtimeProjectionRoom) GetViewerNotificationCount() uint32 {
 		return x.ViewerNotificationCount
 	}
 	return 0
+}
+
+func (x *RealtimeProjectionRoom) GetHasMessageHistory() bool {
+	if x != nil && x.HasMessageHistory != nil {
+		return *x.HasMessageHistory
+	}
+	return false
 }
 
 // Root-message activity that affects lightweight room navigation state.
@@ -3157,11 +3169,13 @@ const file_chatto_realtime_v1_realtime_proto_rawDesc = "" +
 	"\x1dRealtimeProjectionServerState\x12\x17\n" +
 	"\x04motd\x18\x01 \x01(\tH\x00R\x04motd\x88\x01\x01\x12<\n" +
 	"\aruntime\x18\x02 \x01(\v2\".chatto.api.v1.ServerRuntimeConfigR\aruntimeB\a\n" +
-	"\x05_motd\"\xb4\x01\n" +
+	"\x05_motd\"\x81\x02\n" +
 	"\x16RealtimeProjectionRoom\x126\n" +
 	"\x04room\x18\x01 \x01(\v2\".chatto.api.v1.RoomWithViewerStateR\x04room\x12&\n" +
 	"\x0fmember_user_ids\x18\x02 \x03(\tR\rmemberUserIds\x12:\n" +
-	"\x19viewer_notification_count\x18\x03 \x01(\rR\x17viewerNotificationCount\"9\n" +
+	"\x19viewer_notification_count\x18\x03 \x01(\rR\x17viewerNotificationCount\x123\n" +
+	"\x13has_message_history\x18\x04 \x01(\bH\x00R\x11hasMessageHistory\x88\x01\x01B\x16\n" +
+	"\x14_has_message_history\"9\n" +
 	"\x1eRealtimeProjectionRoomActivity\x12\x17\n" +
 	"\aroom_id\x18\x01 \x01(\tR\x06roomId\"7\n" +
 	"\x1cRealtimeProjectionUserRemove\x12\x17\n" +
@@ -3482,6 +3496,7 @@ func file_chatto_realtime_v1_realtime_proto_init() {
 		(*RealtimeProjectionOperation_RoomActivity)(nil),
 	}
 	file_chatto_realtime_v1_realtime_proto_msgTypes[11].OneofWrappers = []any{}
+	file_chatto_realtime_v1_realtime_proto_msgTypes[12].OneofWrappers = []any{}
 	file_chatto_realtime_v1_realtime_proto_msgTypes[21].OneofWrappers = []any{}
 	file_chatto_realtime_v1_realtime_proto_msgTypes[23].OneofWrappers = []any{}
 	file_chatto_realtime_v1_realtime_proto_msgTypes[31].OneofWrappers = []any{}

--- a/docs/architecture/realtime-delivery.md
+++ b/docs/architecture/realtime-delivery.md
@@ -83,11 +83,14 @@ crypto-erased bodies therefore appear only as normal tombstones. Requested
 timeline windows are assembled concurrently with bounded concurrency.
 Never-viewed room bodies are not decrypted during bootstrap.
 
-The projection's room set is exhaustive rather than sidebar-policy-filtered:
-it includes joined DMs that do not yet contain a message. Public directory
-lists may continue hiding those empty conversations, but the projection and
-live-hub authorization capture retain them so a `StartDM` response can be
-navigated immediately and its first message can arrive through the stream.
+The projection's room set is exhaustive rather than navigation-policy-filtered:
+it includes joined DMs that do not yet contain a message. Each DM summary says
+whether it has root-message history; the bundled client retains empty DMs for
+routing and authorization but omits them from the sidebar and quick switcher.
+The first `room_activity` operation promotes the room into navigation, while an
+absent history field from an older server preserves the previous visible
+fallback. This lets a `StartDM` response navigate immediately without exposing
+an unsolicited empty conversation to another participant.
 
 The frontend applies this prefix and every later event through the same
 `ServerProjectionStore` reducer. Server profile, MOTD, and runtime capability

--- a/docs/fdr/FDR-007-direct-messages.md
+++ b/docs/fdr/FDR-007-direct-messages.md
@@ -1,7 +1,7 @@
 # FDR-007: Direct Messages
 
 **Status:** Active
-**Last reviewed:** 2026-07-16
+**Last reviewed:** 2026-07-20
 
 ## Overview
 
@@ -11,6 +11,7 @@ Users can start a direct conversation (1-to-1 or small group, up to 10 participa
 
 - A DM is started from user context menus inside the chat UI (member list clicks, @mention clicks, message author clicks).
 - Starting a DM with a user (or set of users) navigates to the resulting DM room. If a DM with the same participant set already exists, the user lands in that room rather than creating a duplicate.
+- Starting a DM creates the durable room and participant memberships immediately so the complete composer is available, but the empty conversation stays out of every participant's navigation until its first message is sent.
 - The bundled web client starts DMs through ConnectRPC `RoomService.StartDM`, which delegates to the shared core DM model.
 - DM rooms appear in the per-server room sidebar with their participants' names and avatars rather than a room name.
 - Inside a DM room, the room extras sidebar is available but starts closed and does not show the Members panel. The current Files panel and future non-member panels are shared, while channel-style moderation actions such as banning/removing room members remain unavailable.
@@ -59,6 +60,12 @@ Users can start a direct conversation (1-to-1 or small group, up to 10 participa
 **Decision:** Even users with admin/moderator roles cannot edit others' messages, delete others' messages, or otherwise moderate inside a DM room. The deny-list is unconditional regardless of role.
 **Why:** DMs are private by design. An admin who could moderate DMs would have a privacy boundary problem. Treating the deny as a static rule (not a configurable permission) prevents accidental misconfiguration.
 **Tradeoff:** Genuine abuse inside DMs has no in-product moderation path — operators have to address it at the user level (suspend, kick from server) instead. See `dmBoundaryDeniedPermissions` in `permission_resolver.go`.
+
+### 7. Empty rooms are latent conversations
+
+**Decision:** Starting a DM creates its deterministic room and memberships immediately, but navigation surfaces show it only after the first root message. Once activated, retracting every message does not hide the conversation again.
+**Why:** Early creation keeps routing, permissions, attachments, previews, and the ordinary room composer simple while avoiding an unsolicited empty conversation in another participant's UI.
+**Tradeoff:** Empty DM rooms remain in durable history and authorized client state even though they are absent from navigation. This small amount of latent state avoids a separate draft-conversation model and disappears automatically from presentation after replay.
 
 ## Permissions
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -16,7 +16,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-004](FDR-004-message-editing-and-deletion.md) | Message Editing & Deletion | Active | 2026-07-10 |
 | [FDR-005](FDR-005-reactions.md) | Reactions | Active | 2026-07-16 |
 | [FDR-006](FDR-006-mentions.md) | @Mentions | Active | 2026-06-15 |
-| [FDR-007](FDR-007-direct-messages.md) | Direct Messages | Active | 2026-07-16 |
+| [FDR-007](FDR-007-direct-messages.md) | Direct Messages | Active | 2026-07-20 |
 | [FDR-008](FDR-008-file-attachments-and-video.md) | File Attachments & Video Processing | Active | 2026-07-19 |
 | [FDR-009](FDR-009-link-previews.md) | Link Previews | Active | 2026-07-15 |
 | [FDR-010](FDR-010-typing-indicators.md) | Typing Indicators | Active | 2026-05-19 |

--- a/packages/api-types/src/chatto/realtime/v1/realtime_pb.ts
+++ b/packages/api-types/src/chatto/realtime/v1/realtime_pb.ts
@@ -988,6 +988,16 @@ export class RealtimeProjectionRoom extends Message<RealtimeProjectionRoom> {
    */
   viewerNotificationCount = 0;
 
+  /**
+   * Whether this DM room has ever received a root message. False means the
+   * durable room exists only so its initiator can compose the first message.
+   * Once true, message deletion does not reset it. Absent for channel rooms
+   * and servers that predate this field.
+   *
+   * @generated from field: optional bool has_message_history = 4;
+   */
+  hasMessageHistory?: boolean;
+
   constructor(data?: PartialMessage<RealtimeProjectionRoom>) {
     super();
     proto3.util.initPartial(data, this);
@@ -999,6 +1009,7 @@ export class RealtimeProjectionRoom extends Message<RealtimeProjectionRoom> {
     { no: 1, name: "room", kind: "message", T: RoomWithViewerState },
     { no: 2, name: "member_user_ids", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
     { no: 3, name: "viewer_notification_count", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
+    { no: 4, name: "has_message_history", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RealtimeProjectionRoom {

--- a/proto/chatto/realtime/v1/realtime.proto
+++ b/proto/chatto/realtime/v1/realtime.proto
@@ -234,6 +234,11 @@ message RealtimeProjectionRoom {
   repeated string member_user_ids = 2;
   // Current pending notifications targeting this room for the viewer.
   uint32 viewer_notification_count = 3;
+  // Whether this DM room has ever received a root message. False means the
+  // durable room exists only so its initiator can compose the first message.
+  // Once true, message deletion does not reset it. Absent for channel rooms
+  // and servers that predate this field.
+  optional bool has_message_history = 4;
 }
 
 // Root-message activity that affects lightweight room navigation state.


### PR DESCRIPTION
## Why

Opening a DM currently exposes an unsolicited empty conversation to the other participant before anyone has sent a message.

## What changed

- Keep deterministic DM room and membership creation in `StartDM`, but project whether a DM has ever received a root message.
- Retain empty DMs in canonical client state for routing, authorization, attachments, and the full composer while filtering them from the sidebar and quick switcher.
- Promote the room on first-message activity, preserve activation after message retraction, and document latent DMs in FDR-007 and the realtime architecture inventory.

## API compatibility

- Additive and compatible.

Older client → newer server: older clients ignore `has_message_history` and retain the existing visible behavior.

Newer client → older server: the optional field is absent, so newer clients deliberately retain the existing visible behavior instead of hiding all DMs.

Capability discovery or minimum client/server version: none required because the absent-field fallback is safe and the change adds no required wire operation.

## Test plan

- `mise test-cli` — passed.
- `mise test-frontend` — passed (2,324 tests).
- `mise build-e2e-server && pnpm exec playwright test e2e/dm.test.ts --grep 'empty DM stays hidden'` — passed.
- `mise lint` — passed with zero Svelte errors or warnings.
- `mise codegen-proto` and REUSE license validation — passed.
