### PR TITLE
fix(frontend): restore message editor accessible label

### DIFF
--- a/apps/frontend/src/lib/components/composer/TipTapEditor.svelte
+++ b/apps/frontend/src/lib/components/composer/TipTapEditor.svelte
@@ -1186,7 +1186,10 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
           editable,
           autofocus: autofocus ? 'end' : false,
           editorProps: {
-            attributes: testid ? { 'data-testid': testid } : {},
+            attributes: {
+              'aria-label': placeholder,
+              ...(testid ? { 'data-testid': testid } : {})
+            },
             handleKeyDown: (_view, event) => {
               return onKeyDown?.(event) ?? false;
             },
@@ -1266,6 +1269,9 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
   // React to placeholder prop changes (e.g., switching between normal and edit mode)
   $effect(() => {
     if (!editor) return;
+    if (editor.view.dom.getAttribute('aria-label') !== placeholder) {
+      editor.view.dom.setAttribute('aria-label', placeholder);
+    }
     const ext = editor.extensionManager.extensions.find((e) => e.name === 'placeholder');
     if (ext && ext.options.placeholder !== placeholder) {
       ext.options.placeholder = placeholder;


### PR DESCRIPTION
## Summary

- Restore the TipTap message editor's placeholder-derived accessible name.
- Keep the `aria-label` synchronized when switching between compose and edit placeholders.

The release branch added accessibility assertions without carrying over the matching editor attributes, causing both TipTap browser tests to time out.

## Testing

- `mise test-frontend` (1,987 tests passed)
- `mise x -- pnpm --filter chatto-frontend check` (0 errors and 0 warnings)
- Svelte autofixer, Prettier, and `git diff --check`
