### PR TITLE
fix(frontend): unify admin panel and table surfaces

### DIFF
--- a/apps/frontend/DESIGN_SYSTEM.md
+++ b/apps/frontend/DESIGN_SYSTEM.md
@@ -81,8 +81,8 @@ Surfaces form a small semantic ladder:
   mechanically reversing luminance between themes.
 - In light mode, `background` is the pale primary work plane and `surface` is
   the cool gray used for anchored chrome, composers, user cards, dialogs, and
-  panels. These surfaces read as inset and substantial, not as white paper
-  floating above the application.
+  panel frames and headers. These surfaces read as inset and substantial, not
+  as white paper floating above the application.
 - In dark mode, progressively lighter surfaces provide separation from the
   dark primary plane.
 - `surface-emphasized` separates hover states and nested rows from their
@@ -94,9 +94,30 @@ Surfaces form a small semantic ladder:
   paper-like surface; do not use it as the default fill for persistent
   application chrome.
 
-Panels, informational hints, table headers, table bodies, and sticky table
-cells share the same `surface`. Use dividers, spacing, type weight, and icons to
-express their different roles; do not introduce another header-band fill.
+Panel shells provide a `surface` frame around a `background` work plane. Panel
+and table headers also use `surface`, keeping padded forms, row rules, nested
+controls, and the outer frame visually distinct. Sticky table cells must match
+the body background. This contrast is structural, not an additional surface
+level.
+
+`Panel` owns the shared inset geometry for admin content. Titled panels frame a
+clipped `panel-inset` work plane with `px-1 pb-1`; omitting top padding prevents
+the frame gap from visually adding to the title band's bottom padding. Untitled
+edge-to-edge panels use the same rule so the gap does not add to a table header's
+top padding. Untitled padded panels retain `p-1`. Custom shells such as draggable
+room groups must compose the same structure instead of approximating it.
+`DataTable` owns only its scrollable table viewport. Dense matrices may keep an
+intrinsic content width inside it; ordinary record tables fill it. Standard
+record-table headings use `table-header-cell`; matrix headings remain bespoke
+because their vertical labels have different spatial needs.
+
+Panel title bands use `px-6 py-3`. The horizontal inset aligns titles with
+`p-5` panel content after accounting for the frame, while keeping the band
+compact. Panels in scrolling flex columns must not shrink below their content.
+Room-directory group cards use `Panel` as well; reusable product surfaces must
+not assemble `panel-shell` directly when the shared component can express them.
+Hoverable rows inside panel insets use the quiet `surface/70` treatment and a
+`rounded-md` radius; `surface-emphasized` is too strong for transient hover.
 
 Do not infer a new numeric surface level. Choose the nearest semantic role, or
 adjust the owning component when the hierarchy itself is wrong.

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -193,9 +193,9 @@
   --color-presence-invisible: var(--color-presence-invisible);
 }
 
-/* Panel/card shells - canonical bordered surfaces for admin panels, room
- * directory group cards, and similar content containers. Pair with
- * `.panel-header` when the container has a distinct header.
+/* Panel/card shells provide the outer surface frame. Their content sits on a
+ * rounded background work plane owned by `Panel`, keeping the same concentric
+ * geometry for forms, tables, and dense lists.
  */
 @utility panel-shell {
   @apply rounded-lg border border-border bg-surface;
@@ -203,6 +203,20 @@
 
 @utility panel-shell-raised {
   @apply shadow-sm;
+}
+
+/* Concentric work plane inside a panel-shell surface frame. The owning
+ * component supplies p-1 around this inset.
+ */
+@utility panel-inset {
+  @apply rounded-md bg-background;
+}
+
+/* Standard record-table header cell. Matrix headers remain deliberately
+ * bespoke because their vertical labels encode a different interaction.
+ */
+@utility table-header-cell {
+  @apply px-4 py-2.5 font-medium;
 }
 
 /* Compact framed surface for inline rows inside forms, dialogs, and settings. */

--- a/apps/frontend/src/lib/RoomDirectory.svelte
+++ b/apps/frontend/src/lib/RoomDirectory.svelte
@@ -20,6 +20,7 @@ registry.
   import * as m from '$lib/i18n/messages';
   import { Button } from '$lib/ui/form';
   import Dialog from '$lib/ui/Dialog.svelte';
+  import { Panel } from '$lib/components/admin';
   import type { RoomsStore } from '$lib/state/server/rooms.svelte';
   import type { RoomDirectoryStore, DirectoryRoom } from '$lib/state/server/roomDirectory.svelte';
 
@@ -212,8 +213,8 @@ registry.
     roomId: room.id
   })}
   <li
