### PR TITLE
feat(frontend): add context menus for visible rooms

### DIFF
--- a/apps/frontend/src/lib/RoomList.svelte
+++ b/apps/frontend/src/lib/RoomList.svelte
@@ -46,6 +46,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     type ContextMenuTriggerDetails
   } from '$lib/ui/contextMenuTrigger.svelte';
   import { markNavigationRoomAsRead } from '$lib/navigation/readActions';
+  import { toast } from '$lib/ui/toast';
 
   // No props — RoomList reads everything from the active server's stores.
   // All store references go through `stores` ($derived), so when the active
@@ -94,6 +95,18 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
         roomName: room.name
       }
     });
+  }
+
+  async function handleJoinRoom(room: RoomsListItem): Promise<void> {
+    closeRoomContextMenu();
+    const result = await stores.roomDirectory.joinRoom(room.id);
+    if (result.ok) {
+      toast.success(m['room.join.success']({ room: room.name }));
+      return;
+    }
+
+    toast.error(m['room.join.failed']());
+    console.error('Error joining room:', result.error);
   }
 
   // --- Derived layout helpers ---
@@ -331,7 +344,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     aria-current={room.id === activeRoomId ? 'page' : undefined}
     onclick={(e) => handleRoomLinkClick(e, room)}
     onkeydown={(e) => handleRoomLinkKeydown(e, room)}
