### PR TITLE
fix(frontend): stabilise composer word wrapping

### DIFF
--- a/apps/frontend/src/lib/components/composer/TipTapEditor.svelte
+++ b/apps/frontend/src/lib/components/composer/TipTapEditor.svelte
@@ -1535,6 +1535,9 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
   :global(.tiptap-editor .ProseMirror h5),
   :global(.tiptap-editor .ProseMirror h6) {
     margin: 0;
+    /* Stable wrapping is essential while editing: `pretty` and `balance`
+       may move an earlier line break whenever the document changes. */
+    text-wrap: wrap;
   }
 
   :global(.tiptap-editor .ProseMirror > p),

--- a/apps/frontend/src/lib/components/composer/TipTapEditor.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/TipTapEditor.svelte.spec.ts
@@ -1,6 +1,7 @@
 import { page } from 'vitest/browser';
 import { render } from 'vitest-browser-svelte';
 import { describe, expect, it } from 'vitest';
+import '../../../app.css';
 import TipTapEditor from './TipTapEditor.svelte';
 
 describe('TipTapEditor accessibility', () => {
@@ -12,5 +13,17 @@ describe('TipTapEditor accessibility', () => {
     await rendered.rerender({ placeholder: 'Edit your message' });
 
     await expect.element(page.getByRole('textbox', { name: 'Edit your message' })).toBeVisible();
+  });
+});
+
+describe('TipTapEditor wrapping', () => {
+  it('uses stable wrapping instead of global prose wrapping', async () => {
+    const { container } = render(TipTapEditor, { props: { placeholder: 'Write a message' } });
+
+    await expect.element(page.getByRole('textbox', { name: 'Write a message' })).toBeVisible();
+
+    const paragraph = container.querySelector('.ProseMirror p');
+    expect(paragraph).toBeInstanceOf(HTMLParagraphElement);
+    expect(getComputedStyle(paragraph!).textWrap).toBe('wrap');
   });
 });


### PR DESCRIPTION
## Why

Safari applies the global pretty wrapping algorithm to the live message composer, causing earlier line breaks to move as the user types; this restores stable input behaviour and closes #1627.

## What changed

- Override global `pretty` and `balance` wrapping inside TipTap with ordinary `text-wrap: wrap`.
- Add a browser-component regression test that loads the real global stylesheet and verifies the computed wrapping mode.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Unchanged.

Newer client → older server: Unchanged.

Capability discovery or minimum client/server version: None.

## Test plan

- `mise x -- pnpm --filter chatto-frontend exec vitest --run src/lib/components/composer/TipTapEditor.svelte.spec.ts` — 2 tests passed.
- `mise lint-frontend` — design-system checks, Svelte diagnostics, and ESLint passed; manual visual review remains outstanding because no in-app browser was connected.
