### PR TITLE
refactor(core): simplify configuration reads

### DIFF
--- a/cli/cmd/bootstrap_apply.go
+++ b/cli/cmd/bootstrap_apply.go
@@ -102,9 +102,7 @@ func serverDataEmptyForBootstrap(ctx context.Context, c *core.ChattoCore) (bool,
 	}
 
 	if cm := c.ConfigManager(); cm != nil {
-		if cfg, err := cm.GetServerConfig(ctx); err != nil {
-			return false, err
-		} else if cfg != nil {
+		if cfg := cm.GetServerConfig(); cfg != nil {
 			return false, nil
 		}
 	}
@@ -220,10 +218,8 @@ func applyBootstrapServer(ctx context.Context, logger *log.Logger, c *core.Chatt
 	// name field is unset, so an admin-edited server name isn't clobbered
 	// on every dev restart).
 	if cm := c.ConfigManager(); cm != nil {
-		current, err := cm.GetServerConfig(ctx)
-		if err != nil {
-			logger.Warn("Failed to read server config before [bootstrap.server] seed", "error", err)
-		} else if current == nil || current.ServerName == "" {
+		current := cm.GetServerConfig()
+		if current == nil || current.ServerName == "" {
 			if _, err := cm.UpdateServerConfigFunc(ctx, "system:bootstrap", func(current *configv1.ServerConfig) (*configv1.ServerConfig, error) {
 				if current == nil {
 					return &configv1.ServerConfig{ServerName: inst.Name}, nil

--- a/cli/cmd/bootstrap_test.go
+++ b/cli/cmd/bootstrap_test.go
@@ -127,10 +127,7 @@ func TestApplyBootstrap_CreatesUsersAndServer(t *testing.T) {
 	if cm == nil {
 		t.Fatal("expected ConfigManager to be available")
 	}
-	cfgServer, err := cm.GetServerConfig(ctx)
-	if err != nil {
-		t.Fatalf("get server config: %v", err)
-	}
+	cfgServer := cm.GetServerConfig()
 	if cfgServer == nil || cfgServer.ServerName != "Engineering" {
 		t.Errorf("expected server name 'Engineering', got %+v", cfgServer)
 	}

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -2852,10 +2852,7 @@ func TestAdminServerServiceUpdateServerConfig(t *testing.T) {
 		t.Fatalf("updated config response = %+v", resp.Msg.GetConfig())
 	}
 
-	cfg, err := env.core.ConfigManager().GetServerConfig(env.ctx)
-	if err != nil {
-		t.Fatalf("GetServerConfig: %v", err)
-	}
+	cfg := env.core.ConfigManager().GetServerConfig()
 	if cfg.GetServerName() != "Connect Settings" ||
 		cfg.GetDescription() != "Description from Connect" ||
 		cfg.GetMotd() != "MOTD from Connect" ||
@@ -2868,10 +2865,7 @@ func TestAdminServerServiceUpdateServerConfig(t *testing.T) {
 	})); err != nil {
 		t.Fatalf("partial UpdateServerConfig: %v", err)
 	}
-	cfg, err = env.core.ConfigManager().GetServerConfig(env.ctx)
-	if err != nil {
-		t.Fatalf("GetServerConfig after partial update: %v", err)
-	}
+	cfg = env.core.ConfigManager().GetServerConfig()
 	if cfg.GetServerName() != "Connect Settings" || cfg.GetDescription() != "Updated description only" {
 		t.Fatalf("partial stored config = %+v", cfg)
 	}
@@ -2994,10 +2988,7 @@ func TestAdminServerServiceSecurityConfig(t *testing.T) {
 	if want := []string{"root", "reserved", "admin"}; !slices.Equal(updateResp.Msg.GetBlockedUsernames(), want) {
 		t.Fatalf("updated blocked usernames = %q, want %q", updateResp.Msg.GetBlockedUsernames(), want)
 	}
-	stored, err := env.core.ConfigManager().GetEffectiveBlockedUsernames(env.ctx)
-	if err != nil {
-		t.Fatalf("GetEffectiveBlockedUsernames: %v", err)
-	}
+	stored := env.core.ConfigManager().GetEffectiveBlockedUsernames()
 	if stored != "root\nreserved\nadmin" {
 		t.Fatalf("stored blocked usernames = %q, want root/reserved/admin", stored)
 	}

--- a/cli/internal/connectapi/realtime_projection.go
+++ b/cli/internal/connectapi/realtime_projection.go
@@ -175,10 +175,7 @@ func (a *API) BuildRealtimeProjectionSnapshot(ctx context.Context, userID string
 	if err != nil {
 		return nil, fmt.Errorf("assemble realtime server profile: %w", err)
 	}
-	serverState, err := a.BuildRealtimeProjectionServerState(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("assemble realtime authenticated server state: %w", err)
-	}
+	serverState := a.BuildRealtimeProjectionServerState()
 	viewer, err := a.buildViewer(ctx, userID)
 	if err != nil {
 		return nil, fmt.Errorf("assemble realtime viewer: %w", err)
@@ -326,13 +323,9 @@ func (a *API) BuildRealtimeProjectionRoomTimeline(ctx context.Context, userID, r
 
 // BuildRealtimeProjectionServerState returns current authenticated server
 // presentation and runtime settings for snapshot and live convergence.
-func (a *API) BuildRealtimeProjectionServerState(ctx context.Context) (*RealtimeProjectionServerState, error) {
+func (a *API) BuildRealtimeProjectionServerState() *RealtimeProjectionServerState {
 	service := &serverService{api: a}
-	motd, err := service.serverMotd(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return &RealtimeProjectionServerState{MOTD: motd, Runtime: service.serverRuntimeConfig()}, nil
+	return &RealtimeProjectionServerState{MOTD: service.serverMotd(), Runtime: service.serverRuntimeConfig()}
 }
 
 func (a *API) realtimeProjectionUsers(ctx context.Context) ([]*apiv1.DirectoryMember, error) {

--- a/cli/internal/connectapi/server.go
+++ b/cli/internal/connectapi/server.go
@@ -94,32 +94,22 @@ func ifNoneMatch(headerValue, etag string) bool {
 	return false
 }
 
-func (a *API) effectiveServerName(ctx context.Context) string {
+func (a *API) effectiveServerName() string {
 	if a.core != nil && a.core.ConfigManager() != nil {
-		if n, err := a.core.ConfigManager().GetEffectiveServerName(ctx); err == nil {
-			return n
-		}
+		return a.core.ConfigManager().GetEffectiveServerName()
 	}
 	return "Chatto"
 }
 
 func (a *API) serverProfile(ctx context.Context, options serverProfileOptions) (*apiv1.ServerPublicProfile, error) {
-	profile := &apiv1.ServerPublicProfile{Name: a.effectiveServerName(ctx), Version: a.version}
+	profile := &apiv1.ServerPublicProfile{Name: a.effectiveServerName(), Version: a.version}
 
 	if a.core != nil && a.core.ConfigManager() != nil {
 		cm := a.core.ConfigManager()
-		if welcome, err := cm.GetEffectiveWelcomeMessage(ctx); err != nil {
-			if !options.tolerateErrors {
-				return nil, connectError(err)
-			}
-		} else if welcome != "" {
+		if welcome := cm.GetEffectiveWelcomeMessage(); welcome != "" {
 			profile.WelcomeMessage = stringPtr(welcome)
 		}
-		if cfg, err := cm.GetServerConfig(ctx); err != nil {
-			if !options.tolerateErrors {
-				return nil, connectError(err)
-			}
-		} else if cfg != nil && cfg.GetDescription() != "" {
+		if cfg := cm.GetServerConfig(); cfg != nil && cfg.GetDescription() != "" {
 			profile.Description = stringPtr(cfg.GetDescription())
 		}
 	}

--- a/cli/internal/connectapi/server_state.go
+++ b/cli/internal/connectapi/server_state.go
@@ -21,12 +21,8 @@ func (s *serverService) GetMotd(ctx context.Context, _ *connect.Request[apiv1.Ge
 		return nil, err
 	}
 
-	motd, err := s.serverMotd(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	resp := &apiv1.GetMotdResponse{}
+	motd := s.serverMotd()
 	if motd != "" {
 		resp.Motd = stringPtr(motd)
 	}
@@ -224,15 +220,11 @@ func adminServerConfig(cfg *configv1.ServerConfig) *adminv1.ServerConfig {
 	}
 }
 
-func (s *serverService) serverMotd(ctx context.Context) (string, error) {
+func (s *serverService) serverMotd() string {
 	if cm := s.api.core.ConfigManager(); cm != nil {
-		motd, err := cm.GetEffectiveMOTD(ctx)
-		if err != nil {
-			return "", connectError(err)
-		}
-		return motd, nil
+		return cm.GetEffectiveMOTD()
 	}
-	return "", nil
+	return ""
 }
 
 func (a *API) serverViewerState(ctx context.Context, userID string) (*apiv1.ServerViewerPermissions, *apiv1.ServerViewerState, error) {

--- a/cli/internal/core/config_manager.go
+++ b/cli/internal/core/config_manager.go
@@ -49,13 +49,11 @@ func NewConfigManager(
 
 // GetServerConfig returns the raw server configuration values currently held
 // by the projection, or nil when no server config fields have been set.
-// The error return is preserved for signature compatibility; the
-// projection is in-memory and cannot fail to read.
-func (cm *ConfigManager) GetServerConfig(_ context.Context) (*configv1.ServerConfig, error) {
+func (cm *ConfigManager) GetServerConfig() *configv1.ServerConfig {
 	if cm.projection == nil {
-		return nil, nil
+		return nil
 	}
-	return cm.projection.Get(), nil
+	return cm.projection.Get()
 }
 
 // SetServerConfig stores the server configuration by publishing semantic config
@@ -209,29 +207,29 @@ func serverConfigEvents(actorID string, current, next *configv1.ServerConfig) []
 
 // GetEffectiveWelcomeMessage returns the welcome message from the
 // projection. Empty string if not configured.
-func (cm *ConfigManager) GetEffectiveWelcomeMessage(_ context.Context) (string, error) {
+func (cm *ConfigManager) GetEffectiveWelcomeMessage() string {
 	if cm.projection == nil {
-		return "", nil
+		return ""
 	}
-	return cm.projection.EffectiveWelcomeMessage(), nil
+	return cm.projection.EffectiveWelcomeMessage()
 }
 
 // GetEffectiveServerName returns the server name from the projection,
 // falling back to "Chatto" if unset.
-func (cm *ConfigManager) GetEffectiveServerName(_ context.Context) (string, error) {
+func (cm *ConfigManager) GetEffectiveServerName() string {
 	if cm.projection == nil {
-		return "Chatto", nil
+		return "Chatto"
 	}
-	return cm.projection.EffectiveServerName(), nil
+	return cm.projection.EffectiveServerName()
 }
 
 // GetEffectiveMOTD returns the Message of the Day from the projection.
 // Empty string if not configured.
-func (cm *ConfigManager) GetEffectiveMOTD(_ context.Context) (string, error) {
+func (cm *ConfigManager) GetEffectiveMOTD() string {
 	if cm.projection == nil {
-		return "", nil
+		return ""
 	}
-	return cm.projection.EffectiveMOTD(), nil
+	return cm.projection.EffectiveMOTD()
 }
 
 // DefaultDescription is the fallback server description used when no
@@ -241,11 +239,11 @@ const DefaultDescription = "Come join our community!"
 
 // GetEffectiveDescription returns the server description from the
 // projection, falling back to DefaultDescription if unset.
-func (cm *ConfigManager) GetEffectiveDescription(_ context.Context) (string, error) {
+func (cm *ConfigManager) GetEffectiveDescription() string {
 	if cm.projection == nil {
-		return DefaultDescription, nil
+		return DefaultDescription
 	}
-	return cm.projection.EffectiveDescription(), nil
+	return cm.projection.EffectiveDescription()
 }
 
 // =============================================================================
@@ -259,37 +257,30 @@ const DefaultBlockedUsernames = "root\nadmin\nsuperuser\nop\noperator\nsupport"
 // GetEffectiveBlockedUsernames returns the blocked usernames string
 // from the projection. Returns DefaultBlockedUsernames if no config has
 // ever been written; returns "" if the operator explicitly cleared it.
-func (cm *ConfigManager) GetEffectiveBlockedUsernames(_ context.Context) (string, error) {
+func (cm *ConfigManager) GetEffectiveBlockedUsernames() string {
 	if cm.projection == nil {
-		return DefaultBlockedUsernames, nil
+		return DefaultBlockedUsernames
 	}
-	return cm.projection.EffectiveBlockedUsernames(), nil
+	return cm.projection.EffectiveBlockedUsernames()
 }
 
 // GetBlockedUsernamesList returns the blocked usernames as a slice of
 // lowercase strings.
-func (cm *ConfigManager) GetBlockedUsernamesList(ctx context.Context) ([]string, error) {
-	raw, err := cm.GetEffectiveBlockedUsernames(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return parseBlockedUsernames(raw), nil
+func (cm *ConfigManager) GetBlockedUsernamesList() []string {
+	return parseBlockedUsernames(cm.GetEffectiveBlockedUsernames())
 }
 
 // IsUsernameBlocked checks if a username is in the blocked list
 // (case-insensitive).
-func (cm *ConfigManager) IsUsernameBlocked(ctx context.Context, login string) (bool, error) {
-	blockedList, err := cm.GetBlockedUsernamesList(ctx)
-	if err != nil {
-		return false, err
-	}
+func (cm *ConfigManager) IsUsernameBlocked(login string) bool {
+	blockedList := cm.GetBlockedUsernamesList()
 	loginLower := strings.ToLower(login)
 	for _, blocked := range blockedList {
 		if blocked == loginLower {
-			return true, nil
+			return true
 		}
 	}
-	return false, nil
+	return false
 }
 
 // parseBlockedUsernames parses a newline-separated string into a slice

--- a/cli/internal/core/config_manager_test.go
+++ b/cli/internal/core/config_manager_test.go
@@ -19,10 +19,7 @@ func TestConfigManager_GetServerConfig(t *testing.T) {
 	ctx := testContext(t)
 
 	t.Run("returns nil when no config events exist", func(t *testing.T) {
-		cfg, err := core.configManager.GetServerConfig(ctx)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		cfg := core.configManager.GetServerConfig()
 		if cfg != nil {
 			t.Error("expected nil config for fresh server")
 		}
@@ -40,10 +37,7 @@ func TestConfigManager_GetServerConfig(t *testing.T) {
 			t.Fatalf("failed to set config: %v", err)
 		}
 
-		cfg, err := core.configManager.GetServerConfig(ctx)
-		if err != nil {
-			t.Fatalf("failed to get config: %v", err)
-		}
+		cfg := core.configManager.GetServerConfig()
 		if cfg.ServerName != "Test Instance" {
 			t.Errorf("expected server name 'Test Instance', got '%s'", cfg.ServerName)
 		}
@@ -308,10 +302,7 @@ func TestConfigManager_UpdateServerConfigFunc_RecomposesAfterConflict(t *testing
 		}
 	}
 
-	cfg, err := core.configManager.GetServerConfig(ctx)
-	if err != nil {
-		t.Fatalf("GetServerConfig: %v", err)
-	}
+	cfg := core.configManager.GetServerConfig()
 	if cfg.GetServerName() != "Name A" {
 		t.Fatalf("ServerName = %q, want Name A", cfg.GetServerName())
 	}
@@ -370,10 +361,7 @@ func TestConfigManager_GetEffectiveWelcomeMessage(t *testing.T) {
 
 	t.Run("returns empty string when not configured", func(t *testing.T) {
 
-		msg, err := core.configManager.GetEffectiveWelcomeMessage(ctx)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		msg := core.configManager.GetEffectiveWelcomeMessage()
 		if msg != "" {
 			t.Errorf("expected empty string, got '%s'", msg)
 		}
@@ -384,10 +372,7 @@ func TestConfigManager_GetEffectiveWelcomeMessage(t *testing.T) {
 			WelcomeMessage: "Hello, world!",
 		})
 
-		msg, err := core.configManager.GetEffectiveWelcomeMessage(ctx)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		msg := core.configManager.GetEffectiveWelcomeMessage()
 		if msg != "Hello, world!" {
 			t.Errorf("expected 'Hello, world!', got '%s'", msg)
 		}
@@ -400,10 +385,7 @@ func TestConfigManager_GetEffectiveServerName(t *testing.T) {
 
 	t.Run("returns 'Chatto' when not configured", func(t *testing.T) {
 
-		name, err := core.configManager.GetEffectiveServerName(ctx)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		name := core.configManager.GetEffectiveServerName()
 		if name != "Chatto" {
 			t.Errorf("expected 'Chatto', got '%s'", name)
 		}
@@ -414,10 +396,7 @@ func TestConfigManager_GetEffectiveServerName(t *testing.T) {
 			ServerName: "",
 		})
 
-		name, err := core.configManager.GetEffectiveServerName(ctx)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		name := core.configManager.GetEffectiveServerName()
 		if name != "Chatto" {
 			t.Errorf("expected 'Chatto', got '%s'", name)
 		}
@@ -428,10 +407,7 @@ func TestConfigManager_GetEffectiveServerName(t *testing.T) {
 			ServerName: "My Custom Instance",
 		})
 
-		name, err := core.configManager.GetEffectiveServerName(ctx)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		name := core.configManager.GetEffectiveServerName()
 		if name != "My Custom Instance" {
 			t.Errorf("expected 'My Custom Instance', got '%s'", name)
 		}
@@ -444,10 +420,7 @@ func TestConfigManager_GetEffectiveMOTD(t *testing.T) {
 
 	t.Run("returns empty string when not configured", func(t *testing.T) {
 
-		motd, err := core.configManager.GetEffectiveMOTD(ctx)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		motd := core.configManager.GetEffectiveMOTD()
 		if motd != "" {
 			t.Errorf("expected empty string, got '%s'", motd)
 		}
@@ -458,10 +431,7 @@ func TestConfigManager_GetEffectiveMOTD(t *testing.T) {
 			Motd: "Today's announcement",
 		})
 
-		motd, err := core.configManager.GetEffectiveMOTD(ctx)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		motd := core.configManager.GetEffectiveMOTD()
 		if motd != "Today's announcement" {
 			t.Errorf("expected 'Today's announcement', got '%s'", motd)
 		}
@@ -474,10 +444,7 @@ func TestConfigManager_BlockedUsernames(t *testing.T) {
 
 	t.Run("returns default blocked usernames when not configured", func(t *testing.T) {
 
-		blocked, err := core.configManager.GetEffectiveBlockedUsernames(ctx)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		blocked := core.configManager.GetEffectiveBlockedUsernames()
 		if blocked != DefaultBlockedUsernames {
 			t.Errorf("expected default blocked usernames, got '%s'", blocked)
 		}
@@ -488,10 +455,7 @@ func TestConfigManager_BlockedUsernames(t *testing.T) {
 			BlockedUsernames: "blocked1\nblocked2",
 		})
 
-		blocked, err := core.configManager.GetEffectiveBlockedUsernames(ctx)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		blocked := core.configManager.GetEffectiveBlockedUsernames()
 		if blocked != "blocked1\nblocked2" {
 			t.Errorf("expected 'blocked1\\nblocked2', got '%s'", blocked)
 		}
@@ -502,10 +466,7 @@ func TestConfigManager_BlockedUsernames(t *testing.T) {
 			BlockedUsernames: "", // Admin explicitly cleared
 		})
 
-		blocked, err := core.configManager.GetEffectiveBlockedUsernames(ctx)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		blocked := core.configManager.GetEffectiveBlockedUsernames()
 		if blocked != "" {
 			t.Errorf("expected empty string, got '%s'", blocked)
 		}
@@ -518,10 +479,7 @@ func TestConfigManager_GetBlockedUsernamesList(t *testing.T) {
 
 	t.Run("parses default blocked usernames into list", func(t *testing.T) {
 
-		list, err := core.configManager.GetBlockedUsernamesList(ctx)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		list := core.configManager.GetBlockedUsernamesList()
 
 		// Check that default blocked usernames are parsed
 		expected := []string{"root", "admin", "superuser", "op", "operator", "support"}
@@ -540,10 +498,7 @@ func TestConfigManager_GetBlockedUsernamesList(t *testing.T) {
 			BlockedUsernames: "  user1  \n\nuser2\n  \nUSER3  ",
 		})
 
-		list, err := core.configManager.GetBlockedUsernamesList(ctx)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		list := core.configManager.GetBlockedUsernamesList()
 
 		if len(list) != 3 {
 			t.Errorf("expected 3 blocked usernames, got %d: %v", len(list), list)
@@ -562,10 +517,7 @@ func TestConfigManager_IsUsernameBlocked(t *testing.T) {
 
 	t.Run("blocks default usernames", func(t *testing.T) {
 
-		blocked, err := core.configManager.IsUsernameBlocked(ctx, "admin")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		blocked := core.configManager.IsUsernameBlocked("admin")
 		if !blocked {
 			t.Error("expected 'admin' to be blocked by default")
 		}
@@ -573,18 +525,12 @@ func TestConfigManager_IsUsernameBlocked(t *testing.T) {
 
 	t.Run("case-insensitive blocking", func(t *testing.T) {
 
-		blocked, err := core.configManager.IsUsernameBlocked(ctx, "ADMIN")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		blocked := core.configManager.IsUsernameBlocked("ADMIN")
 		if !blocked {
 			t.Error("expected 'ADMIN' to be blocked (case-insensitive)")
 		}
 
-		blocked, err = core.configManager.IsUsernameBlocked(ctx, "Root")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		blocked = core.configManager.IsUsernameBlocked("Root")
 		if !blocked {
 			t.Error("expected 'Root' to be blocked (case-insensitive)")
 		}
@@ -592,10 +538,7 @@ func TestConfigManager_IsUsernameBlocked(t *testing.T) {
 
 	t.Run("allows non-blocked usernames", func(t *testing.T) {
 
-		blocked, err := core.configManager.IsUsernameBlocked(ctx, "regularuser")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		blocked := core.configManager.IsUsernameBlocked("regularuser")
 		if blocked {
 			t.Error("expected 'regularuser' to not be blocked")
 		}
@@ -607,19 +550,13 @@ func TestConfigManager_IsUsernameBlocked(t *testing.T) {
 		})
 
 		// Custom blocked username should be blocked
-		blocked, err := core.configManager.IsUsernameBlocked(ctx, "customblocked")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		blocked := core.configManager.IsUsernameBlocked("customblocked")
 		if !blocked {
 			t.Error("expected 'customblocked' to be blocked")
 		}
 
 		// Default blocked username should NOT be blocked anymore
-		blocked, err = core.configManager.IsUsernameBlocked(ctx, "admin")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		blocked = core.configManager.IsUsernameBlocked("admin")
 		if blocked {
 			t.Error("expected 'admin' to NOT be blocked with custom list")
 		}

--- a/cli/internal/core/config_projection.go
+++ b/cli/internal/core/config_projection.go
@@ -176,30 +176,30 @@ func (p *ConfigProjection) Get() *configv1.ServerConfig {
 	return cfg
 }
 
-func (p *ConfigProjection) ServerLogo() (*corev1.AssetRecord, bool, error) {
+func (p *ConfigProjection) ServerLogo() (*corev1.AssetRecord, bool) {
 	p.RLock()
 	defer p.RUnlock()
 	if p.server.logo == nil {
-		return nil, false, nil
+		return nil, false
 	}
-	return cloneAssetRecord(p.server.logo), true, nil
+	return cloneAssetRecord(p.server.logo), true
 }
 
-func (p *ConfigProjection) ServerBanner() (*corev1.AssetRecord, bool, error) {
+func (p *ConfigProjection) ServerBanner() (*corev1.AssetRecord, bool) {
 	p.RLock()
 	defer p.RUnlock()
 	if p.server.banner == nil {
-		return nil, false, nil
+		return nil, false
 	}
-	return cloneAssetRecord(p.server.banner), true, nil
+	return cloneAssetRecord(p.server.banner), true
 }
 
-func (p *ConfigProjection) UserSettings(userID string) (*corev1.ServerUserPreferences, bool, error) {
+func (p *ConfigProjection) UserSettings(userID string) (*corev1.ServerUserPreferences, bool) {
 	p.RLock()
 	defer p.RUnlock()
 	u := p.users[userID]
 	if u == nil || (u.timezone == nil && u.timeFormat == nil) {
-		return nil, false, nil
+		return nil, false
 	}
 	prefs := &corev1.ServerUserPreferences{}
 	if u.timezone != nil {
@@ -209,7 +209,7 @@ func (p *ConfigProjection) UserSettings(userID string) (*corev1.ServerUserPrefer
 	if u.timeFormat != nil {
 		prefs.TimeFormat = *u.timeFormat
 	}
-	return prefs, true, nil
+	return prefs, true
 }
 
 func (p *ConfigProjection) EffectiveServerName() string {

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -876,8 +876,8 @@ func (c *ChattoCore) ResolvePublicServerAsset(ctx context.Context, key string) (
 	// durable/current public references provide the positive declaration.
 	legacyDeclaredPublic := c.Users != nil && c.Users.IsPublicAvatarAsset(assetID)
 	if c.ServerConfig != nil {
-		logo, _, _ := c.ServerConfig.ServerLogo()
-		banner, _, _ := c.ServerConfig.ServerBanner()
+		logo, _ := c.ServerConfig.ServerLogo()
+		banner, _ := c.ServerConfig.ServerBanner()
 		if assetRecordMatchesKey(logo, assetID) || assetRecordMatchesKey(banner, assetID) {
 			legacyDeclaredPublic = true
 		}

--- a/cli/internal/core/server_branding.go
+++ b/cli/internal/core/server_branding.go
@@ -178,10 +178,10 @@ func (c *ChattoCore) projectedServerBrandingAsset(kind string) *corev1.AssetReco
 		return nil
 	}
 	if kind == "logo" {
-		asset, _, _ := c.ServerConfig.ServerLogo()
+		asset, _ := c.ServerConfig.ServerLogo()
 		return asset
 	}
-	asset, _, _ := c.ServerConfig.ServerBanner()
+	asset, _ := c.ServerConfig.ServerBanner()
 	return asset
 }
 
@@ -280,10 +280,8 @@ func (c *ChattoCore) PublishServerUpdated(ctx context.Context, actorID string) {
 	name := ""
 	description := ""
 	if cm := c.ConfigManager(); cm != nil {
-		if n, err := cm.GetEffectiveServerName(ctx); err == nil {
-			name = n
-		}
-		if cfg, err := cm.GetServerConfig(ctx); err == nil && cfg != nil {
+		name = cm.GetEffectiveServerName()
+		if cfg := cm.GetServerConfig(); cfg != nil {
 			description = cfg.Description
 		}
 	}

--- a/cli/internal/core/server_branding_test.go
+++ b/cli/internal/core/server_branding_test.go
@@ -30,17 +30,11 @@ func TestChattoCore_ServerBrandingUsesConfigEvents(t *testing.T) {
 	if !proto.Equal(logo, got) {
 		t.Fatalf("GetServerLogo = %+v, want %+v", got, logo)
 	}
-	cfg, err := core.ConfigManager().GetServerConfig(ctx)
-	if err != nil {
-		t.Fatalf("GetServerConfig after logo failed: %v", err)
-	}
+	cfg := core.ConfigManager().GetServerConfig()
 	if cfg != nil {
 		t.Fatalf("logo-only update wrote server config: cfg=%+v", cfg)
 	}
-	blocked, err := core.ConfigManager().GetEffectiveBlockedUsernames(ctx)
-	if err != nil {
-		t.Fatalf("GetEffectiveBlockedUsernames after logo failed: %v", err)
-	}
+	blocked := core.ConfigManager().GetEffectiveBlockedUsernames()
 	if blocked != DefaultBlockedUsernames {
 		t.Fatalf("logo-only update changed effective blocked usernames: got %q", blocked)
 	}

--- a/cli/internal/core/server_state_management.go
+++ b/cli/internal/core/server_state_management.go
@@ -22,10 +22,7 @@ func (c *ChattoCore) GetManagedServerConfig(ctx context.Context, actorID string)
 		return nil, err
 	}
 
-	cfg, err := c.ConfigManager().GetServerConfig(ctx)
-	if err != nil {
-		return nil, err
-	}
+	cfg := c.ConfigManager().GetServerConfig()
 	if cfg == nil {
 		return &configv1.ServerConfig{}, nil
 	}
@@ -68,7 +65,7 @@ func (c *ChattoCore) GetServerSecurityConfig(ctx context.Context, actorID string
 	if err := c.requireCanManageServer(ctx, actorID); err != nil {
 		return nil, err
 	}
-	return c.ConfigManager().GetBlockedUsernamesList(ctx)
+	return c.ConfigManager().GetBlockedUsernamesList(), nil
 }
 
 func (c *ChattoCore) UpdateBlockedUsernames(ctx context.Context, actorID string, blockedUsernames []string) ([]string, error) {
@@ -89,7 +86,7 @@ func (c *ChattoCore) UpdateBlockedUsernames(ctx context.Context, actorID string,
 		return nil, err
 	}
 
-	return configMgr.GetBlockedUsernamesList(ctx)
+	return configMgr.GetBlockedUsernamesList(), nil
 }
 
 func normalizeBlockedUsernameEntries(entries []string) string {

--- a/cli/internal/core/user_preferences.go
+++ b/cli/internal/core/user_preferences.go
@@ -35,8 +35,8 @@ func (c *ChattoCore) GetUserSettings(_ context.Context, userID string) (*corev1.
 	if c.ServerConfig == nil {
 		return nil, nil
 	}
-	settings, _, err := c.ServerConfig.UserSettings(userID)
-	return settings, err
+	settings, _ := c.ServerConfig.UserSettings(userID)
+	return settings, nil
 }
 
 // UpdateUserSettings merges the provided fields into the user's existing settings.
@@ -59,10 +59,7 @@ func (c *ChattoCore) UpdateUserSettings(ctx context.Context, userID string, inpu
 
 	changed := false
 	if err := c.configManager.model.updateSubject(ctx, userID, func(_ events.Aggregate, _ string, _ uint64) ([]*corev1.Event, error) {
-		current, _, err := c.ServerConfig.UserSettings(userID)
-		if err != nil {
-			return nil, err
-		}
+		current, _ := c.ServerConfig.UserSettings(userID)
 		var evs []*corev1.Event
 		if input.Timezone != nil {
 			tz := *input.Timezone
@@ -135,9 +132,9 @@ func (c *ChattoCore) deleteUserSettings(ctx context.Context, userID string) erro
 		return nil
 	}
 	return c.configManager.model.updateSubject(ctx, userID, func(_ events.Aggregate, _ string, _ uint64) ([]*corev1.Event, error) {
-		current, _, err := c.ServerConfig.UserSettings(userID)
-		if err != nil || current == nil {
-			return nil, err
+		current, _ := c.ServerConfig.UserSettings(userID)
+		if current == nil {
+			return nil, nil
 		}
 		evs := []*corev1.Event{
 			newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_UserTimezoneCleared{

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -70,11 +70,7 @@ func (c *ChattoCore) CreateUser(ctx context.Context, actorID string, login, disp
 	}
 
 	// Check if login is blocked (defense in depth - HTTP layer should check first)
-	isBlocked, err := c.configManager.IsUsernameBlocked(ctx, login)
-	if err != nil {
-		return nil, fmt.Errorf("failed to check blocked usernames: %w", err)
-	}
-	if isBlocked {
+	if c.configManager.IsUsernameBlocked(login) {
 		return nil, ErrUsernameBlocked
 	}
 	if c.loginConflictsWithMentionHandle(login) {
@@ -902,11 +898,7 @@ func (c *ChattoCore) updateUserProfileAs(ctx context.Context, actorID, userID st
 		loginChanged = user.GetLogin() != nextLogin
 		loginNeedsMentionCheck = loginChanged && !strings.EqualFold(user.GetLogin(), nextLogin)
 		if loginNeedsMentionCheck {
-			isBlocked, err := c.configManager.IsUsernameBlocked(ctx, nextLogin)
-			if err != nil {
-				return nil, fmt.Errorf("failed to check blocked usernames: %w", err)
-			}
-			if isBlocked {
+			if c.configManager.IsUsernameBlocked(nextLogin) {
 				return nil, ErrUsernameBlocked
 			}
 			if c.loginConflictsWithMentionHandle(nextLogin) {
@@ -1085,11 +1077,7 @@ func (c *ChattoCore) applyLoginChange(ctx context.Context, actorID, userID, newL
 
 	caseOnly := strings.EqualFold(user.Login, newLogin)
 	if !caseOnly {
-		isBlocked, err := c.configManager.IsUsernameBlocked(ctx, newLogin)
-		if err != nil {
-			return nil, fmt.Errorf("failed to check blocked usernames: %w", err)
-		}
-		if isBlocked {
+		if c.configManager.IsUsernameBlocked(newLogin) {
 			return nil, ErrUsernameBlocked
 		}
 		if c.loginConflictsWithMentionHandle(newLogin) {

--- a/cli/internal/http_server/auth.go
+++ b/cli/internal/http_server/auth.go
@@ -1,7 +1,6 @@
 package http_server
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -28,9 +27,9 @@ func isStaleLoginCredentialError(err error) bool {
 	return errors.Is(err, core.ErrCookieSessionNotFound) || errors.Is(err, core.ErrAuthTokenNotFound)
 }
 
-func (s *HTTPServer) authEmailServerName(ctx context.Context) string {
+func (s *HTTPServer) authEmailServerName() string {
 	if s.core != nil && s.core.ConfigManager() != nil {
-		if name, err := s.core.ConfigManager().GetEffectiveServerName(ctx); err == nil && strings.TrimSpace(name) != "" {
+		if name := s.core.ConfigManager().GetEffectiveServerName(); strings.TrimSpace(name) != "" {
 			return name
 		}
 	}
@@ -335,7 +334,7 @@ func (s *HTTPServer) setupAuthRoutes() {
 		}
 
 		// Send registration email
-		serverName := s.authEmailServerName(ctx)
+		serverName := s.authEmailServerName()
 		expirationText := s.emailOTPExpirationText()
 		err = s.mailer.Send(email.Message{
 			To:      req.Email,
@@ -442,13 +441,7 @@ func (s *HTTPServer) setupAuthRoutes() {
 		}
 
 		// Check if login is blocked
-		isBlocked, err := s.core.ConfigManager().IsUsernameBlocked(ctx, req.Login)
-		if err != nil {
-			log.Error("Failed to check blocked usernames", "error", err)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Registration failed"})
-			return
-		}
-		if isBlocked {
+		if s.core.ConfigManager().IsUsernameBlocked(req.Login) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "This username is not available"})
 			return
 		}
@@ -579,7 +572,7 @@ func (s *HTTPServer) setupAuthRoutes() {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to send verification code"})
 			return
 		}
-		serverName := s.authEmailServerName(req.Context())
+		serverName := s.authEmailServerName()
 		expirationText := s.emailOTPExpirationText()
 		if err := s.mailer.Send(email.Message{
 			To:      body.Email,
@@ -667,7 +660,7 @@ func (s *HTTPServer) setupAuthRoutes() {
 
 		// Only send email if token was created (email exists and is verified)
 		if token != "" && s.mailer != nil {
-			serverName := s.authEmailServerName(ctx)
+			serverName := s.authEmailServerName()
 			resetURL := fmt.Sprintf("%s/reset-password?token=%s", s.config.Webserver.URL, token)
 			err = s.mailer.Send(email.Message{
 				To:      normalizedEmail,

--- a/cli/internal/http_server/frontend.go
+++ b/cli/internal/http_server/frontend.go
@@ -147,13 +147,13 @@ func (s *HTTPServer) currentPWAIconURLs(ctx context.Context) *pwaServerIconURLs 
 	return icons
 }
 
-func (s *HTTPServer) currentPWAServerName(ctx context.Context) string {
+func (s *HTTPServer) currentPWAServerName() string {
 	if s.core == nil || s.core.ConfigManager() == nil {
 		return "Chatto"
 	}
 
-	name, err := s.core.ConfigManager().GetEffectiveServerName(ctx)
-	if err != nil || strings.TrimSpace(name) == "" {
+	name := s.core.ConfigManager().GetEffectiveServerName()
+	if strings.TrimSpace(name) == "" {
 		return "Chatto"
 	}
 	return name
@@ -266,7 +266,7 @@ func (s *HTTPServer) servePWAWebManifest(c *gin.Context, clientFS fs.FS) {
 	}
 	content, err = dynamicPWAManifest(
 		content,
-		s.currentPWAServerName(c.Request.Context()),
+		s.currentPWAServerName(),
 		s.currentPWAIconURLs(c.Request.Context()),
 	)
 	if err != nil {

--- a/cli/internal/http_server/opengraph.go
+++ b/cli/internal/http_server/opengraph.go
@@ -90,10 +90,10 @@ func (s *HTTPServer) getOpenGraphMeta(ctx context.Context, urlPath string) *Open
 	serverName := "Chatto"
 	description := "Come join our community!"
 	if s.core != nil && s.core.ConfigManager() != nil {
-		if name, err := s.core.ConfigManager().GetEffectiveServerName(ctx); err == nil && name != "" {
+		if name := s.core.ConfigManager().GetEffectiveServerName(); name != "" {
 			serverName = name
 		}
-		if desc, err := s.core.ConfigManager().GetEffectiveDescription(ctx); err == nil && desc != "" {
+		if desc := s.core.ConfigManager().GetEffectiveDescription(); desc != "" {
 			description = desc
 		}
 	}

--- a/cli/internal/http_server/realtime_projection.go
+++ b/cli/internal/http_server/realtime_projection.go
@@ -216,10 +216,7 @@ func (s *HTTPServer) realtimeProjectionFrameForEventWithRooms(ctx context.Contex
 				return nil, false, err
 			}
 			appendOperation(&realtimev1.RealtimeProjectionOperation{Operation: &realtimev1.RealtimeProjectionOperation_ServerUpsert{ServerUpsert: server}})
-			serverState, err := s.connectAPI.BuildRealtimeProjectionServerState(ctx)
-			if err != nil {
-				return nil, false, err
-			}
+			serverState := s.connectAPI.BuildRealtimeProjectionServerState()
 			appendOperation(&realtimev1.RealtimeProjectionOperation{Operation: &realtimev1.RealtimeProjectionOperation_ServerStateUpsert{
 				ServerStateUpsert: realtimeProjectionServerState(serverState),
 			}})


### PR DESCRIPTION
## Why

Pure in-memory configuration reads exposed impossible errors and unused contexts, forcing callers to maintain unreachable failure branches.

## What changed

- Made `ConfigManager` and `ConfigProjection` reads return their values directly.
- Simplified downstream ConnectRPC, realtime, registration, username-validation, branding, OpenGraph, and PWA call paths.
- Updated bootstrap-tagged setup code to use the same infallible read contract.
- Updated tests to assert behavior without fictional read failures.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Unchanged.

Newer client → older server: Unchanged.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `mise test-cli` — passed, including the frontend production build and complete backend test suite.
- Focused core, ConnectRPC, and HTTP configuration/branding/registration tests — passed.
- `CGO_ENABLED=0 go build -trimpath -tags 'bootstrap test_endpoints'` and bootstrap-tagged `cmd` tests — passed.
- `git diff --check` — passed.
