### PR TITLE
refactor(api): simplify followed thread assembly

### DIFF
--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -7995,7 +7995,7 @@ func TestFollowedThreadsResponseOmitsUnavailableRooms(t *testing.T) {
 		TotalCount: 1,
 	}
 
-	resp, err := newThreadAssembler(env.api).followedThreadsResponse(env.ctx, env.viewer.Id, page)
+	resp, err := followedThreadsResponse(env.ctx, env.api, env.viewer.Id, page)
 	if err != nil {
 		t.Fatalf("followedThreadsResponse: %v", err)
 	}

--- a/cli/internal/connectapi/thread_assembler.go
+++ b/cli/internal/connectapi/thread_assembler.go
@@ -11,15 +11,7 @@ import (
 	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
 )
 
-type threadAssembler struct {
-	api *API
-}
-
-func newThreadAssembler(api *API) *threadAssembler {
-	return &threadAssembler{api: api}
-}
-
-func (a *threadAssembler) followedThreadsResponse(ctx context.Context, viewerID string, page *core.FollowedThreadsPage) (*apiv1.ListFollowedThreadsResponse, error) {
+func followedThreadsResponse(ctx context.Context, api *API, viewerID string, page *core.FollowedThreadsPage) (*apiv1.ListFollowedThreadsResponse, error) {
 	if page == nil {
 		return &apiv1.ListFollowedThreadsResponse{
 			Includes: &apiv1.RoomTimelineIncludes{Users: map[string]*apiv1.User{}},
@@ -33,13 +25,13 @@ func (a *threadAssembler) followedThreadsResponse(ctx context.Context, viewerID 
 			messageIDs = append(messageIDs, thread.ThreadRootEventID)
 		}
 	}
-	reactionsByMessageID, err := a.api.core.GetReactionsBatch(ctx, messageIDs)
+	reactionsByMessageID, err := api.core.GetReactionsBatch(ctx, messageIDs)
 	if err != nil {
 		return nil, err
 	}
 
 	h := &timelineHydrator{
-		api:                  a.api,
+		api:                  api,
 		ctx:                  ctx,
 		viewerID:             viewerID,
 		kind:                 core.KindChannel,
@@ -53,7 +45,7 @@ func (a *threadAssembler) followedThreadsResponse(ctx context.Context, viewerID 
 		}
 
 		kind := core.RoomKindFromLegacySpaceID(thread.SpaceID)
-		room, err := a.api.core.GetRoom(ctx, kind, thread.RoomID)
+		room, err := api.core.GetRoom(ctx, kind, thread.RoomID)
 		if err != nil {
 			// List responses omit resources that disappear between the core page
 			// snapshot and response hydration instead of failing the whole page.
@@ -63,7 +55,7 @@ func (a *threadAssembler) followedThreadsResponse(ctx context.Context, viewerID 
 			return nil, err
 		}
 
-		event, err := a.api.core.GetRoomEventByEventID(ctx, kind, thread.RoomID, thread.ThreadRootEventID)
+		event, err := api.core.GetRoomEventByEventID(ctx, kind, thread.RoomID, thread.ThreadRootEventID)
 		if err != nil {
 			return nil, err
 		}

--- a/cli/internal/connectapi/threads.go
+++ b/cli/internal/connectapi/threads.go
@@ -28,7 +28,7 @@ func (s *threadService) ListFollowedThreads(ctx context.Context, req *connect.Re
 		return nil, connectError(err)
 	}
 
-	resp, err := newThreadAssembler(s.api).followedThreadsResponse(ctx, caller.UserID, page)
+	resp, err := followedThreadsResponse(ctx, s.api, caller.UserID, page)
 	if err != nil {
 		return nil, connectError(err)
 	}


### PR DESCRIPTION
## Why

Followed-thread response assembly used a one-method wrapper type that added construction and receiver ceremony without owning meaningful state.

## What changed

- Replace `threadAssembler` and its constructor with a package-level response assembly function.
- Update the ConnectRPC handler and existing disappearing-room coverage to call the function directly.

## API compatibility

- No public API or protocol behaviour changed.
- Older client → newer server: unchanged.
- Newer client → older server: unchanged.
- Capability discovery or minimum client/server version: none required.

## Test plan

- `mise x -- go test ./internal/connectapi -run '^(TestThreadServiceListFollowedThreads.*|TestFollowedThreadsResponseOmitsUnavailableRooms)$' -count=1 -timeout 30s`
- `mise x -- go test ./internal/connectapi -count=1 -timeout 2m`
- `git diff --check origin/main...`
