### PR TITLE
docs: align records with current behavior

### DIFF
--- a/apps/frontend/e2e/registration-disabled.test.ts
+++ b/apps/frontend/e2e/registration-disabled.test.ts
@@ -11,27 +11,17 @@ test.use({
 });
 
 test.describe('Registration disabled', () => {
-  test('login page hides "Create one" registration link when registration is disabled', async ({
+  test('login page hides "Create account" registration link when registration is disabled', async ({
     page
   }) => {
-    // The /login page should query the instance to check if registration is enabled
-    // and hide the "Create one" link when it's disabled.
     await page.goto(routes.login);
     await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
-    // TODO: The /login page doesn't yet check directRegistrationEnabled.
-    // This was previously tested via LoginScreen at / which did check it.
-    // For now, verify the register page itself shows the disabled message.
-    await page.goto(routes.register);
-    await expect(
-      page.getByText('Registration is not available on this instance.')
-    ).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Create account' })).toBeHidden();
   });
 
   test('register page shows disabled message', async ({ page }) => {
     await page.goto(routes.register);
-    await expect(
-      page.getByText('Registration is not available on this instance.')
-    ).toBeVisible();
+    await expect(page.getByText('Registration is not available on this instance.')).toBeVisible();
   });
 
   test('register API returns 403', async ({ page }) => {

--- a/docs/adr/ADR-025-multi-instance-client-architecture.md
+++ b/docs/adr/ADR-025-multi-instance-client-architecture.md
@@ -1,4 +1,6 @@
-# ADR-025: Multi-Instance Client Architecture
+# ADR-025: Multi-Server Client Architecture
+
+**Date:** 2026-03-20
 
 ## Status
 
@@ -6,19 +8,19 @@ Accepted
 
 ## Context
 
-Chatto's frontend was originally designed as a single-instance client — the SPA was always served by the Chatto instance it connected to, and all state (auth, spaces, rooms, notifications) was implicitly scoped to that one server.
+Chatto's frontend was originally designed as a single-server client — the SPA was always served by the Chatto server it connected to, and all state (auth, rooms, notifications) was implicitly scoped to that one server.
 
-Users wanted to connect to multiple Chatto instances from a single client (similar to how Discord or Slack allow multiple workspaces). This required rethinking how the frontend manages authentication, state, and routing.
+Users wanted to connect to multiple Chatto servers from a single client (similar to how Discord or Slack allow multiple workspaces). This required rethinking how the frontend manages authentication, state, and routing.
 
 ## Decision
 
-### Instance-Agnostic UI
+### Server-Agnostic UI
 
-The frontend is instance-agnostic by default. It doesn't assume it's served by a Chatto instance. Instead:
+The frontend is server-agnostic by default. It doesn't assume it is served by a Chatto server. Instead:
 
-1. **Probe-based origin detection**: On init, call `chatto.discovery.v1.ServerDiscoveryService.GetServer` on the current origin. If it responds, auto-register the origin as an instance. If it fails (static hosting), skip.
-2. **No `isHome` flag**: The origin instance is identified by comparing `instance.url` to `window.location.origin` at runtime — no stored flag.
-3. **Bearer-first client auth**: The client stores opaque bearer tokens in `localStorage` for every authenticated instance, including the origin when direct login or registration returns a token. Cookie auth remains as an origin-only fallback for compatibility flows that have not yet handed the SPA a bearer token.
+1. **Probe-based origin detection**: On init, call `chatto.discovery.v1.ServerDiscoveryService.GetServer` on the current origin. If it responds, auto-register the origin as a server. If it fails (static hosting), skip.
+2. **No `isHome` flag**: The origin server is identified by comparing `server.url` to `window.location.origin` at runtime — no stored flag.
+3. **Bearer-first client auth**: The client stores opaque bearer tokens in `localStorage` for every authenticated server, including the origin when direct login or registration returns a token. Cookie auth remains as an origin-only fallback for compatibility flows that have not yet handed the SPA a bearer token.
 
 Bearer tokens are only handed to API clients that need to authenticate
 ConnectRPC, realtime WebSocket, or direct HTTP API traffic. Browser media
@@ -27,18 +29,22 @@ per-user asset access tickets on stable asset URLs instead.
 
 ### Unified Registry + State
 
-`InstanceRegistry` owns both registration data (`RegisteredInstance[]`) and per-instance state stores (`SvelteMap<string, InstanceStateStore>`). Registration and store creation are atomic — when an instance is added, its store exists immediately. This eliminates the race condition where `$derived` expressions see a registered instance but can't find its store.
+`ServerRegistry` owns both registration data (`RegisteredServer[]`) and per-server state stores (`SvelteMap<string, ServerStateStore>`). Registration and store creation are atomic — when a server is added, its store exists immediately. This eliminates the race condition where `$derived` expressions see a registered server but cannot find its store.
 
-### URL-Based Instance Routing
+The persisted `localStorage` slot intentionally remains named `instances` so
+upgrades retain existing server registrations and remote bearer tokens. This
+is a storage-compatibility name, not current domain terminology.
 
-The URL is the sole source of truth for which instance is active:
+### URL-Based Server Routing
 
-- `-` segment = origin instance
-- Hostname segment = remote instance (e.g., `chat.example.com`)
+The URL is the sole source of truth for which server is active:
 
-The `[instanceId]/+layout.svelte` resolves the segment and provides the instance ID via Svelte context. No mutable "active instance" singleton.
+- `-` segment = origin server
+- Hostname segment = remote server (e.g., `chat.example.com`)
 
-### Per-Instance Permissions
+The `[serverId]/+layout.svelte` resolves the segment and provides the server ID via Svelte context. No mutable "active server" singleton.
+
+### Per-Server Permissions
 
 Each server state store has permission and viewer-capability state loaded from ConnectRPC viewer/server-state APIs. This lets the UI show only actions the viewer can perform on the selected server.
 
@@ -50,24 +56,24 @@ Bearer tokens use NATS KV TTL (default 90 days). Each successful `ValidateAuthTo
 
 ### Positive
 
-- Users can connect to multiple Chatto instances from one client
+- Users can connect to multiple Chatto servers from one client
 - The SPA can be served statically (CDN) without a Chatto backend
-- No special-casing for "home" vs "remote" — all instances use the same code paths
+- No special-casing for "home" vs "remote" — all servers use the same code paths
 - Token sliding window means active users never get surprise logouts
 
 ### Negative
 
-- Registered-instance bearer tokens in `localStorage` are vulnerable to XSS (cookie auth is not)
+- Registered-server bearer tokens in `localStorage` are vulnerable to XSS (cookie auth is not)
 - This makes XSS prevention part of the auth boundary. The shipped frontend sets
   a report-only CSP with Trusted Types reporting so deployments can surface
   dangerous script and DOM-sink patterns before policy enforcement is viable for
   the multi-server client.
 - `chatto.discovery.v1.ServerDiscoveryService.GetServer` is the only ConnectRPC endpoint with unconditional wildcard CORS — rich data needed pre-registration must go there, not in authenticated ConnectRPC calls
-- Separately hosted multi-instance frontends must be listed explicitly in each remote server's `webserver.oauth_redirect_origins` or exact `webserver.allowed_origins` before OAuth authorization codes can redirect back to them; wildcard CORS does not imply OAuth redirect trust. `oauth_redirect_origins = ["*"]` exists only as a temporary controlled-alpha escape hatch.
+- Separately hosted multi-server frontends must be listed explicitly in each remote server's `webserver.oauth_redirect_origins` or exact `webserver.allowed_origins` before OAuth authorization codes can redirect back to them; wildcard CORS does not imply OAuth redirect trust. `oauth_redirect_origins = ["*"]` exists only as a temporary controlled-alpha escape hatch.
 - Users approve the first OAuth authorization for each trusted client origin; Chatto remembers that consent per user + origin instead of relying on an operator-managed OAuth client registry
 - The probe is async for unauthenticated users, so the origin may not be registered by the time the first render completes
 
 ### Trade-offs
 
 - During the transition, cookie and token auth still create two disconnect flows: token failures remove the registered credential, while origin cookie fallback can still require server-side logout + hard reload for compatibility paths.
-- SvelteMap for the store map enables reactive `$derived` reads but requires careful separation of imperative writes (`addInstance`) from pure reads (`getStore`)
+- SvelteMap for the store map enables reactive `$derived` reads but requires careful separation of imperative writes (`addServer`) from pure reads (`getStore`)

--- a/docs/adr/ADR-029-instance-to-server-rename.md
+++ b/docs/adr/ADR-029-instance-to-server-rename.md
@@ -2,7 +2,7 @@
 
 - **Status**: Accepted
 - **Date**: 2026-05-11
-- **Related**: [ADR-025: Multi-instance Client Architecture](ADR-025-multi-instance-client-architecture.md), [ADR-027: Instance/Space/Server Consolidation](ADR-027-instance-space-server-consolidation.md)
+- **Related**: [ADR-025: Multi-Server Client Architecture](ADR-025-multi-instance-client-architecture.md), [ADR-027: Instance/Space/Server Consolidation](ADR-027-instance-space-server-consolidation.md)
 
 ## Context
 

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -6,57 +6,61 @@ For more about ADRs, see [Michael Nygard's article](https://cognitect.com/blog/2
 
 ## Decisions
 
-| # | Decision | Date |
-|---|----------|------|
-| [ADR-001](ADR-001-nats-jetstream-as-primary-data-store.md) | NATS JetStream as Primary Data Store | 2026-03-01 |
-| [ADR-002](ADR-002-single-binary-with-embedded-nats.md) | Single Binary with Embedded NATS Server | 2026-03-01 |
-| [ADR-003](ADR-003-graphql-as-primary-api.md) | GraphQL as the Primary API | 2026-03-01 |
-| [ADR-004](ADR-004-authorization-at-api-boundary.md) | Authorization Enforced at the API Boundary, Not in Core | 2026-03-01 |
-| [ADR-005](ADR-005-hierarchy-wins-rbac.md) | Hierarchy-Wins RBAC Permission Resolution | 2026-03-01 |
-| [ADR-006](ADR-006-kv-source-of-truth-streams-audit-log.md) | KV as Source of Truth, Streams as Audit Logs | 2026-03-01 |
-| [ADR-007](ADR-007-per-user-encryption-with-crypto-shredding.md) | Per-User Encryption Keys with Crypto-Shredding for GDPR | 2026-03-01 |
-| [ADR-008](ADR-008-protobuf-for-event-serialization.md) | Protobuf for Event Serialization | 2026-03-01 |
-| [ADR-009](ADR-009-webhook-driven-voice-call-state.md) | Durable LiveKit Call State | 2026-03-01 |
-| [ADR-010](ADR-010-svelte5-reactive-cache-whitelisting.md) | Svelte 5 Reactive Cache Whitelisting | 2026-03-01 |
-| [ADR-011](ADR-011-message-body-event-split.md) | Message Body / Event Split | 2026-03-01 |
-| [ADR-012](ADR-012-two-tier-realtime-events.md) | Two-Tier Real-Time Event System | 2026-03-01 |
-| [ADR-013](ADR-013-per-space-stream-sharding.md) | Per-Space JetStream Stream Sharding with Lazy Initialization | 2026-03-01 |
-| [ADR-014](ADR-014-single-subscription-per-space.md) | Single GraphQL Subscription Per Space | 2026-03-01 |
-| [ADR-015](ADR-015-dms-as-hidden-space.md) | Direct Messages as a Hidden Space | 2026-03-01 |
-| [ADR-016](ADR-016-occ-for-message-publishing.md) | Optimistic Concurrency Control for Message Publishing | 2026-03-01 |
-| [ADR-017](ADR-017-cookie-session-auth-for-websocket.md) | Cookie-Session Authentication Propagated to WebSocket | 2026-03-01 |
-| [ADR-018](ADR-018-sveltekit-spa-embedded-in-go.md) | SvelteKit SPA Embedded in Go Binary | 2026-03-01 |
-| [ADR-019](ADR-019-dataloaders-http-only.md) | Dataloaders Scoped to HTTP Requests Only | 2026-03-01 |
-| [ADR-020](ADR-020-build-tag-test-endpoints.md) | Build-Tag Gated Test Endpoints | 2026-03-01 |
-| [ADR-021](ADR-021-dual-asset-storage.md) | Dual Asset Storage — NATS ObjectStore Default, S3 Optional | 2026-03-01 |
-| [ADR-022](ADR-022-nanoid-with-entity-prefixes.md) | NanoID with Entity-Type Prefixes | 2026-03-01 |
-| [ADR-023](ADR-023-hmac-signed-image-transform-urls.md) | HMAC-Signed Image Transform URLs | 2026-03-01 |
-| [ADR-024](ADR-024-opaque-bearer-tokens-for-cross-origin-auth.md) | Opaque Bearer Tokens for Cross-Origin Authentication | 2026-03-03 |
-| [ADR-025](ADR-025-multi-instance-client-architecture.md) | Multi-Instance Client Architecture | 2026-03-20 |
-| [ADR-026](ADR-026-event-identity-via-nanoid.md) | Event Identity via NanoID, Not JetStream Sequence Numbers | 2026-03-26 |
-| [ADR-027](ADR-027-instance-space-server-consolidation.md) | Consolidate Instance + Space into a Single "Server" Concept | 2026-05-04 |
-| [ADR-028](ADR-028-event-id-keyed-read-state.md) | Event-ID-Keyed Read State | 2026-05-06 |
-| [ADR-029](ADR-029-instance-to-server-rename.md) | Rename `Instance` → `Server` across the codebase | 2026-05-11 |
-| [ADR-030](ADR-030-space-tier-retirement.md) | Retire the Space tier | 2026-05-11 |
-| [ADR-031](ADR-031-room-group-centric-acl.md) | Room-Group-Centric ACL for Room-Scope Permissions | 2026-05-13 |
-| [ADR-032](ADR-032-signed-attachment-locator-urls.md) | Self-Describing Signed Attachment URLs | 2026-05-23 |
-| [ADR-033](ADR-033-event-sourced-state-with-projections.md) | Event-Sourced State with Derived Projections | 2026-05-24 |
-| [ADR-034](ADR-034-single-event-stream.md) | Single Event Stream with Event-Type Subject Lanes | 2026-05-24 |
-| [ADR-035](ADR-035-per-aggregate-phased-migration.md) | Per-Aggregate Phased Migration to Event Sourcing | 2026-05-24 |
-| [ADR-036](ADR-036-runtime-state-kv-boundary.md) | Persist Runtime State in RUNTIME_STATE | 2026-05-27 |
-| [ADR-037](ADR-037-dm-access-via-membership.md) | DM Access via Membership, Not a Read Permission | 2026-05-31 |
-| [ADR-038](ADR-038-room-owned-thread-state.md) | Room-Owned Thread State | 2026-06-05 |
-| [ADR-039](ADR-039-service-worker-virtual-asset-urls.md) | Service Worker Virtual Asset URLs with Ticketed Fallback | 2026-06-08 |
-| [ADR-040](ADR-040-permission-only-rbac-with-owner-override.md) | Permission-Only RBAC with Owner Override | 2026-06-15 |
-| [ADR-041](ADR-041-runtime-units.md) | Runtime Units for Optional Chatto Processes | 2026-06-21 |
-| [ADR-042](ADR-042-protobuf-first-public-api.md) | Protobuf-First Public API with ConnectRPC and Realtime WebSocket | 2026-06-22 |
-| [ADR-043](ADR-043-client-shell-internationalization.md) | Client-Shell Internationalization | 2026-06-22 |
-| [ADR-044](ADR-044-connectrpc-service-conventions.md) | ConnectRPC Service Conventions | 2026-06-25 |
-| [ADR-045](ADR-045-public-api-stability-tiers.md) | Public API Stability Tiers | 2026-06-28 |
-| [ADR-046](ADR-046-typed-runtime-credentials.md) | Typed Runtime Credentials | 2026-06-30 |
-| [ADR-047](ADR-047-direct-ticketed-asset-urls.md) | Direct Ticketed Asset URLs for Browser Media | 2026-07-05 |
-| [ADR-048](ADR-048-frontend-optimistic-ui.md) | Frontend Optimistic UI Uses Scoped Provisional Patches | 2026-07-09 |
-| [ADR-049](ADR-049-process-wide-realtime-event-hub.md) | Process-Wide Realtime Event Hub | 2026-07-14 |
-| [ADR-050](ADR-050-ephemeral-encrypted-projection-snapshots.md) | Ephemeral Encrypted Projection Snapshots | 2026-07-13 |
-| [ADR-051](ADR-051-server-scoped-resumable-client-projection.md) | Server-Scoped Resumable Client Projection | 2026-07-16 |
-| [ADR-052](ADR-052-subject-specific-rbac-with-everyone-baseline.md) | Subject-Specific RBAC with an Everyone Baseline | 2026-07-19 |
+Status describes whether a decision still governs the current architecture.
+Partially superseded records retain a current foundation while later ADRs
+replace part of their original design.
+
+| # | Decision | Status | Date |
+|---|----------|--------|------|
+| [ADR-001](ADR-001-nats-jetstream-as-primary-data-store.md) | NATS JetStream as Primary Data Store | Partially superseded | 2026-03-01 |
+| [ADR-002](ADR-002-single-binary-with-embedded-nats.md) | Single Binary with Embedded NATS Server | Accepted | 2026-03-01 |
+| [ADR-003](ADR-003-graphql-as-primary-api.md) | GraphQL as the Primary API | Superseded | 2026-03-01 |
+| [ADR-004](ADR-004-authorization-at-api-boundary.md) | Authorization Enforced at the API Boundary, Not in Core | Superseded | 2026-03-01 |
+| [ADR-005](ADR-005-hierarchy-wins-rbac.md) | Hierarchy-Wins RBAC Permission Resolution | Superseded | 2026-03-01 |
+| [ADR-006](ADR-006-kv-source-of-truth-streams-audit-log.md) | KV as Source of Truth, Streams as Audit Logs | Superseded | 2026-03-01 |
+| [ADR-007](ADR-007-per-user-encryption-with-crypto-shredding.md) | Per-User Encryption Keys with Crypto-Shredding for GDPR | Accepted | 2026-03-01 |
+| [ADR-008](ADR-008-protobuf-for-event-serialization.md) | Protobuf for Event Serialization | Accepted | 2026-03-01 |
+| [ADR-009](ADR-009-webhook-driven-voice-call-state.md) | Durable LiveKit Call State | Accepted | 2026-03-01 |
+| [ADR-010](ADR-010-svelte5-reactive-cache-whitelisting.md) | Svelte 5 Reactive Cache Whitelisting | Accepted | 2026-03-01 |
+| [ADR-011](ADR-011-message-body-event-split.md) | Message Body / Event Split | Accepted | 2026-03-01 |
+| [ADR-012](ADR-012-two-tier-realtime-events.md) | Two-Tier Real-Time Event System | Accepted | 2026-03-01 |
+| [ADR-013](ADR-013-per-space-stream-sharding.md) | Per-Space JetStream Stream Sharding with Lazy Initialization | Superseded | 2026-03-01 |
+| [ADR-014](ADR-014-single-subscription-per-space.md) | Single GraphQL Subscription Per Space | Superseded | 2026-03-01 |
+| [ADR-015](ADR-015-dms-as-hidden-space.md) | Direct Messages as a Hidden Space | Superseded | 2026-03-01 |
+| [ADR-016](ADR-016-occ-for-message-publishing.md) | Optimistic Concurrency Control for Message Publishing | Accepted | 2026-03-01 |
+| [ADR-017](ADR-017-cookie-session-auth-for-websocket.md) | Cookie-Session Authentication Propagated to WebSocket | Accepted | 2026-03-01 |
+| [ADR-018](ADR-018-sveltekit-spa-embedded-in-go.md) | SvelteKit SPA Embedded in Go Binary | Accepted | 2026-03-01 |
+| [ADR-019](ADR-019-dataloaders-http-only.md) | Dataloaders Scoped to HTTP Requests Only | Superseded | 2026-03-01 |
+| [ADR-020](ADR-020-build-tag-test-endpoints.md) | Build-Tag Gated Test Endpoints | Accepted | 2026-03-01 |
+| [ADR-021](ADR-021-dual-asset-storage.md) | Dual Asset Storage — NATS ObjectStore Default, S3 Optional | Accepted | 2026-03-01 |
+| [ADR-022](ADR-022-nanoid-with-entity-prefixes.md) | NanoID with Entity-Type Prefixes | Accepted | 2026-03-01 |
+| [ADR-023](ADR-023-hmac-signed-image-transform-urls.md) | HMAC-Signed Image Transform URLs | Accepted | 2026-03-01 |
+| [ADR-024](ADR-024-opaque-bearer-tokens-for-cross-origin-auth.md) | Opaque Bearer Tokens for Cross-Origin Authentication | Accepted | 2026-03-03 |
+| [ADR-025](ADR-025-multi-instance-client-architecture.md) | Multi-Server Client Architecture | Accepted | 2026-03-20 |
+| [ADR-026](ADR-026-event-identity-via-nanoid.md) | Event Identity via NanoID, Not JetStream Sequence Numbers | Accepted | 2026-03-26 |
+| [ADR-027](ADR-027-instance-space-server-consolidation.md) | Consolidate Instance + Space into a Single "Server" Concept | Accepted | 2026-05-04 |
+| [ADR-028](ADR-028-event-id-keyed-read-state.md) | Event-ID-Keyed Read State | Accepted | 2026-05-06 |
+| [ADR-029](ADR-029-instance-to-server-rename.md) | Rename `Instance` → `Server` across the codebase | Accepted | 2026-05-11 |
+| [ADR-030](ADR-030-space-tier-retirement.md) | Retire the Space tier | Accepted | 2026-05-11 |
+| [ADR-031](ADR-031-room-group-centric-acl.md) | Room-Group-Centric ACL for Room-Scope Permissions | Accepted | 2026-05-13 |
+| [ADR-032](ADR-032-signed-attachment-locator-urls.md) | Self-Describing Signed Attachment URLs | Superseded | 2026-05-23 |
+| [ADR-033](ADR-033-event-sourced-state-with-projections.md) | Event-Sourced State with Derived Projections | Accepted | 2026-05-24 |
+| [ADR-034](ADR-034-single-event-stream.md) | Single Event Stream with Event-Type Subject Lanes | Accepted | 2026-05-24 |
+| [ADR-035](ADR-035-per-aggregate-phased-migration.md) | Per-Aggregate Phased Migration to Event Sourcing | Accepted | 2026-05-24 |
+| [ADR-036](ADR-036-runtime-state-kv-boundary.md) | Persist Runtime State in RUNTIME_STATE | Accepted | 2026-05-27 |
+| [ADR-037](ADR-037-dm-access-via-membership.md) | DM Access via Membership, Not a Read Permission | Accepted | 2026-05-31 |
+| [ADR-038](ADR-038-room-owned-thread-state.md) | Room-Owned Thread State | Accepted | 2026-06-05 |
+| [ADR-039](ADR-039-service-worker-virtual-asset-urls.md) | Service Worker Virtual Asset URLs with Ticketed Fallback | Superseded | 2026-06-08 |
+| [ADR-040](ADR-040-permission-only-rbac-with-owner-override.md) | Permission-Only RBAC with Owner Override | Accepted | 2026-06-15 |
+| [ADR-041](ADR-041-runtime-units.md) | Runtime Units for Optional Chatto Processes | Accepted | 2026-06-21 |
+| [ADR-042](ADR-042-protobuf-first-public-api.md) | Protobuf-First Public API with ConnectRPC and Realtime WebSocket | Accepted | 2026-06-22 |
+| [ADR-043](ADR-043-client-shell-internationalization.md) | Client-Shell Internationalization | Accepted | 2026-06-22 |
+| [ADR-044](ADR-044-connectrpc-service-conventions.md) | ConnectRPC Service Conventions | Accepted | 2026-06-25 |
+| [ADR-045](ADR-045-public-api-stability-tiers.md) | Public API Stability Tiers | Accepted | 2026-06-28 |
+| [ADR-046](ADR-046-typed-runtime-credentials.md) | Typed Runtime Credentials | Accepted | 2026-06-30 |
+| [ADR-047](ADR-047-direct-ticketed-asset-urls.md) | Direct Ticketed Asset URLs for Browser Media | Accepted | 2026-07-05 |
+| [ADR-048](ADR-048-frontend-optimistic-ui.md) | Frontend Optimistic UI Uses Scoped Provisional Patches | Accepted | 2026-07-09 |
+| [ADR-049](ADR-049-process-wide-realtime-event-hub.md) | Process-Wide Realtime Event Hub | Accepted | 2026-07-14 |
+| [ADR-050](ADR-050-ephemeral-encrypted-projection-snapshots.md) | Ephemeral Encrypted Projection Snapshots | Accepted | 2026-07-13 |
+| [ADR-051](ADR-051-server-scoped-resumable-client-projection.md) | Server-Scoped Resumable Client Projection | Accepted | 2026-07-16 |
+| [ADR-052](ADR-052-subject-specific-rbac-with-everyone-baseline.md) | Subject-Specific RBAC with an Everyone Baseline | Accepted | 2026-07-19 |

--- a/docs/architecture/runtime-state.md
+++ b/docs/architecture/runtime-state.md
@@ -4,7 +4,7 @@ Key files: [`cli/internal/core/core.go`](../../cli/internal/core/core.go),
 [`cli/internal/core/runtime_token_keys.go`](../../cli/internal/core/runtime_token_keys.go),
 [`cli/internal/core/external_identities.go`](../../cli/internal/core/external_identities.go),
 [`cli/internal/core/asset_uploads.go`](../../cli/internal/core/asset_uploads.go), and
-[`cli/internal/projectionsnapshot/repository.go`](../../cli/internal/projectionsnapshot/repository.go)
+[`cli/internal/kms/builtin.go`](../../cli/internal/kms/builtin.go)
 
 Related decision: [ADR-036](../adr/ADR-036-runtime-state-kv-boundary.md).
 
@@ -21,9 +21,18 @@ Related decision: [ADR-036](../adr/ADR-036-runtime-state-kv-boundary.md).
 | Key                   | Description                       |
 | --------------------- | --------------------------------- |
 | `kek.{keyId}`         | Protobuf `UserKeyEncryptionKey` per-user KEK record; the complete object key is also the opaque KMS key ref |
+| `user.{userId}`       | Legacy raw 32-byte per-user encryption key retained only for decrypting pre-envelope message bodies; account deletion shreds it with the user's current KEK |
 | `call.e2ee.{callId}`  | Protobuf `UserKeyEncryptionKey` record containing the raw LiveKit E2EE key for one active call; referenced by `CallStartedEvent.e2ee_key_ref` and shredded when `CallEndedEvent` commits |
 
-Notes: Excluded from backups so backup archives do not contain the KEKs needed to unwrap protected content or the per-call media keys needed to decrypt captured LiveKit media. Chatto core uses the in-process [`internal/kms`](../../cli/internal/kms/) boundary for KEK creation, DEK wrap/unwrap, call-key lookup, and key shredding. App-owned wrapped DEK records live in `RUNTIME_STATE` under `dek.{id}`; that complete key is the content-key ref.
+Notes: Excluded from backups so backup archives do not contain the KEKs needed to unwrap protected content, legacy raw user keys, or the per-call media keys needed to decrypt captured LiveKit media. Chatto core uses the in-process [`internal/kms`](../../cli/internal/kms/) boundary for KEK creation, DEK wrap/unwrap, legacy-key lookup, call-key lookup, and key shredding. App-owned wrapped DEK records live in `RUNTIME_STATE` under `dek.{id}`; that complete key is the content-key ref.
+
+The `user.{userId}` namespace remains a live compatibility constraint: message
+bodies written before envelope encryption still need that key to remain
+readable. It must therefore survive ordinary upgrades and any key-bearing
+backup/export and restore until those bodies no longer need to be read. It is
+not used for new writes. Crypto-shredding must remove both this legacy key and
+the user's current opaque `kek.*` key so deletion covers every message-body
+encryption generation.
 
 The backup CLI stages JetStream snapshots in an owner-only random directory
 beside the destination and always removes plaintext staging. It publishes

--- a/docs/fdr/FDR-018-account-lifecycle.md
+++ b/docs/fdr/FDR-018-account-lifecycle.md
@@ -1,7 +1,7 @@
 # FDR-018: Account Lifecycle
 
 **Status:** Active
-**Last reviewed:** 2026-07-15
+**Last reviewed:** 2026-07-21
 
 ## Overview
 
@@ -11,12 +11,12 @@ This FDR covers the user account from registration through deletion: signup, ema
 
 ### Registration
 
-- A user signs up with a login, email, and password. The login must pass uniqueness, format, and blocked-username checks; email uniqueness is enforced when the address is verified.
-- After signup, an email is sent to the address with a six-digit verification code.
+- A user starts registration with an email address. Chatto returns the same generic response whether the address is available or already claimed, so the registration endpoint does not disclose existing accounts.
+- Chatto sends a six-digit verification code to an available address. Verifying the code returns a short-lived completion token; it does not create an account.
+- The user then chooses a login and password. The login must pass uniqueness, format, and blocked-username checks, and the email is checked again in case it was claimed while the completion token was outstanding.
+- Successful completion creates the account with the email already verified. There is no partially registered or unverified account state in the direct-registration flow.
 - Registration and verification codes are backed by `RUNTIME_STATE` HMAC-derived records with configurable per-key TTLs (default 15 minutes). Raw code values are never written to `EVT` or backup archives. If email delivery fails, the pending OTP is cancelled so the failed send does not consume resend throttle capacity.
-- Until the email is verified, the account has limited capabilities (configurable per server) — typically read-only or some restricted set defined by what the `verified` role grants.
-- Entering the verification code marks the email as verified. The user gains the `verified` implicit role and the full set of permissions that role grants.
-- If the verified email matches an entry in `owners.emails` in the server config, the user is auto-assigned the `owner` role on verification.
+- If the verified email matches an entry in `owners.emails` in the server config, the new user is auto-assigned the `owner` role when the verified email is attached.
 
 ### Email management
 
@@ -39,11 +39,11 @@ This FDR covers the user account from registration through deletion: signup, ema
 
 ## Design Decisions
 
-### 1. Email verification gates non-trivial actions, not access itself
+### 1. Verify email before creating a direct-registration account
 
-**Decision:** Unverified users can sign in and see basic surfaces, but the meaningful permissions come from the `verified` implicit role. Operators decide what that role grants.
-**Why:** Hard-blocking unverified users from logging in is annoying — common operational issues (typo'd email, lost verification mail) become lockouts. Permission-gating instead lets operators decide what "verified" means while keeping the user reachable.
-**Tradeoff:** Operators have to actively configure the `verified` role for it to be meaningful. The default grants ensure the role does something out of the box.
+**Decision:** Direct registration proves control of the email address before asking for the login and password that complete account creation. The verification code yields a short-lived completion token; only successful completion creates the account and attaches the already-verified email.
+**Why:** This avoids durable half-created accounts, prevents unverified users from occupying login names, and ensures every directly registered account begins with a usable recovery address. Generic code-request responses avoid turning the flow into an account-enumeration endpoint.
+**Tradeoff:** Direct registration requires working email delivery before the user can choose credentials or enter the application. A lost or expired code restarts the verification step instead of leaving an account that can be resumed.
 
 ### 2. Multiple verified emails per user
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -27,7 +27,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-015](FDR-015-quick-switcher.md) | Quick Switcher (Cmd-K) | Active | 2026-05-31 |
 | [FDR-016](FDR-016-voice-calls.md) | Voice Calls | Active | 2026-07-15 |
 | [FDR-017](FDR-017-room-groups-and-sidebar-layout.md) | Room Groups & Sidebar Layout | Active | 2026-07-20 |
-| [FDR-018](FDR-018-account-lifecycle.md) | Account Lifecycle | Active | 2026-07-13 |
+| [FDR-018](FDR-018-account-lifecycle.md) | Account Lifecycle | Active | 2026-07-21 |
 | [FDR-019](FDR-019-room-lifecycle.md) | Room Lifecycle | Active | 2026-07-20 |
 | [FDR-020](FDR-020-server-branding-and-configuration.md) | Server Branding & Configuration | Active | 2026-07-14 |
 | [FDR-021](FDR-021-admin-dashboard.md) | Admin Dashboard & System Monitoring | Active | 2026-07-20 |


### PR DESCRIPTION
## Why

Current decision and feature records contained stale registration, client terminology, and encryption-key inventory details that could mislead maintainers and operators.

## What changed

- Document the email-first registration flow and directly test that disabled registration hides the login-page account-creation link.
- Expose ADR lifecycle status in the index and update ADR-025 to current multi-server terminology while retaining the legacy `instances` storage compatibility note.
- Inventory the legacy `user.{userId}` encryption-key namespace and its backup, restore, and crypto-shredding constraints.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: No impact.

Newer client → older server: No impact.

Capability discovery or minimum client/server version: No changes.

## Test plan

- `mise x -- pnpm exec playwright test e2e/registration-disabled.test.ts --retries=0` — 3 passed.
- ESLint and Prettier checks passed for the changed E2E test.
- `git diff --check`, Markdown link validation, and ADR index coverage validation passed.
