### PR TITLE
fix(frontend): preserve pasted Markdown links

### DIFF
--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -1232,6 +1232,44 @@ describe('MessageComposer', () => {
       });
     });
 
+    it('preserves a labelled channel link across repeated edit and save cycles', async () => {
+      const url = 'https://chat.chatto.run/chat/-/REEi0LIuxqwQl3F';
+      let body = `[#announcements](${url})`;
+
+      for (let cycle = 1; cycle <= 3; cycle += 1) {
+        const eventId = `evt_channel_link_${cycle}`;
+        roomStateMock.editState.eventId = eventId;
+        roomStateMock.editState.originalBody = body;
+        const rendered = renderMessageComposer({ roomId: 'room_456' });
+        const editor = await findEditor(rendered.container);
+
+        await vi.waitFor(() => {
+          const link = editor.querySelector('a');
+          expect(link?.textContent).toBe('#announcements');
+          expect(link?.getAttribute('href')).toBe(url);
+        });
+        await placeCaretAtEditorEnd(editor);
+        document.execCommand('insertText', false, '!');
+        const editedBody = `${body}!`;
+        await vi.waitFor(() =>
+          expect(editor.textContent).toBe(`#announcements${'!'.repeat(cycle)}`)
+        );
+
+        (q(rendered.container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
+
+        await vi.waitFor(() => expect(updateMessageConnectMock).toHaveBeenCalledOnce());
+        expect(updateMessageConnectMock).toHaveBeenCalledWith({
+          roomId: expect.any(String),
+          eventId,
+          body: editedBody
+        });
+
+        body = editedBody;
+        rendered.unmount();
+        updateMessageConnectMock.mockClear();
+      }
+    });
+
     it('keeps an existing GFM table renderable after editing and saving', async () => {
       const body = '| Name | Role |\n| --- | --- |\n| Ada | Admin |';
       roomStateMock.editState.eventId = 'evt_table';
@@ -1612,6 +1650,66 @@ describe('MessageComposer', () => {
         roomId,
         body: '[example](https://example.com)'
       });
+    });
+
+    it('round-trips a pasted labelled Markdown channel link', async () => {
+      const body = '[#announcements](https://chat.chatto.run/chat/-/REEi0LIuxqwQl3F)';
+      const { container, roomId } = renderMessageComposer({ roomId: 'room_456' });
+      const editor = await findEditor(container);
+
+      editor.focus();
+      pasteText(editor, body);
+
+      await vi.waitFor(() => {
+        const link = editor.querySelector('a');
+        expect(link?.textContent).toBe('#announcements');
+        expect(link?.getAttribute('href')).toBe('https://chat.chatto.run/chat/-/REEi0LIuxqwQl3F');
+      });
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({ roomId, body });
+    });
+
+    it('round-trips a pasted Markdown channel link surrounded by prose', async () => {
+      const url = 'https://chat.chatto.run/chat/-/REEi0LIuxqwQl3F';
+      const body = `See [#announcements](${url}) for details`;
+      const { container, roomId } = renderMessageComposer({ roomId: 'room_456' });
+      const editor = await findEditor(container);
+
+      editor.focus();
+      pasteText(editor, body);
+
+      await vi.waitFor(() => {
+        expect(editor.textContent).toBe('See #announcements for details');
+        const link = editor.querySelector('a');
+        expect(link?.textContent).toBe('#announcements');
+        expect(link?.getAttribute('href')).toBe(url);
+      });
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({ roomId, body });
+    });
+
+    it('uses the Markdown link from plain text when pasted HTML is also available', async () => {
+      const url = 'https://chat.chatto.run/chat/-/REEi0LIuxqwQl3F';
+      const body = `[#announcements](${url})`;
+      const { container, roomId } = renderMessageComposer({ roomId: 'room_456' });
+      const editor = await findEditor(container);
+
+      editor.focus();
+      pasteText(editor, body, `<a href="https://wrong.example/">wrong label</a>`);
+
+      await vi.waitFor(() => {
+        const link = editor.querySelector('a');
+        expect(link?.textContent).toBe('#announcements');
+        expect(link?.getAttribute('href')).toBe(url);
+      });
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({ roomId, body });
     });
 
     it('preserves a single pasted line break without creating separate paragraphs', async () => {

--- a/apps/frontend/src/lib/components/composer/TipTapEditor.svelte
+++ b/apps/frontend/src/lib/components/composer/TipTapEditor.svelte
@@ -41,6 +41,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
   import type { QuoteInsertionContent, SelectedQuoteBlock } from '$lib/state/room';
 
   const markdownLinkInputRegex = /(^|\s)\[([^\]\n]+)\]\((https?:\/\/[^\s)]+)\)$/;
+  const markdownLinkPasteRegex = /\[([^\]\n]+)\]\((https?:\/\/[^\s)]+)\)/g;
   const codeFenceLineRegex = /^```([\w-]+)?$/;
   const markdownBulletListLineRegex = /^[ \t]{0,3}[-+*]\s(.*)$/;
   const markdownOrderedListLineRegex = /^[ \t]{0,3}(\d{1,9})[.)]\s(.*)$/;
@@ -716,7 +717,37 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     );
   }
 
-  function createLiteralClipboardContent(
+  function createClipboardInlineContent(
+    text: string,
+    schema: Schema,
+    destinationMarks: readonly Mark[]
+  ): ProseMirrorNode[] {
+    const linkType = schema.marks.link;
+    if (!text || !linkType) return text ? [schema.text(text, destinationMarks)] : [];
+
+    const nodes: ProseMirrorNode[] = [];
+    const nonLinkMarks = destinationMarks.filter((mark) => mark.type !== linkType);
+    let index = 0;
+
+    for (const match of text.matchAll(markdownLinkPasteRegex)) {
+      const matchIndex = match.index;
+      const label = match[1];
+      const href = match[2];
+      if (!label || !href || text[matchIndex - 1] === '!' || text[matchIndex - 1] === '\\') {
+        continue;
+      }
+
+      if (matchIndex > index)
+        nodes.push(schema.text(text.slice(index, matchIndex), destinationMarks));
+      nodes.push(schema.text(label, [...nonLinkMarks, linkType.create({ href })]));
+      index = matchIndex + match[0].length;
+    }
+
+    if (index < text.length) nodes.push(schema.text(text.slice(index), destinationMarks));
+    return nodes;
+  }
+
+  function createClipboardContent(
     text: string,
     schema: Schema,
     destinationMarks: readonly Mark[]
@@ -731,7 +762,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
         const lines = paragraphText.split('\n');
 
         lines.forEach((line, index) => {
-          if (line) inlineNodes.push(schema.text(line, paragraphMarks));
+          inlineNodes.push(...createClipboardInlineContent(line, schema, paragraphMarks));
           if (index < lines.length - 1) inlineNodes.push(hardBreakType.create());
         });
 
@@ -1356,12 +1387,12 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
                     markdown.parse.bind(markdown)
                   )
                 : null;
-
-              // Keep ordinary clipboard text literal. ProseMirror's default parser turns every
-              // pasted line into a paragraph, which creates an extra rendered blank line.
+              // Keep ordinary clipboard text literal while recognizing the same link syntax as
+              // typed input. ProseMirror's default parser also turns every pasted line into a
+              // paragraph, which creates an extra rendered blank line.
               const content =
                 fencedCode ??
-                createLiteralClipboardContent(normalizedText, view.state.schema, destinationMarks);
+                createClipboardContent(normalizedText, view.state.schema, destinationMarks);
               return Slice.maxOpen(content);
             },
             handlePaste: (view, event) => {


### PR DESCRIPTION
## Why

Pasted Markdown links could leave their syntax literal while autolinking the destination, producing nested link source that became visible when the message was edited.

## What changed

- Recognize the composer's supported `[label](https://…)` syntax anywhere in pasted plain text while leaving unrelated Markdown literal.
- Preserve surrounding prose, active formatting, multiline clipboard behaviour, and the plain-text representation when clipboard HTML is also present.
- Cover standalone and prose-wrapped channel links plus repeated edit/save cycles.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Unchanged.

Newer client → older server: Unchanged.

Capability discovery or minimum client/server version: None.

## Test plan

- `mise x -- pnpm --filter chatto-frontend exec vitest --run src/lib/components/composer/MessageComposer.svelte.spec.ts` — 121 passed.
- `mise lint-frontend` — passed with zero Svelte errors or warnings.
- Svelte autofixer — no issues.
- `git diff --check` — passed.
