### PR TITLE
fix(calls): show active DM calls in sidebar

### DIFF
--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/calls.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/calls.mdx
@@ -24,7 +24,7 @@ Voice-call request/response APIs backed by Chatto call-state projections.
 
 ### ListActiveCalls
 
-Lists member channel rooms that currently have active calls as a finite
+Lists member rooms that currently have active calls as a finite
 runtime snapshot. Rooms the caller is not a member of are omitted.
 
 Returns an empty list when LiveKit is not configured.
@@ -37,14 +37,14 @@ POST /api/connect/chatto.api.v1.VoiceCallService/ListActiveCalls
 
 #### Input: ListActiveCallsRequest
 
-Request for active channel call snapshots.
+Request for active room call snapshots.
 
 
 <a id="chatto-api-v1-ListActiveCallsResponse"></a>
 
 #### Result: ListActiveCallsResponse
 
-Finite runtime snapshot of active channel calls.
+Finite runtime snapshot of active room calls.
 
 | Field | Type | Description |
 | --- | --- | --- |

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -3077,7 +3077,7 @@ Voice-call request/response APIs backed by Chatto call-state projections.
 
 ### ListActiveCalls
 
-Lists member channel rooms that currently have active calls as a finite
+Lists member rooms that currently have active calls as a finite
 runtime snapshot. Rooms the caller is not a member of are omitted.
 
 Returns an empty list when LiveKit is not configured.
@@ -3090,14 +3090,14 @@ POST /api/connect/chatto.api.v1.VoiceCallService/ListActiveCalls
 
 #### Input: ListActiveCallsRequest
 
-Request for active channel call snapshots.
+Request for active room call snapshots.
 
 
 <a id="chatto-api-v1-ListActiveCallsResponse"></a>
 
 #### Result: ListActiveCallsResponse
 
-Finite runtime snapshot of active channel calls.
+Finite runtime snapshot of active room calls.
 
 | Field | Type | Description |
 | --- | --- | --- |

--- a/apps/frontend/e2e/voice-call.spec.ts
+++ b/apps/frontend/e2e/voice-call.spec.ts
@@ -457,6 +457,53 @@ test.describe('Voice calls', () => {
     });
   });
 