-    class="flex items-center gap-3 rounded px-3 py-1.5 transition-colors {joined
-      ? 'hover:bg-surface-emphasized'
+    class="flex items-center gap-3 rounded-md px-3 py-1.5 transition-colors {joined
+      ? 'hover:bg-surface/70'
       : ''}"
   >
     {#snippet roomLabel()}
@@ -284,38 +285,37 @@ registry.
 {#snippet groupCard(set: { id: string; name: string; roomIds: string[] }, rooms: DirectoryRoom[])}
   {@const joining = directory.joiningGroupIds.has(set.id)}
   {@const canJoinAll = canJoinAllInGroup(rooms)}
-  <div {@attach masonryItem} class="self-start overflow-hidden panel-shell">
-    <div class="flex items-center justify-between gap-4 border-b border-border p-4">
-      <h2 class="truncate text-lg font-semibold">{set.name}</h2>
-      {#if canJoinAll || joining}
-        <!-- Matches the per-row primary buttons: w-28 so the card's
-             header action lines up vertically with Join / Joined. -->
-        <button
-          type="button"
-          class="btn-action btn w-28 shrink-0 justify-center border border-transparent btn-sm transition-none"
-          onclick={() => handleJoinGroup(set)}
-          disabled={joining}
-        >
-          {#if joining}
-            <span class="iconify animate-spin uil--spinner"></span>
-            {m['room.directory.joining']()}
-          {:else}
-            <span class="iconify uil--plus-circle"></span>
-            {m['room.directory.join_all']()}
-          {/if}
-        </button>
-      {/if}
-    </div>
-    <!--
-      Horizontal inset (`px-1` + the menu-item's own `px-3` = 16px)
-      matches the header's `p-4` so the per-row buttons line up with
-      the "Join all" action above.
-    -->
-    <ul class="flex flex-col gap-0.5 px-1 py-2">
-      {#each rooms as room (room.id)}
-        {@render roomRow(room)}
-      {/each}
-    </ul>
+  <div {@attach masonryItem} class="self-start">
+    <Panel title={set.name} noPadding>
+      {#snippet actions()}
+        {#if canJoinAll || joining}
+          <!-- Matches the per-row primary buttons: w-28 so the card's
+               header action lines up vertically with Join / Joined. -->
+          <button
+            type="button"
+            class="btn-action btn w-28 shrink-0 justify-center border border-transparent btn-sm transition-none"
+            onclick={() => handleJoinGroup(set)}
+            disabled={joining}
+          >
+            {#if joining}
+              <span class="iconify animate-spin uil--spinner"></span>
+              {m['room.directory.joining']()}
+            {:else}
+              <span class="iconify uil--plus-circle"></span>
+              {m['room.directory.join_all']()}
+            {/if}
+          </button>
+        {/if}
+      {/snippet}
+
+      <!-- Horizontal inset (`px-1` + the menu-item's own `px-3` = 16px)
+           keeps per-row actions aligned within the shared panel inset. -->
+      <ul class="flex flex-col gap-0.5 px-1 py-2">
+        {#each rooms as room (room.id)}
+          {@render roomRow(room)}
+        {/each}
+      </ul>
+    </Panel>
   </div>
 {/snippet}
 

--- a/apps/frontend/src/lib/RoomDirectory.svelte.spec.ts
+++ b/apps/frontend/src/lib/RoomDirectory.svelte.spec.ts
@@ -2,10 +2,7 @@ import { afterEach, describe, it, expect, vi } from 'vitest';
 import { flushSync } from 'svelte';
 import { render } from 'vitest-browser-svelte';
 import Harness from './RoomDirectoryTestHarness.svelte';
-import {
-  RoomDirectoryStore,
-  type DirectoryRoom
-} from '$lib/state/server/roomDirectory.svelte';
+import { RoomDirectoryStore, type DirectoryRoom } from '$lib/state/server/roomDirectory.svelte';
 import type { RoomsListItem } from '$lib/state/server/rooms.svelte';
 import { RoomType } from '$lib/render/types';
 
@@ -33,9 +30,9 @@ const listedRoom = (id: string, overrides: Partial<RoomsListItem> = {}): RoomsLi
 const joined = (id: string): RoomsListItem => listedRoom(id, { viewerIsMember: true });
 
 function findButton(container: Element, label: string): HTMLButtonElement | undefined {
-  return [...container.querySelectorAll('button')].find(
-    (b) => b.textContent?.trim() === label
-  ) as HTMLButtonElement | undefined;
+  return [...container.querySelectorAll('button')].find((b) => b.textContent?.trim() === label) as
+    | HTMLButtonElement
+    | undefined;
 }
 
 describe('RoomDirectory', () => {
@@ -79,6 +76,13 @@ describe('RoomDirectory', () => {
     // so we look for either via textContent.
     expect(container.textContent).toContain('Joined');
     expect(container.textContent).toContain('Join');
+
+    const joinedRow = [...container.querySelectorAll('li')].find((item) =>
+      item.textContent?.includes('r1')
+    ) as HTMLElement;
+    expect(joinedRow.className).toContain('rounded-md');
+    expect(joinedRow.className).toContain('hover:bg-surface/70');
+    expect(joinedRow.className).not.toContain('hover:bg-surface-emphasized');
   });
 
   it('renders universal joined rooms without a leave action', () => {
@@ -174,6 +178,13 @@ describe('RoomDirectory', () => {
 
     // The section header is rendered.
     expect(container.textContent).toContain('Important');
+
+    const shell = container.querySelector('.panel-shell') as HTMLElement;
+    const header = shell.querySelector(':scope > .panel-header') as HTMLElement;
+    const inset = shell.querySelector('.panel-inset') as HTMLElement;
+    expect(shell.className).toContain('shrink-0');
+    expect(header.className).toContain('px-6');
+    expect(inset).not.toBeNull();
   });
 
   // -- "Join all" group action -----------------------------------------------
@@ -238,9 +249,7 @@ describe('RoomDirectory', () => {
       props: {
         initialRooms: [room('a'), room('b')],
         joinedRooms: [joined('b')],
-        roomGroups: [
-          { id: 'g1', name: 'Mixed', viewerCanManageGroup: false, roomIds: ['a', 'b'] }
-        ]
+        roomGroups: [{ id: 'g1', name: 'Mixed', viewerCanManageGroup: false, roomIds: ['a', 'b'] }]
       }
     });
     flushSync();

--- a/apps/frontend/src/lib/components/admin/DataTable.stories.svelte
+++ b/apps/frontend/src/lib/components/admin/DataTable.stories.svelte
@@ -19,9 +19,9 @@
   ];
 
   const componentDescription = `
-  Admin table primitive with the shared panel-header treatment, empty state row,
-  optional row hover/click affordance, and automatic load-more support. Usually
-  placed inside \`Panel noPadding\` so the table owns the panel edges.
+  Admin table primitive with a rounded scroll viewport, contrasting header and
+  body, empty state row, optional row hover/click affordance, and automatic
+  load-more support. Place it inside \`Panel noPadding\`; Panel owns the shared frame.
   `.trim();
 
   const { Story } = defineMeta({
@@ -45,7 +45,7 @@
     docs: {
       description: {
         story:
-          'The default record table: sticky visual header treatment, hoverable rows, and caller-owned cell layout.'
+          'The default record table: a rounded inset viewport, strong header/body boundary, hoverable ruled rows, and caller-owned cell layout.'
       }
     }
   }}
@@ -88,10 +88,10 @@
 </Story>
 
 {#snippet tableHeader()}
-  <th class="px-4 py-3 font-medium">Name</th>
-  <th class="px-4 py-3 font-medium">ID</th>
-  <th class="px-4 py-3 text-right font-medium">Members</th>
-  <th class="px-4 py-3 font-medium">Visibility</th>
+  <th class="table-header-cell">Name</th>
+  <th class="table-header-cell">ID</th>
+  <th class="table-header-cell text-right">Members</th>
+  <th class="table-header-cell">Visibility</th>
 {/snippet}
 
 {#snippet tableRow(row: SpaceRow)}

--- a/apps/frontend/src/lib/components/admin/DataTable.svelte
+++ b/apps/frontend/src/lib/components/admin/DataTable.svelte
@@ -13,6 +13,7 @@
     getKey,
     getGroupKey,
     group,
+    fitContent = false,
     hoverable = true,
     hasMore = false,
     loadingMore = false,
@@ -30,6 +31,11 @@
     getKey?: (item: T, index: number) => unknown;
     getGroupKey?: (item: T, index: number) => string | null | undefined;
     group?: Snippet<[T]>;
+    /**
+     * Keep the table at its intrinsic width inside the full-width inset
+     * viewport. Use for dense matrices whose columns should not stretch.
+     */
+    fitContent?: boolean;
     /**
      * Whether rows highlight on hover. Defaults to `true` for the standard
      * "list of records" treatment; pass `false` for matrix-style tables
@@ -109,55 +115,57 @@
   };
 </script>
 
-<table class="w-full [&_thead_th]:whitespace-nowrap">
-  <thead>
-    <tr class="panel-header text-left text-sm text-muted">
-      {@render header()}
-    </tr>
-  </thead>
-  <tbody>
-    {#each items as item, index (keyFn(item, index))}
-      {#if shouldRenderGroup(item, index)}
-        <tr class="border-b border-border bg-surface/80">
-          <td colspan={columns} class="px-4 py-2">
-            {@render group?.(item)}
+<div class="overflow-x-auto rounded-md bg-background">
+  <table class={[fitContent ? 'w-max' : 'w-full', '[&_thead_th]:whitespace-nowrap']}>
+    <thead>
+      <tr class="panel-header text-left text-sm text-muted">
+        {@render header()}
+      </tr>
+    </thead>
+    <tbody class="bg-background">
+      {#each items as item, index (keyFn(item, index))}
+        {#if shouldRenderGroup(item, index)}
+          <tr class="border-b border-border bg-surface/80">
+            <td colspan={columns} class="px-4 py-2">
+              {@render group?.(item)}
+            </td>
+          </tr>
+        {/if}
+        <tr
+          class={[
+            'border-b border-border last:border-0',
+            hoverable ? 'hover:bg-surface/70' : '',
+            onRowClick ? 'cursor-pointer' : ''
+          ]}
+          onclick={() => onRowClick?.(item)}
+        >
+          {@render row(item)}
+        </tr>
+      {:else}
+        <tr>
+          <td colspan={columns} class="px-4 py-8 text-center text-muted">{emptyMessage}</td>
+        </tr>
+      {/each}
+
+      {#if hasMore || loadingMore}
+        <tr
+          class="border-b border-border last:border-0"
+          aria-hidden={!loadingMore}
+          {@attach hasMore ? loadMoreSentinel : undefined}
+        >
+          <td
+            colspan={columns}
+            class={loadingMore ? 'px-4 py-3 text-center text-sm text-muted' : 'h-px p-0'}
+          >
+            {#if loadingMore}
+              <span class="inline-flex items-center gap-2" aria-live="polite">
+                <span class="iconify animate-spin text-base uil--spinner" aria-hidden="true"></span>
+                {loadingMoreMessage}
+              </span>
+            {/if}
           </td>
         </tr>
       {/if}
-      <tr
-        class={[
-          'border-b border-border last:border-0',
-          hoverable ? 'hover:bg-surface-emphasized/40' : '',
-          onRowClick ? 'cursor-pointer' : ''
-        ]}
-        onclick={() => onRowClick?.(item)}
-      >
-        {@render row(item)}
-      </tr>
-    {:else}
-      <tr>
-        <td colspan={columns} class="px-4 py-8 text-center text-muted">{emptyMessage}</td>
-      </tr>
-    {/each}
-
-    {#if hasMore || loadingMore}
-      <tr
-        class="border-b border-border last:border-0"
-        aria-hidden={!loadingMore}
-        {@attach hasMore ? loadMoreSentinel : undefined}
-      >
-        <td
-          colspan={columns}
-          class={loadingMore ? 'px-4 py-3 text-center text-sm text-muted' : 'h-px p-0'}
-        >
-          {#if loadingMore}
-            <span class="inline-flex items-center gap-2" aria-live="polite">
-              <span class="iconify animate-spin text-base uil--spinner" aria-hidden="true"></span>
-              {loadingMoreMessage}
-            </span>
-          {/if}
-        </td>
-      </tr>
-    {/if}
-  </tbody>
-</table>
+    </tbody>
+  </table>
+</div>

--- a/apps/frontend/src/lib/components/admin/DataTable.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/admin/DataTable.svelte.spec.ts
@@ -56,6 +56,7 @@ class MockIntersectionObserver implements IntersectionObserver {
 
 function renderTable(
   props: {
+    fitContent?: boolean;
     hoverable?: boolean;
     hasMore?: boolean;
     loadingMore?: boolean;
@@ -92,13 +93,34 @@ describe('DataTable.hoverable', () => {
   it('applies hover bg by default', async () => {
     const { container } = renderTable();
     const tr = container.querySelector('tbody tr') as HTMLElement;
-    expect(tr.className).toContain('hover:bg-surface-emphasized/40');
+    expect(tr.className).toContain('hover:bg-surface/70');
   });
 
   it('omits hover bg when hoverable=false', async () => {
     const { container } = renderTable({ hoverable: false });
     const tr = container.querySelector('tbody tr') as HTMLElement;
-    expect(tr.className).not.toContain('hover:bg-surface-emphasized/40');
+    expect(tr.className).not.toContain('hover:bg-surface/70');
+  });
+
+  it('uses a rounded background viewport beneath the surface header', async () => {
+    const { container } = renderTable();
+    const table = container.querySelector('table') as HTMLTableElement;
+    const viewport = table.parentElement as HTMLElement;
+    const header = container.querySelector('thead tr') as HTMLElement;
+    const body = container.querySelector('tbody') as HTMLElement;
+
+    expect(viewport.className).toContain('rounded-md');
+    expect(viewport.className).toContain('overflow-x-auto');
+    expect(header.className).toContain('panel-header');
+    expect(body.className).toContain('bg-background');
+  });
+
+  it('keeps matrix-style tables at their intrinsic width', async () => {
+    const { container } = renderTable({ fitContent: true });
+    const table = container.querySelector('table') as HTMLTableElement;
+
+    expect(table.className).toContain('w-max');
+    expect(table.className).not.toContain('w-full');
   });
 
   it('still renders cursor-pointer on hoverable=false rows when onRowClick is set', async () => {

--- a/apps/frontend/src/lib/components/admin/Panel.stories.svelte
+++ b/apps/frontend/src/lib/components/admin/Panel.stories.svelte
@@ -7,7 +7,8 @@
   Bordered admin surface for grouped management content. Use \`Panel\` when a
   section needs a title band, optional summary copy, and optional header
   actions. It owns the canonical \`panel-shell panel-shell-raised\` container
-  and the shared, single-surface \`panel-header\` treatment.
+  and the shared \`panel-header\` treatment. A slim surface frame wraps its rounded
+  background work plane so forms, tables, and dense lists share one geometry.
   `.trim();
 
   const { Story } = defineMeta({

--- a/apps/frontend/src/lib/components/admin/Panel.svelte
+++ b/apps/frontend/src/lib/components/admin/Panel.svelte
@@ -20,9 +20,9 @@
   } = $props();
 </script>
 
-<div class={['panel-shell panel-shell-raised', noPadding && 'overflow-hidden']}>
+<div class="shrink-0 overflow-hidden panel-shell panel-shell-raised">
   {#if title}
-    <div class="flex items-center justify-between gap-4 rounded-t-lg panel-header px-5 py-4">
+    <div class="flex items-center justify-between gap-4 panel-header px-6 py-3">
       <div class="min-w-0">
         <h2 class="flex items-center gap-2 text-base font-semibold text-text-top">
           {#if icon}
@@ -44,7 +44,9 @@
       {/if}
     </div>
   {/if}
-  <div class={noPadding ? '' : 'p-5'}>
-    {@render children()}
+  <div class={title || noPadding ? 'px-1 pb-1' : 'p-1'}>
+    <div class={['panel-inset', noPadding ? 'overflow-hidden' : 'p-5']}>
+      {@render children()}
+    </div>
   </div>
 </div>

--- a/apps/frontend/src/lib/components/admin/Panel.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/admin/Panel.svelte.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { testSnippet } from '$lib/test-utils';
+import Panel from './Panel.svelte';
+
+function renderPanel(noPadding = false) {
+  return render(Panel, {
+    props: {
+      title: 'General',
+      noPadding,
+      children: testSnippet('<div data-testid="content">Content</div>')
+    }
+  });
+}
+
+describe('Panel inset structure', () => {
+  it('wraps padded content in the shared surface frame and rounded work plane', async () => {
+    const { container } = renderPanel();
+    const shell = container.querySelector('.panel-shell') as HTMLElement;
+    const header = shell.querySelector(':scope > .panel-header') as HTMLElement;
+    const frame = shell.querySelector(':scope > div:last-child') as HTMLElement;
+    const inset = frame.firstElementChild as HTMLElement;
+
+    expect(shell.className).toContain('overflow-hidden');
+    expect(shell.className).toContain('shrink-0');
+    expect(header.className).toContain('px-6');
+    expect(header.className).toContain('py-3');
+    expect(frame.className).toContain('px-1');
+    expect(frame.className).toContain('pb-1');
+    expect(frame.className).not.toContain('pt-1');
+    expect(inset.className).toContain('panel-inset');
+    expect(inset.className).toContain('p-5');
+    expect(header.className).toContain('panel-header');
+  });
+
+  it('clips edge-to-edge content inside the same rounded work plane', async () => {
+    const { container } = renderPanel(true);
+    const inset = container.querySelector('.panel-shell > div:last-child > div') as HTMLElement;
+
+    expect(inset.className).toContain('overflow-hidden');
+    expect(inset.className).not.toContain('p-5');
+  });
+
+  it('does not stack top frame spacing above edge-to-edge table content', async () => {
+    const { container } = render(Panel, {
+      props: {
+        noPadding: true,
+        children: testSnippet('<div>Content</div>')
+      }
+    });
+    const frame = container.querySelector('.panel-shell > div') as HTMLElement;
+
+    expect(frame.className).toContain('px-1');
+    expect(frame.className).toContain('pb-1');
+    expect(frame.className).not.toContain('pt-1');
+  });
+
+  it('keeps a full frame around untitled padded content', async () => {
+    const { container } = render(Panel, {
+      props: {
+        children: testSnippet('<div>Content</div>')
+      }
+    });
+    const frame = container.querySelector('.panel-shell > div') as HTMLElement;
+
+    expect(frame.className).toContain('p-1');
+  });
+});

--- a/apps/frontend/src/lib/components/admin/UserList.svelte
+++ b/apps/frontend/src/lib/components/admin/UserList.svelte
@@ -54,10 +54,10 @@
       onRowClick={clickable ? handleRowClick : undefined}
     >
       {#snippet header()}
-        <th class="px-4 py-3 font-medium">{m['admin.users.login']()}</th>
-        <th class="px-4 py-3 font-medium">{m['admin.users.display_name']()}</th>
-        <th class="px-4 py-3 font-medium">{m['admin.users.email']()}</th>
-        <th class="px-4 py-3 font-medium">{m['admin.users.id']()}</th>
+        <th class="table-header-cell">{m['admin.users.login']()}</th>
+        <th class="table-header-cell">{m['admin.users.display_name']()}</th>
+        <th class="table-header-cell">{m['admin.users.email']()}</th>
+        <th class="table-header-cell">{m['admin.users.id']()}</th>
       {/snippet}
       {#snippet row(user: User)}
         <td class="px-4 py-3 font-medium">{user.login}</td>

--- a/apps/frontend/src/lib/components/rbac/PermissionMatrix.svelte
+++ b/apps/frontend/src/lib/components/rbac/PermissionMatrix.svelte
@@ -326,137 +326,136 @@ focusing a cell highlights its permission row and role column.
     {#each groupedPermissions as group (group.category)}
       {@const meta = CATEGORY_META[group.category]}
       <Panel title={meta?.title ?? group.category} subtitle={meta?.description} noPadding>
-        <div class="overflow-x-auto" style="width: max-content; max-width: 100%">
-          <DataTable
-            items={group.permissions}
-            columns={roles.length + 1}
-            getKey={(p) => p}
-            emptyMessage={m['rbac.permissions.empty_category']()}
-            hoverable={false}
-          >
-            {#snippet header()}
+        <DataTable
+          items={group.permissions}
+          columns={roles.length + 1}
+          getKey={(p) => p}
+          emptyMessage={m['rbac.permissions.empty_category']()}
+          fitContent
+          hoverable={false}
+        >
+          {#snippet header()}
+            <th
+              class="sticky left-0 z-10 bg-background px-4 py-3 text-left align-bottom font-medium"
+              style="width: 14rem"
+            >
+              {m['rbac.permissions.permission']()}
+            </th>
+            {#each roles as role (role.roleName)}
+              {@const handle =
+                onRoleClick && (isRoleClickable ? isRoleClickable(role) : true)
+                  ? onRoleClick
+                  : undefined}
               <th
-                class="sticky left-0 z-10 bg-surface px-4 py-3 text-left align-bottom font-medium"
-                style="width: 14rem"
+                class={[
+                  'px-0 py-3 text-center align-bottom font-medium',
+                  columnIsHighlighted(group.category, role.roleName)
+                    ? 'bg-action/10 text-action'
+                    : ''
+                ]}
+                style="width: 2rem; min-width: 2rem; height: 12rem"
+                title={`${role.displayName} — click to manage`}
+                data-role={role.roleName}
               >
-                {m['rbac.permissions.permission']()}
+                {#if handle}
+                  <button
+                    type="button"
+                    class="cursor-pointer text-sm hover:underline"
+                    onclick={() => handle(role)}
+                    style="writing-mode: vertical-rl; transform: rotate(180deg); white-space: nowrap"
+                  >
+                    @{role.roleName}
+                  </button>
+                {:else}
+                  <span
+                    class="text-sm"
+                    style="writing-mode: vertical-rl; transform: rotate(180deg); white-space: nowrap"
+                  >
+                    @{role.roleName}
+                  </span>
+                {/if}
               </th>
-              {#each roles as role (role.roleName)}
-                {@const handle =
-                  onRoleClick && (isRoleClickable ? isRoleClickable(role) : true)
-                    ? onRoleClick
-                    : undefined}
-                <th
-                  class={[
-                    'px-0 py-3 text-center align-bottom font-medium',
-                    columnIsHighlighted(group.category, role.roleName)
-                      ? 'bg-action/10 text-action'
-                      : ''
-                  ]}
-                  style="width: 2rem; min-width: 2rem; height: 12rem"
-                  title={`${role.displayName} — click to manage`}
-                  data-role={role.roleName}
-                >
-                  {#if handle}
-                    <button
-                      type="button"
-                      class="cursor-pointer text-sm hover:underline"
-                      onclick={() => handle(role)}
-                      style="writing-mode: vertical-rl; transform: rotate(180deg); white-space: nowrap"
-                    >
-                      @{role.roleName}
-                    </button>
-                  {:else}
-                    <span
-                      class="text-sm"
-                      style="writing-mode: vertical-rl; transform: rotate(180deg); white-space: nowrap"
-                    >
-                      @{role.roleName}
-                    </span>
-                  {/if}
-                </th>
-              {/each}
-            {/snippet}
-            {#snippet row(permission)}
+            {/each}
+          {/snippet}
+          {#snippet row(permission)}
+            <td
+              class={[
+                'sticky left-0 z-10 px-4 py-2 whitespace-nowrap',
+                rowIsHighlighted(group.category, permission) ? 'bg-action/8' : 'bg-background'
+              ]}
+            >
+              <code
+                data-testid="permission-name"
+                class={[
+                  'text-sm',
+                  rowIsHighlighted(group.category, permission) ? 'text-action' : ''
+                ]}>{permission}</code
+              >
+              <HelpTooltip label={`About ${permission}`}>
+                {getPermissionDescription(permission)}
+              </HelpTooltip>
+            </td>
+            {#each roles as role (role.roleName)}
+              {@const ov = overrideState(role, permission)}
+              {@const inh = inheritedState(role, permission)}
+              {@const virtualOwner = roleIsVirtualOwner(role)}
+              {@const displayOverride = virtualOwner ? 'allow' : ov}
+              {@const displayInherited = virtualOwner ? 'neutral' : inh}
+              {@const cellKey = `${role.roleName}::${permission}`}
+              {@const isUpdating = updating.includes(cellKey)}
+              {@const ariaParts = virtualOwner
+                ? [`Owner is always granted ${permission}`]
+                : [
+                    ov !== 'neutral'
+                      ? `Override ${ov} for ${role.displayName} on ${permission}`
+                      : `No override for ${role.displayName} on ${permission}`,
+                    inh !== 'neutral' && inheritedFromLabel
+                      ? `inheriting ${inh} from ${inheritedFromLabel}`
+                      : null
+                  ].filter(Boolean)}
+              {@const ariaLabel = ariaParts.join(', ')}
+              {@const titleParts = virtualOwner
+                ? [
+                    'Allow (owners are always granted all permissions)',
+                    'Owner permissions are not editable'
+                  ]
+                : [
+                    ov !== 'neutral'
+                      ? `${ov === 'allow' ? 'Allow' : 'Deny'} (override at this tier)`
+                      : null,
+                    inh !== 'neutral' && inheritedFromLabel
+                      ? `Inherits ${inh === 'allow' ? 'Allow' : 'Deny'} from ${inheritedFromLabel}`
+                      : null,
+                    ov === 'neutral' && inh === 'neutral' ? 'No decision' : null
+                  ].filter(Boolean)}
               <td
                 class={[
-                  'sticky left-0 z-10 px-4 py-2 whitespace-nowrap',
-                  rowIsHighlighted(group.category, permission) ? 'bg-action/8' : 'bg-surface'
+                  'px-0 py-2 text-center',
+                  cellHighlightClass(group.category, role.roleName, permission)
                 ]}
+                style="width: 2.5rem; min-width: 2.5rem"
+                data-role={role.roleName}
+                data-permission={permission}
+                onmouseenter={() =>
+                  (hoveredCell = coordinate(group.category, role.roleName, permission))}
+                onmouseleave={() => (hoveredCell = null)}
+                onfocusin={() =>
+                  (focusedCell = coordinate(group.category, role.roleName, permission))}
+                onfocusout={() => (focusedCell = null)}
               >
-                <code
-                  data-testid="permission-name"
-                  class={[
-                    'text-sm',
-                    rowIsHighlighted(group.category, permission) ? 'text-action' : ''
-                  ]}>{permission}</code
-                >
-                <HelpTooltip label={`About ${permission}`}>
-                  {getPermissionDescription(permission)}
-                </HelpTooltip>
+                <MatrixCell
+                  override={displayOverride}
+                  inherited={displayInherited}
+                  updating={isUpdating}
+                  disabled={virtualOwner}
+                  {ariaLabel}
+                  title={titleParts.join(' · ')}
+                  onCycle={(next) => void cycle(role, permission, next)}
+                />
               </td>
-              {#each roles as role (role.roleName)}
-                {@const ov = overrideState(role, permission)}
-                {@const inh = inheritedState(role, permission)}
-                {@const virtualOwner = roleIsVirtualOwner(role)}
-                {@const displayOverride = virtualOwner ? 'allow' : ov}
-                {@const displayInherited = virtualOwner ? 'neutral' : inh}
-                {@const cellKey = `${role.roleName}::${permission}`}
-                {@const isUpdating = updating.includes(cellKey)}
-                {@const ariaParts = virtualOwner
-                  ? [`Owner is always granted ${permission}`]
-                  : [
-                      ov !== 'neutral'
-                        ? `Override ${ov} for ${role.displayName} on ${permission}`
-                        : `No override for ${role.displayName} on ${permission}`,
-                      inh !== 'neutral' && inheritedFromLabel
-                        ? `inheriting ${inh} from ${inheritedFromLabel}`
-                        : null
-                    ].filter(Boolean)}
-                {@const ariaLabel = ariaParts.join(', ')}
-                {@const titleParts = virtualOwner
-                  ? [
-                      'Allow (owners are always granted all permissions)',
-                      'Owner permissions are not editable'
-                    ]
-                  : [
-                      ov !== 'neutral'
-                        ? `${ov === 'allow' ? 'Allow' : 'Deny'} (override at this tier)`
-                        : null,
-                      inh !== 'neutral' && inheritedFromLabel
-                        ? `Inherits ${inh === 'allow' ? 'Allow' : 'Deny'} from ${inheritedFromLabel}`
-                        : null,
-                      ov === 'neutral' && inh === 'neutral' ? 'No decision' : null
-                    ].filter(Boolean)}
-                <td
-                  class={[
-                    'px-0 py-2 text-center',
-                    cellHighlightClass(group.category, role.roleName, permission)
-                  ]}
-                  style="width: 2.5rem; min-width: 2.5rem"
-                  data-role={role.roleName}
-                  data-permission={permission}
-                  onmouseenter={() =>
-                    (hoveredCell = coordinate(group.category, role.roleName, permission))}
-                  onmouseleave={() => (hoveredCell = null)}
-                  onfocusin={() =>
-                    (focusedCell = coordinate(group.category, role.roleName, permission))}
-                  onfocusout={() => (focusedCell = null)}
-                >
-                  <MatrixCell
-                    override={displayOverride}
-                    inherited={displayInherited}
-                    updating={isUpdating}
-                    disabled={virtualOwner}
-                    {ariaLabel}
-                    title={titleParts.join(' · ')}
-                    onCycle={(next) => void cycle(role, permission, next)}
-                  />
-                </td>
-              {/each}
-            {/snippet}
-          </DataTable>
-        </div>
+            {/each}
+          {/snippet}
+        </DataTable>
       </Panel>
     {/each}
   </div>

--- a/apps/frontend/src/lib/components/rbac/PermissionMatrix.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/rbac/PermissionMatrix.svelte.spec.ts
@@ -108,22 +108,36 @@ describe('PermissionMatrix', () => {
     expect(container.querySelectorAll('tbody tr').length).toBe(2);
   });
 
-  it('keeps panel, table header, and sticky cells on one surface', async () => {
+  it('contrasts the panel body and sticky cells with the surface header', async () => {
     const { container } = render(PermissionMatrix, { props: { spaceId: 'space-1' } });
     await settle();
 
     const panel = container.querySelector('.panel-shell') as HTMLElement;
     const panelHeader = panel.querySelector(':scope > .panel-header') as HTMLElement;
+    const panelBody = panel.querySelector(':scope > div:last-child') as HTMLElement;
     const tableHeader = panel.querySelector('thead tr') as HTMLElement;
     const stickyHeader = panel.querySelector('thead th.sticky') as HTMLElement;
     const stickyBody = panel.querySelector('tbody td.sticky') as HTMLElement;
     const surfaceColor = getComputedStyle(panel).backgroundColor;
+    const headerColor = getComputedStyle(panelHeader).backgroundColor;
+    const viewport = panel.querySelector('.overflow-x-auto') as HTMLElement;
+    const inset = panel.querySelector(':scope > div:last-child > div') as HTMLElement;
+    const frame = inset.parentElement as HTMLElement;
+
+    const backgroundColor = getComputedStyle(inset).backgroundColor;
 
     expect(surfaceColor).not.toBe('rgba(0, 0, 0, 0)');
-    expect(getComputedStyle(panelHeader).backgroundColor).toBe(surfaceColor);
-    expect(getComputedStyle(tableHeader).backgroundColor).toBe(surfaceColor);
-    expect(getComputedStyle(stickyHeader).backgroundColor).toBe(surfaceColor);
-    expect(getComputedStyle(stickyBody).backgroundColor).toBe(surfaceColor);
+    expect(headerColor).toBe(surfaceColor);
+    expect(backgroundColor).not.toBe(surfaceColor);
+    expect(getComputedStyle(panelBody).backgroundColor).toBe('rgba(0, 0, 0, 0)');
+    expect(getComputedStyle(inset).backgroundColor).toBe(backgroundColor);
+    expect(getComputedStyle(viewport).backgroundColor).toBe(backgroundColor);
+    expect(frame.className).toContain('px-1');
+    expect(frame.className).toContain('pb-1');
+    expect(viewport.className).toContain('rounded-md');
+    expect(getComputedStyle(tableHeader).backgroundColor).toBe(headerColor);
+    expect(getComputedStyle(stickyHeader).backgroundColor).toBe(backgroundColor);
+    expect(getComputedStyle(stickyBody).backgroundColor).toBe(backgroundColor);
   });
 
   it('highlights the hovered permission row and role column', async () => {
@@ -252,16 +266,12 @@ describe('PermissionMatrix', () => {
     });
     await settle();
 
-    const buttons = Array.from(
-      container.querySelectorAll('thead button')
-    ) as HTMLButtonElement[];
+    const buttons = Array.from(container.querySelectorAll('thead button')) as HTMLButtonElement[];
     const adminHeader = buttons.find((b) => b.textContent?.trim() === '@admin');
     expect(adminHeader).toBeDefined();
     adminHeader!.click();
     flushSync();
-    expect(onRoleClick).toHaveBeenCalledWith(
-      expect.objectContaining({ roleName: 'admin' })
-    );
+    expect(onRoleClick).toHaveBeenCalledWith(expect.objectContaining({ roleName: 'admin' }));
   });
 
   it('renders headers as plain text when isRoleClickable returns false', async () => {

--- a/apps/frontend/src/lib/components/rbac/SubjectPermissionsMatrix.svelte
+++ b/apps/frontend/src/lib/components/rbac/SubjectPermissionsMatrix.svelte
@@ -207,11 +207,7 @@ its permission row and scope column.
     return highlightedCell?.category === category && highlightedCell.permission === permission;
   }
 
-  function cellBackgroundClass(
-    category: string,
-    scope: MatrixScope,
-    permission: string
-  ): string {
+  function cellBackgroundClass(category: string, scope: MatrixScope, permission: string): string {
     const row = rowIsHighlighted(category, permission);
     const columnHighlighted = columnIsHighlighted(category, scope.id);
     if (row && columnHighlighted) return 'bg-action/15';
@@ -230,127 +226,126 @@ its permission row and scope column.
         group.permissions.some((p) => cellFor(scope.id, p) !== undefined)
       )}
       <Panel title={meta?.title ?? group.category} subtitle={meta?.description} noPadding>
-        <div class="overflow-x-auto" style="width: max-content; max-width: 100%">
-          <DataTable
-            items={group.permissions}
-            columns={categoryScopes.length + 1}
-            getKey={(p) => p}
-            emptyMessage={m['rbac.permissions.empty_category']()}
-            hoverable={false}
-          >
-            {#snippet header()}
+        <DataTable
+          items={group.permissions}
+          columns={categoryScopes.length + 1}
+          getKey={(p) => p}
+          emptyMessage={m['rbac.permissions.empty_category']()}
+          fitContent
+          hoverable={false}
+        >
+          {#snippet header()}
+            <th
+              class="sticky left-0 z-10 bg-background px-4 py-3 text-left align-bottom font-medium"
+              style="width: 14rem"
+            >
+              Permission
+            </th>
+            {#each categoryScopes as scope (scope.id)}
               <th
-                class="sticky left-0 z-10 bg-surface px-4 py-3 text-left align-bottom font-medium"
-                style="width: 14rem"
-              >
-                Permission
-              </th>
-              {#each categoryScopes as scope (scope.id)}
-                <th
-                  class={[
-                    'px-0 py-3 text-center align-bottom font-medium',
-                    columnIsHighlighted(group.category, scope.id)
-                      ? 'bg-action/10 text-action'
-                      : scopeColumnClass(scope.kind)
-                  ]}
-                  style="width: 2rem; min-width: 2rem; height: 12rem"
-                  title={`${scope.label} (${scope.kind.toLowerCase()})`}
-                  data-scope={scope.id}
-                >
-                  <span
-                    class={[
-                      'text-sm',
-                      scope.kind === 'SERVER' ? 'font-semibold' : '',
-                      scope.kind === 'GROUP' ? 'text-neutral-action' : '',
-                      scope.kind === 'ROOM' ? 'text-muted' : ''
-                    ]}
-                    style="writing-mode: vertical-rl; transform: rotate(180deg); white-space: nowrap"
-                  >
-                    {#if scope.kind === 'ROOM'}#{/if}{scope.label}
-                  </span>
-                </th>
-              {/each}
-            {/snippet}
-            {#snippet row(permission)}
-              <td
                 class={[
-                  'sticky left-0 z-10 px-4 py-2 whitespace-nowrap',
-                  rowIsHighlighted(group.category, permission) ? 'bg-action/8' : 'bg-surface'
+                  'px-0 py-3 text-center align-bottom font-medium',
+                  columnIsHighlighted(group.category, scope.id)
+                    ? 'bg-action/10 text-action'
+                    : scopeColumnClass(scope.kind)
                 ]}
+                style="width: 2rem; min-width: 2rem; height: 12rem"
+                title={`${scope.label} (${scope.kind.toLowerCase()})`}
+                data-scope={scope.id}
               >
-                <code
-                  data-testid="permission-name"
+                <span
                   class={[
                     'text-sm',
-                    rowIsHighlighted(group.category, permission) ? 'text-action' : ''
-                  ]}>{permission}</code
-                >
-                <HelpTooltip label={`About ${permission}`}>
-                  {getPermissionDescription(permission)}
-                </HelpTooltip>
-              </td>
-              {#each categoryScopes as scope (scope.id)}
-                {@const cell = cellFor(scope.id, permission)}
-                {@const cellKey = `${scope.id}::${permission}`}
-                {@const isUpdating = updatingKey === cellKey}
-                <td
-                  class={[
-                    'px-0 py-2 text-center',
-                    cellBackgroundClass(group.category, scope, permission)
+                    scope.kind === 'SERVER' ? 'font-semibold' : '',
+                    scope.kind === 'GROUP' ? 'text-neutral-action' : '',
+                    scope.kind === 'ROOM' ? 'text-muted' : ''
                   ]}
-                  style="width: 2.5rem; min-width: 2.5rem"
-                  data-scope={scope.id}
-                  data-permission={permission}
-                  onmouseenter={cell
-                    ? () => (hoveredCell = coordinate(group.category, scope.id, permission))
-                    : undefined}
-                  onmouseleave={cell ? () => (hoveredCell = null) : undefined}
-                  onfocusin={cell
-                    ? () => (focusedCell = coordinate(group.category, scope.id, permission))
-                    : undefined}
-                  onfocusout={cell ? () => (focusedCell = null) : undefined}
+                  style="writing-mode: vertical-rl; transform: rotate(180deg); white-space: nowrap"
                 >
-                  {#if cell}
-                    {@const ov = decisionToState(cell.override)}
-                    {@const eff = decisionToState(cell.effective)}
-                    {@const displayOverride = forceAllow ? 'allow' : ov}
-                    {@const displayEffective = forceAllow ? 'neutral' : eff}
-                    {@const ariaLabel = forceAllow
-                      ? `${subjectKind} is always granted ${permission} at ${scope.label}`
-                      : ov !== 'neutral'
-                        ? `Override ${ov} for ${permission} at ${scope.label}`
-                        : `No override for ${permission} at ${scope.label}, effective ${eff}`}
-                    {@const titleParts = forceAllow
-                      ? [
-                          'Allow (owners are always granted all permissions)',
-                          'Owner permissions are not editable'
-                        ]
-                      : [
-                          ov !== 'neutral'
-                            ? `${ov === 'allow' ? 'Allow' : 'Deny'} (${subjectKind} override at ${scope.label})`
-                            : null,
-                          ov === 'neutral' && eff !== 'neutral'
-                            ? `Effective ${eff === 'allow' ? 'Allow' : 'Deny'} (inherited)`
-                            : null,
-                          ov === 'neutral' && eff === 'neutral' ? 'No decision' : null
-                        ].filter(Boolean)}
-                    <MatrixCell
-                      override={displayOverride}
-                      inherited={displayEffective}
-                      updating={isUpdating}
-                      disabled={readOnly}
-                      {ariaLabel}
-                      title={titleParts.join(' · ')}
-                      onCycle={(next) => onCycle(scope, permission, next)}
-                    />
-                  {:else}
-                    <span class="inline-block h-10 w-10" aria-hidden="true"></span>
-                  {/if}
-                </td>
-              {/each}
-            {/snippet}
-          </DataTable>
-        </div>
+                  {#if scope.kind === 'ROOM'}#{/if}{scope.label}
+                </span>
+              </th>
+            {/each}
+          {/snippet}
+          {#snippet row(permission)}
+            <td
+              class={[
+                'sticky left-0 z-10 px-4 py-2 whitespace-nowrap',
+                rowIsHighlighted(group.category, permission) ? 'bg-action/8' : 'bg-background'
+              ]}
+            >
+              <code
+                data-testid="permission-name"
+                class={[
+                  'text-sm',
+                  rowIsHighlighted(group.category, permission) ? 'text-action' : ''
+                ]}>{permission}</code
+              >
+              <HelpTooltip label={`About ${permission}`}>
+                {getPermissionDescription(permission)}
+              </HelpTooltip>
+            </td>
+            {#each categoryScopes as scope (scope.id)}
+              {@const cell = cellFor(scope.id, permission)}
+              {@const cellKey = `${scope.id}::${permission}`}
+              {@const isUpdating = updatingKey === cellKey}
+              <td
+                class={[
+                  'px-0 py-2 text-center',
+                  cellBackgroundClass(group.category, scope, permission)
+                ]}
+                style="width: 2.5rem; min-width: 2.5rem"
+                data-scope={scope.id}
+                data-permission={permission}
+                onmouseenter={cell
+                  ? () => (hoveredCell = coordinate(group.category, scope.id, permission))
+                  : undefined}
+                onmouseleave={cell ? () => (hoveredCell = null) : undefined}
+                onfocusin={cell
+                  ? () => (focusedCell = coordinate(group.category, scope.id, permission))
+                  : undefined}
+                onfocusout={cell ? () => (focusedCell = null) : undefined}
+              >
+                {#if cell}
+                  {@const ov = decisionToState(cell.override)}
+                  {@const eff = decisionToState(cell.effective)}
+                  {@const displayOverride = forceAllow ? 'allow' : ov}
+                  {@const displayEffective = forceAllow ? 'neutral' : eff}
+                  {@const ariaLabel = forceAllow
+                    ? `${subjectKind} is always granted ${permission} at ${scope.label}`
+                    : ov !== 'neutral'
+                      ? `Override ${ov} for ${permission} at ${scope.label}`
+                      : `No override for ${permission} at ${scope.label}, effective ${eff}`}
+                  {@const titleParts = forceAllow
+                    ? [
+                        'Allow (owners are always granted all permissions)',
+                        'Owner permissions are not editable'
+                      ]
+                    : [
+                        ov !== 'neutral'
+                          ? `${ov === 'allow' ? 'Allow' : 'Deny'} (${subjectKind} override at ${scope.label})`
+                          : null,
+                        ov === 'neutral' && eff !== 'neutral'
+                          ? `Effective ${eff === 'allow' ? 'Allow' : 'Deny'} (inherited)`
+                          : null,
+                        ov === 'neutral' && eff === 'neutral' ? 'No decision' : null
+                      ].filter(Boolean)}
+                  <MatrixCell
+                    override={displayOverride}
+                    inherited={displayEffective}
+                    updating={isUpdating}
+                    disabled={readOnly}
+                    {ariaLabel}
+                    title={titleParts.join(' · ')}
+                    onCycle={(next) => onCycle(scope, permission, next)}
+                  />
+                {:else}
+                  <span class="inline-block h-10 w-10" aria-hidden="true"></span>
+                {/if}
+              </td>
+            {/each}
+          {/snippet}
+        </DataTable>
       </Panel>
     {/each}
   </div>

--- a/apps/frontend/src/lib/demos/AdminDashboard.stories.svelte
+++ b/apps/frontend/src/lib/demos/AdminDashboard.stories.svelte
@@ -68,11 +68,11 @@
 </Story>
 
 {#snippet tableHeader()}
-  <th class="px-4 py-2 text-left text-xs font-semibold uppercase text-muted">Name</th>
-  <th class="px-4 py-2 text-left text-xs font-semibold uppercase text-muted">ID</th>
-  <th class="px-4 py-2 text-right text-xs font-semibold uppercase text-muted">Members</th>
-  <th class="px-4 py-2 text-right text-xs font-semibold uppercase text-muted">Rooms</th>
-  <th class="px-4 py-2 text-left text-xs font-semibold uppercase text-muted">Visibility</th>
+  <th class="table-header-cell text-left text-xs font-semibold text-muted uppercase">Name</th>
+  <th class="table-header-cell text-left text-xs font-semibold text-muted uppercase">ID</th>
+  <th class="table-header-cell text-right text-xs font-semibold text-muted uppercase">Members</th>
+  <th class="table-header-cell text-right text-xs font-semibold text-muted uppercase">Rooms</th>
+  <th class="table-header-cell text-left text-xs font-semibold text-muted uppercase">Visibility</th>
 {/snippet}
 
 {#snippet tableRow(row: { id: string; name: string; members: number; rooms: number; status: 'public' | 'invite' | 'private' })}

--- a/apps/frontend/src/lib/ui/Utilities.stories.svelte
+++ b/apps/frontend/src/lib/ui/Utilities.stories.svelte
@@ -105,7 +105,7 @@
     docs: {
       description: {
         story:
-          '`panel-shell` is the canonical bordered surface. Add `panel-shell-raised` only when the shell needs to sit above a scrolling page surface.'
+          '`panel-shell` is the canonical bordered surface frame. Add `panel-shell-raised` only when the shell needs to sit above a scrolling page surface.'
       }
     }
   }}
@@ -113,28 +113,32 @@
   <div class="flex max-w-3xl flex-col gap-4">
     <p class="max-w-prose text-sm text-muted">
       Use <code>panel-shell</code> for admin panels, directory group cards, and other durable
-      content containers. Combine with <code>panel-header</code> when the surface has a
-      structured header.
+      content containers. Combine it with <code>panel-header</code>, then wrap content in a
+      side-and-bottom frame and <code>panel-inset</code> work plane.
     </p>
 
     <div class="grid gap-4 md:grid-cols-2">
       <section class="overflow-hidden panel-shell">
-        <header class="rounded-t-xl panel-header px-4 py-3">
+        <header class="panel-header px-6 py-3">
           <h3 class="font-semibold">Flat shell</h3>
           <p class="text-sm text-muted">Embedded in a dense view.</p>
         </header>
-        <div class="p-4 text-sm text-muted">
-          Bordered, token-backed background, no elevation.
+        <div class="px-1 pb-1">
+          <div class="panel-inset p-4 text-sm text-muted">
+            Bordered, token-backed background, no elevation.
+          </div>
         </div>
       </section>
 
       <section class="overflow-hidden panel-shell panel-shell-raised">
-        <header class="rounded-t-xl panel-header px-4 py-3">
+        <header class="panel-header px-6 py-3">
           <h3 class="font-semibold">Raised shell</h3>
           <p class="text-sm text-muted">Used by admin panels.</p>
         </header>
-        <div class="p-4 text-sm text-muted">
-          Same shell with the approved quiet shadow.
+        <div class="px-1 pb-1">
+          <div class="panel-inset p-4 text-sm text-muted">
+            Same shell with the approved quiet shadow.
+          </div>
         </div>
       </section>
     </div>

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/AdminRoomLayoutEditor.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/AdminRoomLayoutEditor.svelte
@@ -412,11 +412,11 @@
           <section
             animate:flip={{ duration: 200 }}
             class={[
-              'overflow-hidden panel-shell panel-shell-raised transition-shadow',
+              'shrink-0 overflow-hidden panel-shell panel-shell-raised transition-shadow',
               layout.draggingGroupId === group.id && 'shadow-lg ring-1 ring-action/30'
             ]}
           >
-            <header class="group-header flex items-center gap-3 panel-header px-4 py-3">
+            <header class="group-header flex items-center gap-3 panel-header px-6 py-3">
               <span
                 role="button"
                 tabindex="0"
@@ -466,75 +466,78 @@
               </div>
             </header>
 
-            <div
-              class="min-h-12 p-2"
-              use:dndzone={{
-                items: group.items,
-                flipDurationMs: 200,
-                dropTargetStyle: {
-                  outline: '2px dashed var(--color-action)',
-                  'outline-offset': '-2px',
-                  'border-radius': '0.5rem',
-                  'background-color': 'color-mix(in srgb, var(--color-action) 5%, transparent)'
-                },
-                type: 'rooms'
-              }}
-              onconsider={(e) => handleGroupConsider(group.id, e)}
-              onfinalize={(e) => handleGroupFinalize(group.id, e)}
-            >
-              {#each group.items as room (room.id)}
-                <div
-                  animate:flip={{ duration: 200 }}
-                  class={[
-                    'group flex cursor-grab items-center gap-3 rounded-lg py-2 pr-2 pl-3 hover:bg-surface',
-                    room.kind === 'room' && room.room.archived && 'opacity-60'
-                  ]}
-                >
-                  <div class="min-w-0 flex-1">
-                    {#if room.kind === 'room'}
-                      <div class="flex min-w-0 items-start gap-2">
-                        <span class="mt-0.5 shrink-0 text-muted">#</span>
-                        <div class="min-w-0 flex-1">
-                          <div class="flex min-w-0 items-center gap-2">
-                            <span class="min-w-0 truncate font-medium">{room.room.name}</span>
-                            {#if room.room.isUniversal}
-                              <Pill
-                                tone="action"
-                                title={m['admin.rooms_admin.universal_room']()}
-                                class="inline-flex shrink-0 items-center gap-1 rounded-md px-1.5"
-                              >
-                                <span class="iconify text-xs uil--globe" aria-hidden="true"></span>
-                                {m['admin.rooms_admin.universal']()}
-                              </Pill>
-                            {/if}
-                            {#if room.room.archived}
-                              <Pill tone="muted" class="shrink-0 rounded-md px-1.5"
-                                >{m['admin.rooms_admin.archived']()}</Pill
-                              >
+            <div class="px-1 pb-1">
+              <div
+                class="min-h-12 overflow-hidden panel-inset p-2"
+                use:dndzone={{
+                  items: group.items,
+                  flipDurationMs: 200,
+                  dropTargetStyle: {
+                    outline: '2px dashed var(--color-action)',
+                    'outline-offset': '-2px',
+                    'border-radius': '0.5rem',
+                    'background-color': 'color-mix(in srgb, var(--color-action) 5%, transparent)'
+                  },
+                  type: 'rooms'
+                }}
+                onconsider={(e) => handleGroupConsider(group.id, e)}
+                onfinalize={(e) => handleGroupFinalize(group.id, e)}
+              >
+                {#each group.items as room (room.id)}
+                  <div
+                    animate:flip={{ duration: 200 }}
+                    class={[
+                      'group flex cursor-grab items-center gap-3 rounded-lg py-2 pr-2 pl-3 hover:bg-surface',
+                      room.kind === 'room' && room.room.archived && 'opacity-60'
+                    ]}
+                  >
+                    <div class="min-w-0 flex-1">
+                      {#if room.kind === 'room'}
+                        <div class="flex min-w-0 items-start gap-2">
+                          <span class="mt-0.5 shrink-0 text-muted">#</span>
+                          <div class="min-w-0 flex-1">
+                            <div class="flex min-w-0 items-center gap-2">
+                              <span class="min-w-0 truncate font-medium">{room.room.name}</span>
+                              {#if room.room.isUniversal}
+                                <Pill
+                                  tone="action"
+                                  title={m['admin.rooms_admin.universal_room']()}
+                                  class="inline-flex shrink-0 items-center gap-1 rounded-md px-1.5"
+                                >
+                                  <span class="iconify text-xs uil--globe" aria-hidden="true"
+                                  ></span>
+                                  {m['admin.rooms_admin.universal']()}
+                                </Pill>
+                              {/if}
+                              {#if room.room.archived}
+                                <Pill tone="muted" class="shrink-0 rounded-md px-1.5"
+                                  >{m['admin.rooms_admin.archived']()}</Pill
+                                >
+                              {/if}
+                            </div>
+                            {#if room.room.description}
+                              <p class="truncate text-sm text-muted">{room.room.description}</p>
                             {/if}
                           </div>
-                          {#if room.room.description}
-                            <p class="truncate text-sm text-muted">{room.room.description}</p>
-                          {/if}
                         </div>
-                      </div>
-                    {:else}
-                      <div class="flex min-w-0 items-baseline gap-1.5">
-                        <span class="iconify text-muted uil--external-link-alt"></span>
-                        <span class="truncate font-medium">{room.link.label}</span>
-                      </div>
-                      <p class="truncate text-sm text-muted">{room.link.url}</p>
-                    {/if}
+                      {:else}
+                        <div class="flex min-w-0 items-baseline gap-1.5">
+                          <span class="iconify text-muted uil--external-link-alt"></span>
+                          <span class="truncate font-medium">{room.link.label}</span>
+                        </div>
+                        <p class="truncate text-sm text-muted">{room.link.url}</p>
+                      {/if}
+                    </div>
+                    <div class="flex items-center gap-1.5">
+                      {@render roomActions(room)}
+                    </div>
                   </div>
-                  <div class="flex items-center gap-1.5">
-                    {@render roomActions(room)}
+                {:else}
+                  <div class="px-3 py-4 text-center text-sm text-muted">
+                    {m['admin.rooms_admin.drop_rooms']()}
                   </div>
-                </div>
-              {:else}
-                <div class="px-3 py-4 text-center text-sm text-muted">
-                  {m['admin.rooms_admin.drop_rooms']()}
-                </div>
-              {/each}
+                {/each}
+              </div>
             </div>
           </section>
         {/each}

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/AdminRoomLayoutEditor.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/AdminRoomLayoutEditor.svelte.spec.ts
@@ -138,6 +138,16 @@ describe('AdminRoomLayoutEditor', () => {
     expect(populatedRender.container.textContent).toContain('Lobby');
     expect(populatedRender.container.textContent).toContain('general');
     expect(populatedRender.container.textContent).toContain('Public room');
+
+    const shell = populatedRender.container.querySelector('section.panel-shell') as HTMLElement;
+    const header = shell.querySelector(':scope > header') as HTMLElement;
+    const frame = shell.querySelector(':scope > div:last-child') as HTMLElement;
+    const inset = frame.firstElementChild as HTMLElement;
+    expect(shell.className).toContain('shrink-0');
+    expect(header.className).toContain('px-6');
+    expect(frame.className).toContain('px-1');
+    expect(frame.className).toContain('pb-1');
+    expect(inset.className).toContain('panel-inset');
   });
 
   it('opens the create-group dialog and delegates submission to the layout store', async () => {

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/event-log/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/event-log/+page.svelte
@@ -274,11 +274,11 @@
           onRowClick={openEntry}
         >
           {#snippet header()}
-            <th class="px-4 py-3 font-medium">{m['admin.event_log.seq']()}</th>
-            <th class="px-4 py-3 font-medium">{m['admin.event_log.time']()}</th>
-            <th class="px-4 py-3 font-medium">{m['admin.event_log.event']()}</th>
-            <th class="px-4 py-3 font-medium">{m['admin.event_log.aggregate']()}</th>
-            <th class="px-4 py-3 font-medium">{m['admin.event_log.actor']()}</th>
+            <th class="table-header-cell">{m['admin.event_log.seq']()}</th>
+            <th class="table-header-cell">{m['admin.event_log.time']()}</th>
+            <th class="table-header-cell">{m['admin.event_log.event']()}</th>
+            <th class="table-header-cell">{m['admin.event_log.aggregate']()}</th>
+            <th class="table-header-cell">{m['admin.event_log.actor']()}</th>
           {/snippet}
           {#snippet row(entry)}
             <td class="px-4 py-3 font-mono text-sm text-muted">{entry.sequence}</td>

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/members/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/members/+page.svelte
@@ -193,10 +193,10 @@
               )}
           >
             {#snippet header()}
-              <th class="px-4 py-3 font-medium">{m['admin.common.user']()}</th>
-              <th class="px-4 py-3 font-medium">{m['admin.users.login']()}</th>
-              <th class="px-4 py-3 font-medium">{m['admin.common.joined']()}</th>
-              <th class="px-4 py-3 font-medium">{m['admin.common.roles']()}</th>
+              <th class="table-header-cell">{m['admin.common.user']()}</th>
+              <th class="table-header-cell">{m['admin.users.login']()}</th>
+              <th class="table-header-cell">{m['admin.common.joined']()}</th>
+              <th class="table-header-cell">{m['admin.common.roles']()}</th>
             {/snippet}
             {#snippet row(user)}
               <td class="px-4 py-3">

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/moderation/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/moderation/+page.svelte
@@ -127,11 +127,11 @@
       <Panel noPadding>
         <DataTable items={bans} columns={5} emptyMessage={m['admin.moderation.empty_bans']()}>
           {#snippet header()}
-            <th class="px-3 py-2 font-medium">{m['admin.common.user']()}</th>
-            <th class="px-3 py-2 font-medium">{m['admin.common.room']()}</th>
-            <th class="px-3 py-2 font-medium">{m['admin.common.reason']()}</th>
-            <th class="px-3 py-2 font-medium">{m['admin.common.expires']()}</th>
-            <th class="px-3 py-2 font-medium"></th>
+            <th class="table-header-cell">{m['admin.common.user']()}</th>
+            <th class="table-header-cell">{m['admin.common.room']()}</th>
+            <th class="table-header-cell">{m['admin.common.reason']()}</th>
+            <th class="table-header-cell">{m['admin.common.expires']()}</th>
+            <th class="table-header-cell"></th>
           {/snippet}
           {#snippet row(ban)}
             {@const user = ban.user}

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/system/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/system/+page.svelte
@@ -368,12 +368,12 @@
         <Panel title={m['admin.system.streams']()} icon="iconify uil--exchange" noPadding>
           <DataTable items={streams} columns={6} emptyMessage={m['admin.system.no_streams']()}>
             {#snippet header()}
-              <th class="px-4 py-3 font-medium">{m['admin.system.stream']()}</th>
-              <th class="px-4 py-3 font-medium">{m['admin.system.storage']()}</th>
-              <th class="px-4 py-3 font-medium">{m['admin.system.messages']()}</th>
-              <th class="px-4 py-3 font-medium">{m['admin.system.bytes']()}</th>
-              <th class="px-4 py-3 font-medium">{m['admin.system.consumers']()}</th>
-              <th class="px-4 py-3 font-medium">{m['admin.system.replicas']()}</th>
+              <th class="table-header-cell">{m['admin.system.stream']()}</th>
+              <th class="table-header-cell">{m['admin.system.storage']()}</th>
+              <th class="table-header-cell">{m['admin.system.messages']()}</th>
+              <th class="table-header-cell">{m['admin.system.bytes']()}</th>
+              <th class="table-header-cell">{m['admin.system.consumers']()}</th>
+              <th class="table-header-cell">{m['admin.system.replicas']()}</th>
             {/snippet}
             {#snippet row(stream)}
               <td class="px-4 py-3">
@@ -399,13 +399,13 @@
         <Panel title={m['admin.system.consumers']()} icon="iconify uil--users-alt" noPadding>
           <DataTable items={consumers} columns={7} emptyMessage={m['admin.system.no_consumers']()}>
             {#snippet header()}
-              <th class="px-4 py-3 font-medium">{m['admin.system.consumer']()}</th>
-              <th class="px-4 py-3 font-medium">{m['admin.system.mode']()}</th>
-              <th class="px-4 py-3 font-medium">{m['admin.system.filters']()}</th>
-              <th class="px-4 py-3 font-medium">{m['admin.system.pending']()}</th>
-              <th class="px-4 py-3 font-medium">{m['admin.system.ack_pending']()}</th>
-              <th class="px-4 py-3 font-medium">{m['admin.system.redelivered']()}</th>
-              <th class="px-4 py-3 font-medium">{m['admin.system.acked_through']()}</th>
+              <th class="table-header-cell">{m['admin.system.consumer']()}</th>
+              <th class="table-header-cell">{m['admin.system.mode']()}</th>
+              <th class="table-header-cell">{m['admin.system.filters']()}</th>
+              <th class="table-header-cell">{m['admin.system.pending']()}</th>
+              <th class="table-header-cell">{m['admin.system.ack_pending']()}</th>
+              <th class="table-header-cell">{m['admin.system.redelivered']()}</th>
+              <th class="table-header-cell">{m['admin.system.acked_through']()}</th>
             {/snippet}
             {#snippet row(consumer)}
               <td class="px-4 py-3">
@@ -469,13 +469,13 @@
             emptyMessage={m['admin.system.no_projections']()}
           >
             {#snippet header()}
-              <th class="px-4 py-3 font-medium">{m['admin.system.projection']()}</th>
-              <th class="px-4 py-3 font-medium">{m['admin.system.state']()}</th>
-              <th class="px-4 py-3 font-medium">{m['admin.system.startup']()}</th>
-              <th class="px-4 py-3 font-medium">{m['admin.system.applied']()}</th>
-              <th class="px-4 py-3 font-medium">{m['admin.system.lag']()}</th>
-              <th class="px-4 py-3 font-medium">{m['admin.system.entries']()}</th>
-              <th class="px-4 py-3 font-medium">{m['admin.system.memory']()}</th>
+              <th class="table-header-cell">{m['admin.system.projection']()}</th>
+              <th class="table-header-cell">{m['admin.system.state']()}</th>
+              <th class="table-header-cell">{m['admin.system.startup']()}</th>
+              <th class="table-header-cell">{m['admin.system.applied']()}</th>
+              <th class="table-header-cell">{m['admin.system.lag']()}</th>
+              <th class="table-header-cell">{m['admin.system.entries']()}</th>
+              <th class="table-header-cell">{m['admin.system.memory']()}</th>
             {/snippet}
             {#snippet row(projection)}
               <td class="px-4 py-3">


### PR DESCRIPTION
## Why

The admin redesign flattened tables and panels into broad grey surfaces, weakening contrast, hierarchy, and the rounded visual language used elsewhere.

## What changed

- Add shared panel inset and table-header primitives with concentric rounded geometry
- Route record tables, permission matrices, room groups, and room-directory cards through the consolidated treatment
- Balance panel/header spacing and use a quieter rounded row hover state
- Document the conventions and expand component, layout, and matrix coverage

## API compatibility

No public API or protocol behaviour changes; this is a bundled frontend styling and component-composition update.

- Older client → newer server: Not applicable
- Newer client → older server: Not applicable
- Capability signal: None

## Test plan

- `mise test-frontend` — 272 files / 2,374 tests passed
- `mise lint-frontend` — passed with 0 errors and 0 warnings
- `mise x -- pnpm --filter chatto-frontend build-storybook` — passed
- `mise x uv@latest -- uvx --with charset-normalizer reuse lint` — passed
- Chrome DevTools — verified affected admin and room-directory surfaces in light and dark themes with no console errors