-    {@attach isJoined && roomMenuTrigger(room)}
+    {@attach roomMenuTrigger(room)}
   >
     {#if isJoined}
       <span class={['sidebar-icon', hasUnreadAttention ? 'text-text-top' : 'text-muted']}>#</span>
@@ -496,9 +509,12 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   >
     <NavigationContextMenu
       kind="room"
+      isRoomMember={contextRoom.viewerIsMember}
+      canJoin={contextRoom.viewerCanJoinRoom}
       canMarkRead={roomUnreadStore.roomIsUnread(contextRoom.id) ||
         contextRoom.viewerNotificationCount > 0}
       canLeave={!contextRoom.isUniversal && contextRoom.type !== RoomType.Dm}
+      onJoin={() => void handleJoinRoom(contextRoom)}
       onMarkRead={() => handleMarkRoomRead(contextRoom)}
       onLeave={() => handleLeaveRoom(contextRoom)}
     />

--- a/apps/frontend/src/lib/RoomList.svelte.spec.ts
+++ b/apps/frontend/src/lib/RoomList.svelte.spec.ts
@@ -76,6 +76,9 @@ const { mocks } = vi.hoisted(() => ({
         incrementUnreadNotification: vi.fn(),
         refreshNotificationCounts: vi.fn().mockResolvedValue(undefined)
       },
+      roomDirectory: {
+        joinRoom: vi.fn()
+      },
       pendingHighlights: {
         set: vi.fn()
       },
@@ -271,6 +274,7 @@ beforeEach(() => {
   });
   mocks.store.notifications.getCleanPath.mockReturnValue('/chat/-/room');
   mocks.store.rooms.refreshNotificationCounts.mockResolvedValue(undefined);
+  mocks.store.roomDirectory.joinRoom.mockResolvedValue({ ok: true });
   mocks.markNavigationRoomAsRead.mockResolvedValue(true);
 });
 
@@ -311,6 +315,45 @@ describe('RoomList', () => {
     markRead!.click();
 
     expect(mocks.markNavigationRoomAsRead).toHaveBeenCalledWith('origin', 'channel-1');
+  });
+
+  it('offers a join action for a visible non-member room', async () => {
+    const { container } = render(RoomList);
+    const row = q(container, '[href="/chat/-/joinable-channel"]') as HTMLAnchorElement;
+
+    row.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
+    await vi.waitFor(() => expect(document.body.textContent).toContain('Join Room'));
+
+    const join = Array.from(document.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Join Room'
+    );
+    const markRead = Array.from(document.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Mark as read'
+    );
+    const leave = Array.from(document.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Leave room'
+    );
+    await expect.element(join ?? null).toBeEnabled();
+    expect(markRead).toBeUndefined();
+    expect(leave).toBeUndefined();
+
+    join!.click();
+    await vi.waitFor(() =>
+      expect(mocks.store.roomDirectory.joinRoom).toHaveBeenCalledWith('joinable-channel')
+    );
+  });
+
+  it('shows a disabled join action for a visible restricted room', async () => {
+    const { container } = render(RoomList);
+    const row = q(container, '[href="/chat/-/restricted-channel"]') as HTMLAnchorElement;
+
+    row.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
+    await vi.waitFor(() => expect(document.body.textContent).toContain('Join Room'));
+
+    const join = Array.from(document.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Join Room'
+    );
+    await expect.element(join ?? null).toBeDisabled();
   });
 
   it('opens room actions after a touch long-press and suppresses its synthetic click', async () => {

--- a/apps/frontend/src/lib/components/menus/NavigationContextMenu.svelte
+++ b/apps/frontend/src/lib/components/menus/NavigationContextMenu.svelte
@@ -1,22 +1,28 @@
 <!--
 @component
 
-Shared actions shown when a server icon or joined room row is right-clicked or long-pressed.
-The parent owns read and leave behavior so this component stays presentation-only.
+Shared actions shown when a server icon or room row is right-clicked or long-pressed.
+The parent owns membership and read behavior so this component stays presentation-only.
 -->
 <script lang="ts">
 	import * as m from '$lib/i18n/messages';
 
 	let {
 		kind,
+		isRoomMember = true,
+		canJoin = false,
 		canMarkRead,
 		canLeave = true,
+		onJoin = () => {},
 		onMarkRead,
 		onLeave
 	}: {
 		kind: 'server' | 'room';
+		isRoomMember?: boolean;
+		canJoin?: boolean;
 		canMarkRead: boolean;
 		canLeave?: boolean;
+		onJoin?: () => void;
 		onMarkRead: () => void;
 		onLeave: () => void;
 	} = $props();
@@ -24,18 +30,31 @@ The parent owns read and leave behavior so this component stays presentation-onl
 
 <div class="menu-section">
 	<nav class="sidebar-nav">
-		<button
-			type="button"
-			class="sidebar-item disabled:cursor-not-allowed disabled:opacity-50"
-			onclick={onMarkRead}
-			disabled={!canMarkRead}
-			role="menuitem"
-		>
-			<span class="sidebar-icon iconify uil--check-circle" aria-hidden="true"></span>
-			{m['room_list.mark_as_read']()}
-		</button>
+		{#if kind === 'room' && !isRoomMember}
+			<button
+				type="button"
+				class="sidebar-item disabled:cursor-not-allowed disabled:opacity-50"
+				onclick={onJoin}
+				disabled={!canJoin}
+				role="menuitem"
+			>
+				<span class="sidebar-icon iconify uil--sign-in-alt" aria-hidden="true"></span>
+				{m['room.join.action']()}
+			</button>
+		{:else}
+			<button
+				type="button"
+				class="sidebar-item disabled:cursor-not-allowed disabled:opacity-50"
+				onclick={onMarkRead}
+				disabled={!canMarkRead}
+				role="menuitem"
+			>
+				<span class="sidebar-icon iconify uil--check-circle" aria-hidden="true"></span>
+				{m['room_list.mark_as_read']()}
+			</button>
+		{/if}
 
-		{#if canLeave}
+		{#if isRoomMember && canLeave}
 			<div role="separator" class="mx-2 my-1 border-t border-text/10"></div>
 			<button
 				type="button"

--- a/docs/fdr/FDR-017-room-groups-and-sidebar-layout.md
+++ b/docs/fdr/FDR-017-room-groups-and-sidebar-layout.md
@@ -1,7 +1,7 @@
 # FDR-017: Room Groups & Sidebar Layout
 
 **Status:** Active
-**Last reviewed:** 2026-07-19
+**Last reviewed:** 2026-07-20
 
 ## Overview
 
@@ -12,6 +12,7 @@ Channel rooms are organized into **room groups** — named, ordered containers t
 - The sidebar shows `room.list`-visible channel rooms and sidebar links grouped under their group's name in operator-defined order. Groups can be collapsed/expanded.
 - ConnectRPC `RoomDirectoryService.ListRoomGroups` exposes the same ordered sidebar structure for protobuf-first clients, filtering room entries to non-archived channel rooms visible to the viewer and preserving sidebar links.
 - Joined channel rooms behave as normal navigation entries. Listable channel rooms the viewer has not joined yet are shown slightly faded; selecting a joinable room asks for confirmation before joining, while selecting a non-joinable room explains that access is not currently available.
+- Every visible room row exposes a context menu. Joined rooms offer unread and leave actions where applicable; non-member rooms offer Join, disabled when the viewer lacks `room.join`.
 - Server admins can create, rename, reorder, and delete groups via the admin UI.
 - Group names are limited to 80 bytes; group descriptions are limited to 500 bytes.
 - Every channel room belongs to exactly one group. There's no "uncategorized" branch — room creation requires a group.

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -26,7 +26,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-014](FDR-014-jump-to-present.md) | Jump to Present | Active | 2026-05-19 |
 | [FDR-015](FDR-015-quick-switcher.md) | Quick Switcher (Cmd-K) | Active | 2026-05-31 |
 | [FDR-016](FDR-016-voice-calls.md) | Voice Calls | Active | 2026-07-15 |
-| [FDR-017](FDR-017-room-groups-and-sidebar-layout.md) | Room Groups & Sidebar Layout | Active | 2026-06-18 |
+| [FDR-017](FDR-017-room-groups-and-sidebar-layout.md) | Room Groups & Sidebar Layout | Active | 2026-07-20 |
 | [FDR-018](FDR-018-account-lifecycle.md) | Account Lifecycle | Active | 2026-07-13 |
 | [FDR-019](FDR-019-room-lifecycle.md) | Room Lifecycle | Active | 2026-07-15 |
 | [FDR-020](FDR-020-server-branding-and-configuration.md) | Server Branding & Configuration | Active | 2026-07-14 |


### PR DESCRIPTION
## Why

Visible rooms that the viewer had not joined lacked the sidebar context menu available on joined rooms, leaving right-click and long-press without a membership-appropriate action.

## What changed

- Attach the room context-menu trigger to every visible channel row.
- Show Join Room for non-members, enabled only when the viewer can join, while preserving Mark as read and Leave room for members.
- Reuse the room-directory join flow and toast feedback, add mounted component coverage, and document the sidebar contract in FDR-017.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: No impact.

Newer client → older server: No impact; the UI uses the existing room-directory join command and viewer capability state.

Capability discovery or minimum client/server version: None.

## Test plan

- `mise x -- pnpm --filter chatto-frontend exec vitest --run src/lib/RoomList.svelte.spec.ts` — 26 tests passed.
- `mise x -- pnpm --dir apps/frontend run check` — design-system guardrails passed; Svelte reported 0 errors and 0 warnings.
- Svelte autofixer reported no issues in the changed components; manual browser review remains outstanding because no browser was connected to the workspace.
