### PR TITLE
refactor(api): simplify asset response mapping

### DIFF
--- a/cli/internal/connectapi/asset_uploads.go
+++ b/cli/internal/connectapi/asset_uploads.go
@@ -84,7 +84,7 @@ func (s *assetUploadService) CompleteUpload(ctx context.Context, req *connect.Re
 	}
 	return connect.NewResponse(&apiv1.CompleteUploadResponse{
 		Upload: apiAssetUpload(upload),
-		Asset:  (&attachmentMapper{api: s.api}).asset(attachment, caller.UserID, assetThumbnailOptions(nil)),
+		Asset:  apiAsset(s.api, attachment, caller.UserID, assetThumbnailOptions(nil)),
 	}), nil
 }
 

--- a/cli/internal/connectapi/attachments.go
+++ b/cli/internal/connectapi/attachments.go
@@ -9,10 +9,6 @@ import (
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
-type attachmentMapper struct {
-	api *API
-}
-
 type assetService struct {
 	api *API
 }
@@ -45,14 +41,13 @@ func (s *roomService) ListRoomAttachments(ctx context.Context, req *connect.Requ
 	}
 
 	thumbnail := assetThumbnailOptions(req.Msg.Thumbnail)
-	mapper := attachmentMapper{api: s.api}
 	attachments := make([]*apiv1.RoomAttachmentListItem, 0, len(result.Items))
 	for _, item := range result.Items {
 		if item == nil {
 			continue
 		}
 		attachments = append(attachments, &apiv1.RoomAttachmentListItem{
-			Attachment:        mapper.asset(item.Attachment, caller.UserID, thumbnail),
+			Attachment:        apiAsset(s.api, item.Attachment, caller.UserID, thumbnail),
 			MessageEventId:    item.MessageEventID,
 			ThreadRootEventId: item.ThreadRootEventID,
 			CreatedAt:         item.CreatedAt,
@@ -78,9 +73,8 @@ func (s *assetService) GetAsset(ctx context.Context, req *connect.Request[apiv1.
 	if err != nil {
 		return nil, connectError(err)
 	}
-	mapper := attachmentMapper{api: s.api}
 	return connect.NewResponse(&apiv1.GetAssetResponse{
-		Asset: mapper.asset(asset, caller.UserID, assetThumbnailOptions(req.Msg.Thumbnail)),
+		Asset: apiAsset(s.api, asset, caller.UserID, assetThumbnailOptions(req.Msg.Thumbnail)),
 	}), nil
 }
 
@@ -98,20 +92,19 @@ func (s *assetService) BatchGetAssets(ctx context.Context, req *connect.Request[
 		return nil, connectError(err)
 	}
 	thumbnail := assetThumbnailOptions(req.Msg.Thumbnail)
-	mapper := attachmentMapper{api: s.api}
 	out := make([]*apiv1.Asset, 0, len(assets))
 	for _, asset := range assets {
-		out = append(out, mapper.asset(asset, caller.UserID, thumbnail))
+		out = append(out, apiAsset(s.api, asset, caller.UserID, thumbnail))
 	}
 	return connect.NewResponse(&apiv1.BatchGetAssetsResponse{Assets: out}), nil
 }
 
-func (s *attachmentMapper) asset(attachment *corev1.Attachment, viewerID string, thumbnail attachmentThumbnailRequest) *apiv1.Asset {
+func apiAsset(api *API, attachment *corev1.Attachment, viewerID string, thumbnail attachmentThumbnailRequest) *apiv1.Asset {
 	if attachment == nil {
 		return nil
 	}
 	h := &timelineHydrator{
-		api:      s.api,
+		api:      api,
 		viewerID: viewerID,
 	}
 	return &apiv1.Asset{
@@ -121,8 +114,8 @@ func (s *attachmentMapper) asset(attachment *corev1.Attachment, viewerID string,
 		Size:              attachment.Size,
 		Width:             attachment.Width,
 		Height:            attachment.Height,
-		AssetUrl:          assetURLView(s.api.core.GetStableAttachmentAssetURL(attachment.Id, viewerID)),
-		ThumbnailAssetUrl: assetURLView(s.api.core.GetStableTransformedAttachmentAssetURL(attachment.Id, viewerID, thumbnail.width, thumbnail.height, thumbnail.fit)),
+		AssetUrl:          assetURLView(api.core.GetStableAttachmentAssetURL(attachment.Id, viewerID)),
+		ThumbnailAssetUrl: assetURLView(api.core.GetStableTransformedAttachmentAssetURL(attachment.Id, viewerID, thumbnail.width, thumbnail.height, thumbnail.fit)),
 		VideoProcessing:   h.videoProcessing(attachment),
 	}
 }


### PR DESCRIPTION
## Why

Asset response mapping used a one-field, one-method wrapper that added construction and local-variable ceremony without owning meaningful state.

## What changed

- Replace `attachmentMapper` with a package-level `apiAsset` function.
- Update room attachment lists, singular and batch asset reads, and completed uploads while preserving viewer-bound URLs, thumbnail transforms, and video-processing metadata.

## API compatibility

- No public API or protocol behaviour changed.
- Older client → newer server: unchanged.
- Newer client → older server: unchanged.
- Capability discovery or minimum client/server version: none required.

## Test plan

- `mise x -- go test ./internal/connectapi -run '^(TestRoomMessageAndAssetServicesListAttachmentsGetMessagesAndGetAssets|TestAssetUploadServiceChunkResumeCompleteAndCancel|TestRoomAndThreadTimelineHydratesProcessedVideoAttachments)$' -count=1 -timeout 60s`
- `mise x -- go test ./internal/connectapi -count=1 -timeout 2m`
- `mise x -- buf breaking . --against '../.git#branch=origin/main,subdir=proto'` from `proto/`
- `git diff --check origin/main...`
