### PR TITLE
feat(frontend): add room group context menu

### DIFF
--- a/apps/frontend/src/lib/RoomList.svelte
+++ b/apps/frontend/src/lib/RoomList.svelte
@@ -68,6 +68,9 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
 
   let activeRoomId = $derived(page.params.roomId);
   let roomContextMenu = $state<(ContextMenuTriggerDetails & { room: RoomsListItem }) | null>(null);
+  let groupContextMenu = $state<(ContextMenuTriggerDetails & { group: RoomsListGroup }) | null>(
+    null
+  );
 
   function roomMenuTrigger(room: RoomsListItem) {
     return contextMenuTrigger((details) => {
@@ -77,6 +80,27 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
 
   function closeRoomContextMenu(): void {
     roomContextMenu = null;
+  }
+
+  function groupMenuTrigger(group: RoomsListGroup) {
+    if (!group.viewerCanManageGroup) return undefined;
+    return contextMenuTrigger((details) => {
+      groupContextMenu = { ...details, group };
+    });
+  }
+
+  function closeGroupContextMenu(): void {
+    groupContextMenu = null;
+  }
+
+  function handleConfigureGroup(group: RoomsListGroup): void {
+    closeGroupContextMenu();
+    void goto(
+      resolve('/chat/[serverId]/manage/room-groups/[groupId]', {
+        serverId: serverSegment,
+        groupId: group.id
+      })
+    );
   }
 
   function handleMarkRoomRead(room: RoomsListItem): void {
@@ -479,22 +503,8 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
           persistKey={serverStorageKey(getActiveServer(), `collapsible:set:${set.id}`)}
           keepVisibleWhenCollapsed={isGroupItemHighlighted}
           class={i === 0 ? 'mt-4 first:mt-0' : 'mt-4'}
-        >
-          {#snippet actions()}
-            {#if set.viewerCanManageGroup}
-              <a
-                href={resolve('/chat/[serverId]/manage/room-groups/[groupId]', {
-                  serverId: serverSegment,
-                  groupId: set.id
-                })}
-                class="icon-action shrink-0"
-                aria-label={m['room_list.group_settings']({ group: set.name })}
-              >
-                <span class="iconify uil--setting" aria-hidden="true"></span>
-              </a>
-            {/if}
-          {/snippet}
-        </CollapsibleGroup>
+          contextMenuTrigger={groupMenuTrigger(set)}
+        />
       {/each}
     {:else if sortedRooms.length > 0}
       <!-- No layout configured yet — alphabetical fallback. -->
@@ -519,6 +529,30 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
       />
     {/if}
   </nav>
+{/if}
+
+{#if groupContextMenu}
+  {@const contextGroup = groupContextMenu.group}
+  <ContextMenu
+    position={groupContextMenu.position}
+    presentation={groupContextMenu.presentation}
+    ariaLabel={m['room_list.group_settings']({ group: contextGroup.name })}
+    onclose={closeGroupContextMenu}
+  >
+    <div class="menu-section">
+      <nav class="sidebar-nav">
+        <button
+          type="button"
+          class="sidebar-item"
+          onclick={() => handleConfigureGroup(contextGroup)}
+          role="menuitem"
+        >
+          <span class="sidebar-icon iconify uil--setting" aria-hidden="true"></span>
+          {m['room_list.group_settings']({ group: contextGroup.name })}
+        </button>
+      </nav>
+    </div>
+  </ContextMenu>
 {/if}
 
 {#if roomContextMenu}

--- a/apps/frontend/src/lib/RoomList.svelte.spec.ts
+++ b/apps/frontend/src/lib/RoomList.svelte.spec.ts
@@ -792,7 +792,7 @@ describe('RoomList', () => {
     expect(link.getAttribute('rel')).toBeNull();
   });
 
-  it('keeps an empty manageable group visible with a settings link', async () => {
+  it('keeps an empty manageable group visible and opens its settings from a context menu', async () => {
     mocks.store.rooms.rooms = [];
     mocks.store.rooms.roomGroups = [
       {
@@ -806,12 +806,26 @@ describe('RoomList', () => {
 
     const { container } = render(RoomList);
 
-    const link = q(
-      container,
-      '[href="/chat/-/manage/room-groups/private-group"]'
-    ) as HTMLAnchorElement;
-    await expect.element(link).toBeInTheDocument();
-    expect(link.getAttribute('aria-label')).toBe('Settings for Private Group');
+    const groupHeader = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Private Group')
+    );
+    await expect.element(groupHeader ?? null).toBeInTheDocument();
+    expect(container.querySelector('.uil--setting')).toBeNull();
+
+    groupHeader!.dispatchEvent(
+      new MouseEvent('contextmenu', { bubbles: true, cancelable: true, clientX: 40, clientY: 60 })
+    );
+    await vi.waitFor(() =>
+      expect(document.body.textContent).toContain('Settings for Private Group')
+    );
+
+    const settings = Array.from(document.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Settings for Private Group'
+    );
+    await expect.element(settings ?? null).toBeInTheDocument();
+
+    settings!.click();
+    expect(mocks.goto).toHaveBeenCalledWith('/chat/-/manage/room-groups/private-group');
   });
 
   it('renders active-server host sidebar links as same-tab anchors', async () => {

--- a/apps/frontend/src/lib/ui/CollapsibleGroup.svelte
+++ b/apps/frontend/src/lib/ui/CollapsibleGroup.svelte
@@ -35,6 +35,7 @@ offline member groups).
 
 <script lang="ts" generics="T extends { id: string }">
   import type { Snippet } from 'svelte';
+  import type { Attachment } from 'svelte/attachments';
   import { slide } from 'svelte/transition';
 
   interface Props {
@@ -43,6 +44,8 @@ offline member groups).
     item: Snippet<[T]>;
     /** Optional controls rendered beside the collapse toggle. */
     actions?: Snippet;
+    /** Optional right-click/long-press behavior for the group header. */
+    contextMenuTrigger?: Attachment<HTMLElement>;
     /** Unique localStorage key for persisting collapsed state. */
     persistKey: string;
     /** Collapsed state when no preference is stored. */
@@ -56,6 +59,7 @@ offline member groups).
     items,
     item,
     actions,
+    contextMenuTrigger,
     persistKey,
     defaultCollapsed = false,
     keepVisibleWhenCollapsed,
@@ -75,10 +79,11 @@ offline member groups).
       type="button"
       onclick={toggle}
       class="flex min-w-0 flex-1 cursor-pointer items-center gap-2 px-1 py-1 text-xs font-semibold tracking-wider text-muted uppercase transition-colors hover:text-text"
+      {@attach contextMenuTrigger}
     >
       <span class="sidebar-icon">
         <span
-          class={['iconify uil--angle-right-b transition-transform', collapsed ? '' : 'rotate-90']}
+          class={['iconify transition-transform uil--angle-right-b', collapsed ? '' : 'rotate-90']}
         ></span>
       </span>
       <span class="truncate">{label}</span>


### PR DESCRIPTION
## Why

Room-group settings should use the same unobtrusive contextual interaction as room and server actions instead of occupying persistent sidebar space with a gear icon.

## What changed

- Removed the room-group gear and added right-click/long-press settings menus for manageable group headers.
- Extended `CollapsibleGroup` with an optional context-menu attachment and covered menu navigation with a component regression test.

## API compatibility

- No public API or protocol behaviour changed; client/server version skew and capability discovery are unaffected.

## Test plan

- `mise x -- pnpm --filter chatto-frontend exec vitest --run src/lib/RoomList.svelte.spec.ts` — 30 tests passed.
- `mise x -- pnpm --dir apps/frontend run check` — design-system guardrails passed; Svelte reported 0 errors and 0 warnings.
- Browser verification remains outstanding because no browser was available in the session.
