### PR TITLE
refactor(api): remove cross-service mapping wrappers

### DIFF
--- a/cli/internal/connectapi/account.go
+++ b/cli/internal/connectapi/account.go
@@ -36,7 +36,7 @@ func (s *accountService) UpdateProfile(ctx context.Context, req *connect.Request
 			return nil, connectError(err)
 		}
 	}
-	user, err := s.accountUser(ctx, updated)
+	user, err := requiredUserSummary(ctx, s.api, updated)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func (s *accountService) UploadAvatar(ctx context.Context, req *connect.Request[
 	if err != nil {
 		return nil, connectError(err)
 	}
-	responseUser, err := s.accountUser(ctx, user)
+	responseUser, err := requiredUserSummary(ctx, s.api, user)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func (s *accountService) DeleteAvatar(ctx context.Context, _ *connect.Request[ap
 	if err != nil {
 		return nil, connectError(err)
 	}
-	responseUser, err := s.accountUser(ctx, user)
+	responseUser, err := requiredUserSummary(ctx, s.api, user)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (s *accountService) UpdatePassword(ctx context.Context, req *connect.Reques
 	if err != nil {
 		return nil, connectError(err)
 	}
-	responseUser, err := s.accountUser(ctx, user)
+	responseUser, err := requiredUserSummary(ctx, s.api, user)
 	if err != nil {
 		return nil, err
 	}
@@ -181,13 +181,6 @@ func (s *accountService) DeleteMyAccount(ctx context.Context, req *connect.Reque
 		return nil, connectError(err)
 	}
 	return connect.NewResponse(&apiv1.DeleteMyAccountResponse{Deleted: true}), nil
-}
-
-func (s *accountService) accountUser(ctx context.Context, user *corev1.User) (*apiv1.User, error) {
-	if user == nil {
-		return nil, connectError(core.ErrNotFound)
-	}
-	return userSummary(ctx, s.api, user, nil)
 }
 
 func apiTimeFormatToCore(format apiv1.TimeFormat) corev1.TimeFormat {

--- a/cli/internal/connectapi/admin_user_management.go
+++ b/cli/internal/connectapi/admin_user_management.go
@@ -177,7 +177,7 @@ func (s *adminUserManagementService) UpdateUser(ctx context.Context, req *connec
 	if err != nil {
 		return nil, err
 	}
-	updatedUser, err := (&accountService{api: s.api}).accountUser(ctx, updated)
+	updatedUser, err := requiredUserSummary(ctx, s.api, updated)
 	if err != nil {
 		return nil, err
 	}
@@ -322,29 +322,6 @@ func (s *adminUserManagementService) adminMemberAfterMutationForUser(ctx context
 		Roles:     append([]string{}, roles...),
 		CreatedAt: user.GetCreatedAt(),
 		User:      apiUser,
-	}
-	return response, nil
-}
-
-func (s *adminUserManagementService) adminMemberForOperator(ctx context.Context, user *core.AdminUserView) (*adminv1.AdminMember, error) {
-	if user == nil || user.User == nil {
-		return nil, connectError(core.ErrNotFound)
-	}
-	verifiedEmails := make([]string, 0, len(user.VerifiedEmails))
-	for _, email := range user.VerifiedEmails {
-		verifiedEmails = append(verifiedEmails, email.Email)
-	}
-	apiUser, err := userSummary(ctx, s.api, user.User, nil)
-	if err != nil {
-		return nil, err
-	}
-	response := &adminv1.AdminMember{
-		Roles:                  append([]string(nil), user.RoleNames...),
-		CreatedAt:              user.User.GetCreatedAt(),
-		HasVerifiedEmail:       len(verifiedEmails) > 0,
-		VerifiedEmails:         verifiedEmails,
-		ViewerCanDeleteAccount: true,
-		User:                   apiUser,
 	}
 	return response, nil
 }

--- a/cli/internal/connectapi/operator_user_management.go
+++ b/cli/internal/connectapi/operator_user_management.go
@@ -29,7 +29,7 @@ func (s *operatorUserService) CreateUser(ctx context.Context, req *connect.Reque
 	if err != nil {
 		return nil, connectError(err)
 	}
-	member, err := s.operatorMember(ctx, created)
+	member, err := operatorAdminMember(ctx, s.api, created)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func (s *operatorUserService) ListUsers(ctx context.Context, req *connect.Reques
 		Page:  apiPageInfo(users.TotalCount, users.HasMore),
 	}
 	for _, user := range users.Users {
-		member, err := s.operatorMember(ctx, user)
+		member, err := operatorAdminMember(ctx, s.api, user)
 		if err != nil {
 			return nil, err
 		}
@@ -90,7 +90,7 @@ func (s *operatorUserService) GetUser(ctx context.Context, req *connect.Request[
 	if err != nil {
 		return nil, connectError(err)
 	}
-	member, err := s.operatorMember(ctx, user)
+	member, err := operatorAdminMember(ctx, s.api, user)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (s *operatorUserService) AssignRole(ctx context.Context, req *connect.Reque
 	if err != nil {
 		return nil, connectError(err)
 	}
-	member, err := s.operatorMember(ctx, user)
+	member, err := operatorAdminMember(ctx, s.api, user)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +134,7 @@ func (s *operatorUserService) RevokeRole(ctx context.Context, req *connect.Reque
 	if err != nil {
 		return nil, connectError(err)
 	}
-	member, err := s.operatorMember(ctx, user)
+	member, err := operatorAdminMember(ctx, s.api, user)
 	if err != nil {
 		return nil, err
 	}
@@ -153,11 +153,11 @@ func (s *operatorUserService) UpdateUser(ctx context.Context, req *connect.Reque
 	if err != nil {
 		return nil, connectError(err)
 	}
-	member, err := s.operatorMember(ctx, updated)
+	member, err := operatorAdminMember(ctx, s.api, updated)
 	if err != nil {
 		return nil, err
 	}
-	user, err := (&accountService{api: s.api}).accountUser(ctx, updated.User)
+	user, err := requiredUserSummary(ctx, s.api, updated.User)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (s *operatorUserService) SetUserPassword(ctx context.Context, req *connect.
 	if err != nil {
 		return nil, connectError(err)
 	}
-	member, err := s.operatorMember(ctx, updated)
+	member, err := operatorAdminMember(ctx, s.api, updated)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func (s *operatorUserService) AddVerifiedEmail(ctx context.Context, req *connect
 	if err != nil {
 		return nil, connectError(err)
 	}
-	member, err := s.operatorMember(ctx, updated)
+	member, err := operatorAdminMember(ctx, s.api, updated)
 	if err != nil {
 		return nil, err
 	}
@@ -205,8 +205,26 @@ func (s *operatorUserService) ClearUsernameCooldown(ctx context.Context, req *co
 	return connect.NewResponse(&operatorv1.ClearUsernameCooldownResponse{Cleared: true}), nil
 }
 
-func (s *operatorUserService) operatorMember(ctx context.Context, user *core.AdminUserView) (*adminv1.AdminMember, error) {
-	return (&adminUserManagementService{api: s.api}).adminMemberForOperator(ctx, user)
+func operatorAdminMember(ctx context.Context, api *API, user *core.AdminUserView) (*adminv1.AdminMember, error) {
+	if user == nil || user.User == nil {
+		return nil, connectError(core.ErrNotFound)
+	}
+	verifiedEmails := make([]string, 0, len(user.VerifiedEmails))
+	for _, email := range user.VerifiedEmails {
+		verifiedEmails = append(verifiedEmails, email.Email)
+	}
+	apiUser, err := userSummary(ctx, api, user.User, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &adminv1.AdminMember{
+		Roles:                  append([]string(nil), user.RoleNames...),
+		CreatedAt:              user.User.GetCreatedAt(),
+		HasVerifiedEmail:       len(verifiedEmails) > 0,
+		VerifiedEmails:         verifiedEmails,
+		ViewerCanDeleteAccount: true,
+		User:                   apiUser,
+	}, nil
 }
 
 func operatorAdminMemberRoles(roles []core.RoleWithPermissions) []*adminv1.AdminRole {

--- a/cli/internal/connectapi/users.go
+++ b/cli/internal/connectapi/users.go
@@ -3,6 +3,7 @@ package connectapi
 import (
 	"context"
 
+	"hmans.de/chatto/internal/core"
 	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
@@ -17,6 +18,13 @@ func userSummary(ctx context.Context, api *API, user *corev1.User, avatar *apiv1
 		return nil, connectError(err)
 	}
 	return userSummaryWithPresence(ctx, api, user, avatar, presence)
+}
+
+func requiredUserSummary(ctx context.Context, api *API, user *corev1.User) (*apiv1.User, error) {
+	if user == nil {
+		return nil, connectError(core.ErrNotFound)
+	}
+	return userSummary(ctx, api, user, nil)
 }
 
 func userSummaryWithPresence(ctx context.Context, api *API, user *corev1.User, avatar *apiv1.ImageTransformOptions, presence string) (*apiv1.User, error) {


### PR DESCRIPTION
## Why

Account, Admin, and Operator handlers constructed other handler types solely to reuse private response-formatting helpers, coupling unrelated transport services together.

## What changed

- Add a shared required-user summary helper that preserves nil-as-`NOT_FOUND` behavior.
- Move Operator admin-member mapping beside the Operator service and remove the `accountUser`, `adminMemberForOperator`, and `operatorMember` wrappers.

## API compatibility

- No public API or protocol behaviour changed.
- Older client → newer server: unchanged.
- Newer client → older server: unchanged.
- Operator API behavior: unchanged.
- Capability discovery or minimum client/server version: none required.

## Test plan

- `mise x -- go test ./internal/connectapi -run '^(TestOperatorUserService.*|TestAdminUserServiceUpdatesUsersAndClearsCooldown|TestMyAccountServiceUpdatesSelfProfileAndSettings|TestMyAccountServiceSetsPassword|TestMyAccountServiceDeletesAvatarAndAccount)$' -count=1 -timeout 60s`
- `mise x -- go test ./internal/connectapi -count=1 -timeout 2m`
- `mise x -- buf breaking . --against '../.git#branch=origin/main,subdir=proto'` from `proto/`
- `git diff --check origin/main...`