+  test('active-call icon and participant avatar appear for a DM participant', async ({
+    page,
+    chatPage,
+    browser,
+    serverURL
+  }) => {
+    const userA = await createAndLoginTestUser(page);
+    await chatPage.goto();
+
+    await withServerUser(browser!, serverURL, async ({ page: page2, user: userB }) => {
+      const roomB = await new DMPage(page2).startConversation(userA.login);
+      await roomB.sendMessage(`seed DM call sidebar ${Date.now()}`);
+      const { roomId } = await getIdsFromUrlViaConnect(page2);
+
+      const dmRow = new DMPage(page).getConversation(userB.displayName);
+      await expect(dmRow).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+      const callIcon = dmRow.getByTestId('room-call-icon');
+      const callParticipants = dmRow.getByTestId('room-call-participants');
+      await expect(callIcon).not.toBeVisible();
+      await expect(callParticipants).not.toBeVisible();
+
+      const joinResponse = await page.request.post('/webhooks/test/call-join', {
+        data: {
+          spaceId: 'DM',
+          roomId,
+          userId: userB.id,
+          displayName: userB.displayName,
+          login: userB.login
+        }
+      });
+      expect(joinResponse.ok()).toBe(true);
+
+      await expect(callIcon).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+      await expect(callIcon.getByTestId('active-call-pulse-icon')).toBeVisible();
+      await expect(callParticipants).toBeVisible();
+      await expect(callParticipants.getByTestId('room-call-participant-avatar')).toBeVisible();
+
+      const leaveResponse = await page.request.post('/webhooks/test/call-leave', {
+        data: { spaceId: 'DM', roomId, userId: userB.id }
+      });
+      expect(leaveResponse.ok()).toBe(true);
+
+      await expect(callIcon).not.toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+      await expect(callParticipants).not.toBeVisible();
+    });
+  });
+
   test('livekitUrl is exposed in instance info', async ({ page, chatPage }) => {
     await createAndLoginTestUser(page);
     await chatPage.goto();

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -4790,6 +4790,88 @@ func TestVoiceCallServiceRecordsAndListsCalls(t *testing.T) {
 	}
 }
 
+func TestVoiceCallServiceListsDMCallsForParticipants(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	env.api.config.LiveKit = config.LiveKitConfig{
+		Enabled:   true,
+		URL:       "ws://livekit.test",
+		APIKey:    "test-key",
+		APISecret: "test-secret",
+		ServerID:  "test-server",
+	}
+
+	participant, err := env.core.CreateUser(env.ctx, core.SystemActorID, "voice-dm-participant", "Voice DM Participant", "password")
+	if err != nil {
+		t.Fatalf("CreateUser participant: %v", err)
+	}
+	outsider, err := env.core.CreateUser(env.ctx, core.SystemActorID, "voice-dm-outsider", "Voice DM Outsider", "password")
+	if err != nil {
+		t.Fatalf("CreateUser outsider: %v", err)
+	}
+
+	viewerCtx := withCaller(env.ctx, env.viewer)
+	start, err := env.rooms.StartDM(viewerCtx, connect.NewRequest(&apiv1.StartDMRequest{
+		ParticipantIds: []string{participant.Id},
+	}))
+	if err != nil {
+		t.Fatalf("StartDM: %v", err)
+	}
+	dm := start.Msg.GetRoom()
+	if dm.GetKind() != apiv1.RoomKind_ROOM_KIND_DM {
+		t.Fatalf("StartDM room kind = %v, want DM", dm.GetKind())
+	}
+
+	join, err := env.voice.JoinCall(viewerCtx, connect.NewRequest(&apiv1.JoinCallRequest{
+		RoomId: dm.GetId(),
+	}))
+	if err != nil {
+		t.Fatalf("JoinCall: %v", err)
+	}
+	if !join.Msg.GetJoined() {
+		t.Fatal("JoinCall joined = false, want true")
+	}
+
+	assertDMCall := func(label string, calls []*apiv1.ActiveCall) {
+		t.Helper()
+		if len(calls) != 1 || calls[0].GetRoom().GetId() != dm.GetId() {
+			t.Fatalf("%s calls = %+v, want DM %s", label, calls, dm.GetId())
+		}
+		participants := calls[0].GetParticipants()
+		if len(participants) != 1 || participants[0].GetUser().GetId() != env.viewer.Id {
+			t.Fatalf("%s participants = %+v, want viewer %s", label, participants, env.viewer.Id)
+		}
+	}
+
+	participantCtx := withCaller(env.ctx, participant)
+	listed, err := env.voice.ListActiveCalls(participantCtx, connect.NewRequest(&apiv1.ListActiveCallsRequest{}))
+	if err != nil {
+		t.Fatalf("ListActiveCalls participant: %v", err)
+	}
+	assertDMCall("ListActiveCalls participant", listed.Msg.GetCalls())
+
+	projected, err := env.api.BuildRealtimeProjectionActiveCalls(env.ctx, participant.Id)
+	if err != nil {
+		t.Fatalf("BuildRealtimeProjectionActiveCalls participant: %v", err)
+	}
+	assertDMCall("realtime projection participant", projected)
+
+	outsiderCtx := withCaller(env.ctx, outsider)
+	outsiderListed, err := env.voice.ListActiveCalls(outsiderCtx, connect.NewRequest(&apiv1.ListActiveCallsRequest{}))
+	if err != nil {
+		t.Fatalf("ListActiveCalls outsider: %v", err)
+	}
+	if len(outsiderListed.Msg.GetCalls()) != 0 {
+		t.Fatalf("ListActiveCalls outsider calls = %+v, want none", outsiderListed.Msg.GetCalls())
+	}
+	outsiderProjected, err := env.api.BuildRealtimeProjectionActiveCalls(env.ctx, outsider.Id)
+	if err != nil {
+		t.Fatalf("BuildRealtimeProjectionActiveCalls outsider: %v", err)
+	}
+	if len(outsiderProjected) != 0 {
+		t.Fatalf("realtime projection outsider calls = %+v, want none", outsiderProjected)
+	}
+}
+
 func TestVoiceCallServiceRoomRemovalClearsCallParticipant(t *testing.T) {
 	env := newConnectAPITestEnv(t)
 	ctx := withCaller(env.ctx, env.viewer)

--- a/cli/internal/connectapi/realtime_projection.go
+++ b/cli/internal/connectapi/realtime_projection.go
@@ -267,7 +267,7 @@ func (a *API) BuildRealtimeProjectionActiveCalls(ctx context.Context, userID str
 	if !a.config.LiveKit.IsConfigured() {
 		return nil, nil
 	}
-	roomIDs, err := a.core.GetActiveCallRoomIDs(ctx, core.LegacySpaceIDForRoomKind(core.KindChannel))
+	roomIDs, err := a.core.GetActiveCallRoomIDs(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/connectapi/voice_calls.go
+++ b/cli/internal/connectapi/voice_calls.go
@@ -26,7 +26,7 @@ func (s *voiceCallService) ListActiveCalls(ctx context.Context, _ *connect.Reque
 		return connect.NewResponse(&apiv1.ListActiveCallsResponse{}), nil
 	}
 
-	roomIDs, err := s.api.core.GetActiveCallRoomIDs(ctx, core.LegacySpaceIDForRoomKind(core.KindChannel))
+	roomIDs, err := s.api.core.GetActiveCallRoomIDs(ctx)
 	if err != nil {
 		return nil, connectError(err)
 	}

--- a/cli/internal/core/voice.go
+++ b/cli/internal/core/voice.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -219,24 +218,11 @@ func (c *ChattoCore) GetCallParticipants(ctx context.Context, spaceID, roomID st
 	return c.CallState.Participants(roomID), nil
 }
 
-// GetActiveCallRoomIDs returns the room IDs in a space that have active voice calls.
+// GetActiveCallRoomIDs returns every room ID that has an active voice call.
 // Reads from the call-state projection, not MEMORY_CACHE.
-// Authorization: Caller must verify space membership before calling.
-func (c *ChattoCore) GetActiveCallRoomIDs(ctx context.Context, spaceID string) ([]string, error) {
-	kind := RoomKindFromLegacySpaceID(spaceID)
-	roomIDs := c.CallState.ActiveRoomIDs()
-	if c.RoomCatalog == nil {
-		return roomIDs, nil
-	}
-	filtered := make([]string, 0, len(roomIDs))
-	for _, roomID := range roomIDs {
-		room, ok := c.RoomCatalog.Get(roomID)
-		if !ok || KindOfRoom(room) == kind {
-			filtered = append(filtered, roomID)
-		}
-	}
-	sort.Strings(filtered)
-	return filtered, nil
+// Authorization: Caller must filter the result to rooms visible to the actor.
+func (c *ChattoCore) GetActiveCallRoomIDs(context.Context) ([]string, error) {
+	return c.CallState.ActiveRoomIDs(), nil
 }
 
 func appendCallJoinedEventForTest(ctx context.Context, publisher *events.Publisher, projector *events.Projector, roomID, userID string, source corev1.CallParticipantEventSource) error {

--- a/cli/internal/core/voice_test.go
+++ b/cli/internal/core/voice_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -860,26 +861,34 @@ func TestGetActiveCallRoomIDs(t *testing.T) {
 	ctx := testContext(t)
 
 	// No active calls initially
-	ids := core.CallState.ActiveRoomIDs()
+	ids, err := core.GetActiveCallRoomIDs(ctx)
+	if err != nil {
+		t.Fatalf("GetActiveCallRoomIDs: %v", err)
+	}
 	if len(ids) != 0 {
 		t.Errorf("Expected 0 room IDs, got %d", len(ids))
 	}
 
-	// Add calls in multiple rooms
-	_ = core.HandleCallParticipantJoined(ctx, "channel", "room1", "user1", "Alice", "alice", "")
-	_ = core.HandleCallParticipantJoined(ctx, "channel", "room2", "user2", "Bob", "bob", "")
-	_ = core.HandleCallParticipantJoined(ctx, "channel", "room3", "user3", "Carol", "carol", "")
+	// Add calls in both channel and DM rooms.
+	_ = core.HandleCallParticipantJoined(ctx, LegacyServerSpaceID, "channel-room", "user1", "Alice", "alice", "")
+	_ = core.HandleCallParticipantJoined(ctx, LegacyDMRoomSpaceID, "dm-room", "user2", "Bob", "bob", "")
 
-	ids = core.CallState.ActiveRoomIDs()
-	if len(ids) != 3 {
-		t.Errorf("Expected 3 room IDs, got %d: %v", len(ids), ids)
+	ids, err = core.GetActiveCallRoomIDs(ctx)
+	if err != nil {
+		t.Fatalf("GetActiveCallRoomIDs after joins: %v", err)
+	}
+	if want := []string{"channel-room", "dm-room"}; !slices.Equal(ids, want) {
+		t.Fatalf("active room IDs = %v, want %v", ids, want)
 	}
 
-	// Remove all participants from room1 — should no longer appear
-	_ = core.HandleCallParticipantLeft(ctx, "channel", "room1", "user1")
-	ids = core.CallState.ActiveRoomIDs()
-	if len(ids) != 2 {
-		t.Errorf("Expected 2 room IDs after leave, got %d: %v", len(ids), ids)
+	// Remove the channel participant; the DM call remains visible.
+	_ = core.HandleCallParticipantLeft(ctx, LegacyServerSpaceID, "channel-room", "user1")
+	ids, err = core.GetActiveCallRoomIDs(ctx)
+	if err != nil {
+		t.Fatalf("GetActiveCallRoomIDs after leave: %v", err)
+	}
+	if want := []string{"dm-room"}; !slices.Equal(ids, want) {
+		t.Fatalf("active room IDs after leave = %v, want %v", ids, want)
 	}
 }
 

--- a/cli/internal/pb/chatto/api/v1/apiv1connect/voice_calls.connect.go
+++ b/cli/internal/pb/chatto/api/v1/apiv1connect/voice_calls.connect.go
@@ -58,7 +58,7 @@ const (
 
 // VoiceCallServiceClient is a client for the chatto.api.v1.VoiceCallService service.
 type VoiceCallServiceClient interface {
-	// Lists member channel rooms that currently have active calls as a finite
+	// Lists member rooms that currently have active calls as a finite
 	// runtime snapshot. Rooms the caller is not a member of are omitted.
 	//
 	// Returns an empty list when LiveKit is not configured.
@@ -204,7 +204,7 @@ func (c *voiceCallServiceClient) LeaveCall(ctx context.Context, req *connect.Req
 
 // VoiceCallServiceHandler is an implementation of the chatto.api.v1.VoiceCallService service.
 type VoiceCallServiceHandler interface {
-	// Lists member channel rooms that currently have active calls as a finite
+	// Lists member rooms that currently have active calls as a finite
 	// runtime snapshot. Rooms the caller is not a member of are omitted.
 	//
 	// Returns an empty list when LiveKit is not configured.

--- a/cli/internal/pb/chatto/api/v1/voice_calls.pb.go
+++ b/cli/internal/pb/chatto/api/v1/voice_calls.pb.go
@@ -23,7 +23,7 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// Request for active channel call snapshots.
+// Request for active room call snapshots.
 type ListActiveCallsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -60,7 +60,7 @@ func (*ListActiveCallsRequest) Descriptor() ([]byte, []int) {
 	return file_chatto_api_v1_voice_calls_proto_rawDescGZIP(), []int{0}
 }
 
-// Finite runtime snapshot of active channel calls.
+// Finite runtime snapshot of active room calls.
 type ListActiveCallsResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Active calls in room order returned by the call-state projection.

--- a/packages/api-types/src/chatto/api/v1/voice_calls_connect.ts
+++ b/packages/api-types/src/chatto/api/v1/voice_calls_connect.ts
@@ -15,7 +15,7 @@ export const VoiceCallService = {
   typeName: "chatto.api.v1.VoiceCallService",
   methods: {
     /**
-     * Lists member channel rooms that currently have active calls as a finite
+     * Lists member rooms that currently have active calls as a finite
      * runtime snapshot. Rooms the caller is not a member of are omitted.
      *
      * Returns an empty list when LiveKit is not configured.

--- a/packages/api-types/src/chatto/api/v1/voice_calls_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/voice_calls_pb.ts
@@ -9,7 +9,7 @@ import { RoomSummary } from "./rooms_pb.js";
 import { User } from "./users_pb.js";
 
 /**
- * Request for active channel call snapshots.
+ * Request for active room call snapshots.
  *
  * @generated from message chatto.api.v1.ListActiveCallsRequest
  */
@@ -42,7 +42,7 @@ export class ListActiveCallsRequest extends Message<ListActiveCallsRequest> {
 }
 
 /**
- * Finite runtime snapshot of active channel calls.
+ * Finite runtime snapshot of active room calls.
  *
  * @generated from message chatto.api.v1.ListActiveCallsResponse
  */

--- a/proto/chatto/api/v1/voice_calls.proto
+++ b/proto/chatto/api/v1/voice_calls.proto
@@ -9,7 +9,7 @@ import "google/protobuf/timestamp.proto";
 
 // Voice-call request/response APIs backed by Chatto call-state projections.
 service VoiceCallService {
-  // Lists member channel rooms that currently have active calls as a finite
+  // Lists member rooms that currently have active calls as a finite
   // runtime snapshot. Rooms the caller is not a member of are omitted.
   //
   // Returns an empty list when LiveKit is not configured.
@@ -57,10 +57,10 @@ service VoiceCallService {
   rpc LeaveCall(LeaveCallRequest) returns (LeaveCallResponse);
 }
 
-// Request for active channel call snapshots.
+// Request for active room call snapshots.
 message ListActiveCallsRequest {}
 
-// Finite runtime snapshot of active channel calls.
+// Finite runtime snapshot of active room calls.
 message ListActiveCallsResponse {
   // Active calls in room order returned by the call-state projection.
   repeated ActiveCall calls = 1;


### PR DESCRIPTION
## Why

After the frontend projection refactor, active calls in DMs were omitted from server-wide active-call snapshots, so other participants did not see the sidebar call indicator or roster avatars.

## What changed

- Enumerate active calls across all room kinds while retaining per-viewer room-membership filtering in ConnectRPC and realtime snapshots.
- Update the public API wording and generated Go, TypeScript, and reference documentation from channel calls to room calls.
- Add core, API/realtime authorization, component, and receiver-perspective browser regression coverage for DM calls.

## API compatibility

- Behavioural change; the existing wire shape now also returns viewer-visible DM calls.

Older client → newer server: Existing clients may receive additional `ActiveCall` entries for DM rooms using the already-supported room shape; the bundled client already renders them safely.

Newer client → older server: DM call indicators remain absent because older servers omit DM calls, while channel call behaviour is unchanged.

Capability discovery or minimum client/server version: None required; this restores existing room-call behaviour without adding a required protocol operation or field.

## Test plan

- `cd cli && mise x -- go test ./internal/core -run '^TestGetActiveCallRoomIDs$' -count=1 -timeout 30s` — passed.
- `cd cli && mise x -- go test ./internal/connectapi -run '^(TestVoiceCallServiceRecordsAndListsCalls|TestVoiceCallServiceListsDMCallsForParticipants)$' -count=1 -timeout 60s` — passed.
- `mise x -- pnpm --filter chatto-frontend exec vitest --run src/lib/RoomList.svelte.spec.ts` — 30 passed.
- `cd apps/frontend && mise x -- pnpm exec playwright test e2e/voice-call.spec.ts --retries=0` — 12 passed.
- `mise lint-frontend`, `mise codegen-proto`, public API `buf breaking`, and `git diff --check` — passed.
