### PR TITLE
fix(frontend): align server settings icon

### DIFF
--- a/apps/frontend/src/lib/components/chat/ServerHeader.svelte
+++ b/apps/frontend/src/lib/components/chat/ServerHeader.svelte
@@ -15,7 +15,7 @@
 </script>
 
 {#if adminHref}
-  <PaneHeader title={serverName} {loading} skeletonButtons={1}>
+  <PaneHeader title={serverName} {loading} skeletonButtons={1} rightInset="compact">
     {#snippet actions()}
       <HeaderIconButton
         icon="uil--setting"

--- a/apps/frontend/src/lib/ui/PaneHeader.stories.svelte
+++ b/apps/frontend/src/lib/ui/PaneHeader.stories.svelte
@@ -56,6 +56,16 @@
   </div>
 </Story>
 
+<Story name="Compact action inset" asChild>
+  <div class="w-64 rounded-md border border-border">
+    <PaneHeader title="Development" rightInset="compact">
+      {#snippet actions()}
+        <HeaderIconButton icon="uil--cog" label="Server settings" />
+      {/snippet}
+    </PaneHeader>
+  </div>
+</Story>
+
 <Story name="Loading" asChild>
   <div class="w-[480px] rounded-md border border-border">
     <PaneHeader title="" loading skeletonButtons={2} />

--- a/apps/frontend/src/lib/ui/PaneHeader.svelte
+++ b/apps/frontend/src/lib/ui/PaneHeader.svelte
@@ -12,6 +12,8 @@ Design language:
   - Left padding is `pl-2` when a back affordance is shown, `pl-4`
     otherwise. The reduced left inset lines the back arrow up with the
     sidebar-nav items rendered below the header.
+  - Right padding defaults to `pr-4`. Use `rightInset="compact"` when
+    actions need to align with controls inside an adjacent `p-2` region.
   - Header icons use a fixed padded hit area so optional backgrounds do
     not change pane header height.
   - Right-side action icons are `<HeaderIconButton>` instances passed
@@ -40,6 +42,7 @@ choice).
     backHref,
     onBack,
     backLabel = m['ui.pane_header.back'](),
+    rightInset = 'default',
     // Deprecated: showMobileNav is no longer used since hamburger menu is always visible
     showMobileNav: _showMobileNav = false
   }: {
@@ -63,6 +66,8 @@ choice).
     onBack?: (event: MouseEvent) => void;
     /** Title attribute / aria-label for the back affordance. */
     backLabel?: string;
+    /** Right-side action inset. `compact` aligns actions with content inside a `p-2` region. */
+    rightInset?: 'default' | 'compact';
     showMobileNav?: boolean;
   } = $props();
 
@@ -71,7 +76,8 @@ choice).
 
 <div
   class={[
-    'flex h-14 shrink-0 items-center justify-between border-b border-border pr-4',
+    'flex h-14 shrink-0 items-center justify-between border-b border-border',
+    rightInset === 'compact' ? 'pr-2' : 'pr-4',
     hasBack ? 'pl-2' : 'pl-4'
   ]}
 >


### PR DESCRIPTION
## Why

The server administration gear had a larger right inset than the room-group settings gear below it, making the controls look misaligned.

## What changed

Added an explicit compact right-inset variant to `PaneHeader` and used it for the server header so both settings controls align without changing other pane headers; Storybook documents the new layout option.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Not applicable.

Newer client → older server: Not applicable.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- Svelte autofixer for `PaneHeader.svelte`, `ServerHeader.svelte`, and `PaneHeader.stories.svelte` — passed
- ESLint for all three changed Svelte files — passed
- `git diff --check` — passed
- Browser verification was unavailable in this agent session.
