### PR TITLE
refactor(api): decouple user response mapping

### DIFF
--- a/cli/internal/connectapi/account.go
+++ b/cli/internal/connectapi/account.go
@@ -187,7 +187,7 @@ func (s *accountService) accountUser(ctx context.Context, user *corev1.User) (*a
 	if user == nil {
 		return nil, connectError(core.ErrNotFound)
 	}
-	return (&userService{api: s.api}).userSummary(ctx, user, nil)
+	return userSummary(ctx, s.api, user, nil)
 }
 
 func apiTimeFormatToCore(format apiv1.TimeFormat) corev1.TimeFormat {

--- a/cli/internal/connectapi/admin_user_management.go
+++ b/cli/internal/connectapi/admin_user_management.go
@@ -314,7 +314,7 @@ func (s *adminUserManagementService) adminMemberAfterMutationForUser(ctx context
 	if err != nil {
 		return nil, connectError(err)
 	}
-	apiUser, err := (&userService{api: s.api}).userSummary(ctx, user, nil)
+	apiUser, err := userSummary(ctx, s.api, user, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -334,7 +334,7 @@ func (s *adminUserManagementService) adminMemberForOperator(ctx context.Context,
 	for _, email := range user.VerifiedEmails {
 		verifiedEmails = append(verifiedEmails, email.Email)
 	}
-	apiUser, err := (&userService{api: s.api}).userSummary(ctx, user.User, nil)
+	apiUser, err := userSummary(ctx, s.api, user.User, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -204,7 +204,7 @@ func TestRequireCaller(t *testing.T) {
 func TestUserSummaryTreatsInvalidPresenceKeyAsOffline(t *testing.T) {
 	env := newConnectAPITestEnv(t)
 
-	user, err := (&userService{api: env.api}).userSummary(env.ctx, core.DeletedUserReference("bad>"), nil)
+	user, err := userSummary(env.ctx, env.api, core.DeletedUserReference("bad>"), nil)
 	if err != nil {
 		t.Fatalf("userSummary: %v", err)
 	}

--- a/cli/internal/connectapi/member_directory.go
+++ b/cli/internal/connectapi/member_directory.go
@@ -261,7 +261,7 @@ func directoryMemberWithPresence(ctx context.Context, api *API, user *corev1.Use
 		Height: int32(avatarSize),
 		Fit:    apiv1.ImageFitMode_IMAGE_FIT_MODE_COVER,
 	}
-	apiUser, err := (&userService{api: api}).userSummaryWithPresence(ctx, user, avatar, presence)
+	apiUser, err := userSummaryWithPresence(ctx, api, user, avatar, presence)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/connectapi/notification_assembler.go
+++ b/cli/internal/connectapi/notification_assembler.go
@@ -126,7 +126,7 @@ func (a *notificationAssembler) actor(ctx context.Context, userID, presence stri
 		}
 		return nil, err
 	}
-	actor, err := (&userService{api: a.api}).userSummaryWithPresence(ctx, user, nil, presence)
+	actor, err := userSummaryWithPresence(ctx, a.api, user, nil, presence)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/connectapi/room_timeline_assembler.go
+++ b/cli/internal/connectapi/room_timeline_assembler.go
@@ -443,7 +443,7 @@ func (h *timelineHydrator) users() (map[string]*apiv1.User, error) {
 		if user == nil {
 			user = core.DeletedUserReference(id)
 		}
-		summary, err := (&userService{api: h.api}).userSummaryWithPresence(h.ctx, user, &apiv1.ImageTransformOptions{
+		summary, err := userSummaryWithPresence(h.ctx, h.api, user, &apiv1.ImageTransformOptions{
 			Width:  int32(avatarWidth),
 			Height: int32(avatarHeight),
 			Fit:    apiv1.ImageFitMode_IMAGE_FIT_MODE_COVER,

--- a/cli/internal/connectapi/users.go
+++ b/cli/internal/connectapi/users.go
@@ -11,15 +11,15 @@ type userService struct {
 	api *API
 }
 
-func (s *userService) userSummary(ctx context.Context, user *corev1.User, avatar *apiv1.ImageTransformOptions) (*apiv1.User, error) {
-	presence, err := s.api.core.GetUserPresence(ctx, user.GetId())
+func userSummary(ctx context.Context, api *API, user *corev1.User, avatar *apiv1.ImageTransformOptions) (*apiv1.User, error) {
+	presence, err := api.core.GetUserPresence(ctx, user.GetId())
 	if err != nil {
 		return nil, connectError(err)
 	}
-	return s.userSummaryWithPresence(ctx, user, avatar, presence)
+	return userSummaryWithPresence(ctx, api, user, avatar, presence)
 }
 
-func (s *userService) userSummaryWithPresence(ctx context.Context, user *corev1.User, avatar *apiv1.ImageTransformOptions, presence string) (*apiv1.User, error) {
+func userSummaryWithPresence(ctx context.Context, api *API, user *corev1.User, avatar *apiv1.ImageTransformOptions, presence string) (*apiv1.User, error) {
 	summary := &apiv1.User{
 		Id:             user.GetId(),
 		Login:          user.GetLogin(),
@@ -28,19 +28,19 @@ func (s *userService) userSummaryWithPresence(ctx context.Context, user *corev1.
 		PresenceStatus: corePresenceStatusToAPI(presence),
 		CustomStatus:   coreCustomStatusToAPI(user.GetCustomStatus()),
 	}
-	avatarURL, err := s.userAvatarURL(ctx, user.GetId(), avatar)
+	avatarURL, err := userAvatarURL(ctx, api, user.GetId(), avatar)
 	if err != nil {
 		return nil, err
 	}
 	if avatarURL != "" {
-		summary.AvatarUrl = stringPtr(s.api.absolutizeAssetURL(ctx, avatarURL))
+		summary.AvatarUrl = stringPtr(api.absolutizeAssetURL(ctx, avatarURL))
 	}
 	return summary, nil
 }
 
-func (s *userService) userAvatarURL(ctx context.Context, userID string, avatar *apiv1.ImageTransformOptions) (string, error) {
+func userAvatarURL(ctx context.Context, api *API, userID string, avatar *apiv1.ImageTransformOptions) (string, error) {
 	if avatar == nil {
-		url, err := s.api.core.GetUserAvatarURL(ctx, userID, nil, nil, "")
+		url, err := api.core.GetUserAvatarURL(ctx, userID, nil, nil, "")
 		if err != nil {
 			return "", connectError(err)
 		}
@@ -52,7 +52,7 @@ func (s *userService) userAvatarURL(ctx context.Context, userID string, avatar *
 	if avatar.GetFit() == apiv1.ImageFitMode_IMAGE_FIT_MODE_CONTAIN {
 		fit = "contain"
 	}
-	url, err := s.api.core.GetUserAvatarURL(ctx, userID, &width, &height, fit)
+	url, err := api.core.GetUserAvatarURL(ctx, userID, &width, &height, fit)
 	if err != nil {
 		return "", connectError(err)
 	}

--- a/cli/internal/connectapi/viewer.go
+++ b/cli/internal/connectapi/viewer.go
@@ -86,7 +86,7 @@ func (s *viewerService) viewerUser(ctx context.Context, user *corev1.User) (*api
 	if err != nil {
 		return nil, connectError(err)
 	}
-	apiUser, err := (&userService{api: s.api}).userSummary(ctx, user, nil)
+	apiUser, err := userSummary(ctx, s.api, user, nil)
 	if err != nil {
 		return nil, connectError(err)
 	}

--- a/cli/internal/connectapi/voice_calls.go
+++ b/cli/internal/connectapi/voice_calls.go
@@ -249,7 +249,7 @@ func (s *voiceCallService) callParticipant(ctx context.Context, participant core
 		return nil, connectError(err)
 	}
 	avatarSize := 96
-	apiUser, err := (&userService{api: s.api}).userSummary(ctx, user, &apiv1.ImageTransformOptions{
+	apiUser, err := userSummary(ctx, s.api, user, &apiv1.ImageTransformOptions{
 		Width:  int32(avatarSize),
 		Height: int32(avatarSize),
 		Fit:    apiv1.ImageFitMode_IMAGE_FIT_MODE_COVER,


### PR DESCRIPTION
## Why

Shared user response mapping was coupled to the `userService` RPC handler, forcing unrelated response assemblers and services to construct temporary handler values solely for formatting.

## What changed

- Convert user summary, presence, and avatar mapping helpers into package functions while keeping `userService` focused on its ConnectRPC operations.
- Update account, admin, directory, notification, timeline, viewer, voice-call, and test callers without changing their response behavior.

## API compatibility

- No public API or protocol behaviour changed.
- Older client → newer server: unchanged.
- Newer client → older server: unchanged.
- Capability discovery or minimum client/server version: none required.

## Test plan

- `mise x -- go test ./internal/connectapi -run '^(TestUserSummary.*|TestUserService.*|TestAdminUserService.*|TestNotificationServiceListsAndDismissesNotifications|TestVoiceCallServiceRecordsAndListsCalls|TestRoomAndThreadTimelineHydratesMessagesWithoutClientNPlusOne)$' -count=1 -timeout 60s`
- `mise x -- go test ./internal/connectapi -count=1 -timeout 2m`
- `mise x -- buf breaking . --against '../.git#branch=origin/main,subdir=proto'` from `proto/`
- `git diff --check origin/main...`
