### PR TITLE
fix(frontend): correct My Threads unread badge

### DIFF
--- a/apps/frontend/src/lib/api-client-tests/viewer.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/viewer.spec.ts
@@ -136,6 +136,7 @@ describe('getCurrentUserViaConnect', () => {
         hasVerifiedEmail: true
       },
       capabilities: {
+        hasUnreadFollowedThreads: true,
         grants: [
           { capability: 'admin.view', granted: true },
           { capability: 'dm.start', granted: true },
@@ -188,6 +189,7 @@ describe('getCurrentUserViaConnect', () => {
         canAdminViewSystem: true,
         canAdminViewAudit: true,
         canManageUserPermissions: true,
+        viewerHasUnreadFollowedThreads: true,
         serverNotificationPreference: {
           level: NotificationLevel.AllMessages,
           effectiveLevel: NotificationLevel.AllMessages

--- a/apps/frontend/src/lib/api-client/viewer.ts
+++ b/apps/frontend/src/lib/api-client/viewer.ts
@@ -61,6 +61,7 @@ export type ViewerState = ViewerCapabilities & {
   roomNotificationPreferences: RoomNotificationPreference[];
   viewerPermissions: Record<string, boolean>;
   viewerHasUnreadRooms: boolean;
+  viewerHasUnreadFollowedThreads: boolean;
 };
 
 const capabilityKeys = {
@@ -131,6 +132,7 @@ export async function getViewerStateViaConnect(config: ViewerAPIConfig): Promise
     canManageUserPermissions: can(capabilityKeys.manageUserPermissions),
     viewerPermissions,
     viewerHasUnreadRooms: response.viewerState?.hasUnreadRooms ?? false,
+    viewerHasUnreadFollowedThreads: response.capabilities?.hasUnreadFollowedThreads ?? false,
     serverNotificationPreference: {
       level: apiNotificationLevel(response.serverNotificationPreference?.level),
       effectiveLevel: apiNotificationLevel(response.serverNotificationPreference?.effectiveLevel)

--- a/apps/frontend/src/lib/components/chat/Chrome.svelte
+++ b/apps/frontend/src/lib/components/chat/Chrome.svelte
@@ -328,7 +328,10 @@
             <span class="sidebar-icon iconify uil--estate"></span>
             {m['chat.overview.title']()}
           </a>
-          <MyThreadsNavItem active={isMyThreadsActive} />
+          <MyThreadsNavItem
+            active={isMyThreadsActive}
+            hasUnread={serverRegistry.getStore(getActiveServer()).rooms.hasUnreadFollowedThreads}
+          />
         </nav>
 
         <hr class="border-border" />

--- a/apps/frontend/src/lib/components/chat/MyThreadsNavItem.svelte
+++ b/apps/frontend/src/lib/components/chat/MyThreadsNavItem.svelte
@@ -2,18 +2,10 @@
   import { resolve } from '$app/paths';
   import { serverIdToSegment } from '$lib/navigation';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
-  import { serverRegistry } from '$lib/state/server/registry.svelte';
-  import { notificationTarget } from '$lib/state/server/notifications.svelte';
   import UnreadDot from '$lib/ui/UnreadDot.svelte';
   import * as m from '$lib/i18n/messages';
 
-  let { active }: { active: boolean } = $props();
-
-  const notificationStore = serverRegistry.getStore(getActiveServer()).notifications;
-
-  const hasUnread = $derived(
-    notificationStore.notifications.some((n) => notificationTarget(n).threadRootId !== null)
-  );
+  let { active, hasUnread }: { active: boolean; hasUnread: boolean } = $props();
 </script>
 
 <a

--- a/apps/frontend/src/lib/components/chat/MyThreadsNavItem.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/chat/MyThreadsNavItem.svelte.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import MyThreadsNavItem from './MyThreadsNavItem.svelte';
+
+vi.mock('$app/paths', () => ({
+  resolve: (path: string, params: Record<string, string>) =>
+    path.replace('[serverId]', params.serverId)
+}));
+
+vi.mock('$lib/navigation', () => ({
+  serverIdToSegment: (serverId: string) => serverId
+}));
+
+vi.mock('$lib/state/activeServer.svelte', () => ({
+  getActiveServer: () => 'server-1'
+}));
+
+describe('MyThreadsNavItem', () => {
+  it('renders and clears the dot from followed-thread unread state', async () => {
+    const rendered = render(MyThreadsNavItem, {
+      props: { active: false, hasUnread: false }
+    });
+
+    expect(rendered.container.querySelector('[data-testid="my-threads-unread-dot"]')).toBeNull();
+
+    await rendered.rerender({ active: false, hasUnread: true });
+    await expect
+      .element(
+        rendered.container.querySelector<HTMLElement>('[data-testid="my-threads-unread-dot"]')
+      )
+      .toBeInTheDocument();
+
+    await rendered.rerender({ active: false, hasUnread: false });
+    expect(rendered.container.querySelector('[data-testid="my-threads-unread-dot"]')).toBeNull();
+  });
+});

--- a/apps/frontend/src/lib/state/server/rooms.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/rooms.svelte.spec.ts
@@ -95,6 +95,7 @@ function makeViewer(overrides: Partial<ViewerState> = {}): ViewerState {
     roomNotificationPreferences: [],
     viewerPermissions: {},
     viewerHasUnreadRooms: false,
+    viewerHasUnreadFollowedThreads: false,
     ...overrides
   };
 }
@@ -252,7 +253,8 @@ describe('RoomsStore - refresh', () => {
               level: NotificationLevel.AllMessages,
               effectiveLevel: NotificationLevel.AllMessages
             }
-          ]
+          ],
+          viewerHasUnreadFollowedThreads: true
         })
       )
     });
@@ -260,6 +262,7 @@ describe('RoomsStore - refresh', () => {
     await store.refresh();
 
     expect(store.currentUserId).toBe('U2');
+    expect(store.hasUnreadFollowedThreads).toBe(true);
     expect(notificationLevels.getServerPreference()).toEqual({
       level: NotificationLevel.Muted,
       effectiveLevel: NotificationLevel.Muted
@@ -268,6 +271,43 @@ describe('RoomsStore - refresh', () => {
       level: NotificationLevel.AllMessages,
       effectiveLevel: NotificationLevel.AllMessages
     });
+  });
+
+  it('coalesces concurrent followed-thread unread refreshes and applies the latest result', async () => {
+    let resolveFirst!: (viewer: ViewerState) => void;
+    const viewerStateLoader = vi
+      .fn<ViewerStateLoader>()
+      .mockImplementationOnce(() => new Promise((resolve) => (resolveFirst = resolve)))
+      .mockResolvedValueOnce(makeViewer({ viewerHasUnreadFollowedThreads: false }));
+    const store = makeStore({ viewerStateLoader });
+
+    const first = store.refreshUnreadFollowedThreads();
+    const second = store.refreshUnreadFollowedThreads();
+
+    expect(first).toBe(second);
+    expect(viewerStateLoader).toHaveBeenCalledOnce();
+
+    resolveFirst(makeViewer({ viewerHasUnreadFollowedThreads: true }));
+    await first;
+
+    expect(viewerStateLoader).toHaveBeenCalledTimes(2);
+    expect(store.hasUnreadFollowedThreads).toBe(false);
+  });
+
+  it('does not let an older full refresh overwrite newer followed-thread unread state', async () => {
+    let resolveFullViewer!: (viewer: ViewerState) => void;
+    const viewerStateLoader = vi
+      .fn<ViewerStateLoader>()
+      .mockImplementationOnce(() => new Promise((resolve) => (resolveFullViewer = resolve)))
+      .mockResolvedValueOnce(makeViewer({ viewerHasUnreadFollowedThreads: false }));
+    const store = makeStore({ viewerStateLoader });
+
+    const fullRefresh = store.refresh();
+    await store.refreshUnreadFollowedThreads();
+    resolveFullViewer(makeViewer({ viewerHasUnreadFollowedThreads: true }));
+    await fullRefresh;
+
+    expect(store.hasUnreadFollowedThreads).toBe(false);
   });
 
   it('discards out-of-order responses', async () => {
@@ -668,5 +708,29 @@ describe('RoomsStore - ingestServerEvent', () => {
     store.ingestServerEvent(makeEvent(RoomEventKind.Heartbeat));
 
     expect(store.refresh).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [RoomEventKind.ThreadFollowChanged, {}],
+    [RoomEventKind.NotificationDismissed, {}],
+    [RoomEventKind.MessagePosted, { threadRootEventId: 'thread-root', roomId: 'room-1' }]
+  ])('refreshes followed-thread unread state on %s', (kind, extra) => {
+    const store = makeStore();
+    store.refreshUnreadFollowedThreads = vi.fn().mockResolvedValue(undefined);
+
+    store.ingestServerEvent(makeEvent(kind, extra));
+
+    expect(store.refreshUnreadFollowedThreads).toHaveBeenCalledOnce();
+  });
+
+  it('does not refresh followed-thread unread state for root messages', () => {
+    const store = makeStore();
+    store.refreshUnreadFollowedThreads = vi.fn().mockResolvedValue(undefined);
+
+    store.ingestServerEvent(
+      makeEvent(RoomEventKind.MessagePosted, { threadRootEventId: null, roomId: 'room-1' })
+    );
+
+    expect(store.refreshUnreadFollowedThreads).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/lib/state/server/rooms.svelte.ts
+++ b/apps/frontend/src/lib/state/server/rooms.svelte.ts
@@ -211,6 +211,7 @@ export class RoomsStore {
   rooms = $state<RoomsListItem[]>([]);
   roomGroups = $state<RoomsListGroup[] | null>(null);
   isInitialLoading = $state(true);
+  hasUnreadFollowedThreads = $state(false);
   // The viewer's user ID, captured from the same sidebar bootstrap query that
   // produced DM `room.members`. Use this in preference to a global auth
   // context when filtering self out of DM labels and avatars.
@@ -218,6 +219,9 @@ export class RoomsStore {
 
   private loadId = 0;
   private notificationCountsLoadId = 0;
+  private threadUnreadRefreshPromise: Promise<void> | null = null;
+  private threadUnreadRefreshQueued = false;
+  private threadUnreadRevision = 0;
 
   constructor(
     private readonly roomDirectoryAPI: RoomDirectoryAPI,
@@ -235,6 +239,7 @@ export class RoomsStore {
   async refresh(): Promise<void> {
     const thisLoad = ++this.loadId;
     const unreadSnapshotRevision = this.roomUnread.captureSnapshotRevision();
+    const threadUnreadSnapshotRevision = this.threadUnreadRevision;
     const [viewer, rooms, roomGroups] = await Promise.all([
       this.viewerStateLoader(),
       this.roomDirectoryAPI.listRooms(RoomDirectoryScope.ALL),
@@ -243,6 +248,9 @@ export class RoomsStore {
     if (this.loadId !== thisLoad) return;
 
     this.currentUserId = viewer.user.id;
+    if (this.threadUnreadRevision === threadUnreadSnapshotRevision) {
+      this.hasUnreadFollowedThreads = viewer.viewerHasUnreadFollowedThreads;
+    }
     this.notificationLevels.setServerPreference(
       viewer.serverNotificationPreference.level,
       viewer.serverNotificationPreference.effectiveLevel
@@ -361,6 +369,36 @@ export class RoomsStore {
     }
   }
 
+  /**
+   * Refresh the exact backend-derived unread state for followed threads.
+   * Concurrent triggers collapse into the current request plus at most one
+   * follow-up so activity that lands during a request cannot be missed.
+   */
+  refreshUnreadFollowedThreads(): Promise<void> {
+    this.threadUnreadRefreshQueued = true;
+    if (this.threadUnreadRefreshPromise) return this.threadUnreadRefreshPromise;
+
+    this.threadUnreadRefreshPromise = (async () => {
+      while (this.threadUnreadRefreshQueued) {
+        this.threadUnreadRefreshQueued = false;
+        try {
+          const viewer = await this.viewerStateLoader();
+          this.threadUnreadRevision += 1;
+          this.hasUnreadFollowedThreads = viewer.viewerHasUnreadFollowedThreads;
+        } catch (err) {
+          console.warn('failed to refresh followed-thread unread state', err);
+        }
+      }
+    })().finally(() => {
+      this.threadUnreadRefreshPromise = null;
+      if (this.threadUnreadRefreshQueued) {
+        void this.refreshUnreadFollowedThreads();
+      }
+    });
+
+    return this.threadUnreadRefreshPromise;
+  }
+
   // -------------------------------------------------------------------------
   // Per-room flag mutations
   // -------------------------------------------------------------------------
@@ -433,9 +471,17 @@ export class RoomsStore {
   ingestServerEvent(serverEvent: { event?: RoomEventKindSource }): void {
     const event = serverEvent.event;
     if (!event) return;
+    const kind = roomEventKind(event);
     if (isRoomStateRefreshEvent(event)) {
       void this.refresh();
       return;
+    }
+    if (
+      kind === RoomEventKind.ThreadFollowChanged ||
+      kind === RoomEventKind.NotificationDismissed ||
+      (isMessagePostedEvent(event) && !!event.threadRootEventId)
+    ) {
+      void this.refreshUnreadFollowedThreads();
     }
     if (isMessagePostedEvent(event)) {
       const roomId = event.roomId;

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -61,7 +61,8 @@
 
   const connection = useConnection();
   const members = $derived(getRoomMembers());
-  const currentUser = $derived(serverRegistry.getStore(getActiveServer()).currentUser);
+  const serverStore = $derived(serverRegistry.getStore(getActiveServer()));
+  const currentUser = $derived(serverStore.currentUser);
 
   const store = new MessagesStore(connection(), () => currentUser.user?.id ?? null);
   onDestroy(() => store.dispose());
@@ -307,11 +308,13 @@
   ): Promise<MarkThreadAsReadResult | null> {
     try {
       const conn = connection();
-      return await createReadStateAPI({
+      const result = await createReadStateAPI({
         serverId: conn.serverId ?? getActiveServer(),
         baseUrl: conn.connectBaseUrl,
         bearerToken: conn.bearerToken
       }).markThreadAsRead({ roomId, threadRootEventId: currentThreadId, upToEventId });
+      void serverStore.rooms.refreshUnreadFollowedThreads();
+      return result;
     } catch (err) {
       console.error('Failed to mark thread as read:', err);
       return null;

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
@@ -26,7 +26,8 @@ const { mocks } = vi.hoisted(() => {
         dismissThreadNotifications: vi.fn().mockResolvedValue({ byRoom: {} })
       },
       rooms: {
-        decrementUnreadNotification: vi.fn()
+        decrementUnreadNotification: vi.fn(),
+        refreshUnreadFollowedThreads: vi.fn().mockResolvedValue(undefined)
       },
       appState: {
         isPresent: true
@@ -189,6 +190,7 @@ describe('ThreadPane', () => {
     expect(mocks.setThread).toHaveBeenCalledWith('room-1', 'thread-root');
     expect(mocks.notifications.dismissThreadNotifications).not.toHaveBeenCalled();
     expect(mocks.rooms.decrementUnreadNotification).not.toHaveBeenCalled();
+    expect(mocks.rooms.refreshUnreadFollowedThreads).toHaveBeenCalledOnce();
   });
 
   it('loads a highlighted reply outside the latest thread page before jumping to it', async () => {


### PR DESCRIPTION
## Summary

Fixes the persistent My Threads dot by using the backend's exact unread-followed-thread state instead of treating every thread-targeted notification as a followed thread.
Keeps that state current after thread replies, follow changes, notification dismissals, successful reads, and reconnects, with coalescing and stale-response protection.
Channel notification counts remain unchanged, so pending attention in unfollowed threads still links to the precise notification target.

## Validation

Targeted frontend tests (34), ESLint, Svelte/TypeScript checks, and focused core tests pass; the full frontend suite passed 1,984 of 1,986 tests, with two unrelated TipTapEditor accessibility failures that reproduce independently.
